### PR TITLE
Adding O10S timeline

### DIFF
--- a/ui/raidboss/data/timelines/o10s.txt
+++ b/ui/raidboss/data/timelines/o10s.txt
@@ -44,17 +44,8 @@ hideall "--sync--"
 186.3 "Horrid Roar" sync /:Midgardsormr:31B9:/
 
 # Add phase
-209.3 "Frost Breath" sync /:Ancient Dragon:33F1:/ # drift 0.048
-215.3 "Rime Wreath" sync /:Ancient Dragon:33F2:/ window 10,10
-219.3 "Frost Breath" sync /:Ancient Dragon:33F1:/
-229.4 "Frost Breath"
-233.4 "Rime Wreath"
-239.4 "Frost Breath"
-249.5 "Rime Wreath"
-251.5 "Frost Breath"
-261.5 "Frost Breath"
-265.5 "Rime Wreath"
-271.5 "Frost Breath"
+209.3 "Frost Breath" sync /:Ancient Dragon:33F1:/ window 2.5,30
+219.3 "Frost Breath ready"
 
 277.6 "Protostar" sync /:Midgardsormr:31C3:/ window 500,500
 

--- a/ui/raidboss/data/timelines/o10s.txt
+++ b/ui/raidboss/data/timelines/o10s.txt
@@ -1,1 +1,204 @@
 # Omega - Alphascape V2.0 (Savage) - O10S
