### PR TITLE
util: Adding starting work on automated timeline testing

### DIFF
--- a/util/test_timeline.py
+++ b/util/test_timeline.py
@@ -1,0 +1,221 @@
+import argparse
+from datetime import datetime
+import fflogs
+import os
+from pathlib import Path
+import re
+
+def load_timeline(timeline):
+    """Loads a timeline file into a list of entry dicts"""
+    timelist = []
+    with timeline as file:
+        for line in file:
+            # Ignore comments, alertall, hideall, etc by
+            # only reading lines starting with a number
+            if not line[0].isdigit():
+                continue
+
+            entry = {}
+            # Remove trailing comment, if any
+            clean_line = line.split('#')[0]
+
+            # Split the line into sections
+            match = re.search(r'^(?P<time>\d+)\s+"(?P<label>[^"]+)"\s+(?P<options>.+)', clean_line)
+            if not match:
+                continue
+
+            entry['time'] = float(match.group('time'))
+            entry['label'] = match.group('label')
+
+            # Get the sync format into the file format
+            sync_match = re.search(r'sync /([^/]+)/', match.group('options'))
+            if not sync_match:
+                continue
+
+            entry['regex'] =  sync_match.group(1).replace(':', '\|')
+            entry['seen'] = 0
+
+            # Get the start and end of the sync window
+            window_match = re.search(r'window ([\d\.]+),?(\d\.]+)?', match.group('options'))
+            
+            if window_match:
+                pre_window = float(window_match.group(1))
+                if window_match.group(2):
+                    post_window = float(window_match.group(2))
+                else:
+                    post_window = pre_window
+            else:
+                pre_window = 2.5
+                post_window = 2.5
+
+            entry['start'] = max(0, entry['time'] - pre_window)
+            entry['end'] = entry['time'] + post_window
+
+            # Get the jump time, if any
+            jump_match = re.search(r'jump ([\d\.]+)', match.group('options'))
+
+            if jump_match:
+                entry['jump'] = float(jump_match.group(1))
+
+            # Add completed entry to the timelist
+            timelist.append(entry)
+
+    return timelist
+
+def parse_time(timestamp):
+    """Parses a timestamp into a datetime object"""
+    return datetime.strptime(timestamp, '%Y-%m-%dT%H:%M:%S')
+
+def parse_line_time(line):
+    """Parses the line's timestamp into a datetime object"""
+    time = parse_time(line[3:22])
+    time = time.replace(microsecond=int(line[23:29]))
+    return time
+
+def run_file(args, timelist):
+    """Runs a timeline against a specified file"""
+    last_entry = False
+    last_sync_position = 0
+    last_jump = 0
+    file_started = False
+    timeline_stopped = True
+
+    with args.file as file:
+        for line in file:
+            # Scan the file until the start timestamp
+            if not file_started and line[14:26] != args.start:
+                continue
+
+            if line[14:26] == args.end:
+                break
+
+            # We're at the start of the encounter now.
+            if not file_started:
+                file_started = True
+                last_sync_timestamp = parse_line_time(line)
+
+            # Get amount of time that's passed since last sync point
+            if timeline_stopped:
+                time_progress_seconds = 0
+            else:
+                time_progress_delta = parse_line_time(line) - last_sync_timestamp
+                time_progress_seconds = time_progress_delta.seconds + time_progress_delta.microseconds / 1000000
+
+            # Get where the timeline would be at this time
+            timeline_position = last_sync_position + time_progress_seconds
+
+            # Search timelist for matches
+            for entry in timelist:
+                if (
+                        'regex' in entry and
+                        re.search(entry['regex'], line) and
+                        timeline_position >= entry['start'] and
+                        timeline_position <= entry['end']
+                ):
+                    # Flag as seen
+                    if last_entry == entry:
+                        continue
+                    
+                    entry['seen'] += 1
+                    last_entry = entry
+
+                    # Check the timeline drift for anomolous timings
+                    drift = entry['time'] - timeline_position
+                    print("{:.3f}: Matched entry: {} {} ({:+.3f}s)".format(timeline_position, entry['time'], entry['label'], drift))
+
+                    if time_progress_seconds > 30:
+                        print("    {:.3f}s since last sync".format(time_progress_seconds))
+
+                    # Find any syncs before this one that were passed without syncing
+                    if not timeline_stopped:
+                        for other_entry in timelist:
+                            if (
+                                    'regex' in other_entry and
+                                    other_entry['time'] > last_jump and
+                                    other_entry['time'] < entry['time'] and
+                                    other_entry['seen'] < entry['seen']
+                            ):
+                                print("        Prior sync missing or outside window: {} at {}".format(other_entry['label'], other_entry['time']))
+                                other_entry['seen'] = entry['seen']
+
+                    # Carry out the sync to make this the new baseline position
+                    if timeline_stopped:
+                        last_jump = entry['time']
+                    timeline_stopped = False
+                    last_sync_timestamp = parse_line_time(line)
+
+                    if 'jump' in entry:
+                        if entry['jump'] == 0:
+                            print("---!Resetting encounter from {}!---".format(last_sync_position))
+                            timeline_stopped = True
+                        else:
+                            print("    Jumping to {:.3f}".format(entry['jump']))
+                        last_jump = entry['jump']
+                        last_sync_position = entry['jump']
+                    else:
+                        last_sync_position = entry['time']
+
+def main(args):
+    # Parse timeline file
+    timelist = load_timeline(args.timeline)
+
+    if args.file:
+        run_file(args, timelist)
+
+
+def timeline_file(arg):
+    """Defines the timeline file argument type"""
+    path = Path('../ui/raidboss/data/timelines/' + arg + '.txt')
+
+    if not path.exists():
+        raise argparse.ArgumentTypeError("Could not load timeline at " + path)
+    else:
+        return path.open()
+
+def timestamp_type(arg):
+    """Defines the timestamp input format"""
+    if re.match(r'\d{2}:\d{2}:\d{2}\.\d{3}', arg) is None:
+        raise argparse.ArgumentTypeError("Invalid timestamp format. Use the format 12:34:56.789")
+    return arg
+
+if __name__ == "__main__":
+    # Set up all of the arguments
+    example_usage = """
+    example:
+        make_timeline.py -f "%APPDATA%\\Advanced Combat Tracker\\FFXIVLogs\\Network_20180206.log" -s 12:30:45.156 -e 12:43:51.395 -t ultima_weapon_ultimate
+
+        Scans Network_20180206.log, starts the encounter at 12:30:45.156, and crawls until
+        12:43:51.395, comparing against the ultima_weapon_ultimate timeline"""
+
+    parser = argparse.ArgumentParser(
+        description="Creates a timeline from a logged encounter",
+        epilog=example_usage,
+        formatter_class=argparse.RawDescriptionHelpFormatter)
+
+    # Add main input vector, fflogs report or network log file
+    group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument('-r', '--report', help="The ID of an FFLogs report")
+    group.add_argument('-f', '--file', type=argparse.FileType('r', encoding="utf8"), help="The path of the log file")
+
+    # Report arguments
+    parser.add_argument('-k', '--key', help="The FFLogs API key to use, from https://www.fflogs.com/accounts/changeuser")
+    parser.add_argument('-rf', '--fight', type=int, help="Fight ID of the report to use. Defaults to longest in the report")
+
+    # Log file arguments
+    parser.add_argument('-s', '--start', type=timestamp_type, help="Timestamp of the start, e.g. '12:34:56.789")
+    parser.add_argument('-e', '--end', type=timestamp_type, help="Timestamp of the end, e.g. '12:34:56.789")
+
+    # Filtering arguments
+    parser.add_argument('-t', '--timeline', type=timeline_file, help="The filename of the timeline to test against, e.g. ultima_weapon_ultimate")
+
+    args = parser.parse_args()
+
+    # Check dependent args
+    if args.file and not (args.start and args.end):
+        raise parser.error("Log file input requires start and end timestamps")
+    
+    if args.report and not args.key:
+        raise parser.error("FFlogs parsing requires an API key. Visit https://www.fflogs.com/profile and use the Public key")
+
+    # Actually call the script
+    main(args)

