### PR TITLE
Remove oopsyraidsy warning message on ninja rabbit cast

### DIFF
--- a/ui/oopsyraidsy/data/00-misc/general.js
+++ b/ui/oopsyraidsy/data/00-misc/general.js
@@ -39,6 +39,6 @@
           return;
         delete data.lostFood[e.targetName];
       },
-    }
+    },
   ],
 }];

--- a/ui/oopsyraidsy/data/00-misc/general.js
+++ b/ui/oopsyraidsy/data/00-misc/general.js
@@ -39,25 +39,6 @@
           return;
         delete data.lostFood[e.targetName];
       },
-    },
-    {
-      id: 'General Rabbit Medium',
-      abilityRegex: gLang.kAbility.RabbitMedium,
-      condition: function(e, data) {
-        return data.IsPlayerId(e.attackerId);
-      },
-      mistake: function(e, data) {
-        return {
-          type: 'warn',
-          blame: e.attackerName,
-          text: {
-            en: 'bunny',
-            de: 'Hase',
-            fr: e.abilityName,
-            ja: e.abilityName,
-          },
-        };
-      },
-    },
+    }
   ],
 }];

--- a/user/oopsyraidsy-example.js
+++ b/user/oopsyraidsy-example.js
@@ -90,6 +90,6 @@ Options.Triggers = [
         },
       };
     },
-  }
+  },
   // ...more triggers here...
 ];

--- a/user/oopsyraidsy-example.js
+++ b/user/oopsyraidsy-example.js
@@ -25,7 +25,6 @@ Options.MinimumTimeForPullMistake = 0.4;
 // each fight in the files inside of this directory:
 // https://github.com/quisquous/cactbot/tree/master/ui/oopsyraidsy/data/
 Options.DisabledTriggers = {
-  'General Rabbit Medium': true,
   'General Early Pull': true,
   'Test Bootshine': true,
 };
@@ -53,7 +52,9 @@ Options.AbilityIdNameMap['26CA'] = 'White Swirly';
 // https://github.com/quisquous/cactbot/tree/master/ui/oopsyraidsy/data/
 //
 // Here's an example trigger to show a line in the mistake log when
-// you crit adlo yourself in Summerford Farms.
+// you crit adlo yourself in Summerford Farms, and a trigger to show
+// a line in the mistake log when you or a party member casts Rabbit Medium
+// (caused when ninjas mess up their mudras).
 Options.Triggers = [
   {
     zoneRegex: /^Middle La Noscea$/,
@@ -71,5 +72,24 @@ Options.Triggers = [
       },
     ],
   },
+  {
+    id: 'General Rabbit Medium',
+    abilityRegex: gLang.kAbility.RabbitMedium,
+    condition: function(e, data) {
+      return data.IsPlayerId(e.attackerId);
+    },
+    mistake: function(e, data) {
+      return {
+        type: 'warn',
+        blame: e.attackerName,
+        text: {
+          en: 'bunny',
+          de: 'Hase',
+          fr: e.abilityName,
+          ja: e.abilityName,
+        },
+      };
+    },
+  }
   // ...more triggers here...
 ];


### PR DESCRIPTION
This PR moves the oopsyraidsy warning message when ninjas mess up their mudras and cast rabbit medium out of the default messages in general.js and into the user example file.

My reasoning was no other class displays individual mechanical errors as a oopsyraidsy warning, and that a mudra error doesn't necessarily even mean a trick attack error--it could be from a raiton/suiton outside of the suiton for trick attack. Even if it was, no other class displays errors even for messing up raid buffs.

Let me know what you think!