### PR TITLE
raidemulator: Fix issue caused by #3029 with initialOffset

### DIFF
--- a/ui/raidboss/emulator/data/Encounter.ts
+++ b/ui/raidboss/emulator/data/Encounter.ts
@@ -119,6 +119,10 @@ export default class Encounter {
     this.startStatus = [...startStatuses].sort().join(', ');
   }
 
+  public get initialTimestamp() : number {
+    return this.startTimestamp + this.initialOffset;
+  }
+
   shouldPersistFight(): boolean {
     return isValidTimestamp(this.firstPlayerAbility) && isValidTimestamp(this.firstEnemyAbility);
   }

--- a/ui/raidboss/emulator/overrides/RaidEmulatorTimeline.js
+++ b/ui/raidboss/emulator/overrides/RaidEmulatorTimeline.js
@@ -23,7 +23,8 @@ export default class RaidEmulatorTimeline extends Timeline {
     // This is a bit complicated due to jumps in timelines. If we've already got a timebase,
     // fightNow needs to be calculated based off of that instead of initialOffset
     // timebase = 0 when not set
-    const baseTimestamp = this.timebase || this.emulator.currentEncounter.encounter.initialOffset;
+    const baseTimestamp = this.timebase ||
+      this.emulator.currentEncounter.encounter.initialTimestamp;
     const fightNow = (currentLogTime - baseTimestamp) / 1000;
 
     this.SyncTo(fightNow, currentLogTime);

--- a/ui/raidboss/emulator/ui/ProgressBar.js
+++ b/ui/raidboss/emulator/ui/ProgressBar.js
@@ -47,7 +47,7 @@ export default class ProgressBar {
     emulator.on('tick', (currentLogTime) => {
       const currentOffset = currentLogTime - emulator.currentEncounter.encounter.startTimestamp;
       const progPercent = (currentOffset / emulator.currentEncounter.encounter.duration) * 100;
-      const progValue = currentLogTime - emulator.currentEncounter.encounter.initialOffset;
+      const progValue = currentLogTime - emulator.currentEncounter.encounter.initialTimestamp;
       this.$progressBarCurrent.textContent = EmulatorCommon.timeToString(progValue, false);
       this.$progressBar.setAttribute('ariaValueNow', progValue);
       this.$progressBar.style.width = progPercent + '%';

--- a/ui/raidboss/raidemulator.js
+++ b/ui/raidboss/raidemulator.js
@@ -214,7 +214,7 @@ import './raidemulator.css';
                   Start: ${new Date(enc.startTimestamp)}
                   End: ${new Date(enc.endTimestamp)}
                   Duration: ${EmulatorCommon.msToDuration(enc.endTimestamp - enc.startTimestamp)}
-                  Pull Duration: ${EmulatorCommon.msToDuration(enc.endTimestamp - enc.initialOffset)}
+                  Pull Duration: ${EmulatorCommon.msToDuration(enc.endTimestamp - enc.initialTimestamp)}
                   Started By: ${enc.startStatus}
                   End Status: ${enc.endStatus}
                   Line Count: ${enc.logLines.length}


### PR DESCRIPTION
Found this issue while testing the RaidEmulatorTimelineUI typescript conversion, basically `initialOffset` is, as the name implies, an offset, but in #3029 when I corrected from using `engageAt` I didn't account for the fact that `engageAt` was a timestamp, not an offset.