### PR TITLE
raidboss: Korean translate

### DIFF
--- a/ui/raidboss/data/05-shb/ultimate/the_epic_of_alexander.js
+++ b/ui/raidboss/data/05-shb/ultimate/the_epic_of_alexander.js
@@ -119,7 +119,7 @@ const kFinalJudgementNisi = ['8B0', '8B1', '85B', '85C'];
           de: 'Tank Cleave',
           ja: 'タンククリーブ',
           fr: 'Tank Cleave',
-          ko: '탱크 범위 공격',
+          ko: '광역 탱버',
           cn: '坦克顺劈',
         };
       },
@@ -1653,7 +1653,7 @@ const kFinalJudgementNisi = ['8B0', '8B1', '85B', '85C'];
         de: 'TANK LB!!',
         ja: 'タンクLB!!',
         fr: 'LB TANK !!',
-        ko: '탱크 LIMITE BREAK!!',
+        ko: '탱커 LIMIT BREAK!!',
         cn: '坦克LB!!',
       },
     },
@@ -2503,7 +2503,7 @@ const kFinalJudgementNisi = ['8B0', '8B1', '85B', '85C'];
             en: 'Tank Swap!',
             de: 'Tank Wechsel!',
             fr: 'Tank Swap !',
-            ko: '탱크 교대!!!',
+            ko: '탱교대!',
             cn: '换T!',
           };
         }

--- a/ui/raidboss/raidboss_config.js
+++ b/ui/raidboss/raidboss_config.js
@@ -125,6 +125,7 @@ let kDetailKeys = {
       fr: 'Durée',
       ja: '存続時間',
       cn: '持续时间',
+      ko: '지속 시간 (초)',
     },
     cls: 'duration-text',
     generatedManually: true,
@@ -216,6 +217,7 @@ const kMiscTranslations = {
     en: '(default)',
     de: '(Standard)',
     fr: '(Défaut)',
+    ko: '(기본값)',
   },
 };
 

--- a/ui/raidboss/raidboss_config.js
+++ b/ui/raidboss/raidboss_config.js
@@ -120,11 +120,11 @@ let kDetailKeys = {
   },
   'duration': {
     label: {
-      en: 'duration',
-      de: 'Dauer',
-      fr: 'Durée',
-      ja: '存続時間',
-      cn: '持续时间',
+      en: 'duration (sec)',
+      de: 'Dauer (Sekunden)',
+      fr: 'Durée (secondes)',
+      ja: '存続時間 (秒)',
+      cn: '持续时间 (秒)',
       ko: '지속 시간 (초)',
     },
     cls: 'duration-text',


### PR DESCRIPTION
I think adding `sec` to duration is better
https://github.com/quisquous/cactbot/blob/6809fe44899ee01b7bf98e7280b3203b411a7f4a/ui/raidboss/raidboss_config.js#L123-L127
`duration` -> `duration (sec)`