### PR TITLE
eureka: fix Eureka fates not being marked red when on cooldown

### DIFF
--- a/ui/eureka/eureka.js
+++ b/ui/eureka/eureka.js
@@ -3229,6 +3229,9 @@ class EurekaTracker {
           this.TransByDispLang(this.options.timeStrings.minute);
         if (nm.timeElement.innerHTML !== nmString)
           nm.timeElement.innerHTML = nmString;
+
+        if (!this.zoneInfo.treatNMsAsSkirmishes)
+          nm.element.classList.add('nm-down');
       }
     }
   }


### PR DESCRIPTION
This `nm-down` line was removed in #2955 because it was marking every
skirmish, CE, and duel as `nm-down` incorrectly.  However, this was
important for Eureka.  So, just early out for Bozja.

There's probably a better solution here, but I'd like to not leave
this broken.

Fixes #3042.