### PR TITLE
util: adding timeline aggregator

### DIFF
--- a/util/make_timeline.py
+++ b/util/make_timeline.py
@@ -3,6 +3,7 @@ from datetime import datetime
 import re
 
 import fflogs
+import timeline_aggregator
 
 
 def timestamp_type(arg):
@@ -185,7 +186,8 @@ def main(args):
     last_ability_time = start_time
     last_entry = {'time': 0, 'ability_id': ''}
 
-    print('0 "Start"')
+    output = []
+    output.append('0 "Start"')
 
     for entry in entries:
         # First up, check if it's an ignored entry
@@ -252,11 +254,11 @@ def main(args):
         # Write the line
         output_entry = '{position:.1f} "{ability_name}" sync /:{combatant}:{ability_id}:/'.format(**entry)
 
-        print(output_entry.encode('ascii', 'ignore').decode('utf8', 'ignore'))
+        output.append(output_entry.encode('ascii', 'ignore').decode('utf8', 'ignore'))
 
         # Save the entry til the next line for filtering
         last_entry = entry
-
+    return output
 
 if __name__ == "__main__":
     # Set up all of the arguments
@@ -291,6 +293,9 @@ if __name__ == "__main__":
     parser.add_argument('-ic', '--ignore-combatant', nargs='*', default=[], help="Combatant names to ignore, e.g. Aratama Soul")
     parser.add_argument('-p', '--phase', nargs='*', default=[], help="Abilities that indicate a new phase, and the time to jump to, e.g. 28EC:1000")
 
+    # Aggregate arguments
+    parser.add_argument('-at', '--aggregate-threshold', type=float, default=2.0, help="Treshold to average events from multiple reports by")
+
     args = parser.parse_args()
 
     # Check dependent args
@@ -301,4 +306,13 @@ if __name__ == "__main__":
         raise parser.error("FFlogs parsing requires an API key. Visit https://www.fflogs.com/accounts/changeuser and use the Public key")
 
     # Actually call the script
-    main(args)
+    if not args.report or len(args.report.split(',')) == 1:
+        print('\n'.join(main(args)))
+    else:
+        timelines = []
+        tmp_args = args
+        for report in args.report.split(','):
+            tmp_args.report = report
+            timelines.append(main(tmp_args))
+        timeline_aggregator = timeline_aggregator.TimelineAggregator(timelines)
+        print('\n'.join(timeline_aggregator.aggregate(args.aggregate_threshold)))

--- a/util/make_timeline.py
+++ b/util/make_timeline.py
@@ -294,7 +294,7 @@ if __name__ == "__main__":
     parser.add_argument('-p', '--phase', nargs='*', default=[], help="Abilities that indicate a new phase, and the time to jump to, e.g. 28EC:1000")
 
     # Aggregate arguments
-    parser.add_argument('-at', '--aggregate-threshold', type=float, default=2.0, help="Treshold to average events from multiple reports by")
+    parser.add_argument('-at', '--aggregate-threshold', type=float, default=2.0, help="Threshold to average events from multiple reports by")
 
     args = parser.parse_args()
 

--- a/util/timeline_aggregator.py
+++ b/util/timeline_aggregator.py
@@ -60,11 +60,11 @@ def output_to_timeline(timeline_event_map):
     return sorted(list(timeline_events), key=lambda s: float(s.split()[0]))
 
 
-def create_averaging_function(treshold):
+def create_averaging_function(threshold):
     """Creates and returns a function to group by.
 
-    Creates the averaging function to be used with the itertools.groupby
-    function. Takes a treshold value in seconds as input to average groups
+    Creates the averaging function to be used with the itertools.groupby()
+    function. Takes a threshold value in seconds as input to average groups
     of similar event times.
     """
     key = None
@@ -76,14 +76,14 @@ def create_averaging_function(treshold):
         """
         nonlocal key
         if key is None:
-            key = event_time + treshold
+            key = event_time + threshold
         elif event_time >= key:
-            key = event_time + treshold
+            key = event_time + threshold
         return key
     return averaging_function
 
 
-def average_similar_events(values, treshold):
+def average_similar_events(values, threshold):
     """Return a list where similar numbers have been averaged.
 
     Items are grouped using the supplied width and criteria and the
