### PR TITLE
util: Fix Translate Timeline

### DIFF
--- a/util/translate_timeline.ts
+++ b/util/translate_timeline.ts
@@ -92,7 +92,8 @@ const run = async (args: { locale: Lang; timeline: string }) => {
 
   // Combine replaced lines with errors.
   const timelineLines = timelineText.split(/\n/);
-  timelineLines.forEach((timelineLine, lineNumber) => {
+  timelineLines.forEach((timelineLine, idx) => {
+    const lineNumber = idx + 1;
     let line = timelineLine.trim();
 
     const lineText = lineToText[lineNumber];


### PR DESCRIPTION
Line number was off by 1 after switching to forEach.

Closes https://github.com/quisquous/cactbot/issues/2965