### PR TITLE
Refactor: generic regex/netregex helper function improve

### DIFF
--- a/resources/conditions.ts
+++ b/resources/conditions.ts
@@ -32,10 +32,10 @@ type TargetableMatches = Matches<Regex<
 
 export default {
   targetIsYou(): (data: Data, matches: TargetableMatches) => boolean {
-    return (data: Data, matches: TargetableMatches) => data.me === matches?.target;
+    return (data: Data, matches: TargetableMatches) => data.me === matches.target;
   },
   targetIsNotYou(): (data: Data, matches: TargetableMatches) => boolean {
-    return (data: Data, matches: TargetableMatches) => data.me !== matches?.target;
+    return (data: Data, matches: TargetableMatches) => data.me !== matches.target;
   },
   caresAboutAOE(): (data: Data) => boolean {
     return (data: Data) => data.role === 'tank' || data.role === 'healer' || data.CanAddle() || data.job === 'BLU';

--- a/resources/conditions.ts
+++ b/resources/conditions.ts
@@ -5,12 +5,37 @@
 import { Data } from '../types/data';
 import { Matches } from '../types/trigger';
 
+import {
+  StartsUsingParams,
+  AbilityParams,
+  AbilityFullParams,
+  HeadMarkerParams,
+  GainsEffectParams,
+  StatusEffectExplicitParams,
+  LosesEffectParams,
+  TetherParams,
+  WasDefeatedParams,
+  Return,
+} from '../resources/regexes';
+
+type TargetableMatches = Matches<Return<
+  StartsUsingParams |
+  AbilityParams |
+  AbilityFullParams |
+  HeadMarkerParams |
+  GainsEffectParams |
+  StatusEffectExplicitParams |
+  LosesEffectParams |
+  TetherParams |
+  WasDefeatedParams
+>>;
+
 export default {
-  targetIsYou(): (data: Data, matches: Matches<unknown>) => boolean {
-    return (data: Data, matches: Matches<unknown>) => data.me === matches.target;
+  targetIsYou(): (data: Data, matches: TargetableMatches) => boolean {
+    return (data: Data, matches: TargetableMatches) => data.me === matches?.target;
   },
-  targetIsNotYou(): (data: Data, matches: Matches<unknown>) => boolean {
-    return (data: Data, matches: Matches<unknown>) => data.me !== matches.target;
+  targetIsNotYou(): (data: Data, matches: TargetableMatches) => boolean {
+    return (data: Data, matches: TargetableMatches) => data.me !== matches?.target;
   },
   caresAboutAOE(): (data: Data) => boolean {
     return (data: Data) => data.role === 'tank' || data.role === 'healer' || data.CanAddle() || data.job === 'BLU';

--- a/resources/conditions.ts
+++ b/resources/conditions.ts
@@ -6,11 +6,11 @@ import { Data } from '../types/data';
 import { Matches } from '../types/trigger';
 
 export default {
-  targetIsYou(): (data: Data, matches: Matches) => boolean {
-    return (data: Data, matches: Matches) => data.me === matches.target;
+  targetIsYou(): (data: Data, matches: Matches<unknown>) => boolean {
+    return (data: Data, matches: Matches<unknown>) => data.me === matches.target;
   },
-  targetIsNotYou(): (data: Data, matches: Matches) => boolean {
-    return (data: Data, matches: Matches) => data.me !== matches.target;
+  targetIsNotYou(): (data: Data, matches: Matches<unknown>) => boolean {
+    return (data: Data, matches: Matches<unknown>) => data.me !== matches.target;
   },
   caresAboutAOE(): (data: Data) => boolean {
     return (data: Data) => data.role === 'tank' || data.role === 'healer' || data.CanAddle() || data.job === 'BLU';

--- a/resources/conditions.ts
+++ b/resources/conditions.ts
@@ -15,10 +15,10 @@ import {
   LosesEffectParams,
   TetherParams,
   WasDefeatedParams,
-  Return,
+  Regex,
 } from '../resources/regexes';
 
-type TargetableMatches = Matches<Return<
+type TargetableMatches = Matches<Regex<
   StartsUsingParams |
   AbilityParams |
   AbilityFullParams |

--- a/resources/conditions.ts
+++ b/resources/conditions.ts
@@ -32,10 +32,10 @@ type TargetableMatches = Matches<Regex<
 
 export default {
   targetIsYou(): (data: Data, matches: TargetableMatches) => boolean {
-    return (data: Data, matches: TargetableMatches) => data.me === matches.target;
+    return (data: Data, matches: TargetableMatches) => data.me === matches?.target;
   },
   targetIsNotYou(): (data: Data, matches: TargetableMatches) => boolean {
-    return (data: Data, matches: TargetableMatches) => data.me !== matches.target;
+    return (data: Data, matches: TargetableMatches) => data.me !== matches?.target;
   },
   caresAboutAOE(): (data: Data) => boolean {
     return (data: Data) => data.role === 'tank' || data.role === 'healer' || data.CanAddle() || data.job === 'BLU';

--- a/resources/netregexes.ts
+++ b/resources/netregexes.ts
@@ -1,9 +1,12 @@
-import Regexes, { Params, Return } from './regexes';
+import { BaseRegExp } from 'types/trigger';
+import Regexes, { Params } from './regexes';
 
 interface Fields {
   field: string;
   value?: string;
 }
+
+export type NetRegex<T extends string> = BaseRegExp<Exclude<T, 'capture'>>;
 
 // Differences from Regexes:
 // * may have more fields
@@ -129,7 +132,7 @@ export default class NetRegexes {
   /**
    * matches: https://github.com/quisquous/cactbot/blob/main/docs/LogGuide.md#14-networkstartscasting
    */
-  static startsUsing(params?: Params<StartsUsingParams>): Return<StartsUsingParams> {
+  static startsUsing(params?: Params<StartsUsingParams>): NetRegex<StartsUsingParams> {
     return parseHelper(params, 'startsUsing', {
       0: { field: 'type', value: '20' },
       1: { field: 'timestamp' },
@@ -148,7 +151,7 @@ export default class NetRegexes {
    * matches: https://github.com/quisquous/cactbot/blob/main/docs/LogGuide.md#15-networkability
    * matches: https://github.com/quisquous/cactbot/blob/main/docs/LogGuide.md#16-networkaoeability
    */
-  static ability(params?: Params<AbilityParams>): Return<AbilityParams> {
+  static ability(params?: Params<AbilityParams>): NetRegex<AbilityParams> {
     return parseHelper(params, 'ability', {
       0: { field: 'type', value: '2[12]' },
       1: { field: 'timestamp' },
@@ -166,7 +169,7 @@ export default class NetRegexes {
    * matches: https://github.com/quisquous/cactbot/blob/main/docs/LogGuide.md#15-networkability
    * matches: https://github.com/quisquous/cactbot/blob/main/docs/LogGuide.md#16-networkaoeability
    */
-  static abilityFull(params?: Params<AbilityFullParams>): Return<AbilityFullParams> {
+  static abilityFull(params?: Params<AbilityFullParams>): NetRegex<AbilityFullParams> {
     return parseHelper(params, 'abilityFull', {
       0: { field: 'type', value: '2[12]' },
       1: { field: 'timestamp' },
@@ -191,7 +194,7 @@ export default class NetRegexes {
   /**
    * matches: https://github.com/quisquous/cactbot/blob/main/docs/LogGuide.md#1b-networktargeticon-head-markers
    */
-  static headMarker(params?: Params<HeadMarkerParams>): Return<HeadMarkerParams> {
+  static headMarker(params?: Params<HeadMarkerParams>): NetRegex<HeadMarkerParams> {
     return parseHelper(params, 'headMarker', {
       0: { field: 'type', value: '27' },
       1: { field: 'timestamp' },
@@ -205,7 +208,7 @@ export default class NetRegexes {
   /**
    * matches: https://github.com/quisquous/cactbot/blob/main/docs/LogGuide.md#03-addcombatant
    */
-  static addedCombatant(params?: Params<AddedCombatantParams>): Return<AddedCombatantParams> {
+  static addedCombatant(params?: Params<AddedCombatantParams>): NetRegex<AddedCombatantParams> {
     return parseHelper(params, 'addedCombatant', {
       0: { field: 'type', value: '03' },
       1: { field: 'timestamp' },
@@ -220,7 +223,7 @@ export default class NetRegexes {
    */
   static addedCombatantFull(
       params?: Params<AddedCombatantFullParams>,
-  ): Return<AddedCombatantFullParams> {
+  ): NetRegex<AddedCombatantFullParams> {
     return parseHelper(params, 'addedCombatantFull', {
       0: { field: 'type', value: '03' },
       1: { field: 'timestamp' },
@@ -247,7 +250,7 @@ export default class NetRegexes {
    */
   static removingCombatant(
       params?: Params<RemovingCombatantParams>,
-  ): Return<RemovingCombatantParams> {
+  ): NetRegex<RemovingCombatantParams> {
     return parseHelper(params, 'removingCombatant', {
       0: { field: 'type', value: '04' },
       1: { field: 'timestamp' },
@@ -261,7 +264,7 @@ export default class NetRegexes {
   /**
    * matches: https://github.com/quisquous/cactbot/blob/main/docs/LogGuide.md#1a-networkbuff
    */
-  static gainsEffect(params?: Params<GainsEffectParams>): Return<GainsEffectParams> {
+  static gainsEffect(params?: Params<GainsEffectParams>): NetRegex<GainsEffectParams> {
     return parseHelper(params, 'gainsEffect', {
       0: { field: 'type', value: '26' },
       1: { field: 'timestamp' },
@@ -283,7 +286,7 @@ export default class NetRegexes {
    */
   static statusEffectExplicit(
       params?: Params<StatusEffectExplicitParams>,
-  ): Return<StatusEffectExplicitParams> {
+  ): NetRegex<StatusEffectExplicitParams> {
     return parseHelper(params, 'statusEffectExplicit', {
       0: { field: 'type', value: '38' },
       1: { field: 'timestamp' },
@@ -307,7 +310,7 @@ export default class NetRegexes {
   /**
    * matches: https://github.com/quisquous/cactbot/blob/main/docs/LogGuide.md#1e-networkbuffremove
    */
-  static losesEffect(params?: Params<LosesEffectParams>): Return<LosesEffectParams> {
+  static losesEffect(params?: Params<LosesEffectParams>): NetRegex<LosesEffectParams> {
     return parseHelper(params, 'losesEffect', {
       0: { field: 'type', value: '30' },
       1: { field: 'timestamp' },
@@ -325,7 +328,7 @@ export default class NetRegexes {
   /**
    * matches: https://github.com/quisquous/cactbot/blob/main/docs/LogGuide.md#23-networktether
    */
-  static tether(params?: Params<TetherParams>): Return<TetherParams> {
+  static tether(params?: Params<TetherParams>): NetRegex<TetherParams> {
     return parseHelper(params, 'tether', {
       0: { field: 'type', value: '35' },
       1: { field: 'timestamp' },
@@ -342,7 +345,7 @@ export default class NetRegexes {
    * 'target' was defeated by 'source'
    * matches: https://github.com/quisquous/cactbot/blob/main/docs/LogGuide.md#19-networkdeath
    */
-  static wasDefeated(params?: Params<WasDefeatedParams>): Return<WasDefeatedParams> {
+  static wasDefeated(params?: Params<WasDefeatedParams>): NetRegex<WasDefeatedParams> {
     return parseHelper(params, 'wasDefeated', {
       0: { field: 'type', value: '25' },
       1: { field: 'timestamp' },
@@ -357,7 +360,7 @@ export default class NetRegexes {
   /**
    * matches: https://github.com/quisquous/cactbot/blob/main/docs/LogGuide.md#00-logline
    */
-  static echo(params?: Params<EchoParams>): Return<EchoParams> {
+  static echo(params?: Params<EchoParams>): NetRegex<EchoParams> {
     if (typeof params === 'undefined')
       params = {};
     Regexes.validateParams(params, 'echo', ['type', 'timestamp', 'code', 'name', 'line', 'capture']);
@@ -369,7 +372,7 @@ export default class NetRegexes {
   /**
    * matches: https://github.com/quisquous/cactbot/blob/main/docs/LogGuide.md#00-logline
    */
-  static dialog(params?: Params<DialogParams>): Return<DialogParams> {
+  static dialog(params?: Params<DialogParams>): NetRegex<DialogParams> {
     if (typeof params === 'undefined')
       params = {};
     Regexes.validateParams(params, 'dialog', ['type', 'timestamp', 'code', 'name', 'line', 'capture']);
@@ -381,7 +384,7 @@ export default class NetRegexes {
   /**
    * matches: https://github.com/quisquous/cactbot/blob/main/docs/LogGuide.md#00-logline
    */
-  static message(params?: Params<MessageParams>): Return<MessageParams> {
+  static message(params?: Params<MessageParams>): NetRegex<MessageParams> {
     if (typeof params === 'undefined')
       params = {};
     Regexes.validateParams(params, 'message', ['type', 'timestamp', 'code', 'name', 'line', 'capture']);
@@ -394,7 +397,7 @@ export default class NetRegexes {
    * fields: code, name, line, capture
    * matches: https://github.com/quisquous/cactbot/blob/main/docs/LogGuide.md#00-logline
    */
-  static gameLog(params?: Params<GameLogParams>): Return<GameLogParams> {
+  static gameLog(params?: Params<GameLogParams>): NetRegex<GameLogParams> {
     return parseHelper(params, 'gameLog', {
       0: { field: 'type', value: '00' },
       1: { field: 'timestamp' },
@@ -408,7 +411,7 @@ export default class NetRegexes {
   /**
    * matches: https://github.com/quisquous/cactbot/blob/main/docs/LogGuide.md#00-logline
    */
-  static gameNameLog(params?: Params<GameNameLogParams>): Return<GameNameLogParams> {
+  static gameNameLog(params?: Params<GameNameLogParams>): NetRegex<GameNameLogParams> {
     // for compat with Regexes.
     return NetRegexes.gameLog(params);
   }
@@ -417,7 +420,7 @@ export default class NetRegexes {
   /**
    * matches: https://github.com/quisquous/cactbot/blob/main/docs/LogGuide.md#0c-playerstats
    */
-  static statChange(params?: Params<StatChangeParams>): Return<StatChangeParams> {
+  static statChange(params?: Params<StatChangeParams>): NetRegex<StatChangeParams> {
     return parseHelper(params, 'statChange', {
       0: { field: 'type', value: '12' },
       1: { field: 'timestamp' },
@@ -444,7 +447,7 @@ export default class NetRegexes {
   /**
    * matches: https://github.com/quisquous/cactbot/blob/main/docs/LogGuide.md#01-changezone
    */
-  static changeZone(params?: Params<ChangeZoneParams>): Return<ChangeZoneParams> {
+  static changeZone(params?: Params<ChangeZoneParams>): NetRegex<ChangeZoneParams> {
     return parseHelper(params, 'changeZone', {
       0: { field: 'type', value: '01' },
       1: { field: 'timestamp' },
@@ -457,7 +460,7 @@ export default class NetRegexes {
   /**
    * matches: https://github.com/quisquous/cactbot/blob/main/docs/LogGuide.md#21-network6d-actor-control-lines
    */
-  static network6d(params?: Params<Network6dParams>): Return<Network6dParams> {
+  static network6d(params?: Params<Network6dParams>): NetRegex<Network6dParams> {
     return parseHelper(params, 'network6d', {
       0: { field: 'type', value: '33' },
       1: { field: 'timestamp' },

--- a/resources/netregexes.ts
+++ b/resources/netregexes.ts
@@ -1,4 +1,4 @@
-import Regexes, { Params } from './regexes';
+import Regexes, { Params, Return } from './regexes';
 
 interface Fields {
   field: string;
@@ -33,6 +33,27 @@ const gameNameLogParams = ['code', 'name', 'line'] as const;
 const statChangeParams = ['job', 'strength', 'dexterity', 'vitality', 'intelligence', 'mind', 'piety', 'attackPower', 'directHit', 'criticalHit', 'attackMagicPotency', 'healMagicPotency', 'determination', 'skillSpeed', 'spellSpeed', 'tenacity'] as const;
 const changeZoneParams = ['id', 'name'] as const;
 const network6dParams = ['instance', 'command', 'data0', 'data1', 'data2', 'data3'] as const;
+
+export type StartsUsingParams = typeof startsUsingParams[number];
+export type AbilityParams = typeof abilityParams[number];
+export type AbilityFullParams = typeof abilityFullParams[number];
+export type HeadMarkerParams = typeof headMarkerParams[number];
+export type AddedCombatantParams = typeof addedCombatantParams[number];
+export type AddedCombatantFullParams = typeof addedCombatantFullParams[number];
+export type RemovingCombatantParams = typeof removingCombatantParams[number];
+export type GainsEffectParams = typeof gainsEffectParams[number];
+export type StatusEffectExplicitParams = typeof statusEffectExplicitParams[number];
+export type LosesEffectParams = typeof losesEffectParams[number];
+export type TetherParams = typeof tetherParams[number];
+export type WasDefeatedParams = typeof wasDefeatedParams[number];
+export type EchoParams = typeof echoParams[number];
+export type DialogParams = typeof dialogParams[number];
+export type MessageParams = typeof messageParams[number];
+export type GameLogParams = typeof gameLogParams[number];
+export type GameNameLogParams = typeof gameNameLogParams[number];
+export type StatChangeParams = typeof statChangeParams[number];
+export type ChangeZoneParams = typeof changeZoneParams[number];
+export type Network6dParams = typeof network6dParams[number];
 
 const parseHelper = (
     params: { timestamp?: string; capture?: boolean } | undefined,
@@ -108,7 +129,7 @@ export default class NetRegexes {
   /**
    * matches: https://github.com/quisquous/cactbot/blob/main/docs/LogGuide.md#14-networkstartscasting
    */
-  static startsUsing(params?: Params<typeof startsUsingParams[number]>): RegExp {
+  static startsUsing(params?: Params<StartsUsingParams>): Return<StartsUsingParams> {
     return parseHelper(params, 'startsUsing', {
       0: { field: 'type', value: '20' },
       1: { field: 'timestamp' },
@@ -127,7 +148,7 @@ export default class NetRegexes {
    * matches: https://github.com/quisquous/cactbot/blob/main/docs/LogGuide.md#15-networkability
    * matches: https://github.com/quisquous/cactbot/blob/main/docs/LogGuide.md#16-networkaoeability
    */
-  static ability(params?: Params<typeof abilityParams[number]>): RegExp {
+  static ability(params?: Params<AbilityParams>): Return<AbilityParams> {
     return parseHelper(params, 'ability', {
       0: { field: 'type', value: '2[12]' },
       1: { field: 'timestamp' },
@@ -145,7 +166,7 @@ export default class NetRegexes {
    * matches: https://github.com/quisquous/cactbot/blob/main/docs/LogGuide.md#15-networkability
    * matches: https://github.com/quisquous/cactbot/blob/main/docs/LogGuide.md#16-networkaoeability
    */
-  static abilityFull(params?: Params<typeof abilityFullParams[number]>): RegExp {
+  static abilityFull(params?: Params<AbilityFullParams>): Return<AbilityFullParams> {
     return parseHelper(params, 'abilityFull', {
       0: { field: 'type', value: '2[12]' },
       1: { field: 'timestamp' },
@@ -170,7 +191,7 @@ export default class NetRegexes {
   /**
    * matches: https://github.com/quisquous/cactbot/blob/main/docs/LogGuide.md#1b-networktargeticon-head-markers
    */
-  static headMarker(params?: Params<typeof headMarkerParams[number]>): RegExp {
+  static headMarker(params?: Params<HeadMarkerParams>): Return<HeadMarkerParams> {
     return parseHelper(params, 'headMarker', {
       0: { field: 'type', value: '27' },
       1: { field: 'timestamp' },
@@ -184,7 +205,7 @@ export default class NetRegexes {
   /**
    * matches: https://github.com/quisquous/cactbot/blob/main/docs/LogGuide.md#03-addcombatant
    */
-  static addedCombatant(params?: Params<typeof addedCombatantParams[number]>): RegExp {
+  static addedCombatant(params?: Params<AddedCombatantParams>): Return<AddedCombatantParams> {
     return parseHelper(params, 'addedCombatant', {
       0: { field: 'type', value: '03' },
       1: { field: 'timestamp' },
@@ -197,7 +218,9 @@ export default class NetRegexes {
   /**
    * matches: https://github.com/quisquous/cactbot/blob/main/docs/LogGuide.md#03-addcombatant
    */
-  static addedCombatantFull(params?: Params<typeof addedCombatantFullParams[number]>): RegExp {
+  static addedCombatantFull(
+      params?: Params<AddedCombatantFullParams>,
+  ): Return<AddedCombatantFullParams> {
     return parseHelper(params, 'addedCombatantFull', {
       0: { field: 'type', value: '03' },
       1: { field: 'timestamp' },
@@ -222,7 +245,9 @@ export default class NetRegexes {
   /**
    * matches: https://github.com/quisquous/cactbot/blob/main/docs/LogGuide.md#04-removecombatant
    */
-  static removingCombatant(params?: Params<typeof removingCombatantParams[number]>): RegExp {
+  static removingCombatant(
+      params?: Params<RemovingCombatantParams>,
+  ): Return<RemovingCombatantParams> {
     return parseHelper(params, 'removingCombatant', {
       0: { field: 'type', value: '04' },
       1: { field: 'timestamp' },
@@ -236,7 +261,7 @@ export default class NetRegexes {
   /**
    * matches: https://github.com/quisquous/cactbot/blob/main/docs/LogGuide.md#1a-networkbuff
    */
-  static gainsEffect(params?: Params<typeof gainsEffectParams[number]>): RegExp {
+  static gainsEffect(params?: Params<GainsEffectParams>): Return<GainsEffectParams> {
     return parseHelper(params, 'gainsEffect', {
       0: { field: 'type', value: '26' },
       1: { field: 'timestamp' },
@@ -256,7 +281,9 @@ export default class NetRegexes {
    * Prefer gainsEffect over this function unless you really need extra data.
    * matches: https://github.com/quisquous/cactbot/blob/main/docs/LogGuide.md#26-networkstatuseffects
    */
-  static statusEffectExplicit(params?: Params<typeof statusEffectExplicitParams[number]>): RegExp {
+  static statusEffectExplicit(
+      params?: Params<StatusEffectExplicitParams>,
+  ): Return<StatusEffectExplicitParams> {
     return parseHelper(params, 'statusEffectExplicit', {
       0: { field: 'type', value: '38' },
       1: { field: 'timestamp' },
@@ -280,7 +307,7 @@ export default class NetRegexes {
   /**
    * matches: https://github.com/quisquous/cactbot/blob/main/docs/LogGuide.md#1e-networkbuffremove
    */
-  static losesEffect(params?: Params<typeof losesEffectParams[number]>): RegExp {
+  static losesEffect(params?: Params<LosesEffectParams>): Return<LosesEffectParams> {
     return parseHelper(params, 'losesEffect', {
       0: { field: 'type', value: '30' },
       1: { field: 'timestamp' },
@@ -298,7 +325,7 @@ export default class NetRegexes {
   /**
    * matches: https://github.com/quisquous/cactbot/blob/main/docs/LogGuide.md#23-networktether
    */
-  static tether(params?: Params<typeof tetherParams[number]>): RegExp {
+  static tether(params?: Params<TetherParams>): Return<TetherParams> {
     return parseHelper(params, 'tether', {
       0: { field: 'type', value: '35' },
       1: { field: 'timestamp' },
@@ -315,7 +342,7 @@ export default class NetRegexes {
    * 'target' was defeated by 'source'
    * matches: https://github.com/quisquous/cactbot/blob/main/docs/LogGuide.md#19-networkdeath
    */
-  static wasDefeated(params?: Params<typeof wasDefeatedParams[number]>): RegExp {
+  static wasDefeated(params?: Params<WasDefeatedParams>): Return<WasDefeatedParams> {
     return parseHelper(params, 'wasDefeated', {
       0: { field: 'type', value: '25' },
       1: { field: 'timestamp' },
@@ -330,7 +357,7 @@ export default class NetRegexes {
   /**
    * matches: https://github.com/quisquous/cactbot/blob/main/docs/LogGuide.md#00-logline
    */
-  static echo(params?: Params<typeof echoParams[number]>): RegExp {
+  static echo(params?: Params<EchoParams>): Return<EchoParams> {
     if (typeof params === 'undefined')
       params = {};
     Regexes.validateParams(params, 'echo', ['type', 'timestamp', 'code', 'name', 'line', 'capture']);
@@ -342,7 +369,7 @@ export default class NetRegexes {
   /**
    * matches: https://github.com/quisquous/cactbot/blob/main/docs/LogGuide.md#00-logline
    */
-  static dialog(params?: Params<typeof dialogParams[number]>): RegExp {
+  static dialog(params?: Params<DialogParams>): Return<DialogParams> {
     if (typeof params === 'undefined')
       params = {};
     Regexes.validateParams(params, 'dialog', ['type', 'timestamp', 'code', 'name', 'line', 'capture']);
@@ -354,7 +381,7 @@ export default class NetRegexes {
   /**
    * matches: https://github.com/quisquous/cactbot/blob/main/docs/LogGuide.md#00-logline
    */
-  static message(params?: Params<typeof messageParams[number]>): RegExp {
+  static message(params?: Params<MessageParams>): Return<MessageParams> {
     if (typeof params === 'undefined')
       params = {};
     Regexes.validateParams(params, 'message', ['type', 'timestamp', 'code', 'name', 'line', 'capture']);
@@ -367,7 +394,7 @@ export default class NetRegexes {
    * fields: code, name, line, capture
    * matches: https://github.com/quisquous/cactbot/blob/main/docs/LogGuide.md#00-logline
    */
-  static gameLog(params?: Params<typeof gameLogParams[number]>): RegExp {
+  static gameLog(params?: Params<GameLogParams>): Return<GameLogParams> {
     return parseHelper(params, 'gameLog', {
       0: { field: 'type', value: '00' },
       1: { field: 'timestamp' },
@@ -381,7 +408,7 @@ export default class NetRegexes {
   /**
    * matches: https://github.com/quisquous/cactbot/blob/main/docs/LogGuide.md#00-logline
    */
-  static gameNameLog(params?: Params<typeof gameNameLogParams[number]>): RegExp {
+  static gameNameLog(params?: Params<GameNameLogParams>): Return<GameNameLogParams> {
     // for compat with Regexes.
     return NetRegexes.gameLog(params);
   }
@@ -390,7 +417,7 @@ export default class NetRegexes {
   /**
    * matches: https://github.com/quisquous/cactbot/blob/main/docs/LogGuide.md#0c-playerstats
    */
-  static statChange(params?: Params<typeof statChangeParams[number]>): RegExp {
+  static statChange(params?: Params<StatChangeParams>): Return<StatChangeParams> {
     return parseHelper(params, 'statChange', {
       0: { field: 'type', value: '12' },
       1: { field: 'timestamp' },
@@ -417,7 +444,7 @@ export default class NetRegexes {
   /**
    * matches: https://github.com/quisquous/cactbot/blob/main/docs/LogGuide.md#01-changezone
    */
-  static changeZone(params?: Params<typeof changeZoneParams[number]>): RegExp {
+  static changeZone(params?: Params<ChangeZoneParams>): Return<ChangeZoneParams> {
     return parseHelper(params, 'changeZone', {
       0: { field: 'type', value: '01' },
       1: { field: 'timestamp' },
@@ -430,7 +457,7 @@ export default class NetRegexes {
   /**
    * matches: https://github.com/quisquous/cactbot/blob/main/docs/LogGuide.md#21-network6d-actor-control-lines
    */
-  static network6d(params?: Params<typeof network6dParams[number]>): RegExp {
+  static network6d(params?: Params<Network6dParams>): Return<Network6dParams> {
     return parseHelper(params, 'network6d', {
       0: { field: 'type', value: '33' },
       1: { field: 'timestamp' },

--- a/resources/regexes.ts
+++ b/resources/regexes.ts
@@ -4,7 +4,7 @@ export type Params<T extends string> =
   Partial<Record<Exclude<T, 'timestamp' | 'capture'>, string | string[]> &
   { 'timestamp': string; 'capture': boolean }>;
 
-export type Return<T extends string> = BaseRegExp<Exclude<T, 'capture'>>;
+export type Regex<T extends string> = BaseRegExp<Exclude<T, 'capture'>>;
 
 type ValidStringOrArray = string | string[];
 
@@ -157,7 +157,7 @@ export default class Regexes {
    * fields: source, id, ability, target, capture
    * matches: https://github.com/quisquous/cactbot/blob/main/docs/LogGuide.md#14-networkstartscasting
    */
-  static startsUsing(f?: Params<StartsUsingParams>): Return<StartsUsingParams> {
+  static startsUsing(f?: Params<StartsUsingParams>): Regex<StartsUsingParams> {
     if (typeof f === 'undefined')
       f = {};
     Regexes.validateParams(f, 'startsUsing', startsUsingParams);
@@ -183,7 +183,7 @@ export default class Regexes {
    * matches: https://github.com/quisquous/cactbot/blob/main/docs/LogGuide.md#15-networkability
    * matches: https://github.com/quisquous/cactbot/blob/main/docs/LogGuide.md#16-networkaoeability
    */
-  static ability(f?: Params<AbilityParams>): Return<AbilityParams> {
+  static ability(f?: Params<AbilityParams>): Regex<AbilityParams> {
     if (typeof f === 'undefined')
       f = {};
     Regexes.validateParams(f, 'ability', abilityParams);
@@ -212,7 +212,7 @@ export default class Regexes {
    * matches: https://github.com/quisquous/cactbot/blob/main/docs/LogGuide.md#15-networkability
    * matches: https://github.com/quisquous/cactbot/blob/main/docs/LogGuide.md#16-networkaoeability
    */
-  static abilityFull(f?: Params<AbilityFullParams>): Return<AbilityFullParams> {
+  static abilityFull(f?: Params<AbilityFullParams>): Regex<AbilityFullParams> {
     if (typeof f === 'undefined')
       f = {};
     Regexes.validateParams(f, 'abilityFull', abilityFullParams);
@@ -270,7 +270,7 @@ export default class Regexes {
    * fields: targetId, target, id, capture
    * matches: https://github.com/quisquous/cactbot/blob/main/docs/LogGuide.md#1b-networktargeticon-head-markers
    */
-  static headMarker(f?: Params<HeadMarkerParams>): Return<HeadMarkerParams> {
+  static headMarker(f?: Params<HeadMarkerParams>): Regex<HeadMarkerParams> {
     if (typeof f === 'undefined')
       f = {};
     Regexes.validateParams(f, 'headMarker', headMarkerParams);
@@ -285,7 +285,7 @@ export default class Regexes {
 
   // fields: name, capture
   // matches: https://github.com/quisquous/cactbot/blob/main/docs/LogGuide.md#03-addcombatant
-  static addedCombatant(f?: Params<AddedCombatantParams>): Return<AddedCombatantParams> {
+  static addedCombatant(f?: Params<AddedCombatantParams>): Regex<AddedCombatantParams> {
     if (typeof f === 'undefined')
       f = {};
     Regexes.validateParams(f, 'addedCombatant', addedCombatantParams);
@@ -302,7 +302,7 @@ export default class Regexes {
    */
   static addedCombatantFull(
       f?: Params<AddedCombatantFullParams>,
-  ): Return<AddedCombatantFullParams> {
+  ): Regex<AddedCombatantFullParams> {
     if (typeof f === 'undefined')
       f = {};
     Regexes.validateParams(f, 'addedCombatantFull', addedCombatantFullParams);
@@ -325,7 +325,7 @@ export default class Regexes {
    * fields: id, name, hp, capture
    * matches: https://github.com/quisquous/cactbot/blob/main/docs/LogGuide.md#04-removecombatant
    */
-  static removingCombatant(f?: Params<RemovingCombatantParams>): Return<RemovingCombatantParams> {
+  static removingCombatant(f?: Params<RemovingCombatantParams>): Regex<RemovingCombatantParams> {
     if (typeof f === 'undefined')
       f = {};
     Regexes.validateParams(f, 'removingCombatant', removingCombatantParams);
@@ -345,7 +345,7 @@ export default class Regexes {
 
   // fields: targetId, target, effect, source, duration, capture
   // matches: https://github.com/quisquous/cactbot/blob/main/docs/LogGuide.md#1a-networkbuff
-  static gainsEffect(f?: Params<GainsEffectParams>): Return<GainsEffectParams> {
+  static gainsEffect(f?: Params<GainsEffectParams>): Regex<GainsEffectParams> {
     if (typeof f === 'undefined')
       f = {};
     Regexes.validateParams(f, 'gainsEffect', gainsEffectParams);
@@ -372,7 +372,7 @@ export default class Regexes {
    */
   static statusEffectExplicit(
       f?: Params<StatusEffectExplicitParams>,
-  ): Return<StatusEffectExplicitParams> {
+  ): Regex<StatusEffectExplicitParams> {
     if (typeof f === 'undefined')
       f = {};
     Regexes.validateParams(f, 'statusEffectExplicit', statusEffectExplicitParams);
@@ -410,7 +410,7 @@ export default class Regexes {
    * fields: targetId, target, effect, source, capture
    * matches: https://github.com/quisquous/cactbot/blob/main/docs/LogGuide.md#1e-networkbuffremove
    */
-  static losesEffect(f?: Params<LosesEffectParams>): Return<LosesEffectParams> {
+  static losesEffect(f?: Params<LosesEffectParams>): Regex<LosesEffectParams> {
     if (typeof f === 'undefined')
       f = {};
     Regexes.validateParams(f, 'losesEffect', losesEffectParams);
@@ -431,7 +431,7 @@ export default class Regexes {
    * fields: source, sourceId, target, targetId, id, capture
    * matches: https://github.com/quisquous/cactbot/blob/main/docs/LogGuide.md#23-networktether
    */
-  static tether(f?: Params<TetherParams>): Return<TetherParams> {
+  static tether(f?: Params<TetherParams>): Regex<TetherParams> {
     if (typeof f === 'undefined')
       f = {};
     Regexes.validateParams(f, 'tether', tetherParams);
@@ -453,7 +453,7 @@ export default class Regexes {
    * fields: target, source, capture
    * matches: https://github.com/quisquous/cactbot/blob/main/docs/LogGuide.md#19-networkdeath
    */
-  static wasDefeated(f?: Params<WasDefeatedParams>): Return<WasDefeatedParams> {
+  static wasDefeated(f?: Params<WasDefeatedParams>): Regex<WasDefeatedParams> {
     if (typeof f === 'undefined')
       f = {};
     Regexes.validateParams(f, 'wasDefeated', wasDefeatedParams);
@@ -471,7 +471,7 @@ export default class Regexes {
    * fields: name, hp, capture
    * matches: https://github.com/quisquous/cactbot/blob/main/docs/LogGuide.md#0d-combatanthp
    */
-  static hasHP(f?: Params<HasHPParams>): Return<HasHPParams> {
+  static hasHP(f?: Params<HasHPParams>): Regex<HasHPParams> {
     if (typeof f === 'undefined')
       f = {};
     Regexes.validateParams(f, 'hasHP', hasHPParams);
@@ -489,7 +489,7 @@ export default class Regexes {
    * fields: code, line, capture
    * matches: https://github.com/quisquous/cactbot/blob/main/docs/LogGuide.md#00-logline
    */
-  static echo(f?: Params<EchoParams>): Return<EchoParams> {
+  static echo(f?: Params<EchoParams>): Regex<EchoParams> {
     if (typeof f === 'undefined')
       f = {};
     Regexes.validateParams(f, 'echo', echoParams);
@@ -505,7 +505,7 @@ export default class Regexes {
    * fields: code, line, name, capture
    * matches: https://github.com/quisquous/cactbot/blob/main/docs/LogGuide.md#00-logline
    */
-  static dialog(f?: Params<DialogParams>): Return<DialogParams> {
+  static dialog(f?: Params<DialogParams>): Regex<DialogParams> {
     if (typeof f === 'undefined')
       f = {};
     Regexes.validateParams(f, 'dialog', dialogParams);
@@ -523,7 +523,7 @@ export default class Regexes {
    * fields: code, line, capture
    * matches: https://github.com/quisquous/cactbot/blob/main/docs/LogGuide.md#00-logline
    */
-  static message(f?: Params<MessageParams>): Return<MessageParams> {
+  static message(f?: Params<MessageParams>): Regex<MessageParams> {
     if (typeof f === 'undefined')
       f = {};
     Regexes.validateParams(f, 'message', messageParams);
@@ -538,7 +538,7 @@ export default class Regexes {
    * fields: code, line, capture
    * matches: https://github.com/quisquous/cactbot/blob/main/docs/LogGuide.md#00-logline
    */
-  static gameLog(f?: Params<GameLogParams>): Return<GameLogParams> {
+  static gameLog(f?: Params<GameLogParams>): Regex<GameLogParams> {
     if (typeof f === 'undefined')
       f = {};
     Regexes.validateParams(f, 'gameLog', gameLogParams);
@@ -557,7 +557,7 @@ export default class Regexes {
    * Some game log lines have names in them, but not all.  All network log lines for these
    * have empty fields, but these get dropped by the ACT FFXV plugin.
    */
-  static gameNameLog(f?: Params<GameNameLogParams>): Return<GameNameLogParams> {
+  static gameNameLog(f?: Params<GameNameLogParams>): Regex<GameNameLogParams> {
     if (typeof f === 'undefined')
       f = {};
     Regexes.validateParams(f, 'gameNameLog', gameNameLogParams);
@@ -576,7 +576,7 @@ export default class Regexes {
    *         skillSpeed, spellSpeed, tenacity, capture
    * matches: https://github.com/quisquous/cactbot/blob/main/docs/LogGuide.md#0c-playerstats
    */
-  static statChange(f?: Params<StatChangeParams>): Return<StatChangeParams> {
+  static statChange(f?: Params<StatChangeParams>): Regex<StatChangeParams> {
     if (typeof f === 'undefined')
       f = {};
     Regexes.validateParams(f, 'statChange', statChangeParams);
@@ -608,7 +608,7 @@ export default class Regexes {
    * fields: name, capture
    * matches: https://github.com/quisquous/cactbot/blob/main/docs/LogGuide.md#01-changezone
    */
-  static changeZone(f?: Params<ChangeZoneParams>): Return<ChangeZoneParams> {
+  static changeZone(f?: Params<ChangeZoneParams>): Regex<ChangeZoneParams> {
     if (typeof f === 'undefined')
       f = {};
     Regexes.validateParams(f, 'changeZone', changeZoneParams);
@@ -624,7 +624,7 @@ export default class Regexes {
    * fields: instance, command, data0, data1, data2, data3
    * matches: https://github.com/quisquous/cactbot/blob/main/docs/LogGuide.md#21-network6d-actor-control-lines
    */
-  static network6d(f?: Params<Network6dParams>): Return<Network6dParams> {
+  static network6d(f?: Params<Network6dParams>): Regex<Network6dParams> {
     if (typeof f === 'undefined')
       f = {};
     Regexes.validateParams(f, 'network6d', network6dParams);

--- a/resources/regexes.ts
+++ b/resources/regexes.ts
@@ -1,6 +1,10 @@
+import { BaseRegExp } from '../types/trigger';
+
 export type Params<T extends string> =
-  Partial<Record<T, string | string[]> &
+  Partial<Record<Exclude<T, 'timestamp' | 'capture'>, string | string[]> &
   { 'timestamp': string; 'capture': boolean }>;
+
+export type Return<T extends string> = BaseRegExp<Exclude<T, 'capture'>>;
 
 type ValidStringOrArray = string | string[];
 
@@ -126,12 +130,34 @@ const gameNameLogParams = ['timestamp', 'code', 'name', 'line', 'capture'] as co
 const changeZoneParams = ['timestamp', 'name', 'capture'] as const;
 const network6dParams = ['timestamp', 'instance', 'command', 'data0', 'data1', 'data2', 'data3', 'capture'] as const;
 
+export type StartsUsingParams = typeof startsUsingParams[number];
+export type AbilityParams = typeof abilityParams[number];
+export type AbilityFullParams = typeof abilityFullParams[number];
+export type HeadMarkerParams = typeof headMarkerParams[number];
+export type AddedCombatantParams = typeof addedCombatantParams[number];
+export type AddedCombatantFullParams = typeof addedCombatantFullParams[number];
+export type RemovingCombatantParams = typeof removingCombatantParams[number];
+export type GainsEffectParams = typeof gainsEffectParams[number];
+export type StatusEffectExplicitParams = typeof statusEffectExplicitParams[number];
+export type LosesEffectParams = typeof losesEffectParams[number];
+export type StatChangeParams = typeof statChangeParams[number];
+export type TetherParams = typeof tetherParams[number];
+export type WasDefeatedParams = typeof wasDefeatedParams[number];
+export type HasHPParams = typeof hasHPParams[number];
+export type EchoParams = typeof echoParams[number];
+export type DialogParams = typeof dialogParams[number];
+export type MessageParams = typeof messageParams[number];
+export type GameLogParams = typeof gameLogParams[number];
+export type GameNameLogParams = typeof gameNameLogParams[number];
+export type ChangeZoneParams = typeof changeZoneParams[number];
+export type Network6dParams = typeof network6dParams[number];
+
 export default class Regexes {
   /**
    * fields: source, id, ability, target, capture
    * matches: https://github.com/quisquous/cactbot/blob/main/docs/LogGuide.md#14-networkstartscasting
    */
-  static startsUsing(f?: Params<typeof startsUsingParams[number]>): RegExp {
+  static startsUsing(f?: Params<StartsUsingParams>): Return<StartsUsingParams> {
     if (typeof f === 'undefined')
       f = {};
     Regexes.validateParams(f, 'startsUsing', startsUsingParams);
@@ -157,7 +183,7 @@ export default class Regexes {
    * matches: https://github.com/quisquous/cactbot/blob/main/docs/LogGuide.md#15-networkability
    * matches: https://github.com/quisquous/cactbot/blob/main/docs/LogGuide.md#16-networkaoeability
    */
-  static ability(f?: Params<typeof abilityParams[number]>): RegExp {
+  static ability(f?: Params<AbilityParams>): Return<AbilityParams> {
     if (typeof f === 'undefined')
       f = {};
     Regexes.validateParams(f, 'ability', abilityParams);
@@ -186,7 +212,7 @@ export default class Regexes {
    * matches: https://github.com/quisquous/cactbot/blob/main/docs/LogGuide.md#15-networkability
    * matches: https://github.com/quisquous/cactbot/blob/main/docs/LogGuide.md#16-networkaoeability
    */
-  static abilityFull(f?: Params<typeof abilityFullParams[number]>): RegExp {
+  static abilityFull(f?: Params<AbilityFullParams>): Return<AbilityFullParams> {
     if (typeof f === 'undefined')
       f = {};
     Regexes.validateParams(f, 'abilityFull', abilityFullParams);
@@ -244,7 +270,7 @@ export default class Regexes {
    * fields: targetId, target, id, capture
    * matches: https://github.com/quisquous/cactbot/blob/main/docs/LogGuide.md#1b-networktargeticon-head-markers
    */
-  static headMarker(f?: Params<typeof headMarkerParams[number]>): RegExp {
+  static headMarker(f?: Params<HeadMarkerParams>): Return<HeadMarkerParams> {
     if (typeof f === 'undefined')
       f = {};
     Regexes.validateParams(f, 'headMarker', headMarkerParams);
@@ -259,7 +285,7 @@ export default class Regexes {
 
   // fields: name, capture
   // matches: https://github.com/quisquous/cactbot/blob/main/docs/LogGuide.md#03-addcombatant
-  static addedCombatant(f?: Params<typeof addedCombatantParams[number]>): RegExp {
+  static addedCombatant(f?: Params<AddedCombatantParams>): Return<AddedCombatantParams> {
     if (typeof f === 'undefined')
       f = {};
     Regexes.validateParams(f, 'addedCombatant', addedCombatantParams);
@@ -274,7 +300,9 @@ export default class Regexes {
    * fields: id, name, hp, x, y, z, npcId, capture
    * matches: https://github.com/quisquous/cactbot/blob/main/docs/LogGuide.md#03-addcombatant
    */
-  static addedCombatantFull(f?: Params<typeof addedCombatantFullParams[number]>): RegExp {
+  static addedCombatantFull(
+      f?: Params<AddedCombatantFullParams>,
+  ): Return<AddedCombatantFullParams> {
     if (typeof f === 'undefined')
       f = {};
     Regexes.validateParams(f, 'addedCombatantFull', addedCombatantFullParams);
@@ -297,7 +325,7 @@ export default class Regexes {
    * fields: id, name, hp, capture
    * matches: https://github.com/quisquous/cactbot/blob/main/docs/LogGuide.md#04-removecombatant
    */
-  static removingCombatant(f?: Params<typeof removingCombatantParams[number]>): RegExp {
+  static removingCombatant(f?: Params<RemovingCombatantParams>): Return<RemovingCombatantParams> {
     if (typeof f === 'undefined')
       f = {};
     Regexes.validateParams(f, 'removingCombatant', removingCombatantParams);
@@ -317,7 +345,7 @@ export default class Regexes {
 
   // fields: targetId, target, effect, source, duration, capture
   // matches: https://github.com/quisquous/cactbot/blob/main/docs/LogGuide.md#1a-networkbuff
-  static gainsEffect(f?: Params<typeof gainsEffectParams[number]>): RegExp {
+  static gainsEffect(f?: Params<GainsEffectParams>): Return<GainsEffectParams> {
     if (typeof f === 'undefined')
       f = {};
     Regexes.validateParams(f, 'gainsEffect', gainsEffectParams);
@@ -342,7 +370,9 @@ export default class Regexes {
    *         data0, data1, data2, data3, data4
    * matches: https://github.com/quisquous/cactbot/blob/main/docs/LogGuide.md#26-networkstatuseffects
    */
-  static statusEffectExplicit(f?: Params<typeof statusEffectExplicitParams[number]>): RegExp {
+  static statusEffectExplicit(
+      f?: Params<StatusEffectExplicitParams>,
+  ): Return<StatusEffectExplicitParams> {
     if (typeof f === 'undefined')
       f = {};
     Regexes.validateParams(f, 'statusEffectExplicit', statusEffectExplicitParams);
@@ -380,7 +410,7 @@ export default class Regexes {
    * fields: targetId, target, effect, source, capture
    * matches: https://github.com/quisquous/cactbot/blob/main/docs/LogGuide.md#1e-networkbuffremove
    */
-  static losesEffect(f?: Params<typeof losesEffectParams[number]>): RegExp {
+  static losesEffect(f?: Params<LosesEffectParams>): Return<LosesEffectParams> {
     if (typeof f === 'undefined')
       f = {};
     Regexes.validateParams(f, 'losesEffect', losesEffectParams);
@@ -401,7 +431,7 @@ export default class Regexes {
    * fields: source, sourceId, target, targetId, id, capture
    * matches: https://github.com/quisquous/cactbot/blob/main/docs/LogGuide.md#23-networktether
    */
-  static tether(f?: Params<typeof tetherParams[number]>): RegExp {
+  static tether(f?: Params<TetherParams>): Return<TetherParams> {
     if (typeof f === 'undefined')
       f = {};
     Regexes.validateParams(f, 'tether', tetherParams);
@@ -423,7 +453,7 @@ export default class Regexes {
    * fields: target, source, capture
    * matches: https://github.com/quisquous/cactbot/blob/main/docs/LogGuide.md#19-networkdeath
    */
-  static wasDefeated(f?: Params<typeof wasDefeatedParams[number]>): RegExp {
+  static wasDefeated(f?: Params<WasDefeatedParams>): Return<WasDefeatedParams> {
     if (typeof f === 'undefined')
       f = {};
     Regexes.validateParams(f, 'wasDefeated', wasDefeatedParams);
@@ -441,7 +471,7 @@ export default class Regexes {
    * fields: name, hp, capture
    * matches: https://github.com/quisquous/cactbot/blob/main/docs/LogGuide.md#0d-combatanthp
    */
-  static hasHP(f?: Params<typeof hasHPParams[number]>): RegExp {
+  static hasHP(f?: Params<HasHPParams>): Return<HasHPParams> {
     if (typeof f === 'undefined')
       f = {};
     Regexes.validateParams(f, 'hasHP', hasHPParams);
@@ -459,7 +489,7 @@ export default class Regexes {
    * fields: code, line, capture
    * matches: https://github.com/quisquous/cactbot/blob/main/docs/LogGuide.md#00-logline
    */
-  static echo(f?: Params<typeof echoParams[number]>): RegExp {
+  static echo(f?: Params<EchoParams>): Return<EchoParams> {
     if (typeof f === 'undefined')
       f = {};
     Regexes.validateParams(f, 'echo', echoParams);
@@ -475,7 +505,7 @@ export default class Regexes {
    * fields: code, line, name, capture
    * matches: https://github.com/quisquous/cactbot/blob/main/docs/LogGuide.md#00-logline
    */
-  static dialog(f?: Params<typeof dialogParams[number]>): RegExp {
+  static dialog(f?: Params<DialogParams>): Return<DialogParams> {
     if (typeof f === 'undefined')
       f = {};
     Regexes.validateParams(f, 'dialog', dialogParams);
@@ -493,7 +523,7 @@ export default class Regexes {
    * fields: code, line, capture
    * matches: https://github.com/quisquous/cactbot/blob/main/docs/LogGuide.md#00-logline
    */
-  static message(f?: Params<typeof messageParams[number]>): RegExp {
+  static message(f?: Params<MessageParams>): Return<MessageParams> {
     if (typeof f === 'undefined')
       f = {};
     Regexes.validateParams(f, 'message', messageParams);
@@ -508,7 +538,7 @@ export default class Regexes {
    * fields: code, line, capture
    * matches: https://github.com/quisquous/cactbot/blob/main/docs/LogGuide.md#00-logline
    */
-  static gameLog(f?: Params<typeof gameLogParams[number]>): RegExp {
+  static gameLog(f?: Params<GameLogParams>): Return<GameLogParams> {
     if (typeof f === 'undefined')
       f = {};
     Regexes.validateParams(f, 'gameLog', gameLogParams);
@@ -527,7 +557,7 @@ export default class Regexes {
    * Some game log lines have names in them, but not all.  All network log lines for these
    * have empty fields, but these get dropped by the ACT FFXV plugin.
    */
-  static gameNameLog(f?: Params<typeof gameNameLogParams[number]>): RegExp {
+  static gameNameLog(f?: Params<GameNameLogParams>): Return<GameNameLogParams> {
     if (typeof f === 'undefined')
       f = {};
     Regexes.validateParams(f, 'gameNameLog', gameNameLogParams);
@@ -546,7 +576,7 @@ export default class Regexes {
    *         skillSpeed, spellSpeed, tenacity, capture
    * matches: https://github.com/quisquous/cactbot/blob/main/docs/LogGuide.md#0c-playerstats
    */
-  static statChange(f?: Params<typeof statChangeParams[number]>): RegExp {
+  static statChange(f?: Params<StatChangeParams>): Return<StatChangeParams> {
     if (typeof f === 'undefined')
       f = {};
     Regexes.validateParams(f, 'statChange', statChangeParams);
@@ -578,7 +608,7 @@ export default class Regexes {
    * fields: name, capture
    * matches: https://github.com/quisquous/cactbot/blob/main/docs/LogGuide.md#01-changezone
    */
-  static changeZone(f?: Params<typeof changeZoneParams[number]>): RegExp {
+  static changeZone(f?: Params<ChangeZoneParams>): Return<ChangeZoneParams> {
     if (typeof f === 'undefined')
       f = {};
     Regexes.validateParams(f, 'changeZone', changeZoneParams);
@@ -594,7 +624,7 @@ export default class Regexes {
    * fields: instance, command, data0, data1, data2, data3
    * matches: https://github.com/quisquous/cactbot/blob/main/docs/LogGuide.md#21-network6d-actor-control-lines
    */
-  static network6d(f?: Params<typeof network6dParams[number]>): RegExp {
+  static network6d(f?: Params<Network6dParams>): Return<Network6dParams> {
     if (typeof f === 'undefined')
       f = {};
     Regexes.validateParams(f, 'network6d', network6dParams);

--- a/types/trigger.d.ts
+++ b/types/trigger.d.ts
@@ -1,9 +1,15 @@
 import { Lang } from './global';
 
+export interface BaseRegExp<T> extends RegExp {
+  groups?: {
+    [s in T]?: string;
+  };
+}
+
 export type Matches<T> =
-  T extends (params?: infer R) => RegExp ?
-  { [s in Exclude<keyof R, 'capture'>]: string } :
-  { [s: string]: string };
+  T extends BaseRegExp ? T['groups'] :
+  T extends RegExp ? { [s: string]: string } :
+  unknown;
 
 
 type TranslatableText = {

--- a/types/trigger.d.ts
+++ b/types/trigger.d.ts
@@ -1,9 +1,9 @@
 import { Lang } from './global';
 
-export type Matches = {
-  target?: string;
-  [s: string]: string;
-}
+export type Matches<T> =
+  T extends (params?: infer R) => RegExp ?
+  { [s in Exclude<keyof R, 'capture'>]: string } :
+  { [s: string]: string };
 
 
 type TranslatableText = {

--- a/types/trigger.d.ts
+++ b/types/trigger.d.ts
@@ -9,7 +9,7 @@ export interface BaseRegExp<T> extends RegExp {
 export type Matches<T> =
   T extends BaseRegExp ? T['groups'] :
   T extends RegExp ? { [s: string]: string } :
-  unknown;
+  never;
 
 
 type TranslatableText = {


### PR DESCRIPTION
This change makes it easier for us to refactor the Trigger data file later on, we can write
```typescript
{
  id: 'General Provoke',
  netRegex: NetRegexes.ability({ id: '1D6D' }),
  condition: function(data: Data, matches: Matches<typeof NetRegexes.ability>): boolean {
    if (matches.source !== data.me && !data.party.inAlliance(matches.source))
      return false;
    return caresAboutTankStuff(data);
  },
},
```
and then TypeScript will automatically derive it as:
```typescript
(parameter) matches: {
    sourceId: string;
    source: string;
    id: string;
    ability: string;
    targetId: string;
    target: string;
    timestamp: string;
}
```

As in VSCode, it would be like this:
![image](https://user-images.githubusercontent.com/19927330/110485864-0b67ed00-8127-11eb-8df6-c71df7b37d50.png)
