### PR TITLE
job: small fix about raidbufftracker's player name in CN

### DIFF
--- a/ui/jobs/jobs.js
+++ b/ui/jobs/jobs.js
@@ -499,7 +499,7 @@ class Buff {
     else
       // These icon can hold only 2 CN/KR charactors. 3 will escape out of box
       txt = initials[0].slice(0, 2);
-      
+
     let color = this.info.borderColor;
 
     let readyKey = 'r:' + this.name + ':' + source;

--- a/ui/jobs/jobs.js
+++ b/ui/jobs/jobs.js
@@ -494,7 +494,7 @@ class Buff {
     // TODO: could consider looking at the party list to make initials unique?
     let txt = '';
     let initials = source.split(' ');
-    if (initials.length == 2)
+    if (initials.length == 2) 
       txt = initials[0][0] + initials[1][0];
     else {
       const pattern = /[\u21-\u7e]+/g;
@@ -502,7 +502,7 @@ class Buff {
         txt = initials[0].slice(0, 3);
       else
         txt = initials[0].slice(0, 2);
-      }
+    }
 
     let color = this.info.borderColor;
 

--- a/ui/jobs/jobs.js
+++ b/ui/jobs/jobs.js
@@ -497,8 +497,9 @@ class Buff {
     if (initials.length == 2)
       txt = initials[0][0] + initials[1][0];
     else
-      txt = initials[0].slice(0, 3);
-
+      // These icon can hold only 2 CN/KR charactors. 3 will escape out of box
+      txt = initials[0].slice(0, 2);
+      
     let color = this.info.borderColor;
 
     let readyKey = 'r:' + this.name + ':' + source;

--- a/ui/jobs/jobs.js
+++ b/ui/jobs/jobs.js
@@ -494,9 +494,9 @@ class Buff {
     // TODO: could consider looking at the party list to make initials unique?
     let txt = '';
     let initials = source.split(' ');
-    if (initials.length == 2) 
+    if (initials.length == 2) {
       txt = initials[0][0] + initials[1][0];
-    else {
+    } else {
       const pattern = /[\u21-\u7e]+/g;
       if (pattern.test(initials[0].substr(0, 3)))
         txt = initials[0].slice(0, 3);

--- a/ui/jobs/jobs.js
+++ b/ui/jobs/jobs.js
@@ -496,9 +496,13 @@ class Buff {
     let initials = source.split(' ');
     if (initials.length == 2)
       txt = initials[0][0] + initials[1][0];
-    else
-      // These icon can hold only 2 CN/KR charactors. 3 will escape out of box
-      txt = initials[0].slice(0, 2);
+      else {
+        const pattern = /[\u21-\u7e]+/g;
+        if (pattern.test(initials[0].substr(0, 3)))
+          txt = initials[0].slice(0, 3);
+        else
+          txt = initials[0].slice(0, 2);
+      }
 
     let color = this.info.borderColor;
 

--- a/ui/jobs/jobs.js
+++ b/ui/jobs/jobs.js
@@ -496,12 +496,12 @@ class Buff {
     let initials = source.split(' ');
     if (initials.length == 2)
       txt = initials[0][0] + initials[1][0];
-      else {
-        const pattern = /[\u21-\u7e]+/g;
-        if (pattern.test(initials[0].substr(0, 3)))
-          txt = initials[0].slice(0, 3);
-        else
-          txt = initials[0].slice(0, 2);
+    else {
+      const pattern = /[\u21-\u7e]+/g;
+      if (pattern.test(initials[0].substr(0, 3)))
+        txt = initials[0].slice(0, 3);
+      else
+        txt = initials[0].slice(0, 2);
       }
 
     let color = this.info.borderColor;


### PR DESCRIPTION
![QQ截图20200803143238](https://user-images.githubusercontent.com/68432572/89153516-9b452780-d597-11ea-9722-b8ab4a8b859e.png)
These icon can hold only 2 CN/Kor charactors. 3 will escape out of box.
(If I'm not misunderstand, this line is for CN/KR player, because only these name can be `length != 2`)