### PR TITLE
Util: make_timeline automation

### DIFF
--- a/util/make_timeline.py
+++ b/util/make_timeline.py
@@ -48,7 +48,7 @@ def is_zone_unseal(line_fields):
 
 def is_line_attack(line_fields):
     # We want only situations where a friendly attacks an enemy
-    return (line_fields[0] in ('21', '22') and line_fields[6].startswith('4'))
+    return line_fields[0] in ('21', '22') and line_fields[6].startswith('4')
 
 def is_limit_reset(line_fields):
     return line_fields[4] == 'The limit gauge resets!'
@@ -142,7 +142,7 @@ def parse_file(args):
             encounter_sets = find_fights_in_file(file)
             # If all we want to do is list encounters, stop here and give to the user.
             if args.search_fights < 0:
-                return [f'{i + 1}. {e_info[0]} {e_info[1]} {e_info[2]}' for i, e_info in enumerate(encounter_sets)]
+                return [f'{i + 1}. {" ".join(e_info)}' for i, e_info in enumerate(encounter_sets)]
             elif args.search_fights > len(encounter_sets):
                 raise Exception('Selected fight index not in selected ACT log.')
         # Scan the file until the start timestamp
@@ -197,7 +197,7 @@ def find_fights_in_file(file):
     encounter_sets = []
     for line in file:
         # Ignore log lines that aren't game status info
-        if not (line[37:41] == '0839' or line[0:2] in ['00', '01', '21', '22', '33']):
+        if line[37:41] != '0839' and line[0:2] not in ['00', '01', '21', '22', '33']:
             continue
         line_fields = line.split('|')
 

--- a/util/make_timeline.py
+++ b/util/make_timeline.py
@@ -29,11 +29,6 @@ def stringify_time(timestamp):
     Trims microseconds to milliseconds."""
     return timestamp.strftime('%H:%M:%S.%f')[:-3]
 
-def is_line_start(line_fields, started):
-    # Zone seal messages are guaranteed to be an encounter start
-    if is_zone_seal(line_fields):
-        return True
-    return is_line_attack(line_fields) and not started
 
 def is_line_end(line_fields):
     if is_zone_unseal(line_fields) or is_limit_reset(line_fields):
@@ -216,12 +211,12 @@ def find_fights_in_file(file):
             continue
 
         # Build start/end time groupings
-        if is_line_start(line_fields, encounter_in_progress):
-            # This nested IF is messy, but it feels like the clearest way to express this
-            if is_zone_seal(line_fields):
-                encounter_start_staging = [parse_line_time(line), line_fields[4].split(' will be sealed off')[0]]
-            else:
-                encounter_start_staging = [parse_line_time(line), current_instance]
+        if is_zone_seal(line_fields):
+            encounter_start_staging = [parse_line_time(line), line_fields[4].split(' will be sealed off')[0]]
+            encounter_in_progress = True
+            continue
+        elif not encounter_in_progress and is_line_attack(line_fields):
+            encounter_start_staging = [parse_line_time(line), current_instance]
             encounter_in_progress = True
             continue
         # If this fired regardless of an encounter being found, we would end up with phantom encounters.

--- a/util/make_timeline.py
+++ b/util/make_timeline.py
@@ -6,18 +6,16 @@ import fflogs
 import timeline_aggregator
 
 
-# def timestamp_type(arg):
-#     """Defines the timestamp input format"""
-#     if re.match(r'\d{2}:\d{2}:\d{2}\.\d{3}', arg) is None:
-#         raise argparse.ArgumentTypeError(
-#             "Invalid timestamp format. Use the format 12:34:56.789")
-#     return arg
-
+def timestamp_type(arg):
+    """Defines the timestamp input format"""
+    if arg and re.match(r'\d{2}:\d{2}:\d{2}\.\d{3}', arg) is None:
+        raise argparse.ArgumentTypeError(
+            "Invalid timestamp format. Use the format 12:34:56.789")
+    return arg
 
 def parse_time(timestamp):
     """Parses a timestamp into a datetime object"""
     return datetime.strptime(timestamp, '%Y-%m-%dT%H:%M:%S')
-
 
 def parse_line_time(line):
     """Parses the line's timestamp into a datetime object"""
