### PR TITLE
raidemulator - Rework the way analyzed triggers are displayed

### DIFF
--- a/ui/raidboss/emulator/data/PopupTextAnalysis.js
+++ b/ui/raidboss/emulator/data/PopupTextAnalysis.js
@@ -167,7 +167,6 @@ export default class PopupTextAnalysis extends StubbedPopupText {
   _onTriggerInternalResponse(triggerHelper) {
     this.currentFunction = '_onTriggerInternalResponse';
     super._onTriggerInternalResponse(triggerHelper);
-    this.currentTriggerStatus.response = triggerHelper.response;
   }
 
   _onTriggerInternalAlarmText(triggerHelper) {
@@ -188,6 +187,11 @@ export default class PopupTextAnalysis extends StubbedPopupText {
   _onTriggerInternalTTS(triggerHelper) {
     this.currentFunction = '_onTriggerInternalTTS';
     super._onTriggerInternalTTS(triggerHelper);
+    if (triggerHelper.ttsText !== undefined &&
+      this.currentTriggerStatus.responseType === undefined) {
+      this.currentTriggerStatus.responseType = 'tts';
+      this.currentTriggerStatus.responseLabel = triggerHelper.ttsText;
+    }
   }
 
   _onTriggerInternalPlayAudio(triggerHelper) {
@@ -208,11 +212,28 @@ export default class PopupTextAnalysis extends StubbedPopupText {
   }
 
   _createTextFor(text, textType, lowerTextKey, duration) {
-    // No-op
+    // No-op for functionality, but store off this info for feedback
+    this.currentTriggerStatus.responseType = textType;
+    this.currentTriggerStatus.responseLabel = text;
   }
 
   _playAudioFile(url, volume) {
-    // No-op
+    // No-op for functionality, but store off this info for feedback
+
+    // If we already have text and this is a default alert sound, don't override that info
+    if (this.currentTriggerStatus.responseType) {
+      if (this.currentTriggerStatus.responseType === 'info' &&
+          url === this.options.InfoSound)
+        return;
+      if (this.currentTriggerStatus.responseType === 'alert' &&
+          url === this.options.AlertSound)
+        return;
+      if (this.currentTriggerStatus.responseType === 'alarm' &&
+          url === this.options.AlarmSound)
+        return;
+    }
+    this.currentTriggerStatus.responseType = 'audiofile';
+    this.currentTriggerStatus.responseLabel = url;
   }
 
   _scheduleRemoveText(container, e, delay) {

--- a/ui/raidboss/raidemulator.css
+++ b/ui/raidboss/raidemulator.css
@@ -153,11 +153,12 @@ body {
 }
 
 .triggerInfoColumn .triggerHideSkippedContainer {
-  position: absolute;
-  top: 0;
-  right: 0;
-  width: 1rem;
-  height: 1rem;
+  float: left;
+}
+
+.triggerInfoColumn .triggerHideCollectorContainer {
+  float: left;
+  padding-left: 5px;
 }
 
 .progress-bar {
@@ -549,18 +550,96 @@ div.row.encountersRow {
   padding-bottom: 0.5rem;
 }
 
-.wrap-collapse .wrap-collapse-button .trigger-label {
+.wrap-collapse .wrap-collapse-button .btn {
+  width: 100%;
+}
+
+.wrap-collapse .wrap-collapse-button .btn.btn-outline-light:hover {
+  background-color: #f8f9fa80;
+}
+
+.wrap-collapse .wrap-collapse-button .trigger-label .trigger-label-time,
+.wrap-collapse .wrap-collapse-button .trigger-label .trigger-label-name {
+  float: left;
+}
+
+.wrap-collapse .wrap-collapse-button .trigger-label .trigger-label-icon,
+.wrap-collapse .wrap-collapse-button .trigger-label .trigger-label-text {
   float: right;
-  height: 31px;
-  line-height: 31px;
+}
+
+.wrap-collapse .wrap-collapse-button .trigger-label .fa {
+  line-height: 2rem;
+  width: 1em;
 }
 
 .wrap-collapse .wrap-collapse-button .trigger-label > * {
-  float: right;
+  float: left;
+  padding-right: 0.5rem;
 }
 
-.wrap-collapse .wrap-collapse-button .trigger-label .trigger-label-time {
+.wrap-collapse .wrap-collapse-button .trigger-label > div {
+  line-height: 2rem;
+  height: 2rem;
+  margin: -4px 0;
+}
+
+.wrap-collapse .wrap-collapse-button .trigger-label > div + div {
   padding-left: 0.5rem;
+}
+
+.wrap-collapse .wrap-collapse-button .trigger-label .trigger-label-icon {
+  padding-right: 0;
+}
+
+.wrap-collapse .wrap-collapse-button .btn,
+.wrap-collapse .wrap-collapse-button .btn.triggertype-data {
+  border-color: white;
+}
+
+.wrap-collapse .wrap-collapse-button .btn .trigger-label > div + div,
+.wrap-collapse .wrap-collapse-button .btn.triggertype-data .trigger-label > div + div {
+  border-left: 1px solid white;
+}
+
+.wrap-collapse .wrap-collapse-button .btn.triggertype-info {
+  border-color: #2b2;
+}
+
+.wrap-collapse .wrap-collapse-button .btn.triggertype-info .trigger-label > div + div {
+  border-left: 1px solid #2b2;
+}
+
+.wrap-collapse .wrap-collapse-button .btn.triggertype-alert {
+  border-color: #fb0;
+}
+
+.wrap-collapse .wrap-collapse-button .btn.triggertype-alert .trigger-label > div + div {
+  border-left: 1px solid #fb0;
+}
+
+.wrap-collapse .wrap-collapse-button .btn.triggertype-alarm {
+  border-color: #f30;
+}
+
+.wrap-collapse .wrap-collapse-button .btn.triggertype-alarm .trigger-label > div + div {
+  border-left: 1px solid #f30;
+}
+
+.wrap-collapse .wrap-collapse-button .btn.triggertype-tts {
+  border-color: whitesmoke;
+}
+
+.wrap-collapse .wrap-collapse-button .btn.triggertype-tts .trigger-label > div + div {
+  border-left: 1px solid whitesmoke;
+}
+
+.wrap-collapse .wrap-collapse-button .btn.triggertype-audiofile {
+  border-color: blue;
+}
+
+.wrap-collapse .wrap-collapse-button .btn.triggertype-audiofile .trigger-label > div + div {
+  border-left: 1px solid blue;
 }
 
 div.templates,

--- a/ui/raidboss/raidemulator.html
+++ b/ui/raidboss/raidemulator.html
@@ -152,8 +152,16 @@
           </div>
         </div>
         <div class="col-5 triggerInfoColumn border-dark border-left border-right">
-          <div class="triggerHideSkippedContainer" data-toggle="tooltip" title="Hide triggers that were not executed">
-            <input type="checkbox" name="hideSkipped" class="triggerHideSkipped" checked="checked">
+          <div class="triggerCheckboxes">
+            <div class="triggerHideSkippedContainer" data-toggle="tooltip" title="Hide triggers that were not executed">
+              <input type="checkbox" name="hideSkipped" class="triggerHideSkipped" checked="checked" id="hideSkipped">
+              <label for="hideSkipped">Hide Skipped</label>
+            </div>
+            <div class="triggerHideCollectorContainer" data-toggle="tooltip" title="Hide triggers that had no output">
+              <input type="checkbox" name="hideCollector" class="triggerHideCollector" checked="checked" id="hideCollector">
+              <label for="hideCollector">Hide Collectors</label>
+            </div>
+            <div style="clear: both"></div>
           </div>
         </div>
         <div class="col-2 partyInfoColumn">
@@ -248,15 +256,18 @@
         <pre class="json-viewer"></pre>
       </template>
       <template class="triggerLabel">
-        <div class="trigger-label">
-          <div class="trigger-label-time"></div>
-          <div class="trigger-label-text"></div>
-        </div>
       </template>
       <template class="wrapCollapse">
         <div class="wrap-collapse">
           <div class="wrap-collapse-button">
-            <button class="btn btn-outline-light btn-sm text-white" type="button"></button>
+            <button class="btn btn-outline-light btn-sm text-white" type="button">
+              <div class="trigger-label">
+                <div class="trigger-label-time"></div>
+                <div class="trigger-label-name"></div>
+                <div class="trigger-label-icon"></div>
+                <div class="trigger-label-text"></div>
+              </div>
+            </button>
           </div>
           <div class="wrap-collapse-wrapper d-none"></div>
         </div>

--- a/ui/raidboss/raidemulator.js
+++ b/ui/raidboss/raidemulator.js
@@ -22,30 +22,7 @@ import raidbossFileData from './data/manifest.txt';
 // eslint-disable-next-line import/default
 import NetworkLogConverterWorker from './emulator/data/NetworkLogConverterWorker';
 
-// @TODO: Some way to not have this be a global?
-
-// See user/raidboss-example.js for documentation.
-const Options = {
-  // These options are ones that are not auto-defined by raidboss_config.js.
-  PlayerNicks: {},
-
-  InfoSound: '../../resources/sounds/freesound/percussion_hit.ogg',
-  AlertSound: '../../resources/sounds/BigWigs/Alert.ogg',
-  AlarmSound: '../../resources/sounds/BigWigs/Alarm.ogg',
-  LongSound: '../../resources/sounds/BigWigs/Long.ogg',
-  PullSound: '../../resources/sounds/freesound/sonar.ogg',
-
-  audioAllowed: true,
-
-  DisabledTriggers: {},
-
-  PerTriggerOptions: {},
-
-  Triggers: [],
-
-  PlayerNameOverride: null,
-  PlayerJobOverride: null,
-};
+import Options from './raidboss_options';
 
 (() => {
   let emulator;


### PR DESCRIPTION
This PR reworks the way analyzed triggers are displayed in raidemulator to make it more obvious at a glance what various triggers do.

This PR also adds an additional checkbox to the trigger display to hide "collector" triggers, e.g. triggers that ran but produced no user-visible output.

Here's an example screenshot:

![image](https://user-images.githubusercontent.com/6119598/113344484-216c6600-92ff-11eb-8ce7-9063e418480f.png)
