### PR TITLE
Fix recursion error from overlay_plugin_api.ts

### DIFF
--- a/ui/raidboss/emulator/overrides/RaidEmulatorOverlayApiHook.js
+++ b/ui/raidboss/emulator/overrides/RaidEmulatorOverlayApiHook.js
@@ -1,20 +1,10 @@
-import { callOverlayHandler, addOverlayListener, removeOverlayListener, setOverride } from '../../../../resources/overlay_plugin_api';
+import { callOverlayHandler, addOverlayListener, removeOverlayListener, setCallOverlayHandlerOverride } from '../../../../resources/overlay_plugin_api';
 
 export default class RaidEmulatorOverlayApiHook {
   constructor(emulator) {
     this.emulator = emulator;
-    this.originalDispatch = window.dispatchOverlayEvent;
-    this.originalAdd = addOverlayListener;
-    this.originalRemove = removeOverlayListener;
-    this.originalCall = callOverlayHandler;
+    this.originalCall = setCallOverlayHandlerOverride(this.call.bind(this)),
     this.timestampOffset = 0;
-
-    setOverride({
-      addOverlayListenerOverride: this.add.bind(this),
-      removeOverlayListenerOverride: this.remove.bind(this),
-      callOverlayHandlerOverride: this.call.bind(this),
-      dispatchOverlayEventOverride: this.dispatch.bind(this),
-    });
 
     emulator.on('tick', (timestampOffset) => {
       this.timestampOffset = timestampOffset;
@@ -28,18 +18,6 @@ export default class RaidEmulatorOverlayApiHook {
         this.timestampOffset = log.offset;
       });
     });
-  }
-
-  dispatch(msg) {
-    return this.originalDispatch(msg);
-  }
-
-  add(event, cb) {
-    return this.originalAdd(event, cb);
-  }
-
-  remove(event, cb) {
-    return this.originalRemove(event, cb);
   }
 
   call(msg) {


### PR DESCRIPTION
After #2611, the raid emulator enters infinite recursion.
```
overlay_plugin_api.ts:97 Uncaught (in promise) RangeError: Maximum call stack size exceeded
    at Object.addOverlayListener [as addOverlayListenerOverride] (overlay_plugin_api.ts:97)
    at Object.addOverlayListener [as addOverlayListenerOverride] (overlay_plugin_api.ts:98)
    at Object.addOverlayListener [as addOverlayListenerOverride] (overlay_plugin_api.ts:98)
    at Object.addOverlayListener [as addOverlayListenerOverride] (overlay_plugin_api.ts:98)
```

This is because of this call sequence:
* original addOverlayListener -> checks for override
* calls RaidEmulatorOverlayApiHook version -> calls original function
* original function checks for override again

The root of the issue is that the "original" function needs to not
include the override.  Fix this by returning an internal function
that does not include the override from the setOverride function.

Also, to avoid having to write this for the add/remove/dispatch,
remove those overrides as they are not used.