### PR TITLE
Add missing raidboss_config.js to raidemulator.html

### DIFF
--- a/ui/raidboss/raidemulator.html
+++ b/ui/raidboss/raidemulator.html
@@ -23,6 +23,7 @@
   <script src="../../resources/lang/cn.js"></script>
   <!-- Cactbot Overlay Scripts-->
   <link rel="stylesheet" type="text/css" href="raidboss.css">
+  <script src="raidboss_config.js"></script>
   <script src="timeline.js"></script>
   <script src="popup-text.js"></script>
   <script src="raidboss.js"></script>


### PR DESCRIPTION
Pretty self explanatory.
This fixes errors like this one:
```
BrowserConsole: Uncaught TypeError: Cannot read property 'E1S Initial' of undefined (Source: file:///.../ui/raidboss/popup-text.js, Line: 330)
```