### PR TITLE
raidboss: fix overriding triggers with disabled in them

### DIFF
--- a/ui/raidboss/popup-text.js
+++ b/ui/raidboss/popup-text.js
@@ -417,10 +417,7 @@ export class PopupText {
       }
       // Adjust triggers for the parser language.
       if (set.triggers && this.options.AlertsEnabled) {
-        // Filter out disabled triggers
-        const enabledTriggers = set.triggers.filter((trigger) => !('disabled' in trigger && trigger.disabled));
-
-        for (const trigger of enabledTriggers) {
+        for (const trigger of set.triggers) {
           // Add an additional resolved regex here to save
           // time later.  This will clobber each time we
           // load this, but that's ok.
@@ -491,9 +488,10 @@ export class PopupText {
         this.resetWhenOutOfCombat &= set.resetWhenOutOfCombat;
     }
 
-    // Store all the collected triggers in order.
-    this.triggers = orderedTriggers.asList();
-    this.netTriggers = orderedNetTriggers.asList();
+    // Store all the collected triggers in order, and filter out disabled triggers.
+    const filterEnabled = (trigger) => !('disabled' in trigger && trigger.disabled);
+    this.triggers = orderedTriggers.asList().filter(filterEnabled);
+    this.netTriggers = orderedNetTriggers.asList().filter(filterEnabled);
 
     this.timelineLoader.SetTimelines(
         timelineFiles,


### PR DESCRIPTION
`disabled` now only applies on the final override.

Mentioned in #2503.