### PR TITLE
raidboss: e12s oracle add callouts for "Yellow" Anger's Hourglass and "Yellow" Sorrow's Hourglasses

### DIFF
--- a/ui/raidboss/data/05-shb/raid/e12s.js
+++ b/ui/raidboss/data/05-shb/raid/e12s.js
@@ -223,14 +223,14 @@ const matchedPositionToDir = (matches) => {
   const x = parseFloat(matches.x);
 
   // In Basic Relativity, hourglass positions are the 8 cardinals + numerical
-  //  numerical slop on a radius=20 circle.
+  // slop on a radius=20 circle.
   // N = (0, -95), E = (20, -75), S = (0, -55), W = (-20, -75)
   // NE = (14, -89), SE = (14, -61), SW = (-14, -61), NW = (-14, -89)
   //
   // In Advanced Relativity, hourglass positions are the 3 northern positions and
   // three southern positions, plus numerical slop on a radius=10 circle
-  //  NW = (-10, -80), N = (0, -86), NE = (10, -80)
-  //  SW = (-10, -69), S = (0, -64), SE = (10, -69)
+  // NW = (-10, -80), N = (0, -86), NE = (10, -80)
+  // SW = (-10, -69), S = (0, -64), SE = (10, -69)
   //
   // Starting with northwest to favor sorting between north and south for
   // Advanced Relativity party splits.

--- a/ui/raidboss/data/05-shb/raid/e12s.js
+++ b/ui/raidboss/data/05-shb/raid/e12s.js
@@ -860,7 +860,7 @@ export default {
     },
     {
       id: 'E12S Adv Relativity Hourglass Collect',
-      // Collect Sorrow Hourglass locations
+      // Collect Sorrow's Hourglass locations
       netRegex: NetRegexes.addedCombatantFull({ npcNameId: '9823' }),
       run: (data, matches) => {
         const id = parseInt(matches.id, 16);
@@ -871,8 +871,8 @@ export default {
         // Positions are also moved downward 75
         // N = (0, -86), S = (0, -64)
         // NE = (10, -80), SE = (10, -69), SW = (-10, -69), NW = (-10, -80)
-        // Map N = 0, NE = 1, ..., NW = 7
-        const dir = Math.round(4 - 4 * Math.atan2(x, y) / Math.PI) % 8;
+        // Map NW = 0, N = 1, ..., W = 7
+        const dir = Math.round(5 - 4 * Math.atan2(x, y) / Math.PI) % 8;
 
         data.sorrows = data.sorrows || {};
         data.sorrows[id] = [dir, false];
@@ -890,21 +890,21 @@ export default {
     },
     {
       id: 'E12S Adv Relativity Speed',
-      // Orient where Oracle Quickens Sorrow Hourglass
+      // Orient where Oracle Quickens Sorrow's Hourglass
       netRegex: NetRegexes.startsUsing({ id: '58DD' }),
       // Tethers happen on same interval, add some delay
       delaySeconds: 0.5,
       durationSeconds: 8,
       infoText: (data, matches, output) => {
         const dirs = {
-          0: output.north(),
-          1: output.northeast(),
-          2: output.east(),
-          3: output.southeast(),
-          4: output.south(),
-          5: output.southwest(),
-          6: output.west(),
-          7: output.northwest(),
+          0: output.northwest(),
+          1: output.north(),
+          2: output.northeast(),
+          3: output.east(),
+          4: output.southeast(),
+          5: output.south(),
+          6: output.southwest(),
+          7: output.west(),
         };
 
         const sorrows = [];
@@ -913,6 +913,9 @@ export default {
         for (const [key, value] of Object.entries(data.sorrows))
           if (value[1]) sorrows.push(value[0]);
 
+        // Sort for North half first
+        sorrows.sort((a, b) => a - b);
+        
         return output.hourglass({
           dir1: dirs[sorrows[0]],
           dir2: dirs[sorrows[1]],

--- a/ui/raidboss/data/05-shb/raid/e12s.js
+++ b/ui/raidboss/data/05-shb/raid/e12s.js
@@ -863,37 +863,28 @@ export default {
       // Collect Sorrow's Hourglass locations
       netRegex: NetRegexes.addedCombatantFull({ npcNameId: '9823' }),
       run: (data, matches) => {
-        const id = parseInt(matches.id, 16);
+        const id = matches.id.toUpperCase();
         const y = parseFloat(matches.y) + 75;
         const x = parseFloat(matches.x);
 
-        // Positions are NE, N, NW, SW, S, SE + numerical slop on a radius=20 circle.
+        // Positions are NE, N, NW, SW, S, SE + numerical slop on a radius=10 circle.
         // Positions are also moved downward 75
         // N = (0, -86), S = (0, -64)
         // NE = (10, -80), SE = (10, -69), SW = (-10, -69), NW = (-10, -80)
-        // Map NW = 0, N = 1, ..., W = 7
+        // Map NW = 0, NE = 1, ..., W = 7
         const dir = Math.round(5 - 4 * Math.atan2(x, y) / Math.PI) % 8;
 
         data.sorrows = data.sorrows || {};
-        data.sorrows[id] = [dir, false];
+        data.sorrows[id] = dir;
       },
     },
     {
-      id: 'E12S Adv Relativity Hourglass Collect Yellow Tethers',
+      id: 'E12S Adv Relativity Hourglass Yellow Tether',
       // '0086' is the Yellow tether that buffs "Quicken"
       // '0085' is the Red tether that buffs "Slow"
       netRegex: NetRegexes.tether({ id: '0086' }),
-      run: (data, matches) => {
-        const id = parseInt(matches.sourceId, 16);
-        data.sorrows[id][1] = true;
-      },
-    },
-    {
-      id: 'E12S Adv Relativity Speed',
-      // Orient where Oracle Quickens Sorrow's Hourglass
-      netRegex: NetRegexes.startsUsing({ id: '58DD' }),
-      // Tethers happen on same interval, add some delay
-      delaySeconds: 0.5,
+      // Only need to grab first match
+      supressSeconds: 3,
       durationSeconds: 8,
       infoText: (data, matches, output) => {
         const dirs = {
@@ -907,18 +898,14 @@ export default {
           7: output.west(),
         };
 
-        const sorrows = [];
-
-        // Push yellow tethered hourglasses to array
-        for (const [key, value] of Object.entries(data.sorrows))
-          if (value[1]) sorrows.push(value[0]);
-
-        // Sort for North half first
-        sorrows.sort((a, b) => a - b);
+        const sorrow1 = data.sorrows[matches.sourceId.toUpperCase()];
+        
+        // Calculate opposite side
+        const sorrow2 = (sorrow1 + 4) % 8;
 
         return output.hourglass({
-          dir1: dirs[sorrows[0]],
-          dir2: dirs[sorrows[1]],
+          dir1: sorrow1 < sorrow2 ? dirs[sorrow1] : dirs[sorrow2],
+          dir2: sorrow1 > sorrow2 ? dirs[sorrow1] : dirs[sorrow2],
         });
       },
       outputStrings: {

--- a/ui/raidboss/data/05-shb/raid/e12s.js
+++ b/ui/raidboss/data/05-shb/raid/e12s.js
@@ -895,7 +895,7 @@ export default {
       // Tethers happen on same interval, add some delay
       delaySeconds: 0.5,
       durationSeconds: 8,
-      infoText: (data, matches, output) => {
+      infoText: (data, _, output) => {
         const dirs = {
           0: output.north(),
           1: output.northeast(),

--- a/ui/raidboss/data/05-shb/raid/e12s.js
+++ b/ui/raidboss/data/05-shb/raid/e12s.js
@@ -216,17 +216,6 @@ const intermediateRelativityOutputStrings = {
   },
 };
 
-const directions = {
-  0: Outputs.north,
-  1: Outputs.northeast,
-  2: Outputs.east,
-  3: Outputs.southeast,
-  4: Outputs.south,
-  5: Outputs.southwest,
-  6: Outputs.west,
-  7: Outputs.northwest,
-};
-
 export default {
   zoneId: ZoneId.EdensPromiseEternitySavage,
   timelineFile: 'e12s.txt',
@@ -826,10 +815,10 @@ export default {
     },
     {
       id: 'E12S Basic Relativity Yellow Hourglass',
-      // Orient where "Yellow" Anger Hourglass spawns
+      // Orient where "Yellow" Anger's Hourglass spawns
       netRegex: NetRegexes.addedCombatantFull({ npcNameId: '9824' }),
-      condition: (data, matches) => data.phase === 'basic',
-      preRun: (data, matches) => {
+      durationSeconds: 15,
+      infoText: (data, _, output) => {
         const y = parseFloat(matches.y) + 75;
         const x = parseFloat(matches.x);
 
@@ -838,18 +827,34 @@ export default {
         // N = (0, -95), E = (20, -75), S = (0, -55), W = (-20, -75)
         // NE = (14, -89), SE = (14, -61), SW = (-14, -61), NW = (-14, -89)
         // Map N = 0, NE = 1, ..., NW = 7
+        const dirs = {
+          0: Outputs.north(),
+          1: Outputs.northeast(),
+          2: Outputs.east(),
+          3: Outputs.southeast(),
+          4: Outputs.south(),
+          5: Outputs.southwest(),
+          6: Outputs.west(),
+          7: Outputs.northwest(),
+        };
+
         const dir = Math.round(4 - 4 * Math.atan2(x, y) / Math.PI) % 8;
 
-        data.yellow = dir;
+        return output.hourglass({
+          dir: dirs[dir],
+        });
       },
-      durationSeconds: 15,
-      infoText: (data, _, output) => output.hourglass({
-        dir1: output[data.yellow](),
-      }),
       outputStrings: {
-        ...directions,
+        north: Outputs.north,
+        northeast: Outputs.northeast,
+        east: Outputs.east,
+        southeast: Outputs.southeast,
+        south: Outputs.south,
+        southwest: Outputs.southwest,
+        west: Outputs.west,
+        northwest: Outputs.northwest,
         hourglass: {
-          en: 'Yellow: ${dir1}',
+          en: 'Yellow: ${dir}',
         },
       },
     },

--- a/ui/raidboss/data/05-shb/raid/e12s.js
+++ b/ui/raidboss/data/05-shb/raid/e12s.js
@@ -818,7 +818,7 @@ export default {
       // Orient where "Yellow" Anger's Hourglass spawns
       netRegex: NetRegexes.addedCombatantFull({ npcNameId: '9824' }),
       durationSeconds: 15,
-      infoText: (data, _, output) => {
+      infoText: (data, matches, output) => {
         const y = parseFloat(matches.y) + 75;
         const x = parseFloat(matches.x);
 

--- a/ui/raidboss/data/05-shb/raid/e12s.js
+++ b/ui/raidboss/data/05-shb/raid/e12s.js
@@ -831,7 +831,7 @@ export default {
       condition: (data, matches) => data.phase === 'basic',
       durationSeconds: 15,
       infoText: (data, _, output) => output.hourglass({
-        dir1: "" + output[data.yellow](),
+        dir1: output[data.yellow](),
       }),
       outputStrings: {
         ...directions,

--- a/ui/raidboss/data/05-shb/raid/e12s.js
+++ b/ui/raidboss/data/05-shb/raid/e12s.js
@@ -829,16 +829,6 @@ export default {
       // Orient where "Yellow" Anger Hourglass spawns
       netRegex: NetRegexes.addedCombatantFull({ npcNameId: '9824' }),
       condition: (data, matches) => data.phase === 'basic',
-      durationSeconds: 15,
-      infoText: (data, _, output) => output.hourglass({
-        dir1: output[data.yellow](),
-      }),
-      outputStrings: {
-        ...directions,
-        hourglass: {
-          en: 'Yellow: ${dir1}',
-        },
-      },
       preRun: (data, matches) => {
         const y = parseFloat(matches.y) + 75;
         const x = parseFloat(matches.x);
@@ -851,6 +841,16 @@ export default {
         const dir = Math.round(4 - 4 * Math.atan2(x, y) / Math.PI) % 8;
 
         data.yellow = dir;
+      },
+      durationSeconds: 15,
+      infoText: (data, _, output) => output.hourglass({
+        dir1: output[data.yellow](),
+      }),
+      outputStrings: {
+        ...directions,
+        hourglass: {
+          en: 'Yellow: ${dir1}',
+        },
       },
     },
   ],

--- a/ui/raidboss/data/05-shb/raid/e12s.js
+++ b/ui/raidboss/data/05-shb/raid/e12s.js
@@ -915,7 +915,7 @@ export default {
 
         // Sort for North half first
         sorrows.sort((a, b) => a - b);
-        
+
         return output.hourglass({
           dir1: dirs[sorrows[0]],
           dir2: dirs[sorrows[1]],

--- a/ui/raidboss/data/05-shb/raid/e12s.js
+++ b/ui/raidboss/data/05-shb/raid/e12s.js
@@ -240,7 +240,7 @@ const matchedPositionToDir = (matches) => {
 };
 
 // Convert dir to Output
-const dirToOutput = (dir) => {
+const dirToOutput = (dir, output) => {
   const dirs = {
     0: output.northwest(),
     1: output.north(),
@@ -858,7 +858,7 @@ export default {
       durationSeconds: 15,
       infoText: (data, matches, output) => {
         return output.hourglass({
-          dir: dirToOutput(matchedPositionToDir(matches)),
+          dir: dirToOutput(matchedPositionToDir(matches), output),
         });
       },
       outputStrings: {
@@ -900,8 +900,8 @@ export default {
         const sorrow2 = (sorrow1 + 4) % 8;
 
         return output.hourglass({
-          dir1: sorrow1 < sorrow2 ? dirToOutput(sorrow1) : dirToOutput(sorrow2),
-          dir2: sorrow1 > sorrow2 ? dirToOutput(sorrow1) : dirToOutput(sorrow2),
+          dir1: sorrow1 < sorrow2 ? dirToOutput(sorrow1, output) : dirToOutput(sorrow2, output),
+          dir2: sorrow1 > sorrow2 ? dirToOutput(sorrow1, output) : dirToOutput(sorrow2, output),
         });
       },
       outputStrings: {

--- a/ui/raidboss/data/05-shb/raid/e12s.js
+++ b/ui/raidboss/data/05-shb/raid/e12s.js
@@ -216,6 +216,17 @@ const intermediateRelativityOutputStrings = {
   },
 };
 
+const directions = {
+  0: Outputs.north,
+  1: Outputs.northeast,
+  2: Outputs.east,
+  3: Outputs.southeast,
+  4: Outputs.south,
+  5: Outputs.southwest,
+  6: Outputs.west,
+  7: Outputs.northwest,
+};
+
 export default {
   zoneId: ZoneId.EdensPromiseEternitySavage,
   timelineFile: 'e12s.txt',
@@ -811,6 +822,35 @@ export default {
           fr: 'Regardez vers l\'extérieur',
           ja: '外に向け',
         },
+      },
+    },
+    {
+      id: 'E12S Basic Relativity Yellow Hourglass',
+      // Orient where "Yellow" Anger Hourglass spawns
+      netRegex: NetRegexes.addedCombatantFull({ npcNameId: '9824' }),
+      condition: (data, matches) => data.phase === 'basic',
+      durationSeconds: 15,
+      infoText: (data, _, output) => output.hourglass({
+        dir1: "" + output[data.yellow](),
+      }),
+      outputStrings: {
+        ...directions,
+        hourglass: {
+          en: 'Yellow: ${dir1}',
+        },
+      },
+      preRun: (data, matches) => {
+        const y = parseFloat(matches.y) + 75;
+        const x = parseFloat(matches.x);
+
+        // Positions are the 8 cardinals + numerical slop on a radius=20 circle.
+        // Positions are also moved downward 75
+        // N = (0, -95), E = (20, -75), S = (0, -55), W = (-20, -75)
+        // NE = (14, -89), SE = (14, -61), SW = (-14, -61), NW = (-14, -89)
+        // Map N = 0, NE = 1, ..., NW = 7
+        const dir = Math.round(4 - 4 * Math.atan2(x, y) / Math.PI) % 8;
+
+        data.yellow = dir;
       },
     },
   ],

--- a/ui/raidboss/data/05-shb/raid/e12s.js
+++ b/ui/raidboss/data/05-shb/raid/e12s.js
@@ -828,14 +828,14 @@ export default {
         // NE = (14, -89), SE = (14, -61), SW = (-14, -61), NW = (-14, -89)
         // Map N = 0, NE = 1, ..., NW = 7
         const dirs = {
-          0: Outputs.north(),
-          1: Outputs.northeast(),
-          2: Outputs.east(),
-          3: Outputs.southeast(),
-          4: Outputs.south(),
-          5: Outputs.southwest(),
-          6: Outputs.west(),
-          7: Outputs.northwest(),
+          0: output.north(),
+          1: output.northeast(),
+          2: output.east(),
+          3: output.southeast(),
+          4: output.south(),
+          5: output.southwest(),
+          6: output.west(),
+          7: output.northwest(),
         };
 
         const dir = Math.round(4 - 4 * Math.atan2(x, y) / Math.PI) % 8;

--- a/ui/raidboss/data/05-shb/raid/e12s.js
+++ b/ui/raidboss/data/05-shb/raid/e12s.js
@@ -891,8 +891,8 @@ export default {
       // '0086' is the Yellow tether that buffs "Quicken"
       // '0085' is the Red tether that buffs "Slow"
       netRegex: NetRegexes.tether({ id: '0086' }),
-      suppressSeconds: 3,
       durationSeconds: 8,
+      suppressSeconds: 3,
       infoText: (data, matches, output) => {
         const sorrow1 = data.sorrows[matches.sourceId.toUpperCase()];
 

--- a/ui/raidboss/data/05-shb/raid/e12s.js
+++ b/ui/raidboss/data/05-shb/raid/e12s.js
@@ -899,7 +899,7 @@ export default {
         };
 
         const sorrow1 = data.sorrows[matches.sourceId.toUpperCase()];
-        
+
         // Calculate opposite side
         const sorrow2 = (sorrow1 + 4) % 8;
 

--- a/ui/raidboss/data/05-shb/raid/e12s.js
+++ b/ui/raidboss/data/05-shb/raid/e12s.js
@@ -895,7 +895,7 @@ export default {
       // Tethers happen on same interval, add some delay
       delaySeconds: 0.5,
       durationSeconds: 8,
-      infoText: (data, _, output) => {
+      infoText: (data, matches, output) => {
         const dirs = {
           0: output.north(),
           1: output.northeast(),

--- a/ui/raidboss/data/05-shb/raid/e12s.js
+++ b/ui/raidboss/data/05-shb/raid/e12s.js
@@ -910,9 +910,8 @@ export default {
         const sorrows = [];
 
         // Push yellow tethered hourglasses to array
-        for (const [key, value] of Object.entries(data.sorrows)){
+        for (const [key, value] of Object.entries(data.sorrows))
           if (value[1]) sorrows.push(value[0]);
-        }
 
         return output.hourglass({
           dir1: dirs[sorrows[0]],

--- a/ui/raidboss/data/05-shb/raid/e12s.js
+++ b/ui/raidboss/data/05-shb/raid/e12s.js
@@ -858,6 +858,81 @@ export default {
         },
       },
     },
+    {
+      id: 'E12S Adv Relativity Hourglass Collect',
+      // Collect Sorrow Hourglass locations
+      netRegex: NetRegexes.addedCombatantFull({ npcNameId: '9823' }),
+      run: (data, matches) => {
+        const id = parseInt(matches.id, 16);
+        const y = parseFloat(matches.y) + 75;
+        const x = parseFloat(matches.x);
+
+        // Positions are NE, N, NW, SW, S, SE + numerical slop on a radius=20 circle.
+        // Positions are also moved downward 75
+        // N = (0, -86), S = (0, -64)
+        // NE = (10, -80), SE = (10, -69), SW = (-10, -69), NW = (-10, -80)
+        // Map N = 0, NE = 1, ..., NW = 7
+        const dir = Math.round(4 - 4 * Math.atan2(x, y) / Math.PI) % 8;
+
+        data.sorrows = data.sorrows || {};
+        data.sorrows[id] = [dir, false];
+      },
+    },
+    {
+      id: 'E12S Adv Relativity Hourglass Collect Yellow Tethers',
+      // '0086' is the Yellow tether that buffs "Quicken"
+      // '0085' is the Red tether that buffs "Slow"
+      netRegex: NetRegexes.tether({ id: '0086' }),
+      run: (data, matches) => {
+        const id = parseInt(matches.sourceId, 16);
+        data.sorrows[id][1] = true;
+      },
+    },
+    {
+      id: 'E12S Adv Relativity Speed',
+      // Orient where Oracle Quickens Sorrow Hourglass
+      netRegex: NetRegexes.startsUsing({ id: '58DD' }),
+      // Tethers happen on same interval, add some delay
+      delaySeconds: 0.5,
+      durationSeconds: 8,
+      infoText: (data, matches, output) => {
+        const dirs = {
+          0: output.north(),
+          1: output.northeast(),
+          2: output.east(),
+          3: output.southeast(),
+          4: output.south(),
+          5: output.southwest(),
+          6: output.west(),
+          7: output.northwest(),
+        };
+
+        const sorrows = [];
+
+        // Push yellow tethered hourglasses to array
+        for (const [key, value] of Object.entries(data.sorrows)){
+          if (value[1]) sorrows.push(value[0]);
+        }
+
+        return output.hourglass({
+          dir1: dirs[sorrows[0]],
+          dir2: dirs[sorrows[1]],
+        });
+      },
+      outputStrings: {
+        north: Outputs.north,
+        northeast: Outputs.northeast,
+        east: Outputs.east,
+        southeast: Outputs.southeast,
+        south: Outputs.south,
+        southwest: Outputs.southwest,
+        west: Outputs.west,
+        northwest: Outputs.northwest,
+        hourglass: {
+          en: 'Yellow: ${dir1} / ${dir2}',
+        },
+      },
+    },
   ],
   timelineReplace: [
     {

--- a/ui/raidboss/data/05-shb/raid/e12s.js
+++ b/ui/raidboss/data/05-shb/raid/e12s.js
@@ -251,7 +251,7 @@ const dirToOutput = (dir) => {
     6: output.southwest(),
     7: output.west(),
   };
-   return (dirs[dir]);
+  return (dirs[dir]);
 };
 
 export default {


### PR DESCRIPTION
This calls out the direction the kb hourglass spawns at.

The Advanced Relativity hourglass could be called out as well via tethers during Oracle's Speed cast or 4 seconds later by the Quicken buff that they get.