### PR TITLE
radar: temporarily disable npcNameId matching

### DIFF
--- a/ui/radar/radar.js
+++ b/ui/radar/radar.js
@@ -108,8 +108,9 @@ class Radar {
   }
 
   AddMonster(log, monster, matches) {
-    if (monster.id && matches.npcNameId !== monster.id)
-      return;
+    // Temporarily disabled due to https://github.com/ravahn/FFXIV_ACT_Plugin/issues/256
+    // if (monster.id && matches.npcNameId !== monster.id)
+    //  return;
     if (monster.regex && !log.match(monster.regex))
       return;
     if (monster.hp && parseFloat(matches.hp) < monster.hp)
@@ -122,8 +123,9 @@ class Radar {
     if (options.Type === 'mob') {
       if (!matches.id.startsWith('4'))
         return;
-      if (!matches.npcNameId || matches.npcNameId === '0')
-        return;
+      // Temporarily disabled due to https://github.com/ravahn/FFXIV_ACT_Plugin/issues/256
+      // if (!matches.npcNameId || matches.npcNameId === '0')
+      //  return;
     }
 
     let mobKey = matches.name.toLowerCase();


### PR DESCRIPTION
Once https://github.com/ravahn/FFXIV_ACT_Plugin/issues/256 has been
fixed then this should be reverted.