### PR TITLE
raidboss: Suppress Twister Dive

### DIFF
--- a/ui/raidboss/data/04-sb/ultimate/unending_coil_ultimate.js
+++ b/ui/raidboss/data/04-sb/ultimate/unending_coil_ultimate.js
@@ -1235,6 +1235,7 @@
       netRegexJa: NetRegexes.ability({ source: 'ツインタニア', id: '26B2', capture: false }),
       netRegexCn: NetRegexes.ability({ source: '双塔尼亚', id: '26B2', capture: false }),
       netRegexKo: NetRegexes.ability({ source: '트윈타니아', id: '26B2', capture: false }),
+      suppressSeconds: 2,
       alertText: {
         en: 'Twisters',
         fr: 'Tornades',


### PR DESCRIPTION
If people die, it calls it twice.

```
[17:14:58.730] 16:40004588:Twintania:26B2:Twisting Dive:106F8A6D:Baddie One:730003:58454401:20:80000:1B:26B28000:0:0:0:0:0:0:0:0:0:0:42735:42735:3745:10000:0:1000:7.374826:7.486454:-0.0005370203:0.9083784:1:5533785:10000:10000:0:1000:-8.4853:22.6273:0:2.356182:0000781D
[17:14:58.730] 16:40004588:Twintania:26B2:Twisting Dive:106BF6B7:Baddie Two:F1730006:38C14401:20:80000:1B:26B28000:0:0:0:0:0:0:0:0:0:0:42719:42719:5400:10000:0:1000:17.22228:-3.507673:-0.001305427:1.968111:1:5533785:10000:10000:0:1000:-8.4853:22.6273:0:2.356182:0000781D
```