### PR TITLE
Timeline fixes

### DIFF
--- a/ui/raidboss/data/timelines/o10s.txt
+++ b/ui/raidboss/data/timelines/o10s.txt
@@ -8,188 +8,204 @@ hideall "--sync--"
 
 0.0 "Start" sync /0044:I am Midgardsormr/ window 0,1
 2.2 "--sync--" sync /:Midgardsormr:31F9:/ window 2.5,0 # first auto
-12.1 "Flip" sync /:Midgardsormr:31AD:/
-23.1 "Spin" sync /:Midgardsormr:31AE:/
-27.1 "Cardinals" sync /:31B3:/ # X hit, not sure of sync yet
+12.3 "Flip" sync /:Midgardsormr:31AD:/
+23.5 "Spin" sync /:Midgardsormr:31AE:/
+27.4 "Cardinals" sync /::31B3:/ # X hit, not sure of sync yet
 
-35.1 "Spin" sync /:Midgardsormr:31AC:/ # drift 0.029
-46.2 "Akh Morn" sync /:Midgardsormr:31AB:/
-52.3 "Spin" sync /:Midgardsormr:31AE:/
-55.4 "Out" sync /:Midgardsormr:31B2:/
-67.5 "Tail End" sync /:Midgardsormr:31AA:/
+35.9 "Spin" sync /:Midgardsormr:31AC:/ # drift 0.029
+47.1 "Akh Morn" sync /:Midgardsormr:31AB:/
+53.6 "Spin" sync /:Midgardsormr:31AE:/
+57.2 "Out" sync /:Midgardsormr:31B2:/
+69.9 "Tail End" sync /:Midgardsormr:31AA:/
 
-75.5 "Spin" sync /:Midgardsormr:31AC:/ # drift 0.039
-86.5 "Flip/Spin" sync /:Midgardsormr:31(AE|B0)/
-89.6 "In/Out" sync /:(Midgardsormr)?:31B(2|4):/ # Sometimes missing actor name
-89.6 "Earth Shaker" sync /:Midgardsormr:31B6:/ # Missing actor name on all but one
+78.2 "Spin" sync /:Midgardsormr:31AC:/ # drift 0.039
+89.4 "Flip/Spin" sync /:Midgardsormr:31(AE|B0)/
+92.9 "In/Out" sync /:(Midgardsormr)?:31B(2|4):/ # Sometimes missing actor name
+92.9 "Earth Shaker" sync /:Midgardsormr:31B6:/ # Missing actor name on all but one
 
-97.7 "Flip" sync /:Midgardsormr:31AD:/
-107.7 "Tail End" sync /:Midgardsormr:31AA:/
-109.7 "Flip/Spin" sync /:Midgardsormr:31(AE|B0):/
-113.7 "Corners/Cardinals" sync /:Midgardsormr:31B(3|5):/
-113.8 "Thunderstorm" sync /:Midgardsormr:31B8:/
+101.8 "Flip" sync /:Midgardsormr:31AD:/
+112.0 "Tail End" sync /:Midgardsormr:31AA:/
+114.1 "Flip/Spin" sync /:Midgardsormr:31(AE|B0):/
+118.1 "Corners/Cardinals" sync /:Midgardsormr:31B(3|5):/
+118.7 "Thunderstorm" sync /:Midgardsormr:31B8:/
 
-125.9 "Time Immemorial" sync /:Midgardsormr:32EF:/
-135.9 "Tail End" sync /:Midgardsormr:31AA:/
-143.9 "Spin" sync /:Midgardsormr:31AC:/ # drift 0.041
-152.9 "Northern Cross" sync /:Midgardsormr:3625:/
-156.9 "Flip/Spin" sync /:Midgardsormr:31AE:/ # drift 0.021
-160.0 "In/Out" sync /:Midgardsormr:31B(2|4):/
-166.1 "Akh Rhai" sync /:Midgardsormr:3622:/
-168.1 "Dry Ice" sync /:Midgardsormr:3631:/
+131.2 "Time Immemorial" sync /:Midgardsormr:32EF:/
+141.5 "Tail End" sync /:Midgardsormr:31AA:/
+149.8 "Spin" sync /:Midgardsormr:31AC:/ # drift 0.041
+158.9 "Northern Cross" sync /:Midgardsormr:3625:/
+163.1 "Flip/Spin" sync /:Midgardsormr:31AE:/ # drift 0.021
+166.6 "In/Out" sync /:Midgardsormr:31B(2|4):/
+173.4 "Akh Rhai" sync /:Midgardsormr:3622:/
+175.3 "Dry Ice" sync /:Midgardsormr:3631:/
 
-172.1 "Spin" sync /:Midgardsormr:31AC:/ # drift 0.036
-183.1 "Flip/Spin" sync /:Midgardsormr:31(AE|B0):/
-186.2 "In/Out" sync /:Midgardsormr:31B(2|4):/
-186.3 "Horrid Roar" sync /:Midgardsormr:31B9:/
+179.7 "Spin" sync /:Midgardsormr:31AC:/ # drift 0.036
+191.0 "Flip/Spin" sync /:Midgardsormr:31(AE|B0):/
+194.5 "In/Out" sync /:Midgardsormr:31B(2|4):/
+194.9 "Horrid Roar" sync /:Midgardsormr:31B9:/
+202.9 "--untargetable--"
 
 # Add phase
