### PR TITLE
jobs: use 0xC player stats log line to determine gcd 

### DIFF
--- a/resources/lang/cn.js
+++ b/resources/lang/cn.js
@@ -48,6 +48,7 @@ class CactbotLanguageCn extends CactbotLanguage {
       ArmysEthos: '军神的契约',
       PresenceOfMind: '神速咏唱',
       Shifu: '士风',
+      CircleOfPower: '魔纹环',
 
       Paralysis: 'FIXME',
       Petrification: '石化',

--- a/resources/lang/cn.js
+++ b/resources/lang/cn.js
@@ -43,7 +43,11 @@ class CactbotLanguageCn extends CactbotLanguage {
       Thundercloud: '雷云',
       Firestarter: '火苗',
       BattleVoice: '战斗之声',
-      Divination: 'FIXME',
+      Divination: '占卜',
+      ArmysMuse: '军神的加护',
+      ArmysEthos: '军神的契约',
+      PresenceOfMind: '神速咏唱',
+      Shifu: '士风',
 
       Paralysis: 'FIXME',
       Petrification: '石化',

--- a/resources/lang/de.js
+++ b/resources/lang/de.js
@@ -48,6 +48,7 @@ class CactbotLanguageDe extends CactbotLanguage {
       ArmysEthos: 'Beistand des Schlachtensängers',
       PresenceOfMind: 'Geistesgegenwart',
       Shifu: 'Shifu',
+      CircleOfPower: 'Ley-Linien',
 
       Paralysis: 'Paralyse',
       Petrification: 'Stein',

--- a/resources/lang/de.js
+++ b/resources/lang/de.js
@@ -36,6 +36,7 @@ class CactbotLanguageDe extends CactbotLanguage {
       Devotion: 'Hingabe', // 0x4bd
       FoeRequiem: 'Requiem Der Feinde', // up 0x8b, down 0x8c
       LeadenFist: 'Verbesserter Schlag auf Schlag',
+      StormsEye: 'Sturmbrecher',
       Devilment: 'Todestango',
       TechnicalFinish: 'Komplexes Finale',
       StandardFinish: 'Einfaches Finale',
@@ -43,6 +44,10 @@ class CactbotLanguageDe extends CactbotLanguage {
       Firestarter: 'Feuga +',
       BattleVoice: 'Ode an die Seele',
       Divination: 'Weissagung',
+      ArmysMuse: 'Gunst des Schlachtensängers',
+      ArmysEthos: 'Beistand des Schlachtensängers',
+      PresenceOfMind: 'Geistesgegenwart',
+      Shifu: 'Shifu',
 
       Paralysis: 'Paralyse',
       Petrification: 'Stein',

--- a/resources/lang/en.js
+++ b/resources/lang/en.js
@@ -48,6 +48,7 @@ class CactbotLanguageEn extends CactbotLanguage {
       ArmysEthos: 'Army\'s Ethos',
       PresenceOfMind: 'Presence Of Mind',
       Shifu: 'Shifu',
+      CircleOfPower: 'Circle Of Power',
 
       Paralysis: 'Paralysis',
       Petrification: 'Petrification',

--- a/resources/lang/en.js
+++ b/resources/lang/en.js
@@ -44,6 +44,10 @@ class CactbotLanguageEn extends CactbotLanguage {
       Firestarter: 'Firestarter',
       BattleVoice: 'Battle Voice',
       Divination: 'Divination',
+      ArmysMuse: 'Army\'s Muse',
+      ArmysEthos: 'Army\'s Ethos',
+      PresenceOfMind: 'Presence Of Mind',
+      Shifu: 'Shifu',
 
       Paralysis: 'Paralysis',
       Petrification: 'Petrification',

--- a/resources/lang/fr.js
+++ b/resources/lang/fr.js
@@ -48,6 +48,7 @@ class CactbotLanguageFr extends CactbotLanguage {
       ArmysEthos: 'Pacte martial',
       PresenceOfMind: 'Présence d\'esprit',
       Shifu: 'Shifû',
+      CircleOfPower: 'Manalignements',
 
       Paralysis: 'Paralysie',
       Petrification: 'Pétrification',

--- a/resources/lang/fr.js
+++ b/resources/lang/fr.js
@@ -36,6 +36,7 @@ class CactbotLanguageFr extends CactbotLanguage {
       Devotion: 'Dévouement', // 0x4bd
       FoeRequiem: 'Requiem ennemi', // up 0x8b, down 0x8c
       LeadenFist: 'Poings de plomb',
+      StormsEye: 'Œil de la tempête',
       Devilment: 'Tango endiablé',
       TechnicalFinish: 'Final technique',
       StandardFinish: 'Final classique',
@@ -43,6 +44,10 @@ class CactbotLanguageFr extends CactbotLanguage {
       Firestarter: 'Pyromane',
       BattleVoice: 'Voix de combat',
       Divination: 'Divination',
+      ArmysMuse: 'Bénédiction martiale',
+      ArmysEthos: 'Pacte martial',
+      PresenceOfMind: 'Présence d\'esprit',
+      Shifu: 'Shifû',
 
       Paralysis: 'Paralysie',
       Petrification: 'Pétrification',

--- a/resources/lang/ja.js
+++ b/resources/lang/ja.js
@@ -48,6 +48,7 @@ class CactbotLanguageJa extends CactbotLanguage {
       ArmysEthos: '軍神の契約',
       PresenceOfMind: '神速魔',
       Shifu: '士風',
+      CircleOfPower: '黒魔紋：効果',
 
       Paralysis: '麻痺',
       Petrification: '石化',

--- a/resources/lang/ja.js
+++ b/resources/lang/ja.js
@@ -36,6 +36,7 @@ class CactbotLanguageJa extends CactbotLanguage {
       Devotion: 'エギの加護', // 0x4bd
       FoeRequiem: '魔人のレクイエム', // up 0x8b, down 0x8c
       LeadenFist: '連撃効果アップ',
+      StormsEye: 'シュトルムブレハ',
       Devilment: '攻めのタンゴ',
       TechnicalFinish: 'テクニカルフィニッシュ',
       StandardFinish: 'スタンダードフィニッシュ',
@@ -43,6 +44,10 @@ class CactbotLanguageJa extends CactbotLanguage {
       Firestarter: 'ファイガ効果アップ',
       BattleVoice: 'バトルボイス',
       Divination: 'ディヴィネーション',
+      ArmysMuse: '軍神の加護',
+      ArmysEthos: '軍神の契約',
+      PresenceOfMind: '神速魔',
+      Shifu: '士風',
 
       Paralysis: '麻痺',
       Petrification: '石化',

--- a/resources/lang/ko.js
+++ b/resources/lang/ko.js
@@ -36,6 +36,7 @@ class CactbotLanguageKo extends CactbotLanguage {
       Devotion: '에기의 가호', // 0x4bd
       FoeRequiem: '마인의 진혼곡', // up 0x8b, down 0x8c
       LeadenFist: 'FIXME',
+      StormsEye: '폭풍의 눈',
       Devilment: 'FIXME',
       TechnicalFinish: 'FIXME',
       StandardFinish: 'FIXME',
@@ -43,6 +44,10 @@ class CactbotLanguageKo extends CactbotLanguage {
       Firestarter: 'FIXME',
       BattleVoice: 'FIXME',
       Divination: 'FIXME',
+      ArmysMuse: 'FIXME',
+      ArmysEthos: 'FIXME',
+      PresenceOfMind: '쾌속의 마법',
+      Shifu: '사풍',
 
       Paralysis: 'FIXME',
       Petrification: '석화',

--- a/resources/lang/ko.js
+++ b/resources/lang/ko.js
@@ -48,6 +48,7 @@ class CactbotLanguageKo extends CactbotLanguage {
       ArmysEthos: 'FIXME',
       PresenceOfMind: '쾌속의 마법',
       Shifu: '사풍',
+      CircleOfPower: '흑마법 문양: 효과',
 
       Paralysis: 'FIXME',
       Petrification: '석화',

--- a/resources/regexes.js
+++ b/resources/regexes.js
@@ -319,24 +319,50 @@ var Regexes = {
     return Regexes.parse(str);
   },
 
+  // fields: job, strength, dexterity, vitality, intelligence, mind, piety, attack_power,
+  //         direct_hit, critical_hit, attack_magic_potency, heal_magic_potency, determination,
+  //         skill_speed, spell_speed, tenacity, capture
   // matches: https://github.com/quisquous/cactbot/blob/master/docs/LogGuide.md#0c-playerstats
-  statChange: () => {
-    let str = '\\y{Timestamp} 0C:Player Stats: ' + '\\d+' + ':' + // skip job field
-      Regexes.namedCapture('strength', '\\d+') + ':' +
-      Regexes.namedCapture('dexterity', '\\d+') + ':' +
-      Regexes.namedCapture('vitality', '\\d+') + ':' +
-      Regexes.namedCapture('intelligence', '\\d+') + ':' +
-      Regexes.namedCapture('mind', '\\d+') + ':' +
-      Regexes.namedCapture('piety', '\\d+') + ':' +
-      Regexes.namedCapture('attack_power', '\\d+') + ':' +
-      Regexes.namedCapture('direct_hit', '\\d+') + ':' +
-      Regexes.namedCapture('critical_hit', '\\d+') + ':' +
-      Regexes.namedCapture('attack_magic_potency', '\\d+') + ':' +
-      Regexes.namedCapture('heal_magic_potency', '\\d+') + ':' +
-      Regexes.namedCapture('determination', '\\d+') + ':' +
-      Regexes.namedCapture('skill_speed', '\\d+') + ':' +
-      Regexes.namedCapture('spell_speed', '\\d+') + ':0:' +
-      Regexes.namedCapture('tenacity', '\\d+');
+  statChange: (f) => {
+    if (typeof f === 'undefined')
+      f = {};
+    validateParams(f, 'statChange', [
+      'job',
+      'strength',
+      'dexterity',
+      'vitality',
+      'intelligence',
+      'mind',
+      'piety',
+      'attack_power',
+      'direct_hit',
+      'critical_hit',
+      'attack_magic_potency',
+      'heal_magic_potency',
+      'determination',
+      'skill_speed',
+      'spell_speed',
+      'tenacity',
+      'capture',
+    ]);
+    let capture = trueIfUndefined(f.capture);
+    let str = '\\y{Timestamp} 0C:Player Stats: ' +
+      Regexes.maybeCapture(capture, 'job', f.job, '\\d+') + ':' +
+      Regexes.maybeCapture(capture, 'strength', f.strength, '\\d+') + ':' +
+      Regexes.maybeCapture(capture, 'dexterity', f.dexterity, '\\d+') + ':' +
+      Regexes.maybeCapture(capture, 'vitality', f.vitality, '\\d+') + ':' +
+      Regexes.maybeCapture(capture, 'intelligence', f.intelligence, '\\d+') + ':' +
+      Regexes.maybeCapture(capture, 'mind', f.mind, '\\d+') + ':' +
+      Regexes.maybeCapture(capture, 'piety', f.piety, '\\d+') + ':' +
+      Regexes.maybeCapture(capture, 'attack_power', f.attack_power, '\\d+') + ':' +
+      Regexes.maybeCapture(capture, 'direct_hit', f.direct_hit, '\\d+') + ':' +
+      Regexes.maybeCapture(capture, 'critical_hit', f.critical_hit, '\\d+') + ':' +
+      Regexes.maybeCapture(capture, 'attack_magic_potency', f.attack_magic_potency, '\\d+') + ':' +
+      Regexes.maybeCapture(capture, 'heal_magic_potency', f.heal_magic_potency, '\\d+') + ':' +
+      Regexes.maybeCapture(capture, 'determination', f.determination, '\\d+') + ':' +
+      Regexes.maybeCapture(capture, 'skill_speed', f.skill_speed, '\\d+') + ':' +
+      Regexes.maybeCapture(capture, 'spell_speed', f.spell_speed, '\\d+') + ':0:' +
+      Regexes.maybeCapture(capture, 'tenacity', f.tenacity, '\\d+');
     return Regexes.parse(str);
   },
 

--- a/resources/regexes.js
+++ b/resources/regexes.js
@@ -321,7 +321,7 @@ var Regexes = {
 
   // matches: https://github.com/quisquous/cactbot/blob/master/docs/LogGuide.md#0c-playerstats
   statChange: () => {
-    let str = '\\y{Timestamp} 0C:Player Stats: ' + '\\d+' + ':' + //skip job field
+    let str = '\\y{Timestamp} 0C:Player Stats: ' + '\\d+' + ':' + // skip job field
       Regexes.namedCapture('strength', '\\d+') + ':' +
       Regexes.namedCapture('dexterity', '\\d+') + ':' +
       Regexes.namedCapture('vitality', '\\d+') + ':' +

--- a/resources/regexes.js
+++ b/resources/regexes.js
@@ -319,6 +319,27 @@ var Regexes = {
     return Regexes.parse(str);
   },
 
+  // matches: https://github.com/quisquous/cactbot/blob/master/docs/LogGuide.md#0c-playerstats
+  statChange: () => {
+    let str = '\\y{Timestamp} 0C:Player Stats: ' + '\\d+' + ':' + //skip job field
+      Regexes.namedCapture('strength', '\\d+') + ':' +
+      Regexes.namedCapture('dexterity', '\\d+') + ':' +
+      Regexes.namedCapture('vitality', '\\d+') + ':' +
+      Regexes.namedCapture('intelligence', '\\d+') + ':' +
+      Regexes.namedCapture('mind', '\\d+') + ':' +
+      Regexes.namedCapture('piety', '\\d+') + ':' +
+      Regexes.namedCapture('attack_power', '\\d+') + ':' +
+      Regexes.namedCapture('direct_hit', '\\d+') + ':' +
+      Regexes.namedCapture('critical_hit', '\\d+') + ':' +
+      Regexes.namedCapture('attack_magic_potency', '\\d+') + ':' +
+      Regexes.namedCapture('heal_magic_potency', '\\d+') + ':' +
+      Regexes.namedCapture('determination', '\\d+') + ':' +
+      Regexes.namedCapture('skill_speed', '\\d+') + ':' +
+      Regexes.namedCapture('spell_speed', '\\d+') + ':0:' +
+      Regexes.namedCapture('tenacity', '\\d+');
+    return Regexes.parse(str);
+  },
+
   // Helper function for building named capture group regexes.
   maybeCapture: (capture, name, value, defaultValue) => {
     if (!value)

--- a/resources/regexes.js
+++ b/resources/regexes.js
@@ -319,9 +319,9 @@ var Regexes = {
     return Regexes.parse(str);
   },
 
-  // fields: job, strength, dexterity, vitality, intelligence, mind, piety, attack_power,
-  //         direct_hit, critical_hit, attack_magic_potency, heal_magic_potency, determination,
-  //         skill_speed, spell_speed, tenacity, capture
+  // fields: job, strength, dexterity, vitality, intelligence, mind, piety, attackPower,
+  //         directHit, criticalHit, attackMagicPotency, healMagicPotency, determination,
+  //         skillSpeed, spellSpeed, tenacity, capture
   // matches: https://github.com/quisquous/cactbot/blob/master/docs/LogGuide.md#0c-playerstats
   statChange: (f) => {
     if (typeof f === 'undefined')
@@ -334,14 +334,14 @@ var Regexes = {
       'intelligence',
       'mind',
       'piety',
-      'attack_power',
-      'direct_hit',
-      'critical_hit',
-      'attack_magic_potency',
-      'heal_magic_potency',
+      'attackPower',
+      'directHit',
+      'criticalHit',
+      'attackMagicPotency',
+      'healMagicPotency',
       'determination',
-      'skill_speed',
-      'spell_speed',
+      'skillSpeed',
+      'spellSpeed',
       'tenacity',
       'capture',
     ]);
@@ -354,14 +354,15 @@ var Regexes = {
       Regexes.maybeCapture(capture, 'intelligence', f.intelligence, '\\d+') + ':' +
       Regexes.maybeCapture(capture, 'mind', f.mind, '\\d+') + ':' +
       Regexes.maybeCapture(capture, 'piety', f.piety, '\\d+') + ':' +
-      Regexes.maybeCapture(capture, 'attack_power', f.attack_power, '\\d+') + ':' +
-      Regexes.maybeCapture(capture, 'direct_hit', f.direct_hit, '\\d+') + ':' +
-      Regexes.maybeCapture(capture, 'critical_hit', f.critical_hit, '\\d+') + ':' +
-      Regexes.maybeCapture(capture, 'attack_magic_potency', f.attack_magic_potency, '\\d+') + ':' +
-      Regexes.maybeCapture(capture, 'heal_magic_potency', f.heal_magic_potency, '\\d+') + ':' +
+      Regexes.maybeCapture(capture, 'attackPower', f.attack_power, '\\d+') + ':' +
+      Regexes.maybeCapture(capture, 'directHit', f.direct_hit, '\\d+') + ':' +
+      Regexes.maybeCapture(capture, 'criticalHit', f.critical_hit, '\\d+') + ':' +
+      Regexes.maybeCapture(capture, 'attackMagicPotency', f.attack_magic_potency, '\\d+') + ':' +
+      Regexes.maybeCapture(capture, 'healMagicPotency', f.heal_magic_potency, '\\d+') + ':' +
       Regexes.maybeCapture(capture, 'determination', f.determination, '\\d+') + ':' +
-      Regexes.maybeCapture(capture, 'skill_speed', f.skill_speed, '\\d+') + ':' +
-      Regexes.maybeCapture(capture, 'spell_speed', f.spell_speed, '\\d+') + ':0:' +
+      Regexes.maybeCapture(capture, 'skillSpeed', f.skill_speed, '\\d+') + ':' +
+      Regexes.maybeCapture(capture, 'spellSpeed', f.spell_speed, '\\d+') +
+      ':0:' +
       Regexes.maybeCapture(capture, 'tenacity', f.tenacity, '\\d+');
     return Regexes.parse(str);
   },

--- a/test/unittests/regex_test.js
+++ b/test/unittests/regex_test.js
@@ -177,6 +177,14 @@ let tests = {
     allLines.push(...messageLines);
     regexCaptureTest(Regexes.gameLog, allLines);
   },
+  statchange: () => {
+    let lines = [
+      '[20:29:29.752] 0C:Player Stats: 23:311:4093:4245:295:280:340:4093:2496:2675:295:280:2334:578:380:0:380',
+      '[12:50:15.438] 0C:Player Stats: 17:311:348:1010:347:315:340:311:380:380:347:315:340:380:380:0:380',
+      '[01:11:57.108] 0C:Player Stats: 23:305:844:793:290:275:340:844:780:755:290:275:340:380:380:0:380',
+    ];
+    regexCaptureTest(Regexes.statChange, lines);
+  },
 };
 
 let keys = Object.keys(tests);

--- a/ui/jobs/jobs.js
+++ b/ui/jobs/jobs.js
@@ -31,12 +31,6 @@ let Options = {
     },
   },
 
-  RdmCastTime: 1.94 + 0.5,
-  WarGcd: 2.45,
-  PldGcd: 2.43,
-  AstGcd: 2.39,
-  BluGcd: 2.40,
-
   BigBuffIconWidth: 44,
   BigBuffIconHeight: 32,
   BigBuffBarHeight: 5,
@@ -59,6 +53,8 @@ let Options = {
   MidHealthThresholdPercent: 0.8,
 };
 
+let kMeleeWithMpJobs = ['DRK', 'PLD'];
+
 let kMPNormalRate = 0.06;
 let kMPCombatRate = 0.02;
 let kMPUI1Rate = 0.30;
@@ -75,6 +71,76 @@ let kYouLoseEffectRegex = null;
 let kYouUseAbilityRegex = null;
 let kAnybodyAbilityRegex = null;
 
+let kStatsRegex = Regexes.statChange();
+//[level][Sub][Div]
+//Source: http://theoryjerks.akhmorning.com/resources/levelmods/
+const kLevelMod = new Array([56, 56], [57, 57], [60, 60], [62, 62], [65, 65],
+                            [68, 68], [70, 70], [73, 73], [76, 76], [78, 78],
+                            [82, 82], [85, 85], [89, 89], [93, 93], [96, 96],
+                            [100, 100], [104, 104], [109, 109], [113, 113], [116, 116],
+                            [122, 122], [127, 127], [133, 133], [138, 138], [144, 144],
+                            [150, 150], [155, 155], [162, 162], [168, 168], [173, 173],
+                            [181, 181], [188, 188], [194, 194], [202, 202], [209, 209],
+                            [215, 215], [223, 223], [229, 229], [236, 236], [244, 244],
+                            [253, 253], [263, 263], [272, 272], [283, 283], [292, 292],
+                            [302, 302], [311, 311], [322, 322], [331, 331], [341, 341],
+                            [342, 393], [344, 444], [345, 496], [346, 548], [347, 600],
+                            [349, 651], [350, 703], [351, 755], [352, 806], [354, 858],
+                            [355, 941], [356, 1032], [357, 1133], [358, 1243], [369, 1364],
+                            [360, 1497], [361, 1643], [362, 1802], [363, 1978], [364, 2170],
+                            [365, 2263], [366, 2360], [367, 2461], [368, 2566], [370, 2676],
+                            [372, 2790], [374, 2910], [376, 3034], [378, 3164], [380, 3300]);
+
+//Source: http://theoryjerks.akhmorning.com/guide/speed/
+function kCalcGCDFromStat(stat, actiondelay) {
+  //default calculates for a 2.50s recast
+  actiondelay = actiondelay || 2500;
+  
+  let kType1Buffs = 0;
+  //TODO: Is there an easy way of tracking Circle of Power?
+  //let kInLeyLines = false;
+  let kType2Buffs = 0;
+  if (gBars.job == 'WHM') {
+    kType1Buffs += gBars.presenceOfMind ? 20 : 0;
+  } else if (gBars.job == 'SAM') {
+      if (gBars.shifu) {
+        if (gBars.level > 77) {
+          kType1Buffs += 13;
+        } else kType1Buffs += 10;
+      }
+  }
+  
+  if (gBars.job == 'NIN') {
+    kType2Buffs += gBars.huton ? 15 : 0;
+  } else if (gBars.job == 'MNK') {
+    kType2Buffs += 5 * gBars.lightningStacks;
+  } else if (gBars.job == 'BRD') {
+    kType2Buffs += 4 * gBars.paeonStacks;
+    switch(gBars.museStacks) {
+      case 1:
+        kType2Buffs += 1;
+        break;
+      case 2:
+        kType2Buffs += 2;
+        break;
+      case 3:
+        kType2Buffs += 4;
+        break;
+      case 4:
+        kType2Buffs += 12;
+        break;
+    } 
+  }
+  //TODO: this probably isn't useful to track
+  let kAstralUmbralMod = 100;
+      
+  let GCDms = Math.floor(1000 - Math.floor(130 * (stat - kLevelMod[gBars.level-1][0]) / kLevelMod[gBars.level-1][1])) * actiondelay / 1000;
+  let A = (100 - kType1Buffs) / 100;
+  let B = (100 - kType2Buffs) / 100; 
+  let GCDc = Math.floor(Math.floor((A * B) * GCDms/10) * kAstralUmbralMod / 100);
+  return GCDc / 100;
+}
+                                                                     
 let kGainSecondsRegex = Regexes.parse('for (\\y{Float}) Seconds\\.');
 function gainSecondsFromLog(log) {
   let m = log.match(kGainSecondsRegex);
@@ -292,8 +358,6 @@ function setupRegexes() {
     gLang.kAbility.Confiteor,
   ]);
 }
-
-let kMeleeWithMpJobs = ['DRK', 'PLD'];
 
 function doesJobNeedMPBar(job) {
   return Util.isCasterJob(job) || kMeleeWithMpJobs.indexOf(job) >= 0;
@@ -858,11 +922,24 @@ class Bars {
     this.inCombat = false;
     this.combo = 0;
     this.comboTimer = null;
+    
+    this.skill_speed = 0;
+    this.spell_speed = 0;
+    this.gcdSkill = () => kCalcGCDFromStat(this.skill_speed);
+    this.gcdSpell = () => kCalcGCDFromStat(this.spell_speed);
+    
+    this.presenceOfMind = 0;
+    this.shifu = 0;
+    this.huton = 0;
+    this.lightningStacks = 0;
+    this.paeonStacks = 0;
+    this.museStacks = 0;
 
     this.comboFuncs = [];
     this.jobFuncs = [];
     this.gainEffectFuncMap = {};
     this.loseEffectFuncMap = {};
+    this.statChangeFuncMap = {};
     this.abilityFuncMap = {};
   }
 
@@ -871,6 +948,7 @@ class Bars {
     this.jobFuncs = [];
     this.gainEffectFuncMap = {};
     this.loseEffectFuncMap = {};
+    this.statChangeFuncMap = {};
     this.abilityFuncMap = {};
 
     this.gainEffectFuncMap[gLang.kEffect.WellFed] = (name, log) => {
@@ -1054,6 +1132,10 @@ class Bars {
       'BLU': this.setupBlu,
       'MNK': this.setupMnk,
       'BLM': this.setupBlm,
+      'BRD': this.setupBrd,
+      'WHM': this.setupWhm,
+      'NIN': this.setupNin,
+      'SAM': this.setupSam,
     };
     if (setup[this.job])
       setup[this.job].bind(this)();
@@ -1162,8 +1244,8 @@ class Bars {
   }
 
   setupWar() {
-    let gcd = this.options.WarGcd;
-
+    let gcd = 2.5;
+    
     let textBox = this.addResourceBox({
       classList: ['war-color-beast'],
     });
@@ -1226,7 +1308,7 @@ class Bars {
       // The new threshold is "can I finish the current combo and still
       // have time to do a Storm's Eye".
       let oldThreshold = parseFloat(eyeBox.threshold);
-      let newThreshold = (minSkillsUntilEye + 2) * gcd;
+      let newThreshold = (minSkillsUntilEye + 2) * this.gcdSkill();
 
       // Because thresholds are nonmonotonic (when finishing a combo)
       // be careful about setting them in ways that are visually poor.
@@ -1244,6 +1326,10 @@ class Bars {
       if (eyeBox.elapsed > 10)
         eyeBox.duration = 0;
     };
+    
+    this.statChangeFuncMap['WAR'] = () => {
+      eyeBox.valuescale = this.gcdSkill();
+    }
   }
 
   setupDrk() {
@@ -1283,8 +1369,8 @@ class Bars {
   }
 
   setupPld() {
-    let gcd = this.options.PldGcd;
-
+    let gcd = 2.5;
+    
     let textBox = this.addResourceBox({
       classList: ['pld-color-oath'],
     });
@@ -1325,10 +1411,15 @@ class Bars {
         goreBox.duration = 22;
       }
     });
+    
+    this.statChangeFuncMap['PLD'] = () => {
+      goreBox.valuescale = this.gcdSkill();
+      goreBox.threshold = this.gcdSkill() * 3 + 0.3;
+    }
   }
 
   setupBlu() {
-    let gcd = this.options.BluGcd;
+    let gcd = 2.5;
 
     let offguardBox = this.addProcBox({
       id: 'blu-procs-offguard',
@@ -1352,11 +1443,18 @@ class Bars {
       tormentBox.duration = 0;
       tormentBox.duration = 30;
     };
+    
+    this.statChangeFuncMap['BLU'] = () => {
+      offguardBox.valuescale = this.gcdSpell();
+      offguardBox.threshold = this.gcdSpell() * 3;
+      tormentBox.valuescale = this.gcdSpell();
+      tormentBox.threshold = this.gcdSpell() * 3;
+    }
   }
 
   // TODO: none of this is actually super useful.
   setupAst() {
-    let gcd = this.options.AstGcd;
+    let gcd = 2.5;
 
     let combustBox = this.addProcBox({
       id: 'ast-procs-combust',
@@ -1392,6 +1490,15 @@ class Bars {
       heliosBox.duration = 0;
       heliosBox.duration = 30;
     };
+    
+    this.statChangeFuncMap['AST'] = () => {
+      combustBox.valuescale = this.gcdSpell();
+      combustBox.threshold = this.gcdSpell() * 3;
+      beneficBox.valuescale = this.gcdSpell();
+      beneficBox.threshold = this.gcdSpell() * 3;
+      heliosBox.valuescale = this.gcdSpell();
+      heliosBox.threshold = this.gcdSpell() * 3;
+    }
   }
 
   setupMnk() {
@@ -1424,9 +1531,9 @@ class Bars {
           p.classList.remove('dim');
       }
 
-      let stacks = jobDetail.lightningStacks;
-      lightningTimer.fg = lightningFgColors[stacks];
-      if (stacks == 0) {
+      this.lightningStacks = jobDetail.lightningStacks;
+      lightningTimer.fg = lightningFgColors[this.lightningStacks];
+      if (this.lightningStacks == 0) {
         // Show sad red bar when you've lost all your pancakes.
         lightningTimer.style = 'fill';
         lightningTimer.value = 0;
@@ -1580,17 +1687,17 @@ class Bars {
 
     this.gainEffectFuncMap[gLang.kEffect.VerstoneReady] = (name, log) => {
       whiteProc.duration = 0;
-      whiteProc.duration = gainSecondsFromLog(log) - this.options.RdmCastTime;
+      whiteProc.duration = gainSecondsFromLog(log) - this.gcdSpell();
     };
     this.loseEffectFuncMap[gLang.kEffect.VerstoneReady] = () => whiteProc.duration = 0;
     this.gainEffectFuncMap[gLang.kEffect.VerfireReady] = (name, log) => {
       blackProc.duration = 0;
-      blackProc.duration = gainSecondsFromLog(log) - this.options.RdmCastTime;
+      blackProc.duration = gainSecondsFromLog(log) - this.gcdSpell();
     };
     this.loseEffectFuncMap[gLang.kEffect.VerfireReady] = () => blackProc.duration = 0;
     this.gainEffectFuncMap[gLang.kEffect.Impactful] = (name, log) => {
       impactfulProc.duration = 0;
-      impactfulProc = gainSecondsFromLog(log) - this.options.RdmCastTime;
+      impactfulProc = gainSecondsFromLog(log) - this.gcdSpell();
     };
     this.loseEffectFuncMap[gLang.kEffect.Impactful] = () => impactfulProc.duration = 0;
   }
@@ -1726,9 +1833,84 @@ class Bars {
     });
   }
 
+  setupBrd() {
+    let ethosStacks = 0;
+    
+    //Bard is complicated
+    //Paeon -> Minuet/Ballad -> muse -> muse ends 
+    //Paeon -> runs out -> ethos -> within 30s -> Minuet/Ballad -> muse -> muse ends
+    //Paeon -> runs out -> ethos -> ethos runs out
+    //Track Paeon Stacks through to next song GCD buff
+    this.gainEffectFuncMap[gLang.kEffect.ArmysMuse] = (name, log) => {
+      //We just entered Minuet/Ballad, add muse effect
+      //If we let paeon run out, get the temp stacks from ethos
+      this.museStacks = ethosStacks ? ethosStacks : this.paeonStacks;
+      this.paeonStacks = 0;
+    };
+    this.loseEffectFuncMap[gLang.kEffect.ArmysMuse] = () => {
+      //Muse effect ends
+      this.museStacks = 0;
+      this.paeonStacks = 0;
+    }
+    this.gainEffectFuncMap[gLang.kEffect.ArmysEthos] = (name, log) => {
+      //Not under muse or paeon, so store the stacks
+      ethosStacks = this.paeonStacks;
+      this.paeonStacks = 0;
+    };
+    this.loseEffectFuncMap[gLang.kEffect.ArmysEthos] = () => {
+      //Didn't use a song and ethos ran out
+      ethosStacks = 0;
+      this.museStacks = 0;
+      this.paeonStacks = 0;
+    }
+    
+    this.jobFuncs.push((jobDetail) => {
+      if (jobDetail.songName == 'Paeon' && this.paeonStacks != jobDetail.songProcs) {
+        this.paeonStacks = jobDetail.songProcs;
+      }
+      //do bard things
+    });
+  }
+  
+  setupWhm() {
+    this.gainEffectFuncMap[gLang.kEffect.PresenceOfMind] = (name, log) => {
+      this.presenceOfMind = 1;
+    };
+    this.loseEffectFuncMap[gLang.kEffect.PresenceOfMind] = () => {
+      this.presenceOfMind = 0;
+    }
+  }
+
+  setupNin() {
+    this.jobFuncs.push((jobDetail) => {
+      if (jobDetail.hutonMilliseconds > 0) {
+        if (this.huton != 1) {
+          this.huton = 1;
+        }
+      } else if (this.huton = 1) {
+        this.huton = 0;
+      }
+    });
+  }
+  
+  setupSam() {
+    this.gainEffectFuncMap[gLang.kEffect.Shifu] = (name, log) => {
+      this.shifu = 1;
+    };
+    this.loseEffectFuncMap[gLang.kEffect.Shifu] = () => {
+      this.shifu = 0;
+    }
+  }
+
   OnComboChange(skill) {
     for (let i = 0; i < this.comboFuncs.length; ++i)
       this.comboFuncs[i](skill);
+  }
+
+  UpdateJobBarGCDs() {
+    let f = this.statChangeFuncMap[this.job];
+    if (f)
+      f();
   }
 
   UpdateHealth() {
@@ -2031,6 +2213,13 @@ class Bars {
         }
         if (log.search(/:test:jobs:/) >= 0) {
           this.Test();
+          continue;
+        }
+        if (log[16] == 'C') {
+          let stats = log.match(kStatsRegex).groups;
+          this.skill_speed = stats.skill_speed;
+          this.spell_speed = stats.spell_speed;
+          this.UpdateJobBarGCDs();
           continue;
         }
       } else if (log[15] == '1') {

--- a/ui/jobs/jobs.js
+++ b/ui/jobs/jobs.js
@@ -72,75 +72,75 @@ let kYouUseAbilityRegex = null;
 let kAnybodyAbilityRegex = null;
 
 let kStatsRegex = Regexes.statChange();
-//[level][Sub][Div]
-//Source: http://theoryjerks.akhmorning.com/resources/levelmods/
-const kLevelMod = new Array([56, 56], [57, 57], [60, 60], [62, 62], [65, 65],
-                            [68, 68], [70, 70], [73, 73], [76, 76], [78, 78],
-                            [82, 82], [85, 85], [89, 89], [93, 93], [96, 96],
-                            [100, 100], [104, 104], [109, 109], [113, 113], [116, 116],
-                            [122, 122], [127, 127], [133, 133], [138, 138], [144, 144],
-                            [150, 150], [155, 155], [162, 162], [168, 168], [173, 173],
-                            [181, 181], [188, 188], [194, 194], [202, 202], [209, 209],
-                            [215, 215], [223, 223], [229, 229], [236, 236], [244, 244],
-                            [253, 253], [263, 263], [272, 272], [283, 283], [292, 292],
-                            [302, 302], [311, 311], [322, 322], [331, 331], [341, 341],
-                            [342, 393], [344, 444], [345, 496], [346, 548], [347, 600],
-                            [349, 651], [350, 703], [351, 755], [352, 806], [354, 858],
-                            [355, 941], [356, 1032], [357, 1133], [358, 1243], [369, 1364],
-                            [360, 1497], [361, 1643], [362, 1802], [363, 1978], [364, 2170],
-                            [365, 2263], [366, 2360], [367, 2461], [368, 2566], [370, 2676],
-                            [372, 2790], [374, 2910], [376, 3034], [378, 3164], [380, 3300]);
+// [level][Sub][Div]
+// Source: http://theoryjerks.akhmorning.com/resources/levelmods/
+const kLevelMod = [[56, 56], [57, 57], [60, 60], [62, 62], [65, 65],
+  [68, 68], [70, 70], [73, 73], [76, 76], [78, 78],
+  [82, 82], [85, 85], [89, 89], [93, 93], [96, 96],
+  [100, 100], [104, 104], [109, 109], [113, 113], [116, 116],
+  [122, 122], [127, 127], [133, 133], [138, 138], [144, 144],
+  [150, 150], [155, 155], [162, 162], [168, 168], [173, 173],
+  [181, 181], [188, 188], [194, 194], [202, 202], [209, 209],
+  [215, 215], [223, 223], [229, 229], [236, 236], [244, 244],
+  [253, 253], [263, 263], [272, 272], [283, 283], [292, 292],
+  [302, 302], [311, 311], [322, 322], [331, 331], [341, 341],
+  [342, 393], [344, 444], [345, 496], [346, 548], [347, 600],
+  [349, 651], [350, 703], [351, 755], [352, 806], [354, 858],
+  [355, 941], [356, 1032], [357, 1133], [358, 1243], [369, 1364],
+  [360, 1497], [361, 1643], [362, 1802], [363, 1978], [364, 2170],
+  [365, 2263], [366, 2360], [367, 2461], [368, 2566], [370, 2676],
+  [372, 2790], [374, 2910], [376, 3034], [378, 3164], [380, 3300]];
 
-//Source: http://theoryjerks.akhmorning.com/guide/speed/
+// Source: http://theoryjerks.akhmorning.com/guide/speed/
 function kCalcGCDFromStat(stat, actiondelay) {
-  //default calculates for a 2.50s recast
+  // default calculates for a 2.50s recast
   actiondelay = actiondelay || 2500;
-  
+
   let kType1Buffs = 0;
-  //TODO: Is there an easy way of tracking Circle of Power?
-  //let kInLeyLines = false;
+  // TODO: Is there an easy way of tracking Circle of Power?
   let kType2Buffs = 0;
   if (gBars.job == 'WHM') {
     kType1Buffs += gBars.presenceOfMind ? 20 : 0;
   } else if (gBars.job == 'SAM') {
-      if (gBars.shifu) {
-        if (gBars.level > 77) {
-          kType1Buffs += 13;
-        } else kType1Buffs += 10;
-      }
+    if (gBars.shifu) {
+      if (gBars.level > 77)
+        kType1Buffs += 13;
+      else kType1Buffs += 10;
+    }
   }
-  
+
   if (gBars.job == 'NIN') {
     kType2Buffs += gBars.huton ? 15 : 0;
   } else if (gBars.job == 'MNK') {
     kType2Buffs += 5 * gBars.lightningStacks;
   } else if (gBars.job == 'BRD') {
     kType2Buffs += 4 * gBars.paeonStacks;
-    switch(gBars.museStacks) {
-      case 1:
-        kType2Buffs += 1;
-        break;
-      case 2:
-        kType2Buffs += 2;
-        break;
-      case 3:
-        kType2Buffs += 4;
-        break;
-      case 4:
-        kType2Buffs += 12;
-        break;
-    } 
+    switch (gBars.museStacks) {
+    case 1:
+      kType2Buffs += 1;
+      break;
+    case 2:
+      kType2Buffs += 2;
+      break;
+    case 3:
+      kType2Buffs += 4;
+      break;
+    case 4:
+      kType2Buffs += 12;
+      break;
+    }
   }
-  //TODO: this probably isn't useful to track
+  // TODO: this probably isn't useful to track
   let kAstralUmbralMod = 100;
-      
-  let GCDms = Math.floor(1000 - Math.floor(130 * (stat - kLevelMod[gBars.level-1][0]) / kLevelMod[gBars.level-1][1])) * actiondelay / 1000;
+
+  let GCDms = Math.floor(1000 - Math.floor(130 * (stat - kLevelMod[gBars.level-1][0]) /
+    kLevelMod[gBars.level-1][1])) * actiondelay / 1000;
   let A = (100 - kType1Buffs) / 100;
-  let B = (100 - kType2Buffs) / 100; 
+  let B = (100 - kType2Buffs) / 100;
   let GCDc = Math.floor(Math.floor((A * B) * GCDms/10) * kAstralUmbralMod / 100);
   return GCDc / 100;
 }
-                                                                     
+
 let kGainSecondsRegex = Regexes.parse('for (\\y{Float}) Seconds\\.');
 function gainSecondsFromLog(log) {
   let m = log.match(kGainSecondsRegex);
@@ -922,12 +922,12 @@ class Bars {
     this.inCombat = false;
     this.combo = 0;
     this.comboTimer = null;
-    
+
     this.skill_speed = 0;
     this.spell_speed = 0;
     this.gcdSkill = () => kCalcGCDFromStat(this.skill_speed);
     this.gcdSpell = () => kCalcGCDFromStat(this.spell_speed);
-    
+
     this.presenceOfMind = 0;
     this.shifu = 0;
     this.huton = 0;
@@ -1245,7 +1245,7 @@ class Bars {
 
   setupWar() {
     let gcd = 2.5;
-    
+
     let textBox = this.addResourceBox({
       classList: ['war-color-beast'],
     });
@@ -1326,10 +1326,10 @@ class Bars {
       if (eyeBox.elapsed > 10)
         eyeBox.duration = 0;
     };
-    
+
     this.statChangeFuncMap['WAR'] = () => {
       eyeBox.valuescale = this.gcdSkill();
-    }
+    };
   }
 
   setupDrk() {
@@ -1370,7 +1370,7 @@ class Bars {
 
   setupPld() {
     let gcd = 2.5;
-    
+
     let textBox = this.addResourceBox({
       classList: ['pld-color-oath'],
     });
@@ -1411,11 +1411,11 @@ class Bars {
         goreBox.duration = 22;
       }
     });
-    
+
     this.statChangeFuncMap['PLD'] = () => {
       goreBox.valuescale = this.gcdSkill();
       goreBox.threshold = this.gcdSkill() * 3 + 0.3;
-    }
+    };
   }
 
   setupBlu() {
@@ -1443,13 +1443,13 @@ class Bars {
       tormentBox.duration = 0;
       tormentBox.duration = 30;
     };
-    
+
     this.statChangeFuncMap['BLU'] = () => {
       offguardBox.valuescale = this.gcdSpell();
       offguardBox.threshold = this.gcdSpell() * 3;
       tormentBox.valuescale = this.gcdSpell();
       tormentBox.threshold = this.gcdSpell() * 3;
-    }
+    };
   }
 
   // TODO: none of this is actually super useful.
@@ -1490,7 +1490,7 @@ class Bars {
       heliosBox.duration = 0;
       heliosBox.duration = 30;
     };
-    
+
     this.statChangeFuncMap['AST'] = () => {
       combustBox.valuescale = this.gcdSpell();
       combustBox.threshold = this.gcdSpell() * 3;
@@ -1498,7 +1498,7 @@ class Bars {
       beneficBox.threshold = this.gcdSpell() * 3;
       heliosBox.valuescale = this.gcdSpell();
       heliosBox.threshold = this.gcdSpell() * 3;
-    }
+    };
   }
 
   setupMnk() {
@@ -1835,71 +1835,68 @@ class Bars {
 
   setupBrd() {
     let ethosStacks = 0;
-    
-    //Bard is complicated
-    //Paeon -> Minuet/Ballad -> muse -> muse ends 
-    //Paeon -> runs out -> ethos -> within 30s -> Minuet/Ballad -> muse -> muse ends
-    //Paeon -> runs out -> ethos -> ethos runs out
-    //Track Paeon Stacks through to next song GCD buff
+
+    // Bard is complicated
+    // Paeon -> Minuet/Ballad -> muse -> muse ends
+    // Paeon -> runs out -> ethos -> within 30s -> Minuet/Ballad -> muse -> muse ends
+    // Paeon -> runs out -> ethos -> ethos runs out
+    // Track Paeon Stacks through to next song GCD buff
     this.gainEffectFuncMap[gLang.kEffect.ArmysMuse] = (name, log) => {
-      //We just entered Minuet/Ballad, add muse effect
-      //If we let paeon run out, get the temp stacks from ethos
+      // We just entered Minuet/Ballad, add muse effect
+      // If we let paeon run out, get the temp stacks from ethos
       this.museStacks = ethosStacks ? ethosStacks : this.paeonStacks;
       this.paeonStacks = 0;
     };
     this.loseEffectFuncMap[gLang.kEffect.ArmysMuse] = () => {
-      //Muse effect ends
+      // Muse effect ends
       this.museStacks = 0;
       this.paeonStacks = 0;
-    }
+    };
     this.gainEffectFuncMap[gLang.kEffect.ArmysEthos] = (name, log) => {
-      //Not under muse or paeon, so store the stacks
+      // Not under muse or paeon, so store the stacks
       ethosStacks = this.paeonStacks;
       this.paeonStacks = 0;
     };
     this.loseEffectFuncMap[gLang.kEffect.ArmysEthos] = () => {
-      //Didn't use a song and ethos ran out
+      // Didn't use a song and ethos ran out
       ethosStacks = 0;
       this.museStacks = 0;
       this.paeonStacks = 0;
-    }
-    
+    };
+
     this.jobFuncs.push((jobDetail) => {
-      if (jobDetail.songName == 'Paeon' && this.paeonStacks != jobDetail.songProcs) {
+      if (jobDetail.songName == 'Paeon' && this.paeonStacks != jobDetail.songProcs)
         this.paeonStacks = jobDetail.songProcs;
-      }
-      //do bard things
     });
   }
-  
+
   setupWhm() {
     this.gainEffectFuncMap[gLang.kEffect.PresenceOfMind] = (name, log) => {
       this.presenceOfMind = 1;
     };
     this.loseEffectFuncMap[gLang.kEffect.PresenceOfMind] = () => {
       this.presenceOfMind = 0;
-    }
+    };
   }
 
   setupNin() {
     this.jobFuncs.push((jobDetail) => {
       if (jobDetail.hutonMilliseconds > 0) {
-        if (this.huton != 1) {
+        if (this.huton != 1)
           this.huton = 1;
-        }
-      } else if (this.huton = 1) {
+      } else if (this.huton == 1) {
         this.huton = 0;
       }
     });
   }
-  
+
   setupSam() {
     this.gainEffectFuncMap[gLang.kEffect.Shifu] = (name, log) => {
       this.shifu = 1;
     };
     this.loseEffectFuncMap[gLang.kEffect.Shifu] = () => {
       this.shifu = 0;
-    }
+    };
   }
 
   OnComboChange(skill) {

--- a/ui/jobs/jobs.js
+++ b/ui/jobs/jobs.js
@@ -97,9 +97,10 @@ function kCalcGCDFromStat(stat, actiondelay) {
   actiondelay = actiondelay || 2500;
 
   let kType1Buffs = 0;
-  // TODO: Is there an easy way of tracking Circle of Power?
   let kType2Buffs = 0;
-  if (gBars.job == 'WHM') {
+  if (gBars.job == 'BLM') {
+    kType1Buffs += gBars.circleOfPower ? 15 : 0;
+  } else if (gBars.job == 'WHM') {
     kType1Buffs += gBars.presenceOfMind ? 20 : 0;
   } else if (gBars.job == 'SAM') {
     if (gBars.shifu) {
@@ -934,6 +935,7 @@ class Bars {
     this.lightningStacks = 0;
     this.paeonStacks = 0;
     this.museStacks = 0;
+    this.circleOfPower = 0;
 
     this.comboFuncs = [];
     this.jobFuncs = [];
@@ -1752,6 +1754,9 @@ class Bars {
       fireProc.duration = gainSecondsFromLog(log);
     };
     this.loseEffectFuncMap[gLang.kEffect.Firestarter] = () => fireProc.duration = 0;
+
+    this.gainEffectFuncMap[gLang.kEffect.CircleOfPower] = () => this.circleOfPower = 1;
+    this.loseEffectFuncMap[gLang.kEffect.CircleOfPower] = () => this.circleOfPower = 0;
 
     // It'd be super nice to use grid here.
     // Maybe some day when cactbot uses new cef.

--- a/ui/jobs/jobs.js
+++ b/ui/jobs/jobs.js
@@ -75,7 +75,8 @@ let kAnybodyAbilityRegex = null;
 let kStatsRegex = Regexes.statChange();
 // [level][Sub][Div]
 // Source: http://theoryjerks.akhmorning.com/resources/levelmods/
-const kLevelMod = [[56, 56], [57, 57], [60, 60], [62, 62], [65, 65],
+const kLevelMod = [[0, 0],
+  [56, 56], [57, 57], [60, 60], [62, 62], [65, 65],
   [68, 68], [70, 70], [73, 73], [76, 76], [78, 78],
   [82, 82], [85, 85], [89, 89], [93, 93], [96, 96],
   [100, 100], [104, 104], [109, 109], [113, 113], [116, 116],
@@ -1902,8 +1903,8 @@ class Bars {
     // TODO: this probably isn't useful to track
     let astralUmbralMod = 100;
 
-    let GCDms = Math.floor(1000 - Math.floor(130 * (stat - kLevelMod[this.level - 1][0]) /
-      kLevelMod[this.level - 1][1])) * actiondelay / 1000;
+    let GCDms = Math.floor(1000 - Math.floor(130 * (stat - kLevelMod[this.level][0]) /
+      kLevelMod[this.level][1])) * actiondelay / 1000;
     let A = (100 - type1Buffs) / 100;
     let B = (100 - type2Buffs) / 100;
     let GCDc = Math.floor(Math.floor((A * B) * GCDms / 10) * astralUmbralMod / 100);
@@ -2220,8 +2221,8 @@ class Bars {
         }
         if (log[16] == 'C') {
           let stats = log.match(kStatsRegex).groups;
-          this.skillSpeed = stats.skill_speed;
-          this.spellSpeed = stats.spell_speed;
+          this.skillSpeed = stats.skillSpeed;
+          this.spellSpeed = stats.spellSpeed;
           this.UpdateJobBarGCDs();
           continue;
         }


### PR DESCRIPTION
Hiya,

I've added 0xC log line support for the jobs overlay as requested in #595. It runs the setupJob() functions with a default 2.5s gcd, then as soon as we see `0C: Player stats:` (usually instantly, unless you reload the overlay manually) it updates the relevant variables. It has support for every status affecting GCDs; I added bare bones support for BRD, NIN, WHM and SAM purely for feature completion.

I'm not really confident that the statChangeRegex in `regexes.js` matches the surrounding functions' style, and I'm open to feedback on that especially.