### PR TITLE
raidboss: fix e10s clone callouts

### DIFF
--- a/ui/raidboss/data/05-shb/raid/e10s.js
+++ b/ui/raidboss/data/05-shb/raid/e10s.js
@@ -373,7 +373,7 @@ export default {
       condition: (data) => data.clones,
       run: (data, matches) => {
         data.myClone = data.myClone || [];
-        const clonesJob = parseInt(matches.job, 16).toString();
+        const clonesJob = parseInt(matches.job, 16);
         if (clonesJob === Util.jobToJobEnum(data.job))
           data.myClone.push(matches.id.toUpperCase());
       },


### PR DESCRIPTION
The conversion of resources/util in f46d96 changed the output
type of Util.jobToJobEnum from string to number.  This caused
the === check in the `E10S Shadow Of A Hero` trigger to fail.

This is untested, but seems quite likely.

Fixes #2530 (probably).