-209.3 "Frost Breath" sync /:Ancient Dragon:33F1:/ window 2.5,30
-219.3 "Frost Breath ready"
+215.9 "Frost Breath" sync /:Ancient Dragon:33F1:/ window 2.5,30
+226.2 "Frost Breath ready"
 
-277.6 "Protostar" sync /:Midgardsormr:31C3:/ window 500,500
+282.0 "--sync--" sync /:Ancient Dragon:341A:/ window 80,10
+284.2 "Protostar" sync /:Midgardsormr:31C3:/ window 500,500
+294.8 "Protostar" # Damage instances
+295.9 "Protostar"
+297.0 "Protostar"
 
-303.7 "Horrid Roar" sync /:Midgardsormr:31B9:/
-304.8 "Thunderstorm" sync /:Midgardsormr:31B8:/
-304.9 "Cauterize" sync /:Midgardsormr:3240:/
-313.0 "Horrid Roar" sync /:Midgardsormr:31B9:/
-314.1 "Thunderstorm" sync /:Midgardsormr:31B8:/
-314.2 "Cauterize" sync /:Midgardsormr:3240:/
-318.2 "Touchdown" sync /:Midgardsormr:31BB:/
+310.9 "Horrid Roar" sync /:Midgardsormr:31B9:/
+312.5 "Thunderstorm" sync /:Midgardsormr:31B8:/
+313.0 "Cauterize" sync /:Midgardsormr:3240:/
+321.8 "Horrid Roar" sync /:Midgardsormr:31B9:/
+323.3 "Thunderstorm" sync /:Midgardsormr:31B8:/
+323.9 "Cauterize" sync /:Midgardsormr:3240:/
+328.0 "Touchdown" sync /:Midgardsormr:31BB:/
+332.5 "--targetable--"
 
-329.2 "Time Immemorial" sync /:Midgardsormr:31BF:/
-340.2 "Crimson Breath" sync /:Midgardsormr:31BC:/
-347.3 "Crimson Breath" sync /:Midgardsormr:31BC:/
-354.4 "Crimson Breath" sync /:Midgardsormr:31BC:/
-361.5 "Crimson Breath" sync /:Midgardsormr:31BC:/
-375.7 "Flame Blast"
-377.8 "Horrid Roar" sync /:Midgardsormr:3414:/
-377.8 "Flame Blast"
-379.9 "Flame Blast"
-383.1 "Hot Tail" sync /:Midgardsormr:31BD:/
+339.2 "Time Immemorial" sync /:Midgardsormr:31BF:/
+350.7 "Crimson Breath" sync /:Midgardsormr:31BC:/
+357.9 "Crimson Breath" sync /:Midgardsormr:31BC:/
+365.3 "Crimson Breath" sync /:Midgardsormr:31BC:/
+372.5 "Crimson Breath" sync /:Midgardsormr:31BC:/
+390.3 "Horrid Roar" sync /:Midgardsormr:3414:/
+390.3 "Flame Blast"
+392.9 "Flame Blast"
+395.3 "Flame Blast"
+396.9 "Hot Tail" sync /:Midgardsormr:31BD:/
 
-398.1 "Exaflare"
-398.2 "Horrid Roar" sync /:Midgardsormr:31B9:/
-400.2 "Cauterize" sync /:Midgardsormr:3240:/
-400.3 "Exaflare"
-402.4 "Exaflare"
-405.4 "Exaflare"
-407.4 "Horrid Roar" sync /:Midgardsormr:31B9:/ # drift 0.033
-407.5 "Exaflare"
-408.5 "Cauterize" sync /:Midgardsormr:3240:/ # drift 0.048
-426.6 "Tail End" sync /:Midgardsormr:31AA:/
-437.7 "Akh Morn" sync /:Midgardsormr:31AB:/ # drift -0.033
-446.8 "Horrid Roar" sync /:Midgardsormr:31B9:/
-447.9 "Thunderstorm" sync /:Midgardsormr:31B8:/
+408.1 "--untargetable--"
+412.3 "Exaflare"
+412.8 "Horrid Roar" sync /:Midgardsormr:31B9:/
+414.9 "Cauterize" sync /:Midgardsormr:3240:/
+415.3 "Exaflare"
+418.3 "Exaflare"
+421.4 "Exaflare"
+423.7 "Horrid Roar" sync /:Midgardsormr:31B9:/ # drift 0.033
+424.4 "Exaflare"
+425.8 "Cauterize" sync /:Midgardsormr:3240:/ # drift 0.048
+
+431.8 "--targetable--"
+444.8 "Tail End" sync /:Midgardsormr:31AA:/
+456.0 "Akh Morn" sync /:Midgardsormr:31AB:/ # drift -0.033
+466.0 "Horrid Roar" sync /:Midgardsormr:31B9:/
+467.6 "Thunderstorm" sync /:Midgardsormr:31B8:/
 
 ##################
 ## Branch point ##
 ##################
 
