### PR TITLE
Util: Move common timeline functions into separate file

### DIFF
--- a/util/encounter_finder.py
+++ b/util/encounter_finder.py
@@ -1,0 +1,111 @@
+"""Provides timeline manipulation utilities for make_timeline and test_timeline"""
+
+from datetime import datetime
+
+def parse_time(timestamp):
+    """Parses a timestamp into a datetime object"""
+    return datetime.strptime(timestamp, '%Y-%m-%dT%H:%M:%S')
+
+def parse_event_time(event):
+    """Parses the line's timestamp into a datetime object"""
+    if isinstance(event, str):
+        # TCPDecoder errors have a 251 at the start instead of a single hex byte
+	# But most just have two digits.
+        if event[3] == '|':
+            time = parse_time(event[4:23])
+            time = time.replace(microsecond=int(event[24:30]))
+        else:
+            time = parse_time(event[3:22])
+            time = time.replace(microsecond=int(event[23:29]))
+        return time
+    elif isinstance(event, dict):
+        return event['time']
+
+def str_time(timestamp):
+    """
+    Parses a datetime object into a string for log comparisons.
+    Trims microseconds to milliseconds."""
+    return timestamp.strftime('%H:%M:%S.%f')[:-3]
+
+def is_line_end(line_fields):
+    if is_zone_unseal(line_fields) or is_limit_reset(line_fields):
+        return True
+    return is_encounter_end_code(line_fields)
+
+def is_zone_seal(line_fields):
+    return line_fields[4].endswith('sealed off in 15 seconds!')
+
+def is_zone_unseal(line_fields):
+    return line_fields[4].endswith('no longer sealed!')
+
+def is_line_attack(line_fields):
+    # We want only situations where a friendly attacks an enemy
+    return line_fields[0] in ('21', '22') and line_fields[6].startswith('4')
+
+def is_limit_reset(line_fields):
+    return line_fields[4] == 'The limit gauge resets!'
+
+def is_instance_begun(line_fields):
+    return line_fields[4].endswith('has begun.')
+
+def is_instance_ended(line_fields):
+    return line_fields[4].endswith('has ended.')
+
+def is_encounter_end_code(line_fields):
+    if not line_fields[0] == '33':
+        return False
+    return line_fields[3] in ('40000010', '40000003')
+
+def find_fights_in_file(file):
+    e_starts = []
+    encounter_start_staging = 0 # Staged to avoid spurious starts such as limit break usage
+    e_ends = []
+    encounter_in_progress = False
+    current_instance = None
+    encounter_sets = []
+    for line in file:
+        # Ignore log lines that aren't game status info
+        if line[37:41] != '0839' and line[0:2] not in ['00', '01', '21', '22', '33']:
+            continue
+        line_fields = line.split('|')
+
+        # Update current instance for returning alongside timestamps
+        # Don't update if we're not entering a combat instance
+        if is_instance_begun(line_fields):
+            current_instance = line_fields[4].split(' has begun')[0]
+            continue
+        if is_instance_ended(line_fields):
+            current_instance = None
+            encounter_in_progress = False
+            continue
+
+        # We don't want to look for encounters outside a combat instance
+        if current_instance is None:
+            continue
+
+        # Build start/end time groupings
+        if is_zone_seal(line_fields):
+            encounter_start_staging = [parse_event_time(line), line_fields[4].split(' will be sealed off')[0]]
+            encounter_in_progress = True
+            continue
+        elif not encounter_in_progress and is_line_attack(line_fields):
+            encounter_start_staging = [parse_event_time(line), current_instance]
+            encounter_in_progress = True
+            continue
+        # If this fired regardless of an encounter being found, we would end up with phantom encounters.
+        if is_line_end(line_fields) and encounter_in_progress:
+            e_starts.append(encounter_start_staging)
+            e_ends.append(parse_event_time(line))
+            encounter_in_progress = False
+            continue
+        continue
+
+    # Build a list of fight start/end pairs
+    for i in range(0, len(e_ends)):
+        # Ignore fights under 1 minute
+        if (e_ends[i] - e_starts[i][0]).total_seconds() < 60:
+            continue
+        encounter_info = [str_time((e_starts[i][0])), str_time(e_ends[i]), str(e_starts[i][1])]
+        encounter_sets.append(encounter_info)
+    file.seek(0)
+    return encounter_sets

--- a/util/encounter_finder.py
+++ b/util/encounter_finder.py
@@ -1,6 +1,14 @@
 """Provides timeline manipulation utilities for make_timeline and test_timeline"""
 
 from datetime import datetime
