### PR TITLE
Util: Force case insensitivity in zone seal regex

### DIFF
--- a/util/test_timeline.py
+++ b/util/test_timeline.py
@@ -237,7 +237,9 @@ def test_match(event, entry):
             # Matching this format generically:
             # 00|2019-01-12T18:08:14.0000000-05:00|0839||The Realm of the Machinists will be sealed off in 15 seconds!|
             log_match = re.search(
-                "^00\|[^\|]*\|{}\|[^\|]*\|{}".format(entry["logid"], entry["line"]), event, re.IGNORECASE
+                "^00\|[^\|]*\|{}\|[^\|]*\|{}".format(entry["logid"], entry["line"]),
+                event,
+                re.IGNORECASE,
             )
             if log_match:
                 return True

--- a/util/test_timeline.py
+++ b/util/test_timeline.py
@@ -237,7 +237,7 @@ def test_match(event, entry):
             # Matching this format generically:
             # 00|2019-01-12T18:08:14.0000000-05:00|0839||The Realm of the Machinists will be sealed off in 15 seconds!|
             log_match = re.search(
-                "^00\|[^\|]*\|{}\|[^\|]*\|{}".format(entry["logid"], entry["line"]), event
+                "^00\|[^\|]*\|{}\|[^\|]*\|{}".format(entry["logid"], entry["line"]), event, re.IGNORECASE
             )
             if log_match:
                 return True


### PR DESCRIPTION
When working with zoneseal messages where casing is not guaranteed, `test_timeline` can break if there are no close-by syncs:

`0 "--sync--" sync /00:0839:The Main Deck will be sealed off/`

This fails if the combat log has `the main deck` instead. Current practice is to title case the "name" portion of the zone seal message. Square's localization team is *very* good, but they seem to have real trouble with casing things, and that collides here.

Probably this logic should be moved to `encounter_tools`, but for now if nothing else this will *work*.