### PR TITLE
util: add support of cn

### DIFF
--- a/util/check_translation.py
+++ b/util/check_translation.py
@@ -5,12 +5,13 @@ import json
 import os
 import re
 
-languages = ['en', 'de', 'fr', 'ja']
+languages = ['en', 'de', 'fr', 'ja', 'cn']
 regex_entries = {
     'regexEn': 'en',
     'regexDe': 'de',
     'regexFr': 'fr',
     'regexJa': 'ja',
+    'regexCn': 'cn',
 }
 
 

--- a/util/fflogs.py
+++ b/util/fflogs.py
@@ -29,7 +29,7 @@ def api(call, report, prefix, options):
     if call not in ('fights', 'events'):
         return {}
 
-    if prefix not in ['www', 'fr', 'ja', 'de']:
+    if prefix not in ['www', 'fr', 'ja', 'de', 'cn']:
         raise Exception('Invalid prefix: %s' % prefix)
 
     api_url = 'https://{}.fflogs.com:443/v1/report/{}/{}'.format(prefix, call, report)

--- a/util/translate_fight.py
+++ b/util/translate_fight.py
@@ -10,12 +10,13 @@ import fflogs
 
 # 'en' here is 'www' which we consider the "base" and do automatically.
 # 'cn' exists on fflogs but does not have proper translations, sorry.
-languages = ['en', 'de', 'fr', 'ja']
+languages = ['en', 'de', 'fr', 'ja', 'cn']
 prefixes = {
     'en': 'www',
     'de': 'de',
     'fr': 'fr',
     'ja': 'ja',
+    'cn': 'cn',
 }
 default_language = 'en'
 ignore_abilities = ['Attack']
@@ -72,6 +73,7 @@ def add_default_sync_mappings(sync_replace):
     sync_replace['de']['Engage!'] = 'Start!'
     sync_replace['fr']['Engage!'] = 'À l\'attaque'
     sync_replace['ja']['Engage!'] = '戦闘開始！'
+    sync_replace['cn']['Engage!'] = '战斗开始！'
 
 
 def build_mapping(translations, ignore_list=[]):
@@ -183,36 +185,18 @@ def main(args):
             continue
         timeline_replace.append({
             'locale': lang,
-            'replaceText': ability_replace[lang],
-            'replaceSync': mob_replace[lang],
+            'replaceSync': dict(sorted(mob_replace[lang].items(), reverse=True)),
+            'replaceText': dict(sorted(ability_replace[lang].items(), reverse=True)),
             # sort this last <_<
-            '~effectNames': effect_replace[lang],
+            '~effectNames': dict(sorted(effect_replace[lang].items(), reverse=True)),
         })
     output = {'timelineReplace': timeline_replace}
-    output_str = json.dumps(output, ensure_ascii=False, indent=2, sort_keys=True)
-
-    # hacky reformatting: single quotes, and remove quotes
-    lines = []
-    headers = ['timelineReplace', 'locale', 'replaceSync', 'replaceText', 'locale']
-    for line in output_str.splitlines():
-        # add trailing commas
-        line = re.sub(r"\"\s*$", "\",", line)
-        line = re.sub(r"]\s*$", "],", line)
-        line = re.sub(r"}\s*$", "},", line)
-
-        # replace all quotes on headers
-        for header in headers:
-            if line.find('"' + header + '":') != -1:
-                line = line.replace('"', '', 2)
-        # replace double with single quotes on any line without apostrophes.
-        if line.find("'") == -1:
-            line = line.replace('"', "'")
-        lines.append(line)
+    output_str = json.dumps(output, ensure_ascii=False, indent=2, sort_keys=False)
 
     # Write that out to the user.
     if args.output_file:
         with open(args.output_file, 'w', encoding='utf-8') as fp:
-            fp.write('\n'.join(lines))
+            fp.write(output_str)
     else:
         try:
             print(output_str)


### PR DESCRIPTION
- add cn language to fflogs & check_translations & translate_fight
- sort replace text from long to short to solve prefix problem
- remove translate_fight reformatting

What's more:
- as for the replace text with space or hyphen in it, I don't think it will be compatible without changing the runtime `timeline.js` to become case-insensitive. I've tried to add case insensitive to `check_translations.py` and add them to triggers but timeline is translated in the runtime script.
  What about adding something like ` text = text.replace(Regexes.Parse('/'+keys[j]+'/i'), r[replaceKey][keys[j]]);` to [timeline.js](https://github.com/quisquous/cactbot/blob/master/ui/raidboss/timeline.js#L55)?
- as for the order of the keys, I managed them in the python script instead of runtime script, python3.6+ will preserve the order of dictionary keys according to [this doc](https://docs.python.org/3/whatsnew/3.6.html#whatsnew36-compactdict)