### PR TITLE
raidboss: Speculative fix for O9S encounter resetting

### DIFF
--- a/ui/raidboss/data/timelines/o9s.txt
+++ b/ui/raidboss/data/timelines/o9s.txt
@@ -4,7 +4,7 @@
 hideall "--Reset--"
 hideall "--sync--"
 
-0 "--Reset--" sync /Removing combatant Chaos/ window 10000 jump 0
+0 "--Reset--" sync /Removing combatant Chaos\.  Max HP: \d{8}/ window 10000 jump 0
 
 0 "Start"
 0.0 "--sync--" sync /:Engage!/ window 0,1


### PR DESCRIPTION
A friend tried this tonight and found that it was resetting mid-phase a lot. Changing the reset line to what it should actually be, specifying the real Chaos getting removed. We might actually want to throw these out in favor of the actor control lines once those are more of a sure thing.