+import re
+import argparse
+
+def timestamp_type(arg):
+    """Defines the timestamp input format"""
+    if arg and re.match(r'\d{2}:\d{2}:\d{2}\.\d{3}', arg) is None:
+        raise argparse.ArgumentTypeError("Invalid timestamp format. Use the format 12:34:56.789")
+    return arg
 
 def parse_time(timestamp):
     """Parses a timestamp into a datetime object"""

--- a/util/encounter_finder.py
+++ b/util/encounter_finder.py
@@ -109,3 +109,15 @@ def find_fights_in_file(file):
         encounter_sets.append(encounter_info)
     file.seek(0)
     return encounter_sets
+
+def choose_fight_times(args, encounters):
+    start_time = end_time = 0
+    if args.search_fights:
+        # Indexing is offset here to allow for 1-based indexing for the user.
+        start_time = (encounters[args.search_fights - 1][0])
+        end_time = (encounters[args.search_fights - 1][1])
+    # In the event the user wishes to enter timestamps manually, we permit that here.
+    else:
+        start_time = args.start
+        end_time = args.end
+    return start_time, end_time

--- a/util/make_timeline.py
+++ b/util/make_timeline.py
@@ -4,6 +4,7 @@ import re
 
 import fflogs
 import timeline_aggregator
+import encounter_finder as e_find
 
 
 def timestamp_type(arg):
@@ -12,52 +13,6 @@ def timestamp_type(arg):
         raise argparse.ArgumentTypeError(
             "Invalid timestamp format. Use the format 12:34:56.789")
     return arg
-
-def parse_time(timestamp):
-    """Parses a timestamp into a datetime object"""
-    return datetime.strptime(timestamp, '%Y-%m-%dT%H:%M:%S')
-
-def parse_line_time(line):
-    """Parses the line's timestamp into a datetime object"""
-    time = parse_time(line[3:22])
-    time = time.replace(microsecond=int(line[23:29]))
-    return time
-
-def stringify_time(timestamp):
-    """
-    Parses a datetime object into a string for log comparisons.
-    Trims microseconds to milliseconds."""
-    return timestamp.strftime('%H:%M:%S.%f')[:-3]
-
-
-def is_line_end(line_fields):
-    if is_zone_unseal(line_fields) or is_limit_reset(line_fields):
-        return True
-    return is_encounter_end_code(line_fields)
-
-def is_zone_seal(line_fields):
-    return line_fields[4].endswith('sealed off in 15 seconds!')
-
-def is_zone_unseal(line_fields):
-    return line_fields[4].endswith('no longer sealed!')
-
-def is_line_attack(line_fields):
-    # We want only situations where a friendly attacks an enemy
-    return line_fields[0] in ('21', '22') and line_fields[6].startswith('4')
-
-def is_limit_reset(line_fields):
-    return line_fields[4] == 'The limit gauge resets!'
-
-def is_instance_begun(line_fields):
-    return line_fields[4].endswith('has begun.')
-
-def is_instance_ended(line_fields):
-    return line_fields[4].endswith('has ended.')
-
-def is_encounter_end_code(line_fields):
-    if not line_fields[0] == '33':
-        return False
-    return line_fields[3] in ('40000010', '40000003')
 
 def parse_report(args):
     """Reads an fflogs report and return a list of entries"""
@@ -134,7 +89,7 @@ def parse_file(args):
     with args.file as file:
         # If searching for encounters, divert and find start/end first3
         if args.search_fights:
-            encounter_sets = find_fights_in_file(file)
+            encounter_sets = e_find.find_fights_in_file(file)
             # If all we want to do is list encounters, stop here and give to the user.
             if args.search_fights < 0:
                 return [f'{i + 1}. {" ".join(e_info)}' for i, e_info in enumerate(encounter_sets)]
@@ -159,7 +114,7 @@ def parse_file(args):
             # We're at the start of the encounter now.
             if not started:
                 started = True
-                last_ability_time = parse_line_time(line)
+                last_ability_time = e_find.parse_event_time(line)
 
             # We're looking for enemy casts
             # These lines will start with 21 or 22, and have an NPC ID (400#####)
