### PR TITLE
jobs: Remove spare css in WHM UI #1806

### DIFF
--- a/ui/jobs/jobs.css
+++ b/ui/jobs/jobs.css
@@ -113,7 +113,6 @@
   height: 10px;
 }
 
-.whm #hp-bar,
 .drk #hp-bar,
 .pld #hp-bar,
 .blu #hp-bar {


### PR DESCRIPTION
I errorly add a whm hp bar style in whm UI #1806   because of my personal change.
Remove it here.