### PR TITLE
Raidboss: E10n timeline and triggers

### DIFF
--- a/ui/raidboss/data/05-shb/raid/e10n.js
+++ b/ui/raidboss/data/05-shb/raid/e10n.js
@@ -1,8 +1,199 @@
+import Conditions from '../../../../../resources/conditions.js';
+import NetRegexes from '../../../../../resources/netregexes.js';
+import { Responses } from '../../../../../resources/responses.js';
 import ZoneId from '../../../../../resources/zone_id.js';
 
 export default {
   zoneId: ZoneId.EdensPromiseLitany,
   timelineFile: 'e10n.txt',
+  timelineTriggers: [
+    {
+      id: 'E10N Umbra Smash',
+      regex: /Umbra Smash/,
+      beforeSeconds: 5,
+      condition: Conditions.caresAboutPhysical(),
+      response: Responses.tankBuster(),
+    },
+  ],
   triggers: [
+    {
+      id: 'E10N Deepshadow Nova',
+      netRegex: NetRegexes.startsUsing({ source: 'Shadowkeeper', id: '56E5', capture: false }),
+      netRegexDe: NetRegexes.startsUsing({ source: 'Schattenkönig', id: '56E5', capture: false }),
+      netRegexFr: NetRegexes.startsUsing({ source: 'Roi De L\'Ombre', id: '56E5', capture: false }),
+      netRegexJa: NetRegexes.startsUsing({ source: '影の王', id: '56E5', capture: false }),
+      condition: Conditions.caresAboutAOE(),
+      response: Responses.aoe(),
+    },
+    {
+      id: 'E10N Forward Implosion',
+      netRegex: NetRegexes.startsUsing({ source: 'Shadowkeeper', id: '56B4', capture: false }),
+      netRegexDe: NetRegexes.startsUsing({ source: 'Schattenkönig', id: '56B4', capture: false }),
+      netRegexFr: NetRegexes.startsUsing({ source: 'Roi De L\'Ombre', id: '56B4', capture: false }),
+      netRegexJa: NetRegexes.startsUsing({ source: '影の王', id: '56B4', capture: false }),
+      response: Responses.getBehind(),
+    },
+    {
+      id: 'E10N Backward Implosion',
+      netRegex: NetRegexes.startsUsing({ source: 'Shadowkeeper', id: '56B7', capture: false }),
+      netRegexDe: NetRegexes.startsUsing({ source: 'Schattenkönig', id: '56B7', capture: false }),
+      netRegexFr: NetRegexes.startsUsing({ source: 'Roi De L\'Ombre', id: '56B7', capture: false }),
+      netRegexJa: NetRegexes.startsUsing({ source: '影の王', id: '56B7', capture: false }),
+      alertText: (data, _, output) => output.text(),
+      outputStrings: {
+        text: {
+          en: 'Go Front',
+        },
+      },
+    },
+    {
+      id: 'E10N Forward Shadow Implosion',
+      netRegex: NetRegexes.startsUsing({ source: 'Shadowkeeper', id: '56B5', capture: false }),
+      netRegexDe: NetRegexes.startsUsing({ source: 'Schattenkönig', id: '56B5', capture: false }),
+      netRegexFr: NetRegexes.startsUsing({ source: 'Roi De L\'Ombre', id: '56B5', capture: false }),
+      netRegexJa: NetRegexes.startsUsing({ source: '影の王', id: '56B5', capture: false }),
+      alertText: (data, _, output) => output.text(),
+      outputStrings: {
+        text: {
+          en: 'Shadow Side',
+          de: 'Schatten Seite',
+          fr: 'Ombre à côté',
+          ja: '影同じ側へ',
+          cn: '影子同侧',
+          ko: '그림자 쪽으로',
+        },
+      },
+    },
+    {
+      id: 'E10N Backward Shadow Implosion',
+      netRegex: NetRegexes.startsUsing({ source: 'Shadowkeeper', id: '56B8', capture: false }),
+      netRegexDe: NetRegexes.startsUsing({ source: 'Schattenkönig', id: '56B8', capture: false }),
+      netRegexFr: NetRegexes.startsUsing({ source: 'Roi De L\'Ombre', id: '56B8', capture: false }),
+      netRegexJa: NetRegexes.startsUsing({ source: '影の王', id: '56B8', capture: false }),
+      alertText: (data, _, output) => output.text(),
+      outputStrings: {
+        text: {
+          en: 'Opposite Shadow',
+          de: 'Gegenüber des Schattens',
+          fr: 'Ombre opposée',
+          ja: '影の反対側へ',
+          cn: '影子异侧',
+          ko: '그림자 반대쪽으로',
+        },
+      },
+    },
+    {
+      id: 'E10N Left Giga Slash',
+      netRegex: NetRegexes.startsUsing({ id: '56B1', source: 'Shadowkeeper', capture: false }),
+      response: Responses.goRight(),
+    },
+    {
+      id: 'E10N Right Giga Slash',
+      netRegex: NetRegexes.startsUsing({ id: '56AE', source: 'Shadowkeeper', capture: false }),
+      response: Responses.goLeft(),
+    },
+    {
+      id: 'E10N Left Right Shadow Slash',
+      netRegex: NetRegexes.startsUsing({ id: ['56AF', '56B2'], source: 'Shadowkeeper' }),
+      alertText: (data, matches, output) => matches.id === '56AF' ? output.left() : output.right(),
+      outputStrings: {
+        left: {
+          en: 'Go Left of Shadows',
+          de: 'Geh links vom Schatten',
+          fr: 'Allez à gauche des ombres',
+          ja: '影の左へ',
+          cn: '影子左侧',
+          ko: '그림자 왼쪽',
+        },
+        right: {
+          en: 'Go Right of Shadows',
+          de: 'Geh rechts vom Schatten',
+          fr: 'Allez à droite des ombres',
+          ja: '影の右へ',
+          cn: '影子右侧',
+          ko: '그림자 오른쪽',
+        },
+      },
+    },
+    {
+      id: 'E10N Shadow\'s Edge',
+      netRegex: NetRegexes.startsUsing({ source: 'Shadowkeeper', id: '5B0B' }),
+      netRegexDe: NetRegexes.startsUsing({ source: 'Schattenkönig', id: '5B0B' }),
+      netRegexFr: NetRegexes.startsUsing({ source: 'Roi De L\'Ombre', id: '5B0B' }),
+      netRegexJa: NetRegexes.startsUsing({ source: '影の王', id: '5B0B' }),
+      response: Responses.tankCleave(),
+    },
+    {
+      id: 'E10N Voidgate',
+      netRegex: NetRegexes.startsUsing({ source: 'Shadowkeeper', id: '56DD', capture: false }),
+      netRegexDe: NetRegexes.startsUsing({ source: 'Schattenkönig', id: '56DD', capture: false }),
+      netRegexFr: NetRegexes.startsUsing({ source: 'Roi De L\'Ombre', id: '56DD', capture: false }),
+      netRegexJa: NetRegexes.startsUsing({ source: '影の王', id: '56DD', capture: false }),
+      delaySeconds: 10, // It's 17 seconds from the time Voidgate starts casting until towers.
+      alertText: (data, _, output) => output.text(),
+      outputStrings: {
+        text: {
+          en: 'Get Puddles',
+          de: 'Flächen nehmen',
+          fr: 'Allez dans les zones au sol',
+          ja: '踏む',
+          cn: '踩圈',
+          ko: '바닥 징 밟기',
+        },
+      },
+    },
+    {
+      id: 'E10N Shadow Warrior',
+      netRegex: NetRegexes.startsUsing({ source: 'Shadowkeeper', id: '56E2', capture: false }),
+      netRegexDe: NetRegexes.startsUsing({ source: 'Schattenkönig', id: '56E2', capture: false }),
+      netRegexFr: NetRegexes.startsUsing({ source: 'Roi De L\'Ombre', id: '56E2', capture: false }),
+      netRegexJa: NetRegexes.startsUsing({ source: '影の王', id: '56E2', capture: false }),
+      infoText: (data, _, output) => output.text(),
+      outputStrings: {
+        text: {
+          en: 'Watch Tethered Dog',
+          de: 'Achte auf den verbundenen Hund',
+          fr: 'Regardez le chien lié',
+          ja: '線で繋がった分身を注視',
+          cn: '找连线的狗',
+          ko: '연결된 쫄 지켜보기',
+        },
+      },
+    },
+    {
+      id: 'E10N Cloak of Shadows ',
+      netRegex: NetRegexes.startsUsing({ source: 'Shadowkeeper', id: '5B11', capture: false }),
+      netRegexDe: NetRegexes.startsUsing({ source: 'Schattenkönig', id: '5B11', capture: false }),
+      netRegexFr: NetRegexes.startsUsing({ source: 'Roi De L\'Ombre', id: '5B11', capture: false }),
+      netRegexJa: NetRegexes.startsUsing({ source: '影の王', id: '5B11', capture: false }),
+      suppressSeconds: 5,
+      infoText: (data, _, output) => output.text(),
+      outputStrings: {
+        text: {
+          // TODO: this could be better if we knew where the shadow was
+          en: 'Away From Black Lines',
+        },
+      },
+    },
+    {
+      // There is technically an AoE marker, but by the time it shows,
+      // it's too late to get out if the player is inside the boss's hitbox.
+      id: 'E10N Throne Of Shadow',
+      netRegex: NetRegexes.startsUsing({ source: 'Shadowkeeper', id: '56C7', capture: false }),
+      netRegexDe: NetRegexes.startsUsing({ source: 'Schattenkönig', id: '56C7', capture: false }),
+      netRegexFr: NetRegexes.startsUsing({ source: 'Roi De L\'Ombre', id: '56C7', capture: false }),
+      netRegexJa: NetRegexes.startsUsing({ source: '影の王', id: '56C7', capture: false }),
+      response: Responses.getOut('alert'),
+    },
+    {
+      // There is technically a visual, but it comes up at precisely the same time as puddles.
+      // Best to make sure the user is reminded.
+      id: 'E10N Distant Scream',
+      netRegex: NetRegexes.startsUsing({ source: 'Shadowkeeper', id: '56C6', capture: false }),
+      netRegexDe: NetRegexes.startsUsing({ source: 'Schattenkönig', id: '56C6', capture: false }),
+      netRegexFr: NetRegexes.startsUsing({ source: 'Roi De L\'Ombre', id: '56C6', capture: false }),
+      netRegexJa: NetRegexes.startsUsing({ source: '影の王', id: '56C6', capture: false }),
+      response: Responses.knockback('alert'),
+    },
   ],
 };