+# -ii 31FA 3249 3630 3623 35BB 35BC 31D6 31B7 31C4 362C 321E 320D
+
+hideall "--Reset--"
+hideall "--sync--"
+
+0.0 "--Reset--" sync /Removing combatant Midgardsormr.  Max HP: \d{8}/ window 10000 jump 0
+
+0.0 "Start" sync /0044:I am Midgardsormr/ window 0,1
+2.2 "--sync--" sync /:Midgardsormr:31F9:/ window 2.5,0 # first auto
+12.1 "Flip" sync /:Midgardsormr:31AD:/
+23.1 "Spin" sync /:Midgardsormr:31AE:/
+27.1 "Cardinals" sync /:31B3:/ # X hit, not sure of sync yet
+
+35.1 "Spin" sync /:Midgardsormr:31AC:/ # drift 0.029
+46.2 "Akh Morn" sync /:Midgardsormr:31AB:/
+52.3 "Spin" sync /:Midgardsormr:31AE:/
+55.4 "Out" sync /:Midgardsormr:31B2:/
+67.5 "Tail End" sync /:Midgardsormr:31AA:/
+
+75.5 "Spin" sync /:Midgardsormr:31AC:/ # drift 0.039
+86.5 "Flip/Spin" sync /:Midgardsormr:31(AE|B0)/
+89.6 "In/Out" sync /:(Midgardsormr)?:31B(2|4):/ # Sometimes missing actor name
+89.6 "Earth Shaker" sync /:Midgardsormr:31B6:/ # Missing actor name on all but one
+
+97.7 "Flip" sync /:Midgardsormr:31AD:/
+107.7 "Tail End" sync /:Midgardsormr:31AA:/
+109.7 "Flip/Spin" sync /:Midgardsormr:31(AE|B0):/
+113.7 "Corners/Cardinals" sync /:Midgardsormr:31B(3|5):/
+113.8 "Thunderstorm" sync /:Midgardsormr:31B8:/
+
+125.9 "Time Immemorial" sync /:Midgardsormr:32EF:/
+135.9 "Tail End" sync /:Midgardsormr:31AA:/
+143.9 "Spin" sync /:Midgardsormr:31AC:/ # drift 0.041
+152.9 "Northern Cross" sync /:Midgardsormr:3625:/
+156.9 "Flip/Spin" sync /:Midgardsormr:31AE:/ # drift 0.021
+160.0 "In/Out" sync /:Midgardsormr:31B(2|4):/
+166.1 "Akh Rhai" sync /:Midgardsormr:3622:/
+168.1 "Dry Ice" sync /:Midgardsormr:3631:/
+
+172.1 "Spin" sync /:Midgardsormr:31AC:/ # drift 0.036
+183.1 "Flip/Spin" sync /:Midgardsormr:31(AE|B0):/
+186.2 "In/Out" sync /:Midgardsormr:31B(2|4):/
+186.3 "Horrid Roar" sync /:Midgardsormr:31B9:/
+
+# Add phase
+209.3 "Frost Breath" sync /:Ancient Dragon:33F1:/ # drift 0.048
+215.3 "Rime Wreath" sync /:Ancient Dragon:33F2:/ window 10,10
+219.3 "Frost Breath" sync /:Ancient Dragon:33F1:/
+229.4 "Frost Breath"
+233.4 "Rime Wreath"
+239.4 "Frost Breath"
+249.5 "Rime Wreath"
+251.5 "Frost Breath"
+261.5 "Frost Breath"
+265.5 "Rime Wreath"
+271.5 "Frost Breath"
+
+277.6 "Protostar" sync /:Midgardsormr:31C3:/ window 500,500
+
+303.7 "Horrid Roar" sync /:Midgardsormr:31B9:/
+304.8 "Thunderstorm" sync /:Midgardsormr:31B8:/
+304.9 "Cauterize" sync /:Midgardsormr:3240:/
+313.0 "Horrid Roar" sync /:Midgardsormr:31B9:/
+314.1 "Thunderstorm" sync /:Midgardsormr:31B8:/
+314.2 "Cauterize" sync /:Midgardsormr:3240:/
+318.2 "Touchdown" sync /:Midgardsormr:31BB:/
+
+329.2 "Time Immemorial" sync /:Midgardsormr:31BF:/
+340.2 "Crimson Breath" sync /:Midgardsormr:31BC:/
+347.3 "Crimson Breath" sync /:Midgardsormr:31BC:/
+354.4 "Crimson Breath" sync /:Midgardsormr:31BC:/
+361.5 "Crimson Breath" sync /:Midgardsormr:31BC:/
+375.7 "Flame Blast"
+377.8 "Horrid Roar" sync /:Midgardsormr:3414:/
+377.8 "Flame Blast"
+379.9 "Flame Blast"
+383.1 "Hot Tail" sync /:Midgardsormr:31BD:/
+
+398.1 "Exaflare"
+398.2 "Horrid Roar" sync /:Midgardsormr:31B9:/
+400.2 "Cauterize" sync /:Midgardsormr:3240:/
+400.3 "Exaflare"
+402.4 "Exaflare"
+405.4 "Exaflare"
+407.4 "Horrid Roar" sync /:Midgardsormr:31B9:/ # drift 0.033
+407.5 "Exaflare"
+408.5 "Cauterize" sync /:Midgardsormr:3240:/ # drift 0.048
+426.6 "Tail End" sync /:Midgardsormr:31AA:/
+437.7 "Akh Morn" sync /:Midgardsormr:31AB:/ # drift -0.033
+446.8 "Horrid Roar" sync /:Midgardsormr:31B9:/
+447.9 "Thunderstorm" sync /:Midgardsormr:31B8:/
+
+##################
+## Branch point ##
+##################
+
+454.0 "Flip/Spin" sync /:Midgardsormr:31AC:/ jump 1454.0 # C means spin
+454.0 "--sync--" sync /:Midgardsormr:31AD:/ jump 2454.0 # D means flip
+464.0 "Tail End" # Cosmetic
+466.0 "Flip/Spin"
+469.1 "In/Out"
+469.2 "Earth Shaker"
+
+## Branch A1: Spin->Earthshaker
+
+1454.0 "Spin" sync /:Midgardsormr:31AC:/
+1464.0 "Tail End" sync /:Midgardsormr:31AA:/
+1466.0 "Flip/Spin" sync /:Midgardsormr:31AE:/
+1469.1 "In/Out" sync /:Midgardsormr:31B(2|4):/
+1469.2 "Earth Shaker" sync /:Midgardsormr:31B6:/
+1479.3 "Time Immemorial" sync /:Midgardsormr:32EF:/ jump 479.3
+1488.4 "Exaflare" # Cosmetic
+1489.4 "Dry Ice"
+1490.5 "Exaflare"
+1493.5 "Exaflare"
+1495.6 "Akh Morn"
+1498.7 "Exaflare"
+
+## Branch B1: Flip->Thunderstorm
+
+2454.0 "Flip" sync /:Midgardsormr:31AD:/
+2464.0 "Tail End" sync /:Midgardsormr:31AA:/
+2466.0 "Flip/Spin" sync /:Midgardsormr:31AE:/
+2469.1 "Corners/Cardinals" sync /:Midgardsormr:31B(3|5):/
+2469.2 "Thunderstorm" sync /:Midgardsormr:31B8:/
+2479.3 "Time Immemorial" sync /:Midgardsormr:32EF:/ jump 479.3
+2488.4 "Exaflare" # Cosmetic
+2489.4 "Dry Ice"
+2490.5 "Exaflare"
+2493.5 "Exaflare"
+2495.6 "Akh Morn"
+2498.7 "Exaflare"
+
+##################################
+## Branches A1/B1 converge back ##
+##################################
+
+479.3 "Time Immemorial" sync /:Midgardsormr:32EF:/
+488.4 "Exaflare"
+489.4 "Dry Ice" sync /:Midgardsormr:3631:/
+490.5 "Exaflare"
+493.5 "Exaflare"
+495.6 "Akh Morn" sync /:Midgardsormr:31AB:/
+495.7 "Exaflare"
+498.7 "Exaflare"
+
+##################
+## Branch point ##
+##################
+
+509.8 "Flip/Spin" sync /:Midgardsormr:31AC:/ jump 1509.8 # C means spin->shaker
+509.8 "--sync--" sync /:Midgardsormr:31AD:/ jump 2509.8 # D means flip->thunder
+518.8 "Northern Cross" # Cosmetic
+522.8 "Spin/Flip"
+526.8 "Position"
+526.9 "Shaker/Thunder"
+
+## Branch A2: Spin->Earthshaker
+1509.8 "Spin" sync /:Midgardsormr:31AC:/
+1518.8 "Northern Cross" sync /:Midgardsormr:3625:/
+1522.8 "Spin/Flip" sync /:Midgardsormr:31AE:/
+1526.8 "In/Out" sync /:Midgardsormr:31B(2|4):/
+1525.9 "Earth Shaker" sync /:Midgardsormr:31B6:/
+1534.0 "Horrid Roar" sync /:Midgardsormr:31B9:/ jump 534.0
+1545.0 "Akh Rhai" # Cosmetic
+1551.0 "Tail End"
+1559.0 "Flip/Spin"
+
+## Branch B2: Flip->Thunderstorm
+2509.8 "Flip" sync /:Midgardsormr:31AD:/
+2518.8 "Northern Cross" sync /:Midgardsormr:3625:/
+2522.8 "Spin/Flip" sync /:Midgardsormr:31AE:/
+2525.8 "Corners/Cardinals" sync /:Midgardsormr:31B(3|5):/
+2525.9 "Thunderstorm" sync /:Midgardsormr:31B8:/
+2534.0 "Horrid Roar" sync /:Midgardsormr:31B9:/ jump 534.0
+2545.0 "Akh Rhai" # Cosmetic
+2551.0 "Tail End"
+2559.0 "Flip/Spin"
+
+##################################
+## Branches A2/B2 converge back ##
+##################################
+
+534.0 "Horrid Roar" sync /:Midgardsormr:31B9:/
+545.0 "Akh Rhai" sync /:Midgardsormr:3622:/
+551.0 "Tail End" sync /:Midgardsormr:31AA:/ # drift 0.026
+
+##################
+## Branch point ##
+##################
+
+# Return to A1/B1
+559.0 "Flip/Spin" sync /:Midgardsormr:31AC:/ jump 1454.0 # C means spin->shaker
+559.0 "--sync--" sync /:Midgardsormr:31AD:/ jump 2454.0 # D means flip->thunder
+569.0 "Tail End" # Cosmetic
+571.0 "Flip/Spin"
+574.1 "Positions"
+574.2 "Shaker/Thunder"
+584.3 "Time Immemorial"
+
+# Enrage
+700.0 "--sync--" sync /:3247:Midgardsormr/ window 700,3000
+705.0 "Enrage"


