### PR TITLE
ocean fishing fix

### DIFF
--- a/ui/fisher/fisher.js
+++ b/ui/fisher/fisher.js
@@ -230,15 +230,13 @@ class Fisher {
       this.ui.startFishing();
       return;
     }
-    // Set place, if it's unset
-    if (!this.place || !this.place.id) {
-      this.place = this.seaBase.getPlace(place);
-      // This lookup could fail and, for German,
-      // this.place.name may differ from place
-      // due to differing cast vs location names.
-      if (this.place.id)
-        this.ui.setPlace(this.place.name);
-    }
+    // Set place (set this every cast because it can change during ocean fishing)
+    this.place = this.seaBase.getPlace(place);
+    // This lookup could fail and, for German,
+    // this.place.name may differ from place
+    // due to differing cast vs location names.
+    if (this.place.id)
+      this.ui.setPlace(this.place.name);
     let _this = this;
 
     this.updateFishData().then(function() {


### PR DESCRIPTION
The fishing spot/place during ocean fishing changes while fishing. Set it on every cast regardless of whether it has already been set to handle this.

This should also fix #1075 as the ocean fish data has already been added.

Only tested in one voyage but it worked, and regular fishing looks like it still works.