### PR TITLE
ci: experimental fix for update-gh-pages

### DIFF
--- a/.github/workflows/update-gh-pages.yml
+++ b/.github/workflows/update-gh-pages.yml
@@ -27,7 +27,7 @@ jobs:
     needs: check-gh-pages
     if: needs.check-gh-pages.outputs.found == 'true'
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
         with:
           node-version: '14'


### PR DESCRIPTION
After #2924, update-gh-pages stopped working.
Switching back to checkout@v2 as an experiment.