### PR TITLE
updating Chinese traslations

### DIFF
--- a/ui/raidboss/data/04-sb/ultimate/unending_coil_ultimate.js
+++ b/ui/raidboss/data/04-sb/ultimate/unending_coil_ultimate.js
@@ -172,7 +172,7 @@ export default {
           de: 'Wirbelstürme',
           fr: 'Tornades',
           ja: '大竜巻',
-          cn: '大龙卷',
+          cn: '旋风',
           ko: '회오리',
         },
       },
@@ -1383,7 +1383,7 @@ export default {
           de: 'Geh in entfernten Turm',
           fr: 'Aller dans une tour lointaine',
           ja: '遠いタワー',
-          cn: '踩远塔',
+          cn: '踩远处的塔',
           ko: '기둥 밟기',
         },
         towerTTS: {
@@ -1479,7 +1479,7 @@ export default {
           de: 'Kein Erdstoß; im süden sammeln',
           fr: 'Pas de Secousse; se rassembler au Sud.',
           ja: 'シェイカーない；頭割りで南',
-          cn: '不地震，南侧集合',
+          cn: '无点名，南侧集合',
           ko: '징 없음, 모여서 쉐어',
         },
         tenstrikeNotOnYou: {


### PR DESCRIPTION
大龙卷 -> 旋风：CN server changed translation to '旋风' for Twister.
踩远塔 -> 踩远处的塔：for a more appropriate expression.
不地震 -> 无点名：The official translation for 'Earth Shaker' is '大地摇动', '不地震' is literally 'No shake',  '无点名' means 'No marker(on you)', which is more appropriate imho.