### PR TITLE
pullcounter: add meta charset to html

### DIFF
--- a/ui/pullcounter/pullcounter.html
+++ b/ui/pullcounter/pullcounter.html
@@ -1,5 +1,6 @@
 <html>
 <head>
+<meta charset="utf-8">
 <link rel="stylesheet" href="../../resources/defaults.css">
 <link rel="stylesheet" href="../../resources/resize_handle.css">
 <script src="../../resources/common.js"></script>


### PR DESCRIPTION
Adding missing `<meta>` tag in pullcounter.html

I've checked other html files and they do have meta charset tags already (except `ui/dps/xephero/manual_dps_test.html` which is a test file).