### PR TITLE
Update monster position

### DIFF
--- a/ui/radar/radar.js
+++ b/ui/radar/radar.js
@@ -119,54 +119,64 @@ class Radar {
 
     let mobKey = matches.groups.name.toLowerCase();
     if (mobKey in this.targetMonsters) {
-      // Update monster position
-      this.targetMonsters[mobKey].pos =
+      // Get positions
+      let playerPos = new Point2D(this.playerPos.x, this.playerPos.y);
+      let curPos = this.targetMonsters[mobKey].pos;
+      let newPos =
         new Point2D(parseFloat(matches.groups.x), parseFloat(matches.groups.y));
-      this.targetMonsters[mobKey].posZ = matches.groups.z;
-      return;
-    }
 
-    // add dom
-    let arrowId = 'arrow-' + matches.groups.id;
-    let tr = document.createElement('tr');
-    let th = document.createElement('th');
-    let img = document.createElement('img');
-    img.setAttribute('id', arrowId);
-    img.setAttribute('src', 'arrow.png');
-    img.setAttribute('class', 'radar-image-40');
-    th.appendChild(img);
-    th.setAttribute('style', 'max-width: 100px');
-    tr.appendChild(th);
-    th = document.createElement('th');
-    th.setAttribute('align', 'left');
-    th.appendChild(document.createElement('div'));
-    tr.appendChild(th);
-    this.table.insertBefore(tr, this.table.childNodes[0]);
+      // Caalculate distances
+      let curDistance = playerPos.distance(curPos);
+      let newDistance = playerPos.distance(newPos);
 
-    let m = {
-      'id': matches.groups.id,
-      'name': matches.groups.name,
-      'rank': monster.rank || '',
-      'hp': parseFloat(matches.groups.hp),
-      'currentHp': parseFloat(matches.groups.hp),
-      'battleTime': 0,
-      'pos': new Point2D(parseFloat(matches.groups.x), parseFloat(matches.groups.y)),
-      'posZ': matches.groups.z,
-      'addTime': Date.now(),
-      'dom': tr,
-      'puller': null,
-    };
-    this.targetMonsters[mobKey] = m;
-    this.UpdateMonsterDom(m);
-    if (options.TTS) {
-      callOverlayHandler({
-        call: 'cactbotSay',
-        text: m.rank + ' ' + m.name,
-      });
-    } else if (options.PopSoundAlert && options.PopSound && options.PopVolume) {
-      let audio = new Audio(options.PopSound);
-      audio.volume = options.PopVolume;
-      audio.play();
+      // Update position only if its closer than the current one
+      if (newDistance < curDistance) {
+        this.targetMonsters[mobKey].pos = newPos;
+        this.targetMonsters[mobKey].posZ = matches.groups.z;
+
+        // Update DOM
+        this.UpdateMonsterDom(this.targetMonsters[mobKey]);
+
+        // Play sound only if its far enough
+        if (curPos.distance(newPos) >= 100) {
+          PlaySound(this.targetMonsters[mobKey], options);
+        }
+      }
+    } else {
+      // Add DOM
+      let arrowId = 'arrow-' + matches.groups.id;
+      let tr = document.createElement('tr');
+      let th = document.createElement('th');
+      let img = document.createElement('img');
+      img.setAttribute('id', arrowId);
+      img.setAttribute('src', 'arrow.png');
+      img.setAttribute('class', 'radar-image-40');
+      th.appendChild(img);
+      th.setAttribute('style', 'max-width: 100px');
+      tr.appendChild(th);
+      th = document.createElement('th');
+      th.setAttribute('align', 'left');
+      th.appendChild(document.createElement('div'));
+      tr.appendChild(th);
+      this.table.insertBefore(tr, this.table.childNodes[0]);
+
+      let m = {
+        'id': matches.groups.id,
+        'name': matches.groups.name,
+        'rank': monster.rank || '',
+        'hp': parseFloat(matches.groups.hp),
+        'currentHp': parseFloat(matches.groups.hp),
+        'battleTime': 0,
+        'pos': new Point2D(parseFloat(matches.groups.x), parseFloat(matches.groups.y)),
+        'posZ': matches.groups.z,
+        'addTime': Date.now(),
+        'dom': tr,
+        'puller': null,
+      };
+      this.targetMonsters[mobKey] = m;
+      this.UpdateMonsterDom(m);
+
+      PlaySound(this.targetMonsters[mobKey], options);
     }
   }
 

