### PR TITLE
Fix(raidboss): arrows at wrong place in trigger info text

### DIFF
--- a/resources/responses.js
+++ b/resources/responses.js
@@ -142,7 +142,7 @@ let Responses = {
         de: 'Tank buster auf ' + data.ShortName(target),
         fr: 'Tank buster sur ' + data.ShortName(target),
         ja: data.ShortName(target) + 'にタンクバスター',
-        cn: '死刑 -> ' + data.ShortName(target),
+        cn: '死刑 点 ' + data.ShortName(target),
         ko: '"' + data.ShortName(target) + '" 탱버',
       };
     };
@@ -186,7 +186,7 @@ let Responses = {
         de: 'Tank buster auf ' + data.ShortName(target),
         fr: 'Tank buster sur ' + data.ShortName(target),
         ja: data.ShortName(target) + 'にタンクバスター',
-        cn: '死刑 -> ' + data.ShortName(target),
+        cn: '死刑 点 ' + data.ShortName(target),
         ko: '탱버 → ' + data.ShortName(target),
       };
     };
@@ -720,7 +720,7 @@ let Responses = {
         de: 'Schlaf auf ' + source,
         fr: 'Sommeil => ' + source,
         ja: 'スリプル => ' + source,
-        cn: '催眠 => ' + source,
+        cn: '催眠 ' + source,
         ko: '슬리플 => ' + source,
       };
     };
@@ -735,7 +735,7 @@ let Responses = {
         de: 'Betäubung auf ' + source,
         fr: 'Étourdissement => ' + source,
         ja: 'スタン => ' + source,
-        cn: '眩晕 => ' + source,
+        cn: '眩晕 ' + source,
         ko: '기절 => ' + source,
       };
     };

--- a/ui/raidboss/data/03-hw/raid/a8s.js
+++ b/ui/raidboss/data/03-hw/raid/a8s.js
@@ -530,7 +530,7 @@
         en: 'Min HP: Provoke Boss => Late NE Tornado',
         de: 'Min HP: Boss herrausfordern => Später No Tornado',
         fr: 'PV Min : Provocation Boss => Cyclone NE en retard',
-        cn: '最少HP:挑衅BOSS=>东北龙卷风',
+        cn: '最少HP:挑衅BOSS => 东北龙卷风',
         ko: 'HP 최소: 보스 도발 => 북동쪽 회오리',
       },
     },

--- a/ui/raidboss/data/04-sb/raid/o12s.js
+++ b/ui/raidboss/data/04-sb/raid/o12s.js
@@ -282,7 +282,7 @@
           de: 'Verwundbarkeit auf ' + data.ShortName(matches.target),
           fr: 'Vulnérabilité sur ' + data.ShortName(matches.target),
           ja: '標的 on ' + data.ShortName(matches.target),
-          cn: '目标识别->' + data.ShortName(matches.target),
+          cn: '目标识别 点' + data.ShortName(matches.target),
           ko: '"' + data.ShortName(matches.target) + '" 표적식별',
         };
       },
@@ -413,7 +413,7 @@
             de: 'Kurzer Stack auf ' + data.ShortName(matches.target),
             fr: 'Marque courte sur ' + data.ShortName(matches.target),
             ja: '早シェア on ' + data.ShortName(matches.target),
-            cn: '短D->' + data.ShortName(matches.target),
+            cn: '短D 点' + data.ShortName(matches.target),
             ko: '"' + data.ShortName(matches.target) + '" 쉐어',
           };
         }

--- a/ui/raidboss/data/04-sb/trial/suzaku-ex.js
+++ b/ui/raidboss/data/04-sb/trial/suzaku-ex.js
@@ -28,7 +28,7 @@
             en: 'Buster on ' + data.ShortName(matches.target),
             de: 'Tankbuster auf ' + data.ShortName(matches.target),
             fr: 'Tank buster sur ' + data.ShortName(matches.target),
-            cn: '死刑->' + data.ShortName(matches.target),
+            cn: '死刑 点' + data.ShortName(matches.target),
             ko: '"' + data.ShortName(matches.target) + '" 탱버',
           };
         }

--- a/ui/raidboss/data/04-sb/trial/tsukuyomi-ex.js
+++ b/ui/raidboss/data/04-sb/trial/tsukuyomi-ex.js
@@ -60,7 +60,7 @@
             en: 'Buster on ' + data.ShortName(matches.target),
             de: 'Tankbuster auf ' + data.ShortName(matches.target),
             fr: 'Tank buster sur ' + data.ShortName(matches.target),
