### PR TITLE
util: Changing make_timeline to round to tenths of seconds

### DIFF
--- a/util/make_timeline.py
+++ b/util/make_timeline.py
@@ -129,7 +129,7 @@ def main(args):
     phases = {}
     for phase in args.phase:
         ability, time = phase.split(':')
-        phases[ability] = int(time)
+        phases[ability] = float(time)
 
     # Get the entry list
     if args.report:
@@ -169,20 +169,20 @@ def main(args):
         last_time_diff_us = last_time_diff.microseconds
         drift = False
 
-        # Round up to the second
-        if last_time_diff_us > 800000:
-            last_time_diff_sec += 1
+        # Round up to the tenth of second
+        if last_time_diff_us > 80000:
+            last_time_diff_sec += .1
 
         # Round up with a note about exceptional drift
-        elif last_time_diff_us > 500000:
-            last_time_diff_sec += 1
-            drift = -1000000 + last_time_diff_us
+        elif last_time_diff_us > 50000:
+            last_time_diff_sec += .1
+            drift = -100000 + last_time_diff_us
 
         # Round down with a note about exceptional drift
-        elif last_time_diff_us > 200000:
+        elif last_time_diff_us > 20000:
             drift = last_time_diff_us
         
-        # If <200ms then there's no need to adjust sec or drift
+        # If <20ms then there's no need to adjust sec or drift
         else:
             pass
 
@@ -198,7 +198,7 @@ def main(args):
         entry['position'] = timeline_position
 
         # Write the line
-        output_entry = '{position} "{ability_name}" sync /:{combatant}:{ability_id}:/'.format(**entry)
+        output_entry = '{position:.1f} "{ability_name}" sync /:{combatant}:{ability_id}:/'.format(**entry)
         if drift:
             output_entry += ' # drift {}'.format(drift/1000000)
 


### PR DESCRIPTION
We'd mentioned this in prior PRs, but the timing on some of the O9S stuff was frustratingly half-second in enough places that I went ahead and made the change. As expected, it makes timelines that gradually increase that decimal place, but it should be a better reflection of what's actually happening, instead of the platonic ideal of how the game is coded. It's also going to mean a lot of variance between pulls, so some care should be taken when combining data from multiple pulls to line up a common starting point; a 100.5 in one pull might well be a 99.9 in another, and both will end up with the timer looking right in-game, but it would mess with it a bit if you then take an ability at 102.5 in the first pull and put it at 102.5 in the second pull, for example.