### PR TITLE
Refactor PopupText class for new raidemulator support

### DIFF
--- a/docs/RaidbossGuide.md
+++ b/docs/RaidbossGuide.md
@@ -176,6 +176,7 @@ Trigger elements are evaluated in this order, and must be listed in this order:
 - disabled
 - regex (and regexDe, regexFr, etc)
 - beforeSeconds (for timelineTriggers)
+- (supressed triggers early out here)
 - condition
 - preRun
 - delaySeconds

--- a/docs/RaidbossGuide.md
+++ b/docs/RaidbossGuide.md
@@ -189,6 +189,7 @@ Trigger elements are evaluated in this order, and must be listed in this order:
 - soundVolume
 - response
 - alarmText
+- alertText
 - infoText
 - groupTTS
 - tts

--- a/ui/raidboss/popup-text.js
+++ b/ui/raidboss/popup-text.js
@@ -210,11 +210,10 @@ class PopupText {
           // Filter out disabled triggers
           let enabledTriggers = set.triggers.filter((trigger) => !('disabled' in trigger && trigger.disabled));
 
-          for (let j = 0; j < enabledTriggers.length; ++j) {
+          for (let trigger of enabledTriggers) {
             // Add an additional resolved regex here to save
             // time later.  This will clobber each time we
             // load this, but that's ok.
-            let trigger = enabledTriggers[j];
             trigger.filename = set.filename;
 
             if (!trigger.regex)
@@ -229,6 +228,7 @@ class PopupText {
             trigger.localRegex = Regexes.parse(regex);
           }
 
+          // Don't bother tracking triggers that don't have a regex to match against
           enabledTriggers = enabledTriggers.filter((trigger)=>{
             return trigger.localRegex !== undefined;
           });
@@ -459,7 +459,7 @@ class PopupText {
       },
       triggerOptions: trigger.id && this.options.PerTriggerOptions[trigger.id] || {},
       triggerAutoConfig: trigger.id && this.options.PerTriggerAutoConfig[trigger.id] || {},
-      // This setting onyl suppresses output, trigger still runs for data/logic purposes
+      // This setting only suppresses output, trigger still runs for data/logic purposes
       userSuppressedOutput: trigger.id && this.options.DisabledTriggers[trigger.id],
       matches: matches,
       response: undefined,
@@ -723,6 +723,7 @@ class PopupText {
   }
 
   _addTextFor(textType, triggerHelper) {
+    // Info
     let textTypeUpper = textType[0].toUpperCase() + textType.slice(1);
     // infoText
     let lowerTextKey = textType + 'Text';

--- a/ui/raidboss/popup-text.js
+++ b/ui/raidboss/popup-text.js
@@ -536,7 +536,7 @@ class PopupText {
 
   _OnTriggerInternal_PreRun(TriggerHelper) {
     if ('preRun' in TriggerHelper.Trigger)
-      TriggerHelper.Trigger.preRun(this.data, matches);
+      TriggerHelper.Trigger.preRun(this.data, TriggerHelper.Matches);
   }
 
   _OnTriggerInternal_DelaySeconds(TriggerHelper) {

--- a/ui/raidboss/popup-text.js
+++ b/ui/raidboss/popup-text.js
@@ -25,7 +25,7 @@ class PopupText {
     this.options = options;
     this.triggers = [];
     this.timers = {};
-    this.CurrentTriggerID = 0;
+    this.currentTriggerID = 0;
     this.inCombat = false;
     this.resetWhenOutOfCombat = true;
     this.infoText = document.getElementById('popup-text-info');
@@ -210,10 +210,11 @@ class PopupText {
           // Filter out disabled triggers
           let enabledTriggers = set.triggers.filter((trigger) => !('disabled' in trigger && trigger.disabled));
 
-          for (let trigger of enabledTriggers) {
+          for (let j = 0; j < enabledTriggers.length; ++j) {
             // Add an additional resolved regex here to save
             // time later.  This will clobber each time we
             // load this, but that's ok.
+            let trigger = enabledTriggers[j];
             trigger.filename = set.filename;
 
             if (!trigger.regex)
@@ -228,8 +229,9 @@ class PopupText {
             trigger.localRegex = Regexes.parse(regex);
           }
 
-          // Exclude triggers that don't have a valid regex
-          enabledTriggers = enabledTriggers.filter((trigger) => 'localRegex' in trigger);
+          enabledTriggers = enabledTriggers.filter((trigger)=>{
+            return trigger.localRegex !== undefined;
+          });
 
           // Save the triggers from each set that matches.
           this.triggers.push(...enabledTriggers);
@@ -370,7 +372,7 @@ class PopupText {
   OnTriggerInternal(trigger, matches) {
     let now = +new Date();
 
-    if (this._OnTriggerInternal_CheckSuppressed(trigger, now))
+    if (!this._onTriggerInternalCheckSuppressed(trigger, now))
       return;
 
     // If using named groups, treat matches.groups as matches
@@ -380,26 +382,26 @@ class PopupText {
 
     // Set up a helper object so we don't have to throw
     // a ton of info back and forth between subfunctions
-    let TriggerHelper = this._OnTriggerInternal_GetHelper(trigger, matches, now);
+    let triggerHelper = this._onTriggerInternalGetHelper(trigger, matches, now);
 
-    if (!this._OnTriggerInternal_Condition(TriggerHelper))
+    if (!this._onTriggerInternalCondition(triggerHelper))
       return;
 
-    this._OnTriggerInternal_PreRun(TriggerHelper);
+    this._onTriggerInternalPreRun(triggerHelper);
 
     // Evaluate for delay here, but run delay later
-    let DelayPromise = this._OnTriggerInternal_DelaySeconds(TriggerHelper);
-    this._OnTriggerInternal_DurationSeconds(TriggerHelper);
-    this._OnTriggerInternal_SuppressSeconds(TriggerHelper);
+    let delayPromise = this._onTriggerInternalDelaySeconds(triggerHelper);
+    this._onTriggerInternalDurationSeconds(triggerHelper);
+    this._onTriggerInternalSuppressSeconds(triggerHelper);
 
-    DelayPromise.then(() => {
-      this._OnTriggerInternal_Promise(TriggerHelper).then(() => {
-        this._OnTriggerInternal_Sound(TriggerHelper);
-        this._OnTriggerInternal_SoundVolume(TriggerHelper);
-        this._OnTriggerInternal_Response(TriggerHelper);
-        this._OnTriggerInternal_AlarmText(TriggerHelper);
-        this._OnTriggerInternal_AlertText(TriggerHelper);
-        this._OnTriggerInternal_InfoText(TriggerHelper);
+    delayPromise.then(() => {
+      this._onTriggerInternalPromise(triggerHelper).then(() => {
+        this._onTriggerInternalSound(triggerHelper);
+        this._onTriggerInternalSoundVolume(triggerHelper);
+        this._onTriggerInternalResponse(triggerHelper);
+        this._onTriggerInternalAlarmText(triggerHelper);
+        this._onTriggerInternalAlertText(triggerHelper);
+        this._onTriggerInternalInfoText(triggerHelper);
 
         // Priority audio order:
         // * user disabled (play nothing)
@@ -424,168 +426,168 @@ class PopupText {
         // being valid but empty, this will take priority over the default
         // tts texts from alarm/alert/info and will prevent tts from playing
         // and allowing sounds to be played instead.
-        this._OnTriggerInternal_GroupTTS(TriggerHelper);
-        this._OnTriggerInternal_TTS(TriggerHelper);
-        this._OnTriggerInternal_PlayAudio(TriggerHelper);
-        this._OnTriggerInternal_Run(TriggerHelper);
+        this._onTriggerInternalGroupTTS(triggerHelper);
+        this._onTriggerInternalTTS(triggerHelper);
+        this._onTriggerInternalPlayAudio(triggerHelper);
+        this._onTriggerInternalRun(triggerHelper);
       });
     });
   }
 
-  // Build a default TriggerHelper object for this trigger
-  _OnTriggerInternal_GetHelper(trigger, matches, now) {
-    let TriggerHelper;
+  // Build a default triggerHelper object for this trigger
+  _onTriggerInternalGetHelper(trigger, matches, now) {
+    let triggerHelper;
     // Separate the creation and assignment to let the ValueOrFunction method work properly
-    TriggerHelper = {
-      Trigger: trigger,
-      Now: now,
-      ValueOrFunction: (f) => {
-        let result = (typeof (f) == 'function') ? f(this.data, TriggerHelper.Matches) : f;
+    triggerHelper = {
+      trigger: trigger,
+      now: now,
+      valueOrFunction: (f) => {
+        let result = (typeof (f) == 'function') ? f(this.data, triggerHelper.matches) : f;
         // All triggers return either a string directly, or an object
         // whose keys are different locale names.  For simplicity, this is
         // valid to do for any trigger entry that can handle a function.
         // In case anybody wants to encapsulate any fancy grammar, the values
         // in this object can also be functions.
-        if (result !== Object(result))
+        if (typeof result !== 'object')
           return result;
         let lang = this.options.AlertsLanguage || this.options.Language || 'en';
         if (result[lang])
-          return TriggerHelper.ValueOrFunction(result[lang]);
+          return triggerHelper.valueOrFunction(result[lang]);
         // For partially localized results where this localization doesn't
         // exist, prefer English over nothing.
-        return TriggerHelper.ValueOrFunction(result['en']);
+        return triggerHelper.valueOrFunction(result['en']);
       },
-      TriggerOptions: trigger.id && this.options.PerTriggerOptions[trigger.id] || {},
-      TriggerAutoConfig: trigger.id && this.options.PerTriggerAutoConfig[trigger.id] || {},
-      // This setting only suppresses output, trigger still runs for data/logic purposes
-      UserSuppressedOutput: trigger.id && this.options.DisabledTriggers[trigger.id],
-      Matches: matches,
-      Response: undefined,
+      triggerOptions: trigger.id && this.options.PerTriggerOptions[trigger.id] || {},
+      triggerAutoConfig: trigger.id && this.options.PerTriggerAutoConfig[trigger.id] || {},
+      // This setting onyl suppresses output, trigger still runs for data/logic purposes
+      userSuppressedOutput: trigger.id && this.options.DisabledTriggers[trigger.id],
+      matches: matches,
+      response: undefined,
       // Default options
-      SoundUrl: undefined,
-      SoundVol: undefined,
-      TriggerSoundVol: undefined,
-      DefaultTTSText: undefined,
-      TextAlertsEnabled: this.options.TextAlertsEnabled,
-      SoundAlertsEnabled: this.options.SoundAlertsEnabled,
-      SpokenAlertsEnabled: this.options.SpokenAlertsEnabled,
+      soundUrl: undefined,
+      soundVol: undefined,
+      triggerSoundVol: undefined,
+      defaultTTSText: undefined,
+      textAlertsEnabled: this.options.TextAlertsEnabled,
+      soundAlertsEnabled: this.options.SoundAlertsEnabled,
+      spokenAlertsEnabled: this.options.SpokenAlertsEnabled,
       GroupSpokenAlertsEnabled: this.options.GroupSpokenAlertsEnabled,
-      Duration: undefined,
-      TTSText: undefined,
+      duration: undefined,
+      ttsText: undefined,
     };
 
-    this._OnTriggerInternal_HelperDefaults(TriggerHelper);
+    this._onTriggerInternalHelperDefaults(triggerHelper);
 
-    return TriggerHelper;
+    return triggerHelper;
   }
 
-  _OnTriggerInternal_CheckSuppressed(trigger, when) {
+  _onTriggerInternalCheckSuppressed(trigger, when) {
     if (trigger.id && trigger.id in this.triggerSuppress) {
       if (this.triggerSuppress[trigger.id] > when)
-        return true;
+        return false;
 
       delete this.triggerSuppress[trigger.id];
     }
-    return false;
+    return true;
   }
 
-  _OnTriggerInternal_Condition(TriggerHelper) {
-    let condition = TriggerHelper.TriggerOptions.Condition || TriggerHelper.Trigger.condition;
+  _onTriggerInternalCondition(triggerHelper) {
+    let condition = triggerHelper.triggerOptions.Condition || triggerHelper.trigger.condition;
     if (condition) {
-      if (!condition(this.data, TriggerHelper.Matches))
+      if (!condition(this.data, triggerHelper.matches))
         return false;
     }
     return true;
   }
 
-  // Set defaults for TriggerHelper object (anything that won't change based on
+  // Set defaults for triggerHelper object (anything that won't change based on
   // other trigger functions running)
-  _OnTriggerInternal_HelperDefaults(TriggerHelper) {
-    if (TriggerHelper.TriggerAutoConfig) {
-      if ('TextAlertsEnabled' in TriggerHelper.TriggerAutoConfig)
-        TriggerHelper.TextAlertsEnabled = TriggerHelper.TriggerAutoConfig.TextAlertsEnabled;
-      if ('SoundAlertsEnabled' in TriggerHelper.TriggerAutoConfig)
-        TriggerHelper.SoundAlertsEnabled = TriggerHelper.TriggerAutoConfig.SoundAlertsEnabled;
-      if ('SpokenAlertsEnabled' in TriggerHelper.TriggerAutoConfig)
-        TriggerHelper.SpokenAlertsEnabled = TriggerHelper.TriggerAutoConfig.SpokenAlertsEnabled;
+  _onTriggerInternalHelperDefaults(triggerHelper) {
+    if (triggerHelper.triggerAutoConfig) {
+      if ('TextAlertsEnabled' in triggerHelper.triggerAutoConfig)
+        triggerHelper.textAlertsEnabled = triggerHelper.triggerAutoConfig.TextAlertsEnabled;
+      if ('SoundAlertsEnabled' in triggerHelper.triggerAutoConfig)
+        triggerHelper.soundAlertsEnabled = triggerHelper.triggerAutoConfig.SoundAlertsEnabled;
+      if ('SpokenAlertsEnabled' in triggerHelper.triggerAutoConfig)
+        triggerHelper.spokenAlertsEnabled = triggerHelper.triggerAutoConfig.SpokenAlertsEnabled;
     }
 
-    if (TriggerHelper.TriggerOptions) {
-      if ('TextAlert' in TriggerHelper.TriggerOptions)
-        TriggerHelper.TextAlertsEnabled = TriggerHelper.TriggerOptions.TextAlert;
-      if ('SoundAlert' in TriggerHelper.TriggerOptions)
-        TriggerHelper.SoundAlertsEnabled = TriggerHelper.TriggerOptions.SoundAlert;
-      if ('SpeechAlert' in TriggerHelper.TriggerOptions)
-        TriggerHelper.SpokenAlertsEnabled = TriggerHelper.TriggerOptions.SpeechAlert;
-      if ('GroupSpeechAlert' in TriggerHelper.TriggerOptions)
-        TriggerHelper.GroupSpokenAlertsEnabled = TriggerHelper.TriggerOptions.GroupSpeechAlert;
+    if (triggerHelper.triggerOptions) {
+      if ('TextAlert' in triggerHelper.triggerOptions)
+        triggerHelper.textAlertsEnabled = triggerHelper.triggerOptions.TextAlert;
+      if ('SoundAlert' in triggerHelper.triggerOptions)
+        triggerHelper.soundAlertsEnabled = triggerHelper.triggerOptions.SoundAlert;
+      if ('SpeechAlert' in triggerHelper.triggerOptions)
+        triggerHelper.spokenAlertsEnabled = triggerHelper.triggerOptions.SpeechAlert;
+      if ('GroupSpeechAlert' in triggerHelper.triggerOptions)
+        triggerHelper.groupSpokenAlertsEnabled = triggerHelper.triggerOptions.GroupSpeechAlert;
     }
 
-    if (TriggerHelper.UserSuppressedOutput) {
-      TriggerHelper.TextAlertsEnabled = false;
-      TriggerHelper.SoundAlertsEnabled = false;
-      TriggerHelper.SpokenAlertsEnabled = false;
-      TriggerHelper.GroupSpokenAlertsEnabled = false;
+    if (triggerHelper.userSuppressedOutput) {
+      triggerHelper.textAlertsEnabled = false;
+      triggerHelper.soundAlertsEnabled = false;
+      triggerHelper.spokenAlertsEnabled = false;
+      triggerHelper.groupSpokenAlertsEnabled = false;
     }
     if (!this.options.audioAllowed) {
-      TriggerHelper.SoundAlertsEnabled = false;
-      TriggerHelper.SpokenAlertsEnabled = false;
-      TriggerHelper.GroupSpokenAlertsEnabled = false;
+      triggerHelper.soundAlertsEnabled = false;
+      triggerHelper.spokenAlertsEnabled = false;
+      triggerHelper.groupSpokenAlertsEnabled = false;
     }
   }
 
-  _OnTriggerInternal_PreRun(TriggerHelper) {
-    if ('preRun' in TriggerHelper.Trigger)
-      TriggerHelper.Trigger.preRun(this.data, TriggerHelper.Matches);
+  _onTriggerInternalPreRun(triggerHelper) {
+    if ('preRun' in triggerHelper.trigger)
+      triggerHelper.trigger.preRun(this.data, triggerHelper.matches);
   }
 
-  _OnTriggerInternal_DelaySeconds(TriggerHelper) {
-    let delay = 'delaySeconds' in TriggerHelper.Trigger ? TriggerHelper.ValueOrFunction(TriggerHelper.Trigger.delaySeconds) : 0;
-    let TriggerID = this.CurrentTriggerID++;
-    this.timers[TriggerID] = true;
+  _onTriggerInternalDelaySeconds(triggerHelper) {
+    let delay = 'delaySeconds' in triggerHelper.trigger ? triggerHelper.valueOrFunction(triggerHelper.trigger.delaySeconds) : 0;
+    let triggerID = this.currentTriggerID++;
+    this.timers[triggerID] = true;
     return new Promise((res, rej) => {
       if (delay > 0) {
         window.setTimeout(() => {
-          if (this.timers[TriggerID])
+          if (this.timers[triggerID])
             res();
           else
             rej();
-          delete this.timers[TriggerID];
+          delete this.timers[triggerID];
         }, delay * 1000);
       } else {
-        delete this.timers[TriggerID];
+        delete this.timers[triggerID];
         res();
       }
     });
   }
 
-  _OnTriggerInternal_DurationSeconds(TriggerHelper) {
-    TriggerHelper.Duration = {
-      FromTrigger: TriggerHelper.ValueOrFunction(TriggerHelper.Trigger.durationSeconds),
+  _onTriggerInternalDurationSeconds(triggerHelper) {
+    triggerHelper.duration = {
+      fromTrigger: triggerHelper.valueOrFunction(triggerHelper.trigger.durationSeconds),
       alarmText: this.options.DisplayAlarmTextForSeconds,
       alertText: this.options.DisplayAlertTextForSeconds,
       infoText: this.options.DisplayInfoTextForSeconds,
     };
   }
 
-  _OnTriggerInternal_SuppressSeconds(TriggerHelper) {
-    let suppress = 'suppressSeconds' in TriggerHelper.Trigger ? TriggerHelper.ValueOrFunction(TriggerHelper.Trigger.suppressSeconds) : 0;
-    if (TriggerHelper.Trigger.id && suppress > 0)
-      this.triggerSuppress[TriggerHelper.Trigger.id] = TriggerHelper.Now + (suppress * 1000);
+  _onTriggerInternalSuppressSeconds(triggerHelper) {
+    let suppress = 'suppressSeconds' in triggerHelper.trigger ? triggerHelper.valueOrFunction(triggerHelper.trigger.suppressSeconds) : 0;
+    if (triggerHelper.trigger.id && suppress > 0)
+      this.triggerSuppress[triggerHelper.trigger.id] = triggerHelper.now + (suppress * 1000);
   }
 
-  _OnTriggerInternal_Promise(TriggerHelper) {
+  _onTriggerInternalPromise(triggerHelper) {
     let promise = null;
-    if ('promise' in TriggerHelper.Trigger) {
-      if (typeof TriggerHelper.Trigger.promise === 'function') {
-        promise = TriggerHelper.Trigger.promise(this.data, TriggerHelper.Matches);
+    if ('promise' in triggerHelper.trigger) {
+      if (typeof triggerHelper.trigger.promise === 'function') {
+        promise = triggerHelper.trigger.promise(this.data, triggerHelper.matches);
         // Make sure we actually get a Promise back from the function
         if (Promise.resolve(promise) !== promise) {
-          console.error('Trigger ' + TriggerHelper.Trigger.id + ': promise function did not return a promise');
+          console.error('Trigger ' + triggerHelper.trigger.id + ': promise function did not return a promise');
           promise = null;
         }
       } else {
-        console.error('Trigger ' + TriggerHelper.Trigger.id + ': promise defined but not a function');
+        console.error('Trigger ' + triggerHelper.trigger.id + ': promise defined but not a function');
       }
     }
     if (promise === null) {
@@ -596,100 +598,102 @@ class PopupText {
     return promise;
   }
 
-  _OnTriggerInternal_Sound(TriggerHelper) {
-    TriggerHelper.SoundUrl = TriggerHelper.ValueOrFunction(TriggerHelper.Trigger.sound);
+  _onTriggerInternalSound(triggerHelper) {
+    triggerHelper.soundUrl = triggerHelper.valueOrFunction(triggerHelper.trigger.sound);
   }
 
-  _OnTriggerInternal_SoundVolume(TriggerHelper) {
-    TriggerHelper.TriggerSoundVol =
-      TriggerHelper.ValueOrFunction(TriggerHelper.Trigger.soundVolume);
+  _onTriggerInternalSoundVolume(triggerHelper) {
+    triggerHelper.triggerSoundVol =
+      triggerHelper.valueOrFunction(triggerHelper.trigger.soundVolume);
   }
 
-  _OnTriggerInternal_Response(TriggerHelper) {
+  _onTriggerInternalResponse(triggerHelper) {
     let response = {};
-    if (TriggerHelper.Trigger.response) {
+    if (triggerHelper.trigger.response) {
       // Can't use ValueOrFunction here as r returns a non-localizable object.
-      let r = TriggerHelper.Trigger.response;
-      response = (typeof (r) == 'function') ? r(this.data, TriggerHelper.Matches) : r;
+      let r = triggerHelper.trigger.response;
+      response = (typeof (r) == 'function') ? r(this.data, triggerHelper.matches) : r;
 
       // Turn falsy values into a default no-op response.
       if (!response)
         response = {};
     }
-    TriggerHelper.Response = response;
+    triggerHelper.response = response;
   }
 
-  _OnTriggerInternal_AlarmText(TriggerHelper) {
-    this._AddTextFor('alarm', TriggerHelper);
+  _onTriggerInternalAlarmText(triggerHelper) {
+    this._addTextFor('alarm', triggerHelper);
   }
 
-  _OnTriggerInternal_AlertText(TriggerHelper) {
-    this._AddTextFor('alert', TriggerHelper);
+  _onTriggerInternalAlertText(triggerHelper) {
+    this._addTextFor('alert', triggerHelper);
   }
 
-  _OnTriggerInternal_InfoText(TriggerHelper) {
-    this._AddTextFor('info', TriggerHelper);
+  _onTriggerInternalInfoText(triggerHelper) {
+    this._addTextFor('info', triggerHelper);
   }
 
-  _OnTriggerInternal_GroupTTS(TriggerHelper) {
-    if (TriggerHelper.GroupSpokenAlertsEnabled) {
-      if ('GroupTTSText' in TriggerHelper.TriggerOptions)
-        TriggerHelper.TTSText = ValueOrFunction(TriggerHelper.TriggerOptions.GroupTTSText);
-      else if ('groupTTS' in TriggerHelper.Trigger)
-        TriggerHelper.TTSText = ValueOrFunction(TriggerHelper.Trigger.groupTTS);
-      else if ('groupTTS' in TriggerHelper.Response)
-        TriggerHelper.TTSText = ValueOrFunction(TriggerHelper.Response.groupTTS);
+  _onTriggerInternalGroupTTS(triggerHelper) {
+    if (triggerHelper.groupSpokenAlertsEnabled) {
+      if ('GroupTTSText' in triggerHelper.triggerOptions) {
+        triggerHelper.ttsText =
+          triggerHelper.valueOrFunction(triggerHelper.triggerOptions.GroupTTSText);
+      } else if ('groupTTS' in triggerHelper.trigger) {
+        triggerHelper.ttsText = triggerHelper.valueOrFunction(triggerHelper.trigger.groupTTS);
+      } else if ('groupTTS' in triggerHelper.response) {
+        triggerHelper.ttsText = triggerHelper.valueOrFunction(triggerHelper.response.groupTTS);
+      }
     }
   }
 
-  _OnTriggerInternal_TTS(TriggerHelper) {
-    if (!TriggerHelper.GroupSpokenAlertsEnabled || typeof TriggerHelper.TTSText === 'undefined') {
-      if ('TTSText' in TriggerHelper.TriggerOptions)
-        TriggerHelper.TTSText = ValueOrFunction(TriggerHelper.TriggerOptions.TTSText);
-      else if ('tts' in TriggerHelper.Trigger)
-        TriggerHelper.TTSText = ValueOrFunction(TriggerHelper.Trigger.tts);
-      else if ('tts' in TriggerHelper.Response)
-        TriggerHelper.TTSText = ValueOrFunction(TriggerHelper.Response.TTSText);
+  _onTriggerInternalTTS(triggerHelper) {
+    if (!triggerHelper.groupSpokenAlertsEnabled || typeof triggerHelper.ttsText === 'undefined') {
+      if ('TTSText' in triggerHelper.triggerOptions)
+        triggerHelper.ttsText = triggerHelper.valueOrFunction(triggerHelper.triggerOptions.TTSText);
+      else if ('tts' in triggerHelper.trigger)
+        triggerHelper.ttsText = triggerHelper.valueOrFunction(triggerHelper.trigger.tts);
+      else if ('tts' in triggerHelper.response)
+        triggerHelper.ttsText = triggerHelper.valueOrFunction(triggerHelper.response.TTSText);
       else
-        TriggerHelper.TTSText = TriggerHelper.DefaultTTSText;
+        triggerHelper.ttsText = triggerHelper.defaultTTSText;
     }
   }
 
-  _OnTriggerInternal_PlayAudio(TriggerHelper) {
-    if (TriggerHelper.Trigger.sound && TriggerHelper.SoundUrl) {
-      let namedSound = TriggerHelper.SoundUrl + 'Sound';
-      let namedSoundVolume = TriggerHelper.SoundUrl + 'SoundVolume';
+  _onTriggerInternalPlayAudio(triggerHelper) {
+    if (triggerHelper.trigger.sound && triggerHelper.soundUrl) {
+      let namedSound = triggerHelper.soundUrl + 'Sound';
+      let namedSoundVolume = triggerHelper.soundUrl + 'SoundVolume';
       if (namedSound in this.options) {
-        TriggerHelper.SoundUrl = this.options[namedSound];
+        triggerHelper.soundUrl = this.options[namedSound];
         if (namedSoundVolume in this.options)
-          TriggerHelper.SoundVol = this.options[namedSoundVolume];
+          triggerHelper.soundVol = this.options[namedSoundVolume];
       }
     }
 
-    TriggerHelper.SoundUrl = TriggerHelper.TriggerOptions.SoundOverride || TriggerHelper.SoundUrl;
-    TriggerHelper.SoundVol = TriggerHelper.TriggerOptions.VolumeOverride ||
-      TriggerHelper.TriggerSoundVol || TriggerHelper.SoundVol;
+    triggerHelper.soundUrl = triggerHelper.triggerOptions.SoundOverride || triggerHelper.soundUrl;
+    triggerHelper.soundVol = triggerHelper.triggerOptions.VolumeOverride ||
+      triggerHelper.triggerSoundVol || triggerHelper.soundVol;
 
     // Text to speech overrides all other sounds.  This is so
     // that a user who prefers tts can still get the benefit
     // of infoText triggers without tts entries by turning
     // on (speech=true, text=true, sound=true) but this will
     // not cause tts to play over top of sounds or noises.
-    if (TriggerHelper.TTSText && TriggerHelper.SpokenAlertsEnabled) {
+    if (triggerHelper.ttsText && triggerHelper.spokenAlertsEnabled) {
       // Heuristics for auto tts.
       // * In case this is an integer.
-      TriggerHelper.TTSText = TriggerHelper.TTSText.toString();
+      triggerHelper.ttsText = triggerHelper.ttsText.toString();
       // * Remove a bunch of chars.
-      TriggerHelper.TTSText = TriggerHelper.TTSText.replace(/[#!]/g, '');
+      triggerHelper.ttsText = triggerHelper.ttsText.replace(/[#!]/g, '');
       // * slashes between mechanics
-      TriggerHelper.TTSText = TriggerHelper.TTSText.replace('/', ' ');
+      triggerHelper.ttsText = triggerHelper.ttsText.replace('/', ' ');
       // * arrows helping visually simple to understand e.g. ↖ Front left / Back right ↘
-      TriggerHelper.TTSText = TriggerHelper.TTSText.replace(/[↖-↙]/g, '');
+      triggerHelper.ttsText = triggerHelper.ttsText.replace(/[↖-↙]/g, '');
       // * Korean TTS reads wrong with '1번째'
-      TriggerHelper.TTSText = TriggerHelper.TTSText.replace('1번째', '첫번째');
+      triggerHelper.ttsText = triggerHelper.ttsText.replace('1번째', '첫번째');
       // * arrows at the front or the end are directions, e.g. "east =>"
-      TriggerHelper.TTSText = TriggerHelper.TTSText.replace(/[-=]>\s*$/g, '');
-      TriggerHelper.TTSText = TriggerHelper.TTSText.replace(/^\s*<[-=]/g, '');
+      triggerHelper.ttsText = triggerHelper.ttsText.replace(/[-=]>\s*$/g, '');
+      triggerHelper.ttsText = triggerHelper.ttsText.replace(/^\s*<[-=]/g, '');
       // * arrows in the middle are a sequence, e.g. "in => out => spread"
       let lang = this.options.AlertsLanguage || this.options.Language || 'en';
       let arrowReplacement = {
@@ -700,53 +704,54 @@ class PopupText {
         ja: 'や',
         ko: ' 그리고 ',
       };
-      TriggerHelper.TTSText = TriggerHelper.TTSText.replace(/\s*(<[-=]|[=-]>)\s*/g, arrowReplacement[lang]);
-      this.ttsSay(TriggerHelper.TTSText);
-    } else if (TriggerHelper.SoundUrl && TriggerHelper.SoundAlertsEnabled) {
-      this._PlayAudioFile(TriggerHelper.SoundUrl, TriggerHelper.SoundVol);
+      triggerHelper.ttsText = triggerHelper.ttsText.replace(/\s*(<[-=]|[=-]>)\s*/g, arrowReplacement[lang]);
+      this.ttsSay(triggerHelper.ttsText);
+    } else if (triggerHelper.soundUrl && triggerHelper.soundAlertsEnabled) {
+      this._playAudioFile(triggerHelper.soundUrl, triggerHelper.soundVol);
     }
   }
 
-  _OnTriggerInternal_Run(TriggerHelper) {
-    if ('run' in TriggerHelper.Trigger)
-      TriggerHelper.Trigger.run(this.data, TriggerHelper.Matches);
+  _onTriggerInternalRun(triggerHelper) {
+    if ('run' in triggerHelper.trigger)
+      triggerHelper.trigger.run(this.data, triggerHelper.matches);
   }
 
-  _AddText(container, e) {
+  _addText(container, e) {
     container.appendChild(e);
     if (container.children.length > this.kMaxRowsOfText)
       container.removeChild(container.children[0]);
   }
 
-  _AddTextFor(TextType, TriggerHelper) {
+  _addTextFor(textType, triggerHelper) {
+    let textTypeUpper = textType[0].toUpperCase() + textType.slice(1);
     // infoText
-    let LowerTextType = TextType + 'Text';
+    let lowerTextKey = textType + 'Text';
     // InfoText
-    let UpperTextType = TextType[0].toUpperCase() + TextType.slice(1) + 'Text';
+    let upperTextKey = textTypeUpper + 'Text';
     // info-text
-    let TextElementClass = TextType + '-text';
-    let textObj = TriggerHelper.TriggerOptions[UpperTextType] ||
-      TriggerHelper.Trigger[LowerTextType] || TriggerHelper.Response[LowerTextType];
+    let textElementClass = textType + '-text';
+    let textObj = triggerHelper.triggerOptions[upperTextKey] ||
+      triggerHelper.trigger[lowerTextKey] || triggerHelper.response[lowerTextKey];
     if (textObj) {
-      let text = TriggerHelper.ValueOrFunction(textObj);
-      TriggerHelper.DefaultTTSText = TriggerHelper.DefaultTTSText || text;
-      if (text && TriggerHelper.TextAlertsEnabled) {
+      let text = triggerHelper.valueOrFunction(textObj);
+      triggerHelper.defaultTTSText = triggerHelper.defaultTTSText || text;
+      if (text && triggerHelper.textAlertsEnabled) {
         text = triggerUpperCase(text);
-        let holder = this[LowerTextType].getElementsByClassName('holder')[0];
-        let div = this._MakeTextElement(text, TextElementClass);
-        this._AddText(holder, div);
-        this._ScheduleRemoveText(holder, div,
-            (TriggerHelper.Duration.FromTrigger || TriggerHelper.Duration[LowerTextType]));
+        let holder = this[lowerTextKey].getElementsByClassName('holder')[0];
+        let div = this._makeTextElement(text, textElementClass);
+        this._addText(holder, div);
+        this._scheduleRemoveText(holder, div,
+            (triggerHelper.duration.fromTrigger || triggerHelper.duration[lowerTextKey]));
 
-        if (!TriggerHelper.SoundUrl) {
-          TriggerHelper.SoundUrl = this.options[TextType + 'Sound'];
-          TriggerHelper.SoundVol = this.options[TextType + 'SoundVolume'];
+        if (!triggerHelper.soundUrl) {
+          triggerHelper.soundUrl = this.options[textTypeUpper + 'Sound'];
+          triggerHelper.soundVol = this.options[textTypeUpper + 'SoundVolume'];
         }
       }
     }
   }
 
-  _MakeTextElement(text, className) {
+  _makeTextElement(text, className) {
     let div = document.createElement('div');
     div.classList.add(className);
     div.classList.add('animate-text');
@@ -754,7 +759,7 @@ class PopupText {
     return div;
   }
 
-  _ScheduleRemoveText(container, e, delay) {
+  _scheduleRemoveText(container, e, delay) {
     window.setTimeout(() => {
       for (let i = 0; i < container.children.length; ++i) {
         if (container.children[i] == e) {
@@ -765,9 +770,9 @@ class PopupText {
     }, delay * 1000);
   }
 
-  _PlayAudioFile(URL, Volume) {
-    let audio = new Audio(URL);
-    audio.volume = Volume;
+  _playAudioFile(url, volume) {
+    let audio = new Audio(url);
+    audio.volume = volume;
     audio.play();
   }
 


### PR DESCRIPTION
This PR refactors the `PopupText` class's `OnTriggerInternal` function to move functionality to subfunctions. This results in cleaner code and allows the raid emulator redesign that I've been working on to override the time-sensitive portions of the functionality with its own logic for pause/seek support.