### PR TITLE
Chore: dungeon timelines improvement

### DIFF
--- a/ui/raidboss/data/05-shb/alliance/the_copied_factory.js
+++ b/ui/raidboss/data/05-shb/alliance/the_copied_factory.js
@@ -792,6 +792,7 @@ export default {
   timelineReplace: [
     {
       'locale': 'de',
+      'missingTranslations': true, // needs 'Back' and 'Front(?!al)' translation
       'replaceSync': {
         '9S-Operated Flight Unit': '9S\' Flugeinheit',
         '9S-Operated Walking Fortress': '9S\' mehrbeinig(?:e|er|es|en) Panzer',
@@ -948,6 +949,8 @@ export default {
         'Marx Crush': 'Pinçage de Marx',
         'Marx Impact': 'Chute de Marx',
         'Marx Smash(?! )': 'Coup de Marx',
+        'Marx Smash Back': 'Coup de Marx Der',
+        'Marx Smash Front': 'Coup de Marx Dev',
         'Marx Smash B/F': 'Coup de Marx Der/Dev',
         'Marx Smash F/B': 'Coup de Marx Dev/Der',
         'Marx Smash L/R': 'Coup de Marx G/D',
@@ -997,6 +1000,8 @@ export default {
         'Warehouse C': '倉庫C',
       },
       'replaceText': {
+        'Front(?!al)': '前',
+        'Back': '後',
         '360-Degree Bombing Maneuver': '攻撃：ミサイル円射',
         '(?<! )Adds': '雑魚',
         'Anti-Personnel Missile': '対人ミサイル乱射',
@@ -1131,6 +1136,8 @@ export default {
         'Marx Impact': '麦喀士冲击',
         'Marx Smash L/R': '麦喀士打击左/右',
         'Marx Smash R/L': '麦喀士打击右/左',
+        'Marx Smash Back': '麦喀士打击后',
+        'Marx Smash Front': '麦喀士打击前',
         'Marx Smash F/B': '麦喀士打击前/后',
         'Marx Smash B/F': '麦喀士打击后/前',
         'Marx Smash(?! )': '麦喀士打击',
@@ -1177,6 +1184,8 @@ export default {
         'Warehouse C': '창고 C',
       },
       'replaceText': {
+        'Front(?!al)': '앞',
+        'Back': '뒤',
         'F/B': '앞/뒤',
         'B/F': '뒤/앞',
         'L/R': '좌/우',

--- a/ui/raidboss/data/05-shb/alliance/the_copied_factory.txt
+++ b/ui/raidboss/data/05-shb/alliance/the_copied_factory.txt
@@ -238,8 +238,8 @@ hideall "--sync--"
 2055.8 "Incendiary Bombing" sync /:Engels:4739:/
 2070.5 "Guided Missile" sync /:Engels:4736:/ duration 3.4
 2078.8 "Diffuse Laser" sync /:Engels:4755:/
-2097.3 "Marx Smash F/B" sync /:Engels:472[AE]:/
-2115.9 "Marx Smash B/F" sync /:Engels:472[AE]:/
+2097.3 "Marx Smash Back" sync /:Engels:472[AE]:/
+2115.9 "Marx Smash Front" sync /:Engels:472[AE]:/
 2135.6 "Energy Barrage" sync /:Engels:473C:/
 2143.4 "Laser Sight" sync /:Engels:473A:/
 2154.1 "Energy Blast" sync /:Engels:473E:/

--- a/ui/raidboss/data/05-shb/dungeon/matoyas_relict.txt
+++ b/ui/raidboss/data/05-shb/dungeon/matoyas_relict.txt
@@ -83,7 +83,7 @@ hideall "--sync--"
 3086.5 "Minced Meat" sync /:Mother Porxie:5911:/ window 50,10
 3093.6 "--untargetable--"
 
-3096.6 "Huff And Puff" sync /:591A:Mother Porxie/ window 96.6,5 duration 34.3
+3096.6 "Huff And Puff" sync /:591A:Mother Porxie/ window 96.6,5 duration 33.7
 3101.6 "Buffet" sync /:Aeolian Cave Sprite:5926:/
 3107.3 "Buffet" sync /:Aeolian Cave Sprite:5926:/
 3112.8 "Buffet" sync /:Aeolian Cave Sprite:5926:/

--- a/ui/raidboss/data/05-shb/dungeon/matoyas_relict.txt
+++ b/ui/raidboss/data/05-shb/dungeon/matoyas_relict.txt
@@ -83,7 +83,7 @@ hideall "--sync--"
 3086.5 "Minced Meat" sync /:Mother Porxie:5911:/ window 50,10
 3093.6 "--untargetable--"
 
-3096.6 "Huff And Puff" sync /:591A:Mother Porxie/ window 96.6,5 duration 49.70
+3096.6 "Huff And Puff" sync /:591A:Mother Porxie/ window 96.6,5 duration 34.3
 3101.6 "Buffet" sync /:Aeolian Cave Sprite:5926:/
 3107.3 "Buffet" sync /:Aeolian Cave Sprite:5926:/
 3112.8 "Buffet" sync /:Aeolian Cave Sprite:5926:/


### PR DESCRIPTION
Rolled back
~~I think this is better than~~

~~This.~~
![K-006](https://user-images.githubusercontent.com/4695371/122912076-eb390280-d392-11eb-87dc-fac18353deea.png)


And, I wonder why there's `(latest version)` written. That would be obviously latest version if you see on the web. Does this mean that this is later version than the release version? (The code is written before it's been released.)