--- a/ui/radar/radar.js
+++ b/ui/radar/radar.js
@@ -138,9 +138,8 @@ class Radar {
         this.UpdateMonsterDom(this.targetMonsters[mobKey]);
 
         // Play sound only if its far enough
-        if (curPos.distance(newPos) >= 100) {
+        if (curPos.distance(newPos) >= 100)
           PlaySound(this.targetMonsters[mobKey], options);
-        }
       }
     } else {
       // Add DOM

--- a/ui/radar/radar.js
+++ b/ui/radar/radar.js
@@ -40,8 +40,19 @@ class Point2D {
     this.y = y;
   }
 
+  // Calculates vector length (magnitude)
   length() {
     return Math.sqrt((this.x) * (this.x) + (this.y) * (this.y));
+  }
+
+  // Calculate delta vector
+  delta(target) {
+    return new Point2D(target.x - this.x, target.y - this.y);
+  }
+
+  // Calculate distance between 2 points
+  distance(target) {
+    return this.delta(target).length();
   }
 }
 

--- a/ui/radar/radar.js
+++ b/ui/radar/radar.js
@@ -94,8 +94,12 @@ class Radar {
     }
 
     let mobKey = matches.groups.name.toLowerCase();
-    if (mobKey in this.targetMonsters)
+    if (mobKey in this.targetMonsters) {
+      // Update monster position
+      this.targetMonsters[mobKey].pos = new Point2D(parseFloat(matches.groups.x), parseFloat(matches.groups.y));
+      this.targetMonsters[mobKey].posZ = matches.groups.z;
       return;
+    }
 
     // add dom
     let arrowId = 'arrow-' + matches.groups.id;

--- a/ui/radar/radar.js
+++ b/ui/radar/radar.js
@@ -62,6 +62,19 @@ function posToMap(h) {
   return h * pitch + offset;
 }
 
+function PlaySound(monster, options) {
+  if (options.TTS) {
+    callOverlayHandler({
+      call: 'cactbotSay',
+      text: m.rank + ' ' + m.name,
+    });
+  } else if (options.PopSoundAlert && options.PopSound && options.PopVolume) {
+    let audio = new Audio(options.PopSound);
+    audio.volume = options.PopVolume;
+    audio.play();
+  }
+}
+
 class Radar {
   constructor(element) {
     this.targetMonsters = {};

--- a/ui/radar/radar.js
+++ b/ui/radar/radar.js
@@ -96,7 +96,8 @@ class Radar {
     let mobKey = matches.groups.name.toLowerCase();
     if (mobKey in this.targetMonsters) {
       // Update monster position
-      this.targetMonsters[mobKey].pos = new Point2D(parseFloat(matches.groups.x), parseFloat(matches.groups.y));
+      this.targetMonsters[mobKey].pos =
+        new Point2D(parseFloat(matches.groups.x), parseFloat(matches.groups.y));
       this.targetMonsters[mobKey].posZ = matches.groups.z;
       return;
     }


### PR DESCRIPTION
Quick change to update monster position when (re-)detected, mainly for B ranks but works for all monsters.

This fixes the situation where (example):
1. You're scouting and gets in range of a B rank.
2. Radar detects B rank and adds it to the list.
3. You fly out of range as you continue scouting.
4. B rank gets killed while you're out of range, causing it to respawn somewhere else.
5. You get in range of said monster's new position.
6. Radar doesn't update the position because the old one is "still alive".

This small change makes it so the radar update the B rank's position in example above. Updating the position in realtime would be suitable but I don't know enough to code it. This should however be enough as hunts don't move too far anyway.