### PR TITLE
resources: Hide Job Data Lists

### DIFF
--- a/resources/common.js
+++ b/resources/common.js
@@ -1,103 +1,109 @@
 'use strict';
 
-const kTankJobs = ['GLA', 'PLD', 'MRD', 'WAR', 'DRK', 'GNB'];
-const kHealerJobs = ['CNJ', 'WHM', 'SCH', 'AST'];
-const kMeleeDpsJobs = ['PGL', 'MNK', 'LNC', 'DRG', 'ROG', 'NIN', 'SAM'];
-const kRangedDpsJobs = ['ARC', 'BRD', 'DNC', 'MCH'];
-const kCasterDpsJobs = ['BLU', 'RDM', 'BLM', 'SMN', 'ACN', 'THM'];
-const kDpsJobs = [...kMeleeDpsJobs, ...kRangedDpsJobs, ...kCasterDpsJobs];
-const kCraftingJobs = ['CRP', 'BSM', 'ARM', 'GSM', 'LTW', 'WVR', 'ALC', 'CUL'];
-const kGatheringJobs = ['MIN', 'BTN', 'FSH'];
+const Util = (() => {
+  const kTankJobs = ['GLA', 'PLD', 'MRD', 'WAR', 'DRK', 'GNB'];
+  const kHealerJobs = ['CNJ', 'WHM', 'SCH', 'AST'];
+  const kMeleeDpsJobs = ['PGL', 'MNK', 'LNC', 'DRG', 'ROG', 'NIN', 'SAM'];
+  const kRangedDpsJobs = ['ARC', 'BRD', 'DNC', 'MCH'];
+  const kCasterDpsJobs = ['BLU', 'RDM', 'BLM', 'SMN', 'ACN', 'THM'];
+  const kDpsJobs = [...kMeleeDpsJobs, ...kRangedDpsJobs, ...kCasterDpsJobs];
+  const kCraftingJobs = ['CRP', 'BSM', 'ARM', 'GSM', 'LTW', 'WVR', 'ALC', 'CUL'];
+  const kGatheringJobs = ['MIN', 'BTN', 'FSH'];
 
-const kStunJobs = ['BLU', ...kTankJobs, ...kMeleeDpsJobs];
-const kSilenceJobs = ['BLU', ...kTankJobs, ...kRangedDpsJobs];
-const kSleepJobs = ['BLM', 'BLU', ...kHealerJobs];
-const kFeintJobs = [...kMeleeDpsJobs];
-const kAddleJobs = [...kCasterDpsJobs];
-const kCleanseJobs = ['BLU', 'BRD', ...kHealerJobs];
-const kAllRoles = ['tank', 'healer', 'dps', 'crafter', 'gatherer', 'none'];
+  const kStunJobs = ['BLU', ...kTankJobs, ...kMeleeDpsJobs];
+  const kSilenceJobs = ['BLU', ...kTankJobs, ...kRangedDpsJobs];
+  const kSleepJobs = ['BLM', 'BLU', ...kHealerJobs];
+  const kFeintJobs = [...kMeleeDpsJobs];
+  const kAddleJobs = [...kCasterDpsJobs];
+  const kCleanseJobs = ['BLU', 'BRD', ...kHealerJobs];
+  const kAllRoles = ['tank', 'healer', 'dps', 'crafter', 'gatherer', 'none'];
 
-const kJobEnumToName = {
-  0: 'NONE',
-  1: 'GLA',
-  2: 'PGL',
-  3: 'MRD',
-  4: 'LNC',
-  5: 'ARC',
-  6: 'CNJ',
-  7: 'THM',
-  8: 'CRP',
-  9: 'BSM',
-  10: 'ARM',
-  11: 'GSM',
-  12: 'LTW',
-  13: 'WVR',
-  14: 'ALC',
-  15: 'CUL',
-  16: 'MIN',
-  17: 'BTN',
-  18: 'FSH',
-  19: 'PLD',
-  20: 'MNK',
-  21: 'WAR',
-  22: 'DRG',
-  23: 'BRD',
-  24: 'WHM',
-  25: 'BLM',
-  26: 'ACN',
-  27: 'SMN',
-  28: 'SCH',
-  29: 'ROG',
-  30: 'NIN',
-  31: 'MCH',
-  32: 'DRK',
-  33: 'AST',
-  34: 'SAM',
-  35: 'RDM',
-  36: 'BLU',
-  37: 'GNB',
-  38: 'DNC',
-};
+  const kJobEnumToName = {
+    0: 'NONE',
+    1: 'GLA',
+    2: 'PGL',
+    3: 'MRD',
+    4: 'LNC',
+    5: 'ARC',
+    6: 'CNJ',
+    7: 'THM',
+    8: 'CRP',
+    9: 'BSM',
+    10: 'ARM',
+    11: 'GSM',
+    12: 'LTW',
+    13: 'WVR',
+    14: 'ALC',
+    15: 'CUL',
+    16: 'MIN',
+    17: 'BTN',
+    18: 'FSH',
+    19: 'PLD',
+    20: 'MNK',
+    21: 'WAR',
+    22: 'DRG',
+    23: 'BRD',
+    24: 'WHM',
+    25: 'BLM',
+    26: 'ACN',
+    27: 'SMN',
+    28: 'SCH',
+    29: 'ROG',
+    30: 'NIN',
+    31: 'MCH',
+    32: 'DRK',
+    33: 'AST',
+    34: 'SAM',
+    35: 'RDM',
+    36: 'BLU',
+    37: 'GNB',
+    38: 'DNC',
+  };
 
-const jobToRoleMap = (() => {
-  const addToMap = (map, keys, value) => keys.forEach((key) => map.set(key, value));
+  const jobToRoleMap = (() => {
+    const addToMap = (map, keys, value) => keys.forEach((key) => map.set(key, value));
 
-  const map = new Map([['NONE', 'none']]);
-  addToMap(map, kTankJobs, 'tank');
-  addToMap(map, kHealerJobs, 'healer');
-  addToMap(map, kDpsJobs, 'dps');
-  addToMap(map, kCraftingJobs, 'crafter');
-  addToMap(map, kGatheringJobs, 'gatherer');
+    const map = new Map([['NONE', 'none']]);
+    addToMap(map, kTankJobs, 'tank');
+    addToMap(map, kHealerJobs, 'healer');
+    addToMap(map, kDpsJobs, 'dps');
+    addToMap(map, kCraftingJobs, 'crafter');
+    addToMap(map, kGatheringJobs, 'gatherer');
 
-  return new Proxy(map, {
-    get: function(target, element) {
-      if (target.has(element))
-        return target.get(element);
-      console.log(`Unknown job role ${element}`);
-      return '';
+    return new Proxy(map, {
+      get: function(target, element) {
+        if (target.has(element))
+          return target.get(element);
+        console.log(`Unknown job role ${element}`);
+        return '';
+      },
+    });
+  })();
+
+  return {
+    jobEnumToJob: (id) => kJobEnumToName[id],
+    jobToJobEnum: (job) => Object.keys(kJobEnumToName).find((k) => kJobEnumToName[k] === job),
+    jobToRole: (job) => jobToRoleMap[job],
+    getAllRoles: () => kAllRoles,
+    isTankJob: (job) => kTankJobs.includes(job),
+    isHealerJob: (job) => kHealerJobs.includes(job),
+    isMeleeDpsJob: (job) => kMeleeDpsJobs.includes(job),
+    isRangedDpsJob: (job) => kRangedDpsJobs.includes(job),
+    isCasterDpsJob: (job) => kCasterDpsJobs.includes(job),
+    isDpsJob: (job) => kDpsJobs.includes(job),
+    isCraftingJob: (job) => kCraftingJobs.includes(job),
+    isGatheringJob: (job) => kGatheringJobs.includes(job),
+    isCombatJob: function(job) {
+      return !this.isCraftingJob(job) && !this.isGatheringJob(job);
     },
-  });
+    canStun: (job) => kStunJobs.includes(job),
+    canSilence: (job) => kSilenceJobs.includes(job),
+    canSleep: (job) => kSleepJobs.includes(job),
+    canCleanse: (job) => kCleanseJobs.includes(job),
+    canFeint: (job) => kFeintJobs.includes(job),
+    canAddle: (job) => kAddleJobs.includes(job),
+  };
 })();
-
-const Util = {
-  jobEnumToJob: (id) => kJobEnumToName[id],
-  jobToJobEnum: (job) => Object.keys(kJobEnumToName).find((k) => kJobEnumToName[k] === job),
-  jobToRole: (job) => jobToRoleMap[job],
-  isTankJob: (job) => kTankJobs.includes(job),
-  isHealerJob: (job) => kHealerJobs.includes(job),
-  isMeleeDpsJob: (job) => kMeleeDpsJobs.includes(job),
-  isRangedDpsJob: (job) => kRangedDpsJobs.includes(job),
-  isCasterDpsJob: (job) => kCasterDpsJobs.includes(job),
-  isDpsJob: (job) => kDpsJobs.includes(job),
-  isCraftingJob: (job) => kCraftingJobs.includes(job),
-  isGatheringJob: (job) => kGatheringJobs.includes(job),
-  canStun: (job) => kStunJobs.includes(job),
-  canSilence: (job) => kSilenceJobs.includes(job),
-  canSleep: (job) => kSleepJobs.includes(job),
-  canCleanse: (job) => kCleanseJobs.includes(job),
-  canFeint: (job) => kFeintJobs.includes(job),
-  canAddle: (job) => kAddleJobs.includes(job),
-};
 
 (function() {
   // Exit early if running within Node

--- a/resources/party.js
+++ b/resources/party.js
@@ -22,7 +22,7 @@ class PartyTracker {
 
     // role -> [names] but only for party
     this.roleToPartyNames_ = {};
-    for (const role of kAllRoles)
+    for (const role of Util.getAllRoles())
       this.roleToPartyNames_[role] = [];
 
     for (const p of e.party) {

--- a/test/unittests/common_test.js
+++ b/test/unittests/common_test.js
@@ -21,6 +21,7 @@ const jobs = (() => {
   const meleeDpsJobs = ['PGL', 'MNK', 'LNC', 'DRG', 'ROG', 'NIN', 'SAM'];
   const rangedDpsJobs = ['ARC', 'BRD', 'DNC', 'MCH'];
   const casterDpsJobs = ['BLU', 'RDM', 'BLM', 'SMN', 'ACN', 'THM'];
+  const dpsJobs = [...meleeDpsJobs, ...rangedDpsJobs, ...casterDpsJobs];
   const craftingJobs = ['CRP', 'BSM', 'ARM', 'GSM', 'LTW', 'WVR', 'ALC', 'CUL'];
   const gatheringJobs = ['MIN', 'BTN', 'FSH'];
 
@@ -67,6 +68,10 @@ let tests = {
   },
   jobToRoleMapTest: () => {
     jobs.forEach((job) => assert(job.role === Util.jobToRole(job.name)));
+  },
+  isCombatJobTest: () => {
+    jobs.filter((job) => ['tank', 'healer', 'dps'].includes(job.role)).forEach((job) => assert(Util.isCombatJob(job.name)));
+    jobs.filter((job) => ['crafter', 'gatherer'].includes(job.role)).forEach((job) => assert(!Util.isCombatJob(job.name)));
   },
 };
 

--- a/ui/dps/dps_common.js
+++ b/ui/dps/dps_common.js
@@ -57,7 +57,7 @@ function InitDpsModule(updateFunc, hideFunc) {
     if (job == gCurrentJob)
       return;
     gCurrentJob = job;
-    if (!kCraftingJobs.includes(job) && !kGatheringJobs.includes(job)) {
+    if (Util.isCombatJob(job)) {
       gIgnoreCurrentJob = false;
       return;
     }


### PR DESCRIPTION
Hide data lists for Util, only exposing the functions as defined in the object returned.

Any remaining reliance on the actual lists themselves being exposed has been updated to be a function instead.