### PR TITLE
raidboss: minor tts replacement fix

### DIFF
--- a/ui/raidboss/popup-text.js
+++ b/ui/raidboss/popup-text.js
@@ -457,7 +457,9 @@ class PopupText {
       if (ttsText && playSpeech) {
         // Heuristics for auto tts.
         // * Remove a bunch of chars.
-        ttsText = ttsText.replace(/[#!\/]/, '');
+        ttsText = ttsText.replace(/[#!]/, '');
+        // * slashes between mechanics
+        ttsText = ttsText.replace('/', ' ');
         // * arrows at the front or the end are directions, e.g. "east =>"
         ttsText = ttsText.replace(/[-=]>\s*$/, '');
         ttsText = ttsText.replace(/^\s*<[-=]/, '');


### PR DESCRIPTION
Surprisingly, the default TTS I have with Windows 10 can pronounce `inout` and `eastwest` just fine; there's probably a very minor subset of words that this would have been an issue with, but just to save ourselves the future code change.

Signed-off-by: Panic Stevenson <panic.stevenson@gmail.com>