### PR TITLE
Jobs: Add lucidBox for RDM

### DIFF
--- a/ui/jobs/jobs.css
+++ b/ui/jobs/jobs.css
@@ -371,6 +371,7 @@
 #ast-procs-luciddreaming,
 #sch-procs-luciddreaming,
 #whm-procs-lucid,
+#rdm-procs-lucid,
 #blm-procs-thunder,
 #blu-procs-lucid {
   position: relative;
@@ -540,6 +541,10 @@
 
 .rdm-color-black-mana.dim {
   background-color: rgb(13, 76, 80);
+}
+
+.rdm-color-lucid {
+  background-color: rgb(227, 148, 210);
 }
 
 .war-color-beast {

--- a/ui/jobs/jobs.js
+++ b/ui/jobs/jobs.js
@@ -2331,6 +2331,19 @@ class Bars {
     });
     blackProc.bigatzero = false;
 
+    let lucidBox = this.addProcBox({
+      id: 'rdm-procs-lucid',
+      fgColor: 'rdm-color-lucid',
+    });
+    this.abilityFuncMap[kAbility.LucidDreaming] = () => {
+      lucidBox.duration = 0;
+      lucidBox.duration = 60;
+    };
+    this.statChangeFuncMap['RDM'] = () => {
+      lucidBox.valuescale = this.gcdSpell();
+      lucidBox.threshold = this.gcdSpell() + 1;
+    };
+
     this.jobFuncs.push(function(jobDetail) {
       let white = jobDetail.whiteMana;
       let black = jobDetail.blackMana;


### PR DESCRIPTION
RDM's MP cost is very high compare to other magical DPS.
Add lucidBox to avoid MP insufficient when you want to cast verraise.