### PR TITLE
raidemulator: Fix various issues related to using relative offsets instead of log line timestamps

### DIFF
--- a/ui/raidboss/emulator/data/RaidEmulator.js
+++ b/ui/raidboss/emulator/data/RaidEmulator.js
@@ -9,7 +9,7 @@ export default class RaidEmulator extends EventBus {
     this.currentEncounter = null;
     this.playingInterval = null;
     this.currentLogLineIndex = null;
-    this.lastLogTimestamp = null;
+    this.lastLogLineTime = null;
     this.lastTickTime = null;
   }
   addEncounter(encounter) {
@@ -82,7 +82,7 @@ export default class RaidEmulator extends EventBus {
           await this.dispatch('emitLogs', { logs: logs });
           logs = [];
         }
-        this.currentLogTime = this.lastLogTimestamp = line.timestamp;
+        this.currentLogTime = this.lastLogLineTime = line.timestamp;
         ++this.currentLogLineIndex;
         await this.dispatch('midSeek', line);
         continue;
@@ -97,7 +97,7 @@ export default class RaidEmulator extends EventBus {
     }
 
     await this.dispatch('postSeek', seekTimestamp);
-    await this.dispatch('tick', this.currentLogTime, this.lastLogTimestamp);
+    await this.dispatch('tick', this.currentLogTime, this.lastLogLineTime);
     if (playing)
       this.play();
   }