--- a/ui/raidboss/data/05-shb/raid/e10n.txt
+++ b/ui/raidboss/data/05-shb/raid/e10n.txt
@@ -4,7 +4,77 @@
 hideall "--Reset--"
 hideall "--sync--"
 
+# Two phase block abilities are not translated:
+# 5B0D, 英雄の影が受けた攻撃：影の遠吠え, which is
+# Attack on the Shadow of the Hero: Howling Shadow (shortened here as Howling Shadow)
+
+# 56CC, 英雄の影が受けた攻撃：ヴォイドパルセーション, which is
+# Attack on the Shadow of the Hero: Void Pulsation (--sync--, since it lines up with Void Pulse)
+
+# -ii 56B0 56B6 56B9 56BA 56BB 56BD 56BE 56C0 56C1 56D4 56D5 56D8 56D9 56E1 56E7 5B09 5B26
+
 0.0 "--Reset--" sync / 21:........:40000010:/ window 10000 jump 0
 
-0 "Start"
-0.0 "--sync--" sync /:Engage!/ window 0,1
+0 "Start" sync /Engage!/ window 0,1
+2.6 "--sync--" sync /:Shadowkeeper:5B09:/ window 2.6,1
+17.0 "Forward Implosion" sync /:Shadowkeeper:56B4:/ window 17,5
+30.5 "Forward Shadow Implosion" sync /:Shadowkeeper:56B5:/
+41.8 "Deepshadow Nova" sync /:Shadowkeeper:56E5:/
+55.0 "Backward Implosion" sync /:Shadowkeeper:56B7:/
+68.5 "Backward Shadow Implosion" sync /:Shadowkeeper:56B8:/
+74.9 "--sync--" sync /:Shadowkeeper:5B08:/ window 74.9,10
+80.3 "Spawn Shadow" sync /:Shadowkeeper:56D6:/
+82.0 "--sync--" sync /:Shadowkeeper:56D7:/
+86.4 "Shadow Warrior" sync /:Shadowkeeper:56E2:/
+99.6 "Barbs Of Agony" sync /:Shadowkeeper:5743:/
+112.7 "Deepshadow Nova" sync /:Shadowkeeper:56E5:/ window 30,30
+118.9 "--sync--" sync /:Shadowkeeper:5B08:/
+124.3 "Fade To Shadow" sync /:Shadowkeeper:56DA:/
+135.4 "--sync--" sync /:Shadowkeeper:56DB:/
+137.9 "Cloak Of Shadows" sync /:Shadowkeeper:5B11:/ window 50,50
+149.1 "Throne Of Shadow" sync /:Shadowkeeper:56C7:/
+157.7 "Umbra Smash x4" duration 5 # sync /:Shadowkeeper:5BAB:/
+169.2 "Shadow's Edge" sync /:Shadowkeeper:5B0B:/
+180.6 "Left/Right Giga Slash" sync /:Shadowkeeper:56(AE|B1):/
+194.1 "Left/Right Shadow Slash" sync /:Shadowkeeper:56(AF|B2):/
+205.5 "Voidgate" sync /:Shadowkeeper:56DD:/ window 50,50
+219.6 "Void Pulse" sync /:Shadowkeeper:56DE:/
+220.2 "--sync--" sync /:Shadowkeeper:56CC:/
+230.8 "Left/Right Shadow Slash" sync /:Shadowkeeper:56(AF|B2):/
+233.9 "Left/Right Shadow Slash" sync /:Shadowkeeper:56(AF|B2):/
+246.6 "Distant Scream" sync /:Shadowkeeper:56C6:/
+
+246.7 "Howling Shadow" sync /:Shadowkeeper:5B0D:/ window 246.7,10
+253.2 "--sync--" sync /:Shadowkeeper:5B08:/
+258.6 "Spawn Shadow" sync /:Shadowkeeper:56D6:/
+260.3 "--sync--" sync /:Shadowkeeper:56D7:/
+264.7 "Shadow Warrior" sync /:Shadowkeeper:56E2:/
+276.9 "Shadowy Eruption" sync /:Shadowkeeper:56(DF|E4):/
+278.0 "Barbs Of Agony" sync /:Shadowkeeper:5743:/
+295.1 "Deepshadow Nova" sync /:Shadowkeeper:56E5:/
+309.4 "Forward Shadow Implosion" sync /:Shadowkeeper:56B5:/
+312.5 "Forward Shadow Implosion" sync /:Shadowkeeper:56B5:/
+320.7 "Deepshadow Nova" sync /:Shadowkeeper:56E5:/
+328.9 "--sync--" sync /:Shadowkeeper:5B08:/
+334.3 "Fade To Shadow" sync /:Shadowkeeper:56DA:/
+345.4 "--sync--" sync /:Shadowkeeper:56DB:/
+347.1 "Forward Implosion" sync /:Shadowkeeper:56B4:/
+347.9 "Cloak Of Shadows" sync /:Shadowkeeper:5B11:/
+359.0 "Throne Of Shadow" sync /:Shadowkeeper:56C7:/
+367.6 "Voidgate" sync /:Shadowkeeper:56DD:/
+381.7 "Void Pulse" sync /:Shadowkeeper:56DE:/
+382.3 "--sync--" sync /:Shadowkeeper:56CC:/
+384.8 "Left/Right Giga Slash" sync /:Shadowkeeper:56(AE|B1):/
+395.2 "Shadowy Eruption" sync /:Shadowkeeper:56(DF|E4):/
+404.4 "Left/Right Shadow Slash" sync /:Shadowkeeper:56(AF|B2):/
+407.5 "Left/Right Shadow Slash" sync /:Shadowkeeper:56(AF|B2):/
+418.6 "Umbra Smash x4" duration 5 # sync /:Shadowkeeper:5BAB:/
+430.0 "Shadow's Edge" sync /:Shadowkeeper:5B0B:/
+439.3 "Shadowy Eruption x4" # sync /:Shadowkeeper:56E0:/
+449.0 "Distant Scream" sync /:Shadowkeeper:56C6:/
+
+449.1 "Howling Shadow" sync /:Shadowkeeper:5B0D:/ jump 246.7
+461.0 "Spawn Shadow"
+467.1 "Shadow Warrior"
+479.3 "Shadowy Eruption"
+480.4 "Barbs Of Agony"

