### PR TITLE
Jobs: Auto remove readied raidbuffs that not be used in 3min

### DIFF
--- a/ui/jobs/buff_tracker.ts
+++ b/ui/jobs/buff_tracker.ts
@@ -104,6 +104,12 @@ export class Buff {
     const readyKey = 'r:' + this.name + ':' + source;
     this.ready[source] = this.makeAura(readyKey, this.readyList, -1, 0,
         this.readySortKeyBase, color, txt, 0.6);
+
+    // if a readied raidbuff not be used in 3min, we can assume that
+    // this player has left the battlefield, or at least his raidbuff is unexpectable.
+    setTimeout(() => {
+      this.ready[source]?.removeCallback();
+    }, 3 * 60 * 1000);
   }
 
   makeAura(


### PR DESCRIPTION
- **Auto remove readied raidbuffs that not be used in 3min.** 
If a readied raidbuff not be used in 3min, we can assume that this player has left the battlefield, or that is a DNC who no longer dance with you, or a DRG who no longer consider you as his left eye, or at least his raidbuff is unexpectable and not worth tracing. 
-- This usually happen in Bozjan/Eureka that a lot of NIN cast `Trick Attack` and leave the battlefield, leaving a lot of `Trick Attack ready` on your `buffTracker`, preventing you to read the coming cooldown of other raidbuffs.