### PR TITLE
e5s triggers

### DIFF
--- a/ui/raidboss/data/05-shb/raid/e5s.js
+++ b/ui/raidboss/data/05-shb/raid/e5s.js
@@ -7,6 +7,206 @@
   },
   timelineFile: 'e5s.txt',
   triggers: [
+    {
+      id: 'E5S Stratospear Summons',
+      regex: Regexes.ability({ id: '4BA5', source: 'Ramuh', capture: false }),
+      regexDe: Regexes.ability({ id: '4BA5', source: 'Ramuh', capture: false }),
+      regexFr: Regexes.ability({ id: '4BA5', source: 'Ramuh', capture: false }),
+      regexJa: Regexes.ability({ id: '4BA5', source: 'ラムウ', capture: false }),
+      regexKo: Regexes.ability({ id: '4BA5', source: '라무', capture: false }),
+      delaySeconds: 5,
+      preRun: function(data) {
+        data.firstSpear = data.firstSpear || 1;
+      },
+      infoText: function(data) {
+        if (data.firstSpear == 1) {
+          return {
+            en: 'Look for small spear',
+            ko: '작은 지팡이 확인',
+          };
+        }
+      },
+      run: function(data) {
+        data.firstSpear++;
+      }
+    },
+    {
+      id: 'E5S Tribunal Summons',
+      regex: Regexes.startsUsing({ id: '4BAC', source: 'Ramuh', capture: false }),
+      regexDe: Regexes.startsUsing({ id: '4BAC', source: 'Ramuh', capture: false }),
+      regexFr: Regexes.startsUsing({ id: '4BAC', source: 'Ramuh', capture: false }),
+      regexJa: Regexes.startsUsing({ id: '4BAC', source: 'ラムウ', capture: false }),
+      regexKo: Regexes.startsUsing({ id: '4BAC', source: '라무', capture: false }),
+      preRun: function(data) {
+        data.adds = data.adds || 0;
+      },
+      infoText: function(data) {
+        if (data.adds != 0) {
+          return {
+            en: 'Look for adds',
+            ko: '쫄 위치 확인',
+          };
+        }
+      },
+      run: function(data) {
+        data.adds++;
+      }
+    },
+    {
+      id: 'E5S Fury\'s Bolt',
+      regex: Regexes.startsUsing({ id: '4BAA', source: 'Ramuh', capture: false }),
+      regexDe: Regexes.startsUsing({ id: '4BAA', source: 'Ramuh', capture: false }),
+      regexFr: Regexes.startsUsing({ id: '4BAA', source: 'Ramuh', capture: false }),
+      regexJa: Regexes.startsUsing({ id: '4BAA', source: 'ラムウ', capture: false }),
+      regexKo: Regexes.startsUsing({ id: '4BAA', source: '라무', capture: false }),
+      infoText: {
+        en: 'Fury\'s Bolt',
+        ko: '라무 강화',
+      },
+    },
+    {
+      id: 'E5S Judgment Volts',
+      regex: Regexes.startsUsing({ id: '4BB5', source: 'Ramuh', capture: false }),
+      regexDe: Regexes.startsUsing({ id: '4BB5', source: 'Ramuh', capture: false }),
+      regexFr: Regexes.startsUsing({ id: '4BB5', source: 'Ramuh', capture: false }),
+      regexJa: Regexes.startsUsing({ id: '4BB5', source: 'ラムウ', capture: false }),
+      regexKo: Regexes.startsUsing({ id: '4BB5', source: '라무', capture: false }),
+      infoText: {
+        en: 'aoe',
+        de: 'AoE',
+        fr: 'Dégâts de zone',
+        cn: 'AOE',
+        ko: '전체 공격',
+      },
+    },
+    {
+      id: 'E5S Stepped Leader',
+      regex: Regexes.startsUsing({ id: '4BC6', source: 'Ramuh', capture: false }),
+      regexDe: Regexes.startsUsing({ id: '4BC6', source: 'Ramuh', capture: false }),
+      regexFr: Regexes.startsUsing({ id: '4BC6', source: 'Ramuh', capture: false }),
+      regexJa: Regexes.startsUsing({ id: '4BC6', source: 'ラムウ', capture: false }),
+      regexKo: Regexes.startsUsing({ id: '4BC6', source: '라무', capture: false }),
+      preRun: function(data) {
+        data.leaderCount = data.leaderCount || 0;
+      },
+      alertText: function(data) {
+        if (data.leaderCount %2 == 0) {
+          return {
+            en: 'Ready Spread',
+            ko: '산개 준비',
+          };
+        } else if (data.leaderCount %2 == 1) {
+          return {
+            en: 'donut AoE',
+            ko: '도넛 장판',
+          };
+        }
+      },
+      run: function(data) {
+        data.leaderCount++;
+      }
+    },
+    {
+      id: 'E5S Stepped Leader Spread',
+      regex: Regexes.ability({ id: '4BC6', source: 'Ramuh', capture: false }),
+      regexDe: Regexes.ability({ id: '4BC6', source: 'Ramuh', capture: false }),
+      regexFr: Regexes.ability({ id: '4BC6', source: 'Ramuh', capture: false }),
+      regexJa: Regexes.ability({ id: '4BC6', source: 'ラムウ', capture: false }),
+      regexKo: Regexes.ability({ id: '4BC6', source: '라무', capture: false }),
+      alarmText: function(data) {
+        if (data.leaderCount %2 == 0) {
+          return {
+            en: 'Spread',
+            de: 'Verteilen',
+            fr: 'Ecartez-vous',
+            ja: '散開',
+            cn: '分散',
+            ko: '산개',
+          };
+        }
+      },
+    },
+    {
+      id: 'E5S Crippling Blow',
+      regex: Regexes.ability({ id: '4BCA', source: 'Ramuh', capture: false }),
+      regexDe: Regexes.ability({ id: '4BCA', source: 'Ramuh', capture: false }),
+      regexFr: Regexes.ability({ id: '4BCA', source: 'Ramuh', capture: false }),
+      regexJa: Regexes.ability({ id: '4BCA', source: 'ラムウ', capture: false }),
+      regexKo: Regexes.ability({ id: '4BCA', source: '라무', capture: false }),
+      alertText: function(data, matches) {
+        if (matches.target == data.me) {
+          return {
+            en: 'Tank Buster on YOU',
+            de: 'Tankbuster auf DIR',
+            fr: 'Tank Buster sur VOUS',
+            ko: '탱버 대상자',
+          };
+        }
+      },
+    },
+    {
+      id: 'E5S Stormcloud Summons',
+      regex: Regexes.startsUsing({ id: '4BB8', source: 'Ramuh', capture: false }),
+      regexDe: Regexes.startsUsing({ id: '4BB8', source: 'Ramuh', capture: false }),
+      regexFr: Regexes.startsUsing({ id: '4BB8', source: 'Ramuh', capture: false }),
+      regexJa: Regexes.startsUsing({ id: '4BB8', source: 'ラムウ', capture: false }),
+      regexKo: Regexes.startsUsing({ id: '4BB8', source: '라무', capture: false }),
+      infoText: {
+        en: 'Position for Stormcloud',
+        ko: '번개 구름 위치',
+      },
+    },
+    {
+      id: 'E5S Centaur\'s Charge',
+      regex: Regexes.startsUsing({ id: '4BAD', source: 'Ramuh', capture: false }),
+      regexDe: Regexes.startsUsing({ id: '4BAD', source: 'Ramuh', capture: false }),
+      regexFr: Regexes.startsUsing({ id: '4BAD', source: 'Ramuh', capture: false }),
+      regexJa: Regexes.startsUsing({ id: '4BAD', source: 'ラムウ', capture: false }),
+      regexKo: Regexes.startsUsing({ id: '4BAD', source: '라무', capture: false }),
+      infoText: {
+        en: 'Be in your position',
+        ko: '자기 위치에 있기',
+      },
+    },
+    {
+      id: 'E5S Thunderstorm',
+      regex: Regexes.ability({ id: '4BBF', source: 'Ramuh', capture: false }),
+      regexDe: Regexes.ability({ id: '4BBF', source: 'Ramuh', capture: false }),
+      regexFr: Regexes.ability({ id: '4BBF', source: 'Ramuh', capture: false }),
+      regexJa: Regexes.ability({ id: '4BBF', source: 'ラムウ', capture: false }),
+      regexKo: Regexes.ability({ id: '4BBF', source: '라무', capture: false }),
+      infoText: {
+        en: 'Avoid AoE',
+        ko: '장판 피하기',
+      },
+    },
+    {
+      id: 'E5S Chain Lightning',
+      regex: Regexes.startsUsing({ id: '4BC4', source: 'Ramuh', capture: false }),
+      regexDe: Regexes.startsUsing({ id: '4BC4', source: 'Ramuh', capture: false }),
+      regexFr: Regexes.startsUsing({ id: '4BC4', source: 'Ramuh', capture: false }),
+      regexJa: Regexes.startsUsing({ id: '4BC4', source: 'ラムウ', capture: false }),
+      regexKo: Regexes.startsUsing({ id: '4BC4', source: '라무', capture: false }),
+      alertText: {
+        en: 'Ready for Chain',
+        ko: '번개 돌려막기 준비',
+      },
+    },
+    {
+      id: 'E5S Levinforce',
+      regex: Regexes.startsUsing({ id: '4BCC', source: 'Ramuh', capture: false }),
+      regexDe: Regexes.startsUsing({ id: '4BCC', source: 'Ramuh', capture: false }),
+      regexFr: Regexes.startsUsing({ id: '4BCC', source: 'Ramuh', capture: false }),
+      regexJa: Regexes.startsUsing({ id: '4BCC', source: 'ラムウ', capture: false }),
+      regexKo: Regexes.startsUsing({ id: '4BCC', source: '라무', capture: false }),
+      infoText: {
+        en: 'knockback',
+        fr: 'Projection',
+        de: 'Rückstoß',
+        ko: '넉백',
+        ja: 'ノックバック',
+      },
+    },
   ],
   timelineReplace: [
   ],

