### PR TITLE
util: add eval check to process-triggers

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -158,7 +158,7 @@ module.exports = {
       'windows',
     ],
     'max-len': [
-      'error',
+      'warn',
       {
         'code': 100,
         'ignoreRegExpLiterals': true,

--- a/resources/user_config.ts
+++ b/resources/user_config.ts
@@ -78,6 +78,19 @@ class UserConfig {
     };
   }
 
+  evalUserFile(content: string, options: BaseOptions): void {
+    const Options = options;
+    console.assert(Options); // Used by eval.
+
+    // This is the one eval cactbot should ever need, which is for handling user files.
+    // Because user files can be located anywhere on disk and there's backwards compat
+    // issues, it's unlikely that these will be able to be anything but eval forever.
+    //
+    /* eslint-disable no-eval */
+    eval(content);
+    /* eslint-enable no-eval */
+  }
+
   registerOptions(overlayName: string, optionTemplate: OptionsTemplate,
       userFileCallback?: UserFileCallback) {
     this.optionTemplates[overlayName] = optionTemplate;
@@ -286,16 +299,7 @@ class UserConfig {
         for (const jsFile of jsFiles) {
           try {
             printUserFile(`local user file: ${basePath}${jsFile}`);
-            const Options = options;
-            console.assert(Options); // Used by eval.
-
-            // This is the one eval cactbot should ever need, which is for handling user files.
-            // Because user files can be located anywhere on disk and there's backwards compat
-            // issues, it's unlikely that these will be able to be anything but eval forever.
-            //
-            /* eslint-disable no-eval */
-            eval(localFiles[jsFile] ?? '');
-            /* eslint-enable no-eval */
+            this.evalUserFile(localFiles[jsFile] ?? '', options);
 
             for (const field of warnOnVariableResetMap[overlayName] ?? []) {
               if (variableTracker[field] && variableTracker[field] !== options[field]) {

--- a/util/process_triggers_folder.ts
+++ b/util/process_triggers_folder.ts
@@ -80,7 +80,7 @@ const processFile = async (filename: string) => {
   }
 
   const contents = lintResult.output;
-  if (!contents) {
+  if (contents === undefined) {
     console.error(`${filename}: Lint returned no contents`);
     process.exit(4);
   }


### PR DESCRIPTION
This will make sure that trigger files actually are usable as user
files on the triggers branch.

Also, make line length a warning now that we have a limit of
zero warnings.  This will make it less noisy and let us detect
other errors in trigger files.