### PR TITLE
Fix issue with party tracker's members never clearing

### DIFF
--- a/resources/party.ts
+++ b/resources/party.ts
@@ -3,37 +3,21 @@ import { Job, Role } from '../types/job.js';
 import Util from './util';
 
 export default class PartyTracker {
-  details: Party[];
-  partyNames_: string[];
-  partyIds_: string[];
-  allianceNames_: string[];
-  allianceIds_: string[];
-  nameToRole_: Record<string, Role>;
-  idToName_: Record<string, string>;
-  roleToPartyNames_: Record<Role, string[]>;
-  constructor() {
-    this.onPartyChanged({ party: [] });
-
-    // original event data
-    this.details = [];
-    this.partyNames_ = [];
-    this.partyIds_ = [];
-    this.allianceNames_ = [];
-    this.allianceIds_ = [];
-    this.nameToRole_ = {};
-    this.idToName_ = {};
-
-    // role -> [names] but only for party
-    this.roleToPartyNames_ = {} as Record<Role, string[]>;
-    for (const role of Util.getAllRoles())
-      this.roleToPartyNames_[role] = [];
-  }
+  details: Party[] = [];
+  partyNames_: string[] = [];
+  partyIds_: string[] = [];
+  allianceNames_: string[] = [];
+  allianceIds_: string[] = [];
+  nameToRole_: Record<string, Role> = {};
+  idToName_: Record<string, string> = {};
+  roleToPartyNames_: Record<Role, string[]> = {} as Record<Role, string[]>;
 
   // Bind this to PartyChanged events.
   onPartyChanged(e: { party: Party[]}): void {
     if (!e || !e.party)
       return;
 
+    this.reset();
     this.details = e.party;
 
     for (const p of e.party) {
@@ -49,6 +33,22 @@ export default class PartyTracker {
         this.roleToPartyNames_[role].push(p.name);
       }
     }
+  }
+
+  reset(): void {
+    // original event data
+    this.details = [];
+    this.partyNames_ = [];
+    this.partyIds_ = [];
+    this.allianceNames_ = [];
+    this.allianceIds_ = [];
+    this.nameToRole_ = {};
+    this.idToName_ = {};
+
+    // role -> [names] but only for party
+    this.roleToPartyNames_ = {} as Record<Role, string[]>;
+    for (const role of Util.getAllRoles())
+      this.roleToPartyNames_[role] = [];
   }
 
   // returns an array of the names of players in your immediate party


### PR DESCRIPTION
As reported by Elestriel on Discord, since https://github.com/quisquous/cactbot/commit/707a44d5124812fc051c70179b43b5a1f65ca77e the party members aren't being cleared properly in PartyTracker when receiving an event.

This commit moves the defaults to the property definitions, removes the spurious call to onPartyChanged from the constructor, and moves the reset logic to its own specific function in case an external piece of code needs to invoke it.