--- a/ui/raidboss/data/05-shb/raid/e10n.txt
+++ b/ui/raidboss/data/05-shb/raid/e10n.txt
@@ -4,17 +4,7 @@
 hideall "--Reset--"
 hideall "--sync--"
 
-# Two phase block abilities are not translated:
-# 5B0D, https://xivapi.com/action/23309, which is
-# Attack on the Shadow of the Hero: Howling Shadow (shortened here as Howling Shadow)
-
-# 56CC, https://xivapi.com/action/22220, which is
-# Attack on the Shadow of the Hero: Void Pulsation (--sync--, since it lines up with Void Pulse)
-
-# Neither of these attacks' names can safely be in the actual file,
-# since multiple utilities throw exceptions based on characters they contain.
-
-# -ii 56B0 56B6 56B9 56BA 56BB 56BD 56BE 56C0 56C1 56D4 56D5 56D8 56D9 56E1 56E7 5B09 5B26
+# -ii 56B0 56B6 56B9 56BA 56BB 56BD 56BE 56C0 56C1 56CC 56D4 56D5 56D8 56D9 56E1 56E7 5B09 5B0D 5B26
 
 0.0 "--Reset--" sync / 21:........:40000010:/ window 10000 jump 0
 
@@ -42,12 +32,10 @@ hideall "--sync--"
 194.1 "Left/Right Shadow Slash" sync /:Shadowkeeper:56(AF|B2):/
 205.5 "Voidgate" sync /:Shadowkeeper:56DD:/ window 50,50
 219.6 "Void Pulse" sync /:Shadowkeeper:56DE:/
