### PR TITLE
Docs: Small addition to Raidboss readme

### DIFF
--- a/docs/RaidbossGuide.md
+++ b/docs/RaidbossGuide.md
@@ -74,16 +74,11 @@ Boolean, defaults to true. If true, timelines and triggers will reset automatica
   promise: function(data, matches) { return promise to wait for resolution of },
   sound: '',
   soundVolume: 1,
-  response: {
-    alarmText: {'Alarm Popup'},
-    alertText: {'Alert Popup'},
-    infoText: {'Info Popup'},
-    tts: {'TTS text'},
-  },
+  response: Responses.doSomething(severity),
   alarmText: {en: 'Alarm Popup'},
   alertText: {en: 'Alert Popup'},
   infoText: {en: 'Info Popup'},
-  tts: {'TTS text'},
+  tts: {en: 'TTS text'},
   run: function(data, matches) { do stuff.. },
 },
 ```


### PR DESCRIPTION
I'm so sorry, that bit about handling the `response` element didn't actually make it in, I was assuming it was still in question. This actually adds it, as well as localizing the `tts` element.