### PR TITLE
npm: Update Hooks to Only Affect Code Changes

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,8 @@
     "chai": "^4.2.0",
     "eslint": "^6.8.0",
     "eslint-config-google": "^0.9.1",
+    "husky": "^4.2.5",
+    "lint-staged": "^10.0.8",
     "markdownlint-cli": "^0.20.0",
     "stylelint": "^12.0.1",
     "stylelint-config-standard": "^19.0.0"
@@ -156,12 +158,13 @@
   },
   "husky": {
     "hooks": {
-      "pre-push": "node_modules/.bin/npm-run-all lint stylelint markdownlint test"
+      "pre-commit": "lint-staged"
     }
   },
-  "dependencies": {
-    "husky": "^4.2.5",
-    "markdownlint": "^0.18.0",
-    "npm-run-all": "^4.1.5"
+  "lint-staged": {
+    "*.css": "stylelint",
+    "*.js": "eslint",
+    "*.md": "markdownlint",
+    "*.py": "python -m pylint --errors-only"
   }
 }


### PR DESCRIPTION
Update Husky to run hooks more frequently, but to take a significantly smaller amount of time by only running on staged code changes.