### PR TITLE
plugin: Revert korean region check and just use FFXIV_ACT_Plugin's language setting

### DIFF
--- a/CactbotOverlay/CactbotEventSource.cs
+++ b/CactbotOverlay/CactbotEventSource.cs
@@ -45,7 +45,6 @@ namespace Cactbot {
     private FFXIVProcess ffxiv_;
     private WipeDetector wipe_detector_;
     private string language_ = null;
-    private string ffxiv_plugin_region_ = null;
     private List<FileSystemWatcher> watchers;
 
     public delegate void ForceReloadHandler(JSEvents.ForceReloadEvent e);
@@ -233,8 +232,6 @@ namespace Cactbot {
       Version ffxiv = versions.GetFFXIVPluginVersion();
       Version act = versions.GetACTVersion();
 
-      ffxiv_plugin_region_ = versions.GetFFXIVPluginRegion();
-
       // Print out version strings and locations to help users debug.
       LogInfo("cactbot: {0} {1} (dir: {2})", local.ToString(), versions.GetCactbotPluginLocation(), versions.GetCactbotDirectory());
       LogInfo("OverlayPlugin: {0} {1}", overlay.ToString(), versions.GetOverlayPluginLocation());
@@ -246,14 +243,12 @@ namespace Cactbot {
         LogInfo("Language: {0}", language_);
       }
 
-      if (ffxiv_plugin_region_ == "ko") {
-        ffxiv_ = new FFXIVProcessKo(this);
-        LogInfo("Version: ko");
-      }
-      // Temporarily target cn if plugin is old v2.0.4.0
-      else if (language_ == "cn" || ffxiv.ToString() == "2.0.4.0") {
+      if (language_ == "cn" || ffxiv.ToString() == "2.0.4.0") {
         ffxiv_ = new FFXIVProcessCn(this);
         LogInfo("Version: cn");
+      } else if (language_ == "ko") {
+        ffxiv_ = new FFXIVProcessKo(this);
+        LogInfo("Version: ko");
       } else {
         ffxiv_ = new FFXIVProcessIntl(this);
         LogInfo("Version: intl");

--- a/CactbotOverlay/CactbotEventSource.cs
+++ b/CactbotOverlay/CactbotEventSource.cs
@@ -243,6 +243,7 @@ namespace Cactbot {
         LogInfo("Language: {0}", language_);
       }
 
+      // Temporarily target cn if plugin is old v2.0.4.0
       if (language_ == "cn" || ffxiv.ToString() == "2.0.4.0") {
         ffxiv_ = new FFXIVProcessCn(this);
         LogInfo("Version: cn");

--- a/CactbotOverlay/VersionChecker.cs
+++ b/CactbotOverlay/VersionChecker.cs
@@ -78,13 +78,6 @@ namespace Cactbot {
         return GetPluginData("FFXIV_ACT_Plugin_Korean.dll") ?? GetPluginData("FFXIV_ACT_Plugin.dll");
     }
 
-    public string GetFFXIVPluginRegion() {
-      var plugin = GetFFXIVPluginData();
-      if (plugin == null)
-        return "";
-      return plugin.pluginFile.ToString().Contains("Korean") ? "ko" : "intl";
-    }
-
     public Version GetFFXIVPluginVersion() {
       var plugin = GetFFXIVPluginData();
       if (plugin == null)


### PR DESCRIPTION
Following the submission of #908 and #906, it's common that the Korean FFXIV_ACT_Plugin dll is being renamed. 

Using the FFXIV_ACT_Plugin's game language setting is also a reliable check, as although it isn't a true check of the region, the international client doesn't have Korean language support and so should only be set as such on a Korean client.