### PR TITLE
raidemulator: Fix issues with getCombatants and issue with NetworkAbility line parsing

### DIFF
--- a/ui/raidboss/emulator/data/AnalyzedEncounter.js
+++ b/ui/raidboss/emulator/data/AnalyzedEncounter.js
@@ -95,6 +95,8 @@ export default class AnalyzedEncounter extends EventBus {
     };
 
     for (const log of this.encounter.logLines) {
+      await this.dispatch('analyzeLine', log);
+
       if (this.encounter.combatantTracker.combatants[ID].hasState(log.timestamp)) {
         popupText.OnPlayerChange({
           detail: {

--- a/ui/raidboss/emulator/data/CombatantState.js
+++ b/ui/raidboss/emulator/data/CombatantState.js
@@ -23,4 +23,17 @@ export default class CombatantState {
         Number(props.MP) || this.MP,
         Number(props.maxMP) || this.maxMP);
   }
+
+  toPluginState() {
+    return {
+      PosX: this.posX,
+      PosY: this.posY,
+      PosZ: this.posZ,
+      Heading: this.heading,
+      CurrentHP: this.HP,
+      MaxHP: this.maxHP,
+      CurrentMP: this.MP,
+      MaxMP: this.maxMP,
+    };
+  }
 }

--- a/ui/raidboss/emulator/data/CombatantTracker.js
+++ b/ui/raidboss/emulator/data/CombatantTracker.js
@@ -20,15 +20,12 @@ export default class CombatantTracker {
   }
 
   initialize(logLines) {
-    const keyedLogLines = {};
     // First pass: Get list of combatants, figure out where they
-    // start at if possible, build our keyed log lines
+    // start at if possible
     for (let i = 0; i < logLines.length; ++i) {
       const line = logLines[i];
       this.firstTimestamp = Math.min(this.firstTimestamp, line.timestamp);
       this.lastTimestamp = Math.max(this.lastTimestamp, line.timestamp);
-
-      keyedLogLines[line.timestamp + '_' + i] = line;
 
       switch (line.hexEvent) {
       // Source/target events
@@ -44,14 +41,15 @@ export default class CombatantTracker {
         this.addCombatantFromLine(line);
         this.addCombatantFromTargetLine(line);
         break;
+      case '00':
+        // For 00 chat lines, don't ever generate combatant data from them
+        break;
 
       default:
         this.addCombatantFromLine(line);
         break;
       }
     }
-
-    const sortedTimestamps = Object.keys(keyedLogLines).sort();
 
     // Between passes: Create our initial combatant states
     for (const id in this.initialStates) {
@@ -71,8 +69,8 @@ export default class CombatantTracker {
 
     // Second pass: Analyze combatant information for tracking
     const eventTracker = {};
-    for (let i = 0; i < sortedTimestamps.length; ++i) {
-      const line = keyedLogLines[sortedTimestamps[i]];
+    for (let i = 0; i < logLines.length; ++i) {
+      const line = logLines[i];
       let state = this.extractStateFromLine(line);
       if (state) {
         eventTracker[line.id] = eventTracker[line.id] || 0;

--- a/ui/raidboss/emulator/data/network_log_converter/LineEvent0x15.js
+++ b/ui/raidboss/emulator/data/network_log_converter/LineEvent0x15.js
@@ -50,10 +50,11 @@ export class LineEvent0x15 extends LineEvent {
     this.sourceMp = parts[36 + offset];
     this.sourceMaxMp = parts[37 + offset];
 
-    this.sourceX = parts[40 + offset];
-    this.sourceY = parts[41 + offset];
-    this.sourceZ = parts[42 + offset];
-    this.sourceHeading = parts[43 + offset];
+    // Also map these to x/y/z/heading for combatant state updates
+    this.x = this.sourceX = parts[40 + offset];
+    this.y = this.sourceY = parts[41 + offset];
+    this.z = this.sourceZ = parts[42 + offset];
+    this.heading = this.sourceHeading = parts[43 + offset];
   }
 }
 


### PR DESCRIPTION
- Fix event 0x15 not mapping x/y/z for combatant state
- Fix issues with RaidEmulatorOverlayApiHook's getCombatants override vs C# property casing
- Fix RaidEmulatorOverlayApiHook's getCombatants override not having the correct timestamp offset when doing initial encounter analysis
- Fix issue with suppressSeconds in RaidEmulator
- Fix issue with slow PCs causing delay in playback, causing desync vs videos