### PR TITLE
various: Fix typo of 'itt' vs 'it'

### DIFF
--- a/resources/party.ts
+++ b/resources/party.ts
@@ -80,32 +80,32 @@ export default class PartyTracker {
     return this.roleToPartyNames_['dps'];
   }
 
-  // returns true iff the named player in your alliance is a particular role
+  // returns true if the named player in your alliance is a particular role
   isRole(name: string, role: string): boolean {
     return this.nameToRole_[name] === role;
   }
 
-  // returns true iff the named player in your alliance is a tank
+  // returns true if the named player in your alliance is a tank
   isTank(name: string): boolean {
     return this.isRole(name, 'tank');
   }
 
-  // returns true iff the named player in your alliance is a healer
+  // returns true if the named player in your alliance is a healer
   isHealer(name: string): boolean {
     return this.isRole(name, 'healer');
   }
 
-  // returns true iff the named player in your alliance is a dps
+  // returns true if the named player in your alliance is a dps
   isDPS(name: string): boolean {
     return this.isRole(name, 'dps');
   }
 
-  // returns true iff the named player is in your immediate party
+  // returns true if the named player is in your immediate party
   inParty(name: string): boolean {
     return this.partyNames.includes(name);
   }
 
-  // returns true iff the named player is in your alliance
+  // returns true if the named player is in your alliance
   inAlliance(name: string): boolean {
     return this.allianceNames.includes(name);
   }

--- a/test/unittests/util_test.js
+++ b/test/unittests/util_test.js
@@ -44,7 +44,7 @@ const jobs = (() => {
 
 describe('util tests', () => {
   // Check test job values match actual values from util.js and return their expected values
-  it('jobs should support Util.canX iff it can', () => {
+  it('jobs should support Util.canX if it can', () => {
     [['Addle', Util.canAddle], ['Cleanse', Util.canCleanse], ['Feint', Util.canFeint], ['Silence', Util.canSilence], ['Sleep', Util.canSleep], ['Stun', Util.canStun]]
       .forEach(([action, functionCall]) => {
         // If job can do X, assert canX returns true

--- a/ui/oopsyraidsy/data/05-shb/raid/e12s.js
+++ b/ui/oopsyraidsy/data/05-shb/raid/e12s.js
@@ -359,7 +359,7 @@ export default {
         const singleTarget = matches.type === '21';
         const hasFireDebuff = data.fire && data.fire[matches.target];
 
-        // Success iff only one person takes it and they have no fire debuff.
+        // Success if only one person takes it and they have no fire debuff.
         if (singleTarget && !hasFireDebuff)
           return;
 


### PR DESCRIPTION
Noticed when running `npm test` that one of the final tests had a typo. Ran a search on the code and corrected all instances of `itt` vs `it`, even though the rest of them were in comments.