### PR TITLE
Util: Tiny QoL fix for make_timeline

### DIFF
--- a/util/make_timeline.py
+++ b/util/make_timeline.py
@@ -186,7 +186,8 @@ def main(args):
     last_entry = {"time": 0, "ability_id": ""}
 
     output = []
-    output.append('0 "Start"')
+    # No reason not to automate syncing if there's a countdown.
+    output.append('0 "Start" sync /Engage!/ window 0,1')
 
     for entry in entries:
         # First up, check if it's an ignored entry


### PR DESCRIPTION
I've forgotten the `Engage!` sync on way too many timelines already. Rather than improve my memory, I'm instead opting to be constructively selfish here.