### PR TITLE
Raidboss: Weeping City of Mhach timeline/triggers

### DIFF
--- a/ui/eureka/eureka.js
+++ b/ui/eureka/eureka.js
@@ -1801,9 +1801,7 @@ class EurekaTracker {
 
     this.fairy = this.zoneInfo.fairy;
     let fairyName = this.TransByParserLang(this.fairy);
-    this.fairy.regex = Regexes.parse('03:\\y{ObjectId}:Added new combatant (' + fairyName + ')\\. .* ' +
-                                     'Pos: \\(([^,]+),([^,]+),([^,]+)\\)');
-
+    this.fairy.regex = Regexes.addedCombatantFull({ name: fairyName });
     this.playerElement = document.createElement('div');
     this.playerElement.classList.add('player');
     container.appendChild(this.playerElement);
@@ -2093,7 +2091,7 @@ class EurekaTracker {
       if (log.indexOf(' 03:') >= 0 || log.indexOf('00:0839:') >= 0) {
         match = log.match(this.fairy.regex);
         if (match)
-          this.AddFairy(match[1], match[2], match[3]);
+          this.AddFairy(match.groups);
       }
     }
   }
@@ -2219,9 +2217,9 @@ class EurekaTracker {
     }, this.options.FlagTimeoutMs);
   }
 
-  AddFairy(name, ex, ey) {
-    const mx = this.EntityToMapX(ex);
-    const my = this.EntityToMapY(ey);
+  AddFairy(matches) {
+    const mx = this.EntityToMapX(parseFloat(matches.x));
+    const my = this.EntityToMapY(parseFloat(matches.y));
     this.AddFlag(mx, my, this.TransByParserLang(this.zoneInfo.fairy), '');
   }
 }

