### PR TITLE
raidboss: Remove Duplicate Timeline Entries

### DIFF
--- a/ui/raidboss/data/03-hw/raid/a3s.txt
+++ b/ui/raidboss/data/03-hw/raid/a3s.txt
@@ -80,10 +80,7 @@ hideall "--sync--"
 280.9 "Hydromorph" sync /:Hydrate Core:F29:/
 282.9 "--sync--" sync /:Hydrate Core:1040:/
 
-
 ### Phase 4: Jiggly Again
-280.9 "Hydromorph" sync /:Hydrate Core:F29:/
-282.9 "--sync--" sync /:Hydrate Core:1040:/
 284.5 "--targetable--"
 284.5 "--sync--" sync /:Living Liquid:EFD:/
 


### PR DESCRIPTION
Remove timeline entries because the timeline currently shows double Hydromorph while leaving adds phase.