### PR TITLE
raidemulator: Follow up fixes for #2879

### DIFF
--- a/ui/raidboss/emulator/data/network_log_converter/LineEvent0x00.ts
+++ b/ui/raidboss/emulator/data/network_log_converter/LineEvent0x00.ts
@@ -5,6 +5,8 @@ import LogRepository from './LogRepository';
 export class LineEvent0x00 extends LineEvent {
   constructor(repo: LogRepository, line: string, parts: string[]) {
     super(repo, line, parts);
+    // The exact reason for this check isn't clear anymore but may be related to
+    // https://github.com/ravahn/FFXIV_ACT_Plugin/issues/250
     if (this.message.split('\u001f\u001f').length > 1)
       this.invalid = true;
   }

--- a/ui/raidboss/emulator/data/network_log_converter/LineEvent0x01.ts
+++ b/ui/raidboss/emulator/data/network_log_converter/LineEvent0x01.ts
@@ -6,7 +6,7 @@ import LogRepository from './LogRepository';
 export class LineEvent0x01 extends LineEvent {
   public properCaseConvertedLine = '';
 
-  public get zoneID(): string {
+  public get zoneId(): string {
     return this.parts[2] ?? '';
   }
 

--- a/ui/raidboss/emulator/data/network_log_converter/LineEvent0x03.ts
+++ b/ui/raidboss/emulator/data/network_log_converter/LineEvent0x03.ts
@@ -125,12 +125,12 @@ export class LineEvent0x03 extends LineEvent {
   }
 
   convert(_: LogRepository): void {
-    let CombatantName = this.name;
+    let combatantName = this.name;
     if (this.worldName !== '')
-      CombatantName = CombatantName + '(' + this.worldName + ')';
+      combatantName = combatantName + '(' + this.worldName + ')';
 
     this.convertedLine = this.prefix() + this.id.toUpperCase() +
-      ':Added new combatant ' + CombatantName +
+      ':Added new combatant ' + combatantName +
       '.  Job: ' + this.jobName +
       ' Level: ' + this.levelString +
       ' Max HP: ' + this.maxHpString +
@@ -138,11 +138,11 @@ export class LineEvent0x03 extends LineEvent {
       ' Pos: (' + this.xString + ',' + this.yString + ',' + this.zString + ')';
 
     // This last part is guesswork for the area between 9 and 10.
-    const UnknownValue = this.npcNameId +
+    const unknownValue = this.npcNameId +
       EmulatorCommon.zeroPad(this.npcBaseId, 8 + Math.max(0, 6 - this.npcNameId.length));
 
-    if (UnknownValue !== '00000000000000')
-      this.convertedLine += ' (' + UnknownValue + ')';
+    if (unknownValue !== '00000000000000')
+      this.convertedLine += ' (' + unknownValue + ')';
 
     this.convertedLine += '.';
   }

--- a/ui/raidboss/emulator/data/network_log_converter/LineEvent0x18.ts
+++ b/ui/raidboss/emulator/data/network_log_converter/LineEvent0x18.ts
@@ -5,7 +5,7 @@ import LogRepository from './LogRepository';
 // DoT/HoT event
 export class LineEvent0x18 extends LineEvent {
   public resolvedName: string;
-  public effectName: string | undefined = '';
+  public effectName?: string;
   public properCaseConvertedLine = '';
 
   constructor(repo: LogRepository, line: string, parts: string[]) {
@@ -19,6 +19,9 @@ export class LineEvent0x18 extends LineEvent {
     });
 
     this.resolvedName = repo.resolveName(this.id, this.name);
+
+    if (this.effectId in LineEvent0x18.showEffectNamesFor)
+      this.effectName = LineEvent0x18.showEffectNamesFor[this.effectId] ?? '';
   }
 
   public get id(): string {
@@ -82,8 +85,6 @@ export class LineEvent0x18 extends LineEvent {
   }
 
   convert(_: LogRepository): void {
-    if (this.effectId.toUpperCase() in LineEvent0x18.showEffectNamesFor)
-      this.effectName = LineEvent0x18.showEffectNamesFor[this.effectId.toUpperCase()];
     let effectPart = '';
     if (this.effectName)
       effectPart = this.effectName + ' ';

--- a/ui/raidboss/emulator/data/network_log_converter/LineEvent0x19.ts
+++ b/ui/raidboss/emulator/data/network_log_converter/LineEvent0x19.ts
@@ -4,8 +4,8 @@ import LogRepository from './LogRepository';
 
 // Combatant defeated event
 export class LineEvent0x19 extends LineEvent {
-  public resolvedName: string | false;
-  public resolvedTargetName: string | false;
+  public resolvedName?: string;
+  public resolvedTargetName?: string;
   public properCaseConvertedLine = '';
 
   constructor(repo: LogRepository, line: string, parts: string[]) {
@@ -25,11 +25,9 @@ export class LineEvent0x19 extends LineEvent {
       despawn: this.timestamp,
     });
 
-    this.resolvedName = false;
     if (this.id !== '00')
       this.resolvedName = repo.resolveName(this.id, this.name);
 
-    this.resolvedTargetName = false;
     if (this.targetId !== '00')
       this.resolvedTargetName = repo.resolveName(this.targetId, this.targetName);
   }
@@ -51,8 +49,8 @@ export class LineEvent0x19 extends LineEvent {
   }
 
   convert(_: LogRepository): void {
-    const defeatedName = (this.resolvedName || this.name);
-    const killerName = (this.resolvedTargetName || this.targetName);
+    const defeatedName = (this.resolvedName ?? this.name);
+    const killerName = (this.resolvedTargetName ?? this.targetName);
     this.convertedLine = this.prefix() + defeatedName +
       ' was defeated by ' + killerName + '.';
     this.properCaseConvertedLine = this.prefix() + EmulatorCommon.properCase(defeatedName) +

--- a/ui/raidboss/emulator/data/network_log_converter/LineEvent0x1A.ts
+++ b/ui/raidboss/emulator/data/network_log_converter/LineEvent0x1A.ts
@@ -69,11 +69,11 @@ export class LineEvent0x1A extends LineEvent {
     return parseInt(this.parts[9] ?? '0');
   }
 
-  public get targetHP(): string {
+  public get targetHp(): string {
     return this.parts[10] ?? '';
   }
 
-  public get sourceHP(): string {
+  public get sourceHp(): string {
     return this.parts[11] ?? '';
   }
 


### PR DESCRIPTION
Follow up PR for fixes mentioned in #2879.

Opted to move `LineEvent0x18`'s `effectName` property initialization to the constructor instead of the `convert` method, since it doesn't need to be delayed for repo population like some other properties.