### PR DESCRIPTION
Technically, I believe these are the flip mechanics:

Coil - first spin, either orientation. 31AC is spin, 31AD is flip
Azure Wings - second spin, either orientation. 31AE is spin, 31B0 is flip
Collectively: Flip/Spin

Azure Wings - hits under the boss into max melee range, changed to In (31B2)
Stygian Maw - hits outside the boss's targetting circle changed to Out (31B4)
Collectively: In/Out

Crimson Wings - hits corners in an X, changed to Cardinals (31B3)
Bloodied Maw - hits a cross to the boss's front, rear, and sides, changed to Corners (31B5)
Collectively: Cardinals/Corners

All final actions together collectively (only shown in the cosmetic fake future parts): Positions

I'm normally very much in favor of leaving original mechanic names in whenever possible, since I believe a timeline should show what is about to happen rather than what to do about it. In this case though, the doubling up of the name Azure Wings and the lack of cast bars makes it difficult to justify. The only time the damage mechanic names appear is when someone gets hit by it, and I don't believe the real flip/spin names are seen anywhere at all. Feel free to change flip/spin to names you prefer if you'd like, I'm not sure how clear they are.

Next, I chose Cardinals/Corners to say where the safe spot is, to continue the style of In/Out which also indicate the safe spot rather than the dangerous spot, but I'm not particularly married to the terms. It feels unintuitive for some reason, so I'm open to swapping those or even changing them for new names I haven't thought of that would better indicate, at a glance, the meaning.

The add phase doesn't really sync properly, and probably never will without an overhaul to the timeline foundations. It does seem to consistently start with Frost Breath at 209, and will do its first Rime Wreath at 215. Frost Breath has a 10 second cooldown, Rime Wreath has a 15 second cooldown. As you might have guessed, both come up around 230, then, and it seems random which one it opts to use first. I've made the consistent ones synced and the rest cosmetic for that reason. It might be a better job for triggers to handle tracking the cooldowns of each and showing Frost Breath to tanks, and both to healers when the cooldowns are nearly up.

Lastly, there's the time-based enrage. The final phase has a loop, which, in the timeline, jumps back to an earlier part. It never completely finishes the second loop, though, as it jumps to enrage at 10:30, and where in the loop you hit 10:30 is determined by your nail phase speed. It is sometimes right after the second round of Exaflare and Akh Morn, and it is sometimes after another set of spin/flip roulette. I opted to not enter a whole third branch for this, and instead reuse the first ones. This means it won't show an enrage timer when nearing enrage, until the actual cast starts, but the enrage timer wouldn't have been accurate anyway.

I've tested up through about 450.0 ingame, and I've tested the whole thing with test_timeline against both a clear log and an enrage log provided by friends. I might be able to test it tomorrow but my raid schedule is in the air right now.