### PR TITLE
- Fix #1453

### DIFF
--- a/ui/raidboss/raidboss.html
+++ b/ui/raidboss/raidboss.html
@@ -13,6 +13,7 @@
   <script src="../../resources/responses.js"></script>
   <script src="../../resources/resize_handle.js"></script>
   <script src="../../resources/timerbar.js"></script>
+  <script src="../../resources/translations.js"></script>
   <script src="../../resources/widgetlist.js"></script>
   <script src="../../resources/user_config.js"></script>
 


### PR DESCRIPTION
This PR fixes #1453 by tracking the countdown/wipe state for the timeline and preventing the `Engage!` event from starting the timeline if there was a wipe during countdown.