### PR TITLE
Raidboss: Initial E6n triggers and updated timeline

### DIFF
--- a/ui/raidboss/data/05-shb/raid/e6n.js
+++ b/ui/raidboss/data/05-shb/raid/e6n.js
@@ -6,8 +6,271 @@
     ko: /^희망의 낙원 에덴: 공명편 \(2\)$/,
   },
   timelineFile: 'e6n.txt',
+  timelineTriggers: [
+    {
+      // We warn the user here because the startsUsing warning gives only 3.5s or so.
+      id: 'E6N Downburst',
+      regex: /Downburst/,
+      beforeSeconds: 5,
+      response: Responses.knockback('info'),
+    },
+
+  ],
   triggers: [
+    {
+      id: 'E6N Superstorm',
+      regex: Regexes.startsUsing({ source: 'Garuda', id: '4BD7', capture: false }),
+      condition: Conditions.caresAboutMagical(),
+      response: Responses.aoe(),
+    }, 
+    {
+      id: 'E6N Ferostorm',
+      regex: Regexes.startsUsing({ source: ['Garuda', 'Raktapaska'], id: ['4BD[DEF]', '4BE[345]'] }),
+      infoText: {
+        en: 'Avoid green nails',
+      },
+    },
+    {
+      id: 'E6N Air Bump',
+      regex: Regexes.headMarker({ id: '00D3' }),
+      suppressSeconds: 1,
+      infoText: function(data, matches) {
+        if (data.me == matches.target) {
+          return {
+            en: 'Enumeration on YOU',
+            de: 'Enumeration aud DIR',
+            fr: 'Enumération sur VOUS',
+          };
+        }
+        return {
+          en: 'Enumeration',
+          de: 'Enumeration',
+          fr: 'Enumération',
+        };
+      },
+    },
+    {
+      id: 'E6N Inferno Howl',
+      regex: Regexes.startsUsing({ source: ['Ifrit', 'Raktapaksa'], id: '4BF1', capture: false }),
+      condition: Conditions.caresAboutMagical(),
+      response: Responses.aoe(),
+    },
+    {
+      // Save ability state since the generic tether used has multiple uses in this fight
+      id: 'E6N Hands of Flame Start',
+      regex: Regexes.startsUsing({ source: ['Ifrit', 'Raktapaksa'], id: '4CFE', capture: false }),
+      preRun: function(data) {
+        data.handsOfFlame = true;
+      },
+    },
+    {
+      // Tank swap if you're not the target
+      // Break tether if you're the target during Ifrit+Garuda phase
+      id: 'E6N Hands of Flame Tether',
+      regex: Regexes.tether({ id: '0068' }),
+      condition: function(data) {
+        return data.handsOfFlame;
+      },
+      infoText: function(data, matches) {
+        if (data.me == matches.target) {
+          return {
+            en: 'Charge on YOU',
+            de: 'Ansturm auf DIR',
+            fr: 'Charge sur VOUS',
+          };
+        }
+        if (data.role != 'tank' || data.phase == 'both')
+          return;
+        return {
+          en: 'Tank Swap',
+          de: 'Tank Swap',
+          fr: 'Tank Swap',
+        };
+      },
+    },
+    {
+      id: 'E6N Hands of Flame Cast',
+      regex: Regexes.ability({ source: ['Ifrit', 'Raktapaksa'], id: '4BE9', capture: false }),
+      suppressSeconds: 1,
+      preRun: function(data) {
+        data.handsOfFlame = false;
+      },
+    },
+    {
+      id: 'E6N Instant Incineration',
+      regex: Regexes.startsUsing({ source: ['Ifrit', 'Raktapaksa'], id: '4BED' }),
+      condition: Conditions.caresAboutMagical(),
+      response: Responses.tankBuster(),
+    },
+    {
+      id: 'E6N Hands of Hell',
+      regex: Regexes.headMarker({ id: '0016' }),
+      condition: Conditions.targetIsYou(),
+      alertText: {
+        en: 'Tether Marker on YOU',
+        de: 'Verbindung auf DIR',
+        fr: 'Marque de lien sur VOUS',
+      },
+    },
+    {
+      id: 'E6N Strike Spark',
+      regex: Regexes.ability({ source: 'Ifrit', id: '4F98'}),
+      // Run only once, because Ifrit's other jumps are not important.
+      condition: function(data) {
+        return !data.seenSpark;
+      },
+      alertText: {
+        en: 'Move to Ifrit',
+      },
+      run: function(data){
+        data.seenSpark =true;
+      },
+    },
+    {
+      id: 'E6N Storm Of Fury',
+      // Garuda uses this ability without eruptions alongside, so she needs no warnings.
+      regex: Regexes.startsUsing({ source: 'Raktapaksa', id: '4BE6' }),
+      response: Responses.stackThenSpread(),
+    },
   ],
   timelineReplace: [
+    {
+      'locale': 'de',
+      'replaceSync': {
+        'twisting blaze': 'Feuersturm',
+        'tumultuous nexus': 'Orkankugel',
+        'great ball of fire': 'Flammenkugel',
+        'Raktapaksa': 'Raktapaksa',
+        'Ifrit': 'Ifrit',
+        'Garuda': 'Garuda',
+      },
+      'replaceText': {
+        'Wind Cutter': 'Schneidender Wind',
+        'Vacuum Slice': 'Vakuumschnitt',
+        'Touchdown': 'Himmelssturz',
+        'Thorns': 'Dornen',
+        'Superstorm': 'Sturm der Zerstörung',
+        'Strike Spark': 'Feuerfunken',
+        'Storm of Fury': 'Wütender Sturm',
+        'Spread of Fire': 'Ausbreitung des Feuers',
+        'Spike of Flame': 'Flammenstachel',
+        'Radiant Plume': 'Scheiterhaufen',
+        'Occluded Front': 'Okklusion',
+        'Meteor Strike': 'Meteorit',
+        'Irresistible Pull': 'Saugkraft',
+        'Instant Incineration': 'Explosive Flamme',
+        'Inferno Howl': 'Glühendes Gebrüll',
+        'Hot Foot': 'Fliegendes Feuer',
+        'Heat Burst': 'Hitzewelle',
+        'Hands of Hell': 'Faust des Schicksals',
+        'Hands of Flame': 'Flammenfaust',
+        'Firestorm': 'Feuersturm',
+        'Ferostorm': 'Angststurm',
+        'Explosion': 'Explosion',
+        'Eruption': 'Eruption',
+        'Downburst': 'Fallböe',
+        'Conflag Strike': 'Feuersbrunst',
+        'Call of the Inferno': 'Flimmernde Hitze',
+        'Blaze': 'Flamme',
+        'Air Bump': 'Aufsteigende Böe',
+      },
+      '~effectNames': {
+        'Magic Vulnerability Up': 'Erhöhte Magie-Verwundbarkeit',
+        'Lightheaded': 'Auf wackeligen Beinen',
+        'Irons of Purgatory': 'Höllenfessel',
+      },
+    },
+    {
+      'locale': 'fr',
+      'replaceSync': {
+        'twisting blaze': 'Vortex enflammé',
+        'tumultuous nexus': 'Rafale',
+        'great ball of fire': 'Ignescence',
+        'Raktapaksa': 'Raktapaksa',
+        'Ifrit': 'Ifrit',
+        'Garuda': 'Garuda',
+      },
+      'replaceText': {
+        'Wind Cutter': 'Trancheur de vent',
+        'Vacuum Slice': 'Lacération du vide',
+        'Touchdown': 'Atterrissage',
+        'Thorns': 'Lardoir',
+        'Superstorm': 'Tempête dévastatrice',
+        'Strike Spark': 'Ignescences',
+        'Storm of Fury': 'Tempête déchaînée',
+        'Spread of Fire': 'Océan de feu',
+        'Spike of Flame': 'Explosion de feu',
+        'Radiant Plume': 'Panache radiant',
+        'Occluded Front': 'Front occlus',
+        'Meteor Strike': 'Frappe de météore',
+        'Irresistible Pull': 'Force d\'aspiration',
+        'Instant Incineration': 'Uppercut enflammé',
+        'Inferno Howl': 'Rugissement ardent',
+        'Hot Foot': 'Jet d\'ignescence',
+        'Heat Burst': 'Vague de chaleur',
+        'Hands of Hell': 'Frappe purgatrice',
+        'Hands of Flame': 'Frappe enflammée',
+        'Firestorm': 'Tempête de feu',
+        'Ferostorm': 'Tempête déchaînée',
+        'Explosion': 'Explosion de vent',
+        'Eruption': 'Éruption',
+        'Downburst': 'Rafale descendante',
+        'Conflag Strike': 'Ekpurosis',
+        'Call of the Inferno': 'Mirage de chaleur',
+        'Blaze': 'Fournaise',
+        'Air Bump': 'Rafale ascendante',
+      },
+      '~effectNames': {
+        'Magic Vulnerability Up': 'Vulnérabilité magique augmentée',
+        'Lightheaded': 'Titubation',
+        'Irons of Purgatory': 'Chaîne du purgatoire',
+      },
+    },
+    {
+      'locale': 'ja',
+      'replaceSync': {
+        'twisting blaze': '火炎旋風',
+        'tumultuous nexus': '暴風球',
+        'great ball of fire': '火焔球',
+        'Raktapaksa': 'ラクタパクシャ',
+        'Ifrit': 'イフリート',
+        'Garuda': 'ガルーダ',
+      },
+      'replaceText': {
+        'Wind Cutter': 'ウィンドカッター',
+        'Vacuum Slice': 'バキュームスラッシュ',
+        'Touchdown': 'タッチダウン',
+        'Thorns': '早贄',
+        'Superstorm': 'スーパーストーム',
+        'Strike Spark': 'ファイアスパーク',
+        'Storm of Fury': 'フューリアスストーム',
+        'Spread of Fire': 'スプレッド・オブ・ファイア',
+        'Spike of Flame': '爆炎',
+        'Radiant Plume': '光輝の炎柱',
+        'Occluded Front': 'オクルーデッドフロント',
+        'Meteor Strike': 'メテオストライク',
+        'Irresistible Pull': '吸引力',
+        'Instant Incineration': '爆裂炎',
+        'Inferno Howl': '灼熱の咆哮',
+        'Hot Foot': '飛び火',
+        'Heat Burst': '熱波',
+        'Hands of Hell': '業炎拳',
+        'Hands of Flame': '火炎拳',
+        'Firestorm': 'ファイアストーム',
+        'Ferostorm': 'フィアスストーム',
+        'Explosion': '爆散',
+        'Eruption': 'エラプション',
+        'Downburst': 'ダウンバースト',
+        'Conflag Strike': 'コンフラグレーションストライク',
+        'Call of the Inferno': '陽炎召喚',
+        'Blaze': '火炎',
+        'Air Bump': 'エアーバンプ',
+      },
+      '~effectNames': {
+        'Magic Vulnerability Up': '被魔法ダメージ増加',
+        'Lightheaded': 'ふらつき',
+        'Irons of Purgatory': '煉獄の鎖',
+      },
+    },
   ],
 }];

