### PR TITLE
WIP: raidboss: Fix formatting in e1/e3 timelines

### DIFF
--- a/ui/raidboss/data/05-shb/raid/e3s.txt
+++ b/ui/raidboss/data/05-shb/raid/e3s.txt
@@ -20,7 +20,7 @@ hideall "--sync--"
 69.7 "Freak Wave" sync /:Leviathan:3FE6:/
 73.7 "Temporary Current" sync /:Leviathan:(3FEB|3FEA):/
 87.9 "Maelstrom" sync /:Leviathan:3FFA:/
-90.0  "--untargetable--"
+90.0 "--untargetable--"
 99.3 "Spinning Dive 1" #sync /:Leviathan:3FFD:/
 101.3 "Spinning Dive 2" #sync /:Leviathan:3FFD:/
 106.0 "--targetable--"


### PR DESCRIPTION
I tried to parse cactbot's timeline files for a little tool of mine but found that naive parsing of spells from the timeline failed because of some formatting errors.

I guess these are unwanted and just happened to be there and not upset cactbot's parsing so I suggest to unify them.