### PR TITLE
raidemulator - Implement timelineTriggers support

### DIFF
--- a/ui/raidboss/emulator/data/AnalyzedEncounter.js
+++ b/ui/raidboss/emulator/data/AnalyzedEncounter.js
@@ -52,6 +52,7 @@ export default class AnalyzedEncounter extends EventBus {
   }
 
   async analyzeFor(ID) {
+    let currentLogIndex = 0;
     const partyMember = this.encounter.combatantTracker.combatants[ID];
 
     if (!partyMember.job) {
@@ -65,8 +66,10 @@ export default class AnalyzedEncounter extends EventBus {
     const timelineUI = new RaidEmulatorTimelineUI(this.options);
     const timelineController =
         new RaidEmulatorTimelineController(this.options, timelineUI, raidbossFileData);
+    timelineController.bindTo(this.emulator);
     const popupText = new PopupTextAnalysis(
         this.popupText.options, new TimelineLoader(timelineController), raidbossFileData);
+    timelineUI.popupText = popupText;
 
     timelineController.SetPopupTextInterface(new PopupTextGenerator(popupText));
 
@@ -91,6 +94,32 @@ export default class AnalyzedEncounter extends EventBus {
       zoneID: parseInt(this.encounter.encounterZoneId, 16),
     });
 
+    timelineController.activeTimeline.SetTrigger(async (trigger, matches) => {
+      // Some async magic here, force waiting for the entirety of
+      // the trigger execution before continuing
+      const delayPromise = new Promise((res) => {
+        popupText.delayResolver = res;
+      });
+      const promisePromise = new Promise((res) => {
+        popupText.promiseResolver = res;
+      });
+      const runPromise = new Promise((res) => {
+        popupText.runResolver = res;
+      });
+
+      popupText.OnTrigger(trigger, matches);
+
+      await delayPromise;
+      await promisePromise;
+      const triggerHelper = await runPromise;
+
+      popupText.currentTriggerStatus.finalData = EmulatorCommon.cloneData(popupText.data);
+
+      popupText.callback(
+          this.encounter.logLines[currentLogIndex],
+          triggerHelper, popupText.currentTriggerStatus);
+    });
+
     popupText.callback = (log, triggerHelper, currentTriggerStatus, finalData) => {
       this.perspectives[ID].triggers.push({
         triggerHelper: triggerHelper,
@@ -107,7 +136,8 @@ export default class AnalyzedEncounter extends EventBus {
       finalData: popupText.data,
     };
 
-    for (const log of this.encounter.logLines) {
+    for (; currentLogIndex < this.encounter.logLines.length; ++currentLogIndex) {
+      const log = this.encounter.logLines[currentLogIndex];
       await this.dispatch('analyzeLine', log);
 
       if (this.encounter.combatantTracker.combatants[ID].hasState(log.timestamp)) {
@@ -128,6 +158,8 @@ export default class AnalyzedEncounter extends EventBus {
 
       await popupText.OnLog(event);
       await popupText.OnNetLog(event);
+      timelineController.OnLogEvent(event);
     }
+    timelineUI.stop();
   }
 }

--- a/ui/raidboss/emulator/overrides/RaidEmulatorTimelineController.js
+++ b/ui/raidboss/emulator/overrides/RaidEmulatorTimelineController.js
@@ -43,7 +43,11 @@ export default class RaidEmulatorTimelineController extends TimelineController {
     e.detail.logs.forEach((line) => {
       this.activeTimeline.emulatedTimeOffset = line.offset;
       this.ui.emulatedTimeOffset = line.offset;
-      this.activeTimeline.OnLogLine(line.properCaseConvertedLine || line.convertedLine);
+      this.activeTimeline.timebase = this.activeTimeline.timebase || line.timestamp;
+      this.activeTimeline.OnLogLine(
+          line.properCaseConvertedLine || line.convertedLine,
+          line.timestamp);
+      this.activeTimeline._OnUpdateTimer(line.timestamp);
     });
   }
 }

--- a/ui/raidboss/emulator/overrides/RaidEmulatorTimelineUI.js
+++ b/ui/raidboss/emulator/overrides/RaidEmulatorTimelineUI.js
@@ -25,7 +25,7 @@ export default class RaidEmulatorTimelineUI extends TimelineUI {
       this.emulatedTimerBars = this.emulatedTimerBars.filter((bar) => {
         return bar.forceRemoveAt > timestampOffset;
       });
-      this.timeline && this.timeline.timebase && this.timeline._OnUpdateTimer();
+      this.timeline && this.timeline.timebase && this.timeline._OnUpdateTimer(lastLogTimestamp);
     });
     emulator.on('play', () => {
       this.emulatedStatus = 'play';
@@ -54,15 +54,17 @@ export default class RaidEmulatorTimelineUI extends TimelineUI {
         this.updateBar(bar, time);
       }
     });
-    emulator.on('currentEncounterChanged', () => {
-      this.timeline && this.timeline.Stop();
-      this.emulatedTimeOffset = 0;
-      for (const i in this.emulatedTimerBars) {
-        const bar = this.emulatedTimerBars[i];
-        bar.$progress.remove();
-      }
-      this.emulatedTimerBars = [];
-    });
+    emulator.on('currentEncounterChanged', this.stop.bind(this));
+  }
+
+  stop() {
+    this.timeline && this.timeline.Stop();
+    this.emulatedTimeOffset = 0;
+    for (const i in this.emulatedTimerBars) {
+      const bar = this.emulatedTimerBars[i];
+      bar.$progress.remove();
+    }
+    this.emulatedTimerBars = [];
   }
 
   updateBar(bar, timestampOffset) {


### PR DESCRIPTION
This PR fixes #2504 by supporting `timelineTriggers` during encounter analysis.

This is a first pass. It's functional but causes a lot of DOM updates (due to the timeline events actually firing during analysis) which makes the initial encounter load slightly slower.

I'm not sure if it's worth the effort of fixing this, I can barely tell a difference on my hardware so I'd prefer if someone with slower hardware can test and let me know how much the performance impact is vs the current `main` code.