### PR TITLE
raidboss PopupText class suppressed check logic

### DIFF
--- a/ui/raidboss/popup-text.js
+++ b/ui/raidboss/popup-text.js
@@ -390,7 +390,7 @@ class PopupText {
   OnTriggerInternal(trigger, matches) {
     let now = +new Date();
 
-    if (!this._onTriggerInternalCheckSuppressed(trigger, now))
+    if (this._onTriggerInternalCheckSuppressed(trigger, now))
       return;
 
     // If using named groups, treat matches.groups as matches
@@ -502,11 +502,11 @@ class PopupText {
   _onTriggerInternalCheckSuppressed(trigger, when) {
     if (trigger.id && trigger.id in this.triggerSuppress) {
       if (this.triggerSuppress[trigger.id] > when)
-        return false;
+        return true;
 
       delete this.triggerSuppress[trigger.id];
     }
-    return true;
+    return false;
   }
 
   _onTriggerInternalCondition(triggerHelper) {


### PR DESCRIPTION
Part of the code review for #1366 was to invert the logic of the _onTriggerInternalCondition method to return false if the condition check fails. This PR changes the logic of the _onTriggerInternalCheckSuppressed method to return true if the trigger is suppressed, which more closely matches the expectation of the method name.