### PR TITLE
fix errors in Hydatos on non-English client

### DIFF
--- a/ui/eureka/eureka.js
+++ b/ui/eureka/eureka.js
@@ -2168,7 +2168,7 @@ class EurekaTracker {
       nm.element = label;
       nm.timeElement = time;
       let mobName = nm.mobName[this.options.Language];
-      if (nm.spawnTrigger)
+      if (nm.spawnTrigger && nm.spawnTrigger[this.options.Language])
         nm.addRegex = Regexes.Parse(nm.spawnTrigger[this.options.Language]);
       if (!nm.addRegex)
         nm.addRegex = Regexes.Parse('03:Added new combatant ' + mobName + '\\.');


### PR DESCRIPTION
fixes the "Uncaught TypeError: Cannot read property 'replace' of undefined" and "Uncaught TypeError: Cannot read property 'style' of undefined" on non-English clients by making sure nm.spawnTrigger[this.options.Language] is only accessed if it's defined