--- a/ui/raidboss/data/05-shb/raid/e5s.js
+++ b/ui/raidboss/data/05-shb/raid/e5s.js
@@ -149,18 +149,6 @@
       },
     },
     {
-      id: 'E5S Thunderstorm',
-      regex: Regexes.ability({ id: '4BBF', source: 'Ramuh', capture: false }),
-      regexDe: Regexes.ability({ id: '4BBF', source: 'Ramuh', capture: false }),
-      regexFr: Regexes.ability({ id: '4BBF', source: 'Ramuh', capture: false }),
-      regexJa: Regexes.ability({ id: '4BBF', source: 'ラムウ', capture: false }),
-      regexKo: Regexes.ability({ id: '4BBF', source: '라무', capture: false }),
-      infoText: {
-        en: 'Avoid AoE',
-        ko: '장판 피하기',
-      },
-    },
-    {
       id: 'E5S Chain Lightning',
       regex: Regexes.startsUsing({ id: '4BC4', source: 'Ramuh', capture: false }),
       regexDe: Regexes.startsUsing({ id: '4BC4', source: 'Ramuh', capture: false }),

--- a/ui/raidboss/data/05-shb/raid/e5s.js
+++ b/ui/raidboss/data/05-shb/raid/e5s.js
@@ -52,7 +52,7 @@
       regexJa: Regexes.startsUsing({ id: '4BAA', source: 'ラムウ', capture: false }),
       regexKo: Regexes.startsUsing({ id: '4BAA', source: '라무', capture: false }),
       infoText: {
-        en: 'pick up orb',
+        en: 'Fury\'s Bolt',
         ko: '라무 강화',
       },
     },

