### PR TITLE
Job: new SMN UI

### DIFF
--- a/ui/jobs/jobs.css
+++ b/ui/jobs/jobs.css
@@ -356,6 +356,7 @@
   left: 142px;
 }
 
+#smn-stacks,
 #blm-stacks {
   display: flex;
   margin-top: 1px;
@@ -381,6 +382,11 @@
   background-color: rgb(200, 50, 200);
 }
 
+#smn-stacks-ruin4 {
+  width: 100%;
+  height: 100%;
+}
+
 #blm-stacks-heart {
   width: 50%;
   height: 100%;
@@ -395,8 +401,21 @@
   height: 100%;
 }
 
+#smn-stacks-ruin4 > div {
+  background-color: rgba(174, 227, 235, 0.2);
+  margin-right: 2px;
+  display: inline-block;
+  border: 1px solid black;
+  width: calc(25% - 4px);
+  height: 100%;
+}
+
 #blm-stacks-heart > div.active {
   background-color: rgb(174, 227, 235);
+}
+
+#smn-stacks-ruin4 > div.active {
+  background-color: rgb(65, 0, 200);
 }
 
 .blm-umbral-timer {

--- a/ui/jobs/jobs.css
+++ b/ui/jobs/jobs.css
@@ -568,6 +568,46 @@
   background-color: rgb(150, 233, 140);
 }
 
+.smn-color-aetherflow {
+  background-color: rgb(255, 96, 207);
+}
+
+.smn-color-aetherflow.too-much-stacks {
+  background-color: rgb(240, 30, 30);
+}
+
+.smn-color-biosmn {
+  background-color: olivedrab;
+}
+
+.smn-color-miasma {
+  background-color: cornflowerblue;
+}
+
+.smn-color-energydrain {
+  background-color: brown;
+}
+
+.smn-color-trance {
+  background-color: rgb(60, 80, 200);
+}
+
+.smn-color-demisummon {
+  background-color: rgb(180, 200, 220);
+}
+
+.smn-color-demisummon.bahamutready {
+  background-color: rgb(64, 65, 163);
+}
+
+.smn-color-demisummon.firebirdready {
+  background-color: orange;
+}
+
+.smn-color-demisummon.last {
+  background-color: rgb(240, 30, 30);
+}
+
 .mnk-color-chakra {
   background-color: rgb(230, 20, 20);
 }
@@ -634,46 +674,6 @@
 
 .sch-color-lucid {
   background-color: rgb(227, 148, 210);
-}
-
-.smn-color-aetherflow {
-  background-color: rgb(255, 96, 207);
-}
-
-.smn-color-aetherflow.too-much-stacks {
-  background-color: rgb(240, 30, 30);
-}
-
-.smn-color-biosmn {
-  background-color: olivedrab;
-}
-
-.smn-color-miasma {
-  background-color: cornflowerblue;
-}
-
-.smn-color-energydrain {
-  background-color: brown;
-}
-
-.smn-color-trance {
-  background-color: rgb(60, 80, 200);
-}
-
-.smn-color-demisummon {
-  background-color: rgb(180, 200, 220);
-}
-
-.smn-color-demisummon.bahamutready {
-  background-color: rgb(64, 65, 163);
-}
-
-.smn-color-demisummon.firebirdready {
-  background-color: orange;
-}
-
-.smn-color-demisummon.last {
-  background-color: rgb(240, 30, 30);
 }
 
 .ast-color-combust {

--- a/ui/jobs/jobs.css
+++ b/ui/jobs/jobs.css
@@ -26,18 +26,9 @@
   left: 242px;
 }
 
-.rdm #right-side-icons {
-  left: 278px;
-}
-
-.sch #right-side-icons {
-  left: 278px;
-}
-
-.smn #right-side-icons {
-  left: 278px;
-}
-
+.rdm #right-side-icons,
+.sch #right-side-icons,
+.smn #right-side-icons,
 .ast #right-side-icons {
   left: 278px;
 }

--- a/ui/jobs/jobs.css
+++ b/ui/jobs/jobs.css
@@ -303,13 +303,18 @@
 #mnk-procs,
 #ast-procs,
 #sch-procs,
-#smn-procs,
 #blu-procs,
 #drk-procs,
 #blm-procs {
   position: absolute;
   top: 146px;
   left: 10px;
+}
+
+#smn-procs {
+  position: absolute;
+  top: 146px;
+  left: 0;
 }
 
 #mnk-procs-dragonkick,
@@ -326,13 +331,13 @@
 #smn-procs-biosmn {
   position: relative;
   display: inline-block;
-  left: calc(142px / 3);
+  left: calc(152px / 3);
 }
 
 #smn-procs-energydrain {
   position: relative;
   display: inline-block;
-  left: calc(142px / 3 * 2);
+  left: calc(152px / 3 * 2);
 }
 
 #mnk-procs-twinsnakes,
@@ -348,12 +353,17 @@
 #mnk-procs-demolish,
 #ast-procs-luciddreaming,
 #sch-procs-luciddreaming,
-#smn-procs-trance,
 #blm-procs-thunder,
 #blu-procs-lucid {
   position: relative;
   display: inline-block;
   left: 142px;
+}
+
+#smn-procs-trance {
+  position: relative;
+  display: inline-block;
+  left: 152px;
 }
 
 #smn-stacks,
@@ -650,19 +660,19 @@
   background-color: rgb(60, 80, 200);
 }
 
