### PR TITLE
Add remaining timers for TEA

### DIFF
--- a/ui/raidboss/data/05-shb/ultimate/the_epic_of_alexander.txt
+++ b/ui/raidboss/data/05-shb/ultimate/the_epic_of_alexander.txt
@@ -163,9 +163,8 @@ hideall "Liquid Gaol"
 
 ### Transition 3: DPS Checks
 699.4 "Summon Alexander" sync /:Alexander Prime:4A55:/
-705.7 "J Storm + Waves x12" sync /:Brute Justice:4876:/ duration 38
+705.7 "J Storm + Waves x16" sync /:Brute Justice:4876:/ duration 52
 731.7 "Eternal Darkness Enrage" sync /:Cruise Chaser:4875:/
-750.0 "Brute Justice Enrage" #Estimated
 771.9 "Divine Judgment Enrage" sync /:Alexander Prime:4879:/
 787.3 "Divine Judgment" sync /:Alexander:487A:/
 772.0 "Down for the Count" duration 66

--- a/ui/raidboss/data/05-shb/ultimate/the_epic_of_alexander.txt
+++ b/ui/raidboss/data/05-shb/ultimate/the_epic_of_alexander.txt
@@ -63,94 +63,92 @@ hideall "Liquid Gaol"
 217.7 "Hawk Blaster"
 218.3 "Super Blassty Charge" sync /:Cruise Chaser:4B4F:/
 219.9 "Middle Blaster"
-221.5 "Alpha Sword" sync /:Cruise Chaser:4834:/
-223.3 "Super Blassty Charge" sync /:Cruise Chaser:4B4F:/
+221.4 "Alpha Sword" sync /:Cruise Chaser:4834:/
+222.9 "Super Blassty Charge" sync /:Cruise Chaser:4B4F:/
 
 ### Phase 2: Cruise Chaser and Brute Justice
-227.3 "J Kick" sync /:Brute Justice:4854:/
-239.1 "Whirlwind" sync /:Cruise Chaser:49C2:/
-242.1 "Judgment Nisi" sync /:Brute Justice:483E:/
-249.3 "Link-Up" sync /:Brute Justice:483F:/
-257.4 "Optical Sight" sync /:Cruise Chaser:482F:/
-258.3 "Chakrams" sync /:Steam Chakram:4855:/
-261.5 "Hawk Blaster" sync /:(Liquid Rage|Living Liquid):4830:/
-263.5 "Photon" sync /:Cruise Chaser:4836:/
-270.6 "Spin Crusher" sync /:Cruise Chaser:4A72:/
-278.2 "Crashing/Punishing Wave and Thunders" sync /:(Liquid Rage|Living Liquid):484[1-3]:/
-289.7 "Earth Missile" sync /:(Liquid Rage|Living Liquid):484E:/
-291.7 "Hidden Minefield" sync /:(Liquid Rage|Living Liquid):4851:/
-293.8 "Enumeration" sync /:(Liquid Rage|Living Liquid):4850:/
-298.2 "Crashing/Punishing Wave and Thunders" sync /:(Liquid Rage|Living Liquid):484[1-3]:/
-302.8 "Drainage" sync /:(Liquid Rage|Living Liquid):4844:/
-310.6 "Crashing/Punishing Wave and Thunders" sync /:(Liquid Rage|Living Liquid):484[1-3]:/
-317.3 "Limit Cut" sync /:Cruise Chaser:4833:/
-317.9 "--Cruise Chaser Invincible--" duration 6.3
-319.3 "Flamethrower" sync /:Brute Justice:4845:/
-331.2 "Whirlwind" sync /:Cruise Chaser:49C2:/
-340.2 "Crashing/Punishing Wave and Thunders" sync /:(Liquid Rage|Living Liquid):484[1-3]:/
-358.4 "Propeller Wind" sync /:Cruise Chaser:4832:/
-360.3 "Gavel" sync /:Brute Justice:483C:/
-363.3 "Final Sentence" sync /:You:483D:/
+226.1 "J Kick" sync /:Brute Justice:4854:/
+238.3 "Whirlwind" sync /:Cruise Chaser:49C2:/
+241.3 "Judgment Nisi" sync /:Brute Justice:483E:/
+247.4 "Link-Up" sync /:Brute Justice:483F:/
+255.4 "Optical Sight" sync /:Cruise Chaser:482F:/
+256.2 "Chakrams" sync /:Steam Chakram:4855:/
+260.6 "Hawk Blaster" sync /:(Liquid Rage|Living Liquid):4830:/
+262.5 "Photon" sync /:Cruise Chaser:4836:/
+272.7 "Spin Crusher" sync /:Cruise Chaser:4A72:/
+277.3 "Crashing/Punishing Wave and Thunders" sync /:(Liquid Rage|Living Liquid):484[1-3]:/
+288.6 "Earth Missile" sync /:(Liquid Rage|Living Liquid):484E:/
+290.6 "Hidden Minefield" sync /:(Liquid Rage|Living Liquid):4851:/
+292.7 "Enumeration" sync /:(Liquid Rage|Living Liquid):4850:/
+302.9 "Drainage" #sync /:(Liquid Rage|Living Liquid):4844:/
+306.7 "Crashing/Punishing Wave and Thunders" sync /:(Liquid Rage|Living Liquid):484[1-3]:/
+313.5 "Limit Cut" sync /:Cruise Chaser:4833:/
+314.1 "--Cruise Chaser Invincible--" duration 6.3
+315.5 "Flamethrower" sync /:Brute Justice:4845:/
+327.6 "Whirlwind" sync /:Cruise Chaser:49C2:/
+336.2 "Crashing/Punishing Wave and Thunders" sync /:(Liquid Rage|Living Liquid):484[1-3]:/
+354.5 "Propeller Wind" sync /:Cruise Chaser:4832:/
+356.5 "Gavel" sync /:Brute Justice:483C:/
+366.7 "Final Sentence" sync /:You:483D:/
 370.6 "Photon" sync /:Cruise Chaser:4836:/
-378.7 "Double Rocket Punch" sync /:Brute Justice:4847:/
-386.0 "Super Jump" sync /:Brute Justice:484A:/
-389.0 "Apocalyptic Ray x5" duration 4.3
-399.0 "Whirlwind" sync /:Cruise Chaser:4B4F:/
-407.1 "Whirlwind" sync /:Cruise Chaser:4B4F:/
-415.7 "Final Sentence" sync /:Brute Justice:4856:/
-425.7 "Eternal Darkness Enrage" sync /:Cruise Chaser:483A:/
+374.8 "Double Rocket Punch" sync /:Brute Justice:4847:/
+382.1 "Super Jump" sync /:Brute Justice:484A:/
+384.4 "Apocalyptic Ray x5" duration 4.4
+395.0 "Whirlwind" sync /:Cruise Chaser:4B4F:/
+403.1 "Whirlwind" sync /:Cruise Chaser:4B4F:/
+413.7 "Final Sentence" sync /:Brute Justice:4856:/
+423.7 "Eternal Darkness Enrage" sync /:Cruise Chaser:483A:/
 
 ### Transition 2: Cruise Chaser, Brute Justice and Alexander Prime
 500.0 "Temporal Stasis" sync /:Alexander Prime:485A:/ window 500,0
 503.1 "Surety and Severity" sync /:Liquid Rage:486[13]:/
 505.1 "Alpha Sword" sync /:Cruise Chaser:486B:/
-505.2 "Flamethrower 1" sync /:Brute Justice:486C:/
-506.3 "Alpha Sword" #sync /:Cruise Chaser:486B:/
+505.2 "Flamethrower 1" #sync /:Brute Justice:486C:/
+506.1 "Alpha Sword" #sync /:Cruise Chaser:486B:/
 507.4 "Flamethrower 2" #sync /:Brute Justice:486C:/
