### PR TITLE
Add canned regex helpers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ matrix:
   include:
   - language: node_js
     node_js:
-      - 8.12.0
+      - 12.13.0
     before_install:
       # alias python3.7.1 to python3
       - pyenv global 3.7.1

--- a/AdvancedCactbot.md
+++ b/AdvancedCactbot.md
@@ -212,7 +212,7 @@ The set of extensions are:
 * `\y{Name}`: Matches any character or ability name (including empty strings which the FFXIV ACT plugin can generate when unknown).
 * `\y{ObjectId}`: Matches the 8 hex character object id in network log lines.
 * `\y{AbilityCode}`: Matches the FFXIV ACT plugin's format for the number code of a spell or ability.
-* `\y{TimeStamp}`: Matches the time stamp at the front of each log event such as `[10:23:34.123]`.
+* `\y{Timestamp}`: Matches the time stamp at the front of each log event such as `[10:23:34.123]`.
 * `\y{LogType}`: Matches the FFXIV ACT plugin's format for the number code describing the type of log event, found near the front of each log event.
 
 See this [cactbot-user git repo](https://github.com/quisquous/cactbot-user) for more examples.

--- a/package.json
+++ b/package.json
@@ -117,5 +117,8 @@
         "never"
       ]
     }
+  },
+  "dependencies": {
+    "chai": "^4.2.0"
   }
 }

--- a/resources/lang.js
+++ b/resources/lang.js
@@ -218,6 +218,7 @@ class CactbotLanguage {
     return Regexes.parse(' 1E:\\y{ObjectId}:' + this.playerName + ' loses the effect of ' + Regexes.anyOf(effects) + ' from .*\\.');
   }
 
