### PR TITLE
Fix(jobs): MPTicker/repertoreTimer bar goes left

### DIFF
--- a/ui/jobs/components/brd.js
+++ b/ui/jobs/components/brd.js
@@ -60,6 +60,7 @@ export function setup(bars) {
     id: 'brd-timers-repertoire',
     fgColor: 'brd-color-song',
   });
+  repertoireTimer.toward = 'right';
   // Only with-DoT-target you last attacked will trigger bars timer.
   // So it work not well in multiple targets fight.
   bars.updateDotTimerFuncs.push(() => repertoireTimer.duration = 2.91666);

--- a/ui/jobs/jobs.js
+++ b/ui/jobs/jobs.js
@@ -319,6 +319,7 @@ class Bars {
       this.o.mpTicker.height = window.getComputedStyle(this.o.mpTickContainer).height;
       this.o.mpTicker.bg = computeBackgroundColorFrom(this.o.mpTicker, 'bar-border-color');
       this.o.mpTicker.stylefill = 'fill';
+      this.o.mpTicker.toward = 'right';
       this.o.mpTicker.loop = true;
     }
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/19927330/117983784-dae04180-b369-11eb-9beb-7173f733e9b2.png)


It seems like the last PR changed the default value of `toward` property in `resources/timerbar.ts`, so the MPTicker doesn't go right as before.