### PR TITLE
Revert "refactor(resources): migrate WidgetList to TypeScript"

### DIFF
--- a/resources/widgetlist.js
+++ b/resources/widgetlist.js
@@ -1,40 +1,17 @@
 // NOTE
 // This class should be considered deprecated, and any users of this class should
 // just switch over to using CSS grid.
-type Sorter = () => number;
 
-const getRandomInt = function(max: number) {
-  return Math.floor(Math.random() * Math.floor(max));
-};
-
-export default class WidgetList extends HTMLElement {
-  private _nextId = 1;
-  private _nameToId: { [key: string]: number } = {};
-  private _elements: { [key: number]: Sorter } = {};
-  private _sorted: number[] = [];
-  private _elementwidth = 100;
-  private _elementheight = 100;
-  private _xinc1 = 1;
-  private _xinc2 = 0;
-  private _yinc1 = 0;
-  private _yinc2 = 1;
-  private _rowcolsize = 5;
-  private _maxnumber = 1000;
-  private _connected = false;
-  private rootElement: HTMLElement;
-
-  static get observedAttributes(): string[] {
+class WidgetList extends HTMLElement {
+  static get observedAttributes() {
     return ['toward', 'elementwidth', 'elementheight', 'rowcolsize', 'maxnumber'];
   }
 
   // All visual dimensions are scaled by this.
-  set scale(s: string | null) {
-    if (s === null)
-      this.removeAttribute('scale');
-    else
-      this.setAttribute('scale', s);
+  set scale(s) {
+    this.setAttribute('scale', s);
   }
-  get scale(): string | null {
+  get scale() {
     return this.getAttribute('scale');
   }
 
@@ -44,58 +21,43 @@ export default class WidgetList extends HTMLElement {
   // and the second being the direction is wraps for the next
   // row/column. eg. "left down" will grow a list toward the left,
   // and subsequent rows will be below the first.
-  set toward(s: string | null) {
-    if (s === null)
-      this.removeAttribute('toward');
-    else
-      this.setAttribute('toward', s);
+  set toward(s) {
+    this.setAttribute('toward', s);
   }
-  get toward(): string | null {
+  get toward() {
     return this.getAttribute('toward');
   }
 
   // The elementwidth of each element in the list.
-  set elementwidth(w: string | null) {
-    if (w === null)
-      this.removeAttribute('elementwidth');
-    else
-      this.setAttribute('elementwidth', w);
+  set elementwidth(w) {
+    this.setAttribute('elementwidth', w);
   }
-  get elementwidth(): string | null {
+  get elementwidth() {
     return this.getAttribute('elementwidth');
   }
 
   // The height of each element in the list.
-  set elementheight(w: string | null) {
-    if (w === null)
-      this.removeAttribute('elementheight');
-    else
-      this.setAttribute('elementheight', w);
+  set elementheight(w) {
+    this.setAttribute('elementheight', w);
   }
-  get elementheight(): string | null {
+  get elementheight() {
     return this.getAttribute('elementheight');
   }
 
   // The number of elements to show before wrapping to a new
   // row/column.
-  set rowcolsize(w: string | null) {
-    if (w === null)
-      this.removeAttribute('rowcolsize');
-    else
-      this.setAttribute('rowcolsize', w);
+  set rowcolsize(w) {
+    this.setAttribute('rowcolsize', w);
   }
-  get rowcolsize(): string | null {
+  get rowcolsize() {
     return this.getAttribute('rowcolsize');
   }
 
   // The maximum number of widgets to show at a time.
-  set maxnumber(w: string | null) {
-    if (w === null)
-      this.removeAttribute('maxnumber');
-    else
-      this.setAttribute('maxnumber', w);
+  set maxnumber(w) {
+    this.setAttribute('maxnumber', w);
   }
-  get maxnumber(): string | null {
+  get maxnumber() {
     return this.getAttribute('maxnumber');
   }
 
@@ -103,26 +65,71 @@ export default class WidgetList extends HTMLElement {
   constructor() {
     super();
     const root = this.attachShadow({ mode: 'open' });
+    this.init(root);
+  }
+
+  // These would be used by document.registerElement, which is deprecated but
+  // ACT uses an old CEF which has this instead of the newer APIs.
+  createdCallback() {
+    const root = this.createShadowRoot();
+    this.init(root);
+  }
+  // Convert from the deprecated API names to the modern API names.
+  attachedCallback() {
+    this.connectedCallback();
+  }
+  detachedCallback() {
+    this.disconnectedCallback();
+  }
+
+  init(root) {
     root.innerHTML = `
       <div id="root" style="position: relative"></div>
     `;
 
-    if (this.shadowRoot === null)
-      throw new Error('shadowRoot of widget-list is null');
+    this._nextId = 1;
+    this._nameToId = {};
+    this._elements = {};
+    this._sorted = [];
 
-    this.rootElement = this.shadowRoot.getElementById('root') as HTMLElement;
+    this.rootElement = this.shadowRoot.getElementById('root');
   }
 
-  connectedCallback(): void {
+  connectedCallback() {
+    // Default values.
+    this._scale = 1;
+    this._elementwidth = 100;
+    this._elementheight = 100;
+    this._rowcolsize = 5;
+    this._maxnumber = 1000;
+    // Multiplier how far to move X for each item.
+    this._xinc1 = 1;
+    // Multiplier how far to move Y for each item.
+    this._yinc1 = 0;
+    // When reaching rowcolsize, multiplier to move X to
+    // reach the next row/column.
+    this._xinc2 = 0;
+    // When reaching rowcolsize, multiplier to move Y to
+    // reach the next row/column.
+    this._yinc2 = 1;
+
+    if (this.scale !== null) this._scale = Math.max(parseFloat(this.scale), 0.01);
+    if (this.elementwidth !== null) this._elementwidth = Math.max(parseInt(this.elementwidth), 1);
+    if (this.elementheight !== null)
+      this._elementheight = Math.max(parseInt(this.elementheight), 1);
+    if (this.rowcolsize !== null) this._rowcolsize = Math.max(parseInt(this.rowcolsize), 1);
+    if (this.toward !== null) this.parseToward(this.toward);
+    if (this.maxnumber !== null) this._maxnumber = Math.max(parseInt(this.maxnumber), 1);
+
     this._connected = true;
     this.layout();
   }
 
-  disconnectedCallback(): void {
+  disconnectedCallback() {
     this._connected = false;
   }
 
-  parseToward(toward: string): void {
+  parseToward(toward) {
     const t = toward.split(' ');
     if (t.length !== 2) {
       console.log('widget-list: Invalid toward format');
@@ -192,7 +199,7 @@ export default class WidgetList extends HTMLElement {
     this._yinc2 = y2inc;
   }
 
-  attributeChangedCallback(name: string, _: string, newValue: string): void {
+  attributeChangedCallback(name, oldValue, newValue) {
     if (name === 'toward') {
       this.parseToward(newValue);
       this.layout();
@@ -211,7 +218,7 @@ export default class WidgetList extends HTMLElement {
     }
   }
 
-  addElement(name: string, element: HTMLElement, sortKey: number | Sorter): void {
+  addElement(name, element, sortKey) {
     const id = this._nextId;
     this._nextId = this._nextId + 1;
 
@@ -231,75 +238,79 @@ export default class WidgetList extends HTMLElement {
     this._nameToId[name] = id;
     this._elements[id] = sortKeyFn;
     this._sorted.push(id);
+    const that = this;
     this._sorted.sort((a, b) => {
-      return (this._elements[a]?.() ?? 0) - (this._elements[b]?.() ?? 0);
+      return that._elements[a]() - that._elements[b]();
     });
 
     element.style.position = 'relative';
-    element.style.left = element.style.top = '0';
+    element.style.left = element.style.top = 0;
 
     const container = document.createElement('div');
     container.appendChild(element);
-    container.id = `child${id}`;
+    container.id = 'child' + id;
 
     this.rootElement.appendChild(container);
 
     this.layout();
   }
 
-  removeElement(name: string): ChildNode | undefined {
+  removeElement(name) {
     const id = this._nameToId[name];
     if (!id)
       return;
-    const container = this.shadowRoot?.getElementById(`child${id}`);
-    if (container !== null && container !== undefined) {
-      const element = container.childNodes[0];
-      this.rootElement.removeChild(container);
-      return element;
+    const container = this.shadowRoot.getElementById('child' + id);
+    const element = container.childNodes[0];
+    this.rootElement.removeChild(container);
+
+    delete this._nameToId[name];
+    delete this._elements[id];
+    for (const i in this._sorted) {
+      if (this._sorted[i] === id) {
+        this._sorted.splice(i, 1);
+        break;
+      }
     }
-    return;
+
+    this.layout();
+    return element;
   }
 
-  clear(): void {
+  clear() {
     for (const name in this._nameToId)
       this.removeElement(name);
   }
 
-  layout(): void {
+  layout() {
     if (!this._connected)
       return;
 
-    this.rootElement.style.width = String(this._rowcolsize * this._elementwidth);
-    this.rootElement.style.height = String(this._rowcolsize * this._elementheight);
+    this.rootElement.style.width = this._rowcolsize * this._elementwidth;
+    this.rootElement.style.height = this._rowcolsize * this._elementheight;
 
     let x = this._xinc1 < 0 ? -this._elementwidth : 0;
     let y = this._yinc1 < 0 ? -this._elementheight : 0;
     let rowcolindex = 0;
     let count = 0;
 
-    this._sorted.forEach((id: number) => {
-      if (id === 0) {
-        console.error('An id in _sorted isn\'t in _elements?');
-        return;
-      }
-      const container = this.shadowRoot?.getElementById(`child${id}`);
-      if (container === null || container === undefined) {
-        console.error(`Element with id child${id} is missing?`);
-        return;
-      }
+    for (const i in this._sorted) {
+      const id = this._sorted[i];
+      console.assert(id !== 0, 'An id in _sorted isn\'t in _elements?');
+      const container = this.shadowRoot.getElementById('child' + id);
+      console.assert(container !== null, 'Element with id child' + id + ' is missing?');
 
       if (count >= this._maxnumber) {
         container.style.display = 'none';
-        return;
+        continue;
+      } else {
+        container.style.display = 'block';
       }
-      container.style.display = 'block';
-
 
       count++;
 
       container.style.position = 'absolute';
-      container.style.left = String(x);
-      container.style.top = String(y);
+      container.style.left = x;
+      container.style.top = y;
 
       x = x + (this._xinc1 * this._elementwidth);
       y = y + (this._yinc1 * this._elementheight);
@@ -311,26 +322,35 @@ export default class WidgetList extends HTMLElement {
         y = y + (this._yinc2 * this._elementheight);
         rowcolindex = 0;
       }
-    });
+    }
   }
 
-  test(): void {
+  test() {
     for (let i = 0; i < 8; ++i) {
       const div = document.createElement('div');
-      div.style.width = String(this._elementwidth * 3 / 4);
-      div.style.height = String(this._elementheight * 3 / 4);
+      div.style.width = this._elementwidth * 3 / 4;
+      div.style.height = this._elementheight * 3 / 4;
       div.style.overflow = 'hidden';
-      div.style.backgroundColor = `#${getRandomInt(9)}${getRandomInt(9)}${getRandomInt(9)}`;
+      div.style.backgroundColor = '#' + parseInt(Math.random() * 10) + '' + parseInt(Math.random() * 10) + '' + parseInt(Math.random() * 10);
       div.style.textAlign = 'center';
       div.style.fontFamily = 'arial';
-      div.style.fontSize = String(this._elementheight / 6);
+      div.style.fontSize = this._elementheight / 6;
       div.style.fontWeight = 'bold';
       div.style.color = 'white';
       div.style.textShadow = '-1px 0 3px black, 0 1px 3px black, 1px 0 3px black, 0 -1px 3px black';
-      div.innerHTML = `<br/>${i + 1}`;
-      this.addElement(`test${i}`, div, () => 0);
+      div.innerHTML = '<br/>' + (i + 1);
+      this.addElement('test' + i, div, () => {
+        0;
+      });
     }
   }
 }
 
-window.customElements.define('widget-list', WidgetList);
+if (window.customElements) {
+  // Preferred method but old CEF doesn't have this.
+  window.customElements.define('widget-list', WidgetList);
+} else {
+  document.registerElement('widget-list', {
+    prototype: Object.create(WidgetList.prototype),
+  });
+}

--- a/ui/jobs/jobs.js
+++ b/ui/jobs/jobs.js
@@ -17,7 +17,7 @@ import '../../resources/resourcebar';
 import '../../resources/timerbar';
 import '../../resources/timerbox';
 import '../../resources/timericon';
-import '../../resources/widget_list';
+import '../../resources/widgetlist';
 
 // See user/jobs-example.js for documentation.
 const Options = {


### PR DESCRIPTION
Reverts quisquous/cactbot#2532

@Trim21 I'm sorry to revert this, but this patch was causing all of my overlays to run with extreme lag.  Normally I wouldn't revert and would just fix, but I think this is a pretty bad bug.  My jobs overlay would print `BrowserConsole: Element with id child20 is missing? (Source: http://localhost:8080/dist/jobs.bundle.js, Line: 10214)` many times a second.  When I reverted this patch locally it stopped happening, so I feel pretty confident that this is the issue.