### PR TITLE
raidboss: add implicit trigger overrides

### DIFF
--- a/docs/RaidbossGuide.md
+++ b/docs/RaidbossGuide.md
@@ -97,8 +97,16 @@ Boolean, defaults to true. If true, timelines and triggers will reset automatica
 ### Trigger Elements
 
 **id string**
- An id string for the trigger, used to disable triggers. Every built-in trigger that has a text/sound output should have an id so it can be disabled.
-(User-defined triggers not intended for inclusion in the cactbot repository need not have one.)
+ An id string for the trigger.
+ Every built-in trigger in cactbot has a unique id,
+ and it is recommended but not required that user triggers also have them.
+
+Trigger ids must be unique.
+If a trigger is found with the same id as a previous trigger,
+then the first trigger will be skipped entirely
+and the second trigger will override it and take its place.
+This allows easier for copying and pasting of triggers into user overrides for edits.
+Triggers without ids cannot be overridden.
 
 The current structure for `Regexes/NetRegexes` does not require that the ability/effect/whatever name be present as part of the expression.
 Because of this, it is extremely important that that information is somewhere close by.

--- a/ui/raidboss/popup-text.js
+++ b/ui/raidboss/popup-text.js
@@ -66,6 +66,46 @@ function onTriggerException(trigger, e) {
     console.error(lines[i]);
 }
 
+// Helper for handling trigger overrides.
+//
+// asList will return a list of triggers in the same order as append was called, except:
+// If a later trigger has the same id as a previous trigger, it will replace the previous trigger
+// and appear in the same order that the previous trigger appeared.
+// e.g. a, b1, c, b2 (where b1 and b2 share the same id) yields [a, b2, c] as the final list.
+//
+// JavaScript dictionaries are *almost* ordered automatically as we would want,
+// but want to handle missing ids and integer ids (you shouldn't, but just in case).
+class OrderedTriggerList {
+  constructor() {
+    this.idToIndex = {};
+    this.triggers = [];
+  }
+
+  push(trigger) {
+    if (trigger.id && trigger.id in this.idToIndex) {
+      const idx = this.idToIndex[trigger.id];
+
+      // TODO: be verbose now while this is fresh, but hide this output behind debug flags later.
+      const triggerFile = (trigger) => trigger.filename ? `'trigger.filename'` : 'user override';
+      const oldFile = triggerFile(this.triggers[idx]);
+      const newFile = triggerFile(trigger);
+      console.log(`Overriding '${trigger.id}' from ${oldFile} with ${newFile}.`);
+
+      this.triggers[idx] = trigger;
+      return;
+    }
+
+    // Normal case of a new trigger, with no overriding.
+    if (trigger.id)
+      this.idToIndex[trigger.id] = this.triggers.length;
+    this.triggers.push(trigger);
+  }
+
+  asList() {
+    return this.triggers;
+  }
+}
+
 class PopupText {
   constructor(options) {
     this.options = options;
@@ -151,7 +191,7 @@ class PopupText {
   }
 
   OnDataFilesRead(e) {
-    this.triggerSets = this.options.Triggers;
+    this.triggerSets = [];
     for (let filename in e.detail.files) {
       if (!filename.endsWith('.js'))
         continue;
@@ -181,6 +221,9 @@ class PopupText {
       }
       Array.prototype.push.apply(this.triggerSets, json);
     }
+
+    // User triggers must come last so that they override built-in files.
+    Array.prototype.push.apply(this.triggerSets, this.options.Triggers);
   }
 
   OnChangeZone(e) {
@@ -206,6 +249,9 @@ class PopupText {
     let timelineTriggers = [];
     let timelineStyles = [];
     this.resetWhenOutOfCombat = true;
+
+    const orderedTriggers = new OrderedTriggerList();
+    const orderedNetTriggers = new OrderedTriggerList();
 
     // Recursively/iteratively process timeline entries for triggers.
     // Functions get called with data, arrays get iterated, strings get appended.
@@ -287,13 +333,13 @@ class PopupText {
           let regex = trigger[regexParserLang] || trigger.regex;
           if (regex) {
             trigger.localRegex = Regexes.parse(regex);
-            this.triggers.push(trigger);
+            orderedTriggers.push(trigger);
           }
 
           let netRegex = trigger[netRegexParserLang] || trigger.netRegex;
           if (netRegex) {
             trigger.localNetRegex = Regexes.parse(netRegex);
-            this.netTriggers.push(trigger);
+            orderedNetTriggers.push(trigger);
           }
 
           if (!regex && !netRegex) {
@@ -323,6 +369,10 @@ class PopupText {
       if (set.resetWhenOutOfCombat !== undefined)
         this.resetWhenOutOfCombat &= set.resetWhenOutOfCombat;
     }
+
+    // Store all the collected triggers in order.
+    this.triggers = orderedTriggers.asList();
+    this.netTriggers = orderedNetTriggers.asList();
 
     this.timelineLoader.SetTimelines(
         timelineFiles,


### PR DESCRIPTION
Rather than adding an explicit `override` property on triggers,
this change implicitly makes all triggers with the same id override any
previously processed triggers.  For cactbot internal triggers, this
shouldn't be an issue, as all triggers must be unique.  User triggers
will be processed after internal triggers for obvious reasons.

There is a potential present hazard here that users have triggers with
ids that match existing ids, but are not meant to override that trigger,
and will be defaulted into to unexpected behavior.

There is also a future hazard, if ids ever conflict.  Cactbot internal
triggers have a unique prefix per file that will prevent this from
happening internally, but this is still a potential hazard for future
triggers (new cactbot triggers colliding with old user triggers, or
new user triggers colliding with old user triggers).

For these reasons, there's verbose logging when any trigger is
overridden.  We can relax this in the future and hide behind debug
flags, but especially as this is a breaking change it makes sense to be
loud.

Fixes #1786.