### PR TITLE
Fixed UCoB regex filter for JP clients.

### DIFF
--- a/ui/raidboss/data/04-sb/ultimate/unending_coil_ultimate.js
+++ b/ui/raidboss/data/04-sb/ultimate/unending_coil_ultimate.js
@@ -911,7 +911,7 @@
       regex: /:(Iceclaw:26C6|Thunderwing:26C7|Fang [Oo]f Light:26CA|Tail [Oo]f Darkness:26C9|Firehorn:26C5):.*:(\y{Float}):(\y{Float}):\y{Float}:\y{Float}:[^:]*:?$/,
       regexFr: /:(Griffe-de-glace:26C6|Aile-de-foudre:26C7|Croc de lumière:26CA|Queue de ténèbres:26C9|Corne-de-feu:26C5):.*:(\y{Float}):(\y{Float}):\y{Float}:\y{Float}:[^:]*:?$/,
       regexDe: /:(Eisklaue:26C6|Donnerschwinge:26C7|Lichtklaue:26CA|Dunkelschweif:26C9|Feuerhorn:26C5):.*:(\y{Float}):(\y{Float}):\y{Float}:\y{Float}:[^:]*:?$/,
-      regexJa: /:(アイスクロウ:26C6|サンダーウィング:26C7|ライトファング:26CA|ダークテイル:26C9|ファイアホーン:26C5):.*:(\y{Float}):(\y{Float}):\y{Float}:[^:]*:?$/,
+      regexJa: /:(アイスクロウ:26C6|サンダーウィング:26C7|ライトファング:26CA|ダークテイル:26C9|ファイアホーン:26C5):.*:(\y{Float}):(\y{Float}):\y{Float}:\y{Float}:[^:]*:?$/,
       condition: function(data, matches) {
         return !data.seenDragon || !(matches[1] in data.seenDragon);
       },


### PR DESCRIPTION
Took me longer to realize this was the issue I was chasing, but here it is nonetheless.  The regex match for the JP client was missing one of the floats and wouldn't match properly which threw off calculating dragon positions.