### PR TITLE
Raidboss: Targetable timings O8N and E6N

### DIFF
--- a/ui/raidboss/data/04-sb/raid/o8n.txt
+++ b/ui/raidboss/data/04-sb/raid/o8n.txt
@@ -80,5 +80,5 @@ hideall "--sync--"
 425 "Thrumming Thunder"
 431 "Timely Teleport"
 431 "--untargetable--"
-434 "--utargetable--"
+434 "--targetable--"
 434 "Aero/Ruin" duration 3

--- a/ui/raidboss/data/04-sb/raid/o8n.txt
+++ b/ui/raidboss/data/04-sb/raid/o8n.txt
@@ -21,6 +21,8 @@ hideall "--sync--"
 129 "Flagrant Fire" sync /:Kefka:2920:/
 131 "Blizzard Blitz" sync /:Kefka:291(4|6|8|9):/
 137 "Timely Teleport" sync /:Kefka:2922:/
+137 "--untargetable--"
+140 "--targetable--"
 140 "Aero/Ruin" duration 3
 148 "Aero Assault" sync /:Kefka:2924:/
 
@@ -40,7 +42,9 @@ hideall "--sync--"
 240 "Flagrant Fire" sync /:Kefka:291F:/
 242 "Thrumming Thunder" sync /:Kefka:291(B|D):/
 248 "Timely Teleport" sync /:Kefka:2922:/
-254 "Aero/Ruin" duration 3
+248 "--untargetable--"
+251 "--targetable--"
+251 "Aero/Ruin" duration 3
 
 268 "Graven Image" sync /:Kefka:2925:/
 274 "Half Arena" sync /:Graven Image:292(9|A):/
@@ -58,6 +62,8 @@ hideall "--sync--"
 341 "Statue Gaze" sync /:Graven Image:292(B|C):/
 342 "Thrumming Thunder" sync /:Kefka:291(B|D):/
 348 "Timely Teleport" sync /:Kefka:2922:/
+348 "--untargetable--"
+351 "--targetable--"
 351 "Aero/Ruin" duration 3
 366 "Hyperdrive" sync /:Kefka:292E:/
 
@@ -73,4 +79,6 @@ hideall "--sync--"
 424 "Statue Gaze"
 425 "Thrumming Thunder"
 431 "Timely Teleport"
+431 "--untargetable--"
+434 "--utargetable--"
 434 "Aero/Ruin" duration 3

--- a/ui/raidboss/data/05-shb/raid/e6n.txt
+++ b/ui/raidboss/data/05-shb/raid/e6n.txt
@@ -13,7 +13,7 @@ hideall "--sync--"
 
 # Garuda solo
 2.0 "--sync--" sync /:Garuda:366:/ window 3,1
-13.5 "Ferostorm"# sync /:Garuda:4BD[DEF]:/
+13.5 "Ferostorm" # sync /:Garuda:4BD[DEF]:/
 20.6 "Superstorm" sync /:Garuda:4BD7:/ window 20,30
 31.4 "Air Bump" sync /:Garuda:4BD1:/
 36.8 "Thorns" sync /:Garuda:4BDA:/
@@ -25,11 +25,11 @@ hideall "--sync--"
 81.7 "Vacuum Slice" sync /:Garuda:4BD5:/
 88.8 "Occluded Front" sync /:Garuda:4BD2:/ window 30,30
 98.3 "Irresistible Pull" sync /:Garuda:4BD6:/
-111.5 "--untargetable--"
+111.0 "--untargetable--"
 
 # Ifrit solo
-114.0 "--targetable--"
-114.0 "Touchdown" sync /:Ifrit:4BE8:/ window 30,30
+114.1 "Touchdown" sync /:Ifrit:4BE8:/ window 30,30
+115.5 "--targetable--"
 129.2 "Hands Of Flame" sync /:Ifrit:4CFE:/
 143.6 "Hands Of Hell" sync /:Ifrit:4CFF:/
 152.3 "Instant Incineration" sync /:Ifrit:4BED:/ window 30,30
@@ -37,11 +37,11 @@ hideall "--sync--"
 166.1 "Strike Spark" sync /:Ifrit:4BD3:/
 177.5 "Hot Foot" sync /:Ifrit:4BEF:/
 188.2 "Inferno Howl" sync /:Ifrit:4BF1:/ window 30,30
