### PR TITLE
Fix find_missing_translations.js Regex

### DIFF
--- a/util/find_missing_translations.js
+++ b/util/find_missing_translations.js
@@ -87,8 +87,8 @@ const parseJavascriptFile = (file, locales) => {
   let keys = [];
   let openMatch = null;
 
-  const openObjRe = new RegExp('(\\s*)(.*{)\\s*$');
-  const keyRe = new RegExp('\\s*(\\w{2}):');
+  const openObjRe = new RegExp('^(\\s*)(.*{)\\s*$');
+  const keyRe = new RegExp('^\\s*(\\w{2}):');
 
   lineReader.on('line', (line, idx = lineCounter()) => {
     // Immediately exit if the file is auto-generated


### PR DESCRIPTION
Make regex within the JavaScript version of find_missing_translations
more accurately match the Python version.