### PR TITLE
Enrage sync and Handprint Move Callouts

### DIFF
--- a/ui/raidboss/data/timelines/seiryu-ex.txt
+++ b/ui/raidboss/data/timelines/seiryu-ex.txt
@@ -120,4 +120,4 @@ hideall "--sync--"
 869.6 "--rotate--" sync /:Seiryu:37C4:/
 876.9 "Fifth Element" sync /:Seiryu:37C3:/
 883.9 "Fifth Element" sync /:Seiryu:37C3:/
-906.0 "Enrage"
+906.0 "Enrage" sync /:Seiryu:3CA9:/

--- a/ui/raidboss/data/triggers/seiryu-ex.js
+++ b/ui/raidboss/data/triggers/seiryu-ex.js
@@ -197,13 +197,11 @@
             fr: 'Allez vers les serpents',
 		      };
 		    }
-		    else {
-		      return {
+		    return {
 	          en: 'Out of Middle, Toward Snakes',
 		        de: 'Raus aus der Mitte, Zu den Schlangen',
             fr: 'Allez vers les serpents',
-		      };
-		    }
+		    };
       },
 	    run: function(data) {
 		    data.withForce = true;

--- a/ui/raidboss/data/triggers/seiryu-ex.js
+++ b/ui/raidboss/data/triggers/seiryu-ex.js
@@ -135,7 +135,7 @@
     },
     {
       id: 'SeiryuEx Handprint East Move',
-      regex: /:Yama-no-shiki:37E5:/,
+      regex: / 15:\y{ObjectId}:Yama-no-shiki:37E5:Handprint:/,
       regexDe: / 15:\y{ObjectId}:Yama no Shiki:37E5:Handabdruck:/,
       condition: function(data) {
         return data.firstHandprint !== undefined;

--- a/ui/raidboss/data/triggers/seiryu-ex.js
+++ b/ui/raidboss/data/triggers/seiryu-ex.js
@@ -161,11 +161,11 @@
         de: 'Osten =>',
         fr: 'Est =>',
       },
-	    tts: {
+      tts: {
         en: 'East',
         de: 'Osten',
         fr: 'Est',
-	    },
+      },
     },
     {
       id: 'SeiryuEx Handprint West',
@@ -177,11 +177,11 @@
         de: '<= Westen',
         fr: '<= Ouest',
       },
-	    tts: {
+      tts: {
         en: 'West',
         de: 'Westen',
         fr: 'Ouest',
-	    },
+      },
     },
     {
       id: 'SeiryuEx Find Sneks',
@@ -192,20 +192,20 @@
       alarmText: function(data) {
         if (data.withForce === undefined) {
           return {
-			      en: 'Go To Snakes',
+            en: 'Go To Snakes',
             de: 'Zu den Schlangen',
             fr: 'Allez vers les serpents',
-		      };
-		    }
-		    return {
-	          en: 'Out of Middle, Toward Snakes',
-		        de: 'Raus aus der Mitte, Zu den Schlangen',
-            fr: 'Allez vers les serpents',
-		    };
+          };
+        }
+        return {
+          en: 'Out of Middle, Toward Snakes',
+          de: 'Raus aus der Mitte, Zu den Schlangen',
+          fr: 'Allez vers les serpents',
+        };
       },
