### PR TITLE
raidboss: Allow partial TTS entries

### DIFF
--- a/docs/RaidbossGuide.md
+++ b/docs/RaidbossGuide.md
@@ -255,6 +255,27 @@ May be a string or a `function(data, matches, output)` that returns a string.
 **tts**
 An alternative text string for the chosen TTS option to use for callouts.
 This can be a localized object just like the text popups.
+If this is set, but there is no key matching your current language,
+Raidboss will default to the text from the text popups.
+
+For example, consider this configuration:
+
+```typescript
+{
+  ...
+  infoText: {
+    en: 'Tank Buster',
+    de: 'AoE',
+    fr: 'Cleave',
+  },
+  tts: {
+    de: 'Spread',
+  },
+}
+```
+
+If your language is `en`, you will receive the `Tank Buster` message.
+If your language is `de`, you will receive the `Spread` message.
 
 **run: function(data, matches, output)**
 If the trigger activates, the function will run as the last action before the trigger ends.

--- a/types/trigger.d.ts
+++ b/types/trigger.d.ts
@@ -42,6 +42,11 @@ export type TriggerOutput<Data, Matches> =
     undefined | null | LocaleText | string | number | boolean |
     ((d: Data, m: Matches, o: Output) => TriggerOutput<Data, Matches>);
 
+// Used if the function doesn't need to return an en key
+export type PartialTriggerOutput<Data, Matches> =
+    undefined | null | Partial<LocaleText> | string | number | boolean |
+    ((d: Data, m: Matches, o: Output) => PartialTriggerOutput<Data, Matches>);
+
 // The type of a non-response trigger field.
 export type TriggerFunc<Data, Matches, Return> =
     (data: Data, matches: Matches, output: Output) => Return;
@@ -95,7 +100,7 @@ export type BaseTrigger<Data> = {
   alarmText?: TriggerField<Data, TriggerOutput<Data, MatchesAny>>;
   alertText?: TriggerField<Data, TriggerOutput<Data, MatchesAny>>;
   infoText?: TriggerField<Data, TriggerOutput<Data, MatchesAny>>;
-  tts?: TriggerField<Data, TriggerOutput<Data, MatchesAny>>;
+  tts?: TriggerField<Data, PartialTriggerOutput<Data, MatchesAny>>;
   run?: TriggerField<Data, void>;
   outputStrings?: OutputStrings;
 }

--- a/types/trigger.d.ts
+++ b/types/trigger.d.ts
@@ -51,12 +51,12 @@ export type PartialTriggerOutput<Data, Matches> =
 export type TriggerFunc<Data, Matches, Return> =
     (data: Data, matches: Matches, output: Output) => Return;
 
-// Valid fields to return from a ResponseFunc.
-type ResponseFields = 'infoText' | 'alertText' | 'alarmText' | 'tts';
-
 // The output from a response function (different from other TriggerOutput functions).
 export type ResponseOutput<Data, Matches> = {
-  [text in ResponseFields]?: TriggerFunc<Data, Matches, TriggerOutput<Data, Matches>>;
+  infoText?: TriggerFunc<Data, Matches, TriggerOutput<Data, Matches>>;
+  alertText?: TriggerFunc<Data, Matches, TriggerOutput<Data, Matches>>;
+  alarmText?: TriggerFunc<Data, Matches, TriggerOutput<Data, Matches>>;
+  tts?: TriggerFunc<Data, Matches, PartialTriggerOutput<Data, Matches>>;
 };
 // The type of a response trigger field.
 export type ResponseFunc<Data, Matches> =

--- a/ui/raidboss/popup-text.ts
+++ b/ui/raidboss/popup-text.ts
@@ -10,7 +10,7 @@ import ZoneId from '../../resources/zone_id';
 import {
   LooseTrigger, OutputStrings, TriggerSet, TimelineFunc, LooseTriggerSet,
   ResponseField, TriggerAutoConfig, MatchesAny, TriggerField, TriggerOutput,
-  Output, ResponseOutput, NetRegexTrigger, RegexTrigger,
+  Output, ResponseOutput, NetRegexTrigger, RegexTrigger, PartialTriggerOutput,
 } from '../../types/trigger';
 import { UnreachableCode } from '../../resources/not_reached';
 import { Lang } from '../../resources/languages';
@@ -357,8 +357,10 @@ class TriggerOutputProxy {
 }
 
 export type RaidbossTriggerField =
-  TriggerField<RaidbossData, TriggerOutput<RaidbossData, MatchesAny>>;
-export type RaidbossTriggerOutput = TriggerOutput<RaidbossData, MatchesAny>;
+  TriggerField<RaidbossData, TriggerOutput<RaidbossData, MatchesAny>> |
+  TriggerField<RaidbossData, PartialTriggerOutput<RaidbossData, MatchesAny>>;
+export type RaidbossTriggerOutput = TriggerOutput<RaidbossData, MatchesAny> |
+  PartialTriggerOutput<RaidbossData, MatchesAny>;
 
 const defaultOutput = TriggerOutputProxy.makeOutput({}, 'en');
 
@@ -1152,9 +1154,8 @@ export class PopupText {
           result = triggerHelper.valueOrFunction(resp.tts);
       }
 
-      result ??= triggerHelper.defaultTTSText;
-
-      triggerHelper.ttsText = result?.toString();
+      if (result)
+        triggerHelper.ttsText = result?.toString();
     }
   }
 

--- a/ui/raidboss/popup-text.ts
+++ b/ui/raidboss/popup-text.ts
@@ -1156,6 +1156,8 @@ export class PopupText {
 
       if (result)
         triggerHelper.ttsText = result?.toString();
+      else
+        triggerHelper.ttsText = triggerHelper.defaultTTSText;
     }
   }
 

--- a/ui/raidboss/popup-text.ts
+++ b/ui/raidboss/popup-text.ts
@@ -1154,10 +1154,14 @@ export class PopupText {
           result = triggerHelper.valueOrFunction(resp.tts);
       }
 
-      if (result)
-        triggerHelper.ttsText = result?.toString();
-      else
+      // Allow false or null to disable tts entirely
+      // Undefined will fall back to defaultTTSText
+      if (result !== undefined) {
+        if (result)
+          triggerHelper.ttsText = result?.toString();
+      } else {
         triggerHelper.ttsText = triggerHelper.defaultTTSText;
+      }
     }
   }
 


### PR DESCRIPTION
Closes #3063 

Makes `trigger.tts` completely Partial, adjusts logic for tts to only set `triggerHelper.ttsText` if the value resolves.

If `triggerHelper.ttsText` is undefined, `_onTriggerInternalPlayAudio` will by default fall back to the audio alert.

There might need to be a new `Default alert output` option for `TTS w/ fallback to Sound`, since otherwise this state can't be encountered in normal operation anyways?