### PR TITLE
Jobs: Remove obsolete timerbox reset calls

### DIFF
--- a/ui/jobs/components/ast.js
+++ b/ui/jobs/components/ast.js
@@ -67,20 +67,16 @@ export function setup(bars) {
   });
 
   bars.onUseAbility([kAbility.Combust2, kAbility.Combust3], () => {
-    combustBox.duration = 0;
     combustBox.duration = 30;
   });
   bars.onUseAbility(kAbility.Combust, () => {
-    combustBox.duration = 0;
     combustBox.duration = 18;
   });
 
   bars.onUseAbility(kAbility.Draw, () => {
-    drawBox.duration = 0;
     drawBox.duration = 30;
   });
   bars.onUseAbility(kAbility.LucidDreaming, () => {
-    lucidBox.duration = 0;
     lucidBox.duration = 60;
   });
 

--- a/ui/jobs/components/blm.js
+++ b/ui/jobs/components/blm.js
@@ -33,18 +33,15 @@ export function setup(bars) {
     [kAbility.Thunder4]: 18,
   };
   bars.onUseAbility(Object.keys(thunderDurationMap), (abilityId) => {
-    thunderDot.duration = 0;
     thunderDot.duration = thunderDurationMap[abilityId];
   });
 
   bars.onYouGainEffect(EffectId.Thundercloud, (_, matches) => {
-    thunderProc.duration = 0;
     thunderProc.duration = parseFloat(matches.duration);
   });
   bars.onYouLoseEffect(EffectId.Thundercloud, () => thunderProc.duration = 0);
 
   bars.onYouGainEffect(EffectId.Firestarter, (_, matches) => {
-    fireProc.duration = 0;
     fireProc.duration = parseFloat(matches.duration);
   });
   bars.onYouLoseEffect(EffectId.Firestarter, () => fireProc.duration = 0);

--- a/ui/jobs/components/blu.js
+++ b/ui/jobs/components/blu.js
@@ -26,28 +26,22 @@ export function setup(bars) {
   });
 
   bars.onUseAbility(kAbility.OffGuard, () => {
-    offguardBox.duration = 0;
     offguardBox.duration = calcGCDFromStat(bars, bars.spellSpeed, 60000);
   });
   bars.onUseAbility(kAbility.PeculiarLight, () => {
-    offguardBox.duration = 0;
     offguardBox.duration = calcGCDFromStat(bars, bars.spellSpeed, 60000);
   });
   bars.onUseAbility(kAbility.SongOfTorment, () => {
-    tormentBox.duration = 0;
     tormentBox.duration = 30;
   });
   // +0.5&0.8 for animation delay
   bars.onUseAbility(kAbility.AetherialSpark, () => {
-    tormentBox.duration = 0;
     tormentBox.duration = 15 + 0.5;
   });
   bars.onUseAbility(kAbility.Nightbloom, () => {
-    tormentBox.duration = 0;
     tormentBox.duration = 60 + 0.8;
   });
   bars.onUseAbility(kAbility.LucidDreaming, () => {
-    lucidBox.duration = 0;
     lucidBox.duration = 60;
   });
 

--- a/ui/jobs/components/brd.js
+++ b/ui/jobs/components/brd.js
@@ -11,7 +11,6 @@ export function setup(bars) {
   });
   straightShotProc.bigatzero = false;
   bars.onYouGainEffect(EffectId.StraightShotReady, () => {
-    straightShotProc.duration = 0;
     straightShotProc.duration = 10;
   });
   bars.onYouLoseEffect(EffectId.StraightShotReady, () => straightShotProc.duration = 0);
