### PR TITLE
Raidboss: Initial e6n timeline

### DIFF
--- a/ui/raidboss/data/05-shb/raid/e6n.txt
+++ b/ui/raidboss/data/05-shb/raid/e6n.txt
@@ -4,4 +4,101 @@
 hideall "--Reset--"
 hideall "--sync--"
 
+# -ii 4BDD 4BE1 4BEB 4BEA 4BE5 4BE9 4BEC 4BD9 4BE7 4E39 4C1D 4C20 4F98
+# -ic "Tumultuous Nexus" "Great Ball Of Fire"
+
 0.0 "--Reset--" sync / 21:........:40000010:/ window 10000 jump 0
+
+0.0 "--sync--" sync /:Engage!/ window 0,1
+
+# Garuda solo
+2.0 "--sync--" sync /:Garuda:366:/ window 3,1
+13.5 "Ferostorm" sync /:Garuda:4BDE:/ window 15,30
+20.6 "Superstorm" sync /:Garuda:4BD7:/
+31.4 "Air Bump" sync /:Garuda:4BD1:/
+36.8 "Thorns" sync /:Garuda:4BDA:/
+48.0 "Downburst" sync /:Garuda:4BDB:/ window 30,30
+54.6 "Air Bump" sync /:Garuda:4BD1:/
+60.0 "Thorns" sync /:Garuda:4BDA:/
+72.2 "Storm Of Fury" sync /:Garuda:4BE0:/
+75.4 "--sync--" sync /:Garuda:4BD0:/
+81.7 "Vacuum Slice" sync /:Garuda:4BD5:/
+88.8 "Occluded Front" sync /:Garuda:4BD2:/ window 30,30
+98.3 "Irresistible Pull" sync /:Garuda:4BD6:/
+
+# Ifrit solo
+114.0 "Touchdown" sync /:Ifrit:4BE8:/ window 30,30
+129.2 "Hands Of Flame" sync /:Ifrit:4CFE:/
+143.6 "Hands Of Hell" sync /:Ifrit:4CFF:/
+152.3 "Instant Incineration" sync /:Ifrit:4BED:/ window 30,30
+156.9 "Eruption" sync /:Ifrit:4BF3:/
+166.1 "Strike Spark" sync /:Ifrit:4BD3:/
+177.5 "Hot Foot" sync /:Ifrit:4BEF:/
+188.2 "Inferno Howl" sync /:Ifrit:4BF1:/ window 30,30
+
+# Garuda and Ifrit
+200.9 "--sync--" sync /:Garuda:4BD0:/ window 30,30
+207.2 "Vacuum Slice" sync /:Garuda:4BD5:/
+209.9 "Eruption" sync /:Ifrit:4BF3:/
+209.9 "Eruption" sync /:Ifrit:4BF4:/
+213.1 "--sync--" sync /:Ifrit:4F98:/
+214.3 "Occluded Front" sync /:Garuda:4BD2:/
+221.2 "Hot Foot" sync /:Ifrit:4BEF:/
+223.8 "Irresistible Pull" sync /:Garuda:4BD6:/ window 30,30
+228.0 "Air Bump" sync /:Garuda:4BD1:/
+233.3 "Thorns" sync /:Garuda:4BDA:/
+237.9 "Hands Of Hell" sync /:Ifrit:4CFF:/
+245.5 "Ferostorm" sync /:Garuda:4BDF:/
+
+# Raktapaksa initial block
+257.1 "--sync--" sync /:Raktapaksa:4D55:/ window 30,30
+267.9 "Firestorm" sync /:Raktapaksa:4BD8:/
+283.2 "Radiant Plume" sync /:Raktapaksa:4BF2:/
+286.2 "Ferostorm" sync /:Raktapaksa:4BE4:/
+297.3 "Hands Of Flame" sync /:Raktapaksa:4CFE:/ window 30,30
+301.1 "Heat Burst" sync /:Raktapaksa:4C1E:/
+311.2 "Eruption" sync /:Raktapaksa:4BF4:/
+312.6 "Thorns" sync /:Raktapaksa:4BDA:/
+313.7 "Hands Of Hell" sync /:Raktapaksa:4CFF:/
+317.6 "Heat Burst" sync /:Raktapaksa:4C1E:/
+325.2 "Downburst" sync /:Raktapaksa:4BDC:/ window 30,30
+336.6 "Radiant Plume" sync /:Raktapaksa:4BF2:/
+341.6 "Eruption" sync /:Raktapaksa:4BF4:/
+348.1 "Radiant Plume" sync /:Raktapaksa:4BF2:/
+353.1 "Eruption" sync /:Raktapaksa:4BF4:/
+360.4 "Conflag Strike" sync /:Raktapaksa:4BEE:/ window 30,30
+
+# Raktapaksa rotation block
+375.6 "Ferostorm" sync /:Raktapaksa:4BE3:/
+377.6 "Air Bump" sync /:Raktapaksa:4BD4:/
+382.5 "Thorns" sync /:Raktapaksa:4BDA:/ window 30,30
+390.7 "Storm Of Fury" sync /:Raktapaksa:4BE6:/
+391.7 "Eruption" sync /:Raktapaksa:4BF4:/
+401.4 "Inferno Howl" sync /:Raktapaksa:4BF1:/
+415.6 "Eruption" sync /:Raktapaksa:4BF4:/
+416.6 "Hands Of Hell" sync /:Raktapaksa:4CFF:/ window 30,30
+420.5 "Heat Burst" sync /:Raktapaksa:4C1E:/
+427.2 "Instant Incineration" sync /:Raktapaksa:4BED:/
+433.4 "Radiant Plume" sync /:Raktapaksa:4BF2:/
+439.4 "Inferno Howl" sync /:Raktapaksa:4BF1:/ window 30,30
+
+454.6 "Ferostorm" sync /:Raktapaksa:4BE3:/
+456.6 "Air Bump" sync /:Raktapaksa:4BD4:/
+461.5 "Thorns" sync /:Raktapaksa:4BDA:/ window 30,30
+469.7 "Storm Of Fury" sync /:Raktapaksa:4BE6:/
+470.7 "Eruption" sync /:Raktapaksa:4BF4:/
+480.4 "Inferno Howl" sync /:Raktapaksa:4BF1:/
+494.6 "Eruption" sync /:Raktapaksa:4BF4:/
+495.6 "Hands Of Hell" sync /:Raktapaksa:4CFF:/ window 30,30
+499.5 "Heat Burst" sync /:Raktapaksa:4C1E:/
+506.2 "Instant Incineration" sync /:Raktapaksa:4BED:/
+512.4 "Radiant Plume" sync /:Raktapaksa:4BF2:/
+518.4 "Inferno Howl" sync /:Raktapaksa:4BF1:/ window 30,30 jump 439.4
+
+533.6 "Ferostorm"
+535.6 "Air Bump"
+540.5 "Thorns"
+548.7 "Storm Of Fury"
+549.7 "Eruption"
+559.4 "Inferno Howl"
+573.6 "Eruption"

