### PR TITLE
Raidboss: E12N timeline and basic triggers

### DIFF
--- a/ui/raidboss/data/05-shb/raid/e12n.js
+++ b/ui/raidboss/data/05-shb/raid/e12n.js
@@ -23,7 +23,6 @@ export default {
     {
       id: 'E12N Formless Judgment',
       netRegex: NetRegexes.startsUsing({ id: '5873', source: 'Eden\'s Promise' }),
-      condition: Conditions.caresAboutMagical(),
       response: Responses.tankCleave(),
     },
     {

--- a/ui/raidboss/data/05-shb/raid/e12n.js
+++ b/ui/raidboss/data/05-shb/raid/e12n.js
@@ -1,8 +1,65 @@
+import Conditions from '../../../../../resources/conditions.js';
+import NetRegexes from '../../../../../resources/netregexes.js';
+import { Responses } from '../../../../../resources/responses.js';
 import ZoneId from '../../../../../resources/zone_id.js';
-
 export default {
   zoneId: ZoneId.EdensPromiseEternity,
   timelineFile: 'e12n.txt',
   triggers: [
+    {
+      id: 'E12N Maleficium',
+      netRegex: NetRegexes.startsUsing({ id: '5872', source: 'Eden\'s Promise', capture: false }),
+      condition: Conditions.caresAboutAOE(),
+      response: Responses.aoe(),
+    },
+    {
+      id: 'E12N Formless Judgment',
+      netRegex: NetRegexes.startsUsing({ id: '5873', source: 'Eden\'s Promise' }),
+      condition: Conditions.caresAboutMagical(),
+      response: Responses.tankCleave(),
+    },
+    {
+      id: 'E12N Boulders Impact',
+      netRegex: NetRegexes.ability({ id: '586E', source: 'Titanic Bomb Boulder', capture: false }),
+      suppressSeconds: 5,
+      infoText: (data, _, output) => output.text(),
+      outputStrings: {
+        text: {
+          en: 'Between small boulders',
+        },
+      },
+    },
+    {
+      id: 'E12N Boulders Explosion',
+      netRegex: NetRegexes.ability({ id: '586F', source: 'Titanic Bomb Boulder', capture: false }),
+      suppressSeconds: 5,
+      infoText: (data, _, output) => output.text(),
+      outputStrings: {
+        text: {
+          en: 'Move to last explosions',
+        },
+      },
+    },
+    {
+      id: 'E12N Rapturous Reach',
+      netRegex: NetRegexes.headMarker({ id: '003E' }),
+      response: Responses.stackMarkerOn(),
+    },
+    {
+      id: 'E12N Diamond Dust',
+      netRegex: NetRegexes.startsUsing({ id: '5864', source: 'Eden\'s Promise', capture: false }),
+      infoText: (data, _, output) => output.text(),
+      outputStrings: {
+        text: {
+          en: 'Spread, don\'t move',
+        },
+      },
+    },
+    {
+      id: 'E12N Frigid Stone',
+      netRegex: NetRegexes.headMarker({ id: '0060' }),
+      condition: Conditions.targetIsYou(),
+      response: Responses.spread(),
+    },
   ],
 };

--- a/ui/raidboss/data/05-shb/raid/e12n.js
+++ b/ui/raidboss/data/05-shb/raid/e12n.js
@@ -53,14 +53,15 @@ export default {
       response: Responses.stackMarkerOn(),
     },
     {
-      id: 'E12N Diamond Dust',
+      id: 'E12N Diamond Dust Spread',
       netRegex: NetRegexes.startsUsing({ id: '5864', source: 'Eden\'s Promise', capture: false }),
-      infoText: (data, _, output) => output.text(),
-      outputStrings: {
-        text: {
-          en: 'Spread, don\'t move',
-        },
-      },
+      response: Responses.spread(),
+    },
+    {
+      id: 'E12N Diamond Dust Stop',
+      netRegex: NetRegexes.startsUsing({ id: '5864', source: 'Eden\'s Promise', capture: false }),
+      delaySeconds: 1, // Avoiding collision with the spread call
+      response: Responses.stopMoving('info'),
     },
     {
       id: 'E12N Frigid Stone',

--- a/ui/raidboss/data/05-shb/raid/e12n.js
+++ b/ui/raidboss/data/05-shb/raid/e12n.js
@@ -2,6 +2,14 @@ import Conditions from '../../../../../resources/conditions.js';
 import NetRegexes from '../../../../../resources/netregexes.js';
 import { Responses } from '../../../../../resources/responses.js';
 import ZoneId from '../../../../../resources/zone_id.js';
+
+// TODO: Tether mechanic callouts. Each tether type is used for one primal,
+// so we could just do a collect > analyze > call system based on which tethers are seen.
+// TODO: Handle the EarthShaker bait --> beam intercept mechanic during the intermission.
+// TODO: Math the spawn position of the Titanic Bomb Boulders to call the safe direction like E4s.
+// TODO: Fix the Rapturous Reach trigger so it doesn't double call during the intermission.
+
+
 export default {
   zoneId: ZoneId.EdensPromiseEternity,
   timelineFile: 'e12n.txt',
@@ -25,7 +33,7 @@ export default {
       infoText: (data, _, output) => output.text(),
       outputStrings: {
         text: {
-          en: 'Between small boulders',
+          en: 'Between small bombs',
         },
       },
     },

--- a/ui/raidboss/data/05-shb/raid/e12n.txt
+++ b/ui/raidboss/data/05-shb/raid/e12n.txt
@@ -6,5 +6,154 @@ hideall "--sync--"
 
 0.0 "--Reset--" sync / 21:........:40000010:/ window 10000 jump 0
 
-0 "Start"
+# -ii 4B47 4B1D 5865 585B 586B 5874 5875 5876 587E 587F 5882 5884 5889 588A 588B
+# -ic "Lissom Sculpture" "Beastly Sculpture"
+
+
 0.0 "--sync--" sync /:Engage!/ window 0,1
+1.0 "--sync--" sync /:Eden's Promise:4B1D:/ window 1,1
+14.9 "Maleficium" sync /:Eden's Promise:5872:/ window 14.9,5
+22.1 "--sync--" sync /:Eden's Promise:5879:/
+25.3 "Initialize Recall" sync /:Eden's Promise:5859:/
+34.9 "Judgment Jolt" sync /:Eden's Promise:585F:/
+45.6 "Temporary Current" sync /:Eden's Promise:585C:/
+56.3 "Judgment Jolt" sync /:Eden's Promise:585F:/
+67.0 "Temporary Current" sync /:Eden's Promise:585C:/
+80.0 "Formless Judgment" sync /:Eden's Promise:5873:/
+87.3 "--sync--" sync /:Eden's Promise:5879:/
+96.7 "Conflag Strike" sync /:Eden's Promise:585D:/
+107.4 "Ferostorm" sync /:Eden's Promise:585E:/
+118.1 "Conflag Strike" sync /:Eden's Promise:585D:/
+128.7 "Ferostorm" sync /:Eden's Promise:585E:/
+140.1 "Maleficium" sync /:Eden's Promise:5872:/
+145.9 "--sync--" sync /:Eden's Promise:585A:/ window 145.9
+148.4 "--untargetable--"
+
+# Intermission. Can be pushed, unknown threshold, maybe 70% HP?
+196.5 "Eternal Oblivion" sync /:Eden's Promise:587A:/ window 50,10
+204.3 "--sync--" sync /:Eden's Promise:4B20:/
+232.9 "Earth Shaker" sync /:Eden's Promise:5885:/
+232.9 "Obliteration" sync /:Eden's Promise:4B43:/
+251.2 "Eternal Oblivion" sync /:Eden's Promise:587B:/ window 20,20
+259.0 "--sync--" sync /:Eden's Promise:4B21:/
+267.3 "Classical Sculpture" sync /:Chiseled Sculpture:5886:/
+290.2 "Rapturous Reach" sync /:Eden's Promise:5887:/
+290.2 "Palm Of Temperance" sync /:Eden's Promise:4B44:/
+308.4 "Eternal Oblivion" sync /:Eden's Promise:587C:/ window 20,20
+316.2 "--sync--" sync /:Eden's Promise:4B22:/
+337.5 "Laser Eye" sync /:Eden's Promise:4B47:/
+356.3 "Eternal Oblivion" sync /:Eden's Promise:587D:/ window 20,20
+364.1 "--sync--" sync /:Eden's Promise:4B23:/
+
+
+# Post-intermission initial block.
+500.0 "--sync--" sync /:4B48:Eden's Promise/ window 500,10
+504.9 "Paradise Lost" sync /:Eden's Promise:4B48:/
+511.9 "--targetable--"
+522.0 "Initialize Recall" sync /:Eden's Promise:5859:/ window 30,30
+534.1 "Stock" sync /:Eden's Promise:5860:/
+542.8 "Formless Judgment" sync /:Eden's Promise:5873:/ window 30,30
+545.6 "--sync--" sync /:Eden's Promise:5879:/
+555.7 "Double Primal Attack" sync /:Eden's Promise:5861:/
+
+
+568.6 "Stock" sync /:Eden's Promise:5860:/ window 15,30
+578.3 "Junction Shiva?" sync /:Eden's Promise:5862:/ jump 700.0
+578.3 "Junction Titan?" sync /:Eden's Promise:5863:/ jump 800.0
+589.0 "Diamond Dust?"
+589.0 "Earthen Fury?"
+594.0 "Impact 1?"
+597.0 "Impact 2?"
+600.2 "Frigid Stone?"
+
+
+# Paths split here. Titan OR Shiva can be used first,
+# and then this first block, always ending in 5861 Release,
+# is followed by:
+
+# Unknown_5879 > Cast > Cast > Malefecium
+# The time between 5861 Release and Unknown 5879
+# is consistent at 9 seconds for both Shiva and Titan.
+
+# It will then continue to the other of Titan/Shiva,
+# which will in turn be followed by the other closing pattern:
+
+# Stock > Formless Judgment > Unknown_5879 > Release
+# The time between Release and Stock is consistent at 14 seconds.
+
+# Shiva Block
+690.4 "Stock" sync /:Eden's Promise:5860:/
+700.0 "Junction Shiva" sync /:Eden's Promise:5862:/
+710.7 "Diamond Dust" sync /:Eden's Promise:5864:/ window 30,30
+716.8 "--sync--" sync /:Eden's Promise:5866:/
+721.9 "Frigid Stone" sync /:Eden's Promise:5867:/
+727.9 "Ice Floe" sync /:Eden's Promise:5868:/
+732.9 "Rapturous Reach" sync /:Eden's Promise:5878:/ window 30,30
+735.4 "Frigid Stone" # sync /:Eden's Promise:5869:/
+735.6 "--sync--" sync /:Eden's Promise:5871:/
+738.2 "--sync--" sync /:Eden's Promise:5879:/
+747.6 "Double Primal Attack" sync /:Eden's Promise:5861:/
+
+756.6 "--sync--" sync /:Eden's Promise:5879:/ jump 900.0
+761.5 "Stock?" sync /:Eden's Promise:5860:/ jump 1000.0
+766.2 "Double Primal Attack?"
+770.2 "Formless Judgment?"
+776.9 "Double Primal Attack?"
+782.4 "Double Primal Attack?"
+784.6 "Maleficium?"
+
+
+# Titan Block
+790.3 "Stock" sync /:Eden's Promise:5860:/
+800.0 "Junction Titan" sync /:Eden's Promise:5863:/
+810.7 "Earthen Fury" sync /:Eden's Promise:586A:/ window 30,30
+815.7 "Impact 1" sync /:Titanic Bomb Boulder:586E:/
+818.7 "Impact 2" # sync /:Bomb Boulder:586C:/
+822.7 "Explosion 1" sync /:Titanic Bomb Boulder:586F:/
+825.7 "Explosion 2" # sync /:Bomb Boulder:586D:/
+831.7 "Rapturous Reach" sync /:Eden's Promise:5878:/ window 30,30
+834.2 "Under The Weight" sync /:Eden's Promise:5870:/
+834.3 "--sync--" sync /:Eden's Promise:5871:/
+836.9 "--sync--" sync /:Eden's Promise:5879:/
+846.3 "Double Primal Attack" sync /:Eden's Promise:5861:/
+
+855.3 "--sync--" sync /:Eden's Promise:5879:/ jump 900.0
+860.2 "Stock?" sync /:Eden's Promise:5860:/ jump 1000.0
+864.9 "Double Primal Attack?"
+868.9 "Formless Judgment?"
+875.6 "Double Primal Attack?"
+881.1 "Double Primal Attack?"
+883.3 "Maleficium?"
+
+# Maleficium Block
+900.0 "--sync--" sync /:Eden's Promise:5879:/
+909.6 "Double Primal Attack" sync /:Eden's Promise:4E2C:/
+920.3 "Double Primal Attack" sync /:Eden's Promise:4E2C:/
+928.0 "Maleficium" sync /:Eden's Promise:5872:/ window 15,15
+
+940.9 "Stock" sync /:Eden's Promise:5860:/
+950.5 "Junction Shiva?" sync /:Eden's Promise:5862:/ window 15,15 jump 700.0
+950.5 "Junction Titan?" sync /:Eden's Promise:5863:/ window 15,15 jump 800.0
+961.2 "Diamond Dust?"
+961.2 "Earthen Fury?"
+966.2 "Impact 1?"
+969.2 "Impact 2?"
+972.4 "Frigid Stone?"
+973.2 "Explosion 1?"
+
+
+# Formless Judgment Block
+1000.0 "Stock" sync /:Eden's Promise:5860:/
+1008.7 "Formless Judgment" sync /:Eden's Promise:5873:/ window 15,15
+1011.5 "--sync--" sync /:Eden's Promise:5879:/
+1020.9 "Double Primal Attack" sync /:Eden's Promise:5861:/
+
+1034.8 "Stock" sync /:Eden's Promise:5860:/
+1044.4 "Junction Shiva?" sync /:Eden's Promise:5862:/ jump 700.0
+1044.4 "Junction Titan?" sync /:Eden's Promise:5863:/ jump 800.0
+1055.1 "Diamond Dust?"
+1055.1 "Earthen Fury?"
+1060.1 "Impact 1?"
+1063.1 "Impact 2?"
+1066.3 "Frigid Stone?"
+1067.1 "Explosion 1?"

--- a/ui/raidboss/data/05-shb/raid/e12n.txt
+++ b/ui/raidboss/data/05-shb/raid/e12n.txt
@@ -30,7 +30,7 @@ hideall "--sync--"
 148.4 "--untargetable--"
 
 # Intermission. Can be pushed, unknown threshold, maybe 70% HP?
-196.5 "Eternal Oblivion" sync /:Eden's Promise:587A:/ window 50,10
+196.5 "Eternal Oblivion" sync /:Eden's Promise:587A:/ window 200,10
 204.3 "--sync--" sync /:Eden's Promise:4B20:/
 232.9 "Earth Shaker" sync /:Eden's Promise:5885:/
 232.9 "Obliteration" sync /:Eden's Promise:4B43:/
@@ -71,7 +71,7 @@ hideall "--sync--"
 # and then this first block, always ending in 5861 Release,
 # is followed by:
 
-# Unknown_5879 > Cast > Cast > Malefecium
+# Unknown_5879 > Cast > Cast > Maleficium
 # The time between 5861 Release and Unknown 5879
 # is consistent at 9 seconds for both Shiva and Titan.
 

--- a/ui/raidboss/data/05-shb/raid/e12n.txt
+++ b/ui/raidboss/data/05-shb/raid/e12n.txt
@@ -54,7 +54,7 @@ hideall "--sync--"
 534.1 "Stock" sync /:Eden's Promise:5860:/
 542.8 "Formless Judgment" sync /:Eden's Promise:5873:/ window 30,30
 545.6 "--sync--" sync /:Eden's Promise:5879:/
-555.7 "Double Primal Attack" sync /:Eden's Promise:5861:/
+555.7 "Release" sync /:Eden's Promise:5861:/
 
 
 568.6 "Stock" sync /:Eden's Promise:5860:/ window 15,30
@@ -92,14 +92,14 @@ hideall "--sync--"
 735.4 "Frigid Stone" # sync /:Eden's Promise:5869:/
 735.6 "--sync--" sync /:Eden's Promise:5871:/
 738.2 "--sync--" sync /:Eden's Promise:5879:/
-747.6 "Double Primal Attack" sync /:Eden's Promise:5861:/
+747.6 "Release" sync /:Eden's Promise:5861:/
 
 756.6 "--sync--" sync /:Eden's Promise:5879:/ jump 900.0
 761.5 "Stock?" sync /:Eden's Promise:5860:/ jump 1000.0
-766.2 "Double Primal Attack?"
+766.2 "Cast?"
 770.2 "Formless Judgment?"
-776.9 "Double Primal Attack?"
-782.4 "Double Primal Attack?"
+776.9 "Cast?"
+782.4 "Release?"
 784.6 "Maleficium?"
 
 
@@ -115,20 +115,20 @@ hideall "--sync--"
 834.2 "Under The Weight" sync /:Eden's Promise:5870:/
 834.3 "--sync--" sync /:Eden's Promise:5871:/
 836.9 "--sync--" sync /:Eden's Promise:5879:/
-846.3 "Double Primal Attack" sync /:Eden's Promise:5861:/
+846.3 "Release" sync /:Eden's Promise:5861:/
 
 855.3 "--sync--" sync /:Eden's Promise:5879:/ jump 900.0
 860.2 "Stock?" sync /:Eden's Promise:5860:/ jump 1000.0
-864.9 "Double Primal Attack?"
+864.9 "Cast?"
 868.9 "Formless Judgment?"
-875.6 "Double Primal Attack?"
-881.1 "Double Primal Attack?"
+875.6 "Cast?"
+881.1 "Release?"
 883.3 "Maleficium?"
 
 # Maleficium Block
 900.0 "--sync--" sync /:Eden's Promise:5879:/
-909.6 "Double Primal Attack" sync /:Eden's Promise:4E2C:/
-920.3 "Double Primal Attack" sync /:Eden's Promise:4E2C:/
+909.6 "Cast" sync /:Eden's Promise:4E2C:/
+920.3 "Cast" sync /:Eden's Promise:4E2C:/
 928.0 "Maleficium" sync /:Eden's Promise:5872:/ window 15,15
 
 940.9 "Stock" sync /:Eden's Promise:5860:/
@@ -146,7 +146,7 @@ hideall "--sync--"
 1000.0 "Stock" sync /:Eden's Promise:5860:/
 1008.7 "Formless Judgment" sync /:Eden's Promise:5873:/ window 15,15
 1011.5 "--sync--" sync /:Eden's Promise:5879:/
-1020.9 "Double Primal Attack" sync /:Eden's Promise:5861:/
+1020.9 "Release" sync /:Eden's Promise:5861:/
 
 1034.8 "Stock" sync /:Eden's Promise:5860:/
 1044.4 "Junction Shiva?" sync /:Eden's Promise:5862:/ jump 700.0


### PR DESCRIPTION
*None of this has had live testing, I haven't had time to do that today and won't until much later tonight. `test_timeline` is mostly happy with it, the only timing variability I've seen is when Stock is cast leading into the second and subsequent primal blocks. Other than that, timing seems consistent across all logs I checked.*

This is a middling-complexity timeline. Not overly difficult, but not a nice straightforward one either. I think the in-line comments mostly cover what's needed. Shiva or Titan can be used first after the intermission, but the coda block that follows Shiva/Titan is fixed. (Odd coda blocks are Maleficium, even coda blocks are Formless Judgment.)

From everything I've seen, the opening block and its primal skills are fixed. It's possible Eden may open with Garuda/Ifrit first, but I've never seen it.

Triggers are extremely basic, since I haven't had time to deal with how to best handle Cast/Stock/Release. I would have preferred to use head markers for Formless Judgment, but because the markers are on both tanks, we would have to collect > call to avoid duplicate callouts, and that's super not worth it for a basic tank cleave.

I don't really like the special callout on Diamond Dust, as opposed to `Responses.stopMoving()`, but given that people might be in bad positions and panic during Diamond Dust, I think it's worth it to pre-call the spread.

TODO: Tether mechanic callouts. From preliminary analysis, each tether type is used for one primal, so I'm thinking we'll just do a collect > analyze > call system based on which tethers are seen.

TODO: Handle the EarthShaker bait --> beam intercept mechanic during the intermission.

TODO: Math out the spawn position of the Titanic Bomb Boulders so we can call the safe direction in much the same way we do on E4s.

TODO: Fix the Rapturous Reach trigger so it doesn't double call during the intermission.