### PR TITLE
Util: Update encounter_tools to permit "#" in timeline text

### DIFF
--- a/util/encounter_tools.py
+++ b/util/encounter_tools.py
@@ -169,8 +169,8 @@ def clean_tl_line(line):
     # Any lines containing # before any quote marks
     # should be returned with anything following # stripped.
     if re.search(r'^[^"]*#.*$', line):
-        return line.split('#')[0]
-    
+        return line.split("#")[0]
+
     # If a timeline text entry contains a "#" character as a string literal, this function breaks
     # unless we do this little dance.
     line_groups = line.split('"')

--- a/util/encounter_tools.py
+++ b/util/encounter_tools.py
@@ -166,10 +166,13 @@ def choose_fight_times(args, encounters):
 
 # Timeline test/translate functions
 def clean_tl_line(line):
-    # If a timeline text entry has a "#" character, this function breaks
+    # Any lines containing # before any quote marks
+    # should be returned with anything following # stripped.
+    if re.search(r'^[^"]*#.*$', line):
+        return line.split('#')[0]
+    
+    # If a timeline text entry contains a "#" character as a string literal, this function breaks
     # unless we do this little dance.
-    if line[0] is "#" or not re.search(r'"', line):
-        return line
     line_groups = line.split('"')
     line_groups[2] = line_groups[2].split("#")[0]
     return '"'.join(line_groups[i] for i in range(0, 3))

--- a/util/encounter_tools.py
+++ b/util/encounter_tools.py
@@ -166,7 +166,13 @@ def choose_fight_times(args, encounters):
 
 # Timeline test/translate functions
 def clean_tl_line(line):
-    return line.split("#")[0]
+    # If a timeline text entry has a "#" character, this function breaks
+    # unless we do this little dance.
+    if line[0] is "#" or not re.search(r'"', line):
+        return line
+    line_groups = line.split('"')
+    line_groups[2] = line_groups[2].split("#")[0]
+    return '"'.join(line_groups[i] for i in range(0, 3))
 
 
 def split_tl_line(line):


### PR DESCRIPTION
This should resolve #1499. Nothing much to say about it, It Works On My Machine. Cleaner implementation suggestions welcome, I mostly tossed this together.

(It is technically not necessary to handle the case of full-line comments, since for any situation where comments would appear, they would have been ignored before reaching `clean_line`. But of course it doesn't hurt to Just Make Sure.)

```
1251.082: Matched entry: 1251.1 Morn Afah #1 (+0.018s)
1257.462: Matched entry: 1257.5 Akh Morn #1 (+0.038s)
1269.843: Matched entry: 1270.0 Exaflare #1 (+0.157s)
1289.231: Matched entry: 1289.3 Akh Morn #2 (+0.069s)
1306.903: Matched entry: 1306.9 Morn Afah #2 (-0.003s)
1319.180: Matched entry: 1319.2 Exaflare #2 (+0.020s)
1340.391: Matched entry: 1340.5 Morn Afah #3 (+0.109s)
1352.693: Matched entry: 1352.7 Akh Morn #3 (+0.007s)
1369.366: Matched entry: 1369.4 Exaflare #3 (+0.034s)
```