### PR TITLE
FFXIV_ACT_Plugin_Korean.dll is not needed

### DIFF
--- a/plugin/CactbotEventSource/FFXIVPlugin.cs
+++ b/plugin/CactbotEventSource/FFXIVPlugin.cs
@@ -32,7 +32,7 @@ namespace Cactbot {
       IActPluginV1 ffxiv_plugin = null;
       foreach (var plugin in ActGlobals.oFormActMain.ActPlugins) {
         var file = plugin.pluginFile.Name;
-        if (file == "FFXIV_ACT_Plugin.dll" || file == "FFXIV_ACT_Plugin_Korean.dll") {
+        if (file == "FFXIV_ACT_Plugin.dll") {
           if (ffxiv_plugin != null) {
             logger_.LogWarning("Multiple FFXIV_ACT_Plugin.dll plugins loaded");
           }


### PR DESCRIPTION
There is no need to find FFXIV_ACT_Plugin_Korean.dll anymore.