### PR TITLE
ci: Pin isort Dependency

### DIFF
--- a/.github/workflows/python-lint.yml
+++ b/.github/workflows/python-lint.yml
@@ -41,8 +41,8 @@ jobs:
         run: |
           echo "::add-matcher::.github/matchers/${{ github.job }}.json"
       - name: Install Dependencies
-        run: |
-          pip install pylint==2.2.3 PyYAML==5.1.2 requests==2.22.0
+        run: | # TODO: Update pylint version to one that natively caps isort dependency
+          pip install pylint==2.2.3 isort==4.3.21 PyYAML==5.1.2 requests==2.22.0
       - name: pylint **/*.py --errors-only
         run: |
           pylint **/*.py --errors-only


### PR DESCRIPTION
Pin CI system isort dependency until pylint is upgraded to a version where the dependency is properly capped. Addresses the dependency issues found in #1541.