### PR TITLE
add Korean supports to resources/lang, raidboss\data\00-misc

### DIFF
--- a/resources/lang/ko.js
+++ b/resources/lang/ko.js
@@ -21,47 +21,47 @@ class CactbotLanguageKo extends CactbotLanguage {
       Medicated: '강화약', // tbc
       BattleLitany: '전투 기도', // 0x312
       Embolden: '성원', // 0x4d7
-      Arrow: 'FIXME', // 0x75c
+      Arrow: '오쉬온의 화살', // 0x75c
       Balance: '아제마의 균형', // 0x75a
-      Bole: 'FIXME', // 0x75b
-      Ewer: 'FIXME', // 0x75e
-      Spear: 'FIXME', // 0x75d
-      Spire: 'FIXME', // 0x75f
-      LadyOfCrowns: 'FIXME', // 0x755
-      LordOfCrowns: 'FIXME', // 0x754
+      Bole: '세계수의 줄기', // 0x75b
+      Ewer: '살리아크의 물병', // 0x75e
+      Spear: '할로네의 창', // 0x75d
+      Spire: '비레고의 탑', // 0x75f
+      LadyOfCrowns: '여왕의 날개', // 0x755
+      LordOfCrowns: '왕의 검', // 0x754
       Hypercharge: '과충전', // 0x2b0
       LeftEye: '용의 왼쪽 눈', // 0x4a0
       RightEye: '용의 오른쪽 눈', // 0x49f
       Brotherhood: '도원결의', // 0x49e
       Devotion: '에기의 가호', // 0x4bd
       FoeRequiem: '마인의 진혼곡', // up 0x8b, down 0x8c
-      LeadenFist: 'FIXME',
+      LeadenFist: '연격 효과 향상',
       StormsEye: '폭풍의 눈',
-      Devilment: 'FIXME',
-      TechnicalFinish: 'FIXME',
-      StandardFinish: 'FIXME',
-      Thundercloud: 'FIXME',
-      Firestarter: 'FIXME',
-      BattleVoice: 'FIXME',
-      Divination: 'FIXME',
-      ArmysMuse: 'FIXME',
-      ArmysEthos: 'FIXME',
+      Devilment: '공세의 탱고',
+      TechnicalFinish: '기교 마무리',
+      StandardFinish: '정석 마무리',
+      Thundercloud: '선더 계열 효과 향상',
+      Firestarter: '파이가 효과 향상',
+      BattleVoice: '전장의 노래',
+      Divination: '점복',
+      ArmysMuse: '군신의 가호',
+      ArmysEthos: '군신의 계약',
       PresenceOfMind: '쾌속의 마법',
       Shifu: '사풍',
       CircleOfPower: '흑마법 문양: 효과',
 
-      Paralysis: 'FIXME',
+      Paralysis: '마비',
       Petrification: '석화',
       BeyondDeath: '죽음의 초월',
       Burns: '화상',
       Sludge: '진흙탕',
       Doom: '죽음의 선고',
-      StoneCurse: 'FIXME',
-      Imp: 'FIXME',
-      Toad: 'FIXME',
-      FoolsTumble: 'FIXME', // 0x183
-      Dropsy: 'FIXME',
-      Throttle: 'FIXME',
+      StoneCurse: '석화의 저주',
+      Imp: '물요정',
+      Toad: '두꺼비',
+      FoolsTumble: '추락 환각', // 0x183
+      Dropsy: '물독',
+      Throttle: '질식',
 
       // UWU
       Windburn: '열상',
@@ -80,13 +80,13 @@ class CactbotLanguageKo extends CactbotLanguage {
       return /:전투 시작!/;
     };
     this.countdownCancelRegex = function() {
-      return / 님이 초읽기를 취소했습니다./;
+      return / 님이 초읽기를 취소했습니다\./;
     };
     this.areaSealRegex = function() {
-      return /:(\y{Float})초 후에 (.*)(이|가) 봉쇄됩니다./;
+      return /:(\y{Float})초 후에 (.*)(이|가) 봉쇄됩니다\./;
     };
     this.areaUnsealRegex = function() {
-      return /:(.*)의 봉쇄가 해제되었습니다./;
+      return /:(.*)의 봉쇄가 해제되었습니다\./;
     };
   }
 }