-220.2 "--sync--" sync /:Shadowkeeper:56CC:/
 230.8 "Left/Right Shadow Slash" sync /:Shadowkeeper:56(AF|B2):/
 233.9 "Left/Right Shadow Slash" sync /:Shadowkeeper:56(AF|B2):/
-246.6 "Distant Scream" sync /:Shadowkeeper:56C6:/
+246.6 "Distant Scream" sync /:Shadowkeeper:56C6:/ window 246.6,10
 
-246.7 "Howling Shadow" sync /:Shadowkeeper:5B0D:/ window 246.7,10
 253.2 "--center--" sync /:Shadowkeeper:5B08:/
 258.6 "Spawn Shadow" sync /:Shadowkeeper:56D6:/
 260.3 "--sync--" sync /:Shadowkeeper:56D7:/
@@ -66,7 +54,6 @@ hideall "--sync--"
 359.0 "Throne Of Shadow" sync /:Shadowkeeper:56C7:/
 367.6 "Voidgate" sync /:Shadowkeeper:56DD:/
 381.7 "Void Pulse" sync /:Shadowkeeper:56DE:/
-382.3 "--sync--" sync /:Shadowkeeper:56CC:/
 384.8 "Left/Right Giga Slash" sync /:Shadowkeeper:56(AE|B1):/
 395.2 "Shadowy Eruption" sync /:Shadowkeeper:56(DF|E4):/
 404.4 "Left/Right Shadow Slash" sync /:Shadowkeeper:56(AF|B2):/
