### PR TITLE
Jobs: Fix bar in stack guage

### DIFF
--- a/ui/jobs/jobs.css
+++ b/ui/jobs/jobs.css
@@ -75,7 +75,7 @@
 .bar-container {
   position: relative;
   width: 201px;
-  height: 7px;
+  height: 0;
   background: rgba(30, 30, 30, 0.7);
 }
 


### PR DESCRIPTION
Due to #2043 , there is a mistake that an unnecessary bar appear in the stack guage.
Other bars define there height there own, but delete this line seems result in a default height, so change it to 0.