### PR TITLE
Adding timelines for Sigmascape 6-8N

### DIFF
--- a/ui/raidboss/data/manifest.txt
+++ b/ui/raidboss/data/manifest.txt
@@ -24,8 +24,11 @@ timelines/o3s.txt
 timelines/o4s.txt
 timelines/o5n.txt
 timelines/o5s.txt
+timelines/o6n.txt
 timelines/o6s.txt
+timelines/o7n.txt
 timelines/o7s.txt
+timelines/o8n.txt
 timelines/o8s.txt
 timelines/test.txt
 timelines/unending_coil_ultimate.txt

--- a/ui/raidboss/data/timelines/o6n.txt
+++ b/ui/raidboss/data/timelines/o6n.txt
@@ -1,0 +1,68 @@
+# Omega - Sigmascape V2.0 - O6N
+
+hideall "--Reset--"
+hideall "--sync--"
+
+0 "--Reset--" sync /(Removing combatant Demon Chadarnook|has initiated a ready check)/ window 10000 jump 0
+
+0 "Start" sync /00:0044:I have claimed the girl in the picture! She's mine! You can't have her!/ window 0,1
+18 "--targetable--"
+21 "Demonic Howl" sync /:Demon Chadarnook:282C:/ window 21,2.5
+30 "Demonic Shear" sync /:Demon Chadarnook:282A:/
+
+54 "Possession" sync /:Demon Chadarnook:2803:/
+59 "Flash Fire" sync /:Portrayal of Fire:280B:/
+66 "Demonic Howl" sync /:Demon Chadarnook:282C:/
+76 "Demonic Shear" sync /:Demon Chadarnook:282A:/
+86 "Release" sync /:Demon Chadarnook:2804:/
+
+99 "Possession" sync /:Demon Chadarnook:2803:/
+104 "Earthquake" sync /:Portrayal of Earth:2811:/
+118 "Demonic Stone" sync /:Demon Chadarnook:2847:/
+125 "Demonic Howl" sync /:Demon Chadarnook:282C:/
+138 "Demonic Shear" sync /:Demon Chadarnook:282A:/
+146 "Release" sync /:Demon Chadarnook:2804:/
+
+159 "Possession" sync /:Demon Chadarnook:2803:/
+170 "Demonic Wave" sync /:Portrayal of Water:2831:/
+179 "Demonic Howl" sync /:Demon Chadarnook:282C:/
+187 "Demonic Shear" sync /:Demon Chadarnook:282A:/
+195 "Demonic Spout" sync /:Demon Chadarnook:2835:/
+200 "Demonic Spout" sync /:Demon Chadarnook:2837:/
+209 "Release" sync /:Demon Chadarnook:2804:/
+
+222 "Possession" sync /:Demon Chadarnook:2803:/
+227 "Demonic Typhoon" sync /:Demon Chadarnook:283D:/
+244 "Demonic Howl" sync /:Demon Chadarnook:282C:/
+245 "Featherlance" sync /:Easterly:2AE8:/
+253 "Demonic Pain" sync /:Demon Chadarnook:2AEB:/
+264 "Flash Gale" sync /:Demon Chadarnook:2842:/
+275 "Release" sync /:Demon Chadarnook:2804:/
+
+# loop starts here
+288 "Possession" sync /:Demon Chadarnook:2803:/
+293 "Flash Fire" sync /:Portrayal of Fire:280B:/
+299 "Demonic Wave" sync /:Portrayal of Water:2831:/
+308 "Demonic Howl" sync /:Demon Chadarnook:282C:/
+318 "Demonic Spout" sync /:Demon Chadarnook:2835:/
+323 "Demonic Spout" sync /:Demon Chadarnook:2837:/
+330 "Demonic Shear" sync /:Demon Chadarnook:282A:/
+341 "Release" sync /:Haunt:2809:/
+
+354 "Possession" sync /:Demon Chadarnook:2803:/
+359 "Earthquake" sync /:Portrayal of Earth:2811:/
+359 "Flash Fire" sync /:Portrayal of Fire:280B:/
+368 "Materialize" sync /:Demon Chadarnook:282D:/
+381 "Demonic Stone" sync /:Demon Chadarnook:2847:/
+384 "Demonic Howl" sync /:Demon Chadarnook:282C:/
+394 "Demonic Shear" sync /:Demon Chadarnook:282A:/
+404 "Demonic Howl" sync /:Demon Chadarnook:282C:/
+415 "Release" sync /:Demon Chadarnook:2804:/
+# loop ends here
+
+428 "Possession" sync /:Demon Chadarnook:2803:/ jump 288
+433 "Flash Fire"
+439 "Demonic Wave"
+448 "Demonic Howl"
+455 "Demonic Spout"
+458 "Demonic Spout"

