### PR TITLE
resources: add Matches type aliases

### DIFF
--- a/resources/matches.ts
+++ b/resources/matches.ts
@@ -1,0 +1,46 @@
+import {
+  StartsUsingParams,
+  AbilityParams,
+  AbilityFullParams,
+  HeadMarkerParams,
+  AddedCombatantParams,
+  AddedCombatantFullParams,
+  RemovingCombatantParams,
+  GainsEffectParams,
+  StatusEffectExplicitParams,
+  LosesEffectParams,
+  TetherParams,
+  WasDefeatedParams,
+  EchoParams,
+  DialogParams,
+  MessageParams,
+  GameLogParams,
+  GameNameLogParams,
+  StatChangeParams,
+  ChangeZoneParams,
+  Network6dParams,
+  NameToggleParams,
+} from './netregexes';
+import { Matches } from '../types/trigger';
+
+export type MatchesStartsUsing = Matches<StartsUsingParams>;
+export type MatchesAbility = Matches<AbilityParams>;
+export type MatchesAbilityFull = Matches<AbilityFullParams>;
+export type MatchesHeadMarker = Matches<HeadMarkerParams>;
+export type MatchesAddedCombatant = Matches<AddedCombatantParams>;
+export type MatchesAddedCombatantFull = Matches<AddedCombatantFullParams>;
+export type MatchesRemovingCombatant = Matches<RemovingCombatantParams>;
+export type MatchesGainsEffect = Matches<GainsEffectParams>;
+export type MatchesStatusEffectExplicit = Matches<StatusEffectExplicitParams>;
+export type MatchesLosesEffect = Matches<LosesEffectParams>;
+export type MatchesTether = Matches<TetherParams>;
+export type MatchesWasDefeated = Matches<WasDefeatedParams>;
+export type MatchesEcho = Matches<EchoParams>;
+export type MatchesDialog = Matches<DialogParams>;
+export type MatchesMessage = Matches<MessageParams>;
+export type MatchesGameLog = Matches<GameLogParams>;
+export type MatchesGameNameLog = Matches<GameNameLogParams>;
+export type MatchesStatChange = Matches<StatChangeParams>;
+export type MatchesChangeZone = Matches<ChangeZoneParams>;
+export type MatchesNetwork6d = Matches<Network6dParams>;
+export type MatchesNameToggle = Matches<NameToggleParams>;

--- a/resources/netregexes.ts
+++ b/resources/netregexes.ts
@@ -1,10 +1,12 @@
-import { NetRegex } from 'types/trigger';
+import { BaseRegExp } from '../types/trigger';
 import Regexes, { Params } from './regexes';
 
 interface Fields {
   field: string;
   value?: string;
 }
+
+export type NetRegex<T extends string> = BaseRegExp<Exclude<T, 'capture'>>;
 
 // Differences from Regexes:
 // * may have more fields

--- a/types/trigger.d.ts
+++ b/types/trigger.d.ts
@@ -6,18 +6,12 @@ export interface BaseRegExp<T> extends RegExp {
   };
 }
 
-export type NetRegex<T extends string> = BaseRegExp<Exclude<T, 'capture'>>;
-
-export type Matches<T> =
-  T extends BaseRegExp ? T['groups'] :
-  T extends NetRegex ? T['groups'] :
-  T extends RegExp ? { [s: string]: string } :
-  never;
+export type Matches<Params> = { [s in Params]?: string } | undefined;
 
 // TargetedMatches can be used for generic functions in responses or conditions
 // that use matches from any number of Regex or NetRegex functions.
 export type TargetedParams = 'sourceId' | 'source' | 'targetId' | 'target';
-export type TargetedMatches = Matches<BaseRegExp<TargetedParams>>;
+export type TargetedMatches = Matches<TargetedParams>;
 
 export type FullLocaleText = Record<Lang, string>;
 

--- a/ui/jobs/buff_tracker.ts
+++ b/ui/jobs/buff_tracker.ts
@@ -1,9 +1,8 @@
-import { BaseRegExp, Matches } from '../../types/trigger';
 import { JobsOptions } from './types';
 
 import WidgetList from '../../resources/widget_list';
 import EffectId from '../../resources/effect_id';
