### PR TITLE
types: rename Data to RaidbossData

### DIFF
--- a/resources/conditions.ts
+++ b/resources/conditions.ts
@@ -1,7 +1,7 @@
 // For consistency with Responses, Conditions
 // are also functions.
 
-import { Data } from '../types/data';
+import { RaidbossData as Data } from '../types/data';
 import { TargetedMatches } from '../types/trigger';
 
 export default {

--- a/resources/responses.ts
+++ b/resources/responses.ts
@@ -19,7 +19,7 @@
 // anything with data or matches.  See `responses_test.js`.
 
 import { LocaleText, ResponseOutput, ResponseFunc, TriggerFunc, TargetedMatches, Output } from '../types/trigger';
-import { Data } from '../types/data';
+import { RaidbossData as Data } from '../types/data';
 import Outputs from './outputs';
 
 type TargetedResponseOutput = ResponseOutput<TargetedMatches>;

--- a/types/data.d.ts
+++ b/types/data.d.ts
@@ -11,10 +11,7 @@ export interface BaseOptions {
   // todo: complete this type
 }
 
-// TODO: should this be named RaidbossData? Or can code that is using both this and oopsy
-// differentiate themselves if they need to? Probably this *file* needs to be renamed
-// to be raidboss_data.d.ts?
-export interface Data {
+export interface RaidbossData {
   job: Job;
   me: string;
   role: Role;


### PR DESCRIPTION
This will let us differentiate OopsyData when that exists,
as well as letting individual trigger files define something
like `Data extends RaidbossData` to have shorter type definitions.