### PR TITLE
coverage: add oopsy to coverage report

### DIFF
--- a/ui/oopsyraidsy/oopsy_fields.js
+++ b/ui/oopsyraidsy/oopsy_fields.js
@@ -1,0 +1,18 @@
+// This is the set of fields that will create mistakes.
+export const oopsyTriggerSetOutputFields = [
+  'damageWarn',
+  'damageFail',
+  'shareWarn',
+  'shareFail',
+  'gainsEffectWarn',
+  'gainsEffectFail',
+  'triggers',
+];
+
+// TODO: use this for testing validity of oopsy trigger sets in the event
+// that we eventually get oopsy unit tests.  /o\
+export const oopsyTriggerSetFields = [
+  'zoneId',
+  'zoneRegex',
+  ...oopsyTriggerSetOutputFields,
+];

--- a/util/coverage/coverage.css
+++ b/util/coverage/coverage.css
@@ -52,14 +52,14 @@ body > div {
 
 #expansion-grid {
   display: grid;
-  grid-template-columns: max-content repeat(6, minmax(60px, max-content));
+  grid-template-columns: max-content repeat(7, minmax(60px, max-content));
   column-gap: 20px;
   row-gap: 10px;
 }
 
 #zone-grid {
   display: grid;
-  grid-template-columns: max-content repeat(4, minmax(60px, max-content));
+  grid-template-columns: max-content repeat(5, minmax(60px, max-content));
   column-gap: 20px;
   row-gap: 10px;
   justify-items: left;

--- a/util/coverage/coverage.js
+++ b/util/coverage/coverage.js
@@ -157,7 +157,9 @@ const zoneGridHeaders = {
     ja: 'タイムライン',
     cn: '时间轴',
   },
-  // TODO: oopsy
+  oopsy: {
+    en: 'Oopsy',
+  },
   // TODO: missing translation items
 };
 
@@ -177,6 +179,10 @@ const miscStrings = {
     fr: 'Total',
     ja: '概要',
     cn: '总览',
+  },
+  // Oopsy label for the expansion table.
+  oopsy: {
+    ...zoneGridHeaders.oopsy,
   },
   // Warning when generator hasn't been run.
   runGenerator: {
@@ -206,6 +212,7 @@ const buildExpansionGrid = (container, lang, totals) => {
     const text = translate(contentTypeToLabel[contentType], lang);
     addDiv(container, 'label', text);
   }
+  addDiv(container, 'label', translate(miscStrings.oopsy, lang));
 
   // By expansion.
   for (const exVersion in exVersionToName) {
@@ -214,23 +221,26 @@ const buildExpansionGrid = (container, lang, totals) => {
 
     const versionInfo = totals.byExpansion[exVersion];
     const overall = versionInfo.overall;
-    addDiv(container, 'data', `${overall.num} / ${overall.total}`);
+    addDiv(container, 'data', `${overall.raidboss} / ${overall.total}`);
 
     for (const contentType of contentTypeLabelOrder) {
       const accum = versionInfo.byContentType[contentType];
-      const text = accum.total ? `${accum.num} / ${accum.total}` : undefined;
+      const text = accum.total ? `${accum.raidboss} / ${accum.total}` : undefined;
       addDiv(container, 'data', text);
     }
+
+    addDiv(container, 'data', `${overall.oopsy} / ${overall.total}`);
   }
 
   // Totals.
   addDiv(container, 'label');
-  addDiv(container, 'data', `${totals.overall.num} / ${totals.overall.total}`);
+  addDiv(container, 'data', `${totals.overall.raidboss} / ${totals.overall.total}`);
   for (const contentType of contentTypeLabelOrder) {
     const accum = totals.byContentType[contentType];
-    const text = accum.total ? `${accum.num} / ${accum.total}` : undefined;
+    const text = accum.total ? `${accum.raidboss} / ${accum.total}` : undefined;
     addDiv(container, 'data', text);
   }
+  addDiv(container, 'data', `${totals.overall.oopsy} / ${totals.overall.total}`);
 };
 
 const buildZoneGrid = (container, lang, coverage) => {
@@ -247,6 +257,7 @@ const buildZoneGrid = (container, lang, coverage) => {
         continue;
 
       const zoneCoverage = coverage[zoneId] ? coverage[zoneId] : {
+        oopsy: {},
         triggers: {},
         timeline: {},
       };
@@ -267,18 +278,23 @@ const buildZoneGrid = (container, lang, coverage) => {
           addDiv(container, 'text', name);
         },
         triggers: () => {
-          const triggerEmoji = zoneCoverage.triggers.num > 0 ? '✔️' : undefined;
-          addDiv(container, 'emoji', triggerEmoji);
+          const emoji = zoneCoverage.triggers && zoneCoverage.triggers.num > 0 ? '✔️' : undefined;
+          addDiv(container, 'emoji', emoji);
         },
         timeline: () => {
-          let timelineEmoji = undefined;
-          if (zoneCoverage.timeline.timelineNeedsFixing)
-            timelineEmoji = '⚠️';
-          else if (zoneCoverage.timeline.hasFile)
-            timelineEmoji = '✔️';
+          let emoji = undefined;
+          if (zoneCoverage.timeline) {
+            if (zoneCoverage.timeline.timelineNeedsFixing)
+              emoji = '⚠️';
+            else if (zoneCoverage.timeline.hasFile)
+              emoji = '✔️';
+          }
 
-
-          addDiv(container, 'emoji', timelineEmoji);
+          addDiv(container, 'emoji', emoji);
+        },
+        oopsy: () => {
+          const emoji = zoneCoverage.oopsy && zoneCoverage.oopsy.num > 0 ? '✔️' : undefined;
+          addDiv(container, 'emoji', emoji);
         },
       };
 


### PR DESCRIPTION
The main "expansion" table is a little confusing because oopsy is tacked
on at the end, as if it's a separate content type.  We could add a
separate oopsy table, but that's overkill for what most people care
about.

I think it would make sense to defer fixing up the table until the
coverage report handles translations as well, and we can see what that
looks like overall.