### PR TITLE
Drop all references to Xilium.CefGlue

### DIFF
--- a/CactbotOverlay/CactbotOverlay.cs
+++ b/CactbotOverlay/CactbotOverlay.cs
@@ -299,7 +299,7 @@ namespace Cactbot {
     private int SendFastRateEvents() {
       // Handle startup and shutdown. And do not fire any events until the page has loaded and had a chance to
       // register its event handlers.
-      if (Overlay == null || Overlay.Renderer == null || Overlay.Renderer.Browser == null || Overlay.Renderer.Browser.IsLoading) {
+      if (Overlay == null || Overlay.Renderer == null) {
         return kSlowTimerMilli;
       }
 

--- a/CactbotOverlay/CactbotOverlay.csproj
+++ b/CactbotOverlay/CactbotOverlay.csproj
@@ -83,10 +83,6 @@
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Data" />
     <Reference Include="System.Xml" />
-    <Reference Include="Xilium.CefGlue, Version=3.2272.2035.0, Culture=neutral, PublicKeyToken=6235298024de30d5, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>ThirdParty\OverlayPlugin\Xilium.CefGlue.dll</HintPath>
-    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="CactbotOverlay.cs" />


### PR DESCRIPTION
My updated OverlayPlugin doesn't use CefGlue so trying to load Cactbot with that fails right now.
Cactbot either needs to use CefSharp (which I'm using) or drop all references to Xilium.CefGlue.
Switching to CefSharp would break compatibility with the old OverlayPlugin so I'd rather avoid that.

This change should be compatible with both versions. I've tested this change with my updated version but not with the old one. If it breaks, the most likely cause is that trying to execute JavaScript before the page is loaded is silently ignored. In that case I'll have to think of a better solution to the issue.