### PR TITLE
ci: Update Markdownlint Command to Work Universally

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "lint": "node_modules/.bin/eslint resources ui user test util",
     "lintfix": "node_modules/.bin/eslint --fix resources ui user test util",
     "stylelint": "node_modules/.bin/stylelint resources/**/*.css ui/**/*.css user/**/*.css test/**/*.css",
-    "markdownlint": "node_modules/.bin/markdownlint **/*.md --ignore node_modules --ignore publish --ignore CactbotOverlay/ThirdParty",
+    "markdownlint": "node_modules/.bin/markdownlint . --ignore node_modules --ignore publish --ignore CactbotOverlay/ThirdParty",
     "test": "python test/run_tests.py"
   },
   "devDependencies": {


### PR DESCRIPTION
This was an (un)interesting issue. The original command:
```
node_modules/.bin/markdownlint **/*.md --ignore node_modules --ignore publish --ignore CactbotOverlay/ThirdParty
```
when run through the command line directly would not pick up root level changes to Markdown files. However, running the npm wrapper command:
```
npm run markdownlint
```
would pick it up.

However, neither the original command nor the npm wrapper command would work on my MacOS command line when attempting to find issues to files in the root directory. This updated command should work for all variations, Unix/Windows, command line directly, and npm wrapper command.