### PR TITLE
Raidboss: Reduce alarm annoyance in Matoya's Relict

### DIFF
--- a/ui/raidboss/data/05-shb/dungeon/matoyas_relict.js
+++ b/ui/raidboss/data/05-shb/dungeon/matoyas_relict.js
@@ -171,7 +171,7 @@ export default {
       netRegexFr: NetRegexes.ability({ id: '5916', source: 'mère porxie', capture: false }),
       netRegexJa: NetRegexes.ability({ id: '5916', source: 'マザーポークシー', capture: false }),
       delaySeconds: 5,
-      alarmText: (data, _, output) => output.awayFrom(),
+      alertText: (data, _, output) => output.awayFrom(),
       outputStrings: {
         awayFrom: {
           en: 'Away From Boss',

--- a/ui/raidboss/data/05-shb/dungeon/matoyas_relict.js
+++ b/ui/raidboss/data/05-shb/dungeon/matoyas_relict.js
@@ -185,7 +185,8 @@ export default {
     },
     {
       id: 'Matoyas Porxie Sucked In',
-      netRegex: NetRegexes.gainsEffect({ effectId: '9B6', capture: false }),
+      netRegex: NetRegexes.gainsEffect({ effectId: '9B6' }),
+      suppressSeconds: (data, matches) => parseFloat(matches.duration),
       alarmText: (data, _, output) => output.runAway(),
       outputStrings: {
         runAway: {


### PR DESCRIPTION
Per #2207, things are *really* noisy during Barbeque. I've added a suppression for Sucked In, and moved Barbeque down to Alert, since it's not quite so urgent at that point.