### PR TITLE
fix(config): view source fragment

### DIFF
--- a/ui/raidboss/raidboss_config.js
+++ b/ui/raidboss/raidboss_config.js
@@ -608,7 +608,7 @@ class RaidbossConfigurator {
           // 02-arr/raids/t1.js
           urlFilepath = `${path[0]}-${path[1]}/${path[2]}/${[...path].slice(3).join('-')}`;
         }
-        const escapedTriggerId = trig.id.replace(/'/g, '\\\'');
+        const escapedTriggerId = trig.id.replaceAll(/'/g, '\\\'');
         const uriComponent = encodeURIComponent(`id: '${escapedTriggerId}'`).replaceAll(/'/g, '%27');
         const urlString = `${baseUrl}/${urlFilepath}.js#ref-for-fragment-directive:~:text=${uriComponent}`;
         div.innerHTML = `<a href="${urlString}" target="_blank">(${this.base.translate(kMiscTranslations.viewTriggerSource)})</a>`;

--- a/ui/raidboss/raidboss_config.js
+++ b/ui/raidboss/raidboss_config.js
@@ -686,6 +686,7 @@ class RaidbossConfigurator {
     for (let i = 0; i < kFakeData.length; ++i)
       kFakeData[i] = Object.assign({}, kFakeData[i], kBaseFakeData);
 
+
     const kFakeMatches = {
       // TODO: really should convert all triggers to use regexes.js.
       // Mooooost triggers use matches[1] to be a name.
@@ -710,6 +711,7 @@ class RaidbossConfigurator {
       name: 'Name',
       capture: true,
     };
+
 
     const output = {};
     const keys = ['alarmText', 'alertText', 'infoText', 'tts', 'sound'];

--- a/ui/raidboss/raidboss_config.js
+++ b/ui/raidboss/raidboss_config.js
@@ -608,8 +608,8 @@ class RaidbossConfigurator {
           // 02-arr/raids/t1.js
           urlFilepath = `${path[0]}-${path[1]}/${path[2]}/${[...path].slice(3).join('-')}`;
         }
-        const uriComponent = encodeURIComponent(`id: ${trig.id}`).replace(/\'/g, '%5C%27'); // Hack to force encoding for \'
-        const urlString = `${baseUrl}/${urlFilepath}.js#:~:text=${uriComponent}`;
+        const uriComponent = escape(`id: '${trig.id}'`);
+        const urlString = `${baseUrl}/${urlFilepath}.js#ref-for-fragment-directive:~:text=${uriComponent}`;
         div.innerHTML = `<a href="${urlString}" target="_blank">(${this.base.translate(kMiscTranslations.viewTriggerSource)})</a>`;
 
         triggerDetails.appendChild(div);
@@ -686,7 +686,6 @@ class RaidbossConfigurator {
     for (let i = 0; i < kFakeData.length; ++i)
       kFakeData[i] = Object.assign({}, kFakeData[i], kBaseFakeData);
 
-
     const kFakeMatches = {
       // TODO: really should convert all triggers to use regexes.js.
       // Mooooost triggers use matches[1] to be a name.
@@ -711,7 +710,6 @@ class RaidbossConfigurator {
       name: 'Name',
       capture: true,
     };
-
 
     const output = {};
     const keys = ['alarmText', 'alertText', 'infoText', 'tts', 'sound'];

--- a/ui/raidboss/raidboss_config.js
+++ b/ui/raidboss/raidboss_config.js
@@ -610,7 +610,7 @@ class RaidbossConfigurator {
         }
         const escapedTriggerId = trig.id.replaceAll(/'/g, '\\\'');
         const uriComponent = encodeURIComponent(`id: '${escapedTriggerId}'`).replaceAll(/'/g, '%27');
-        const urlString = `${baseUrl}/${urlFilepath}.js#ref-for-fragment-directive:~:text=${uriComponent}`;
+        const urlString = `${baseUrl}/${urlFilepath}.js#:~:text=${uriComponent}`;
         div.innerHTML = `<a href="${urlString}" target="_blank">(${this.base.translate(kMiscTranslations.viewTriggerSource)})</a>`;
 
         triggerDetails.appendChild(div);

--- a/ui/raidboss/raidboss_config.js
+++ b/ui/raidboss/raidboss_config.js
@@ -608,7 +608,8 @@ class RaidbossConfigurator {
           // 02-arr/raids/t1.js
           urlFilepath = `${path[0]}-${path[1]}/${path[2]}/${[...path].slice(3).join('-')}`;
         }
-        const uriComponent = escape(`id: '${trig.id}'`);
+        const escapedTriggerId = trig.id.replace(/'/g, '\\\'');
+        const uriComponent = encodeURIComponent(`id: '${escapedTriggerId}'`).replaceAll(/'/g, '%27');
         const urlString = `${baseUrl}/${urlFilepath}.js#ref-for-fragment-directive:~:text=${uriComponent}`;
         div.innerHTML = `<a href="${urlString}" target="_blank">(${this.base.translate(kMiscTranslations.viewTriggerSource)})</a>`;
 


### PR DESCRIPTION
generating url in this way: https://github.com/quisquous/cactbot/blob/triggers/04-sb/dungeon/bardams_mettle.js#:~:text=id%3A%20%27Bardam%5C%27s%20Mettle%20Rush%27

it's `id: 'Bardam\'s Mettle Rush'`

previous:

https://github.com/quisquous/cactbot/blob/triggers/04-sb/dungeon/bardams_mettle.js#:~:text=id%3A%20Bardam%5C%27s%20Mettle%20Rush

it's `id: Bardam\'s Mettle Rush`
