### PR TITLE
Fix SSL/TLS issue when attempting to read manifest file from github pages

### DIFF
--- a/CactbotOverlay/CactbotOverlay.cs
+++ b/CactbotOverlay/CactbotOverlay.cs
@@ -286,6 +286,7 @@ namespace Cactbot {
         notify_state_.sent_data_dir = true;
 
         var web = new System.Net.WebClient();
+				System.Net.ServicePointManager.SecurityProtocol = System.Net.SecurityProtocolType.Ssl3 | System.Net.SecurityProtocolType.Tls | System.Net.SecurityProtocolType.Tls11 | System.Net.SecurityProtocolType.Tls12;
 
         var data_file_paths = new List<string>();
         try {

--- a/CactbotOverlay/CactbotOverlay.cs
+++ b/CactbotOverlay/CactbotOverlay.cs
@@ -27,6 +27,8 @@ namespace Cactbot {
     private static int kUberSlowTimerMilli = 3000;
     private static int kRequiredNETVersionMajor = 4;
     private static int kRequiredNETVersionMinor = 6;
+		private static string realUrl = null;
+		private static string currentConfigUrl = null;
 
     private SemaphoreSlim log_lines_semaphore_ = new SemaphoreSlim(1);
     // Not thread-safe, as OnLogLineRead may happen at any time. Use |log_lines_semaphore_| to access it.
@@ -285,12 +287,27 @@ namespace Cactbot {
       if (!notify_state_.sent_data_dir && Config.Url.Length > 0) {
         notify_state_.sent_data_dir = true;
 
-        var web = new System.Net.WebClient();
+				if(realUrl == null || currentConfigUrl != Config.Url) //use a singleton pattern so this expensive operation only happens once
+				{
+					realUrl = Config.Url;
+					currentConfigUrl = Config.Url;
+					if (realUrl.StartsWith("file:///")) //check for remote pointer and update config url
+					{
+						var html = File.ReadAllText(new Uri(realUrl).LocalPath);
+						var match = System.Text.RegularExpressions.Regex.Match(html, @"<meta http-equiv=""refresh"" content=""0; url=(.*)?""\/?>");
+						if (match.Groups.Count > 1)
+						{
+							realUrl = match.Groups[1].Value;
+						}
+					}
+				}
+
+				var web = new System.Net.WebClient();
 				System.Net.ServicePointManager.SecurityProtocol = System.Net.SecurityProtocolType.Ssl3 | System.Net.SecurityProtocolType.Tls | System.Net.SecurityProtocolType.Tls11 | System.Net.SecurityProtocolType.Tls12;
 
         var data_file_paths = new List<string>();
         try {
-          var data_dir_manifest = new Uri(new Uri(Config.Url), "data/manifest.txt");
+          var data_dir_manifest = new Uri(new Uri(realUrl), "data/manifest.txt");
           var manifest_reader = new StringReader(web.DownloadString(data_dir_manifest));
           for (var line = manifest_reader.ReadLine(); line != null; line = manifest_reader.ReadLine()) {
             line = line.Trim();
@@ -319,7 +336,7 @@ namespace Cactbot {
           var file_data = new Dictionary<string, string>();
           foreach (string data_filename in data_file_paths) {
             try {
-              var file_path = new Uri(new Uri(Config.Url), "data/" + data_filename);
+              var file_path = new Uri(new Uri(realUrl), "data/" + data_filename);
               var file_reader = new StringReader(web.DownloadString(file_path));
               file_data[data_filename] = file_reader.ReadToEnd();
             } catch (Exception e) {


### PR DESCRIPTION
Fix allows the web.DownloadString to download the manifest.txt file when remotely hosting the overlay from github pages