### PR TITLE
Raidboss: E7n minor updates

### DIFF
--- a/ui/raidboss/data/05-shb/raid/e7n.js
+++ b/ui/raidboss/data/05-shb/raid/e7n.js
@@ -130,13 +130,13 @@
       },
     },
     {
-      //Safety in case the user dies during Dark/Light Course.
+      // Safety in case the user dies during Dark/Light Course.
       id: 'E7N Color Cleanup',
       regex: Regexes.startsUsing({ source: 'The Idol Of Darkness', id: '4C39', ability: 'Away With Thee', capture: false }),
       run: function(data) {
         delete data.colorCount;
       },
-    }
+    },
   ],
   timelineReplace: [
     {

--- a/ui/raidboss/data/05-shb/raid/e7n.js
+++ b/ui/raidboss/data/05-shb/raid/e7n.js
@@ -102,7 +102,7 @@
       condition: Conditions.targetIsYou(),
       suppressSeconds: 3,
       infoText: function(data) {
-        data.colorCount = data.colorCount + 1 || 1;
+        data.colorCount = data.colorCount + 1 || 0;
         if (data.colorCount == 3) {
           delete data.colorCount;
           return;
@@ -119,7 +119,7 @@
       condition: Conditions.targetIsYou(),
       suppressSeconds: 3,
       infoText: function(data) {
-        data.colorCount = data.colorCount + 1 || 1;
+        data.colorCount = data.colorCount + 1 || 0;
         if (data.colorCount == 3) {
           delete data.colorCount;
           return;
@@ -129,6 +129,14 @@
         };
       },
     },
+    {
+      //Safety in case the user dies during Dark/Light Course.
+      id: 'E7N Color Cleanup',
+      regex: Regexes.startsUsing({ source: 'The Idol Of Darkness', id: '4C39', ability: 'Away With Thee', capture: false }),
+      run: function(data) {
+        delete data.colorCount;
+      },
+    }
   ],
   timelineReplace: [
     {

--- a/ui/raidboss/data/05-shb/raid/e7n.txt
+++ b/ui/raidboss/data/05-shb/raid/e7n.txt
@@ -53,7 +53,7 @@ hideall "--sync--"
 
 # Rotation block. 135.6 seconds
 400.0 "Empty Flood" sync /:The Idol Of Darkness:(?:4E5[46]|4C53):/ window 400,20
-408.9 "--targetable--"
+410.3 "--targetable--"
 414.4 "Unjoined Aspect" sync /:The Idol Of Darkness:4C3B:/
 419.6 "Betwixt Worlds" sync /:The Idol Of Darkness:4CF8:/
 424.6 "Words of Night" sync /:The Idol Of Darkness:4C2C:/ window 30,30


### PR DESCRIPTION
As it turns out, counting is hard. The color triggers will no longer fail to warn the user on the third application of darkness/light. The color tracking will also clean up after itself now. (I deliberately added the ability name to the cleanup trigger so it was clear what ability was being used without doing a lookup.) Also a small but significant correction to re-targeting time after the intermission.