### PR TITLE
Util: De-combine the clean and split timeline functions in encounter_tools

### DIFF
--- a/util/encounter_tools.py
+++ b/util/encounter_tools.py
@@ -169,9 +169,12 @@ def choose_fight_times(args, encounters):
 
 
 # Timeline test/translate functions
-def clean_and_split_tl_line(line):
+def clean_tl_line(line):
+    return line.split('#')[0]
+
+def split_tl_line(line):
     return re.search(
-        r'^(?P<time>[\d\.]+)\s+"(?P<label>[^"]+)"\s+(?P<options>.+)', line.split("#")[0]
+        r'^(?P<time>[\d\.]+)\s+"(?P<label>[^"]+)"\s+(?P<options>.+)', line
     )
 
 

--- a/util/test_timeline.py
+++ b/util/test_timeline.py
@@ -21,7 +21,11 @@ def load_timeline(timeline):
             entry = {}
             # Remove trailing comment, if any,
             # then split the line into sections
-            match = e_tools.clean_and_split_tl_line(line)
+
+            cleaned_line = e_tools.clean_tl_line(line)
+
+            match = e_tools.split_tl_line(cleaned_line)
+
             if not match:
                 continue
 


### PR DESCRIPTION
I originally combined these two functions in #755, but after some work in November on translation stuff, it became clear that this probably wasn't ideal. In preparation (I *hope*) for some actual progress on translation utilities this summer, I'm just tossing this change in now.