### PR TITLE
raidboss: Correct Arrays That Should Be Maps

### DIFF
--- a/ui/raidboss/data/03-hw/raid/a3s.js
+++ b/ui/raidboss/data/03-hw/raid/a3s.js
@@ -186,7 +186,7 @@ export default {
       id: 'A3S Ferrofluid Signs',
       netRegex: NetRegexes.headMarker({ id: ['0030', '0031'] }),
       run: function(data, matches) {
-        data.ferroMarker = data.ferroMarker || [];
+        data.ferroMarker = data.ferroMarker || {};
         data.ferroMarker[matches.target] = matches.id;
       },
     },
@@ -201,7 +201,7 @@ export default {
       netRegexKo: NetRegexes.startsUsing({ source: '살아있는 액체', id: 'F01' }),
       alertText: function(data, matches, output) {
         data.ferroTether = data.ferroTether || {};
-        data.ferroMarker = data.ferroMarker || [];
+        data.ferroMarker = data.ferroMarker || {};
         const partner = data.ferroTether[data.me];
         const marker1 = data.ferroMarker[data.me];
         const marker2 = data.ferroMarker[partner];

--- a/ui/raidboss/data/04-sb/ultimate/unending_coil_ultimate.js
+++ b/ui/raidboss/data/04-sb/ultimate/unending_coil_ultimate.js
@@ -956,7 +956,7 @@ export default {
       },
       run: function(data, matches) {
         // seenDragon[dragon name] => boolean
-        data.seenDragon = data.seenDragon || [];
+        data.seenDragon = data.seenDragon || {};
         data.seenDragon[matches.source] = true;
 
         const x = parseFloat(matches.x);

--- a/ui/raidboss/data/05-shb/raid/e7s.js
+++ b/ui/raidboss/data/05-shb/raid/e7s.js
@@ -496,7 +496,7 @@ export default {
       netRegexCn: NetRegexes.startsUsing({ source: '未被宽恕的盲崇', id: '(?:4C2C|4C65)', capture: false }),
       netRegexKo: NetRegexes.startsUsing({ source: '면죄되지 않은 숭배', id: '(?:4C2C|4C65)', capture: false }),
       alertText: function(data, _, output) {
-        data.colorMap = data.colorMap || [];
+        data.colorMap = data.colorMap || {};
         const colorTrans = data.colorMap[data.color] || {};
         const color = colorTrans[data.displayLang];
         if (!color)
@@ -611,7 +611,7 @@ export default {
       netRegexCn: NetRegexes.startsUsing({ source: '暗黑心象', id: '4C7E', capture: false }),
       netRegexKo: NetRegexes.startsUsing({ source: '어둠의 우상', id: '4C7E', capture: false }),
       alertText: function(data, _, output) {
-        data.colorMap = data.colorMap || [];
+        data.colorMap = data.colorMap || {};
         const colorTrans = data.colorMap[data.color] || {};
         const color = colorTrans[data.displayLang];
         if (!color)

--- a/ui/raidboss/data/05-shb/trial/ruby_weapon-ex.js
+++ b/ui/raidboss/data/05-shb/trial/ruby_weapon-ex.js
@@ -186,7 +186,7 @@ export default {
       id: 'RubyEx Pall of Rage',
       netRegex: NetRegexes.gainsEffect({ effectId: '8A2' }),
       preRun: function(data, matches) {
-        data.colors = data.colors || [];
+        data.colors = data.colors || {};
         data.colors[matches.target] = 'blue';
       },
       infoText: function(data, matches, output) {
@@ -208,7 +208,7 @@ export default {
       id: 'RubyEx Pall of Grief',
       netRegex: NetRegexes.gainsEffect({ effectId: '8A3' }),
       preRun: function(data, matches) {
-        data.colors = data.colors || [];
+        data.colors = data.colors || {};
         data.colors[matches.target] = 'red';
       },
       infoText: function(data, matches, output) {


### PR DESCRIPTION
Fix incorrect instances of arrays that should be maps, given their usage
throughout the rest of the trigger file. This was not done exhaustively,
searching for instances of arrays within raidboss and ensuring that they
are not accessed in unexpected ways.