### PR TITLE
Fixed/Update MCH Job Support

### DIFF
--- a/CactbotOverlay/FFXIVProcess.cs
+++ b/CactbotOverlay/FFXIVProcess.cs
@@ -956,26 +956,26 @@ namespace Cactbot {
     }
 
     public class MachinistJobData {
-      public uint overheat_ms = 0;
       public int heat = 0;
-      public int ammunition = 0;
-      public bool gauss = false;
+      public uint overheatTime = 0;
+      public int battery = 0;
+      public uint batteryTime = 0;
 
       public override bool Equals(object obj) {
         var o = obj as MachinistJobData;
         return o != null &&
-          overheat_ms != o.overheat_ms &&
           heat != o.heat &&
-          ammunition != o.ammunition &&
-          gauss != o.gauss;
+          overheatTime != o.overheatTime &&
+          battery != o.batteryTime &&
+          batteryTime != o.batteryTime;
       }
 
       public override int GetHashCode() {
         int hash = 17;
-        hash = hash * 31 + overheat_ms.GetHashCode();
         hash = hash * 31 + heat.GetHashCode();
-        hash = hash * 31 + ammunition.GetHashCode();
-        hash = hash * 31 + gauss.GetHashCode();
+        hash = hash * 31 + overheatTime.GetHashCode();
+        hash = hash * 31 + battery.GetHashCode();
+        hash = hash * 31 + batteryTime.GetHashCode();
         return hash;
       }
     }
@@ -986,10 +986,10 @@ namespace Cactbot {
         return null;
 
       var j = new MachinistJobData();
-      j.overheat_ms = BitConverter.ToUInt16(bytes, kJobDataInnerStructOffsetJobSpecificData);
-      j.heat = bytes[kJobDataInnerStructOffsetJobSpecificData + 2];
-      j.ammunition = bytes[kJobDataInnerStructOffsetJobSpecificData + 3];
-      j.gauss = bytes[kJobDataInnerStructOffsetJobSpecificData + 4] == 1;
+      j.heat = bytes[kJobDataInnerStructOffsetJobSpecificData + 4];
+      j.overheatTime = BitConverter.ToUInt16(bytes, kJobDataInnerStructOffsetJobSpecificData);
+      j.battery = bytes[kJobDataInnerStructOffsetJobSpecificData + 5];
+      j.batteryTime = BitConverter.ToUInt16(bytes, kJobDataInnerStructOffsetJobSpecificData + 2);
       return j;
     }
 

--- a/CactbotOverlay/JSEvents.cs
+++ b/CactbotOverlay/JSEvents.cs
@@ -213,11 +213,11 @@ namespace Cactbot {
       }
 
       public struct MachinistDetail {
-        public MachinistDetail(FFXIVProcess.MachinistJobData d) { overheatMilliseconds = d.overheat_ms; heat = d.heat; ammunition = d.ammunition; gauss = d.gauss; }
-        public uint overheatMilliseconds;
+        public MachinistDetail(FFXIVProcess.MachinistJobData d) { heat = d.heat; overheatTime = d.overheatTime; battery = d.battery; batteryTime = d.batteryTime; }
         public int heat;
-        public int ammunition;
-        public bool gauss;
+        public uint overheatTime;
+        public int battery;
+        public uint batteryTime;
       }
 
       public struct AstrologianDetail {


### PR DESCRIPTION
Updated MachinistJobData in FFXIVProcess.cs (lines 958 - 995)
Updated MachinistDetail in JSEvents.cs (lines 215 - 221)

Fixes support for heat/battery gauge and timers for overheated/rook/queen summons.