+  // TODO: change uses of these to new regexes functions
   abilityRegex(abilityId, attacker, target, flags) {
     if (!abilityId)
       abilityId = '[^:]*';

--- a/resources/regexes.js
+++ b/resources/regexes.js
@@ -31,7 +31,7 @@ var Regexes = {
   },
 
   // fields: name, id, ability, capture
-  ability(f) {
+  ability: (f) => {
     let capture = trueIfUndefined(f.capture);
     let str = '\\y{TimeStamp} 1[56]:\\y{ObjectId}:' +
       Regexes.maybeCapture(capture, 'name', f.name, '.*?') + ':';
@@ -46,7 +46,7 @@ var Regexes = {
   },
 
   // fields: name, id, ability, target, flags, x, y, z, heading, capture
-  abilityFull(f) {
+  abilityFull: (f) => {
     let capture = trueIfUndefined(f.capture);
     let str = '\\y{TimeStamp} 1[56]:\\y{ObjectId}:' +
       Regexes.maybeCapture(capture, 'name', f.name, '.*?') + ':' +
@@ -219,7 +219,7 @@ var Regexes = {
     return str;
   },
 
-  parse: function(regexpString) {
+  parse: (regexpString) => {
     let kCactbotCategories = {
       TimeStamp: '^.{14}',
       LogType: '[0-9A-Fa-f]{2}',

--- a/resources/regexes.js
+++ b/resources/regexes.js
@@ -12,14 +12,14 @@ let trueIfUndefined = (value) => {
 var Regexes = {
 /* eslint-enable */
 
-  // fields: name, id, ability, target, capture
+  // fields: source, id, ability, target, capture
   startsUsing: (f) => {
     let capture = trueIfUndefined(f.capture);
     let str = '\\y{TimeStamp} 14:' +
       Regexes.maybeCapture(capture, 'id', f.id, '\\y{AbilityCode}') + ':';
 
-    if (f.name || f.id || f.target || capture)
-      str += Regexes.maybeCapture(capture, 'name', f.name, '.*?') + ' starts using ';
+    if (f.source || f.id || f.target || capture)
+      str += Regexes.maybeCapture(capture, 'source', f.source, '.*?') + ' starts using ';
 
     if (f.ability || f.target || capture)
       str += Regexes.maybeCapture(capture, 'ability', f.ability, '.*?') + ' on ';
@@ -30,11 +30,11 @@ var Regexes = {
     return Regexes.parse(str);
   },
 
-  // fields: name, id, ability, capture
+  // fields: source, id, ability, capture
   ability: (f) => {
     let capture = trueIfUndefined(f.capture);
     let str = '\\y{TimeStamp} 1[56]:\\y{ObjectId}:' +
-      Regexes.maybeCapture(capture, 'name', f.name, '.*?') + ':';
+      Regexes.maybeCapture(capture, 'source', f.source, '.*?') + ':';
 
     if (f.id || f.ability || capture)
       str += Regexes.maybeCapture(capture, 'id', f.id, '\\y{AbilityCode}') + ':';
@@ -45,11 +45,11 @@ var Regexes = {
     return Regexes.parse(str);
   },
 
-  // fields: name, id, ability, target, flags, x, y, z, heading, capture
+  // fields: source, id, ability, target, flags, x, y, z, heading, capture
   abilityFull: (f) => {
     let capture = trueIfUndefined(f.capture);
     let str = '\\y{TimeStamp} 1[56]:\\y{ObjectId}:' +
-      Regexes.maybeCapture(capture, 'name', f.name, '.*?') + ':' +
+      Regexes.maybeCapture(capture, 'source', f.source, '.*?') + ':' +
       Regexes.maybeCapture(capture, 'id', f.id, '\\y{AbilityCode}') + ':' +
       Regexes.maybeCapture(capture, 'ability', f.ability, '.*?') + ':\\y{ObjectId}:' +
       Regexes.maybeCapture(capture, 'target', f.target, '.*?') + ':' +
@@ -63,11 +63,11 @@ var Regexes = {
     return Regexes.parse(str);
   },
 
-  // fields: name, id, capture
+  // fields: target, id, capture
   headmarker: (f) => {
     let capture = trueIfUndefined(f.capture);
     let str = '\\y{TimeStamp} 1B:\\y{ObjectId}:' +
-      Regexes.maybeCapture(capture, 'name', f.name, '.*?') + ':....:....:' +
+      Regexes.maybeCapture(capture, 'target', f.target, '.*?') + ':....:....:' +
       Regexes.maybeCapture(capture, 'id', f.id, '....') + ':';
     return Regexes.parse(str);
   },
@@ -103,11 +103,11 @@ var Regexes = {
     return Regexes.parse(str);
   },
 
-  // fields: name, effect, source, duration, capture
+  // fields: target, effect, source, duration, capture
   gainsEffect: (f) => {
     let capture = trueIfUndefined(f.capture);
     let str = '\\y{TimeStamp} 1A:\\y{ObjectId}:' +
-      Regexes.maybeCapture(capture, 'name', f.name, '.*?') +
+      Regexes.maybeCapture(capture, 'target', f.target, '.*?') +
       ' gains the effect of ' +
       Regexes.maybeCapture(capture, 'effect', f.effect, '.*?') +
       ' from ' +
@@ -118,11 +118,11 @@ var Regexes = {
     return Regexes.parse(str);
   },
 
-  // fields: name, effect, source, capture
+  // fields: target, effect, source, capture
   losesEffect: (f) => {
     let capture = trueIfUndefined(f.capture);
     let str = '\\y{TimeStamp} 1E:\\y{ObjectId}:' +
-      Regexes.maybeCapture(capture, 'name', f.name, '.*?') +
+      Regexes.maybeCapture(capture, 'target', f.target, '.*?') +
       ' loses the effect of ' +
       Regexes.maybeCapture(capture, 'effect', f.effect, '.*?') +
       ' from ' +
@@ -130,13 +130,13 @@ var Regexes = {
     return Regexes.parse(str);
   },
 
-  // fields: name1, name2, id, capture
+  // fields: source, target, id, capture
   tether: (f) => {
     let capture = trueIfUndefined(f.capture);
     let str = '\\y{TimeStamp} 23:\\y{ObjectId}:' +
-      Regexes.maybeCapture(capture, 'name1', f.name1, '.*?') +
+      Regexes.maybeCapture(capture, 'source', f.source, '.*?') +
       ':\\y{ObjectId}:' +
-      Regexes.maybeCapture(capture, 'name2', f.name2, '.*?') +
+      Regexes.maybeCapture(capture, 'target', f.target, '.*?') +
       ':....:....:' +
       Regexes.maybeCapture(capture, 'id', f.id, '....') + ':';
     return Regexes.parse(str);

--- a/resources/regexes.js
+++ b/resources/regexes.js
@@ -13,6 +13,7 @@ var Regexes = {
 /* eslint-enable */
 
   // fields: source, id, ability, target, capture
+  // matches: https://github.com/quisquous/cactbot/blob/master/docs/LogGuide.md#14-networkstartscasting
   startsUsing: (f) => {
     let capture = trueIfUndefined(f.capture);
     let str = '\\y{Timestamp} 14:' +
@@ -31,6 +32,8 @@ var Regexes = {
   },
 
   // fields: source, id, ability, capture
+  // matches: https://github.com/quisquous/cactbot/blob/master/docs/LogGuide.md#15-networkability
+  // matches: https://github.com/quisquous/cactbot/blob/master/docs/LogGuide.md#16-networkaoeability
   ability: (f) => {
     let capture = trueIfUndefined(f.capture);
     let str = '\\y{Timestamp} 1[56]:\\y{ObjectId}:' +
@@ -46,6 +49,8 @@ var Regexes = {
   },
 
   // fields: source, id, ability, target, flags, x, y, z, heading, capture
+  // matches: https://github.com/quisquous/cactbot/blob/master/docs/LogGuide.md#15-networkability
+  // matches: https://github.com/quisquous/cactbot/blob/master/docs/LogGuide.md#16-networkaoeability
   abilityFull: (f) => {
     let capture = trueIfUndefined(f.capture);
     let str = '\\y{Timestamp} 1[56]:\\y{ObjectId}:' +
@@ -64,6 +69,7 @@ var Regexes = {
   },
 
   // fields: target, id, capture
+  // matches: https://github.com/quisquous/cactbot/blob/master/docs/LogGuide.md#1b-networktargeticon-head-markers
   headMarker: (f) => {
     let capture = trueIfUndefined(f.capture);
     let str = '\\y{Timestamp} 1B:\\y{ObjectId}:' +
@@ -73,6 +79,7 @@ var Regexes = {
   },
 
   // fields: name, capture
+  // matches: https://github.com/quisquous/cactbot/blob/master/docs/LogGuide.md#03-addcombatant
   addedCombatant: (f) => {
     let capture = trueIfUndefined(f.capture);
     let str = '\\y{Timestamp} 03:\\y{ObjectId}:Added new combatant ' +
@@ -81,6 +88,7 @@ var Regexes = {
   },
 
   // fields: id, name, hp, x, y, z, capture
+  // matches: https://github.com/quisquous/cactbot/blob/master/docs/LogGuide.md#03-addcombatant
   addedCombatantFull: (f) => {
     let capture = trueIfUndefined(f.capture);
     let str = '\\y{Timestamp} 03:' + Regexes.maybeCapture(capture, 'id', f.id, '\\y{ObjectId}') +
@@ -95,6 +103,7 @@ var Regexes = {
   },
 
   // fields: name, hp, capture
+  // matches: https://github.com/quisquous/cactbot/blob/master/docs/LogGuide.md#04-removecombatant
   removingCombatant: (f) => {
     let capture = trueIfUndefined(f.capture);
     let str = '\\y{Timestamp} 04:\\y{ObjectId}:Removing combatant ' +
@@ -104,6 +113,7 @@ var Regexes = {
   },
 
   // fields: target, effect, source, duration, capture
+  // matches: https://github.com/quisquous/cactbot/blob/master/docs/LogGuide.md#1a-networkbuff
   gainsEffect: (f) => {
     let capture = trueIfUndefined(f.capture);
     let str = '\\y{Timestamp} 1A:\\y{ObjectId}:' +
@@ -119,6 +129,7 @@ var Regexes = {
   },
 
   // fields: target, effect, source, capture
+  // matches: https://github.com/quisquous/cactbot/blob/master/docs/LogGuide.md#1e-networkbuffremove
   losesEffect: (f) => {
     let capture = trueIfUndefined(f.capture);
     let str = '\\y{Timestamp} 1E:\\y{ObjectId}:' +
@@ -131,6 +142,7 @@ var Regexes = {
   },
 
   // fields: source, target, id, capture
+  // matches: https://github.com/quisquous/cactbot/blob/master/docs/LogGuide.md#23-networktether
   tether: (f) => {
     let capture = trueIfUndefined(f.capture);
     let str = '\\y{Timestamp} 23:\\y{ObjectId}:' +
@@ -143,6 +155,7 @@ var Regexes = {
   },
 
   // fields: line, capture
+  // matches: https://github.com/quisquous/cactbot/blob/master/docs/LogGuide.md#00-logline
   echo: (f) => {
     return Regexes.gameLog({
       line: f.line,
@@ -152,6 +165,7 @@ var Regexes = {
   },
 
   // fields: line, name, capture
+  // matches: https://github.com/quisquous/cactbot/blob/master/docs/LogGuide.md#00-logline
   dialog: (f) => {
     let capture = trueIfUndefined(f.capture);
     let str = '\\y{Timestamp} 00:' +
@@ -162,6 +176,7 @@ var Regexes = {
   },
 
   // fields: line, capture
+  // matches: https://github.com/quisquous/cactbot/blob/master/docs/LogGuide.md#00-logline
   message: (f) => {
     return Regexes.gameLog({
       line: f.line,
@@ -171,6 +186,7 @@ var Regexes = {
   },
 
   // fields: code, line, capture
+  // matches: https://github.com/quisquous/cactbot/blob/master/docs/LogGuide.md#00-logline
   gameLog: (f) => {
     let capture = trueIfUndefined(f.capture);
     let str = '\\y{Timestamp} 00:' +

--- a/resources/regexes.js
+++ b/resources/regexes.js
@@ -15,7 +15,7 @@ var Regexes = {
   // fields: source, id, ability, target, capture
   startsUsing: (f) => {
     let capture = trueIfUndefined(f.capture);
-    let str = '\\y{TimeStamp} 14:' +
+    let str = '\\y{Timestamp} 14:' +
       Regexes.maybeCapture(capture, 'id', f.id, '\\y{AbilityCode}') + ':';
 
     if (f.source || f.id || f.target || capture)
@@ -33,7 +33,7 @@ var Regexes = {
   // fields: source, id, ability, capture
   ability: (f) => {
     let capture = trueIfUndefined(f.capture);
-    let str = '\\y{TimeStamp} 1[56]:\\y{ObjectId}:' +
+    let str = '\\y{Timestamp} 1[56]:\\y{ObjectId}:' +
       Regexes.maybeCapture(capture, 'source', f.source, '.*?') + ':';
 
     if (f.id || f.ability || capture)
@@ -48,7 +48,7 @@ var Regexes = {
   // fields: source, id, ability, target, flags, x, y, z, heading, capture
   abilityFull: (f) => {
     let capture = trueIfUndefined(f.capture);
-    let str = '\\y{TimeStamp} 1[56]:\\y{ObjectId}:' +
+    let str = '\\y{Timestamp} 1[56]:\\y{ObjectId}:' +
       Regexes.maybeCapture(capture, 'source', f.source, '.*?') + ':' +
       Regexes.maybeCapture(capture, 'id', f.id, '\\y{AbilityCode}') + ':' +
       Regexes.maybeCapture(capture, 'ability', f.ability, '.*?') + ':\\y{ObjectId}:' +
@@ -64,9 +64,9 @@ var Regexes = {
   },
 
   // fields: target, id, capture
-  headmarker: (f) => {
+  headMarker: (f) => {
     let capture = trueIfUndefined(f.capture);
-    let str = '\\y{TimeStamp} 1B:\\y{ObjectId}:' +
+    let str = '\\y{Timestamp} 1B:\\y{ObjectId}:' +
       Regexes.maybeCapture(capture, 'target', f.target, '.*?') + ':....:....:' +
       Regexes.maybeCapture(capture, 'id', f.id, '....') + ':';
     return Regexes.parse(str);
@@ -75,7 +75,7 @@ var Regexes = {
   // fields: name, capture
   addedCombatant: (f) => {
     let capture = trueIfUndefined(f.capture);
-    let str = '\\y{TimeStamp} 03:\\y{ObjectId}:Added new combatant ' +
+    let str = '\\y{Timestamp} 03:\\y{ObjectId}:Added new combatant ' +
       Regexes.maybeCapture(capture, 'name', f.name, '.*?') + '\\.';
     return Regexes.parse(str);
   },
@@ -83,7 +83,7 @@ var Regexes = {
   // fields: id, name, hp, x, y, z, capture
   addedCombatantFull: (f) => {
     let capture = trueIfUndefined(f.capture);
-    let str = '\\y{TimeStamp} 03:' + Regexes.maybeCapture(capture, 'id', f.id, '\\y{ObjectId}') +
+    let str = '\\y{Timestamp} 03:' + Regexes.maybeCapture(capture, 'id', f.id, '\\y{ObjectId}') +
       ':Added new combatant ' + Regexes.maybeCapture(capture, 'name', f.name, '.*?') + '\\.' +
       '.*?Max HP: ' +
       Regexes.maybeCapture(capture, 'hp', f.hp, '[0-9]+') + '\.' +
@@ -97,7 +97,7 @@ var Regexes = {
   // fields: name, hp, capture
   removingCombatant: (f) => {
     let capture = trueIfUndefined(f.capture);
-    let str = '\\y{TimeStamp} 04:\\y{ObjectId}:Removing combatant ' +
+    let str = '\\y{Timestamp} 04:\\y{ObjectId}:Removing combatant ' +
       Regexes.maybeCapture(capture, 'name', f.name, '.*?') + '\\.' +
       '.*?Max HP: ' + Regexes.maybeCapture(capture, 'hp', f.hp, '[0-9]+') + '\.';
     return Regexes.parse(str);
@@ -106,7 +106,7 @@ var Regexes = {
   // fields: target, effect, source, duration, capture
   gainsEffect: (f) => {
     let capture = trueIfUndefined(f.capture);
-    let str = '\\y{TimeStamp} 1A:\\y{ObjectId}:' +
+    let str = '\\y{Timestamp} 1A:\\y{ObjectId}:' +
       Regexes.maybeCapture(capture, 'target', f.target, '.*?') +
       ' gains the effect of ' +
       Regexes.maybeCapture(capture, 'effect', f.effect, '.*?') +
@@ -121,7 +121,7 @@ var Regexes = {
   // fields: target, effect, source, capture
   losesEffect: (f) => {
     let capture = trueIfUndefined(f.capture);
-    let str = '\\y{TimeStamp} 1E:\\y{ObjectId}:' +
+    let str = '\\y{Timestamp} 1E:\\y{ObjectId}:' +
       Regexes.maybeCapture(capture, 'target', f.target, '.*?') +
       ' loses the effect of ' +
       Regexes.maybeCapture(capture, 'effect', f.effect, '.*?') +
@@ -133,7 +133,7 @@ var Regexes = {
   // fields: source, target, id, capture
   tether: (f) => {
     let capture = trueIfUndefined(f.capture);
-    let str = '\\y{TimeStamp} 23:\\y{ObjectId}:' +
+    let str = '\\y{Timestamp} 23:\\y{ObjectId}:' +
       Regexes.maybeCapture(capture, 'source', f.source, '.*?') +
       ':\\y{ObjectId}:' +
       Regexes.maybeCapture(capture, 'target', f.target, '.*?') +
@@ -154,7 +154,7 @@ var Regexes = {
   // fields: line, name, capture
   dialog: (f) => {
     let capture = trueIfUndefined(f.capture);
-    let str = '\\y{TimeStamp} 00:' +
+    let str = '\\y{Timestamp} 00:' +
       Regexes.maybeCapture(capture, 'code', '0044') + ':' +
       Regexes.maybeCapture(capture, 'name', f.name, '.*?') + ':' +
       Regexes.maybeCapture(capture, 'line', f.line, '.*');
@@ -173,7 +173,7 @@ var Regexes = {
   // fields: code, line, capture
   gameLog: (f) => {
     let capture = trueIfUndefined(f.capture);
-    let str = '\\y{TimeStamp} 00:' +
+    let str = '\\y{Timestamp} 00:' +
       Regexes.maybeCapture(capture, 'code', f.code, '....') + ':' +
       Regexes.maybeCapture(capture, 'line', f.line, '.*');
     return Regexes.parse(str);
@@ -221,7 +221,7 @@ var Regexes = {
 
   parse: (regexpString) => {
     let kCactbotCategories = {
-      TimeStamp: '^.{14}',
+      Timestamp: '^.{14}',
       LogType: '[0-9A-Fa-f]{2}',
       AbilityCode: '[0-9A-Fa-f]{1,4}',
       ObjectId: '[0-9A-F]{8}',

--- a/test/run_tests.py
+++ b/test/run_tests.py
@@ -4,7 +4,11 @@ import sys
 import test_manifests
 import test_timelines
 import test_triggers
+import unittests
 
 if __name__ == '__main__':
-    EXIT_STATUS = test_manifests.main() | test_timelines.main() | test_triggers.main()
+    EXIT_STATUS = test_manifests.main()
+    EXIT_STATUS |= test_timelines.main()
+    EXIT_STATUS |= test_triggers.main()
+    EXIT_STATUS |= unittests.main()
     sys.exit(EXIT_STATUS)

--- a/test/test_triggers.py
+++ b/test/test_triggers.py
@@ -21,8 +21,6 @@ def main():
     exit_status = 0
 
     for filepath in Path(CactbotModule.RAIDBOSS.directory(), DATA_DIRECTORY).glob('**/*.js'):
-        exit_status |= subprocess.call(['node', str(filepath)])
-
         # Run individual trigger tests
         for test_file in TRIGGER_TEST_DIRECTORY.iterdir():
             exit_status |= subprocess.call(['node', str(test_file), str(filepath)])

--- a/test/trigger/test_trigger.js
+++ b/test/trigger/test_trigger.js
@@ -6,6 +6,7 @@
 // TODO: Remove ` ?` before each hex value once global prefix `^.{14} ` is added.
 // JavaScript doesn't allow for possessive operators in regular expressions.
 
+let Regexes = require('../../resources/regexes.js');
 let fs = require('fs');
 
 let exitCode = 0;

--- a/test/unittests.py
+++ b/test/unittests.py
@@ -1,0 +1,30 @@
+"""Validates the integrity of the manifest files and data directories for Cactbot modules."""
+
+from pathlib import Path
+import subprocess
+import sys
+from definitions import  PROJECT_ROOT_DIRECTORY, TEST_DIRECTORY
+
+UNITTEST_DIRECTORY = 'unittests'
+
+UNITTEST_TEST_DIRECTORY = Path(PROJECT_ROOT_DIRECTORY, TEST_DIRECTORY, UNITTEST_DIRECTORY)
+
+
+def main():
+    """Runs unit tests
+
+    Returns:
+        An exit status code of 0 or 1 if the tests passed successfully or failed, respectively.
+    """
+    exit_status = 0
+    
+    # Run individual unit tests
+    for test_file in UNITTEST_TEST_DIRECTORY.iterdir():
+        exit_status |= subprocess.call(['node', str(test_file)])
+
+    return exit_status
+
+
+if __name__ == '__main__':
+    EXIT_STATUS = main()
+    sys.exit(EXIT_STATUS)

--- a/test/unittests.py
+++ b/test/unittests.py
@@ -17,7 +17,7 @@ def main():
         An exit status code of 0 or 1 if the tests passed successfully or failed, respectively.
     """
     exit_status = 0
-    
+
     # Run individual unit tests
     for test_file in UNITTEST_TEST_DIRECTORY.iterdir():
         exit_status |= subprocess.call(['node', str(test_file)])

--- a/test/unittests/regex_test.js
+++ b/test/unittests/regex_test.js
@@ -1,0 +1,174 @@
+'use strict';
+
+let Regexes = require('../../resources/regexes.js');
+let assert = require('chai').assert;
+
+// Quite bogus.
+let bogusLine = 'using act is cheating';
+
+// An automated way to test standard regex functions that take a dictionary of fields.
+let regexCaptureTest = (func, lines) => {
+  // regex should not match the bogus line.
+  assert.isNull(bogusLine.match(func({})));
+
+  for (let i = 0; i < lines.length; ++i) {
+    let line = lines[i];
+
+    // Empty params (default capture).
+    let emptyParamsMatch = line.match(func({}));
+    assert.isNotNull(emptyParamsMatch, '' + func({}) + ' did not match ' + line);
+    assert.notPropertyVal(emptyParamsMatch, 'groups', undefined);
+
+    // No capture match.
+    let noCaptureMatch = line.match(func({ capture: false }));
+    assert.isNotNull(noCaptureMatch);
+    assert.propertyVal(noCaptureMatch, 'groups', undefined);
+
+    // Capture match.
+    let captureMatch = line.match(func({ capture: true }));
+    assert.isNotNull(captureMatch);
+    assert.notPropertyVal(captureMatch, 'groups', undefined);
+    assert.isObject(captureMatch.groups);
+
+    // Capture always needs at least one thing.
+    let keys = Object.keys(captureMatch.groups);
+    assert.isAbove(keys.length, 0);
+
+    let explicitFields = {};
+    explicitFields.capture = true;
+    for (let j = 0; j < keys.length; ++j) {
+      let key = keys[j];
+
+      // Because matched values may have special regex
+      // characters in it, escape these when specifying.
+      let value = captureMatch.groups[key];
+      let escaped = value.replace(/[.*+?^${}()]/g, '\\$&');
+      explicitFields[key] = escaped;
+    }
+
+    // Specifying all the fields explicitly and capturing should
+    // both match, and return the same thing.
+    // This verifies that input parameters to the regex fields and
+    // named matching groups are equivalent.
+    let explicitCaptureMatch = line.match(func(explicitFields));
+    assert.isNotNull(explicitCaptureMatch);
+    assert.notPropertyVal(explicitCaptureMatch, 'groups', undefined);
+    assert.isObject(explicitCaptureMatch.groups);
+    assert.deepEqual(explicitCaptureMatch.groups, captureMatch.groups);
+
+    // Not capturing with explicit fields should also work.
+    explicitFields.capture = false;
+    let explicitNoCaptureMatch = line.match(func(explicitFields));
+    assert.isNotNull(explicitNoCaptureMatch);
+    assert.propertyVal(explicitNoCaptureMatch, 'groups', undefined);
+  }
+};
+
+let tests = {
+  startsUsing: () => {
+    let lines = [
+      '[14:13:23.660] 14:5B2:Twintania starts using Death Sentence on Potato Chippy.',
+      '[12:25:03.586] 14:6CE:Phlegethon starts using Megiddo Flame on Unknown.',
+      '[12:50:05.414] 14:04:T\'ini Poutini starts using Mount on T\'ini Poutini.',
+    ];
+    regexCaptureTest(Regexes.startsUsing, lines);
+  },
+  ability: () => {
+    let lines = [
+      '[11:48:11.476] 16:10683258:Okonomi Yaki:3F40:Double Standard Finish:10683258:Okonomi Yaki:50F:71D0000:0:0:0:0:0:0:0:0:0:0:0:0:0:0:783:783:10000:10000:0:1000:-265.2183:-77.28939:4.323432:1.70142:783:783:10000:10000:0:1000:-265.2183:-77.28939:4.323432:1.70142:0000AC32',
+      '[12:05:12.479] 15:4007CA96:Graffias:366:Attack:106E8400:Tako Yaki:710003:3F0000:0:0:0:0:0:0:0:0:0:0:0:0:0:0:967:1107:10000:10000:0:1000:223.4988:-147.7532:-39.29175:-3.109571:1604:10948:0:0:0:1000:225.452:-145.6169:-39.29175:-3.013695:0000B2D4',
+      '[12:48:31.881] 16:4004D36E:Necropsyche:46A8:Neuro Squama:4004D3F1:Lefse:750003:74E0000:1C:46A88000:0:0:0:0:0:0:0:0:0:0:0:0:46373:48662:7000:7000:0:1000:-528.4657:387.2892:45.88464:0.6611078:2074788:4874688:10000:10000:0:1000:-525.4445:391.1954:46.67033:-1.60059:005286B5',
+    ];
+    regexCaptureTest(Regexes.ability, lines);
+    regexCaptureTest(Regexes.abilityFull, lines);
+  },
+  headmarker: () => {
+    let lines = [
+      '[21:51:06.027] 1B:107C73B8:Aloo Gobi:0000:5DC3:00C0:0000:0000:0000:',
+      '[20:23:38.707] 1B:10595B8B:Baked Potato:0000:0000:0017:0000:0000:0000:',
+      '[12:14:44.048] 1B:102D9908:Au Gratin:0000:0000:0005:0000:0000:0000:',
+    ];
+    regexCaptureTest(Regexes.headmarker, lines);
+  },
+  addedCombatant: () => {
+    let lines = [
+      '[12:11:18.753] 03:4000226B:Added new combatant Valar.  Job: N/A Level: 50 Max HP: 10195 Max MP: 2800 Pos: (-461.2344,269.7031,41.6) (82100000002399).',
+      '[12:19:45.493] 03:103410A1:Added new combatant Pot Pie(Goblin).  Job: Brd Level: 50 Max HP: 6701 Max MP: 10000 Pos: (-109.8864,-43.24811,38.21077).',
+      '[19:20:54.327] 03:4000637B:Added new combatant Automaton Queen.  Job: N/A Level: 80 Max HP: 98170 Max MP: 10000 Pos: (94.95013,106.0116,-2.384186E-07) (82300000010490).',
+    ];
+    regexCaptureTest(Regexes.addedCombatant, lines);
+    regexCaptureTest(Regexes.addedCombatantFull, lines);
+  },
+  removingCombatant: () => {
+    let lines = [
+      '[19:21:04.737] 04:40006379:Removing combatant Demi-Phoenix.  Max HP: 561184. Pos: (86.62549,117.9675,0).',
+      '[19:22:02.069] 04:40006274:Removing combatant Eden.  Max HP: 21495808. Pos: (100,100,0).',
+      '[21:58:30.439] 04:40007FDF:Removing combatant Haurchefant Greystone.  Max HP: 68. Pos: (102.85,102.85,7.152558E-07).',
+    ];
+    regexCaptureTest(Regexes.removingCombatant, lines);
+  },
+  gainsEffect: () => {
+    let lines = [
+      '[21:46:43.348] 1A:10595A8C:Papas Fritas gains the effect of Battle Litany from Potato Casserole for 20.00 Seconds.',
+      '[21:51:06.027] 1A:10686259:Patatas Bravas gains the effect of Doom from  for 10.00 Seconds.',
+      '[21:58:02.948] 1A:106CBE53:Potato Latke gains the effect of Aetherflow from Potato Latke for 9999.00 Seconds. (2)',
+    ];
+    regexCaptureTest(Regexes.gainsEffect, lines);
+  },
+  losesEffect: () => {
+    let lines = [
+      '[21:58:30.880] 1E:10686259:Hash Brown loses the effect of Light In The Dark from .',
+      '[21:48:06.010] 1E:1076C23F:Tater Tot loses the effect of Enhanced Wheeling Thrust from Tater Tot.',
+      '[21:48:12.191] 1E:40007FD4:Hades loses the effect of Biolysis from Potato Croquette.',
+    ];
+    regexCaptureTest(Regexes.losesEffect, lines);
+  },
+  tether: () => {
+    let lines = [
+      '[21:49:14.345] 23:4000804B:Shadow of the Ancients:106CAF53:Dum Aloo:3CDF:0000:0011:106CAF53:000F:7F10:',
+      '[19:39:36.673] 23:40005B1A:Voidwalker:40005C4E:The Hand of Erebos:D1A8:0000:005C:40005C4E:000F:7F1E:',
+      '[12:17:54.515] 23:1032A977:French Fry:4000229C:Magic Pot:03AC:0000:0003:4000229C:000F:7FF1:',
+    ];
+    regexCaptureTest(Regexes.tether, lines);
+  },
+  gameLog: () => {
+    let echoLines = [
+      '[12:18:38.000] 00:0038:cactbot wipe',
+      '[03:12:18.000] 00:0038:end',
+      '[03:12:18.000] 00:0038:hello world',
+    ];
+    regexCaptureTest(Regexes.echo, echoLines);
+
+    let dialogLines = [
+      '[18:44:08.000] 00:0044:Rhitahtyn sas Arvina:My shields are impregnable! Join the countless challengers who have dashed themselves against them!',
+      '[21:47:25.000] 00:0044:Hades:You are no match for my mastery of the arcane!',
+      '[13:52:19.000] 00:0044:Byakko:There is no turning back!',
+    ];
+    regexCaptureTest(Regexes.dialog, dialogLines);
+
+    let messageLines = [
+      '[23:12:47.000] 00:0839:An avatar of Absolute Virtue has manifested somewhere in Hydatos!',
+      '[19:39:13.000] 00:0839:The Hand of Erebos manifests!',
+      '[12:10:44.000] 00:0839:The Pools of Folly will be sealed off in 15 seconds!',
+    ];
+    regexCaptureTest(Regexes.message, messageLines);
+
+    let allLines = [];
+    allLines.push(...echoLines);
+    allLines.push(...dialogLines);
+    allLines.push(...messageLines);
+    regexCaptureTest(Regexes.gameLog, allLines);
+  },
+};
+
+let keys = Object.keys(tests);
+let exitCode = 0;
+for (let i = 0; i < keys.length; ++i) {
+  try {
+    tests[keys[i]]();
+  } catch (e) {
+    console.log(e);
+    exitCode = 1;
+  }
+}
+process.exit(exitCode);

--- a/test/unittests/regex_test.js
+++ b/test/unittests/regex_test.js
@@ -82,13 +82,13 @@ let tests = {
     regexCaptureTest(Regexes.ability, lines);
     regexCaptureTest(Regexes.abilityFull, lines);
   },
-  headmarker: () => {
+  headMarker: () => {
     let lines = [
       '[21:51:06.027] 1B:107C73B8:Aloo Gobi:0000:5DC3:00C0:0000:0000:0000:',
       '[20:23:38.707] 1B:10595B8B:Baked Potato:0000:0000:0017:0000:0000:0000:',
       '[12:14:44.048] 1B:102D9908:Au Gratin:0000:0000:0005:0000:0000:0000:',
     ];
-    regexCaptureTest(Regexes.headmarker, lines);
+    regexCaptureTest(Regexes.headMarker, lines);
   },
   addedCombatant: () => {
     let lines = [

--- a/ui/raidboss/data/04-sb/raid/o5n.js
+++ b/ui/raidboss/data/04-sb/raid/o5n.js
@@ -18,12 +18,12 @@
 
     {
       id: 'O5N Doom Strike',
-      regex: / 14:28A3:Phantom Train starts using Doom Strike on (\y{Name})/,
-      regexDe: / 14:28A3:Phantomzug starts using Vernichtungsschlag on (\y{Name})/,
-      regexFr: / 14:28A3:Train Fantôme starts using Frappe Létale on (\y{Name})/,
-      regexJa: / 14:28A3:魔列車 starts using 魔霊撃 on (\y{Name})/,
+      regex: Regexes.startsUsing({ name: 'Phantom Train', id: '28A3' }),
+      regexDe: Regexes.startsUsing({ name: 'Phantomzug', id: '28A3' }),
+      regexFr: Regexes.startsUsing({ name: 'Train Fantôme', id: '28A3' }),
+      regexJa: Regexes.startsUsing({ name: '魔列車', id: '28A3' }),
       alertText: function(data, matches) {
-        if (matches[1] == data.me) {
+        if (matches.target == data.me) {
           return {
             en: 'Tank Buster on YOU',
             de: 'Tank Buster auf DIR',
@@ -39,7 +39,7 @@
         }
       },
       tts: function(data, matches) {
-        if (matches[1] == data.me) {
+        if (matches.target == data.me) {
           return {
             en: 'buster',
             de: 'tenkbasta',

--- a/ui/raidboss/popup-text.js
+++ b/ui/raidboss/popup-text.js
@@ -260,7 +260,7 @@ class PopupText {
       return;
 
     // If using named groups, treat matches.groups as matches
-    // so triggers can do things like matches.targetName.
+    // so triggers can do things like matches.target.
     if (matches.groups)
       matches = matches.groups;
 

--- a/ui/raidboss/popup-text.js
+++ b/ui/raidboss/popup-text.js
@@ -259,6 +259,11 @@ class PopupText {
     if ('disabled' in trigger && trigger.disabled)
       return;
 
+    // If using named groups, treat matches.groups as matches
+    // so triggers can do things like matches.targetName.
+    if (matches.groups)
+      matches = matches.groups;
+
     let now = +new Date();
     if (trigger.id && trigger.id in this.triggerSuppress) {
       if (this.triggerSuppress[trigger.id] > now)


### PR DESCRIPTION
Adds a number of regex helper functions that all take a dictionary of optional fields.  Fields can be filled in optionally with strings/regular expressions/arrays of multiple values.  If field values are unspecified, it will match anything.

Each dictionary of fields can also specify `capture` as a boolean variable.  If not specified, capture is true.  If capture is true, then everything in the regex will be captured as a named group (with the same name as the field that would have specified it).

Examples:
* `Regexes.losesEffect({effect: '(?:Doom|Forked Lightning)'})`
* `Regexes.startsUsing({id: ['1C7F', '1C90'], name: 'Deathgaze Hollow', ability: 'Void Death'})`
* `Regexes.ability({name: 'Caduceus', id: '4B8', ability: 'Hood Swing'})`

Fixes #543.