### PR TITLE
Cleaning up timelines

### DIFF
--- a/ui/raidboss/data/timelines/ridorana_lighthouse.txt
+++ b/ui/raidboss/data/timelines/ridorana_lighthouse.txt
@@ -16,9 +16,9 @@ hideall "--sync--"
 26 "Water IV" sync /:Famfrit, the Darkening Cloud:2C3D:/
 35 "Briny Cannonade" sync /:Famfrit, the Darkening Cloud:2C45:/
 47 "Tsunami sync /:Famfrit, the Darkening Cloud:2C50:/
-53 "Tsunami" duration 3
-65 "Tsunami" duration 3
-77 "Tsunami" duration 3
+54 "Tsunami" duration 3
+66 "Tsunami" duration 3
+78 "Tsunami" duration 3
 86 "Water IV" sync /:Famfrit, the Darkening Cloud:2C3D:/
 97 "Dark Ewer (cross)" sync /:Famfrit, the Darkening Cloud:2C43:/
 110 "Tide Pod" sync /:Famfrit, the Darkening Cloud:2C3E:/
@@ -34,10 +34,10 @@ hideall "--sync--"
 176 "Dark Cannonade" sync /:Famfrit, the Darkening Cloud:2C42:/
 200 "Water IV" sync /:Famfrit, the Darkening Cloud:2C3D:/
 208 "Tsunami" sync /:Famfrit, the Darkening Cloud:2C50:/
-214 "Tsunami" duration 3
-228 "Tsunami" duraiton 3
+215 "Tsunami" duration 3
+227 "Tsunami" duration 3
 228 "Briny Cannonade" sync /:Famfrit, the Darkening Cloud:2C45:/
-240 "Tsunami" duration 3
+239 "Tsunami" duration 3
 247 "Water IV" sync /:Famfrit, the Darkening Cloud:2C3D:/
 259 "Tide Pod" sync /:Famfrit, the Darkening Cloud:2C3E:/
 272 "Water IV" sync /:Famfrit, the Darkening Cloud:2C3D:/
@@ -47,6 +47,9 @@ hideall "--sync--"
 311 "Briny Cannonade" sync /:Famfrit, the Darkening Cloud:2C45:/
 318 "Dark Ewer (orbit)" sync /:Famfrit, the Darkening Cloud:2C43:/
 324 "Tsunami" sync /:Famfrit, the Darkening Cloud:2C48:/
+331 "Tsunami" duration 3
+343 "Tsunami" duration 3
+355 "Tsunami" duration 3
 357 "Briny Cannonade" sync /:Famfrit, the Darkening Cloud:2C45:/
 364 "Water IV" sync /:Famfrit, the Darkening Cloud:2C3D:/
 371 "Water IV" sync /:Famfrit, the Darkening Cloud:2C3D:/
@@ -195,37 +198,40 @@ hideall "--sync--"
 3074 "Magnetic Lysis" sync /:Yiazmat:2C2A:/
 3082 "Dust Storm" sync /:Yiazmat:2C36:/
 3088 "Gust Front" duration 4
-3093 "Dust Storm" sync /:Yiazmat:2C36:/
-3102 "Magnetic Genesis" sync /:Yiazmat:2C2B:/
-3109 "Rake (combo)" sync /:Yiazmat:2C3C:/
-3128 "White Breath" sync /:Yiazmat:2C31:/
-3143 "Rake (single)" sync /:Yiazmat:2C26:/
-3154 "Gust Front" duration 4
-3157 "Stone Breath" sync /:Yiazmat:2C29:/
-3170 "Summon" sync /:Yiazmat:2C37:/
-3181 "Magnetic Lysis" sync /:Yiazmat:2C2A:/
-3189 "White Breath" sync /:Yiazmat:2C31:/
-3196 "Dust Storm" sync /:Yiazmat:2C36:/
-3203 "Death Strike" sync /:Yiazmat:2C34:/
-3208 "Magnetic Genesis" sync /:Yiazmat:2C2B:/
-3223 "Cyclone" sync /:Yiazmat:2C23:/ duration 4
+3092 "Stone Breath" sync /:Yiazmat:2C29:/
+3098 "Dust Storm" sync /:Yiazmat:2C36:/
+3101 "Magnetic Genesis" sync /:Yiazmat:2C2B:/
+3114 "Rake (combo)" duration 14
+3134 "White Breath" sync /:Yiazmat:2C31:/
+3149 "Rake (single)" sync /:Yiazmat:2C26:/
+3160 "Gust Front" duration 4
+3162 "Stone Breath" sync /:Yiazmat:2C29:/
+3175 "Summon" sync /:Yiazmat:2C37:/
+3186 "Magnetic Lysis" sync /:Yiazmat:2C2A:/
+3194 "White Breath" sync /:Yiazmat:2C31:/
+3201 "Dust Storm" sync /:Yiazmat:2C36:/
+3208 "Death Strike" sync /:Yiazmat:2C34:/
+3213 "Magnetic Genesis" sync /:Yiazmat:2C2B:/
+3222 "Cyclone" sync /:Yiazmat:2C23:/ duration 4
 
 # Adds
 3241 "Archaeodemon spawn"
