### PR TITLE
lint: Initial Markdownlint Changes

### DIFF
--- a/AdvancedCactbot.md
+++ b/AdvancedCactbot.md
@@ -1,11 +1,13 @@
 # Advanced Cactbot Usage
 
 1. [Configuring UI Modules](#configuring-ui-modules)
-  1. [Customizing Appearance](#customizing-appearance)
-  1. [Customizing Behavior](#customizing-behavior)
-  1. [Text To Speech](#text-to-speech)
-  1. [Adding Custom Triggers](#adding-custom-triggers)
-  1. [Regular Expression Extensions](#regular-expression-extensions)
+    1. [User Directory](#user-directory)
+    1. [Customizing Appearance](#customizing-appearance)
+    1. [Customizing Behavior](#customizing-behavior)
+    1. [Per Trigger Options](#per-trigger-options)
+    1. [Text To Speech](#text-to-speech)
+    1. [Adding Custom Triggers](#adding-custom-triggers)
+    1. [Regular Expression Extensions](#regular-expression-extensions)
 1. [Writing a cactbot UI Module](#writing-a-cactbot-ui-module)
 
 ## Configuring UI modules
@@ -17,7 +19,7 @@ will prevent your changes from being clobbered during future cactbot updates.
 All cactbot UI modules can load user settings from the [user/](user/) directory. The user/
 directory already includes some example configuration files, which you can rename and use.
 For example the **user/raidboss-example.js** can be renamed to **user/raidboss.js**
-and edited to change the behaviour of the **raidboss** module.
+and edited to change the behavior of the **raidboss** module.
 
 If you want to do it yourself, then create a **user/\<name\>.css** or a **user/\<name\>.js**
 file, where **\<name\>** is the name of the UI module, such as [raidboss](ui/raidboss) or
@@ -42,7 +44,7 @@ For example in [ui/raidboss/raidboss.css](ui/raidboss/raidboss.css), you see the
 to different positions as desired. The size and color of info text alerts can also be changed by
 making a CSS rule for the `.info-text` class such as below:
 
-```
+```css
 .info-text {
   font-size: 200%;
   color: rgb(50, 100, 50);
@@ -58,7 +60,7 @@ you see the `BarExpiresSoonSeconds` option which controls when timeline bars sho
 highlighted. You can change that option from the default value to 5 seconds by editing
 **user/raidboss.js** to say:
 
-```
+```javascript
 Options.BarExpiresSoonSeconds = 5
 ```
 
@@ -66,7 +68,7 @@ To disable a text/sound alert that comes built-in for a fight, find the trigger'
 [ui/raidboss/data/triggers](ui/raidboss/data/triggers). Then add the `id` to the `Options.DisabledTriggers`
 in the **user/raidboss.js** file, such as:
 
-```
+```javascript
 Options.DisabledTriggers = {
   'O4S1 Fire III': true,
 }
@@ -82,7 +84,7 @@ Add the following code to your **user/raidboss.js** file.  If you have other exi
 
 This option disables the original twisters trigger and adds a second trigger that just says `Panic!` instead.  The gives you maximum flexibility, but the downside of this approach is that if the trigger regex ever changes, then when cactbot updates, you will need to update your custom trigger as well.  Note that this is fairly unlikely.
 
-```
+```javascript
 Options.DisabledTriggers = {
   'UCU Twisters': true,
 };
@@ -107,7 +109,7 @@ The [user/raidboss-example.js](https://github.com/quisquous/cactbot/blob/master/
 
 If you wanted to change the twister cast to say `Panic!` as above, you would do the following:
 
-```
+```javascript
 Options.PerTriggerOptions = {
   'UCU Twisters': {
     'AlertText': '',
@@ -139,7 +141,7 @@ If you dislike the built-in sound info, alert, and alarm noises that cactbot use
 prefer to use text to speech (tts), you can set a global option by including this line
 in your **user/raidboss.js** file:
 
-```
+```javascript
 // Including this line will make any trigger with text to speech use that instead of other
 // noises.
 Options.SpokenAlertsEnabled = true;
@@ -155,7 +157,7 @@ how to configure text, sound, and tts options on a per trigger basis.
 
 To add a sound alert that can be activated in any zone, for example, add the following to **user/raidboss.js**:
 
-```
+```javascript
 Options.Triggers = [
   { zoneRegex: /./,
     triggers: [
@@ -175,7 +177,7 @@ Options.Triggers = [
 A more sophisticated example that shows an alert message after a 1 second delay, but
 only when the player's character name appears in the FFXIV log message:
 
-```
+```javascript
 Options.Triggers = [
   // .. other zones here ..
 
@@ -205,16 +207,15 @@ convenience to avoid having to match against all possible unicode characters
 or to know the details of how the FFXIV ACT plugin writes things.
 
 The set of extensions are:
-- `\y{Float}`: Matches a floating-point number, accounting for locale-specific encodings.
-- `\y{Name}`: Matches any character or ability name (including empty strings which the FFXIV ACT plugin can generate when unknown).
-- `\y{ObjectId}`: Matches the 8 hex character object id in network log lines.
-- `\y{AbilityCode}`: Matches the FFXIV ACT plugin's format for the number code of a spell or ability.
-- `\y{TimeStamp}`: Matches the time stamp at the front of each log event such as `[10:23:34.123]`.
-- `\y{LogType}`: Matches the FFXIV ACT plugin's format for the number code describing the type of log event, found near the front of each log event.
+
+* `\y{Float}`: Matches a floating-point number, accounting for locale-specific encodings.
+* `\y{Name}`: Matches any character or ability name (including empty strings which the FFXIV ACT plugin can generate when unknown).
+* `\y{ObjectId}`: Matches the 8 hex character object id in network log lines.
+* `\y{AbilityCode}`: Matches the FFXIV ACT plugin's format for the number code of a spell or ability.
+* `\y{TimeStamp}`: Matches the time stamp at the front of each log event such as `[10:23:34.123]`.
+* `\y{LogType}`: Matches the FFXIV ACT plugin's format for the number code describing the type of log event, found near the front of each log event.
 
 See this [cactbot-user git repo](https://github.com/quisquous/cactbot-user) for more examples.
-
-
 
 ## Writing a cactbot UI module
 
@@ -235,7 +236,7 @@ regular expressions in order to support non-english characters.
 
 There are a number of web components that provide widgets for building your ui, including the
 [timerbar](resources/timerbar.js), [timerbox](resources/timerbox.js) or
-[resourcebar](resources/resourcebar.js). Include the file and then instatiate it by making an
+[resourcebar](resources/resourcebar.js). Include the file and then instantiate it by making an
 element of that type, such as `<timer-bar></timer-bar>` or `<resource-bar></resource-bar>`.
 
 The set of Javascript events that can be listened for via `document.addEventListener` is found

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -68,9 +68,9 @@ members of the project's leadership.
 ## Attribution
 
 This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4,
-available at https://www.contributor-covenant.org/version/1/4/code-of-conduct.html
+available at <https://www.contributor-covenant.org/version/1/4/code-of-conduct.html>
 
 [homepage]: https://www.contributor-covenant.org
 
 For answers to common questions about this code of conduct, see
-https://www.contributor-covenant.org/faq
+<https://www.contributor-covenant.org/faq>

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,7 +33,7 @@ Each pull request should be small and be self-contained in terms of what it is c
 If your change is small, just send a pull request and we can have a conversation there.
 If your change is big, consider having a conversation before you embark on a lot of work.
 
-If you want to make large mechanical changes to parts of the code, 
+If you want to make large mechanical changes to parts of the code,
 for example you're irritated at some style usage and want to make everything consistent,
 it's especially best to put that in a separate pull request.
 
@@ -45,6 +45,7 @@ Pull requests are a collaborative effort!
 The Chromium project has excellent resources on good pull requests and code reviews.
 Some of it doesn't apply, but much of the philosophy does.
 See these links:
+
 * [Respectful Changes](https://chromium.googlesource.com/chromium/src/+/master/docs/cl_respect.md)
 * [Respectful Code Reviews](https://chromium.googlesource.com/chromium/src/+/master/docs/cr_respect.md)
 
@@ -70,6 +71,7 @@ before a pull request.
 
 If you are wondering how to contribute to cactbot,
 here's a set of features that will almost always be needed:
+
 * fixing bugs
 * [issues marked "help wanted"](https://github.com/quisquous/cactbot/issues?utf8=%E2%9C%93&q=label%3A%22help+wanted%22)
 * [adding missing timelines](https://github.com/quisquous/cactbot/issues/414)
@@ -95,7 +97,7 @@ As always, try to be consistent with the surrounding code.
   * you will wipe the raid if you mess this up
   * ideally used on random mechanics (one person gets X)
   * ideally used only once or twice in a raid
- 
+
 * alert (yellow text)
   * you will get killed if you mess this up (or kill others)
   * used for important mechanics
@@ -108,7 +110,7 @@ As always, try to be consistent with the surrounding code.
 
 Another consideration for trigger severity is to make them contextually useful.
 For example, if you may get selected for one of two mechanics,
-it's preferable to have one mechanic be info and the other alert 
+it's preferable to have one mechanic be info and the other alert
 (or one alert and the other alarm)
 so that it is obvious from the noise which mechanic you have.
 

--- a/docs/LogGuide.md
+++ b/docs/LogGuide.md
@@ -4,77 +4,80 @@ This is intended to be a comprehensive guide to log lines
 for folks who want to write ACT triggers for ff14.
 
 This guide was last updated for:
+
 * [FF14](https://na.finalfantasyxiv.com/lodestone/special/patchnote_log/) Patch 4.58
 * [FFXIV Plugin](https://github.com/ravahn/FFXIV_ACT_Plugin/releases) 1.7.2.13
 
 With updates for:
+
 * [FF14](https://na.finalfantasyxiv.com/lodestone/special/patchnote_log/) Patch 5.08
 * [FFXIV Plugin](https://github.com/ravahn/FFXIV_ACT_Plugin/releases) 2.0.4.0
 
 <!-- manually generated via https://imthenachoman.github.io/nGitHubTOC/ -->
 ## TOC
-- [Data Flow](#data-flow)
-  - [Viewing logs after a fight](#viewing-logs-after-a-fight)
-  - [Importing an old fight](#importing-an-old-fight)
-  - [Importing into ffxivmon](#importing-into-ffxivmon)
-- [Glossary of Terms](#glossary-of-terms)
-  - [Network Data](#network-data)
-  - [Network Log Lines](#network-log-lines)
-  - [ACT Log Lines](#act-log-lines)
-  - [Game Log Lines](#game-log-lines)
-  - [Object/Actor/Entity/Mob/Combatant](#objectactorentitymobcombatant)
-  - [Object ID](#object-id)
-  - [Ability ID](#ability-id)
-- [Log Line Overview](#log-line-overview)
-  - [00: LogLine](#00-logline)
-    - [Don't Write Triggers Against Game Log Lines](#dont-write-triggers-against-game-log-lines)
-  - [01: ChangeZone](#01-changezone)
-  - [02: ChangePrimaryPlayer](#02-changeprimaryplayer)
-  - [03: AddCombatant](#03-addcombatant)
-  - [04: RemoveCombatant](#04-removecombatant)
-  - [05: AddBuff](#05-addbuff)
-  - [06: RemoveBuff](#06-removebuff)
-  - [07: FlyingText](#07-flyingtext)
-  - [08: OutgoingAbility](#08-outgoingability)
-  - [0A: IncomingAbility](#0a-incomingability)
-  - [0B: PartyList](#0b-partylist)
-  - [0C: PlayerStats](#0c-playerstats)
-  - [0D: CombatantHP](#0d-combatanthp)
-  - [14: NetworkStartsCasting](#14-networkstartscasting)
-  - [15: NetworkAbility](#15-networkability)
-    - [Ability Flags](#ability-flags)
-    - [Ability Damage](#ability-damage)
-    - [Special Case Shifts](#special-case-shifts)
-    - [Ability Examples](#ability-examples)
-  - [16: NetworkAOEAbility](#16-networkaoeability)
-  - [17: NetworkCancelAbility](#17-networkcancelability)
-  - [18: NetworkDoT](#18-networkdot)
-  - [19: NetworkDeath](#19-networkdeath)
-  - [1A: NetworkBuff](#1a-networkbuff)
-  - [1B: NetworkTargetIcon (Head Markers)](#1b-networktargeticon-head-markers)
-  - [1C: NetworkRaidMarker](#1c-networkraidmarker)
-  - [1D: NetworkTargetMarker](#1d-networktargetmarker)
-  - [1E: NetworkBuffRemove](#1e-networkbuffremove)
-  - [1F: NetworkGauge](#1f-networkgauge)
-  - [20: NetworkWorld](#20-networkworld)
-  - [21: Network6D (Actor Control Lines)](#21-network6d-actor-control-lines)
-  - [22: NetworkNameToggle](#22-networknametoggle)
-  - [23: NetworkTether](#23-networktether)
-  - [24: LimitBreak](#24-limitbreak)
-  - [25: NetworkEffectResult](#25-networkeffectresult)
-  - [26: NetworkStatusEffects](#26-networkstatuseffects)
-  - [27: NetworkUpdateHP](#27-networkupdatehp)
-  - [FB: Debug](#fb-debug)
-  - [FC: PacketDump](#fc-packetdump)
-  - [FD: Version](#fd-version)
-  - [FE: Error](#fe-error)
-  - [FF: Timer](#ff-timer)
-- [Future Network Data Science](#future-network-data-science)
+
+* [Data Flow](#data-flow)
+  * [Viewing logs after a fight](#viewing-logs-after-a-fight)
+  * [Importing an old fight](#importing-an-old-fight)
+  * [Importing into ffxivmon](#importing-into-ffxivmon)
+* [Glossary of Terms](#glossary-of-terms)
+  * [Network Data](#network-data)
+  * [Network Log Lines](#network-log-lines)
+  * [ACT Log Lines](#act-log-lines)
+  * [Game Log Lines](#game-log-lines)
+  * [Object/Actor/Entity/Mob/Combatant](#objectactorentitymobcombatant)
+  * [Object ID](#object-id)
+  * [Ability ID](#ability-id)
+* [Log Line Overview](#log-line-overview)
+  * [00: LogLine](#00-logline)
+    * [Don't Write Triggers Against Game Log Lines](#dont-write-triggers-against-game-log-lines)
+  * [01: ChangeZone](#01-changezone)
+  * [02: ChangePrimaryPlayer](#02-changeprimaryplayer)
+  * [03: AddCombatant](#03-addcombatant)
+  * [04: RemoveCombatant](#04-removecombatant)
+  * [05: AddBuff](#05-addbuff)
+  * [06: RemoveBuff](#06-removebuff)
+  * [07: FlyingText](#07-flyingtext)
+  * [08: OutgoingAbility](#08-outgoingability)
+  * [0A: IncomingAbility](#0a-incomingability)
+  * [0B: PartyList](#0b-partylist)
+  * [0C: PlayerStats](#0c-playerstats)
+  * [0D: CombatantHP](#0d-combatanthp)
+  * [14: NetworkStartsCasting](#14-networkstartscasting)
+  * [15: NetworkAbility](#15-networkability)
+    * [Ability Flags](#ability-flags)
+    * [Ability Damage](#ability-damage)
+    * [Special Case Shifts](#special-case-shifts)
+    * [Ability Examples](#ability-examples)
+  * [16: NetworkAOEAbility](#16-networkaoeability)
+  * [17: NetworkCancelAbility](#17-networkcancelability)
+  * [18: NetworkDoT](#18-networkdot)
+  * [19: NetworkDeath](#19-networkdeath)
+  * [1A: NetworkBuff](#1a-networkbuff)
+  * [1B: NetworkTargetIcon (Head Markers)](#1b-networktargeticon-head-markers)
+  * [1C: NetworkRaidMarker](#1c-networkraidmarker)
+  * [1D: NetworkTargetMarker](#1d-networktargetmarker)
+  * [1E: NetworkBuffRemove](#1e-networkbuffremove)
+  * [1F: NetworkGauge](#1f-networkgauge)
+  * [20: NetworkWorld](#20-networkworld)
+  * [21: Network6D (Actor Control Lines)](#21-network6d-actor-control-lines)
+  * [22: NetworkNameToggle](#22-networknametoggle)
+  * [23: NetworkTether](#23-networktether)
+  * [24: LimitBreak](#24-limitbreak)
+  * [25: NetworkEffectResult](#25-networkeffectresult)
+  * [26: NetworkStatusEffects](#26-networkstatuseffects)
+  * [27: NetworkUpdateHP](#27-networkupdatehp)
+  * [FB: Debug](#fb-debug)
+  * [FC: PacketDump](#fc-packetdump)
+  * [FD: Version](#fd-version)
+  * [FE: Error](#fe-error)
+  * [FF: Timer](#ff-timer)
+* [Future Network Data Science](#future-network-data-science)
 
 ## Data Flow
 
 ![Alt text](https://g.gravizo.com/source/data_flow?https%3A%2F%2Fraw.githubusercontent.com%2Fquisquous%2Fcactbot%2Fmaster%2Fdocs%2FLogGuide.md)
-<details> 
+<details>
 <summary></summary>
 data_flow
   digraph G {
@@ -168,7 +171,8 @@ These lines are still processed and filtered by the ffxiv plugin,
 and are (mostly) not raw network data.
 
 Here are some example network log lines:
-```
+
+```log
 21|2019-05-31T21:14:56.8980000-07:00|10686258|Tini Poutini|DF9|Fire IV|40002F21|Zombie Brobinyak|150003|3B9D4002|1C|DF98000|0|0|0|0|0|0|0|0|0|0|0|0|104815|348652|12000|12000|1000|1000|-767.7882|156.939|-672.0446|26285|28784|13920|15480|1000|1000|-771.8156|157.1111|-671.3281||8eaa0245ad01981b69fc1af04ea8f9a1
 30|2019-05-31T20:02:41.4560000-07:00|6b4|Boost|0.00|1069C23F|Potato Chippy|1069C23F|Potato Chippy|00|3394|3394||4f7b1fa11ec7a2746a8c46379481267c
 20|2019-05-31T20:02:41.4660000-07:00|105E3321|Tater Tot|2C9D|Peculiar Light|105E3321|Tater Tot||c375d8a2d1cf48efceccb136584ed250
@@ -183,6 +187,7 @@ The ffxiv plugin does not write the ACT log lines that plugins interact with
 to disk.
 
 The network log lines are used by some tools, such as:
+
 * fflogs uploader
 * ffxivmon
 * cactbot make_timeline utility
@@ -200,7 +205,8 @@ Data in ACT log lines is separated by colons, i.e. `:`.
 The log line type is in hex.
 
 Here is an example:
-```
+
+```log
 [21:16:44.288] 15:10686258:Potato Chippy:9C:Scathe:40001299:Striking Dummy:750003:90D0000:1C:9C8000:0:0:0:0:0:0:0:0:0:0:0:0:2778:2778:0:0:1000:1000:-653.9767:-807.7275:31.99997:26945:28784:6720:15480:1000:1000:-631.5208:-818.5244:31.95173:
 ```
 
@@ -250,7 +256,7 @@ You can use xivapi.com to look up a particular action, as sometimes these are
 listed as "Unknown" from the ffxiv plugin if it hasn't updated yet.
 For example, Fire IV has the ability id 0xDF9 = 3577,
 so this link will give you more information about it:
-https://xivapi.com/action/3577?columns=ID,Name,Description,ClassJobCategory.Name
+<https://xivapi.com/action/3577?columns=ID,Name,Description,ClassJobCategory.Name>
 
 This works for both players and enemies, abilities and spells.
 
@@ -276,7 +282,8 @@ Structure:
 `00:[Message Type ID]:Message displayed In-Game`
 
 Examples:
-```
+
+```log
 00:0839:The Right Hand of Bahamut is no longer sealed!
 00:0840:The Final Coil of Bahamut - Turn 2 completion time: 8:37.
 00:0b3a:You are defeated by the oppressor 0.5.
@@ -295,6 +302,7 @@ the full set of LogTypes is not well-documented.
 #### Don't Write Triggers Against Game Log Lines
 
 There are a number of reasons to avoid basing triggers on game log lines:
+
 * show up later than ACT log lines (often up to half a second)
 * [do not always show up](https://github.com/ravahn/FFXIV_ACT_Plugin/issues/100)
 * inconsistent text (gains effect vs suffers effect, begins casting vs readies, you vs player name)
@@ -315,7 +323,8 @@ Structure:
 `01:Changed Zone to [Zone Name].`
 
 Examples:
-```
+
+```log
 01:Changed Zone to The Lavender Beds.
 01:Changed Zone to The Unending Coil Of Bahamut (Ultimate).
 ```
@@ -328,7 +337,8 @@ Structure:
 `02:Changed primary player to [Player Name].`
 
 Examples
-```
+
+```log
 02:Changed primary player to Potato Chippy.
 02:Changed primary player to Tini Poutini.
 ```
@@ -342,14 +352,16 @@ Structure:
 `03:[ObjectId]:Added new combatant [Combatant Name].  Job: [Job-ID] Level: [Level-Value] Max HP: [Max-HP-Value] Max MP: [Max-MP-Value] Pos: ([X-Pos],[Z-Pos],[Y-Pos]).`
 
 Examples:
-```
+
+```log
 03:40123456:Added new combatant Pagos Deepeye.  Job: N/A Level: 70 Max HP: 348652 Max MP: 12000 Pos: (-720.9337,90.80706,-679.6056).
 03:10987654:Added new combatant Tater Tot (Jenova).  Job: 28 Level: 70 Max HP: 39835 Max MP: 16461 Pos: (-143.9604,168.5795,-4.999999).
 ```
 
 This combatant may be invisible and fake.  The real ones have more HP.
 For example, at the start of t5 you will see messages like this:
-```
+
+```log
 03:40123450:Added new combatant Twintania.  Job: N/A Level: 50 Max HP: 2778 Max MP: 0 Pos: (-6.27745,-5.304218,50.00586).
 03:40123451:Added new combatant Twintania.  Job: N/A Level: 50 Max HP: 2778 Max MP: 0 Pos: (-6.27745,-5.304218,50.00586).
 03:40123452:Added new combatant Twintania.  Job: N/A Level: 50 Max HP: 2778 Max MP: 0 Pos: (-6.27745,-5.304218,50.00586).
@@ -383,7 +395,8 @@ Structure:
 `04:[ObjectId]:Removing combatant [Combatant Name].  Max HP: [Max-HP-Value]. Pos: ([X-Pos],[Z-Pos],[Y-Pos])`
 
 Examples:
-```
+
+```log
 04:10987654:Removing combatant Potato Chippy.  Max HP: 28784. Pos: (-776.6765,152.5261,-671.2197)
 04:40123462:Removing combatant Frozen Void Dragon.  Max HP: 348652. Pos: (-710.7075,49.39039,-646.7071)
 ```
@@ -397,7 +410,8 @@ Structure:
 `05:[Target Name] gains the effect of [Status] from [Source Name]`
 
 Examples:
-```
+
+```log
 05:Striking Dummy gains the effect of Reprisal from Tini Poutini.
 05:Potato Chippy gains the effect of Passage Of Arms from Potato Chippy.
 ```
@@ -411,7 +425,8 @@ Structure:
 `06:[Target Name] loses the effect of [Status] from [Source Name]`
 
 Examples:
-```
+
+```log
 06:Striking Dummy loses the effect of Reprisal from Tini Poutini.
 06:Striking Dummy loses the effect of Circle Of Scorn from Potato Chippy.
 ```
@@ -425,7 +440,8 @@ Structure:
 `07:[Type Name] tick on [Source Name] for [Value] damage.`
 
 Examples:
-```
+
+```log
 07:DoT tick on Striking Dummy for 509 damage.
 ```
 
@@ -438,7 +454,8 @@ Structure:
 `08:[Source Name] starts using [Ability Name] on [Target Name].`
 
 Examples:
-```
+
+```log
 08:Potato Chippy starts using Circle Of Scorn on Striking Dummy.
 ```
 
@@ -448,7 +465,8 @@ This is the memory-parsing equivalent of [15: NetworkAbility](#15-networkability
 Do not write triggers against this as this is only emitted when parsing from memory.
 
 Examples:
-```
+
+```log
 0A:10686258:Potato Chippy:17:Circle Of Scorn:40001299:Striking Dummy:710003:6850000:ef010f:f80000:0:0:0:0:0:0:0:0:0:0:0:0:2778:2778:0
 ```
 
@@ -474,7 +492,8 @@ Structure:
 `0D:[Target Name] HP at [HP-Value]%.`
 
 Examples:
-```
+
+```log
 0D:Striking Dummy HP at 96%.
 0D:Tini Poutini HP at 98%.
 ```
@@ -489,7 +508,8 @@ Structure:
 `14:[Source ID]:[Source Name] starts using [Ability Name] on [Target Name].`
 
 Examples:
-```
+
+```log
 14:5B2:Twintania starts using Death Sentence on Potato Chippy.
 14:DF9:Tini Poutini starts using Fire IV on Striking Dummy.
 ```
@@ -533,7 +553,7 @@ Index | Example | Explanation
 29 | -653.9767 | target x position
 30 | -807.7275 | target y position
 31 | 31.99997 | target z position
-32 | 66480 | caster current hp 
+32 | 66480 | caster current hp
 33 | 74095 | caster max hp
 34 | 4560 | caster current mp
 35 | 4560 | caster max mp
@@ -553,6 +573,7 @@ This means that there's a number of caveats going on to handling all the data in
 #### Ability Flags
 
 Damage bitmasks:
+
 * 0x01 = dodge
 * 0x03 = damage done
 * 0x05 = blocked damage
@@ -563,6 +584,7 @@ Damage bitmasks:
 * 0x300 = crit direct hit damage
 
 Heal bitmasks:
+
 * 0x00004 = heal
 * 0x10004 = crit heal
 
@@ -621,6 +643,7 @@ These are always followed by `4C3`.
 Therefore, these should also be shifted over two to find the real flags.
 
 #### Ability Examples
+
 1) 18216 damage from Grand Cross Alpha (basic damage)
 `16:40001333:Neo Exdeath:242B:Grand Cross Alpha:1048638C:Tater Tot:750003:47280000:1C:80242B:0:0:0:0:0:0:0:0:0:0:0:0:36906:41241:5160:5160:880:1000:0.009226365:-7.81128:-1.192093E-07:16043015:17702272:12000:12000:1000:1000:-0.01531982:-19.02808:0:`
 
@@ -653,7 +676,8 @@ Structure:
 `17:[Source ID]:[Source Name]:[Ability ID]:[Ability Name]:Cancelled.`
 
 Examples:
-```
+
+```log
 17:105EDD08:Potato Chippy:1D07:Stone IV:Cancelled:
 17:40000FE3:Raiden:3878:Ultimate Zantetsuken:Cancelled:
 ```
@@ -673,7 +697,8 @@ Structure:
 `18:[Type Name] on [Source Name] for [Value] damage.`
 
 Examples:
-```
+
+```log
 18:DoT Tick on Ovni for 13003 damage.
 18:HoT Tick on Tini Poutini for 2681 damage.
 18:Shadow Flare DoT Tick on Arsenal Centaur for 151 damage.
@@ -689,7 +714,8 @@ Structure:
 `19:[Target Name] was defeated by [Source Name].`
 
 Examples:
-```
+
+```log
 19:Tini Poutini was defeated by Ovni.
 19:The Scourge Of Meracydia was defeated by Unknown.
 ```
@@ -702,7 +728,8 @@ Structure:
 `1A:[ObjectId]:[Target Name] gains the effect of [Status] from [Source Name] for [Float_Value] Seconds`
 
 Exampless:
-```
+
+```log
 1A:105EDD08:Tini Poutini gains the effect of Sprint from Tini Poutini for 20.00 Seconds.
 1A:10660108:Potato Chippy gains the effect of Protect from Tater Tot for 1800.00 Seconds.
 1A:405EFA09:Ovni gains the effect of Aero II from  for 18.00 Seconds.
@@ -728,7 +755,8 @@ Structure:
 `1B:[ObjectId]:[Player Name]:[Unknown1 (4 bytes)]:[Unknown2 (4 bytes)]:[Type (4 bytes)]:0000:0000:0000`
 
 Examples:
-```
+
+```log
 1B:10686258:Tini Poutini:0000:0000:0027:0000:0000:0000:
 1B:106F0213:Potato Chippy:0000:0EE3:0061:0000:0000:0000:
 ```
@@ -765,7 +793,7 @@ Marker Code | Name | Sample Locations | Consistent meaning?
 004B | Acceleration Bomb | Weeping City boss 3, Susano N/EX, o4s | Yes
 004C | Purple Fire Circle (large) | e2n/s | Yes
 0054 | Thunder Tether (orange) | Titania EX | N/A
-0057 | Flare | o4n/s, e2n/s | Yes 
+0057 | Flare | o4n/s, e2n/s | Yes
 005C | Prey (dark) | Dun Scaith boss 3/4, Holminster Switch boss 3 | No
 005D | Stack Marker (tank--no border) | Dun Scaith boss 4, e4s | Yes
 0060 | Orange Spread Circle (small) | Hades N | Yes
@@ -796,7 +824,6 @@ Marker Code | Name | Sample Locations | Consistent meaning?
 00BD | Purple Spread Circle (giant) | TItania N/EX | Yes
 00BF | Granite Gaol | e4s | N/A
 
-
 ### 1C: NetworkRaidMarker
 
 Unknown?
@@ -814,7 +841,8 @@ Structure:
 `1E:[ObjectId]:[Target Name] loses the effect of [Status] from [Source Name]`
 
 Examples:
-```
+
+```log
 1E:10657868:Tini Poutini loses the effect of Sprint from Tini Poutini.
 1E:10299838:Potato Chippy loses the effect of Protect from Tater Tot.
 1E:40686258:Ovni loses the effect of Aero II.
@@ -825,7 +853,8 @@ Examples:
 Info about the current player's job gauge.
 
 Examples:
-```
+
+```log
 1F:10686258:Tini Poutini:C8000019:FD32:D0DF8C00:7FC0
 1F:10686258:Potato Chippy:C863AC19:1000332:D0DF8C00:7FC0
 ```
@@ -842,6 +871,7 @@ Unused.
 ### 21: Network6D (Actor Control Lines)
 
 Actor control lines are for several miscellaneous zone commands:
+
 * changing the music
 * resetting an entire zone after a wipe
 * limit gauge for bosses
@@ -851,7 +881,8 @@ Structure:
 `21:ZoneID (4 bytes):Command (4 bytes):Data (4x 4? byte extra data)`
 
 Examples:
-```
+
+```log
 21:8003753A:40000010:00:00:00:00
 21:80034E52:8000000D:1601:00:00:00
 21:80037543:80000004:257:00:00:00
@@ -865,6 +896,7 @@ Wipes on most raids and primals these days can be detected via this regex:
 such as coil turns where there is a zone seal.
 
 Known types:
+
 * Initial commence: `21:zone:40000001:time:` (time is the lockout time in seconds)
 * Recommence: `21:zone:40000006:time:00:00:00`
 * Lockout time adjust: `21:zone:80000004:time:00:00:00`
@@ -874,6 +906,7 @@ Known types:
 * Wipe 2: `21:zone:40000012:00:00:00:00` (always comes after Wipe 1)
 
 Still unknown:
+
 * `21:zone:40000003:00:00:00:00` (victory?)
 * `21:zone:40000005:00:00:00:00` (fade to black during wipe?)
 * `21:zone:40000007:00:00:00:00`
@@ -887,7 +920,8 @@ Structure:
 `22:[ObjectId]:[Target Name]:[ObjectId]:[Target Name]:[Display State]`
 
 Examples:
-```
+
+```log
 22:105E3321:Tini Poutini:105E3321:Tini Poutini:01
 22:40018065:Twintania:40018065:Twintania:00
 ```
@@ -902,7 +936,8 @@ Structure:
 `23:[SourceId]:[SourceName]:[TargetId]:[TargetName]:[Unknown1 (4 bytes)]:[Unknown2 (4 bytes)]:[Type (4 bytes)]:[TargetId]:[Unknown3 (4 bytes)]:[Unknown4 (4 bytes)]:`
 
 Examples:
-```
+
+```log
 23:40015B4E:Weapons Node:40015B4D:Gravity Node:751E:0000:000E:40015B4D:000F:7F4B:
 23:4000E84B:Zu Cockerel:1048638C:Tini Poutini:0000:0000:0006:1048638C:000F:7FEF:
 23:40001614:Omega:10686258:Potato Chippy:0023:0000:0054:10686258:000F:0000:
@@ -914,6 +949,7 @@ Like [1B: NetworkTargetIcon (Head Markers)](#1b-networktargeticon-head-markers),
 Type is consistent across fights and represents a particular visual style of tether.
 
 There are also a number of examples where tethers are generated in some other way:
+
 * ultima aetheroplasm orbs: NpcSpawn parentActorId set to opposite orb
 * t12 redfire orb: NpcSpawn parentActorId set to target
 * t13 dark aether orbs: NpcSpawn parentActorId and targetId set to target player
@@ -938,7 +974,8 @@ Structure:
 `24:Limit Break: [Value]`
 
 Examples:
-```
+
+```log
 24:Limit Break: 7530
 ```
 
@@ -953,9 +990,11 @@ Structure:
 `25:[Player ObjectId]:[Sequence Number]:[Current HP]:[Max HP]:[Current MP]:[Max MP]:[Current TP]:[Max TP]:[Position X]:[Position Y]:[Position Z]:[Facing]:[packet data thereafter]`
 
 Examples:
-```
+
+```log
 25:12345678:PlayerOne:0000132A:33635:35817:10000:10000:0::0.3841706:-207.8767:2.901163:-3.00212:03E8:2500:0:01:03000000:0:0:E0000000:
 ```
+
 ## 26:NetworkStatusEffects
 
 For NPC opponents (and possibly PvP) this log line is generated alongside `18:NetworkDoT` lines.
@@ -967,9 +1006,11 @@ Structure:
 `26:[Target Id]:[Target Name]:[Job Levels]:[Current HP]:[Max Hp]:[Current Mp]:[Max MP]:[Current TP]:[Max TP]:[Position X]:[Position Y]:[Position Z]:[Facing]:<status list; format unknown>`
 
 Examples:
-```
+
+```log
 26:12345678:PlayerOne:3C503C1C:24136:24136:9045:10000:4:0:-0.4730835:-158.1598:-23.9:3.110625:03E8:45:0:020130:0:106501CA:0129:4172D113:106501CA:012A:4168C8B4:106501CA:012B:40919168:106501CA:0232:40E00000:E0000000:
 ```
+
 It seems likely that this line was added in order to extend functionality
 for the `18`, `1A`, and `1E` log lines without breaking previous content or plugins.
 
@@ -983,7 +1024,8 @@ Structure:
 `27:[Target ID]:[Target Name]:[Current HP]:[Max HP]:[Current MP]:[Max MP]:[Current TP]:[Max TP]:[position X]:[position Y]:[position Z]:[Facing]`
 
 Examples:
-```
+
+```log
 27:12345678:Eos:22851:22851:10000:10000:0:0:12.13086:-169.9398:-23.90031:-2.310888:
 ```
 

--- a/docs/MemorySignatures.md
+++ b/docs/MemorySignatures.md
@@ -14,6 +14,7 @@ some programming, and have extreme levels of patience.
 
 <!-- manually generated via https://imthenachoman.github.io/nGitHubTOC/ -->
 ## TOC
+
 - [Installation](#installation)
 - [Finding New Memory Signatures](#finding-new-memory-signatures)
   - [Connect Cheat Engine to the Game](#connect-cheat-engine-to-the-game)
@@ -29,8 +30,7 @@ some programming, and have extreme levels of patience.
 
 ## Installation
 
-Install the [latest version of Cheat Engine]
-(https://github.com/cheat-engine/cheat-engine/releases/latest).
+Install the [latest version of Cheat Engine](https://github.com/cheat-engine/cheat-engine/releases/latest).
 The installer tries to tack some additional garbage on,
 so be sure to turn this off and don't blindly click next.
 Sorry.  It's gross.
@@ -281,7 +281,7 @@ until we find the line that sets `rcx`.
 You can see that `rcx` gets set on the `mov rcx,[ffxiv_dx11.exe+1AAE118]` line.
 This means that `rcx` is set from whatever is stored in memory at that location.
 
-```
+```assembly
 48 8B 0D 23C14201     - mov rcx,[ffxiv_dx11.exe+1AAE118] { (14116E120) }
 48 85 C9              - test rcx,rcx
 74 B8                 - je ffxiv_dx11.exe+681FB2
@@ -294,7 +294,7 @@ RIP relative addressing means that offsets are relative to the instruction point
 The `RIP` register is the instruction pointer register and contains
 the address of the instruction immediately following this instruction.
 You can find out what this address is by double clicking on the
-next line (the `text rcx,rcx` line). 
+next line (the `text rcx,rcx` line).
 In my case, it says the address is `13FD41FF5`.
 Because we are on a [little endian](https://en.wikipedia.org/wiki/Endianness)
 system, the `23C14201` hex is the 4 byte integer `01 42 C1 23` (bytes reversed).
@@ -339,7 +339,7 @@ so ideally you want to find something that will stand the test of time.
 In this case, let's just start copying bytes out from the bytes column,
 starting with the `mov rcx, ...` line.
 
-```
+```assembly
 48 8B 0D 23C14201     - mov rcx,[ffxiv_dx11.exe+1AAE118] { (14116E120) }
 48 85 C9              - test rcx,rcx
 74 B8                 - je ffxiv_dx11.exe+681FB2
@@ -362,6 +362,7 @@ You can see this [in cactbot itself](https://github.com/quisquous/cactbot/blob/d
 It's important to do a [scan for existing memory signatures](#scan-for-existing-memory-signatures) to make sure that this signature is unique.
 
 Then, in your plugin, the process would be the following.
+
 * search for this signature in memory
 * convert the RIP relative addressing to a real pointer (e.g. `14116E118`)
 * find the pointer at that memory location (e.g. `14116E120`)

--- a/docs/TimelineGuide.md
+++ b/docs/TimelineGuide.md
@@ -12,6 +12,7 @@ or triggers that are based on timelines themselves.
 
 <!-- manually generated via https://imthenachoman.github.io/nGitHubTOC/ -->
 ## TOC
+
 - [History](#history)
 - [Timeline File Syntax](#timeline-file-syntax)
   - [Comments](#comments)
@@ -38,7 +39,6 @@ or triggers that are based on timelines themselves.
   - [Putting it all together](#putting-it-all-together)
   - [Testing Timelines](#testing-timelines)
   - [Test against other timelines](#test-against-other-timelines)
-
 
 ## History
 
@@ -116,7 +116,7 @@ Instead, alerts based on timelines in cactbot should use [timeline triggers](#ti
 
 ### Examples
 
-```
+```bash
 677.0 "Heavensfall Trio"
 1044 "Enrage" # ???
 35.2 "Flare Breath x3" duration 4
@@ -168,6 +168,7 @@ cactbot adds all of its timeline triggers from the timeline file.
 This is done by adding a `timelineTriggers` section to the triggers file.
 
 Examples:
+
 * [Orbonne Monastery](https://github.com/quisquous/cactbot/blob/master/ui/raidboss/data/04-sb/alliance/orbonne_monastery.js)
 * [T9](https://github.com/quisquous/cactbot/blob/master/ui/raidboss/data/02-arr/raid/t9.js)
 * [O12 normal](https://github.com/quisquous/cactbot/blob/master/ui/raidboss/data/04-sb/raid/o12n.js)
@@ -231,12 +232,14 @@ In particular, you can't get rp text lines, the text for the zone sealing/unseal
 Once you've run the combat, you'll have generated a couple of [network log files](LogGuide.md#network-log-lines).
 
 If you want to try these examples, here are a couple of files:
+
 1. [CapeWestwind.log](data/CapeWestwind.log)
 1. [CapeWestwind2.log](data/CapeWestwind2.log)
 
 Follow those links, click **Raw**, then right click and **Save As** to save them to disk.
 
 Good guidelines for getting good logs are:
+
 1. run long enough to see the enrage
 1. have enough people to see all the mechanics (e.g. t11 tethers don't appear without two people)
 1. per phase, run long enough to see the mechanics loop
@@ -267,7 +270,8 @@ Timeline files can only be loaded via triggers files,
 so the triggers file is always required.
 
 An initial triggers file should look like the following:
-```
+
+```javascript
 'use strict';
 
 [{
@@ -297,7 +301,8 @@ Once you have a network log file, you need to find the start and the finish.
 ![encounter logs screenshot](images/timelineguide_encounterlogs.png)
 
 For example, in this fight, these are the relevant log lines and times:
-```
+
+```log
 [18:42:23.614] 15:10686258:Potato Chippy:2E:Tomahawk:4000EE16:Rhitahtyn sas Arvina:710003:9450000:1C:2E8000:0:0:0:0:0:0:0:0:0:0:0:0:140279:140279:8010:8010:1000:1000:-707.8608:-822.4221:67.74045:3858:74095:4560:0:1000:1000:-693.7162:-816.4633:65.55687:
 [18:49:22.934] 19:Rhitahtyn Sas Arvina was defeated by Potato Chippy.
 ```
@@ -305,8 +310,9 @@ For example, in this fight, these are the relevant log lines and times:
 (Known bug: sometimes network logs from other people's timezones require converting the time from what the act log lines.  Patches welcome.)
 
 You can then make a timeline from those times by running the following command.
-```
-$ python util/make_timeline.py -f CapeWestwind.log -s 18:42:23.614 -e 18:49:22.934
+
+```bash
+python util/make_timeline.py -f CapeWestwind.log -s 18:42:23.614 -e 18:49:22.934
 
 0 "Start"
 2.0 "Shield Skewer" sync /:Rhitahtyn sas Arvina:471:/
@@ -433,7 +439,8 @@ You can look at the time and figure out where they go yourself.
 (Patches welcome to add either of these into **make_timeline.py** automatically.)
 
 The relevant lines here are:
-```
+
+```log
 [18:45:27.041] 03:Added new combatant 7Th Cohort Optio.  Job: 0 Level: 49 Max HP: 24057 Max MP: 8010 Pos: (-665.5159,-804.6631,62.33055).
 [18:45:27.041] 03:Added new combatant 7Th Cohort Optio.  Job: 0 Level: 49 Max HP: 24057 Max MP: 8010 Pos: (-665.5013,-807.1013,62.45256).
 [18:42:24.000] 00:0044:Rhitahtyn sas Arvina:I will suffer none to oppose Lord van Baelsar!
@@ -452,7 +459,8 @@ From observation, it looks like there's a number of phase pushes.
 
 Here's what the initial phase looks like, with some extra line breaks
 for clarity.
-```
+
+```bash
 2.0 "Shield Skewer" sync /:Rhitahtyn sas Arvina:471:/
 10.6 "Shield Skewer" sync /:Rhitahtyn sas Arvina:471:/
 19.0 "Shield Skewer" sync /:Rhitahtyn sas Arvina:471:/
@@ -478,8 +486,9 @@ timeline file, adjusted by any amount, positive or negative.
 (Note: it will not adjust jumps.)
 
 Here's an abbreviated version of the output from running this command:
-```
-$ python util/timeline_adjust.py --file=ui/raidboss/data/timelines/cape_westwind.txt --adjust=27.8
+
+```bash
+python util/timeline_adjust.py --file=ui/raidboss/data/timelines/cape_westwind.txt --adjust=27.8
 
 29.8 "Shield Skewer" sync /:Rhitahtyn sas Arvina:471:/
 38.4 "Shield Skewer" sync /:Rhitahtyn sas Arvina:471:/
@@ -515,7 +524,8 @@ relative times stay the same.  In both cases when `Gate Of Tartarus`
 occurs, there's a `Shield Skewer` in 5.4 seconds after it.
 
 We'll add the jumps in later.
-```
+
+```bash
 2.0 "Shield Skewer" sync /:Rhitahtyn sas Arvina:471:/
 10.6 "Shield Skewer" sync /:Rhitahtyn sas Arvina:471:/
 19.0 "Shield Skewer" sync /:Rhitahtyn sas Arvina:471:/
@@ -557,7 +567,8 @@ Here's the new command line we've built up to:
 
 This gets us the following output for phase 2,
 with manually added blank lines to break out the loops.
-```
+
+```bash
 # manually added in
 199.0 "--sync--" sync /00:0044:[^:]*:My shields are impregnable/
 200.0 "Shield Skewer" sync /:Rhitahtyn sas Arvina:471:/
@@ -590,7 +601,7 @@ The loop time is 34.6.  Time to break out **timeline_adjust.py** again.
 Running `python util/timeline_adjust.py --file=ui/raidboss/data/timelines/cape_westwind.txt --adjust=27.8`,
 the relevant output is:
 
-```
+```bash
 234.6 "Shield Skewer" sync /:Rhitahtyn sas Arvina:471:/
 238.9 "Shrapnel Shell" sync /:Rhitahtyn sas Arvina:474:/
 243.4 "Winds Of Tartarus" sync /:Rhitahtyn sas Arvina:472:/
@@ -613,7 +624,7 @@ from **timeline_adjust.py**.
 
 The current state of our timeline is now:
 
-```
+```bash
 0 "Start"
 2.0 "Shield Skewer" sync /:Rhitahtyn sas Arvina:471:/
 10.6 "Shield Skewer" sync /:Rhitahtyn sas Arvina:471:/
@@ -664,7 +675,8 @@ From reading the timeline, there's a random
 "Gate of Tartarus" around the time the adds show up.
 
 This is the original timeline, before any phases were adjusted:
-```
+
+```bash
 175.8 "Gate Of Tartarus" sync /:Rhitahtyn sas Arvina:473:/
 183.5 "Adds"
 ```
@@ -680,7 +692,8 @@ then we can start phase 3 at t=400.
 
 Here's the adjusted output, with the adds manually
 added back in:
-```
+
+```bash
 400.0 "Gate Of Tartarus" sync /:Rhitahtyn sas Arvina:473:/
 403.5 "Shield Skewer" sync /:Rhitahtyn sas Arvina:471:/
 
@@ -717,7 +730,7 @@ whether the `Shrapnel Shell` is part of phase 3 or phase 4.
 I know from observation that `Magitek Missiles` is the last phase,
 so because the Shrapnel Shell breaks the pattern let's assume
 it starts phase 4.
-We'll test this later. 
+We'll test this later.
 
 It looks a bit like there's another loop just like phase 2.
 
@@ -731,7 +744,7 @@ It's pretty clear that this loop is also a 36.2 second loop.
 Using **timeline_adjust.py** with a 36.2 adjustment gets
 this output:
 
-```
+```bash
 445.0 "Shield Skewer" sync /:Rhitahtyn sas Arvina:471:/
 449.5 "Shrapnel Shell" sync /:Rhitahtyn sas Arvina:474:/
 454.2 "Winds Of Tartarus" sync /:Rhitahtyn sas Arvina:472:/
@@ -759,7 +772,7 @@ first use of `Magitek Missile` (ability id 478) to be t=610.
 Here's the final command line, including this second phase:
 `python util/make_timeline.py -f CapeWestwind.log -s 18:42:23.614 -e 18:49:22.934 -ii 0A 2CD 2CE 194 14 -p 474:204.3 478:610`
 
-```
+```bash
 # manually added in
 595.0 "--sync--" sync /00:0044:[^:]*:Your defeat will bring/ window 600,0
 600.0 "Shrapnel Shell" sync /:Rhitahtyn sas Arvina:474:/
@@ -799,9 +812,9 @@ Here's the final command line, including this second phase:
 
 This sure looks like a 40.2 second loop.
 Using **timeline_adjust.py**, with a 40.2 second adjustment,
-we get the folllowing output:
+we get the following output:
 
-```
+```bash
 650.2 "Magitek Missiles" sync /:Rhitahtyn sas Arvina:478:/
 655.3 "Drill Shot" sync /:Rhitahtyn sas Arvina:475:/
 659.6 "Firebomb" sync /:Rhitahtyn sas Arvina:476:/
@@ -813,12 +826,11 @@ we get the folllowing output:
 
 This is a perfect match for the original times, so there's our loop.
 
-
 ### Boilerplate glue
 
 In general, most timelines should include some boilerplate at the top like this:
 
-```
+```bash
 # Cape Westwind
 # -ii 0A 2CD 2CE 194 14 -p 474:204 478:610
 
@@ -850,7 +862,8 @@ If the first boss ability is slow to happen, you should also include the first
 auto so that the timeline starts.
 
 For instances, on o11s, the first two lines are:
-```
+
+```bash
 0.0 "--sync--" sync /:Engage!/ window 0,1
 2.5 "--sync--" sync /:Omega:368:/ window 3,0
 ```
@@ -861,7 +874,7 @@ Here's the phase 1 loop, again.
 We're going to edit this so that whenever we get to 52.2 seconds
 it will jump back to 24.4 seconds seamlessly.
 
-```
+```bash
 2.0 "Shield Skewer" sync /:Rhitahtyn sas Arvina:471:/
 10.6 "Shield Skewer" sync /:Rhitahtyn sas Arvina:471:/
 19.0 "Shield Skewer" sync /:Rhitahtyn sas Arvina:471:/
@@ -895,7 +908,8 @@ on infrequent or important abilities so that the timeline
 can sync there.
 
 This leaves us with this final version of the initial loop.
-```
+
+```bash
 2.0 "Shield Skewer" sync /:Rhitahtyn sas Arvina:471:/
 10.6 "Shield Skewer" sync /:Rhitahtyn sas Arvina:471:/
 19.0 "Shield Skewer" sync /:Rhitahtyn sas Arvina:471:/
@@ -922,7 +936,8 @@ us with the following timeline.
 
 Because there are so many `Shield Skewer` abilities, any
 loops are on less frequent abilities just to be more careful.
-```
+
+```bash
 # Cape Westwind
 # -ii 0A 2CD 2CE 194 14 -p 474:204 478:610
 
@@ -1039,7 +1054,8 @@ adjusting timelines to be more accurate.
 Here's an example.
 The `-t` parameter here refers to the file name of the timeline you want to test against
 in the **ui/raidboss/data/timelines** folder, minus the .txt extension.
-```
+
+```bash
 $ python util/test_timeline.py -f CapeWestwind.log -s 18:42:23.614 -e 18:49:22.
 934 -t cape_westwind
 0.000: Matched entry: 2.0 Shield Skewer (+2.000s)
@@ -1143,7 +1159,8 @@ The `Missed sync` lines are the ones to look at more closely.
 These three examples aren't worrisome because they are just the end of the loop
 and we've skipped forward in time to the next phase.
 (Patches welcome to figure out how to not warn on this sort of jump.)
-```
+
+```text
 48.695: Matched entry: 199.0 --sync-- (+150.305s)
     Missed sync: Gate Of Tartarus at 52.2 (last seen at 24.411)
 
@@ -1159,7 +1176,8 @@ and we've skipped forward in time to the next phase.
 ```
 
 However, this looks like a problem:
-```
+
+```text
 620.783: Matched entry: 610.0 Magitek Missiles (-10.783s)
     Missed sync: Shrapnel Shell at 600.0 (last seen at 610.739)
     Missed sync: Firebomb at 604.5 (last seen at 615.247)
@@ -1171,7 +1189,8 @@ Because we added such a large window on `Magitek Missile` the timeline
 resynced (thank goodness), but some of the abilities before that were wrong.
 
 The original timeline is:
-```
+
+```bash
 595.0 "--sync--" sync /00:0044:[^:]*:Your defeat will bring/ window 600,0
 600.0 "Shrapnel Shell" sync /:Rhitahtyn sas Arvina:474:/
 ```
@@ -1181,13 +1200,14 @@ as the tester output mentioned `(last seen at 610.739)`.
 The fix is to move the rp text sync back in time by that amount.
 The new time will be 595 - 10.7 = 584.3.
 
-```
+```bash
 584.3 "--sync--" sync /00:0044:[^:]*:Your defeat will bring/ window 600,0
 600.0 "Shrapnel Shell" sync /:Rhitahtyn sas Arvina:474:/
 ```
 
 Rerunning the tester (most output omitted)
-```
+
+```bash
 $ python util/test_timeline.py -f CapeWestwind.log -s 18:42:23.614 -e 18:49:22.
 934 -t cape_westwind
 
@@ -1214,12 +1234,14 @@ Here's an example of running against the **CapeWestwind2.log** file.
 If you run `python util/test_timeline.py -f CapeWestwind2.log -s 13:21:00.688 -e 13:29:36.976 -t cape_westwind` yourself, you can spot at least two problems.
 
 One minor problem is that this boss is inconsistent:
-```
+
+```text
 447.329: Matched entry: 445.0 Shield Skewer (-2.329s)
 443.789: Matched entry: 445.0 Shield Skewer (+1.211s)
 444.792: Matched entry: 445.0 Shield Skewer (+0.208s)
 447.361: Matched entry: 445.0 Shield Skewer (-2.361s)
 ```
+
 This `Shield Skewer` in phase 3 comes at wildly different times.
 However, the abilities before and after seem to be just fine.
 Often if there are inconsistencies like this,
@@ -1227,7 +1249,8 @@ the best thing to do is make sure there are larger windows around surrounding ab
 to make sure that even if one ability is inconsistent the entire timeline doesn't get derailed.
 
 However, one major problem is that there's a missing `Shield Skewer`:
-```
+
+```text
 403.454: Matched entry: 403.5 Shield Skewer (+0.046s)
 407.876: Matched entry: 413.2 Shrapnel Shell (+5.324s)
     Missed sync: Shield Skewer at 408.7 (last seen at 403.454)
@@ -1239,6 +1262,7 @@ And the `Shrapnel Shell` is horribly mistimed here.
 
 What to do in this case is subjective.
 Here are some options:
+
 * get more data, and make a timeline for the most common case
 * leave a comment in the timeline
 * if this is an important ability (e.g. tankbuster) put a question mark on it so players know it's not guaranteed

--- a/ui/raidboss/data/README.md
+++ b/ui/raidboss/data/README.md
@@ -2,7 +2,7 @@
 
 ## File Structure
 
-```
+```javascript
 [{
   zoneRegex: /match for the zone/,
   timelineFile: 'filename.txt',
@@ -34,7 +34,8 @@
   ]
 }]
 ```
-# Elements
+
+### Elements
 
 **zoneRegex**
 Largely self-explanatory. For most situations you will want to match the encounter zone as reported by ACT and nothing else.
@@ -59,7 +60,7 @@ Boolean, defaults to true. If true, timelines and triggers will reset automatica
 
 ## Trigger Structure
 
-```
+```javascript
 {
   id: 'id string',
   regex: /trigger-regex-(with-position-1)(and-position-2)-here/,
@@ -80,7 +81,8 @@ Boolean, defaults to true. If true, timelines and triggers will reset automatica
   disabled: false,
 },
 ```
-# Trigger Elements
+
+### Trigger Elements
 
 **id string**
  An id string for the trigger, used to disable triggers. Every built-in trigger that has a text/sound output should have an id so it can be disabled. User-defined triggers need not have one.
@@ -153,7 +155,7 @@ Trigger elements are evaluated in this order:
 ## Timeline Info
 
 The trigger subfolders may contain timeline text files in the format defined by ACT Timeline plugin, which described in here:
-http://dtguilds.enjin.com/forum/m/37032836/viewthread/26353492-act-timeline-plugin
+<http://dtguilds.enjin.com/forum/m/37032836/viewthread/26353492-act-timeline-plugin>
 
 Each timeline file Cactbot uses has to be loaded by a relative directory reference from the given [TRIGGER-FILE].js. Typically the filename for the timeline file will match the name of the trigger file, and for specific encounters the filenames should at least loosely match the zone name.
 


### PR DESCRIPTION
Update various Markdown files in accordance with Markdownlint's
suggestions. Changes related to spacing were added via Markdownlint's
--fix option, while other changes were mostly implemented manually. As
for the code block language distinctions, I picked what seemed
reasonable for each type, opting for `bash` as the option for the
timeline output, seeing as that gives it _some_ color, but nothing too
distracting.

Spelling changes were done manually.

Markdownlint can be added to automation eventually, but there are still
some decisions that need to be made before that happens, namely:

* Unordered list convention is not consistent.
  * Markdownlint picks whichever is the first used unordered list
   character, and assumes that should be used everywhere. Some files
   begin with dashes, and others with asterisks, leaving inconsistent
   styling. I believe this is mainly due to the Table of Content
   generation in some files, which we can automate as well with
   whichever style we prefer.
* Line length.
  * Markdownlint wants to enforce line length to be 80 characters. I'm
   not too partial here other than 80 sounds too low. I'm open to 100 or
   120, but there are a lot of files that don't follow any line length
   conventions. Depending on what we decide, we might not want to
   enforce this.