### PR TITLE
eureka: update ko v5.4 CE opcode

### DIFF
--- a/plugin/CactbotEventSource/FateWatcher.cs
+++ b/plugin/CactbotEventSource/FateWatcher.cs
@@ -62,12 +62,12 @@ namespace Cactbot {
     // v5.41            0x0120
     //
     // KR
-    // v5.35            0x0347
-    //
+    // v5.35            0x347
+    // v5.4             0x1d1
 
     private static readonly CEDirectorOPCodes cedirector_ko = new CEDirectorOPCodes(
       0x30,
-      0x0347
+      0x1d1
     );
 
     private static readonly CEDirectorOPCodes cedirector_cn = new CEDirectorOPCodes(


### PR DESCRIPTION
Found an amazing plugin to find CE opcode. https://github.com/kshman/DutyContent
![제목 없음](https://user-images.githubusercontent.com/4695371/120843624-4d2ef500-c5a9-11eb-9404-75a2bede779b.png)


I've built the cactbot plugin with this change, and successfully detected CE from v5.4 Korean server.