### PR TITLE
ci: Pin Python Version

### DIFF
--- a/.github/workflows/python-lint.yml
+++ b/.github/workflows/python-lint.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v2
         with:
-          python-version: '3.7'
+          python-version: '3.7.7'
       - name: Install Dependencies
         run: |
           pip install black==19.10b0 PyYAML==5.1.2 requests==2.22.0
@@ -36,7 +36,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v2
         with:
-          python-version: '3.7'
+          python-version: '3.7.7'
       - name: Add Custom Problem Matcher
         run: |
           echo "::add-matcher::.github/matchers/${{ github.job }}.json"


### PR DESCRIPTION
Pin the CPython version in Python-oriented GitHub Actions to a micro/patch version.

I have been waffling on this issue for a couple hours now, trying to exactly pinpoint what broke in the upgrade to [CPython 3.7.8](https://docs.python.org/release/3.7.8/whatsnew/changelog.html#changelog):

<details>
<summary>
Click for recent Python-lint GitHub Action run error output.
</summary>

```sh
Run pip install pylint==2.2.3 PyYAML==5.1.2 requests==2.22.0
  pip install pylint==2.2.3 PyYAML==5.1.2 requests==2.22.0
  shell: /bin/bash -e {0}
  env:
    pythonLocation: /opt/hostedtoolcache/Python/3.7.8/x64
Collecting pylint==2.2.3
  Downloading pylint-2.2.3-py3-none-any.whl (750 kB)
Collecting PyYAML==5.1.2
  Downloading PyYAML-5.1.2.tar.gz (265 kB)
Collecting requests==2.22.0
  Downloading requests-2.22.0-py2.py3-none-any.whl (57 kB)
Collecting astroid<2.2.0,>=2.0
  Downloading astroid-2.1.0-py3-none-any.whl (176 kB)
Collecting mccabe
  Downloading mccabe-0.6.1-py2.py3-none-any.whl (8.6 kB)
Collecting isort>=4.2.5
  Downloading isort-5.0.4-py3-none-any.whl (153 kB)
Collecting idna<2.9,>=2.5
  Downloading idna-2.8-py2.py3-none-any.whl (58 kB)
Requirement already satisfied: urllib3!=1.25.0,!=1.25.1,<1.26,>=1.21.1 in /opt/hostedtoolcache/Python/3.7.8/x64/lib/python3.7/site-packages/urllib3-1.25.9-py3.7.egg (from requests==2.22.0) (1.25.9)
Requirement already satisfied: chardet<3.1.0,>=3.0.2 in /opt/hostedtoolcache/Python/3.7.8/x64/lib/python3.7/site-packages/chardet-3.0.4-py3.7.egg (from requests==2.22.0) (3.0.4)
Requirement already satisfied: certifi>=2017.4.17 in /opt/hostedtoolcache/Python/3.7.8/x64/lib/python3.7/site-packages/certifi-2020.6.20-py3.7.egg (from requests==2.22.0) (2020.6.20)
Collecting wrapt
  Downloading wrapt-1.12.1.tar.gz (27 kB)
Collecting lazy-object-proxy
  Downloading lazy_object_proxy-1.5.0-cp37-cp37m-manylinux1_x86_64.whl (57 kB)
Requirement already satisfied: six in /opt/hostedtoolcache/Python/3.7.8/x64/lib/python3.7/site-packages/six-1.15.0-py3.7.egg (from astroid<2.2.0,>=2.0->pylint==2.2.3) (1.15.0)
Building wheels for collected packages: PyYAML, wrapt
  Building wheel for PyYAML (setup.py): started
  Building wheel for PyYAML (setup.py): finished with status 'done'
  Created wheel for PyYAML: filename=PyYAML-5.1.2-cp37-cp37m-linux_x86_64.whl size=44104 sha256=ada23ec8ea389863aa4b5f9b886c93d3d01099392a0d5056b08235ae39b4d961
  Stored in directory: /home/runner/.cache/pip/wheels/23/b9/73/57aaccb6957d94ed63f474b51a9f7f992c5eff4635052c0557
  Building wheel for wrapt (setup.py): started
  Building wheel for wrapt (setup.py): finished with status 'done'
  Created wheel for wrapt: filename=wrapt-1.12.1-cp37-cp37m-linux_x86_64.whl size=71068 sha256=3f43a05b73e73190d1b4d32faced1f696b52f7b072f6d1fb6e7410059d0ad5c4
  Stored in directory: /home/runner/.cache/pip/wheels/62/76/4c/aa25851149f3f6d9785f6c869387ad82b3fd37582fa8147ac6
Successfully built PyYAML wrapt
ERROR: aws-sam-cli 0.53.0 has requirement requests==2.23.0, but you'll have requests 2.22.0 which is incompatible.
Installing collected packages: wrapt, lazy-object-proxy, astroid, mccabe, isort, pylint, PyYAML, idna, requests
  Attempting uninstall: PyYAML
    Found existing installation: PyYAML 5.3.1
    Uninstalling PyYAML-5.3.1:
      Successfully uninstalled PyYAML-5.3.1
  Attempting uninstall: idna
    Found existing installation: idna 2.10
    Uninstalling idna-2.10:
      Successfully uninstalled idna-2.10
  Attempting uninstall: requests
    Found existing installation: requests 2.23.0
    Uninstalling requests-2.23.0:
      Successfully uninstalled requests-2.23.0
Successfully installed PyYAML-5.1.2 astroid-2.1.0 idna-2.8 isort-5.0.4 lazy-object-proxy-1.5.0 mccabe-0.6.1 pylint-2.2.3 requests-2.22.0 wrapt-1.12.1
Traceback (most recent call last):
  File "/opt/hostedtoolcache/Python/3.7.8/x64/bin/pip", line 8, in <module>
    sys.exit(main())
  File "/opt/hostedtoolcache/Python/3.7.8/x64/lib/python3.7/site-packages/pip/_internal/cli/main.py", line 75, in main
    return command.main(cmd_args)
  File "/opt/hostedtoolcache/Python/3.7.8/x64/lib/python3.7/site-packages/pip/_internal/cli/base_command.py", line 114, in main
    return self._main(args)
  File "/opt/hostedtoolcache/Python/3.7.8/x64/lib/python3.7/site-packages/pip/_internal/cli/base_command.py", line 226, in _main
    self.handle_pip_version_check(options)
  File "/opt/hostedtoolcache/Python/3.7.8/x64/lib/python3.7/site-packages/pip/_internal/cli/req_command.py", line 155, in handle_pip_version_check
    timeout=min(5, options.timeout)
  File "/opt/hostedtoolcache/Python/3.7.8/x64/lib/python3.7/site-packages/pip/_internal/cli/req_command.py", line 100, in _build_session
    index_urls=self._get_index_urls(options),
  File "/opt/hostedtoolcache/Python/3.7.8/x64/lib/python3.7/site-packages/pip/_internal/network/session.py", line 249, in __init__
    self.headers["User-Agent"] = user_agent()
  File "/opt/hostedtoolcache/Python/3.7.8/x64/lib/python3.7/site-packages/pip/_internal/network/session.py", line 159, in user_agent
    setuptools_version = get_installed_version("setuptools")
  File "/opt/hostedtoolcache/Python/3.7.8/x64/lib/python3.7/site-packages/pip/_internal/utils/misc.py", line 634, in get_installed_version
    working_set = pkg_resources.WorkingSet()
  File "/opt/hostedtoolcache/Python/3.7.8/x64/lib/python3.7/site-packages/pip/_vendor/pkg_resources/__init__.py", line 567, in __init__
    self.add_entry(entry)
  File "/opt/hostedtoolcache/Python/3.7.8/x64/lib/python3.7/site-packages/pip/_vendor/pkg_resources/__init__.py", line 623, in add_entry
    for dist in find_distributions(entry, True):
  File "/opt/hostedtoolcache/Python/3.7.8/x64/lib/python3.7/site-packages/pip/_vendor/pkg_resources/__init__.py", line 1983, in find_eggs_in_zip
    if metadata.has_metadata('PKG-INFO'):
  File "/opt/hostedtoolcache/Python/3.7.8/x64/lib/python3.7/site-packages/pip/_vendor/pkg_resources/__init__.py", line 1414, in has_metadata
    return self._has(path)
  File "/opt/hostedtoolcache/Python/3.7.8/x64/lib/python3.7/site-packages/pip/_vendor/pkg_resources/__init__.py", line 1854, in _has
    return zip_path in self.zipinfo or zip_path in self._index()
  File "/opt/hostedtoolcache/Python/3.7.8/x64/lib/python3.7/site-packages/pip/_vendor/pkg_resources/__init__.py", line 1731, in zipinfo
    return self._zip_manifests.load(self.loader.archive)
  File "/opt/hostedtoolcache/Python/3.7.8/x64/lib/python3.7/site-packages/pip/_vendor/pkg_resources/__init__.py", line 1688, in load
    mtime = os.stat(path).st_mtime
FileNotFoundError: [Errno 2] No such file or directory: '/opt/hostedtoolcache/Python/3.7.8/x64/lib/python3.7/site-packages/PyYAML-5.3.1-py3.7-linux-x86_64.egg'
##[error]Process completed with exit code 1.
```

</details>

As it turns out, re-running CPython 3.7.7 builds works, but I didn't absolutely love this as a solution since we're already pinned at the minor release (informed readers may already know this is the ending to the story, but don't let that discourage you from reading the tales below!), I felt as though patches should be natural and hopefully non-breaking (or breaking, but in a good way). Additionally, up-pinning our PyYAML version also works, which I considered to be a better approach at the time. Digging into _why_ it works though is pretty bad.

There's a pretty curious error message that gets output:

```
ERROR: aws-sam-cli 0.53.0 has requirement requests==2.23.0, but you'll have requests 2.22.0 which is incompatible.
```

And I had spent a good amount of time wondering where this had come from, and what one of our three dependencies and their chain might be installing this; turns out, I installed [pipdeptree](https://pypi.org/project/pipdeptree/) locally and none of them are installing this.

So, I shelved that, and I went to go look at why two days ago (previous working runs) this hadn't been an issue. The [setup-python](https://github.com/actions/setup-python) GitHub Action doesn't look at the upstream PyPi for its resolution, but instead at [python-versions](https://github.com/actions/python-versions), which still didn't tell me why two days ago this worked, since the latest release was older than that. From there, I looked into what's installed on the [GitHub Action runners](https://github.com/actions/virtual-environments/blob/master/images/linux/Ubuntu1804-README.md) and found that it's installing the AWS SDK.

This is basically a long-winded way of saying that [the AWS SDK](https://github.com/awslabs/aws-sam-cli/blob/cd5efb07ea8a2423ed9886004df1e7e72eec4019/requirements/base.txt) is installing PyYAML at 5.3.1, which means that up-pinning PyYAML _does_ work, but for all the wrong reasons (basically it says we already have that dependency and skips it, 🎉 ).

There's a lot more red-herrings in here around some other things like [setuptools not working explicitly for pyyaml](https://github.com/pypa/setuptools/issues/2228), but that doesn't seem correct either since we should be using an older version (47.1.0) as per the CPython release notes/changelog (verified), and upgrading to the fixed version in the linked issue doesn't fix the problem.

There are alternative answers here as well, such as up-pinning PyYAML (I may warm up to this idea, but it sounds fundamentally bad), or adding `--ignore-installed` to the pip command, but all in all I'd prefer this command to be something you'd expect someone to invoke locally as well. I think this is (probably) a non-issue for most people, since I think I'm one of the few unix users of cactbot, and more specifically one of the few people that even runs Ubuntu, and this still doesn't affect me since I don't have weird conflicting issues with PyYAML locally.

This is all to say that I don't have an answer, this is acceptable, and it "solves" broken things for the time being. Future me will probably shake his future head at past/current me, but until then I think this is "good enough" for now. Thanks for coming to my TED talk.