### PR TITLE
Raidboss: O12S minor timeline fix

### DIFF
--- a/ui/raidboss/data/04-sb/raid/o12s.txt
+++ b/ui/raidboss/data/04-sb/raid/o12s.txt
@@ -29,7 +29,7 @@ hideall "--sync--"
 102.6 "Subject Simulation M" sync /:Omega-M:32F4:/ window 53.5
 114.1 "Electric Slide" sync /:Omega:3354:/
 122.7 "Discharger + Bladework" sync /:Omega:3327:/
-132.0 "Firewall" sync /:Omega:3339:/
+132.0 "Firewall" sync /:Omega:3339:/ window 132.0
 141.2 "Resonance" sync /:Omega:333B:/
 155.6 "Fundamental Synergy" sync /:Omega:333D:/
 

--- a/ui/raidboss/data/04-sb/raid/o12s.txt
+++ b/ui/raidboss/data/04-sb/raid/o12s.txt
@@ -26,7 +26,7 @@ hideall "--sync--"
 90.5 "Optimized Fire III" sync /:Omega-F:3337:/
 
 # Twin phase
-102.6 "Subject Simulation M" sync /:Omega-M:32F4:/
+102.6 "Subject Simulation M" sync /:Omega-M:32F4:/ window 53.5
 114.1 "Electric Slide" sync /:Omega:3354:/
 122.7 "Discharger + Bladework" sync /:Omega:3327:/
 132.0 "Firewall" sync /:Omega:3339:/


### PR DESCRIPTION
With modern unsynced DPS output, it's possible to enter the duo phase well before the developers intended us to. These windows ensure that the raidboss timeline will always be at the correct place.

(Strictly speaking only the Firewall sync is necessary, but it's nice to have the non-targetable intermission displayed too.)