### PR TITLE
raidboss: remove group tts

### DIFF
--- a/docs/RaidbossGuide.md
+++ b/docs/RaidbossGuide.md
@@ -357,7 +357,6 @@ Trigger elements are evaluated in this order, and must be listed in this order:
 - alarmText
 - alertText
 - infoText
-- groupTTS
 - tts
 - run
 - outputStrings

--- a/docs/zh-CN/RaidbossGuide.md
+++ b/docs/zh-CN/RaidbossGuide.md
@@ -160,7 +160,6 @@
 - alarmText
 - alertText
 - infoText
-- groupTTS
 - tts
 - run
 

--- a/resources/responses.js
+++ b/resources/responses.js
@@ -28,7 +28,6 @@ export const triggerFunctions = [
   'delaySeconds',
   'disabled',
   'durationSeconds',
-  'groupTTS',
   'id',
   'infoText',
   'preRun',
@@ -47,7 +46,6 @@ export const triggerOutputFunctions = [
   'alarmText',
   'alertText',
   'infoText',
-  'groupTTS', // please remove me T_T
   'response',
   'tts',
 ];

--- a/test/trigger/test_trigger.js
+++ b/test/trigger/test_trigger.js
@@ -335,7 +335,6 @@ const testTriggerFieldsSorted = function(file, triggerSet) {
     'alarmText',
     'alertText',
     'infoText',
-    'groupTTS',
     'tts',
     'run',
   ];

--- a/ui/raidboss/data/00-misc/test.js
+++ b/ui/raidboss/data/00-misc/test.js
@@ -134,14 +134,6 @@ export default {
       netRegexCn: NetRegexes.gameNameLog({ line: '.*激励木人.*?', capture: false }),
       netRegexKo: NetRegexes.gameNameLog({ line: '.*나무인형에게 힘을 불어넣습니다.*?', capture: false }),
       alertText: (data, _, output) => output.text(),
-      groupTTS: {
-        en: 'group psych',
-        de: 'Gruppen auf gehts',
-        fr: 'motivation de groupe',
-        ja: 'グループ、活を入れる',
-        cn: '组激励',
-        ko: '단체 격려',
-      },
       tts: {
         en: 'psych',
         de: 'auf gehts',
@@ -171,14 +163,6 @@ export default {
       netRegexKo: NetRegexes.gameNameLog({ line: '.*나무인형을 보고 폭소를 터뜨립니다.*?', capture: false }),
       suppressSeconds: 5,
       alarmText: (data, _, output) => output.text(),
-      groupTTS: {
-        en: 'group laugh',
-        de: 'Gruppenlache',
-        fr: 'rire de groupe',
-        ja: 'グループハハハ',
-        cn: '组哈哈',
-        ko: '단체 웃음',
-      },
       tts: {
         en: 'hahahahaha',
         de: 'hahahahaha',

--- a/ui/raidboss/emulator/data/PopupTextAnalysis.js
+++ b/ui/raidboss/emulator/data/PopupTextAnalysis.js
@@ -185,11 +185,6 @@ export default class PopupTextAnalysis extends StubbedPopupText {
     super._onTriggerInternalInfoText(triggerHelper);
   }
 
-  _onTriggerInternalGroupTTS(triggerHelper) {
-    this.currentFunction = '_onTriggerInternalGroupTTS';
-    super._onTriggerInternalGroupTTS(triggerHelper);
-  }
-
   _onTriggerInternalTTS(triggerHelper) {
     this.currentFunction = '_onTriggerInternalTTS';
     super._onTriggerInternalTTS(triggerHelper);

--- a/ui/raidboss/popup-text.js
+++ b/ui/raidboss/popup-text.js
@@ -654,8 +654,6 @@ export class PopupText {
         // Priority audio order:
         // * user disabled (play nothing)
         // * if tts options are enabled globally or for this trigger:
-        //   * user groupTTS trigger groupTTS/tts override
-        //   * groupTTS entries in the trigger
         //   * user TTS triggers tts override
         //   * tts entries in the trigger
         //   * default alarm tts
@@ -674,7 +672,6 @@ export class PopupText {
         // being valid but empty, this will take priority over the default
         // tts texts from alarm/alert/info and will prevent tts from playing
         // and allowing sounds to be played instead.
-        this._onTriggerInternalGroupTTS(triggerHelper);
         this._onTriggerInternalTTS(triggerHelper);
         this._onTriggerInternalPlayAudio(triggerHelper);
         this._onTriggerInternalRun(triggerHelper);
@@ -889,19 +886,6 @@ export class PopupText {
 
   _onTriggerInternalInfoText(triggerHelper) {
     this._addTextFor('info', triggerHelper);
-  }
-
-  _onTriggerInternalGroupTTS(triggerHelper) {
-    if (triggerHelper.groupSpokenAlertsEnabled) {
-      if ('GroupTTSText' in triggerHelper.triggerOptions) {
-        triggerHelper.ttsText =
-          triggerHelper.valueOrFunction(triggerHelper.triggerOptions.GroupTTSText);
-      } else if ('groupTTS' in triggerHelper.trigger) {
-        triggerHelper.ttsText = triggerHelper.valueOrFunction(triggerHelper.trigger.groupTTS);
-      } else if ('groupTTS' in triggerHelper.response) {
-        triggerHelper.ttsText = triggerHelper.valueOrFunction(triggerHelper.response.groupTTS);
-      }
-    }
   }
 
   _onTriggerInternalTTS(triggerHelper) {


### PR DESCRIPTION
This was originally going to be some way to have tts for discord
purposes, but I think the overlayplugin shared tab does this better.
Additionally, cactbot triggers are designed for individuals and it
seems pretty clear that nobody has time to edit a million triggers
to behave properly in this group tts mode.