-	    run: function(data) {
-		    data.withForce = true;
-	    },
+      run: function(data) {
+        data.withForce = true;
+      },
     },
     {
       id: 'SeiryuEx Silence',

--- a/ui/raidboss/data/triggers/seiryu-ex.js
+++ b/ui/raidboss/data/triggers/seiryu-ex.js
@@ -134,22 +134,40 @@
       },
     },
     {
-        // Ability IDs:
-        // Left Handprint 37E6
-        // Right Handprint 37E5
-        // Middle Force of Nature 37E9
-        id: 'SeiryuEx Handprint East',
-        regex: / 15:\y{ObjectId}:Yama-no-shiki:37E5:Handprint:/,
-        regexDe: / 15:\y{ObjectId}:Yama no Shiki:37E5:Handabdruck:/,
-        condition: function(data) {
-            return data.firstHandprint === undefined;
-        },
-        infoText: {
-            en: 'East =>',
-        },
-        run: function(data) {
-            data.firstHandprint = true;
-        },
+      id: 'SeiryuEx Handprint East Move',
+      regex: /:Yama-no-shiki:37E5:/,
+      regexDe: / 15:\y{ObjectId}:Yama no Shiki:37E5:Handabdruck:/,
+      condition: function(data) {
+        return data.firstHandprint !== undefined;
+      },
+      infoText: {
+        en: 'Move, East',
+      },
+    },
+    {
+      id: 'SeiryuEx Handprint West Move',
+      regex: / 15:\y{ObjectId}:Yama-no-shiki:37E6:Handprint:/,
+      regexDe: / 15:\y{ObjectId}:Yama no Shiki:37E6:Handabdruck:/,
+      condition: function(data) {
+        return data.firstHandprint !== undefined;
+      },
+      infoText: {
+        en: 'Move, West',
+      },
+    },
+    {
+      id: 'SeiryuEx Handprint East',
+      regex: / 15:\y{ObjectId}:Yama-no-shiki:37E5:Handprint:/,
+      regexDe: / 15:\y{ObjectId}:Yama no Shiki:37E5:Handabdruck:/,
+      condition: function(data) {
+          return data.firstHandprint === undefined;
+      },
+      infoText: {
+          en: 'East',
+      },
+      run: function(data) {
+          data.firstHandprint = true;
+      },
     },
     {
       id: 'SeiryuEx Handprint West',
@@ -159,49 +177,23 @@
         return data.firstHandprint === undefined;
       },
       infoText: {
-        en: '<= West',
+        en: 'West',
       },
       run: function(data) {
         data.firstHandprint = true;
       },
     },
     {
-      id: 'SeiryuEx Handprint East 2',
-      regex: / 15:\y{ObjectId}:Yama-no-shiki:37E5:Handprint:/,
-      regexDe: / 15:\y{ObjectId}:Yama no Shiki:37E5:Handabdruck:/,
-      condition: function(data) {
-        return data.firstHandprint !== undefined;
-      },
+      id: 'SeiryuEx Force of Nature',
+      regex: /Yama-no-shiki:37E9:/,
+      delaySeconds: 1,
       infoText: {
-        en: 'East =>',
+        en: 'Out of middle',
+        de: 'Raus aus der Mitte',
       },
-      tts: {
-        en: 'Move (East)',
+      run: function(data) {
+        delete data.firstHandprint;
       },
-    },
-    {
-      id: 'SeiryuEx Handprint West 2',
-      regex: / 15:\y{ObjectId}:Yama-no-shiki:37E6:Handprint:/,
-      regexDe: / 15:\y{ObjectId}:Yama no Shiki:37E6:Handabdruck:/,
-      condition: function(data) {
-        return data.firstHandprint !== undefined;
-      },
-      infoText: {
-        en: '<= West',
-      },
-      tts: {
-        en: 'Move (West)',
-      },
-    },
-    {
-        id: 'SeiryuEx Force of Nature',
-        regex: /Yama-no-shiki:37E9:/,
-        alertText: {
-            en: 'Avoid Middle',
-        },
-        run: function(data) {
-            delete data.firstHandprint;
-        },
     },
     {
       id: 'SeiryuEx Find Sneks',

--- a/ui/raidboss/data/triggers/seiryu-ex.js
+++ b/ui/raidboss/data/triggers/seiryu-ex.js
@@ -160,13 +160,13 @@
       regex: / 15:\y{ObjectId}:Yama-no-shiki:37E5:Handprint:/,
       regexDe: / 15:\y{ObjectId}:Yama no Shiki:37E5:Handabdruck:/,
       condition: function(data) {
-          return data.firstHandprint === undefined;
+        return data.firstHandprint === undefined;
       },
       infoText: {
-          en: 'East',
+        en: 'East',
       },
       run: function(data) {
-          data.firstHandprint = true;
+        data.firstHandprint = true;
       },
     },
     {

--- a/ui/raidboss/data/triggers/seiryu-ex.js
+++ b/ui/raidboss/data/triggers/seiryu-ex.js
@@ -189,7 +189,7 @@
       regexDe: / 14:37F7:Seiryu starts using Woge der Schlange/,
       regexFr: / 14:37F7:Seiryû starts using Vague De Serpents/,
       regexJa: / 14:37F7:青龍 starts using 蛇崩/,
-      alarmText: {
+      alarmText: function(data) {
         if (data.withForce === undefined) {
           return {
 			en: 'Go To Snakes',

--- a/ui/raidboss/data/triggers/seiryu-ex.js
+++ b/ui/raidboss/data/triggers/seiryu-ex.js
@@ -161,11 +161,11 @@
         de: 'Osten =>',
         fr: 'Est =>',
       },
-	  tts: {
+	    tts: {
         en: 'East',
         de: 'Osten',
         fr: 'Est',
-	  },
+	    },
     },
     {
       id: 'SeiryuEx Handprint West',
@@ -177,11 +177,11 @@
         de: '<= Westen',
         fr: '<= Ouest',
       },
-	  tts: {
+	    tts: {
         en: 'West',
         de: 'Westen',
         fr: 'Ouest',
-	  },
+	    },
     },
     {
       id: 'SeiryuEx Find Sneks',
@@ -192,22 +192,22 @@
       alarmText: function(data) {
         if (data.withForce === undefined) {
           return {
-			en: 'Go To Snakes',
+			      en: 'Go To Snakes',
             de: 'Zu den Schlangen',
             fr: 'Allez vers les serpents',
-		  };
-		}
-		else {
-		  return {
-	        en: 'Out of Middle, Toward Snakes',
-		    de: 'Raus aus der Mitte, Zu den Schlangen',
+		      };
+		    }
+		    else {
+		      return {
+	          en: 'Out of Middle, Toward Snakes',
+		        de: 'Raus aus der Mitte, Zu den Schlangen',
             fr: 'Allez vers les serpents',
-		  };
-		}
+		      };
+		    }
       },
-	  run: function(data) {
-		  data.withForce = true;
-	  },
+	    run: function(data) {
+		    data.withForce = true;
+	    },
     },
     {
       id: 'SeiryuEx Silence',

--- a/ui/raidboss/data/triggers/seiryu-ex.js
+++ b/ui/raidboss/data/triggers/seiryu-ex.js
@@ -134,21 +134,75 @@
       },
     },
     {
+      // Ability IDs:
+      // Left Handprint 37E6
+      // Right Handprint 37E5
+	    // Middle Force of Nature 37E9
       id: 'SeiryuEx Handprint East',
       regex: / 15:\y{ObjectId}:Yama-no-shiki:37E5:Handprint:/,
       regexDe: / 15:\y{ObjectId}:Yama no Shiki:37E5:Handabdruck:/,
+      condition: function(data) {
+        return data.firstHandprint === undefined;
+      },
       infoText: {
         en: 'East =>',
+      },
+      run: function(data) {
+        data.firstHandprint = true;
       },
     },
     {
       id: 'SeiryuEx Handprint West',
       regex: / 15:\y{ObjectId}:Yama-no-shiki:37E6:Handprint:/,
       regexDe: / 15:\y{ObjectId}:Yama no Shiki:37E6:Handabdruck:/,
+      condition: function(data) {
+        return data.firstHandprint === undefined;
+      },
       infoText: {
         en: '<= West',
       },
+      run: function(data) {
+        data.firstHandprint = true;
+      },
     },
