### PR TITLE
Raidboss: ARF initial dungeon package

### DIFF
--- a/ui/oopsyraidsy/data/03-hw/dungeon/aetherochemical_research_facility.js
+++ b/ui/oopsyraidsy/data/03-hw/dungeon/aetherochemical_research_facility.js
@@ -1,0 +1,79 @@
+'use strict';
+
+// Aetherochemical Research Facility
+[{
+  zoneRegex: /Aetherochemical Research Facility/,
+  damageWarn: {
+    'Facility Grand Sword': '216', // Conal AoE, Scrambled Iron Giant trash
+    'Facility Cermet Drill': '20E', // Line AoE, 6th Legion Magitek Vanguard trash
+    'Magitek Slug': '10DB', // Line AoE, boss 1
+    'Aetherochemical Grenado': '10E2', // Large targeted circle AoE, Magitek Turret II, boss 1
+    'Magitek Spread': '10DC', // 270-degree roomwide AoE, boss 1
+    'Eerie Soundwave': '1170', // Targeted circle AoE, Cultured Empusa trash, before boss 2
+    'Tail Slap': '125F', // Conal AoE, Cultured Dancer trash, before boss 2
+    'Calcifying Mist': '123A', // Conal AoE, Cultured Naga trash, before boss 2
+    'Puncture': '1171', // Short line AoE, Cultured Empusa trash, before boss 2
+    'Sideswipe': '11A7', // Conal AoE, Cultured Reptoid trash, before boss 2
+    'Gust': '395', // Targeted small circle AoE, Cultured Mirrorknight trash, before boss 2
+    'Marrow Drain': 'D0E', // Conal AoE, Cultured Chimera trash, before boss 2
+    'Riddle Of The Sphinx': '10E4', // Targeted circle AoE, boss 2
+    'Ka': '106E', // Conal AoE, boss 2
+    'Rotoswipe': '11CC', // Conal AoE, Facility Dreadnought trash, before boss 3
+    'Auto-cannons': '12D9', // Line AoE, Monitoring Drone trash, before boss 3
+    'Death\'s Door': '4EC', // Line AoE, Cultured Shabti trash, before boss 3
+    'Spellsword': '4EB', // Conal AoE, Cultured Shabti trash, before boss 3
+    'End Of Days': '10FD', // Line AoE, boss 3
+    'Blizzard Burst': '10FE', // Fixed circle AoEs, Igeyorhm, boss 3
+    'Fire Burst': '10FF', // Fixed circle AoEs, Lahabrea, boss 3
+    'Sea Of Pitch': '12DE', // Targeted persistent circle AoEs, boss 3
+    'Dark Blizzard II': '10F3', // Random circle AoEs, Igeyorhm, boss 3
+    'Dark Fire II': '10F8', // Random circle AoEs, Lahabrea, boss 3
+    'Ancient Eruption': '1104', // Self-targeted circle AoE, boss 4
+    'Entropic Flame': '1108', // Line AoEs,  boss 4
+  },
+  triggers: [
+    {
+      // Instant tank cleave, boss 2
+      id: 'Facility Chthonic Hush',
+      damageRegex: '10E7',
+      condition: function(e) {
+        // Double taps only
+        return e.type != '15';
+      },
+      mistake: function(e, data) {
+        return { type: 'warn', blame: e.targetName, text: e.abilityName };
+      },
+    },
+    {
+      id: 'Facility Petrifaction',
+      gainsEffectRegex: gLang.kEffect.Petrification,
+      mistake: function(e, data) {
+        return { type: 'warn', blame: e.targetName, text: e.abilityName };
+      },
+    },
+    {
+      // Tank cleave, boss 4
+      id: 'Facility Height Of Chaos',
+      damageRegex: '1101',
+      condition: function(e) {
+        // Double taps only
+        return e.type != '15';
+      },
+      mistake: function(e, data) {
+        return { type: 'warn', blame: e.targetName, text: e.abilityName };
+      },
+    },
+    {
+      // Targeted donut AoEs, boss 4
+      id: 'Facility Ancient Circle',
+      damageRegex: '1102',
+      condition: function(e) {
+        // Double taps only
+        return e.type != '15';
+      },
+      mistake: function(e, data) {
+        return { type: 'warn', blame: e.targetName, text: e.abilityName };
+      },
+    },
+  ],
+}];

--- a/ui/oopsyraidsy/data/manifest.txt
+++ b/ui/oopsyraidsy/data/manifest.txt
@@ -2,6 +2,7 @@
 00-misc/test.js
 02-arr/trial/ifrit_nm.js
 02-arr/trial/titan_ex.js
+03-hw/dungeon/aetherochemical_research_facility.js
 03-hw/dungeon/fractal_continuum.js
 03-hw/dungeon/gubal_library_hard.js
 04-sb/dungeon/ala_mhigo.js

--- a/ui/raidboss/data/03-hw/dungeon/aetherochemical_research_facility.js
+++ b/ui/raidboss/data/03-hw/dungeon/aetherochemical_research_facility.js
@@ -105,8 +105,7 @@
           return {
             en: 'Tank buster on YOU',
           };
