### PR TITLE
Raidboss player name override features

### DIFF
--- a/resources/party.js
+++ b/resources/party.js
@@ -121,9 +121,8 @@ class PartyTracker {
   // returns the job name of the specified party member
   jobName(name) {
     let partyIndex = this.partyNames.indexOf(name);
-    if(partyIndex >= 0) {
+    if (partyIndex >= 0)
       return Util.jobEnumToJob(this.details[partyIndex].job);
-    }
     return null;
   }
 }

--- a/resources/party.js
+++ b/resources/party.js
@@ -117,4 +117,13 @@ class PartyTracker {
       return names[0];
     return null;
   }
+
+  // returns the job name of the specified party member
+  jobName(name) {
+    let partyIndex = this.partyNames.indexOf(name);
+    if(partyIndex >= 0) {
+      return Util.jobEnumToJob(this.details[partyIndex].job);
+    }
+    return null;
+  }
 }

--- a/ui/raidboss/autoplay_helper.js
+++ b/ui/raidboss/autoplay_helper.js
@@ -1,0 +1,23 @@
+'use strict';
+
+class AutoplayHelper {
+  static Check() {
+    let context = new AudioContext();
+    return context.state === 'suspended';
+  }
+
+  static Prompt() {
+    let button = document.createElement('button');
+    button.innerText = 'Click to enable audio';
+    button.classList.add('autoplay-helper-button');
+    button.onclick = function() {
+      button.remove();
+    };
+    document.body.appendChild(button);
+  }
+
+  static CheckAndPrompt() {
+    if (AutoplayHelper.Check())
+      AutoplayHelper.Prompt();
+  }
+}

