### PR TITLE
jobs: fix combo tracker calling callback unexpectedly

### DIFF
--- a/ui/jobs/jobs.js
+++ b/ui/jobs/jobs.js
@@ -239,8 +239,10 @@ class ComboTracker {
   }
 
   HandleAbility(id) {
-    if (id in this.considerNext)
+    if (id in this.considerNext) {
       this.StateTransition(id, this.considerNext[id]);
+      return;
+    }
 
     if (this.comboBreakers.includes(id))
       this.AbortCombo(id);
@@ -260,7 +262,9 @@ class ComboTracker {
         this.AbortCombo(null);
       }, kComboDelayMs);
     }
-    if (id)
+
+    // If not aborting, then this is a valid combo skill.
+    if (nextState !== null)
       this.callback(id);
   }
 


### PR DESCRIPTION
Pull #1825 forgot an early return if an id was handled in the state
transition.  It meant that valid ids that were both part of a combo and
treated as combo breakers (e.g. Maim) would get handled twice, causing
Maim to end the combo.

The other issue is that AbortCombo reuses StateTransition, and so
the callback should not be called in these cases.

Fixes #1845.  This is an alternative approach to #1848.