### PR TITLE
Raidboss: E3N timeline touch-up

### DIFF
--- a/ui/raidboss/data/05-shb/raid/e3n.txt
+++ b/ui/raidboss/data/05-shb/raid/e3n.txt
@@ -16,8 +16,8 @@ hideall "--sync--"
 51.1 "Monster Wave" sync /:Leviathan:3FCA:/
 55.1 "Freak Wave" sync /:Leviathan:3FCB:/
 60.2 "Temporary Current" sync /:Leviathan:3FC[DE]:/
-70.4 "Tidal Roar" sync /:Leviathan:3FC4:/
-77.4 "Rip Current" sync /:Leviathan:3FC6:/ window 30,30
+70.4 "Tidal Roar" sync /:Leviathan:3FC4:/ window 30,30
+77.4 "Rip Current" sync /:Leviathan:3FC6:/
 98.7 "Tidal Wave" sync /:Leviathan:3FD3:/
 
 105.6 "Undersea Quake" sync /:Leviathan:3FD0:/ window 105.6,10

--- a/ui/raidboss/data/05-shb/raid/e3n.txt
+++ b/ui/raidboss/data/05-shb/raid/e3n.txt
@@ -7,7 +7,6 @@ hideall "--sync--"
 
 0.0 "--Reset--" sync / 21:........:40000010:/ window 10000 jump 0
 
-0 "Start"
 0.0 "--sync--" sync /:Engage!/ window 0,1
 0.5 "--sync--" sync /:Leviathan:42D8:/ window 1,0
 12.5 "Tidal Roar" sync /:Leviathan:3FC4:/ window 13,5
@@ -17,70 +16,70 @@ hideall "--sync--"
 51.1 "Monster Wave" sync /:Leviathan:3FCA:/
 55.1 "Freak Wave" sync /:Leviathan:3FCB:/
 60.2 "Temporary Current" sync /:Leviathan:3FC[DE]:/
-70.4 "Tidal Roar" sync /:Leviathan:3FC4:/ window 3,3
-77.4 "Rip Current" sync /:Leviathan:3FC6:/
+70.4 "Tidal Roar" sync /:Leviathan:3FC4:/
+77.4 "Rip Current" sync /:Leviathan:3FC6:/ window 30,30
 98.7 "Tidal Wave" sync /:Leviathan:3FD3:/
 
-105.6 "Undersea Quake" sync /:Leviathan:3FD0:/
+105.6 "Undersea Quake" sync /:Leviathan:3FD0:/ window 105.6,10
 114.8 "Crashing Pulse" sync /:Leviathan:3FC9:/
 118.9 "Monster Wave" sync /:Leviathan:3FCA:/
 122.9 "Killer Wave" sync /:Leviathan:3FCC:/
-128.9 "Tidal Roar" sync /:Leviathan:3FC4:/ window 3,3
-140.0 "Temporary Current" sync /:Leviathan:3FC[DE]:/
+128.9 "Tidal Roar" sync /:Leviathan:3FC4:/
+140.0 "Temporary Current" sync /:Leviathan:3FC[DE]:/ window 30,30
 162.3 "Tsunami" sync /:Leviathan:441B:/
 171.9 "Surging Tsunami" sync /:Leviathan:4011:/
 178.9 "Smothering Tsunami" sync /:Leviathan:3FD7:/
 184.9 "Splashing Tsunami" sync /:Leviathan:3FD6:/
 185.8 "Swirling Tsunami" sync /:Leviathan:3FD5:/
 192.8 "Surging Tsunami" sync /:Leviathan:4011:/
-203.5 "Tidal Roar" sync /:Leviathan:3FC4:/ window 3,3
+203.5 "Tidal Roar" sync /:Leviathan:3FC4:/ window 20,20
 
-216.7 "Maelstrom" sync /:Leviathan:3FD8:/ duration 30
+216.7 "Maelstrom" sync /:Leviathan:3FD8:/ window 216.7,2.5 duration 30
 218.7 "--untargetable--"
 222.0 "--sync--" sync /:Leviathan:3F7E:/
-226.9 "Spinning Dive" sync /:Leviathan:3FDB:/
+226.9 "Spinning Dive 1" sync /:Leviathan:3FDB:/
 229.1 "--sync--" sync /:Leviathan:3F7E:/
-234.0 "Spinning Dive" sync /:Leviathan:3FDB:/
+234.0 "Spinning Dive 2" sync /:Leviathan:3FDB:/
 240.4 "--targetable--"
