### PR TITLE
Raidboss: Dun scaith trigger cleanup

### DIFF
--- a/ui/raidboss/data/03-hw/alliance/dun_scaith.js
+++ b/ui/raidboss/data/03-hw/alliance/dun_scaith.js
@@ -375,12 +375,7 @@
       // Triggering off the Bit appearance
       // The cast time on Aetheromodulator is under 3 seconds
       id: 'Dun Scaith Bit Circles',
-      netRegex: NetRegexes.addedCombatant({ name: 'Proto Bit', capture: false }),
-      netRegexDe: NetRegexes.addedCombatant({ name: 'Proto-Drohne', capture: false }),
-      netRegexFr: NetRegexes.addedCombatant({ name: 'Proto-Foret', capture: false }),
-      netRegexJa: NetRegexes.addedCombatant({ name: 'プロトビット', capture: false }),
-      netRegexCn: NetRegexes.addedCombatant({ name: '原型浮游炮', capture: false }),
-      netRegexKo: NetRegexes.addedCombatant({ name: '프로토 비트', capture: false }),
+      netRegex: NetRegexes.addedCombatantFull({ npcNameId: '3782', capture: false }),
       suppressSeconds: 5,
       infoText: {
         en: 'Avoid Bit AoEs',
@@ -391,12 +386,7 @@
     },
     {
       id: 'Dun Scaith Aether Collectors',
-      netRegex: NetRegexes.addedCombatant({ name: 'Aether Collector', capture: false }),
-      netRegexDe: NetRegexes.addedCombatant({ name: 'Ätherakkumulator', capture: false }),
-      netRegexFr: NetRegexes.addedCombatant({ name: 'Accumulateur D\'Éther', capture: false }),
-      netRegexJa: NetRegexes.addedCombatant({ name: 'エーテル集積器', capture: false }),
-      netRegexCn: NetRegexes.addedCombatant({ name: '以太收集器', capture: false }),
-      netRegexKo: NetRegexes.addedCombatant({ name: '에테르 집적기', capture: false }),
+      netRegex: NetRegexes.addedCombatantFull({ npcNameId: '3781', capture: false }),
       suppressSeconds: 5,
       alertText: {
         en: 'Kill collectors',

--- a/ui/raidboss/data/03-hw/alliance/dun_scaith.js
+++ b/ui/raidboss/data/03-hw/alliance/dun_scaith.js
@@ -283,23 +283,6 @@
     },
     // PROTO-ULTIMA
     {
-      // The trident laser is a series of three separate casts
-      // Each has an incremental ID: 1D96, 1D97, 1D98
-      id: 'Dun Scaith Aetherochemical Laser',
-      netRegex: NetRegexes.startsUsing({ id: '1D96', source: 'Proto Ultima', capture: false }),
-      netRegexDe: NetRegexes.startsUsing({ id: '1D96', source: 'Proto-Ultima', capture: false }),
-      netRegexFr: NetRegexes.startsUsing({ id: '1D96', source: 'Proto-Ultima', capture: false }),
-      netRegexJa: NetRegexes.startsUsing({ id: '1D96', source: 'プロトアルテマ', capture: false }),
-      netRegexCn: NetRegexes.startsUsing({ id: '1D96', source: '究极神兵原型', capture: false }),
-      netRegexKo: NetRegexes.startsUsing({ id: '1D96', source: '프로토 알테마', capture: false }),
-      infoText: {
-        en: 'Dodge trident laser',
-        de: 'Weiche dem Laser aus',
-        fr: 'Evitez le laser',
-        cn: '躲避三向激光',
-      },
-    },
-    {
       // Handles both 1E52 Aetherochemical Flare and 1D9D Supernova
       id: 'Dun Scaith Proto-Ultima Raid Damage',
       netRegex: NetRegexes.startsUsing({ id: ['1E52', '1D9D'], source: 'Proto Ultima', capture: false }),
@@ -325,50 +308,6 @@
             cn: '离开人群并保持移动',
           };
         }
