### PR TITLE
radar: Add missing dom update on pull

### DIFF
--- a/ui/radar/radar.js
+++ b/ui/radar/radar.js
@@ -147,6 +147,7 @@ class Radar {
     if (monster.puller !== null)
       return;
     monster.puller = puller;
+    this.UpdateMonsterDom(monster);
     console.log('Pull: ' + puller + ' => ' + monster.name);
   }
 


### PR DESCRIPTION
Adds a missing dom update when the monster is pulled.

Allows for the puller name to appear immediately without needing to nudge a bit to see it.