### PR TITLE
Adding O8S timeline syncs

### DIFF
--- a/ui/raidboss/data/timelines/o8s.txt
+++ b/ui/raidboss/data/timelines/o8s.txt
@@ -193,13 +193,13 @@ hideall "--sync--"
 1584 "2x Wings of Destruction" sync /:Kefka:2900:/
 1586 "Soak"
 1590 "Ultima" sync /:Kefka:2911:/
-1597 "Statue Half Cleave" sync /:Graven Image:28D(E|F):/
-1598 "1x Wings of Destruction" sync /:Kefka:28FF:/
+1595 "Statue Half Cleave"
+1596 "1x Wings of Destruction" sync /:Kefka:28FF:/
 
 # Enrage
-1604 "Ultima" sync /:Kefka:2911:/
-1612 "Ultima" sync /:Kefka:2911:/
-1620 "Ultima" sync /:Kefka:2911:/
-1628 "Ultima" sync /:Kefka:2911:/
-1632 "--sync--" sync /:2A52:Kefka/
-1642 "Enrage" sync /:Kefka:2A52:/ jump 0
+1602 "Ultima" sync /:Kefka:283D:/
+1610 "Ultima" sync /:Kefka:283D:/
+1618 "Ultima" sync /:Kefka:283D:/
+1626 "Ultima" sync /:Kefka:283D:/
+1630 "--sync--" sync /:2A52:Kefka/
+1640 "Enrage" sync /:Kefka:2A52:/ jump 0

--- a/ui/raidboss/data/timelines/o8s.txt
+++ b/ui/raidboss/data/timelines/o8s.txt
@@ -132,6 +132,7 @@ hideall "--sync--"
 1201 "--sync--" sync /14:28E9:Kefka starts using Forsaken/ window 120,60
 1206 "Forsaken #2" sync /:Kefka:28E9:/
 1214 "Starstrafe" sync /:Kefka:2902:/
+1221 "Past/Future End" sync /:Kefka:28F(5|8):/
 1228 "All Things Ending" sync /:Kefka:28F6:/
 1233 "Meteor" sync /:Kefka:2905:/
 
@@ -153,6 +154,7 @@ hideall "--sync--"
 1340 "--sync--" sync /14:28E9:Kefka starts using Forsaken/ window 120,60
 1345 "Forsaken #3" sync /:Kefka:28E9:/
 1358 "Ultima" sync /:Kefka:2911:/
+1359 "Knockback Tethers" sync /:Graven Image:28DD:/
 1362 "Soak" sync /:Light of Consecration:28EA:/
 1364 "Ultimate Embrace" sync /:Kefka:2910:/
 1371 "Sleep/Confuse Tethers" sync /:Graven Image:28E(5|6):/
@@ -181,6 +183,7 @@ hideall "--sync--"
 1525 "--sync--" sync /14:28E9:Kefka starts using Forsaken/ window 120,60
 1530 "Forsaken #4" sync /:Kefka:28E9:/
 1543 "Ultima" sync /:Kefka:2911:/
+1544 "Knockback Tethers" sync /:Graven Image:28DD:/
 1547 "Soak" sync /:Light of Consecration:28EA:/
 1549 "Ultimate Embrace" sync /:Kefka:2910:/
 1556 "Sleep/Confuse Tethers" sync /:Graven Image:28E(5|6):/

--- a/ui/raidboss/data/timelines/o8s.txt
+++ b/ui/raidboss/data/timelines/o8s.txt
@@ -92,80 +92,111 @@ hideall "--sync--"
 404 "--untargetable--"
 408 "Light Of Judgment" sync /:Kefka:2A51:/
 
-
-
+#############
+# GOD KEFKA #
+#############
 
 1000 "Start"
 1001 "--sync--" sync /:Kefka:28EC:/ window 1001,0
 1006 "--sync--" sync /14:28FA:Kefka starts using Heartless Angel/ window 10,0
