### PR TITLE
build: Use Webpack v5 Native TerserPlugin

### DIFF
--- a/webpack/webpack.config.cjs
+++ b/webpack/webpack.config.cjs
@@ -154,6 +154,7 @@ module.exports = function(env, argv) {
     optimization: {
       minimize: true,
       minimizer: [
+        // Apply option overrides to Webpack v5's native TerserPlugin
         () => ({
           extractComments: false,
         }),

--- a/webpack/webpack.config.cjs
+++ b/webpack/webpack.config.cjs
@@ -155,7 +155,7 @@ module.exports = function(env, argv) {
     optimization: {
       minimize: true,
       minimizer: [
-        new TerserWebpackPlugin({
+        () => ({
           extractComments: false,
         }),
         new CssMinimizerPlugin(),

--- a/webpack/webpack.config.cjs
+++ b/webpack/webpack.config.cjs
@@ -2,7 +2,6 @@
 
 const path = require('path');
 const webpack = require('webpack');
-const TerserWebpackPlugin = require('terser-webpack-plugin');
 const { CleanWebpackPlugin } = require('clean-webpack-plugin');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 const MiniCssExtractPlugin = require('mini-css-extract-plugin');


### PR DESCRIPTION
Webpack v5 has a native TerserPlugin. Creating a new one led to an
increase in build times by nearly 50%.