--- a/ui/raidboss/data/timelines/o7n.txt
+++ b/ui/raidboss/data/timelines/o7n.txt
@@ -1,0 +1,88 @@
+# Omega - Sigmascape V3.0 - O7N
+
+hideall "--Reset--"
+hideall "--sync--"
+
+0 "--Reset--" sync /(Removing combatant Guardian|has initiated a ready check)/ window 10000 jump 0
+
+0 "Start" sync /00:0044:WEAPON SYSTEMS ONLINE/
+11 "Magitek Ray" sync /:Guardian:276B:/
+21 "Arm And Hammer" sync /:Guardian:276C:/
+31 "Missile" sync /:Guardian:276D:/
+39 "Load" sync /:Guardian:275C:/
+
+# Ultros
+200 "--sync--" sync /Guardian gains the effect of Ultros/ window 2000,2000
+203 "Ink" sync /:Guardian:275D:/
+209 "Diffractive Plasma" sync /:Guardian:276E:/
+219 "Tentacle Simulation" sync /:Guardian:275E:/
+223 "Tentacle" sync /:Tentacle:275F:/
+229 "Wallop" sync /:Tentacle:2760:/
+231 "Run Program" sync /:Guardian:276F:/
+237 "--untargetable--" sync /:Guardian:2937:/
+244 "Chain Cannon" duration 2
+250 "Main Cannon" sync /:Guardian:2771:/
+253 "--targetable--" sync /:Guardian:2938:/
+260 "Diffractive Plasma" sync /:Guardian:276E:/
+266 "Magitek Ray" sync /:Guardian:276B:/ # drift 0.35
+275 "Arm And Hammer" sync /:Guardian:276C:/
+284 "Load" sync /:Guardian:275C:/
+
+# Dadaluma
+400 "--sync--" sync /Guardian gains the effect of Dadaluma/ window 2000,2000
+404 "Shockwave" sync /:Guardian:2766:/
+415 "--sync--" sync /:Guardian:276B:/ jump 1215 # rare version
+424 "Chakra Burst" sync /:Guardian:276A:/
+427 "Run Program" sync /:Guardian:276F:/
+436 "Aura Cannon"
+441 "Missile" sync /:Guardian:276D:/
+449 "Magitek Ray" sync /:Guardian:276B:/
+460 "Load" sync /:Guardian:275C:/
+
+# Air Force
+600 "--sync--" sync /Guardian gains the effect of Air Force/ window 2000,2000
+604 "Diffractive Laser" sync /:Guardian:2761:/
+613 "Missile Simulation" sync /:Guardian:2764:/
+614 "--sync--" sync /:Guardian:276F:/ jump 1014 # rare version
+623 "Diffractive Plasma" sync /:Guardian:276E:/
+637 "Bomb Deployment" sync /:Guardian:2762:/
+648 "Arm And Hammer" sync /:Guardian:276C:/
+659 "Run Program" sync /:Guardian:276F:/
+672 "Missile" sync /:Guardian:276D:/
+678 "Plane Laser"
+682 "Diffractive Plasma" sync /:Guardian:276E:/
+688 "Load" sync /:Guardian:275C:/
+
+# Bibliotaph
+800 "--sync--" sync /Guardian gains the effect of Bibliotaph/ window 2000,2000
+817 "Demon Simulation" sync /:Guardian:2752:/
+824 "Run Program" sync /:Guardian:276F:/
+838 "Burst/Darkness" sync /:Bibliotaph:29(BF|C0):/
+840 "Magitek Ray" sync /:Guardian:276B:/
+851 "Arm And Hammer" sync /:Guardian:276C:/
+860 "Diffractive Plasma" sync /:Guardian:276E:/
+870 "Load" sync /:Guardian:275C:/
+
+# Air Force later
+1000 "--sync--"
+1004 "Diffractive Laser" sync /:Guardian:2761:/
+1014 "Run Program" sync /:Guardian:276F:/
+1033 "Missile Simulation" sync /:Guardian:2764:/
+1034 "Plane Laser"
+1036 "--untargetable--" sync /:Guardian:2937:/
+1043 "Chain Cannon" duration 2
+1049 "Main Cannon" sync /:Guardian:2771:/
+1052 "--targetable--" sync /:Guardian:2938:/
+1062 "Bomb Deployment" sync /:Guardian:2762:/
+1085 "Load" sync /:Guardian:275C:/
+
+# Dadaluma later
+1200 "--sync--"
+1204 "Shockwave" sync /:Guardian:2766:/
+1215 "Magitek Ray" sync /:Guardian:276B:/
+1224 "Chakra Burst" sync /:Guardian:276A:/
+1227 "Magitek Ray" sync /:Guardian:276B:/
+1238 "Diffractive Plasma" sync /:Guardian:276E:/
+1246 "Missile" sync /:Guardian:276D:/
+1254 "Arm And Hammer" sync /:Guardian:276C:/
+1266 "Load" sync /:Guardian:275C:/

