### PR TITLE
Jobs: fix bug for Korean server

### DIFF
--- a/resources/translations.js
+++ b/resources/translations.js
@@ -79,7 +79,7 @@ if (typeof module !== 'undefined') {
       fr: '(Vous fabriquez|Votre synthèse d\'essai pour fabriquer) (?<recipe>.*)( a été couronnée de succès!)?',
       ja: '(?<player>\\y{Name})は(?<recipe>.*)(を完成させた|の製作練習に成功した)！',
       cn: '(?<player>\\y{Name})制作(?<recipe>.*)成功！',
-      ko: '(?<player>\\y{Name}) 님이 (?<recipe>.*)(×[2-9]개)?(을|를) 완성했습니다!',
+      ko: '(?<player>\\y{Name}) 님이 (?<recipe>.*)(을|를) 완성했습니다!',
     },
     craftingFail: {
       en: 'Your (synthesis fails!|trial synthesis of failed\\.{3})',

--- a/resources/translations.js
+++ b/resources/translations.js
@@ -79,7 +79,7 @@ if (typeof module !== 'undefined') {
       fr: '(Vous fabriquez|Votre synthèse d\'essai pour fabriquer) (?<recipe>.*)( a été couronnée de succès!)?',
       ja: '(?<player>\\y{Name})は(?<recipe>.*)(を完成させた|の製作練習に成功した)！',
       cn: '(?<player>\\y{Name})制作(?<recipe>.*)成功！',
-      ko: '(?<recipe>.*)(개를)? 완성했습니다!',
+      ko: '(?<player>\\y{Name}) 님이 (?<recipe>.*)(×[2-9]개)?(을|를) 완성했습니다!',
     },
     craftingFail: {
       en: 'Your (synthesis fails!|trial synthesis of failed\\.{3})',


### PR DESCRIPTION
This should fix unintended UI hiding bug.
I wonder if `(?<recipe>.*)` returns string with "x3" thing (multiple craft output)
I added `×[2-9]` in regex, but I'm not sure this is right.

This fixes #1772.

Successfully tested that this code does not make UI hide with other player's craft done.