### PR TITLE
Raidboss: E11N timeline and intial triggers

### DIFF
--- a/ui/raidboss/data/05-shb/raid/e11n.js
+++ b/ui/raidboss/data/05-shb/raid/e11n.js
@@ -1,8 +1,133 @@
+import Conditions from '../../../../../resources/conditions.js';
+import NetRegexes from '../../../../../resources/netregexes.js';
+import { Responses } from '../../../../../resources/responses.js';
 import ZoneId from '../../../../../resources/zone_id.js';
+
+// EDEN'S PROMISE: ANAMORPHOSIS
+// E11 NORMAL
+
+// TODO: Handle Bound of Faith
+// TODO: Callouts for the intermission Burnt Strike
+// TODO: See whether it's possible to math out the spawn locations for Blasting Zone
 
 export default {
   zoneId: ZoneId.EdensPromiseAnamorphosis,
   timelineFile: 'e11n.txt',
   triggers: [
+    {
+      id: 'E11N Burnished Glory',
+      netRegex: NetRegexes.startsUsing({ source: 'Fatebreaker', id: '5650', capture: false }),
+      netRegexDe: NetRegexes.startsUsing({ source: 'Fusioniert(?:e|er|es|en) Ascian', id: '5650', capture: false }),
+      netRegexFr: NetRegexes.startsUsing({ source: 'Sabreur De Destins', id: '5650', capture: false }),
+      netRegexJa: NetRegexes.startsUsing({ source: 'フェイトブレイカー', id: '5650', capture: false }),
+      condition: Conditions.caresAboutAOE(),
+      response: Responses.aoe(),
+    },
+    {
+      id: 'E11N Powder Mark',
+      netRegex: NetRegexes.startsUsing({ source: 'Fatebreaker', id: '564E' }),
+      netRegexDe: NetRegexes.startsUsing({ source: 'Fusioniert(?:e|er|es|en) Ascian', id: '564E' }),
+      netRegexFr: NetRegexes.startsUsing({ source: 'Sabreur De Destins', id: '564E' }),
+      netRegexJa: NetRegexes.startsUsing({ source: 'フェイトブレイカー', id: '564E' }),
+      condition: Conditions.caresAboutMagical(),
+      response: Responses.tankBuster(),
+    },
+    {
+      id: 'E11N Powder Mark Explosion',
+      netRegex: NetRegexes.gainsEffect({ source: 'Fatebreaker', effectId: '993' }),
+      netRegexDe: NetRegexes.gainsEffect({ source: 'Fusioniert(?:e|er|es|en) Ascian', effectId: '993' }),
+      netRegexFr: NetRegexes.gainsEffect({ source: 'Sabreur De Destins', effectId: '993' }),
+      netRegexJa: NetRegexes.gainsEffect({ source: 'フェイトブレイカー', effectId: '993' }),
+      condition: Conditions.targetIsYou(),
+      delaySeconds: (data, matches) => parseFloat(matches.duration) - 4,
+      alertText: (data, _, output) => output.awayFromGroup(),
+      outputStrings: {
+        awayFromGroup: {
+          en: 'Away from Group',
+          de: 'Weg von der Gruppe',
+          fr: 'Éloignez-vous du groupe',
+          ja: '外へ',
+          cn: '远离人群',
+          ko: '다른 사람들이랑 떨어지기',
+        },
+      },
+    },
+    {
+      id: 'E11N Burnt Strike Fire',
+      netRegex: NetRegexes.startsUsing({ source: 'Fatebreaker', id: '562C', capture: false }),
+      netRegexDe: NetRegexes.startsUsing({ source: 'Fusioniert(?:e|er|es|en) Ascian', id: '562C', capture: false }),
+      netRegexFr: NetRegexes.startsUsing({ source: 'Sabreur De Destins', id: '562C', capture: false }),
+      netRegexJa: NetRegexes.startsUsing({ source: 'フェイトブレイカー', id: '562C', capture: false }),
+      alertText: (data, _, output) => output.text(),
+      outputStrings: {
+        text: {
+          en: 'Line Cleave -> Knockback',
+          de: 'Linien AoE -> Rückstoß',
+          ko: '직선 장판 -> 넉백',
+        },
+      },
+    },
+    {
+      id: 'E11N Burnt Strike Lightning',
+      netRegex: NetRegexes.startsUsing({ source: 'Fatebreaker', id: '562E', capture: false }),
+      netRegexDe: NetRegexes.startsUsing({ source: 'Fusioniert(?:e|er|es|en) Ascian', id: '562E', capture: false }),
+      netRegexFr: NetRegexes.startsUsing({ source: 'Sabreur De Destins', id: '562E', capture: false }),
+      netRegexJa: NetRegexes.startsUsing({ source: 'フェイトブレイカー', id: '562E', capture: false }),
+      alertText: (data, _, output) => output.text(),
+      outputStrings: {
+        text: {
+          en: 'Line Cleave -> Out',
+          de: 'Linien AoE -> Raus',
+          ko: '직선 장판 -> 바깥으로',
+        },
+      },
+    },
+    {
+      id: 'E11N Burnt Strike Holy',
+      netRegex: NetRegexes.startsUsing({ source: 'Fatebreaker', id: '5630', capture: false }),
+      netRegexDe: NetRegexes.startsUsing({ source: 'Fusioniert(?:e|er|es|en) Ascian', id: '5630', capture: false }),
+      netRegexFr: NetRegexes.startsUsing({ source: 'Sabreur De Destins', id: '5630', capture: false }),
+      netRegexJa: NetRegexes.startsUsing({ source: 'フェイトブレイカー', id: '5630', capture: false }),
+      alertText: (data, _, output) => output.text(),
+      outputStrings: {
+        text: {
+          en: 'Line Cleave + Bait',
+          de: 'Linien AoE -> Ködern',
+          ko: '직선 장판 + 장판 유도',
+        },
+      },
+    },
+    {
+      id: 'E11N Turn of the Heavens Fire',
+      netRegex: NetRegexes.startsUsing({ source: 'Fatebreaker', id: '5639', capture: false }),
+      netRegexDe: NetRegexes.startsUsing({ source: 'Fusioniert(?:e|er|es|en) Ascian', id: '5639', capture: false }),
+      netRegexFr: NetRegexes.startsUsing({ source: 'Sabreur De Destins', id: '5639', capture: false }),
+      netRegexJa: NetRegexes.startsUsing({ source: 'フェイトブレイカー', id: '5639', capture: false }),
+      durationSeconds: 10,
+      infoText: (data, _, output) => output.text(),
+      outputStrings: {
+        text: {
+          en: 'Fire: Go to Blue',
+          de: 'Feuer: Geh zu Blau',
+          ko: '화염: 파랑으로',
+        },
+      },
+    },
+    {
+      id: 'E11N Turn of the Heavens Lightning',
+      netRegex: NetRegexes.startsUsing({ source: 'Fatebreaker', id: '563A', capture: false }),
+      netRegexDe: NetRegexes.startsUsing({ source: 'Fusioniert(?:e|er|es|en) Ascian', id: '563A', capture: false }),
+      netRegexFr: NetRegexes.startsUsing({ source: 'Sabreur De Destins', id: '563A', capture: false }),
+      netRegexJa: NetRegexes.startsUsing({ source: 'フェイトブレイカー', id: '563A', capture: false }),
+      durationSeconds: 10,
+      infoText: (data, _, output) => output.text(),
+      outputStrings: {
+        text: {
+          en: 'Lightning: Go to Red',
+          de: 'Blitz: Geh zu Rot',
+          ko: '번개: 빨강으로',
+        },
+      },
+    },
   ],
 };

