### PR TITLE
eureka: Complete names & enriched content for Save-The-Queen

### DIFF
--- a/ui/eureka/eureka.css
+++ b/ui/eureka/eureka.css
@@ -198,6 +198,12 @@
   display: none;
 }
 
+.nm-enriched {
+  display: block;
+  text-align: center;
+  color: #cfcfcf;
+}
+
 /* non-critical bozja fates are less important, so make smaller */
 .bozjasouthern > .nm,
 .zadnor > .nm {

--- a/ui/eureka/eureka.js
+++ b/ui/eureka/eureka.js
@@ -3614,9 +3614,9 @@ class EurekaTracker {
 
     // Enriched options for Save-The-Queen content
     // Adds field note drops, name, id & rarity of those
-    if (this.zoneInfo.treatNMsAsSkirmishes && this.options.EnrichedSTQ && nm.dropsFieldNotes) {
+    if (this.zoneInfo.treatNMsAsSkirmishes && this.options.EnrichedSTQ && nm.fieldNotes) {
       for (const note of fieldNotesList) {
-        if (note.id === nm.FieldNotes)
+        if (note.id === nm.fieldNotes)
           enriched.innerHTML = `#${note.id}: ${note.shortName} ${gRarityIcon.repeat(note.rarity)}`;
       }
     }

--- a/ui/eureka/eureka.js
+++ b/ui/eureka/eureka.js
@@ -1733,108 +1733,108 @@ const Options = {
       mapToPixelYScalar: 48.938,
       mapToPixelYConstant: -349.22,
       fieldNotes: [
-      	{
-      		id: 1,
-      		name: "Bajsaljen Ulgasch",
-      		shortname: "Bajsalen",
-      		rarity: 1,
-      	},
-      	{
-      		id: 2,
-      		name: "Marsak Apella",
-      		shortname: "Marsak",
-      		rarity: 1,
-      	},
-      	{
-      		id: 3,
-      		name: "Xeven Scanasch",
-      		shortname: "Xeven",
-      		rarity: 1,
-      	},
-      	{
-      		id: 4,
-      		name: "Isolde Covey",
-      		shortname: "Isolde",
-      		rarity: 2,
-      	},
-      	{
-      		id: 5,
-      		name: "Stanik Alubov",
-      		shortname: "Stanik",
-      		rarity: 1,
-      	},
-      	{
-      		id: 6,
-      		name: "Blaz Azetina",
-      		shortname: "Blaz",
-      		rarity: 3,
-      	},
-      	{
-      		id: 7,
-      		name: "Velibor Azetina",
-      		shortname: "Velibor",
-      		rarity: 3,
-      	},
-      	{
-      		id: 8,
-      		name: "Aggie Glover",
-      		shortname: "Aggie",
-      		rarity: 1,
-      	},
-      	{
-      		id: 9,
-      		name: "Llofii pyr Potitus",
-      		shortname: "Llofii",
-      		rarity: 2,
-      	},
         {
-      		id: 10,
-      		name: "Hernais pyr Longus",
-      		shortname: "Hernais",
-      		rarity: 3,
-      	},
-      	{
-      		id: 11,
-      		name: "Dabog aan Inivisch",
-      		shortname: "Dabog",
-      		rarity: 5,
-      	},
-      	{
-      		id: 12,
-      		name: "Dyunbu pyr Potitus",
-      		shortname: "Dyunbu",
-      		rarity: 4,
-      	},
-      	{
-      		id: 13,
-      		name: "Clarricie quo Priscus",
-      		shortname: "Clarricie",
-      		rarity: 2,
-      	},
-      	{
-      		id: 14,
-      		name: "Sartauvoir quo Soranus",
-      		shortname: "Sartauvoir",
-      		rarity: 5,
-      	},
-      	{
-      		id: 15,
-      		name: "Sicinius mal Vellutus",
-      		shortname: "Sicinius",
-      		rarity: 3,
-      	},
-      	{
-      		id: 16,
-      		name: "Sadr rem Albeleo",
-      		shortname: "Albeleo",
-      		rarity: 3,
-      	},
-      	{
-      		id: 17,
-      		name: "Lyon rem Helsos",
-      		shortname: "Lyon",
-      		rarity: 5,
-      	},
+          id: 1,
+          name: 'Bajsaljen Ulgasch',
+          shortName: 'Bajsalen',
+          rarity: 1,
+        },
+        {
+          id: 2,
+          name: 'Marsak Apella',
+          shortName: 'Marsak',
+          rarity: 1,
+        },
+        {
+          id: 3,
+          name: 'Xeven Scanasch',
+          shortName: 'Xeven',
+          rarity: 1,
+        },
+        {
+          id: 4,
+          name: 'Isolde Covey',
+          shortName: 'Isolde',
+          rarity: 2,
+        },
+        {
+          id: 5,
+          name: 'Stanik Alubov',
+          shortName: 'Stanik',
+          rarity: 1,
+        },
+        {
+          id: 6,
+          name: 'Blaz Azetina',
+          shortName: 'Blaz',
+          rarity: 3,
+        },
+        {
+          id: 7,
+          name: 'Velibor Azetina',
+          shortName: 'Velibor',
+          rarity: 3,
+        },
+        {
+          id: 8,
+          name: 'Aggie Glover',
+          shortName: 'Aggie',
+          rarity: 1,
+        },
+        {
+          id: 9,
+          name: 'Llofii pyr Potitus',
+          shortName: 'Llofii',
+          rarity: 2,
+        },
+        {
+          id: 10,
+          name: 'Hernais pyr Longus',
+          shortName: 'Hernais',
+          rarity: 3,
+        },
+        {
+          id: 11,
+          name: 'Dabog aan Inivisch',
+          shortName: 'Dabog',
+          rarity: 5,
+        },
+        {
+          id: 12,
+          name: 'Dyunbu pyr Potitus',
+          shortName: 'Dyunbu',
+          rarity: 4,
+        },
+        {
+          id: 13,
+          name: 'Clarricie quo Priscus',
+          shortName: 'Clarricie',
+          rarity: 2,
+        },
+        {
+          id: 14,
+          name: 'Sartauvoir quo Soranus',
+          shortName: 'Sartauvoir',
+          rarity: 5,
+        },
+        {
+          id: 15,
+          name: 'Sicinius mal Vellutus',
+          shortName: 'Sicinius',
+          rarity: 3,
+        },
+        {
+          id: 16,
+          name: 'Sadr rem Albeleo',
+          shortName: 'Albeleo',
+          rarity: 3,
+        },
+        {
+          id: 17,
+          name: 'Lyon rem Helsos',
+          shortName: 'Lyon',
+          rarity: 5,
+        },
       ],
       nms: {
         sneak: {
@@ -1848,8 +1848,8 @@ const Options = {
           },
           dropsFieldNotes: false,
           shortLabel: {
-          	en: 'Sneak',
-          	fr: 'Yeux',
+            en: 'Sneak',
+            fr: 'Yeux',
           },
           x: 20.3,
           y: 26.8,
@@ -1867,8 +1867,8 @@ const Options = {
           dropsFieldNotes: true,
           fieldNotes: 8,
           shortLabel: {
-          	en: 'Robots',
-          	fr: 'Araignées',
+            en: 'Robots',
+            fr: 'Araignées',
           },
           x: 24.8,
           y: 27.5,
@@ -1886,8 +1886,8 @@ const Options = {
           dropsFieldNotes: true,
           fieldNotes: 3,
           shortLabel: {
-          	en: 'Beasts',
-          	fr: 'Museler',
+            en: 'Beasts',
+            fr: 'Museler',
           },
           x: 20.3,
           y: 26.8,
@@ -1904,8 +1904,8 @@ const Options = {
           },
           dropsFieldNotes: false,
           shortLabel: {
-          	en: 'Unrest',
-          	fr: 'Pas de quartier',
+            en: 'Unrest',
+            fr: 'Pas de quartier',
           },
           x: 24.8,
           y: 27.5,
@@ -1924,8 +1924,8 @@ const Options = {
           dropsFieldNotes: true,
           fieldNotes: 1,
           shortLabel: {
-          	en: 'Machine',
-          	fr: 'Machine',
+            en: 'Machine',
+            fr: 'Machine',
           },
           x: 28.4,
           y: 29.3,
@@ -1943,8 +1943,8 @@ const Options = {
           dropsFieldNotes: true,
           fieldNotes: 5,
           shortLabel: {
-          	en: 'Plants',
-          	fr: 'Racines',
+            en: 'Plants',
+            fr: 'Racines',
           },
           x: 34.4,
           y: 29.3,
@@ -1961,8 +1961,8 @@ const Options = {
           },
           dropsFieldNotes: false,
           shortLabel: {
-          	en: 'Seeq',
-          	fr: 'Ménagerie',
+            en: 'Seeq',
+            fr: 'Ménagerie',
           },
           x: 28.9,
           y: 26.1,
@@ -1981,8 +1981,8 @@ const Options = {
           dropsFieldNotes: true,
           fieldNotes: 2,
           shortLabel: {
-          	en: 'Pets',
-          	fr: 'Plantes',
+            en: 'Pets',
+            fr: 'Plantes',
           },
           x: 17.3,
           y: 26.6,
@@ -2000,8 +2000,8 @@ const Options = {
           dropsFieldNotes: true,
           fieldNotes: 4,
           shortLabel: {
-          	en: 'First Law',
-          	fr: 'Numéros dix',
+            en: 'First Law',
+            fr: 'Numéros dix',
           },
           x: 34.4,
           y: 29.3,
@@ -2018,8 +2018,8 @@ const Options = {
           },
           dropsFieldNotes: false,
           shortLabel: {
-          	en: 'Heal',
-          	fr: 'Miséricorde',
+            en: 'Heal',
+            fr: 'Miséricorde',
           },
           x: 28.9,
           y: 26.1,
@@ -2037,8 +2037,8 @@ const Options = {
           dropsFieldNotes: true,
           fieldNotes: 10,
           shortLabel: {
-          	en: 'Mash',
-          	fr: 'Retour du chien',
+            en: 'Mash',
+            fr: 'Retour du chien',
           },
           x: 31.3,
           y: 22.0,
@@ -2056,8 +2056,8 @@ const Options = {
           isCEPrecursor: true,
           dropsFieldNotes: false,
           shortLabel: {
-          	en: 'Alert',
-          	fr: 'Chocobos',
+            en: 'Alert',
+            fr: 'Chocobos',
           },
           x: 27.3,
           y: 17.7,
@@ -2076,8 +2076,8 @@ const Options = {
           dropsFieldNotes: true,
           fieldNotes: 13,
           shortLabel: {
-          	en: 'Unicorn',
-          	fr: 'Licorne',
+            en: 'Unicorn',
+            fr: 'Licorne',
           },
           x: 32.3,
           y: 17.0,
@@ -2094,8 +2094,8 @@ const Options = {
           },
           dropsFieldNotes: false,
           shortLabel: {
-          	en: 'Recreation',
-          	fr: 'Innovation',
+            en: 'Recreation',
+            fr: 'Innovation',
           },
           x: 25.6,
           y: 22.6,
@@ -2112,8 +2112,8 @@ const Options = {
           },
           dropsFieldNotes: false,
           shortLabel: {
-          	en: 'Supplies',
-          	fr: 'Vivres',
+            en: 'Supplies',
+            fr: 'Vivres',
           },
           x: 17.5,
           y: 23.4,
@@ -2131,8 +2131,8 @@ const Options = {
           dropsFieldNotes: true,
           fieldNotes: 15,
           shortLabel: {
-          	en: 'Boots',
-          	fr: 'Force',
+            en: 'Boots',
+            fr: 'Force',
           },
           x: 31.3,
           y: 22.0,
@@ -2150,8 +2150,8 @@ const Options = {
           dropsFieldNotes: true,
           fieldNotes: 6,
           shortLabel: {
-          	en: 'Camping',
-          	fr: 'Idéaux',
+            en: 'Camping',
+            fr: 'Idéaux',
           },
           x: 17.5,
           y: 23.4,
@@ -2169,8 +2169,8 @@ const Options = {
           dropsFieldNotes: true,
           fieldNotes: 7,
           shortLabel: {
-          	en: 'Scavengers',
-          	fr: 'Dévoreurs',
+            en: 'Scavengers',
+            fr: 'Dévoreurs',
           },
           x: 25.6,
           y: 22.6,
@@ -2187,8 +2187,8 @@ const Options = {
           },
           dropsFieldNotes: false,
           shortLabel: {
-          	en: 'Help',
-          	fr: 'Résister',
+            en: 'Help',
+            fr: 'Résister',
           },
           x: 18.3,
           y: 20.7,
@@ -2206,8 +2206,8 @@ const Options = {
           dropsFieldNotes: true,
           fieldNotes: 7,
           shortLabel: {
-          	en: 'Pyromancer',
-          	fr: 'Brûlant',
+            en: 'Pyromancer',
+            fr: 'Brûlant',
           },
           x: 18.3,
           y: 20.7,
@@ -2225,8 +2225,8 @@ const Options = {
           dropsFieldNotes: true,
           fieldNotes: 13,
           shortLabel: {
-          	en: 'Rainbow',
-          	fr: 'Couleurs',
+            en: 'Rainbow',
+            fr: 'Couleurs',
           },
           x: 25.1,
           y: 15.0,
@@ -2243,8 +2243,8 @@ const Options = {
           },
           dropsFieldNotes: false,
           shortLabel: {
-          	en: 'Wild Bunch',
-          	fr: 'Sans maîtres',
+            en: 'Wild Bunch',
+            fr: 'Sans maîtres',
           },
           x: 21.0,
           y: 14.3,
@@ -2261,8 +2261,8 @@ const Options = {
           },
           dropsFieldNotes: false,
           shortLabel: {
-          	en: 'Family',
-          	fr: 'Incorruptible',
+            en: 'Family',
+            fr: 'Incorruptible',
           },
           x: 11.0,
           y: 14.6,
@@ -2280,8 +2280,8 @@ const Options = {
           isCEPrecursor: true,
           dropsFieldNotes: false,
           shortLabel: {
-          	en: 'Mechanical',
-          	fr: 'Plan B',
+            en: 'Mechanical',
+            fr: 'Plan B',
           },
           x: 20.8,
           y: 17.7,
@@ -2299,8 +2299,8 @@ const Options = {
           dropsFieldNotes: true,
           fieldNotes: 11,
           shortLabel: {
-          	en: 'Murder',
-          	fr: 'Des Machines',
+            en: 'Murder',
+            fr: 'Des Machines',
           },
           x: 14.0,
           y: 15.3,
@@ -2317,8 +2317,8 @@ const Options = {
           },
           dropsFieldNotes: false,
           shortLabel: {
-          	en: 'Seeking',
-          	fr: 'Creusent',
+            en: 'Seeking',
+            fr: 'Creusent',
           },
           x: 24.8,
           y: 17.1,
@@ -2336,8 +2336,8 @@ const Options = {
           dropsFieldNotes: true,
           fieldNotes: 5,
           shortLabel: {
-          	en: 'Supplies',
-          	fr: 'Casser',
+            en: 'Supplies',
+            fr: 'Casser',
           },
           x: 21.0,
           y: 14.3,
@@ -2354,8 +2354,8 @@ const Options = {
           },
           dropsFieldNotes: false,
           shortLabel: {
-          	en: 'Demonic',
-          	fr: 'Hémoglobine',
+            en: 'Demonic',
+            fr: 'Hémoglobine',
           },
           x: 11.1,
           y: 20.2,
@@ -2373,8 +2373,8 @@ const Options = {
           dropsFieldNotes: true,
           fieldNotes: 12,
           shortLabel: {
-          	en: 'Absent',
-          	fr: 'Vengeresse',
+            en: 'Absent',
+            fr: 'Vengeresse',
           },
           isCEPrecursor: true,
           x: 13.8,
@@ -2394,8 +2394,8 @@ const Options = {
           dropsFieldNotes: true,
           fieldNotes: 14,
           shortLabel: {
-          	en: 'Steel',
-          	fr: 'Fer & Feu',
+            en: 'Steel',
+            fr: 'Fer & Feu',
           },
           x: 13.8,
           y: 18.3,
@@ -2413,8 +2413,8 @@ const Options = {
           dropsFieldNotes: true,
           fieldNotes: 4,
           shortLabel: {
-          	en: 'Dogs',
-          	fr: 'Brigade',
+            en: 'Dogs',
+            fr: 'Brigade',
           },
           x: 14.0,
           y: 15.3,
@@ -2432,8 +2432,8 @@ const Options = {
           dropsFieldNotes: true,
           fieldNotes: 3,
           shortLabel: {
-          	en: 'War',
-          	fr: 'Cent Mille',
+            en: 'War',
+            fr: 'Cent Mille',
           },
           x: 11.1,
           y: 20.2,
@@ -2476,8 +2476,8 @@ const Options = {
           dropsFieldNotes: true,
           fieldNotes: 13,
           shortLabel: {
-          	en: 'Kill it',
-          	fr: 'Pestilence',
+            en: 'Kill it',
+            fr: 'Pestilence',
           },
           x: 17.4,
           y: 26.9,
@@ -2495,8 +2495,8 @@ const Options = {
           },
           dropsFieldNotes: false,
           shortLabel: {
-          	en: 'Hounds',
-          	fr: 'Chien',
+            en: 'Hounds',
+            fr: 'Chien',
           },
           x: 22.8,
           y: 28.8,
@@ -2514,8 +2514,8 @@ const Options = {
           },
           dropsFieldNotes: false,
           shortLabel: {
-          	en: 'Vigil',
-          	fr: 'Vigile',
+            en: 'Vigil',
+            fr: 'Vigile',
           },
           x: 28.4,
           y: 29.5,
@@ -2535,8 +2535,8 @@ const Options = {
           dropsFieldNotes: true,
           fieldNotes: 11,
           shortLabel: {
-          	en: 'Aces High',
-          	fr: 'Force divine',
+            en: 'Aces High',
+            fr: 'Force divine',
           },
           x: 32.3,
           y: 26.8,
@@ -2557,8 +2557,8 @@ const Options = {
           dropsFieldNotes: true,
           fieldNotes: 3,
           shortLabel: {
-          	en: 'Shadow',
-          	fr: 'Ailes noires',
+            en: 'Shadow',
+            fr: 'Ailes noires',
           },
           x: 36.5,
           y: 25.8,
@@ -2577,8 +2577,8 @@ const Options = {
           dropsFieldNotes: true,
           fieldNotes: 9,
           shortLabel: {
-          	en: 'Furlong',
-          	fr: 'Menace',
+            en: 'Furlong',
+            fr: 'Menace',
           },
           x: 33.3,
           y: 17.5,
@@ -2596,8 +2596,8 @@ const Options = {
           },
           dropsFieldNotes: false,
           shortLabel: {
-          	en: 'Choctober',
-          	fr: 'Ruée en Rouge',
+            en: 'Choctober',
+            fr: 'Ruée en Rouge',
           },
           x: 27.3,
           y: 17.7,
@@ -2617,8 +2617,8 @@ const Options = {
           dropsFieldNotes: true,
           fieldNotes: 17,
           shortLabel: {
-          	en: 'Beast of Man',
-          	fr: 'Roi Bestial',
+            en: 'Beast of Man',
+            fr: 'Roi Bestial',
           },
           x: 23.3,
           y: 20.4,
@@ -2638,8 +2638,8 @@ const Options = {
           },
           dropsFieldNotes: false,
           shortLabel: {
-          	en: 'Fires of War',
-          	fr: 'Brasier',
+            en: 'Fires of War',
+            fr: 'Brasier',
           },
           x: 20.8,
           y: 23.9,
@@ -2657,8 +2657,8 @@ const Options = {
           },
           dropsFieldNotes: false,
           shortLabel: {
-          	en: 'Patriot',
-          	fr: 'Patriote',
+            en: 'Patriot',
+            fr: 'Patriote',
           },
           x: 14.2,
           y: 21.2,
@@ -2676,8 +2676,8 @@ const Options = {
           },
           dropsFieldNotes: false,
           shortLabel: {
-          	en: 'Trampled',
-          	fr: 'Œil du malin',
+            en: 'Trampled',
+            fr: 'Œil du malin',
           },
           x: 9.9,
           y: 18.1,
@@ -2696,8 +2696,8 @@ const Options = {
           dropsFieldNotes: true,
           fieldNotes: 14,
           shortLabel: {
-          	en: 'Flames',
-          	fr: 'Phénix',
+            en: 'Flames',
+            fr: 'Phénix',
           },
           x: 18.8,
           y: 15.9,
@@ -2717,8 +2717,8 @@ const Options = {
           },
           dropsFieldNotes: false,
           shortLabel: {
-          	en: 'Metal Fox',
-          	fr: 'Guerrier de Métal',
+            en: 'Metal Fox',
+            fr: 'Guerrier de Métal',
           },
           x: 13.8,
           y: 18.3,
@@ -2738,8 +2738,8 @@ const Options = {
           dropsFieldNotes: true,
           fieldNotes: 15,
           shortLabel: {
-          	en: 'Rise',
-          	fr: 'Soulèvement',
+            en: 'Rise',
+            fr: 'Soulèvement',
           },
           x: 21.2,
           y: 17.6,
@@ -2757,8 +2757,8 @@ const Options = {
           },
           dropsFieldNotes: false,
           shortLabel: {
-          	en: 'Behemoth',
-          	fr: 'Mastodonte',
+            en: 'Behemoth',
+            fr: 'Mastodonte',
           },
           x: 24.2,
           y: 14.9,
@@ -2779,103 +2779,103 @@ const Options = {
       mapToPixelXConstant: 10.03,
       mapToPixelYScalar: 39.247,
       mapToPixelYConstant: -202.55,
-      fieldNotes:[
-      	{
-      		id: 31,
-      		name: "Atori Moribe",
-      		shortname: "Atori",
-      		rarity: 1,
-      	},
-      	{
-      		id: 32,
-      		name: "Kosyu",
-      		shortname: "Kosyu",
-      		rarity: 2,
-      	},
-      	{
-      		id: 33,
-      		name: "Oboro Torioi",
-      		shortname: "Oboro",
-      		rarity: 1,
-      	},
-      	{
-      		id: 34,
-      		name: "Tsubame",
-      		shortname: "Tsubame Oshidari",
-      		rarity: 3,
-      	},
-      	{
-      		id: 35,
-      		name: "Meryall Miller",
-      		shortname: "Meryall",
-      		rarity: 2,
-      	},
-      	{
-      		id: 36,
-      		name: "Lovro aan Slanasch",
-      		shortname: "Lovro",
-      		rarity: 3,
-      	},
-      	{
-      		id: 37,
-      		name: "Llofii pyr Potitus",
-      		shortname: "Llofii",
-      		rarity: 4,
-      	},
-      	{
-      		id: 38,
-      		name: "Fabineau quo Soranus",
-      		shortname: "Fabineau",
-      		rarity: 2,
-      	},
-      	{
-      		id: 39,
-      		name: "Yamatsumi pyr Urabe",
-      		shortname: "Yamatsumi",
-      		rarity: 3,
-      	},
-      	{
-      		id: 40,
-      		name: "Pagaga quo Vochstein",
-      		shortname: "Pagaga",
-      		rarity: 1,
-      	},
-      	{
-      		id: 41,
-      		name: "Daguza oen Sus",
-      		shortname: "Daguza",
-      		rarity: 1,
-      	},
-      	{
-      		id: 42,
-      		name: "Gilbrisbert quo Buteo",
-      		shortname: "Gilbrisbert",
-      		rarity: 2,
-      	},
-      	{
-      		id: 43,
-      		name: "Dabog aan Inivisch",
-      		shortname: "Dabog",
-      		rarity: 5,
-      	},
-      	{
-      		id: 44,
-      		name: "Lyon quo Helsos",
-      		shortname: "Lyon",
-      		rarity: 5,
-      	},
-      	{
-      		id: 45,
-      		name: "Menenius sas Lanatus",
-      		shortname: "Menenius",
-      		rarity: 5,
-      	},
-      	{
-      		id: 46,
-      		name: "Diablo",
-      		shortname: "Diablo",
-      		rarity: 3,
-      	},
+      fieldNotes: [
+        {
+          id: 31,
+          name: 'Atori Moribe',
+          shortName: 'Atori',
+          rarity: 1,
+        },
+        {
+          id: 32,
+          name: 'Kosyu',
+          shortName: 'Kosyu',
+          rarity: 2,
+        },
+        {
+          id: 33,
+          name: 'Oboro Torioi',
+          shortName: 'Oboro',
+          rarity: 1,
+        },
+        {
+          id: 34,
+          name: 'Tsubame',
+          shortName: 'Tsubame Oshidari',
+          rarity: 3,
+        },
+        {
+          id: 35,
+          name: 'Meryall Miller',
+          shortName: 'Meryall',
+          rarity: 2,
+        },
+        {
+          id: 36,
+          name: 'Lovro aan Slanasch',
+          shortName: 'Lovro',
+          rarity: 3,
+        },
+        {
+          id: 37,
+          name: 'Llofii pyr Potitus',
+          shortName: 'Llofii',
+          rarity: 4,
+        },
+        {
+          id: 38,
+          name: 'Fabineau quo Soranus',
+          shortName: 'Fabineau',
+          rarity: 2,
+        },
+        {
+          id: 39,
+          name: 'Yamatsumi pyr Urabe',
+          shortName: 'Yamatsumi',
+          rarity: 3,
+        },
+        {
+          id: 40,
+          name: 'Pagaga quo Vochstein',
+          shortName: 'Pagaga',
+          rarity: 1,
+        },
+        {
+          id: 41,
+          name: 'Daguza oen Sus',
+          shortName: 'Daguza',
+          rarity: 1,
+        },
+        {
+          id: 42,
+          name: 'Gilbrisbert quo Buteo',
+          shortName: 'Gilbrisbert',
+          rarity: 2,
+        },
+        {
+          id: 43,
+          name: 'Dabog aan Inivisch',
+          shortName: 'Dabog',
+          rarity: 5,
+        },
+        {
+          id: 44,
+          name: 'Lyon quo Helsos',
+          shortName: 'Lyon',
+          rarity: 5,
+        },
+        {
+          id: 45,
+          name: 'Menenius sas Lanatus',
+          shortName: 'Menenius',
+          rarity: 5,
+        },
+        {
+          id: 46,
+          name: 'Diablo',
+          shortName: 'Diablo',
+          rarity: 3,
+        },
       ],
       nms: {
         ofbeastsandbraggadocio: {
@@ -2887,8 +2887,8 @@ const Options = {
           dropsFieldNotes: true,
           fieldNotes: 31,
           shortLabel: {
-          	en: 'Beasts',
-          	fr: 'Dresseuse',
+            en: 'Beasts',
+            fr: 'Dresseuse',
           },
           x: 24.1,
           y: 37.4,
@@ -2903,8 +2903,8 @@ const Options = {
           dropsFieldNotes: true,
           fieldNotes: 33,
           shortLabel: {
-          	en: 'Parcel',
-          	fr: 'Astres',
+            en: 'Parcel',
+            fr: 'Astres',
           },
           x: 22.8,
           y: 34.2,
@@ -2920,8 +2920,8 @@ const Options = {
           dropsFieldNotes: true,
           fieldNotes: 37,
           shortLabel: {
-          	en: 'Dilemma',
-          	fr: 'Retrouvailles',
+            en: 'Dilemma',
+            fr: 'Retrouvailles',
           },
           x: 22.7,
           y: 34.2,
@@ -2935,8 +2935,8 @@ const Options = {
           },
           dropsFieldNotes: false,
           shortLabel: {
-          	en: 'Divination',
-          	fr: 'Prêtre',
+            en: 'Divination',
+            fr: 'Prêtre',
           },
           x: 24.8,
           y: 31.4,
@@ -2950,8 +2950,8 @@ const Options = {
           },
           dropsFieldNotes: false,
           shortLabel: {
-          	en: 'Wrench',
-          	fr: 'Ni vu ni connu',
+            en: 'Wrench',
+            fr: 'Ni vu ni connu',
           },
           x: 29.4,
           y: 35.4,
@@ -2966,8 +2966,8 @@ const Options = {
           isCEPrecursor: true,
           dropsFieldNotes: false,
           shortLabel: {
-          	en: 'Pilot',
-          	fr: 'Dabog',
+            en: 'Pilot',
+            fr: 'Dabog',
           },
           x: 28.0,
           y: 29.2,
@@ -2981,8 +2981,8 @@ const Options = {
           },
           dropsFieldNotes: false,
           shortLabel: {
-          	en: 'Ice',
-          	fr: 'Pique',
+            en: 'Ice',
+            fr: 'Pique',
           },
           x: 24.8,
           y: 31.1,
@@ -2997,8 +2997,8 @@ const Options = {
           dropsFieldNotes: true,
           fieldNotes: 42,
           shortLabel: {
-          	en: 'Puppet',
-          	fr: 'Ficelles',
+            en: 'Puppet',
+            fr: 'Ficelles',
           },
           x: 24.1,
           y: 37.4,
@@ -3013,8 +3013,8 @@ const Options = {
           dropsFieldNotes: true,
           fieldNotes: 40,
           shortLabel: {
-          	en: 'Challenge',
-          	fr: 'Problème',
+            en: 'Challenge',
+            fr: 'Problème',
           },
           x: 7.2,
           y: 28.8,
@@ -3028,8 +3028,8 @@ const Options = {
           },
           dropsFieldNotes: false,
           shortLabel: {
-          	en: 'T\'huban',
-          	fr: 'Dinosaure',
+            en: 'T\'huban',
+            fr: 'Dinosaure',
           },
           x: 8.6,
           y: 34.4,
@@ -3045,8 +3045,8 @@ const Options = {
           dropsFieldNotes: true,
           fieldNotes: 38,
           shortLabel: {
-          	en: 'Atrocities',
-          	fr: 'Le malsain',
+            en: 'Atrocities',
+            fr: 'Le malsain',
           },
           x: 4.9,
           y: 25.3,
@@ -3061,8 +3061,8 @@ const Options = {
           dropsFieldNotes: true,
           fieldNotes: 34,
           shortLabel: {
-          	en: 'Pursuit',
-          	fr: 'Recherché',
+            en: 'Pursuit',
+            fr: 'Recherché',
           },
           x: 11.6,
           y: 27.6,
@@ -3077,8 +3077,8 @@ const Options = {
           isCEPrecursor: true,
           dropsFieldNotes: false,
           shortLabel: {
-          	en: 'Tanking',
-          	fr: 'Se baisser',
+            en: 'Tanking',
+            fr: 'Se baisser',
           },
           x: 8.1,
           y: 24.0,
@@ -3093,8 +3093,8 @@ const Options = {
           dropsFieldNotes: true,
           fieldNotes: 43,
           shortLabel: {
-          	en: 'Supersoldier',
-          	fr: 'Guet-apens',
+            en: 'Supersoldier',
+            fr: 'Guet-apens',
           },
           x: 8.1,
           y: 24.0,
@@ -3109,8 +3109,8 @@ const Options = {
           dropsFieldNotes: true,
           fieldNotes: 36,
           shortLabel: {
-          	en: 'Demented',
-          	fr: 'Magie',
+            en: 'Demented',
+            fr: 'Magie',
           },
           x: 7.2,
           y: 28.8,
@@ -3125,8 +3125,8 @@ const Options = {
           dropsFieldNotes: true,
           fieldNotes: 32,
           shortLabel: {
-          	en: 'Sever',
-          	fr: 'Marionnettes',
+            en: 'Sever',
+            fr: 'Marionnettes',
           },
           x: 11.6,
           y: 27.6,
@@ -3141,8 +3141,8 @@ const Options = {
           isCEPrecursor: true,
           dropsFieldNotes: false,
           shortLabel: {
-          	en: 'Beasts',
-          	fr: 'Pagagaille',
+            en: 'Beasts',
+            fr: 'Pagagaille',
           },
           x: 25.4,
           y: 14.3,
@@ -3156,8 +3156,8 @@ const Options = {
           },
           dropsFieldNotes: false,
           shortLabel: {
-          	en: 'Still',
-          	fr: 'Sans défense',
+            en: 'Still',
+            fr: 'Sans défense',
           },
           x: 14.5,
           y: 10.4,
@@ -3172,8 +3172,8 @@ const Options = {
           dropsFieldNotes: true,
           fieldNotes: 41,
           shortLabel: {
-          	en: 'Seeq',
-          	fr: 'Non !',
+            en: 'Seeq',
+            fr: 'Non !',
           },
           x: 20.3,
           y: 16.5,
@@ -3188,8 +3188,8 @@ const Options = {
           dropsFieldNotes: true,
           fieldNotes: 39,
           shortLabel: {
-          	en: 'Mean',
-          	fr: 'Trésor',
+            en: 'Mean',
+            fr: 'Trésor',
           },
           x: 25.4,
           y: 14.3,
@@ -3204,8 +3204,8 @@ const Options = {
           dropsFieldNotes: true,
           fieldNotes: 32,
           shortLabel: {
-          	en: 'Relic',
-          	fr: 'Sans issue',
+            en: 'Relic',
+            fr: 'Sans issue',
           },
           x: 25.4,
           y: 14.3,
@@ -3219,8 +3219,8 @@ const Options = {
           },
           dropsFieldNotes: false,
           shortLabel: {
-          	en: 'Mages',
-          	fr: 'Cailloux',
+            en: 'Mages',
+            fr: 'Cailloux',
           },
           x: 20.3,
           y: 16.5,
@@ -3236,8 +3236,8 @@ const Options = {
           dropsFieldNotes: true,
           fieldNotes: 43,
           shortLabel: {
-          	en: 'Hyper',
-          	fr: 'Opportunité',
+            en: 'Hyper',
+            fr: 'Opportunité',
           },
           x: 16.6,
           y: 16.8,
@@ -3253,8 +3253,8 @@ const Options = {
           dropsFieldNotes: true,
           fieldNotes: 35,
           shortLabel: {
-          	en: 'Supersoldiers',
-          	fr: 'Plus d\'un',
+            en: 'Supersoldiers',
+            fr: 'Plus d\'un',
           },
           x: 16.6,
           y: 16.8,
@@ -3269,8 +3269,8 @@ const Options = {
           dropsFieldNotes: true,
           fieldNotes: 36,
           shortLabel: {
-          	en: 'Student',
-          	fr: 'Élève',
+            en: 'Student',
+            fr: 'Élève',
           },
           x: 14.5,
           y: 10.4,
@@ -3284,8 +3284,8 @@ const Options = {
           },
           dropsFieldNotes: false,
           shortLabel: {
-          	en: 'Machines',
-          	fr: 'En série',
+            en: 'Machines',
+            fr: 'En série',
           },
           x: 12.1,
           y: 13.6,
@@ -3299,8 +3299,8 @@ const Options = {
           },
           dropsFieldNotes: false,
           shortLabel: {
-          	en: 'Dalriada',
-          	fr: 'Dal\'riada',
+            en: 'Dalriada',
+            fr: 'Dal\'riada',
           },
           x: 25.9,
           y: 8.2,
@@ -3317,8 +3317,8 @@ const Options = {
           },
           dropsFieldNotes: false,
           shortLabel: {
-          	en: 'Serpents',
-          	fr: 'Zirnitrop',
+            en: 'Serpents',
+            fr: 'Zirnitrop',
           },
           x: 31.4,
           y: 37.4,
@@ -3334,8 +3334,8 @@ const Options = {
           dropsFieldNotes: true,
           fieldNotes: 35,
           shortLabel: {
-          	en: 'Burn',
-          	fr: 'Progrès',
+            en: 'Burn',
+            fr: 'Progrès',
           },
           x: 16.6,
           y: 16.8,
@@ -3352,8 +3352,8 @@ const Options = {
           dropsFieldNotes: true,
           fieldNotes: 43,
           shortLabel: {
-          	en: 'Blade',
-          	fr: 'Dabog',
+            en: 'Blade',
+            fr: 'Dabog',
           },
           x: 26.5,
           y: 35.6,
@@ -3371,8 +3371,8 @@ const Options = {
           dropsFieldNotes: true,
           fieldNotes: 37,
           shortLabel: {
-          	en: 'Grave',
-          	fr: 'Sycophante',
+            en: 'Grave',
+            fr: 'Sycophante',
           },
           x: 20.2,
           y: 37.4,
@@ -3387,8 +3387,8 @@ const Options = {
           },
           dropsFieldNotes: true,
           shortLabel: {
-          	en: 'Diremite',
-          	fr: 'Ma nature',
+            en: 'Diremite',
+            fr: 'Ma nature',
           },
           x: 17.0,
           y: 32.1,
@@ -3403,8 +3403,8 @@ const Options = {
           },
           dropsFieldNotes: false,
           shortLabel: {
-          	en: 'Cavalry',
-          	fr: 'Cavalier',
+            en: 'Cavalry',
+            fr: 'Cavalier',
           },
           x: 6.4,
           y: 37.2,
@@ -3420,8 +3420,8 @@ const Options = {
           dropsFieldNotes: true,
           fieldNotes: 45,
           shortLabel: {
-          	en: 'Snake',
-          	fr: 'Par l\'exemple',
+            en: 'Snake',
+            fr: 'Par l\'exemple',
           },
           x: 5.3,
           y: 31.9,
@@ -3438,8 +3438,8 @@ const Options = {
           },
           dropsFieldNotes: false,
           shortLabel: {
-          	en: 'Blood',
-          	fr: 'Cendres',
+            en: 'Blood',
+            fr: 'Cendres',
           },
           x: 13.7,
           y: 26.0,
@@ -3454,8 +3454,8 @@ const Options = {
           },
           dropsFieldNotes: false,
           shortLabel: {
-          	en: 'Wolf',
-          	fr: 'Hród\'vnir',
+            en: 'Wolf',
+            fr: 'Hród\'vnir',
           },
           x: 4.9,
           y: 25.3,
@@ -3471,8 +3471,8 @@ const Options = {
           },
           dropsFieldNotes: false,
           shortLabel: {
-          	en: 'Time',
-          	fr: 'Titan',
+            en: 'Time',
+            fr: 'Titan',
           },
           x: 10.5,
           y: 21.5,
@@ -3487,8 +3487,8 @@ const Options = {
           },
           dropsFieldNotes: false,
           shortLabel: {
-          	en: 'Lean, Mean',
-          	fr: 'Réusinage',
+            en: 'Lean, Mean',
+            fr: 'Réusinage',
           },
           x: 15.2,
           y: 13.0,
@@ -3503,8 +3503,8 @@ const Options = {
           },
           dropsFieldNotes: false,
           shortLabel: {
-          	en: 'Shadow',
-          	fr: 'Oiseau',
+            en: 'Shadow',
+            fr: 'Oiseau',
           },
           x: 11.8,
           y: 7.6,
@@ -3519,8 +3519,8 @@ const Options = {
           },
           dropsFieldNotes: false,
           shortLabel: {
-          	en: 'Familiar',
-          	fr: 'Ordonnateur',
+            en: 'Familiar',
+            fr: 'Ordonnateur',
           },
           x: 28.0,
           y: 29.2,
@@ -3536,8 +3536,8 @@ const Options = {
           },
           dropsFieldNotes: false,
           shortLabel: {
-          	en: 'Looks',
-          	fr: 'Écaillage',
+            en: 'Looks',
+            fr: 'Écaillage',
           },
           x: 17.4,
           y: 9.8,
@@ -3553,8 +3553,8 @@ const Options = {
           dropsFieldNotes: true,
           fieldNotes: 44,
           shortLabel: {
-          	en: 'Lyon\'s',
-          	fr: 'Lyon',
+            en: 'Lyon\'s',
+            fr: 'Lyon',
           },
           x: 22.5,
           y: 13.2,
@@ -3679,15 +3679,14 @@ class EurekaTracker {
     // Short labels only exist for Save-The-Queen content
     // Changes names' length depending on users options
     // If no strings are available, the english short ones will be the default ones
-    if(this.zoneInfo.treatNMsAsSkirmishes)
-    {
-        if (this.options.CompleteNamesSTQ)
-            name.innerText = this.TransByDispLang(nm.label);
-        if(!name.innerText)
-            name.innerText = this.TransByDispLang(nm.shortLabel);
-    }
-    else
+    if (this.zoneInfo.treatNMsAsSkirmishes) {
+      if (this.options.CompleteNamesSTQ)
         name.innerText = this.TransByDispLang(nm.label);
+      if (!name.innerText)
+        name.innerText = this.TransByDispLang(nm.shortLabel);
+    } else {
+      name.innerText = this.TransByDispLang(nm.label);
+    }
 
     const progress = document.createElement('span');
     progress.innerText = '';
@@ -3705,22 +3704,21 @@ class EurekaTracker {
 
     // Enriched options for Save-The-Queen content
     // Adds field note drops, name, id & rarity of those
-    if(this.zoneInfo.treatNMsAsSkirmishes && this.options.EnrichedSTQ && nm.dropsFieldNotes) {
-        for (var i=0; i < Object.keys(fieldNotesList).length; i++) {
-            if (fieldNotesList[i].id === nm.fieldNotes) {
-                enriched.innerText = ("#" + fieldNotesList[i].id + " : " + fieldNotesList[i].shortname + " - ");
-                for (var i2 = 0; i2 != fieldNotesList[i].rarity; i2++) {
-                    enriched.innerText += (gRarityIcon);
-                }
-            }
+    if (this.zoneInfo.treatNMsAsSkirmishes && this.options.EnrichedSTQ && nm.dropsFieldNotes) {
+      for (let i = 0; i < Object.keys(fieldNotesList).length; i++) {
+        if (fieldNotesList[i].id === nm.fieldNotes) {
+          enriched.innerText = ('#' + fieldNotesList[i].id + ' : ' + fieldNotesList[i].shortName + ' - ');
+          for (let i2 = 0; i2 !== fieldNotesList[i].rarity; i2++)
+            enriched.innerHTML += (gRarityIcon);
         }
+      }
     }
 
     label.appendChild(icon);
     label.appendChild(name);
     // We don't need an extra empty span if not in Bozja or if user doesn't need it
     if (this.options.EnrichedSTQ && this.zoneInfo.treatNMsAsSkirmishes)
-        label.appendChild(enriched);
+      label.appendChild(enriched);
     label.appendChild(progress);
     label.appendChild(time);
     container.appendChild(label);
@@ -3834,12 +3832,12 @@ class EurekaTracker {
         this.PlaySound(this.options.BunnyPopSound, this.options.BunnyPopVolume);
     } else if (fate.isCritical) {
       const shouldPlay = fate.isDuelPrecursor && this.options.PopNoiseForDuel ||
-          this.options.PopNoiseForCriticalEngagement;
+        this.options.PopNoiseForCriticalEngagement;
       if (shouldPlay && this.options.CriticalPopSound && this.options.CriticalPopVolume)
         this.PlaySound(this.options.CriticalPopSound, this.options.CriticalPopVolume);
     } else {
       const shouldPlay = this.zoneInfo.treatNMsAsSkirmishes && this.options.PopNoiseForSkirmish ||
-          !this.zoneInfo.treatNMsAsSkirmishes && this.options.PopNoiseForNM;
+        !this.zoneInfo.treatNMsAsSkirmishes && this.options.PopNoiseForNM;
       if (shouldPlay && this.options.PopSound && this.options.PopVolume)
         this.PlaySound(this.options.PopSound, this.options.PopVolume);
     }

--- a/ui/eureka/eureka.js
+++ b/ui/eureka/eureka.js
@@ -3827,12 +3827,12 @@ class EurekaTracker {
         this.PlaySound(this.options.BunnyPopSound, this.options.BunnyPopVolume);
     } else if (fate.isCritical) {
       const shouldPlay = fate.isDuelPrecursor && this.options.PopNoiseForDuel ||
-        this.options.PopNoiseForCriticalEngagement;
+          this.options.PopNoiseForCriticalEngagement;
       if (shouldPlay && this.options.CriticalPopSound && this.options.CriticalPopVolume)
         this.PlaySound(this.options.CriticalPopSound, this.options.CriticalPopVolume);
     } else {
       const shouldPlay = this.zoneInfo.treatNMsAsSkirmishes && this.options.PopNoiseForSkirmish ||
-        !this.zoneInfo.treatNMsAsSkirmishes && this.options.PopNoiseForNM;
+          !this.zoneInfo.treatNMsAsSkirmishes && this.options.PopNoiseForNM;
       if (shouldPlay && this.options.PopSound && this.options.PopVolume)
         this.PlaySound(this.options.PopSound, this.options.PopVolume);
     }

--- a/ui/eureka/eureka.js
+++ b/ui/eureka/eureka.js
@@ -1846,7 +1846,6 @@ const Options = {
             cn: '遭遇术师大队',
             ko: '술사대대 발견',
           },
-          dropsFieldNotes: false,
           shortLabel: {
             en: 'Sneak',
             fr: 'Yeux',
@@ -1864,7 +1863,6 @@ const Options = {
             cn: '遭遇无人魔导兵器',
             ko: '무인 마도 병기 발견',
           },
-          dropsFieldNotes: true,
           fieldNotes: 8,
           shortLabel: {
             en: 'Robots',
@@ -1883,7 +1881,6 @@ const Options = {
             cn: '发现忠犬',
             ko: '충견과 조우하다',
           },
-          dropsFieldNotes: true,
           fieldNotes: 3,
           shortLabel: {
             en: 'Beasts',
@@ -1902,7 +1899,6 @@ const Options = {
             cn: '奇袭术师大队',
             ko: '술사대대 기습',
           },
-          dropsFieldNotes: false,
           shortLabel: {
             en: 'Unrest',
             fr: 'Pas de quartier',
@@ -1921,7 +1917,6 @@ const Options = {
             ko: '유인 마도 병기 요격',
           },
           isCEPrecursor: true,
-          dropsFieldNotes: true,
           fieldNotes: 1,
           shortLabel: {
             en: 'Machine',
@@ -1940,7 +1935,6 @@ const Options = {
             cn: '排除野生生物',
             ko: '야생 생물을 제거하라',
           },
-          dropsFieldNotes: true,
           fieldNotes: 5,
           shortLabel: {
             en: 'Plants',
@@ -1959,7 +1953,6 @@ const Options = {
             cn: '兽性兽心的驯兽师',
             ko: '시크족 마수 조련사',
           },
-          dropsFieldNotes: false,
           shortLabel: {
             en: 'Seeq',
             fr: 'Ménagerie',
@@ -1978,7 +1971,6 @@ const Options = {
             ko: '화려한 희귀마수 조련사',
           },
           isCEPrecursor: true,
-          dropsFieldNotes: true,
           fieldNotes: 2,
           shortLabel: {
             en: 'Pets',
@@ -1997,7 +1989,6 @@ const Options = {
             cn: '破坏劳动十号',
             ko: '노동 10호 파괴 명령',
           },
-          dropsFieldNotes: true,
           fieldNotes: 4,
           shortLabel: {
             en: 'First Law',
@@ -2016,7 +2007,6 @@ const Options = {
             cn: '施恩布德的术师队',
             ko: '은덕의 술사들',
           },
-          dropsFieldNotes: false,
           shortLabel: {
             en: 'Heal',
             fr: 'Miséricorde',
@@ -2034,7 +2024,6 @@ const Options = {
             cn: '忠犬的逆袭',
             ko: '충견의 역습',
           },
-          dropsFieldNotes: true,
           fieldNotes: 10,
           shortLabel: {
             en: 'Mash',
@@ -2054,7 +2043,6 @@ const Options = {
             ko: '시크족과 붉은 초코보',
           },
           isCEPrecursor: true,
-          dropsFieldNotes: false,
           shortLabel: {
             en: 'Alert',
             fr: 'Chocobos',
@@ -2073,7 +2061,6 @@ const Options = {
             ko: '결백한 탈주병',
           },
           isCEPrecursor: true,
-          dropsFieldNotes: true,
           fieldNotes: 13,
           shortLabel: {
             en: 'Unicorn',
@@ -2092,7 +2079,6 @@ const Options = {
             cn: '调查敌方新兵器',
             ko: '적의 신병기를 조사하라',
           },
-          dropsFieldNotes: false,
           shortLabel: {
             en: 'Recreation',
             fr: 'Innovation',
@@ -2110,7 +2096,6 @@ const Options = {
             cn: '奇袭整备场',
             ko: '정비소 기습 작전',
           },
-          dropsFieldNotes: false,
           shortLabel: {
             en: 'Supplies',
             fr: 'Vivres',
@@ -2128,7 +2113,6 @@ const Options = {
             cn: '破坏魔导劳工',
             ko: '마도 노동자 파괴 명령',
           },
-          dropsFieldNotes: true,
           fieldNotes: 15,
           shortLabel: {
             en: 'Boots',
@@ -2147,7 +2131,6 @@ const Options = {
             cn: '进攻野营地',
             ko: '야영지 선제 공격',
           },
-          dropsFieldNotes: true,
           fieldNotes: 6,
           shortLabel: {
             en: 'Camping',
@@ -2166,7 +2149,6 @@ const Options = {
             cn: '噬魂的妖异',
             ko: '혼을 먹는 요마들',
           },
-          dropsFieldNotes: true,
           fieldNotes: 7,
           shortLabel: {
             en: 'Scavengers',
@@ -2185,7 +2167,6 @@ const Options = {
             cn: '术师大队的猛攻',
             ko: '술사대대의 맹공격',
           },
-          dropsFieldNotes: false,
           shortLabel: {
             en: 'Help',
             fr: 'Résister',
@@ -2203,7 +2184,6 @@ const Options = {
             cn: '最强的火焰法师',
             ko: '최강의 불꽃술사',
           },
-          dropsFieldNotes: true,
           fieldNotes: 7,
           shortLabel: {
             en: 'Pyromancer',
@@ -2222,7 +2202,6 @@ const Options = {
             cn: '华丽魔女与心爱珍兽',
             ko: '화려한 애완마수',
           },
-          dropsFieldNotes: true,
           fieldNotes: 13,
           shortLabel: {
             en: 'Rainbow',
@@ -2241,7 +2220,6 @@ const Options = {
             cn: '排除失控魔兽',
             ko: '폭주 마수 처리',
           },
-          dropsFieldNotes: false,
           shortLabel: {
             en: 'Wild Bunch',
             fr: 'Sans maîtres',
@@ -2259,7 +2237,6 @@ const Options = {
             cn: '兽性兽心的劝诱',
             ko: '포섭하는 시크족',
           },
-          dropsFieldNotes: false,
           shortLabel: {
             en: 'Family',
             fr: 'Incorruptible',
@@ -2278,7 +2255,6 @@ const Options = {
             ko: '마도 노동자 B형 파괴 명령',
           },
           isCEPrecursor: true,
-          dropsFieldNotes: false,
           shortLabel: {
             en: 'Mechanical',
             fr: 'Plan B',
@@ -2296,7 +2272,6 @@ const Options = {
             cn: '袭击强化兵部队',
             ko: '강화병 부대의 습격',
           },
-          dropsFieldNotes: true,
           fieldNotes: 11,
           shortLabel: {
             en: 'Murder',
@@ -2315,7 +2290,6 @@ const Options = {
             cn: '战场的偷盗者',
             ko: '전장의 도굴자',
           },
-          dropsFieldNotes: false,
           shortLabel: {
             en: 'Seeking',
             fr: 'Creusent',
@@ -2333,7 +2307,6 @@ const Options = {
             cn: '补给物资夺取战',
             ko: '보급 물자 강탈 작전',
           },
-          dropsFieldNotes: true,
           fieldNotes: 5,
           shortLabel: {
             en: 'Supplies',
@@ -2352,7 +2325,6 @@ const Options = {
             cn: '闻血而来',
             ko: '피비린내에 이끌려',
           },
-          dropsFieldNotes: false,
           shortLabel: {
             en: 'Demonic',
             fr: 'Hémoglobine',
@@ -2370,7 +2342,6 @@ const Options = {
             cn: '南方战线的激战',
             ko: '타오르는 남부 전선',
           },
-          dropsFieldNotes: true,
           fieldNotes: 12,
           shortLabel: {
             en: 'Absent',
@@ -2391,7 +2362,6 @@ const Options = {
             ko: '타오르는 남부 전선 속편',
           },
           isCEPrecursor: true,
-          dropsFieldNotes: true,
           fieldNotes: 14,
           shortLabel: {
             en: 'Steel',
@@ -2410,7 +2380,6 @@ const Options = {
             cn: '释放战场之犬',
             ko: '전장에 개를 풀어라',
           },
-          dropsFieldNotes: true,
           fieldNotes: 4,
           shortLabel: {
             en: 'Dogs',
@@ -2429,7 +2398,6 @@ const Options = {
             cn: '西西尼乌斯的实验场',
             ko: '시시니우스의 실험장',
           },
-          dropsFieldNotes: true,
           fieldNotes: 3,
           shortLabel: {
             en: 'War',
@@ -2448,7 +2416,6 @@ const Options = {
             cn: '湖岸堡',
             ko: '공성전',
           },
-          dropsFieldNotes: false,
           shortLabel: {
             en: 'Castrum',
             de: 'Castrum',
@@ -2473,7 +2440,6 @@ const Options = {
             cn: '皮里福尔',
             ko: '피어리풀',
           },
-          dropsFieldNotes: true,
           fieldNotes: 13,
           shortLabel: {
             en: 'Kill it',
@@ -2493,7 +2459,6 @@ const Options = {
             cn: '恐惧妖犬',
             ko: '카니스 디루스',
           },
-          dropsFieldNotes: false,
           shortLabel: {
             en: 'Hounds',
             fr: 'Chien',
@@ -2512,7 +2477,6 @@ const Options = {
             cn: '守夜',
             ko: '비질',
           },
-          dropsFieldNotes: false,
           shortLabel: {
             en: 'Vigil',
             fr: 'Vigile',
@@ -2532,7 +2496,6 @@ const Options = {
             cn: '加百列',
             ko: '가브리엘',
           },
-          dropsFieldNotes: true,
           fieldNotes: 11,
           shortLabel: {
             en: 'Aces High',
@@ -2554,7 +2517,6 @@ const Options = {
             cn: '阿库巴巴',
             ko: '아크바바',
           },
-          dropsFieldNotes: true,
           fieldNotes: 3,
           shortLabel: {
             en: 'Shadow',
@@ -2574,7 +2536,6 @@ const Options = {
             cn: '地生人',
             ko: '스파르토이',
           },
-          dropsFieldNotes: true,
           fieldNotes: 9,
           shortLabel: {
             en: 'Furlong',
@@ -2594,7 +2555,6 @@ const Options = {
             cn: '红色彗星',
             ko: '붉은 혜성',
           },
-          dropsFieldNotes: false,
           shortLabel: {
             en: 'Choctober',
             fr: 'Ruée en Rouge',
@@ -2614,7 +2574,6 @@ const Options = {
             cn: '兽王莱昂',
             ko: '마수왕 라이언',
           },
-          dropsFieldNotes: true,
           fieldNotes: 17,
           shortLabel: {
             en: 'Beast of Man',
@@ -2636,7 +2595,6 @@ const Options = {
             cn: '火焰百夫队',
             ko: '화염백인대',
           },
-          dropsFieldNotes: false,
           shortLabel: {
             en: 'Fires of War',
             fr: 'Brasier',
@@ -2655,7 +2613,6 @@ const Options = {
             cn: '爱国者',
             ko: '패트리어트',
           },
-          dropsFieldNotes: false,
           shortLabel: {
             en: 'Patriot',
             fr: 'Patriote',
@@ -2674,7 +2631,6 @@ const Options = {
             cn: '耶鲁',
             ko: '에알레',
           },
-          dropsFieldNotes: false,
           shortLabel: {
             en: 'Trampled',
             fr: 'Œil du malin',
@@ -2693,7 +2649,6 @@ const Options = {
             cn: '萨托瓦尔',
             ko: '사르토부아르',
           },
-          dropsFieldNotes: true,
           fieldNotes: 14,
           shortLabel: {
             en: 'Flames',
@@ -2715,7 +2670,6 @@ const Options = {
             cn: '达因斯莱瓦',
             ko: '다인슬라이프',
           },
-          dropsFieldNotes: false,
           shortLabel: {
             en: 'Metal Fox',
             fr: 'Guerrier de Métal',
@@ -2735,7 +2689,6 @@ const Options = {
             cn: '魔导劳工X式',
             ko: '마도 노동자 X형',
           },
-          dropsFieldNotes: true,
           fieldNotes: 15,
           shortLabel: {
             en: 'Rise',
@@ -2755,7 +2708,6 @@ const Options = {
             cn: '奇尔维尼克',
             ko: '칠레브니크',
           },
-          dropsFieldNotes: false,
           shortLabel: {
             en: 'Behemoth',
             fr: 'Mastodonte',
@@ -2884,7 +2836,6 @@ const Options = {
             de: 'Bestienbändigerin',
             fr: 'Un jour, je serai la meilleure dresseuse',
           },
-          dropsFieldNotes: true,
           fieldNotes: 31,
           shortLabel: {
             en: 'Beasts',
@@ -2900,7 +2851,6 @@ const Options = {
             de: 'Oboro',
             fr: 'Les astres du jour et de la nuit',
           },
-          dropsFieldNotes: true,
           fieldNotes: 33,
           shortLabel: {
             en: 'Parcel',
@@ -2917,7 +2867,6 @@ const Options = {
             fr: 'Malheureuses retrouvailles',
           },
           isCEPrecursor: true,
-          dropsFieldNotes: true,
           fieldNotes: 37,
           shortLabel: {
             en: 'Dilemma',
@@ -2933,7 +2882,6 @@ const Options = {
             de: 'Mörderischer Onmyoji',
             fr: 'Prêtre pernicieux',
           },
-          dropsFieldNotes: false,
           shortLabel: {
             en: 'Divination',
             fr: 'Prêtre',
@@ -2948,7 +2896,6 @@ const Options = {
             de: 'Beobachten verboten',
             fr: 'Ni vu ni connu',
           },
-          dropsFieldNotes: false,
           shortLabel: {
             en: 'Wrench',
             fr: 'Ni vu ni connu',
@@ -2964,7 +2911,6 @@ const Options = {
             fr: 'Dabog, soldat augmenté',
           },
           isCEPrecursor: true,
-          dropsFieldNotes: false,
           shortLabel: {
             en: 'Pilot',
             fr: 'Dabog',
@@ -2979,7 +2925,6 @@ const Options = {
             de: 'Eiskalt',
             fr: 'Qui s\'y frotte s\'y pique',
           },
-          dropsFieldNotes: false,
           shortLabel: {
             en: 'Ice',
             fr: 'Pique',
@@ -2994,7 +2939,6 @@ const Options = {
             de: 'Puppen',
             fr: 'Celui qui tire les ficelles',
           },
-          dropsFieldNotes: true,
           fieldNotes: 42,
           shortLabel: {
             en: 'Puppet',
@@ -3010,7 +2954,6 @@ const Options = {
             de: 'Größtmöglicher',
             fr: 'Un problème de taille',
           },
-          dropsFieldNotes: true,
           fieldNotes: 40,
           shortLabel: {
             en: 'Challenge',
@@ -3026,7 +2969,6 @@ const Options = {
             de: 'Bestien',
             fr: 'Le dernier dinosaure',
           },
-          dropsFieldNotes: false,
           shortLabel: {
             en: 'T\'huban',
             fr: 'Dinosaure',
@@ -3042,7 +2984,6 @@ const Options = {
             fr: 'L\'immaculée contre le malsain',
           },
           isCEPrecursor: true,
-          dropsFieldNotes: true,
           fieldNotes: 38,
           shortLabel: {
             en: 'Atrocities',
@@ -3058,7 +2999,6 @@ const Options = {
             de: 'mörderische Meister',
             fr: 'Recherché dans deux pays',
           },
-          dropsFieldNotes: true,
           fieldNotes: 34,
           shortLabel: {
             en: 'Pursuit',
@@ -3075,7 +3015,6 @@ const Options = {
             fr: 'Y\'a qu\'à se baisser',
           },
           isCEPrecursor: true,
-          dropsFieldNotes: false,
           shortLabel: {
             en: 'Tanking',
             fr: 'Se baisser',
@@ -3090,7 +3029,6 @@ const Options = {
             de: 'Magitek-Soldat',
             fr: 'Guet-apens magitek',
           },
-          dropsFieldNotes: true,
           fieldNotes: 43,
           shortLabel: {
             en: 'Supersoldier',
@@ -3106,7 +3044,6 @@ const Options = {
             de: 'Rettende Hiebe',
             fr: 'Magie couleur sang',
           },
-          dropsFieldNotes: true,
           fieldNotes: 36,
           shortLabel: {
             en: 'Demented',
@@ -3122,7 +3059,6 @@ const Options = {
             de: 'Endkampf (Puppenspieler)',
             fr: 'Ainsi font les petites marionnettes',
           },
-          dropsFieldNotes: true,
           fieldNotes: 32,
           shortLabel: {
             en: 'Sever',
@@ -3139,7 +3075,6 @@ const Options = {
             fr: 'Des bêtes en pagagaille',
           },
           isCEPrecursor: true,
-          dropsFieldNotes: false,
           shortLabel: {
             en: 'Beasts',
             fr: 'Pagagaille',
@@ -3154,7 +3089,6 @@ const Options = {
             de: 'Schillernde ',
             fr: 'Clarricie, sans défense ou presque',
           },
-          dropsFieldNotes: false,
           shortLabel: {
             en: 'Still',
             fr: 'Sans défense',
@@ -3169,7 +3103,6 @@ const Options = {
             de: 'Farbe des Blutes',
             fr: 'Non, c\'est non !',
           },
-          dropsFieldNotes: true,
           fieldNotes: 41,
           shortLabel: {
             en: 'Seeq',
@@ -3185,7 +3118,6 @@ const Options = {
             de: 'Onmyoji!',
             fr: 'Le trésor du clan Urabe',
           },
-          dropsFieldNotes: true,
           fieldNotes: 39,
           shortLabel: {
             en: 'Mean',
@@ -3201,7 +3133,6 @@ const Options = {
             de: 'Famfrit',
             fr: 'Sans issue',
           },
-          dropsFieldNotes: true,
           fieldNotes: 32,
           shortLabel: {
             en: 'Relic',
@@ -3217,7 +3148,6 @@ const Options = {
             de: 'Was du heute kannst besorgen',
             fr: 'Des cailloux, des cailloux, des cailloux !',
           },
-          dropsFieldNotes: false,
           shortLabel: {
             en: 'Mages',
             fr: 'Cailloux',
@@ -3233,7 +3163,6 @@ const Options = {
             fr: 'Une opportunité en or',
           },
           isCEPrecursor: true,
-          dropsFieldNotes: true,
           fieldNotes: 43,
           shortLabel: {
             en: 'Hyper',
@@ -3250,7 +3179,6 @@ const Options = {
             fr: 'Il est plus d\'un',
           },
           isCEPrecursor: true,
-          dropsFieldNotes: true,
           fieldNotes: 35,
           shortLabel: {
             en: 'Supersoldiers',
@@ -3266,7 +3194,6 @@ const Options = {
             de: 'Rettende Hiebe 2',
             fr: 'L\'élève dépasse le maître',
           },
-          dropsFieldNotes: true,
           fieldNotes: 36,
           shortLabel: {
             en: 'Student',
@@ -3282,7 +3209,6 @@ const Options = {
             de: 'Magitek-Maschinen en masse',
             fr: 'Fabrication en série',
           },
-          dropsFieldNotes: false,
           shortLabel: {
             en: 'Machines',
             fr: 'En série',
@@ -3297,7 +3223,6 @@ const Options = {
             de: 'The Dalriada',
             fr: 'Le Dal\'riada',
           },
-          dropsFieldNotes: false,
           shortLabel: {
             en: 'Dalriada',
             fr: 'Dal\'riada',
@@ -3315,7 +3240,6 @@ const Options = {
             de: 'Geistertrupp',
             fr: 'Zirnitrop',
           },
-          dropsFieldNotes: false,
           shortLabel: {
             en: 'Serpents',
             fr: 'Zirnitrop',
@@ -3331,7 +3255,6 @@ const Options = {
             de: 'Schwarzbrands',
             fr: 'On arrête le progrès',
           },
-          dropsFieldNotes: true,
           fieldNotes: 35,
           shortLabel: {
             en: 'Burn',
@@ -3349,7 +3272,6 @@ const Options = {
             de: 'Hyper-Dabog',
             fr: 'Dabog, l\'hyper-renforcé',
           },
-          dropsFieldNotes: true,
           fieldNotes: 43,
           shortLabel: {
             en: 'Blade',
@@ -3368,7 +3290,6 @@ const Options = {
             de: 'Shemhazai',
             fr: 'Le Sycophante',
           },
-          dropsFieldNotes: true,
           fieldNotes: 37,
           shortLabel: {
             en: 'Grave',
@@ -3385,7 +3306,6 @@ const Options = {
             de: 'Hedetet',
             fr: 'C\'est dans ma nature',
           },
-          dropsFieldNotes: true,
           shortLabel: {
             en: 'Diremite',
             fr: 'Ma nature',
@@ -3401,7 +3321,6 @@ const Options = {
             de: 'Halb Pferd',
             fr: 'Un cavalier qui surgit hors de la nuit',
           },
-          dropsFieldNotes: false,
           shortLabel: {
             en: 'Cavalry',
             fr: 'Cavalier',
@@ -3417,7 +3336,6 @@ const Options = {
             de: 'Menenius',
             fr: 'Mener par l\'exemple',
           },
-          dropsFieldNotes: true,
           fieldNotes: 45,
           shortLabel: {
             en: 'Snake',
@@ -3436,7 +3354,6 @@ const Options = {
             de: 'Hanbi',
             fr: 'Le Roi des Cendres',
           },
-          dropsFieldNotes: false,
           shortLabel: {
             en: 'Blood',
             fr: 'Cendres',
@@ -3452,7 +3369,6 @@ const Options = {
             de: 'Hrodvitnir',
             fr: 'Et n\'y Hród\'viens plus !',
           },
-          dropsFieldNotes: false,
           shortLabel: {
             en: 'Wolf',
             fr: 'Hród\'vnir',
@@ -3469,7 +3385,6 @@ const Options = {
             de: 'Belias',
             fr: 'Le Titan',
           },
-          dropsFieldNotes: false,
           shortLabel: {
             en: 'Time',
             fr: 'Titan',
@@ -3485,7 +3400,6 @@ const Options = {
             de: 'Gepanzerte Zenturie',
             fr: 'Réusinage de code',
           },
-          dropsFieldNotes: false,
           shortLabel: {
             en: 'Lean, Mean',
             fr: 'Réusinage',
@@ -3501,7 +3415,6 @@ const Options = {
             de: 'Alkonost',
             fr: 'Oiseau d\'enfer',
           },
-          dropsFieldNotes: false,
           shortLabel: {
             en: 'Shadow',
             fr: 'Oiseau',
@@ -3517,7 +3430,6 @@ const Options = {
             de: 'Hashmallim',
             fr: 'Le Grand Ordonnateur',
           },
-          dropsFieldNotes: false,
           shortLabel: {
             en: 'Familiar',
             fr: 'Ordonnateur',
@@ -3534,7 +3446,6 @@ const Options = {
             de: 'Ayda',
             fr: 'Écaillage en règle',
           },
-          dropsFieldNotes: false,
           shortLabel: {
             en: 'Looks',
             fr: 'Écaillage',
@@ -3550,7 +3461,6 @@ const Options = {
             de: 'Revanche: Lyon',
             fr: 'La revanche de Lyon',
           },
-          dropsFieldNotes: true,
           fieldNotes: 44,
           shortLabel: {
             en: 'Lyon\'s',

--- a/ui/eureka/eureka.js
+++ b/ui/eureka/eureka.js
@@ -1732,15 +1732,124 @@ const Options = {
       mapToPixelXConstant: -292.56,
       mapToPixelYScalar: 48.938,
       mapToPixelYConstant: -349.22,
+      fieldNotes: {
+      	bajsaljen: {
+      		id: 1,
+      		name: "Bajsaljen Ulgasch",
+      		shortname: "Bajsalen",
+      		rarity: 1,
+      	},
+      	marsak: {
+      		id: 2,
+      		name: "Marsak Apella",
+      		shortname: "Marsak",
+      		rarity: 1,
+      	},
+      	xeven: {
+      		id: 3,
+      		name: "Xeven Scanasch",
+      		shortname: "Xeven",
+      		rarity: 1,
+      	},
+      	isolde: {
+      		id: 4,
+      		name: "Isolde Covey",
+      		shortname: "Isolde",
+      		rarity: 2,
+      	},
+      	stanik: {
+      		id: 5,
+      		name: "Stanik Alubov",
+      		shortname: "Stanik",
+      		rarity: 1,
+      	},
+      	blaz: {
+      		id: 6,
+      		name: "Blaz Azetina",
+      		shortname: "Blaz",
+      		rarity: 3,
+      	},
+      	velibor: {
+      		id: 7,
+      		name: "Velibor Azetina",
+      		shortname: "Velibor",
+      		rarity: 3,
+      	},
+      	aggie: {
+      		id: 8,
+      		name: "Aggie Glover",
+      		shortname: "Aggie",
+      		rarity: 1,
+      	},
+      	llofii: {
+      		id: 9,
+      		name: "Llofii pyr Potitus",
+      		shortname: "Llofii",
+      		rarity: 2,
+      	},
+      	hernais: {
+      		id: 10,
+      		name: "Hernais pyr Longus",
+      		shortname: "Hernais",
+      		rarity: 3,
+      	},
+      	dabog: {
+      		id: 11,
+      		name: "Dabog aan Inivisch",
+      		shortname: "Dabog",
+      		rarity: 5,
+      	},
+      	dyunbu: {
+      		id: 12,
+      		name: "Dyunbu pyr Potitus",
+      		shortname: "Dyunbu",
+      		rarity: 4,
+      	},
+      	clarricie: {
+      		id: 13,
+      		name: "Clarricie quo Priscus",
+      		shortname: "Clarricie",
+      		rarity: 2,
+      	},
+      	sartauvoir: {
+      		id: 14,
+      		name: "Sartauvoir quo Soranus",
+      		shortname: "Sartauvoir",
+      		rarity: 5,
+      	},
+      	sicinius: {
+      		id: 15,
+      		name: "Sicinius mal Vellutus",
+      		shortname: "Sicinius",
+      		rarity: 3,
+      	},
+      	albeleo: {
+      		id: 16,
+      		name: "Sadr rem Albeleo",
+      		shortname: "Albeleo",
+      		rarity: 3,
+      	},
+      	lyon: {
+      		id: 17,
+      		name: "Lyon rem Helsos",
+      		shortname: "Lyon",
+      		rarity: 5,
+      	},
+      },
       nms: {
         sneak: {
           label: {
-            en: 'Sneak',
+            en: 'Sneak & Spell',
             de: 'Taktisches Gemetzel',
             fr: 'Les yeux de l\'ennemi',
             ja: '術士大隊との会敵',
             cn: '遭遇术师大队',
             ko: '술사대대 발견',
+          },
+          dropsFieldNotes: false,
+          shortLabel: {
+          	en: 'Sneak',
+          	fr: 'Yeux',
           },
           x: 20.3,
           y: 26.8,
@@ -1748,12 +1857,18 @@ const Options = {
         },
         robots: {
           label: {
-            en: 'Robots',
+            en: 'None of Them Knew They Were Robots',
             de: 'Nichts als Schrott',
             fr: 'Les araignées de fer',
             ja: '無人魔導兵器との会敵',
             cn: '遭遇无人魔导兵器',
             ko: '무인 마도 병기 발견',
+          },
+          dropsFieldNotes: true,
+          fieldNotes: 8,
+          shortLabel: {
+          	en: 'Robots',
+          	fr: 'Araignées',
           },
           x: 24.8,
           y: 27.5,
@@ -1761,12 +1876,18 @@ const Options = {
         },
         beasts: {
           label: {
-            en: 'Beasts',
+            en: 'The Beasts Must Die',
             de: 'Husch, ins Körbchen!',
             fr: 'Museler le Chien',
             ja: '忠犬との遭遇',
             cn: '发现忠犬',
             ko: '충견과 조우하다',
+          },
+          dropsFieldNotes: true,
+          fieldNotes: 3,
+          shortLabel: {
+          	en: 'Beasts',
+          	fr: 'Museler',
           },
           x: 20.3,
           y: 26.8,
@@ -1774,12 +1895,17 @@ const Options = {
         },
         unrest: {
           label: {
-            en: 'Unrest',
+            en: 'Unrest for the Wicked',
             de: 'Wer rastet, der blutet',
             fr: 'Pas de quartier',
             ja: '術士大隊への奇襲',
             cn: '奇袭术师大队',
             ko: '술사대대 기습',
+          },
+          dropsFieldNotes: false,
+          shortLabel: {
+          	en: 'Unrest',
+          	fr: 'Pas de quartier',
           },
           x: 24.8,
           y: 27.5,
@@ -1787,12 +1913,19 @@ const Options = {
         },
         machine: {
           label: {
-            en: 'Machine',
+            en: 'More Machine Now Than Man',
             de: 'Auf zum Gegenangriff',
             fr: 'Machines aux trousses',
             ja: '有人魔導兵器の迎撃',
             cn: '迎击有人魔导兵器',
             ko: '유인 마도 병기 요격',
+          },
+          isCEPrecursor: true,
+          dropsFieldNotes: true,
+          fieldNotes: 1,
+          shortLabel: {
+          	en: 'Machine',
+          	fr: 'Machine',
           },
           x: 28.4,
           y: 29.3,
@@ -1800,12 +1933,18 @@ const Options = {
         },
         plants: {
           label: {
-            en: 'Plants',
+            en: 'Can Carnivorous Plants Bloom Even on a Battlefield?',
             de: 'Linientreue',
-            fr: 'Des racines et des crocs',
+            fr: 'Des Racines et des Crocs',
             ja: '野生生物を排除せよ',
             cn: '排除野生生物',
             ko: '야생 생물을 제거하라',
+          },
+          dropsFieldNotes: true,
+          fieldNotes: 5,
+          shortLabel: {
+          	en: 'Plants',
+          	fr: 'Racines',
           },
           x: 34.4,
           y: 29.3,
@@ -1813,12 +1952,17 @@ const Options = {
         },
         seeq: {
           label: {
-            en: 'Seeq',
+            en: 'Seeq and Destroy',
             de: 'Dem Rüpel seine Meute',
             fr: 'Ménagerie guerrière',
             ja: '豚面の魔獣使い',
             cn: '兽性兽心的驯兽师',
             ko: '시크족 마수 조련사',
+          },
+          dropsFieldNotes: false,
+          shortLabel: {
+          	en: 'Seeq',
+          	fr: 'Ménagerie',
           },
           x: 28.9,
           y: 26.1,
@@ -1826,12 +1970,19 @@ const Options = {
         },
         pets: {
           label: {
-            en: 'Pets',
+            en: 'All Pets are Off',
             de: 'Ungeheuerlich!',
             fr: 'Belles plantes',
             ja: '華麗なる珍獣使い',
             cn: '华丽魔女的珍兽使者',
             ko: '화려한 희귀마수 조련사',
+          },
+          isCEPrecursor: true,
+          dropsFieldNotes: true,
+          fieldNotes: 2,
+          shortLabel: {
+          	en: 'Pets',
+          	fr: 'Plantes',
           },
           x: 17.3,
           y: 26.6,
@@ -1839,12 +1990,18 @@ const Options = {
         },
         firstlaw: {
           label: {
-            en: 'First Law',
+            en: 'Conflicting with the First Law',
             de: 'Schufter-10',
             fr: 'Que des numéros dix',
             ja: '労働十号破壊命令',
             cn: '破坏劳动十号',
             ko: '노동 10호 파괴 명령',
+          },
+          dropsFieldNotes: true,
+          fieldNotes: 4,
+          shortLabel: {
+          	en: 'First Law',
+          	fr: 'Numéros dix',
           },
           x: 34.4,
           y: 29.3,
@@ -1852,12 +2009,17 @@ const Options = {
         },
         heal: {
           label: {
-            en: 'Heal',
+            en: 'Brought to Heal',
             de: 'Nächstenliebe',
             fr: 'Miséricorde impériale',
             ja: '恩徳の術士たち',
             cn: '施恩布德的术师队',
             ko: '은덕의 술사들',
+          },
+          dropsFieldNotes: false,
+          shortLabel: {
+          	en: 'Heal',
+          	fr: 'Miséricorde',
           },
           x: 28.9,
           y: 26.1,
@@ -1865,12 +2027,18 @@ const Options = {
         },
         mash: {
           label: {
-            en: 'Mash',
+            en: 'The Monster Mash',
             de: 'Rache ist Blutwurst',
             fr: 'Le retour du chien fidèle',
             ja: '忠犬の逆襲',
             cn: '忠犬的逆袭',
             ko: '충견의 역습',
+          },
+          dropsFieldNotes: true,
+          fieldNotes: 10,
+          shortLabel: {
+          	en: 'Mash',
+          	fr: 'Retour du chien',
           },
           x: 31.3,
           y: 22.0,
@@ -1878,12 +2046,18 @@ const Options = {
         },
         alert: {
           label: {
-            en: 'Alert',
+            en: 'Red Chocobo Alert',
             de: 'Großes Federlassen',
             fr: 'Quand les chocobos voient rouge',
             ja: '豚面と赤い馬鳥',
             cn: '兽性兽心与红色马鸟',
             ko: '시크족과 붉은 초코보',
+          },
+          isCEPrecursor: true,
+          dropsFieldNotes: false,
+          shortLabel: {
+          	en: 'Alert',
+          	fr: 'Chocobos',
           },
           x: 27.3,
           y: 17.7,
@@ -1891,12 +2065,19 @@ const Options = {
         },
         unicorn: {
           label: {
-            en: 'Unicorn',
+            en: 'Unicorn Flakes',
             de: 'Llofii',
             fr: 'La licorne des plaines',
             ja: '潔白の脱走兵',
             cn: '洁白心的逃脱战',
             ko: '결백한 탈주병',
+          },
+          isCEPrecursor: true,
+          dropsFieldNotes: true,
+          fieldNotes: 13,
+          shortLabel: {
+          	en: 'Unicorn',
+          	fr: 'Licorne',
           },
           x: 32.3,
           y: 17.0,
@@ -1904,12 +2085,17 @@ const Options = {
         },
         recreation: {
           label: {
-            en: 'Recreation',
+            en: 'Parts and Recreation',
             de: 'Aufräumen im Dienst',
             fr: 'La bataille de l\'innovation',
             ja: '敵新兵器を調査せよ',
             cn: '调查敌方新兵器',
             ko: '적의 신병기를 조사하라',
+          },
+          dropsFieldNotes: false,
+          shortLabel: {
+          	en: 'Recreation',
+          	fr: 'Innovation',
           },
           x: 25.6,
           y: 22.6,
@@ -1917,12 +2103,17 @@ const Options = {
         },
         element: {
           label: {
-            en: 'Element',
+            en: 'The Element of Supplies',
             de: 'Verhinderte Wartung',
             fr: 'Couper les vivres',
             ja: '整備場奇襲作戦',
             cn: '奇袭整备场',
             ko: '정비소 기습 작전',
+          },
+          dropsFieldNotes: false,
+          shortLabel: {
+          	en: 'Supplies',
+          	fr: 'Vivres',
           },
           x: 17.5,
           y: 23.4,
@@ -1930,12 +2121,18 @@ const Options = {
         },
         heavyboots: {
           label: {
-            en: 'Boots',
+            en: 'Heavy Boots of Lead',
             de: 'Arbeitsniederlegung',
             fr: 'Force ouvrière',
             ja: '魔導レイバー破壊命令',
             cn: '破坏魔导劳工',
             ko: '마도 노동자 파괴 명령',
+          },
+          dropsFieldNotes: true,
+          fieldNotes: 15,
+          shortLabel: {
+          	en: 'Boots',
+          	fr: 'Force',
           },
           x: 31.3,
           y: 22.0,
@@ -1943,12 +2140,18 @@ const Options = {
         },
         camping: {
           label: {
-            en: 'Camping',
+            en: 'No Camping Allowed',
             de: 'Unfreundlicher Besuch',
             fr: 'Idéaux irréconciliables',
             ja: '野営地への先制攻撃',
             cn: '进攻野营地',
             ko: '야영지 선제 공격',
+          },
+          dropsFieldNotes: true,
+          fieldNotes: 6,
+          shortLabel: {
+          	en: 'Camping',
+          	fr: 'Idéaux',
           },
           x: 17.5,
           y: 23.4,
@@ -1956,12 +2159,18 @@ const Options = {
         },
         scavengers: {
           label: {
-            en: 'Scavengers',
+            en: 'Scavengers of Human Sorrow',
             de: 'Zurück ins Nichts',
             fr: 'Les dévoreurs d\'âmes',
             ja: '魂喰いの妖異たち',
             cn: '噬魂的妖异',
             ko: '혼을 먹는 요마들',
+          },
+          dropsFieldNotes: true,
+          fieldNotes: 7,
+          shortLabel: {
+          	en: 'Scavengers',
+          	fr: 'Dévoreurs',
           },
           x: 25.6,
           y: 22.6,
@@ -1976,18 +2185,29 @@ const Options = {
             cn: '术师大队的猛攻',
             ko: '술사대대의 맹공격',
           },
+          dropsFieldNotes: false,
+          shortLabel: {
+          	en: 'Help',
+          	fr: 'Résister',
+          },
           x: 18.3,
           y: 20.7,
           fateID: 1615,
         },
         pyromancer: {
           label: {
-            en: 'Pyromancer',
+            en: 'Pyromancer Supreme',
             de: 'Pyromant',
             fr: 'Duel brûlant',
             ja: '最強のパイロマンサー',
             cn: '最强的火焰法师',
             ko: '최강의 불꽃술사',
+          },
+          dropsFieldNotes: true,
+          fieldNotes: 7,
+          shortLabel: {
+          	en: 'Pyromancer',
+          	fr: 'Brûlant',
           },
           x: 18.3,
           y: 20.7,
@@ -1995,12 +2215,18 @@ const Options = {
         },
         rainbow: {
           label: {
-            en: 'Rainbow',
+            en: 'Waste the Rainbow',
             de: 'Ende einer ... Karriere',
             fr: 'De toutes les couleurs',
             ja: '華麗なるお気に入り',
             cn: '华丽魔女与心爱珍兽',
             ko: '화려한 애완마수',
+          },
+          dropsFieldNotes: true,
+          fieldNotes: 13,
+          shortLabel: {
+          	en: 'Rainbow',
+          	fr: 'Couleurs',
           },
           x: 25.1,
           y: 15.0,
@@ -2008,12 +2234,17 @@ const Options = {
         },
         wildbunch: {
           label: {
-            en: 'Wild Bunch',
+            en: 'The Wild Bunch',
             de: 'Revierkämpfe',
             fr: 'Sans maîtres ni loi',
             ja: '暴走魔獣の排除',
             cn: '排除失控魔兽',
             ko: '폭주 마수 처리',
+          },
+          dropsFieldNotes: false,
+          shortLabel: {
+          	en: 'Wild Bunch',
+          	fr: 'Sans maîtres',
           },
           x: 21.0,
           y: 14.3,
@@ -2021,12 +2252,17 @@ const Options = {
         },
         familyotheranimals: {
           label: {
-            en: 'Family',
+            en: 'My Family and Other Animals',
             de: 'rüpelhaftes Großmaul',
             fr: 'L\'incorruptible',
             ja: '豚面の勧誘者',
             cn: '兽性兽心的劝诱',
             ko: '포섭하는 시크족',
+          },
+          dropsFieldNotes: false,
+          shortLabel: {
+          	en: 'Family',
+          	fr: 'Incorruptible',
           },
           x: 11.0,
           y: 14.6,
@@ -2034,12 +2270,18 @@ const Options = {
         },
         mechanicalman: {
           label: {
-            en: 'Mechanical Man',
+            en: 'I\'m a Mechanical Man',
             de: 'Arbeitsniederlegung - Plan B',
             fr: 'Plan B',
             ja: '魔導レイバーB型破壊命令',
             cn: '破坏魔导劳工B型',
             ko: '마도 노동자 B형 파괴 명령',
+          },
+          isCEPrecursor: true,
+          dropsFieldNotes: false,
+          shortLabel: {
+          	en: 'Mechanical',
+          	fr: 'Plan B',
           },
           x: 20.8,
           y: 17.7,
@@ -2047,12 +2289,18 @@ const Options = {
         },
         murder: {
           label: {
-            en: 'Murder',
+            en: 'Murder Death Kill',
             de: 'Neu und besser',
             fr: 'Des machines et des hommes',
             ja: '強化兵部隊の襲撃',
             cn: '袭击强化兵部队',
             ko: '강화병 부대의 습격',
+          },
+          dropsFieldNotes: true,
+          fieldNotes: 11,
+          shortLabel: {
+          	en: 'Murder',
+          	fr: 'Des Machines',
           },
           x: 14.0,
           y: 15.3,
@@ -2060,12 +2308,17 @@ const Options = {
         },
         seeking: {
           label: {
-            en: 'Seeking',
+            en: 'Desperately Seeking Something',
             de: 'fällt selbst hinein',
             fr: 'Ceux qui creusent',
             ja: '戦場の盗掘者',
             cn: '战场的偷盗者',
             ko: '전장의 도굴자',
+          },
+          dropsFieldNotes: false,
+          shortLabel: {
+          	en: 'Seeking',
+          	fr: 'Creusent',
           },
           x: 24.8,
           y: 17.1,
@@ -2073,12 +2326,18 @@ const Options = {
         },
         suppliesparty: {
           label: {
-            en: 'Supplies',
+            en: 'Supplies Party',
             de: 'Deins wird meins',
             fr: 'Casser la voie',
             ja: '補給物資強奪作戦',
             cn: '补给物资夺取战',
             ko: '보급 물자 강탈 작전',
+          },
+          dropsFieldNotes: true,
+          fieldNotes: 5,
+          shortLabel: {
+          	en: 'Supplies',
+          	fr: 'Casser',
           },
           x: 21.0,
           y: 14.3,
@@ -2086,12 +2345,17 @@ const Options = {
         },
         demonic: {
           label: {
-            en: 'Demonic',
+            en: 'Demonstrably Demonic',
             de: 'Der Geruch der Angst',
             fr: 'Par l\'hémoglobine alléchés',
             ja: '血の匂いに誘われて',
             cn: '闻血而来',
             ko: '피비린내에 이끌려',
+          },
+          dropsFieldNotes: false,
+          shortLabel: {
+          	en: 'Demonic',
+          	fr: 'Hémoglobine',
           },
           x: 11.1,
           y: 20.2,
@@ -2099,25 +2363,39 @@ const Options = {
         },
         absentfriends: {
           label: {
-            en: 'Absent',
+            en: 'For Absent Friends',
             de: 'Eine neue Unordnung',
             fr: 'Miséricorde vengeresse',
             ja: '燃え上がる南方戦線',
             cn: '南方战线的激战',
             ko: '타오르는 남부 전선',
           },
+          dropsFieldNotes: true,
+          fieldNotes: 12,
+          shortLabel: {
+          	en: 'Absent',
+          	fr: 'Vengeresse',
+          },
+          isCEPrecursor: true,
           x: 13.8,
           y: 18.3,
           fateID: 1625,
         },
         steelflame: {
           label: {
-            en: 'Steel',
+            en: 'Of Steel and Flame',
             de: 'Auf und ab',
             fr: 'Le fer et le feu',
             ja: '続・燃え上がる南方戦線',
             cn: '南方战线的续战',
             ko: '타오르는 남부 전선 속편',
+          },
+          isCEPrecursor: true,
+          dropsFieldNotes: true,
+          fieldNotes: 14,
+          shortLabel: {
+          	en: 'Steel',
+          	fr: 'Fer & Feu',
           },
           x: 13.8,
           y: 18.3,
@@ -2125,12 +2403,18 @@ const Options = {
         },
         dogsofwar: {
           label: {
-            en: 'Dogs',
+            en: 'Let Slip the Dogs of War',
             de: 'Vor die Hunde gekommen',
             fr: 'Brigade canine',
             ja: '戦場の犬を解き放て',
             cn: '释放战场之犬',
             ko: '전장에 개를 풀어라',
+          },
+          dropsFieldNotes: true,
+          fieldNotes: 4,
+          shortLabel: {
+          	en: 'Dogs',
+          	fr: 'Brigade',
           },
           x: 14.0,
           y: 15.3,
@@ -2138,12 +2422,18 @@ const Options = {
         },
         warmachines: {
           label: {
-            en: 'War',
+            en: 'The War Against the Machine',
             de: 'Ende Gelände',
             fr: 'Cent mille guerriers de métal',
             ja: 'シシニアスの実験場',
             cn: '西西尼乌斯的实验场',
             ko: '시시니우스의 실험장',
+          },
+          dropsFieldNotes: true,
+          fieldNotes: 3,
+          shortLabel: {
+          	en: 'War',
+          	fr: 'Cent Mille',
           },
           x: 11.1,
           y: 20.2,
@@ -2151,6 +2441,15 @@ const Options = {
         },
         castrumlacuslitore: {
           label: {
+            en: 'Castrum Lacus Litore',
+            de: 'Castrum Lacus Litore',
+            fr: 'Castrum Lacus Litore',
+            ja: 'カストルム',
+            cn: '湖岸堡',
+            ko: '공성전',
+          },
+          dropsFieldNotes: false,
+          shortLabel: {
             en: 'Castrum',
             de: 'Castrum',
             fr: 'Castrum',
@@ -2174,6 +2473,12 @@ const Options = {
             cn: '皮里福尔',
             ko: '피어리풀',
           },
+          dropsFieldNotes: true,
+          fieldNotes: 13,
+          shortLabel: {
+          	en: 'Kill it',
+          	fr: 'Pestilence',
+          },
           x: 17.4,
           y: 26.9,
           isCritical: true,
@@ -2181,12 +2486,17 @@ const Options = {
         },
         bayinghounds: {
           label: {
-            en: 'Hounds',
+            en: 'The Baying of the Hound(s)',
             de: 'Canis dirus',
             fr: 'Le chien des enfers',
             ja: 'カニスディルス',
             cn: '恐惧妖犬',
             ko: '카니스 디루스',
+          },
+          dropsFieldNotes: false,
+          shortLabel: {
+          	en: 'Hounds',
+          	fr: 'Chien',
           },
           x: 22.8,
           y: 28.8,
@@ -2195,12 +2505,17 @@ const Options = {
         },
         vigilforthelost: {
           label: {
-            en: 'Vigil',
+            en: 'Vigil for the Lost',
             de: 'Vigil',
             fr: 'Vigile de feu',
             ja: 'ヴィジル',
             cn: '守夜',
             ko: '비질',
+          },
+          dropsFieldNotes: false,
+          shortLabel: {
+          	en: 'Vigil',
+          	fr: 'Vigile',
           },
           x: 28.4,
           y: 29.5,
@@ -2217,6 +2532,12 @@ const Options = {
             cn: '加百列',
             ko: '가브리엘',
           },
+          dropsFieldNotes: true,
+          fieldNotes: 11,
+          shortLabel: {
+          	en: 'Aces High',
+          	fr: 'Force divine',
+          },
           x: 32.3,
           y: 26.8,
           isCritical: true,
@@ -2226,12 +2547,18 @@ const Options = {
         },
         shadowdeathshand: {
           label: {
-            en: 'Shadow',
+            en: 'The Shadow of Death\'s Hand',
             de: 'Akbaba',
             fr: 'Les ailes noires de la mort',
             ja: '黒アクババ',
             cn: '阿库巴巴',
             ko: '아크바바',
+          },
+          dropsFieldNotes: true,
+          fieldNotes: 3,
+          shortLabel: {
+          	en: 'Shadow',
+          	fr: 'Ailes noires',
           },
           x: 36.5,
           y: 25.8,
@@ -2240,12 +2567,18 @@ const Options = {
         },
         finalfurlong: {
           label: {
-            en: 'Final Furlong',
+            en: 'The Final Furlong',
             de: 'Spartoi',
             fr: 'Menace spectrale',
             ja: 'スパルトイ',
             cn: '地生人',
             ko: '스파르토이',
+          },
+          dropsFieldNotes: true,
+          fieldNotes: 9,
+          shortLabel: {
+          	en: 'Furlong',
+          	fr: 'Menace',
           },
           x: 33.3,
           y: 17.5,
@@ -2254,12 +2587,17 @@ const Options = {
         },
         choctober: {
           label: {
-            en: 'Choctober',
+            en: 'The Hunt for Red Choctober',
             de: 'Roter Meteor',
             fr: 'Une ruée en rouge',
             ja: '赤レッドコメット',
             cn: '红色彗星',
             ko: '붉은 혜성',
+          },
+          dropsFieldNotes: false,
+          shortLabel: {
+          	en: 'Choctober',
+          	fr: 'Ruée en Rouge',
           },
           x: 27.3,
           y: 17.7,
@@ -2276,6 +2614,12 @@ const Options = {
             cn: '兽王莱昂',
             ko: '마수왕 라이언',
           },
+          dropsFieldNotes: true,
+          fieldNotes: 17,
+          shortLabel: {
+          	en: 'Beast of Man',
+          	fr: 'Roi Bestial',
+          },
           x: 23.3,
           y: 20.4,
           isCritical: true,
@@ -2285,12 +2629,17 @@ const Options = {
         },
         firesofwar: {
           label: {
-            en: 'Fires of War',
+            en: 'The Fires of War',
             de: 'Flammenden Hundert',
             fr: 'Brasier de guerre',
             ja: '火焔百人隊',
             cn: '火焰百夫队',
             ko: '화염백인대',
+          },
+          dropsFieldNotes: false,
+          shortLabel: {
+          	en: 'Fires of War',
+          	fr: 'Brasier',
           },
           x: 20.8,
           y: 23.9,
@@ -2306,6 +2655,11 @@ const Options = {
             cn: '爱国者',
             ko: '패트리어트',
           },
+          dropsFieldNotes: false,
+          shortLabel: {
+          	en: 'Patriot',
+          	fr: 'Patriote',
+          },
           x: 14.2,
           y: 21.2,
           isCritical: true,
@@ -2313,12 +2667,17 @@ const Options = {
         },
         trampledunderhoof: {
           label: {
-            en: 'Trampled',
+            en: 'Trampled under Hoof',
             de: 'Die bösen Blicke der Eale',
             fr: 'L\'œil du malin',
             ja: '邪エアレー',
             cn: '耶鲁',
             ko: '에알레',
+          },
+          dropsFieldNotes: false,
+          shortLabel: {
+          	en: 'Trampled',
+          	fr: 'Œil du malin',
           },
           x: 9.9,
           y: 18.1,
@@ -2327,12 +2686,18 @@ const Options = {
         },
         flameswenthigher: {
           label: {
-            en: 'Flames',
+            en: 'And the Flames Went Higher',
             de: 'Sartauvoir',
-            fr: '"L\'envol du phénix',
+            fr: 'L\'envol du phénix',
             ja: 'サルトヴォアール',
             cn: '萨托瓦尔',
             ko: '사르토부아르',
+          },
+          dropsFieldNotes: true,
+          fieldNotes: 14,
+          shortLabel: {
+          	en: 'Flames',
+          	fr: 'Phénix',
           },
           x: 18.8,
           y: 15.9,
@@ -2350,6 +2715,11 @@ const Options = {
             cn: '达因斯莱瓦',
             ko: '다인슬라이프',
           },
+          dropsFieldNotes: false,
+          shortLabel: {
+          	en: 'Metal Fox',
+          	fr: 'Guerrier de Métal',
+          },
           x: 13.8,
           y: 18.3,
           isCritical: true,
@@ -2358,12 +2728,18 @@ const Options = {
         },
         riseoftherobots: {
           label: {
-            en: 'Rise',
+            en: 'Rise of the Robots',
             de: 'Modell X',
             fr: 'Le soulèvement des machines',
             ja: '魔導レイバーX型',
             cn: '魔导劳工X式',
             ko: '마도 노동자 X형',
+          },
+          dropsFieldNotes: true,
+          fieldNotes: 15,
+          shortLabel: {
+          	en: 'Rise',
+          	fr: 'Soulèvement',
           },
           x: 21.2,
           y: 17.6,
@@ -2372,12 +2748,17 @@ const Options = {
         },
         wherestrodebehemoth: {
           label: {
-            en: 'Behemoth',
+            en: 'Where Strode the Behemoth',
             de: 'Der untote Chlevnik',
             fr: 'Le mastodonte enragé',
             ja: 'チルヴニク',
             cn: '奇尔维尼克',
             ko: '칠레브니크',
+          },
+          dropsFieldNotes: false,
+          shortLabel: {
+          	en: 'Behemoth',
+          	fr: 'Mastodonte',
           },
           x: 24.2,
           y: 14.9,
@@ -2398,12 +2779,116 @@ const Options = {
       mapToPixelXConstant: 10.03,
       mapToPixelYScalar: 39.247,
       mapToPixelYConstant: -202.55,
+      fieldNotes:{
+      	atori: {
+      		id: 31,
+      		name: "Atori Moribe",
+      		shortname: "Atori",
+      		rarity: 1,
+      	},
+      	kosyu: {
+      		id: 32,
+      		name: "Kosyu",
+      		shortname: "Kosyu",
+      		rarity: 2,
+      	},
+      	oboro: {
+      		id: 33,
+      		name: "Oboro Torioi",
+      		shortname: "Oboro",
+      		rarity: 1,
+      	},
+      	tsubame: {
+      		id: 34,
+      		name: "Tsubame",
+      		shortname: "Tsubame Oshidari",
+      		rarity: 3,
+      	},
+      	meryall: {
+      		id: 35,
+      		name: "Meryall Miller",
+      		shortname: "Meryall",
+      		rarity: 2,
+      	},
+      	lovro: {
+      		id: 36,
+      		name: "Lovro aan Slanasch",
+      		shortname: "Lovro",
+      		rarity: 3,
+      	},
+      	llofii: {
+      		id: 37,
+      		name: "Llofii pyr Potitus",
+      		shortname: "Llofii",
+      		rarity: 4,
+      	},
+      	fabineau: {
+      		id: 38,
+      		name: "Fabineau quo Soranus",
+      		shortname: "Fabineau",
+      		rarity: 2,
+      	},
+      	yamatsumi: {
+      		id: 39,
+      		name: "Yamatsumi pyr Urabe",
+      		shortname: "Yamatsumi",
+      		rarity: 3,
+      	},
+      	pagaga: {
+      		id: 40,
+      		name: "Pagaga quo Vochstein",
+      		shortname: "Pagaga",
+      		rarity: 1,
+      	},
+      	daguza: {
+      		id: 41,
+      		name: "Daguza oen Sus",
+      		shortname: "Daguza",
+      		rarity: 1,
+      	},
+      	gilbrisbert: {
+      		id: 42,
+      		name: "Gilbrisbert quo Buteo",
+      		shortname: "Gilbrisbert",
+      		rarity: 2,
+      	},
+      	dabog: {
+      		id: 43,
+      		name: "Dabog aan Inivisch",
+      		shortname: "Dabog",
+      		rarity: 5,
+      	},
+      	lyon: {
+      		id: 44,
+      		name: "Lyon quo Helsos",
+      		shortname: "Lyon",
+      		rarity: 5,
+      	},
+      	menenius: {
+      		id: 45,
+      		name: "Menenius sas Lanatus",
+      		shortname: "Menenius",
+      		rarity: 5,
+      	},
+      	diablo: {
+      		id: 46,
+      		name: "Diablo",
+      		shortname: "Diablo",
+      		rarity: 3,
+      	},
+      },
       nms: {
         ofbeastsandbraggadocio: {
           label: {
-            en: 'Beasts',
+            en: 'Of Beasts and Braggadocio',
             de: 'Bestienbändigerin',
             fr: 'Un jour, je serai la meilleure dresseuse',
+          },
+          dropsFieldNotes: true,
+          fieldNotes: 31,
+          shortLabel: {
+          	en: 'Beasts',
+          	fr: 'Dresseuse',
           },
           x: 24.1,
           y: 37.4,
@@ -2411,9 +2896,15 @@ const Options = {
         },
         partsandparcel: {
           label: {
-            en: 'Parcel',
+            en: 'Parts and Parcel',
             de: 'Oboro',
             fr: 'Les astres du jour et de la nuit',
+          },
+          dropsFieldNotes: true,
+          fieldNotes: 33,
+          shortLabel: {
+          	en: 'Parcel',
+          	fr: 'Astres',
           },
           x: 22.8,
           y: 34.2,
@@ -2421,9 +2912,16 @@ const Options = {
         },
         animmoraldilemma: {
           label: {
-            en: 'Dilemma',
+            en: 'An Immoral Dilemma',
             de: 'Ketzer Fabineau',
             fr: 'Malheureuses retrouvailles',
+          },
+          isCEPrecursor: true,
+          dropsFieldNotes: true,
+          fieldNotes: 37,
+          shortLabel: {
+          	en: 'Dilemma',
+          	fr: 'Retrouvailles',
           },
           x: 22.7,
           y: 34.2,
@@ -2431,9 +2929,14 @@ const Options = {
         },
         deadlydivination: {
           label: {
-            en: 'Divination',
+            en: 'Deadly Divination',
             de: 'Mörderischer Onmyoji',
             fr: 'Prêtre pernicieux',
+          },
+          dropsFieldNotes: false,
+          shortLabel: {
+          	en: 'Divination',
+          	fr: 'Prêtre',
           },
           x: 24.8,
           y: 31.4,
@@ -2441,9 +2944,14 @@ const Options = {
         },
         awrenchinthereconnaissanceeffort: {
           label: {
-            en: 'Wrench',
+            en: 'A Wrench in the Reconnaissance Effort',
             de: 'Beobachten verboten',
             fr: 'Ni vu ni connu',
+          },
+          dropsFieldNotes: false,
+          shortLabel: {
+          	en: 'Wrench',
+          	fr: 'Ni vu ni connu',
           },
           x: 29.4,
           y: 35.4,
@@ -2451,9 +2959,15 @@ const Options = {
         },
         anotherpilotepisode: {
           label: {
-            en: 'Pilot',
+            en: 'Another Pilot episode',
             de: 'Magitek-Soldaten',
             fr: 'Dabog, soldat augmenté',
+          },
+          isCEPrecursor: true,
+          dropsFieldNotes: false,
+          shortLabel: {
+          	en: 'Pilot',
+          	fr: 'Dabog',
           },
           x: 28.0,
           y: 29.2,
@@ -2461,9 +2975,14 @@ const Options = {
         },
         breakingtheice: {
           label: {
-            en: 'Ice',
+            en: 'Breaking the Ice',
             de: 'Eiskalt',
             fr: 'Qui s\'y frotte s\'y pique',
+          },
+          dropsFieldNotes: false,
+          shortLabel: {
+          	en: 'Ice',
+          	fr: 'Pique',
           },
           x: 24.8,
           y: 31.1,
@@ -2471,9 +2990,15 @@ const Options = {
         },
         meetthepuppetmaster: {
           label: {
-            en: 'Puppet',
+            en: 'Meet the Puppetmaster',
             de: 'Puppen',
             fr: 'Celui qui tire les ficelles',
+          },
+          dropsFieldNotes: true,
+          fieldNotes: 42,
+          shortLabel: {
+          	en: 'Puppet',
+          	fr: 'Ficelles',
           },
           x: 24.1,
           y: 37.4,
@@ -2481,9 +3006,15 @@ const Options = {
         },
         challengeaccepted: {
           label: {
-            en: 'Challenge',
+            en: 'Challenge Accepted',
             de: 'Größtmöglicher',
             fr: 'Un problème de taille',
+          },
+          dropsFieldNotes: true,
+          fieldNotes: 40,
+          shortLabel: {
+          	en: 'Challenge',
+          	fr: 'Problème',
           },
           x: 7.2,
           y: 28.8,
@@ -2491,9 +3022,14 @@ const Options = {
         },
         thubantheterrible: {
           label: {
-            en: 'Th\'uban',
+            en: 'Th\'uban the Terrible',
             de: 'Bestien',
             fr: 'Le dernier dinosaure',
+          },
+          dropsFieldNotes: false,
+          shortLabel: {
+          	en: 'T\'huban',
+          	fr: 'Dinosaure',
           },
           x: 8.6,
           y: 34.4,
@@ -2501,9 +3037,16 @@ const Options = {
         },
         anendtoatrocities: {
           label: {
-            en: 'Atrocities',
+            en: 'An End to Atrocities',
             de: 'Endkampf (Ketzer)',
             fr: 'L\'immaculée contre le malsain',
+          },
+          isCEPrecursor: true,
+          dropsFieldNotes: true,
+          fieldNotes: 38,
+          shortLabel: {
+          	en: 'Atrocities',
+          	fr: 'Le malsain',
           },
           x: 4.9,
           y: 25.3,
@@ -2511,9 +3054,15 @@ const Options = {
         },
         ajustpursuit: {
           label: {
-            en: 'Pursuit',
+            en: 'A Just Pursuit',
             de: 'mörderische Meister',
             fr: 'Recherché dans deux pays',
+          },
+          dropsFieldNotes: true,
+          fieldNotes: 34,
+          shortLabel: {
+          	en: 'Pursuit',
+          	fr: 'Recherché',
           },
           x: 11.6,
           y: 27.6,
@@ -2521,9 +3070,15 @@ const Options = {
         },
         tankingup: {
           label: {
-            en: 'Tanking',
+            en: 'Tanking Up',
             de: 'Seiryu Zwo',
             fr: 'Y\'a qu\'à se baisser',
+          },
+          isCEPrecursor: true,
+          dropsFieldNotes: false,
+          shortLabel: {
+          	en: 'Tanking',
+          	fr: 'Se baisser',
           },
           x: 8.1,
           y: 24.0,
@@ -2531,9 +3086,15 @@ const Options = {
         },
         supersolderrising: {
           label: {
-            en: 'Supersoldier',
+            en: 'Supersoldier Rising',
             de: 'Magitek-Soldat',
             fr: 'Guet-apens magitek',
+          },
+          dropsFieldNotes: true,
+          fieldNotes: 43,
+          shortLabel: {
+          	en: 'Supersoldier',
+          	fr: 'Guet-apens',
           },
           x: 8.1,
           y: 24.0,
@@ -2541,9 +3102,15 @@ const Options = {
         },
         dementedmentor: {
           label: {
-            en: 'Demented',
+            en: 'Demented Mentor',
             de: 'Rettende Hiebe',
             fr: 'Magie couleur sang',
+          },
+          dropsFieldNotes: true,
+          fieldNotes: 36,
+          shortLabel: {
+          	en: 'Demented',
+          	fr: 'Magie',
           },
           x: 7.2,
           y: 28.8,
@@ -2551,9 +3118,15 @@ const Options = {
         },
         severthestrings: {
           label: {
-            en: 'Sever',
+            en: 'Sever the Strings',
             de: 'Endkampf (Puppenspieler)',
             fr: 'Ainsi font les petites marionnettes',
+          },
+          dropsFieldNotes: true,
+          fieldNotes: 32,
+          shortLabel: {
+          	en: 'Sever',
+          	fr: 'Marionnettes',
           },
           x: 11.6,
           y: 27.6,
@@ -2561,9 +3134,15 @@ const Options = {
         },
         thebeastsareback: {
           label: {
-            en: 'Back',
+            en: 'The Beasts are Back',
             de: 'Allergrößte gibt nicht auf',
             fr: 'Des bêtes en pagagaille',
+          },
+          isCEPrecursor: true,
+          dropsFieldNotes: false,
+          shortLabel: {
+          	en: 'Beasts',
+          	fr: 'Pagagaille',
           },
           x: 25.4,
           y: 14.3,
@@ -2571,9 +3150,14 @@ const Options = {
         },
         stillonlycountsasone: {
           label: {
-            en: 'Still',
+            en: 'Still Only Counts as One',
             de: 'Schillernde ',
             fr: 'Clarricie, sans défense ou presque',
+          },
+          dropsFieldNotes: false,
+          shortLabel: {
+          	en: 'Still',
+          	fr: 'Sans défense',
           },
           x: 14.5,
           y: 10.4,
@@ -2581,9 +3165,15 @@ const Options = {
         },
         seeqandyouwillfind: {
           label: {
-            en: 'Seeq',
+            en: 'Seeq and You Will Find',
             de: 'Farbe des Blutes',
             fr: 'Non, c\'est non !',
+          },
+          dropsFieldNotes: true,
+          fieldNotes: 41,
+          shortLabel: {
+          	en: 'Seeq',
+          	fr: 'Non !',
           },
           x: 20.3,
           y: 16.5,
@@ -2591,9 +3181,15 @@ const Options = {
         },
         meanspirited: {
           label: {
-            en: 'Mean',
+            en: 'Mean-spirited',
             de: 'Onmyoji!',
             fr: 'Le trésor du clan Urabe',
+          },
+          dropsFieldNotes: true,
+          fieldNotes: 39,
+          shortLabel: {
+          	en: 'Mean',
+          	fr: 'Trésor',
           },
           x: 25.4,
           y: 14.3,
@@ -2601,9 +3197,15 @@ const Options = {
         },
         arelicunleashed: {
           label: {
-            en: 'Relic',
+            en: 'A Relic Unleashed',
             de: 'Famfrit',
             fr: 'Sans issue',
+          },
+          dropsFieldNotes: true,
+          fieldNotes: 32,
+          shortLabel: {
+          	en: 'Relic',
+          	fr: 'Sans issue',
           },
           x: 25.4,
           y: 14.3,
@@ -2611,9 +3213,14 @@ const Options = {
         },
         whenmagesrage: {
           label: {
-            en: 'Mages',
+            en: 'When Mages Rage',
             de: 'Was du heute kannst besorgen',
             fr: 'Des cailloux, des cailloux, des cailloux !',
+          },
+          dropsFieldNotes: false,
+          shortLabel: {
+          	en: 'Mages',
+          	fr: 'Cailloux',
           },
           x: 20.3,
           y: 16.5,
@@ -2621,9 +3228,16 @@ const Options = {
         },
         hypertunedhavoc: {
           label: {
-            en: 'Hyper',
-            de: 'goldene Gelegenheit',
+            en: 'Hypertuned Havoc',
+            de: 'Goldene Gelegenheit',
             fr: 'Une opportunité en or',
+          },
+          isCEPrecursor: true,
+          dropsFieldNotes: true,
+          fieldNotes: 43,
+          shortLabel: {
+          	en: 'Hyper',
+          	fr: 'Opportunité',
           },
           x: 16.6,
           y: 16.8,
@@ -2631,9 +3245,16 @@ const Options = {
         },
         attackofthesupersoldiers: {
           label: {
-            en: 'Soldiers',
+            en: 'Attack of the Supersoldiers',
             de: 'Verstärkung .. Mech-Einheit',
             fr: 'Il est plus d\'un',
+          },
+          isCEPrecursor: true,
+          dropsFieldNotes: true,
+          fieldNotes: 35,
+          shortLabel: {
+          	en: 'Supersoldiers',
+          	fr: 'Plus d\'un',
           },
           x: 16.6,
           y: 16.8,
@@ -2641,9 +3262,15 @@ const Options = {
         },
         thestudentbecalmsthemaster: {
           label: {
-            en: 'Student',
+            en: 'The Student Becalms the Master',
             de: 'Rettende Hiebe 2',
             fr: 'L\'élève dépasse le maître',
+          },
+          dropsFieldNotes: true,
+          fieldNotes: 36,
+          shortLabel: {
+          	en: 'Student',
+          	fr: 'Élève',
           },
           x: 14.5,
           y: 10.4,
@@ -2651,9 +3278,14 @@ const Options = {
         },
         attackofthemachines: {
           label: {
-            en: 'Machines',
+            en: 'Attack of the Machines',
             de: 'Magitek-Maschinen en masse',
             fr: 'Fabrication en série',
+          },
+          dropsFieldNotes: false,
+          shortLabel: {
+          	en: 'Machines',
+          	fr: 'En série',
           },
           x: 12.1,
           y: 13.6,
@@ -2661,9 +3293,14 @@ const Options = {
         },
         dalriada: {
           label: {
-            en: 'Dalriada',
-            de: 'Dalriada',
-            fr: 'Dal\'riada',
+            en: 'The Dalriada',
+            de: 'The Dalriada',
+            fr: 'Le Dal\'riada',
+          },
+          dropsFieldNotes: false,
+          shortLabel: {
+          	en: 'Dalriada',
+          	fr: 'Dal\'riada',
           },
           x: 25.9,
           y: 8.2,
@@ -2674,9 +3311,14 @@ const Options = {
         },
         onserpentswings: {
           label: {
-            en: 'Serpents',
+            en: 'On Serpents\' Wings',
             de: 'Geistertrupp',
             fr: 'Zirnitrop',
+          },
+          dropsFieldNotes: false,
+          shortLabel: {
+          	en: 'Serpents',
+          	fr: 'Zirnitrop',
           },
           x: 31.4,
           y: 37.4,
@@ -2685,9 +3327,15 @@ const Options = {
         },
         feelingtheburn: {
           label: {
-            en: 'Feeling',
+            en: 'Feeling the Burn',
             de: 'Schwarzbrands',
             fr: 'On arrête le progrès',
+          },
+          dropsFieldNotes: true,
+          fieldNotes: 35,
+          shortLabel: {
+          	en: 'Burn',
+          	fr: 'Progrès',
           },
           x: 16.6,
           y: 16.8,
@@ -2697,9 +3345,15 @@ const Options = {
         },
         thebrokenblade: {
           label: {
-            en: 'Blade',
+            en: 'The Broken Blade',
             de: 'Hyper-Dabog',
             fr: 'Dabog, l\'hyper-renforcé',
+          },
+          dropsFieldNotes: true,
+          fieldNotes: 43,
+          shortLabel: {
+          	en: 'Blade',
+          	fr: 'Dabog',
           },
           x: 26.5,
           y: 35.6,
@@ -2710,9 +3364,15 @@ const Options = {
         },
         frombeyondthegrave: {
           label: {
-            en: 'Grave',
+            en: 'From Beyond the Grave',
             de: 'Shemhazai',
             fr: 'Le Sycophante',
+          },
+          dropsFieldNotes: true,
+          fieldNotes: 37,
+          shortLabel: {
+          	en: 'Grave',
+          	fr: 'Sycophante',
           },
           x: 20.2,
           y: 37.4,
@@ -2721,9 +3381,14 @@ const Options = {
         },
         withdiremiteandmain: {
           label: {
-            en: 'Diremite',
+            en: 'With Diremite and Main',
             de: 'Hedetet',
             fr: 'C\'est dans ma nature',
+          },
+          dropsFieldNotes: true,
+          shortLabel: {
+          	en: 'Diremite',
+          	fr: 'Ma nature',
           },
           x: 17.0,
           y: 32.1,
@@ -2732,9 +3397,14 @@ const Options = {
         },
         herecomesthecavalry: {
           label: {
-            en: 'Cavalry',
+            en: 'Here Comes the Cavalry',
             de: 'Halb Pferd',
             fr: 'Un cavalier qui surgit hors de la nuit',
+          },
+          dropsFieldNotes: false,
+          shortLabel: {
+          	en: 'Cavalry',
+          	fr: 'Cavalier',
           },
           x: 6.4,
           y: 37.2,
@@ -2743,9 +3413,15 @@ const Options = {
         },
         headofthesnake: {
           label: {
-            en: 'Snake',
+            en: 'Head of the Snake',
             de: 'Menenius',
             fr: 'Mener par l\'exemple',
+          },
+          dropsFieldNotes: true,
+          fieldNotes: 45,
+          shortLabel: {
+          	en: 'Snake',
+          	fr: 'Par l\'exemple',
           },
           x: 5.3,
           y: 31.9,
@@ -2756,9 +3432,14 @@ const Options = {
         },
         therewouldbeblood: {
           label: {
-            en: 'Blood',
+            en: 'There Would Be Blood',
             de: 'Hanbi',
             fr: 'Le Roi des Cendres',
+          },
+          dropsFieldNotes: false,
+          shortLabel: {
+          	en: 'Blood',
+          	fr: 'Cendres',
           },
           x: 13.7,
           y: 26.0,
@@ -2767,9 +3448,14 @@ const Options = {
         },
         nevercrywolf: {
           label: {
-            en: 'Wolf',
+            en: 'Never Cry Wolf',
             de: 'Hrodvitnir',
             fr: 'Et n\'y Hród\'viens plus !',
+          },
+          dropsFieldNotes: false,
+          shortLabel: {
+          	en: 'Wolf',
+          	fr: 'Hród\'vnir',
           },
           x: 4.9,
           y: 25.3,
@@ -2779,9 +3465,14 @@ const Options = {
         },
         timetoburn: {
           label: {
-            en: 'Time',
+            en: 'Time to Burn',
             de: 'Belias',
             fr: 'Le Titan',
+          },
+          dropsFieldNotes: false,
+          shortLabel: {
+          	en: 'Time',
+          	fr: 'Titan',
           },
           x: 10.5,
           y: 21.5,
@@ -2790,9 +3481,14 @@ const Options = {
         },
         leanmeanmagitekmachines: {
           label: {
-            en: 'Magitek',
+            en: 'Lean, Mean, Magitek Machines',
             de: 'Gepanzerte Zenturie',
             fr: 'Réusinage de code',
+          },
+          dropsFieldNotes: false,
+          shortLabel: {
+          	en: 'Lean, Mean',
+          	fr: 'Réusinage',
           },
           x: 15.2,
           y: 13.0,
@@ -2801,9 +3497,14 @@ const Options = {
         },
         worntoashadow: {
           label: {
-            en: 'Shadow',
+            en: 'Worn to a Shadow',
             de: 'Alkonost',
             fr: 'Oiseau d\'enfer',
+          },
+          dropsFieldNotes: false,
+          shortLabel: {
+          	en: 'Shadow',
+          	fr: 'Oiseau',
           },
           x: 11.8,
           y: 7.6,
@@ -2812,9 +3513,14 @@ const Options = {
         },
         afamiliarface: {
           label: {
-            en: 'Familiar',
+            en: 'A Familiar Face',
             de: 'Hashmallim',
             fr: 'Le Grand Ordonnateur',
+          },
+          dropsFieldNotes: false,
+          shortLabel: {
+          	en: 'Familiar',
+          	fr: 'Ordonnateur',
           },
           x: 28.0,
           y: 29.2,
@@ -2824,9 +3530,14 @@ const Options = {
         },
         lookstodiefor: {
           label: {
-            en: 'Looks',
+            en: 'Looks to Die For',
             de: 'Ayda',
             fr: 'Écaillage en règle',
+          },
+          dropsFieldNotes: false,
+          shortLabel: {
+          	en: 'Looks',
+          	fr: 'Écaillage',
           },
           x: 17.4,
           y: 9.8,
@@ -2835,9 +3546,15 @@ const Options = {
         },
         takingthelyonsshare: {
           label: {
-            en: 'Lyon\'s',
+            en: 'Taking the Lyon\'s Share',
             de: 'Revanche: Lyon',
             fr: 'La revanche de Lyon',
+          },
+          dropsFieldNotes: true,
+          fieldNotes: 44,
+          shortLabel: {
+          	en: 'Lyon\'s',
+          	fr: 'Lyon',
           },
           x: 22.5,
           y: 13.2,
@@ -2866,6 +3583,8 @@ const gWeatherIcons = {
 };
 const gNightIcon = '&#x1F319;';
 const gDayIcon = '&#x263C;';
+// ✭ for rarity for field notes listing
+const gRarityIcon = '&#x272D;';
 
 let gTracker;
 class EurekaTracker {
@@ -2936,6 +3655,7 @@ class EurekaTracker {
   AddElement(container, nmKey) {
     const nm = this.nms[nmKey];
     const label = document.createElement('div');
+    const fieldNotesList = this.zoneInfo.fieldNotes;
     label.classList.add('nm');
 
     if (nm.isCritical)
@@ -2955,7 +3675,20 @@ class EurekaTracker {
     const name = document.createElement('span');
     name.classList.add('nm-name');
     name.classList.add('text');
-    name.innerText = this.TransByDispLang(nm.label);
+
+    // Short labels only exist for Save-The-Queen content
+    // Changes names' length depending on users options
+    // If no strings are available, the english short ones will be the default ones
+    if(this.zoneInfo.treatNMsAsSkirmishes)
+    {
+        if (this.options.CompleteNamesSTQ)
+            name.innerText = this.TransByDispLang(nm.label);
+        if(!name.innerText)
+            name.innerText = this.TransByDispLang(nm.shortLabel);
+    }
+    else
+        name.innerText = this.TransByDispLang(nm.label);
+
     const progress = document.createElement('span');
     progress.innerText = '';
     progress.classList.add('nm-progress');
@@ -2963,12 +3696,31 @@ class EurekaTracker {
     const time = document.createElement('span');
     time.classList.add('nm-time');
     time.classList.add('text');
+    const enriched = document.createElement('span');
+    enriched.classList.add('nm-enriched');
+    enriched.classList.add('text');
 
     if (nm.bunny)
       label.classList.add('bunny');
 
+    // Enriched options for Save-The-Queen content
+    // Adds field note drops, name, id & rarity of those
+    if(this.zoneInfo.treatNMsAsSkirmishes && this.options.EnrichedSTQ && nm.dropsFieldNotes) {
+        for (var i=0; i < Object.keys(fieldNotesList).length; i++) {
+            if (fieldNotesList[i].id === nm.fieldNotes) {
+                enriched.innerText = ("#" + fieldNotesList[i].id + " : " + fieldNotesList[i].shortname + " - ");
+                for (var i2 = 0; i2 != fieldNotesList[i].rarity; i2++) {
+                    enriched.innerText += (gRarityIcon);
+                }
+            }
+        }
+    }
+
     label.appendChild(icon);
     label.appendChild(name);
+    // We don't need an extra empty span if not in Bozja or if user doesn't need it
+    if (this.options.EnrichedSTQ && this.zoneInfo.treatNMsAsSkirmishes)
+        label.appendChild(enriched);
     label.appendChild(progress);
     label.appendChild(time);
     container.appendChild(label);

--- a/ui/eureka/eureka.js
+++ b/ui/eureka/eureka.js
@@ -1732,110 +1732,110 @@ const Options = {
       mapToPixelXConstant: -292.56,
       mapToPixelYScalar: 48.938,
       mapToPixelYConstant: -349.22,
-      fieldNotes: {
-      	bajsaljen: {
+      fieldNotes: [
+      	{
       		id: 1,
       		name: "Bajsaljen Ulgasch",
       		shortname: "Bajsalen",
       		rarity: 1,
       	},
-      	marsak: {
+      	{
       		id: 2,
       		name: "Marsak Apella",
       		shortname: "Marsak",
       		rarity: 1,
       	},
-      	xeven: {
+      	{
       		id: 3,
       		name: "Xeven Scanasch",
       		shortname: "Xeven",
       		rarity: 1,
       	},
-      	isolde: {
+      	{
       		id: 4,
       		name: "Isolde Covey",
       		shortname: "Isolde",
       		rarity: 2,
       	},
-      	stanik: {
+      	{
       		id: 5,
       		name: "Stanik Alubov",
       		shortname: "Stanik",
       		rarity: 1,
       	},
-      	blaz: {
+      	{
       		id: 6,
       		name: "Blaz Azetina",
       		shortname: "Blaz",
       		rarity: 3,
       	},
-      	velibor: {
+      	{
       		id: 7,
       		name: "Velibor Azetina",
       		shortname: "Velibor",
       		rarity: 3,
       	},
-      	aggie: {
+      	{
       		id: 8,
       		name: "Aggie Glover",
       		shortname: "Aggie",
       		rarity: 1,
       	},
-      	llofii: {
+      	{
       		id: 9,
       		name: "Llofii pyr Potitus",
       		shortname: "Llofii",
       		rarity: 2,
       	},
-      	hernais: {
+        {
       		id: 10,
       		name: "Hernais pyr Longus",
       		shortname: "Hernais",
       		rarity: 3,
       	},
-      	dabog: {
+      	{
       		id: 11,
       		name: "Dabog aan Inivisch",
       		shortname: "Dabog",
       		rarity: 5,
       	},
-      	dyunbu: {
+      	{
       		id: 12,
       		name: "Dyunbu pyr Potitus",
       		shortname: "Dyunbu",
       		rarity: 4,
       	},
-      	clarricie: {
+      	{
       		id: 13,
       		name: "Clarricie quo Priscus",
       		shortname: "Clarricie",
       		rarity: 2,
       	},
-      	sartauvoir: {
+      	{
       		id: 14,
       		name: "Sartauvoir quo Soranus",
       		shortname: "Sartauvoir",
       		rarity: 5,
       	},
-      	sicinius: {
+      	{
       		id: 15,
       		name: "Sicinius mal Vellutus",
       		shortname: "Sicinius",
       		rarity: 3,
       	},
-      	albeleo: {
+      	{
       		id: 16,
       		name: "Sadr rem Albeleo",
       		shortname: "Albeleo",
       		rarity: 3,
       	},
-      	lyon: {
+      	{
       		id: 17,
       		name: "Lyon rem Helsos",
       		shortname: "Lyon",
       		rarity: 5,
       	},
-      },
+      ],
       nms: {
         sneak: {
           label: {
@@ -2779,104 +2779,104 @@ const Options = {
       mapToPixelXConstant: 10.03,
       mapToPixelYScalar: 39.247,
       mapToPixelYConstant: -202.55,
-      fieldNotes:{
-      	atori: {
+      fieldNotes:[
+      	{
       		id: 31,
       		name: "Atori Moribe",
       		shortname: "Atori",
       		rarity: 1,
       	},
-      	kosyu: {
+      	{
       		id: 32,
       		name: "Kosyu",
       		shortname: "Kosyu",
       		rarity: 2,
       	},
-      	oboro: {
+      	{
       		id: 33,
       		name: "Oboro Torioi",
       		shortname: "Oboro",
       		rarity: 1,
       	},
-      	tsubame: {
+      	{
       		id: 34,
       		name: "Tsubame",
       		shortname: "Tsubame Oshidari",
       		rarity: 3,
       	},
-      	meryall: {
+      	{
       		id: 35,
       		name: "Meryall Miller",
       		shortname: "Meryall",
       		rarity: 2,
       	},
-      	lovro: {
+      	{
       		id: 36,
       		name: "Lovro aan Slanasch",
       		shortname: "Lovro",
       		rarity: 3,
       	},
-      	llofii: {
+      	{
       		id: 37,
       		name: "Llofii pyr Potitus",
       		shortname: "Llofii",
       		rarity: 4,
       	},
-      	fabineau: {
+      	{
       		id: 38,
       		name: "Fabineau quo Soranus",
       		shortname: "Fabineau",
       		rarity: 2,
       	},
-      	yamatsumi: {
+      	{
       		id: 39,
       		name: "Yamatsumi pyr Urabe",
       		shortname: "Yamatsumi",
       		rarity: 3,
       	},
-      	pagaga: {
+      	{
       		id: 40,
       		name: "Pagaga quo Vochstein",
       		shortname: "Pagaga",
       		rarity: 1,
       	},
-      	daguza: {
+      	{
       		id: 41,
       		name: "Daguza oen Sus",
       		shortname: "Daguza",
       		rarity: 1,
       	},
-      	gilbrisbert: {
+      	{
       		id: 42,
       		name: "Gilbrisbert quo Buteo",
       		shortname: "Gilbrisbert",
       		rarity: 2,
       	},
-      	dabog: {
+      	{
       		id: 43,
       		name: "Dabog aan Inivisch",
       		shortname: "Dabog",
       		rarity: 5,
       	},
-      	lyon: {
+      	{
       		id: 44,
       		name: "Lyon quo Helsos",
       		shortname: "Lyon",
       		rarity: 5,
       	},
-      	menenius: {
+      	{
       		id: 45,
       		name: "Menenius sas Lanatus",
       		shortname: "Menenius",
       		rarity: 5,
       	},
-      	diablo: {
+      	{
       		id: 46,
       		name: "Diablo",
       		shortname: "Diablo",
       		rarity: 3,
       	},
-      },
+      ],
       nms: {
         ofbeastsandbraggadocio: {
           label: {

--- a/ui/eureka/eureka_config.ts
+++ b/ui/eureka/eureka_config.ts
@@ -35,6 +35,24 @@ UserConfig.registerOptions('eureka', {
       },
     },
     {
+      id: 'CompleteNamesSTQ',
+      name: {
+        en: 'Prefer complete names for BSF and Zadnor\'s Skirmishes/Critical Engagements',
+        fr: 'Préférer les noms complet pour les escarmouches/Affrontements Cruciaux dans Bozja/Zadnor',
+      },
+      type: 'checkbox',
+      default: false,
+    },
+    {
+      id: 'EnrichedSTQ',
+      name: {
+        en: 'Add information about BSF and Zadnor\'s Fields Notes',
+        fr: 'Ajouter les informations relatives aux Notes ',
+      },
+      type: 'checkbox',
+      default: false,
+    },
+    {
       id: 'PopNoiseForNM',
       name: {
         en: 'Play pop sound for NMs',


### PR DESCRIPTION
Following our discussion in [this PR](https://github.com/quisquous/cactbot/pull/3076), here are new features and changes/additions for cactbot-eureka:

1. User Option to allow complete names
2. User Option to allow enriched content
3. Complete names of the Skirmish/CE (english short names moved to "shortname" property)
4. Field Notes informations (data gathered manually, may be off somewhere but I kinda doubt that)
5. Field Notes display if Skirmish/CE has one

These user options are disabled by default and the changes have been made so that they're 100% opt-in. 

![Advanced_Combat_Tracker_oW8pIosfgA](https://user-images.githubusercontent.com/4359469/121830984-a6440a80-ccc6-11eb-958d-83d4dcb848eb.png)
Complete names and enriched informations, English
![Advanced_Combat_Tracker_1DSkSiOjwd](https://user-images.githubusercontent.com/4359469/121830982-a5ab7400-ccc6-11eb-9879-9fa123ece0b3.png)
Short names and enriched informations, French

These new features were tested by bruteforcing them in the eureka.bundle.js (sorry) in the 4 parts of Eureka, Bozja and Zadnor. 
The user options couldn't be correctly tested tho, as it wasn't something I was 100% sure of nor was able to try out. 

I don't speak German/Japanese/Korean/Chinese so I couldn't do short/long versions for those ; also, German looks like it's both having short and long versions mixed in, so I didn't touch them at all.

Finally, CSS isn't my cup of tea so I didn't touch it at all, but the new span for enriched information is named "nm-enriched". Feel free to make it pretty !