### PR TITLE
plugin: Add cn/kr FATE opcodes

### DIFF
--- a/plugin/CactbotEventSource/CactbotEventSource.cs
+++ b/plugin/CactbotEventSource/CactbotEventSource.cs
@@ -267,7 +267,7 @@ namespace Cactbot {
         LogInfo("Version: intl");
       }
       wipe_detector_ = new WipeDetector(this);
-      fate_watcher_ = new FateWatcher(this);
+      fate_watcher_ = new FateWatcher(this, language_);
 
       // Incoming events.
       Advanced_Combat_Tracker.ActGlobals.oFormActMain.OnLogLineRead += OnLogLineRead;

--- a/plugin/CactbotEventSource/FateWatcher.cs
+++ b/plugin/CactbotEventSource/FateWatcher.cs
@@ -49,10 +49,10 @@ namespace Cactbot {
       // Fate start
       // param1: fateID
       // param2: unknown
-
+      //
       // Fate end
       // param1: fateID
-
+      //
       // Fate update
       // param1: fateID
       // param2: progress (0-100)
@@ -193,10 +193,8 @@ namespace Cactbot {
       if (a == opcodes[region_].add) {
         AddFate(*(int*)&buffer[Param1_Offset]);
       } else if (a == opcodes[region_].remove) {
-
         RemoveFate(*(int*)&buffer[Param1_Offset]);
       } else if (a == opcodes[region_].update) {
-
         int param1 = *(int*)&buffer[Param1_Offset];
         int param2 = *(int*)&buffer[Param2_Offset];
         if (!fates.ContainsKey(param1)) {
@@ -209,7 +207,6 @@ namespace Cactbot {
     }
 
     private void AddFate(int fateID) {
-
       if (!fates.ContainsKey(fateID)) {
         fates.TryAdd(fateID, 0);
         client_.DispatchToJS(new JSEvents.FateEvent("add", fateID, 0));
@@ -217,7 +214,6 @@ namespace Cactbot {
     }
 
     private void RemoveFate(int fateID) {
-
       if (fates.ContainsKey(fateID)) {
         client_.DispatchToJS(new JSEvents.FateEvent("remove", fateID, fates[fateID]));
         fates.TryRemove(fateID, out _);
@@ -225,7 +221,6 @@ namespace Cactbot {
     }
 
     private void UpdateFate(int fateID, int progress) {
-
       fates.AddOrUpdate(fateID, progress, (int id, int prog) => progress);
       client_.DispatchToJS(new JSEvents.FateEvent("update", fateID, progress));
     }

--- a/plugin/CactbotEventSource/FateWatcher.cs
+++ b/plugin/CactbotEventSource/FateWatcher.cs
@@ -13,12 +13,33 @@ namespace Cactbot {
     private string region_;
     private IDataSubscription subscription;
 
+    // Fate start
+    // param1: fateID
+    // param2: unknown
+    //
+    // Fate end
+    // param1: fateID
+    //
+    // Fate update
+    // param1: fateID
+    // param2: progress (0-100)
     private struct OPCodes {
-      public OPCodes(int add_, int remove_, int update_) { this.add = add_; this.remove = remove_; this.update = update_; }
+    public OPCodes(int add_, int remove_, int update_) { this.add = add_; this.remove = remove_; this.update = update_; }
       public int add;
       public int remove;
       public int update;
-    }
+    };
+    private OPCodes v5_1 = new OPCodes(
+      0x74,
+      0x79,
+      0x9B
+    );
+    private OPCodes v5_2 = new OPCodes(
+      0x935,
+      0x936,
+      0x93E
+    );
+
     private Dictionary<string, OPCodes> opcodes = null;
 
     private Type MessageType = null;
@@ -45,53 +66,9 @@ namespace Cactbot {
         region_ = "intl";
 
       opcodes = new Dictionary<string, OPCodes>();
-
-      // Fate start
-      // param1: fateID
-      // param2: unknown
-      //
-      // Fate end
-      // param1: fateID
-      //
-      // Fate update
-      // param1: fateID
-      // param2: progress (0-100)
-
-      //
-      // for FFXIV KO version: 5.11
-      //
-      // Latest KO version can be found at:
-      // https://www.ff14.co.kr/news/notice?category=3
-      //
-      opcodes.Add("ko", new OPCodes(
-        0x74,
-        0x79,
-        0x9B
-        ));
-
-      //
-      // for FFXIV CN version: 5.15
-      //
-      // Latest CN version can be found at:
-      // http://ff.sdo.com/web8/index.html#/patchnote
-      //
-      opcodes.Add("cn", new OPCodes(
-        0x74,
-        0x79,
-        0x9B
-        ));
-
-      //
-      // for FFXIV intl version: 5.25
-      //
-      // Latest intl version can be fount at:
-      // https://eu.finalfantasyxiv.com/lodestone/special/patchnote_log/
-      //
-      opcodes.Add("intl", new OPCodes(
-        0x935,
-        0x936,
-        0x93E
-        ));
+      opcodes.Add("ko", v5_1);
+      opcodes.Add("cn", v5_1);
+      opcodes.Add("intl", v5_2);
 
       fates = new ConcurrentDictionary<int, int>();
 


### PR DESCRIPTION
Add the missing OPCodes for KR/CN regions.
I've confirmed the KR opcode with @Jaehyuk-Lee, I'm assuming the CN opcode is the same until 5.2.

This should fix #1359.