--- a/ui/raidboss/data/05-shb/raid/e5s.js
+++ b/ui/raidboss/data/05-shb/raid/e5s.js
@@ -123,25 +123,10 @@
       regexFr: Regexes.ability({ id: '4BCA', source: 'Ramuh' }),
       regexJa: Regexes.ability({ id: '4BCA', source: 'ラムウ' }),
       regexKo: Regexes.ability({ id: '4BCA', source: '라무' }),
-      alertText: function(data, matches) {
-        if (matches.target == data.me) {
-          return {
-            en: 'Tank Buster on YOU',
-            de: 'Tankbuster auf DIR',
-            fr: 'Tank Buster sur VOUS',
-            ko: '탱버 대상자',
-          };
-        }
+      condition: function(data) {
+        return data.role == 'tank' || data.role == 'healer';
       },
-      infoText: function(data, matches) {
-        if (data.role == 'healer') {
-          return {
-            en: 'Tank Buster on ' + data.ShortName(matches.target),
-            fr: 'Tankbuster sur ' + data.ShortName(matches.target),
-            ko: '"' + data.ShortName(matches.target) + '" 탱버',
-          };
-        }
-      },
+      response: Responses.tankBuster(),
     },
     {
       id: 'E5S Stormcloud Summons',
@@ -152,7 +137,7 @@
       regexKo: Regexes.startsUsing({ id: '4BB8', source: '라무', capture: false }),
       infoText: {
         en: 'Position for Stormcloud',
-        ko: '번개 구름 위치',
+        ko: '번개 구름 위치 잡기',
       },
     },
     {

--- a/ui/raidboss/data/05-shb/raid/e5s.js
+++ b/ui/raidboss/data/05-shb/raid/e5s.js
@@ -10,8 +10,8 @@
     {
       id: 'E5S Fury\'s Bolt Gain',
       regex: Regexes.gainsEffect({ target: 'Ramuh', effect: 'Fury\'s Bolt', capture: false }),
-      regexDe: Regexes.gainsEffect({ target: 'Ramuh', effect: 'Fury\'s Bolt', capture: false }),
-      regexFr: Regexes.gainsEffect({ target: 'Ramuh', effect: 'Fury\'s Bolt', capture: false }),
+      regexDe: Regexes.gainsEffect({ target: 'Ramuh', effect: 'Wütender Blitz', capture: false }),
+      regexFr: Regexes.gainsEffect({ target: 'Ramuh', effect: 'Boules de foudre', capture: false }),
       regexJa: Regexes.gainsEffect({ target: 'ラムウ', effect: 'チャージボルト', capture: false }),
       run: function(data) {
         data.fury = true;
@@ -20,8 +20,8 @@
     {
       id: 'E5S Fury\'s Bolt Lose',
       regex: Regexes.losesEffect({ target: 'Ramuh', effect: 'Fury\'s Bolt', capture: false }),
-      regexDe: Regexes.losesEffect({ target: 'Ramuh', effect: 'Fury\'s Bolt', capture: false }),
-      regexFr: Regexes.losesEffect({ target: 'Ramuh', effect: 'Fury\'s Bolt', capture: false }),
+      regexDe: Regexes.losesEffect({ target: 'Ramuh', effect: 'Wütender Blitz', capture: false }),
+      regexFr: Regexes.losesEffect({ target: 'Ramuh', effect: 'Boules de foudre', capture: false }),
       regexJa: Regexes.losesEffect({ target: 'ラムウ', effect: 'チャージボルト', capture: false }),
       run: function(data) {
         data.fury = false;

--- a/ui/raidboss/data/05-shb/raid/e5s.js
+++ b/ui/raidboss/data/05-shb/raid/e5s.js
@@ -28,7 +28,7 @@
       },
       run: function(data) {
         data.firstSpear++;
-      }
+      },
     },
     {
       id: 'E5S Tribunal Summons',
@@ -50,7 +50,7 @@
       },
       run: function(data) {
         data.adds++;
-      }
+      },
     },
     {
       id: 'E5S Fury\'s Bolt',
@@ -104,7 +104,7 @@
       },
       run: function(data) {
         data.leaderCount++;
-      }
+      },
     },
     {
       id: 'E5S Stepped Leader Spread',

--- a/ui/raidboss/data/05-shb/raid/e5s.js
+++ b/ui/raidboss/data/05-shb/raid/e5s.js
@@ -113,17 +113,16 @@
       regexFr: Regexes.ability({ id: '4BC6', source: 'Ramuh', capture: false }),
       regexJa: Regexes.ability({ id: '4BC6', source: 'ラムウ', capture: false }),
       regexKo: Regexes.ability({ id: '4BC6', source: '라무', capture: false }),
-      alarmText: function(data) {
-        if (!data.fury) {
-          return {
-            en: 'Spread',
-            de: 'Verteilen',
-            fr: 'Ecartez-vous',
-            ja: '散開',
-            cn: '分散',
-            ko: '산개',
-          };
-        }
+      condition: function(data) {
+        return !data.fury;
+      },
+      alarmText: {
+        en: 'Spread',
+        de: 'Verteilen',
+        fr: 'Ecartez-vous',
+        ja: '散開',
+        cn: '分散',
+        ko: '산개',
       },
     },
     {

--- a/ui/raidboss/data/05-shb/raid/e5s.js
+++ b/ui/raidboss/data/05-shb/raid/e5s.js
@@ -120,11 +120,12 @@
     },
     {
       id: 'E5S Stepped Leader Spread',
-      regex: Regexes.ability({ id: '4BC6', source: 'Ramuh', capture: false }),
-      regexDe: Regexes.ability({ id: '4BC6', source: 'Ramuh', capture: false }),
-      regexFr: Regexes.ability({ id: '4BC6', source: 'Ramuh', capture: false }),
-      regexJa: Regexes.ability({ id: '4BC6', source: 'ラムウ', capture: false }),
-      regexKo: Regexes.ability({ id: '4BC6', source: '라무', capture: false }),
+      regex: Regexes.startsUsing({ id: '4BC6', source: 'Ramuh', capture: false }),
+      regexDe: Regexes.startsUsing({ id: '4BC6', source: 'Ramuh', capture: false }),
+      regexFr: Regexes.startsUsing({ id: '4BC6', source: 'Ramuh', capture: false }),
+      regexJa: Regexes.startsUsing({ id: '4BC6', source: 'ラムウ', capture: false }),
+      regexKo: Regexes.startsUsing({ id: '4BC6', source: '라무', capture: false }),
+      delaySeconds: 3.5,
       condition: function(data) {
         return !data.fury;
       },

--- a/ui/raidboss/data/05-shb/raid/e5s.js
+++ b/ui/raidboss/data/05-shb/raid/e5s.js
@@ -33,19 +33,15 @@
       regexFr: Regexes.startsUsing({ id: '4BAC', source: 'Ramuh', capture: false }),
       regexJa: Regexes.startsUsing({ id: '4BAC', source: 'ラムウ', capture: false }),
       regexKo: Regexes.startsUsing({ id: '4BAC', source: '라무', capture: false }),
-      preRun: function(data) {
-        data.adds = data.adds || 0;
+      condition: function(data) {
+        return !data.firstAdd;
       },
-      infoText: function(data) {
-        if (data.adds != 0) {
-          return {
-            en: 'Look for adds',
-            ko: '쫄 위치 확인',
-          };
-        }
+      infoText: {
+        en: 'Look for adds',
+        ko: '쫄 위치 확인',
       },
       run: function(data) {
-        data.adds++;
+        data.firstAdd = false;
       },
     },
     {

--- a/ui/raidboss/data/05-shb/raid/e5s.js
+++ b/ui/raidboss/data/05-shb/raid/e5s.js
@@ -15,19 +15,11 @@
       regexJa: Regexes.ability({ id: '4BA5', source: 'ラムウ', capture: false }),
       regexKo: Regexes.ability({ id: '4BA5', source: '라무', capture: false }),
       delaySeconds: 5,
-      preRun: function(data) {
-        data.firstSpear = data.firstSpear || 1;
-      },
-      infoText: function(data) {
-        if (data.firstSpear == 1) {
-          return {
-            en: 'Look for small spear',
-            ko: '작은 지팡이 확인',
-          };
-        }
-      },
-      run: function(data) {
-        data.firstSpear++;
+      condition: function(data) { return data.seenFirstSpear; },
+      run: function(data) { data.seenFirstSpear = true; },
+      infoText:{
+        en: 'Look for small spear',
+        ko: '작은 지팡이 확인',
       },
     },
     {
@@ -60,7 +52,7 @@
       regexJa: Regexes.startsUsing({ id: '4BAA', source: 'ラムウ', capture: false }),
       regexKo: Regexes.startsUsing({ id: '4BAA', source: '라무', capture: false }),
       infoText: {
-        en: 'Fury\'s Bolt',
+        en: 'pick up orb',
         ko: '라무 강화',
       },
     },
@@ -71,13 +63,7 @@
       regexFr: Regexes.startsUsing({ id: '4BB5', source: 'Ramuh', capture: false }),
       regexJa: Regexes.startsUsing({ id: '4BB5', source: 'ラムウ', capture: false }),
       regexKo: Regexes.startsUsing({ id: '4BB5', source: '라무', capture: false }),
-      infoText: {
-        en: 'aoe',
-        de: 'AoE',
-        fr: 'Dégâts de zone',
-        cn: 'AOE',
-        ko: '전체 공격',
-      },
+      response: Responses.aoe(),
     },
     {
       id: 'E5S Stepped Leader',
@@ -128,11 +114,11 @@
     },
     {
       id: 'E5S Crippling Blow',
-      regex: Regexes.ability({ id: '4BCA', source: 'Ramuh', capture: false }),
-      regexDe: Regexes.ability({ id: '4BCA', source: 'Ramuh', capture: false }),
-      regexFr: Regexes.ability({ id: '4BCA', source: 'Ramuh', capture: false }),
-      regexJa: Regexes.ability({ id: '4BCA', source: 'ラムウ', capture: false }),
-      regexKo: Regexes.ability({ id: '4BCA', source: '라무', capture: false }),
+      regex: Regexes.ability({ id: '4BCA', source: 'Ramuh' }),
+      regexDe: Regexes.ability({ id: '4BCA', source: 'Ramuh' }),
+      regexFr: Regexes.ability({ id: '4BCA', source: 'Ramuh' }),
+      regexJa: Regexes.ability({ id: '4BCA', source: 'ラムウ' }),
+      regexKo: Regexes.ability({ id: '4BCA', source: '라무' }),
       alertText: function(data, matches) {
         if (matches.target == data.me) {
           return {
@@ -140,6 +126,15 @@
             de: 'Tankbuster auf DIR',
             fr: 'Tank Buster sur VOUS',
             ko: '탱버 대상자',
+          };
+        }
+      },
+      infoText: function(data, matches) {
+        if (data.role == 'healer') {
+          return {
+            en: 'Tank Buster on ' + data.ShortName(matches.target),
+            fr: 'Tankbuster sur ' + data.ShortName(matches.target),
+            fr: '"' + data.ShortName(matches.target) + '" 탱버',
           };
         }
       },
@@ -199,13 +194,7 @@
       regexFr: Regexes.startsUsing({ id: '4BCC', source: 'Ramuh', capture: false }),
       regexJa: Regexes.startsUsing({ id: '4BCC', source: 'ラムウ', capture: false }),
       regexKo: Regexes.startsUsing({ id: '4BCC', source: '라무', capture: false }),
-      infoText: {
-        en: 'knockback',
-        fr: 'Projection',
-        de: 'Rückstoß',
-        ko: '넉백',
-        ja: 'ノックバック',
-      },
+      response: Responses.knockback(),
     },
   ],
   timelineReplace: [

--- a/ui/raidboss/data/05-shb/raid/e5s.js
+++ b/ui/raidboss/data/05-shb/raid/e5s.js
@@ -8,6 +8,26 @@
   timelineFile: 'e5s.txt',
   triggers: [
     {
+      id: 'E5S Fury\'s Bolt Gain',
+      regex: Regexes.gainsEffect({ target: 'Ramuh', effect: 'Fury\'s Bolt', capture: false }),
+      regexDe: Regexes.gainsEffect({ target: 'Ramuh', effect: 'Fury\'s Bolt', capture: false }),
+      regexFr: Regexes.gainsEffect({ target: 'Ramuh', effect: 'Fury\'s Bolt', capture: false }),
+      regexJa: Regexes.gainsEffect({ target: 'ラムウ', effect: 'チャージボルト', capture: false }),
+      run: function(data) {
+        data.fury = true;
+      },
+    },
+    {
+      id: 'E5S Fury\'s Bolt Lose',
+      regex: Regexes.losesEffect({ target: 'Ramuh', effect: 'Fury\'s Bolt', capture: false }),
+      regexDe: Regexes.losesEffect({ target: 'Ramuh', effect: 'Fury\'s Bolt', capture: false }),
+      regexFr: Regexes.losesEffect({ target: 'Ramuh', effect: 'Fury\'s Bolt', capture: false }),
+      regexJa: Regexes.losesEffect({ target: 'ラムウ', effect: 'チャージボルト', capture: false }),
+      run: function(data) {
+        data.fury = false;
+      },
+    },
+    {
       id: 'E5S Stratospear Summons',
       regex: Regexes.ability({ id: '4BA5', source: 'Ramuh', capture: false }),
       regexDe: Regexes.ability({ id: '4BA5', source: 'Ramuh', capture: false }),
@@ -72,24 +92,18 @@
       regexFr: Regexes.startsUsing({ id: '4BC6', source: 'Ramuh', capture: false }),
       regexJa: Regexes.startsUsing({ id: '4BC6', source: 'ラムウ', capture: false }),
       regexKo: Regexes.startsUsing({ id: '4BC6', source: '라무', capture: false }),
-      preRun: function(data) {
-        data.leaderCount = data.leaderCount || 0;
-      },
       alertText: function(data) {
-        if (data.leaderCount %2 == 0) {
+        if (!data.fury) {
           return {
             en: 'Ready Spread',
             ko: '산개 준비',
           };
-        } else if (data.leaderCount %2 == 1) {
+        } else if (data.fury) {
           return {
             en: 'donut AoE',
             ko: '도넛 장판',
           };
         }
-      },
-      run: function(data) {
-        data.leaderCount++;
       },
     },
     {
@@ -100,7 +114,7 @@
       regexJa: Regexes.ability({ id: '4BC6', source: 'ラムウ', capture: false }),
       regexKo: Regexes.ability({ id: '4BC6', source: '라무', capture: false }),
       alarmText: function(data) {
-        if (data.leaderCount %2 == 0) {
+        if (!data.fury) {
           return {
             en: 'Spread',
             de: 'Verteilen',

--- a/ui/raidboss/data/05-shb/raid/e5s.js
+++ b/ui/raidboss/data/05-shb/raid/e5s.js
@@ -15,9 +15,13 @@
       regexJa: Regexes.ability({ id: '4BA5', source: 'ラムウ', capture: false }),
       regexKo: Regexes.ability({ id: '4BA5', source: '라무', capture: false }),
       delaySeconds: 5,
-      condition: function(data) { return data.seenFirstSpear; },
-      run: function(data) { data.seenFirstSpear = true; },
-      infoText:{
+      condition: function(data) {
+        return data.seenFirstSpear;
+      },
+      run: function(data) {
+        data.seenFirstSpear = true;
+      },
+      infoText: {
         en: 'Look for small spear',
         ko: '작은 지팡이 확인',
       },
@@ -134,7 +138,7 @@
           return {
             en: 'Tank Buster on ' + data.ShortName(matches.target),
             fr: 'Tankbuster sur ' + data.ShortName(matches.target),
-            fr: '"' + data.ShortName(matches.target) + '" 탱버',
+            ko: '"' + data.ShortName(matches.target) + '" 탱버',
           };
         }
       },

--- a/ui/raidboss/data/05-shb/raid/e5s.js
+++ b/ui/raidboss/data/05-shb/raid/e5s.js
@@ -139,11 +139,11 @@
     },
     {
       id: 'E5S Crippling Blow',
-      regex: Regexes.ability({ id: '4BCA', source: 'Ramuh', capture: false }),
-      regexDe: Regexes.ability({ id: '4BCA', source: 'Ramuh', capture: false }),
-      regexFr: Regexes.ability({ id: '4BCA', source: 'Ramuh', capture: false }),
-      regexJa: Regexes.ability({ id: '4BCA', source: 'ラムウ', capture: false }),
-      regexKo: Regexes.ability({ id: '4BCA', source: '라무', capture: false }),
+      regex: Regexes.ability({ id: '4BCA', source: 'Ramuh' }),
+      regexDe: Regexes.ability({ id: '4BCA', source: 'Ramuh' }),
+      regexFr: Regexes.ability({ id: '4BCA', source: 'Ramuh' }),
+      regexJa: Regexes.ability({ id: '4BCA', source: 'ラムウ' }),
+      regexKo: Regexes.ability({ id: '4BCA', source: '라무' }),
       condition: function(data) {
         return data.role == 'tank' || data.role == 'healer';
       },

--- a/ui/raidboss/data/05-shb/raid/e5s.js
+++ b/ui/raidboss/data/05-shb/raid/e5s.js
@@ -77,6 +77,18 @@
       },
     },
     {
+      id: 'E5S Fury\'s Fourteen',
+      regex: Regexes.startsUsing({ id: '4BAB', source: 'Ramuh', capture: false }),
+      regexDe: Regexes.startsUsing({ id: '4BAB', source: 'Ramuh', capture: false }),
+      regexFr: Regexes.startsUsing({ id: '4BAB', source: 'Ramuh', capture: false }),
+      regexJa: Regexes.startsUsing({ id: '4BAB', source: 'ラムウ', capture: false }),
+      regexKo: Regexes.startsUsing({ id: '4BAB', source: '라무', capture: false }),
+      infoText: {
+        en: 'Grab an orb',
+        ko: '구슬 줍기',
+      },
+    },
+    {
       id: 'E5S Judgment Volts',
       regex: Regexes.startsUsing({ id: '4BB5', source: 'Ramuh', capture: false }),
       regexDe: Regexes.startsUsing({ id: '4BB5', source: 'Ramuh', capture: false }),

--- a/ui/raidboss/data/05-shb/raid/e5s.js
+++ b/ui/raidboss/data/05-shb/raid/e5s.js
@@ -139,11 +139,11 @@
     },
     {
       id: 'E5S Crippling Blow',
-      regex: Regexes.ability({ id: '4BCA', source: 'Ramuh' }),
-      regexDe: Regexes.ability({ id: '4BCA', source: 'Ramuh' }),
-      regexFr: Regexes.ability({ id: '4BCA', source: 'Ramuh' }),
-      regexJa: Regexes.ability({ id: '4BCA', source: 'ラムウ' }),
-      regexKo: Regexes.ability({ id: '4BCA', source: '라무' }),
+      regex: Regexes.ability({ id: '4BCA', source: 'Ramuh', capture: false  }),
+      regexDe: Regexes.ability({ id: '4BCA', source: 'Ramuh', capture: false  }),
+      regexFr: Regexes.ability({ id: '4BCA', source: 'Ramuh', capture: false  }),
+      regexJa: Regexes.ability({ id: '4BCA', source: 'ラムウ', capture: false  }),
+      regexKo: Regexes.ability({ id: '4BCA', source: '라무', capture: false  }),
       condition: function(data) {
         return data.role == 'tank' || data.role == 'healer';
       },

--- a/ui/raidboss/data/05-shb/raid/e5s.js
+++ b/ui/raidboss/data/05-shb/raid/e5s.js
@@ -139,11 +139,11 @@
     },
     {
       id: 'E5S Crippling Blow',
-      regex: Regexes.ability({ id: '4BCA', source: 'Ramuh', capture: false  }),
-      regexDe: Regexes.ability({ id: '4BCA', source: 'Ramuh', capture: false  }),
-      regexFr: Regexes.ability({ id: '4BCA', source: 'Ramuh', capture: false  }),
-      regexJa: Regexes.ability({ id: '4BCA', source: 'ラムウ', capture: false  }),
-      regexKo: Regexes.ability({ id: '4BCA', source: '라무', capture: false  }),
+      regex: Regexes.ability({ id: '4BCA', source: 'Ramuh', capture: false }),
+      regexDe: Regexes.ability({ id: '4BCA', source: 'Ramuh', capture: false }),
+      regexFr: Regexes.ability({ id: '4BCA', source: 'Ramuh', capture: false }),
+      regexJa: Regexes.ability({ id: '4BCA', source: 'ラムウ', capture: false }),
+      regexKo: Regexes.ability({ id: '4BCA', source: '라무', capture: false }),
       condition: function(data) {
         return data.role == 'tank' || data.role == 'healer';
       },

--- a/ui/raidboss/data/05-shb/raid/e5s.js
+++ b/ui/raidboss/data/05-shb/raid/e5s.js
@@ -36,7 +36,7 @@
       regexKo: Regexes.ability({ id: '4BA5', source: '라무', capture: false }),
       delaySeconds: 5,
       condition: function(data) {
-        return data.seenFirstSpear;
+        return !data.seenFirstSpear;
       },
       run: function(data) {
         data.seenFirstSpear = true;


### PR DESCRIPTION
`E5S Stratospear Summons` can be changed to timelineTrigger, but there's no timeline now, so I added there. (Only the first *Stratospear Summons* (4BA5) is needed.)
There's something needed to be fixed. `E5S Stepped Leader` has problem, it only alerts `data.leaderCount %2 == 0` (ready spread). I believe this logic should do both. Strangely, `E5S Stepped Leader Spread` is working well. only when `data.leaderCount %2 == 0`, it says to Spread.
I don't know why this happens..
Other things are all working fine. I've tested so many times with melee DPS. (So, I didn't actually tested `E5S Crippling Blow` but, it should be fine.)