--- a/ui/raidboss/data/timelines/o8n.txt
+++ b/ui/raidboss/data/timelines/o8n.txt
@@ -1,0 +1,76 @@
+# Omega - Sigmascape V4.0 - O6N
+
+hideall "--Reset--"
+hideall "--sync--"
+
+0 "--Reset--" sync /(Removing combatant Kefka|has initiated a ready check)/ window 10000 jump 0
+
+0 "Start" sync /00:0044:Destroy! Destroy! Destroy! I will destroy it all!/
+15 "Hyper Drive" sync /:Kefka:292E:/
+23 "Blizzard Blitz" sync /:Kefka:291(4|6|8|9):/
+36 "Flagrant Fire" sync /:Kefka:291F:/
+38 "Thrumming Thunder" sync /:Kefka:291(B|D):/
+54 "Blizzard Blitz" sync /:Kefka:291(4|6|8|9):/
+62 "Thrumming Thunder" sync /:Kefka:291(B|D):/
+
+82 "Graven Image" sync /:Kefka:2925:/
+94 "Wave Cannon" sync /:Graven Image:2928:/
+95 "Shockwave" sync /:Graven Image:2927:/
+107 "Ultima Upsurge" sync /:Kefka:292D:/
+115 "Hyper Drive" sync /:Kefka:292E:/
+129 "Flagrant Fire" sync /:Kefka:2920:/
+131 "Blizzard Blitz" sync /:Kefka:291(4|6|8|9):/
+137 "Timely Teleport" sync /:Kefka:2922:/
+140 "Aero/Ruin" duration 3
+148 "Aero Assault" sync /:Kefka:2924:/
+
+160 "Graven Image" sync /:Kefka:2925:/
+170 "Thrumming Thunder" sync /:Kefka:291(B|D):/
+172 "Wave Cannon" sync /:Graven Image:2928:/
+173 "Shockwave" sync /:Graven Image:2927:/
+183 "Ultima Upsurge" sync /:Kefka:292D:/
+190 "Hyper Drive" sync /:Kefka:292E:/
+
+204 "Graven Image" sync /:Kefka:2925:/
+210 "Half Arena" sync /:Graven Image:(292A|2929):/
+218 "Ultima Upsurge" sync /:Kefka:292D:/
+
+228 "Graven Image" sync /:Kefka:2925:/
+234 "Half Arena" sync /:Graven Image:(292A|2929):/
+240 "Flagrant Fire" sync /:Kefka:291F:/
+242 "Thrumming Thunder" sync /:Kefka:291(B|D):/
+248 "Timely Teleport" sync /:Kefka:2922:/
+254 "Aero/Ruin" duration 3
+
+268 "Graven Image" sync /:Kefka:2925:/
+274 "Half Arena" sync /:Graven Image:292(9|A):/
+275 "Thrumming Thunder" sync /:Kefka:291(B|D):/
+282 "Ultima Upsurge" sync /:Kefka:292D:/
+289 "Hyper Drive" sync /:Kefka:292E:/
+
+302 "Graven Image" sync /:Kefka:2925:/
+308 "Gaze" sync /:Graven Image:292C:/
+318 "Ultima Upsurge" sync /:Kefka:292D:/
+325 "Ultima Upsurge" sync /:Kefka:292D:/
+
+# loop here
+335 "Graven Image" sync /:Kefka:2925:/
+341 "Gaze" sync /:Graven Image:292(B|C):/
+342 "Thrumming Thunder" sync /:Kefka:291(B|D):/
+348 "Timely Teleport" sync /:Kefka:2922:/
+351 "Aero/Ruin" duration 3
+366 "Hyper Drive" sync /:Kefka:292E:/
+
+374 "Graven Image" sync /:Kefka:2925:/
+380 "Gaze" sync /:Graven Image:292(B|C):/
+386 "Flagrant Fire" sync /:Kefka:291F:/
+388 "Blizzard Blitz" sync /:Kefka:291(4|6|8|9):/
+401 "Ultima Upsurge" sync /:Kefka:292D:/
+408 "Ultima Upsurge" sync /:Kefka:292D:/
+# end loop
+
+418 "Graven Image" sync /:Kefka:2925:/ jump 333
+424 "Gaze"
+425 "Thrumming Thunder"
+431 "Timely Teleport"
+434 "Aero/Ruin" duration 3

