### PR TITLE
raidboss: Add Trigger Source to Config

### DIFF
--- a/ui/config/config.css
+++ b/ui/config/config.css
@@ -232,6 +232,10 @@ html {
   align-self: center;
 }
 
+.trigger-source {
+  justify-content: flex-end;
+}
+
 .alarm-text {
   color: #f30;
 }

--- a/ui/raidboss/raidboss_config.js
+++ b/ui/raidboss/raidboss_config.js
@@ -579,6 +579,27 @@ class RaidbossConfigurator {
 
           triggerDetails.appendChild(div);
         }
+
+        const label = document.createElement('div');
+        triggerDetails.appendChild(label);
+
+        const div = document.createElement('div');
+        div.classList.add('option-input-container', 'trigger-source');
+        const baseUrl = 'https://github.com/quisquous/cactbot/blob/triggers';
+        const path = key.split('-');
+        let urlFilepath;
+        if (path.length === 3) {
+          // 00-misc/general.js
+          urlFilepath = `${path[0]}-${path[1]}/${[...path].slice(2).join('-')}`;
+        } else {
+          // 02-arr/raids/t1.js
+          urlFilepath = `${path[0]}-${path[1]}/${path[2]}/${[...path].slice(3).join('-')}`;
+        }
+        const uriComponent = encodeURIComponent(trig.id).replace(/\'/g, '%5C%27');
+        const urlString = `${baseUrl}/${urlFilepath}.js#:~:text=${uriComponent}`;
+        div.innerHTML = `<a href="${urlString}" target="_blank">(View Trigger Source)</a>`;
+
+        triggerDetails.appendChild(div);
       }
     }
   }

--- a/ui/raidboss/raidboss_config.js
+++ b/ui/raidboss/raidboss_config.js
@@ -595,7 +595,7 @@ class RaidbossConfigurator {
           // 02-arr/raids/t1.js
           urlFilepath = `${path[0]}-${path[1]}/${path[2]}/${[...path].slice(3).join('-')}`;
         }
-        const uriComponent = encodeURIComponent(trig.id).replace(/\'/g, '%5C%27');
+        const uriComponent = encodeURIComponent(`id: ${trig.id}`).replace(/\'/g, '%5C%27'); // Hack to force encoding for \'
         const urlString = `${baseUrl}/${urlFilepath}.js#:~:text=${uriComponent}`;
         div.innerHTML = `<a href="${urlString}" target="_blank">(View Trigger Source)</a>`;
 


### PR DESCRIPTION
Add the ability to view the `triggers` branch from within the config
UI.

Ideally, the link would open in Chrome to take advantage of text
highlighting, but that functionality doesn't exist yet.