### PR TITLE
ci: Use Preinstalled Node Version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ matrix:
   include:
   - language: node_js
     node_js:
-      - 4.0
+      - 8.12.0
     before_install:
       # alias python3.7.1 to python3
       - pyenv global 3.7.1


### PR DESCRIPTION
There was an issue in #684 with the Node version installed on the Travis CI node being too low. Bump the Node version to instead use the preinstalled version.