### PR TITLE
raidboss: Adding Suzaku EX timeline

### DIFF
--- a/ui/raidboss/data/manifest.txt
+++ b/ui/raidboss/data/manifest.txt
@@ -19,6 +19,7 @@ timelines/sephirot-ex.txt
 timelines/shinryu-ex.txt
 timelines/sophia-ex.txt
 timelines/susano-ex.txt
+timelines/suzaku-ex.txt
 timelines/tsukuyomi-ex.txt
 timelines/o1s.txt
 timelines/o2s.txt
@@ -69,6 +70,7 @@ triggers/sephirot-ex.js
 triggers/shinryu-ex.js
 triggers/sophia-ex.js
 triggers/susano-ex.js
+triggers/suzaku-ex.js
 triggers/tsukuyomi-ex.js
 triggers/o1s.js
 triggers/o2s.js

--- a/ui/raidboss/data/timelines/suzaku-ex.txt
+++ b/ui/raidboss/data/timelines/suzaku-ex.txt
@@ -1,0 +1,122 @@
+# Suzaku Extreme
+# -ii 32DC 32E5
+
+hideall "--Reset--"
+hideall "--sync--"
+
+0.0 "--Reset--" sync /Removing combatant Suzaku\.  Max HP: \d{8}/ window 10000 jump 0
+
+0.0 "Start" sync /0044:Tenzen/
+2.5 "--sync--" sync /:Suzaku:367:/ window 5,0
+11.5 "Screams Of The Damned" sync /:Suzaku:32D2:/ window 12,20
+24.5 "Rout" sync /:Suzaku:32F0:/
+26.2 "Rekindle" sync /:Suzaku:32E0:/
+35.3 "Fleeting Summer" sync /:Suzaku:32D3:/
+42.8 "Cremate" sync /:Suzaku:32D1:/
+54.3 "Phoenix Down" sync /:Suzaku:3224:/
+67.4 "Rekindle" sync /:Suzaku:32E0:/
+78.5 "Cremate" sync /:Suzaku:32D1:/
+79.6 "Wing And A Prayer" sync /:Scarlet Tail Feather:32D4:/
+92.2 "Screams Of The Damned" sync /:Suzaku:32D2:/
+109.2 "Eternal Flame" sync /:Suzaku:3222:/ # drift 0.023
+111.3 "--unatargetable--"
+
+# DDR phase
+126.5 "--sync--" sync /:Suzaku:3226:/
+132.7 "--sync--" sync /:Suzaku:3485:/
+137.8 "Scarlet Hymn"
+138.9 "Scarlet Hymn"
+140.0 "Scarlet Hymn"
+144.6 "--sync--" sync /:Suzaku:3486:/
+147.7 "Scarlet Hymn"
+149.8 "Scarlet Hymn"
+150.9 "Scarlet Hymn"
+152.0 "Scarlet Hymn"
+154.2 "Scarlet Hymn"
+156.3 "Scarlet Hymn"
+157.5 "Scarlet Hymn"
+174.7 "Scarlet Fever" sync /:Suzaku:32D9:/ window 165,20
+
+# Main phase
+179.9 "--targetable--"
+189.4 "Southron Star" sync /:Suzaku:32DF:/ window 20,20
+195.0 "--sync--" sync /:Suzaku:322E:/
+200.1 "Mesmerizing Melody" sync /:Suzaku:32DA:/
+208.1 "Well Of Flame" sync /:Suzaku:32E1:/
+208.8 "Rekindle" sync /:Suzaku:32E0:/
+215.2 "Scathing Net" sync /:Suzaku:3243:/
+220.2 "Phantom Flurry" sync /:Suzaku:32DD:/ # drift 0.035
+226.3 "Phantom Half" sync /:Suzaku:32DE:/
+
+# Simon says 1 (8+8)
+231.0 "Scarlet Hymn" sync /:Suzaku:3237:/
+252.1 "Hotspot x8" duration 7.7
+269.9 "Hotspot x8" duration 7.7
+
+# Back to center
+286.7 "--sync--" sync /:Suzaku:323A:/ window 20,20
+288.8 "--sync--" sync /:Suzaku:322E:/
+294.2 "Ruthless/Mesmerizing" sync /:Suzaku:32D(A|B):/
+305.3 "Close-Quarter Crescendo" sync /:Suzaku:32E4:/
+317.4 "Pay The Piper"
+321.1 "--sync--" sync /:Suzaku:322E:/
+327.0 "Well Of Flame" sync /:Suzaku:32E1:/
+327.6 "Rekindle" sync /:Suzaku:32E0:/
+334.1 "Scathing Net" sync /:Suzaku:3243:/
+338.2 "Phantom Flurry" sync /:Suzaku:32DD:/
+344.4 "Phantom Half" sync /:Suzaku:32DE:/
+
+# Simon Says 2 (8+8 with aoe)
+350.7 "Scarlet Hymn" sync /:Suzaku:3237:/
+360.2 "--sync--" sync /:Suzaku:322E:/
+365.3 "Ruthless/Mesmerizing" sync /:Suzaku:32D(A|B):/
+370.4 "Hotspot x8" duration 7.7
+385.9 "Southron Star" sync /:Suzaku:32DF:/
+391.0 "Hotspot x8" duration 7.7
+
+# Back to center
+407.5 "--sync--" sync /:Suzaku:323A:/
+413.6 "Phantom Flurry" sync /:Suzaku:32DD:/
+419.7 "Phantom Half" sync /:Suzaku:32DE:/
+430.4 "Southron Star" sync /:Suzaku:32DF:/
+442.0 "Incandescent Interlude" sync /:Suzaku:323C:/
+446.1 "--sync--" sync /:Suzaku:322E:/
+452.1 "Ruthless Refrain" sync /:Suzaku:32DB:/
+454.6 "Rekindle" sync /:Suzaku:32E0:/
+459.5 "Well Of Flame" sync /:Suzaku:32E1:/
+
+# Simon Says 2 (4+4+4+4 with forced march, knock/draw, phantom half)
+466.7 "Scarlet Hymn" sync /:Suzaku:3237:/
+483.6 "Well Of Flame" sync /:Suzaku:32E1:/
+484.3 "Rekindle" sync /:Suzaku:32E0:/
+489.4 "Hotspot x4" duration 3.3
+496.6 "Close-Quarter Crescendo" sync /:Suzaku:32E4:/
+508.7 "Pay the Piper"
+508.8 "Hotspot x4" duration 3.3
+517.9 "--sync--" sync /:Suzaku:322E:/
+523.4 "Ruthless/Mesmerizing" sync /:Suzaku:32D(A|B):/
+528.5 "Hotspot x4" duration 3.3
+539.6 "Phantom Flurry" sync /:Suzaku:32DD:/
+545.8 "Phantom Half" sync /:Suzaku:32DE:/
+547.9 "Hotspot x4" duration 3.3
+
+# Back to center
+562.4 "--sync--" sync /:Suzaku:323A:/
+572.5 "Southron Star" sync /:Suzaku:32DF:/
+580.0 "--sync--" sync /:Suzaku:322E:/
+585.5 "Ruthless/Mesmerizing" sync /:Suzaku:32D(A|B):/
+597.9 "Well Of Flame" sync /:Suzaku:32E1:/
+598.5 "Rekindle" sync /:Suzaku:32E0:/
+605.1 "Scathing Net" sync /:Suzaku:3243:/
+610.2 "Phantom Flurry" sync /:Suzaku:32DD:/
+616.4 "Phantom Half" sync /:Suzaku:32DE:/
+626.5 "Southron Star" sync /:Suzaku:32DF:/
+633.6 "--sync--" sync /:Suzaku:322E:/
+638.7 "Ruthless/Mesmerizing" sync /:Suzaku:32D(A|B):/
+651.8 "Southron Star" sync /:Suzaku:32DF:/
+658.0 "Phantom Flurry" sync /:Suzaku:32DD:/
+664.1 "Phantom Half" sync /:Suzaku:32DE:/
+
+# Enrage
+665.2 "Scarlet Hymn" sync /:Suzaku:3237:/
+675.3 "Enrage"

--- a/ui/raidboss/data/triggers/suzaku-ex.js
+++ b/ui/raidboss/data/triggers/suzaku-ex.js
@@ -1,0 +1,9 @@
+'use strict';
+
+// Suzaku Extreme
+[{
+  zoneRegex: /^Hells\' Kier \(Extreme\)$/,
+  timelineFile: 'suzaku-ex.txt',
+  timelineTriggers: [
+  ],
+}];


### PR DESCRIPTION
Tested this on four runs and it worked well, added in the targetable/untargetable lines afterwards from logs and I don't imagine that will break anything.

32DD and 32DE are both called Phantom Flurry; the first is the rapid tank hits and the second is the half-arena hit. I've renamed the second one to Phantom Half for clarity. 322E is the boss jump to center, but I've opted to keep it as invisible --sync-- lines since she doesn't actually drop target in that time (bless). 

I've opted to show the 10 Scarlet Hymns (DDR) individually, since it's really the only thing going on, but there's a case to make them two separate durations, for the first 3 and last 7, which come in 1 second intervals with 5 seconds between the two groups. It's debatable. The Hotspots (simon says) are durations since there actually is other stuff you care about happening in the midst of them.