### PR TITLE
Added Dun Scaith triggers

### DIFF
--- a/ui/raidboss/data/manifest.txt
+++ b/ui/raidboss/data/manifest.txt
@@ -92,6 +92,7 @@ triggers/byakko-ex.js
 triggers/cape_westwind.js
 triggers/dohn_mheg.js
 triggers/drowned_city_of_skalla.js
+triggers/dun_scaith.js
 triggers/e1n.js
 triggers/e2n.js
 triggers/e3n.js

--- a/ui/raidboss/data/triggers/dun_scaith.js
+++ b/ui/raidboss/data/triggers/dun_scaith.js
@@ -284,7 +284,7 @@
       },
     },
     {
-      id:' Dun Scaith Thirty Arrows',
+      id: 'Dun Scaith Thirty Arrows',
       regex: / 14:1D2F:Scathach starts using Thirty Arrows/,
       infoText: {
         en: 'Avoid line AoEs',
@@ -371,7 +371,7 @@
       condition: function(data) {
         return data.role == 'tank' || data.role == 'healer';
       },
-      alertText:  {
+      alertText: {
         en: 'Boss hitting hard--Shield/Mitigate',
       },
     },
@@ -463,4 +463,5 @@
       },
     },
   ],
-},];
+},
+];

--- a/ui/raidboss/data/triggers/dun_scaith.js
+++ b/ui/raidboss/data/triggers/dun_scaith.js
@@ -28,7 +28,7 @@
       id: 'Dun Scaith Void Death',
       regex: / 14:(?:1C7F|1C90):Deathgaze Hollow starts using Void Death/,
       suppressSeconds: 5,
-      infoText: {
+      alertText: {
         en: 'Out of death circle',
       },
     },
@@ -47,14 +47,6 @@
       },
     },
     {
-      id: 'Dun Scaith Blizzard Fan',
-      regex: / 14:1C8A:Deathgaze Hollow starts using Void Blizzard III/,
-      suppressSeconds: 5,
-      alertText: {
-        en: 'Avoid ice fan',
-      },
-    },
-    {
       // There's another Void Blizzard IV with ID 1C77, but it's not the timing we want
       // The actual knockback cast is Void Aero IV, but it gives only 2-3s warning.
       id: 'Dun Scaith Blizzard Pillars',
@@ -68,7 +60,7 @@
       id: 'Dun Scaith Void Sprite',
       regex: / 03:........:Added new combatant Void Sprite/,
       suppressSeconds: 10,
-      alertText: {
+      infoText: {
         en: 'Kill sprites',
       },
     },
@@ -78,7 +70,7 @@
       condition: function(data, matches) {
         return data.me == matches[1];
       },
-      alertText: {
+      infoText: {
         en: 'Drop Tornado outside',
       },
     },
@@ -109,19 +101,12 @@
       id: 'Dun Scaith Scythe Drop',
       regex: / 1B:........:(\y{Name}):....:....:0017/,
       suppressSeconds: 5,
-      alertText: function(data, matches) {
+      infoText: function(data, matches) {
         if (data.me == matches[1]) {
           return {
             en: 'Drop scythe outside',
           };
         }
-      },
-    },
-    {
-      id: 'Dun Scaith Jester\'s Reap',
-      regex: / 14:1E41:Ferdiad Hollow starts using Jester's Reap/,
-      alertText: {
-        en: 'Frontal Cleave',
       },
     },
     {
@@ -133,9 +118,11 @@
             en: 'Tank buster on YOU',
           };
         }
+      },
+      infoText: function(data) {
         if (data.role == 'healer') {
           return {
-            en: 'Buster on ' + + data.ShortName(matches[1]),
+            en: 'Buster on ' + data.ShortName(matches[1]),
           };
         }
       },
