### PR TITLE
raiboss: e12s oracle prevent adv yellow tethers check trigger during basic

### DIFF
--- a/ui/raidboss/data/05-shb/raid/e12s.js
+++ b/ui/raidboss/data/05-shb/raid/e12s.js
@@ -892,7 +892,7 @@ export default {
       // '0086' is the Yellow tether that buffs "Quicken"
       // '0085' is the Red tether that buffs "Slow"
       netRegex: NetRegexes.tether({ id: '0086' }),
-      conditition: (data, matches) => data.phase === 'advanced',
+      condition: (data, matches) => data.phase === 'advanced',
       durationSeconds: 8,
       suppressSeconds: 3,
       infoText: (data, matches, output) => {

--- a/ui/raidboss/data/05-shb/raid/e12s.js
+++ b/ui/raidboss/data/05-shb/raid/e12s.js
@@ -892,6 +892,7 @@ export default {
       // '0086' is the Yellow tether that buffs "Quicken"
       // '0085' is the Red tether that buffs "Slow"
       netRegex: NetRegexes.tether({ id: '0086' }),
+      conditition: (data, matches) => data.phase === 'advanced',
       durationSeconds: 8,
       suppressSeconds: 3,
       infoText: (data, matches, output) => {


### PR DESCRIPTION
After reviewing some OverlayPlugin debug output, I noticed E12S Adv Relativity Hourglass Collect Yellow Tethers errors like TypeError: Cannot read property '...' of undefined (Source: webpack://cactbot/./ui/raidboss/popup-text.js?, Line: 84). This happened to be caused by the tethers appearing in Basic Relativity that I overlooked which activate the trigger.