### PR TITLE
Raidboss: Fix for broken TEA headmarker fix

### DIFF
--- a/ui/raidboss/data/05-shb/ultimate/the_epic_of_alexander.js
+++ b/ui/raidboss/data/05-shb/ultimate/the_epic_of_alexander.js
@@ -30,7 +30,9 @@
 // added to their ID. This offset currently appears to be set per instance, so
 // we can determine what it is from the first overhead marker we see.
 let getHeadmarkerId = (data, matches) => {
-  if (!data.decOffset) {
+  // If we naively just check !data.decOffset and leave it, it breaks if the first marker is 004F.
+  // (This makes the offset 0, and !0 is true.)
+  if (typeof(data.decOffset) == 'undefined') {
     // The first 1B marker in the encounter is Limit Cut 1, ID 004F.
     data.decOffset = parseInt(matches.id, 16) - 79;
   }


### PR DESCRIPTION
This should resolve #1346 . The fix introduced for the 5.2 scrambling of the TEA markers had a ridiculously subtle bug. As the comment notes, any time the initial head marker is `004F`, the offset is zero. Since zero is falsy, this collides with the naive check for "did we find the offset yet?" This wasn't a problem in 5.2 content, since the odds of hitting That One Instance where the offset was actually 0 are extremely low. No surprise it wasn't noticed until people had to do this on 5.1! 

Many thanks to quisquous for taking the time to look through this and point me in the right direction. Thanks Jaehyuk-Lee for the bug report!