@@ -177,7 +164,7 @@
     {
       id: 'Dun Scaith Blackfire',
       regex: / 14:1CAA:Ferdiad Hollow starts using Blackfire/,
-      alertText: {
+      infoText: {
         en: 'Avoid puddles',
       },
     },
@@ -206,7 +193,7 @@
       // Each has an incremental ID: 1D96, 1D97, 1D98
       id: 'Dun Scaith Aetherochemical Laser',
       regex: / 14:1D96:Proto Ultima starts using Aetherochemical Laser/,
-      alertText: {
+      infoText: {
         en: 'Dodge trident laser',
       },
     },
@@ -263,8 +250,8 @@
       id: 'Dun Scaith Bit Circles',
       regex: / 03:........:Added new combatant Proto Bit/,
       suppressSeconds: 5,
-      alertText: {
-        en: 'Watch for Bit AoEs',
+      infoText: {
+        en: 'Avoid Bit AoEs',
       },
     },
     {
@@ -284,7 +271,7 @@
       id: 'Dun Scaith Shadespin',
       regex: / 14:1D1(E|F):Scathach starts using Shadespin/,
       suppressSeconds: 5,
-      alertText: {
+      infoText: {
         en: 'Avoid arm slaps',
       },
     },
@@ -297,9 +284,9 @@
       },
     },
     {
-      id: 'Dun Scaith Thirty Arrows',
+      id:' Dun Scaith Thirty Arrows',
       regex: / 14:1D2F:Scathach starts using Thirty Arrows/,
-      alertText: {
+      infoText: {
         en: 'Avoid line AoEs',
       },
     },
@@ -319,7 +306,7 @@
       id: 'Dun Scaith Shadow Links',
       regex: /Shadows gather on the floor/,
       suppressSeconds: 5,
-      alertText: {
+      infoText: {
         en: 'Stop moving',
       },
     },
@@ -356,7 +343,7 @@
     {
       id: 'Dun Scaith Shadethrust',
       regex: / 14:(?:1D23:Scathach|1C1A:Diabolos Hollow) starts using Shadethrust/,
-      alertText: {
+      infoText: {
         en: 'Away from front',
       },
     },
@@ -366,7 +353,7 @@
     {
       id: 'Dun Scaith Ultimate Terror',
       regex: / 14:1C12:Diabolos starts using Ultimate Terror/,
-      alertText: {
+      infoText: {
         en: 'Get in',
       },
     },
@@ -379,19 +366,13 @@
     },
     {
       id: 'Dun Scaith Noctoshield',
-      regex: / 1A:........:Diabolos (?:gains|loses) the effect of Noctoshield/,
+      regex: / 1A:........:Diabolos gains the effect of Noctoshield/,
+      suppressSeconds: 5,
       condition: function(data) {
-        return data.role != 'dps';
+        return data.role == 'tank' || data.role == 'healer';
       },
-      alertText: function(matches) {
-        if (matches[1] == 'gains') {
-          return {
-            en: 'Boss hitting hard--Shield/Mitigate',
-          };
-        }
-        return {
-          en: 'Boss has stopped auto-critting',
-        };
+      alertText:  {
+        en: 'Boss hitting hard--Shield/Mitigate',
       },
     },
     {
@@ -409,7 +390,7 @@
       id: 'Dun Scaith Deathgates',
       regex: / 03:........:Added new combatant Deathgate/,
       suppressSeconds: 5,
-      alertText: {
+      infoText: {
         en: 'Kill the deathgates',
       },
     },
@@ -422,6 +403,8 @@
             en: 'Tank buster on YOU',
           };
         }
+      },
+      infoText: function(data) {
         if (data.role == 'healer') {
           return {
             en: 'Buster on ' + data.ShortName(matches[1]),
@@ -480,4 +463,4 @@
       },
     },
   ],
-}];
+},];

--- a/ui/raidboss/data/triggers/dun_scaith.js
+++ b/ui/raidboss/data/triggers/dun_scaith.js
@@ -341,7 +341,7 @@
         en: 'Avoid AoE, Kill Connla',
       },
     },
