### PR TITLE
plugin: VersionChecker - replace regex matching with GetVersionInfo call

### DIFF
--- a/CactbotOverlay/VersionChecker.cs
+++ b/CactbotOverlay/VersionChecker.cs
@@ -48,11 +48,8 @@ namespace Cactbot {
       var plugin = GetFFXIVPluginData();
       if (plugin == null)
         return new Version();
-      var match = System.Text.RegularExpressions.Regex.Match(plugin.pluginVersion, @"\nFileVersion: ([0-9]+\.[0-9]+\.[0-9]+\.[0-9]+)\n");
-      if (match.Groups.Count > 1) {
-        return new Version(match.Groups[1].Value);
-      }
-      return new Version();    }
+      return new Version(System.Diagnostics.FileVersionInfo.GetVersionInfo(plugin.pluginFile.FullName).FileVersion);
+    }
 
     public string GetFFXIVPluginLocation() {
       var plugin = GetFFXIVPluginData();


### PR DESCRIPTION
Replaces the regex matching with a call to
```C#
System.Diagnostics.FileVersionInfo.GetVersionInfo(plugin.pluginFile.FullName).FileVersion
```

Thanks!