### PR TITLE
jobs: Hide UI except hp/mp bar in pvp zone

### DIFF
--- a/ui/jobs/jobs.html
+++ b/ui/jobs/jobs.html
@@ -16,6 +16,7 @@
   <script src="../../resources/user_config.js"></script>
   <script src="../../resources/translations.js"></script>
   <script src="../../resources/zone_info.js"></script>
+  <script src="../../resources/zone_id.js"></script>
 
   <link rel="stylesheet" href="jobs.css">
   <script src="jobs.js"></script>

--- a/ui/jobs/jobs.js
+++ b/ui/jobs/jobs.js
@@ -1078,7 +1078,7 @@ class Bars {
     this.abilityFuncMap = {};
 
     this.contentType = 0;
-    this.isPVPZone = false;
+    this.notPVPZone = true;
     this.crafting = false;
 
     const lang = this.options.ParserLanguage;
@@ -1108,13 +1108,16 @@ class Bars {
     ];
   }
 
-  uiDisplay(options) {
+  UpdateUIVisibility(visible) {
     const bars = document.getElementById('bars');
     if (bars) {
       const barList = bars.children;
       for (const bar of barList) {
         if (bar.id === 'hp-bar' || bar.id === 'mp-bar') continue;
-        bar.style.display = options;
+        if (visible === true)
+          bar.style.display = '';
+        if (visible === false)
+          bar.style.display = 'none'
       }
     }
   }
@@ -1328,10 +1331,7 @@ class Bars {
     this.UpdateJobBarGCDs();
 
     // Hide UI except HP and MP bar if in pvp area.
-    if (this.isPVPZone === true)
-      this.uiDisplay('none');
-    else
-      this.uiDisplay('');
+    this.UpdateUIVisibility(this.notPVPZone);
   }
 
   validateKeys() {
@@ -2804,18 +2804,15 @@ class Bars {
     for (const func of this.changeZoneFuncs)
       func(e);
 
-    this.isPVPZone = false;
+    this.notPVPZone = true;
     if (zoneInfo) {
       // 6 => pvp content, 250 => Wolves' Den Pier
       if (zoneInfo.contentType === 6 || e.zoneID === 250)
-        this.isPVPZone = true;
+        this.notPVPZone = false;
     }
 
     // Hide UI except HP and MP bar if change to pvp area.
-    if (this.isPVPZone === true)
-      this.uiDisplay('none');
-    else
-      this.uiDisplay('');
+    this.UpdateUIVisibility(this.notPVPZone);
   }
 
   SetPullCountdown(seconds) {

--- a/ui/jobs/jobs.js
+++ b/ui/jobs/jobs.js
@@ -1078,7 +1078,7 @@ class Bars {
     this.abilityFuncMap = {};
 
     this.contentType = 0;
-    this.notPVPZone = true;
+    this.isPVPZone = false;
     this.crafting = false;
 
     const lang = this.options.ParserLanguage;
@@ -1108,16 +1108,16 @@ class Bars {
     ];
   }
 
-  UpdateUIVisibility(visible) {
+  UpdateUIVisibility() {
     const bars = document.getElementById('bars');
     if (bars) {
       const barList = bars.children;
       for (const bar of barList) {
         if (bar.id === 'hp-bar' || bar.id === 'mp-bar') continue;
-        if (visible === true)
-          bar.style.display = '';
-        if (visible === false)
+        if (this.isPVPZone === true)
           bar.style.display = 'none';
+        else
+          bar.style.display = '';
       }
     }
   }
@@ -1331,7 +1331,7 @@ class Bars {
     this.UpdateJobBarGCDs();
 
     // Hide UI except HP and MP bar if in pvp area.
-    this.UpdateUIVisibility(this.notPVPZone);
+    this.UpdateUIVisibility();
   }
 
   validateKeys() {
@@ -2804,15 +2804,15 @@ class Bars {
     for (const func of this.changeZoneFuncs)
       func(e);
 
-    this.notPVPZone = true;
+    this.isPVPZone = false;
     if (zoneInfo) {
       // 6 => pvp content, 250 => Wolves' Den Pier
       if (zoneInfo.contentType === 6 || e.zoneID === 250)
-        this.notPVPZone = false;
+        this.isPVPZone = true;
     }
 
     // Hide UI except HP and MP bar if change to pvp area.
-    this.UpdateUIVisibility(this.notPVPZone);
+    this.UpdateUIVisibility();
   }
 
   SetPullCountdown(seconds) {

--- a/ui/jobs/jobs.js
+++ b/ui/jobs/jobs.js
@@ -1078,7 +1078,7 @@ class Bars {
     this.abilityFuncMap = {};
 
     this.contentType = 0;
-
+    this.isPVPZone = 0;
     this.crafting = false;
 
     const lang = this.options.ParserLanguage;
@@ -1106,6 +1106,17 @@ class Bars {
       trialCraftingFailRegex,
       trialCraftingCancelRegex,
     ];
+  }
+
+  uiDisplay(options) {
+    const bars = document.getElementById('bars');
+    if (bars) {
+      const barList = bars.children;
+      for (const bar of barList) {
+        if (bar.id == 'hp-bar' || bar.id == 'mp-bar') continue;
+        bar.style.display = options;
+      }
+    }
   }
 
   UpdateJob() {
@@ -1315,6 +1326,12 @@ class Bars {
     // Many jobs use the gcd to calculate thresholds and value scaling.
     // Run this initially to set those values.
     this.UpdateJobBarGCDs();
+
+    // Hide UI except HP and MP bar if in pvp area.
+    if (this.isPVPZone == 1)
+      this.uiDisplay('none');
+    else
+      this.uiDisplay('');
   }
 
   validateKeys() {
@@ -2786,6 +2803,19 @@ class Bars {
 
     for (const func of this.changeZoneFuncs)
       func(e);
+
+    this.isPVPZone = 0;
+    if (zoneInfo) {
+      // 6 => pvp content, 250 => Wolves' Den Pier
+      if (zoneInfo.contentType == 6 || e.zoneID == 250)
+        this.isPVPZone = 1;
+    }
+
+    // Hide UI except HP and MP bar if change to pvp area.
+    if (this.isPVPZone == 1)
+      this.uiDisplay('none');
+    else
+      this.uiDisplay('');
   }
 
   SetPullCountdown(seconds) {

--- a/ui/jobs/jobs.js
+++ b/ui/jobs/jobs.js
@@ -1078,7 +1078,7 @@ class Bars {
     this.abilityFuncMap = {};
 
     this.contentType = 0;
-    this.isPVPZone = 0;
+    this.isPVPZone = false;
     this.crafting = false;
 
     const lang = this.options.ParserLanguage;
@@ -1328,7 +1328,7 @@ class Bars {
     this.UpdateJobBarGCDs();
 
     // Hide UI except HP and MP bar if in pvp area.
-    if (this.isPVPZone == 1)
+    if (this.isPVPZone == true)
       this.uiDisplay('none');
     else
       this.uiDisplay('');
@@ -2804,15 +2804,15 @@ class Bars {
     for (const func of this.changeZoneFuncs)
       func(e);
 
-    this.isPVPZone = 0;
+    this.isPVPZone = false;
     if (zoneInfo) {
       // 6 => pvp content, 250 => Wolves' Den Pier
       if (zoneInfo.contentType == 6 || e.zoneID == 250)
-        this.isPVPZone = 1;
+        this.isPVPZone = true;
     }
 
     // Hide UI except HP and MP bar if change to pvp area.
-    if (this.isPVPZone == 1)
+    if (this.isPVPZone == true)
       this.uiDisplay('none');
     else
       this.uiDisplay('');

--- a/ui/jobs/jobs.js
+++ b/ui/jobs/jobs.js
@@ -2806,7 +2806,6 @@ class Bars {
 
     this.isPVPZone = false;
     if (zoneInfo) {
-      // 6 => pvp content, 250 => Wolves' Den Pier
       if (zoneInfo.contentType === ContentType.Pvp || e.zoneID === ZoneId.WolvesDenPier)
         this.isPVPZone = true;
     }

--- a/ui/jobs/jobs.js
+++ b/ui/jobs/jobs.js
@@ -2807,7 +2807,7 @@ class Bars {
     this.isPVPZone = false;
     if (zoneInfo) {
       // 6 => pvp content, 250 => Wolves' Den Pier
-      if (zoneInfo.contentType === 6 || e.zoneID === 250)
+      if (zoneInfo.contentType === ContentType.Pvp || e.zoneID === ZoneId.WolvesDenPier)
         this.isPVPZone = true;
     }
 

--- a/ui/jobs/jobs.js
+++ b/ui/jobs/jobs.js
@@ -1117,7 +1117,7 @@ class Bars {
         if (visible === true)
           bar.style.display = '';
         if (visible === false)
-          bar.style.display = 'none'
+          bar.style.display = 'none';
       }
     }
   }

--- a/ui/jobs/jobs.js
+++ b/ui/jobs/jobs.js
@@ -1113,7 +1113,7 @@ class Bars {
     if (bars) {
       const barList = bars.children;
       for (const bar of barList) {
-        if (bar.id == 'hp-bar' || bar.id == 'mp-bar') continue;
+        if (bar.id === 'hp-bar' || bar.id === 'mp-bar') continue;
         bar.style.display = options;
       }
     }
@@ -1328,7 +1328,7 @@ class Bars {
     this.UpdateJobBarGCDs();
 
     // Hide UI except HP and MP bar if in pvp area.
-    if (this.isPVPZone == true)
+    if (this.isPVPZone === true)
       this.uiDisplay('none');
     else
       this.uiDisplay('');
@@ -2807,12 +2807,12 @@ class Bars {
     this.isPVPZone = false;
     if (zoneInfo) {
       // 6 => pvp content, 250 => Wolves' Den Pier
-      if (zoneInfo.contentType == 6 || e.zoneID == 250)
+      if (zoneInfo.contentType === 6 || e.zoneID === 250)
         this.isPVPZone = true;
     }
 
     // Hide UI except HP and MP bar if change to pvp area.
-    if (this.isPVPZone == true)
+    if (this.isPVPZone === true)
       this.uiDisplay('none');
     else
       this.uiDisplay('');


### PR DESCRIPTION
As once discussed in issue #1672 also closes #1672  
Early return from `UpdateJob()` meet some error on zone change, so just hide them.
Seems calling `UpdateJob()` in `OnChangeZone(e)` will cause something wrong.