-507.5 "Alpha Sword" #sync /:Cruise Chaser:486B:/
-521.8 "Chastenning Heat" sync /:Alexander Prime:4A80:/
-525.0 "Divine Spear 1" sync /:Alexander Prime:4A82:/
-527.1 "Divine Spear 2" #sync /:Alexander Prime:4A82:/
-529.2 "Divine Spear 3" #sync /:Alexander Prime:4A82:/
+507.2 "Alpha Sword" #sync /:Cruise Chaser:486B:/
+521.5 "Chastenning Heat" sync /:Alexander Prime:4A80:/
+524.6 "Divine Spear 1" sync /:Alexander Prime:4A82:/
+526.7 "Divine Spear 2" #sync /:Alexander Prime:4A82:/
+528.8 "Divine Spear 3" #sync /:Alexander Prime:4A82:/
 
 ### Phase 3 Part 1 - Inception Formation
-538.4 "Inception Formation" sync /:Alexander Prime:486F:/
-552.9 "Judgment Crystal" sync /:Alexander Prime:485B:/
-554.0 "Aetheroplasm" sync /:Plasmasphere:4872:/
-554.9 "Electromagnetic Burst" sync /:Liquid Rage:4874:/
-557.3 "Aetheroplasm" sync /:Plasmasphere:4872:/
-558.9 "Judgment Crystal + True Heart" sync /:Liquid Rage:485C:/ duration 6
-560.2 "Aetheroplasm" sync /:Plasmasphere:4872:/
-570.3 "Flamethrower 1" sync /:Brute Justice:486C:/
-572.5 "Flamethrower 2" #sync /:Brute Justice:486C:/
-574.7 "Flamethrower 3" #sync /:Brute Justice:486C:/
-582.0 "Inception" sync /:Alexander Prime:485E:/
-588.2 "Tetrashatter" sync /:Judgment Crystal:485D:/
-590.1 "Surety, Solidarity and Severity" sync /:Liquid Rage:486[1-3]:/
-590.4 "Sacrament" sync /:Alexander Prime:485F:/
-596.4 "Alpha Sword" sync /:Cruise Chaser:486B:/
+537.9 "Inception Formation" sync /:Alexander Prime:486F:/
+552.4 "Judgment Crystal" sync /:Alexander Prime:485B:/
+556.6 "Aetheroplasm" sync /:Plasmasphere:4872:/
+557.5 "Electromagnetic Burst" sync /:Liquid Rage:4874:/
+558.2 "Judgment Crystal + True Heart" sync /:Liquid Rage:485C:/ duration 6
+560.8 "Aetheroplasm" sync /:Plasmasphere:4872:/
+569.5 "Flamethrower 1" sync /:Brute Justice:486C:/
+571.7 "Flamethrower 2" #sync /:Brute Justice:486C:/
+573.8 "Flamethrower 3" #sync /:Brute Justice:486C:/
+581.0 "Inception" sync /:Alexander Prime:485E:/
+587.2 "Tetrashatter" sync /:Judgment Crystal:485D:/
+589.1 "Surety, Solidarity and Severity" sync /:Liquid Rage:486[1-3]:/
+589.4 "Sacrament" sync /:Alexander Prime:485F:/
+595.3 "Alpha Sword" sync /:Cruise Chaser:486B:/
+596.4 "Alpha Sword" #sync /:Cruise Chaser:486B:/
 597.5 "Alpha Sword" #sync /:Cruise Chaser:486B:/
-598.6 "Alpha Sword" #sync /:Cruise Chaser:486B:/
-599.8 "Super Jump" sync /:Brute Justice:484A:/
-612.1 "Chastenning Heat" sync /:Alexander Prime:4A80:/
-617.3 "Divine Spear 1" sync /:Alexander Prime:4A82:/
-619.4 "Divine Spear 2" #sync /:Alexander Prime:4A82:/
-621.5 "Divine Spear 3" #sync /:Alexander Prime:4A82:/
+598.3 "Super Jump" sync /:Brute Justice:484A:/
+610.9 "Chastenning Heat" sync /:Alexander Prime:4A80:/
+616.0 "Divine Spear 1" sync /:Alexander Prime:4A82:/
+618.1 "Divine Spear 2" #sync /:Alexander Prime:4A82:/
+620.2 "Divine Spear 3" #sync /:Alexander Prime:4A82:/
 
 ### Phase 3 Part 2 - Wormhole Formation
-630.7 "Wormhole Formation" sync /:Alexander Prime:486E:/
-639.2 "Limit Cut" sync /:Cruise Chaser:4B0F:/
-642.3 "Link-Up" sync /:Brute Justice:483F:/
-645.4 "Void Of Repentance" sync /:Alexander Prime:4866:/
-651.3 "Chakrams" sync /:Steam Chakram:4855:/
-652.7 "Super Jump" sync /:Brute Justice:484A:/
-652.8 "Alpha Sword" sync /:Cruise Chaser:4834:/
-654.3 "Super Blassty Charge" sync /:Cruise Chaser:49C3:/
-655.9 "Apocalyptic Ray x5" duration 4.3
-657.2 "Alpha Sword" #sync /:Cruise Chaser:4834:/
-657.6 "Repentance" sync /:Liquid Rage:4869:/
-657.7 "Confession" sync /:Liquid Rage:486A:/
-658.8 "Super Blassty Charge" sync /:Cruise Chaser:49C3:/
-660.1 "Sacrament" sync /:Alexander Prime:4857:/
-662.5 "Alpha Sword" #sync /:Cruise Chaser:4834:/
-662.9 "Confession" sync /:Liquid Rage:486A:/
+629.3 "Wormhole Formation" sync /:Alexander Prime:486E:/
+637.7 "Limit Cut" sync /:Cruise Chaser:4B0F:/
+640.7 "Link-Up" sync /:Brute Justice:483F:/
+643.7 "Void Of Repentance" sync /:Alexander Prime:4866:/
+649.5 "Chakrams" sync /:Steam Chakram:4855:/
+650.9 "Super Jump" sync /:Brute Justice:484A:/
+650.9 "Alpha Sword" sync /:Cruise Chaser:4834:/
+652.4 "Super Blassty Charge" sync /:Cruise Chaser:49C3:/
+653.3 "Apocalyptic Ray x5" duration 5
+655.2 "Alpha Sword" #sync /:Cruise Chaser:4834:/
+655.6 "Repentance" sync /:Liquid Rage:4869:/
+655.7 "Confession" sync /:Liquid Rage:486A:/
+656.7 "Super Blassty Charge" sync /:Cruise Chaser:49C3:/
+657.9 "Sacrament" sync /:Alexander Prime:4857:/
+659.5 "Alpha Sword" #sync /:Cruise Chaser:4834:/
+659.9 "Confession" sync /:Liquid Rage:486A:/

--- a/ui/raidboss/data/05-shb/ultimate/the_epic_of_alexander.txt
+++ b/ui/raidboss/data/05-shb/ultimate/the_epic_of_alexander.txt
@@ -27,7 +27,7 @@ hideall "Liquid Gaol"
 71.9 "Protean Wave 2" sync /:Living Liquid:4823:/
 74.9 "Sluice" sync /:Liquid Rage:49B1:/
 75.0 "Protean Wave 3" sync /:Living Liquid:4823:/
-81.1 "Splash x6" sync /:Living Liquid:49B2:/ window 3,0
+81.1 "Splash x6" duration 5.6
 86.6 "Drainage" sync /:Liquid Rage:4827:/
 89.1 "Hand of Pain" sync /:Liquid Hand:482D:/
 91.7 "Cascade" sync /:Living Liquid:4826:/
