### PR TITLE
raidboss: Eden Furor Incineration Trigger fix

### DIFF
--- a/ui/raidboss/data/05-shb/raid/e6n.js
+++ b/ui/raidboss/data/05-shb/raid/e6n.js
@@ -138,7 +138,7 @@
       netRegexJa: NetRegexes.startsUsing({ source: ['イフリート', 'ラクタパクシャ'], id: '4BED' }),
       netRegexCn: NetRegexes.startsUsing({ source: ['伊弗利特', '赤翼罗羯坨博叉'], id: '4BED' }),
       netRegexKo: NetRegexes.startsUsing({ source: ['이프리트', '락타팍샤'], id: '4BED' }),
-      condition: Conditions.caresAboutMagical(),
+      condition: Conditions.caresAboutPhysical(),
       response: Responses.tankBuster(),
     },
     {

--- a/ui/raidboss/data/05-shb/raid/e6s.js
+++ b/ui/raidboss/data/05-shb/raid/e6s.js
@@ -271,7 +271,7 @@
       netRegexJa: NetRegexes.startsUsing({ source: ['イフリート', 'ラクタパクシャ'], id: '4C0E' }),
       netRegexCn: NetRegexes.startsUsing({ source: ['伊弗利特', '赤翼罗羯坨博叉'], id: '4C0E' }),
       netRegexKo: NetRegexes.startsUsing({ source: ['이프리트', '락타팍샤'], id: '4C0E' }),
-      condition: Conditions.caresAboutMagical(),
+      condition: Conditions.caresAboutPhysical(),
       response: Responses.tankBuster(),
     },
     {


### PR DESCRIPTION
Instant Incineration is physical damage.
See [here](https://fflogs.com/reports/hXYR6ZV8fTb9Djnp#fight=5&type=casts&hostility=1&source=19). (blue is magical, orange is physical)