-.smn-color-demisummom {
+.smn-color-demisummon {
   background-color: rgb(180, 200, 220);
 }
 
-.smn-color-demisummom.bahamutready {
+.smn-color-demisummon.bahamutready {
   background-color: rgb(64, 65, 163);
 }
 
-.smn-color-demisummom.firebirdready {
+.smn-color-demisummon.firebirdready {
   background-color: orange;
 }
 
-.smn-color-demisummom.last {
+.smn-color-demisummon.last {
   background-color: rgb(240, 30, 30);
 }
 

--- a/ui/jobs/jobs.css
+++ b/ui/jobs/jobs.css
@@ -34,6 +34,10 @@
   left: 278px;
 }
 
+.smn #right-side-icons {
+  left: 278px;
+}
+
 .ast #right-side-icons {
   left: 278px;
 }
@@ -170,6 +174,7 @@
 /* Relative to #bars */
 #rdm-boxes,
 #sch-boxes,
+#smn-boxes,
 #ast-boxes,
 #war-boxes,
 #mnk-boxes,
@@ -185,6 +190,7 @@
 
 #rdm-boxes > div,
 #sch-boxes > div,
+#smn-boxes > div,
 #ast-boxes > div,
 #war-boxes > div,
 #mnk-boxes > div,
@@ -215,6 +221,7 @@
 }
 
 #sch-boxes > div,
+#smn-boxes > div,
 #ast-boxes > div,
 #rdm-boxes > div {
   width: 28px;
@@ -228,6 +235,7 @@
 
 #rdm-boxes .text,
 #sch-boxes .text,
+#smn-boxes .text,
 #ast-boxes .text,
 #war-boxes .text,
 #mnk-boxes .text,
@@ -246,6 +254,7 @@
 }
 
 #sch-boxes .text,
+#smn-boxes .text,
 #ast-boxes .text,
 #rdm-boxes .text {
   top: 5px;
@@ -303,6 +312,7 @@
 #mnk-procs,
 #ast-procs,
 #sch-procs,
+#smn-procs,
 #blu-procs,
 #drk-procs,
 #blm-procs {
@@ -314,6 +324,7 @@
 #mnk-procs-dragonkick,
 #ast-procs-combust,
 #sch-procs-bio,
+#smn-procs-dot,
 #blu-procs-offguard,
 #blm-procs-fire {
   position: relative;
@@ -324,6 +335,7 @@
 #mnk-procs-twinsnakes,
 #ast-procs-draw,
 #sch-procs-aetherflow,
+#smn-procs-energydrain,
 #blu-procs-torment,
 #blm-dot-thunder {
   position: relative;
@@ -334,6 +346,7 @@
 #mnk-procs-demolish,
 #ast-procs-luciddreaming,
 #sch-procs-luciddreaming,
+#smn-procs-trance,
 #blm-procs-thunder,
 #blu-procs-lucid {
   position: relative;
@@ -524,10 +537,6 @@
   background-color: rgb(150, 233, 140);
 }
 
-.smn-color-aetherflow {
-  background-color: rgb(255, 96, 207);
-}
-
 .mnk-color-chakra {
   background-color: rgb(230, 20, 20);
 }
@@ -594,6 +603,42 @@
 
 .sch-color-lucid {
   background-color: rgb(227, 148, 210);
+}
+
+.smn-color-aetherflow {
+  background-color: rgb(255, 96, 207);
+}
+
+.smn-color-aetherflow.too-much-stacks {
+  background-color: rgb(240, 30, 30);
+}
+
+.smn-color-dot {
+  background-color: olivedrab;
+}
+
+.smn-color-energydrain {
+  background-color: orange;
+}
+
+.smn-color-trance {
+  background-color: rgb(60, 80, 200);
+}
+
+.smn-color-demisummom {
+  background-color: rgb(180, 200, 220);
+}
+
+.smn-color-demisummom.bahamutready {
+  background-color: rgb(64, 65, 163);
+}
+
+.smn-color-demisummom.firebirdready {
+  background-color: orange;
+}
+
+.smn-color-demisummom.last {
+  background-color: rgb(240, 30, 30);
 }
 
 .ast-color-combust {

--- a/ui/jobs/jobs.css
+++ b/ui/jobs/jobs.css
@@ -324,7 +324,7 @@
 #mnk-procs-dragonkick,
 #ast-procs-combust,
 #sch-procs-bio,
-#smn-procs-dot,
+#smn-procs-miasma,
 #blu-procs-offguard,
 #blm-procs-fire {
   position: relative;
@@ -332,10 +332,21 @@
   left: 0;
 }
 
+#smn-procs-biosmn {
+  position: relative;
+  display: inline-block;
+  left: calc(142px / 3);
+}
+
+#smn-procs-energydrain {
+  position: relative;
+  display: inline-block;
+  left: calc(142px / 3 * 2);
+}
+
 #mnk-procs-twinsnakes,
 #ast-procs-draw,
 #sch-procs-aetherflow,
-#smn-procs-energydrain,
 #blu-procs-torment,
 #blm-dot-thunder {
   position: relative;
@@ -613,12 +624,16 @@
   background-color: rgb(240, 30, 30);
 }
 