@@ -41,7 +41,7 @@ hideall "Liquid Gaol"
 115.1 "Rage Wave 2" sync /:Liquid Rage:49B6:/
 119.1 "Pressurize" sync /:Liquid Rage:4829:/
 124.2 "Hand of Prayer/Parting" sync /:Liquid Hand:482[BC]:/
-127.4 "Splash x6" sync /:Living Liquid:49B2:/ window 3,0
+127.4 "Splash x6" duration 5.6
 129.3 "Hand of Pain" sync /:Liquid Hand:482D:/
 134.1 "Fluid Swing" sync /:Living Liquid:49B0:/
 142.1 "Cascade Enrage" sync /:Living Liquid:49B3:/
@@ -94,11 +94,7 @@ hideall "Liquid Gaol"
 370.6 "Photon" sync /:Cruise Chaser:4836:/
 378.7 "Double Rocket Punch" sync /:Brute Justice:4847:/
 386.0 "Super Jump" sync /:Brute Justice:484A:/
-389.0 "Apocalyptic Ray" sync /:Liquid Rage:484C:/
-390.1 "Apocalyptic Ray" sync /:Liquid Rage:484C:/
-391.2 "Apocalyptic Ray" sync /:Liquid Rage:484C:/
-392.3 "Apocalyptic Ray" sync /:Liquid Rage:484C:/
-393.4 "Apocalyptic Ray" sync /:Liquid Rage:484C:/
+389.0 "Apocalyptic Ray x5" duration 4.3
 399.0 "Whirlwind" sync /:Cruise Chaser:4B4F:/
 407.1 "Whirlwind" sync /:Cruise Chaser:4B4F:/
 415.7 "Final Sentence" sync /:Brute Justice:4856:/
@@ -109,9 +105,9 @@ hideall "Liquid Gaol"
 503.1 "Surety and Severity" sync /:Liquid Rage:486[13]:/
 505.1 "Alpha Sword" sync /:Cruise Chaser:486B:/
 505.2 "Flamethrower 1" sync /:Brute Justice:486C:/
-506.3 "Alpha Sword" sync /:Cruise Chaser:486B:/
-507.4 "Flamethrower 2" sync /:Brute Justice:486C:/
-507.5 "Alpha Sword" sync /:Cruise Chaser:486B:/
+506.3 "Alpha Sword" #sync /:Cruise Chaser:486B:/
+507.4 "Flamethrower 2" #sync /:Brute Justice:486C:/
+507.5 "Alpha Sword" #sync /:Cruise Chaser:486B:/
 521.8 "Chastenning Heat" sync /:Alexander Prime:4A80:/
 525.0 "Divine Spear 1" sync /:Alexander Prime:4A82:/
 527.1 "Divine Spear 2" #sync /:Alexander Prime:4A82:/
@@ -126,15 +122,15 @@ hideall "Liquid Gaol"
 558.9 "Judgment Crystal + True Heart" sync /:Liquid Rage:485C:/ duration 6
 560.2 "Aetheroplasm" sync /:Plasmasphere:4872:/
 570.3 "Flamethrower 1" sync /:Brute Justice:486C:/
-572.5 "Flamethrower 2" sync /:Brute Justice:486C:/
-574.7 "Flamethrower 3" sync /:Brute Justice:486C:/
+572.5 "Flamethrower 2" #sync /:Brute Justice:486C:/
+574.7 "Flamethrower 3" #sync /:Brute Justice:486C:/
 582.0 "Inception" sync /:Alexander Prime:485E:/
 588.2 "Tetrashatter" sync /:Judgment Crystal:485D:/
 590.1 "Surety, Solidarity and Severity" sync /:Liquid Rage:486[1-3]:/
 590.4 "Sacrament" sync /:Alexander Prime:485F:/
 596.4 "Alpha Sword" sync /:Cruise Chaser:486B:/
-597.5 "Alpha Sword" sync /:Cruise Chaser:486B:/
-598.6 "Alpha Sword" sync /:Cruise Chaser:486B:/
+597.5 "Alpha Sword" #sync /:Cruise Chaser:486B:/
+598.6 "Alpha Sword" #sync /:Cruise Chaser:486B:/
 599.8 "Super Jump" sync /:Brute Justice:484A:/
 612.1 "Chastenning Heat" sync /:Alexander Prime:4A80:/
 617.3 "Divine Spear 1" sync /:Alexander Prime:4A82:/
@@ -150,15 +146,11 @@ hideall "Liquid Gaol"
 652.7 "Super Jump" sync /:Brute Justice:484A:/
 652.8 "Alpha Sword" sync /:Cruise Chaser:4834:/
 654.3 "Super Blassty Charge" sync /:Cruise Chaser:49C3:/
-655.9 "Apocalyptic Ray" sync /:Liquid Rage:484C:/
-657.0 "Apocalyptic Ray" sync /:Liquid Rage:484C:/
-657.2 "Alpha Sword" sync /:Cruise Chaser:4834:/
+655.9 "Apocalyptic Ray x5" duration 4.3
+657.2 "Alpha Sword" #sync /:Cruise Chaser:4834:/
 657.6 "Repentance" sync /:Liquid Rage:4869:/
 657.7 "Confession" sync /:Liquid Rage:486A:/
-658.2 "Apocalyptic Ray" sync /:Liquid Rage:484C:/
 658.8 "Super Blassty Charge" sync /:Cruise Chaser:49C3:/
-659.3 "Apocalyptic Ray" sync /:Liquid Rage:484C:/
 660.1 "Sacrament" sync /:Alexander Prime:4857:/
-661.2 "Apocalyptic Ray" sync /:Liquid Rage:484C:/
-662.5 "Alpha Sword" sync /:Cruise Chaser:4834:/
+662.5 "Alpha Sword" #sync /:Cruise Chaser:4834:/
 662.9 "Confession" sync /:Liquid Rage:486A:/

--- a/ui/raidboss/data/05-shb/ultimate/the_epic_of_alexander.txt
+++ b/ui/raidboss/data/05-shb/ultimate/the_epic_of_alexander.txt
@@ -146,9 +146,32 @@ hideall "Liquid Gaol"
 652.4 "Super Blassty Charge" sync /:Cruise Chaser:49C3:/
 653.3 "Apocalyptic Ray x5" duration 5
 655.2 "Alpha Sword" #sync /:Cruise Chaser:4834:/
-655.6 "Repentance" sync /:Liquid Rage:4869:/
-655.7 "Confession" sync /:Liquid Rage:486A:/
+655.6 "Repentance 1" sync /:Liquid Rage:4869:/
 656.7 "Super Blassty Charge" sync /:Cruise Chaser:49C3:/
 657.9 "Sacrament" sync /:Alexander Prime:4857:/
 659.5 "Alpha Sword" #sync /:Cruise Chaser:4834:/
-659.9 "Confession" sync /:Liquid Rage:486A:/
+659.7 "Repentance 2" sync /:Liquid Rage:4868:/
+660.8 "Super Blassty Charge" sync /:Cruise Chaser:49C3:/
+663.6 "Alpha Sword" #sync /:Cruise Chaser:4834:/
+664.0 "Repentance 3" sync /:Liquid Rage:4867:/
+665.1 "Super Blassty Charge" sync /:Cruise Chaser:49C3:/
+666.4 "Missile Command" sync /:Brute Justice:484D:/
+670.0 "Incinerating Heat" sync /:Alexander Prime:4A51:/
+674.6 "Enumeration" sync /:Liquid Rage:4850:/
+682.9 "Mega Holy" sync /:Alexander Prime:4A83:/
+690.0 "Mega Holy" sync /:Alexander Prime:4A83:/
+
+### Transition 3: DPS Checks
+699.4 "Summon Alexander" sync /:Alexander Prime:4A55:/
+705.7 "J Waves x12" sync /:Brute Justice:4876:/ duration 36
+731.7 "Eternal Darkness Enrage" sync /:Cruise Chaser:4875:/
+# Estimations
+750.0 "Brute Justice Enrage"
+770.0 "Divine Judgment Enrage" sync /:Alexander Prime:487[9A]:/
+772.0 "Down for the Count" duration 45
+
+### Phase 4: Perfect Alexander
+900.0 "The Final Word" sync /:Perfect Alexander:487D:/ window 900,0
+904.0 "Ordained Stillness" sync /:Perfect Alexander:4(8(7F|8[01])|A60):/
+908.0 "Ordained Motion" sync /:Perfect Alexander:4(A5F|8(7[EF]|80)):/
+912.0 "Optical Sight" #sync /:Perfect Alexander::/

