### PR TITLE
add .vscode ignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .vs
+.vscode/
 **/*.suo
 bin/
 obj/


### PR DESCRIPTION
There's new vscode extension.
I think we need `.vscode/` ignore.