-    
+
     // These triggers are common to both Scathach and Diabolos
 
     {

--- a/ui/raidboss/data/triggers/dun_scaith.js
+++ b/ui/raidboss/data/triggers/dun_scaith.js
@@ -237,10 +237,10 @@
       regex: / 14:1DA4:Proto Ultima starts using Flare Star/,
       suppressSeconds: 1,
       preRun: function(data) {
-        data.flareStarCount = (data.flareStarCount || 0);
+        data.flareStarCount = (data.flareStarCount || 0) + 1;
       },
       alertText: function(data) {
-        if (data.flareStarCount == 0) {
+        if (data.flareStarCount == 1) {
           return {
             en: 'Out of center--Wait for outer ring then keep going',
           };
@@ -248,9 +248,6 @@
         return {
           en: 'Avoid flares--Wait for outer ring then keep going',
         };
-      },
-      run: function(data) {
-        data.flareStarCount + 1;
       },
     },
     {

--- a/ui/raidboss/data/triggers/dun_scaith.js
+++ b/ui/raidboss/data/triggers/dun_scaith.js
@@ -56,7 +56,7 @@
     },
     {
       // There's another Void Blizzard IV with ID 1C77, but it's not the timing we want
-      //T he actual knockback cast is Void Aero IV, but it gives only 2-3s warning.
+      // The actual knockback cast is Void Aero IV, but it gives only 2-3s warning.
       id: 'Dun Scaith Blizzard Pillars',
       regex: / 14:1C8B:Deathgaze Hollow starts using Void Blizzard IV/,
       suppressSeconds: 5,

--- a/ui/raidboss/data/triggers/dun_scaith.js
+++ b/ui/raidboss/data/triggers/dun_scaith.js
@@ -5,7 +5,7 @@
   timelineFile: 'dun_scaith.txt',
   triggers: [
 
-    //Basic stack occurs across all encounters except Deathgaze.
+    // Basic stack occurs across all encounters except Deathgaze.
 
     {
       id: 'Dun Scaith Generic Stack-up',
@@ -19,7 +19,7 @@
         return {
           en: 'Stack on ' + data.ShortName(matches[1]),
         };
-      }
+      },
     },
 
     // DEATHGAZE
@@ -30,12 +30,12 @@
       suppressSeconds: 5,
       infoText: {
         en: 'Out of death circle',
-      }
+      },
     },
     {
-      //Currently set up to just notify the healers/Bard to cleanse.
-      //Could also go with something like / 16:........:Deathgaze Hollow:1C85:Doomsay:........:(\y{Name})
-      //This would allow for notifying who needs cleansing directly, but might be spammy
+      // Currently set up to just notify the healers/Bard to cleanse.
+      // Or use / 16:........:Deathgaze Hollow:1C85:Doomsay:........:(\y{Name})
+      // This would allow for notifying who needs cleansing directly, but might be spammy
 
       id: 'Dun Scaith Doom',
       regex: / 14:1C8[45]:Deathgaze Hollow starts using Doomsay/,
@@ -44,25 +44,25 @@
       },
       alertText: {
         en: 'Cleanse Doom soon!',
-      }
+      },
     },
     {
       id: 'Dun Scaith Blizzard Fan',
       regex: / 14:1C8A:Deathgaze Hollow starts using Void Blizzard III/,
       suppressSeconds: 5,
       alertText: {
-        en: 'Avoid ice fan', 
-      }
+        en: 'Avoid ice fan',
+      },
     },
     {
-      //There's another Void Blizzard IV with ID 1C77, but it's not the timing we want
-      //The actual knockback cast is Void Aero IV, but it gives only 2-3s warning.
+      // There's another Void Blizzard IV with ID 1C77, but it's not the timing we want
+      //T he actual knockback cast is Void Aero IV, but it gives only 2-3s warning.
       id: 'Dun Scaith Blizzard Pillars',
       regex: / 14:1C8B:Deathgaze Hollow starts using Void Blizzard IV/,
       suppressSeconds: 5,
       alertText: {
         en: 'Knockback soon--Get in front of ice pillar',
-      }
+      },
     },
     {
       id: 'Dun Scaith Void Sprite',
@@ -70,7 +70,7 @@
       suppressSeconds: 10,
       alertText: {
         en: 'Kill sprites',
-      }
+      },
     },
     {
       id: 'Dun Scaith Aero 2',
@@ -80,18 +80,18 @@
       },
       alertText: {
         en: 'Drop Tornado outside',
-      }
+      },
     },
     {
-      //Deathgaze has two separate casts for this
-      //Which one appears to depend on whether it's used alongside Bolt of Darkness
-      //Mechanically the handling is the same
+      // Deathgaze has two separate casts for this
+      // Which one appears to depend on whether it's used alongside Bolt of Darkness
+      // Mechanically the handling is the same
       id: 'Dun Scaith Aero 3',
       regex: / 14:(?:1C7B|1C8D):Deathgaze Hollow starts using Void Aero III/,
       suppressSeconds: 5,
       alertText: {
         en: 'Knockback from center',
-      } 
+      },
     },
     {
 
@@ -100,7 +100,7 @@
       suppressSeconds: 5,
       alertText: {
         en: 'Avoid death squares',
-      }
+      },
     },
 
     // FERDIAD
@@ -115,34 +115,34 @@
             en: 'Drop scythe outside',
           };
         }
-      }
+      },
     },
     {
       id: 'Dun Scaith Jester\'s Reap',
       regex: / 14:1E41:Ferdiad Hollow starts using Jester's Reap/,
       alertText: {
         en: 'Frontal Cleave',
-      }
+      },
     },
     {
       id: 'Dun Scaith Jongleur\'s X',
       regex: / 14:1C98:Ferdiad Hollow starts using Jongleur's X on (\y{Name})/,
-      alertText: function(data, matches){
+      alertText: function(data, matches) {
         if (matches[1] == data.me) {
           return {
-            en:'Tank buster on YOU',
-          }
+            en: 'Tank buster on YOU',
+          };
         }
         if (data.role == 'healer') {
           return {
             en: 'Buster on ' + + data.ShortName(matches[1]),
           };
         }
-      }
+      },
     },
     {
-      //Wailing Atomos is blue, Cursed Atomos is yellow.
-      //1C9F:Aether is the circle AoE, 1CA0:Aetherial Chakram is the donut AoE
+      // Wailing Atomos is blue, Cursed Atomos is yellow.
+      // 1C9F:Aether is the circle AoE, 1CA0:Aetherial Chakram is the donut AoE
       id: 'Dun Scaith Blue Atomos',
       regex: / 14:(\y{AbilityCode}):\y{Name} starts using Juggling Sphere on Wailing Atomos/,
       alertText: function(matches) {
@@ -156,7 +156,7 @@
             en: 'Go to Untethered Blue',
           };
         }
-      }
+      },
     },
     {
       id: 'Dun Scaith Yellow Atomos',
@@ -172,14 +172,14 @@
             en: 'Go to Untethered Yellow',
           };
         }
-      }
+      },
     },
     {
       id: 'Dun Scaith Blackfire',
       regex: / 14:1CAA:Ferdiad Hollow starts using Blackfire/,
       alertText: {
         en: 'Avoid puddles',
-      }
+      },
     },
     {
       id: 'Dun Scaith Debilitator',
@@ -188,30 +188,30 @@
       alertText: function(matches) {
         if (matches[1] == 'Water') {
           return {
-            en: 'Change puddles to fire'
+            en: 'Change puddles to fire',
           };
         }
         if (matches[1] == 'Fire') {
           return {
-            en: 'Change puddles to water'
+            en: 'Change puddles to water',
           };
         }
-      }
+      },
     },
 