-3248 "Karma/Unholy Darkness" sync /:Archaeodemon:2672:/
-3249 "Gust Front" duration 4
-3260 "Death Strike" sync /:Yiazmat:2C33:/
+3248 "Gust Front" duration 4
+3250 "Karma/Unholy Darkness"
+3258 "Death Strike" sync /:Yiazmat:2C33:/
+3262 "Karma/Unholy Darkness"
+3301 "Enrage"
 
 # Adds complete
 3400 "Solar Storm" sync /:Yiazmat:2C2C:/ window 5000,600
-3420 "Rake (combo)" sync /:Yiazmat:2C3C:/
+3420 "Rake (combo)" duration 14
 3425 "Gust Front" duration 4
 3439 "White Breath" sync /:Yiazmat:2C31:/
 3450 "Rake (single)" sync /:Yiazmat:2C26:/
 
 # Begin loop
 3456 "Magnetic Lysis" sync /:Yiazmat:2C2A:/
-3463 "Rake (combo)" sync /:Yiazmat:2C3C:/
+3463 "Rake (combo)" duration 14
 3481 "Dust Storm" sync /:Yiazmat:2C36:/
 3483 "Magnetic Genesis" sync /:Yiazmat:2C2B:/
 3493 "Cyclone" sync /:Yiazmat:2C23:/ duration 4
@@ -254,10 +260,10 @@ hideall "--sync--"
 # 9.99% push
 3694 "--sync--" sync /:2C32:Yiazmat/ window 5000,306
 3700 "Growing Threat" sync /:Yiazmat:2C32:/ window 5000,300
-3707 "Rake (combo)" sync /:Yiazmat:2C3C:/
+3707 "Rake (combo)" duration 14
 3727 "White Breath" sync /:Yiazmat:2C31:/
 3734 "Dust Storm" sync /:Yiazmat:2C36:/
-3740 "Rake (combo)" sync /:Yiazmat:2C3C:/
+3740 "Rake (combo)" duration 14
 3752 "Gust Front" duration 4
 3761 "Stone Breath" sync /:Yiazmat:2C29:/
 3767 "Dust Storm" sync /:Yiazmat:2C36:/

--- a/ui/raidboss/data/timelines/tsukuyomi-ex.txt
+++ b/ui/raidboss/data/timelines/tsukuyomi-ex.txt
@@ -14,7 +14,7 @@ hideall "--sync--"
 81 "Nightbloom" sync /:Tsukuyomi:2BC7:/ window 80,3
 103 "Homeland adds" sync /:Added new combatant Specter Of The Patriarch/
 140 "Empire adds" sync /:Added new combatant Specter Of Asahi/ window 40,3
-200 "--sync--" sync /:Specter Of Zenos:2BC8:/ window 60,30 # this line doesn't work for some reason
+200 "--sync--" sync /:Specter of Zenos:2BC8:/ window 60,30 # this line doesn't work for some reason
 202 "Concentrativity" # stun/knockback is actually 2s after the real cast (2BC8)
 207 "--sync--" sync /:Specter of Zenos:2CA8:/ window 67,3
 214 "--sync--" sync /:Specter of Zenos:2BCA:/

--- a/ui/raidboss/data/timelines/tsukuyomi-ex.txt
+++ b/ui/raidboss/data/timelines/tsukuyomi-ex.txt
@@ -14,7 +14,7 @@ hideall "--sync--"
 81 "Nightbloom" sync /:Tsukuyomi:2BC7:/ window 80,3
 103 "Homeland adds" sync /:Added new combatant Specter Of The Patriarch/
 140 "Empire adds" sync /:Added new combatant Specter Of Asahi/ window 40,3
-200 "--sync--" sync /:Specter of Zenos:2BC8:/ window 60,30 # this line doesn't work for some reason
+200 "--sync--" sync /:Specter of Zenos:2BC8:/ window 60,30
 202 "Concentrativity" # stun/knockback is actually 2s after the real cast (2BC8)
 207 "--sync--" sync /:Specter of Zenos:2CA8:/ window 67,3
 214 "--sync--" sync /:Specter of Zenos:2BCA:/

