### PR TITLE
npm: Add lint-staged Script

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -72,11 +72,7 @@ along with a suite of linters and tests to ensure code quality.
 These validations are done both on a client-side (your computer)
 and on the server-side (GitHub).
 
-To cut down on pre-commit check times,
-it is recommended to install `lint-staged` globally via `npm install -g lint-staged`,
-as that will reduce the operation time for each commit.
-
-Additionally, if the pre-commit validations are causing you significant problems,
+If the pre-commit validations are causing you significant problems,
 feel free to bypass the checks with `--no-verify` flag,
 such as `git commit --no-verify`,
 and open a pull request even if not everything is passing on your end.

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "lintfix": "node_modules/.bin/eslint --fix resources ui user test util",
     "stylelint": "node_modules/.bin/stylelint resources/**/*.css ui/**/*.css user/**/*.css test/**/*.css",
     "markdownlint": "node_modules/.bin/markdownlint . --ignore node_modules --ignore publish --ignore CactbotOverlay/ThirdParty",
-    "test": "python test/run_tests.py"
+    "test": "python test/run_tests.py",
+    "lint-staged": "node_modules/.bin/lint-staged"
   },
   "devDependencies": {
     "chai": "^4.2.0",
@@ -158,7 +159,7 @@
   },
   "husky": {
     "hooks": {
-      "pre-commit": "npx lint-staged"
+      "pre-commit": "npm run lint-staged"
     }
   },
   "lint-staged": {


### PR DESCRIPTION
Create `lint-staged` npm script to match how other third-party npm modules are executed. Updates the `husky` command from running `npx` to instead invoking `lint-staged` via an npm script.

Changing from `npx` to invoking `lint-staged` via `npm run lint-staged` should decrease the delta in execution time between developers while still allowing contributors to utilize third-party desktop applications to create and edit git commits.

Testing between the various alternatives:
 - Direct invocation:
   ```
   time lint-staged
   ℹ No staged files found.
   lint-staged  0.17s user 0.06s system 109% cpu 0.204 total
   ```

 - npm script:
   ```
   time npm run lint-staged

   > cactbot@ lint-staged /c/cactbot
   > lint-staged

   ℹ No staged files found.
   npm run lint-staged  0.37s user 0.10s system 96% cpu 0.492 total
   ```

 - Previously recorded npx times:
   ```
   time npx lint-staged
   npx: installed 97 in 3.824s
   ℹ No staged files found.
   npx lint-staged  3.73s user 2.18s system 109% cpu 5.409 total
   ```

Since `husky` wraps the invocation anyway, the difference between direct invocation and the npm script runtimes will probably feel exactly the same to the average person.

Additionally, remove documentation advising contributors to install `lint-staged` globally to decrease pre-commit validation times as the new `husky` pre-commit execution shouldn't require any global installation.