@@ -74,9 +61,8 @@ hideall "--sync--"
 418.6 "Umbra Smash x4" duration 5 # sync /:Shadowkeeper:5BAB:/
 430.0 "Shadow's Edge" sync /:Shadowkeeper:5B0B:/
 439.3 "Shadowy Eruption x3" # sync /:Shadowkeeper:56E0:/
-449.0 "Distant Scream" sync /:Shadowkeeper:56C6:/
+449.0 "Distant Scream" sync /:Shadowkeeper:56C6:/ jump 246.6
 
-449.1 "Howling Shadow" sync /:Shadowkeeper:5B0D:/ jump 246.7
 461.0 "Spawn Shadow"
 467.1 "Shadow Warrior"
 479.3 "Shadowy Eruption"

--- a/ui/raidboss/data/05-shb/raid/e10n.txt
+++ b/ui/raidboss/data/05-shb/raid/e10n.txt
@@ -5,11 +5,14 @@ hideall "--Reset--"
 hideall "--sync--"
 
 # Two phase block abilities are not translated:
-# 5B0D, 英雄の影が受けた攻撃：影の遠吠え, which is
+# 5B0D, https://xivapi.com/action/23309, which is
 # Attack on the Shadow of the Hero: Howling Shadow (shortened here as Howling Shadow)
 
