### PR TITLE
raidboss: Lugus Timeline Updates

### DIFF
--- a/ui/raidboss/data/05-shb/dungeon/the_grand_cosmos.txt
+++ b/ui/raidboss/data/05-shb/dungeon/the_grand_cosmos.txt
@@ -85,30 +85,30 @@ hideall "--sync--"
 1026.8 "Black Flame" sync /:Lugus:475D:/
 1030.3 "Otherworldly Heat" sync /:Lugus:475C:/
 1037.8 "Captive Bolt" sync /:Lugus:4764:/
-1048.2 "Mortal Flame" sync /:Lugus:4759:/
-1077.1 "Fire's Domain" sync /:Lugus:4760:/
+1048.2 "Mortal Flame" sync /:Lugus:4759:/ window 20,0
+1077.1 "Fire's Domain" sync /:Lugus:47(5F|60):/
 1080.2 "Fire's Ire" sync /:Lugus:4761:/
-1081.7 "Fire's Domain" sync /:Lugus:4760:/
+1081.7 "Fire's Domain" sync /:Lugus:47(5F|60):/
 1084.7 "Fire's Ire" sync /:Lugus:4761:/
-1086.2 "Fire's Domain" sync /:Lugus:4760:/
+1086.2 "Fire's Domain" sync /:Lugus:47(5F|60):/
 1089.2 "Fire's Ire" sync /:Lugus:4761:/
-1090.7 "Fire's Domain" sync /:Lugus:4760:/
+1090.7 "Fire's Domain" sync /:Lugus:47(5F|60):/
 1093.7 "Fire's Ire" sync /:Lugus:4761:/
+1106.4 "Scorching Left/Right" sync /:Lugus:476[23]:/
 
-1106.4 "Scorching Left/Right" sync /:Lugus:476[23]:/ window 20,20
-1122.9 "Culling Blade" sync /:Lugus:4765:/
+1122.9 "Culling Blade" sync /:Lugus:4765:/ window 25,20
 1126.2 "Plummet" sync /:Lugus:4767:/
 1133.3 "Black Flame" sync /:Lugus:475D:/
 1136.7 "Otherworldly Heat" sync /:Lugus:475C:/
 1142.4 "Mortal Flame" sync /:Lugus:4759:/
-1169.1 "Scorching Right" sync /:Lugus:4762:/
-1181.8 "Fire's Domain" sync /:Lugus:4760:/
+1169.1 "Scorching Left/Right" sync /:Lugus:476[23]:/
+1181.8 "Fire's Domain" sync /:Lugus:47(5F|60):/
 1184.9 "Fire's Ire" sync /:Lugus:4761:/
-1186.4 "Fire's Domain" sync /:Lugus:4760:/
+1186.4 "Fire's Domain" sync /:Lugus:47(5F|60):/
 1189.4 "Fire's Ire" sync /:Lugus:4761:/
-1190.9 "Fire's Domain" sync /:Lugus:4760:/
+1190.9 "Fire's Domain" sync /:Lugus:47(5F|60):/
 1193.9 "Fire's Ire" sync /:Lugus:4761:/
-1195.4 "Fire's Domain" sync /:Lugus:4760:/
+1195.4 "Fire's Domain" sync /:Lugus:47(5F|60):/
 1198.4 "Fire's Ire" sync /:Lugus:4761:/
 
 1205.9 "Captive Bolt" sync /:Lugus:4764:/ window 20,20
@@ -116,13 +116,13 @@ hideall "--sync--"
 1218.5 "Otherworldly Heat" sync /:Lugus:475C:/
 1226.1 "Culling Blade" sync /:Lugus:4765:/
 1238.9 "Scorching Left/Right" sync /:Lugus:476[23]:/
-1251.6 "Fire's Domain" sync /:Lugus:4760:/
+1251.6 "Fire's Domain" sync /:Lugus:47(5F|60):/
 1254.7 "Fire's Ire" sync /:Lugus:4761:/
-1256.2 "Fire's Domain" sync /:Lugus:4760:/
+1256.2 "Fire's Domain" sync /:Lugus:47(5F|60):/
 1259.2 "Fire's Ire" sync /:Lugus:4761:/
-1260.7 "Fire's Domain" sync /:Lugus:4760:/
+1260.7 "Fire's Domain" sync /:Lugus:47(5F|60):/
 1263.7 "Fire's Ire" sync /:Lugus:4761:/
-1265.0 "Fire's Domain" sync /:Lugus:4760:/
+1265.0 "Fire's Domain" sync /:Lugus:47(5F|60):/
 1268.2 "Fire's Ire" sync /:Lugus:4761:/
 
 1275.7 "Captive Bolt" sync /:Lugus:4764:/ window 50,50 jump 1205.9


### PR DESCRIPTION
Apparently if you push Lugus, you can skip the first tankbuster. Also, it appears that if you fail the tether mechanic then you get hit with a different move, 475F, instead of 4760, which can mess up synchronization.

Also, you can skip a Sorching Left/Right if his HP is too low.