### PR TITLE
raidemulator: Update job fields to use Job type

### DIFF
--- a/ui/raidboss/emulator/data/Combatant.ts
+++ b/ui/raidboss/emulator/data/Combatant.ts
@@ -1,4 +1,5 @@
 import { UnreachableCode } from '../../../../resources/not_reached';
+import { Job } from '../../../../types/job';
 import CombatantState from './CombatantState';
 
 export default class Combatant {
@@ -8,7 +9,7 @@ export default class Combatant {
   states: { [timestamp: number]: CombatantState } = {};
   significantStates: number[] = [];
   latestTimestamp = -1;
-  job?: string;
+  job?: Job;
   jobId?: number;
   level?: number;
 

--- a/ui/raidboss/emulator/data/CombatantJobSearch.ts
+++ b/ui/raidboss/emulator/data/CombatantJobSearch.ts
@@ -3,8 +3,10 @@ import { Job } from '../../../../types/job';
 export default class CombatantJobSearch {
   static getJob(abilityId: number): Job | undefined {
     for (const [key, value] of Object.entries(CombatantJobSearch.abilities)) {
-      if (value.includes(abilityId))
-        return key as Job;
+      if (value) {
+        if (value.includes(abilityId))
+          return key as Job;
+      }
     }
   }
 

--- a/ui/raidboss/emulator/data/CombatantJobSearch.ts
+++ b/ui/raidboss/emulator/data/CombatantJobSearch.ts
@@ -1,14 +1,20 @@
+import { Job } from '../../../../types/job';
+
 export default class CombatantJobSearch {
-  static getJob(abilityId: number): string | undefined {
-    for (const job in CombatantJobSearch.abilities) {
-      if (CombatantJobSearch.abilities[job]?.includes(abilityId))
+  static getJob(abilityId: number): Job | undefined {
+    for (const key in CombatantJobSearch.abilities) {
+      const job = key as Job;
+      const list = CombatantJobSearch.abilities[job];
+      if (!list)
+        continue;
+      if (list.includes(abilityId))
         return job;
     }
   }
 
   static readonly abilityMatchRegex = /[a-fA-F0-9]{1,4}/i;
 
-  static readonly abilities: { [job: string]: number[] } = {
+  static readonly abilities: { [job in Job]?: number[] } = {
     PLD: [
       12959, 12961, 12964, 12967, 12968, 12969, 12970, 12971, 12972, 12973, 12974, 12975,
       12976, 12978, 12980, 12981, 12982, 12983, 12984, 12985, 12986, 12987, 12988, 12989,

--- a/ui/raidboss/emulator/data/CombatantJobSearch.ts
+++ b/ui/raidboss/emulator/data/CombatantJobSearch.ts
@@ -2,13 +2,9 @@ import { Job } from '../../../../types/job';
 
 export default class CombatantJobSearch {
   static getJob(abilityId: number): Job | undefined {
-    for (const key in CombatantJobSearch.abilities) {
-      const job = key as Job;
-      const list = CombatantJobSearch.abilities[job];
-      if (!list)
-        continue;
-      if (list.includes(abilityId))
-        return job;
+    for (const [key, value] of Object.entries(CombatantJobSearch.abilities)) {
+      if (value.includes(abilityId))
+        return key as Job;
     }
   }
 

--- a/ui/raidboss/emulator/data/CombatantJobSearch.ts
+++ b/ui/raidboss/emulator/data/CombatantJobSearch.ts
@@ -4,7 +4,7 @@ export default class CombatantJobSearch {
   static getJob(abilityId: number): Job | undefined {
     for (const [key, value] of Object.entries(CombatantJobSearch.abilities)) {
       if (value?.includes(abilityId))
-        return key as Job;
+        return key as keyof typeof CombatantJobSearch.abilities;
     }
   }
 

--- a/ui/raidboss/emulator/data/CombatantJobSearch.ts
+++ b/ui/raidboss/emulator/data/CombatantJobSearch.ts
@@ -3,10 +3,8 @@ import { Job } from '../../../../types/job';
 export default class CombatantJobSearch {
   static getJob(abilityId: number): Job | undefined {
     for (const [key, value] of Object.entries(CombatantJobSearch.abilities)) {
-      if (value) {
-        if (value.includes(abilityId))
-          return key as Job;
-      }
+      if (value?.includes(abilityId))
+        return key as Job;
     }
   }
 

--- a/ui/raidboss/emulator/data/CombatantTracker.ts
+++ b/ui/raidboss/emulator/data/CombatantTracker.ts
@@ -125,9 +125,6 @@ export default class CombatantTracker {
       if (!combatant.job && !line.id.startsWith('4') && line.abilityId !== undefined)
         combatant.job = CombatantJobSearch.getJob(line.abilityId);
     }
-
-    if (combatant.job)
-      combatant.job = combatant.job.toUpperCase();
   }
 
   addCombatantFromTargetLine(line: LineEventTarget): void {

--- a/ui/raidboss/emulator/data/network_log_converter/LineEvent.ts
+++ b/ui/raidboss/emulator/data/network_log_converter/LineEvent.ts
@@ -1,3 +1,4 @@
+import { Job } from '../../../../../types/job';
 import EmulatorCommon from '../../EmulatorCommon';
 import LogRepository from './LogRepository';
 
@@ -105,7 +106,7 @@ export const isLineEventTarget = (line: LineEvent): line is LineEventTarget => {
 
 export interface LineEventJobLevel extends LineEvent {
   readonly isJobLevel: true;
-  readonly job: string;
+  readonly job: Job;
   readonly jobId: number;
   readonly level: number;
 }

--- a/ui/raidboss/emulator/data/network_log_converter/LineEvent0x03.ts
+++ b/ui/raidboss/emulator/data/network_log_converter/LineEvent0x03.ts
@@ -2,6 +2,7 @@ import LineEvent, { LineEventJobLevel, LineEventSource } from './LineEvent';
 import EmulatorCommon from '../../EmulatorCommon';
 import Util from '../../../../../resources/util';
 import LogRepository from './LogRepository';
+import { Job } from '../../../../../types/job';
 
 const fields = {
   id: 2,
@@ -31,7 +32,7 @@ export class LineEvent0x03 extends LineEvent implements LineEventSource, LineEve
   public readonly name: string;
   public readonly jobIdHex: string;
   public readonly jobId: number;
-  public readonly job: string;
+  public readonly job: Job;
   public readonly levelString: string;
   public readonly level: number;
   public readonly ownerId: string;

--- a/ui/raidboss/emulator/data/network_log_converter/LineEvent0x26.ts
+++ b/ui/raidboss/emulator/data/network_log_converter/LineEvent0x26.ts
@@ -2,6 +2,7 @@ import LineEvent, { LineEventJobLevel, LineEventSource } from './LineEvent';
 import EmulatorCommon from '../../EmulatorCommon';
 import Util from '../../../../../resources/util';
 import LogRepository from './LogRepository';
+import { Job } from '../../../../../types/job';
 
 const fields = {
   id: 2,
@@ -23,7 +24,7 @@ const fields = {
 export class LineEvent0x26 extends LineEvent implements LineEventSource, LineEventJobLevel {
   public readonly jobIdHex: string;
   public readonly jobId: number;
-  public readonly job: string;
+  public readonly job: Job;
   public readonly level: number;
   public readonly id: string;
   public readonly name: string;


### PR DESCRIPTION
I feel like there's a better way to handle CombatantJobSearch but I can't see it?

This is in prep for converting PopupTextAnalysis to typescript. I'll probably visit the JobDetail type next since that's also causing some annoyances with conversion.