### PR TITLE
oopsy: use netRegex for all effects

### DIFF
--- a/ui/oopsyraidsy/data/00-misc/general.js
+++ b/ui/oopsyraidsy/data/00-misc/general.js
@@ -137,21 +137,22 @@ let missedMitigationAbility = missedHeal;
     },
     {
       id: 'General Food Buff',
-      losesEffectRegex: gLang.kEffect.WellFed,
-      condition: function(e, data) {
+      // Well Fed
+      netRegex: NetRegexes.losesEffect({ effectId: '48' }),
+      condition: function(e, data, matches) {
         // Prevent "Eos loses the effect of Well Fed from Critlo Mcgee"
-        return e.targetName == e.attackerName;
+        return matches.target === matches.source;
       },
-      mistake: function(e, data) {
+      mistake: function(e, data, matches) {
         data.lostFood = data.lostFood || {};
         // Well Fed buff happens repeatedly when it falls off (WHY),
         // so suppress multiple occurrences.
-        if (!data.inCombat || data.lostFood[e.targetName])
+        if (!data.inCombat || data.lostFood[matches.target])
           return;
-        data.lostFood[e.targetName] = true;
+        data.lostFood[matches.target] = true;
         return {
           type: 'warn',
-          blame: e.targetName,
+          blame: matches.target,
           text: {
             en: 'lost food buff',
             de: 'Nahrungsbuff verloren',
@@ -164,11 +165,11 @@ let missedMitigationAbility = missedHeal;
     },
     {
       id: 'General Well Fed',
-      gainsEffectRegex: gLang.kEffect.WellFed,
-      run: function(e, data) {
+      netRegex: NetRegexes.gainsEffect({ effectId: '48' }),
+      run: function(e, data, matches) {
         if (!data.lostFood)
           return;
-        delete data.lostFood[e.targetName];
+        delete data.lostFood[matches.target];
       },
     },
     {

--- a/ui/oopsyraidsy/data/03-hw/dungeon/aetherochemical_research_facility.js
+++ b/ui/oopsyraidsy/data/03-hw/dungeon/aetherochemical_research_facility.js
@@ -43,9 +43,9 @@
   triggers: [
     {
       id: 'Facility Petrifaction',
-      gainsEffectRegex: gLang.kEffect.Petrification,
-      mistake: function(e, data) {
-        return { type: 'warn', blame: e.targetName, text: e.abilityName };
+      netRegex: NetRegexes.gainsEffect({ effectId: '01' }),
+      mistake: function(e, data, matches) {
+        return { type: 'warn', blame: e.target, text: e.effect };
       },
     },
   ],

--- a/ui/oopsyraidsy/data/03-hw/dungeon/gubal_library_hard.js
+++ b/ui/oopsyraidsy/data/03-hw/dungeon/gubal_library_hard.js
@@ -41,20 +41,28 @@
   },
   triggers: [
     {
-      id: 'Gubal Hard Burns', // Fire gate in hallway to boss 2, magnet failure on boss 2
-      gainsEffectRegex: gLang.kEffect.Burns,
-      mistake: function(e, data) {
-        return { type: 'warn', blame: e.targetName, text: e.effectName };
+      // Fire gate in hallway to boss 2, magnet failure on boss 2
+      id: 'Gubal Hard Burns',
+      netRegex: NetRegexes.gainsEffect({ effectId: '10B' }),
+      mistake: function(e, data, matches) {
+        return { type: 'warn', blame: e.target, text: e.effect };
       },
     },
     {
       // Helper for Thunder 3 failures
-      id: 'Gubal Hard Imp Tracking',
-      gainsEffectRegex: gLang.kEffect.Imp,
-      losesEffectRegex: gLang.kEffect.Imp,
-      run: function(e, data) {
+      id: 'Gubal Hard Imp Gain',
+      netRegex: NetRegexes.gainsEffect({ effectId: '46E' }),
+      run: function(e, data, matches) {
         data.hasImp = data.hasImp || {};
-        data.hasImp[e.targetName] = e.gains;
+        data.hasImp[matches.target] = true;
+      },
+    },
+    {
+      id: 'Gubal Hard Imp Lose',
+      netRegex: NetRegexes.loseEffect({ effectId: '46E' }),
+      run: function(e, data, matches) {
+        data.hasImp = data.hasImp || {};
+        data.hasImp[matches.target] = false;
       },
     },
     {

--- a/ui/oopsyraidsy/data/04-sb/dungeon/ala_mhigo.js
+++ b/ui/oopsyraidsy/data/04-sb/dungeon/ala_mhigo.js
@@ -37,9 +37,10 @@
       // It's possible players might just wander into the bad on the outside,
       // but normally people get pushed into it.
       id: 'Ala Mhigo Art Of The Swell',
-      gainsEffectRegex: gLang.kEffect.DamageDown,
-      mistake: function(e) {
-        return { type: 'warn', blame: e.targetName, text: e.abilityName };
+      // Damage Down
+      netRegex: NetRegexes.gainsEffect({ effectId: '2B8' }),
+      mistake: function(e, data, matches) {
+        return { type: 'warn', blame: e.target, text: e.effect };
       },
     },
   ],

--- a/ui/oopsyraidsy/data/04-sb/raid/o2n.js
+++ b/ui/oopsyraidsy/data/04-sb/raid/o2n.js
@@ -18,12 +18,12 @@
       // We could try to separate out the mistake that led to the player being petrified.
       // However, it's Normal mode, why overthink it?
       id: 'O2N Petrification',
-      gainsEffectRegex: gLang.kEffect.Petrification,
+      netRegex: NetRegexes.gainsEffect({ effectId: '262' }),
       // The user might get hit by another petrifying ability before the effect ends.
       // There's no point in notifying for that.
       suppressSeconds: 10,
-      mistake: function(e) {
-        return { type: 'warn', name: e.targetName, text: e.effectName };
+      mistake: function(e, data, matches) {
+        return { type: 'warn', blame: e.target, text: e.effect };
       },
     },
     {

--- a/ui/oopsyraidsy/data/04-sb/raid/o4n.js
+++ b/ui/oopsyraidsy/data/04-sb/raid/o4n.js
@@ -25,9 +25,9 @@
   triggers: [
     {
       id: 'O4N Doom', // Kills target if not cleansed
-      gainsEffectRegex: gLang.kEffect.Doom,
-      deathReason: function(e) {
-        return { type: 'fail', name: e.targetName, reason: { en: 'Cleansers missed Doom!' } };
+      netRegex: NetRegexes.gainsEffect({ effectId: '38E' }),
+      deathReason: function(e, data, matches) {
+        return { type: 'fail', name: e.target, reason: { en: 'Cleansers missed Doom!' } };
       },
     },
     {
@@ -39,9 +39,9 @@
     },
     {
       id: 'O4N Empowered Blizzard', // Room-wide AoE, freezes non-moving targets
-      gainsEffectRegex: gLang.kEffect.DeepFreeze,
-      mistake: function(e) {
-        return { type: 'warn', name: e.targetName, text: e.effectName };
+      netRegex: NetRegexes.gainsEffect({ effectId: '4E6' }),
+      mistake: function(e, data, matches) {
+        return { type: 'warn', blame: e.target, text: e.effect };
       },
     },
   ],

--- a/ui/oopsyraidsy/data/04-sb/raid/o4s.js
+++ b/ui/oopsyraidsy/data/04-sb/raid/o4s.js
@@ -61,13 +61,13 @@
     },
     {
       id: 'O4S2 Petrified',
-      gainsEffectRegex: gLang.kEffect.Petrification,
-      mistake: function(e, data) {
+      netRegex: NetRegexes.gainsEffect({ effectId: '262' }),
+      mistake: function(e, data, matches) {
         // On Neo, being petrified is because you looked at Shriek, so your fault.
         if (data.isNeoExdeath)
-          return { type: 'fail', blame: e.targetName, text: e.effectName };
+          return { type: 'fail', blame: matches.target, text: matches.effect };
         // On normal ExDeath, this is due to White Hole.
-        return { type: 'warn', name: e.targetName, text: e.effectName };
+        return { type: 'warn', name: matches.target, text: matches.effect };
       },
     },
     {
@@ -97,28 +97,35 @@
       },
     },
     {
-      id: 'O4S2 Beyond Death Collect',
-      gainsEffectRegex: gLang.kEffect.BeyondDeath,
-      losesEffectRegex: gLang.kEffect.BeyondDeath,
-      run: function(e, data) {
+      id: 'O4S2 Beyond Death Gain',
+      netRegex: NetRegexes.gainsEffect({ effectId: '566' }),
+      run: function(e, data, matches) {
         data.hasBeyondDeath = data.hasBeyondDeath || {};
-        data.hasBeyondDeath[e.targetName] = e.gains;
+        data.hasBeyondDeath[matches.target] = true;
+      },
+    },
+    {
+      id: 'O4S2 Beyond Death Lose',
+      netRegex: NetRegexes.losesEffect({ effectId: '566' }),
+      run: function(e, data, matches) {
+        data.hasBeyondDeath = data.hasBeyondDeath || {};
+        data.hasBeyondDeath[matches.target] = false;
       },
     },
     {
       id: 'O4S2 Beyond Death',
-      gainsEffectRegex: gLang.kEffect.BeyondDeath,
-      delaySeconds: function(e) {
-        return e.durationSeconds - 1;
+      netRegex: NetRegexes.gainsEffect({ effectId: '566' }),
+      delaySeconds: function(e, data, matches) {
+        return parseFloat(matches.duration) - 0.5;
       },
-      deathReason: function(e, data) {
+      deathReason: function(e, data, matches) {
         if (!data.hasBeyondDeath)
           return;
-        if (!data.hasBeyondDeath[e.targetName])
+        if (!data.hasBeyondDeath[matches.target])
           return;
         return {
-          name: e.targetName,
-          reason: e.effectName,
+          name: matches.target,
+          reason: matches.effect,
         };
       },
     },

--- a/ui/oopsyraidsy/data/04-sb/trial/shinryu.js
+++ b/ui/oopsyraidsy/data/04-sb/trial/shinryu.js
@@ -26,9 +26,10 @@
     {
       // Icy floor attack.
       id: 'Shinryu Normal Diamond Dust',
-      gainsEffectRegex: gLang.kEffect.ThinIce,
-      deathReason: function(e) {
-        return { type: 'fail', name: e.targetName, reason: { en: 'Slid off!' } };
+      // Thin Ice
+      netRegex: NetRegexes.gainsEffect({ effectId: '38F' }),
+      deathReason: function(e, data, matches) {
+        return { type: 'fail', name: matches.target, reason: { en: 'Slid off!' } };
       },
     },
     {

--- a/ui/oopsyraidsy/data/04-sb/ultimate/ultima_weapon_ultimate.js
+++ b/ui/oopsyraidsy/data/04-sb/ultimate/ultima_weapon_ultimate.js
@@ -23,11 +23,11 @@
   triggers: [
     {
       id: 'UWU Windburn',
-      gainsEffectRegex: gLang.kEffect.Windburn,
+      netRegex: NetRegexes.gainsEffect({ effectId: 'EB' }),
       // TODO: implement suppressSeconds <_<
       suppressSeconds: 2,
-      mistake: function(e) {
-        return { type: 'warn', blame: e.targetName, text: e.effectName };
+      mistake: function(e, data, matches) {
+        return { type: 'warn', blame: e.target, text: e.effect };
       },
     },
     {

--- a/ui/oopsyraidsy/data/04-sb/ultimate/unending_coil_ultimate.js
+++ b/ui/oopsyraidsy/data/04-sb/ultimate/unending_coil_ultimate.js
@@ -79,25 +79,32 @@
     },
     {
       id: 'UCU Burns',
-      gainsEffectRegex: gLang.kEffect.Burns,
-      mistake: function(e) {
-        return { type: 'fail', blame: e.targetName, text: e.effectName };
+      netRegex: NetRegexes.gainsEffect({ effectId: 'FA' }),
+      mistake: function(e, data, matches) {
+        return { type: 'warn', blame: e.target, text: e.effect };
       },
     },
     {
       id: 'UCU Sludge',
-      gainsEffectRegex: gLang.kEffect.Sludge,
-      mistake: function(e) {
-        return { type: 'fail', blame: e.targetName, text: e.effectName };
+      netRegex: NetRegexes.gainsEffect({ effectId: '11F' }),
+      mistake: function(e, data, matches) {
+        return { type: 'fail', blame: e.target, text: e.effect };
       },
     },
     {
-      id: 'UCU Doom Collect',
-      gainsEffectRegex: gLang.kEffect.Doom,
-      losesEffectRegex: gLang.kEffect.Doom,
-      run: function(e, data) {
+      id: 'UCU Doom Gain',
+      netRegex: NetRegexes.gainsEffect({ effectId: 'D2' }),
+      run: function(e, data, matches) {
         data.hasDoom = data.hasDoom || {};
-        data.hasDoom[e.targetName] = e.gains;
+        data.hasDoom[matches.target] = true;
+      },
+    },
+    {
+      id: 'UCU Doom Lose',
+      netRegex: NetRegexes.losesEffect({ effectId: 'D2' }),
+      run: function(e, data, matches) {
+        data.hasDoom = data.hasDoom || {};
+        data.hasDoom[matches.target] = false;
       },
     },
     {
@@ -114,21 +121,21 @@
       // died to doom.  You can get non-fatally iceballed or auto'd in between,
       // but what can you do.
       id: 'UCU Doom Death',
-      gainsEffectRegex: gLang.kEffect.Doom,
-      delaySeconds: function(e) {
-        return e.durationSeconds - 1;
+      netRegex: NetRegexes.gainsEffect({ effectId: 'D2' }),
+      delaySeconds: function(e, data, matches) {
+        return parseFloat(matches.duration) - 1;
       },
       deathReason: function(e, data, matches) {
-        if (!data.hasDoom || !data.hasDoom[e.targetName])
+        if (!data.hasDoom || !data.hasDoom[matches.target])
           return;
         let reason;
         if (e.durationSeconds < 9)
-          reason = e.effectName + ' #1';
+          reason = matches.effect + ' #1';
         else if (e.durationSeconds < 14)
-          reason = e.effectName + ' #2';
+          reason = matches.effect + ' #2';
         else
-          reason = e.effectName + ' #3';
-        return { name: e.targetName, reason: reason };
+          reason = matches.effect + ' #3';
+        return { name: matches.target, reason: reason };
       },
     },
   ],

--- a/ui/oopsyraidsy/data/05-shb/dungeon/dohn_mheg.js
+++ b/ui/oopsyraidsy/data/05-shb/dungeon/dohn_mheg.js
@@ -26,23 +26,23 @@
   triggers: [
     {
       id: 'Dohn Mheg Imp Choir',
-      gainsEffectRegex: gLang.kEffect.Imp,
-      mistake: function(e) {
-        return { type: 'warn', blame: e.targetName, text: e.effectName };
+      netRegex: NetRegexes.gainsEffect({ effectId: '46E' }),
+      mistake: function(e, data, matches) {
+        return { type: 'warn', blame: matches.target, text: matches.effect };
       },
     },
     {
       id: 'Dohn Mheg Toad Choir',
-      gainsEffectRegex: gLang.kEffect.Toad,
-      mistake: function(e) {
-        return { type: 'warn', blame: e.targetName, text: e.effectName };
+      netRegex: NetRegexes.gainsEffect({ effectId: '1B7' }),
+      mistake: function(e, data, matches) {
+        return { type: 'warn', blame: matches.target, text: matches.effect };
       },
     },
     {
       id: 'Dohn Mheg Fool\'s Tumble',
-      gainsEffectRegex: gLang.kEffect.FoolsTumble,
-      mistake: function(e) {
-        return { type: 'warn', blame: e.targetName, text: e.effectName };
+      netRegex: NetRegexes.gainsEffect({ effectId: '183' }),
+      mistake: function(e, data, matches) {
+        return { type: 'warn', blame: matches.target, text: matches.effect };
       },
     },
   ],

--- a/ui/oopsyraidsy/data/05-shb/raid/e2s.js
+++ b/ui/oopsyraidsy/data/05-shb/raid/e2s.js
@@ -23,9 +23,10 @@
   triggers: [
     {
       id: 'E2S Shadoweye',
-      gainsEffectRegex: gLang.kEffect.StoneCurse,
-      mistake: function(e, data) {
-        return { type: 'fail', blame: e.targetName, text: e.effectName };
+      // Stone Curse
+      netRegex: NetRegexes.gainsEffect({ effectId: '589' }),
+      mistake: function(e, data, matches) {
+        return { type: 'fail', blame: matches.target, text: matches.effect };
       },
     },
     {

--- a/ui/oopsyraidsy/data/05-shb/raid/e5n.js
+++ b/ui/oopsyraidsy/data/05-shb/raid/e5n.js
@@ -20,19 +20,26 @@
     {
       // This happens when a player gets 4+ stacks of orbs. Don't be greedy!
       id: 'E5N Static Condensation',
-      gainsEffectRegex: gLang.kEffect.StaticCondensation,
-      mistake: function(e) {
-        return { type: 'warn', blame: e.targetName, text: e.effectName };
+      netRegex: NetRegexes.gainsEffect({ effectId: '8B5' }),
+      mistake: function(e, data, matches) {
+        return { type: 'warn', blame: matches.target, text: matches.effect };
       },
     },
     {
       // Helper for orb pickup failures
-      id: 'E5N Orb Tracking',
-      gainsEffectRegex: gLang.kEffect.SurgeProtection,
-      losesEffectRegex: gLang.kEffect.SurgeProtection,
-      run: function(e, data) {
+      id: 'E5N Orb Gain',
+      netRegex: NetRegexes.gainsEffect({ effectId: '8B4' }),
+      run: function(e, data, matches) {
         data.hasOrb = data.hasOrb || {};
-        data.hasOrb[e.targetName] = e.gains;
+        data.hasOrb[matches.target] = true;
+      },
+    },
+    {
+      id: 'E5N Orb Lose',
+      netRegex: NetRegexes.losesEffect({ effectId: '8B4' }),
+      run: function(e, data, matches) {
+        data.hasOrb = data.hasOrb || {};
+        data.hasOrb[matches.target] = false;
       },
     },
     {

--- a/ui/oopsyraidsy/data/05-shb/raid/e5s.js
+++ b/ui/oopsyraidsy/data/05-shb/raid/e5s.js
@@ -37,12 +37,19 @@ let noOrb = (str) => {
   triggers: [
     {
       // Helper for orb pickup failures
-      id: 'E5S Orb Tracking',
-      gainsEffectRegex: gLang.kEffect.SurgeProtection,
-      losesEffectRegex: gLang.kEffect.SurgeProtection,
-      run: function(e, data) {
+      id: 'E5S Orb Gain',
+      netRegex: NetRegexes.gainsEffect({ effectId: '8B4' }),
+      run: function(e, data, matches) {
         data.hasOrb = data.hasOrb || {};
-        data.hasOrb[e.targetName] = e.gains;
+        data.hasOrb[matches.target] = true;
+      },
+    },
+    {
+      id: 'E5S Orb Lose',
+      netRegex: NetRegexes.losesEffect({ effectId: '8B4' }),
+      run: function(e, data, matches) {
+        data.hasOrb = data.hasOrb || {};
+        data.hasOrb[matches.target] = false;
       },
     },
     {

--- a/ui/oopsyraidsy/data/05-shb/raid/e7n.js
+++ b/ui/oopsyraidsy/data/05-shb/raid/e7n.js
@@ -51,21 +51,35 @@ let noBuff = (str) => {
       },
     },
     {
-      id: 'E7N Astral Tracking',
-      gainsEffectRegex: gLang.kEffect.AstralEffect,
-      losesEffectRegex: gLang.kEffect.AstralEffect,
-      run: function(e, data) {
+      id: 'E7N Astral Effect Gain',
+      netRegex: NetRegexes.gainsEffect({ effectId: '8BE' }),
+      run: function(e, data, matches) {
         data.hasAstral = data.hasAstral || {};
-        data.hasAstral[e.targetName] = e.gains;
+        data.hasAstral[matches.target] = true;
       },
     },
     {
-      id: 'E7N Umbral Tracking',
-      gainsEffectRegex: gLang.kEffect.UmbralEffect,
-      losesEffectRegex: gLang.kEffect.UmbralEffect,
-      run: function(e, data) {
+      id: 'E7N Astral Effect Lose',
+      netRegex: NetRegexes.losesEffect({ effectId: '8BE' }),
+      run: function(e, data, matches) {
+        data.hasAstral = data.hasAstral || {};
+        data.hasAstral[matches.target] = false;
+      },
+    },
+    {
+      id: 'E7N Umbral Effect Gain',
+      netRegex: NetRegexes.gainsEffect({ effectId: '8BF' }),
+      run: function(e, data, matches) {
         data.hasUmbral = data.hasUmbral || {};
-        data.hasUmbral[e.targetName] = e.gains;
+        data.hasUmbral[matches.target] = true;
+      },
+    },
+    {
+      id: 'E7N Umbral Effect Lose',
+      netRegex: NetRegexes.losesEffect({ effectId: '8BF' }),
+      run: function(e, data, matches) {
+        data.hasUmbral = data.hasUmbral || {};
+        data.hasUmbral[matches.target] = false;
       },
     },
     {

--- a/ui/oopsyraidsy/data/05-shb/raid/e7s.js
+++ b/ui/oopsyraidsy/data/05-shb/raid/e7s.js
@@ -96,21 +96,35 @@ let noBuff = (str) => {
       },
     },
     {
-      id: 'E7S Astral Tracking',
-      gainsEffectRegex: gLang.kEffect.AstralEffect,
-      losesEffectRegex: gLang.kEffect.AstralEffect,
-      run: function(e, data) {
+      id: 'E7S Astral Effect Gain',
+      netRegex: NetRegexes.gainsEffect({ effectId: '8BE' }),
+      run: function(e, data, matches) {
         data.hasAstral = data.hasAstral || {};
-        data.hasAstral[e.targetName] = e.gains;
+        data.hasAstral[matches.target] = true;
       },
     },
     {
-      id: 'E7S Umbral Tracking',
-      gainsEffectRegex: gLang.kEffect.UmbralEffect,
-      losesEffectRegex: gLang.kEffect.UmbralEffect,
-      run: function(e, data) {
+      id: 'E7S Astral Effect Lose',
+      netRegex: NetRegexes.losesEffect({ effectId: '8BE' }),
+      run: function(e, data, matches) {
+        data.hasAstral = data.hasAstral || {};
+        data.hasAstral[matches.target] = false;
+      },
+    },
+    {
+      id: 'E7S Umbral Effect Gain',
+      netRegex: NetRegexes.gainsEffect({ effectId: '8BF' }),
+      run: function(e, data, matches) {
         data.hasUmbral = data.hasUmbral || {};
-        data.hasUmbral[e.targetName] = e.gains;
+        data.hasUmbral[matches.target] = true;
+      },
+    },
+    {
+      id: 'E7S Umbral Effect Lose',
+      netRegex: NetRegexes.losesEffect({ effectId: '8BF' }),
+      run: function(e, data, matches) {
+        data.hasUmbral = data.hasUmbral || {};
+        data.hasUmbral[matches.target] = false;
       },
     },
     {

--- a/ui/oopsyraidsy/data/05-shb/raid/e8n.js
+++ b/ui/oopsyraidsy/data/05-shb/raid/e8n.js
@@ -24,9 +24,9 @@
   triggers: [
     {
       id: 'E8N Shining Armor',
-      gainsEffectRegex: gLang.kEffect.Stun,
-      mistake: function(e) {
-        return { type: 'warn', blame: e.targetName, reason: gLang.kEffect.Stun };
+      netRegex: NetRegexes.gainsEffect({ effectId: '95' }),
+      mistake: function(e, data, matches) {
+        return { type: 'warn', blame: matches.target, text: matches.effect };
       },
     },
     {
@@ -38,9 +38,10 @@
     },
     {
       id: 'E8N Frost Armor',
-      gainsEffectRegex: gLang.kEffect.ThinIce,
-      deathReason: function(e) {
-        return { type: 'fail', name: e.targetName, reason: { en: 'Slid off!' } };
+      // Thin Ice
+      netRegex: NetRegexes.gainsEffect({ effectId: '38F' }),
+      deathReason: function(e, data, matches) {
+        return { type: 'fail', name: matches.target, reason: { en: 'Slid off!' } };
       },
     },
   ],

--- a/ui/oopsyraidsy/data/05-shb/raid/e8s.js
+++ b/ui/oopsyraidsy/data/05-shb/raid/e8s.js
@@ -61,9 +61,10 @@
   triggers: [
     {
       id: 'E8S Shining Armor',
-      gainsEffectRegex: gLang.kEffect.Stun,
-      mistake: function(e) {
-        return { type: 'fail', blame: e.targetName, reason: gLang.kEffect.Stun };
+      // Stun
+      netRegex: NetRegexes.gainsEffect({ effectId: '95' }),
+      mistake: function(e, data, matches) {
+        return { type: 'fail', blame: matches.target, text: matches.effect };
       },
     },
     {

--- a/ui/oopsyraidsy/data/05-shb/trial/hades-ex.js
+++ b/ui/oopsyraidsy/data/05-shb/trial/hades-ex.js
@@ -84,54 +84,68 @@
       },
     },
     {
-      id: 'HadesEx Beyond Death Track',
-      gainsEffectRegex: gLang.kEffect.BeyondDeath,
-      losesEffectRegex: gLang.kEffect.BeyondDeath,
-      run: function(e, data) {
+      id: 'HadesEx Beyond Death Gain',
+      netRegex: NetRegexes.gainsEffect({ effectId: '566' }),
+      run: function(e, data, matches) {
         data.hasBeyondDeath = data.hasBeyondDeath || {};
-        data.hasBeyondDeath[e.targetName] = e.gains;
+        data.hasBeyondDeath[matches.target] = true;
+      },
+    },
+    {
+      id: 'HadesEx Beyond Death Lose',
+      netRegex: NetRegexes.losesEffect({ effectId: '566' }),
+      run: function(e, data, matches) {
+        data.hasBeyondDeath = data.hasBeyondDeath || {};
+        data.hasBeyondDeath[matches.target] = false;
       },
     },
     {
       id: 'HadesEx Beyond Death',
-      gainsEffectRegex: gLang.kEffect.BeyondDeath,
-      delaySeconds: function(e) {
-        return e.durationSeconds - 0.5;
+      netRegex: NetRegexes.gainsEffect({ effectId: '566' }),
+      delaySeconds: function(e, data, matches) {
+        return parseFloat(matches.duration) - 0.5;
       },
-      deathReason: function(e, data) {
+      deathReason: function(e, data, matches) {
         if (!data.hasBeyondDeath)
           return;
-        if (!data.hasBeyondDeath[e.targetName])
+        if (!data.hasBeyondDeath[matches.target])
           return;
         return {
-          name: e.targetName,
-          reason: e.effectName,
+          name: matches.target,
+          reason: matches.effect,
         };
       },
     },
     {
-      id: 'HadesEx Doom Track',
-      gainsEffectRegex: gLang.kEffect.Doom,
-      losesEffectRegex: gLang.kEffect.Doom,
-      run: function(e, data) {
+      id: 'HadesEx Doom Gain',
+      netRegex: NetRegexes.gainsEffect({ effectId: '6E9' }),
+      run: function(e, data, matches) {
         data.hasDoom = data.hasDoom || {};
-        data.hasDoom[e.targetName] = e.gains;
+        data.hasDoom[matches.target] = true;
+      },
+    },
+    {
+      id: 'HadesEx Doom Lose',
+      netRegex: NetRegexes.losesEffect({ effectId: '6E9' }),
+      run: function(e, data, matches) {
+        data.hasDoom = data.hasDoom || {};
+        data.hasDoom[matches.target] = false;
       },
     },
     {
       id: 'HadesEx Doom',
-      gainsEffectRegex: gLang.kEffect.Doom,
-      delaySeconds: function(e) {
-        return e.durationSeconds - 0.5;
+      netRegex: NetRegexes.gainsEffect({ effectId: '6E9' }),
+      delaySeconds: function(e, data, matches) {
+        return parseFloat(matches.duration) - 0.5;
       },
-      deathReason: function(e, data) {
+      deathReason: function(e, data, matches) {
         if (!data.hasDoom)
           return;
-        if (!data.hasDoom[e.targetName])
+        if (!data.hasDoom[matches.target])
           return;
         return {
-          name: e.targetName,
-          reason: e.effectName,
+          name: matches.target,
+          reason: matches.effect,
         };
       },
     },

--- a/ui/oopsyraidsy/data/05-shb/ultimate/the_epic_of_alexander.js
+++ b/ui/oopsyraidsy/data/05-shb/ultimate/the_epic_of_alexander.js
@@ -85,9 +85,9 @@
     },
     {
       id: 'TEA Dropsy',
-      gainsEffectRegex: gLang.kEffect.Dropsy,
-      mistake: function(e, data) {
-        return { type: 'warn', name: e.targetName, text: e.effectName };
+      netRegex: NetRegexes.gainsEffect({ effectId: '121' }),
+      mistake: function(e, data, matches) {
+        return { type: 'warn', blame: matches.target, text: matches.effect };
       },
     },
     {
@@ -125,28 +125,35 @@
       },
     },
     {
-      id: 'TEA Throttle Tracking',
-      gainsEffectRegex: gLang.kEffect.Throttle,
-      losesEffectRegex: gLang.kEffect.Throttle,
-      run: function(e, data) {
+      id: 'TEA Throttle Gain',
+      netRegex: NetRegexes.gainsEffect({ effectId: '2BC' }),
+      run: function(e, data, matches) {
         data.hasThrottle = data.hasThrottle || {};
-        data.hasThrottle[e.targetName] = e.gains;
+        data.hasThrottle[matches.target] = true;
+      },
+    },
+    {
+      id: 'TEA Throttle Lose',
+      netRegex: NetRegexes.losesEffect({ effectId: '2BC' }),
+      run: function(e, data, matches) {
+        data.hasThrottle = data.hasThrottle || {};
+        data.hasThrottle[matches.target] = false;
       },
     },
     {
       id: 'TEA Throttle',
-      gainsEffectRegex: gLang.kEffect.Throttle,
-      delaySeconds: function(e) {
-        return e.durationSeconds - 0.5;
+      netRegex: NetRegexes.gainsEffect({ effectId: '2BC' }),
+      delaySeconds: function(e, data, matches) {
+        return parseFloat(matches.duration) - 0.5;
       },
-      deathReason: function(e, data) {
+      deathReason: function(e, data, matches) {
         if (!data.hasThrottle)
           return;
-        if (!data.hasThrottle[e.targetName])
+        if (!data.hasThrottle[matches.target])
           return;
         return {
-          name: e.targetName,
-          reason: e.effectName,
+          name: matches.target,
+          reason: matches.effect,
         };
       },
     },


### PR DESCRIPTION
This is a very indirect patch which is getting rid of non-jobs usages of
gLang.kEffect, so I can use netRegex for effects in jobs, remove
gLang.kEffect entirely, in order to track atonement stacks for #725.

This also contributes to several other ongoing nebulous efforts like
using NetRegexes for oopsy instead of events (#1487) and also cleaning
up the unfortunate gLang data structures (#1221).