### PR TITLE
Jobs: Show HP number in Healer

### DIFF
--- a/ui/jobs/jobs.css
+++ b/ui/jobs/jobs.css
@@ -114,6 +114,9 @@
   height: 10px;
 }
 
+.whm #hp-bar,
+.sch #hp-bar,
+.ast #hp-bar,
 .drk #hp-bar,
 .pld #hp-bar,
 .blu #hp-bar {

--- a/ui/jobs/jobs.js
+++ b/ui/jobs/jobs.js
@@ -9,7 +9,7 @@ const kWellFedContentTypes = [
 
 // See user/jobs-example.js for documentation.
 let Options = {
-  ShowHPNumber: ['PLD', 'WAR', 'DRK', 'GNB', 'BLU'],
+  ShowHPNumber: ['PLD', 'WAR', 'DRK', 'GNB', 'BLU', 'AST', 'WHM', 'SCH'],
   ShowMPNumber: ['PLD', 'DRK', 'BLM', 'AST', 'WHM', 'SCH', 'BLU'],
 
   ShowMPTicker: ['BLM'],


### PR DESCRIPTION
Healer's HP is as important as Tank's.
Many times I saw healers are busy at restoring other's HP, 
but ignore their own HP is not enough and got killed in AoE, causing party wipe.
Also healer who makes barrier sometimes want to know how much damage can it nullify.
So I think it's necessary to show HP number in Healer.