--- a/ui/raidboss/data/05-shb/ultimate/the_epic_of_alexander.txt
+++ b/ui/raidboss/data/05-shb/ultimate/the_epic_of_alexander.txt
@@ -105,7 +105,7 @@ hideall "Liquid Gaol"
 425.7 "Eternal Darkness Enrage" sync /:Cruise Chaser:483A:/
 
 ### Transition 2: Cruise Chaser, Brute Justice and Alexander Prime
-500.0 "Temporal Stasis" sync /:Alexander Prime:485A:/  window 500,0
+500.0 "Temporal Stasis" sync /:Alexander Prime:485A:/ window 500,0
 503.1 "Surety and Severity" sync /:Liquid Rage:486[13]:/
 505.1 "Alpha Sword" sync /:Cruise Chaser:486B:/
 505.2 "Flamethrower 1" sync /:Brute Justice:486C:/

--- a/ui/raidboss/data/05-shb/ultimate/the_epic_of_alexander.txt
+++ b/ui/raidboss/data/05-shb/ultimate/the_epic_of_alexander.txt
@@ -117,7 +117,7 @@ hideall "Liquid Gaol"
 552.4 "Judgment Crystal" sync /:Alexander Prime:485B:/
 556.6 "Aetheroplasm" sync /:Plasmasphere:4872:/
 557.5 "Electromagnetic Burst" sync /:Liquid Rage:4874:/
-558.2 "Judgment Crystal + True Heart" sync /:Liquid Rage:485C:/ duration 6
+558.2 "Judgment Crystal + True Heart" sync /:Liquid Rage:485C:/
 560.8 "Aetheroplasm" sync /:Plasmasphere:4872:/
 569.5 "Flamethrower 1" sync /:Brute Justice:486C:/
 571.7 "Flamethrower 2" #sync /:Brute Justice:486C:/
@@ -163,7 +163,7 @@ hideall "Liquid Gaol"
 
 ### Transition 3: DPS Checks
 699.4 "Summon Alexander" sync /:Alexander Prime:4A55:/
-705.7 "J Storm + Waves x16" sync /:Brute Justice:4876:/ duration 52
+705.7 "J Storm + Waves x16" sync /:Brute Justice:4876:/ duration 50
 731.7 "Eternal Darkness Enrage" sync /:Cruise Chaser:4875:/
 771.9 "Divine Judgment Enrage" sync /:Alexander Prime:4879:/
 787.3 "Divine Judgment" sync /:Alexander:487A:/

--- a/ui/raidboss/data/05-shb/ultimate/the_epic_of_alexander.txt
+++ b/ui/raidboss/data/05-shb/ultimate/the_epic_of_alexander.txt
@@ -116,7 +116,6 @@ hideall "Liquid Gaol"
 537.9 "Inception Formation" sync /:Alexander Prime:486F:/
 552.4 "Judgment Crystal" sync /:Alexander Prime:485B:/
 556.6 "Aetheroplasm" sync /:Plasmasphere:4872:/
-557.5 "Electromagnetic Burst" sync /:Liquid Rage:4874:/
 558.2 "Judgment Crystal + True Heart" sync /:Liquid Rage:485C:/
 560.8 "Aetheroplasm" sync /:Plasmasphere:4872:/
 569.5 "Flamethrower 1" sync /:Brute Justice:486C:/
@@ -169,22 +168,76 @@ hideall "Liquid Gaol"
 787.3 "Divine Judgment" sync /:Alexander:487A:/
 772.0 "Down for the Count" duration 66
 
