### PR TITLE
raidboss: remove browser tts

### DIFF
--- a/ui/raidboss/browser_tts_engine.ts
+++ b/ui/raidboss/browser_tts_engine.ts
@@ -1,15 +1,6 @@
 import { Lang } from 'types/global';
 
-const TTSEngineType = {
-  SpeechSynthesis: 0,
-  GoogleTTS: 1,
-};
-
-interface TTSItem {
-  play: () => void;
-}
-
-class SpeechTTSItem implements TTSItem {
+class TTSItem {
   readonly text: string;
   readonly item: SpeechSynthesisUtterance;
 
@@ -27,52 +18,16 @@ class SpeechTTSItem implements TTSItem {
   }
 }
 
-class GoogleTTSItem implements TTSItem {
-  readonly text: string;
-  readonly lang: string;
-  private item: Element | null = null;
-
-  constructor(text: string, lang: string) {
-    this.text = text;
-    this.lang = lang;
-    const iframe = document.createElement('iframe');
-    // remove sandbox so we can modify contents/call play on audio element later
-    iframe.removeAttribute('sandbox');
-    iframe.style.display = 'none';
-    document.body.appendChild(iframe);
-    const encText = encodeURIComponent(text);
-    if (iframe.contentDocument) {
-      iframe.contentDocument.body.innerHTML = '<audio src="https://translate.google.com/translate_tts?ie=UTF-8&client=tw-ob&tl=' + lang + '&q=' + encText + '" id="TTS">';
-      this.item = iframe.contentDocument.body.firstElementChild;
-    }
-  }
-
-  play() {
-    if (this.item) {
-      // Unfortunately, it doesn't seem like there's a great way to avoid casting here since
-      // HTMLIFrameElement Window's version of HTMLAudioElement uses a different constructor
-      // than the global Window's version.
-      // https://github.com/microsoft/TypeScript/issues/21568
-      void (this.item as HTMLAudioElement).play();
-    }
-  }
-}
-
 type TTSItemDictionary = {
   [key: string]: TTSItem;
 }
 
 export default class BrowserTTSEngine {
   readonly ttsItems: TTSItemDictionary = {};
-  readonly googleTTSLang;
-  private engineType = TTSEngineType.GoogleTTS;
   private speechLang?: string;
   private speechVoice?: SpeechSynthesisVoice;
 
   constructor(lang: Lang) {
-    this.googleTTSLang = lang === 'cn' ? 'zh' : lang;
-    // TODO: should there be options for different voices here so that
-    // everybody isn't forced into Microsoft Anna?
     const cactbotLangToSpeechLang = {
       en: 'en-US',
       de: 'de-DE',
@@ -92,41 +47,31 @@ export default class BrowserTTSEngine {
           this.speechLang = speechLang;
           this.speechVoice = voice;
           window.speechSynthesis.onvoiceschanged = null;
-          this.engineType = TTSEngineType.SpeechSynthesis;
         }
       };
+    }
+
+    if (!this.speechVoice) {
+      if (window.speechSynthesis !== undefined)
+        console.error('BrowserTTS error: could not find voice');
+      else
+        console.error('BrowserTTS error: no browser support for window.speechSynthesis');
     }
   }
 
   play(text: string): void {
+    if (!this.speechVoice)
+      return;
+
     try {
-      const ttsItem = this.ttsItems[text];
-      ttsItem ? ttsItem.play() : this.playTTS(text);
+      let ttsItem = this.ttsItems[text];
+      if (!ttsItem) {
+        ttsItem = new TTSItem(text, this.speechLang, this.speechVoice);
+        this.ttsItems[text] = ttsItem;
+      }
+      ttsItem.play();
     } catch (e) {
-      console.log('Exception performing TTS', e);
+      console.error('Exception performing TTS', e);
     }
-  }
-
-  playTTS(text: string): void {
-    switch (this.engineType) {
-    case TTSEngineType.SpeechSynthesis:
-      this.playSpeechTTS(text);
-      break;
-    case TTSEngineType.GoogleTTS:
-      this.playGoogleTTS(text);
-      break;
-    }
-  }
-
-  playSpeechTTS(text: string): void {
-    const ttsItem = new SpeechTTSItem(text, this.speechLang, this.speechVoice);
-    this.ttsItems[text] = ttsItem;
-    ttsItem.play();
-  }
-
-  playGoogleTTS(text: string): void {
-    const ttsItem = new GoogleTTSItem(text, this.googleTTSLang);
-    this.ttsItems[text] = ttsItem;
-    ttsItem.play();
   }
 }

--- a/ui/raidboss/popup-text.js
+++ b/ui/raidboss/popup-text.js
@@ -238,9 +238,9 @@ export class PopupText {
     this.parserLang = this.options.ParserLanguage || 'en';
     this.displayLang = this.options.AlertsLanguage || this.options.DisplayLanguage || this.options.ParserLanguage || 'en';
 
-    if (this.options.IsRemoteRaidboss || this.options.BrowserTTS) {
+    if (this.options.IsRemoteRaidboss) {
       this.ttsEngine = new BrowserTTSEngine(this.displayLang);
-      this.ttsSay = function(text) {
+      this.ttsSay = (text) => {
         this.ttsEngine.play(text);
       };
     } else {

--- a/ui/raidboss/raidboss_config.js
+++ b/ui/raidboss/raidboss_config.js
@@ -1414,19 +1414,6 @@ const templateOptions = {
       default: 1,
     },
     {
-      id: 'BrowserTTS',
-      name: {
-        en: 'Use Browser for Text to Speech',
-        de: 'Verwenden Sie den Browser für Text zu Sprache', // Machine translation
-        fr: 'Utiliser le navigateur pour la synthèse vocale', // Machine Translation
-        ja: 'ブラウザでTTS',
-        cn: '忽略ACT的设置，使用Cactbot自带的Google TTS功能（需联网）',
-        ko: '웹브라우저를 이용해서 TTS 작동시키기',
-      },
-      type: 'checkbox',
-      default: false,
-    },
-    {
       id: 'cactbotWormholeStrat',
       // TODO: maybe need some way to group these kinds of
       // options if we end up having a lot?

--- a/ui/raidboss/raidboss_options.ts
+++ b/ui/raidboss/raidboss_options.ts
@@ -81,7 +81,6 @@ const defaultRaidbossConfigOptions = {
   InfoSoundVolume: 1,
   LongSoundVolume: 1,
   PullSoundVolume: 1,
-  BrowserTTS: false,
   cactbotWormholeStrat: false,
   cactbote8sUptimeKnockbackStrat: false,
 };


### PR DESCRIPTION
Remove the extremely unofficial undocumented API tts path which appears to no longer be working for many users along with the raidboss config option.  The "browser TTS" path now only supports the built-in browser `window.speechSynthesis` path for remote raidboss and that option is enabled implicitly when needed.

If users want to change their cactbot tts voices when using an overlay, they should change their ACT tts voice by going to ACT -> Options -> Sound Settings -> Text to Speech Control Panel Applet and change the Windows tts voice there.

Fixes #2860 {/airquotes}