### PR TITLE
UTIL: Updating translate_fight.py to use XIVAPI

### DIFF
--- a/util/encounter_tools.py
+++ b/util/encounter_tools.py
@@ -142,7 +142,7 @@ def is_tl_line_begincast(poss_match):
     return re.search(r'^:([0-9A-F\(\)\|]+):([^:]+)', poss_match)
 
 def is_tl_line_buff(poss_match):
-    return re.search(r'1A:.......:(.+) gains the effect of (.+)( from)?', poss_match)
+    return re.search(r'1A:........:(.+) gains the effect of (.+)( from)?', poss_match)
 
 def is_tl_line_cast(poss_match):
     return re.search(r'^:([^:]+):([0-9A-F\(\)\|]+)', poss_match)

--- a/util/encounter_tools.py
+++ b/util/encounter_tools.py
@@ -132,8 +132,11 @@ def choose_fight_times(args, encounters):
 
 
 # Timeline test/translate functions
-def clean_and_split_tl_line(line):
-    return re.search(r'^(?P<time>[\d\.]+)\s+"(?P<label>[^"]+)"\s+(?P<options>.+)', line.split('#')[0])
+def clean_and_split_tl_line(line, split):
+    to_parse = line
+    if split:
+        to_parse = line.split('#')[0]
+    return re.search(r'^(?P<time>[\d\.]+)\s+"(?P<label>[^"]+)"\s+(?P<options>.+)', to_parse)
 
 def is_tl_line_syncmatch(line):
     return re.search(r'sync /([^/]+)/', line.group('options'))

--- a/util/test_timeline.py
+++ b/util/test_timeline.py
@@ -21,7 +21,7 @@ def load_timeline(timeline):
             entry = {}
             # Remove trailing comment, if any,
             # then split the line into sections
-            match = e_tools.clean_and_split_tl_line(line)
+            match = e_tools.clean_and_split_tl_line(line, True)
             if not match:
                 continue
 
@@ -424,12 +424,12 @@ def timeline_file(filename):
     # Allow for just specifying the base filename, e.g. "o12s.txt" or "o12s"
     if not os.path.exists(filename):
         for root, dirs, files in os.walk(data_path):
-          if filename in files:
-            filename = os.path.join(root, filename)
-            break
-          if '%s.txt' % filename in files:
-            filename = os.path.join(root, '%s.txt' % filename)
-            break
+            if filename in files:
+                filename = os.path.join(root, filename)
+                break
+            if '%s.txt' % filename in files:
+                filename = os.path.join(root, '%s.txt' % filename)
+                break
 
     path = Path(filename)
     if not path.exists():

--- a/util/translate_fight.py
+++ b/util/translate_fight.py
@@ -5,15 +5,15 @@ from collections import defaultdict
 import json
 import re
 import sys
-import encounter_tools as e_tools
-import requests
 import time
-
+import requests
 import fflogs
+import encounter_tools as e_tools
+
 
 # 'en' here is 'www' which we consider the "base" and do automatically.
 # 'cn' exists on fflogs but does not have proper translations, sorry.
