### PR TITLE
raidboss: Update ARR Triggers Conditions

### DIFF
--- a/ui/raidboss/data/02-arr/dungeon/brayfloxs_longstop.js
+++ b/ui/raidboss/data/02-arr/dungeon/brayfloxs_longstop.js
@@ -11,9 +11,7 @@
       netRegexJa: NetRegexes.startsUsing({ id: '1FA', source: 'グレート・イエローペリカン' }),
       netRegexKo: NetRegexes.startsUsing({ id: '1FA', source: '노란 왕사다새' }),
       netRegexCn: NetRegexes.startsUsing({ id: '1FA', source: '大黄鹈鹕' }),
-      condition: function(data, matches) {
-        return data.CanStun();
-      },
+      condition: (data) => data.CanStun(),
       response: Responses.stun('info'),
     },
     {
@@ -71,9 +69,7 @@
       netRegexJa: NetRegexes.startsUsing({ id: '205', source: 'アッシュドレイク' }),
       netRegexKo: NetRegexes.startsUsing({ id: '205', source: '잿빛도마뱀' }),
       netRegexCn: NetRegexes.startsUsing({ id: '205', source: '白烬火蛟' }),
-      condition: function(data, matches) {
-        return data.CanStun();
-      },
+      condition: (data) => data.CanStun(),
       response: Responses.stun('info'),
     },
     {
@@ -90,9 +86,7 @@
       netRegexJa: NetRegexes.startsUsing({ id: '3D8', source: 'インフェルノドレイク' }),
       netRegexKo: NetRegexes.startsUsing({ id: '3D8', source: '지옥불 도마뱀' }),
       netRegexCn: NetRegexes.startsUsing({ id: '3D8', source: '狱炎火蛟' }),
-      condition: function(data, matches) {
-        return data.CanStun();
-      },
+      condition: (data) => data.CanStun(),
       response: Responses.stun('info'),
     },
     {
@@ -132,9 +126,7 @@
       netRegexJa: NetRegexes.startsUsing({ id: '22F', source: 'アイアタル' }),
       netRegexKo: NetRegexes.startsUsing({ id: '22F', source: '아이아타르' }),
       netRegexCn: NetRegexes.startsUsing({ id: '22F', source: '阿杰特' }),
-      condition: function(data, matches) {
-        return data.CanStun();
-      },
+      condition: (data) => data.CanStun(),
       response: Responses.stun('info'),
     },
     {

--- a/ui/raidboss/data/02-arr/dungeon/haukke_manor.js
+++ b/ui/raidboss/data/02-arr/dungeon/haukke_manor.js
@@ -29,12 +29,12 @@
     {
       // Particle and spell effects make this particular Dark Mist hard to see.
       id: 'Haukke Normal Amandine Dark Mist Dodge',
-      netRegex: NetRegexes.startsUsing({ id: '2C1', source: 'Lady Amandine' }),
-      netRegexDe: NetRegexes.startsUsing({ id: '2C1', source: 'Lady Amandine' }),
-      netRegexFr: NetRegexes.startsUsing({ id: '2C1', source: 'Dame Amandine' }),
-      netRegexJa: NetRegexes.startsUsing({ id: '2C1', source: 'レディ・アマンディヌ' }),
-      netRegexKo: NetRegexes.startsUsing({ id: '2C1', source: '레이디 아망딘' }),
-      netRegexCn: NetRegexes.startsUsing({ id: '2C1', source: '阿芒迪娜女士' }),
+      netRegex: NetRegexes.startsUsing({ id: '2C1', source: 'Lady Amandine', capture: false }),
+      netRegexDe: NetRegexes.startsUsing({ id: '2C1', source: 'Lady Amandine', capture: false }),
+      netRegexFr: NetRegexes.startsUsing({ id: '2C1', source: 'Dame Amandine', capture: false }),
+      netRegexJa: NetRegexes.startsUsing({ id: '2C1', source: 'レディ・アマンディヌ', capture: false }),
+      netRegexKo: NetRegexes.startsUsing({ id: '2C1', source: '레이디 아망딘', capture: false }),
+      netRegexCn: NetRegexes.startsUsing({ id: '2C1', source: '阿芒迪娜女士', capture: false }),
       condition: (data) => !data.CanStun(),
       response: Responses.outOfMelee('alert'),
     },

--- a/ui/raidboss/data/02-arr/dungeon/haukke_manor.js
+++ b/ui/raidboss/data/02-arr/dungeon/haukke_manor.js
@@ -11,9 +11,7 @@
       netRegexJa: NetRegexes.startsUsing({ id: '2C1', source: ['御用邸のメイド', '御用邸のクラヴィジャー', 'レディ・アマンディヌ'] }),
       netRegexKo: NetRegexes.startsUsing({ id: '2C1', source: ['별궁의 하녀', '별궁 청지기', '레이디 아망딘'] }),
       netRegexCn: NetRegexes.startsUsing({ id: '2C1', source: ['庄园的女仆', '庄园的女工', '阿芒迪娜女士'] }),
-      condition: function(data, matches) {
-        return data.CanStun();
-      },
+      condition: (data) => data.CanStun(),
       suppressSeconds: 2,
       response: Responses.stun('info'),
     },
