### PR TITLE
dps: Fix rdmty healing meter hps value

### DIFF
--- a/ui/dps/rdmty/dps.js
+++ b/ui/dps/rdmty/dps.js
@@ -6,6 +6,7 @@ var EncountersArray = [];
 
 var React = window.React;
 var parseHealing = function(healing, percent) {
+	healing = parseFloat(healing, 10);
 	var max_pct = 100;
 	percent = parseInt(percent.replace('%', ''));
 	return formatNumber(healing * (max_pct - percent) / max_pct);


### PR DESCRIPTION
Healing hps value currently always shows NaN because the healing variable contains a string in parseHealing.

I've added a parseFloat just like formatNumber right below does it.