### PR TITLE
raidboss: Fix timeline sync based on area seal message

### DIFF
--- a/ui/raidboss/common_replacement.ts
+++ b/ui/raidboss/common_replacement.ts
@@ -5,7 +5,7 @@ import { Lang, NonEnLang } from 'resources/languages';
 // It's awkward to refer to these string keys, so name them as replaceSync[keys.sealKey].
 export const syncKeys = {
   // Match Regexes, NetRegexes, and timeline constructions of seal log lines.
-  seal: '(?<=00:0839:|00.*0839.*\\\\\|)(.*) will be sealed off(?: in (?:[0-9]+ seconds)?)?',
+  seal: '(?<=00:0839:|00\\|0839\\|)(.*) will be sealed off(?: in (?:[0-9]+ seconds)?)?',
   unseal: 'is no longer sealed',
   engage: 'Engage!',
 };

--- a/ui/raidboss/common_replacement.ts
+++ b/ui/raidboss/common_replacement.ts
@@ -5,7 +5,7 @@ import { Lang, NonEnLang } from 'resources/languages';
 // It's awkward to refer to these string keys, so name them as replaceSync[keys.sealKey].
 export const syncKeys = {
   // Match Regexes, NetRegexes, and timeline constructions of seal log lines.
-  seal: '(?<=00:0839:|00\\|0839\\|)(.*) will be sealed off(?: in (?:[0-9]+ seconds)?)?',
+  seal: '(?<=00:0839:|00\\|[^|]*\\|0839\\|\\|)(.*) will be sealed off(?: in (?:[0-9]+ seconds)?)?',
   unseal: 'is no longer sealed',
   engage: 'Engage!',
 };


### PR DESCRIPTION
This should, I think, fix #3040.

Please review this one more thoroughly, as I'm not as familiar with exactly how common replacements work through all the components.

The fix looks good in raidemulator using the log attached to the issue, at least.