### PR TITLE
Bump CactbotOverlay to 0.15.3.0.

### DIFF
--- a/plugin/CactbotOverlay/Properties/AssemblyInfo.cs
+++ b/plugin/CactbotOverlay/Properties/AssemblyInfo.cs
@@ -20,5 +20,5 @@ using System.Runtime.InteropServices;
 // - Build Number
 // - Revision
 // GitHub has only 3 version components, so Revision should always be 0.
-[assembly: AssemblyVersion("0.15.2.0")]
-[assembly: AssemblyFileVersion("0.15.2.0")]
+[assembly: AssemblyVersion("0.15.3.0")]
+[assembly: AssemblyFileVersion("0.15.3.0")]


### PR DESCRIPTION
CactbotOverlay wasn't bumped in the 0.15.3.0 release and still shows as 0.15.2.0.