### PR TITLE
Oopsy: E6N initial

### DIFF
--- a/ui/oopsyraidsy/data/05-shb/raid/e6n.js
+++ b/ui/oopsyraidsy/data/05-shb/raid/e6n.js
@@ -31,9 +31,9 @@
         return e.type != '15';
       },
       mistake: function(e) {
-        // This is a failure because it will kill non-tanks
+        // Kills non-tanks who get hit by it.
         return { type: 'fail', blame: e.targetName, text: e.abilityName };
       },
-    }
+    },
   ],
 }];

--- a/ui/oopsyraidsy/data/05-shb/raid/e6n.js
+++ b/ui/oopsyraidsy/data/05-shb/raid/e6n.js
@@ -6,9 +6,34 @@
     ko: /^희망의 낙원 에덴: 공명편 \(2\)$/,
   },
   damageWarn: {
+    '4BDA': 'Thorns', // AoE markers after Enumeration
+    '4BDD': 'Ferostorm 1',
+    '4BE0': 'Storm of Fury 1', // Circle AoE during tethers--Garuda
+    '4BE2': 'Explosion', // AoE circles, Garuda orbs
+    '4BE5': 'Ferostorm 2',
+    '4BE6': 'Storm Of Fury 2', // Circle AoE during tethers--Raktapaksa
+    '4BEC': 'Heat Burst',
+    '4BEE': 'Conflag Strike', // 270-degree frontal AoE
+    '4BF0': 'Spike Of Flame', // Orb explosions after Strike Spark
+    '4BF2': 'Radiant Plume',
+    '4BF4': 'Eruption',
   },
   damageFail: {
+    '4BD5': 'Vacuum Slice', // Dark line AoE from Garuda
+    '4BDB': 'Downburst', // Blue knockback circle. Actual knockback is unknown ability 4C20
   },
   triggers: [
+    {
+      id: 'E6N Instant Incineration',
+      damageRegex: '4BED',
+      condition: function(e) {
+        // Double taps only
+        return e.type != '15';
+      },
+      mistake: function(e) {
+        // This is a failure because it will kill non-tanks
+        return { type: 'fail', blame: e.targetName, text: e.abilityName };
+      },
+    }
   ],
 }];


### PR DESCRIPTION
Standard stuff for the most part.

Known deficiencies:

1. Storm of Fury tethers. It's going to be a bit of work to figure out overlap tracking for this one, since checking for double-taps won't work. (It's not a mistake for multiple people to be hit by an individual cone.) Currently I'm thinking of something like pre-collecting the tether targets, then collecting all cone targets, seeing whether there are duplicates, and THEN seeing whether the tether targets are *also* in that list of duplicates. A lot of code for one thing, and there's gotta be a better way.

2. No handling for Hands of Hell. I'm not really sure what we want to do with it, so I left it alone for now.

3. Ferostorm IDs might be incomplete? I'm not sure. I'm wondering whether the actual cones have only one ID, and then the different directions are two different casts. Not sure.