### PR TITLE
Revert "fix(config): view source fragment"

### DIFF
--- a/ui/raidboss/raidboss_config.js
+++ b/ui/raidboss/raidboss_config.js
@@ -608,8 +608,7 @@ class RaidbossConfigurator {
           // 02-arr/raids/t1.js
           urlFilepath = `${path[0]}-${path[1]}/${path[2]}/${[...path].slice(3).join('-')}`;
         }
-        const escapedTriggerId = trig.id.replaceAll(/'/g, '\\\'');
-        const uriComponent = encodeURIComponent(`id: '${escapedTriggerId}'`).replaceAll(/'/g, '%27');
+        const uriComponent = encodeURIComponent(`id: ${trig.id}`).replace(/\'/g, '%5C%27'); // Hack to force encoding for \'
         const urlString = `${baseUrl}/${urlFilepath}.js#:~:text=${uriComponent}`;
         div.innerHTML = `<a href="${urlString}" target="_blank">(${this.base.translate(kMiscTranslations.viewTriggerSource)})</a>`;
 


### PR DESCRIPTION
Reverts quisquous/cactbot#2986.

`replaceAll` is a Chrome M85 feature, which OverlayPlugin does not support.

This patch caused "trig.id.replaceAll is not a function" errors which prevented the config from loading.