-### Phase 4: Perfect Alexander
-900.0 "The Final Word" sync /:Perfect Alexander:487D:/ window 900,0
-907.1 "Ordained Motion/Stillness" sync /:Perfect Alexander:4A(5F|60):/
-914.6 "Divine Retribution" sync /:Liquid Rage:4883:/
-917.3 "Ordained Motion/Stillness" sync /:Perfect Alexander:4A(5F|60):/
-924.8 "Divine Retribution" sync /:Liquid Rage:4883:/
-927.5 "Optical Sight 1" sync /:Perfect Alexander:488[AB]:/
-929.6 "Individual/Collective Reprobation" sync /:Liquid Rage:488[CD]:/
-933.7 "Optical Sight 2" sync /:Perfect Alexander::488[AB]/
-935.8 "Individual/Collective Reprobation" sync /:Liquid Rage:488[CD]:/
-953.6 "Fate Projection α" sync /:Perfect Alexander:487B:/
-978.7 "Fate Calibration α" sync /:Perfect Alexander:487C:/
-986.9 "Ordained Motion/Stillness" sync /:Perfect Alexander:49A[BC]:/
-# Estimations
-994.4 "Divine Retribution"
-995.5 "Defamation"
-996.5 "Surety, Solidarity and Severity"
-997.0 "Sacrament x3" duration 1.5
-1015.0 "Ordained Capital Punishment" sync /:Perfect Alexander:4892:/
+### Phase 4: Perfect Alexander Part 1 - Fate Projection α
+900.0 "" sync /:Perfect Alexander:4A8B:/ window 900,0
+909.1 "The Final Word" sync /:Perfect Alexander:487D:/
+910.1 "Ordained Motion/Stillness" sync /:Perfect Alexander:487[EF]:/
+916.3 "Ordained Motion/Stillness" sync /:Perfect Alexander:487[EF]:/
+936.5 "Optical Sight 1" sync /:Perfect Alexander:488[AB]:/
+938.6 "Individual/Collective Reprobation" sync /:Liquid Rage:488[CD]:/
+942.7 "Optical Sight 2" sync /:Perfect Alexander::488[AB]/
+944.7 "Individual/Collective Reprobation" sync /:Liquid Rage:488[CD]:/
+957.6 "Fate Projection α" sync /:Perfect Alexander:487B:/
+### Enigma Codex Revealed Events
+966.8 "Fate: Ordained Motion/Stillness" sync /:Perfect Alexander:4(898|9AA):/
+966.9 "Fate: Obloquy, Solidarity and 2x Severity" sync /:Liquid Rage:4B0E:/
+974.9 "Fate: Ordained Motion/Stillness" sync /:Perfect Alexander:4(898|9AA):/
+975.9 "Fate: Sacrament x3" duration 1.5
+982.6 "Fate Calibration α" sync /:Perfect Alexander:487C:/
+989.8 "Ordained Motion/Stillness" sync /:Perfect Alexander:49(AC|5F):/
+992.8 "Obloquy, Solidarity and 2x Severity" sync  /:Liquid Rage:4860:/
+993.8 "Ordained Motion/Stillness" sync /:Perfect Alexander:49A(AC|5F):/
+993.8 "Sacrament x3" duration 1.5
+
+### Phase 4 Part 2 - Fate Projection β
+1008.0 "Ordained Capital Punishment" sync /:Perfect Alexander:4892:/
+1011.1 "Ordained Capital Punishment 1" #sync /:Liquid Rage:4893:/
+1012.2 "Ordained Capital Punishment 2" #sync /:Liquid Rage:4893:/
+1013.3 "Ordained Capital Punishment 3" #sync /:Liquid Rage:4893:/
+1017.2 "Ordained Punishment" sync /:Perfect Alexander:4891:/
+1032.3 "Fate Projection β" sync /:Perfect Alexander:4B13:/
+### Enigma Codex Revealed Events
+1047.7 "Fate: Surety and Solidarity" #sync /:Liquid Rage:489C:/
+1050.5 "Fate: J Jump" sync /:Perfect Alexander:489D:/
+1056.0 "Fate: Optical Sight" sync /:Perfect Alexander:48A0:/
+1058.1 "Fate: Individual/Collective Reprobation" sync /:Liquid Rage:48A2:/
+1061.5 "Fate: Radiant Sacrament" sync /:Perfect Alexander:489E:/
+1070.3 "Fate Calibration β" sync /:Perfect Alexander:4B14:/
+1081.5 "Surety and Solidarity" sync /:Liquid Rage:4863:/
+1082.5 "J Jump" sync /:Perfect Alexander:4884:/
+1086.5 "Optical Sight 1" sync /:Perfect Alexander:49AD:/
+1088.6 "Individual/Collective Reprobation" sync /:Liquid Rage:488[CD]:/
+1093.5 "Radiant Sacrament" sync /:Perfect Alexander:4886:/
+1106.8 "Ordained Capital Punishment" sync /:Perfect Alexander:4892:/
+1109.9 "Ordained Capital Punishment 1" #sync /:Liquid Rage:4893:/
+1111.0 "Ordained Capital Punishment 2" #sync /:Liquid Rage:4893:/
+1112.1 "Ordained Capital Punishment 3" #sync /:Liquid Rage:4893:/
+
+### Phase 4 Part 3 - Almighty Judgments and Burn
+1126.2 "Almighty Judgment" sync /:Perfect Alexander:488E:/
+1130.8 "Almighty Judgment Reveal x3" duration 6
+1137.4 "Almighty Judgment 1" #sync /:Liquid Rage:4890:/
+1139.4 "Almighty Judgment 2" #sync /:Liquid Rage:4890:/
+1141.4 "Almighty Judgment 3" #sync /:Liquid Rage:4890:/
+1142.5 "Irresistible Grace" sync /:Perfect Alexander:4894:/
+1152.6 "Ordained Capital Punishment" sync /:Perfect Alexander:4892:/
+1155.7 "Ordained Capital Punishment 1" #sync /:Liquid Rage:4893:/
+1156.8 "Ordained Capital Punishment 2" #sync /:Liquid Rage:4893:/
+1157.9 "Ordained Capital Punishment 3" #sync /:Liquid Rage:4893:/
+1161.8 "Ordained Punishment" sync /:Perfect Alexander:4891:/
+1171.7 "Almighty Judgment" sync /:Perfect Alexander:488E:/
+1176.3 "Almighty Judgment Reveal x3" duration 6
+1182.9 "Almighty Judgment 1" #sync /:Liquid Rage:4890:/
+1184.9 "Almighty Judgment 2" #sync /:Liquid Rage:4890:/
+1186.9 "Almighty Judgment 3" #sync /:Liquid Rage:4890:/
+1187.9 "Irresistible Grace" sync /:Perfect Alexander:4894:/
+1202.8 "Temporal Interference" sync /:Perfect Alexander:4896:/
+1216.4 "7 Players Remaining"
+1221.4 "6 Players Remaining"
+1226.4 "5 Players Remaining"
+1231.5 "4 Players Remaining"
+1236.5 "3 Players Remaining"
+1241.6 "2 Players Remaining"
+1246.6 "1 Players Remaining"
+1247.6 "Temporal Prison Enrage" sync /:Perfect Alexander:4897:/ duration 9
+1249.8 "0 Players Remaining"

--- a/ui/raidboss/data/05-shb/ultimate/the_epic_of_alexander.txt
+++ b/ui/raidboss/data/05-shb/ultimate/the_epic_of_alexander.txt
@@ -6,7 +6,7 @@ hideall "Liquid Gaol"
 
 0.0 "--Reset--" sync / 21:........:40000010:/ window 10000 jump 0
 
-### Living Liquid
+### Phase 1: Living Liquid
 0 "Start"
 0.0 "--sync--" sync /:Engage!/ window 0,1
 3.2 "--sync--" sync /:Living Liquid:4978:/ window 5,0
@@ -27,7 +27,7 @@ hideall "Liquid Gaol"
 71.9 "Protean Wave 2" sync /:Living Liquid:4823:/
 74.9 "Sluice" sync /:Liquid Rage:49B1:/
 75.0 "Protean Wave 3" sync /:Living Liquid:4823:/
-81.1 "Splash" sync /:Living Liquid:49B2:/ window 3,0
+81.1 "Splash x6" sync /:Living Liquid:49B2:/ window 3,0
 86.6 "Drainage" sync /:Liquid Rage:4827:/
 89.1 "Hand of Pain" sync /:Liquid Hand:482D:/
 91.7 "Cascade" sync /:Living Liquid:4826:/
@@ -41,12 +41,12 @@ hideall "Liquid Gaol"
 115.1 "Rage Wave 2" sync /:Liquid Rage:49B6:/
 119.1 "Pressurize" sync /:Liquid Rage:4829:/
 124.2 "Hand of Prayer/Parting" sync /:Liquid Hand:482[BC]:/
-127.4 "Splash" sync /:Living Liquid:49B2:/ window 3,0
+127.4 "Splash x6" sync /:Living Liquid:49B2:/ window 3,0
 129.3 "Hand of Pain" sync /:Liquid Hand:482D:/
 134.1 "Fluid Swing" sync /:Living Liquid:49B0:/
 142.1 "Cascade Enrage" sync /:Living Liquid:49B3:/
 
-# Transition
+### Transition 1: Cruise Chaser
 200.0 "Hawk Blaster" sync /:(Liquid Rage|Living Liquid):4830:/ window 200,0
 202.2 "Hawk Blaster"
 204.4 "Hawk Blaster" 
@@ -65,9 +65,16 @@ hideall "Liquid Gaol"
 219.9 "Middle Blaster"
 221.5 "Alpha Sword" sync /:Cruise Chaser:4834:/
 223.3 "Super Blassty Charge" sync /:Cruise Chaser:4B4F:/
+
+### Phase 2: Cruise Chaser and Brute Justice
 227.3 "J Kick" sync /:Brute Justice:4854:/
 239.1 "Whirlwind" sync /:Cruise Chaser:49C2:/
+242.1 "Judgment Nisi" sync /:Brute Justice:483E:/
+249.3 "Link-Up" sync /:Brute Justice:483F:/
+257.4 "Optical Sight" sync /:Cruise Chaser:482F:/
+258.3 "Chakrams" sync /:Steam Chakram:4855:/
 261.5 "Hawk Blaster" sync /:(Liquid Rage|Living Liquid):4830:/
+263.5 "Photon" sync /:Cruise Chaser:4836:/
 270.6 "Spin Crusher" sync /:Cruise Chaser:4A72:/
 278.2 "Crashing/Punishing Wave and Thunders" sync /:(Liquid Rage|Living Liquid):484[1-3]:/
 289.7 "Earth Missile" sync /:(Liquid Rage|Living Liquid):484E:/
@@ -84,3 +91,74 @@ hideall "Liquid Gaol"
 358.4 "Propeller Wind" sync /:Cruise Chaser:4832:/
 360.3 "Gavel" sync /:Brute Justice:483C:/
 363.3 "Final Sentence" sync /:You:483D:/
