### PR TITLE
Eureka: Update Bozja opcodes for v5.45hotfix

### DIFF
--- a/plugin/CactbotEventSource/FateWatcher.cs
+++ b/plugin/CactbotEventSource/FateWatcher.cs
@@ -61,9 +61,9 @@ namespace Cactbot {
       0x144
     );
 
-    private static readonly CEDirectorOPCodes cedirector_v5_45 = new CEDirectorOPCodes(
+    private static readonly CEDirectorOPCodes cedirector_v5_45hotfix = new CEDirectorOPCodes(
       0x30,
-      0x3e1
+      0x1f5
     );
 
     private struct ActorControl143{
@@ -133,7 +133,7 @@ namespace Cactbot {
       ac143opcodes.Add("intl", ac143_v5_2);
 
       cedirectoropcodes = new Dictionary<string, CEDirectorOPCodes>();
-      cedirectoropcodes.Add("intl", cedirector_v5_45);
+      cedirectoropcodes.Add("intl", cedirector_v5_45hotfix);
 
       cedirectoropcodes.Add("cn", cedirector_v5_35_cn);
       fates = new Dictionary<int, int>();

--- a/plugin/CactbotEventSource/FateWatcher.cs
+++ b/plugin/CactbotEventSource/FateWatcher.cs
@@ -41,35 +41,24 @@ namespace Cactbot {
       public int size;
       public int opcode;
     }
+    //
+    // CE Opcode History
+    // Global
+    // v5.35            0x299
+    // v5.35h           0x143
+    // v5.40            0x3c1
+    // v5.40h           0x31b
+    // v5.41            0x31B
+    // v5.45            0x3e1
+    // v5.45h           0x1f5
+    //
+    // CN
+    // v5.35            0x144
+    //
 
-    private static readonly CEDirectorOPCodes cedirector_v5_35 = new CEDirectorOPCodes(
-      0x30,
-      0x299
-    );
-    
     private static readonly CEDirectorOPCodes cedirector_v5_35_cn = new CEDirectorOPCodes(
       0x30,
       0x144
-    );
-
-    private static readonly CEDirectorOPCodes cedirector_v5_35_hotfix = new CEDirectorOPCodes(
-      0x30,
-      0x143
-    );
-
-    private static readonly CEDirectorOPCodes cedirector_v5_40 = new CEDirectorOPCodes(
-      0x30,
-      0x3c1
-    );
-
-    private static readonly CEDirectorOPCodes cedirector_v5_40_hotfix = new CEDirectorOPCodes(
-      0x30,
-      0x31B
-    );
-
-    private static readonly CEDirectorOPCodes cedirector_v5_41 = new CEDirectorOPCodes(
-      0x30,
-      0x118
     );
 
     private static readonly CEDirectorOPCodes cedirector_v5_45 = new CEDirectorOPCodes(

--- a/plugin/CactbotEventSource/FateWatcher.cs
+++ b/plugin/CactbotEventSource/FateWatcher.cs
@@ -43,7 +43,7 @@ namespace Cactbot {
     }
     //
     // CE Opcode History
-    // Global
+    // Intl
     // v5.35            0x299
     // v5.35h           0x143
     // v5.40            0x3c1
@@ -56,12 +56,12 @@ namespace Cactbot {
     // v5.35            0x144
     //
 
-    private static readonly CEDirectorOPCodes cedirector_v5_35_cn = new CEDirectorOPCodes(
+    private static readonly CEDirectorOPCodes cedirector_cn = new CEDirectorOPCodes(
       0x30,
       0x144
     );
 
-    private static readonly CEDirectorOPCodes cedirector_v5_45hotfix = new CEDirectorOPCodes(
+    private static readonly CEDirectorOPCodes cedirector_intl = new CEDirectorOPCodes(
       0x30,
       0x1f5
     );
@@ -133,9 +133,9 @@ namespace Cactbot {
       ac143opcodes.Add("intl", ac143_v5_2);
 
       cedirectoropcodes = new Dictionary<string, CEDirectorOPCodes>();
-      cedirectoropcodes.Add("intl", cedirector_v5_45hotfix);
+      cedirectoropcodes.Add("cn", cedirector_cn);
+      cedirectoropcodes.Add("intl", cedirector_intl);
 
-      cedirectoropcodes.Add("cn", cedirector_v5_35_cn);
       fates = new Dictionary<int, int>();
       ces = new Dictionary<int, CEDirectorData>();
 


### PR DESCRIPTION
I've also removed the old opcodes from the active code. I had hoped they would be useful for the other regions but it doesn't look like that is going to be the case. I've left a comment with the previous opcodes for reference.

This also fixes #2482 