### PR TITLE
Respons.js correction Fr

### DIFF
--- a/resources/responses.js
+++ b/resources/responses.js
@@ -218,7 +218,7 @@ let Responses = {
       return {
         en: 'Avoid tank cleave',
         de: 'Tank Cleave ausweichen',
-        fr: 'Évitez le cleave sur le tank',
+        fr: 'Évitez le tank cleave',
         ja: '前方範囲攻撃を避け',
         ko: '광역 탱버 피하기',
         cn: '远离顺劈',
@@ -267,7 +267,7 @@ let Responses = {
     obj[defaultInfoText(sev)] = {
       en: 'Spread',
       de: 'Verteilen',
-      fr: 'Écartez-vous',
+      fr: 'Dispersion',
       ja: '散開',
       cn: '分散',
       ko: '산개',
@@ -279,7 +279,7 @@ let Responses = {
     obj[defaultAlertText(sev)] = {
       en: 'Stack',
       de: 'Sammeln',
-      fr: 'Packez-vous',
+      fr: 'Regroupement',
       ja: 'スタック',
       cn: '集合',
       ko: '집합',
@@ -294,7 +294,7 @@ let Responses = {
         return {
           en: 'Stack on YOU',
           de: 'Auf DIR sammeln',
-          fr: 'Package sur VOUS',
+          fr: 'Regroupement sur VOUS',
           ja: '自分にスタック',
           cn: '集合点名',
           ko: '쉐어징 대상자',
@@ -303,7 +303,7 @@ let Responses = {
       return {
         en: 'Stack on ' + data.ShortName(target),
         de: 'Auf ' + data.ShortName(target) + ' sammeln',
-        fr: 'Packez-vous sur ' + data.ShortName(target),
+        fr: 'Regroupement sur ' + data.ShortName(target),
         ja: data.ShortName(target) + 'にスタック',
         cn: '靠近 ' + data.ShortName(target) + '集合',
         ko: '쉐어징 → ' + data.ShortName(target),
@@ -315,7 +315,7 @@ let Responses = {
     let obj = {};
     obj[defaultInfoText(sev)] = {
       en: 'Stack in middle',
-      fr: 'Packez-vous au milieu',
+      fr: 'Regroupement au milieu',
       de: 'In der Mitte sammeln',
       ja: '中央でスタック',
       ko: '중앙에서 모이기',
@@ -328,7 +328,7 @@ let Responses = {
     obj[defaultAlertText(sev)] = {
       en: 'Dorito Stack',
       de: 'Mit Marker sammeln',
-      fr: 'Packez-vous avec les autres marqueurs',
+      fr: 'Regroupement des marquages',
       ja: 'マーカー付けた人とスタック',
       cn: '点名集合',
     };
@@ -339,7 +339,7 @@ let Responses = {
     obj[defaultAlertText(sev)] = {
       en: 'Spread => Stack',
       de: 'Verteilen => Sammeln',
-      fr: 'Écartez-vous => Packez-vous',
+      fr: 'Dispersion => Regroupement',
       ja: '散開 => スタック',
       cn: '分散 => 集合',
       ko: '산개 => 집합',
@@ -351,7 +351,7 @@ let Responses = {
     obj[defaultAlertText(sev)] = {
       en: 'Stack => Spread',
       de: 'Sammeln => Verteilen',
-      fr: 'Packez-vous => Écartez-vous',
+      fr: 'Regroupement => Dispersion',
       ja: 'スタック => 散開',
       cn: '集合 => 分散',
       ko: '집합 => 산개',
@@ -459,7 +459,7 @@ let Responses = {
     obj[defaultInfoText(sev)] = {
       en: 'Get Under',
       de: 'Unter ihn',
-      fr: 'Intérieur',
+      fr: 'En dessous',
       ja: '中へ',
       ko: '보스 아래로',
       cn: '去脚下',
@@ -472,7 +472,7 @@ let Responses = {
     obj[defaultAlertText(sev)] = {
       en: 'In',
       de: 'Rein',
-      fr: 'Dedans',
+      fr: 'Intérieur',
       ja: '中へ',
       cn: '靠近',
       ko: '안으로',
@@ -486,7 +486,7 @@ let Responses = {
       en: 'Out',
       de: 'Raus',
       ja: '外へ',
-      fr: 'Dehors',
+      fr: 'Exterieur',
       cn: '远离',
       ko: '밖으로',
     };
@@ -497,7 +497,7 @@ let Responses = {
     obj[defaultInfoText(sev)] = {
       en: 'Out of melee',
       de: 'Raus aus Nahkampf',
-      fr: 'Éloignez-vous du CaC',
+      fr: 'Hors de la mêlée',
       ja: '近接最大レンジ',
       cn: '近战最远距离回避',
       ko: '근접범위 밖으로',
@@ -509,7 +509,7 @@ let Responses = {
     obj[defaultInfoText(sev)] = {
       en: 'In, then out',
       de: 'Rein, dann raus',
-      fr: 'Dedans, puis dehors',
+      fr: 'Intérieur, puis extérieur',
       ja: '中 => 外',
       cn: '先靠近，再远离',
       ko: '안으로 => 밖으로',
@@ -521,7 +521,7 @@ let Responses = {
     obj[defaultInfoText(sev)] = {
       en: 'Out, then in',
       de: 'Raus, dann rein',
-      fr: 'Dehors, puis dedans',
+      fr: 'Extérieur, puis intérieur',
       ja: '外 => 中',
       cn: '先远离，再靠近',
       ko: '밖으로 => 안으로',
@@ -642,7 +642,7 @@ let Responses = {
     obj[defaultAlertText(sev)] = {
       en: 'Away From Front',
       de: 'Weg von Vorne',
-      fr: 'Éloignez vous de l\'avant',
+      fr: 'Loin de l\'avant',
       ja: '前方から離れて',
       ko: '보스 전방 피하기',
       cn: '远离正面',
@@ -732,7 +732,7 @@ let Responses = {
         return {
           en: 'Away from Group',
           de: 'Weg von der Gruppe',
-          fr: 'Éloignez-vous du groupe',
+          fr: 'Loin du groupe',
           ja: '外へ',
           cn: '远离人群',
         };
@@ -740,7 +740,7 @@ let Responses = {
       return {
         en: 'Away from ' + data.ShortName(target),
         de: 'Weg von ' + data.ShortName(target),
-        fr: 'Éloignez-vous de ' + data.ShortName(target),
+        fr: 'Loin de ' + data.ShortName(target),
         ja: data.ShortName(target) + 'から離れて',
         cn: '远离' + data.ShortName(target),
       };
@@ -787,8 +787,8 @@ let Responses = {
     let obj = {};
     obj[defaultInfoText(sev)] = {
       en: 'Move!',
-      de: 'Bewegen',
-      fr: 'Bougez',
+      de: 'Bewegen!',
+      fr: 'Bougez !',
       ja: '動く！',
       ko: '움직이기!',
       cn: '快动！',

--- a/resources/responses.js
+++ b/resources/responses.js
@@ -642,7 +642,7 @@ let Responses = {
     obj[defaultAlertText(sev)] = {
       en: 'Away From Front',
       de: 'Weg von Vorne',
-      fr: 'Loin de l\'avant',
+      fr: 'Éloignez-vous du davant',
       ja: '前方から離れて',
       ko: '보스 전방 피하기',
       cn: '远离正面',

--- a/resources/responses.js
+++ b/resources/responses.js
@@ -267,7 +267,7 @@ let Responses = {
     obj[defaultInfoText(sev)] = {
       en: 'Spread',
       de: 'Verteilen',
-      fr: 'Dispersion',
+      fr: 'Dispersez-vous',
       ja: '散開',
       cn: '分散',
       ko: '산개',
@@ -279,7 +279,7 @@ let Responses = {
     obj[defaultAlertText(sev)] = {
       en: 'Stack',
       de: 'Sammeln',
-      fr: 'Regroupement',
+      fr: 'Packez-vous',
       ja: 'スタック',
       cn: '集合',
       ko: '집합',
@@ -294,7 +294,7 @@ let Responses = {
         return {
           en: 'Stack on YOU',
           de: 'Auf DIR sammeln',
-          fr: 'Regroupement sur VOUS',
+          fr: 'Package sur VOUS',
           ja: '自分にスタック',
           cn: '集合点名',
           ko: '쉐어징 대상자',
@@ -303,7 +303,7 @@ let Responses = {
       return {
         en: 'Stack on ' + data.ShortName(target),
         de: 'Auf ' + data.ShortName(target) + ' sammeln',
-        fr: 'Regroupement sur ' + data.ShortName(target),
+        fr: 'Packez-vous sur ' + data.ShortName(target),
         ja: data.ShortName(target) + 'にスタック',
         cn: '靠近 ' + data.ShortName(target) + '集合',
         ko: '쉐어징 → ' + data.ShortName(target),
@@ -315,7 +315,7 @@ let Responses = {
     let obj = {};
     obj[defaultInfoText(sev)] = {
       en: 'Stack in middle',
-      fr: 'Regroupement au milieu',
+      fr: 'Packez-vous au milieu',
       de: 'In der Mitte sammeln',
       ja: '中央でスタック',
       ko: '중앙에서 모이기',
@@ -328,7 +328,7 @@ let Responses = {
     obj[defaultAlertText(sev)] = {
       en: 'Dorito Stack',
       de: 'Mit Marker sammeln',
-      fr: 'Regroupement des marquages',
+      fr: 'Packez les marquages',
       ja: 'マーカー付けた人とスタック',
       cn: '点名集合',
     };
@@ -339,7 +339,7 @@ let Responses = {
     obj[defaultAlertText(sev)] = {
       en: 'Spread => Stack',
       de: 'Verteilen => Sammeln',
-      fr: 'Dispersion => Regroupement',
+      fr: 'Dispersion => Package',
       ja: '散開 => スタック',
       cn: '分散 => 集合',
       ko: '산개 => 집합',
@@ -351,7 +351,7 @@ let Responses = {
     obj[defaultAlertText(sev)] = {
       en: 'Stack => Spread',
       de: 'Sammeln => Verteilen',
-      fr: 'Regroupement => Dispersion',
+      fr: 'Package => Dispersion',
       ja: 'スタック => 散開',
       cn: '集合 => 分散',
       ko: '집합 => 산개',
@@ -591,7 +591,7 @@ let Responses = {
     let obj = {};
     obj[defaultAlertText(sev)] = {
       en: 'Go Front/Back',
-      de: 'Geh nach Vorne/ Hinten',
+      de: 'Geh nach Vorne/Hinten',
       fr: 'Allez Devant/Derrière',
       ja: '縦へ',
       ko: '앞/뒤로',
@@ -732,7 +732,7 @@ let Responses = {
         return {
           en: 'Away from Group',
           de: 'Weg von der Gruppe',
-          fr: 'Loin du groupe',
+          fr: 'Éloignez-vous du groupe',
           ja: '外へ',
           cn: '远离人群',
         };
@@ -740,7 +740,7 @@ let Responses = {
       return {
         en: 'Away from ' + data.ShortName(target),
         de: 'Weg von ' + data.ShortName(target),
-        fr: 'Loin de ' + data.ShortName(target),
+        fr: 'Éloignez-vous de ' + data.ShortName(target),
         ja: data.ShortName(target) + 'から離れて',
         cn: '远离' + data.ShortName(target),
       };

--- a/resources/responses.js
+++ b/resources/responses.js
@@ -642,7 +642,7 @@ let Responses = {
     obj[defaultAlertText(sev)] = {
       en: 'Away From Front',
       de: 'Weg von Vorne',
-      fr: 'Éloignez-vous du davant',
+      fr: 'Éloignez-vous du devant',
       ja: '前方から離れて',
       ko: '보스 전방 피하기',
       cn: '远离正面',


### PR DESCRIPTION
- Several friends who speak good English have told me about my mistakes. So we are meeting to discuss this.
After a very long debate on the mechanics and announcements to be made, we decided to make these changes.
 - Some words like (spread) or (stack), they complicated, because there are different lines with these words. In order to keep the same word for each line using it, some have been conjugate and others have been transformed.
- (package, packez) have been deleted because the definition is not correct. (package) Only concerns objects or files, but I could accept it.
- the rest has been simplified while remaining logical.
- I think that a party of French players who raid put FFXIV in English, and I would like those who put it in French to benefit from the calls in French. If (spread, stack) still causes problems for someone on the translation. I would simply suggest not the translates.
- I would use it as a basis (respons) for all my other translations (ARR, Hw, St, Shb) and i will correct all the files where I made these errors, once this request has been validated.
- Would sorting alphabetically in this file for the research be helpful?
- I remain open to any suggestions, And do you approve of these changes ? @mooondark .

**My apologies to all of you for these new changes.** @quisquous (wait for a response before merge).