### PR TITLE
fisher: Add support for undiscovered fishing holes

### DIFF
--- a/ui/fisher/fisher.js
+++ b/ui/fisher/fisher.js
@@ -108,7 +108,7 @@ class Fisher {
         'nocatch': /00:08c3:([\w\s-']+)?(?:\u3044\u3064\u306e\u9593\u306b\u304b\u91e3\u308a\u990c\u3092\u3068\u3089\u308c\u3066\u3057\u307e\u3063\u305f\u2026\u2026\u3002|\u3044\u3064\u306e\u9593\u306b\u304b.+\u3092\u30ed\u30b9\u30c8\u3057\u3066\u3057\u307e\u3063\u305f\uff01|\u3044\u3064\u306e\u9593\u306b\u304b\u91e3\u308a\u990c\u3092\u3068\u3089\u308c\u3066\u3057\u307e\u3063\u305f\u2026\u2026\u3002|\u91e3\u308a\u91dd\u306b\u304b\u304b\u3063\u305f\u9b5a\u306b\u9003\u3052\u3089\u308c\u3066\u3057\u307e\u3063\u305f\u2026\u2026\u3002|\u30e9\u30a4\u30f3\u30d6\u30ec\u30a4\u30af\uff01\uff01|\u4f55\u3082\u304b\u304b\u3089\u306a\u304b\u3063\u305f\u2026\u2026\u3002\n\n\u91e3\u308a\u990c\u304c\u91e3\u308a\u5834\u306b\u3042\u3063\u3066\u306a\u3044\u3088\u3046\u3060\u3002|\u4f55\u3082\u304b\u304b\u3089\u306a\u304b\u3063\u305f\u2026\u2026\u3002|.+\u306f\u91e3\u308a\u3092\u4e2d\u65ad\u3057\u305f\u3002|\u9b5a\u306b\u9003\u3052\u3089\u308c\u3001.+\u3092\u30ed\u30b9\u30c8\u3057\u3066\u3057\u307e\u3063\u305f\u2026\u2026\u3002|\u9b5a\u305f\u3061\u306b\u8b66\u6212\u3055\u308c\u3066\u3057\u307e\u3063\u305f\u3088\u3046\u3060\u2026\u2026|.+\u3092\u91e3\u308a\u4e0a\u3052\u305f\u304c\u3001\u3053\u308c\u4ee5\u4e0a\u6301\u3066\u306a\u3044\u305f\u3081\u30ea\u30ea\u30fc\u30b9\u3057\u305f\u3002)/,
         'mooch': /00:08c3:(?:[\w\s-']+)\u306f\u91e3\u308a\u4e0a\u3052\u305f.+\u3092\u614e\u91cd\u306b\u6295\u3052\u8fbc\u307f\u3001\u6cf3\u304c\u305b\u91e3\u308a\u3092\u8a66\u307f\u305f\u3002/,
         'quit': /00:08c3:(?:[\w\s-']+)?(?:\u306f\u91e3\u308a\u3092\u7d42\u3048\u305f\u3002|\u6226\u95d8\u4e0d\u80fd\u306b\u306a\u3063\u305f\u305f\u3081\u3001\u91e3\u308a\u304c\u4e2d\u65ad\u3055\u308c\u307e\u3057\u305f\u3002|\u306f\u91e3\u308a\u3092\u7d42\u3048\u305f\u3002|\u6575\u304b\u3089\u653b\u6483\u3092\u53d7\u3051\u305f\u305f\u3081\u3001\u91e3\u308a\u304c\u4e2d\u65ad\u3055\u308c\u307e\u3057\u305f\u3002)/,
-          'discovered': /00:08c3:\u91E3\u308A\u624B\u5E33\u306B\u65B0\u3057\u3044\u91E3\u308A\u5834「([\u3000-\u30ff\u3400-\u4dbf\u4e00-\u9faf]+)」\u306E\u60C5\u5831\u3092\u8A18\u9332\u3057\u305F\uFF01/,
+        'discovered': /00:08c3:\u91E3\u308A\u624B\u5E33\u306B\u65B0\u3057\u3044\u91E3\u308A\u5834「([\u3000-\u30ff\u3400-\u4dbf\u4e00-\u9faf]+)」\u306E\u60C5\u5831\u3092\u8A18\u9332\u3057\u305F\uFF01/,
       },
       'cn': {
         'undiscovered': /\u672a\u77e5\u9493\u573a/,
@@ -122,7 +122,7 @@ class Fisher {
         'snaggain': /00:08ae:(⇒ )?(?:[\w\s-'\u4e00-\u9fa5·]+)附加了“.*钓组.*”效果。/,
         'snagfade': /00:08b0:(?:[\w\s-'\u4e00-\u9fa5·]+)的“.*钓组.*”状态效果消失了。/,
         'quit': /00:08c3:(?:[\w\s-'\u4e00-\u9fa5·]+)?(?:收回了鱼线。|陷入了战斗不能状态，钓鱼中断。|收回了鱼线。|受到了敌人的攻击，钓鱼中断。)/,
-        'discovered':/00:08c3:将新钓场.*([\u3000-\u30ff\u3400-\u4dbf\u4e00-\u9faf·]+\d*).*记录到了钓鱼笔记中！/,
+        'discovered': /00:08c3:将新钓场.*([\u3000-\u30ff\u3400-\u4dbf\u4e00-\u9faf·]+\d*).*记录到了钓鱼笔记中！/,
       },
     };
 
@@ -203,34 +203,33 @@ class Fisher {
     this.castGet = null;
     this.fishing = true;
 
-    //undiscovered fishing hole
+    // undiscovered fishing hole
     if (this.regex[Options.Language]['undiscovered'].test(place)) {
       // store this for now
       // if we catch anything we'll pull the data then
       // "data on 'x' is added to your fishing log" is printed before the catch
       this.place = place;
       this.ui.setPlace(this.place);
-      //clear previous fish data (if any)
+      // clear previous fish data (if any)
       this.ui.redrawFish({}, {});
 
       this.ui.startFishing();
       return;
-    } else {
-      // Set place, if it's unset
-      if (!this.place || !this.place.id) {
-        this.place = this.seaBase.getPlace(place);
-        // This lookup could fail and, for German,
-        // this.place.name may differ from place
-        // due to differing cast vs location names.
-        if (this.place.id)
-          this.ui.setPlace(this.place.name);
-      }
-      let _this = this;
-
-      this.updateFishData().then(function () {
-        _this.ui.startFishing();
-      });
     }
+    // Set place, if it's unset
+    if (!this.place || !this.place.id) {
+      this.place = this.seaBase.getPlace(place);
+      // This lookup could fail and, for German,
+      // this.place.name may differ from place
+      // due to differing cast vs location names.
+      if (this.place.id)
+        this.ui.setPlace(this.place.name);
+    }
+    let _this = this;
+
+    this.updateFishData().then(function() {
+      _this.ui.startFishing();
+    });
   }
 
   handleBite() {
@@ -312,7 +311,7 @@ class Fisher {
     this.ui.setPlace(null);
     this.element.style.opacity = 0;
   }
-  
+
   handleDiscover(place) {
     this.place = this.seaBase.getPlace(place);
     // This lookup could fail and, for German,

--- a/ui/fisher/fisher.js
+++ b/ui/fisher/fisher.js
@@ -39,11 +39,12 @@ class Fisher {
     this.castGet = null;
 
     this.regex = {
-      // Localized strings from: https://xivapi.com/LogMessage?pretty=1&columns=ID,Text_de,Text_en,Text_fr,Text_ja&ids=1110,1111,1112,1113,1116,1117,1118,1119,1120,1121,1127,1129,3511,3512,3515,3516,3525
+      // Localized strings from: https://xivapi.com/LogMessage?pretty=1&columns=ID,Text_de,Text_en,Text_fr,Text_ja&ids=1110,1111,1112,1113,1115,1116,1117,1118,1119,1120,1121,1127,1129,3511,3512,3515,3516,3525
       // 1110: cast
       // 1111: quit (stop)
       // 1112: quit (death)
       // 1113: quit (combat)
+      // 1115: discovered (area)
       // 1116: bite
       // 1117: nocatch (lose bait)
       // 1118: nocatch (lose lure)
@@ -62,6 +63,7 @@ class Fisher {
         // Note, the preposition in German is stored in the cast string, so is ignored here.
         // We could attempt to trim prepositions in the fishing data and then include all
         // potential prepositions here, but I don't know German that well.
+        'undiscovered': /unerforschten Angelplatz/,
         'cast': /00:08c3:Du hast mit dem Fischen (.+) begonnen\./,
         'bite': /00:08c3:Etwas hat angebissen!/,
         'catch': /00:0843:Du hast (?:einen |eine )?.+?\s?([\w\s\-\'\.\d\u00c4-\u00fc]{3,})(?: | [^\w] |[^\w\s\-\'\u00c4-\u00fc].+ )\(\d/,
@@ -72,8 +74,10 @@ class Fisher {
         'snaggain': /00:08ae:⇒ You gain the effect of Reißen/,
         'snagfade': /00:08b0:You lose the effect of Reßien/,
         'quit': /00:08c3:(?:Du hast das Fischen beendet\.|Das Fischen wurde abgebrochen)/,
+        'discovered': /00:08c3:Die neue Angelstelle ([^\w\s\-\'\u00c4-\u00fc].+ ) wurde in deinem Fischer-Notizbuch vermerkt\./,
       },
       'en': {
+        'undiscovered': /undiscovered fishing hole/,
         'cast': /00:08c3:(?:[\w']\.?)(?:[\w'\s]+\.?)? cast(?:s?) (?:your|his|her) line (?:on|in|at) (?:the )?([\w\s'&()]+)\./,
         'bite': /00:08c3:Something bites!/,
         'catch': /00:0843:(?:[\w']\.?)(?:[\w'\s]+\.?)? land(?:s?) (?:a|an|[\d]+ )?.+?([\w\s\-\'\#\d]{3,})(?: | [^\w] |[^\w\s].+ )measuring \d/,
@@ -84,24 +88,30 @@ class Fisher {
         'snaggain': /00:08ae:⇒ You gain the effect of Snagging/,
         'snagfade': /00:08b0:You lose the effect of Snagging/,
         'quit': /00:08c3:(?:(?:[\w']\.?)(?:[\w'\s]+\.?)? put(?:s?) away (?:your|his|her) rod\.|Fishing canceled)/,
+        'discovered': /00:08c3:(?:Data on ([\w\s'&()]+)) is added to your fishing log\./,
       },
       'fr': {
+        'undiscovered': /Zone de pêche inconnue/,
         'cast': /00:08c3:Vous commencez \u00e0 p\u00eacher. Point de p\u00eache: ([\w\s\'\(\)\u00c0-\u017f]+)/,
         'bite': /00:08c3:Vous avez une touche!/,
         'catch': /00:0843:Vous avez p\u00each\u00e9 (?:un |une )?.+?\s?([\w\s\-\'\u00b0\u00c0-\u017f]{3,})\ue03c?.+de \d/,
         'nocatch': /00:08c3:(?:L'app\u00e2t a disparu|Vous avez perdu votre|L'app\u00e2t a disparu|Le poisson a r\u00e9ussi \u00e0 se d\u00e9faire de l'hame\u00e7on|Le fil s'est cass\u00e9|Vous n'avez pas eu de touche|Vous n'avez pas r\u00e9ussi \u00e0 ferrer le poisson|Vous arr\u00eatez de p\u00eacher|Le poisson s'est enfui et a emport\u00e9 avec lui votre|Les poissons sont devenus m\u00e9fiants|Vous avez p\u00each\u00e9 .+, mais ne pouvez en poss\u00e9der davantage et l'avez donc rel\u00e2ch\u00e9)/,
         'mooch': /00:08c3:Vous essayez de p\u00eacher au vif avec/,
         'quit': /00:08c3:(?:Vous arr\u00eatez de p\u00eacher\.|P\u00eache interrompue)/,
+        'discovered': /00:08c3:Vous notez le banc de poissons “([\w\s\'\(\)\u00c0-\u017f]+)” dans votre carnet\./,
       },
       'ja': {
+        'undiscovered': /\u672a\u77e5\u306e\u91e3\u308a\u5834/,
         'cast': /00:08c3:(?:[\w\s-']+)\u306f([\u3000-\u30ff\u3400-\u4dbf\u4e00-\u9faf]+)\u3067\u91e3\u308a\u3092\u958b\u59cb\u3057\u305f\u3002/,
         'bite': /00:08c3:\u9b5a\u3092\u30d5\u30c3\u30ad\u30f3\u30b0\u3057\u305f\uff01/,
         'catch': /00:0843:(?:[\w\s-']+)\u306f.+?([\u3000-\u30ff\u3400-\u4dbf\u4e00-\u9faf]+)(?:[^\u3000-\u30ff\u3400-\u4dbf\u4e00-\u9faf]+)?\uff08\d+\.\d\u30a4\u30eb\u30e0\uff09\u3092\u91e3\u308a\u4e0a\u3052\u305f\u3002/,
         'nocatch': /00:08c3:([\w\s-']+)?(?:\u3044\u3064\u306e\u9593\u306b\u304b\u91e3\u308a\u990c\u3092\u3068\u3089\u308c\u3066\u3057\u307e\u3063\u305f\u2026\u2026\u3002|\u3044\u3064\u306e\u9593\u306b\u304b.+\u3092\u30ed\u30b9\u30c8\u3057\u3066\u3057\u307e\u3063\u305f\uff01|\u3044\u3064\u306e\u9593\u306b\u304b\u91e3\u308a\u990c\u3092\u3068\u3089\u308c\u3066\u3057\u307e\u3063\u305f\u2026\u2026\u3002|\u91e3\u308a\u91dd\u306b\u304b\u304b\u3063\u305f\u9b5a\u306b\u9003\u3052\u3089\u308c\u3066\u3057\u307e\u3063\u305f\u2026\u2026\u3002|\u30e9\u30a4\u30f3\u30d6\u30ec\u30a4\u30af\uff01\uff01|\u4f55\u3082\u304b\u304b\u3089\u306a\u304b\u3063\u305f\u2026\u2026\u3002\n\n\u91e3\u308a\u990c\u304c\u91e3\u308a\u5834\u306b\u3042\u3063\u3066\u306a\u3044\u3088\u3046\u3060\u3002|\u4f55\u3082\u304b\u304b\u3089\u306a\u304b\u3063\u305f\u2026\u2026\u3002|.+\u306f\u91e3\u308a\u3092\u4e2d\u65ad\u3057\u305f\u3002|\u9b5a\u306b\u9003\u3052\u3089\u308c\u3001.+\u3092\u30ed\u30b9\u30c8\u3057\u3066\u3057\u307e\u3063\u305f\u2026\u2026\u3002|\u9b5a\u305f\u3061\u306b\u8b66\u6212\u3055\u308c\u3066\u3057\u307e\u3063\u305f\u3088\u3046\u3060\u2026\u2026|.+\u3092\u91e3\u308a\u4e0a\u3052\u305f\u304c\u3001\u3053\u308c\u4ee5\u4e0a\u6301\u3066\u306a\u3044\u305f\u3081\u30ea\u30ea\u30fc\u30b9\u3057\u305f\u3002)/,
         'mooch': /00:08c3:(?:[\w\s-']+)\u306f\u91e3\u308a\u4e0a\u3052\u305f.+\u3092\u614e\u91cd\u306b\u6295\u3052\u8fbc\u307f\u3001\u6cf3\u304c\u305b\u91e3\u308a\u3092\u8a66\u307f\u305f\u3002/,
         'quit': /00:08c3:(?:[\w\s-']+)?(?:\u306f\u91e3\u308a\u3092\u7d42\u3048\u305f\u3002|\u6226\u95d8\u4e0d\u80fd\u306b\u306a\u3063\u305f\u305f\u3081\u3001\u91e3\u308a\u304c\u4e2d\u65ad\u3055\u308c\u307e\u3057\u305f\u3002|\u306f\u91e3\u308a\u3092\u7d42\u3048\u305f\u3002|\u6575\u304b\u3089\u653b\u6483\u3092\u53d7\u3051\u305f\u305f\u3081\u3001\u91e3\u308a\u304c\u4e2d\u65ad\u3055\u308c\u307e\u3057\u305f\u3002)/,
+          'discovered': /00:08c3:\u91E3\u308A\u624B\u5E33\u306B\u65B0\u3057\u3044\u91E3\u308A\u5834「([\u3000-\u30ff\u3400-\u4dbf\u4e00-\u9faf]+)」\u306E\u60C5\u5831\u3092\u8A18\u9332\u3057\u305F\uFF01/,
       },
       'cn': {
+        'undiscovered': /\u672a\u77e5\u9493\u573a/,
         'cast': /00:08c3:(?:[\w\s-'\u4e00-\u9fa5]+)在([\w\s-'\u4e00-\u9fa5·]+)甩出了鱼线开始钓鱼。/,
         'bite': /00:08c3:有鱼上钩了！/,
         'catch': /00:0843:(?:[\w\s-'\u4e00-\u9fa5·]+)?成功钓上了.*?([\u3000-\u30ff\u3400-\u4dbf\u4e00-\u9faf·]+\d*).*（\d+\.\d星寸）。/,
@@ -112,6 +122,7 @@ class Fisher {
         'snaggain': /00:08ae:(⇒ )?(?:[\w\s-'\u4e00-\u9fa5·]+)附加了“.*钓组.*”效果。/,
         'snagfade': /00:08b0:(?:[\w\s-'\u4e00-\u9fa5·]+)的“.*钓组.*”状态效果消失了。/,
         'quit': /00:08c3:(?:[\w\s-'\u4e00-\u9fa5·]+)?(?:收回了鱼线。|陷入了战斗不能状态，钓鱼中断。|收回了鱼线。|受到了敌人的攻击，钓鱼中断。)/,
+        'discovered':/00:08c3:将新钓场.*([\u3000-\u30ff\u3400-\u4dbf\u4e00-\u9faf·]+\d*).*记录到了钓鱼笔记中！/,
       },
     };
 
@@ -192,21 +203,34 @@ class Fisher {
     this.castGet = null;
     this.fishing = true;
 
-    // Set place, if it's unset
-    if (!this.place || !this.place.id) {
-      this.place = this.seaBase.getPlace(place);
-      // This lookup could fail and, for German,
-      // this.place.name may differ from place
-      // due to differing cast vs location names.
-      if (this.place.id)
-        this.ui.setPlace(this.place.name);
+    //undiscovered fishing hole
+    if (this.regex[Options.Language]['undiscovered'].test(place)) {
+      // store this for now
+      // if we catch anything we'll pull the data then
+      // "data on 'x' is added to your fishing log" is printed before the catch
+      this.place = place;
+      this.ui.setPlace(this.place);
+      //clear previous fish data (if any)
+      this.ui.redrawFish({}, {});
+
+      this.ui.startFishing();
+      return;
+    } else {
+      // Set place, if it's unset
+      if (!this.place || !this.place.id) {
+        this.place = this.seaBase.getPlace(place);
+        // This lookup could fail and, for German,
+        // this.place.name may differ from place
+        // due to differing cast vs location names.
+        if (this.place.id)
+          this.ui.setPlace(this.place.name);
+      }
+      let _this = this;
+
+      this.updateFishData().then(function () {
+        _this.ui.startFishing();
+      });
     }
-
-    let _this = this;
-
-    this.updateFishData().then(function() {
-      _this.ui.startFishing();
-    });
   }
 
   handleBite() {
@@ -288,6 +312,16 @@ class Fisher {
     this.ui.setPlace(null);
     this.element.style.opacity = 0;
   }
+  
+  handleDiscover(place) {
+    this.place = this.seaBase.getPlace(place);
+    // This lookup could fail and, for German,
+    // this.place.name may differ from place
+    // due to differing cast vs location names.
+    if (this.place.id)
+      this.ui.setPlace(this.place.name);
+    this.updateFishData();
+  }
 
   parseLine(log) {
     let result = null;
@@ -307,6 +341,7 @@ class Fisher {
         case 'chumgain': this.handleChumGain(); break;
         case 'chumfade': this.handleChumFade(); break;
         case 'quit': this.handleQuit(); break;
+        case 'discovered': this.handleDiscover(result[1]); break;
         }
       }
     }


### PR DESCRIPTION
Hiya, following a discussion on the ACT discord, the current fisher overlay doesn't handle undiscovered fishing holes very well.
I'm not very confident with the chinese regexes I've added, but I was able to test the en/fr/de/ja entries.

@xephero If you would like to look this over I'm open to any comments you may have.

Thanks!