### PR TITLE
resources: Update Common Job Util Functions

### DIFF
--- a/resources/common.js
+++ b/resources/common.js
@@ -1,21 +1,23 @@
 'use strict';
 
-let kCasterJobs = ['BLU', 'RDM', 'BLM', 'WHM', 'SCH', 'SMN', 'ACN', 'AST', 'CNJ', 'THM'];
-let kRangedDpsJobs = ['ARC', 'BRD', 'DNC', 'MCH'];
-let kTankJobs = ['GLA', 'PLD', 'MRD', 'WAR', 'DRK', 'GNB'];
-let kHealerJobs = ['CNJ', 'WHM', 'SCH', 'AST'];
-let kCraftingJobs = ['CRP', 'BSM', 'ARM', 'GSM', 'LTW', 'WVR', 'ALC', 'CUL'];
-let kGatheringJobs = ['MIN', 'BTN', 'FSH'];
+const kTankJobs = ['GLA', 'PLD', 'MRD', 'WAR', 'DRK', 'GNB'];
+const kHealerJobs = ['CNJ', 'WHM', 'SCH', 'AST'];
+const kMeleeDpsJobs = ['PGL', 'MNK', 'LNC', 'DRG', 'ROG', 'NIN', 'SAM'];
+const kRangedDpsJobs = ['ARC', 'BRD', 'DNC', 'MCH'];
+const kCasterDpsJobs = ['BLU', 'RDM', 'BLM', 'SMN', 'ACN', 'THM'];
+const kDpsJobs = [...kMeleeDpsJobs, ...kRangedDpsJobs, ...kCasterDpsJobs];
+const kCraftingJobs = ['CRP', 'BSM', 'ARM', 'GSM', 'LTW', 'WVR', 'ALC', 'CUL'];
+const kGatheringJobs = ['MIN', 'BTN', 'FSH'];
 
-let kStunJobs = ['SAM', 'NIN', 'ROG', 'DRG', 'LNC', 'MNK', 'PGL', 'WAR', 'MRD', 'PLD', 'GLA', 'DRK', 'GNB'];
-let kSilenceJobs = ['MCH', 'BRD', 'ARC', 'DNC', 'BLU', 'GLA', 'PLD', 'MRD', 'WAR', 'DRK', 'GNB'];
-let kSleepJobs = ['BLM', 'WHM', 'SCH', 'AST'];
-let kFeintJobs = ['SAM', 'NIN', 'ROG', 'DRG', 'LNC', 'MNK', 'PGL'];
-let kAddleJobs = ['BLU', 'RDM', 'SMN', 'ACN', 'BLM', 'THM'];
-let kCleanseJobs = ['AST', 'BRD', 'CNJ', 'SCH', 'WHM'];
-let kAllRoles = ['tank', 'healer', 'dps', 'crafter', 'gatherer', 'none'];
+const kStunJobs = ['BLU', ...kTankJobs, ...kMeleeDpsJobs];
+const kSilenceJobs = ['BLU', ...kTankJobs, ...kRangedDpsJobs];
+const kSleepJobs = ['BLM', 'BLU', ...kHealerJobs];
+const kFeintJobs = [...kMeleeDpsJobs];
+const kAddleJobs = [...kCasterDpsJobs];
+const kCleanseJobs = ['BLU', 'BRD', ...kHealerJobs];
+const kAllRoles = ['tank', 'healer', 'dps', 'crafter', 'gatherer', 'none'];
 
