### PR TITLE
E11S: Timeline updates

### DIFF
--- a/ui/raidboss/data/05-shb/raid/e11s.js
+++ b/ui/raidboss/data/05-shb/raid/e11s.js
@@ -647,6 +647,7 @@ export default {
   timelineReplace: [
     {
       'locale': 'de',
+      'missingTranslations': true,
       'replaceSync': {
         'Demi-Gukumatz': 'Demi-Gukumatz',
         'Fatebreaker(?!\'s image)': 'fusioniert(?:e|er|es|en) Ascian',
@@ -683,6 +684,7 @@ export default {
     },
     {
       'locale': 'fr',
+      'missingTranslations': true,
       'replaceSync': {
         'Demi-Gukumatz': 'demi-Gukumatz',
         'Fatebreaker(?!\'s image)': 'Sabreur de destins',
@@ -719,6 +721,7 @@ export default {
     },
     {
       'locale': 'ja',
+      'missingTranslations': true,
       'replaceSync': {
         'Demi-Gukumatz': 'デミグクマッツ',
         'Fatebreaker(?!\'s image)': 'フェイトブレイカー',

--- a/ui/raidboss/data/05-shb/raid/e11s.txt
+++ b/ui/raidboss/data/05-shb/raid/e11s.txt
@@ -76,7 +76,9 @@ hideall "--sync--"
 169.4 "Sinsmoke" sync /:Fatebreaker's Image:5681:/
 169.4 "Sinsmite" sync /:Fatebreaker's Image:5684:/
 169.8 "Bow Shock" sync /:Fatebreaker's Image:5685:/
+173.0 "Burnt Strike " sync /:Fatebreaker's Image:567B:/
 174.7 "Burnout" sync /:Fatebreaker's Image:567C:/
+176.0 "Burnt Strike" sync /:Fatebreaker's Image:5679:/
 178.0 "Blastburn" sync /:Fatebreaker's Image:567A:/
 180.7 "--targetable--"
 
@@ -115,9 +117,12 @@ hideall "--sync--"
 370.5 "Resounding Crack" sync /:Demi-Gukumatz:5688:/
 372.5 "Sinsmoke" sync /:Fatebreaker's Image:5681:/
 372.6 "Sinsight" sync /:Fatebreaker's Image:5BC7:/
+376.5 "Burnt Strike" sync /:Fatebreaker's Image:567D:/
 378.2 "Mortal Burn Mark" sync /:Fatebreaker's Image:5BC8:/
+380.1 "Burnt Strike " sync /:Fatebreaker's Image:567B:/
 381.6 "Shining Blade" sync /:Fatebreaker's Image:567E:/
 381.8 "Burnout" sync /:Fatebreaker's Image:567C:/
+383.6 "Burnt Strike" sync /:Fatebreaker's Image:5679:/
 385.6 "Blastburn" sync /:Fatebreaker's Image:567A:/
 386.4 "--targetable--"
 
@@ -175,7 +180,7 @@ hideall "--sync--"
 
 728.2 "--center--" sync /:Fatebreaker:5908:/ window 30,30
 735.0 "Burnished Glory?"
-737.2 "--Cycle Of Faith--" sync /:Fatebreaker:568A:/ jump 900.0
+737.2 "Cycle Of Faith" sync /:Fatebreaker:568A:/ jump 900.0
 737.2 "--sync--" sync /:Fatebreaker:569A:/ jump 800.0
 737.3 "Elemental Break"
 739.8 "Sinsight/Sinsmite/Sinsmoke"
@@ -233,5 +238,5 @@ hideall "--sync--"
 946.7 "Floating Fetters"
 
 
-992.3 "Burnished Glory" sync /:5529:Fatebreaker/ window 1000,5 duration 9.7
+992.3 "Burnished Glory" sync /:5529:Fatebreaker/ window 1000,0
 1000.0 "Burnished Glory Enrage" sync /:Fatebreaker:5529:/

--- a/ui/raidboss/data/05-shb/raid/e11s.txt
+++ b/ui/raidboss/data/05-shb/raid/e11s.txt
@@ -11,7 +11,7 @@ hideall "--Reset--"
 hideall "--sync--"
 
 # TODO: 5664 is protean
-# TODO: 5908 is --middle--?
+# TODO: 5908 is --center--?
 
 # example lightning bound of faith
 # 46.7 "Bound Of Faith" sync /:Fatebreaker:565[8B]:/
@@ -26,6 +26,13 @@ hideall "--sync--"
 # 49.0 "Solemn Charge" sync /:Fatebreaker:5659:/
 # 50.3 "Sinsmoke" sync /:Fatebreaker:565A:/
 
+# example holy bound of faith
+# 46.7 "Bound Of Faith" sync /:Fatebreaker:565F:/
+# 46.9 "Floating Fetters" sync /:Fatebreaker:58F4:/
+# 49.0 "Solemn Charge" sync /:Fatebreaker:5660:/
+# 50.3 "Sinsight" sync /:Fatebreaker:5661:/
+# 55.9 "Mortal Burn Mark" sync /:Fatebreaker:5662:/
+
 # Burnt Strike timings:
 # * Burnout, lightning, 5655, 1.7s delay
 # * Blastburn, fire, 5653, 2.0s delay
@@ -39,10 +46,9 @@ hideall "--sync--"
 0 "Start"
 0.0 "--sync--" sync /:Engage!/ window 0,1
 2.8 "--sync--" sync /:Fatebreaker:366:/ window 3,0
-10.9 "--sync--" sync /:5666:Fatebreaker/ window 11,10
 17.4 "Elemental Break" sync /:Fatebreaker:566[36]:/
 19.9 "Sinsmoke/Sinsmite" sync /:Fatebreaker:566[57]:/
-23.9 "--middle--" sync /:Fatebreaker:5908:/
+23.9 "--center--" sync /:Fatebreaker:5908:/
 33.0 "Burnt Strike" sync /:Fatebreaker:565[24]:/
 34.7 "Burnout/Blastburn" #sync /:Fatebreaker:565[35]:/
 46.7 "Bound Of Faith" sync /:Fatebreaker:565[8B]:/
@@ -52,35 +58,36 @@ hideall "--sync--"
 70.4 "Powder Mark" sync /:Fatebreaker:56A2:/
 77.9 "Turn Of The Heavens" sync /:Fatebreaker:566A:/
 89.3 "Burn Mark" sync /:Fatebreaker:56A3:/
-89.7 "Brightfire" sync /:Halo of Flame:566D:/
+89.7 "Brightfire" # sync /:Halo of Flame:566D:/
 
-94.4 "--middle--" sync /:Fatebreaker:5908:/
-103.9 "Burnt Strike" sync /:Fatebreaker:5654:/
+94.4 "--center--" sync /:Fatebreaker:5908:/
+103.9 "Burnt Strike" sync /:Fatebreaker:565[24]:/
 105.6 "Burnout/Blastburn" #sync /:Fatebreaker:565[35]:/
-117.6 "Bound Of Faith" sync /:Fatebreaker:5658:/
+117.6 "Bound Of Faith" sync /:Fatebreaker:565[8B]:/
 121.3 "Sinsmoke/Sinsmite" sync /:Fatebreaker:565[AD]:/
 
 # Dragon trio
-132.6 "Elemental Break" sync /:Fatebreaker:5666:/
-135.1 "Sinsmite" sync /:Fatebreaker:5667:/
+132.6 "Elemental Break" sync /:Fatebreaker:566[36]:/
+135.1 "Sinsmite/Sinsmoke" sync /:Fatebreaker:56(5A|57|65|67):/ window 10,10
 147.1 "Shifting Sky" sync /:Fatebreaker:567[56]:/
 149.5 "--untargetable--"
 154.7 "Ageless Serpent" sync /:Demi-Gukumatz:5687:/
 165.8 "Resonant Winds" sync /:Demi-Gukumatz:5689:/
-169.4 "Sinsmoke" sync /:Fatebreaker's image:5681:/
-169.4 "Sinsmite" sync /:Fatebreaker's image:5684:/
-169.8 "Bow Shock" sync /:Fatebreaker's image:5685:/
-174.7 "Burnout" sync /:Fatebreaker's image:567C:/
-178.0 "Blastburn" sync /:Fatebreaker's image:567A:/
+169.4 "Sinsmoke" sync /:Fatebreaker's Image:5681:/
+169.4 "Sinsmite" sync /:Fatebreaker's Image:5684:/
+169.8 "Bow Shock" sync /:Fatebreaker's Image:5685:/
+174.7 "Burnout" sync /:Fatebreaker's Image:567C:/
+178.0 "Blastburn" sync /:Fatebreaker's Image:567A:/
+180.7 "--targetable--"
 
 # Phase 2: light sparkles
-191.5 "Elemental Break" sync /:Fatebreaker:566[36]:/
-194.1 "Sinsmoke/Sinsmite" sync /:Fatebreaker:566[57]:/
+191.5 "Elemental Break" sync /:Fatebreaker:566[368]:/
+194.1 "Sinsmite/Sinsmoke" sync /:Fatebreaker:56(5A|57|65|67):/
 204.0 "Burnished Glory" sync /:Fatebreaker:56A4:/
 
 221.1 "Elemental Break" sync /:Fatebreaker:5668:/
 223.6 "Sinsight" sync /:Fatebreaker:5669:/
-227.6 "--middle--" sync /:Fatebreaker:5908:/
+227.6 "--center--" sync /:Fatebreaker:5908:/
 237.0 "Burnt Strike" sync /:Fatebreaker:5656:/
 242.0 "Shining Blade" sync /:Fatebreaker:5657:/
 250.7 "Bound Of Faith" sync /:Fatebreaker:565F:/
@@ -89,49 +96,142 @@ hideall "--sync--"
 
 264.1 "Burnished Glory" sync /:Fatebreaker:56A4:/
 274.6 "Powder Mark" sync /:Fatebreaker:56A2:/
-282.1 "Right Of The Heavens" sync /:Fatebreaker:566E:/ window 50,50
+282.1 "Right Of The Heavens" sync /:Fatebreaker:566[EF]:/ window 50,50
 293.5 "Burn Mark" sync /:Fatebreaker:56A3:/
 
-298.6 "--middle--" sync /:Fatebreaker:5908:/
-308.2 "Burnt Strike" sync /:Fatebreaker:565[24]:/
+298.6 "--center--" sync /:Fatebreaker:5908:/
+308.2 "Burnt Strike" sync /:Fatebreaker:565[246]:/
 309.9 "Burnout/Blastburn" #sync /:Fatebreaker:565[35]:/
-321.9 "Bound Of Faith" sync /:Fatebreaker:565[8B]:/
-325.6 "Sinsmoke/Sinsmite" sync /:Fatebreaker:565[AD]:/
-336.9 "Elemental Break" sync /:Fatebreaker:566[36]:/
-339.4 "Sinsmoke/Sinsmite" sync /:Fatebreaker:566[57]:/
+321.9 "Bound Of Faith" sync /:Fatebreaker:565[8BF]:/
+325.6 "Sinsmoke/Sinsmite/Sinsight" sync /:Fatebreaker:56(5[AD]|6[159]):/
+331.2 "Mortal Burn Mark?" # sync /:Fatebreaker:5662:/
+336.9 "Elemental Break" sync /:Fatebreaker:566[368]:/
+339.4 "Sinsmoke/Sinsmite/Sinsight" sync /:Fatebreaker:56(5[AD]|6[1579]):/
 
 # dragon trio 2
 351.4 "Sundered Sky" sync /:Fatebreaker:567[78]:/ window 50,50
+353.8 "--untargetable--"
 359.0 "Ageless Serpent" sync /:Demi-Gukumatz:5687:/
 370.5 "Resounding Crack" sync /:Demi-Gukumatz:5688:/
-372.5 "Sinsmoke" sync /:Fatebreaker's image:5681:/
-372.6 "Sinsight" sync /:Fatebreaker's image:5BC7:/
-378.2 "Mortal Burn Mark" sync /:Fatebreaker's image:5BC8:/
-381.6 "Shining Blade" sync /:Fatebreaker's image:567E:/
-381.8 "Burnout" sync /:Fatebreaker's image:567C:/
-385.6 "Blastburn" sync /:Fatebreaker's image:567A:/
+372.5 "Sinsmoke" sync /:Fatebreaker's Image:5681:/
+372.6 "Sinsight" sync /:Fatebreaker's Image:5BC7:/
+378.2 "Mortal Burn Mark" sync /:Fatebreaker's Image:5BC8:/
+381.6 "Shining Blade" sync /:Fatebreaker's Image:567E:/
+381.8 "Burnout" sync /:Fatebreaker's Image:567C:/
+385.6 "Blastburn" sync /:Fatebreaker's Image:567A:/
+386.4 "--targetable--"
 
-397.1 "Elemental Break" sync /:Fatebreaker:5668:/
-399.6 "Sinsight" sync /:Fatebreaker:5669:/
+397.1 "Elemental Break" sync /:Fatebreaker:566[368]:/
+399.6 "Sinsight/Sinsmite" sync /:Fatebreaker:566[579]:/
 409.6 "Burnished Glory" sync /:Fatebreaker:56A4:/
 
 427.1 "Turn Of The Heavens" sync /:Fatebreaker:566[AB]:/ window 50,50
-429.6 "--middle--" sync /:Fatebreaker:5908:/
-438.6 "Elemental Break" sync /:Fatebreaker:566[36]:/
-441.1 "Sinsmoke/Sinsmite" sync /:Fatebreaker:566[57]:/
+429.6 "--center--" sync /:Fatebreaker:5908:/
+438.6 "Elemental Break" sync /:Fatebreaker:566[368]:/
+441.1 "Sinsmite/Sinsmoke" sync /:Fatebreaker:56(5A|57|65|67):/
 450.6 "Powder Mark" sync /:Fatebreaker:56A2:/
 458.1 "Right Of The Heavens" sync /:Fatebreaker:566[EF]:/
-460.6 "--middle--" sync /:Fatebreaker:5908:/
+460.6 "--center--" sync /:Fatebreaker:5908:/
 469.5 "Burn Mark" sync /:Fatebreaker:56A3:/
-469.5 "Bound Of Faith" sync /:Fatebreaker:565F:/
-471.6 "Solemn Charge" sync /:Fatebreaker:5660:/
-472.9 "Sinsight" sync /:Fatebreaker:5661:/
-478.5 "Mortal Burn Mark" sync /:Fatebreaker:5662:/
-488.3 "--middle--" sync /:Fatebreaker:5908:/
+469.5 "Bound Of Faith" sync /:Fatebreaker:565[8F]:/
+471.6 "Solemn Charge" sync /:Fatebreaker:56(59|60):/
+472.9 "Sinsight/Sinsmoke" sync /:Fatebreaker:56[56][159A]:/
+478.5 "Mortal Burn Mark?" # sync /:Fatebreaker:5662:/
+488.3 "--center--" sync /:Fatebreaker:5908:/
 
-493.7 "Prismatic Deception" sync /:Fatebreaker:5672:/
+493.7 "Prismatic Deception" sync /:Fatebreaker:5672:/ window 493.7,10
+496.8 "--untargetable--"
+513.9 "Blasting Zone" sync /:Fatebreaker's Image:56A5:/
+532.0 "Blasting Zone" sync /:Fatebreaker's Image:56A5:/
+537.9 "--targetable--"
 549.2 "Burnished Glory" sync /:Fatebreaker:56A4:/ window 30,30
 
-561.7 "--middle--" sync /:Fatebreaker:5908:/
-570.7 "Cycle of Faith 1"
-# TODO: three groups of mechanics
+
+561.7 "--center--" sync /:Fatebreaker:5908:/
+570.7 "Cycle Of Faith" sync /:Fatebreaker:5692:/ jump 700
+570.7 "--sync--" sync /:Fatebreaker:569A:/ jump 800
+570.7 "--sync--" sync /:Fatebreaker:568B:/ jump 900
+570.8 "Elemental Break"
+573.3 "Sinsight/Sinsmite/Sinsmoke"
+575.2 "Burnt Strike?"
+575.5 "Blastburn?"
+580.2 "Shining Blade?"
+580.2 "Floating Fetters"
+
+
+
+# Lightning Cycle
+691.0 "--center--" sync /:Fatebreaker:5908:/
+700.0 "Cycle Of Faith" sync /:Fatebreaker:5692:/
+700.1 "Elemental Break" sync /:Fatebreaker:5693:/
+702.7 "Sinsmite" sync /:Fatebreaker:5694:/
+704.5 "Burnt Strike" sync /:Fatebreaker:5695:/
+706.2 "Burnout" sync /:Fatebreaker:5696:/
+709.6 "Floating Fetters" sync /:Fatebreaker:5920:/
+711.6 "Solemn Charge" sync /:Fatebreaker:5697:/
+713.1 "Sinsmite" sync /:Fatebreaker:5698:/
+713.2 "Bow Shock" sync /:Fatebreaker:5699:/
+725.7 "Burnished Glory" sync /:Fatebreaker:56A4:/
+
+728.2 "--center--" sync /:Fatebreaker:5908:/ window 30,30
+735.0 "Burnished Glory?"
+737.2 "--Cycle Of Faith--" sync /:Fatebreaker:568A:/ jump 900.0
+737.2 "--sync--" sync /:Fatebreaker:569A:/ jump 800.0
+737.3 "Elemental Break"
+739.8 "Sinsight/Sinsmite/Sinsmoke"
+741.7 "Burnt Strike?"
+742.0 "Blastburn?"
+746.7 "Shining Blade?"
+746.7 "Floating Fetters"
+
+
+# Holy Cycle
+791.0 "--center--" sync /:Fatebreaker:5908:/
+800.0 "Cycle Of Faith" sync /:Fatebreaker:569A:/
+800.1 "Elemental Break" sync /:Fatebreaker:56[89]B:/
+802.7 "Sinsight" sync /:Fatebreaker:569C:/
+804.5 "Burnt Strike" sync /:Fatebreaker:569D:/
+809.5 "Shining Blade" sync /:Fatebreaker:569E:/
+809.6 "Floating Fetters" sync /:Fatebreaker:5920:/
+811.6 "Solemn Charge" sync /:Fatebreaker:569F:/
+813.1 "Sinsight" sync /:Fatebreaker:56A0:/
+818.7 "Mortal Burn Mark" sync /:Fatebreaker:56A1:/
+825.7 "Burnished Glory" sync /:Fatebreaker:56A4:/
+
+828.2 "--center--" sync /:Fatebreaker:5908:/ window 30,30
+835.0 "Burnished Glory?"
+837.2 "Cycle Of Faith" sync /:Fatebreaker:5692:/
+837.2 "--sync--" sync /:Fatebreaker:568A:/
+837.3 "Elemental Break"
+839.8 "Sinsight/Sinsmite/Sinsmoke"
+841.7 "Burnt Strike?"
+842.0 "Blastburn?"
+846.7 "Shining Blade?"
+846.7 "Floating Fetters"
+
+# Fire Cycle
+891.0 "--center--" sync /:Fatebreaker:5908:/
+900.0 "Cycle Of Faith" sync /:Fatebreaker:568A:/
+900.1 "Elemental Break" sync /:Fatebreaker:568B:/
+902.7 "Sinsmoke" sync /:Fatebreaker:568D:/
+904.5 "Burnt Strike" sync /:Fatebreaker:568E:/
+906.5 "Blastburn" sync /:Fatebreaker:568F:/
+909.6 "Floating Fetters" sync /:Fatebreaker:5920:/
+911.6 "Solemn Charge" sync /:Fatebreaker:5690:/
+913.1 "Sinsmoke" sync /:Fatebreaker:5691:/
+925.7 "Burnished Glory" sync /:Fatebreaker:56A4:/
+
+928.2 "--center--" sync /:Fatebreaker:5908:/ window 30,30
+935.0 "Burnished Glory?"
+937.2 "Cycle Of Faith" sync /:Fatebreaker:5692:/ jump 700
+937.2 "--sync--" sync /:Fatebreaker:569A:/ jump 800
+937.3 "Elemental Break"
+939.8 "Sinsight/Sinsmite/Sinsmoke"
+941.7 "Burnt Strike?"
+942.0 "Blastburn?"
+946.7 "Shining Blade?"
+946.7 "Floating Fetters"
+
+
+992.3 "Burnished Glory" sync /:5529:Fatebreaker/ window 1000,5 duration 9.7
+1000.0 "Burnished Glory Enrage" sync /:Fatebreaker:5529:/


### PR DESCRIPTION
I had a look through some of quisquous's enrage logs from this week and made some changes. The biggest addition is of course the cycle blocks and enrage at the end. Those ones I'm 100% confident on.

A *lot* of the Bound of Faith stuff seems a bit inscrutable. It got to the point where I felt like I was just throwing random extra IDs in to make things work. As it stands, this version passed every iteration of `test_timeline` I threw at it, which was about 10 different pulls. A couple of them had 0.5-1s drift on the "move to center" timing during the cycles, and the exact timing on Sinsight/Sinsmite/Sinmoke seems to just vary no matter where it is. Other than that, the timings seemed reasonably rigid.

Suggestions welcome. I'm not at this encounter yet, so everything I've done here is from viewing streams and *lots* of re-running `test`.