### PR TITLE
Raidboss: Matoya's Relict timelines should now function correctly

### DIFF
--- a/ui/raidboss/data/05-shb/dungeon/matoyas_relict.txt
+++ b/ui/raidboss/data/05-shb/dungeon/matoyas_relict.txt
@@ -8,7 +8,7 @@ hideall "--sync--"
 ### Mudman
 # -p 547F:1011
 # -ii 368 5481 5487 548E 548F 5490 5492
-1000.0 "--sync--" sync / 00:0839:Clayclot Cauldron will be sealed off/ window 1000,0
+1000.0 "--sync--" sync / 00:0839:The Clayclot Cauldron will be sealed off/ window 1000,0
 # Loop 3 times
 1011.0 "Hard Rock" sync /:Mudman:547F:/ window 10,10
 1020.2 "Petrified Peat" sync /:Mudman:5480:/
@@ -47,7 +47,7 @@ hideall "--sync--"
 ### Nixie
 # -p 598F:2009.2
 # -ii 598E 5990 5992 5993 5994 5995 5996 5BB9
-2000.0 "--sync--" sync / 00:0839:Clearnote Cauldron will be sealed off/ window 2000,0
+2000.0 "--sync--" sync / 00:0839:The Clearnote Cauldron will be sealed off/ window 2000,0
 
 2009.2 "Crash-Smash" sync /:Nixie:598F:/ window 10,10
 2023.4 "Shower Power" sync /:Nixie:5991:/
@@ -69,7 +69,7 @@ hideall "--sync--"
 ### Mother Porxie
 # -p 5913:3010.0
 # -ii 4A8F 5912 5914 5917 5918 591E 591F 5923 5925
-3000.0 "--sync--" sync / 00:0839:Woebegone Workshop will be sealed off/ window 3000,0
+3000.0 "--sync--" sync / 00:0839:The Woebegone Workshop will be sealed off/ window 3000,0
 
 3011.3 "Tender Loin" sync /:Mother Porxie:5913:/
 3029.5 "Huff And Puff" sync /:Mother Porxie:5919:/


### PR DESCRIPTION
Currently the timeline start parsing is not smart enough to figure out that `The` is sometimes elided. This change should restore functionality to the timeline. `Test_timeline` correctly started for every encounter I tried it on.