### PR TITLE
The Vault--Added triggers and timelines

### DIFF
--- a/ui/raidboss/data/03-hw/dungeon/the_vault.js
+++ b/ui/raidboss/data/03-hw/dungeon/the_vault.js
@@ -1,0 +1,292 @@
+'use strict';
+
+// The Vault
+[{
+  zoneRegex: /The Vault/,
+  timelineFile: 'the_vault.txt',
+  timelineTriggers: [
+    {
+      id: 'The Vault Heavenly Slash',
+      regex: /Heavenly Slash/,
+      beforeSeconds: 3.5,
+      infoText: function(data) {
+        if (data.role == 'tank') {
+          return {
+            en: 'Tank cleave',
+          };
+        }
+        return {
+          en: 'Avoid tank cleave',
+        };
+      },
+    },
+    {
+      id: 'The Vault Shining Blade',
+      regex: /Shining Blade/,
+      beforeSeconds: 3,
+      suppressSeconds: 10,
+      infoText: {
+        en: 'Avoid dashes',
+      },
+    },
+    {
+      id: 'The Vault Heavy Swing',
+      regex: /Heavy Swing/,
+      beforeSeconds: 4,
+      infoText: function(data) {
+        if (data.role == 'tank') {
+          return {
+            en: 'Tank cleave',
+          };
+        }
+        return {
+          en: 'Avoid tank cleave',
+        };
+      },
+    },
+    {
+      id: 'The Vault Altar Candle',
+      regex: /Altar Candle/,
+      beforeSeconds: 5,
+      condition: function(data) {
+        return data.role != 'dps';
+      },
+      alertText: {
+        en: 'Tank buster',
+      },
+    },
+  ],
+  triggers: [
+    {
+      id: 'The Vault Holiest of Holy',
+      regex: / 14:101E:Ser Adelphel starts using Holiest Of Holy/,
+      condition: function(data) {
+        return data.role == 'healer';
+      },
+      infoText: {
+        en: 'AoE',
+      },
+    },
+    {
+      id: 'The Vault Holy Shield Bash',
+      regex: /14:101F:Ser Adelphel starts using Holy Shield Bash on (\y{Name})/,
+      condition: function(data, matches) {
+        return data.me != matches[1];
+      },
+      alertText: function(data, matches) {
+        if (data.role == 'healer') {
+          return {
+            en: 'Heal + shield ' + data.shortName(matches[1]),
+          };
+        }
+        return {
+          en: 'Avoid Shield Charge',
+        };
+      },
+    },
+    {
+      id: 'The Vault Execution',
+      regex: / 1B:\y{ObjectId}:(\y{Name}):....:....:0020/,
+      infoText: function(data, matches) {
+        if (data.me == matches[1]) {
+          return {
+            en: 'Spread marker on YOU',
+          };
+        }
+        return {
+          en: 'Avoid ' + data.shortName(matches[1]),
+        };
+      },
+    },
+    {
+      id: 'The Vault Black Nebula',
+      regex: / 14:1042:Face Of The Hero starts using Black Nebula/,
+      condition: function(data) {
+        return data.CanStun();
+      },
+      infoText: {
+        en: 'Interrupt the Knight',
+      },
+    },
+    {
+      id: 'The Vault Faith Unmoving',
+      regex: /14:1027:Ser Grinnaux starts using Faith Unmoving/,
+      infoText: {
+        en: 'Knockback',
+      },
+    },
+    {
+      id: 'The Vault Dimensional Torsion',
+      regex: /23:\y{ObjectId}:Aetherial Tear:\y{ObjectId}:(\y{Name}):....:....:0001/,
+      suppressSeconds: 5,
+      condition: function(data, matches) {
+        return data.me == matches[1];
+      },
+      alarmText: {
+        en: 'Away from rifts',
+      },
+    },
+    {
+      id: 'The Vault Altar Pyre',
+      regex: / 14:1035:Ser Charibert starts using Altar Pyre/,
+      condition: function(data) {
+        return data.role == 'healer';
+      },
+      alertText: {
+        en: 'AoE',
+      },
+    },
+    {
+      id: 'The Vault Holy Chains',
+      regex: / 1B:\y{ObjectId}:(\y{Name}):....:....:0061/,
+      condition: function(data, matches) {
+        return data.me == matches[1];
+      },
+      alertText: {
+        en: 'Away from tether partner',
+      },
+    },
+    {
+      id: 'The Vault Knights March',
+      regex: / 03:\y{ObjectId}:Added new combatant (Dawn|Dusk) Knight/,
+      suppressSeconds: 4,
+      infoText: {
+        en: 'Evade marching knights',
+      },
+    },
+  ],
+  timelineReplace: [
+    {
+      'locale': 'de',
+      'replaceSync': {
+        'Ser Adelphel Brightblade': 'Adelphel',
+        'Ser Adelphel': 'Adelphel',
+        'Ser Grinnaux the Bull': 'Grinnaux',
+        'Ser Grinnaux': 'Grinnaux',
+        'Ser Charibert': 'Charibert',
+
+        'The Quire': 'Chorempore',
+        'The chapter house': 'Himmelsgewölbe',
+        'The Chancel': 'Bekenntnis des Glaubens',
+      },
+      'replaceText': {
+        'Fast Blade': 'Vortexschnitt',
+        'Bloodstain': 'Befleckung',
+        'Advent': 'Wiederkunft',
+        'Holiest Of Holy': 'Quell der Heiligkeit',
+        'Heavenly Slash': 'Himmelsschlag',
+        'Holy Shield Bash': 'Heiliger Schildschlag',
+        'Solid Ascension': 'Gipfelstürmer',
+        'Shining Blade': 'Glänzende Klinge',
+        'Execution': 'Exekution',
+        'Retreat': 'Rückzug',
+
+        'Overpower': 'Kahlrodung',
+        'Rive': 'Spalten',
+        'Dimensional Collapse': 'Dimensionskollaps',
+        'Heavy Swing': 'Schwerer Schwinger',
+        'Hyperdimensional Slash': 'Hyperdimensionsschlag',
+        'Dimensional Rip': 'Dimensionsriss',
+        'Faith Unmoving': 'Fester Glaube',
+
+        'Altar Candle': 'Altarkerze',
+        'Heavensflame': 'Himmlische Flamme',
+        'Holy Chain': 'Heilige Kette',
+        'Knights Appear': 'Knights Appear', // FIXME
+        'Altar Pyre': 'Scheiterhaufen',
+        'Black Knight\s Tour': 'Schwarzer Rösselsprung',
+        'White Knight\'s Tour': 'Weißer Rösselsprung',
+        'Pure Of Heart': 'Reines Herz',
+        'Sacred Flame': 'Heilige Flamme',
+      },
+    },
+    {
+      'locale': 'fr',
+      'replaceSync': {
+        'Ser Adelphel Brightblade': 'sire Adelphel',
+        'Ser Adelphel': 'sire Adelphel',
+        'Ser Grinnaux the Bull': 'sire Grinnaux',
+        'Ser Grinnaux': 'sire Grinnaux',
+        'Ser Charibert': 'sire Charibert',
+
+        'The Quire': 'Chœur',
+        'The chapter house': 'Kiosque du patio',
+        'The Chancel': 'Salle de prière du sanctuaire de l\'Azur',
+      },
+      'replaceText': {
+        'Fast Blade': 'Lame rapide',
+        'Bloodstain': 'Tache de sang',
+        'Advent': 'Avènement',
+        'Holiest Of Holy': 'Saint des saints',
+        'Heavenly Slash': 'Lacération céleste',
+        'Holy Shield Bash': 'Coup de bouclier saint',
+        'Solid Ascension': 'Ascension solide',
+        'Shining Blade': 'Lame brillante',
+        'Execution': 'Exécution',
+        'Retreat': 'Retraite',
+
+        'Overpower': 'Domination',
+        'Rive': 'Coupure',
+        'Dimensional Collapse': 'Effondrement dimensionnel',
+        'Heavy Swing': 'Swing céleste',
+        'Hyperdimensional Slash': 'Lacération hyperdimensionnelle',
+        'Dimensional Rip': 'Déchirure dimensionnelle',
+        'Faith Unmoving': 'Foi immuable',
+
+        'Altar Candle': 'Cierge funéraire',
+        'Heavensflame': 'Flamme céleste',
+        'Holy Chain': 'Chaîne sacrée',
+        'Knights Appear': 'Knights Appear', // FIXME
+        'Altar Pyre': 'Bûcher funéraire',
+        'Black Knight\s Tour': 'Tour de cavalier noir',
+        'White Knight\'s Tour': 'Tour de cavalier blanc',
+        'Pure Of Heart': 'Pureté du cœur',
+        'Sacred Flame': 'Flamme sacrée',
+      },
+    },
+    {
+      'locale': 'ja',
+      'replaceSync': {
+        'Ser Adelphel Brightblade': '美剣のアデルフェル',
+        'Ser Adelphel': '聖騎士アデルフェル',
+        'Ser Grinnaux the Bull': '戦狂のグリノー',
+        'Ser Grinnaux': '聖騎士グリノー',
+        'Ser Charibert': '聖騎士シャリベル',
+
+        'The Quire': '聖歌隊席',
+        'The chapter house': '庭園の小ホール',
+        'The Chancel': '氷天宮礼拝堂',
+      },
+      'replaceText': {
+        'Fast Blade': 'ファストブレード',
+        'Bloodstain': 'ブラッドステイン',
+        'Advent': '再臨',
+        'Holiest Of Holy': 'ホリエストホーリー',
+        'Heavenly Slash': 'ヘヴンリースラッシュ',
+        'Holy Shield Bash': 'ホーリーシールドバッシュ',
+        'Solid Ascension': 'ソリッドライズ',
+        'Shining Blade': 'シャイニングブレード',
+        'Execution': 'エクスキューション',
+        'Retreat': '撤退',
+
+        'Overpower': 'オーバーパワー',
+        'Rive': 'ライブ',
+        'Dimensional Collapse': 'ディメンションクラッシュ',
+        'Heavy Swing': 'ヘヴンリースイング',
+        'Hyperdimensional Slash': 'ハイパーディメンション',
+        'Dimensional Rip': 'ディメンションリップ',
+        'Faith Unmoving': 'フェイスアンムーブ',
+
+        'Altar Candle': 'アルターキャンドル',
+        'Heavensflame': 'へヴンフレイム',
+        'Holy Chain': 'ホーリーチェーン',
+        'Knights Appear': 'Knights Appear', // FIXME
+        'Altar Pyre': 'アルターパイヤ',
+        'Black Knight\s Tour': 'ブラックナイトツアー',
+        'White Knight\'s Tour': 'ホワイトナイトツアー',
+        'Pure Of Heart': 'ピュア・オブ・ハート',
+        'Sacred Flame': '聖火燃焼',
+      },
+    },
+  ],
+}];

