### PR TITLE
eslint: ignore `.venv/` dir

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -79,6 +79,7 @@ module.exports = {
     // Do not ignore dot files.  /o\
     '!.*',
     '.git/',
+    '.venv/',
     'dist/',
     'plugin/',
     'publish/',


### PR DESCRIPTION
find that eslint become extremely slow, try debugging, eslint is trying to lint file in `.venv/` dir.