### PR TITLE
Raidboss: eureka_hydatos fr

### DIFF
--- a/ui/raidboss/data/04-sb/eureka/eureka_hydatos.js
+++ b/ui/raidboss/data/04-sb/eureka/eureka_hydatos.js
@@ -611,6 +611,7 @@
       id: 'BA AV Eidos Relative Virtue Astral',
       regex: Regexes.gameLog({ line: 'Relative Virtue gains the effect of Astral Essence.*?', capture: false }),
       regexDe: Regexes.gameLog({ line: 'Die Relative Tugend erhält den Effekt von.*?Arm der Lichts.*?', capture: false }),
+      regexFr: Regexes.gameLog({ line: 'Vertu relative bénéficie de l\'effet  Bras de Lumière.*?', capture: false }),
       condition: function(data) {
         return data.sealed;
       },
@@ -625,6 +626,7 @@
       id: 'BA AV Eidos Relative Virtue Umbral',
       regex: Regexes.gameLog({ line: 'Relative Virtue gains the effect of Umbral Essence.*?', capture: false }),
       regexDe: Regexes.gameLog({ line: 'Die Relative Tugend erhält den Effekt von.*?Arm der Dunkelheit.*?', capture: false }),
+      regexFr: Regexes.gameLog({ line: 'Vertu relative bénéficie de l\'effet  Bras de Ténèbres.*?', capture: false }),
       condition: function(data) {
         return data.sealed;
       },

--- a/ui/raidboss/data/04-sb/eureka/eureka_hydatos.js
+++ b/ui/raidboss/data/04-sb/eureka/eureka_hydatos.js
@@ -611,7 +611,7 @@
       id: 'BA AV Eidos Relative Virtue Astral',
       regex: Regexes.gameLog({ line: 'Relative Virtue gains the effect of Astral Essence.*?', capture: false }),
       regexDe: Regexes.gameLog({ line: 'Die Relative Tugend erhält den Effekt von.*?Arm der Lichts.*?', capture: false }),
-      regexFr: Regexes.gameLog({ line: 'Vertu relative bénéficie de l\'effet  Bras de Lumière.*?', capture: false }),
+      regexFr: Regexes.gameLog({ line: 'Vertu relative bénéficie de l\'effet.*?Bras de Lumière.*?', capture: false }),
       condition: function(data) {
         return data.sealed;
       },
@@ -626,7 +626,7 @@
       id: 'BA AV Eidos Relative Virtue Umbral',
       regex: Regexes.gameLog({ line: 'Relative Virtue gains the effect of Umbral Essence.*?', capture: false }),
       regexDe: Regexes.gameLog({ line: 'Die Relative Tugend erhält den Effekt von.*?Arm der Dunkelheit.*?', capture: false }),
-      regexFr: Regexes.gameLog({ line: 'Vertu relative bénéficie de l\'effet  Bras de Ténèbres.*?', capture: false }),
+      regexFr: Regexes.gameLog({ line: 'Vertu relative bénéficie de l\'effet.*?Bras de Ténèbres.*?', capture: false }),
       condition: function(data) {
         return data.sealed;
       },


### PR DESCRIPTION
adds regex fr, questions sorry, i have this:
**in act log** 
![astral essence](https://user-images.githubusercontent.com/61565834/87245870-7272bc00-c449-11ea-9622-350fabb855f3.PNG)

**in my network log**
Vertu relative bénéficie de l'effet  Bras de Lumière.

I don't know if the one I added is well written or it should just be
`regexFr: Regexes.gameLog({ line: 'Vertu relative bénéficie de l\'effet Bras de Lumière.*?', capture: false }),`