### PR TITLE
Util: QoL adjustment for timeline_adjust

### DIFF
--- a/util/timeline_adjust.py
+++ b/util/timeline_adjust.py
@@ -22,13 +22,14 @@ def main():
         description="A utility to uniformly adjust times in an act timeline file"
     )
     parser.add_argument(
-        "--file",
+        "-file", "-f",
         required=True,
         type=argparse.FileType("r", encoding="utf8"),
         help="The timeline file to adjust times in",
     )
     parser.add_argument(
-        "--adjust", required=True, type=float, help="The amount of time to adjust each entry by"
+        "-adjust", "-a",
+        required=True, type=float, help="The amount of time to adjust each entry by"
     )
 
     args = parser.parse_args()

--- a/util/timeline_adjust.py
+++ b/util/timeline_adjust.py
@@ -29,7 +29,9 @@ def main():
     )
     parser.add_argument(
         "-adjust", "-a",
-        required=True, type=float, help="The amount of time to adjust each entry by"
+        required=True,
+        type=float,
+        help="The amount of time to adjust each entry by"
     )
 
     args = parser.parse_args()


### PR DESCRIPTION
It's the tiniest of tiny nits, but every time I go to adjust a timeline I forget that the arguments aren't aliased. No more forgetting!