### PR TITLE
Oopsy: E7N Light's Course fix

### DIFF
--- a/ui/oopsyraidsy/data/05-shb/raid/e7n.js
+++ b/ui/oopsyraidsy/data/05-shb/raid/e7n.js
@@ -68,7 +68,7 @@
       condition: function(e, data) {
         return !data.hasUmbral[e.targetName];
       },
-      mistake: function(e) {
+      mistake: function(e, data) {
         if (data.hasAstral[e.targetName])
           return { type: 'fail', blame: e.targetName, text: e.abilityName + ' wrong buff' };
         return { type: 'warn', blame: e.targetName, text: e.abilityName + ' no buff' };


### PR DESCRIPTION
I'm not sure how this happened, but I'm guessing it was a copy/paste error when we redid the oopsy triggers to use regex replacements.