### PR TITLE
jobs: AST part Remake

### DIFF
--- a/ui/jobs/jobs.css
+++ b/ui/jobs/jobs.css
@@ -34,6 +34,10 @@
   left: 278px;
 }
 
+.ast #right-side-icons {
+  left: 278px;
+}
+
 .drk #right-side-icons {
   left: 250px;
 }
@@ -166,6 +170,7 @@
 /* Relative to #bars */
 #rdm-boxes,
 #sch-boxes,
+#ast-boxes,
 #war-boxes,
 #mnk-boxes,
 #pld-boxes,
@@ -180,6 +185,7 @@
 
 #rdm-boxes > div,
 #sch-boxes > div,
+#ast-boxes > div,
 #war-boxes > div,
 #mnk-boxes > div,
 #pld-boxes > div,
@@ -209,6 +215,7 @@
 }
 
 #sch-boxes > div,
+#ast-boxes > div,
 #rdm-boxes > div {
   width: 28px;
   height: 28px;
@@ -221,6 +228,7 @@
 
 #rdm-boxes .text,
 #sch-boxes .text,
+#ast-boxes .text,
 #war-boxes .text,
 #mnk-boxes .text,
 #pld-boxes .text,
@@ -238,6 +246,7 @@
 }
 
 #sch-boxes .text,
+#ast-boxes .text,
 #rdm-boxes .text {
   top: 5px;
 }
@@ -313,7 +322,7 @@
 }
 
 #mnk-procs-twinsnakes,
-#ast-procs-benefic,
+#ast-procs-draw,
 #sch-procs-aetherflow,
 #blu-procs-torment,
 #blm-dot-thunder {
@@ -323,7 +332,7 @@
 }
 
 #mnk-procs-demolish,
-#ast-procs-helios,
+#ast-procs-luciddreaming,
 #sch-procs-luciddreaming,
 #blm-procs-thunder,
 #blu-procs-lucid {
