### PR TITLE
Raidboss: Gubal Hard and O4N fixes

### DIFF
--- a/ui/raidboss/data/03-hw/dungeon/gubal_library_hard.js
+++ b/ui/raidboss/data/03-hw/dungeon/gubal_library_hard.js
@@ -76,13 +76,13 @@
           delete data.markers;
           if (sameMarkers) {
             return {
-              en: 'Away from boss',
-              fr: 'Eloignez-vous du boss',
+              en: 'Close to boss',
+              fr: 'Près du boss',
             };
           }
           return {
-            en: 'Close to boss',
-            fr: 'Près du boss',
+            en: 'Away from boss',
+            fr: 'Eloignez-vous du boss',
           };
         }
       },

--- a/ui/raidboss/data/04-sb/raid/o4n.js
+++ b/ui/raidboss/data/04-sb/raid/o4n.js
@@ -22,24 +22,20 @@
     },
     {
       id: 'O4N Standard Thunder',
-      regex: / 14:24BD:Exdeath starts using Thunder III on (\y{Name})/,
-      regexDe: / 14:24BD:Exdeath starts using Blitzga on (\y{Name})/,
-      regexFr: / 14:24BD:Exdeath starts using Méga Foudre on (\y{Name})/,
-      regexJa: / 14:24BD:エクスデス starts using サンダガ on (\y{Name})/,
-      infoText: function(data, matches) {
-        if (matches[1] == data.me) {
+      regex: / 14:24BD:Exdeath starts using Thunder III/,
+      regexDe: / 14:24BD:Exdeath starts using Blitzga/,
+      regexFr: / 14:24BD:Exdeath starts using Méga Foudre/,
+      regexJa: / 14:24BD:エクスデス starts using サンダガ/,
+      infoText: function(data) {
+        if (data.role == 'tank') {
           return {
-            en: 'Tank buster on YOU',
+            en: 'Tank cleave soon!',
           };
         }
       },
-      alertText: function(data, matches) {
-        if (data.role == 'healer') {
-          return {
-            en: 'Buster on ' + data.ShortName(matches[1]),
-          };
-        }
-      },
+      return {
+        en: 'Avoid tank cleave'
+      }
     },
     {
       id: 'O4N Standard Fire',

--- a/ui/raidboss/data/04-sb/raid/o4n.js
+++ b/ui/raidboss/data/04-sb/raid/o4n.js
@@ -32,10 +32,10 @@
             en: 'Tank cleave soon!',
           };
         }
+        return {
+          en: 'Avoid tank cleave',
+        };
       },
-      return {
-        en: 'Avoid tank cleave'
-      }
     },
     {
       id: 'O4N Standard Fire',


### PR DESCRIPTION
Per #838, this fixes the diametrically wrong Ferrofluid trigger. Also threw in a change for Exdeath normal, as I happened to run that tonight and saw that the tank buster doesn't work as I thought it did. (Instead of "Exdeath casts buster on tank", it's "Exdeath casts buster on Exdeath, and at the end of that cast, instantly uses buster on tank". Because of this, there's no way to reliably extract the correct target. I'll probably revisit this when I get around to doing a timeline for this one, use the new party data to figure out which tank has threat, and adjust the callouts from there.)