--- a/ui/raidboss/data/05-shb/raid/e11n.js
+++ b/ui/raidboss/data/05-shb/raid/e11n.js
@@ -10,6 +10,107 @@ import ZoneId from '../../../../../resources/zone_id.js';
 // TODO: Callouts for the intermission Burnt Strike
 // TODO: See whether it's possible to math out the spawn locations for Blasting Zone
 
+// sinsmite = lightning elemental break
+// sinsmoke = fire elemental break
+// sinsight = light elemental break
+// blastburn = burnt strike fire knockback
+// burnout = burnt strike lightning out
+// shining blade = burnt strike light bait
+
+const tetherIds = ['0002', '0005', '0006'];
+
+const unknownTarget = {
+  en: '???',
+  de: '???',
+  fr: '???',
+  ja: '???',
+  cn: '???',
+  ko: '???',
+};
+
+const boundOfFaithFireTetherResponse = (data, _, output) => {
+  // cactbot-builtin-response
+  output.responseOutputStrings = {
+    stackOnYou: {
+      en: 'Stack on YOU',
+      de: 'Auf DIR sammeln',
+      fr: 'Package sur VOUS',
+      ja: '自分にスタック',
+      cn: '集合点名',
+      ko: '쉐어징 대상자',
+    },
+    stackOnTarget: {
+      en: 'Stack on ${player}',
+      de: 'Auf ${player} sammeln',
+      fr: 'Packez-vous sur ${player}',
+      ja: '${player}にスタック',
+      cn: '靠近 ${player}集合',
+      ko: '"${player}" 쉐어징',
+    },
+    unknownTarget: unknownTarget,
+  };
+
+  const targets = Object.keys(data.tethers || {});
+  if (targets.includes(data.me))
+    return { alertText: output.stackOnYou() };
+  if (targets.length === 0)
+    return { alertText: output.stackOnTarget({ player: output.unknownTarget() }) };
+  return { alertText: output.stackOnTarget({ player: data.ShortName(targets[0]) }) };
+};
+
+const boundOfFaithLightningTetherResponse = (data, _, output) => {
+  // cactbot-builtin-response
+  output.responseOutputStrings = {
+    onYou: {
+      en: 'Lightning on YOU',
+    },
+    tetherInfo: {
+      en: 'Lightning on ${player}',
+      de: 'Lichtverbindung auf ${player}',
+      ko: '"${player}" 번개징 대상자',
+    },
+    unknownTarget: unknownTarget,
+  };
+
+  const targets = Object.keys(data.tethers || {});
+  if (targets.includes(data.me))
+    return { alarmText: output.onYou() };
+
+  const target = targets.length === 1 ? data.ShortName(targets[0]) : output.unknownTarget();
+  return { infoText: output.tetherInfo({ player: target }) };
+};
+
+const boundOfFaithHolyTetherResponse = (data, _, output) => {
+  // cactbot-builtin-response
+  output.responseOutputStrings = {
+    awayFromGroup: {
+      en: 'Away from Group',
+      de: 'Weg von der Gruppe',
+      fr: 'Éloignez-vous du groupe',
+      ja: '外へ',
+      cn: '远离人群',
+      ko: '다른 사람들이랑 떨어지기',
+    },
+    awayFromTarget: {
+      en: 'Away from ${player}',
+      de: 'Weg von ${player}',
+      fr: 'Éloignez-vous de ${player}',
+      ja: '${player}から離れ',
+      cn: '远离${player}',
+      ko: '"${player}"에서 멀어지기',
+    },
+    unknownTarget: unknownTarget,
+  };
+
+  const targets = Object.keys(data.tethers || {});
+  if (targets.includes(data.me))
+    return { alarmText: output.awayFromGroup() };
+  if (targets.length === 0)
+    return { infoText: output.awayFromTarget({ player: output.unknownTarget() }) };
+  return { infoText: output.awayFromTarget({ player: data.ShortName(targets[0]) }) };
+};
+
+
 export default {
   zoneId: ZoneId.EdensPromiseAnamorphosis,
   timelineFile: 'e11n.txt',
@@ -96,6 +197,71 @@ export default {
           ko: '직선 장판 + 장판 유도',
         },
       },