--- a/ui/raidboss/data/timelines/tsukuyomi-ex.txt
+++ b/ui/raidboss/data/timelines/tsukuyomi-ex.txt
@@ -1,4 +1,5 @@
 # Tsukuyomi Extreme
+hideall "--sync--"
 
 0 "--Reset--" sync /Removing combatant Tsukuyomi/ window 10000 jump 0
 
@@ -9,18 +10,26 @@
 42 "Nightfall" sync /:Tsukuyomi:2BB(C|D):/
 49 "Steel/Lead"
 67 "Reprimand" sync /:Tsukuyomi:2BBA:/
-78 "Nightbloom" sync /:Tsukuyomi:2BC7:/ window 80,80
-# Add spawn times here
-155 "Concentrativity" sync /:Specter Of Zenos:2BC8:/
-170 "--targetable--"
-178 "Dispersivity" sync /:Specter:2BCC:/
-184 "Dispersivity" sync /:Specter:2BCC:/
-190 "Dispersivity" sync /:Specter:2BCC:/
-196 "Dispersivity" sync /:Specter:2BCC:/
-202 "Dispersivity" sync /:Specter:2BCC:/
+75 "--sync--" sync /:2BC7:Tsuyukomi/ window 72,3 # can push this before reprimand
+81 "Nightbloom" sync /:Tsukuyomi:2BC7:/ window 80,3
+103 "Homeland adds" sync /:Added new combatant Specter Of The Patriarch/
+140 "Empire adds" sync /:Added new combatant Specter Of Asahi/ window 40,3
+200 "--sync--" sync /:Specter Of Zenos:2BC8:/ window 60,30 # this line doesn't work for some reason
+202 "Concentrativity" # stun/knockback is actually 2s after the real cast (2BC8)
+207 "--sync--" sync /:Specter of Zenos:2CA8:/ window 67,3
+214 "--sync--" sync /:Specter of Zenos:2BCA:/
+217 "--targetable--"
+224 "Dispersivity" sync /:Specter:2BCC:/
+230 "Dispersivity" sync /:Specter:2BCC:/
+236 "Dispersivity" sync /:Specter:2BCC:/
+242 "Dispersivity" sync /:Specter:2BCC:/
+248 "Dispersivity" sync /:Specter:2BCC:/
 
 # Adds complete, crescent phase
+486 "--sync--" sync /Specter of Gosetsu:2CD6:/ window 486,0
+496 "--sync--" sync /:2CAF:Tsukuyomi/
 500 "Nightbloom" sync /:Tsukuyomi:2CAF:/ window 500,0
+506 "--targetable--"
 
 # Begin loop
 520 "Supreme Selenomancy" sync /:Tsukuyomi:2EB0:/

--- a/ui/raidboss/data/timelines/tsukuyomi-ex.txt
+++ b/ui/raidboss/data/timelines/tsukuyomi-ex.txt
@@ -33,10 +33,9 @@ hideall "--sync--"
 
 # Begin loop
 520 "Supreme Selenomancy" sync /:Tsukuyomi:2EB0:/
-529 "Lunar Halo" sync /:Moonlight:2BD6:/
 539 "Tsuki-no-Kakera" sync /:Tsukuyomi:2BD0:/
-545 "Nightfall" sync /:Tsukuyomi:2BBC:/
-551 "Lead/Steel"
+545 "Nightfall (gun)" sync /:Tsukuyomi:2BBC:/
+551 "Lead of the Underworld"
 564 "Moonfall" sync /:Moondust:2BD1:/
 565 "Midnight Rain" sync /:Tsukuyomi:2BCE:/
 568 "Moonburst" sync /:Moondust:2BD2:/ # drift 0.28
@@ -53,44 +52,52 @@ hideall "--sync--"
 628 "Tsuki-no-Maiogi"
 629 "Lead/Steel" sync /:Tsukuyomi:2BBE:/
 645 "Torment Unto Death" sync /:Tsukuyomi:2BBB:/
-656 "Supreme Selenomancy" sync /:Tsukuyomi:2EB0:/ jump 520
-# End loop
 
-# Dummy loop future
-665 "Lunar Halo" sync /:Moonlight:2BD6:/
+656 "Supreme Selenomancy" sync /:Tsukuyomi:2EB0:/
 675 "Tsuki-no-Kakera" sync /:Tsukuyomi:2BD0:/
-681 "Nightfall" sync /:Tsukuyomi:2BB(C|D):/
+681 "Nightfall (spear)" sync /:Tsukuyomi:2BBD:/
+688 "Steel Of The Underworld"
+700 "Midnight Rain" sync /:Tsukuyomi:2BCE:/
+714 "Lunar Rays" sync /:Tsukuyomi:2BD3:/
+727 "Antitwilight" sync /:Tsukuyomi:2BD8:/ # drift 0.283
 
 # 35% push
