### PR TITLE
eureka: remove character name on map

### DIFF
--- a/ui/eureka/eureka.js
+++ b/ui/eureka/eureka.js
@@ -2056,9 +2056,9 @@ class EurekaTracker {
       let gRegex = this.Translate(this.options.Regex);
       let gFlagRegex = gRegex['gFlagRegex'];
       let match = log.match(gFlagRegex);
-      if (match){
+      if (match) {
         // remove character name on Korean server (if not /echo)
-        if(this.options.Language == 'ko' && !log.match(/00:0038:/))
+        if (this.options.Language == 'ko' && !log.match(/00:0038:/))
           match[1] = match[1].replace(/(.*):/, '');
         this.AddFlag(match[2], match[3], match[1], match[4]);
       }

--- a/ui/eureka/eureka.js
+++ b/ui/eureka/eureka.js
@@ -2171,6 +2171,8 @@ class EurekaTracker {
       afterText = '';
     }
     beforeText = beforeText.replace(/(?: at|@)$/, '');
+    // remove party member number in the front
+    beforeText = beforeText.replace(/\uE090-\uE097/g, '');
 
     let container = document.getElementById('flag-labels');
     let label = document.createElement('div');

--- a/ui/eureka/eureka.js
+++ b/ui/eureka/eureka.js
@@ -2056,8 +2056,12 @@ class EurekaTracker {
       let gRegex = this.Translate(this.options.Regex);
       let gFlagRegex = gRegex['gFlagRegex'];
       let match = log.match(gFlagRegex);
-      if (match)
+      if (match){
+        // remove character name on Korean server (if not /echo)
+        if(this.options.Language == 'ko' && !log.match(/00:0038:/))
+          match[1] = match[1].replace(/(.*):/, '');
         this.AddFlag(match[2], match[3], match[1], match[4]);
+      }
       let gTrackerRegex = gRegex['gTrackerRegex'];
       match = log.match(gTrackerRegex);
       if (match)
@@ -2171,8 +2175,6 @@ class EurekaTracker {
       afterText = '';
     }
     beforeText = beforeText.replace(/(?: at|@)$/, '');
-    // remove party member number in the front
-    beforeText = beforeText.replace(/[\uE090-\uE097]/g, '');
 
     let container = document.getElementById('flag-labels');
     let label = document.createElement('div');

--- a/ui/eureka/eureka.js
+++ b/ui/eureka/eureka.js
@@ -2172,7 +2172,7 @@ class EurekaTracker {
     }
     beforeText = beforeText.replace(/(?: at|@)$/, '');
     // remove party member number in the front
-    beforeText = beforeText.replace(/\uE090-\uE097/g, '');
+    beforeText = beforeText.replace(/[\uE090-\uE097]/g, '');
 
     let container = document.getElementById('flag-labels');
     let label = document.createElement('div');

--- a/ui/eureka/eureka.js
+++ b/ui/eureka/eureka.js
@@ -102,19 +102,19 @@ let Options = {
   },
   Regex: {
     en: {
-      'gFlagRegex': Regexes.parse(/00:00..:(?:[^:]*:)?(.*)Eureka (?:Anemos|Pagos|Pyros|Hydatos) \( (\y{Float})\s*, (\y{Float}) \)(.*$)/),
+      'gFlagRegex': Regexes.parse(/00:00(?:38:|..:[^:]*:)(.*)Eureka (?:Anemos|Pagos|Pyros|Hydatos) \( (\y{Float})\s*, (\y{Float}) \)(.*$)/),
       'gTrackerRegex': Regexes.parse(/(?:https:\/\/)?ffxiv-eureka\.com\/(?!maps\/)(\S*)\/?/),
       'gImportRegex': Regexes.parse(/00:00..:(.*)NMs on cooldown: (\S.*\))/),
       'gTimeRegex': Regexes.parse(/(.*) \((\d*)m\)/),
     },
     cn: {
-      'gFlagRegex': Regexes.parse(/00:00..:(.*)(?:常风之地|恒冰之地|涌火之地|丰水之地) \( (\y{Float})\s*, (\y{Float}) \)(.*$)/),
+      'gFlagRegex': Regexes.parse(/00:00(?:38:|..:[^:]*:)(.*)(?:常风之地|恒冰之地|涌火之地|丰水之地) \( (\y{Float})\s*, (\y{Float}) \)(.*$)/),
       'gTrackerRegex': Regexes.parse(/(?:https:\/\/)?ffxiv-eureka\.com\/(?!maps\/)(\S*)\/?/),
       'gImportRegex': Regexes.parse(/00:00..:(.*)冷却中的NM: (\S.*\))/),
       'gTimeRegex': Regexes.parse(/(.*) \((\d*)分(钟*)\)/),
     },
     ko: {
-      'gFlagRegex': Regexes.parse(/00:00..:(.*)에우레카: (?:아네모스|파고스|피로스|히다토스) 지대 \( (\y{Float})\s*, (\y{Float}) \)(.*$)/),
+      'gFlagRegex': Regexes.parse(/00:00(?:38:|..:[^:]*:)(.*)에우레카: (?:아네모스|파고스|피로스|히다토스) 지대 \( (\y{Float})\s*, (\y{Float}) \)(.*$)/),
       'gTrackerRegex': Regexes.parse(/(?:https:\/\/)?ffxiv-eureka\.com\/(?!maps\/)(\S*)\/?/),
       'gImportRegex': Regexes.parse(/00:00..:(.*)토벌한 마물: (\S.*\))/),
       'gTimeRegex': Regexes.parse(/(.*) \((\d*)분\)/),
@@ -2056,12 +2056,8 @@ class EurekaTracker {
       let gRegex = this.Translate(this.options.Regex);
       let gFlagRegex = gRegex['gFlagRegex'];
       let match = log.match(gFlagRegex);
-      if (match) {
-        // remove character name on Korean server (if not /echo)
-        if (this.options.Language == 'ko' && !log.match(/00:0038:/))
-          match[1] = match[1].replace(/(.*):/, '');
+      if (match)
         this.AddFlag(match[2], match[3], match[1], match[4]);
-      }
       let gTrackerRegex = gRegex['gTrackerRegex'];
       match = log.match(gTrackerRegex);
       if (match)

--- a/ui/eureka/eureka.js
+++ b/ui/eureka/eureka.js
@@ -1192,7 +1192,7 @@ let Options = {
             fr: 'Eldthurs',
             ja: 'エルドスルス',
             cn: '火巨人',
-            ko: '구부',
+            ko: '엘드투르스',
           },
           trackerName: {
             en: 'Eldthurs',


### PR DESCRIPTION
remove these characters on map ![ffxiv_20200423_211302_148](https://user-images.githubusercontent.com/4695371/80098090-4280ee80-85a7-11ea-9026-b4906d5b6225.png)
party member's \<flag\> chat -> those party member's number also printed on map

one better Korean label name.