### PR TITLE
raidemulator: Fix loading encounters with a different base language, issue with getCombatants

### DIFF
--- a/ui/raidboss/emulator/data/RaidEmulator.js
+++ b/ui/raidboss/emulator/data/RaidEmulator.js
@@ -16,7 +16,14 @@ export default class RaidEmulator extends EventBus {
     this.encounters.push(encounter);
   }
   setCurrent(index) {
-    this.currentEncounter = new AnalyzedEncounter(this.options, this.encounters[index], this);
+    const enc = this.encounters[index];
+
+    // If language was autodetected from the encounter, set the current ParserLanguage
+    // appropriately
+    if (enc.language)
+      this.options.ParserLanguage = enc.language;
+
+    this.currentEncounter = new AnalyzedEncounter(this.options, enc, this);
     this.dispatch('preCurrentEncounterChanged', this.currentEncounter);
     this.currentEncounter.analyze(this.popupText).then(() => {
       this.dispatch('currentEncounterChanged', this.currentEncounter);

--- a/ui/raidboss/emulator/overrides/RaidEmulatorOverlayApiHook.js
+++ b/ui/raidboss/emulator/overrides/RaidEmulatorOverlayApiHook.js
@@ -51,9 +51,9 @@ export default class RaidEmulatorOverlayApiHook {
           const lines = this.emulator.currentEncounter.encounter.logLines
             .filter((l) => l.decEvent === 3 && l.id === c.ID);
           if (lines.length > 0) {
-            c.OwnerID = parseInt(lines[0].parts[6]);
-            c.BNpcNameID = parseInt(lines[0].parts[9]);
-            c.BNpcID = parseInt(lines[0].parts[10]);
+            c.OwnerID = parseInt(lines[0].ownerId);
+            c.BNpcNameID = parseInt(lines[0].npcNameId);
+            c.BNpcID = parseInt(lines[0].npcBaseId);
           }
         });
         res({


### PR DESCRIPTION
As discussed in #2942, set Options.ParserLanguage to the auto-detected language when analyzing and loading encounters for playback.

This can be done via a single set in `RaidEmulator.setCurrent`.

This PR also fixes an issue with the getCombatants call which was caused by writing the additional non-tracked field code against the old version of LineEvent whereas the new version doesn't store the `parts` array because all relevant parts are extracted to proper fields now.