-import { AbilityParams, GainsEffectParams, LosesEffectParams } from '../../resources/netregexes';
+import { MatchesAbility, MatchesGainsEffect, MatchesLosesEffect } from '../../resources/matches';
 
 import { kAbility } from './constants';
 import { makeAuraTimerIcon } from './utils';
@@ -564,7 +563,7 @@ export class BuffTracker {
     // }
   }
 
-  onUseAbility(id: string, matches: Matches<BaseRegExp<AbilityParams>>): void {
+  onUseAbility(id: string, matches: MatchesAbility): void {
     const buffs = this.gainAbilityMap[id];
     if (!buffs)
       return;
@@ -575,7 +574,7 @@ export class BuffTracker {
 
   onGainEffect(
       buffs: BuffInfo[] | undefined,
-      matches: Matches<BaseRegExp<GainsEffectParams>>,
+      matches: MatchesGainsEffect,
   ): void {
     if (!buffs)
       return;
@@ -592,7 +591,7 @@ export class BuffTracker {
 
   onLoseEffect(
       buffs: BuffInfo[] | undefined,
-      _matches: Matches<BaseRegExp<LosesEffectParams>>,
+      _matches: MatchesLosesEffect,
   ): void {
     if (!buffs)
       return;
@@ -600,19 +599,19 @@ export class BuffTracker {
       this.onLoseBigBuff(b.name);
   }
 
-  onYouGainEffect(name: string, matches: Matches<BaseRegExp<GainsEffectParams>>): void {
+  onYouGainEffect(name: string, matches: MatchesGainsEffect): void {
     this.onGainEffect(this.gainEffectMap[name], matches);
   }
 
-  onYouLoseEffect(name: string, matches: Matches<BaseRegExp<LosesEffectParams>>): void {
+  onYouLoseEffect(name: string, matches: MatchesLosesEffect): void {
     this.onLoseEffect(this.loseEffectMap[name], matches);
   }
 
-  onMobGainsEffect(name: string, matches: Matches<BaseRegExp<GainsEffectParams>>): void {
+  onMobGainsEffect(name: string, matches: MatchesGainsEffect): void {
     this.onGainEffect(this.mobGainsEffectMap[name], matches);
   }
 
-  onMobLosesEffect(name: string, matches: Matches<BaseRegExp<LosesEffectParams>>): void {
+  onMobLosesEffect(name: string, matches: MatchesLosesEffect): void {
     this.onLoseEffect(this.mobLosesEffectMap[name], matches);
   }
 

--- a/ui/radar/radar.ts
+++ b/ui/radar/radar.ts
@@ -1,11 +1,11 @@
 import { BaseOptions } from '../../types/data';
 import { EventMap } from '../../types/event';
 import { Lang } from '../../types/global';
-import { Matches, NetRegex } from '../../types/trigger';
 
 import { callOverlayHandler, addOverlayListener } from '../../resources/overlay_plugin_api';
 import HuntData, { HuntEntry, HuntMap, Rank } from '../../resources/hunt';
-import NetRegexes, { AddedCombatantFullParams } from '../../resources/netregexes';
+import { MatchesAddedCombatantFull } from '../../resources/matches';
+import NetRegexes from '../../resources/netregexes';
 import { UnreachableCode } from '../../resources/not_reached';
 import UserConfig from '../../resources/user_config';
 
@@ -205,7 +205,7 @@ class Radar {
   }
 
   AddMonster(log: string, hunt: HuntEntry,
-      matches: Matches<NetRegex<AddedCombatantFullParams>>) {
+      matches: MatchesAddedCombatantFull) {
     if (!this.playerPos)
       return;
     if (!matches)


### PR DESCRIPTION
This changes Matches from being `Matches<RegexType<Params>>` to just
`Matches<Params>` for simplicity, as there's no concrete differences
between these types.

It also seems useful to have an indirection between our Match types
and the actual templated type so that we don't have to change
a million trigger files if we ever change how they are implemented.