### PR TITLE
user_config: return options rather than using global options

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -73,7 +73,6 @@ module.exports = {
     'plugin/',
     'publish/',
     'resources/lib/',
-    'ui/dps/rdmty/',
   ],
   'env': {
     'browser': true,

--- a/types/data.d.ts
+++ b/types/data.d.ts
@@ -2,13 +2,21 @@ import PartyTracker from '../resources/party.js';
 import { Lang } from './global';
 import { Job, Role } from './job';
 
+// All overlay options support these fields.
+// Different overlay types should extend this interface with extra fields.
 export interface BaseOptions {
   ParserLanguage: Lang;
-  ShortLocale: string;
   DisplayLanguage: Lang;
+  ShortLocale: string;
+  SystemLocale: string;
+  Debug: boolean;
   Skin: string;
+
+  /** @deprecated for backwards compatibility, use ParserLanguage/DisplayLanguage instead */
+  Language: Lang;
+
+  // This supports setting values from config files from unknown keys in user_config.ts.
   [key: string]: unknown;
-  // todo: complete this type
 }
 
 // TODO: should this be named RaidbossData? Or can code that is using both this and oopsy

--- a/ui/config/config.js
+++ b/ui/config/config.js
@@ -12,9 +12,6 @@ import '../oopsyraidsy/oopsyraidsy_config';
 import '../radar/radar_config';
 import '../raidboss/raidboss_config';
 
-const Options = {};
-let gConfig = null;
-
 // Text in the butter bar, to prompt the user to reload after a config change.
 const kReloadText = {
   en: 'To apply configuration changes, reload cactbot overlays.',
@@ -617,8 +614,9 @@ export default class CactbotConfigurator {
   }
 }
 
-UserConfig.getUserConfigLocation('config', Options, async (e) => {
-  gConfig = new CactbotConfigurator(
-      Options,
+const initialOptions = {};
+UserConfig.getUserConfigLocation('config', initialOptions, async (options) => {
+  const configurator = new CactbotConfigurator(
+      options,
       UserConfig.savedConfig);
 });

--- a/ui/dps/dps_common.js
+++ b/ui/dps/dps_common.js
@@ -4,7 +4,7 @@ import ContentType from '../../resources/content_type';
 import Util from '../../resources/util';
 import ZoneInfo from '../../resources/zone_info';
 
-export const Options = {
+export const defaultOptions = {
   Language: 'en',
   IgnoreContentTypes: [
     ContentType.Pvp,
@@ -18,7 +18,7 @@ let gCurrentJob = null;
 let gCurrentZone = null;
 let gInCombat = false;
 
-export const InitDpsModule = function(updateFunc, hideFunc) {
+export const InitDpsModule = function(options, updateFunc, hideFunc) {
   addOverlayListener('CombatData', (e) => {
     // DPS numbers in large pvp is not useful and hella noisy.
     if (gIgnoreCurrentZone || gIgnoreCurrentJob)
@@ -49,7 +49,7 @@ export const InitDpsModule = function(updateFunc, hideFunc) {
 
     const zoneInfo = ZoneInfo[e.zoneID];
     const contentType = zoneInfo ? zoneInfo.contentType : 0;
-    gIgnoreCurrentZone = Options.IgnoreContentTypes.includes(contentType);
+    gIgnoreCurrentZone = options.IgnoreContentTypes.includes(contentType);
   });
 
   addOverlayListener('onInCombatChangedEvent', (e) => {

--- a/ui/dps/rdmty/dps.js
+++ b/ui/dps/rdmty/dps.js
@@ -1,8 +1,8 @@
-import { InitDpsModule, Options } from '../dps_common';
+import { InitDpsModule, defaultOptions } from '../dps_common';
 import UserConfig from '../../../resources/user_config';
 
 // fiddle: http://jsfiddle.net/v1ddnsvh/8/
-/* global window */
+/* eslint-disable */
 
 const IMAGE_PATH = '../../../resources/ffxiv';
 const EncountersArray = [];
@@ -573,6 +573,7 @@ Object.defineProperty(DamageMeter.prototype, 'render', {
   },
 });
 
+/* eslint-enable */
 
 DamageMeter.defaultProps = {
   chartViews: [
@@ -603,6 +604,6 @@ function hideOverlay() {
   document.getElementById('container').style.display = 'none';
 }
 
-UserConfig.getUserConfigLocation('rdmty', Options, (e) => {
-  InitDpsModule(onOverlayDataUpdate, hideOverlay);
+UserConfig.getUserConfigLocation('rdmty', defaultOptions, (options) => {
+  InitDpsModule(options, onOverlayDataUpdate, hideOverlay);
 });

--- a/ui/dps/xephero/xephero.js
+++ b/ui/dps/xephero/xephero.js
@@ -1,7 +1,7 @@
 import { addOverlayListener } from '../../../resources/overlay_plugin_api';
 
 import DpsPhaseTracker from './dps_phase_tracker';
-import { InitDpsModule, Options } from '../dps_common';
+import { InitDpsModule, defaultOptions } from '../dps_common';
 import UserConfig from '../../../resources/user_config';
 
 const rows = 10;
@@ -154,14 +154,14 @@ function updatePhase(phase, dpsOrder) {
     maxPhaseDPS.row.addClass('highestdps');
 }
 
-UserConfig.getUserConfigLocation('xephero', Options, (e) => {
-  const tracker = new DpsPhaseTracker(Options);
+UserConfig.getUserConfigLocation('xephero', defaultOptions, (options) => {
+  const tracker = new DpsPhaseTracker(options);
   const onOverlayDataUpdateEvent = (e) => {
     tracker.onOverlayDataUpdate(e.detail);
     update(e.detail, tracker);
   };
 
-  InitDpsModule(onOverlayDataUpdateEvent, hideOverlay);
+  InitDpsModule(options, onOverlayDataUpdateEvent, hideOverlay);
 
   addOverlayListener('ChangeZone', (e) => {
     const currentZone = e.zoneName;

--- a/ui/eureka/eureka.js
+++ b/ui/eureka/eureka.js
@@ -17,7 +17,7 @@ const bunnyLabel = {
   ko: '토끼',
 };
 
-const Options = {
+const defaultOptions = {
   Debug: false,
   PopSound: '../../resources/sounds/freesound/sonar.ogg',
   BunnyPopSound: '../../resources/sounds/freesound/water_drop.ogg',
@@ -3032,7 +3032,7 @@ class EurekaTracker {
   }
 }
 
-UserConfig.getUserConfigLocation('eureka', Options, (e) => {
+UserConfig.getUserConfigLocation('eureka', defaultOptions, (options) => {
   addOverlayListener('onPlayerChangedEvent', (e) => {
     gTracker.OnPlayerChange(e);
   });
@@ -3049,5 +3049,5 @@ UserConfig.getUserConfigLocation('eureka', Options, (e) => {
     gTracker.OnCE(e);
   });
 
-  gTracker = new EurekaTracker(Options);
+  gTracker = new EurekaTracker(options);
 });

--- a/ui/fisher/fisher.js
+++ b/ui/fisher/fisher.js
@@ -4,7 +4,7 @@ import FisherUI from './fisher-ui';
 import SeaBase from './seabase';
 import UserConfig from '../../resources/user_config';
 
-const Options = {
+const defaultOptions = {
   IQRHookQuantity: 100,
   IQRTugQuantity: 10,
   Colors: {
@@ -15,10 +15,9 @@ const Options = {
   },
 };
 
-let gFisher;
-
 class Fisher {
-  constructor(element) {
+  constructor(options, element) {
+    this.options = options;
     this.element = element;
 
     this.zone = null;
@@ -144,8 +143,8 @@ class Fisher {
       },
     };
 
-    this.ui = new FisherUI(element, Options);
-    this.seaBase = new SeaBase(Options);
+    this.ui = new FisherUI(element, this.options);
+    this.seaBase = new SeaBase(this.options);
   }
 
   getActiveBait() {
@@ -222,7 +221,7 @@ class Fisher {
     this.fishing = true;
 
     // undiscovered fishing hole
-    if (this.regex[Options.ParserLanguage]['undiscovered'].test(place)) {
+    if (this.regex[this.options.ParserLanguage]['undiscovered'].test(place)) {
       // store this for now
       // if we catch anything we'll pull the data then
       // "data on 'x' is added to your fishing log" is printed before the catch
@@ -339,8 +338,8 @@ class Fisher {
   parseLine(log) {
     let result = null;
 
-    for (const type in this.regex[Options.ParserLanguage]) {
-      result = this.regex[Options.ParserLanguage][type].exec(log);
+    for (const type in this.regex[this.options.ParserLanguage]) {
+      result = this.regex[this.options.ParserLanguage][type].exec(log);
       if (result) {
         switch (type) {
         // case 'bait': this.handleBait(result[1]); break;
@@ -383,18 +382,18 @@ class Fisher {
   }
 }
 
-UserConfig.getUserConfigLocation('fisher', Options, () => {
-  gFisher = new Fisher(document.getElementById('fisher'));
+UserConfig.getUserConfigLocation('fisher', defaultOptions, (options) => {
+  const fisher = new Fisher(options, document.getElementById('fisher'));
 
   addOverlayListener('onLogEvent', (e) => {
-    gFisher.OnLogEvent(e);
+    fisher.OnLogEvent(e);
   });
 
   addOverlayListener('ChangeZone', (e) => {
-    gFisher.OnChangeZone(e);
+    fisher.OnChangeZone(e);
   });
 
   addOverlayListener('onPlayerChangedEvent', (e) => {
-    gFisher.OnPlayerChange(e);
+    fisher.OnPlayerChange(e);
   });
 });

--- a/ui/jobs/jobs.js
+++ b/ui/jobs/jobs.js
@@ -22,7 +22,7 @@ import '../../resources/timericon';
 import '../../resources/widget_list';
 
 // See user/jobs-example.js for documentation.
-const Options = {
+const defaultOptions = {
   ShowHPNumber: ['PLD', 'WAR', 'DRK', 'GNB', 'WHM', 'SCH', 'AST', 'BLU'],
   ShowMPNumber: ['PLD', 'DRK', 'WHM', 'SCH', 'AST', 'BLM', 'BLU'],
 
@@ -1024,30 +1024,28 @@ class Bars {
   }
 }
 
-let gBars;
+UserConfig.getUserConfigLocation('jobs', defaultOptions, (options) => {
+  const bars = new Bars(options);
 
-UserConfig.getUserConfigLocation('jobs', Options, () => {
   addOverlayListener('onPlayerChangedEvent', (e) => {
-    gBars._onPlayerChanged(e);
+    bars._onPlayerChanged(e);
   });
   addOverlayListener('EnmityTargetData', (e) => {
-    gBars._updateEnmityTargetData(e);
+    bars._updateEnmityTargetData(e);
   });
   addOverlayListener('onPartyWipe', (e) => {
-    gBars._onPartyWipe(e);
+    bars._onPartyWipe(e);
   });
   addOverlayListener('onInCombatChangedEvent', (e) => {
-    gBars._onInCombatChanged(e);
+    bars._onInCombatChanged(e);
   });
   addOverlayListener('ChangeZone', (e) => {
-    gBars._onChangeZone(e);
+    bars._onChangeZone(e);
   });
   addOverlayListener('onLogEvent', (e) => {
-    gBars._onLogEvent(e);
+    bars._onLogEvent(e);
   });
   addOverlayListener('LogLine', (e) => {
-    gBars._onNetLog(e);
+    bars._onNetLog(e);
   });
-
-  gBars = new Bars(Options);
 });

--- a/ui/oopsyraidsy/oopsyraidsy.js
+++ b/ui/oopsyraidsy/oopsyraidsy.js
@@ -13,7 +13,7 @@ import './oopsyraidsy_config';
 
 import oopsyFileData from './data/manifest.txt';
 
-const Options = {
+const defaultOptions = {
   Triggers: [],
   PlayerNicks: {},
   DisabledTriggers: {},
@@ -219,12 +219,12 @@ Examples:
 
 /* eslint-enable */
 
-function ShortNamify(name) {
+function ShortNamify(name, options) {
   // TODO: make this unique among the party in case of first name collisions.
   // TODO: probably this should be a general cactbot utility.
 
-  if (name in Options.PlayerNicks)
-    return Options.PlayerNicks[name];
+  if (name in options.PlayerNicks)
+    return options.PlayerNicks[name];
 
   const idx = name.indexOf(' ');
   return idx < 0 ? name : name.substr(0, idx);
@@ -557,7 +557,7 @@ class MistakeCollector {
   OnMistakeText(type, blame, text, time) {
     if (!text)
       return;
-    const blameText = blame ? ShortNamify(blame) + ': ' : '';
+    const blameText = blame ? ShortNamify(blame, this.options) + ': ' : '';
     this.listView.AddLine(type, blameText + text, this.GetFormattedTime(time));
   }
 
@@ -720,7 +720,7 @@ class DamageTracker {
       role: this.role,
       party: this.partyTracker,
       inCombat: this.inCombat,
-      ShortName: ShortNamify,
+      ShortName: (name) => ShortNamify(name, this.options),
       IsPlayerId: IsPlayerId,
 
       // Deprecated.
@@ -1255,7 +1255,7 @@ class DamageTracker {
   }
 }
 
-UserConfig.getUserConfigLocation('oopsyraidsy', Options, () => {
+UserConfig.getUserConfigLocation('oopsyraidsy', defaultOptions, (options) => {
   let listView;
   let mistakeCollector;
 
@@ -1265,14 +1265,14 @@ UserConfig.getUserConfigLocation('oopsyraidsy', Options, () => {
   // Choose the ui based on whether this is the summary view or the live list.
   // They have different elements in the file.
   if (summaryElement) {
-    listView = new OopsySummaryList(Options, summaryElement);
-    mistakeCollector = new MistakeCollector(Options, listView);
+    listView = new OopsySummaryList(options, summaryElement);
+    mistakeCollector = new MistakeCollector(options, listView);
   } else {
-    listView = new OopsyLiveList(Options, liveListElement);
-    mistakeCollector = new MistakeCollector(Options, listView);
+    listView = new OopsyLiveList(options, liveListElement);
+    mistakeCollector = new MistakeCollector(options, listView);
   }
 
-  const damageTracker = new DamageTracker(Options, mistakeCollector, oopsyFileData);
+  const damageTracker = new DamageTracker(options, mistakeCollector, oopsyFileData);
 
   addOverlayListener('onLogEvent', (e) => damageTracker.OnLogEvent(e));
   addOverlayListener('LogLine', (e) => damageTracker.OnNetLog(e));

--- a/ui/pullcounter/pullcounter.js
+++ b/ui/pullcounter/pullcounter.js
@@ -5,7 +5,7 @@ import Regexes from '../../resources/regexes';
 import UserConfig from '../../resources/user_config';
 import ZoneId from '../../resources/zone_id';
 
-const Options = {
+const defaultOptions = {
   Language: 'en',
 };
 
@@ -130,11 +130,9 @@ const gBossFightTriggers = [
   },
 ];
 
-
-let gPullCounter;
-
 class PullCounter {
-  constructor(element) {
+  constructor(options, element) {
+    this.options = options;
     this.element = element;
     this.zoneName = null;
     this.bossStarted = false;
@@ -142,13 +140,13 @@ class PullCounter {
     this.bosses = [];
 
     this.resetRegex = Regexes.echo({ line: '.*pullcounter reset.*?' });
-    this.countdownEngageRegex = LocaleRegex.countdownEngage[Options.ParserLanguage] ||
+    this.countdownEngageRegex = LocaleRegex.countdownEngage[this.options.ParserLanguage] ||
       LocaleRegex.countdownEngage['en'];
 
     callOverlayHandler({
       call: 'cactbotLoadData',
       overlay: 'pullcounter',
-    }).then((data) => gPullCounter.SetSaveData(data));
+    }).then((data) => this.SetSaveData(data));
 
     this.ReloadTriggers();
   }
@@ -308,12 +306,12 @@ class PullCounter {
   }
 }
 
-UserConfig.getUserConfigLocation('pullcounter', Options, () => {
-  gPullCounter = new PullCounter(document.getElementById('pullcounttext'));
+UserConfig.getUserConfigLocation('pullcounter', defaultOptions, (options) => {
+  const pullcounter = new PullCounter(options, document.getElementById('pullcounttext'));
 
-  addOverlayListener('onLogEvent', (e) => gPullCounter.OnLogEvent(e));
-  addOverlayListener('ChangeZone', (e) => gPullCounter.OnChangeZone(e));
-  addOverlayListener('onInCombatChangedEvent', (e) => gPullCounter.OnInCombatChange(e));
-  addOverlayListener('onPartyWipe', () => gPullCounter.OnPartyWipe());
-  addOverlayListener('PartyChanged', (e) => gPullCounter.OnPartyChange(e));
+  addOverlayListener('onLogEvent', (e) => pullcounter.OnLogEvent(e));
+  addOverlayListener('ChangeZone', (e) => pullcounter.OnChangeZone(e));
+  addOverlayListener('onInCombatChangedEvent', (e) => pullcounter.OnInCombatChange(e));
+  addOverlayListener('onPartyWipe', () => pullcounter.OnPartyWipe());
+  addOverlayListener('PartyChanged', (e) => pullcounter.OnPartyChange(e));
 });

--- a/ui/radar/radar.js
+++ b/ui/radar/radar.js
@@ -6,7 +6,7 @@ import UserConfig from '../../resources/user_config';
 
 import './radar_config';
 
-const Options = {
+const defaultOptions = {
   PopSound: '../../resources/sounds/freesound/sonar.ogg',
   RankOptions: {
     'S': {
@@ -39,8 +39,6 @@ const Options = {
 // TODO: probably all mobs should be tracked with ids to avoid this.
 // TODO: this would also let us handle mobs with the same name better.
 const kMinDistanceBeforeSound = 100;
-
-let gRadar;
 
 const instanceChangedRegexes = {
   en: NetRegexes.gameLog({ code: '0039', line: 'You are now in the instanced area.*?' }),
@@ -94,12 +92,12 @@ function PlaySound(monster, options) {
 }
 
 class Radar {
-  constructor(element) {
+  constructor(options, element) {
     this.targetMonsters = {};
     this.playerPos = {};
     this.playerRotation = 0;
     this.table = element;
-    this.options = Options;
+    this.options = options;
     this.monsters = Object.assign({}, gMonster, Options.CustomMonsters);
     this.lang = this.options.ParserLanguage || 'en';
     this.nameToMonster = {};
@@ -350,18 +348,18 @@ class Radar {
   }
 }
 
-UserConfig.getUserConfigLocation('radar', Options, () => {
+UserConfig.getUserConfigLocation('radar', defaultOptions, (options) => {
+  const radar = new Radar(options, document.getElementById('radar-table'));
+
   addOverlayListener('LogLine', (e) => {
-    gRadar.OnNetLog(e);
+    radar.OnNetLog(e);
   });
 
   addOverlayListener('onPlayerChangedEvent', (e) => {
-    gRadar.OnPlayerChange(e);
+    radar.OnPlayerChange(e);
   });
 
   addOverlayListener('ChangeZone', (e) => {
-    gRadar.OnChangeZone(e);
+    radar.OnChangeZone(e);
   });
-
-  gRadar = new Radar(document.getElementById('radar-table'));
 });

--- a/ui/raidboss/emulator/data/RaidEmulator.js
+++ b/ui/raidboss/emulator/data/RaidEmulator.js
@@ -2,9 +2,10 @@ import EventBus from '../EventBus';
 import AnalyzedEncounter from './AnalyzedEncounter';
 
 export default class RaidEmulator extends EventBus {
-  constructor(options) {
+  constructor() {
     super();
-    this.options = options;
+    // Set later via setOptions.
+    this.options = undefined;
     this.encounters = [];
     this.currentEncounter = null;
     this.playing = false;
@@ -13,10 +14,14 @@ export default class RaidEmulator extends EventBus {
     this.lastLogTimestamp = null;
     this.internalTimestampTracker = null;
   }
+  setOptions(options) {
+    this.options = options;
+  }
   addEncounter(encounter) {
     this.encounters.push(encounter);
   }
   setCurrent(index) {
+    console.assert(this.options);
     this.currentEncounter = new AnalyzedEncounter(this.options, this.encounters[index], this);
     this.dispatch('preCurrentEncounterChanged', this.currentEncounter);
     this.currentEncounter.analyze(this.popupText).then(() => {

--- a/ui/raidboss/raidboss.js
+++ b/ui/raidboss/raidboss.js
@@ -10,29 +10,29 @@ import UserConfig from '../../resources/user_config';
 import { addRemotePlayerSelectUI } from '../../resources/player_override';
 import raidbossFileData from './data/manifest.txt';
 
-import Options from './raidboss_options';
+import defaultOptions from './raidboss_options';
 
-UserConfig.getUserConfigLocation('raidboss', Options, (e) => {
+UserConfig.getUserConfigLocation('raidboss', defaultOptions, (options) => {
   // Query params override default and user options.
   // This allows for html files that say "timeline only" or "alerts only".
   const params = new URLSearchParams(window.location.search);
 
-  Options.IsRemoteRaidboss = false;
+  options.IsRemoteRaidboss = false;
   if (params.get('OVERLAY_WS')) {
     const wsParam = decodeURIComponent(params.get('OVERLAY_WS'));
     // TODO: is there a better way to do this?? This seems better than looking for ngrok.
     const isLocal = wsParam.includes('localhost') || wsParam.includes('127.0.0.1');
-    Options.IsRemoteRaidboss = !isLocal;
+    options.IsRemoteRaidboss = !isLocal;
   }
 
   const playerNameParam = params.get('player');
   if (playerNameParam) {
-    Options.PlayerNameOverride = playerNameParam;
+    options.PlayerNameOverride = playerNameParam;
     console.log('Enabling player name override via query parameter, name: ' + playerNameParam);
   }
 
-  if (Options.IsRemoteRaidboss && playerNameParam === null) {
-    const lang = Options.DisplayLanguage || Options.ParserLanguage || 'en';
+  if (options.IsRemoteRaidboss && playerNameParam === null) {
+    const lang = options.DisplayLanguage || options.ParserLanguage || 'en';
     addRemotePlayerSelectUI(lang);
 
     // Page will reload once player selected.
@@ -43,46 +43,46 @@ UserConfig.getUserConfigLocation('raidboss', Options, (e) => {
   if (ttsParam) {
     const forceEnable = !!parseInt(ttsParam);
     if (forceEnable) {
-      Options.SpokenAlertsEnabled = true;
+      options.SpokenAlertsEnabled = true;
       console.log('Force enabling TTS via query parameter');
     }
   }
 
   const alertsParam = params.get('alerts');
   if (alertsParam !== null) {
-    const previous = Options.AlertsEnabled;
-    Options.AlertsEnabled = !!parseInt(alertsParam);
-    if (!previous && Options.AlertsEnabled)
+    const previous = options.AlertsEnabled;
+    options.AlertsEnabled = !!parseInt(alertsParam);
+    if (!previous && options.AlertsEnabled)
       console.log('Enabling alerts via query parameter');
   }
   const timelineParam = params.get('timeline');
   if (timelineParam !== null) {
-    const previous = Options.TimelineEnabled;
-    Options.TimelineEnabled = !!parseInt(timelineParam);
-    if (!previous && Options.TimelineEnabled)
+    const previous = options.TimelineEnabled;
+    options.TimelineEnabled = !!parseInt(timelineParam);
+    if (!previous && options.TimelineEnabled)
       console.log('Enabling timeline via query parameter');
   }
   const audioParam = params.get('audio');
   if (audioParam !== null) {
-    const previous = Options.AudioAllowed;
-    Options.AudioAllowed = !!parseInt(audioParam);
-    if (!previous && Options.AudioAllowed)
+    const previous = options.AudioAllowed;
+    options.AudioAllowed = !!parseInt(audioParam);
+    if (!previous && options.AudioAllowed)
       console.log('Enabling audio via query parameter');
   }
 
   const container = document.getElementById('container');
-  if (!Options.AlertsEnabled)
+  if (!options.AlertsEnabled)
     container.classList.add('hide-alerts');
-  if (!Options.TimelineEnabled)
+  if (!options.TimelineEnabled)
     container.classList.add('hide-timeline');
 
-  const timelineUI = new TimelineUI(Options);
-  const timelineController = new TimelineController(Options, timelineUI, raidbossFileData);
+  const timelineUI = new TimelineUI(options);
+  const timelineController = new TimelineController(options, timelineUI, raidbossFileData);
   const timelineLoader = new TimelineLoader(timelineController);
-  const popupText = new PopupText(Options, timelineLoader, raidbossFileData);
+  const popupText = new PopupText(options, timelineLoader, raidbossFileData);
 
   // Connect the timelines to the popup text, if alerts are desired.
-  if (Options.AlertsEnabled)
+  if (options.AlertsEnabled)
     timelineController.SetPopupTextInterface(new PopupTextGenerator(popupText));
 
   addOverlayListener('onLogEvent', (e) => {

--- a/ui/raidboss/raidemulator.js
+++ b/ui/raidboss/raidemulator.js
@@ -22,7 +22,7 @@ import raidbossFileData from './data/manifest.txt';
 // eslint-disable-next-line import/default
 import NetworkLogConverterWorker from './emulator/data/NetworkLogConverterWorker';
 
-import Options from './raidboss_options';
+import defaultOptions from './raidboss_options';
 
 (() => {
   let emulator;
@@ -38,7 +38,7 @@ import Options from './raidboss_options';
   let logConverterWorker;
 
   document.addEventListener('DOMContentLoaded', () => {
-    emulator = new RaidEmulator(Options);
+    emulator = new RaidEmulator();
     progressBar = new ProgressBar(emulator);
     persistor = new Persistor();
     encounterTab = new EncounterTab(persistor);
@@ -129,23 +129,24 @@ import Options from './raidboss_options';
 
     // Wait for the DB to be ready before doing anything that might invoke the DB
     persistor.on('ready', () => {
-      UserConfig.getUserConfigLocation('raidboss', Options, (e) => {
+      UserConfig.getUserConfigLocation('raidboss', defaultOptions, (options) => {
         document.querySelector('.websocketConnected').classList.remove('d-none');
         document.querySelector('.websocketDisconnected').classList.add('d-none');
 
         // Initialize the Raidboss components, bind them to the emulator for event listeners
-        timelineUI = new RaidEmulatorTimelineUI(Options);
+        timelineUI = new RaidEmulatorTimelineUI(options);
         timelineUI.bindTo(emulator);
         timelineController =
-            new RaidEmulatorTimelineController(Options, timelineUI, raidbossFileData);
+            new RaidEmulatorTimelineController(options, timelineUI, raidbossFileData);
         timelineController.bindTo(emulator);
         popupText = new RaidEmulatorPopupText(
-            Options, new TimelineLoader(timelineController), raidbossFileData);
+            options, new TimelineLoader(timelineController), raidbossFileData);
         popupText.bindTo(emulator);
 
         timelineController.SetPopupTextInterface(new PopupTextGenerator(popupText));
 
         emulator.setPopupText(popupText);
+        emulator.setOptions(options);
 
         // Load the encounter metadata from the DB
         encounterTab.refresh();


### PR DESCRIPTION
The lint is changed for rdmty because changing a file that is ignored
is a warning and we have a maximum number of warnings of zero.
So, instead eslint-disable is added to that file.