### PR TITLE
fisher: adding place id check to prevent unmatched place from stickin…

### DIFF
--- a/ui/fisher/fisher.js
+++ b/ui/fisher/fisher.js
@@ -174,7 +174,7 @@ class Fisher {
     this.fishing = true;
 
     // Set place, if it's unset
-    if (!this.place) {
+    if (!this.place || !this.place.id) {
       this.place = this.seaBase.getPlace(place);
       this.ui.setPlace(place);
     }


### PR DESCRIPTION
This should resolve #346. Thankfully, I had a few undiscovered ones left for testing. It only updates the place if the place isn't set, and it's unset after quitting, but the undiscovered hole would count as a set place while still being (obviously) not an actual place. Would be nice to polish it later to grab the message where the new hole is discovered to record the very first catch's data, but this should resolve the immediate issue.