### PR TITLE
raidboss: fix resetWhenOutOfCombat

### DIFF
--- a/ui/raidboss/popup-text.js
+++ b/ui/raidboss/popup-text.js
@@ -535,7 +535,7 @@ export class PopupText {
     if (this.inCombat === inCombat)
       return;
 
-    if (inCombat || this.resetWhenOutOfCombat)
+    if (this.resetWhenOutOfCombat)
       this.SetInCombat(inCombat);
   }
 


### PR DESCRIPTION
This fixes issues where going into combat would reset which
CE the Zadnor triggers thought you were in.  In particular,
if resetWhenOutOfCombat is set, the triggers themselves
must always specify stopping combat.