--- a/ui/raidboss/data/03-hw/alliance/weeping_city.js
+++ b/ui/raidboss/data/03-hw/alliance/weeping_city.js
@@ -145,7 +145,7 @@
     },
     {
       id: 'Weeping City Mortal Ray',
-      netRegex: NetRegexes.startsUsing({ id: '17D4', source: 'Summoned Haagenti', capture: false }),
+      netRegex: NetRegexes.startsUsing({ id: '17D4', source: 'Summoned Haagenti' }),
       response: Responses.lookAwayFrom(),
     },
     {

--- a/ui/raidboss/data/03-hw/alliance/weeping_city.js
+++ b/ui/raidboss/data/03-hw/alliance/weeping_city.js
@@ -161,7 +161,7 @@
       id: 'Weeping City Mega Death',
       netRegex: NetRegexes.startsUsing({ id: '17CA', source: 'Forgall', capture: false }),
       alertText: {
-        en: 'Get 1 Stack In Puddle',
+        en: 'Stand in one puddle',
       },
     },
     {
@@ -183,23 +183,40 @@
     },
     {
       // The ability used here is Ozma entering Cube form.
-      // Flare Star and Explosion follow shortly.
-      id: 'Weeping City Flare Star',
+      // Flare Star and tank lasers follow shortly.
+      id: 'Weeping City Flare Star Ring',
       netRegex: NetRegexes.ability({ id: '1803', source: 'Ozma', capture: false }),
+      response: Responses.getIn(),
+    },
+    {
+      // The ability used here is Ozma entering Cube form. The actual laser ability, 1831,
+      // is literally named "attack". Ozma zaps the 3 highest-threat targets. (Not always tanks!)
+      // This continues until the next Sphere form, whether by time or by HP push.
+      id: 'Weeping City Tank Lasers',
+      netRegex: NetRegexes.ability({ id: '1803', source: 'Ozma', capture: false }),
+      // Delaying here to avoid colliding with other Flare Star triggers.
+      delaySeconds: 4,
       alertText: function(data) {
         if (data.role == 'tank') {
           return {
             en: 'Tank lasers--Avoid party',
           };
         }
-        if (data.role == 'healer') {
-          return {
-            en: 'Avoid tanks, get orbs',
-          };
-        }
         return {
-          en: 'Avoid tanks and healers',
+          en: 'Avoid tanks',
         };
+      },
+    },
+    {
+      // The NPC name is Ozmasphere. These need to be popped just like any other Flare Star.
+      // Failing to pop an orb means it will explode, dealing damage with 1808 Aethernova.
+      id: 'Weeping City Flare Star Orbs',
+      netRegex: NetRegexes.addedCombatantFull({ npcBaseId: '4889', capture: false }),
+      condition: function(data) {
+        return data.role == 'tank' || data.role == 'healer';
+      },
+      infoText: {
+        en: 'Get orbs',
       },
     },
     {

--- a/ui/raidboss/data/03-hw/alliance/weeping_city.js
+++ b/ui/raidboss/data/03-hw/alliance/weeping_city.js
@@ -40,8 +40,8 @@
       id: 'Weeping City Bloodied Nail',
       regex: /Bloodied Nail/,
       beforeSeconds: 4,
-      suppressSeconds: 10,
       condition: Conditions.caresAboutPhysical(),
+      suppressSeconds: 10,
       response: Responses.tankBuster(),
     },
     {
@@ -184,8 +184,8 @@
     {
       // The ability used here is Ozma entering Cube form.
       // Flare Star and Explosion follow shortly.
-      id: 'Weeping City Execration',
-      netRegex: NetRegexes.ability({ id: '1826', source: 'Ozma', capture: false }),
+      id: 'Weeping City Flare Star',
+      netRegex: NetRegexes.ability({ id: '1803', source: 'Ozma', capture: false }),
       alertText: function(data) {
         if (data.role == 'tank') {
           return {

--- a/ui/raidboss/data/03-hw/alliance/weeping_city.js
+++ b/ui/raidboss/data/03-hw/alliance/weeping_city.js
@@ -1,0 +1,312 @@
+'use strict';
+
+[{
+  zoneRegex: {
+    en: /^The Weeping City Of Mhach$/,
+  },
+  zoneId: ZoneId.TheWeepingCityOfMhach,
+  timelineFile: 'weeping_city.txt',
+  timelineTriggers: [
+    {
+      id: 'Weeping City Dark Spike',
+      regex: /Dark Spike/,
+      beforeSeconds: 4,
+      condition: Conditions.caresAboutPhysical(),
+      response: Responses.tankBuster(),
+    },
+    {
+      id: 'Weeping City Widow\'s Kiss',
+      regex: /The Widow's Kiss/,
+      beforeSeconds: 5,
+      // Probably kills the player if failed, so it gets an alert.
+      alertText: {
+        en: 'Stand on webs',
+      },
+    },
+    {
+      id: 'Weeping City Punishing Ray',
+      regex: /Punishing Ray/,
+      beforeSeconds: 10,
+      infoText: {
+        en: 'Get Puddles',
+        de: 'Flächen nehmen',
+        fr: 'Allez dans les zones au sol',
+        ja: '踏む',
+        cn: '踩圈',
+        ko: '바닥 징 밟기',
+      },
+    },
+    {
+      id: 'Weeping City Bloodied Nail',
+      regex: /Bloodied Nail/,
+      beforeSeconds: 4,
+      suppressSeconds: 10,
+      condition: Conditions.caresAboutPhysical(),
+      response: Responses.tankBuster(),
+    },
+    {
+      id: 'Weeping City Split End',
+      regex: /Split End/,
+      beforeSeconds: 4,
+      suppressSeconds: 10,
+      response: Responses.tankCleave(),
+    },
+    {
+      id: 'Weeping City Aura Burst',
+      regex: /Aura Burst/,
+      beforeSeconds: 4,
+      condition: Conditions.caresAboutAOE(),
+      response: Responses.aoe(),
+    },
+  ],
+  triggers: [
+    {
+      // 2 of the 4 encounters in Weeping City use the 0017 head marker.
+      // 2 of the 4 use the 003E head marker.
+      // Because of this, we restrict those triggers for each boss to activate
+      // only when that boss is in progress.
+      id: 'Weeping City HeadMarker Arachne',
+      netRegex: NetRegexes.message({ line: '.*Queen\'s Room will be sealed off.*?', capture: false }),
+      run: function(data) {
+        data.arachneStarted = true;
+      },
+    },
+    {
+      id: 'Weeping City HeadMarker Ozma',
+      netRegex: NetRegexes.message({ line: '.*Gloriole will be sealed off.*?', capture: false }),
+      run: function(data) {
+        data.arachneStarted = false;
+        data.ozmaStarted = true;
+      },
+    },
+    {
+      id: 'Weeping City HeadMarker Calofisteri',
+      netRegex: NetRegexes.message({ line: '.*Tomb Of The Nullstone will be sealed off.*?', capture: false }),
+      run: function(data) {
+        data.ozmaStarted = false;
+        data.calStarted = true;
+      },
+    },
+    {
+      id: 'Weeping City Sticky Wicket',
+      netRegex: NetRegexes.headMarker({ id: '003C', capture: false }),
+      suppressSeconds: 10,
+      response: Responses.spread(),
+    },
+    {
+      id: 'Weeping City Shadow Burst',
+      netRegex: NetRegexes.headMarker({ id: '003E' }),
+      condition: function(data) {
+        return data.arachneStarted;
+      },
+      response: Responses.stackOn(),
+    },
+    {
+      id: 'Weeping City Frond Affeared',
+      netRegex: NetRegexes.startsUsing({ id: '183A', source: 'Arachne Eve', capture: false }),
+      response: Responses.lookAway(),
+    },
+    {
+      id: 'Weeping City Arachne Web',
+      netRegex: NetRegexes.headMarker({ id: '0017' }),
+      condition: function(data, matches) {
+        return data.arachneStarted && data.me == matches.target;
+      },
+      infoText: {
+        en: 'Drop Web Outside',
+      },
+    },
+    {
+      id: 'Weeping City Brand Of The Fallen',
+      netRegex: NetRegexes.headMarker({ id: '0037' }),
+      condition: Conditions.targetIsYou(),
+      response: Responses.doritoStack(),
+    },
+    {
+      id: 'Weeping City Dark Eruption',
+      netRegex: NetRegexes.headMarker({ id: '0019' }),
+      condition: Conditions.targetIsYou(),
+      infoText: {
+        en: 'Puddles on YOU',
+        de: 'Pfützen auf DIR',
+        fr: 'Mare sur VOUS',
+        ja: '自分に床範囲',
+        cn: '点名',
+        ko: '장판 바깥에 깔기',
+      },
+    },
+    {
+      id: 'Weeping City Beguiling Mist',
+      netRegex: NetRegexes.startsUsing({ id: '17CE', source: 'Summoned Succubus' }),
+      condition: function(data) {
+        return data.canSilence();
+      },
+      response: Responses.interrupt(),
+    },
+    {
+      id: 'Weeping City Mortal Ray',
+      netRegex: NetRegexes.startsUsing({ id: '17D4', source: 'Summoned Haagenti', capture: false }),
+      response: Responses.lookAway(),
+    },
+    {
+      id: 'Weeping City Hell Wind',
+      netRegex: NetRegexes.startsUsing({ id: '17CB', source: 'Forgall', capture: false }),
+      // Hell Wind sets HP to single digits, so mitigations don't work. Don't notify non-healers.
+      condition: function(data) {
+        return data.role == 'healer';
+      },
+      response: Responses.aoe(),
+    },
+    {
+      id: 'Weeping City Mega Death',
+      netRegex: NetRegexes.startsUsing({ id: '17CA', source: 'Forgall', capture: false }),
+      alertText: {
+        en: 'Get 1 Stack In Puddle',
+      },
+    },
+    {
+      id: 'Weeping City Meteor Impact',
+      netRegex: NetRegexes.headMarker({ id: '0039' }),
+      condition: Conditions.targetIsYou(),
+      alertText: {
+        en: 'Drop meteor back or left',
+      },
+    },
+    {
+      // The ability used here is Ozma entering Pyramid form.
+      // Execration follows this up almost immediately.
+      id: 'Weeping City Execration',
+      netRegex: NetRegexes.ability({ id: '1826', source: 'Ozma', capture: false }),
+      alertText: {
+        en: 'Get off rectangle platform',
+      },
+    },
+    {
+      // The ability used here is Ozma entering Cube form.
+      // Flare Star and Explosion follow shortly.
+      id: 'Weeping City Execration',
+      netRegex: NetRegexes.ability({ id: '1826', source: 'Ozma', capture: false }),
+      alertText: function(data) {
+        if (data.role == 'tank') {
+          return {
+            en: 'Explosion--Avoid party',
+          };
+        }
+        if (data.role == 'healer') {
+          return {
+            en: 'Avoid tanks, get orbs',
+          };
+        }
+        return {
+          en: 'Avoid tanks and healers',
+        };
+      },
+    },
+    {
+      id: 'Weeping City Acceleration Bomb',
+      netRegex: NetRegexes.gainsEffect({ effectId: '430' }),
+      condition: Conditions.targetIsYou(),
+      delaySeconds: function(data, matches) {
+        return parseFloat(matches.duration) - 3;
+      },
+      response: Responses.stopEverything(),
+    },
+    {
+      id: 'Weeping City Assimilation',
+      netRegex: NetRegexes.startsUsing({ id: '1802', source: 'Ozmashade', capture: false }),
+      response: Responses.lookAway(),
+    },
+    {
+      // Each party gets a stack marker, so this is the best we can do.
+      id: 'Weeping City Meteor Stack',
+      netRegex: NetRegexes.headMarker({ id: '003E', capture: false }),
+      condition: function(data) {
+        return data.ozmaStarted;
+      },
+      suppressSeconds: 5,
+      response: Responses.stack(),
+    },
+    {
+      // Coif Change is always followed up shortly by Haircut.
+      // There's no castbar or indicator except that she grows a scythe on one side.
+      // It's not a very obvious visual cue unless the player knows to look for it.
+      id: 'Weeping City Coif Change Left',
+      netRegex: NetRegexes.ability({ id: '180A', source: 'Calofisteri', capture: false }),
+      response: Responses.goRight(),
+    },
+    {
+      id: 'Weeping City Coif Change Right',
+      netRegex: NetRegexes.ability({ id: '180E', source: 'Calofisteri', capture: false }),
+      response: Responses.goLeft(),
+    },
+    {
+      // 4899 is the base ID for bulb hair. 4900 is axe hair.
+      // Bulbs do a circle AoE surrounding them, while axes are a donut.
+      id: 'Weeping City Living Lock Axes',
+      netRegex: NetRegexes.addedCombatantFull({ npcNameId: ['4899', '4900'], capture: false }),
+      suppressSeconds: 5,
+      infoText: {
+        en: 'Close to axes, far from bulbs',
+      },
+    },
+    {
+      id: 'Weeping City Living Lock Scythes',
+      netRegex: NetRegexes.addedCombatantFull({ npcNameId: '4898', capture: false }),
+      suppressSeconds: 5,
+      alertText: {
+        en: 'Avoid scythe line AoEs',
+      },
+    },
+    {
+      // These adds are the purple circles waiting to grab people and Garrotte them.
+      id: 'Weeping City Entanglement',
+      netRegex: NetRegexes.addedCombatantFull({ npcNameId: '4904', capture: false }),
+      suppressSeconds: 5,
+      infoText: {
+        en: 'Avoid purple circles',
+      },
+    },
+    {
+      // If by some chance someone actually did stand in the purple circles, break them out.
+      // The actual ability here is an Unknown ability, but it begins slightly before Garrotte.
+      id: 'Weeping City Garrotte',
+      netRegex: NetRegexes.ability({ id: '181D', source: 'Entanglement', capture: false }),
+      response: Responses.killExtraAdd(),
+    },
+    {
+      id: 'Weeping City Particle Beam',
+      netRegex: NetRegexes.headMarker({ id: '0017' }),
+      condition: function(data) {
+        return data.calStarted;
+      },
+      alertText: function(data, matches) {
+        if (data.me == matches.target) {
+          return {
+            en: '16x Sky Laser on YOU!',
+          };
+        }
+        return {
+          en: 'Avoid Sky Lasers',
+        };
+      },
+    },
+    {
+      // The actual ability here is Mana Drain, which ends the intermission.
+      // Dancing Mad follows this up closely enough to make this the best time to notify.
+      id: 'Weeping City Dancing Mad',
+      netRegex: NetRegexes.ability({ id: '1819', source: 'Calofisteri', capture: false }),
+      condition: Conditions.caresAboutAOE(),
+      response: Responses.aoe(),
+    },
+    {
+      id: 'Weeping City Penetration',
+      netRegex: NetRegexes.startsUsing({ id: '1822', source: 'Calofisteri', capture: false }),
+      response: Responses.lookAway(),
+    },
+    {
+      id: 'Weeping City Depth Charge',
+      netRegex: NetRegexes.startsUsing({ id: '1820', source: 'Calofisteri', capture: false }),
+      response: Responses.awayFromFront(),
+    },
+  ],
+}];

--- a/ui/raidboss/data/03-hw/alliance/weeping_city.js
+++ b/ui/raidboss/data/03-hw/alliance/weeping_city.js
@@ -146,7 +146,7 @@
     {
       id: 'Weeping City Mortal Ray',
       netRegex: NetRegexes.startsUsing({ id: '17D4', source: 'Summoned Haagenti', capture: false }),
-      response: Responses.lookAway(),
+      response: Responses.lookAwayFrom(),
     },
     {
       id: 'Weeping City Hell Wind',

--- a/ui/raidboss/data/03-hw/alliance/weeping_city.js
+++ b/ui/raidboss/data/03-hw/alliance/weeping_city.js
@@ -139,7 +139,7 @@
       id: 'Weeping City Beguiling Mist',
       netRegex: NetRegexes.startsUsing({ id: '17CE', source: 'Summoned Succubus' }),
       condition: function(data) {
-        return data.canSilence();
+        return data.CanSilence();
       },
       response: Responses.interrupt(),
     },
@@ -263,7 +263,7 @@
       netRegex: NetRegexes.addedCombatantFull({ npcNameId: ['4899', '4900'], capture: false }),
       suppressSeconds: 5,
       infoText: {
-        en: 'Close to axes, far from bulbs',
+        en: 'Close to axes, avoid bulbs',
       },
     },
     {
@@ -288,6 +288,7 @@
       // The actual ability here is an Unknown ability, but it begins slightly before Garrotte.
       id: 'Weeping City Garrotte',
       netRegex: NetRegexes.ability({ id: '181D', source: 'Entanglement', capture: false }),
+      suppressSeconds: 5,
       response: Responses.killExtraAdd(),
     },
     {

--- a/ui/raidboss/data/03-hw/alliance/weeping_city.js
+++ b/ui/raidboss/data/03-hw/alliance/weeping_city.js
@@ -146,7 +146,7 @@
     {
       id: 'Weeping City Mortal Ray',
       netRegex: NetRegexes.startsUsing({ id: '17D4', source: 'Summoned Haagenti' }),
-      response: Responses.lookAwayFrom(),
+      response: Responses.lookAway(),
     },
     {
       id: 'Weeping City Hell Wind',

--- a/ui/raidboss/data/03-hw/alliance/weeping_city.js
+++ b/ui/raidboss/data/03-hw/alliance/weeping_city.js
@@ -189,7 +189,7 @@
       alertText: function(data) {
         if (data.role == 'tank') {
           return {
-            en: 'Explosion--Avoid party',
+            en: 'Tank lasers--Avoid party',
           };
         }
         if (data.role == 'healer') {

--- a/ui/raidboss/data/03-hw/alliance/weeping_city.js
+++ b/ui/raidboss/data/03-hw/alliance/weeping_city.js
@@ -145,7 +145,7 @@
     },
     {
       id: 'Weeping City Mortal Ray',
-      netRegex: NetRegexes.startsUsing({ id: '17D4', source: 'Summoned Haagenti' }),
+      netRegex: NetRegexes.startsUsing({ id: '17D4', source: 'Summoned Haagenti', capture: false }),
       response: Responses.lookAway(),
     },
     {

--- a/ui/raidboss/data/03-hw/alliance/weeping_city.txt
+++ b/ui/raidboss/data/03-hw/alliance/weeping_city.txt
@@ -1,0 +1,118 @@
+### THE WEEPING CITY OF MHACH
+
+hideall "--Reset--"
+hideall "--sync--"
+
+0 "--Reset--" sync /00:0839:.*is no longer sealed/ window 100000 jump 0
+
+#~~~~~~~~~~~~~#
+# ARACHNE EVE #
+#~~~~~~~~~~~~~#
+
+# -ii 368 1835 1836
+# -ic "Webmaiden" "Spitting Spider" "Skittering Spider" "Earth Aether"
+
+0 "Start" sync /Engage!/ window 0,1
+0 "--sync--" sync / 00:0839:.*Queen's Room will be sealed off/
+9.8 "Dark Spike" sync /:Arachne Eve:1823:/
+21.6 "Silken Spray" sync /:Arachne Eve:1824:/
+30.4 "Arachne Web x3" duration 5 # sync /:Arachne Eve:185E:/
+41.9 "Tremblor x3" sync /:Arachne Eve:1837:/ # 3 separate abilities, 1837/1836/1835
+48.4 "--sync--" sync /:Arachne Eve:1889:/
+49.9 "Pitfall" sync /:Arachne Eve:1825:/
+52.1 "--sync--" sync /:Arachne Eve:1847:/ # Sticky Wicket windup
+55.7 "Sticky Wicket x3" # sync /:Arachne Eve:183F:/
+64.1 "Silken Spray" sync /:Arachne Eve:1824:/
+
+# Intermission up in her web. There's a LOT of stuff going on here,
+# but the add spawns and abilities are dependent on what the team kills.
+# Implosion is the only real consistency we have through the intermission.
+95.7 "Implosion" sync /:Arachne Eve:1833:/ window 95.7,2.5
+113.9 "Implosion" sync /:Arachne Eve:1833:/
+132.1 "Implosion" sync /:Arachne Eve:1833:/
+150.3 "Implosion" sync /:Arachne Eve:1833:/ jump 95.7
+168.5 "Implosion"
+186.7 "Implosion"
+
+# Back on the ground for a relatively short bridge block
+200.0 "Dark Spike" sync /:Arachne Eve:1823:/ window 200,5
+206.3 "--sync--" sync /:Arachne Eve:1847:/
+210.5 "Sticky Wicket x3" # sync /:Arachne Eve:183F:/
+216.7 "Tremblor x3" sync /:Arachne Eve:1837:/
+223.9 "--sync--" sync /:Arachne Eve:1889:/
+225.5 "Pitfall" sync /:Arachne Eve:1825:/
+233.2 "Arachne Web x3" duration 5 # sync /:Arachne Eve:185E:/
+246.3 "Shadow Burst" sync /:Arachne Eve:1838:/
+253.0 "Dark Spike" sync /:Arachne Eve:1823:/
+264.4 "Frond Affeared" sync /:Arachne Eve:183A:/ window 30,30
+271.1 "Silken Spray" sync /:Arachne Eve:1824:/
+277.9 "Dark Spike" sync /:Arachne Eve:1823:/
+287.7 "Arachne Web x3" duration 5 # sync /:Arachne Eve:185E:/
+297.9 "the Widow's Kiss" duration 5 # sync /:Arachne Eve:1842:/
+305.9 "the Widow's Embrace" sync /:Arachne Eve:1888:/
+308.5 "Pitfall" sync /:Arachne Eve:1845:/
+317.2 "Dark Spike" sync /:Arachne Eve:1823:/
+
+# And up we go again.
+347.2 "Implosion" sync /:Arachne Eve:1833:/ window 147,5
+365.4 "Implosion" sync /:Arachne Eve:1833:/
+383.6 "Implosion" sync /:Arachne Eve:1833:/ jump 347.2
+401.8 "Implosion"
+420.0 "Implosion"
+
+# Back down again for another bridge block
+464.9 "Dark Spike" sync /:Arachne Eve:1823:/ window 120,5
+476.4 "Arachne Web" sync /:Arachne Eve:185E:/
+479.0 "Arachne Web" sync /:Arachne Eve:185E:/
+483.8 "--sync--" sync /:Arachne Eve:1847:/
+487.4 "Sticky Wicket x3" # sync /:Arachne Eve:183F:/
+494.4 "Tremblor x3" sync /:Arachne Eve:1837:/
+501.3 "the Widow's Kiss x3" duration 5 # sync /:Arachne Eve:1842:/
+509.3 "the Widow's Embrace" sync /:Arachne Eve:1888:/
+511.9 "Pitfall" sync /:Arachne Eve:1845:/
+520.6 "Dark Spike" sync /:Arachne Eve:1823:/
+526.4 "Silken Spray" sync /:Arachne Eve:1824:/
+535.0 "Dark Spike" sync /:Arachne Eve:1823:/
+546.3 "Frond Affeared" sync /:Arachne Eve:183A:/ window 30,30
+559.7 "Shadow Burst" sync /:Arachne Eve:1838:/
+565.2 "Dark Spike" sync /:Arachne Eve:1823:/
+572.2 "--sync--" sync /:Arachne Eve:1847:/
+575.9 "Sticky Wicket x3" # sync /:Arachne Eve:183F:/
+582.9 "Tremblor x3" sync /:Arachne Eve:1837:/
+
+# And *finally* we get to rotation blocks!
+# It may not be necessary to sync so widely, but it's probably a safe bet,
+# since we don't have any network logs that get this far to verify.
+589.4 "--sync--" sync /:Arachne Eve:1889:/ window 100,5
+590.9 "Pitfall" sync /:Arachne Eve:1825:/
+604.6 "Arachne Web" sync /:Arachne Eve:185E:/
+609.3 "Arachne Web" sync /:Arachne Eve:185E:/
+617.8 "Dark Spike" sync /:Arachne Eve:1823:/
+623.3 "Silken Spray" sync /:Arachne Eve:1824:/
+631.8 "Dark Spike" sync /:Arachne Eve:1823:/
+642.8 "Frond Affeared" sync /:Arachne Eve:183A:/ window 30,30
+656.5 "Shadow Burst" sync /:Arachne Eve:1838:/
+662.0 "Dark Spike" sync /:Arachne Eve:1823:/
+677.0 "Arachne Web" sync /:Arachne Eve:185E:/
+679.4 "Arachne Web" sync /:Arachne Eve:185E:/
+684.9 "the Widow's Kiss x3" duration 5 # sync /:Arachne Eve:1842:/
+692.9 "the Widow's Embrace" sync /:Arachne Eve:1888:/
+695.4 "Pitfall" sync /:Arachne Eve:1845:/
+703.4 "--sync--" sync /:Arachne Eve:1847:/
+707.1 "Sticky Wicket x3" # sync /:Arachne Eve:183F:/
+716.1 "Dark Spike" sync /:Arachne Eve:1823:/
+721.6 "Silken Spray" sync /:Arachne Eve:1824:/
+730.1 "Dark Spike" sync /:Arachne Eve:1823:/
+741.1 "Frond Affeared" sync /:Arachne Eve:183A:/ window 30,30
+754.7 "Shadow Burst" sync /:Arachne Eve:1838:/
+760.2 "Dark Spike" sync /:Arachne Eve:1823:/
+767.2 "--sync--" sync /:Arachne Eve:1847:/
+770.8 "Sticky Wicket x3" # sync /:Arachne Eve:183F:/
+777.6 "Tremblor x3" # sync /:Arachne Eve:1837:/
+
+784.1 "--sync--" sync /:Arachne Eve:1889:/ jump 589.4
+785.6 "Pitfall"
+799.3 "Arachne Web"
+804.0 "Arachne Web"
+812.5 "Dark Spike"
+818.0 "Silken Spray"

--- a/ui/raidboss/data/03-hw/alliance/weeping_city.txt
+++ b/ui/raidboss/data/03-hw/alliance/weeping_city.txt
@@ -211,7 +211,8 @@ hideall "--sync--"
 2157.1 "Execration" sync /:Ozma:1828:/
 2178.4 "Acceleration Bomb" sync /:Ozma:182F:/
 2195.7 "Transfiguration (Sphere)" sync /:Ozma:1827:/
-2203.8 "Black Hole"
+2199.1 "--sync--" sync /:1800:Ozma/ window 48.8,5
+2203.8 "Black Hole" sync /:Ozma:1800:/ window 53,5 jump 2400.0
 
 # Cube-first path
 
@@ -219,7 +220,8 @@ hideall "--sync--"
 2257.0 "Flare Star" sync /:Ozma:1805:/
 2288.0 "Holy" sync /:Ozma:182E:/
 2300.0 "Transfiguration (Sphere)" sync /:Ozma:1804:/
-2308.0 "Black Hole" sync /:Ozma:1800:/ window 300,5 jump 2400.0
+2303.3 "--sync-- /:1800:Ozma/ window 53.3,5
+2308.0 "Black Hole" sync /:Ozma:1800:/ window 58,5 jump 2400.0
 
 # Intermission
 

--- a/ui/raidboss/data/03-hw/alliance/weeping_city.txt
+++ b/ui/raidboss/data/03-hw/alliance/weeping_city.txt
@@ -12,7 +12,7 @@ hideall "--sync--"
 # -ii 368 1835 1836
 # -ic "Webmaiden" "Spitting Spider" "Skittering Spider" "Earth Aether"
 
-0 "--sync--" sync /00:0839:.*Queen's Room will be sealed off/
+0 "--sync--" sync /00:0839:The Queen's Room will be sealed off/
 9.8 "Dark Spike" sync /:Arachne Eve:1823:/
 21.6 "Silken Spray" sync /:Arachne Eve:1824:/
 30.4 "Arachne Web x3" duration 5 # sync /:Arachne Eve:185E:/
@@ -36,7 +36,9 @@ hideall "--sync--"
 186.7 "Implosion"
 
 # Back on the ground for a relatively short bridge block
-200.0 "Dark Spike" sync /:Arachne Eve:1823:/ window 100,5
+# We sync to a 14/20 startsUsing log line instead of a 15/21 ability line.
+# This lets us jump out of the intermission slightly earlier.
+197.3 "Dark Spike" sync /:1823:Arachne Eve/ window 100,5
 206.3 "--sync--" sync /:Arachne Eve:1847:/
 210.5 "Sticky Wicket x3" # sync /:Arachne Eve:183F:/
 212.1 "--untargetable--"
@@ -132,7 +134,7 @@ hideall "--sync--"
 
 # -ii 366 17D5 17C1 17D6
 
-1000.0 "--sync--" sync /00:0839:.*Shrine of the Goetic will be sealed off/ window 1000,5
+1000.0 "--sync--" sync /00:0839:The Shrine Of The Goetic will be sealed off/ window 1000,5
 1014.2 "Necropurge" sync /:Shriveled Talon:17D7:/
 1024.4 "Megiddo Flame" sync /:Forgall:17C0:/
 1032.4 "Necropurge" sync /:Forgall:17BE:/
@@ -188,11 +190,11 @@ hideall "--sync--"
 # She begins in Sphere form and can morph into Cube or Pyramid stance.
 # The complete flow looks like:
 
-# Sphere opening block -->              --> Cube   bridge block -->       . - - - - - - - - - - ---
+# Sphere opening block -->              --> Cube bridge block ---->       . - - - - - - - - - - ---
 #                                                                         V                       |
-# Cube   opening block --> Intermission --> Sphere bridge block --> (Cube|Sphere) rotation blocks |
+# Cube opening block ----> Intermission --> Sphere bridge block --> (Cube|Sphere) rotation blocks |
 
-2000.0 "--sync--" sync /00:0839:.*Gloriole will be sealed off/ window 2000,5
+2000.0 "--sync--" sync /00:0839:The Gloriole will be sealed off/ window 2000,5
 2015.0 "Meteor Headmarkers"
 2024.0 "Meteor Impact" sync /:Singularity Fragment:1935:/
 
@@ -320,7 +322,7 @@ hideall "--sync--"
 
 # 1811 and 180D are releasing hair after Haircut and Split End cleaves
 
-4000.0 "--sync--" sync /00:0839:.*Tomb Of The Nullstone will be sealed off/ window 4000,5
+4000.0 "--sync--" sync /00:0839:Tomb Of The Nullstone will be sealed off/ window 4000,5
 4004.1 "Bloodied Nail x4" # sync /:Calofisteri:181F:/
 4018.8 "Coif Change" sync /:Calofisteri:180[AE]:/ window 18.8,5
 4027.8 "Haircut" sync /:Calofisteri:180[BF]:/

--- a/ui/raidboss/data/03-hw/alliance/weeping_city.txt
+++ b/ui/raidboss/data/03-hw/alliance/weeping_city.txt
@@ -289,7 +289,7 @@ hideall "--sync--"
 # CALOFISTERI #
 #~~~~~~~~~~~~~#
 
-# -ii 181B 181C 181D 181E
+# -ii 181B 181C 181D 181E 1928
 
 # 1811 and 180D are releasing hair after Haircut and Split End cleaves
 
@@ -320,7 +320,7 @@ hideall "--sync--"
 # An intermission full of SKY LASERS
 4112.3 "Feint Particle Beam x16" sync /:Calofisteri:1927:/ duration 10
 4131.6 "Feint Particle Beam x16" sync /:Calofisteri:1927:/ duration 10
-4140.9 "Feint Particle Beam x16" jump 4112.3
+4140.9 "Feint Particle Beam x16" sync /:Calofisteri:1927:/ jump 4112.3
 4160.8 "Feint Particle Beam x16"
 
 

--- a/ui/raidboss/data/03-hw/alliance/weeping_city.txt
+++ b/ui/raidboss/data/03-hw/alliance/weeping_city.txt
@@ -220,7 +220,7 @@ hideall "--sync--"
 2257.0 "Flare Star" sync /:Ozma:1805:/
 2288.0 "Holy" sync /:Ozma:182E:/
 2300.0 "Transfiguration (Sphere)" sync /:Ozma:1804:/
-2303.3 "--sync-- /:1800:Ozma/ window 53.3,5
+2303.3 "--sync--" sync /:1800:Ozma/ window 53.3,5
 2308.0 "Black Hole" sync /:Ozma:1800:/ window 58,5 jump 2400.0
 
 # Intermission

--- a/ui/raidboss/data/03-hw/alliance/weeping_city.txt
+++ b/ui/raidboss/data/03-hw/alliance/weeping_city.txt
@@ -133,15 +133,15 @@ hideall "--sync--"
 # -ii 366 17D5 17C1 17D6
 
 1000.0 "--sync--" sync /00:0839:.*Shrine of the Goetic will be sealed off/ window 1000,5
-1014.4 "Necropurge" sync /:Shriveled Talon:17D7:/
-1024.2 "Megiddo Flame" sync /:Forgall:17C0:/
+1014.2 "Necropurge" sync /:Shriveled Talon:17D7:/
+1024.4 "Megiddo Flame" sync /:Forgall:17C0:/
 1032.4 "Necropurge" sync /:Forgall:17BE:/
 1060.7 "Megiddo Flame" sync /:Forgall:17C0:/
 1066.7 "Punishing Ray" sync /:Forgall:17C4:/
 1081.0 "Brand of the Fallen" sync /:Forgall:17CC:/ window 20,20
 1090.3 "Evil Mist" sync /:Forgall:17C5:/
 1101.3 "Necropurge" sync /:Shriveled Talon:17D7:/
-1118.5 "Necropurge" sync /:Forgall:17BE:/
+1118.3 "Necropurge" sync /:Forgall:17BE:/
 1131.6 "Necropurge" sync /:Forgall:17BF:/
 1132.8 "Brand of the Fallen" sync /:Forgall:17CC:/ window 20,20
 1141.1 "--sync--" sync /:Forgall:17C2:/ # Dark Eruption markers go out.
@@ -159,7 +159,7 @@ hideall "--sync--"
 1360.2 "Necropurge" sync /:Forgall:17BE:/ window 200,5
 1373.4 "Necropurge" sync /:Forgall:17BF:/
 1373.4 "--sync--" sync /:Poison Mist:17D8:/
-1377.4 "Mega Death" sync /:Forgall:17CA:/ window 20,20
+1377.5 "Mega Death" sync /:Forgall:17CA:/ window 20,20
 1388.5 "--sync--" sync /:Forgall:17C2:/
 1393.7 "Dark Eruption x3" # sync /:Forgall:17C3:/
 1395.7 "Megiddo Flame" sync /:Forgall:17C0:/

--- a/ui/raidboss/data/03-hw/alliance/weeping_city.txt
+++ b/ui/raidboss/data/03-hw/alliance/weeping_city.txt
@@ -16,10 +16,12 @@ hideall "--sync--"
 9.8 "Dark Spike" sync /:Arachne Eve:1823:/
 21.6 "Silken Spray" sync /:Arachne Eve:1824:/
 30.4 "Arachne Web x3" duration 5 # sync /:Arachne Eve:185E:/
+36.8 "--untargetable--"
 41.9 "Tremblor x3" sync /:Arachne Eve:1837:/ # 3 separate abilities, 1837/1836/1835
 48.4 "--sync--" sync /:Arachne Eve:1889:/
 49.9 "Pitfall" sync /:Arachne Eve:1825:/
-52.1 "--sync--" sync /:Arachne Eve:1847:/ # Sticky Wicket windup
+51.9 "--targetable--"
+52.1 "--sync--" sync /:Arachne Eve:1847:/ # Sticky Wicket head markers
 55.7 "Sticky Wicket x3" # sync /:Arachne Eve:183F:/
 64.1 "Silken Spray" sync /:Arachne Eve:1824:/
 
@@ -37,9 +39,11 @@ hideall "--sync--"
 200.0 "Dark Spike" sync /:Arachne Eve:1823:/ window 100,5
 206.3 "--sync--" sync /:Arachne Eve:1847:/
 210.5 "Sticky Wicket x3" # sync /:Arachne Eve:183F:/
+212.1 "--untargetable--"
 216.7 "Tremblor x3" sync /:Arachne Eve:1837:/
 223.9 "--sync--" sync /:Arachne Eve:1889:/
 225.5 "Pitfall" sync /:Arachne Eve:1825:/
+227.5 "--targetable--"
 233.2 "Arachne Web x3" duration 5 # sync /:Arachne Eve:185E:/
 246.3 "Shadow Burst" sync /:Arachne Eve:1838:/
 253.0 "Dark Spike" sync /:Arachne Eve:1823:/
@@ -47,9 +51,11 @@ hideall "--sync--"
 271.1 "Silken Spray" sync /:Arachne Eve:1824:/
 277.9 "Dark Spike" sync /:Arachne Eve:1823:/
 287.7 "Arachne Web x3" duration 5 # sync /:Arachne Eve:185E:/
+294.2 "--untargetable--"
 297.9 "The Widow's Kiss" duration 5 # sync /:Arachne Eve:1842:/
 305.9 "The Widow's Embrace" sync /:Arachne Eve:1888:/
 308.5 "Pitfall" sync /:Arachne Eve:1845:/
+310.5 "--targetable--"
 317.2 "Dark Spike" sync /:Arachne Eve:1823:/
 
 # And up we go again.
@@ -64,10 +70,12 @@ hideall "--sync--"
 476.4 "Arachne Web x3" duration 5 # sync /:Arachne Eve:185E:/
 483.8 "--sync--" sync /:Arachne Eve:1847:/
 487.4 "Sticky Wicket x3" # sync /:Arachne Eve:183F:/
+489.8 "--untargetable--"
 494.4 "Tremblor x3" sync /:Arachne Eve:1837:/
 501.3 "The Widow's Kiss x3" duration 5 # sync /:Arachne Eve:1842:/
 509.3 "The Widow's Embrace" sync /:Arachne Eve:1888:/
 511.9 "Pitfall" sync /:Arachne Eve:1845:/
+513.9 "--targetable--"
 520.6 "Dark Spike" sync /:Arachne Eve:1823:/
 526.4 "Silken Spray" sync /:Arachne Eve:1824:/
 535.0 "Dark Spike" sync /:Arachne Eve:1823:/
@@ -76,6 +84,7 @@ hideall "--sync--"
 565.2 "Dark Spike" sync /:Arachne Eve:1823:/
 572.2 "--sync--" sync /:Arachne Eve:1847:/
 575.9 "Sticky Wicket x3" # sync /:Arachne Eve:183F:/
+578.3 "--untargetable--"
 582.9 "Tremblor x3" sync /:Arachne Eve:1837:/
 
 # And *finally* we get to rotation blocks!
@@ -83,6 +92,7 @@ hideall "--sync--"
 # since we don't have any network logs that get this far to verify.
 589.4 "--sync--" sync /:Arachne Eve:1889:/ window 100,5
 590.9 "Pitfall" sync /:Arachne Eve:1825:/
+592.9 "--targetable--"
 604.6 "Arachne Web x3" duration 5 # sync /:Arachne Eve:185E:/
 617.8 "Dark Spike" sync /:Arachne Eve:1823:/
 623.3 "Silken Spray" sync /:Arachne Eve:1824:/
@@ -91,9 +101,11 @@ hideall "--sync--"
 656.5 "Shadow Burst" sync /:Arachne Eve:1838:/
 662.0 "Dark Spike" sync /:Arachne Eve:1823:/
 677.0 "Arachne Web x3" duration 5 # sync /:Arachne Eve:185E:/
+681.2 "--untargetable--"
 684.9 "The Widow's Kiss x3" duration 5 # sync /:Arachne Eve:1842:/
 692.9 "The Widow's Embrace" sync /:Arachne Eve:1888:/
 695.4 "Pitfall" sync /:Arachne Eve:1845:/
+697.4 "--targetable--"
 703.4 "--sync--" sync /:Arachne Eve:1847:/
 707.1 "Sticky Wicket x3" # sync /:Arachne Eve:183F:/
 716.1 "Dark Spike" sync /:Arachne Eve:1823:/
@@ -104,10 +116,12 @@ hideall "--sync--"
 760.2 "Dark Spike" sync /:Arachne Eve:1823:/
 767.2 "--sync--" sync /:Arachne Eve:1847:/
 770.8 "Sticky Wicket x3" # sync /:Arachne Eve:183F:/
+773.0 "--untargetable--"
 777.6 "Tremblor x3" # sync /:Arachne Eve:1837:/
 
 784.1 "--sync--" sync /:Arachne Eve:1889:/ jump 589.4
 785.6 "Pitfall"
+787.6 "--targetable--"
 799.3 "Arachne Web"
 812.5 "Dark Spike"
 818.0 "Silken Spray"
@@ -270,3 +284,106 @@ hideall "--sync--"
 3242.0 "Flare Star"
 3248.8 "Explosion x5"
 3254.3 "Holy"
+
+#~~~~~~~~~~~~~#
+# CALOFISTERI #
+#~~~~~~~~~~~~~#
+
+# -ii 181B 181C 181D 181E
+
+# 1811 and 180D are releasing hair after Haircut and Split End cleaves
+
+4000.0 "--sync--" sync /00:0839:.*Tomb Of The Nullstone will be sealed off/ window 4000,5
+4004.1 "Bloodied Nail x4" # sync /:Calofisteri:181F:/
+4018.8 "Coif Change" sync /:Calofisteri:180[AE]:/ window 18.8,5
+4027.8 "Haircut" sync /:Calofisteri:180[BF]:/
+4030.8 "Split End" sync /:Calofisteri:18(0C|10):/
+4035.8 "Split End" sync /:Calofisteri:18(0C|10):/
+4040.8 "Extension" sync /:Calofisteri:1812:/
+4043.8 "Split End" sync /:Calofisteri:18(0C|10):/
+4047.8 "Split End" sync /:Calofisteri:18(0C|10):/
+4051.9 "--sync--" sync /:Calofisteri:18(0D|11):/ window 51,5
+4054.9 "Coif Change" sync /:Calofisteri:180[AE]:/
+4063.9 "Haircut" sync /:Calofisteri:180[BF]:/
+4066.9 "Split End" sync /:Calofisteri:18(0C|10):/
+4071.9 "Split End" sync /:Calofisteri:18(0C|10):/
+4076.9 "Extension" sync /:Calofisteri:1812:/
+4079.9 "Split End" sync /:Calofisteri:18(0C|10):/
+4083.9 "Split End" sync /:Calofisteri:18(0C|10):/
+4090.9 "Haircut" sync /:Calofisteri:180[BF]:/
+4093.9 "Split End" sync /:Calofisteri:18(0C|10):/
+4096.9 "Aura Burst" sync /:Calofisteri:1821:/
+4099.8 "--sync--" sync /:Calofisteri:18(0D|11):/ window 40,5
+4101.4 "--untargetable--"
+4103.8 "Dancing Mad" sync /:Calofisteri:1818:/ window 103.8,5
+
+# An intermission full of SKY LASERS
+4112.3 "Feint Particle Beam x16" sync /:Calofisteri:1927:/ duration 10
+4131.6 "Feint Particle Beam x16" sync /:Calofisteri:1927:/ duration 10
+4140.9 "Feint Particle Beam x16" jump 4112.3
+4160.8 "Feint Particle Beam x16"
+
+
+# Returning to a broken bridge block.
+# It doesn't look like time taken on the intermission affects how many times
+# Dancing Mad strikes.
+
+4200.0 "Mana Drain" sync /:Calofisteri:1819:/ window 80,5
+4204.0 "Dancing Mad" sync /:Calofisteri:181A:/
+4212.9 "--targetable--"
+4215.0 "Coif Change" sync /:Calofisteri:180[AE]:/
+4224.0 "Haircut" sync /:Calofisteri:180[BF]:/
+4227.0 "--sync--" sync /:Calofisteri:18(0D|11):/
+4232.0 "Extension" sync /:Calofisteri:1812:/
+4237.0 "--sync--" sync /:Calofisteri:1813:/
+4238.0 "Bloodied Nail x3" # sync /:Calofisteri:181F:/
+4249.0 "Evil Curl/Evil Tress" sync /:Living Lock:181[67]:/
+4251.5 "Extension" sync /:Calofisteri:1812:/
+4253.5 "Coif Change" sync /:Calofisteri:180[AE]:/ window 15,15
+
+# This section of the bridge may be skipped depending on DPS. HP% for push is unknown.
+4262.5 "Haircut" sync /:Calofisteri:180[BF]:/
+4268.5 "Aura Burst" sync /:Calofisteri:1821:/
+4273.5 "Split End" sync /:Calofisteri:18(0C|10):/
+4278.5 "Split End" sync /:Calofisteri:18(0C|10):/
+
+4280.5 "--sync--" sync /:Calofisteri:18(0D|11):/ window 27,15
+4285.5 "Extension" sync /:Calofisteri:1812:/
+4290.5 "--sync--" sync /:Calofisteri:1813:/
+4293.4 "Penetration" sync /:Calofisteri:1822:/
+
+# Rotation block to 0%
+4296.9 "Coif Change" sync /:Calofisteri:180[AE]:/ window 15,15
+4307.2 "Depth Charge" sync /:Calofisteri:1820:/
+4311.2 "Haircut" sync /:Calofisteri:180[BF]:/
+4317.2 "--sync--" sync /:Calofisteri:18(0D|11):/
+4322.2 "Extension" sync /:Calofisteri:1812:/
+4325.2 "Bloodied Nail x3" # sync /:Calofisteri:181F:/
+4332.2 "Aura Burst" sync /:Calofisteri:1821:/
+4338.7 "Coif Change" sync /:Calofisteri:180[AE]:/ window 15,15
+4339.2 "Evil Switch" sync /:Living Lock:1815:/
+4345.7 "Haircut" sync /:Calofisteri:180[BF]:/
+4351.7 "Extension" sync /:Calofisteri:1812:/
+4356.7 "Split End" sync /:Calofisteri:18(0C|10):/
+4358.7 "--sync--" sync /:Calofisteri:18(0D|11):/
+4363.7 "Extension" sync /:Calofisteri:1812:/
+4367.7 "Bloodied Nail x3" # sync /:Calofisteri:181F:/
+4377.2 "Aura Burst" sync /:Calofisteri:1821:/
+4379.2 "Coif Change" sync /:Calofisteri:180[AE]:/ window 15,15
+4380.7 "Evil Curl/Evil Tress" sync /:Living Lock:181[67]:/
+4386.3 "Haircut" sync /:Calofisteri:180[BF]:/
+4392.3 "Split End" sync /:Calofisteri:18(0C|10):/
+4397.3 "Split End" sync /:Calofisteri:18(0C|10):/
+4402.3 "Aura Burst" sync /:Calofisteri:1821:/
+4404.3 "--sync--" sync /:Calofisteri:18(0D|11):/
+4409.3 "Extension" sync /:Calofisteri:1812:/
+4414.3 "--sync--" sync /:Calofisteri:1813:/
+4417.7 "Penetration" sync /:Calofisteri:1822:/
+4421.2 "Evil Curl/Evil Tress" sync /:Living Lock:181[67]:/
+
+4421.2 "Coif Change" sync /:Calofisteri:180[AE]:/ window 15,15 jump 4296.9
+4431.5 "Depth Charge"
+4435.5 "Haircut"
+4446.5 "Extension"
+4449.5 "Bloodied Nail x3"
+4456.5 "Aura Burst"

--- a/ui/raidboss/data/03-hw/alliance/weeping_city.txt
+++ b/ui/raidboss/data/03-hw/alliance/weeping_city.txt
@@ -12,8 +12,7 @@ hideall "--sync--"
 # -ii 368 1835 1836
 # -ic "Webmaiden" "Spitting Spider" "Skittering Spider" "Earth Aether"
 
-0 "Start" sync /Engage!/ window 0,1
-0 "--sync--" sync / 00:0839:.*Queen's Room will be sealed off/
+0 "--sync--" sync /00:0839:.*Queen's Room will be sealed off/
 9.8 "Dark Spike" sync /:Arachne Eve:1823:/
 21.6 "Silken Spray" sync /:Arachne Eve:1824:/
 30.4 "Arachne Web x3" duration 5 # sync /:Arachne Eve:185E:/
@@ -48,8 +47,8 @@ hideall "--sync--"
 271.1 "Silken Spray" sync /:Arachne Eve:1824:/
 277.9 "Dark Spike" sync /:Arachne Eve:1823:/
 287.7 "Arachne Web x3" duration 5 # sync /:Arachne Eve:185E:/
-297.9 "the Widow's Kiss" duration 5 # sync /:Arachne Eve:1842:/
-305.9 "the Widow's Embrace" sync /:Arachne Eve:1888:/
+297.9 "The Widow's Kiss" duration 5 # sync /:Arachne Eve:1842:/
+305.9 "The Widow's Embrace" sync /:Arachne Eve:1888:/
 308.5 "Pitfall" sync /:Arachne Eve:1845:/
 317.2 "Dark Spike" sync /:Arachne Eve:1823:/
 
@@ -62,13 +61,12 @@ hideall "--sync--"
 
 # Back down again for another bridge block
 464.9 "Dark Spike" sync /:Arachne Eve:1823:/ window 120,5
-476.4 "Arachne Web" sync /:Arachne Eve:185E:/
-479.0 "Arachne Web" sync /:Arachne Eve:185E:/
+476.4 "Arachne Web x3" duration 5 # sync /:Arachne Eve:185E:/
 483.8 "--sync--" sync /:Arachne Eve:1847:/
 487.4 "Sticky Wicket x3" # sync /:Arachne Eve:183F:/
 494.4 "Tremblor x3" sync /:Arachne Eve:1837:/
-501.3 "the Widow's Kiss x3" duration 5 # sync /:Arachne Eve:1842:/
-509.3 "the Widow's Embrace" sync /:Arachne Eve:1888:/
+501.3 "The Widow's Kiss x3" duration 5 # sync /:Arachne Eve:1842:/
+509.3 "The Widow's Embrace" sync /:Arachne Eve:1888:/
 511.9 "Pitfall" sync /:Arachne Eve:1845:/
 520.6 "Dark Spike" sync /:Arachne Eve:1823:/
 526.4 "Silken Spray" sync /:Arachne Eve:1824:/
@@ -85,18 +83,16 @@ hideall "--sync--"
 # since we don't have any network logs that get this far to verify.
 589.4 "--sync--" sync /:Arachne Eve:1889:/ window 100,5
 590.9 "Pitfall" sync /:Arachne Eve:1825:/
-604.6 "Arachne Web" sync /:Arachne Eve:185E:/
-609.3 "Arachne Web" sync /:Arachne Eve:185E:/
+604.6 "Arachne Web x3" duration 5 # sync /:Arachne Eve:185E:/
 617.8 "Dark Spike" sync /:Arachne Eve:1823:/
 623.3 "Silken Spray" sync /:Arachne Eve:1824:/
 631.8 "Dark Spike" sync /:Arachne Eve:1823:/
 642.8 "Frond Affeared" sync /:Arachne Eve:183A:/ window 30,30
 656.5 "Shadow Burst" sync /:Arachne Eve:1838:/
 662.0 "Dark Spike" sync /:Arachne Eve:1823:/
-677.0 "Arachne Web" sync /:Arachne Eve:185E:/
-679.4 "Arachne Web" sync /:Arachne Eve:185E:/
-684.9 "the Widow's Kiss x3" duration 5 # sync /:Arachne Eve:1842:/
-692.9 "the Widow's Embrace" sync /:Arachne Eve:1888:/
+677.0 "Arachne Web x3" duration 5 # sync /:Arachne Eve:185E:/
+684.9 "The Widow's Kiss x3" duration 5 # sync /:Arachne Eve:1842:/
+692.9 "The Widow's Embrace" sync /:Arachne Eve:1888:/
 695.4 "Pitfall" sync /:Arachne Eve:1845:/
 703.4 "--sync--" sync /:Arachne Eve:1847:/
 707.1 "Sticky Wicket x3" # sync /:Arachne Eve:183F:/
@@ -113,6 +109,57 @@ hideall "--sync--"
 784.1 "--sync--" sync /:Arachne Eve:1889:/ jump 589.4
 785.6 "Pitfall"
 799.3 "Arachne Web"
-804.0 "Arachne Web"
 812.5 "Dark Spike"
 818.0 "Silken Spray"
+
+#~~~~~~~~~#
+# FORGALL #
+#~~~~~~~~~#
+
+# -ii 366 17D5 17C1 17D6
+
+1000.0 "--sync--" sync /00:0839:.*Shrine of the Goetic will be sealed off/ window 1000,5
+1014.4 "Necropurge" sync /:Shriveled Talon:17D7:/
+1024.2 "Megiddo Flame" sync /:Forgall:17C0:/
+1032.4 "Necropurge" sync /:Forgall:17BE:/
+1060.7 "Megiddo Flame" sync /:Forgall:17C0:/
+1066.7 "Punishing Ray" sync /:Forgall:17C4:/
+1081.0 "Brand of the Fallen" sync /:Forgall:17CC:/ window 20,20
+1090.3 "Evil Mist" sync /:Forgall:17C5:/
+1101.3 "Necropurge" sync /:Shriveled Talon:17D7:/
+1118.5 "Necropurge" sync /:Forgall:17BE:/
+1131.6 "Necropurge" sync /:Forgall:17BF:/
+1132.8 "Brand of the Fallen" sync /:Forgall:17CC:/ window 20,20
+1141.1 "--sync--" sync /:Forgall:17C2:/ # Dark Eruption markers go out.
+1146.3 "Dark Eruption x3" # sync /:Forgall:17C3:/
+1163.2 "--sync--" sync /:Forgall:17C7:/ window 163.2 # Pushes at 50% HP.
+
+# We don't know how long the intermission goes.
+# There's no data available to tell us what, if anything,
+# happens if the three adds aren't killed in time.
+# It could even be nothing.
+# If the intermission goes longer than 3 minutes, something is WRONG.
+
+1350.0 "Mana Eruption" sync /:Forgall:17C9:/ window 350,5
+
+1360.2 "Necropurge" sync /:Forgall:17BE:/
+1373.4 "Necropurge" sync /:Forgall:17BF:/
+1373.4 "--sync--" sync /:Poison Mist:17D8:/
+1377.4 "Mega Death" sync /:Forgall:17CA:/ window 20,20
+1388.5 "--sync--" sync /:Forgall:17C2:/
+1393.7 "Dark Eruption x3" # sync /:Forgall:17C3:/
+1395.7 "Megiddo Flame" sync /:Forgall:17C0:/
+1400.9 "Evil Mist" sync /:Forgall:17C5:/
+1414.9 "Necropurge" sync /:Forgall:17BF:/
+1414.9 "--sync--" sync /:Poison Mist:17D8:/
+1419.1 "Mega Death" sync /:Forgall:17CA:/ window 20,20
+1439.2 "Hell Wind" sync /:Forgall:17CB:/
+1453.3 "Brand of the Fallen" sync /:Forgall:17CC:/
+1459.5 "Punishing Ray" sync /:Forgall:17C4:/
+1465.6 "Brand of the Fallen" sync /:Forgall:17CC:/
+
+1481.9 "Necropurge" sync /:Forgall:17BE:/ jump 1360.2
+1495.1 "Necropurge"
+1499.1 "Mega Death"
+1515.4 "Dark Eruption x3"
+

--- a/ui/raidboss/data/03-hw/alliance/weeping_city.txt
+++ b/ui/raidboss/data/03-hw/alliance/weeping_city.txt
@@ -34,7 +34,7 @@ hideall "--sync--"
 186.7 "Implosion"
 
 # Back on the ground for a relatively short bridge block
-200.0 "Dark Spike" sync /:Arachne Eve:1823:/ window 200,5
+200.0 "Dark Spike" sync /:Arachne Eve:1823:/ window 100,5
 206.3 "--sync--" sync /:Arachne Eve:1847:/
 210.5 "Sticky Wicket x3" # sync /:Arachne Eve:183F:/
 216.7 "Tremblor x3" sync /:Arachne Eve:1837:/
@@ -140,9 +140,9 @@ hideall "--sync--"
 # It could even be nothing.
 # If the intermission goes longer than 3 minutes, something is WRONG.
 
-1350.0 "Mana Eruption" sync /:Forgall:17C9:/ window 350,5
+1350.0 "Mana Explosion" sync /:Forgall:17C8:/ window 350,5
 
-1360.2 "Necropurge" sync /:Forgall:17BE:/
+1360.2 "Necropurge" sync /:Forgall:17BE:/ window 200,5
 1373.4 "Necropurge" sync /:Forgall:17BF:/
 1373.4 "--sync--" sync /:Poison Mist:17D8:/
 1377.4 "Mega Death" sync /:Forgall:17CA:/ window 20,20
@@ -163,3 +163,110 @@ hideall "--sync--"
 1499.1 "Mega Death"
 1515.4 "Dark Eruption x3"
 
+#~~~~~~#
+# OZMA #
+#~~~~~~#
+
+# -ii 366 367 368 1806 1829 1830 1831 1832
+
+# Ozma is based on an A/B timeline pattern.
+# She begins in Sphere form and can morph into Cube or Pyramid stance.
+# Whichever she chooses sets the path for the remainder of the encounter.
+
+2000.0 "--sync--" sync /00:0839:.*Gloriole will be sealed off/ window 2000,5
+2015.0 "Meteor Headmarkers"
+2024.0 "Meteor Impact" sync /:Singularity Fragment:1935:/
+
+2045.5 "Transfiguration (Pyramid)" sync /:Ozma:1826:/
+2045.5 "--sync--" sync /:Ozma:1803:/
+2052.6 "Execration?"
+2052.6 "Flare Star?"
+2059.0 "Explosion x5?"
+2073.9 "Acceleration Bomb?"
+
+# Pyramid-first path
+
+2150.0 "Transfiguration (Pyramid)" sync /:Ozma:1826:/
+2157.1 "Execration" sync /:Ozma:1828:/
+2178.4 "Acceleration Bomb" sync /:Ozma:182F:/
+2195.7 "Transfiguration (Sphere)" sync /:Ozma:1827:/
+2203.8 "Black Hole" sync /:Ozma:1800:/
+
+# Cube-first path
+
+2250.0 "Transfiguration (Cube)" sync /:Ozma:1803:/
+2257.0 "Flare Star" sync /:Ozma:1805:/
+2263.5 "Explosion x5" # sync /:Ozmasphere:1807:/
+2288.0 "Holy" sync /:Ozma:182E:/
+2300.0 "Transfiguration (Sphere)" sync /:Ozma:1804:/
+2308.0 "Black Hole" sync /:Ozma:1800:/ window 300,5 jump 2400.0
+
+# Intermission
+
+2400.0 "Black Hole" # seems to be a 55% HP push.
+# We can't really do anything with this intermission.
+# The only real repetition is the Singularity Echoes casting stuff.
+# But they die well before the intermission ends, so no point.
+# Instead, we just let the timeline play on dead space.
+# The intermission's enrage is probably under 3 minutes, but we have no way to know.
+
+2600.0 "--sync--" sync /:Ozma:1826:/ window 200,5 jump 2700.0
+2600.0 "--sync--" sync /:Ozma:1803:/ window 200,5 jump 3000.0
+
+
+# Pyramid-first continued
+2700.0 "Transfiguration (Pyramid)" sync /:Ozma:1826:/
+2707.0 "Execration" sync /:Ozma:1828:/
+2728.0 "Acceleration Bomb" sync /:Ozma:182F:/
+2745.0 "Transfiguration (Sphere)" sync /:Ozma:1827:/
+2763.0 "Meteor Impact" sync /:Singularity Fragment:1935:/
+
+2790.8 "Transfiguration (Pyramid)" sync /:Ozma:1826:/
+2797.8 "Execration" sync /:Ozma:1828:/
+2813.8 "Acceleration Bomb" sync /:Ozma:182F:/
+2816.8 "Meteor Impact" sync /:Singularity Fragment:1935:/
+2837.3 "Meteor" # sync /:Ozma:182D:/
+2851.8 "Acceleration Bomb" sync /:Ozma:182F:/
+2853.8 "Transfiguration (Sphere)" sync /:Ozma:1827:/
+2865.8 "Transfiguration (Cube)" sync /:Ozma:1803:/
+2872.8 "Flare Star" sync /:Ozma:1805:/
+2879.3 "Explosion x5" # sync /:Ozmasphere:1807:/
+2884.8 "Holy" sync /:Ozma:182E:/
+2900.9 "Meteor Impact" sync /:Singularity Fragment:1935:/
+2906.9 "Holy" sync /:Ozma:182E:/
+2922.4 "Meteor" # sync /:Ozma:182D:/
+2929.0 "Transfiguration (Sphere)" sync /:Ozma:1804:/
+
+2941.0 "Transfiguration (Pyramid)" sync /:Ozma:1826:/ jump 2790.8
+2948.0 "Execration"
+2964.0 "Acceleration Bomb"
+2967.0 "Meteor Impact"
+
+# Cube-first continued
+
+3000.0 "Transfiguration (Cube)" sync /:Ozma:1803:/
+3007.0 "Flare Star" sync /:Ozma:1805:/
+3013.6 "Explosion x5" # sync /:Ozmasphere:1807:/
+3029.7 "Transfiguration (Sphere)" sync /:Ozma:1804:/
+3047.9 "Meteor Impact" sync /:Singularity Fragment:1935:/
+
+3080.7 "Transfiguration (Cube)" sync /:Ozma:1803:/
+3087.8 "Flare Star" sync /:Ozma:1805:/
+3094.6 "Explosion x5" # sync /:Ozmasphere:1807:/
+3100.1 "Holy" sync /:Ozma:182E:/
+3116.3 "Meteor Impact" sync /:Singularity Fragment:1935:/
+3122.7 "Holy" sync /:Ozma:182E:/
+3138.7 "Meteor" # sync /:Ozma:182D:/
+3145.7 "Transfiguration (Sphere)" sync /:Ozma:1804:/
+3157.9 "Transfiguration (Pyramid)" sync /:Ozma:1826:/
+3165.0 "Execration" sync /:Ozma:1828:/
+3181.5 "Acceleration Bomb" sync /:Ozma:182F:/
+3184.2 "Meteor Impact" sync /:Singularity Fragment:1935:/
+3205.2 "Meteor" # sync /:Ozma:182D:/
+3220.3 "Acceleration Bomb" sync /:Ozma:182F:/
+3222.4 "Transfiguration (Sphere)" sync /:Ozma:1827:/
+
+3234.9 "Transfiguration (Cube)" sync /:Ozma:1803:/ jump 3080.7
+3242.0 "Flare Star"
+3248.8 "Explosion x5"
+3254.3 "Holy"

--- a/ui/raidboss/data/03-hw/alliance/weeping_city.txt
+++ b/ui/raidboss/data/03-hw/alliance/weeping_city.txt
@@ -181,11 +181,16 @@ hideall "--sync--"
 # OZMA #
 #~~~~~~#
 
-# -ii 366 367 368 1806 1829 1830 1832
+# -ii 366 367 368 1802 1806 1807 1829 1830 1832
+# -ic "Singularity Ripple" "Singularity Trace"
 
 # Ozma is based on an A/B timeline pattern.
 # She begins in Sphere form and can morph into Cube or Pyramid stance.
-# Whichever she chooses sets the path for the remainder of the encounter.
+# The complete flow looks like:
+
+# Sphere opening block -->              --> Cube   bridge block -->       . - - - - - - - - - - ---
+#                                                                         V                       |
+# Cube   opening block --> Intermission --> Sphere bridge block --> (Cube|Sphere) rotation blocks |
 
 2000.0 "--sync--" sync /00:0839:.*Gloriole will be sealed off/ window 2000,5
 2015.0 "Meteor Headmarkers"
@@ -210,7 +215,6 @@ hideall "--sync--"
 
 2250.0 "Transfiguration (Cube)" sync /:Ozma:1803:/
 2257.0 "Flare Star" sync /:Ozma:1805:/
-2263.5 "Explosion x5" # sync /:Ozmasphere:1807:/
 2288.0 "Holy" sync /:Ozma:182E:/
 2300.0 "Transfiguration (Sphere)" sync /:Ozma:1804:/
 2308.0 "Black Hole" sync /:Ozma:1800:/ window 300,5 jump 2400.0
@@ -224,12 +228,14 @@ hideall "--sync--"
 # Instead, we just let the timeline play on dead space.
 # The intermission's enrage is probably under 3 minutes, but we have no way to know.
 
+2594.4 "--sync--" sync /:Ozma:182D:/ window 194.4,0
 2600.0 "--sync--" sync /:Ozma:1826:/ window 200,5 jump 2700.0
 2600.0 "--sync--" sync /:Ozma:1803:/ window 200,5 jump 3000.0
 
 # The continuation from the intermission is dependent on whichever was first.
 # Each has its own bridge block, each one leading into a pair of rotation blocks.
 # Because of this, it's necessary to jump around way more than we should have to.
+# Each block seems? to be full of tiny HP pushes back into Sphere form.
 
 
 # Cube-first continued
@@ -260,37 +266,35 @@ hideall "--sync--"
 3080.8 "--sync--" sync /:Ozma:1803:/ window 50,5 jump 3400
 3087.8 "Execration?"
 3087.8 "Flare Star?"
+3091.8 "Tank Lasers?"
 3099.8 "Holy?"
 3103.8 "Acceleration Bomb?"
-3106.8 "Meteor Impact?"
-3116.8 "Meteor Impact?"
 
 
 # Pyramid standard rotation
 
 3200.0 "Transfiguration (Pyramid)" sync /:Ozma:1826:/
 3207.0 "Execration" sync /:Ozma:1828:/
-3211.0 "Tank Lasers" # sync /:Ozma:1831:/
 3223.0 "Acceleration Bomb" sync /:Ozma:182F:/
 3226.0 "Meteor Impact" sync /:Singularity Fragment:1935:/
 3246.5 "Meteor" # sync /:Ozma:182D:/
 3261.0 "Acceleration Bomb" sync /:Ozma:182F:/
-3263.0 "Transfiguration (Sphere)" sync /:Ozma:1827:/window 50,5
+3263.0 "Transfiguration (Sphere)" sync /:Ozma:1827:/ window 50,5
 
 3275.0 "Transfiguration (Cube/Pyramid?)" sync /:Ozma:1826:/ window 50,5 jump 3200
 3275.0 "--sync--" sync /:Ozma:1803:/ jump 3400
 3282.0 "Execration?"
 3282.0 "Flare Star?"
+3286.0 "Tank Lasers?"
 3294.0 "Holy?"
 3298.0 "Acceleration Bomb?"
-3301.0 "Meteor Impact?"
 
 
 # Cube standard rotation
 
 3400.0 "Transfiguration (Cube)" sync /:Ozma:1803:/
 3407.0 "Flare Star" sync /:Ozma:1805:/
-3411.0 "Tank Lasers"
+3411.0 "Tank Lasers" # sync /:Ozma:1831:/
 3419.0 "Holy" sync /:Ozma:182E:/
 3435.1 "Meteor Impact" sync /:Singularity Fragment:1935:/
 3441.1 "Holy" sync /:Ozma:182E:/
@@ -301,9 +305,10 @@ hideall "--sync--"
 3475.2 "--sync--" sync /:Ozma:1803:/ window 50,5 jump 3400
 3482.2 "Execration?"
 3482.2 "Flare Star?"
+3486.2 "Tank Lasers?"
 3494.2 "Holy?"
 3498.2 "Acceleration Bomb?"
-3501.2 "Meteor Impact?"
+
 
 
 

--- a/ui/raidboss/data/03-hw/alliance/weeping_city.txt
+++ b/ui/raidboss/data/03-hw/alliance/weeping_city.txt
@@ -181,7 +181,7 @@ hideall "--sync--"
 # OZMA #
 #~~~~~~#
 
-# -ii 366 367 368 1806 1829 1830 1831 1832
+# -ii 366 367 368 1806 1829 1830 1832
 
 # Ozma is based on an A/B timeline pattern.
 # She begins in Sphere form and can morph into Cube or Pyramid stance.
@@ -191,8 +191,8 @@ hideall "--sync--"
 2015.0 "Meteor Headmarkers"
 2024.0 "Meteor Impact" sync /:Singularity Fragment:1935:/
 
-2045.5 "Transfiguration (Pyramid)" sync /:Ozma:1826:/
-2045.5 "--sync--" sync /:Ozma:1803:/
+2045.5 "Transfiguration (Pyramid)" sync /:Ozma:1826:/ jump 2150.0
+2045.5 "--sync--" sync /:Ozma:1803:/ jump 2250.0
 2052.6 "Execration?"
 2052.6 "Flare Star?"
 2059.0 "Explosion x5?"
@@ -204,7 +204,7 @@ hideall "--sync--"
 2157.1 "Execration" sync /:Ozma:1828:/
 2178.4 "Acceleration Bomb" sync /:Ozma:182F:/
 2195.7 "Transfiguration (Sphere)" sync /:Ozma:1827:/
-2203.8 "Black Hole" sync /:Ozma:1800:/
+2203.8 "Black Hole"
 
 # Cube-first path
 
@@ -227,63 +227,85 @@ hideall "--sync--"
 2600.0 "--sync--" sync /:Ozma:1826:/ window 200,5 jump 2700.0
 2600.0 "--sync--" sync /:Ozma:1803:/ window 200,5 jump 3000.0
 
+# The continuation from the intermission is dependent on whichever was first.
+# Each has its own bridge block, each one leading into a pair of rotation blocks.
+# Because of this, it's necessary to jump around way more than we should have to.
 
-# Pyramid-first continued
+
+# Cube-first continued
 2700.0 "Transfiguration (Pyramid)" sync /:Ozma:1826:/
 2707.0 "Execration" sync /:Ozma:1828:/
 2728.0 "Acceleration Bomb" sync /:Ozma:182F:/
-2745.0 "Transfiguration (Sphere)" sync /:Ozma:1827:/
+2745.0 "Transfiguration (Sphere)" sync /:Ozma:1827:/ window 45,5
 2763.0 "Meteor Impact" sync /:Singularity Fragment:1935:/
 
-2790.8 "Transfiguration (Pyramid)" sync /:Ozma:1826:/
-2797.8 "Execration" sync /:Ozma:1828:/
-2813.8 "Acceleration Bomb" sync /:Ozma:182F:/
-2816.8 "Meteor Impact" sync /:Singularity Fragment:1935:/
-2837.3 "Meteor" # sync /:Ozma:182D:/
-2851.8 "Acceleration Bomb" sync /:Ozma:182F:/
-2853.8 "Transfiguration (Sphere)" sync /:Ozma:1827:/
-2865.8 "Transfiguration (Cube)" sync /:Ozma:1803:/
-2872.8 "Flare Star" sync /:Ozma:1805:/
-2879.3 "Explosion x5" # sync /:Ozmasphere:1807:/
-2884.8 "Holy" sync /:Ozma:182E:/
-2900.9 "Meteor Impact" sync /:Singularity Fragment:1935:/
-2906.9 "Holy" sync /:Ozma:182E:/
-2922.4 "Meteor" # sync /:Ozma:182D:/
-2929.0 "Transfiguration (Sphere)" sync /:Ozma:1804:/
+2790.8 "Transfiguration (Cube/Pyramid?)" sync /:Ozma:1826:/ window 50,5 jump 3200
+2790.8 "--sync--" sync /:Ozma:1803:/ window 50,5 jump 3400
+2797.8 "Execration?"
+2797.8 "Flare Star?"
+2809.8 "Holy?"
+2813.8 "Acceleration Bomb?"
+2816.8 "Meteor Impact?"
 
-2941.0 "Transfiguration (Pyramid)" sync /:Ozma:1826:/ jump 2790.8
-2948.0 "Execration"
-2964.0 "Acceleration Bomb"
-2967.0 "Meteor Impact"
 
-# Cube-first continued
+# Pyramid-first continued
 
 3000.0 "Transfiguration (Cube)" sync /:Ozma:1803:/
 3007.0 "Flare Star" sync /:Ozma:1805:/
-3013.6 "Explosion x5" # sync /:Ozmasphere:1807:/
+3011.0 "Tank Lasers" # sync /:Ozma:1831:/
 3029.7 "Transfiguration (Sphere)" sync /:Ozma:1804:/
 3047.9 "Meteor Impact" sync /:Singularity Fragment:1935:/
 
-3080.7 "Transfiguration (Cube)" sync /:Ozma:1803:/
-3087.8 "Flare Star" sync /:Ozma:1805:/
-3094.6 "Explosion x5" # sync /:Ozmasphere:1807:/
-3100.1 "Holy" sync /:Ozma:182E:/
-3116.3 "Meteor Impact" sync /:Singularity Fragment:1935:/
-3122.7 "Holy" sync /:Ozma:182E:/
-3138.7 "Meteor" # sync /:Ozma:182D:/
-3145.7 "Transfiguration (Sphere)" sync /:Ozma:1804:/
-3157.9 "Transfiguration (Pyramid)" sync /:Ozma:1826:/
-3165.0 "Execration" sync /:Ozma:1828:/
-3181.5 "Acceleration Bomb" sync /:Ozma:182F:/
-3184.2 "Meteor Impact" sync /:Singularity Fragment:1935:/
-3205.2 "Meteor" # sync /:Ozma:182D:/
-3220.3 "Acceleration Bomb" sync /:Ozma:182F:/
-3222.4 "Transfiguration (Sphere)" sync /:Ozma:1827:/
+3080.8 "Transfiguration (Cube/Pyramid?)" sync /:Ozma:1826:/ window 50,5 jump 3200
+3080.8 "--sync--" sync /:Ozma:1803:/ window 50,5 jump 3400
+3087.8 "Execration?"
+3087.8 "Flare Star?"
+3099.8 "Holy?"
+3103.8 "Acceleration Bomb?"
+3106.8 "Meteor Impact?"
+3116.8 "Meteor Impact?"
 
-3234.9 "Transfiguration (Cube)" sync /:Ozma:1803:/ jump 3080.7
-3242.0 "Flare Star"
-3248.8 "Explosion x5"
-3254.3 "Holy"
+
+# Pyramid standard rotation
+
+3200.0 "Transfiguration (Pyramid)" sync /:Ozma:1826:/
+3207.0 "Execration" sync /:Ozma:1828:/
+3211.0 "Tank Lasers" # sync /:Ozma:1831:/
+3223.0 "Acceleration Bomb" sync /:Ozma:182F:/
+3226.0 "Meteor Impact" sync /:Singularity Fragment:1935:/
+3246.5 "Meteor" # sync /:Ozma:182D:/
+3261.0 "Acceleration Bomb" sync /:Ozma:182F:/
+3263.0 "Transfiguration (Sphere)" sync /:Ozma:1827:/window 50,5
+
+3275.0 "Transfiguration (Cube/Pyramid?)" sync /:Ozma:1826:/ window 50,5 jump 3200
+3275.0 "--sync--" sync /:Ozma:1803:/ jump 3400
+3282.0 "Execration?"
+3282.0 "Flare Star?"
+3294.0 "Holy?"
+3298.0 "Acceleration Bomb?"
+3301.0 "Meteor Impact?"
+
+
+# Cube standard rotation
+
+3400.0 "Transfiguration (Cube)" sync /:Ozma:1803:/
+3407.0 "Flare Star" sync /:Ozma:1805:/
+3411.0 "Tank Lasers"
+3419.0 "Holy" sync /:Ozma:182E:/
+3435.1 "Meteor Impact" sync /:Singularity Fragment:1935:/
+3441.1 "Holy" sync /:Ozma:182E:/
+3456.6 "Meteor" # sync /:Ozma:182D:/
+3463.2 "Transfiguration (Sphere)" sync /:Ozma:1804:/ window 50,5
+
+3475.2 "Transfiguration (Cube/Pyramid?)" sync /:Ozma:1826:/ window 50,5 jump 3200
+3475.2 "--sync--" sync /:Ozma:1803:/ window 50,5 jump 3400
+3482.2 "Execration?"
+3482.2 "Flare Star?"
+3494.2 "Holy?"
+3498.2 "Acceleration Bomb?"
+3501.2 "Meteor Impact?"
+
+
 
 #~~~~~~~~~~~~~#
 # CALOFISTERI #

--- a/ui/raidboss/data/03-hw/alliance/weeping_city.txt
+++ b/ui/raidboss/data/03-hw/alliance/weeping_city.txt
@@ -196,7 +196,7 @@ hideall "--sync--"
 2015.0 "Meteor Headmarkers"
 2024.0 "Meteor Impact" sync /:Singularity Fragment:1935:/
 
-2045.5 "Transfiguration (Pyramid)" sync /:Ozma:1826:/ jump 2150.0
+2045.5 "Transfiguration (Pyramid/Cube?)" sync /:Ozma:1826:/ jump 2150.0
 2045.5 "--sync--" sync /:Ozma:1803:/ jump 2250.0
 2052.6 "Execration?"
 2052.6 "Flare Star?"
@@ -295,9 +295,9 @@ hideall "--sync--"
 3400.0 "Transfiguration (Cube)" sync /:Ozma:1803:/
 3407.0 "Flare Star" sync /:Ozma:1805:/
 3411.0 "Tank Lasers" # sync /:Ozma:1831:/
-3419.0 "Holy" sync /:Ozma:182E:/
+3419.2 "Holy" sync /:Ozma:182E:/
 3435.1 "Meteor Impact" sync /:Singularity Fragment:1935:/
-3441.1 "Holy" sync /:Ozma:182E:/
+3441.3 "Holy" sync /:Ozma:182E:/
 3456.6 "Meteor" # sync /:Ozma:182D:/
 3463.2 "Transfiguration (Sphere)" sync /:Ozma:1804:/ window 50,5
 

--- a/ui/raidboss/data/manifest.txt
+++ b/ui/raidboss/data/manifest.txt
@@ -37,6 +37,8 @@
 02-arr/trial/titan-ex.txt
 03-hw/alliance/dun_scaith.js
 03-hw/alliance/dun_scaith.txt
+03-hw/alliance/weeping_city.js
+03-hw/alliance/weeping_city.txt
 03-hw/dungeon/aetherochemical_research_facility.js
 03-hw/dungeon/aetherochemical_research_facility.txt
 03-hw/dungeon/fractal_continuum.js


### PR DESCRIPTION
A primary difficulty in building packages for older alliance raids is that ACT has been significantly improved since 2016. It's tough to get logs with all the necessary information in them, so the work represented here is a combination of generation from 4 years's worth of different logs in addition to trawling FFLogs for the longest possible encounters I could find. ([Arachne Eve](https://www.fflogs.com/reports/MC7HrDWkTPabLKYg#fight=3), [Forgall](https://www.fflogs.com/reports/YpchN4C21yTVa67v#fight=45), [Ozma](https://www.fflogs.com/reports/kWKBtdr8jYJfyTap#fight=1), [Calofisteri](https://www.fflogs.com/reports/R831VACkL2tNMndX#fight=last), for anyone who wants to have a look themselves.)

The timelines are reasonably accurate, but there's probably a good bit of improvement that could be done there. I'm relatively sure there's something causing variance in the Meteor Impacts in Ozma, as the timing seems all over the place there while the rest of Ozma's phases are mostly okay.

Ozma's timeline is awful in itself. I mostly laid the issues out in-line, but the opening block and the block immediately after are random, so it's necessary to account for both. The post-intermission is broken into bridge blocks and rotation blocks, and of course each has to have a faked loop after to provide continuity. Each of the bridges can jump to either rotation block, and each rotation block can jump to itself or the other. It's all a mess.

Calofisteri's timeline is simple enough, but of course all her abilities are determined by which side her hair is on, so we have to ensure that's accounted for everywhere. Extra eyes to make sure I didn't miss any doubled syncs would be appreciated!

For triggers, Arachne Eve has the Sticky Wicket ability, which puts the green Mucus Spray headmarkers on three people. I have this one set as `Spread()` for everyone, but I'm completely in favor of a better option if someone can think of it. There's just no good way to handle the mechanic consistently.

On Ozma, I don't really like the Cube handling trigger, but I can't think of a better way to do things that's as concise. It is a bit prescriptive to have the healers do Flare Star, but it is the standard strategy for NA. Suggestions solicited!

For Calofisteri, in theory we could note the spawn locations of the scythe Living Locks and tell the player a safe location from the line AoEs based on that, but it's too much work.

Dancing Mad is listed as `caresAboutAOE()`, but this notifies casters, who can't help with it because Calofisteri isn't targetable yet. Maybe it would be better to set the condition as something like...

`return ['DRK', 'PLD', 'WAR'].includes(data.job) || data.role == 'healer`

Maybe I'm overthinking it.

Finally, there's no translation or oopsy work. For translations, @Akurosia has been gracious enough to clean that up for me on a couple of my recent submissions, and I'll ask here for assistance once again. On oopsy, I'm a little burnt out from this one and can't really do it right now. If I were to "just do a few of the important ones", it's likely I wouldn't go back and fill it out later.