### PR TITLE
Fix the new user config for users who haven't used it, yet.

### DIFF
--- a/CactbotOverlay/CactbotEventSourceConfig.cs
+++ b/CactbotOverlay/CactbotEventSourceConfig.cs
@@ -69,8 +69,7 @@ namespace Cactbot {
     [JsonIgnore]
     public string UserConfigFile {
       get {
-        var options = OverlayData["options"];
-        if (options == null)
+        if (!OverlayData.TryGetValue("options", out JToken options))
           return null;
         var general = options["general"];
         if (general == null)
@@ -87,8 +86,7 @@ namespace Cactbot {
     [JsonIgnore]
     public bool WatchFileChanges {
       get {
-        var options = OverlayData["options"];
-        if (options == null)
+        if (!OverlayData.TryGetValue("options", out JToken options))
           return false;
         var general = options["general"];
         if (general == null)

--- a/resources/user_config.js
+++ b/resources/user_config.js
@@ -35,12 +35,15 @@ let UserConfig = {
 
       // Handle processOptions after default language selection above,
       // but before css below which may load skin files.
-      this.savedConfig = (await readOptions).data;
-      this.processOptions(
-          Options,
-          this.savedConfig[overlayName],
-          this.optionTemplates[overlayName],
-      );
+      let userOptions = await readOptions;
+      if (userOptions) {
+        this.savedConfig = userOptions.data;
+        this.processOptions(
+            Options,
+            this.savedConfig[overlayName],
+            this.optionTemplates[overlayName],
+        );
+      }
 
       // In cases where the user files are local but the overlay url
       // is remote, local files needed to be read by the plugin and


### PR DESCRIPTION
C# `Dictionary`s throw an exception if a missing key is accessed. I used `TryGetValue` to avoid that.
The `JToken` objects behave as expected (a missing key just returns `null`).

Finally, I had to change `user_config.js` because it tried to access a property on a `null` value when `cactbotLoadData` returns `null`.