### PR TITLE
docs: Update Issues Link

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,7 +22,7 @@ The code of conduct for cactbot can be found here:
 
 Please file all issues with cactbot on github,
 via this url:
-[https://github.com/quisquous/cactbot/issues/new](https://github.com/quisquous/cactbot/issues/new)
+<https://github.com/quisquous/cactbot/issues/new/choose>
 
 ## Pull Requests
 


### PR DESCRIPTION
Update the issues link to point to the templatized version of the issues
page to hopefully encourage using issues that automatically label
themselves.