### PR TITLE
raidboss: make Matches have required fields

### DIFF
--- a/types/trigger.d.ts
+++ b/types/trigger.d.ts
@@ -7,7 +7,7 @@ export interface BaseRegExp<T> extends RegExp {
   };
 }
 
-export type Matches<Params> = { [s in Params]?: string };
+export type Matches<Params> = { [s in Params]: string } | MatchesAny;
 
 // TargetedMatches can be used for generic functions in responses or conditions
 // that use matches from any number of Regex or NetRegex functions.


### PR DESCRIPTION
This will let trigger files have required matches fields but
popup-text will deal with non-required MatchesAny.

It's a bit of a hack, but I think the eslint rule for making
sure that all triggers have the right matches will make this work?

Closes #2994.