-    //PROTO-ULTIMA
+    // PROTO-ULTIMA
 
     {
-      //The trident laser is a series of three separate casts
-      //Each has an incremental ID: 1D96, 1D97, 1D98
+      // The trident laser is a series of three separate casts
+      // Each has an incremental ID: 1D96, 1D97, 1D98
       id: 'Dun Scaith Aetherochemical Laser',
       regex: / 14:1D96:Proto Ultima starts using Aetherochemical Laser/,
       alertText: {
         en: 'Dodge trident laser',
-      }
+      },
     },
     {
-      //Handles both 1E52 Aetherochemical Flare and 1D9D Supernova
+      // Handles both 1E52 Aetherochemical Flare and 1D9D Supernova
       id: 'Dun Scaith Proto-Ultima Raid Damage',
       regex: / 14:(?:1E52|1D9D): Proto Ultima Starts Using/,
       condition: function(data) {
@@ -219,7 +219,7 @@
       },
       alertText: {
         en: 'Raid Damage',
-      }
+      },
     },
     {
       id: 'Dun Scaith Prey Markers',
@@ -230,7 +230,7 @@
             en: 'Prey--Avoid party and keep moving',
           };
         }
-      }
+      },
     },
     {
       id: 'Dun Scaith Flare Star',
@@ -251,24 +251,24 @@
       },
       run: function(data) {
         data.flareStarCount + 1;
-      }
+      },
     },
     {
       id: 'Dun Scaith Citadel Buster',
       regex: / 14:1DAB:Proto Ultima starts using Citadel Buster/,
-      alertText: { 
+      alertText: {
         en: 'Avoid line AoE',
-      }
+      },
     },
     {
-      //Triggering off the Bit appearance
-      //The cast time on Aetheromodulator is under 3 seconds
+      // Triggering off the Bit appearance
+      // The cast time on Aetheromodulator is under 3 seconds
       id: 'Dun Scaith Bit Circles',
       regex: / 03:........:Added new combatant Proto Bit/,
       suppressSeconds: 5,
       alertText: {
         en: 'Watch for Bit AoEs',
-      }
+      },
     },
     {
       id: 'Dun Scaith Aether Collectors',
@@ -276,20 +276,20 @@
       suppressSeconds: 5,
       alertText: {
         en: 'Kill collectors',
-      }
+      },
     },
 
 
-    //SCATHACH
+    // SCATHACH
 
     {
-      //The actual attack is 1D20, but the castbar windup is 1D1F
+      // The actual attack is 1D20, but the castbar windup is 1D1F
       id: 'Dun Scaith Shadespin',
       regex: / 14:1D1(E|F):Scathach starts using Shadespin/,
       suppressSeconds: 5,
       alertText: {
         en: 'Avoid arm slaps',
-      }
+      },
     },
     {
       id: 'Dun Scaith Thirty Thorns',
@@ -297,14 +297,14 @@
       suppressSeconds: 5,
       alertText: {
         en: 'Out of melee',
-      }
+      },
     },
     {
-      id:' Dun Scaith Thirty Arrows',
+      id: 'Dun Scaith Thirty Arrows',
       regex: / 14:1D2F:Scathach starts using Thirty Arrows/,
       alertText: {
         en: 'Avoid line AoEs',
-      }
+      },
     },
     {
       id: 'Dun Scaith Thirty Souls',
@@ -314,17 +314,17 @@
       },
       alertText: {
         en: 'Raid damage',
-      } 
+      },
     },
     {
-      //Ordinarily we wouldn't use a game log line for this.
-      //However, the RP text seems to be the only indicator.
+      // Ordinarily we wouldn't use a game log line for this.
+      // However, the RP text seems to be the only indicator.
       id: 'Dun Scaith Shadow Links',
-      regex:  /Shadows gather on the floor/,
+      regex: /Shadows gather on the floor/,
       suppressSeconds: 5,
       alertText: {
         en: 'Stop moving',
-      }
+      },
     },
     {
       id: 'Dun Scaith Shadow Limb Spawn',
@@ -339,10 +339,10 @@
       regex: / 14:1CD1:Connla starts using Pitfall/,
       alertText: {
         en: 'Avoid AoE, Kill Connla',
-      }
+      },
     },
-
-      //These triggers are common to both Scathach and Diabolos
+    
+    // These triggers are common to both Scathach and Diabolos
 
     {
       id: 'Dun Scaith Nox Orbs',
@@ -354,31 +354,31 @@
             en: 'Take orb outside',
           };
         }
-      }
+      },
     },
     {
       id: 'Dun Scaith Shadethrust',
       regex: / 14:(?:1D23:Scathach|1C1A:Diabolos Hollow) starts using Shadethrust/,
       alertText: {
         en: 'Away from front',
-      }
+      },
     },
 