--- a/ui/raidboss/data/05-shb/raid/e6n.js
+++ b/ui/raidboss/data/05-shb/raid/e6n.js
@@ -25,7 +25,7 @@
     },
     {
       id: 'E6N Ferostorm',
-      regex: Regexes.startsUsing({ source: ['Garuda', 'Raktapaska'], id: ['4BD[DEF]', '4BE[345]'] }),
+      regex: Regexes.startsUsing({ source: ['Garuda', 'Raktapaska'], id: ['4BD[DEF]', '4BE[345]'], capture: false }),
       infoText: {
         en: 'Avoid green nails',
       },
@@ -114,7 +114,7 @@
     },
     {
       id: 'E6N Strike Spark',
-      regex: Regexes.ability({ source: 'Ifrit', id: '4F98' }),
+      regex: Regexes.ability({ source: 'Ifrit', id: '4F98', capture: false }),
       // Run only once, because Ifrit's other jumps are not important.
       condition: function(data) {
         return !data.seenSpark;
@@ -129,7 +129,7 @@
     {
       id: 'E6N Storm Of Fury',
       // Garuda uses this ability without eruptions alongside, so she needs no warnings.
-      regex: Regexes.startsUsing({ source: 'Raktapaksa', id: '4BE6' }),
+      regex: Regexes.startsUsing({ source: 'Raktapaksa', id: '4BE6', capture: false }),
       response: Responses.stackThenSpread(),
     },
   ],

--- a/ui/raidboss/data/05-shb/raid/e6n.js
+++ b/ui/raidboss/data/05-shb/raid/e6n.js
@@ -22,7 +22,7 @@
       regex: Regexes.startsUsing({ source: 'Garuda', id: '4BD7', capture: false }),
       condition: Conditions.caresAboutMagical(),
       response: Responses.aoe(),
-    }, 
+    },
     {
       id: 'E6N Ferostorm',
       regex: Regexes.startsUsing({ source: ['Garuda', 'Raktapaska'], id: ['4BD[DEF]', '4BE[345]'] }),
@@ -114,7 +114,7 @@
     },
     {
       id: 'E6N Strike Spark',
-      regex: Regexes.ability({ source: 'Ifrit', id: '4F98'}),
+      regex: Regexes.ability({ source: 'Ifrit', id: '4F98' }),
       // Run only once, because Ifrit's other jumps are not important.
       condition: function(data) {
         return !data.seenSpark;
@@ -122,8 +122,8 @@
       alertText: {
         en: 'Move to Ifrit',
       },
-      run: function(data){
-        data.seenSpark =true;
+      run: function(data) {
+        data.seenSpark = true;
       },
     },
     {

--- a/ui/raidboss/data/05-shb/raid/e6n.txt
+++ b/ui/raidboss/data/05-shb/raid/e6n.txt
@@ -25,10 +25,11 @@ hideall "--sync--"
 81.7 "Vacuum Slice" sync /:Garuda:4BD5:/
 88.8 "Occluded Front" sync /:Garuda:4BD2:/ window 30,30
 98.3 "Irresistible Pull" sync /:Garuda:4BD6:/
-111.5 "--untargetable--" sync /22:........:Garuda:........:Garuda:00/
+111.5 "--untargetable--"
 
 # Ifrit solo
-114.0 "--targetable--" sync /22:........:Ifrit:........:Ifrit:01/ window 30,30
+114.0 "--targetable--"
+114.0 "Touchdown" sync /:Ifrit:4BE8:/ window 30,30
 129.2 "Hands Of Flame" sync /:Ifrit:4CFE:/
 143.6 "Hands Of Hell" sync /:Ifrit:4CFF:/
 152.3 "Instant Incineration" sync /:Ifrit:4BED:/ window 30,30
@@ -36,12 +37,12 @@ hideall "--sync--"
 166.1 "Strike Spark" sync /:Ifrit:4BD3:/
 177.5 "Hot Foot" sync /:Ifrit:4BEF:/
 188.2 "Inferno Howl" sync /:Ifrit:4BF1:/ window 30,30
-196.5 "--untargetable--" sync /22:........:Ifrit:........:Ifrit:00/
+196.5 "--untargetable--"
 
 
 # Garuda and Ifrit
-200.8 "--targetable--" sync /22:........:Garuda:........:Garuda:01/ window 30,30
-207.2 "Vacuum Slice" sync /:Garuda:4BD5:/
+200.8 "--targetable--"
+207.2 "Vacuum Slice" sync /:Garuda:4BD5:/ window 30,30
 209.9 "Eruption" sync /:Ifrit:4BF3:/
 209.9 "Eruption" sync /:Ifrit:4BF4:/
 213.1 "--sync--" sync /:Ifrit:4F98:/
@@ -52,12 +53,12 @@ hideall "--sync--"
 233.3 "Thorns" sync /:Garuda:4BDA:/
 237.9 "Hands Of Hell" sync /:Ifrit:4CFF:/
 245.5 "Ferostorm"# sync /:Garuda:4BD[DEF]:/
-250.2 "--untargetable--" sync /22:........:Garuda:........:Garuda:00/
+250.2 "--untargetable--"
 
 
 # Raktapaksa initial block
-267.9 "Firestorm" sync /:Raktapaksa:4BD8:/
-271.2 "--targetable--" sync/22:........:Raktapaksa:........:Raktapaksa:01/
+267.9 "Firestorm" sync /:Raktapaksa:4BD8:/ window 30,30
+271.2 "--targetable--"
 283.2 "Radiant Plume" sync /:Raktapaksa:4BF2:/
 286.2 "Ferostorm"# sync /:Raktapaksa:4BE[345]:/
 297.3 "Hands Of Flame" sync /:Raktapaksa:4CFE:/ window 30,30

--- a/ui/raidboss/data/05-shb/raid/e6n.txt
+++ b/ui/raidboss/data/05-shb/raid/e6n.txt
@@ -28,7 +28,7 @@ hideall "--sync--"
 111.5 "--untargetable--" sync /22:........:Garuda:........:Garuda:00/
 
 # Ifrit solo
-114.0 "--targetable--" sync /:Ifrit:4BE8:/ window 30,30
+114.0 "--targetable--" sync /22:........:Ifrit:........:Ifrit:01/ window 30,30
 129.2 "Hands Of Flame" sync /:Ifrit:4CFE:/
 143.6 "Hands Of Hell" sync /:Ifrit:4CFF:/
 152.3 "Instant Incineration" sync /:Ifrit:4BED:/ window 30,30

--- a/ui/raidboss/data/05-shb/raid/e6n.txt
+++ b/ui/raidboss/data/05-shb/raid/e6n.txt
@@ -13,7 +13,7 @@ hideall "--sync--"
 
 # Garuda solo
 2.0 "--sync--" sync /:Garuda:366:/ window 3,1
-13.5 "Ferostorm"# sync /:Garuda:4BDE:/
+13.5 "Ferostorm"# sync /:Garuda:4BD[DEF]:/
 20.6 "Superstorm" sync /:Garuda:4BD7:/ window 20,30
 31.4 "Air Bump" sync /:Garuda:4BD1:/
 36.8 "Thorns" sync /:Garuda:4BDA:/
@@ -25,9 +25,10 @@ hideall "--sync--"
 81.7 "Vacuum Slice" sync /:Garuda:4BD5:/
 88.8 "Occluded Front" sync /:Garuda:4BD2:/ window 30,30
 98.3 "Irresistible Pull" sync /:Garuda:4BD6:/
+111.5 "--untargetable--" sync /22:........:Garuda:........:Garuda:00/
 
 # Ifrit solo
-114.0 "Touchdown" sync /:Ifrit:4BE8:/ window 30,30
+114.0 "--targetable--" sync /:Ifrit:4BE8:/ window 30,30
 129.2 "Hands Of Flame" sync /:Ifrit:4CFE:/
 143.6 "Hands Of Hell" sync /:Ifrit:4CFF:/
 152.3 "Instant Incineration" sync /:Ifrit:4BED:/ window 30,30
@@ -35,9 +36,11 @@ hideall "--sync--"
 166.1 "Strike Spark" sync /:Ifrit:4BD3:/
 177.5 "Hot Foot" sync /:Ifrit:4BEF:/
 188.2 "Inferno Howl" sync /:Ifrit:4BF1:/ window 30,30
+196.5 "--untargetable--" sync /22:........:Ifrit:........:Ifrit:00/
+
 
 # Garuda and Ifrit
-200.9 "--sync--" sync /:Garuda:4BD0:/ window 30,30
+200.8 "--targetable--" sync /22:........:Garuda:........:Garuda:01/ window 30,30
 207.2 "Vacuum Slice" sync /:Garuda:4BD5:/
 209.9 "Eruption" sync /:Ifrit:4BF3:/
 209.9 "Eruption" sync /:Ifrit:4BF4:/
@@ -48,13 +51,15 @@ hideall "--sync--"
 228.0 "Air Bump" sync /:Garuda:4BD1:/
 233.3 "Thorns" sync /:Garuda:4BDA:/
 237.9 "Hands Of Hell" sync /:Ifrit:4CFF:/
-245.5 "Ferostorm"# sync /:Garuda:4BDF:/
+245.5 "Ferostorm"# sync /:Garuda:4BD[DEF]:/
+250.2 "--untargetable--" sync /22:........:Garuda:........:Garuda:00/
+
 
 # Raktapaksa initial block
-257.1 "--sync--" sync /:Raktapaksa:4D55:/ window 30,30
 267.9 "Firestorm" sync /:Raktapaksa:4BD8:/
+271.2 "--targetable--" sync/22:........:Raktapaksa:........:Raktapaksa:01/
 283.2 "Radiant Plume" sync /:Raktapaksa:4BF2:/
-286.2 "Ferostorm"# sync /:Raktapaksa:4BE4:/
+286.2 "Ferostorm"# sync /:Raktapaksa:4BE[345]:/
 297.3 "Hands Of Flame" sync /:Raktapaksa:4CFE:/ window 30,30
 301.1 "Heat Burst" sync /:Raktapaksa:4C1E:/
 311.2 "Eruption" sync /:Raktapaksa:4BF4:/
@@ -69,7 +74,7 @@ hideall "--sync--"
 360.4 "Conflag Strike" sync /:Raktapaksa:4BEE:/ window 30,30
 
 # Raktapaksa rotation block
-375.6 "Ferostorm"# sync /:Raktapaksa:4BE3:/
+375.6 "Ferostorm"# sync /:Raktapaksa:4BE[345]:/
 377.6 "Air Bump" sync /:Raktapaksa:4BD4:/
 382.5 "Thorns" sync /:Raktapaksa:4BDA:/ window 30,30
 390.7 "Storm Of Fury" sync /:Raktapaksa:4BE6:/
@@ -82,7 +87,7 @@ hideall "--sync--"
 433.4 "Radiant Plume" sync /:Raktapaksa:4BF2:/
 439.4 "Inferno Howl" sync /:Raktapaksa:4BF1:/ window 30,30
 
-454.6 "Ferostorm"# sync /:Raktapaksa:4BE3:/
+454.6 "Ferostorm"# sync /:Raktapaksa:4BE[345]:/
 456.6 "Air Bump" sync /:Raktapaksa:4BD4:/
 461.5 "Thorns" sync /:Raktapaksa:4BDA:/ window 30,30
 469.7 "Storm Of Fury" sync /:Raktapaksa:4BE6:/


### PR DESCRIPTION
As with E5n, most of this is shamelessly stolen from elsewhere in the repository. I think I caught all the changes necessary, but I can't test the tank/healer triggers due to not being comfortable in this content with those roles. Everything that I was able to test functions as expected. Timing on targetable/untargetable lines may need slight adjustments.

To do:

1. Math out Ifrit's jump after Strike Spark, so we can tell the user the direction instead of just a simple warning.

2. Warn the user of the surprise Eruptions alongside Enumeration + Hands of Hell. (It's going to be just complex enough to call that I'm leaving it out for now, but it's one of the MAJOR sources of deaths in pickup runs. I'm actually a little surprised Square included it in a normal-difficulty encounter.)