### PR TITLE
Add infoText to show Short Stack on DPS during Hello World

### DIFF
--- a/ui/raidboss/data/triggers/o12s.js
+++ b/ui/raidboss/data/triggers/o12s.js
@@ -362,11 +362,11 @@
       regexFr: / 1A:(\y{Name}) gains the effect of (?:Unknown_680|Bogue critique: partage) from (?:.*) for (.*) Seconds/,
       regexJa: / 1A:(\y{Name}) gains the effect of (?:Unknown_680|クリティカルバグ：シェア) from (?:.*) for (.*) Seconds/,
       delaySeconds: function(data, matches) {
-        return matches[1] == data.me ? 0 : 2;
+        return matches[1] == data.me ? 0 : 1;
       },
       alertText: function(data, matches) {
         let t = parseFloat(matches[2]);
-        if (!(data.me == matches[1]))
+        if (data.me != matches[1])
           return;
         if (!(t > 0))
           return;

--- a/ui/raidboss/data/triggers/o12s.js
+++ b/ui/raidboss/data/triggers/o12s.js
@@ -361,6 +361,9 @@
       regexDe: / 1A:(\y{Name}) gains the effect of (?:Unknown_680|Kritischer Bug: Synchronisierung) from (?:.*) for (.*) Seconds/,
       regexFr: / 1A:(\y{Name}) gains the effect of (?:Unknown_680|Bogue critique: partage) from (?:.*) for (.*) Seconds/,
       regexJa: / 1A:(\y{Name}) gains the effect of (?:Unknown_680|クリティカルバグ：シェア) from (?:.*) for (.*) Seconds/,
+      delaySeconds: function(data, matches) {
+        return matches[1] == data.me ? 0 : 2;
+      },
       alertText: function(data, matches) {
         let t = parseFloat(matches[2]);
         if (!(data.me == matches[1]))

--- a/ui/raidboss/data/triggers/o12s.js
+++ b/ui/raidboss/data/triggers/o12s.js
@@ -15,6 +15,7 @@
       run: function(data) {
         data.isFinalOmega = true;
 
+        data.dpsShortStack = true;
         data.helloDebuffs = {};
         data.archiveMarkers = {};
         data.armValue = 0;
@@ -360,24 +361,38 @@
       regexDe: / 1A:(\y{Name}) gains the effect of (?:Unknown_680|Kritischer Bug: Synchronisierung) from (?:.*) for (.*) Seconds/,
       regexFr: / 1A:(\y{Name}) gains the effect of (?:Unknown_680|Bogue critique: partage) from (?:.*) for (.*) Seconds/,
       regexJa: / 1A:(\y{Name}) gains the effect of (?:Unknown_680|クリティカルバグ：シェア) from (?:.*) for (.*) Seconds/,
-      condition: function(data, matches) {
-        return data.me == matches[1];
-      },
       alertText: function(data, matches) {
         let t = parseFloat(matches[2]);
+        if(!(data.me == matches[1]))
+          return;
         if (!(t > 0))
           return;
         if (t <= 8) {
           return {
-            en: 'Short Stack',
-            de: 'Kurzer Stack',
+            en: 'Short Stack on YOU',
+            de: 'Kurzer Stack auf YOU',
           };
         }
         return {
-          en: 'Long Stack',
-          de: 'Langer Stack',
+          en: 'Long Stack on YOU',
+          de: 'Langer Stack auf YOU',
         };
       },
+      infoText: function(data, matches) {
+        if (data.me == matches[1])
+            return;
+        if (!data.dpsShortStack)
+            return;
+        let t = parseFloat(matches[2]);
+        if (t <= 8) {
+          data.dpsShortStack = false;
+          return {
+            en: 'Short Stack on ' + matches[1],
+            de: 'Kurzer Stack auf ' + matches[1],
+          };
+        }
+        return;
+     }
     },
     {
       id: 'O12S Hello World No Marker',

--- a/ui/raidboss/data/triggers/o12s.js
+++ b/ui/raidboss/data/triggers/o12s.js
@@ -363,7 +363,7 @@
       regexJa: / 1A:(\y{Name}) gains the effect of (?:Unknown_680|クリティカルバグ：シェア) from (?:.*) for (.*) Seconds/,
       alertText: function(data, matches) {
         let t = parseFloat(matches[2]);
-        if( !(data.me == matches[1]))
+        if (!(data.me == matches[1]))
           return;
         if (!(t > 0))
           return;

--- a/ui/raidboss/data/triggers/o12s.js
+++ b/ui/raidboss/data/triggers/o12s.js
@@ -363,7 +363,7 @@
       regexJa: / 1A:(\y{Name}) gains the effect of (?:Unknown_680|クリティカルバグ：シェア) from (?:.*) for (.*) Seconds/,
       alertText: function(data, matches) {
         let t = parseFloat(matches[2]);
-        if(!(data.me == matches[1]))
+        if( !(data.me == matches[1]))
           return;
         if (!(t > 0))
           return;
@@ -380,9 +380,9 @@
       },
       infoText: function(data, matches) {
         if (data.me == matches[1])
-            return;
+          return;
         if (!data.dpsShortStack)
-            return;
+          return;
         let t = parseFloat(matches[2]);
         if (t <= 8) {
           data.dpsShortStack = false;
@@ -392,7 +392,7 @@
           };
         }
         return;
-     }
+      },
     },
     {
       id: 'O12S Hello World No Marker',

--- a/ui/raidboss/data/triggers/o12s.js
+++ b/ui/raidboss/data/triggers/o12s.js
@@ -379,11 +379,13 @@
         };
       },
       infoText: function(data, matches) {
+        let t = parseFloat(matches[2]);
         if (data.me == matches[1])
           return;
         if (!data.dpsShortStack)
           return;
-        let t = parseFloat(matches[2]);
+        if (!(t > 0))
+          return;
         if (t <= 8) {
           data.dpsShortStack = false;
           return {


### PR DESCRIPTION
This only shows the infoText if you do not have the Short Stack, or if it is only on the first DPS player (any future "short stacks" won't show up)

I made it as infoText, because it looked odd having 2 alertText running at once about the same mechanic. having the difference between info and alert made it look a lot cleaner in my opinion.

Not sure if there's a better of doing this, but if there is I'd be happy to change it.

Also, I don't know German, so the translation there is likely wrong - but I did my best.