### PR TITLE
raidboss: fix text typo in alex ultimate

### DIFF
--- a/ui/raidboss/data/05-shb/ultimate/the_epic_of_alexander.js
+++ b/ui/raidboss/data/05-shb/ultimate/the_epic_of_alexander.js
@@ -2240,7 +2240,7 @@ const kFinalJudgementNisi = ['8B0', '8B1', '85B', '85C'];
           '2': {
             en: 'Purple, no tether: E->W',
             de: 'Lila, keine Verbindung: O->W',
-            ja: '接触禁止, 線無し: 東から西へ',
+            ja: '逃亡禁止, 線無し: 東から西へ',
             fr: 'Violet, pas de lien : E->O',
             ko: '보라/접촉금지/선없음: 동→서',
             cn: '紫色, 无连线: 东->西',


### PR DESCRIPTION
@r4ha Sorry for disturbing.

https://github.com/quisquous/cactbot/blob/c5a6c24c8690fc7ab1c31d6134dd31d28b3c9806/ui/raidboss/data/05-shb/ultimate/the_epic_of_alexander.js#L2240-L2247

I think the text in here should be "逃亡禁止" instead of "接触禁止". Is it my misunderstanding or just your typo here?
Waiting for your reply.
