### PR TITLE
raidboss: allow for timeline overriding

### DIFF
--- a/docs/CactbotCustomization.md
+++ b/docs/CactbotCustomization.md
@@ -294,7 +294,43 @@ and also reading through existing triggers in [ui/raidboss/data](../ui/raidboss/
 
 ## Overriding Raidboss Timelines
 
-Sorry, this is hard to do right now.
+Overriding a raidboss timeline is similar to [overriding a trigger](#overriding-raidboss-triggers).
+
+The steps to override a timeline are:
+
+1) Copy the timeline text file out of cactbot and into your user folder
+
+  For example, you could copy [ui/raidboss/data/05-shb/ultimate/the_epic_of_alexander.txt](../ui/raidboss/data/05-shb/ultimate/the_epic_of_alexander.txt).
+
+1) Add a section to your user/raidboss.js file to override this.
+
+  Like adding a trigger, you add a section with the `zoneId`,
+  along with `overrideTimelineFile: true`,
+  and a `timelineFile` with the name of the text file.
+
+  ```javascript
+  Options.Triggers.push({
+    zoneId: ZoneId.TheEpicOfAlexanderUltimate,
+    overrideTimelineFile: true,
+    timelineFile: 'the_epic_of_alexander.txt',
+  });
+  ```
+
+  In this case, this assumes that you have followed step 1
+  and there is a `user/the_epic_of_alexander.txt` file.
+
+  By setting `overrideTimelineFile: true`,
+  it tells cactbot to replace the built-in timeline entirely
+  with any new timeline that you add.
+
+1) Edit your new timeline file in your user folder as needed
+
+  Refer to the [timeline guide](TimelineGuide.md) for more documentation on the timeline format.
+
+**Note**: Editing timelines is a bit risky,
+as there may be timeline triggers that refer to specific timeline text.
+For instance, in TEA, there are timeline triggers for `Fluid Swing` and `Propeller Wind`, etc.
+If these names are changed or removed, then the timeline triggers will also be broken.
 
 ## Customizing Behavior
 

--- a/docs/CactbotCustomization.md
+++ b/docs/CactbotCustomization.md
@@ -300,32 +300,34 @@ The steps to override a timeline are:
 
 1) Copy the timeline text file out of cactbot and into your user folder
 
-  For example, you could copy [ui/raidboss/data/05-shb/ultimate/the_epic_of_alexander.txt](../ui/raidboss/data/05-shb/ultimate/the_epic_of_alexander.txt).
+    For example, you could copy
+    [ui/raidboss/data/05-shb/ultimate/the_epic_of_alexander.txt](../ui/raidboss/data/05-shb/ultimate/the_epic_of_alexander.txt)
+    to `user/the_epic_of_alexander.txt`.
 
 1) Add a section to your user/raidboss.js file to override this.
 
-  Like adding a trigger, you add a section with the `zoneId`,
-  along with `overrideTimelineFile: true`,
-  and a `timelineFile` with the name of the text file.
+    Like adding a trigger, you add a section with the `zoneId`,
+    along with `overrideTimelineFile: true`,
+    and a `timelineFile` with the name of the text file.
 
-  ```javascript
-  Options.Triggers.push({
-    zoneId: ZoneId.TheEpicOfAlexanderUltimate,
-    overrideTimelineFile: true,
-    timelineFile: 'the_epic_of_alexander.txt',
-  });
-  ```
+    ```javascript
+    Options.Triggers.push({
+      zoneId: ZoneId.TheEpicOfAlexanderUltimate,
+      overrideTimelineFile: true,
+      timelineFile: 'the_epic_of_alexander.txt',
+    });
+    ```
 
-  In this case, this assumes that you have followed step 1
-  and there is a `user/the_epic_of_alexander.txt` file.
+    In this case, this assumes that you have followed step 1
+    and there is a `user/the_epic_of_alexander.txt` file.
 
-  By setting `overrideTimelineFile: true`,
-  it tells cactbot to replace the built-in timeline entirely
-  with any new timeline that you add.
+    By setting `overrideTimelineFile: true`,
+    it tells cactbot to replace the built-in timeline entirely
+    with any new timeline that you add.
 
 1) Edit your new timeline file in your user folder as needed
 
-  Refer to the [timeline guide](TimelineGuide.md) for more documentation on the timeline format.
+    Refer to the [timeline guide](TimelineGuide.md) for more documentation on the timeline format.
 
 **Note**: Editing timelines is a bit risky,
 as there may be timeline triggers that refer to specific timeline text.