+    },
+    {
+      id: 'E11N Burnt Strike Lightning Clone',
+      netRegex: NetRegexes.startsUsing({ source: 'Fatebreaker\'s Image', id: '5645', capture: false }),
+      netRegexDe: NetRegexes.startsUsing({ source: 'Abbild[p] des fusionierten Ascians', id: '5645', capture: false }),
+      netRegexFr: NetRegexes.startsUsing({ source: 'double du Sabreur de destins', id: '5645', capture: false }),
+      netRegexJa: NetRegexes.startsUsing({ source: 'フェイトブレイカーの幻影', id: '5645', capture: false }),
+      alertText: (data, _, output) => output.text(),
+      outputStrings: {
+        text: {
+          en: 'Dodge Lightning First -> Rotate For Fire',
+        },
+      },
+    },
+    {
+      id: 'E11N Burnt Strike Fire Clone',
+      netRegex: NetRegexes.startsUsing({ source: 'Fatebreaker\'s Image', id: '5643', capture: false }),
+      netRegexDe: NetRegexes.startsUsing({ source: 'Abbild[p] des fusionierten Ascians', id: '5643', capture: false }),
+      netRegexFr: NetRegexes.startsUsing({ source: 'double du Sabreur de destins', id: '5643', capture: false }),
+      netRegexJa: NetRegexes.startsUsing({ source: 'フェイトブレイカーの幻影', id: '5643', capture: false }),
+      alertText: (data, _, output) => output.text(),
+      outputStrings: {
+        text: {
+          en: 'Fire Knockback After Lightning',
+        },
+      },
+    },
+    {
+      id: 'E11N Bound Of Faith Tether Collector',
+      netRegex: NetRegexes.tether({ id: tetherIds }),
+      run: (data, matches) => {
+        data.tethers = data.tethers || {};
+        data.tethers[matches.target] = matches.sourceId;
+      },
+    },
+    {
+      id: 'E11N Bound Of Faith Tether Collector Cleanup',
+      netRegex: NetRegexes.tether({ id: tetherIds, capture: false }),
+      delaySeconds: 20,
+      run: (data) => delete data.tethers,
+    },
+    {
+      id: 'E11N Bound Of Faith Fire',
+      netRegex: NetRegexes.startsUsing({ source: 'Fatebreaker', id: '4B18', capture: false }),
+      netRegexDe: NetRegexes.startsUsing({ source: 'Fusioniert(?:e|er|es|en) Ascian', id: '4B18', capture: false }),
+      netRegexFr: NetRegexes.startsUsing({ source: 'Sabreur De Destins', id: '4B18', capture: false }),
+      netRegexJa: NetRegexes.startsUsing({ source: 'フェイトブレイカー', id: '4B18', capture: false }),
+      response: boundOfFaithFireTetherResponse,
+    },
+    {
+      id: 'E11N Bound Of Faith Lightning',
+      netRegex: NetRegexes.startsUsing({ source: 'Fatebreaker', id: '4B19' }),
+      netRegexDe: NetRegexes.startsUsing({ source: 'Fusioniert(?:e|er|es|en) Ascian', id: '4B19' }),
+      netRegexFr: NetRegexes.startsUsing({ source: 'Sabreur De Destins', id: '4B19' }),
+      netRegexJa: NetRegexes.startsUsing({ source: 'フェイトブレイカー', id: '4B19' }),
+      condition: (data, matches) => data.me === matches.target || data.role === 'healer',
+      response: boundOfFaithLightningTetherResponse,
+    },
+    {
+      id: 'E11N Bound Of Faith Holy',
+      netRegex: NetRegexes.startsUsing({ source: 'Fatebreaker', id: '4B1B', capture: false }),
+      netRegexDe: NetRegexes.startsUsing({ source: 'Fusioniert(?:e|er|es|en) Ascian', id: '4B1B', capture: false }),
+      netRegexFr: NetRegexes.startsUsing({ source: 'Sabreur De Destins', id: '4B1B', capture: false }),
+      netRegexJa: NetRegexes.startsUsing({ source: 'フェイトブレイカー', id: '4B1B', capture: false }),
+      response: boundOfFaithHolyTetherResponse,
     },
     {
       id: 'E11N Turn of the Heavens Fire',

--- a/ui/raidboss/data/05-shb/raid/e11n.txt
+++ b/ui/raidboss/data/05-shb/raid/e11n.txt
@@ -6,5 +6,93 @@ hideall "--sync--"
 
 0.0 "--Reset--" sync / 21:........:40000010:/ window 10000 jump 0
 
-0 "Start"
-0.0 "--sync--" sync /:Engage!/ window 0,1
+# -ii 366 4B18 4B19 4B1B
+
+# Opening Block. Introduces Fire/Lightning in a random order.
+0 "Start" sync /Engage!/ window 0,1
+1.2 "--sync--" sync /:Fatebreaker:366:/ window 1.2,1
+11.0 "--center--" sync /:Fatebreaker:5908:/ window 11,5
+21.8 "Burnt Strike" sync /:Fatebreaker:562[CE]:/
+23.5 "Blastburn/Burnout" # sync /:Fatebreaker:562[DF]:/
+39.3 "Floating Fetters" sync /:Fatebreaker:58F4:/
+41.4 "Solemn Charge" sync /:Fatebreaker:563[24]:/
+42.7 "Sinsmite/Sinsmoke" sync /:Fatebreaker:563[35]:/
+54.5 "Burnished Glory" sync /:Fatebreaker:5650:/ window 54.5,5
+65.0 "Powder Mark" sync /:Fatebreaker:564E:/
+67.5 "--center--" sync /:Fatebreaker:5908:/ window 30,30
+78.7 "Burnt Strike" sync /:Fatebreaker:562[CE]:/
+78.9 "Burn Mark" sync /:Fatebreaker:564F:/
+80.4 "Blastburn/Burnout" # sync /:Fatebreaker:562[DF]:/
+88.8 "Burnished Glory" sync /:Fatebreaker:5650:/
+103.6 "Floating Fetters" sync /:Fatebreaker:58F4:/
+105.6 "Solemn Charge" sync /:Fatebreaker:563[24]:/
+106.9 "Sinsmite/Sinsmoke" sync /:Fatebreaker:563[35]:/
+
+# Turn of the Heavens introduced, random element.
+121.7 "Turn Of The Heavens" sync /:Fatebreaker:563[9A]:/ window 121.7,5
+133.5 "Brightfire" # sync /:Halo Of Flame:563[BC]:/
+146.2 "Burnished Glory" sync /:Fatebreaker:5650:/
+159.7 "Shifting Sky" sync /:Fatebreaker:563F:/ window 159.7,5
+162.1 "--untargetable--"
+
+# Single serpent intermission. Lightning Burnt Strike is always first.
+167.2 "--sync--" sync /:Demi-Gukumatz:564B:/
+167.3 "Ageless Serpent" sync /:Demi-Gukumatz:564C:/ window 167.3,5
+174.7 "Resounding Crack" sync /:Demi-Gukumatz:564D:/
+183.9 "Burnt Strike" sync /:Fatebreaker's Image:5645:/
+185.6 "Burnout" sync /:Fatebreaker's Image:5646:/
+187.9 "Burnt Strike" sync /:Fatebreaker's Image:5643:/
+189.9 "Blastburn" sync /:Fatebreaker's Image:5644:/
+195.7 "--targetable--"
+
+# Holy introduction block.
+201.9 "Burnished Glory" sync /:Fatebreaker:5650:/ window 40,5
+213.5 "--center--" sync /:Fatebreaker:5908:/
+224.5 "Burnt Strike" sync /:Fatebreaker:5630:/
+229.5 "Shining Blade" sync /:Fatebreaker:5631:/
+236.6 "Burnished Glory" sync /:Fatebreaker:5650:/
+250.4 "Floating Fetters" sync /:Fatebreaker:58F4:/ window 50,30
+252.4 "Solemn Charge" sync /:Fatebreaker:5636:/
+253.7 "Sinsight" sync /:Fatebreaker:5637:/
+259.3 "Mortal Burn Mark" sync /:Fatebreaker:5638:/
+260.5 "--center--" sync /:Fatebreaker:5908:/
+269.1 "Prismatic Deception" sync /:Fatebreaker:563D:/ window 269.1,5
+272.2 "--untargetable--"
+
+# Clone intermission.
+294.5 "Blasting Zone" sync /:Fatebreaker's Image:563E:/
+300.4 "--targetable--"
+
+# Multi-Strike rotation block
+306.5 "Burnished Glory" sync /:Fatebreaker:5650:/
+319.1 "Powder Mark" sync /:Fatebreaker:564E:/
+329.6 "Turn Of The Heavens" sync /:Fatebreaker:563[9A]:/ window 30,30
+333.0 "Burn Mark" sync /:Fatebreaker:564F:/
+341.4 "Brightfire" # sync /:Halo Of Flame:563[BC]:/
+346.1 "--center--" sync /:Fatebreaker:5908:/
+356.8 "Burnt Strike" sync /:Fatebreaker:56(2C|2E|30):/
+358.5 "Blastburn/Burnout" # sync /:Fatebreaker:(2D|2F|31):/
+369.2 "Burnt Strike" sync /:Fatebreaker:56(2C|2E|30):/
+370.9 "Blastburn/Burnout" # sync /:Fatebreaker:(2D|2F|31):/
+381.2 "Burnished Glory" sync /:Fatebreaker:5650:/
+
+# Fetters rotation block
+391.7 "Burnished Glory" sync /:Fatebreaker:5650:/
+404.2 "Powder Mark" sync /:Fatebreaker:564E:/
+414.7 "Turn Of The Heavens" sync /:Fatebreaker:563[9A]:/ window 30,30
+418.1 "Burn Mark" sync /:Fatebreaker:564F:/
+426.5 "Brightfire" # sync /:Halo Of Flame:563[BC]:/
+431.2 "--center--" sync /:Fatebreaker:5908:/
+442.1 "Burnt Strike" sync /:Fatebreaker:56(2C|2E|30):/
+446.9 "Shining Blade" # sync /:Fatebreaker:5631:/
+454.2 "Burnished Glory" sync /:Fatebreaker:5650:/
+466.9 "Floating Fetters" sync /:Fatebreaker:58F4:/
+469.0 "Solemn Charge" sync /:Fatebreaker:563[246]:/
+470.3 "Sinsmite/Sinsmoke/Sinsight" sync /:Fatebreaker:563[357]:/
+475.9 "Mortal Burn Mark?" sync /:Fatebreaker:5638:/
+
+480.1 "Burnished Glory" sync /:Fatebreaker:5650:/ jump 306.5
+492.7 "Powder Mark"
+503.2 "Turn Of The Heavens"
+506.6 "Burn Mark"
+515.0 "Brightfire"


### PR DESCRIPTION
(@quisquous next time we add placeholders, we can probably include all imports rather than just `ZoneID`, unless that would cause linting problems.)

Nothing really special on this one. The opening block, introducing the basic mechanics, can be Fire or Lightning in a random order. The block following the Serpent intermission is Holy 100%. After Prismatic Deception, any Burnt Strike can be any element, with the exception that two in succession will not be the same. No matter what element Burnt Strike is, anywhere, it will not affect the timing on subsequent mechanics other than Blastburn/Burnout/Shining Blade.

Triggers are largely stolen from quisquous's work on E11S. I double-checked all IDs and verified that all non-healer/tank-specific callouts are functioning.

I haven't done Bound of Faith yet because I'd like to just copy quisquous's work there wholesale. However, I need to find the tether IDs, since on Normal the tethers are element-specific. (Not hard, but I ran out of time and need at least *some* sleep.)

I also need to figure out how best to handle the serpent intermission with the Lightning --> Fire Burst strikes. Maybe with a fresh night's sleep it will be easier.

That all being said, apart from any reviewer notes, this one is ready for merging immediately.