### PR TITLE
More auto-type-inferrence for triggers

### DIFF
--- a/resources/conditions.ts
+++ b/resources/conditions.ts
@@ -2,14 +2,14 @@
 // are also functions.
 
 import { RaidbossData as Data } from '../types/data';
-import { TargetedMatches } from '../types/trigger';
+import { MatchesAny, TargetedMatches } from '../types/trigger';
 
 export default {
   targetIsYou(): (data: Data, matches: TargetedMatches) => boolean {
-    return (data: Data, matches: TargetedMatches) => data.me === matches?.target;
+    return (data: Data, matches: MatchesAny) => 'target' in matches && data.me === matches?.target;
   },
   targetIsNotYou(): (data: Data, matches: TargetedMatches) => boolean {
-    return (data: Data, matches: TargetedMatches) => data.me !== matches?.target;
+    return (data: Data, matches: MatchesAny) => 'target' in matches && data.me !== matches?.target;
   },
   caresAboutAOE(): (data: Data) => boolean {
     return (data: Data) => data.role === 'tank' || data.role === 'healer' || data.CanAddle() || data.job === 'BLU';

--- a/resources/conditions.ts
+++ b/resources/conditions.ts
@@ -6,10 +6,10 @@ import { MatchesAny, TargetedMatches } from '../types/trigger';
 
 export default {
   targetIsYou(): (data: Data, matches: TargetedMatches) => boolean {
-    return (data: Data, matches: MatchesAny) => 'target' in matches && data.me === matches?.target;
+    return (data: Data, matches: MatchesAny) => 'target' in matches && data.me === matches.target;
   },
   targetIsNotYou(): (data: Data, matches: TargetedMatches) => boolean {
-    return (data: Data, matches: MatchesAny) => 'target' in matches && data.me !== matches?.target;
+    return (data: Data, matches: MatchesAny) => 'target' in matches && data.me !== matches.target;
   },
   caresAboutAOE(): (data: Data) => boolean {
     return (data: Data) => data.role === 'tank' || data.role === 'healer' || data.CanAddle() || data.job === 'BLU';

--- a/resources/matches.ts
+++ b/resources/matches.ts
@@ -44,3 +44,29 @@ export type MatchesStatChange = Matches<StatChangeParams>;
 export type MatchesChangeZone = Matches<ChangeZoneParams>;
 export type MatchesNetwork6d = Matches<Network6dParams>;
 export type MatchesNameToggle = Matches<NameToggleParams>;
+
+export interface MatchesAll {
+  'StartsUsingParams': MatchesStartsUsing;
+  'AbilityParams': MatchesAbility;
+  'AbilityFullParams': MatchesAbilityFull;
+  'HeadMarkerParams': MatchesHeadMarker;
+  'AddedCombatantParams': MatchesAddedCombatant;
+  'AddedCombatantFullParams': MatchesAddedCombatantFull;
+  'RemovingCombatantParams': MatchesRemovingCombatant;
+  'GainsEffectParams': MatchesGainsEffect;
+  'StatusEffectExplicitParams': MatchesStatusEffectExplicit;
+  'LosesEffectParams': MatchesLosesEffect;
+  'TetherParams': MatchesTether;
+  'WasDefeatedParams': MatchesWasDefeated;
+  'EchoParams': MatchesEcho;
+  'DialogParams': MatchesDialog;
+  'MessageParams': MatchesMessage;
+  'GameLogParams': MatchesGameLog;
+  'GameNameLogParams': MatchesGameNameLog;
+  'StatChangeParams': MatchesStatChange;
+  'ChangeZoneParams': MatchesChangeZone;
+  'Network6dParams': MatchesNetwork6d;
+  'NameToggleParams': MatchesNameToggle;
+}
+
+export type MatchesAllTypes = keyof MatchesAll;

--- a/resources/regexes.ts
+++ b/resources/regexes.ts
@@ -152,6 +152,31 @@ export type GameNameLogParams = typeof gameNameLogParams[number];
 export type ChangeZoneParams = typeof changeZoneParams[number];
 export type Network6dParams = typeof network6dParams[number];
 
+export interface ParamsAll {
+  'StartsUsingParams': StartsUsingParams;
+  'AbilityParams': AbilityParams;
+  'AbilityFullParams': AbilityFullParams;
+  'HeadMarkerParams': HeadMarkerParams;
+  'AddedCombatantParams': AddedCombatantParams;
+  'AddedCombatantFullParams': AddedCombatantFullParams;
+  'RemovingCombatantParams': RemovingCombatantParams;
+  'GainsEffectParams': GainsEffectParams;
+  'StatusEffectExplicitParams': StatusEffectExplicitParams;
+  'LosesEffectParams': LosesEffectParams;
+  'TetherParams': TetherParams;
+  'WasDefeatedParams': WasDefeatedParams;
+  'EchoParams': EchoParams;
+  'DialogParams': DialogParams;
+  'MessageParams': MessageParams;
+  'GameLogParams': GameLogParams;
+  'GameNameLogParams': GameNameLogParams;
+  'StatChangeParams': StatChangeParams;
+  'ChangeZoneParams': ChangeZoneParams;
+  'Network6dParams': Network6dParams;
+}
+
+export type ParamsAllTypes = keyof ParamsAll;
+
 export default class Regexes {
   /**
    * fields: source, id, ability, target, capture
@@ -695,7 +720,7 @@ export default class Regexes {
     return anyOfArray(array);
   }
 
-  static parse(regexpString: RegExp | string): RegExp {
+  static parse<T extends ParamsAllTypes>(regexpString: RegExp | string): Regex<ParamsAll[T]> {
     const kCactbotCategories = {
       Timestamp: '^.{14}',
       NetTimestamp: '.{33}',
@@ -723,7 +748,7 @@ export default class Regexes {
     regexpString = regexpString.replace(/\\y\{(.*?)\}/g, (match, group) => {
       return kCactbotCategories[group as keyof typeof kCactbotCategories] || match;
     });
-    return new RegExp(regexpString, modifiers);
+    return new RegExp(regexpString, modifiers) as Regex<ParamsAll[T]>;
   }
 
   // Like Regex.Regexes.parse, but force global flag.

--- a/resources/responses.ts
+++ b/resources/responses.ts
@@ -18,7 +18,7 @@
 // function that sets outputStrings and returns an object without doing
 // anything with data or matches.  See `responses_test.js`.
 
-import { LocaleText, ResponseOutput, ResponseFunc, TriggerFunc, TargetedMatches, Output, TriggerOutput } from '../types/trigger';
+import { LocaleText, ResponseOutput, ResponseFunc, TriggerFunc, TargetedMatches, Output, TriggerOutput, MatchesAny } from '../types/trigger';
 import { RaidbossData as Data } from '../types/data';
 
 import Outputs from './outputs';
@@ -26,7 +26,7 @@ import Outputs from './outputs';
 type TargetedResponseOutput = ResponseOutput<Data, TargetedMatches>;
 type TargetedResponseFunc = ResponseFunc<Data, TargetedMatches>;
 type TargetedFunc = TriggerFunc<Data, TargetedMatches, TriggerOutput<Data, TargetedMatches>>;
-type StaticResponseFunc = ResponseFunc<Data, unknown>;
+type StaticResponseFunc = ResponseFunc<Data, MatchesAny>;
 
 type Severity = 'info' | 'alert' | 'alarm';
 type SevText = 'infoText' | 'alertText' | 'alarmText';

--- a/ui/radar/radar.ts
+++ b/ui/radar/radar.ts
@@ -5,7 +5,7 @@ import { Lang } from '../../resources/languages';
 import { callOverlayHandler, addOverlayListener } from '../../resources/overlay_plugin_api';
 import HuntData, { HuntEntry, HuntMap, Rank } from '../../resources/hunt';
 import { MatchesAddedCombatantFull } from '../../resources/matches';
-import NetRegexes from '../../resources/netregexes';
+import NetRegexes, { AbilityFullParams, AddedCombatantFullParams, GameLogParams, NetRegex, WasDefeatedParams } from '../../resources/netregexes';
 import { UnreachableCode } from '../../resources/not_reached';
 import UserConfig from '../../resources/user_config';
 
@@ -171,10 +171,10 @@ class Radar {
   private lang: Lang;
   private nameToHuntEntry: HuntMap;
   private regexes: {
-    abilityFull: RegExp;
-    addedCombatantFull: RegExp;
-    instanceChanged: RegExp;
-    wasDefeated: RegExp;
+    abilityFull: NetRegex<AbilityFullParams>;
+    addedCombatantFull: NetRegex<AddedCombatantFullParams>;
+    instanceChanged: NetRegex<GameLogParams>;
+    wasDefeated: NetRegex<WasDefeatedParams>;
   };
 
   constructor(element: HTMLElement) {

--- a/ui/raidboss/popup-text.ts
+++ b/ui/raidboss/popup-text.ts
@@ -362,8 +362,8 @@ class TriggerOutputProxy {
 }
 
 export type RaidbossTriggerField =
-  TriggerField<RaidbossData, TriggerOutput<RaidbossData, MatchesAny>> |
-  TriggerField<RaidbossData, PartialTriggerOutput<RaidbossData, MatchesAny>>;
+  TriggerField<RaidbossData, TriggerOutput<RaidbossData, MatchesAny>, MatchesAny> |
+  TriggerField<RaidbossData, PartialTriggerOutput<RaidbossData, MatchesAny>, MatchesAny>;
 export type RaidbossTriggerOutput = TriggerOutput<RaidbossData, MatchesAny> |
   PartialTriggerOutput<RaidbossData, MatchesAny>;
 
@@ -1147,7 +1147,7 @@ export class PopupText {
   }
 
   _onTriggerInternalResponse(triggerHelper: TriggerHelper): void {
-    let response: ResponseField<RaidbossData> = {};
+    let response: ResponseField<RaidbossData, MatchesAny> = {};
     const trigger = triggerHelper.trigger;
     if (trigger.response) {
       // Can't use ValueOrFunction here as r returns a non-localizable object.
@@ -1182,7 +1182,7 @@ export class PopupText {
       } else if (triggerHelper.trigger.tts) {
         result = triggerHelper.valueOrFunction(triggerHelper.trigger.tts);
       } else if (triggerHelper.response) {
-        const resp: ResponseField<RaidbossData> = triggerHelper.response;
+        const resp: ResponseField<RaidbossData, MatchesAny> = triggerHelper.response;
         if (resp.tts)
           result = triggerHelper.valueOrFunction(resp.tts);
       }

--- a/ui/raidboss/raidboss_options.ts
+++ b/ui/raidboss/raidboss_options.ts
@@ -14,7 +14,7 @@ export type PerTriggerOption = Partial<{
   GroupSpeechAlert: boolean; // TODO: we should remove this
   SoundOverride: string;
   VolumeOverride: number;
-  Condition: TriggerField<RaidbossData, boolean>;
+  Condition: TriggerField<RaidbossData, boolean, MatchesAny>;
   InfoText: TriggerOutput<RaidbossData, MatchesAny>;
   AlertText: TriggerOutput<RaidbossData, MatchesAny>;
   AlarmText: TriggerOutput<RaidbossData, MatchesAny>;


### PR DESCRIPTION
This wizard's library sure has a lot of nice books.

Closes #3119 

You still need to specify the type for callbacks, but this fixes type inference:

![image](https://user-images.githubusercontent.com/6119598/122290414-b2e08280-cec1-11eb-8127-4cea208072ba.png)
![image](https://user-images.githubusercontent.com/6119598/122290445-bbd15400-cec1-11eb-846e-dade852a358d.png)

I couldn't see a better way to handle the return value for `Regexes.parse` and `NetRegexes.parse`?