### PR TITLE
config: show user triggers in the ui

### DIFF
--- a/resources/user_config.js
+++ b/resources/user_config.js
@@ -127,6 +127,10 @@ class UserConfig {
       reloadOnce();
     });
 
+    this.loadUserFiles(overlayName, options, callback);
+  }
+
+  loadUserFiles(overlayName, options, callback) {
     const readOptions = callOverlayHandler({
       call: 'cactbotLoadData',
       overlay: 'options',

--- a/ui/config/config.js
+++ b/ui/config/config.js
@@ -1,3 +1,4 @@
+import Regexes from '../../resources/regexes.js';
 import UserConfig from '../../resources/user_config.js';
 import ZoneInfo from '../../resources/zone_info.js';
 import contentList from '../../resources/content_list.js';
@@ -10,7 +11,6 @@ import '../oopsyraidsy/oopsyraidsy_config.js';
 import '../radar/radar_config.js';
 import '../raidboss/raidboss_config.js';
 import '../../resources/common.js';
-import Regexes from '../../resources/regexes.js';
 
 const Options = {};
 let gConfig = null;

--- a/ui/config/config.js
+++ b/ui/config/config.js
@@ -96,6 +96,9 @@ const kPrefixToCategory = {
     cn: '暗影之逆焰 (5.x)',
     ko: '칠흑의 반역자 (5.x)',
   },
+  'user': {
+    en: 'User Triggers',
+  },
 };
 
 // Translating data subfolders to encounter type.
@@ -482,7 +485,7 @@ export default class CactbotConfigurator {
     parent.appendChild(div);
   }
 
-  processFiles(files) {
+  processFiles(files, userTriggerSets) {
     const map = {};
     for (const filename in files) {
       if (!filename.endsWith('.js'))
@@ -522,10 +525,44 @@ export default class CactbotConfigurator {
         filename: filename,
         fileKey: fileKey,
         prefixKey: prefixKey,
-        typeKey: typeKey,
         prefix: this.translate(kPrefixToCategory[prefixKey]),
+        section: this.translate(kPrefixToCategory[prefixKey]),
         type: this.translate(kDirectoryToCategory[typeKey]),
         title: title,
+        triggerSet: triggerSet,
+        zoneId: zoneId,
+      };
+    }
+
+    const userMap = {};
+    let userFileIdx = 0;
+    for (const triggerSet of userTriggerSets || []) {
+      if (!triggerSet)
+        continue;
+      const fileKey = `user/${triggerSet.filename}/${userFileIdx++}`;
+
+      // cactbot triggers all use zoneId, but user triggers in the wild
+      // may also use zoneRegex or also have errors and not have either.
+      let title = triggerSet.filename;
+      let zoneId = undefined;
+      if ('zoneId' in triggerSet) {
+        zoneId = triggerSet.zoneId;
+        // Use the translatable zone info name, if possible.
+        const zoneInfo = ZoneInfo[zoneId];
+        if (zoneInfo)
+          title = this.translate(zoneInfo.name);
+      } else if ('zoneRegex' in triggerSet) {
+        title = `/${triggerSet.zoneRegex.source}/`;
+      }
+
+      userMap[fileKey] = {
+        filename: triggerSet.filename,
+        fileKey: fileKey,
+        prefixKey: 'user',
+        prefix: this.translate(kPrefixToCategory['user']),
+        section: triggerSet.filename,
+        title: title,
+        type: null,
         triggerSet: triggerSet,
         zoneId: zoneId,
       };
@@ -561,6 +598,10 @@ export default class CactbotConfigurator {
     const sortedMap = {};
     for (const key of sortedEntries)
       sortedMap[key] = map[key];
+
+    // Tack on user triggers at the end in the order they were eval'd.
+    for (const key in userMap)
+      sortedMap[key] = userMap[key];
 
     return sortedMap;
   }

--- a/ui/config/config.js
+++ b/ui/config/config.js
@@ -10,6 +10,7 @@ import '../oopsyraidsy/oopsyraidsy_config.js';
 import '../radar/radar_config.js';
 import '../raidboss/raidboss_config.js';
 import '../../resources/common.js';
+import Regexes from '../../resources/regexes.js';
 
 const Options = {};
 let gConfig = null;
@@ -543,8 +544,8 @@ export default class CactbotConfigurator {
 
       // cactbot triggers all use zoneId, but user triggers in the wild
       // may also use zoneRegex or also have errors and not have either.
-      let title = triggerSet.filename;
-      let zoneId = undefined;
+      let title = '???';
+      let zoneId = 'undefined';
       if ('zoneId' in triggerSet) {
         zoneId = triggerSet.zoneId;
         // Use the translatable zone info name, if possible.
@@ -552,7 +553,12 @@ export default class CactbotConfigurator {
         if (zoneInfo)
           title = this.translate(zoneInfo.name);
       } else if ('zoneRegex' in triggerSet) {
-        title = `/${triggerSet.zoneRegex.source}/`;
+        // zoneRegex can be a localized object.
+        let zoneRegex = this.translate(triggerSet.zoneRegex);
+        if (typeof zoneRegex === 'string')
+          zoneRegex = Regexes.parse(zoneRegex);
+        if (zoneRegex instanceof RegExp)
+          title = `/${zoneRegex.source}/`;
       }
 
       userMap[fileKey] = {

--- a/ui/config/config.js
+++ b/ui/config/config.js
@@ -99,6 +99,7 @@ const kPrefixToCategory = {
   },
   'user': {
     en: 'User Triggers',
+    fr: 'Triggers Utilisateur',
   },
 };
 

--- a/ui/raidboss/raidboss.js
+++ b/ui/raidboss/raidboss.js
@@ -9,28 +9,7 @@ import UserConfig from '../../resources/user_config.js';
 import { addRemotePlayerSelectUI } from '../../resources/player_override.js';
 import raidbossFileData from './data/manifest.txt';
 
-// See user/raidboss-example.js for documentation.
-const Options = {
-  // These options are ones that are not auto-defined by raidboss_config.js.
-  PlayerNicks: {},
-
-  InfoSound: '../../resources/sounds/freesound/percussion_hit.ogg',
-  AlertSound: '../../resources/sounds/BigWigs/Alert.ogg',
-  AlarmSound: '../../resources/sounds/BigWigs/Alarm.ogg',
-  LongSound: '../../resources/sounds/BigWigs/Long.ogg',
-  PullSound: '../../resources/sounds/freesound/sonar.ogg',
-
-  AudioAllowed: true,
-
-  DisabledTriggers: {},
-
-  PerTriggerOptions: {},
-
-  Triggers: [],
-
-  PlayerNameOverride: null,
-  IsRemoteRaidboss: false,
-};
+import Options from './raidboss_options.js';
 
 UserConfig.getUserConfigLocation('raidboss', Options, (e) => {
   // Query params override default and user options.

--- a/ui/raidboss/raidboss_options.js
+++ b/ui/raidboss/raidboss_options.js
@@ -1,0 +1,26 @@
+// These are the base options that raidboss expects to see.
+
+// See user/raidboss-example.js for documentation.
+const Options = {
+  // These options are ones that are not auto-defined by raidboss_config.js.
+  PlayerNicks: {},
+
+  InfoSound: '../../resources/sounds/freesound/percussion_hit.ogg',
+  AlertSound: '../../resources/sounds/BigWigs/Alert.ogg',
+  AlarmSound: '../../resources/sounds/BigWigs/Alarm.ogg',
+  LongSound: '../../resources/sounds/BigWigs/Long.ogg',
+  PullSound: '../../resources/sounds/freesound/sonar.ogg',
+
+  AudioAllowed: true,
+
+  DisabledTriggers: {},
+
+  PerTriggerOptions: {},
+
+  Triggers: [],
+
+  PlayerNameOverride: null,
+  IsRemoteRaidboss: false,
+};
+
+export default Options;


### PR DESCRIPTION
Fixes #2083.

User triggers now show up in the ui.  Each user-defined js file is shown
in its own section as a peer to each expansion section.  Within that
section, each trigger set is given its own subsection even if multiple
trigger sets apply to the same zone.

Like cactbot triggers, user-defined triggers must use output strings in
order to have configurable output text, but other options like duration
and tts vs text can still be configured as long as the trigger has an
id.

This pr handles deprecated-but-still-supported-in-the-wild user
features like zoneRegex and missing trigger ids.  It's nice that the
code to evaluate trigger text is still there, as it applies to
user triggers without output strings.

Triggers with missing ids can't be configured, because all config
options are handled via globally unique ids (whoops?).  This probably
also means that such triggers don't handle suppressSeconds either.
Maybe we should think about using ids for overriding but some other key
for suppressSeconds/config uniqueness.