### PR TITLE
Add Regex.zoneSealed and Regex.zoneUnsealed functions #2677

### DIFF
--- a/resources/regexes.ts
+++ b/resources/regexes.ts
@@ -129,6 +129,8 @@ const gameLogParams = ['timestamp', 'code', 'line', 'capture'] as const;
 const gameNameLogParams = ['timestamp', 'code', 'name', 'line', 'capture'] as const;
 const changeZoneParams = ['timestamp', 'name', 'capture'] as const;
 const network6dParams = ['timestamp', 'instance', 'command', 'data0', 'data1', 'data2', 'data3', 'capture'] as const;
+const zoneSealedParams = ['timestamp', 'name', 'time', 'capture'] as const;
+const zoneUnsealedParams = ['timestamp', 'name', 'capture'] as const;
 
 export type StartsUsingParams = typeof startsUsingParams[number];
 export type AbilityParams = typeof abilityParams[number];
@@ -151,6 +153,8 @@ export type GameLogParams = typeof gameLogParams[number];
 export type GameNameLogParams = typeof gameNameLogParams[number];
 export type ChangeZoneParams = typeof changeZoneParams[number];
 export type Network6dParams = typeof network6dParams[number];
+export type ZoneSealedParams = typeof zoneSealedParams[number];
+export type ZoneUnsealedParams = typeof zoneUnsealedParams[number];
 
 export default class Regexes {
   /**
@@ -481,6 +485,42 @@ export default class Regexes {
       Regexes.maybeCapture(capture, 'name', f.name, '.*?') +
       ' HP at ' +
       Regexes.maybeCapture(capture, 'hp', f.hp, '\\d+') + '%';
+    return Regexes.parse(str);
+  }
+
+
+  /**
+   * fields: name, time, capture
+   * Specialised function for zone is sealed message
+   */
+  static zoneSealed(f?: Params<ZoneSealedParams>): Regex<ZoneSealedParams> {
+    if (typeof f === 'undefined')
+      f = {};
+    Regexes.validateParams(f, 'zoneSealed', zoneSealedParams);
+    const capture = Regexes.trueIfUndefined(f.capture);
+    const str = Regexes.maybeCapture(capture, 'timestamp', '\\y{Timestamp}') +
+      ' 00:0839:' +
+      Regexes.maybeCapture(capture, 'name', f.name, '.*?') +
+      ' will be sealed off in ' +
+      Regexes.maybeCapture(capture, 'time', f.time, '.*?') +
+      ' second!';
+    return Regexes.parse(str);
+  }
+
+
+  /**
+   * fields: name, capture
+   * Specialised function for zone is no longer sealed message
+   */
+  static zoneUnsealed(f?: Params<ZoneUnsealedParams>): Regex<ZoneUnsealedParams> {
+    if (typeof f === 'undefined')
+      f = {};
+    Regexes.validateParams(f, 'zoneUnsealed', zoneUnsealedParams);
+    const capture = Regexes.trueIfUndefined(f.capture);
+    const str = Regexes.maybeCapture(capture, 'timestamp', '\\y{Timestamp}') +
+      ' 00:0839:' +
+      Regexes.maybeCapture(capture, 'name', f.name, '.*?') +
+      ' is no longer sealed.*?';
     return Regexes.parse(str);
   }
 

--- a/test/unittests/regex_test.js
+++ b/test/unittests/regex_test.js
@@ -205,6 +205,25 @@ describe('regex tests', () => {
     assert.equal(matches.name, 'Tini Poutini');
     assert.equal(matches.hp, '96');
   });
+  it('zoneSealed', () => {
+    const lines = [
+      '[21:14:50.793] 00:0839:The Gloriole will be sealed off in 15 second!',
+    ];
+    regexCaptureTest(Regexes.zoneSealed, lines);
+
+    const matches = lines[0].match(Regexes.zoneSealed()).groups;
+    assert.equal(matches.name, 'The Gloriole');
+    assert.equal(matches.time, '15');
+  });
+  it('zoneUnsealed', () => {
+    const lines = [
+      '[21:14:50.793] 00:0839:The Gloriole is no longer sealed!',
+    ];
+    regexCaptureTest(Regexes.zoneUnsealed, lines);
+
+    const matches = lines[0].match(Regexes.zoneUnsealed()).groups;
+    assert.equal(matches.name, 'The Gloriole');
+  });
   it('gameLog', () => {
     const echoLines = [
       '[12:18:38.000] 00:0038:cactbot wipe',


### PR DESCRIPTION
(accedentily removed branch before)
basic concept was added.
@quisquous  might you be able to help, why it does not recognize other languages other than en (are commen replacements not applied here?)?

Sealed example: `[10:35:26.000] 00:0839:Noch 15 Sekunden, bis sich die Rambade schließt.`
Unsealed example: `[10:35:44.000] 00:0839:Die Rambade öffnet sich wieder.`