### PR TITLE
plugin: KR v5.35 CE opcode

### DIFF
--- a/plugin/CactbotEventSource/FateWatcher.cs
+++ b/plugin/CactbotEventSource/FateWatcher.cs
@@ -55,6 +55,14 @@ namespace Cactbot {
     // CN
     // v5.35            0x144
     //
+    // KR
+    // v5.35            0x0347
+    //
+
+    private static readonly CEDirectorOPCodes cedirector_ko = new CEDirectorOPCodes(
+      0x30,
+      0x0347
+    );
 
     private static readonly CEDirectorOPCodes cedirector_cn = new CEDirectorOPCodes(
       0x30,
@@ -133,6 +141,7 @@ namespace Cactbot {
       ac143opcodes.Add("intl", ac143_v5_2);
 
       cedirectoropcodes = new Dictionary<string, CEDirectorOPCodes>();
+      cedirectoropcodes.Add("ko", cedirector_ko);
       cedirectoropcodes.Add("cn", cedirector_cn);
       cedirectoropcodes.Add("intl", cedirector_intl);
 


### PR DESCRIPTION
Fixes #2596

I finally found it, but I don't like the way I did.
I waited for CE spawn with watching my PC clock (with seconds), I saw two CE spawn at the same time - this was lucky.
The time was 20:45:54 and I wrote all the opcode logged on that timestamp.
```
0203
02D0
0204
02D0
02F0
02F0
0204
007C
007C
02D0
017A
02D0
017A
030E
02F0
02F0
02F0
02F0
02F0
007C
0204
0203
0204
017A
017A
0351
0204
030E
017A
0347
0347
0268
030E
02F0
...(many same opcode)
02F0
0203
0268
0204
0204
0203
0203
02F0
02F0
02F0
```
copied to spreadsheet and  did `=COUNTIF(S17:S73,0347)` thing.
The opcodes which logged twice were `0347` and `0268`.
I tried `0x0347` and built the project. yes... it worked well.

![K-004](https://user-images.githubusercontent.com/4695371/111628840-fe887f00-8833-11eb-93b8-6ef26e2315c1.png)


Is this the right way to find opcode? I guess there should be something better.