### PR TITLE
oopsy: Logic Error Fixes from TypeScript Compiler

### DIFF
--- a/ui/oopsyraidsy/data/05-shb/raid/e7n.js
+++ b/ui/oopsyraidsy/data/05-shb/raid/e7n.js
@@ -103,7 +103,7 @@ export default {
       condition: function(e, data) {
         return !data.hasAstral || !data.hasAstral[e.targetName];
       },
-      mistake: function(e) {
+      mistake: function(e, data) {
         if (data.hasUmbral && data.hasUmbral[e.targetName])
           return { type: 'fail', blame: e.targetName, text: wrongBuff(e.abilityName) };
         // This case is probably impossible, as the debuff ticks after death,

--- a/ui/oopsyraidsy/data/05-shb/raid/e7s.js
+++ b/ui/oopsyraidsy/data/05-shb/raid/e7s.js
@@ -148,7 +148,7 @@ export default {
       condition: function(e, data) {
         return !data.hasAstral || !data.hasAstral[e.targetName];
       },
-      mistake: function(e) {
+      mistake: function(e, data) {
         if (data.hasUmbral && data.hasUmbral[e.targetName])
           return { type: 'fail', blame: e.targetName, text: wrongBuff(e.abilityName) };
         // This case is probably impossible, as the debuff ticks after death,


### PR DESCRIPTION
Issues found from converting oopsy to TypeScript manually and
running tsc.

Ignoring issues around unused variables or type assertion, or anything
that applies to TypeScript exclusively.