-454.0 "Flip/Spin" sync /:Midgardsormr:31AC:/ jump 1454.0 # C means spin
-454.0 "--sync--" sync /:Midgardsormr:31AD:/ jump 2454.0 # D means flip
-464.0 "Tail End" # Cosmetic
-466.0 "Flip/Spin"
-469.1 "In/Out"
-469.2 "Earth Shaker"
+474.4 "Flip/Spin" sync /:Midgardsormr:31AC:/ jump 1474.4 # C means spin
+474.4 "--sync--" sync /:Midgardsormr:31AD:/ jump 2474.4 # D means flip
+484.5 "Tail End" # Cosmetic
+486.6 "Flip/Spin"
+490.6 "Signal?"
+492.1 "Positions?"
 
 ## Branch A1: Spin->Earthshaker
 
-1454.0 "Spin" sync /:Midgardsormr:31AC:/
-1464.0 "Tail End" sync /:Midgardsormr:31AA:/
-1466.0 "Flip/Spin" sync /:Midgardsormr:31AE:/
-1469.1 "In/Out" sync /:Midgardsormr:31B(2|4):/
-1469.2 "Earth Shaker" sync /:Midgardsormr:31B6:/
-1479.3 "Time Immemorial" sync /:Midgardsormr:32EF:/ jump 479.3
-1488.4 "Exaflare" # Cosmetic
-1489.4 "Dry Ice"
-1490.5 "Exaflare"
-1493.5 "Exaflare"
-1495.6 "Akh Morn"
-1498.7 "Exaflare"
+1474.4 "Spin" sync /:Midgardsormr:31AC:/
+1484.5 "Tail End" sync /:Midgardsormr:31AA:/
+1486.6 "Flip/Spin" sync /:Midgardsormr:31AE:/
+1490.6 "In/Out" sync /:Midgardsormr:31B(2|4):/
+1490.6 "Earth Shaker" sync /:Midgardsormr:31B6:/
+1502.3 "Time Immemorial" sync /:Midgardsormr:32EF:/ jump 502.3
+1512.6 "Exaflare" # Cosmetic
+1513.7 "Dry Ice"
+1515.7 "Exaflare"
+1518.6 "Exaflare"
+1520.8 "Akh Morn"
+1521.7 "Exaflare"
 
 ## Branch B1: Flip->Thunderstorm
 
-2454.0 "Flip" sync /:Midgardsormr:31AD:/
-2464.0 "Tail End" sync /:Midgardsormr:31AA:/
-2466.0 "Flip/Spin" sync /:Midgardsormr:31AE:/
-2469.1 "Corners/Cardinals" sync /:Midgardsormr:31B(3|5):/
-2469.2 "Thunderstorm" sync /:Midgardsormr:31B8:/
-2479.3 "Time Immemorial" sync /:Midgardsormr:32EF:/ jump 479.3
-2488.4 "Exaflare" # Cosmetic
-2489.4 "Dry Ice"
-2490.5 "Exaflare"
-2493.5 "Exaflare"
-2495.6 "Akh Morn"
-2498.7 "Exaflare"
+2474.4 "Flip" sync /:Midgardsormr:31AD:/
+2484.5 "Tail End" sync /:Midgardsormr:31AA:/
+2486.6 "Flip/Spin" sync /:Midgardsormr:31AE:/
+2490.6 "Corners/Cardinals" sync /:Midgardsormr:31B(3|5):/
+2492.1 "Thunderstorm" sync /:Midgardsormr:31B8:/
+2502.3 "Time Immemorial" sync /:Midgardsormr:32EF:/ jump 502.3
+2512.6 "Exaflare" # Cosmetic
+2513.7 "Dry Ice"
+2515.7 "Exaflare"
+2518.6 "Exaflare"
+2520.8 "Akh Morn"
+2521.7 "Exaflare"
 
 ##################################
 ## Branches A1/B1 converge back ##
 ##################################
 
-479.3 "Time Immemorial" sync /:Midgardsormr:32EF:/
-488.4 "Exaflare"
-489.4 "Dry Ice" sync /:Midgardsormr:3631:/
-490.5 "Exaflare"
-493.5 "Exaflare"
-495.6 "Akh Morn" sync /:Midgardsormr:31AB:/
-495.7 "Exaflare"
-498.7 "Exaflare"
+502.3 "Time Immemorial" sync /:Midgardsormr:32EF:/
+512.6 "Exaflare"
+513.7 "Dry Ice" sync /:Midgardsormr:3631:/
+515.7 "Exaflare"
+518.6 "Exaflare"
+520.8 "Akh Morn" sync /:Midgardsormr:31AB:/
+521.7 "Exaflare"
+524.7 "Exaflare"
 
 ##################
 ## Branch point ##
 ##################
 