--- a/ui/raidboss/data/triggers/o6n.js
+++ b/ui/raidboss/data/triggers/o6n.js
@@ -1,6 +1,7 @@
 // O6N - Sigmascape 2.0 Normal
 [{
   zoneRegex: /^(Sigmascape \(V2\.0\)|Sigmascape 2\.0)$/,
+  timelineFile: 'o6n.txt',
   triggers: [
     {
       id: 'O6N Demonic Shear',

--- a/ui/raidboss/data/triggers/o7n.js
+++ b/ui/raidboss/data/triggers/o7n.js
@@ -1,6 +1,7 @@
 // O7N - Sigmascape 3.0 Normal
 [{
   zoneRegex: /^(Sigmascape \(V3\.0\)|Sigmascape V3\.0)$/,
+  timelineFile: 'o7n.txt',
   triggers: [
     {
       id: 'O7N Magitek Ray',

--- a/ui/raidboss/data/triggers/o8n.js
+++ b/ui/raidboss/data/triggers/o8n.js
@@ -1,6 +1,7 @@
 // O8N - Sigmascape 4.0 Normal
 [{
   zoneRegex: /^(Sigmascape \(V4\.0\)|Sigmascape V4\.0)$/,
+  timelineFile: 'o8n.txt',
   triggers: [
     {
       id: 'O8N Hyper Drive',


### PR DESCRIPTION
O6N:
Pretty standard. Just like savage, there's no real RNG, and a pretty early loop. One tricky part is that Demonic Wave is two casts; the boss has the long castbar, and then Portrayal of Water casts the real one 1 second after the cast bar finishes. Was always kind of confusing trying to pop out and in of melee range for it, and that explains why. No more, thanks to the timeline!

A nearly final version is here, the only thing I took out is the first (fake, boss castbar) Demonic Wave inside the loop: https://www.twitch.tv/videos/229684132

O7N:
There's no set order that I could detect. The only consistency is that a program will not be one of the last two loaded; that is, if the order goes Ultros -> Air Force, the next one will be either Dadaluma or Bibliotaph. If the third is Dadaluma, then the one after will either be Bibliotaph or Ultros. After the first two it always seems like a 50/50 shot, so in lieu of modelling out every sequential pair possible, I just have it empty after Load until the buff appears.

I encountered a few rare phases, usually in the later half of the fight, for Air Force and Dadaluma. I'm unsure if any alternate phases for Ultros or Bibliotaph exist, though. Either way, I opted to use universal sync windows instead of jumps just in case something unexpected happened, so it would pick up at the next Load. Having the fight be modular phases like that really helps for this purpose. You can see the rare phase happen in the video at 8:00, the Magitek Ray casting is the tell that Dadaluma isn't actually going to spawn.

A video of the final version of this timeline is here: https://www.twitch.tv/videos/229689480

O8N:
I'm not totally sure about the randomness of the first iterations of gazes and aero assault/revolting ruin before the loop, whether or not those are random. Same with the half arena hits. Still, there's triggers that call those out and it's not a huge deal to have some ambiguity there, especially in normal modes. I also opted to exclude the Flagrant Fire cast that simply causes the markers to show up, and instead only have the Flagrant Fire that is the damage actually going off. The stack/spread of those, too, might not be random.

A video of the final version of this timeline is here: https://www.twitch.tv/videos/229679385