### PR TITLE
added only-combatant option to make timeline

### DIFF
--- a/util/make_timeline.py
+++ b/util/make_timeline.py
@@ -429,14 +429,14 @@ if __name__ == "__main__":
         "--ignore-combatant",
         nargs="*",
         default=[],
-        help="Combatant names to ignore, e.g. \"Aratama Soul\"",
+        help='Combatant names to ignore, e.g. "Aratama Soul"',
     )
     parser.add_argument(
         "-oc",
         "--only-combatant",
         nargs="*",
         default=[],
-        help="Only the listed combatants will generate timeline data, e.g. \"Aratama Soul\"",
+        help='Only the listed combatants will generate timeline data, e.g. "Aratama Soul"',
     )
     parser.add_argument(
         "-p",

--- a/util/make_timeline.py
+++ b/util/make_timeline.py
@@ -436,7 +436,7 @@ if __name__ == "__main__":
         "--only-combatant",
         nargs="*",
         default=[],
-        help="Only the listed combatants will generate timeline data, e.g. \"Aratama Soul\"",
+        help="Only the listed combatants will generate timeline data, e.g. Aratama Soul",
     )
     parser.add_argument(
         "-p",

--- a/util/make_timeline.py
+++ b/util/make_timeline.py
@@ -290,7 +290,7 @@ def main(args):
             continue
 
         # if only combatants was specified and combatant not in the list
-        if args.only_combatant != [] and entry["combatant"] not in args.only_combatant:
+        if args.only_combatant and entry["combatant"] not in args.only_combatant:
             continue
 
         # Ignore aoe spam
@@ -436,7 +436,7 @@ if __name__ == "__main__":
         "--only-combatant",
         nargs="*",
         default=[],
-        help="Combatant names to only pay attantion to, e.g. Aratama Soul",
+        help="Only the listed combatants will generate timeline data, e.g. \"Aratama Soul\"",
     )
     parser.add_argument(
         "-p",

--- a/util/make_timeline.py
+++ b/util/make_timeline.py
@@ -429,14 +429,14 @@ if __name__ == "__main__":
         "--ignore-combatant",
         nargs="*",
         default=[],
-        help="Combatant names to ignore, e.g. Aratama Soul",
+        help="Combatant names to ignore, e.g. \"Aratama Soul\"",
     )
     parser.add_argument(
         "-oc",
         "--only-combatant",
         nargs="*",
         default=[],
-        help="Only the listed combatants will generate timeline data, e.g. Aratama Soul",
+        help="Only the listed combatants will generate timeline data, e.g. \"Aratama Soul\"",
     )
     parser.add_argument(
         "-p",

--- a/util/make_timeline.py
+++ b/util/make_timeline.py
@@ -428,6 +428,13 @@ if __name__ == "__main__":
         help="Combatant names to ignore, e.g. Aratama Soul",
     )
     parser.add_argument(
+        "-oc",
+        "--only-combatant",
+        nargs="*",
+        default=[],
+        help="Combatant names to only pay attantion to, e.g. Aratama Soul",
+    )
+    parser.add_argument(
         "-p",
         "--phase",
         nargs="*",

--- a/util/make_timeline.py
+++ b/util/make_timeline.py
@@ -289,6 +289,10 @@ def main(args):
         ):
             continue
 
+        # if only combatants was specified and combatant not in the list
+        if args.only_combatant != [] and entry["combatant"] not in args.only_combatant:
+            continue
+
         # Ignore aoe spam
         if entry["time"] == last_entry["time"] and entry["ability_id"] == last_entry["ability_id"]:
             continue


### PR DESCRIPTION
Making timelines for Critical engangements can be confusing with action from random mobs.
With this option you can specify the enemy you want to make a timeline around (mostly usefull in eureka and bozja)