--- a/ui/raidboss/data/03-hw/dungeon/the_vault.js
+++ b/ui/raidboss/data/03-hw/dungeon/the_vault.js
@@ -70,18 +70,12 @@
     {
       id: 'The Vault Holy Shield Bash',
       regex: /14:101F:Ser Adelphel starts using Holy Shield Bash on (\y{Name})/,
-      condition: function(data, matches) {
-        return data.me != matches[1];
-      },
       alertText: function(data, matches) {
         if (data.role == 'healer') {
           return {
-            en: 'Heal + shield ' + data.shortName(matches[1]),
+            en: 'Heal + shield ' + data.ShortName(matches[1]),
           };
         }
-        return {
-          en: 'Avoid Shield Charge',
-        };
       },
     },
     {
@@ -94,7 +88,7 @@
           };
         }
         return {
-          en: 'Avoid ' + data.shortName(matches[1]),
+          en: 'Avoid ' + data.ShortName(matches[1]),
         };
       },
     },
@@ -143,7 +137,7 @@
         return data.me == matches[1];
       },
       alertText: {
-        en: 'Away from tether partner',
+        en: 'Break chains',
       },
     },
     {

--- a/ui/raidboss/data/03-hw/dungeon/the_vault.txt
+++ b/ui/raidboss/data/03-hw/dungeon/the_vault.txt
@@ -1,0 +1,215 @@
+hideall "--reset--"
+hideall "--sync--"
+
+0 "--reset--" sync /is no longer sealed/ window 10000 jump 0
+
+###Ser Adelphel Brightblade
+# -ii 101B 1374 1019 101C
+
+# Pre-phase
+# Barely worth including, but oh well.
+
+0.0 "--sync--" sync /The Quire will be sealed off/ window 0,1
+5.4 "Fast Blade" sync /:Ser Adelphel Brightblade:2CD:/
+12.5 "Bloodstain" sync /:Ser Adelphel Brightblade:44B:/
+15.8 "Fast Blade" sync /:Ser Adelphel Brightblade:2CD:/
+26.5 "Fast Blade" sync /:Ser Adelphel Brightblade:2CD:/
+
+33.6 "Bloodstain" sync /:Ser Adelphel Brightblade:44B:/
+36.8 "Fast Blade" sync /:Ser Adelphel Brightblade:2CD:/
+47.5 "Fast Blade" sync /:Ser Adelphel Brightblade:2CD:/ jump 26.5
+
+54.7 "Bloodstain"
+57.8 "Fast Blade"
+68.7 "Fast Blade"
+
+# Phase 1
+
+100.0 "Advent" sync /:Ser Adelphel Brightblade:1373:/ window 100,30
+102.1 "Advent" sync /:Ser Adelphel Brightblade:101A:/
+
+110.3 "Holiest Of Holy" sync /:Ser Adelphel:101E:/
+114.5 "Heavenly Slash" sync /:Ser Adelphel:101D:/
+122.8 "Holy Shield Bash" sync /:Ser Adelphel:101F:/
+123.9 "Solid Ascension x2" sync /:Ser Adelphel:1020:/
+131.8 "Heavenly Slash" sync /:Ser Adelphel:101D:/
+
+140.0 "Holiest Of Holy" sync /:Ser Adelphel:101E:/
+144.2 "Heavenly Slash" sync /:Ser Adelphel:101D:/
+152.5 "Holy Shield Bash" sync /:Ser Adelphel:101F:/
+153.6 "Solid Ascension x2" sync /:Ser Adelphel:1020:/
+161.5 "Heavenly Slash" sync /:Ser Adelphel:101D:/ window 10,5 jump 131.8
+
+169.7 "Holiest Of Holy"
+173.9 "Heavenly Slash"
+182.2 "Holy Shield Bash"
+183.3 "Solid Ascension x2"
+191.2 "Heavenly Slash"
+
+# Phase 2 at < 70% HP
+
+300.0 "Shining Blade 1" sync /:Ser Adelphel:1022:/ window 300,0
+302.4 "Shining Blade 2" sync /:Ser Adelphel:1022:/ window 2,2
+304.6 "Shining Blade 3" sync /:Ser Adelphel:1022:/ window 2,2
+307.0 "Shining Blade 4" sync /:Ser Adelphel:1022:/ window 2,2
+309.0 "--Untargetable--"
+311.7 "--Targetable--"
+311.7 "Execution" sync /:Ser Adelphel:1023:/
+322.8 "Holiest Of Holy" sync /:Ser Adelphel:101E:/
+328.0 "Heavenly Slash" sync /:Ser Adelphel:101D:/
+337.2 "Holy Shield Bash" sync /:Ser Adelphel:101F:/
+338.3 "Solid Ascension x2" sync /:Ser Adelphel:1020:/
+349.1 "Holiest Of Holy" sync /:Ser Adelphel:101E:/
+353.3 "Heavenly Slash" sync /:Ser Adelphel:101D:/
+
+357.4 "Shining Blade 1" sync /:Ser Adelphel:1022:/ window 2,2
+359.8 "Shining Blade 2" sync /:Ser Adelphel:1022:/ window 2,2
+362.0 "Shining Blade 3" sync /:Ser Adelphel:1022:/ window 2,2 
+364.4 "Shining Blade 4" sync /:Ser Adelphel:1022:/ window 2,2
+366.4 "--Untargetable--"
+369.0 "--Targetable--"
+369.1 "Execution" sync /:Ser Adelphel:1023:/
+380.2 "Holiest Of Holy" sync /:Ser Adelphel:101E:/
+385.4 "Heavenly Slash" sync /:Ser Adelphel:101D:/
+394.6 "Holy Shield Bash" sync /:Ser Adelphel:101F:/
+395.7 "Solid Ascension x2" sync /:Ser Adelphel:1020:/
+406.5 "Holiest Of Holy" sync /:Ser Adelphel:101E:/
+410.7 "Heavenly Slash" sync /:Ser Adelphel:101D:/ window 15,15 jump 353.3
+
+414.8 "Shining Blade 1"
+417.2 "Shining Blade 2"
+419.4 "Shining Blade 3"
+421.8 "Shining Blade 4"
+426.5 "Execution"
+437.6 "Holiest Of Holy"
+
+# Closing sequence
+441.9 "--sync--" sync /:Ser Adelphel Brightblade:10A0:/ window 450,0
+442.0 "Retreating" duration 8.0
+450 "Retreat" sync /:Ser Adelphel Brightblade:10A1:/
+
+###Ser Grinneaux the Bull
+# -ii 101A
+
+# Pre-phase
+1000 "--sync--" sync /The chapter house will be sealed off/ window 1000,1
+1006.7 "Overpower" sync /:Ser Grinnaux the Bull:88C:/
+1015.6 "Rive" sync /:Ser Grinnaux the Bull:46F:/
+1018.9 "Overpower" sync /:Ser Grinnaux the Bull:88C:/
+1031.2 "Overpower" sync /:Ser Grinnaux the Bull:88C:/
+1039.9 "Rive" sync /:Ser Grinnaux the Bull:46F:/
+
+1043.2 "Overpower" sync /:Ser Grinnaux the Bull:88C:/
+1055.5 "Overpower" sync /:Ser Grinnaux the Bull:88C:/
+1064.2 "Rive" sync /:Ser Grinnaux the Bull:46F:/ jump 1039.9
+
+1067.5 "Overpower"
+1079.8 "Overpower"
+1088.5 "Rive"
+
+# Phase transition
+1100.0 "Advent" sync /:Ser Grinnaux the Bull:1373:/ window 100,5
+1101.0 "Advent" sync /:Ser Grinnaux:1374:/
+1101.9 "--sync--" sync /:Ser Grinnaux:101B:/
+
+# Main Phase
+1109.6 "Dimensional Collapse" sync /:Ser Grinnaux:1028:/
+1113.7 "Heavy Swing" sync /:Ser Grinnaux:1025:/
+1118.0 "Heavy Swing" sync /:Ser Grinnaux:1025:/
+1125.1 "Hyperdimensional Slash" sync /:Ser Grinnaux:1026:/
+1130.3 "Hyperdimensional Slash" sync /:Ser Grinnaux:1026:/
+1134.4 "Heavy Swing" sync /:Ser Grinnaux:1025:/
+1139.4 "Faith Unmoving" sync /:Ser Grinnaux:1027:/
+
+1144.1 "Dimensional Collapse" sync /:Ser Grinnaux:1028:/
+1152.3 "Dimensional Rip" sync /:Ser Grinnaux:102C:/
+1155.5 "Heavy Swing" sync /:Ser Grinnaux:1025:/
+1161.6 "Hyperdimensional Slash" sync /:Ser Grinnaux:1026:/
+1166.8 "Hyperdimensional Slash" sync /:Ser Grinnaux:1026:/
+1170.8 "Heavy Swing" sync /:Ser Grinnaux:1025:/
+1177.4 "Dimensional Collapse" sync /:Ser Grinnaux:1028:/
+1182.5 "Faith Unmoving" sync /:Ser Grinnaux:1027:/
+
+1192.7 "Dimensional Rip" sync /:Ser Grinnaux:102C:/ window 15,15
+1195.9 "Heavy Swing" sync /:Ser Grinnaux:1025:/
+1202.1 "Hyperdimensional Slash" sync /:Ser Grinnaux:1026:/
+1207.9 "Hyperdimensional Slash" sync /:Ser Grinnaux:1026:/
+1212.1 "Heavy Swing" sync /:Ser Grinnaux:1025:/
+1218.7 "Dimensional Collapse" sync /:Ser Grinnaux:1028:/
+1223.8 "Faith Unmoving" sync /:Ser Grinnaux:1027:/
+
+1234.0 "Dimensional Rip" sync /:Ser Grinnaux:102C:/
+1237.1 "Heavy Swing" sync /:Ser Grinnaux:1025:/
+1243.3 "Hyperdimensional Slash" sync /:Ser Grinnaux:1026:/
+1248.8 "Hyperdimensional Slash" sync /:Ser Grinnaux:1026:/
+1253.0 "Heavy Swing" sync /:Ser Grinnaux:1025:/
+1259.6 "Dimensional Collapse" sync /:Ser Grinnaux:1028:/
+1264.7 "Faith Unmoving" sync /:Ser Grinnaux:1027:/ jump 1182.5
+
+# Closing sequence
+1441.9 "--sync--" sync /:Ser Grinnaux the Bull:10A0:/ window 500,10
+1442.0 "Retreating" duration 8
+1450.0 "Retreat" sync /:Ser Grinnaux the Bull:10A1:/
+
+
+###Ser Charibert
+
+2000.0 "--sync--" sync /The Chancel will be sealed off/ window 2000,0
+2006.3 "Altar Candle" sync /:Ser Charibert:1030:/
+2015.0 "Heavensflame" sync /:Ser Charibert:1031:/
+2019.2 "Holy Chain" sync /:Ser Charibert:1033:/
+2024.4 "Altar Candle" sync /:Ser Charibert:1030:/
+2028.7 "Knights Appear"
+2037.6 "Altar Pyre" sync /:Ser Charibert:1035:/
+
+2046.6 "Altar Candle" sync /:Ser Charibert:1030:/
+2055.3 "Heavensflame" sync /:Ser Charibert:1031:/
+2059.5 "Holy Chain" sync /:Ser Charibert:1033:/
+2064.7 "Altar Candle" sync /:Ser Charibert:1030:/
+2068.8 "Knights Appear"
+2077.9 "Altar Pyre" sync /:Ser Charibert:1035:/ window 15,15 jump 2037.6
+
+2086.9 "Altar Candle"
+2095.6 "Heavensflame"
+2099.8 "Holy Chain"
+2105.0 "Altar Candle"
+
+# Intermission at < 60% HP
+
+2200.0 "Unknown_1019" sync /:Ser Charibert:1019:/ window 200,5
+2205.1 "--sync--" sync /:Ser Charibert:1018:/
+2207.2 "--sync--" sync /:Ser Charibert:1036:/
+2218.4 "Black Knight's Tour" sync /:Dusk Knight:1039:/
+2218.5 "White Knight's Tour" sync /:Dawn Knight:1038:/
+2231.7 "Black Knight's Tour" sync /:Dusk Knight:1039:/
+2231.9 "White Knight's Tour" sync /:Dawn Knight:1038:/
+2245.0 "Black Knight's Tour" sync /:Dusk Knight:1039:/
+2245.2 "White Knight's Tour" sync /:Dawn Knight:1038:/
+2250 "--sync--" sync /:Ser Charibert:1037:/ window 50,1 jump 2294.0
+2252.4 "Pure Of Heart?" sync /:Ser Charibert:1037:/
+2254.5 "Sacred Flame Enrage?" sync /:Holy Flame:103C:/
+
+2294.0 "--sync--" # Landing for correct intermission handling
+
+# The party might survive an intermission enrage, so a wide sync here
+2300.0 "Altar Candle" sync /:Ser Charibert:1030:/ window 100,20
+2309.0 "Altar Pyre" sync /:Ser Charibert:1035:/
+2316.3 "Kinghts Appear"
+2318.6 "Heavensflame" sync /:Ser Charibert:1031:/
+2322.8 "Holy Chain" sync /:Ser Charibert:1033:/
+2332.0 "Altar Pyre" sync /:Ser Charibert:1035:/
+2336.1 "Altar Candle" sync /:Ser Charibert:1030:/
+
+2345.3 "Altar Candle" sync /:Ser Charibert:1030:/
+2354.3 "Altar Pyre" sync /:Ser Charibert:1035:/
+2356.6 "Knights Appear"
+2363.9 "Heavensflame" sync /:Ser Charibert:1031:/
+2368.1 "Holy Chain" sync /:Ser Charibert:1033:/
+2377.3 "Altar Pyre" sync /:Ser Charibert:1035:/
+2381.4 "Altar Candle" sync /:Ser Charibert:1030:/ window 15,5 jump 2336.1
+
+2390.6 "Altar Candle"
+2399.6 "Altar Pyre"
+2409.2 "Heavensflame"
+2413.4 "Holy Chain"
+2422.6 "Altar Pyre"

--- a/ui/raidboss/data/03-hw/dungeon/the_vault.txt
+++ b/ui/raidboss/data/03-hw/dungeon/the_vault.txt
@@ -176,7 +176,7 @@ hideall "--sync--"
 
 # Intermission at < 60% HP
 
-2200.0 "Unknown_1019" sync /:Ser Charibert:1019:/ window 200,5
+2200.0 "--sync--" sync /:Ser Charibert:1019:/ window 200,5
 2205.1 "--sync--" sync /:Ser Charibert:1018:/
 2207.2 "--sync--" sync /:Ser Charibert:1036:/
 2218.4 "Black Knight's Tour" sync /:Dusk Knight:1039:/
@@ -185,16 +185,15 @@ hideall "--sync--"
 2231.9 "White Knight's Tour" sync /:Dawn Knight:1038:/
 2245.0 "Black Knight's Tour" sync /:Dusk Knight:1039:/
 2245.2 "White Knight's Tour" sync /:Dawn Knight:1038:/
-2250 "--sync--" sync /:Ser Charibert:1037:/ window 50,1 jump 2294.0
-2252.4 "Pure Of Heart?" sync /:Ser Charibert:1037:/
-2254.5 "Sacred Flame Enrage?" sync /:Holy Flame:103C:/
+2254.5 "Sacred Flame Enrage?"
 
-2294.0 "--sync--" # Landing for correct intermission handling
+2294.0 "--sync--" sync /:Ser Charibert:1037:/ window 2294,0
 
-# The party might survive an intermission enrage, so a wide sync here
+# The party might survive an intermission enrage.
+# This wide window on Candle allows for that.
 2300.0 "Altar Candle" sync /:Ser Charibert:1030:/ window 100,20
 2309.0 "Altar Pyre" sync /:Ser Charibert:1035:/
-2316.3 "Kinghts Appear"
+2316.3 "Knights Appear"
 2318.6 "Heavensflame" sync /:Ser Charibert:1031:/
 2322.8 "Holy Chain" sync /:Ser Charibert:1033:/
 2332.0 "Altar Pyre" sync /:Ser Charibert:1035:/

--- a/ui/raidboss/data/manifest.txt
+++ b/ui/raidboss/data/manifest.txt
@@ -33,6 +33,8 @@
 03-hw/alliance/dun_scaith.txt
 03-hw/dungeon/fractal_continuum.js
 03-hw/dungeon/fractal_continuum.txt
+03-hw/dungeon/the_vault.js
+03-hw/dungeon/the_vault.txt
 03-hw/dungeon/sohm_al.js
 03-hw/pvp/shatter.js
 03-hw/raid/a10s.js


### PR DESCRIPTION
After the pain that was Fractal Continuum, this was amazingly simple. Everything matches up nicely and I had no issues putting this together.

The inconsistent timings on tank busters vs AoE are to avoid unfortunate overlaps on mechanics. If everything were set to 5 seconds, it could be easy for users to assume that one popup was meant for a different mechanic, if they just go by sounds. The timings are adjusted to account for this as much as possible.

The one thing that could be added would be a popup to tell the user to try to overlap Hyperdimensional Slashes on Grinnaux. I couldn't think of a concise enough way to put it, and it would be spammy because he doesn't target these at a player. Perhaps later on when I feel like doing the math to determine his facing relative to player positions. (Obviously it's possible, since you do something similar for bomb boulder triggers in E4s, and facing is available also.)

Grinnaux's rotation isn't exact, because Dimensional Collapse appears to be on a slightly offset timer relative to the rest of his rotation. However, what I've done here is close enough, and it would take about 7 minutes of combat to desync to the point where it's noticeable. I don't think this will be an issue for the Vault.

Charibert's intermission is messier than I would like, but it's functional as it is. It's vastly unlikely that a party that can't clear the intermission would survive the enrage, so I didn't put too much effort into handling that. (The enrage is "soft" in the sense that it's not an automatic wipe; instead each flame that wasn't destroyed explodes for high damage.) Pure of Heart is used to close the intermission whether or not the flames are destroyed, so if it's used before the enrage time, I had the timeline jump to resume the rotation. Suggestions for better handling here are welcome.