### PR TITLE
ci: label script will match key with lang only

### DIFF
--- a/.github/scripts/auto-label.cjs
+++ b/.github/scripts/auto-label.cjs
@@ -156,7 +156,7 @@ const getChangedFiles = async (github, identifier) => {
 const parseChangedLang = (patch) => {
   const set = new Set();
   for (const lang of ['cn', 'de', 'ja', 'fr', 'ko']) {
-    const pattern = new RegExp(`^\s*[+] *(?:${lang}|'${lang}'): `);
+    const pattern = new RegExp(`^\s*[+]\s*(?:${lang}|'${lang}'): `);
     for (const line of patch.split('\n')) {
       if (pattern.test(line)) {
         // TODO: it'd be nice to add the file/line number here.

--- a/.github/scripts/auto-label.cjs
+++ b/.github/scripts/auto-label.cjs
@@ -156,7 +156,7 @@ const getChangedFiles = async (github, identifier) => {
 const parseChangedLang = (patch) => {
   const set = new Set();
   for (const lang of ['cn', 'de', 'ja', 'fr', 'ko']) {
-    const pattern = new RegExp(`^\s*[+].*(?:${lang}|'${lang}'): `);
+    const pattern = new RegExp(`^\s*[+] *(?:${lang}|'${lang}'): `);
     for (const line of patch.split('\n')) {
       if (pattern.test(line)) {
         // TODO: it'd be nice to add the file/line number here.

--- a/.github/scripts/auto-label.cjs
+++ b/.github/scripts/auto-label.cjs
@@ -156,7 +156,7 @@ const getChangedFiles = async (github, identifier) => {
 const parseChangedLang = (patch) => {
   const set = new Set();
   for (const lang of ['cn', 'de', 'ja', 'fr', 'ko']) {
-    const pattern = new RegExp(String.raw`^\s*[+]\s*(?:${lang}|'${lang}'): `);
+    const pattern = new RegExp(String.raw`^[+]\s*(?:${lang}|'${lang}'): `);
     for (const line of patch.split('\n')) {
       if (pattern.test(line)) {
         // TODO: it'd be nice to add the file/line number here.

--- a/.github/scripts/auto-label.cjs
+++ b/.github/scripts/auto-label.cjs
@@ -156,7 +156,7 @@ const getChangedFiles = async (github, identifier) => {
 const parseChangedLang = (patch) => {
   const set = new Set();
   for (const lang of ['cn', 'de', 'ja', 'fr', 'ko']) {
-    const pattern = new RegExp(`^\s*[+]\s*(?:${lang}|'${lang}'): `);
+    const pattern = new RegExp(`^\\s*[+]\\s*(?:${lang}|'${lang}'): `);
     for (const line of patch.split('\n')) {
       if (pattern.test(line)) {
         // TODO: it'd be nice to add the file/line number here.

--- a/.github/scripts/auto-label.cjs
+++ b/.github/scripts/auto-label.cjs
@@ -156,7 +156,7 @@ const getChangedFiles = async (github, identifier) => {
 const parseChangedLang = (patch) => {
   const set = new Set();
   for (const lang of ['cn', 'de', 'ja', 'fr', 'ko']) {
-    const pattern = new RegExp(`^\\s*[+]\\s*(?:${lang}|'${lang}'): `);
+    const pattern = new RegExp(String.raw`^\s*[+]\s*(?:${lang}|'${lang}'): `);
     for (const line of patch.split('\n')) {
       if (pattern.test(line)) {
         // TODO: it'd be nice to add the file/line number here.

--- a/.github/scripts/auto-label.cjs
+++ b/.github/scripts/auto-label.cjs
@@ -156,7 +156,7 @@ const getChangedFiles = async (github, identifier) => {
 const parseChangedLang = (patch) => {
   const set = new Set();
   for (const lang of ['cn', 'de', 'ja', 'fr', 'ko']) {
-    const pattern = new RegExp(String.raw`^[+]\s*(?:${lang}|'${lang}'): `);
+    const pattern = new RegExp(String.raw`^\+\s*(?:${lang}|'${lang}'): `);
     for (const line of patch.split('\n')) {
       if (pattern.test(line)) {
         // TODO: it'd be nice to add the file/line number here.


### PR DESCRIPTION
```js
mocha.setup('bdd');

const assert = chai.assert;

/**
 * @param {string} patch
 */
const parseChangedLang = (patch) => {
  const set = new Set();
  for (const lang of ['cn', 'de', 'ja', 'fr', 'ko']) {
    const pattern = new RegExp(String.raw`^\+\s*(?:${lang}|'${lang}'):`);
    for (const line of patch.split('\n')) {
      if (pattern.test(line)) {
        // TODO: it'd be nice to add the file/line number here.
        if (!set.has(lang))
          console.log(`label: ${lang} [translation]`);
        set.add(lang);
      }
    }
  }
  return Array.from(set.values());
};

describe('parseChangedLang', () => {
  it('should match only single word', () => {
    assert.deepEqual(parseChangedLang(`+  de: 'hello',`), ['de']);
  });

  it('should match quoted', () => {
    assert.deepEqual(parseChangedLang(`+  'de': 'hello',`), ['de']);
  });

  it('should match only single word', () => {
    assert.deepEqual(parseChangedLang(`+  // parentNode: { classList: () };`), []);
  });

  it('should match only single word', () => {
    assert.deepEqual(parseChangedLang(`+  parentNode: { classList: () };`), []);
  });
});


mocha.run();
```
https://codepen.io/Trim21/pen/gOmeyGo