--- a/ui/raidboss/data/00-misc/general.js
+++ b/ui/raidboss/data/00-misc/general.js
@@ -140,7 +140,7 @@
       regexFr: Regexes.gameLog({ line: 'Un appel de préparation a été lancé par \y{Name}\.', capture: false }),
       regexJa: Regexes.gameLog({ line: '(?:\y{Name}が)?レディチェックを開始しました。', capture: false }),
       regexCn: Regexes.gameLog({ line: '\y{Name}?发起了准备确认', capture: false }),
-      regexKo: Regexes.gameLog({ line: '(?:\y{Name} 님이 )?준비 확인을 시작(했습|합)니다\.', capture: false }),
+      regexKo: Regexes.gameLog({ line: '(\y{Name} 님이 )?준비 확인을 시작(했습|합)니다\.', capture: false }),
       sound: '../../resources/sounds/Overwatch/D.Va_-_Game_on.ogg',
       soundVolume: 0.6,
     },

--- a/ui/raidboss/data/00-misc/general.js
+++ b/ui/raidboss/data/00-misc/general.js
@@ -18,6 +18,7 @@
           fr: 'Provocation: ' + name,
           ja: '挑発: ' + name,
           cn: '挑衅: ' + name,
+          ko: '도발: ' + name,
         };
       },
     },
@@ -35,6 +36,7 @@
           fr: 'Dérobade: ' + name,
           ja: 'シャーク: ' + name,
           cn: '退避: ' + name,
+          ko: '기피: ' + name,
         };
       },
     },
@@ -50,6 +52,7 @@
           en: 'Holmgang: ' + name,
           ja: 'ホルムギャング: ' + name,
           cn: '死斗: ' + name,
+          ko: '일대일 결투: ' + name,
         };
       },
     },
@@ -67,6 +70,7 @@
           fr: 'Invincible: ' + name,
           ja: 'インビンシブル: ' + name,
           cn: '神圣领域: ' + name,
+          ko: '천하무적: ' + name,
         };
       },
     },
@@ -84,6 +88,7 @@
           fr: 'Bolide: ' + name,
           ja: 'ボーライド: ' + name,
           cn: '超火流星: ' + name,
+          ko: '폭발 유성: ' + name,
         };
       },
     },
@@ -101,6 +106,7 @@
           fr: 'Mort-vivant: ' + name,
           ja: 'リビングデッド: ' + name,
           cn: '行尸走肉: ' + name,
+          ko: '산송장: ' + name,
         };
       },
     },
@@ -111,6 +117,7 @@
       regexFr: Regexes.gainsEffect({ effect: 'Marcheur Des Limbes' }),
       regexJa: Regexes.gainsEffect({ effect: 'ウォーキングデッド' }),
       regexCn: Regexes.gainsEffect({ effect: '死而不僵' }),
+      regexKo: Regexes.gainsEffect({ effect: '움직이는 시체' }),
       condition: function(data) {
         return data.role == 'tank' || data.role == 'healer';
       },
@@ -122,6 +129,7 @@
           fr: 'Marcheur Des Limbes: ' + name,
           ja: 'ウォーキングデッド: ' + name,
           cn: '死而不僵: ' + name,
+          ko: '움직이는 시체: ' + name,
         };
       },
     },
@@ -132,6 +140,7 @@
       regexFr: Regexes.gameLog({ line: 'Un appel de préparation a été lancé par \y{Name}\.', capture: false }),
       regexJa: Regexes.gameLog({ line: '(?:\y{Name}が)?レディチェックを開始しました。', capture: false }),
       regexCn: Regexes.gameLog({ line: '\y{Name}?发起了准备确认', capture: false }),
+      regexKo: Regexes.gameLog({ line: '(?:\y{Name} 님이 )?준비 확인을 시작(했습|합)니다\.', capture: false }),
       sound: '../../resources/sounds/Overwatch/D.Va_-_Game_on.ogg',
       soundVolume: 0.6,
     },

