### PR TITLE
eureka: KR v5.35 CE opcode

### DIFF
--- a/plugin/CactbotEventSource/FateWatcher.cs
+++ b/plugin/CactbotEventSource/FateWatcher.cs
@@ -55,6 +55,14 @@ namespace Cactbot {
     // CN
     // v5.35            0x144
     //
+    // KR
+    // v5.35            0x0347
+    //
+
+    private static readonly CEDirectorOPCodes cedirector_ko = new CEDirectorOPCodes(
+      0x30,
+      0x0347
+    );
 
     private static readonly CEDirectorOPCodes cedirector_cn = new CEDirectorOPCodes(
       0x30,
@@ -133,6 +141,7 @@ namespace Cactbot {
       ac143opcodes.Add("intl", ac143_v5_2);
 
       cedirectoropcodes = new Dictionary<string, CEDirectorOPCodes>();
+      cedirectoropcodes.Add("ko", cedirector_ko);
       cedirectoropcodes.Add("cn", cedirector_cn);
       cedirectoropcodes.Add("intl", cedirector_intl);
 

--- a/ui/eureka/eureka.js
+++ b/ui/eureka/eureka.js
@@ -154,7 +154,7 @@ const Options = {
       'gTimeRegex': Regexes.parse(/(.*) \((\d*)分(钟*)\)/),
     },
     ko: {
-      'gFlagRegex': Regexes.parse(/00:00(?:38:|..:[^:]*:)(.*)\ue0bb(에우레카: (?:아네모스|파고스|피로스|히다토스) 지대|남부 보즈야 전선) \( (\y{Float})\s*, (\y{Float}) \)(.*$)/),
+      'gFlagRegex': Regexes.parse(/00:00(?:38:|..:[^:]*:)(.*)\ue0bb(?:에우레카: (?:아네모스|파고스|피로스|히다토스) 지대|남부 보즈야 전선) \( (\y{Float})\s*, (\y{Float}) \)(.*$)/),
       'gTrackerRegex': Regexes.parse(/(?:https:\/\/)?ffxiv-eureka\.com\/([\w-]{6})(?:[^\w-]|$)/),
       'gImportRegex': Regexes.parse(/00:00..:(.*)토벌한 마물: (\S.*\))/),
       'gTimeRegex': Regexes.parse(/(.*) \((\d*)분\)/),

--- a/ui/eureka/eureka_config.js
+++ b/ui/eureka/eureka_config.js
@@ -91,7 +91,7 @@ UserConfig.registerOptions('eureka', {
         fr: 'Jouer un son pour l\'apparition des duels',
         ja: '一騎打ち通知機能を有効にする',
         cn: '一对一决斗出现时播放提示音',
-        ko: 'duels 알림 소리 켜기',
+        ko: '결투 알림 소리 켜기',
       },
       type: 'checkbox',
       default: false,


### PR DESCRIPTION
Fixes #2596

I finally found it, but I don't like the way I did.
I waited for CE spawn with watching my PC clock (with seconds), I saw two CE spawn at the same time - this was lucky.
The time was 20:45:54 and I wrote all the opcode logged on that timestamp.
```
0203
02D0
0204
02D0
02F0
02F0
0204
007C
007C
02D0
017A
02D0
017A
030E
02F0
02F0
02F0
02F0
02F0
007C
0204
0203
0204
017A
017A
0351
0204
030E
017A
0347
0347
0268
030E
02F0
...(many same opcode)
02F0
0203
0268
0204
0204
0203
0203
02F0
02F0
02F0
```
copied to spreadsheet and  did `=COUNTIF(S17:S73,0347)` thing.
The opcodes which logged twice were `0347` and `0268`.
I tried `0x0347` and built the project. yes... it worked well.

Is this the right way to find opcode? I guess there should be something better.