@@ -170,7 +125,7 @@ def parse_file(args):
             # At this point, we have a combat line for the timeline.
             line_fields = line.split('|')
             entry = {
-                'time': parse_line_time(line),
+                'time': e_find.parse_event_time(line),
                 'combatant': line_fields[3],
                 'ability_id': line_fields[4],
                 'ability_name': line_fields[5],
@@ -182,61 +137,6 @@ def parse_file(args):
         raise Exception('Fight start not found')
 
     return entries, last_ability_time
-
-def find_fights_in_file(file):
-    e_starts = []
-    encounter_start_staging = 0 # Staged to avoid spurious starts such as limit break usage
-    e_ends = []
-    encounter_in_progress = False
-    current_instance = None
-    encounter_sets = []
-    for line in file:
-        # Ignore log lines that aren't game status info
-        if line[37:41] != '0839' and line[0:2] not in ['00', '01', '21', '22', '33']:
-            continue
-        line_fields = line.split('|')
-
-        # Update current instance for returning alongside timestamps
-        # Don't update if we're not entering a combat instance
-        if is_instance_begun(line_fields):
-            current_instance = line_fields[4].split(' has begun')[0]
-            continue
-        if is_instance_ended(line_fields):
-            current_instance = None
-            encounter_in_progress = False
-            continue
-
-        # We don't want to look for encounters outside a combat instance
-        if current_instance is None:
-            continue
-
-        # Build start/end time groupings
-        if is_zone_seal(line_fields):
-            encounter_start_staging = [parse_line_time(line), line_fields[4].split(' will be sealed off')[0]]
-            encounter_in_progress = True
-            continue
-        elif not encounter_in_progress and is_line_attack(line_fields):
-            encounter_start_staging = [parse_line_time(line), current_instance]
-            encounter_in_progress = True
-            continue
-        # If this fired regardless of an encounter being found, we would end up with phantom encounters.
-        if is_line_end(line_fields) and encounter_in_progress:
-            e_starts.append(encounter_start_staging)
-            e_ends.append(parse_line_time(line))
-            encounter_in_progress = False
-            continue
-        continue
-
-    # Build a list of fight start/end pairs
-    for i in range(0, len(e_ends)):
-        # Ignore fights under 1 minute
-        if (e_ends[i] - e_starts[i][0]).total_seconds() < 60:
-            continue
-        encounter_info = [stringify_time((e_starts[i][0])), stringify_time(e_ends[i]), str(e_starts[i][1])]
-        encounter_sets.append(encounter_info)
-    file.seek(0)
-    return encounter_sets
-
 
 def main(args):
     timeline_position = 0

--- a/util/make_timeline.py
+++ b/util/make_timeline.py
@@ -87,7 +87,7 @@ def parse_file(args):
     started = False
     encounter_sets = []
     with args.file as file:
-        # If searching for encounters, divert and find start/end first3
+        # If searching for encounters, divert and find start/end first.
         if args.search_fights:
             encounter_sets = e_find.find_fights_in_file(file)
             # If all we want to do is list encounters, stop here and give to the user.
@@ -95,20 +95,15 @@ def parse_file(args):
                 return [f'{i + 1}. {" ".join(e_info)}' for i, e_info in enumerate(encounter_sets)]
             elif args.search_fights > len(encounter_sets):
                 raise Exception('Selected fight index not in selected ACT log.')
+
+        start_time, end_time = e_find.choose_fight_times(args, encounter_sets)
         # Scan the file until the start timestamp
         for line in file:
-            start_time = end_time = 0
-            if args.search_fights:
-                # Indexing is offset here to allow for 1-based indexing for the user.
-                start_time = (encounter_sets[args.search_fights - 1][0])
-                end_time = (encounter_sets[args.search_fights - 1][1])
-            else:
-                start_time = args.start
-                end_time = args.end
-            if not started and start_time not in (line[14:26], line[14:29]):
+
+            if not started and start_time != line[14:26]:
                 continue
 
-            if end_time in (line[14:26], line[14:29]):
+            if end_time == line[14:26]:
                 break
 
             # We're at the start of the encounter now.
@@ -130,6 +125,10 @@ def parse_file(args):
                 'ability_id': line_fields[4],
                 'ability_name': line_fields[5],
             }
+
+            # Unknown abilities should be hidden sync lines by default.
+            if line_fields[5].startswith('Unknown_'):
+                entry['ability_name'] = '--sync--'
 
             entries.append(entry)
 

--- a/util/make_timeline.py
+++ b/util/make_timeline.py
@@ -7,13 +7,6 @@ import timeline_aggregator
 import encounter_finder as e_find
 
 
-def timestamp_type(arg):
-    """Defines the timestamp input format"""
-    if arg and re.match(r'\d{2}:\d{2}:\d{2}\.\d{3}', arg) is None:
-        raise argparse.ArgumentTypeError(
-            "Invalid timestamp format. Use the format 12:34:56.789")
-    return arg
-
 def parse_report(args):
     """Reads an fflogs report and return a list of entries"""
 
@@ -292,8 +285,8 @@ if __name__ == "__main__":
     parser.add_argument('-rf', '--fight', type=int, help="Fight ID of the report to use. Defaults to longest in the report")
 
     # Log file arguments