+370.6 "Photon" sync /:Cruise Chaser:4836:/
+378.7 "Double Rocket Punch" sync /:Brute Justice:4847:/
+386.0 "Super Jump" sync /:Brute Justice:484A:/
+389.0 "Apocalyptic Ray" sync /:Liquid Rage:484C:/
+390.1 "Apocalyptic Ray" sync /:Liquid Rage:484C:/
+391.2 "Apocalyptic Ray" sync /:Liquid Rage:484C:/
+392.3 "Apocalyptic Ray" sync /:Liquid Rage:484C:/
+393.4 "Apocalyptic Ray" sync /:Liquid Rage:484C:/
+399.0 "Whirlwind" sync /:Cruise Chaser:4B4F:/
+407.1 "Whirlwind" sync /:Cruise Chaser:4B4F:/
+415.7 "Final Sentence" sync /:Brute Justice:4856:/
+425.7 "Eternal Darkness Enrage" sync /:Cruise Chaser:483A:/
+
+### Transition 2: Cruise Chaser, Brute Justice and Alexander Prime
+500.0 "Temporal Stasis" sync /:Alexander Prime:485A:/  window 500,0
+503.1 "Surety and Severity" sync /:Liquid Rage:486[13]:/
+505.1 "Alpha Sword" sync /:Cruise Chaser:486B:/
+505.2 "Flamethrower 1" sync /:Brute Justice:486C:/
+506.3 "Alpha Sword" sync /:Cruise Chaser:486B:/
+507.4 "Flamethrower 2" sync /:Brute Justice:486C:/
+507.5 "Alpha Sword" sync /:Cruise Chaser:486B:/
+521.8 "Chastenning Heat" sync /:Alexander Prime:4A80:/
+525.0 "Divine Spear 1" sync /:Alexander Prime:4A82:/
+527.1 "Divine Spear 2" #sync /:Alexander Prime:4A82:/
+529.2 "Divine Spear 3" #sync /:Alexander Prime:4A82:/
+
+### Phase 3 Part 1 - Inception Formation
+538.4 "Inception Formation" sync /:Alexander Prime:486F:/
+552.9 "Judgment Crystal" sync /:Alexander Prime:485B:/
+554.0 "Aetheroplasm" sync /:Plasmasphere:4872:/
+554.9 "Electromagnetic Burst" sync /:Liquid Rage:4874:/
+557.3 "Aetheroplasm" sync /:Plasmasphere:4872:/
+558.9 "Judgement Crystal + True Heart" sync /:Liquid Rage:485C:/ duration 6
+560.2 "Aetheroplasm" sync /:Plasmasphere:4872:/
+570.3 "Flamethrower 1" sync /:Brute Justice:486C:/
+572.5 "Flamethrower 2" sync /:Brute Justice:486C:/
+574.7 "Flamethrower 3" sync /:Brute Justice:486C:/
+582.0 "Inception" sync /:Alexander Prime:485E:/
+588.2 "Tetrashatter" sync /:Judgment Crystal:485D:/
+590.1 "Surety, Solidarity and Severity" sync /:Liquid Rage:486[1-3]:/
+590.4 "Sacrament" sync /:Alexander Prime:485F:/
+596.4 "Alpha Sword" sync /:Cruise Chaser:486B:/
+597.5 "Alpha Sword" sync /:Cruise Chaser:486B:/
+598.6 "Alpha Sword" sync /:Cruise Chaser:486B:/
+599.8 "Super Jump" sync /:Brute Justice:484A:/
+612.1 "Chastenning Heat" sync /:Alexander Prime:4A80:/
+617.3 "Divine Spear 1" sync /:Alexander Prime:4A82:/
+619.4 "Divine Spear 2" #sync /:Alexander Prime:4A82:/
+621.5 "Divine Spear 3" #sync /:Alexander Prime:4A82:/
+
+### Phase 3 Part 2 - Wormhole Formation
+630.7 "Wormhole Formation" sync /:Alexander Prime:486E:/
+639.2 "Limit Cut" sync /:Cruise Chaser:4B0F:/
+642.3 "Link-Up" sync /:Brute Justice:483F:/
+645.4 "Void Of Repentance" sync /:Alexander Prime:4866:/
+651.3 "Chakrams" sync /:Steam Chakram:4855:/
+652.7 "Super Jump" sync /:Brute Justice:484A:/
+652.8 "Alpha Sword" sync /:Cruise Chaser:4834:/
+654.3 "Super Blassty Charge" sync /:Cruise Chaser:49C3:/
+655.9 "Apocalyptic Ray" sync /:Liquid Rage:484C:/
+657.0 "Apocalyptic Ray" sync /:Liquid Rage:484C:/
+657.2 "Alpha Sword" sync /:Cruise Chaser:4834:/
+657.6 "Repentance" sync /:Liquid Rage:4869:/
+657.7 "Confession" sync /:Liquid Rage:486A:/
+658.2 "Apocalyptic Ray" sync /:Liquid Rage:484C:/
+658.8 "Super Blassty Charge" sync /:Cruise Chaser:49C3:/
+659.3 "Apocalyptic Ray" sync /:Liquid Rage:484C:/
+660.1 "Sacrament" sync /:Alexander Prime:4857:/
+661.2 "Apocalyptic Ray" sync /:Liquid Rage:484C:/
+662.5 "Alpha Sword" sync /:Cruise Chaser:4834:/
+662.9 "Confession" sync /:Liquid Rage:486A:/

--- a/ui/raidboss/data/05-shb/ultimate/the_epic_of_alexander.txt
+++ b/ui/raidboss/data/05-shb/ultimate/the_epic_of_alexander.txt
@@ -179,14 +179,14 @@ hideall "Liquid Gaol"
 944.7 "Individual/Collective Reprobation" sync /:Liquid Rage:488[CD]:/
 957.6 "Fate Projection α" sync /:Perfect Alexander:487B:/
 ### Enigma Codex Revealed Events
-966.8 "Fate: Ordained Motion/Stillness" sync /:Perfect Alexander:4(898|9AA):/
-966.9 "Fate: Obloquy, Solidarity and 2x Severity" sync /:Liquid Rage:4B0E:/
-974.9 "Fate: Ordained Motion/Stillness" sync /:Perfect Alexander:4(898|9AA):/
+966.8 "Fate: Ordained Motion/Stillness" sync /:Liquid Rage:4B0[DE]:/
+972.7 "Fate: Obloquy, Solidarity and 2x Severity" sync /:Liquid Rage:4BA4:/
+974.9 "Fate: Ordained Motion/Stillness" sync /:Liquid Rage:489[9A]:/
 975.9 "Fate: Sacrament x3" duration 1.5
 982.6 "Fate Calibration α" sync /:Perfect Alexander:487C:/
-989.8 "Ordained Motion/Stillness" sync /:Perfect Alexander:49(AC|5F):/
+989.8 "Ordained Motion/Stillness" sync /:Perfect Alexander:49A[BC]:/
 992.8 "Obloquy, Solidarity and 2x Severity" sync  /:Liquid Rage:4860:/
-993.8 "Ordained Motion/Stillness" sync /:Perfect Alexander:49A(AC|5F):/
+993.8 "Ordained Motion/Stillness" sync /:Perfect Alexander:49A[BC]:/
 993.8 "Sacrament x3" duration 1.5
 
 ### Phase 4 Part 2 - Fate Projection β

--- a/ui/raidboss/data/05-shb/ultimate/the_epic_of_alexander.txt
+++ b/ui/raidboss/data/05-shb/ultimate/the_epic_of_alexander.txt
@@ -199,13 +199,13 @@ hideall "Liquid Gaol"
 ### Enigma Codex Revealed Events
 1047.7 "Fate: Surety and Solidarity" #sync /:Liquid Rage:489C:/
 1050.5 "Fate: J Jump" sync /:Perfect Alexander:489D:/
