### PR TITLE
typescript: remove tsconfig noImplicitReturns

### DIFF
--- a/resources/party.ts
+++ b/resources/party.ts
@@ -121,7 +121,6 @@ export default class PartyTracker {
       return names[1];
     if (names[1] === name)
       return names[0];
-    return;
   }
 
   // see: otherTank, but for healers.
@@ -133,7 +132,6 @@ export default class PartyTracker {
       return names[1];
     if (names[1] === name)
       return names[0];
-    return;
   }
 
   // returns the job name of the specified party member
@@ -141,7 +139,6 @@ export default class PartyTracker {
     const partyIndex = this.partyNames.indexOf(name);
     if (partyIndex >= 0)
       return Util.jobEnumToJob(this.details[partyIndex]?.job as number);
-    return;
   }
 
   nameFromId(id: string): string | undefined {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -27,7 +27,6 @@
     "alwaysStrict": true,
     "noUnusedLocals": true,
     "noUnusedParameters": false,
-    "noImplicitReturns": true,
     "noFallthroughCasesInSwitch": true,
     "noUncheckedIndexedAccess": true,
     //    "noPropertyAccessFromIndexSignature": false, // used by trigger output strings


### PR DESCRIPTION
When functions have return types, TypeScript already handles the case
where a function cannot have an undefined return type, implicit or
explicit.

I think it noisy to have to add a `return;` at the end of a function
that can return undefined as a type.  This will especially be the
case for triggers, which use implicit return undefined as a way
to not output things in many trigger functions.

Turning this off for now will help make that conversion easier.
If this creates an issue, then once everything has turned into
TypeScript we can revisit and turn it back on.