### PR TITLE
Add VSCode Recommendations and Basic Settings

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,17 @@
+# editorconfig.org
+
+# top-most EditorConfig file
+root = true
+
+# Default settings:
+# A newline ending every file
+# Use spaces as indentation
+[*]
+insert_final_newline = true
+indent_style = space
+
+[*{.js,.json}]
+indent_size = 2
+
+[*.py]
+indent_size = 4

--- a/.gitattributes
+++ b/.gitattributes
@@ -4,5 +4,3 @@
 *.ogg binary
 *.mp3 binary
 *.wav binary
-
-.vscode/*.json jsonc

--- a/.gitattributes
+++ b/.gitattributes
@@ -4,3 +4,6 @@
 *.ogg binary
 *.mp3 binary
 *.wav binary
+
+# Fix comment highlighting
+.vscode/*.json         linguist-language=jsonc

--- a/.gitattributes
+++ b/.gitattributes
@@ -5,5 +5,5 @@
 *.mp3 binary
 *.wav binary
 
-# Fix comment highlighting
+# Set the language for these files to jsonc to ensure GitHub doesn't show the comments as errors
 .vscode/*.json         linguist-language=jsonc

--- a/.gitattributes
+++ b/.gitattributes
@@ -4,3 +4,5 @@
 *.ogg binary
 *.mp3 binary
 *.wav binary
+
+.vscode/*.json jsonc

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -3,6 +3,7 @@
   // for the documentation about the extensions.json format
   "recommendations": [
     "dbaeumer.vscode-eslint",
+    "EditorConfig.EditorConfig",
     "maikotan.cactbot-highlight"
   ]
 }

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,8 @@
+{
+  // See https://go.microsoft.com/fwlink/?LinkId=827846
+  // for the documentation about the extensions.json format
+  "recommendations": [
+    "dbaeumer.vscode-eslint",
+    "maikotan.cactbot-highlight"
+  ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,14 @@
+{
+  "files.associations": {
+    "**/data/**/*.txt": "cactbot-timeline"
+  },
+  "files.exclude": {
+    ".git": true,
+  },
+  "files.insertFinalNewline": true,
+  "files.trimTrailingWhitespace": true,
+  "search.exclude": {
+    "**/node_modules": true,
+    "dist/**": true
+  }
+}

--- a/resources/conditions.js
+++ b/resources/conditions.js
@@ -19,4 +19,3 @@ export default class Conditions {
     return (data) => data.role === 'tank' || data.role === 'healer' || data.CanFeint() || data.job === 'BLU';
   }
 }
-

--- a/resources/regexes.js
+++ b/resources/regexes.js
@@ -599,7 +599,7 @@ export default class Regexes {
     let modifiers = 'i';
     if (regexpString instanceof RegExp) {
       modifiers += (regexpString.global ? 'g' : '') +
-                   (regexpString.multiline ? 'm' : '');
+                    (regexpString.multiline ? 'm' : '');
       regexpString = regexpString.source;
     }
     regexpString = regexpString.replace(/\\y\{(.*?)\}/g, (match, group) => {

--- a/util/make_timeline.py
+++ b/util/make_timeline.py
@@ -11,19 +11,19 @@ import encounter_tools as e_tools
 
 """FFLogs returns battle events in a list of dicts that looks something like this:
     {
-      "timestamp": 4816719,
-      "type": "cast",
-      "sourceID": 113,
-      "sourceIsFriendly": false,
-      "targetID": 95,
-      "targetIsFriendly": true,
-      "ability": {
-        "name": "attack",
-        "guid": 870,
-        "type": 128,
-        "abilityIcon": "000000-000405.png"
-      },
-      "pin": "0"
+        "timestamp": 4816719,
+        "type": "cast",
+        "sourceID": 113,
+        "sourceIsFriendly": false,
+        "targetID": 95,
+        "targetIsFriendly": true,
+        "ability": {
+            "name": "attack",
+            "guid": 870,
+            "type": 128,
+            "abilityIcon": "000000-000405.png"
+        },
+        "pin": "0"
     },
 We map from the type property here to ACT network log line numbers.
 Technically there are both 21 and 22 log lines,
@@ -32,26 +32,26 @@ but for the purposes of this script it doesn't matter which one we map to.
 Sometimes there's an environmental actor that doesn't have the same layout.
 These are assigned a GUID of 9020. They will have a "source" property:
 {
-  "timestamp": 5308320,
-  "type": "cast",
-  "source": {
-    "name": "Leviathan",
-    "id": 31,
-    "guid": 9020,
-    "type": "NPC",
-    "icon": "NPC"
-  },
-  "sourceInstance": 1,
-  "sourceIsFriendly": false,
-  "targetID": 1,
-  "targetIsFriendly": true,
-  "ability": {
-    "name": "Rip Current",
-    "guid": 16353,
-    "type": 1024,
-    "abilityIcon": "000000-000405.png"
-  },
-  "pin": "0"
+    "timestamp": 5308320,
+    "type": "cast",
+    "source": {
+        "name": "Leviathan",
+        "id": 31,
+        "guid": 9020,
+        "type": "NPC",
+        "icon": "NPC"
+    },
+    "sourceInstance": 1,
+    "sourceIsFriendly": false,
+    "targetID": 1,
+    "targetIsFriendly": true,
+    "ability": {
+        "name": "Rip Current",
+        "guid": 16353,
+        "type": 1024,
+        "abilityIcon": "000000-000405.png"
+    },
+    "pin": "0"
 }
 """
 


### PR DESCRIPTION
Initial VSCode extension recommendations (basically just ESLint and @MaikoTan's highlighting extension from https://github.com/quisquous/cactbot/issues/1846), as well as some simple settings.

File associations won't be upset if the cactbot-highlight extension isn't installed. I don't know if there's any reason to have the `.git` folder appear in VSCode (potentially maybe node_modules can be here too?). Likewise, I don't think there's much point in search results showing dist or node_modules.

Perhaps these can be extended to include third-party files, such as lodash.min.js, etc. but I figured it might be best to ground something small first.