### PR TITLE
Jobs: Fix Thunder2 ID out of date

### DIFF
--- a/ui/jobs/constants.ts
+++ b/ui/jobs/constants.ts
@@ -204,7 +204,7 @@ export const kAbility = {
   Flourish: '3E8D',
   // BLM
   Thunder1: '90',
-  Thunder2: '94',
+  Thunder2: '1D17',
   Thunder3: '99',
   Thunder4: '1CFC',
   // SMN


### PR DESCRIPTION
This has been changed since 4.0. Maybe no one has tested it in leveling dungeon...