### PR TITLE
util: Force UTF-8 Encoding for Translation Scripts

### DIFF
--- a/util/check_translation.py
+++ b/util/check_translation.py
@@ -9,6 +9,10 @@ import json
 import os
 import re
 
+# Write to stdout with an explicit encoding of UTF-8
+# See: https://stackoverflow.com/a/3597849
+utf8stdout = open(1, "w", encoding="utf-8", closefd=False)
+
 languages = ["en", "de", "fr", "ja", "cn", "ko"]
 regex_entries = {
     "regexEn": "en",
@@ -160,7 +164,7 @@ def parse_translations(triggers):
     try:
         ret_list = json.loads("".join(lines))
     except json.decoder.JSONDecodeError as e:
-        print("Error json format:{}".format("".join(lines)))
+        print("Error json format:{}".format("".join(lines)), file=utf8stdout)
         raise e
 
     ret_dict = {}
@@ -234,15 +238,15 @@ def print_timeline(locale, timeline_file, trans, missing_filter):
 def filter_print_timeline(text, missing_filter):
     if missing_filter == "all":
         if " #MISSINGSYNC" in text or " #MISSINGTEXT" in text:
-            print(text)
+            print(text, file=utf8stdout)
     elif missing_filter == "sync":
         if " #MISSINGSYNC" in text:
-            print(text)
+            print(text, file=utf8stdout)
     elif missing_filter == "text":
         if " #MISSINGTEXT" in text:
-            print(text)
+            print(text, file=utf8stdout)
     else:
-        print(text)
+        print(text, file=utf8stdout)
 
 
 def main(args):

--- a/util/make_timeline.py
+++ b/util/make_timeline.py
@@ -59,6 +59,10 @@ log_event_types = {
     "cast": "21",
 }
 
+# Write to stdout with an explicit encoding of UTF-8
+# See: https://stackoverflow.com/a/3597849
+utf8stdout = open(1, "w", encoding="utf-8", closefd=False)
+
 
 def make_entry(overrides):
     # This should include all of the fields that any entry uses.
@@ -497,7 +501,7 @@ if __name__ == "__main__":
 
     # Actually call the script
     if not args.report or len(args.report.split(",")) == 1:
-        print("\n".join(main(args)))
+        print("\n".join(main(args)), file=utf8stdout)
     else:
         timelines = []
         tmp_args = args
@@ -505,4 +509,4 @@ if __name__ == "__main__":
             tmp_args.report = report
             timelines.append(main(tmp_args))
         timeline_aggregator = timeline_aggregator.TimelineAggregator(timelines)
-        print("\n".join(timeline_aggregator.aggregate(args.aggregate_threshold)))
+        print("\n".join(timeline_aggregator.aggregate(args.aggregate_threshold)), file=utf8stdout)


### PR DESCRIPTION
Force UTF-8 encoding for stdout for check_translation.py and
make_timeline.py. A bit of a hack to make things work; but,
hopefully won't cause any issues and hopefully will restore
some functionality.

Closes https://github.com/quisquous/cactbot/issues/2665 and https://github.com/quisquous/cactbot/issues/2510