--- a/util/test_timeline.py
+++ b/util/test_timeline.py
@@ -36,11 +36,11 @@ def load_timeline(timeline):
             entry['seen'] = 0
 
             # Get the start and end of the sync window
-            window_match = re.search(r'window ([\d\.]+),?(\d\.]+)?', match.group('options'))
+            window_match = re.search(r'window ([\d\.]+),?([\d\.]+)?', match.group('options'))
             
             if window_match:
                 pre_window = float(window_match.group(1))
-                if window_match.group(2):
+                if window_match.group(2) != None:
                     post_window = float(window_match.group(2))
                 else:
                     post_window = pre_window


### PR DESCRIPTION
Hello! I haven't done much in a while, but I had a spare weekend and decided to put it towards cactbot.

The goal for this is to have a system where we can point to a timeline, point to a log, and run that timeline against that log to see how it lines up. This will complement (possibly replace, but probably not completely) the old process of making a timeline, recording a vod of it, going over it later to see where it desynced, and so on. It's pretty basic right now, but it should get there eventually. Hopefully before 4.4.

Syntax is similar to make_timeline, with the added argument of a timeline filename. I ran the uwu timeline against the furthest pull i have (suppression gaol) like so:

```
test_timeline.py -f "%APPDATA%\Advanced Combat Tracker\FFXIVLogs\Network_20180727.log" -s 19:11:46.000 -e 19:25:29.442 -t ultima_weapon_ultimate > out.txt
```

and the result is here: [out.txt](https://github.com/quisquous/cactbot/files/2239934/out.txt)

Some things to note about the output, I'll probably clean some of these up eventually.

- Downburst missing at 27.0 actually happened at 29.6 or so. I might make an expanded pseudo-window in order to catch cases like that, to give better context instead of just shrugging and saying they're missing
- All the missing stuff after 100.470 (and several other places later): It synced Eye of the Storm at both 19:13:23.834 and 19:13:26.850. I keep track of the number of times each entry has been synced in order to print when something gets missed. Since it saw the same Eye of the Storm entry twice, it assumed that there'd been a loop and it simply missed all of the syncs since the target of last jump. In this case, there was no jump, so it just replayed from the beginning, as though there was a jump 0 and then fast-forwarded to the repeat Eye of the Storm. I'm sure there's a way to address this case, I just have to spend some more time thinking about it.

Let me know if there's any particular timeline-making pitfalls you run into that could be built into this thing, too! I want to get it up and running with fflogs next, even though it will have the caveats of not syncing encounter start/end (because fflogs doesn't record Heehee HAHA hahaha HEEHEE haha HEEEEEE, for example), and I'll have to re-parse out the specific format of :Actor:####: into its constituent fflogs fields.