### PR TITLE
Util: Test_timeline terminal color-coding

### DIFF
--- a/util/encounter_tools.py
+++ b/util/encounter_tools.py
@@ -256,10 +256,12 @@ def is_tl_line_adds(poss_match):
 
 
 def colorize(input_text, color_code):
-    return '{}{}{}'.format(color_code, input_text, tcolor.END)
+    return "{}{}{}".format(color_code, input_text, tcolor.END)
+
 
 def color_fail(entry_text):
     return colorize(tcolor.FAIL, entry_text)
+
 
 def color_warn(entry_text):
     return colorize(tcolor.WARN, entry_text)

--- a/util/encounter_tools.py
+++ b/util/encounter_tools.py
@@ -4,11 +4,13 @@ from datetime import datetime
 import re
 import argparse
 
+
 class tcolor:
     WARN = "\033[33m"
     FAIL = "\033[91m"
     CAUTION = "\033[93m"
     END = "\033[0m"
+
 
 def timestamp_type(arg):
     """Defines the timestamp input format"""
@@ -252,8 +254,10 @@ def is_tl_line_log(poss_match):
 def is_tl_line_adds(poss_match):
     return re.search(r"Added new combatant (.*$)", poss_match)
 
+
 def color_fail(entry_text):
     return tcolor.FAIL + entry_text + tcolor.END
+
 
 def color_warn(entry_text):
     return tcolor.WARN + entry_text + tcolor.END

--- a/util/encounter_tools.py
+++ b/util/encounter_tools.py
@@ -4,6 +4,11 @@ from datetime import datetime
 import re
 import argparse
 
+class tcolor:
+    WARN = "\033[33m"
+    FAIL = "\033[91m"
+    CAUTION = "\033[93m"
+    END = "\033[0m"
 
 def timestamp_type(arg):
     """Defines the timestamp input format"""
@@ -246,3 +251,9 @@ def is_tl_line_log(poss_match):
 
 def is_tl_line_adds(poss_match):
     return re.search(r"Added new combatant (.*$)", poss_match)
+
+def color_fail(entry_text):
+    return tcolor.FAIL + entry_text + tcolor.END
+
+def color_warn(entry_text):
+    return tcolor.WARN + entry_text + tcolor.END

--- a/util/encounter_tools.py
+++ b/util/encounter_tools.py
@@ -255,9 +255,11 @@ def is_tl_line_adds(poss_match):
     return re.search(r"Added new combatant (.*$)", poss_match)
 
 
-def color_fail(entry_text):
-    return tcolor.FAIL + entry_text + tcolor.END
+def colorize(input_text, color_code):
+    return '{}{}{}'.format(color_code, input_text, tcolor.END)
 
+def color_fail(entry_text):
+    return colorize(tcolor.FAIL, entry_text)
 
 def color_warn(entry_text):
-    return tcolor.WARN + entry_text + tcolor.END
+    return colorize(tcolor.WARN, entry_text)

--- a/util/test_timeline.py
+++ b/util/test_timeline.py
@@ -9,11 +9,13 @@ import re
 import fflogs
 import encounter_tools as e_tools
 
+
 class tcolor:
-    WARN = '\033[33m'
-    FAIL = '\033[91m'
-    SYNCWARN = '\033[93m'
-    END = '\033[0m'
+    WARN = "\033[33m"
+    FAIL = "\033[91m"
+    SYNCWARN = "\033[93m"
+    END = "\033[0m"
+
 
 def load_timeline(timeline):
     """Loads a timeline file into a list of entry dicts"""

--- a/util/test_timeline.py
+++ b/util/test_timeline.py
@@ -9,6 +9,11 @@ import re
 import fflogs
 import encounter_tools as e_tools
 
+class tcolor:
+    WARN = '\033[33m'
+    FAIL = '\033[91m'
+    SYNCWARN = '\033[93m'
+    END = '\033[0m'
 
 def load_timeline(timeline):
     """Loads a timeline file into a list of entry dicts"""
@@ -281,11 +286,11 @@ def test_match(event, entry):
 
 
 def drift_fail(entry_text):
-    return "\033[91m" + entry_text + "\033[0m"
+    return tcolor.FAIL + entry_text + tcolor.END
 
 
 def drift_warn(entry_text):
