### PR TITLE
Util: Automate zone seal messages in make_timeline

### DIFF
--- a/util/make_timeline.py
+++ b/util/make_timeline.py
@@ -175,15 +175,32 @@ def parse_file(args):
 
             # We're looking for enemy casts or enemies becoming targetable/untargetable.
             # These lines will start with 21, 22, or 34, and have an NPC ID (400#####)
-            # If this isn't one, skip the line
+            # If there's a zone seal, we want that also.
+            # If none of these apply, skip the line
 
-            if not (line[0:2] in ["21", "22", "34"]) or not line[37:40] == "400":
+            if (not line[0:2] in ["21", "22", "34"] or not line[37:40] == "400") and line[0:2] != "00":
                 continue
             line_fields = line.split("|")
             # We aren't including targetable lines unless the user explicitly says to.
             if line[0:2] == "34" and not line_fields[3] in args.include_targetable:
                 continue
 
+            # If it's a zone seal, we want to make a special entry.
+            if e_tools.is_zone_seal(line_fields):
+                entry = make_entry(
+                    {
+                        "line_type": "zone_seal",
+                        "time": e_tools.parse_event_time(line),
+                        "zone_message": line_fields[4].split(" will be sealed off")[0]
+                    }
+                )
+                entries.append(entry)
+                continue
+
+            # If we're here, we don't care about any other 00 log lines.
+            if line[0:2] == "00":
+                continue
+                
             # At this point, we have a combat line for the timeline.
             entry = make_entry(
                 {
@@ -266,7 +283,11 @@ def main(args):
     last_entry = make_entry({})
 
     output = []
-    output.append('0 "Start" sync /Engage!/ window 0,1')
+    if entries[0]["line_type"] and entries[0]["line_type"] == "zone_seal":
+        output.append('0 "Start" sync /00:0839:{} will be sealed off/ window 0,1'.format(entries[0]["zone_message"].title()))
+        entries.pop(0)
+    else:
+        output.append('0 "Start" sync /Engage!/ window 0,1')
 
     for entry in entries:
 

--- a/util/make_timeline.py
+++ b/util/make_timeline.py
@@ -178,7 +178,7 @@ def parse_file(args):
                         {
                             "line_type": "zone_seal",
                             "time": e_tools.parse_event_time(line),
-                            "zone_message": line.split("|")[4].split(" will be sealed off")[0]
+                            "zone_message": line.split("|")[4].split(" will be sealed off")[0],
                         }
                     )
                     entries.append(entry)
@@ -276,7 +276,11 @@ def main(args):
 
     output = []
     if entries[0]["line_type"] and entries[0]["line_type"] == "zone_seal":
-        output.append('0 "Start" sync /00:0839:{} will be sealed off/ window 0,1'.format(entries[0]["zone_message"].title()))
+        output.append(
+            '0 "Start" sync /00:0839:{} will be sealed off/ window 0,1'.format(
+                entries[0]["zone_message"].title()
+            )
+        )
         entries.pop(0)
     else:
         output.append('0 "Start" sync /Engage!/ window 0,1')

--- a/util/make_timeline.py
+++ b/util/make_timeline.py
@@ -172,35 +172,27 @@ def parse_file(args):
             if not started:
                 started = True
                 last_ability_time = e_tools.parse_event_time(line)
+                # If it's a zone seal, we want to make a special entry.
+                if e_tools.is_zone_seal(line.split("|")):
+                    entry = make_entry(
+                        {
+                            "line_type": "zone_seal",
+                            "time": e_tools.parse_event_time(line),
+                            "zone_message": line.split("|")[4].split(" will be sealed off")[0]
+                        }
+                    )
+                    entries.append(entry)
 
             # We're looking for enemy casts or enemies becoming targetable/untargetable.
             # These lines will start with 21, 22, or 34, and have an NPC ID (400#####)
-            # If there's a zone seal, we want that also.
             # If none of these apply, skip the line
 
-            if (not line[0:2] in ["21", "22", "34"] or not line[37:40] == "400") and line[0:2] != "00":
+            if not line[0:2] in ["21", "22", "34"] or not line[37:40] == "400":
                 continue
             line_fields = line.split("|")
             # We aren't including targetable lines unless the user explicitly says to.
             if line[0:2] == "34" and not line_fields[3] in args.include_targetable:
                 continue
-
-            # If it's a zone seal, we want to make a special entry.
-            if e_tools.is_zone_seal(line_fields):
-                entry = make_entry(
-                    {
-                        "line_type": "zone_seal",
-                        "time": e_tools.parse_event_time(line),
-                        "zone_message": line_fields[4].split(" will be sealed off")[0]
-                    }
-                )
-                entries.append(entry)
-                continue
-
-            # If we're here, we don't care about any other 00 log lines.
-            if line[0:2] == "00":
-                continue
-                
             # At this point, we have a combat line for the timeline.
             entry = make_entry(
                 {


### PR DESCRIPTION
This is another one of those little annoying things that bugged me enough to fix. This will automagically fill in the zone name, title-cased, if the start event is a zone seal.

I'm really not happy with the setup I used to do this, but the approach suffers from some circular problems. `is_zone_seal` depends on being fed pre-split log lines, but during each iteration of the loop, we don't split until after we might already have rejected a zone-seal message. I'd rather not split every log line for performance reasons. I guess maybe we could instead rewrite the "set `started` to true" block to be more like this?

```
            if not started:
                started = True
                last_ability_time = e_tools.parse_event_time(line)
                if e_tools.is_zone_seal(line.split("|")):
                    entry = make_entry(
                        {
                            "line_type": "zone_seal",
                            "time": e_tools.parse_event_time(line),
                            "zone_message": line_fields[4].split(" will be sealed off")[0]
                        }
                    )
                    entries.append(entry)
```

I'm also not terribly happy with selecting the type of start line in `main`, but there's not a lot of help for that without a drastic re-write.

EDIT: Never mind, it's clearly better to make the special entry at the time we know it's the start line. Let's just avoid the considerations altogether.