### PR TITLE
config: add link to coverage report

### DIFF
--- a/resources/user_config.ts
+++ b/resources/user_config.ts
@@ -46,7 +46,7 @@ type ConfigValue = string | number | boolean;
 type ConfigEntry = {
   id: string;
   name: LocaleText;
-  type: 'checkbox' | 'select' | 'float' | 'integer' | 'directory';
+  type: 'checkbox' | 'select' | 'float' | 'integer' | 'directory' | 'html';
   default: ConfigValue;
   debug?: boolean;
   debugOnly?: boolean;

--- a/ui/config/config.js
+++ b/ui/config/config.js
@@ -316,6 +316,7 @@ export default class CactbotConfigurator {
             continue;
           const buildFunc = {
             checkbox: this.buildCheckbox,
+            html: this.buildHtml,
             select: this.buildSelect,
             float: this.buildFloat,
             integer: this.buildInteger,
@@ -378,6 +379,15 @@ export default class CactbotConfigurator {
     input.type = 'checkbox';
     input.checked = this.getOption(group, opt.id, opt.default);
     input.onchange = () => this.setOption(group, opt.id, input.checked);
+
+    parent.appendChild(this.buildNameDiv(opt));
+    parent.appendChild(div);
+  }
+
+  buildHtml(parent, opt, group) {
+    const div = document.createElement('div');
+    div.classList.add('option-input-container');
+    div.innerHTML = this.translate(opt.html);
 
     parent.appendChild(this.buildNameDiv(opt));
     parent.appendChild(div);

--- a/ui/raidboss/raidboss_config.js
+++ b/ui/raidboss/raidboss_config.js
@@ -991,7 +991,7 @@ const templateOptions = {
     {
       id: 'Coverage',
       name: {
-        en: 'Supported content',
+        en: 'Supported content (latest version)',
       },
       type: 'html',
       html: {

--- a/ui/raidboss/raidboss_config.js
+++ b/ui/raidboss/raidboss_config.js
@@ -362,6 +362,10 @@ class DoNothingFuncProxy {
   }
 }
 
+const makeLink = (href) => {
+  return `<a href="${href}" target="_blank">${href}</a>`;
+};
+
 class RaidbossConfigurator {
   constructor(cactbotConfigurator) {
     this.base = cactbotConfigurator;
@@ -984,6 +988,22 @@ const templateOptions = {
     }
   },
   options: [
+    {
+      id: 'Coverage',
+      name: {
+        en: 'Supported content',
+      },
+      type: 'html',
+      html: {
+        // TODO: it'd be nice if OverlayPlugin could open links on the system outside of ACT.
+        en: makeLink('https://quisquous.github.io/cactbot/util/coverage/coverage.html?lang=en'),
+        de: makeLink('https://quisquous.github.io/cactbot/util/coverage/coverage.html?lang=de'),
+        fr: makeLink('https://quisquous.github.io/cactbot/util/coverage/coverage.html?lang=fr'),
+        ja: makeLink('https://quisquous.github.io/cactbot/util/coverage/coverage.html?lang=ja'),
+        cn: makeLink('https://quisquous.github.io/cactbot/util/coverage/coverage.html?lang=cn'),
+        ko: makeLink('https://quisquous.github.io/cactbot/util/coverage/coverage.html?lang=ko'),
+      },
+    },
     {
       id: 'Debug',
       name: {


### PR DESCRIPTION
Requested by @MyTechnoHunter because this link is hard to find.

Also add support for html "inputs".  Maybe this is a case where we need
some other way to add more text at the beginning of a section, but we
can figure that out if we get more examples.

I left this as the raw link text to make it super clear that it was
a link to click on, and what that link was so you could find it outside
of ACT.

It would be really nice if OverlayPlugin supported something like the
`cactbotChooseDirectory` overlay handler for opening links in a browser
outside of ACT.  I would use it for this and view source if it existed.