-1056.0 "Fate: Optical Sight" sync /:Perfect Alexander:48A0:/
-1058.1 "Fate: Individual/Collective Reprobation" sync /:Liquid Rage:48A2:/
+1056.0 "Fate: Optical Sight" sync /:Perfect Alexander:48A[01]:/
+1058.1 "Fate: Individual/Collective Reprobation" sync /:Liquid Rage:48A[23]:/
 1061.5 "Fate: Radiant Sacrament" sync /:Perfect Alexander:489E:/
 1070.3 "Fate Calibration β" sync /:Perfect Alexander:4B14:/
 1081.5 "Surety and Solidarity" sync /:Liquid Rage:4863:/
 1082.5 "J Jump" sync /:Perfect Alexander:4884:/
-1086.5 "Optical Sight 1" sync /:Perfect Alexander:49AD:/
+1086.5 "Optical Sight 1" sync /:Perfect Alexander:49A[ED]:/
 1088.6 "Individual/Collective Reprobation" sync /:Liquid Rage:488[CD]:/
 1093.5 "Radiant Sacrament" sync /:Perfect Alexander:4886:/
 1106.8 "Ordained Capital Punishment" sync /:Perfect Alexander:4892:/

--- a/ui/raidboss/data/05-shb/ultimate/the_epic_of_alexander.txt
+++ b/ui/raidboss/data/05-shb/ultimate/the_epic_of_alexander.txt
@@ -163,15 +163,29 @@ hideall "Liquid Gaol"
 
 ### Transition 3: DPS Checks
 699.4 "Summon Alexander" sync /:Alexander Prime:4A55:/
-705.7 "J Waves x12" sync /:Brute Justice:4876:/ duration 36
+705.7 "J Storm + Waves x12" sync /:Brute Justice:4876:/ duration 38
 731.7 "Eternal Darkness Enrage" sync /:Cruise Chaser:4875:/
-# Estimations
-750.0 "Brute Justice Enrage"
-770.0 "Divine Judgment Enrage" sync /:Alexander Prime:487[9A]:/
-772.0 "Down for the Count" duration 45
+750.0 "Brute Justice Enrage" #Estimated
+771.9 "Divine Judgment Enrage" sync /:Alexander Prime:4879:/
+787.3 "Divine Judgment" sync /:Alexander:487A:/
+772.0 "Down for the Count" duration 66
 
 ### Phase 4: Perfect Alexander
 900.0 "The Final Word" sync /:Perfect Alexander:487D:/ window 900,0
-904.0 "Ordained Stillness" sync /:Perfect Alexander:4(8(7F|8[01])|A60):/
-908.0 "Ordained Motion" sync /:Perfect Alexander:4(A5F|8(7[EF]|80)):/
-912.0 "Optical Sight" #sync /:Perfect Alexander::/
+907.1 "Ordained Motion/Stillness" sync /:Perfect Alexander:4A(5F|60):/
+914.6 "Divine Retribution" sync /:Liquid Rage:4883:/
+917.3 "Ordained Motion/Stillness" sync /:Perfect Alexander:4A(5F|60):/
+924.8 "Divine Retribution" sync /:Liquid Rage:4883:/
+927.5 "Optical Sight 1" sync /:Perfect Alexander:488[AB]:/
+929.6 "Individual/Collective Reprobation" sync /:Liquid Rage:488[CD]:/
+933.7 "Optical Sight 2" sync /:Perfect Alexander::488[AB]/
+935.8 "Individual/Collective Reprobation" sync /:Liquid Rage:488[CD]:/
+953.6 "Fate Projection α" sync /:Perfect Alexander:487B:/
+978.7 "Fate Calibration α" sync /:Perfect Alexander:487C:/
+986.9 "Ordained Motion/Stillness" sync /:Perfect Alexander:49A[BC]:/
+# Estimations
+994.4 "Divine Retribution"
+995.5 "Defamation"
+996.5 "Surety, Solidarity and Severity"
+997.0 "Sacrament x3" duration 1.5
+1015.0 "Ordained Capital Punishment" sync /:Perfect Alexander:4892:/

--- a/ui/raidboss/data/05-shb/ultimate/the_epic_of_alexander.txt
+++ b/ui/raidboss/data/05-shb/ultimate/the_epic_of_alexander.txt
@@ -2,7 +2,6 @@
 
 hideall "--Reset--"
 hideall "--sync--"
-hideall "Liquid Gaol"
 
 0.0 "--Reset--" sync / 21:........:40000010:/ window 10000 jump 0
 
@@ -18,8 +17,8 @@ hideall "Liquid Gaol"
 37.8 "Fluid Strike" sync /:Liquid Hand:49B7:/
 38.7 "Rage Wave 2" sync /:Liquid Rage:49B6:/
 39.7 "Exhaust" sync /:Jagd Doll:481E:/
-42.8 "Hand of Pain" sync /:Liquid Hand:482D:/
 43.8 "Embolus" sync /:Liquid Rage:4829:/
+44.1 "Hand of Pain" sync /:Liquid Hand:482D:/
 50.3 "Exhaust" sync /:Jagd Doll:481E:/
 56.7 "Fluid Swing" sync /:Living Liquid:49B0:/
 56.9 "Fluid Strike" sync /:Liquid Hand:49B7:/
@@ -81,7 +80,6 @@ hideall "Liquid Gaol"
 288.6 "Earth Missile" sync /:(Liquid Rage|Living Liquid):484E:/
 290.6 "Hidden Minefield" sync /:(Liquid Rage|Living Liquid):4851:/
 292.7 "Enumeration" sync /:(Liquid Rage|Living Liquid):4850:/
-302.9 "Drainage" #sync /:(Liquid Rage|Living Liquid):4844:/
 306.7 "Crashing/Punishing Wave and Thunders" sync /:(Liquid Rage|Living Liquid):484[1-3]:/
 313.5 "Limit Cut" sync /:Cruise Chaser:4833:/
 314.1 "--Cruise Chaser Invincible--" duration 6.3
@@ -123,7 +121,6 @@ hideall "Liquid Gaol"
 571.7 "Flamethrower 2" #sync /:Brute Justice:486C:/
 573.8 "Flamethrower 3" #sync /:Brute Justice:486C:/
 581.0 "Inception" sync /:Alexander Prime:485E:/
-587.2 "Tetrashatter" sync /:Judgment Crystal:485D:/
 589.1 "Surety, Solidarity and Severity" sync /:Liquid Rage:486[1-3]:/
 589.4 "Sacrament" sync /:Alexander Prime:485F:/
 595.3 "Alpha Sword" sync /:Cruise Chaser:486B:/
@@ -165,23 +162,24 @@ hideall "Liquid Gaol"
 699.4 "Summon Alexander" sync /:Alexander Prime:4A55:/
 705.7 "J Storm + Waves x16" sync /:Brute Justice:4876:/ duration 50
 731.7 "Eternal Darkness Enrage" sync /:Cruise Chaser:4875:/
-771.9 "Divine Judgment Enrage" sync /:Alexander Prime:4879:/
+771.9 "Divine Judgment Enrage" sync /:Alexander Prime:4879:/ window 67,5
 787.3 "Divine Judgment" sync /:Alexander:487A:/
 787.4 "Down for the Count" duration 57
 
 ### Phase 4: Perfect Alexander Part 1 - Fate Projection α
-900.0 "" sync /:Perfect Alexander:4A8B:/ window 900,0
+845.4 "--targetable--"
+900.0 "--sync--" sync /:Perfect Alexander:4A8B:/ window 900,0
 909.1 "The Final Word" sync /:Perfect Alexander:487D:/
