### PR TITLE
Jobs: Add combo timer for WAR, DRK, MCH

### DIFF
--- a/ui/jobs/jobs.css
+++ b/ui/jobs/jobs.css
@@ -468,6 +468,10 @@
   background-color: rgb(20, 50, 20);
 }
 
+.combo-color {
+  background-color: rgb(180, 200, 220);
+}
+
 /* PLD */
 .pld-color-oath {
   background-color: rgb(255, 210, 45);
@@ -534,10 +538,6 @@
 
 .gnb-color-cartridge.full {
   background-color: rgb(250, 86, 45);
-}
-
-.gnb-color-combo {
-  background-color: rgb(180, 200, 220);
 }
 
 .gnb-color-gnashingfang {
@@ -778,10 +778,6 @@
   background-color: rgb(255, 42, 0);
 }
 
-.nin-color-combo {
-  background-color: rgb(180, 200, 220);
-}
-
 /* SAM */
 
 /* BRD */
@@ -828,10 +824,6 @@
 /* MCH */
 
 /* DNC */
-.dnc-color-combo {
-  background-color: rgb(180, 200, 220);
-}
-
 .dnc-color-standardstep {
   background-color: rgb(235, 235, 50);
 }

--- a/ui/jobs/jobs.js
+++ b/ui/jobs/jobs.js
@@ -1928,7 +1928,7 @@ class Bars {
         eyeBox.threshold = newThreshold;
       else
         eyeBox.threshold = oldThreshold;
-      
+
       comboTimer.duration = 0;
       if (this.combo.isFinalSkill)
         return;

--- a/ui/jobs/jobs.js
+++ b/ui/jobs/jobs.js
@@ -1850,6 +1850,11 @@ class Bars {
       fgColor: 'war-color-eye',
     });
 
+    const comboTimer = this.addTimerBar({
+      id: 'war-timers-combo',
+      fgColor: 'combo-color',
+    });
+
     this.comboFuncs.push((skill) => {
       // TODO: remove this condition when CN or KO launch patch 5.3
       if (this.options.ParserLanguage === 'cn' || this.options.ParserLanguage === 'ko') {
@@ -1923,6 +1928,12 @@ class Bars {
         eyeBox.threshold = newThreshold;
       else
         eyeBox.threshold = oldThreshold;
+      
+      comboTimer.duration = 0;
+      if (this.combo.isFinalSkill)
+        return;
+      if (skill)
+        comboTimer.duration = 15;
     });
 
     this.loseEffectFuncMap[EffectId.StormsEye] = () => {
@@ -1972,6 +1983,19 @@ class Bars {
         darksideBox.duration = seconds;
       }
     });
+
+    const comboTimer = this.addTimerBar({
+      id: 'drk-timers-combo',
+      fgColor: 'combo-color',
+    });
+
+    this.comboFuncs.push((skill) => {
+      comboTimer.duration = 0;
+      if (this.combo.isFinalSkill)
+        return;
+      if (skill)
+        comboTimer.duration = 15;
+    });
   }
 
   setupGnb() {
@@ -2018,7 +2042,7 @@ class Bars {
     });
     const comboTimer = this.addTimerBar({
       id: 'gnb-timers-combo',
-      fgColor: 'gnb-color-combo',
+      fgColor: 'combo-color',
     });
     const cartridgeComboTimer = this.addTimerBar({
       id: 'gnb-timers-cartridgecombo',
@@ -2632,7 +2656,7 @@ class Bars {
     });
     const comboTimer = this.addTimerBar({
       id: 'nin-timers-combo',
-      fgColor: 'nin-color-combo',
+      fgColor: 'combo-color',
     });
     this.comboFuncs.push((skill) => {
       comboTimer.duration = 0;
@@ -2807,7 +2831,7 @@ class Bars {
   setupDnc() {
     const comboTimer = this.addTimerBar({
       id: 'dnc-timers-combo',
-      fgColor: 'dnc-color-combo',
+      fgColor: 'combo-color',
     });
     this.comboFuncs.push((skill) => {
       comboTimer.duration = 0;

--- a/ui/jobs/jobs.js
+++ b/ui/jobs/jobs.js
@@ -1611,7 +1611,7 @@ class Bars {
       'NIN': this.setupNin,
       'SAM': this.setupSam,
       'BRD': this.setupBrd,
-      // 'MCH': this.setupMch,
+      'MCH': this.setupMch,
       'DNC': this.setupDnc,
       'BLM': this.setupBlm,
       'SMN': this.setupSmn,
@@ -2824,9 +2824,20 @@ class Bars {
     };
   }
 
-  // setupMch() {
+  setupMch() {
+    const comboTimer = this.addTimerBar({
+      id: 'mch-timers-combo',
+      fgColor: 'combo-color',
+    });
 
-  // }
+    this.comboFuncs.push((skill) => {
+      comboTimer.duration = 0;
+      if (this.combo.isFinalSkill)
+        return;
+      if (skill)
+        comboTimer.duration = 15;
+    });
+  }
 
   setupDnc() {
     const comboTimer = this.addTimerBar({


### PR DESCRIPTION
These jobs have a lot of insertable skills that do not break combo(like FC*5), but easy to let combo timeout.
Besides, combotimers share a same color across jobs, so merge them.