-509.8 "Flip/Spin" sync /:Midgardsormr:31AC:/ jump 1509.8 # C means spin->shaker
-509.8 "--sync--" sync /:Midgardsormr:31AD:/ jump 2509.8 # D means flip->thunder
-518.8 "Northern Cross" # Cosmetic
-522.8 "Spin/Flip"
-526.8 "Position"
-526.9 "Shaker/Thunder"
+536.8 "Flip/Spin" sync /:Midgardsormr:31AC:/ jump 1536.8 # C means spin->shaker
+536.8 "--sync--" sync /:Midgardsormr:31AD:/ jump 2536.8 # D means flip->thunder
+545.9 "Northern Cross" # Cosmetic
+550.1 "Spin/Flip"
+553.6 "Position"
+553.6 "Shaker/Thunder"
 
 ## Branch A2: Spin->Earthshaker
-1509.8 "Spin" sync /:Midgardsormr:31AC:/
-1518.8 "Northern Cross" sync /:Midgardsormr:3625:/
-1522.8 "Spin/Flip" sync /:Midgardsormr:31AE:/
-1526.8 "In/Out" sync /:Midgardsormr:31B(2|4):/
-1525.9 "Earth Shaker" sync /:Midgardsormr:31B6:/
-1534.0 "Horrid Roar" sync /:Midgardsormr:31B9:/ jump 534.0
-1545.0 "Akh Rhai" # Cosmetic
-1551.0 "Tail End"
-1559.0 "Flip/Spin"
+1536.8 "Spin" sync /:Midgardsormr:31AC:/
+1545.9 "Northern Cross" sync /:Midgardsormr:3625:/
+1550.1 "Spin/Flip" sync /:Midgardsormr:31AE:/
+1553.6 "In/Out" sync /:Midgardsormr:31B(2|4):/
+1553.6 "Earth Shaker" sync /:Midgardsormr:31B6:/
+1562.3 "Horrid Roar" sync /:Midgardsormr:31B9:/ jump 562.3
+1573.4 "Akh Rhai" # Cosmetic
+1579.6 "Tail End"
+1587.9 "Flip/Spin"
 
 ## Branch B2: Flip->Thunderstorm
-2509.8 "Flip" sync /:Midgardsormr:31AD:/
-2518.8 "Northern Cross" sync /:Midgardsormr:3625:/
-2522.8 "Spin/Flip" sync /:Midgardsormr:31AE:/
-2525.8 "Corners/Cardinals" sync /:Midgardsormr:31B(3|5):/
-2525.9 "Thunderstorm" sync /:Midgardsormr:31B8:/
-2534.0 "Horrid Roar" sync /:Midgardsormr:31B9:/ jump 534.0
-2545.0 "Akh Rhai" # Cosmetic
-2551.0 "Tail End"
-2559.0 "Flip/Spin"
+2536.8 "Flip" sync /:Midgardsormr:31AD:/
+2545.9 "Northern Cross" sync /:Midgardsormr:3625:/
+2550.1 "Spin/Flip" sync /:Midgardsormr:31AE:/
+2553.6 "Corners/Cardinals" sync /:Midgardsormr:31B(3|5):/
+2555.1 "Thunderstorm" sync /:Midgardsormr:31B8:/
+2562.3 "Horrid Roar" sync /:Midgardsormr:31B9:/ jump 562.3
+2573.4 "Akh Rhai" # Cosmetic
+2579.6 "Tail End"
+2587.9 "Flip/Spin"
 
 ##################################
 ## Branches A2/B2 converge back ##
 ##################################
 
-534.0 "Horrid Roar" sync /:Midgardsormr:31B9:/
-545.0 "Akh Rhai" sync /:Midgardsormr:3622:/
-551.0 "Tail End" sync /:Midgardsormr:31AA:/ # drift 0.026
+562.3 "Horrid Roar" sync /:Midgardsormr:31B9:/
+573.4 "Akh Rhai" sync /:Midgardsormr:3622:/
+579.6 "Tail End" sync /:Midgardsormr:31AA:/ # drift 0.026
 
 ##################
 ## Branch point ##
 ##################
 
 # Return to A1/B1
-559.0 "Flip/Spin" sync /:Midgardsormr:31AC:/ jump 1454.0 # C means spin->shaker
-559.0 "--sync--" sync /:Midgardsormr:31AD:/ jump 2454.0 # D means flip->thunder
-569.0 "Tail End" # Cosmetic
-571.0 "Flip/Spin"
-574.1 "Positions"
-574.2 "Shaker/Thunder"
-584.3 "Time Immemorial"
+587.9 "Flip/Spin" sync /:Midgardsormr:31AC:/ jump 1474.4 # C means spin->shaker
+587.9 "--sync--" sync /:Midgardsormr:31AD:/ jump 2474.4 # D means flip->thunder
+598.0 "Tail End" # Cosmetic
+600.1 "Flip/Spin"
+604.1 "Signal?"
+605.6 "Positions?"
+615.8 "Time Immemorial"
 
 # Enrage
 700.0 "--sync--" sync /:3247:Midgardsormr/ window 700,3000
