### PR TITLE
util: Update Standalone Scripts as Executables

### DIFF
--- a/util/check_translation.py
+++ b/util/check_translation.py
@@ -1,4 +1,6 @@
-# Checks a trigger file and timeline for translations.
+#!/usr/bin/env python
+
+"""Checks a trigger file and timeline for translations."""
 
 # TODO: this does not handle multi-line regexes.  You have to join them before running this.  <_<
 

--- a/util/coinach.py
+++ b/util/coinach.py
@@ -1,5 +1,6 @@
-# Helper for automating SaintCoinach
-# https://github.com/ufx/SaintCoinach
+#!/usr/bin/env python
+
+"""Helper for automating SaintCoinach -- https://github.com/ufx/SaintCoinach"""
 
 import json
 import re

--- a/util/find_missing_translations.py
+++ b/util/find_missing_translations.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+
 import argparse
 import io
 import os

--- a/util/gen_fisher_data.py
+++ b/util/gen_fisher_data.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+
 import csv
 import coinach
 import json

--- a/util/gen_hunt_data.py
+++ b/util/gen_hunt_data.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+
 import csv
 import urllib.request
 import os

--- a/util/gen_territory_type.py
+++ b/util/gen_territory_type.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+
 import coinach
 import csv
 import os

--- a/util/gen_weather_rate.py
+++ b/util/gen_weather_rate.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+
 import csv
 import coinach
 import os

--- a/util/make_timeline.py
+++ b/util/make_timeline.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+
 import argparse
 from datetime import datetime
 import re

--- a/util/publish.sh
+++ b/util/publish.sh
@@ -1,3 +1,5 @@
+#!/usr/bin/env bash
+
 BASE=$(dirname "$0")/../
 BIN=$BASE/bin/x64/Release
 OUT=$BASE/publish/cactbot-release/cactbot

--- a/util/test_timeline.py
+++ b/util/test_timeline.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+
 import argparse
 from datetime import datetime
 from pathlib import Path

--- a/util/timeline_adjust.py
+++ b/util/timeline_adjust.py
@@ -1,4 +1,5 @@
 #!/usr/bin/python
+
 from __future__ import print_function
 import argparse
 import re

--- a/util/translate_fight.py
+++ b/util/translate_fight.py
@@ -1,4 +1,6 @@
-# Generates en/de/fr/ja translations for a given fflogs report.
+#!/usr/bin/env python
+
+"""Generates en/de/fr/ja translations for a given fflogs report"""
 
 import argparse
 from collections import defaultdict


### PR DESCRIPTION
Add shebangs to standalone scripts and change the executable flag so they can be invoked shorthand.