### PR TITLE
Responses: combineFuncs will now combine identical severity levels

### DIFF
--- a/resources/responses.js
+++ b/resources/responses.js
@@ -109,7 +109,7 @@ const combineFuncs = function(text1, func1, text2, func2) {
     obj[text2] = func2;
   } else {
     obj[text1] = (data, matches, output) => {
-      func1(data, matches, output) || func2(data, matches, output);
+      return func1(data, matches, output) || func2(data, matches, output);
     };
   }
   return obj;


### PR DESCRIPTION
(This resolves #2793 )

Briefly, for those not immediately familiar with the internals of `Responses`, some response functions take two parameters, the "primary" severity, and the "secondary". (Usually these functions are assigned different default severity levels.) The user can then choose specific severity levels for the response in the trigger body. If the severity levels are different, the two different output functions are assigned to different severity levels in the trigger response object and it's then returned.

If the severity levels are the same, the response object is supposed to be a function that returns the correct response. However, a missing `return` meant that this function just evaluated `true` and exited. Since it's *incredibly* uncommon to assign non-default severity to `Responses`, we never noticed before.

To be clear, quisquous tracked down this problem, all I did was throw data at them.