### PR TITLE
Oopsyraidsy Malikah

### DIFF
--- a/ui/oopsyraidsy/data/malikahs_well.js
+++ b/ui/oopsyraidsy/data/malikahs_well.js
@@ -1,0 +1,17 @@
+'use strict';
+
+[{
+  zoneRegex: /^Malikah\'s Well$/,
+  damageWarn: {
+    'Malikah Falling Rock': '3CEA',
+    'Malikah Wellbore': '3CED',
+    'Malikah Geyser Eruption': '3CEE',
+    'Malikah Swift Spill': '3CF0',
+    'Malikah Breaking Wheel 1': '3CF5',
+    'Malikah Crystal Nail': '3CF7',
+    'Malikah Heretic\'s Fork 1': '3CF9',
+    'Malikah Breaking Wheel 2': '3CFA',
+    'Malikah Heretic\'s Fork 2': '3E0E',
+    'Malikah Earthshake': '3E39',
+  },
+}];

--- a/ui/oopsyraidsy/data/manifest.txt
+++ b/ui/oopsyraidsy/data/manifest.txt
@@ -19,6 +19,7 @@ o5s.js
 o6s.js
 o7s.js
 o8s.js
+malikahs_well.js
 mt_gulg.js
 susano-ex.js
 test.js


### PR DESCRIPTION
This one wasn't hard at all. No failure/death conditions in this dungeon, it's remarkably easy overall.

One thing I considered is adding a line comment indicating briefly what the mechanic is. This would look like:
```  
'Malikah Falling Rock': '3CEA', // Boss 1 boulder drops
'Malikah Wellbore': '3CED', // Boss 2 get-out circle
```
etc. I feel like this might be helpful to players who want to disable specific triggers, as they might be able to identify them more easily. (*"Are the ground circles on boss 2 Swift Spill or Geyser Eruption? Hmm..."*) I left that out because that's not really in the spirit of this particular request, but if you think it's okay I'll do a separate request to update the dungeon oopsies with that as a batch next week.

One other thing I also didn't do was to alphabetize the manifest. I didn't want to do that without verifying whether you had it ordered for a particular reason.
