### PR TITLE
outputs fr

### DIFF
--- a/resources/outputs.ts
+++ b/resources/outputs.ts
@@ -342,7 +342,7 @@ export default {
   right: {
     en: 'Right',
     de: 'Rechts',
-    fr: 'À droite ',
+    fr: 'À droite',
     ja: '右へ',
     cn: '右',
     ko: '오른쪽',

--- a/resources/outputs.ts
+++ b/resources/outputs.ts
@@ -342,7 +342,7 @@ export default {
   right: {
     en: 'Right',
     de: 'Rechts',
-    fr: 'Droite ',
+    fr: 'À droite ',
     ja: '右へ',
     cn: '右',
     ko: '오른쪽',
@@ -350,7 +350,7 @@ export default {
   left: {
     en: 'Left',
     de: 'Links',
-    fr: 'Gauche',
+    fr: 'À gauche',
     ja: '左へ',
     cn: '左',
     ko: '왼쪽',


### PR DESCRIPTION
Better translations.
The addition of the preposition (à) is to give the order to go in the direction.
