### PR TITLE
build: only generate TypeScript declaration in dev

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,8 +5,8 @@
   },
   "compilerOptions": {
     "checkJs": false,
-    "declaration": true,
-    "declarationMap": true,
+    "declaration": false,
+    "declarationMap": false,
     "sourceMap": true,
     "allowSyntheticDefaultImports": true,
     "outDir": "./dist",

--- a/webpack/webpack.config.cjs
+++ b/webpack/webpack.config.cjs
@@ -218,6 +218,9 @@ module.exports = function(env, argv) {
         {
           test: /\.ts$/,
           loader: 'ts-loader',
+          options: {
+            compilerOptions: dev ? { declaration: true, declarationMap: true } : {},
+          },
         },
         {
           test: /\.css$/,


### PR DESCRIPTION
Well in fact, I don't like this solution. But it is not very well to bundle `*.d.ts` and `*.map` in release and ship it to end users. So disable it, and enable in development.