### PR TITLE
lint: Initial Python Formatting

### DIFF
--- a/test/unittests.py
+++ b/test/unittests.py
@@ -3,7 +3,7 @@
 from pathlib import Path
 import subprocess
 import sys
-from definitions import  PROJECT_ROOT_DIRECTORY, TEST_DIRECTORY
+from definitions import PROJECT_ROOT_DIRECTORY, TEST_DIRECTORY
 
 UNITTEST_DIRECTORY = 'unittests'
 

--- a/util/check_translation.py
+++ b/util/check_translation.py
@@ -47,7 +47,7 @@ class FileLikeArray:
 
 
 def base_triggers_path():
-    return os.path.join(os.path.dirname(__file__), '../ui/raidboss/data/');
+    return os.path.join(os.path.dirname(__file__), '../ui/raidboss/data/')
 
 
 def construct_relative_triggers_path(filename):
@@ -123,7 +123,7 @@ def update_triggers(triggers, trans):
                         if lang in trans:
                             new_regex = translate_regex(found_base.group(1), trans[lang])
                             if new_regex:
-                                new_line = '      regex' + lang.capitalize() + ': ' + new_regex + ',\n'
+                                new_line = f'      regex{lang.capitalize()}: {new_regex},\n'
                                 fp.write(new_line)
 
                     regex_langs = {}

--- a/util/gen_fisher_data.py
+++ b/util/gen_fisher_data.py
@@ -20,6 +20,7 @@ if len(sys.argv) > 1:
 else:
     xivapi_key = False
 
+
 def cleanup_german(word):
     word = word.replace('[A]', 'er')
     word = word.replace('[p]', '')
@@ -31,9 +32,10 @@ def cleanup_german(word):
     # [a] is complicated, and can mean different things in different contexts.
     # Just cover all our bases here.
     endings = ['e', 'en', 'es', 'er']
-    return list(map(lambda x : word.replace('[a]', x), endings))
+    return list(map(lambda x: word.replace('[a]', x), endings))
 
-def xivapi(content, filters = {}):
+
+def xivapi(content, filters={}):
     """Fetches content columns from XIVAPI"""
     page = 1
     url = f'{base}{content}'
@@ -70,7 +72,7 @@ def xivapi(content, filters = {}):
         results = response
 
     # Loop requests until the page is over
-    while (not by_id and response['Pagination']['Page'] != response['Pagination']['PageTotal']):
+    while not by_id and response['Pagination']['Page'] != response['Pagination']['PageTotal']:
         page += 1
         response = requests.get(f'{url}&page={page}')
         if response.status_code != 200:
@@ -85,6 +87,7 @@ def xivapi(content, filters = {}):
 
     return results
 
+
 def fish_tracker():
     response = requests.get(fishTrackerBase)
     if response.status_code != 200:
@@ -94,6 +97,7 @@ def fish_tracker():
         exit()
 
     return yaml.load(response.text, yaml.Loader)
+
 
 def get_fish_data():
     """Returns dictionaries for places, fish, and place->fish mapping"""
@@ -170,12 +174,13 @@ def get_fish_data():
 
     return places, fishes, placefish
 
+
 def get_tackle():
     # Also get fishing tackle
     response = xivapi('ItemSearchCategory', {'id': tackle_id, 'columns': ['GameContentLinks.Item.ItemSearchCategory']})
 
     item_ids = response['GameContentLinks']['Item']['ItemSearchCategory']
-    columns = ['ID'] + [f'Singular_{locale}'for locale in locales]
+    columns = ['ID'] + [f'Singular_{locale}' for locale in locales]
 
     results = xivapi('Item', {'columns': columns, 'ids': item_ids})
 
@@ -193,6 +198,7 @@ def get_tackle():
 
     return tackle
 
+
 def find_fish_by_name(fishes, name):
     for id, value in fishes['en'].items():
         if type(value) is list:
@@ -202,6 +208,7 @@ def find_fish_by_name(fishes, name):
         else:
             if value == name:
                 return id
+
 
 def get_tugs(fishes):
     tugs = {}
@@ -225,6 +232,7 @@ def get_tugs(fishes):
                 tugs[id] = tug
 
     return tugs
+
 
 def append_special_place_names(places):
     # handle special german casting names
@@ -253,6 +261,7 @@ def append_special_place_names(places):
           places['de'][place].append(m.group(1))
         else:
           places['de'][place] = [places['de'][place], m.group(1)]
+
 
 def get_cn_data():
     global locales, base
@@ -290,7 +299,7 @@ if __name__ == "__main__":
         'places': places,
         'fish': fishes,
         'placefish': placefish,
-        'tugs': tugs
+        'tugs': tugs,
     }
 
     filename = Path(__file__).resolve().parent.parent / 'ui' / 'fisher' / 'static-data.js'

--- a/util/gen_territory_type.py
+++ b/util/gen_territory_type.py
@@ -64,7 +64,6 @@ def parse_data(csvfile):
     return all_rates
 
 
-
 def update(reader, writer):
     data = reader.exd('TerritoryType')
     all_rates = parse_data(data)

--- a/util/gen_weather_rate.py
+++ b/util/gen_weather_rate.py
@@ -22,7 +22,7 @@ def parse_data(csvfile):
             if not weather_name:
                 break
             weathers.append(weather_name)
