### PR TITLE
Raidboss: E7N additional timeline syncs

### DIFF
--- a/ui/raidboss/data/05-shb/raid/e7n.txt
+++ b/ui/raidboss/data/05-shb/raid/e7n.txt
@@ -13,11 +13,11 @@ hideall "--sync--"
 0.0 "--sync--" sync /:Engage!/ window 0,1
 3.8 "--sync--" sync /:The Idol Of Darkness:4C50:/ window 3,1
 12.8 "Empty Wave" sync /:The Idol Of Darkness:4C52:/ window 12,30
-25.0 "Unshadowed Stake" sync /:The Idol Of Darkness:4C51:/
-37.8 "Words of Motion" sync /:The Idol Of Darkness:4C2B:/
+25.0 "Unshadowed Stake" sync /:The Idol Of Darkness:4C51:/ window 25,30
+37.8 "Words of Motion" sync /:The Idol Of Darkness:4C2B:/ window 37.8, 30
 49.6 "Light's Course" # sync /:Unforgiven Idolatry:4C3C:/
 52.6 "Light's Course" # sync /:Unforgiven Idolatry:4C3C:/
-55.5 "Betwixt Worlds" sync /:The Idol Of Darkness:4CF8:/ window 20,20
+55.5 "Betwixt Worlds" sync /:The Idol Of Darkness:4CF8:/ window 55.5,20
 72.7 "Light's Course" # sync /:Unforgiven Idolatry:(?:4E63|4C3C):/
 75.7 "Light's Course" # sync /:Unforgiven Idolatry:(?:4E63|4C3C):/
 78.7 "Light's Course" # sync /:Unforgiven Idolatry:4C40:/
@@ -27,7 +27,7 @@ hideall "--sync--"
 107.9 "Light's Course" # sync /:Unforgiven Idolatry:(?:4E63|4C3C):/
 110.8 "Light's Course" # sync /:Unforgiven Idolatry:4C40:/
 113.8 "Light's Course" # sync /:Unforgiven Idolatry:4C40:/
-124.6 "Away with Thee" sync /:The Idol Of Darkness:4C39:/ window 30,30
+124.6 "Away with Thee" sync /:The Idol Of Darkness:4C39:/ window 124.6,30
 141.8 "False Twilight" sync /:The Idol Of Darkness:4C59:/
 145.9 "Stygian Sword" sync /:The Idol Of Darkness:4C55:/
 150.9 "Silver Sledge" sync /:The Idol Of Darkness:4C54:/
@@ -44,7 +44,7 @@ hideall "--sync--"
 # Intermission block
 226.3 "--targetable--"
 236.8 "Away with Thee" sync /:The Idol Of Darkness:(?:4C39|4E7E):/ window 30,30
-251.7 "Strength in Numbers" sync /:Idolatry:4C4[CD]:/
+251.7 "Strength in Numbers" sync /:Idolatry:4C4[CD]:/ window 251.7,5
 262.3 "Silver Shot" sync /:The Idol Of Darkness:4E7[CD]:/
 270.3 "Silver Shot" sync /:The Idol Of Darkness:4E7[CD]:/
 271.7 "Strength in Numbers" sync /:Idolatry:4C4[CD]:/

--- a/ui/raidboss/data/05-shb/raid/e7n.txt
+++ b/ui/raidboss/data/05-shb/raid/e7n.txt
@@ -11,10 +11,10 @@ hideall "--sync--"
 
 # Opening block
 0.0 "--sync--" sync /:Engage!/ window 0,1
-3.8 "--sync--" sync /:The Idol Of Darkness:4C50:/ window 3,1
-12.8 "Empty Wave" sync /:The Idol Of Darkness:4C52:/ window 12,30
+3.8 "--sync--" sync /:The Idol Of Darkness:4C50:/ window 3.8,1
+12.8 "Empty Wave" sync /:The Idol Of Darkness:4C52:/ window 12.8,30
 25.0 "Unshadowed Stake" sync /:The Idol Of Darkness:4C51:/ window 25,30
