### PR TITLE
raidboss: add gatherer diadem support + multiple zoneId

### DIFF
--- a/ui/oopsyraidsy/oopsyraidsy.js
+++ b/ui/oopsyraidsy/oopsyraidsy.js
@@ -1098,7 +1098,7 @@ class DamageTracker {
 
     for (const set of this.triggerSets) {
       if ('zoneId' in set) {
-        if (set.zoneId !== ZoneId.MatchAll && set.zoneId !== this.zoneId)
+        if (set.zoneId !== ZoneId.MatchAll && set.zoneId !== this.zoneId && !(typeof set.zoneId == 'object' && set.zoneId.includes(this.zoneId)))
           continue;
       } else if ('zoneRegex' in set) {
         const zoneError = (s) => {

--- a/ui/raidboss/data/05-shb/etc/the_diadem.js
+++ b/ui/raidboss/data/05-shb/etc/the_diadem.js
@@ -1,0 +1,40 @@
+'use strict';
+
+[{
+  zoneId: ZoneId.TheDiadem,
+  resetWhenOutOfCombat: false,
+  triggers: [
+    {
+      id: 'Diadem Falling Asleep',
+      netRegex: NetRegexes.gameLog({ line: '7 minutes have elapsed since your last activity..*?', capture: false }),
+      netRegexDe: NetRegexes.gameLog({ line: 'Seit deiner letzten Aktivität sind 7 Minuten vergangen..*?', capture: false }),
+      netRegexFr: NetRegexes.gameLog({ line: 'Votre personnage est inactif depuis 7 minutes.*?', capture: false }),
+      netRegexCn: NetRegexes.gameLog({ line: '已经7分钟没有进行任何操作.*?', capture: false }),
+      netRegexKo: NetRegexes.gameLog({ line: '7분 동안 아무 조작을 하지 않았습니다..*?', capture: false }),
+      alarmText: {
+        en: 'WAKE UP',
+        de: 'AUFWACHEN',
+        fr: 'RÉVEILLES-TOI',
+        ja: '目を覚めて',
+        cn: '醒醒！动一动！！',
+        ko: '강제 퇴장 3분 전',
+      },
+    },
+    {
+      id: 'Diadem Found Gather Point',
+      netRegex: NetRegexes.gameLog({ line: 'I don\'t know in English.*?', capture: false }),
+      netRegexKo: NetRegexes.gameLog({ line: '(동|서|남|북)+쪽에 레벨 80 환상의 (광맥|바위터|성목|약초밭)(이|가) 있습니다!.*?', capture: false }),
+      alertText: {
+        ko: '환상의 광맥/성목 발견',
+      },
+    },
+    {
+      id: 'Diadem Flag Alert',
+      netRegex: NetRegexes.gameLog({ line: '.*\ue0bbThe Diadem *?', capture: false }),
+      netRegexKo: NetRegexes.gameLog({ line: '.*\ue0bb디아뎀 제도 .*?', capture: false }),
+      infoText: {
+        ko: '디아뎀 좌표 채팅 올라옴',
+      },
+    },
+  ],
+}];

--- a/ui/raidboss/data/05-shb/etc/the_diadem.js
+++ b/ui/raidboss/data/05-shb/etc/the_diadem.js
@@ -22,9 +22,10 @@
     },
     {
       id: 'Diadem Found Gather Point',
-      netRegex: NetRegexes.gameLog({ line: 'I don\'t know in English.*?', capture: false }),
-      netRegexKo: NetRegexes.gameLog({ line: '(동|서|남|북)+쪽에 레벨 80 환상의 (광맥|바위터|성목|약초밭)(이|가) 있습니다!.*?', capture: false }),
+      netRegex: NetRegexes.gameLog({ line: 'You sense a grade .* clouded (?:mineral deposit|rocky outcrop|mature tree|lush vegetation patch).*?', capture: false }),
+      netRegexKo: NetRegexes.gameLog({ line: '(?:동|서|남|북)+쪽에 레벨 80 환상의 (?:광맥|바위터|성목|약초밭)(?:이|가) 있습니다!.*?', capture: false }),
       alertText: {
+        en: 'Found clouded gather point',
         ko: '환상의 광맥/성목 발견',
       },
     },
@@ -33,6 +34,7 @@
       netRegex: NetRegexes.gameLog({ line: '.*\ue0bbThe Diadem *?', capture: false }),
       netRegexKo: NetRegexes.gameLog({ line: '.*\ue0bb디아뎀 제도 .*?', capture: false }),
       infoText: {
+        en: 'Check coordinate on chat',
         ko: '디아뎀 좌표 채팅 올라옴',
       },
     },

--- a/ui/raidboss/data/05-shb/etc/the_diadem.js
+++ b/ui/raidboss/data/05-shb/etc/the_diadem.js
@@ -1,7 +1,7 @@
 'use strict';
 
 [{
-  zoneId: ZoneId.TheDiadem,
+  zoneId: [ZoneId.TheDiadem, ZoneId.TheDiadem521],
   resetWhenOutOfCombat: false,
   triggers: [
     {

--- a/ui/raidboss/data/manifest.txt
+++ b/ui/raidboss/data/manifest.txt
@@ -106,6 +106,7 @@
 04-sb/eureka/eureka_hydatos.txt
 04-sb/eureka/eureka_pagos.js
 04-sb/eureka/eureka_pyros.js
+05-shb/etc/the_diadem.js
 04-sb/raid/o10n.js
 04-sb/raid/o10n.txt
 04-sb/raid/o10s.js

--- a/ui/raidboss/data/manifest.txt
+++ b/ui/raidboss/data/manifest.txt
@@ -106,7 +106,6 @@
 04-sb/eureka/eureka_hydatos.txt
 04-sb/eureka/eureka_pagos.js
 04-sb/eureka/eureka_pyros.js
-05-shb/etc/the_diadem.js
 04-sb/raid/o10n.js
 04-sb/raid/o10n.txt
 04-sb/raid/o10s.js
@@ -204,6 +203,7 @@
 05-shb/dungeon/the_grand_cosmos.txt
 05-shb/dungeon/twinning.js
 05-shb/dungeon/twinning.txt
+05-shb/etc/the_diadem.js
 05-shb/raid/e1n.js
 05-shb/raid/e1n.txt
 05-shb/raid/e1s.js

--- a/ui/raidboss/popup-text.js
+++ b/ui/raidboss/popup-text.js
@@ -235,7 +235,7 @@ class PopupText {
       }
 
       if (set.zoneId) {
-        if (set.zoneId !== ZoneId.MatchAll && set.zoneId !== this.zoneId)
+        if (set.zoneId !== ZoneId.MatchAll && set.zoneId !== this.zoneId && !(typeof set.zoneId == 'object' && set.zoneId.includes(this.zoneId)))
           continue;
       } else if (set.zoneRegex) {
         let zoneRegex = set.zoneRegex;

--- a/util/gen_zone_id_and_info.py
+++ b/util/gen_zone_id_and_info.py
@@ -18,6 +18,7 @@ _CONTENT_TYPE_OUTPUT_FILE = "content_type.js"
 
 # name_key to territory_id mappings for locations with conflicts
 known_ids = {
+    "TheDiadem521": 901,
     "TheDiadem": 929,
 }
 

--- a/util/gen_zone_id_and_info.py
+++ b/util/gen_zone_id_and_info.py
@@ -18,7 +18,6 @@ _CONTENT_TYPE_OUTPUT_FILE = "content_type.js"
 
 # name_key to territory_id mappings for locations with conflicts
 known_ids = {
-    "TheDiadem521": 901,
     "TheDiadem": 929,
 }
 


### PR DESCRIPTION
I added gatherer diadem thing in raidboss, it's not actually raid thing though.

`Diadem Falling Asleep` same as eureka's one, but this is 7 minutes alert, not 5 minute. I think 7 minute is better for eureka, too.
`Diadem Found Gather Point` I don't know expression for English. I tried to alert rare gather points founds.
`Diadem Flag Alert`, show infoText, when \<flag\> on diadem was on chat.

## About some `npm run test` errors
### the_diadem.js: id prefix 'Diadem F' is not a full word, must end in a space

I guess this error is thinking that `Diadem F` is prefix, but it's not.

### Found inconsistent capturing groups between languages for trigger id 'Diadem Found Gather Point'.

I don't know what's the problem.

## English translation
`netRegex` is needed, so I just added `I don\'t know in English` there. I need English expression for that. I don't know how to say this in English, you can see these gather points in [garland bell](https://garlandtools.org/bell/) (No Diadem points though.)