### PR TITLE
raidemulator: Fix delaySeconds/suppressSeconds implementation

### DIFF
--- a/ui/raidboss/emulator/data/AnalyzedEncounter.js
+++ b/ui/raidboss/emulator/data/AnalyzedEncounter.js
@@ -107,17 +107,19 @@ export default class AnalyzedEncounter extends EventBus {
         popupText.runResolver = res;
       });
 
-      popupText.OnTrigger(trigger, matches);
+      const currentLine = this.encounter.logLines[currentLogIndex];
+
+      popupText.OnTrigger(trigger, matches, currentLine.timestamp);
 
       await delayPromise;
       await promisePromise;
       const triggerHelper = await runPromise;
 
-      popupText.currentTriggerStatus.finalData = EmulatorCommon.cloneData(popupText.data);
+      triggerHelper.resolver.status.finalData = EmulatorCommon.cloneData(popupText.data);
 
       popupText.callback(
-          this.encounter.logLines[currentLogIndex],
-          triggerHelper, popupText.currentTriggerStatus);
+          currentLine,
+          triggerHelper, triggerHelper.resolver.status);
     });
 
     popupText.callback = (log, triggerHelper, currentTriggerStatus, finalData) => {
@@ -129,6 +131,7 @@ export default class AnalyzedEncounter extends EventBus {
           (currentTriggerStatus.delay * 1000),
       });
     };
