### PR TITLE
lint: Add Non-Block Body Statement Below

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -185,6 +185,7 @@ module.exports = {
     'no-undef': 'off',
     'no-unused-vars': 'off',
     'no-useless-escape': 'off',
+    'nonblock-statement-body-position': ['error', 'below'],
     'object-curly-newline': [
       'error',
       {

--- a/eslint/cactbot-output-strings.js
+++ b/eslint/cactbot-output-strings.js
@@ -39,7 +39,8 @@ const ruleModule = {
     const getAllKeys = (props) => {
       const propKeys = [];
 
-      if (!props) return propKeys;
+      if (!props)
+        return propKeys;
 
       props.forEach((prop) => {
         if (t.isProperty(prop)) {
@@ -62,7 +63,8 @@ const ruleModule = {
      * @param node {t.ObjectExpression}
      */
     const extractTemplate = function(node) {
-      if (node.properties === undefined) return;
+      if (node.properties === undefined)
+        return;
       const outputTemplateKey = {};
       for (const outputString of
         node.properties.filter((s) => !t.isSpreadElement(s) && !t.isMemberExpression(s.value))) {

--- a/resources/overlay_plugin_api.ts
+++ b/resources/overlay_plugin_api.ts
@@ -110,7 +110,8 @@ export const removeOverlayListener: IRemoveOverlayListener = (event, cb): void =
     const list = subscribers[event];
     const pos = list?.indexOf(cb as VoidFunc<unknown>);
 
-    if (pos && pos > -1) list?.splice(pos, 1);
+    if (pos && pos > -1)
+      list?.splice(pos, 1);
   }
 };
 
@@ -165,7 +166,8 @@ export const setCallOverlayHandlerOverride = (override?: IOverlayHandler): IOver
 };
 
 export const init = (): void => {
-  if (inited) return;
+  if (inited)
+    return;
 
   if (typeof window !== 'undefined') {
     wsUrl = /[\?&]OVERLAY_WS=([^&]+)/.exec(window.location.href);

--- a/resources/resourcebar.ts
+++ b/resources/resourcebar.ts
@@ -225,20 +225,34 @@ export default class ResourceBar extends HTMLElement {
     this._centerText = '';
     this._rightText = '';
 
-    if (this.value !== null) this._value = Math.max(parseFloat(this.value), 0);
-    if (this.maxvalue !== null) this._maxValue = Math.max(parseFloat(this.maxvalue), 0);
-    if (this.extravalue !== null) this._extraValue = Math.max(0, parseInt(this.extravalue));
-    if (this.extracolor !== null) this._extraColor = this.extracolor;
-    if (this.width !== null) this._width = Math.max(parseInt(this.width), 1);
-    if (this.height !== null) this._height = Math.max(parseInt(this.height), 1);
-    if (this.bg !== null) this._bg = this.bg;
-    if (this.fg !== null) this._fg = this.fg;
-    if (this.scale !== null) this._scale = Math.max(parseFloat(this.scale), 0.01);
-    if (this.toward !== null) this._towardRight = this.toward !== 'left';
-    if (this.stylefill !== null) this._fill = this.stylefill !== 'empty';
-    if (this.lefttext !== null) this._leftText = this.lefttext;
-    if (this.centertext !== null) this._centerText = this.centertext;
-    if (this.righttext !== null) this._rightText = this.righttext;
+    if (this.value !== null)
+      this._value = Math.max(parseFloat(this.value), 0);
+    if (this.maxvalue !== null)
+      this._maxValue = Math.max(parseFloat(this.maxvalue), 0);
+    if (this.extravalue !== null)
+      this._extraValue = Math.max(0, parseInt(this.extravalue));
+    if (this.extracolor !== null)
+      this._extraColor = this.extracolor;
+    if (this.width !== null)
+      this._width = Math.max(parseInt(this.width), 1);
+    if (this.height !== null)
+      this._height = Math.max(parseInt(this.height), 1);
+    if (this.bg !== null)
+      this._bg = this.bg;
+    if (this.fg !== null)
+      this._fg = this.fg;
+    if (this.scale !== null)
+      this._scale = Math.max(parseFloat(this.scale), 0.01);
+    if (this.toward !== null)
+      this._towardRight = this.toward !== 'left';
+    if (this.stylefill !== null)
+      this._fill = this.stylefill !== 'empty';
+    if (this.lefttext !== null)
+      this._leftText = this.lefttext;
+    if (this.centertext !== null)
+      this._centerText = this.centertext;
+    if (this.righttext !== null)
+      this._rightText = this.righttext;
   }
 
   // // These would be used by document.registerElement, which is deprecated but

--- a/resources/timerbar.ts
+++ b/resources/timerbar.ts
@@ -86,7 +86,8 @@ export default class TimerBar extends HTMLElement {
     this.attributeChangedCallback('value', this.value, s);
   }
   get value(): string {
-    if (!this._start) return this._duration.toString();
+    if (!this._start)
+      return this._duration.toString();
     const elapsedMs = new Date().getTime() - this._start;
     return Math.max(0, this._duration - (elapsedMs / 1000)).toString();
   }
@@ -96,7 +97,8 @@ export default class TimerBar extends HTMLElement {
     this.attributeChangedCallback('elapsed', this.elapsed, s);
   }
   get elapsed(): string {
-    if (!this._start) return '0';
+    if (!this._start)
+      return '0';
     return ((new Date().getTime() - this._start) / 1000).toString();
   }
 
@@ -500,7 +502,8 @@ export default class TimerBar extends HTMLElement {
     const elapsedSec = Math.max(0, this._duration - remainSec);
     this._start = new Date().getTime() - (elapsedSec * 1000);
 
-    if (!this._connected) return;
+    if (!this._connected)
+      return;
 
     this.show();
     clearTimeout(this._hideTimer ?? 0);

--- a/resources/timerbox.ts
+++ b/resources/timerbox.ts
@@ -147,14 +147,16 @@ export default class TimerBox extends HTMLElement {
 
   // The length remaining in the count down.
   get value(): string {
-    if (!this._start) return this._duration.toString();
+    if (!this._start)
+      return this._duration.toString();
     const elapsedMs = new Date().getTime() - this._start;
     return Math.max(0, this._duration - (elapsedMs / 1000)).toString();
   }
 
   // The elapsed time.
   get elapsed(): string {
-    if (!this._start) return '0';
+    if (!this._start)
+      return '0';
     return ((new Date().getTime() - this._start) / 1000).toString();
   }
 
@@ -210,14 +212,22 @@ export default class TimerBox extends HTMLElement {
     this._timer = 0;
     this._animationFrame = 0;
 
-    if (this.duration !== null) this._duration = Math.max(parseFloat(this.duration), 0);
-    if (this.threshold !== null) this._threshold = parseFloat(this.threshold);
-    if (this.bg !== null) this._bg = this.bg;
-    if (this.fg !== null) this._fg = this.fg;
-    if (this.scale !== null) this._scale = Math.max(parseFloat(this.scale), 0.01);
-    if (this.toward !== null) this._towardTop = this.toward !== 'bottom';
-    if (this.stylefill !== null) this._fill = this.stylefill !== 'empty';
-    if (this.hideafter !== null && this.hideafter !== '') this._hideAfter = Math.max(parseFloat(this.hideafter), 0);
+    if (this.duration !== null)
+      this._duration = Math.max(parseFloat(this.duration), 0);
+    if (this.threshold !== null)
+      this._threshold = parseFloat(this.threshold);
+    if (this.bg !== null)
+      this._bg = this.bg;
+    if (this.fg !== null)
+      this._fg = this.fg;
+    if (this.scale !== null)
+      this._scale = Math.max(parseFloat(this.scale), 0.01);
+    if (this.toward !== null)
+      this._towardTop = this.toward !== 'bottom';
+    if (this.stylefill !== null)
+      this._fill = this.stylefill !== 'empty';
+    if (this.hideafter !== null && this.hideafter !== '')
+      this._hideAfter = Math.max(parseFloat(this.hideafter), 0);
   }
 
   init(root: ShadowRoot): void {
@@ -351,7 +361,8 @@ export default class TimerBox extends HTMLElement {
   }
 
   draw(): void {
-    if (!this._connected) return;
+    if (!this._connected)
+      return;
 
     const elapsedSec = (new Date().getTime() - this._start) / 1000;
     const remainingSec = Math.max(0, this._duration - elapsedSec);
@@ -391,7 +402,8 @@ export default class TimerBox extends HTMLElement {
   }
 
   reset(): void {
-    if (!this._connected) return;
+    if (!this._connected)
+      return;
 
     this.show();
     clearTimeout(this._hideTimer ?? 0);

--- a/resources/timericon.ts
+++ b/resources/timericon.ts
@@ -190,17 +190,28 @@ export default class TimerIcon extends HTMLElement {
     this._timer = 0;
     this._hideTimer = 0;
 
-    if (this.duration !== null) this._duration = Math.max(parseFloat(this.duration), 0);
-    if (this.width !== null) this._width = Math.max(parseInt(this.width), 1);
-    if (this.height !== null) this._height = Math.max(parseInt(this.height), 1);
-    if (this.bordercolor !== null) this._borderFg = this.bordercolor;
-    if (this.bordersize !== null) this._colorBorderSize = Math.max(parseInt(this.bordersize), 0);
-    if (this.scale !== null) this._scale = Math.max(parseFloat(this.scale), 0.01);
-    if (this.hideafter !== null && this.hideafter !== '') this._hideAfter = Math.max(parseFloat(this.hideafter), 0);
-    if (this.icon !== null) this._icon = this.icon;
-    if (this.zoom !== null) this._zoom = Math.max(parseInt(this.zoom), 0);
-    if (this.text !== null) this._text = this.text;
-    if (this.textcolor !== null) this._textColor = this.textcolor;
+    if (this.duration !== null)
+      this._duration = Math.max(parseFloat(this.duration), 0);
+    if (this.width !== null)
+      this._width = Math.max(parseInt(this.width), 1);
+    if (this.height !== null)
+      this._height = Math.max(parseInt(this.height), 1);
+    if (this.bordercolor !== null)
+      this._borderFg = this.bordercolor;
+    if (this.bordersize !== null)
+      this._colorBorderSize = Math.max(parseInt(this.bordersize), 0);
+    if (this.scale !== null)
+      this._scale = Math.max(parseFloat(this.scale), 0.01);
+    if (this.hideafter !== null && this.hideafter !== '')
+      this._hideAfter = Math.max(parseFloat(this.hideafter), 0);
+    if (this.icon !== null)
+      this._icon = this.icon;
+    if (this.zoom !== null)
+      this._zoom = Math.max(parseInt(this.zoom), 0);
+    if (this.text !== null)
+      this._text = this.text;
+    if (this.textcolor !== null)
+      this._textColor = this.textcolor;
   }
 
   init(root: ShadowRoot): void {

--- a/resources/translations.ts
+++ b/resources/translations.ts
@@ -121,13 +121,15 @@ class RegexSet {
   netRegexes?: LocaleRegexesObj;
 
   get localeRegex(): LocaleRegexesObj {
-    if (this.regexes) return this.regexes;
+    if (this.regexes)
+      return this.regexes;
     this.regexes = this.buildLocaleRegexes(localeLines, (s: string) => Regexes.gameLog({ line: s + '.*?' }));
     return this.regexes;
   }
 
   get localeNetRegex(): LocaleRegexesObj {
-    if (this.netRegexes) return this.netRegexes;
+    if (this.netRegexes)
+      return this.netRegexes;
     this.netRegexes = this.buildLocaleRegexes(localeLines, (s: string) => NetRegexes.gameLog({ line: s + '[^|]*?' }));
     return this.netRegexes;
   }

--- a/ui/jobs/jobs.js
+++ b/ui/jobs/jobs.js
@@ -127,7 +127,8 @@ class Bars {
     if (bars) {
       const barList = bars.children;
       for (const bar of barList) {
-        if (bar.id === 'hp-bar' || bar.id === 'mp-bar') continue;
+        if (bar.id === 'hp-bar' || bar.id === 'mp-bar')
+          continue;
         if (this.isPVPZone)
           bar.style.display = 'none';
         else
@@ -524,7 +525,8 @@ class Bars {
   }
 
   _updateHealth() {
-    if (!this.o.healthBar) return;
+    if (!this.o.healthBar)
+      return;
     this.o.healthBar.value = this.hp;
     this.o.healthBar.maxvalue = this.maxHP;
     this.o.healthBar.extravalue = this.currentShield;
@@ -540,7 +542,8 @@ class Bars {
   }
 
   _updateMPTicker() {
-    if (!this.o.mpTicker) return;
+    if (!this.o.mpTicker)
+      return;
     const delta = this.mp - this.prevMP;
     this.prevMP = this.mp;
 
@@ -554,9 +557,12 @@ class Bars {
 
     const baseTick = this.inCombat ? kMPCombatRate : kMPNormalRate;
     let umbralTick = 0;
-    if (this.umbralStacks === -1) umbralTick = kMPUI1Rate;
-    if (this.umbralStacks === -2) umbralTick = kMPUI2Rate;
-    if (this.umbralStacks === -3) umbralTick = kMPUI3Rate;
+    if (this.umbralStacks === -1)
+      umbralTick = kMPUI1Rate;
+    if (this.umbralStacks === -2)
+      umbralTick = kMPUI2Rate;
+    if (this.umbralStacks === -3)
+      umbralTick = kMPUI3Rate;
 
     const mpTick = Math.floor(this.maxMP * baseTick) + Math.floor(this.maxMP * umbralTick);
     if (delta === mpTick && this.umbralStacks <= 0) // MP ticks disabled in AF
@@ -564,15 +570,18 @@ class Bars {
 
     // Update color based on the astral fire/ice state
     let colorTag = 'mp-tick-color';
-    if (this.umbralStacks < 0) colorTag = 'mp-tick-color.ice';
-    if (this.umbralStacks > 0) colorTag = 'mp-tick-color.fire';
+    if (this.umbralStacks < 0)
+      colorTag = 'mp-tick-color.ice';
+    if (this.umbralStacks > 0)
+      colorTag = 'mp-tick-color.fire';
     this.o.mpTicker.fg = computeBackgroundColorFrom(this.o.mpTicker, colorTag);
   }
 
   _updateMana() {
     this._updateMPTicker();
 
-    if (!this.o.manaBar) return;
+    if (!this.o.manaBar)
+      return;
     this.o.manaBar.value = this.mp;
     this.o.manaBar.maxvalue = this.maxMP;
     let lowMP = -1;
@@ -604,13 +613,15 @@ class Bars {
   }
 
   _updateCp() {
-    if (!this.o.cpBar) return;
+    if (!this.o.cpBar)
+      return;
     this.o.cpBar.value = this.cp;
     this.o.cpBar.maxvalue = this.maxCP;
   }
 
   _updateGp() {
-    if (!this.o.gpBar) return;
+    if (!this.o.gpBar)
+      return;
     this.o.gpBar.value = this.gp;
     this.o.gpBar.maxvalue = this.maxGP;
 
@@ -722,7 +733,8 @@ class Bars {
   }
 
   _setPullCountdown(seconds) {
-    if (!this.o.pullCountdown) return;
+    if (!this.o.pullCountdown)
+      return;
 
     const inCountdown = seconds > 0;
     const showingCountdown = parseFloat(this.o.pullCountdown.duration) > 0;

--- a/ui/jobs/utils.js
+++ b/ui/jobs/utils.js
@@ -65,7 +65,8 @@ export function calcGCDFromStat(bars, stat, actionDelay) {
     if (bars.speedBuffs.shifu) {
       if (bars.level > 77)
         type1Buffs += 13;
-      else type1Buffs += 10;
+      else
+        type1Buffs += 10;
     }
   }
 

--- a/ui/raidboss/data/04-sb/ultimate/unending_coil_ultimate.js
+++ b/ui/raidboss/data/04-sb/ultimate/unending_coil_ultimate.js
@@ -76,7 +76,8 @@ export default {
       netRegexCn: NetRegexes.startsUsing({ id: '26E2', source: '至尊巴哈姆特', capture: false }),
       netRegexKo: NetRegexes.startsUsing({ id: '26E2', source: '바하무트 프라임', capture: false }),
       run: function(data) {
-        if (data.resetTrio) data.resetTrio('quickmarch');
+        if (data.resetTrio)
+          data.resetTrio('quickmarch');
       },
     },
     {
@@ -88,7 +89,8 @@ export default {
       netRegexCn: NetRegexes.startsUsing({ id: '26E3', source: '至尊巴哈姆特', capture: false }),
       netRegexKo: NetRegexes.startsUsing({ id: '26E3', source: '바하무트 프라임', capture: false }),
       run: function(data) {
-        if (data.resetTrio) data.resetTrio('blackfire');
+        if (data.resetTrio)
+          data.resetTrio('blackfire');
       },
     },
     {
@@ -100,7 +102,8 @@ export default {
       netRegexCn: NetRegexes.startsUsing({ id: '26E4', source: '至尊巴哈姆特', capture: false }),
       netRegexKo: NetRegexes.startsUsing({ id: '26E4', source: '바하무트 프라임', capture: false }),
       run: function(data) {
-        if (data.resetTrio) data.resetTrio('fellruin');
+        if (data.resetTrio)
+          data.resetTrio('fellruin');
       },
     },
     {
@@ -112,7 +115,8 @@ export default {
       netRegexCn: NetRegexes.startsUsing({ id: '26E5', source: '至尊巴哈姆特', capture: false }),
       netRegexKo: NetRegexes.startsUsing({ id: '26E5', source: '바하무트 프라임', capture: false }),
       run: function(data) {
-        if (data.resetTrio) data.resetTrio('heavensfall');
+        if (data.resetTrio)
+          data.resetTrio('heavensfall');
       },
     },
     {
@@ -124,7 +128,8 @@ export default {
       netRegexCn: NetRegexes.startsUsing({ id: '26E6', source: '至尊巴哈姆特', capture: false }),
       netRegexKo: NetRegexes.startsUsing({ id: '26E6', source: '바하무트 프라임', capture: false }),
       run: function(data) {
-        if (data.resetTrio) data.resetTrio('tenstrike');
+        if (data.resetTrio)
+          data.resetTrio('tenstrike');
       },
     },
     {
@@ -136,7 +141,8 @@ export default {
       netRegexCn: NetRegexes.startsUsing({ id: '26E7', source: '至尊巴哈姆特', capture: false }),
       netRegexKo: NetRegexes.startsUsing({ id: '26E7', source: '바하무트 프라임', capture: false }),
       run: function(data) {
-        if (data.resetTrio) data.resetTrio('octet');
+        if (data.resetTrio)
+          data.resetTrio('octet');
       },
     },
     {

--- a/ui/raidboss/emulator/data/CombatantTracker.js
+++ b/ui/raidboss/emulator/data/CombatantTracker.js
@@ -164,17 +164,28 @@ export default class CombatantTracker {
 
     const state = {};
 
-    if (line.x !== undefined) state.posX = line.x;
-    if (line.y !== undefined) state.posY = line.y;
-    if (line.z !== undefined) state.posZ = line.z;
-    if (line.heading !== undefined) state.heading = line.heading;
-    if (line.targetable !== undefined) state.targetable = line.targetable;
-    if (line.hp !== undefined) state.HP = line.hp;
-    if (line.maxHp !== undefined) state.maxHP = line.maxHp;
-    if (line.mp !== undefined) state.MP = line.mp;
-    if (line.maxMp !== undefined) state.maxMP = line.maxMp;
-    if (line.jobName !== undefined) state.job = line.jobName;
-    if (line.level !== undefined) state.level = line.level;
+    if (line.x !== undefined)
+      state.posX = line.x;
+    if (line.y !== undefined)
+      state.posY = line.y;
+    if (line.z !== undefined)
+      state.posZ = line.z;
+    if (line.heading !== undefined)
+      state.heading = line.heading;
+    if (line.targetable !== undefined)
+      state.targetable = line.targetable;
+    if (line.hp !== undefined)
+      state.HP = line.hp;
+    if (line.maxHp !== undefined)
+      state.maxHP = line.maxHp;
+    if (line.mp !== undefined)
+      state.MP = line.mp;
+    if (line.maxMp !== undefined)
+      state.maxMP = line.maxMp;
+    if (line.jobName !== undefined)
+      state.job = line.jobName;
+    if (line.level !== undefined)
+      state.level = line.level;
 
     return state;
   }
@@ -185,14 +196,22 @@ export default class CombatantTracker {
 
     const state = {};
 
-    if (line.targetX !== undefined) state.posX = line.targetX;
-    if (line.targetY !== undefined) state.posY = line.targetY;
-    if (line.targetZ !== undefined) state.posZ = line.targetZ;
-    if (line.targetHeading !== undefined) state.heading = line.targetHeading;
-    if (line.targetHp !== undefined) state.HP = line.targetHp;
-    if (line.targetMaxHp !== undefined) state.maxHP = line.targetMaxHp;
-    if (line.targetMp !== undefined) state.MP = line.targetMp;
-    if (line.targetMaxMp !== undefined) state.maxMP = line.targetMaxMp;
+    if (line.targetX !== undefined)
+      state.posX = line.targetX;
+    if (line.targetY !== undefined)
+      state.posY = line.targetY;
+    if (line.targetZ !== undefined)
+      state.posZ = line.targetZ;
+    if (line.targetHeading !== undefined)
+      state.heading = line.targetHeading;
+    if (line.targetHp !== undefined)
+      state.HP = line.targetHp;
+    if (line.targetMaxHp !== undefined)
+      state.maxHP = line.targetMaxHp;
+    if (line.targetMp !== undefined)
+      state.MP = line.targetMp;
+    if (line.targetMaxMp !== undefined)
+      state.maxMP = line.targetMaxMp;
 
     return state;
   }

--- a/ui/raidboss/timeline.ts
+++ b/ui/raidboss/timeline.ts
@@ -497,7 +497,8 @@ export class Timeline {
     // Sort by time, but when the time is the same, sort by file order.
     // Then assign a sortKey to each event so that we can maintain that order.
     this.events.sort((a, b) => {
-      if (a.time === b.time) return a.id - b.id;
+      if (a.time === b.time)
+        return a.id - b.id;
       return a.time - b.time;
     });
     this.events.forEach((event, idx) => event.sortKey = idx);

--- a/util/coinach.ts
+++ b/util/coinach.ts
@@ -58,8 +58,10 @@ export class CoinachReader {
       }
     }
 
-    if (!coinachPath) throw new CoinachError('coinach path not found');
-    if (!ffxivPath) throw new CoinachError('ffxiv path not found');
+    if (!coinachPath)
+      throw new CoinachError('coinach path not found');
+    if (!ffxivPath)
+      throw new CoinachError('ffxiv path not found');
     this.coinachPath = coinachPath;
     this.ffxivPath = ffxivPath;
 


### PR DESCRIPTION
As part of a potential series of commits to move to [prettier-eslint](https://github.com/prettier/prettier-eslint), add some rules to enforce desired styles.

For this style, specifically, Prettier will default to putting lines without braces onto a single line if it is able to. The options here would be to either add braces for single line control statements, or to force these one-liners onto two lines. Picking the latter because the changeset is smaller.