### PR TITLE
util: support FIXME to mark improvable translations

### DIFF
--- a/util/find_missing_translations.js
+++ b/util/find_missing_translations.js
@@ -74,10 +74,12 @@ const parseJavascriptFile = (file, locales) => {
 
   let lineNumber = 0;
   let keys = [];
+  let fixme = [];
   let openMatch = null;
 
   const openObjRe = /^(\s*)(.*{)\s*$/;
   const keyRe = /^\s*(\w{2}):/;
+  const fixmeRe = /\/\/ FIX-?ME/;
 
   lineReader.on('line', (line, idx = lineCounter()) => {
     // Immediately exit if the file is auto-generated
@@ -95,6 +97,7 @@ const parseJavascriptFile = (file, locales) => {
       // idx is zero-based, but line numbers are not.
       lineNumber = idx + 1;
       keys = [];
+      fixme = [];
       return;
     }
 
@@ -107,7 +110,9 @@ const parseJavascriptFile = (file, locales) => {
     if (line.match(`${openMatch[1]}}`)) {
       // Check if these keys look like a translation block.
       if (keys.includes('en')) {
-        const missingKeys = new Set([...locales].filter((locale) => !keys.includes(locale)));
+        const missingKeys = new Set([...locales].filter((locale) => {
+          return !keys.includes(locale) || fixme.includes(locale);
+        }));
 
         const openStr = openMatch[2];
         // Only some locales care about zoneRegex, so special case.
@@ -127,8 +132,14 @@ const parseJavascriptFile = (file, locales) => {
 
     // If we're inside an object, find anything that looks like a key.
     const keyMatch = line.match(keyRe);
-    if (keyMatch)
-      keys.push(keyMatch[1]);
+    if (keyMatch) {
+      const lang = keyMatch[1];
+      keys.push(lang);
+
+      // Track if this line has a FIXME comment on it, so we can include it as "missing".
+      if (fixmeRe.test(line))
+        fixme.push(lang);
+    }
   });
 };
 


### PR DESCRIPTION
Something that comes up every once in a while is that it can be useful
to update the text of a trigger to be slightly better or slightly
different.  The translations for this trigger are not necessarily wrong
(and using what's there is better than English), but it's the kind of
thing where you want to mark it for somebody to come back and look at
later without deleting it.

This patch supports adding `// FIXME` commments on the lines of
translations you want to leave but mark as needing re-translation.