-705.0 "Enrage"
+704.9 "Enrage Hit 1"
+707.2 "Enrage Hit 2"
+708.5 "Enrage Hit 3"
+709.8 "Enrage Hit 4"
+711.1 "Enrage Hit 5"
+712.2 "Enrage Hit 6"
+713.3 "Enrage Hit 7"
+714.4 "Enrage Hit 8"

--- a/ui/raidboss/data/timelines/o9s.txt
+++ b/ui/raidboss/data/timelines/o9s.txt
@@ -10,160 +10,156 @@ hideall "--sync--"
 2.5 "--sync--" sync /:Chaos:316F:/ window 3,0 # First autoattack
 
 ## Branch between Fire/Water paths
-10.1 "--sync--" sync /:317(2|3):Chaos/ jump 2010.1 # Long/lat means water path
-10.7 "--sync--" sync /:3171:Chaos/ jump 1010.7 # Edict means fire path
+10.7 "--sync--" sync /:317(2|3):Chaos/ window 12,12 jump 2010.1 # Long/lat means water path
+10.7 "--sync--" sync /:3171:Chaos/ window 12,12 jump 1010.7 # Edict means fire path
 
 # Fake water path
-15.1 "Latitudinal Implosion?"
-29.2 "Tsunami?"
-38.3 "Umbra Smash?"
-39.4 "Stray Spray?"
+15.7 "Long/Lat Implosion?"
+29.7 "Tsunami?"
+38.7 "Umbra Smash?"
+40.2 "Stray Spray?"
 
 # Fake fire path
-16.1 "Damning Edict?"
-29.1 "Blaze?"
+16.7 "Damning Edict?"
+29.9 "Blaze?"
 
 #############
 # Fire path #
 #############
 
 # Fire phase
-1016.1 "Damning Edict" sync /:Chaos:3171:/
-1029.1 "Blaze" sync /:Chaos:3206:/ # drift 0.027
-1040.2 "(T/H) Stray Flames" sync /:Chaos:318C:/
-1045.3 "Long/Lat Implosion" sync /:Chaos:317(2|3):/
-1053.4 "(DPS) Stray Flames" sync /:Chaos:318C:/
-1063.5 "Chaotic Dispersion" sync /:Chaos:3170:/
-1075.5 "Blaze" sync /:Chaos:3206:/ # drift 0.028
-1086.6 "(T/H) Stray Flames" sync /:Chaos:318C:/
-1093.7 "Knock" sync /:Chaos:317E:/
-1099.8 "(DPS) Stray Flames" sync /:Chaos:318C:/
-1103.9 "Big Bang" sync /:Chaos:3180:/
-1112.0 "Fiendish Orbs" sync /:Chaos:317C:/
+1016.7 "Damning Edict" sync /:Chaos:3171:/
+1029.9 "Blaze" sync /:Chaos:3206:/
+1041.7 "(T/H) Stray Flames" sync /:Chaos:318C:/
+1047.6 "Long/Lat Implosion" sync /:Chaos:317(2|3):/
+1055.8 "(DPS) Stray Flames" sync /:Chaos:318C:/
+1066.8 "Chaotic Dispersion" sync /:Chaos:3170:/
+1079.1 "Blaze" sync /:Chaos:3206:/ # drift 0.028
+1090.9 "(T/H) Stray Flames" sync /:Chaos:318C:/
+1098.8 "Knock" sync /:Chaos:317E:/
+1104.9 "(DPS) Stray Flames" sync /:Chaos:318C:/
+1109.8 "Big Bang" sync /:Chaos:3180:/
+1118.6 "Fiendish Orbs" sync /:Chaos:317C:/
 
 # Wind phase
-1134.0 "Cyclone" sync /:Chaos:3208:/ # drift 0.039
-1146.0 "Umbra Smash" sync /:Chaos:3175:/
-1153.1 "Cyclone" sync /:Chaos:318F:/
-1155.2 "Damning Edict" sync /:Chaos:3171:/
-1173.2 "Chaotic Dispersion" sync /:Chaos:3170:/ # drift 0.021
-1185.2 "Cyclone" sync /:Chaos:3208:/ # drift 0.027
-1197.3 "Knock" sync /:Chaos:317F:/
-1197.4 "Cyclone" sync /:Chaos:318F:/
-1203.5 "Big Bang" sync /:Chaos:3181:/
-1214.6 "Fiendish Orbs" sync /:Chaos:317D:/
+1141.0 "Cyclone" sync /:Chaos:3208:/
+1153.2 "Umbra Smash" sync /:Chaos:3175:/
+1160.7 "Cyclone" sync /:Chaos:318F:/
+1163.4 "Damning Edict" sync /:Chaos:3171:/
+1181.6 "Chaotic Dispersion" sync /:Chaos:3170:/
+1194.0 "Cyclone" sync /:Chaos:3208:/
+1207.2 "Knock" sync /:Chaos:317F:/
+1214.2 "Big Bang" sync /:Chaos:3181:/
+1225.6 "Fiendish Orbs" sync /:Chaos:317D:/
 
 # Orb phase
