### PR TITLE
raidemulator: Fix promise not evaluating sync during analysis

### DIFF
--- a/ui/raidboss/emulator/data/PopupTextAnalysis.ts
+++ b/ui/raidboss/emulator/data/PopupTextAnalysis.ts
@@ -210,7 +210,7 @@ export default class PopupTextAnalysis extends StubbedPopupText {
       return ret;
     if (triggerHelper.resolver)
       triggerHelper.resolver.setPromise(ret);
-    return;
+    return ret;
   }
 
   _onTriggerInternalTTS(triggerHelper: EmulatorTriggerHelper): void {


### PR DESCRIPTION
This got broken during the typescript conversion, the previous behavior returned a promise from resolver but that was accidentally left out as part of the resolver refactoring that was done during the conversion.