-    return "\033[33m" + entry_text + "\033[0m"
+    return tcolor.WARN + entry_text + tcolor.END
 
 
 def check_event(event, timelist, state):

--- a/util/test_timeline.py
+++ b/util/test_timeline.py
@@ -313,12 +313,12 @@ def check_event(event, timelist, state):
             # Check the timeline drift for anomolous timings
             drift = entry["time"] - timeline_position
             entry_text = "{:.3f}: Matched entry: {} {} ({:+.3f}s)".format(
-                    timeline_position, entry["time"], entry["label"], drift
-                )
+                timeline_position, entry["time"], entry["label"], drift
+            )
             if abs(drift) > 1:
-                print('\033[91m' + entry_text + '\033[0m')
+                print("\033[91m" + entry_text + "\033[0m")
             elif 1 > abs(drift) > 0.2:
-                print('\033[33m' + entry_text + '\033[0m')
+                print("\033[33m" + entry_text + "\033[0m")
             else:
                 print(entry_text)
 

--- a/util/test_timeline.py
+++ b/util/test_timeline.py
@@ -315,9 +315,9 @@ def check_event(event, timelist, state):
             entry_text = "{:.3f}: Matched entry: {} {} ({:+.3f}s)".format(
                     timeline_position, entry["time"], entry["label"], drift
                 )
-            if drift > 1 or drift < -1:
+            if abs(drift) > 1:
                 print('\033[91m' + entry_text + '\033[0m')
-            elif 1 > drift > 0.2 or  -1 < drift < -0.2:
+            elif 1 > abs(drift) > 0.2:
                 print('\033[33m' + entry_text + '\033[0m')
             else:
                 print(entry_text)

--- a/util/test_timeline.py
+++ b/util/test_timeline.py
@@ -312,11 +312,18 @@ def check_event(event, timelist, state):
 
             # Check the timeline drift for anomolous timings
             drift = entry["time"] - timeline_position
-            print(
-                "{:.3f}: Matched entry: {} {} ({:+.3f}s)".format(
+            entry_text = "{:.3f}: Matched entry: {} {} ({:+.3f}s)".format(
                     timeline_position, entry["time"], entry["label"], drift
                 )
-            )
+            if drift > 1 or drift < -1:
+                print('\033[91m' + entry_text + '\033[0m')
+            elif 1 > drift > 0.2 or  -1 < drift < -0.2:
+                print('\033[33m' + entry_text + '\033[0m')
+            else:
+                print(entry_text)
+
+            if time_progress_seconds > 30:
+                print("    Warning: {:.3f}s since last sync".format(time_progress_seconds))
 
             if time_progress_seconds > 30:
                 print("    Warning: {:.3f}s since last sync".format(time_progress_seconds))

--- a/util/test_timeline.py
+++ b/util/test_timeline.py
@@ -10,12 +10,6 @@ import fflogs
 import encounter_tools as e_tools
 
 
-class tcolor:
-    WARN = "\033[33m"
-    FAIL = "\033[91m"
-    SYNCWARN = "\033[93m"
-    END = "\033[0m"
-
 
 def load_timeline(timeline):
     """Loads a timeline file into a list of entry dicts"""
@@ -287,14 +281,6 @@ def test_match(event, entry):
     return False
 
 
-def drift_fail(entry_text):
-    return tcolor.FAIL + entry_text + tcolor.END
-
-
-def drift_warn(entry_text):
-    return tcolor.WARN + entry_text + tcolor.END
-
-
 def check_event(event, timelist, state):
     # Get amount of time that's passed since last sync point
     if state["timeline_stopped"]:
@@ -331,9 +317,9 @@ def check_event(event, timelist, state):
                 timeline_position, entry["time"], entry["label"], drift
             )
             if abs(drift) > args.drift_failure:
-                print(drift_fail(entry_text))
+                print(e_tools.color_fail(entry_text))
             elif args.drift_failure > abs(drift) > args.drift_warning:
-                print(drift_warn(entry_text))
+                print(e_tools.color_warn(entry_text))
             else:
                 print(entry_text)
 

--- a/util/test_timeline.py
+++ b/util/test_timeline.py
@@ -10,7 +10,6 @@ import fflogs
 import encounter_tools as e_tools
 
 
-
 def load_timeline(timeline):
     """Loads a timeline file into a list of entry dicts"""
     timelist = []

