### PR TITLE
Add timeline tests for text replacement uniqueness

### DIFF
--- a/test/test_timelines.py
+++ b/test/test_timelines.py
@@ -62,7 +62,7 @@ def main():
 
         # Run individual timeline tests
         for test_file in TIMELINE_TEST_DIRECTORY.iterdir():
-            exit_status |= subprocess.call(["node", str(test_file), str(filepath)])
+            exit_status |= subprocess.call(["node", str(test_file), str(filepath), str(trigger_filename)])
 
     return exit_status
 

--- a/test/timeline/test_timeline.js
+++ b/test/timeline/test_timeline.js
@@ -1,25 +1,34 @@
 'use strict';
 
-// This test loads an individual raidboss timeline and makes sure
-// that timeline.js can parse it without errors.
-
 let fs = require('fs');
 let Timeline = require('../../ui/raidboss/timeline.js');
 
 let exitCode = 0;
 
-let inputFilename = String(process.argv.slice(2));
+let timelineFile = String(process.argv[2]);
+let triggersFile = String(process.argv[3]);
+let timeline = fs.readFileSync(timelineFile) + '';
+let triggers = fs.readFileSync(triggersFile) + '';
 
-let testTimelineFile = function(file) {
-  let contents = fs.readFileSync(file) + '';
-  let t = new Timeline(contents);
-  for (let i = 0; i < t.errors.length; ++i) {
-    let e = t.errors[i];
-    console.error(file + ':' + e.lineNumber + ': ' + e.error + ': ' + e.line);
-    exitCode = 1;
-  }
+let errorFunc = (str) => {
+  console.error(str);
+  exitCode = 1;
 };
 
-testTimelineFile(inputFilename);
+let tests = {
+  // This test loads an individual raidboss timeline and makes sure
+  // that timeline.js can parse it without errors.
+  timelineErrorTest: () => {
+    let t = new Timeline(timeline);
+    for (let i = 0; i < t.errors.length; ++i) {
+      let e = t.errors[i];
+      errorFunc(timelineFile + ':' + e.lineNumber + ': ' + e.error + ': ' + e.line);
+    }
+  },
+};
+
+for (let name in tests)
+  tests[name]();
+
 
 process.exit(exitCode);

--- a/test/timeline/test_timeline.js
+++ b/test/timeline/test_timeline.js
@@ -1,28 +1,138 @@
 'use strict';
 
 let fs = require('fs');
+let assert = require('chai').assert;
+let Regexes = require('../../resources/regexes.js');
+let Conditions = require('../../resources/conditions.js');
+let responseModule = require('../../resources/responses.js');
+let Responses = responseModule.responses;
 let Timeline = require('../../ui/raidboss/timeline.js');
 
 let exitCode = 0;
-
-let timelineFile = String(process.argv[2]);
-let triggersFile = String(process.argv[3]);
-let timeline = fs.readFileSync(timelineFile) + '';
-let triggers = fs.readFileSync(triggersFile) + '';
 
 let errorFunc = (str) => {
   console.error(str);
   exitCode = 1;
 };
 
+// Global setup.
+let timelineFile = process.argv[2];
+let triggersFile = process.argv[3];
+let timelineText = String(fs.readFileSync(timelineFile));
+let timeline = new Timeline(timelineText);
+let triggerSet = eval(String(fs.readFileSync(triggersFile)));
+
+if (triggerSet.length != 1) {
+  console.log(triggerSet.length);
+  errorFunc(triggersFile + ':Break out multiple trigger sets into multiple files');
+}
+let triggers = triggerSet[0];
+
 let tests = {
   // This test loads an individual raidboss timeline and makes sure
   // that timeline.js can parse it without errors.
   timelineErrorTest: () => {
-    let t = new Timeline(timeline);
-    for (let i = 0; i < t.errors.length; ++i) {
-      let e = t.errors[i];
+    for (let e of timeline.errors)
       errorFunc(timelineFile + ':' + e.lineNumber + ': ' + e.error + ': ' + e.line);
+  },
+
+  translationTest: () => {
+    let translations = triggers.timelineReplace;
+    if (!translations)
+      return;
+
+    for (let trans of translations) {
+      let locale = trans.locale;
+      if (!locale) {
+        errorFunc(triggersFile + ': missing locale in translation block');
+        continue;
+      }
+
+      let testCases = [
+        {
+          type: 'replaceSync',
+          list: timeline.syncStarts,
+          extract: (testItem) => testItem.regex.source,
+          replace: trans.replaceSync,
+        },
+        {
+          type: 'replaceText',
+          list: timeline.events,
+          extract: (testItem) => testItem.text,
+          replace: trans.replaceText,
+        },
+      ];
+
+      // For both texts and syncs...
+      for (let testCase of testCases) {
+        // For every event the timeline knows about...
+        for (let testItem of testCase.list) {
+          let orig = testCase.extract(testItem);
+
+          // For every translation for that timeline...
+          for (let regex in testCase.replace) {
+            let replaced = orig.replace(Regexes.parse(regex), testCase.replace[regex]);
+            if (orig === replaced)
+              continue;
+
+            // If we get here, then |regex| is a valid replacemnt in |orig|.
+            // The goal is to ensure via testing that there are no ordering
+            // constraints in the timeline translations.  To fix these issues,
+            // add negative lookahead/lookbehind assertions to make the regexes unique.
+
+            // (1) Verify that there is no pre-replacement collision,.
+            // i.e. two regexes that apply to the same text or sync.
+            // e.g. "Holy IV" is affected by both /Holy IV/ and /Holy/.
+            for (let otherRegex in testCase.replace) {
+              if (regex === otherRegex)
+                continue;
+              let otherReplaced =
+                  orig.replace(Regexes.parse(otherRegex), testCase.replace[otherRegex]);
+              if (orig === otherReplaced)
+                continue;
+
+              // If we get here, then there is a pre-replacement collision.
+              // Verify if these two regexes can be applied in either order
+              // to get the same result, if so, then this collision can be
+              // safely ignored.
+              // e.g. "Magnetism/Repel" is affected by both /Magnetism/ and /Repel/,
+              // however these are independent and could be applied in either order.
+
+              let otherFirst = otherReplaced.replace(Regexes.parse(regex), testCase.replace[regex]);
+              let otherSecond = replaced.replace(Regexes.parse(otherRegex),
+                  testCase.replace[otherRegex]);
+              if (otherFirst === otherSecond)
+                continue;
+
+              errorFunc(`${triggersFile}:locale ${locale}: pre-translation collision on ${testCase.type} '${orig}' for '${regex}' and '${otherRegex}'`);
+            }
+
+            // (2) Verify that there is no post-replacement collision with this text,
+            // i.e. a regex that applies to the replaced text that another regex
+            // has already modified.
+            for (let otherRegex in testCase.replace) {
+              if (regex === otherRegex)
+                continue;
+              let otherSecond =
+                  replaced.replace(Regexes.parse(otherRegex), testCase.replace[otherRegex]);
+              if (replaced === otherSecond)
+                continue;
+
+              // If we get here, then there is a post-replacement collision.
+              // Verify if these two regexes can be applied in either order
+              // to get the same result, if so, then this collision can be
+              // safely ignored.
+              let otherFirst = orig.replace(Regexes.parse(otherRegex),
+                  testCase.replace[otherRegex]);
+              otherFirst = otherFirst.replace(Regexes.parse(regex), testCase.replace[regex]);
+              if (otherFirst === otherSecond)
+                continue;
+
+              errorFunc(`${triggersFile}:locale ${locale}: post-translation collision on ${testCase.type} '${orig}' for '${regex}' => '${testCase.replace[regex]}', then '${otherRegex}'`);
+            }
+          }
+        }
+      }
     }
   },
 };

--- a/test/timeline/test_timeline.js
+++ b/test/timeline/test_timeline.js
@@ -36,7 +36,7 @@ let tests = {
       errorFunc(timelineFile + ':' + e.lineNumber + ': ' + e.error + ': ' + e.line);
   },
 
-  translationTest: () => {
+  translationConflictTest: () => {
     let translations = triggers.timelineReplace;
     if (!translations)
       return;
@@ -48,6 +48,8 @@ let tests = {
         errorFunc(triggersFile + ': missing locale in translation block');
         continue;
       }
+
+      // Note: even if translations are missing, they should not have conflicts.
 
       let testCases = [
         {
@@ -140,6 +142,9 @@ let tests = {
     for (let trans of translations) {
       let locale = trans.locale;
       if (!locale)
+        continue;
+
+      if (trans.missingTranslations)
         continue;
 
       let testCases = [

--- a/test/timeline/test_timeline.js
+++ b/test/timeline/test_timeline.js
@@ -167,6 +167,7 @@ let tests = {
         '^ ?21:',
         '^ ?1B:',
         '^::\\y{AbilityCode}:$',
+        '^\\.\\*$',
       ].map((x) => Regexes.parse(x));
       let isIgnored = (x) => {
         for (let ig of ignore) {

--- a/test/timeline/test_timeline.js
+++ b/test/timeline/test_timeline.js
@@ -166,6 +166,7 @@ let tests = {
         'Start',
         '^ ?21:',
         '^ ?1B:',
+        '^::\\y{AbilityCode}:$',
       ].map((x) => Regexes.parse(x));
       let isIgnored = (x) => {
         for (let ig of ignore) {

--- a/test/timeline/test_timeline.js
+++ b/test/timeline/test_timeline.js
@@ -63,12 +63,18 @@ let tests = {
         },
       ];
 
+      // Extract all texts and syncs from parsed timeline, and find unique ones.
+      for (let testCase of testCases) {
+        testCase.items = [];
+        for (let testItem of testCase.list)
+          testCase.items.push(testCase.extract(testItem));
+        testCase.items = new Set(testCase.items);
+      }
+
       // For both texts and syncs...
       for (let testCase of testCases) {
-        // For every event the timeline knows about...
-        for (let testItem of testCase.list) {
-          let orig = testCase.extract(testItem);
-
+        // For every unique replaceable text or sync the timeline knows about...
+        for (let orig of testCase.items) {
           // For every translation for that timeline...
           for (let regex in testCase.replace) {
             let replaced = orig.replace(Regexes.parse(regex), testCase.replace[regex]);


### PR DESCRIPTION
Adding this as a proposal to make timeline text replacement easier to understand.  Right now, timeline translations apply in key order, and keys are regexes.  This is definitely confusing, and @Akurosia resorted a lot of them in #986 and #987, which creates some risk that translations that used to work no longer work (if they ever did?)

This pull request adds the stipulation that if you have two translations of the same text and both of them match the text, then they must be able to be applied in either order and get the same result.

For example, it's ok to have the text "Magnetism/Repel" and then have a translation for "Magnetism" and "Repel", because you can apply those in either order.  It's not ok to have text "Savage Wave Cannon" and then have a translation for "Savage Wave Cannon" and "Wave Cannon" (pre-translation collision).   It's also not ok to have the text "Time Eruption", translate "Time Eruption" as "Zeiteruption" and also have a translation for "Eruption" on its own (post-translation collision).

Here's the errors: https://travis-ci.com/quisquous/cactbot/jobs/282776584

This is a fairly loose way of catching these errors, but it still allows for partial translations where possible.  Other options that are more understandable would be only allowing full text translations or full sync translations (between colons), which leads to some small explosion of translations in cases where there's like "(In)" and "(Out)" on various things.  However, it is much more straightforward to explain as well.

The other context for this discussion is that I would like to eventually have the translation block handle triggers at runtime too and remove all of the `regexDe` etc style regexes everywhere.  The things that need to get replaced in regexes are targets, effects, and messages (more or less).  This makes me wonder if I should break up the translations into more categories to reduce collisions? We could have timeline text, targets, effects, syncs/messages (with the idea that the current timeline syncs would be included across the targets and syncs categories).

The followup to this test is to add a test that says "if a translation locale applies, then it must translate everything" and it would also be easy to warn or error about translations that don't match anything.