### PR TITLE
ci: Add GitHub Workflows to Release Artifacts

### DIFF
--- a/.github/workflows/create-tag.yml
+++ b/.github/workflows/create-tag.yml
@@ -1,0 +1,55 @@
+name: Create Tag
+
+on:
+  push:
+    branches:
+      - 'main'
+    paths:
+      - 'plugin/CactbotEventSource/Properties/AssemblyInfo.cs'
+      - 'plugin/CactbotOverlay/Properties/AssemblyInfo.cs'
+
+jobs:
+  create-tag:
+    runs-on: ubuntu-latest
+    if: ${{ github.repository == 'quisquous/cactbot' }}
+    env:
+      GITHUB_TOKEN: ${{ secrets.BOT_TOKEN }}
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v2
+      - name: Parse Plugin Version
+        id: parse-version
+        run: |
+          # Parse new tag from AssemblyFileVersion
+          VERSION="$(cat plugin/CactbotEventSource/Properties/AssemblyInfo.cs | sed -ne 's/.*AssemblyFileVersion.*"\([0-9]*\.[0-9]*\.[0-9]*\)\.0".*/\1/p')"
+
+          # Check both AssemblyInfo files have the correct version
+          if cat plugin/CactbotEventSource/Properties/AssemblyInfo.cs | grep -q ${VERSION} && cat plugin/CactbotOverlay/Properties/AssemblyInfo.cs | grep -q ${VERSION}; then
+            echo "::set-env name=TAG_NAME::v$VERSION"
+            echo "Matching assembly file version values found."
+          else
+            echo "Different assembly file version values found. Skipping tag creation..."
+            exit 1
+          fi
+      - name: Check Existing Tags
+        run: |
+          if ! curl -fsL https://api.github.com/repos/quisquous/cactbot/git/refs/tags/${{ env.TAG_NAME }}; then
+            echo "No existing tags for the version number exist. Creating new tag..."
+          else
+            echo "Tagged version already exists. Skipping tag creation..."
+            exit 1
+          fi
+      - name: Create Tag
+        run: |
+          # Get current commit hash
+          commit=$(git rev-parse HEAD)
+
+          # POST a new ref to repo via Github API
+          curl -s -X POST https://api.github.com/repos/quisquous/cactbot/git/refs \
+          -H "Authorization: token $GITHUB_TOKEN" \
+          -d @- << EOF
+          {
+            "ref": "refs/tags/${{ env.TAG_NAME }}",
+            "sha": "$commit"
+          }
+          EOF

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,16 @@ jobs:
         run: |
           echo ::set-env name=CACTBOT_RELEASE::cactbot-${GITHUB_REF#refs/tags/v}
         shell: bash
+      - name: Check dependencies cache
+        id: cache-dependencies
+        uses: actions/cache@v2
+        with:
+          path: ./plugin/ThirdParty
+          key: ${{ runner.os }}-cactbot-${{ hashFiles('./util/fetch_deps.py', './util/DEPS.py') }}
+          restore-keys: |
+            ${{ runner.os }}-cactbot-
       - name: Fetch Dependencies
+        if: steps.cache-dependencies.outputs.cache-hit != 'true'
         run: |
           ./util/fetch_deps.py
         shell: bash

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,65 @@
+name: Create Release Artifact
+
+on:
+  push:
+    tags:
+    - 'v*'
+
+jobs:
+  create-release:
+    runs-on: windows-latest
+    if: ${{ github.repository == 'quisquous/cactbot' }}
+    env:
+      GITHUB_TOKEN: ${{ secrets.BOT_TOKEN }}
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v2
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: '3.1.x'
+      - name: Setup Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.7'
+      # Gets the numerical output of the git tag and assigns it to an environment variable
+      - name: Get Tag Version
+        run: |
+          echo ::set-env name=CACTBOT_RELEASE::cactbot-${GITHUB_REF#refs/tags/v}
+        shell: bash
+      - name: Fetch Dependencies
+        run: |
+          ./util/fetch_deps.py
+        shell: bash
+      - name: Build Cactbot Plugin
+        run: |
+          dotnet build plugin/Cactbot.sln /p:Configuration=Release /p:Platform=x64
+      - name: Setup Staging Directory
+        run: |
+          ./util/publish.sh
+        shell: bash
+      - name: Create Release Artifact
+        run: |
+          mkdir ${{ env.CACTBOT_RELEASE }}
+          mv publish/cactbot-release/cactbot/ ${{ env.CACTBOT_RELEASE }}
+          compress-archive ${{ env.CACTBOT_RELEASE }} ${{ env.CACTBOT_RELEASE }}.zip
+        shell: pwsh
+      - name: Create Release
+        id: create_release
+        uses: actions/create-release@v1
+        with:
+          tag_name: ${{ github.ref }}
+          release_name: ${{ env.CACTBOT_RELEASE }}
+          body: |
+            Changes in this release:
+            - plugin
+            - raidboss
+          draft: true
+          prerelease: false
+      - name: Upload Release Asset
+        uses: actions/upload-release-asset@v1
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ./${{ env.CACTBOT_RELEASE }}.zip
+          asset_name: ${{ env.CACTBOT_RELEASE }}.zip
+          asset_content_type: application/zip


### PR DESCRIPTION
Add GitHub workflows to create a tag off version updates and create a
draft release off of a tag being created.