### PR TITLE
Oopsy: E7N Initial

### DIFF
--- a/resources/lang/cn.js
+++ b/resources/lang/cn.js
@@ -64,8 +64,8 @@ class CactbotLanguageCn extends CactbotLanguage {
       Throttle: 'FIXME',
       StaticCondensation: '蓄电',
       DamageDown: '伤害降低',
-      AstralEffect: 'Astral Effect'
-      UmbralEffect: 'Umbral Effect'
+      AstralEffect: 'Astral Effect',
+      UmbralEffect: 'Umbral Effect',
 
       // UWU
       Windburn: '裂伤',

--- a/resources/lang/cn.js
+++ b/resources/lang/cn.js
@@ -64,6 +64,8 @@ class CactbotLanguageCn extends CactbotLanguage {
       Throttle: 'FIXME',
       StaticCondensation: '蓄电',
       DamageDown: '伤害降低',
+      AstralEffect: 'Astral Effect'
+      UmbralEffect: 'Umbral Effect'
 
       // UWU
       Windburn: '裂伤',

--- a/resources/lang/de.js
+++ b/resources/lang/de.js
@@ -66,6 +66,8 @@ class CactbotLanguageDe extends CactbotLanguage {
       Throttle: 'Erstickung',
       StaticCondensation: 'Statische Ladung',
       DamageDown: 'Schaden -',
+      AstralEffect: 'Denaturation Licht',
+      UmbralEffect: 'Denaturation Dunkelheit',
 
       Windburn: 'Beißender Wind',
     });

--- a/resources/lang/en.js
+++ b/resources/lang/en.js
@@ -64,6 +64,8 @@ class CactbotLanguageEn extends CactbotLanguage {
       Throttle: 'Throttle', // 0x2bc
       StaticCondensation: 'Static Condensation',
       DamageDown: 'Damage Down',
+      AstralEffect: 'Astral Effect',
+      UmbralEffect: 'Umbral Effect',
 
       // UWU
       Windburn: 'Windburn',

--- a/resources/lang/fr.js
+++ b/resources/lang/fr.js
@@ -66,6 +66,8 @@ class CactbotLanguageFr extends CactbotLanguage {
       Throttle: 'Suffocation',
       StaticCondensation: 'Charge électrique',
       DamageDown: 'Malus de dégâts',
+      AstralEffect: 'Corruption de Lumière',
+      UmbralEffect: 'Corruption de Ténèbres',
 
       WindBurn: 'Brûlure du vent',
     });

--- a/resources/lang/ja.js
+++ b/resources/lang/ja.js
@@ -66,6 +66,8 @@ class CactbotLanguageJa extends CactbotLanguage {
       Throttle: '窒息',
       StaticCondensation: '蓄電',
       DamageDown: 'ダメージ低下',
+      AstralEffect: '偏属性：光',
+      UmbralEffect: '偏属性：闇',
 
       // UWU
       Windburn: '裂傷',

--- a/resources/lang/ko.js
+++ b/resources/lang/ko.js
@@ -64,6 +64,8 @@ class CactbotLanguageKo extends CactbotLanguage {
       Throttle: '질식',
       StaticCondensation: '축전',
       DamageDown: '주는 피해량 감소',
+      AstralEffect: 'Astral Effect'
+      UmbralEffect: 'Umbral Effect'
 
       // UWU
       Windburn: '열상',

--- a/resources/lang/ko.js
+++ b/resources/lang/ko.js
@@ -64,8 +64,8 @@ class CactbotLanguageKo extends CactbotLanguage {
       Throttle: '질식',
       StaticCondensation: '축전',
       DamageDown: '주는 피해량 감소',
-      AstralEffect: 'Astral Effect'
-      UmbralEffect: 'Umbral Effect'
+      AstralEffect: 'Astral Effect',
+      UmbralEffect: 'Umbral Effect',
 
       // UWU
       Windburn: '열상',

--- a/ui/oopsyraidsy/data/05-shb/raid/e7n.js
+++ b/ui/oopsyraidsy/data/05-shb/raid/e7n.js
@@ -37,7 +37,7 @@
       // If we don't set this up ahead of time, the Dark/Light Course triggers will fail
       // on the first two uses of Light's Course, since the Astral/Umbral properties wouldn't exist.
       id: 'E7N Debuff Setup',
-      regex: Regexes.startsUsing({ source: 'The Idol Of Darkness', id: '4C2C' }),
+      regex: Regexes.startsUsing({ source: 'The Idol Of Darkness', id: '4C2B' }),
       condition: function(e, data) {
         return !(data.hasAstral && data.hasUmbral);
       },

--- a/ui/oopsyraidsy/data/05-shb/raid/e7n.js
+++ b/ui/oopsyraidsy/data/05-shb/raid/e7n.js
@@ -66,20 +66,20 @@
       id: 'E7N Light\'s Course',
       damageRegex: ['4C3E', '4C40', '4C22', '4C3C', '4E63'],
       condition: function(e, data) {
-        return data.hasAstral[e.targetName];
+        return !data.hasUmbral[e.targetName];
       },
       mistake: function(e) {
-        return { type: 'fail', blame: e.targetName, text: e.abilityName + ' wrong buff' };
+        return { type: 'fail', blame: e.targetName, text: e.abilityName + ' wrong/no buff' };
       },
     },
     {
       id: 'E7N Darks\'s Course',
       damageRegex: ['4C3D', '4C23', '4C41', '4C43'],
       condition: function(e, data) {
-        return !data.hasAstral[e.targetName];
+        return data.hasUmbral[e.targetName];
       },
       mistake: function(e) {
-        return { type: 'fail', blame: e.targetName, text: e.abilityName + ' wrong/no buff' };
+        return { type: 'fail', blame: e.targetName, text: e.abilityName + ' wrong buff' };
       },
     },
   ],

--- a/ui/oopsyraidsy/data/05-shb/raid/e7n.js
+++ b/ui/oopsyraidsy/data/05-shb/raid/e7n.js
@@ -69,7 +69,9 @@
         return !data.hasUmbral[e.targetName];
       },
       mistake: function(e) {
-        return { type: 'fail', blame: e.targetName, text: e.abilityName + ' wrong/no buff' };
+        if (data.hasAstral[e.targetName])
+          return { type: 'fail', blame: e.targetName, text: e.abilityName + ' wrong buff' };
+        return { type: 'warn', blame: e.targetName, text: e.abilityName + ' no buff' };
       },
     },
     {

--- a/ui/oopsyraidsy/data/05-shb/raid/e7n.js
+++ b/ui/oopsyraidsy/data/05-shb/raid/e7n.js
@@ -65,13 +65,13 @@
     {
       id: 'E7N Light\'s Course',
       // Would be nice to use an array instead, as
-      // damageRegex: ['4C3E', '4C40', '4C22', '4C3C', '4E63']
+      damageRegex: ['4C3E', '4C40', '4C22', '4C3C', '4E63'],
       // rather than this awful cup of regex soup.
       // We could instead split this out into individual triggers for each ID,
       // but that seems ridiculous.
-      damageRegex: '(?:4C(?:22|40|3[CE])|4E63)',
+      // damageRegex: '(?:4C(?:22|40|3[CE])|4E63)',
       condition: function(e, data) {
-        return data.hasAstral[targetName];
+        return data.hasAstral[e.targetName];
       },
       mistake: function(e) {
         return { type: 'fail', blame: e.targetName, text: e.abilityName + ' wrong buff' };

--- a/ui/oopsyraidsy/data/05-shb/raid/e7n.js
+++ b/ui/oopsyraidsy/data/05-shb/raid/e7n.js
@@ -71,10 +71,10 @@
       // but that seems ridiculous.
       damageRegex: '(?:4C(?:22|40|3[CE])|4E63)',
       condition: function(e, data) {
-        return !data.hasUmbral[e.targetName];
+        return data.hasAstral[targetName];
       },
       mistake: function(e) {
-        return { type: 'fail', blame: e.targetName, text: e.abilityName + ' wrong/no buff' };
+        return { type: 'fail', blame: e.targetName, text: e.abilityName + ' wrong buff' };
       },
     },
     {

--- a/ui/oopsyraidsy/data/05-shb/raid/e7n.js
+++ b/ui/oopsyraidsy/data/05-shb/raid/e7n.js
@@ -64,12 +64,7 @@
     },
     {
       id: 'E7N Light\'s Course',
-      // Would be nice to use an array instead, as
       damageRegex: ['4C3E', '4C40', '4C22', '4C3C', '4E63'],
-      // rather than this awful cup of regex soup.
-      // We could instead split this out into individual triggers for each ID,
-      // but that seems ridiculous.
-      // damageRegex: '(?:4C(?:22|40|3[CE])|4E63)',
       condition: function(e, data) {
         return data.hasAstral[e.targetName];
       },
@@ -79,8 +74,7 @@
     },
     {
       id: 'E7N Darks\'s Course',
-      // damageRegex: ['4C3D', '4C23', '4C41', '4C43']
-      damageRegex: '4C(?:23|3D|4[13])',
+      damageRegex: ['4C3D', '4C23', '4C41', '4C43'],
       condition: function(e, data) {
         return !data.hasAstral[e.targetName];
       },

--- a/ui/oopsyraidsy/data/05-shb/raid/e7n.js
+++ b/ui/oopsyraidsy/data/05-shb/raid/e7n.js
@@ -6,9 +6,87 @@
     ko: /^희망의 낙원 에덴: 공명편 \(3\)$/,
   },
   damageWarn: {
+    '4C55': 'Stygian Sword', // Circle ground AoEs after False Twilight
+    '4C4C': 'Strength In Numbers 1', // Large donut ground AoEs, intermission
+    '4C4D': 'Strength In Numbers 2', // Large circle ground AoEs, intermission
   },
   damageFail: {
   },
   triggers: [
+    {
+      id: 'E7N Stygian Stake', // Laser tank buster, outside intermission phase
+      damageRegex: '4C33',
+      condition: function(e) {
+        return e.type != '15';
+      },
+      mistake: function(e) {
+        return { type: 'warn', blame: e.targetName, text: e.abilityName };
+      },
+    },
+    {
+      id: 'E5N Silver Shot', // Spread markers, intermission
+      damageRegex: '4E7D',
+      condition: function(e) {
+        return e.type != '15';
+      },
+      mistake: function(e) {
+        return { type: 'warn', blame: e.targetName, text: e.abilityName };
+      },
+    },
+    {
+      // If we don't set this up ahead of time, the Dark/Light Course triggers will fail
+      // on the first two uses of Light's Course, since the Astral/Umbral properties wouldn't exist.
+      id: 'E7N Debuff Setup',
+      regex: Regexes.startsUsing({ source: 'The Idol Of Darkness', id: '4C2C' }),
+      condition: function(e, data) {
+        return !(data.hasAstral && data.hasUmbral);
+      },
+      run: function(e, data) {
+        data.hasAstral = data.hasAstral || {};
+        data.hasUmbral = data.hasUmbral || {};
+      },
+    },
+    {
+      id: 'E7N Astral Tracking',
+      gainsEffectRegex: gLang.kEffect.AstralEffect,
+      losesEffectRegex: gLang.kEffect.AstralEffect,
+      run: function(e, data) {
+        data.hasAstral[e.targetName] = e.gains;
+      },
+    },
+    {
+      id: 'E7N Umbral Tracking',
+      gainsEffectRegex: gLang.kEffect.UmbralEffect,
+      losesEffectRegex: gLang.kEffect.UmbralEffect,
+      run: function(e, data) {
+        data.hasUmbral[e.targetName] = e.gains;
+      },
+    },
+    {
+      id: 'E7N Light\'s Course',
+      // Would be nice to use an array instead, as
+      // damageRegex: ['4C3E', '4C40', '4C22', '4C3C', '4E63']
+      // rather than this awful cup of regex soup.
+      // We could instead split this out into individual triggers for each ID,
+      // but that seems ridiculous.
+      damageRegex: '(?:4C(?:22|40|3[CE])|4E63)',
+      condition: function(e, data) {
+        return !data.hasUmbral[e.targetName];
+      },
+      mistake: function(e) {
+        return { type: 'fail', blame: e.targetName, text: e.abilityName + ' wrong/no buff' };
+      },
+    },
+    {
+      id: 'E7N Darks\'s Course',
+      // damageRegex: ['4C3D', '4C23', '4C41', '4C43']
+      damageRegex: '4C(?:23|3D|4[13])',
+      condition: function(e, data) {
+        return !data.hasAstral[e.targetName];
+      },
+      mistake: function(e) {
+        return { type: 'fail', blame: e.targetName, text: e.abilityName + ' wrong/no buff' };
+      },
+    },
   ],
 }];

