### PR TITLE
Fixing issue with bait resetting during mooch catch

### DIFF
--- a/ui/fisher/fisher.js
+++ b/ui/fisher/fisher.js
@@ -198,7 +198,6 @@ class Fisher {
   }
 
   handleBite() {
-    this.fishing = false;
     this.castEnd = new Date();
     this.ui.stopFishing();
   }


### PR DESCRIPTION
This should fix #363. Tested with Hedgemole Cricket and it recorded catches after the change, when it was erroring before. The issue ended up being that it was setting `this.fishing` to `false` when the bite happened, and when the fish was actually retrieved. The OnPlayerChange event (which includes bait updates) is set to only change the bait when not currently fishing. Apparently in that time while the reel animation plays, the bait given in memory is some kind of invalid data, and the overlay was respecting that. Now, the bait is locked in, by keeping `this.fishing = true`, until the catch is complete (in `handleCatch` and `handleNoCatch`), which more closely reflects the actual relationship between bait and catch.