@@ -34,14 +33,12 @@ export function setup(bars) {
     EffectId.Stormbite,
     EffectId.Windbite,
   ], () => {
-    stormBiteBox.duration = 0;
     stormBiteBox.duration = 30 - 0.5;
   });
   bars.onMobGainsEffectFromYou([
     EffectId.CausticBite,
     EffectId.VenomousBite,
   ], () => {
-    causticBiteBox.duration = 0;
     causticBiteBox.duration = 30 - 0.5;
   });
   bars.onStatChange('BRD', () => {
@@ -99,10 +96,8 @@ export function setup(bars) {
 
     const oldSeconds = parseFloat(songBox.duration) - parseFloat(songBox.elapsed);
     const seconds = jobDetail.songMilliseconds / 1000.0;
-    if (!songBox.duration || seconds > oldSeconds) {
-      songBox.duration = 0;
+    if (!songBox.duration || seconds > oldSeconds)
       songBox.duration = seconds;
-    }
 
     // Soul Voice
     if (jobDetail.soulGauge !== soulVoiceBox.innerText) {

--- a/ui/jobs/components/dnc.js
+++ b/ui/jobs/components/dnc.js
@@ -24,7 +24,6 @@ export function setup(bars) {
     fgColor: 'dnc-color-standardstep',
   });
   bars.onUseAbility(kAbility.StandardStep, () => {
-    standardStep.duration = 0;
     standardStep.duration = 30;
   });
 
@@ -34,7 +33,6 @@ export function setup(bars) {
     fgColor: 'dnc-color-technicalstep',
   });
   bars.onUseAbility(kAbility.TechnicalStep, () => {
-    technicalStep.duration = 0;
     technicalStep.duration = 120;
   });
   let technicalIsActive = false;
@@ -70,7 +68,6 @@ export function setup(bars) {
   let flourishEffect = [];
   let flourishIsActive = false;
   bars.onUseAbility(kAbility.Flourish, () => {
-    flourish.duration = 0;
     flourish.duration = 20;
     flourishEffect = [];
     flourishIsActive = true;

--- a/ui/jobs/components/drg.js
+++ b/ui/jobs/components/drg.js
@@ -16,7 +16,6 @@ export function setup(bars) {
     kAbility.HighJump,
     kAbility.Jump,
   ], () => {
-    highJumpBox.duration = 0;
     highJumpBox.duration = 30;
   });
 
@@ -26,10 +25,8 @@ export function setup(bars) {
     notifyWhenExpired: true,
   });
   bars.onCombo((skill) => {
-    if (skill === kAbility.Disembowel) {
-      disembowelBox.duration = 0;
+    if (skill === kAbility.Disembowel)
       disembowelBox.duration = 30 + 1;
-    }
   });
   const lanceChargeBox = bars.addProcBox({
     id: 'drg-procs-lancecharge',
@@ -37,7 +34,6 @@ export function setup(bars) {
     threshold: 20,
   });
   bars.onUseAbility(kAbility.LanceCharge, () => {
-    lanceChargeBox.duration = 0;
     lanceChargeBox.duration = 20;
     lanceChargeBox.fg = computeBackgroundColorFrom(lanceChargeBox, 'drg-color-lancecharge.active');
     tid1 = setTimeout(() => {
@@ -51,7 +47,6 @@ export function setup(bars) {
     threshold: 20,
   });
   bars.onUseAbility(kAbility.DragonSight, () => {
-    dragonSightBox.duration = 0;
     dragonSightBox.duration = 20;
     dragonSightBox.fg = computeBackgroundColorFrom(dragonSightBox, 'drg-color-dragonsight.active');
     tid2 = setTimeout(() => {

--- a/ui/jobs/components/drk.ts
+++ b/ui/jobs/components/drk.ts
@@ -37,10 +37,8 @@ export const setup = (bars: Bars): void => {
 
     const oldSeconds = parseFloat(darksideBox.duration ?? '0') - parseFloat(darksideBox.elapsed);
     const seconds = jobDetail.darksideMilliseconds / 1000.0;
-    if (!darksideBox.duration || seconds > oldSeconds) {
-      darksideBox.duration = '0';
+    if (!darksideBox.duration || seconds > oldSeconds)
       darksideBox.duration = seconds.toString();
-    }
   });
 
   const comboTimer = bars.addTimerBar({
@@ -61,7 +59,6 @@ export const setup = (bars: Bars): void => {
     fgColor: 'drk-color-bloodweapon',
   });
   bars.onUseAbility(kAbility.BloodWeapon, () => {
-    bloodWeapon.duration = '0';
     bloodWeapon.duration = '10';
     bloodWeapon.threshold = '10';
     bloodWeapon.fg = computeBackgroundColorFrom(bloodWeapon, 'drk-color-bloodweapon.active');
@@ -77,7 +74,6 @@ export const setup = (bars: Bars): void => {
     fgColor: 'drk-color-delirium',
   });
   bars.onUseAbility(kAbility.Delirium, () => {
-    delirium.duration = '0';
     delirium.duration = '10.5';
     delirium.threshold = '20';
     delirium.fg = computeBackgroundColorFrom(delirium, 'drk-color-delirium.active');
@@ -93,7 +89,6 @@ export const setup = (bars: Bars): void => {
     fgColor: 'drk-color-livingshadow',
   });
   bars.onUseAbility(kAbility.LivingShadow, () => {
-    livingShadow.duration = '0';
     livingShadow.duration = '24';
     livingShadow.threshold = '24';
     livingShadow.fg = computeBackgroundColorFrom(livingShadow, 'drk-color-livingshadow.active');

--- a/ui/jobs/components/gnb.ts
+++ b/ui/jobs/components/gnb.ts
@@ -16,7 +16,6 @@ export const setup = (bars: Bars): void => {
     fgColor: 'gnb-color-nomercy',
   });
   bars.onUseAbility(kAbility.NoMercy, () => {
-    noMercyBox.duration = '0';
     noMercyBox.duration = '20';
     noMercyBox.threshold = '1000';
     noMercyBox.fg = computeBackgroundColorFrom(noMercyBox, 'gnb-color-nomercy.active');
@@ -32,7 +31,6 @@ export const setup = (bars: Bars): void => {
     fgColor: 'gnb-color-bloodfest',
   });
   bars.onUseAbility(kAbility.Bloodfest, () => {
-    bloodfestBox.duration = '0';
     bloodfestBox.duration = '90';
   });
 
@@ -57,7 +55,6 @@ export const setup = (bars: Bars): void => {
     fgColor: 'gnb-color-gnashingfang',
   });
   bars.onUseAbility(kAbility.GnashingFang, () => {
-    gnashingFangBox.duration = '0';
     gnashingFangBox.duration = calcGCDFromStat(bars, bars.skillSpeed, 30000).toString();
     cartridgeComboTimer.duration = '0';
     cartridgeComboTimer.duration = '15';

--- a/ui/jobs/components/mch.js
+++ b/ui/jobs/components/mch.js
@@ -53,7 +53,6 @@ export function setup(bars) {
     kAbility.Drill,
     kAbility.Bioblaster,
   ], () => {
-    drillBox.duration = 0;
     drillBox.duration = calcGCDFromStat(bars, bars.skillSpeed, 20000);
   });
 
@@ -65,7 +64,6 @@ export function setup(bars) {
     kAbility.AirAnchor,
     kAbility.HotShot,
   ], () => {
-    airAnchorBox.duration = 0;
     airAnchorBox.duration = calcGCDFromStat(bars, bars.skillSpeed, 40000);
   });
 
@@ -112,7 +110,6 @@ export function setup(bars) {
     fgColor: 'mch-color-wildfire',
   });
   bars.onUseAbility(kAbility.WildFire, () => {
-    wildFireBox.duration = 0;
     wildFireBox.duration = 10 + 0.9; // animation delay
     wildFireBox.threshold = 1000;
     wildFireBox.fg = computeBackgroundColorFrom(wildFireBox, 'mch-color-wildfire.active');

--- a/ui/jobs/components/mnk.js
+++ b/ui/jobs/components/mnk.js
@@ -63,21 +63,18 @@ export function setup(bars) {
   });
 
   bars.onYouGainEffect(EffectId.TwinSnakes, (name, matches) => {
-    twinSnakesBox.duration = 0;
     // -0.5 for logline delay
     twinSnakesBox.duration = (parseFloat(matches.duration) - 0.5).toString();
   });
   bars.onYouLoseEffect(EffectId.TwinSnakes, () => twinSnakesBox.duration = 0);
 
   bars.onUseAbility(kAbility.Demolish, () => {
-    demolishBox.duration = 0;
     // it start counting down when you cast demolish
     // but DOT appears on target about 1 second later
     demolishBox.duration = 18 + 1;
   });
 
   bars.onYouGainEffect(EffectId.LeadenFist, () => {
-    dragonKickBox.duration = 0;
     dragonKickBox.duration = 30;
   });
   bars.onYouLoseEffect(EffectId.LeadenFist, () => dragonKickBox.duration = 0);

--- a/ui/jobs/components/nin.js
+++ b/ui/jobs/components/nin.js
@@ -23,7 +23,6 @@ export function setup(bars) {
     fgColor: 'nin-color-bunshin',
   });
   bars.onUseAbility(kAbility.Bunshin, () => {
-    bunshin.duration = 0;
     bunshin.duration = 90;
   });
   const ninjutsu = bars.addProcBox({
@@ -37,13 +36,10 @@ export function setup(bars) {
     if (!mudraTriggerCd)
       return;
     const old = parseFloat(ninjutsu.duration) - parseFloat(ninjutsu.elapsed);
-    if (old > 0) {
-      ninjutsu.duration = 0;
+    if (old > 0)
       ninjutsu.duration = old + 20;
-    } else {
-      ninjutsu.duration = 0;
+    else
       ninjutsu.duration = 20 - 0.5;
-    }
     mudraTriggerCd = false;
   });
   // On each mudra, Mudra effect will be gain once,
@@ -53,7 +49,6 @@ export function setup(bars) {
   bars.onYouLoseEffect(EffectId.Kassatsu, () => mudraTriggerCd = true);
   bars.onUseAbility(kAbility.Hide, () => ninjutsu.duration = 0);
   bars.onUseAbility(kAbility.TrickAttack, () => {
-    trickAttack.duration = 0;
     trickAttack.duration = 15;
     trickAttack.threshold = 1000;
     trickAttack.fg = computeBackgroundColorFrom(trickAttack, 'nin-color-trickattack.active');
@@ -86,10 +81,8 @@ export function setup(bars) {
       ninki.parentNode.classList.add('high');
     const oldSeconds = parseFloat(hutonBox.duration) - parseFloat(hutonBox.elapsed);
     const seconds = jobDetail.hutonMilliseconds / 1000.0;
-    if (!hutonBox.duration || seconds > oldSeconds) {
-      hutonBox.duration = 0;
+    if (!hutonBox.duration || seconds > oldSeconds)
       hutonBox.duration = seconds;
-    }
   });
   const comboTimer = bars.addTimerBar({
     id: 'nin-timers-combo',

--- a/ui/jobs/components/pld.js
+++ b/ui/jobs/components/pld.js
@@ -45,7 +45,6 @@ export function setup(bars) {
 
   bars.onCombo((skill) => {
     if (skill === kAbility.GoringBlade) {
-      goreBox.duration = 0;
       // Technically, goring blade is 21, but 2.43 * 9 = 21.87, so if you
       // have the box show 21, it looks like you're awfully late with
       // your goring blade and just feels really bad.  So, lie to the

--- a/ui/jobs/components/rdm.js
+++ b/ui/jobs/components/rdm.js
@@ -54,7 +54,6 @@ export function setup(bars) {
     fgColor: 'rdm-color-lucid',
   });
   bars.onUseAbility(kAbility.LucidDreaming, () => {
-    lucidBox.duration = 0;
     lucidBox.duration = 60;
   });
   bars.onStatChange('RDM', () => {
@@ -88,7 +87,6 @@ export function setup(bars) {
   });
 
   bars.onYouGainEffect(EffectId.VerstoneReady, (name, matches) => {
-    whiteProc.duration = 0;
     whiteProc.duration = parseFloat(matches.duration) - bars.gcdSpell;
   });
   bars.onYouLoseEffect(EffectId.VerstoneReady, () => whiteProc.duration = 0);

--- a/ui/jobs/components/sam.js
+++ b/ui/jobs/components/sam.js
@@ -68,7 +68,6 @@ export function setup(bars) {
     notifyWhenExpired: true,
   });
   bars.onYouGainEffect(EffectId.Shifu, (id, matches) => {
-    shifu.duration = 0;
     shifu.duration = matches.duration - 0.5; // -0.5s for log line delay
     bars.speedBuffs.shifu = 1;
   });
@@ -83,7 +82,6 @@ export function setup(bars) {
     notifyWhenExpired: true,
   });
   bars.onYouGainEffect(EffectId.Jinpu, (id, matches) => {
-    jinpu.duration = 0;
     jinpu.duration = matches.duration - 0.5; // -0.5s for log line delay
   });
   bars.onYouLoseEffect(EffectId.Jinpu, () => {
@@ -99,7 +97,6 @@ export function setup(bars) {
     kAbility.KaeshiGoken,
     kAbility.KaeshiSetsugekka,
   ], () => {
-    tsubameGaeshi.duration = 0;
     tsubameGaeshi.duration = 60;
   });
 
@@ -109,7 +106,6 @@ export function setup(bars) {
     notifyWhenExpired: true,
   });
   bars.onMobGainsEffectFromYou(EffectId.Higanbana, () => {
-    higanbana.duration = 0;
     higanbana.duration = 60 - 0.5; // -0.5s for log line delay
   });
 

--- a/ui/jobs/components/sch.js
+++ b/ui/jobs/components/sch.js
@@ -60,17 +60,14 @@ export function setup(bars) {
     kAbility.Bio2,
     kAbility.Biolysis,
   ], () => {
-    bioBox.duration = 0;
     bioBox.duration = 30;
   });
 
   bars.onUseAbility(kAbility.Aetherflow, () => {
-    aetherflowBox.duration = 0;
     aetherflowBox.duration = 60;
     aetherflowStackBox.parentNode.classList.remove('too-much-stacks');
   });
   bars.onUseAbility(kAbility.LucidDreaming, () => {
-    lucidBox.duration = 0;
     lucidBox.duration = 60;
   });
 

--- a/ui/jobs/components/smn.js
+++ b/ui/jobs/components/smn.js
@@ -114,7 +114,6 @@ export function setup(bars) {
     kAbility.Miasma,
     kAbility.Miasma3,
   ], () => {
-    miasmaBox.duration = 0;
     miasmaBox.duration = 30;
   });
   bars.onUseAbility([
@@ -122,22 +121,18 @@ export function setup(bars) {
     kAbility.BioSmn2,
     kAbility.Bio3,
   ], () => {
-    bioSmnBox.duration = 0;
     bioSmnBox.duration = 30;
   });
   // Tridisaster refresh miasma and bio both, so repeat below.
   // TODO: remake onXxx like node's EventEmitter
   bars.onUseAbility(kAbility.Tridisaster, () => {
-    miasmaBox.duration = 0;
     miasmaBox.duration = 30;
-    bioSmnBox.duration = 0;
     bioSmnBox.duration = 30;
   });
   bars.onUseAbility([
     kAbility.EnergyDrain,
     kAbility.EnergySiphon,
   ], () => {
-    energyDrainBox.duration = 0;
     energyDrainBox.duration = 30;
     aetherflowStackBox.parentNode.classList.remove('too-much-stacks');
   });
@@ -148,7 +143,6 @@ export function setup(bars) {
     kAbility.DreadwyrmTrance,
     kAbility.FirebirdTrance,
   ], () => {
-    tranceBox.duration = 0;
     tranceBox.duration = 60;
   });
 

--- a/ui/jobs/components/war.js
+++ b/ui/jobs/components/war.js
@@ -71,7 +71,6 @@ export function setup(bars) {
   });
 
   bars.onYouGainEffect(EffectId.StormsEye, (id, e) => {
-    eyeBox.duration = 0;
     eyeBox.duration = e.duration;
   });
   bars.onYouLoseEffect(EffectId.StormsEye, () => {

--- a/ui/jobs/components/whm.js
+++ b/ui/jobs/components/whm.js
@@ -66,19 +66,15 @@ export function setup(bars) {
   });
 
   bars.onUseAbility([kAbility.Aero, kAbility.Aero2], () => {
-    diaBox.duration = 0;
     diaBox.duration = 18 + 1;
   });
   bars.onUseAbility(kAbility.Dia, () => {
-    diaBox.duration = 0;
     diaBox.duration = 30;
   });
   bars.onUseAbility(kAbility.Assize, () => {
-    assizeBox.duration = 0;
     assizeBox.duration = 45;
   });
   bars.onUseAbility(kAbility.LucidDreaming, () => {
-    lucidBox.duration = 0;
     lucidBox.duration = 60;
   });
 


### PR DESCRIPTION
In the past it seems it was necessary to set the duration of a
timerbox to 0 before setting the new duration. Most likely in order to
somehow reset the timerbox.

As setting a new duration will always result in calling the reset
function of a timerbox, this shouldn't be necessary anymore.

Removing the unnecessary calls will also prevent that the onReset
callbacks will be called more often than necessary.