-    parser.add_argument('-s', '--start', type=timestamp_type, help="Timestamp of the start, e.g. '12:34:56.789")
-    parser.add_argument('-e', '--end', type=timestamp_type, help="Timestamp of the end, e.g. '12:34:56.789")
+    parser.add_argument('-s', '--start', type=e_find.timestamp_type, help="Timestamp of the start, e.g. '12:34:56.789")
+    parser.add_argument('-e', '--end', type=e_find.timestamp_type, help="Timestamp of the end, e.g. '12:34:56.789")
     parser.add_argument('-lf', '--search_fights', nargs='?', const=-1, type=int, help="Encounter in log to use, e.g. '1'. If no number is specified, returns a list of encounters.")
 
     # Filtering arguments

--- a/util/test_timeline.py
+++ b/util/test_timeline.py
@@ -440,12 +440,6 @@ def timeline_file(filename):
         return path.open()
 
 
-def timestamp_type(arg):
-    """Defines the timestamp input format"""
-    if arg and re.match(r'\d{2}:\d{2}:\d{2}\.\d{3}', arg) is None:
-        raise argparse.ArgumentTypeError("Invalid timestamp format. Use the format 12:34:56.789")
-    return arg
-
 
 if __name__ == "__main__":
     # Set up all of the arguments
@@ -471,8 +465,8 @@ if __name__ == "__main__":
     parser.add_argument('-rf', '--fight', type=int, help="Fight ID of the report to use. Defaults to longest in the report")
 
     # Log file arguments
-    parser.add_argument('-s', '--start', type=timestamp_type, help="Timestamp of the start, e.g. '12:34:56.789")
-    parser.add_argument('-e', '--end', type=timestamp_type, help="Timestamp of the end, e.g. '12:34:56.789")
+    parser.add_argument('-s', '--start', type=e_find.timestamp_type, help="Timestamp of the start, e.g. '12:34:56.789")
+    parser.add_argument('-e', '--end', type=e_find.timestamp_type, help="Timestamp of the end, e.g. '12:34:56.789")
     parser.add_argument('-lf', '--search_fights', nargs='?', const=-1, type=int, help="Encounter in log to use, e.g. '1'. If no number is specified, returns a list of encounters.")
 
     # Filtering arguments

--- a/util/test_timeline.py
+++ b/util/test_timeline.py
@@ -348,9 +348,10 @@ def run_file(args, timelist):
         'timeline_stopped': True
     }
     started = False
+    encounter_sets = []
 
     with args.file as file:
-        # If searching for encounters, divert and find start/end first3
+        # If searching for encounters, divert and find start/end first.
         if args.search_fights:
             encounter_sets = e_find.find_fights_in_file(file)
             # If all we want to do is list encounters, stop here and give to the user.

--- a/util/test_timeline.py
+++ b/util/test_timeline.py
@@ -347,7 +347,7 @@ def run_file(args, timelist):
         'branch': 1,
         'timeline_stopped': True
     }
-    file_started = False
+    started = False
 
     with args.file as file:
         # If searching for encounters, divert and find start/end first3
@@ -358,31 +358,25 @@ def run_file(args, timelist):
                 return [f'{i + 1}. {" ".join(e_info)}' for i, e_info in enumerate(encounter_sets)]
             elif args.search_fights > len(encounter_sets) or args.search_fights < -1:
                 raise Exception('Selected fight index not in selected ACT log.')
-        # Scan the file until the start timestamp
 
+        start_time, end_time = e_find.choose_fight_times(args, encounter_sets)
+        # Scan the file until the start timestamp
         for line in file:
-            start_time = end_time = 0
-            if args.search_fights:
-                # Indexing is offset here to allow for 1-based indexing for the user.
-                start_time = (encounter_sets[args.search_fights - 1][0])
-                end_time = (encounter_sets[args.search_fights - 1][1])
-            else:
-                start_time = args.start
-                end_time = args.end
+
             # Scan the file until the start timestamp
-            if not file_started and line[14:26] != start_time:
+            if not started and line[14:26] != start_time:
                 continue
 
             if line[14:26] == end_time:
                 break
 
             # We're at the start of the encounter now.
-            if not file_started:
-                file_started = True
+            if not started:
+                started = True
                 state['last_sync_timestamp'] = e_find.parse_event_time(line)
 
             state = check_event(line, timelist, state)
-    if not file_started:
+    if not started:
         raise Exception('Fight start not found')
 
 


### PR DESCRIPTION
Per #719, we have a new file containing most of the additional functionality that was introduced for the `make_timeline` updates. It's a fairly naive implementation as I'm not that familiar with Python's modularization potential, so I just went with what I could easily understand. I kept this solely as a function library rather than making it standalone, since there's *probably* not much reason to just list encounters in a file, and if the user actually does want that, the overhead from using that functionality within `make` or `test` is low enough to be negligible.

It's entirely possible we could move the fiddly bits hunting for the start/end timestamps into a helper function in `finder`, but that gets a little more complicated and would require passing state in as well.