-37.8 "Words of Motion" sync /:The Idol Of Darkness:4C2B:/ window 37.8, 30
+37.8 "Words of Motion" sync /:The Idol Of Darkness:4C2B:/ window 37.8,30
 49.6 "Light's Course" # sync /:Unforgiven Idolatry:4C3C:/
 52.6 "Light's Course" # sync /:Unforgiven Idolatry:4C3C:/
 55.5 "Betwixt Worlds" sync /:The Idol Of Darkness:4CF8:/ window 55.5,20

--- a/ui/raidboss/data/05-shb/raid/e7n.txt
+++ b/ui/raidboss/data/05-shb/raid/e7n.txt
@@ -13,11 +13,11 @@ hideall "--sync--"
 0.0 "--sync--" sync /:Engage!/ window 0,1
 3.8 "--sync--" sync /:The Idol Of Darkness:4C50:/ window 3.8,1
 12.8 "Empty Wave" sync /:The Idol Of Darkness:4C52:/ window 12.8,30
-25.0 "Unshadowed Stake" sync /:The Idol Of Darkness:4C51:/ window 25,30
-37.8 "Words of Motion" sync /:The Idol Of Darkness:4C2B:/ window 37.8,30
+25.0 "Unshadowed Stake" sync /:The Idol Of Darkness:4C51:/
+37.8 "Words of Motion" sync /:The Idol Of Darkness:4C2B:/ window 30,30
 49.6 "Light's Course" # sync /:Unforgiven Idolatry:4C3C:/
 52.6 "Light's Course" # sync /:Unforgiven Idolatry:4C3C:/
-55.5 "Betwixt Worlds" sync /:The Idol Of Darkness:4CF8:/ window 55.5,20
+55.5 "Betwixt Worlds" sync /:The Idol Of Darkness:4CF8:/ window 20,20
 72.7 "Light's Course" # sync /:Unforgiven Idolatry:(?:4E63|4C3C):/
 75.7 "Light's Course" # sync /:Unforgiven Idolatry:(?:4E63|4C3C):/
 78.7 "Light's Course" # sync /:Unforgiven Idolatry:4C40:/
@@ -27,7 +27,7 @@ hideall "--sync--"
 107.9 "Light's Course" # sync /:Unforgiven Idolatry:(?:4E63|4C3C):/
 110.8 "Light's Course" # sync /:Unforgiven Idolatry:4C40:/
 113.8 "Light's Course" # sync /:Unforgiven Idolatry:4C40:/
-124.6 "Away with Thee" sync /:The Idol Of Darkness:4C39:/ window 124.6,30
+124.6 "Away with Thee" sync /:The Idol Of Darkness:4C39:/ window 30,30
 141.8 "False Twilight" sync /:The Idol Of Darkness:4C59:/
 145.9 "Stygian Sword" sync /:The Idol Of Darkness:4C55:/
 150.9 "Silver Sledge" sync /:The Idol Of Darkness:4C54:/

--- a/ui/raidboss/data/05-shb/raid/e7n.txt
+++ b/ui/raidboss/data/05-shb/raid/e7n.txt
@@ -43,7 +43,7 @@ hideall "--sync--"
 
 # Intermission block
 226.3 "--targetable--"
-236.8 "Away with Thee" sync /:The Idol Of Darkness:(?:4C39|4E7E):/ window 30,30
+236.8 "Away with Thee" sync /:The Idol Of Darkness:(4C39|4E7E):/ window 30,30
 251.7 "Strength in Numbers" sync /:Idolatry:4C4[CD]:/ window 251.7,5
 262.3 "Silver Shot" sync /:The Idol Of Darkness:4E7[CD]:/
 270.3 "Silver Shot" sync /:The Idol Of Darkness:4E7[CD]:/


### PR DESCRIPTION
I've noticed this one seems to be *very* inconsistent on whether or not it starts. I think it's because I initially put down slightly narrower starting windows than I should have. After the changes, it seems much happier. (The post-intermission rotation block is already fairly well covered for syncs, and I've never noticed any issues there.)