### PR TITLE
e8s: Add "Sharingan/Ayatori" Light Rampant strat

### DIFF
--- a/ui/raidboss/data/05-shb/raid/e8s.js
+++ b/ui/raidboss/data/05-shb/raid/e8s.js
@@ -322,11 +322,12 @@
       id: 'E8S Refulgent Chain',
       regex: Regexes.tether({ id: '006E' }),
       condition: function(data, matches) {
-        if (data.options.cactbote8sLightRampantStrat === undefined || data.options.cactbote8sLightRampantStrat === 'None')
+        if (data.options.cactbote8sLightRampantStrat === undefined || data.options.cactbote8sLightRampantStrat === 'none')
           return data.me == matches.source;
 
         if (data.options.cactbote8sLightRampantStrat === 'sharingan') {
-          data.rampant = data.rampant || {
+          data.rampant = data.rampant || {};
+          data.rampant.chain = data.rampant.chain || {
             chains: {},
             total: 0,
             meChain: false,
@@ -334,44 +335,44 @@
             chainSwapDps: 'Stay',
           };
           if (data.party.isTank(matches.source)) {
-            data.rampant.chains.tank = matches;
+            data.rampant.chain.chains.tank = matches;
           } else {
             if (data.party.isHealer(matches.source)) {
-              data.rampant.chains.healer = matches;
+              data.rampant.chain.chains.healer = matches;
             } else {
-              if (data.rampant.chains.dps1 === undefined)
-                data.rampant.chains.dps1 = matches;
+              if (data.rampant.chain.chains.dps1 === undefined)
+                data.rampant.chain.chains.dps1 = matches;
               else
-                data.rampant.chains.dps2 = matches;
+                data.rampant.chain.chains.dps2 = matches;
             }
             if (data.party.isTank(matches.target))
-              data.rampant.chains.tankReverse = matches;
+              data.rampant.chain.chains.tankReverse = matches;
           }
-          ++data.rampant.total;
-          data.rampant.meChain = data.rampant.meChain || data.me == matches.source;
-          if (data.rampant.total===4) {
+          ++data.rampant.chain.total;
+          data.rampant.chain.meChain = data.rampant.chain.meChain || data.me == matches.source;
+          if (data.rampant.chain.total===4) {
             // First figure out which DPS is in which corner
             // So we can ensure dps1 is southwest and dps2 is southeast
             let meleePriority = ['MNK', 'DRG', 'NIN', 'SAM'];
             let rangedPriority = ['BRD', 'MCH', 'DNC', 'BLM', 'SMN', 'RDM'];
-            let dps1Role = data.party.jobName(data.rampant.chains.dps1.source);
-            let dps2Role = data.party.jobName(data.rampant.chains.dps2.source);
+            let dps1Role = data.party.jobName(data.rampant.chain.chains.dps1.source);
+            let dps2Role = data.party.jobName(data.rampant.chain.chains.dps2.source);
             let dps1Priority = meleePriority.indexOf(dps1Role);
             let dps2Priority = meleePriority.indexOf(dps2Role);
             if (dps1Priority >= 0 && dps2Priority >= 0) {
               // Both melee, so go on priority
               if (dps1Priority > dps2Priority) {
                 // Swap, they're out of order
-                let tmp = data.rampant.chains.dps1;
-                data.rampant.chains.dps1 = data.rampant.chains.dps2;
-                data.rampant.chains.dps2 = tmp;
+                let tmp = data.rampant.chain.chains.dps1;
+                data.rampant.chain.chains.dps1 = data.rampant.chain.chains.dps2;
+                data.rampant.chain.chains.dps2 = tmp;
               }
             } else if (dps1Priority >= 0 || dps2Priority >= 0) {
               if (dps2Priority >= 0) {
                 // Swap, they're out of order
-                let tmp = data.rampant.chains.dps1;
-                data.rampant.chains.dps1 = data.rampant.chains.dps2;
-                data.rampant.chains.dps2 = tmp;
+                let tmp = data.rampant.chain.chains.dps1;
+                data.rampant.chain.chains.dps1 = data.rampant.chain.chains.dps2;
+                data.rampant.chain.chains.dps2 = tmp;
               }
             } else {
               // Both ranged, so go on priority
@@ -379,41 +380,41 @@
               dps2Priority = rangedPriority.indexOf(dps2Role);
               if (dps1Priority > dps2Priority) {
                 // Swap, they're out of order
-                let tmp = data.rampant.chains.dps1;
-                data.rampant.chains.dps1 = data.rampant.chains.dps2;
-                data.rampant.chains.dps2 = tmp;
+                let tmp = data.rampant.chain.chains.dps1;
+                data.rampant.chain.chains.dps1 = data.rampant.chain.chains.dps2;
+                data.rampant.chain.chains.dps2 = tmp;
               }
             }
             // All positions based on tank tethers
             let tankTether1 = (
-              data.rampant.chains.tank.target === data.rampant.chains.healer.source ? 'NE' : (
-                data.rampant.chains.tank.target === data.rampant.chains.dps1.source ? 'SW' : 'SE'
+              data.rampant.chain.chains.tank.target === data.rampant.chain.chains.healer.source ? 'NE' : (
+                data.rampant.chain.chains.tank.target === data.rampant.chain.chains.dps1.source ? 'SW' : 'SE'
               )
             );
             let tankTether2 = (
-              data.rampant.chains.tankReverse.source === data.rampant.chains.healer.target ? 'NE' : (
-                data.rampant.chains.tankReverse.source === data.rampant.chains.dps1.target ? 'SW' : 'SE'
+              data.rampant.chain.chains.tankReverse.source === data.rampant.chain.chains.healer.target ? 'NE' : (
+                data.rampant.chain.chains.tankReverse.source === data.rampant.chain.chains.dps1.target ? 'SW' : 'SE'
               )
             );
             if ((tankTether1 === 'NE' && tankTether2 === 'SW') ||
                 (tankTether1 === 'SW' && tankTether2 === 'NE')) {
               // If the tank is tethered to NE and SW (makes a box)
               // Tank swaps with SW to make bowtie
-              data.rampant.chainSwapTank = 'SW';
-              data.rampant.chainSwapDps = data.rampant.chains.dps1.source;
+              data.rampant.chain.chainSwapTank = 'SW';
+              data.rampant.chain.chainSwapDps = data.rampant.chain.chains.dps1.source;
             } else if ((tankTether1 === 'NE' && tankTether2 === 'SE') ||
                 (tankTether1 === 'SE' && tankTether2 === 'NE')) {
               // If the tank is tethered to NE and SE (makes an hourglass)
               // Tank swaps with SE to make bowtie
-              data.rampant.chainSwapTank = 'SE';
-              data.rampant.chainSwapDps = data.rampant.chains.dps2.source;
+              data.rampant.chain.chainSwapTank = 'SE';
+              data.rampant.chain.chainSwapDps = data.rampant.chain.chains.dps2.source;
             }
           }
-          return data.rampant.total===4;
+          return data.rampant.chain.total===4;
         }
       },
       infoText: function(data, matches) {
-        if (data.options.cactbote8sLightRampantStrat === undefined || data.options.cactbote8sLightRampantStrat === 'None') {
+        if (data.options.cactbote8sLightRampantStrat === undefined || data.options.cactbote8sLightRampantStrat === 'none') {
           return {
             en: 'Chain on YOU',
             de: 'Kette auf DIR',
@@ -425,15 +426,15 @@
 
         if (data.options.cactbote8sLightRampantStrat === 'sharingan') {
           let ret = {};
-          if (data.rampant.meChain) {
+          if (data.rampant.chain.meChain) {
             let extra = '';
             if (data.rampant.chainSwapTank!=='Stay') {
-              if (data.rampant.chains.tank.source == data.me)
-                extra = ', Swap '+data.rampant.chainSwapTank;
+              if (data.rampant.chain.chains.tank.source == data.me)
+                extra = ', Swap '+data.rampant.chain.chainSwapTank;
               else if (data.rampant.chainSwapDps == data.me)
                 extra = ', Swap NW';
               else if (data.party.isHealer(data.me))
-                extra = ', Tank swap with '+data.rampant.chainSwapTank;
+                extra = ', Tank swap with '+data.rampant.chain.chainSwapTank;
             }
             ret = {
               en: 'Chain on YOU'+extra,
@@ -453,7 +454,7 @@
       regex: Regexes.tether({ id: '0002' }),
       condition: Conditions.targetIsYou(),
       promise: function(data, matches) {
-        if (data.options.cactbote8sLightRampantStrat === undefined || data.options.cactbote8sLightRampantStrat === 'None')
+        if (data.options.cactbote8sLightRampantStrat === undefined || data.options.cactbote8sLightRampantStrat === 'none')
           return null;
 
         let p = new Promise(async (res) => {
@@ -461,21 +462,22 @@
             call: 'getCombatants',
             ids: [matches.sourceId],
           });
+          data.rampant = data.rampant || {};
           if (!(combatantData !== null &&
             combatantData.combatants &&
             combatantData.combatants.length)) {
-            data.rampantOrb = null;
+            data.rampant.orb = null;
             res();
             return;
           }
-          data.rampantOrb = combatantData.combatants.pop();
+          data.rampant.orb = combatantData.combatants.pop();
           res();
         });
         return p;
       },
       run: function(data, matches) {
         if (data.options.cactbote8sLightRampantStrat === undefined ||
-          data.options.cactbote8sLightRampantStrat === 'None' ||
+          data.options.cactbote8sLightRampantStrat === 'none' ||
           data.rampantOrb === null)
           return;
 
@@ -495,7 +497,7 @@
       },
       infoText: function(data) {
         if (data.options.cactbote8sLightRampantStrat === undefined ||
-          data.options.cactbote8sLightRampantStrat === 'None' ||
+          data.options.cactbote8sLightRampantStrat === 'none' ||
           data.rampantOrb === null) {
           return {
             en: 'Orb on YOU',

--- a/ui/raidboss/data/05-shb/raid/e8s.js
+++ b/ui/raidboss/data/05-shb/raid/e8s.js
@@ -420,7 +420,7 @@
     },
     {
       id: 'E8S Holy Light',
-      regex: Regexes.tether({ id: '0002' }),
+      regex: Regexes.tether({ id: '0002', source: 'Holy Light' }),
       condition: Conditions.targetIsYou(),
       promise: function(data, matches) {
         if (data.options.e8sLightRampantStrat === undefined || data.options.e8sLightRampantStrat === 'none') {
@@ -487,6 +487,15 @@
           delete data.rampant.orb;
           break;
         }
+      },
+    },
+    {
+      id: 'E8S Holy Light Absorb',
+      regex: Regexes.tether({ id: '0002', source: 'Holy Light' }),
+      condition: Conditions.targetIsYou(),
+      delaySeconds: 15,
+      alertText: {
+        en: 'Absorb Orb',
       },
     },
     {

--- a/ui/raidboss/data/05-shb/raid/e8s.js
+++ b/ui/raidboss/data/05-shb/raid/e8s.js
@@ -475,26 +475,6 @@
         });
         return p;
       },
-      run: function(data, matches) {
-        if (data.options.cactbote8sLightRampantStrat === undefined ||
-          data.options.cactbote8sLightRampantStrat === 'none' ||
-          data.rampantOrb === null)
-          return;
-
-        if (data.options.cactbote8sLightRampantStrat === 'sharingan') {
-          // Take orb to opposite side of spawn
-          if (data.rampantOrb.PosX > 105)
-            data.rampantOrbText = 'W';
-          else if (data.rampantOrb.PosX < 95)
-            data.rampantOrbText = 'E';
-          else if (data.rampantOrb.PosY > 105)
-            data.rampantOrbText = 'S';
-          else if (data.rampantOrb.PosY < 95)
-            data.rampantOrbText = 'N';
-          else
-            data.rampantOrbText = '???';
-        }
-      },
       infoText: function(data) {
         if (data.options.cactbote8sLightRampantStrat === undefined ||
           data.options.cactbote8sLightRampantStrat === 'none' ||
@@ -515,6 +495,26 @@
           ko: '구슬 대상자, '+data.rampantOrbText,
           cn: '拉球, '+data.rampantOrbText,
         };
+      },
+      run: function(data, matches) {
+        if (data.options.cactbote8sLightRampantStrat === undefined ||
+          data.options.cactbote8sLightRampantStrat === 'none' ||
+          data.rampantOrb === null)
+          return;
+
+        if (data.options.cactbote8sLightRampantStrat === 'sharingan') {
+          // Take orb to opposite side of spawn
+          if (data.rampantOrb.PosX > 105)
+            data.rampantOrbText = 'W';
+          else if (data.rampantOrb.PosX < 95)
+            data.rampantOrbText = 'E';
+          else if (data.rampantOrb.PosY > 105)
+            data.rampantOrbText = 'S';
+          else if (data.rampantOrb.PosY < 95)
+            data.rampantOrbText = 'N';
+          else
+            data.rampantOrbText = '???';
+        }
       },
     },
     {

--- a/ui/raidboss/data/05-shb/raid/e8s.js
+++ b/ui/raidboss/data/05-shb/raid/e8s.js
@@ -384,6 +384,7 @@
             ret = {
               en: 'Chain: Tank NW',
             };
+            alertFor = [tank];
           }
 
           // If we need to move, alert us, otherwise just show info

--- a/ui/raidboss/data/05-shb/raid/e8s.js
+++ b/ui/raidboss/data/05-shb/raid/e8s.js
@@ -410,8 +410,12 @@
         };
       },
       run: function(data) {
-        // Clean up for later
-        delete data.rampant.chains, data.rampant.chainCount;
+        switch (data.options.e8sLightRampantStrat) {
+        case 'sharingan':
+          // Clean up for later
+          delete data.rampant.chains, data.rampant.chainCount;
+          break;
+        }
       },
     },
     {
@@ -419,8 +423,11 @@
       regex: Regexes.tether({ id: '0002' }),
       condition: Conditions.targetIsYou(),
       promise: function(data, matches) {
-        if (data.options.e8sLightRampantStrat === undefined || data.options.e8sLightRampantStrat === 'none')
-          return null;
+        if (data.options.e8sLightRampantStrat === undefined || data.options.e8sLightRampantStrat === 'none') {
+          return new Promise((res)=>{
+            res();
+          });
+        }
 
         // Orbs spawn at combat start but are not moved into position until the tethers go out
         // So we need to fetch up-to-date position info from the game client
@@ -474,8 +481,12 @@
         };
       },
       run: function(data) {
-        // Clean up for later
-        delete data.rampant.orb;
+        switch (data.options.e8sLightRampantStrat) {
+        case 'sharingan':
+          // Clean up for later
+          delete data.rampant.orb;
+          break;
+        }
       },
     },
     {

--- a/ui/raidboss/raidboss_config.js
+++ b/ui/raidboss/raidboss_config.js
@@ -1108,5 +1108,19 @@ UserConfig.registerOptions('raidboss', {
       type: 'checkbox',
       default: false,
     },
+    {
+      id: 'cactbote8sLightRampantStrat',
+      name: {
+        en: 'e8s: enable specific Light Rampant strat',
+      },
+      type: 'select',
+      options: {
+        en: {
+          'None': 'none',
+          'Sharingan/Ayatori': 'sharingan',
+        },
+      },
+      default: 'none',
+    },
   ],
 });

--- a/ui/raidboss/raidboss_config.js
+++ b/ui/raidboss/raidboss_config.js
@@ -1109,7 +1109,7 @@ UserConfig.registerOptions('raidboss', {
       default: false,
     },
     {
-      id: 'cactbote8sLightRampantStrat',
+      id: 'e8sLightRampantStrat',
       name: {
         en: 'e8s: enable specific Light Rampant strat',
       },
@@ -1117,6 +1117,7 @@ UserConfig.registerOptions('raidboss', {
       options: {
         en: {
           'None': 'none',
+          // See: https://ff14.toolboxgaming.space/?id=29987164943851&preview=1
           'Sharingan/Ayatori': 'sharingan',
         },
       },


### PR DESCRIPTION
This PR:
- Switches the regex for Refulgent Chain to the tether
- Adds an option to config for which Light Rampant strat to use
- Adds strat for sharingan/ayatori (bowtie, orbs opposite of spawn location)

This isn't fully tested due to my group not running today. I won't be able to properly test this until maybe Thursday depending on how re-clears go.

This should be extensible to allow for other strats to be added, I'm just not familiar with any other strats to add them.

`006E` is the initial tether. `006F` is the second tether that snaps in place partway into the mechanic when the distance between tethers snapshots.