### PR TITLE
raidboss: Add helper to watch combatants

### DIFF
--- a/resources/util.ts
+++ b/resources/util.ts
@@ -84,7 +84,6 @@ type WatchCombatantParams = {
   names?: string[];
   props?: string[];
   delay?: number;
-  maxRetries?: number;
   maxDuration?: number;
 };
 
@@ -93,7 +92,6 @@ type WatchCombatantFunc = (params: WatchCombatantParams,
 
 type WatchCombatantMapEntry = {
   cancel: boolean;
-  tries: number;
   start: number;
 };
 
@@ -102,8 +100,6 @@ const watchCombatantMap: WatchCombatantMapEntry[] = [];
 const shouldCancelWatch =
   (params: WatchCombatantParams, entry: WatchCombatantMapEntry): boolean => {
     if (entry.cancel)
-      return true;
-    if (params.maxRetries !== undefined && entry.tries > params.maxRetries)
       return true;
     if (params.maxDuration !== undefined && Date.now() - entry.start > params.maxDuration)
       return true;
@@ -129,14 +125,12 @@ const watchCombatant: WatchCombatantFunc = (params, func) => {
 
     const entry: WatchCombatantMapEntry = {
       cancel: false,
-      tries: 0,
       start: Date.now(),
     };
 
     watchCombatantMap.push(entry);
 
     const checkFunc = () => {
-      ++entry.tries;
       if (shouldCancelWatch(params, entry)) {
         rej();
         return;

--- a/types/event.d.ts
+++ b/types/event.d.ts
@@ -317,12 +317,47 @@ type PlayerChangedRet = Job extends infer T ? T extends Job ? {
   debugJob: string;
 } : never : never;
 
+// Member names taken from OverlayPlugin's MiniParse.cs
+// Types taken from FFXIV parser plugin
+export interface PluginCombatantState {
+  CurrentWorldID?: number;
+  WorldID?: number;
+  WorldName?: string;
+  BNpcID?: number;
+  BNpcNameID?: number;
+  PartyType?: number;
+  ID?: number;
+  OwnerID?: number;
+  type?: number;
+  Job?: number;
+  Level?: number;
+  Name?: string;
+  CurrentHP: number;
+  MaxHP: number;
+  CurrentMP: number;
+  MaxMP: number;
+  PosX: number;
+  PosY: number;
+  PosZ: number;
+  Heading: number;
+}
+
+export type GetCombatantsCall = {
+  call: 'getCombatants';
+  ids?: number[];
+  names?: string[];
+  props?: string[];
+};
+
+export type GetCombatantsRet = { combatants: PluginCombatantState[] };
+
 export type IOverlayHandler = {
   // OutputPlugin build-in
   (msg: {
     call: 'subscribe';
     events: string[];
   }): Promise<null>;
+  (msg: GetCombatantsCall): Promise<GetCombatantsRet>;
   // TODO: add OverlayPlugin build-in handlers
   // Cactbot
   // TODO: fill up all handler types

--- a/ui/raidboss/data/00-misc/test.js
+++ b/ui/raidboss/data/00-misc/test.js
@@ -255,8 +255,6 @@ export default {
           data.me,
           strikingDummyNames[data.lang] || strikingDummyNames['en'],
         ],
-        // 100 retries
-        maxRetries: 100,
         // 50 seconds
         maxDuration: 50000,
       },

--- a/ui/raidboss/data/00-misc/test.js
+++ b/ui/raidboss/data/00-misc/test.js
@@ -255,6 +255,10 @@ export default {
           data.me,
           strikingDummyNames[data.lang] || strikingDummyNames['en'],
         ],
+        // 100 retries
+        maxRetries: 100,
+        // 50 seconds
+        maxDuration: 50000,
       },
       (ret) => {
         const me = ret.combatants.find((c) => c.Name === data.me);

--- a/ui/raidboss/data/00-misc/test.js
+++ b/ui/raidboss/data/00-misc/test.js
@@ -1,5 +1,6 @@
 import NetRegexes from '../../../../resources/netregexes';
 import outputs from '../../../../resources/outputs';
+import Util from '../../../../resources/util';
 import ZoneId from '../../../../resources/zone_id';
 
 export default {
@@ -240,6 +241,33 @@ export default {
           infoText: output.infoThree(),
           tts: output.ttsFour(),
         };
+      },
+    },
+    {
+      id: 'Test Watch',
+      netRegex: NetRegexes.echo({ line: 'cactbot test watch.*?', capture: false }),
+      promise: (data) => Util.watchCombatant({ names: [data.me, 'Striking Dummy'] }, (ret) => {
+        const me = ret.combatants.filter((c) => c.Name === data.me)[0];
+        const dummies = ret.combatants.filter((c) => c.Name === 'Striking Dummy');
+        if (me && dummies) {
+          for (const dummy of dummies) {
+            const distX = Math.abs(me.PosX - dummy.PosX);
+            const distY = Math.abs(me.PosY - dummy.PosY);
+            const dist = Math.hypot(distX, distY);
+            console.log(`test watch: distX = ${distX}; distY = ${distY}; dist = ${dist}`);
+            if (dist < 5)
+              return true;
+          }
+          return false;
+        }
+        console.log(`test watch: me = ${me ? 'true' : 'false'}; ${dummy ? 'true' : 'false'}`);
+        return false;
+      }),
+      infoText: (_data, _matches, output) => output.close(),
+      outputStrings: {
+        close: {
+          en: 'Dummy close!',
+        },
       },
     },
   ],

--- a/ui/raidboss/data/00-misc/test.js
+++ b/ui/raidboss/data/00-misc/test.js
@@ -3,6 +3,10 @@ import outputs from '../../../../resources/outputs';
 import Util from '../../../../resources/util';
 import ZoneId from '../../../../resources/zone_id';
 
+const strikingDummyNames = {
+  en: 'Striking Dummy',
+};
+
 export default {
   zoneId: ZoneId.MiddleLaNoscea,
   timelineFile: 'test.txt',
@@ -246,9 +250,16 @@ export default {
     {
       id: 'Test Watch',
       netRegex: NetRegexes.echo({ line: 'cactbot test watch.*?', capture: false }),
-      promise: (data) => Util.watchCombatant({ names: [data.me, 'Striking Dummy'] }, (ret) => {
+      promise: (data) => Util.watchCombatant({
+        names: [
+          data.me,
+          strikingDummyNames[data.lang] || strikingDummyNames['en'],
+        ],
+      },
+      (ret) => {
         const me = ret.combatants.find((c) => c.Name === data.me);
-        const dummies = ret.combatants.filter((c) => c.Name === 'Striking Dummy');
+        const dummyName = strikingDummyNames[data.lang] || strikingDummyNames['en'];
+        const dummies = ret.combatants.filter((c) => c.Name === dummyName);
         if (me && dummies) {
           for (const dummy of dummies) {
             const distX = Math.abs(me.PosX - dummy.PosX);

--- a/ui/raidboss/data/00-misc/test.js
+++ b/ui/raidboss/data/00-misc/test.js
@@ -247,7 +247,7 @@ export default {
       id: 'Test Watch',
       netRegex: NetRegexes.echo({ line: 'cactbot test watch.*?', capture: false }),
       promise: (data) => Util.watchCombatant({ names: [data.me, 'Striking Dummy'] }, (ret) => {
-        const me = ret.combatants.filter((c) => c.Name === data.me)[0];
+        const me = ret.combatants.find((c) => c.Name === data.me);
         const dummies = ret.combatants.filter((c) => c.Name === 'Striking Dummy');
         if (me && dummies) {
           for (const dummy of dummies) {

--- a/ui/raidboss/emulator/data/CombatantState.ts
+++ b/ui/raidboss/emulator/data/CombatantState.ts
@@ -1,27 +1,4 @@
-// Member names taken from OverlayPlugin's MiniParse.cs
-// Types taken from FFXIV parser plugin
-export interface PluginState {
-  CurrentWorldID?: number;
-  WorldID?: number;
-  WorldName?: string;
-  BNpcID?: number;
-  BNpcNameID?: number;
-  PartyType?: number;
-  ID?: number;
-  OwnerID?: number;
-  type?: number;
-  Job?: number;
-  Level?: number;
-  Name?: string;
-  CurrentHP: number;
-  MaxHP: number;
-  CurrentMP: number;
-  MaxMP: number;
-  PosX: number;
-  PosY: number;
-  PosZ: number;
-  Heading: number;
-}
+import { PluginCombatantState } from '../../../../types/event';
 
 export default class CombatantState {
   posX: number;
@@ -61,7 +38,7 @@ export default class CombatantState {
         props.maxMp ?? this.maxMp);
   }
 
-  toPluginState(): PluginState {
+  toPluginState(): PluginCombatantState {
     return {
       PosX: this.posX,
       PosY: this.posY,

--- a/ui/raidboss/popup-text.ts
+++ b/ui/raidboss/popup-text.ts
@@ -804,6 +804,7 @@ export class PopupText {
   }
 
   Reset(): void {
+    Util.clearWatchCombatants();
     this.data = this.getDataObject();
     this.StopTimers();
     this.triggerSuppress = {};


### PR DESCRIPTION
This PR adds a `Util.watchCombatants` helper method to monitor combatants, as well as a test trigger showing the usage.

As discussed in #3099