### PR TITLE
Raidboss: The Ghimlyt Dark timelines and triggers

### DIFF
--- a/ui/raidboss/data/04-sb/dungeon/ghimlyt_dark.js
+++ b/ui/raidboss/data/04-sb/dungeon/ghimlyt_dark.js
@@ -1,0 +1,110 @@
+'use strict';
+
+[{
+  zoneId: ZoneId.TheGhimlytDark,
+  timelineFile: 'ghimlyt_dark.txt',
+  timelineTriggers: [
+    {
+      id: 'Ghimlyt Dark Prometheus Laser',
+      regex: /Heat/,
+      beforeSeconds: 5,
+      infoText: (data, _, output) => output.text(),
+      outputStrings: {
+        text: {
+          en: 'Avoid laser from wall',
+        },
+      },
+    },
+  ],
+  triggers: [
+    {
+      id: 'Ghimlyt Dark Jarring Blow',
+      netRegex: NetRegexes.startsUsing({ id: '376E', source: 'Mark III-B Magitek Colossus' }),
+      condition: Conditions.caresAboutPhysical(),
+      response: Responses.tankBuster(),
+    },
+    {
+      id: 'Ghimlyt Dark Wild Fire Beam',
+      netRegex: NetRegexes.headMarker({ id: '008B' }),
+      condition: Conditions.targetIsYou(),
+      response: Responses.spread(),
+    },
+    {
+      id: 'Ghimlyt Dark Ceruleum Vent',
+      netRegex: NetRegexes.startsUsing({ id: '3773', source: 'Mark III-B Magitek Colossus', capture: false }),
+      condition: Conditions.caresAboutAOE(),
+      response: Responses.aoe(),
+    },
+    {
+      id: 'Ghimlyt Dark Magitek Ray',
+      netRegex: NetRegexes.headMarker({ id: '003E' }),
+      response: Responses.stackMarkerOn(),
+    },
+    {
+      id: 'Ghimlyt Dark Magitek Slash',
+      netRegex: NetRegexes.startsUsing({ id: '3774', source: 'Mark III-B Magitek Colossus', capture: false }),
+      infoText: (data, _, output) => output.text(),
+      outputStrings: {
+        text: {
+          en: 'Avoid spinning laser',
+        },
+      },
+    },
+    {
+      id: 'Ghimlyt Dark Nitrospin',
+      netRegex: NetRegexes.startsUsing({ id: '3455', source: 'Prometheus', capture: false }),
+      condition: Conditions.caresAboutAOE(),
+      response: Responses.aoe(),
+    },
+    {
+      id: 'Ghimlyt Dark Cermet Drill',
+      netRegex: NetRegexes.startsUsing({ id: '3459', source: 'Prometheus' }),
+      condition: Conditions.caresAboutPhysical(),
+      response: Responses.tankBuster(),
+    },
+    {
+      id: 'Ghimlyt Dark Freezing Missile',
+      netRegex: NetRegexes.startsUsing({ id: '345C', source: 'Prometheus', capture: false }),
+      suppressSeconds: 5,
+      response: Responses.goMiddle(),
+    },
+    {
+      id: 'Ghimlyt Dark Artifical Plasma',
+      netRegex: NetRegexes.startsUsing({ id: '3727', source: 'Julia Quo Soranus', capture: false }),
+      condition: Conditions.caresAboutAOE(),
+      response: Responses.aoe(),
+    },
+    {
+      id: 'Ghimlyt Dark Innocence',
+      netRegex: NetRegexes.startsUsing({ id: '3729', source: 'Julia Quo Soranus' }),
+      condition: Conditions.caresAboutPhysical(),
+      response: Responses.tankBuster(),
+    },
+    {
+      id: 'Ghimlyt Dark Delta Trance',
+      netRegex: NetRegexes.startsUsing({ id: '372A', source: 'Annia Quo Soranus' }),
+      condition: Conditions.caresAboutPhysical(),
+      response: Responses.tankBuster(),
+    },
+    {
+      // This head marker is used on players and NPCs, so we have to exclude NPCs explicitly.
+      id: 'Ghimlyt Dark Heirsbane',
+      netRegex: NetRegexes.headMarker({ id: '0001' }),
+      condition: (data, matches) => matches.targetId[0] !== '4' && data.role === 'healer',
+      infoText: (data, matches, output) => {
+        return output.text({ player: data.ShortName(matches.target) });
+      },
+      outputStrings: {
+        text: {
+          en: 'Incoming damage on ${player}',
+        },
+      },
+    },
+    {
+      id: 'Ghimlyt Dark Covering Fire',
+      netRegex: NetRegexes.headMarker({ id: '0078' }),
+      condition: Conditions.targetIsYou(),
+      response: Responses.spread(),
+    },
+  ],
+}];

