### PR TITLE
raidboss: convert remaining responses to output strings

### DIFF
--- a/test/trigger/test_trigger.js
+++ b/test/trigger/test_trigger.js
@@ -178,7 +178,8 @@ let testInvalidCapturingGroupRegex = function(file, contents) {
             continue;
           }
           // Built-in response functions can be safely called once.
-          currentTriggerFunction = currentTriggerFunction({}, {}, {});
+          const output = new TestOutputProxy(trigger, {}, errorFunc);
+          currentTriggerFunction = currentTriggerFunction({}, {}, output);
         }
         if (func === 'response' && typeof currentTriggerFunction === 'object') {
           // Treat a response object as its own trigger and look at all the functions it returns.
@@ -418,6 +419,27 @@ let testBadZoneId = function(file, contents) {
     errorFunc(`${file}: use zoneId instead of zoneRegex`);
 };
 
+class TestOutputProxy {
+  constructor(trigger, responseOutputStrings, errorFunc) {
+    return new Proxy(this, {
+      get(target, name) {
+        // We can't validate all possible paths from the trigger,
+        // so always succeed here and we'll validate later.
+        return () => '';
+      },
+      set(target, property, value) {
+        if (property === 'responseOutputStrings') {
+          // The normal output proxy
+          Object.assign(responseOutputStrings, value);
+          return true;
+        }
+
+        errorFunc(`Trigger ${trigger.id} set invalid '${property}' on output.`);
+      },
+    });
+  }
+}
+
 // responses_test.js will handle testing any response with builtInResponseStr.
 // triggers using `response:` otherwise cannot be tested, because we cannot
 // safely call the response function.
@@ -440,12 +462,13 @@ const testOutputStrings = (file, contents) => {
         if (typeof trigger.response !== 'function')
           continue;
         const funcStr = trigger.response.toString();
-        if (!funcStr.includes(builtInResponseStr))
+        if (!funcStr.includes(builtInResponseStr)) {
+          errorFunc(`${file}: '${trigger.id}' built-in response does not include "${builtInResponseStr}".`);
           continue;
-        const output = { responseOutputStrings: undefined };
+        }
+        const output = new TestOutputProxy(trigger, outputStrings, errorFunc);
         // Call the function to get the outputStrings.
         response = trigger.response({}, {}, output);
-        outputStrings = output.responseOutputStrings;
 
         if (typeof outputStrings !== 'object') {
           errorFunc(`${file}: '${trigger.id}' built-in response did not set outputStrings.`);
@@ -481,6 +504,11 @@ const testOutputStrings = (file, contents) => {
       // For each outputString, find and validate all of the parameters.
       for (const key in outputStrings) {
         let templateObj = outputStrings[key];
+        if (typeof templateObj === 'string') {
+          // Strings are acceptable as output strings, but convert to a translatable object
+          // to make the rest of the code simpler.
+          templateObj = { en: templateObj };
+        }
         if (typeof templateObj !== 'object') {
           errorFunc(`${file}: '${key}' in '${trigger.id}' outputStrings is not a translatable object`);
           continue;
@@ -526,6 +554,9 @@ const testOutputStrings = (file, contents) => {
 
       const usedOutputStringEntries = new Set();
 
+      // Detects uses of `output[variable]()` which could be anything.
+      let dynamicOutputStringAccess = false;
+
       // Now, we have an optional |outputStrings| and an optional |response|.
       // Verify that any function in |trigger| or |response| using |output|
       // has a corresponding key in |outputStrings|.  But hackily.
@@ -536,6 +567,8 @@ const testOutputStrings = (file, contents) => {
           continue;
         const funcStr = func.toString();
         const keys = [];
+
+        dynamicOutputStringAccess |= /\boutput\[/.test(funcStr);
 
         // Validate that any calls to output.word() have a corresponding outputStrings entry.
         funcStr.replace(/\boutput\.(\w*)\(/g, (fullMatch, key) => {
@@ -558,7 +591,7 @@ const testOutputStrings = (file, contents) => {
 
       // Responses can have unused output strings in some cases, such as ones
       // that work with and without matching.
-      if (!response) {
+      if (!response && !dynamicOutputStringAccess) {
         for (const key in outputStrings) {
           if (!usedOutputStringEntries.has(key))
             errorFunc(`${file}: '${trigger.id}' has unused outputStrings entry '${key}'`);

--- a/test/trigger/test_trigger.js
+++ b/test/trigger/test_trigger.js
@@ -429,7 +429,8 @@ class TestOutputProxy {
       },
       set(target, property, value) {
         if (property === 'responseOutputStrings') {
-          // The normal output proxy
+          // The normal output proxy assigns here, but we want to keep the same
+          // object so we can inspect it outside the proxy.
           Object.assign(responseOutputStrings, value);
           return true;
         }
@@ -494,6 +495,7 @@ const testOutputStrings = (file, contents) => {
 
       // TODO: should we prevent `output['phrase with spaces']()` style constructions?
       // TODO: should we restrict outputStrings keys to valid variable characters?
+      // TODO: should we prevent built in responses from returning other Response functions?
 
       // TODO: share this with popup-text.js?
       const paramRegex = /\${\s*([^}\s]+)\s*}/g;

--- a/ui/raidboss/data/00-misc/test.js
+++ b/ui/raidboss/data/00-misc/test.js
@@ -244,7 +244,8 @@
       id: 'Test Response',
       netRegex: NetRegexes.echo({ line: 'cactbot test response.*?', capture: false }),
       netRegexDe: NetRegexes.echo({ line: 'cactbot test antwort.*?', capture: false }),
-      response: function(data, _, output) {
+      response: (data, _, output) => {
+        // cactbot-builtin-response
         output.responseOutputStrings = {
           alarmOne: '1',
           alertTwo: '2',

--- a/ui/raidboss/data/02-arr/trial/shiva-ex.js
+++ b/ui/raidboss/data/02-arr/trial/shiva-ex.js
@@ -49,24 +49,18 @@
       netRegexJa: NetRegexes.ability({ source: 'シヴァ', id: '995', capture: false }),
       netRegexKo: NetRegexes.ability({ source: '시바', id: '995', capture: false }),
       netRegexCn: NetRegexes.ability({ source: '希瓦', id: '995', capture: false }),
-      response: (data) => {
-        if (data.role === 'tank') {
-          if (data.currentTank && data.blunt && data.blunt[data.currentTank]) {
-            return {
-              alertText: {
-                en: 'Staff (Tank Swap)',
-                de: 'Stab (Tankwechsel)',
-                fr: 'Bâton (Tank Swap)',
-                ja: '杖 (スイッチ)',
-                cn: '权杖（换T）',
-                ko: '지팡이 (탱커 교대)',
-              },
-            };
-          }
-        }
-
-        return {
-          infoText: {
+      response: (data, _, output) => {
+        // cactbot-builtin-response
+        output.responseOutputStrings = {
+          staffTankSwap: {
+            en: 'Staff (Tank Swap)',
+            de: 'Stab (Tankwechsel)',
+            fr: 'Bâton (Tank Swap)',
+            ja: '杖 (スイッチ)',
+            cn: '权杖（换T）',
+            ko: '지팡이 (탱커 교대)',
+          },
+          staff: {
             en: 'Staff',
             de: 'Stab',
             fr: 'Bâton',
@@ -75,6 +69,13 @@
             ko: '지팡이',
           },
         };
+
+        if (data.role === 'tank') {
+          if (data.currentTank && data.blunt && data.blunt[data.currentTank])
+            return { alertText: output.staffTankSwap() };
+        }
+
+        return { infoText: output.staff() };
       },
       run: (data) => data.soonAfterWeaponChange = true,
     },
@@ -86,24 +87,18 @@
       netRegexJa: NetRegexes.ability({ source: 'シヴァ', id: '993', capture: false }),
       netRegexKo: NetRegexes.ability({ source: '시바', id: '993', capture: false }),
       netRegexCn: NetRegexes.ability({ source: '希瓦', id: '993', capture: false }),
-      response: (data) => {
-        if (data.role === 'tank') {
-          if (data.currentTank && data.slashing && data.slashing[data.currentTank]) {
-            return {
-              alertText: {
-                en: 'Sword (Tank Swap)',
-                de: 'Schwert (Tankwechsel)',
-                fr: 'Épée (Tank Swap)',
-                ja: '剣 (スイッチ)',
-                cn: '剑（换T）',
-                ko: '검 (탱커 교대)',
-              },
-            };
-          }
-        }
-
-        return {
-          infoText: {
+      response: (data, _, output) => {
+        // cactbot-builtin-response
+        output.responseOutputStrings = {
+          swordTankSwap: {
+            en: 'Sword (Tank Swap)',
+            de: 'Schwert (Tankwechsel)',
+            fr: 'Épée (Tank Swap)',
+            ja: '剣 (スイッチ)',
+            cn: '剑（换T）',
+            ko: '검 (탱커 교대)',
+          },
+          sword: {
             en: 'Sword',
             de: 'Schwert',
             fr: 'Épée',
@@ -112,6 +107,12 @@
             ko: '검',
           },
         };
+        if (data.role === 'tank') {
+          if (data.currentTank && data.slashing && data.slashing[data.currentTank])
+            return { alertText: output.swordTankSwap() };
+        }
+
+        return { infoText: output.sword() };
       },
       run: (data) => data.soonAfterWeaponChange = true,
     },

--- a/ui/raidboss/data/03-hw/raid/a10s.js
+++ b/ui/raidboss/data/03-hw/raid/a10s.js
@@ -3,6 +3,41 @@
 // Notes:
 // Ignoring Gobsway Rumblerocks (1AA0) aoe trigger, as it is small and frequent.
 
+const chargeOutputStrings = {
+  getIn: {
+    en: 'In',
+    de: 'Rein',
+    fr: 'Intérieur',
+    ja: '中へ',
+    cn: '靠近',
+    ko: '안으로',
+  },
+  getOut: {
+    en: 'Out',
+    de: 'Raus',
+    ja: '外へ',
+    fr: 'Exterieur',
+    cn: '远离',
+    ko: '밖으로',
+  },
+  spread: {
+    en: 'Spread',
+    de: 'Verteilen',
+    fr: 'Dispersez-vous',
+    ja: '散開',
+    cn: '分散',
+    ko: '산개',
+  },
+  stackMarker: {
+    en: 'Stack',
+    de: 'Sammeln',
+    fr: 'Packez-vous',
+    ja: '頭割り',
+    cn: '分摊',
+    ko: '쉐어뎀',
+  },
+};
+
 [{
   zoneId: ZoneId.AlexanderTheBreathOfTheCreatorSavage,
   timelineFile: 'a10s.txt',
@@ -106,16 +141,20 @@
       preRun: function(data, matches) {
         data.charges = data.charges || [];
         data.charges.push({
-          '1AB8': Responses.getIn,
-          '1AB9': Responses.getOut,
-          '1ABA': Responses.spread,
-          '1ABB': Responses.stack,
+          '1AB8': 'getIn',
+          '1AB9': 'getOut',
+          '1ABA': 'spread',
+          '1ABB': 'stackMarker',
         }[matches.id]);
       },
-      response: function(data) {
+      response: function(data, _, output) {
+        // cactbot-builtin-response
+        output.responseOutputStrings = chargeOutputStrings;
+
         // Call the first one out with alert, the other two with info.
-        let severity = data.charges.length > 1 ? 'info' : 'alert';
-        return data.charges[data.charges.length - 1](severity);
+        data.charges = data.charges || [];
+        let severity = data.charges.length > 1 ? 'infoText' : 'alertText';
+        return { [severity]: output[data.charges[data.charges.length - 1]]() };
       },
     },
     {
@@ -140,11 +179,14 @@
       netRegexCn: NetRegexes.ability({ source: '佣兵雷姆普里克斯', id: '1A9[ABCE]', capture: false }),
       netRegexKo: NetRegexes.ability({ source: '용병 레임브릭스', id: '1A9[ABCE]', capture: false }),
       suppressSeconds: 0.5,
-      response: function(data) {
+      response: function(data, _, output) {
+        // cactbot-builtin-response
+        output.responseOutputStrings = chargeOutputStrings;
+
         if (!data.charges || !data.charges.length)
           return;
 
-        return data.charges.shift()('alert');
+        return { alertText: output[data.charges.shift()]() };
       },
     },
     {

--- a/ui/raidboss/data/03-hw/raid/a5s.js
+++ b/ui/raidboss/data/03-hw/raid/a5s.js
@@ -102,14 +102,22 @@ let bombLocation = (matches) => {
     {
       id: 'A5S Concussion',
       netRegex: NetRegexes.gainsEffect({ effectId: '3E4' }),
-      response: function(data, matches) {
-        if (matches.target === data.me)
-          return;
-        if (data.role === 'tank')
-          return Responses.tankSwap('alarm');
-        if (data.job === 'BLU')
-          return Responses.tankSwap('info');
+      condition: (data, matches) => {
+        if (data.me !== matches.target)
+          return false;
+        return data.role === 'tank';
       },
+      response: Responses.tankBusterSwap('alarm'),
+    },
+    {
+      id: 'A5S Concussion BLU',
+      netRegex: NetRegexes.gainsEffect({ effectId: '3E4' }),
+      condition: (data, matches) => {
+        if (data.me !== matches.target)
+          return false;
+        return data.role !== 'tank' && data.job === 'BLU';
+      },
+      response: Responses.tankBusterSwap('info'),
     },
     {
       id: 'A5S Bomb Direction',

--- a/ui/raidboss/data/05-shb/alliance/the_puppets_bunker.js
+++ b/ui/raidboss/data/05-shb/alliance/the_puppets_bunker.js
@@ -457,25 +457,26 @@ const swipeOutputStrings = {
       netRegexDe: NetRegexes.startsUsing({ source: '905P: Läufer', id: '5001' }),
       netRegexFr: NetRegexes.startsUsing({ source: '905P : Avec Unité Terrestre Lourde', id: '5001' }),
       netRegexJa: NetRegexes.startsUsing({ source: '９０５Ｐ：重陸戦ユニット装備', id: '5001' }),
-      response: function(data, matches) {
-        if (data.role === 'tank' || matches.target === data.me) {
-          return {
-            alertText: {
-              en: 'Tank Laser Cleave on YOU',
-              de: 'Tank Laser cleave auf DIR',
-              fr: 'Tank Laser cleave sur VOUS',
-              ko: '탱커 레이저 대상자',
-            },
-          };
-        }
-        return {
-          infoText: {
+      response: function(data, matches, output) {
+        // cactbot-builtin-response
+        output.responseOutputStrings = {
+          tankCleaveOnYou: {
+            en: 'Tank Laser Cleave on YOU',
+            de: 'Tank Laser cleave auf DIR',
+            fr: 'Tank Laser cleave sur VOUS',
+            ko: '탱커 레이저 대상자',
+          },
+          avoidTankCleaves: {
             en: 'Avoid tank laser cleaves',
             de: 'Tank Laser cleave ausweichen',
             fr: 'Évitez les cleaves du laser sur les tanks',
             ko: '탱커 레이저 피하기',
           },
         };
+        if (data.role === 'tank' || matches.target === data.me)
+          return { alertText: output.tankCleaveOnYou() };
+
+        return { infoText: output.avoidTankCleaves() };
       },
     },
     {

--- a/ui/raidboss/data/05-shb/raid/e7s.js
+++ b/ui/raidboss/data/05-shb/raid/e7s.js
@@ -437,20 +437,25 @@
         let oppositeColor = matches.id === '4C5C' ? 'dark' : 'light';
         return data.color === oppositeColor;
       },
-      response: function(data, matches) {
+      response: function(data, matches, output) {
+        // cactbot-builtin-response
+        output.responseOutputStrings = {
+          text: {
+            en: 'Avoid ${player}',
+            de: 'Vermeide ${player}',
+            fr: 'Évitez ${player}',
+            ko: '${player}피하기',
+            cn: '躲开 ${player}',
+          },
+        };
+        if (!data.boundless)
+          return;
+
         // If somebody is taking both, definitely don't stack with them!
         if (data.boundless.light === data.boundless.dark) {
           if (matches.target === data.me)
             return;
-          return {
-            infoText: {
-              en: 'Avoid ' + data.ShortName(matches.target),
-              de: 'Vermeide ' + data.ShortName(matches.target),
-              fr: 'Évitez ' + data.ShortName(matches.target),
-              ko: data.ShortName(matches.target) + '피하기',
-              cn: '躲开 ' + data.ShortName(matches.target),
-            },
-          };
+          return { infoText: output.text({ player: data.ShortName(matches.target) }) };
         }
         return Responses.stackMarkerOn();
       },

--- a/ui/raidboss/data/05-shb/raid/e8s.js
+++ b/ui/raidboss/data/05-shb/raid/e8s.js
@@ -382,34 +382,35 @@
         data.akhMornTargets = data.akhMornTargets || [];
         data.akhMornTargets.push(matches.target);
       },
-      response: function(data, matches) {
-        if (data.me === matches.target) {
-          let onYou = {
+      response: function(data, matches, output) {
+        // cactbot-builtin-response
+        output.responseOutputStrings = {
+          akhMornOnYou: {
             en: 'Akh Morn on YOU',
             de: 'Akh Morn auf DIR',
             fr: 'Akh Morn sur VOUS',
             cn: '死亡轮回点名',
             ko: '아크몬 대상자',
-          };
+          },
+          akhMornOn: {
+            en: 'Akh Morn: ${players}',
+            de: 'Akh Morn: ${players}',
+            fr: 'Akh Morn : ${players}',
+            ko: '아크몬 : ${players}',
+            cn: '死亡轮回: ${players}',
+          },
+        };
+        if (data.me === matches.target) {
           // It'd be nice to have this be an alert, but it mixes with a lot of
           // other alerts (akh rhai "move" and worm's lament numbers).
-          if (data.role === 'tank')
-            return { infoText: onYou };
-          return { alarmText: onYou };
+          return { [data.role === 'tank' ? 'infoText' : 'alarmText']: output.akhMornOnYou() };
         }
         if (data.akhMornTargets.length !== 2)
           return;
         if (data.akhMornTargets.includes(data.me))
           return;
-        return {
-          infoText: {
-            en: 'Akh Morn: ' + data.akhMornTargets.map((x) => data.ShortName(x)).join(', '),
-            de: 'Akh Morn: ' + data.akhMornTargets.map((x) => data.ShortName(x)).join(', '),
-            fr: 'Akh Morn : ' + data.akhMornTargets.map((x) => data.ShortName(x)).join(', '),
-            ko: '아크몬 : ' + data.akhMornTargets.map((x) => data.ShortName(x)).join(', '),
-            cn: '死亡轮回: ' + data.akhMornTargets.map((x) => data.ShortName(x)).join(', '),
-          },
-        };
+        const players = data.akhMornTargets.map((x) => data.ShortName(x)).join(', ');
+        return { infoText: akhMornOn({ players: players }) };
       },
     },
     {

--- a/ui/raidboss/data/05-shb/trial/shiva-un.js
+++ b/ui/raidboss/data/05-shb/trial/shiva-un.js
@@ -49,24 +49,18 @@
       netRegexJa: NetRegexes.ability({ source: 'シヴァ', id: '5367', capture: false }),
       netRegexKo: NetRegexes.ability({ source: '시바', id: '5367', capture: false }),
       netRegexCn: NetRegexes.ability({ source: '希瓦', id: '5367', capture: false }),
-      response: function(data) {
-        if (data.role === 'tank') {
-          if (data.currentTank && data.blunt && data.blunt[data.currentTank]) {
-            return {
-              alertText: {
-                en: 'Staff (Tank Swap)',
-                de: 'Stab (Tankwechsel)',
-                fr: 'Bâton (Tank Swap)',
-                ja: '杖 (スイッチ)',
-                cn: '权杖（换T）',
-                ko: '지팡이 (탱커 교대)',
-              },
-            };
-          }
-        }
-
-        return {
-          infoText: {
+      response: (data, _, output) => {
+        // cactbot-builtin-response
+        output.responseOutputStrings = {
+          staffTankSwap: {
+            en: 'Staff (Tank Swap)',
+            de: 'Stab (Tankwechsel)',
+            fr: 'Bâton (Tank Swap)',
+            ja: '杖 (スイッチ)',
+            cn: '权杖（换T）',
+            ko: '지팡이 (탱커 교대)',
+          },
+          staff: {
             en: 'Staff',
             de: 'Stab',
             fr: 'Bâton',
@@ -75,6 +69,13 @@
             ko: '지팡이',
           },
         };
+
+        if (data.role === 'tank') {
+          if (data.currentTank && data.blunt && data.blunt[data.currentTank])
+            return { alertText: output.staffTankSwap() };
+        }
+
+        return { infoText: output.staff() };
       },
       run: function(data) {
         data.soonAfterWeaponChange = true;
@@ -88,24 +89,18 @@
       netRegexJa: NetRegexes.ability({ source: 'シヴァ', id: '5366', capture: false }),
       netRegexKo: NetRegexes.ability({ source: '시바', id: '5366', capture: false }),
       netRegexCn: NetRegexes.ability({ source: '希瓦', id: '5366', capture: false }),
-      response: function(data) {
-        if (data.role === 'tank') {
-          if (data.currentTank && data.slashing && data.slashing[data.currentTank]) {
-            return {
-              alertText: {
-                en: 'Sword (Tank Swap)',
-                de: 'Schwert (Tankwechsel)',
-                fr: 'Épée (Tank Swap)',
-                ja: '剣 (スイッチ)',
-                cn: '剑（换T）',
-                ko: '검 (탱커 교대)',
-              },
-            };
-          }
-        }
-
-        return {
-          infoText: {
+      response: (data, _, output) => {
+        // cactbot-builtin-response
+        output.responseOutputStrings = {
+          swordTankSwap: {
+            en: 'Sword (Tank Swap)',
+            de: 'Schwert (Tankwechsel)',
+            fr: 'Épée (Tank Swap)',
+            ja: '剣 (スイッチ)',
+            cn: '剑（换T）',
+            ko: '검 (탱커 교대)',
+          },
+          sword: {
             en: 'Sword',
             de: 'Schwert',
             fr: 'Épée',
@@ -114,6 +109,12 @@
             ko: '검',
           },
         };
+        if (data.role === 'tank') {
+          if (data.currentTank && data.slashing && data.slashing[data.currentTank])
+            return { alertText: output.swordTankSwap() };
+        }
+
+        return { infoText: output.sword() };
       },
       run: function(data) {
         data.soonAfterWeaponChange = true;

--- a/ui/raidboss/data/05-shb/trial/varis-ex.js
+++ b/ui/raidboss/data/05-shb/trial/varis-ex.js
@@ -40,7 +40,27 @@
       regex: /^Festina Lente$/,
       beforeSeconds: 6,
       durationSeconds: 6,
-      response: function(data) {
+      response: function(data, _, output) {
+        // cactbot-builtin-response
+        output.responseOutputStrings = {
+          dodgeClonesAndStack: {
+            en: 'Dodge Clones + Stack',
+            de: 'Klonen ausweichen und Sammeln',
+            fr: 'Évitez les Clones + packez-vous',
+            ja: 'ターミナス・エストを避け／頭割り集合',
+            cn: '躲避剑气 + 集合分摊',
+            ko: '분신 피하기 + 집합',
+          },
+          stackMarker: {
+            en: 'Stack',
+            de: 'Sammeln',
+            fr: 'Packez-vous',
+            ja: '頭割り',
+            cn: '分摊',
+            ko: '쉐어뎀',
+          },
+        };
+
         // In any case where you need to position stacks in the right lane,
         // use this special call, no matter how far ahead in time it is.
         if (data.clonesActive) {
@@ -48,18 +68,9 @@
           // In these cases, don't also call out "dodge clones", by setting this variable.
           // For cases where they are far apart, this gets cleared in the cleanup trigger.
           data.suppressDodgeCloneCall = true;
-          return {
-            alertText: {
-              en: 'Dodge Clones + Stack',
-              de: 'Klonen ausweichen und Sammeln',
-              fr: 'Évitez les Clones + packez-vous',
-              ja: 'ターミナス・エストを避け／頭割り集合',
-              cn: '躲避剑气 + 集合分摊',
-              ko: '분신 피하기 + 집합',
-            },
-          };
+          return { alertText: output.dodgeClonesAndStack() };
         }
-        return Responses.stackMarker('alert');
+        return { alertText: output.stackMarker() };
       },
     },
     {
@@ -280,10 +291,21 @@
       netRegexJa: NetRegexes.ability({ source: 'ヴァリス・イェー・ガルヴァス', id: '4CDE', capture: false }),
       netRegexCn: NetRegexes.ability({ source: '瓦厉斯·耶·加尔乌斯', id: '4CDE', capture: false }),
       netRegexKo: NetRegexes.ability({ source: '바리스 예 갈부스', id: '4CDE', capture: false }),
-      response: function(data) {
+      response: function(data, _, output) {
+        // cactbot-builtin-response
+        output.responseOutputStrings = {
+          text: {
+            en: 'Spread',
+            de: 'Verteilen',
+            fr: 'Dispersez-vous',
+            ja: '散開',
+            cn: '分散',
+            ko: '산개',
+          },
+        };
         // This is easily forgetable after dodging and seems to get people killed.
         // This also differentiates spread from the spread => stack in the last phase.
-        return Responses.spread(data.phase === 5 ? 'alarm' : 'alert');
+        return { [data.phase === 5 ? 'alarmText' : 'alertText']: output.text() };
       },
     },
     {

--- a/ui/raidboss/data/05-shb/trial/wol.js
+++ b/ui/raidboss/data/05-shb/trial/wol.js
@@ -289,12 +289,9 @@
       // Both for Absolute Holy and Katon San
       id: 'WOL Absolute Holy Katon San',
       netRegex: NetRegexes.headMarker({ id: '00A1' }),
+      condition: (data) => data.deluge !== data.me,
       delaySeconds: 0.5,
-      response: function(data, matches) {
-        if (data.deluge === data.me)
-          return;
-        return Responses.stackMarkerOn();
-      },
+      response: Responses.stackMarkerOn(),
     },
     {
       id: 'WOL Radiant Braver',


### PR DESCRIPTION
Fix up tests to catch this case.  Also, support output strings that are
string values and not just translatable objects in tests.

It's no longer useful to call Responses dynamically from inside a
`response` object, because we can't dynamically know the output strings
that it will need.  This adds some duplication here, unfortunately.
The long term plan is:
https://github.com/quisquous/cactbot/issues/1307#issuecomment-723486775