--- a/ui/raidboss/data/00-misc/general.js
+++ b/ui/raidboss/data/00-misc/general.js
@@ -140,7 +140,7 @@
       regexFr: Regexes.gameLog({ line: 'Un appel de préparation a été lancé par \y{Name}\.', capture: false }),
       regexJa: Regexes.gameLog({ line: '(?:\y{Name}が)?レディチェックを開始しました。', capture: false }),
       regexCn: Regexes.gameLog({ line: '\y{Name}?发起了准备确认', capture: false }),
-      regexKo: Regexes.gameLog({ line: '(\y{Name} 님이 )?준비 확인을 시작(했습|합)니다\.', capture: false }),
+      regexKo: Regexes.gameLog({ line: '(\y{Name} 님이 준비 확인을 시작했습니다\.|준비 확인을 시작합니다\.)', capture: false }),
       sound: '../../resources/sounds/Overwatch/D.Va_-_Game_on.ogg',
       soundVolume: 0.6,
     },

--- a/ui/raidboss/data/00-misc/general.js
+++ b/ui/raidboss/data/00-misc/general.js
@@ -140,7 +140,7 @@
       regexFr: Regexes.gameLog({ line: 'Un appel de préparation a été lancé par \y{Name}\.', capture: false }),
       regexJa: Regexes.gameLog({ line: '(?:\y{Name}が)?レディチェックを開始しました。', capture: false }),
       regexCn: Regexes.gameLog({ line: '\y{Name}?发起了准备确认', capture: false }),
-      regexKo: Regexes.gameLog({ line: '(\y{Name} 님이 준비 확인을 시작했습니다\.|준비 확인을 시작합니다\.)', capture: false }),
+      regexKo: Regexes.gameLog({ line: '\y{Name} 님이 준비 확인을 시작했습니다\.|준비 확인을 시작합니다\.', capture: false }),
       sound: '../../resources/sounds/Overwatch/D.Va_-_Game_on.ogg',
       soundVolume: 0.6,
     },

--- a/ui/raidboss/data/00-misc/test.js
+++ b/ui/raidboss/data/00-misc/test.js
@@ -1,7 +1,7 @@
 'use strict';
 
 [{
-  zoneRegex: /^(Middle La Noscea|中拉诺西亚)$/,
+  zoneRegex: /^(Middle La Noscea|中拉诺西亚|중부 라노시아)$/,
   timelineFile: 'test.txt',
   // timeline here is additions to the timeline.  They can
   // be strings, or arrays of strings, or functions that
@@ -48,18 +48,21 @@
       regex: /(Angry Dummy)/,
       regexDe: /(Wütender Dummy)/,
       regexCn: /愤怒的木人/,
+      regexKo: /화난 나무인형/,
       beforeSeconds: 2,
       infoText: function(data, matches) {
         return {
           en: 'Stack for ' + matches[1],
           de: 'Sammeln für ' + matches[1],
           cn: '木人处集合',
+          ko: matches[1] + '에 집합',
         };
       },
       tts: {
         en: 'Stack',
         de: 'Sammeln',
         cn: '集合',
+        ko: '집합',
       },
     },
   ],
@@ -82,6 +85,25 @@
         'You bow courteously to the striking dummy': 'Du verbeugst dich hochachtungsvoll vor der Trainingspuppe',
         'test sync': 'test sync',
         'Engage!': 'Start!',
+      },
+    },    {
+      locale: 'ko',
+      replaceText: {
+        'Final Sting': '마지막 벌침',
+        'Almagest': '알마게스트',
+        'Angry Dummy': '화난 나무인형',
+        'Long Castbar': '긴 시전바',
+        'Dummy Stands Still': '나무인형이 아직 살아있다',
+        'Death': '데스',
+        'Super Tankbuster': '초강력 탱크버스터',
+        'Pentacle Sac': 'Pentacle Sac',
+        'Engage': '시작',
+      },
+      replaceSync: {
+        'You bid farewell to the striking dummy': '.*나무인형에게 작별 인사를 합니다',
+        'You bow courteously to the striking dummy': '.*나무인형에게 공손하게 인사합니다',
+        'test sync': '테스트 싱크',
+        'Engage!': '전투 시작!',
       },
     },
     {
@@ -127,6 +149,7 @@
       regexDe: /:Du stupst die Trainingspuppe an/,
       regexFr: /:Vous touchez légèrement le mannequin d'entraînement du doigt/,
       regexCn: /:.*用手指戳向木人/,
+      regexKo: /:.*나무인형을 쿡쿡 찌릅니다/,
       preRun: function(data) {
         data.pokes = (data.pokes || 0) + 1;
       },
@@ -136,6 +159,7 @@
           de: 'stups #' + data.pokes,
           fr: 'Touché #' + data.pokes,
           cn: '戳 #' + data.pokes,
+          ko: data.pokes + '번 찌름',
         };
       },
     },