-    //DIABOLOS
+    // DIABOLOS
 
     {
       id: 'Dun Scaith Ultimate Terror',
       regex: / 14:1C12:Diabolos starts using Ultimate Terror/,
       alertText: {
         en: 'Get in',
-      }
+      },
     },
     {
       id: 'Dun Scaith Nightmare',
       regex: / 14:(1C0E|1C20):\y{Name} starts using (Nightmare|Hollow Nightmare)/,
       alertText: {
         en: ' Look away',
-      }
+      },
     },
     {
       id: 'Dun Scaith Noctoshield',
@@ -394,8 +394,8 @@
         }
         return {
           en: 'Boss has stopped auto-critting',
-        }
-      }
+        };
+      },
     },
     {
       id: 'Dun Scaith Ruinous Omen',
@@ -406,7 +406,7 @@
       },
       alertText: {
         en: 'Raid damage incoming',
-      }
+      },
     },
     {
       id: 'Dun Scaith Deathgates',
@@ -414,7 +414,7 @@
       suppressSeconds: 5,
       alertText: {
         en: 'Kill the deathgates',
-      }
+      },
     },
     {
       id: 'Dun Scaith Camisado',
@@ -430,7 +430,7 @@
             en: 'Buster on ' + data.ShortName(matches[1]),
           };
         }
-      }
+      },
     },
     {
       id: 'Dun Scaith Hollow Night',
@@ -444,7 +444,7 @@
         return {
           en: 'Stack on ' + data.ShortName(matches[1]) + ' and look away',
         };
-      }
+      },
     },
     {
       id: 'Dun Scaith Hollow Omen',
@@ -455,10 +455,10 @@
       },
       alertText: {
         en: 'Extreme raid damage!',
-      }
+      },
     },
     {
-      //This is the tank version of the stack marker. It has minimal circular bordering
+      // This is the tank version of the stack marker. It has minimal circular bordering
       id: 'Dun Scaith Blindside',
       regex: / 1B:........:(\y{Name}):....:....:005D/,
       alertText: function(data, matches) {
@@ -470,7 +470,7 @@
         return {
           en: 'Stack on ' + data.ShortName(matches[1]),
         };
-      }
+      },
     },
     {
       id: 'Dun Scaith Earth Shaker',
@@ -479,8 +479,8 @@
         return matches[1] == data.me;
       },
       alertText: {
-            en: 'Earth Shaker on YOU',
+        en: 'Earth Shaker on YOU',
       },
-    }
-  ]
-}]
+    },
+  ],
+}];

