### PR TITLE
eslint: add prefer-arrow/prefer-arrow-functions rule

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -21,18 +21,9 @@ module.exports = {
       },
     },
     {
-      'files': ['**/raidboss/data/**/*'],
-      'rules': {
-        'no-unused-vars': ['error', { 'args': 'all', 'argsIgnorePattern': '^_' }],
-        'rulesdir/cactbot-output-strings': 'error',
-        'rulesdir/cactbot-timeline-triggers': 'error',
-        'rulesdir/cactbot-response-default-severities': 'error',
-      },
-    },
-    {
       'files': ['**/*.ts'],
       'parser': '@typescript-eslint/parser',
-      'plugins': ['@typescript-eslint'],
+      'plugins': ['@typescript-eslint', 'prefer-arrow'],
       'parserOptions': {
         'tsconfigRootDir': __dirname,
         'project': ['./tsconfig.json'],
@@ -65,6 +56,16 @@ module.exports = {
             objectLiteralTypeAssertions: 'never',
           },
         ],
+      },
+    },
+    {
+      'files': ['**/raidboss/data/**/*'],
+      'rules': {
+        'no-unused-vars': ['error', { 'args': 'all', 'argsIgnorePattern': '^_' }],
+        'prefer-arrow/prefer-arrow-functions': 'warn',
+        'rulesdir/cactbot-output-strings': 'error',
+        'rulesdir/cactbot-timeline-triggers': 'error',
+        'rulesdir/cactbot-response-default-severities': 'error',
       },
     },
   ],

--- a/package-lock.json
+++ b/package-lock.json
@@ -3094,6 +3094,12 @@
         }
       }
     },
+    "eslint-plugin-prefer-arrow": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-prefer-arrow/-/eslint-plugin-prefer-arrow-1.2.3.tgz",
+      "integrity": "sha512-J9I5PKCOJretVuiZRGvPQxCbllxGAV/viI20JO3LYblAodofBxyMnZAJ+WGeClHgANnSJberTNoFWWjrWKBuXQ==",
+      "dev": true
+    },
     "eslint-plugin-rulesdir": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/eslint-plugin-rulesdir/-/eslint-plugin-rulesdir-0.1.0.tgz",

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "eslint-config-google": "^0.9.1",
     "eslint-import-resolver-typescript": "^2.4.0",
     "eslint-plugin-import": "^2.22.1",
+    "eslint-plugin-prefer-arrow": "^1.2.3",
     "eslint-plugin-rulesdir": "^0.1.0",
     "eslint-plugin-tsc": "^2.0.0",
     "husky": "^4.2.5",


### PR DESCRIPTION
This only applies to raidboss data files at the moment.