### PR TITLE
raidemulator: Clean up some issues with typescript conversion

### DIFF
--- a/ui/raidboss/emulator/data/Encounter.js
+++ b/ui/raidboss/emulator/data/Encounter.js
@@ -32,8 +32,9 @@ export default class Encounter {
       if (res) {
         this.firstLineIndex = i;
         this.startStatus.add(res.groups.StartType);
-        if (parseInt(res.groups.StartIn) >= 0)
-          this.engageAt = Math.min(line.timestamp + parseInt(res.groups.StartIn), this.engageAt);
+        const startIn = parseInt(res.groups.StartIn);
+        if (startIn >= 0)
+          this.engageAt = Math.min(line.timestamp + startIn, this.engageAt);
       } else {
         res = EmulatorCommon.matchEnd(line.networkLine);
         if (res) {

--- a/ui/raidboss/emulator/data/Encounter.js
+++ b/ui/raidboss/emulator/data/Encounter.js
@@ -32,8 +32,8 @@ export default class Encounter {
       if (res) {
         this.firstLineIndex = i;
         this.startStatus.add(res.groups.StartType);
-        if (res.groups.StartIn >= 0)
-          this.engageAt = Math.min(line.timestamp + res.groups.StartIn, this.engageAt);
+        if (parseInt(res.groups.StartIn) >= 0)
+          this.engageAt = Math.min(line.timestamp + parseInt(res.groups.StartIn), this.engageAt);
       } else {
         res = EmulatorCommon.matchEnd(line.networkLine);
         if (res) {

--- a/ui/raidboss/emulator/data/LogEventHandler.ts
+++ b/ui/raidboss/emulator/data/LogEventHandler.ts
@@ -6,7 +6,7 @@ import { LineEvent0x01 } from './network_log_converter/LineEvent0x01';
 export default class LogEventHandler extends EventBus {
   public currentFight: LineEvent[] = [];
   public currentZoneName = 'Unknown';
-  public currentZoneId = -1;
+  public currentZoneId = '-1';
 
   parseLogs(logs: LineEvent[]): void {
     for (const lineObj of logs) {
@@ -18,7 +18,7 @@ export default class LogEventHandler extends EventBus {
       if (res) {
         this.endFight();
       } else if (lineObj instanceof LineEvent0x01) {
-        this.currentZoneId = parseInt(lineObj.zoneId);
+        this.currentZoneId = lineObj.zoneId;
         this.currentZoneName = lineObj.zoneName;
         this.endFight();
       }


### PR DESCRIPTION
Found two outstanding issues with typescript conversion for raidemulator while testing the parsing plugin update yesterday.

I'll probably revisit the `zoneId` issue once the rest of raidemulator is converted, since it makes more sense to do the `parseInt` conversion when loading and parsing the log data, rather than later when persisting the encounter to DB.