### PR TITLE
Raidboss: O4S timeline refresh

### DIFF
--- a/ui/raidboss/data/04-sb/raid/o4s.js
+++ b/ui/raidboss/data/04-sb/raid/o4s.js
@@ -1123,6 +1123,12 @@ export default {
   ],
   timelineReplace: [
     {
+      'locale': 'en',
+      'replaceText': {
+        'Blizzard III/Fire III/Thunder III': 'Blizzard/Fire/Thunder III',
+      },
+    },
+    {
       'locale': 'de',
       'missingTranslations': true,
       'replaceSync': {

--- a/ui/raidboss/data/04-sb/raid/o4s.js
+++ b/ui/raidboss/data/04-sb/raid/o4s.js
@@ -1042,7 +1042,7 @@ export default {
       netRegexJa: NetRegexes.startsUsing({ id: '241E', source: 'ネオエクスデス', capture: false }),
       netRegexCn: NetRegexes.startsUsing({ id: '241E', source: '新生艾克斯迪司', capture: false }),
       netRegexKo: NetRegexes.startsUsing({ id: '241E', source: '네오 엑스데스', capture: false }),
-      response: Responses.stackMarker(),
+      response: Responses.getTogether(),
     },
     {
       id: 'O4S Neo Almagest',
@@ -1124,6 +1124,7 @@ export default {
   timelineReplace: [
     {
       'locale': 'de',
+      'missingTranslations': true,
       'replaceSync': {
         'Exdeath': 'Exdeath',
       },
@@ -1208,6 +1209,7 @@ export default {
     },
     {
       'locale': 'ja',
+      'missingTranslations': true,
       'replaceSync': {
         'Exdeath': 'エクスデス',
       },
@@ -1253,6 +1255,7 @@ export default {
     },
     {
       'locale': 'cn',
+      'missingTranslations': true,
       'replaceSync': {
         '(?<! )Exdeath': '艾克斯迪司',
         'Neo Exdeath': '新生艾克斯迪司',
@@ -1301,6 +1304,7 @@ export default {
     },
     {
       'locale': 'ko',
+      'missingTranslations': true,
       'replaceSync': {
         'Exdeath': '엑스데스',
       },

--- a/ui/raidboss/data/04-sb/raid/o4s.txt
+++ b/ui/raidboss/data/04-sb/raid/o4s.txt
@@ -1,92 +1,79 @@
 # Omega - Deltascape V4.0 (Savage) - O4S
-# Created by Shasta Kota of Death & Taxes (DnT) on Gilgamesh
-# Shasta's reddit: /u/shastaxc
-# Last Updated: 08/01/2017
 
-#############################################################
-########CUSTOMIZE your timeline. Remove the hashtag from
-########the beginning of the following lines to prevent
-########them from appearing on your timeline.
+hideall "--Reset--"
+hideall "--sync--"
 
-#hideall "--Reset--"
-#########DPS CAN HIDE THESE
-
-
-#########HEALERS CAN HIDE THESE
-
-
-#########TANKS CAN HIDE THESE
-
-##############################################################
-################## Windows 8 & 10 Voices ##################
-########REMOVE THE HASTAG to select a voice
-#define speaker "voice" "Microsoft Zira Desktop" 0 100
-#define speaker "voice" "Microsoft David Desktop" 0 100
-
-#################### Windows 7 Voices ####################
-########REMOVE THE HASTAG to select a voice
-#define speaker "voice" "Microsoft Anna" 0 100
-
-################ CUSTOMIZE Call Outs #####################
-########REMOVE THE HASHTAG to enable each call out
-
-
-##############################################################
 0.0 "--Reset--" sync / 21:........:40000010:/ window 10000 jump 0
 
+# -ii 23F2 23F8 2400 240C 2410 2413 2414 2415 241B 2421 2422 242F 2431 2432 244C 244D 245E 24DC
 
-######Phase 1
-13	"Dualcast"	sync /:Exdeath:23F4:/ window 20,0
-16	"Blizzard III"
-19	"Blizzard III"
-24	"Dualcast"
-31	"Thunder III"
-37	"Dualcast"
-43	"Fire III (DPS)"	#Fire III on DPS
-47	"Fire III (T/H)"	#Fire III on Tanks & Healers
-54	"White Hole"
-66	"--Untargetable--"
-73	"Knockback"
-75	"Holy"
-78	"Flare" duration 5	#1 tank, 1 healer, 1 DPS
-79	"Zombie Breath"
+# Exfaust
+0 "Start" sync /Engage!/ window 0,1
+3.8 "--sync--" sync /:Exdeath:23F2:/ window 3.8,0
+12.2 "Dualcast" sync /:Exdeath:23F4:/ window 12.2,5
+16.8 "--sync--" sync /:Exdeath:23F7:/
+17.3 "Blizzard III" sync /:Exdeath:23F8:/
+19.9 "Blizzard III" sync /:Exdeath:23F8:/
+24.8 "Dualcast" sync /:Exdeath:23F4:/
+30.8 "--sync--" sync /:Exdeath:23F9:/
+31.5 "Thunder III" sync /:Exdeath:23FA:/
+32.6 "Thunder III" sync /:Exdeath:23FA:/
+37.9 "Dualcast" sync /:Exdeath:23F4:/
+42.5 "--sync--" sync /:Exdeath:23F5:/
+43.1 "Fire III" sync /:Exdeath:23F6:/
+47.1 "Fire III" sync /:Exdeath:23F6:/
+53.6 "White Hole" sync /:Exdeath:23FF:/
+64.7 "The Decisive Battle" sync /:Exdeath:2408:/
+66.5 "--untargetable--"
 
+70.6 "--sync--" sync /:Exdeath:240A:/
+71.8 "Collision" sync /:Exdeath:2409:/
+73.8 "Holy" sync /:Exdeath:2403:/
+77.7 "Zombie Breath" sync /:Exdeath:240B:/
+82.4 "Flare" sync /:Exdeath:2401:/
 
-######Phase 2
-86	"--Targetable--"
-90	"Random Elemental"	#Enhanced Thunder/Fire/Blizzard III
-97	"Vacuum Wave (1)"
-107	"White Hole"
-119	"Black Hole"	#Black Holes tether to Tanks & Healers + AoE dmg + HP Down Debuff
-119.01	"HP Down Debuff" duration 21  #Debuff is 20 seconds but applies to people staggered over time
-128	"Fire III (DPS)"	#Fire III on DPS
-132	"Fire III (T/H)"	#Fire III on Tanks & Healers
-135	"Holy"	#Stack Mechanic
-144	"White Hole"
-159	"Thunder III"
-167	"Meteor"
-180	"--Untargetable--"
-186	"Knockback"	#Collision
-188	"Holy"	#Stack Mechanic
-191	"Flare" duration 5	#1 tank, 1 healer, 1 DPS
-192	"Zombie Breath"
+85.2 "--targetable--"
+89.2 "Blizzard III/Fire III/Thunder III" sync /:Exdeath:23F[BCD]:/
+95.4 "Vacuum Wave" sync /:Exdeath:23FE:/
+105.6 "White Hole" sync /:Exdeath:23FF:/
+118.0 "Black Hole" sync /:Exdeath:2406:/
+123.1 "Dualcast" sync /:Exdeath:23F4:/
+127.7 "--sync--" sync /:Exdeath:23F5:/
+128.3 "Fire III" sync /:Exdeath:23F6:/
+132.2 "Fire III" sync /:Exdeath:23F6:/
+134.8 "Holy" sync /:Exdeath:240[23]:/
+144.0 "White Hole" sync /:Exdeath:23FF:/
+153.1 "Dualcast" sync /:Exdeath:23F4:/
+159.1 "--sync--" sync /:Exdeath:23F9:/
+159.8 "Thunder III" sync /:Exdeath:23FA:/
+160.9 "Thunder III" sync /:Exdeath:23FA:/
+166.1 "Meteor" sync /:Exdeath:2404:/
+179.4 "The Decisive Battle" sync /:Exdeath:2408:/
+181.5 "--untargetable--"
 
-######Phase 3
-200	"--Targetable--"
-203	"Random Elemental"	#Enhanced Thunder/Fire/Blizzard III
-210	"Vacuum Wave (1)"	#Vacuum Wave
-220	"White Hole"	#Need full HP
-232	"Black Hole"	#Black Holes tether to Tanks & Healers + AoE dmg + HP Down Debuff
-232.01	"HP Down Debuff" duration 21  #Debuff is 20 seconds but applies to people staggered over time
-241	"Blizzard III"	#Healers + DPS
-243	"Blizzard III"	#Healers + DPS
-243	"Flare" duration 5	#1 tank, 1 healer, 1 DPS
-258	"White Hole"	#Need full HP
-265	"Dualcast"
-273	"Thunder III"
-280	"Meteor"	#Party wipe if boss HP>65%
-282	"--Untargetable--"
-344	"--LB Gauge Resets--"
+185.3 "--sync--" sync /:Exdeath:240A:/
+186.4 "Collision" sync /:Exdeath:2409:/
+188.7 "Holy" sync /:Exdeath:2403:/
+192.4 "Zombie Breath" sync /:Exdeath:240B:/
+197.1 "Flare" sync /:Exdeath:2401:/
+
+200.0 "--targetable--"
+203.9 "Blizzard III/Fire III/Thunder III" sync /:Exdeath:23F[BCD]:/
+210.3 "Vacuum Wave" sync /:Exdeath:23FE:/
+220.5 "White Hole" sync /:Exdeath:23FF:/
+232.8 "Black Hole" sync /:Exdeath:2406:/
+237.9 "Dualcast" sync /:Exdeath:23F4:/
+242.5 "--sync--" sync /:Exdeath:23F7:/
+243.0 "Blizzard III" sync /:Exdeath:23F8:/
+245.6 "Blizzard III" sync /:Exdeath:23F8:/
+249.6 "Flare" sync /:Exdeath:2401:/
+258.8 "White Hole" sync /:Exdeath:23FF:/
+267.9 "Dualcast" sync /:Exdeath:23F4:/
+274.0 "--sync--" sync /:Exdeath:23F9:/
+274.7 "Thunder III" sync /:Exdeath:23FA:/
+275.8 "Thunder III" sync /:Exdeath:23FA:/
+281.0 "Meteor" sync /:Exdeath:2404:/
+282.0 "--untargetable--"
 
 ######################################################
 ######Neo Phase 1
@@ -209,3 +196,128 @@
 1246	"Frenzied Fist x9"	#Small Raid AoEs
 1253	"Frenzied Sphere (8)"	#Big Raid AoE
 1266	"Enrage"	#Long Almagest
+
+
+0 "Start" sync /Engage!/ window 0,1
+7.7 "Almagest" sync /:Neo Exdeath:2417:/
+16.7 "Aero III" sync /:Neo Exdeath:2419:/
+26.7 "Delta Attack" sync /:Neo Exdeath:241E:/
+27.2 "Blizzard III" sync /:Neo Exdeath:23F8:/
+27.4 "Thunder III" sync /:Neo Exdeath:23FA:/
+27.7 "Fire III" sync /:Neo Exdeath:23F6:/
+28.4 "Thunder III" sync /:Neo Exdeath:23FA:/
+30.2 "Blizzard III" sync /:Neo Exdeath:23F8:/
+30.7 "Fire III" sync /:Neo Exdeath:23F6:/
+
+42.7 "Grand Cross Alpha" sync /:Neo Exdeath:242B:/
+53.7 "Flood Of Naught (charge)" sync /:Neo Exdeath:2416:/
+61.7 "Flood Of Naught (colors)" sync /:Neo Exdeath:(2411|2412):/
+73.2 "Double Attack" sync /:Neo Exdeath:241C:/
+83.8 "Emptiness x8" sync /:Neo Exdeath:2420:/ duration 10
+91.8 "Flood Of Naught (lasers)" sync /:Neo Exdeath:(240E|240F):/
+101.9 "Aero III" sync /:Neo Exdeath:2419:/
+
+116.0 "Grand Cross Delta" sync /:Neo Exdeath:242C:/
+129.0 "Flood Of Naught (colors/lasers)" sync /:Neo Exdeath:(2411|2412|240E|240F):/
+138.0 "Almagest" sync /:Neo Exdeath:2417:/
+149.1 "Aero III" sync /:Neo Exdeath:2419:/
+158.9 "Earth Shaker" sync /:Neo Exdeath:241A:/
+164.4 "Vacuum Wave" sync /:Neo Exdeath:241D:/
+178.4 "Emptiness x8" sync /:Neo Exdeath:2420:/ duration 10
+186.4 "Light And Darkness" sync /:Neo Exdeath:241F:/
+192.4 "Flare" sync /:Neo Exdeath:2401:/
+192.4 "Holy" sync /:Neo Exdeath:2403:/
+192.4 "Flare" sync /:Neo Exdeath:2401:/
+197.4 "Flood Of Naught (lasers)" sync /:Neo Exdeath:(240E|240F):/
+211.4 "Meteor" sync /:Neo Exdeath:2424:/
+224.4 "Flood Of Naught (colors)" sync /:Neo Exdeath:(2411|2412):/
+237.4 "Charybdis" sync /:Neo Exdeath:2423:/
+244.9 "Double Attack" sync /:Neo Exdeath:241C:/
+260.4 "Almagest" sync /:Neo Exdeath:2417:/
+266.4 "Vacuum Wave" sync /:Neo Exdeath:241D:/
+272.4 "Aero III" sync /:Neo Exdeath:2419:/
+277.5 "Emptiness x8" sync /:Neo Exdeath:2420:/ duration 10
+
+286.5 "Grand Cross Alpha" sync /:Neo Exdeath:242B:/
+297.5 "Flood Of Naught (charge)" sync /:Neo Exdeath:2416:/
+305.5 "Flood Of Naught (colors)" sync /:Neo Exdeath:(2411|2412):/
+322.5 "Delta Attack" sync /:Neo Exdeath:241E:/
+323.0 "Blizzard III" sync /:Neo Exdeath:23F8:/
+323.2 "Thunder III" sync /:Neo Exdeath:23FA:/
+323.5 "Fire III" sync /:Neo Exdeath:23F6:/
+324.2 "Thunder III" sync /:Neo Exdeath:23FA:/
+326.0 "Blizzard III" sync /:Neo Exdeath:23F8:/
+326.5 "Fire III" sync /:Neo Exdeath:23F6:/
+330.5 "Flood Of Naught (colors/lasers)" sync /:Neo Exdeath:(2411|2412|240E|240F):/
+
+339.5 "Grand Cross Omega" sync /:Neo Exdeath:242D:/
+346.5 "The Final Battle" sync /:Neo Exdeath:242A:/
+354.6 "Flood Of Naught" sync /:Neo Exdeath:(2411|2412|240E|240F):/
+359.6 "Flood Of Naught" sync /:Neo Exdeath:(2411|2412|240E|240F):/
+365.6 "Flood Of Naught" sync /:Neo Exdeath:(2411|2412|240E|240F):/
+378.1 "Flood Of Naught (charge)" sync /:Neo Exdeath:2416:/
+389.1 "Almagest" sync /:Neo Exdeath:2417:/
+
+396.3 "Emptiness x8" sync /:Neo Exdeath:2420:/ duration 10
+404.4 "Flood Of Naught" sync /:Neo Exdeath:(2411|2412|240E|240F):/
+414.6 "Aero III" sync /:Neo Exdeath:2419:/
+
+428.6 "Grand Cross Delta" sync /:Neo Exdeath:242C:/
+441.6 "Flood Of Naught (colors/lasers)" sync /:Neo Exdeath:(2411|2412|240E|240F):/
+450.6 "Almagest" sync /:Neo Exdeath:2417:/
+461.6 "Aero III" sync /:Neo Exdeath:2419:/
+471.3 "Earth Shaker" sync /:Neo Exdeath:241A:/
+476.8 "Vacuum Wave" sync /:Neo Exdeath:241D:/
+490.8 "Emptiness x8" sync /:Neo Exdeath:2420:/ duration 10
+498.8 "Light And Darkness" sync /:Neo Exdeath:241F:/
+504.8 "Flare" sync /:Neo Exdeath:2401:/
+504.8 "Holy" sync /:Neo Exdeath:2403:/
+509.8 "Flood Of Naught (lasers)" sync /:Neo Exdeath:(240E|240F):/
+523.8 "Meteor" sync /:Neo Exdeath:2424:/
+536.8 "Flood Of Naught (colors)" sync /:Neo Exdeath:(2411|2412):/
+549.8 "Charybdis" sync /:Neo Exdeath:2423:/
+557.3 "Double Attack" sync /:Neo Exdeath:241C:/
+572.8 "Almagest" sync /:Neo Exdeath:2417:/
+578.8 "Vacuum Wave" sync /:Neo Exdeath:241D:/
+584.8 "Aero III" sync /:Neo Exdeath:2419:/
+589.9 "Emptiness x8" sync /:Neo Exdeath:2420:/ duration 10
+
+598.9 "Grand Cross Alpha" sync /:Neo Exdeath:242B:/
+609.9 "Flood Of Naught (charge)" sync /:Neo Exdeath:2416:/
+617.9 "Flood Of Naught (colors)" sync /:Neo Exdeath:(2411|2412):/
+634.9 "Delta Attack" sync /:Neo Exdeath:241E:/
+635.4 "Blizzard III" sync /:Neo Exdeath:23F8:/
+635.6 "Thunder III" sync /:Neo Exdeath:23FA:/
+635.9 "Fire III" sync /:Neo Exdeath:23F6:/
+636.6 "Thunder III" sync /:Neo Exdeath:23FA:/
+638.4 "Blizzard III" sync /:Neo Exdeath:23F8:/
+638.9 "Fire III" sync /:Neo Exdeath:23F6:/
+642.9 "Flood Of Naught" sync /:Neo Exdeath:(2411|2412|240E|240F):/
+
+652.1 "Neverwhere" sync /:Neo Exdeath:2426:/
+660.2 "Charybdis" sync /:Neo Exdeath:2423:/
+663.4 "Flying Frenzy" sync /:Neo Exdeath:2427:/
+664.4 "Frenzied Fist x9" # sync /:Neo Exdeath:2428:/
+671.2 "Frenzied Sphere" sync /:Neo Exdeath:2429:/
+673.2 "Flying Frenzy" sync /:Neo Exdeath:2427:/
+674.1 "Frenzied Fist x9" # sync /:Neo Exdeath:2428:/
+681.0 "Frenzied Sphere" sync /:Neo Exdeath:2429:/
+683.2 "Flying Frenzy" sync /:Neo Exdeath:2427:/
+684.1 "Frenzied Fist x9" # sync /:Neo Exdeath:2428:/
+691.0 "Frenzied Sphere" sync /:Neo Exdeath:2429:/
+693.2 "Flying Frenzy" sync /:Neo Exdeath:2427:/
+694.1 "Frenzied Fist x9" # sync /:Neo Exdeath:2428:/
+701.0 "Frenzied Sphere" sync /:Neo Exdeath:2429:/
+703.2 "Flying Frenzy" sync /:Neo Exdeath:2427:/
+704.1 "Frenzied Fist x9" # sync /:Neo Exdeath:2428:/
+711.0 "Frenzied Sphere" sync /:Neo Exdeath:2429:/
+713.2 "Flying Frenzy" sync /:Neo Exdeath:2427:/
+714.1 "Frenzied Fist x9" # sync /:Neo Exdeath:2428:/
+721.0 "Frenzied Sphere" sync /:Neo Exdeath:2429:/
+723.2 "Flying Frenzy" sync /:Neo Exdeath:2427:/
+724.1 "Frenzied Fist x9" # sync /:Neo Exdeath:2428:/
+731.0 "Frenzied Sphere" sync /:Neo Exdeath:2429:/
+733.2 "Flying Frenzy" sync /:Neo Exdeath:2427:/
+734.1 "Frenzied Fist x9" # sync /:Neo Exdeath:2428:/
+741.0 "Frenzied Sphere" sync /:Neo Exdeath:2429:/
+753.2 "Almagest" sync /:Neo Exdeath:2418:/

--- a/ui/raidboss/data/04-sb/raid/o4s.txt
+++ b/ui/raidboss/data/04-sb/raid/o4s.txt
@@ -5,7 +5,7 @@ hideall "--sync--"
 
 0.0 "--Reset--" sync / 21:........:40000010:/ window 10000 jump 0
 
-# -ii 23F2 23F8 2400 240C 2410 2413 2414 2415 241B 2421 2422 242F 2431 2432 244C 244D 245E 24DC
+# -ii 23F2 23F8 2400 240C
 
 # Exfaust
 3.8 "--sync--" sync /:Exdeath:23F2:/ window 3.8,0
@@ -75,6 +75,9 @@ hideall "--sync--"
 282.0 "--untargetable--"
 
 
+# -ii 2410 2413 2414 2415 241B 2421 2422 242F 2431 2432 244C 244D 245E 24DC
+# -p 242C:1116 242D:1339.5 2426:1652.1
+
 # Neo Exdeath
 1002.0 "--sync--" sync /:2417:Neo Exdeath/ window 1002,5
 1007.7 "Almagest" sync /:Neo Exdeath:2417:/ window 1008,5
@@ -111,6 +114,7 @@ hideall "--sync--"
 1192.8 "--targetable"
 1197.6 "Flood Of Naught (lasers)" sync /:Neo Exdeath:(240E|240F):/
 1211.6 "Meteor" sync /:Neo Exdeath:2424:/
+1212.3 "--adds targetable--"
 1224.7 "Flood Of Naught (colors)" sync /:Neo Exdeath:(2411|2412):/
 1237.4 "Charybdis" sync /:Neo Exdeath:2423:/
 1244.9 "Double Attack" sync /:Neo Exdeath:241C:/
@@ -161,6 +165,7 @@ hideall "--sync--"
 1505.2 "--targetable--"
 1509.8 "Flood Of Naught (lasers)" sync /:Neo Exdeath:(240E|240F):/
 1523.8 "Meteor" sync /:Neo Exdeath:2424:/
+1524.5 "--adds targetable--"
 1536.8 "Flood Of Naught (colors)" sync /:Neo Exdeath:(2411|2412):/
 1549.8 "Charybdis" sync /:Neo Exdeath:2423:/
 1557.3 "Double Attack" sync /:Neo Exdeath:241C:/

--- a/ui/raidboss/data/04-sb/raid/o4s.txt
+++ b/ui/raidboss/data/04-sb/raid/o4s.txt
@@ -8,20 +8,19 @@ hideall "--sync--"
 # -ii 23F2 23F8 2400 240C 2410 2413 2414 2415 241B 2421 2422 242F 2431 2432 244C 244D 245E 24DC
 
 # Exfaust
-0 "Start" sync /Engage!/ window 0,1
 3.8 "--sync--" sync /:Exdeath:23F2:/ window 3.8,0
 12.2 "Dualcast" sync /:Exdeath:23F4:/ window 12.2,5
 16.8 "--sync--" sync /:Exdeath:23F7:/
-17.3 "Blizzard III" sync /:Exdeath:23F8:/
-19.9 "Blizzard III" sync /:Exdeath:23F8:/
+17.3 "Blizzard III" # sync /:Exdeath:23F8:/
+19.9 "Blizzard III" # sync /:Exdeath:23F8:/
 24.8 "Dualcast" sync /:Exdeath:23F4:/
 30.8 "--sync--" sync /:Exdeath:23F9:/
-31.5 "Thunder III" sync /:Exdeath:23FA:/
-32.6 "Thunder III" sync /:Exdeath:23FA:/
+31.5 "Thunder III" # sync /:Exdeath:23FA:/
+32.6 "Thunder III" # sync /:Exdeath:23FA:/
 37.9 "Dualcast" sync /:Exdeath:23F4:/
 42.5 "--sync--" sync /:Exdeath:23F5:/
-43.1 "Fire III" sync /:Exdeath:23F6:/
-47.1 "Fire III" sync /:Exdeath:23F6:/
+43.1 "Fire III" # sync /:Exdeath:23F6:/
+47.1 "Fire III" # sync /:Exdeath:23F6:/
 53.6 "White Hole" sync /:Exdeath:23FF:/
 64.7 "The Decisive Battle" sync /:Exdeath:2408:/
 66.5 "--untargetable--"
@@ -33,20 +32,20 @@ hideall "--sync--"
 82.4 "Flare" sync /:Exdeath:2401:/
 
 85.2 "--targetable--"
-89.2 "Blizzard III/Fire III/Thunder III" sync /:Exdeath:23F[BCD]:/
+89.2 "Blizzard III/Fire III/Thunder III" sync /:Exdeath:23F[BCD]:/ window 10,10
 95.4 "Vacuum Wave" sync /:Exdeath:23FE:/
 105.6 "White Hole" sync /:Exdeath:23FF:/
 118.0 "Black Hole" sync /:Exdeath:2406:/
 123.1 "Dualcast" sync /:Exdeath:23F4:/
 127.7 "--sync--" sync /:Exdeath:23F5:/
-128.3 "Fire III" sync /:Exdeath:23F6:/
-132.2 "Fire III" sync /:Exdeath:23F6:/
+128.3 "Fire III" # sync /:Exdeath:23F6:/
+132.2 "Fire III" # sync /:Exdeath:23F6:/
 134.8 "Holy" sync /:Exdeath:240[23]:/
 144.0 "White Hole" sync /:Exdeath:23FF:/
 153.1 "Dualcast" sync /:Exdeath:23F4:/
 159.1 "--sync--" sync /:Exdeath:23F9:/
-159.8 "Thunder III" sync /:Exdeath:23FA:/
-160.9 "Thunder III" sync /:Exdeath:23FA:/
+159.8 "Thunder III" # sync /:Exdeath:23FA:/
+160.9 "Thunder III" # sync /:Exdeath:23FA:/
 166.1 "Meteor" sync /:Exdeath:2404:/
 179.4 "The Decisive Battle" sync /:Exdeath:2408:/
 181.5 "--untargetable--"
@@ -64,260 +63,150 @@ hideall "--sync--"
 232.8 "Black Hole" sync /:Exdeath:2406:/
 237.9 "Dualcast" sync /:Exdeath:23F4:/
 242.5 "--sync--" sync /:Exdeath:23F7:/
-243.0 "Blizzard III" sync /:Exdeath:23F8:/
-245.6 "Blizzard III" sync /:Exdeath:23F8:/
+243.0 "Blizzard III" # sync /:Exdeath:23F8:/
+245.6 "Blizzard III" # sync /:Exdeath:23F8:/
 249.6 "Flare" sync /:Exdeath:2401:/
 258.8 "White Hole" sync /:Exdeath:23FF:/
 267.9 "Dualcast" sync /:Exdeath:23F4:/
 274.0 "--sync--" sync /:Exdeath:23F9:/
-274.7 "Thunder III" sync /:Exdeath:23FA:/
-275.8 "Thunder III" sync /:Exdeath:23FA:/
+274.7 "Thunder III" # sync /:Exdeath:23FA:/
+275.8 "Thunder III" # sync /:Exdeath:23FA:/
 281.0 "Meteor" sync /:Exdeath:2404:/
 282.0 "--untargetable--"
 
-######################################################
-######Neo Phase 1
-507	"Almagest"	sync /:Neo Exdeath:2418:/ window 520,0	#AoE + 15s DoT
-516	"Aero III"  # Tank buster
-527	"Delta Attack"	#Blizzard III (Healers & DPS) + Fire III (DPS)
-530	"Delta Attack 2"	#Blizzard III (Healers & DPS) + Fire III (Tanks & Healers)
-543	"Grand Cross Alpha"	#AoE + Debuffs (Hysteria, White/Black Wound, 16s Allagan Field, 15s Acceleration Bomb)
-546	"--Untargetable--"
-549	"--Targetable--"
-555	"Charge"
-558	"--Acceleration Bomb Resolves--"
-559	"--Allagan Field Explodes--"
-563	"Flood of Naught"	#1 of 4 Flood of Naught variants
-569	"Double Attack Tethers"	#Double Attack Tether
-574	"Double Attack"	#Boss jumps to target, knockback target, jumps back
 
-######Neo Phase 2
-588	"Emptiness"	sync /:Neo Exdeath:2420:/ window 20	#Linearly propagating circle AoEs
-593	"Flood of Naught"	#1 of 4 Flood of Naught variants
-604	"Aero III"  # Tank buster
-619	"Grand Cross Delta"	#AOE + Debuffs (8s Forked Lightning x2, 7s Cursed Shriek x2, 8s Compressed Water x1, something else)
-626	"Cursed Shriek"	#Look away from Cursed Shriek players
-627	"Forked Lightning + Water"	#Lightning alone, stack on water
-631	"Flood of Naught"	#1 of 4 random variants
-640	"Almagest"	#AoE + 15s DoT
-652	"Aero III"  # Tank buster
-662	"Earth Shaker"	#On Tanks
-667	"Vacuum Wave"	#Vacuum Wave
-684	"Emptiness"	sync /:Neo Exdeath:2420:/ window 20	#Linearly propagating circle AoEs
-688	"Light and Darkness"	#Flare Markers Out (DPS, Healer, Tank) & Stack Inidicator (Healer)
-695	"Flare + Holy"
-701	"Flood of Naught"	#1 of 4 Flood of Naught variants
-716	"Meteors" duration 20
-729	"Flood of Naught"	#1 of 4 Flood of Naught variants
-742	"Charybdis"	#Everyone to low HP
-745	"Double Attack Tethers"	#Double Attack Tether
-750	"Double Attack"	#Boss jumps to target, knockback target, jumps back
-765	"Almagest"	#AoE + 15s DoT
-771	"Vacuum Wave"	#Vacuum Wave
-778	"Aero III"  # Tank buster
-785	"Emptiness"	sync /:Neo Exdeath:2420:/ window 20	#Linearly propagating circle AoEs
-793	"Grand Cross Alpha"	#AoE + Debuffs (Hysteria, White/Black Wound, 16s Allagan Field, 15s Acceleration Bomb)
-795	"--Untargetable--"
-798	"--Targetable--"
-804	"Charge"
-808	"--Acceleration Bomb Resolves--"
-809	"--Allagan Field Explodes--"
-812	"Flood of Naught"	#1 of 4 Flood of Naught variants
-829	"Delta Attack"	#Blizzard III (Healers & DPS) + Fire III (DPS)
-832	"Delta Attack 2"	#Blizzard III (Healers & DPS) + Fire III (Tanks & Healers)
-837	"Flood of Naught"	#1 of 4 Flood of Naught variants
+# Neo Exdeath
+1002.0 "--sync--" sync /:2417:Neo Exdeath/ window 1002,5
+1007.7 "Almagest" sync /:Neo Exdeath:2417:/ window 1008,5
+1016.7 "Aero III" sync /:Neo Exdeath:2419:/
+1026.7 "Delta Attack" sync /:Neo Exdeath:241E:/
+1027.2 "Blizzard III" # sync /:Neo Exdeath:23F8:/
+1027.4 "Thunder III" # sync /:Neo Exdeath:23FA:/
+1027.7 "Fire III" # sync /:Neo Exdeath:23F6:/
+1028.4 "Thunder III" # sync /:Neo Exdeath:23FA:/
+1030.2 "Blizzard III" # sync /:Neo Exdeath:23F8:/
+1030.7 "Fire III" # sync /:Neo Exdeath:23F6:/
 
-######Neo Phase 3
-847	"Grand Cross Omega"	#AoE + Debuffs (White/Black Wound, Hysteria, Forked Lightning, Cursed Shriek, Allagan Field, Acceleration Bomb, something else)
-854	"Final Battle"
-859	"Forked Lightning"
-861	"Flood of Naught"	#1 of 4 Flood of Naught variants
-866	"Flood of Naught"	#1 of 4 Flood of Naught variants
-873	"Flood of Naught"	#1 of 4 Flood of Naught variants
-876	"--Acceleration Bomb Resolves--"
-877	"Cursed Shriek"	#Look away from Cursed Shriek player
-885	"Charge"
-891	"--Allagan Field Explodes--"
-896	"Almagest"	#AoE + 15s DoT
+1042.7 "Grand Cross Alpha" sync /:Neo Exdeath:242B:/
+1045.8 "--untargetable--"
+1048.9 "--targetable--"
+1053.7 "Flood Of Naught (charge)" sync /:Neo Exdeath:2416:/
+1061.7 "Flood Of Naught (colors)" sync /:Neo Exdeath:(2411|2412):/
+1073.2 "Double Attack" sync /:Neo Exdeath:241C:/
+1083.8 "Emptiness x8" sync /:Neo Exdeath:2420:/ duration 10
+1091.8 "Flood Of Naught (lasers)" sync /:Neo Exdeath:(240E|240F):/
+1101.9 "Aero III" sync /:Neo Exdeath:2419:/
 
-######Neo Phase 4 (Loop of Neo P2)
-906	"Emptiness"	sync /:Neo Exdeath:2420:/ window 20	#Linearly propagating circle AoEs
-911	"Flood of Naught"	#1 of 4 Flood of Naught variants
-922	"Aero III"  # Tank buster
-937	"Grand Cross Delta"	#AOE + Debuffs (8s Forked Lightning x2, 7s Cursed Shriek x2, 8s Compressed Water x1, something else)
-944	"Cursed Shriek"	#Look away from Cursed Shriek players
-946	"Forked Lightning + Water"	#Lightning alone, stack on water
-949	"Flood of Naught"	#1 of 4 Flood of Naught variants
-958	"Almagest"	#AoE + 15s DoT
-970	"Aero III"  # Tank buster
-980	"Earth Shaker"	#On Tanks
-985	"Vacuum Wave"
-1002	"Emptiness"	sync /:Neo Exdeath:2420:/ window 20	#Linearly propagating circle AoEs
-1007	"Light and Darkness"	#Flare Markers Out (DPS, Healer, Tank) & Stack Inidicator (Healer)
-1013	"Flare + Holy"
-1019	"Flood of Naught"	#1 of 4 Flood of Naught variants
-1034	"Meteors" duration 20
-1047	"Flood of Naught"	#1 of 4 Flood of Naught variants
-1060	"Charybdis"	#Everyone to low HP
-1063	"Double Attack Tethers"	#Double Attack Tether
-1068	"Double Attack"	#Boss jumps to target, knockback target, jumps back
-1083	"Almagest"	#AoE + 15s DoT
-1089	"Vacuum Wave"
-1096	"Aero III"  # Tank buster
-1103	"Emptiness"	sync /:Neo Exdeath:2420:/ window 20	#Linearly propagating circle AoEs
-1111	"Grand Cross Alpha"	#AoE + Debuffs (Hysteria, White/Black Wound, 16s Allagan Field, 15s Acceleration Bomb)
-1113	"--Untargetable--"
-1116	"--Targetable--"
-1121	"Charge"
-1125	"--Acceleration Bomb Resolves--"
-1126	"--Allagan Field Explodes--"
-1129	"Flood of Naught"	#1 of 4 Flood of Naught variants
-1146	"Delta Attack"	#Blizzard III (Healers & DPS) + Fire III (DPS)
-1150	"Delta Attack 2"	#Blizzard III (Healers & DPS) + Fire III (Tanks & Healers)
-1155	"Flood of Naught"	#1 of 4 Flood of Naught variants
+1116.0 "Grand Cross Delta" sync /:Neo Exdeath:242C:/ window 116,10
+1129.0 "Flood Of Naught (colors/lasers)" sync /:Neo Exdeath:(2411|2412|240E|240F):/
+1138.0 "Almagest" sync /:Neo Exdeath:2417:/
+1149.1 "Aero III" sync /:Neo Exdeath:2419:/
+1158.9 "Earth Shaker" sync /:Neo Exdeath:241A:/
+1164.4 "Vacuum Wave" sync /:Neo Exdeath:241D:/
+1178.4 "Emptiness x8" sync /:Neo Exdeath:2420:/ duration 10
+1186.4 "Light And Darkness" sync /:Neo Exdeath:241F:/
+1189.5 "--untargetable--"
+1192.4 "Flare" sync /:Neo Exdeath:2401:/
+1192.4 "Holy" sync /:Neo Exdeath:2403:/
+1192.8 "--targetable"
+1197.6 "Flood Of Naught (lasers)" sync /:Neo Exdeath:(240E|240F):/
+1211.6 "Meteor" sync /:Neo Exdeath:2424:/
+1224.7 "Flood Of Naught (colors)" sync /:Neo Exdeath:(2411|2412):/
+1237.4 "Charybdis" sync /:Neo Exdeath:2423:/
+1244.9 "Double Attack" sync /:Neo Exdeath:241C:/
+1260.4 "Almagest" sync /:Neo Exdeath:2417:/
+1266.4 "Vacuum Wave" sync /:Neo Exdeath:241D:/
+1272.4 "Aero III" sync /:Neo Exdeath:2419:/
+1277.5 "Emptiness x8" sync /:Neo Exdeath:2420:/ duration 10
 
-######Neo Phase 5
-1164	"Neverwhere"	#Starts soft enrage
-1173	"Charybdis"	#Everyone to low HP
-1176	"Frenzied Fist x9"	#Small Raid AoEs
-1183	"Frenzied Sphere (1)"	#Big Raid AoE
-1186	"Frenzied Fist x9"	#Small Raid AoEs
-1193	"Frenzied Sphere (2)"	#Big Raid AoE
-1196	"Frenzied Fist x9"	#Small Raid AoEs
-1203	"Frenzied Sphere (3)"	#Big Raid AoE
-1206	"Frenzied Fist x9"	#Small Raid AoEs
-1213	"Frenzied Sphere (4)"	#Big Raid AoE
-1216	"Frenzied Fist x9"	#Small Raid AoEs
-1223	"Frenzied Sphere (5)"	#Big Raid AoE
-1226	"Frenzied Fist x9"	#Small Raid AoEs
-1233	"Frenzied Sphere (6)"	#Big Raid AoE
-1236	"Frenzied Fist x9"	#Small Raid AoEs
-1243	"Frenzied Sphere (7)"	#Big Raid AoE
-1246	"Frenzied Fist x9"	#Small Raid AoEs
-1253	"Frenzied Sphere (8)"	#Big Raid AoE
-1266	"Enrage"	#Long Almagest
+1286.5 "Grand Cross Alpha" sync /:Neo Exdeath:242B:/ window 170,10
+1289.6 "--untargetable--"
+1292.7 "--targetable--"
+1297.5 "Flood Of Naught (charge)" sync /:Neo Exdeath:2416:/
+1305.5 "Flood Of Naught (colors)" sync /:Neo Exdeath:(2411|2412):/
+1322.5 "Delta Attack" sync /:Neo Exdeath:241E:/
+1323.0 "Blizzard III" # sync /:Neo Exdeath:23F8:/
+1323.2 "Thunder III" # sync /:Neo Exdeath:23FA:/
+1323.5 "Fire III" # sync /:Neo Exdeath:23F6:/
+1324.2 "Thunder III" # sync /:Neo Exdeath:23FA:/
+1326.0 "Blizzard III" # sync /:Neo Exdeath:23F8:/
+1326.5 "Fire III" # sync /:Neo Exdeath:23F6:/
+1330.5 "Flood Of Naught (lasers)" sync /:Neo Exdeath:(240E|240F):/
 
+1339.5 "Grand Cross Omega" sync /:Neo Exdeath:242D:/ window 340,10
+1345.5 "--untargetable--"
+1346.5 "The Final Battle" sync /:Neo Exdeath:242A:/
+1354.6 "Flood Of Naught (colors/lasers)" sync /:Neo Exdeath:(2411|2412|240E|240F):/
+1359.6 "Flood Of Naught (colors/lasers)" sync /:Neo Exdeath:(2411|2412|240E|240F):/
+1365.6 "Flood Of Naught (lasers)" sync /:Neo Exdeath:(240E|240F):/
+1371.7 "--targetable--"
+1378.1 "Flood Of Naught (charge)" sync /:Neo Exdeath:2416:/
+1389.1 "Almagest" sync /:Neo Exdeath:2417:/
 
-0 "Start" sync /Engage!/ window 0,1
-7.7 "Almagest" sync /:Neo Exdeath:2417:/
-16.7 "Aero III" sync /:Neo Exdeath:2419:/
-26.7 "Delta Attack" sync /:Neo Exdeath:241E:/
-27.2 "Blizzard III" sync /:Neo Exdeath:23F8:/
-27.4 "Thunder III" sync /:Neo Exdeath:23FA:/
-27.7 "Fire III" sync /:Neo Exdeath:23F6:/
-28.4 "Thunder III" sync /:Neo Exdeath:23FA:/
-30.2 "Blizzard III" sync /:Neo Exdeath:23F8:/
-30.7 "Fire III" sync /:Neo Exdeath:23F6:/
+1396.3 "Emptiness x8" sync /:Neo Exdeath:2420:/ duration 10
+1404.4 "Flood Of Naught" sync /:Neo Exdeath:(2411|2412|240E|240F):/
+1414.6 "Aero III" sync /:Neo Exdeath:2419:/
 
-42.7 "Grand Cross Alpha" sync /:Neo Exdeath:242B:/
-53.7 "Flood Of Naught (charge)" sync /:Neo Exdeath:2416:/
-61.7 "Flood Of Naught (colors)" sync /:Neo Exdeath:(2411|2412):/
-73.2 "Double Attack" sync /:Neo Exdeath:241C:/
-83.8 "Emptiness x8" sync /:Neo Exdeath:2420:/ duration 10
-91.8 "Flood Of Naught (lasers)" sync /:Neo Exdeath:(240E|240F):/
-101.9 "Aero III" sync /:Neo Exdeath:2419:/
+1428.6 "Grand Cross Delta" sync /:Neo Exdeath:242C:/ window 90,10
+1441.6 "Flood Of Naught (colors/lasers)" sync /:Neo Exdeath:(2411|2412|240E|240F):/
+1450.6 "Almagest" sync /:Neo Exdeath:2417:/
+1461.6 "Aero III" sync /:Neo Exdeath:2419:/
+1471.3 "Earth Shaker" sync /:Neo Exdeath:241A:/
+1476.8 "Vacuum Wave" sync /:Neo Exdeath:241D:/
+1490.8 "Emptiness x8" sync /:Neo Exdeath:2420:/ duration 10
+1498.8 "Light And Darkness" sync /:Neo Exdeath:241F:/
+1501.9 "--untargetable--"
+1504.8 "Flare" sync /:Neo Exdeath:2401:/
+1504.8 "Holy" sync /:Neo Exdeath:2403:/
+1505.2 "--targetable--"
+1509.8 "Flood Of Naught (lasers)" sync /:Neo Exdeath:(240E|240F):/
+1523.8 "Meteor" sync /:Neo Exdeath:2424:/
+1536.8 "Flood Of Naught (colors)" sync /:Neo Exdeath:(2411|2412):/
+1549.8 "Charybdis" sync /:Neo Exdeath:2423:/
+1557.3 "Double Attack" sync /:Neo Exdeath:241C:/
+1572.8 "Almagest" sync /:Neo Exdeath:2417:/
+1578.8 "Vacuum Wave" sync /:Neo Exdeath:241D:/
+1584.8 "Aero III" sync /:Neo Exdeath:2419:/
+1589.9 "Emptiness x8" sync /:Neo Exdeath:2420:/ duration 10
 
-116.0 "Grand Cross Delta" sync /:Neo Exdeath:242C:/
-129.0 "Flood Of Naught (colors/lasers)" sync /:Neo Exdeath:(2411|2412|240E|240F):/
-138.0 "Almagest" sync /:Neo Exdeath:2417:/
-149.1 "Aero III" sync /:Neo Exdeath:2419:/
-158.9 "Earth Shaker" sync /:Neo Exdeath:241A:/
-164.4 "Vacuum Wave" sync /:Neo Exdeath:241D:/
-178.4 "Emptiness x8" sync /:Neo Exdeath:2420:/ duration 10
-186.4 "Light And Darkness" sync /:Neo Exdeath:241F:/
-192.4 "Flare" sync /:Neo Exdeath:2401:/
-192.4 "Holy" sync /:Neo Exdeath:2403:/
-192.4 "Flare" sync /:Neo Exdeath:2401:/
-197.4 "Flood Of Naught (lasers)" sync /:Neo Exdeath:(240E|240F):/
-211.4 "Meteor" sync /:Neo Exdeath:2424:/
-224.4 "Flood Of Naught (colors)" sync /:Neo Exdeath:(2411|2412):/
-237.4 "Charybdis" sync /:Neo Exdeath:2423:/
-244.9 "Double Attack" sync /:Neo Exdeath:241C:/
-260.4 "Almagest" sync /:Neo Exdeath:2417:/
-266.4 "Vacuum Wave" sync /:Neo Exdeath:241D:/
-272.4 "Aero III" sync /:Neo Exdeath:2419:/
-277.5 "Emptiness x8" sync /:Neo Exdeath:2420:/ duration 10
+1598.9 "Grand Cross Alpha" sync /:Neo Exdeath:242B:/ window 170,10
+1602.0 "--untargetable--"
+1605.3 "--targetable--"
+1609.9 "Flood Of Naught (charge)" sync /:Neo Exdeath:2416:/
+1617.9 "Flood Of Naught (colors)" sync /:Neo Exdeath:(2411|2412):/
+1634.9 "Delta Attack" sync /:Neo Exdeath:241E:/
+1635.4 "Blizzard III" # sync /:Neo Exdeath:23F8:/
+1635.6 "Thunder III" # sync /:Neo Exdeath:23FA:/
+1635.9 "Fire III" # sync /:Neo Exdeath:23F6:/
+1636.6 "Thunder III" # sync /:Neo Exdeath:23FA:/
+1638.4 "Blizzard III" # sync /:Neo Exdeath:23F8:/
+1638.9 "Fire III" # sync /:Neo Exdeath:23F6:/
+1642.9 "Flood Of Naught (lasers)" sync /:Neo Exdeath:(240E|240F):/
 
-286.5 "Grand Cross Alpha" sync /:Neo Exdeath:242B:/
-297.5 "Flood Of Naught (charge)" sync /:Neo Exdeath:2416:/
-305.5 "Flood Of Naught (colors)" sync /:Neo Exdeath:(2411|2412):/
-322.5 "Delta Attack" sync /:Neo Exdeath:241E:/
-323.0 "Blizzard III" sync /:Neo Exdeath:23F8:/
-323.2 "Thunder III" sync /:Neo Exdeath:23FA:/
-323.5 "Fire III" sync /:Neo Exdeath:23F6:/
-324.2 "Thunder III" sync /:Neo Exdeath:23FA:/
-326.0 "Blizzard III" sync /:Neo Exdeath:23F8:/
-326.5 "Fire III" sync /:Neo Exdeath:23F6:/
-330.5 "Flood Of Naught (colors/lasers)" sync /:Neo Exdeath:(2411|2412|240E|240F):/
-
-339.5 "Grand Cross Omega" sync /:Neo Exdeath:242D:/
-346.5 "The Final Battle" sync /:Neo Exdeath:242A:/
-354.6 "Flood Of Naught" sync /:Neo Exdeath:(2411|2412|240E|240F):/
-359.6 "Flood Of Naught" sync /:Neo Exdeath:(2411|2412|240E|240F):/
-365.6 "Flood Of Naught" sync /:Neo Exdeath:(2411|2412|240E|240F):/
-378.1 "Flood Of Naught (charge)" sync /:Neo Exdeath:2416:/
-389.1 "Almagest" sync /:Neo Exdeath:2417:/
-
-396.3 "Emptiness x8" sync /:Neo Exdeath:2420:/ duration 10
-404.4 "Flood Of Naught" sync /:Neo Exdeath:(2411|2412|240E|240F):/
-414.6 "Aero III" sync /:Neo Exdeath:2419:/
-
-428.6 "Grand Cross Delta" sync /:Neo Exdeath:242C:/
-441.6 "Flood Of Naught (colors/lasers)" sync /:Neo Exdeath:(2411|2412|240E|240F):/
-450.6 "Almagest" sync /:Neo Exdeath:2417:/
-461.6 "Aero III" sync /:Neo Exdeath:2419:/
-471.3 "Earth Shaker" sync /:Neo Exdeath:241A:/
-476.8 "Vacuum Wave" sync /:Neo Exdeath:241D:/
-490.8 "Emptiness x8" sync /:Neo Exdeath:2420:/ duration 10
-498.8 "Light And Darkness" sync /:Neo Exdeath:241F:/
-504.8 "Flare" sync /:Neo Exdeath:2401:/
-504.8 "Holy" sync /:Neo Exdeath:2403:/
-509.8 "Flood Of Naught (lasers)" sync /:Neo Exdeath:(240E|240F):/
-523.8 "Meteor" sync /:Neo Exdeath:2424:/
-536.8 "Flood Of Naught (colors)" sync /:Neo Exdeath:(2411|2412):/
-549.8 "Charybdis" sync /:Neo Exdeath:2423:/
-557.3 "Double Attack" sync /:Neo Exdeath:241C:/
-572.8 "Almagest" sync /:Neo Exdeath:2417:/
-578.8 "Vacuum Wave" sync /:Neo Exdeath:241D:/
-584.8 "Aero III" sync /:Neo Exdeath:2419:/
-589.9 "Emptiness x8" sync /:Neo Exdeath:2420:/ duration 10
-
-598.9 "Grand Cross Alpha" sync /:Neo Exdeath:242B:/
-609.9 "Flood Of Naught (charge)" sync /:Neo Exdeath:2416:/
-617.9 "Flood Of Naught (colors)" sync /:Neo Exdeath:(2411|2412):/
-634.9 "Delta Attack" sync /:Neo Exdeath:241E:/
-635.4 "Blizzard III" sync /:Neo Exdeath:23F8:/
-635.6 "Thunder III" sync /:Neo Exdeath:23FA:/
-635.9 "Fire III" sync /:Neo Exdeath:23F6:/
-636.6 "Thunder III" sync /:Neo Exdeath:23FA:/
-638.4 "Blizzard III" sync /:Neo Exdeath:23F8:/
-638.9 "Fire III" sync /:Neo Exdeath:23F6:/
-642.9 "Flood Of Naught" sync /:Neo Exdeath:(2411|2412|240E|240F):/
-
-652.1 "Neverwhere" sync /:Neo Exdeath:2426:/
-660.2 "Charybdis" sync /:Neo Exdeath:2423:/
-663.4 "Flying Frenzy" sync /:Neo Exdeath:2427:/
-664.4 "Frenzied Fist x9" # sync /:Neo Exdeath:2428:/
-671.2 "Frenzied Sphere" sync /:Neo Exdeath:2429:/
-673.2 "Flying Frenzy" sync /:Neo Exdeath:2427:/
-674.1 "Frenzied Fist x9" # sync /:Neo Exdeath:2428:/
-681.0 "Frenzied Sphere" sync /:Neo Exdeath:2429:/
-683.2 "Flying Frenzy" sync /:Neo Exdeath:2427:/
-684.1 "Frenzied Fist x9" # sync /:Neo Exdeath:2428:/
-691.0 "Frenzied Sphere" sync /:Neo Exdeath:2429:/
-693.2 "Flying Frenzy" sync /:Neo Exdeath:2427:/
-694.1 "Frenzied Fist x9" # sync /:Neo Exdeath:2428:/
-701.0 "Frenzied Sphere" sync /:Neo Exdeath:2429:/
-703.2 "Flying Frenzy" sync /:Neo Exdeath:2427:/
-704.1 "Frenzied Fist x9" # sync /:Neo Exdeath:2428:/
-711.0 "Frenzied Sphere" sync /:Neo Exdeath:2429:/
-713.2 "Flying Frenzy" sync /:Neo Exdeath:2427:/
-714.1 "Frenzied Fist x9" # sync /:Neo Exdeath:2428:/
-721.0 "Frenzied Sphere" sync /:Neo Exdeath:2429:/
-723.2 "Flying Frenzy" sync /:Neo Exdeath:2427:/
-724.1 "Frenzied Fist x9" # sync /:Neo Exdeath:2428:/
-731.0 "Frenzied Sphere" sync /:Neo Exdeath:2429:/
-733.2 "Flying Frenzy" sync /:Neo Exdeath:2427:/
-734.1 "Frenzied Fist x9" # sync /:Neo Exdeath:2428:/
-741.0 "Frenzied Sphere" sync /:Neo Exdeath:2429:/
-753.2 "Almagest" sync /:Neo Exdeath:2418:/
+1652.1 "Neverwhere" sync /:Neo Exdeath:2426:/ window 652.1,10
+1660.2 "Charybdis" sync /:Neo Exdeath:2423:/
+1663.4 "Flying Frenzy" sync /:Neo Exdeath:2427:/
+1664.4 "Frenzied Fist x9" # sync /:Neo Exdeath:2428:/
+1671.2 "Frenzied Sphere 1" sync /:Neo Exdeath:2429:/
+1673.2 "Flying Frenzy" sync /:Neo Exdeath:2427:/
+1674.1 "Frenzied Fist x9" # sync /:Neo Exdeath:2428:/
+1681.0 "Frenzied Sphere 2" sync /:Neo Exdeath:2429:/
+1683.2 "Flying Frenzy" sync /:Neo Exdeath:2427:/
+1684.1 "Frenzied Fist x9" # sync /:Neo Exdeath:2428:/
+1691.0 "Frenzied Sphere 3" sync /:Neo Exdeath:2429:/
+1693.2 "Flying Frenzy" sync /:Neo Exdeath:2427:/
+1694.1 "Frenzied Fist x9" # sync /:Neo Exdeath:2428:/
+1701.0 "Frenzied Sphere 4" sync /:Neo Exdeath:2429:/
+1703.2 "Flying Frenzy" sync /:Neo Exdeath:2427:/
+1704.1 "Frenzied Fist x9" # sync /:Neo Exdeath:2428:/
+1711.0 "Frenzied Sphere 5" sync /:Neo Exdeath:2429:/
+1713.2 "Flying Frenzy" sync /:Neo Exdeath:2427:/
+1714.1 "Frenzied Fist x9" # sync /:Neo Exdeath:2428:/
+1721.0 "Frenzied Sphere 6" sync /:Neo Exdeath:2429:/
+1723.2 "Flying Frenzy" sync /:Neo Exdeath:2427:/
+1724.1 "Frenzied Fist x9" # sync /:Neo Exdeath:2428:/
+1731.0 "Frenzied Sphere 7" sync /:Neo Exdeath:2429:/
+1733.2 "Flying Frenzy" sync /:Neo Exdeath:2427:/
+1734.1 "Frenzied Fist x9" # sync /:Neo Exdeath:2428:/
+1741.0 "Frenzied Sphere 8" sync /:Neo Exdeath:2429:/
+1753.2 "Almagest (enrage)" sync /:Neo Exdeath:2418:/


### PR DESCRIPTION
In light of BLU updates, quisquous and I thought it would be best to modernize the outstanding Deltascape timelines. Many thanks to Shasta for the initial Very Definitely Good Enough timeline that's only now being replaced.

This timeline is unfortunately not as accurate as I should like. There are a lot of places where timing is off by 0.05-0.15 seconds. This currently is rather difficult to fix because I don't have any logs more recent than mid-2019. (I'd rather not hunt-and-peck replace individual times without having modern logs to compare against.) I think we can let this ride for a week or so and then make adjustments as necessary.

Neither part of the encounter uses an `Engage!` sync, since in two-part encounters that's ambiguous. Fortunately, even though Neo doesn't have autos, the `startsCasting` line for Almagest is just about at the same place as an auto *would* be, so we lose nothing here.

We'll very likely have to make some adjustments to triggers to accommodate BLU, but it's probably best to hold on that until we see patch notes.