### PR TITLE
raidboss: have delaySeconds in triggers run before promise

### DIFF
--- a/test/trigger/test_trigger.js
+++ b/test/trigger/test_trigger.js
@@ -311,11 +311,12 @@ let testTriggerFieldsSorted = function(file, contents) {
     'beforeSeconds',
     'condition',
     'preRun',
-    'promise',
     'delaySeconds',
     'durationSeconds',
     'suppressSeconds',
     // This is where the delay happens.
+    'promise',
+    // This is where the promise delay happens.
     'sound',
     'soundVolume',
     'response',

--- a/ui/raidboss/data/00-misc/test.js
+++ b/ui/raidboss/data/00-misc/test.js
@@ -76,6 +76,8 @@
       regexDe: /(Wütender Dummy)/,
       regexCn: /愤怒的木人/,
       regexKo: /화난 나무인형/,
+      // Add in a huge delay to make it obvious the delay runs before promise.
+      delaySeconds: 10,
       promise: function(data, matches) {
         data.delayedDummyTimestampBefore = Date.now();
         let p = new Promise((res) => {

--- a/ui/raidboss/data/README.md
+++ b/ui/raidboss/data/README.md
@@ -155,19 +155,28 @@ object, e.g. instead of returning 'Get Out', they can return {en: 'Get Out', fr:
 instead.  Fields can also return a function that return a localized object as well.  If the current locale
 does not exist in the object, the 'en' result will be returned.
 
-Trigger elements are evaluated in this order:
+Trigger elements are evaluated in this order, and must be listed in this order:
 
-1. condition
-2. preRun
-3. promise
-4. delaySeconds
-5. durationSeconds
-6. suppressSeconds
-7. infoText
-8. alertText
-9. alarmText
-10. tts
-11. run
+- id
+- disabled
+- regex (and regexDe, regexFr, etc)
+- beforeSeconds (for timelineTriggers)
+- condition
+- preRun
+- delaySeconds
+- durationSeconds
+- suppressSeconds
+- (the delaySeconds occurs here)
+- promise
+- (awaiting the promise occurs here)
+- sound
+- soundVolume
+- response
+- alarmText
+- infoText
+- groupTTS
+- tts
+- run
 
 ## Timeline Info
 


### PR DESCRIPTION
In particular, delaySeconds runs, and the promise trigger field itself is not evaluated until after the delaySeconds.

Requested in #1269.