-      },
-    },
-    {
-      id: 'Dun Scaith Flare Star',
-      netRegex: NetRegexes.startsUsing({ id: '1DA4', source: 'Proto Ultima', capture: false }),
-      netRegexDe: NetRegexes.startsUsing({ id: '1DA4', source: 'Proto-Ultima', capture: false }),
-      netRegexFr: NetRegexes.startsUsing({ id: '1DA4', source: 'Proto-Ultima', capture: false }),
-      netRegexJa: NetRegexes.startsUsing({ id: '1DA4', source: 'プロトアルテマ', capture: false }),
-      netRegexCn: NetRegexes.startsUsing({ id: '1DA4', source: '究极神兵原型', capture: false }),
-      netRegexKo: NetRegexes.startsUsing({ id: '1DA4', source: '프로토 알테마', capture: false }),
-      preRun: function(data) {
-        data.flareStarCount = (data.flareStarCount || 0) + 1;
-      },
-      suppressSeconds: 1,
-      alertText: function(data) {
-        if (data.flareStarCount == 1) {
-          return {
-            en: 'Out of center--Wait for outer ring then keep going',
-            de: 'Raus aus der Mitte - Warte auf den äuseren Ring',
-            fr: 'Loin du centre - Attendez l\'anneau extérieur et continuez',
-            cn: '远离中心--在外圈内等待再进行移动',
-          };
-        }
-        return {
-          en: 'Avoid flares--Wait for outer ring then keep going',
-          de: 'Flares ausweichen - Warte auf den äuseren Ring',
-          fr: 'Evitez les explosions - Attendez l\'anneau extérieur et continuez',
-          cn: '避免爆炸--在外圈内等待再进行移动',
-        };
-      },
-    },
-    {
-      id: 'Dun Scaith Citadel Buster',
-      netRegex: NetRegexes.startsUsing({ id: '1DAB', source: 'Proto Ultima', capture: false }),
-      netRegexDe: NetRegexes.startsUsing({ id: '1DAB', source: 'Proto-Ultima', capture: false }),
-      netRegexFr: NetRegexes.startsUsing({ id: '1DAB', source: 'Proto-Ultima', capture: false }),
-      netRegexJa: NetRegexes.startsUsing({ id: '1DAB', source: 'プロトアルテマ', capture: false }),
-      netRegexCn: NetRegexes.startsUsing({ id: '1DAB', source: '究极神兵原型', capture: false }),
-      netRegexKo: NetRegexes.startsUsing({ id: '1DAB', source: '프로토 알테마', capture: false }),
-      alertText: {
-        en: 'Avoid line AoE',
-        de: 'Weiche der Linien AoE aus',
-        fr: 'Evitez l\'AoE en ligne',
-        cn: '躲避直线AOE',
       },
     },
     {

--- a/ui/raidboss/data/03-hw/alliance/dun_scaith.js
+++ b/ui/raidboss/data/03-hw/alliance/dun_scaith.js
@@ -4,6 +4,15 @@
   zoneId: ZoneId.DunScaith,
   timelineNeedsFixing: true,
   timelineFile: 'dun_scaith.txt',
+  timelineTriggers: [
+    {
+      id: 'Dun Scaith Spike Of Darkness',
+      regex: /Spike Of Darkness/,
+      beforeSeconds: 4,
+      condition: Conditions.caresAboutMagical(),
+      response: Responses.tankBuster(),
+    },
+  ],
   triggers: [
     // Basic stack occurs across all encounters except Deathgaze.
     {
@@ -33,12 +42,12 @@
       // Or use / 16:\y{ObjectId}:Deathgaze Hollow:1C85:Doomsay:\y{ObjectId}:(\y{Name})
       // This would allow for notifying who needs cleansing directly, but might be spammy
       id: 'Dun Scaith Doom',
-      netRegex: NetRegexes.startsUsing({ id: '1C8[45]', source: 'Deathgaze Hollow', capture: false }),
-      netRegexDe: NetRegexes.startsUsing({ id: '1C8[45]', source: 'Nihil-Thanatos', capture: false }),
-      netRegexFr: NetRegexes.startsUsing({ id: '1C8[45]', source: 'Mortalis Nihil', capture: false }),
-      netRegexJa: NetRegexes.startsUsing({ id: '1C8[45]', source: 'デスゲイズ・ホロー', capture: false }),
-      netRegexCn: NetRegexes.startsUsing({ id: '1C8[45]', source: '虚空死亡凝视', capture: false }),
-      netRegexKo: NetRegexes.startsUsing({ id: '1C8[45]', source: '공허의 저승파수꾼', capture: false }),
+      netRegex: NetRegexes.startsUsing({ id: ['1C84', '1C85'], source: 'Deathgaze Hollow', capture: false }),
+      netRegexDe: NetRegexes.startsUsing({ id: ['1C84', '1C85'], source: 'Nihil-Thanatos', capture: false }),
+      netRegexFr: NetRegexes.startsUsing({ id: ['1C84', '1C85'], source: 'Mortalis Nihil', capture: false }),
+      netRegexJa: NetRegexes.startsUsing({ id: ['1C84', '1C85'], source: 'デスゲイズ・ホロー', capture: false }),
+      netRegexCn: NetRegexes.startsUsing({ id: ['1C84', '1C85'], source: '虚空死亡凝视', capture: false }),
+      netRegexKo: NetRegexes.startsUsing({ id: ['1C84', '1C85'], source: '공허의 저승파수꾼', capture: false }),
       condition: function(data) {
         return data.CanCleanse();
       },
@@ -64,12 +73,7 @@
     },
     {
       id: 'Dun Scaith Void Sprite',
-      netRegex: NetRegexes.addedCombatant({ name: 'Void Sprite', capture: false }),
-      netRegexDe: NetRegexes.addedCombatant({ name: 'Nichts-Exergon', capture: false }),
-      netRegexFr: NetRegexes.addedCombatant({ name: 'Élémentaire Du Vide', capture: false }),
-      netRegexJa: NetRegexes.addedCombatant({ name: 'ヴォイド・スプライト', capture: false }),
-      netRegexCn: NetRegexes.addedCombatant({ name: '虚无元精', capture: false }),
-      netRegexKo: NetRegexes.addedCombatant({ name: '보이드 정령', capture: false }),
+      netRegex: NetRegexes.addedCombatantFull({ npcNameId: '5508', capture: false }),
       suppressSeconds: 10,
       infoText: {
         en: 'Kill sprites',
@@ -106,13 +110,16 @@
       response: Responses.knockback(),
     },
     {
+      // It's not certain what causes Deathgaze to choose which ability.
+      // Both are present with cast times of 2.7 seconds,
+      // and neither seems to target players directly.
       id: 'Dun Scaith Void Death Squares',
-      netRegex: NetRegexes.startsUsing({ id: '1C82', source: 'Deathgaze Hollow', capture: false }),
-      netRegexDe: NetRegexes.startsUsing({ id: '1C82', source: 'Nihil-Thanatos', capture: false }),
-      netRegexFr: NetRegexes.startsUsing({ id: '1C82', source: 'Mortalis Nihil', capture: false }),
-      netRegexJa: NetRegexes.startsUsing({ id: '1C82', source: 'デスゲイズ・ホロー', capture: false }),
-      netRegexCn: NetRegexes.startsUsing({ id: '1C82', source: '虚空死亡凝视', capture: false }),
-      netRegexKo: NetRegexes.startsUsing({ id: '1C82', source: '공허의 저승파수꾼', capture: false }),
+      netRegex: NetRegexes.startsUsing({ id: ['1C82', '1C83'], source: 'Deathgaze Hollow', capture: false }),
+      netRegexDe: NetRegexes.startsUsing({ id: ['1C82', '1C83'], source: 'Nihil-Thanatos', capture: false }),
+      netRegexFr: NetRegexes.startsUsing({ id: ['1C82', '1C83'], source: 'Mortalis Nihil', capture: false }),
+      netRegexJa: NetRegexes.startsUsing({ id: ['1C82', '1C83'], source: 'デスゲイズ・ホロー', capture: false }),
+      netRegexCn: NetRegexes.startsUsing({ id: ['1C82', '1C83'], source: '虚空死亡凝视', capture: false }),
+      netRegexKo: NetRegexes.startsUsing({ id: ['1C82', '1C83'], source: '공허의 저승파수꾼', capture: false }),
       suppressSeconds: 5,
       alertText: {
         en: 'Avoid death squares',
@@ -145,6 +152,7 @@
       netRegexJa: NetRegexes.startsUsing({ id: '1C98', source: 'フェルディア・ホロー' }),
       netRegexCn: NetRegexes.startsUsing({ id: '1C98', source: '虚空弗迪亚' }),
       netRegexKo: NetRegexes.startsUsing({ id: '1C98', source: '공허의 페르디아' }),
+      condition: Conditions.caresAboutMagical(),
       response: Responses.tankBuster(),
     },
     {
@@ -386,12 +394,12 @@
     },
     {
       id: 'Dun Scaith Thirty Thorns',
-      netRegex: NetRegexes.ability({ id: '1D[12]B', source: 'Scathach', capture: false }),
-      netRegexDe: NetRegexes.ability({ id: '1D[12]B', source: 'Scathach', capture: false }),
-      netRegexFr: NetRegexes.ability({ id: '1D[12]B', source: 'Scáthach', capture: false }),
-      netRegexJa: NetRegexes.ability({ id: '1D[12]B', source: 'スカアハ', capture: false }),
-      netRegexCn: NetRegexes.ability({ id: '1D[12]B', source: '斯卡哈', capture: false }),
-      netRegexKo: NetRegexes.ability({ id: '1D[12]B', source: '스카하크', capture: false }),
+      netRegex: NetRegexes.ability({ id: ['1D1B', '1D2B'], source: 'Scathach', capture: false }),
+      netRegexDe: NetRegexes.ability({ id: ['1D1B', '1D2B'], source: 'Scathach', capture: false }),
+      netRegexFr: NetRegexes.ability({ id: ['1D1B', '1D2B'], source: 'Scáthach', capture: false }),
+      netRegexJa: NetRegexes.ability({ id: ['1D1B', '1D2B'], source: 'スカアハ', capture: false }),
+      netRegexCn: NetRegexes.ability({ id: ['1D1B', '1D2B'], source: '斯卡哈', capture: false }),
+      netRegexKo: NetRegexes.ability({ id: ['1D1B', '1D2B'], source: '스카하크', capture: false }),
       suppressSeconds: 5,
       response: Responses.outOfMelee(),
     },
@@ -438,12 +446,7 @@
     },
     {
       id: 'Dun Scaith Shadow Limb Spawn',
-      netRegex: NetRegexes.addedCombatant({ name: 'Shadow Limb', capture: false }),
-      netRegexDe: NetRegexes.addedCombatant({ name: 'Schattenhand', capture: false }),
-      netRegexFr: NetRegexes.addedCombatant({ name: 'Main Ombrale', capture: false }),
-      netRegexJa: NetRegexes.addedCombatant({ name: '影の手', capture: false }),
-      netRegexCn: NetRegexes.addedCombatant({ name: '影之手', capture: false }),
-      netRegexKo: NetRegexes.addedCombatant({ name: '그림자 손', capture: false }),
+      netRegex: NetRegexes.addedCombatantFull({ npcNameId: '5516', capture: false }),
       suppressSeconds: 5,
       alertText: {
         en: 'Kill the hands',
@@ -530,12 +533,12 @@
     },
     {
       id: 'Dun Scaith Ruinous Omen',
-      netRegex: NetRegexes.startsUsing({ id: '1C1[01]', source: 'Diabolos', capture: false }),
-      netRegexDe: NetRegexes.startsUsing({ id: '1C1[01]', source: 'Diabolos', capture: false }),
-      netRegexFr: NetRegexes.startsUsing({ id: '1C1[01]', source: 'Diabolos', capture: false }),
-      netRegexJa: NetRegexes.startsUsing({ id: '1C1[01]', source: 'ディアボロス', capture: false }),
-      netRegexCn: NetRegexes.startsUsing({ id: '1C1[01]', source: '迪亚波罗斯', capture: false }),
-      netRegexKo: NetRegexes.startsUsing({ id: '1C1[01]', source: '디아볼로스', capture: false }),
+      netRegex: NetRegexes.startsUsing({ id: ['1C10', '1C11'], source: 'Diabolos', capture: false }),
+      netRegexDe: NetRegexes.startsUsing({ id: ['1C10', '1C11'], source: 'Diabolos', capture: false }),
+      netRegexFr: NetRegexes.startsUsing({ id: ['1C10', '1C11'], source: 'Diabolos', capture: false }),
+      netRegexJa: NetRegexes.startsUsing({ id: ['1C10', '1C11'], source: 'ディアボロス', capture: false }),
+      netRegexCn: NetRegexes.startsUsing({ id: ['1C10', '1C11'], source: '迪亚波罗斯', capture: false }),
+      netRegexKo: NetRegexes.startsUsing({ id: ['1C10', '1C11'], source: '디아볼로스', capture: false }),
       condition: function(data) {
         return data.role == 'healer';
       },
@@ -544,12 +547,7 @@
     },
     {
       id: 'Dun Scaith Deathgates',
-      netRegex: NetRegexes.addedCombatant({ name: 'Deathgate', capture: false }),
-      netRegexDe: NetRegexes.addedCombatant({ name: 'Tor Des Todes', capture: false }),
-      netRegexFr: NetRegexes.addedCombatant({ name: 'Porte De Mort', capture: false }),
-      netRegexJa: NetRegexes.addedCombatant({ name: '召喚の扉', capture: false }),
-      netRegexCn: NetRegexes.addedCombatant({ name: '召唤之门', capture: false }),
-      netRegexKo: NetRegexes.addedCombatant({ name: '소환의 문', capture: false }),
+      netRegex: NetRegexes.addedCombatantFull({ npcNameId: '5523', capture: false }),
       suppressSeconds: 5,
       infoText: {
         en: 'Kill the deathgates',
@@ -590,12 +588,12 @@
     },
     {
       id: 'Dun Scaith Hollow Omen',
-      netRegex: NetRegexes.startsUsing({ id: '1C2[23]', source: 'Diabolos Hollow', capture: false }),
-      netRegexDe: NetRegexes.startsUsing({ id: '1C2[23]', source: 'Nihil-Diabolos', capture: false }),
-      netRegexFr: NetRegexes.startsUsing({ id: '1C2[23]', source: 'Diabolos Nihil', capture: false }),
-      netRegexJa: NetRegexes.startsUsing({ id: '1C2[23]', source: 'ディアボロス・ホロー', capture: false }),
-      netRegexCn: NetRegexes.startsUsing({ id: '1C2[23]', source: '虚空迪亚波罗斯', capture: false }),
-      netRegexKo: NetRegexes.startsUsing({ id: '1C2[23]', source: '공허의 디아볼로스', capture: false }),
+      netRegex: NetRegexes.startsUsing({ id: ['1C22', '1C23'], source: 'Diabolos Hollow', capture: false }),
+      netRegexDe: NetRegexes.startsUsing({ id: ['1C22', '1C23'], source: 'Nihil-Diabolos', capture: false }),
+      netRegexFr: NetRegexes.startsUsing({ id: ['1C22', '1C23'], source: 'Diabolos Nihil', capture: false }),
+      netRegexJa: NetRegexes.startsUsing({ id: ['1C22', '1C23'], source: 'ディアボロス・ホロー', capture: false }),
+      netRegexCn: NetRegexes.startsUsing({ id: ['1C22', '1C23'], source: '虚空迪亚波罗斯', capture: false }),
+      netRegexKo: NetRegexes.startsUsing({ id: ['1C22', '1C23'], source: '공허의 디아볼로스', capture: false }),
       condition: function(data) {
         return data.role == 'healer';
       },

--- a/ui/raidboss/data/03-hw/alliance/dun_scaith.js
+++ b/ui/raidboss/data/03-hw/alliance/dun_scaith.js
@@ -218,6 +218,8 @@
             cn: '靠近黄色小怪',
           };
         }
+        // If there's only a Sphere on the field, the other Atomos color isn't guaranteed safe.
+        // Therefore we need to specify staying away from the Sphere-tethered Atomos.
         if (data.sphere[0] === 'wailing') {
           return {
             en: 'Avoid Untethered Blue',
@@ -238,7 +240,7 @@
       id: 'Dun Scaith Atomos Cleanup',
       netRegex: NetRegexes.ability({ id: ['1CA1', '1CA2'], capture: false }),
       run: function(data) {
-        for (let el of ['atomos', 'cursing', 'wailing', 'sphere', 'donut'])
+        for (let el of ['cursing', 'wailing', 'sphere', 'donut'])
           delete data[el];
       },
     },
@@ -431,7 +433,7 @@
       },
     },
     {
-      // This trigger is common to both Scathach and Diabolos, since handling is 100$ identical.
+      // This trigger is common to both Scathach and Diabolos, since handling is 100% identical.
       id: 'Dun Scaith Nox Orbs',
       netRegex: NetRegexes.headMarker({ id: '005C' }),
       suppressSeconds: 5,
@@ -447,7 +449,7 @@
       },
     },
     {
-      // This trigger is common to both Scathach and Diabolos, since handling is 100$ identical.
+      // This trigger is common to both Scathach and Diabolos, since handling is 100% identical.
       id: 'Dun Scaith Shadethrust',
       netRegex: NetRegexes.startsUsing({ id: ['1D23', '1C1A'], source: ['Scathach', 'Diabolos Hollow'], capture: false }),
       netRegexDe: NetRegexes.startsUsing({ id: ['1D23', '1C1A'], source: ['Scathach', 'Nihil-Diabolos'], capture: false }),


### PR DESCRIPTION
(This should resolve #549.)

This probably isn't as self-explanatory as some others, unfortunately. NetRegexes have made most of this possible.

To begin with, anytime there's a trigger that uses a choice of abilities, we now use the `['ID1', 'ID2']` construction, rather than `'ID[12]'`. It's so nice not to use bare regexes anymore!

Certain triggers on Proto-Ultima have been removed. All of them have prominent AoE indicators alongside, so there's really no good reason to keep them. (It was good practice for me at the time though!)

All `addedCombatant` lines have been replaced with `addedCombatantFull` in order to be completely language-agnostic without the need for language-specific regexes. (It's technically not necessary for all of them, but since the Atomos triggers *do* require it, it seemed to make sense to be consistent across the entire trigger file.)

The biggest change is to the Atomos triggers. Two problems existed here. First, anytime there were two tethered Atomos on the field, the user would be notified twice, once for each. This was annoying, and potentially a big deal for users with auditory processing sensitivities. (Particularly so if they happen to be using TTS.)

To understand the second problem, we need to go through the process for how the Atomos mechanic works:

1. Ferdiad summons variously-colored Atomos and 1-2 Aether/Aetherial Chakram.
2. Each Aether/Aetherial Chakram tethers to an Atomos and casts Juggling Sphere.
3. The Aether/Aetherial Chakram warps to the untethered Atomos of the same color and casts its Explosion ability. (`1CA1` for Aether, `1CA2` for Chakram.)

This is fine, but sometimes we get a situation where the packet containing the spawn information is processed out of order and something like this happens:

```
03|2020-08-04T20:47:00.2470000-04:00|40001026|Aether|0|3c|0|
35|2020-08-04T20:47:01.4530000-04:00|40001026|Aether|40001029||C3B3|
20|2020-08-04T20:47:01.5410000-04:00|40001026|Aether|1C9F|Juggling Sphere|40001029||6.70|
03|2020-08-04T20:47:01.4010000-04:00|40001029|Wailing Atomos|0|3c|0|
03|2020-08-04T20:47:01.4010000-04:00|40001028|Wailing Atomos|0|3c|0|
03|2020-08-04T20:47:01.4010000-04:00|40001027|Cursing Atomos|0|3c|0|
```

The old triggers relied on the name of the Atomos being present in the log line, but as we can see, if the Atomos spawn is later in the log, the name field in the Juggling Sphere line will be empty. In order to solve this problem, we have to go to the annoying nonsense of "collect -> delay -> notify -> cleanup". The path through the Atomos triggers should be relatively self-explanatory, but I'll lay it out here so my thought process can be better understood and so that errors might be easier to catch:

1. [SETUP TRIGGER] Atomos spawn in whatever configuration, always 3-4 of them, and always in a 1-2/2-2 split. We add their entity ID to the appropriate `data` property, identifying them by their BNPCname.
2. [COMPILE TRIGGER] When an Aether/Aetherial Chakram starts casting, we delay for half a second to allow the `addedCombatantFull` trigger to populate the `cursing/wailing` properties. We then check what color Atomos the Aether/Chakram is tethered to and increment the `data.atomos` property accordingly. (We do not stringify here because we need this to remain a number through the compilation log lines.)
3. [RESPONSE TRIGGER] At the same time the compile trigger activates, we delay for a full second, and then read the value contained in `data.atomos`. We do some awful manipulation to format the string correctly for the response enumeration object. (The situation where there's exactly one Chakram is coerced to the same value whether or not there's an Aether present, as the handling wouldn't change.) We then return the appropriate response.
4. The cleanup trigger cleans up.

Suggestions on cleaner handling for Atomos information would be welcome. I don't really like the string manipulation necessary to format things for the response object, but it seemed like a relatively simple way of cleanly compiling the information.

Finally, some triggers were doing double duty. Aetherochemical Flare and Supernova are combined on Proto-ultima, while Shadethrust and Nox are combined on Scathach and Diabolos. I considered changing this, since it isn't quite according to modern standards, but I think that it's acceptable even so since the handling in each case is literally identical.