-248.4 "Tidal Roar" sync /:Leviathan:3FC4:/ window 3,3
-255.4 "Rip Current" sync /:Leviathan:3FC6:/
+248.4 "Tidal Roar" sync /:Leviathan:3FC4:/
+255.4 "Rip Current" sync /:Leviathan:3FC6:/ window 30,30
 276.8 "Tidal Wave" sync /:Leviathan:3FD3:/
 
 283.8 "Undersea Quake" sync /:Leviathan:3FCF:/ window 300,100
 293.0 "Drenching Pulse" sync /:Leviathan:3FC8:/
 297.1 "Monster Wave" sync /:Leviathan:3FCA:/
 301.1 "Freak Wave" sync /:Leviathan:3FCB:/
-308.2 "Temporary Current" sync /:Leviathan:3FC[DE]:/
-317.3 "Temporary Current" sync /:Leviathan:3FC[DE]:/
-332.5 "Tidal Roar" sync /:Leviathan:3FC4:/ window 3,3
-338.6 "Tidal Roar" sync /:Leviathan:3FC4:/ window 3,3
-348.8 "Rip Current" sync /:Leviathan:3FC6:/
+308.2 "Temporary Current 1" sync /:Leviathan:3FC[DE]:/
+317.3 "Temporary Current 2" sync /:Leviathan:3FC[DE]:/
+332.5 "Tidal Roar" sync /:Leviathan:3FC4:/
+338.6 "Tidal Roar" sync /:Leviathan:3FC4:/
+348.8 "Rip Current" sync /:Leviathan:3FC6:/ window 30,30
 360.0 "Drenching Pulse" sync /:Leviathan:3FC8:/
 364.1 "Monster Wave" sync /:Leviathan:3FCA:/
 368.1 "Freak Wave" sync /:Leviathan:3FCB:/
 
-372.1 "Undersea Quake" sync /:Leviathan:3FD0:/
+372.1 "Undersea Quake" sync /:Leviathan:3FD0:/ window 30,30
 386.3 "Tsunami" sync /:Leviathan:441B:/
 395.9 "Surging Tsunami" sync /:Leviathan:4011:/
 402.9 "Smothering Tsunami" sync /:Leviathan:3FD7:/
 408.8 "Splashing Tsunami" sync /:Leviathan:3FD6:/
 409.8 "Swirling Tsunami" sync /:Leviathan:3FD5:/
 416.8 "Surging Tsunami" sync /:Leviathan:4011:/
-429.4 "Temporary Current" sync /:Leviathan:3FC[DE]:/
-438.4 "Temporary Current" sync /:Leviathan:3FC[DE]:/
-449.4 "Rip Current" sync /:Leviathan:3FC6:/
-455.4 "Tidal Roar" sync /:Leviathan:3FC4:/ window 3,3
-461.4 "Tidal Roar" sync /:Leviathan:3FC4:/ window 3,3
+429.4 "Temporary Current 1" sync /:Leviathan:3FC[DE]:/
+438.4 "Temporary Current 2" sync /:Leviathan:3FC[DE]:/
+449.4 "Rip Current" sync /:Leviathan:3FC6:/ window 30,30
+455.4 "Tidal Roar" sync /:Leviathan:3FC4:/
+461.4 "Tidal Roar" sync /:Leviathan:3FC4:/
 
 476.4 "Maelstrom" sync /:Leviathan:3FD8:/ duration 30
 478.4 "--untargetable--"
 481.4 "--sync--" sync /:Leviathan:3F7E:/
-486.4 "Spinning Dive" sync /:Leviathan:3FDB:/
+486.4 "Spinning Dive 1" sync /:Leviathan:3FDB:/
 488.4 "--sync--" sync /:Leviathan:3F7E:/
-493.4 "Spinning Dive" sync /:Leviathan:3FDB:/
+493.4 "Spinning Dive 2" sync /:Leviathan:3FDB:/
 499.9 "--targetable--"
-507.9 "Tidal Roar" sync /:Leviathan:3FC4:/ window 3,3
-515.0 "Rip Current" sync /:Leviathan:3FC6:/
+507.9 "Tidal Roar" sync /:Leviathan:3FC4:/
+515.0 "Rip Current" sync /:Leviathan:3FC6:/ window 30,30
 536.4 "Tidal Wave" sync /:Leviathan:3FD3:/
 
 543.4 "Undersea Quake" sync /:Leviathan:3FCF:/ window 100,100 jump 283.8


### PR DESCRIPTION
I happened to get E3N in Mentor Roulette tonight, and I noticed that the Rip Current at 77.4 can be skipped. I made a change to account for that.

While I was at it, I added more and wider sync windows to better match modern practice. This should guarantee that the user won't be de-synced for too long. (Previously they would have had to wait until the second Undersea Quake for the timeline to catch up.)

Finally, I added numbers to Spinning Dive and Temporary Current. This better fits with modern expectations of "if it's different and close together, differentiate it a little in the text."