### PR TITLE
force javascript calculate numbers

### DIFF
--- a/ui/jobs/jobs.js
+++ b/ui/jobs/jobs.js
@@ -990,7 +990,7 @@ class Bars {
       this.o.leftBuffsList.rowcolsize = 7;
       this.o.leftBuffsList.maxnumber = 7;
       this.o.leftBuffsList.toward = 'left down';
-      this.o.rightBuffsList.elementwidth = parseInt(this.options.BigBuffIconWidth) + 2;
+      this.o.leftBuffsList.elementwidth = parseInt(this.options.BigBuffIconWidth) + 2;
     }
 
     if (Util.isCraftingJob(this.job)) {

--- a/ui/jobs/jobs.js
+++ b/ui/jobs/jobs.js
@@ -968,7 +968,7 @@ class Bars {
     this.o.rightBuffsList.rowcolsize = 7;
     this.o.rightBuffsList.maxnumber = 7;
     this.o.rightBuffsList.toward = 'right down';
-    this.o.rightBuffsList.elementwidth = this.options.BigBuffIconWidth + 2;
+    this.o.rightBuffsList.elementwidth = parseInt(this.options.BigBuffIconWidth) + 2;
 
     if (this.options.JustBuffTracker) {
       // Just alias these two together so the rest of the code doesn't have
@@ -990,7 +990,7 @@ class Bars {
       this.o.leftBuffsList.rowcolsize = 7;
       this.o.leftBuffsList.maxnumber = 7;
       this.o.leftBuffsList.toward = 'left down';
-      this.o.leftBuffsList.elementwidth = this.options.BigBuffIconWidth + 2;
+      this.o.rightBuffsList.elementwidth = parseInt(this.options.BigBuffIconWidth) + 2;
     }
 
     if (Util.isCraftingJob(this.job)) {


### PR DESCRIPTION
someone got problem with this code, (maybe this problem is for everyone)
`this.options.BigBuffIconWidth + 2` was not calculating numbers. was attaching those two as strings.
I think this will fix this problem.