### PR TITLE
Jobs: MCH Wildfire refactor

### DIFF
--- a/resources/effect_id.js
+++ b/resources/effect_id.js
@@ -1313,6 +1313,7 @@ export default {
   'Whistle': '370',
   'WhiteWound': '564',
   'WideAwake': '7FF',
+  'Wildfire': '35D',
   'WillOfTheWater': '2CE',
   'WillOfTheWind': '2CD',
   'WindResistanceUp': '20A',

--- a/ui/jobs/components/mch.js
+++ b/ui/jobs/components/mch.js
@@ -85,16 +85,11 @@ export function setup(bars) {
   const refreshWildFireGuage = () => {
     for (let i = 0; i < 6; ++i) {
       wildFireStacks[i].classList.remove('fix', 'active');
-      if (wildFireActive) {
-        if (wildFireCounts > i)
+      if (wildFireCounts > i) {
+        if (wildFireActive)
           wildFireStacks[i].classList.add('active');
         else
-          wildFireStacks[i].classList.remove('active');
-      } else {
-        if (wildFireCounts > i)
           wildFireStacks[i].classList.add('fix');
-        else
-          wildFireStacks[i].classList.remove('fix');
       }
     }
   };

--- a/ui/jobs/components/mch.js
+++ b/ui/jobs/components/mch.js
@@ -97,6 +97,7 @@ export function setup(bars) {
     wildFireActive = true;
     wildFireCounts = e.count;
     refreshWildFireGauge();
+    stacksContainer.classList.remove('hide');
   });
   bars.onMobLosesEffectFromYou(EffectId.Wildfire, () => {
     wildFireActive = false;
@@ -110,7 +111,6 @@ export function setup(bars) {
     wildFireBox.duration = 0;
     wildFireBox.duration = 10 + 0.9; // animation delay
     wildFireBox.threshold = 1000;
-    stacksContainer.classList.remove('hide');
     wildFireBox.fg = computeBackgroundColorFrom(wildFireBox, 'mch-color-wildfire.active');
     setTimeout(() => {
       wildFireBox.duration = 110 - 0.9;

--- a/ui/jobs/components/mch.js
+++ b/ui/jobs/components/mch.js
@@ -82,7 +82,7 @@ export function setup(bars) {
 
   let wildFireCounts = 0;
   let wildFireActive = false;
-  const refreshWildFireGuage = () => {
+  const refreshWildFireGauge = () => {
     for (let i = 0; i < 6; ++i) {
       wildFireStacks[i].classList.remove('fix', 'active');
       if (wildFireCounts > i) {
@@ -96,11 +96,11 @@ export function setup(bars) {
   bars.onMobGainsEffectFromYou(EffectId.Wildfire, (id, e) => {
     wildFireActive = true;
     wildFireCounts = e.count;
-    refreshWildFireGuage();
+    refreshWildFireGauge();
   });
   bars.onMobLosesEffectFromYou(EffectId.Wildfire, () => {
     wildFireActive = false;
-    refreshWildFireGuage();
+    refreshWildFireGauge();
   });
   const wildFireBox = bars.addProcBox({
     id: 'mch-procs-wildfire',
@@ -120,7 +120,7 @@ export function setup(bars) {
     setTimeout(() => {
       stacksContainer.classList.add('hide');
       wildFireCounts = 0;
-    }, 12500);
+    }, 15000);
   });
 
   bars.onStatChange('MCH', () => {

--- a/ui/jobs/components/mch.js
+++ b/ui/jobs/components/mch.js
@@ -97,6 +97,10 @@ export function setup(bars) {
     wildFireCounts = e.count;
     refreshWildFireGuage();
   });
+  bars.onMobLosesEffectFromYou(EffectId.Wildfire, () => {
+    wildFireActive = false;
+    refreshWildFireGuage();
+  });
   const wildFireBox = bars.addProcBox({
     id: 'mch-procs-wildfire',
     fgColor: 'mch-color-wildfire',
@@ -113,8 +117,6 @@ export function setup(bars) {
       wildFireBox.duration = 110 - 0.9;
       wildFireBox.threshold = bars.gcdSkill + 1;
       wildFireBox.fg = computeBackgroundColorFrom(wildFireBox, 'mch-color-wildfire');
-      wildFireActive = false;
-      refreshWildFireGuage();
     }, 10000);
     setTimeout(() => {
       stacksContainer.classList.add('hide');

--- a/ui/jobs/components/mch.js
+++ b/ui/jobs/components/mch.js
@@ -94,6 +94,7 @@ export function setup(bars) {
     }
   };
   bars.onMobGainsEffectFromYou(EffectId.Wildfire, (id, e) => {
+    wildFireActive = true;
     wildFireCounts = e.count;
     refreshWildFireGuage();
   });
@@ -109,8 +110,6 @@ export function setup(bars) {
     wildFireBox.duration = 0;
     wildFireBox.duration = 10 + 0.9; // animation delay
     wildFireBox.threshold = 1000;
-    wildFireActive = true;
-    refreshWildFireGuage();
     stacksContainer.classList.remove('hide');
     wildFireBox.fg = computeBackgroundColorFrom(wildFireBox, 'mch-color-wildfire.active');
     setTimeout(() => {

--- a/ui/jobs/jobs.css
+++ b/ui/jobs/jobs.css
@@ -383,6 +383,10 @@
   background-color: rgb(250, 0, 0);
 }
 
+#mch-stacks-wildfire > div.fix {
+  background-color: rgb(190, 80, 70);
+}
+
 #blm-stacks-heart > div.active {
   background-color: rgb(174, 227, 235);
 }

--- a/ui/jobs/jobs.js
+++ b/ui/jobs/jobs.js
@@ -469,25 +469,29 @@ class Bars {
   onMobGainsEffectFromYou(effectIds, callback) {
     if (Array.isArray(effectIds))
       effectIds.forEach((id) => this.mobGainEffectFromYouFuncMap[id] = callback);
-    this.mobGainEffectFromYouFuncMap[effectIds] = callback;
+    else
+      this.mobGainEffectFromYouFuncMap[effectIds] = callback;
   }
 
   onMobLosesEffectFromYou(effectIds, callback) {
     if (Array.isArray(effectIds))
       effectIds.forEach((id) => this.mobLoseEffectFromYouFuncMap[id] = callback);
-    this.mobLoseEffectFromYouFuncMap[effectIds] = callback;
+    else
+      this.mobLoseEffectFromYouFuncMap[effectIds] = callback;
   }
 
   onYouGainEffect(effectIds, callback) {
     if (Array.isArray(effectIds))
       effectIds.forEach((id) => this.gainEffectFuncMap[id] = callback);
-    this.gainEffectFuncMap[effectIds] = callback;
+    else
+      this.gainEffectFuncMap[effectIds] = callback;
   }
 
   onYouLoseEffect(effectIds, callback) {
     if (Array.isArray(effectIds))
       effectIds.forEach((id) => this.loseEffectFuncMap[id] = callback);
-    this.loseEffectFuncMap[effectIds] = callback;
+    else
+      this.loseEffectFuncMap[effectIds] = callback;
   }
 
   onJobDetailUpdate(callback) {
@@ -501,7 +505,8 @@ class Bars {
   onUseAbility(abilityIds, callback) {
     if (Array.isArray(abilityIds))
       abilityIds.forEach((id) => this.abilityFuncMap[id] = callback);
-    this.abilityFuncMap[abilityIds] = callback;
+    else
+      this.abilityFuncMap[abilityIds] = callback;
   }
 
   _onComboChange(skill) {

--- a/ui/jobs/jobs.js
+++ b/ui/jobs/jobs.js
@@ -102,6 +102,7 @@ class Bars {
     this.updateDotTimerFuncs = [];
     this.gainEffectFuncMap = {};
     this.mobGainEffectFromYouFuncMap = {};
+    this.mobLoseEffectFromYouFuncMap = {};
     this.loseEffectFuncMap = {};
     this.statChangeFuncMap = {};
     this.abilityFuncMap = {};
@@ -139,6 +140,7 @@ class Bars {
     this.changeZoneFuncs = [];
     this.gainEffectFuncMap = {};
     this.mobGainEffectFromYouFuncMap = {};
+    this.mobLoseEffectFromYouFuncMap = {};
     this.loseEffectFuncMap = {};
     this.statChangeFuncMap = {};
     this.abilityFuncMap = {};
@@ -468,6 +470,12 @@ class Bars {
     if (Array.isArray(effectIds))
       effectIds.forEach((id) => this.mobGainEffectFromYouFuncMap[id] = callback);
     this.mobGainEffectFromYouFuncMap[effectIds] = callback;
+  }
+
+  onMobLosesEffectFromYou(effectIds, callback) {
+    if (Array.isArray(effectIds))
+      effectIds.forEach((id) => this.mobLoseEffectFromYouFuncMap[id] = callback);
+    this.mobLoseEffectFromYouFuncMap[effectIds] = callback;
   }
 
   onYouGainEffect(effectIds, callback) {
@@ -902,6 +910,9 @@ class Bars {
           if (index > -1)
             this.dotTarget.splice(index, 1);
         }
+        const f = this.mobLoseEffectFromYouFuncMap[effectId];
+        if (f)
+          f(effectId, m.groups);
       }
     } else if (type === '21' || type === '22') {
       let m = log.match(this.regexes.YouUseAbilityRegex);

--- a/util/gen_effect_id.py
+++ b/util/gen_effect_id.py
@@ -47,6 +47,7 @@ known_mapping = {
     "Venomous Bite": "124",
     "Flourishing Fan Dance": "1820",
     "Higanbana": "1228",
+    "Wildfire": "861",
 }
 
 


### PR DESCRIPTION
- Use Wildfire buff `count` from network log instead of counting GCD. This makes Wildfire gauge more accurate.
- Now wildfire gauge will remain displaying for 2.5s after finish Wildfire. It will change to a dimmer color at this time. ( Fixes #2559 )

Co-Authored-By: 迷子 (Maiko Tan) <19927330+MaikoTan@users.noreply.github.com>