--- a/ui/raidboss/browser_tts_engine.js
+++ b/ui/raidboss/browser_tts_engine.js
@@ -42,7 +42,18 @@ class GoogleTTSItem extends TTSItem {
 
 class BrowserTTSEngine {
   constructor() {
-    this.engineType = null;
+    // figure out what TTS engine type we need
+    if (window.speechSynthesis !== undefined) {
+      let me = this;
+      window.speechSynthesis.onvoiceschanged = function() {
+        if (window.speechSynthesis.getVoices().length > 0) {
+          window.speechSynthesis.onvoiceschanged = null;
+          me.engineType = TTSEngineType.SpeechSynthesis;
+        }
+      };
+    }
+
+    this.engineType = TTSEngineType.GoogleTTS;
     this.ttsItems = {};
   }
 
@@ -51,27 +62,21 @@ class BrowserTTSEngine {
       if (this.ttsItems[text] !== undefined) {
         this.ttsItems[text].play();
       } else {
-        switch (this.engineType) {
-        case null:
-          // figure out what TTS engine type we need
-          if (window.speechSynthesis !== undefined &&
-            window.speechSynthesis.getVoices().length > 0)
-            this.engineType = TTSEngineType.SpeechSynthesis;
-          else
-            this.engineType = TTSEngineType.GoogleTTS;
-          // just recurse to avoid repeating code
-          this.play(text);
-          break;
-        case TTSEngineType.SpeechSynthesis:
-          this.playSpeechTTS(text);
-          break;
-        case TTSEngineType.GoogleTTS:
-          this.playGoogleTTS(text);
-          break;
-        }
+        this.playTTS(text);
       }
     } catch (e) {
       console.log('Exception performing TTS', e);
+    }
+  }
+
+  playTTS(text) {
+    switch (this.engineType) {
+    case TTSEngineType.SpeechSynthesis:
+      this.playSpeechTTS(text);
+      break;
+    case TTSEngineType.GoogleTTS:
+      this.playGoogleTTS(text);
+      break;
     }
   }
 

--- a/ui/raidboss/browser_tts_engine.js
+++ b/ui/raidboss/browser_tts_engine.js
@@ -42,8 +42,8 @@ class GoogleTTSItem extends TTSItem {
 
 class BrowserTTSEngine {
   constructor() {
-    engineType = null;
-    ttsItems = {};
+    this.engineType = null;
+    this.ttsItems = {};
   }
 
   play(text) {

--- a/ui/raidboss/browser_tts_engine.js
+++ b/ui/raidboss/browser_tts_engine.js
@@ -59,11 +59,10 @@ class BrowserTTSEngine {
 
   play(text) {
     try {
-      if (this.ttsItems[text] !== undefined) {
+      if (this.ttsItems[text] !== undefined)
         this.ttsItems[text].play();
-      } else {
+      else
         this.playTTS(text);
-      }
     } catch (e) {
       console.log('Exception performing TTS', e);
     }

--- a/ui/raidboss/browser_tts_engine.js
+++ b/ui/raidboss/browser_tts_engine.js
@@ -44,11 +44,10 @@ class BrowserTTSEngine {
   constructor() {
     // figure out what TTS engine type we need
     if (window.speechSynthesis !== undefined) {
-      let me = this;
-      window.speechSynthesis.onvoiceschanged = function() {
+      window.speechSynthesis.onvoiceschanged = () => {
         if (window.speechSynthesis.getVoices().length > 0) {
           window.speechSynthesis.onvoiceschanged = null;
-          me.engineType = TTSEngineType.SpeechSynthesis;
+          this.engineType = TTSEngineType.SpeechSynthesis;
         }
       };
     }

--- a/ui/raidboss/browser_tts_engine.js
+++ b/ui/raidboss/browser_tts_engine.js
@@ -4,20 +4,20 @@ class BrowserTTSEngine {
   static play(text) {
     try {
       // check to see if we've already gotten this tts before
-      let iframe = window.document.querySelector("[data-tts=\""+text+"\"]");
+      let iframe = window.document.querySelector('[data-tts="'+text+'"]');
       if (iframe === null) {
-        iframe = document.createElement("iframe");
+        iframe = document.createElement('iframe');
         // remove sandbox so we can modify contents/call play on audio element later
         iframe.removeAttribute('sandbox');
-        iframe.style.display = "none";
+        iframe.style.display = 'none';
         document.body.appendChild(iframe);
         let encText = encodeURIComponent(text);
-        iframe.contentDocument.body.innerHTML = "<audio src=\"https://translate.google.com/translate_tts?ie=UTF-8&client=tw-ob&tl=en&q=" + encText + "\" id=\"TTS\">";
-        iframe.dataset["tts"] = text;
+        iframe.contentDocument.body.innerHTML = '<audio src="https://translate.google.com/translate_tts?ie=UTF-8&client=tw-ob&tl=en&q=' + encText + '" id="TTS">';
+        iframe.dataset['tts'] = text;
       }
       iframe.contentDocument.body.firstElementChild.play();
-    } catch(e) {
-        console.log("Exception performing TTS", e);
+    } catch (e) {
+      console.log('Exception performing TTS', e);
     }
   }
 }

--- a/ui/raidboss/browser_tts_engine.js
+++ b/ui/raidboss/browser_tts_engine.js
@@ -1,23 +1,87 @@
 'use strict';
 
+const TTSEngineType = {
+  SpeechSynthesis: 0,
+  GoogleTTS: 1,
+};
+
+class TTSItem {
+  play() {}
+}
+
+class SpeechTTSItem extends TTSItem {
+  constructor(text) {
+    super();
+    this.text = text;
+    this.item = new SpeechSynthesisUtterance(text);
+  }
+
+  play() {
+    window.speechSynthesis.speak(this.item);
+  }
+}
+
+class GoogleTTSItem extends TTSItem {
+  constructor(text) {
+    super();
+    this.text = text;
+    let iframe = document.createElement('iframe');
+    // remove sandbox so we can modify contents/call play on audio element later
+    iframe.removeAttribute('sandbox');
+    iframe.style.display = 'none';
+    document.body.appendChild(iframe);
+    let encText = encodeURIComponent(text);
+    iframe.contentDocument.body.innerHTML = '<audio src="https://translate.google.com/translate_tts?ie=UTF-8&client=tw-ob&tl=en&q=' + encText + '" id="TTS">';
+    this.item = iframe.contentDocument.body.firstElementChild;
+  }
+
+  play() {
+    this.item.play();
+  }
+}
+
 class BrowserTTSEngine {
-  static play(text) {
+  constructor() {
+    engineType = null;
+    ttsItems = {};
+  }
+
+  play(text) {
     try {
-      // check to see if we've already gotten this tts before
-      let iframe = window.document.querySelector('[data-tts="'+text+'"]');
-      if (iframe === null) {
-        iframe = document.createElement('iframe');
-        // remove sandbox so we can modify contents/call play on audio element later
-        iframe.removeAttribute('sandbox');
-        iframe.style.display = 'none';
-        document.body.appendChild(iframe);
-        let encText = encodeURIComponent(text);
-        iframe.contentDocument.body.innerHTML = '<audio src="https://translate.google.com/translate_tts?ie=UTF-8&client=tw-ob&tl=en&q=' + encText + '" id="TTS">';
-        iframe.dataset['tts'] = text;
+      if (this.ttsItems[text] !== undefined) {
+        this.ttsItems[text].play();
+      } else {
+        switch (this.engineType) {
+        case null:
+          // figure out what TTS engine type we need
+          if (window.speechSynthesis !== undefined &&
+            window.speechSynthesis.getVoices().length > 0)
+            this.engineType = TTSEngineType.SpeechSynthesis;
+          else
+            this.engineType = TTSEngineType.GoogleTTS;
+          // just recurse to avoid repeating code
+          this.play(text);
+          break;
+        case TTSEngineType.SpeechSynthesis:
+          this.playSpeechTTS(text);
+          break;
+        case TTSEngineType.GoogleTTS:
+          this.playGoogleTTS(text);
+          break;
+        }
       }
-      iframe.contentDocument.body.firstElementChild.play();
     } catch (e) {
       console.log('Exception performing TTS', e);
     }
+  }
+
+  playSpeechTTS(text) {
+    this.ttsItems[text] = new SpeechTTSItem(text);
+    this.ttsItems[text].play();
+  }
+
+  playGoogleTTS(text) {
+    this.ttsItems[text] = new GoogleTTSItem(text);
+    this.ttsItems[text].play();
   }
 }

--- a/ui/raidboss/browser_tts_engine.js
+++ b/ui/raidboss/browser_tts_engine.js
@@ -1,0 +1,23 @@
+'use strict';
+
+class BrowserTTSEngine {
+  static play(text) {
+    try {
+      // check to see if we've already gotten this tts before
+      let iframe = window.document.querySelector("[data-tts=\""+text+"\"]");
+      if (iframe === null) {
+        iframe = document.createElement("iframe");
+        // remove sandbox so we can modify contents/call play on audio element later
+        iframe.removeAttribute('sandbox');
+        iframe.style.display = "none";
+        document.body.appendChild(iframe);
+        let encText = encodeURIComponent(text);
+        iframe.contentDocument.body.innerHTML = "<audio src=\"https://translate.google.com/translate_tts?ie=UTF-8&client=tw-ob&tl=en&q=" + encText + "\" id=\"TTS\">";
+        iframe.dataset["tts"] = text;
+      }
+      iframe.contentDocument.body.firstElementChild.play();
+    } catch(e) {
+        console.log("Exception performing TTS", e);
+    }
+  }
+}

--- a/ui/raidboss/popup-text.js
+++ b/ui/raidboss/popup-text.js
@@ -632,8 +632,13 @@ class PopupText {
           ko: ' 그리고 ',
         };
         ttsText = ttsText.replace(/\s*(<[-=]|[=-]>)\s*/, arrowReplacement[lang]);
-        let cmd = { 'call': 'cactbotSay', 'text': ttsText };
-        window.callOverlayHandler(cmd);
+        // if we're overriding player name and browser tts engine is loaded, use that
+        if(Options.PlayerNameOverride !== null && typeof BrowserTTSEngine === "function") {
+          BrowserTTSEngine.play(ttsText);
+        } else {
+          let cmd = { 'call': 'cactbotSay', 'text': ttsText };
+          window.callOverlayHandler(cmd);
+        }
       } else if (soundUrl && playSounds) {
         let audio = new Audio(soundUrl);
         audio.volume = soundVol;

--- a/ui/raidboss/popup-text.js
+++ b/ui/raidboss/popup-text.js
@@ -31,6 +31,19 @@ class PopupText {
     this.alertText = document.getElementById('popup-text-alert');
     this.alarmText = document.getElementById('popup-text-alarm');
 
+    if (Options.PlayerNameOverride !== null &&
+      typeof BrowserTTSEngine === 'function') {
+      this.ttsEngine = new BrowserTTSEngine();
+      this.ttsSay = function(text) {
+        this.ttsEngine.play(ttsText);
+      };
+    } else {
+      this.ttsSay = function(text) {
+        let cmd = { 'call': 'cactbotSay', 'text': ttsText };
+        window.callOverlayHandler(cmd);
+      };
+    }
+
     this.partyTracker = new PartyTracker();
     addOverlayListener('PartyChanged', (e) => {
       this.partyTracker.onPartyChanged(e);
@@ -635,13 +648,7 @@ class PopupText {
         };
         ttsText = ttsText.replace(/\s*(<[-=]|[=-]>)\s*/, arrowReplacement[lang]);
         // if we're overriding player name and browser tts engine is loaded, use that
-        if (Options.PlayerNameOverride !== null &&
-            typeof BrowserTTSEngine === 'function') {
-          BrowserTTSEngine.play(ttsText);
-        } else {
-          let cmd = { 'call': 'cactbotSay', 'text': ttsText };
-          window.callOverlayHandler(cmd);
-        }
+        this.ttsSay(ttsText);
       } else if (soundUrl && playSounds) {
         let audio = new Audio(soundUrl);
         audio.volume = soundVol;

--- a/ui/raidboss/popup-text.js
+++ b/ui/raidboss/popup-text.js
@@ -78,12 +78,11 @@ class PopupText {
   OnPlayerChange(e) {
     // allow override of player via query parameter
     // only apply override if player is in party
-    if (Options.PlayerNameOverride !== null &&
-        this.partyTracker.inParty(Options.PlayerNameOverride)) {
-      let tmpJob;
+    if (Options.PlayerNameOverride !== null) {
+      let tmpJob = null;
       if (Options.PlayerJobOverride !== null)
         tmpJob = Options.PlayerJobOverride;
-      else
+      else if (this.partyTracker.inParty(Options.PlayerNameOverride))
         tmpJob = this.partyTracker.jobName(this.me);
       // if there's any issue with looking up player name for
       // override, don't perform override

--- a/ui/raidboss/popup-text.js
+++ b/ui/raidboss/popup-text.js
@@ -31,8 +31,7 @@ class PopupText {
     this.alertText = document.getElementById('popup-text-alert');
     this.alarmText = document.getElementById('popup-text-alarm');
 
-    if (Options.PlayerNameOverride !== null &&
-      typeof BrowserTTSEngine === 'function') {
+    if (this.options.BrowserTTS || Options.PlayerNameOverride !== null) {
       this.ttsEngine = new BrowserTTSEngine();
       this.ttsSay = function(text) {
         this.ttsEngine.play(text);

--- a/ui/raidboss/popup-text.js
+++ b/ui/raidboss/popup-text.js
@@ -81,13 +81,13 @@ class PopupText {
     if (Options.PlayerNameOverride !== null &&
         this.partyTracker.inParty(Options.PlayerNameOverride)) {
       let tmpJob;
-      if(Options.PlayerJobOverride !== null) 
+      if (Options.PlayerJobOverride !== null)
         tmpJob = Options.PlayerJobOverride;
       else
         tmpJob = this.partyTracker.jobName(this.me);
       // if there's any issue with looking up player name for
       // override, don't perform override
-      if(tmpJob !== null) {
+      if (tmpJob !== null) {
         e.detail.job = tmpJob;
         e.detail.name = Options.PlayerNameOverride;
       }

--- a/ui/raidboss/popup-text.js
+++ b/ui/raidboss/popup-text.js
@@ -229,11 +229,13 @@ class PopupText {
   OnJobChange(e) {
     // allow override of player via query parameter
     // only apply override if player is in party
-    if(Options.PlayerNameOverride !== null && this.partyTracker.inParty(Options.PlayerNameOverride)) {
+    if (Options.PlayerNameOverride !== null 
+        && this.partyTracker.inParty(Options.PlayerNameOverride)) {
       this.me = Options.PlayerNameOverride;
       this.job = this.partyTracker.jobName(this.me);
-      // if there's any issue with looking up player name for override, fall back to default behavior
-      if(this.job === null || this.job === undefined) {
+      // if there's any issue with looking up player name for
+      // override, fall back to default behavior
+      if (this.job === null || this.job === undefined) {
         this.me = e.detail.name;
         this.job = e.detail.job;
       }
@@ -633,7 +635,8 @@ class PopupText {
         };
         ttsText = ttsText.replace(/\s*(<[-=]|[=-]>)\s*/, arrowReplacement[lang]);
         // if we're overriding player name and browser tts engine is loaded, use that
-        if(Options.PlayerNameOverride !== null && typeof BrowserTTSEngine === "function") {
+        if (Options.PlayerNameOverride !== null 
+            && typeof BrowserTTSEngine === 'function') {
           BrowserTTSEngine.play(ttsText);
         } else {
           let cmd = { 'call': 'cactbotSay', 'text': ttsText };

--- a/ui/raidboss/popup-text.js
+++ b/ui/raidboss/popup-text.js
@@ -31,7 +31,7 @@ class PopupText {
     this.alertText = document.getElementById('popup-text-alert');
     this.alarmText = document.getElementById('popup-text-alarm');
 
-    if (this.options.BrowserTTS || Options.PlayerNameOverride !== null) {
+    if (this.options.BrowserTTS) {
       this.ttsEngine = new BrowserTTSEngine();
       this.ttsSay = function(text) {
         this.ttsEngine.play(text);
@@ -41,6 +41,12 @@ class PopupText {
         let cmd = { 'call': 'cactbotSay', 'text': text };
         window.callOverlayHandler(cmd);
       };
+    }
+
+    // check to see if we need user interaction to play audio
+    // only if audio is enabled in options
+    if (Options.audioAllowed) {
+      AutoplayHelper.CheckAndPrompt();
     }
 
     this.partyTracker = new PartyTracker();
@@ -646,7 +652,6 @@ class PopupText {
           ko: ' 그리고 ',
         };
         ttsText = ttsText.replace(/\s*(<[-=]|[=-]>)\s*/, arrowReplacement[lang]);
-        // if we're overriding player name and browser tts engine is loaded, use that
         this.ttsSay(ttsText);
       } else if (soundUrl && playSounds) {
         let audio = new Audio(soundUrl);

--- a/ui/raidboss/popup-text.js
+++ b/ui/raidboss/popup-text.js
@@ -45,9 +45,8 @@ class PopupText {
 
     // check to see if we need user interaction to play audio
     // only if audio is enabled in options
-    if (Options.audioAllowed) {
+    if (Options.audioAllowed)
       AutoplayHelper.CheckAndPrompt();
-    }
 
     this.partyTracker = new PartyTracker();
     addOverlayListener('PartyChanged', (e) => {

--- a/ui/raidboss/popup-text.js
+++ b/ui/raidboss/popup-text.js
@@ -35,11 +35,11 @@ class PopupText {
       typeof BrowserTTSEngine === 'function') {
       this.ttsEngine = new BrowserTTSEngine();
       this.ttsSay = function(text) {
-        this.ttsEngine.play(ttsText);
+        this.ttsEngine.play(text);
       };
     } else {
       this.ttsSay = function(text) {
-        let cmd = { 'call': 'cactbotSay', 'text': ttsText };
+        let cmd = { 'call': 'cactbotSay', 'text': text };
         window.callOverlayHandler(cmd);
       };
     }

--- a/ui/raidboss/popup-text.js
+++ b/ui/raidboss/popup-text.js
@@ -227,8 +227,20 @@ class PopupText {
   }
 
   OnJobChange(e) {
-    this.me = e.detail.name;
-    this.job = e.detail.job;
+    // allow override of player via query parameter
+    // only apply override if player is in party
+    if(Options.PlayerNameOverride !== null && this.partyTracker.inParty(Options.PlayerNameOverride)) {
+      this.me = Options.PlayerNameOverride;
+      this.job = this.partyTracker.jobName(this.me);
+      // if there's any issue with looking up player name for override, fall back to default behavior
+      if(this.job === null || this.job === undefined) {
+        this.me = e.detail.name;
+        this.job = e.detail.job;
+      }
+    } else {
+      this.me = e.detail.name;
+      this.job = e.detail.job;
+    }
     this.role = Util.jobToRole(this.job);
     this.ReloadTimelines();
   }

--- a/ui/raidboss/popup-text.js
+++ b/ui/raidboss/popup-text.js
@@ -651,7 +651,7 @@ class PopupText {
           ja: 'や',
           ko: ' 그리고 ',
         };
-        ttsText = ttsText.replace(/\s*(<[-=]|[=-]>)\s*/, arrowReplacement[lang]);
+        ttsText = ttsText.replace(/\s*(<[-=]|[=-]>)\s*/g, arrowReplacement[lang]);
         this.ttsSay(ttsText);
       } else if (soundUrl && playSounds) {
         let audio = new Audio(soundUrl);

--- a/ui/raidboss/popup-text.js
+++ b/ui/raidboss/popup-text.js
@@ -229,8 +229,8 @@ class PopupText {
   OnJobChange(e) {
     // allow override of player via query parameter
     // only apply override if player is in party
-    if (Options.PlayerNameOverride !== null 
-        && this.partyTracker.inParty(Options.PlayerNameOverride)) {
+    if (Options.PlayerNameOverride !== null &&
+        this.partyTracker.inParty(Options.PlayerNameOverride)) {
       this.me = Options.PlayerNameOverride;
       this.job = this.partyTracker.jobName(this.me);
       // if there's any issue with looking up player name for
@@ -635,8 +635,8 @@ class PopupText {
         };
         ttsText = ttsText.replace(/\s*(<[-=]|[=-]>)\s*/, arrowReplacement[lang]);
         // if we're overriding player name and browser tts engine is loaded, use that
-        if (Options.PlayerNameOverride !== null 
-            && typeof BrowserTTSEngine === 'function') {
+        if (Options.PlayerNameOverride !== null &&
+            typeof BrowserTTSEngine === 'function') {
           BrowserTTSEngine.play(ttsText);
         } else {
           let cmd = { 'call': 'cactbotSay', 'text': ttsText };

--- a/ui/raidboss/popup-text.js
+++ b/ui/raidboss/popup-text.js
@@ -76,6 +76,22 @@ class PopupText {
   }
 
   OnPlayerChange(e) {
+    // allow override of player via query parameter
+    // only apply override if player is in party
+    if (Options.PlayerNameOverride !== null &&
+        this.partyTracker.inParty(Options.PlayerNameOverride)) {
+      let tmpJob;
+      if(Options.PlayerJobOverride !== null) 
+        tmpJob = Options.PlayerJobOverride;
+      else
+        tmpJob = this.partyTracker.jobName(this.me);
+      // if there's any issue with looking up player name for
+      // override, don't perform override
+      if(tmpJob !== null) {
+        e.detail.job = tmpJob;
+        e.detail.name = Options.PlayerNameOverride;
+      }
+    }
     if (this.job != e.detail.job || this.me != e.detail.name)
       this.OnJobChange(e);
     this.data.currentHP = e.detail.currentHP;
@@ -244,22 +260,8 @@ class PopupText {
   }
 
   OnJobChange(e) {
-    // allow override of player via query parameter
-    // only apply override if player is in party
-    if (Options.PlayerNameOverride !== null &&
-        this.partyTracker.inParty(Options.PlayerNameOverride)) {
-      this.me = Options.PlayerNameOverride;
-      this.job = this.partyTracker.jobName(this.me);
-      // if there's any issue with looking up player name for
-      // override, fall back to default behavior
-      if (this.job === null || this.job === undefined) {
-        this.me = e.detail.name;
-        this.job = e.detail.job;
-      }
-    } else {
-      this.me = e.detail.name;
-      this.job = e.detail.job;
-    }
+    this.me = e.detail.name;
+    this.job = e.detail.job;
     this.role = Util.jobToRole(this.job);
     this.ReloadTimelines();
   }

--- a/ui/raidboss/raidboss.css
+++ b/ui/raidboss/raidboss.css
@@ -122,3 +122,11 @@
   top: 0;
   left: calc(100%);
 }
+
+.autoplay-helper-button {
+  position: absolute;
+  top: 0;
+  left: 0;
+  margin: 0.2em;
+  max-width: 100vw;
+}

--- a/ui/raidboss/raidboss.html
+++ b/ui/raidboss/raidboss.html
@@ -26,6 +26,7 @@
   <script src="raidboss_config.js"></script>
   <script src="timeline.js"></script>
   <script src="browser_tts_engine.js"></script>
+  <script src="autoplay_helper.js"></script>
   <script src="popup-text.js"></script>
   <script src="raidboss.js"></script>
 </head>

--- a/ui/raidboss/raidboss.html
+++ b/ui/raidboss/raidboss.html
@@ -25,6 +25,7 @@
   <script src="common_replacement.js"></script>
   <script src="raidboss_config.js"></script>
   <script src="timeline.js"></script>
+  <script src="browser_tts_engine.js"></script>
   <script src="popup-text.js"></script>
   <script src="raidboss.js"></script>
 </head>

--- a/ui/raidboss/raidboss.js
+++ b/ui/raidboss/raidboss.js
@@ -20,6 +20,7 @@ let Options = {
   Triggers: [],
 
   PlayerNameOverride: null,
+  PlayerJobOverride: null,
 };
 
 let gTimelineController;
@@ -55,10 +56,16 @@ UserConfig.getUserConfigLocation('raidboss', function(e) {
   }
 
   let PlayerNameOverride = params.get('player');
-  if (PlayerNameOverride !== null) {
+  if (PlayerNameOverride !== null)
     Options.PlayerNameOverride = PlayerNameOverride;
+
+  let PlayerJobOverride = params.get('job');
+  if (PlayerJobOverride !== null)
+    Options.PlayerJobOverride = PlayerJobOverride;
+
+  if (PlayerNameOverride !== null || PlayerJobOverride !== null) {
     Options.BrowserTTS = true;
-    console.log('Enabling player name override via query parameter, ' + PlayerNameOverride);
+    console.log('Enabling player name override via query parameter, name: ' + PlayerNameOverride + ', job: ' + PlayerJobOverride);
   }
 
   let container = document.getElementById('container');

--- a/ui/raidboss/raidboss.js
+++ b/ui/raidboss/raidboss.js
@@ -57,6 +57,7 @@ UserConfig.getUserConfigLocation('raidboss', function(e) {
   let PlayerNameOverride = params.get('player');
   if (PlayerNameOverride !== null) {
     Options.PlayerNameOverride = PlayerNameOverride;
+    Options.BrowserTTS = true;
     console.log('Enabling player name override via query parameter, ' + PlayerNameOverride);
   }
 

--- a/ui/raidboss/raidboss.js
+++ b/ui/raidboss/raidboss.js
@@ -58,6 +58,12 @@ UserConfig.getUserConfigLocation('raidboss', function(e) {
   if (PlayerNameOverride !== null) {
     Options.PlayerNameOverride = PlayerNameOverride;
     console.log('Enabling player name override via query parameter, ' + PlayerNameOverride);
+    if (Options.audioAllowed) {
+      // include the tts engine script
+      // re-using this since it's already created
+      UserConfig.appendJSLink('browser_tts_engine.js');
+      console.log('Enabling browser TTS engine');
+    }
   }
 
   let container = document.getElementById('container');

--- a/ui/raidboss/raidboss.js
+++ b/ui/raidboss/raidboss.js
@@ -58,12 +58,6 @@ UserConfig.getUserConfigLocation('raidboss', function(e) {
   if (PlayerNameOverride !== null) {
     Options.PlayerNameOverride = PlayerNameOverride;
     console.log('Enabling player name override via query parameter, ' + PlayerNameOverride);
-    if (Options.audioAllowed) {
-      // include the tts engine script
-      // re-using this since it's already created
-      UserConfig.appendJSLink('browser_tts_engine.js');
-      console.log('Enabling browser TTS engine');
-    }
   }
 
   let container = document.getElementById('container');

--- a/ui/raidboss/raidboss.js
+++ b/ui/raidboss/raidboss.js
@@ -18,6 +18,8 @@ let Options = {
   PerTriggerOptions: {},
 
   Triggers: [],
+
+  PlayerNameOverride: null,
 };
 
 let gTimelineController;
@@ -50,6 +52,12 @@ UserConfig.getUserConfigLocation('raidboss', function(e) {
     Options.audioAllowed = !!parseInt(audio);
     if (!previous && Options.audioAllowed)
       console.log('Enabling audio via query parameter');
+  }
+
+  let PlayerNameOverride = params.get('player');
+  if (PlayerNameOverride !== null) {
+    Options.PlayerNameOverride = PlayerNameOverride;
+    console.log('Enabling player name override via query parameter, ' + PlayerNameOverride);
   }
 
   let container = document.getElementById('container');

--- a/ui/raidboss/raidboss_config.js
+++ b/ui/raidboss/raidboss_config.js
@@ -1072,6 +1072,18 @@ UserConfig.registerOptions('raidboss', {
       default: 1,
     },
     {
+      id: 'BrowserTTS',
+      name: {
+        en: 'Use Browser for Text to Speech',
+        de: 'Verwenden Sie den Browser für Text zu Sprache', // Machine translation
+        fr: 'Utiliser le navigateur pour la synthèse vocale', // Machine Translation
+        ko: '텍스트 음성 변환을위한 브라우저 사용', // Machine translation
+        cn: '使用浏览器进行文字转语音', // Machine translation
+      },
+      type: 'checkbox',
+      default: false,
+    },
+    {
       id: 'cactbotWormholeStrat',
       // TODO: maybe need some way to group these kinds of
       // options if we end up having a lot?

--- a/ui/raidboss/raidemulator.html
+++ b/ui/raidboss/raidemulator.html
@@ -26,6 +26,8 @@
   <script src="common_replacement.js"></script>
   <script src="raidboss_config.js"></script>
   <script src="timeline.js"></script>
+  <script src="browser_tts_engine.js"></script>
+  <script src="autoplay_helper.js"></script>
   <script src="popup-text.js"></script>
   <script src="raidboss.js"></script>
   <script src="raidemulator.js"></script>


### PR DESCRIPTION
Allow overriding player name and playing TTS through browser when using raidboss overlay with websocket. Example query string:
`&player=Some%20Person`

If that person is in your party, raidboss will display the same timeline as normal, but give callouts for that person and their job instead of the person hosting the ACT/Overlay/WS/Cactbot instance.

Text to Speech is done via google services as that was the simplest to implement. Audio should only be fetched once per TTS string per page load.

Initial tests for this functionality are good but haven't had a chance to do extensive testing yet.