-# 56CC, 英雄の影が受けた攻撃：ヴォイドパルセーション, which is
+# 56CC, https://xivapi.com/action/22220, which is
 # Attack on the Shadow of the Hero: Void Pulsation (--sync--, since it lines up with Void Pulse)
+
+# Neither of these attacks' names can safely be in the actual file,
+# since multiple utilities throw exceptions based on characters they contain.
 
 # -ii 56B0 56B6 56B9 56BA 56BB 56BD 56BE 56C0 56C1 56D4 56D5 56D8 56D9 56E1 56E7 5B09 5B26
 
@@ -22,13 +25,13 @@ hideall "--sync--"
 41.8 "Deepshadow Nova" sync /:Shadowkeeper:56E5:/
 55.0 "Backward Implosion" sync /:Shadowkeeper:56B7:/
 68.5 "Backward Shadow Implosion" sync /:Shadowkeeper:56B8:/
-74.9 "--sync--" sync /:Shadowkeeper:5B08:/ window 74.9,10
+74.9 "--center--" sync /:Shadowkeeper:5B08:/ window 74.9,10
 80.3 "Spawn Shadow" sync /:Shadowkeeper:56D6:/
 82.0 "--sync--" sync /:Shadowkeeper:56D7:/
 86.4 "Shadow Warrior" sync /:Shadowkeeper:56E2:/
 99.6 "Barbs Of Agony" sync /:Shadowkeeper:5743:/
 112.7 "Deepshadow Nova" sync /:Shadowkeeper:56E5:/ window 30,30
-118.9 "--sync--" sync /:Shadowkeeper:5B08:/
+118.9 "--center--" sync /:Shadowkeeper:5B08:/
 124.3 "Fade To Shadow" sync /:Shadowkeeper:56DA:/
 135.4 "--sync--" sync /:Shadowkeeper:56DB:/
 137.9 "Cloak Of Shadows" sync /:Shadowkeeper:5B11:/ window 50,50