--- a/docs/RaidbossGuide.md
+++ b/docs/RaidbossGuide.md
@@ -5,6 +5,7 @@
 ```javascript
 [{
   zoneId: ZoneId.TheWeaponsRefrainUltimate,
+  overrideTimelineFile: false,
   timelineFile: 'filename.txt',
   timeline: `hideall`,
   timelineReplace: [
@@ -47,6 +48,11 @@ A trigger set must have one of zoneId or zoneRegex to specify the zone
 **zoneRegex**
 A regular expression that matches against the zone name (coming from ACT).
 If the regular expression matches, then the triggers will apply to that zone.
+
+**overrideTimelineFile**
+An optional boolean value that specifies that the `timelineFile` and `timeline`
+specified in this trigger set override all timelines previously found.
+This is a way to replace timelines in user files and is not used inside cactbot itself.
 
 **timelineFile**
 An optional timeline file to load for this zone. These files live alongside their parent trigger file in the appropriate folder. (As for example `raidboss/data/04-sb/raid/`).

--- a/plugin/CactbotEventSource/CactbotEventSource.cs
+++ b/plugin/CactbotEventSource/CactbotEventSource.cs
@@ -596,6 +596,11 @@ namespace Cactbot {
           user_files[Path.GetFileName(filename)] = File.ReadAllText(filename) +
             $"\n//# sourceURL={filename}";
         }
+
+        var textFilenames = Directory.EnumerateFiles(path, "*.txt");
+        foreach (string filename in textFilenames) {
+          user_files[Path.GetFileName(filename)] = File.ReadAllText(filename);
+        }
       } catch (Exception e) {
         LogError("User error file exception: {0}", e.ToString());
       }

--- a/resources/user_config.js
+++ b/resources/user_config.js
@@ -2,9 +2,12 @@
 
 let UserConfig = {
   optionTemplates: {},
+  userFileCallbacks: {},
   savedConfig: null,
-  registerOptions: function(overlayName, optionTemplates) {
+  registerOptions: function(overlayName, optionTemplates, userFileCallback) {
     this.optionTemplates[overlayName] = optionTemplates;
+    if (userFileCallback)
+      this.userFileCallbacks[overlayName] = userFileCallback;
   },
 
   getUserConfigLocation: function(overlayName, options, callback) {
@@ -89,7 +92,11 @@ let UserConfig = {
         if (jsFile in localFiles) {
           try {
             printUserFile('local user file: ' + basePath + '\\' + jsFile);
-            eval(localFiles[jsFile]);
+
+            if (this.userFileCallbacks[overlayName])
+              this.userFileCallbacks[overlayName](jsFile, localFiles, options);
+            else
+              eval(localFiles[jsFile]);
           } catch (e) {
             // Be very visible for users.
             console.log('*** ERROR IN USER FILE ***');

--- a/ui/raidboss/popup-text.js
+++ b/ui/raidboss/popup-text.js
@@ -280,7 +280,7 @@ class PopupText {
         continue;
       }
       if (haveZoneId && set.zoneId === undefined) {
-        const filename = set.filename ? `'set.filename'` : '(user file)';
+        const filename = set.filename ? `'${set.filename}'` : '(user file)';
         console.error(`Trigger set has zoneId, but with nothing specified in ${filename}.  ` +
                       `Did you misspell the ZoneId.ZoneName?`);
         continue;
@@ -355,15 +355,28 @@ class PopupText {
         }
       }
 
+      if (set.overrideTimelineFile) {
+        const filename = set.filename ? `'${set.filename}'` : '(user file)';
+        console.log(`Overriding timeline from ${filename}.`);
+
+        // If the timeline file override is set, all previously loaded timeline info is dropped.
+        // Styles, triggers, and translations are kept, as they may still apply to the new one.
+        timelineFiles = [];
+        timelines = [];
+      }
+
       // And set the timeline files/timelines from each set that matches.
       if (set.timelineFile) {
         if (set.filename) {
           let dir = set.filename.substring(0, set.filename.lastIndexOf('/'));
           timelineFiles.push(dir + '/' + set.timelineFile);
         } else {
+          // Note: For user files, this should get handled by raidboss_config.js,
+          // where `timelineFile` should get converted to `timeline`.
           console.error('Can\'t specify timelineFile in non-manifest file:' + set.timelineFile);
         }
       }
+
       if (set.timeline)
         addTimeline(set.timeline);
       if (set.timelineReplace)

--- a/user/raidboss-example.js
+++ b/user/raidboss-example.js
@@ -65,6 +65,18 @@ Options.Triggers.push({
 });
 
 
+// Here's an example of overriding a timeline.
+// This overrides the test timeline that you normally play with a `/countdown 5` in Middle La Noscea
+// with an updated one from `user/test-override.txt`.
+Options.Triggers.push({
+  zoneId: ZoneId.MiddleLaNoscea,
+  // This flag is required to clear any previously specified timelines.
+  overrideTimelineFile: true,
+  // This file is in the same directory as this JavaScript file.
+  timelineFile: 'test-override.txt',
+});
+
+
 // Here's an example of a adding a custom regen trigger.
 // It reminds you to use regen again when you are in Sastasha (unsynced).
 Options.Triggers.push({

--- a/user/test-override.txt
+++ b/user/test-override.txt
@@ -1,0 +1,19 @@
+# I am but a wee little test timeline override
+#
+# This is an example of how to override your timeline.
+#
+# The original file is in:
+# https://github.com/quisquous/cactbot/blob/main/ui/raidboss/data/00-misc/test.txt
+
+0 "--Reset--" sync /You bid farewell to the striking dummy/ window 10000 jump 0
+
+0 "Engage" sync /:Engage!/ window 100000,100000
+0 "Start" sync /:You bow courteously to the striking dummy/ window 0,1
+6 "Angry Dummy II"
+10 "Long Castbar IV" duration 10
+12 "If you see this"
+13 "you have overridden"
+14 "the test timeline"
+15 "with user/raidboss.js"
+25 "Final Sting X"
+40 "Death"


### PR DESCRIPTION
* Change the plugin to also load text files.
* Change user_config.js to allow a custom user file processor.
* Add a custom user file processor to raidboss_config.js.
* In this processor, convert timeline filenames into timeline contents,
  as user-specified timeline files are not part of the data files and so
  can't be loaded by name later.
* Add a new overrideTimelineFile flag that clears previously loaded
  timeline information.
* Add documentation for all of this.