### PR TITLE
various: Fixes in preparation for popup-text typescript conversion

### DIFF
--- a/resources/player_override.ts
+++ b/resources/player_override.ts
@@ -15,10 +15,10 @@ import Util from './util';
 // jobs remotely due to gauge data being local and many bits of information
 // loaded from memory.
 
-type PlayerChangedDetail = { detail: PlayerChangedRet };
+export type PlayerChangedDetail = { detail: PlayerChangedRet };
 type PlayerChangedFunc = (e: PlayerChangedDetail) => void;
 
-export const addPlayerChangedOverrideListener = (playerName: string,
+export const addPlayerChangedOverrideListener = (playerName: string | null,
     func: PlayerChangedFunc): void => {
   if (!func)
     return;

--- a/resources/player_override.ts
+++ b/resources/player_override.ts
@@ -18,6 +18,7 @@ import Util from './util';
 export type PlayerChangedDetail = { detail: PlayerChangedRet };
 type PlayerChangedFunc = (e: PlayerChangedDetail) => void;
 
+// @TODO: Swap the order of these arguments, make playerName optional instead
 export const addPlayerChangedOverrideListener = (playerName: string | null,
     func: PlayerChangedFunc): void => {
   if (!func)

--- a/resources/responses.ts
+++ b/resources/responses.ts
@@ -25,7 +25,7 @@ import Outputs from './outputs';
 
 type TargetedResponseOutput = ResponseOutput<Data, TargetedMatches>;
 type TargetedResponseFunc = ResponseFunc<Data, TargetedMatches>;
-type TargetedFunc = TriggerFunc<Data, TargetedMatches, TriggerOutput>;
+type TargetedFunc = TriggerFunc<Data, TargetedMatches, TriggerOutput<Data, TargetedMatches>>;
 type StaticResponseFunc = ResponseFunc<Data, unknown>;
 
 type Severity = 'info' | 'alert' | 'alarm';

--- a/resources/user_config.ts
+++ b/resources/user_config.ts
@@ -75,6 +75,10 @@ class UserConfig {
       ParserLanguage: 'en',
       ShortLocale: 'en',
       DisplayLanguage: 'en',
+      TextAlertsEnabled: true,
+      SoundAlertsEnabled: true,
+      SpokenAlertsEnabled: false,
+      GroupSpokenAlertsEnabled: false,
     };
   }
 

--- a/types/data.d.ts
+++ b/types/data.d.ts
@@ -6,6 +6,10 @@ export interface BaseOptions {
   ParserLanguage: Lang;
   ShortLocale: string;
   DisplayLanguage: Lang;
+  TextAlertsEnabled: boolean;
+  SoundAlertsEnabled: boolean;
+  SpokenAlertsEnabled: boolean;
+  GroupSpokenAlertsEnabled: boolean;
   Skin?: string;
   [key: string]: unknown;
   // todo: complete this type
@@ -16,7 +20,9 @@ export interface RaidbossData {
   me: string;
   role: Role;
   party: PartyTracker;
-  lang: string;
+  lang: Lang;
+  parserLang: Lang;
+  displayLang: Lang;
   currentHP: number;
   options: BaseOptions;
   ShortName: (x?: string) => string;

--- a/types/event.d.ts
+++ b/types/event.d.ts
@@ -263,6 +263,10 @@ export interface EventMap {
   // #endregion
 }
 
+export type EventResponses = {
+  [event in keyof EventMap]: Parameters<EventMap[event]>[0];
+};
+
 export type LogEvent = {
   type: 'onLogEvent';
   detail: {

--- a/types/manifest.d.ts
+++ b/types/manifest.d.ts
@@ -1,6 +1,6 @@
 declare module '*/raidboss_manifest.txt' {
   export interface RaidbossFileData {
-    [filename: string]: string;
+    [filename: string]: TriggerSet;
   }
   const raidbossFileData: RaidbossFileData;
   export default raidbossFileData;

--- a/types/trigger.d.ts
+++ b/types/trigger.d.ts
@@ -1,5 +1,5 @@
 import { Lang, NonEnLang } from '../resources/languages';
-import { Replacement } from '../ui/raidboss/timeline';
+import { TimelineReplacement, TimelineStyle } from '../ui/raidboss/timeline';
 import { RaidbossData } from './data';
 
 export interface BaseRegExp<T> extends RegExp {
@@ -135,8 +135,8 @@ export type TriggerSet<Data> = {
   timeline?: TimelineFunc;
   triggers?: NetRegexTrigger<Data>[];
   timelineTriggers?: TimelineTrigger<Data>[];
-  timelineReplace?: Replacement[];
-  timelineStyles?: Style[];
+  timelineReplace?: TimelineReplacement[];
+  timelineStyles?: TimelineStyle[];
 }
 
 // Less strict type for user triggers + built-in triggers, including deprecated fields.

--- a/types/trigger.d.ts
+++ b/types/trigger.d.ts
@@ -1,4 +1,5 @@
 import { Lang, NonEnLang } from '../resources/languages';
+import { Replacement } from '../ui/raidboss/timeline';
 import { RaidbossData } from './data';
 
 export interface BaseRegExp<T> extends RegExp {
@@ -37,8 +38,9 @@ export type Output = {
 };
 
 // The output of any non-response raidboss trigger function.
-export type TriggerOutput =
-    undefined | null | LocaleText | string | number | boolean | (() => TriggerOutput);
+export type TriggerOutput<Data, Matches> =
+    undefined | null | LocaleText | string | number | boolean |
+    ((d: Data, m: Matches, o: Output) => TriggerOutput<Data, Matches>);
 
 // The type of a non-response trigger field.
 export type TriggerFunc<Data, Matches, Return> =
@@ -49,7 +51,7 @@ type ResponseFields = 'infoText' | 'alertText' | 'alarmText' | 'tts';
 
 // The output from a response function (different from other TriggerOutput functions).
 export type ResponseOutput<Data, Matches> = {
-  [text in ResponseFields]?: TriggerFunc<Data, Matches, TriggerOutput>;
+  [text in ResponseFields]?: TriggerFunc<Data, Matches, TriggerOutput<Data, Matches>>;
 };
 // The type of a response trigger field.
 export type ResponseFunc<Data, Matches> =
@@ -62,6 +64,9 @@ export type TriggerAutoConfig = {
   Duration?: number;
   BeforeSeconds?: number;
   OutputStrings?: OutputStrings;
+  TextAlertsEnabled?: boolean;
+  SoundAlertsEnabled?: boolean;
+  SpokenAlertsEnabled?: boolean;
 }
 
 export type MatchesAny = { [s in T]?: string };
@@ -83,14 +88,14 @@ export type BaseTrigger<Data> = {
   delaySeconds?: TriggerField<Data, number>;
   durationSeconds?: TriggerField<Data, number>;
   suppressSeconds?: TriggerField<Data, number>;
-  promise?: TriggerField<Promise<Data, void>>;
+  promise?: TriggerField<Data, Promise<void>>;
   sound?: TriggerField<Data, string>;
   soundVolume?: TriggerField<Data, number>;
   response?: ResponseField<Data>;
-  alarmText?: TriggerField<Data, TriggerOutput>;
-  alertText?: TriggerField<Data, TriggerOutput>;
-  infoText?: TriggerField<Data, TriggerOutput>;
-  tts?: TriggerField<Data, TriggerOutput>;
+  alarmText?: TriggerField<Data, TriggerOutput<Data, MatchesAny>>;
+  alertText?: TriggerField<Data, TriggerOutput<Data, MatchesAny>>;
+  infoText?: TriggerField<Data, TriggerOutput<Data, MatchesAny>>;
+  tts?: TriggerField<Data, TriggerOutput<Data, MatchesAny>>;
   run?: TriggerField<Data, void>;
   outputStrings?: OutputStrings;
 }
@@ -130,12 +135,8 @@ export type TriggerSet<Data> = {
   timeline?: TimelineFunc;
   triggers?: NetRegexTrigger<Data>[];
   timelineTriggers?: TimelineTrigger<Data>[];
-  timelineReplace?: {
-    locale: Lang;
-    missingTranslations?: boolean;
-    replaceText?: { [regex: string]: string };
-    replaceSync?: { [regex: string]: string };
-  }[];
+  timelineReplace?: Replacement[];
+  timelineStyles?: Style[];
 }
 
 // Less strict type for user triggers + built-in triggers, including deprecated fields.

--- a/ui/raidboss/raidboss_options.ts
+++ b/ui/raidboss/raidboss_options.ts
@@ -14,11 +14,11 @@ export type PerTriggerOption = Partial<{
   GroupSpeechAlert: boolean; // TODO: we should remove this
   SoundOverride: string;
   VolumeOverride: number;
-  Condition?: TriggerField<RaidbossData, boolean>; // TODO: trigger condition function
-  InfoText: TriggerOutput<RaidbossData, MatchesAny>; // TODO: trigger function
-  AlertText: TriggerOutput<RaidbossData, MatchesAny>; // TODO: trigger function
-  AlarmText: TriggerOutput<RaidbossData, MatchesAny>; // TODO: trigger function
-  TTSText: TriggerOutput<RaidbossData, MatchesAny>; // TODO: trigger function
+  Condition: TriggerField<RaidbossData, boolean>;
+  InfoText: TriggerOutput<RaidbossData, MatchesAny>;
+  AlertText: TriggerOutput<RaidbossData, MatchesAny>;
+  AlarmText: TriggerOutput<RaidbossData, MatchesAny>;
+  TTSText: TriggerOutput<RaidbossData, MatchesAny>;
 }>;
 
 export type PerTriggerAutoConfig = { [triggerId: string]: TriggerAutoConfig };
@@ -36,7 +36,7 @@ type RaidbossNonConfigOptions = {
   DisabledTriggers: DisabledTriggers;
   PerTriggerAutoConfig: PerTriggerAutoConfig;
   PerTriggerOptions: PerTriggerOptions;
-  Triggers: LooseTrigger[]; // one giant TODO
+  Triggers: LooseTrigger[];
   PlayerNameOverride: string | null;
   IsRemoteRaidboss: boolean;
   // Transforms text before passing it to TTS.

--- a/ui/raidboss/raidboss_options.ts
+++ b/ui/raidboss/raidboss_options.ts
@@ -1,25 +1,29 @@
-import { BaseOptions } from '../../types/data';
+import { BaseOptions, RaidbossData } from '../../types/data';
 import UserConfig from '../../resources/user_config';
 import { Lang } from '../../resources/languages';
-import { TriggerAutoConfig } from '../../types/trigger';
+import { LooseTrigger, MatchesAny, TriggerAutoConfig, TriggerField, TriggerOutput } from '../../types/trigger';
 
 // This file defines the base options that raidboss expects to see.
 
 // Backwards compat for this old style of overriding triggers.
 // TODO: we should probably deprecate and remove this.
-type PerTriggerOption = Partial<{
+export type PerTriggerOption = Partial<{
   TextAlert: boolean;
   SoundAlert: boolean;
   SpeechAlert: boolean;
   GroupSpeechAlert: boolean; // TODO: we should remove this
   SoundOverride: string;
   VolumeOverride: number;
-  Condition: unknown; // TODO: trigger condition function
-  InfoText: unknown; // TODO: trigger function
-  AlertText: unknown; // TODO: trigger function
-  AlarmText: unknown; // TODO: trigger function
-  TTSText: unknown; // TODO: trigger function
+  Condition?: TriggerField<RaidbossData, boolean>; // TODO: trigger condition function
+  InfoText: TriggerOutput<RaidbossData, MatchesAny>; // TODO: trigger function
+  AlertText: TriggerOutput<RaidbossData, MatchesAny>; // TODO: trigger function
+  AlarmText: TriggerOutput<RaidbossData, MatchesAny>; // TODO: trigger function
+  TTSText: TriggerOutput<RaidbossData, MatchesAny>; // TODO: trigger function
 }>;
+
+export type PerTriggerAutoConfig = { [triggerId: string]: TriggerAutoConfig };
+export type PerTriggerOptions = { [triggerId: string]: PerTriggerOption };
+export type DisabledTriggers = { [triggerId: string]: boolean };
 
 type RaidbossNonConfigOptions = {
   PlayerNicks: { [gameName: string]: string };
@@ -29,10 +33,10 @@ type RaidbossNonConfigOptions = {
   LongSound: string;
   PullSound: string;
   AudioAllowed: boolean;
-  DisabledTriggers: { [triggerId: string]: boolean };
-  PerTriggerAutoConfig: { [triggerId: string]: TriggerAutoConfig };
-  PerTriggerOptions: { [triggerId: string]: PerTriggerOption };
-  Triggers: unknown; // one giant TODO
+  DisabledTriggers: DisabledTriggers;
+  PerTriggerAutoConfig: PerTriggerAutoConfig;
+  PerTriggerOptions: PerTriggerOptions;
+  Triggers: LooseTrigger[]; // one giant TODO
   PlayerNameOverride: string | null;
   IsRemoteRaidboss: boolean;
   // Transforms text before passing it to TTS.

--- a/ui/raidboss/timeline.ts
+++ b/ui/raidboss/timeline.ts
@@ -71,14 +71,14 @@ const activeText = {
   ko: '시전중:',
 };
 
-export type Replacement = {
+export type TimelineReplacement = {
   locale: string;
   missingTranslations?: boolean;
-  replaceSync?: { [key: string]: string };
-  replaceText?: { [key: string]: string };
+  replaceSync?: { [regexString: string]: string };
+  replaceText?: { [timelineText: string]: string };
 };
 
-type Style = {
+type TimelineStyle = {
   style: { [key: string]: string };
   regex: RegExp;
 }
@@ -154,7 +154,7 @@ export class Timeline {
   private options: RaidbossOptions;
   private perTriggerAutoConfig: { [triggerId: string]: TriggerAutoConfig };
   private activeText: string;
-  private replacements: Replacement[];
+  private replacements: TimelineReplacement[];
 
   private ignores: { [ignoreId: string]: boolean };
   public events: Event[];
@@ -183,8 +183,8 @@ export class Timeline {
 
   private updateTimer = 0;
 
-  constructor(text: string, replacements: Replacement[], triggers: LooseTimelineTrigger[],
-      styles: Style[], options: RaidbossOptions) {
+  constructor(text: string, replacements: TimelineReplacement[], triggers: LooseTimelineTrigger[],
+      styles: TimelineStyle[], options: RaidbossOptions) {
     this.options = options || {};
     this.perTriggerAutoConfig = this.options['PerTriggerAutoConfig'] || {};
     this.replacements = replacements;
@@ -270,7 +270,7 @@ export class Timeline {
     ].map((x) => Regexes.parse(x));
   }
 
-  private LoadFile(text: string, triggers: LooseTimelineTrigger[], styles: Style[]): void {
+  private LoadFile(text: string, triggers: LooseTimelineTrigger[], styles: TimelineStyle[]): void {
     this.events = [];
     this.syncStarts = [];
     this.syncEnds = [];
@@ -1154,7 +1154,8 @@ export class TimelineController {
   }
 
   public SetActiveTimeline(timelineFiles: string[], timelines: string[],
-      replacements: Replacement[], triggers: LooseTimelineTrigger[], styles: Style[]): void {
+      replacements: TimelineReplacement[], triggers: LooseTimelineTrigger[],
+      styles: TimelineStyle[]): void {
     this.activeTimeline = null;
 
     let text = '';
@@ -1186,8 +1187,9 @@ export class TimelineLoader {
     this.timelineController = timelineController;
   }
 
-  public SetTimelines(timelineFiles: string[], timelines: string[], replacements: Replacement[],
-      triggers: LooseTimelineTrigger[], styles: Style[]): void {
+  public SetTimelines(timelineFiles: string[], timelines: string[],
+      replacements: TimelineReplacement[], triggers: LooseTimelineTrigger[],
+      styles: TimelineStyle[]): void {
     this.timelineController.SetActiveTimeline(
         timelineFiles,
         timelines,

--- a/ui/raidboss/timeline.ts
+++ b/ui/raidboss/timeline.ts
@@ -7,6 +7,7 @@ import { Lang } from '../../resources/languages';
 import TimerBar from '../../resources/timerbar';
 import { LogEvent } from '../../types/event';
 import { LooseTimelineTrigger, TriggerAutoConfig } from '../../types/trigger';
+import { PopupTextGenerator } from './popup-text';
 
 const kBig = 1000000000; // Something bigger than any fight length in seconds.
 
@@ -70,10 +71,11 @@ const activeText = {
   ko: '시전중:',
 };
 
-type Replacement = {
+export type Replacement = {
   locale: string;
-  replaceSync: { [key: string]: string };
-  replaceText: { [key: string]: string };
+  missingTranslations?: boolean;
+  replaceSync?: { [key: string]: string };
+  replaceText?: { [key: string]: string };
 };
 
 type Style = {
@@ -217,9 +219,10 @@ export class Timeline {
     for (const r of this.replacements) {
       if (r.locale && r.locale !== replaceLang)
         continue;
-      if (!r[replaceKey])
+      const reps = r[replaceKey];
+      if (!reps)
         continue;
-      for (const [key, value] of Object.entries(r[replaceKey]))
+      for (const [key, value] of Object.entries(reps))
         text = text.replace(Regexes.parse(key), value);
     }
     // Common Replacements
@@ -832,14 +835,6 @@ export class Timeline {
   }
 }
 
-interface PopupText {
-  Info: PopupTextCallback;
-  Alert: PopupTextCallback;
-  Alarm: PopupTextCallback;
-  TTS: PopupTextCallback;
-  Trigger: TriggerCallback;
-}
-
 export class TimelineUI {
   private init: boolean;
   private lang: Lang;
@@ -857,7 +852,7 @@ export class TimelineUI {
 
   protected timeline: Timeline | null = null;
 
-  private popupText?: PopupText;
+  private popupText?: PopupTextGenerator;
 
   constructor(protected options: RaidbossOptions) {
     this.options = options;
@@ -924,7 +919,7 @@ export class TimelineUI {
       this.debugElement = document.createElement('div');
   }
 
-  public SetPopupTextInterface(popupText: PopupText): void {
+  public SetPopupTextInterface(popupText: PopupTextGenerator): void {
     this.popupText = popupText;
   }
 
@@ -1120,7 +1115,7 @@ export class TimelineController {
     this.wipeRegex = Regexes.network6d({ command: '40000010' });
   }
 
-  public SetPopupTextInterface(popupText: PopupText): void {
+  public SetPopupTextInterface(popupText: PopupTextGenerator): void {
     this.ui.SetPopupTextInterface(popupText);
   }
 

--- a/webpack/webpack.config.cjs
+++ b/webpack/webpack.config.cjs
@@ -286,6 +286,7 @@ module.exports = function(env, argv) {
     ],
     stats: {
       children: true,
+      errorDetails: true,
     },
   };
 };


### PR DESCRIPTION
A lot of miscellaneous adjustments I hit while converting popup-text to typescript.

These are fine to push to main before the actual popup-text conversion (which is also done), so I thought I should PR these separately so that the popup-text PR is smaller.

Tested these changes with raidemulator and in-game within overlayplugin overlay via raidboss. Didn't test jobs or the other overlays, since I'm not familiar with them, but they shouldn't have any problems?