### PR TITLE
plugin: set config dir explicitly if found implicitly

### DIFF
--- a/plugin/CactbotEventSource/CactbotEventSource.cs
+++ b/plugin/CactbotEventSource/CactbotEventSource.cs
@@ -633,6 +633,11 @@ namespace Cactbot {
             local_files = null;
           }
         }
+
+        // Set any implicitly discovered cactbot user config dirs as explicit.
+        // This will help in the future when there aren't local plugins or html.
+        if (config_dir != null)
+          Config.UserConfigFile = config_dir;
       }
     }
 

--- a/plugin/CactbotEventSource/CactbotEventSource.cs
+++ b/plugin/CactbotEventSource/CactbotEventSource.cs
@@ -242,6 +242,11 @@ namespace Cactbot {
         LogInfo("System Locale: {0}", pc_locale_);
       }
 
+      // This will be set explicitly, so if it's not set now, it will be set after reloading ACT.
+      // Log this for now as there will likely be a lot of questions, re: user directories.
+      if (Config.UserConfigFile != null)
+        LogInfo("cactbot user directory: {0}", Config.UserConfigFile);
+
       // Temporarily target cn if plugin is old v2.0.4.0
       if (language_ == "cn" || ffxiv.ToString() == "2.0.4.0") {
         ffxiv_ = new FFXIVProcessCn(this);

--- a/plugin/CactbotEventSource/CactbotEventSourceConfig.cs
+++ b/plugin/CactbotEventSource/CactbotEventSourceConfig.cs
@@ -81,6 +81,18 @@ namespace Cactbot {
           return null;
         return dir.ToString();
       }
+      set {
+        if (!OverlayData.TryGetValue("options", out JToken options)) {
+          options = new JObject();
+          OverlayData.Add("options", options);
+        }
+        var general = options["general"];
+        if (general == null) {
+          general = new JObject();
+          options["general"] = general;
+        }
+        general["CactbotUserDirectory"] = value;
+      }
     }
 
     [JsonIgnore]


### PR DESCRIPTION
This is to work towards #1767, by setting the user folder directly
from any implicit values.