-1010 "Heartless Angel"
-1016 "Ultima"
-1024 "Hyperdrive"
-1032 "Celestriad"
-1042 "Ultima"
-1049 "--sync--" sync /14:28E9:Kefka starts using Forsaken/ window 120,60
-1054 "Forsaken #1"
-1064 "Heartless Archangel"
-1077 "2x Wings of Destruction"
-1084 "Ultima"
-1093 "Heartless Archangel"
-1109 "Light of Judgment"
-1125 "Trine (small)"
-1130 "1x Wings of Destruction"
-1141 "2x Wings of Destruction"
-1158 "Ultima"
-1166 "Past/Future"
-1176 "Ultimate Embrace"
-1183 "Hyperdrive"
-1190 "Ultima"
-1202 "--sync--" sync /14:28E9:Kefka starts using Forsaken/ window 120,60
-1207 "Forsaken #2"
-1216 "Starstrafe"
-1222 "Past/Future"
-1241 "Light of Judgment"
-1257 "Celestriad"
-1265 "1x Wings of Destruction"
-1272 "Ultima"
-1288 "Trine (big)"
-1298 "Past/Future"
-1308 "2x Wings of Destruction"
-1314 "Ultimate Embrace"
-1321 "Hyperdrive"
-1342 "--sync--" sync /14:28E9:Kefka starts using Forsaken/ window 120,60
-1347 "Forsaken #3"
-1357 "Knockback Tethers"
-1370 "Sleep/Confuse Tethers"
-1379 "Ultima"
-1388 "Heartless Archangel"
-1401 "2x Wings of Destruction"
-1402 "4x Path of Light"
-1407 "Ultima"
-1414 "Statue Half Cleave"
-1415 "1x Wings of Destruction"
-1421 "Light of Judgment"
-1435 "Trine (small)"
-1442 "1x Wings of Destruction"
-1453 "2x Wings of Destruction"
-1459 "Ultimate Embrace"
-1475 "Trine (big)"
-1485 "Past/Future"
-1496 "Hyperdrive"
-1504 "Ultima"
-1512 "Ultima"
+1010 "Heartless Angel" sync /:Kefka:28FA:/
+1016 "Ultima" sync /:Kefka:2911:/ 
+1023 "Hyperdrive" sync /:Kefka:2912:/
+1032 "Celestriad" sync /:Kefka:2907:/
+1034 "Thunder III" sync /:Kefka:290A:/
+1035 "(DPS) Fire III" sync /:Kefka:290B:/
+1041 "Ultima" sync /:Kefka:2911:/
+
+# Forsaken 1
+1048 "--sync--" sync /14:28E9:Kefka starts using Forsaken/ window 120,60
+1053 "Forsaken #1" sync /:Kefka:28E9:/
+1064 "Heartless Archangel" sync /:Kefka:28FB:/
+1067 "Soak" sync /:Light of Consecration:28EA:/
+1077 "2x Wings of Destruction" sync /:Kefka:2900:/
+1083 "Ultima" sync /:Kefka:2911:/
+1093 "Heartless Archangel" sync /:Kefka:28FB:/
+1096 "Soak" sync /:Light of Consecration:28EA:/
+
+# Light 1
+1108 "Light Of Judgment" sync /:Kefka:28ED:/
+1122 "Trine (small)" sync /:Kefka:290D:/
+1129 "1x Wings Of Destruction" sync /:Kefka:28FE:/
+1140 "2x Wings Of Destruction" sync /:Kefka:2900:/
+1157 "Ultima" sync /:Kefka:2911:/
+1165 "Past/Future" sync /:Kefka:28(EF|F1):/
+1175 "Ultimate Embrace" sync /:Kefka:2910:/
+1182 "Hyperdrive" sync /:Kefka:2912:/
+1189 "Ultima" sync /:Kefka:2911:/
+
+# Forsaken 2
+1201 "--sync--" sync /14:28E9:Kefka starts using Forsaken/ window 120,60
+1206 "Forsaken #2" sync /:Kefka:28E9:/
+1214 "Starstrafe" sync /:Kefka:2902:/
+1228 "All Things Ending" sync /:Kefka:28F6:/
+1233 "Meteor" sync /:Kefka:2905:/
+
+# Light 2
+1240 "Light Of Judgment" sync /:Kefka:28ED:/
+1256 "Celestriad" sync /:Kefka:2907:/
+1258 "Thunder III" sync /:Kefka:290A:/
+1259 "(DPS) Fire III" sync /:Kefka:290B:/
+1264 "1x Wings Of Destruction" sync /:Kefka:28FF:/
+1271 "Ultima" sync /:Kefka:2911:/
+1287 "Trine (big)" sync /:Kefka:290D:/
+1297 "Past/Future" sync /:Kefka:28(EF|F1):/
+1307 "2x Wings Of Destruction" sync /:Kefka:2900:/
+1313 "Ultimate Embrace" sync /:Kefka:2910:/
+1320 "Hyperdrive" sync /:Kefka:2912:/
+1328 "Ultima" sync /:Kefka:2911:/
+
+# Forsaken 3
+1340 "--sync--" sync /14:28E9:Kefka starts using Forsaken/ window 120,60
+1345 "Forsaken #3" sync /:Kefka:28E9:/
+1358 "Ultima" sync /:Kefka:2911:/
+1362 "Soak" sync /:Light of Consecration:28EA:/
+1364 "Ultimate Embrace" sync /:Kefka:2910:/
+1371 "Sleep/Confuse Tethers" sync /:Graven Image:28E(5|6):/
+1377 "Ultima" sync /:Kefka:2911:/
+1386 "Heartless Archangel" sync /:Kefka:28FB:/
+1389 "Soak" sync /:Light of Consecration:28EA:/
+1399 "2x Wings of Destruction" sync /:Kefka:2900:/
+1400 "Soak"
+1405 "Ultima" sync /:Kefka:2911:/
+1412 "Statue Half Cleave" sync /:Graven Image:28D(E|F):/
+1413 "1x Wings of Destruction" sync /:Kefka:28FF:/
+
+# Light 3
+1421 "Light of Judgment" sync /:Kefka:28ED:/
+1435 "Trine (small)" sync /:Kefka:290D:/
+1442 "1x Wings of Destruction" sync /:Kefka:28FF:/
+1453 "2x Wings of Destruction" sync /:Kefka:2900:/
+1459 "Ultimate Embrace" sync /:Kefka:2910:/
+1475 "Trine (big)" sync /:Kefka:290D:/
+1485 "Past/Future" sync /:Kefka:28(EF|F1):/
+1496 "Hyperdrive" sync /:Kefka:2912:/
+1504 "Ultima" sync /:Kefka:2911:/
+1512 "Ultima" sync /:Kefka:2911:/
+
+# Forsaken 4 (repeats #3)
 1525 "--sync--" sync /14:28E9:Kefka starts using Forsaken/ window 120,60