-1239.6 "Bowels Of Agony" sync /:Chaos:318A:/ # drift 0.04
-1253.6 "(DPS) Stray Flames" sync /:Chaos:318C:/
-1255.7 "(T/H) Stray Spray" sync /:Chaos:318D:/
-1280.8 "Soul Of Chaos" sync /:Chaos:318B:/ window 500,500 # drift -0.045
+1251.0 "Bowels Of Agony" sync /:Chaos:318A:/ # drift 0.04
+1265.1 "(DPS) Stray Flames" sync /:Chaos:318C:/
+1268.1 "(T/H) Stray Spray" sync /:Chaos:318D:/
+1293.1 "Soul Of Chaos" sync /:Chaos:318B:/ window 500,500
 
 # Water phase
-1307.6 "Long/Lat Implosion" sync /:Chaos:317(2|3):/
-1321.7 "Tsunami" sync /:Chaos:3207:/
-1330.8 "Umbra Smash" sync /:Chaos:3175:/
-1331.9 "(T/H) Stray Spray" sync /:Chaos:318D:/
-1338.9 "(DPS) Stray Spray" sync /:Chaos:318D:/
-1340.9 "Damning Edict" sync /:Chaos:3171:/
-1359.0 "Chaotic Dispersion" sync /:Chaos:3170:/
-1371.1 "Tsunami" sync /:Chaos:3207:/
-1381.2 "(T/H) Stray Spray" sync /:Chaos:318D:/
-1381.3 "Knock" sync /:Chaos:317F:/
-1387.4 "(DPS) Stray Spray" sync /:Chaos:318D:/
-1387.5 "Big Bang" sync /:Chaos:3181:/
-1398.6 "Fiendish Orbs" sync /:Chaos:317D:/
+1320.1 "Long/Lat Implosion" sync /:Chaos:317(2|3):/
+1334.5 "Tsunami" sync /:Chaos:3207:/
+1343.6 "Umbra Smash" sync /:Chaos:3175:/
+1345.1 "(T/H) Stray Spray" sync /:Chaos:318D:/
+1352.1 "(DPS) Stray Spray" sync /:Chaos:318D:/
+1353.8 "Damning Edict" sync /:Chaos:3171:/
+1371.9 "Chaotic Dispersion" sync /:Chaos:3170:/
+1384.3 "Tsunami" sync /:Chaos:3207:/
+1395.0 "(T/H) Stray Spray" sync /:Chaos:318D:/
+1395.4 "Knock" sync /:Chaos:317F:/
+1402.0 "(DPS) Stray Spray" sync /:Chaos:318D:/
+1402.3 "Big Bang" sync /:Chaos:3181:/
+1413.7 "Fiendish Orbs" sync /:Chaos:317D:/
 
 # Earth phase
-1420.7 "Earthquake" sync /:Chaos:3209:/
-1430.8 "Earthquake" sync /:Chaos:3190:/ # drift -0.022
-1433.9 "Long/Lat Implosion" sync /:Chaos:317(2|3):/
-1453.0 "Chaotic Dispersion" sync /:Chaos:3170:/
-1465.1 "Earthquake" sync /:Chaos:3209:/
-1475.2 "Earthquake" sync /:Chaos:3190:/
-1477.3 "Knock" sync /:Chaos:317E:/
-1481.4 "Big Bang" sync /:Chaos:3180:/
-1489.5 "Fiendish Orbs" sync /:Chaos:317C:/
+1436.0 "Earthquake" sync /:Chaos:3209:/
+1446.0 "Earthquake" sync /:Chaos:3190:/
+1449.6 "Long/Lat Implosion" sync /:Chaos:317(2|3):/
+1468.8 "Chaotic Dispersion" sync /:Chaos:3170:/
+1491.1 "Earthquake" sync /:Chaos:3190:/
+1494.2 "Knock" sync /:Chaos:317E:/
+1499.1 "Big Bang" sync /:Chaos:3180:/
+1507.9 "Fiendish Orbs" sync /:Chaos:317C:/
 
 # Enrage phase
-1519.6 "Blaze" sync /:Chaos:3206:/
-1526.7 "(ALL) Stray Flames" sync /:Chaos:318C:/
-1531.8 "Tsunami" sync /:Chaos:3207:/
-1537.9 "(ALL) Stray Spray" sync /:Chaos:318D:/
-1544.0 "Cyclone" sync /:Chaos:3208:/
-1550.6 "Stray Gusts"
-1557.0 "Earthquake" sync /:Chaos:3209:/
-1565.2 "Stray Earth"
+1538.4 "Blaze" sync /:Chaos:3206:/
+1546.1 "(ALL) Stray Flames" sync /:Chaos:318C:/
+1551.4 "Tsunami" sync /:Chaos:3207:/
+1558.0 "(ALL) Stray Spray" sync /:Chaos:318D:/
+1564.6 "Cyclone" sync /:Chaos:3208:/
+1571.3 "Stray Gusts"
+1577.6 "Earthquake" sync /:Chaos:3209:/
+1585.9 "Stray Earth"
 
 ##############
 # Water Path #
 ##############
 
 # Water phase