@@ -117,7 +117,7 @@ export default class RaidEmulator extends EventBus {
       ++i) {
       if (this.currentEncounter.encounter.logLines[i].timestamp <= lastTimestamp) {
         logs.push(this.currentEncounter.encounter.logLines[i]);
-        this.lastLogTimestamp = this.currentEncounter.encounter.logLines[i].timestamp;
+        this.lastLogLineTime = this.currentEncounter.encounter.logLines[i].timestamp;
         ++this.currentLogLineIndex;
         continue;
       }
@@ -128,7 +128,7 @@ export default class RaidEmulator extends EventBus {
     if (logs.length)
       await this.dispatch('emitLogs', { logs: logs });
 
-    await this.dispatch('tick', this.currentLogTime, this.lastLogTimestamp);
+    await this.dispatch('tick', this.currentLogTime, this.lastLogLineTime);
   }
 
   setPopupText(popupText) {

--- a/ui/raidboss/emulator/overrides/RaidEmulatorOverlayApiHook.js
+++ b/ui/raidboss/emulator/overrides/RaidEmulatorOverlayApiHook.js
@@ -4,18 +4,18 @@ export default class RaidEmulatorOverlayApiHook {
   constructor(emulator) {
     this.emulator = emulator;
     this.originalCall = setCallOverlayHandlerOverride(this.call.bind(this));
-    this.currentTimestamp = 0;
+    this.currentLogTime = 0;
 
-    emulator.on('tick', (currentTimestamp) => {
-      this.currentTimestamp = currentTimestamp;
+    emulator.on('tick', (currentLogTime) => {
+      this.currentLogTime = currentLogTime;
     });
-    emulator.on('preSeek', (currentTimestamp) => {
-      this.currentTimestamp = 0;
+    emulator.on('preSeek', (currentLogTime) => {
+      this.currentLogTime = 0;
     });
     emulator.on('preCurrentEncounterChanged', (encounter) => {
-      this.currentTimestamp = 0;
+      this.currentLogTime = 0;
       encounter.on('analyzeLine', (log) => {
-        this.currentTimestamp = log.offset;
+        this.currentLogTime = log.timestamp;
       });
     });
   }
@@ -23,7 +23,7 @@ export default class RaidEmulatorOverlayApiHook {
   call(msg) {
     if (msg.call === 'getCombatants') {
       const tracker = this.emulator.currentEncounter.encounter.combatantTracker;
-      const timestamp = this.currentTimestamp;
+      const timestamp = this.currentLogTime;
       return new Promise((res) => {
         const combatants = [];
         const hasIds = msg.ids !== undefined && msg.ids.length > 0;

--- a/ui/raidboss/emulator/overrides/RaidEmulatorOverlayApiHook.js
+++ b/ui/raidboss/emulator/overrides/RaidEmulatorOverlayApiHook.js
@@ -4,18 +4,18 @@ export default class RaidEmulatorOverlayApiHook {
   constructor(emulator) {
     this.emulator = emulator;
     this.originalCall = setCallOverlayHandlerOverride(this.call.bind(this));
-    this.timestampOffset = 0;
+    this.currentTimestamp = 0;
 
-    emulator.on('tick', (timestampOffset) => {
-      this.timestampOffset = timestampOffset;
+    emulator.on('tick', (currentTimestamp) => {
+      this.currentTimestamp = currentTimestamp;
     });
-    emulator.on('preSeek', (timestampOffset) => {
-      this.timestampOffset = 0;
+    emulator.on('preSeek', (currentTimestamp) => {
+      this.currentTimestamp = 0;
     });
     emulator.on('preCurrentEncounterChanged', (encounter) => {
-      this.timestampOffset = 0;
+      this.currentTimestamp = 0;
       encounter.on('analyzeLine', (log) => {
-        this.timestampOffset = log.offset;
+        this.currentTimestamp = log.offset;
       });
     });
   }
@@ -23,8 +23,7 @@ export default class RaidEmulatorOverlayApiHook {
   call(msg) {
     if (msg.call === 'getCombatants') {
       const tracker = this.emulator.currentEncounter.encounter.combatantTracker;
-      const timestamp = this.emulator.currentEncounter.encounter.startTimestamp +
-        this.timestampOffset;
+      const timestamp = this.currentTimestamp;
       return new Promise((res) => {
         const combatants = [];
         const hasIds = msg.ids !== undefined && msg.ids.length > 0;

--- a/ui/raidboss/emulator/overrides/RaidEmulatorPopupText.js
+++ b/ui/raidboss/emulator/overrides/RaidEmulatorPopupText.js
@@ -18,20 +18,20 @@ export default class RaidEmulatorPopupText extends StubbedPopupText {
     this.audioDebugTextDuration = 2000;
   }
 
-  async doUpdate(timestampOffset) {
-    this.emulatedOffset = timestampOffset;
+  async doUpdate(currentTimestamp) {
+    this.emulatedOffset = currentTimestamp;
     for (const t of this.scheduledTriggers) {
-      const remaining = t.expires - timestampOffset;
+      const remaining = t.expires - currentTimestamp;
       if (remaining <= 0) {
         t.resolver();
         await t.promise;
       }
     }
     this.scheduledTriggers = this.scheduledTriggers.filter((t) => {
-      return t.expires - timestampOffset > 0;
+      return t.expires - currentTimestamp > 0;
     });
     this.displayedText = this.displayedText.filter((t) => {
-      const remaining = t.expires - timestampOffset;
+      const remaining = t.expires - currentTimestamp;
       if (remaining > 0) {
         t.element.querySelector('.popup-text-remaining').textContent = '(' + (remaining / 1000).toFixed(1) + ')';
         return true;
@@ -74,11 +74,11 @@ export default class RaidEmulatorPopupText extends StubbedPopupText {
       this.OnLog(event.logs);
       this.OnNetLog(event.logs);
     });
-    emulator.on('tick', async (timestampOffset) => {
-      await this.doUpdate(timestampOffset);
+    emulator.on('tick', async (currentTimestamp) => {
+      await this.doUpdate(currentTimestamp);
     });
     emulator.on('midSeek', async (line) => {
-      await this.doUpdate(line.offset);
+      await this.doUpdate(line.timestamp);
     });
     emulator.on('preSeek', (time) => {
       this.seeking = true;

--- a/ui/raidboss/emulator/overrides/RaidEmulatorPopupText.js
+++ b/ui/raidboss/emulator/overrides/RaidEmulatorPopupText.js
@@ -18,20 +18,20 @@ export default class RaidEmulatorPopupText extends StubbedPopupText {
     this.audioDebugTextDuration = 2000;
   }
 
-  async doUpdate(currentTimestamp) {
-    this.emulatedOffset = currentTimestamp;
+  async doUpdate(currentLogTime) {
+    this.emulatedOffset = currentLogTime;
     for (const t of this.scheduledTriggers) {
-      const remaining = t.expires - currentTimestamp;
+      const remaining = t.expires - currentLogTime;
       if (remaining <= 0) {
         t.resolver();
         await t.promise;
       }
     }
     this.scheduledTriggers = this.scheduledTriggers.filter((t) => {
-      return t.expires - currentTimestamp > 0;
+      return t.expires - currentLogTime > 0;
     });
     this.displayedText = this.displayedText.filter((t) => {
-      const remaining = t.expires - currentTimestamp;
+      const remaining = t.expires - currentLogTime;
       if (remaining > 0) {
         t.element.querySelector('.popup-text-remaining').textContent = '(' + (remaining / 1000).toFixed(1) + ')';
         return true;
@@ -74,8 +74,8 @@ export default class RaidEmulatorPopupText extends StubbedPopupText {
       this.OnLog(event.logs);
       this.OnNetLog(event.logs);
     });
-    emulator.on('tick', async (currentTimestamp) => {
-      await this.doUpdate(currentTimestamp);
+    emulator.on('tick', async (currentLogTime) => {
+      await this.doUpdate(currentLogTime);
     });
     emulator.on('midSeek', async (line) => {
       await this.doUpdate(line.timestamp);

--- a/ui/raidboss/emulator/overrides/RaidEmulatorTimeline.js
+++ b/ui/raidboss/emulator/overrides/RaidEmulatorTimeline.js
@@ -3,16 +3,11 @@ import { Timeline } from '../../timeline';
 export default class RaidEmulatorTimeline extends Timeline {
   constructor(text, replacements, triggers, styles, options) {
     super(text, replacements, triggers, styles, options);
-    this.emulatedTimeOffset = 0;
-    this.emulatedFightSync = 0;
-    this.emulatedFightSyncLastOffset = 0;
     this.emulatedStatus = 'pause';
   }
 
   bindTo(emulator) {
-    emulator.on('tick', (timestampOffset, lastLogTimestamp) => {
-      this.emulatedTimeOffset = timestampOffset;
-    });
+    this.emulator = emulator;
     emulator.on('play', () => {
       this.emulatedStatus = 'play';
     });
@@ -21,24 +16,21 @@ export default class RaidEmulatorTimeline extends Timeline {
     });
   }
 
-  emulatedSync(timestampOffset) {
-    if (!this.emulatedFightSyncLastOffset)
+  emulatedSync(currentTimestamp) {
+    if (!currentTimestamp)
       return;
 
-    this.SyncTo(this.emulatedFightSync +
-      ((timestampOffset - this.emulatedFightSyncLastOffset) / 1000), timestampOffset);
-    this._OnUpdateTimer(timestampOffset);
+    // This is a bit complicated due to jumps in timelines. If we've already got a timebase,
+    // fightNow needs to be calculated based off of that instead of engageAt
+    // timebase = 0 when not set
+    const baseTimestamp = this.timebase || this.emulator.currentEncounter.encounter.engageAt;
+    const fightNow = (currentTimestamp - baseTimestamp) / 1000;
+
+    this.SyncTo(fightNow, currentTimestamp);
+    this._OnUpdateTimer(currentTimestamp);
   }
 
   // Override
   _ScheduleUpdate(fightNow) {
-  }
-
-  // Override
-  SyncTo(fightNow, currentTime) {
-    super.SyncTo(fightNow, currentTime);
-
-    this.emulatedFightSync = fightNow;
-    this.emulatedFightSyncLastOffset = this.emulatedTimeOffset;
   }
 }

--- a/ui/raidboss/emulator/overrides/RaidEmulatorTimeline.js
+++ b/ui/raidboss/emulator/overrides/RaidEmulatorTimeline.js
@@ -16,18 +16,18 @@ export default class RaidEmulatorTimeline extends Timeline {
     });
   }
 
-  emulatedSync(currentTimestamp) {
-    if (!currentTimestamp)
+  emulatedSync(currentLogTime) {
+    if (!currentLogTime)
       return;
 
     // This is a bit complicated due to jumps in timelines. If we've already got a timebase,
     // fightNow needs to be calculated based off of that instead of engageAt
     // timebase = 0 when not set
     const baseTimestamp = this.timebase || this.emulator.currentEncounter.encounter.engageAt;
-    const fightNow = (currentTimestamp - baseTimestamp) / 1000;
+    const fightNow = (currentLogTime - baseTimestamp) / 1000;
 
-    this.SyncTo(fightNow, currentTimestamp);
-    this._OnUpdateTimer(currentTimestamp);
+    this.SyncTo(fightNow, currentLogTime);
+    this._OnUpdateTimer(currentLogTime);
   }
 
   // Override

--- a/ui/raidboss/emulator/overrides/RaidEmulatorTimelineUI.js
+++ b/ui/raidboss/emulator/overrides/RaidEmulatorTimelineUI.js
@@ -10,7 +10,7 @@ export default class RaidEmulatorTimelineUI extends TimelineUI {
   }
 
   bindTo(emulator) {
-    emulator.on('tick', (currentLogTime, lastLogTimestamp) => {
+    emulator.on('tick', (currentLogTime, lastLogLineTime) => {
       for (const i in this.emulatedTimerBars) {
         const bar = this.emulatedTimerBars[i];
         this.updateBar(bar, currentLogTime);
@@ -24,7 +24,7 @@ export default class RaidEmulatorTimelineUI extends TimelineUI {
       this.emulatedTimerBars = this.emulatedTimerBars.filter((bar) => {
         return bar.forceRemoveAt > currentLogTime;
       });
-      this.timeline && this.timeline.timebase && this.timeline._OnUpdateTimer(lastLogTimestamp);
+      this.timeline && this.timeline.timebase && this.timeline._OnUpdateTimer(lastLogLineTime);
     });
     emulator.on('play', () => {
       this.emulatedStatus = 'play';

--- a/ui/raidboss/emulator/overrides/RaidEmulatorTimelineUI.js
+++ b/ui/raidboss/emulator/overrides/RaidEmulatorTimelineUI.js
@@ -10,25 +10,25 @@ export default class RaidEmulatorTimelineUI extends TimelineUI {
   }
 
   bindTo(emulator) {
-    emulator.on('tick', (currentTimestamp, lastLogTimestamp) => {
+    emulator.on('tick', (currentLogTime, lastLogTimestamp) => {
       for (const i in this.emulatedTimerBars) {
         const bar = this.emulatedTimerBars[i];
-        this.updateBar(bar, currentTimestamp);
+        this.updateBar(bar, currentLogTime);
       }
       const toRemove = this.emulatedTimerBars
-        .filter((bar) => bar.forceRemoveAt <= currentTimestamp);
+        .filter((bar) => bar.forceRemoveAt <= currentLogTime);
       for (const i in toRemove) {
         const bar = toRemove[i];
         bar.$progress.remove();
       }
       this.emulatedTimerBars = this.emulatedTimerBars.filter((bar) => {
-        return bar.forceRemoveAt > currentTimestamp;
+        return bar.forceRemoveAt > currentLogTime;
       });
       this.timeline && this.timeline.timebase && this.timeline._OnUpdateTimer(lastLogTimestamp);
     });
     emulator.on('play', () => {
       this.emulatedStatus = 'play';
-      this.timeline && this.timeline.emulatedSync(emulator.currentTimestamp);
+      this.timeline && this.timeline.emulatedSync(emulator.currentLogTime);
     });
     emulator.on('pause', () => {
       this.emulatedStatus = 'pause';
@@ -44,12 +44,12 @@ export default class RaidEmulatorTimelineUI extends TimelineUI {
       this.timeline && (tmpPopupText = this.timeline.popupText);
       this.timeline && (this.timeline.popupText = null);
     });
-    emulator.on('postSeek', (currentTimestamp) => {
+    emulator.on('postSeek', (currentLogTime) => {
       this.timeline && (this.timeline.popupText = tmpPopupText);
-      this.timeline && this.timeline.emulatedSync(currentTimestamp);
+      this.timeline && this.timeline.emulatedSync(currentLogTime);
       for (const i in this.emulatedTimerBars) {
         const bar = this.emulatedTimerBars[i];
-        this.updateBar(bar, currentTimestamp);
+        this.updateBar(bar, currentLogTime);
       }
     });
     emulator.on('currentEncounterChanged', this.stop.bind(this));
@@ -64,8 +64,8 @@ export default class RaidEmulatorTimelineUI extends TimelineUI {
     this.emulatedTimerBars = [];
   }
 
-  updateBar(bar, currentTimestamp) {
-    const barElapsed = currentTimestamp - bar.start;
+  updateBar(bar, currentLogTime) {
+    const barElapsed = currentLogTime - bar.start;
     let barProg = Math.min((barElapsed / bar.duration) * 100, 100);
     if (bar.style === 'empty')
       barProg = 100 - barProg;

--- a/ui/raidboss/emulator/ui/EmulatedPartyInfo.js
+++ b/ui/raidboss/emulator/ui/EmulatedPartyInfo.js
@@ -20,7 +20,7 @@ export default class EmulatedPartyInfo extends EventBus {
     for (let i = 0; i < 8; ++i)
       this.triggerBars[i] = this.$triggerBar.querySelector('.player' + i);
 
-    emulator.on('tick', (currentTimestamp, lastLogTimestamp) => {
+    emulator.on('tick', (currentLogTime, lastLogTimestamp) => {
       if (lastLogTimestamp) {
         this.updatePartyInfo(emulator, lastLogTimestamp);
         this.latestDisplayedState = Math.max(this.latestDisplayedState, lastLogTimestamp);

--- a/ui/raidboss/emulator/ui/EmulatedPartyInfo.js
+++ b/ui/raidboss/emulator/ui/EmulatedPartyInfo.js
@@ -20,7 +20,7 @@ export default class EmulatedPartyInfo extends EventBus {
     for (let i = 0; i < 8; ++i)
       this.triggerBars[i] = this.$triggerBar.querySelector('.player' + i);
 
-    emulator.on('tick', (timestampOffset, lastLogTimestamp) => {
+    emulator.on('tick', (currentTimestamp, lastLogTimestamp) => {
       if (lastLogTimestamp) {
         this.updatePartyInfo(emulator, lastLogTimestamp);
         this.latestDisplayedState = Math.max(this.latestDisplayedState, lastLogTimestamp);

--- a/ui/raidboss/emulator/ui/EmulatedPartyInfo.js
+++ b/ui/raidboss/emulator/ui/EmulatedPartyInfo.js
@@ -20,10 +20,10 @@ export default class EmulatedPartyInfo extends EventBus {
     for (let i = 0; i < 8; ++i)
       this.triggerBars[i] = this.$triggerBar.querySelector('.player' + i);
 
-    emulator.on('tick', (currentLogTime, lastLogTimestamp) => {
-      if (lastLogTimestamp) {
-        this.updatePartyInfo(emulator, lastLogTimestamp);
-        this.latestDisplayedState = Math.max(this.latestDisplayedState, lastLogTimestamp);
+    emulator.on('tick', (currentLogTime, lastLogLineTime) => {
+      if (lastLogLineTime) {
+        this.updatePartyInfo(emulator, lastLogLineTime);
+        this.latestDisplayedState = Math.max(this.latestDisplayedState, lastLogLineTime);
       }
     });
     emulator.on('currentEncounterChanged', (encounter) => {

--- a/ui/raidboss/emulator/ui/ProgressBar.js
+++ b/ui/raidboss/emulator/ui/ProgressBar.js
@@ -44,12 +44,12 @@ export default class ProgressBar {
         this.$engageIndicator.style.left = initialPercent + '%';
       }
     });
-    emulator.on('tick', (timestampOffset) => {
-      const progPercent = (timestampOffset / emulator.currentEncounter.encounter.duration) * 100;
-      this.$progressBarCurrent.textContent = EmulatorCommon.timeToString(
-          timestampOffset - emulator.currentEncounter.encounter.initialOffset,
-          false);
-      this.$progressBar.setAttribute('ariaValueNow', timestampOffset - emulator.currentEncounter.encounter.initialOffset);
+    emulator.on('tick', (currentTimestamp) => {
+      const currentOffset = currentTimestamp - emulator.currentEncounter.encounter.startTimestamp;
+      const progPercent = (currentOffset / emulator.currentEncounter.encounter.duration) * 100;
+      const progValue = currentTimestamp - emulator.currentEncounter.encounter.engageAt;
+      this.$progressBarCurrent.textContent = EmulatorCommon.timeToString(progValue, false);
+      this.$progressBar.setAttribute('ariaValueNow', progValue);
       this.$progressBar.style.width = progPercent + '%';
     });
     const $play = document.querySelector('.progressBarRow button.play');

--- a/ui/raidboss/emulator/ui/ProgressBar.js
+++ b/ui/raidboss/emulator/ui/ProgressBar.js
@@ -44,10 +44,10 @@ export default class ProgressBar {
         this.$engageIndicator.style.left = initialPercent + '%';
       }
     });
-    emulator.on('tick', (currentTimestamp) => {
-      const currentOffset = currentTimestamp - emulator.currentEncounter.encounter.startTimestamp;
+    emulator.on('tick', (currentLogTime) => {
+      const currentOffset = currentLogTime - emulator.currentEncounter.encounter.startTimestamp;
       const progPercent = (currentOffset / emulator.currentEncounter.encounter.duration) * 100;
-      const progValue = currentTimestamp - emulator.currentEncounter.encounter.engageAt;
+      const progValue = currentLogTime - emulator.currentEncounter.encounter.engageAt;
       this.$progressBarCurrent.textContent = EmulatorCommon.timeToString(progValue, false);
       this.$progressBar.setAttribute('ariaValueNow', progValue);
       this.$progressBar.style.width = progPercent + '%';


### PR DESCRIPTION
This PR fixes a number of minor issues related to using offsets instead of log line timestamps which were left over from #2862, which I incorrectly attributed to the changes in #2942.

Also included in this PR is a fix for a long outstanding issue with seeking during an encounter with a jump (e.g. e12s p2) which these fixes exposed the root cause of.