### PR TITLE
raidboss: support English timelineReplace

### DIFF
--- a/test/timeline/test_timeline.js
+++ b/test/timeline/test_timeline.js
@@ -170,8 +170,13 @@ const tests = {
       if (!locale)
         continue;
       // English is a partial translation.
-      if (locale === 'en')
+      if (locale === 'en') {
+        if (trans.missingTranslations)
+          errorFunc(`${triggersFile}:locale ${locale}:should not specify missingTranslations`);
+        if (trans.replaceSync)
+          errorFunc(`${triggersFile}:locale ${locale}:should not specify replaceSync`);
         continue;
+      }
 
       if (trans.missingTranslations)
         continue;

--- a/test/timeline/test_timeline.js
+++ b/test/timeline/test_timeline.js
@@ -169,6 +169,9 @@ const tests = {
       const locale = trans.locale;
       if (!locale)
         continue;
+      // English is a partial translation.
+      if (locale === 'en')
+        continue;
 
       if (trans.missingTranslations)
         continue;

--- a/ui/raidboss/data/05-shb/raid/e9s.js
+++ b/ui/raidboss/data/05-shb/raid/e9s.js
@@ -819,6 +819,12 @@ export default {
   ],
   timelineReplace: [
     {
+      'locale': 'en',
+      'replaceText': {
+        'The Art Of Darkness(?! \\\\())': 'Art Of Dark (Clock/Stacks)',
+      },
+    },
+    {
       'locale': 'de',
       'replaceSync': {
         'Cloud Of Darkness': 'Wolke der Dunkelheit',

--- a/ui/raidboss/data/05-shb/raid/e9s.txt
+++ b/ui/raidboss/data/05-shb/raid/e9s.txt
@@ -10,8 +10,8 @@ hideall "--sync--"
 0 "Start" sync /Engage!/ window 0,1
 0.8 "--sync--" sync /:Cloud Of Darkness:5627:/ window 1,0
 16.9 "Ground-Razing Particle Beam" sync /:Cloud Of Darkness:5625:/ window 17,10
-27.1 "The Art Of Darkness (P/S)" sync /:Cloud Of Darkness:5B4[56]:/
-36.8 "The Art Of Darkness (P/S)" sync /:Cloud Of Darkness:5B4[56]:/
+27.1 "The Art Of Darkness" sync /:Cloud Of Darkness:5B4[56]:/
+36.8 "The Art Of Darkness" sync /:Cloud Of Darkness:5B4[56]:/
 47.5 "Devouring Dark" sync /:Cloud Of Darkness:5623:/
 
 ## Woods
@@ -36,7 +36,7 @@ hideall "--sync--"
 216.0 "Hypercharged Condensation" sync /:Cloud Of Darkness:560C:/
 231.2 "Full-Perimeter Particle Beam" sync /:Cloud Of Darkness:5629:/
 248.5 "The Art Of Darkness (L/R)" sync /:Cloud Of Darkness:5A9[56]:/
-264.3 "The Art Of Darkness (P/S)" sync /:Cloud Of Darkness:55F[BE]:/
+264.3 "The Art Of Darkness" sync /:Cloud Of Darkness:55F[BE]:/
 279.0 "Deluge Of Darkness" sync /:Cloud Of Darkness:55F1:/
 
 ## Default
@@ -64,7 +64,7 @@ hideall "--sync--"
 495.0 "Hypercharged Condensation" sync /:Cloud Of Darkness:560C:/
 510.2 "Full-Perimeter Particle Beam" sync /:Cloud Of Darkness:5629:/
 527.5 "The Art Of Darkness (L/R)" sync /:Cloud Of Darkness:5A9[56]:/
-543.3 "The Art Of Darkness (P/S)" sync /:Cloud Of Darkness:55F[BE]:/
+543.3 "The Art Of Darkness" sync /:Cloud Of Darkness:55F[BE]:/
 564.2 "The Art Of Darkness (L/R)" sync /:Cloud Of Darkness:5A9[56]:/
-580.0 "The Art Of Darkness (P/S)" sync /:Cloud Of Darkness:55F[BE]:/
+580.0 "The Art Of Darkness" sync /:Cloud Of Darkness:55F[BE]:/
 597.1 "Enrage" sync /:Cloud Of Darkness:562A:/


### PR DESCRIPTION
Fixes #2146.

In the future, rather than abbreviating abilities in the timeline
itself, we should keep all abilities as their full names, and
then abbreviate in English via timelineReplace.