### PR TITLE
raidboss: adding e3s tts triggers without slashes

### DIFF
--- a/ui/raidboss/data/triggers/e3s.js
+++ b/ui/raidboss/data/triggers/e3s.js
@@ -377,6 +377,9 @@
         en: 'left front / back right',
         ja: '左前 / 右後ろ',
       },
+      tts: {
+        en: 'left front back right',
+      },
     },
     {
       id: 'E3S Front Right Temporary Current',
@@ -385,6 +388,9 @@
       infoText: {
         en: 'right front / back left',
         ja: '右前 / 左後ろ',
+      },
+      tts: {
+        en: 'right front back left',
       },
     },
     {
@@ -403,6 +409,9 @@
         en: 'left front / back right',
         ja: '左前 / 右後ろ',
       },
+      tts: {
+        en: 'left front back right',
+      },
     },
     {
       id: 'E3S Front Right Temporary Current 2',
@@ -415,6 +424,9 @@
       alertText: {
         en: 'right front / back left',
         ja: '右前 / 左後ろ',
+      },
+      tts: {
+        en: 'right front back left',
       },
     },
   ],


### PR DESCRIPTION
Quick fix for the immediate issue presented in https://github.com/quisquous/cactbot/issues/505.

A longer term fix should be implemented for everything that has unfriendly characters in the text-to-speech, either by including a `tts:` block without the special characters as I've done here, or by updating the alerts themselves. I feel like the latter is the better option in general, as it prevents drift, but this should be an immediate fix for anyone progging E3S with TTS alerts.

Signed-off-by: Panic Stevenson <panic.stevenson@gmail.com>