### PR TITLE
util: process and generate triggers branch

### DIFF
--- a/.github/workflows/update-triggers-branch.yml
+++ b/.github/workflows/update-triggers-branch.yml
@@ -1,0 +1,41 @@
+name: Update triggers
+on:
+  push:
+    branches: [ main ]
+
+jobs:
+  check-triggers:
+    runs-on: ubuntu-latest
+    outputs:
+      found: ${{ steps.check-triggers.outputs.found }}
+    steps:
+      - name: Check triggers Exists
+        id: check-triggers
+        shell: bash
+        run: |
+          GITHUB_URL="https://github.com/${{ github.repository }}"
+          if git ls-remote --exit-code --heads $GITHUB_URL triggers; then
+            echo "::set-output name=found::true"
+            echo "triggers branch found. Updating..."
+          else
+            echo "::set-output name=found::false"
+            echo "triggers branch not found. Skipping..."
+          fi
+  update-triggers:
+    runs-on: ubuntu-latest
+    needs: check-triggers
+    if: needs.check-triggers.outputs.found == 'true'
+    steps:
+      - uses: actions/checkout@v2
+      - name: Build
+        run: |
+          npm install
+          npm run process-triggers
+      - name: Deploy
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./dist/triggers/ui/raidboss/data
+          user_name: "github-actions"
+          user_email: "github-actions@github.com"
+          commit_message: "gh-pages build: ${{ github.event.head_commit.message }}"

--- a/.github/workflows/update-triggers-branch.yml
+++ b/.github/workflows/update-triggers-branch.yml
@@ -36,6 +36,8 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./dist/triggers/ui/raidboss/data
+          publish_branch: triggers
           user_name: "github-actions"
           user_email: "github-actions@github.com"
-          commit_message: "gh-pages build: ${{ github.event.head_commit.message }}"
+          commit_message: "triggers build: ${{ github.event.head_commit.message }}"
+          enable_jekyll: true # Don't commit the .nojekyll file

--- a/docs/CactbotCustomization.md
+++ b/docs/CactbotCustomization.md
@@ -184,6 +184,13 @@ what jobs they run for,
 and how long they stay on screen,
 and anything else.
 
+You can see readable JavaScript versions of all of the cactbot triggers
+in this branch: <https://github.com/quisquous/cactbot/tree/triggers>
+This is the preferred reference to use for viewing, copying, and pasting.
+Triggers in the main branch
+or shipped in a cactbot release are often in unreadable bundles
+or are TypeScript which is not supported in user folders.
+
 In your user-defined js file for raidboss,
 there is an `Options.Triggers` list that contains a list of trigger sets.
 You can use this to append new triggers and
@@ -218,7 +225,7 @@ Modify the `zoneId` line to have the zone id for the zone you care about,
 usually from the top of the cactbot trigger file.
 [This file](../resources/zone_id.js) has a list of all the zone ids.
 If you specify one incorrectly, you will get a warning in the OverlayPlugin log window.