--- a/ui/oopsyraidsy/oopsyraidsy.js
+++ b/ui/oopsyraidsy/oopsyraidsy.js
@@ -986,15 +986,15 @@ class DamageTracker {
       for (let j = 0; j < set.triggers.length; ++j) {
         let trigger = set.triggers[j];
         if ('regex' in trigger) {
-          trigger.regex = Regexes.parse(trigger.regex);
+          trigger.regex = Regexes.parse(Regexes.anyOf(trigger.regex));
           this.generalTriggers.push(trigger);
         }
         if ('damageRegex' in trigger) {
-          trigger.idRegex = Regexes.parse('^' + trigger.damageRegex + '$');
+          trigger.idRegex = Regexes.parse('^' + Regexes.anyOf(trigger.damageRegex) + '$');
           this.damageTriggers.push(trigger);
         }
         if ('abilityRegex' in trigger) {
-          trigger.idRegex = Regexes.parse('^' + trigger.abilityRegex + '$');
+          trigger.idRegex = Regexes.parse('^' + Regexes.anyOf(trigger.abilityRegex) + '$');
           this.abilityTriggers.push(trigger);
         }
         if ('gainsEffectRegex' in trigger) {
@@ -1006,7 +1006,7 @@ class DamageTracker {
           this.effectTriggers.push(trigger);
         }
         if ('healRegex' in trigger) {
-          trigger.idRegex = Regexes.parse('^' + trigger.healRegex + '$');
+          trigger.idRegex = Regexes.parse('^' + Regexes.anyOf(trigger.healRegex) + '$');
           this.healTriggers.push(trigger);
         }
       }


### PR DESCRIPTION
There aren't a lot of mistakes to be made in this encounter either. (Or, more properly, there are only a LOT of variations of a few categories.)

I'm really not happy with the handling for Dark's/Light's Course. There's gotta be a better way than spending five(!) triggers on two mechanics. However, I'm hesitant to move any of that functionality in-line since we tend to keep things separated elsewhere in the repository. Improvements to this mess would be welcome. (Also, anything we do here "should" be a suitable drop-in for Savage once the ability IDs are switched out.)

Another thing that could use improvement, as I mentioned in-line, is that I don't like the regex soup I used to check for damage events on Course casts. Should I have used the `regex: Regexes.ability()` construction here instead? Not sure how that all interacts with Oopsy. Or did we want literally a trigger per ID?

I'm also planning to improve this by having a check for each player's position when the stun from Away With Thee wears off. Unlike most "can take you off the platform" mechanics, it (seems to me it) should be definite whether the player's teleport left them on the platform or not. (I need to test further, but I think the platform coordinates are 80,80-120,120, with origin at northwest off the platform. Or I could have been totally misreading the log lines when I checked last night. It was late, and Daylight Saving is horrible.) Maybe someday the log lines can tell us "fell off" directly. A human can dream...