### PR TITLE
Raidboss: Shiva hm/ex + common

### DIFF
--- a/ui/raidboss/common_replacement.js
+++ b/ui/raidboss/common_replacement.js
@@ -47,7 +47,7 @@ const commonReplacement = {
     '--adds targetable--': {
       de: '--adds anvisierbar--',
       fr: '--adds ciblables--',
-      ja: '--fixme--',
+      ja: '--雑魚ターゲット可能--',
       cn: '--小怪可选中--',
       ko: '--쫄 타겟 가능--',
     },

--- a/ui/raidboss/common_replacement.js
+++ b/ui/raidboss/common_replacement.js
@@ -44,6 +44,13 @@ const commonReplacement = {
       cn: '--小怪出现--',
       ko: '--쫄 소환--',
     },
+    '--adds targetable--': {
+      de: '--adds anvisierbar--',
+      fr: '--adds ciblables--',
+      ja: '--fixme--',
+      cn: '--小怪可选中--',
+      ko: '--쫄 타겟 가능--',
+    },
     '--center--': {
       de: '--mitte--',
       fr: '--centre--',

--- a/ui/raidboss/data/02-arr/trial/shiva-ex.js
+++ b/ui/raidboss/data/02-arr/trial/shiva-ex.js
@@ -26,6 +26,7 @@
       alertText: {
         en: 'Party Share Tankbuster',
         de: 'Tankbuster mit der Gruppe Teilen',
+        fr: 'Partagez le Tank buster avec le groupe',
       },
     },
   ],
@@ -45,6 +46,7 @@
               alertText: {
                 en: 'Staff (Tank Swap)',
                 de: 'Stab (Tankwechsel)',
+                fr: 'Bâton (Tank Swap)',
               },
             };
           }
@@ -54,6 +56,7 @@
           infoText: {
             en: 'Staff',
             de: 'Stab',
+            fr: 'Bâton',
           },
         };
       },
@@ -76,6 +79,7 @@
               alertText: {
                 en: 'Sword (Tank Swap)',
                 de: 'Schwert (Tankwechsel)',
+                fr: 'Épée (Tank Swap)',
               },
             };
           }
@@ -85,6 +89,7 @@
           infoText: {
             en: 'Sword',
             de: 'Schwert',
+            fr: 'Épée',
           },
         };
       },
@@ -199,6 +204,7 @@
       alarmText: {
         en: 'Knockback Laser on YOU',
         de: 'Rückstoß-Laser auf DIR',
+        fr: 'Poussée-Laser sur VOUS',
       },
     },
     {
@@ -208,6 +214,7 @@
       infoText: {
         en: 'Avoid Laser',
         de: 'Laser ausweichen',
+        fr: 'Évitez le laser',
       },
     },
     {
@@ -242,6 +249,7 @@
         return {
           en: 'Free ' + data.ShortName(matches.target),
           de: 'Befreie ' + data.ShortName(matches.target),
+          fr: 'Libérez ' + data.ShortName(matches.target),
         };
       },
     },
@@ -256,7 +264,6 @@
       'replaceText': {
         '\\(circle\\)': '(Kreis)',
         '\\(cross\\)': '(Kreuz)',
-        '--adds targetable--': '--Adds erscheinen--',
         '--frozen--': '--eingefroren--',
         'Absolute Zero': 'Absoluter Nullpunkt',
         'Avalanche': 'Lawine',
@@ -278,12 +285,15 @@
     },
     {
       'locale': 'fr',
-      'missingTranslations': true,
       'replaceSync': {
         'Ice Soldier': 'soldat de glace',
         'Shiva': 'Shiva',
       },
       'replaceText': {
+        '\\?': ' ?',
+        '\\(circle\\)': '(cercle)',
+        '\\(cross\\)': '(croix)',
+        '--frozen--': '--gelé--',
         'Absolute Zero': 'Zéro absolu',
         'Avalanche': 'Avalanche',
         'Diamond Dust': 'Poussière de diamant',

--- a/ui/raidboss/data/02-arr/trial/shiva-hm.js
+++ b/ui/raidboss/data/02-arr/trial/shiva-hm.js
@@ -50,6 +50,7 @@
         return {
           en: 'Free ' + data.ShortName(matches.target),
           de: 'Befreie ' + data.ShortName(matches.target),
+          fr: 'Libérez ' + data.ShortName(matches.target),
         };
       },
     },
@@ -64,7 +65,6 @@
       'replaceText': {
         '\\(circle\\)': '(Kreis)',
         '\\(cross\\)': '(Kreuz)',
-        '--adds targetable--': '--Adds erscheinen--',
         '--frozen--': '--eingefroren--',
         'Absolute Zero': 'Absoluter Nullpunkt',
         'Diamond Dust': 'Diamantenstaub',
@@ -87,9 +87,9 @@
         'Shiva': 'Shiva',
       },
       'replaceText': {
+        '\\?': ' ?',
         '\\(circle\\)': '(cercle)',
         '\\(cross\\)': '(croix)',
-        '--adds targetable--': '--adds ciblable--',
         '--frozen--': '--gelé--',
         'Absolute Zero': 'Zéro absolu',
         'Diamond Dust': 'Poussière de diamant',

--- a/ui/raidboss/data/05-shb/ultimate/the_epic_of_alexander.js
+++ b/ui/raidboss/data/05-shb/ultimate/the_epic_of_alexander.js
@@ -2862,7 +2862,6 @@ const kFinalJudgementNisi = ['8B0', '8B1', '85B', '85C'];
       },
       'replaceText': {
         '--Cruise Chaser Invincible--': '--Chaser-Mecha unverwundbar--',
-        '--adds targetable--': '--adds anvisierbar--',
         '--alex untargetable--': '--alex nich anvisierbar--',
         'Almighty Judgment': 'Göttliches Letzturteil',
         'Alpha Sword': 'Alpha-Schwert',
@@ -2953,7 +2952,6 @@ const kFinalJudgementNisi = ['8B0', '8B1', '85B', '85C'];
         'Steam Chakram': 'chakram de vapeur',
       },
       'replaceText': {
-        '--adds targetable--': '--adds ciblables--',
         '--alex untargetable--': '--alex non ciblable--',
         '--Cruise Chaser Invincible--': '--Croiseur-chasseur Invincible--',
         'Almighty Judgment': 'Sentence divine',
@@ -3125,7 +3123,6 @@ const kFinalJudgementNisi = ['8B0', '8B1', '85B', '85C'];
       },
       'replaceText': {
         '--Cruise Chaser Invincible--': '--巡航驱逐者无敌--',
-        '--adds targetable--': '--小怪可选中--',
         '--alex untargetable--': '--亚历山大无法选中--',
         'True Heart': '真心',
         'Waves': '水波',
@@ -3227,7 +3224,6 @@ const kFinalJudgementNisi = ['8B0', '8B1', '85B', '85C'];
       },
       'replaceText': {
         '--Cruise Chaser Invincible--': '--순항추격기 무적--',
-        '--adds targetable--': '--쫄 타겟 가능--',
         '--alex untargetable--': '--알렉산더 타겟 불가능--',
         'True Heart': '진심',
         'Reveal': '예고',


### PR DESCRIPTION
- adds missing translations fr.
- removal lines `adds targetable` on shiva-ex/hm + epic_alex for add common. there was a misunderstanding between appear and targetable on the German translation that I corrected.  anvisierbar=targetable and erscheinen=appear