-let kJobEnumToName = {
+const kJobEnumToName = {
   0: 'NONE',
   1: 'GLA',
   2: 'PGL',
@@ -57,87 +59,51 @@ let kJobEnumToName = {
   38: 'DNC',
 };
 
-let Util = {
-  jobEnumToJob: function(id) {
-    return kJobEnumToName[id];
-  },
-  jobToJobEnum: function(job) {
-    return Object.keys(kJobEnumToName).filter((k) => kJobEnumToName[k] === job).pop();
-  },
-  jobToRole: function(job) {
-    let role;
-    if (job.search(/^(WAR|DRK|PLD|GNB|MRD|GLA)$/) >= 0) {
-      role = 'tank';
-    } else if (job.search(/^(WHM|SCH|AST|CNJ)$/) >= 0) {
-      role = 'healer';
-    } else if (job.search(/^(MNK|NIN|DRG|SAM|ROG|LNC|PGL)$/) >= 0) {
-      role = 'dps';
-    } else if (job.search(/^(BLU|BLM|SMN|RDM|THM|ACN)$/) >= 0) {
-      role = 'dps';
-    } else if (job.search(/^(BRD|MCH|DNC|ARC)$/) >= 0) {
-      role = 'dps';
-    } else if (job.search(/^(CRP|BSM|ARM|GSM|LTW|WVR|ALC|CUL)$/) >= 0) {
-      role = 'crafter';
-    } else if (job.search(/^(MIN|BTN|FSH)$/) >= 0) {
-      role = 'gatherer';
-    } else if (job === 'NONE') {
-      role = 'none';
-    } else {
-      role = '';
-      console.log('Unknown job role');
-    }
-    return role;
-  },
+const jobToRoleMap = (() => {
+  const addToMap = (map, keys, value) => keys.forEach((key) => map.set(key, value));
 
-  isCasterJob: function(job) {
-    return kCasterJobs.indexOf(job) >= 0;
-  },
+  const map = new Map([['NONE', 'none']]);
+  addToMap(map, kTankJobs, 'tank');
+  addToMap(map, kHealerJobs, 'healer');
+  addToMap(map, kDpsJobs, 'dps');
+  addToMap(map, kCraftingJobs, 'crafter');
+  addToMap(map, kGatheringJobs, 'gatherer');
 
-  isRangedDpsJob: function(job) {
-    return kRangedDpsJobs.indexOf(job) >= 0;
-  },
+  return new Proxy(map, {
+    get: function(target, element) {
+      if (target.has(element))
+        return target.get(element);
+      console.log(`Unknown job role ${element}`);
+      return '';
+    },
+  });
+})();
 
-  isTankJob: function(job) {
-    return kTankJobs.indexOf(job) >= 0;
-  },
-
-  isHealerJob: function(job) {
-    return kHealerJobs.indexOf(job) >= 0;
-  },
-
-  isCraftingJob: function(job) {
-    return kCraftingJobs.indexOf(job) >= 0;
-  },
-
-  isGatheringJob: function(job) {
-    return kGatheringJobs.indexOf(job) >= 0;
-  },
-
-  isCombatJob: function(job) {
-    return !this.isCraftingJob(job) && !this.isGatheringJob(job);
-  },
-
-  canStun: function(job) {
-    return kStunJobs.indexOf(job) >= 0;
-  },
-  canSilence: function(job) {
-    return kSilenceJobs.indexOf(job) >= 0;
-  },
-  canSleep: function(job) {
-    return kSleepJobs.indexOf(job) >= 0;
-  },
-  canCleanse: function(job) {
-    return kCleanseJobs.indexOf(job) >= 0;
-  },
-  canFeint: function(job) {
-    return kFeintJobs.indexOf(job) >= 0;
-  },
-  canAddle: function(job) {
-    return kAddleJobs.indexOf(job) >= 0;
-  },
+const Util = {
+  jobEnumToJob: (id) => kJobEnumToName[id],
+  jobToJobEnum: (job) => Object.keys(kJobEnumToName).find((k) => kJobEnumToName[k] === job),
+  jobToRole: (job) => jobToRoleMap[job],
+  isTankJob: (job) => kTankJobs.includes(job),
+  isHealerJob: (job) => kHealerJobs.includes(job),
+  isMeleeDpsJob: (job) => kMeleeDpsJobs.includes(job),
+  isRangedDpsJob: (job) => kRangedDpsJobs.includes(job),
+  isCasterDpsJob: (job) => kCasterDpsJobs.includes(job),
+  isDpsJob: (job) => kDpsJobs.includes(job),
+  isCraftingJob: (job) => kCraftingJobs.includes(job),
+  isGatheringJob: (job) => kGatheringJobs.includes(job),
+  canStun: (job) => kStunJobs.includes(job),
+  canSilence: (job) => kSilenceJobs.includes(job),
+  canSleep: (job) => kSleepJobs.includes(job),
+  canCleanse: (job) => kCleanseJobs.includes(job),
+  canFeint: (job) => kFeintJobs.includes(job),
+  canAddle: (job) => kAddleJobs.includes(job),
 };
 
 (function() {
+  // Exit early if running within Node
+  if (typeof location === 'undefined')
+    return;
+
   let wsUrl = /[\?&]OVERLAY_WS=([^&]+)/.exec(location.href);
   let ws = null;
   let queue = [];
@@ -289,3 +255,9 @@ let Util = {
     return p;
   };
 })();
+
+if (typeof module !== 'undefined' && module.exports) {
+  module.exports = {
+    util: Util,
+  };
+}

--- a/test/unittests/common_test.js
+++ b/test/unittests/common_test.js
@@ -1,0 +1,83 @@
+'use strict';
+
+let commonModule = require('../../resources/common.js');
+let Util = commonModule.util;
+
+let assert = require('chai').assert;
+
+// Duplicate values from common.js
+// Expect to update these as patches and expansions change job capabilities
+const jobs = (() => {
+  class Job {
+    constructor(name, role, actions = []) {
+      this.name = name,
+      this.role = role,
+      this.actions = actions;
+    }
+  }
+
+  const tankJobs = ['GLA', 'PLD', 'MRD', 'WAR', 'DRK', 'GNB'];
+  const healerJobs = ['CNJ', 'WHM', 'SCH', 'AST'];
+  const meleeDpsJobs = ['PGL', 'MNK', 'LNC', 'DRG', 'ROG', 'NIN', 'SAM'];
+  const rangedDpsJobs = ['ARC', 'BRD', 'DNC', 'MCH'];
+  const casterDpsJobs = ['BLU', 'RDM', 'BLM', 'SMN', 'ACN', 'THM'];
+  const craftingJobs = ['CRP', 'BSM', 'ARM', 'GSM', 'LTW', 'WVR', 'ALC', 'CUL'];
+  const gatheringJobs = ['MIN', 'BTN', 'FSH'];
+
+  const jobs = [];
+
+  // Initialize all the jobs with standardized role action values
+  tankJobs.forEach((job) => jobs.push(new Job(job, 'tank', ['Silence', 'Stun'])));
+  healerJobs.forEach((job) => jobs.push(new Job(job, 'healer', ['Cleanse', 'Sleep'])));
+  meleeDpsJobs.forEach((job) => jobs.push(new Job(job, 'dps', ['Feint', 'Stun'])));
+  rangedDpsJobs.forEach((job) => jobs.push(new Job(job, 'dps', ['Silence'])));
+  casterDpsJobs.forEach((job) => jobs.push(new Job(job, 'dps', ['Addle'])));
+  craftingJobs.forEach((job) => jobs.push(new Job(job, 'crafter')));
+  gatheringJobs.forEach((job) => jobs.push(new Job(job, 'gatherer')));
+
+  // Special classes
+  jobs.find((job) => job.name === 'BRD').actions.push('Cleanse');
+  jobs.find((job) => job.name === 'BLM').actions.push('Sleep');
+  jobs.find((job) => job.name === 'BLU').actions.push('Cleanse', 'Silence', 'Sleep', 'Stun');
+
+  return jobs;
+})();
+
+let tests = {
+  // Check test job values match actual values from common.js and return their expected values
+  actionsTest: () => {
+    [['Addle', Util.canAddle], ['Cleanse', Util.canCleanse], ['Feint', Util.canFeint], ['Silence', Util.canSilence], ['Sleep', Util.canSleep], ['Stun', Util.canStun]]
+      .forEach(([action, functionCall]) => {
+        // If job can do X, assert canX returns true
+        jobs.filter((job) => job.actions.includes(action))
+          .forEach((job) => assert(functionCall(job.name)));
+        // If job can't do X, assert canX returns false
+        jobs.filter((job) => !job.actions.includes(action))
+          .forEach((job) => assert(!functionCall(job.name)));
+      });
+  },
+  rolesTest: () => {
+    [['crafter', Util.isCraftingJob], ['dps', Util.isDpsJob], ['gatherer', Util.isGatheringJob], ['healer', Util.isHealerJob], ['tank', Util.isTankJob]]
+      .forEach(([role, functionCall]) => {
+        // If job is a role, assert isRole returns true
+        jobs.filter((job) => job.role === role).forEach((job) => assert(functionCall(job.name)));
+        // If job is not a role, assert isRole returns false
+        jobs.filter((job) => job.role !== role).forEach((job) => assert(!functionCall(job.name)));
+      });
+  },
+  jobToRoleMapTest: () => {
+    jobs.forEach((job) => assert(job.role === Util.jobToRole(job.name)));
+  },
+};
+
+let keys = Object.keys(tests);
+let exitCode = 0;
+for (let i = 0; i < keys.length; ++i) {
+  try {
+    tests[keys[i]]();
+  } catch (e) {
+    console.log(e);
+    exitCode = 1;
+  }
+}
+process.exit(exitCode);

--- a/ui/jobs/jobs.js
+++ b/ui/jobs/jobs.js
@@ -386,7 +386,7 @@ function setupRegexes(playerName) {
 }
 
 function doesJobNeedMPBar(job) {
-  return Util.isCasterJob(job) || kMeleeWithMpJobs.indexOf(job) >= 0;
+  return Util.isCasterDpsJob(job) || Util.isHealerJob(job) || kMeleeWithMpJobs.includes(job);
 }
 
 function computeBackgroundColorFrom(element, classList) {
@@ -1122,7 +1122,7 @@ class Bars {
       barsLayoutContainer.classList.add('tank');
     else if (Util.isHealerJob(this.job))
       barsLayoutContainer.classList.add('healer');
-    else if (Util.isCombatJob(this.job))
+    else if (Util.isDpsJob(this.job))
       barsLayoutContainer.classList.add('dps');
     else if (Util.isCraftingJob(this.job))
       barsLayoutContainer.classList.add('crafting');


### PR DESCRIPTION
Updates the job to role mapping to instead use the user-defined lists as
a reference when determining job role.
Additionally shortening the function logic for most function calls to
directly check if the user-defined list includes the job.
Adds a quick exit within WSServer code if location is undefined,
primarily for local usecases (such as running tests).
Lastly, adding tests for the logic around job util functions and
creating the jobToRoleMap.