@@ -25,9 +23,7 @@
       netRegexJa: NetRegexes.startsUsing({ id: '35C', source: '御用邸の執事長' }),
       netRegexKo: NetRegexes.startsUsing({ id: '35C', source: '별궁의 집사장' }),
       netRegexCn: NetRegexes.startsUsing({ id: '35C', source: '庄园的总管' }),
-      condition: function(data, matches) {
-        return data.CanStun();
-      },
+      condition: (data) => data.CanStun(),
       response: Responses.stun('info'),
     },
     {
@@ -39,9 +35,7 @@
       netRegexJa: NetRegexes.startsUsing({ id: '2C1', source: 'レディ・アマンディヌ' }),
       netRegexKo: NetRegexes.startsUsing({ id: '2C1', source: '레이디 아망딘' }),
       netRegexCn: NetRegexes.startsUsing({ id: '2C1', source: '阿芒迪娜女士' }),
-      condition: function(data, matches) {
-        return !data.CanStun();
-      },
+      condition: (data) => !data.CanStun(),
       response: Responses.outOfMelee('alert'),
     },
     {
@@ -52,9 +46,7 @@
       netRegexJa: NetRegexes.startsUsing({ id: '356', source: 'レディ・アマンディヌ' }),
       netRegexKo: NetRegexes.startsUsing({ id: '356', source: '레이디 아망딘' }),
       netRegexCn: NetRegexes.startsUsing({ id: '356', source: '阿芒迪娜女士' }),
-      condition: function(data, matches) {
-        return data.CanSilence();
-      },
+      condition: (data) => data.CanSilence(),
       response: Responses.interrupt('info'),
     },
     {

--- a/ui/raidboss/data/02-arr/raid/t1.js
+++ b/ui/raidboss/data/02-arr/raid/t1.js
@@ -11,9 +11,7 @@
       netRegexJa: NetRegexes.startsUsing({ source: '制御システム', id: '5A7' }),
       netRegexCn: NetRegexes.startsUsing({ source: '自卫系统', id: '5A7' }),
       netRegexKo: NetRegexes.startsUsing({ source: '제어 시스템', id: '5A7' }),
-      condition: function(data) {
-        return data.CanSilence();
-      },
+      condition: (data) => data.CanSilence(),
       response: Responses.interrupt(),
     },
     {

--- a/ui/raidboss/data/02-arr/raid/t2.js
+++ b/ui/raidboss/data/02-arr/raid/t2.js
@@ -6,9 +6,7 @@
     {
       id: 'T2 High Voltage',
       netRegex: NetRegexes.startsUsing({ id: '4C0' }),
-      condition: function(data) {
-        return data.CanSilence();
-      },
+      condition: (data) => data.CanSilence(),
       response: Responses.interrupt(),
     },
     {

--- a/ui/raidboss/data/02-arr/raid/t7.js
+++ b/ui/raidboss/data/02-arr/raid/t7.js
@@ -12,10 +12,8 @@
       netRegexJa: NetRegexes.startsUsing({ id: '860', source: 'プロトキマイラ', capture: false }),
       netRegexCn: NetRegexes.startsUsing({ id: '860', source: '原型奇美拉', capture: false }),
       netRegexKo: NetRegexes.startsUsing({ id: '860', source: '프로토 키마이라', capture: false }),
-      condition: function(data) {
-        // TODO: is this silenceable in 5.0?
-        return data.CanStun() || data.CanSilence();
-      },
+      // TODO: is this silenceable in 5.0?
+      condition: (data) => data.CanStun() || data.CanSilence(),
       infoText: (data, _, output) => output.text(),
       outputStrings: {
         text: {
@@ -35,10 +33,8 @@
       netRegexJa: NetRegexes.startsUsing({ id: '861', source: 'プロトキマイラ', capture: false }),
       netRegexCn: NetRegexes.startsUsing({ id: '861', source: '原型奇美拉', capture: false }),
       netRegexKo: NetRegexes.startsUsing({ id: '861', source: '프로토 키마이라', capture: false }),
-      condition: function(data) {
-        // TODO: is this silenceable in 5.0?
-        return data.CanStun() || data.CanSilence();
-      },
+      // TODO: is this silenceable in 5.0?
+      condition: (data) => data.CanStun() || data.CanSilence(),
       infoText: (data, _, output) => output.text(),
       outputStrings: {
         text: {

--- a/ui/raidboss/data/02-arr/raid/t9.js
+++ b/ui/raidboss/data/02-arr/raid/t9.js
@@ -148,9 +148,7 @@
       netRegexJa: NetRegexes.startsUsing({ id: '7F5', source: 'ダラガブゴーレム', capture: false }),
       netRegexCn: NetRegexes.startsUsing({ id: '7F5', source: '卫月巨像', capture: false }),
       netRegexKo: NetRegexes.startsUsing({ id: '7F5', source: '달라가브 골렘', capture: false }),
-      condition: function(data) {
-        return data.CanSilence();
-      },
+      condition: (data) => data.CanSilence(),
       alertText: (data, _, output) => output.text(),
       outputStrings: {
         text: {

--- a/ui/raidboss/data/02-arr/trial/titan-ex.js
+++ b/ui/raidboss/data/02-arr/trial/titan-ex.js
@@ -26,9 +26,7 @@
       id: 'TitanEx Tumult',
       regex: /Tumult/,
       beforeSeconds: 5,
-      condition: function(data) {
-        return data.role == 'healer' || data.role == 'tank' || data.CanAddle();
-      },
+      condition: Conditions.caresAboutMagical(),
       response: Responses.aoe(),
     },
     {

--- a/ui/raidboss/data/02-arr/trial/titan-hm.js
+++ b/ui/raidboss/data/02-arr/trial/titan-hm.js
@@ -32,9 +32,7 @@
       id: 'TitanHm Tumult',
       regex: /Tumult/,
       beforeSeconds: 5,
-      condition: function(data) {
-        return data.role == 'healer' || data.role == 'tank' || data.CanAddle();
-      },
+      condition: Conditions.caresAboutMagical(),
       response: Responses.aoe(),
     },
   ],
@@ -42,9 +40,7 @@
     {
       id: 'TitanHm Damage Down',
       netRegex: NetRegexes.gainsEffect({ effectId: '3E' }),
-      condition: function(data) {
-        return data.CanCleanse();
-      },
+      condition: (data) => data.CanCleanse(),
       infoText: function(data, matches) {
         return {
           en: 'Cleanse ' + data.ShortName(matches.target),


### PR DESCRIPTION
Update conditions for ARR triggers to use canned responses where
available, and/or use arrow functions where it makes sense.

Addresses all utility functions from common (CanCleanse, CanStun,
etc.) and all conditions from Conditions that aren't targetIsYou /
targetIsNotYou.