### PR TITLE
fix minor CN translation in TEA raidboss

### DIFF
--- a/ui/raidboss/data/05-shb/ultimate/the_epic_of_alexander.js
+++ b/ui/raidboss/data/05-shb/ultimate/the_epic_of_alexander.js
@@ -1640,7 +1640,7 @@ export default {
           de: 'Köder Sprung mit Cooldowns',
           fr: 'Attirez le Saut avec des Cooldowns',
           ja: 'スパジャン誘導',
-          cn: '引导冷却跳跃',
+          cn: '减伤引导跳跃',
           ko: '슈퍼 점프 유도',
         },
       },


### PR DESCRIPTION
冷却 is ambiguous here saying the jump is "cold". I think the trigger intended to let tank bait jump with some mitigation.