### PR TITLE
ci: Update NPM Cache and Install Commands

### DIFF
--- a/.github/workflows/build-artifact.yml
+++ b/.github/workflows/build-artifact.yml
@@ -66,21 +66,18 @@ jobs:
       run: msbuild /p:Configuration=Release /p:Platform=x64 plugin/Cactbot.sln
       shell: cmd
 
-    - name: Get npm cache directory
-      id: npm-cache-dir
-      run: |
-        echo "::set-output name=dir::$(npm config get cache)"
-
-    - uses: actions/cache@v2
+    - name: Cache Dependencies
+      id: cache
+      uses: actions/cache@v2
       with:
-        path: ${{ steps.npm-cache-dir.outputs.dir }}
-        key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
-        restore-keys: |
-          ${{ runner.os }}-node-
+        path: ./node_modules
+        key: modules-${{ hashFiles('package-lock.json') }}
 
     - name: Install Node Dependencies
+      if: steps.cache.outputs.cache-hit != 'true'
       run: |
-        npm install
+        npm ci --ignore-scripts
+
     - name: Build JavaScript UI Module Bundles
       run: |
         npm run build

--- a/.github/workflows/css-lint.yml
+++ b/.github/workflows/css-lint.yml
@@ -22,20 +22,21 @@ jobs:
         with:
           node-version: '14'
 
-      - uses: actions/cache@v2
+      - name: Cache Dependencies
+        id: cache
+        uses: actions/cache@v2
         with:
-          path: ~/.npm
-          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-node-
+          path: ./node_modules
+          key: modules-${{ hashFiles('package-lock.json') }}
 
       - name: Add Custom Problem Matcher
         run: |
           echo "::add-matcher::.github/matchers/${{ github.job }}.json"
 
       - name: Install Dependencies
+        if: steps.cache.outputs.cache-hit != 'true'
         run: |
-          npm ci
+          npm ci --ignore-scripts
 
       - name: npm run stylelint
         run: |

--- a/.github/workflows/javascript-lint.yml
+++ b/.github/workflows/javascript-lint.yml
@@ -28,16 +28,17 @@ jobs:
         with:
           node-version: '14'
 
-      - uses: actions/cache@v2
+      - name: Cache Dependencies
+        id: cache
+        uses: actions/cache@v2
         with:
-          path: ~/.npm
-          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-node-
+          path: ./node_modules
+          key: modules-${{ hashFiles('package-lock.json') }}
 
       - name: Install Dependencies
+        if: steps.cache.outputs.cache-hit != 'true'
         run: |
-          npm ci
+          npm ci --ignore-scripts
 
       - name: TypeScript checking
         run: |

--- a/.github/workflows/markdown-lint.yml
+++ b/.github/workflows/markdown-lint.yml
@@ -22,20 +22,21 @@ jobs:
         with:
           node-version: '14'
 
-      - uses: actions/cache@v2
+      - name: Cache Dependencies
+        id: cache
+        uses: actions/cache@v2
         with:
-          path: ~/.npm
-          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-node-
+          path: ./node_modules
+          key: modules-${{ hashFiles('package-lock.json') }}
 
       - name: Add Custom Problem Matcher
         run: |
           echo "::add-matcher::.github/matchers/${{ github.job }}.json"
 
       - name: Install Dependencies
+        if: steps.cache.outputs.cache-hit != 'true'
         run: |
-          npm ci
+          npm ci --ignore-scripts
 
       - name: npm run markdownlint
         run: |

--- a/.github/workflows/post-process.yml
+++ b/.github/workflows/post-process.yml
@@ -26,16 +26,17 @@ jobs:
         with:
           node-version: '14'
 
-      - uses: actions/cache@v2
+      - name: Cache Dependencies
+        id: cache
+        uses: actions/cache@v2
         with:
-          path: ~/.npm
-          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-node-
+          path: ./node_modules
+          key: modules-${{ hashFiles('package-lock.json') }}
 
       - name: Install Dependencies
+        if: steps.cache.outputs.cache-hit != 'true'
         run: |
-          npm ci
+          npm ci --ignore-scripts
 
       - name: npm run coverage-report
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,19 +44,16 @@ jobs:
         run: |
           dotnet build plugin/Cactbot.sln /p:Configuration=Release /p:Platform=x64
 
-      - name: Get npm cache directory
-        id: npm-cache-dir
-        run: |
-          echo "::set-output name=dir::$(npm config get cache)"
-      - uses: actions/cache@v2
+      - name: Cache Dependencies
+        id: cache
+        uses: actions/cache@v2
         with:
-          path: ${{ steps.npm-cache-dir.outputs.dir }}
-          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-node-
+          path: ./node_modules
+          key: modules-${{ hashFiles('package-lock.json') }}
       - name: Install Node Dependencies
+        if: steps.cache.outputs.cache-hit != 'true'
         run: |
-          npm install
+          npm ci --ignore-scripts
       - name: Build JavaScript UI Module Bundles
         run: |
           npm run build

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,20 +28,21 @@ jobs:
         with:
           node-version: '14'
 
-      - uses: actions/cache@v2
+      - name: Cache Dependencies
+        id: cache
+        uses: actions/cache@v2
         with:
-          path: ~/.npm
-          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-node-
+          path: ./node_modules
+          key: modules-${{ hashFiles('package-lock.json') }}
 
       - uses: actions/setup-python@v2
         with:
           python-version: '3.7'
 
       - name: Install Dependencies
+        if: steps.cache.outputs.cache-hit != 'true'
         run: |
-          npm ci
+          npm ci --ignore-scripts
 
       - name: npm test
         run: |

--- a/.github/workflows/update-gh-pages.yml
+++ b/.github/workflows/update-gh-pages.yml
@@ -31,9 +31,18 @@ jobs:
       - uses: actions/setup-node@v2
         with:
           node-version: '14'
+      - name: Cache Dependencies
+        id: cache
+        uses: actions/cache@v2
+        with:
+          path: ./node_modules
+          key: modules-${{ hashFiles('package-lock.json') }}
+      - name: Install Dependencies
+        if: steps.cache.outputs.cache-hit != 'true'
+        run: |
+          npm ci --ignore-scripts
       - name: Build
         run: |
-          npm install
           npm run coverage-report
           npm run build
       - name: git setup

--- a/.github/workflows/update-triggers-branch.yml
+++ b/.github/workflows/update-triggers-branch.yml
@@ -30,9 +30,18 @@ jobs:
       - uses: actions/setup-node@v2
         with:
           node-version: '14'
+      - name: Cache Dependencies
+        id: cache
+        uses: actions/cache@v2
+        with:
+          path: ./node_modules
+          key: modules-${{ hashFiles('package-lock.json') }}
+      - name: Install Dependencies
+        if: steps.cache.outputs.cache-hit != 'true'
+        run: |
+          npm ci --ignore-scripts
       - name: Build
         run: |
-          npm install
           npm run process-triggers
       - name: Deploy
         uses: peaceiris/actions-gh-pages@v3


### PR DESCRIPTION
Update `npm install` to instead use `npm ci`.

After looking into an error in the [update-gh-pages](https://github.com/quisquous/cactbot/runs/2707837316?check_suite_focus=true) action, I noticed a
number of workflows are still using `npm install` that should be using
`npm ci`. While looking for best practices, I found [this blog post](https://www.voorhoede.nl/en/blog/super-fast-npm-install-on-github-actions/), which
I've implemented the "even faster alternative" here.