### PR TITLE
fix(timeline): execute timeline trigger with current time

### DIFF
--- a/ui/raidboss/timeline.ts
+++ b/ui/raidboss/timeline.ts
@@ -699,6 +699,7 @@ export class Timeline {
       ++this.nextEvent;
     }
   }
+
   private _AddPassedTexts(fightNow: number, currentTime: number): void {
     while (this.nextText < this.texts.length) {
       const t = this.texts[this.nextText];

--- a/ui/raidboss/timeline.ts
+++ b/ui/raidboss/timeline.ts
@@ -709,16 +709,16 @@ export class Timeline {
         break;
       if (t.type === 'info') {
         if (this.showInfoTextCallback)
-          this.showInfoTextCallback(t.text, this.timebase);
+          this.showInfoTextCallback(t.text, currentTime);
       } else if (t.type === 'alert') {
         if (this.showAlertTextCallback)
-          this.showAlertTextCallback(t.text, this.timebase);
+          this.showAlertTextCallback(t.text, currentTime);
       } else if (t.type === 'alarm') {
         if (this.showAlarmTextCallback)
-          this.showAlarmTextCallback(t.text, this.timebase);
+          this.showAlarmTextCallback(t.text, currentTime);
       } else if (t.type === 'tts') {
         if (this.speakTTSCallback)
-          this.speakTTSCallback(t.text, this.timebase);
+          this.speakTTSCallback(t.text, currentTime);
       } else if (t.type === 'trigger') {
         if (this.triggerCallback)
           this.triggerCallback(t.trigger, t.matches, currentTime);

--- a/ui/raidboss/timeline.ts
+++ b/ui/raidboss/timeline.ts
@@ -699,8 +699,7 @@ export class Timeline {
       ++this.nextEvent;
     }
   }
-
-  private _AddPassedTexts(fightNow: number): void {
+  private _AddPassedTexts(fightNow: number, currentTime: number): void {
     while (this.nextText < this.texts.length) {
       const t = this.texts[this.nextText];
       if (!t)
@@ -721,7 +720,7 @@ export class Timeline {
           this.speakTTSCallback(t.text, this.timebase);
       } else if (t.type === 'trigger') {
         if (this.triggerCallback)
-          this.triggerCallback(t.trigger, t.matches, this.timebase);
+          this.triggerCallback(t.trigger, t.matches, currentTime);
       }
       ++this.nextText;
     }
@@ -802,7 +801,7 @@ export class Timeline {
     // This is the number of seconds into the fight (subtracting Dates gives milliseconds).
     const fightNow = (currentTime - this.timebase) / 1000;
     // Send text events now or they'd be skipped by _AdvanceTimeTo().
-    this._AddPassedTexts(fightNow);
+    this._AddPassedTexts(fightNow, currentTime);
     this._AdvanceTimeTo(fightNow);
     this._CollectActiveSyncs(fightNow);
 


### PR DESCRIPTION
should close #3126, this was introduced in https://github.com/quisquous/cactbot/pull/3079


In old implement, all timeline trigger is executed as `timeline.timebase`, not the current time.

the make all `currentTime` become base time, not real current time.

could be tested with dummy:

```JS
const trigger = {
  zoneId: ZoneId.MiddleLaNoscea,
  timeline: [
    `5 "test"`,
    `10 "test"`,
    `15 "test"`,
    `20 "test"`,
    `25 "test"`,
    `30 "test"`,
    `35 "test"`,
  ],
  timelineTriggers: [
    {
      id: 'trim21 test refresh',
      regex: /Death/,
      run() {
        // location.reload();
      },
    },
    {
      id: 'trim21 test',
      regex: /test/,
      preRun(data) {
        data.times = data.times ?? 0;
        data.times++;
      },
      suppressSeconds: 1,
      beforeSeconds: 3,
      infoText(data) {return `test message ${data.times}`;},
    },
  ],
};

Options.Triggers.push(trigger);
```