### PR TITLE
Raidboss: O8s Futures Numbered works again

### DIFF
--- a/ui/raidboss/data/04-sb/raid/o8s.js
+++ b/ui/raidboss/data/04-sb/raid/o8s.js
@@ -113,12 +113,12 @@
     },
     {
       id: 'O8S Futures Numbered',
-      netRegex: NetRegexes.startsUsing({ id: '28EF', source: 'Kefka', capture: false }),
-      netRegexDe: NetRegexes.startsUsing({ id: '28EF', source: 'Kefka', capture: false }),
-      netRegexFr: NetRegexes.startsUsing({ id: '28EF', source: 'Kefka', capture: false }),
-      netRegexJa: NetRegexes.startsUsing({ id: '28EF', source: 'ケフカ', capture: false }),
-      netRegexCn: NetRegexes.startsUsing({ id: '28EF', source: '凯夫卡', capture: false }),
-      netRegexKo: NetRegexes.startsUsing({ id: '28EF', source: '케프카', capture: false }),
+      netRegex: NetRegexes.startsUsing({ id: '28EE', source: 'Kefka', capture: false }),
+      netRegexDe: NetRegexes.startsUsing({ id: '28EE', source: 'Kefka', capture: false }),
+      netRegexFr: NetRegexes.startsUsing({ id: '28EE', source: 'Kefka', capture: false }),
+      netRegexJa: NetRegexes.startsUsing({ id: '28EE', source: 'ケフカ', capture: false }),
+      netRegexCn: NetRegexes.startsUsing({ id: '28EE', source: '凯夫卡', capture: false }),
+      netRegexKo: NetRegexes.startsUsing({ id: '28EE', source: '케프카', capture: false }),
       alertText: {
         en: 'Future: Stack and Through',
         fr: 'Futur : Stack et traversez',


### PR DESCRIPTION
At some point during one of the many regex conversions we've done in the last three years, the ID for Futures Numbered got corrupted. Futures Numbered follows the awful "Cast one thing on self, then instantly use another thing on targets/AoEs". (Using ACT lines here since I still happen to have it open, but the network log is the same.)

```
[00:57:00.655] 14:28EE:Kefka starts using Futures Numbered on Kefka.
[00:57:05.549] 15:4001A7BF:Kefka:28EE:Futures Numbered:4001A7BF:Kefka:3C:0:1B:
[00:57:05.861] 15:4001A7BF:Kefka:28EF:Futures Numbered:E0000000::0:35374003:1B:
```
