### PR TITLE
raidemulator: Fix issue with LineEvent getter data passing postMessage boundary

### DIFF
--- a/ui/raidboss/emulator/data/NetworkLogConverter.ts
+++ b/ui/raidboss/emulator/data/NetworkLogConverter.ts
@@ -21,7 +21,6 @@ export default class NetworkLogConverter extends EventBus {
     let lineEvents = lines.map((l) => ParseLine.parse(repo, l)).filter(isLineEvent);
     // Call `convert` to convert the network line to non-network format and update indexing values
     lineEvents = lineEvents.map((l, i) => {
-      l.convert(repo);
       l.index = i;
       return l;
     });

--- a/ui/raidboss/emulator/data/NetworkLogConverterWorker.js
+++ b/ui/raidboss/emulator/data/NetworkLogConverterWorker.js
@@ -4,6 +4,17 @@ import LogEventHandler from './LogEventHandler';
 import NetworkLogConverter from './NetworkLogConverter';
 import LogRepository from './network_log_converter/LogRepository';
 
+const getClassPropertyDescriptors = (obj) => {
+  if (obj && obj !== Object.prototype) {
+    const proto = Object.getPrototypeOf(obj);
+    return {
+      ...getClassPropertyDescriptors(proto),
+      ...Object.getOwnPropertyDescriptors(obj),
+    };
+  }
+  return null;
+};
+
 onmessage = async (msg) => {
   const logConverter = new NetworkLogConverter();
   const localLogHandler = new LogEventHandler();
@@ -13,9 +24,21 @@ onmessage = async (msg) => {
   localLogHandler.on('fight', async (day, zoneId, zoneName, lines) => {
     const enc = new Encounter(day, zoneId, zoneName, lines);
     if (enc.shouldPersistFight()) {
+      // Due to using getters on LineEvent classes, we need to manually convert these over
+      const baseEnc = EmulatorCommon.cloneData(enc);
+      baseEnc.logLines = enc.logLines.map((l) => {
+        const ret = Object.assign({}, l);
+        // Get all getters on the line class and add them to the cloned object
+        const props = getClassPropertyDescriptors(l);
+        for (const prop in props) {
+          if (props[prop].get)
+            ret[prop] = l[prop];
+        }
+        return ret;
+      });
       postMessage({
         type: 'encounter',
-        encounter: enc,
+        encounter: baseEnc,
         name: enc.combatantTracker.getMainCombatantName(),
       });
     }

--- a/ui/raidboss/emulator/data/network_log_converter/LineEvent.ts
+++ b/ui/raidboss/emulator/data/network_log_converter/LineEvent.ts
@@ -1,37 +1,31 @@
 import EmulatorCommon from '../../EmulatorCommon';
 import LogRepository from './LogRepository';
 
+const fields = {
+  event: 0,
+  timestamp: 1,
+} as const;
+
 /**
  * Generic class to track an FFXIV log line
  */
 export default class LineEvent {
   public offset = 0;
-  public convertedLine = '';
+  public convertedLine: string;
   public invalid = false;
   public index = 0;
+  public readonly decEvent: number;
+  public readonly hexEvent: string;
+  public readonly timestamp: number;
+  public readonly checksum: string;
 
-  constructor(repo: LogRepository, public networkLine: string, protected parts: string[]) {
+  constructor(repo: LogRepository, public networkLine: string, parts: string[]) {
+    this.decEvent = parseInt(parts[fields.event] ?? '0');
+    this.hexEvent = EmulatorCommon.zeroPad(this.decEvent.toString(16).toUpperCase());
+    this.timestamp = new Date(parts[fields.timestamp] ?? '0').getTime();
+    this.checksum = parts.slice(-1)[0] ?? '';
     repo.updateTimestamp(this.timestamp);
-  }
-
-  public get decEvent(): number {
-    return parseInt(this.parts[0] ?? '0');
-  }
-
-  public get hexEvent(): string {
-    return EmulatorCommon.zeroPad(this.decEvent.toString(16).toUpperCase());
-  }
-
-  public get timestamp(): number {
-    return new Date(this.parts[1] ?? '0').getTime();
-  }
-
-  public get checksum(): string {
-    return this.parts.slice(-1)[0] ?? '';
-  }
-
-  convert(_: LogRepository): void {
-    this.convertedLine = this.prefix() + (this.parts.join(':')).replace('|', ':');
+    this.convertedLine = this.prefix() + (parts.join(':')).replace('|', ':');
   }
 
   prefix(): string {

--- a/ui/raidboss/emulator/data/network_log_converter/LineEvent0x00.ts
+++ b/ui/raidboss/emulator/data/network_log_converter/LineEvent0x00.ts
@@ -1,34 +1,34 @@
 import LineEvent from './LineEvent';
 import LogRepository from './LogRepository';
 
+const fields = {
+  type: 2,
+  speaker: 3,
+} as const;
+
 // Chat event
 export class LineEvent0x00 extends LineEvent {
+  public readonly type: string;
+  public readonly speaker: string;
+  public readonly message: string;
+
   constructor(repo: LogRepository, line: string, parts: string[]) {
     super(repo, line, parts);
+
+    this.type = parts[fields.type] ?? '';
+    this.speaker = parts[fields.speaker] ?? '';
+    this.message = parts.slice(4, -1).join('|');
+
     // The exact reason for this check isn't clear anymore but may be related to
     // https://github.com/ravahn/FFXIV_ACT_Plugin/issues/250
     if (this.message.split('\u001f\u001f').length > 1)
       this.invalid = true;
-  }
 
-  public get type(): string {
-    return this.parts[2] ?? '';
-  }
-
-  public get speaker(): string {
-    return this.parts[3] ?? '';
-  }
-
-  public get message(): string {
-    return this.parts.slice(4, -1).join('|');
-  }
-
-  convert(_: LogRepository): void {
     this.convertedLine =
       this.prefix() + this.type + ':' +
-       // If speaker is blank, it's excluded from the converted line
-       (this.speaker !== '' ? this.speaker + ':' : '') +
-       this.message.trim();
+        // If speaker is blank, it's excluded from the converted line
+        (this.speaker !== '' ? this.speaker + ':' : '') +
+        this.message.trim();
     this.convertedLine = LineEvent00.replaceChatSymbols(this.convertedLine);
   }
 

--- a/ui/raidboss/emulator/data/network_log_converter/LineEvent0x01.ts
+++ b/ui/raidboss/emulator/data/network_log_converter/LineEvent0x01.ts
@@ -2,23 +2,26 @@ import LineEvent from './LineEvent';
 import EmulatorCommon from '../../EmulatorCommon';
 import LogRepository from './LogRepository';
 
+const fields = {
+  zoneId: 2,
+  zoneName: 3,
+} as const;
+
 // Zone change event
 export class LineEvent0x01 extends LineEvent {
-  public properCaseConvertedLine = '';
+  public readonly properCaseConvertedLine: string;
 
-  public get zoneId(): string {
-    return this.parts[2] ?? '';
-  }
+  public readonly zoneId: string;
+  public readonly zoneName: string;
+  public readonly zoneNameProperCase: string;
 
-  public get zoneName(): string {
-    return this.parts[3] ?? '';
-  }
+  constructor(repo: LogRepository, networkLine: string, parts: string[]) {
+    super(repo, networkLine, parts);
 
-  public get zoneNameProperCase(): string {
-    return EmulatorCommon.properCase(this.zoneName);
-  }
+    this.zoneId = parts[fields.zoneId] ?? '';
+    this.zoneName = parts[fields.zoneName] ?? '';
+    this.zoneNameProperCase = EmulatorCommon.properCase(this.zoneName);
 
-  convert(_: LogRepository): void {
     this.convertedLine = this.prefix() +
       'Changed Zone to ' + this.zoneName + '.';
     this.properCaseConvertedLine = this.prefix() +

--- a/ui/raidboss/emulator/data/network_log_converter/LineEvent0x02.ts
+++ b/ui/raidboss/emulator/data/network_log_converter/LineEvent0x02.ts
@@ -1,21 +1,22 @@
 import LineEvent from './LineEvent';
 import LogRepository from './LogRepository';
 
+const fields = {
+  id: 2,
+  name: 3,
+} as const;
+
 // Player change event
 export class LineEvent0x02 extends LineEvent {
+  public readonly id: string;
+  public readonly name: string;
+
   constructor(repo: LogRepository, line: string, parts: string[]) {
     super(repo, line, parts);
-  }
 
-  public get id(): string {
-    return this.parts[2]?.toUpperCase() ?? '';
-  }
+    this.id = parts[fields.id]?.toUpperCase() ?? '';
+    this.name = parts[fields.name] ?? '';
 
-  public get name(): string {
-    return this.parts[3] ?? '';
-  }
-
-  convert(_: LogRepository): void {
     this.convertedLine = this.prefix() + 'Changed primary player to ' + this.name + '.';
   }
 }

--- a/ui/raidboss/emulator/data/network_log_converter/LineEvent0x03.ts
+++ b/ui/raidboss/emulator/data/network_log_converter/LineEvent0x03.ts
@@ -3,10 +3,88 @@ import EmulatorCommon from '../../EmulatorCommon';
 import Util from '../../../../../resources/util';
 import LogRepository from './LogRepository';
 
+const fields = {
+  id: 2,
+  name: 3,
+  jobIdHex: 4,
+  levelString: 5,
+  ownerId: 6,
+  worldId: 7,
+  worldName: 8,
+  npcNameId: 9,
+  npcBaseId: 10,
+  currentHp: 11,
+  maxHpString: 14,
+  currentMp: 13,
+  maxMpString: 14,
+  currentTp: 15,
+  maxTp: 16,
+  xString: 17,
+  yString: 18,
+  zString: 19,
+  heading: 20,
+} as const;
+
 // Added combatant event
 export class LineEvent0x03 extends LineEvent {
+  public readonly id: string;
+  public readonly name: string;
+  public readonly jobIdHex: string;
+  public readonly jobIdDec: number;
+  public readonly jobName: string;
+  public readonly levelString: string;
+  public readonly level: number;
+  public readonly ownerId: string;
+  public readonly worldId: string;
+  public readonly worldName: string;
+  public readonly npcNameId: string;
+  public readonly npcBaseId: string;
+  public readonly currentHp: number;
+  public readonly maxHpString: string;
+  public readonly maxHp: number;
+  public readonly currentMp: number;
+  public readonly maxMpString: string;
+  public readonly maxMp: number;
+  public readonly currentTp: number;
+  public readonly maxTp: number;
+  public readonly xString: string;
+  public readonly x: number;
+  public readonly yString: string;
+  public readonly y: number;
+  public readonly zString: string;
+  public readonly z: number;
+  public readonly heading: number;
+
   constructor(repo: LogRepository, line: string, parts: string[]) {
     super(repo, line, parts);
+
+    this.id = parts[fields.id]?.toUpperCase() ?? '';
+    this.name = parts[fields.name] ?? '';
+    this.jobIdHex = parts[fields.jobIdHex]?.toUpperCase() ?? '';
+    this.jobIdDec = parseInt(this.jobIdHex, 16);
+    this.jobName = Util.jobEnumToJob(this.jobIdDec);
+    this.levelString = parts[fields.levelString] ?? '';
+    this.level = parseFloat(this.levelString);
+    this.ownerId = parts[fields.ownerId]?.toUpperCase() ?? '';
+    this.worldId = parts[fields.worldId] ?? '';
+    this.worldName = parts[fields.worldName] ?? '';
+    this.npcNameId = parts[fields.npcNameId] ?? '';
+    this.npcBaseId = parts[fields.npcBaseId] ?? '';
+    this.currentHp = parseFloat(parts[fields.currentHp] ?? '');
+    this.maxHpString = parts[fields.maxHpString] ?? '';
+    this.maxHp = parseFloat(this.maxHpString);
+    this.currentMp = parseFloat(parts[fields.currentMp] ?? '');
+    this.maxMpString = parts[fields.maxMpString] ?? '';
+    this.maxMp = parseFloat(this.maxMpString);
+    this.currentTp = parseFloat(parts[fields.currentTp] ?? '');
+    this.maxTp = parseFloat(parts[fields.maxTp] ?? '');
+    this.xString = parts[fields.xString] ?? '';
+    this.x = parseFloat(this.xString);
+    this.yString = parts[fields.yString] ?? '';
+    this.y = parseFloat(this.yString);
+    this.zString = parts[fields.zString] ?? '';
+    this.z = parseFloat(this.zString);
+    this.heading = parseFloat(parts[fields.heading] ?? '');
 
     repo.updateCombatant(this.id, {
       name: this.name,
@@ -14,117 +92,7 @@ export class LineEvent0x03 extends LineEvent {
       despawn: this.timestamp,
       job: this.jobIdHex,
     });
-  }
 
-  public get id(): string {
-    return this.parts[2]?.toUpperCase() ?? '';
-  }
-
-  public get name(): string {
-    return this.parts[3] ?? '';
-  }
-
-  public get jobIdHex(): string {
-    return this.parts[4]?.toUpperCase() ?? '';
-  }
-
-  public get jobIdDec(): number {
-    return parseInt(this.jobIdHex, 16);
-  }
-
-  public get jobName(): string {
-    return Util.jobEnumToJob(this.jobIdDec);
-  }
-
-  public get levelString(): string {
-    return this.parts[5] ?? '';
-  }
-
-  public get level(): number {
-    return parseFloat(this.levelString);
-  }
-
-  public get ownerId(): string {
-    return this.parts[6]?.toUpperCase() ?? '';
-  }
-
-  public get worldId(): string {
-    return this.parts[7] ?? '';
-  }
-
-  public get worldName(): string {
-    return this.parts[8] ?? '';
-  }
-
-  public get npcNameId(): string {
-    return this.parts[9] ?? '';
-  }
-
-  public get npcBaseId(): string {
-    return this.parts[10] ?? '';
-  }
-
-  public get currentHp(): number {
-    return parseFloat(this.parts[11] ?? '');
-  }
-
-  public get maxHpString(): string {
-    return this.parts[14] ?? '';
-  }
-
-  public get maxHp(): number {
-    return parseFloat(this.maxHpString);
-  }
-
-  public get currentMp(): number {
-    return parseFloat(this.parts[13] ?? '');
-  }
-
-  public get maxMpString(): string {
-    return this.parts[14] ?? '';
-  }
-
-  public get maxMp(): number {
-    return parseFloat(this.maxMpString);
-  }
-
-  public get currentTp(): number {
-    return parseFloat(this.parts[15] ?? '');
-  }
-
-  public get maxTp(): number {
-    return parseFloat(this.parts[16] ?? '');
-  }
-
-  public get xString(): string {
-    return this.parts[17] ?? '';
-  }
-
-  public get x(): number {
-    return parseFloat(this.xString);
-  }
-
-  public get yString(): string {
-    return this.parts[18] ?? '';
-  }
-
-  public get y(): number {
-    return parseFloat(this.yString);
-  }
-
-  public get zString(): string {
-    return this.parts[19] ?? '';
-  }
-
-  public get z(): number {
-    return parseFloat(this.zString);
-  }
-
-  public get heading(): number {
-    return parseFloat(this.parts[20] ?? '');
-  }
-
-  convert(_: LogRepository): void {
     let combatantName = this.name;
     if (this.worldName !== '')
       combatantName = combatantName + '(' + this.worldName + ')';

--- a/ui/raidboss/emulator/data/network_log_converter/LineEvent0x04.ts
+++ b/ui/raidboss/emulator/data/network_log_converter/LineEvent0x04.ts
@@ -7,9 +7,7 @@ import LogRepository from './LogRepository';
 export class LineEvent0x04 extends LineEvent0x03 {
   constructor(repo: LogRepository, line: string, parts: string[]) {
     super(repo, line, parts);
-  }
 
-  convert(_: LogRepository): void {
     this.convertedLine = this.prefix() + this.id.toUpperCase() +
       ':Removing combatant ' + this.name +
       '. Max MP: ' + this.maxMpString +

--- a/ui/raidboss/emulator/data/network_log_converter/LineEvent0x0C.ts
+++ b/ui/raidboss/emulator/data/network_log_converter/LineEvent0x0C.ts
@@ -1,79 +1,66 @@
 import LineEvent from './LineEvent';
 import LogRepository from './LogRepository';
 
+const fields = {
+  class: 2,
+  strength: 3,
+  dexterity: 4,
+  vitality: 5,
+  intelligence: 6,
+  mind: 7,
+  piety: 8,
+  attackPower: 9,
+  directHit: 10,
+  criticalHit: 11,
+  attackMagicPotency: 12,
+  healMagicPotency: 13,
+  determination: 14,
+  skillSpeed: 15,
+  spellSpeed: 16,
+  tenacity: 18,
+} as const;
+
 // Player stats event
 export class LineEvent0x0C extends LineEvent {
+  public readonly class: string;
+  public readonly strength: string;
+  public readonly dexterity: string;
+  public readonly vitality: string;
+  public readonly intelligence: string;
+  public readonly mind: string;
+  public readonly piety: string;
+  public readonly attackPower: string;
+  public readonly directHit: string;
+  public readonly criticalHit: string;
+  public readonly attackMagicPotency: string;
+  public readonly healMagicPotency: string;
+  public readonly determination: string;
+  public readonly skillSpeed: string;
+  public readonly spellSpeed: string;
+  public readonly tenacity: string;
+
   constructor(repo: LogRepository, line: string, parts: string[]) {
     super(repo, line, parts);
-  }
 
-  public get class(): string {
-    return this.parts[2] ?? '';
-  }
+    this.class = parts[fields.class] ?? '';
+    this.strength = parts[fields.strength] ?? '';
+    this.dexterity = parts[fields.dexterity] ?? '';
+    this.vitality = parts[fields.vitality] ?? '';
+    this.intelligence = parts[fields.intelligence] ?? '';
+    this.mind = parts[fields.mind] ?? '';
+    this.piety = parts[fields.piety] ?? '';
+    this.attackPower = parts[fields.attackPower] ?? '';
+    this.directHit = parts[fields.directHit] ?? '';
+    this.criticalHit = parts[fields.criticalHit] ?? '';
+    this.attackMagicPotency = parts[fields.attackMagicPotency] ?? '';
+    this.healMagicPotency = parts[fields.healMagicPotency] ?? '';
+    this.determination = parts[fields.determination] ?? '';
+    this.skillSpeed = parts[fields.skillSpeed] ?? '';
+    this.spellSpeed = parts[fields.spellSpeed] ?? '';
+    this.tenacity = parts[fields.tenacity] ?? '';
 
-  public get strength(): string {
-    return this.parts[3] ?? '';
-  }
-
-  public get dexterity(): string {
-    return this.parts[4] ?? '';
-  }
-
-  public get vitality(): string {
-    return this.parts[5] ?? '';
-  }
-
-  public get intelligence(): string {
-    return this.parts[6] ?? '';
-  }
-
-  public get mind(): string {
-    return this.parts[7] ?? '';
-  }
-
-  public get piety(): string {
-    return this.parts[8] ?? '';
-  }
-
-  public get attackPower(): string {
-    return this.parts[9] ?? '';
-  }
-
-  public get directHit(): string {
-    return this.parts[10] ?? '';
-  }
-
-  public get criticalHit(): string {
-    return this.parts[11] ?? '';
-  }
-
-  public get attackMagicPotency(): string {
-    return this.parts[12] ?? '';
-  }
-
-  public get healMagicPotency(): string {
-    return this.parts[13] ?? '';
-  }
-
-  public get determination(): string {
-    return this.parts[14] ?? '';
-  }
-
-  public get skillSpeed(): string {
-    return this.parts[15] ?? '';
-  }
-
-  public get spellSpeed(): string {
-    return this.parts[16] ?? '';
-  }
-
-  public get tenacity(): string {
-    return this.parts[18] ?? '';
-  }
-
-  convert(_: LogRepository): void {
     this.convertedLine = this.prefix() +
-      'Player Stats: ' + this.parts.slice(2, this.parts.length - 1).join(':').replace(/\|/g, ':');
+      'Player Stats: ' + parts.slice(2, parts.length - 1).join(':').replace(/\|/g, ':');
   }
 }
 

--- a/ui/raidboss/emulator/data/network_log_converter/LineEvent0x14.ts
+++ b/ui/raidboss/emulator/data/network_log_converter/LineEvent0x14.ts
@@ -2,12 +2,38 @@ import LineEvent from './LineEvent';
 import EmulatorCommon from '../../EmulatorCommon';
 import LogRepository from './LogRepository';
 
+const fields = {
+  id: 2,
+  name: 3,
+  abilityId: 4,
+  abilityName: 5,
+  targetId: 6,
+  targetName: 7,
+  duration: 8,
+} as const;
+
 // Ability use event
 export class LineEvent0x14 extends LineEvent {
-  public properCaseConvertedLine = '';
+  public readonly properCaseConvertedLine: string;
+
+  public readonly id: string;
+  public readonly name: string;
+  public readonly abilityId: string;
+  public readonly abilityName: string;
+  public readonly targetId: string;
+  public readonly targetName: string;
+  public readonly duration: string;
 
   constructor(repo: LogRepository, line: string, parts: string[]) {
     super(repo, line, parts);
+
+    this.id = parts[fields.id]?.toUpperCase() ?? '';
+    this.name = parts[fields.name] ?? '';
+    this.abilityId = parts[fields.abilityId]?.toUpperCase() ?? '';
+    this.abilityName = parts[fields.abilityName] ?? '';
+    this.targetId = parts[fields.targetId]?.toUpperCase() ?? '';
+    this.targetName = parts[fields.targetName] ?? '';
+    this.duration = parts[fields.duration] ?? '';
 
     repo.updateCombatant(this.id, {
       job: undefined,
@@ -22,44 +48,14 @@ export class LineEvent0x14 extends LineEvent {
       spawn: this.timestamp,
       despawn: this.timestamp,
     });
-  }
 
-  public get id(): string {
-    return this.parts[2]?.toUpperCase() ?? '';
-  }
-
-  public get name(): string {
-    return this.parts[3] ?? '';
-  }
-
-  public get abilityId(): string {
-    return this.parts[4]?.toUpperCase() ?? '';
-  }
-
-  public get abilityName(): string {
-    return this.parts[5] ?? '';
-  }
-
-  public get targetId(): string {
-    return this.parts[6]?.toUpperCase() ?? '';
-  }
-
-  public get targetName(): string {
-    return this.parts[7] ?? '';
-  }
-
-  public get duration(): string {
-    return this.parts[8] ?? '';
-  }
-
-  convert(_: LogRepository): void {
     const target = this.targetName.length === 0 ? 'Unknown' : this.targetName;
 
     this.convertedLine = this.prefix() + this.abilityId +
       ':' + this.name +
       ' starts using ' + this.abilityName +
       ' on ' + target + '.';
-    this.convertedLine = this.prefix() + this.abilityId +
+    this.properCaseConvertedLine = this.prefix() + this.abilityId +
       ':' + EmulatorCommon.properCase(this.name) +
       ' starts using ' + this.abilityName +
       ' on ' + EmulatorCommon.properCase(target) + '.';

--- a/ui/raidboss/emulator/data/network_log_converter/LineEvent0x15.ts
+++ b/ui/raidboss/emulator/data/network_log_converter/LineEvent0x15.ts
@@ -1,15 +1,94 @@
 import LineEvent from './LineEvent';
 import LogRepository from './LogRepository';
 
+const fields = {
+  id: 2,
+  name: 3,
+  flags: 8,
+  damage: 9,
+  abilityId: 4,
+  abilityName: 5,
+  targetId: 6,
+  targetName: 7,
+  targetHp: 24,
+  targetMaxHp: 25,
+  targetMp: 26,
+  targetMaxMp: 27,
+  targetX: 30,
+  targetY: 31,
+  targetZ: 32,
+  targetHeading: 33,
+  sourceHp: 34,
+  sourceMaxHp: 35,
+  sourceMp: 36,
+  sourceMaxMp: 37,
+  x: 40,
+  y: 41,
+  z: 42,
+  heading: 43,
+} as const;
+
 // Ability hit single target event
 export class LineEvent0x15 extends LineEvent {
-  private fieldOffset = 0;
+  public readonly damage: number;
+  public readonly id: string;
+  public readonly name: string;
+  public readonly abilityId: string;
+  public readonly abilityName: string;
+  public readonly targetId: string;
+  public readonly targetName: string;
+  public readonly flags: string;
+  public readonly targetHp: string;
+  public readonly targetMaxHp: string;
+  public readonly targetMp: string;
+  public readonly targetMaxMp: string;
+  public readonly targetX: string;
+  public readonly targetY: string;
+  public readonly targetZ: string;
+  public readonly targetHeading: string;
+  public readonly sourceHp: string;
+  public readonly sourceMaxHp: string;
+  public readonly sourceMp: string;
+  public readonly sourceMaxMp: string;
+  public readonly x: string;
+  public readonly y: string;
+  public readonly z: string;
+  public readonly heading: string;
 
   constructor(repo: LogRepository, line: string, parts: string[]) {
     super(repo, line, parts);
 
-    if (this.flags === '3F')
-      this.fieldOffset = 2;
+    this.id = parts[fields.id]?.toUpperCase() ?? '';
+    this.name = parts[fields.name] ?? '';
+
+    this.flags = parts[fields.flags] ?? '';
+
+    const fieldOffset = this.flags === '3F' ? 2 : 0;
+
+    this.damage = LineEvent.calculateDamage(parts[fields.damage + fieldOffset] ?? '');
+    this.abilityId = parts[fields.abilityId]?.toUpperCase() ?? '';
+    this.abilityName = parts[fields.abilityName] ?? '';
+    this.targetId = parts[fields.targetId]?.toUpperCase() ?? '';
+    this.targetName = parts[fields.targetName] ?? '';
+
+    this.targetHp = parts[fields.targetHp + fieldOffset] ?? '';
+    this.targetMaxHp = parts[fields.targetMaxHp + fieldOffset] ?? '';
+    this.targetMp = parts[fields.targetMp + fieldOffset] ?? '';
+    this.targetMaxMp = parts[fields.targetMaxMp + fieldOffset] ?? '';
+    this.targetX = parts[fields.targetX + fieldOffset] ?? '';
+    this.targetY = parts[fields.targetY + fieldOffset] ?? '';
+    this.targetZ = parts[fields.targetZ + fieldOffset] ?? '';
+    this.targetHeading = parts[fields.targetHeading + fieldOffset] ?? '';
+
+    this.sourceHp = parts[fields.sourceHp + fieldOffset] ?? '';
+    this.sourceMaxHp = parts[fields.sourceMaxHp + fieldOffset] ?? '';
+    this.sourceMp = parts[fields.sourceMp + fieldOffset] ?? '';
+    this.sourceMaxMp = parts[fields.sourceMaxMp + fieldOffset] ?? '';
+    this.x = parts[fields.x + fieldOffset] ?? '';
+    this.y = parts[fields.y + fieldOffset] ?? '';
+    this.z = parts[fields.z + fieldOffset] ?? '';
+    this.heading = parts[fields.heading + fieldOffset] ?? '';
+
 
     repo.updateCombatant(this.id, {
       job: undefined,
@@ -24,102 +103,6 @@ export class LineEvent0x15 extends LineEvent {
       spawn: this.timestamp,
       despawn: this.timestamp,
     });
-  }
-
-  public get damage(): number {
-    return LineEvent.calculateDamage(this.parts[9 + this.fieldOffset] ?? '');
-  }
-
-  public get id(): string {
-    return this.parts[2]?.toUpperCase() ?? '';
-  }
-
-  public get name(): string {
-    return this.parts[3] ?? '';
-  }
-
-  public get abilityId(): string {
-    return this.parts[4]?.toUpperCase() ?? '';
-  }
-
-  public get abilityName(): string {
-    return this.parts[5] ?? '';
-  }
-
-  public get targetId(): string {
-    return this.parts[6]?.toUpperCase() ?? '';
-  }
-
-  public get targetName(): string {
-    return this.parts[7] ?? '';
-  }
-
-  public get flags(): string {
-    return this.parts[8] ?? '';
-  }
-
-  public get targetHp(): string {
-    return this.parts[24 + this.fieldOffset] ?? '';
-  }
-
-  public get targetMaxHp(): string {
-    return this.parts[25 + this.fieldOffset] ?? '';
-  }
-
-  public get targetMp(): string {
-    return this.parts[26 + this.fieldOffset] ?? '';
-  }
-
-  public get targetMaxMp(): string {
-    return this.parts[27 + this.fieldOffset] ?? '';
-  }
-
-  public get targetX(): string {
-    return this.parts[30 + this.fieldOffset] ?? '';
-  }
-
-  public get targetY(): string {
-    return this.parts[31 + this.fieldOffset] ?? '';
-  }
-
-  public get targetZ(): string {
-    return this.parts[32 + this.fieldOffset] ?? '';
-  }
-
-  public get targetHeading(): string {
-    return this.parts[33 + this.fieldOffset] ?? '';
-  }
-
-  public get sourceHp(): string {
-    return this.parts[34 + this.fieldOffset] ?? '';
-  }
-
-  public get sourceMaxHp(): string {
-    return this.parts[35 + this.fieldOffset] ?? '';
-  }
-
-  public get sourceMp(): string {
-    return this.parts[36 + this.fieldOffset] ?? '';
-  }
-
-  public get sourceMaxMp(): string {
-    return this.parts[37 + this.fieldOffset] ?? '';
-  }
-
-  public get x(): string {
-    return this.parts[40 + this.fieldOffset] ?? '';
-  }
-
-  public get y(): string {
-    return this.parts[41 + this.fieldOffset] ?? '';
-  }
-
-  public get z(): string {
-    return this.parts[42 + this.fieldOffset] ?? '';
-  }
-
-  public get heading(): string {
-    return this.parts[43 + this.fieldOffset] ?? '';
   }
 }
 

--- a/ui/raidboss/emulator/data/network_log_converter/LineEvent0x17.ts
+++ b/ui/raidboss/emulator/data/network_log_converter/LineEvent0x17.ts
@@ -1,30 +1,30 @@
 import LineEvent from './LineEvent';
 import LogRepository from './LogRepository';
 
+const fields = {
+  id: 2,
+  name: 3,
+  abilityId: 4,
+  abilityName: 5,
+  reason: 6,
+} as const;
+
 // Cancel ability event
 export class LineEvent0x17 extends LineEvent {
+  public readonly id: string;
+  public readonly name: string;
+  public readonly abilityId: string;
+  public readonly abilityName: string;
+  public readonly reason: string;
+
   constructor(repo: LogRepository, line: string, parts: string[]) {
     super(repo, line, parts);
-  }
 
-  public get id(): string {
-    return this.parts[2]?.toUpperCase() ?? '';
-  }
-
-  public get name(): string {
-    return this.parts[3] ?? '';
-  }
-
-  public get abilityId(): string {
-    return this.parts[4]?.toUpperCase() ?? '';
-  }
-
-  public get abilityName(): string {
-    return this.parts[5] ?? '';
-  }
-
-  public get reason(): string {
-    return this.parts[6] ?? '';
+    this.id = parts[fields.id]?.toUpperCase() ?? '';
+    this.name = parts[fields.name] ?? '';
+    this.abilityId = parts[fields.abilityId]?.toUpperCase() ?? '';
+    this.abilityName = parts[fields.abilityName] ?? '';
+    this.reason = parts[fields.reason] ?? '';
   }
 }
 

--- a/ui/raidboss/emulator/data/network_log_converter/LineEvent0x18.ts
+++ b/ui/raidboss/emulator/data/network_log_converter/LineEvent0x18.ts
@@ -2,14 +2,64 @@ import LineEvent from './LineEvent';
 import EmulatorCommon from '../../EmulatorCommon';
 import LogRepository from './LogRepository';
 
+const fields = {
+  id: 2,
+  name: 3,
+  type: 4,
+  effectId: 5,
+  damage: 6,
+  currentHp: 7,
+  maxHp: 8,
+  currentMp: 9,
+  maxMp: 10,
+  currentTp: 11,
+  maxTp: 12,
+  x: 13,
+  y: 14,
+  z: 15,
+  heading: 16,
+} as const;
+
 // DoT/HoT event
 export class LineEvent0x18 extends LineEvent {
-  public resolvedName: string;
-  public effectName?: string;
-  public properCaseConvertedLine = '';
+  public readonly properCaseConvertedLine: string;
+
+  public readonly id: string;
+  public readonly name: string;
+  public readonly type: string;
+  public readonly effectId: string;
+  public readonly damage: number;
+  public readonly currentHp: number;
+  public readonly maxHp: number;
+  public readonly currentMp: number;
+  public readonly maxMp: number;
+  public readonly currentTp: number;
+  public readonly maxTp: number;
+  public readonly x: number;
+  public readonly y: number;
+  public readonly z: number;
+  public readonly heading: number;
 
   constructor(repo: LogRepository, line: string, parts: string[]) {
     super(repo, line, parts);
+
+    this.id = parts[fields.id]?.toUpperCase() ?? '';
+    this.name = parts[fields.name] ?? '';
+
+    this.type = parts[fields.type] ?? '';
+    this.effectId = parts[fields.effectId]?.toUpperCase() ?? '';
+    this.damage = parseInt(parts[fields.damage] ?? '', 16);
+
+    this.currentHp = parseInt(parts[fields.currentHp] ?? '');
+    this.maxHp = parseInt(parts[fields.maxHp] ?? '');
+    this.currentMp = parseInt(parts[fields.currentMp] ?? '');
+    this.maxMp = parseInt(parts[fields.maxMp] ?? '');
+    this.currentTp = parseInt(parts[fields.currentTp] ?? '');
+    this.maxTp = parseInt(parts[fields.maxTp] ?? '');
+    this.x = parseFloat(parts[fields.x] ?? '');
+    this.y = parseFloat(parts[fields.y] ?? '');
+    this.z = parseFloat(parts[fields.z] ?? '');
+    this.heading = parseFloat(parts[fields.heading] ?? '');
 
     repo.updateCombatant(this.id, {
       job: undefined,
@@ -18,83 +68,22 @@ export class LineEvent0x18 extends LineEvent {
       despawn: this.timestamp,
     });
 
-    this.resolvedName = repo.resolveName(this.id, this.name);
+    let effectName = '';
+    const resolvedName = repo.resolveName(this.id, this.name);
 
     if (this.effectId in LineEvent0x18.showEffectNamesFor)
-      this.effectName = LineEvent0x18.showEffectNamesFor[this.effectId] ?? '';
-  }
+      effectName = LineEvent0x18.showEffectNamesFor[this.effectId] ?? '';
 
-  public get id(): string {
-    return this.parts[2]?.toUpperCase() ?? '';
-  }
-
-  public get name(): string {
-    return this.parts[3] ?? '';
-  }
-
-  public get type(): string {
-    return this.parts[4] ?? '';
-  }
-
-  public get effectId(): string {
-    return this.parts[5]?.toUpperCase() ?? '';
-  }
-
-  public get damage(): number {
-    return parseInt(this.parts[6] ?? '', 16);
-  }
-
-  public get currentHp(): number {
-    return parseInt(this.parts[7] ?? '');
-  }
-
-  public get maxHp(): number {
-    return parseInt(this.parts[8] ?? '');
-  }
-
-  public get currentMp(): number {
-    return parseInt(this.parts[9] ?? '');
-  }
-
-  public get maxMp(): number {
-    return parseInt(this.parts[10] ?? '');
-  }
-
-  public get currentTp(): number {
-    return parseInt(this.parts[11] ?? '');
-  }
-
-  public get maxTp(): number {
-    return parseInt(this.parts[12] ?? '');
-  }
-
-  public get x(): number {
-    return parseFloat(this.parts[13] ?? '');
-  }
-
-  public get y(): number {
-    return parseFloat(this.parts[14] ?? '');
-  }
-
-  public get z(): number {
-    return parseFloat(this.parts[15] ?? '');
-  }
-
-  public get heading(): number {
-    return parseFloat(this.parts[16] ?? '');
-  }
-
-  convert(_: LogRepository): void {
     let effectPart = '';
-    if (this.effectName)
-      effectPart = this.effectName + ' ';
+    if (effectName)
+      effectPart = effectName + ' ';
 
     this.convertedLine = this.prefix() + effectPart + this.type +
-      ' Tick on ' + this.resolvedName +
+      ' Tick on ' + resolvedName +
       ' for ' + this.damage.toString() + ' damage.';
 
     this.properCaseConvertedLine = this.prefix() + effectPart + this.type +
-      ' Tick on ' + EmulatorCommon.properCase(this.resolvedName) +
+      ' Tick on ' + EmulatorCommon.properCase(resolvedName) +
       ' for ' + this.damage.toString() + ' damage.';
   }
 

--- a/ui/raidboss/emulator/data/network_log_converter/LineEvent0x19.ts
+++ b/ui/raidboss/emulator/data/network_log_converter/LineEvent0x19.ts
@@ -2,14 +2,28 @@ import LineEvent from './LineEvent';
 import EmulatorCommon from '../../EmulatorCommon';
 import LogRepository from './LogRepository';
 
+const fields = {
+  id: 2,
+  name: 3,
+  targetId: 4,
+  targetName: 5,
+} as const;
+
 // Combatant defeated event
 export class LineEvent0x19 extends LineEvent {
-  public resolvedName?: string;
-  public resolvedTargetName?: string;
-  public properCaseConvertedLine = '';
+  public readonly properCaseConvertedLine: string;
+  public readonly id: string;
+  public readonly name: string;
+  public readonly targetId: string;
+  public readonly targetName: string;
 
   constructor(repo: LogRepository, line: string, parts: string[]) {
     super(repo, line, parts);
+
+    this.id = parts[fields.id]?.toUpperCase() ?? '';
+    this.name = parts[fields.name] ?? '';
+    this.targetId = parts[fields.targetId]?.toUpperCase() ?? '';
+    this.targetName = parts[fields.targetName] ?? '';
 
     repo.updateCombatant(this.id, {
       job: undefined,
@@ -25,32 +39,17 @@ export class LineEvent0x19 extends LineEvent {
       despawn: this.timestamp,
     });
 
+    let resolvedName: string | undefined = undefined;
+    let resolvedTargetName: string | undefined = undefined;
+
     if (this.id !== '00')
-      this.resolvedName = repo.resolveName(this.id, this.name);
+      resolvedName = repo.resolveName(this.id, this.name);
 
     if (this.targetId !== '00')
-      this.resolvedTargetName = repo.resolveName(this.targetId, this.targetName);
-  }
+      resolvedTargetName = repo.resolveName(this.targetId, this.targetName);
 
-  public get id(): string {
-    return this.parts[2]?.toUpperCase() ?? '';
-  }
-
-  public get name(): string {
-    return this.parts[3] ?? '';
-  }
-
-  public get targetId(): string {
-    return this.parts[4]?.toUpperCase() ?? '';
-  }
-
-  public get targetName(): string {
-    return this.parts[5] ?? '';
-  }
-
-  convert(_: LogRepository): void {
-    const defeatedName = (this.resolvedName ?? this.name);
-    const killerName = (this.resolvedTargetName ?? this.targetName);
+    const defeatedName = (resolvedName ?? this.name);
+    const killerName = (resolvedTargetName ?? this.targetName);
     this.convertedLine = this.prefix() + defeatedName +
       ' was defeated by ' + killerName + '.';
     this.properCaseConvertedLine = this.prefix() + EmulatorCommon.properCase(defeatedName) +

--- a/ui/raidboss/emulator/data/network_log_converter/LineEvent0x1A.ts
+++ b/ui/raidboss/emulator/data/network_log_converter/LineEvent0x1A.ts
@@ -2,15 +2,52 @@ import LineEvent from './LineEvent';
 import EmulatorCommon from '../../EmulatorCommon';
 import LogRepository from './LogRepository';
 
+const fields = {
+  abilityId: 2,
+  abilityName: 3,
+  durationString: 4,
+  id: 5,
+  name: 6,
+  targetId: 7,
+  targetName: 8,
+  stacks: 9,
+  targetHp: 10,
+  sourceHp: 11,
+} as const;
+
 // Gain status effect event
 export class LineEvent0x1A extends LineEvent {
-  public resolvedName: string;
-  public resolvedTargetName: string;
-  public fallbackResolvedTargetName: string;
-  public properCaseConvertedLine = '';
+  public readonly resolvedName: string;
+  public readonly resolvedTargetName: string;
+  public readonly fallbackResolvedTargetName: string;
+  public readonly properCaseConvertedLine: string;
+
+  public readonly abilityId: string;
+  public readonly abilityName: string;
+  public readonly durationFloat: number;
+  public readonly durationString: string;
+  public readonly id: string;
+  public readonly name: string;
+  public readonly targetId: string;
+  public readonly targetName: string;
+  public readonly stacks: number;
+  public readonly targetHp: string;
+  public readonly sourceHp: string;
 
   constructor(repo: LogRepository, line: string, parts: string[]) {
     super(repo, line, parts);
+
+    this.abilityId = parts[fields.abilityId]?.toUpperCase() ?? '';
+    this.abilityName = parts[fields.abilityName] ?? '';
+    this.durationString = parts[fields.durationString] ?? '';
+    this.durationFloat = parseFloat(this.durationString);
+    this.id = parts[fields.id]?.toUpperCase() ?? '';
+    this.name = parts[fields.name] ?? '';
+    this.targetId = parts[fields.targetId]?.toUpperCase() ?? '';
+    this.targetName = parts[fields.targetName] ?? '';
+    this.stacks = parseInt(parts[fields.stacks] ?? '0');
+    this.targetHp = parts[fields.targetHp] ?? '';
+    this.sourceHp = parts[fields.sourceHp] ?? '';
 
     repo.updateCombatant(this.id, {
       name: this.name,
@@ -31,69 +68,23 @@ export class LineEvent0x1A extends LineEvent {
 
     this.fallbackResolvedTargetName =
       repo.resolveName(this.id, this.name, this.targetId, this.targetName);
-  }
 
-  public get abilityId(): string {
-    return this.parts[2]?.toUpperCase() ?? '';
-  }
-
-  public get abilityName(): string {
-    return this.parts[3] ?? '';
-  }
-
-  public get durationFloat(): number {
-    return parseFloat(this.durationString);
-  }
-
-  public get durationString(): string {
-    return this.parts[4] ?? '';
-  }
-
-  public get id(): string {
-    return this.parts[5]?.toUpperCase() ?? '';
-  }
-
-  public get name(): string {
-    return this.parts[6] ?? '';
-  }
-
-  public get targetId(): string {
-    return this.parts[7]?.toUpperCase() ?? '';
-  }
-
-  public get targetName(): string {
-    return this.parts[8] ?? '';
-  }
-
-  public get stacks(): number {
-    return parseInt(this.parts[9] ?? '0');
-  }
-
-  public get targetHp(): string {
-    return this.parts[10] ?? '';
-  }
-
-  public get sourceHp(): string {
-    return this.parts[11] ?? '';
-  }
-
-  convert(_: LogRepository): void {
     let stackCountText = '';
     if (this.stacks > 0 && this.stacks < 20 &&
       LineEvent0x1A.showStackCountFor.includes(this.abilityId))
       stackCountText = ' (' + this.stacks.toString() + ')';
 
     this.convertedLine = this.prefix() + this.targetId +
-    ':' + this.targetName +
-    ' gains the effect of ' + this.abilityName +
-    ' from ' + this.fallbackResolvedTargetName +
-    ' for ' + this.durationString + ' Seconds.' + stackCountText;
+      ':' + this.targetName +
+      ' gains the effect of ' + this.abilityName +
+      ' from ' + this.fallbackResolvedTargetName +
+      ' for ' + this.durationString + ' Seconds.' + stackCountText;
 
-    this.convertedLine = this.prefix() + this.targetId +
-    ':' + EmulatorCommon.properCase(this.targetName) +
-    ' gains the effect of ' + this.abilityName +
-    ' from ' + EmulatorCommon.properCase(this.fallbackResolvedTargetName) +
-    ' for ' + this.durationString + ' Seconds.' + stackCountText;
+    this.properCaseConvertedLine = this.prefix() + this.targetId +
+      ':' + EmulatorCommon.properCase(this.targetName) +
+      ' gains the effect of ' + this.abilityName +
+      ' from ' + EmulatorCommon.properCase(this.fallbackResolvedTargetName) +
+      ' for ' + this.durationString + ' Seconds.' + stackCountText;
   }
 
   static showStackCountFor: readonly string[] = [

--- a/ui/raidboss/emulator/data/network_log_converter/LineEvent0x1B.ts
+++ b/ui/raidboss/emulator/data/network_log_converter/LineEvent0x1B.ts
@@ -1,22 +1,24 @@
 import LineEvent from './LineEvent';
 import LogRepository from './LogRepository';
 
+const fields = {
+  targetId: 2,
+  targetName: 3,
+  headmarkerId: 6,
+} as const;
+
 // Head marker event
 export class LineEvent0x1B extends LineEvent {
+  public readonly targetId: string;
+  public readonly targetName: string;
+  public readonly headmarkerId: string;
+
   constructor(repo: LogRepository, line: string, parts: string[]) {
     super(repo, line, parts);
-  }
 
-  public get targetId(): string {
-    return this.parts[2]?.toUpperCase() ?? '';
-  }
-
-  public get targetName(): string {
-    return this.parts[3] ?? '';
-  }
-
-  public get headmarkerId(): string {
-    return this.parts[6] ?? '';
+    this.targetId = parts[fields.targetId]?.toUpperCase() ?? '';
+    this.targetName = parts[fields.targetName] ?? '';
+    this.headmarkerId = parts[fields.headmarkerId] ?? '';
   }
 }
 

--- a/ui/raidboss/emulator/data/network_log_converter/LineEvent0x1C.ts
+++ b/ui/raidboss/emulator/data/network_log_converter/LineEvent0x1C.ts
@@ -1,38 +1,36 @@
 import LineEvent from './LineEvent';
 import LogRepository from './LogRepository';
 
+const fields = {
+  operation: 2,
+  waymark: 3,
+  id: 4,
+  name: 5,
+  x: 6,
+  y: 7,
+  z: 8,
+} as const;
+
 // Floor waymarker event
 export class LineEvent0x1C extends LineEvent {
+  public readonly operation: string;
+  public readonly waymark: string;
+  public readonly id: string;
+  public readonly name: string;
+  public readonly x: string;
+  public readonly y: string;
+  public readonly z: string;
+
   constructor(repo: LogRepository, line: string, parts: string[]) {
     super(repo, line, parts);
-  }
 
-  public get operation(): string {
-    return this.parts[2] ?? '';
-  }
-
-  public get waymark(): string {
-    return this.parts[3] ?? '';
-  }
-
-  public get id(): string {
-    return this.parts[4]?.toUpperCase() ?? '';
-  }
-
-  public get name(): string {
-    return this.parts[5] ?? '';
-  }
-
-  public get x(): string {
-    return this.parts[6] ?? '';
-  }
-
-  public get y(): string {
-    return this.parts[7] ?? '';
-  }
-
-  public get z(): string {
-    return this.parts[8] ?? '';
+    this.operation = parts[fields.operation] ?? '';
+    this.waymark = parts[fields.waymark] ?? '';
+    this.id = parts[fields.id]?.toUpperCase() ?? '';
+    this.name = parts[fields.name] ?? '';
+    this.x = parts[fields.x] ?? '';
+    this.y = parts[fields.y] ?? '';
+    this.z = parts[fields.z] ?? '';
   }
 }
 

--- a/ui/raidboss/emulator/data/network_log_converter/LineEvent0x1D.ts
+++ b/ui/raidboss/emulator/data/network_log_converter/LineEvent0x1D.ts
@@ -1,34 +1,33 @@
 import LineEvent from './LineEvent';
 import LogRepository from './LogRepository';
 
+const fields = {
+  operation: 2,
+  waymark: 3,
+  id: 4,
+  name: 5,
+  targetId: 6,
+  targetName: 7,
+} as const;
+
 // Waymarker
 export class LineEvent0x1D extends LineEvent {
+  public readonly operation: string;
+  public readonly waymark: string;
+  public readonly id: string;
+  public readonly name: string;
+  public readonly targetId: string;
+  public readonly targetName: string;
+
   constructor(repo: LogRepository, line: string, parts: string[]) {
     super(repo, line, parts);
-  }
 
-  public get operation(): string {
-    return this.parts[2] ?? '';
-  }
-
-  public get waymark(): string {
-    return this.parts[3] ?? '';
-  }
-
-  public get id(): string {
-    return this.parts[4]?.toUpperCase() ?? '';
-  }
-
-  public get name(): string {
-    return this.parts[5] ?? '';
-  }
-
-  public get targetId(): string {
-    return this.parts[6]?.toUpperCase() ?? '';
-  }
-
-  public get targetName(): string {
-    return this.parts[7] ?? '';
+    this.operation = parts[fields.operation] ?? '';
+    this.waymark = parts[fields.waymark] ?? '';
+    this.id = parts[fields.id]?.toUpperCase() ?? '';
+    this.name = parts[fields.name] ?? '';
+    this.targetId = parts[fields.targetId]?.toUpperCase() ?? '';
+    this.targetName = parts[fields.targetName] ?? '';
   }
 }
 

--- a/ui/raidboss/emulator/data/network_log_converter/LineEvent0x1E.ts
+++ b/ui/raidboss/emulator/data/network_log_converter/LineEvent0x1E.ts
@@ -6,11 +6,11 @@ import LogRepository from './LogRepository';
 // Extend the gain status event to reduce duplicate code since they're
 // the same from a data perspective
 export class LineEvent0x1E extends LineEvent0x1A {
+  public readonly properCaseConvertedLine: string;
+
   constructor(repo: LogRepository, line: string, parts: string[]) {
     super(repo, line, parts);
-  }
 
-  convert(_: LogRepository): void {
     let stackCountText = '';
     if (this.stacks > 0 && this.stacks < 20 &&
       LineEvent0x1A.showStackCountFor.includes(this.abilityId))

--- a/ui/raidboss/emulator/data/network_log_converter/LineEvent0x1F.ts
+++ b/ui/raidboss/emulator/data/network_log_converter/LineEvent0x1F.ts
@@ -2,21 +2,41 @@ import LineEvent from './LineEvent';
 import EmulatorCommon from '../../EmulatorCommon';
 import LogRepository from './LogRepository';
 
+const splitFunc = (s: string) => [
+  s.substr(6, 2),
+  s.substr(4, 2),
+  s.substr(2, 2),
+  s.substr(0, 2),
+];
+
+const fields = {
+  id: 2,
+  dataBytes1: 3,
+  dataBytes2: 4,
+  dataBytes3: 5,
+  dataBytes4: 6,
+} as const;
+
 // Job gauge event
 export class LineEvent0x1F extends LineEvent {
-  public jobGaugeBytes: string[];
-  public name = '';
-  public properCaseConvertedLine = '';
+  public readonly jobGaugeBytes: string[];
+  public readonly name: string;
+  public readonly properCaseConvertedLine: string;
+
+  public readonly id: string;
+  public readonly dataBytes1: string;
+  public readonly dataBytes2: string;
+  public readonly dataBytes3: string;
+  public readonly dataBytes4: string;
 
   constructor(repo: LogRepository, line: string, parts: string[]) {
     super(repo, line, parts);
 
-    const splitFunc = (s: string) => [
-      s.substr(6, 2),
-      s.substr(4, 2),
-      s.substr(2, 2),
-      s.substr(0, 2),
-    ];
+    this.id = parts[fields.id]?.toUpperCase() ?? '';
+    this.dataBytes1 = EmulatorCommon.zeroPad(parts[fields.dataBytes1] ?? '');
+    this.dataBytes2 = EmulatorCommon.zeroPad(parts[fields.dataBytes2] ?? '');
+    this.dataBytes3 = EmulatorCommon.zeroPad(parts[fields.dataBytes3] ?? '');
+    this.dataBytes4 = EmulatorCommon.zeroPad(parts[fields.dataBytes4] ?? '');
 
     this.jobGaugeBytes = [
       ...splitFunc(this.dataBytes1),
@@ -25,36 +45,15 @@ export class LineEvent0x1F extends LineEvent {
       ...splitFunc(this.dataBytes4),
     ];
 
+    this.name = repo.Combatants[this.id]?.name || '';
+
     repo.updateCombatant(this.id, {
-      name: undefined,
+      name: repo.Combatants[this.id]?.name,
       spawn: this.timestamp,
       despawn: this.timestamp,
       job: this.jobGaugeBytes[0]?.toUpperCase(),
     });
-  }
 
-  public get id(): string {
-    return this.parts[2]?.toUpperCase() ?? '';
-  }
-
-  public get dataBytes1(): string {
-    return EmulatorCommon.zeroPad(this.parts[3] ?? '');
-  }
-
-  public get dataBytes2(): string {
-    return EmulatorCommon.zeroPad(this.parts[4] ?? '');
-  }
-
-  public get dataBytes3(): string {
-    return EmulatorCommon.zeroPad(this.parts[5] ?? '');
-  }
-
-  public get dataBytes4(): string {
-    return EmulatorCommon.zeroPad(this.parts[6] ?? '');
-  }
-
-  convert(repo: LogRepository): void {
-    this.name = repo.Combatants[this.id]?.name || '';
     this.convertedLine = this.prefix() +
       this.id + ':' + this.name +
       ':' + this.dataBytes1 +

--- a/ui/raidboss/emulator/data/network_log_converter/LineEvent0x22.ts
+++ b/ui/raidboss/emulator/data/network_log_converter/LineEvent0x22.ts
@@ -1,30 +1,30 @@
 import LineEvent from './LineEvent';
 import LogRepository from './LogRepository';
 
+const fields = {
+  id: 2,
+  name: 3,
+  targetId: 4,
+  targetName: 5,
+  targetable: 6,
+} as const;
+
 // Nameplate toggle
 export class LineEvent0x22 extends LineEvent {
+  public readonly id: string;
+  public readonly name: string;
+  public readonly targetId: string;
+  public readonly targetName: string;
+  public readonly targetable: boolean;
+
   constructor(repo: LogRepository, line: string, parts: string[]) {
     super(repo, line, parts);
-  }
 
-  public get id(): string {
-    return this.parts[2]?.toUpperCase() ?? '';
-  }
-
-  public get name(): string {
-    return this.parts[3] ?? '';
-  }
-
-  public get targetId(): string {
-    return this.parts[4]?.toUpperCase() ?? '';
-  }
-
-  public get targetName(): string {
-    return this.parts[5] ?? '';
-  }
-
-  public get targetable(): boolean {
-    return !!parseInt(this.parts[6] ?? '', 16);
+    this.id = parts[fields.id]?.toUpperCase() ?? '';
+    this.name = parts[fields.name] ?? '';
+    this.targetId = parts[fields.targetId]?.toUpperCase() ?? '';
+    this.targetName = parts[fields.targetName] ?? '';
+    this.targetable = !!parseInt(parts[fields.targetable] ?? '', 16);
   }
 }
 

--- a/ui/raidboss/emulator/data/network_log_converter/LineEvent0x23.ts
+++ b/ui/raidboss/emulator/data/network_log_converter/LineEvent0x23.ts
@@ -1,30 +1,30 @@
 import LineEvent from './LineEvent';
 import LogRepository from './LogRepository';
 
+const fields = {
+  id: 2,
+  name: 3,
+  targetId: 4,
+  targetName: 5,
+  tetherId: 8,
+} as const;
+
 // Tether event
 export class LineEvent0x23 extends LineEvent {
+  public readonly id: string;
+  public readonly name: string;
+  public readonly targetId: string;
+  public readonly targetName: string;
+  public readonly tetherId: string;
+
   constructor(repo: LogRepository, line: string, parts: string[]) {
     super(repo, line, parts);
-  }
 
-  public get id(): string {
-    return this.parts[2]?.toUpperCase() ?? '';
-  }
-
-  public get name(): string {
-    return this.parts[3] ?? '';
-  }
-
-  public get targetId(): string {
-    return this.parts[4]?.toUpperCase() ?? '';
-  }
-
-  public get targetName(): string {
-    return this.parts[5] ?? '';
-  }
-
-  public get tetherId(): string {
-    return this.parts[8] ?? '';
+    this.id = parts[fields.id]?.toUpperCase() ?? '';
+    this.name = parts[fields.name] ?? '';
+    this.targetId = parts[fields.targetId]?.toUpperCase() ?? '';
+    this.targetName = parts[fields.targetName] ?? '';
+    this.tetherId = parts[fields.tetherId] ?? '';
   }
 }
 

--- a/ui/raidboss/emulator/data/network_log_converter/LineEvent0x24.ts
+++ b/ui/raidboss/emulator/data/network_log_converter/LineEvent0x24.ts
@@ -1,25 +1,24 @@
 import LineEvent from './LineEvent';
 import LogRepository from './LogRepository';
 
+const fields = {
+  valueHex: 2,
+  bars: 3,
+} as const;
+
 // Limit gauge event
 export class LineEvent0x24 extends LineEvent {
+  public readonly valueHex: string;
+  public readonly valueDec: number;
+  public readonly bars: string;
+
   constructor(repo: LogRepository, line: string, parts: string[]) {
     super(repo, line, parts);
-  }
 
-  public get valueHex(): string {
-    return this.parts[2] ?? '';
-  }
+    this.valueHex = parts[fields.valueHex] ?? '';
+    this.valueDec = parseInt(this.valueHex, 16);
+    this.bars = parts[fields.bars] ?? '';
 
-  public get valueDec(): number {
-    return parseInt(this.valueHex, 16);
-  }
-
-  public get bars(): string {
-    return this.parts[3] ?? '';
-  }
-
-  convert(_: LogRepository): void {
     this.convertedLine = this.prefix() + 'Limit Break: ' + this.valueHex;
   }
 }

--- a/ui/raidboss/emulator/data/network_log_converter/LineEvent0x25.ts
+++ b/ui/raidboss/emulator/data/network_log_converter/LineEvent0x25.ts
@@ -1,62 +1,54 @@
 import LineEvent from './LineEvent';
 import LogRepository from './LogRepository';
 
+const fields = {
+  id: 2,
+  name: 3,
+  sequenceId: 4,
+  currentHp: 5,
+  maxHp: 6,
+  currentMp: 7,
+  maxMp: 8,
+  currentTp: 9,
+  maxTp: 10,
+  x: 11,
+  y: 12,
+  z: 13,
+  heading: 14,
+} as const;
+
 // Action sync event
 export class LineEvent0x25 extends LineEvent {
+  public readonly id: string;
+  public readonly name: string;
+  public readonly sequenceId: string;
+  public readonly currentHp: string;
+  public readonly maxHp: string;
+  public readonly currentMp: string;
+  public readonly maxMp: string;
+  public readonly currentTp: string;
+  public readonly maxTp: string;
+  public readonly x: string;
+  public readonly y: string;
+  public readonly z: string;
+  public readonly heading: string;
+
   constructor(repo: LogRepository, line: string, parts: string[]) {
     super(repo, line, parts);
-  }
 
-  public get id(): string {
-    return this.parts[2]?.toUpperCase() ?? '';
-  }
-
-  public get name(): string {
-    return this.parts[3] ?? '';
-  }
-
-  public get sequenceId(): string {
-    return this.parts[4] ?? '';
-  }
-
-  public get currentHp(): string {
-    return this.parts[5] ?? '';
-  }
-
-  public get maxHp(): string {
-    return this.parts[6] ?? '';
-  }
-
-  public get currentMp(): string {
-    return this.parts[7] ?? '';
-  }
-
-  public get maxMp(): string {
-    return this.parts[8] ?? '';
-  }
-
-  public get currentTp(): string {
-    return this.parts[9] ?? '';
-  }
-
-  public get maxTp(): string {
-    return this.parts[10] ?? '';
-  }
-
-  public get x(): string {
-    return this.parts[11] ?? '';
-  }
-
-  public get y(): string {
-    return this.parts[12] ?? '';
-  }
-
-  public get z(): string {
-    return this.parts[13] ?? '';
-  }
-
-  public get heading(): string {
-    return this.parts[14] ?? '';
+    this.id = parts[fields.id]?.toUpperCase() ?? '';
+    this.name = parts[fields.name] ?? '';
+    this.sequenceId = parts[fields.sequenceId] ?? '';
+    this.currentHp = parts[fields.currentHp] ?? '';
+    this.maxHp = parts[fields.maxHp] ?? '';
+    this.currentMp = parts[fields.currentMp] ?? '';
+    this.maxMp = parts[fields.maxMp] ?? '';
+    this.currentTp = parts[fields.currentTp] ?? '';
+    this.maxTp = parts[fields.maxTp] ?? '';
+    this.x = parts[fields.x] ?? '';
+    this.y = parts[fields.y] ?? '';
+    this.z = parts[fields.z] ?? '';
+    this.heading = parts[fields.heading] ?? '';
   }
 }
 

--- a/ui/raidboss/emulator/data/network_log_converter/LineEvent0x26.ts
+++ b/ui/raidboss/emulator/data/network_log_converter/LineEvent0x26.ts
@@ -3,15 +3,60 @@ import EmulatorCommon from '../../EmulatorCommon';
 import Util from '../../../../../resources/util';
 import LogRepository from './LogRepository';
 
+const fields = {
+  id: 2,
+  name: 3,
+  jobLevelData: 4,
+  currentHp: 5,
+  maxHp: 6,
+  currentMp: 7,
+  maxMp: 8,
+  currentTp: 9,
+  maxTp: 10,
+  x: 11,
+  y: 12,
+  z: 13,
+  heading: 14,
+} as const;
+
 // Network status effect event
 export class LineEvent0x26 extends LineEvent {
-  public jobIdHex: string;
-  public jobIdDec: number;
-  public jobName: string;
-  public level: number;
+  public readonly jobIdHex: string;
+  public readonly jobIdDec: number;
+  public readonly jobName: string;
+  public readonly level: number;
+  public readonly id: string;
+  public readonly name: string;
+  public readonly jobLevelData: string;
+  public readonly currentHp: string;
+  public readonly maxHp: string;
+  public readonly currentMp: string;
+  public readonly maxMp: string;
+  public readonly currentTp: string;
+  public readonly maxTp: string;
+  public readonly x: string;
+  public readonly y: string;
+  public readonly z: string;
+  public readonly heading: string;
 
   constructor(repo: LogRepository, line: string, parts: string[]) {
     super(repo, line, parts);
+
+    this.id = parts[fields.id]?.toUpperCase() ?? '';
+    this.name = parts[fields.name] ?? '';
+
+    this.jobLevelData = parts[fields.jobLevelData] ?? '';
+
+    this.currentHp = parts[fields.currentHp] ?? '';
+    this.maxHp = parts[fields.maxHp] ?? '';
+    this.currentMp = parts[fields.currentMp] ?? '';
+    this.maxMp = parts[fields.maxMp] ?? '';
+    this.currentTp = parts[fields.currentTp] ?? '';
+    this.maxTp = parts[fields.maxTp] ?? '';
+    this.x = parts[fields.x] ?? '';
+    this.y = parts[fields.y] ?? '';
+    this.z = parts[fields.z] ?? '';
+    this.heading = parts[fields.heading] ?? '';
 
     const padded = EmulatorCommon.zeroPad(this.jobLevelData, 8);
 
@@ -20,58 +65,6 @@ export class LineEvent0x26 extends LineEvent {
     this.jobName = Util.jobEnumToJob(this.jobIdDec);
 
     this.level = parseInt(padded.substr(4, 2), 16);
-  }
-
-  public get id(): string {
-    return this.parts[2]?.toUpperCase() ?? '';
-  }
-
-  public get name(): string {
-    return this.parts[3] ?? '';
-  }
-
-  public get jobLevelData(): string {
-    return this.parts[4] ?? '';
-  }
-
-  public get currentHp(): string {
-    return this.parts[5] ?? '';
-  }
-
-  public get maxHp(): string {
-    return this.parts[6] ?? '';
-  }
-
-  public get currentMp(): string {
-    return this.parts[7] ?? '';
-  }
-
-  public get maxMp(): string {
-    return this.parts[8] ?? '';
-  }
-
-  public get currentTp(): string {
-    return this.parts[9] ?? '';
-  }
-
-  public get maxTp(): string {
-    return this.parts[10] ?? '';
-  }
-
-  public get x(): string {
-    return this.parts[11] ?? '';
-  }
-
-  public get y(): string {
-    return this.parts[12] ?? '';
-  }
-
-  public get z(): string {
-    return this.parts[13] ?? '';
-  }
-
-  public get heading(): string {
-    return this.parts[14] ?? '';
   }
 }
 

--- a/ui/raidboss/emulator/data/network_log_converter/LineEvent0x27.ts
+++ b/ui/raidboss/emulator/data/network_log_converter/LineEvent0x27.ts
@@ -1,58 +1,51 @@
 import LineEvent from './LineEvent';
 import LogRepository from './LogRepository';
 
+const fields = {
+  id: 2,
+  name: 3,
+  currentHp: 4,
+  maxHp: 5,
+  currentMp: 6,
+  maxMp: 7,
+  currentTp: 8,
+  maxTp: 9,
+  x: 10,
+  y: 11,
+  z: 12,
+  heading: 13,
+} as const;
+
 // Network update hp event
 export class LineEvent0x27 extends LineEvent {
+  public readonly id: string;
+  public readonly name: string;
+  public readonly currentHp: number;
+  public readonly maxHp: number;
+  public readonly currentMp: number;
+  public readonly maxMp: number;
+  public readonly currentTp: number;
+  public readonly maxTp: number;
+  public readonly x: number;
+  public readonly y: number;
+  public readonly z: number;
+  public readonly heading: number;
+
   constructor(repo: LogRepository, line: string, parts: string[]) {
     super(repo, line, parts);
-  }
 
-  public get id(): string {
-    return this.parts[2]?.toUpperCase() ?? '';
-  }
-
-  public get name(): string {
-    return this.parts[3] ?? '';
-  }
-
-  public get currentHp(): number {
-    return parseInt(this.parts[4] ?? '');
-  }
-
-  public get maxHp(): number {
-    return parseInt(this.parts[5] ?? '');
-  }
-
-  public get currentMp(): number {
-    return parseInt(this.parts[6] ?? '');
-  }
-
-  public get maxMp(): number {
-    return parseInt(this.parts[7] ?? '');
-  }
-
-  public get currentTp(): number {
-    return parseInt(this.parts[8] ?? '');
-  }
-
-  public get maxTp(): number {
-    return parseInt(this.parts[9] ?? '');
-  }
-
-  public get x(): number {
-    return parseFloat(this.parts[10] ?? '');
-  }
-
-  public get y(): number {
-    return parseFloat(this.parts[11] ?? '');
-  }
-
-  public get z(): number {
-    return parseFloat(this.parts[12] ?? '');
-  }
-
-  public get heading(): number {
-    return parseFloat(this.parts[13] ?? '');
+    this.id = parts[fields.id]?.toUpperCase() ?? '';
+    this.name = parts[fields.name] ?? '';
+    this.currentHp = parseInt(parts[fields.currentHp] ?? '');
+    this.maxHp = parseInt(parts[fields.maxHp] ?? '');
+    this.currentMp = parseInt(parts[fields.currentMp] ?? '');
+    this.maxMp = parseInt(parts[fields.maxMp] ?? '');
+    this.currentTp = parseInt(parts[fields.currentTp] ?? '');
+    this.maxTp = parseInt(parts[fields.maxTp] ?? '');
+    this.x = parseFloat(parts[fields.x] ?? '');
+    this.y = parseFloat(parts[fields.y] ?? '');
+    this.z = parseFloat(parts[fields.z] ?? '');
+    this.heading = parseFloat(parts[fields.heading] ?? '');
   }
 }
 


### PR DESCRIPTION
After the conversion of LineEvent to use getters, that data was no longer capable of passing the postMessage boundary from the worker to the main window thread. This fixes the issue by iterating the getters on the lines and populating them on the passed generic object.

Note that, even if we were to get rid of the Worker threading, this would still be required as IndexedDB only stores plain objects.

This may make more sense to put directly in the `EmulatorCommon.cloneData` function as base functionality but the performance impact on that is noticeable.