### PR TITLE
test: Manifest Integrity Validation Fixes

### DIFF
--- a/test/manifest_integrity.py
+++ b/test/manifest_integrity.py
@@ -87,12 +87,14 @@ def get_data_directory_files(root_directory):
     """
     data_files = []
 
-    for file in root_directory.glob('**/*.*'):
-        # Filter manifest or README files from the result set
-        if file.stem in ['manifest', 'README']:
-            continue
-        # Match the expected file format listed within the manifest
-        data_files.append(str(file.relative_to(root_directory)))
+    # Manifest files only contain .js or .txt files
+    for extension in ['js', 'txt']:
+        for file in root_directory.glob(f'**/*.{extension}'):
+            # Filter manifest or README files from the result set
+            if not file.stem or file.stem in ['manifest', 'README']:
+                continue
+            # Match the expected file format listed within the manifest
+            data_files.append(str(file.relative_to(root_directory)))
 
     return data_files
 


### PR DESCRIPTION
Addresses the possibility of empty lines within the manifest being validated by skipping all empty lines before writing the manifest entries list.

Addresses any swap files, unexpected files, or otherwise unknown files by only including .js and .txt files in the glob when searching the data directory.

Resolves #562