### PR TITLE
Fix the way HPS is displayed on 'rdmty' overlay

### DIFF
--- a/ui/dps/rdmty/dps.js
+++ b/ui/dps/rdmty/dps.js
@@ -5,7 +5,11 @@ var IMAGE_PATH = '../../../resources/icon';
 var EncountersArray = [];
 
 var React = window.React;
-
+var parseHealing = function(healing, percent) {
+	var max_pct = 100;
+	percent = parseInt(percent.replace('%', ''));
+	return formatNumber(healing * (max_pct - percent) / max_pct);
+};
 var formatNumber = function(number)  {
     number = parseFloat(number, 10);
 
@@ -269,7 +273,6 @@ var ____Class3=React.Component;for(var ____Class3____Key in ____Class3){if(____C
         for (var i = 0; i < names.length; i++) {
             combatant = isDataArray ? this.props.data[i] : this.props.data[names[i]];
             stats = null;
-
             isSelf = combatant.name === 'YOU' || combatant.name === 'You';
 
             if (combatant.Job !== "") {
@@ -284,7 +287,7 @@ var ____Class3=React.Component;for(var ____Class3____Key in ____Class3){if(____C
                             characterName: combatant.name,
                             total: combatant.healed,
                             totalFormatted: formatNumber(combatant.healed),
-                            perSecond: formatNumber(combatant.enchps),
+                            perSecond: parseHealing(combatant.enchps, combatant['OverHealPct']),
                             additional: combatant['OverHealPct'],
                             percentage: combatant['healed%']
                         }


### PR DESCRIPTION
Currently, on the "rdmty" overlay the HPS numbers that are shown display the amount of healing that is being done, but does not take the % overheal into account.
This means, that by purely spamming Cure 2 or any other heal on a full hp target, the number would keep growing - even though the effective HPS isn't truly changing.

This change should help reflect better on that, by making it so you see the effective HPS of each encounter.

There's probably a better way to do this, but this has been working flawlessly for the past few months of me using it, so I thought I may as well submit a pull request.

This could break if `combatant['OverHealPct']` somehow doesn't have a formatted number showing "100%" etc, but that hasn't happened yet, in all of my testings.

If you have a suggestion of how I can make this cleaner, let me know and I'll be happy to do so.