### PR TITLE
jobs: add MP tick timer for BLM

### DIFF
--- a/ui/jobs/jobs.css
+++ b/ui/jobs/jobs.css
@@ -48,7 +48,7 @@
 }
 
 /* Relative to #bars */
-#pull-bar, #hp-bar, #mp-bar, #cp-bar, #gp-bar {
+#pull-bar, #hp-bar, #mp-bar, #mp-tick, #cp-bar, #gp-bar {
   width: 202px;
   height: 7px;
 }
@@ -389,6 +389,15 @@
 }
 .mp-color.medium {
   background-color: rgb(65, 0, 200);
+}
+.mp-tick-color {
+  background-color: rgb(133, 192, 231);
+}
+.mp-tick-color.ice {
+  background-color: rgb(30, 80, 245);
+}
+.mp-tick-color.fire {
+  background-color: rgb(229, 56, 53);
 }
 .cp-color {
   background-color: rgb(75, 135, 230);


### PR DESCRIPTION
BLM is a job that relies heavily on exact MP tick timings, since getting
a lucky MP tick early on in the umbral ice phase allows BLMs to skip
needing a second filler spell for mana.

This commit adds support for tracking the MP tick timer. To detect MP
tick events, we hard-code the known constants for MP tick numbers (these
were known even before SHB, which is why I'm hard-coding them as a
percentage of max MP rather than using exact values, even though max MP
is now fixed at 10000).

To continue tracking the MP tick even when mana ticks are disabled (such
as in astral fire) or mana is high enough that excess mana from ticks is
cut off, we extend the timer-bar class to support seamlessly looping the
timer.

The user is able to control the display of this MP ticker as well as
hide it when out of combat, which is the default behavior.