@@ -143,12 +141,14 @@ def parse_file(args):
     started = False
     encounter_sets = []
     with args.file as file:
-        # If searching for encounters, divert and find start/end first
+        # If searching for encounters, divert and find start/end first3
         if args.search_fights:
             encounter_sets = find_fights_in_file(file)
             # If all we want to do is list encounters, stop here and give to the user.
             if args.search_fights < 0:
                 return [f'{i + 1}. {e_info[0]} {e_info[1]} {e_info[2]}' for i, e_info in enumerate(encounter_sets)]
+            elif args.search_fights > len(encounter_sets):
+                raise Exception('Selected fight index not in selected ACT log.')
         # Scan the file until the start timestamp
         for line in file:
             start_time = end_time = 0
@@ -399,8 +399,8 @@ if __name__ == "__main__":
     parser.add_argument('-rf', '--fight', type=int, help="Fight ID of the report to use. Defaults to longest in the report")
 
     # Log file arguments
-    parser.add_argument('-s', '--start', help="Timestamp of the start, e.g. '12:34:56.789")
-    parser.add_argument('-e', '--end', help="Timestamp of the end, e.g. '12:34:56.789")
+    parser.add_argument('-s', '--start', type=timestamp_type, help="Timestamp of the start, e.g. '12:34:56.789")
+    parser.add_argument('-e', '--end', type=timestamp_type, help="Timestamp of the end, e.g. '12:34:56.789")
     parser.add_argument('-lf', '--search_fights', nargs='?', const=-1, type=int, help="Encounter in log to use, e.g. '1'. If no number is specified, returns a list of encounters.")
 
     # Filtering arguments

--- a/util/make_timeline.py
+++ b/util/make_timeline.py
@@ -275,7 +275,9 @@ def main(args):
         'Minfilia',
         'Thancred',
         'Urianger',
-        ''
+        '',
+        '2P',
+        'Crystal Exarch',
     ]
 
     # Format the phase timings

--- a/util/make_timeline.py
+++ b/util/make_timeline.py
@@ -25,6 +25,12 @@ def parse_line_time(line):
     time = time.replace(microsecond=int(line[23:29]))
     return time
 
+def stringify_time(timestamp):
+    """
+    Parses a datetime object into a string for log comparisons.
+    Trims microseconds to milliseconds."""
+    return timestamp.strftime('%H:%M:%S.%f')[:-3]
+
 def is_line_start(line_fields, started):
     # FIXME: May need localization?
     if (line_fields[4].endswith('sealed off in 15 seconds!')):
@@ -117,10 +123,9 @@ def parse_file(args):
         # If searching for encounters, divert and find start/end first
         if args.search_fights:
             encounter_sets = find_fights_in_file(file)
+            # If all we want to do is list encounters, stop here and give to the user.
             if args.search_fights[0] < 0:
-                for j in range(0, len(encounter_sets)):
-                    encounter_sets[j] = str(j) + '. ' + (" ").join(encounter_sets[j])
-                return encounter_sets
+                return [f'{i}. {encounter_name}' for i, encounter_name in enumerate(encounter_sets)]
         # Scan the file until the start timestamp
         for line in file:
             start_time = end_time = 0
@@ -212,7 +217,7 @@ def find_fights_in_file(file):
         # Ignore fights under 1 minute
         if (e_ends[i] - e_starts[i][0]).total_seconds() < 60:
             continue
-        encounter_info = [str((e_starts[i][0]).time()), str(e_ends[i].time()), str(e_starts[i][1])]
+        encounter_info = [stringify_time((e_starts[i][0])), stringify_time(e_ends[i]), str(e_starts[i][1])]
         encounter_sets.append(encounter_info)
     file.seek(0)
     return encounter_sets


### PR DESCRIPTION
It's here! Sort of.

