### PR TITLE
util: Adjust typings in trigger.d.ts

### DIFF
--- a/types/trigger.d.ts
+++ b/types/trigger.d.ts
@@ -31,7 +31,7 @@ export type OutputStrings = { [outputKey: string]: LocaleText };
 // TODO: is it awkward to have Outputs the static class and Output the unrelated type?
 // This type corresponds to TriggerOutputProxy.
 export type Output = {
-  responseOutputStrings: OutputStrings | string;
+  responseOutputStrings: OutputStrings;
 } & {
   [key: string]: (params?: { [param: string]: string | undefined }) => string;
 };
@@ -92,9 +92,7 @@ export type BaseTrigger<Data> = {
   infoText?: TriggerField<Data, TriggerOutput>;
   tts?: TriggerField<Data, TriggerOutput>;
   run?: TriggerField<Data, void>;
-  outputStrings?: {
-    [key: string]: LocaleText;
-  };
+  outputStrings?: OutputStrings;
 }
 
 export type NetRegexTrigger<Data> = BaseTrigger<Data> & {

--- a/types/trigger.d.ts
+++ b/types/trigger.d.ts
@@ -26,12 +26,12 @@ export type LocaleText = LocaleObject<string>;
 
 export type ZoneId = number | null;
 
+export type OutputStrings = { [outputKey: string]: LocaleText };
+
 // TODO: is it awkward to have Outputs the static class and Output the unrelated type?
 // This type corresponds to TriggerOutputProxy.
 export type Output = {
-  responseOutputStrings: {
-    [outputKey: string]: LocaleText;
-  };
+  responseOutputStrings: OutputStrings | string;
 } & {
   [key: string]: (params?: { [param: string]: string | undefined }) => string;
 };
@@ -61,7 +61,7 @@ export type TriggerAutoConfig = {
   Output?: Output;
   Duration?: number;
   BeforeSeconds?: number;
-  OutputStrings?: { [outputKey: string]: Lang };
+  OutputStrings?: OutputStrings;
 }
 
 export type MatchesAny = { [s in T]?: string };

--- a/ui/raidboss/data/00-misc/test.js
+++ b/ui/raidboss/data/00-misc/test.js
@@ -1,4 +1,5 @@
 import NetRegexes from '../../../../resources/netregexes';
+import outputs from '../../../../resources/outputs';
 import ZoneId from '../../../../resources/zone_id';
 
 export default {
@@ -228,10 +229,10 @@ export default {
       response: (_data, _matches, output) => {
         // cactbot-builtin-response
         output.responseOutputStrings = {
-          alarmOne: '1',
-          alertTwo: '2',
-          infoThree: '3',
-          ttsFour: '4',
+          alarmOne: outputs.num1,
+          alertTwo: outputs.num2,
+          infoThree: outputs.num3,
+          ttsFour: outputs.num4,
         };
         return {
           alarmText: output.alarmOne(),


### PR DESCRIPTION
While working on converting popup-text.js to typescript, I noticed a typing issue with trigger.d.ts.

Basically, `./ui/raidboss/data/00-misc/test.js` has the following trigger which doesn't use language keys. Either the `Output` type in trigger.d.ts needs adjusted, or this trigger needs adjusted. Either way, to avoid having to redefine types, the typing of OutputStrings was moved to its own type definition and exported.

I opted to allow plain strings in this PR because I don't know if this is the only trigger that's using plain strings here and I don't have a good way to search all the triggers to check.

```js
    {
      id: 'Test Response',
      netRegex: NetRegexes.echo({ line: 'cactbot test response.*?', capture: false }),
      netRegexDe: NetRegexes.echo({ line: 'cactbot test antwort.*?', capture: false }),
      response: (_data, _matches, output) => {
        // cactbot-builtin-response
        output.responseOutputStrings = {
          alarmOne: '1',
          alertTwo: '2',
          infoThree: '3',
          ttsFour: '4',
        };
        return {
          alarmText: output.alarmOne(),
          alertText: output.alertTwo(),
          infoText: output.infoThree(),
          tts: output.ttsFour(),
        };
      },
    },
```