### PR TITLE
radar: pass options to PlaySound

### DIFF
--- a/ui/radar/radar.js
+++ b/ui/radar/radar.js
@@ -146,7 +146,7 @@ class Radar {
 
         // Play sound only if its far enough
         if (oldPos.distance(newPos) >= kMinDistanceBeforeSound)
-          PlaySound(this.targetMonsters[mobKey]);
+          PlaySound(this.targetMonsters[mobKey], options);
       }
     } else {
       // Add DOM
@@ -182,7 +182,7 @@ class Radar {
       this.targetMonsters[mobKey] = m;
       this.UpdateMonsterDom(m);
 
-      PlaySound(this.targetMonsters[mobKey]);
+      PlaySound(this.targetMonsters[mobKey], options);
     }
   }
 


### PR DESCRIPTION
I spotted options wasn't being passed to PlaySound after the cleanup was reverted, this commit re-adds it.

Reason the cleanup broke PlaySound is because of lines 116-119, which creates a local version of the variable options, which is then used for PlaySound.