### PR TITLE
raidemulator: Performance and fixes

### DIFF
--- a/ui/raidboss/emulator/data/AnalyzedEncounter.js
+++ b/ui/raidboss/emulator/data/AnalyzedEncounter.js
@@ -2,11 +2,11 @@ import EmulatorCommon from '../EmulatorCommon';
 import EventBus from '../EventBus';
 import { PopupTextGenerator } from '../../popup-text';
 import RaidEmulatorTimelineController from '../overrides/RaidEmulatorTimelineController';
-import RaidEmulatorTimelineUI from '../overrides/RaidEmulatorTimelineUI';
 import PopupTextAnalysis from '../data/PopupTextAnalysis';
 import { TimelineLoader } from '../../timeline';
 import Util from '../../../../resources/util';
 import raidbossFileData from '../../data/raidboss_manifest.txt';
+import RaidEmulatorAnalysisTimelineUI from '../overrides/RaidEmulatorAnalysisTimelineUI';
 
 export default class AnalyzedEncounter extends EventBus {
   constructor(options, encounter, emulator) {
@@ -63,7 +63,7 @@ export default class AnalyzedEncounter extends EventBus {
       return;
     }
 
-    const timelineUI = new RaidEmulatorTimelineUI(this.options);
+    const timelineUI = new RaidEmulatorAnalysisTimelineUI(this.options);
     const timelineController =
         new RaidEmulatorTimelineController(this.options, timelineUI, raidbossFileData);
     timelineController.bindTo(this.emulator);

--- a/ui/raidboss/emulator/overrides/RaidEmulatorAnalysisTimelineUI.js
+++ b/ui/raidboss/emulator/overrides/RaidEmulatorAnalysisTimelineUI.js
@@ -1,0 +1,16 @@
+import RaidEmulatorTimelineUI from './RaidEmulatorTimelineUI';
+
+export default class RaidEmulatorAnalysisTimelineUI extends RaidEmulatorTimelineUI {
+  constructor(options) {
+    super(options);
+    this.$barContainer = document.createElement('div');
+    this.$progressTemplate = document.querySelector('template.progress').content.firstElementChild;
+  }
+
+  // Stub out these methods for performance
+  updateBar(bar, currentLogTime) {}
+  OnAddTimer(fightNow, e, channeling) {}
+
+  // Override
+  OnRemoveTimer(e, expired) {}
+}

--- a/ui/raidboss/raidemulator.js
+++ b/ui/raidboss/raidemulator.js
@@ -56,33 +56,24 @@ import './raidemulator.css';
       emulator.selectPerspective(id);
     });
 
+    emulator.on('currentEncounterChanged', (enc) => {
+      // Store our current loaded encounter to auto-load next time
+      window.localStorage.setItem('currentEncounter', enc.encounter.id);
+      // Once we've loaded the encounter, seek to the start of the encounter
+      if (!isNaN(enc.encounter.initialOffset))
+        emulator.seek(enc.encounter.initialOffset);
+    });
+
     // Listen for the user to attempt to load an encounter from the encounters pane
     encounterTab.on('load', (id) => {
-      let p;
       // Attempt to set the current emulated encounter
       if (!emulator.setCurrentByID(id)) {
-        let resolver;
-        p = new Promise((res) => {
-          resolver = res;
-        });
         // If that encounter isn't loaded, load it
         persistor.loadEncounter(id).then((enc) => {
           emulator.addEncounter(enc);
           emulator.setCurrentByID(id);
-          resolver();
-        });
-      } else {
-        p = new Promise((res) => {
-          res();
         });
       }
-      // Once we've loaded the encounter, seek to the start of the encounter
-      p.then(() => {
-        // Store our current loaded encounter to auto-load next time
-        window.localStorage.setItem('currentEncounter', id);
-        if (!isNaN(emulator.currentEncounter.encounter.initialOffset))
-          emulator.seek(emulator.currentEncounter.encounter.initialOffset);
-      });
     });
 
     // Listen for the user to select re-parse on the encounters tab, then refresh it in the DB


### PR DESCRIPTION
This PR fixes a performance issue mentioned and caused by timeline trigger support, as well as an issue with async vs non-async execution when loading encounters, which caused seeking to the start of the encounter to happen before analysis was complete in some cases.