### PR TITLE
ci: Revert Checkout Action to V1

### DIFF
--- a/.github/workflows/build-artifact.yml
+++ b/.github/workflows/build-artifact.yml
@@ -25,7 +25,7 @@ jobs:
     runs-on: windows-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v1
 
     - name: Set artifact name
       shell: bash

--- a/.github/workflows/css-lint.yml
+++ b/.github/workflows/css-lint.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v1
       - name: Setup Node
         uses: actions/setup-node@v2-beta
         with:

--- a/.github/workflows/javascript-lint.yml
+++ b/.github/workflows/javascript-lint.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v1
       - name: Setup Node
         uses: actions/setup-node@v2-beta
         with:

--- a/.github/workflows/markdown-lint.yml
+++ b/.github/workflows/markdown-lint.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v1
       - name: Setup Node
         uses: actions/setup-node@v2-beta
         with:

--- a/.github/workflows/python-lint.yml
+++ b/.github/workflows/python-lint.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v1
       - name: Setup Python
         uses: actions/setup-python@v2
         with:
@@ -34,7 +34,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v1
       - name: Setup Python
         uses: actions/setup-python@v2
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v1
       - name: Setup Node
         uses: actions/setup-node@v2-beta
         with:


### PR DESCRIPTION
Revert actions/checkout to V1 from V2, as there are existing bugs within
checkout@V2 causing it to possibly checkout the wrong commit SHA.

See:
 - https://github.com/actions/checkout/issues/299
 - https://github.com/quisquous/cactbot/pull/1600