### PR TITLE
plugin: re-add shield values for 5.41

### DIFF
--- a/plugin/CactbotEventSource/FFXIVProcessIntl.cs
+++ b/plugin/CactbotEventSource/FFXIVProcessIntl.cs
@@ -40,6 +40,9 @@ namespace Cactbot {
 
       [FieldOffset(0x1C4)]
       public CharacterDetails charDetails;
+
+      [FieldOffset(0x1977)]
+      public byte shieldPercentage;
     }
 
     [StructLayout(LayoutKind.Explicit)]
@@ -71,10 +74,6 @@ namespace Cactbot {
 
       [FieldOffset(0x1F)]
       public byte level;
-
-      // TODO: find this again
-      // [FieldOffset(0x65)]
-      // public short shieldPercentage;
     }
     public FFXIVProcessIntl(ILogger logger) : base(logger) { }
 
@@ -199,10 +198,7 @@ namespace Cactbot {
           // This doesn't exist in memory, so just send the right value.
           // As there are other versions that still have it, don't change the event.
           entity.max_mp = 10000;
-
-          // TODO: fix me
-          // entity.shield_value = mem.charDetails.shieldPercentage * entity.max_hp / 100;
-          entity.shield_value = 0;
+          entity.shield_value = mem.shieldPercentage * entity.max_hp / 100;
 
           if (IsGatherer(entity.job)) {
             entity.gp = mem.charDetails.gp;


### PR DESCRIPTION
Re-enables the shield percentage since it seems to be back in patch 5.41. 
It feels a bit messy to copy such a large amount of memory for just one byte so far away from the start but I guess it's fine?

Thanks to @AmenneHolelane in https://github.com/quisquous/cactbot/issues/2107#issuecomment-758983952 (and Pohky on the goat place discord!) for finding the value.

Fixes #2107