### PR TITLE
output fr minor correction

### DIFF
--- a/resources/outputs.ts
+++ b/resources/outputs.ts
@@ -432,7 +432,7 @@ export default {
   stunTarget: {
     en: 'Stun ${name}',
     de: 'Betäubung auf ${name}',
-    fr: 'Étourdissement sur ${name}',
+    fr: 'Étourdissez ${name}',
     ja: '${name} にスタン',
     cn: '眩晕 ${name}',
     ko: '${name}기절',


### PR DESCRIPTION
I had not seen that it was the adjective and not the conjugate form, this which distorts the indication. I replace by the form conjugate to make the indication correct and understandable.