--- a/ui/raidboss/data/04-sb/dungeon/ghimlyt_dark.js
+++ b/ui/raidboss/data/04-sb/dungeon/ghimlyt_dark.js
@@ -11,7 +11,7 @@
       infoText: (data, _, output) => output.text(),
       outputStrings: {
         text: {
-          en: 'Avoid laser from wall',
+          en: 'Avoid wall laser',
         },
       },
     },
@@ -41,12 +41,16 @@
       response: Responses.stackMarkerOn(),
     },
     {
+      // 00A7 is the orange clockwise indicator. 00A8 is the blue counterclockwise one.
       id: 'Ghimlyt Dark Magitek Slash',
-      netRegex: NetRegexes.startsUsing({ id: '3774', source: 'Mark III-B Magitek Colossus', capture: false }),
-      infoText: (data, _, output) => output.text(),
+      netRegex: NetRegexes.headMarker({ id: ['00A7', '00A8'] }),
+      infoText: (data, matches, output) => {
+        const direction = matches.id === '00A7' ? 'Left' : 'Right';
+        return output.text({ direction: direction });
+      },
       outputStrings: {
         text: {
-          en: 'Avoid spinning laser',
+          en: 'Rotate ${direction}',
         },
       },
     },
@@ -90,15 +94,8 @@
       // This head marker is used on players and NPCs, so we have to exclude NPCs explicitly.
       id: 'Ghimlyt Dark Heirsbane',
       netRegex: NetRegexes.headMarker({ id: '0001' }),