--- a/ui/raidboss/data/triggers/dun_scaith.js
+++ b/ui/raidboss/data/triggers/dun_scaith.js
@@ -1,0 +1,486 @@
+'use strict';
+
+[{
+  zoneRegex: /Dun Scaith/,
+  timelineFile: 'dun_scaith.txt',
+  triggers: [
+
+    //Basic stack occurs across all encounters except Deathgaze.
+
+    {
+      id: 'Dun Scaith Generic Stack-up',
+      regex: / 1B:........:(\y{Name}):....:....:003E/,
+      alertText: function(data, matches) {
+        if (matches[1] == data.me) {
+          return {
+            en: 'Stack on YOU',
+          };
+        }
+        return {
+          en: 'Stack on ' + data.ShortName(matches[1]),
+        };
+      }
+    },
+
+    // DEATHGAZE
+
+    {
+      id: 'Dun Scaith Void Death',
+      regex: / 14:(?:1C7F|1C90):Deathgaze Hollow starts using Void Death/,
+      suppressSeconds: 5,
+      infoText: {
+        en: 'Out of death circle',
+      }
+    },
+    {
+      //Currently set up to just notify the healers/Bard to cleanse.
+      //Could also go with something like / 16:........:Deathgaze Hollow:1C85:Doomsay:........:(\y{Name})
+      //This would allow for notifying who needs cleansing directly, but might be spammy
+
+      id: 'Dun Scaith Doom',
+      regex: / 14:1C8[45]:Deathgaze Hollow starts using Doomsay/,
+      condition: function(data) {
+        return data.CanCleanse();
+      },
+      alertText: {
+        en: 'Cleanse Doom soon!',
+      }
+    },
+    {
+      id: 'Dun Scaith Blizzard Fan',
+      regex: / 14:1C8A:Deathgaze Hollow starts using Void Blizzard III/,
+      suppressSeconds: 5,
+      alertText: {
+        en: 'Avoid ice fan', 
+      }
+    },
+    {
+      //There's another Void Blizzard IV with ID 1C77, but it's not the timing we want
+      //The actual knockback cast is Void Aero IV, but it gives only 2-3s warning.
+      id: 'Dun Scaith Blizzard Pillars',
+      regex: / 14:1C8B:Deathgaze Hollow starts using Void Blizzard IV/,
+      suppressSeconds: 5,
+      alertText: {
+        en: 'Knockback soon--Get in front of ice pillar',
+      }
+    },
+    {
+      id: 'Dun Scaith Void Sprite',
+      regex: / 03:........:Added new combatant Void Sprite/,
+      suppressSeconds: 10,
+      alertText: {
+        en: 'Kill sprites',
+      }
+    },
+    {
+      id: 'Dun Scaith Aero 2',
+      regex: / 1B:........:(\y{Name}):....:....:0046/,
+      condition: function(data, matches) {
+        return data.me == matches[1];
+      },
+      alertText: {
+        en: 'Drop Tornado outside',
+      }
+    },
+    {
+      //Deathgaze has two separate casts for this
+      //Which one appears to depend on whether it's used alongside Bolt of Darkness
+      //Mechanically the handling is the same
+      id: 'Dun Scaith Aero 3',
+      regex: / 14:(?:1C7B|1C8D):Deathgaze Hollow starts using Void Aero III/,
+      suppressSeconds: 5,
+      alertText: {
+        en: 'Knockback from center',
+      } 
+    },
+    {
+
+      id: 'Dun Scaith Void Death',
+      regex: / 14:1C82:Deathgaze Hollow starts using Void Death/,
+      suppressSeconds: 5,
+      alertText: {
+        en: 'Avoid death squares',
+      }
+    },
+
+    // FERDIAD
+
+    {
+      id: 'Dun Scaith Scythe Drop',
+      regex: / 1B:........:(\y{Name}):....:....:0017/,
+      suppressSeconds: 5,
+      alertText: function(data, matches) {
+        if (data.me == matches[1]) {
+          return {
+            en: 'Drop scythe outside',
+          };
+        }
+      }
+    },
+    {
+      id: 'Dun Scaith Jester\'s Reap',
+      regex: / 14:1E41:Ferdiad Hollow starts using Jester's Reap/,
+      alertText: {
+        en: 'Frontal Cleave',
+      }
+    },
+    {
+      id: 'Dun Scaith Jongleur\'s X',
+      regex: / 14:1C98:Ferdiad Hollow starts using Jongleur's X on (\y{Name})/,
+      alertText: function(data, matches){
+        if (matches[1] == data.me) {
+          return {
+            en:'Tank buster on YOU',
+          }
+        }
+        if (data.role == 'healer') {
+          return {
+            en: 'Buster on ' + + data.ShortName(matches[1]),
+          };
+        }
+      }
+    },
+    {
+      //Wailing Atomos is blue, Cursed Atomos is yellow.
+      //1C9F:Aether is the circle AoE, 1CA0:Aetherial Chakram is the donut AoE
+      id: 'Dun Scaith Blue Atomos',
+      regex: / 14:(\y{AbilityCode}):\y{Name} starts using Juggling Sphere on Wailing Atomos/,
+      alertText: function(matches) {
+        if (matches[1] == '1C9F') {
+          return {
+            en: 'Avoid Untethered Blue',
+          };
+        }
+        if (matches[1] == '1CA0') {
+          return {
+            en: 'Go to Untethered Blue',
+          };
+        }
+      }
+    },
+    {
+      id: 'Dun Scaith Yellow Atomos',
+      regex: / 14:(\y{AbilityCode}):\y{Name} starts using Juggling Sphere on Cursing Atomos/,
+      alertText: function(matches) {
+        if (matches[1] == '1C9F') {
+          return {
+            en: 'Avoid Untethered Yellow',
+          };
+        }
+        if (matches[1] == '1CA0') {
+          return {
+            en: 'Go to Untethered Yellow',
+          };
+        }
+      }
+    },
+    {
+      id: 'Dun Scaith Blackfire',
+      regex: / 14:1CAA:Ferdiad Hollow starts using Blackfire/,
+      alertText: {
+        en: 'Avoid puddles',
+      }
+    },
+    {
+      id: 'Dun Scaith Debilitator',
+      regex: / 1A:........:\y{Name} gains the effect of (Fire|Water) Resistance Down/,
+      suppressSeconds: 10,
+      alertText: function(matches) {
+        if (matches[1] == 'Water') {
+          return {
+            en: 'Change puddles to fire'
+          };
+        }
+        if (matches[1] == 'Fire') {
+          return {
+            en: 'Change puddles to water'
+          };
+        }
+      }
+    },
+
+    //PROTO-ULTIMA
+
+    {
+      //The trident laser is a series of three separate casts
+      //Each has an incremental ID: 1D96, 1D97, 1D98
+      id: 'Dun Scaith Aetherochemical Laser',
+      regex: / 14:1D96:Proto Ultima starts using Aetherochemical Laser/,
+      alertText: {
+        en: 'Dodge trident laser',
+      }
+    },
+    {
+      //Handles both 1E52 Aetherochemical Flare and 1D9D Supernova
+      id: 'Dun Scaith Proto-Ultima Raid Damage',
+      regex: / 14:(?:1E52|1D9D): Proto Ultima Starts Using/,
+      condition: function(data) {
+        return data.role == 'healer';
+      },
+      alertText: {
+        en: 'Raid Damage',
+      }
+    },
+    {
+      id: 'Dun Scaith Prey Markers',
+      regex: / 1A:........:(\y{Name}) gains the effect of Prey/,
+      alertText: function(data, matches) {
+        if (data.me == matches[1]) {
+          return {
+            en: 'Prey--Avoid party and keep moving',
+          };
+        }
+      }
+    },
+    {
+      id: 'Dun Scaith Flare Star',
+      regex: / 14:1DA4:Proto Ultima starts using Flare Star/,
+      suppressSeconds: 1,
+      preRun: function(data) {
+        data.flareStarCount = (data.flareStarCount || 0);
+      },
+      alertText: function(data) {
+        if (data.flareStarCount == 0) {
+          return {
+            en: 'Out of center--Wait for outer ring then keep going',
+          };
+        }
+        return {
+          en: 'Avoid flares--Wait for outer ring then keep going',
+        };
+      },
+      run: function(data) {
+        data.flareStarCount + 1;
+      }
+    },
+    {
+      id: 'Dun Scaith Citadel Buster',
+      regex: / 14:1DAB:Proto Ultima starts using Citadel Buster/,
+      alertText: { 
+        en: 'Avoid line AoE',
+      }
+    },
+    {
+      //Triggering off the Bit appearance
+      //The cast time on Aetheromodulator is under 3 seconds
+      id: 'Dun Scaith Bit Circles',
+      regex: / 03:........:Added new combatant Proto Bit/,
+      suppressSeconds: 5,
+      alertText: {
+        en: 'Watch for Bit AoEs',
+      }
+    },
+    {
+      id: 'Dun Scaith Aether Collectors',
+      regex: /03:........:Added new combatant Aether Collector/,
+      suppressSeconds: 5,
+      alertText: {
+        en: 'Kill collectors',
+      }
+    },
+
+
+    //SCATHACH
+
+    {
+      //The actual attack is 1D20, but the castbar windup is 1D1F
+      id: 'Dun Scaith Shadespin',
+      regex: / 14:1D1(E|F):Scathach starts using Shadespin/,
+      suppressSeconds: 5,
+      alertText: {
+        en: 'Avoid arm slaps',
+      }
+    },
+    {
+      id: 'Dun Scaith Thirty Thorns',
+      regex: / (1[56]:........:Scathach:1D2B:Thirty Thorns|1[56]:........:Scathach:1D1B:Soar)/,
+      suppressSeconds: 5,
+      alertText: {
+        en: 'Out of melee',
+      }
+    },
+    {
+      id:' Dun Scaith Thirty Arrows',
+      regex: / 14:1D2F:Scathach starts using Thirty Arrows/,
+      alertText: {
+        en: 'Avoid line AoEs',
+      }
+    },
+    {
+      id: 'Dun Scaith Thirty Souls',
+      regex: / 14:1D32:Scathach starts using Thirty Souls/,
+      condition: function(data) {
+        return data.role == 'healer';
+      },
+      alertText: {
+        en: 'Raid damage',
+      } 
+    },
+    {
+      //Ordinarily we wouldn't use a game log line for this.
+      //However, the RP text seems to be the only indicator.
+      id: 'Dun Scaith Shadow Links',
+      regex:  /Shadows gather on the floor/,
+      suppressSeconds: 5,
+      alertText: {
+        en: 'Stop moving',
+      }
+    },
+    {
+      id: 'Dun Scaith Shadow Limb Spawn',
+      regex: / 03:........:Added new combatant Shadow Limb/,
+      suppressSeconds: 5,
+      alertText: {
+        en: 'Kill the hands',
+      },
+    },
+    {
+      id: 'Dun Scaith Connla Spawn',
+      regex: / 14:1CD1:Connla starts using Pitfall/,
+      alertText: {
+        en: 'Avoid AoE, Kill Connla',
+      }
+    },
+
+      //These triggers are common to both Scathach and Diabolos
+
+    {
+      id: 'Dun Scaith Nox Orbs',
+      regex: / 1B:........:(\y{Name}):....:....:005C/,
+      suppressSeconds: 5,
+      alertText: function(data, matches) {
+        if (matches[1] == data.me) {
+          return {
+            en: 'Take orb outside',
+          };
+        }
+      }
+    },
+    {
+      id: 'Dun Scaith Shadethrust',
+      regex: / 14:(?:1D23:Scathach|1C1A:Diabolos Hollow) starts using Shadethrust/,
+      alertText: {
+        en: 'Away from front',
+      }
+    },
+
+    //DIABOLOS
+
+    {
+      id: 'Dun Scaith Ultimate Terror',
+      regex: / 14:1C12:Diabolos starts using Ultimate Terror/,
+      alertText: {
+        en: 'Get in',
+      }
+    },
+    {
+      id: 'Dun Scaith Nightmare',
+      regex: / 14:(1C0E|1C20):\y{Name} starts using (Nightmare|Hollow Nightmare)/,
+      alertText: {
+        en: ' Look away',
+      }
+    },
+    {
+      id: 'Dun Scaith Noctoshield',
+      regex: / 1A:........:Diabolos (?:gains|loses) the effect of Noctoshield/,
+      condition: function(data) {
+        return data.role != 'dps';
+      },
+      alertText: function(matches) {
+        if (matches[1] == 'gains') {
+          return {
+            en: 'Boss hitting hard--Shield/Mitigate',
+          };
+        }
+        return {
+          en: 'Boss has stopped auto-critting',
+        }
+      }
+    },
+    {
+      id: 'Dun Scaith Ruinous Omen',
+      regex: / 14:(?:1C10|1C11):Diabolos starts using Ruinous Omen/,
+      suppressSeconds: 5,
+      condition: function(data) {
+        return data.role == 'healer';
+      },
+      alertText: {
+        en: 'Raid damage incoming',
+      }
+    },
+    {
+      id: 'Dun Scaith Deathgates',
+      regex: / 03:........:Added new combatant Deathgate/,
+      suppressSeconds: 5,
+      alertText: {
+        en: 'Kill the deathgates',
+      }
+    },
+    {
+      id: 'Dun Scaith Camisado',
+      regex: / 14:1C19:Diabolos Hollow starts using Hollow Camisado on (\y{Name})/,
+      alertText: function(data, matches) {
+        if (matches[1] == data.me) {
+          return {
+            en: 'Tank buster on YOU',
+          };
+        }
+        if (data.role == 'healer') {
+          return {
+            en: 'Buster on ' + data.ShortName(matches[1]),
+          };
+        }
+      }
+    },
+    {
+      id: 'Dun Scaith Hollow Night',
+      regex: / 1B:........:(\y{Name}):....:....:005B/,
+      alertText: function(data, matches) {
+        if (matches[1] == data.me) {
+          return {
+            en: 'Gaze stack on YOU',
+          };
+        }
+        return {
+          en: 'Stack on ' + data.ShortName(matches[1]) + ' and look away',
+        };
+      }
+    },
+    {
+      id: 'Dun Scaith Hollow Omen',
+      regex: / (?:14:1C22|14:1C23):Diabolos Hollow starts using Hollow Omen/,
+      suppressSeconds: 5,
+      condition: function(data) {
+        return data.role == 'healer';
+      },
+      alertText: {
+        en: 'Extreme raid damage!',
+      }
+    },
+    {
+      //This is the tank version of the stack marker. It has minimal circular bordering
+      id: 'Dun Scaith Blindside',
+      regex: / 1B:........:(\y{Name}):....:....:005D/,
+      alertText: function(data, matches) {
+        if (matches[1] == data.me) {
+          return {
+            en: 'Stack on YOU',
+          };
+        }
+        return {
+          en: 'Stack on ' + data.ShortName(matches[1]),
+        };
+      }
+    },
+    {
+      id: 'Dun Scaith Earth Shaker',
+      regex: /1B:........:(\y{Name}):....:....:0028/,
+      condition: function(data, matches) {
+        return matches[1] == data.me;
+      },
+      alertText: {
+            en: 'Earth Shaker on YOU',
+      },
+    }
+  ]
+}]

