### PR TITLE
ci: Use Consistent Action Dependencies

### DIFF
--- a/.github/workflows/update-gh-pages.yml
+++ b/.github/workflows/update-gh-pages.yml
@@ -27,7 +27,10 @@ jobs:
     needs: check-gh-pages
     if: needs.check-gh-pages.outputs.found == 'true'
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v1
+      - uses: actions/setup-node@v2
+        with:
+          node-version: '14'
       - name: Build
         run: |
           npm install

--- a/.github/workflows/update-triggers-branch.yml
+++ b/.github/workflows/update-triggers-branch.yml
@@ -26,7 +26,10 @@ jobs:
     needs: check-triggers
     if: needs.check-triggers.outputs.found == 'true'
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v1
+      - uses: actions/setup-node@v2
+        with:
+          node-version: '14'
       - name: Build
         run: |
           npm install


### PR DESCRIPTION
Use consistent action dependencies across workflows using the checkout
action as well as setup-node in an attempt to fix the most recent build
error: https://github.com/quisquous/cactbot/runs/2661413115