### PR TITLE
raidboss: e12s oracle cataclysm callout

### DIFF
--- a/ui/raidboss/data/05-shb/raid/e12s.js
+++ b/ui/raidboss/data/05-shb/raid/e12s.js
@@ -989,8 +989,8 @@ export default {
         // select the Oracle Of Darkness with same source id
         let oracleData = null;
         oracleData = await window.callOverlayHandler({
-            call: 'getCombatants',
-            ids: [parseInt(matches.sourceId, 16)],
+          call: 'getCombatants',
+          ids: [parseInt(matches.sourceId, 16)],
         });
 
         // if we could not retrieve combatant data, the

--- a/ui/raidboss/data/05-shb/raid/e12s.js
+++ b/ui/raidboss/data/05-shb/raid/e12s.js
@@ -979,6 +979,81 @@ export default {
       },
     },
     {
+      id: 'E12S Oracle Cataclysm',
+      netRegex: NetRegexes.startsUsing({ source: 'Oracle Of Darkness', id: '58C2', capture: false }),
+      netRegexDe: NetRegexes.startsUsing({ source: 'Orakel Der Dunkelheit', id: '58C2', capture: false }),
+      netRegexFr: NetRegexes.startsUsing({ source: 'Prêtresse Des Ténèbres', id: '58C2', capture: false }),
+      netRegexJa: NetRegexes.startsUsing({ source: '闇の巫女', id: '58C2', capture: false }),
+      delaySeconds: 0.5,
+      promise: async (data, _, output) => {
+        const oracleLocaleNames = {
+          en: 'Oracle Of Darkness',
+          de: 'Orakel Der Dunkelheit',
+          fr: 'Prêtresse Des Ténèbres',
+          ja: '闇の巫女',
+        };
+
+        // select the Oracle Of Darkness
+        let combatantName = null;
+        combatantName = oracleLocaleNames[data.parserLang];
+
+        let combatantData = null;
+        if (combatantName) {
+          combatantData = await window.callOverlayHandler({
+            call: 'getCombatants',
+            names: [combatantName],
+          });
+        }
+
+        // if we could not retrieve combatant data, the
+        // trigger will not work, so just resume promise here
+        if (combatantData === null) {
+          console.error(`Oracle Of Darkness: null data`);
+          data.safeZone = null;
+          return;
+        }
+        if (!combatantData.combatants) {
+          console.error(`Oracle Of Darkness: null combatants`);
+          data.safeZone = null;
+          return;
+        }
+
+        // we need to filter for the Oracle Of Darkness with the highest ID
+        // as that one is the one that always casts Cataclysm
+        const combatant = combatantData.combatants.sort((a, b) => a.ID - b.ID).pop();
+
+        // Snap heading to closest card and add 2 for opposite direction
+        // N = 0, E = 1, S = 2, W = 3
+        const cardinal = ((2 - Math.round(combatant.Heading * 4 / Math.PI) / 2) + 2) % 4;
+
+        const dirs = {
+          0: output.north(),
+          1: output.east(),
+          2: output.south(),
+          3: output.west(),
+        };
+
+        data.safeZone = dirs[cardinal];
+      },
+      infoText: (data, _, output) => {
+        return !data.safeZone ? output.unknown() : data.safeZone;
+      },
+      outputStrings: {
+        unknown: {
+          en: '???',
+          de: '???',
+          fr: '???',
+          ja: '???',
+          cn: '???',
+          ko: '???',
+        },
+        north: Outputs.north,
+        east: Outputs.east,
+        south: Outputs.south,
+        west: Outputs.west,
+      },
+    },
+    {
       id: 'E12S Shell Crusher',
       netRegex: NetRegexes.startsUsing({ source: 'Oracle Of Darkness', id: '58C3', capture: false }),
       netRegexDe: NetRegexes.startsUsing({ source: 'Orakel Der Dunkelheit', id: '58C3', capture: false }),


### PR DESCRIPTION
Call out opposite direction of cataclysm, a bit more advanced than "getBehind".

I had tested getBehind early on in the tier, but never made a PR with it as ideally a cardinal would have been nicer to have. I will test this out later this week, I am unsure if delaySeconds 0.5 is enough.