### PR TITLE
Resources: Spelling fix for responses.js

### DIFF
--- a/resources/responses.js
+++ b/resources/responses.js
@@ -306,7 +306,7 @@ let Responses = {
     };
     return obj;
   },
-  spreadThanStack: (sev) => {
+  spreadThenStack: (sev) => {
     let obj = {};
     obj[defaultAlertText(sev)] = {
       en: 'Spread => Stack',
@@ -318,7 +318,7 @@ let Responses = {
     };
     return obj;
   },
-  stackThanSpread: (sev) => {
+  stackThenSpread: (sev) => {
     let obj = {};
     obj[defaultAlertText(sev)] = {
       en: 'Stack => Spread',


### PR DESCRIPTION
I did a few searches and couldn't find any other uses in the repository, so I think we're safe to change this. E6n will most likely be a near-future use once I get the triggers working for that.