### PR TITLE
add common replacement

### DIFF
--- a/ui/raidboss/common_replacement.js
+++ b/ui/raidboss/common_replacement.js
@@ -1,0 +1,53 @@
+'use strict';
+
+let commonReplacement = {
+  ':([0-9]{4}):(.*) will be sealed off': {
+    de: ':$1:Noch 15 Sekunden bis sich der Zugang zu $2 schließt',
+    fr: ':$1:Fermeture $2 dans',
+    ja: '$1:$2の封鎖まであと',
+    cn: ':([0-9]{4}):(.*) will be sealed off', // FIXME
+    ko: ':$1:15초 후에 $2(이|가) 봉쇄됩니다',
+  },
+  'is no longer sealed': {
+    de: 'öffnet sich erneut',
+    fr: 'Ouverture ',
+    ja: 'の封鎖が解かれた',
+    cn: 'is no longer sealed', // FIXME
+    ko: '의 봉쇄가 해제되었습니다',
+  },
+  'Engage!': {
+    de: 'Start!',
+    fr: 'À l\'attaque',
+    ja: '戦闘開始！',
+    cn: '战斗开始！',
+    ko: '전투 시작!',
+  },
+  'attack': {
+    de: 'Attacke',
+    fr: 'Attaque',
+    ja: '攻撃',
+    cn: '攻击',
+    ko: '공격',
+  },
+  'Enrage': {
+    de: 'Finalangriff',
+    fr: 'Enrage',
+    ja: 'Enrage', // FIXME
+    cn: '狂暴',
+    ko: '전멸기',
+  },
+  '--untargetable--': {
+    de: '--nich anvisierbar--',
+    fr: '--Impossible à cibler--',
+    ja: '--untargetable--', // FIXME
+    cn: '--无法选中--',
+    ko: '--타겟 불가능--',
+  },
+  '--targetable--': {
+    de: '--anvisierbar--',
+    fr: '--Ciblable--',
+    ja: '--targetable--', // FIXME
+    cn: '--可选中--',
+    ko: '--타겟 가능--',
+  },
+};

--- a/ui/raidboss/raidboss.html
+++ b/ui/raidboss/raidboss.html
@@ -22,6 +22,7 @@
   <script src="../../resources/lang/cn.js"></script>
 
   <link rel="stylesheet" type="text/css" href="raidboss.css">
+  <script src="common_replacement.js"></script>
   <script src="raidboss_config.js"></script>
   <script src="timeline.js"></script>
   <script src="popup-text.js"></script>

--- a/ui/raidboss/raidemulator.html
+++ b/ui/raidboss/raidemulator.html
@@ -23,6 +23,7 @@
   <script src="../../resources/lang/cn.js"></script>
   <!-- Cactbot Overlay Scripts-->
   <link rel="stylesheet" type="text/css" href="raidboss.css">
+  <script src="common_replacement.js"></script>
   <script src="raidboss_config.js"></script>
   <script src="timeline.js"></script>
   <script src="popup-text.js"></script>

--- a/ui/raidboss/timeline.js
+++ b/ui/raidboss/timeline.js
@@ -60,9 +60,9 @@ class Timeline {
   GetReplacedCommon(text) {
     let locale = this.options.Language || 'en';
     let keys = Object.keys(commonReplacement);
-    for (let j = 0; j < keys.length; ++j){
-        let re = new RegExp(keys[j],"gi");
-        text = text.replace(re, commonReplacement[keys[j]][locale])
+    for (let j = 0; j < keys.length; ++j) {
+      let re = new RegExp(keys[j], 'gi');
+      text = text.replace(re, commonReplacement[keys[j]][locale]);
     }
     return text;
   }

--- a/ui/raidboss/timeline.js
+++ b/ui/raidboss/timeline.js
@@ -57,12 +57,22 @@ class Timeline {
     return text;
   }
 
+  GetReplacedCommon(text) {
+    let locale = this.options.Language || 'en';
+    let keys = Object.keys(commonReplacement);
+    for (let j = 0; j < keys.length; ++j){
+        let re = new RegExp(keys[j],"gi");
+        text = text.replace(re, commonReplacement[keys[j]][locale])
+    }
+    return text;
+  }
+
   GetReplacedText(text) {
-    return this.GetReplacedHelper(text, 'replaceText');
+    return this.GetReplacedCommon(this.GetReplacedHelper(text, 'replaceText'));
   }
 
   GetReplacedSync(sync) {
-    return this.GetReplacedHelper(sync, 'replaceSync');
+    return this.GetReplacedCommon(this.GetReplacedHelper(sync, 'replaceSync'));
   }
 
   GetMissingTranslationsToIgnore() {

--- a/ui/raidboss/timeline.js
+++ b/ui/raidboss/timeline.js
@@ -54,11 +54,7 @@ class Timeline {
       for (let j = 0; j < keys.length; ++j)
         text = text.replace(Regexes.parse(keys[j]), r[replaceKey][keys[j]]);
     }
-    return text;
-  }
-
-  GetReplacedCommon(text) {
-    let locale = this.options.Language || 'en';
+    // Common Replacements
     let keys = Object.keys(commonReplacement);
     for (let j = 0; j < keys.length; ++j) {
       let re = new RegExp(keys[j], 'gi');
@@ -68,11 +64,11 @@ class Timeline {
   }
 
   GetReplacedText(text) {
-    return this.GetReplacedCommon(this.GetReplacedHelper(text, 'replaceText'));
+    return this.GetReplacedHelper(text, 'replaceText');
   }
 
   GetReplacedSync(sync) {
-    return this.GetReplacedCommon(this.GetReplacedHelper(sync, 'replaceSync'));
+    return this.GetReplacedHelper(sync, 'replaceSync');
   }
 
   GetMissingTranslationsToIgnore() {


### PR DESCRIPTION
I've done some code with common replacement.

`ui/raidboss/timeline.js` part can be improved much, but I don't know how this code exactly works. I've just added new function, but it's having error.
Suggestions to this code is needed.
```
TypeError: Cannot read property 'Language' of undefined
    at Timeline.GetReplacedCommon (/home/travis/build/Jaehyuk-Lee/cactbot/ui/raidboss/timeline.js:61:31)
    at Timeline.GetReplacedText (/home/travis/build/Jaehyuk-Lee/cactbot/ui/raidboss/timeline.js:71:17)
    at Timeline.LoadFile (/home/travis/build/Jaehyuk-Lee/cactbot/ui/raidboss/timeline.js:166:20)
    at new Timeline (/home/travis/build/Jaehyuk-Lee/cactbot/ui/raidboss/timeline.js:37:10)
    at Object.<anonymous> (/home/travis/build/Jaehyuk-Lee/cactbot/test/timeline/test_timeline.js:22:16)
    at Module._compile (internal/modules/cjs/loader.js:956:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:973:10)
    at Module.load (internal/modules/cjs/loader.js:812:32)
    at Function.Module._load (internal/modules/cjs/loader.js:724:14)
    at Function.Module.runMain (internal/modules/cjs/loader.js:1025:10)
/home/travis/build/Jaehyuk-Lee/cactbot/ui/raidboss/timeline.js:61
    let locale = this.options.Language || 'en';
```
[error log on travis-ci](https://travis-ci.com/Jaehyuk-Lee/cactbot/jobs/287864890)

 * I think common replacements should include only those are really commonly used strings. Like, at least five times used.