### PR TITLE
docs: Update GitHub Badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 <img align="right" src="https://raw.githubusercontent.com/quisquous/cactbot/master/screenshots/cactbot-logo-320x320.png">
 
 [![GitHub Workflow Status (branch)](https://img.shields.io/github/workflow/status/quisquous/cactbot/Test/master)](https://github.com/quisquous/cactbot/actions?query=workflow%3ATest+branch%3Amaster)
-[![GitHub release (latest SemVer)](https://img.shields.io/github/v/release/quisquous/cactbot?color=brightgreen&sort=semver)](https://github.com/quisquous/cactbot/releases)
+[![GitHub release (latest SemVer)](https://img.shields.io/github/v/release/quisquous/cactbot?color=brightgreen&sort=semver)](https://github.com/quisquous/cactbot/releases/latest)
 
 1. [About](#about)
 1. [Installing](#installing)

--- a/README.md
+++ b/README.md
@@ -2,7 +2,8 @@
 
 <img align="right" src="https://raw.githubusercontent.com/quisquous/cactbot/master/screenshots/cactbot-logo-320x320.png">
 
-[![build status](https://travis-ci.org/quisquous/cactbot.svg?branch=master)](https://travis-ci.org/quisquous/cactbot)
+[![GitHub Workflow Status (branch)](https://img.shields.io/github/workflow/status/quisquous/cactbot/Test/master)](https://github.com/quisquous/cactbot/actions?query=workflow%3ATest+branch%3Amaster)
+[![GitHub release (latest SemVer)](https://img.shields.io/github/v/release/quisquous/cactbot?color=brightgreen&sort=semver)](https://github.com/quisquous/cactbot/releases)
 
 1. [About](#about)
 1. [Installing](#installing)


### PR DESCRIPTION
Update Travis CI build status badge to instead point to GitHub Actions' Test workflow off master. Add badge noting the latest semver release, redirecting to the Releases page.