### PR TITLE
Util: Added missing parser error to test_timeline

### DIFF
--- a/util/test_timeline.py
+++ b/util/test_timeline.py
@@ -537,6 +537,9 @@ if __name__ == "__main__":
     if args.search_fights and not args.file:
         raise parser.error("Automatic encounter listing requires an input file")
 
+    if args.search_fights > -1 and not args.timeline:
+        raise parser.error("You must specify a timeline file before testing against a specific encounter.")
+
     if args.file and not ((args.start and args.end) or args.search_fights):
         raise parser.error("Log file input requires start and end timestamps")
 


### PR DESCRIPTION
Per #1062 this should resolve the error if the user attempts to test against a fight without a timeline selected. I'm not 100% sure it's correct to order the errors like this, but I think it's clearer this way.