--- a/ui/raidboss/popup-text.js
+++ b/ui/raidboss/popup-text.js
@@ -16,6 +16,7 @@ class PopupText {
     this.stunJobs = ['SAM', 'NIN', 'ROG', 'DRG', 'LNC', 'MNK', 'PGL', 'WAR', 'MRD', 'PLD', 'GLA', 'DRK', 'GNB'];
     this.silenceJobs = ['MCH', 'BRD', 'ARC', 'DNC', 'BLU', 'GNB', 'GLA', 'PLD', 'MRD', 'WAR', 'DRK', 'GNB'];
     this.sleepJobs = ['BLM', 'WHM'];
+    this.cleanseJobs = ['AST', 'BRD', 'CNJ', 'SCH', 'WHM'];
 
     this.Reset();
   }
@@ -209,6 +210,7 @@ class PopupText {
       CanStun: () => this.stunJobs.indexOf(this.job) >= 0,
       CanSilence: () => this.silenceJobs.indexOf(this.job) >= 0,
       CanSleep: () => this.sleepJobs.indexOf(this.job) >= 0,
+      CanCleanse: () => this.cleanseJobs.indexOf(this.job) >= 0,
     };
     this.StopTimers();
     this.triggerSuppress = {};


### PR DESCRIPTION
This is the result of a week's worth of running and testing. There's still some stuff that could be added, and there are currently no timelines available, but this should cover most of the major stuff. Note that I haven't tested the tank/healer-specific triggers. Apart from an incorrect notification on Flare Star and a similar one on Noctoshield this should be ready for public release.

~~Known Issues

1. Detection on the correct Atomos targets during Ferdiad is not functional. I've isolated the mechanics for how the game works the sphere vs donut, but I'm clearly overlooking something obvious on the detection regex. (This goes for a few of these issues, actually.)

2. Detection on Flameflow. Same issue as 1. There's no way to determine which element is correct apart from checking the 1A log lines, and obviously I'm not correctly reading the results of the regex match.

3. Proto-Bit spawn overlaps with the second set of Prey markers on Proto-Ultima. No good fix for this without either using timeline triggers or delaying notification on one or the other.

4. Flare Start count is not functioning as expected. (Same notification on both Flare Stars.) Probably stems from a misunderstanding of how the Run command operates. (Similar issue later on with Noctoshield.)

5. Currently no support for determining *who* has a hand tether on Scathach. If someone has the correct tether IDs I can add that in, but as it is all I've been able to find has been *after* the tethered player has turned to face the hand.

6. Currently no support for warnings on the Particle Beam circles. It may be necessary to do this with timeline triggers.