### PR TITLE
plugin: Fix FateWatcher casting ActorControl143 Category as int instead of ushort

### DIFF
--- a/plugin/CactbotEventSource/FateWatcher.cs
+++ b/plugin/CactbotEventSource/FateWatcher.cs
@@ -165,7 +165,7 @@ namespace Cactbot {
     }
 
     public unsafe void ProcessMessage(byte* buffer, byte[] message) {
-      int a = *((int*)&buffer[Category_Offset]);
+      int a = *(ushort*)&buffer[Category_Offset];
 
       if (a == opcodes[region_].add) {
         AddFate(*(int*)&buffer[Param1_Offset]);


### PR DESCRIPTION
FIxes #1688 

Category should always have been a ushort but it seems with 5.3 there can now be garbage bytes resulting in erroneous values.