### PR TITLE
Jobs: Flash proc box when expired and in combat

### DIFF
--- a/resources/timerbox.ts
+++ b/resources/timerbox.ts
@@ -407,6 +407,7 @@ export default class TimerBox extends HTMLElement {
     this._hideTimer = null;
     clearTimeout(this._timer ?? 0);
     this._timer = null;
+    this.classList.remove('expired');
 
     this._start = new Date().getTime();
     this.advance();
@@ -418,6 +419,7 @@ export default class TimerBox extends HTMLElement {
       // Sets the attribute to 0 so users can see the counter is done, and
       // if they set the same duration again it will count.
       this._duration = 0;
+      this.classList.add('expired');
       if (this._hideAfter > 0)
         this._hideTimer = window.setTimeout(this.hide.bind(this), this._hideAfter);
       else if (this._hideAfter === 0)

--- a/ui/jobs/components/ast.js
+++ b/ui/jobs/components/ast.js
@@ -14,6 +14,7 @@ export function setup(bars) {
   const combustBox = bars.addProcBox({
     id: 'ast-procs-combust',
     fgColor: 'ast-color-combust',
+    flashWhenExpired: true,
   });
 
   const drawBox = bars.addProcBox({

--- a/ui/jobs/components/ast.js
+++ b/ui/jobs/components/ast.js
@@ -14,7 +14,7 @@ export function setup(bars) {
   const combustBox = bars.addProcBox({
     id: 'ast-procs-combust',
     fgColor: 'ast-color-combust',
-    flashWhenExpired: true,
+    notifyWhenExpired: true,
   });
 
   const drawBox = bars.addProcBox({

--- a/ui/jobs/components/blm.js
+++ b/ui/jobs/components/blm.js
@@ -8,6 +8,7 @@ export function setup(bars) {
     id: 'blm-dot-thunder',
     fgColor: 'blm-color-dot',
     threshold: 4,
+    flashWhenExpired: true,
   });
   const thunderProc = bars.addProcBox({
     id: 'blm-procs-thunder',

--- a/ui/jobs/components/blm.js
+++ b/ui/jobs/components/blm.js
@@ -8,7 +8,7 @@ export function setup(bars) {
     id: 'blm-dot-thunder',
     fgColor: 'blm-color-dot',
     threshold: 4,
-    flashWhenExpired: true,
+    notifyWhenExpired: true,
   });
   const thunderProc = bars.addProcBox({
     id: 'blm-procs-thunder',

--- a/ui/jobs/components/brd.js
+++ b/ui/jobs/components/brd.js
@@ -19,10 +19,12 @@ export function setup(bars) {
   const causticBiteBox = bars.addProcBox({
     id: 'brd-procs-causticbite',
     fgColor: 'brd-color-causticbite',
+    flashWhenExpired: true,
   });
   const stormBiteBox = bars.addProcBox({
     id: 'brd-procs-stormbite',
     fgColor: 'brd-color-stormbite',
+    flashWhenExpired: true,
   });
   // Iron jaws just refreshes these effects by gain once more,
   // so it doesn't need to be handled separately.

--- a/ui/jobs/components/brd.js
+++ b/ui/jobs/components/brd.js
@@ -19,12 +19,12 @@ export function setup(bars) {
   const causticBiteBox = bars.addProcBox({
     id: 'brd-procs-causticbite',
     fgColor: 'brd-color-causticbite',
-    flashWhenExpired: true,
+    notifyWhenExpired: true,
   });
   const stormBiteBox = bars.addProcBox({
     id: 'brd-procs-stormbite',
     fgColor: 'brd-color-stormbite',
-    flashWhenExpired: true,
+    notifyWhenExpired: true,
   });
   // Iron jaws just refreshes these effects by gain once more,
   // so it doesn't need to be handled separately.

--- a/ui/jobs/components/drg.js
+++ b/ui/jobs/components/drg.js
@@ -23,7 +23,7 @@ export function setup(bars) {
   const disembowelBox = bars.addProcBox({
     id: 'drg-procs-disembowel',
     fgColor: 'drg-color-disembowel',
-    flashWhenExpired: true,
+    notifyWhenExpired: true,
   });
   bars.onCombo((skill) => {
     if (skill === kAbility.Disembowel) {

--- a/ui/jobs/components/drg.js
+++ b/ui/jobs/components/drg.js
@@ -23,6 +23,7 @@ export function setup(bars) {
   const disembowelBox = bars.addProcBox({
     id: 'drg-procs-disembowel',
     fgColor: 'drg-color-disembowel',
+    flashWhenExpired: true,
   });
   bars.onCombo((skill) => {
     if (skill === kAbility.Disembowel) {

--- a/ui/jobs/components/pld.js
+++ b/ui/jobs/components/pld.js
@@ -40,6 +40,7 @@ export function setup(bars) {
 
   const goreBox = bars.addProcBox({
     fgColor: 'pld-color-gore',
+    flashWhenExpired: true,
   });
 
   bars.onCombo((skill) => {

--- a/ui/jobs/components/pld.js
+++ b/ui/jobs/components/pld.js
@@ -40,7 +40,7 @@ export function setup(bars) {
 
   const goreBox = bars.addProcBox({
     fgColor: 'pld-color-gore',
-    flashWhenExpired: true,
+    notifyWhenExpired: true,
   });
 
   bars.onCombo((skill) => {

--- a/ui/jobs/components/sam.js
+++ b/ui/jobs/components/sam.js
@@ -65,7 +65,7 @@ export function setup(bars) {
   const shifu = bars.addProcBox({
     id: 'sam-procs-shifu',
     fgColor: 'sam-color-shifu',
-    flashWhenExpired: true,
+    notifyWhenExpired: true,
   });
   bars.onYouGainEffect(EffectId.Shifu, (id, matches) => {
     shifu.duration = 0;
@@ -80,7 +80,7 @@ export function setup(bars) {
   const jinpu = bars.addProcBox({
     id: 'sam-procs-jinpu',
     fgColor: 'sam-color-jinpu',
-    flashWhenExpired: true,
+    notifyWhenExpired: true,
   });
   bars.onYouGainEffect(EffectId.Jinpu, (id, matches) => {
     jinpu.duration = 0;
@@ -106,7 +106,7 @@ export function setup(bars) {
   const higanbana = bars.addProcBox({
     id: 'sam-procs-higanbana',
     fgColor: 'sam-color-higanbana',
-    flashWhenExpired: true,
+    notifyWhenExpired: true,
   });
   bars.onMobGainsEffectFromYou(EffectId.Higanbana, () => {
     higanbana.duration = 0;

--- a/ui/jobs/components/sam.js
+++ b/ui/jobs/components/sam.js
@@ -65,6 +65,7 @@ export function setup(bars) {
   const shifu = bars.addProcBox({
     id: 'sam-procs-shifu',
     fgColor: 'sam-color-shifu',
+    flashWhenExpired: true,
   });
   bars.onYouGainEffect(EffectId.Shifu, (id, matches) => {
     shifu.duration = 0;
@@ -79,6 +80,7 @@ export function setup(bars) {
   const jinpu = bars.addProcBox({
     id: 'sam-procs-jinpu',
     fgColor: 'sam-color-jinpu',
+    flashWhenExpired: true,
   });
   bars.onYouGainEffect(EffectId.Jinpu, (id, matches) => {
     jinpu.duration = 0;
@@ -104,6 +106,7 @@ export function setup(bars) {
   const higanbana = bars.addProcBox({
     id: 'sam-procs-higanbana',
     fgColor: 'sam-color-higanbana',
+    flashWhenExpired: true,
   });
   bars.onMobGainsEffectFromYou(EffectId.Higanbana, () => {
     higanbana.duration = 0;

--- a/ui/jobs/components/sch.js
+++ b/ui/jobs/components/sch.js
@@ -14,6 +14,7 @@ export function setup(bars) {
   const bioBox = bars.addProcBox({
     id: 'sch-procs-bio',
     fgColor: 'sch-color-bio',
+    flashWhenExpired: true,
   });
 
   const aetherflowBox = bars.addProcBox({

--- a/ui/jobs/components/sch.js
+++ b/ui/jobs/components/sch.js
@@ -14,7 +14,7 @@ export function setup(bars) {
   const bioBox = bars.addProcBox({
     id: 'sch-procs-bio',
     fgColor: 'sch-color-bio',
-    flashWhenExpired: true,
+    notifyWhenExpired: true,
   });
 
   const aetherflowBox = bars.addProcBox({

--- a/ui/jobs/components/smn.js
+++ b/ui/jobs/components/smn.js
@@ -16,11 +16,13 @@ export function setup(bars) {
   const miasmaBox = bars.addProcBox({
     id: 'smn-procs-miasma',
     fgColor: 'smn-color-miasma',
+    flashWhenExpired: true,
   });
 
   const bioSmnBox = bars.addProcBox({
     id: 'smn-procs-biosmn',
     fgColor: 'smn-color-biosmn',
+    flashWhenExpired: true,
   });
 
   const energyDrainBox = bars.addProcBox({

--- a/ui/jobs/components/smn.js
+++ b/ui/jobs/components/smn.js
@@ -16,13 +16,13 @@ export function setup(bars) {
   const miasmaBox = bars.addProcBox({
     id: 'smn-procs-miasma',
     fgColor: 'smn-color-miasma',
-    flashWhenExpired: true,
+    notifyWhenExpired: true,
   });
 
   const bioSmnBox = bars.addProcBox({
     id: 'smn-procs-biosmn',
     fgColor: 'smn-color-biosmn',
-    flashWhenExpired: true,
+    notifyWhenExpired: true,
   });
 
   const energyDrainBox = bars.addProcBox({

--- a/ui/jobs/components/war.js
+++ b/ui/jobs/components/war.js
@@ -28,6 +28,7 @@ export function setup(bars) {
 
   const eyeBox = bars.addProcBox({
     fgColor: 'war-color-eye',
+    flashWhenExpired: true,
   });
 
   const comboTimer = bars.addTimerBar({

--- a/ui/jobs/components/war.js
+++ b/ui/jobs/components/war.js
@@ -28,7 +28,7 @@ export function setup(bars) {
 
   const eyeBox = bars.addProcBox({
     fgColor: 'war-color-eye',
-    flashWhenExpired: true,
+    notifyWhenExpired: true,
   });
 
   const comboTimer = bars.addTimerBar({

--- a/ui/jobs/components/whm.js
+++ b/ui/jobs/components/whm.js
@@ -14,6 +14,7 @@ export function setup(bars) {
   const diaBox = bars.addProcBox({
     id: 'whm-procs-dia',
     fgColor: 'whm-color-dia',
+    flashWhenExpired: true,
   });
   const assizeBox = bars.addProcBox({
     id: 'whm-procs-assize',

--- a/ui/jobs/components/whm.js
+++ b/ui/jobs/components/whm.js
@@ -14,7 +14,7 @@ export function setup(bars) {
   const diaBox = bars.addProcBox({
     id: 'whm-procs-dia',
     fgColor: 'whm-color-dia',
-    flashWhenExpired: true,
+    notifyWhenExpired: true,
   });
   const assizeBox = bars.addProcBox({
     id: 'whm-procs-assize',

--- a/ui/jobs/jobs.css
+++ b/ui/jobs/jobs.css
@@ -1141,14 +1141,3 @@
 .blu-color-lucid {
   background-color: rgb(227, 148, 210);
 }
-
-.proc-box[incombat] .flash-when-expired.expired {
-  display: block;
-  animation: flash 1s infinite;
-}
-
-@keyframes flash {
-  50% {
-    opacity: 0%;
-  }
-}

--- a/ui/jobs/jobs.css
+++ b/ui/jobs/jobs.css
@@ -1141,3 +1141,14 @@
 .blu-color-lucid {
   background-color: rgb(227, 148, 210);
 }
+
+.proc-box[incombat] .flash-when-expired.expired {
+  display: block;
+  animation: flash 1s infinite;
+}
+
+@keyframes flash {
+  50% {
+    opacity: 0%;
+  }
+}

--- a/ui/jobs/jobs.css
+++ b/ui/jobs/jobs.css
@@ -1,7 +1,3 @@
-:root {
-  --proc-box-flash-repeat: infinite;
-}
-
 #jobs {
   position: relative;
 }
@@ -1147,9 +1143,9 @@
 }
 
 /* Proc box animation */
-.proc-box.in-combat .flash-when-expired.expired {
+.proc-box.in-combat .notify-when-expired.expired {
   display: block;
-  animation: var(--proc-box-flash-animation, proc-box-flash) var(--proc-box-flash-duration, 1s) var(--proc-box-flash-repeat);
+  animation: var(--proc-box-notfy-animation, proc-box-flash) var(--proc-box-notify-duration, 1s) var(--proc-box-notify-repeat, infinite);
 }
 
 @keyframes proc-box-flash {

--- a/ui/jobs/jobs.css
+++ b/ui/jobs/jobs.css
@@ -1,3 +1,7 @@
+:root {
+  --proc-box-flash-repeat: infinite;
+}
+
 #jobs {
   position: relative;
 }
@@ -1140,4 +1144,16 @@
 
 .blu-color-lucid {
   background-color: rgb(227, 148, 210);
+}
+
+/* Proc box animation */
+.proc-box.in-combat .flash-when-expired.expired {
+  display: block;
+  animation: var(--proc-box-flash-animation, proc-box-flash) var(--proc-box-flash-duration, 1s) var(--proc-box-flash-repeat);
+}
+
+@keyframes proc-box-flash {
+  50% {
+    opacity: 0;
+  }
 }

--- a/ui/jobs/jobs.js
+++ b/ui/jobs/jobs.js
@@ -125,26 +125,14 @@ class Bars {
     this.isPVPZone = false;
     this.crafting = false;
 
-    this.addProcFlashCSS();
+    this.updateProcBoxFlashRepeat();
   }
 
-  addProcFlashCSS() {
-    console.log(`Add css, repeat: ${this.options.FlashExpiredProcsInCombat}`);
+  updateProcBoxFlashRepeat() {
     if (this.options.FlashExpiredProcsInCombat >= 0) {
       const repeats = this.options.FlashExpiredProcsInCombat === 0 ? 'infinite' : this.options.FlashExpiredProcsInCombat;
-      const animationRule = `.proc-box.in-combat .flash-when-expired.expired {
-  display: block;
-  animation: flash 1s ${repeats};
-}
 
-@keyframes flash {
-  50% {
-    opacity: 0;
-  }
-}`;
-      const animationStyle = document.createElement('style');
-      animationStyle.innerHTML = animationRule;
-      document.head.appendChild(animationStyle);
+      document.documentElement.style.setProperty('--proc-box-flash-repeat', repeats);
     }
   }
 

--- a/ui/jobs/jobs.js
+++ b/ui/jobs/jobs.js
@@ -125,14 +125,14 @@ class Bars {
     this.isPVPZone = false;
     this.crafting = false;
 
-    this.updateProcBoxFlashRepeat();
+    this.updateProcBoxNotifyRepeat();
   }
 
-  updateProcBoxFlashRepeat() {
-    if (this.options.FlashExpiredProcsInCombat >= 0) {
-      const repeats = this.options.FlashExpiredProcsInCombat === 0 ? 'infinite' : this.options.FlashExpiredProcsInCombat;
+  updateProcBoxNotifyRepeat() {
+    if (this.options.NotifyExpiredProcsInCombat >= 0) {
+      const repeats = this.options.NotifyExpiredProcsInCombat === 0 ? 'infinite' : this.options.NotifyExpiredProcsInCombat;
 
-      document.documentElement.style.setProperty('--proc-box-flash-repeat', repeats);
+      document.documentElement.style.setProperty('--proc-box-notify-repeat', repeats);
     }
   }
 
@@ -426,7 +426,7 @@ class Bars {
     fgColor,
     threshold,
     scale,
-    flashWhenExpired,
+    notifyWhenExpired,
   }) {
     const elementId = this.job.toLowerCase() + '-procs';
 
@@ -453,8 +453,8 @@ class Bars {
       timerBox.id = id;
       timerBox.classList.add('timer-box');
     }
-    if (flashWhenExpired)
-      timerBox.classList.add('flash-when-expired');
+    if (notifyWhenExpired)
+      timerBox.classList.add('notify-when-expired');
     return timerBox;
   }
 
@@ -578,8 +578,8 @@ class Bars {
       this.o.healthBar.fg = computeBackgroundColorFrom(this.o.healthBar, 'hp-color');
   }
 
-  _updateProcBoxFlashState() {
-    if (this.options.FlashExpiredProcsInCombat >= 0) {
+  _updateProcBoxNotifyState() {
+    if (this.options.NotifyExpiredProcsInCombat >= 0) {
       const boxes = document.getElementsByClassName('proc-box');
       for (const box of boxes) {
         if (this.inCombat)
@@ -760,7 +760,7 @@ class Bars {
     this._updateOpacity();
     this._updateFoodBuff();
     this._updateMPTicker();
-    this._updateProcBoxFlashState();
+    this._updateProcBoxNotifyState();
   }
 
   _onChangeZone(e) {
@@ -894,7 +894,7 @@ class Bars {
       this._updateJob();
       // On reload, we need to set the opacity after setting up the job bars.
       this._updateOpacity();
-      this._updateProcBoxFlashState();
+      this._updateProcBoxNotifyState();
       // Set up the buff tracker after the job bars are created.
       this.buffTracker = new BuffTracker(
           this.options, this.me, this.o.leftBuffsList, this.o.rightBuffsList, this.partyTracker);

--- a/ui/jobs/jobs.js
+++ b/ui/jobs/jobs.js
@@ -467,7 +467,6 @@ class Bars {
     }
     if (flashWhenExpired)
       timerBox.classList.add('flash-when-expired');
-    timerBox.classList.add('expired');
     return timerBox;
   }
 

--- a/ui/jobs/jobs.js
+++ b/ui/jobs/jobs.js
@@ -416,6 +416,7 @@ class Bars {
     fgColor,
     threshold,
     scale,
+    flashWhenExpired,
   }) {
     const elementId = this.job.toLowerCase() + '-procs';
 
@@ -442,6 +443,9 @@ class Bars {
       timerBox.id = id;
       timerBox.classList.add('timer-box');
     }
+    if (flashWhenExpired)
+      timerBox.classList.add('flash-when-expired');
+    timerBox.classList.add('expired');
     return timerBox;
   }
 
@@ -563,6 +567,18 @@ class Bars {
       this.o.healthBar.fg = computeBackgroundColorFrom(this.o.healthBar, 'hp-color.mid');
     else
       this.o.healthBar.fg = computeBackgroundColorFrom(this.o.healthBar, 'hp-color');
+  }
+
+  _updateProcBoxFlashState() {
+    if (this.options.FlashExpiredProcsInCombat) {
+      const boxes = document.getElementsByClassName('proc-box');
+      for (const box of boxes) {
+        if (this.inCombat)
+          box.setAttribute('incombat', '');
+        else
+          box.removeAttribute('incombat');
+      }
+    }
   }
 
   _updateMPTicker() {
@@ -735,6 +751,7 @@ class Bars {
     this._updateOpacity();
     this._updateFoodBuff();
     this._updateMPTicker();
+    this._updateProcBoxFlashState();
   }
 
   _onChangeZone(e) {
@@ -868,6 +885,7 @@ class Bars {
       this._updateJob();
       // On reload, we need to set the opacity after setting up the job bars.
       this._updateOpacity();
+      this._updateProcBoxFlashState();
       // Set up the buff tracker after the job bars are created.
       this.buffTracker = new BuffTracker(
           this.options, this.me, this.o.leftBuffsList, this.o.rightBuffsList, this.partyTracker);

--- a/ui/jobs/jobs.js
+++ b/ui/jobs/jobs.js
@@ -582,10 +582,13 @@ class Bars {
     if (this.options.NotifyExpiredProcsInCombat >= 0) {
       const boxes = document.getElementsByClassName('proc-box');
       for (const box of boxes) {
-        if (this.inCombat)
+        if (this.inCombat) {
           box.classList.add('in-combat');
-        else
+          for (const child of box.children)
+            child.classList.remove('expired');
+        } else {
           box.classList.remove('in-combat');
+        }
       }
     }
   }

--- a/ui/jobs/jobs.js
+++ b/ui/jobs/jobs.js
@@ -124,6 +124,28 @@ class Bars {
     this.contentType = 0;
     this.isPVPZone = false;
     this.crafting = false;
+
+    this.addProcFlashCSS();
+  }
+
+  addProcFlashCSS() {
+    console.log(`Add css, repeat: ${this.options.FlashExpiredProcsInCombat}`);
+    if (this.options.FlashExpiredProcsInCombat >= 0) {
+      const repeats = this.options.FlashExpiredProcsInCombat === 0 ? 'infinite' : this.options.FlashExpiredProcsInCombat;
+      const animationRule = `.proc-box.in-combat .flash-when-expired.expired {
+  display: block;
+  animation: flash 1s ${repeats};
+}
+
+@keyframes flash {
+  50% {
+    opacity: 0;
+  }
+}`;
+      const animationStyle = document.createElement('style');
+      animationStyle.innerHTML = animationRule;
+      document.head.appendChild(animationStyle);
+    }
   }
 
   get gcdSkill() {
@@ -570,13 +592,13 @@ class Bars {
   }
 
   _updateProcBoxFlashState() {
-    if (this.options.FlashExpiredProcsInCombat) {
+    if (this.options.FlashExpiredProcsInCombat >= 0) {
       const boxes = document.getElementsByClassName('proc-box');
       for (const box of boxes) {
         if (this.inCombat)
-          box.setAttribute('incombat', '');
+          box.classList.add('in-combat');
         else
-          box.removeAttribute('incombat');
+          box.classList.remove('in-combat');
       }
     }
   }

--- a/ui/jobs/jobs_config.ts
+++ b/ui/jobs/jobs_config.ts
@@ -213,15 +213,11 @@ UserConfig.registerOptions('jobs', {
     {
       id: 'FlashExpiredProcsInCombat',
       name: {
-        en: 'Flash procs boxes of inactive dots/etc. while in combat.',
-        de: 'Dot/etc. boxen blinken when im Kampf und dot ist nicht aktiv.',
-        fr: 'Flash procs boxes of inactive dots/etc. while in combat.',
-        ja: 'Flash procs boxes of inactive dots/etc. while in combat.',
-        cn: 'Flash procs boxes of inactive dots/etc. while in combat.',
-        ko: 'Flash procs boxes of inactive dots/etc. while in combat.',
+        en: 'Flash procs boxes of inactive dots/etc. up to n times while in combat. (-1: disabled, 0: infinite)',
+        de: 'Dot/etc. boxen blinken bis zu n mal wenn im Kampf und dot ist nicht aktiv. (-1: deaktiviert, 0: ohne Limit)',
       },
-      type: 'checkbox',
-      default: false,
+      type: 'integer',
+      default: 4,
     },
   ],
 });

--- a/ui/jobs/jobs_config.ts
+++ b/ui/jobs/jobs_config.ts
@@ -217,7 +217,7 @@ UserConfig.registerOptions('jobs', {
         de: 'Dot/etc. boxen blinken bis zu n mal wenn im Kampf und dot ist nicht aktiv. (-1: deaktiviert, 0: ohne Limit)',
       },
       type: 'integer',
-      default: 4,
+      default: -1,
     },
   ],
 });

--- a/ui/jobs/jobs_config.ts
+++ b/ui/jobs/jobs_config.ts
@@ -210,5 +210,18 @@ UserConfig.registerOptions('jobs', {
       type: 'float',
       default: 0.8,
     },
+    {
+      id: 'FlashExpiredProcsInCombat',
+      name: {
+        en: 'Flash procs boxes of inactive dots/etc. while in combat.',
+        de: 'Dot/etc. boxen blinken when im Kampf und dot ist nicht aktiv.',
+        fr: 'Flash procs boxes of inactive dots/etc. while in combat.',
+        ja: 'Flash procs boxes of inactive dots/etc. while in combat.',
+        cn: 'Flash procs boxes of inactive dots/etc. while in combat.',
+        ko: 'Flash procs boxes of inactive dots/etc. while in combat.',
+      },
+      type: 'checkbox',
+      default: false,
+    },
   ],
 });

--- a/ui/jobs/jobs_config.ts
+++ b/ui/jobs/jobs_config.ts
@@ -211,7 +211,7 @@ UserConfig.registerOptions('jobs', {
       default: 0.8,
     },
     {
-      id: 'FlashExpiredProcsInCombat',
+      id: 'NotifyExpiredProcsInCombat',
       name: {
         en: 'Flash procs boxes of inactive dots/etc. up to n times while in combat. (-1: disabled, 0: infinite)',
         de: 'Dot/etc. boxen blinken bis zu n mal wenn im Kampf und dot ist nicht aktiv. (-1: deaktiviert, 0: ohne Limit)',

--- a/ui/jobs/types.d.ts
+++ b/ui/jobs/types.d.ts
@@ -19,6 +19,7 @@ export interface NonConfigOptions extends BaseOptions {
   BigBuffBorderSize: number;
   GpAlarmPoint: number;
   GpAlarmSoundVolume: number;
+  FlashExpiredProcsInCombat: boolean;
 }
 
 export interface ConfigOptions {


### PR DESCRIPTION
In case a proc box expires (reaches a duration of 0) and we are still
in combat, continuously flash the box to draw attention to it.

This is intended for proc boxes like dots or self-bufs which should be
always active/running while in combat.

The feature can be turned on in the Jobs settings via the variable
FlashExpiredProcsInCombat.

Proc boxes that should flash should pass
  flashWhenExpired: true
to the addProcBox call that creates them.