### PR TITLE
method of `Output` should accpet `number` as param value

### DIFF
--- a/types/trigger.d.ts
+++ b/types/trigger.d.ts
@@ -34,7 +34,7 @@ export type OutputStrings = { [outputKey: string]: LocaleText };
 export type Output = {
   responseOutputStrings: OutputStrings;
 } & {
-  [key: string]: (params?: { [param: string]: string | undefined }) => string;
+  [key: string]: (params?: { [param: string]: string | number | undefined }) => string;
 };
 
 // The output of any non-response raidboss trigger function.


### PR DESCRIPTION
`number` should be a current type of the parameter of `output.method()`, as we accept a number as replacement value in popup-text.

![image](https://user-images.githubusercontent.com/13553903/122161460-56bb3580-cea4-11eb-9d48-33e47c4a262b.png)

```diff
diff --git a/types/trigger.d.ts b/types/trigger.d.ts
index 73c0452a..649663f0 100644
--- a/types/trigger.d.ts
+++ b/types/trigger.d.ts
@@ -34,7 +34,7 @@ export type OutputStrings = { [outputKey: string]: LocaleText };
 export type Output = {
   responseOutputStrings: OutputStrings;
 } & {
-  [key: string]: (params?: { [param: string]: string | undefined }) => string;
+  [key: string]: (params?: { [param: string]: string | number | undefined }) => string;
 };
 
 // The output of any non-response raidboss trigger function.
```
