### PR TITLE
raidboss: Fix some triggers using `matches.duration` instead of `matches.castTime`

### DIFF
--- a/ui/raidboss/data/04-sb/dungeon/st_mocianne_hard.js
+++ b/ui/raidboss/data/04-sb/dungeon/st_mocianne_hard.js
@@ -125,7 +125,7 @@ export default {
       netRegexJa: NetRegexes.startsUsing({ id: '3132', source: 'シルトゴーレム' }),
       netRegexCn: NetRegexes.startsUsing({ id: '3132', source: '淤泥巨像' }),
       netRegexKo: NetRegexes.startsUsing({ id: '3132', source: '실트 골렘' }),
-      delaySeconds: (_data, matches) => parseFloat(matches.duration) - 6,
+      delaySeconds: (_data, matches) => parseFloat(matches.castTime) - 6,
       infoText: (_data, _matches, output) => output.text(),
       outputStrings: {
         text: {

--- a/ui/raidboss/data/05-shb/alliance/the_tower_at_paradigms_breach.js
+++ b/ui/raidboss/data/05-shb/alliance/the_tower_at_paradigms_breach.js
@@ -163,7 +163,7 @@ export default {
       netRegexDe: NetRegexes.startsUsing({ id: '5EB1', source: 'Herzbube' }),
       netRegexFr: NetRegexes.startsUsing({ id: '5EB1', source: 'Jack' }),
       netRegexJa: NetRegexes.startsUsing({ id: '5EB1', source: 'ジャック' }),
-      delaySeconds: (_data, matches) => matches.duration - 6,
+      delaySeconds: (_data, matches) => matches.castTime - 6,
       durationSeconds: 5,
       infoText: (_data, _matches, output) => output.text(),
       outputStrings: {
@@ -184,7 +184,7 @@ export default {
       netRegexFr: NetRegexes.startsUsing({ id: '5EB1', source: 'Réplique De Jack' }),
       netRegexJa: NetRegexes.startsUsing({ id: '5EB1', source: '複製サレタジャック' }),
       condition: (data) => !data.cloneLunge,
-      delaySeconds: (_data, matches) => matches.duration - 6,
+      delaySeconds: (_data, matches) => matches.castTime - 6,
       durationSeconds: 5,
       infoText: (_data, _matches, output) => output.text(),
       run: (data) => data.cloneLunge = true,
@@ -206,7 +206,7 @@ export default {
       netRegexFr: NetRegexes.startsUsing({ id: '60C7', source: 'Jack' }),
       netRegexJa: NetRegexes.startsUsing({ id: '60C7', source: 'ジャック' }),
       // Half a second longer cast time than the Lunge itself
-      delaySeconds: (_data, matches) => matches.duration - 6.5,
+      delaySeconds: (_data, matches) => matches.castTime - 6.5,
       durationSeconds: 5,
       alertText: (_data, _matches, output) => output.text(),
       outputStrings: {
@@ -226,7 +226,7 @@ export default {
       netRegexDe: NetRegexes.startsUsing({ id: '60C8', source: 'Herzbube' }),
       netRegexFr: NetRegexes.startsUsing({ id: '60C8', source: 'Jack' }),
       netRegexJa: NetRegexes.startsUsing({ id: '60C8', source: 'ジャック' }),
-      delaySeconds: (_data, matches) => matches.duration - 6.5,
+      delaySeconds: (_data, matches) => matches.castTime - 6.5,
       durationSeconds: 5,
       alertText: (_data, _matches, output) => output.text(),
       outputStrings: {

--- a/ui/raidboss/data/05-shb/alliance/the_tower_at_paradigms_breach.js
+++ b/ui/raidboss/data/05-shb/alliance/the_tower_at_paradigms_breach.js
@@ -163,7 +163,7 @@ export default {
       netRegexDe: NetRegexes.startsUsing({ id: '5EB1', source: 'Herzbube' }),
       netRegexFr: NetRegexes.startsUsing({ id: '5EB1', source: 'Jack' }),
       netRegexJa: NetRegexes.startsUsing({ id: '5EB1', source: 'ジャック' }),
-      delaySeconds: (_data, matches) => matches.castTime - 6,
+      delaySeconds: (_data, matches) => parseFloat(matches.castTime) - 6,
       durationSeconds: 5,
       infoText: (_data, _matches, output) => output.text(),
       outputStrings: {
@@ -184,7 +184,7 @@ export default {
       netRegexFr: NetRegexes.startsUsing({ id: '5EB1', source: 'Réplique De Jack' }),
       netRegexJa: NetRegexes.startsUsing({ id: '5EB1', source: '複製サレタジャック' }),
       condition: (data) => !data.cloneLunge,
-      delaySeconds: (_data, matches) => matches.castTime - 6,
+      delaySeconds: (_data, matches) => parseFloat(matches.castTime) - 6,
       durationSeconds: 5,
       infoText: (_data, _matches, output) => output.text(),
       run: (data) => data.cloneLunge = true,
@@ -206,7 +206,7 @@ export default {
       netRegexFr: NetRegexes.startsUsing({ id: '60C7', source: 'Jack' }),
       netRegexJa: NetRegexes.startsUsing({ id: '60C7', source: 'ジャック' }),
       // Half a second longer cast time than the Lunge itself
-      delaySeconds: (_data, matches) => matches.castTime - 6.5,
+      delaySeconds: (_data, matches) => parseFloat(matches.castTime) - 6.5,
       durationSeconds: 5,
       alertText: (_data, _matches, output) => output.text(),
       outputStrings: {
@@ -226,7 +226,7 @@ export default {
       netRegexDe: NetRegexes.startsUsing({ id: '60C8', source: 'Herzbube' }),
       netRegexFr: NetRegexes.startsUsing({ id: '60C8', source: 'Jack' }),
       netRegexJa: NetRegexes.startsUsing({ id: '60C8', source: 'ジャック' }),
-      delaySeconds: (_data, matches) => matches.castTime - 6.5,
+      delaySeconds: (_data, matches) => parseFloat(matches.castTime) - 6.5,
       durationSeconds: 5,
       alertText: (_data, _matches, output) => output.text(),
       outputStrings: {


### PR DESCRIPTION
Noticed when testing performance in alliance raids, there were some triggers using `matches.duration` instead of `matches.castTime`. Checked with this regex and found another case:

```
NetRegexes.startsUsing.*?\n(?:      [^ ].*\n)*      delaySeconds.*duration
```

I checked any other cases of `\.duration[^a-zA-Z]` in triggers and it looks like these are the only cases?