+    popupText.triggerResolvers = [];
 
     this.perspectives[ID] = {
       initialData: EmulatorCommon.cloneData(popupText.data, []),

--- a/ui/raidboss/emulator/data/PopupTextAnalysis.js
+++ b/ui/raidboss/emulator/data/PopupTextAnalysis.js
@@ -1,20 +1,64 @@
 import EmulatorCommon from '../EmulatorCommon';
 import StubbedPopupText from '../overrides/StubbedPopupText';
 
+class Resolver {
+  constructor() {
+    this.promise = null;
+    this.run = null;
+    this.delayUntil = null;
+    this.final = null;
+  }
+  async isResolved(log) {
+    if (this.delayUntil) {
+      if (this.delayUntil < log.timestamp) {
+        this.delayUntil = null;
+        this.delayResolver();
+        await this.delayPromise;
+      } else {
+        return false;
+      }
+    }
+    if (this.promise)
+      await this.promise;
+    if (this.run)
+      this.run();
+    if (this.final)
+      this.final();
+    return true;
+  }
+  setDelay(delayUntil) {
+    this.delayUntil = delayUntil;
+    return this.delayPromise = new Promise((res) => {
+      this.delayResolver = res;
+    });
+  }
+  setPromise(promise) {
+    this.promise = promise;
+  }
+  setRun(run) {
+    this.run = run;
+  }
+  setFinal(final) {
+    this.final = final;
+  }
+  setHelper(triggerHelper) {
+    this.triggerHelper = triggerHelper;
+  }
+}
+
 export default class PopupTextAnalysis extends StubbedPopupText {
-  OnTriggerInternal(trigger, matches, currentTime) {
-    this.currentTriggerStatus = {
-      initialData: EmulatorCommon.cloneData(this.data),
-      condition: undefined,
-      response: false,
-      result: false,
-      delay: false,
-      suppressed: false,
-      executed: false,
-      promise: undefined,
-    };
-    this.currentFunction = 'initial';
-    super.OnTriggerInternal(trigger, matches, currentTime);
+  constructor(options, timelineLoader, raidbossFileData) {
+    super(options, timelineLoader, raidbossFileData);
+    this.triggerResolvers = [];
+  }
+
+  // Override `OnTrigger` so we can use our own exception handler
+  OnTrigger(trigger, matches, currentTime) {
+    try {
+      this.OnTriggerInternal(trigger, matches, currentTime);
+    } catch (e) {
+      console.log(trigger, e);
+    }
   }
 
   async OnLog(e) {
@@ -27,29 +71,30 @@ export default class PopupTextAnalysis extends StubbedPopupText {
       for (const trigger of this.triggers) {
         const r = log.match(trigger.localRegex);
         if (r) {
-          // Some async magic here, force waiting for the entirety of
-          // the trigger execution before continuing
-          const delayPromise = new Promise((res) => {
-            this.delayResolver = res;
+          const resolver = this.currentResolver = new Resolver();
+          resolver.status = {
+            initialData: EmulatorCommon.cloneData(this.data),
+            condition: undefined,
+            response: false,
+            result: false,
+            delay: false,
+            suppressed: false,
+            executed: false,
+            promise: undefined,
+          };
+          this.triggerResolvers.push(resolver);
+
+          this.OnTrigger(trigger, r, logObj.timestamp);
+
+          resolver.setFinal(() => {
+            resolver.status.finalData = EmulatorCommon.cloneData(this.data);
+            delete resolver.triggerHelper.resolver;
+            this.callback(logObj, resolver.triggerHelper, resolver.status, this.data);
           });
-          const promisePromise = new Promise((res) => {
-            this.promiseResolver = res;
-          });
-          const runPromise = new Promise((res) => {
-            this.runResolver = res;
-          });
-
-          this.OnTrigger(trigger, r);
-
-          await delayPromise;
-          await promisePromise;
-          const triggerHelper = await runPromise;
-
-          this.currentTriggerStatus.finalData = EmulatorCommon.cloneData(this.data);
-
-          this.callback(logObj, triggerHelper, this.currentTriggerStatus);
         }
       }
+
+      await this.checkResolved(logObj);
     }
   }
 
@@ -60,183 +105,120 @@ export default class PopupTextAnalysis extends StubbedPopupText {
       for (const trigger of this.netTriggers) {
         const r = log.match(trigger.localNetRegex);
         if (r) {
-          // Some async magic here, force waiting for the entirety of
-          // the trigger execution before continuing
-          const delayPromise = new Promise((res) => {
-            this.delayResolver = res;
+          const resolver = this.currentResolver = new Resolver();
+          resolver.status = {
+            initialData: EmulatorCommon.cloneData(this.data),
+            condition: undefined,
+            response: false,
+            result: false,
+            delay: false,
+            suppressed: false,
+            executed: false,
+            promise: undefined,
+          };
+          this.triggerResolvers.push(resolver);
+
+          this._onTriggerInternalGetHelper(trigger, r, logObj.timestamp);
+          this.OnTrigger(trigger, r, logObj.timestamp);
+
+          resolver.setFinal(() => {
+            resolver.status.finalData = EmulatorCommon.cloneData(this.data);
+            delete resolver.triggerHelper.resolver;
+            this.callback(logObj, resolver.triggerHelper, resolver.status, this.data);
           });
-          const promisePromise = new Promise((res) => {
-            this.promiseResolver = res;
-          });
-          const runPromise = new Promise((res) => {
-            this.runResolver = res;
-          });
-
-          this.OnTrigger(trigger, r);
-
-          await delayPromise;
-          await promisePromise;
-          const triggerHelper = await runPromise;
-
-          this.currentTriggerStatus.finalData = EmulatorCommon.cloneData(this.data);
-
-          this.callback(logObj, triggerHelper, this.currentTriggerStatus, this.data);
         }
       }
+
+      await this.checkResolved(logObj);
     }
   }
 
-  _onTriggerInternalCheckSuppressed(trigger, when) {
-    this.currentFunction = '_onTriggerInternalCheckSuppressed';
-    const ret = super._onTriggerInternalCheckSuppressed(trigger, when);
-    this.currentTriggerStatus.suppressed = ret;
-    if (ret) {
-      this.delayResolver();
-      this.promiseResolver();
-      this.runResolver({ trigger: trigger });
-    }
-    return ret;
+  async checkResolved(logObj) {
+    await Promise.all(
+        this.triggerResolvers.map(async (resolver) => await resolver.isResolved(logObj)))
+      .then((results) => {
+        this.triggerResolvers = this.triggerResolvers.filter((_, index) => !results[index]);
+      });
   }
 
   _onTriggerInternalCondition(triggerHelper) {
-    this.currentFunction = '_onTriggerInternalCondition';
     const ret = super._onTriggerInternalCondition(triggerHelper);
-    this.currentTriggerStatus.condition = ret;
-    if (!ret) {
-      this.delayResolver();
-      this.promiseResolver();
-      this.runResolver(triggerHelper);
-    }
+    triggerHelper.resolver.status.condition = ret;
     return ret;
   }
 
-  // This is pointless right now since _onTriggerInternalHelperDefaults won't ever
-  // modify the data state, but adding it for consistency
-  _onTriggerInternalHelperDefaults(triggerHelper) {
-    this.currentFunction = '_onTriggerInternalHelperDefaults';
-    super._onTriggerInternalHelperDefaults(triggerHelper);
-  }
-
-  _onTriggerInternalPreRun(triggerHelper) {
-    this.currentFunction = '_onTriggerInternalPreRun';
-    super._onTriggerInternalPreRun(triggerHelper);
-  }
-
   _onTriggerInternalDelaySeconds(triggerHelper) {
-    this.currentFunction = '_onTriggerInternalDelaySeconds';
     // Can't inherit the default logic for delay since we don't
     // want to delay for mass processing of the timeline
     const delay = 'delaySeconds' in triggerHelper.trigger ? triggerHelper.valueOrFunction(triggerHelper.trigger.delaySeconds) : 0;
-    this.currentTriggerStatus.delay = delay;
-    return new Promise((res) => {
-      this.delayResolver();
-      res();
-    });
-  }
-
-  _onTriggerInternalDurationSeconds(triggerHelper) {
-    this.currentFunction = '_onTriggerInternalDurationSeconds';
-    super._onTriggerInternalDurationSeconds(triggerHelper);
-  }
-
-  _onTriggerInternalSuppressSeconds(triggerHelper) {
-    this.currentFunction = '_onTriggerInternalSuppressSeconds';
-    super._onTriggerInternalSuppressSeconds(triggerHelper);
+    triggerHelper.resolver.status.delay = delay;
+    if (!delay || delay <= 0)
+      return null;
+    return triggerHelper.resolver.setDelay(triggerHelper.now + (delay * 1000));
   }
 
   _onTriggerInternalPromise(triggerHelper) {
-    this.currentFunction = '_onTriggerInternalPromise';
     const ret = super._onTriggerInternalPromise(triggerHelper);
-    this.currentTriggerStatus.promise = ret;
-    return (async () => {
-      await ret;
-      this.promiseResolver();
-    })();
-  }
-
-  _onTriggerInternalSound(triggerHelper) {
-    this.currentFunction = '_onTriggerInternalSound';
-    super._onTriggerInternalSound(triggerHelper);
-  }
-
-  _onTriggerInternalSoundVolume(triggerHelper) {
-    this.currentFunction = '_onTriggerInternalSoundVolume';
-    super._onTriggerInternalSoundVolume(triggerHelper);
-  }
-
-  _onTriggerInternalResponse(triggerHelper) {
-    this.currentFunction = '_onTriggerInternalResponse';
-    super._onTriggerInternalResponse(triggerHelper);
-  }
-
-  _onTriggerInternalAlarmText(triggerHelper) {
-    this.currentFunction = '_onTriggerInternalAlarmText';
-    super._onTriggerInternalAlarmText(triggerHelper);
-  }
-
-  _onTriggerInternalAlertText(triggerHelper) {
-    this.currentFunction = '_onTriggerInternalAlertText';
-    super._onTriggerInternalAlertText(triggerHelper);
-  }
-
-  _onTriggerInternalInfoText(triggerHelper) {
-    this.currentFunction = '_onTriggerInternalInfoText';
-    super._onTriggerInternalInfoText(triggerHelper);
+    triggerHelper.resolver.status.promise = ret;
+    if (!ret)
+      return ret;
+    return triggerHelper.resolver.setPromise(ret);
   }
 
   _onTriggerInternalTTS(triggerHelper) {
-    this.currentFunction = '_onTriggerInternalTTS';
     super._onTriggerInternalTTS(triggerHelper);
     if (triggerHelper.ttsText !== undefined &&
-      this.currentTriggerStatus.responseType === undefined) {
-      this.currentTriggerStatus.responseType = 'tts';
-      this.currentTriggerStatus.responseLabel = triggerHelper.ttsText;
+      triggerHelper.resolver.status.responseType === undefined) {
+      triggerHelper.resolver.status.responseType = 'tts';
+      triggerHelper.resolver.status.responseLabel = triggerHelper.ttsText;
     }
-  }
-
-  _onTriggerInternalPlayAudio(triggerHelper) {
-    this.currentFunction = '_onTriggerInternalPlayAudio';
-    super._onTriggerInternalPlayAudio(triggerHelper);
   }
 
   _onTriggerInternalRun(triggerHelper) {
-    this.currentFunction = '_onTriggerInternalRun';
-    this.currentTriggerStatus.executed = true;
-    super._onTriggerInternalRun(triggerHelper);
-    this.runResolver(triggerHelper);
+    triggerHelper.resolver.setRun(() => {
+      triggerHelper.resolver.status.executed = true;
+      super._onTriggerInternalRun(triggerHelper);
+    });
   }
 
-  _makeTextElement(text, className) {
-    this.currentTriggerStatus.result = this.currentTriggerStatus.result || text;
+  _makeTextElement(triggerHelper, text, className) {
+    triggerHelper.resolver.status.result = triggerHelper.resolver.status.result || text;
     return null;
   }
 
-  _createTextFor(text, textType, lowerTextKey, duration) {
+  _createTextFor(triggerHelper, text, textType, lowerTextKey, duration) {
     // No-op for functionality, but store off this info for feedback
-    this.currentTriggerStatus.responseType = textType;
-    this.currentTriggerStatus.responseLabel = text;
+    triggerHelper.resolver.status.responseType = textType;
+    triggerHelper.resolver.status.responseLabel = text;
   }
 
-  _playAudioFile(url, volume) {
+  _playAudioFile(triggerHelper, url, volume) {
     // No-op for functionality, but store off this info for feedback
 
     // If we already have text and this is a default alert sound, don't override that info
-    if (this.currentTriggerStatus.responseType) {
-      if (this.currentTriggerStatus.responseType === 'info' &&
+    if (triggerHelper.resolver.status.responseType) {
+      if (triggerHelper.resolver.status.responseType === 'info' &&
           url === this.options.InfoSound)
         return;
-      if (this.currentTriggerStatus.responseType === 'alert' &&
+      if (triggerHelper.resolver.status.responseType === 'alert' &&
           url === this.options.AlertSound)
         return;
-      if (this.currentTriggerStatus.responseType === 'alarm' &&
+      if (triggerHelper.resolver.status.responseType === 'alarm' &&
           url === this.options.AlarmSound)
         return;
     }
-    this.currentTriggerStatus.responseType = 'audiofile';
-    this.currentTriggerStatus.responseLabel = url;
+    triggerHelper.resolver.status.responseType = 'audiofile';
+    triggerHelper.resolver.status.responseLabel = url;
   }
 
   _scheduleRemoveText(container, e, delay) {
     // No-op
+  }
+
+  _onTriggerInternalGetHelper(trigger, matches, now) {
+    const ret = super._onTriggerInternalGetHelper(trigger, matches, now);
+    ret.resolver = this.currentResolver;
+    ret.resolver.setHelper(ret);
+    return ret;
   }
 }

--- a/ui/raidboss/emulator/overrides/RaidEmulatorOverlayApiHook.js
+++ b/ui/raidboss/emulator/overrides/RaidEmulatorOverlayApiHook.js
@@ -33,7 +33,7 @@ export default class RaidEmulatorOverlayApiHook {
           // nextSignificantState is a bit inefficient but given that this isn't run every tick
           // we can afford to be a bit inefficient for readability's sake
           const combatantState = combatant.nextSignificantState(timestamp).toPluginState();
-          if (msg.ids && msg.ids.includes(id))
+          if (msg.ids && msg.ids.includes(parseInt(id, 16)))
             combatants.push(combatantState);
           else if (msg.names && msg.names.includes(tracker.combatants[id].name))
             combatants.push(combatantState);

--- a/ui/raidboss/emulator/overrides/RaidEmulatorTimelineController.js
+++ b/ui/raidboss/emulator/overrides/RaidEmulatorTimelineController.js
@@ -43,11 +43,13 @@ export default class RaidEmulatorTimelineController extends TimelineController {
     e.detail.logs.forEach((line) => {
       this.activeTimeline.emulatedTimeOffset = line.offset;
       this.ui.emulatedTimeOffset = line.offset;
-      this.activeTimeline.timebase = this.activeTimeline.timebase || line.timestamp;
       this.activeTimeline.OnLogLine(
           line.properCaseConvertedLine || line.convertedLine,
           line.timestamp);
-      this.activeTimeline._OnUpdateTimer(line.timestamp);
+      // Only call _OnUpdateTimer if we have a timebase from the previous call to OnLogLine
+      // This avoids spamming the console with a ton of messages
+      if (this.activeTimeline.timebase)
+        this.activeTimeline._OnUpdateTimer(line.timestamp);
     });
   }
 }

--- a/ui/raidboss/emulator/ui/EmulatedPartyInfo.js
+++ b/ui/raidboss/emulator/ui/EmulatedPartyInfo.js
@@ -243,15 +243,13 @@ export default class EmulatedPartyInfo extends EventBus {
       name: 'Initial Data',
       classes: ['data'],
       $obj: $initDataViewer,
-      callback: () => {
-        $initDataViewer.textContent = JSON.stringify(per.initialData, null, 2);
-      },
     }));
 
     const $triggerContainer = $container.querySelector('.d-flex.flex-column');
 
     for (const i in per.triggers.sort((l, r) => l.resolvedOffset - r.resolvedOffset)) {
       const $triggerDataViewer = this.$jsonViewerTemplate.cloneNode(true);
+      $triggerDataViewer.textContent = JSON.stringify(per.triggers[i], null, 2);
       const triggerText = this.getTriggerLabelText(per.triggers[i]);
       const $trigger = this._wrapCollapse({
         time: this.getTriggerResolvedLabelTime(per.triggers[i]),
@@ -260,9 +258,6 @@ export default class EmulatedPartyInfo extends EventBus {
         text: triggerText,
         classes: [per.triggers[i].status.responseType],
         $obj: $triggerDataViewer,
-        callback: () => {
-          $triggerDataViewer.textContent = JSON.stringify(per.triggers[i], null, 2);
-        },
       });
       if (per.triggers[i].status.executed)
         $trigger.classList.add('trigger-executed');
@@ -289,9 +284,6 @@ export default class EmulatedPartyInfo extends EventBus {
       name: 'Final Data',
       classes: ['data'],
       $obj: $finalDataViewer,
-      callback: () => {
-        $finalDataViewer.textContent = JSON.stringify(per.finalData, null, 2);
-      },
     }));
 
     return $ret;

--- a/ui/raidboss/popup-text.js
+++ b/ui/raidboss/popup-text.js
@@ -975,7 +975,7 @@ export class PopupText {
           arrowReplacement[this.displayLang]);
       this.ttsSay(triggerHelper.ttsText);
     } else if (triggerHelper.soundUrl && triggerHelper.soundAlertsEnabled) {
-      this._playAudioFile(triggerHelper.soundUrl, triggerHelper.soundVol);
+      this._playAudioFile(triggerHelper, triggerHelper.soundUrl, triggerHelper.soundVol);
     }
   }
 
@@ -984,13 +984,13 @@ export class PopupText {
       triggerHelper.trigger.run(this.data, triggerHelper.matches, triggerHelper.trigger.output);
   }
 
-  _createTextFor(text, textType, lowerTextKey, duration) {
+  _createTextFor(triggerHelper, text, textType, lowerTextKey, duration) {
     // info-text
     const textElementClass = textType + '-text';
     if (textType !== 'info')
       text = triggerUpperCase(text);
     const holder = this[lowerTextKey].getElementsByClassName('holder')[0];
-    const div = this._makeTextElement(text, textElementClass);
+    const div = this._makeTextElement(triggerHelper, text, textElementClass);
 
     holder.appendChild(div);
     if (holder.children.length > this.kMaxRowsOfText)
@@ -1018,7 +1018,7 @@ export class PopupText {
         // per-trigger option > trigger field > option duration by text type
         const duration = triggerHelper.duration.fromConfig ||
           triggerHelper.duration.fromTrigger || triggerHelper.duration[lowerTextKey];
-        this._createTextFor(text, textType, lowerTextKey, duration);
+        this._createTextFor(triggerHelper, text, textType, lowerTextKey, duration);
         if (!triggerHelper.soundUrl) {
           triggerHelper.soundUrl = this.options[textTypeUpper + 'Sound'];
           triggerHelper.soundVol = this.options[textTypeUpper + 'SoundVolume'];
@@ -1027,7 +1027,7 @@ export class PopupText {
     }
   }
 
-  _makeTextElement(text, className) {
+  _makeTextElement(triggerHelper, text, className) {
     const div = document.createElement('div');
     div.classList.add(className);
     div.classList.add('animate-text');
@@ -1035,7 +1035,7 @@ export class PopupText {
     return div;
   }
 
-  _playAudioFile(url, volume) {
+  _playAudioFile(triggerHelper, url, volume) {
     const audio = new Audio(url);
     audio.volume = volume || 1;
     audio.play();


### PR DESCRIPTION
This PR fixes the delaySeconds and suppressSeconds implementations for raidemulator, resolving the last two outstanding tasks in #2161.

Also fixes two other issues that have cropped up over time while cleaning up the other tasks in #2161.

Fixing delaySeconds required rewriting a pretty large chunk of code related to how triggers are tracked and processed. I've run this set of changes through the following scenarios:

1. e12s clear
2. e12s partial clear, no delaySeconds got clipped short
3. Several encounters with no triggers
4. Several encounters with only delaySeconds triggers
5. Several encounters with only suppressSeconds triggers

The only scenario I couldn't test is where a trigger with `delaySeconds` never has its delay resolve before the end of the encounter. I don't anticipate there being any issues with this but if someone has a log sitting around where this happens, I'd appreciate a test run.