### PR TITLE
util: fix find_missing_translations to report timelineReplace mismatches

### DIFF
--- a/resources/netregexes.ts
+++ b/resources/netregexes.ts
@@ -58,6 +58,22 @@ export type StatChangeParams = typeof statChangeParams[number];
 export type ChangeZoneParams = typeof changeZoneParams[number];
 export type Network6dParams = typeof network6dParams[number];
 
+// If NetRegexes.setFlagTranslationsNeeded is set to true, then any
+// regex created that requires a translation will begin with this string
+// and match the magicStringRegex.  This is maybe a bit goofy, but is
+// a pretty straightforward way to mark regexes for translations.
+// If issue #1306 is ever resolved, we can remove this.  Chosen
+// to create a cute noop face at the beginning of such regexes.
+const magicTranslationString = `(💧^|^)`;
+const magicStringRegex = new RegExp(`^\\(💧\\^\\|\\^\\)`);
+const keysThatRequireTranslation = [
+  'ability',
+  'name',
+  'source',
+  'target',
+  'line',
+];
+
 const parseHelper = (
     params: { timestamp?: string; capture?: boolean } | undefined,
     funcName: string,
@@ -90,8 +106,17 @@ const parseHelper = (
     }
   }
 
+  // For testing, it's useful to know if this is a regex that requires
+  // translation.  We test this by seeing if there are any specified
+  // fields, and if so, inserting a magic string that we can detect.
+  // This lets us differentiate between "regex that should be translated"
+  // e.g. a regex with `target` specified, and "regex that shouldn't"
+  // e.g. a gains effect with just effectId specified.
+  const transParams = Object.keys(params).filter((k) => keysThatRequireTranslation.includes(k));
+  const needsTranslations = NetRegexes.flagTranslationsNeeded && transParams.length > 0;
+
   // Build the regex from the fields.
-  let str = '^';
+  let str = needsTranslations ? magicTranslationString : '^';
   let lastKey = -1;
   for (const _key in fields) {
     const key = parseInt(_key);
@@ -129,6 +154,17 @@ const parseHelper = (
 };
 
 export default class NetRegexes {
+  static flagTranslationsNeeded = false;
+  static setFlagTranslationsNeeded(value: boolean): void {
+    NetRegexes.flagTranslationsNeeded = value;
+  }
+  static doesNetRegexNeedTranslation(regex: RegExp | string): boolean {
+    // Need to `setFlagTranslationsNeeded` before calling this function.
+    console.assert(NetRegexes.flagTranslationsNeeded);
+    const str = typeof regex === 'string' ? regex : regex.source;
+    return !!magicStringRegex.exec(str);
+  }
+
   /**
    * matches: https://github.com/quisquous/cactbot/blob/main/docs/LogGuide.md#14-networkstartscasting
    */

--- a/resources/netregexes.ts
+++ b/resources/netregexes.ts
@@ -62,10 +62,9 @@ export type Network6dParams = typeof network6dParams[number];
 // regex created that requires a translation will begin with this string
 // and match the magicStringRegex.  This is maybe a bit goofy, but is
 // a pretty straightforward way to mark regexes for translations.
-// If issue #1306 is ever resolved, we can remove this.  Chosen
-// to create a cute noop face at the beginning of such regexes.
-const magicTranslationString = `(💧^|^)`;
-const magicStringRegex = new RegExp(`^\\(💧\\^\\|\\^\\)`);
+// If issue #1306 is ever resolved, we can remove this.
+const magicTranslationString = `^^`;
+const magicStringRegex = new RegExp('^\\^\\^');
 const keysThatRequireTranslation = [
   'ability',
   'name',

--- a/util/find_missing_timeline_translations.js
+++ b/util/find_missing_timeline_translations.js
@@ -1,8 +1,11 @@
 import fs from 'fs';
 import path from 'path';
 import Regexes from '../resources/regexes';
+import NetRegexes from '../resources/netregexes';
 import { Timeline } from '../ui/raidboss/timeline';
 import { commonReplacement, partialCommonReplacementKeys } from '../ui/raidboss/common_replacement';
+
+NetRegexes.setFlagTranslationsNeeded(true);
 
 export async function findMissing(triggersFile, locale) {
   // Hackily assume that any file with a txt file of the same name is a trigger/timeline.
@@ -64,7 +67,7 @@ function findLineNumberByTriggerId(text, id) {
 
 function findMissingRegex(triggers, triggerLines, timeline, trans, triggersFile, locale) {
   for (const trigger of triggers) {
-    let origRegex = trigger.regex;
+    let origRegex = trigger.netRegex;
     if (!origRegex)
       continue;
 
@@ -90,7 +93,10 @@ function findMissingRegex(triggers, triggerLines, timeline, trans, triggersFile,
 
     transRegex = transRegex.toLowerCase();
 
-    const localeReg = 'regex' + locale[0].toUpperCase() + locale[1];
+    if (!NetRegexes.doesNetRegexNeedTranslation(transRegex))
+      continue;
+
+    const localeReg = 'netRegex' + locale[0].toUpperCase() + locale[1];
     let locRegex = trigger[localeReg];
     if (locRegex) {
       // Things are in a good state if the translation regex matches the

--- a/util/find_missing_timeline_translations.js
+++ b/util/find_missing_timeline_translations.js
@@ -5,6 +5,8 @@ import NetRegexes from '../resources/netregexes';
 import { Timeline } from '../ui/raidboss/timeline';
 import { commonReplacement, partialCommonReplacementKeys } from '../ui/raidboss/common_replacement';
 
+// Set a global flag to mark regexes for NetRegexes.doesNetRegexNeedTranslation.
+// See details in that function for more information.
 NetRegexes.setFlagTranslationsNeeded(true);
 
 export async function findMissing(triggersFile, locale) {


### PR DESCRIPTION
This used to work, but when we switched over to netregexes from regexes
this broke and nobody ever noticed.  Unfortunately, there's a lot of
regexes that don't need to be translated, so this adds an
*EXTREMELY* hacky method to detect them.

NetRegexes know what fields that they have on construction, and only
particular fields need translation.  Therefore, if a global flag is
flipped and a NetRegex needs that field, insert a noop character
sequence at the beginning of the NetRegex that we can then detect
in order to know if this NetRegex had such fields when it was
constructed.