@@ -45,20 +48,20 @@ hideall "--sync--"
 246.6 "Distant Scream" sync /:Shadowkeeper:56C6:/
 
 246.7 "Howling Shadow" sync /:Shadowkeeper:5B0D:/ window 246.7,10
-253.2 "--sync--" sync /:Shadowkeeper:5B08:/
+253.2 "--center--" sync /:Shadowkeeper:5B08:/
 258.6 "Spawn Shadow" sync /:Shadowkeeper:56D6:/
 260.3 "--sync--" sync /:Shadowkeeper:56D7:/
 264.7 "Shadow Warrior" sync /:Shadowkeeper:56E2:/
 276.9 "Shadowy Eruption" sync /:Shadowkeeper:56(DF|E4):/
 278.0 "Barbs Of Agony" sync /:Shadowkeeper:5743:/
 295.1 "Deepshadow Nova" sync /:Shadowkeeper:56E5:/
-309.4 "Forward Shadow Implosion" sync /:Shadowkeeper:56B5:/
-312.5 "Forward Shadow Implosion" sync /:Shadowkeeper:56B5:/
+309.4 "Front/Back Shadow Implosion" sync /:Shadowkeeper:56B[58]:/
+312.5 "Front/Back Shadow Implosion" sync /:Shadowkeeper:56B[58]:/
 320.7 "Deepshadow Nova" sync /:Shadowkeeper:56E5:/
-328.9 "--sync--" sync /:Shadowkeeper:5B08:/
+328.9 "--center--" sync /:Shadowkeeper:5B08:/
 334.3 "Fade To Shadow" sync /:Shadowkeeper:56DA:/
 345.4 "--sync--" sync /:Shadowkeeper:56DB:/
-347.1 "Forward Implosion" sync /:Shadowkeeper:56B4:/
+347.1 "Forward/Backward Implosion" sync /:Shadowkeeper:56B[47]:/
 347.9 "Cloak Of Shadows" sync /:Shadowkeeper:5B11:/
 359.0 "Throne Of Shadow" sync /:Shadowkeeper:56C7:/
 367.6 "Voidgate" sync /:Shadowkeeper:56DD:/
@@ -70,7 +73,7 @@ hideall "--sync--"
 407.5 "Left/Right Shadow Slash" sync /:Shadowkeeper:56(AF|B2):/
 418.6 "Umbra Smash x4" duration 5 # sync /:Shadowkeeper:5BAB:/
 430.0 "Shadow's Edge" sync /:Shadowkeeper:5B0B:/
-439.3 "Shadowy Eruption x4" # sync /:Shadowkeeper:56E0:/
+439.3 "Shadowy Eruption x3" # sync /:Shadowkeeper:56E0:/
 449.0 "Distant Scream" sync /:Shadowkeeper:56C6:/
 
 449.1 "Howling Shadow" sync /:Shadowkeeper:5B0D:/ jump 246.7


### PR DESCRIPTION
Nothing much to say on the encounter itself. It's very straightforward for both timeline and triggers. Much appreciation to @quisquous for finishing up E10s so I could borrow!

I noted it in-line in the timeline file, but the two phase change abilities are not translated: `英雄の影が受けた攻撃：影の遠吠え`, "Attack on the Shadow of the Hero: Howling Shadow", and `英雄の影が受けた攻撃：ヴォイドパルセーション`, "Attack on the Shadow of the Hero: Void Pulsation". I translated or `"--sync--"`d both. (This is also 100% necessary because both the plugin and `test_timeline` complain about having "unknown characters" if the untranslated names are even in timeline comments. It's easily solvable in `test_timeline` by ensuring the timeline is opened as UTF-8, but I'm not 100% sure of the solution for the timeline controller.) Thanks @panicstevenson for talking me through the encoding issue!

Finally, `"Front/Back Shadow Implosion"` is not correct. It should be `"Forward/Backward Shadow Implosion"`. I shortened it this way in the interests of space. Improvement suggestions are welcome.