### PR TITLE
ci: add eslint custom rules for locale order

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -152,6 +152,7 @@
     "unicode-bom": [
       "error",
       "never"
-    ]
+    ],
+    "cactbot-locale-order": "warn"
   }
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -10,5 +10,10 @@
   "search.exclude": {
     "**/node_modules": true,
     "dist/**": true
-  }
+  },
+  "eslint.options": {
+    "rulePaths": [
+      "./eslint"
+    ]
+  },
 }

--- a/eslint/cactbot-locale-order.js
+++ b/eslint/cactbot-locale-order.js
@@ -7,145 +7,6 @@ const orderMap = {
   ko: 5,
 };
 
-/**
- * Determines whether the given node is a `null` literal.
- * @param {ASTNode} node The node to check
- * @return {boolean} `true` if the node is a `null` literal
- */
-function isNullLiteral(node) {
-  /*
-   * Checking `node.value === null` does not guarantee that a literal is a null literal.
-   * When parsing values that cannot be represented in the current environment (e.g. unicode
-   * regexes in Node 4), `node.value` is set to `null` because it wouldn't be possible to
-   * set `node.value` to a unicode regex. To make sure a literal is actually `null`, check
-   * `node.regex` instead. Also see: https://github.com/eslint/eslint/issues/8020
-   */
-  return node.type === 'Literal' && node.value === null && !node.regex && !node.bigint;
-}
-
-
-/**
- * Returns the result of the string conversion applied to the evaluated value of the given expression node,
- * if it can be determined statically.
- *
- * This function returns a `string` value for all `Literal` nodes and simple `TemplateLiteral` nodes only.
- * In all other cases, this function returns `null`.
- * @param {ASTNode} node Expression node.
- * @return {string|null} String value if it can be determined. Otherwise, `null`.
- */
-function getStaticStringValue(node) {
-  switch (node.type) {
-  case 'Literal':
-    if (node.value === null) {
-      if (isNullLiteral(node))
-        return String(node.value); // "null"
-
-      if (node.regex)
-        return `/${node.regex.pattern}/${node.regex.flags}`;
-
-      if (node.bigint)
-        return node.bigint;
-
-
-      // Otherwise, this is an unknown literal. The function will return null.
-    } else {
-      return String(node.value);
-    }
-    break;
-  case 'TemplateLiteral':
-    if (node.expressions.length === 0 && node.quasis.length === 1)
-      return node.quasis[0].value.cooked;
-
-    break;
-
-    // no default
-  }
-
-  return null;
-}
-
-
-/**
- * Gets the property name of a given node.
- * The node can be a MemberExpression, a Property, or a MethodDefinition.
- *
- * If the name is dynamic, this returns `null`.
- *
- * For examples:
- *
- *     a.b           // => "b"
- *     a["b"]        // => "b"
- *     a['b']        // => "b"
- *     a[`b`]        // => "b"
- *     a[100]        // => "100"
- *     a[b]          // => null
- *     a["a" + "b"]  // => null
- *     a[tag`b`]     // => null
- *     a[`${b}`]     // => null
- *
- *     let a = {b: 1}            // => "b"
- *     let a = {["b"]: 1}        // => "b"
- *     let a = {['b']: 1}        // => "b"
- *     let a = {[`b`]: 1}        // => "b"
- *     let a = {[100]: 1}        // => "100"
- *     let a = {[b]: 1}          // => null
- *     let a = {["a" + "b"]: 1}  // => null
- *     let a = {[tag`b`]: 1}     // => null
- *     let a = {[`${b}`]: 1}     // => null
- * @param {ASTNode} node The node to get.
- * @return {string|null} The property name if static. Otherwise, null.
- */
-function getStaticPropertyName(node) {
-  let prop;
-
-  switch (node && node.type) {
-  case 'ChainExpression':
-    return getStaticPropertyName(node.expression);
-
-  case 'Property':
-  case 'MethodDefinition':
-    prop = node.key;
-    break;
-
-  case 'MemberExpression':
-    prop = node.property;
-    break;
-
-    // no default
-  }
-
-  if (prop) {
-    if (prop.type === 'Identifier' && !node.computed)
-      return prop.name;
-
-
-    return getStaticStringValue(prop);
-  }
-
-  return null;
-}
-
-
-/**
- * Gets the property name of the given `Property` node.
- *
- * - If the property's key is an `Identifier` node, this returns the key's name
- *   whether it's a computed property or not.
- * - If the property has a static name, this returns the static name.
- * - Otherwise, this returns null.
- * @param {ASTNode} node The `Property` node to get.
- * @return {string|null} The property name or null.
- * @private
- */
-function getPropertyName(node) {
-  const staticName = getStaticPropertyName(node);
-
-  if (staticName !== null)
-    return staticName;
-
-
-  return node.key.name || null;
-}
 
 function isValidOrder(a, b) {
   const orderA = orderMap[a];
@@ -162,7 +23,10 @@ function isValidOrder(a, b) {
 // Rule Definition
 // ------------------------------------------------------------------------------
 
-module.exports = {
+/**
+ * @type Rule.RuleModule
+ */
+const ruleModule = {
   meta: {
     type: 'suggestion',
 
@@ -179,12 +43,12 @@ module.exports = {
     },
   },
   create: function(context) {
-    // The stack to save the previous property's name for each object literals.
     let stack = null;
     return {
       ObjectExpression(node) {
         stack = {
           upper: stack,
+          prev: null,
           prevName: null,
           numKeys: node.properties.length,
         };
@@ -197,19 +61,24 @@ module.exports = {
         if (node.parent.type === 'ObjectPattern')
           return;
 
-
         const prevName = stack.prevName;
-        const thisName = getPropertyName(node);
+        const prevNode = stack.prev;
+        const thisName = node.key.name;
 
-        if (thisName !== null)
+        if (thisName !== null) {
           stack.prevName = thisName;
-
+          stack.prev = node;
+        }
 
         if (prevName === null || thisName === null)
           return;
 
-
         if (!isValidOrder(prevName, thisName)) {
+          const range = [prevNode.range[0], node.range[1]];
+
+          const sourceCode = context.getSourceCode();
+          const text = `${sourceCode.getText(node)},\n${' '.repeat(node.loc.start.column)}${sourceCode.getText(prevNode)}`;
+
           context.report({
             node,
             loc: node.key.loc,
@@ -218,9 +87,12 @@ module.exports = {
               thisName,
               prevName,
             },
+            fix: (fixer) => fixer.replaceTextRange(range, text),
           });
         }
       },
     };
   },
 };
+
+module.exports = ruleModule;

--- a/eslint/cactbot-locale-order.js
+++ b/eslint/cactbot-locale-order.js
@@ -1,0 +1,226 @@
+const orderMap = {
+  en: 0,
+  de: 1,
+  fr: 2,
+  ja: 3,
+  cn: 4,
+  ko: 5,
+};
+
+/**
+ * Determines whether the given node is a `null` literal.
+ * @param {ASTNode} node The node to check
+ * @return {boolean} `true` if the node is a `null` literal
+ */
+function isNullLiteral(node) {
+  /*
+   * Checking `node.value === null` does not guarantee that a literal is a null literal.
+   * When parsing values that cannot be represented in the current environment (e.g. unicode
+   * regexes in Node 4), `node.value` is set to `null` because it wouldn't be possible to
+   * set `node.value` to a unicode regex. To make sure a literal is actually `null`, check
+   * `node.regex` instead. Also see: https://github.com/eslint/eslint/issues/8020
+   */
+  return node.type === 'Literal' && node.value === null && !node.regex && !node.bigint;
+}
+
+
+/**
+ * Returns the result of the string conversion applied to the evaluated value of the given expression node,
+ * if it can be determined statically.
+ *
+ * This function returns a `string` value for all `Literal` nodes and simple `TemplateLiteral` nodes only.
+ * In all other cases, this function returns `null`.
+ * @param {ASTNode} node Expression node.
+ * @return {string|null} String value if it can be determined. Otherwise, `null`.
+ */
+function getStaticStringValue(node) {
+  switch (node.type) {
+  case 'Literal':
+    if (node.value === null) {
+      if (isNullLiteral(node))
+        return String(node.value); // "null"
+
+      if (node.regex)
+        return `/${node.regex.pattern}/${node.regex.flags}`;
+
+      if (node.bigint)
+        return node.bigint;
+
+
+      // Otherwise, this is an unknown literal. The function will return null.
+    } else {
+      return String(node.value);
+    }
+    break;
+  case 'TemplateLiteral':
+    if (node.expressions.length === 0 && node.quasis.length === 1)
+      return node.quasis[0].value.cooked;
+
+    break;
+
+    // no default
+  }
+
+  return null;
+}
+
+
+/**
+ * Gets the property name of a given node.
+ * The node can be a MemberExpression, a Property, or a MethodDefinition.
+ *
+ * If the name is dynamic, this returns `null`.
+ *
+ * For examples:
+ *
+ *     a.b           // => "b"
+ *     a["b"]        // => "b"
+ *     a['b']        // => "b"
+ *     a[`b`]        // => "b"
+ *     a[100]        // => "100"
+ *     a[b]          // => null
+ *     a["a" + "b"]  // => null
+ *     a[tag`b`]     // => null
+ *     a[`${b}`]     // => null
+ *
+ *     let a = {b: 1}            // => "b"
+ *     let a = {["b"]: 1}        // => "b"
+ *     let a = {['b']: 1}        // => "b"
+ *     let a = {[`b`]: 1}        // => "b"
+ *     let a = {[100]: 1}        // => "100"
+ *     let a = {[b]: 1}          // => null
+ *     let a = {["a" + "b"]: 1}  // => null
+ *     let a = {[tag`b`]: 1}     // => null
+ *     let a = {[`${b}`]: 1}     // => null
+ * @param {ASTNode} node The node to get.
+ * @return {string|null} The property name if static. Otherwise, null.
+ */
+function getStaticPropertyName(node) {
+  let prop;
+
+  switch (node && node.type) {
+  case 'ChainExpression':
+    return getStaticPropertyName(node.expression);
+
+  case 'Property':
+  case 'MethodDefinition':
+    prop = node.key;
+    break;
+
+  case 'MemberExpression':
+    prop = node.property;
+    break;
+
+    // no default
+  }
+
+  if (prop) {
+    if (prop.type === 'Identifier' && !node.computed)
+      return prop.name;
+
+
+    return getStaticStringValue(prop);
+  }
+
+  return null;
+}
+
+
+/**
+ * Gets the property name of the given `Property` node.
+ *
+ * - If the property's key is an `Identifier` node, this returns the key's name
+ *   whether it's a computed property or not.
+ * - If the property has a static name, this returns the static name.
+ * - Otherwise, this returns null.
+ * @param {ASTNode} node The `Property` node to get.
+ * @return {string|null} The property name or null.
+ * @private
+ */
+function getPropertyName(node) {
+  const staticName = getStaticPropertyName(node);
+
+  if (staticName !== null)
+    return staticName;
+
+
+  return node.key.name || null;
+}
+
+function isValidOrder(a, b) {
+  const orderA = orderMap[a];
+  const orderB = orderMap[b];
+
+  if (orderA === undefined || orderB === undefined)
+    return true;
+
+
+  return orderA <= orderB;
+}
+
+// ------------------------------------------------------------------------------
+// Rule Definition
+// ------------------------------------------------------------------------------
+
+module.exports = {
+  meta: {
+    type: 'suggestion',
+
+    docs: {
+      description: 'suggest the locale object key order',
+      category: 'Stylistic Issues',
+      recommended: true,
+      url: 'https://github.com/quisquous/cactbot/blob/main/docs/RaidbossGuide.md#trigger-elements',
+    },
+    fixable: 'code',
+    schema: [],
+    messages: {
+      sortKeys: 'Expected locale object keys to be in an order like [en, de, fr, ja, cn, ko]. \'{{thisName}}\' should be before \'{{prevName}}\'.',
+    },
+  },
+  create: function(context) {
+    // The stack to save the previous property's name for each object literals.
+    let stack = null;
+    return {
+      ObjectExpression(node) {
+        stack = {
+          upper: stack,
+          prevName: null,
+          numKeys: node.properties.length,
+        };
+      },
+
+      'ObjectExpression:exit'() {
+        stack = stack.upper;
+      },
+      Property(node) {
+        if (node.parent.type === 'ObjectPattern')
+          return;
+
+
+        const prevName = stack.prevName;
+        const thisName = getPropertyName(node);
+
+        if (thisName !== null)
+          stack.prevName = thisName;
+
+
+        if (prevName === null || thisName === null)
+          return;
+
+
+        if (!isValidOrder(prevName, thisName)) {
+          context.report({
+            node,
+            loc: node.key.loc,
+            messageId: 'sortKeys',
+            data: {
+              thisName,
+              prevName,
+            },
+          });
+        }
+      },
+    };
+  },
+};

--- a/eslint/package.json
+++ b/eslint/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "cactbot-eslint-rules",
+  "license": "Apache-2.0",
+  "type": "commonjs"
+}

--- a/package.json
+++ b/package.json
@@ -9,8 +9,8 @@
   "scripts": {
     "build": "node_modules/.bin/webpack --config webpack/webpack.config.cjs --mode production",
     "start": "node_modules/.bin/webpack-dev-server --config webpack/webpack.config.cjs --mode development",
-    "lint": "node_modules/.bin/eslint resources ui user test util",
-    "lintfix": "node_modules/.bin/eslint --fix resources ui user test util",
+    "lint": "node_modules/.bin/eslint --rulesdir ./eslint resources ui user test util",
+    "lintfix": "node_modules/.bin/eslint --rulesdir ./eslint --fix resources ui user test util",
     "stylelint": "node_modules/.bin/stylelint resources/**/*.css ui/**/*.css user/**/*.css test/**/*.css util/**/*.css",
     "markdownlint": "node_modules/.bin/markdownlint . --ignore node_modules --ignore publish --ignore CactbotOverlay/ThirdParty",
     "test": "python test/run_tests.py",


### PR DESCRIPTION
## Summary

Last month I planed to add [this new feature](https://github.com/MaikoTan/cactbot-highlight/pull/5) in my VSCode extension cactbot-highlight,
but I found it is hard to implement the fixture from VSCode extension because I don't know how to fetch and parse code blocks around.

So I abandoned that approach, and try to implement this feature via eslint's existing ecosystem.

This also allows contributors using different editors or IDEs, not only VSCode supports it, even Github Actions would report warnings.

So, this PR planning to implement just like the previous PR that I mentioned:

- [x] check locale order
- [x] offer a quick fix interface

## Screenshot

![image](https://user-images.githubusercontent.com/19927330/100244876-6576e500-2f72-11eb-9621-9b116e9006e1.png)