-2015.1 "Long/Lat Implosion" sync /:Chaos:317(2|3):/
-2029.2 "Tsunami" sync /:Chaos:3207:/
-2038.3 "Umbra Smash" sync /:Chaos:3175:/
-2039.4 "(T/H) Stray Spray" sync /:Chaos:318D:/
-2045.5 "(DPS) Stray Spray" sync /:Chaos:318D:/
-2046.6 "Damning Edict" sync /:Chaos:3171:/
-2064.7 "Chaotic Dispersion" sync /:Chaos:3170:/
-2076.7 "Tsunami" sync /:Chaos:3207:/ # drift 0.028
-2086.8 "(T/H) Stray Spray" sync /:Chaos:318D:/
-2086.9 "Knock" sync /:Chaos:317F:/
-2093.0 "(DPS) Stray Spray" sync /:Chaos:318D:/
-2093.1 "Big Bang" sync /:Chaos:3181:/
-2104.2 "Fiendish Orbs" sync /:Chaos:317D:/
+2015.7 "Long/Lat Implosion" sync /:Chaos:317(2|3):/
+2029.7 "Tsunami" sync /:Chaos:3207:/
+2038.7 "Umbra Smash" sync /:Chaos:3175:/
+2040.2 "(T/H) Stray Spray" sync /:Chaos:318D:/
+2048.8 "Damning Edict" sync /:Chaos:3171:/
+2066.8 "Chaotic Dispersion" sync /:Chaos:3170:/
+2078.8 "Tsunami" sync /:Chaos:3207:/
+2096.3 "(T/H) Stray Spray" sync /:Chaos:318D:/
+2089.6 "Knock" sync /:Chaos:317F:/
+2096.3 "(DPS) Stray Spray" sync /:Chaos:318D:/
+2096.5 "Big Bang" sync /:Chaos:3181:/
+2107.8 "Fiendish Orbs" sync /:Chaos:317D:/
 
 # Earth phase
-2126.2 "Earthquake" sync /:Chaos:3209:/ # drift 0.036
-2136.2 "Earthquake" sync /:Chaos:3190:/
-2139.3 "Long/Lat Implosion" sync /:Chaos:317(2|3):/
-2147.4 "Stray Earth" sync /:Chaos:31A2:/
-2157.5 "Chaotic Dispersion" sync /:Chaos:3170:/
-2169.5 "Earthquake" sync /:Chaos:3209:/ # drift 0.031
-2179.5 "Earthquake" sync /:Chaos:3190:/
-2181.6 "Knock" sync /:Chaos:317E:/
-2185.7 "Big Bang" sync /:Chaos:3180:/
-2193.8 "Fiendish Orbs" sync /:Chaos:317C:/
+2129.8 "Earthquake" sync /:Chaos:3209:/
+2139.8 "Earthquake" sync /:Chaos:3190:/
+2143.3 "Long/Lat Implosion" sync /:Chaos:317(2|3):/
+2162.3 "Chaotic Dispersion" sync /:Chaos:3170:/
+2174.3 "Earthquake" sync /:Chaos:3209:/
+2184.3 "Earthquake" sync /:Chaos:3190:/
+2187.2 "Knock" sync /:Chaos:317E:/
+2192.0 "Big Bang" sync /:Chaos:3180:/
+2200.6 "Fiendish Orbs" sync /:Chaos:317C:/
 
 # Orb phase
-2218.8 "Bowels Of Agony" sync /:Chaos:318A:/ # drift 0.038
-2232.8 "(DPS) Stray Flames" sync /:Chaos:318C:/
-2235.8 "(T/H) Stray Spray" sync /:Chaos:318D:/
-2255.9 "Soul Of Chaos" sync /:Chaos:318B:/ window 500,500
+2225.6 "Bowels Of Agony" sync /:Chaos:318A:/ # drift 0.038
+2239.6 "(DPS) Stray Flames" sync /:Chaos:318C:/
+2242.6 "(T/H) Stray Spray" sync /:Chaos:318D:/
+2267.6 "Soul Of Chaos" sync /:Chaos:318B:/ window 500,500
 
 # Fire phase
