### PR TITLE
ci: Update Python Linting

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,4 +22,4 @@ matrix:
       - pip install pylint==2.2.3 requests==2.22.0 PyYAML==5.1.2 black==19.10b0
     script:
       - pylint **/*.py --errors-only
-      - black **/*.py --line-length 100 --diff
+      - black **/*.py --line-length 100 --check --diff

--- a/test/test_timelines.py
+++ b/test/test_timelines.py
@@ -62,7 +62,9 @@ def main():
 
         # Run individual timeline tests
         for test_file in TIMELINE_TEST_DIRECTORY.iterdir():
-            exit_status |= subprocess.call(["node", str(test_file), str(filepath), str(trigger_filename)])
+            exit_status |= subprocess.call(
+                ["node", str(test_file), str(filepath), str(trigger_filename)]
+            )
 
     return exit_status
 

--- a/util/encounter_tools.py
+++ b/util/encounter_tools.py
@@ -170,12 +170,11 @@ def choose_fight_times(args, encounters):
 
 # Timeline test/translate functions
 def clean_tl_line(line):
-    return line.split('#')[0]
+    return line.split("#")[0]
+
 
 def split_tl_line(line):
-    return re.search(
-        r'^(?P<time>[\d\.]+)\s+"(?P<label>[^"]+)"\s+(?P<options>.+)', line
-    )
+    return re.search(r'^(?P<time>[\d\.]+)\s+"(?P<label>[^"]+)"\s+(?P<options>.+)', line)
 
 
 def is_tl_line_syncmatch(line):

--- a/util/gen_hunt_data.py
+++ b/util/gen_hunt_data.py
@@ -68,7 +68,7 @@ def parse_data(monsters, csvfile, lang="en", name_map=None):
             rank = "B"
 
         if nm_id in monsters:
-            assert monsters[nm_id]['id'] == name_id
+            assert monsters[nm_id]["id"] == name_id
             assert monsters[nm_id]["rank"] == rank
         else:
             monsters[nm_id] = {"id": name_id, "rank": rank, "name": {}}

--- a/util/make_timeline.py
+++ b/util/make_timeline.py
@@ -112,8 +112,8 @@ def parse_file(args):
                 continue
             line_fields = line.split("|")
             # We aren't including targetable lines unless the user explicitly says to.
-            if line[0:2] == '34' and not line_fields[3] in args.include_targetable:
-              continue
+            if line[0:2] == "34" and not line_fields[3] in args.include_targetable:
+                continue
 
             # At this point, we have a combat line for the timeline.
             entry = {
@@ -122,14 +122,16 @@ def parse_file(args):
                 "combatant": line_fields[3],
             }
             if line[0:2] in ["21", "22"]:
-              entry["ability_id"] = line_fields[4]
-              entry["ability_name"] = line_fields[5]
+                entry["ability_id"] = line_fields[4]
+                entry["ability_name"] = line_fields[5]
 
-              # Unknown abilities should be hidden sync lines by default.
-              if line_fields[5].startswith("Unknown_"):
-                  entry["ability_name"] = "--sync--"
+            # Unknown abilities should be hidden sync lines by default.
+            if line_fields[5].startswith("Unknown_"):
+                entry["ability_name"] = "--sync--"
             else:
-              entry["targetable"] = "--targetable--" if line_fields[6] == "01" else "--untargetable--"
+                entry["targetable"] = (
+                    "--targetable--" if line_fields[6] == "01" else "--untargetable--"
+                )
             entries.append(entry)
 
     if not started:
@@ -199,28 +201,28 @@ def main(args):
 
         # Ignore targetable/untargetable while processing ignored entries
         if entry["line_type"] in ["21", "22"]:
-          # First up, check if it's an ignored entry
-          # Ignore autos, probably need a better rule than this
-          if entry["ability_name"] == "Attack":
-              continue
+            # First up, check if it's an ignored entry
+            # Ignore autos, probably need a better rule than this
+            if entry["ability_name"] == "Attack":
+                continue
 
-          # Ignore abilities by NPC allies
-          if entry["combatant"] in npc_combatants:
-              continue
+        # Ignore abilities by NPC allies
+        if entry["combatant"] in npc_combatants:
+            continue
 
-          # Ignore lines by arguments
-          if (
-              entry["ability_name"] in args.ignore_ability
-              or entry["ability_id"] in args.ignore_id
-              or entry["combatant"] in args.ignore_combatant
-          ):
-              continue
+        # Ignore lines by arguments
+        if (
+            entry["ability_name"] in args.ignore_ability
+            or entry["ability_id"] in args.ignore_id
+            or entry["combatant"] in args.ignore_combatant
+        ):
+            continue
 
-          # Ignore aoe spam
-          if entry["time"] == last_entry["time"] and entry["ability_id"] == last_entry["ability_id"]:
-              continue
+        # Ignore aoe spam
+        if entry["time"] == last_entry["time"] and entry["ability_id"] == last_entry["ability_id"]:
+            continue
         elif entry["line_type"] == "34" and not args.include_targetable:
-          continue
+            continue
 
         # Find out how long it's been since our last ability
         line_time = entry["time"]
@@ -266,13 +268,11 @@ def main(args):
 
         # Write the line
         if entry["line_type"] == "34":
-          output_entry = '{position:.1f} "{targetable}"'.format(
-              **entry
-          )
+            output_entry = '{position:.1f} "{targetable}"'.format(**entry)
         else:
-          output_entry = '{position:.1f} "{ability_name}" sync /:{combatant}:{ability_id}:/'.format(
-            **entry
-          )
+            output_entry = '{position:.1f} "{ability_name}" sync /:{combatant}:{ability_id}:/'.format(
+                **entry
+            )
 
         output.append(output_entry.encode("ascii", "ignore").decode("utf8", "ignore"))
 
@@ -327,10 +327,7 @@ if __name__ == "__main__":
         help="Timestamp of the start, e.g. '12:34:56.789",
     )
     parser.add_argument(
-        "-e",
-        "--end",
-        type=e_tools.timestamp_type,
-        help="Timestamp of the end, e.g. '12:34:56.789"
+        "-e", "--end", type=e_tools.timestamp_type, help="Timestamp of the end, e.g. '12:34:56.789'"
     )
     parser.add_argument(
         "-lf",
@@ -367,11 +364,11 @@ if __name__ == "__main__":
         help="Abilities that indicate a new phase, and the time to jump to, e.g. 28EC:1000",
     )
     parser.add_argument(
-      "-it",
-      "--include_targetable",
-      nargs="*",
-      default=[],
-      help="Set this flag to include '34' log lines when making the timeline",
+        "-it",
+        "--include_targetable",
+        nargs="*",
+        default=[],
+        help="Set this flag to include '34' log lines when making the timeline",
     )
 
     # Aggregate arguments

--- a/util/test_timeline.py
+++ b/util/test_timeline.py
@@ -542,7 +542,9 @@ if __name__ == "__main__":
         raise parser.error("Automatic encounter listing requires an input file")
 
     if args.search_fights > -1 and not args.timeline:
-        raise parser.error("You must specify a timeline file before testing against a specific encounter.")
+        raise parser.error(
+            "You must specify a timeline file before testing against a specific encounter."
+        )
 
     if args.file and not ((args.start and args.end) or args.search_fights):
         raise parser.error("Log file input requires start and end timestamps")

--- a/util/timeline_adjust.py
+++ b/util/timeline_adjust.py
@@ -22,16 +22,18 @@ def main():
         description="A utility to uniformly adjust times in an act timeline file"
     )
     parser.add_argument(
-        "-file", "-f",
+        "-file",
+        "-f",
         required=True,
         type=argparse.FileType("r", encoding="utf8"),
         help="The timeline file to adjust times in",
     )
     parser.add_argument(
-        "-adjust", "-a",
+        "-adjust",
+        "-a",
         required=True,
         type=float,
-        help="The amount of time to adjust each entry by"
+        help="The amount of time to adjust each entry by",
     )
 
     args = parser.parse_args()


### PR DESCRIPTION
Past pull requests to enable linting (https://github.com/quisquous/cactbot/pull/978) did not properly enable failing on lint failure within CI systems; update existing code base to conform to [black](https://black.readthedocs.io/en/stable/)'s standards of pythonic beauty and enable failing within CI on unformatted Python code to prevent further drift.