@@ -597,6 +606,34 @@
 
 .ast-color-helios {
   background-color: rgb(175, 235, 215);
+}
+
+.ast-color-draw {
+  background-color: rgb(64, 65, 163);
+}
+
+.ast-color-card {
+  background-color: rgb(180, 200, 220);
+}
+
+.ast-color-card.range {
+  background-color: rgb(255, 96, 207);
+}
+
+.ast-color-card.melee {
+  background-color: rgb(120, 170, 250);
+}
+
+.ast-color-seal {
+  background-color: rgb(180, 200, 220);
+}
+
+.ast-color-seal.ready {
+  background-color: rgb(62, 224, 170);
+}
+
+.ast-color-lucid {
+  background-color: rgb(227, 148, 210);
 }
 
 .blu-color-offguard {

--- a/ui/jobs/jobs.js
+++ b/ui/jobs/jobs.js
@@ -1643,70 +1643,63 @@ class Bars {
     let sealBox = this.addResourceBox({
       classList: ['ast-color-seal'],
     });
-    
+
     this.jobFuncs.push((jobDetail) => {
-      let Card = jobDetail.heldCard
-      let seal = jobDetail.arcanums
+      let Card = jobDetail.heldCard;
+      let seal = jobDetail.arcanums;
 
       // Show on which kind of jobs your card plays better by color
       // Blue on melee, purple on ranged, and grey when no card
       let c = cardBox.parentNode;
       c.classList.remove('melee');
       c.classList.remove('range');
-      if (Card == "Arrow" || Card == "Spear" || Card == "Balance") {
+      if (Card == 'Arrow' || Card == 'Spear' || Card == 'Balance')
         c.classList.add('melee');
-      }
-      if (Card == "Bole" || Card == "Spire" || Card == "Ewer") {
+      if (Card == 'Bole' || Card == 'Spire' || Card == 'Ewer')
         c.classList.add('range');
-      }
-      
+
       // Show whether you already have this seal
       // O means it's OK to play this card
       // X means don't play this card directly if time permits
       if (Card == 'Balance' || Card == 'Bole') {
-        if (seal.indexOf("Solar") != -1) {
-          cardBox.innerText = "X"
-        } else {
-          cardBox.innerText = "O"
-        }}
-      if (Card == 'Arrow' || Card == 'Ewer') {
-        if (seal.indexOf("Lunar") != -1) {
-          cardBox.innerText = "X"
-        } else {
-          cardBox.innerText = "O"
-        }}
-      if (Card == 'Spear' || Card == 'Spire') {
-        if (seal.indexOf("Celestial") != -1) {
-          cardBox.innerText = "X"
-        } else {
-          cardBox.innerText = "O"
-        }}
-      if (seal == 'None') {
-        if (Card != 'None'){
-          cardBox.innerText = "O"
-        }}
-      if (Card == 'None') {
-        cardBox.innerText = ""
+        if (seal.indexOf('Solar') != -1)
+          cardBox.innerText = 'X';
+        else
+          cardBox.innerText = 'O';
       }
+      if (Card == 'Arrow' || Card == 'Ewer') {
+        if (seal.indexOf('Lunar') != -1)
+          cardBox.innerText = 'X';
+        else
+          cardBox.innerText = 'O';
+      }
+      if (Card == 'Spear' || Card == 'Spire') {
+        if (seal.indexOf('Celestial') != -1)
+          cardBox.innerText = 'X';
+        else
+          cardBox.innerText = 'O';
+      }
+      if (seal == 'None') {
+        if (Card != 'None')
+          cardBox.innerText = 'O';
+      }
+      if (Card == 'None') 
+        cardBox.innerText = '';
 
       // Show how many kind of seals you already have
       // Turn green when you have all 3 kinds of seal
-      let sealcount = 0
-      if (seal.indexOf("Solar") != -1) {
-        sealcount =sealcount + 1
-      }
-      if (seal.indexOf("Lunar") != -1) {
-        sealcount = sealcount + 1
-      }
-      if (seal.indexOf("Celestial") != -1) {
-        sealcount = sealcount + 1
-      }      
-      sealBox.innerText = sealcount
-      if (sealcount == 3) {
-        sealBox.parentNode.classList.add('ready')
-      } else {
-        sealBox.parentNode.classList.remove('ready')
-      }
+      let sealcount = 0;
+      if (seal.indexOf("Solar") != -1)
+        sealcount =sealcount + 1;
+      if (seal.indexOf("Lunar") != -1)
+        sealcount = sealcount + 1;
+      if (seal.indexOf("Celestial") != -1)
+        sealcount = sealcount + 1 ;  
+      sealBox.innerText = sealcount;
+      if (sealcount == 3)
+        sealBox.parentNode.classList.add('ready');
+      else
+        sealBox.parentNode.classList.remove('ready');
     });
 
     this.abilityFuncMap[kAbility.Combust3] = () => {
@@ -1721,6 +1714,7 @@ class Bars {
       combustBox.duration = 0;
       combustBox.duration = 18;
     };
+
     this.abilityFuncMap[kAbility.Draw] = () => {
       drawBox.duration = 0;
       drawBox.duration = 30;

--- a/ui/jobs/jobs.js
+++ b/ui/jobs/jobs.js
@@ -1675,7 +1675,7 @@ class Bars {
         else
           cardBox.innerText = 'O';
       }
-      if (seal == 'None' && card != 'None')
+      if (seals == 'None' && card != 'None')
         cardBox.innerText = 'O';
 
       // Show how many kind of seals you already have

--- a/ui/jobs/jobs.js
+++ b/ui/jobs/jobs.js
@@ -1680,13 +1680,13 @@ class Bars {
 
       // Show how many kind of seals you already have
       // Turn green when you have all 3 kinds of seal
-      let sealcount = 0;
+      let sealCount = 0;
       ['Solar', 'Lunar', 'Celestial'].forEach((value) => {
         if (seals.includes(value))
-          sealcount++;
+          sealCount++;
       });
-      sealBox.innerText = sealcount;
-      if (sealcount == 3)
+      sealBox.innerText = sealCount;
+      if (sealCount == 3)
         sealBox.parentNode.classList.add('ready');
       else
         sealBox.parentNode.classList.remove('ready');

--- a/ui/jobs/jobs.js
+++ b/ui/jobs/jobs.js
@@ -1621,6 +1621,15 @@ class Bars {
   }
 
   setupAst() {
+    const cardsMap = {
+      'Balance': { 'bonus': 'melee', 'seal': 'Solar' },
+      'Bole': { 'bonus': 'range', 'seal': 'Solar' },
+      'Arrow': { 'bonus': 'melee', 'seal': 'Lunar' },
+      'Ewer': { 'bonus': 'range', 'seal': 'Lunar' },
+      'Spear': { 'bonus': 'melee', 'seal': 'Celestial' },
+      'Spire': { 'bonus': 'range', 'seal': 'Celestial' },
+    };
+
     let combustBox = this.addProcBox({
       id: 'ast-procs-combust',
       fgColor: 'ast-color-combust',
@@ -1645,56 +1654,37 @@ class Bars {
     });
 
     this.jobFuncs.push((jobDetail) => {
-      let Card = jobDetail.heldCard;
-      let seal = jobDetail.arcanums;
+      let card = jobDetail.heldCard;
+      let seals = jobDetail.arcanums;
 
       // Show on which kind of jobs your card plays better by color
       // Blue on melee, purple on ranged, and grey when no card
-      let c = cardBox.parentNode;
-      c.classList.remove('melee');
-      c.classList.remove('range');
-      if (Card == 'Arrow' || Card == 'Spear' || Card == 'Balance')
-        c.classList.add('melee');
-      if (Card == 'Bole' || Card == 'Spire' || Card == 'Ewer')
-        c.classList.add('range');
+      let cardParent = cardBox.parentNode;
+      cardParent.classList.remove('melee', 'range');
+      if (card in cardsMap)
+        cardParent.classList.add(cardsMap[card].bonus);
 
       // Show whether you already have this seal
       // O means it's OK to play this card
       // X means don't play this card directly if time permits
-      if (Card == 'Balance' || Card == 'Bole') {
-        if (seal.indexOf('Solar') != -1)
+      cardBox.innerText = '';
+      if (card in cardsMap) {
+        const seal = cardsMap[card].seal;
+        if (seals.includes(seal))
           cardBox.innerText = 'X';
         else
           cardBox.innerText = 'O';
       }
-      if (Card == 'Arrow' || Card == 'Ewer') {
-        if (seal.indexOf('Lunar') != -1)
-          cardBox.innerText = 'X';
-        else
-          cardBox.innerText = 'O';
-      }
-      if (Card == 'Spear' || Card == 'Spire') {
-        if (seal.indexOf('Celestial') != -1)
-          cardBox.innerText = 'X';
-        else
-          cardBox.innerText = 'O';
-      }
-      if (seal == 'None') {
-        if (Card != 'None')
-          cardBox.innerText = 'O';
-      }
-      if (Card == 'None')
-        cardBox.innerText = '';
+      if (seal == 'None' && card != 'None')
+        cardBox.innerText = 'O';
 
       // Show how many kind of seals you already have
       // Turn green when you have all 3 kinds of seal
       let sealcount = 0;
-      if (seal.indexOf('Solar') != -1)
-        sealcount = sealcount + 1;
-      if (seal.indexOf('Lunar') != -1)
-        sealcount = sealcount + 1;
-      if (seal.indexOf('Celestial') != -1)
-        sealcount = sealcount + 1;
+      ['Solar', 'Lunar', 'Celestial'].forEach((value) => {
+        if (seals.includes(value))
+          sealcount++;
+      });
       sealBox.innerText = sealcount;
       if (sealcount == 3)
         sealBox.parentNode.classList.add('ready');

--- a/ui/jobs/jobs.js
+++ b/ui/jobs/jobs.js
@@ -1655,7 +1655,7 @@ class Bars {
 
     this.jobFuncs.push((jobDetail) => {
       let card = jobDetail.heldCard;
-      let seals = jobDetail.arcanums;
+      let seals = jobDetail.arcanums.split(', ').filter((seal) => seal !== 'None');
 
       // Show on which kind of jobs your card plays better by color
       // Blue on melee, purple on ranged, and grey when no card
@@ -1667,15 +1667,11 @@ class Bars {
       // Show whether you already have this seal
       // O means it's OK to play this card
       // X means don't play this card directly if time permits
-      cardBox.innerText = '';
-      if (card in cardsMap) {
-        const seal = cardsMap[card].seal;
-        if (seals.includes(seal))
-          cardBox.innerText = 'X';
-        else
-          cardBox.innerText = 'O';
-      }
-      if (seals == 'None' && card != 'None')
+      if (card === 'None')
+        cardBox.innerText = '';
+      else if (seals.includes(cardsMap[card].seal))
+        cardBox.innerText = 'X';
+      else
         cardBox.innerText = 'O';
 
       // Show how many kind of seals you already have

--- a/ui/jobs/jobs.js
+++ b/ui/jobs/jobs.js
@@ -1683,18 +1683,18 @@ class Bars {
         if (Card != 'None')
           cardBox.innerText = 'O';
       }
-      if (Card == 'None') 
+      if (Card == 'None')
         cardBox.innerText = '';
 
       // Show how many kind of seals you already have
       // Turn green when you have all 3 kinds of seal
       let sealcount = 0;
-      if (seal.indexOf("Solar") != -1)
-        sealcount =sealcount + 1;
-      if (seal.indexOf("Lunar") != -1)
+      if (seal.indexOf('Solar') != -1)
         sealcount = sealcount + 1;
-      if (seal.indexOf("Celestial") != -1)
-        sealcount = sealcount + 1 ;  
+      if (seal.indexOf('Lunar') != -1)
+        sealcount = sealcount + 1;
+      if (seal.indexOf('Celestial') != -1)
+        sealcount = sealcount + 1;
       sealBox.innerText = sealcount;
       if (sealcount == 3)
         sealBox.parentNode.classList.add('ready');

--- a/ui/jobs/jobs.js
+++ b/ui/jobs/jobs.js
@@ -1654,8 +1654,8 @@ class Bars {
     });
 
     this.jobFuncs.push((jobDetail) => {
-      let card = jobDetail.heldCard;
-      let seals = jobDetail.arcanums.split(', ').filter((seal) => seal !== 'None');
+      const card = jobDetail.heldCard;
+      const seals = jobDetail.arcanums.split(', ').filter((seal) => seal !== 'None');
 
       // Show on which kind of jobs your card plays better by color
       // Blue on melee, purple on ranged, and grey when no card
@@ -1676,11 +1676,7 @@ class Bars {
 
       // Show how many kind of seals you already have
       // Turn green when you have all 3 kinds of seal
-      let sealCount = 0;
-      ['Solar', 'Lunar', 'Celestial'].forEach((value) => {
-        if (seals.includes(value))
-          sealCount++;
-      });
+      const sealCount = new Set(seals).size;
       sealBox.innerText = sealCount;
       if (sealCount == 3)
         sealBox.parentNode.classList.add('ready');

--- a/ui/jobs/jobs.js
+++ b/ui/jobs/jobs.js
@@ -111,8 +111,10 @@ const kAbility = {
   BloodPrice: 'E2F',
   TheBlackestNight: '1CE1',
   Delirium: '1CDE',
+  Combust: 'E0F',
   Combust2: 'E18',
   Combust3: '40AA',
+  Draw: 'E06',
   AspectedBenefic: 'E0B',
   AspectedHelios: 'E11',
   Bio: '45C8',
@@ -1618,44 +1620,123 @@ class Bars {
     };
   }
 
-  // TODO: none of this is actually super useful.
   setupAst() {
     let combustBox = this.addProcBox({
       id: 'ast-procs-combust',
       fgColor: 'ast-color-combust',
     });
 
-    let beneficBox = this.addProcBox({
-      id: 'ast-procs-benefic',
-      fgColor: 'ast-color-benefic',
+    let drawBox = this.addProcBox({
+      id: 'ast-procs-draw',
+      fgColor: 'ast-color-draw',
     });
 
-    let heliosBox = this.addProcBox({
-      id: 'ast-procs-helios',
-      fgColor: 'ast-color-helios',
+    let lucidBox = this.addProcBox({
+      id: 'ast-procs-luciddreaming',
+      fgColor: 'ast-color-lucid',
     });
 
-    // Sorry, no differentation for noct asts here.  <_<
+    let cardBox = this.addResourceBox({
+      classList: ['ast-color-card'],
+    });
+
+    let sealBox = this.addResourceBox({
+      classList: ['ast-color-seal'],
+    });
+    
+    this.jobFuncs.push((jobDetail) => {
+      let Card = jobDetail.heldCard
+      let seal = jobDetail.arcanums
+
+      // Show on which kind of jobs your card plays better by color
+      // Blue on melee, purple on ranged, and grey when no card
+      let c = cardBox.parentNode;
+      c.classList.remove('melee');
+      c.classList.remove('range');
+      if (Card == "Arrow" || Card == "Spear" || Card == "Balance") {
+        c.classList.add('melee');
+      }
+      if (Card == "Bole" || Card == "Spire" || Card == "Ewer") {
+        c.classList.add('range');
+      }
+      
+      // Show whether you already have this seal
+      // O means it's OK to play this card
+      // X means don't play this card directly if time permits
+      if (Card == 'Balance' || Card == 'Bole') {
+        if (seal.indexOf("Solar") != -1) {
+          cardBox.innerText = "X"
+        } else {
+          cardBox.innerText = "O"
+        }}
+      if (Card == 'Arrow' || Card == 'Ewer') {
+        if (seal.indexOf("Lunar") != -1) {
+          cardBox.innerText = "X"
+        } else {
+          cardBox.innerText = "O"
+        }}
+      if (Card == 'Spear' || Card == 'Spire') {
+        if (seal.indexOf("Celestial") != -1) {
+          cardBox.innerText = "X"
+        } else {
+          cardBox.innerText = "O"
+        }}
+      if (seal == 'None') {
+        if (Card != 'None'){
+          cardBox.innerText = "O"
+        }}
+      if (Card == 'None') {
+        cardBox.innerText = ""
+      }
+
+      // Show how many kind of seals you already have
+      // Turn green when you have all 3 kinds of seal
+      let sealcount = 0
+      if (seal.indexOf("Solar") != -1) {
+        sealcount =sealcount + 1
+      }
+      if (seal.indexOf("Lunar") != -1) {
+        sealcount = sealcount + 1
+      }
+      if (seal.indexOf("Celestial") != -1) {
+        sealcount = sealcount + 1
+      }      
+      sealBox.innerText = sealcount
+      if (sealcount == 3) {
+        sealBox.parentNode.classList.add('ready')
+      } else {
+        sealBox.parentNode.classList.remove('ready')
+      }
+    });
+
     this.abilityFuncMap[kAbility.Combust3] = () => {
       combustBox.duration = 0;
       combustBox.duration = 30;
     };
-    this.abilityFuncMap[kAbility.AspectedBenefic] = () => {
-      beneficBox.duration = 0;
-      beneficBox.duration = 15;
+    this.abilityFuncMap[kAbility.Combust2] = () => {
+      combustBox.duration = 0;
+      combustBox.duration = 30;
     };
-    this.abilityFuncMap[kAbility.AspectedHelios] = () => {
-      heliosBox.duration = 0;
-      heliosBox.duration = 15;
+    this.abilityFuncMap[kAbility.Combust] = () => {
+      combustBox.duration = 0;
+      combustBox.duration = 18;
+    };
+    this.abilityFuncMap[kAbility.Draw] = () => {
+      drawBox.duration = 0;
+      drawBox.duration = 30;
+    };
+    this.abilityFuncMap[kAbility.LucidDreaming] = () => {
+      lucidBox.duration = 0;
+      lucidBox.duration = 60;
     };
 
     this.statChangeFuncMap['AST'] = () => {
       combustBox.valuescale = this.gcdSpell();
-      combustBox.threshold = this.gcdSpell() * 3;
-      beneficBox.valuescale = this.gcdSpell();
-      beneficBox.threshold = this.gcdSpell() * 3;
-      heliosBox.valuescale = this.gcdSpell();
-      heliosBox.threshold = this.gcdSpell() * 3;
+      combustBox.threshold = this.gcdSpell() + 1;
+      drawBox.valuescale = this.gcdSpell();
+      drawBox.threshold = this.gcdSpell() + 1;
+      lucidBox.valuescale = this.gcdSpell();
+      lucidBox.threshold = this.gcdSpell() + 1;
     };
   }
 


### PR DESCRIPTION
![job-ast](https://user-images.githubusercontent.com/68432572/89122777-c6c70400-d4fc-11ea-9a28-6410aa27135a.png)
### Additions:
- **CardBox**
Show on which kind of jobs your card plays better by color. Blue on melee, purple on ranged, and grey when no card.
Also show whether you already have the seal of this card by O/X. O means it's OK to play this card, and X means don't play this card directly if time permits.
- **SealBox**
Show how many kind of seals you already have. Turn green when you have all 3 kinds of seal.
- **Combust DoT Tracker**
Support all combusts that AST have.
- **Draw Cooldown Tracker**
A good AST never forgets draw on time.
- **LucidDreaming Cooldown Tracker**
AST's mana is very poor, cast LucidDreaming on time to ensure your mana.

### Deletions:
- **AspectedBeneficBox and AspectedHeliosBox**
These boxes only work for Diurnal AST, and they use these spells rarely. 
Besides, in these days Nocturnal AST is more common in Raids.