-            cn: '死刑->' + data.ShortName(matches.target),
+            cn: '死刑 点' + data.ShortName(matches.target),
             ko: '"' + data.ShortName(target) + '" 탱버',
           };
         }

--- a/ui/raidboss/data/05-shb/raid/e4s.js
+++ b/ui/raidboss/data/05-shb/raid/e4s.js
@@ -421,7 +421,7 @@
           de: 'Auf ' + data.ShortName(matches.target) + ' sammeln',
           fr: 'Packez-vous sur ' + data.ShortName(matches.target),
           ja: data.ShortName(matches.target) + 'にシェア',
-          cn: '集合 ->' + data.ShortName(matches.target),
+          cn: '与 ' + data.ShortName(matches.target) + ' 集合',
           ko: '"' + data.ShortName(matches.target) + '" 쉐어징',
         };
       },

--- a/ui/raidboss/data/05-shb/trial/hades.js
+++ b/ui/raidboss/data/05-shb/trial/hades.js
@@ -41,7 +41,7 @@
             de: 'Tankbuster auf ' + data.ShortName(matches.target),
             fr: 'Tank buster sur ' + data.ShortName(matches.target),
             ja: data.ShortName(matches.target) + 'にタンクバスター',
-            cn: '死刑 ->' + data.ShortName(matches.target),
+            cn: '死刑 点' + data.ShortName(matches.target),
             ko: '탱버 ->' + data.ShortName(matches.target),
           };
         }

--- a/ui/raidboss/data/05-shb/trial/innocence-ex.js
+++ b/ui/raidboss/data/05-shb/trial/innocence-ex.js
@@ -147,7 +147,7 @@
             de: 'Tankbuster auf ' + data.ShortName(matches.target),
             fr: 'Tank buster sur ' + data.ShortName(matches.target),
             ja: data.ShortName(matches.target) + 'にタンクバスター',
-            cn: '死刑 -> ' + data.ShortName(matches.target),
+            cn: '死刑 点' + data.ShortName(matches.target),
             ko: '탱버 -> ' + data.ShortName(matches.target),
           };
         }

--- a/ui/raidboss/data/05-shb/trial/varis-ex.js
+++ b/ui/raidboss/data/05-shb/trial/varis-ex.js
@@ -157,7 +157,7 @@
           de: 'Tank buster auf ' + data.ShortName(target),
           fr: 'Tank buster sur ' + data.ShortName(target),
           ja: data.ShortName(target) + 'にタンクバスター',
-          cn: '死刑 -> ' + data.ShortName(target),
+          cn: '死刑 点 ' + data.ShortName(target),
           ko: '탱버 → ' + data.ShortName(target),
         };
       },

--- a/ui/raidboss/data/05-shb/ultimate/the_epic_of_alexander.js
+++ b/ui/raidboss/data/05-shb/ultimate/the_epic_of_alexander.js
@@ -82,7 +82,7 @@ const kFinalJudgementNisi = ['8B0', '8B1', '85B', '85C'];
               fr: 'Tank buster sur ' + data.ShortName(data.liquidTank),
               ja: 'タンクバスター',
               ko: '탱크버스터',
-              cn: '死刑 -> ' + data.ShortName(data.liquidTank),
+              cn: '死刑 点' + data.ShortName(data.liquidTank),
             };
           }
           return {
@@ -1240,7 +1240,7 @@ const kFinalJudgementNisi = ['8B0', '8B1', '85B', '85C'];
           fr: 'Peine collective sur ' + data.ShortName(matches.target),
           ja: data.ShortName(matches.target) + ' に集団罰',
           ko: data.ShortName(matches.target) + ' 에게 단체형',
-          cn: '集团罪->' + data.ShortName(matches.target),
+          cn: '集团罪 点' + data.ShortName(matches.target),
         };
       },
     },


### PR DESCRIPTION
https://github.com/quisquous/cactbot/blob/3cdb806d2b0b9cb8325e3e4fc8bdd81eb51a7170/ui/raidboss/popup-text.js#L774-L787

There are some translators translate `Tankbuster on someone` as `死刑 => someone`, but the code above would replace every arrow in the middle as `然后(then)`, so TTS would call out like `死刑然后someone (Tankbuster then someone)`.

(I think the correct TTS info should be like `Tankbuster on someone (死刑 点 someone)`.)

It confused players and should be fixed.

EDIT:
It seems there other languages have the same problem. For now I have only modified Chinese translations, because I don't know whether the other languages should be fixed or not.