-languages = ['en', 'de', 'fr', 'ja', 'cn']
+fflogs_languages = ['en', 'de', 'fr', 'ja', 'cn']
 prefixes = {
     'en': 'www',
     'de': 'de',
@@ -43,7 +43,7 @@ def find_timeline_translatables(args):
     translatables = defaultdict(dict)
     # These keys do double duty as the indices for XIVAPI's search function.
     for element in ['action_ids', 'status', 'bnpcname', 'PlaceName']:
-        translatables[element] = []   
+        translatables[element] = []
 
     with args.timeline as file:
         for line in file:
@@ -52,7 +52,7 @@ def find_timeline_translatables(args):
                 continue
 
             # Boil each remaining line down to its sync regexes
-            cleaned_line = re.search(r'^(?P<time>[\d\.]+)\s+"(?P<label>[^"]+)"\s+(?P<options>.+)', line)
+            cleaned_line = e_tools.clean_and_split_tl_line(line, False)
 
             # If for some reason the line doesn't clean up properly, just skip it.
             if cleaned_line is None:
@@ -278,6 +278,7 @@ def main(args):
         languages = xiv_langs
 
     else:
+        languages = fflogs_languages
         # Get overall reports and enemies.
         enemies = defaultdict(dict)
         options = {

--- a/util/translate_fight.py
+++ b/util/translate_fight.py
@@ -5,6 +5,9 @@ from collections import defaultdict
 import json
 import re
 import sys
+import encounter_tools as e_tools
+import requests
+import time
 
 import fflogs
 
@@ -27,6 +30,145 @@ ignore_effects = [
     'Vulnerability Up',
     'Weakness',
 ]
+
+# Setting the languages for use with XIVAPI/CafeMaker
+xiv_langs = ['en', 'de', 'fr', 'ja']
+xiv_lang_map = {'en': 'Name_en',
+                'de': 'Name_de',
+                'fr': 'Name_fr',
+                'ja': 'Name_ja',
+                }
+
+def find_timeline_translatables(args):
+    translatables = defaultdict(dict)
+    # These keys do double duty as the indices for XIVAPI's search function.
+    for element in ['action_ids', 'status', 'bnpcname', 'PlaceName']:
+        translatables[element] = []   
+
+    with args.timeline as file:
+        for line in file:
+            # Ignore all commented lines
+            if not line[0].isdigit():
+                continue
+
+            # Boil each remaining line down to its sync regexes
+            cleaned_line = re.search(r'^(?P<time>[\d\.]+)\s+"(?P<label>[^"]+)"\s+(?P<options>.+)', line)
+
+            # If for some reason the line doesn't clean up properly, just skip it.
+            if cleaned_line is None:
+                continue
+
+            sync_match = e_tools.is_tl_line_syncmatch(cleaned_line)
+
+            # If we don't have a match for whatever reason, ignore the line.
+            if sync_match is None:
+                continue
+
+            # We don't want to catch the reset line.
+            if sync_match.group(1).startswith('is no longer sealed'):
+                continue
+
+            # Check through each line for its translatable elements,
+            # adding new information to storage if found.
+
+            # Looking for lines formatted as /:Enemy:CastID:/
+            cast_match = e_tools.is_tl_line_cast(sync_match.group(0).split('/')[1])
+
+            # Some lines include alternatives in the format 12(34|56). This breaks, and usually
+            # these wouldn't be directly translated anyway.
+            if cast_match and not re.search(r'\(.+\|.+\)', cast_match.group(0)):
+                cast_match = cast_match.group(0).split(':')
+                    # Here and for begincast we convert the hex ability ID to decimal,
+                    # since that's what XIVAPI expects. We then convert back to string
+                    # to avoid later complications.
+                if not (str(int(cast_match[2], base=16)) in translatables['action_ids']):
+                    translatables['action_ids'].append(str(int(cast_match[2], base=16)))
+                if not (cast_match[1] in translatables['bnpcname']):
+                    translatables['bnpcname'].append(cast_match[1])
+                continue
+
+            begincast_match = e_tools.is_tl_line_begincast(sync_match.group(0).split('/')[1])
+            if begincast_match and not re.search(r'\(.+\|.+\)', begincast_match.group(0)):
+                if not (begincast_match.group(1) in translatables['action_ids']):
+                    translatables['action_ids'].append(str(int(begincast_match.group(1), base=16)))
+                if not (begincast_match.group(2) in translatables['bnpcname']):
+                    translatables['bnpcname'].append(begincast_match.group(2))
+                continue
+            
+            # FIXME: The is_tl_line_buff() helper regex is currently bugged, and will NOT correctly return the buff/debuff.
+            # The second capture group will eat the source/caster name up with the buff.
+            # This line split  nonsense is to work around that
+            buff_match = e_tools.is_tl_line_buff(sync_match.group(0))
+            if buff_match:
+                buff_match = buff_match.group(2).split(' from')[0]
+                if not (buff_match in ['status']):
+                    translatables['status'].append(buff_match)
+                continue
+
+            # Currently only looks for zone seal messages from log lines.
+            # FIXME: Add other log line possibilities here if necessary.
+            log_match = e_tools.is_tl_line_log(sync_match.group(1))
+            if log_match and 'will be sealed off' in log_match.group(2):
+                if not (log_match.group(2).split(' will be')[0] in translatables['PlaceName']):
+                    translatables['PlaceName'].append(log_match.group(2).split(' will be')[0])
+
+            add_match = e_tools.is_tl_line_adds(sync_match.group(1))
+            if add_match:
+                if not (add_match.group(1) in translatables['bnpcname']):
+                    translatables['bnpcname'].append(add_match.group(1))
+    print(translatables)
+    return translatables
+
+def compile_and_send(translatables):
+    # XIVAPI/cafemaker allows for returning multiple items in one request if the item IDs are known.
+    IDstr = ",".join(translatables['action_ids'])
+
+    # These columns will be used for every XIVAPI request, so we alias them now.
+    columns = 'Name_en,Name_de,Name_fr,Name_ja'
+    ID_req = requests.get('https://xivapi.com/action', params={'ids': IDstr, 'columns': columns})
+    ID_JSON = ID_req.json()['Results']
+
+    finished_items = defaultdict(dict)
+    for element in ['abilities', 'status', 'bnpcname', 'PlaceName']:
+        finished_items[element] = defaultdict(dict)
+
+    # Nested loops to unroll the abilities into something usable, yay!
+    for ability in range(0, len(ID_JSON)):
+        # Some abilities have no names.
+        if ID_JSON[ability]['Name_en'] is '':
+            continue
+        for lang in xiv_langs:
+            finished_items['abilities'][lang][ID_JSON[ability]['Name_en']] = ID_JSON[ability][xiv_lang_map[lang]]
+
+    # Clearing the actions from the translation dict so we can iterate over it cleanly.
+    translatables.pop('action_ids')
+
+    # Because XIVAPI imposes rate limits, we manually stay under.
+    requestcount = 1
+
+    # Because we don't have the IDs for other elements, we have to search for them individually.
+    # The Requests module blocks by default, so we don't need any asynchronous handling here.
+    # TODO: Look up IDs in St Coinach so we can collapse all this into one request per type?
+    # Nested loops are just THE BEST
+    for element in translatables:
+        working_dict = finished_items[element]
+        if element is 'PlaceName':
+            working_dict = finished_items['bnpcname']
+        for item in translatables[element]:
+            # To avoid being timed out by the server, we manually slow down here.
+            # TODO: Allow for users to include their XIVAPI developer key to increase this limit.
+            if requestcount % 11 is 0:
+                time.sleep(1)
+            req_payload = {'string': item, 'indexes': element, 'columns':columns,  'string_algo':'match'}
+            search_req_results = requests.get('https://xivapi.com/search', params=req_payload).json()['Results']
+            if len(search_req_results) is 0:
+                continue
+
+            # We assume here that the first result will be accurate.
+            for lang in xiv_langs:
+                working_dict[lang][search_req_results[0]['Name_en']] = search_req_results[0][xiv_lang_map[lang]]
+            requestcount += 1
+    return finished_items
 
 
 def find_start_end_time(report, args):
@@ -69,11 +211,12 @@ def add_default_ability_mappings(ability_replace):
     ability_replace['fr']['--sync--'] = '--Synchronisation--'
 
 
-def add_default_sync_mappings(sync_replace):
+def add_default_sync_mappings(sync_replace, args):
     sync_replace['de']['Engage!'] = 'Start!'
     sync_replace['fr']['Engage!'] = 'À l\'attaque'
     sync_replace['ja']['Engage!'] = '戦闘開始！'
-    sync_replace['cn']['Engage!'] = '战斗开始！'
+    if not args.timeline:
+        sync_replace['cn']['Engage!'] = '战斗开始！'
 
 
 def build_mapping(translations, ignore_list=[]):
@@ -117,79 +260,93 @@ def format_output_str(output_str):
 
 
 def main(args):
-    # Get overall reports and enemies.
-    enemies = defaultdict(dict)
-    options = {
-        'api_key': args.key,
-        'translate': 'true',
-    }
-    fight_id = 0
+    mob_replace = defaultdict(dict)
+    effect_replace = defaultdict(dict)
+    ability_replace = defaultdict(dict)
 
-    for lang in languages:
-        report = fflogs.api('fights', args.report, prefixes[lang], options)
-        if fight_id == 0:
-            start_time, end_time, fight_id = find_start_end_time(report, args)
-        for enemy in report['enemies']:
-            # Because the overall report contains all enemies from any report,
-            # filter them by the fight_id that we care about.
-            for fight in enemy['fights']:
-                if fight['id'] == fight_id:
-                    enemies[enemy['id']][lang] = enemy['name']
-                    break
+    # If we're working with an existing timeline file, go find everything to translate within it,
+    # instead of using FFLogs to translate.
+    if args.timeline:
+        translatables = find_timeline_translatables(args)
+        compiled_items = compile_and_send(translatables)
+        mob_replace = compiled_items['bnpcname']
+        effect_replace = compiled_items['status']
+        ability_replace = compiled_items['abilities']
 
-    # Get abilities for the chosen fight.
-    options = {
-        'api_key': args.key,
-        'start': start_time,
-        'end': end_time,
-        # filtering for disposition='enemy' drops neutral abilities like Encumber.
-        # including death also gets you Wroth Ghosts that don't show up otherwise.
-        'filter': 'source.type="NPC" and (type="cast" or type="death" or type="begincast")',
-        'translate': 'true',
-    }
-    abilities = defaultdict(dict)
-    for lang in languages:
-        events = fflogs.api('events', args.report, prefixes[lang], options)['events']
-        for event in events:
-            actor = 0
-            if 'targetID' in event:
-                actor = event['targetID']
 
-            if 'ability' not in event:
-                # Some mobs don't show up in the fight enemy list, but are things that get death events.
-                # e.g. {'sourceIsFriendly': False, 'type': 'death', 'target': {'guid': 58, 'name': 'Wroth Ghost', 'type': 'NPC' } }
-                if event['type'] == 'death' and not actor and 'target' in event:
-                    target = event['target']
-                    enemies[target['guid']][lang] = target['name']
-                continue
-            ability = event['ability']
-            abilities[(actor, ability['guid'])][lang] = ability['name']
+        # We don't want key errors popping up, so we ensure that Main looks only for languages we're working with.
+        languages = xiv_langs
 
-    # Finally, get boss debuff names.  These aren't used directly in timeline replacement
-    # but are helpful to have listed when writing other triggers.
-    options = {
-        'api_key': args.key,
-        'start': start_time,
-        'end': end_time,
-        'filter': 'source.type="NPC" and (type="applydebuffstack" or type="applydebuff" or type="refreshdebuff")',
-        'translate': 'true',
-    }
-    effects = defaultdict(dict)
-    for lang in languages:
-        events = fflogs.api('events', args.report, prefixes[lang], options)['events']
-        for event in events:
-            actor = 0
-            if 'targetID' in event:
-                actor = event['targetID']
-            ability = event['ability']
-            effects[(actor, ability['guid'])][lang] = ability['name']
+    else:
+        # Get overall reports and enemies.
+        enemies = defaultdict(dict)
+        options = {
+            'api_key': args.key,
+            'translate': 'true',
+        }
+        fight_id = 0
 
-    # Generate mappings of english => locale names.
-    mob_replace = build_mapping(enemies)
-    ability_replace = build_mapping(abilities, ignore_abilities)
-    effect_replace = build_mapping(effects, ignore_effects)
+        for lang in languages:
+            report = fflogs.api('fights', args.report, prefixes[lang], options)
+            if fight_id == 0:
+                start_time, end_time, fight_id = find_start_end_time(report, args)
+            for enemy in report['enemies']:
+                # Because the overall report contains all enemies from any report,
+                # filter them by the fight_id that we care about.
+                for fight in enemy['fights']:
+                    if fight['id'] == fight_id:
+                        enemies[enemy['id']][lang] = enemy['name']
+                        break
 
-    add_default_sync_mappings(mob_replace)
+        # Get abilities for the chosen fight.
+        abilities = defaultdict(dict)
+        options = {
+            'api_key': args.key,
+            'start': start_time,
+            'end': end_time,
+            # filtering for disposition='enemy' drops neutral abilities like Encumber.
+            # including death also gets you Wroth Ghosts that don't show up otherwise.
+            'filter': 'source.type="NPC" and (type="cast" or type="death" or type="begincast")',
+            'translate': 'true',
+        }
+
+        for lang in languages:
+            events = fflogs.api('events', args.report, prefixes[lang], options)['events']
+            for event in events:
+                actor = 0
+                if 'targetID' in event:
+                    actor = event['targetID']
+
+                if 'ability' not in event:
+                    # Some mobs don't show up in the fight enemy list, but are things that get death events.
+                    # e.g. {'sourceIsFriendly': False, 'type': 'death', 'target': {'guid': 58, 'name': 'Wroth Ghost', 'type': 'NPC' } }
+                    if event['type'] == 'death' and not actor and 'target' in event:
+                        target = event['target']
+                        enemies[target['guid']][lang] = target['name']
+                    continue
+                ability = event['ability']
+                abilities[(actor, ability['guid'])][lang] = ability['name']
+
+        # Finally, get boss debuff names.  These aren't used directly in timeline replacement
+        # but are helpful to have listed when writing other triggers.
+        options['filter'] = 'source.type="NPC" and (type="applydebuffstack" or type="applydebuff" or type="refreshdebuff")'
+
+        effects = defaultdict(dict)
+        for lang in languages:
+            events = fflogs.api('events', args.report, prefixes[lang], options)['events']
+            for event in events:
+                actor = 0
+                if 'targetID' in event:
+                    actor = event['targetID']
+                ability = event['ability']
+                effects[(actor, ability['guid'])][lang] = ability['name']
+
+        # Generate mappings of english => locale names.
+        mob_replace = build_mapping(enemies)
+        ability_replace = build_mapping(abilities, ignore_abilities)
+        effect_replace = build_mapping(effects, ignore_effects)
+
+    add_default_sync_mappings(mob_replace, args)
     add_default_ability_mappings(ability_replace)
 
     # Build some JSON similar to what cactbot expects in trigger files.
@@ -234,6 +391,7 @@ if __name__ == "__main__":
         formatter_class=argparse.RawDescriptionHelpFormatter)
 
     parser.add_argument('-r', '--report', help="The ID of an FFLogs report")
+    parser.add_argument('-t', '--timeline', type=argparse.FileType('r', encoding="utf8"), help="Timeline for encounter to translate.")
     parser.add_argument('-of', '--output-file', help="The file to write output in")
 
     parser.add_argument('-k', '--key', help="The FFLogs API key (public) to use, from https://www.fflogs.com/accounts/changeuser")
@@ -241,7 +399,7 @@ if __name__ == "__main__":
 
     args = parser.parse_args()
 
-    if not args.key and not args.report:
+    if not args.report and not args.timeline:
         parser.print_help()
         sys.exit(0)
 

--- a/util/translate_fight.py
+++ b/util/translate_fight.py
@@ -81,27 +81,28 @@ def find_timeline_translatables(args):
                     # Here and for begincast we convert the hex ability ID to decimal,
                     # since that's what XIVAPI expects. We then convert back to string
                     # to avoid later complications.
-                if not (str(int(cast_match[2], base=16)) in translatables['action_ids']):
+                if not str(int(cast_match[2], base=16)) in translatables['action_ids']:
                     translatables['action_ids'].append(str(int(cast_match[2], base=16)))
-                if not (cast_match[1] in translatables['bnpcname']):
+                if not cast_match[1] in translatables['bnpcname']:
                     translatables['bnpcname'].append(cast_match[1])
                 continue
 
             begincast_match = e_tools.is_tl_line_begincast(sync_match.group(0).split('/')[1])
             if begincast_match and not re.search(r'\(.+\|.+\)', begincast_match.group(0)):
-                if not (begincast_match.group(1) in translatables['action_ids']):
+                if not begincast_match.group(1) in translatables['action_ids']:
                     translatables['action_ids'].append(str(int(begincast_match.group(1), base=16)))
-                if not (begincast_match.group(2) in translatables['bnpcname']):
+                if not begincast_match.group(2) in translatables['bnpcname']:
                     translatables['bnpcname'].append(begincast_match.group(2))
                 continue
-            
-            # FIXME: The is_tl_line_buff() helper regex is currently bugged, and will NOT correctly return the buff/debuff.
+
+            # FIXME: The is_tl_line_buff() helper regex is currently bugged,
+            # and will NOT correctly return the buff/debuff.
             # The second capture group will eat the source/caster name up with the buff.
             # This line split  nonsense is to work around that
             buff_match = e_tools.is_tl_line_buff(sync_match.group(0))
             if buff_match:
                 buff_match = buff_match.group(2).split(' from')[0]
-                if not (buff_match in ['status']):
+                if not buff_match in ['status']:
                     translatables['status'].append(buff_match)
                 continue
 
@@ -109,14 +110,13 @@ def find_timeline_translatables(args):
             # FIXME: Add other log line possibilities here if necessary.
             log_match = e_tools.is_tl_line_log(sync_match.group(1))
             if log_match and 'will be sealed off' in log_match.group(2):
-                if not (log_match.group(2).split(' will be')[0] in translatables['PlaceName']):
+                if not log_match.group(2).split(' will be')[0] in translatables['PlaceName']:
                     translatables['PlaceName'].append(log_match.group(2).split(' will be')[0])
 
             add_match = e_tools.is_tl_line_adds(sync_match.group(1))
             if add_match:
-                if not (add_match.group(1) in translatables['bnpcname']):
+                if not add_match.group(1) in translatables['bnpcname']:
                     translatables['bnpcname'].append(add_match.group(1))
-    print(translatables)
     return translatables
 
 def compile_and_send(translatables):
@@ -159,7 +159,7 @@ def compile_and_send(translatables):
             # TODO: Allow for users to include their XIVAPI developer key to increase this limit.
             if requestcount % 11 is 0:
                 time.sleep(1)
-            req_payload = {'string': item, 'indexes': element, 'columns':columns,  'string_algo':'match'}
+            req_payload = {'string': item, 'indexes': element, 'columns':columns, 'string_algo':'match'}
             search_req_results = requests.get('https://xivapi.com/search', params=req_payload).json()['Results']
             if len(search_req_results) is 0:
                 continue
@@ -241,7 +241,7 @@ def build_mapping(translations, ignore_list=[]):
                     # raise Exception('Conflict on %s: "%s" and "%s"' % (default_name, existing_name, name))
                     pass
             else:
-                if default_name and name :
+                if default_name and name:
                     replace[lang][default_name] = name
     return replace
 
@@ -365,7 +365,7 @@ def main(args):
     output = {'timelineReplace': timeline_replace}
     output_str = json.dumps(output, ensure_ascii=False, indent=2, sort_keys=False)
     output_str = format_output_str(output_str)
-    
+
     # Write that out to the user.
     if args.output_file:
         with open(args.output_file, 'w', encoding='utf-8') as fp:


### PR DESCRIPTION
Alright, here's a draft for this. There's a lot of bad in here, but it's minimally functional and is faster than the FFLogs functionality that existed previously. As with the updates to `make_timeline` and `test_timeline`, this doesn't change previously-existing functionality except as necessary to add new stuff.

Currently, because I'm unsure of Cafemaker's search endpoint, this doesn't include support for Chinese translations. 

This is the German output for Copied Factory:

```
 {
   'locale': 'de',
   'replaceSync': {
     'small biped': 'klein[a] Zweibeiner',
     'serial-jointed service model': 'Modell[p] mit Omnigelenk',
     'serial-jointed command model': 'Befehlsmodell[p] mit Omnigelenk',
     'reverse-jointed Goliath': 'Goliath[p] mit Inversgelenk',
     'multi-leg medium model': 'mittelgroß[a] mehrbeinig[a] Modell',
     'medium exploder': 'mittelgroß[a] Selbstzerstörung',
     'flight unit': 'Flugeinheit',
     'Warehouse C': 'Warenlager C',
     'Warehouse B': 'Warenlager B',
     'Warehouse A': 'Warenlager A',
     'Quality Assurance': 'Warenkontrollhalle',
     'Marx': 'Marx',
     'Hobbes': 'Hobbes',
     'Goliath tank': 'Goliath-Panzer',
     'Engels': 'Engels',
     'Engage!': 'Start!',
     '9S-operated walking fortress': '9S\' mehrbeinig[a] Panzer',
     '9S-operated flight unit': '9S\' Flugeinheit',
   },
   'replaceText': {
     'Winds of Tartarus': 'Wind des Tartarus',
     'Wide-angle Diffuse Laser': 'Schwerer Diffusionslaser',
     'Undock': 'Abdocken',
     'Total Annihilation Maneuver': 'Offensive: Totale Vernichtung',
     'Throat Stab': 'Halsstich',
     'Systematic Targeting': 'Jagdformation',
     'Systematic Suppression': 'Artillerieformation',
     'Systematic Siege': 'Kesselformation',
     'Systematic Airstrike': 'Luftformation',
     'Surface Missile': 'Raketenschlag',
     'Spirit Dart': 'Geistpfeil',
     'Shrapnel Impact': 'Wrackteilregen',
     'Short-range Missile': 'Kurzstreckenrakete',
     'Shockwave': 'Schockwelle',
     'Ring Laser': 'Ringlaser',
     'Radiate Heat': 'Thermaloffensive',
     'Precision Guided Missile': 'Schwere Lenkrakete',
     'Oil Well': 'Ölaustritt',
     'Neutralization': 'Unterwerfung',
     'Marx Thrust': 'Marxscher Ansturm',
     'Marx Smash': 'Marxscher Schlag',
     'Marx Impact': 'Marxscher Sturz',
     'Marx Crush': 'Marxsche Offensive',
     'Marx Activation': 'Marx-Aktivierung',
     'Lightfast Blade': 'Lichtklingenschnitt',
     'Laser-resistance Test': 'Laserresistenztest',
     'Laser Turret': 'Hauptgeschützlaser',
     'Laser Sight': 'Laserbestrahlung',
     'Laser Saturation': 'Omnidirektionallaser',
     'Incendiary Saturation Bombing': 'Streubrandraketen',
     'Incendiary Bombing': 'Brandraketen',
     'High-powered Laser': 'Hochleistungslaser',
     'High-frequency Laser': 'Hochfrequenzlaser',
     'High-caliber Laser': 'Großkaliberlaser',
     'Hack Goliath Tank': 'Hacken: Goliath-Panzer',
     'Guided Missile': 'Lenkraketen',
     'Ground-to-ground Missile': 'Boden-Boden-Rakete',
     'Frontal Somersault': 'Sprungoffensive',
     'Freefire': 'Schwerer Beschuss',
     'Forceful Impact': 'Heftiges Beben',
     'Flash': 'Blitzlicht',
     'Fast Blade': 'Vortexschnitt',
     'Enrage': 'Finalangriff',
     'Engage Marx Support': 'Verstärkung: Marx',
     'Engage Goliath Tank Support': 'Verstärkung: Goliath-Panzer',
     'Energy Ring': 'Omnidirektionalenergie',
     'Energy Bombardment': 'Energiemörser',
     'Energy Blast': 'Energetische Explosion',
     'Energy Barrage': 'Energetisches Sperrfeuer',
     'Energy Assault': 'Energieschauer',
     'Diffuse Laser': 'Diffusionslaser',
     'Demolish Structure': 'Terraintilgung',
     'Crushing Wheel': 'Zangenradoffensive',
     'Convenient Self-destruction': 'Selbstsprengung',
     'Clanging Blow': 'Schwerer Angriff',
     'Ballistic Impact': 'Raketeneinschlag',
     'Arm Laser': 'Armlaser',
     'Area Bombing Maneuver': 'Offensive: Raketensalve',
     'Area Bombardment': 'Blindraketen',
     'Anti-personnel Missile': 'Antipersonenrakete',
     '360-degree Bombing Maneuver': 'Offensive: Raketenring',
     '--untargetable--': '--nich anvisierbar--',
     '--targetable--': '--anvisierbar--',
   },
   '~effectNames': {},
 },
```

Apart from the speed, another benefit here is that only relevant items will be translated. This has been one thing that's annoyed me about using FFLogs to translate, so this helps out in that regard.

Given how long this has been in progress, I'm not even sure what else to say about it. Criticize away and let's make this usable!