-910.1 "Ordained Motion/Stillness" sync /:Perfect Alexander:487[EF]:/
-916.3 "Ordained Motion/Stillness" sync /:Perfect Alexander:487[EF]:/
+916.1 "Ordained Motion/Stillness" sync /:Perfect Alexander:487[EF]:/
+926.3 "Ordained Motion/Stillness" sync /:Perfect Alexander:487[EF]:/
 936.5 "Optical Sight 1" sync /:Perfect Alexander:488[AB]:/
 938.6 "Individual/Collective Reprobation" sync /:Liquid Rage:488[CD]:/
-942.7 "Optical Sight 2" sync /:Perfect Alexander::488[AB]/
+942.7 "Optical Sight 2" sync /:Perfect Alexander:488[AB]:/
 944.7 "Individual/Collective Reprobation" sync /:Liquid Rage:488[CD]:/
 957.6 "Fate Projection α" sync /:Perfect Alexander:487B:/
 ### Enigma Codex Revealed Events
 966.8 "Fate: Ordained Motion/Stillness" sync /:Liquid Rage:4B0[DE]:/
-972.7 "Fate: Obloquy, Solidarity and 2x Severity" sync /:Liquid Rage:4BA4:/
+972.7 "Fate: Obloquy, Solidarity and 2x Severity" sync /:Liquid Rage:48A4:/
 974.9 "Fate: Ordained Motion/Stillness" sync /:Liquid Rage:489[9A]:/
 975.9 "Fate: Sacrament x3" duration 1.5
 982.6 "Fate Calibration α" sync /:Perfect Alexander:487C:/
@@ -205,7 +203,7 @@ hideall "Liquid Gaol"
 1061.5 "Fate: Radiant Sacrament" sync /:Perfect Alexander:489E:/
 1070.3 "Fate Calibration β" sync /:Perfect Alexander:4B14:/
 1081.5 "Surety and Solidarity" sync /:Liquid Rage:4863:/
-1082.5 "J Jump" sync /:Perfect Alexander:4884:/
+1082.5 "J Jump" sync /:Perfect Alexander:4885:/
 1086.5 "Optical Sight 1" sync /:Perfect Alexander:49A[ED]:/
 1088.6 "Individual/Collective Reprobation" sync /:Liquid Rage:488[CD]:/
 1093.5 "Radiant Sacrament" sync /:Perfect Alexander:4886:/

--- a/ui/raidboss/data/05-shb/ultimate/the_epic_of_alexander.txt
+++ b/ui/raidboss/data/05-shb/ultimate/the_epic_of_alexander.txt
@@ -90,7 +90,7 @@ hideall "Liquid Gaol"
 354.5 "Propeller Wind" sync /:Cruise Chaser:4832:/
 356.5 "Gavel" sync /:Brute Justice:483C:/
 366.7 "Final Sentence" sync /:You:483D:/
-370.6 "Photon" sync /:Cruise Chaser:4836:/
+366.8 "Photon" sync /:Cruise Chaser:4836:/
 374.8 "Double Rocket Punch" sync /:Brute Justice:4847:/
 382.1 "Super Jump" sync /:Brute Justice:484A:/
 384.4 "Apocalyptic Ray x5" duration 4.4

--- a/ui/raidboss/data/05-shb/ultimate/the_epic_of_alexander.txt
+++ b/ui/raidboss/data/05-shb/ultimate/the_epic_of_alexander.txt
@@ -123,7 +123,7 @@ hideall "Liquid Gaol"
 554.0 "Aetheroplasm" sync /:Plasmasphere:4872:/
 554.9 "Electromagnetic Burst" sync /:Liquid Rage:4874:/
 557.3 "Aetheroplasm" sync /:Plasmasphere:4872:/
-558.9 "Judgement Crystal + True Heart" sync /:Liquid Rage:485C:/ duration 6
+558.9 "Judgment Crystal + True Heart" sync /:Liquid Rage:485C:/ duration 6
 560.2 "Aetheroplasm" sync /:Plasmasphere:4872:/
 570.3 "Flamethrower 1" sync /:Brute Justice:486C:/
 572.5 "Flamethrower 2" sync /:Brute Justice:486C:/

--- a/ui/raidboss/data/05-shb/ultimate/the_epic_of_alexander.txt
+++ b/ui/raidboss/data/05-shb/ultimate/the_epic_of_alexander.txt
@@ -19,6 +19,7 @@ hideall "Liquid Gaol"
 38.7 "Rage Wave 2" sync /:Liquid Rage:49B6:/
 39.7 "Exhaust" sync /:Jagd Doll:481E:/
 42.8 "Hand of Pain" sync /:Liquid Hand:482D:/
+43.8 "Embolus" sync /:Liquid Rage:4829:/
 50.3 "Exhaust" sync /:Jagd Doll:481E:/
 56.7 "Fluid Swing" sync /:Living Liquid:49B0:/
 56.9 "Fluid Strike" sync /:Liquid Hand:49B7:/
@@ -31,7 +32,7 @@ hideall "Liquid Gaol"
 86.6 "Drainage" sync /:Liquid Rage:4827:/
 89.1 "Hand of Pain" sync /:Liquid Hand:482D:/
 91.7 "Cascade" sync /:Living Liquid:4826:/
-95.9 "Liquid Gaol" sync /:Liquid Rage:4828:/
+95.9 "Throttles" sync /:Liquid Rage:4828:/
 107.0 "Protean Wave 1" sync /:Living Liquid:4822:/
 109.0 "Hand of Pain" sync /:Liquid Hand:482D:/
 109.1 "Protean Wave 2" sync /:Living Liquid:4823:/
@@ -39,7 +40,7 @@ hideall "Liquid Gaol"
 112.1 "Protean Wave 3" sync /:Living Liquid:4823:/
 113.0 "Rage Wave 1" sync /:Liquid Rage:49B5:/
 115.1 "Rage Wave 2" sync /:Liquid Rage:49B6:/
-119.1 "Pressurize" sync /:Liquid Rage:4829:/
+119.1 "Embolus" sync /:Liquid Rage:4829:/
 124.2 "Hand of Prayer/Parting" sync /:Liquid Hand:482[BC]:/
 127.4 "Splash x6" duration 5.6
 129.3 "Hand of Pain" sync /:Liquid Hand:482D:/

--- a/ui/raidboss/data/05-shb/ultimate/the_epic_of_alexander.txt
+++ b/ui/raidboss/data/05-shb/ultimate/the_epic_of_alexander.txt
@@ -167,7 +167,7 @@ hideall "Liquid Gaol"
 731.7 "Eternal Darkness Enrage" sync /:Cruise Chaser:4875:/
 771.9 "Divine Judgment Enrage" sync /:Alexander Prime:4879:/
 787.3 "Divine Judgment" sync /:Alexander:487A:/
-772.0 "Down for the Count" duration 66
+787.4 "Down for the Count" duration 57
 
 ### Phase 4: Perfect Alexander Part 1 - Fate Projection α
 900.0 "" sync /:Perfect Alexander:4A8B:/ window 900,0


### PR DESCRIPTION
Added x6 to Splash to mirror Tumults in e4s, I propose to make this a duration timer as well.
Adjusted some of the later timers for the Cruise Chaser transition with new logs.
Comments for phases and transition titles.

Based on these logs:
https://www.fflogs.com/reports/rGj4dhJZv2nQmBFP#fight=23
https://www.fflogs.com/reports/kWpGy7gKPNJ3jrYH#fight=18

Edit:
Twitch VoD for the first set of logs - https://www.twitch.tv/videos/508191550?t=07h22m50s could be useful for trigger development.