### PR TITLE
Docs: Updates to timeline guide

### DIFF
--- a/docs/TimelineGuide.md
+++ b/docs/TimelineGuide.md
@@ -5,7 +5,7 @@ primarily for cactbot.
 
 ![import screenshot](images/timelineguide_timeline.png)
 
-Cactbot uses the [raidboss module](https://github.com/quisquous/cactbot#raidboss-module)
+cactbot uses the [raidboss module](https://github.com/quisquous/cactbot#raidboss-module)
 for triggers and timelines.
 These are combined together so that you can make triggers that are based on actions
 or triggers that are based on timelines themselves.
@@ -46,7 +46,7 @@ That plugin is now part of Hojoring.
 
 There's also an older [kaizoban](https://github.com/090/act_timeline/releases) version of the plugin that some people have used that predates anoyetta's work.
 
-Cactbot timeline files were originally intended to be backwards compatible with these,
+cactbot timeline files were originally intended to be backwards compatible with these,
 and so cactbot-specific extensions are injected later from the triggers file.
 
 ## Timeline File Syntax
@@ -213,7 +213,7 @@ This has two purposes.
 The first purpose is for tools, to autogenerate regular expression translations for triggers.
 
 The second purpose is for timelines at runtime.
-Cactbot will use the `replaceSync` section to auto-replace anything inside a `sync /text`/ on a timeline line,
+cactbot will use the `replaceSync` section to auto-replace anything inside a `sync /text`/ on a timeline line,
 and the `replaceText` section to auto-replace anything inside the ability text.
 
 These do not match the entire line (that is, they are non-greedy) by default.
@@ -228,7 +228,7 @@ This is pretty straightforward and only requires one person to test, so is a goo
 
 The first step in making a timeline is generating a few ACT logs.
 
-Cactbot will also let you make timelines from fflogs clears, but this drops many log lines.
+cactbot will also let you make timelines from fflogs clears, but this drops many log lines.
 In particular, you can't get rp text lines, the text for the zone sealing/unsealing, and new combatants.
 
 Once you've run the combat, you'll have generated a couple of [network log files](LogGuide.md#network-log-lines).
@@ -1052,7 +1052,7 @@ hideall "--sync--"
 
 ### Testing Timelines
 
-Cactbot has a testing tool called **util/test_timeline.py** that can
+cactbot has a testing tool called **util/test_timeline.py** that can
 test a network log file or an fflogs fight against an existing timeline.
 
 The test tool will tell you when a sync in your timeline is not matched against the fight,

--- a/docs/TimelineGuide.md
+++ b/docs/TimelineGuide.md
@@ -87,11 +87,11 @@ You can use `duration` to show the action for that length of time.
 It does not need a sync to do this.
 
 `window Number,Number` is the time frame in which to consider the sync.
-By default, if `window` is not specified, then it is the
-same as specifying `window 5,5`.  In other words,
-5 seconds before the ability time and 5 seconds after.
+By default, if `window` is not specified, cactbot considers it the
+same as specifying `window 2.5,2.5`.  In other words,
+2.5 seconds before the ability time and 2.5 seconds after.
 As an example, for the line `3118.9 "Lancing Bolt" sync /:Raiden:3876:/`,
-if the regular expression `/:Raiden:3876:/` is encountered anywhere between 3115.9 and 3123.9
+if the regular expression `/:Raiden:3876:/` is encountered anywhere between 3116.4 and 3121.4
 then it will resync the timeline playback to 3118.9.
 Often timelines will use very large windows for unique abilities,
 to make sure that timelines sync to the right place even if started mid-fight.
@@ -144,7 +144,8 @@ These are guidelines that cactbot tries to follow for timelines.
 
 * add syncs for everything possible
 * always add an Engage! entry, but add syncs in case there's no /countdown
-* if the first boss action is an auto, add a sync to start the timeline asap
+* if the first boss action is an auto-attack, add a sync to start the timeline asap.
+(Note that sometimes boss auto-attacks are not literally "Attack"!)
 * include the command line used to generate the timeline in a comment at the top
 * prefer actions for syncs over rp text, but rp text syncs if that's the only option
 * if you do sync a phase with rp text, add a large window sync for an action
@@ -155,7 +156,8 @@ These are guidelines that cactbot tries to follow for timelines.
 * do not put any triggers or tts or alerts in the timeline file itself
 * use [timeline triggers](#timeline-triggers) for any alerts
 * add at least a 30 second lookahead window for loops
-* remove syncs from any abilities that are within 7 seconds of each other
+* comment out syncs from any abilities that are within 7 seconds of each other
+(This preserves the ability ID for future maintainers.)
 
 ## Timeline Triggers
 
@@ -211,10 +213,11 @@ This has two purposes.
 The first purpose is for tools, to autogenerate regular expression translations for triggers.
 
 The second purpose is for timelines at runtime.
-cactbot will use the `replaceSync` section to auto-replace anything inside a `sync /text`/ on a timeline line and the `replaceText` section to auto-replace anything inside the ability text.
+cactbot will use the `replaceSync` section to auto-replace anything inside a `sync /text`/ on a timeline line,
+and the `replaceText` section to auto-replace anything inside the ability text.
 
-These do not match the entire line by default.
-So, some care is needed to make sure that replacements are not overzealous.
+These do not match the entire line (that is, they are non-greedy) by default.
+Care is needed to make sure that replacements are not overzealous.
 
 ## Example Timeline Creation
 

--- a/docs/TimelineGuide.md
+++ b/docs/TimelineGuide.md
@@ -216,7 +216,7 @@ The second purpose is for timelines at runtime.
 cactbot will use the `replaceSync` section to auto-replace anything inside a `sync /text`/ on a timeline line,
 and the `replaceText` section to auto-replace anything inside the ability text.
 
-These do not match the entire line (that is, they are non-greedy) by default.
+These match only the exact text of the regex within the line, not the entire line.
 Care is needed to make sure that replacements are not overzealous.
 
 ## Example Timeline Creation

--- a/docs/TimelineGuide.md
+++ b/docs/TimelineGuide.md
@@ -401,8 +401,10 @@ python util/make_timeline.py -f CapeWestwind.log -s 18:42:23.614 -e 18:49:22.934
 398.1 "Firebomb" sync /:Rhitahtyn sas Arvina:476:/
 402.4 "Winds Of Tartarus" sync /:Rhitahtyn sas Arvina:472:/
 ```
+
 (Note that you can also use the `-lf` parameter to list the encounters in the combat log.
-```
+
+```bash
 python make_timeline.py -f CapeWestwind.log -lf
 1. 02:03:44.018 02:16:53.632 Cape Westwind
 2. 18:32:52.981 18:36:14.086 Cape Westwind
@@ -411,6 +413,7 @@ python make_timeline.py -f CapeWestwind.log -lf
 5. 19:29:42.265 19:36:22.437 Cape Westwind
 6. 19:40:20.606 19:46:44.342 Cape Westwind
 ```
+
 From here, you can then rerun the command with the number of the encounter you want to use,
 as `-lf 3`.)
 

--- a/docs/TimelineGuide.md
+++ b/docs/TimelineGuide.md
@@ -5,7 +5,7 @@ primarily for cactbot.
 
 ![import screenshot](images/timelineguide_timeline.png)
 
-cactbot uses the [raidboss module](https://github.com/quisquous/cactbot#raidboss-module)
+Cactbot uses the [raidboss module](https://github.com/quisquous/cactbot#raidboss-module)
 for triggers and timelines.
 These are combined together so that you can make triggers that are based on actions
 or triggers that are based on timelines themselves.
@@ -46,7 +46,7 @@ That plugin is now part of Hojoring.
 
 There's also an older [kaizoban](https://github.com/090/act_timeline/releases) version of the plugin that some people have used that predates anoyetta's work.
 
-cactbot timeline files were originally intended to be backwards compatible with these,
+Cactbot timeline files were originally intended to be backwards compatible with these,
 and so cactbot-specific extensions are injected later from the triggers file.
 
 ## Timeline File Syntax
@@ -213,7 +213,7 @@ This has two purposes.
 The first purpose is for tools, to autogenerate regular expression translations for triggers.
 
 The second purpose is for timelines at runtime.
-cactbot will use the `replaceSync` section to auto-replace anything inside a `sync /text`/ on a timeline line,
+Cactbot will use the `replaceSync` section to auto-replace anything inside a `sync /text`/ on a timeline line,
 and the `replaceText` section to auto-replace anything inside the ability text.
 
 These do not match the entire line (that is, they are non-greedy) by default.
@@ -228,7 +228,7 @@ This is pretty straightforward and only requires one person to test, so is a goo
 
 The first step in making a timeline is generating a few ACT logs.
 
-cactbot will also let you make timelines from fflogs clears, but this drops many log lines.
+Cactbot will also let you make timelines from fflogs clears, but this drops many log lines.
 In particular, you can't get rp text lines, the text for the zone sealing/unsealing, and new combatants.
 
 Once you've run the combat, you'll have generated a couple of [network log files](LogGuide.md#network-log-lines).
@@ -1037,7 +1037,7 @@ hideall "--sync--"
 
 ### Testing Timelines
 
-cactbot has a testing tool called **util/test_timeline.py** that can
+Cactbot has a testing tool called **util/test_timeline.py** that can
 test a network log file or an fflogs fight against an existing timeline.
 
 The test tool will tell you when a sync in your timeline is not matched against the fight,

--- a/docs/TimelineGuide.md
+++ b/docs/TimelineGuide.md
@@ -401,6 +401,18 @@ python util/make_timeline.py -f CapeWestwind.log -s 18:42:23.614 -e 18:49:22.934
 398.1 "Firebomb" sync /:Rhitahtyn sas Arvina:476:/
 402.4 "Winds Of Tartarus" sync /:Rhitahtyn sas Arvina:472:/
 ```
+(Note that you can also use the `-lf` parameter to list the encounters in the combat log.
+```
+python make_timeline.py -f CapeWestwind.log -lf
+1. 02:03:44.018 02:16:53.632 Cape Westwind
+2. 18:32:52.981 18:36:14.086 Cape Westwind
+3. 18:42:23.614 18:49:22.934 Cape Westwind
+4. 18:57:09.114 19:10:13.200 Cape Westwind
+5. 19:29:42.265 19:36:22.437 Cape Westwind
+6. 19:40:20.606 19:46:44.342 Cape Westwind
+```
+From here, you can then rerun the command with the number of the encounter you want to use,
+as `-lf 3`.)
 
 This isn't really a workable timeline yet, but it's a start.
 Paste this into **ui/raidboss/data/timelines/cape_westwind.txt**.
@@ -1051,6 +1063,7 @@ adjusting timelines to be more accurate.
 Here's an example.
 The `-t` parameter here refers to the file name of the timeline you want to test against
 in the **ui/raidboss/data/timelines** folder, minus the .txt extension.
+(As with `make_timeline`, you can use the `-lf` parameter to list encounters.)
 
 ```bash
 $ python util/test_timeline.py -f CapeWestwind.log -s 18:42:23.614 -e 18:49:22.


### PR DESCRIPTION
This update contains three independent elements:

1. Changed the information on sync windows to reflect current usage.
2. A throwaway capitalization change if the word "cactbot" appears as the first word of a sentence. (It doesn't really matter, but I was editing the file, so in it went.)
3. Information on `-lf`. Best to have that documented in this file.

(Maybe we should expand the command line arguments information into its own section, since it cuts across both of the timeline utilities in the guide?)