### PR TITLE
util: Rework overlay API types to make backing types more accessible

### DIFF
--- a/resources/user_config.ts
+++ b/resources/user_config.ts
@@ -213,7 +213,7 @@ class UserConfig {
   }
 
   loadUserFiles(overlayName: string, options: BaseOptions, callback: () => void) {
-    const readOptions = callOverlayHandler({
+    const readOptions = callOverlayHandler<'cactbotLoadData'>({
       call: 'cactbotLoadData',
       overlay: 'options',
     });
@@ -347,7 +347,7 @@ class UserConfig {
       void callOverlayHandler({ call: 'cactbotRequestState' });
     };
 
-    void callOverlayHandler({
+    void callOverlayHandler<'cactbotLoadUser'>({
       call: 'cactbotLoadUser',
       source: location.href,
       overlayName: overlayName,

--- a/resources/util.ts
+++ b/resources/util.ts
@@ -1,4 +1,4 @@
-import { GetCombatantsCall, GetCombatantsRet } from '../types/event';
+import { OverlayHandlerRequests, OverlayHandlerResponseTypes } from '../types/event';
 import { Job, Role } from '../types/job';
 import { callOverlayHandler } from './overlay_plugin_api';
 
@@ -88,7 +88,7 @@ type WatchCombatantParams = {
 };
 
 type WatchCombatantFunc = (params: WatchCombatantParams,
-  func: (ret: GetCombatantsRet) => boolean) => Promise<boolean>;
+  func: (ret: OverlayHandlerResponseTypes['getCombatants']) => boolean) => Promise<boolean>;
 
 type WatchCombatantMapEntry = {
   cancel: boolean;
@@ -110,7 +110,7 @@ const watchCombatant: WatchCombatantFunc = (params, func) => {
   return new Promise<boolean>((res, rej) => {
     const delay = params.delay ?? 1000;
 
-    const call: GetCombatantsCall = {
+    const call: OverlayHandlerRequests['getCombatants'] = {
       call: 'getCombatants',
     };
 
@@ -135,7 +135,7 @@ const watchCombatant: WatchCombatantFunc = (params, func) => {
         rej();
         return;
       }
-      void callOverlayHandler(call).then((response) => {
+      void callOverlayHandler<'getCombatants'>(call).then((response) => {
         if (entry.cancel) {
           rej();
           return;

--- a/types/event.d.ts
+++ b/types/event.d.ts
@@ -351,51 +351,90 @@ export interface PluginCombatantState {
   Heading: number;
 }
 
-export type GetCombatantsCall = {
+type SubscribeHandler = (msg: {
+  call: 'subscribe';
+  events: string[];
+}) => void;
+
+type GetCombatantsHandler = (msg: {
   call: 'getCombatants';
   ids?: number[];
   names?: string[];
   props?: string[];
+}) => { combatants: PluginCombatantState[] };
+
+type CactbotReloadOverlaysHandler = (msg: {
+  call: 'cactbotReloadOverlays';
+}) => void;
+
+type CactbotLoadUserHandler = (msg: {
+  call: 'cactbotLoadUser';
+  source: string;
+  overlayName: string;
+}) => { detail: CactbotLoadUserRet };
+
+type CactbotRequestPlayerUpdateHandler = (msg: {
+  call: 'cactbotRequestPlayerUpdate';
+}) => void;
+
+type CactbotRequestStateHandler = (msg: {
+  call: 'cactbotRequestState';
+}) => void;
+
+type CactbotSayHandler = (msg: {
+  call: 'cactbotSay';
+  text: string;
+}) => void;
+
+type CactbotSaveDataHandler = (msg: {
+  call: 'cactbotSaveData';
+}) => void;
+
+type CactbotLoadDataHandler = (msg: {
+  call: 'cactbotLoadData';
+  overlay: string;
+}) => ({ data: SavedConfig } | undefined);
+
+type CactbotChooseDirectoryHandler = <T>(msg: {
+  call: 'cactbotChooseDirectory';
+}) => ({ data: T } | undefined);
+
+export type OverlayHandlerAll = {
+  'subscribe': SubscribeHandler;
+  'getCombatants': GetCombatantsHandler;
+  'cactbotReloadOverlays': CactbotReloadOverlaysHandler;
+  'cactbotLoadUser': CactbotLoadUserHandler;
+  'cactbotRequestPlayerUpdate': CactbotRequestPlayerUpdateHandler;
+  'cactbotRequestState': CactbotRequestStateHandler;
+  'cactbotSay': CactbotSayHandler;
+  'cactbotSaveData': CactbotSaveDataHandler;
+  'cactbotLoadData': CactbotLoadDataHandler;
+  'cactbotChooseDirectory': CactbotChooseDirectoryHandler;
 };
 
-export type GetCombatantsRet = { combatants: PluginCombatantState[] };
+export type OverlayHandlerTypes = keyof OverlayHandlerAll;
 
-export type IOverlayHandler = {
-  // OutputPlugin build-in
-  (msg: {
-    call: 'subscribe';
-    events: string[];
-  }): Promise<null>;
-  (msg: GetCombatantsCall): Promise<GetCombatantsRet>;
-  // TODO: add OverlayPlugin build-in handlers
-  // Cactbot
-  // TODO: fill up all handler types
-  (msg: {
-    call: 'cactbotReloadOverlays';
-  }): Promise<null>;
-  (msg: {
-    call: 'cactbotLoadUser';
-    source: string;
-    overlayName: string;
-  }): Promise<{ detail: CactbotLoadUserRet }>;
-  (msg: {
-    call: 'cactbotRequestPlayerUpdate';
-  }): Promise<null>;
-  (msg: {
-    call: 'cactbotRequestState';
-  }): Promise<null>;
-  (msg: {
-    call: 'cactbotSay';
-    text: string;
-  }): Promise<null>;
-  (msg: {
-    call: 'cactbotSaveData';
-  }): Promise<null>;
-  (msg: {
-    call: 'cactbotLoadData';
-    overlay: string;
-  }): Promise<{ data: SavedConfig } | null>;
-  <T>(msg: {
-    call: 'cactbotChooseDirectory';
-  }): Promise<{ data: T } | null>;
+export type OverlayHandlerRequests = {
+  [call in OverlayHandlerTypes]: Parameters<OverlayHandlerAll[call]>[0];
 };
+
+export type OverlayHandlerAnyRequest = OverlayHandlerRequests[OverlayHandlerTypes];
+
+export type OverlayHandlerResponseTypes = {
+  [call in OverlayHandlerTypes]: ReturnType<OverlayHandlerAll[call]>;
+};
+
+export type OverlayHandlerResponses = {
+  [call in OverlayHandlerTypes]: Promise<OverlayHandlerResponseTypes[call]>;
+};
+
+export type OverlayHandlerAnyResponse = OverlayHandlerResponses[OverlayHandlerTypes];
+
+export type OverlayHandlerFuncs = {
+  [call in OverlayHandlerTypes]:
+      (msg: Parameters<OverlayHandlerAll[call]>[0]) => OverlayHandlerResponses[call];
+};
+
+export type IOverlayHandler =
+    <T extends OverlayHandlerTypes>(msg: OverlayHandlerRequests[T]) =>
+    Promise<OverlayHandlerResponseTypes[T]>;

--- a/ui/raidboss/emulator/overrides/RaidEmulatorOverlayApiHook.js
+++ b/ui/raidboss/emulator/overrides/RaidEmulatorOverlayApiHook.js
@@ -20,7 +20,7 @@ const toCache = (data) => {
 export default class RaidEmulatorOverlayApiHook {
   constructor(emulator) {
     this.emulator = emulator;
-    this.originalCall = setCallOverlayHandlerOverride(this.call.bind(this));
+    setCallOverlayHandlerOverride('getCombatants', this.call.bind(this));
     this.currentLogTime = 0;
     this.connected = false;
 
@@ -39,10 +39,7 @@ export default class RaidEmulatorOverlayApiHook {
   }
 
   async call(msg) {
-    if (msg.call === 'getCombatants')
-      return await this._getCombatantsOverride(msg);
-
-    return await this.originalCall(msg);
+    return await this._getCombatantsOverride(msg);
   }
 
   async _getCombatantsOverride(msg) {


### PR DESCRIPTION
This PR reworks the way that the overlay API event types are typed out to make request/response type/response promise type more accessible.

I tried to get the `callOverlayHandler` function to properly auto-type the parameter and return value but for some reason it wasn't working, I'm not sure why, so I updated `user_config.ts` and `util.ts` calls to `callOverlayHandler` to pass the call type in.

This rework is required to convert RaidEmulatorOverlayApiHook to typescript.

Verified raidemulator and basic raidboss functionality in-game (general triggers) but didn't have time to run any content tonight.