### PR TITLE
Raidboss: fix timeline instruction language

### DIFF
--- a/ui/raidboss/timeline.js
+++ b/ui/raidboss/timeline.js
@@ -615,7 +615,7 @@ class TimelineUI {
   }
 
   AddDebugInstructions() {
-    const lang = this.lang in timelineInstructions ? this.lang : 'en';
+    const lang = this.options.DisplayLanguage in timelineInstructions ? this.options.DisplayLanguage : 'en';
     const instructions = timelineInstructions[lang];
 
     // Helper for positioning/resizing when locked.


### PR DESCRIPTION
`this.lang` returns `undefined`
There's maybe better object to get language information, but anyway this fixes the problem.