### PR TITLE
Raidboss: Fix diametrically wrong E12N N/S callouts

### DIFF
--- a/ui/raidboss/data/05-shb/raid/e12n.js
+++ b/ui/raidboss/data/05-shb/raid/e12n.js
@@ -128,15 +128,15 @@ export default {
     },
     {
       // Titanic Bombs spawn at two of four points:
-      // NW X: -11.31371 Y: -63.68629
-      // SW X: -11.31371 Y: -86.3137
-      // NE X: 11.31371 Y: -63.68629
-      // SE X: 11.31371 Y: -86.3137
+      // SW X: -11.31371 Y: -63.68629
+      // NW X: -11.31371 Y: -86.3137
+      // SE X: 11.31371 Y: -63.68629
+      // NE X: 11.31371 Y: -86.3137
       id: 'E12N Bomb Collect',
       netRegex: NetRegexes.addedCombatantFull({ npcNameId: '9816' }),
       run: (data, matches) => {
         const bomb = {};
-        bomb.north = parseFloat(matches.y) + 70 > 0;
+        bomb.north = parseFloat(matches.y) + 70 < 0;
         bomb.east = parseFloat(matches.x) > 0;
         data.bombs = data.bombs || [];
         data.bombs.push(bomb);


### PR DESCRIPTION
Thanks to @valarnin for chasing down instances where this happened. It looks like the coordinate system Square uses is just awful all round. (If it weren't completely impossible given what we know of Square, I would have speculated that the coordinates were randomized on each entry.)