### PR TITLE
lint: A better way to implement locale order eslint rule plugin

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -176,6 +176,9 @@ module.exports = {
       'error',
       'never',
     ],
-    'rulesdir/cactbot-locale-order': 'warn',
+    'rulesdir/cactbot-locale-order': [
+      'warn',
+      ['en', 'de', 'fr', 'ja', 'cn', 'ko'],
+    ],
   },
 };

--- a/eslint/cactbot-locale-order.js
+++ b/eslint/cactbot-locale-order.js
@@ -13,8 +13,7 @@ function compareOrder(a, b) {
   const orderA = orderList.indexOf(a);
   const orderB = orderList.indexOf(b);
 
-  if (orderA === -1 || orderB === -1)
-    return 0;
+// All keys are known to be in `orderList` by the `isLocaleObject` check below.
 
   return orderA - orderB;
 }

--- a/eslint/cactbot-locale-order.js
+++ b/eslint/cactbot-locale-order.js
@@ -58,12 +58,12 @@ const ruleModule = {
     },
   },
   create: function(context) {
+    // fill orderList with option,
+    // otherwise use the default one.
+    orderList = context.options[0] || defaultOrderList;
+
     return {
       ObjectExpression(node) {
-        // fill orderList with option,
-        // otherwise use the default one.
-        orderList = context.options[0] || defaultOrderList;
-
         const properties = node.properties;
 
         const isLocaleObject = properties.every((prop) => {

--- a/eslint/cactbot-locale-order.js
+++ b/eslint/cactbot-locale-order.js
@@ -13,8 +13,7 @@ function compareOrder(a, b) {
   const orderA = orderList.indexOf(a);
   const orderB = orderList.indexOf(b);
 
-// All keys are known to be in `orderList` by the `isLocaleObject` check below.
-
+  // All keys are known to be in `orderList` by the `isLocaleObject` check below.
   return orderA - orderB;
 }
 

--- a/eslint/cactbot-locale-order.js
+++ b/eslint/cactbot-locale-order.js
@@ -53,7 +53,7 @@ const ruleModule = {
       },
     ],
     messages: {
-      sortKeys: 'Expected locale object keys ordered like {{expectedOrder}} (\'{{beforeKey}}\' should before \'{{nextKey}}\')',
+      sortKeys: 'Expected locale object keys ordered like {{expectedOrder}} (\'{{beforeKey}}\' should be before \'{{nextKey}}\')',
     },
   },
   create: function(context) {

--- a/eslint/cactbot-locale-order.js
+++ b/eslint/cactbot-locale-order.js
@@ -54,7 +54,7 @@ const ruleModule = {
       },
     ],
     messages: {
-      sortKeys: 'Expected locale object keys ordered like [en, de, fr, ja, cn, ko] (\'{{beforeKey}}\' should before \'{{nextKey}}\')',
+      sortKeys: 'Expected locale object keys ordered like {{expectedOrder}} (\'{{beforeKey}}\' should before \'{{nextKey}}\')',
     },
   },
   create: function(context) {
@@ -91,6 +91,7 @@ const ruleModule = {
               loc: node.loc,
               messageId: 'sortKeys',
               data: {
+                expectedOrder: `[${orderList.join(',')}]`,
                 beforeKey: valid.beforeKey,
                 nextKey: valid.nextKey,
               },

--- a/eslint/cactbot-locale-order.js
+++ b/eslint/cactbot-locale-order.js
@@ -1,22 +1,30 @@
-const orderMap = {
-  en: 0,
-  de: 1,
-  fr: 2,
-  ja: 3,
-  cn: 4,
-  ko: 5,
-};
+const defaultOrderList = [
+  'en',
+  'de',
+  'fr',
+  'ja',
+  'cn',
+  'ko',
+];
 
+let orderList = [];
 
-function isValidOrder(a, b) {
-  const orderA = orderMap[a];
-  const orderB = orderMap[b];
+function compareOrder(a, b) {
+  const orderA = orderList.indexOf(a);
+  const orderB = orderList.indexOf(b);
 
-  if (orderA === undefined || orderB === undefined)
-    return true;
+  if (orderA === -1 || orderB === -1)
+    return 0;
 
+  return orderA - orderB;
+}
 
-  return orderA <= orderB;
+function generateValidObject(props, sourceCode) {
+  const sortedPropsText = [...props]
+    .sort((a, b) => compareOrder(a.key.name, b.key.name))
+    .map((prop) => ' '.repeat(prop.loc.start.column) + sourceCode.getText(prop))
+    .join(',\n');
+  return `{\n${sortedPropsText},\n${' '.repeat(props[0].loc.start.column - 2)}}`;
 }
 
 // ------------------------------------------------------------------------------
@@ -37,57 +45,58 @@ const ruleModule = {
       url: 'https://github.com/quisquous/cactbot/blob/main/docs/RaidbossGuide.md#trigger-elements',
     },
     fixable: 'code',
-    schema: [],
+    schema: [
+      {
+        'type': 'array',
+        'items': {
+          'type': 'string',
+        },
+      },
+    ],
     messages: {
-      sortKeys: 'Expected locale object keys to be in an order like [en, de, fr, ja, cn, ko]. \'{{thisName}}\' should be before \'{{prevName}}\'.',
+      sortKeys: 'Expected locale object keys ordered like [en, de, fr, ja, cn, ko] (\'{{beforeKey}}\' should before \'{{nextKey}}\')',
     },
   },
   create: function(context) {
-    let stack = null;
     return {
       ObjectExpression(node) {
-        stack = {
-          upper: stack,
-          prev: null,
-          prevName: null,
-          numKeys: node.properties.length,
-        };
-      },
+        // fill orderList with option,
+        // otherwise use the default one.
+        orderList = context.options[0] || defaultOrderList;
 
-      'ObjectExpression:exit'() {
-        stack = stack.upper;
-      },
-      Property(node) {
-        if (node.parent.type === 'ObjectPattern')
+        const properties = node.properties;
+
+        const isLocaleObject = properties.every((prop) => {
+          return prop.key && orderList.includes(prop.key.name);
+        });
+        if (!isLocaleObject)
           return;
 
-        const prevName = stack.prevName;
-        const prevNode = stack.prev;
-        const thisName = node.key.name;
+        const validList = [];
 
-        if (thisName !== null) {
-          stack.prevName = thisName;
-          stack.prev = node;
+        for (let i = 1; i < properties.length; i++) {
+          if (compareOrder(properties[i - 1].key.name, properties[i].key.name) > 0) {
+            validList.push({
+              nextKey: properties[i - 1].key.name,
+              beforeKey: properties[i].key.name,
+            });
+          }
         }
 
-        if (prevName === null || thisName === null)
-          return;
-
-        if (!isValidOrder(prevName, thisName)) {
-          const range = [prevNode.range[0], node.range[1]];
-
+        if (validList.length >= 1) {
           const sourceCode = context.getSourceCode();
-          const text = `${sourceCode.getText(node)},\n${' '.repeat(node.loc.start.column)}${sourceCode.getText(prevNode)}`;
-
-          context.report({
-            node,
-            loc: node.key.loc,
-            messageId: 'sortKeys',
-            data: {
-              thisName,
-              prevName,
-            },
-            fix: (fixer) => fixer.replaceTextRange(range, text),
+          validList.forEach((valid) => {
+            context.report({
+              node,
+              loc: node.loc,
+              messageId: 'sortKeys',
+              data: {
+                beforeKey: valid.beforeKey,
+                nextKey: valid.nextKey,
+              },
+              fix: (fixer) =>
+                fixer.replaceTextRange(node.range, generateValidObject(properties, sourceCode)),
+            });
           });
         }
       },


### PR DESCRIPTION
- Sort keys in one-click, even there are multiple invalid orders.
- Add configurable option support. (leave it null or undefined then it would use the default one)
- Use ES6 helper functions, might be a little faster?
- Shorten the notification text.