--- a/util/test_timeline.py
+++ b/util/test_timeline.py
@@ -315,7 +315,7 @@ def check_event(event, timelist, state):
             entry_text = "{:.3f}: Matched entry: {} {} ({:+.3f}s)".format(
                 timeline_position, entry["time"], entry["label"], drift
             )
-            if abs(drift) > args.drift_failure:
+            if args.drift_max > abs(drift) > args.drift_failure:
                 print(e_tools.color_fail(entry_text))
             elif args.drift_failure > abs(drift) > args.drift_warning:
                 print(e_tools.color_warn(entry_text))
@@ -556,6 +556,14 @@ if __name__ == "__main__":
         default=0.2,
         type=float,
         help="If an entry misses its timestamp by more than this value in seconds, it is displayed in yellow. Defaults to 0.2.",
+    )
+    parser.add_argument(
+        "-dm",
+        "--drift-max",
+        nargs="?",
+        default=10,
+        type=float,
+        help="If an entry misses its timestamp by more than this value in seconds, it is assumed to be a jump and will not be highlighted. Defaults to 10.",
     )
 
     args = parser.parse_args()

--- a/util/test_timeline.py
+++ b/util/test_timeline.py
@@ -280,6 +280,14 @@ def test_match(event, entry):
     return False
 
 
+def drift_fail(entry_text):
+    return "\033[91m" + entry_text + "\033[0m"
+
+
+def drift_warn(entry_text):
+    return "\033[33m" + entry_text + "\033[0m"
+
+
 def check_event(event, timelist, state):
     # Get amount of time that's passed since last sync point
     if state["timeline_stopped"]:
@@ -315,10 +323,10 @@ def check_event(event, timelist, state):
             entry_text = "{:.3f}: Matched entry: {} {} ({:+.3f}s)".format(
                 timeline_position, entry["time"], entry["label"], drift
             )
-            if abs(drift) > 1:
-                print("\033[91m" + entry_text + "\033[0m")
-            elif 1 > abs(drift) > 0.2:
-                print("\033[33m" + entry_text + "\033[0m")
+            if abs(drift) > args.drift_failure:
+                print(drift_fail(entry_text))
+            elif args.drift_failure > abs(drift) > args.drift_warning:
+                print(drift_warn(entry_text))
             else:
                 print(entry_text)
 
@@ -538,6 +546,24 @@ if __name__ == "__main__":
         "--timeline",
         type=timeline_file,
         help="The filename of the timeline to test against, e.g. ultima_weapon_ultimate",
+    )
+
+    # Output Format arguments
+    parser.add_argument(
+        "-df",
+        "--drift-failure",
+        nargs="?",
+        default=1,
+        type=float,
+        help="If an entry misses its timestamp by more than this value in seconds, it is displayed in red. Defaults to 1.",
+    )
+    parser.add_argument(
+        "-dw",
+        "--drift-warning",
+        nargs="?",
+        default=0.2,
+        type=float,
+        help="If an entry misses its timestamp by more than this value in seconds, it is displayed in yellow. Defaults to 0.2.",
     )
 
     args = parser.parse_args()

--- a/util/test_timeline.py
+++ b/util/test_timeline.py
@@ -325,9 +325,6 @@ def check_event(event, timelist, state):
             if time_progress_seconds > 30:
                 print("    Warning: {:.3f}s since last sync".format(time_progress_seconds))
 
-            if time_progress_seconds > 30:
-                print("    Warning: {:.3f}s since last sync".format(time_progress_seconds))
-
             # Find any syncs before this one that were passed without syncing
             if not state["timeline_stopped"]:
                 for other_entry in timelist:


### PR DESCRIPTION
(This is currently a proof-of-concept only! It needs lots of refinement.)

It occurred to me that it would be nice to color-code certain lines in `test_timeline` that drift by more than a second. The technique I used here is obviously not what will make it into the final version, but at least we have a baseline for what we want. Note that this currently works on my (Windows 10) machine in Powershell, but after some brief testing from @panicstevenson it looks like it does *not* work in Git Bash.

Todo:

1. Make the conditions/string formatting not-ugly. We have plenty of room for improvement there.
2. Make the thresholds configurable at the command line. This should be relatively trivial.
3. 
![Test_timeline_colors](https://user-images.githubusercontent.com/9992895/102422205-37fee380-3fd4-11eb-942d-992437b8f82c.png)

