### PR TITLE
radar: Log death of monsters

### DIFF
--- a/ui/radar/radar.js
+++ b/ui/radar/radar.js
@@ -267,6 +267,7 @@ class Radar {
 
   RemoveMonster(mobKey) {
     if (mobKey in this.targetMonsters) {
+      console.log(this.targetMonsters[mobKey].name + ' killed');
       this.targetMonsters[mobKey].dom.remove();
       delete this.targetMonsters[mobKey];
     }


### PR DESCRIPTION
Sometimes a hunt can spawn in the middle of the night when someone's AFKing in the zone - they'll see it go up on the logs, but not down, meaning there's no precise timer. This gives them a time of death.