### PR TITLE
style: add default Chinese font.

### DIFF
--- a/resources/defaults.css
+++ b/resources/defaults.css
@@ -33,6 +33,25 @@ body {
     sans-serif;
 }
 
+@font-face {
+  font-family: "黑体";
+  src: url(https://act.diemoe.net/overlays/common/SmartisanHei.ttf);
+  font-weight: normal;
+  font-style: normal;
+}
+
+.lang-cn .text {
+  font-family:
+    "黑体",
+    "SimHei",
+    "微软雅黑",
+    "Microsoft Yahei UI",
+    "Lato",
+    Arial,
+    Helvetica,
+    sans-serif;
+}
+
 .hide {
   display: none !important;
 }


### PR DESCRIPTION
As mentioned in #2042 , this PR changed the default font for Chinese.
For 黑体(SimHei) font, I used @DieMoe233 's mirror, which has better display readability, larger charset, and wide accessibility in mainland China.
For those players who are not in mainland China, or just failed in downloading the font, their default font would fallback to just SimHei, which included in Windows Chinese language pack.