### PR TITLE
Jobs: Shorten lucidBox.threshold for BLU

### DIFF
--- a/ui/jobs/jobs.js
+++ b/ui/jobs/jobs.js
@@ -1715,7 +1715,7 @@ class Bars {
     this.statChangeFuncMap['BLU'] = () => {
       offguardBox.threshold = this.gcdSpell() * 2;
       tormentBox.threshold = this.gcdSpell() * 3;
-      lucidBox.threshold = this.gcdSpell() * 4;
+      lucidBox.threshold = this.gcdSpell() + 1;
     };
 
     this.abilityFuncMap[kAbility.OffGuard] = () => {


### PR DESCRIPTION
Since all lucidBox except this one use `this.gcdSpell() + 1`, and you can cast lucid at almost anytime, 4*gcd is unnecessary and may cause additional disturbtion.