### PR TITLE
raidboss: Fixing Typo in Example Documentation

### DIFF
--- a/user/oopsyraidsy-example.js
+++ b/user/oopsyraidsy-example.js
@@ -53,7 +53,7 @@ Options.AbilityIdNameMap['26CA'] = 'White Swirly';
 // https://github.com/quisquous/cactbot/tree/master/ui/oopsyraidsy/data/
 //
 // Here's an example trigger to show a line in the mistake log when
-// you crit adlo yourself in Summerfield Farms.
+// you crit adlo yourself in Summerford Farms.
 Options.Triggers = [
   {
     zoneRegex: /^Middle La Noscea$/,

--- a/user/raidboss-example.js
+++ b/user/raidboss-example.js
@@ -223,7 +223,7 @@ Options.PerTriggerOptions = {
       return 'Custom Poke (' + data.pokes + ')';
     },
   },
-  // This makes /clack-ing a striking dummy override the default
+  // This makes /clap-ing a striking dummy override the default
   // behavior to use the group TTS
   'Test Clap': {
     GroupSpeechAlert: true,


### PR DESCRIPTION
Small fixes to the user documentation within the example JavaScript for the raidboss and oopsyraidsy modules.