### PR TITLE
doc: update cactbot-highlight url

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -108,7 +108,7 @@ as its source.
 
 #### VSCode extension for cactbot
 
-If you are using VSCode, there is an extension [cactbot-highlight](https://github.com/MaikoTan/cactbot-highlight) created by Maiko Tan,
+If you are using VSCode, there is an extension [cactbot-highlight](https://marketplace.visualstudio.com/items?itemName=MaikoTan.cactbot-highlight) created by Maiko Tan,
 providing timeline highlighting and some useful snippets.
 
 This extension is still in development, if you have any suggestions or bug reports,


### PR DESCRIPTION
cactbot-highlight is now available on Visual Studio Market,
so update the URL