### PR TITLE
raidemulator: Fix #3021

### DIFF
--- a/ui/raidboss/emulator/data/Encounter.js
+++ b/ui/raidboss/emulator/data/Encounter.js
@@ -25,7 +25,6 @@ export default class Encounter {
     this.encounterZoneName = encounterZoneName;
     this.encounterDay = encounterDay;
     this.logLines = logLines;
-    this.initialize();
   }
 
   initialize() {

--- a/ui/raidboss/emulator/data/NetworkLogConverterWorker.js
+++ b/ui/raidboss/emulator/data/NetworkLogConverterWorker.js
@@ -12,6 +12,7 @@ onmessage = async (msg) => {
   // Listen for LogEventHandler to dispatch fights and persist them
   localLogHandler.on('fight', async (day, zoneId, zoneName, lines) => {
     const enc = new Encounter(day, zoneId, zoneName, lines);
+    enc.initialize();
     if (enc.shouldPersistFight()) {
       postMessage({
         type: 'encounter',

--- a/ui/raidboss/emulator/data/Persistor.js
+++ b/ui/raidboss/emulator/data/Persistor.js
@@ -110,6 +110,7 @@ export default class Persistor extends EventBus {
               res(ret);
             });
           } else {
+            ret.initialize();
             res(ret);
           }
         });


### PR DESCRIPTION
This PR fixes two issues identified in #3021:

- In #2997 code was added to upgrade encounters that were older to a newer format, but this code couldn't trigger due to `Encounter.initialize` being called in the constructor.
  - `Encounter.initialize` moved out of the constructor and to downstream locations
- In #2606 when timeline trigger support was added, the code assumed that every loaded fight would have a timeline.
  - An `if` check was added to prevent timeline trigger handlers from being added if the encounter has no timeline associated with it