### PR TITLE
raidboss: e8s mirror 4 uptime knockback callout

### DIFF
--- a/ui/raidboss/data/05-shb/raid/e8s.js
+++ b/ui/raidboss/data/05-shb/raid/e8s.js
@@ -352,7 +352,7 @@
       regexCn: Regexes.startsUsing({ source: '希瓦', id: '4D77', capture: false }),
       regexKo: Regexes.startsUsing({ source: '시바', id: '4D77', capture: false }),
       // This gives a warning within 1.4 seconds, so you can hit arm's length.
-      delaySeconds: 3.6,
+      delaySeconds: 8.6,
       durationSeconds: 1.4,
       response: Responses.knockback(),
     },

--- a/ui/raidboss/data/05-shb/raid/e8s.js
+++ b/ui/raidboss/data/05-shb/raid/e8s.js
@@ -351,10 +351,10 @@
       regexJa: Regexes.startsUsing({ source: 'シヴァ', id: '4D77', capture: false }),
       regexCn: Regexes.startsUsing({ source: '希瓦', id: '4D77', capture: false }),
       regexKo: Regexes.startsUsing({ source: '시바', id: '4D77', capture: false }),
-      response: Responses.knockback(),
       // This gives a warning within 1.4 seconds, so you can hit arm's length.
       delaySeconds: 3.6,
       durationSeconds: 1.4,
+      response: Responses.knockback(),
     },
     {
       id: 'E8S Wyrm\'s Lament',

--- a/ui/raidboss/data/05-shb/raid/e8s.js
+++ b/ui/raidboss/data/05-shb/raid/e8s.js
@@ -4,7 +4,7 @@
 //   Options.cactbote8sUptimeKnockbackStrat = true;
 // .. if you want cactbot to callout Mirror Mirror 4's double knockback
 // Callout happens during/after boss turns and requires <1.4s reaction time
-// to avoid both Green and Read Mirror knockbacks. 
+// to avoid both Green and Read Mirror knockbacks.
 // Example: https://clips.twitch.tv/CreativeDreamyAsparagusKlappa
 // Group splits into two groups behind boss after the jump.
 // Tanks adjust to where the Red and Green Mirror are located.

--- a/ui/raidboss/data/05-shb/raid/e8s.js
+++ b/ui/raidboss/data/05-shb/raid/e8s.js
@@ -1,5 +1,16 @@
 'use strict';
 
+// In your cactbot/user/raidboss.js file, add the line:
+//   Options.cactbote8sUptimeKnockbackStrat = true;
+// .. if you want cactbot to callout Mirror Mirror 4's double knockback
+// Callout happens during/after boss turns and requires <1.4s reaction time
+// to avoid both Green and Read Mirror knockbacks. 
+// Example: https://clips.twitch.tv/CreativeDreamyAsparagusKlappa
+// Group splits into two groups behind boss after the jump.
+// Tanks adjust to where the Red and Green Mirror are located.
+// One tank must be inbetween the party, the other closest to Greem Mirror.
+// Once Green Mirror goes off, the tanks adjust for Red Mirror.
+
 // TODO: figure out *anything* with mirrors and mirror colors
 // TODO: yell at you to take the last tower for Light Rampant if needed
 // TODO: yell at you to take the last tower for Icelit Dragonsong if needed
@@ -351,6 +362,9 @@
       regexJa: Regexes.startsUsing({ source: 'シヴァ', id: '4D77', capture: false }),
       regexCn: Regexes.startsUsing({ source: '希瓦', id: '4D77', capture: false }),
       regexKo: Regexes.startsUsing({ source: '시바', id: '4D77', capture: false }),
+      condition: function(data) {
+        return data.options.cactbote8sUptimeKnockbackStrat;
+      },
       // This gives a warning within 1.4 seconds, so you can hit arm's length.
       delaySeconds: 8.6,
       durationSeconds: 1.4,

--- a/ui/raidboss/data/05-shb/raid/e8s.js
+++ b/ui/raidboss/data/05-shb/raid/e8s.js
@@ -344,6 +344,19 @@
       response: Responses.goLeft(),
     },
     {
+      id: 'E8S Hallowed Wings Knockback',
+      regex: Regexes.startsUsing({ source: 'Shiva', id: '4D77', capture: false }),
+      regexDe: Regexes.startsUsing({ source: 'Shiva', id: '4D77', capture: false }),
+      regexFr: Regexes.startsUsing({ source: 'Shiva', id: '4D77', capture: false }),
+      regexJa: Regexes.startsUsing({ source: 'シヴァ', id: '4D77', capture: false }),
+      regexCn: Regexes.startsUsing({ source: '希瓦', id: '4D77', capture: false }),
+      regexKo: Regexes.startsUsing({ source: '시바', id: '4D77', capture: false }),
+      response: Responses.knockback(),
+      // This gives a warning within 1.4 seconds, so you can hit arm's length.
+      delaySeconds: 3.6,
+      durationSeconds: 1.4,
+    },
+    {
       id: 'E8S Wyrm\'s Lament',
       regex: Regexes.startsUsing({ source: 'Shiva', id: '4D7C', capture: false }),
       regexDe: Regexes.startsUsing({ source: 'Shiva', id: '4D7C', capture: false }),

--- a/ui/raidboss/raidboss_config.js
+++ b/ui/raidboss/raidboss_config.js
@@ -1095,5 +1095,13 @@ UserConfig.registerOptions('raidboss', {
       type: 'checkbox',
       default: false,
     },
+    {
+      id: 'cactbote8sUptimeKnockbackStrat',
+      name: {
+        en: 'e8s: enable cactbot Uptime Knockback strat',
+      },
+      type: 'checkbox',
+      default: false,
+    },
   ],
 });


### PR DESCRIPTION
- Players can dodge both knockbacks if action is used during boss' turn to attack target.
Example: https://clips.twitch.tv/CreativeDreamyAsparagusKlappa
Log with earliest: https://www.fflogs.com/reports/rYgBcTKLkNqHdPmF#fight=9
Log with latest: https://www.fflogs.com/reports/rYgBcTKLkNqHdPmF#fight=7

In this situation, tanks have to adjust for mirrors everyone else can stay put. There could be callouts for the tanks to adjust to mirror, but the timing for all this is very quick.

I suspect the latest possible reaction time is 1.4s, but the best log I have is a 1.337s.