### PR TITLE
Initial Gubal (Hard) triggers and timelines

### DIFF
--- a/ui/oopsyraidsy/data/03-hw/dungeon/gubal_library_hard.js
+++ b/ui/oopsyraidsy/data/03-hw/dungeon/gubal_library_hard.js
@@ -66,7 +66,7 @@
       id: 'Gubal Hard Imp Tracking',
       gainsEffectRegex: gLang.kEffect.Imp,
       losesEffectRegex: gLang.kEffect.Imp,
-      run: function (e, data) {
+      run: function(e, data) {
         data.hasImp = data.hasImp || {};
         data.hasImp[e.targetName] = e.gains;
         console.log(data);

--- a/ui/oopsyraidsy/data/03-hw/dungeon/gubal_library_hard.js
+++ b/ui/oopsyraidsy/data/03-hw/dungeon/gubal_library_hard.js
@@ -1,0 +1,109 @@
+'use strict';
+
+// Great Gubal Library (Hard)
+[{
+  zoneRegex: /Great Gubal Library \(Hard\)/,
+  damageWarn: {
+    'Gubal Hard Terror Eye': '930', // Circle AoE, Spine Breaker trash
+    'Gubal Hard Batter': '198A', // Circle AoE, trash before boss 1
+    'Gubal Hard Condemnation': '390', // Conal AoE, Bibliovore trash
+    'Gubal Hard Discontinue 1': '1943', // Falling book shadow, boss 1
+    'Gubal Hard Discontinue 2': '1940', // Rush AoE from ends, boss 1
+    'Gubal Hard Discontinue 3': '1942', // Rush AoE across, boss 1
+    'Gubal Hard Frightful Roar': '193B', // Get-Out AoE, boss 1
+    'Gubal Hard Issue 1': '193D', // Initial end book warning AoE, boss 1
+    'Gubal Hard Issue 2': '193F', // Initial end book warning AoE, boss 1
+    'Gubal Hard Issue 3': '1941', // Initial side book warning AoE, boss 1
+    'Gubal Hard Desolation': '198C', // Line AoE, Biblioclast trash
+    'Gubal Hard Double Smash': '26A', // Conal AoE, Biblioclast trash
+    'Gubal Hard Darkness': '3A0', // Conal AoE, Inkstain trash
+    'Gubal Hard Firewater': '3BA', // Circle AoE, Biblioclast trash
+    'Gubal Hard Elbow Drop': 'CBA', // Conal AoE, Biblioclast trash
+    'Gubal Hard Dark': '19DF', // Large circle AoE, Inkstain trash
+    'Gubal Hard Seals': '194A', // Sun/Moonseal failure, boss 2
+    'Gubal Hard Water III': '1C67', // Large circle AoE, Porogo Pegist trash
+    'Gubal Hard Raging Axe': '1703', // Small conal AoE, Mechanoservitor trash
+    'Gubal Hard Magic Hammer': '1990', // Large circle AoE, Apanda mini-boss
+    'Gubal Hard Properties Of Gravity': '1950', // Circle AoE from gravity puddles, boss 3
+    'Gubal Hard Properties Of Levitation': '194F', // Circle AoE from levitation puddles, boss 3
+    'Gubal Hard Comet': '1969', // Small circle AoE, intermission, boss 3
+  },
+  damageFail: {
+    'Gubal Hard Ecliptic Meteor': '195C', // LoS mechanic, boss 3
+  },
+  triggers: [
+    {
+      id: 'Gubal Hard Burns', // Fire gate in hallway to boss 2, magnet failure on boss 2
+      gainsEffectRegex: gLang.kEffect.Burns,
+      mistake: function(e, data) {
+        return { type: 'warn', blame: e.targetName, text: e.effectName };
+      },
+    },
+    {
+      id: 'Gubal Hard Searing Wind', // Tank cleave, boss 2
+      damageRegex: '1944',
+      condition: function(e, data) {
+        // Double taps only, but tanks are always hit by this
+        return data.role != 'tank' && e.type != '15';
+      },
+      mistake: function(e, data) {
+        return { type: 'warn', blame: e.targetName, text: e.abilityName };
+      },
+    },
+    {
+      id: 'Gubal Hard Thunder', // Spread marker, boss 3
+      damageRegex: '195[AB]',
+      condition: function(e, data) {
+        // Double taps only
+        return e.type != '15';
+      },
+      mistake: function(e, data) {
+        return { type: 'warn', blame: e.targetName, text: e.abilityName };
+      },
+    },
+    {
+      // Helper for Thunder 3 failures
+      id: 'Gubal Hard Imp Tracking',
+      gainsEffectRegex: gLang.kEffect.Imp,
+      losesEffectRegex: gLang.kEffect.Imp,
+      run: function (e, data) {
+        data.hasImp = data.hasImp || {};
+        data.hasImp[e.targetName] = e.gains;
+        console.log(data);
+      },
+    },
+    {
+      // Targets with Imp when Thunder III resolves receive a vulnerability stack and brief stun
+      id: 'Gubal Hard Imp Thunder',
+      damageRegex: '195[AB]',
+      condition: function(e, data) {
+        return data.hasImp[e.targetName];
+      },
+      mistake: function(e, data) {
+        return { type: 'warn', blame: e.targetName, text: 'Shocked Imp' };
+      },
+    },
+    {
+      id: 'Gubal Hard Quake',
+      damageRegex: '1956',
+      condition: function(e, data) {
+        // Always hits target, but if correctly resolved will deal 0 damage
+        return e.damage > 0;
+      },
+      mistake: function(e, data) {
+        return { type: 'warn', blame: e.targetName, text: e.abilityName };
+      },
+    },
+    {
+      id: 'Gubal Hard Tornado',
+      damageRegex: '195[78]',
+      condition: function(e, data) {
+        // Always hits target, but if correctly resolved will deal 0 damage
+        return e.damage > 0;
+      },
+      mistake: function(e, data) {
+        return { type: 'warn', blame: e.targetName, text: e.abilityName };
+      },
+    },
+  ],
+}];

--- a/ui/oopsyraidsy/data/manifest.txt
+++ b/ui/oopsyraidsy/data/manifest.txt
@@ -3,6 +3,7 @@
 02-arr/trial/ifrit_nm.js
 02-arr/trial/titan_ex.js
 03-hw/dungeon/fractal_continuum.js
+03-hw/dungeon/gubal_library_hard.js
 04-sb/raid/o4s.js
 04-sb/raid/o5s.js
 04-sb/raid/o6s.js

--- a/ui/raidboss/data/03-hw/dungeon/gubal_library_hard.js
+++ b/ui/raidboss/data/03-hw/dungeon/gubal_library_hard.js
@@ -68,7 +68,7 @@
     },
     {
       id: 'Gubal Hard Ferrofluid Execute',
-      regex: / 1B:\y{ObjectId}:\y{Name}:....:....:0030|0031:/,
+      regex: / 1B:\y{ObjectId}:\y{Name}:....:....:(?:0030|0031):/,
       suppressSeconds: 5,
       delaySeconds: 0.5,
       infoText: function(data) {
@@ -177,7 +177,7 @@
       regex: /14:195D:Behemoth Ward starts using Ecliptic Meteor/,
       delaySeconds: 14, // Leaving about 10s warning to complete the LoS
       alertText: {
-        en: 'LoS Behemoth with boulder',
+        en: 'Hide behind boulder',
       },
     },
   ],

--- a/ui/raidboss/data/03-hw/dungeon/gubal_library_hard.js
+++ b/ui/raidboss/data/03-hw/dungeon/gubal_library_hard.js
@@ -1,0 +1,300 @@
+'use strict';
+
+// The Great Gubal Library--Hard
+[{
+  zoneRegex: /Great Gubal Library \(Hard\)/,
+  timelineFile: 'gubal_library_hard.txt',
+  timelineTriggers: [
+    {
+      id: 'Gubal Hard Triclip',
+      regex: /Triclip/,
+      beforeSeconds: 5,
+      condition: function(data) {
+        return data.role == 'healer' || data.role == 'tank';
+      },
+      infoText: {
+        en: 'Tank Buster',
+      },
+    },
+    {
+      id: 'Gubal Hard Searing Wind',
+      regex: /Searing Wind/,
+      beforeSeconds: 5,
+      infoText: function(data) {
+        if (data.role == 'tank') {
+          return {
+            en: 'Tank Cleave on you',
+          };
+        }
+        return {
+          en: 'Avoid tank cleave',
+        };
+      },
+    },
+    {
+      id: 'Gubal Hard Properties of Darkness',
+      regex: /Darkness \(buster\)/,
+      beforeSeconds: 5,
+      condition: function(data) {
+        return data.role == 'healer' || data.role == 'tank';
+      },
+      infoText: {
+        en: 'Tank Buster',
+      },
+    },
+  ],
+  triggers: [
+    {
+      id: 'Gubal Hard Bibliocide',
+      regex: / 14:1945:Liquid Flame starts using Bibliocide/,
+      condition: function(data) {
+        return data.role == 'healer';
+      },
+      infoText: {
+        en: 'AoE',
+      },
+    },
+    {
+      // Ferrofluid handling is shamelessly copied from Hades Normal
+      id: 'Gubal Hard Ferrofluid Collect',
+      regex: / 1B:\y{ObjectId}:(\y{Name}):....:....:(0030|0031):/,
+      run: function(data, matches) {
+        data.fluid = data.fluid || {};
+        if (matches[2] == '0030')
+          data.fluid[matches[1]] = 'positive';
+        if (matches[2] == '0031')
+          data.fluid[matches[1]] = 'negative';
+      },
+    },
+    {
+      id: 'Gubal Hard Ferrofluid Execute',
+      regex: / 1B:\y{ObjectId}:\y{Name}:....:....:0030|0031:/,
+      suppressSeconds: 5,
+      delaySeconds: 0.5,
+      infoText: function(data) {
+        if (data.fluid[data.me] == data.fluid['Liquid Flame']) {
+          return {
+            en: 'Close to boss',
+          };
+        }
+        return {
+          en: 'Away from boss',
+        };
+      },
+    },
+    {
+      id: 'Gubal Hard Ferrofluid Cleanup',
+      regex: / 1B:\y{ObjectId}:\y{Name}:....:....:003[01]:/,
+      delaySeconds: 5,
+      run: function(data) {
+        delete data.fluid;
+      },
+    },
+    {
+      id: 'Gubal Hard Slosh',
+      regex: / 23:\y{ObjectId}:Liquid Flame:\y{ObjectId}:(\y{Name}):....:....:0039/,
+      condition: function(data, matches) {
+        return data.me == matches[1];
+      },
+      infoText: {
+        en: 'Away from boss',
+      },
+    },
+    {
+      id: 'Gubal Hard Seals',
+      regex: / 1A:\y{ObjectId}:(\y{Name}) gains the effect of (Moon|Sun)seal/,
+      condition: function (data, matches) {
+        return data.me == matches[1];
+      },
+      infoText: function(data, matches) {
+        if (matches[2] == 'Moon') {
+          return {
+            en: 'Stand in blue',
+          };
+        }
+        return {
+          en: 'Stand in red',
+        };
+      },
+    },
+    {
+      // This inflicts a vulnerability stack on the tank if not interrupted
+      id: 'Gubal Hard Condensed Libra',
+      regex: / 14:198D:Mechanoscribe starts using Condensed Libra on \y{Name}/,
+      infoText: function(data) {
+        if (data.CanStun()) {
+          return {
+            en: 'Stun Mechanoscribe',
+          };
+        }
+        if (data.CanSilence()) {
+          return {
+            en: 'Interrupt Mechanoscribe',
+          };
+        }
+      },
+    },
+    {
+      id: 'Gubal Hard Properties of Quakes',
+      regex: / 14:1956:Strix starts using On The Properties Of Quakes/,
+      infoText: {
+        en: 'Stand in light circle',
+      },
+    },
+    {
+      id: 'Gubal Hard Properties of Tornadoes',
+      regex: / 14:1957:Strix starts using On The Properties Of Tornados/,
+      infoText: {
+        en: 'Stand in dark circle',
+      },
+    },
+    {
+      id: 'Gubal Hard Properties of Imps',
+      regex: / 14:1959:Strix starts using On The Properties Of Imps/,
+      infoText: {
+        en: 'Cleanse in green circle',
+      },
+    },
+    {
+      id: 'Gubal Hard Properties of Thunder',
+      regex: /14:195A:Strix starts using On The Properties Of Thunder III/,
+      infoText: {
+        en: 'Spread',
+      },
+    },
+    {
+      id: 'Gubal Hard Properties of Darkness II',
+      regex: / 14:1955:Strix starts using On The Properties Of Darkness II/,
+      condition: function(data) {
+        return data.role == 'healer';
+      },
+      infoText: {
+        en: 'AoE',
+      },
+    },
+    {
+      id: 'Gubal Hard Ecliptic Meteor',
+      regex: /14:195D:Behemoth Ward starts using Ecliptic Meteor/,
+      delaySeconds: 14, // Leaving about 10s warning to complete the LoS
+      alertText: {
+        en: 'LoS Behemoth with boulder',
+      },
+    },
+  ],
+  timelineReplace: [
+    {
+      'locale': 'de',
+      'replaceSync': {
+        'Demon of the Tome': 'Bücherdämon',
+        'Liquid Flame': 'flüssig[a] Flamme',
+        // Strix is the same for DE
+
+        'The Hall of Magicks': 'Halle der Magie',
+        'The Astrology and Astromancy Camera': 'Astrologisches und Astronomisches Gewölbe',
+        'The Rare Tomes Room': 'Abteilung für seltene Schriften',
+      },
+      'replaceText': {
+        'Triclip': 'Dreischnitt',
+        'Folio': 'Foliant',
+        'Book Drop': 'Publizieren',
+        'Issue': 'Publizieren',
+        'Frightful Roar': 'Furchtbares Brüllen',
+        'Discontinue': 'Druck einstellen',
+
+        'Searing Wind': 'Versengen',
+        'Bibliocide': 'Bibliozid',
+        'Sea Of Flames': 'Flammenmeer',
+        'Slosh': 'Durchbläuen',
+        'Seal Of Night And Day': 'Siegel',
+        'Magnetism': 'Magnetismus',
+        'Repel': 'Abstoßung',
+
+        'Check Out': 'Anthologie',
+        'Properties Of Darkness (buster)': 'Theorie der Dunkelung',
+        'Properties Of Quakes': 'Theorie des Seisga',
+        'Properties Of Darkness II': 'Theorie der Dunkelung II',
+        'Properties Of Tornados': 'Theorie des Tornado',
+        'Properties Of Imps': 'Über Flusskobolde',
+        'Properties Of Thunder III': 'Theorie des Blitzga',
+        'Meteor Impact': 'Meteoreinschlag',
+        'Ecliptic Meteor': 'Ekliptik-Meteor',
+      },
+    },
+    {
+      'locale': 'fr',
+      'replaceSync': {
+        'Demon of the Tome': 'Démon du Tome',
+        'Liquid Flame': 'flamme liquide',
+        // Strix is the same for FR
+
+        'The Hall of Magicks': 'Puits des magies',
+        'The Astrology and Astromancy Camera': 'Dôme d\'astrologie et d\'astromancie',
+        'The Rare Tomes Room': 'Dôme des manuscrits rares',
+      },
+      'replaceText': {
+        // Triclip is the same for FR
+        'Folio': 'Réimpression',
+        'Book Drop': 'Publication',
+        'Issue': 'Publication',
+        'Frightful Roar': 'Rugissement effroyable',
+        'Discontinue': 'Arrêt de publication',
+
+        'Searing Wind': 'Carbonisation',
+        // Bibliocide is the same for FR
+        'Sea Of Flames': 'Mer de flammes',
+        'Slosh': 'Ruée',
+        'Seal Of Night And Day': 'Gravure',
+        'Magnetism': 'Magnétisme',
+        'Repel': 'Répulsion',
+
+        'Check Out': 'Anthologie',
+        'Properties Of Darkness (buster)': 'Des propriétés d\'Obscurité',
+        'Properties Of Quakes': 'Des propriétés de Méga Séisme',
+        'Properties Of Darkness II': 'Des propriétés d\'Obscurité II',
+        'Properties Of Tornados': 'Des propriétés de Tornade',
+        'Properties Of Imps': 'Des propriétés de Coup du kappa',
+        'Properties Of Thunder III': 'Des propriétés de Méga Foudre',
+        'Meteor Impact': 'Impact de météore',
+        'Ecliptic Meteor': 'Météore écliptique',
+      },
+    },
+    {
+      'locale': 'ja',
+      'replaceSync': {
+        'Demon of the Tome': 'デモン・オブ・トーム',
+        'Liquid Flame': 'リクイドフレイム',
+        'Strix': 'ストリックス',
+
+        'The Hall of Magicks': '魔書の翼廊',
+        'The Astrology and Astromancy Camera': '占星学研究室',
+        'The Rare Tomes Room': '思想稀覯書庫',
+      },
+      'replaceText': {
+        'Triclip': 'トライクリップ',
+        'Folio': '重版',
+        'Book Drop': '刊行',
+        'Issue': '刊行',
+        'Frightful Roar': 'フライトフルロア',
+        'Discontinue': '廃刊',
+
+        'Searing Wind': '熱風',
+        'Bibliocide': '火炎',
+        'Sea Of Flames': 'シー・オブ・フレイム',
+        'Slosh': '突進',
+        'Seal Of Night And Day': '刻印',
+        'Magnetism': '磁力',
+        'Repel': '反発',
+
+        'Check Out': '選書',
+        'Properties Of Darkness (buster)': 'ダークの章',
+        'Properties Of Quakes': 'クエイガの章',
+        'Properties Of Darkness II': 'ダークラの章',
+        'Properties Of Tornados': 'トルネドの章',
+        'Properties Of Imps': 'カッパの章',
+        'Properties Of Thunder III': 'サンダガの章',
+        'Meteor Impact': 'メテオインパクト',
+        'Ecliptic Meteor': 'エクリプスメテオ',
+      },
+    },
+  ],
+}];

--- a/ui/raidboss/data/03-hw/dungeon/gubal_library_hard.js
+++ b/ui/raidboss/data/03-hw/dungeon/gubal_library_hard.js
@@ -58,7 +58,7 @@
       id: 'Gubal Hard Ferrofluid',
       regex: / 1B:(\y{ObjectId}):(\y{Name}):....:....:(0030|0031):/,
       condition: function(data, matches) {
-        return data.me == matches[2] || matches[1].slice(0,1) == '4';
+        return data.me == matches[2] || matches[1].slice(0, 1) == '4';
       },
       preRun: function(data, matches) {
         data.markers = data.markers || [];

--- a/ui/raidboss/data/03-hw/dungeon/gubal_library_hard.js
+++ b/ui/raidboss/data/03-hw/dungeon/gubal_library_hard.js
@@ -55,39 +55,28 @@
       },
     },
     {
-      // Ferrofluid handling is shamelessly copied from Hades Normal
-      id: 'Gubal Hard Ferrofluid Collect',
-      regex: / 1B:\y{ObjectId}:(\y{Name}):....:....:(0030|0031):/,
-      run: function(data, matches) {
-        data.fluid = data.fluid || {};
-        if (matches[2] == '0030')
-          data.fluid[matches[1]] = 'positive';
-        if (matches[2] == '0031')
-          data.fluid[matches[1]] = 'negative';
+      id: 'Gubal Hard Ferrofluid',
+      regex: / 1B:(\y{ObjectId}):(\y{Name}):....:....:(0030|0031):/,
+      condition: function(data, matches) {
+        return data.me == matches[2] || matches[1].slice(0,1) == '4';
       },
-    },
-    {
-      id: 'Gubal Hard Ferrofluid Execute',
-      regex: / 1B:\y{ObjectId}:\y{Name}:....:....:(?:0030|0031):/,
-      suppressSeconds: 5,
-      delaySeconds: 0.5,
+      preRun: function(data, matches) {
+        data.markers = data.markers || [];
+        data.markers.push(matches[3]);
+      },
       infoText: function(data) {
-        if (data.fluid[data.me] == data.fluid['Liquid Flame']) {
+        if (data.markers.length == 2) {
+          let sameMarkers = data.markers[0] == data.markers[1];
+          delete data.markers;
+          if (sameMarkers) {
+            return {
+              en: 'Away from boss',
+            };
+          }
           return {
             en: 'Close to boss',
           };
         }
-        return {
-          en: 'Away from boss',
-        };
-      },
-    },
-    {
-      id: 'Gubal Hard Ferrofluid Cleanup',
-      regex: / 1B:\y{ObjectId}:\y{Name}:....:....:003[01]:/,
-      delaySeconds: 5,
-      run: function(data) {
-        delete data.fluid;
       },
     },
     {

--- a/ui/raidboss/data/03-hw/dungeon/gubal_library_hard.js
+++ b/ui/raidboss/data/03-hw/dungeon/gubal_library_hard.js
@@ -103,7 +103,7 @@
     {
       id: 'Gubal Hard Seals',
       regex: / 1A:\y{ObjectId}:(\y{Name}) gains the effect of (Moon|Sun)seal/,
-      condition: function (data, matches) {
+      condition: function(data, matches) {
         return data.me == matches[1];
       },
       infoText: function(data, matches) {

--- a/ui/raidboss/data/03-hw/dungeon/gubal_library_hard.js
+++ b/ui/raidboss/data/03-hw/dungeon/gubal_library_hard.js
@@ -101,20 +101,23 @@
       },
     },
     {
-      id: 'Gubal Hard Seals',
-      regex: / 1A:\y{ObjectId}:(\y{Name}) gains the effect of (Moon|Sun)seal/,
+      id: 'Gubal Hard Sunseal',
+      regex: / 1A:\y{ObjectId}:(\y{Name}) gains the effect of Sunseal/,
       condition: function(data, matches) {
         return data.me == matches[1];
       },
-      infoText: function(data, matches) {
-        if (matches[2] == 'Moon') {
-          return {
-            en: 'Stand in blue',
-          };
-        }
-        return {
-          en: 'Stand in red',
-        };
+      infoText: {
+        en: 'Stand in red',
+      },
+    },
+    {
+      id: 'Gubal Hard Moonseal',
+      regex: / 1A:\y{ObjectId}:(\y{Name}) gains the effect of Moonseal/,
+      condition: function(data, matches) {
+        return data.me == matches[1];
+      },
+      infoText: {
+        en: 'Stand in blue',
       },
     },
     {
@@ -122,14 +125,14 @@
       id: 'Gubal Hard Condensed Libra',
       regex: / 14:198D:Mechanoscribe starts using Condensed Libra on \y{Name}/,
       infoText: function(data) {
-        if (data.CanStun()) {
-          return {
-            en: 'Stun Mechanoscribe',
-          };
-        }
         if (data.CanSilence()) {
           return {
             en: 'Interrupt Mechanoscribe',
+          };
+        }
+        if (data.CanStun()) {
+          return {
+            en: 'Stun Mechanoscribe',
           };
         }
       },

--- a/ui/raidboss/data/03-hw/dungeon/gubal_library_hard.txt
+++ b/ui/raidboss/data/03-hw/dungeon/gubal_library_hard.txt
@@ -1,0 +1,157 @@
+hideall "--Reset--"
+hideall "--sync--"
+
+0.0 "--Reset--" sync / is no longer sealed/ window 5000 jump 0
+
+# Demon of the Tome
+# -ii 1951 1952
+
+0 "--sync--" sync /The Hall of Magicks will be sealed off/
+6.1 "Triclip" sync /:Demon of the Tome:193A:/
+17.3 "Folio" sync /:Demon of the Tome:193C:/
+23.4 "--sync--" sync /:Top Shelf Tome:193D:/
+24.0 "Book Drop" sync /:Top Shelf Tome:193E:/
+
+29.5 "Triclip" sync /:Demon of the Tome:193A:/
+38.7 "Folio" sync /:Demon of the Tome:193C:/
+44.8 "--sync--" sync /:Top Shelf Tome:193D:/
+45.4 "Book Drop" sync /:Top Shelf Tome:193E:/
+47.0 "Issue" sync /:Middle Shelf Tome:193F:/
+52.6 "Discontinue" sync /:Middle Shelf Tome:1940:/
+58.3 "Frightful Roar" sync /:Demon of the Tome:193B:/
+63.5 "Triclip" sync /:Demon of the Tome:193A:/
+71.5 "Folio" sync /:Demon of the Tome:193C:/
+77.6 "Issue"
+82.2 "Discontinue"
+83.6 "Issue"
+84.2 "Discontinue x3"
+
+102.7 "Triclip" sync /:Demon of the Tome:193A:/ window 15,15
+111.9 "Folio" sync /:Demon of the Tome:193C:/
+118.0 "--sync--" sync /:Top Shelf Tome:193D:/
+118.6 "Book Drop" sync /:Top Shelf Tome:193E:/
+120.2 "Issue" sync /:Middle Shelf Tome:193F:/
+125.8 "Discontinue" sync /:Middle Shelf Tome:1940:/
+131.5 "Frightful Roar" sync /:Demon of the Tome:193B:/
+136.7 "Triclip" sync /:Demon of the Tome:193A:/
+144.7 "Folio" sync /:Demon of the Tome:193C:/
+150.8 "Issue"
+155.4 "Discontinue"
+156.8 "Issue"
+157.4 "Discontinue x3"
+
+# Ordinarily we would sync from the end of the last block
+# However, this tends to break due to multiple identical mechanics close together
+175.9 "Triclip" sync /:Demon of the Tome:193A:/ window 15,15 jump 102.7
+185.1 "Folio"
+191.8 "Book Drop"
+193.4 "Issue"
+199.0 "Discontinue"
+204.7 "Frightful Roar"
+
+# Liquid Flame
+# -ii 1946 1953 194B
+# We use game log lines for the phases because the ACT log lines are unreliable
+# Whichever intermission comes second ends up with phantom "Gains Effect" lines
+
+1000.0 "--sync--"  sync /The Astrology and Astromancy Camera will be sealed off/ window 1000,0
+1007.3 "Searing Wind" sync /:Liquid Flame:1944:/
+1014.3 "Bibliocide" sync /:Liquid Flame:1945:/
+1025.7 "Sea Of Flames x3"
+1030.5 "Slosh" sync /:Liquid Flame:1947:/ window 10,10
+1034.6 "Searing Wind" sync /:Liquid Flame:1944:/
+1042.7 "Bibliocide" sync /:Liquid Flame:1945:/
+1054.3 "Hand/Tornado?"
+
+# Hand Form
+1100.0 "--sync--" sync /00:....:The liquid flame gains the effect of Chiromorph/ window 100,250
+1108.4 "Seal Of Night And Day" sync /:Liquid Flame:1949:/ window 10,10
+1112.5 "Searing Wind" sync /:Liquid Flame:1948:/
+1116.4 "Searing Wind" sync /:Liquid Flame:1948:/
+1126.5 "Seal Of Night And Day" sync /:Liquid Flame:1949:/ window 10,10
+1130.6 "Searing Wind" sync /:Liquid Flame:1948:/
+1134.7 "Searing Wind" sync /:Liquid Flame:1948:/
+1138.9 "Searing Wind" sync /:Liquid Flame:1948:/
+1149.1 "Form Shift"
+
+# Tornado Form
+1200.0 "--sync--" sync /00:....:The liquid flame gains the effect of Anemomorph/ window 200,0
+1204.5 "Bibliocide" sync /:Liquid Flame:1945:/ window 10,10
+1215.4 "Magnetism/Repel?" sync /:Liquid Flame:194[CD]:/
+1226.9 "Bibliocide" sync /:Liquid Flame:1945:/
+1237.8 "Magnetism/Repel" sync /:Liquid Flame:194[CD]:/
+1246.1 "Form Shift"
+
+# Human Form
+1300.0 "--sync--" sync /00:....:The liquid flame gains the effect of Anthropomorph/ window 300,10
+1307.5 "Searing Wind" sync /:Liquid Flame:1944:/ window 10,20
+1314.7 "Bibliocide" sync /:Liquid Flame:1945:/
+1326.0 "Sea Of Flames x3"
+1331.3 "Slosh" sync /:Liquid Flame:1947:/ window 10,10
+1335.5 "Searing Wind" sync /:Liquid Flame:1944:/
+1343.8 "Bibliocide" sync /:Liquid Flame:1945:/
+
+1355.2 "Searing Wind" sync /:Liquid Flame:1944:/ window 10,20
+1362.4 "Bibliocide" sync /:Liquid Flame:1945:/
+1373.8 "Sea Of Flames x3"
+1379.0 "Slosh" sync /:Liquid Flame:1947:/ window 10,10
+1383.2 "Searing Wind" sync /:Liquid Flame:1944:/
+1391.5 "Bibliocide" sync /:Liquid Flame:1945:/ jump 1343.8
+
+1402.9 "Searing Wind"
+1410.1 "Bibliocide"
+1421.4 "Sea Of Flames x3"
+1426.7 "Slosh"
+
+
+# Strix
+# -ii 194F 1950 1958 195B 1969
+
+2000.0 "--sync--" sync /The Rare Tomes Room will be sealed off/ window 2000,5
+2009.2 "Check Out" sync /:Strix:194E:/
+2017.5 "Properties Of Darkness (buster)" sync /:Strix:1954:/
+2029.6 "Properties Of Quakes" sync /:Strix:1956:/
+2033.8 "Properties Of Darkness (buster)" sync /:Strix:1954:/
+2040.1 "Check Out" sync /:Strix:194E:/
+2048.4 "Properties Of Darkness (buster)" sync /:Strix:1954:/
+2056.7 "Properties Of Darkness II" sync /:Strix:1955:/
+2069.9 "Properties Of Tornados" sync /:Strix:1957:/
+2074.2 "Properties Of Darkness (buster)" sync /:Strix:1954:/
+2082.4 "Properties Of Imps" sync /:Strix:1959:/
+2085.5 "Properties Of Darkness" sync /:Strix:1954:/
+2094.7 "Properties Of Thunder III" sync /:Strix:195A:/
+
+# Intermission
+2109.2 "Check Out" sync /:Strix:194E:/
+2125.6 "Properties Of Darkness (buster)" sync /:Strix:1954:/
+2126.1 "--sync--" sync /:Meteor:1A6A:/
+2126.7 "Meteor Impact" sync /:Behemoth Ward:195E:/
+2133.8 "Properties Of Darkness (buster)" sync /:Strix:1954:/
+2135.1 "--sync--" sync /:Meteor:1A6A:/
+2135.6 "Meteor Impact" sync /:Behemoth Ward:195E:/
+2143.7 "Ecliptic Meteor" sync /:Behemoth Ward:195D:/
+2144.7 "--sync--" sync /:Behemoth Ward:195C:/
+
+2155.0 "Check Out" sync /:Strix:194E:/ window 20,20
+2172.3 "Quakes/Tornados" sync /:Strix:195[67]:/
+2178.6 "Properties Of Darkness II" sync /:Strix:1955:/
+2181.8 "Properties Of Darkness (buster)" sync /:Strix:1954:/
+2188.1 "Properties Of Imps" sync /:Strix:1959:/
+2196.3 "Properties Of Thunder III" sync /:Strix:195A:/
+2203.5 "Properties Of Darkness II" sync /:Strix:1955:/
+2207.7 "Properties Of Darkness (buster)" sync /:Strix:1954:/
+
+2214.9 "Check Out" sync /:Strix:194E:/ window 20,20
+2232.3 "Quakes/Tornados" sync /:Strix:195[67]:/
+2238.6 "Properties Of Darkness II" sync /:Strix:1955:/
+2241.8 "Properties Of Darkness (buster)" sync /:Strix:1954:/
+2248.1 "Properties Of Imps" sync /:Strix:1959:/
+2256.3 "Properties Of Thunder III" sync /:Strix:195A:/
+2263.5 "Properties Of Darkness II" sync /:Strix:1955:/
+2267.7 "Properties Of Darkness (buster)" sync /:Strix:1954:/ jump 2207.7
+
+2274.9 "Check Out"
+2292.2 "Quakes/Tornados"
+2298.5 "Properties Of Darkness II"
+2301.7 "Properties Of Darkness (buster)"
+2308.0 "Properties Of Imps"

--- a/ui/raidboss/data/manifest.txt
+++ b/ui/raidboss/data/manifest.txt
@@ -33,8 +33,8 @@
 03-hw/alliance/dun_scaith.txt
 03-hw/dungeon/fractal_continuum.js
 03-hw/dungeon/fractal_continuum.txt
-03-hw/dungeon/great_gubal_hard.js
-03-hw/dungeon/great_gubal_hard.txt
+03-hw/dungeon/gubal_library_hard.js
+03-hw/dungeon/gubal_library_hard.txt
 03-hw/dungeon/the_vault.js
 03-hw/dungeon/the_vault.txt
 03-hw/dungeon/sohm_al.js

--- a/ui/raidboss/data/manifest.txt
+++ b/ui/raidboss/data/manifest.txt
@@ -33,6 +33,8 @@
 03-hw/alliance/dun_scaith.txt
 03-hw/dungeon/fractal_continuum.js
 03-hw/dungeon/fractal_continuum.txt
+03-hw/dungeon/great_gubal_hard.js
+03-hw/dungeon/great_gubal_hard.txt
 03-hw/dungeon/the_vault.js
 03-hw/dungeon/the_vault.txt
 03-hw/dungeon/sohm_al.js


### PR DESCRIPTION
Taking a break  from the (very) slow progress on `make_timeline`, this dungeon ended up being relatively simple.

I'm not terribly happy about the `00` game log lines for the phase changes on Liquid Flame, but as I noted in the timeline file, whichever phase comes second inevitably has multiple `gainsEffect` lines. I couldn't think of a way to clean that up with ACT log lines since the defining abilities (Sun/Moon seal, Magnetism, and Slosh) inside each phase are much too far in to be usable. (Maybe something could be done with `26`? But I didn't really have the time to untangle that one.)

Strix's ability names are too long. I cut "On The" from each to make things fit better, but if there's a better solution I'm much happier to do that. (Especially since this doesn't help at all for the FR localization.)