-        }
-        else if (data.role == 'healer') {
+        } else if (data.role == 'healer') {
           return {
             en: 'Buster on ' + data.shortName(matches[1]),
           };

--- a/ui/raidboss/data/03-hw/dungeon/aetherochemical_research_facility.js
+++ b/ui/raidboss/data/03-hw/dungeon/aetherochemical_research_facility.js
@@ -1,0 +1,336 @@
+'use strict';
+
+// Aetherochemical Research Facility
+[{
+  zoneRegex: /Aetherochemical Research Facility/,
+  timelineFile: 'aetherochemical_research_facility.txt',
+  timelineTriggers: [
+    {
+      id: 'Facility Bastardbluss',
+      regex: /Bastardbluss/,
+      beforeSeconds: 4,
+      condition: function(data) {
+        return data.role == 'healer' || data.role == 'tank';
+      },
+      infoText: {
+        en: 'Tank buster',
+      },
+    },
+    {
+      id: 'Facility Hood Swing',
+      regex: /Hood Swing/,
+      beforeSeconds: 4,
+      condition: function(data) {
+        return data.role == 'healer' || data.role == 'tank';
+      },
+      infoText: {
+        en: 'Tank buster',
+      },
+    },
+    {
+      id: 'Facility Chthonic Hush',
+      regex: /Chthonic Hush/,
+      beforeSeconds: 4,
+      infoText: function(data) {
+        if (data.role == 'tank') {
+          return {
+            en: 'Tank cleave on YOU',
+            de: 'Tank Cleave auf DIR',
+            fr: 'Tank cleave sur vous',
+          };
+        }
+        return {
+          en: 'Avoid tank cleave',
+        };
+      },
+    },
+    {
+      id: 'Facility Height Of Chaos',
+      regex: /Height Of Chaos/,
+      beforeSeconds: 4,
+      infoText: function(data) {
+        if (data.role == 'tank') {
+          return {
+            en: 'Tank cleave on YOU',
+            de: 'Tank Cleave auf DIR',
+            fr: 'Tank cleave sur vous',
+          };
+        }
+        return {
+          en: 'Avoid tank cleave',
+        };
+      },
+    },
+  ],
+  triggers: [
+    {
+      id: 'Facility Petrifaction',
+      regex: / 14:10EB:Harmachis starts using Petrifaction/,
+      regexDe: / 14:10EB:Harmachis starts using Versteinerung/,
+      regexFr: / 14:10EB:Horamakhet starts using Pétrification/,
+      regexJa: / 14:10EB:ハルマキス starts using ペトリファクション/,
+      infoText: {
+        en: 'Look away',
+        de: 'Wegschauen!',
+        fr: 'Ne regardez pas',
+      },
+    },
+    {
+      id: 'Facility Inertia Stream',
+      regex: / 15:\y{ObjectId}:Harmachis:10ED:Inertia Stream:\y{ObjectId}:(\y{Name}):/,
+      regexDe: / 15:\y{ObjectId}:Harmachis:10ED:Trägheitsstrom:\y{ObjectId}:(\y{Name}):/,
+      regexFr: / 15:\y{ObjectId}:Horamakhet:10ED:Courant indolent:\y{ObjectId}:(\y{Name}):/,
+      regexJa: / 15:\y{ObjectId}:ハルマキス:10ED:イナーシャストリーム:\y{ObjectId}:(\y{Name}):/,
+      condition: function(data) {
+        // Tanks technically shouldn't assist with this mechanic
+        // The mechanic target can't do anything about it
+        return data.role != 'tank' && data.me != matches[1];
+      },
+      alertText: function(data, matches) {
+        return {
+          en: 'Stack on ' + data.shortName(matches[1]),
+          de: 'Stack auf ' + data.shortName(matches[1]),
+          fr: 'Stack sur ' + data.shortName(matches[1]),
+        };
+      },
+    },
+    {
+      id: 'Facility Dark Orb',
+      regex: /14:10FC:(?:Igeyorhm|Lahabrea) starts using Dark Orb on (\y{Name})/,
+      regexDe: /14:10FC:(?:Igeyorhm|Lahabrea) starts using Dunkler Orbis on (\y{Name})/,
+      regexFr: /14:10FC:(?:Igeyorhm|Lahabrea) starts using Orbe ténébreux on (\y{Name})/,
+      regexJa: /14:10FC:(?:アシエン・イゲオルム|アシエン・ラハブレア) starts using ダークオーブ on (\y{Name})/,
+      infoText: function(data) {
+        if (matches[1] == data.me) {
+          return {
+            en: 'Tank buster on YOU',
+          };
+        }
+        else if (data.role == 'healer') {
+          return {
+            en: 'Buster on ' + data.shortName(matches[1]),
+          };
+        }
+      },
+    },
+    {
+      id: 'Facility Shadow Flare',
+      regex: / 14:1109:Ascian Prime starts using Shadow Flare/,
+      regexDe: / 14:1109:Prim-Ascian starts using Schattenflamme/,
+      regexFr: / 14:1109:Primo-Ascien starts using Éruption ténébreuse/,
+      regexJa: / 14:1109:アシエン・プライム starts using シャドウフレア/,
+      condition: function(data) {
+        return data.role == 'healer';
+      },
+      infoText: {
+        en: 'AoE',
+        fr: 'Dégâts de zone',
+      },
+    },
+    {
+      id: 'Facility Annihilation',
+      regex: / 14:110A:Ascian Prime starts using Annihilation/,
+      regexDe: / 14:110A:Prim-Ascian starts using Annihilation/,
+      regexFr: / 14:110A:Primo-Ascien starts using Annihilation/,
+      regexJa: / 14:110A:アシエン・プライム starts using アナイアレイション/,
+      condition: function(data) {
+        return data.role == 'healer';
+      },
+      infoText: {
+        en: 'AoE',
+        fr: 'Dégâts de zone',
+      },
+    },
+    {
+      id: 'Facility Universal Manipulation',
+      regex: / 14:1105:Ascian Prime starts using Universal Manipulation/,
+      regexDe: / 14:1105:Prim-Ascian starts using Umwertung aller Werte/,
+      regexFr: / 14:1105:Primo-Ascien starts using Manipulation universelle/,
+      regexJa: / 14:1105:アシエン・プライム starts using 法則改変/,
+      // The cast is ~10s, but it takes about 2s for correct execution to register
+      // 6s to execute is *usually* enough time
+      delaySeconds: 4,
+      alertText: {
+        en: 'Stand in dark portal',
+      },
+    },
+    {
+      id: 'Facility Chaosphere',
+      regex: / 03:\y{ObjectId}:Added new combatant Chaosphere/,
+      regexDe: /03:\y{ObjectId}:Added new combatant Chaossphäre/,
+      regexFr: /03:\y{ObjectId}:Added new combatant sphère de chaos/,
+      regexJa: /03:\y{ObjectId}:Added new combatant カオススフィア/,
+      suppressSeconds: 5,
+      infoText: {
+        en: 'Avoid your orb--pop others\'',
+      },
+    },
+  ],
+  timelineReplace: [
+    {
+      'locale': 'de',
+      'replaceSync': {
+        'Regula van Hydrus': 'Regula van Hydrus',
+        'Harmachis': 'Harmachis',
+        'Igeyorhm': 'Igeyorhm',
+        'Lahabrea': 'Lahabrea',
+        'Ascian Prime': 'Prim-Ascian',
+
+        'Analysis and Proving': 'Prototypentest',
+        'Evaluation and Authentication': 'Evaluation und Zertifikation',
+        'Neurolink Nacelle': 'Neurolink-Zelle',
+      },
+      'replaceText': {
+        'Bastardbluss': 'Lacération vicieuse',
+        'Judgment': 'Jugement',
+        'Magitek Turret': 'Magitek-Gefechtsturm',
+        'Magitek Slug': 'Magitek-Projektil',
+        'Self-detonate': 'Zerbersten',
+        'Quickstep': 'Schneller Schritt',
+        'Aetherochemical Grenado': 'Magitek-Granate',
+        'Magitek Spread': 'Magitek-Streuschuss',
+
+        'Weighing of the Heart': 'Gewissensprüfung',
+        'Steel Scales': 'Stahlschuppen',
+        'Hood Swing': 'Kapuzenschwung',
+        'Chthonic Hush': 'Chthonisches Schweigen',
+        'Riddle of the Sphinx': 'Rätsel der Sphinx',
+        'Petrifaction': 'Versteinerung',
+        'Circle of Flames': 'Feuerkreis',
+        'Ka': 'Ka',
+        'Inertia Stream': 'Trägheitsstrom',
+        'Ballistic Missile': 'Ballistische Rakete',
+        'Gaseous Bomb': 'Ballistische Rakete',
+
+        'Dark Orb': 'Dunkler Orbis',
+        'End of Days': 'Megiddoflamme',
+        'Sea of Pitch': 'Pech-See',
+        'Blizzard Sphere': 'Eissphäre',
+        'Fire Sphere': 'Feuersphäre',
+        'Blizzard Burst': 'Eissplitter',
+        'Fire Burst': 'Feuerknall',
+        'Dark Blizzard II': 'Dunkel-Eisra',
+        'Shadow Flare': 'Schattenflamme',
+        'Dark Fire II': 'Dunkel-Feura',
+        'Permafrost': 'Pergelisol',
+
+        'Height of Chaos': 'Klimax des Chaos',
+        'Ancient Eruption': 'Antike Eruption',
+        'Ancient Circle': 'Orbis Antiquus',
+        'Annihilation': 'Annihilation',
+        'Universal Manipulation': 'Umwertung aller Werte',
+        'Entropic Flame': 'Entropische Flamme',
+      },
+    },
+    {
+      'locale': 'fr',
+      'replaceSync': {
+        'Regula van Hydrus': 'Regula van Hydrus',
+        'Harmachis': 'Horamakhet',
+        'Igeyorhm': 'Igeyorhm',
+        'Lahabrea': 'Lahabrea',
+        'Ascian Prime': 'Primo-Ascien',
+
+        'Analysis and Proving': 'Analyse et Essai',
+        'Evaluation and Authentication': 'Évaluation et Authentification',
+        'Neurolink Nacelle': 'Nacelle neurolien',
+      },
+      'replaceText': {
+        'Bastardbluss': 'Lacération vicieuse',
+        'Judgment': 'Jugement',
+        'Magitek Turret': 'Tourelle magitek',
+        'Magitek Slug': 'Projectile magitek',
+        'Self-detonate': 'Auto-atomisation',
+        'Quickstep': 'Pas rapides',
+        'Aetherochemical Grenado': 'Grenade magitek',
+        'Magitek Spread': 'Ensemencement magitek',
+
+        'Weighing of the Heart': 'Pesée du cœur',
+        'Steel Scales': 'Écailles d\'acier',
+        'Hood Swing': 'Coup de capot',
+        'Chthonic Hush': 'Silence chthonien',
+        'Riddle of the Sphinx': 'Énigme du Sphinx',
+        'Petrifaction': 'Pétrification',
+        'Circle of Flames': 'Cercle de flammes',
+        'Ka': 'Ka',
+        'Inertia Stream': 'Courant indolent',
+        'Ballistic Missile': 'Missile balistique',
+        'Gaseous Bomb': 'Bombe gazeuse',
+
+        'Dark Orb': 'Orbe ténébreux',
+        'End of Days': 'Jugement dernier',
+        'Sea of Pitch': 'Océan de goudron',
+        'Blizzard Sphere': 'Sphère de glace',
+        'Fire Sphere': 'Sphère de feu',
+        'Blizzard Burst': 'Explosion glaciale',
+        'Fire Burst': 'Explosion ardente',
+        'Dark Blizzard II': 'Extra Glace ténébreuse',
+        'Shadow Flare': 'Éruption ténébreuse',
+        'Dark Fire II': 'Extra Feu ténébreux',
+        'Permafrost': 'Pergélisol',
+
+        'Height of Chaos': 'Apogée du chaos',
+        'Ancient Eruption': 'Éruption ancienne',
+        'Ancient Circle': 'Cercle ancien',
+        'Annihilation': 'Annihilation',
+        'Universal Manipulation': 'Manipulation universelle',
+        'Entropic Flame': 'Flamme entropique',
+      },
+    },
+    {
+      'locale': 'ja',
+      'replaceSync': {
+        'Regula van Hydrus': 'レグラ・ヴァン・ヒュドルス',
+        'Harmachis': 'ハルマキス',
+        'Igeyorhm': 'アシエン・イゲオルム',
+        'Lahabrea': 'アシエン・ラハブレア',
+        'Ascian Prime': 'アシエン・プライム',
+
+        'Analysis and Proving': '試作機実験庫',
+        'Evaluation and Authentication': '評価試験場',
+        'Neurolink Nacelle': 'ニューロリンク・ナセル',
+      },
+      'replaceText': {
+        'Bastardbluss': 'ガンバスタード',
+        'Judgment': 'ジャッジメント',
+        'Magitek Turret': '魔導タレット',
+        'Magitek Spread': '魔導バックショット',
+        'Magitek Slug': '魔導スラッグショット',
+        'Self-detonate': '爆発霧散',
+        'Aetherochemical Grenado': '魔導榴弾',
+        'Quickstep': 'クイックステップ',
+
+        'Weighing of the Heart': '転生の儀',
+        'Steel Scales': 'スチールスケール',
+        'Hood Swing': 'フードスイング',
+        'Chthonic Hush': 'クトニオスハッシュ',
+        'Riddle of the Sphinx': '謎かけ',
+        'Petrifaction': 'ペトリファクション',
+        'Circle of Flames': 'サークル・オブ・フレイム',
+        'Ka': 'カー',
+        'Inertia Stream': 'イナーシャストリーム',
+        'Ballistic Missile': 'バリスティックミサイル',
+        'Gaseous Bomb': '気化爆弾',
+
+        'Dark Orb': 'ダークオーブ',
+        'End of Days': 'メギドフレイム',
+        'Sea of Pitch': 'シー・オブ・ピッチ',
+        'Blizzard Sphere': 'ブリザードスフィア',
+        'Fire Sphere': 'ファイアスフィア',
+        'Blizzard Burst': 'ブリザードバースト',
+        'Fire Burst': 'ファイアバースト',
+        'Dark Blizzard II': 'ダークブリザラ',
+        'Shadow Flare': 'シャドウフレア',
+        'Dark Fire II': 'ダークファイラ',
+        'Permafrost': '永久凍土',
+
+        'Height of Chaos': 'ハイト・オブ・カオス',
+        'Ancient Eruption': 'エンシェントエラプション',
+        'Ancient Circle': 'エンシェントリング',
+        'Annihilation': 'アナイアレイション',
+        'Universal Manipulation': '法則改変',
+        'Entropic Flame': 'エントロピックフレイム',
+      },
+    },
+  ],
+}];

--- a/ui/raidboss/data/03-hw/dungeon/aetherochemical_research_facility.js
+++ b/ui/raidboss/data/03-hw/dungeon/aetherochemical_research_facility.js
@@ -83,10 +83,14 @@
       regexJa: / 15:\y{ObjectId}:ハルマキス:10ED:イナーシャストリーム:\y{ObjectId}:(\y{Name}):/,
       condition: function(data) {
         // Tanks technically shouldn't assist with this mechanic
-        // The mechanic target can't do anything about it
-        return data.role != 'tank' && data.me != matches[1];
+        return data.role != 'tank';
       },
       alertText: function(data, matches) {
+        if (data.me == matches[1]) {
+          return {
+            en: 'Laser Stack on YOU',
+          };
+        }
         return {
           en: 'Stack on ' + data.shortName(matches[1]),
           de: 'Stack auf ' + data.shortName(matches[1]),

--- a/ui/raidboss/data/03-hw/dungeon/aetherochemical_research_facility.txt
+++ b/ui/raidboss/data/03-hw/dungeon/aetherochemical_research_facility.txt
@@ -248,85 +248,150 @@ hideall "--sync--"
 2118.5 "Fire Burst" sync /:Firesphere:10FF:/
 
 # Modified rotation to HP < 50%
-2122.6 "Dark Blizzard II" sync /:Igeyorhm:10F2:/ window 20,20
-2123.9 "End Of Days" sync /:Lahabrea:10FD:/
-2131.9 "Shadow Flare" sync /:Igeyorhm:10FA:/
-2137.4 "Dark Fire II" sync /:Lahabrea:10F7:/
-2143.1 "Dark Orb" sync /:Igeyorhm:10FC:/
-2148.2 "Sea Of Pitch" sync /:Igeyorhm:10FB:/ window 20,20
-2151.8 "End Of Days" sync /:Lahabrea:10FD:/
-2156.4 "Dark Orb" sync /:Igeyorhm:10FC:/
-2163.7 "Dark Blizzard II" sync /:Igeyorhm:10F2:/ window 20,20
-2165.3 "Dark Fire II" sync /:Lahabrea:10F7:/
-2173.0 "Shadow Flare" sync /:Igeyorhm:10FA:/
-2179.8 "End Of Days" sync /:Lahabrea:10FD:/
-2184.2 "Dark Orb" sync /:Igeyorhm:10FC:/
-2189.3 "Sea Of Pitch" sync /:Igeyorhm:10FB:/ window 20,20
-2193.3 "Dark Fire II" sync /:Lahabrea:10F7:/
-2197.6 "Dark Orb" sync /:Igeyorhm:10FC:/
+# The two Ascians de-sync here. This section
+# is super-long to avoid any possibility of choppiness.
 
-2204.8 "Dark Blizzard II" sync /:Igeyorhm:10F2:/ jump 2122.6
-2206.1 "End Of Days"
-2214.1 "Shadow Flare"
-2219.6 "Dark Fire II"
-2225.3 "Dark Orb"
-2230.4 "Sea Of Pitch"
-2234.0 "End Of Days"
+2122.6 "Dark Blizzard II" sync /:Igeyorhm:10F2:/ window 20,20
+2123.8 "End Of Days" sync /:Lahabrea:10FD:/
+2131.7 "Shadow Flare" sync /:Igeyorhm:10FA:/
+2137.4 "Dark Fire II" sync /:Lahabrea:10F7:/
+2142.9 "Dark Orb" sync /:Igeyorhm:10FC:/
+2148.1 "Sea Of Pitch" sync /:Igeyorhm:10FB:/ window 20,20
+2151.9 "End Of Days" sync /:Lahabrea:10FD:/
+2156.3 "Dark Orb" sync /:Igeyorhm:10FC:/
+2163.5 "Dark Blizzard II" sync /:Igeyorhm:10F2:/window 20,20
+2165.3 "Dark Fire II" sync /:Lahabrea:10F7:/
+2172.5 "Shadow Flare" sync /:Igeyorhm:10FA:/
+2179.7 "End Of Days" sync /:Lahabrea:10FD:/
+2183.6 "Dark Orb" sync /:Igeyorhm:10FC:/
+2188.8 "Sea Of Pitch" sync /:Igeyorhm:10FB:/ window 20,20
+2193.0 "Dark Fire II" sync /:Lahabrea:10F7:/
+2197.0 "Dark Orb" sync /:Igeyorhm:10FC:/
+
+2204.2 "Dark Blizzard II" sync /:Igeyorhm:10F2:/ window 20,20
+2207.4 "End Of Days" sync /:Lahabrea:10FD:/
+2213.2 "Shadow Flare" sync /:Igeyorhm:10FA:/
+2220.8 "Dark Fire II" sync /:Lahabrea:10F7:/
+2224.4 "Dark Orb" sync /:Igeyorhm:10FC:/
+2229.6 "Sea Of Pitch" sync /:Igeyorhm:10FB:/ window 20,20
+2235.3 "End Of Days" sync /:Lahabrea:10FD:/
+2237.9 "Dark Orb" sync /:Igeyorhm:10FC:/
+2245.0 "Dark Blizzard II" sync /:Igeyorhm:10F2:/ window 20,20
+2248.7 "Dark Fire II" sync /:Lahabrea:10F7:/
+2254.1 "Shadow Flare" sync /:Igeyorhm:10FA:/
+2263.0 "End Of Days" sync /:Lahabrea:10FD:/
+2265.5 "Dark Orb" sync /:Igeyorhm:10FC:/
+2270.6 "Sea Of Pitch" sync /:Igeyorhm:10FB:/ window 20,20
+2276.4 "Dark Fire II" sync /:Lahabrea:10F7:/
+2278.8 "Dark Orb" sync /:Igeyorhm:10FC:/
+
+#Lahabrea de-syncs from here, so we just sync to Igeyorhm now
+2285.9 "Dark Blizzard II" sync /:Igeyorhm:10F2:/
+2295.0 "Shadow Flare" sync /:Igeyorhm:10FA:/
+2306.2 "Dark Orb" sync /:Igeyorhm:10FC:/
+2311.3 "Sea Of Pitch" sync /:Igeyorhm:10FB:/
+2319.6 "Dark Orb" sync /:Igeyorhm:10FC:/
+2326.7 "Dark Blizzard II" sync /:Igeyorhm:10F2:/
+2335.8 "Shadow Flare" sync /:Igeyorhm:10FA:/
+2346.9 "Dark Orb" sync /:Igeyorhm:10FC:/
+2352.1 "Sea Of Pitch" sync /:Igeyorhm:10FB:/
+2360.3 "Dark Orb" sync /:Igeyorhm:10FC:/
+
+2367.4 "Dark Blizzard II" sync /:Igeyorhm:10F2:/
+2376.6 "Shadow Flare" sync /:Igeyorhm:10FA:/
+2387.8 "Dark Orb" sync /:Igeyorhm:10FC:/
+2392.9 "Sea Of Pitch" sync /:Igeyorhm:10FB:/
+2401.2 "Dark Orb" sync /:Igeyorhm:10FC:/ jump 2360.3
+# Jump here and hope for the best. This should never happen
+2408.4 "Dark Blizzard II"
+2417.5 "Shadow Flare"
+2428.7 "Dark Orb"
+2433.8 "Sea Of Pitch"
+2442.1 "Dark Orb"
 
 # Ascians swap roles at Igeyorhm HP <= 50%
 
-2250.0 "End Of Days" sync /:Igeyorhm:10FD:/ window 250,5
-2255.1 "Dark Orb" sync /:Lahabrea:10FC:/
-2260.2 "Sea Of Pitch" sync /:Lahabrea:10FB:/
-2264.5 "End Of Days" sync /:Igeyorhm:10FD:/
-2267.3 "Dark Fire II" sync /:Lahabrea:10F7:/ window 20,20
-2274.4 "Dark Orb" sync /:Lahabrea:10FC:/
+2500.0 "End Of Days" sync /:Igeyorhm:10FD:/ window 400,5
+2505.1 "Dark Orb" sync /:Lahabrea:10FC:/
+2510.2 "Sea Of Pitch" sync /:Lahabrea:10FB:/
+2514.5 "End Of Days" sync /:Igeyorhm:10FD:/
+2517.3 "Dark Fire II" sync /:Lahabrea:10F7:/ window 20,20
+2524.4 "Dark Orb" sync /:Lahabrea:10FC:/
 
-2278.9 "End Of Days" sync /:Igeyorhm:10FD:/
-2284.0 "Dark Orb" sync /:Lahabrea:10FC:/
-2289.1 "Sea Of Pitch" sync /:Lahabrea:10FB:/
-2293.4 "End Of Days" sync /:Igeyorhm:10FD:/
-2296.2 "Dark Fire II" sync /:Lahabrea:10F7:/ window 20,20
-2303.3 "Dark Orb" sync /:Lahabrea:10FC:/ jump 2274.4
+2528.9 "End Of Days" sync /:Igeyorhm:10FD:/
+2534.0 "Dark Orb" sync /:Lahabrea:10FC:/
+2539.1 "Sea Of Pitch" sync /:Lahabrea:10FB:/
+2543.4 "End Of Days" sync /:Igeyorhm:10FD:/
+2546.2 "Dark Fire II" sync /:Lahabrea:10F7:/ window 20,20
+2553.3 "Dark Orb" sync /:Lahabrea:10FC:/ jump 2274.4
 
-2307.8 "End Of Days"
-2312.9 "Dark Orb"
-2318.0 "Sea Of Pitch"
-2322.3 "End Of Days"
-2325.1 "Dark Fire II"
-2332.2 "Dark Orb"
+2557.8 "End Of Days"
+2562.9 "Dark Orb"
+2568.0 "Sea Of Pitch"
+2572.3 "End Of Days"
+2575.1 "Dark Fire II"
+2582.2 "Dark Orb"
 
 # Special attack at HP < 75%
-2350.0 "Permafrost" sync /:Igeyorhm:10F4:/ window 350,5
-2354.0 "Dark Fire II" sync /:Lahabrea:10F7:/
-2359.1 "Dark Fire II" sync /:Lahabrea:10F7:/
-2364.2 "Dark Fire II" sync /:Lahabrea:10F7:/
-2373.4 "Dark Fire II" sync /:Lahabrea:10F7:/
+2600.0 "Permafrost" sync /:Igeyorhm:10F4:/ window 500,5
+2604.0 "Dark Fire II" sync /:Lahabrea:10F7:/
+2609.1 "Dark Fire II" sync /:Lahabrea:10F7:/
+2614.2 "Dark Fire II" sync /:Lahabrea:10F7:/
+2623.4 "Dark Fire II" sync /:Lahabrea:10F7:/
 
 # Modified rotation to HP < 50%
-2374.6 "End Of Days" sync /:Igeyorhm:10FD:/ window 30,15
-2382.5 "Shadow Flare" sync /:Lahabrea:1381:/
-2388.0 "Dark Blizzard II" sync /:Igeyorhm:10F2:/
-2393.6 "Dark Orb" sync /:Lahabrea:10FC:/
-2398.8 "Sea Of Pitch" sync /:Lahabrea:10FB:/ window 20,20
-2402.4 "End Of Days" sync /:Igeyorhm:10FD:/
-2407.0 "Dark Orb" sync /:Lahabrea:10FC:/
-2414.2 "Dark Fire II" sync /:Lahabrea:10F7:/
-2415.8 "Dark Blizzard II" sync /:Igeyorhm:10F2:/
-2423.2 "Shadow Flare" sync /:Lahabrea:1381:/ window 20,20
-2430.2 "End Of Days" sync /:Igeyorhm:10FD:/
-2434.2 "Dark Orb" sync /:Lahabrea:10FC:/
-2439.4 "Sea Of Pitch" sync /:Lahabrea:10FB:/
-2443.6 "Dark Blizzard II" sync /:Igeyorhm:10F2:/
-2447.5 "Dark Orb" sync /:Lahabrea:10FC:/
-2454.7 "Dark Fire II" sync /:Lahabrea:10F7:/
+2624.6 "End Of Days" sync /:Igeyorhm:10FD:/
+2632.4 "Shadow Flare" sync /:Lahabrea:1381:/
+2638.0 "Dark Blizzard II" sync /:Igeyorhm:10F2:/
+2643.5 "Dark Orb" sync /:Lahabrea:10FC:/
+2648.7 "Sea Of Pitch" sync /:Lahabrea:10FB:/
+2652.8 "End Of Days" sync /:Igeyorhm:10FD:/
+2657.0 "Dark Orb" sync /:Lahabrea:10FC:/
+2664.1 "Dark Fire II" sync /:Lahabrea:10F7:/
+2666.3 "Dark Blizzard II" sync /:Igeyorhm:10F2:/
+2673.4 "Shadow Flare" sync /:Lahabrea:1381:/
+2680.9 "End Of Days" sync /:Igeyorhm:10FD:/
+2684.5 "Dark Orb" sync /:Lahabrea:10FC:/
+2689.8 "Sea Of Pitch" sync /:Lahabrea:10FB:/
+2694.3 "Dark Blizzard II" sync /:Igeyorhm:10F2:/
+2697.9 "Dark Orb" sync /:Lahabrea:10FC:/
+2705.1 "Dark Fire II" sync /:Lahabrea:10F7:/
 
-2457.9 "End Of Days" sync /:Igeyorhm:10FD:/ jump 2374.6
-2465.8 "Shadow Flare"
-2471.3 "Dark Blizzard II"
-2476.9 "Dark Orb"
-2482.1 "Sea Of Pitch"
-2485.7 "End Of Days"
+2708.8 "End Of Days" sync /:Igeyorhm:10FD:/
+2714.3 "Shadow Flare" sync /:Lahabrea:1381:/
+2722.3 "Dark Blizzard II" sync /:Igeyorhm:10F2:/
+2725.4 "Dark Orb" sync /:Lahabrea:10FC:/
+2730.5 "Sea Of Pitch" sync /:Lahabrea:10FB:/
+2736.9 "End Of Days" sync /:Igeyorhm:10FD:/
+2738.7 "Dark Orb" sync /:Lahabrea:10FC:/
+2745.9 "Dark Fire II" sync /:Lahabrea:10F7:/
+2750.4 "Dark Blizzard II" sync /:Igeyorhm:10F2:/
+2755.1 "Shadow Flare" sync /:Lahabrea:1381:/
+2765.1 "End Of Days" sync /:Igeyorhm:10FD:/
+2766.4 "Dark Orb" sync /:Lahabrea:10FC:/
+2771.5 "Sea Of Pitch" sync /:Lahabrea:10FB:/
+2778.6 "Dark Blizzard II" sync /:Igeyorhm:10F2:/
+2779.6 "Dark Orb" sync /:Lahabrea:10FC:/
+2786.8 "Dark Fire II" sync /:Lahabrea:10F7:/
+
+# Same as before, just sync to Lahabrea now
+2795.9 "Shadow Flare" sync /:Lahabrea:1381:/
+2807.2 "Dark Orb" sync /:Lahabrea:10FC:/
+2812.3 "Sea Of Pitch" sync /:Lahabrea:10FB:/
+2820.7 "Dark Orb" sync /:Lahabrea:10FC:/
+2827.8 "Dark Fire II" sync /:Lahabrea:10F7:/
+
+2837.0 "Shadow Flare" sync /:Lahabrea:1381:/
+2848.3 "Dark Orb" sync /:Lahabrea:10FC:/
+2853.4 "Sea Of Pitch" sync /:Lahabrea:10FB:/
+2861.8 "Dark Orb" sync /:Lahabrea:10FC:/
+2868.9 "Dark Fire II" sync /:Lahabrea:10F7:/ jump 2827.8
+
+2878.1 "Shadow Flare"
+2889.4 "Dark Orb"
+2894.5 "Sea Of Pitch"
+2902.9 "Dark Orb"
+2910.0 "Dark Fire II"
 
 #~~~~~~~~~~~~~~#
 # Ascian Prime #
@@ -392,19 +457,19 @@ hideall "--sync--"
 3356.2 "Height Of Chaos" sync /:Ascian Prime:1101:/ window 50,5
 3363.3 "Entropic Flame" sync /:Ascian Prime:1107:/
 3368.5 "Height Of Chaos" sync /:Ascian Prime:1101:/
-3375.6 "Ancient Eruption" sync /:Ascian Prime:1103:/ window 30,30
+3375.6 "Ancient Eruption" sync /:Ascian Prime:1103:/ window 15,15
 3384.8 "Shadow Flare" sync /:Ascian Prime:1109:/
 3390.9 "Height Of Chaos x3" duration 5.0
 
 3402.7 "Height Of Chaos" sync /:Ascian Prime:1101:/
 3409.8 "Entropic Flame" sync /:Ascian Prime:1107:/
 3415.0 "Height Of Chaos" sync /:Ascian Prime:1101:/
-3422.1 "Ancient Eruption" sync /:Ascian Prime:1103:/ window 30,30
+3422.1 "Ancient Eruption" sync /:Ascian Prime:1103:/ window 15,15
 3431.3 "Shadow Flare" sync /:Ascian Prime:1109:/
 3437.4 "Height Of Chaos x3" duration 5.0
 
 # Jumping from a following block to avoid sync issues with Height of Chaos x3
-3449.2 "Height Of Chaos" sync /:Ascian Prime:1101:/ jump 3390.9
+3449.2 "Height Of Chaos" sync /:Ascian Prime:1101:/ jump 3402.7
 3456.3 "Entropic Flame"
 3461.5 "Height Of Chaos"
 3468.6 "Ancient Eruption"

--- a/ui/raidboss/data/03-hw/dungeon/aetherochemical_research_facility.txt
+++ b/ui/raidboss/data/03-hw/dungeon/aetherochemical_research_facility.txt
@@ -259,7 +259,7 @@ hideall "--sync--"
 2148.1 "Sea Of Pitch" sync /:Igeyorhm:10FB:/ window 20,20
 2151.9 "End Of Days" sync /:Lahabrea:10FD:/
 2156.3 "Dark Orb" sync /:Igeyorhm:10FC:/
-2163.5 "Dark Blizzard II" sync /:Igeyorhm:10F2:/window 20,20
+2163.5 "Dark Blizzard II" sync /:Igeyorhm:10F2:/ window 20,20
 2165.3 "Dark Fire II" sync /:Lahabrea:10F7:/
 2172.5 "Shadow Flare" sync /:Igeyorhm:10FA:/
 2179.7 "End Of Days" sync /:Lahabrea:10FD:/
@@ -341,35 +341,35 @@ hideall "--sync--"
 
 # Modified rotation to HP < 50%
 2624.6 "End Of Days" sync /:Igeyorhm:10FD:/
-2632.4 "Shadow Flare" sync /:Lahabrea:1381:/
+2632.4 "Shadow Flare" sync /:Lahabrea:1381:/ window 20,20
 2638.0 "Dark Blizzard II" sync /:Igeyorhm:10F2:/
 2643.5 "Dark Orb" sync /:Lahabrea:10FC:/
-2648.7 "Sea Of Pitch" sync /:Lahabrea:10FB:/
+2648.7 "Sea Of Pitch" sync /:Lahabrea:10FB:/ window 20,20
 2652.8 "End Of Days" sync /:Igeyorhm:10FD:/
 2657.0 "Dark Orb" sync /:Lahabrea:10FC:/
-2664.1 "Dark Fire II" sync /:Lahabrea:10F7:/
+2664.1 "Dark Fire II" sync /:Lahabrea:10F7:/ window 20,20
 2666.3 "Dark Blizzard II" sync /:Igeyorhm:10F2:/
 2673.4 "Shadow Flare" sync /:Lahabrea:1381:/
 2680.9 "End Of Days" sync /:Igeyorhm:10FD:/
 2684.5 "Dark Orb" sync /:Lahabrea:10FC:/
-2689.8 "Sea Of Pitch" sync /:Lahabrea:10FB:/
+2689.8 "Sea Of Pitch" sync /:Lahabrea:10FB:/ window 20,20
 2694.3 "Dark Blizzard II" sync /:Igeyorhm:10F2:/
 2697.9 "Dark Orb" sync /:Lahabrea:10FC:/
 2705.1 "Dark Fire II" sync /:Lahabrea:10F7:/
 
 2708.8 "End Of Days" sync /:Igeyorhm:10FD:/
-2714.3 "Shadow Flare" sync /:Lahabrea:1381:/
+2714.3 "Shadow Flare" sync /:Lahabrea:1381:/ window 20,20
 2722.3 "Dark Blizzard II" sync /:Igeyorhm:10F2:/
 2725.4 "Dark Orb" sync /:Lahabrea:10FC:/
-2730.5 "Sea Of Pitch" sync /:Lahabrea:10FB:/
+2730.5 "Sea Of Pitch" sync /:Lahabrea:10FB:/ window 20,20
 2736.9 "End Of Days" sync /:Igeyorhm:10FD:/
 2738.7 "Dark Orb" sync /:Lahabrea:10FC:/
-2745.9 "Dark Fire II" sync /:Lahabrea:10F7:/
+2745.9 "Dark Fire II" sync /:Lahabrea:10F7:/ window 20,20
 2750.4 "Dark Blizzard II" sync /:Igeyorhm:10F2:/
 2755.1 "Shadow Flare" sync /:Lahabrea:1381:/
 2765.1 "End Of Days" sync /:Igeyorhm:10FD:/
 2766.4 "Dark Orb" sync /:Lahabrea:10FC:/
-2771.5 "Sea Of Pitch" sync /:Lahabrea:10FB:/
+2771.5 "Sea Of Pitch" sync /:Lahabrea:10FB:/ window 20,20
 2778.6 "Dark Blizzard II" sync /:Igeyorhm:10F2:/
 2779.6 "Dark Orb" sync /:Lahabrea:10FC:/
 2786.8 "Dark Fire II" sync /:Lahabrea:10F7:/
@@ -377,13 +377,13 @@ hideall "--sync--"
 # Same as before, just sync to Lahabrea now
 2795.9 "Shadow Flare" sync /:Lahabrea:1381:/
 2807.2 "Dark Orb" sync /:Lahabrea:10FC:/
-2812.3 "Sea Of Pitch" sync /:Lahabrea:10FB:/
+2812.3 "Sea Of Pitch" sync /:Lahabrea:10FB:/ window 20,20
 2820.7 "Dark Orb" sync /:Lahabrea:10FC:/
 2827.8 "Dark Fire II" sync /:Lahabrea:10F7:/
 
 2837.0 "Shadow Flare" sync /:Lahabrea:1381:/
 2848.3 "Dark Orb" sync /:Lahabrea:10FC:/
-2853.4 "Sea Of Pitch" sync /:Lahabrea:10FB:/
+2853.4 "Sea Of Pitch" sync /:Lahabrea:10FB:/ window 20,20
 2861.8 "Dark Orb" sync /:Lahabrea:10FC:/
 2868.9 "Dark Fire II" sync /:Lahabrea:10F7:/ jump 2827.8
 

--- a/ui/raidboss/data/03-hw/dungeon/aetherochemical_research_facility.txt
+++ b/ui/raidboss/data/03-hw/dungeon/aetherochemical_research_facility.txt
@@ -308,7 +308,7 @@ hideall "--sync--"
 2382.5 "Shadow Flare" sync /:Lahabrea:1381:/
 2388.0 "Dark Blizzard II" sync /:Igeyorhm:10F2:/
 2393.6 "Dark Orb" sync /:Lahabrea:10FC:/
-2398.8 "Sea Of Pitch" sync /:Lahabrea:10FB:/ 20,20
+2398.8 "Sea Of Pitch" sync /:Lahabrea:10FB:/ window 20,20
 2402.4 "End Of Days" sync /:Igeyorhm:10FD:/
 2407.0 "Dark Orb" sync /:Lahabrea:10FC:/
 2414.2 "Dark Fire II" sync /:Lahabrea:10F7:/

--- a/ui/raidboss/data/03-hw/dungeon/aetherochemical_research_facility.txt
+++ b/ui/raidboss/data/03-hw/dungeon/aetherochemical_research_facility.txt
@@ -1,0 +1,411 @@
+hideall "--Reset--"
+hideall "--sync--"
+
+0.0 "--Reset--" sync /is no longer sealed/ window 10000,0
+
+#~~~~~~~~~~~~~~~~~~~#
+# Regula van Hydrus #
+#~~~~~~~~~~~~~~~~~~~#
+
+# -ii 10E1
+0.0 "--sync--" sync /Analysis and Proving will be sealed off/
+2.9 "--sync--" sync /:Regula van Hydrus:366/
+6.3 "Bastardbluss" sync /:Regula van Hydrus:10DA:/
+
+13.4 "Judgment" sync /:Regula van Hydrus:10DD:/
+18.6 "Judgment" sync /:Regula van Hydrus:10DE:/
+25.5 "Bastardbluss" sync /:Regula van Hydrus:10DA:/
+37.8 "Bastardbluss" sync /:Regula van Hydrus:10DA:/
+
+44.9 "Judgment" sync /:Regula van Hydrus:10DD:/
+50.1 "Judgment" sync /:Regula van Hydrus:10DE:/
+57.0 "Bastardbluss" sync /:Regula van Hydrus:10DA:/
+69.3 "Bastardbluss" sync /:Regula van Hydrus:10DA:/ jump 37.8
+
+76.4 "Judgment"
+81.6 "Judgment"
+88.5 "Bastardbluss"
+100.8 "Bastardbluss"
+
+# First turrets at HP < 80%
+150.0 "Magitek Turret" sync /:Regula van Hydrus:10E0:/ window 150,5
+152.4 "--sync--" sync /:Regula van Hydrus:10DF:/
+157.8 "Magitek Slug" sync /:Regula van Hydrus:10DB:/
+161.4 "Magitek Slug" sync /:Regula van Hydrus:10DB:/
+165.1 "Magitek Slug" sync /:Regula van Hydrus:10DB:/
+166.4 "--sync--" sync /:Regula van Hydrus:10DF:/
+171.6 "Magitek Slug" sync /:Regula van Hydrus:10DB:/
+175.5 "Magitek Slug" sync /:Regula van Hydrus:10DB:/
+179.2 "Magitek Slug" sync /:Regula van Hydrus:10DB:/
+180.5 "--sync--" sync /:Regula van Hydrus:10DF:/
+185.4 "Magitek Slug" sync /:Regula van Hydrus:10DB:/
+188.8 "Self-Detonate?" sync /:Magitek Turret I:10E3:/
+189.2 "Magitek Slug" sync /:Regula van Hydrus:10DB:/
+193.0 "Magitek Slug" sync /:Regula van Hydrus:10DB:/
+
+# Rotation resumes here whether or not turrets are successful
+199.3 "Bastardbluss" sync /:Regula van Hydrus:10DA:/ window 100,5
+202.4 "Bastardbluss" sync /:Regula van Hydrus:10DA:/
+209.7 "Judgment" sync /:Regula van Hydrus:10DD:/
+215.0 "Judgment" sync /:Regula van Hydrus:10DE:/
+
+221.9 "Bastardbluss" sync /:Regula van Hydrus:10DA:/ window 10,10
+234.2 "Bastardbluss" sync /:Regula van Hydrus:10DA:/
+237.5 "Bastardbluss" sync /:Regula van Hydrus:10DA:/
+244.7 "Judgment" sync /:Regula van Hydrus:10DD:/
+249.9 "Judgment" sync /:Regula van Hydrus:10DE:/ jump 215.0
+
+256.8 "Bastardbluss"
+269.1 "Bastardbluss"
+272.4 "Bastardbluss"
+279.6 "Judgment"
+284.8 "Judgment"
+
+# Second turrets at HP < 50%
+330.1 "Magitek Turret" sync /:Regula van Hydrus:10E0:/ window 150,5
+332.5 "--sync--" sync /:Regula van Hydrus:10DF:/
+337.8 "Magitek Slug" sync /:Regula van Hydrus:10DB:/
+340.7 "Aetherochemical Grenado" sync /:Magitek Turret II:10E2:/
+341.4 "Magitek Slug" sync /:Regula van Hydrus:10DB:/
+345.0 "Magitek Slug" sync /:Regula van Hydrus:10DB:/
+345.7 "Aetherochemical Grenado" sync /:Magitek Turret II:10E2:/
+346.2 "--sync--" sync /:Regula van Hydrus:10DF:/
+350.9 "Aetherochemical Grenado" sync /:Magitek Turret II:10E2:/
+351.4 "Magitek Slug" sync /:Regula van Hydrus:10DB:/
+355.1 "Magitek Slug" sync /:Regula van Hydrus:10DB:/
+356.1 "Aetherochemical Grenado" sync /:Magitek Turret II:10E2:/
+358.8 "Magitek Slug" sync /:Regula van Hydrus:10DB:/
+360.0 "--sync--" sync /:Regula van Hydrus:10DF:/
+361.3 "Aetherochemical Grenado" sync /:Magitek Turret II:10E2:/
+365.0 "Magitek Slug" sync /:Regula van Hydrus:10DB:/
+368.0 "Self-Detonate?" sync /:Magitek Turret (I|II):10E3:/
+368.7 "Magitek Slug" sync /:Regula van Hydrus:10DB:/
+372.5 "Magitek Slug" sync /:Regula van Hydrus:10DB:/
+373.7 "--sync--" sync /:Regula van Hydrus:10DF:/
+
+# Brief rotation block
+379.3 "Magitek Spread" sync /:Regula van Hydrus:10DC:/ window 150,5
+386.5 "Bastardbluss" sync /:Regula van Hydrus:10DA:/
+389.6 "Bastardbluss" sync /:Regula van Hydrus:10DA:/
+392.7 "Bastardbluss" sync /:Regula van Hydrus:10DA:/
+399.8 "Judgment" sync /:Regula van Hydrus:10DD:/
+405.0 "Judgment" sync /:Regula van Hydrus:10DE:/
+414.9 "Magitek Spread" sync /:Regula van Hydrus:10DC:/
+422.0 "Bastardbluss" sync /:Regula van Hydrus:10DA:/
+
+# More turrets, same as the second set
+# Clean loop to HP = 0
+429.1 "Magitek Turret" sync /:Regula van Hydrus:10E0:/ window 50,5 jump 330.1
+436.8 "Magitek Slug"
+439.7 "Aetherochemical Grenado"
+440.4 "Magitek Slug"
+444.0 "Magitek Slug"
+444.7 "Aetherochemical Grenado"
+449.9 "Aetherochemical Grenado"
+450.4 "Magitek Slug"
+454.1 "Magitek Slug"
+455.1 "Aetherochemical Grenado"
+457.8 "Magitek Slug"
+
+#~~~~~~~~~~~#
+# Harmachis #
+#~~~~~~~~~~~#
+
+# -ii 10ES
+# 10E8 is used at the beginning and end of all transformation sequences
+# It's not included at phase starts because each start is accompanied
+# by a unique version of the skill as well.
+
+1000.0 "--sync--" sync /Evaluation and Authentication will be sealed off/ window 1000,5
+
+# Cobra is immediate
+1001.4 "--sync--" sync /:Harmachis:366:/ window 2,2
+1008.6 "Weighing Of The Heart" sync /:Harmachis:10E8:/
+1011.7 "Steel Scales" sync /:Harmachis:10EA:/
+1014.8 "Hood Swing" sync /:Harmachis:10E9:/
+1019.0 "Weighing Of The Heart" sync /:Harmachis:138F:/
+
+# Base rotation after Cobra
+1024.6 "Chthonic Hush" sync /:Harmachis:10E7:/
+1033.3 "Riddle Of The Sphinx" sync /:Harmachis:10E4:/
+1040.3 "Chthonic Hush" sync /:Harmachis:10E7:/
+1049.0 "Riddle Of The Sphinx" sync /:Harmachis:10E4:/
+
+1056.0 "Chthonic Hush" sync /:Harmachis:10E7:/
+1064.7 "Riddle Of The Sphinx" sync /:Harmachis:10E4:/
+1071.7 "Chthonic Hush" sync /:Harmachis:10E7:/
+1080.4 "Riddle Of The Sphinx" sync /:Harmachis:10E4:/ jump 1049.0
+
+1087.4 "Chthonic Hush"
+1096.1 "Riddle Of The Sphinx"
+1103.1 "Chthonic Hush"
+
+# Naga form at HP < 80%
+1133.5 "Weighing Of The Heart" sync /:Harmachis:ECE:/ window 130,5
+1139.6 "Petrifaction" sync /:Harmachis:10EB:/
+1142.8 "Circle Of Flames x2" # Same ID for both, syncing breaks things
+1145.9 "Weighing Of The Heart" sync /:Harmachis:138F:/
+
+# Modified rotation after Naga
+1151.5 "Chthonic Hush" sync /:Harmachis:10E7:/ window 10,10
+1160.1 "Riddle Of The Sphinx" sync /:Harmachis:10E4:/
+1169.4 "Ka" sync /:Harmachis:10E6:/
+
+1177.0 "Chthonic Hush" sync /:Harmachis:10E7:/ window 10,10
+1185.6 "Riddle Of The Sphinx" sync /:Harmachis:10E4:/
+1194.9 "Ka" sync /:Harmachis:10E6:/ jump 1169.4
+
+1202.5 "Chthonic Hush"
+1211.1 "Riddle Of The Sphinx"
+1220.4 "Ka"
+1228.0 "Chthonic Hush"
+
+# Machina at HP < 50%
+1250.0 "Weighing Of The Heart" sync /:Harmachis:ED0:/ window 250,5
+1253.2 "Inertia Stream" sync /:Harmachis:10ED:/
+1258.3 "Ballistic Missile 1" sync /:Harmachis:10EE:/
+1259.3 "Ballistic Missile 2" sync /:Harmachis:12A3:/
+1260.4 "Ballistic Missile 3" sync /:Harmachis:10EF:/
+1265.6 "Gaseous Bomb" sync /:Harmachis:10F0:/
+1269.7 "Weighing Of The Heart" sync /:Harmachis:138F:/
+
+# Rotation resumes to HP = 0
+# Single rotation block is alternated with random form shift blocks
+1275.2 "Chthonic Hush" sync /:Harmachis:10E7:/
+1283.8 "Riddle Of The Sphinx" sync /:Harmachis:10E4:/
+1293.1 "Ka" sync /:Harmachis:10E6:/
+1300.4 "Weighing Of The Heart"
+1300.4 "--sync--" sync /:Harmachis:ED0:/ jump 1250.0 # Machina
+1300.4 "--sync--" sync /:Harmachis:10E8:/ jump 1350.0 # Cobra
+1300.4 "--sync--" sync /:Harmachis:ECE:/ jump 1400.0 # Naga
+1303.5 "Steel Scales?"
+1303.6 "Inertia Stream?"
+1306.5 "Petrifaction?"
+
+# Random shift Cobra
+1350.0 "Weighing Of The Heart" sync /:Harmachis:10E8:/
+1353.3 "Steel Scales" sync /:Harmachis:10EA:/
+1356.5 "Hood Swing" sync /:Harmachis:10E9:/
+1360.5 "Weighing Of The Heart" sync /:Harmachis:138F:/
+1366.2 "Chthonic Hush" sync /:Harmachis:10E7:/ window 10,10 jump 1275.2
+1374.8 "Riddle Of The Sphinx"
+1384.1 "Ka"
+1391.4 "Weighing Of The Heart"
+1394.5 "Steel Scales?"
+1394.6 "Inertia Stream?"
+1397.5 "Petrifaction?"
+
+# Random shift Naga
+1400.0 "Weighing Of The Heart" sync /:Harmachis:ECE:/
+1406.1 "Petrifaction" sync /:Harmachis:10EB:/
+1409.3 "Circle Of Flames x2" # Same ID for both, syncing breaks things
+1412.4 "Weighing Of The Heart" sync /:Harmachis:138F:/
+1418.0 "Chthonic Hush" sync /:Harmachis:10E8:/ window 10,10 jump 1275.2
+1426.6 "Riddle Of The Sphinx"
+1435.9 "Ka"
+1443.2 "Weighing Of The Heart"
+1446.3 "Steel Scales?"
+1446.4 "Inertia Stream?"
+1449.3 "Petrifaction?"
+
+#~~~~~~~~~~~~~~~~~~~~~~~~#
+# Igeyorhm and LahabreaD #
+#~~~~~~~~~~~~~~~~~~~~~~~~#
+
+# -ii 10F1 10F3 10F6 10F8 10F9 12DE
+# We can't sync to the zone seal message because it's a two-part battle
+
+2000.5 "--sync--" sync /:Igeyorhm:10F1:/ window 2000.5,0
+2008.6 "Dark Orb" sync /:Igeyorhm:10FC:/
+
+2009.0 "End Of Days" sync /:Lahabrea:10FD:/
+2015.8 "Dark Orb" sync /:Igeyorhm:10FC:/
+2020.9 "Sea Of Pitch" sync /:Igeyorhm:10FB:/
+2023.4 "End Of Days" sync /:Lahabrea:10FD:/
+2024.5 "Sea Of Pitch" sync /:Igeyorhm:12DE:/
+2029.0 "Dark Orb" sync /:Igeyorhm:10FC:/
+2037.2 "Dark Orb" sync /:Igeyorhm:10FC:/
+
+2037.7 "End Of Days" sync /:Lahabrea:10FD:/
+2044.3 "Dark Orb" sync /:Igeyorhm:10FC:/
+2049.5 "Sea Of Pitch" sync /:Igeyorhm:10FB:/ window 15,15
+2052.2 "End Of Days" sync /:Lahabrea:10FD:/
+2057.7 "Dark Orb" sync /:Igeyorhm:10FC:/
+2066.0 "Dark Orb" sync /:Igeyorhm:10FC:/ jump 2037.2
+
+2066.5 "End Of Days"
+2073.1 "Dark Orb"
+2078.3 "Sea Of Pitch"
+2081.0 "End Of Days"
+2086.5 "Dark Orb"
+2094.8 "Dark Orb"
+
+# Special attack at HP < 75%
+2100.0 "Blizzard Sphere" sync /:Igeyorhm:10F5:/ window 100,5
+2105.2 "Blizzard Burst" sync /:Blizzardsphere:10FE:/
+2108.3 "Fire Burst" sync /:Firesphere:10FF:/
+2115.4 "Blizzard Burst" sync /:Blizzardsphere:10FE:/
+2118.5 "Fire Burst" sync /:Firesphere:10FF:/
+
+# Modified rotation to HP < 50%
+2122.6 "Dark Blizzard II" sync /:Igeyorhm:10F2:/ window 20,20
+2123.9 "End Of Days" sync /:Lahabrea:10FD:/
+2131.9 "Shadow Flare" sync /:Igeyorhm:10FA:/
+2137.4 "Dark Fire II" sync /:Lahabrea:10F7:/
+2143.1 "Dark Orb" sync /:Igeyorhm:10FC:/
+2148.2 "Sea Of Pitch" sync /:Igeyorhm:10FB:/ window 20,20
+2151.8 "End Of Days" sync /:Lahabrea:10FD:/
+2156.4 "Dark Orb" sync /:Igeyorhm:10FC:/
+2163.7 "Dark Blizzard II" sync /:Igeyorhm:10F2:/ window 20,20
+2165.3 "Dark Fire II" sync /:Lahabrea:10F7:/
+2173.0 "Shadow Flare" sync /:Igeyorhm:10FA:/
+2179.8 "End Of Days" sync /:Lahabrea:10FD:/
+2184.2 "Dark Orb" sync /:Igeyorhm:10FC:/
+2189.3 "Sea Of Pitch" sync /:Igeyorhm:10FB:/ window 20,20
+2193.3 "Dark Fire II" sync /:Lahabrea:10F7:/
+2197.6 "Dark Orb" sync /:Igeyorhm:10FC:/
+
+2204.8 "Dark Blizzard II" sync /:Igeyorhm:10F2:/ jump 2122.6
+2206.1 "End Of Days"
+2214.1 "Shadow Flare"
+2219.6 "Dark Fire II"
+2225.3 "Dark Orb"
+2230.4 "Sea Of Pitch"
+2234.0 "End Of Days"
+
+# Ascians swap roles at Igeyorhm HP <= 50%
+
+2250.0 "End Of Days" sync /:Igeyorhm:10FD:/ window 250,5
+2255.1 "Dark Orb" sync /:Lahabrea:10FC:/
+2260.2 "Sea Of Pitch" sync /:Lahabrea:10FB:/
+2264.5 "End Of Days" sync /:Igeyorhm:10FD:/
+2267.3 "Dark Fire II" sync /:Lahabrea:10F7:/ window 20,20
+2274.4 "Dark Orb" sync /:Lahabrea:10FC:/
+
+2278.9 "End Of Days" sync /:Igeyorhm:10FD:/
+2284.0 "Dark Orb" sync /:Lahabrea:10FC:/
+2289.1 "Sea Of Pitch" sync /:Lahabrea:10FB:/
+2293.4 "End Of Days" sync /:Igeyorhm:10FD:/
+2296.2 "Dark Fire II" sync /:Lahabrea:10F7:/ window 20,20
+2303.3 "Dark Orb" sync /:Lahabrea:10FC:/ jump 2274.4
+
+2307.8 "End Of Days"
+2312.9 "Dark Orb"
+2318.0 "Sea Of Pitch"
+2322.3 "End Of Days"
+2325.1 "Dark Fire II"
+2332.2 "Dark Orb"
+
+# Special attack at HP < 75%
+2350.0 "Permafrost" sync /:Igeyorhm:10F4:/ window 350,5
+2354.0 "Dark Fire II" sync /:Lahabrea:10F7:/
+2359.1 "Dark Fire II" sync /:Lahabrea:10F7:/
+2364.2 "Dark Fire II" sync /:Lahabrea:10F7:/
+2373.4 "Dark Fire II" sync /:Lahabrea:10F7:/
+
+# Modified rotation to HP < 50%
+2374.6 "End Of Days" sync /:Igeyorhm:10FD:/ window 30,15
+2382.5 "Shadow Flare" sync /:Lahabrea:1381:/
+2388.0 "Dark Blizzard II" sync /:Igeyorhm:10F2:/
+2393.6 "Dark Orb" sync /:Lahabrea:10FC:/
+2398.8 "Sea Of Pitch" sync /:Lahabrea:10FB:/ 20,20
+2402.4 "End Of Days" sync /:Igeyorhm:10FD:/
+2407.0 "Dark Orb" sync /:Lahabrea:10FC:/
+2414.2 "Dark Fire II" sync /:Lahabrea:10F7:/
+2415.8 "Dark Blizzard II" sync /:Igeyorhm:10F2:/
+2423.2 "Shadow Flare" sync /:Lahabrea:1381:/ window 20,20
+2430.2 "End Of Days" sync /:Igeyorhm:10FD:/
+2434.2 "Dark Orb" sync /:Lahabrea:10FC:/
+2439.4 "Sea Of Pitch" sync /:Lahabrea:10FB:/
+2443.6 "Dark Blizzard II" sync /:Igeyorhm:10F2:/
+2447.5 "Dark Orb" sync /:Lahabrea:10FC:/
+2454.7 "Dark Fire II" sync /:Lahabrea:10F7:/
+
+2457.9 "End Of Days" sync /:Igeyorhm:10FD:/ jump 2374.6
+2465.8 "Shadow Flare"
+2471.3 "Dark Blizzard II"
+2476.9 "Dark Orb"
+2482.1 "Sea Of Pitch"
+2485.7 "End Of Days"
+
+#~~~~~~~~~~~~~~#
+# Ascian Prime #
+#~~~~~~~~~~~~~~#
+
+# -ii 1104 1108 -ic "Aetherial Tear" "Chaosphere"
+# We can't sync to the zone seal message because it's a two-part battle
+
+3002.3 "--sync--" sync /:Ascian Prime:1100:/ window 3003,2
+3005.8 "Height Of Chaos" sync /:Ascian Prime:1101:/
+3013.0 "Ancient Eruption" sync /:Ascian Prime:1103:/
+3022.1 "Shadow Flare" sync /:Ascian Prime:1109:/
+3028.2 "Height Of Chaos" sync /:Ascian Prime:1101:/
+
+3038.0 "Height Of Chaos" sync /:Ascian Prime:1101:/
+3045.2 "Ancient Eruption" sync /:Ascian Prime:1103:/
+3054.3 "Shadow Flare" sync /:Ascian Prime:1109:/
+3060.4 "Height Of Chaos" sync /:Ascian Prime:1101:/ jump 3028.2
+
+3070.2 "Height Of Chaos"
+3077.4 "Ancient Eruption"
+3086.5 "Shadow Flare"
+3092.6 "Height Of Chaos"
+
+# Intermission 1 at HP < 80%
+3100.0 "--sync--" sync /03:........:Added new combatant Firesphere/ window 100,5
+
+3110.0 "Ancient Circle Appears"
+3115.1 "Ancient Circle" sync /:Ascian Prime:1102:/
+3123.1 "Annihilation" sync /:Ascian Prime:110A:/ window 25,5
+3132.1 "Ancient Eruption" sync /:Ascian Prime:1103:/
+3147.3 "Universal Manipulation" sync /:Ascian Prime:1105:/
+
+3156.4 "Height Of Chaos" sync /:Ascian Prime:1101:/ window 50,5
+3163.5 "Entropic Flame" sync /:Ascian Prime:1107:/
+3168.6 "Height Of Chaos" sync /:Ascian Prime:1101:/
+3175.7 "Ancient Eruption" sync /:Ascian Prime:1103:/
+3184.8 "Shadow Flare" sync /:Ascian Prime:1109:/
+
+3194.0 "Height Of Chaos" sync /:Ascian Prime:1101:/
+3201.1 "Entropic Flame" sync /:Ascian Prime:1107:/ window 30,30
+3206.2 "Height Of Chaos" sync /:Ascian Prime:1101:/
+3213.3 "Ancient Eruption" sync /:Ascian Prime:1103:/
+3222.4 "Shadow Flare" sync /:Ascian Prime:1109:/ jump 3184.8
+
+3231.6 "Height Of Chaos"
+3238.7 "Entropic Flame"
+3243.8 "Height Of Chaos"
+3250.9 "Ancient Eruption"
+3260.0 "Shadow Flare"
+
+# Intermission 2 at HP < 40%
+3300.0 "--sync--" sync /03:........:Added new combatant Firesphere/ window 200,5
+
+3304.6 "Ancient Circle Appears"
+3309.7 "Ancient Circle" sync /:Ascian Prime:1102:/
+3314.7 "Ancient Circle Appears"
+3319.8 "Ancient Circle" sync /:Ascian Prime:1102:/
+3322.8 "Annihilation" sync /:Ascian Prime:110A:/ window 30,30
+3331.8 "Ancient Eruption" sync /:Ascian Prime:1103:/
+3347.0 "Universal Manipulation" sync /:Ascian Prime:1105:/
+
+3356.2 "Height Of Chaos" sync /:Ascian Prime:1101:/ window 50,5
+3363.3 "Entropic Flame" sync /:Ascian Prime:1107:/
+3368.5 "Height Of Chaos" sync /:Ascian Prime:1101:/
+3375.6 "Ancient Eruption" sync /:Ascian Prime:1103:/ window 30,30
+3384.8 "Shadow Flare" sync /:Ascian Prime:1109:/
+3390.9 "Height Of Chaos x3" duration 5.0
+
+3402.7 "Height Of Chaos" sync /:Ascian Prime:1101:/
+3409.8 "Entropic Flame" sync /:Ascian Prime:1107:/
+3415.0 "Height Of Chaos" sync /:Ascian Prime:1101:/
+3422.1 "Ancient Eruption" sync /:Ascian Prime:1103:/ window 30,30
+3431.3 "Shadow Flare" sync /:Ascian Prime:1109:/
+3437.4 "Height Of Chaos x3" duration 5.0
+
+# Jumping from a following block to avoid sync issues with Height of Chaos x3
+3449.2 "Height Of Chaos" sync /:Ascian Prime:1101:/ jump 3390.9
+3456.3 "Entropic Flame"
+3461.5 "Height Of Chaos"
+3468.6 "Ancient Eruption"
+3477.8 "Shadow Flare"

--- a/ui/raidboss/data/manifest.txt
+++ b/ui/raidboss/data/manifest.txt
@@ -31,6 +31,8 @@
 02-arr/trial/titan_ex.txt
 03-hw/alliance/dun_scaith.js
 03-hw/alliance/dun_scaith.txt
+03-hw/dungeon/aetherochemical_research_facility.js
+03-hw/dungeon/aetherochemical_research_facility.txt
 03-hw/dungeon/fractal_continuum.js
 03-hw/dungeon/fractal_continuum.txt
 03-hw/dungeon/gubal_library_hard.js


### PR DESCRIPTION
This one's not quite as good as I would like, but I'm not sure what the best way to resolve that is. No issues with Oopsy or triggers, but unfortunately the Ascian Twins timeline is messy. Because it's a two-enemy boss, and the bosses are on separate + unequal timer loops, each phase will desync the longer it goes. Apologies for the wall of text (this is from Lahabrea, HP < 75%, but it's representative of both bosses' HP < 75% phases:)
```
2354.113: Matched entry: 2354.0 Dark Fire II (-0.113s)
2359.195: Matched entry: 2359.1 Dark Fire II (-0.095s)
2364.269: Matched entry: 2364.2 Dark Fire II (-0.069s)
2373.388: Matched entry: 2373.4 Dark Fire II (+0.012s)
2374.601: Matched entry: 2374.6 End Of Days (-0.001s)
2382.512: Matched entry: 2382.5 Shadow Flare (-0.012s)
2388.077: Matched entry: 2388.0 Dark Blizzard II (-0.077s)
2393.606: Matched entry: 2393.6 Dark Orb (-0.006s)
2398.814: Matched entry: 2398.8 Sea Of Pitch (-0.014s)
2402.372: Matched entry: 2402.4 End Of Days (+0.028s)
2406.980: Matched entry: 2407.0 Dark Orb (+0.020s)
2414.231: Matched entry: 2414.2 Dark Fire II (-0.031s)
2415.847: Matched entry: 2415.8 Dark Blizzard II (-0.047s)
2423.204: Matched entry: 2423.2 Shadow Flare (-0.004s)
2430.146: Matched entry: 2430.2 End Of Days (+0.054s)
2434.405: Matched entry: 2434.2 Dark Orb (-0.205s)
2439.410: Matched entry: 2439.4 Sea Of Pitch (-0.010s)
2443.429: Matched entry: 2443.6 Dark Blizzard II (+0.171s)
2447.751: Matched entry: 2447.5 Dark Orb (-0.251s)
2454.785: Matched entry: 2454.7 Dark Fire II (-0.085s)
2457.748: Matched entry: 2457.9 End Of Days (+0.152s)
    Jumping to 2374.600
2380.692: Matched entry: 2382.5 Shadow Flare (+1.808s)
2389.947: Matched entry: 2388.0 Dark Blizzard II (-1.947s)
2391.811: Matched entry: 2393.6 Dark Orb (+1.789s)
2398.845: Matched entry: 2398.8 Sea Of Pitch (-0.045s)
2404.236: Matched entry: 2402.4 End Of Days (-1.836s)
2405.165: Matched entry: 2407.0 Dark Orb (+1.835s)
2414.191: Matched entry: 2414.2 Dark Fire II (+0.009s)
2417.699: Matched entry: 2415.8 Dark Blizzard II (-1.899s)
2421.451: Matched entry: 2423.2 Shadow Flare (+1.749s)
2431.966: Matched entry: 2430.2 End Of Days (-1.766s)
2432.598: Matched entry: 2434.2 Dark Orb (+1.602s)
2439.452: Matched entry: 2439.4 Sea Of Pitch (-0.052s)
2445.261: Matched entry: 2443.6 Dark Blizzard II (-1.661s)
2445.889: Matched entry: 2447.5 Dark Orb (+1.611s)
2454.735: Matched entry: 2454.7 Dark Fire II (-0.035s)
2459.559: Matched entry: 2457.9 End Of Days (-1.659s)
    Jumping to 2374.600
2388.087: Matched entry: 2388.0 Dark Blizzard II (-0.087s)
    Missed sync: Shadow Flare at 2382.5 (last seen at 2378.816)
2402.426: Matched entry: 2402.4 End Of Days (-0.026s)
    Missed sync: Dark Orb at 2393.6 (last seen at 2389.931)
    Missed sync: Sea Of Pitch at 2398.8 (last seen at 2395.124)
2415.717: Matched entry: 2415.8 Dark Blizzard II (+0.083s)
    Missed sync: Dark Orb at 2407.0 (last seen at 2403.225)
    Missed sync: Dark Fire II at 2414.2 (last seen at 2410.422)
2419.543: Matched entry: 2423.2 Shadow Flare (+3.657s)
2434.337: Matched entry: 2434.2 Dark Orb (-0.137s)
    Missed sync: End Of Days at 2430.2 (last seen at 2433.7889999999998)
2439.401: Matched entry: 2439.4 Sea Of Pitch (-0.001s)
2447.522: Matched entry: 2447.5 Dark Orb (-0.022s)
    Missed sync: Dark Blizzard II at 2443.6 (last seen at 2447.068)
2454.685: Matched entry: 2454.7 Dark Fire II (+0.015s)
```

As you can see, it's mostly clean on the first loop, and then it oscillates wildly on timings, but ability order is the same. For now, I've put aggressive sync windows inside each block, so it will sort of tell the user what will happen, but it's really choppy and not-fun. Is there a better way to handle this situation, or is there an easy solution that's evading me at the moment?

Other than that, this package is ready. There was a little more manual translation work than I was expecting because this instance isn't on FFLogs, so I had to pull down the translations from XIVAPI instead. That wasn't exceedingly difficult to script, but if there are tools for that I overlooked in `translate_fight` or `check_translation`, I would much prefer that over what I did, since it was more handwork than I would like. The popup text is obviously incomplete, I just tossed in what I could find from a lazy look through the repository.