-1530 "Forsaken #4"
-1541 "Knockback Tethers"
-1549 "Ultimate Embrace"
-1552 "Sleep/Confuse Tethers"
-1562 "Ultima"
-1571 "Heartless Archangel"
-1584 "2x Wings of Destruction"
-1586 "4x Path of Light"
-1590 "Ultima"
-1597 "Statue Half Cleave"
-1598 "1x Wings of Destruction"
-1603 "Ultima"
-1611 "Ultima"
-1619 "Ultima"
-1627 "Ultima"
-1642 "Enrage"
+1530 "Forsaken #4" sync /:Kefka:28E9:/
+1543 "Ultima" sync /:Kefka:2911:/
+1547 "Soak" sync /:Light of Consecration:28EA:/
+1549 "Ultimate Embrace" sync /:Kefka:2910:/
+1556 "Sleep/Confuse Tethers" sync /:Graven Image:28E(5|6):/
+1562 "Ultima" sync /:Kefka:2911:/
+1571 "Heartless Archangel" sync /:Kefka:28FB:/
+1574 "Soak"
+1584 "2x Wings of Destruction" sync /:Kefka:2900:/
+1586 "Soak"
+1590 "Ultima" sync /:Kefka:2911:/
+1597 "Statue Half Cleave" sync /:Graven Image:28D(E|F):/
+1598 "1x Wings of Destruction" sync /:Kefka:28FF:/
+
+# Enrage
+1604 "Ultima" sync /:Kefka:2911:/
+1612 "Ultima" sync /:Kefka:2911:/
+1620 "Ultima" sync /:Kefka:2911:/
+1628 "Ultima" sync /:Kefka:2911:/
+1632 "--sync--" sync /:2A52:Kefka/
+1642 "Enrage" sync /:Kefka:2A52:/ jump 0


### PR DESCRIPTION
The diff may not be super useful, so I'll summarize the changes (beyond simply adding syncs). My group got to 1389 on this, so up to that is script-generated, past that is hand-made from fflogs. Preserved your existing naming for the most part.

- Added the Thunder/Fire hits of Celestriad
- Fixed some slight +/- 1s timing issues
- Added all non-starstrafe Soaks (The Path of Light, renamed for clarity), since they were included, albeit inconsistently, later on in the fight. Having specific timing for them is useful for dodging into it.
- Added All Things Ending to Past/Future End during Starstrafe. The ATE cast on the normal ones is fast enough (3s) that it's not worth timing it, but there's a bigger gap in that one (8s).
- Also added Meteor hit (the stack) during Starstrafe
- Added some missing Ultimas (1328, 1358, 1543)
- Added a missing Ultimate Embrace (1364)
- Changed tether times to activation rather than appearance

This is untested so far. I go in again on Friday, I just wanted to put it up now in case there's anything glaring