### PR TITLE
plugin: level fix

### DIFF
--- a/CactbotOverlay/FFXIVProcessCn.cs
+++ b/CactbotOverlay/FFXIVProcessCn.cs
@@ -76,7 +76,7 @@ namespace Cactbot {
       public EntityJob job;
 
       [FieldOffset(0x3A)]
-      public short level;
+      public byte level;
 
       [FieldOffset(0x5C)]
       public short shieldPercentage;

--- a/CactbotOverlay/FFXIVProcessIntl.cs
+++ b/CactbotOverlay/FFXIVProcessIntl.cs
@@ -71,7 +71,7 @@ namespace Cactbot {
       public EntityJob job;
 
       [FieldOffset(0x3E)]
-      public short level;
+      public byte level;
 
       [FieldOffset(0x5F)]
       public short shieldPercentage;


### PR DESCRIPTION
Hiya,

Another bug introduced during #750. 😭 
Level should be an 8-bit int, not 16. Was causing undefined errors in jobs, and probably a lot more..