### PR TITLE
raidemulator - Fix #2477 related to party events during encounter analysis

### DIFF
--- a/ui/raidboss/emulator/data/AnalyzedEncounter.js
+++ b/ui/raidboss/emulator/data/AnalyzedEncounter.js
@@ -20,12 +20,25 @@ export default class AnalyzedEncounter extends EventBus {
 
   selectPerspective(ID) {
     const partyMember = this.encounter.combatantTracker.combatants[ID];
+    this.popupText.partyTracker.onPartyChanged({
+      party: this.encounter.combatantTracker.partyMembers.map((ID) => {
+        return {
+          name: this.encounter.combatantTracker.combatants[ID].name,
+          job: Util.jobToJobEnum(this.encounter.combatantTracker.combatants[ID].job),
+          inParty: true,
+        };
+      }),
+    });
     this.popupText.OnPlayerChange({
       detail: {
         name: partyMember.name,
         job: partyMember.job,
         currentHP: partyMember.getState(this.encounter.logLines[0].timestamp).HP,
       },
+    });
+    this.popupText.OnChangeZone({
+      zoneName: this.encounter.encounterZoneName,
+      zoneID: parseInt(this.encounter.encounterZoneId, 16),
     });
   }
 

--- a/ui/raidboss/emulator/data/NetworkLogConverterWorker.js
+++ b/ui/raidboss/emulator/data/NetworkLogConverterWorker.js
@@ -31,7 +31,7 @@ onmessage = async (msg) => {
     nextOffset < buf.length && nextOffset !== -1;
     currentOffset = nextOffset) {
     nextOffset = buf.indexOf(0x0A, nextOffset + 1);
-    const line = decoder.decode(buf.slice(currentOffset + 1, nextOffset)).trim();
+    const line = decoder.decode(buf.slice(currentOffset, nextOffset)).trim();
     if (line.length) {
       ++lineCount;
       lines.push(line);


### PR DESCRIPTION
This PR fixes the bug in #2477 caused by party state not being updated per perspective change in AnalyzedEncounter.
Also fixes a bug that was found during investigating the issue, where import code skipped the first line of the imported log file.