### PR TITLE
ci: set retention of artifacts as 30 days

### DIFF
--- a/.github/workflows/build-artifact.yml
+++ b/.github/workflows/build-artifact.yml
@@ -74,3 +74,4 @@ jobs:
       with:
         name: cactbot-${{ env.artifact_sha }}
         path: publish/cactbot-release/
+        retention-days: 30


### PR DESCRIPTION
According to https://github.blog/changelog/2020-10-08-github-actions-ability-to-change-retention-days-for-artifacts-and-logs/ ,
we can set retention days as 30,
so don't need to keep massive artifact storage within default 90 days.