### PR TITLE
Fix issue with async trigger promise call not referencing this

### DIFF
--- a/ui/raidboss/popup-text.js
+++ b/ui/raidboss/popup-text.js
@@ -669,7 +669,7 @@ class PopupText {
 
     if ('promise' in trigger) {
       if (typeof trigger.promise === 'function') {
-        promise = trigger.promise(data, matches);
+        promise = trigger.promise(this.data, matches);
         // Make sure we actually get a Promise back from the function
         if (Promise.resolve(promise) !== promise) {
           console.error('Trigger ' + trigger.id + ': promise function did not return a promise');


### PR DESCRIPTION
This PR is to fix a bug found with the new async trigger functionality while testing my e6s football trigger. The bug only happens if a trigger has a `promise` function.