### PR TITLE
raidboss: Eliminiate a race condition during raidboss initialization.

### DIFF
--- a/ui/raidboss/popup-text.js
+++ b/ui/raidboss/popup-text.js
@@ -14,6 +14,19 @@ class PopupText {
     this.kMaxRowsOfText = 2;
 
     this.Reset();
+
+    addOverlayListener('onPlayerChangedEvent', (e) => {
+      this.OnPlayerChange(e);
+    });
+    addOverlayListener('onZoneChangedEvent', (e) => {
+      this.OnZoneChange(e);
+    });
+    addOverlayListener('onInCombatChangedEvent', (e) => {
+      this.OnInCombatChange(e.detail.inGameCombat);
+    });
+    addOverlayListener('onLogEvent', (e) => {
+      this.OnLog(e);
+    });
   }
 
   SetTimelineLoader(timelineLoader) {
@@ -558,21 +571,3 @@ class PopupTextGenerator {
 }
 
 let gPopupText;
-
-addOverlayListener('onPlayerChangedEvent', function(e) {
-  gPopupText.OnPlayerChange(e);
-});
-addOverlayListener('onZoneChangedEvent', function(e) {
-  gPopupText.OnZoneChange(e);
-});
-addOverlayListener('onInCombatChangedEvent', function(e) {
-  gPopupText.OnInCombatChange(e.detail.inGameCombat);
-});
-addOverlayListener('onLogEvent', function(e) {
-  gPopupText.OnLog(e);
-});
-
-callOverlayHandler({
-  call: 'cactbotReadDataFiles',
-  source: location.href,
-}).then((e) => gPopupText.OnDataFilesRead(e));

--- a/ui/raidboss/raidboss.js
+++ b/ui/raidboss/raidboss.js
@@ -57,6 +57,7 @@ UserConfig.getUserConfigLocation('raidboss', function(e) {
     source: location.href,
   }).then((e) => {
     gTimelineController.SetDataFiles(e.detail.files);
+    gPopupText.OnDataFilesRead(e);
     gPopupText.ReloadTimelines();
   });
 


### PR DESCRIPTION
If we attach the overlay listeners before gPopupText has been set, we risk triggering a "Cannot read property '...' of undefined" error. If we attach them in the constructor instead, we can be sure that the object exists.
Since only one instance of PopupText is ever created, we don't have to worry about detaching the overlay listeners.

This should fix the issue reported in https://github.com/quisquous/cactbot/issues/660#issuecomment-542819459.

I've also eliminated a duplicated call to `cactbotReadDataFiles` which was part of the modified code.