### PR TITLE
raidemulator: Fix async issue, fix tts still actually triggering tts during analysis

### DIFF
--- a/ui/raidboss/emulator/data/PopupTextAnalysis.ts
+++ b/ui/raidboss/emulator/data/PopupTextAnalysis.ts
@@ -5,6 +5,9 @@ import { LooseTrigger, MatchesAny } from '../../../../types/trigger';
 import { TriggerHelper, Text, TextText, ProcessedTrigger } from '../../popup-text';
 import { EventResponses, LogEvent } from '../../../../types/event';
 import { UnreachableCode } from '../../../../resources/not_reached';
+import { RaidbossFileData } from '../../data/raidboss_manifest.txt';
+import { RaidbossOptions } from '../../raidboss_options';
+import { TimelineLoader } from '../../timeline';
 
 type ResolverFunc = () => void;
 
@@ -83,6 +86,16 @@ export default class PopupTextAnalysis extends StubbedPopupText {
       triggerHelper: EmulatorTriggerHelper | undefined,
       currentTriggerStatus: ResolverStatus,
       finalData: DataType) => void;
+
+  constructor(
+      options: RaidbossOptions,
+      timelineLoader: TimelineLoader,
+      raidbossFileData: RaidbossFileData) {
+    super(options, timelineLoader, raidbossFileData);
+    this.ttsSay = (_text: string) => {
+      return;
+    };
+  }
 
   // Override `OnTrigger` so we can use our own exception handler
   OnTrigger(trigger: LooseTrigger, matches: RegExpExecArray | null, currentTime: number): void {

--- a/ui/raidboss/raidemulator.js
+++ b/ui/raidboss/raidemulator.js
@@ -65,11 +65,14 @@ import './raidemulator.css';
           }),
         ]);
         if (websocketConnected) {
-          await UserConfig.getUserConfigLocation('raidboss', defaultOptions, (e) => {
-            // Update options from anything changed via getUserConfigLocation.
-            options = { ...defaultOptions };
-            document.querySelector('.websocketConnected').classList.remove('d-none');
-            document.querySelector('.websocketDisconnected').classList.add('d-none');
+          await new Promise((res) => {
+            UserConfig.getUserConfigLocation('raidboss', defaultOptions, (e) => {
+              // Update options from anything changed via getUserConfigLocation.
+              options = { ...defaultOptions };
+              document.querySelector('.websocketConnected').classList.remove('d-none');
+              document.querySelector('.websocketDisconnected').classList.add('d-none');
+              res();
+            });
           });
         }
       }


### PR DESCRIPTION
This PR fixes an async issue caused by #3115 (basically, actual cactbot user options weren't being applied).

As well this PR fixes TTS audibly still happening during encounter analysis, which caused my ears to bleed when the entire e12s p2 fight TTS'd for all 8 players at the same time a few minutes ago.