### PR TITLE
Util: Remove limit resets from encounter_tools' automated encounter detection

### DIFF
--- a/util/encounter_tools.py
+++ b/util/encounter_tools.py
@@ -41,7 +41,7 @@ def str_time(timestamp):
 
 
 def is_line_end(line_fields):
-    if is_zone_unseal(line_fields) or is_limit_reset(line_fields):
+    if is_zone_unseal(line_fields):
         return True
     return is_encounter_end_code(line_fields)
 
@@ -57,10 +57,6 @@ def is_zone_unseal(line_fields):
 def is_line_attack(line_fields):
     # We want only situations where a friendly attacks an enemy
     return line_fields[0] in ("21", "22") and line_fields[6].startswith("4")
-
-
-def is_limit_reset(line_fields):
-    return line_fields[4] == "The limit gauge resets!"
 
 
 def is_instance_begun(line_fields):


### PR DESCRIPTION
This should resolve #1498. It's unlikely Square will implement many more two-part encounters, and since most players deliberately wipe after checkpoints for a clean reset, this will work for 99% of content. For the other 1%, we still have the old start/end flags available for manual usage.

(There's other "minor" cleanup I need to do on this file, but I'd prefer to do that as a separate request to keep things organized.)