### PR TITLE
raidboss: Change new Date calls to emit from log events

### DIFF
--- a/ui/raidboss/emulator/data/PopupTextAnalysis.js
+++ b/ui/raidboss/emulator/data/PopupTextAnalysis.js
@@ -2,7 +2,7 @@ import EmulatorCommon from '../EmulatorCommon';
 import StubbedPopupText from '../overrides/StubbedPopupText';
 
 export default class PopupTextAnalysis extends StubbedPopupText {
-  OnTriggerInternal(trigger, matches) {
+  OnTriggerInternal(trigger, matches, currentTime) {
     this.currentTriggerStatus = {
       initialData: EmulatorCommon.cloneData(this.data),
       condition: undefined,
@@ -14,7 +14,7 @@ export default class PopupTextAnalysis extends StubbedPopupText {
       promise: undefined,
     };
     this.currentFunction = 'initial';
-    super.OnTriggerInternal(trigger, matches);
+    super.OnTriggerInternal(trigger, matches, currentTime);
   }
 
   async OnLog(e) {

--- a/ui/raidboss/emulator/overrides/RaidEmulatorTimeline.js
+++ b/ui/raidboss/emulator/overrides/RaidEmulatorTimeline.js
@@ -26,8 +26,8 @@ export default class RaidEmulatorTimeline extends Timeline {
       return;
 
     this.SyncTo(this.emulatedFightSync +
-      ((timestampOffset - this.emulatedFightSyncLastOffset) / 1000));
-    this._OnUpdateTimer();
+      ((timestampOffset - this.emulatedFightSyncLastOffset) / 1000), timestampOffset);
+    this._OnUpdateTimer(timestampOffset);
   }
 
   // Override
@@ -35,8 +35,8 @@ export default class RaidEmulatorTimeline extends Timeline {
   }
 
   // Override
-  SyncTo(fightNow) {
-    super.SyncTo(fightNow);
+  SyncTo(fightNow, currentTime) {
+    super.SyncTo(fightNow, currentTime);
 
     this.emulatedFightSync = fightNow;
     this.emulatedFightSyncLastOffset = this.emulatedTimeOffset;

--- a/ui/raidboss/popup-text.js
+++ b/ui/raidboss/popup-text.js
@@ -602,6 +602,9 @@ export class PopupText {
   }
 
   OnLog(e) {
+    // This could conceivably be determined based on the line's contents as well, but
+    // not sure if that's worth the effort
+    const currentTime = +new Date();
     for (const log of e.detail.logs) {
       if (log.includes('00:0038:cactbot wipe'))
         this.SetInCombat(false);
@@ -609,32 +612,33 @@ export class PopupText {
       for (const trigger of this.triggers) {
         const r = log.match(trigger.localRegex);
         if (r)
-          this.OnTrigger(trigger, r);
+          this.OnTrigger(trigger, r, currentTime);
       }
     }
   }
 
   OnNetLog(e) {
     const log = e.rawLine;
+    // This could conceivably be determined based on `new Date(e.line[1])` as well, but
+    // not sure if that's worth the effort
+    const currentTime = +new Date();
     for (const trigger of this.netTriggers) {
       const r = log.match(trigger.localNetRegex);
       if (r)
-        this.OnTrigger(trigger, r);
+        this.OnTrigger(trigger, r, currentTime);
     }
   }
 
-  OnTrigger(trigger, matches) {
+  OnTrigger(trigger, matches, currentTime) {
     try {
-      this.OnTriggerInternal(trigger, matches);
+      this.OnTriggerInternal(trigger, matches, currentTime);
     } catch (e) {
       onTriggerException(trigger, e);
     }
   }
 
-  OnTriggerInternal(trigger, matches) {
-    const now = +new Date();
-
-    if (this._onTriggerInternalCheckSuppressed(trigger, now))
+  OnTriggerInternal(trigger, matches, currentTime) {
+    if (this._onTriggerInternalCheckSuppressed(trigger, currentTime))
       return;
 
     // If using named groups, treat matches.groups as matches
@@ -644,7 +648,7 @@ export class PopupText {
 
     // Set up a helper object so we don't have to throw
     // a ton of info back and forth between subfunctions
-    const triggerHelper = this._onTriggerInternalGetHelper(trigger, matches, now);
+    const triggerHelper = this._onTriggerInternalGetHelper(trigger, matches, currentTime);
 
     if (!this._onTriggerInternalCondition(triggerHelper))
       return;
@@ -1073,6 +1077,7 @@ export class PopupTextGenerator {
   }
 
   Trigger(trigger, matches) {
-    this.popupText.OnTrigger(trigger, matches);
+    const currentTime = +new Date();
+    this.popupText.OnTrigger(trigger, matches, currentTime);
   }
 }


### PR DESCRIPTION
This PR changes the calls to `new Date` in PopupText and the Timeline classes to instead be emitted from log line events, per various discussions.