-            sum += int(row[i+1])
+            sum += int(row[i + 1])
             rates.append(sum)
         # add leading zeroes so they sort properly.
         all_rates["%04d" % int(row[0])] = {

--- a/util/make_timeline.py
+++ b/util/make_timeline.py
@@ -130,6 +130,7 @@ def parse_file(args):
 
     return entries, last_ability_time
 
+
 def main(args):
     timeline_position = 0
     last_ability_time = 0
@@ -223,11 +224,11 @@ def main(args):
 
         # Round up to the tenth of second
         if last_time_diff_us > 60000:
-            last_time_diff_sec += .1
+            last_time_diff_sec += 0.1
 
         # Round up with a note about exceptional drift
         elif last_time_diff_us > 50000:
-            last_time_diff_sec += .1
+            last_time_diff_sec += 0.1
             drift = -100000 + last_time_diff_us
 
         # Round down with a note about exceptional drift
@@ -257,8 +258,6 @@ def main(args):
         # Save the entry til the next line for filtering
         last_entry = entry
     return output
-
-
 
 
 if __name__ == "__main__":

--- a/util/test_timeline.py
+++ b/util/test_timeline.py
@@ -145,7 +145,7 @@ def parse_report(args):
             'time': datetime.fromtimestamp((report_start_time + event['timestamp']) / 1000),
             'ability_id': hex(event['ability']['guid'])[2:].upper(),
             'ability_name': event['ability']['name'],
-            'type': event['type']
+            'type': event['type'],
         }
 
         # In the applydebuff case, the source is -1 (environment) and we want the target instead
@@ -160,12 +160,14 @@ def parse_report(args):
 
     return entries, datetime.fromtimestamp((report_start_time + start_time) / 1000)
 
+
 def get_regex(event):
     """Gets the regex for the event for both file and report types"""
     if isinstance(event, str):
         return event
     elif isinstance(event, dict):
         return event['regex']
+
 
 def get_type(event):
     """Gets the line type for both file and report types"""
@@ -335,6 +337,7 @@ def check_event(event, timelist, state):
 
     return state
 
+
 def run_file(args, timelist):
     """Runs a timeline against a specified file"""
     state = {
@@ -343,7 +346,7 @@ def run_file(args, timelist):
         'last_sync_position': 0,
         'last_jump': 0,
         'branch': 1,
-        'timeline_stopped': True
+        'timeline_stopped': True,
     }
     started = False
     encounter_sets = []
@@ -396,7 +399,7 @@ def run_report(args, timelist):
         'last_sync_timestamp': start_time,
         'last_jump': 0,
         'branch': 1,
-        'timeline_stopped': False
+        'timeline_stopped': False,
     }
 
     for event in events:
@@ -423,7 +426,7 @@ def timeline_file(filename):
     data_path = Path(__file__).resolve().parent.parent / 'ui' / 'raidboss' / 'data'
     # Allow for just specifying the base filename, e.g. "o12s.txt" or "o12s"
     if not os.path.exists(filename):
-        for root, dirs, files in os.walk(data_path):
+        for root, _, files in os.walk(data_path):
           if filename in files:
             filename = os.path.join(root, filename)
             break
@@ -436,7 +439,6 @@ def timeline_file(filename):
         raise argparse.ArgumentTypeError("Could not load timeline: %s" % filename)
     else:
         return path.open()
-
 
 
 if __name__ == "__main__":

--- a/util/timeline_aggregator.py
+++ b/util/timeline_aggregator.py
@@ -68,6 +68,7 @@ def create_averaging_function(threshold):
     of similar event times.
     """
     key = None
+
     def averaging_function(event_time):
         """Averages event time values based on a threshold.
 
@@ -80,6 +81,7 @@ def create_averaging_function(threshold):
         elif event_time >= key:
             key = event_time + threshold
         return key
+
     return averaging_function
 
 
@@ -95,15 +97,15 @@ def average_similar_events(values, threshold):
     return list(round(mean(group), 1) for _, group in grouped_values)
 
 
-class TimelineAggregator():
+class TimelineAggregator:
     """Aggregates timelines and averages their event times.
 
     Takes an input of N timelines and attempts to smooth their event times to
     find the line of best fit when determining when events occur.
     """
+
     def __init__(self, timelines):
         self.timelines = timelines
-
 
     def aggregate(self, averaging_threshold=2.0):
         """Aggregates timelines and returns a list of their events.

--- a/util/translate_fight.py
+++ b/util/translate_fight.py
@@ -98,14 +98,14 @@ def build_mapping(translations, ignore_list=[]):
                     # raise Exception('Conflict on %s: "%s" and "%s"' % (default_name, existing_name, name))
                     pass
             else:
-                if default_name and name :
+                if default_name and name:
                     replace[lang][default_name] = name
     return replace
 
 
 def format_output_str(output_str):
     output_str = output_str.replace("'", "\\'")
-    output_str = output_str.replace("\"","'")
+    output_str = output_str.replace("\"", "'")
     output_str = output_str.replace("'timelineReplace'", "timelineReplace")
     regex = re.compile(r"]$", re.M)
     output_str = regex.sub("],", output_str)


### PR DESCRIPTION
Initial pass at using [black](https://github.com/psf/black) to format the Python code in the repository; there is a lot left out, because this was done without the single to double quote conversion or taking line-length into account in order to reduce noise and catch any possible issues or other ways to clean up code without resorting to line breaks, and to increase individual pull request readability.