### PR TITLE
raidboss: Additional ESLint Rules for ARR Triggers

### DIFF
--- a/ui/raidboss/data/02-arr/dungeon/brayfloxs_longstop.js
+++ b/ui/raidboss/data/02-arr/dungeon/brayfloxs_longstop.js
@@ -25,7 +25,7 @@
     },
     {
       id: 'Brayflox Normal Pelican Poison Healer',
-      netRegex: NetRegexes.gainsEffect({ effectId: '12' }),
+      netRegex: NetRegexes.gainsEffect({ effectId: '12', capture: false }),
       condition: (data) => data.role === 'healer',
       delaySeconds: 1,
       suppressSeconds: 2,
@@ -139,7 +139,7 @@
     {
       // Move Aiatar out of Puddles
       id: 'Brayflox Normal Aiatar Toxic Vomit Tank',
-      netRegex: NetRegexes.gainsEffect({ effectId: '117' }),
+      netRegex: NetRegexes.gainsEffect({ effectId: '117', capture: false }),
       condition: (data) => data.role === 'tank',
       alertText: (data, _, output) => output.text(),
       outputStrings: {

--- a/ui/raidboss/data/02-arr/dungeon/brayfloxs_longstop.js
+++ b/ui/raidboss/data/02-arr/dungeon/brayfloxs_longstop.js
@@ -29,7 +29,7 @@
       condition: (data) => data.role === 'healer',
       delaySeconds: 1,
       suppressSeconds: 2,
-      alertText: (data, matches, output) => {
+      alertText: (data, _, output) => {
         if (!data.pelicanPoisons)
           return;
 
@@ -102,7 +102,7 @@
       netRegexJa: NetRegexes.ability({ id: '3D3', source: 'ヘルベンダー' }),
       netRegexKo: NetRegexes.ability({ id: '3D3', source: '장수도롱뇽' }),
       netRegexCn: NetRegexes.ability({ id: '3D3', source: '水栖蝾螈' }),
-      infoText: function(data, matches, output) {
+      infoText: (data, matches, output) => {
         if (matches.target !== data.me)
           return output.breakBubbleOn({ player: data.ShortName(matches.target) });
 
@@ -140,9 +140,7 @@
       // Move Aiatar out of Puddles
       id: 'Brayflox Normal Aiatar Toxic Vomit Tank',
       netRegex: NetRegexes.gainsEffect({ effectId: '117' }),
-      condition: function(data, matches) {
-        return data.role === 'tank';
-      },
+      condition: (data) => data.role === 'tank',
       alertText: (data, _, output) => output.text(),
       outputStrings: {
         text: {
@@ -159,7 +157,7 @@
       id: 'Brayflox Normal Aiatar Poison Healer',
       netRegex: NetRegexes.gainsEffect({ effectId: '113' }),
       condition: (data) => data.role === 'healer',
-      alertText: function(data, matches, output) {
+      alertText: (data, matches, output) => {
         if (matches.target !== data.me)
           return output.esunaPoisonOn({ player: data.ShortName(matches.target) });
 

--- a/ui/raidboss/data/02-arr/raid/t1.js
+++ b/ui/raidboss/data/02-arr/raid/t1.js
@@ -23,9 +23,7 @@
       netRegexJa: NetRegexes.ability({ source: 'カドゥケウス', id: '4B8.*?', capture: false }),
       netRegexCn: NetRegexes.ability({ source: '神杖巨蛇', id: '4B8.*?', capture: false }),
       netRegexKo: NetRegexes.ability({ source: '카두케우스', id: '4B8.*?', capture: false }),
-      run: function(data) {
-        data.started = true;
-      },
+      run: (data) => data.started = true,
     },
     {
       id: 'T1 Regorge',
@@ -55,9 +53,7 @@
       netRegexJa: NetRegexes.addedCombatant({ name: 'カドゥケウス.*?', capture: false }),
       netRegexCn: NetRegexes.addedCombatant({ name: '神杖巨蛇.*?', capture: false }),
       netRegexKo: NetRegexes.addedCombatant({ name: '카두케우스.*?', capture: false }),
-      condition: function(data) {
-        return data.started;
-      },
+      condition: (data) => data.started,
       suppressSeconds: 5,
       alertText: (data, _, output) => output.text(),
       outputStrings: {

--- a/ui/raidboss/data/02-arr/raid/t10.js
+++ b/ui/raidboss/data/02-arr/raid/t10.js
@@ -27,12 +27,12 @@
     {
       id: 'T10 Wild Charge',
       netRegex: NetRegexes.headMarker({ id: '001F' }),
-      alarmText: function(data, matches, output) {
-        if (data.me == matches.target)
+      alarmText: (data, matches, output) => {
+        if (data.me === matches.target)
           return output.chargeOnYou();
       },
-      infoText: function(data, matches, output) {
-        if (data.me != matches.target)
+      infoText: (data, matches, output) => {
+        if (data.me !== matches.target)
           return output.chargeOn({ player: data.ShortName(matches.target) });
       },
       outputStrings: {
@@ -65,12 +65,12 @@
       netRegexJa: NetRegexes.tether({ id: '0015', source: 'イムドゥグド' }),
       netRegexCn: NetRegexes.tether({ id: '0015', source: '伊姆都古德' }),
       netRegexKo: NetRegexes.tether({ id: '0015', source: '임두구드' }),
-      alarmText: function(data, matches, output) {
-        if (data.me == matches.target)
+      alarmText: (data, matches, output) => {
+        if (data.me === matches.target)
           return output.cyclonicOnYou();
       },
-      infoText: function(data, matches, output) {
-        if (data.me != matches.target)
+      infoText: (data, matches, output) => {
+        if (data.me !== matches.target)
           return output.cyclonicOn({ player: data.ShortName(matches.target) });
       },
       outputStrings: {

--- a/ui/raidboss/data/02-arr/raid/t11.js
+++ b/ui/raidboss/data/02-arr/raid/t11.js
@@ -12,9 +12,7 @@
       netRegexJa: NetRegexes.ability({ source: 'カーリア', id: 'B73' }),
       netRegexCn: NetRegexes.ability({ source: '卡利亚', id: 'B73' }),
       netRegexKo: NetRegexes.ability({ source: '칼리야', id: 'B73' }),
-      alertText: function(data, matches, output) {
-        return output.text({ player: data.ShortName(matches.target) });
-      },
+      alertText: (data, matches, output) => output.text({ player: data.ShortName(matches.target) }),
       outputStrings: {
         text: {
           en: 'Stun on ${player}',
@@ -33,11 +31,9 @@
       netRegexJa: NetRegexes.ability({ source: 'カーリア', id: 'B74', capture: false }),
       netRegexCn: NetRegexes.ability({ source: '卡利亚', id: 'B74', capture: false }),
       netRegexKo: NetRegexes.ability({ source: '칼리야', id: 'B74', capture: false }),
-      condition: function(data) {
-        return !data.firstSeed;
-      },
+      condition: (data) => !data.firstSeed,
       response: Responses.spreadThenStack(),
-      run: function(data) {
+      run: (data) => {
         if (!data.firstSeed)
           data.firstSeed = 'river';
       },
@@ -50,11 +46,9 @@
       netRegexJa: NetRegexes.ability({ id: 'B75', source: 'カーリア', capture: false }),
       netRegexCn: NetRegexes.ability({ id: 'B75', source: '卡利亚', capture: false }),
       netRegexKo: NetRegexes.ability({ id: 'B75', source: '칼리야', capture: false }),
-      condition: function(data) {
-        return !data.firstSeed;
-      },
+      condition: (data) => !data.firstSeed,
       response: Responses.stackThenSpread(),
-      run: function(data) {
+      run: (data) => {
         if (!data.firstSeed)
           data.firstSeed = 'sea';
       },
@@ -67,13 +61,9 @@
       netRegexJa: NetRegexes.ability({ id: 'B76', source: 'カーリア', capture: false }),
       netRegexCn: NetRegexes.ability({ id: 'B76', source: '卡利亚', capture: false }),
       netRegexKo: NetRegexes.ability({ id: 'B76', source: '칼리야', capture: false }),
-      condition: function(data) {
-        return !data.firstSeed;
-      },
+      condition: (data) => !data.firstSeed,
       response: Responses.stackMarker(),
-      run: function(data) {
-        delete data.firstSeed;
-      },
+      run: (data) => delete data.firstSeed,
     },
     {
       id: 'T11 Seed Sea Second',
@@ -83,13 +73,9 @@
       netRegexJa: NetRegexes.ability({ id: 'B77', source: 'カーリア', capture: false }),
       netRegexCn: NetRegexes.ability({ id: 'B77', source: '卡利亚', capture: false }),
       netRegexKo: NetRegexes.ability({ id: 'B77', source: '칼리야', capture: false }),
-      condition: function(data) {
-        return !data.firstSeed;
-      },
+      condition: (data) => !data.firstSeed,
       response: Responses.spread(),
-      run: function(data) {
-        delete data.firstSeed;
-      },
+      run: (data) => delete data.firstSeed,
     },
     {
       id: 'T11 Phase 2',
@@ -159,7 +145,7 @@
       netRegexJa: NetRegexes.tether({ id: '001C', target: 'カーリア' }),
       netRegexCn: NetRegexes.tether({ id: '001C', target: '卡利亚' }),
       netRegexKo: NetRegexes.tether({ id: '001C', target: '칼리야' }),
-      run: function(data, matches) {
+      run: (data, matches) => {
         data.tetherA = data.tetherA || [];
         data.tetherA.push(matches.source);
       },
@@ -172,7 +158,7 @@
       netRegexJa: NetRegexes.tether({ id: '001D', target: 'カーリア' }),
       netRegexCn: NetRegexes.tether({ id: '001D', target: '卡利亚' }),
       netRegexKo: NetRegexes.tether({ id: '001D', target: '칼리야' }),
-      run: function(data, matches) {
+      run: (data, matches) => {
         data.tetherB = data.tetherB || [];
         data.tetherB.push(matches.source);
       },
@@ -185,14 +171,12 @@
       netRegexJa: NetRegexes.tether({ id: '001C', target: 'カーリア', capture: false }),
       netRegexCn: NetRegexes.tether({ id: '001C', target: '卡利亚', capture: false }),
       netRegexKo: NetRegexes.tether({ id: '001C', target: '칼리야', capture: false }),
-      condition: function(data) {
-        return data.tetherA.length == 2;
-      },
-      alarmText: function(data, _, output) {
+      condition: (data) => data.tetherA.length === 2,
+      alarmText: (data, _, output) => {
         let partner = undefined;
-        if (data.tetherA[0] == data.me)
+        if (data.tetherA[0] === data.me)
           partner = data.tetherA[1];
-        if (data.tetherA[1] == data.me)
+        if (data.tetherA[1] === data.me)
           partner = data.tetherA[0];
         if (!partner)
           return;
@@ -216,14 +200,12 @@
       netRegexJa: NetRegexes.tether({ id: '001D', target: 'カーリア', capture: false }),
       netRegexCn: NetRegexes.tether({ id: '001D', target: '卡利亚', capture: false }),
       netRegexKo: NetRegexes.tether({ id: '001D', target: '칼리야', capture: false }),
-      condition: function(data) {
-        return data.tetherB.length == 2;
-      },
-      alarmText: function(data, _, output) {
+      condition: (data) => data.tetherB.length === 2,
+      alarmText: (data, _, output) => {
         let partner = undefined;
-        if (data.tetherB[0] == data.me)
+        if (data.tetherB[0] === data.me)
           partner = data.tetherB[1];
-        if (data.tetherB[1] == data.me)
+        if (data.tetherB[1] === data.me)
           partner = data.tetherB[0];
         if (!partner)
           return;
@@ -247,7 +229,7 @@
       netRegexJa: NetRegexes.ability({ id: 'B7B', source: 'カーリア', capture: false }),
       netRegexCn: NetRegexes.ability({ id: 'B7B', source: '卡利亚', capture: false }),
       netRegexKo: NetRegexes.ability({ id: 'B7B', source: '칼리야', capture: false }),
-      run: function(data) {
+      run: (data) => {
         delete data.tetherA;
         delete data.tetherB;
       },

--- a/ui/raidboss/data/02-arr/raid/t12.js
+++ b/ui/raidboss/data/02-arr/raid/t12.js
@@ -13,9 +13,7 @@
       netRegexCn: NetRegexes.ability({ id: 'B96', source: '不死鸟', capture: false }),
       netRegexKo: NetRegexes.ability({ id: 'B96', source: '피닉스', capture: false }),
       sound: 'Long',
-      run: function(data) {
-        data.phase = 3;
-      },
+      run: (data) => data.phase = 3,
     },
     {
       id: 'T12 Bennu',
@@ -27,7 +25,7 @@
       netRegexKo: NetRegexes.addedCombatant({ name: '벤누', capture: false }),
       delaySeconds: 55,
       durationSeconds: 4.5,
-      infoText: function(data, _, output) {
+      infoText: (data, _, output) => {
         if (data.phase >= 3)
           return;
         return output.text();
@@ -50,12 +48,12 @@
       netRegexJa: NetRegexes.startsUsing({ id: 'B87', source: 'フェニックス' }),
       netRegexCn: NetRegexes.startsUsing({ id: 'B87', source: '不死鸟' }),
       netRegexKo: NetRegexes.startsUsing({ id: 'B87', source: '피닉스' }),
-      alertText: function(data, matches, output) {
-        if (matches.target == data.me)
+      alertText: (data, matches, output) => {
+        if (matches.target === data.me)
           return output.revelationOnYou();
       },
-      infoText: function(data, matches, output) {
-        if (matches.target != data.me)
+      infoText: (data, matches, output) => {
+        if (matches.target !== data.me)
           return output.awayFromPlayer({ player: data.ShortName(matches.target) });
       },
       outputStrings: {
@@ -128,12 +126,12 @@
       // Chain Of Purgatory
       id: 'T12 Chain',
       netRegex: NetRegexes.gainsEffect({ effectId: '24D' }),
-      alertText: function(data, matches, output) {
-        if (matches.target == data.me)
+      alertText: (data, matches, output) => {
+        if (matches.target === data.me)
           return output.chainOnYou();
       },
-      infoText: function(data, matches, output) {
-        if (matches.target != data.me)
+      infoText: (data, matches, output) => {
+        if (matches.target !== data.me)
           return output.chainOn({ player: data.ShortName(matches.target) });
       },
       outputStrings: {

--- a/ui/raidboss/data/02-arr/raid/t13.js
+++ b/ui/raidboss/data/02-arr/raid/t13.js
@@ -20,9 +20,8 @@
       netRegexJa: NetRegexes.startsUsing({ id: 'BB9', source: 'バハムート・プライム', capture: false }),
       netRegexCn: NetRegexes.startsUsing({ id: 'BB9', source: '至尊巴哈姆特', capture: false }),
       netRegexKo: NetRegexes.startsUsing({ id: 'BB9', source: '바하무트 프라임', capture: false }),
-      condition: (data) =>
-        // Only the first two gigas are phase changes, the rest are in final phase.
-        !(data.gigaflare > 1),
+      // Only the first two gigas are phase changes, the rest are in final phase.
+      condition: (data) => !(data.gigaflare > 1),
       sound: 'Long',
       infoText: (data, _, output) => {
         if (data.gigaflare)

--- a/ui/raidboss/data/02-arr/raid/t13.js
+++ b/ui/raidboss/data/02-arr/raid/t13.js
@@ -20,16 +20,15 @@
       netRegexJa: NetRegexes.startsUsing({ id: 'BB9', source: 'バハムート・プライム', capture: false }),
       netRegexCn: NetRegexes.startsUsing({ id: 'BB9', source: '至尊巴哈姆特', capture: false }),
       netRegexKo: NetRegexes.startsUsing({ id: 'BB9', source: '바하무트 프라임', capture: false }),
-      condition: function(data) {
+      condition: (data) =>
         // Only the first two gigas are phase changes, the rest are in final phase.
-        return !(data.gigaflare > 1);
-      },
+        !(data.gigaflare > 1),
       sound: 'Long',
-      infoText: function(data, _, output) {
+      infoText: (data, _, output) => {
         if (data.gigaflare)
           return output.text();
       },
-      run: function(data) {
+      run: (data) => {
         data.gigaflare = data.gigaflare || 0;
         data.gigaflare++;
       },
@@ -52,14 +51,14 @@
       netRegexJa: NetRegexes.startsUsing({ id: 'BAE', source: 'バハムート・プライム' }),
       netRegexCn: NetRegexes.startsUsing({ id: 'BAE', source: '至尊巴哈姆特' }),
       netRegexKo: NetRegexes.startsUsing({ id: 'BAE', source: '바하무트 프라임' }),
-      alertText: function(data, matches, output) {
-        if (matches.target == data.me)
+      alertText: (data, matches, output) => {
+        if (matches.target === data.me)
           return output.flattenOnYou();
       },
-      infoText: function(data, matches, output) {
-        if (matches.target == data.me)
+      infoText: (data, matches, output) => {
+        if (matches.target === data.me)
           return;
-        if (data.role == 'healer' || data.job == 'BLU')
+        if (data.role === 'healer' || data.job === 'BLU')
           return output.flattenOn({ player: data.ShortName(matches.target) });
       },
       outputStrings: {
@@ -111,9 +110,7 @@
       netRegexJa: NetRegexes.tether({ id: '0004', target: 'バハムート・プライム' }),
       netRegexCn: NetRegexes.tether({ id: '0004', target: '至尊巴哈姆特' }),
       netRegexKo: NetRegexes.tether({ id: '0004', target: '바하무트 프라임' }),
-      condition: function(data, matches) {
-        return data.me == matches.source;
-      },
+      condition: (data, matches) => data.me === matches.source,
       infoText: (data, _, output) => output.text(),
       outputStrings: {
         text: {
@@ -134,12 +131,12 @@
       netRegexJa: NetRegexes.startsUsing({ id: 'BC2', source: 'バハムート・プライム' }),
       netRegexCn: NetRegexes.startsUsing({ id: 'BC2', source: '至尊巴哈姆特' }),
       netRegexKo: NetRegexes.startsUsing({ id: 'BC2', source: '바하무트 프라임' }),
-      alertText: function(data, matches, output) {
-        if (matches.target == data.me)
+      alertText: (data, matches, output) => {
+        if (matches.target === data.me)
           return output.akhMornOnYou();
       },
-      infoText: function(data, matches, output) {
-        if (matches.target != data.me)
+      infoText: (data, matches, output) => {
+        if (matches.target !== data.me)
           return output.akhMornOn({ player: data.ShortName(matches.target) });
       },
       outputStrings: {

--- a/ui/raidboss/data/02-arr/raid/t2.js
+++ b/ui/raidboss/data/02-arr/raid/t2.js
@@ -19,12 +19,12 @@
       // Allagan Rot
       id: 'T2 Rot',
       netRegex: NetRegexes.gainsEffect({ effectId: '14D' }),
-      alarmText: function(data, matches, output) {
-        if (data.me == matches.target)
+      alarmText: (data, matches, output) => {
+        if (data.me === matches.target)
           return output.rotOnYou();
       },
-      infoText: function(data, matches, output) {
-        if (data.me != matches.target)
+      infoText: (data, matches, output) => {
+        if (data.me !== matches.target)
           return output.rotOn({ player: data.ShortName(matches.target) });
       },
       outputStrings: {
@@ -48,11 +48,9 @@
       id: 'T2 Pass Rot',
       netRegex: NetRegexes.gainsEffect({ effectId: '14D' }),
       condition: Conditions.targetIsYou(),
-      preRun: function(data) {
-        data.rot = true;
-      },
+      preRun: (data) => data.rot = true,
       delaySeconds: 11,
-      alertText: function(data, _, output) {
+      alertText: (data, _, output) => {
         if (!data.rot)
           return;
         return output.text();
@@ -71,9 +69,7 @@
       id: 'T2 Lost Rot',
       netRegex: NetRegexes.losesEffect({ effectId: '14D' }),
       condition: Conditions.targetIsYou(),
-      run: function(data) {
-        delete data.rot;
-      },
+      run: (data) => delete data.rot,
     },
   ],
   timelineReplace: [

--- a/ui/raidboss/data/02-arr/raid/t5.js
+++ b/ui/raidboss/data/02-arr/raid/t5.js
@@ -12,9 +12,7 @@
       netRegexJa: NetRegexes.startsUsing({ source: 'ツインタニア', id: '5B2' }),
       netRegexCn: NetRegexes.startsUsing({ source: '双塔尼亚', id: '5B2' }),
       netRegexKo: NetRegexes.startsUsing({ source: '트윈타니아', id: '5B2' }),
-      condition: function(data, matches) {
-        return data.me == matches.target || data.role == 'healer' || data.job == 'BLU';
-      },
+      condition: (data, matches) => data.me === matches.target || data.role === 'healer' || data.job === 'BLU',
       response: Responses.tankBuster(),
     },
     {
@@ -25,9 +23,7 @@
       netRegexJa: NetRegexes.startsUsing({ source: 'ツインタニア', id: '5B2', capture: false }),
       netRegexCn: NetRegexes.startsUsing({ source: '双塔尼亚', id: '5B2', capture: false }),
       netRegexKo: NetRegexes.startsUsing({ source: '트윈타니아', id: '5B2', capture: false }),
-      condition: function(data) {
-        return data.role == 'tank' || data.role == 'healer' || data.job == 'BLU';
-      },
+      condition: (data) => data.role === 'tank' || data.role === 'healer' || data.job === 'BLU',
       delaySeconds: 30,
       suppressSeconds: 5,
       infoText: (data, _, output) => output.text(),
@@ -80,12 +76,12 @@
       netRegexJa: NetRegexes.ability({ source: 'ツインタニア', id: '5AC' }),
       netRegexCn: NetRegexes.ability({ source: '双塔尼亚', id: '5AC' }),
       netRegexKo: NetRegexes.ability({ source: '트윈타니아', id: '5AC' }),
-      alertText: function(data, matches, output) {
-        if (data.me == matches.target)
+      alertText: (data, matches, output) => {
+        if (data.me === matches.target)
           return output.fireballOnYou();
       },
-      infoText: function(data, matches, output) {
-        if (data.me != matches.target)
+      infoText: (data, matches, output) => {
+        if (data.me !== matches.target)
           return output.fireballOn({ player: data.ShortName(matches.target) });
       },
       outputStrings: {
@@ -115,12 +111,12 @@
       netRegexJa: NetRegexes.ability({ source: 'ツインタニア', id: '5AB' }),
       netRegexCn: NetRegexes.ability({ source: '双塔尼亚', id: '5AB' }),
       netRegexKo: NetRegexes.ability({ source: '트윈타니아', id: '5AB' }),
-      alarmText: function(data, matches, output) {
-        if (data.me == matches.target)
+      alarmText: (data, matches, output) => {
+        if (data.me === matches.target)
           return output.conflagOnYou();
       },
-      infoText: function(data, matches, output) {
-        if (data.me != matches.target)
+      infoText: (data, matches, output) => {
+        if (data.me !== matches.target)
           return output.conflagOn({ player: data.ShortName(matches.target) });
       },
       outputStrings: {
@@ -203,8 +199,8 @@
       netRegexJa: NetRegexes.ability({ source: 'ツインタニア', id: '4E3' }),
       netRegexCn: NetRegexes.ability({ source: '双塔尼亚', id: '4E3' }),
       netRegexKo: NetRegexes.ability({ source: '트윈타니아', id: '4E3' }),
-      infoText: function(data, matches, output) {
-        if (data.me == matches.target)
+      infoText: (data, matches, output) => {
+        if (data.me === matches.target)
           return output.knightOnYou();
 
         return output.knightOn({ player: data.ShortName(matches.target) });
@@ -266,12 +262,12 @@
       netRegexJa: NetRegexes.ability({ source: 'ツインタニア', id: '5AD' }),
       netRegexCn: NetRegexes.ability({ source: '双塔尼亚', id: '5AD' }),
       netRegexKo: NetRegexes.ability({ source: '트윈타니아', id: '5AD' }),
-      alertText: function(data, matches, output) {
-        if (data.me == matches.target)
+      alertText: (data, matches, output) => {
+        if (data.me === matches.target)
           return output.hatchOnYou();
       },
-      infoText: function(data, matches, output) {
-        if (data.me != matches.target)
+      infoText: (data, matches, output) => {
+        if (data.me !== matches.target)
           return output.hatchOn({ player: data.ShortName(matches.target) });
       },
       outputStrings: {

--- a/ui/raidboss/data/02-arr/raid/t6.js
+++ b/ui/raidboss/data/02-arr/raid/t6.js
@@ -7,7 +7,7 @@
     {
       id: 'T6 Thorn Whip Collect',
       netRegex: NetRegexes.tether({ id: '0012' }),
-      run: function(data, matches) {
+      run: (data, matches) => {
         data.thornMap = data.thornMap || {};
         data.thornMap[matches.source] = data.thornMap[matches.source] || [];
         data.thornMap[matches.source].push(matches.target);
@@ -24,15 +24,15 @@
       netRegexCn: NetRegexes.ability({ id: '879', source: '大王花' }),
       netRegexKo: NetRegexes.ability({ id: '879', source: '라플레시아' }),
       condition: Conditions.targetIsYou(),
-      infoText: function(data, _, output) {
-        let partners = data.thornMap[data.me];
+      infoText: (data, _, output) => {
+        const partners = data.thornMap[data.me];
         if (!partners)
           return output.thornsOnYou();
 
-        if (partners.length == 1)
+        if (partners.length === 1)
           return output.oneTether({ player: data.ShortName(partners[0]) });
 
-        if (partners.length == 2) {
+        if (partners.length === 2) {
           return output.twoTethers({
             player1: data.ShortName(partners[0]),
             player2: data.ShortName(partners[1]),
@@ -41,9 +41,7 @@
 
         return output.threeOrMoreTethers({ num: partners.length });
       },
-      run: function(data) {
-        delete data.thornMap;
-      },
+      run: (data) => delete data.thornMap,
       outputStrings: {
         thornsOnYou: {
           en: 'Thorns on YOU',
@@ -80,34 +78,30 @@
       id: 'T6 Honey On',
       netRegex: NetRegexes.gainsEffect({ effectId: '1BE' }),
       condition: Conditions.targetIsYou(),
-      run: function(data) {
-        data.honey = true;
-      },
+      run: (data) => data.honey = true,
     },
     {
       id: 'T6 Honey Off',
       netRegex: NetRegexes.losesEffect({ effectId: '1BE' }),
       condition: Conditions.targetIsYou(),
-      run: function(data) {
-        delete data.honey;
-      },
+      run: (data) => delete data.honey,
     },
     {
       id: 'T6 Flower',
       netRegex: NetRegexes.headMarker({ id: '000D' }),
-      alarmText: function(data, _, output) {
+      alarmText: (data, _, output) => {
         if (data.honey)
           return output.getEaten();
       },
-      alertText: function(data, matches, output) {
+      alertText: (data, matches, output) => {
         if (data.honey)
           return;
 
-        if (data.me == matches.target)
+        if (data.me === matches.target)
           return output.jumpInNewThorns();
       },
-      infoText: function(data, matches, output) {
-        if (data.honey || data.me == matches.target)
+      infoText: (data, matches, output) => {
+        if (data.honey || data.me === matches.target)
           return;
 
         return output.avoidDevour();
@@ -164,13 +158,9 @@
       netRegexJa: NetRegexes.startsUsing({ id: '79E', source: 'ラフレシア', capture: false }),
       netRegexCn: NetRegexes.startsUsing({ id: '79E', source: '大王花', capture: false }),
       netRegexKo: NetRegexes.startsUsing({ id: '79E', source: '라플레시아', capture: false }),
-      condition: function(data) {
-        return !data.seenLeafstorm;
-      },
+      condition: (data) => !data.seenLeafstorm,
       sound: 'Long',
-      run: function(data) {
-        data.seenLeafstorm = true;
-      },
+      run: (data) => data.seenLeafstorm = true,
     },
     {
       id: 'T6 Swarm Stack',
@@ -199,15 +189,13 @@
       netRegexJa: NetRegexes.ability({ id: '7A0', source: 'ラフレシア' }),
       netRegexCn: NetRegexes.ability({ id: '7A0', source: '大王花' }),
       netRegexKo: NetRegexes.ability({ id: '7A0', source: '라플레시아' }),
-      condition: function(data, matches) {
-        return data.me == matches.target || data.role == 'healer' || data.job == 'BLU';
-      },
-      alertText: function(data, matches, output) {
-        if (matches.target == data.me)
+      condition: (data, matches) => data.me === matches.target || data.role === 'healer' || data.job === 'BLU',
+      alertText: (data, matches, output) => {
+        if (matches.target === data.me)
           return output.swarmOnYou();
       },
-      infoText: function(data, matches, output) {
-        if (matches.target != data.me)
+      infoText: (data, matches, output) => {
+        if (matches.target !== data.me)
           return output.swarmOn({ player: data.ShortName(matches.target) });
       },
       outputStrings: {
@@ -230,8 +218,8 @@
     {
       id: 'T6 Rotten Stench',
       netRegex: NetRegexes.headMarker({ id: '000E' }),
-      alertText: function(data, matches, output) {
-        if (data.me == matches.target)
+      alertText: (data, matches, output) => {
+        if (data.me === matches.target)
           return output.shareLaserOnYou();
 
         return output.shareLaserOn({ player: data.ShortName(matches.target) });

--- a/ui/raidboss/data/02-arr/raid/t7.js
+++ b/ui/raidboss/data/02-arr/raid/t7.js
@@ -54,9 +54,7 @@
       netRegexJa: NetRegexes.ability({ id: '7A8', source: 'メリュジーヌ' }),
       netRegexCn: NetRegexes.ability({ id: '7A8', source: '美瑠姬奴' }),
       netRegexKo: NetRegexes.ability({ id: '7A8', source: '멜뤼진' }),
-      condition: function(data, matches) {
-        return data.me == matches.target && data.job == 'BLU';
-      },
+      condition: (data, matches) => data.me === matches.target && data.job === 'BLU',
       delaySeconds: 6,
       suppressSeconds: 5,
       infoText: (data, _, output) => output.text(),
@@ -93,9 +91,7 @@
       id: 'T7 Cursed Voice',
       netRegex: NetRegexes.gainsEffect({ effectId: '1C3' }),
       condition: Conditions.targetIsYou(),
-      delaySeconds: function(data, matches) {
-        return matches.duration - 3;
-      },
+      delaySeconds: (data, matches) => matches.duration - 3,
       alertText: (data, _, output) => output.text(),
       outputStrings: {
         text: {
@@ -111,12 +107,12 @@
       id: 'T7 Cursed Shriek',
       netRegex: NetRegexes.gainsEffect({ effectId: '1C4' }),
       durationSeconds: 3,
-      alarmText: function(data, matches, output) {
-        if (data.me == matches.target)
+      alarmText: (data, matches, output) => {
+        if (data.me === matches.target)
           return output.shriekOnYou();
       },
-      infoText: function(data, matches, output) {
-        if (data.me != matches.target)
+      infoText: (data, matches, output) => {
+        if (data.me !== matches.target)
           return output.shriekOn({ player: data.ShortName(matches.target) });
       },
       outputStrings: {
@@ -141,8 +137,8 @@
       netRegex: NetRegexes.gainsEffect({ effectId: '1C4' }),
       delaySeconds: 7,
       durationSeconds: 3,
-      infoText: function(data, matches, output) {
-        if (data.me == matches.target)
+      infoText: (data, matches, output) => {
+        if (data.me === matches.target)
           return output.shriekSoon();
 
         return output.dodgeShriek();

--- a/ui/raidboss/data/02-arr/raid/t8.js
+++ b/ui/raidboss/data/02-arr/raid/t8.js
@@ -18,9 +18,7 @@
       netRegexCn: NetRegexes.message({ line: '地雷分布在了各处.*?', capture: false }),
       netRegexKo: NetRegexes.message({ line: '지뢰가 뿌려졌습니다.*?', capture: false }),
       alertText: (data, _, output) => output.text(),
-      run: function(data) {
-        data.landmines = {};
-      },
+      run: (data) => data.landmines = {},
       outputStrings: {
         text: {
           en: 'Explode Landmines',
@@ -39,21 +37,19 @@
       netRegexJa: NetRegexes.ability({ id: '7D1', source: 'アラガンマイン' }),
       netRegexCn: NetRegexes.ability({ id: '7D1', source: '亚拉戈机雷' }),
       netRegexKo: NetRegexes.ability({ id: '7D1', source: '알라그 지뢰' }),
-      infoText: function(data, matches, output) {
+      infoText: (data, matches, output) => {
         if (matches.target in data.landmines)
           return;
         const num = Object.keys(data.landmines).length + 1;
         return output.landmine({ num: num });
       },
-      tts: function(data, matches, output) {
+      tts: (data, matches, output) => {
         if (matches.target in data.landmines)
           return;
         const num = Object.keys(data.landmines).length + 1;
         return output.landmineTTS({ num: num });
       },
-      run: function(data, matches) {
-        data.landmines[matches.target] = true;
-      },
+      run: (data, matches) => data.landmines[matches.target] = true,
       outputStrings: {
         landmine: {
           en: '${num} / 3',
@@ -82,9 +78,7 @@
       netRegexCn: NetRegexes.tether({ id: '0005', target: '降世化身' }),
       netRegexKo: NetRegexes.tether({ id: '0005', target: '아바타' }),
       suppressSeconds: 6,
-      infoText: function(data, matches, output) {
-        return output.text({ player: data.ShortName(matches.source) });
-      },
+      infoText: (data, matches, output) => output.text({ player: data.ShortName(matches.source) }),
       outputStrings: {
         text: {
           en: 'Missile Tether (on ${player})',
@@ -103,12 +97,12 @@
       netRegexJa: NetRegexes.startsUsing({ id: '7C3', source: 'アバター' }),
       netRegexCn: NetRegexes.startsUsing({ id: '7C3', source: '降世化身' }),
       netRegexKo: NetRegexes.startsUsing({ id: '7C3', source: '아바타' }),
-      alertText: function(data, matches, output) {
-        if (data.me == matches.target)
+      alertText: (data, matches, output) => {
+        if (data.me === matches.target)
           return output.brainjackOnYou();
       },
-      infoText: function(data, matches, output) {
-        if (data.me != matches.target)
+      infoText: (data, matches, output) => {
+        if (data.me !== matches.target)
           return output.brainjackOn({ player: data.ShortName(matches.target) });
       },
       outputStrings: {
@@ -136,12 +130,12 @@
       netRegexJa: NetRegexes.startsUsing({ id: '7C4', source: 'アバター' }),
       netRegexCn: NetRegexes.startsUsing({ id: '7C4', source: '降世化身' }),
       netRegexKo: NetRegexes.startsUsing({ id: '7C4', source: '아바타' }),
-      alertText: function(data, matches, output) {
-        if (data.me == matches.target)
+      alertText: (data, matches, output) => {
+        if (data.me === matches.target)
           return output.allaganFieldOnYou();
       },
-      infoText: function(data, matches, output) {
-        if (data.me != matches.target)
+      infoText: (data, matches, output) => {
+        if (data.me !== matches.target)
           return output.allaganFieldOn({ player: data.ShortName(matches.target) });
       },
       outputStrings: {

--- a/ui/raidboss/data/02-arr/raid/t9.js
+++ b/ui/raidboss/data/02-arr/raid/t9.js
@@ -35,9 +35,7 @@ const diveDirections = {
       id: 'T9 Claw',
       regex: /Bahamut's Claw x5/,
       beforeSeconds: 5,
-      condition: function(data) {
-        return data.role == 'tank' || data.role == 'healer' || data.job == 'BLU';
-      },
+      condition: (data) => data.role === 'tank' || data.role === 'healer' || data.job === 'BLU',
       response: Responses.tankBuster(),
     },
     {
@@ -78,9 +76,7 @@ const diveDirections = {
       id: 'T9 Raven Blight You',
       netRegex: NetRegexes.gainsEffect({ effectId: '1CA' }),
       condition: Conditions.targetIsYou(),
-      delaySeconds: function(data, matches) {
-        return matches.duration - 5;
-      },
+      delaySeconds: (data, matches) => matches.duration - 5,
       durationSeconds: 5,
       alarmText: (data, _, output) => output.text(),
       outputStrings: {
@@ -98,13 +94,9 @@ const diveDirections = {
       id: 'T9 Raven Blight Not You',
       netRegex: NetRegexes.gainsEffect({ effectId: '1CA' }),
       condition: Conditions.targetIsNotYou(),
-      delaySeconds: function(data, matches) {
-        return matches.duration - 5;
-      },
+      delaySeconds: (data, matches) => matches.duration - 5,
       durationSeconds: 5,
-      infoText: function(data, matches, output) {
-        return output.text({ player: data.ShortName(matches.target) });
-      },
+      infoText: (data, matches, output) => output.text({ player: data.ShortName(matches.target) }),
       outputStrings: {
         text: {
           en: 'Blight on ${player}',
@@ -131,8 +123,8 @@ const diveDirections = {
     {
       id: 'T9 Stack',
       netRegex: NetRegexes.headMarker({ id: '000F' }),
-      alertText: function(data, matches, output) {
-        if (data.me == matches.target)
+      alertText: (data, matches, output) => {
+        if (data.me === matches.target)
           return output.thermoOnYou();
 
         return output.stackOn({ player: data.ShortName(matches.target) });
@@ -210,13 +202,9 @@ const diveDirections = {
     {
       id: 'T9 Garotte Twist Gain',
       netRegex: NetRegexes.gainsEffect({ effectId: '1CE' }),
-      condition: function(data, matches) {
-        return data.me == matches.target && !data.garotte;
-      },
+      condition: (data, matches) => data.me === matches.target && !data.garotte,
       infoText: (data, _, output) => output.text(),
-      run: function(data) {
-        data.garotte = true;
-      },
+      run: (data) => data.garotte = true,
       outputStrings: {
         text: {
           en: 'Garotte on YOU',
@@ -236,9 +224,7 @@ const diveDirections = {
       netRegexJa: NetRegexes.ability({ id: '7FA', source: 'メラシディアン・ゴースト', capture: false }),
       netRegexCn: NetRegexes.ability({ id: '7FA', source: '美拉西迪亚幽龙', capture: false }),
       netRegexKo: NetRegexes.ability({ id: '7FA', source: '메라시디아의 유령', capture: false }),
-      condition: function(data) {
-        return data.garotte;
-      },
+      condition: (data) => data.garotte,
       alarmText: (data, _, output) => output.text(),
       outputStrings: {
         text: {
@@ -254,12 +240,8 @@ const diveDirections = {
     {
       id: 'T9 Garotte Twist Lose',
       netRegex: NetRegexes.losesEffect({ effectId: '1CE' }),
-      condition: function(data, matches) {
-        return data.me == matches.target && data.garotte;
-      },
-      run: function(data) {
-        delete data.garotte;
-      },
+      condition: (data, matches) => data.me === matches.target && data.garotte,
+      run: (data) => delete data.garotte,
     },
     {
       id: 'T9 Final Phase',
@@ -269,13 +251,9 @@ const diveDirections = {
       netRegexJa: NetRegexes.startsUsing({ id: '7E6', source: 'ネール・デウス・ダーナス', capture: false }),
       netRegexCn: NetRegexes.startsUsing({ id: '7E6', source: '奈尔·神·达纳斯', capture: false }),
       netRegexKo: NetRegexes.startsUsing({ id: '7E6', source: '넬 데우스 다르누스', capture: false }),
-      condition: function(data) {
-        return !data.seenFinalPhase;
-      },
+      condition: (data) => !data.seenFinalPhase,
       sound: 'Long',
-      run: function(data) {
-        data.seenFinalPhase = true;
-      },
+      run: (data) => data.seenFinalPhase = true,
     },
     {
       id: 'T9 Dragon Locations',
@@ -285,9 +263,9 @@ const diveDirections = {
       netRegexJa: NetRegexes.addedCombatantFull({ name: ['ファイアホーン', 'アイスクロウ', 'サンダーウィング'] }),
       netRegexCn: NetRegexes.addedCombatantFull({ name: ['火角', '冰爪', '雷翼'] }),
       netRegexKo: NetRegexes.addedCombatantFull({ name: ['화염뿔', '얼음발톱', '번개날개'] }),
-      run: function(data, matches) {
+      run: (data, matches) => {
         // Lowercase all of the names here for case insensitive matching.
-        let allNames = {
+        const allNames = {
           en: ['firehorn', 'iceclaw', 'thunderwing'],
           de: ['feuerhorn', 'eisklaue', 'donnerschwinge'],
           fr: ['corne-de-feu', 'griffe-de-glace ', 'aile-de-foudre'],
@@ -295,13 +273,13 @@ const diveDirections = {
           cn: ['火角', '冰爪', '雷翼'],
           ko: ['화염뿔', '얼음발톱', '번개날개'],
         };
-        let names = allNames[data.parserLang];
-        let idx = names.indexOf(matches.name.toLowerCase());
-        if (idx == -1)
+        const names = allNames[data.parserLang];
+        const idx = names.indexOf(matches.name.toLowerCase());
+        if (idx === -1)
           return;
 
-        let x = parseFloat(matches.x);
-        let y = parseFloat(matches.y);
+        const x = parseFloat(matches.x);
+        const y = parseFloat(matches.y);
 
         // Most dragons are out on a circle of radius=~28.
         // Ignore spurious dragons like "Pos: (0.000919255,0.006120025,2.384186E-07)"
@@ -311,7 +289,7 @@ const diveDirections = {
         // Positions are the 8 cardinals + numerical slop on a radius=28 circle.
         // N = (0, -28), E = (28, 0), S = (0, 28), W = (-28, 0)
         // Map N = 0, NE = 1, ..., NW = 7
-        let dir = Math.round(4 - 4 * Math.atan2(x, y) / Math.PI) % 8;
+        const dir = Math.round(4 - 4 * Math.atan2(x, y) / Math.PI) % 8;
 
         data.dragons = data.dragons || [0, 0, 0];
         data.dragons[idx] = dir;
@@ -325,12 +303,12 @@ const diveDirections = {
       netRegexJa: NetRegexes.startsUsing({ id: '7E6', source: 'ネール・デウス・ダーナス', capture: false }),
       netRegexCn: NetRegexes.startsUsing({ id: '7E6', source: '奈尔·神·达纳斯', capture: false }),
       netRegexKo: NetRegexes.startsUsing({ id: '7E6', source: '넬 데우스 다르누스', capture: false }),
-      run: function(data) {
+      run: (data) => {
         data.tetherCount = 0;
         data.naelDiveMarkerCount = 0;
 
         // Missing dragons??
-        if (!data.dragons || data.dragons.length != 3) {
+        if (!data.dragons || data.dragons.length !== 3) {
           data.naelMarks = ['unknown', 'unknown'];
           data.safeZone = 'unknown';
           return;
@@ -340,8 +318,8 @@ const diveDirections = {
         // The first two are always split, so A is the first dragon + 1.
         // The last one is single, so B is the last dragon + 1.
 
-        let dragons = data.dragons.sort();
-        let dirNames = [
+        const dragons = data.dragons.sort();
+        const dirNames = [
           'north',
           'northeast',
           'east',
@@ -351,15 +329,13 @@ const diveDirections = {
           'west',
           'northwest',
         ];
-        data.naelMarks = [dragons[0], dragons[2]].map(function(i) {
-          return dirNames[(i + 1) % 8];
-        });
+        data.naelMarks = [dragons[0], dragons[2]].map((i) => dirNames[(i + 1) % 8]);
 
         // Safe zone is one to the left of the first dragon, unless
         // the last dragon is diving there.  If that's true, use
         // one to the right of the second dragon.
         let possibleSafe = (dragons[0] - 1 + 8) % 8;
-        if ((dragons[2] + 2) % 8 == possibleSafe)
+        if ((dragons[2] + 2) % 8 === possibleSafe)
           possibleSafe = (dragons[1] + 1) % 8;
         data.safeZone = dirNames[possibleSafe];
       },
@@ -373,12 +349,10 @@ const diveDirections = {
       netRegexCn: NetRegexes.startsUsing({ id: '7E6', source: '奈尔·神·达纳斯', capture: false }),
       netRegexKo: NetRegexes.startsUsing({ id: '7E6', source: '넬 데우스 다르누스', capture: false }),
       durationSeconds: 12,
-      infoText: function(data, _, output) {
-        return output.marks({
-          dir1: output[data.naelMarks[0]](),
-          dir2: output[data.naelMarks[1]](),
-        });
-      },
+      infoText: (data, _, output) => output.marks({
+        dir1: output[data.naelMarks[0]](),
+        dir2: output[data.naelMarks[1]](),
+      }),
       outputStrings: {
         ...diveDirections,
         marks: {
@@ -399,11 +373,11 @@ const diveDirections = {
       netRegexJa: NetRegexes.tether({ id: '0005', source: 'ファイアホーン' }),
       netRegexCn: NetRegexes.tether({ id: '0005', source: '火角' }),
       netRegexKo: NetRegexes.tether({ id: '0005', source: '화염뿔' }),
-      preRun: function(data) {
+      preRun: (data) => {
         data.tetherCount = data.tetherCount || 0;
         data.tetherCount++;
       },
-      alertText: function(data, matches, output) {
+      alertText: (data, matches, output) => {
         if (data.me !== matches.target)
           return;
         // Out, In, Out, In
@@ -411,7 +385,7 @@ const diveDirections = {
           return output.fireOutOnYou();
         return output.fireInOnYou;
       },
-      infoText: function(data, matches, output) {
+      infoText: (data, matches, output) => {
         if (data.me === matches.target)
           return;
         // Out, In, Out, In
@@ -473,17 +447,17 @@ const diveDirections = {
       id: 'T9 Dragon Marker',
       netRegex: NetRegexes.headMarker({ id: '0014' }),
       condition: Conditions.targetIsYou(),
-      alarmText: function(data, matches, output) {
+      alarmText: (data, matches, output) => {
         data.naelDiveMarkerCount = data.naelDiveMarkerCount || 0;
-        if (matches.target != data.me)
+        if (matches.target !== data.me)
           return;
-        let marker = ['A', 'B', 'C'][data.naelDiveMarkerCount];
-        let dir = data.naelMarks[data.naelDiveMarkerCount];
+        const marker = ['A', 'B', 'C'][data.naelDiveMarkerCount];
+        const dir = data.naelMarks[data.naelDiveMarkerCount];
         return output.goToMarkerInDir({ marker: marker, dir: dir });
       },
-      tts: function(data, matches, output) {
+      tts: (data, matches, output) => {
         data.naelDiveMarkerCount = data.naelDiveMarkerCount || 0;
-        if (matches.target != data.me)
+        if (matches.target !== data.me)
           return;
         return output.goToMarker({ marker: ['A', 'B', 'C'][data.naelDiveMarkerCount] });
       },

--- a/ui/raidboss/data/02-arr/trial/shiva-ex.js
+++ b/ui/raidboss/data/02-arr/trial/shiva-ex.js
@@ -49,7 +49,7 @@
       netRegexJa: NetRegexes.ability({ source: 'シヴァ', id: '995', capture: false }),
       netRegexKo: NetRegexes.ability({ source: '시바', id: '995', capture: false }),
       netRegexCn: NetRegexes.ability({ source: '希瓦', id: '995', capture: false }),
-      response: function(data) {
+      response: (data) => {
         if (data.role === 'tank') {
           if (data.currentTank && data.blunt && data.blunt[data.currentTank]) {
             return {
@@ -76,9 +76,7 @@
           },
         };
       },
-      run: function(data) {
-        data.soonAfterWeaponChange = true;
-      },
+      run: (data) => data.soonAfterWeaponChange = true,
     },
     {
       id: 'ShivaEx Sword Phase',
@@ -88,7 +86,7 @@
       netRegexJa: NetRegexes.ability({ source: 'シヴァ', id: '993', capture: false }),
       netRegexKo: NetRegexes.ability({ source: '시바', id: '993', capture: false }),
       netRegexCn: NetRegexes.ability({ source: '希瓦', id: '993', capture: false }),
-      response: function(data) {
+      response: (data) => {
         if (data.role === 'tank') {
           if (data.currentTank && data.slashing && data.slashing[data.currentTank]) {
             return {
@@ -115,9 +113,7 @@
           },
         };
       },
-      run: function(data) {
-        data.soonAfterWeaponChange = true;
-      },
+      run: (data) => data.soonAfterWeaponChange = true,
     },
     {
       id: 'ShivaEx Weapon Change Delayed',
@@ -128,14 +124,12 @@
       netRegexKo: NetRegexes.ability({ source: '시바', id: ['993', '995'], capture: false }),
       netRegexCn: NetRegexes.ability({ source: '希瓦', id: ['993', '995'], capture: false }),
       delaySeconds: 30,
-      run: function(data) {
-        data.soonAfterWeaponChange = false;
-      },
+      run: (data) => data.soonAfterWeaponChange = false,
     },
     {
       id: 'ShivaEx Slashing Resistance Down Gain',
       netRegex: NetRegexes.gainsEffect({ effectId: '23C' }),
-      run: function(data, matches) {
+      run: (data, matches) => {
         data.slashing = data.slashing || {};
         data.slashing[matches.target] = true;
       },
@@ -143,7 +137,7 @@
     {
       id: 'ShivaEx Slashing Resistance Down Lose',
       netRegex: NetRegexes.losesEffect({ effectId: '23C' }),
-      run: function(data, matches) {
+      run: (data, matches) => {
         data.slashing = data.slashing || {};
         data.slashing[matches.target] = false;
       },
@@ -151,7 +145,7 @@
     {
       id: 'ShivaEx Blunt Resistance Down Gain',
       netRegex: NetRegexes.gainsEffect({ effectId: '23D' }),
-      run: function(data, matches) {
+      run: (data, matches) => {
         data.blunt = data.blunt || {};
         data.blunt[matches.target] = true;
       },
@@ -159,7 +153,7 @@
     {
       id: 'ShivaEx Blunt Resistance Down Lose',
       netRegex: NetRegexes.losesEffect({ effectId: '23D' }),
-      run: function(data, matches) {
+      run: (data, matches) => {
         data.blunt = data.blunt || {};
         data.blunt[matches.target] = false;
       },
@@ -172,9 +166,7 @@
       netRegexJa: NetRegexes.ability({ source: 'シヴァ', id: 'BE5' }),
       netRegexKo: NetRegexes.ability({ source: '시바', id: 'BE5' }),
       netRegexCn: NetRegexes.ability({ source: '希瓦', id: 'BE5' }),
-      run: function(data, matches) {
-        data.currentTank = matches.target;
-      },
+      run: (data, matches) => data.currentTank = matches.target,
     },
     {
       id: 'ShivaEx Hailstorm Marker',
@@ -200,9 +192,7 @@
       netRegexJa: NetRegexes.ability({ source: 'シヴァ', id: '98A', capture: false }),
       netRegexKo: NetRegexes.ability({ source: '시바', id: '98A', capture: false }),
       netRegexCn: NetRegexes.ability({ source: '希瓦', id: '98A', capture: false }),
-      run: function(data) {
-        data.seenDiamondDust = true;
-      },
+      run: (data) => data.seenDiamondDust = true,
     },
     {
       id: 'ShivaEx Frost Bow',
@@ -213,7 +203,7 @@
       netRegexKo: NetRegexes.ability({ source: '시바', id: 'BDD', capture: false }),
       netRegexCn: NetRegexes.ability({ source: '希瓦', id: 'BDD', capture: false }),
       response: Responses.getBehind('alarm'),
-      run: function(data) {
+      run: (data) => {
         // Just in case ACT has crashed or something, make sure this state is correct.
         data.seenDiamondDust = true;
       },
@@ -259,13 +249,13 @@
       netRegexJa: NetRegexes.abilityFull({ source: 'シヴァ', id: 'BEB' }),
       netRegexKo: NetRegexes.abilityFull({ source: '시바', id: 'BEB' }),
       netRegexCn: NetRegexes.abilityFull({ source: '希瓦', id: 'BEB' }),
-      condition: function(data, matches) {
+      condition: (data, matches) => {
         // Ignore other middle circles and try to only target the Icicle Impact x9.
         if (!data.seenDiamondDust || data.soonAfterWeaponChange)
           return false;
 
-        let x = parseFloat(matches.x);
-        let y = parseFloat(matches.y);
+        const x = parseFloat(matches.x);
+        const y = parseFloat(matches.y);
         return Math.abs(x) < 0.1 && Math.abs(y) < 0.1;
       },
       // This can hit multiple people.
@@ -281,9 +271,7 @@
       id: 'ShivaEx Ice Boulder',
       netRegex: NetRegexes.ability({ id: 'C8A' }),
       condition: Conditions.targetIsNotYou(),
-      infoText: function(data, matches, output) {
-        return output.text({ player: data.ShortName(matches.target) });
-      },
+      infoText: (data, matches, output) => output.text({ player: data.ShortName(matches.target) }),
       outputStrings: {
         text: {
           en: 'Free ${player}',

--- a/ui/raidboss/data/02-arr/trial/shiva-hm.js
+++ b/ui/raidboss/data/02-arr/trial/shiva-hm.js
@@ -43,9 +43,7 @@
       id: 'ShivaHm Ice Boulder',
       netRegex: NetRegexes.ability({ id: '9A3' }),
       condition: Conditions.targetIsNotYou(),
-      infoText: function(data, matches, output) {
-        return output.text({ player: data.ShortName(matches.target) });
-      },
+      infoText: (data, matches, output) => output.text({ player: data.ShortName(matches.target) }),
       outputStrings: {
         text: {
           en: 'Free ${player}',

--- a/ui/raidboss/data/02-arr/trial/titan-ex.js
+++ b/ui/raidboss/data/02-arr/trial/titan-ex.js
@@ -8,18 +8,14 @@
       id: 'TitanEx Mountain Buster',
       regex: /Mountain Buster/,
       beforeSeconds: 7,
-      condition: function(data) {
-        return data.role == 'healer' || data.role == 'tank';
-      },
+      condition: (data) => data.role === 'healer' || data.role === 'tank',
       response: Responses.tankBuster(),
     },
     {
       id: 'TitanEx Mountain Buster Avoid',
       regex: /Mountain Buster/,
       beforeSeconds: 7,
-      condition: function(data) {
-        return data.role != 'healer' && data.role != 'tank';
-      },
+      condition: (data) => data.role !== 'healer' && data.role !== 'tank',
       response: Responses.tankCleave(),
     },
     {

--- a/ui/raidboss/data/02-arr/trial/titan-hm.js
+++ b/ui/raidboss/data/02-arr/trial/titan-hm.js
@@ -8,18 +8,14 @@
       id: 'TitanHm Mountain Buster',
       regex: /Mountain Buster/,
       beforeSeconds: 7,
-      condition: function(data) {
-        return data.role == 'healer' || data.role == 'tank';
-      },
+      condition: (data) => data.role === 'healer' || data.role === 'tank',
       response: Responses.tankBuster(),
     },
     {
       id: 'TitanHm Mountain Buster Avoid',
       regex: /Mountain Buster/,
       beforeSeconds: 7,
-      condition: function(data) {
-        return data.role != 'healer' && data.role != 'tank';
-      },
+      condition: (data) => data.role !== 'healer' && data.role !== 'tank',
       response: Responses.tankCleave(),
     },
     {
@@ -41,9 +37,7 @@
       id: 'TitanHm Damage Down',
       netRegex: NetRegexes.gainsEffect({ effectId: '3E' }),
       condition: (data) => data.CanCleanse(),
-      infoText: function(data, matches, output) {
-        return output.text({ player: data.ShortName(matches.target) });
-      },
+      infoText: (data, matches, output) => output.text({ player: data.ShortName(matches.target) }),
       outputStrings: {
         text: {
           en: 'Cleanse ${player}',

--- a/ui/raidboss/data/02-arr/trial/titan-nm.js
+++ b/ui/raidboss/data/02-arr/trial/titan-nm.js
@@ -29,7 +29,7 @@
       // Gaol callout for both yourself and others
       id: 'TitanNm Gaols',
       netRegex: NetRegexes.gainsEffect({ effectId: '124' }),
-      alertText: function(data, matches, output) {
+      alertText: (data, matches, output) => {
         if (matches.target !== data.me)
           return output.breakGaolOn({ player: data.ShortName(matches.target) });
 


### PR DESCRIPTION
Enable additional core ESLint rules for triggers:
- https://eslint.org/docs/rules/arrow-body-style
- https://eslint.org/docs/rules/eqeqeq
- https://eslint.org/docs/rules/no-unused-vars (with `_` as an exception)
- https://eslint.org/docs/rules/prefer-arrow-callback
- https://eslint.org/docs/rules/prefer-const

Additionally, running the following rule locally:
- https://www.npmjs.com/package/eslint-plugin-prefer-arrow