### PR TITLE
responses: Korean better translation for "move"

### DIFF
--- a/resources/responses.js
+++ b/resources/responses.js
@@ -876,7 +876,7 @@ let Responses = {
     return obj;
   },
   moveAround: (sev) => {
-    // to avoid bllizard
+    // should jump or move
     let obj = {};
     obj[defaultInfoText(sev)] = {
       en: 'Move!',

--- a/resources/responses.js
+++ b/resources/responses.js
@@ -856,7 +856,7 @@ let Responses = {
       fr: 'Bougez !',
       ja: '動く！',
       cn: '快动！',
-      ko: '움직이기!',
+      ko: '이동하기!',
     };
     return obj;
   },

--- a/resources/responses.js
+++ b/resources/responses.js
@@ -278,7 +278,7 @@ let Responses = {
     };
     return obj;
   },
-  stack: (sev) => {
+  stackMarker: (sev) => {
     // for stack marker
     let obj = {};
     obj[defaultAlertText(sev)] = {
@@ -304,7 +304,7 @@ let Responses = {
     };
     return obj;
   },
-  stackOn: (sev) => {
+  stackMarkerOn: (sev) => {
     let obj = {};
     obj[defaultAlertText(sev)] = (data, matches) => {
       let target = getTarget(matches);

--- a/resources/responses.js
+++ b/resources/responses.js
@@ -848,7 +848,7 @@ let Responses = {
     };
     return obj;
   },
-  move: (sev) => {
+  moveAway: (sev) => {
     let obj = {};
     obj[defaultInfoText(sev)] = {
       en: 'Move!',
@@ -857,6 +857,18 @@ let Responses = {
       ja: '動く！',
       cn: '快动！',
       ko: '이동하기!',
+    };
+    return obj;
+  },
+  moveAround: (sev) => {
+    let obj = {};
+    obj[defaultInfoText(sev)] = {
+      en: 'Move!',
+      de: 'Bewegen!',
+      fr: 'Bougez !',
+      ja: '動く！',
+      cn: '快动！',
+      ko: '움직이기!',
     };
     return obj;
   },

--- a/resources/responses.js
+++ b/resources/responses.js
@@ -849,6 +849,7 @@ let Responses = {
     return obj;
   },
   moveAway: (sev) => {
+    // to dodge aoes
     let obj = {};
     obj[defaultInfoText(sev)] = {
       en: 'Move!',
@@ -861,6 +862,7 @@ let Responses = {
     return obj;
   },
   moveAround: (sev) => {
+    // to avoid bllizard
     let obj = {};
     obj[defaultInfoText(sev)] = {
       en: 'Move!',

--- a/resources/responses.js
+++ b/resources/responses.js
@@ -279,6 +279,7 @@ let Responses = {
     return obj;
   },
   stack: (sev) => {
+    // for stack marker
     let obj = {};
     obj[defaultAlertText(sev)] = {
       en: 'Stack',
@@ -286,7 +287,20 @@ let Responses = {
       fr: 'Packez-vous',
       ja: 'スタック',
       cn: '集合',
-      ko: '집합',
+      ko: '쉐어뎀',
+    };
+    return obj;
+  },
+  getTogether: (sev) => {
+    // for getting together without stack marker
+    let obj = {};
+    obj[defaultAlertText(sev)] = {
+      en: 'Stack',
+      de: 'Sammeln',
+      fr: 'Packez-vous',
+      ja: 'スタック',
+      cn: '集合',
+      ko: '모이기',
     };
     return obj;
   },

--- a/ui/raidboss/data/02-arr/raid/t11.js
+++ b/ui/raidboss/data/02-arr/raid/t11.js
@@ -67,7 +67,7 @@
       condition: function(data) {
         return !data.firstSeed;
       },
-      response: Responses.stack(),
+      response: Responses.stackMarker(),
       run: function(data) {
         delete data.firstSeed;
       },

--- a/ui/raidboss/data/02-arr/raid/t8.js
+++ b/ui/raidboss/data/02-arr/raid/t8.js
@@ -7,7 +7,7 @@
     {
       id: 'T8 Stack',
       netRegex: NetRegexes.headMarker({ id: '0011' }),
-      response: Responses.stackOn('info'),
+      response: Responses.stackMarkerOn('info'),
     },
     {
       id: 'T8 Landmine Start',

--- a/ui/raidboss/data/03-hw/alliance/dun_scaith.js
+++ b/ui/raidboss/data/03-hw/alliance/dun_scaith.js
@@ -18,7 +18,7 @@
     {
       id: 'Dun Scaith Generic Stack-up',
       netRegex: NetRegexes.headMarker({ id: '003E' }),
-      response: Responses.stackOn(),
+      response: Responses.stackMarkerOn(),
     },
     // DEATHGAZE
     {
@@ -598,7 +598,7 @@
       // This is the tank version of the stack marker. It has minimal circular bordering
       id: 'Dun Scaith Blindside',
       netRegex: NetRegexes.headMarker({ id: '005D' }),
-      response: Responses.stackOn(),
+      response: Responses.stackMarkerOn(),
     },
     {
       id: 'Dun Scaith Earth Shaker',

--- a/ui/raidboss/data/03-hw/alliance/weeping_city.js
+++ b/ui/raidboss/data/03-hw/alliance/weeping_city.js
@@ -114,7 +114,7 @@
       condition: function(data) {
         return data.arachneStarted;
       },
-      response: Responses.stackOn(),
+      response: Responses.stackMarkerOn(),
     },
     {
       id: 'Weeping City Frond Affeared',
@@ -322,7 +322,7 @@
         return data.ozmaStarted;
       },
       suppressSeconds: 5,
-      response: Responses.stack(),
+      response: Responses.stackMarker(),
     },
     {
       // Coif Change is always followed up shortly by Haircut.

--- a/ui/raidboss/data/03-hw/dungeon/aetherochemical_research_facility.js
+++ b/ui/raidboss/data/03-hw/dungeon/aetherochemical_research_facility.js
@@ -59,7 +59,7 @@
         // Tanks technically shouldn't assist with this mechanic
         return data.role != 'tank';
       },
-      response: Responses.stackOn(),
+      response: Responses.stackMarkerOn(),
     },
     {
       id: 'Facility Dark Orb',

--- a/ui/raidboss/data/03-hw/dungeon/sohm_al.js
+++ b/ui/raidboss/data/03-hw/dungeon/sohm_al.js
@@ -7,7 +7,7 @@
     {
       id: 'Sohm Al Myath Stack',
       netRegex: NetRegexes.headMarker({ id: '0017' }),
-      response: Responses.stackOn(),
+      response: Responses.stackMarkerOn(),
     },
     {
       id: 'Sohm Al Myath Spread',

--- a/ui/raidboss/data/03-hw/raid/a12s.js
+++ b/ui/raidboss/data/03-hw/raid/a12s.js
@@ -101,7 +101,7 @@
     {
       id: 'A12S Incinerating Heat',
       netRegex: NetRegexes.headMarker({ id: '003E' }),
-      response: Responses.stackOn(),
+      response: Responses.stackMarkerOn(),
     },
     {
       id: 'A12S Laser Sacrament',

--- a/ui/raidboss/data/03-hw/raid/a5s.js
+++ b/ui/raidboss/data/03-hw/raid/a5s.js
@@ -88,7 +88,7 @@ let bombLocation = (matches) => {
     {
       id: 'A5S Gobcut Stack',
       netRegex: NetRegexes.headMarker({ id: '003E' }),
-      response: Responses.stackOn('alert'),
+      response: Responses.stackMarkerOn('alert'),
     },
     {
       id: 'A5S Concussion',

--- a/ui/raidboss/data/03-hw/raid/a8n.js
+++ b/ui/raidboss/data/03-hw/raid/a8n.js
@@ -207,7 +207,7 @@
       id: 'A8N Long Needle Party',
       netRegex: NetRegexes.headMarker({ id: '003E' }),
       condition: (data) => !(data.me === data.bruteTank && data.bruteTankOut),
-      response: Responses.stackOn(),
+      response: Responses.stackMarkerOn(),
     },
     {
       id: 'A8N Long Needle Active Tank',

--- a/ui/raidboss/data/03-hw/raid/a9s.js
+++ b/ui/raidboss/data/03-hw/raid/a9s.js
@@ -203,7 +203,7 @@
       netRegex: NetRegexes.headMarker({ id: '003E' }),
       // TODO: dubious to tell the person tanking to do it here.
       // But maybe fine to inform.
-      response: Responses.stackOn(),
+      response: Responses.stackMarkerOn(),
     },
     {
       id: 'A9S Spread',

--- a/ui/raidboss/data/04-sb/alliance/orbonne_monastery.js
+++ b/ui/raidboss/data/04-sb/alliance/orbonne_monastery.js
@@ -497,7 +497,7 @@
       id: 'Orbonne Cid Hallowed Bolt Stack',
       netRegex: NetRegexes.headMarker({ id: '003E', capture: false }),
       suppressSeconds: 10,
-      response: Responses.stack(),
+      response: Responses.stackMarker(),
     },
     {
       id: 'Orbonne Cid Divine Ruination',

--- a/ui/raidboss/data/04-sb/alliance/ridorana_lighthouse.js
+++ b/ui/raidboss/data/04-sb/alliance/ridorana_lighthouse.js
@@ -225,7 +225,7 @@
       condition: function(data) {
         return !data.accelerateSpreadOnMe;
       },
-      response: Responses.stackOn(),
+      response: Responses.stackMarkerOn(),
     },
     {
       id: 'Ridorana Construct Accelerate Cleanup',

--- a/ui/raidboss/data/04-sb/dungeon/temple_of_the_fist.js
+++ b/ui/raidboss/data/04-sb/dungeon/temple_of_the_fist.js
@@ -204,7 +204,7 @@
       netRegexJa: NetRegexes.startsUsing({ id: '1FEE', source: '双豹のイヴォン' }),
       netRegexCn: NetRegexes.startsUsing({ id: '1FEE', source: '双豹伊沃恩' }),
       netRegexKo: NetRegexes.startsUsing({ id: '1FEE', source: '쌍표범 이본' }),
-      response: Responses.stackOn(),
+      response: Responses.stackMarkerOn(),
     },
   ],
   timelineReplace: [

--- a/ui/raidboss/data/04-sb/eureka/eureka_anemos.js
+++ b/ui/raidboss/data/04-sb/eureka/eureka_anemos.js
@@ -37,7 +37,7 @@
       netRegexJa: NetRegexes.startsUsing({ id: '29EB', source: '賞金首：サボテンダー・コリード' }),
       netRegexCn: NetRegexes.startsUsing({ id: '29EB', source: '悬赏魔物：科里多仙人刺' }),
       netRegexKo: NetRegexes.startsUsing({ id: '29EB', source: '현상수배: 사보텐더 코리도' }),
-      response: Responses.stackOn(),
+      response: Responses.stackMarkerOn(),
     },
     {
       id: 'Eureka Poly Swipe',

--- a/ui/raidboss/data/04-sb/raid/o12s.js
+++ b/ui/raidboss/data/04-sb/raid/o12s.js
@@ -145,7 +145,7 @@
         return !data.isFinalOmega;
       },
       suppressSeconds: 1,
-      response: Responses.stack('info'),
+      response: Responses.stackMarker('info'),
     },
     {
       id: 'O12S Optimized Meteor',
@@ -505,7 +505,7 @@
       condition: function(data, matches) {
         return data.isFinalOmega && matches.target == data.me;
       },
-      response: Responses.stackOn('info'),
+      response: Responses.stackMarkerOn('info'),
     },
     {
       id: 'O12S Archive All Spread Marker',

--- a/ui/raidboss/data/04-sb/raid/o1n.js
+++ b/ui/raidboss/data/04-sb/raid/o1n.js
@@ -24,7 +24,7 @@
       netRegexJa: NetRegexes.startsUsing({ id: '23E1', source: 'アルテ・ロイテ' }),
       netRegexCn: NetRegexes.startsUsing({ id: '23E1', source: '老者' }),
       netRegexKo: NetRegexes.startsUsing({ id: '23E1', source: '알테 로이테' }),
-      response: Responses.stackOn(),
+      response: Responses.stackMarkerOn(),
     },
     {
       id: 'O1N Breath Wing',

--- a/ui/raidboss/data/04-sb/raid/o1s.js
+++ b/ui/raidboss/data/04-sb/raid/o1s.js
@@ -13,7 +13,7 @@
       netRegexJa: NetRegexes.startsUsing({ id: '1EDD', source: 'アルテ・ロイテ', capture: false }),
       netRegexCn: NetRegexes.startsUsing({ id: '1EDD', source: '老者', capture: false }),
       netRegexKo: NetRegexes.startsUsing({ id: '1EDD', source: '알테 로이테', capture: false }),
-      response: Responses.stack(),
+      response: Responses.stackMarker(),
     },
     {
       id: 'O1S Breath Wing',

--- a/ui/raidboss/data/04-sb/raid/o3n.js
+++ b/ui/raidboss/data/04-sb/raid/o3n.js
@@ -114,7 +114,7 @@
         data.holyCounter = data.holyCounter || 0;
         return (data.holyCounter % 2 == 0);
       },
-      response: Responses.stackOn(),
+      response: Responses.stackMarkerOn(),
       run: function(data) {
         data.holyCounter += 1;
         delete data.holyTargets;

--- a/ui/raidboss/data/04-sb/raid/o3s.js
+++ b/ui/raidboss/data/04-sb/raid/o3s.js
@@ -281,7 +281,7 @@
       netRegexJa: NetRegexes.startsUsing({ id: '22F9', source: 'ハリカルナッソス', capture: false }),
       netRegexCn: NetRegexes.startsUsing({ id: '22F9', source: '哈利卡纳苏斯', capture: false }),
       netRegexKo: NetRegexes.startsUsing({ id: '22F9', source: '할리카르나소스', capture: false }),
-      response: Responses.stack(),
+      response: Responses.getTogether(),
     },
     {
       id: 'O3S Squelch',

--- a/ui/raidboss/data/04-sb/raid/o4n.js
+++ b/ui/raidboss/data/04-sb/raid/o4n.js
@@ -161,7 +161,7 @@
     {
       id: 'O4N Holy',
       netRegex: NetRegexes.headMarker({ id: '003E' }),
-      response: Responses.stackOn(),
+      response: Responses.stackMarkerOn(),
     },
     {
       id: 'O4N Meteor',

--- a/ui/raidboss/data/04-sb/raid/o4s.js
+++ b/ui/raidboss/data/04-sb/raid/o4s.js
@@ -976,7 +976,7 @@
       netRegexJa: NetRegexes.startsUsing({ id: '241E', source: 'ネオエクスデス', capture: false }),
       netRegexCn: NetRegexes.startsUsing({ id: '241E', source: '新生艾克斯迪司', capture: false }),
       netRegexKo: NetRegexes.startsUsing({ id: '241E', source: '네오 엑스데스', capture: false }),
-      response: Responses.stack(),
+      response: Responses.stackMarker(),
     },
     {
       id: 'O4S Neo Almagest',

--- a/ui/raidboss/data/04-sb/raid/o4s.js
+++ b/ui/raidboss/data/04-sb/raid/o4s.js
@@ -126,7 +126,7 @@
       netRegexJa: NetRegexes.startsUsing({ id: '23FC', source: 'エクスデス', capture: false }),
       netRegexCn: NetRegexes.startsUsing({ id: '23FC', source: '艾克斯迪司', capture: false }),
       netRegexKo: NetRegexes.startsUsing({ id: '23FC', source: '엑스데스', capture: false }),
-      response: Responses.move(),
+      response: Responses.moveAround(),
     },
     {
       // Thunder III after Decisive Battle.

--- a/ui/raidboss/data/04-sb/raid/o8n.js
+++ b/ui/raidboss/data/04-sb/raid/o8n.js
@@ -163,7 +163,7 @@
     {
       id: 'O8N Flagrant Fire Stack',
       netRegex: NetRegexes.headMarker({ id: '003E' }),
-      response: Responses.stackOn(),
+      response: Responses.stackMarkerOn(),
     },
     {
       id: 'O8N Thrumming Thunder Real',

--- a/ui/raidboss/data/04-sb/trial/rathalos-ex.js
+++ b/ui/raidboss/data/04-sb/trial/rathalos-ex.js
@@ -75,7 +75,7 @@
     {
       id: 'RathEx Fireball',
       netRegex: NetRegexes.headMarker({ id: ['0084', '005D'] }),
-      response: Responses.stackOn(),
+      response: Responses.stackMarkerOn(),
     },
     {
       id: 'RathEx Adds',

--- a/ui/raidboss/data/04-sb/trial/tsukuyomi-ex.js
+++ b/ui/raidboss/data/04-sb/trial/tsukuyomi-ex.js
@@ -13,7 +13,7 @@
       netRegexJa: NetRegexes.startsUsing({ id: '2BBC', source: 'ツクヨミ', capture: false }),
       netRegexCn: NetRegexes.startsUsing({ id: '2BBC', source: '月读', capture: false }),
       netRegexKo: NetRegexes.startsUsing({ id: '2BBC', source: '츠쿠요미', capture: false }),
-      response: Responses.stack(),
+      response: Responses.stackMarker(),
     },
     {
       id: 'Tsukuyomi Nightfall Spear',
@@ -183,7 +183,7 @@
     {
       id: 'Tsukuyomi Lunacy',
       netRegex: NetRegexes.headMarker({ id: '003E', capture: false }),
-      response: Responses.stack(),
+      response: Responses.stackMarker(),
     },
     {
       id: 'Tsukuyomi Hagetsu',

--- a/ui/raidboss/data/05-shb/alliance/the_copied_factory.js
+++ b/ui/raidboss/data/05-shb/alliance/the_copied_factory.js
@@ -245,7 +245,7 @@
       netRegexFr: NetRegexes.startsUsing({ id: '4807', source: 'Hobbes', capture: false }),
       netRegexJa: NetRegexes.startsUsing({ id: '4807', source: 'ホッブス', capture: false }),
       netRegexKo: NetRegexes.startsUsing({ id: '4807', source: '홉스', capture: false }),
-      response: Responses.stack(),
+      response: Responses.stackMarker(),
     },
     {
       id: 'Copied Hobbes Electric Floor',
@@ -723,7 +723,7 @@
       netRegexJa: NetRegexes.startsUsing({ id: '48F3', source: '９Ｓ：多脚戦車従属', capture: false }),
       netRegexKo: NetRegexes.startsUsing({ id: '48F3', source: '9S: 다각전차 종속', capture: false }),
       suppressSeconds: 2,
-      response: Responses.stack('info'),
+      response: Responses.stackMarker('info'),
     },
     {
       id: 'Copied 9S Bubble',

--- a/ui/raidboss/data/05-shb/alliance/the_puppets_bunker.js
+++ b/ui/raidboss/data/05-shb/alliance/the_puppets_bunker.js
@@ -384,7 +384,7 @@
       netRegexJa: NetRegexes.startsUsing({ source: '９０５Ｐ：重陸戦ユニット装備', id: '5086', capture: false }),
       delaySeconds: 5.3,
       suppressSeconds: 5,
-      response: Responses.move('info'),
+      response: Responses.moveAway('info'),
     },
     {
       id: 'Puppet Heavy Unconventional Voltage',

--- a/ui/raidboss/data/05-shb/alliance/the_puppets_bunker.js
+++ b/ui/raidboss/data/05-shb/alliance/the_puppets_bunker.js
@@ -112,7 +112,7 @@
       netRegexDe: NetRegexes.startsUsing({ source: '813P: Bollwerk', id: '508F', capture: false }),
       netRegexFr: NetRegexes.startsUsing({ source: '813P : Avec Unité Rempart', id: '508F', capture: false }),
       netRegexJa: NetRegexes.startsUsing({ source: '８１３Ｐ：拠点防衛ユニット装備', id: '508F', capture: false }),
-      response: Responses.stack(),
+      response: Responses.stackMarker(),
     },
     {
       id: 'Puppet Aegis Life\'s Last Song',
@@ -591,7 +591,7 @@
       id: 'Puppet Compound 2P Three Parts Disdain',
       netRegex: NetRegexes.headMarker({ id: '003E' }),
       condition: (data) => data.phase === 'compound',
-      response: Responses.stackOn(),
+      response: Responses.stackMarkerOn(),
     },
     {
       id: 'Puppet Compound 2P Three Parts Disdain Knockback',

--- a/ui/raidboss/data/05-shb/dungeon/anamnesis_anyder.js
+++ b/ui/raidboss/data/05-shb/dungeon/anamnesis_anyder.js
@@ -111,7 +111,7 @@
     {
       id: 'AnAnyder Open Hearth Flying Fount',
       netRegex: NetRegexes.headMarker({ id: '003E' }),
-      response: Responses.stackOn(),
+      response: Responses.stackMarkerOn(),
     },
     {
       id: 'AnAnyder Bonebreaker',

--- a/ui/raidboss/data/05-shb/dungeon/dohn_mheg.js
+++ b/ui/raidboss/data/05-shb/dungeon/dohn_mheg.js
@@ -100,7 +100,7 @@
     {
       id: 'Dohn Mheg Leap Stack',
       netRegex: NetRegexes.headMarker({ id: '003E' }),
-      response: Responses.stackOn(),
+      response: Responses.stackMarkerOn(),
     },
     {
       id: 'Dohn Mheg Timber',

--- a/ui/raidboss/data/05-shb/dungeon/holminster_switch.js
+++ b/ui/raidboss/data/05-shb/dungeon/holminster_switch.js
@@ -69,7 +69,7 @@
     {
       id: 'Holminster Exorcise Stack',
       netRegex: NetRegexes.headMarker({ id: '003E' }),
-      response: Responses.stackOn(),
+      response: Responses.stackMarkerOn(),
     },
     {
       id: 'Holminster Scavenger',

--- a/ui/raidboss/data/05-shb/dungeon/malikahs_well.js
+++ b/ui/raidboss/data/05-shb/dungeon/malikahs_well.js
@@ -20,7 +20,7 @@
     {
       id: 'Malikah Head Toss Stack',
       netRegex: NetRegexes.headMarker({ id: '003E' }),
-      response: Responses.stackOn(),
+      response: Responses.stackMarkerOn(),
     },
     {
       id: 'Malikah Right Round',

--- a/ui/raidboss/data/05-shb/dungeon/qitana_ravel.js
+++ b/ui/raidboss/data/05-shb/dungeon/qitana_ravel.js
@@ -189,7 +189,7 @@
     {
       id: 'Qitana Confession of Faith Stack',
       netRegex: NetRegexes.headMarker({ id: '003E' }),
-      response: Responses.stackOn('alert'),
+      response: Responses.stackMarkerOn('alert'),
     },
     {
       id: 'Qitana Confession of Faith Spread',

--- a/ui/raidboss/data/05-shb/dungeon/the_grand_cosmos.js
+++ b/ui/raidboss/data/05-shb/dungeon/the_grand_cosmos.js
@@ -20,7 +20,7 @@
     {
       id: 'Cosmos Dark Pulse',
       netRegex: NetRegexes.headMarker({ id: '003E' }),
-      response: Responses.stackOn('info'),
+      response: Responses.stackMarkerOn('info'),
     },
     {
       id: 'Cosmos Dark Well Far Winds',

--- a/ui/raidboss/data/05-shb/dungeon/twinning.js
+++ b/ui/raidboss/data/05-shb/dungeon/twinning.js
@@ -83,7 +83,7 @@
     {
       id: 'Twinning Charge Eradicated',
       netRegex: NetRegexes.headMarker({ id: '005D' }),
-      response: Responses.stackOn(),
+      response: Responses.stackMarkerOn(),
     },
     {
       id: 'Twinning Thunder Beam',

--- a/ui/raidboss/data/05-shb/raid/e2n.js
+++ b/ui/raidboss/data/05-shb/raid/e2n.js
@@ -108,7 +108,7 @@
     {
       id: 'E2N Unholy Darkness No Waiting',
       netRegex: NetRegexes.headMarker({ id: '003E' }),
-      response: Responses.stackOn(),
+      response: Responses.stackMarkerOn(),
     },
     {
       id: 'E2N Shadoweye No Waiting',
@@ -194,7 +194,7 @@
           return false;
         return data.spell[matches.target] == 'stack';
       },
-      response: Responses.stackOn(),
+      response: Responses.stackMarkerOn(),
     },
     {
       id: 'E2N Shadoweye Collect',

--- a/ui/raidboss/data/05-shb/raid/e2s.js
+++ b/ui/raidboss/data/05-shb/raid/e2s.js
@@ -189,7 +189,7 @@
       condition: function(data) {
         return !data.waiting;
       },
-      response: Responses.stackOn(),
+      response: Responses.stackMarkerOn(),
     },
     {
       id: 'E2S Unholy Darkness Collect',
@@ -223,7 +223,7 @@
       condition: function(data, matches) {
         return !data.hellWind && data.spell[matches.target] == 'stack';
       },
-      response: Responses.stackOn(),
+      response: Responses.stackMarkerOn(),
     },
     {
       id: 'E2S Dark Fire No Waiting',

--- a/ui/raidboss/data/05-shb/raid/e3n.js
+++ b/ui/raidboss/data/05-shb/raid/e3n.js
@@ -123,7 +123,7 @@
       // Crashing Pulse and Smothering Waters
       id: 'E3N Stack',
       netRegex: NetRegexes.headMarker({ id: '003E' }),
-      response: Responses.stackOn(),
+      response: Responses.stackMarkerOn(),
     },
     {
       id: 'E3N Surging Waters Marker',

--- a/ui/raidboss/data/05-shb/raid/e3s.js
+++ b/ui/raidboss/data/05-shb/raid/e3s.js
@@ -430,7 +430,7 @@
         return parseFloat(matches.duration) - 3;
       },
       suppressSeconds: 1,
-      response: Responses.stack(),
+      response: Responses.stackMarker(),
     },
     {
       id: 'E3S Scouring Waters',

--- a/ui/raidboss/data/05-shb/raid/e4s.js
+++ b/ui/raidboss/data/05-shb/raid/e4s.js
@@ -95,7 +95,7 @@
       condition: function(data, matches) {
         return data.me == matches.target;
       },
-      response: Responses.stack(),
+      response: Responses.stackMarker(),
     },
     {
       id: 'E4S Voice of the Land',

--- a/ui/raidboss/data/05-shb/raid/e5s.js
+++ b/ui/raidboss/data/05-shb/raid/e5s.js
@@ -205,7 +205,7 @@
         return !data.furysBoltActive;
       },
       delaySeconds: 3,
-      response: Responses.move('alarm'),
+      response: Responses.moveAway('alarm'),
     },
     {
       id: 'E5S Stepped Leader Cast',

--- a/ui/raidboss/data/05-shb/raid/e7s.js
+++ b/ui/raidboss/data/05-shb/raid/e7s.js
@@ -423,7 +423,7 @@
             },
           };
         }
-        return Responses.stackOn();
+        return Responses.stackMarkerOn();
       },
     },
     {

--- a/ui/raidboss/data/05-shb/raid/e8s.js
+++ b/ui/raidboss/data/05-shb/raid/e8s.js
@@ -557,7 +557,7 @@
       netRegexJa: NetRegexes.ability({ source: 'シヴァ', id: '4DD2', capture: false }),
       netRegexCn: NetRegexes.ability({ source: '希瓦', id: '4DD2', capture: false }),
       netRegexKo: NetRegexes.ability({ source: '시바', id: '4DD2', capture: false }),
-      response: Responses.move('alert'),
+      response: Responses.moveAway('alert'),
     },
     {
       id: 'E8S Reflected Drachen Armor',
@@ -567,7 +567,7 @@
       netRegexJa: NetRegexes.ability({ source: '氷面鏡', id: '4DC2', capture: false }),
       netRegexCn: NetRegexes.ability({ source: '冰面镜', id: '4DC2', capture: false }),
       netRegexKo: NetRegexes.ability({ source: '얼음 거울', id: '4DC2', capture: false }),
-      response: Responses.move('alert'),
+      response: Responses.moveAway('alert'),
     },
     {
       id: 'E8S Holy',

--- a/ui/raidboss/data/05-shb/raid/e8s.js
+++ b/ui/raidboss/data/05-shb/raid/e8s.js
@@ -329,7 +329,7 @@
       netRegexJa: NetRegexes.startsUsing({ source: 'シヴァ', id: '4D80', capture: false }),
       netRegexCn: NetRegexes.startsUsing({ source: '希瓦', id: '4D80', capture: false }),
       netRegexKo: NetRegexes.startsUsing({ source: '시바', id: '4D80', capture: false }),
-      response: Responses.stack('info'),
+      response: Responses.stackMarker('info'),
     },
     {
       id: 'E8S Banish III Divided',

--- a/ui/raidboss/data/05-shb/trial/hades-ex.js
+++ b/ui/raidboss/data/05-shb/trial/hades-ex.js
@@ -53,7 +53,7 @@
       netRegexJa: NetRegexes.startsUsing({ id: '47A8', source: 'ハーデス', capture: false }),
       netRegexKo: NetRegexes.startsUsing({ id: '47A8', source: '하데스', capture: false }),
       delaySeconds: 5.5,
-      response: Responses.move('alert'),
+      response: Responses.moveAway('alert'),
     },
     {
       id: 'HadesEx Ravenous Assault',

--- a/ui/raidboss/data/05-shb/trial/hades.js
+++ b/ui/raidboss/data/05-shb/trial/hades.js
@@ -327,7 +327,7 @@
       condition: function(data, matches) {
         return data.me == matches.target;
       },
-      response: Responses.stackOn(),
+      response: Responses.stackMarkerOn(),
     },
     {
       id: 'Hades Ancient Collect',

--- a/ui/raidboss/data/05-shb/trial/ruby_weapon-ex.js
+++ b/ui/raidboss/data/05-shb/trial/ruby_weapon-ex.js
@@ -121,7 +121,7 @@
       netRegexCn: NetRegexes.startsUsing({ source: '红宝石神兵', id: '4AD8' }),
       netRegexKo: NetRegexes.startsUsing({ source: '루비 웨폰', id: '4AD8' }),
       condition: Conditions.targetIsYou(),
-      response: Responses.stackOn('alert'),
+      response: Responses.stackMarkerOn('alert'),
     },
     {
       id: 'RubyEx High-Powered Homing Lasers',
@@ -132,7 +132,7 @@
       netRegexCn: NetRegexes.startsUsing({ source: '红宝石神兵', id: '4AD8' }),
       netRegexKo: NetRegexes.startsUsing({ source: '루비 웨폰', id: '4AD8' }),
       condition: Conditions.targetIsNotYou(),
-      response: Responses.stack('info'),
+      response: Responses.stackMarker('info'),
     },
     {
       id: 'RubyEx Raven\'s Image',

--- a/ui/raidboss/data/05-shb/trial/ruby_weapon.js
+++ b/ui/raidboss/data/05-shb/trial/ruby_weapon.js
@@ -111,7 +111,7 @@
       netRegexCn: NetRegexes.startsUsing({ source: '红宝石神兵', id: '4AC5' }),
       netRegexKo: NetRegexes.startsUsing({ source: '루비 웨폰', id: '4AC5' }),
       condition: Conditions.targetIsYou(),
-      response: Responses.stackOn('alert'),
+      response: Responses.stackMarkerOn('alert'),
     },
     {
       id: 'Ruby High-Powered Homing Lasers',
@@ -122,7 +122,7 @@
       netRegexCn: NetRegexes.startsUsing({ source: '红宝石神兵', id: '4AC5' }),
       netRegexKo: NetRegexes.startsUsing({ source: '루비 웨폰', id: '4AC5' }),
       condition: Conditions.targetIsNotYou(),
-      response: Responses.stack('info'),
+      response: Responses.stackMarker('info'),
     },
     {
       id: 'Ruby Dynamics',

--- a/ui/raidboss/data/05-shb/trial/titania-ex.js
+++ b/ui/raidboss/data/05-shb/trial/titania-ex.js
@@ -150,7 +150,7 @@
       netRegexCn: NetRegexes.startsUsing({ id: '42D7', source: '缇坦妮雅', capture: false }),
       netRegexKo: NetRegexes.startsUsing({ id: '42D7', source: '티타니아', capture: false }),
       delaySeconds: 3,
-      response: Responses.move('alert'),
+      response: Responses.moveAway('alert'),
     },
     {
       id: 'TitaniaEx Bramble Knockback',

--- a/ui/raidboss/data/05-shb/trial/titania.js
+++ b/ui/raidboss/data/05-shb/trial/titania.js
@@ -168,7 +168,7 @@
     {
       id: 'Titania Pucks Breath Markers',
       netRegex: NetRegexes.headMarker({ id: '00A1' }),
-      response: Responses.stackOn(),
+      response: Responses.stackMarkerOn(),
     },
     {
       id: 'Titania Knockback',

--- a/ui/raidboss/data/05-shb/trial/varis-ex.js
+++ b/ui/raidboss/data/05-shb/trial/varis-ex.js
@@ -59,7 +59,7 @@
             },
           };
         }
-        return Responses.stack('alert');
+        return Responses.stackMarker('alert');
       },
     },
     {
@@ -332,7 +332,7 @@
       netRegexFr: NetRegexes.startsUsing({ source: 'bouclier-canon', id: '4E4F', capture: false }),
       netRegexJa: NetRegexes.startsUsing({ source: 'ガンシールド', id: '4E4F', capture: false }),
       netRegexCn: NetRegexes.startsUsing({ source: '枪盾', id: '4E4F', capture: false }),
-      response: Responses.stack('info'),
+      response: Responses.stackMarker('info'),
     },
     {
       id: 'VarisEx Magitek Spark',

--- a/ui/raidboss/data/05-shb/trial/wol-ex.js
+++ b/ui/raidboss/data/05-shb/trial/wol-ex.js
@@ -505,7 +505,7 @@ const translate = (data, obj) => {
       netRegex: NetRegexes.headMarker({ id: '00A1', capture: false }),
       condition: (data) => data.ultimateSeen && data.ninja || data.isAddPhase,
       suppressSeconds: 2,
-      response: Responses.stack(),
+      response: Responses.stackMarker(),
     },
     {
       id: 'WOLEx Perfect Decimation',
@@ -553,7 +553,7 @@ const translate = (data, obj) => {
       id: 'WOLEx Absolute Holy',
       netRegex: NetRegexes.headMarker({ id: '00A1' }),
       condition: (data) => !data.deluge && !data.ninja && !data.isAddPhase,
-      response: Responses.stackOn(),
+      response: Responses.stackMarkerOn(),
     },
     {
       id: 'WOLEx Coruscant Saber Out',

--- a/ui/raidboss/data/05-shb/trial/wol.js
+++ b/ui/raidboss/data/05-shb/trial/wol.js
@@ -265,7 +265,7 @@
       response: function(data, matches) {
         if (data.deluge === data.me)
           return;
-        return Responses.stackOn();
+        return Responses.stackMarkerOn();
       },
     },
     {

--- a/ui/raidboss/data/05-shb/trial/wol.js
+++ b/ui/raidboss/data/05-shb/trial/wol.js
@@ -77,7 +77,7 @@
       netRegexDe: NetRegexes.startsUsing({ source: 'Krieger Des Lichts', id: '4F2D', capture: false }),
       netRegexFr: NetRegexes.startsUsing({ source: 'Guerrier De La Lumière Primordial', id: '4F2D', capture: false }),
       netRegexJa: NetRegexes.startsUsing({ source: 'ウォーリア・オブ・ライト', id: '4F2D', capture: false }),
-      response: Responses.move('alert'),
+      response: Responses.moveAround('alert'),
     },
     {
       id: 'WOL Absolute Fire III',


### PR DESCRIPTION
original one, `움직이기!` is used in two triggers
changed one, `이동하기!` is used in four triggers
These two are slightly different in meaning, but if player knows mechanics in battle, they'll understand with any of which shows.

But, I have some concerns, sometimes other languages don't have exact same meaning words corresponding to English, 
which means it seems fine to use same `Responses` for multiple triggers in English, sometimes it does not in other languages.

How do we deal with it?
I already sacrificed some readability in Korean responses, it's bearable now but there can be very different meaning in Korean in the future.