### PR TITLE
test: Pin Travis CI Python Dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,6 @@ matrix:
     python:
       - 3.6
     install:
-      - pip install pylint requests
+      - pip install pylint==2.2.3 requests==2.22.0
     script:
       - pylint **/*.py --errors-only


### PR DESCRIPTION
Pin the version for both pylint and requests Python packages to ensure no unwanted changes slip in.