@@ -91,7 +91,7 @@ def average_similar_events(values, treshold):
     averages are not rounded.
 
     """
-    grouped_values = itertools.groupby(values, create_averaging_function(treshold))
+    grouped_values = itertools.groupby(values, create_averaging_function(threshold))
     return list(round(mean(group), 1) for _, group in grouped_values)
 
 

--- a/util/timeline_aggregator.py
+++ b/util/timeline_aggregator.py
@@ -1,0 +1,127 @@
+"""Creates a module and necessary tools for averaging and aggregating timeline reports."""
+
+from collections import defaultdict
+import itertools
+import re
+from statistics import mean
+
+
+def parse_timeline_events(timeline):
+    """Update the timeline event map from the timeline output.
+
+    Non-commented timeline entries are parsed and the event timestamp is appended
+    to the list of times an event label occurs.
+
+    For example:
+        3.5 "Phantom Flurry" sync /:Suzaku:32DD:/
+        7.0 "Screams Of The Damned" sync /:Suzaku:32D2:/
+        10.5 "Phantom Flurry" sync /:Suzaku:32DD:/
+
+    Will create the following mapping:
+        {
+            '"Phantom Flurry" sync /:Suzaku:32DD:/': [3.5, 10.5],
+            '"Screams Of The Damned" sync /:Suzaku:32D2:/': [7.0]
+        }
+    """
+    timeline_event_map = defaultdict(list)
+    for line in timeline:
+        # Ignore comments, alertall, hideall, etc by
+        # only reading lines starting with a number
+        if not line[0].isdigit():
+            continue
+
+        # Remove trailing comment, if any
+        clean_line = line.split('#')[0]
+
+        # Split the line into sections
+        match = re.search(r'^(?P<time>[\d\.]+)\s+"(?P<label>.+)"\s+(?P<options>.+)', clean_line)
+        if not match:
+            continue
+
+        event_time = float(match[1])
+        label = '"{match[2]}" {match[3]}'.format(match=match)
+
+        # Add the timestamp to the event's list of occurrences
+        timeline_event_map[label].append(event_time)
+    return timeline_event_map
+
+
+def output_to_timeline(timeline_event_map):
+    """Returns a timeline-friendly list from an event mapping.
+
+    Creates a list of events sorted in ascending numerical order as Advanced
+    Combat Tracker would expect. Returns the list as a Python list, to be altered
+    or printed into the expected parsable format.
+    """
+    timeline_events = set()
+    for key, values in timeline_event_map.items():
+        for value in values:
+            timeline_events.add('{time} {event}'.format(time=value, event=key))
+    return sorted(list(timeline_events), key=lambda s: float(s.split()[0]))
+
+
+def create_averaging_function(treshold):
+    """Creates and returns a function to group by.
+
+    Creates the averaging function to be used with the itertools.groupby
+    function. Takes a treshold value in seconds as input to average groups
+    of similar event times.
+    """
+    key = None
+    def averaging_function(event_time):
+        """Averages event time values based on a threshold.
+
+        For any event where the event time is less than the key value, keep
+        returning key. If the event time exceeds the key, update the key value.
+        """
+        nonlocal key
+        if key is None:
+            key = event_time + treshold
+        elif event_time >= key:
+            key = event_time + treshold
+        return key
+    return averaging_function
+
+
+def average_similar_events(values, treshold):
+    """Return a list where similar numbers have been averaged.
+
+    Items are grouped using the supplied width and criteria and the
+    result is rounded to precision if it is supplied.  Otherwise
+    averages are not rounded.
+
+    """
+    grouped_values = itertools.groupby(values, create_averaging_function(treshold))
+    return list(round(mean(group), 1) for _, group in grouped_values)
+
+
+class TimelineAggregator():
+    """Aggregates timelines and averages their event times.
+
+    Takes an input of N timelines and attempts to smooth their event times to
+    find the line of best fit when determining when events occur.
+    """
+    def __init__(self, timelines):
+        self.timelines = timelines
+
+
+    def aggregate(self, averaging_threshold=2.0):
+        """Aggregates timelines and returns a list of their events.
+
+        Aggregates timelines with an averaging threshold defined in seconds. Any
+        duplicate events found with the same memory signature within those events
+        will be averaged by taking the mean of each near-duplicate event grouping.
+        """
+        aggregate_event_map = defaultdict(list)
+
+        # Parse all events within the timelines passed to the aggregator
+        for timeline in self.timelines:
+            for key, values in parse_timeline_events(timeline).items():
+                aggregate_event_map[key] += values
+
+        # Average similar values for duplicate events to get a better approximate timeline
+        for key, values in aggregate_event_map.items():
+            aggregate_event_map[key] = average_similar_events(sorted(values), averaging_threshold)
+
+        # Return the aggregated event mapping as a timeline output
+        return output_to_timeline(aggregate_event_map)


### PR DESCRIPTION
Adding functionality to the make_timeline.py util to allow for timeline aggregation/event timestamp averaging.

Updates to make_timeline.py:
* Adding import statement for timeline_aggregator
* Updating print statements to return an array
* Main function call will return expected results to stdout
* Reports can handle a comma-separated list of values to parse multiple fflogs reports at the same time, `-r report1,report2` or `-r "report1,report2"` if you're easily scared without quotes
* Adding argparse option `-at` for the averaging threshold, not required and only used when supplying multiple reports

timeline_aggregator.py:
* Could have a better/more accurate name
* Takes N fflogs reports, uses make_timeline to create the timeline, and returns a new timeline with the event timestamps hopefully smoothed out
* Code is both objectively bad and objectively slow from a big O point of view
* Uses janky methods for doing the grouping/aggregating into averaging; there's probably a _much_ better way to do this via any of the number of libraries that do data-anything in Python
  * If you know of a better way, please assist
* Works, but could work order of magnitudes better

Issues that came up:
* Drift
  * Minor things, such as the boss repositioning or flavor text, can impact long-term drift
* Fast vs slow instances
  * Fast instances seemingly hit enrage ~0.5-1% faster than slow instances, which can add up over a 10+ minute encounter.

With both of these issues, the question becomes what should be the source of truth (fast vs slow, absolute timestamps vs relative offsets), but the bigger question is does any of it really matter if you're syncing with every ability used?

Last second edits:
* Actually works pretty well with `--phase`
* Passing multiple reports should be updated to follow how you pass multiple phases