### PR TITLE
util: Fix test_timeline forward syncs

### DIFF
--- a/util/test_timeline.py
+++ b/util/test_timeline.py
@@ -244,7 +244,7 @@ def check_event(event, timelist, state):
                 timeline_position <= entry['end']
         ):
             # Flag with current branch
-            if state['last_entry'] == entry:
+            if state['last_entry'] == entry and time_progress_seconds < 2.5:
                 continue
 
             entry['branch'] = state['branch']


### PR DESCRIPTION
This is a change that allows it to sync the Frost Breaths in O10S properly. Previously it would ignore multiple syncs to the same entry to avoid the issue of spamming one sync repeatedly, but an exception should be made for wide windows where that's potentially the intent.