### PR TITLE
Jobs: move line-height of boxtext to jobs.css

### DIFF
--- a/resources/defaults.css
+++ b/resources/defaults.css
@@ -50,7 +50,6 @@ body {
     Arial,
     Helvetica,
     sans-serif;
-  line-height: 1.1em;
 }
 
 .hide {

--- a/ui/jobs/jobs.css
+++ b/ui/jobs/jobs.css
@@ -142,6 +142,7 @@
   position: relative;
   top: 5px;
   font-size: 16px;
+  line-height: 1.1em;
 }
 
 /* Height of HP + MP bar(show number) */


### PR DESCRIPTION
Seems that this font problem(#2091 ) only affect jobs module, leave it in default may cause some other problem, so move it to only affect jobs module.