### PR TITLE
refactor(perf): change string.match to regExp.test

### DIFF
--- a/test/timeline/test_timeline.js
+++ b/test/timeline/test_timeline.js
@@ -187,7 +187,7 @@ let tests = {
       let ignore = timeline.GetMissingTranslationsToIgnore();
       let isIgnored = (x) => {
         for (let ig of ignore) {
-          if (x.match(ig))
+          if (ig.test(x))
             return true;
         }
         return false;
@@ -199,7 +199,7 @@ let tests = {
             continue;
           let matched = false;
           for (let regex in testCase.replace) {
-            if (item.match(Regexes.parse(regex))) {
+            if (Regexes.parse(regex).test(item)) {
               matched = true;
               break;
             }

--- a/ui/config/config.js
+++ b/ui/config/config.js
@@ -158,7 +158,7 @@ const fileNameToTitle = (filename) => {
   let capitalized = name.replace(/(?:^| )\w/g, (c) => c.toUpperCase());
 
   // Fully capitalize acronyms like e4n.
-  if (capitalized.match(/^\w[0-9]+\w$/))
+  if (/^\w[0-9]+\w$/.test(capitalized))
     capitalized = capitalized.toUpperCase();
 
   return capitalized;

--- a/ui/dps/xephero/dps_phase_tracker.js
+++ b/ui/dps/xephero/dps_phase_tracker.js
@@ -40,7 +40,7 @@ class DpsPhaseTracker {
   onLogEvent(logs) {
     if (!this.defaultPhase) {
       for (const log of logs) {
-        if (log.match(this.areaSealRegex) || log.includes(kTestPhaseStart)) {
+        if (this.areaSealRegex.test(log) || log.includes(kTestPhaseStart)) {
           this.defaultPhaseIdx++;
           this.defaultPhase = 'B' + this.defaultPhaseIdx;
           this.onFightPhaseStart(this.defaultPhase, this.lastData);
@@ -49,7 +49,7 @@ class DpsPhaseTracker {
       }
     } else {
       for (const log of logs) {
-        if (log.match(this.areaUnsealRegex) || log.includes(kTestPhaseEnd)) {
+        if (this.areaUnsealRegex.test(log) || log.includes(kTestPhaseEnd)) {
           this.onFightPhaseEnd(this.defaultPhase, this.lastData);
           this.defaultPhase = 0;
           return;

--- a/ui/jobs/jobs.js
+++ b/ui/jobs/jobs.js
@@ -3470,7 +3470,7 @@ class Bars {
         if (log[16] == '5' || log[16] == '6') {
           // use of GP Potion
           let cordialRegex = Regexes.ability({ source: this.me, id: '20(017FD|F5A3D|F844F|0420F|0317D)' });
-          if (log.match(cordialRegex)) {
+          if (cordialRegex.test(log)) {
             this.gpPotion = true;
             setTimeout(() => {
               this.gpPotion = false;

--- a/ui/oopsyraidsy/oopsyraidsy.js
+++ b/ui/oopsyraidsy/oopsyraidsy.js
@@ -734,9 +734,9 @@ class DamageTracker {
     const type = splitLine[0];
 
     if (type === '00') {
-      if (line.match(this.countdownEngageRegex))
+      if (this.countdownEngageRegex.test(line))
         this.collector.AddEngage();
-      if (line.match(this.countdownStartRegex) || line.match(this.countdownCancelRegex))
+      if (this.countdownStartRegex.test(line) || this.countdownCancelRegex.test(line))
         this.collector.Reset();
     } else if (type === '26') {
       this.OnEffectEvent(line);
@@ -800,7 +800,7 @@ class DamageTracker {
 
     const abilityId = matches.id;
     for (const trigger of this.abilityTriggers) {
-      if (!abilityId.match(trigger.idRegex))
+      if (!trigger.idRegex.test(abilityId))
         continue;
       if (!evt)
         evt = this.ProcessMatchesIntoEvent(line, matches);
@@ -815,7 +815,7 @@ class DamageTracker {
     // Healing?
     if (lowByte == '04') {
       for (const trigger of this.healTriggers) {
-        if (!abilityId.match(trigger.idRegex))
+        if (!trigger.idRegex.test(abilityId))
           continue;
         if (!evt)
           evt = this.ProcessMatchesIntoEvent(line, matches);
@@ -835,7 +835,7 @@ class DamageTracker {
       this.lastDamage[matches.target] = matches;
 
     for (const trigger of this.damageTriggers) {
-      if (!abilityId.match(trigger.idRegex))
+      if (!trigger.idRegex.test(abilityId))
         continue;
       if (!evt)
         evt = this.ProcessMatchesIntoEvent(line, matches);

--- a/ui/pullcounter/pullcounter.js
+++ b/ui/pullcounter/pullcounter.js
@@ -175,9 +175,9 @@ class PullCounter {
     if (this.bossStarted)
       return;
     for (const log of e.detail.logs) {
-      if (log.match(this.resetRegex))
+      if (this.resetRegex.test(log))
         this.ResetPullCounter();
-      if (log.match(this.countdownEngageRegex)) {
+      if (this.countdownEngageRegex.test(log)) {
         if (this.countdownBoss)
           this.OnFightStart(this.countdownBoss);
         else
@@ -185,7 +185,7 @@ class PullCounter {
         return;
       }
       for (const boss of this.bosses) {
-        if (boss.startRegex && log.match(boss.startRegex)) {
+        if (boss.startRegex && boss.startRegex.test(log)) {
           this.OnFightStart(boss);
           return;
         }

--- a/ui/radar/radar.js
+++ b/ui/radar/radar.js
@@ -36,7 +36,7 @@ const kMinDistanceBeforeSound = 100;
 
 let gRadar;
 
-const instanceChangedRegex = {
+const instanceChangedRegexes = {
   en: NetRegexes.gameLog({ code: '0039', line: 'You are now in the instanced area.*?' }),
   de: NetRegexes.gameLog({ code: '0039', line: 'Du bist nun in dem instanziierten Areal.*?' }),
   fr: NetRegexes.gameLog({ code: '0039', line: 'Vous êtes maintenant dans la zone instanciée.*?' }),
@@ -97,6 +97,10 @@ class Radar {
     this.monsters = Object.assign({}, gMonster, Options.CustomMonsters);
     this.lang = this.options.ParserLanguage || 'en';
     this.nameToMonster = {};
+    this.instanceChangedRegex =
+      instanceChangedRegexes[this.options.ParserLanguage] ||
+      instanceChangedRegexes['en'];
+
     for (let i in this.monsters) {
       let monster = this.monsters[i];
       let lang = this.lang || 'en';
@@ -115,7 +119,7 @@ class Radar {
   AddMonster(log, monster, matches) {
     if (monster.id && matches.npcNameId !== monster.id)
       return;
-    if (monster.regex && !log.match(monster.regex))
+    if (monster.regex && !monster.regex.test(log))
       return;
     if (monster.hp && parseFloat(matches.hp) < monster.hp)
       return;
@@ -292,8 +296,7 @@ class Radar {
 
     // change instance
     if (type === '00') {
-      const lang = this.options.ParserLanguage;
-      if (log.match(instanceChangedRegex[lang] || instanceChangedRegex['en'])) {
+      if (this.instanceChangedRegex.test(log)) {
         // don't remove mobs lasting less than 10 seconds
         this.ClearTargetMonsters(10);
       }

--- a/ui/raidboss/data/03-hw/raid/a4s.js
+++ b/ui/raidboss/data/03-hw/raid/a4s.js
@@ -6,6 +6,7 @@
   timelineTriggers: [
     {
       id: 'A4S Hydrothermal Missile',
+      regex: /Hydrothermal Missile/,
       beforeSeconds: 5,
       suppressSeconds: 5,
       response: Responses.tankCleave('info'),

--- a/ui/raidboss/timeline.js
+++ b/ui/raidboss/timeline.js
@@ -152,6 +152,20 @@ class Timeline {
 
     let uniqueid = 1;
     let texts = {};
+    const regexes = {
+      comment: /^\s*#/,
+      commentLine: /#.*$/,
+      durationCommand: /(?:[^#]*?\s)?(duration\s+([0-9]+(?:\.[0-9]+)?))(\s.*)?$/,
+      ignore: /^hideall\s+\"([^"]+)\"$/,
+      jumpCommand: /(?:[^#]*?\s)?(jump\s+([0-9]+(?:\.[0-9]+)?))(?:\s.*)?$/,
+      line: /^(([0-9]+(?:\.[0-9]+)?)\s+"(.*?)")(\s+(.*))?/,
+      popupText: /^(info|alert|alarm)text\s+\"([^"]+)\"\s+before\s+(-?[0-9]+(?:\.[0-9]+)?)(?:\s+\"([^"]+)\")?$/,
+      soundAlert: /^define\s+soundalert\s+"[^"]*"\s+"[^"]*"$/,
+      speaker: /define speaker "[^"]*"(\s+"[^"]*")?\s+(-?[0-9]+(?:\.[0-9]+)?)\s+(-?[0-9]+(?:\.[0-9]+)?)/,
+      syncCommand: /(?:[^#]*?\s)?(sync\s*\/(.*)\/)(\s.*)?$/,
+      tts: /^alertall\s+"([^"]*)"\s+before\s+(-?[0-9]+(?:\.[0-9]+)?)\s+(sound|speak\s+"[^"]*")\s+"([^"]*)"$/,
+      windowCommand: /(?:[^#]*?\s)?(window\s+(?:([0-9]+(?:\.[0-9]+)?),)?([0-9]+(?:\.[0-9]+)?))(?:\s.*)?$/,
+    };
 
     // Make all regexes case insensitive, and parse any special \y{} groups.
     if (triggers) {
@@ -167,17 +181,17 @@ class Timeline {
       let line = lines[i];
       line = line.trim();
       // Drop comments and empty lines.
-      if (!line || line.match(/^\s*#/))
+      if (!line || regexes.comment.test(line))
         continue;
       let originalLine = line;
 
-      let match = line.match(/^hideall\s+\"([^"]+)\"$/);
+      let match = line.match(regexes.ignore);
       if (match != null) {
         this.ignores[match[1]] = true;
         continue;
       }
 
-      match = line.match(/^alertall\s+"([^"]*)"\s+before\s+(-?[0-9]+(?:\.[0-9]+)?)\s+(sound|speak\s+"[^"]*")\s+"([^"]*)"$/);
+      match = line.match(regexes.tts);
       if (match != null) {
         // TODO: Support alert sounds?
         if (match[3] == 'sound')
@@ -190,14 +204,14 @@ class Timeline {
         });
         continue;
       }
-      match = line.match(/^define\s+soundalert\s+"[^"]*"\s+"[^"]*"$/);
+      match = line.match(regexes.soundAlert);
       if (match)
         continue;
-      match = line.match(/define speaker "[^"]*"(\s+"[^"]*")?\s+(-?[0-9]+(?:\.[0-9]+)?)\s+(-?[0-9]+(?:\.[0-9]+)?)/);
+      match = line.match(regexes.speaker);
       if (match)
         continue;
 
-      match = line.match(/^(info|alert|alarm)text\s+\"([^"]+)\"\s+before\s+(-?[0-9]+(?:\.[0-9]+)?)(?:\s+\"([^"]+)\")?$/);
+      match = line.match(regexes.popupText);
       if (match != null) {
         texts[match[2]] = texts[match[2]] || [];
         texts[match[2]].push({
@@ -208,7 +222,7 @@ class Timeline {
         continue;
       }
 
-      match = line.match(/^(([0-9]+(?:\.[0-9]+)?)\s+"(.*?)")(\s+(.*))?/);
+      match = line.match(regexes.line);
       if (match == null) {
         this.errors.push({
           lineNumber: lineNumber,
@@ -220,7 +234,7 @@ class Timeline {
       }
       line = line.replace(match[1], '').trim();
       // There can be # in the ability name, but probably not in the regex.
-      line = line.replace(/#.*$/, '').trim();
+      line = line.replace(regexes.commentLine, '').trim();
 
       let seconds = parseFloat(match[2]);
       let e = {
@@ -234,12 +248,12 @@ class Timeline {
         lineNumber: lineNumber,
       };
       if (line) {
-        let commandMatch = line.match(/(?:[^#]*?\s)?(duration\s+([0-9]+(?:\.[0-9]+)?))(\s.*)?$/);
+        let commandMatch = line.match(regexes.durationCommand);
         if (commandMatch) {
           line = line.replace(commandMatch[1], '').trim();
           e.duration = parseFloat(commandMatch[2]);
         }
-        commandMatch = line.match(/(?:[^#]*?\s)?(sync\s*\/(.*)\/)(\s.*)?$/);
+        commandMatch = line.match(regexes.syncCommand);
         if (commandMatch) {
           line = line.replace(commandMatch[1], '').trim();
           let sync = {
@@ -251,7 +265,7 @@ class Timeline {
             lineNumber: lineNumber,
           };
           if (commandMatch[3]) {
-            let argMatch = commandMatch[3].match(/(?:[^#]*?\s)?(window\s+(?:([0-9]+(?:\.[0-9]+)?),)?([0-9]+(?:\.[0-9]+)?))(?:\s.*)?$/);
+            let argMatch = commandMatch[3].match(regexes.windowCommand);
             if (argMatch) {
               line = line.replace(argMatch[1], '').trim();
               if (argMatch[2]) {
@@ -262,7 +276,7 @@ class Timeline {
                 sync.end = seconds + (parseFloat(argMatch[3]) / 2);
               }
             }
-            argMatch = commandMatch[3].match(/(?:[^#]*?\s)?(jump\s+([0-9]+(?:\.[0-9]+)?))(?:\s.*)?$/);
+            argMatch = commandMatch[3].match(regexes.jumpCommand);
             if (argMatch) {
               line = line.replace(argMatch[1], '').trim();
               sync.jump = parseFloat(argMatch[2]);
@@ -273,7 +287,7 @@ class Timeline {
         }
       }
       // If there's text left that isn't a comment then we didn't parse that text so report it.
-      if (line && !line.match(/^\s*#/)) {
+      if (line && !line.match(regexes.comment)) {
         console.log('Unknown content \'' + line + '\' in timeline: ' + originalLine);
         this.errors.push({
           lineNumber: lineNumber,
@@ -290,7 +304,7 @@ class Timeline {
       for (const trigger of triggers) {
         let found = false;
         for (const event of this.events) {
-          if (event.name.match(trigger.regex)) {
+          if (trigger.regex && trigger.regex.test(event.name)) {
             found = true;
             break;
           }
@@ -333,8 +347,7 @@ class Timeline {
 
       if (styles) {
         for (const style of styles) {
-          const m = e.name.match(style.regex);
-          if (!m)
+          if (!style.regex.test(e.name))
             continue;
           Object.assign(e, { style: style.style });
         }

--- a/util/find_missing_timeline_translations.js
+++ b/util/find_missing_timeline_translations.js
@@ -58,7 +58,7 @@ function findLineNumberByTriggerId(text, id) {
   for (let line of text) {
     lineNumber++;
 
-    if (line.match(regex))
+    if (regex.test(line))
       return lineNumber;
   }
 


### PR DESCRIPTION
Replace all string.match with regExp.test where applicable, also precompile regex in timeline.js `LoadFile()` since they're used in a loop which is a big performance penalty.  
Fixed a4s missing Hydrothermal Missile regex which caused the tests to fail (`!!event.name.match(undefined) === true`)

`string.match` vs `regExp.test` bench http://jsbench.github.io/#edf82fee9c75a58c7f48889ff0449453