### PR TITLE
lint: Add timelineTrigger Syntax Checks

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -24,6 +24,7 @@ module.exports = {
       'files': ['**/raidboss/data/**/*'],
       'rules': {
         'rulesdir/cactbot-output-strings': 'error',
+        'rulesdir/cactbot-timeline-triggers': 'error',
       },
     },
     {

--- a/eslint/cactbot-timeline-triggers.js
+++ b/eslint/cactbot-timeline-triggers.js
@@ -1,0 +1,25 @@
+module.exports = {
+  meta: {
+    type: 'problem',
+    docs: {
+      description: 'prevent syntax issues within timelineTriggers',
+      category: 'Syntax Issues',
+      recommended: true,
+      url: 'https://github.com/quisquous/cactbot/blob/main/docs/RaidbossGuide.md#trigger-elements',
+    },
+    schema: [],
+  },
+
+  create: (context) => {
+    return {
+      'Property[key.name=\'timelineTriggers\'] > ArrayExpression > ObjectExpression > Property[key.name=\'regex\'] > :not(Identifier, Literal)': (node) => context.report({
+        node,
+        message: 'timelineTrigger regex has to be a regular expression literal, such as /^Ability Name$/',
+      }),
+      'Property[key.name=\'timelineTriggers\'] > ArrayExpression > ObjectExpression > Property[key.name=/(?:netRegex.{0,2}|regex.{2})/]': (node) => context.report({
+        node,
+        message: 'timelineTriggers only support "regex"',
+      }),
+    };
+  },
+};


### PR DESCRIPTION
Add rules for checking the timelineTrigger syntax.

Ensure that the `regex` property uses a regular expression literal:
![](https://puu.sh/Hxfdp/d1b5b00530.png)

Ensure properties such as `netRegex` or `regexFr` are not present:
![](https://puu.sh/Hxf9q/a55ee289c3.png)