(This is in response to #646)

Before we go into details, there's a great deal of room for improvement on this one. It's truly a draft and will need much more input before it's ready to go live. Most of the choices I made on handling various aspects of this had to do with "This was an obvious tool to use from the standard library" or "I just want this to work, we can always clean it up later". I haven't used Python for anything besides personal education before, so this was a bit of an adventure.

Now then. The changes I made involve the addition of an argument, `search_fights` (aliased to `-lf` currently,) which is (intended to be) mutually exclusive with `-start` + `-end` or `-report`. All other arguments should be compatible. 

`-search_fights` takes zero or one integer arguments, from 1 upward, indicating which encounter in the chosen log file to use. When called without, it lists the encounters found in the log file.

```
python make_timeline.py -f testlog.log -lf -1
0. 01:06:51 01:08:49 The Astrology and Astromancy Camera
1. 01:30:31 01:33:32 Repurposing
2. 01:37:26 01:40:05 Aetherial Observation
3. 01:43:36 01:47:45 The Cornice
4. 01:57:27 01:59:03 The Hall of the Tainted
5. 02:00:06 02:01:08 The Walk of Lament
6. 02:01:33 02:02:37 The Hall of the Deviant
7. 02:03:50 02:05:18 The Walk of Fire
8. 02:07:04 02:08:38.349000 The Hall of the Inexorable
9. 02:11:28.053000 02:18:08.061000 Eden's Gate: Resurrection
10. 14:47:31 14:49:25 Repurposing
11. 14:52:07 14:54:02 Aetherial Observation
12. 14:56:54 14:59:45.967000 The Cornice
13. 15:50:23.554000 15:57:28.049000 Eden's Gate: Resurrection
14. 16:08:05.251000 16:14:45.434000 Eden's Gate: Descent
15. 16:37:58.044000 16:44:57.727000 Eden's Gate: Inundation
16. 16:56:10.509000 17:02:34.354000 Eden's Gate: Sepulture
17. 17:55:52.948000 18:03:00.745000 Eden's Gate: Resurrection
18. 18:28:07.463000 18:35:45.697000 Eden's Gate: Descent
19. 18:37:48.648000 18:46:24.621000 Eden's Gate: Inundation
```

From here, the user can either repeat the command, replacing -1 with the index of the fight they want, or they may opt to copy those timestamps and run them through manually.

Known issues/deficiencies:

1. Double-pass file parsing. Because I'm not terribly familiar with Python's file handling, I opted to scan the file for encounters first before actually making the timeline. This does potentially double the run time.

2. Microsecond elision. By default, `datetime` objects elide zero-value microseconds.  If the user were to select one of the encounters without microseconds, as seen in 0-8 and 10-12, the command would fail to find any encounters. (The script would attempt to match, say, `01:06:51` in the generated encounter listing against `01:06:51.000` in the log.)  This isn't insurmountable, as there are a couple of places in the new code where we could check whether the timestamp format fits and pad/trim it as necessary. However, I didn't want to do that without input on how/where, since it would be even messier otherwise.

3. Unguarded arguments. `-search_fights` does not currently validate that the user's index input is -1 or greater. I wasn't sure where to handle that, and I didn't have the time to fully familiarize with `argparse`. In line with that, timestamp validation for `-start` and `-end` is currently disabled so that I could actually get the script to run.

4. Duplicated/excessive string handling. Every `00`, `01`, `33`, and `36` log line is  split, whether or not it's relevant. This made it easier for me to do comparisons in the `is_line_start`/`is_line_end` functions, but it could clearly be improved.

5. Large log files. As I've noted elsewhere, I default to 24 hours as the longest any of my log files grow. I have no idea what would happen if the user attempted this on a multi-day file.

The operation of `make_timeline` is unchanged as far as its internal workings. The entirety of the new functionality branches right after the log file is opened, at line 101/116. From there, the file is scanned for encounters, and if the user didn't specify one to return, the list of encounters is printed to the console in the same way timelines are. If they did, the start and end times at that index are set as the start/end times for `parse_file`, and the script continues just as if the user had used `-start` + `-end`.

Most of the new functionality is commented, but there are likely places that will need fuller explanation. I would be happy to receive suggestions on what could be improved.

All that being said, in its current state, the script would be "usable" for new work immediately, in the sense that it can quickly and accurately identify encounters within a log file. It's not merge-ready, but it's mostly functional.