--- a/ui/raidboss/data/05-shb/raid/e6n.txt
+++ b/ui/raidboss/data/05-shb/raid/e6n.txt
@@ -13,8 +13,8 @@ hideall "--sync--"
 
 # Garuda solo
 2.0 "--sync--" sync /:Garuda:366:/ window 3,1
-13.5 "Ferostorm" sync /:Garuda:4BDE:/ window 15,30
-20.6 "Superstorm" sync /:Garuda:4BD7:/
+13.5 "Ferostorm"# sync /:Garuda:4BDE:/
+20.6 "Superstorm" sync /:Garuda:4BD7:/ window 20,30
 31.4 "Air Bump" sync /:Garuda:4BD1:/
 36.8 "Thorns" sync /:Garuda:4BDA:/
 48.0 "Downburst" sync /:Garuda:4BDB:/ window 30,30
@@ -48,13 +48,13 @@ hideall "--sync--"
 228.0 "Air Bump" sync /:Garuda:4BD1:/
 233.3 "Thorns" sync /:Garuda:4BDA:/
 237.9 "Hands Of Hell" sync /:Ifrit:4CFF:/
-245.5 "Ferostorm" sync /:Garuda:4BDF:/
+245.5 "Ferostorm"# sync /:Garuda:4BDF:/
 
 # Raktapaksa initial block
 257.1 "--sync--" sync /:Raktapaksa:4D55:/ window 30,30
 267.9 "Firestorm" sync /:Raktapaksa:4BD8:/
 283.2 "Radiant Plume" sync /:Raktapaksa:4BF2:/
-286.2 "Ferostorm" sync /:Raktapaksa:4BE4:/
+286.2 "Ferostorm"# sync /:Raktapaksa:4BE4:/
 297.3 "Hands Of Flame" sync /:Raktapaksa:4CFE:/ window 30,30
 301.1 "Heat Burst" sync /:Raktapaksa:4C1E:/
 311.2 "Eruption" sync /:Raktapaksa:4BF4:/
@@ -69,7 +69,7 @@ hideall "--sync--"
 360.4 "Conflag Strike" sync /:Raktapaksa:4BEE:/ window 30,30
 
 # Raktapaksa rotation block
-375.6 "Ferostorm" sync /:Raktapaksa:4BE3:/
+375.6 "Ferostorm"# sync /:Raktapaksa:4BE3:/
 377.6 "Air Bump" sync /:Raktapaksa:4BD4:/
 382.5 "Thorns" sync /:Raktapaksa:4BDA:/ window 30,30
 390.7 "Storm Of Fury" sync /:Raktapaksa:4BE6:/
@@ -82,7 +82,7 @@ hideall "--sync--"
 433.4 "Radiant Plume" sync /:Raktapaksa:4BF2:/
 439.4 "Inferno Howl" sync /:Raktapaksa:4BF1:/ window 30,30
 
-454.6 "Ferostorm" sync /:Raktapaksa:4BE3:/
+454.6 "Ferostorm"# sync /:Raktapaksa:4BE3:/
 456.6 "Air Bump" sync /:Raktapaksa:4BD4:/
 461.5 "Thorns" sync /:Raktapaksa:4BDA:/ window 30,30
 469.7 "Storm Of Fury" sync /:Raktapaksa:4BE6:/


### PR DESCRIPTION
No triggers alongside this yet, I'll probably have those soon enough. Minimal testing went into this etc.

Ferostorm is not synced because there are multiple different ability IDs to go with it. (I believe each cardinal direction can be one, in much the same way Double Sever in Fractal Continuum, or Port/Star and Fore/Aft in Temple of the Fist have separate IDs for each direction.) Rather than try to find all the correct IDs for both Garuda and Raktapaksa, I figured it was better just not to sync at all. [(The syncs are commented out rather than deleted so that if we do translation work based on timelines in the future, we still have those ability IDs available.](https://github.com/quisquous/cactbot/issues/749#issuecomment-557830256))