### PR TITLE
eslint: add indent rule for TypeScript

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -98,6 +98,12 @@ const rules = {
         'parameters': 2,
       },
       'ignoreComments': false,
+      'ignoredNodes': [
+        // The indent rule does a poor job with TypeScript type declarations, so disable.
+        'TSIntersectionType *',
+        'TSTypeAliasDeclaration *',
+        'TSUnionType *',
+      ],
       'ObjectExpression': 1,
     },
   ],
@@ -217,6 +223,7 @@ const tsOverrides = {
       },
     ],
     '@typescript-eslint/explicit-module-boundary-types': ['error', { 'allowHigherOrderFunctions': false }],
+    '@typescript-eslint/indent': rules.indent,
     '@typescript-eslint/member-delimiter-style': ['error', {
       'multiline': {
         'delimiter': 'semi',
@@ -233,6 +240,7 @@ const tsOverrides = {
     '@typescript-eslint/no-unused-vars': ['error', { 'argsIgnorePattern': '^_\\w+' }],
     '@typescript-eslint/object-curly-spacing': ['error', 'always'],
     'func-style': ['error', 'expression', { 'allowArrowFunctions': true }],
+    'indent': 'off',
     'object-shorthand': ['error', 'consistent'],
   },
 };

--- a/resources/overlay_plugin_api.ts
+++ b/resources/overlay_plugin_api.ts
@@ -154,7 +154,7 @@ export const callOverlayHandler: IOverlayHandler = (
   init();
   if (callOverlayHandlerOverride) {
     return callOverlayHandlerOverride(
-      _msg as Parameters<IOverlayHandler>[0],
+        _msg as Parameters<IOverlayHandler>[0],
     ) as Promise<unknown>;
   }
   return callOverlayHandlerInternal(_msg as Parameters<IOverlayHandler>[0]);

--- a/ui/raidboss/emulator/data/AnalyzedEncounter.ts
+++ b/ui/raidboss/emulator/data/AnalyzedEncounter.ts
@@ -32,9 +32,9 @@ type Perspectives = { [id: string]: Perspective };
 export default class AnalyzedEncounter extends EventBus {
   perspectives: Perspectives = {};
   constructor(
-    public options: RaidbossOptions,
-    public encounter: Encounter,
-    public emulator: RaidEmulator) {
+      public options: RaidbossOptions,
+      public encounter: Encounter,
+      public emulator: RaidEmulator) {
     super();
   }
 

--- a/ui/raidboss/emulator/data/Encounter.ts
+++ b/ui/raidboss/emulator/data/Encounter.ts
@@ -44,10 +44,10 @@ export default class Encounter {
   language: Lang = 'en';
 
   constructor(
-    public encounterDay: string,
-    public encounterZoneId: string,
-    public encounterZoneName: string,
-    public logLines: LineEvent[]) {
+      public encounterDay: string,
+      public encounterZoneId: string,
+      public encounterZoneName: string,
+      public logLines: LineEvent[]) {
     this.version = Encounter.encounterVersion;
   }
 

--- a/ui/raidboss/emulator/data/PopupTextAnalysis.ts
+++ b/ui/raidboss/emulator/data/PopupTextAnalysis.ts
@@ -84,9 +84,9 @@ export default class PopupTextAnalysis extends StubbedPopupText {
   triggerResolvers: Resolver[] = [];
   currentResolver?: Resolver;
   public callback?: (log: LineEvent,
-      triggerHelper: EmulatorTriggerHelper | undefined,
-      currentTriggerStatus: ResolverStatus,
-      finalData: DataType) => void;
+    triggerHelper: EmulatorTriggerHelper | undefined,
+    currentTriggerStatus: ResolverStatus,
+    finalData: DataType) => void;
 
   constructor(
       options: RaidbossOptions,


### PR DESCRIPTION
This is Trim21's #3102 with a workaround extended from:
https://stackoverflow.com/questions/59851672/eslint-indent-and-ignorenodes-trouble-getting-ast-selectors-to-work-correctl/59852368#59852368