### PR TITLE
util: Fixing Environment combatant and large-window syncs

### DIFF
--- a/util/make_timeline.py
+++ b/util/make_timeline.py
@@ -27,7 +27,6 @@ def parse_report(args):
     start_time = 0
     end_time = 0
     enemies = {}
-    last_ability = start_time
 
     # Get report information
     report_data = fflogs.api('fights', args.report, 'www', {'api_key': args.key})
@@ -50,6 +49,10 @@ def parse_report(args):
         raise Exception('Fight ID not found in report')
 
     # Build an enemy name list, since these aren't in the events
+    # Environment special case
+    enemies[-1] = ''
+
+    # Real enemies
     for enemy in report_data['enemies']:
         enemies[enemy['id']] = enemy['name']
 
@@ -67,6 +70,9 @@ def parse_report(args):
 
     # Actually make the entry dicts
     for event in event_data['events']:
+        if 'sourceID' not in event:
+            event['sourceID'] = event['source']['id']
+
         entry = {
             'time': datetime.fromtimestamp((report_start_time + event['timestamp']) / 1000),
             'combatant': enemies[event['sourceID']],

--- a/util/test_timeline.py
+++ b/util/test_timeline.py
@@ -136,8 +136,10 @@ def parse_report(args):
         # In the applydebuff case, the source is -1 (environment) and we want the target instead
         if event['type'] == 'applydebuff':
             entry['combatant'] = enemies[event['targetID']]
-        else:
+        elif 'sourceID' in event:
             entry['combatant'] = enemies[event['sourceID']]
+        else:
+            entry['combatant'] = ''
 
         entries.append(entry)
 
@@ -263,14 +265,15 @@ def check_event(event, timelist, state):
                 for other_entry in timelist:
                     if (
                             'regex' in other_entry and
-                            other_entry['time'] >state['last_jump'] and
+                            other_entry['time'] > state['last_jump'] and
                             other_entry['time'] < entry['time'] and
                             other_entry['branch'] < entry['branch']
                     ):
-                        if 'last' in other_entry:
+                        if 'last' in other_entry and drift < 999:
                             print("    Missed sync: {} at {} (last seen at {})".format(other_entry['label'], other_entry['time'], other_entry['last']))
-                        else:
+                        elif drift < 999:
                             print("    Missed sync: {} at {}".format(other_entry['label'], other_entry['time']))
+                        # If this is a sync from a large window, ignore missed syncs
                         other_entry['branch'] = state['branch']
 
             # Carry out the sync to make this the new baseline position


### PR DESCRIPTION
A few small things, mostly just:

1. Fixing the case where casts are from the Environment combatant, which is where ACT couldn't resolve the name of the enemy doing it. These have shown up a bit in 10, but 12 was the first time it broke both make and test, so I added logic to catch those cases.

2. Not printing lines about missing syncs with a large window. Testing the very beginning of Omega+ or whatever we're calling that boss, I noticed it (correctly) indicated it missed syncs for the entirety of the M/F timeline. Having a window over 999 seconds probably means missing those syncs is something expected, so there's no reason to spam it.