### PR TITLE
ci: add workflow lint pr title

### DIFF
--- a/.github/workflows/sematic-pr-title.yml
+++ b/.github/workflows/sematic-pr-title.yml
@@ -1,0 +1,54 @@
+name: "Sematic PR Title"
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - synchronize
+
+jobs:
+  main:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@v3.4.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          types: |
+            build
+            ci
+            fix
+            feat
+            refactor
+            chore
+            docs
+            style
+            perf
+            test
+          scopes: |
+            resources
+            ui
+            pullcounter
+            raidboss
+            oopsy
+            radar
+            eureka
+            jobs
+            test
+            util
+            config
+
+          requireScope: false
+          # For work-in-progress PRs you can typically use draft pull requests 
+          # from Github. However, private repositories on the free plan don't have 
+          # this option and therefore this action allows you to opt-in to using the 
+          # special "[WIP]" prefix to indicate this state. This will avoid the 
+          # validation of the PR title and the pull request checks remain pending.
+          # Note that a second check will be reported if this is enabled.
+          wip: true
+          # When using "Squash and merge" on a PR with only one commit, GitHub
+          # will suggest using that commit message instead of the PR title for the
+          # merge commit, and it's easy to commit this by mistake. Enable this option
+          # to also validate the commit message for one commit PRs.
+          validateSingleCommit: true

--- a/.github/workflows/sematic-pr-title.yml
+++ b/.github/workflows/sematic-pr-title.yml
@@ -26,6 +26,7 @@ jobs:
             style
             perf
             test
+            i18n
           scopes: |
             resources
             ui


### PR DESCRIPTION
Import [amannn/action-semantic-pull-request](https://github.com/amannn/action-semantic-pull-request) to make sure that PR title matches [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/),
i.e. something like:
```
<type>[optional scope]: <description>
```

in particular, this PR defines types such as 
- build: build-related change only
- ci: CI(Github Actions currently) changes only
- fix: fixed a bug
- feat: added a new feature
- refactor: neither fix a bug nor add a feature
- chore: others
- docs: documents changes only
- style: code style changes only
- perf: improved performance
- test: test changes only
- i18n: translation only

Also defines scopes such as:
- resources
- ui
- pullcounter
- raidboss
- oopsy
- radar
- eureka
- jobs
- test
- util
- config