### PR TITLE
test: Add Additional Tests for Regex Cleanliness

### DIFF
--- a/ui/raidboss/data/03-hw/alliance/dun_scaith.js
+++ b/ui/raidboss/data/03-hw/alliance/dun_scaith.js
@@ -200,7 +200,7 @@
     {
       // Handles both 1E52 Aetherochemical Flare and 1D9D Supernova
       id: 'Dun Scaith Proto-Ultima Raid Damage',
-      regex: / 14:(?:1E52|1D9D): Proto Ultima Starts Using/,
+      regex: / 14:(?:1E52|1D9D):Proto Ultima starts using/,
       condition: function(data) {
         return data.role == 'healer';
       },
@@ -269,7 +269,7 @@
     {
       // The actual attack is 1D20, but the castbar windup is 1D1F
       id: 'Dun Scaith Shadespin',
-      regex: / 14:1D1(E|F):Scathach starts using Shadespin/,
+      regex: / 14:1D1[EF]:Scathach starts using Shadespin/,
       suppressSeconds: 5,
       infoText: {
         en: 'Avoid arm slaps',
@@ -277,7 +277,7 @@
     },
     {
       id: 'Dun Scaith Thirty Thorns',
-      regex: / (1[56]:\y{ObjectId}:Scathach:1D2B:Thirty Thorns|1[56]:\y{ObjectId}:Scathach:1D1B:Soar)/,
+      regex: / 1[56]:\y{ObjectId}:Scathach:1D[12]B:(?:Soar|Thirty Thorns)/,
       suppressSeconds: 5,
       alertText: {
         en: 'Out of melee',
@@ -359,9 +359,9 @@
     },
     {
       id: 'Dun Scaith Nightmare',
-      regex: / 14:(1C0E|1C20):\y{Name} starts using (Nightmare|Hollow Nightmare)/,
+      regex: / 14:(?:1C0E|1C20):\y{Name} starts using (?:Nightmare|Hollow Nightmare)/,
       alertText: {
-        en: ' Look away',
+        en: 'Look away',
       },
     },
     {
@@ -377,7 +377,7 @@
     },
     {
       id: 'Dun Scaith Ruinous Omen',
-      regex: / 14:(?:1C10|1C11):Diabolos starts using Ruinous Omen/,
+      regex: / 14:1C1[01]:Diabolos starts using Ruinous Omen/,
       suppressSeconds: 5,
       condition: function(data) {
         return data.role == 'healer';
@@ -428,7 +428,7 @@
     },
     {
       id: 'Dun Scaith Hollow Omen',
-      regex: / 14:(?:1C22|1C23):Diabolos Hollow starts using Hollow Omen/,
+      regex: / 14:1C2[23]:Diabolos Hollow starts using Hollow Omen/,
       suppressSeconds: 5,
       condition: function(data) {
         return data.role == 'healer';

--- a/ui/raidboss/data/04-sb/eureka/eureka_anemos.js
+++ b/ui/raidboss/data/04-sb/eureka/eureka_anemos.js
@@ -214,7 +214,7 @@
       id: 'Eureka Wraith Count',
       regex: / 19:Shadow Wraith was defeated by/,
       regexDe: / 19:Schatten-Geist was defeated by/,
-      regexFr: /(Spectre Des Ombres a été vaincu|Vous avez vaincu le spectre des ombres)/,
+      regexFr: /(?:Spectre Des Ombres a été vaincu|Vous avez vaincu le spectre des ombres)/,
       infoText: function(data) {
         data.wraithCount = data.wraithCount || 0;
         data.wraithCount++;

--- a/ui/raidboss/data/04-sb/raid/o12s.js
+++ b/ui/raidboss/data/04-sb/raid/o12s.js
@@ -587,10 +587,10 @@
     },
     {
       id: 'O12S Archive Peripheral',
-      regex: / 1B:\y{ObjectId}:Right Arm Unit:....:....:009(?:C|D):0000:0000:0000:/,
-      regexDe: / 1B:\y{ObjectId}:Rechter Arm:....:....:009(?:C|D):0000:0000:0000:/,
-      regexFr: / 1B:\y{ObjectId}:Unité Bras Droit:....:....:009(?:C|D):0000:0000:0000:/,
-      regexJa: / 1B:\y{ObjectId}:ライトアームユニット:....:....:009(?:C|D):0000:0000:0000:/,
+      regex: / 1B:\y{ObjectId}:Right Arm Unit:....:....:009[CD]:0000:0000:0000:/,
+      regexDe: / 1B:\y{ObjectId}:Rechter Arm:....:....:009[CD]:0000:0000:0000:/,
+      regexFr: / 1B:\y{ObjectId}:Unité Bras Droit:....:....:009[CD]:0000:0000:0000:/,
+      regexJa: / 1B:\y{ObjectId}:ライトアームユニット:....:....:009[CD]:0000:0000:0000:/,
       condition: function(data) {
         return data.numArms == 3;
       },

--- a/ui/raidboss/data/04-sb/raid/o1s.js
+++ b/ui/raidboss/data/04-sb/raid/o1s.js
@@ -7,7 +7,7 @@
   triggers: [
     {
       id: 'O1S Blaze',
-      regex: /:1EDD:Alte Roite starts using/,
+      regex: / 14:1EDD:Alte Roite starts using/,
       infoText: {
         en: 'Blaze: Stack up',
         de: 'Flamme: Stacken',
@@ -19,7 +19,7 @@
     },
     {
       id: 'O1S Breath Wing',
-      regex: /:1ED6:Alte Roite starts using/,
+      regex: / 14:1ED6:Alte Roite starts using/,
       infoText: {
         en: 'Breath Wing: Be beside boss',
         de: 'Atemschwinge: Neben Boss gehen',
@@ -31,7 +31,7 @@
     },
     {
       id: 'O1S Clamp',
-      regex: /:1EDE:Alte Roite starts using/,
+      regex: / 14:1EDE:Alte Roite starts using/,
       infoText: {
         en: 'Clamp: Get out of front',
         de: 'Klammer: Vorm Boss weg',
@@ -43,7 +43,7 @@
     },
     {
       id: 'O1S Downburst',
-      regex: /:1ED8:Alte Roite starts using/,
+      regex: / 14:1ED8:Alte Roite starts using/,
       infoText: {
         en: 'Downburst: Knockback',
         de: 'Fallböe: Rückstoß',
@@ -55,7 +55,7 @@
     },
     {
       id: 'O1S Roar',
-      regex: /:1ED4:Alte Roite starts using/,
+      regex: / 14:1ED4:Alte Roite starts using/,
       infoText: {
         en: 'Roar: AOE damage',
         de: 'Brüllen: Flächenschaden',
@@ -70,7 +70,7 @@
     },
     {
       id: 'O1S Charybdis',
-      regex: /:1ED3:Alte Roite starts using/,
+      regex: / 14:1ED3:Alte Roite starts using/,
       infoText: {
         en: 'Charybdis: AOE damage',
         de: 'Charybdis: Flächenschaden',

--- a/ui/raidboss/data/04-sb/raid/o2s.js
+++ b/ui/raidboss/data/04-sb/raid/o2s.js
@@ -17,8 +17,8 @@
   ],
   triggers: [
     { // Phase Tracker: Maniacal Probe.
-      regex: /:235A:Catastrophe starts using/,
-      regexDe: /:235A:Katastroph starts using/,
+      regex: / 14:235A:Catastrophe starts using/,
+      regexDe: / 14:235A:Katastroph starts using/,
       run: function(data) {
         data.probeCount = (data.probeCount || 0) + 1;
         data.dpsProbe = data.probeCount == 2 || data.probeCount == 4;
@@ -47,8 +47,8 @@
     },
     {
       id: 'O2S -100Gs',
-      regex: /:235E:Catastrophe starts using/,
-      regexDe: /:235E:Katastroph starts using/,
+      regex: / 14:235E:Catastrophe starts using/,
+      regexDe: / 14:235E:Katastroph starts using/,
       infoText: {
         en: '-100 Gs: Go north/south and look away',
         de: '-100G: Nach Norden/Süden und wegschauen',
@@ -60,8 +60,8 @@
     },
     {
       id: 'O2S Death\'s Gaze',
-      regex: /:236F:Catastrophe starts using/,
-      regexDe: /:236F:Katastroph starts using/,
+      regex: / 14:236F:Catastrophe starts using/,
+      regexDe: / 14:236F:Katastroph starts using/,
       alarmText: {
         en: 'Death\'s Gaze: Look away',
         de: 'Todesblick: Wegschauen',
@@ -73,8 +73,8 @@
     },
     {
       id: 'O2S Earthquake',
-      regex: /:2374:Catastrophe starts using/,
-      regexDe: /:2374:Katastroph starts using/,
+      regex: / 14:2374:Catastrophe starts using/,
+      regexDe: / 14:2374:Katastroph starts using/,
       infoText: function(data) {
         if (data.levitating) {
           return {
@@ -127,8 +127,8 @@
     },
     {
       id: 'O2S Gravitational Wave',
-      regex: /:2372:Catastrophe starts using/,
-      regexDe: /:2372:Katastroph starts using/,
+      regex: / 14:2372:Catastrophe starts using/,
+      regexDe: / 14:2372:Katastroph starts using/,
       infoText: 'Gravitational Wave: AOE damage',
       condition: function(data) {
         return data.role == 'healer';
@@ -140,8 +140,8 @@
     },
     {
       id: 'O2S Maniacal Probe',
-      regex: /:235A:Catastrophe starts using/,
-      regexDe: /:235A:Katastroph starts using/,
+      regex: / 14:235A:Catastrophe starts using/,
+      regexDe: / 14:235A:Katastroph starts using/,
       infoText: function(data) {
         if (!data.myProbe) {
           if (!data.dpsProbe) {

--- a/ui/raidboss/data/04-sb/raid/o4s.js
+++ b/ui/raidboss/data/04-sb/raid/o4s.js
@@ -391,8 +391,8 @@
       },
     },
     { // Laser counter.
-      regex: / 14:24(OE|0F|11|12):Neo Exdeath starts using/,
-      run: function(data, matches) {
+      regex: / 14:24(?:OE|0F|11|12):Neo Exdeath starts using/,
+      run: function(data) {
         if (data.phase != 'omega')
           return;
 

--- a/ui/raidboss/data/05-shb/dungeon/twinning.js
+++ b/ui/raidboss/data/05-shb/dungeon/twinning.js
@@ -54,7 +54,7 @@
     {
       // The handling for these mechanics is similar enough it makes sense to combine the trigger
       id: 'Twinning Impact + Pounce',
-      regex: / 1B:\y{ObjectId}:\y{Name}:....:....:(003[2-5]|005A)/,
+      regex: / 1B:\y{ObjectId}:\y{Name}:....:....:(?:003[2-5]|005A)/,
       suppressSeconds: 10,
       infoText: {
         en: 'Spread (avoid cages)',


### PR DESCRIPTION
Make the regex matching for previous tests stricter. Ensure there are no invalid combinations of '.' operators within the trigger regexes. Inform the user when there are instances of matching a single character via the use of groups instead of picking a character from a set.

Note: The former isn't that smart, and can't tell if you've used something like `(?:ABC1|ABC2)`; only if you're using `ABC(?:1|2)`.