### PR TITLE
Feature(Raidboss): show default value instead of (default)

### DIFF
--- a/ui/config/config.css
+++ b/ui/config/config.css
@@ -274,7 +274,7 @@ input[type=text] {
 }
 
 .trigger-duration > input[type=text] {
-  width: 60px;
+  width: 90px;
   text-align: left;
 }
 

--- a/ui/config/config.css
+++ b/ui/config/config.css
@@ -274,7 +274,7 @@ input[type=text] {
 }
 
 .trigger-duration > input[type=text] {
-  width: 90px;
+  width: 75px;
   text-align: left;
 }
 

--- a/ui/raidboss/raidboss_config.js
+++ b/ui/raidboss/raidboss_config.js
@@ -554,7 +554,7 @@ class RaidbossConfigurator {
           div.appendChild(input);
           input.type = 'text';
           input.step = 'any';
-          input.placeholder = trig.durationSeconds || 3;
+          input.placeholder = `${trig.durationSeconds || 3}${this.base.translate(kMiscTranslations.valueDefault)}`;
           input.value = this.base.getOption('raidboss', 'triggers', trig.id, optionKey, '');
           const setFunc = () => {
             const val = validDurationOrUndefined(input.value) || '';

--- a/ui/raidboss/raidboss_config.js
+++ b/ui/raidboss/raidboss_config.js
@@ -554,7 +554,7 @@ class RaidbossConfigurator {
           div.appendChild(input);
           input.type = 'text';
           input.step = 'any';
-          input.placeholder = `${trig.durationSeconds || 3} ${this.base.translate(kMiscTranslations.valueDefault)}`;
+          input.placeholder = `${trig.durationSeconds || ''} ${this.base.translate(kMiscTranslations.valueDefault)}`;
           input.value = this.base.getOption('raidboss', 'triggers', trig.id, optionKey, '');
           const setFunc = () => {
             const val = validDurationOrUndefined(input.value) || '';

--- a/ui/raidboss/raidboss_config.js
+++ b/ui/raidboss/raidboss_config.js
@@ -554,7 +554,7 @@ class RaidbossConfigurator {
           div.appendChild(input);
           input.type = 'text';
           input.step = 'any';
-          input.placeholder = `${trig.durationSeconds || 3}${this.base.translate(kMiscTranslations.valueDefault)}`;
+          input.placeholder = `${trig.durationSeconds || 3} ${this.base.translate(kMiscTranslations.valueDefault)}`;
           input.value = this.base.getOption('raidboss', 'triggers', trig.id, optionKey, '');
           const setFunc = () => {
             const val = validDurationOrUndefined(input.value) || '';

--- a/ui/raidboss/raidboss_config.js
+++ b/ui/raidboss/raidboss_config.js
@@ -554,7 +554,7 @@ class RaidbossConfigurator {
           div.appendChild(input);
           input.type = 'text';
           input.step = 'any';
-          input.placeholder = this.base.translate(kMiscTranslations.valueDefault);
+          input.placeholder = trig.durationSeconds || 3;
           input.value = this.base.getOption('raidboss', 'triggers', trig.id, optionKey, '');
           const setFunc = () => {
             const val = validDurationOrUndefined(input.value) || '';

--- a/ui/raidboss/raidboss_config.js
+++ b/ui/raidboss/raidboss_config.js
@@ -554,7 +554,10 @@ class RaidbossConfigurator {
           div.appendChild(input);
           input.type = 'text';
           input.step = 'any';
-          input.placeholder = `${trig.durationSeconds || ''} ${this.base.translate(kMiscTranslations.valueDefault)}`;
+          if (typeof trig.durationSeconds === 'number')
+            input.placeholder = `${trig.durationSeconds} ${this.base.translate(kMiscTranslations.valueDefault)}`;
+          else
+            input.placeholder = this.base.translate(kMiscTranslations.valueDefault);
           input.value = this.base.getOption('raidboss', 'triggers', trig.id, optionKey, '');
           const setFunc = () => {
             const val = validDurationOrUndefined(input.value) || '';

--- a/ui/raidboss/raidboss_config.js
+++ b/ui/raidboss/raidboss_config.js
@@ -555,7 +555,7 @@ class RaidbossConfigurator {
           input.type = 'text';
           input.step = 'any';
           if (typeof trig.durationSeconds === 'number')
-            input.placeholder = `${trig.durationSeconds} ${this.base.translate(kMiscTranslations.valueDefault)}`;
+            input.placeholder = `${trig.durationSeconds}`;
           else
             input.placeholder = this.base.translate(kMiscTranslations.valueDefault);
           input.value = this.base.getOption('raidboss', 'triggers', trig.id, optionKey, '');


### PR DESCRIPTION
Sometimes I find a trigger not show long enough, but I turn to config only to find it `(default)`.
What is default value? I have to view source code to know.
So this feature enable user to know actual default value without source code.