-196.5 "--untargetable--"
+196.3 "--untargetable--"
 
 
 # Garuda and Ifrit
-200.8 "--targetable--"
+200.6 "--targetable--"
 207.2 "Vacuum Slice" sync /:Garuda:4BD5:/ window 30,30
 209.9 "Eruption" sync /:Ifrit:4BF3:/
 209.9 "Eruption" sync /:Ifrit:4BF4:/
@@ -52,22 +52,24 @@ hideall "--sync--"
 228.0 "Air Bump" sync /:Garuda:4BD1:/
 233.3 "Thorns" sync /:Garuda:4BDA:/
 237.9 "Hands Of Hell" sync /:Ifrit:4CFF:/
-245.5 "Ferostorm"# sync /:Garuda:4BD[DEF]:/
+245.5 "Ferostorm" # sync /:Garuda:4BD[DEF]:/
 250.2 "--untargetable--"
 
 
 # Raktapaksa initial block
 267.9 "Firestorm" sync /:Raktapaksa:4BD8:/ window 30,30
-271.2 "--targetable--"
+272.1 "--targetable--"
 283.2 "Radiant Plume" sync /:Raktapaksa:4BF2:/
-286.2 "Ferostorm"# sync /:Raktapaksa:4BE[345]:/
+286.2 "Ferostorm" # sync /:Raktapaksa:4BE[345]:/
 297.3 "Hands Of Flame" sync /:Raktapaksa:4CFE:/ window 30,30
 301.1 "Heat Burst" sync /:Raktapaksa:4C1E:/
 311.2 "Eruption" sync /:Raktapaksa:4BF4:/
 312.6 "Thorns" sync /:Raktapaksa:4BDA:/
 313.7 "Hands Of Hell" sync /:Raktapaksa:4CFF:/
 317.6 "Heat Burst" sync /:Raktapaksa:4C1E:/
+325.2 "--untargetable--"
 325.2 "Downburst" sync /:Raktapaksa:4BDC:/ window 30,30
+329.5 "--targetable--"
 336.6 "Radiant Plume" sync /:Raktapaksa:4BF2:/
 341.6 "Eruption" sync /:Raktapaksa:4BF4:/
 348.1 "Radiant Plume" sync /:Raktapaksa:4BF2:/
@@ -75,7 +77,7 @@ hideall "--sync--"
 360.4 "Conflag Strike" sync /:Raktapaksa:4BEE:/ window 30,30
 
 # Raktapaksa rotation block
-375.6 "Ferostorm"# sync /:Raktapaksa:4BE[345]:/
+375.6 "Ferostorm" # sync /:Raktapaksa:4BE[345]:/
 377.6 "Air Bump" sync /:Raktapaksa:4BD4:/
 382.5 "Thorns" sync /:Raktapaksa:4BDA:/ window 30,30
 390.7 "Storm Of Fury" sync /:Raktapaksa:4BE6:/
@@ -88,7 +90,7 @@ hideall "--sync--"
 433.4 "Radiant Plume" sync /:Raktapaksa:4BF2:/
 439.4 "Inferno Howl" sync /:Raktapaksa:4BF1:/ window 30,30
 
-454.6 "Ferostorm"# sync /:Raktapaksa:4BE[345]:/
+454.6 "Ferostorm" # sync /:Raktapaksa:4BE[345]:/
 456.6 "Air Bump" sync /:Raktapaksa:4BD4:/
 461.5 "Thorns" sync /:Raktapaksa:4BDA:/ window 30,30
 469.7 "Storm Of Fury" sync /:Raktapaksa:4BE6:/


### PR DESCRIPTION
I have been annoyed with my bad timings on the E6N timeline for ages but never annoyed enough to remember to fix it. (It was from before we had a helpful flag to auto-generate these timings, but I still should have done better at the time.) As long as I was doing this, I figured I would also drop in timings for Kefka normal, since I ran that after. I left Kefka as separate commits since that's an older timeline. I don't plan to regenerate it right now, but I might look into it at some point in the future. If it's better to just do all that at once later, I can revert the Kefka changes.