### PR TITLE
Raidboss: Ala Mhigo oopsy, timeline, and triggers

### DIFF
--- a/ui/oopsyraidsy/data/04-sb/dungeon/ala_mhigo.js
+++ b/ui/oopsyraidsy/data/04-sb/dungeon/ala_mhigo.js
@@ -38,8 +38,8 @@
       id: 'Ala Mhigo Unmoving Troika',
       damageRegex: '2060',
       condition: function(e, data) {
-        // Non-tanks shouldn't be hit
-        return data.role != 'tank';
+        // Double taps only
+        return e.type != '15';
       },
       mistake: function(e, data) {
         return { type: 'warn', blame: e.targetName, text: e.abilityName };

--- a/ui/oopsyraidsy/data/04-sb/dungeon/ala_mhigo.js
+++ b/ui/oopsyraidsy/data/04-sb/dungeon/ala_mhigo.js
@@ -1,0 +1,80 @@
+'use strict';
+
+// Ala Mhigo
+[{
+  zoneRegex: /Ala Mhigo/,
+  damageWarn: {
+    'Ala Mhigo Magitek Ray': '24CE', // Line AoE, Legion Predator trash, before boss 1
+    'Ala Mhigo Lock On': '2047', // Homing circles, boss 1
+    'Ala Mhigo Tail Laser 1': '2049', // Frontal line AoE, boss 1
+    'Ala Mhigo Tail Laser 2': '204B', // Rear line AoE, boss 1
+    'Ala Mhigo Tail Laser 3': '204C', // Rear line AoE, boss 1
+    'Ala Mhigo Shoulder Cannon': '24D0', // Circle AoE, Legion Avenger trash, before boss 2
+    'Ala Mhigo Cannonfire': '23ED', // Environmental circle AoE, path to boss 2
+    'Ala Mhigo Aetherochemical Grenado': '205A', // Circle AoE, boss 2
+    'Ala Mhigo Integrated Aetheromodulator': '205B', // Ring AoE, boss 2
+    'Ala Mhigo Circle Of Death': '24D4', // Proximity circle AoE, Hexadrone trash, before boss 3
+    'Ala Mhigo Exhaust': '24D3', // Line AoE, Legion Colossus trash, before boss 3
+    'Ala Mhigo Grand Sword': '24D2', // Conal AoE, Legion Colossus trash, before boss 3
+    'Ala Mhigo Art Of The Storm 1': '2066', // Proximity circle AoE, pre-intermission, boss 3
+    'Ala Mhigo Art Of The Storm 2': '2587', // Proximity circle AoE, intermission, boss 3
+    'Ala Mhigo Vein Splitter 1': '24B6', // Proximity circle AoE, primary entity, boss 3
+    'Ala Mhigo Vein Splitter 2': '206C', // Proximity circle AoE, helper entity, boss 3
+    'Ala Mhigo Lightless Spark': '206B', // Conal AoE, boss 3
+  },
+  triggers: [
+    {
+      id: 'Ala Mhigo Demimagicks',
+      damageRegex: '205E',
+      condition: function(e, data) {
+        // Double taps only
+        return e.type != '15';
+      },
+      mistake: function(e, data) {
+        return { type: 'warn', blame: e.targetName, text: e.abilityName };
+      },
+    },
+    {
+      id: 'Ala Mhigo Unmoving Troika',
+      damageRegex: '2060',
+      condition: function(e, data) {
+        // Non-tanks shouldn't be hit
+        return data.role != 'tank';
+      },
+      mistake: function(e, data) {
+        return { type: 'warn', blame: e.targetName, text: e.abilityName };
+      },
+    },
+    {
+      id: 'Ala Mhigo Art Of The Sword 1',
+      damageRegex: '2069',
+      condition: function(e, data) {
+        // Double taps only
+        return e.type != '15';
+      },
+      mistake: function(e, data) {
+        return { type: 'warn', blame: e.targetName, text: e.abilityName };
+      },
+    },
+    {
+      id: 'Ala Mhigo Art Of The Sword 2',
+      damageRegex: '2589',
+      condition: function(e, data) {
+        // Double taps only
+        return e.type != '15';
+      },
+      mistake: function(e, data) {
+        return { type: 'warn', blame: e.targetName, text: e.abilityName };
+      },
+    },
+    {
+      // It's possible players might just wander into the bad on the outside,
+      // but normally people get pushed into it.
+      id: 'Ala Mhigo Art Of The Swell',
+      gainsEffectRegex: gLang.kEffect.DamageDown,
+      mistake: function(e, data) {
+        return { type: 'warn', blame: e.targetName, text: e.abilityName };
+      },
+    },
+  ],
+}];

--- a/ui/oopsyraidsy/data/manifest.txt
+++ b/ui/oopsyraidsy/data/manifest.txt
@@ -4,6 +4,7 @@
 02-arr/trial/titan_ex.js
 03-hw/dungeon/fractal_continuum.js
 03-hw/dungeon/gubal_library_hard.js
+04-sb/dungeon/ala_mhigo.js
 04-sb/raid/o4s.js
 04-sb/raid/o5s.js
 04-sb/raid/o6s.js

--- a/ui/raidboss/data/04-sb/dungeon/ala_mhigo.js
+++ b/ui/raidboss/data/04-sb/dungeon/ala_mhigo.js
@@ -1,0 +1,206 @@
+'use strict';
+
+[{
+  zoneRegex: /Ala Mhigo/,
+  timelineFile: 'ala_mhigo.txt',
+  timelineTriggers: [
+    {
+      id: 'Ala Mhigo Umoving Troika',
+      regex: /Unmoving Troika/,
+      beforeSeconds: 5,
+      alertText: function(data) {
+        if (data.role == 'tank') {
+          return {
+            en: 'Tank cleave on YOU',
+          };
+        }
+        return {
+          en: 'Avoid tank cleave',
+        };
+      },
+    },
+  ],
+  triggers: [
+    {
+      id: 'Ala Mhigo Electromagnetic Field',
+      regex: / 14:204D:Magitek Scorpion starts using Electromagnetic Field/,
+      condition: function(data) {
+        return data.role == 'healer';
+      },
+      infoText: {
+        en: 'AoE',
+      },
+    },
+    {
+      id: 'Ala Mhigo Mana Burst',
+      regex: / 14:204F:Aulus [mM]al Asina starts using Mana Burst/,
+      condition: function(data) {
+        return data.role == 'healer';
+      },
+      infoText: {
+        en: 'AoE',
+      },
+    },
+    {
+      id: 'Ala Mhigo Demimagicks',
+      regex: / 14:205D:Aulus [mM]al Asina starts using Demimagicks/,
+      infoText: {
+        en: 'Spread',
+      },
+    },
+    {
+      id: 'Ala Mhigo Storm',
+      regex: / 14:(?:2066|2587):Zenos [yY]ae Galvus starts using Art Of The Storm/,
+      infoText: {
+        en: 'Out of blue circle',
+      },
+    },
+    {
+      id: 'Ala Mhigo Swell',
+      regex: / 14:(?:2065|2586):Zenos [yY]ae Galvus starts using Art Of The Swell/,
+      infoText: {
+        en: 'Knockback',
+      },
+    },
+    {
+      id: 'Ala Mhigo Sword',
+      regex: / 14:(?:2068|2588):Zenos [yY]ae Galvus starts using Art Of The Sword/,
+      alertText: {
+        en: 'Protean',
+      },
+    },
+    {
+      id: 'Ala Mhigo Lightless Spark',
+      regex: / 23:\y{ObjectId}:Zenos [yY]ae Galvus:\y{ObjectId}:(\y{Name}):....:....:0029:/,
+      condition: function(data, matches) {
+        return data.me == matches[1];
+      },
+      alertText: {
+        en: 'Face tether out',
+      },
+    },
+    {
+      id: 'Ala Mhigo Concentrativity',
+      regex: / 14:206D:Zenos [yY]ae Galvus starts using Concentrativity/,
+      condition: function(data) {
+        return data.role == 'healer';
+      },
+      infoText: {
+        en: 'AoE',
+      },
+    },
+  ],
+  timelineReplace: [
+    {
+      'locale': 'de',
+      'replaceSync': {
+        'Magitek Scorpion': 'Wachskorpion',
+        'Aulus Mal Asina': 'Aulus Mal Asina',
+        'Zenos Yae Galvus': 'Zenos Yae Galvus',
+
+        'Rhalgr\'s Gate': 'Rhalgrs Tor',
+        'The Chamber of Knowledge': 'Wiege des Wissens',
+        'The Hall of the Griffin': 'Halle des Greifen',
+      },
+      'replaceText': {
+        'Electromagnetic Field': 'Elektromagnetisches Feld',
+        'Target Search': 'Zielsucher',
+        'Lock On': 'Feststellen',
+        'Tail Laser': 'Schweiflaser',
+
+        'Mana Burst': 'Mana-Knall',
+        'Order To Charge': 'Angriffsbefehl',
+        'Order To Fire': 'Feuerbefehl',
+        'Aetherochemical Grenado': 'Magitek-Granate',
+        'Integrated Aetheromodulator': 'Linearbeschleuniger',
+        'Magitek Disruptor': 'Magitek-Disruptor',
+        'Mindjack': 'Gehirnwäsche',
+        'Magitek Ray': 'Magitek-Laser',
+        'Demimagicks': 'Demimagie',
+
+        'Art Of The Swell': 'Kunst des Windes',
+        'Art Of The Storm': 'Kunst des Sturmes',
+        'Art Of the Sword': 'Kunst des Schwertes',
+        'Unmoving Troika': 'Unbewegte Troika',
+        'Vein Splitter': 'Erdader-Spalter',
+        'Lightless Spark': 'Lichtloser Funke',
+        'Concentrativity': 'Konzentriertheit',
+        'Storm, Swell, Sword': 'Wind, Sturm, Schwert',
+      },
+    },
+    {
+      'locale': 'fr',
+      'replaceSync': {
+        'Magitek Scorpion': 'scorpion magitek',
+        'Aulus Mal Asina': 'Aulus Mal Asina',
+        'Zenos Yae Galvus': 'Zenos Yae Galvus',
+
+        'Rhalgr\'s Gate': 'Porte de Rhalgr',
+        'The Chamber of Knowledge': 'Chambre du Savoir',
+        'The Hall of the Griffin': 'Salle du Griffon',
+      },
+      'replaceText': {
+        'Electromagnetic Field': 'Champ électromagnétique',
+        'Target Search': 'Recherche de cible',
+        'Lock On': 'Verrouillage',
+        'Tail Laser': 'Laser caudal',
+
+        'Mana Burst': 'Explosion de mana',
+        'Order To Charge': 'Ordre d\'attaquer',
+        'Order To Fire': 'Ordre de tirer',
+        'Aetherochemical Grenado': 'Grenade magitek',
+        'Integrated Aetheromodulator': 'Rayon accélérateur',
+        'Magitek Disruptor': 'Disrupteur magitek',
+        'Mindjack': 'Détournement cérébral',
+        'Magitek Ray': 'Rayon magitek',
+        'Demimagicks': 'Demimagie',
+
+        'Art Of The Swell': 'Art de la tempête',
+        'Art Of The Storm': 'Art de l\'orage',
+        'Art Of the Sword': 'Art de l\'épée',
+        'Unmoving Troika': 'Troïka immobile',
+        'Vein Splitter': 'Fendeur du sol',
+        'Lightless Spark': 'Étincelle sans lueur',
+        'Concentrativity': 'Kenki concentré',
+        'Storm, Swell, Sword': 'Tempête, orage, épée',
+      },
+    },
+    {
+      'locale': 'ja',
+      'replaceSync': {
+        'Magitek Scorpion': 'ガードスコーピオン',
+        'Aulus Mal Asina': 'アウルス・マル・アシナ',
+        'Zenos Yae Galvus': 'ゼノス・イェー・ガルヴァス',
+
+        'Rhalgr\'s Gate': '壊神門前',
+        'The Chamber of Knowledge': 'アシナ仮設実験場',
+        'The Hall of the Griffin': '鷲獅子の間',
+      },
+      'replaceText': {
+        'Electromagnetic Field': '電磁フィールド',
+        'Target Search': 'ターゲット・サーチ',
+        'Lock On': 'ロックオン',
+        'Tail Laser': 'テイルレーザー',
+
+        'Mana Burst': 'マナバースト',
+        'Order To Charge': '出撃命令',
+        'Order To Fire': '攻撃命令',
+        'Aetherochemical Grenado': '魔導榴弾',
+        'Integrated Aetheromodulator': '加速レーザー',
+        'Magitek Disruptor': '魔導ジャマー',
+        'Mindjack': 'ブレインジャック',
+        'Magitek Ray': '魔導レーザー',
+        'Demimagicks': 'デミマジック',
+
+        'Art Of The Swell': '風断一閃',
+        'Art Of The Storm': '雷切一閃',
+        'Art Of the Sword': '妖刀一閃',
+        'Unmoving Troika': '不動三段',
+        'Vein Splitter': '地脈断ち',
+        'Lightless Spark': '無明閃',
+        'Concentrativity': '圧縮剣気',
+        'Storm, Swell, Sword': '秘剣風雷妖',
+      },
+    },
+  ],
+}];

--- a/ui/raidboss/data/04-sb/dungeon/ala_mhigo.js
+++ b/ui/raidboss/data/04-sb/dungeon/ala_mhigo.js
@@ -33,7 +33,7 @@
     },
     {
       id: 'Ala Mhigo Mana Burst',
-      regex: / 14:204F:Aulus [mM]al Asina starts using Mana Burst/,
+      regex: / 14:204F:Aulus Mal Asina starts using Mana Burst/,
       condition: function(data) {
         return data.role == 'healer';
       },
@@ -43,35 +43,35 @@
     },
     {
       id: 'Ala Mhigo Demimagicks',
-      regex: / 14:205D:Aulus [mM]al Asina starts using Demimagicks/,
+      regex: / 14:205D:Aulus Mal Asina starts using Demimagicks/,
       infoText: {
         en: 'Spread',
       },
     },
     {
       id: 'Ala Mhigo Storm',
-      regex: / 14:(?:2066|2587):Zenos [yY]ae Galvus starts using Art Of The Storm/,
+      regex: / 14:(?:2066|2587):Zenos Yae Galvus starts using Art Of The Storm/,
       infoText: {
         en: 'Out of blue circle',
       },
     },
     {
       id: 'Ala Mhigo Swell',
-      regex: / 14:(?:2065|2586):Zenos [yY]ae Galvus starts using Art Of The Swell/,
+      regex: / 14:(?:2065|2586):Zenos Yae Galvus starts using Art Of The Swell/,
       infoText: {
         en: 'Knockback',
       },
     },
     {
       id: 'Ala Mhigo Sword',
-      regex: / 14:(?:2068|2588):Zenos [yY]ae Galvus starts using Art Of The Sword/,
+      regex: / 14:(?:2068|2588):Zenos Yae Galvus starts using Art Of The Sword/,
       alertText: {
         en: 'Protean',
       },
     },
     {
       id: 'Ala Mhigo Lightless Spark',
-      regex: / 23:\y{ObjectId}:Zenos [yY]ae Galvus:\y{ObjectId}:(\y{Name}):....:....:0029:/,
+      regex: / 23:\y{ObjectId}:Zenos Yae Galvus:\y{ObjectId}:(\y{Name}):....:....:0029:/,
       condition: function(data, matches) {
         return data.me == matches[1];
       },
@@ -81,7 +81,7 @@
     },
     {
       id: 'Ala Mhigo Concentrativity',
-      regex: / 14:206D:Zenos [yY]ae Galvus starts using Concentrativity/,
+      regex: / 14:206D:Zenos Yae Galvus starts using Concentrativity/,
       condition: function(data) {
         return data.role == 'healer';
       },

--- a/ui/raidboss/data/04-sb/dungeon/ala_mhigo.txt
+++ b/ui/raidboss/data/04-sb/dungeon/ala_mhigo.txt
@@ -1,0 +1,207 @@
+hideall "--Reset--"
+hideall "--sync--"
+
+0.0 "--Reset--" sync / is no longer sealed/ window 5000 jump 0
+
+# Guard Scorpion
+# -ii 2049 204A 204B 204C
+0.0 "--Start--" sync /Rhalgr's Gate will be sealed off/
+4.1 "--sync--" sync /:Magitek Scorpion:2457:/ window 3,1
+9.6 "Electromagnetic Field" sync /:Magitek Scorpion:204D:/
+18.8 "Target Search" sync /:Magitek Scorpion:2046:/
+29.4 "Lock On" sync /:Magitek Scorpion:2047:/
+31.5 "Tail Laser" sync /:Magitek Scorpion:2048:/
+56.7 "Electromagnetic Field" sync /:Magitek Scorpion:204D:/
+
+64.9 "Target Search" sync /:Magitek Scorpion:2046:/
+72.2 "Tail Laser" sync /:Magitek Scorpion:2048:/
+75.5 "Lock On" sync /:Magitek Scorpion:2047:/
+85.5 "Tail Laser" sync /:Magitek Scorpion:2048:/w
+93.9 "Lock On" sync /:Magitek Scorpion:2047:/
+101.6 "Electromagnetic Field" sync /:Magitek Scorpion:204D:/
+111.8 "Electromagnetic Field" sync /:Magitek Scorpion:204D:/
+126.0 "Electromagnetic Field" sync /:Magitek Scorpion:204D:/ jump 56.7
+
+134.2 "Target Search"
+141.5 "Tail Laser"
+144.8 "Lock On"
+154.8 "Tail Laser"
+163.2 "Lock On"
+
+# Aulus mal Asina
+# -ii 2051 2052 205E
+1000.0 "--Start--" sync /The Chamber of Knowledge will be sealed off/ window 1000,5
+1002.7 "--sync--" sync /:Aulus mal Asina:2458:/ window 3,1
+1013.2 "Mana Burst" sync /:Aulus mal Asina:204F:/
+1019.4 "Order To Charge" sync /:Aulus mal Asina:2057:/
+1020.2 "--sync--" sync /:Prototype Bit:2053:/
+1025.6 "Order To Fire" sync /:Aulus mal Asina:2058:/
+1029.2 "Aetherochemical Grenado" sync /:Prototype Bit:205A:/
+1033.8 "Integrated Aetheromodulator" sync /:Prototype Bit:205B:/
+1035.9 "--sync--" sync /:Prototype Bit:2053:/
+1050.6 "Magitek Disruptor" sync /:Aulus mal Asina:2050:/
+1055.7 "Mindjack" sync /:Aulus mal Asina:204E:/ window 50,10
+
+# Intermission.
+1056.9 "--sync--" sync /:Prototype Bit:2053:/ window 50,5
+1067.8 "Magitek Ray" sync /:Prototype Bit:2054:/
+1073.8 "Magitek Ray" sync /:Prototype Bit:2054:/ jump 1067.8
+1079.8 "Magitek Ray"
+1085.8 "Magitek Ray"
+1091.8 "Magitek Ray"
+1097.8 "Magitek Ray"
+
+# Intermission closing
+1200.0 "--sync--" sync /:Aulus mal Asina:2056:/ window 200,5
+1201.5 "--sync--" sync /:Prototype Bit:2053:/
+1216.5 "Mana Burst" sync /:Aulus mal Asina:204F:/
+
+# Main rotation resumes
+1222.7 "Order To Charge" sync /:Aulus mal Asina:2057:/ window 150,30
+1223.5 "--sync--" sync /:Prototype Bit:2053:/
+1228.9 "Order To Fire" sync /:Aulus mal Asina:2058:/
+1231.8 "Integrated Aetheromodulator" sync /:Prototype Bit:205B:/
+1232.5 "Aetherochemical Grenado" sync /:Prototype Bit:205A:/
+1237.1 "Demimagicks" sync /:Aulus mal Asina:205D:/
+1237.1 "Integrated Aetheromodulator" sync /:Prototype Bit:205B:/
+1239.2 "--sync--" sync /:Prototype Bit:2053:/
+1247.2 "Mana Burst" sync /:Aulus mal Asina:204F:/
+1260.3 "Mana Burst" sync /:Aulus mal Asina:204F:/
+
+1266.5 "Order To Charge" sync /:Aulus mal Asina:2057:/ window 15,15
+1267.3 "--sync--" sync /:Prototype Bit:2053:/
+1272.7 "Order To Fire" sync /:Aulus mal Asina:2058:/
+1275.6 "Integrated Aetheromodulator" sync /:Prototype Bit:205B:/
+1276.3 "Aetherochemical Grenado" sync /:Prototype Bit:205A:/
+1280.9 "Demimagicks" sync /:Aulus mal Asina:205D:/
+1280.9 "Integrated Aetheromodulator" sync /:Prototype Bit:205B:/
+1283.0 "--sync--" sync /:Prototype Bit:2053:/
+1291.0 "Mana Burst" sync /:Aulus mal Asina:204F:/
+1304.1 "Mana Burst" sync /:Aulus mal Asina:204F:/ jump 1141.7
+
+1310.3 "Order To Charge"
+1316.5 "Order To Fire"
+1319.4 "Integrated Aetheromodulator"
+1320.1 "Aetherochemical Grenado"
+1324.7 "Demimagicks"
+1324.7 "Integrated Aetheromodulator"
+1334.8 "Mana Burst"
+
+# Zenos yae Galvus
+# -ii 2061 2062 2064 2067 2069 2589
+
+2000.0 "--Start--" sync /The Hall of the Griffin will be sealed off/ window 2000,5
+2003.5 "--sync--" sync /:Zenos yae Galvus:366:/ window 3,1
+2009.7 "--sync--" sync /:Zenos yae Galvus:205F:/
+2023.4 "Art Of The Swell" sync /:Zenos yae Galvus:2065:/
+
+2032.8 "Unmoving Troika" sync /:Zenos yae Galvus:2060:/
+2050.6 "Art Of The Storm" sync /:Zenos yae Galvus:2066:/
+2059.3 "Art Of The Sword" sync /:Zenos yae Galvus:2068:/
+2068.5 "Unmoving Troika" sync /:Zenos yae Galvus:2060:/
+
+2088.4 "Art Of The Swell" sync /:Zenos yae Galvus:2065:/
+2097.1 "Art Of The Sword" sync /:Zenos yae Galvus:2068:/
+2106.4 "Unmoving Troika" sync /:Zenos yae Galvus:2060:/
+2126.2 "Art Of The Storm" sync /:Zenos yae Galvus:2066:/
+2134.9 "Art Of The Sword" sync /:Zenos yae Galvus:2068:/
+2144.2 "Unmoving Troika" sync /:Zenos yae Galvus:2060:/ jump 2068.5
+
+2164.0 "Art Of The Swell"
+2172.7 "Art Of The Sword"
+2182.0 "Unmoving Troika"
+2201.8 "Art Of The Storm"
+2210.5 "Art Of The Sword"
+2219.8 "Unmoving Troika"
+
+# Phase 2 at <= 65% HP
+2300.0 "--sync--" sync /:Zenos yae Galvus:239F:/ window 300,5
+2307.5 "Vein Splitter" sync /:Zenos yae Galvus:24B6:/
+2310.1 "Vein Splitter" sync /:Zenos yae Galvus:206C:/
+2323.3 "Lightless Spark" sync /:Zenos yae Galvus:206B:/
+2331.6 "Unmoving Troika" sync /:Zenos yae Galvus:2060:/
+2341.7 "Concentrativity" sync /:Zenos yae Galvus:206D:/
+2354.4 "Storm?/Swell?" sync /:Zenos yae Galvus:206[56]:/
+2366.5 "Concentrativity" sync /:Zenos yae Galvus:206D:/
+2371.7 "--sync--" sync /:Zenos yae Galvus:239F:/
+
+# Paths diverge into Storm/Swell blocks
+# Blocks loop at random to 20% HP
+2379.3 "Art Of The Swell?" sync /:Zenos yae Galvus:2065:/ jump 2600.0
+2379.3 "Art Of The Storm?" sync /:Zenos yae Galvus:2066:/ jump 2500.0
+2381.8 "Vein Splitter"
+2385.3 "Lightless Spark?"
+2388.0 "Art Of The Sword"
+2396.3 "Unmoving Troika"
+2406.3 "Concentrativity"
+
+# Storm block
+2500.0 "Art Of The Storm" sync /:Zenos yae Galvus:2066:/
+2502.5 "Vein Splitter" sync /:Zenos yae Galvus:206C:/
+2508.7 "Art Of The Sword" sync /:Zenos yae Galvus:2068:/
+2517.0 "Unmoving Troika" sync /:Zenos yae Galvus:2060:/
+2527.0 "Concentrativity" sync /:Zenos yae Galvus:206D:/
+2539.3 "Storm?/Swell?/Sword?" sync /:Zenos yae Galvus:206[568]:/
+2551.4 "Concentrativity" sync /:Zenos yae Galvus:206D:/
+2556.4 "--sync--" sync /:Zenos yae Galvus:239F:/ window 20,20
+
+2564.0 "Art Of The Swell?" sync /:Zenos yae Galvus:2065:/ jump 2600.0
+2564.0 "Art Of The Storm?" sync /:Zenos yae Galvus:2066:/ jump 2500.0
+2566.5 "Vein Splitter"
+2570.0 "Lightless Spark"
+2572.7 "Art Of The Sword"
+2581.0 "Unmoving Troika"
+2591.0" Concentrativity"
+
+# Swell block
+2600.0 "Art Of The Swell" sync /:Zenos yae Galvus:2065:/
+2602.5 "Vein Splitter" sync /:Zenos yae Galvus:206C:/
+2606.0 "Lightless Spark" sync /:Zenos yae Galvus:206B:/
+2608.7 "Art Of The Sword" sync /:Zenos yae Galvus:2068:/
+2617.0 "Unmoving Troika" sync /:Zenos yae Galvus:2060:/
+2627.0 "Concentrativity" sync /:Zenos yae Galvus:206D:/
+2639.8 "Storm?/Swell?/Sword?" sync /:Zenos yae Galvus:206[568]:/
+2651.8 "Concentrativity" sync /:Zenos yae Galvus:206D:/
+2656.8 "--sync--" sync /:Zenos yae Galvus:239F:/ window 20,20
+
+2664.4 "Art Of The Storm?" sync /:Zenos yae Galvus:2066:/ jump 2500.0
+2664.4 "Art Of The Swell?" sync /:Zenos yae Galvus:2065:/ jump 2600.0
+2666.9 "Vein Splitter"
+2670.4 "Lightless Spark?"
+2673.1 "Art Of The Sword"
+2681.4 "Unmoving Troika"
+2691.4 "Concentrativity"
+
+# Intermission at < 20% HP
+2700.0 "Unknown_206E" sync /:Zenos yae Galvus:206E:/ window 700,5
+2706.0 "--sync--" sync /:Zenos yae Galvus:239F:/
+2712.7 "Swell/Sword" sync /:Zenos yae Galvus:258[68]:/
+2715.1 "Art Of The Storm" sync /:Zenos yae Galvus:2587:/
+2732.0 "--sync--" sync /:Zenos yae Galvus:239F:/
+2739.1 "Swell/Sword" sync /:Zenos yae Galvus:258[68]:/
+2741.1 "Art Of The Storm" sync /:Zenos yae Galvus:2587:/
+2763.0 "--sync--" sync /:Zenos yae Galvus:239F:/
+2769.6 "Swell/Sword" sync /:Zenos yae Galvus:258[68]:/
+2772.0 "Art Of The Storm" sync /:Zenos yae Galvus:2587:/
+2789.0 "--sync--" sync /:Zenos yae Galvus:239F:/
+2796.0 "Swell/Sword" sync /:Zenos yae Galvus:258[68]:/
+2798.0 "Art Of The Storm" sync /:Zenos yae Galvus:2587:/
+2815.0 "--sync--" sync /:Zenos yae Galvus:239F:/
+2822.0 "Swell/Sword" sync /:Zenos yae Galvus:258[68]:/
+2824.0" Art Of The Storm" sync /:Zenos yae Galvus:2587:/
+
+# The intermission closes here regardless.
+# Parties reaching here naturally will die to a full boss gauge.
+2836.1 "Storm, Swell, Sword" sync /:Zenos yae Galvus:206F:/ window 135,10
+2839.0 "--sync--" sync /:The Storm:239E:/
+2843.1 "Storm, Swell, Sword" sync /:Zenos yae Galvus:2070:/
+
+2855.9 "Concentrativity" sync /:Zenos yae Galvus:206D:/ window 20,5
+2866.1 "Concentrativity" sync /:Zenos yae Galvus:206D:/
+2876.3 "Concentrativity" sync /:Zenos yae Galvus:206D:/
+2886.5 "Concentrativity" sync /:Zenos yae Galvus:206D:/ jump 2855.9
+2896.7 "Concentrativity"
+2906.9 "Concentrativity"
+2917.1 "Concentrativity"
+2927.3 "Concentrativity"
+2937.5 "Concentrativity"

--- a/ui/raidboss/data/04-sb/dungeon/ala_mhigo.txt
+++ b/ui/raidboss/data/04-sb/dungeon/ala_mhigo.txt
@@ -16,7 +16,7 @@ hideall "--sync--"
 64.9 "Target Search" sync /:Magitek Scorpion:2046:/
 72.2 "Tail Laser" sync /:Magitek Scorpion:2048:/
 75.5 "Lock On" sync /:Magitek Scorpion:2047:/
-85.5 "Tail Laser" sync /:Magitek Scorpion:2048:/w
+85.5 "Tail Laser" sync /:Magitek Scorpion:2048:/
 93.9 "Lock On" sync /:Magitek Scorpion:2047:/
 101.6 "Electromagnetic Field" sync /:Magitek Scorpion:204D:/
 111.8 "Electromagnetic Field" sync /:Magitek Scorpion:204D:/
@@ -151,7 +151,7 @@ hideall "--sync--"
 2570.0 "Lightless Spark?"
 2572.7 "Art Of The Sword"
 2581.0 "Unmoving Troika"
-2591.0" Concentrativity"
+2591.0 "Concentrativity"
 
 # Swell block
 2600.0 "Art Of The Swell" sync /:Zenos yae Galvus:2065:/
@@ -188,7 +188,7 @@ hideall "--sync--"
 2798.0 "Art Of The Storm" sync /:Zenos yae Galvus:2587:/
 2815.0 "--sync--" sync /:Zenos yae Galvus:239F:/
 2822.0 "Swell/Sword" sync /:Zenos yae Galvus:258[68]:/
-2824.0" Art Of The Storm" sync /:Zenos yae Galvus:2587:/
+2824.0 "Art Of The Storm" sync /:Zenos yae Galvus:2587:/
 
 # The intermission closes here regardless.
 # Parties reaching here naturally will die to a full boss gauge.

--- a/ui/raidboss/data/04-sb/dungeon/ala_mhigo.txt
+++ b/ui/raidboss/data/04-sb/dungeon/ala_mhigo.txt
@@ -148,7 +148,7 @@ hideall "--sync--"
 2564.0 "Art Of The Swell?" sync /:Zenos yae Galvus:2065:/ jump 2600.0
 2564.0 "Art Of The Storm?" sync /:Zenos yae Galvus:2066:/ jump 2500.0
 2566.5 "Vein Splitter"
-2570.0 "Lightless Spark"
+2570.0 "Lightless Spark?"
 2572.7 "Art Of The Sword"
 2581.0 "Unmoving Troika"
 2591.0" Concentrativity"

--- a/ui/raidboss/data/manifest.txt
+++ b/ui/raidboss/data/manifest.txt
@@ -75,6 +75,8 @@
 04-sb/alliance/ridorana_lighthouse.txt
 04-sb/alliance/royal_city_of_rabanastre.js
 04-sb/alliance/royal_city_of_rabanastre.txt
+04-sb/dungeon/ala_mhigo.js
+04-sb/dungeon/ala_mhigo.txt
 04-sb/dungeon/drowned_city_of_skalla.js
 04-sb/dungeon/fractal_continuum_hard.js
 04-sb/dungeon/temple_of_the_fist.js


### PR DESCRIPTION
This one was easy enough. I ended up doing some of the testing for the `make_timeline` changes on this. Magitek Scorpion is boring and a terrible boss.

Aulus Mal Asina is sort of interesting, in that the party members are cloned during the intermission, and everything then happens to the clones. It's fascinating how Square handles these things.

Zenos is just a well-designed battle overall. Each of the phases flows naturally into the next, and it's all put together so cleanly that I never noticed the divisions before deliberately looking for them. The action list within each block is also long enough to disguise the rotation once he is brought under 65% HP, especially combined with the randomizing of Storm and Swell. Square really outdid themselves with this one, and I wish I had appreciated it more at Stormblood's release.