### PR TITLE
raidboss: Fix e9s callout not being declared properly

### DIFF
--- a/ui/raidboss/data/05-shb/raid/e9s.js
+++ b/ui/raidboss/data/05-shb/raid/e9s.js
@@ -538,7 +538,7 @@ export default {
       durationSeconds: (data) => data.finalArtOfDarkness ? 16 : 9,
       alertText: (data, _matches, output) => {
         // Perform the callout now, regardless if it's The Second or Third Art Of Darkness
-        callout = data.artOfDarkness.slice();
+        const callout = data.artOfDarkness.slice();
         if (data.finalArtOfDarkness)
           callout.push(data.finalArtOfDarkness);
         return callout.map((key) => output[key]()).join(' -> ');


### PR DESCRIPTION
Noticed this issue while testing the language fix for raidemulator.

Edit:

Fixes #2995.