### PR TITLE
npm: Update Lint-Staged Command to Run Via npx

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -64,6 +64,18 @@ Additionally, doing work in feature branches
 allows you to do two parallel pull requests at the same time,
 without entangling them together in the same commits and pull.
 
+#### Commit Validation, Testing, and Linting
+
+Cactbot uses a combination of [husky](https://github.com/typicode/husky)
+and [lint-staged](https://github.com/okonet/lint-staged),
+along with a suite of linters and tests to ensure code quality.
+These validations are done both on a client-side (your computer)
+and on the server-side (GitHub).
+
+To cut down on pre-commit check times,
+it is recommended to install `lint-staged` globally via `npm -g lint-staged`,
+as that will reduce the operation time for each commit.
+
 ### Code Review Culture
 
 Ideally, all changes should get code review.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -76,6 +76,16 @@ To cut down on pre-commit check times,
 it is recommended to install `lint-staged` globally via `npm -g lint-staged`,
 as that will reduce the operation time for each commit.
 
+Additionally, if the pre-commit validations are causing you significant problems,
+feel free to bypass the checks with `--no-verify` flag,
+such as `git commit --no-verify`,
+and open a pull request even if not everything is passing on your end.
+We can try to help with any tests that are failing
+and it helps us find any potentially confusing areas in the code.
+
+New contributors are always welcome
+and we definitely don't expect anyone to know everything right away.
+
 ### Code Review Culture
 
 Ideally, all changes should get code review.

--- a/package.json
+++ b/package.json
@@ -158,7 +158,7 @@
   },
   "husky": {
     "hooks": {
-      "pre-commit": "lint-staged"
+      "pre-commit": "npx lint-staged"
     }
   },
   "lint-staged": {


### PR DESCRIPTION
Changes `lint-staged` to run via `npx` rather than being invoked
directly. This change sets up the PATH for various programs like VSCode
or GitHub Desktop that might be running into issues where `lint-staged`
is attempting to be directly executed, outside of Node.