### PR TITLE
Correction Jap general.js

### DIFF
--- a/ui/oopsyraidsy/data/00-misc/general.js
+++ b/ui/oopsyraidsy/data/00-misc/general.js
@@ -57,7 +57,7 @@
             en: 'bunny',
             de: 'Hase',
             fr: 'lapin',
-            ja: 'ウサギ',
+            ja: 'バニー',
             cn: '兔子',
             ko: '토끼',
           },

--- a/ui/oopsyraidsy/data/00-misc/general.js
+++ b/ui/oopsyraidsy/data/00-misc/general.js
@@ -57,7 +57,7 @@
             en: 'bunny',
             de: 'Hase',
             fr: 'lapin',
-            ja: 'バニー',
+            ja: 'うさぎ',
             cn: '兔子',
             ko: '토끼',
           },


### PR DESCRIPTION
I added this line (Ja) which did not exist, and I have just seen another translation in newly created lines. I therefore correct for more consistency.

If the translator (ja) wants to comment, it's welcome. Picture taken in (ui / eureka / eureka.js)
![Bunny](https://user-images.githubusercontent.com/61565834/80798725-562ee500-8ba5-11ea-8522-91e633bf130a.PNG)