@@ -145,23 +169,27 @@
       regexDe: /:Du willst wahren Kampfgeist in der Trainingspuppe entfachen/,
       regexFr: /:Vous vous motivez devant le mannequin d'entraînement/,
       regexCn: /:.*激励木人/,
+      regexKo: /:.*나무인형에게 힘을 불어넣습니다/,
       alertText: {
         en: 'PSYCH!!!',
         de: 'AUF GEHTS!!!',
         fr: 'MOTIVATION !!!',
         cn: '激励！！',
+        ko: '힘내라!!',
       },
       tts: {
         en: 'psych',
         de: 'auf gehts',
         fr: 'Motivation',
         cn: '激励',
+        ko: '힘내라!',
       },
       groupTTS: {
         en: 'group psych',
         de: 'Gruppen auf gehts',
         fr: 'group motivation',
         cn: '组激励',
+        ko: '단체 격려',
       },
     },
     {
@@ -170,24 +198,28 @@
       regexDe: /:Du lachst herzlich mit der Trainingspuppe/,
       regexFr: /:Vous vous esclaffez devant le mannequin d'entraînement/,
       regexCn: /:.*看着木人高声大笑/,
+      regexKo: /:.*나무인형을 보고 폭소를 터뜨립니다/,
       suppressSeconds: 5,
       alarmText: {
         en: 'hahahahaha',
         de: 'hahahahaha',
         fr: 'Mouahahaha',
         cn: '2333333333',
+        ko: '푸하하하하핳',
       },
       tts: {
         en: 'hahahahaha',
         de: 'hahahahaha',
         fr: 'Haha mort de rire',
         cn: '哈哈哈哈哈哈',
+        ko: '푸하하하하핳',
       },
       groupTTS: {
         en: 'group laugh',
         de: 'Gruppenlache',
         fr: 'group motivation',
         cn: '组哈哈',
+        ko: '단체 웃음',
       },
     },
     {
@@ -196,6 +228,7 @@
       regexDe: /:Du klatschst begeistert Beifall für die Trainingspuppe/,
       regexFr: /:Vous applaudissez le mannequin d'entraînement/,
       regexCn: /:.*向木人送上掌声/,
+      regexKo: /:.*나무인형에게 박수를 보냅니다/,
       sound: '../../resources/sounds/WeakAuras/Applause.ogg',
       soundVolume: 0.3,
       tts: {
@@ -203,6 +236,7 @@
         de: 'klatschen',
         fr: 'Bravo, vive la France',
         cn: '鼓掌',
+        ko: '박수 짝짝짝',
       },
     },
     {
@@ -210,11 +244,13 @@
       // In game: /echo cactbot lang
       regex: / 00:0038:cactbot lang/,
       regexDe: / 00:0038:cactbot sprache/,
+      regexKo: / 00:0038:cactbot 언어/,
       infoText: function(data) {
         return {
           en: 'Language: ' + data.lang,
           de: 'Sprache: ' + data.lang,
           cn: '语言: ' + data.lang,
+          ko: '언어: ' + data.lang,
         };
       },
     },

--- a/ui/raidboss/data/00-misc/test.js
+++ b/ui/raidboss/data/00-misc/test.js
@@ -86,7 +86,8 @@
         'test sync': 'test sync',
         'Engage!': 'Start!',
       },
-    },    {
+    },
+    {
       locale: 'ko',
       replaceText: {
         'Final Sting': '마지막 벌침',


### PR DESCRIPTION
Thanks for updating cactbot supports Korean. I have tested test.js and it worked well except playing tts and sound file.

and may I ask a question?
Dose it need in translating raidboss triggers to match exactly '~effectNames' with in-game data like 'Physical Vulnerability Up'? I saw translated titania and innocence triggers and find some difference.