### PR TITLE
raidemulator: Make websocket connection optional

### DIFF
--- a/resources/languages.ts
+++ b/resources/languages.ts
@@ -4,6 +4,57 @@ export type Lang = typeof languages[number];
 
 export type NonEnLang = Exclude<Lang, 'en'>;
 
+export const LangMap: { [lang in Lang]: { [lang in Lang]: string } } = {
+  en: {
+    en: 'English',
+    de: 'German',
+    fr: 'French',
+    ja: 'Japanese',
+    cn: 'Chinese',
+    ko: 'Korean',
+  },
+  de: {
+    en: 'Englisch',
+    de: 'Deutsch',
+    fr: 'Französisch',
+    ja: 'Japanisch',
+    cn: 'Chinesisch',
+    ko: 'Koreanisch',
+  },
+  fr: {
+    en: 'Anglais',
+    de: 'Allemand',
+    fr: 'Français',
+    ja: 'Japonais',
+    cn: 'Chinois',
+    ko: 'Coréen',
+  },
+  ja: {
+    en: '英語',
+    de: 'ドイツ語',
+    fr: 'フランス語',
+    ja: '日本語',
+    cn: '中国語',
+    ko: '韓国語',
+  },
+  cn: {
+    en: '英语',
+    de: '德语',
+    fr: '法语',
+    ja: '日语',
+    cn: '中文',
+    ko: '韩语',
+  },
+  ko: {
+    en: '영어',
+    de: '독일어',
+    fr: '프랑스어',
+    ja: '일본어',
+    cn: '중국어',
+    ko: '한국어',
+  },
+} as const;
+
 export const isLang = (lang?: string): lang is Lang => {
   const langStrs: readonly string[] = languages;
   if (!lang)

--- a/resources/languages.ts
+++ b/resources/languages.ts
@@ -4,7 +4,7 @@ export type Lang = typeof languages[number];
 
 export type NonEnLang = Exclude<Lang, 'en'>;
 
-export const LangMap: { [lang in Lang]: { [lang in Lang]: string } } = {
+export const langMap: { [lang in Lang]: { [lang in Lang]: string } } = {
   en: {
     en: 'English',
     de: 'German',

--- a/ui/raidboss/emulator/data/Persistor.js
+++ b/ui/raidboss/emulator/data/Persistor.js
@@ -7,60 +7,53 @@ export default class Persistor extends EventBus {
   constructor() {
     super();
     this.DB = null;
-    this.initializeDB();
   }
 
   initializeDB() {
-    if (this.DB !== null) {
-      this.dispatch('ready');
-      return;
-    }
-    const request = window.indexedDB.open('RaidEmulatorEncounters', Persistor.dbVersion);
-    request.addEventListener('success', (ev) => {
-      this.DB = ev.target.result;
-      this.dispatch('ready');
-    });
-    request.addEventListener('upgradeneeded', (ev) => {
-      const promises = [];
-      let encountersStorage;
-      let encounterSummariesStorage;
-      // We deliberately avoid using breaks for this switch/case to allow
-      // incremental upgrades to apply in sequence
-      switch (ev.oldVersion) {
-      case 0:
-        encountersStorage = ev.target.result.createObjectStore('Encounters', {
-          keyPath: 'id',
-          autoIncrement: true,
-        });
-        encounterSummariesStorage = ev.target.result.createObjectStore('EncounterSummaries', {
-          keyPath: 'id',
-          autoIncrement: true,
-        });
-        encounterSummariesStorage.createIndex('zoneName', 'zoneName');
-        encounterSummariesStorage.createIndex('start', 'start');
-        encounterSummariesStorage.createIndex('zoneName_start', ['zoneName', 'start']);
-      }
-      promises.push(new Promise((res) => {
-        encountersStorage.transaction.addEventListener('complete', (tev) => {
-          res();
-        });
-      }));
-      promises.push(new Promise((res) => {
-        encounterSummariesStorage.transaction.addEventListener('complete', (tev) => {
-          res();
-        });
-      }));
+    return new Promise((resolver) => {
+      const request = window.indexedDB.open('RaidEmulatorEncounters', Persistor.dbVersion);
+      request.addEventListener('success', (ev) => {
+        this.DB = ev.target.result;
+        resolver();
+      });
+      request.addEventListener('upgradeneeded', (ev) => {
+        const promises = [];
+        let encountersStorage;
+        let encounterSummariesStorage;
+        // We deliberately avoid using breaks for this switch/case to allow
+        // incremental upgrades to apply in sequence
+        switch (ev.oldVersion) {
+        case 0:
+          encountersStorage = ev.target.result.createObjectStore('Encounters', {
+            keyPath: 'id',
+            autoIncrement: true,
+          });
+          encounterSummariesStorage = ev.target.result.createObjectStore('EncounterSummaries', {
+            keyPath: 'id',
+            autoIncrement: true,
+          });
+          encounterSummariesStorage.createIndex('zoneName', 'zoneName');
+          encounterSummariesStorage.createIndex('start', 'start');
+          encounterSummariesStorage.createIndex('zoneName_start', ['zoneName', 'start']);
+        }
+        promises.push(new Promise((res) => {
+          encountersStorage.transaction.addEventListener('complete', (tev) => {
+            res();
+          });
+        }));
+        promises.push(new Promise((res) => {
+          encounterSummariesStorage.transaction.addEventListener('complete', (tev) => {
+            res();
+          });
+        }));
 
-      let completed = 0;
-      for (const i in promises) {
-        promises[i].then(() => {
-          ++completed;
-          if (completed === promises.length) {
+        for (const i in promises) {
+          Promise.all(promises).then(() => {
             this.DB = ev.target.result;
-            this.dispatch('ready');
-          }
-        });
-      }
+            resolver();
+          });
+        }
+      });
     });
   }
 

--- a/ui/raidboss/emulator/data/Persistor.js
+++ b/ui/raidboss/emulator/data/Persistor.js
@@ -11,6 +11,10 @@ export default class Persistor extends EventBus {
   }
 
   initializeDB() {
+    if (this.DB !== null) {
+      this.dispatch('ready');
+      return;
+    }
     const request = window.indexedDB.open('RaidEmulatorEncounters', Persistor.dbVersion);
     request.addEventListener('success', (ev) => {
       this.DB = ev.target.result;

--- a/ui/raidboss/emulator/overrides/RaidEmulatorOverlayApiHook.js
+++ b/ui/raidboss/emulator/overrides/RaidEmulatorOverlayApiHook.js
@@ -102,6 +102,7 @@ export default class RaidEmulatorOverlayApiHook {
       this.originalCall(msg).then((data) => {
         this.cachedData[key] = toCache(data);
         window.localStorage.setItem('raidEmulatorCachedCalls', JSON.stringify(this.cachedData));
+        window.localStorage.setItem('raidEmulatorCacheTime', new Date().toString());
         res(data);
       });
     });

--- a/ui/raidboss/emulator/overrides/RaidEmulatorOverlayApiHook.js
+++ b/ui/raidboss/emulator/overrides/RaidEmulatorOverlayApiHook.js
@@ -1,10 +1,31 @@
 import { callOverlayHandler, addOverlayListener, removeOverlayListener, setCallOverlayHandlerOverride } from '../../../../resources/overlay_plugin_api';
 
+const cachedCactbotCalls = ['cactbotLoadUser', 'cactbotLoadData'];
+const excludedReqProps = ['source'];
+const excludedRespProps = ['rseq'];
+
+const getKey = (msg) => {
+  const clonedMsg = JSON.parse(JSON.stringify(msg));
+  for (const prop of excludedReqProps)
+    delete clonedMsg[prop];
+  return JSON.stringify(clonedMsg);
+};
+
+const toCache = (data) => {
+  const clonedData = JSON.parse(JSON.stringify(data));
+  for (const prop of excludedRespProps)
+    delete clonedData[prop];
+  return clonedData;
+};
+
 export default class RaidEmulatorOverlayApiHook {
   constructor(emulator) {
     this.emulator = emulator;
     this.originalCall = setCallOverlayHandlerOverride(this.call.bind(this));
     this.currentLogTime = 0;
+    this.connected = false;
+
+    this.cachedData = JSON.parse(window.localStorage.getItem('raidEmulatorCachedCalls')) || {};
 
     emulator.on('tick', (currentLogTime) => {
       this.currentLogTime = currentLogTime;
@@ -20,47 +41,79 @@ export default class RaidEmulatorOverlayApiHook {
     });
   }
 
-  call(msg) {
+  async call(msg) {
     if (msg.call === 'getCombatants') {
-      const tracker = this.emulator.currentEncounter.encounter.combatantTracker;
-      const timestamp = this.currentLogTime;
-      return new Promise((res) => {
-        const combatants = [];
-        const hasIds = msg.ids !== undefined && msg.ids.length > 0;
-        const hasNames = msg.names !== undefined && msg.names.length > 0;
-
-        for (const [id, combatant] of Object.entries(tracker.combatants)) {
-          // nextSignificantState is a bit inefficient but given that this isn't run every tick
-          // we can afford to be a bit inefficient for readability's sake
-          const combatantState = {
-            ID: combatant.id,
-            Name: combatant.name,
-            Level: combatant.level,
-            Job: combatant.job,
-            ...combatant.nextSignificantState(timestamp).toPluginState(),
-          };
-          if (!hasIds && !hasNames)
-            combatants.push(combatantState);
-          else if (hasIds && msg.ids.includes(parseInt(id, 16)))
-            combatants.push(combatantState);
-          else if (hasNames && msg.names.includes(tracker.combatants[id].name))
-            combatants.push(combatantState);
-        }
-        // @TODO: Move this to track properly on the Combatant object
-        combatants.forEach((c) => {
-          const lines = this.emulator.currentEncounter.encounter.logLines
-            .filter((l) => l.decEvent === 3 && l.id === c.ID);
-          if (lines.length > 0) {
-            c.OwnerID = parseInt(lines[0].ownerId);
-            c.BNpcNameID = parseInt(lines[0].npcNameId);
-            c.BNpcID = parseInt(lines[0].npcBaseId);
-          }
-        });
-        res({
-          combatants: combatants,
-        });
-      });
+      return await this._getCombatantsOverride(msg);
+    } else if (cachedCactbotCalls.includes(msg.call)) {
+      if (!this.connected) {
+        if (this.hasCachedCactbotCall(msg))
+          return await this._cactbotCachedCall(msg);
+      } else {
+        return await this._cacheCall(msg);
+      }
     }
-    return this.originalCall(msg);
+
+    return await this.originalCall(msg);
+  }
+
+  async _getCombatantsOverride(msg) {
+    const tracker = this.emulator.currentEncounter.encounter.combatantTracker;
+    const timestamp = this.currentLogTime;
+
+    const combatants = [];
+    const hasIds = msg.ids !== undefined && msg.ids.length > 0;
+    const hasNames = msg.names !== undefined && msg.names.length > 0;
+
+    for (const [id, combatant] of Object.entries(tracker.combatants)) {
+      // nextSignificantState is a bit inefficient but given that this isn't run every tick
+      // we can afford to be a bit inefficient for readability's sake
+      const combatantState = {
+        ID: combatant.id,
+        Name: combatant.name,
+        Level: combatant.level,
+        Job: combatant.job,
+        ...combatant.nextSignificantState(timestamp).toPluginState(),
+      };
+      if (!hasIds && !hasNames)
+        combatants.push(combatantState);
+      else if (hasIds && msg.ids.includes(parseInt(id, 16)))
+        combatants.push(combatantState);
+      else if (hasNames && msg.names.includes(tracker.combatants[id].name))
+        combatants.push(combatantState);
+    }
+    // @TODO: Move this to track properly on the Combatant object
+    combatants.forEach((c) => {
+      const lines = this.emulator.currentEncounter.encounter.logLines
+        .filter((l) => l.decEvent === 3 && l.id === c.ID);
+      if (lines.length > 0) {
+        c.OwnerID = parseInt(lines[0].ownerId);
+        c.BNpcNameID = parseInt(lines[0].npcNameId);
+        c.BNpcID = parseInt(lines[0].npcBaseId);
+      }
+    });
+    return {
+      combatants: combatants,
+    };
+  }
+
+  async _cacheCall(msg) {
+    const key = getKey(msg);
+    return new Promise((res) => {
+      this.originalCall(msg).then((data) => {
+        this.cachedData[key] = toCache(data);
+        window.localStorage.setItem('raidEmulatorCachedCalls', JSON.stringify(this.cachedData));
+        res(data);
+      });
+    });
+  }
+
+  hasCachedCactbotCall(msg) {
+    const key = getKey(msg);
+    return key in this.cachedData;
+  }
+
+  async _cactbotCachedCall(msg) {
+    const key = getKey(msg);
+    return this.cachedData[key];
   }
 }

--- a/ui/raidboss/raidemulator.html
+++ b/ui/raidboss/raidemulator.html
@@ -68,9 +68,10 @@
           <div class="modal-body">
             <p>Welcome to the Raid Emulator.</p>
             <p>This tool replays encounters and shows what triggers were fired when, and allows you to view the encounter from any player's perspective.</p>
-            <p>This tool requires that ACT be running in the background with both ngld's OverlayPlugin and the Cactbot plugin loaded.</p>
+            <p>This tool optionally accepts an <strong>OVERLAY_WS</strong> parameter to connect to an ACT web socket with both ngld's OverlayPlugin and the Cactbot plugin loaded.</p>
+            <p>If connected to a web socket, this tool will load and respect user configuration files for cactbot/raidboss.</p>
             <p>No overlays need to be created.</p>
-            <p>Current WebSocket status: <span class="d-none websocketConnected text-success">Connected</span><span class="websocketDisconnected text-error">Disconnected</span>.</p>
+            <p>Current WebSocket status: <span class="d-none websocketConnected text-success">Connected</span><span class="websocketDisconnected text-warning">Disconnected</span>.</p>
             <p>To get started, you need to import an encounter via one of the following options:</p>
             <p>
               <ul>

--- a/ui/raidboss/raidemulator.html
+++ b/ui/raidboss/raidemulator.html
@@ -71,7 +71,7 @@
             <p>This tool optionally accepts an <strong>OVERLAY_WS</strong> parameter to connect to an ACT web socket with both ngld's OverlayPlugin and the Cactbot plugin loaded.</p>
             <p>If connected to a web socket, this tool will load and respect user configuration files for cactbot/raidboss.</p>
             <p>No overlays need to be created.</p>
-            <p>Current WebSocket status: <span class="d-none websocketConnected text-success">Connected</span><span class="websocketDisconnected text-warning">Disconnected</span>.</p>
+            <p>Current WebSocket status: <span class="d-none websocketConnected text-success">Connected</span><span class="d-none websocketCached text-warning">Cached</span><span class="websocketDisconnected text-warning">Disconnected</span>.</p>
             <p>To get started, you need to import an encounter via one of the following options:</p>
             <p>
               <ul>

--- a/ui/raidboss/raidemulator.html
+++ b/ui/raidboss/raidemulator.html
@@ -71,7 +71,7 @@
             <p>This tool optionally accepts an <strong>OVERLAY_WS</strong> parameter to connect to an ACT web socket with both ngld's OverlayPlugin and the Cactbot plugin loaded.</p>
             <p>If connected to a web socket, this tool will load and respect user configuration files for cactbot/raidboss.</p>
             <p>No overlays need to be created.</p>
-            <p>Current WebSocket status: <span class="d-none websocketConnected text-success">Connected</span><span class="d-none websocketCached text-warning">Cached</span><span class="websocketDisconnected text-warning">Disconnected</span>.</p>
+            <p>Current WebSocket status: <span class="d-none websocketConnected text-success">Connected</span><span class="websocketDisconnected text-warning">Disconnected</span>.</p>
             <p>To get started, you need to import an encounter via one of the following options:</p>
             <p>
               <ul>
@@ -107,20 +107,13 @@
           </div>
           <div class="modal-body">
             <p>Raid Emulator is currently disconnected from ACT.</p>
-            <div class="d-none cachedWarning">
-              <p>You are using cached data from a previous connection to ACT.</p>
-              <p>The date of the cached data is: <span class="cachedTime"></span></p>
-              <p>Any changes to settings in ACT or to user configuration files since this date will not be reflected in Raid Emulator.</p>
-            </div>
-            <div class="disconnectedWarning">
-              <p>Raid Emulator will use the default settings for raidboss. These are:</p>
-              <ul>
-                <li>Display language: English</li>
-                <li>Default alert output: Text and Sound</li>
-                <li>Alerts language: English</li>
-                <li>Timeline language: English</li>
-              </ul>
-            </div>
+            <p>Raid Emulator will use the default settings for raidboss. These are:</p>
+            <ul>
+              <li>Display language: <span class="discLangDisplay"></span></li>
+              <li>Default alert output: Text and Sound</li>
+              <li>Alerts language: <span class="discLangAlerts"></span></li>
+              <li>Timeline language: <span class="discLangTimeline"></span></li>
+            </ul>
           </div>
           <div class="modal-footer">
             <button type="button" class="btn btn-secondary pull-right" data-dismiss="modal">Close</button>
@@ -177,10 +170,7 @@
               class="connectedIndicator fa fa-plug text-success" data-toggle="tooltip"
               title="Connected to websocket"></i>
             <i
-              class="cachedIndicator fa fa-plug text-warning d-none" data-toggle="tooltip"
-              title="Using cached data"></i>
-            <i
-              class="disconnectedIndicator fa fa-plug text-danger d-none" data-toggle="tooltip"
+              class="disconnectedIndicator fa fa-ban text-danger d-none" data-toggle="tooltip"
               title="Disconnected from websocket"></i>
           </span>
         </div>

--- a/ui/raidboss/raidemulator.html
+++ b/ui/raidboss/raidemulator.html
@@ -96,6 +96,38 @@
         </div>
       </div>
     </div>
+    <div class="modal disconnectedModal text-dark" tabindex="-1" role="dialog">
+      <div class="modal-dialog" role="document">
+        <div class="modal-content">
+          <div class="modal-header">
+            <h5 class="modal-title">Currently Disconnected</h5>
+            <button type="button" class="close" aria-label="Close">
+              <span aria-hidden="true">&times;</span>
+            </button>
+          </div>
+          <div class="modal-body">
+            <p>Raid Emulator is currently disconnected from ACT.</p>
+            <div class="d-none cachedWarning">
+              <p>You are using cached data from a previous connection to ACT.</p>
+              <p>The date of the cached data is: <span class="cachedTime"></span></p>
+              <p>Any changes to settings in ACT or to user configuration files since this date will not be reflected in Raid Emulator.</p>
+            </div>
+            <div class="disconnectedWarning">
+              <p>Raid Emulator will use the default settings for raidboss. These are:</p>
+              <ul>
+                <li>Display language: English</li>
+                <li>Default alert output: Text and Sound</li>
+                <li>Alerts language: English</li>
+                <li>Timeline language: English</li>
+              </ul>
+            </div>
+          </div>
+          <div class="modal-footer">
+            <button type="button" class="btn btn-secondary pull-right" data-dismiss="modal">Close</button>
+          </div>
+        </div>
+      </div>
+    </div>
     <div class="container-fluid d-flex flex-column flex-fill h-100">
       <div class="row my-3 progressBarRow">
         <div class="col-auto">
@@ -138,6 +170,19 @@
           <div class="d-inline progress-bar-timestamp current-timestamp">00:00</div>
           <div class="d-inline progress-bar-timestamp divider-timestamp">/</div>
           <div class="d-inline progress-bar-timestamp duration-timestamp">00:00</div>
+        </div>
+        <div class="col-auto">
+          <span class="connectionIndicator">
+            <i
+              class="connectedIndicator fa fa-plug text-success" data-toggle="tooltip"
+              title="Connected to websocket"></i>
+            <i
+              class="cachedIndicator fa fa-plug text-warning d-none" data-toggle="tooltip"
+              title="Using cached data"></i>
+            <i
+              class="disconnectedIndicator fa fa-plug text-danger d-none" data-toggle="tooltip"
+              title="Disconnected from websocket"></i>
+          </span>
         </div>
       </div>
       <div class="row mainContentRow flex-fill">

--- a/ui/raidboss/raidemulator.js
+++ b/ui/raidboss/raidemulator.js
@@ -21,6 +21,7 @@ import raidbossFileData from './data/raidboss_manifest.txt';
 // eslint can't detect the custom loader for the worker
 // eslint-disable-next-line import/default
 import NetworkLogConverterWorker from './emulator/data/NetworkLogConverterWorker';
+import { callOverlayHandler } from '../../resources/overlay_plugin_api';
 
 import Options from './raidboss_options';
 
@@ -122,252 +123,268 @@ import './raidemulator.css';
     });
 
     // Wait for the DB to be ready before doing anything that might invoke the DB
-    persistor.on('ready', () => {
-      UserConfig.getUserConfigLocation('raidboss', Options, (e) => {
-        document.querySelector('.websocketConnected').classList.remove('d-none');
-        document.querySelector('.websocketDisconnected').classList.add('d-none');
+    persistor.on('ready', async () => {
+      // Give the websocket 500ms to connect, then abort.
+      const websocketConnected = await Promise.race([
+        new Promise((res) => {
+          callOverlayHandler({ call: 'cactbotRequestState' }).then(() => {
+            res(true);
+          });
+        }),
+        new Promise((res) => {
+          window.setTimeout(() => {
+            res(false);
+          }, 500);
+        }),
+      ]);
+      if (websocketConnected) {
+        await UserConfig.getUserConfigLocation('raidboss', Options, (e) => {
+          document.querySelector('.websocketConnected').classList.remove('d-none');
+          document.querySelector('.websocketDisconnected').classList.add('d-none');
+        });
+      }
 
-        // Initialize the Raidboss components, bind them to the emulator for event listeners
-        timelineUI = new RaidEmulatorTimelineUI(Options);
-        timelineUI.bindTo(emulator);
-        timelineController =
-            new RaidEmulatorTimelineController(Options, timelineUI, raidbossFileData);
-        timelineController.bindTo(emulator);
-        popupText = new RaidEmulatorPopupText(
-            Options, new TimelineLoader(timelineController), raidbossFileData);
-        popupText.bindTo(emulator);
+      // Initialize the Raidboss components, bind them to the emulator for event listeners
+      timelineUI = new RaidEmulatorTimelineUI(Options);
+      timelineUI.bindTo(emulator);
+      timelineController =
+          new RaidEmulatorTimelineController(Options, timelineUI, raidbossFileData);
+      timelineController.bindTo(emulator);
+      popupText = new RaidEmulatorPopupText(
+          Options, new TimelineLoader(timelineController), raidbossFileData);
+      popupText.bindTo(emulator);
 
-        timelineController.SetPopupTextInterface(new PopupTextGenerator(popupText));
+      timelineController.SetPopupTextInterface(new PopupTextGenerator(popupText));
 
-        emulator.setPopupText(popupText);
+      emulator.setPopupText(popupText);
 
-        // Load the encounter metadata from the DB
-        encounterTab.refresh();
+      // Load the encounter metadata from the DB
+      encounterTab.refresh();
 
-        // If we don't have any encounters stored, show the intro modal
-        persistor.listEncounters().then((encounters) => {
-          if (encounters.length === 0) {
-            showModal('.introModal');
-          } else {
-            let lastEncounter = window.localStorage.getItem('currentEncounter');
-            if (lastEncounter !== undefined) {
-              lastEncounter = parseInt(lastEncounter);
-              const matchedEncounters = encounters.filter((e) => e.id === lastEncounter);
-              if (matchedEncounters.length)
-                encounterTab.dispatch('load', lastEncounter);
-            }
+      // If we don't have any encounters stored, show the intro modal
+      persistor.listEncounters().then((encounters) => {
+        if (encounters.length === 0) {
+          showModal('.introModal');
+        } else {
+          let lastEncounter = window.localStorage.getItem('currentEncounter');
+          if (lastEncounter !== undefined) {
+            lastEncounter = parseInt(lastEncounter);
+            const matchedEncounters = encounters.filter((e) => e.id === lastEncounter);
+            if (matchedEncounters.length)
+              encounterTab.dispatch('load', lastEncounter);
           }
-        });
-
-        const checkFile = async (file) => {
-          if (file.type === 'application/json') {
-            // Import a DB file by passing it to Persistor
-            // DB files are just json representations of the DB
-            file.text().then((txt) => {
-              const DB = JSON.parse(txt);
-              persistor.importDB(DB).then(() => {
-                encounterTab.refresh();
-              });
-            });
-          } else {
-            // Assume it's a log file?
-            const importModal = showModal('.importProgressModal');
-            const bar = importModal.querySelector('.progress-bar');
-            bar.style.width = '0px';
-            const label = importModal.querySelector('.label');
-            label.innerText = '';
-            const encLabel = importModal.querySelector('.encounterLabel');
-            encLabel.innerText = 'N/A';
-
-            const doneButton = importModal.querySelector('.btn');
-            doneButton.disabled = true;
-
-            const doneButtonTimeout = doneButton.querySelector('.doneBtnTimeout');
-
-            const promises = [];
-
-            logConverterWorker.onmessage = (msg) => {
-              switch (msg.data.type) {
-              case 'progress':
-                {
-                  const percent = ((msg.data.bytes / msg.data.totalBytes) * 100).toFixed(2);
-                  bar.style.width = percent + '%';
-                  label.innerText = `${msg.data.bytes}/${msg.data.totalBytes} bytes, ${msg.data.lines} lines (${percent}%)`;
-                }
-                break;
-              case 'encounter':
-                {
-                  const enc = msg.data.encounter;
-
-                  encLabel.innerText = `
-                  Zone: ${enc.encounterZoneName}
-                  Encounter: ${msg.data.name}
-                  Start: ${new Date(enc.startTimestamp)}
-                  End: ${new Date(enc.endTimestamp)}
-                  Duration: ${EmulatorCommon.msToDuration(enc.endTimestamp - enc.startTimestamp)}
-                  Pull Duration: ${EmulatorCommon.msToDuration(enc.endTimestamp - enc.initialTimestamp)}
-                  Started By: ${enc.startStatus}
-                  End Status: ${enc.endStatus}
-                  Line Count: ${enc.logLines.length}
-                  `;
-                  // Objects sent via message are raw objects, not typed.
-                  // Need to get the name another way and override for Persistor.
-                  enc.combatantTracker.getMainCombatantName = () => msg.data.name;
-                  promises.push(persistor.persistEncounter(enc));
-                }
-                break;
-              case 'done':
-                Promise.all(promises).then(() => {
-                  encounterTab.refresh();
-                  doneButton.disabled = false;
-                  let seconds = 5;
-                  doneButtonTimeout.innerText = ` (${seconds})`;
-                  const interval = window.setInterval(() => {
-                    --seconds;
-                    doneButtonTimeout.innerText = ` (${seconds})`;
-                    if (seconds === 0) {
-                      window.clearInterval(interval);
-                      hideModal('.importProgressModal');
-                    }
-                  }, 1000);
-                });
-                break;
-              }
-            };
-            file.arrayBuffer().then((b) => {
-              logConverterWorker.postMessage(b, [b]);
-            });
-          }
-        };
-
-        const ignoreEvent = (e) => {
-          e.preventDefault();
-          e.stopPropagation();
-        };
-
-        // Handle drag+drop of files. Have to ignore dragenter/dragover for compatibility reasons.
-        document.body.addEventListener('dragenter', ignoreEvent);
-        document.body.addEventListener('dragover', ignoreEvent);
-
-        document.body.addEventListener('drop', async (e) => {
-          e.preventDefault();
-          e.stopPropagation();
-          const dt = e.dataTransfer;
-          const files = dt.files;
-          for (let i = 0; i < files.length; ++i) {
-            const file = files[i];
-            await checkFile(file);
-          }
-        });
-
-        const $exportButton = document.querySelector('.exportDBButton');
-
-        new Tooltip($exportButton, 'bottom',
-            'Export DB is very slow and shows a 0 byte download, but it does work eventually.');
-
-        // Auto initialize all collapse elements on the page
-        document.querySelectorAll('[data-toggle="collapse"]').forEach((n) => {
-          const target = document.querySelector(n.getAttribute('data-target'));
-          n.addEventListener('click', () => {
-            if (n.getAttribute('aria-expanded') === 'false') {
-              n.setAttribute('aria-expanded', 'true');
-              target.classList.add('show');
-            } else {
-              n.setAttribute('aria-expanded', 'false');
-              target.classList.remove('show');
-            }
-          });
-        });
-
-        // Handle DB export
-        $exportButton.addEventListener('click', (e) => {
-          persistor.exportDB().then((obj) => {
-            // Convert encounter DB to json, then base64 encode it
-            // Encounters can have unicode, can't use btoa for base64 encode
-            const blob = new Blob([JSON.stringify(obj)], { type: 'application/json' });
-            obj = null;
-            // Offer download to user
-            const a = document.createElement('a');
-            a.href = URL.createObjectURL(blob);
-            a.setAttribute('download', 'RaidEmulator_DBExport_' + (+new Date()) + '.json');
-            a.click();
-            // After a second (so after user accepts/declines)
-            // remove the object URL to avoid memory issues
-            window.setTimeout(() => {
-              URL.revokeObjectURL(a.href);
-            }, 1000);
-          });
-        });
-
-        const $fileInput = document.querySelector('.loadFileInput');
-
-        // Handle the `Load Network Log` button when user selects files
-        $fileInput.addEventListener('change', async (e) => {
-          for (let i = 0; i < e.target.files.length; ++i) {
-            const file = e.target.files[i];
-            checkFile(file);
-          }
-        });
-
-        // Prompt user to select files if they click the `Load Network Log` or `Import DB` buttons.
-        // These buttons really do the same thing.
-        document.querySelectorAll('.importDBButton, .loadNetworkLogButton').forEach((n) => {
-          n.addEventListener('click', (e) => {
-            $fileInput.click();
-          });
-        });
-
-        // Handle all modal close buttons
-        document.querySelectorAll('.modal button.close, [data-dismiss="modal"]').forEach((n) => {
-          n.addEventListener('click', (e) => {
-            // Find the parent modal from the close button and close it
-            let target = e.currentTarget;
-            while (!target.classList.contains('modal') && target !== document.body)
-              target = target.parentElement;
-
-            if (target !== document.body)
-              hideModal('.' + [...target.classList].join('.'));
-          });
-        });
-
-        // Handle closing all modals if the user clicks outside the modal
-        document.querySelectorAll('.modal').forEach((n) => {
-          n.addEventListener('click', (e) => {
-            // Only close the modal if the user actually clicked outside it, not child clicks
-            if (e.target === n)
-              hideModal();
-          });
-        });
-
-        // Ask the user if they're really sure they want to clear the DB
-        document.querySelector('.clearDBButton').addEventListener('click', (e) => {
-          showModal('.deleteDBModal');
-        });
-
-        // Handle user saying they're really sure they want to clear the DB by wiping it then
-        // refreshing the encounter tab
-        document.querySelector('.deleteDBModal .btn-primary').addEventListener('click', (e) => {
-          persistor.clearDB().then(() => {
-            encounterTab.refresh();
-            hideModal('.deleteDBModal');
-          });
-        });
-
-        // Make the emulator state available for debugging
-        window.raidEmulator = {
-          emulator: emulator,
-          progressBar: progressBar,
-          timelineController: timelineController,
-          popupText: popupText,
-          persistor: persistor,
-          encounterTab: encounterTab,
-          emulatedPartyInfo: emulatedPartyInfo,
-          emulatedMap: emulatedMap,
-          emulatedWebSocket: emulatedWebSocket,
-          timelineUI: timelineUI,
-        };
+        }
       });
+
+      const checkFile = async (file) => {
+        if (file.type === 'application/json') {
+          // Import a DB file by passing it to Persistor
+          // DB files are just json representations of the DB
+          file.text().then((txt) => {
+            const DB = JSON.parse(txt);
+            persistor.importDB(DB).then(() => {
+              encounterTab.refresh();
+            });
+          });
+        } else {
+          // Assume it's a log file?
+          const importModal = showModal('.importProgressModal');
+          const bar = importModal.querySelector('.progress-bar');
+          bar.style.width = '0px';
+          const label = importModal.querySelector('.label');
+          label.innerText = '';
+          const encLabel = importModal.querySelector('.encounterLabel');
+          encLabel.innerText = 'N/A';
+
+          const doneButton = importModal.querySelector('.btn');
+          doneButton.disabled = true;
+
+          const doneButtonTimeout = doneButton.querySelector('.doneBtnTimeout');
+
+          const promises = [];
+
+          logConverterWorker.onmessage = (msg) => {
+            switch (msg.data.type) {
+            case 'progress':
+              {
+                const percent = ((msg.data.bytes / msg.data.totalBytes) * 100).toFixed(2);
+                bar.style.width = percent + '%';
+                label.innerText = `${msg.data.bytes}/${msg.data.totalBytes} bytes, ${msg.data.lines} lines (${percent}%)`;
+              }
+              break;
+            case 'encounter':
+              {
+                const enc = msg.data.encounter;
+
+                encLabel.innerText = `
+                Zone: ${enc.encounterZoneName}
+                Encounter: ${msg.data.name}
+                Start: ${new Date(enc.startTimestamp)}
+                End: ${new Date(enc.endTimestamp)}
+                Duration: ${EmulatorCommon.msToDuration(enc.endTimestamp - enc.startTimestamp)}
+                Pull Duration: ${EmulatorCommon.msToDuration(enc.endTimestamp - enc.initialTimestamp)}
+                Started By: ${enc.startStatus}
+                End Status: ${enc.endStatus}
+                Line Count: ${enc.logLines.length}
+                `;
+                // Objects sent via message are raw objects, not typed.
+                // Need to get the name another way and override for Persistor.
+                enc.combatantTracker.getMainCombatantName = () => msg.data.name;
+                promises.push(persistor.persistEncounter(enc));
+              }
+              break;
+            case 'done':
+              Promise.all(promises).then(() => {
+                encounterTab.refresh();
+                doneButton.disabled = false;
+                let seconds = 5;
+                doneButtonTimeout.innerText = ` (${seconds})`;
+                const interval = window.setInterval(() => {
+                  --seconds;
+                  doneButtonTimeout.innerText = ` (${seconds})`;
+                  if (seconds === 0) {
+                    window.clearInterval(interval);
+                    hideModal('.importProgressModal');
+                  }
+                }, 1000);
+              });
+              break;
+            }
+          };
+          file.arrayBuffer().then((b) => {
+            logConverterWorker.postMessage(b, [b]);
+          });
+        }
+      };
+
+      const ignoreEvent = (e) => {
+        e.preventDefault();
+        e.stopPropagation();
+      };
+
+      // Handle drag+drop of files. Have to ignore dragenter/dragover for compatibility reasons.
+      document.body.addEventListener('dragenter', ignoreEvent);
+      document.body.addEventListener('dragover', ignoreEvent);
+
+      document.body.addEventListener('drop', async (e) => {
+        e.preventDefault();
+        e.stopPropagation();
+        const dt = e.dataTransfer;
+        const files = dt.files;
+        for (let i = 0; i < files.length; ++i) {
+          const file = files[i];
+          await checkFile(file);
+        }
+      });
+
+      const $exportButton = document.querySelector('.exportDBButton');
+
+      new Tooltip($exportButton, 'bottom',
+          'Export DB is very slow and shows a 0 byte download, but it does work eventually.');
+
+      // Auto initialize all collapse elements on the page
+      document.querySelectorAll('[data-toggle="collapse"]').forEach((n) => {
+        const target = document.querySelector(n.getAttribute('data-target'));
+        n.addEventListener('click', () => {
+          if (n.getAttribute('aria-expanded') === 'false') {
+            n.setAttribute('aria-expanded', 'true');
+            target.classList.add('show');
+          } else {
+            n.setAttribute('aria-expanded', 'false');
+            target.classList.remove('show');
+          }
+        });
+      });
+
+      // Handle DB export
+      $exportButton.addEventListener('click', (e) => {
+        persistor.exportDB().then((obj) => {
+          // Convert encounter DB to json, then base64 encode it
+          // Encounters can have unicode, can't use btoa for base64 encode
+          const blob = new Blob([JSON.stringify(obj)], { type: 'application/json' });
+          obj = null;
+          // Offer download to user
+          const a = document.createElement('a');
+          a.href = URL.createObjectURL(blob);
+          a.setAttribute('download', 'RaidEmulator_DBExport_' + (+new Date()) + '.json');
+          a.click();
+          // After a second (so after user accepts/declines)
+          // remove the object URL to avoid memory issues
+          window.setTimeout(() => {
+            URL.revokeObjectURL(a.href);
+          }, 1000);
+        });
+      });
+
+      const $fileInput = document.querySelector('.loadFileInput');
+
+      // Handle the `Load Network Log` button when user selects files
+      $fileInput.addEventListener('change', async (e) => {
+        for (let i = 0; i < e.target.files.length; ++i) {
+          const file = e.target.files[i];
+          checkFile(file);
+        }
+      });
+
+      // Prompt user to select files if they click the `Load Network Log` or `Import DB` buttons.
+      // These buttons really do the same thing.
+      document.querySelectorAll('.importDBButton, .loadNetworkLogButton').forEach((n) => {
+        n.addEventListener('click', (e) => {
+          $fileInput.click();
+        });
+      });
+
+      // Handle all modal close buttons
+      document.querySelectorAll('.modal button.close, [data-dismiss="modal"]').forEach((n) => {
+        n.addEventListener('click', (e) => {
+          // Find the parent modal from the close button and close it
+          let target = e.currentTarget;
+          while (!target.classList.contains('modal') && target !== document.body)
+            target = target.parentElement;
+
+          if (target !== document.body)
+            hideModal('.' + [...target.classList].join('.'));
+        });
+      });
+
+      // Handle closing all modals if the user clicks outside the modal
+      document.querySelectorAll('.modal').forEach((n) => {
+        n.addEventListener('click', (e) => {
+          // Only close the modal if the user actually clicked outside it, not child clicks
+          if (e.target === n)
+            hideModal();
+        });
+      });
+
+      // Ask the user if they're really sure they want to clear the DB
+      document.querySelector('.clearDBButton').addEventListener('click', (e) => {
+        showModal('.deleteDBModal');
+      });
+
+      // Handle user saying they're really sure they want to clear the DB by wiping it then
+      // refreshing the encounter tab
+      document.querySelector('.deleteDBModal .btn-primary').addEventListener('click', (e) => {
+        persistor.clearDB().then(() => {
+          encounterTab.refresh();
+          hideModal('.deleteDBModal');
+        });
+      });
+
+      // Make the emulator state available for debugging
+      window.raidEmulator = {
+        emulator: emulator,
+        progressBar: progressBar,
+        timelineController: timelineController,
+        popupText: popupText,
+        persistor: persistor,
+        encounterTab: encounterTab,
+        emulatedPartyInfo: emulatedPartyInfo,
+        emulatedMap: emulatedMap,
+        emulatedWebSocket: emulatedWebSocket,
+        timelineUI: timelineUI,
+      };
     });
+    persistor.initializeDB();
   });
 })();
 

--- a/ui/raidboss/raidemulator.js
+++ b/ui/raidboss/raidemulator.js
@@ -17,7 +17,7 @@ import RaidEmulatorTimelineUI from './emulator/overrides/RaidEmulatorTimelineUI'
 import { TimelineLoader } from './timeline';
 import Tooltip from './emulator/ui/Tooltip';
 import UserConfig from '../../resources/user_config';
-import { isLang, Lang, LangMap } from '../../resources/languages';
+import { isLang, Lang, langMap } from '../../resources/languages';
 import raidbossFileData from './data/raidboss_manifest.txt';
 // eslint can't detect the custom loader for the worker
 // eslint-disable-next-line import/default
@@ -196,7 +196,7 @@ import './raidemulator.css';
               encounterTab.dispatch('load', lastEncounter);
           }
           if (!websocketConnected) {
-            const dispLang = LangMap[Options.ParserLanguage][Options.ParserLanguage];
+            const dispLang = langMap[Options.ParserLanguage][Options.ParserLanguage];
             const discModal = showModal('.disconnectedModal');
             const indicator = document.querySelector('.connectionIndicator');
             indicator.querySelector('.connectedIndicator').classList.add('d-none');

--- a/ui/raidboss/raidemulator.js
+++ b/ui/raidboss/raidemulator.js
@@ -123,25 +123,27 @@ import './raidemulator.css';
     });
 
     // Wait for the DB to be ready before doing anything that might invoke the DB
-    persistor.on('ready', async () => {
-      // Give the websocket 500ms to connect, then abort.
-      const websocketConnected = await Promise.race([
-        new Promise((res) => {
-          callOverlayHandler({ call: 'cactbotRequestState' }).then(() => {
-            res(true);
+    persistor.initializeDB().then(async () => {
+      if (window.location.href.indexOf('OVERLAY_WS') > 0) {
+        // Give the websocket 500ms to connect, then abort.
+        const websocketConnected = await Promise.race([
+          new Promise((res) => {
+            callOverlayHandler({ call: 'cactbotRequestState' }).then(() => {
+              res(true);
+            });
+          }),
+          new Promise((res) => {
+            window.setTimeout(() => {
+              res(false);
+            }, 500);
+          }),
+        ]);
+        if (websocketConnected) {
+          await UserConfig.getUserConfigLocation('raidboss', Options, (e) => {
+            document.querySelector('.websocketConnected').classList.remove('d-none');
+            document.querySelector('.websocketDisconnected').classList.add('d-none');
           });
-        }),
-        new Promise((res) => {
-          window.setTimeout(() => {
-            res(false);
-          }, 500);
-        }),
-      ]);
-      if (websocketConnected) {
-        await UserConfig.getUserConfigLocation('raidboss', Options, (e) => {
-          document.querySelector('.websocketConnected').classList.remove('d-none');
-          document.querySelector('.websocketDisconnected').classList.add('d-none');
-        });
+        }
       }
 
       // Initialize the Raidboss components, bind them to the emulator for event listeners
@@ -384,7 +386,6 @@ import './raidemulator.css';
         timelineUI: timelineUI,
       };
     });
-    persistor.initializeDB();
   });
 })();
 


### PR DESCRIPTION
This has been possible for a while, since the switch to webpack for manifest files, I just never got around to making websocket optional.

The change to Persistor is due to an unintentional race condition with event ordering which was only apparent when there was an actual delay to websocket connection.

It might make sense additionally to check for OVERLAY_WS in the URL and skip the attempt to connect entirely?