### PR TITLE
jobs: make space for BLM's Xeno counter resource box

### DIFF
--- a/ui/jobs/jobs.css
+++ b/ui/jobs/jobs.css
@@ -228,7 +228,6 @@
 }
 
 /* Space for no resource box */
-.blm #right-side-icons,
 .blu #right-side-icons {
   left: 204px;
 }


### PR DESCRIPTION
The #right-side-icons are being pulled back behind the resource box as BLM is being treated as having 0 boxes on the right side.

Before: 
![image](https://user-images.githubusercontent.com/73085/103151518-11a22a80-47c2-11eb-9392-83cac663884a.png)

After: 
![image](https://user-images.githubusercontent.com/73085/103151522-1ebf1980-47c2-11eb-88c1-a4a2f2a6925d.png)

