### PR TITLE
- Add async support for triggers

### DIFF
--- a/resources/responses.js
+++ b/resources/responses.js
@@ -26,6 +26,7 @@ const triggerFunctions = [
   'id',
   'infoText',
   'preRun',
+  'promise',
   'response',
   'run',
   'sound',

--- a/test/trigger/test_trigger.js
+++ b/test/trigger/test_trigger.js
@@ -311,6 +311,7 @@ let testTriggerFieldsSorted = function(file, contents) {
     'beforeSeconds',
     'condition',
     'preRun',
+    'promise',
     'delaySeconds',
     'durationSeconds',
     'suppressSeconds',

--- a/ui/raidboss/data/00-misc/test.js
+++ b/ui/raidboss/data/00-misc/test.js
@@ -76,7 +76,7 @@
       regexDe: /(Wütender Dummy)/,
       regexCn: /愤怒的木人/,
       regexKo: /화난 나무인형/,
-      promise: function(data) {
+      promise: function(data, matches) {
         data.delayedDummyTimestampBefore = Date.now();
         let p = new Promise((res) => {
           window.setTimeout(() => {

--- a/ui/raidboss/data/00-misc/test.js
+++ b/ui/raidboss/data/00-misc/test.js
@@ -70,6 +70,29 @@
         ko: '집합',
       },
     },
+    {
+      id: 'Test Delayed Dummy',
+      regex: /(Angry Dummy)/,
+      regexDe: /(Wütender Dummy)/,
+      regexCn: /愤怒的木人/,
+      regexKo: /화난 나무인형/,
+      promise: function(data) {
+        data.delayedDummyTimestampBefore = Date.now();
+        let p = new Promise((res) => {
+          window.setTimeout(() => {
+            data.delayedDummyTimestampAfter = Date.now();
+            res();
+          }, 3000);
+        });
+        return p;
+      },
+      infoText: function(data) {
+        let elapsed = data.delayedDummyTimestampAfter - data.delayedDummyTimestampBefore;
+        return {
+          en: 'Elapsed ms: ' + elapsed,
+        };
+      },
+    },
   ],
   timelineReplace: [
     {

--- a/ui/raidboss/data/README.md
+++ b/ui/raidboss/data/README.md
@@ -70,6 +70,7 @@ Boolean, defaults to true. If true, timelines and triggers will reset automatica
   durationSeconds: 3,
   condition: function(data, matches) { return true if it should run },
   preRun: function(data, matches) { do stuff.. },
+  promise: function(data) { return promise to wait for resolution of },
   infoText: {'Info popup'},
   alertText: {'Alert Popup'},
   alarmText: {'Alarm Popup'},
@@ -138,6 +139,9 @@ Activates the trigger if the function returns `true`. If it does not return `tru
 **preRun: function(data, matches)**
 If the trigger activates, the function will run as the first action after the activation condition is met.
 
+**promise: function(data)**
+If present and a function which returns a promise, will wait for promise to resolve before continuing with trigger. This runs after `preRun` and before the `delaySeconds` delay.
+
 **run: function(data, matches)**
 If the trigger activates, the function will run as the last action before the trigger ends.
 
@@ -155,14 +159,15 @@ Trigger elements are evaluated in this order:
 
 1. condition
 2. preRun
-3. delaySeconds
-4. durationSeconds
-5. suppressSeconds
-6. infoText
-7. alertText
-8. alarmText
-9. tts
-10. run
+3. promise
+4. delaySeconds
+5. durationSeconds
+6. suppressSeconds
+7. infoText
+8. alertText
+9. alarmText
+10. tts
+11. run
 
 ## Timeline Info
 

--- a/ui/raidboss/data/README.md
+++ b/ui/raidboss/data/README.md
@@ -70,7 +70,7 @@ Boolean, defaults to true. If true, timelines and triggers will reset automatica
   durationSeconds: 3,
   condition: function(data, matches) { return true if it should run },
   preRun: function(data, matches) { do stuff.. },
-  promise: function(data) { return promise to wait for resolution of },
+  promise: function(data, matches) { return promise to wait for resolution of },
   infoText: {'Info popup'},
   alertText: {'Alert Popup'},
   alarmText: {'Alarm Popup'},
@@ -139,7 +139,7 @@ Activates the trigger if the function returns `true`. If it does not return `tru
 **preRun: function(data, matches)**
 If the trigger activates, the function will run as the first action after the activation condition is met.
 
-**promise: function(data)**
+**promise: function(data, matches)**
 If present and a function which returns a promise, will wait for promise to resolve before continuing with trigger. This runs after `preRun` and before the `delaySeconds` delay.
 
 **run: function(data, matches)**

--- a/ui/raidboss/popup-text.js
+++ b/ui/raidboss/popup-text.js
@@ -667,11 +667,20 @@ class PopupText {
 
     let promise = null;
 
-    if ('promise' in trigger && typeof trigger.promise === "function")
-      promise = trigger.promise();
+    if ('promise' in trigger) {
+      if (typeof trigger.promise === 'function') {
+        promise = trigger.promise();
+        // Make sure we actually get a Promise back from the function
+        if (Promise.resolve(promise) !== promise) {
+          console.error('Trigger ' + trigger.id + ': promise function did not return a promise');
+          promise = null;
+        }
+      } else {
+        console.error('Trigger ' + trigger.id + ': promise defined but not a function');
+      }
+    }
 
-    //Make sure we actually get a Promise back from the function
-    if (Promise.resolve(promise) !== promise) {
+    if (promise === null) {
       promise = new Promise((res) => {
         res(matches);
       });

--- a/ui/raidboss/popup-text.js
+++ b/ui/raidboss/popup-text.js
@@ -669,7 +669,7 @@ class PopupText {
 
     if ('promise' in trigger) {
       if (typeof trigger.promise === 'function') {
-        promise = trigger.promise(data);
+        promise = trigger.promise(data, matches);
         // Make sure we actually get a Promise back from the function
         if (Promise.resolve(promise) !== promise) {
           console.error('Trigger ' + trigger.id + ': promise function did not return a promise');
@@ -682,7 +682,7 @@ class PopupText {
 
     if (promise === null) {
       promise = new Promise((res) => {
-        res(matches);
+        res();
       });
     }
 

--- a/ui/raidboss/popup-text.js
+++ b/ui/raidboss/popup-text.js
@@ -669,7 +669,7 @@ class PopupText {
 
     if ('promise' in trigger) {
       if (typeof trigger.promise === 'function') {
-        promise = trigger.promise();
+        promise = trigger.promise(data);
         // Make sure we actually get a Promise back from the function
         if (Promise.resolve(promise) !== promise) {
           console.error('Trigger ' + trigger.id + ': promise function did not return a promise');
@@ -687,13 +687,7 @@ class PopupText {
     }
 
     // Allow promise to return a new set of matches
-    promise.then((pMatches) => {
-      matches = pMatches;
-
-      // Re-apply the groups logic above if we've got a new set of matches
-      if ((matches != undefined) && (matches.groups != undefined))
-        matches = matches.groups;
-
+    promise.then(() => {
       // Run immediately?
       if (!delay) {
         f();

--- a/ui/raidboss/popup-text.js
+++ b/ui/raidboss/popup-text.js
@@ -426,7 +426,7 @@ class PopupText {
     let suppress = 'suppressSeconds' in trigger ? ValueOrFunction(trigger.suppressSeconds) : 0;
     if (trigger.id && suppress > 0)
       this.triggerSuppress[trigger.id] = now + suppress * 1000;
-    let promise = 'promise' in trigger ? promise : () => {
+    let promise = 'promise' in trigger ? trigger.promise : () => {
       return new Promise((res) => {
         res(matches);
       });

--- a/ui/raidboss/popup-text.js
+++ b/ui/raidboss/popup-text.js
@@ -686,7 +686,6 @@ class PopupText {
       });
     }
 
-    // Allow promise to return a new set of matches
     promise.then(() => {
       // Run immediately?
       if (!delay) {


### PR DESCRIPTION
This PR adds support for async triggers. A trigger can define a `promise` property which should be a function which returns a `Promise`. This is in response to @quisquous comment here: <https://github.com/ngld/OverlayPlugin/pull/116#issuecomment-593735692>

An example trigger might look like this:

```javascript
{
  id: 'Test Trigger',
  regex: Regexes.ability({ id: '1234' }),
  condition: function(data, matches) {
    return true;
  },
  promise: function() {
    let p = new Promise((res) => {
      window.setTimeout(() => {
        res({
          name: "Testing",
        });
      }, 1000);
    });
  },
  infoText: function(data, matches) {
    let name = matches.name;
    return {
      en: 'Test Trigger: ' + name,
    };
  },
},
```

With the `window.setTimeout` being replaced by some other async function as needed.