### PR TITLE
docs: Add Issue Templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,6 +1,9 @@
 ---
 name: Bug Report 🐛
 about: Something isn't working as expected? Report it here.
+title: ''
+labels: bug
+assignees: ''
 ---
 
 <!--

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,22 @@
+---
+name: Bug Report 🐛
+about: Something isn't working as expected? Report it here.
+---
+
+<!--
+  Please include as much information as possible, this information allows cactbot maintainers to diagnose (and fix!) your issue as quickly as possible.
+
+  Useful Links:
+  - Common Issues and Workarounds: https://github.com/quisquous/cactbot#potential-errors-and-workarounds
+  - ACT Discord: https://discord.gg/ahFKcmx
+
+  Before opening a new issue, please search existing issues: https://github.com/quisquous/cactbot/issues
+-->
+
+## Description
+
+Description of the issue you're seeing.
+
+## Additional information
+
+If available, please include any logs or screenshots depicting the issue you're experiencing.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,6 +1,9 @@
 ---
 name: Feature Request 🚀
 about: Suggest a new idea.
+title: ''
+labels: enhancement
+assignees: ''
 ---
 
 <!--

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,20 @@
+---
+name: Feature Request 🚀
+about: Suggest a new idea.
+---
+
+<!--
+  Please include as much information as possible, such as example behavior and motivation behind the change.
+
+  Useful Links:
+  - Contribution Guidelines: https://github.com/quisquous/cactbot/blob/master/CONTRIBUTING.md
+  - Code of Conduct: https://github.com/quisquous/cactbot/blob/master/CODE_OF_CONDUCT.md
+
+  Before opening a new issue, please search existing issues: https://github.com/quisquous/cactbot/issues
+
+  Please note: Not every feature request will be added to cactbot, but hearing about what you want out of cactbot is important. Please don't be afraid to add a feature request!
+-->
+
+## Summary
+
+Brief explanation of the feature you'd like to request.

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -1,0 +1,20 @@
+---
+name: Question ❓
+about: General question about cactbot.
+---
+
+<!--
+  NOTE: GitHub issues are NOT the recommended method of asking general questions about cactbot.
+  
+  General questions are allowed but generally discouraged due to adding noise to the project's issue page. Please look at the documentation below or join the ACT Discord for any generic questions or reach out in a related issue. If all else fails, please open an issue here.
+
+  Useful Links:
+  - Common Issues and Workarounds: https://github.com/quisquous/cactbot#potential-errors-and-workarounds
+  - ACT Discord: https://discord.gg/ahFKcmx
+
+  Before opening a new issue, please search existing issues: https://github.com/quisquous/cactbot/issues
+-->
+
+## Question
+
+What would you like to ask?

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -1,6 +1,9 @@
 ---
 name: Question ❓
 about: General question about cactbot.
+title: ''
+labels: question
+assignees: ''
 ---
 
 <!--


### PR DESCRIPTION
Add GitHub issue templates to help guide users between their various concerns when opening issues.

An example of what this feature looks like can be seen when creating an issue off of my fork: https://github.com/panicstevenson/cactbot/issues/new/choose

Read more: [GitHub Documentation](https://help.github.com/en/github/building-a-strong-community/about-issue-and-pull-request-templates#issue-templates)