### PR TITLE
resources: move notReached to common UnreachableCode error

### DIFF
--- a/resources/not_reached.ts
+++ b/resources/not_reached.ts
@@ -1,0 +1,14 @@
+// Helper Error for TypeScript situations where the programmer thinks they
+// know better than TypeScript that some situation will never occur.
+
+// The intention here is that the programmer does not expect a particular
+// bit of code to happen, and so has not written careful error handling.
+// If it does occur, at least there will be an error and we can figure out why.
+
+// One common example is a regex, where if the regex matches then all of the
+// (non-optional) regex groups will also be valid, but TypeScript doesn't know.
+export class UnreachableCode extends Error {
+  constructor() {
+    super('This code shouldn\'t be reached');
+  }
+}

--- a/resources/not_reached.ts
+++ b/resources/not_reached.ts
@@ -4,6 +4,8 @@
 // The intention here is that the programmer does not expect a particular
 // bit of code to happen, and so has not written careful error handling.
 // If it does occur, at least there will be an error and we can figure out why.
+// This is preferable to casting or disabling TypeScript altogether in order to
+// avoid syntax errors.
 
 // One common example is a regex, where if the regex matches then all of the
 // (non-optional) regex groups will also be valid, but TypeScript doesn't know.

--- a/resources/user_config.ts
+++ b/resources/user_config.ts
@@ -3,6 +3,7 @@ import { BaseOptions } from '../types/data';
 import { CactbotLoadUserRet, SavedConfig, SavedConfigEntry } from '../types/event';
 import { LocaleText } from '../types/trigger';
 import { addOverlayListener, callOverlayHandler } from './overlay_plugin_api';
+import { UnreachableCode } from './not_reached';
 
 // TODO:
 // The convention of "import X as _X; const X = _X;" is currently
@@ -95,18 +96,16 @@ class UserConfig {
     return keys.sort((keyA, keyB) => {
       const listA = splitKeyMap[keyA];
       const listB = splitKeyMap[keyB];
-      // Convince TypeScript these two exist.
       if (listA === undefined || listB === undefined)
-        return 0;
+        throw new UnreachableCode();
 
       const maxLen = Math.max(listA.length, listB.length);
       for (let idx = 0; idx < maxLen; ++idx) {
         const entryA = listA[idx];
         const entryB = listB[idx];
-        // Convince TypeScript these exist.
         // In practice, there's always at least one entry.
         if (entryA === undefined || entryB === undefined)
-          break;
+          throw new UnreachableCode();
 
         // If both subdirectories or both files, then compare names.
         const isLastA = listA.length - 1 === idx;

--- a/ui/raidboss/timeline.js
+++ b/ui/raidboss/timeline.js
@@ -1,6 +1,7 @@
 import { commonReplacement } from './common_replacement';
 import Regexes from '../../resources/regexes';
 import { LocaleRegex } from '../../resources/translations';
+import { UnreachableCode } from '../../resources/not_reached';
 
 const timelineInstructions = {
   en: [
@@ -72,11 +73,6 @@ function computeBackgroundColorFrom(element, classList) {
   element.removeChild(div);
   return color;
 }
-
-// TODO: Move to a centralized place
-const notReached = () => {
-  throw new Error('This code shouldn\'t be reached');
-};
 
 // This class reads the format of ACT Timeline plugin, described in
 // docs/TimelineGuide.md
@@ -218,7 +214,7 @@ export class Timeline {
       if (match && match['groups']) {
         const tts = match['groups'];
         if (!tts.id || !tts.beforeSeconds || !tts.command)
-          notReached();
+          throw new UnreachableCode();
         // TODO: Support alert sounds?
         if (tts.command === 'sound')
           continue;
@@ -242,7 +238,7 @@ export class Timeline {
       if (match && match['groups']) {
         const popupText = match['groups'];
         if (!popupText.type || !popupText.id || !popupText.beforeSeconds)
-          notReached();
+          throw new UnreachableCode();
         const popupTextItems = texts[popupText.id] || [];
         texts[popupText.id] = popupTextItems;
         popupTextItems.push({
@@ -265,7 +261,7 @@ export class Timeline {
       const parsedLine = match['groups'];
       // Technically the name can be empty
       if (!parsedLine.text || !parsedLine.time || parsedLine.name === undefined)
-        notReached();
+        throw new UnreachableCode();
       line = line.replace(parsedLine.text, '').trim();
       // There can be # in the ability name, but probably not in the regex.
       line = line.replace(regexes.commentLine, '').trim();
@@ -286,7 +282,7 @@ export class Timeline {
         if (commandMatch && commandMatch['groups']) {
           const durationCommand = commandMatch['groups'];
           if (!durationCommand.text || !durationCommand.seconds)
-            notReached();
+            throw new UnreachableCode();
           line = line.replace(durationCommand.text, '').trim();
           e.duration = parseFloat(durationCommand.seconds);
         }
@@ -295,7 +291,7 @@ export class Timeline {
         if (commandMatch && commandMatch['groups']) {
           const syncCommand = commandMatch['groups'];
           if (!syncCommand.text || !syncCommand.regex)
-            notReached();
+            throw new UnreachableCode();
           line = line.replace(syncCommand.text, '').trim();
           const sync = {
             id: uniqueid,
@@ -311,7 +307,7 @@ export class Timeline {
             if (argMatch && argMatch['groups']) {
               const windowCommand = argMatch['groups'];
               if (!windowCommand.text || !windowCommand.end)
-                notReached();
+                throw new UnreachableCode();
               line = line.replace(windowCommand.text, '').trim();
               if (windowCommand.start) {
                 sync.start = seconds - parseFloat(windowCommand.start);
@@ -325,7 +321,7 @@ export class Timeline {
             if (argMatch && argMatch['groups']) {
               const jumpCommand = argMatch['groups'];
               if (!jumpCommand.text || !jumpCommand.seconds)
-                notReached();
+                throw new UnreachableCode();
               line = line.replace(jumpCommand.text, '').trim();
               sync.jump = parseFloat(jumpCommand.seconds);
             }


### PR DESCRIPTION
Unfortunately, even a function that returns `never` is not enough
for TypeScript to trust this in all cases, so convert this to an
Error type instead.

This should remove the need for "convince TypeScript" sort of comments
as well.