### PR TITLE
Fractal timeline additions

### DIFF
--- a/ui/raidboss/data/03-hw/dungeon/fractal_continuum.js
+++ b/ui/raidboss/data/03-hw/dungeon/fractal_continuum.js
@@ -3,6 +3,46 @@
 // Fractal Continuum
 [{
   zoneRegex: /^The Fractal Continuum$/,
+  timelineFile: 'fractal_continuum.txt',
+  timelineTriggers: [
+    {
+      id: 'Fractal Atmospheric Displacement',
+      regex: /Atmospheric Displacement/,
+      beforeSeconds: 5,
+      condition: function(data) {
+        return data.role == healer;
+      },
+      infoText: {
+        en: 'AoE',
+      },
+    },
+    {
+      id: 'Fractal Sanctification',
+      regex: /Sanctification/,
+      beforeSeconds: 5,
+      infoText: function(data, matches) {
+        if (data.role == 'tank') {
+          return {
+            en: 'Tank cleave on YOU',
+          };
+        }
+        return {
+          en: 'Avoid tank cleave',
+        };
+      },
+    },
+    {
+      id: 'Fractal Unholy',
+      regex: /Unholy/,
+      beforeSeconds: 5,
+      condition: function(data) {
+        return data.role == 'healer';
+      },
+      infoText: {
+        en: 'AoE',
+      },
+    },
+  ],
   triggers: [
     {
       id: 'Fractal Rapid Sever',
@@ -61,17 +101,112 @@
     {
       id: 'Fractal Alarums',
       regex: / 03:(\y{ObjectId}):Added new combatant Clockwork Alarum/,
-      suppresSeconds: 5,
+      suppressSeconds: 5,
       infoText: {
         en: 'Kill adds',
       },
     },
+  ],
+  timelineReplace: [
     {
-      id: 'Fractal Mines',
-      regex: / 03:(\y{ObjectId}):Added new combatant Aetherochemical Mine/,
-      suppressSeconds: 30,
-      alertText: {
-        en: 'Avoid mines',
+      'locale': 'de',
+      'replaceSync': {
+        'Phantom Ray': 'Phantomschimmer',
+        'Minotaur': 'Minotaurus',
+        'The Curator': 'Kurator',
+
+        'Exhibit level III will be sealed off': 'Ausstellungssektor III schließt',
+        'The high-level incubation bay will be sealed off': 'Inkubationskammer schließt',
+        'The reality augmentation bay will be sealed off': 'Dilatationskammer schließt',
+      },
+      'replaceText': {
+        'Rapid Sever': 'Radikale Abtrennung',
+        'Atmospheric Displacement': 'Schnitttest',
+        'Double Sever': 'Zweifachabtrennung',
+        'Damage Up': 'Schaden +',
+        'Atmospheric Compression': 'Schnittdruck',
+
+        '11-Tonze Swipe': '11-Tonzen-Hieb',
+        '111-Tonze Swing': '111-Tonzen-Schwung',
+        'Disorienting Groan': 'Kampfgebrüll',
+        'Zoom': 'Heranholen',
+        '10-Tonze Slash': '11-Tonzen-Schlag', // FIXME: Check XIVAPI's correctness on this one
+        '1111-Tonze Swing': '1111-Tonzen-Schwung',
+        'Feast': 'Festmahl',
+
+        'Sanctification': 'Sanktifikation',
+        'Unholy': 'Unheilig',
+        'Aetherochemical Explosive': 'Ätherochemisches Explosivum',
+        'The Educator': 'Zuchtmeister',
+        'Aetherochemical Mine': 'Ätherochemische Mine',
+      },
+    },
+    {
+      'locale': 'fr',
+      'replaceSync': {
+        'Phantom Ray': 'Rayon Fantomatique',
+        'Minotaur': 'Minotaure',
+        'The Curator': 'Conservateur',
+
+        // FIXME
+        'Exhibit level III will be sealed off': 'Exhibit level III will be sealed off',
+        'The high-level incubation bay will be sealed off': 'The high-level incubation bay will be sealed off',
+        'The reality augmentation bay will be sealed off': 'The reality augmentation bay will be sealed off',
+      },
+      'replaceText': {
+        'Rapid Sever': 'Tranchage rapide',
+        'Atmospheric Displacement': 'Moulinet infernal',
+        'Double Sever': 'Double tranchage',
+        'Damage Up': 'Bonus de dégâts physiques',
+        'Atmospheric Compression': 'Écrasement',
+
+        '11-Tonze Swipe': 'Fauche de 11 tonz',
+        '111-Tonze Swing': 'Swing de 111 tonz',
+        'Disorienting Groan': 'Cri désorientant',
+        'Zoom': 'Charge',
+        '10-Tonze Slash': 'Taillade de 10 tonz',
+        '1111-Tonze Swing': 'Swing de 1111 tonz',
+        'Feast': 'Festin',
+
+        'Sanctification': 'Sanctification',
+        'Unholy': 'Sombre miracle',
+        'Aetherochemical Explosive': 'Bombe magismologique',
+        'The Educator': 'Disciplinaire',
+        'Aetherochemical Mine': 'Mine magismologique',
+      },
+    },
+    {
+      'locale': 'ja',
+      'replaceSync': {
+        'Phantom Ray': 'ファントムレイ',
+        'Minotaur': 'ミノタウロス',
+        'The Curator': 'キュレーター',
+
+        // FIXME
+        'Exhibit level III will be sealed off': 'Exhibit level III will be sealed off',
+        'The high-level incubation bay will be sealed off': 'The high-level incubation bay will be sealed off',
+        'The reality augmentation bay will be sealed off': 'The reality augmentation bay will be sealed off',
+      },
+      'replaceText': {
+        'Rapid Sever': '滅多斬り',
+        'Atmospheric Displacement': '剣風',
+        'Double Sever': '多重斬り',
+        'Damage Up': 'ダメージ上昇',
+        'Atmospheric Compression': '剣圧',
+
+        '11-Tonze Swipe': '11トンズ・スワイプ',
+        '111-Tonze Swing': '111トンズ・スイング',
+        'Disorienting Groan': '雄叫び',
+        'Zoom': 'ズームイン',
+        '10-Tonze Slash': '10トンズ・スラッシュ',
+        '1111-Tonze Swing': '1111トンズ・スイング',
+        'Feast': 'フィースト',
+
+        'Sanctification': '聖別の光',
+        'Unholy': 'アンホーリー',
+        'Aetherochemical Explosive': '魔科学爆弾',
+        'The Educator': 'エデュケーター',
+        'Aetherochemical Mine': '魔科学地雷',
       },
     },
   ],

--- a/ui/raidboss/data/03-hw/dungeon/fractal_continuum.txt
+++ b/ui/raidboss/data/03-hw/dungeon/fractal_continuum.txt
@@ -1,0 +1,156 @@
+hideall "--reset--"
+hideall "--sync--"
+hideall "--start--"
+
+0 "--reset--" sync /:Exhibit level III is no longer sealed/ window 10000 jump 0
+0 "--reset--" sync /:The high-level incubation bay is no longer sealed/ window 10000 jump 0
+0 "--reset--" sync /:The reality augmentation bay is no longer sealed/ window 10000 jump 0
+
+
+###Phantom Ray
+#-ii F7D
+
+0 "Start"
+0.0 "--start--" sync /Exhibit level III will be sealed off/ window 0,1
+10.3 "Rapid Sever" sync /:Phantom Ray:F7A:/
+16.6 "Atmospheric Displacement" sync /:Phantom Ray:F7E:/
+21.4 "Double Sever 1" sync /:Phantom Ray:F7B:/
+25.6 "Double Sever 2" sync /:Phantom Ray:F7C:/
+27.4 "Atmospheric Displacement" sync /:Phantom Ray:F7E:/
+
+41.5 "Rapid Sever" sync /:Phantom Ray:F7A:/
+47.7 "Atmospheric Displacement" sync /:Phantom Ray:F7E:/
+52.5 "Double Sever 1" sync /:Phantom Ray:F7B:/
+56.5 "Double Sever 2" sync /:Phantom Ray:F7C:/
+58.3 "Atmospheric Displacement" sync /:Phantom Ray:F7E:/window 8,10 jump 27.4
+
+72.4 "Rapid Sever" sync /:Phantom Ray:F7A:/ jump 41.5
+78.6 "Atmospheric Displacement"
+83.3 "Double Sever 1" sync
+87.4 "Double Sever 2" sync
+89.2 "Atmospheric Displacement"
+#Phase 2 at < 75% HP
+
+97.7 "--sync--" #landing for phase 2 loop
+100.0 "Damage Up" sync /:Phantom Ray:F7F:/  window 100,30 #Overclock
+104.8 "Double Sever 1" sync /:Phantom Ray:F7B:/
+107.6 "Atmospheric Compression" sync /:Phantom Ray:F80:/
+109.0 "Double Sever 2" sync /:Phantom Ray:F7C:/
+111.8 "Atmospheric Displacement" sync /:Phantom Ray:F7E:/
+118.9 "Rapid Sever" sync /:Phantom Ray:F7A:/
+124.0 "Rapid Sever" sync /:Phantom Ray:F7A:/
+128.2 "Atmospheric Displacement" sync /:Phantom Ray:F7E:/
+133.1 "Double Sever 1" sync /:Phantom Ray:F7B:/
+137.3 "Double Sever 2" sync /:Phantom Ray:F7C:/
+139.0 "Atmospheric Displacement" sync /:Phantom Ray:F7E:/
+146.1 "Atmospheric Displacement" sync /:Phantom Ray:F7E:/ jump 97.7
+
+148.4 "Damage Up" sync
+153.2 "Double Sever 1"
+155.8 "Atmospheric Compression"
+157.4 "Double Sever 2"
+160.2 "Atmospheric Displacement"
+167.4 "Rapid Sever"
+172.5 "Rapid Sever"
+176.7 "Atmospheric Displacement"
+
+###Minotaur
+1000.0 "--start--" sync /:The high-level incubation bay will be sealed off/ window 1999,5
+1000.0 "Start"
+1003.4 "--sync--" /:Minotaur:366:/ window 3.4,0
+1008.8 "11-Tonze Swipe" sync /:Minotaur:F81:/
+1019.0 "111-Tonze Swing" sync /:Minotaur:F82:/
+1028.2 "Disorienting Groan" sync /:Minotaur:F84:/
+1029.4 "Zoom In x3" sync /:Minotaur:F86:/ duration 3.7
+1034.3 "10-Tonze Slash" sync /:Minotaur:F83:/
+1043.5 "11-Tonze Swipe" sync /:Minotaur:F81:/
+
+
+#Rotation desyncs here due to timing on cage use
+1048.0  "--sync--" sync /:F87:1111-Tonze Swing:Cancelled:/ window 10,15 jump 1151.0
+1064.2 "Feast?" sync /:Minotaur:F88:/ window 60,15 jump 1167.2
+1064.3 "1111-Tonze Swing?" sync /:Minotaur:F87:/ window 1,10 jump 1167.3
+
+1076.4 "11-Tonze Swipe" sync /:Minotaur:F81:/ jump 1179.4
+1086.7 "111-Tonze Swing"
+
+#Second rotation landing spots
+1151.0"--sync--" #landing for correct cage use
+1167.2 "Feast" sync /:Minotaur:F88:/ window 60,15
+1167.3 "--sync--" #landing for missed cage
+
+#Second rotation, same as the first
+1179.4 "11-Tonze Swipe" sync /:Minotaur:F81:/ window 15,15
+1189.7 "111-Tonze Swing" sync /:Minotaur:F82:/
+1199.0 "Disorienting Groan" sync /:Minotaur:F84:/
+1200.1 "Zoom In x3" sync /:Minotaur:F86:/ duration 3.7
+1204.7 "10-Tonze Slash" sync /:Minotaur:F83:/
+1214.0 "11-Tonze Swipe" sync /:Minotaur:F81:/
+1219.0 "--sync--" sync /:F87:1111-Tonze Swing:Cancelled:/ window 10,15 jump 1151.0
+1235.2 "Feast?" sync /:Minotaur:F88:/ window 50,15 jump 1167.2
+1235.3 "1111-Tonze Swing?" sync /:Minotaur:F87:/ window 1,10 jump 1167.3
+
+1247.4 "11-Tonze Swipe" jump 1179.4
+1263.6 "111-Tonze Swing"
+
+###The Curator
+# -ii F8C F8E F8F F90 F91 F92
+
+2000 "--start--" sync /:The reality augmentation bay will be sealed off/ window 2000,0
+2000.0 "Start"
+2003.0 "--sync--" /:The Curator:368:/ window 3,2
+
+2006.2 "Sanctification" sync /:The Curator:F89:/
+2011.4 "Unholy" sync /:The Curator:F8A:/
+2020.6 "Sanctification" sync /:The Curator:F89:/
+2028.8 "Aetherochemical Explosive" sync /:The Curator:F8B:/
+2033.0 "Unholy" sync /:The Curator:F8A:/
+2035.8 "Sanctification" sync /:The Curator:F89:/
+2042.0 "Unholy" sync /:The Curator:F8A:/
+2044.1 "Sanctification" sync /:The Curator:F89:/
+2053.2 "Aetherochemical Explosive" sync /:The Curator:F8B:/
+2066.4 "The Educator" sync /:The Curator:F8D:/
+
+2073.2 "Sanctification" sync /:The Curator:F89:/
+2078.4 "Unholy" sync /:The Curator:F8A:/
+2087.6 "Sanctification" sync /:The Curator:F89:/
+2095.8 "Aetherochemical Explosive" sync /:The Curator:F8B:/
+2100.0 "Unholy" sync /:The Curator:F8A:/
+2102.8 "Sanctification" sync /:The Curator:F89:/
+2109.0 "Unholy" sync /:The Curator:F8A:/
+2111.1 "Sanctification" sync /:The Curator:F89:/
+2120.2 "Aetherochemical Explosive" sync /:The Curator:F8B:/
+2133.4 "The Educator" sync /:The Curator:F8D:/ window 10,10 jump 2066.4
+
+2140.2 "Sanctification" sync /:The Curator:F89:/ jump 2073.2
+2145.4 "Unholy"
+2154.6 "Sanctification"
+2162.8 "Aetherochemical Explosive"
+2167.0 "Unholy"
+2169.8 "Sanctification"
+
+#Phase 2 at first Educator after HP < 69%?
+
+2191.7 "--sync--" #landing for phase 2 loop
+2196.1 "Sanctification" sync /:The Curator:F89:/
+2200.0 "Aetherochemical Mine" sync /:Repository Node:F8F:/ window 2200,10
+2201.3 "Unholy" sync /:The Curator:F8A:/
+2210.7 "Sanctification" sync /:The Curator:F89:/
+2218.8 "Aetherochemical Explosive" sync /:The Curator:F8B:/
+2221.1 "Aetherochemical Mine" sync /:Repository Node:F8F:/
+2222.9 "Unholy" sync /:The Curator:F8A:/
+2225.1 "Sanctification" sync /:The Curator:F89:/
+2231.1 "Unholy" sync /:The Curator:F8A:/
+2233.5 "Sanctification" sync /:The Curator:F89:/
+2238.1 "Aetherochemical Mine" sync /:Repository Node:F8F:/
+2242.6 "Aetherochemical Explosive" sync /:The Curator:F8B:/
+2255.8 "The Educator" sync /:The Curator:F8D:/ window 15,15 jump 2191.7
+
+2263.1 "Sanctification" sync /:The Curator:F89:/ jump 2196.1
+2267.0 "Aetherochemical Mine"
+2268.3 "Unholy"
+2277.7 "Sanctification"
+2285.8 "Aetherochemical Explosive"
+2288.1 "Aetherochemical Mine"
+2289.9 "Unholy"
+2292.1 "Sanctification"

--- a/ui/raidboss/data/03-hw/dungeon/fractal_continuum.txt
+++ b/ui/raidboss/data/03-hw/dungeon/fractal_continuum.txt
@@ -8,14 +8,14 @@ hideall "--sync--"
 #-ii F7D -p F7F:100
 
 0.0 "--sync--" sync /Exhibit level III will be sealed off/ window 0,1
-10.3 "Rapid Sever" sync /:Phantom Ray:F7A:/
-16.6 "Atmospheric Displacement" sync /:Phantom Ray:F7E:/ window 5,5
+10.3 "Rapid Sever" sync /:Phantom Ray:F7A:/ window 15,15
+16.6 "Atmospheric Displacement" sync /:Phantom Ray:F7E:/
 21.4 "Double Sever 1" sync /:Phantom Ray:F7B:/
 25.6 "Double Sever 2" sync /:Phantom Ray:F7C:/
 27.4 "Atmospheric Displacement" sync /:Phantom Ray:F7E:/
 
-41.5 "Rapid Sever" sync /:Phantom Ray:F7A:/
-47.7 "Atmospheric Displacement" sync /:Phantom Ray:F7E:/ window 5,5
+41.5 "Rapid Sever" sync /:Phantom Ray:F7A:/ window 15,15
+47.7 "Atmospheric Displacement" sync /:Phantom Ray:F7E:/
 52.5 "Double Sever 1" sync /:Phantom Ray:F7B:/
 56.5 "Double Sever 2" sync /:Phantom Ray:F7C:/
 58.3 "Atmospheric Displacement" sync /:Phantom Ray:F7E:/

--- a/ui/raidboss/data/03-hw/dungeon/fractal_continuum.txt
+++ b/ui/raidboss/data/03-hw/dungeon/fractal_continuum.txt
@@ -22,12 +22,12 @@ hideall "--start--"
 47.7 "Atmospheric Displacement" sync /:Phantom Ray:F7E:/
 52.5 "Double Sever 1" sync /:Phantom Ray:F7B:/
 56.5 "Double Sever 2" sync /:Phantom Ray:F7C:/
-58.3 "Atmospheric Displacement" sync /:Phantom Ray:F7E:/window 8,10 jump 27.4
+58.3 "Atmospheric Displacement" sync /:Phantom Ray:F7E:/ window 8,10 jump 27.4
 
 72.4 "Rapid Sever" sync /:Phantom Ray:F7A:/ jump 41.5
 78.6 "Atmospheric Displacement"
-83.3 "Double Sever 1" sync
-87.4 "Double Sever 2" sync
+83.3 "Double Sever 1"
+87.4 "Double Sever 2"
 89.2 "Atmospheric Displacement"
 #Phase 2 at < 75% HP
 
@@ -57,7 +57,7 @@ hideall "--start--"
 ###Minotaur
 1000.0 "--start--" sync /:The high-level incubation bay will be sealed off/ window 1999,5
 1000.0 "Start"
-1003.4 "--sync--" /:Minotaur:366:/ window 3.4,0
+1003.4 "--sync--" sync /:Minotaur:366:/ window 3.4,0
 1008.8 "11-Tonze Swipe" sync /:Minotaur:F81:/
 1019.0 "111-Tonze Swing" sync /:Minotaur:F82:/
 1028.2 "Disorienting Groan" sync /:Minotaur:F84:/
@@ -75,7 +75,7 @@ hideall "--start--"
 1086.7 "111-Tonze Swing"
 
 #Second rotation landing spots
-1151.0"--sync--" #landing for correct cage use
+1151.0 "--sync--" #landing for correct cage use
 1167.2 "Feast" sync /:Minotaur:F88:/ window 60,15
 1167.3 "--sync--" #landing for missed cage
 
@@ -90,7 +90,7 @@ hideall "--start--"
 1235.2 "Feast?" sync /:Minotaur:F88:/ window 50,15 jump 1167.2
 1235.3 "1111-Tonze Swing?" sync /:Minotaur:F87:/ window 1,10 jump 1167.3
 
-1247.4 "11-Tonze Swipe" jump 1179.4
+1247.4 "11-Tonze Swipe" sync /:Minotaur:F81:/ jump 1179.4
 1263.6 "111-Tonze Swing"
 
 ###The Curator
@@ -98,7 +98,7 @@ hideall "--start--"
 
 2000 "--start--" sync /:The reality augmentation bay will be sealed off/ window 2000,0
 2000.0 "Start"
-2003.0 "--sync--" /:The Curator:368:/ window 3,2
+2003.0 "--sync--" sync /:The Curator:368:/ window 3,2
 
 2006.2 "Sanctification" sync /:The Curator:F89:/
 2011.4 "Unholy" sync /:The Curator:F8A:/

--- a/ui/raidboss/data/03-hw/dungeon/fractal_continuum.txt
+++ b/ui/raidboss/data/03-hw/dungeon/fractal_continuum.txt
@@ -1,37 +1,32 @@
 hideall "--reset--"
 hideall "--sync--"
-hideall "--start--"
 
-0 "--reset--" sync /:Exhibit level III is no longer sealed/ window 10000 jump 0
-0 "--reset--" sync /:The high-level incubation bay is no longer sealed/ window 10000 jump 0
-0 "--reset--" sync /:The reality augmentation bay is no longer sealed/ window 10000 jump 0
+0 "--reset--" sync /is no longer sealed/ window 10000 jump 0
 
 
 ###Phantom Ray
-#-ii F7D
+#-ii F7D -p F7F:100
 
-0 "Start"
-0.0 "--start--" sync /Exhibit level III will be sealed off/ window 0,1
+0.0 "--sync--" sync /Exhibit level III will be sealed off/ window 0,1
 10.3 "Rapid Sever" sync /:Phantom Ray:F7A:/
-16.6 "Atmospheric Displacement" sync /:Phantom Ray:F7E:/
+16.6 "Atmospheric Displacement" sync /:Phantom Ray:F7E:/ window 5,5
 21.4 "Double Sever 1" sync /:Phantom Ray:F7B:/
 25.6 "Double Sever 2" sync /:Phantom Ray:F7C:/
 27.4 "Atmospheric Displacement" sync /:Phantom Ray:F7E:/
 
 41.5 "Rapid Sever" sync /:Phantom Ray:F7A:/
-47.7 "Atmospheric Displacement" sync /:Phantom Ray:F7E:/
+47.7 "Atmospheric Displacement" sync /:Phantom Ray:F7E:/ window 5,5
 52.5 "Double Sever 1" sync /:Phantom Ray:F7B:/
 56.5 "Double Sever 2" sync /:Phantom Ray:F7C:/
-58.3 "Atmospheric Displacement" sync /:Phantom Ray:F7E:/ window 8,10 jump 27.4
+58.3 "Atmospheric Displacement" sync /:Phantom Ray:F7E:/
 
-72.4 "Rapid Sever" sync /:Phantom Ray:F7A:/ jump 41.5
+72.4 "Rapid Sever" sync /:Phantom Ray:F7A:/  window 15,15 jump 41.5
 78.6 "Atmospheric Displacement"
 83.3 "Double Sever 1"
 87.4 "Double Sever 2"
 89.2 "Atmospheric Displacement"
-#Phase 2 at < 75% HP
+# Phase 2 at < 75% HP
 
-97.7 "--sync--" #landing for phase 2 loop
 100.0 "Damage Up" sync /:Phantom Ray:F7F:/  window 100,30 #Overclock
 104.8 "Double Sever 1" sync /:Phantom Ray:F7B:/
 107.6 "Atmospheric Compression" sync /:Phantom Ray:F80:/
@@ -43,63 +38,65 @@ hideall "--start--"
 133.1 "Double Sever 1" sync /:Phantom Ray:F7B:/
 137.3 "Double Sever 2" sync /:Phantom Ray:F7C:/
 139.0 "Atmospheric Displacement" sync /:Phantom Ray:F7E:/
-146.1 "Atmospheric Displacement" sync /:Phantom Ray:F7E:/ jump 97.7
+146.1 "Atmospheric Displacement" sync /:Phantom Ray:F7E:/
 
-148.4 "Damage Up" sync /:Phantom Ray:F7F:/ jump 100.0
+148.4 "Damage Up" sync /:Phantom Ray:F7F:/ window 15,15 jump 100.0
 153.2 "Double Sever 1"
-155.8 "Atmospheric Compression"
+156.0 "Atmospheric Compression"
 157.4 "Double Sever 2"
 160.2 "Atmospheric Displacement"
-167.4 "Rapid Sever"
-172.5 "Rapid Sever"
-176.7 "Atmospheric Displacement"
+167.3 "Rapid Sever"
+172.4 "Rapid Sever"
+176.6 "Atmospheric Displacement"
 
 ###Minotaur
-1000.0 "--start--" sync /:The high-level incubation bay will be sealed off/ window 1999,5
-1000.0 "Start"
+1000.0 "--sync--" sync /:The high-level incubation bay will be sealed off/ window 1999,5
 1003.4 "--sync--" sync /:Minotaur:366:/ window 3.4,0
 1008.8 "11-Tonze Swipe" sync /:Minotaur:F81:/
-1019.0 "111-Tonze Swing" sync /:Minotaur:F82:/
+1019.0 "111-Tonze Swing" sync /:Minotaur:F82:/ window 20,20
 1028.2 "Disorienting Groan" sync /:Minotaur:F84:/
 1029.4 "Zoom In x3" sync /:Minotaur:F86:/ duration 3.7
-1034.3 "10-Tonze Slash" sync /:Minotaur:F83:/
+1034.3 "10-Tonze Slash" sync /:Minotaur:F83:/ window 20,20
 1043.5 "11-Tonze Swipe" sync /:Minotaur:F81:/
 
-
-#Rotation desyncs here due to timing on cage use
-1048.0  "--sync--" sync /:F87:1111-Tonze Swing:Cancelled:/ window 10,15 jump 1151.0
-1064.2 "Feast?" sync /:Minotaur:F88:/ window 60,15 jump 1167.2
+# Rotation desyncs here due to timing on cage use
+1048.0  "--sync--" sync /1B:........:Minotaur:....:....:0036:/ window 45,15 jump 1151.0
+1064.2 "Feast?"
 1064.3 "1111-Tonze Swing?" sync /:Minotaur:F87:/ window 1,10 jump 1167.3
 
-1076.4 "11-Tonze Swipe" sync /:Minotaur:F81:/ jump 1179.4
+1076.4 "11-Tonze Swipe"
 1086.7 "111-Tonze Swing"
 
-#Second rotation landing spots
+# Second rotation landing spots
 1151.0 "--sync--" #landing for correct cage use
-1167.2 "Feast" sync /:Minotaur:F88:/ window 60,15
+1167.2 "Feast" sync /:Minotaur:F88:/ window 15,15
 1167.3 "--sync--" #landing for missed cage
 
-#Second rotation, same as the first
+# Second rotation, same as the first
+# Necessary for a clean landing after cages
 1179.4 "11-Tonze Swipe" sync /:Minotaur:F81:/ window 15,15
-1189.7 "111-Tonze Swing" sync /:Minotaur:F82:/
+1189.7 "111-Tonze Swing" sync /:Minotaur:F82:/ window 20,20
 1199.0 "Disorienting Groan" sync /:Minotaur:F84:/
 1200.1 "Zoom In x3" sync /:Minotaur:F86:/ duration 3.7
-1204.7 "10-Tonze Slash" sync /:Minotaur:F83:/
+1204.7 "10-Tonze Slash" sync /:Minotaur:F83:/ window 20,20
 1214.0 "11-Tonze Swipe" sync /:Minotaur:F81:/
-1219.0 "--sync--" sync /:F87:1111-Tonze Swing:Cancelled:/ window 10,15 jump 1151.0
-1235.2 "Feast?" sync /:Minotaur:F88:/ window 50,15 jump 1167.2
+1219.0 "--sync--" sync /1B:........:Minotaur:....:....:0036:/ window 45,15 jump 1151.0
+1235.2 "Feast?"
 1235.3 "1111-Tonze Swing?" sync /:Minotaur:F87:/ window 1,10 jump 1167.3
 
-1247.4 "11-Tonze Swipe" sync /:Minotaur:F81:/ jump 1179.4
+1247.4 "11-Tonze Swipe"
 1263.6 "111-Tonze Swing"
 
 ###The Curator
 # -ii F8C F8E F8F F90 F91 F92
+# Ability F91 is a ground effect, Seed of the Rivers.
+# It's excluded because it's the only difference between phase 2 > 3,
+# phase 3 can enter at any one of those three points,
+# and there's no way to disambiguate where.
+# Phase length is the same regardless of added abilities.
 
-2000 "--start--" sync /:The reality augmentation bay will be sealed off/ window 2000,0
-2000.0 "Start"
+2000 "--sync--" sync /:The reality augmentation bay will be sealed off/ window 2000,0
 2003.0 "--sync--" sync /:The Curator:368:/ window 3,2
-
 2006.2 "Sanctification" sync /:The Curator:F89:/
 2011.4 "Unholy" sync /:The Curator:F8A:/
 2020.6 "Sanctification" sync /:The Curator:F89:/
@@ -120,37 +117,36 @@ hideall "--start--"
 2109.0 "Unholy" sync /:The Curator:F8A:/
 2111.1 "Sanctification" sync /:The Curator:F89:/
 2120.2 "Aetherochemical Explosive" sync /:The Curator:F8B:/
-2133.4 "The Educator" sync /:The Curator:F8D:/ window 10,10 jump 2066.4
+2133.4 "The Educator" sync /:The Curator:F8D:/
 
-2140.2 "Sanctification" sync /:The Curator:F89:/ jump 2073.2
+2140.2 "Sanctification" sync /:The Curator:F89:/ window 15,15 jump 2073.2
 2145.4 "Unholy"
 2154.6 "Sanctification"
 2162.8 "Aetherochemical Explosive"
 2167.0 "Unholy"
 2169.8 "Sanctification"
 
-#Phase 2 at first Educator after HP < 69%?
+# Phase 2 after first Educator. Maybe HP threshold?
 
-2191.7 "--sync--" #landing for phase 2 loop
-2196.1 "Sanctification" sync /:The Curator:F89:/
-2200.0 "Aetherochemical Mine" sync /:Repository Node:F8F:/ window 2200,10
-2201.3 "Unholy" sync /:The Curator:F8A:/
-2210.7 "Sanctification" sync /:The Curator:F89:/
-2218.8 "Aetherochemical Explosive" sync /:The Curator:F8B:/
-2221.1 "Aetherochemical Mine" sync /:Repository Node:F8F:/
-2222.9 "Unholy" sync /:The Curator:F8A:/
-2225.1 "Sanctification" sync /:The Curator:F89:/
-2231.1 "Unholy" sync /:The Curator:F8A:/
-2233.5 "Sanctification" sync /:The Curator:F89:/
-2238.1 "Aetherochemical Mine" sync /:Repository Node:F8F:/
-2242.6 "Aetherochemical Explosive" sync /:The Curator:F8B:/
-2255.8 "The Educator" sync /:The Curator:F8D:/ window 15,15 jump 2191.7
+2200.0 "Sanctification" sync /:The Curator:F89:/
+2203.9 "Aetherochemical Mine" sync /:Repository Node:F8F:/ window 2200,10
+2205.2 "Unholy" sync /:The Curator:F8A:/
+2214.6 "Sanctification" sync /:The Curator:F89:/
+2222.7 "Aetherochemical Explosive" sync /:The Curator:F8B:/
+2225.0 "Aetherochemical Mine" sync /:Repository Node:F8F:/
+2226.8 "Unholy" sync /:The Curator:F8A:/
+2229.0 "Sanctification" sync /:The Curator:F89:/
+2235.0 "Unholy" sync /:The Curator:F8A:/
+2237.4 "Sanctification" sync /:The Curator:F89:/
+2242.0 "Aetherochemical Mine" sync /:Repository Node:F8F:/
+2246.5 "Aetherochemical Explosive" sync /:The Curator:F8B:/
+2259.7 "The Educator" sync /:The Curator:F8D:/
 
-2263.1 "Sanctification" sync /:The Curator:F89:/ jump 2196.1
-2267.0 "Aetherochemical Mine"
-2268.3 "Unholy"
-2277.7 "Sanctification"
-2285.8 "Aetherochemical Explosive"
-2288.1 "Aetherochemical Mine"
-2289.9 "Unholy"
-2292.1 "Sanctification"
+2267.0 "Sanctification" sync /:The Curator:F89:/ window 15,15 jump 2196.1
+2270.9 "Aetherochemical Mine"
+2272.2 "Unholy"
+2281.6 "Sanctification"
+2289.7 "Aetherochemical Explosive"
+2292.0 "Aetherochemical Mine"
+2293.8 "Unholy"
+2296.0 "Sanctification"

--- a/ui/raidboss/data/03-hw/dungeon/fractal_continuum.txt
+++ b/ui/raidboss/data/03-hw/dungeon/fractal_continuum.txt
@@ -45,7 +45,7 @@ hideall "--start--"
 139.0 "Atmospheric Displacement" sync /:Phantom Ray:F7E:/
 146.1 "Atmospheric Displacement" sync /:Phantom Ray:F7E:/ jump 97.7
 
-148.4 "Damage Up" sync
+148.4 "Damage Up" sync /:Phantom Ray:F7F:/ jump 100.0
 153.2 "Double Sever 1"
 155.8 "Atmospheric Compression"
 157.4 "Double Sever 2"

--- a/ui/raidboss/data/03-hw/dungeon/fractal_continuum.txt
+++ b/ui/raidboss/data/03-hw/dungeon/fractal_continuum.txt
@@ -10,14 +10,14 @@ hideall "--sync--"
 0.0 "--sync--" sync /Exhibit level III will be sealed off/ window 0,1
 10.3 "Rapid Sever" sync /:Phantom Ray:F7A:/ window 15,15
 16.6 "Atmospheric Displacement" sync /:Phantom Ray:F7E:/
-21.4 "Double Sever 1" sync /:Phantom Ray:F7B:/
-25.6 "Double Sever 2" sync /:Phantom Ray:F7C:/
+21.4 "Double Sever 1" sync /:Phantom Ray:F7[BC]:/
+25.6 "Double Sever 2" sync /:Phantom Ray:F7[BC]:/
 27.4 "Atmospheric Displacement" sync /:Phantom Ray:F7E:/
 
 41.5 "Rapid Sever" sync /:Phantom Ray:F7A:/ window 15,15
 47.7 "Atmospheric Displacement" sync /:Phantom Ray:F7E:/
-52.5 "Double Sever 1" sync /:Phantom Ray:F7B:/
-56.5 "Double Sever 2" sync /:Phantom Ray:F7C:/
+52.5 "Double Sever 1" sync /:Phantom Ray:F7[BC]:/
+56.5 "Double Sever 2" sync /:Phantom Ray:F7[BC]:/
 58.3 "Atmospheric Displacement" sync /:Phantom Ray:F7E:/
 
 72.4 "Rapid Sever" sync /:Phantom Ray:F7A:/  window 15,15 jump 41.5
@@ -28,15 +28,15 @@ hideall "--sync--"
 # Phase 2 at < 75% HP
 
 100.0 "Damage Up" sync /:Phantom Ray:F7F:/  window 100,30 #Overclock
-104.8 "Double Sever 1" sync /:Phantom Ray:F7B:/
+104.8 "Double Sever 1" sync /:Phantom Ray:F7[BC]:/
 107.6 "Atmospheric Compression" sync /:Phantom Ray:F80:/
-109.0 "Double Sever 2" sync /:Phantom Ray:F7C:/
+109.0 "Double Sever 2" sync /:Phantom Ray:F7[BC]:/
 111.8 "Atmospheric Displacement" sync /:Phantom Ray:F7E:/
 118.9 "Rapid Sever" sync /:Phantom Ray:F7A:/
 124.0 "Rapid Sever" sync /:Phantom Ray:F7A:/
 128.2 "Atmospheric Displacement" sync /:Phantom Ray:F7E:/
-133.1 "Double Sever 1" sync /:Phantom Ray:F7B:/
-137.3 "Double Sever 2" sync /:Phantom Ray:F7C:/
+133.1 "Double Sever 1" sync /:Phantom Ray:F7[BC]:/
+137.3 "Double Sever 2" sync /:Phantom Ray:F7[BC]:/
 139.0 "Atmospheric Displacement" sync /:Phantom Ray:F7E:/
 146.1 "Atmospheric Displacement" sync /:Phantom Ray:F7E:/
 

--- a/ui/raidboss/data/manifest.txt
+++ b/ui/raidboss/data/manifest.txt
@@ -32,6 +32,7 @@
 03-hw/alliance/dun_scaith.js
 03-hw/alliance/dun_scaith.txt
 03-hw/dungeon/fractal_continuum.js
+03-hw/dungeon/fractal_continuum.txt
 03-hw/dungeon/sohm_al.js
 03-hw/pvp/shatter.js
 03-hw/raid/a10s.js


### PR DESCRIPTION
I had thought Fractal Continuum would be an easy introduction to timeline creation, but it very definitely was not. Phantom Ray was the only straightforward part.

Minotaur's timeline is messy due to several interlocking possibilities. The basic Swipe > Swing > Groan > Slash > Swipe rotation is simple enough. The intended flow after this is that he starts a long 1111-Tonze Swing cast, which is then interrupted by opening a cage. This starts a long Feast cast, which leads back into the primary rotation. However, if the cage is not used, Minotaur jumps to the basic rotation immediately after using 1111-Tonze Swing. It's fiddly to get this to work, but it's functional in this release.

There is currently an issue with Minotaur in that it's possible to use a cage early. This will send him to where he uses Feast in the rotation, but the timeline is not set up to handle this. It will continue to display the standard rotation until Feast is used, at which point it will jump to the correct point. This is because I set it up to look for the cancellation message on 1111-Tonze Swing. The most correct way to handle it would be to look for the tether marker that indicates he's tethered to the bait. (This is the 1B overhead marker 0036, although it displays visually as a tether.) However, this would involve a regex similar to `/..../..../0036/` or `/1B:........:Minotaur:/`, and I wasn't sure whether long regex strings were okay in timelines.

The Curator is fully functional and correct so far as it goes, but is missing a third phase. Unlike Phantom Ray, Curator does not immediately go to the start of his next phase upon reaching his HP threshold. I wasn't able to figure out completely how this works, but I *think* it's based on when he reaches his threshold prior to casting The Educator. This holds true for the 1 > 2 transition, but unfortunately the phase 3 transition can enter anywhere during the rotation. There are 3 casts of Seed of the Rivers in phase 3, and he can enter at any of them. Worse, none of the abilities following these casts are safe attachment points for a wider sync window. Fortunately, the Seed of the River casts are added to the standard rotation without displacing anything, so the only deficiency in this version of the timeline is that they won't be displayed.

I also removed the trigger for mines. They're visually distinct on the field, and the trigger really didn't seem to add anything.