### PR TITLE
plugin: Update Korean FateWatcher to use 5.2 opcodes

### DIFF
--- a/plugin/CactbotEventSource/FateWatcher.cs
+++ b/plugin/CactbotEventSource/FateWatcher.cs
@@ -66,7 +66,7 @@ namespace Cactbot {
         region_ = "intl";
 
       opcodes = new Dictionary<string, OPCodes>();
-      opcodes.Add("ko", v5_1);
+      opcodes.Add("ko", v5_2);
       opcodes.Add("cn", v5_2);
       opcodes.Add("intl", v5_2);
 


### PR DESCRIPTION
Untested as I don't have access to the KO client, but I expect it will match the intl and cn releases.