### PR TITLE
Fix web worker for raidemulator loading over file:// URIs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9248,6 +9248,52 @@
       "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
       "dev": true
     },
+    "worker-loader": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/worker-loader/-/worker-loader-3.0.8.tgz",
+      "integrity": "sha512-XQyQkIFeRVC7f7uRhFdNMe/iJOdO6zxAaR3EWbDp45v3mDhrTi+++oswKNxShUNjPC/1xUp5DB29YKLhFo129g==",
+      "dev": true,
+      "requires": {
+        "loader-utils": "^2.0.0",
+        "schema-utils": "^3.0.0"
+      },
+      "dependencies": {
+        "ajv": {
+          "version": "6.12.6",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+          "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+          "dev": true,
+          "requires": {
+            "fast-deep-equal": "^3.1.1",
+            "fast-json-stable-stringify": "^2.0.0",
+            "json-schema-traverse": "^0.4.1",
+            "uri-js": "^4.2.2"
+          }
+        },
+        "loader-utils": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.0.tgz",
+          "integrity": "sha512-rP4F0h2RaWSvPEkD7BLDFQnvSf+nK+wr3ESUjNTyAGobqrijmW92zc+SO6d4p4B1wh7+B/Jg1mkQe5NYUEHtHQ==",
+          "dev": true,
+          "requires": {
+            "big.js": "^5.2.2",
+            "emojis-list": "^3.0.0",
+            "json5": "^2.1.2"
+          }
+        },
+        "schema-utils": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.0.0.tgz",
+          "integrity": "sha512-6D82/xSzO094ajanoOSbe4YvXWMfn2A//8Y1+MUqFAJul5Bs+yn36xbK9OtNDcRVSBJ9jjeoXftM6CfztsjOAA==",
+          "dev": true,
+          "requires": {
+            "@types/json-schema": "^7.0.6",
+            "ajv": "^6.12.5",
+            "ajv-keywords": "^3.5.2"
+          }
+        }
+      }
+    },
     "workerpool": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-6.1.0.tgz",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,8 @@
     "typescript": "^4.1.5",
     "webpack": "^5.11.0",
     "webpack-cli": "^3.3.12",
-    "webpack-dev-server": "^3.11.0"
+    "webpack-dev-server": "^3.11.0",
+    "worker-loader": "^3.0.8"
   },
   "engines": {
     "node": ">=14.15.0"

--- a/ui/raidboss/raidemulator.js
+++ b/ui/raidboss/raidemulator.js
@@ -18,6 +18,9 @@ import { TimelineLoader } from './timeline';
 import Tooltip from './emulator/ui/Tooltip';
 import UserConfig from '../../resources/user_config';
 import raidbossFileData from './data/manifest.txt';
+// eslint can't detect the custom loader for the worker
+// eslint-disable-next-line import/default
+import NetworkLogConverterWorker from './emulator/data/NetworkLogConverterWorker';
 
 // @TODO: Some way to not have this be a global?
 
@@ -65,7 +68,7 @@ const Options = {
     emulatedPartyInfo = new EmulatedPartyInfo(emulator);
     emulatedMap = new EmulatedMap(emulator);
     emulatedWebSocket = new RaidEmulatorOverlayApiHook(emulator);
-    logConverterWorker = new Worker('../../dist/raidemulatorWorker.bundle.js');
+    logConverterWorker = new NetworkLogConverterWorker();
 
     // Listen for the user to click a player in the party list on the right
     // and persist that over to the emulator

--- a/webpack/webpack.config.cjs
+++ b/webpack/webpack.config.cjs
@@ -17,7 +17,6 @@ module.exports = function(env, argv) {
       radar: './ui/radar/radar.js',
       raidboss: './ui/raidboss/raidboss.js',
       raidemulator: './ui/raidboss/raidemulator.js',
-      raidemulatorWorker: './ui/raidboss/emulator/data/NetworkLogConverterWorker.js',
       test: './ui/test/test.js',
     },
     optimization: {
@@ -47,6 +46,25 @@ module.exports = function(env, argv) {
     },
     module: {
       rules: [
+        {
+          // Worker has to go before normal js
+          test: /NetworkLogConverterWorker\.(?:c|m)?js$/,
+          loader: 'worker-loader',
+          options: {
+            esModule: true,
+            inline: 'fallback',
+            worker: {
+              type: 'Worker',
+              options: {
+                type: 'classic',
+                name: 'NetworkLogConverterWorker',
+              },
+            },
+          },
+          resolve: {
+            fullySpecified: false,
+          },
+        },
         {
           // this will allow importing without extension in js files.
           test: /\.m?js$/,


### PR DESCRIPTION
This PR fixes #2564 though the fix isn't that great. I added the `worker-loader` loader to npm/webpack and used that to load the worker, which resolves loading over file URI by automatically switching to a blob, but it makes the actual worker import code a bit ugly. Copy/pasting the comment for reference:

```js
// @TODO: For some reason this absolutely has to be imported as `Worker`, no matter what settings
// are specified in webpack.config.cjs
// Using `{ Worker as NetworkLogConverterWorker }` also fails for some reason.
// Using `{}` works for some reason too.
// eslint-disable-next-line import/default
import Worker from './emulator/data/NetworkLogConverterWorker';
```

The `Worker` portion of the import line also shows as an error in vscode and eslint without the ignore rule.

@quisquous I'm pretty iffy on this one, it feels like there should be a better way than this, but I can't see it. Maybe this'll be better once raidemulator is moved over to typescript (if that's in the plans in general).