### PR TITLE
oopsy: Added gainsEffect helper

### DIFF
--- a/ui/oopsyraidsy/oopsyraidsy.js
+++ b/ui/oopsyraidsy/oopsyraidsy.js
@@ -964,6 +964,23 @@ class DamageTracker {
     }
   }
 
+  AddGainsEffectTriggers(type, dict) {
+    if (!dict)
+      return;
+    let keys = Object.keys(dict);
+    for (let key of keys) {
+      let id = dict[key];
+      let trigger = {
+        id: key,
+        netRegex: NetRegexes.gainsEffect({ effectId: id }),
+        mistake: function(e, data, matches) {
+          return { type: type, blame: matches.target, text: matches.effect };
+        },
+      };
+      this.netTriggers.push(trigger);
+    }
+  }
+
   // Helper function for "double tap" shares where multiple players share
   // damage when it should only be on one person, such as a spread mechanic.
   AddShareTriggers(type, dict) {
@@ -1040,8 +1057,11 @@ class DamageTracker {
 
       if (this.zoneName.search(zoneRegex) < 0)
         continue;
+
       this.AddSimpleTriggers('warn', set.damageWarn);
       this.AddSimpleTriggers('fail', set.damageFail);
+      this.AddGainsEffectTriggers('warn', set.gainsEffectWarn);
+      this.AddGainsEffectTriggers('fail', set.gainsEffectFail);
       this.AddShareTriggers('warn', set.shareWarn);
       this.AddShareTriggers('fail', set.shareFail);
 


### PR DESCRIPTION
In line with #1504 , this adds support for `gainsEffect` mistakes without requiring dedicated triggers in a given instance's oopsy file. This is support only, with no changes to existing instance oopsy files.

Note that this helper uses the `matches` parameter rather than `event` in the returned `mistake` object. This is primarily because I don't have a firm enough grasp of `event` to have it work correctly with `netRegex` in the trigger body. This works, and is what we want to move toward in future anyway, so I feel that it's relatively acceptable here even if it doesn't exactly match the surrounding helpers.

I'm rather unhappy with 
```
      this.AddSimpleTriggers('warn', set.damageWarn);
      this.AddSimpleTriggers('fail', set.damageFail);
      this.AddGainsEffectTriggers('warn', set.gainsEffectWarn);
      this.AddGainsEffectTriggers('fail', set.gainsEffectFail);
      this.AddShareTriggers('warn', set.shareWarn);
      this.AddShareTriggers('fail', set.shareFail);
```
but realistically rewriting it to be "less bad" wouldn't save us much in terms of space or readability. Suggestions welcome!