### PR TITLE
raidboss: convert function+this usage in trigger files

### DIFF
--- a/ui/raidboss/data/04-sb/raid/o4s.js
+++ b/ui/raidboss/data/04-sb/raid/o4s.js
@@ -214,17 +214,17 @@ export default {
 
         // TODO: should have options for this.
         data.dieOnLaser = 1;
-        data.shouldDieOnLaser = function() {
-          if (!this.beyondDeath)
+        data.shouldDieOnLaser = () => {
+          if (!data.beyondDeath)
             return false;
           // Beyond death doesn't update for laser #2 if you died on
           // laser #1, so don't tell anybody to die on laser #2.
           // If you still have beyond death, it'll remind you for #3.
-          if (this.omegaLaserCount === 2 && this.omegaProbablyDiedOnLaser)
+          if (data.omegaLaserCount === 2 && data.omegaProbablyDiedOnLaser)
             return false;
-          if (this.phase !== 'omega')
+          if (data.phase !== 'omega')
             return true;
-          return this.omegaLaserCount >= this.dieOnLaser;
+          return data.omegaLaserCount >= data.dieOnLaser;
         };
       },
     },

--- a/ui/raidboss/data/04-sb/ultimate/unending_coil_ultimate.js
+++ b/ui/raidboss/data/04-sb/ultimate/unending_coil_ultimate.js
@@ -1616,10 +1616,10 @@ export default {
           4: [],
         };
 
-        data.resetTrio = function(trio) {
-          this.trio = trio;
-          this.shakers = [];
-          this.megaStack = [];
+        data.resetTrio = (trio) => {
+          data.trio = trio;
+          data.shakers = [];
+          data.megaStack = [];
         };
 
         // Begin copy and paste from dragon_test.js.

--- a/ui/raidboss/data/05-shb/ultimate/the_epic_of_alexander.js
+++ b/ui/raidboss/data/05-shb/ultimate/the_epic_of_alexander.js
@@ -489,13 +489,13 @@ export default {
       netRegexKo: NetRegexes.startsUsing({ source: '포악한 심판자', id: '483E', capture: false }),
       run: function(data) {
         data.phase = 'brute';
-        data.resetState = function() {
-          this.enumerations = [];
-          this.buffMap = {};
-          this.tetherBois = {};
-          this.vuln = {};
-          delete this.limitCutNumber;
-          delete this.limitCutDelay;
+        data.resetState = () => {
+          data.enumerations = [];
+          data.buffMap = {};
+          data.tetherBois = {};
+          data.vuln = {};
+          delete data.limitCutNumber;
+          delete data.limitCutDelay;
         };
         data.resetState();
       },


### PR DESCRIPTION
These are the three places that are assigning a function() to
data, and then using `this` inside of that function.

In preparation for auto-converting triggers to use arrow functions,
and an eslint rule, convert these to arrow functions.

In the future, this form of function+this will still be ok even with
the eslint rule, but it makes the auto-conversions fully automatic.

I also think it's cleaner.