+    {
+      id: 'SeiryuEx Handprint East 2',
+      regex: / 15:\y{ObjectId}:Yama-no-shiki:37E5:Handprint:/,
+      regexDe: / 15:\y{ObjectId}:Yama no Shiki:37E5:Handabdruck:/,
+      condition: function(data) {
+        return data.firstHandprint !== undefined;
+      },
+      infoText: {
+        en: 'East =>',
+      },
+      tts: {
+        en: 'Move (East)',
+      },
+    },
+    {
+      id: 'SeiryuEx Handprint West 2',
+      regex: / 15:\y{ObjectId}:Yama-no-shiki:37E6:Handprint:/,
+      regexDe: / 15:\y{ObjectId}:Yama no Shiki:37E6:Handabdruck:/,
+      condition: function(data) {
+        return data.firstHandprint !== undefined;
+      },
+      infoText: {
+        en: '<= West',
+      },
+      tts: {
+        en: 'Move (West)',
+      },
+    },
+    {
+	    id: 'SeiryuEx Force of Nature',
+	    regex: /Yama-no-shiki:37E9:/,
+	    run: function(data) {
+        delete data.firstHandprint;
+      },
+	    alertText: {
+	      en: 'Avoid Middle',
+	    },
+	  },
     {
       id: 'SeiryuEx Find Sneks',
       regex: / 14:37F7:Seiryu starts using Coursing River/,

--- a/ui/raidboss/data/triggers/seiryu-ex.js
+++ b/ui/raidboss/data/triggers/seiryu-ex.js
@@ -134,22 +134,22 @@
       },
     },
     {
-      // Ability IDs:
-      // Left Handprint 37E6
-      // Right Handprint 37E5
-	    // Middle Force of Nature 37E9
-      id: 'SeiryuEx Handprint East',
-      regex: / 15:\y{ObjectId}:Yama-no-shiki:37E5:Handprint:/,
-      regexDe: / 15:\y{ObjectId}:Yama no Shiki:37E5:Handabdruck:/,
-      condition: function(data) {
-        return data.firstHandprint === undefined;
-      },
-      infoText: {
-        en: 'East =>',
-      },
-      run: function(data) {
-        data.firstHandprint = true;
-      },
+        // Ability IDs:
+        // Left Handprint 37E6
+        // Right Handprint 37E5
+        // Middle Force of Nature 37E9
+        id: 'SeiryuEx Handprint East',
+        regex: / 15:\y{ObjectId}:Yama-no-shiki:37E5:Handprint:/,
+        regexDe: / 15:\y{ObjectId}:Yama no Shiki:37E5:Handabdruck:/,
+        condition: function(data) {
+            return data.firstHandprint === undefined;
+        },
+        infoText: {
+            en: 'East =>',
+        },
+        run: function(data) {
+            data.firstHandprint = true;
+        },
     },
     {
       id: 'SeiryuEx Handprint West',
@@ -194,15 +194,15 @@
       },
     },
     {
-	    id: 'SeiryuEx Force of Nature',
-	    regex: /Yama-no-shiki:37E9:/,
-	    run: function(data) {
-        delete data.firstHandprint;
-      },
-	    alertText: {
-	      en: 'Avoid Middle',
-	    },
-	  },
+        id: 'SeiryuEx Force of Nature',
+        regex: /Yama-no-shiki:37E9:/,
+        alertText: {
+            en: 'Avoid Middle',
+        },
+        run: function(data) {
+            delete data.firstHandprint;
+        },
+    },
     {
       id: 'SeiryuEx Find Sneks',
       regex: / 14:37F7:Seiryu starts using Coursing River/,


### PR DESCRIPTION
Removed the => and <= as they were being called out with TTS when I tested (maybe was my settings?).

Idea is that cardinal is called where it starts, then it is assumed the player went to the cardinal and stood there and needs to move for the next hand.

Out of middle call is added, but may be removed. It's primary use is to clear up the tracking of the first hand, and second give increased emphasis on the middle circle where the deadly hand will land.

The last Fifth Element is an 18 second cast according to my logs.