### PR TITLE
Raidboss: E11S timeline fixes and QoL

### DIFF
--- a/ui/raidboss/data/05-shb/raid/e11s.txt
+++ b/ui/raidboss/data/05-shb/raid/e11s.txt
@@ -199,8 +199,8 @@ hideall "--sync--"
 
 828.2 "--center--" sync /:Fatebreaker:5908:/ window 30,30
 835.0 "Burnished Glory?"
-837.2 "Cycle Of Faith" sync /:Fatebreaker:5692:/
-837.2 "--sync--" sync /:Fatebreaker:568A:/
+837.2 "Cycle Of Faith" sync /:Fatebreaker:5692:/ jump 700.0
+837.2 "--sync--" sync /:Fatebreaker:568A:/ jump 900.0
 837.3 "Elemental Break"
 839.8 "Sinsight/Sinsmite/Sinsmoke"
 841.7 "Burnt Strike?"

--- a/ui/raidboss/data/05-shb/raid/e11s.txt
+++ b/ui/raidboss/data/05-shb/raid/e11s.txt
@@ -133,8 +133,8 @@ hideall "--sync--"
 460.6 "--center--" sync /:Fatebreaker:5908:/
 469.5 "Burn Mark" sync /:Fatebreaker:56A3:/
 469.5 "Bound Of Faith" sync /:Fatebreaker:565[8F]:/
-471.6 "Solemn Charge" sync /:Fatebreaker:56(59|60):/
-472.9 "Sinsight/Sinsmoke" sync /:Fatebreaker:56[56][159A]:/
+471.6 "Solemn Charge" # sync /:Fatebreaker:56(59|60):/
+472.9 "Sinsight/Sinsmoke" # sync /:Fatebreaker:56[56][159A]:/
 478.5 "Mortal Burn Mark?" # sync /:Fatebreaker:5662:/
 488.3 "--center--" sync /:Fatebreaker:5908:/
 
@@ -152,7 +152,7 @@ hideall "--sync--"
 570.7 "--sync--" sync /:Fatebreaker:568B:/ jump 900
 570.8 "Elemental Break"
 573.3 "Sinsight/Sinsmite/Sinsmoke"
-575.2 "Burnt Strike?"
+575.2 "Burnt Strike"
 575.5 "Blastburn?"
 580.2 "Shining Blade?"
 580.2 "Floating Fetters"
@@ -166,22 +166,19 @@ hideall "--sync--"
 702.7 "Sinsmite" sync /:Fatebreaker:5694:/
 704.5 "Burnt Strike" sync /:Fatebreaker:5695:/
 706.2 "Burnout" sync /:Fatebreaker:5696:/
-709.6 "Floating Fetters" sync /:Fatebreaker:5920:/
 711.6 "Solemn Charge" sync /:Fatebreaker:5697:/
 713.1 "Sinsmite" sync /:Fatebreaker:5698:/
-713.2 "Bow Shock" sync /:Fatebreaker:5699:/
+713.2 "--sync--" sync /:Fatebreaker:5699:/
 725.7 "Burnished Glory" sync /:Fatebreaker:56A4:/
 
 728.2 "--center--" sync /:Fatebreaker:5908:/ window 30,30
-735.0 "Burnished Glory?"
 737.2 "Cycle Of Faith" sync /:Fatebreaker:568A:/ jump 900.0
 737.2 "--sync--" sync /:Fatebreaker:569A:/ jump 800.0
 737.3 "Elemental Break"
 739.8 "Sinsight/Sinsmite/Sinsmoke"
-741.7 "Burnt Strike?"
+741.7 "Burnt Strike"
 742.0 "Blastburn?"
 746.7 "Shining Blade?"
-746.7 "Floating Fetters"
 
 
 # Holy Cycle
@@ -191,22 +188,19 @@ hideall "--sync--"
 802.7 "Sinsight" sync /:Fatebreaker:569C:/
 804.5 "Burnt Strike" sync /:Fatebreaker:569D:/
 809.5 "Shining Blade" sync /:Fatebreaker:569E:/
-809.6 "Floating Fetters" sync /:Fatebreaker:5920:/
 811.6 "Solemn Charge" sync /:Fatebreaker:569F:/
 813.1 "Sinsight" sync /:Fatebreaker:56A0:/
 818.7 "Mortal Burn Mark" sync /:Fatebreaker:56A1:/
 825.7 "Burnished Glory" sync /:Fatebreaker:56A4:/
 
 828.2 "--center--" sync /:Fatebreaker:5908:/ window 30,30
-835.0 "Burnished Glory?"
 837.2 "Cycle Of Faith" sync /:Fatebreaker:5692:/ jump 700.0
 837.2 "--sync--" sync /:Fatebreaker:568A:/ jump 900.0
 837.3 "Elemental Break"
 839.8 "Sinsight/Sinsmite/Sinsmoke"
-841.7 "Burnt Strike?"
+841.7 "Burnt Strike"
 842.0 "Blastburn?"
 846.7 "Shining Blade?"
-846.7 "Floating Fetters"
 
 # Fire Cycle
 891.0 "--center--" sync /:Fatebreaker:5908:/
@@ -215,21 +209,18 @@ hideall "--sync--"
 902.7 "Sinsmoke" sync /:Fatebreaker:568D:/
 904.5 "Burnt Strike" sync /:Fatebreaker:568E:/
 906.5 "Blastburn" sync /:Fatebreaker:568F:/
-909.6 "Floating Fetters" sync /:Fatebreaker:5920:/
 911.6 "Solemn Charge" sync /:Fatebreaker:5690:/
 913.1 "Sinsmoke" sync /:Fatebreaker:5691:/
 925.7 "Burnished Glory" sync /:Fatebreaker:56A4:/
 
 928.2 "--center--" sync /:Fatebreaker:5908:/ window 30,30
-935.0 "Burnished Glory?"
 937.2 "Cycle Of Faith" sync /:Fatebreaker:5692:/ jump 700
 937.2 "--sync--" sync /:Fatebreaker:569A:/ jump 800
 937.3 "Elemental Break"
 939.8 "Sinsight/Sinsmite/Sinsmoke"
-941.7 "Burnt Strike?"
+941.7 "Burnt Strike"
 942.0 "Blastburn?"
 946.7 "Shining Blade?"
-946.7 "Floating Fetters"
 
 
 992.3 "Burnished Glory" sync /:5529:Fatebreaker/ window 1000,0


### PR DESCRIPTION
Some buddies were running E11S last night and noted that they had some small issues with the Cycle portion of the timeline. The general feeling was that there was just too much information in the timeline, and that not all of it was useful.

### Fixes
1. (Temporary only, to be properly fixed when there's time.) I commented out the Solemn Charge syncs at 471. Unfortunately, the possibilities for each overlap here, causing bad timeline jumpiness. This should be resolved by figuring out the actual IDs for each ability and then doing a full match instead of the compact format used here. (That is, `sync /:Fatebreaker:(5659|5960):/` as opposed to `sync /:Fatebreaker:56(59|60):/`, and similarly for other possible collision points.)
2.  Holy Cycle closing jumps. This is a *bad* mistake and I'm not sure how it didn't turn up when I tested this before submitting. Sorry about that!

### Quality of Life
I removed the "Is the enrage happening here?" Burnished Glory from all the lookahead blocks on the cycles. Players who are at this point should *know* whether they are in cycle 3 or not. I also removed Floating Fetters, since it's not terribly relevant compared to everything else that's happening.