### PR TITLE
ci: add workflow_dispatch in build-artifact

### DIFF
--- a/.github/workflows/build-artifact.yml
+++ b/.github/workflows/build-artifact.yml
@@ -19,6 +19,7 @@ on:
       - 'util/publish.sh'
       - 'util/DEPS.py'
       - 'util/fetch_deps.py'
+  workflow_dispatch:
 
 jobs:
   msbuild:


### PR DESCRIPTION
so user can trigger the workflow manually by clicky.

![image](https://user-images.githubusercontent.com/19927330/100957776-145c8780-3556-11eb-8d10-a49fd9500a79.png)