-      condition: (data, matches) => matches.targetId[0] !== '4' && data.role === 'healer',
-      infoText: (data, matches, output) => {
-        return output.text({ player: data.ShortName(matches.target) });
-      },
-      outputStrings: {
-        text: {
-          en: 'Incoming damage on ${player}',
-        },
-      },
+      condition: (data, matches) => matches.targetId[0] !== '4' && Conditions.caresAboutPhysical()(data, matches),
+      response: Responses.tankBuster(),
     },
     {
       id: 'Ghimlyt Dark Order To Bombard',

--- a/ui/raidboss/data/04-sb/dungeon/ghimlyt_dark.js
+++ b/ui/raidboss/data/04-sb/dungeon/ghimlyt_dark.js
@@ -101,6 +101,11 @@
       },
     },
     {
+      id: 'Ghimlyt Dark Order To Bombard',
+      netRegex: NetRegexes.ability({ id: '3710', source: 'Annia Quo Soranus', capture: false }),
+      response: Responses.knockback(),
+    },
+    {
       id: 'Ghimlyt Dark Covering Fire',
       netRegex: NetRegexes.headMarker({ id: '0078' }),
       condition: Conditions.targetIsYou(),

--- a/ui/raidboss/data/04-sb/dungeon/ghimlyt_dark.js
+++ b/ui/raidboss/data/04-sb/dungeon/ghimlyt_dark.js
@@ -45,12 +45,14 @@
       id: 'Ghimlyt Dark Magitek Slash',
       netRegex: NetRegexes.headMarker({ id: ['00A7', '00A8'] }),
       infoText: (data, matches, output) => {
-        const direction = matches.id === '00A7' ? 'Left' : 'Right';
-        return output.text({ direction: direction });
+        return matches.id === '00A7' ? output.left() : output.right();
       },
       outputStrings: {
-        text: {
-          en: 'Rotate ${direction}',
+        left: {
+          en: 'Rotate left',
+        },
+        right: {
+          en: 'Rotate right',
         },
       },
     },

--- a/ui/raidboss/data/04-sb/dungeon/ghimlyt_dark.txt
+++ b/ui/raidboss/data/04-sb/dungeon/ghimlyt_dark.txt
@@ -92,7 +92,7 @@ hideall "--sync--"
 
 2097.0 "--sync--" sync /:Annia Quo Soranus:370F:/
 2100.0 "Artificial Plasma" sync /:Julia Quo Soranus:3727:/
-2108.2 # "Angry Salamander" sync /:Annia Quo Soranus:372C:/
+2108.2 "Angry Salamander" # sync /:Annia Quo Soranus:372C:/
 2108.4 "Innocence" sync /:Julia Quo Soranus:3729:/
 2117.5 "Commence Air Strike" sync /:Julia Quo Soranus:3716:/
 2119.3 "--sync--" sync /:Julia Quo Soranus:370E:/

--- a/ui/raidboss/data/04-sb/dungeon/ghimlyt_dark.txt
+++ b/ui/raidboss/data/04-sb/dungeon/ghimlyt_dark.txt
@@ -49,14 +49,14 @@ hideall "--sync--"
 
 1000.0 "Start" sync /00:0839:The Impact Crater will be sealed off/ window 1000,1
 1012.2 "Nitrospin" sync /:Prometheus:3455:/
-1023.4 "Needle Gun/Oil Shower" sync /:Prometheus:(345A|3456):/
+1023.4 "Needle Gun" sync /:Prometheus:345A:/
 1031.1 "--untargetable--"
 1031.2 "Tunnel" sync /:Prometheus:3457:/ window 31.2,5
 1042.8 "Heat" duration 4 # sync /:Prometheus:3458:/
 1048.0 "--targetable--"
 
 1056.2 "Unbreakable Cermet Drill" sync /:Prometheus:3459:/ window 30,30
-1068.3 "Needle Gun/Oil Shower" sync /:Prometheus:(345A|3456):/
+1068.3 "Needle Gun" sync /:Prometheus:345A:/
 1075.4 "Needle Gun/Oil Shower" sync /:Prometheus:(345A|3456):/
 1086.4 "Nitrospin" sync /:Prometheus:3455:/
 1097.8 "Freezing Missile (windup)" sync /:Prometheus:345B:/
@@ -67,7 +67,7 @@ hideall "--sync--"
 1118.2 "--targetable--"
 
 1131.5 "Unbreakable Cermet Drill" sync /:Prometheus:3459:/ jump 1056.2
-1143.6 "Needle Gun/Oil Shower"
+1143.6 "Needle Gun"
 1150.7 "Needle Gun/Oil Shower"
 1161.9 "Nitrospin"
 

--- a/ui/raidboss/data/04-sb/dungeon/ghimlyt_dark.txt
+++ b/ui/raidboss/data/04-sb/dungeon/ghimlyt_dark.txt
@@ -1,0 +1,225 @@
+### THE GHIMLYT DARK
+
+hideall "--Reset--"
+hideall "--sync--"
+
+0.0 "--Reset--" sync / 00:0839:.*is no longer sealed/ window 5000 jump 0
+
+#~~~~~~~~~~~~~~~~~~#
+# MAGITEK COLOSSUS #
+#~~~~~~~~~~~~~~~~~~#
+
+# -ii 394F 3775
+
+0 "Start" sync / 00:0839:The Field Of Dust will be sealed off/ window 0,1
+12.9 "Jarring Blow" sync /:Mark III-B Magitek Colossus:376E:/
+15.0 "--sync--" sync /:Mark III-B Magitek Colossus:3771:/
+22.1 "Wild Fire Beam" sync /:Mark III-B Magitek Colossus:3772:/ window 30,30
+28.8 "Magitek Slash x5" sync /:Mark III-B Magitek Colossus:3774:/ duration 8
+45.5 "Exhaust" sync /:Mark III-B Magitek Colossus:3770:/
+55.7 "Ceruleum Vent" sync /:Mark III-B Magitek Colossus:3773:/
+
+68.0 "Magitek Slash x5" sync /:Mark III-B Magitek Colossus:3774:/ duration 8
+80.2 "Magitek Slash x5" sync /:Mark III-B Magitek Colossus:3774:/ duration 8
+97.4 "Magitek Ray" sync /:Mark III-B Magitek Colossus:376F:/
+102.6 "Exhaust" sync /:Mark III-B Magitek Colossus:3770:/
+116.8 "Ceruleum Vent" sync /:Mark III-B Magitek Colossus:3773:/ window 20,20
+120.0 "--sync--" sync /:Mark III-B Magitek Colossus:3771:/
+127.1 "Wild Fire Beam" sync /:Mark III-B Magitek Colossus:3772:/
+133.1 "Magitek Ray" sync /:Mark III-B Magitek Colossus:376F:/
+138.3 "Exhaust" sync /:Mark III-B Magitek Colossus:3770:/
+143.7 "Exhaust" sync /:Mark III-B Magitek Colossus:3770:/
+156.0 "Jarring Blow" sync /:Mark III-B Magitek Colossus:376E:/ window 30,30
+162.1 "Ceruleum Vent" sync /:Mark III-B Magitek Colossus:3773:/
+169.3 "Ceruleum Vent" sync /:Mark III-B Magitek Colossus:3773:/
+
+176.5 "Magitek Slash x5" sync /:Mark III-B Magitek Colossus:3774:/ jump 68.0
+188.7 "Magitek Slash x5"
+205.9 "Magitek Ray"
+211.1 "Exhaust"
+
+#~~~~~~~~~~~~#
+# PROMETHEUS #
+#~~~~~~~~~~~~#
+
+# Unfortunately there are no log lines for when Prometheus fires after using Heat.
+
+# -ic "Lyse" "Pipin Of The Steel Heart" "Schola Centurion" "Schola Laquearius" "Schola Signifer"
+# -ii 3AC6
+
+1000.0 "Start" sync /00:0839:The Impact Crater will be sealed off/ window 1000,1
+1012.2 "Nitrospin" sync /:Prometheus:3455:/
+1023.4 "Needle Gun/Oil Shower" sync /:Prometheus:(345A|3456):/
+1031.1 "--untargetable--"
+1031.2 "Tunnel" sync /:Prometheus:3457:/ window 31.2,5
+1042.8 "Heat" duration 4 # sync /:Prometheus:3458:/
+1048.0 "--targetable--"
+
+1056.2 "Unbreakable Cermet Drill" sync /:Prometheus:3459:/ window 30,30
+1068.3 "Needle Gun/Oil Shower" sync /:Prometheus:(345A|3456):/
+1075.4 "Needle Gun/Oil Shower" sync /:Prometheus:(345A|3456):/
+1086.4 "Nitrospin" sync /:Prometheus:3455:/
+1097.8 "Freezing Missile (windup)" sync /:Prometheus:345B:/
+1100.4 "--untargetable--"
+1100.5 "Tunnel" sync /:Prometheus:3457:/ window 30,30
+1108.9 "Freezing Missile (cast)" sync /:Prometheus:345C:/
+1113.1 "Heat" duration 4 # sync /:Prometheus:3458:/
+1118.2 "--targetable--"
+
+1131.5 "Unbreakable Cermet Drill" sync /:Prometheus:3459:/ jump 1056.2
+1143.6 "Needle Gun/Oil Shower"
+1150.7 "Needle Gun/Oil Shower"
+1161.9 "Nitrospin"
+
+
+#~~~~~~~~~~~~~#
+# SORANUS DUO #
+#~~~~~~~~~~~~~#
+
+2000.0 "Start" sync /00:0839:The Provisional Imperial Landing will be sealed off/ window 2000,5
+2000.4 "--sync--" sync /:Annia Quo Soranus:370F:/ jump 2097.0
+2000.4 "--sync--" sync /:Julia Quo Soranus:370E:/ jump 2297.0
+2003.4 "Artificial Plasma?"
+2010.6 "Heirsbane?"
+2011.6 "Angry Salamander?"
+2011.8 "Innocence?"
+2013.5 "Delta Trance?"
+2018.2 "Heirsbane?"
+2020.9 "Commence Air Strike?"
+
+
+# Julia active
+
+2097.0 "--sync--" sync /:Annia Quo Soranus:370F:/
+2100.0 "Artificial Plasma" sync /:Julia Quo Soranus:3727:/
+2108.2 # "Angry Salamander" sync /:Annia Quo Soranus:372C:/
+2108.4 "Innocence" sync /:Julia Quo Soranus:3729:/
+2117.5 "Commence Air Strike" sync /:Julia Quo Soranus:3716:/
+2119.3 "--sync--" sync /:Julia Quo Soranus:370E:/
+2121.8 "Roundhouse" sync /:Annia Quo Soranus:3718:/
+
+# We have to sync widely here because if Julia is first she skips one Aglaia Bite.
+2124.7 "Heirsbane" sync /:Julia Quo Soranus:3719:/ window 15,15
+2127.6 "Burst x5" duration 8 # sync /:Ceruleum Tank:371A:/
+2132.3 "Angry Salamander" sync /:Annia Quo Soranus:372C:/
+2145.2 "Artificial Plasma" sync /:Julia Quo Soranus:3727:/
+2147.9 "Angry Salamander" sync /:Annia Quo Soranus:372C:/
+2151.4 "--sync--" sync /:Julia Quo Soranus:370E:/
+
+# During the rotation block, we can't sync Aglaia Bite,
+# since the double usage is just too close together.
+2153.2 "The Order" sync /:Julia Quo Soranus:3713:/ window 30,30
+2158.3 "Order To Fire" sync /:Annia Quo Soranus:372D:/
+2158.3 "Missile Impact" sync /:Annia Quo Soranus:372E:/
+2159.3 "The Order" sync /:Julia Quo Soranus:39BA:/
+2159.3 "Quaternity" sync /:Soranus Duo:3989:/
+2164.6 "Artificial Plasma" sync /:Julia Quo Soranus:3727:/
+2168.8 "Angry Salamander" sync /:Annia Quo Soranus:372C:/
+2174.9 "Artificial Plasma" sync /:Julia Quo Soranus:3727:/
+2182.2 "Angry Salamander" sync /:Annia Quo Soranus:372C:/
+2183.2 "Innocence" sync /:Julia Quo Soranus:3729:/
+2192.5 "Commence Air Strike" sync /:Julia Quo Soranus:3716:/ window 30,30
+2194.1 "--sync--" sync /:Julia Quo Soranus:370E:/
+2194.8 "Aglaia Bite" # sync /:Annia Quo Soranus:3717:/
+2196.9 "Aglaia Bite/Roundhouse" # sync /:Annia Quo Soranus:371[78]:/
+2199.6 "Heirsbane" sync /:Julia Quo Soranus:3719:/
+2202.5 "Burst x5" duration 12 # sync /:Ceruleum Tank:371A:/
+2207.2 "Angry Salamander" sync /:Annia Quo Soranus:372C:/
+2220.2 "Artificial Plasma" sync /:Julia Quo Soranus:3727:/
+2222.8 "Angry Salamander" sync /:Annia Quo Soranus:372C:/
+2226.3 "--sync--" sync /:Julia Quo Soranus:370E:/
+
+2228.1 "The Order" sync /:Julia Quo Soranus:3713:/ window 30,30 jump 2153.2
+2233.2 "Order To Fire"
+2233.2 "Missile Impact"
+2234.2 "The Order"
+2234.2 "Quaternity"
+2239.5 "Artificial Plasma"
+2243.7 "Angry Salamander"
+2249.8 "Artificial Plasma"
+2257.1 "Angry Salamander"
+2258.1 "Innocence"
+
+# Annia active
+
+2297.0 "--sync--" sync /:Julia Quo Soranus:370E:/
+2307.2 "Heirsbane" sync /:Julia Quo Soranus:372B:/
+2310.3 "Delta Trance" sync /:Annia Quo Soranus:372A:/
+2314.9 "Heirsbane" sync /:Julia Quo Soranus:372B:/
+2321.3 "The Order" sync /:Julia Quo Soranus:3713:/
+2325.1 "Order To Bombard" sync /:Annia Quo Soranus:3710:/
+2327.5 "--sync--" sync /:Annia Quo Soranus:370F:/
+
+2329.5 "The Order" sync /:Julia Quo Soranus:3714:/ window 30,30
+2329.7 "Crossbones" sync /:Soranus Duo:3C80:/
+2331.6 "Angry Salamander" sync /:Annia Quo Soranus:372C:/
+2332.4 "Bombardment" sync /:Annia Quo Soranus:3711:/
+2340.5 "The Order" sync /:Julia Quo Soranus:3713:/
+2341.9 "Artificial Plasma" sync /:Annia Quo Soranus:3728:/
+2347.1 "Quaternity" sync /:Soranus Duo:3733:/
+2347.1 "The Order" sync /:Julia Quo Soranus:39BA:/ window 30,30
+2351.7 "Delta Trance" sync /:Annia Quo Soranus:372A:/
+2355.8 "Heirsbane" sync /:Julia Quo Soranus:372B:/
+2361.8 "Stunning Sweep" sync /:Annia Quo Soranus:3712:/
+2363.1 "Heirsbane" sync /:Julia Quo Soranus:372B:/
+2370.8 "Artificial Plasma" sync /:Annia Quo Soranus:3728:/
+2382.3 "The Order" sync /:Julia Quo Soranus:3713:/
+2386.1 "Order To Bombard" sync /:Annia Quo Soranus:3710:/
+2388.5 "--sync--" sync /:Annia Quo Soranus:370F:/
+
+2390.5 "The Order" sync /:Julia Quo Soranus:3714:/ jump 2329.5 window 30,30
+2390.7 "Crossbones"
+2392.6 "Angry Salamander"
+2393.4 "Bombardment"
+2401.5 "The Order"
+2402.9 "Artificial Plasma"
+2408.1 "Quaternity"
+2408.1 "The Order"
+2412.7 "Delta Trance"
+2416.8 "Heirsbane"
+
+# Intermission
+
+# Order To Support and Covering Fire are only on the second intermission.
+
+
+2494.3 "Order To Support" sync /:Annia Quo Soranus:371B:/ window 494.3,5
+2500.0 "Crosshatch" sync /:Soranus Duo:3721:/ window 500,5
+2506.6 "--sync--" sync /:Annia Quo Soranus:3723:/
+2506.8 "--sync--" sync /:Julia Quo Soranus:384B:/
+2507.1 "--sync--" sync /:Annia Quo Soranus:384C:/
+2507.4 "--sync--" sync /:Julia Quo Soranus:3724:/
+2508.2 "--sync--" sync /:Annia Quo Soranus:396A:/
+2508.6 "--sync--" sync /:Julia Quo Soranus:3969:/
+2508.7 "Crosshatch 1" # sync /:Annia Quo Soranus:3722:/
+2508.9 "Crosshatch 2" # sync /:Julia Quo Soranus:3722:/
+2509.0 "--sync--" sync /:Annia Quo Soranus:384D:/
+2509.4 "Covering Fire?" sync /:Annia Quo Soranus:371C:/
+2509.4 "Crosshatch 3" # sync /:Annia Quo Soranus:3722:/
+2509.6 "--sync--" sync /:Julia Quo Soranus:396B:/
+2509.9 "Crosshatch 4" # sync /:Julia Quo Soranus:3722:/
+2511.1 "Crosshatch 5" # sync /:Annia Quo Soranus:3722:/
+2511.8 "Crosshatch 6" # sync /:Julia Quo Soranus:3722:/
+2512.3 "Crosshatch 7" # sync /:Annia Quo Soranus:3722:/
+2512.8 "Crosshatch 8" # sync /:Julia Quo Soranus:3722:/
+2515.9 "--sync--" sync /:Julia Quo Soranus:3726:/
+2516.0 "--sync--" sync /:Annia Quo Soranus:3725:/
+2519.0 "--sync--" sync /:Annia Quo Soranus:370F:/ window 10,10 jump 2097.0
+2519.0 "--sync--" sync /:Julia Quo Soranus:370E:/ window 10,10 jump 2297.0
+2522.4 "Artificial Plasma?"
+2529.6 "Heirsbane?"
+2530.6 "Angry Salamander?"
+2530.8 "Innocence?"
+2532.5 "Delta Trance?"
+2537.2 "Heirsbane?"
+2539.9 "Commence Air Strike?"
+
+# Enrage after two intermissions.
+
+# 2597.3 "--sync--" sync /:372F:Julia Quo Soranus/ window 597.3
+2597.3 "Artificial Boost" sync /:3730:Annia Quo Soranus/ window 597.3
+# 2600.0 "--sync--" sync /:Julia Quo Soranus:372F:/ window 600,5
+2600.0 "Artificial Boost" sync /:Annia Quo Soranus:3730:/ window 600,5
+# 2603.2 "--sync--" sync /:3731:Julia Quo Soranus/
+2603.2 "Imperial Authority" sync /:3732:Annia Quo Soranus/ duration 39.7
+2642.9 "Imperial Authority Enrage" sync /:Annia Quo Soranus:3732:/ 

--- a/ui/raidboss/data/manifest.txt
+++ b/ui/raidboss/data/manifest.txt
@@ -102,6 +102,8 @@
 04-sb/dungeon/drowned_city_of_skalla.js
 04-sb/dungeon/fractal_continuum_hard.js
 04-sb/dungeon/fractal_continuum_hard.txt
+04-sb/dungeon/ghimlyt_dark.js
+04-sb/dungeon/ghimlyt_dark.txt
 04-sb/dungeon/hells_lid.js
 04-sb/dungeon/hells_lid.txt
 04-sb/dungeon/temple_of_the_fist.js


### PR DESCRIPTION
The direction the Colossus spins for Magitek Slash is indicated by a head marker, but I couldn't think of a concise way to convey that to the player usefully. Slash itself seems to have a slightly variable timing, up to about 0.5 seconds in either direction, so I just called it good and left it, since everything else seemed to line up okay.

On Prometheus, Needle Gun/Oil Shower are the cast-time telegraphed 90-degree frontal and 270-degree rear cleaves. When running solo, Needle Gun is used twice, while on all my test runs with party members it was invariably Needle Gun followed by Oil Shower. I'm *relatively* sure it's determined by whether there's a target within the affected radius at the time the cast starts, but I figured it was safe to just account for both possibilities.

I didn't see anything easily usable in the logs to indicate where the wall laser was coming from. The glowy spot is visible earlier than the timeline-based notification, but this is the earliest we can tell the user to move without colliding with the Freezing Missile notification. (We could theoretically remove that one though, I just added it because a *lot* of people seem to miss the proximity markers.)

The Soranus Duo is remarkably free of the issues that plagued the Igeyorhm/LahabreaD encounter in Aetherochemical Research Facility. The inactive member's actions don't seem to misalign too much. I did have to remove a couple of syncs here and there where it caused really weird artifacts for `test_timeline`, as for example:

```
2099.987: Matched entry: 2100.0 Artificial Plasma (+0.013s)
2108.146: Matched entry: 2108.4 Innocence (+0.254s)
    Missed sync: Angry Salamander at 2108.2 (last seen at 2331.6209999999996)
2108.400: Matched entry: 2108.2 Angry Salamander (-0.200s)
2108.333: Matched entry: 2108.4 Innocence (+0.067s)
```

I'm not overlay attached to the numerous `--sync--` elements during the Crosshatch intermission, but I thought it might be best to leave them in since we can't sync to the actual Crosshatch casts. (Plus, out of all the phase loops, these syncs are the most exact each run, on the order of milliseconds.)