-1000 "Dance Of The Dead" sync /:Tsukuyomi:2CD0:/ window 1000,0
-1017 "Bright/Dark Blade" sync /:Tsukuyomi:2BD(A|B):/
-1018 "Waning/Waxing Grudge" sync /:Tsukuyomi:2BD(E|F):/
-1030 "Bright/Dark Blade" sync /:Tsukuyomi:2BD(A|B):/
-1031 "Waning/Waxing Grudge" sync /:Tsukuyomi:2BD(E|F):/
+739 "Dance Of The Dead" sync /:Tsukuyomi:2CD0:/ window 1000,0
+756 "Bright/Dark Blade" sync /:Tsukuyomi:2BD(A|B):/
+757 "Waning/Waxing Grudge" sync /:Tsukuyomi:2BD(E|F):/
+769 "Bright/Dark Blade" sync /:Tsukuyomi:2BD(A|B):/
+770 "Waning/Waxing Grudge" sync /:Tsukuyomi:2BD(E|F):/
 
 # Begin loop
 # Rotating fans
-1041 "Reprimand" sync /:Tsukuyomi:2BBA:/
-1053 "Lunacy" duration 4
-1054 "Tsuki-no-Maiogi" duration 3
+780 "Reprimand" sync /:Tsukuyomi:2BBA:/
+792 "Lunacy" duration 4
+793 "Tsuki-no-Maiogi" duration 3
 
-1064 "Bright/Dark Blade" sync /:Tsukuyomi:2BD(A|B):/
-1065 "Waning/Waxing Grudge" sync /:Tsukuyomi:2BD(E|F):/
-1074 "Torment Unto Death" sync /:Tsukuyomi:2EB2:/
+803 "Bright/Dark Blade" sync /:Tsukuyomi:2BD(A|B):/
+804 "Waning/Waxing Grudge" sync /:Tsukuyomi:2BD(E|F):/
+813 "Torment Unto Death" sync /:Tsukuyomi:2EB2:/
 
 # Side fans
-1087 "Hagetsu" duration 4
-1089 "Tsuki-no-Maiogi"
-1092 "Tsuki-no-Maiogi"
+826 "Hagetsu" duration 4
+828 "Tsuki-no-Maiogi"
+831 "Tsuki-no-Maiogi"
 
-1097 "Bright/Dark Blade" sync /:Tsukuyomi:2BD(A|B):/
-1098 "Waning/Waxing Grudge" sync /:Tsukuyomi:2BD(E|F):/
-1106 "Reprimand" sync /:Tsukuyomi:2BBA:/
-1113 "Reprimand" sync /:Tsukuyomi:2BBA:/ jump 1041
+836 "Bright/Dark Blade" sync /:Tsukuyomi:2BD(A|B):/
+837 "Waning/Waxing Grudge" sync /:Tsukuyomi:2BD(E|F):/
+845 "Reprimand" sync /:Tsukuyomi:2BBA:/
+852 "Reprimand" sync /:Tsukuyomi:2BBA:/ jump 1041
 # End loop
 
 # Dummy loop future
-1125 "Lunacy" duration 4
-1126 "Tsuki-no-Maiogi" duration 3
-1137 "Bright/Dark Blade"
-1138 "Waning/Waxing Grudge"
+864 "Lunacy" duration 4
+865 "Tsuki-no-Maiogi" duration 3
+876 "Bright/Dark Blade"
+877 "Waning/Waxing Grudge"
+
+
+
+
+
+
+

--- a/ui/raidboss/data/timelines/tsukuyomi-ex.txt
+++ b/ui/raidboss/data/timelines/tsukuyomi-ex.txt
@@ -94,10 +94,3 @@ hideall "--sync--"
 865 "Tsuki-no-Maiogi" duration 3
 876 "Bright/Dark Blade"
 877 "Waning/Waxing Grudge"
-
-
-
-
-
-
-


### PR DESCRIPTION
Fixed some timing issues in Ridorana and added the add phase in Tsukuyomi. Weirdly, line 17 doesn't work even though I'm sure that line is present in the logs. Not sure what's up with that, probably a FFXIV plugin hiccup, but it only causes Concentrativity to show the wrong timing and it's pretty clearly visible. Might want to just hide that for now though.

Can see the Tsukuyomi timeline in action here: https://www.twitch.tv/videos/265667584?t=1h19m15s

I did learn from this low-dps learning party that the middle phase isn't actually a real loop, it will only run until the second Antitwilight/Perilune, so I might change that from a loop to the real sequence, but this is good enough to be useful as-is.