### PR TITLE
Raidboss: Emanation (Lakshmi normal mode) timeline and triggers

### DIFF
--- a/ui/raidboss/data/04-sb/trial/lakshmi-ex.js
+++ b/ui/raidboss/data/04-sb/trial/lakshmi-ex.js
@@ -347,7 +347,6 @@ export default {
         'Lakshmi': 'Lakshmi',
       },
       'replaceText': {
-        '--Chanchala over--': '--Chanchala terminé--',
         '/dance': '/danse',
         '\\(mid\\)': '(milieu)',
         '\\(out\\)': '(extérieur)',
@@ -443,7 +442,6 @@ export default {
         'The Pall Of Light': '빛의 폭포',
         'The Path Of Light': '빛의 파동',
         'The Pull Of Light': '빛의 급류',
-        'over': '끝',
       },
     },
   ],

--- a/ui/raidboss/data/04-sb/trial/lakshmi-ex.js
+++ b/ui/raidboss/data/04-sb/trial/lakshmi-ex.js
@@ -9,7 +9,7 @@ export default {
   timelineFile: 'lakshmi-ex.txt',
   timelineTriggers: [
     {
-      id: 'Lakshmi EX Path of Light',
+      id: 'LakshmiEx Path of Light',
       regex: /Path of Light/,
       beforeSeconds: 5,
       condition: function(data) {
@@ -20,7 +20,7 @@ export default {
   ],
   triggers: [
     {
-      id: 'Lakshmi EX Chanchala Gain',
+      id: 'LakshmiEx Chanchala Gain',
       netRegex: NetRegexes.startsUsing({ id: '2148', source: 'Lakshmi', capture: false }),
       netRegexDe: NetRegexes.startsUsing({ id: '2148', source: 'Lakshmi', capture: false }),
       netRegexFr: NetRegexes.startsUsing({ id: '2148', source: 'Lakshmi', capture: false }),
@@ -32,7 +32,7 @@ export default {
       },
     },
     {
-      id: 'Lakshmi EX Chanchala Lose',
+      id: 'LakshmiEx Chanchala Lose',
       netRegex: NetRegexes.losesEffect({ target: 'Lakshmi', effectId: '582', capture: false }),
       netRegexDe: NetRegexes.losesEffect({ target: 'Lakshmi', effectId: '582', capture: false }),
       netRegexFr: NetRegexes.losesEffect({ target: 'Lakshmi', effectId: '582', capture: false }),
@@ -44,7 +44,7 @@ export default {
       },
     },
     {
-      id: 'Lakshmi EX Pull of Light Tank',
+      id: 'LakshmiEx Pull of Light Tank',
       netRegex: NetRegexes.startsUsing({ id: '215E', source: 'Lakshmi' }),
       netRegexDe: NetRegexes.startsUsing({ id: '215E', source: 'Lakshmi' }),
       netRegexFr: NetRegexes.startsUsing({ id: '215E', source: 'Lakshmi' }),
@@ -57,7 +57,7 @@ export default {
       response: Responses.tankBuster('info'),
     },
     {
-      id: 'Lakshmi EX Pull of Light Unexpected',
+      id: 'LakshmiEx Pull of Light Unexpected',
       netRegex: NetRegexes.startsUsing({ id: '215E', source: 'Lakshmi' }),
       netRegexDe: NetRegexes.startsUsing({ id: '215E', source: 'Lakshmi' }),
       netRegexFr: NetRegexes.startsUsing({ id: '215E', source: 'Lakshmi' }),
@@ -70,7 +70,7 @@ export default {
       response: Responses.tankBuster('alarm'),
     },
     {
-      id: 'Lakshmi EX Divine Denial',
+      id: 'LakshmiEx Divine Denial',
       netRegex: NetRegexes.startsUsing({ id: '2149', source: 'Lakshmi', capture: false }),
       netRegexDe: NetRegexes.startsUsing({ id: '2149', source: 'Lakshmi', capture: false }),
       netRegexFr: NetRegexes.startsUsing({ id: '2149', source: 'Lakshmi', capture: false }),
@@ -90,7 +90,7 @@ export default {
       },
     },
     {
-      id: 'Lakshmi EX Divine Desire',
+      id: 'LakshmiEx Divine Desire',
       netRegex: NetRegexes.startsUsing({ id: '214B', source: 'Lakshmi', capture: false }),
       netRegexDe: NetRegexes.startsUsing({ id: '214B', source: 'Lakshmi', capture: false }),
       netRegexFr: NetRegexes.startsUsing({ id: '214B', source: 'Lakshmi', capture: false }),
@@ -110,7 +110,7 @@ export default {
       },
     },
     {
-      id: 'Lakshmi EX Divine Doubt',
+      id: 'LakshmiEx Divine Doubt',
       netRegex: NetRegexes.startsUsing({ id: '214A', source: 'Lakshmi', capture: false }),
       netRegexDe: NetRegexes.startsUsing({ id: '214A', source: 'Lakshmi', capture: false }),
       netRegexFr: NetRegexes.startsUsing({ id: '214A', source: 'Lakshmi', capture: false }),
@@ -130,7 +130,7 @@ export default {
       },
     },
     { // Stack marker
-      id: 'Lakshmi EX Pall of Light',
+      id: 'LakshmiEx Pall of Light',
       netRegex: NetRegexes.headMarker({ id: '003E' }),
       alertText: function(data, matches, output) {
         if (!data.chanchala)
@@ -186,7 +186,7 @@ export default {
       },
     },
     {
-      id: 'Lakshmi Stotram',
+      id: 'LakshmiEx Stotram',
       netRegex: NetRegexes.startsUsing({ id: '2147', source: 'Lakshmi', capture: false }),
       netRegexDe: NetRegexes.startsUsing({ id: '2147', source: 'Lakshmi', capture: false }),
       netRegexFr: NetRegexes.startsUsing({ id: '2147', source: 'Lakshmi', capture: false }),
@@ -208,7 +208,7 @@ export default {
     },
     {
       // Offtank cleave
-      id: 'Lakshmi Path of Light Marker',
+      id: 'LakshmiEx Path of Light Marker',
       netRegex: NetRegexes.headMarker({ id: '000E' }),
       condition: Conditions.targetIsYou(),
       alarmText: function(data, _, output) {
@@ -238,7 +238,7 @@ export default {
     },
     {
       // Cross aoe
-      id: 'Lakshmi Hand of Grace',
+      id: 'LakshmiEx Hand of Grace',
       netRegex: NetRegexes.headMarker({ id: '006B' }),
       condition: Conditions.targetIsYou(),
       infoText: function(data, _, output) {
@@ -268,7 +268,7 @@ export default {
     },
     {
       // Flower marker (healers)
-      id: 'Lakshmi Hand of Beauty',
+      id: 'LakshmiEx Hand of Beauty',
       netRegex: NetRegexes.headMarker({ id: '006D' }),
       condition: Conditions.targetIsYou(),
       infoText: function(data, _, output) {
@@ -298,7 +298,7 @@ export default {
     },
     {
       // Red marker during add phase
-      id: 'Lakshmi Water III',
+      id: 'LakshmiEx Water III',
       netRegex: NetRegexes.headMarker({ id: '0017' }),
       condition: Conditions.targetIsYou(),
       alertText: (data, _, output) => output.text(),

--- a/ui/raidboss/data/04-sb/trial/lakshmi-ex.js
+++ b/ui/raidboss/data/04-sb/trial/lakshmi-ex.js
@@ -9,7 +9,7 @@ export default {
   timelineFile: 'lakshmi-ex.txt',
   timelineTriggers: [
     {
-      id: 'Lakshmi Path of Light',
+      id: 'Lakshmi EX Path of Light',
       regex: /Path of Light/,
       beforeSeconds: 5,
       condition: function(data) {
@@ -20,7 +20,7 @@ export default {
   ],
   triggers: [
     {
-      id: 'Lakshmi Chanchala Gain',
+      id: 'Lakshmi EX Chanchala Gain',
       netRegex: NetRegexes.startsUsing({ id: '2148', source: 'Lakshmi', capture: false }),
       netRegexDe: NetRegexes.startsUsing({ id: '2148', source: 'Lakshmi', capture: false }),
       netRegexFr: NetRegexes.startsUsing({ id: '2148', source: 'Lakshmi', capture: false }),
@@ -32,7 +32,7 @@ export default {
       },
     },
     {
-      id: 'Lakshmi Chanchala Lose',
+      id: 'Lakshmi EX Chanchala Lose',
       netRegex: NetRegexes.losesEffect({ target: 'Lakshmi', effectId: '582', capture: false }),
       netRegexDe: NetRegexes.losesEffect({ target: 'Lakshmi', effectId: '582', capture: false }),
       netRegexFr: NetRegexes.losesEffect({ target: 'Lakshmi', effectId: '582', capture: false }),
@@ -44,7 +44,7 @@ export default {
       },
     },
     {
-      id: 'Lakshmi Pull of Light Tank',
+      id: 'Lakshmi EX Pull of Light Tank',
       netRegex: NetRegexes.startsUsing({ id: '215E', source: 'Lakshmi' }),
       netRegexDe: NetRegexes.startsUsing({ id: '215E', source: 'Lakshmi' }),
       netRegexFr: NetRegexes.startsUsing({ id: '215E', source: 'Lakshmi' }),
@@ -57,7 +57,7 @@ export default {
       response: Responses.tankBuster('info'),
     },
     {
-      id: 'Lakshmi Pull of Light Unexpected',
+      id: 'Lakshmi EX Pull of Light Unexpected',
       netRegex: NetRegexes.startsUsing({ id: '215E', source: 'Lakshmi' }),
       netRegexDe: NetRegexes.startsUsing({ id: '215E', source: 'Lakshmi' }),
       netRegexFr: NetRegexes.startsUsing({ id: '215E', source: 'Lakshmi' }),
@@ -70,7 +70,7 @@ export default {
       response: Responses.tankBuster('alarm'),
     },
     {
-      id: 'Lakshmi Divine Denial',
+      id: 'Lakshmi EX Divine Denial',
       netRegex: NetRegexes.startsUsing({ id: '2149', source: 'Lakshmi', capture: false }),
       netRegexDe: NetRegexes.startsUsing({ id: '2149', source: 'Lakshmi', capture: false }),
       netRegexFr: NetRegexes.startsUsing({ id: '2149', source: 'Lakshmi', capture: false }),
@@ -90,7 +90,7 @@ export default {
       },
     },
     {
-      id: 'Lakshmi Divine Desire',
+      id: 'Lakshmi EX Divine Desire',
       netRegex: NetRegexes.startsUsing({ id: '214B', source: 'Lakshmi', capture: false }),
       netRegexDe: NetRegexes.startsUsing({ id: '214B', source: 'Lakshmi', capture: false }),
       netRegexFr: NetRegexes.startsUsing({ id: '214B', source: 'Lakshmi', capture: false }),
@@ -110,7 +110,7 @@ export default {
       },
     },
     {
-      id: 'Lakshmi Divine Doubt',
+      id: 'Lakshmi EX Divine Doubt',
       netRegex: NetRegexes.startsUsing({ id: '214A', source: 'Lakshmi', capture: false }),
       netRegexDe: NetRegexes.startsUsing({ id: '214A', source: 'Lakshmi', capture: false }),
       netRegexFr: NetRegexes.startsUsing({ id: '214A', source: 'Lakshmi', capture: false }),
@@ -130,7 +130,7 @@ export default {
       },
     },
     { // Stack marker
-      id: 'Lakshmi Pall of Light',
+      id: 'Lakshmi EX Pall of Light',
       netRegex: NetRegexes.headMarker({ id: '003E' }),
       alertText: function(data, matches, output) {
         if (!data.chanchala)

--- a/ui/raidboss/data/04-sb/trial/lakshmi-ex.txt
+++ b/ui/raidboss/data/04-sb/trial/lakshmi-ex.txt
@@ -40,7 +40,7 @@ hideall "Alluring Arm"
 225.5 "The Pull Of Light" # end of castbar
 228.5 "The Path Of Light" duration 5.5 # hat -> cleave
 246.0 "Divine Desire" # end of castbar
-249.5 "--Chanchala over--"
+249.5 "--chanchala end--"
 
 258.2 "The Pull Of Light" # end of castbar
 266.2 "The Path Of Light" duration 5.5 # hat -> cleave
@@ -62,7 +62,7 @@ hideall "Alluring Arm"
 459.5 "Divine Doubt" # end of castbar
 470.5 "The Path Of Light" duration 5.5 # hat -> cleave
 485.2 "The Pull Of Light" # end of castbar
-488.5 "--Chanchala over--"
+488.5 "--chanchala end--"
 
 504.5 "Blissful Spear (Z)" duration 8.5 # appearing -> disappearing
 510.7 "The Pull Of Light" # end of castbar

--- a/ui/raidboss/data/04-sb/trial/lakshmi.js
+++ b/ui/raidboss/data/04-sb/trial/lakshmi.js
@@ -246,7 +246,6 @@ export default {
         'Lakshmi': 'Lakshmi',
       },
       'replaceText': {
-        '--Chanchala lose--': '--Chanchala terminé--',
         'Adds Appear': 'Apparition d\'adds',
         'Alluring Arm': 'Bras séduisants',
         'Blissful Spear': 'Épieu béatifiant',

--- a/ui/raidboss/data/04-sb/trial/lakshmi.js
+++ b/ui/raidboss/data/04-sb/trial/lakshmi.js
@@ -3,7 +3,7 @@ import NetRegexes from '../../../../../resources/netregexes';
 import { Responses } from '../../../../../resources/responses';
 import ZoneId from '../../../../../resources/zone_id';
 
-// Lakshmi Extreme
+// Lakshmi Normal
 export default {
   zoneId: ZoneId.Emanation,
   timelineFile: 'lakshmi.txt',
@@ -129,7 +129,7 @@ export default {
           return;
         if (data.me === matches.target)
           return output.stackOnYou();
-        return output.stack({ target: matches.target });
+        return output.stackOn({ player: matches.target });
       },
       outputStrings: {
         dontStack: {
@@ -143,8 +143,13 @@ export default {
           cn: '分摊点名',
           ko: '쉐어징 대상자',
         },
-        stack: {
-          en: 'Stack on ${target}',
+        stackOn: {
+          en: 'Stack on ${player}',
+          de: 'Sammeln auf ${player}',
+          fr: 'Packez-vous sur ${player}',
+          ja: '${player}と頭割り',
+          cn: '靠近${player}分摊',
+          ko: '"${player}" 쉐어징',
         },
       },
     },

--- a/ui/raidboss/data/04-sb/trial/lakshmi.js
+++ b/ui/raidboss/data/04-sb/trial/lakshmi.js
@@ -82,7 +82,7 @@ export default {
       alertText: (data, _, output) => output.text(),
       outputStrings: {
         text: {
-          en: 'Vrill + Knockback',
+          en: 'Vril + Knockback',
           de: 'Vril + Rückstoß',
           fr: 'Vril + Poussée',
           ja: 'エーテル + 完全なる拒絶',

--- a/ui/raidboss/data/04-sb/trial/lakshmi.js
+++ b/ui/raidboss/data/04-sb/trial/lakshmi.js
@@ -1,0 +1,338 @@
+import Conditions from '../../../../../resources/conditions';
+import NetRegexes from '../../../../../resources/netregexes';
+import { Responses } from '../../../../../resources/responses';
+import ZoneId from '../../../../../resources/zone_id';
+
+// Lakshmi Extreme
+export default {
+  zoneId: ZoneId.Emanation,
+  timelineFile: 'lakshmi.txt',
+  triggers: [
+    {
+      id: 'Lakshmi Chanchala Gain',
+      netRegex: NetRegexes.gainsEffect({ target: 'Lakshmi', effectId: '582', capture: false }),
+      netRegexDe: NetRegexes.gainsEffect({ target: 'Lakshmi', effectId: '582', capture: false }),
+      netRegexFr: NetRegexes.gainsEffect({ target: 'Lakshmi', effectId: '582', capture: false }),
+      netRegexJa: NetRegexes.gainsEffect({ target: 'ラクシュミ', effectId: '582', capture: false }),
+      netRegexCn: NetRegexes.gainsEffect({ target: '吉祥天女', effectId: '582', capture: false }),
+      netRegexKo: NetRegexes.gainsEffect({ target: '락슈미', effectId: '582', capture: false }),
+      run: function(data) {
+        data.chanchala = true;
+      },
+    },
+    {
+      id: 'Lakshmi Chanchala Lose',
+      netRegex: NetRegexes.losesEffect({ target: 'Lakshmi', effectId: '582', capture: false }),
+      netRegexDe: NetRegexes.losesEffect({ target: 'Lakshmi', effectId: '582', capture: false }),
+      netRegexFr: NetRegexes.losesEffect({ target: 'Lakshmi', effectId: '582', capture: false }),
+      netRegexJa: NetRegexes.losesEffect({ target: 'ラクシュミ', effectId: '582', capture: false }),
+      netRegexCn: NetRegexes.losesEffect({ target: '吉祥天女', effectId: '582', capture: false }),
+      netRegexKo: NetRegexes.losesEffect({ target: '락슈미', effectId: '582', capture: false }),
+      run: function(data) {
+        data.chanchala = false;
+      },
+    },
+    {
+      // 2492 is normal, 2493 is under Chanchala
+      id: 'Lakshmi Pull of Light',
+      netRegex: NetRegexes.startsUsing({ id: ['2492', '2493'], source: 'Lakshmi' }),
+      netRegexDe: NetRegexes.startsUsing({ id: ['2492', '2493'], source: 'Lakshmi' }),
+      netRegexFr: NetRegexes.startsUsing({ id: ['2492', '2493'], source: 'Lakshmi' }),
+      netRegexJa: NetRegexes.startsUsing({ id: ['2492', '2493'], source: 'ラクシュミ' }),
+      netRegexCn: NetRegexes.startsUsing({ id: ['2492', '2493'], source: '吉祥天女' }),
+      netRegexKo: NetRegexes.startsUsing({ id: ['2492', '2493'], source: '락슈미' }),
+      condition: Conditions.caresAboutMagical(),
+      response: Responses.tankBuster('info'),
+    },
+    {
+      id: 'Lakshmi Stotram',
+      netRegex: NetRegexes.startsUsing({ id: '249E', source: 'Lakshmi', capture: false }),
+      netRegexDe: NetRegexes.startsUsing({ id: '249E', source: 'Lakshmi', capture: false }),
+      netRegexFr: NetRegexes.startsUsing({ id: '249E', source: 'Lakshmi', capture: false }),
+      netRegexJa: NetRegexes.startsUsing({ id: '249E', source: 'ラクシュミ', capture: false }),
+      netRegexCn: NetRegexes.startsUsing({ id: '249E', source: '吉祥天女', capture: false }),
+      netRegexKo: NetRegexes.startsUsing({ id: '249E', source: '락슈미', capture: false }),
+      condition: Conditions.caresAboutAOE(),
+      response: Responses.aoe(),
+    },
+    {
+      // Intermission ability. The user WILL die if they don't use Vril.
+      id: 'Lakshmi Jagadishwari',
+      netRegex: NetRegexes.ability({ id: '2342', source: 'Lakshmi', capture: false }),
+      netRegexDe: NetRegexes.ability({ id: '2342', source: 'Lakshmi', capture: false }),
+      netRegexFr: NetRegexes.ability({ id: '2342', source: 'Lakshmi', capture: false }),
+      netRegexJa: NetRegexes.ability({ id: '2342', source: 'ラクシュミ', capture: false }),
+      netRegexCn: NetRegexes.ability({ id: '2342', source: '吉祥天女', capture: false }),
+      netRegexKo: NetRegexes.ability({ id: '2342', source: '락슈미', capture: false }),
+      alarmText: (data, _, output) => output.text(),
+      outputStrings: {
+        text: {
+          en: 'USE VRIL OR DIE',
+        },
+      },
+    },
+    {
+      id: 'Lakshmi Divine Denial',
+      netRegex: NetRegexes.startsUsing({ id: '2485', source: 'Lakshmi', capture: false }),
+      netRegexDe: NetRegexes.startsUsing({ id: '2485', source: 'Lakshmi', capture: false }),
+      netRegexFr: NetRegexes.startsUsing({ id: '2485', source: 'Lakshmi', capture: false }),
+      netRegexJa: NetRegexes.startsUsing({ id: '2485', source: 'ラクシュミ', capture: false }),
+      netRegexCn: NetRegexes.startsUsing({ id: '2485', source: '吉祥天女', capture: false }),
+      netRegexKo: NetRegexes.startsUsing({ id: '2485', source: '락슈미', capture: false }),
+      alertText: (data, _, output) => output.text(),
+      outputStrings: {
+        text: {
+          en: 'Vrill + Knockback',
+          de: 'Vril + Rückstoß',
+          fr: 'Vril + Poussée',
+          ja: 'エーテル + 完全なる拒絶',
+          cn: '完全拒绝',
+          ko: '락슈미 에테르 + 넉백',
+        },
+      },
+    },
+    {
+      // Nobody with a different marker should be told to stack.
+      id: 'Lakshmi Headmarker Collect',
+      netRegex: NetRegexes.headMarker({ }),
+      run: (data, matches) => {
+        data.avoidStack = data.avoidStack || [];
+        if (matches.id !== '003E')
+          data.avoidStack.push(matches.target);
+      },
+    },
+    {
+      // Activating on any use of Hand of Beauty/Grace or Alluring Arm.
+      // Head markers don't appear until the end of the castbar,
+      // and every head marker section begins with one of these abilities,
+      // so this should be perfectly safe.
+      id: 'Lakshmi Headmarker Cleanup',
+      netRegex: NetRegexes.startsUsing({ id: ['2486', '2487', '2488'], source: 'Lakshmi', capture: false }),
+      netRegexDe: NetRegexes.startsUsing({ id: ['2486', '2487', '2488'], source: 'Lakshmi', capture: false }),
+      netRegexFr: NetRegexes.startsUsing({ id: ['2486', '2487', '2488'], source: 'Lakshmi', capture: false }),
+      netRegexJa: NetRegexes.startsUsing({ id: ['2486', '2487', '2488'], source: 'ラクシュミ', capture: false }),
+      netRegexCn: NetRegexes.startsUsing({ id: ['2486', '2487', '2488'], source: '吉祥天女', capture: false }),
+      netRegexKo: NetRegexes.startsUsing({ id: ['2486', '2487', '2488'], source: '락슈미', capture: false }),
+      run: (data) => delete data.avoidStack,
+    },
+    { // Stack marker
+      id: 'Lakshmi Pall of Light',
+      netRegex: NetRegexes.headMarker({ id: '003E' }),
+      delaySeconds: 0.5,
+      alertText: function(data, matches, output) {
+        if (!data.avoidStack.includes(data.me))
+          return;
+        return output.dontStack();
+      },
+      infoText: function(data, matches, output) {
+        if (data.avoidStack.includes(data.me))
+          return;
+        if (data.me === matches.target)
+          return output.stackOnYou();
+        return output.stack({ target: matches.target });
+      },
+      outputStrings: {
+        dontStack: {
+          en: 'Don\'t Stack!',
+        },
+        stackOnYou: {
+          en: 'Stack on YOU',
+          de: 'Stack auf DIR',
+          fr: 'Package sur VOUS',
+          ja: '自分に頭割り',
+          cn: '分摊点名',
+          ko: '쉐어징 대상자',
+        },
+        stack: {
+          en: 'Stack on ${target}',
+        },
+      },
+    },
+    {
+      // Off-tank cleave
+      id: 'Lakshmi Path of Light',
+      netRegex: NetRegexes.headMarker({ id: '000E' }),
+      response: Responses.tankCleave(),
+    },
+    {
+      // Cross aoe
+      id: 'Lakshmi Hand of Grace',
+      netRegex: NetRegexes.headMarker({ id: '006B' }),
+      condition: Conditions.targetIsYou(),
+      infoText: (data, _, output) => output.text(),
+      outputStrings: {
+        text: {
+          en: 'Cross Marker',
+          de: 'Kreuz-Marker',
+          fr: 'Marqueur croix',
+          ja: '自分に右手',
+          cn: '十字点名',
+          ko: '십자 장판 징',
+        },
+      },
+    },
+    {
+      // Circle
+      id: 'Lakshmi Hand of Beauty',
+      netRegex: NetRegexes.headMarker({ id: '006D' }),
+      condition: Conditions.targetIsYou(),
+      infoText: function(data, _, output) {
+        if (data.chanchala)
+          return output.powerFlower();
+
+        return output.flower();
+      },
+      outputStrings: {
+        powerFlower: {
+          en: 'Expanding Flower Marker',
+        },
+        flower: {
+          en: 'Flower Marker',
+          de: 'Blumen-Marker',
+          fr: 'Marqueur fleur',
+          ja: '自分に左手',
+          cn: '花点名',
+          ko: '원형 장판 징',
+        },
+      },
+    },
+  ],
+  timelineReplace: [
+    {
+      'locale': 'en',
+      'replaceText': {
+        'Blissful Arrow': 'Blissful Arrow (cross)',
+        'Blissful Spear': 'Blissful Spear (circle)',
+        'The Pall Of Light': 'Pall Of Light (stack)',
+        'The Path Of Light': 'Path Of Light (OT cleave)',
+        'The Pull Of Light': 'Pull Of Light (MT buster)',
+      },
+    },
+    {
+      'locale': 'de',
+      'missingTranslations': true,
+      'replaceSync': {
+        'Dreaming Kshatriya': 'verträumt(?:e|er|es|en) Kshatriya',
+        'Lakshmi': 'Lakshmi',
+      },
+      'replaceText': {
+        'Adds Appear': 'Adds erscheinen',
+        'Alluring Arm': 'Anziehender Arm',
+        'Blissful Spear': 'Speer der Gnade',
+        'Chanchala': 'Chanchala',
+        'Divine Denial': 'Göttliche Leugnung',
+        'Divine Desire': 'Göttliche Lockung',
+        'Divine Doubt': 'Göttliche Bestürzung',
+        'Hand Of Beauty': 'Hand der Schönheit',
+        'Hand Of Grace': 'Hand der Anmut',
+        'Hands Of Grace/Beauty': 'Hand Der Anmut/Schönheit',
+        'Inner Demons': 'Dämonen in dir',
+        'Stotram': 'Stotram',
+        'The Pall Of Light': 'Flut des Lichts',
+        'The Path Of Light': 'Pfad des Lichts',
+        'The Pull Of Light': 'Strom des Lichts',
+      },
+    },
+    {
+      'locale': 'fr',
+      'missingTranslations': true,
+      'replaceSync': {
+        'Dreaming Kshatriya': 'kshatriya rêveuse',
+        'Lakshmi': 'Lakshmi',
+      },
+      'replaceText': {
+        '--Chanchala lose--': '--Chanchala terminé--',
+        'Adds Appear': 'Apparition d\'adds',
+        'Alluring Arm': 'Bras séduisants',
+        'Blissful Spear': 'Épieu béatifiant',
+        'Chanchala': 'Chanchala',
+        'Divine Denial': 'Refus divin',
+        'Divine Desire': 'Désir divin',
+        'Divine Doubt': 'Doute divin',
+        'Hand Of Beauty': 'Main de la beauté',
+        'Hand Of Grace': 'Main de la grâce',
+        'Hands Of Grace/Beauty': 'Main De La Grâce/Beauté',
+        'Inner Demons': 'Démons intérieurs',
+        'Stotram': 'Stotram',
+        'The Pall Of Light': 'Voile de lumière',
+        'The Path Of Light': 'Voie de lumière',
+        'The Pull Of Light': 'Flot de lumière',
+      },
+    },
+    {
+      'locale': 'ja',
+      'missingTranslations': true,
+      'replaceSync': {
+        'Dreaming Kshatriya': 'テンパード・クシャトリア',
+        'Lakshmi': 'ラクシュミ',
+      },
+      'replaceText': {
+        'Adds Appear': '雑魚',
+        'Alluring Arm': '魅惑の腕',
+        'Blissful Spear': '聖なる槍',
+        'Chanchala': 'チャンチャラー',
+        'Divine Denial': '完全なる拒絶',
+        'Divine Desire': '完全なる誘引',
+        'Divine Doubt': '完全なる惑乱',
+        'Hand Of Beauty': '優美なる左手',
+        'Hand Of Grace': '優雅なる右手',
+        'Hands Of Grace/Beauty': '右手/左手',
+        'Inner Demons': 'イナーデーモン',
+        'Stotram': 'ストトラム',
+        'The Pall Of Light': '光の瀑布',
+        'The Path Of Light': '光の波動',
+        'The Pull Of Light': '光の奔流',
+      },
+    },
+    {
+      'locale': 'cn',
+      'missingTranslations': true,
+      'replaceSync': {
+        'Dreaming Kshatriya': '梦寐的刹帝利',
+        'Lakshmi': '吉祥天女',
+      },
+      'replaceText': {
+        'Adds Appear': '小怪出现',
+        'Alluring Arm': '魅惑之臂',
+        'Blissful Spear': '圣枪',
+        'Chanchala': '反复无常',
+        'Divine Denial': '完全拒绝',
+        'Divine Desire': '完全引诱',
+        'Divine Doubt': '完全惑乱',
+        'Hand Of Beauty': '优美的左手',
+        'Hand Of Grace': '优雅的右手',
+        'Hands Of Grace/Beauty': '右手/左手',
+        'Inner Demons': '心魔',
+        'Stotram': '赞歌',
+        'The Pall Of Light': '光之瀑布',
+        'The Path Of Light': '光之波动',
+        'The Pull Of Light': '光之奔流',
+      },
+    },
+    {
+      'locale': 'ko',
+      'missingTranslations': true,
+      'replaceSync': {
+        'Dreaming Kshatriya': '신도화된 크샤트리아',
+        'Lakshmi': '락슈미',
+      },
+      'replaceText': {
+        'Adds Appear': '쫄',
+        'Alluring Arm': '매혹적인 팔',
+        'Blissful Spear': '성스러운 창',
+        'Chanchala': '찬찰라',
+        'Divine Denial': '완전한 거절',
+        'Divine Desire': '완전한 유인',
+        'Divine Doubt': '완전한 혼란',
+        'Hand Of Beauty': '아름다운 왼손',
+        'Hand Of Grace': '우아한 오른손',
+        'Hands Of Grace/Beauty': '아름다운 왼손/오른손',
+        'Inner Demons': '내면의 악마',
+        'Stotram': '스토트람',
+        'The Pall Of Light': '빛의 폭포',
+        'The Path Of Light': '빛의 파동',
+        'The Pull Of Light': '빛의 급류',
+      },
+    },
+  ],
+};

--- a/ui/raidboss/data/04-sb/trial/lakshmi.txt
+++ b/ui/raidboss/data/04-sb/trial/lakshmi.txt
@@ -18,81 +18,79 @@ hideall "Alluring Arm"
 
 # We can't sync to abilities here to make the loop visible,
 # since two adds are present, and the timeline would jerk around.
-60.0 "--sync--" sync /.*/ window 0,30 jump 30
+# A group that actually manages to bridge this gap is doing so deliberately,
+# and it's probably not necessary to account for that edge case.
 
-100.0 "--sync--" sync /:Lakshmi:2157:/ window 100,5
-107.1 "Hand Of Grace" sync /:Lakshmi:2486:/
-121.3 "Blissful Arrow" sync /:Lakshmi:2489:/
-121.9 "Blissful Spear" sync /:Lakshmi:248B:/
-132.3 "The Pull Of Light" sync /:Lakshmi:2492:/
-144.5 "Hand Of Beauty" sync /:Lakshmi:2487:/
-158.8 "Blissful Spear" sync /:Lakshmi:2494:/
-165.7 "Stotram" sync /:Lakshmi:2483:/
-167.9 "--vril spawn--"
-169.0 "--untargetable--"
+1000.0 "--sync--" sync /:Lakshmi:2157:/ window 1000,5
+1007.1 "Hand Of Grace" sync /:Lakshmi:2486:/
+1021.3 "Blissful Arrow" sync /:Lakshmi:2489:/
+1021.9 "Blissful Spear" sync /:Lakshmi:248B:/
+1032.3 "The Pull Of Light" sync /:Lakshmi:2492:/
+1044.5 "Hand Of Beauty" sync /:Lakshmi:2487:/
+1058.8 "Blissful Spear" sync /:Lakshmi:2494:/
+1065.7 "Stotram" sync /:Lakshmi:2483:/
+1067.9 "--vril spawn--"
+1069.0 "--untargetable--"
 
-169.9 "Jagadishwari" sync /:Lakshmi:2342:/ window 169.9,30
-186.1 "--sync--" sync /:Lakshmi:2459:/
-189.6 "--stun--"
-190.4 "--sync--" sync /:Lakshmi:245A:/
-191.2 "--sync--" sync /:Lakshmi:248E:/
-206.9 "Alluring Embrace" sync /:Lakshmi:2496:/
-211.3 "--targetable--"
+1069.9 "Jagadishwari" sync /:Lakshmi:2342:/ window 169.9,30
+1086.1 "--sync--" sync /:Lakshmi:2459:/
+1089.6 "--stun--"
+1090.4 "--sync--" sync /:Lakshmi:245A:/
+1091.2 "--sync--" sync /:Lakshmi:248E:/
+1106.9 "Alluring Embrace" sync /:Lakshmi:2496:/
+1111.3 "--targetable--"
 
-214.5 "Chanchala" sync /:Lakshmi:2484:/ window 214.5,15
-216.7 "--chanchala gain--"
-222.6 "Stotram" sync /:Lakshmi:249E:/
-224.5 "--vril spawn--"
-234.9 "Divine Denial" sync /:Lakshmi:2485:/ window 234.9,30
-234.9 "--vril despawn--"
-247.1 "Hand Of Beauty" sync /:Lakshmi:2487:/
-254.3 "The Pull Of Light" sync /:Lakshmi:2493:/
-261.4 "Blissful Spear" sync /:Lakshmi:2495:/
-270.7 "The Path Of Light" sync /:Lakshmi:24A1:/ window 270.7,30
-284.9 "Hand Of Grace" sync /:Lakshmi:2486:/
-292.1 "The Pall Of Light" sync /:Lakshmi:2491:/
-299.1 "Blissful Arrow" sync /:Lakshmi:248A:/
-299.7 "Blissful Spear" sync /:Lakshmi:248C:/
-305.3 "Stotram" sync /:Lakshmi:249E:/
-307.6 "--vril spawn--"
-320.2 "Divine Denial" sync /:Lakshmi:2485:/ window 30,30
-320.2 "--vril despawn--"
-321.6 "--chanchala lose--"
-334.5 "Alluring Arm" sync /:Lakshmi:2488:/
-348.8 "Blissful Arrow/Spear" sync /:Lakshmi:(2489|2494):/
-356.8 "The Pull Of Light" sync /:Lakshmi:2492:/
+1114.5 "Chanchala" sync /:Lakshmi:2484:/ window 214.5,15
+1116.7 "--chanchala gain--"
+1122.6 "Stotram" sync /:Lakshmi:249E:/
+1124.5 "--vril spawn--"
+1134.9 "Divine Denial" sync /:Lakshmi:2485:/ window 234.9,30
+1134.9 "--vril despawn--"
+1147.1 "Hand Of Beauty" sync /:Lakshmi:2487:/
+1154.3 "The Pull Of Light" sync /:Lakshmi:2493:/
+1161.4 "Blissful Spear" sync /:Lakshmi:2495:/
+1170.7 "The Path Of Light" sync /:Lakshmi:24A1:/ window 270.7,30
+1184.9 "Hand Of Grace" sync /:Lakshmi:2486:/
+1192.1 "The Pall Of Light" sync /:Lakshmi:2491:/
+1199.1 "Blissful Arrow" sync /:Lakshmi:248A:/
+1199.7 "Blissful Spear" sync /:Lakshmi:248C:/
+1205.3 "Stotram" sync /:Lakshmi:249E:/
+1207.6 "--vril spawn--"
+1220.2 "Divine Denial" sync /:Lakshmi:2485:/ window 30,30
+1220.2 "--vril despawn--"
+1221.6 "--chanchala lose--"
+1234.5 "Alluring Arm" sync /:Lakshmi:2488:/
+1248.8 "Blissful Arrow/Spear" sync /:Lakshmi:(2489|2494):/
+1256.8 "The Pull Of Light" sync /:Lakshmi:2492:/
 
-365.0 "Chanchala" sync /:Lakshmi:2484:/ window 30,30
-365.9 "--chanchala gain--"
-379.2 "Hand Of Grace" sync /:Lakshmi:2486:/
-392.4 "The Pall Of Light" sync /:Lakshmi:2491:/
-393.4 "Blissful Arrow" sync /:Lakshmi:248A:/
-394.0 "Blissful Spear" sync /:Lakshmi:248C:/
-402.6 "Stotram" sync /:Lakshmi:249E:/
-404.4 "--vril spawn--"
-417.9 "Divine Denial" sync /:Lakshmi:2485:/ window 30,30
-417.9 "--vril despawn--"
-432.1 "Alluring Arm" sync /:Lakshmi:2488:/
-446.4 "Blissful Arrow/Spear" sync /:Lakshmi:(248A|2495):/
-448.4 "The Pall Of Light" sync /:Lakshmi:2491:/ window 30,30
-460.5 "The Pull Of Light" sync /:Lakshmi:2493:/
-460.9 "--chanchala lose--"
-478.9 "Alluring Arm" sync /:Lakshmi:2488:/
-492.1 "Stotram" sync /:Lakshmi:2483:/ window 30,30
-493.9 "--vril spawn--"
-493.2 "Blissful Spear" sync /:Lakshmi:2494:/
-502.3 "The Pull Of Light" sync /:Lakshmi:2492:/
-507.4 "--vril despawn--"
-521.5 "Alluring Arm" sync /:Lakshmi:2488:/
-530.9 "The Path Of Light" sync /:Lakshmi:248F:/ window 30,30
-535.7 "Blissful Spear" sync /:Lakshmi:2494:/
-540.0 "The Pall Of Light" sync /:Lakshmi:2490:/
-552.2 "The Pull Of Light" sync /:Lakshmi:2492:/
+1265.0 "Chanchala" sync /:Lakshmi:2484:/ window 30,30
+1265.9 "--chanchala gain--"
+1279.2 "Hand Of Grace" sync /:Lakshmi:2486:/
+1292.4 "The Pall Of Light" sync /:Lakshmi:2491:/
+1293.4 "Blissful Arrow" sync /:Lakshmi:248A:/
+1294.0 "Blissful Spear" sync /:Lakshmi:248C:/
+1302.6 "Stotram" sync /:Lakshmi:249E:/
+1304.4 "--vril spawn--"
+1317.9 "Divine Denial" sync /:Lakshmi:2485:/ window 30,30
+1317.9 "--vril despawn--"
+1332.1 "Alluring Arm" sync /:Lakshmi:2488:/
+1346.4 "Blissful Arrow/Spear" sync /:Lakshmi:(248A|2495):/
+1348.4 "The Pall Of Light" sync /:Lakshmi:2491:/ window 30,30
+1360.5 "The Pull Of Light" sync /:Lakshmi:2493:/
+1360.9 "--chanchala lose--"
+1378.9 "Alluring Arm" sync /:Lakshmi:2488:/
+1392.1 "Stotram" sync /:Lakshmi:2483:/ window 30,30
+1393.9 "--vril spawn--"
+1393.2 "Blissful Spear" sync /:Lakshmi:2494:/
+1402.3 "The Pull Of Light" sync /:Lakshmi:2492:/
+1407.4 "--vril despawn--"
+1421.5 "Alluring Arm" sync /:Lakshmi:2488:/
+1430.9 "The Path Of Light" sync /:Lakshmi:248F:/ window 30,30
+1435.7 "Blissful Spear" sync /:Lakshmi:2494:/
+1440.0 "The Pall Of Light" sync /:Lakshmi:2490:/
+1452.2 "The Pull Of Light" sync /:Lakshmi:2492:/
 
-565.5 "Chanchala" sync /:Lakshmi:2484:/ window 30,30 jump 365.0
-566.4 "--chanchala gain--"
-579.7 "Hand Of Grace"
-592.9 "The Pall Of Light"
-593.9 "Blissful Arrow"
-594.5 "Blissful Spear"
-603.1 "Stotram"
+1465.5 "Chanchala" sync /:Lakshmi:2484:/ window 30,30 jump 365.0
+1466.4 "--chanchala gain--"
+1479.7 "Hand Of Grace"
+1492.9 "The Pall Of Light"

--- a/ui/raidboss/data/04-sb/trial/lakshmi.txt
+++ b/ui/raidboss/data/04-sb/trial/lakshmi.txt
@@ -1,0 +1,98 @@
+# Emanation (normal mode)
+# Lakshmi
+
+hideall "--Reset--"
+hideall "--sync--"
+hideall "Alluring Arm"
+
+# -ii 2157 248B 248D
+
+0.0 "--Reset--" sync / 21:........:40000010:/ window 10000 jump 0
+
+0 "Start" sync /Engage!/ window 0,1
+3.9 "Vril" sync /:Dreaming Kshatriya:2482:/ window 3.9,5
+13.0 "Stotram" sync /:Lakshmi:2483:/ window 13,5
+16.1 "Inner Demons" # sync /:Dreaming Kshatriya:258D:/
+19.0 "Aether Drain" sync /:Vril:248D:/
+29.3 "Tail Slap" # sync /:Dreaming Kshatriya:258C:/
+
+# We can't sync to abilities here to make the loop visible,
+# since two adds are present, and the timeline would jerk around.
+60.0 "--sync--" sync /.*/ window 0,30 jump 30
+
+100.0 "--sync--" sync /:Lakshmi:2157:/ window 100,5
+107.1 "Hand Of Grace" sync /:Lakshmi:2486:/
+121.3 "Blissful Arrow" sync /:Lakshmi:2489:/
+121.9 "Blissful Spear" sync /:Lakshmi:248B:/
+132.3 "The Pull Of Light" sync /:Lakshmi:2492:/
+144.5 "Hand Of Beauty" sync /:Lakshmi:2487:/
+158.8 "Blissful Spear" sync /:Lakshmi:2494:/
+165.7 "Stotram" sync /:Lakshmi:2483:/
+167.9 "--vril spawn--"
+169.0 "--untargetable--"
+
+169.9 "Jagadishwari" sync /:Lakshmi:2342:/ window 169.9,30
+186.1 "--sync--" sync /:Lakshmi:2459:/
+189.6 "--stun--"
+190.4 "--sync--" sync /:Lakshmi:245A:/
+191.2 "--sync--" sync /:Lakshmi:248E:/
+206.9 "Alluring Embrace" sync /:Lakshmi:2496:/
+211.3 "--targetable--"
+
+214.5 "Chanchala" sync /:Lakshmi:2484:/ window 214.5,15
+216.7 "--chanchala gain--"
+222.6 "Stotram" sync /:Lakshmi:249E:/
+224.5 "--vril spawn--"
+234.9 "Divine Denial" sync /:Lakshmi:2485:/ window 234.9,30
+234.9 "--vril despawn--"
+247.1 "Hand Of Beauty" sync /:Lakshmi:2487:/
+254.3 "The Pull Of Light" sync /:Lakshmi:2493:/
+261.4 "Blissful Spear" sync /:Lakshmi:2495:/
+270.7 "The Path Of Light" sync /:Lakshmi:24A1:/ window 270.7,30
+284.9 "Hand Of Grace" sync /:Lakshmi:2486:/
+292.1 "The Pall Of Light" sync /:Lakshmi:2491:/
+299.1 "Blissful Arrow" sync /:Lakshmi:248A:/
+299.7 "Blissful Spear" sync /:Lakshmi:248C:/
+305.3 "Stotram" sync /:Lakshmi:249E:/
+307.6 "--vril spawn--"
+320.2 "Divine Denial" sync /:Lakshmi:2485:/ window 30,30
+320.2 "--vril despawn--"
+321.6 "--chanchala lose--"
+334.5 "Alluring Arm" sync /:Lakshmi:2488:/
+348.8 "Blissful Arrow/Spear" sync /:Lakshmi:(2489|2494):/
+356.8 "The Pull Of Light" sync /:Lakshmi:2492:/
+
+365.0 "Chanchala" sync /:Lakshmi:2484:/ window 30,30
+365.9 "--chanchala gain--"
+379.2 "Hand Of Grace" sync /:Lakshmi:2486:/
+392.4 "The Pall Of Light" sync /:Lakshmi:2491:/
+393.4 "Blissful Arrow" sync /:Lakshmi:248A:/
+394.0 "Blissful Spear" sync /:Lakshmi:248C:/
+402.6 "Stotram" sync /:Lakshmi:249E:/
+404.4 "--vril spawn--"
+417.9 "Divine Denial" sync /:Lakshmi:2485:/ window 30,30
+417.9 "--vril despawn--"
+432.1 "Alluring Arm" sync /:Lakshmi:2488:/
+446.4 "Blissful Arrow/Spear" sync /:Lakshmi:(248A|2495):/
+448.4 "The Pall Of Light" sync /:Lakshmi:2491:/ window 30,30
+460.5 "The Pull Of Light" sync /:Lakshmi:2493:/
+460.9 "--chanchala lose--"
+478.9 "Alluring Arm" sync /:Lakshmi:2488:/
+492.1 "Stotram" sync /:Lakshmi:2483:/ window 30,30
+493.9 "--vril spawn--"
+493.2 "Blissful Spear" sync /:Lakshmi:2494:/
+502.3 "The Pull Of Light" sync /:Lakshmi:2492:/
+507.4 "--vril despawn--"
+521.5 "Alluring Arm" sync /:Lakshmi:2488:/
+530.9 "The Path Of Light" sync /:Lakshmi:248F:/ window 30,30
+535.7 "Blissful Spear" sync /:Lakshmi:2494:/
+540.0 "The Pall Of Light" sync /:Lakshmi:2490:/
+552.2 "The Pull Of Light" sync /:Lakshmi:2492:/
+
+565.5 "Chanchala" sync /:Lakshmi:2484:/ window 30,30 jump 365.0
+566.4 "--chanchala gain--"
+579.7 "Hand Of Grace"
+592.9 "The Pall Of Light"
+593.9 "Blissful Arrow"
+594.5 "Blissful Spear"
+603.1 "Stotram"

--- a/ui/raidboss/data/04-sb/trial/lakshmi.txt
+++ b/ui/raidboss/data/04-sb/trial/lakshmi.txt
@@ -41,7 +41,7 @@ hideall "Alluring Arm"
 1111.3 "--targetable--"
 
 1114.5 "Chanchala" sync /:Lakshmi:2484:/ window 214.5,15
-1116.7 "--chanchala gain--"
+1116.7 "--chanchala start--"
 1122.6 "Stotram" sync /:Lakshmi:249E:/
 1124.5 "--vril spawn--"
 1134.9 "Divine Denial" sync /:Lakshmi:2485:/ window 234.9,30
@@ -58,13 +58,13 @@ hideall "Alluring Arm"
 1207.6 "--vril spawn--"
 1220.2 "Divine Denial" sync /:Lakshmi:2485:/ window 30,30
 1220.2 "--vril despawn--"
-1221.6 "--chanchala lose--"
+1221.6 "--chanchala end--"
 1234.5 "Alluring Arm" sync /:Lakshmi:2488:/
 1248.8 "Blissful Arrow/Spear" sync /:Lakshmi:(2489|2494):/
 1256.8 "The Pull Of Light" sync /:Lakshmi:2492:/
 
 1265.0 "Chanchala" sync /:Lakshmi:2484:/ window 30,30
-1265.9 "--chanchala gain--"
+1265.9 "--chanchala start--"
 1279.2 "Hand Of Grace" sync /:Lakshmi:2486:/
 1292.4 "The Pall Of Light" sync /:Lakshmi:2491:/
 1293.4 "Blissful Arrow" sync /:Lakshmi:248A:/
@@ -77,7 +77,7 @@ hideall "Alluring Arm"
 1346.4 "Blissful Arrow/Spear" sync /:Lakshmi:(248A|2495):/
 1348.4 "The Pall Of Light" sync /:Lakshmi:2491:/ window 30,30
 1360.5 "The Pull Of Light" sync /:Lakshmi:2493:/
-1360.9 "--chanchala lose--"
+1360.9 "--chanchala end--"
 1378.9 "Alluring Arm" sync /:Lakshmi:2488:/
 1392.1 "Stotram" sync /:Lakshmi:2483:/ window 30,30
 1393.9 "--vril spawn--"
@@ -91,6 +91,6 @@ hideall "Alluring Arm"
 1452.2 "The Pull Of Light" sync /:Lakshmi:2492:/
 
 1465.5 "Chanchala" sync /:Lakshmi:2484:/ window 30,30 jump 365.0
-1466.4 "--chanchala gain--"
+1466.4 "--chanchala start--"
 1479.7 "Hand Of Grace"
 1492.9 "The Pall Of Light"

--- a/ui/raidboss/data/04-sb/trial/lakshmi.txt
+++ b/ui/raidboss/data/04-sb/trial/lakshmi.txt
@@ -90,7 +90,7 @@ hideall "Alluring Arm"
 1440.0 "The Pall Of Light" sync /:Lakshmi:2490:/
 1452.2 "The Pull Of Light" sync /:Lakshmi:2492:/
 
-1465.5 "Chanchala" sync /:Lakshmi:2484:/ window 30,30 jump 365.0
+1465.5 "Chanchala" sync /:Lakshmi:2484:/ window 30,30 jump 1365.0
 1466.4 "--chanchala start--"
 1479.7 "Hand Of Grace"
 1492.9 "The Pall Of Light"

--- a/ui/raidboss/data/manifest.txt
+++ b/ui/raidboss/data/manifest.txt
@@ -176,6 +176,8 @@
 04-sb/raid/o9s.txt
 04-sb/trial/byakko-ex.js
 04-sb/trial/byakko-ex.txt
+04-sb/trial/lakshmi.js
+04-sb/trial/lakshmi.txt
 04-sb/trial/lakshmi-ex.js
 04-sb/trial/lakshmi-ex.txt
 04-sb/trial/rathalos-ex.js


### PR DESCRIPTION
I modified the trigger names in EX so as to avoid any possibility of collisions. I didn't *think* this was a problem since it's a necessary disambiguation, but I can revert those changes and submit them separately if necessary.

One of the patterns involving stack markers combined with other markers does technically give people enough time to stack, but it's probably best to keep them away so puddle people don't clip the stack. This is particularly important during Chanchala phases, since the puddles expand significantly.

There are a lot of abilities that have different IDs at different points in the timeline. This is because all her skills are empowered under Chanchala, and Square implements this by just using different skills.

This doesn't attempt to check for whether a non-tank has the cleave (`the Path of Light`,) so that we can warn them specifically to use Vril. It can be done, but the weekend is over and I won't have a lot of time to look at this until next weekend at the earliest.