### PR TITLE
ci: Fix GitHub Actions Using set-env

### DIFF
--- a/.github/workflows/build-artifact.yml
+++ b/.github/workflows/build-artifact.yml
@@ -55,7 +55,7 @@ jobs:
         python .\util\fetch_deps.py
 
     - name: Set up msbuild
-      uses: microsoft/setup-msbuild@v1.0.1
+      uses: microsoft/setup-msbuild@v1.0.2
 
     - name: Add Custom Problem Matcher
       run: |

--- a/.github/workflows/build-artifact.yml
+++ b/.github/workflows/build-artifact.yml
@@ -31,7 +31,7 @@ jobs:
       shell: bash
       run: |
         sha=$(echo ${{ github.sha }} | cut -c 1-8)
-        echo "::set-env name=artifact_sha::$sha"
+        echo "artifact_sha=$sha" >> $GITHUB_ENV
 
     - name: Check dependencies cache
       id: cache-dependencies

--- a/.github/workflows/create-tag.yml
+++ b/.github/workflows/create-tag.yml
@@ -25,7 +25,7 @@ jobs:
 
           # Check both AssemblyInfo files have the correct version
           if cat plugin/CactbotEventSource/Properties/AssemblyInfo.cs | grep -q ${VERSION} && cat plugin/CactbotOverlay/Properties/AssemblyInfo.cs | grep -q ${VERSION}; then
-            echo "::set-env name=TAG_NAME::v$VERSION"
+            echo "TAG_NAME=v$VERSION" >> $GITHUB_ENV
             echo "Matching assembly file version values found."
           else
             echo "Different assembly file version values found. Skipping tag creation..."

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
       # Gets the numerical output of the git tag and assigns it to an environment variable
       - name: Get Tag Version
         run: |
-          echo ::set-env name=CACTBOT_RELEASE::cactbot-${GITHUB_REF#refs/tags/v}
+          echo "CACTBOT_RELEASE=cactbot-${GITHUB_REF#refs/tags/v}" >> $GITHUB_ENV
         shell: bash
       - name: Check dependencies cache
         id: cache-dependencies


### PR DESCRIPTION
Apparently there is a [security vulnerability](https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/) in using `set-env`. Updating all `set-env` invocations to use the `$GITHUB_ENV` file, as described in [the updated workflow documentation.](https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-commands-for-github-actions#environment-files)