### PR TITLE
Oopsy: Minor fixes

### DIFF
--- a/ui/oopsyraidsy/data/03-hw/dungeon/fractal_continuum.js
+++ b/ui/oopsyraidsy/data/03-hw/dungeon/fractal_continuum.js
@@ -17,10 +17,11 @@
     {
       id: 'Fractal Sanctification', // Instant conal buster, boss 3
       damageRegex: 'F89',
-      condition: function(data) {
-        return data.role != 'tank';
+      condition: function(e) {
+        // Double taps only
+        return e.type != '15';
       },
-      mistake: function(e, data) {
+      mistake: function(e) {
         return { type: 'warn', blame: e.targetName, text: e.abilityName };
       },
     },

--- a/ui/oopsyraidsy/data/03-hw/dungeon/gubal_library_hard.js
+++ b/ui/oopsyraidsy/data/03-hw/dungeon/gubal_library_hard.js
@@ -42,11 +42,11 @@
     {
       id: 'Gubal Hard Searing Wind', // Tank cleave, boss 2
       damageRegex: '1944',
-      condition: function(e, data) {
+      condition: function(e) {
         // Double taps only, but tanks are always hit by this
-        return data.role != 'tank' && e.type != '15';
+        e.type != '15';
       },
-      mistake: function(e, data) {
+      mistake: function(e) {
         return { type: 'warn', blame: e.targetName, text: e.abilityName };
       },
     },
@@ -69,7 +69,6 @@
       run: function(e, data) {
         data.hasImp = data.hasImp || {};
         data.hasImp[e.targetName] = e.gains;
-        console.log(data);
       },
     },
     {
@@ -79,29 +78,29 @@
       condition: function(e, data) {
         return data.hasImp[e.targetName];
       },
-      mistake: function(e, data) {
+      mistake: function(e) {
         return { type: 'warn', blame: e.targetName, text: 'Shocked Imp' };
       },
     },
     {
       id: 'Gubal Hard Quake',
       damageRegex: '1956',
-      condition: function(e, data) {
+      condition: function(e) {
         // Always hits target, but if correctly resolved will deal 0 damage
         return e.damage > 0;
       },
-      mistake: function(e, data) {
+      mistake: function(e) {
         return { type: 'warn', blame: e.targetName, text: e.abilityName };
       },
     },
     {
       id: 'Gubal Hard Tornado',
       damageRegex: '195[78]',
-      condition: function(e, data) {
+      condition: function(e) {
         // Always hits target, but if correctly resolved will deal 0 damage
         return e.damage > 0;
       },
-      mistake: function(e, data) {
+      mistake: function(e) {
         return { type: 'warn', blame: e.targetName, text: e.abilityName };
       },
     },

--- a/ui/oopsyraidsy/data/04-sb/dungeon/ala_mhigo.js
+++ b/ui/oopsyraidsy/data/04-sb/dungeon/ala_mhigo.js
@@ -26,44 +26,44 @@
     {
       id: 'Ala Mhigo Demimagicks',
       damageRegex: '205E',
-      condition: function(e, data) {
+      condition: function(e) {
         // Double taps only
         return e.type != '15';
       },
-      mistake: function(e, data) {
+      mistake: function(e) {
         return { type: 'warn', blame: e.targetName, text: e.abilityName };
       },
     },
     {
       id: 'Ala Mhigo Unmoving Troika',
       damageRegex: '2060',
-      condition: function(e, data) {
+      condition: function(e) {
         // Double taps only
         return e.type != '15';
       },
-      mistake: function(e, data) {
+      mistake: function(e) {
         return { type: 'warn', blame: e.targetName, text: e.abilityName };
       },
     },
     {
       id: 'Ala Mhigo Art Of The Sword 1',
       damageRegex: '2069',
-      condition: function(e, data) {
+      condition: function(e) {
         // Double taps only
         return e.type != '15';
       },
-      mistake: function(e, data) {
+      mistake: function(e) {
         return { type: 'warn', blame: e.targetName, text: e.abilityName };
       },
     },
     {
       id: 'Ala Mhigo Art Of The Sword 2',
       damageRegex: '2589',
-      condition: function(e, data) {
+      condition: function(e) {
         // Double taps only
         return e.type != '15';
       },
-      mistake: function(e, data) {
+      mistake: function(e) {
         return { type: 'warn', blame: e.targetName, text: e.abilityName };
       },
     },
@@ -72,7 +72,7 @@
       // but normally people get pushed into it.
       id: 'Ala Mhigo Art Of The Swell',
       gainsEffectRegex: gLang.kEffect.DamageDown,
-      mistake: function(e, data) {
+      mistake: function(e) {
         return { type: 'warn', blame: e.targetName, text: e.abilityName };
       },
     },

--- a/ui/oopsyraidsy/data/05-shb/dungeon/dohn_mheg.js
+++ b/ui/oopsyraidsy/data/05-shb/dungeon/dohn_mheg.js
@@ -23,21 +23,21 @@
     {
       id: 'Dohn Mheg Imp Choir',
       gainsEffectRegex: gLang.kEffect.Imp,
-      mistake: function(e, data) {
+      mistake: function(e) {
         return { type: 'warn', blame: e.targetName, text: e.effectName };
       },
     },
     {
       id: 'Dohn Mheg Toad Choir',
       gainsEffectRegex: gLang.kEffect.Toad,
-      mistake: function(e, data) {
+      mistake: function(e) {
         return { type: 'warn', blame: e.targetName, text: e.effectName };
       },
     },
     {
       id: 'Dohn Mheg Fool\'s Tumble',
       gainsEffectRegex: gLang.kEffect.FoolsTumble,
-      mistake: function(e, data, matches) {
+      mistake: function(e) {
         return { type: 'warn', blame: e.targetName, text: e.effectName };
       },
     },

--- a/ui/oopsyraidsy/data/05-shb/dungeon/holminster_switch.js
+++ b/ui/oopsyraidsy/data/05-shb/dungeon/holminster_switch.js
@@ -22,18 +22,18 @@
     {
       id: 'Holminster Flagellation',
       damageRegex: '3DD6',
-      condition: function(e, data) {
+      condition: function(e) {
         // Double taps only.
         return e.type != '15';
       },
-      mistake: function(e, data) {
+      mistake: function(e) {
         return { type: 'warn', blame: e.targetName, text: e.abilityName };
       },
     },
     {
       id: 'Holminster Taphephobia',
       damageRegex: '4181',
-      condition: function(e, data) {
+      condition: function(e) {
         // Double taps only.
         return e.type != '15';
       },

--- a/ui/oopsyraidsy/data/05-shb/dungeon/qitana_ravel.js
+++ b/ui/oopsyraidsy/data/05-shb/dungeon/qitana_ravel.js
@@ -25,11 +25,11 @@
       // AoE from the 00AB poison head marker, boss three
       id: 'Qitana Viper Poison 1',
       damageRegex: '3C9D',
-      condition: function(e, data) {
+      condition: function(e) {
         // Double taps only.
         return e.type != '15';
       },
-      mistake: function(e, data) {
+      mistake: function(e) {
         return { type: 'warn', blame: e.targetName, text: e.abilityName };
       },
     },
@@ -37,7 +37,7 @@
       // Overlapped circles failure on the spread circles version of the mechanic
       id: 'Qitana Confession of Faith 2',
       damageRegex: '3CA3',
-      condition: function(e, data) {
+      condition: function(e) {
         // Double taps only.
         return e.type != '15';
       },


### PR DESCRIPTION
Or maybe that should be "extremely urgent". Who knows? Don't even look at Gubal Hard. It's awful. Just push the button on that one.

(More seriously, `console.log` might be worth adding to the test suite as a warning, even as blatantly obvious as it should be.)

I happened to be looking through the Oopsy folder for something else and noticed a couple of points where I had unthinkingly used `role == 'tank'` as a condition. As long as I was going to fix that, I went through all my Oopsy contributions and removed the unused `data` parameter from the triggers.