### PR TITLE
raid emulator: Add Element Ids for Tooltip Templates

### DIFF
--- a/ui/raidboss/emulator/ui/Tooltip.js
+++ b/ui/raidboss/emulator/ui/Tooltip.js
@@ -14,7 +14,9 @@ class Tooltip {
     };
     this.target = target;
     this.direction = direction;
-    this.tooltip = document.querySelector('template.tooltip.' + direction)
+    // Technically, templates should use querySelector, but this gets called so often
+    // on trigger-heavy encounters that we should hack its performance a bit
+    this.tooltip = document.getElementById(`${direction}TooltipTemplate`)
       .content.firstElementChild.cloneNode(true);
     this.setText(text);
     document.body.append(this.tooltip);

--- a/ui/raidboss/raidemulator.html
+++ b/ui/raidboss/raidemulator.html
@@ -334,13 +334,13 @@
           <div class="encounterEndStatus">End Status: <span class="label"></span></div>
         </div>
       </template>
-      <template class="tooltip bottom">
+      <template id="bottomTooltipTemplate" class="tooltip bottom">
         <div class="tooltip bs-tooltip-bottom" role="tooltip" x-placement="bottom">
           <div class="arrow"></div>
           <div class="tooltip-inner"></div>
         </div>
       </template>
-      <template class="tooltip left">
+      <template id="leftTooltipTemplate" class="tooltip left">
         <div class="tooltip bs-tooltip-left" role="tooltip" x-placement="left">
           <div class="arrow"></div>
           <div class="tooltip-inner"></div>


### PR DESCRIPTION
Small hack to speed up the rendering steps for trigger-heavy encounters within
the raid emulator.

Before:

![](https://user-images.githubusercontent.com/8849608/98886139-4b081c00-2448-11eb-99ff-13d603636342.png)

After:

![](https://user-images.githubusercontent.com/8849608/98886126-4479a480-2448-11eb-977d-451fa02487c4.png)

This adds a bit to the `Recalculate Style` step, but the performance hit there
is outweighed by the speed increase in selecting the DOM element.

I saw roughly a ~50% reduction in total time to load a trigger-heavy
encounter (TEA). With a ~70% reduction in total drawing time after the
log events had been loaded.