-2283.7 "Damning Edict" sync /:Chaos:3171:/
-2296.7 "Blaze" sync /:Chaos:3206:/ # drift 0.024
-2307.8 "(T/H) Stray Flames" sync /:Chaos:318C:/
-2312.9 "Long/Lat Implosion" sync /:Chaos:317(2|3):/
-2321.0 "(DPS) Stray Flames" sync /:Chaos:318C:/
-2331.1 "Chaotic Dispersion" sync /:Chaos:3170:/
-2343.1 "Blaze" sync /:Chaos:3206:/ # drift 0.033
-2354.2 "(T/H) Stray Flames" sync /:Chaos:318C:/
-2361.3 "Knock" sync /:Chaos:317E:/
-2367.4 "(DPS) Stray Flames" sync /:Chaos:318C:/
-2371.5 "Big Bang" sync /:Chaos:3180:/
-2379.6 "Fiendish Orbs" sync /:Chaos:317C:/
+2295.3 "Damning Edict" sync /:Chaos:3171:/
+2308.3 "Blaze" sync /:Chaos:3206:/
+2320.0 "(T/H) Stray Flames" sync /:Chaos:318C:/
+2325.8 "Long/Lat Implosion" sync /:Chaos:317(2|3):/
+2334.0 "(DPS) Stray Flames" sync /:Chaos:318C:/
+2344.8 "Chaotic Dispersion" sync /:Chaos:3170:/
+2356.8 "Blaze" sync /:Chaos:3206:/
+2368.5 "(T/H) Stray Flames" sync /:Chaos:318C:/
+2376.2 "Knock" sync /:Chaos:317E:/
+2382.5 "(DPS) Stray Flames" sync /:Chaos:318C:/
+2387.0 "Big Bang" sync /:Chaos:3180:/
+2395.6 "Fiendish Orbs" sync /:Chaos:317C:/
 
 # Wind phase
-2401.6 "Cyclone" sync /:Chaos:3208:/ # drift 0.037
-2413.6 "Umbra Smash" sync /:Chaos:3175:/
-2420.7 "Cyclone" sync /:Chaos:318F:/
-2422.8 "Damning Edict" sync /:Chaos:3171:/
-2440.8 "Chaotic Dispersion" sync /:Chaos:3170:/
-2452.8 "Cyclone" sync /:Chaos:3208:/ # drift 0.025
-2464.9 "Knock" sync /:Chaos:317F:/
-2465.0 "Cyclone" sync /:Chaos:318F:/
-2471.1 "Big Bang" sync /:Chaos:3181:/
-2482.2 "Fiendish Orbs" sync /:Chaos:317D:/
+2417.6 "Cyclone" sync /:Chaos:3208:/
+2429.6 "Umbra Smash" sync /:Chaos:3175:/
+2437.1 "Cyclone" sync /:Chaos:318F:/
+2439.7 "Damning Edict" sync /:Chaos:3171:/
+2457.7 "Chaotic Dispersion" sync /:Chaos:3170:/
+2469.7 "Cyclone" sync /:Chaos:3208:/
+2482.6 "Knock" sync /:Chaos:317F:/
+2482.7 "Cyclone" sync /:Chaos:318F:/
+2489.4 "Big Bang" sync /:Chaos:3181:/
+2500.7 "Fiendish Orbs" sync /:Chaos:317D:/
 
 # Enrage phase
-2512.3 "Blaze" sync /:Chaos:3206:/ # drift -0.047
-2519.4 "(ALL) Stray Flames" sync /:Chaos:318C:/
-2524.5 "Tsunami" sync /:Chaos:3207:/
-2530.6 "(ALL) Stray Spray" sync /:Chaos:318D:/
-2536.7 "Cyclone" sync /:Chaos:3208:/
-2543.3 "Stray Gusts"
-2549.7 "Earthquake" sync /:Chaos:3209:/
-2557.9 "Stray Earth"
+2530.8 "Blaze" sync /:Chaos:3206:/
+2538.5 "(ALL) Stray Flames" sync /:Chaos:318C:/
+2543.8 "Tsunami" sync /:Chaos:3207:/
+2550.4 "(ALL) Stray Spray" sync /:Chaos:318D:/
+2556.9 "Cyclone" sync /:Chaos:3208:/
+2563.5 "Stray Gusts"
+2569.7 "Earthquake" sync /:Chaos:3209:/
+2578.0 "Stray Earth"

--- a/util/make_timeline.py
+++ b/util/make_timeline.py
@@ -169,8 +169,15 @@ def main(args):
         last_time_diff_us = last_time_diff.microseconds
         drift = False
 
+        # Find the difference to the 0.1 second
+        last_time_diff_tenthsec = int(last_time_diff_us / 100000) / 10
+
+        # Adjust other diffs
+        last_time_diff_sec += last_time_diff_tenthsec
+        last_time_diff_us %= 100000
+
         # Round up to the tenth of second
-        if last_time_diff_us > 80000:
+        if last_time_diff_us > 60000:
             last_time_diff_sec += .1
 
         # Round up with a note about exceptional drift
@@ -179,7 +186,7 @@ def main(args):
             drift = -100000 + last_time_diff_us
 
         # Round down with a note about exceptional drift
-        elif last_time_diff_us > 20000:
+        elif last_time_diff_us > 40000:
             drift = last_time_diff_us
         
         # If <20ms then there's no need to adjust sec or drift


### PR DESCRIPTION
I had an oversight when I changed make_timeline to use tenths of seconds and noticed inaccuracies when I would run test_timeline against the same exact timeline used to generate them. I sort of shrugged it off until now but I dug in and found the issue. I corrected the Suzaku one with manual adjustments, but 9 and 10 were still affected; these commits fix both the tools and the timelines. Besides the timings, I think the only change is adding un/targetable lines in 10, and some extra info around Protostar. Hopefully this will make the rest of the timelines a little smoother to produce; I'm going to work on 11 and 12 (which I haven't actually entered yet myself) tonight.