-.smn-color-dot {
+.smn-color-biosmn {
   background-color: olivedrab;
 }
 
+.smn-color-miasma {
+  background-color: cornflowerblue;
+}
+
 .smn-color-energydrain {
-  background-color: orange;
+  background-color: brown;
 }
 
 .smn-color-trance {

--- a/ui/jobs/jobs.js
+++ b/ui/jobs/jobs.js
@@ -138,8 +138,8 @@ const kAbility = {
   LucidDreaming: '1D8A',
   Miasma: 'A8',
   Miasma3: '1D01',
-  smnBio: 'A4',
-  smnBio2: 'B2',
+  Biosmn: 'A4',
+  Biosmn2: 'B2',
   Bio3: '1D00',
   Tridisaster: 'DFC',
   EnergyDrain: '407C',
@@ -1861,10 +1861,6 @@ class Bars {
     }
 
     let furtherRuin = 0;
-    this.changeZoneFuncs.push((e) => {
-      furtherRuin = 0;
-      refreshfurtherRuin();
-    });
     function refreshfurtherRuin() {
       for (let i = 0; i < 4; ++i) {
         if (furtherRuin > i)
@@ -1881,6 +1877,10 @@ class Bars {
       furtherRuin = 0;
       refreshfurtherRuin();
     };
+    this.changeZoneFuncs.push((e) => {
+      furtherRuin = 0;
+      refreshfurtherRuin();
+    });
 
     this.jobFuncs.push((jobDetail) => {
       let stack = jobDetail.aetherflowStacks;
@@ -1929,11 +1929,11 @@ class Bars {
       miasmaBox.duration = 0;
       miasmaBox.duration = 30;
     };
-    this.abilityFuncMap[kAbility.smnBio] = () => {
+    this.abilityFuncMap[kAbility.Biosmn] = () => {
       bioSmnBox.duration = 0;
       bioSmnBox.duration = 30;
     };
-    this.abilityFuncMap[kAbility.smnBio2] = () => {
+    this.abilityFuncMap[kAbility.Biosmn2] = () => {
       bioSmnBox.duration = 0;
       bioSmnBox.duration = 30;
     };

--- a/ui/jobs/jobs.js
+++ b/ui/jobs/jobs.js
@@ -1857,17 +1857,17 @@ class Bars {
       let p = aetherflowStackBox.parentNode;
       let s = parseFloat(energyDrainBox.duration || 0) - parseFloat(energyDrainBox.elapsed);
       if ((stack == 2) && (s <= 8))
-        p.classList.add('too-much-stacks')
+        p.classList.add('too-much-stacks');
       else
-        p.classList.remove('too-much-stacks')
+        p.classList.remove('too-much-stacks');
 
       // Turn red when only 7s remain, to alarm that use the second Enkindle.
       // Also alarm that don't cast a spell that has cast time, or a WW will be missed.
       let pp = demiSummomingBox.parentNode;
       if (time <= 7 && summoned == 3)
-        pp.classList.add('last')
+        pp.classList.add('last');
       else
-        pp.classList.remove('last')
+        pp.classList.remove('last');
     });
     
     // Boxes are not enough so we can only trace the latetest one DoT.
@@ -1902,7 +1902,7 @@ class Bars {
       energyDrainBox.duration = 30;
       aetherflowStackBox.parentNode.classList.remove('too-much-stacks');
     };
-    // Trance cooldown is 55s, 
+    // Trance cooldown is 55s,
     // but wait till 60s will be better on matching raidbuffs.
     // Threshold will be used to tell real cooldown.
     this.abilityFuncMap[kAbility.DreadwyrmTrance] = () => {
@@ -1921,7 +1921,7 @@ class Bars {
       energyDrainBox.threshold = this.gcdSpell() + 1;
       tranceBox.valuescale = this.gcdSpell();
       tranceBox.threshold = this.gcdSpell() + 7;
-    }
+    };
   }
 
   setupMnk() {

--- a/ui/jobs/jobs.js
+++ b/ui/jobs/jobs.js
@@ -1070,6 +1070,7 @@ class Bars {
 
     this.comboFuncs = [];
     this.jobFuncs = [];
+    this.changeZoneFuncs = [];
     this.gainEffectFuncMap = {};
     this.loseEffectFuncMap = {};
     this.statChangeFuncMap = {};
@@ -1085,6 +1086,7 @@ class Bars {
   UpdateJob() {
     this.comboFuncs = [];
     this.jobFuncs = [];
+    this.changeZoneFuncs = [];
     this.gainEffectFuncMap = {};
     this.loseEffectFuncMap = {};
     this.statChangeFuncMap = {};
@@ -1859,6 +1861,10 @@ class Bars {
     }
 
     let furtherRuin = 0;
+    this.changeZoneFuncs.push((e) => {
+      furtherRuin = 0;
+      refreshfurtherRuin();
+    });
     function refreshfurtherRuin() {
       for (let i = 0; i < 4; ++i) {
         if (furtherRuin > i)
@@ -1875,10 +1881,6 @@ class Bars {
       furtherRuin = 0;
       refreshfurtherRuin();
     };
-    addOverlayListener('ChangeZone', function(e) {
-      furtherRuin = 0;
-      refreshfurtherRuin();
-    });
 
     this.jobFuncs.push((jobDetail) => {
       let stack = jobDetail.aetherflowStacks;
@@ -2653,6 +2655,9 @@ class Bars {
     this.UpdateFoodBuff();
     if (this.buffTracker)
       this.buffTracker.clear();
+
+    for (let i = 0; i < this.changeZoneFuncs.length; ++i)
+    this.changeZoneFuncs[i](e);
   }
 
   SetPullCountdown(seconds) {

--- a/ui/jobs/jobs.js
+++ b/ui/jobs/jobs.js
@@ -1859,14 +1859,18 @@ class Bars {
 
       // Show time remain when summoming/trancing.
       // Turn blue when buhamut ready, and turn orange when firebird ready.
+      // Also change tramceBox color.
       demiSummomingBox.innerText = '';
       demiSummomingBox.parentNode.classList.remove('bahamutready', 'firebirdready');
-      if (time > 0)
+      tranceBox.fg = computeBackgroundColorFrom(tranceBox, 'smn-color-trance');
+      if (time > 0) {
         demiSummomingBox.innerText = time;
-      else if (jobDetail.dreadwyrmStacks == 2)
+      } else if (jobDetail.dreadwyrmStacks == 2) {
         demiSummomingBox.parentNode.classList.add('bahamutready');
-      else if (jobDetail.phoenixReady == true)
+      } else if (jobDetail.phoenixReady == true) {
         demiSummomingBox.parentNode.classList.add('firebirdready');
+        tranceBox.fg = computeBackgroundColorFrom(tranceBox, 'smn-color-demisummom.firebirdready');
+      }
 
       // Turn red when only 7s summoming time remain, to alarm that cast the second Enkindle.
       // Also alarm that don't cast a spell that has cast time, or a WW/SF will be missed.

--- a/ui/jobs/jobs.js
+++ b/ui/jobs/jobs.js
@@ -136,6 +136,15 @@ const kAbility = {
   Thunder4: '1CFC',
   Divination: '40A8',
   LucidDreaming: '1D8A',
+  miasma: 'A8',
+  miasma3: '1D01',
+  smnBio: 'A4',
+  smnBio2: 'B2',
+  Bio3: '1D00',
+  Tridisaster: 'DFC',
+  EnergyDrain: '407C',
+  DreadwyrmTrance: 'DFD',
+  FirebirdTrance: '40A5',
 };
 
 const kMeleeWithMpJobs = ['DRK', 'PLD'];
@@ -1258,6 +1267,7 @@ class Bars {
       'PLD': this.setupPld,
       'AST': this.setupAst,
       'SCH': this.setupSch,
+      'SMN': this.setupSmn,
       'BLU': this.setupBlu,
       'MNK': this.setupMnk,
       'BLM': this.setupBlm,
@@ -1802,6 +1812,116 @@ class Bars {
       lucidBox.valuescale = this.gcdSpell();
       lucidBox.threshold = this.gcdSpell() + 1;
     };
+  }
+
+  setupSmn() {
+    let aetherflowStackBox = this.addResourceBox({
+      classList: ['smn-color-aetherflow'],
+    });
+
+    let demiSummomingBox = this.addResourceBox({
+      classList: ['smn-color-demisummom'],
+    });
+
+    let dotBox = this.addProcBox({
+      id: 'smn-procs-dot',
+      fgColor: 'smn-color-dot',
+    });
+
+    let energyDrainBox = this.addProcBox({
+      id: 'smn-procs-energydrain',
+      fgColor: 'smn-color-energydrain',
+    });
+
+    let tranceBox = this.addProcBox({
+      id: 'smn-procs-trance',
+      fgColor: 'smn-color-trance',
+    });
+
+    this.jobFuncs.push((jobDetail) => {
+      let stack = jobDetail.aetherflowStacks;
+      let summoned = jobDetail.bahamutSummoned;
+      let time = (jobDetail.stanceMilliseconds / 1000).toFixed(0);
+
+      aetherflowStackBox.innerText = stack;
+      demiSummomingBox.innerText = '';
+      demiSummomingBox.parentNode.classList.remove('bahamutready', 'firebirdready');
+      if (time > 0)
+        demiSummomingBox.innerText = time;
+      else if (jobDetail.dreadwyrmStacks == 2)
+        demiSummomingBox.parentNode.classList.add('bahamutready');
+      else if (jobDetail.phoenixReady == true)
+        demiSummomingBox.parentNode.classList.add('firebirdready');
+
+      // turn red when you have too much stacks before EnergyDrain ready.
+      let p = aetherflowStackBox.parentNode;
+      let s = parseFloat(energyDrainBox.duration || 0) - parseFloat(energyDrainBox.elapsed);
+      if ((stack == 2) && (s <= 8))
+        p.classList.add('too-much-stacks')
+      else
+        p.classList.remove('too-much-stacks')
+
+      // Turn red when only 7s remain, to alarm that use the second Enkindle.
+      // Also alarm that don't cast a spell that has cast time, or a WW will be missed.
+      let pp = demiSummomingBox.parentNode;
+      if (time <= 7 && summoned == 3)
+        pp.classList.add('last')
+      else
+        pp.classList.remove('last')
+    });
+    
+    // Boxes are not enough so we can only trace the latetest one DoT.
+    // Make sure you always cast two DoT at the same time!
+    this.abilityFuncMap[kAbility.miasma] = () => {
+      dotBox.duration = 0;
+      dotBox.duration = 30;
+    };
+    this.abilityFuncMap[kAbility.miasma3] = () => {
+      dotBox.duration = 0;
+      dotBox.duration = 30;
+    };
+    this.abilityFuncMap[kAbility.smnBio] = () => {
+      dotBox.duration = 0;
+      dotBox.duration = 30;
+    };
+    this.abilityFuncMap[kAbility.smnBio2] = () => {
+      dotBox.duration = 0;
+      dotBox.duration = 30;
+    };
+    this.abilityFuncMap[kAbility.Bio3] = () => {
+      dotBox.duration = 0;
+      dotBox.duration = 30;
+    };
+    this.abilityFuncMap[kAbility.Tridisaster] = () => {
+      dotBox.duration = 0;
+      dotBox.duration = 30;
+    };
+
+    this.abilityFuncMap[kAbility.EnergyDrain] = () => {
+      energyDrainBox.duration = 0;
+      energyDrainBox.duration = 30;
+      aetherflowStackBox.parentNode.classList.remove('too-much-stacks');
+    };
+    // Trance cooldown is 55s, 
+    // but wait till 60s will be better on matching raidbuffs.
+    // Threshold will be used to tell real cooldown.
+    this.abilityFuncMap[kAbility.DreadwyrmTrance] = () => {
+      tranceBox.duration = 0;
+      tranceBox.duration = 60;
+    };
+    this.abilityFuncMap[kAbility.FirebirdTrance] = () => {
+      tranceBox.duration = 0;
+      tranceBox.duration = 60;
+    };
+
+    this.statChangeFuncMap['SMN'] = () => {
+      dotBox.valuescale = this.gcdSpell();
+      dotBox.threshold = this.gcdSpell() + 1;
+      energyDrainBox.valuescale = this.gcdSpell();
+      energyDrainBox.threshold = this.gcdSpell() + 1;
+      tranceBox.valuescale = this.gcdSpell();
+      tranceBox.threshold = this.gcdSpell() + 7;
+    }
   }
 
   setupMnk() {

--- a/ui/jobs/jobs.js
+++ b/ui/jobs/jobs.js
@@ -143,6 +143,7 @@ const kAbility = {
   Bio3: '1D00',
   Tridisaster: 'DFC',
   EnergyDrain: '407C',
+  EnergySiphon: '407E',
   DreadwyrmTrance: 'DFD',
   FirebirdTrance: '40A5',
 };
@@ -1942,6 +1943,11 @@ class Bars {
     };
 
     this.abilityFuncMap[kAbility.EnergyDrain] = () => {
+      energyDrainBox.duration = 0;
+      energyDrainBox.duration = 30;
+      aetherflowStackBox.parentNode.classList.remove('too-much-stacks');
+    };
+    this.abilityFuncMap[kAbility.EnergySiphon] = () => {
       energyDrainBox.duration = 0;
       energyDrainBox.duration = 30;
       aetherflowStackBox.parentNode.classList.remove('too-much-stacks');

--- a/ui/jobs/jobs.js
+++ b/ui/jobs/jobs.js
@@ -1869,7 +1869,7 @@ class Bars {
       else
         pp.classList.remove('last');
     });
-    
+
     // Boxes are not enough so we can only trace the latetest one DoT.
     // Make sure you always cast two DoT at the same time!
     this.abilityFuncMap[kAbility.miasma] = () => {

--- a/ui/jobs/jobs.js
+++ b/ui/jobs/jobs.js
@@ -1875,7 +1875,7 @@ class Bars {
       if (time <= 7 && summoned == 3)
         pp.classList.add('last');
       else if (time > 0 && time <= 2 && summoned == 0)
-        pp.classList.add('last');     
+        pp.classList.add('last');
       else
         pp.classList.remove('last');
     });

--- a/ui/jobs/jobs.js
+++ b/ui/jobs/jobs.js
@@ -1060,7 +1060,6 @@ class Bars {
     this.gcdSkill = () => this.CalcGCDFromStat(this.skillSpeed);
     this.gcdSpell = () => this.CalcGCDFromStat(this.spellSpeed);
 
-    this.furtherRuin = 0;
     this.presenceOfMind = 0;
     this.shifu = 0;
     this.huton = 0;
@@ -1859,6 +1858,11 @@ class Bars {
       ruin4Stacks.push(d);
     }
 
+    let furtherRuin = 0;
+    addOverlayListener('ChangeZone', function(e) {
+      furtherRuin = 0;
+    });
+
     this.jobFuncs.push((jobDetail) => {
       let stack = jobDetail.aetherflowStacks;
       let summoned = jobDetail.bahamutSummoned;
@@ -1867,13 +1871,13 @@ class Bars {
       // FurtherRuin Stack Guage
       this.gainEffectFuncMap[EffectId.FurtherRuin] = (name, e) => {
         if (e.count) // ensure e.count is exist
-          this.furtherRuin = parseInt(e.count);
+          furtherRuin = parseInt(e.count);
       };
       this.loseEffectFuncMap[EffectId.FurtherRuin] = () => {
-        this.furtherRuin = 0;
+        furtherRuin = 0;
       };
       for (let i = 0; i < 4; ++i) {
-        if (this.furtherRuin > i)
+        if (furtherRuin > i)
           ruin4Stacks[i].classList.add('active');
         else
           ruin4Stacks[i].classList.remove('active');

--- a/ui/jobs/jobs.js
+++ b/ui/jobs/jobs.js
@@ -138,8 +138,8 @@ const kAbility = {
   LucidDreaming: '1D8A',
   Miasma: 'A8',
   Miasma3: '1D01',
-  Biosmn: 'A4',
-  Biosmn2: 'B2',
+  BioSmn: 'A4',
+  BioSmn2: 'B2',
   Bio3: '1D00',
   Tridisaster: 'DFC',
   EnergyDrain: '407C',
@@ -1761,7 +1761,7 @@ class Bars {
     this.jobFuncs.push((jobDetail) => {
       let aetherflow = jobDetail.aetherflowStacks;
       let fairygauge = jobDetail.fairyGauge;
-      let milli = (jobDetail.fairyMilliseconds / 1000).toFixed(0);
+      let milli = Math.floor(jobDetail.fairyMilliseconds / 1000);
       aetherflowStackBox.innerText = aetherflow;
       fairyGaugeBox.innerText = fairygauge;
       let f = fairyGaugeBox.parentNode;
@@ -1861,31 +1861,31 @@ class Bars {
     }
 
     let furtherRuin = 0;
-    function refreshfurtherRuin() {
+    const refreshFurtherRuin = () => {
       for (let i = 0; i < 4; ++i) {
         if (furtherRuin > i)
           ruin4Stacks[i].classList.add('active');
         else
           ruin4Stacks[i].classList.remove('active');
       }
-    }
+    };
     this.gainEffectFuncMap[EffectId.FurtherRuin] = (name, e) => {
       furtherRuin = parseInt(e.count);
-      refreshfurtherRuin();
+      refreshFurtherRuin();
     };
     this.loseEffectFuncMap[EffectId.FurtherRuin] = () => {
       furtherRuin = 0;
-      refreshfurtherRuin();
+      refreshFurtherRuin();
     };
     this.changeZoneFuncs.push((e) => {
       furtherRuin = 0;
-      refreshfurtherRuin();
+      refreshFurtherRuin();
     });
 
     this.jobFuncs.push((jobDetail) => {
       let stack = jobDetail.aetherflowStacks;
       let summoned = jobDetail.bahamutSummoned;
-      let time = (jobDetail.stanceMilliseconds / 1000).toFixed(0);
+      let time = Math.floor(jobDetail.stanceMilliseconds / 1000);
 
       // turn red when you have too much stacks before EnergyDrain ready.
       aetherflowStackBox.innerText = stack;
@@ -1929,11 +1929,11 @@ class Bars {
       miasmaBox.duration = 0;
       miasmaBox.duration = 30;
     };
-    this.abilityFuncMap[kAbility.Biosmn] = () => {
+    this.abilityFuncMap[kAbility.BioSmn] = () => {
       bioSmnBox.duration = 0;
       bioSmnBox.duration = 30;
     };
-    this.abilityFuncMap[kAbility.Biosmn2] = () => {
+    this.abilityFuncMap[kAbility.BioSmn2] = () => {
       bioSmnBox.duration = 0;
       bioSmnBox.duration = 30;
     };
@@ -2656,8 +2656,8 @@ class Bars {
     if (this.buffTracker)
       this.buffTracker.clear();
 
-    for (let i = 0; i < this.changeZoneFuncs.length; ++i)
-      this.changeZoneFuncs[i](e);
+    for (const func of this.changeZoneFuncs)
+      func(e);
   }
 
   SetPullCountdown(seconds) {

--- a/ui/jobs/jobs.js
+++ b/ui/jobs/jobs.js
@@ -1059,6 +1059,7 @@ class Bars {
     this.gcdSkill = () => this.CalcGCDFromStat(this.skillSpeed);
     this.gcdSpell = () => this.CalcGCDFromStat(this.spellSpeed);
 
+    this.furtherRuin = 0;
     this.presenceOfMind = 0;
     this.shifu = 0;
     this.huton = 0;
@@ -1843,10 +1844,39 @@ class Bars {
       fgColor: 'smn-color-trance',
     });
 
+    // Create a Stack Container
+    let stacksContainer = document.createElement('div');
+    stacksContainer.id = 'smn-stacks';
+    this.addJobBarContainer().appendChild(stacksContainer);
+    let ruin4Container = document.createElement('div');
+    ruin4Container.id = 'smn-stacks-ruin4';
+    stacksContainer.appendChild(ruin4Container);
+    let ruin4Stacks = [];
+    for (let i = 0; i < 4; ++i) {
+      let d = document.createElement('div');
+      ruin4Container.appendChild(d);
+      ruin4Stacks.push(d);
+    }
+
     this.jobFuncs.push((jobDetail) => {
       let stack = jobDetail.aetherflowStacks;
       let summoned = jobDetail.bahamutSummoned;
       let time = (jobDetail.stanceMilliseconds / 1000).toFixed(0);
+
+      // FurtherRuin Stack Guage
+      this.gainEffectFuncMap[EffectId.FurtherRuin] = (name, e) => {
+        if (e.count) // ensure e.count is exist
+          this.furtherRuin = parseInt(e.count);
+      };
+      this.loseEffectFuncMap[EffectId.FurtherRuin] = () => {
+        this.furtherRuin = 0;
+      };
+      for (let i = 0; i < 4; ++i) {
+        if (this.furtherRuin > i)
+          ruin4Stacks[i].classList.add('active');
+        else
+          ruin4Stacks[i].classList.remove('active');
+      }
 
       // turn red when you have too much stacks before EnergyDrain ready.
       aetherflowStackBox.innerText = stack;

--- a/ui/jobs/jobs.js
+++ b/ui/jobs/jobs.js
@@ -1823,9 +1823,14 @@ class Bars {
       classList: ['smn-color-demisummom'],
     });
 
-    let dotBox = this.addProcBox({
-      id: 'smn-procs-dot',
-      fgColor: 'smn-color-dot',
+    let miasmaBox = this.addProcBox({
+      id: 'smn-procs-miasma',
+      fgColor: 'smn-color-miasma',
+    });
+
+    let bioSmnBox = this.addProcBox({
+      id: 'smn-procs-biosmn',
+      fgColor: 'smn-color-biosmn',
     });
 
     let energyDrainBox = this.addProcBox({
@@ -1843,7 +1848,17 @@ class Bars {
       let summoned = jobDetail.bahamutSummoned;
       let time = (jobDetail.stanceMilliseconds / 1000).toFixed(0);
 
+      // turn red when you have too much stacks before EnergyDrain ready.
       aetherflowStackBox.innerText = stack;
+      let p = aetherflowStackBox.parentNode;
+      let s = parseFloat(energyDrainBox.duration || 0) - parseFloat(energyDrainBox.elapsed);
+      if ((stack == 2) && (s <= 8))
+        p.classList.add('too-much-stacks');
+      else
+        p.classList.remove('too-much-stacks');
+
+      // Show time remain when summoming/trancing.
+      // Turn blue when buhamut ready, and turn orange when firebird ready.
       demiSummomingBox.innerText = '';
       demiSummomingBox.parentNode.classList.remove('bahamutready', 'firebirdready');
       if (time > 0)
@@ -1853,48 +1868,43 @@ class Bars {
       else if (jobDetail.phoenixReady == true)
         demiSummomingBox.parentNode.classList.add('firebirdready');
 
-      // turn red when you have too much stacks before EnergyDrain ready.
-      let p = aetherflowStackBox.parentNode;
-      let s = parseFloat(energyDrainBox.duration || 0) - parseFloat(energyDrainBox.elapsed);
-      if ((stack == 2) && (s <= 8))
-        p.classList.add('too-much-stacks');
-      else
-        p.classList.remove('too-much-stacks');
-
-      // Turn red when only 7s remain, to alarm that use the second Enkindle.
-      // Also alarm that don't cast a spell that has cast time, or a WW will be missed.
+      // Turn red when only 7s summoming time remain, to alarm that cast the second Enkindle.
+      // Also alarm that don't cast a spell that has cast time, or a WW/SF will be missed.
+      // Turn red when only 2s trancing time remain, to alarm that cast deathflare.
       let pp = demiSummomingBox.parentNode;
       if (time <= 7 && summoned == 3)
         pp.classList.add('last');
+      else if (time > 0 && time <= 2 && summoned == 0)
+        pp.classList.add('last');     
       else
         pp.classList.remove('last');
     });
 
-    // Boxes are not enough so we can only trace the latetest one DoT.
-    // Make sure you always cast two DoT at the same time!
     this.abilityFuncMap[kAbility.miasma] = () => {
-      dotBox.duration = 0;
-      dotBox.duration = 30;
+      miasmaBox.duration = 0;
+      miasmaBox.duration = 30;
     };
     this.abilityFuncMap[kAbility.miasma3] = () => {
-      dotBox.duration = 0;
-      dotBox.duration = 30;
+      miasmaBox.duration = 0;
+      miasmaBox.duration = 30;
     };
     this.abilityFuncMap[kAbility.smnBio] = () => {
-      dotBox.duration = 0;
-      dotBox.duration = 30;
+      bioSmnBox.duration = 0;
+      bioSmnBox.duration = 30;
     };
     this.abilityFuncMap[kAbility.smnBio2] = () => {
-      dotBox.duration = 0;
-      dotBox.duration = 30;
+      bioSmnBox.duration = 0;
+      bioSmnBox.duration = 30;
     };
     this.abilityFuncMap[kAbility.Bio3] = () => {
-      dotBox.duration = 0;
-      dotBox.duration = 30;
+      bioSmnBox.duration = 0;
+      bioSmnBox.duration = 30;
     };
     this.abilityFuncMap[kAbility.Tridisaster] = () => {
-      dotBox.duration = 0;
-      dotBox.duration = 30;
+      miasmaBox.duration = 0;
+      miasmaBox.duration = 30;
+      bioSmnBox.duration = 0;
+      bioSmnBox.duration = 30;
     };
 
     this.abilityFuncMap[kAbility.EnergyDrain] = () => {
@@ -1915,8 +1925,10 @@ class Bars {
     };
 
     this.statChangeFuncMap['SMN'] = () => {
-      dotBox.valuescale = this.gcdSpell();
-      dotBox.threshold = this.gcdSpell() + 1;
+      miasmaBox.valuescale = this.gcdSpell();
+      miasmaBox.threshold = this.gcdSpell() + 1;
+      bioSmnBox.valuescale = this.gcdSpell();
+      bioSmnBox.threshold = this.gcdSpell() + 1;
       energyDrainBox.valuescale = this.gcdSpell();
       energyDrainBox.threshold = this.gcdSpell() + 1;
       tranceBox.valuescale = this.gcdSpell();

--- a/ui/jobs/jobs.js
+++ b/ui/jobs/jobs.js
@@ -2657,7 +2657,7 @@ class Bars {
       this.buffTracker.clear();
 
     for (let i = 0; i < this.changeZoneFuncs.length; ++i)
-    this.changeZoneFuncs[i](e);
+      this.changeZoneFuncs[i](e);
   }
 
   SetPullCountdown(seconds) {

--- a/ui/jobs/jobs.js
+++ b/ui/jobs/jobs.js
@@ -136,8 +136,8 @@ const kAbility = {
   Thunder4: '1CFC',
   Divination: '40A8',
   LucidDreaming: '1D8A',
-  miasma: 'A8',
-  miasma3: '1D01',
+  Miasma: 'A8',
+  Miasma3: '1D01',
   smnBio: 'A4',
   smnBio2: 'B2',
   Bio3: '1D00',
@@ -1820,8 +1820,8 @@ class Bars {
       classList: ['smn-color-aetherflow'],
     });
 
-    let demiSummomingBox = this.addResourceBox({
-      classList: ['smn-color-demisummom'],
+    let demiSummoningBox = this.addResourceBox({
+      classList: ['smn-color-demisummon'],
     });
 
     let miasmaBox = this.addProcBox({
@@ -1844,7 +1844,7 @@ class Bars {
       fgColor: 'smn-color-trance',
     });
 
-    // Create a Stack Container
+    // FurtherRuin Stack Guage
     let stacksContainer = document.createElement('div');
     stacksContainer.id = 'smn-stacks';
     this.addJobBarContainer().appendChild(stacksContainer);
@@ -1859,8 +1859,25 @@ class Bars {
     }
 
     let furtherRuin = 0;
+    function refreshfurtherRuin() {
+      for (let i = 0; i < 4; ++i) {
+        if (furtherRuin > i)
+          ruin4Stacks[i].classList.add('active');
+        else
+          ruin4Stacks[i].classList.remove('active');
+      }
+    }
+    this.gainEffectFuncMap[EffectId.FurtherRuin] = (name, e) => {
+      furtherRuin = parseInt(e.count);
+      refreshfurtherRuin();
+    };
+    this.loseEffectFuncMap[EffectId.FurtherRuin] = () => {
+      furtherRuin = 0;
+      refreshfurtherRuin();
+    };
     addOverlayListener('ChangeZone', function(e) {
       furtherRuin = 0;
+      refreshfurtherRuin();
     });
 
     this.jobFuncs.push((jobDetail) => {
@@ -1868,62 +1885,45 @@ class Bars {
       let summoned = jobDetail.bahamutSummoned;
       let time = (jobDetail.stanceMilliseconds / 1000).toFixed(0);
 
-      // FurtherRuin Stack Guage
-      this.gainEffectFuncMap[EffectId.FurtherRuin] = (name, e) => {
-        if (e.count) // ensure e.count is exist
-          furtherRuin = parseInt(e.count);
-      };
-      this.loseEffectFuncMap[EffectId.FurtherRuin] = () => {
-        furtherRuin = 0;
-      };
-      for (let i = 0; i < 4; ++i) {
-        if (furtherRuin > i)
-          ruin4Stacks[i].classList.add('active');
-        else
-          ruin4Stacks[i].classList.remove('active');
-      }
-
       // turn red when you have too much stacks before EnergyDrain ready.
       aetherflowStackBox.innerText = stack;
-      let p = aetherflowStackBox.parentNode;
       let s = parseFloat(energyDrainBox.duration || 0) - parseFloat(energyDrainBox.elapsed);
       if ((stack == 2) && (s <= 8))
-        p.classList.add('too-much-stacks');
+        aetherflowStackBox.parentNode.classList.add('too-much-stacks');
       else
-        p.classList.remove('too-much-stacks');
+        aetherflowStackBox.parentNode.classList.remove('too-much-stacks');
 
-      // Show time remain when summoming/trancing.
+      // Show time remain when summoning/trancing.
       // Turn blue when buhamut ready, and turn orange when firebird ready.
-      // Also change tramceBox color.
-      demiSummomingBox.innerText = '';
-      demiSummomingBox.parentNode.classList.remove('bahamutready', 'firebirdready');
+      // Also change tranceBox color.
+      demiSummoningBox.innerText = '';
+      demiSummoningBox.parentNode.classList.remove('bahamutready', 'firebirdready');
       tranceBox.fg = computeBackgroundColorFrom(tranceBox, 'smn-color-trance');
       if (time > 0) {
-        demiSummomingBox.innerText = time;
+        demiSummoningBox.innerText = time;
       } else if (jobDetail.dreadwyrmStacks == 2) {
-        demiSummomingBox.parentNode.classList.add('bahamutready');
+        demiSummoningBox.parentNode.classList.add('bahamutready');
       } else if (jobDetail.phoenixReady == true) {
-        demiSummomingBox.parentNode.classList.add('firebirdready');
-        tranceBox.fg = computeBackgroundColorFrom(tranceBox, 'smn-color-demisummom.firebirdready');
+        demiSummoningBox.parentNode.classList.add('firebirdready');
+        tranceBox.fg = computeBackgroundColorFrom(tranceBox, 'smn-color-demisummon.firebirdready');
       }
 
-      // Turn red when only 7s summoming time remain, to alarm that cast the second Enkindle.
+      // Turn red when only 7s summoning time remain, to alarm that cast the second Enkindle.
       // Also alarm that don't cast a spell that has cast time, or a WW/SF will be missed.
       // Turn red when only 2s trancing time remain, to alarm that cast deathflare.
-      let pp = demiSummomingBox.parentNode;
       if (time <= 7 && summoned == 3)
-        pp.classList.add('last');
+        demiSummoningBox.parentNode.classList.add('last');
       else if (time > 0 && time <= 2 && summoned == 0)
-        pp.classList.add('last');
+        demiSummoningBox.parentNode.classList.add('last');
       else
-        pp.classList.remove('last');
+        demiSummoningBox.parentNode.classList.remove('last');
     });
 
-    this.abilityFuncMap[kAbility.miasma] = () => {
+    this.abilityFuncMap[kAbility.Miasma] = () => {
       miasmaBox.duration = 0;
       miasmaBox.duration = 30;
     };
-    this.abilityFuncMap[kAbility.miasma3] = () => {
+    this.abilityFuncMap[kAbility.Miasma3] = () => {
       miasmaBox.duration = 0;
       miasmaBox.duration = 30;
     };


### PR DESCRIPTION
![SMNUI](https://user-images.githubusercontent.com/68432572/89975513-87d14500-dc98-11ea-93a8-79e01736302a.png)
### **Following function has been added:**
- **Aetherflow Box**
Show how many Aetherflow Stack you have.
Turn red when you still have 2 stack and Energy Drain is about to ready in 8s(for finish current cast, then cast a Fester).
- **Demi-Summoning Box**
When not in Demi-Summoning/Trancing, show what you can summon next turn by color.
While Summoning/Trancing, show time remains.
Turn red when Demi-Summon time remains less than 7s, to alarm player cast the second Enkindle, and don't cast a spell which has cast time. 
Also turn red when Trance time remain less than 2s for Deathflare.
- **Miasma & Bio DoT Tracker**
To track 2 DoT, Tracker part looks a little crowded.
- **Energy Drain Cooldown Tracker**
Both Energy Drain and Energy Siphon is supported.
- **Trance Cooldown Tracker**
Infact, Trance's Cooldown is 55s, but wait till 60s is better on matching Raid buffs.
A long Threshold at about 9s is set for those who want to use 55s rotation.