-Then, copy the trigger text into this block.
+Then, [copy the trigger text](https://github.com/quisquous/cactbot/tree/triggers) into this block.
 Edit as needed.
 Repeat for all the triggers you want to modify.
 Reload your raidboss overlay to apply your changes.
@@ -241,7 +248,7 @@ you could do this via [Changing Trigger Text with the cactbot UI](#changing-trig
 
 One way to adjust this is to edit the trigger output for this trigger.
 You can find the original fireball #1 trigger in
-[ui/raidboss/data/04-sb/ultimate/unending_coil_ultimate.js](https://github.com/quisquous/cactbot/blob/cce8bc6b10d2210fa512bd1c8edd39c260cc3df8/ui/raidboss/data/04-sb/ultimate/unending_coil_ultimate.js#L715-L743).
+[ui/raidboss/data/04-sb/ultimate/unending_coil_ultimate.js](https://github.com/quisquous/cactbot/blob/triggers/04-sb/ultimate/unending_coil_ultimate.js#:~:text=UCU%20Nael%20Fireball%201).
 
 This chunk of code is what you would paste into the bottom of your user-defined js file.
 
@@ -281,7 +288,7 @@ This edit also removed languages other than English.
 Currently, provoke only works for players in your alliance and not for all jobs.
 This example shows how to make it work for all players.
 The provoke trigger can be found in
-[ui/raidboss/data/00-misc/general.js](https://github.com/quisquous/cactbot/blob/cce8bc6b10d2210fa512bd1c8edd39c260cc3df8/ui/raidboss/data/00-misc/general.js#L11-L30).
+[ui/raidboss/data/00-misc/general.js](https://github.com/quisquous/cactbot/blob/triggers/00-misc/general.js#:~:text=General%20Provoke).
 
 Here is a modified version with a different `condition` function.
 Because this shares the same `General Provoke` id with the built-in cactbot trigger,

--- a/docs/ko-KR/CactbotCustomization.md
+++ b/docs/ko-KR/CactbotCustomization.md
@@ -210,7 +210,7 @@ Options.Triggers.push({
 
 이를 해결하는 방법으로는 트리거의 출력을 수정하여 조정하는 것이 있습니다.
 fireball #1 원본 트리거는
-[ui/raidboss/data/04-sb/ultimate/unending_coil_ultimate.js](https://github.com/quisquous/cactbot/blob/cce8bc6b10d2210fa512bd1c8edd39c260cc3df8/ui/raidboss/data/04-sb/ultimate/unending_coil_ultimate.js#L715-L743)에서 찾을 수 있습니다.
+[ui/raidboss/data/04-sb/ultimate/unending_coil_ultimate.js](https://github.com/quisquous/cactbot/blob/triggers/04-sb/ultimate/unending_coil_ultimate.js#:~:text=UCU%20Nael%20Fireball%201)에서 찾을 수 있습니다.
 
 이 코드들을 `cactbot/user/raidboss.js` 파일 아래 부분에 붙여넣습니다.
 
@@ -247,7 +247,7 @@ Options.Triggers.push({
 지금은 도발 알림이 같은 파티나 연합 파티에 있는 경우에만 작동하고, 일부 직업에 대해서만 작동하고 있습니다.
 이 예시는 어떻게 모든 플레이어에 대해 알림을 보여주도록 만들 수 있는지 보여줍니다.
 도발 트리거는
-[ui/raidboss/data/00-misc/general.js](https://github.com/quisquous/cactbot/blob/cce8bc6b10d2210fa512bd1c8edd39c260cc3df8/ui/raidboss/data/00-misc/general.js#L11-L30)에서 찾을 수 있습니다.
+[ui/raidboss/data/00-misc/general.js](https://github.com/quisquous/cactbot/blob/triggers/00-misc/general.js#:~:text=General%20Provoke)에서 찾을 수 있습니다.
 
 다음 예시는 `condition` 함수(function)가 수정된 버전입니다.
 이 트리거는 cactbot에 내장된 트리거인 `General Provoke`와 id가 동일하기 때문에

--- a/docs/zh-CN/CactbotCustomization.md
+++ b/docs/zh-CN/CactbotCustomization.md
@@ -130,7 +130,7 @@ Options.Triggers.push({
 
 若您只是想修改 `信息文本`，你可以 [通过cactbot配置界面改变触发器文本](#changing-trigger-text-with-the-cactbot-ui) 实现。
 
-其中一种调整方式是编辑触发器的输出。 您可以在 [ui/raidboss/data/04-sb/ultimate/unending_coil_ultimate.js](https://github.com/quisquous/cactbot/blob/cce8bc6b10d2210fa512bd1c8edd39c260cc3df8/ui/raidboss/data/04-sb/ultimate/unending_coil_ultimate.js#L715-L743) 中找到原本的 fireball #1 触发器。
+其中一种调整方式是编辑触发器的输出。 您可以在 [ui/raidboss/data/04-sb/ultimate/unending_coil_ultimate.js](https://github.com/quisquous/cactbot/blob/triggers/04-sb/ultimate/unending_coil_ultimate.js#:~:text=UCU%20Nael%20Fireball%201) 中找到原本的 fireball #1 触发器。
 
 您需要将以下的代码粘贴至您的用户自定义js文件底部。
 
@@ -167,7 +167,7 @@ Options.Triggers.push({
 
 ### 例2：使挑衅提示适用于全职业
 
-目前，只有团队成员的挑衅会触发提示，并且不是所有职业都能收到提示。 该例子展示了如何使其适用于所有职业。 该挑衅触发器可以在 [ui/raidboss/data/00-misc/general.js](https://github.com/quisquous/cactbot/blob/cce8bc6b10d2210fa512bd1c8edd39c260cc3df8/ui/raidboss/data/00-misc/general.js#L11-L30) 中找到。
+目前，只有团队成员的挑衅会触发提示，并且不是所有职业都能收到提示。 该例子展示了如何使其适用于所有职业。 该挑衅触发器可以在 [ui/raidboss/data/00-misc/general.js](https://github.com/quisquous/cactbot/blob/triggers/00-misc/general.js#:~:text=General%20Provoke) 中找到。
 
 我们需要修改 `condition` 函数(function)。 由于此处的id与内置的 `General Provoke` 触发器一致，因此会覆盖同名的内置触发器。
 

--- a/docs/zh-TW/CactbotCustomization.md
+++ b/docs/zh-TW/CactbotCustomization.md
@@ -130,7 +130,7 @@ Options.Triggers.push({
 
 若您只是想修改 `資訊文字`，你可以 [透過cactbot配置介面改變觸發器文字](#changing-trigger-text-with-the-cactbot-ui) 實現。
 
-其中一種調整方式是編輯觸發器的輸出。 您可以在 [ui/raidboss/data/04-sb/ultimate/unending_coil_ultimate.js](https://github.com/quisquous/cactbot/blob/cce8bc6b10d2210fa512bd1c8edd39c260cc3df8/ui/raidboss/data/04-sb/ultimate/unending_coil_ultimate.js#L715-L743) 中找到原本的 fireball #1 觸發器。
+其中一種調整方式是編輯觸發器的輸出。 您可以在 [ui/raidboss/data/04-sb/ultimate/unending_coil_ultimate.js](https://github.com/quisquous/cactbot/blob/triggers/04-sb/ultimate/unending_coil_ultimate.js#:~:text=UCU%20Nael%20Fireball%201) 中找到原本的 fireball #1 觸發器。
 
 您需要將以下的程式碼貼上至您的使用者自定義js檔案底部。
 
@@ -167,7 +167,7 @@ Options.Triggers.push({
 
 ### 例2：使挑釁提示適用於全職業
 
-目前，只有團隊成員的挑釁會觸發提示，並且不是所有職業都能收到提示。 該例子展示了如何使其適用於所有職業。 該挑釁觸發器可以在 [ui/raidboss/data/00-misc/general.js](https://github.com/quisquous/cactbot/blob/cce8bc6b10d2210fa512bd1c8edd39c260cc3df8/ui/raidboss/data/00-misc/general.js#L11-L30) 中找到。
+目前，只有團隊成員的挑釁會觸發提示，並且不是所有職業都能收到提示。 該例子展示了如何使其適用於所有職業。 該挑釁觸發器可以在 [ui/raidboss/data/00-misc/general.js](https://github.com/quisquous/cactbot/blob/triggers/00-misc/general.js#:~:text=General%20Provoke) 中找到。
 
 我們需要修改 `condition` 函式(function)。 由於此處的id與內建的 `General Provoke` 觸發器一致，因此會覆蓋同名的內建觸發器。
 

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "lint-staged": "node_modules/.bin/lint-staged",
     "coverage-report": "node --loader ts-node/esm util/gen_coverage_report.js",
     "find-translations": "node --loader ts-node/esm util/find_missing_translations.js",
-    "translate-timeline": "node --loader ts-node/esm util/translate_timeline.js"
+    "translate-timeline": "node --loader ts-node/esm util/translate_timeline.js",
+    "process-triggers": "node --loader ts-node/esm util/process_triggers_folder.js"
   },
   "devDependencies": {
     "@babel/types": "7.12.*",

--- a/tsconfig_triggers.json
+++ b/tsconfig_triggers.json
@@ -1,0 +1,28 @@
+{
+  "ts-node": {
+    "compiler": "ttypescript"
+  },
+  "compilerOptions": {
+    "plugins": [
+      {
+        "transform": "@zoltu/typescript-transformer-append-js-extension/output/index.js",
+        "after": true
+      }
+    ],
+    // nullish coalescing operator not supported in OverlayPlugin's Chrome M75
+    // TODO: change to ES2020 once OverlayPlugin rolls CEF past M80.
+    "target": "ES2019",
+    "module": "ES2020",
+    "allowJs": true,
+    "types": [ "node" ],
+    "outDir": "./dist/triggers",
+    "rootDir": "./",
+    "moduleResolution": "node",
+    "baseUrl": "./",
+    "esModuleInterop": true,
+    "skipLibCheck": true
+  },
+  "include": [
+    "./ui/raidboss/data/"
+  ]
+}

--- a/util/file_utils.ts
+++ b/util/file_utils.ts
@@ -15,3 +15,19 @@ export const walkDirSync = (dir: string, callback: (filename: string) => void): 
       callback(path.posix.join(dir, f));
   });
 };
+
+// Allows for an asynchronous callback, but still serializes them all
+// and does not run them in parallel.
+export const walkDirAsync = async (dir: string,
+    callback: (filename: string) => Promise<void>): Promise<void> => {
+  if (fs.statSync(dir).isFile()) {
+    await callback(path.posix.join(dir));
+    return;
+  }
+  const subdirs = fs.readdirSync(dir);
+  for (const subdir of subdirs) {
+    const dirPath = path.posix.join(dir, subdir);
+    const isDirectory = fs.statSync(dirPath).isDirectory();
+    await (isDirectory ? walkDirAsync(dirPath, callback) : callback(dirPath));
+  }
+};

--- a/util/process_triggers_folder.ts
+++ b/util/process_triggers_folder.ts
@@ -3,23 +3,10 @@ import eslint from 'eslint';
 import fs from 'fs';
 import path from 'path';
 import process from 'process';
+import { walkDirAsync } from './file_utils';
 
 const root = '../dist/triggers/ui/raidboss/data/';
 const tscCmd = `..\\node_modules\\.bin\\tsc --build ..\\tsconfig_triggers.json`;
-
-// Utility function to walk directories
-const asyncWalkDir = async (dir: string, callback: (filename: string) => Promise<void>) => {
-  if (fs.statSync(dir).isFile()) {
-    await callback(path.posix.join(dir));
-    return;
-  }
-  const subdirs = fs.readdirSync(dir);
-  for (const subdir of subdirs) {
-    const dirPath = path.posix.join(dir, subdir);
-    const isDirectory = fs.statSync(dirPath).isDirectory();
-    await (isDirectory ? asyncWalkDir(dirPath, callback) : callback(dirPath));
-  }
-};
 
 // Probably we could do this more cleanly with babel, but we'll just regex for simplicitly.
 const removeImports = (lines: string[]) => {
@@ -98,7 +85,7 @@ const processAllFiles = async (root: string, tscCmd: string) => {
   execSync(tscCmd);
 
   // Process files.
-  await asyncWalkDir(root, async (filename) => processFile(filename));
+  await walkDirAsync(root, async (filename) => processFile(filename));
   process.exit(0);
 };
 

--- a/util/process_triggers_folder.ts
+++ b/util/process_triggers_folder.ts
@@ -1,0 +1,105 @@
+import { execSync } from 'child_process';
+import eslint from 'eslint';
+import fs from 'fs';
+import path from 'path';
+import process from 'process';
+
+const root = '../dist/triggers/ui/raidboss/data/';
+const tscCmd = `..\\node_modules\\.bin\\tsc --build ..\\tsconfig_triggers.json`;
+
+// Utility function to walk directories
+const asyncWalkDir = async (dir: string, callback: (filename: string) => Promise<void>) => {
+  if (fs.statSync(dir).isFile()) {
+    await callback(path.posix.join(dir));
+    return;
+  }
+  const subdirs = fs.readdirSync(dir);
+  for (const subdir of subdirs) {
+    const dirPath = path.posix.join(dir, subdir);
+    const isDirectory = fs.statSync(dirPath).isDirectory();
+    await (isDirectory ? asyncWalkDir(dirPath, callback) : callback(dirPath));
+  }
+};
+
+// Probably we could do this more cleanly with babel, but we'll just regex for simplicitly.
+const removeImports = (lines: string[]) => {
+  // You can't import in a user file, so remove these lines.
+  // TODO: we really should test that all imports are ones that can be used in eval.
+  return lines.filter((line) => !/^import /.exec(line));
+};
+
+const changeExportToPush = (lines: string[]) => {
+  // User files are not modules and so push onto a global Options variable rather than
+  // exporting, so modify these files so that they can be used directly as user files.
+  const exportRegex = /^export default {\s*/;
+  const closingRegex = /^};\s*$/;
+
+  let replacedExportCount = 0;
+  let replacedClosingCount = 0;
+  lines = lines.map((line) => {
+    if (exportRegex.exec(line)) {
+      replacedExportCount++;
+      line = line.replace(exportRegex, 'Options.Triggers.push({');
+    }
+    // Function definitions that match closingRegex can happen before the export line.
+    if (replacedExportCount && closingRegex.exec(line)) {
+      replacedClosingCount++;
+      line = line.replace(closingRegex, '});');
+    }
+    return line;
+  });
+
+  if (replacedExportCount !== 1 || replacedClosingCount !== 1) {
+    console.error(`Found ${replacedExportCount} export lines and ${replacedClosingCount} closing lines, aborting.`);
+    process.exit(3);
+  }
+
+  return lines;
+};
+
+const lintToFile = async (lines: string[], outputFileName: string) => {
+  const linter = new eslint.ESLint({ fix: true });
+  const contents = lines.join('\n');
+  // Deliberately don't pass filename here, as dist/ is ignored in eslint.
+  const results = await linter.lintText(contents);
+
+  // There's only one result from lintText, as per documentation.
+  const lintResult = results[0];
+  if (!lintResult) {
+    console.error('No result from linting?');
+    process.exit(2);
+  }
+  if (lintResult.errorCount > 0 || lintResult.warningCount > 0) {
+    // Errors aren't great, but tsc can create unfixable line length errors, so ignore them.
+    console.error(`Lint ran with errors: ${JSON.stringify(lintResult.messages)}`);
+  }
+
+  // Overwrite the file, if it already exists.
+  fs.writeFileSync(outputFileName, lintResult.output);
+};
+
+const processFile = async (filename: string) => {
+  console.log(`Processing file: ${filename}`);
+  const originalContents = fs.readFileSync(filename).toString();
+  let lines = originalContents.split(/[\r\n]+/);
+
+  lines = removeImports(lines);
+  lines = changeExportToPush(lines);
+  await lintToFile(lines, filename);
+};
+
+const processAllFiles = async (root: string, tscCmd: string) => {
+  process.chdir(path.dirname(process.argv[1] ?? ''));
+
+  // Clean up previous directory so tsc doesn't ignore them.
+  fs.rmdirSync(root, { recursive: true });
+
+  // Generate javascript from typescript.
+  execSync(tscCmd);
+
+  // Process files.
+  await asyncWalkDir(root, async (filename) => processFile(filename));
+  process.exit(0);
+};
+
+void processAllFiles(root, tscCmd);

--- a/util/process_triggers_folder.ts
+++ b/util/process_triggers_folder.ts
@@ -82,6 +82,7 @@ const processAllFiles = async (root: string, tscCmd: string) => {
   fs.rmdirSync(root, { recursive: true });
 
   // Generate javascript from typescript.
+  // TODO: replace this with programatic use of TypeScript API.
   execSync(tscCmd);
 
   // Process files.

--- a/util/process_triggers_folder.ts
+++ b/util/process_triggers_folder.ts
@@ -6,7 +6,7 @@ import process from 'process';
 import { walkDirAsync } from './file_utils';
 
 const root = '../dist/triggers/ui/raidboss/data/';
-const tscCmd = `..\\node_modules\\.bin\\tsc --build ..\\tsconfig_triggers.json`;
+const tscCmd = `${['..', 'node_modules', '.bin', 'tsc'].join(path.sep)} --build ${['..', 'tsconfig_triggers.json'].join(path.sep)}`;
 
 // Probably we could do this more cleanly with babel, but we'll just regex for simplicitly.
 const removeImports = (lines: string[]) => {


### PR DESCRIPTION
As trigger files are diverging more and more from things that users
can copy and paste into javascript file, create a triggers branch
that can be viewed online that has the most recent version of all
of the triggers.

This will allow us to start converting trigger files and still
have a place that users can look to see a JavaScript transpiled
version that they can more easily copy and paste as needed.