### PR TITLE
plugin: Fetch remote FateWatcher opcodes

### DIFF
--- a/plugin/CactbotEventSource/CactbotEventSource.cs
+++ b/plugin/CactbotEventSource/CactbotEventSource.cs
@@ -268,7 +268,7 @@ namespace Cactbot {
         LogInfo("Version: intl");
       }
       wipe_detector_ = new WipeDetector(this);
-      fate_watcher_ = new FateWatcher(this, language_);
+      fate_watcher_ = new FateWatcher(this, Config, language_);
 
       // Incoming events.
       Advanced_Combat_Tracker.ActGlobals.oFormActMain.OnLogLineRead += OnLogLineRead;

--- a/plugin/CactbotEventSource/CactbotEventSource.csproj
+++ b/plugin/CactbotEventSource/CactbotEventSource.csproj
@@ -81,6 +81,7 @@
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Drawing" />
+    <Reference Include="System.Net.Http" />
     <Reference Include="System.Web" />
     <Reference Include="System.Web.Extensions" />
     <Reference Include="System.Windows.Forms" />

--- a/plugin/CactbotEventSource/CactbotEventSourceConfig.cs
+++ b/plugin/CactbotEventSource/CactbotEventSourceConfig.cs
@@ -113,5 +113,59 @@ namespace Cactbot {
         general["DisableAutomaticOpcodeUpdates"] = value;
       }
     }
+
+    [JsonIgnore]
+    public bool UseCustomOpcodeSource {
+      get {
+        if (!OverlayData.TryGetValue("options", out JToken options))
+          return false;
+        var general = options["general"];
+        if (general == null)
+          return false;
+        var disableRemoteOpcodes = general["UseCustomOpcodeSource"];
+        if (disableRemoteOpcodes == null)
+          return false;
+        return disableRemoteOpcodes.ToObject<bool>();
+      }
+      set {
+        if (!OverlayData.TryGetValue("options", out JToken options)) {
+          options = new JObject();
+          OverlayData.Add("options", options);
+        }
+        var general = options["general"];
+        if (general == null) {
+          general = new JObject();
+          options["general"] = general;
+        }
+        general["UseCustomOpcodeSource"] = value;
+      }
+    }
+
+    [JsonIgnore]
+    public string CustomOpcodeSourceUrl {
+      get {
+        if (!OverlayData.TryGetValue("options", out JToken options))
+          return null;
+        var general = options["general"];
+        if (general == null)
+          return null;
+        var url = general["CustomOpcodeSourceUrl"];
+        if (url == null)
+          return null;
+        return url.ToString();
+      }
+      set {
+        if (!OverlayData.TryGetValue("options", out JToken options)) {
+          options = new JObject();
+          OverlayData.Add("options", options);
+        }
+        var general = options["general"];
+        if (general == null) {
+          general = new JObject();
+          options["general"] = general;
+        }
+        general["CustomOpcodeSourceUrl"] = value;
+      }
+    }
   }
 }

--- a/plugin/CactbotEventSource/CactbotEventSourceConfig.cs
+++ b/plugin/CactbotEventSource/CactbotEventSourceConfig.cs
@@ -86,5 +86,32 @@ namespace Cactbot {
         general["CactbotUserDirectory"] = value;
       }
     }
+
+    [JsonIgnore]
+    public bool DisableAutomaticOpcodeUpdates {
+      get {
+        if (!OverlayData.TryGetValue("options", out JToken options))
+          return false;
+        var general = options["general"];
+        if (general == null)
+          return false;
+        var disableRemoteOpcodes = general["DisableAutomaticOpcodeUpdates"];
+        if (disableRemoteOpcodes == null)
+          return false;
+        return disableRemoteOpcodes.ToObject<bool>();
+      }
+      set {
+        if (!OverlayData.TryGetValue("options", out JToken options)) {
+          options = new JObject();
+          OverlayData.Add("options", options);
+        }
+        var general = options["general"];
+        if (general == null) {
+          general = new JObject();
+          options["general"] = general;
+        }
+        general["DisableAutomaticOpcodeUpdates"] = value;
+      }
+    }
   }
 }

--- a/plugin/CactbotEventSource/FateWatcher.cs
+++ b/plugin/CactbotEventSource/FateWatcher.cs
@@ -42,7 +42,7 @@ namespace Cactbot {
     private CactbotEventSource client_;
     private IDataSubscription subscription;
 
-    private static readonly string remoteOpcodeURL = "http://127.0.0.1:8080/FATEOpcodes.json";
+    private static readonly string remoteOpcodeURL = "https://katttails.github.io/TestRepo/FATEOpcodes.json";
 
     bool opcodesLoaded = false;
     private Region OpCodes;

--- a/plugin/CactbotEventSource/FateWatcher.cs
+++ b/plugin/CactbotEventSource/FateWatcher.cs
@@ -47,17 +47,6 @@ namespace Cactbot {
     bool opcodesLoaded = false;
     private Region OpCodes;
 
-    // Fate start
-    // param1: fateID
-    // param2: unknown
-    //
-    // Fate end
-    // param1: fateID
-    //
-    // Fate update
-    // param1: fateID
-    // param2: progress (0-100)
-
     public struct AC143Category {
       [JsonConverter(typeof(HexStringJsonConverter))]
       public uint add;
@@ -83,32 +72,6 @@ namespace Cactbot {
       public Region cn;
       public Region ko;
     }
-
-    //
-    // CE Opcode History
-    // Intl
-    // v5.35            0x299
-    // v5.35h           0x143
-    // v5.40            0x3c1
-    // v5.40h           0x31b
-    // v5.41            0x31B
-    // v5.45            0x3e1
-    // v5.45h           0x1f5
-    // v5.5             0x2e7
-    // v5.5h            0x160
-    // v5.55            0x1ac
-    // v5.55h           0x248
-    //
-    // CN
-    // v5.35            0x144
-    // v5.40            0x129
-    // v5.41            0x0120
-    // v5.45            0x009e
-    //
-    // KR
-    // v5.35            0x347
-    // v5.4             0x1d1
-    // v5.41            0x341
 
     [Serializable]
     [StructLayout(LayoutKind.Explicit)]
@@ -288,6 +251,17 @@ namespace Cactbot {
 
     public unsafe void ProcessActorControl143(byte* buffer, byte[] message) {
       int a = *(ushort*)&buffer[actorControl143.categoryOffset];
+
+      // Fate start
+      // param1: fateID
+      // param2: unknown
+      //
+      // Fate end
+      // param1: fateID
+      //
+      // Fate update
+      // param1: fateID
+      // param2: progress (0-100)
 
       fateSemaphore.WaitAsync();
       try {

--- a/ui/config/config.css
+++ b/ui/config/config.css
@@ -273,6 +273,12 @@ input[type=text] {
   text-align: right;
 }
 
+input[type=url] {
+  padding: 3px;
+  width: 80%;
+  text-align: left;
+}
+
 .trigger-duration > input[type=text] {
   width: 75px;
   text-align: left;

--- a/ui/config/config.js
+++ b/ui/config/config.js
@@ -317,6 +317,7 @@ export default class CactbotConfigurator {
           const buildFunc = {
             checkbox: this.buildCheckbox,
             html: this.buildHtml,
+            url: this.buildUrl,
             select: this.buildSelect,
             float: this.buildFloat,
             integer: this.buildInteger,
@@ -388,6 +389,22 @@ export default class CactbotConfigurator {
     const div = document.createElement('div');
     div.classList.add('option-input-container');
     div.innerHTML = this.translate(opt.html);
+
+    parent.appendChild(this.buildNameDiv(opt));
+    parent.appendChild(div);
+  }
+
+  buildUrl(parent, opt, group) {
+    const div = document.createElement('div');
+    div.classList.add('option-input-container');
+
+    const input = document.createElement('input');
+    div.appendChild(input);
+    input.type = 'url';
+    input.value = this.getOption(group, opt.id, opt.default);
+    const setFunc = () => this.setOption(group, opt.id, input.value);
+    input.onchange = setFunc;
+    input.oninput = setFunc;
 
     parent.appendChild(this.buildNameDiv(opt));
     parent.appendChild(div);

--- a/ui/config/general_config.js
+++ b/ui/config/general_config.js
@@ -111,5 +111,23 @@ UserConfig.registerOptions('general', {
       type: 'checkbox',
       default: false,
     },
+    {
+      id: 'UseCustomOpcodeSource',
+      name: {
+        en: 'Use custom opcode source',
+      },
+      type: 'checkbox',
+      default: false,
+      debugOnly: true,
+    },
+    {
+      id: 'CustomOpcodeSourceUrl',
+      name: {
+        en: 'Custom opcode source URL',
+      },
+      type: 'url',
+      default: null,
+      debugOnly: true,
+    },
   ],
 });

--- a/ui/config/general_config.js
+++ b/ui/config/general_config.js
@@ -103,5 +103,13 @@ UserConfig.registerOptions('general', {
         options['DisplayLanguage'] = value;
       },
     },
+    {
+      id: 'DisableAutomaticOpcodeUpdates',
+      name: {
+        en: 'Disable automatic FATE/CE opcode updates',
+      },
+      type: 'checkbox',
+      default: false,
+    },
   ],
 });

--- a/ui/eureka/FATEOpcodes.json
+++ b/ui/eureka/FATEOpcodes.json
@@ -1,0 +1,35 @@
+{
+  "intl": {
+    "ac143category": {
+      "add": "0x935",
+      "remove": "0x936",
+      "update": "0x93e"
+    },
+    "ce": {
+      "opcode": "0x3ce",
+      "size": 30
+    }
+  },
+  "cn": {
+    "ac143category": {
+      "add": "0x935",
+      "remove": "0x936",
+      "update": "0x93e"
+    },
+    "ce": {
+      "opcode": "0x9e",
+      "size": 30
+    }
+  },
+  "ko": {
+    "ac143category": {
+      "add": "0x935",
+      "remove": "0x936",
+      "update": "0x93e"
+    },
+    "ce": {
+      "opcode": "0x341",
+      "size": 30
+    }
+  }
+}


### PR DESCRIPTION
This should ready for an initial review, any and all feedback is welcome.

I'm open to ideas on if a fallback should be added in case of failure to fetch the remote json. Considering the nature of ACT and FFXIV it would be expected that there wouldn't be connection problems and that the remote file is always available. On the other hand, a fallback to a locally stored copy of the opcode.json wouldn't be hard to implement and would alleviate any connection issues. 

I'm also open to suggestions on the appropriate location for the FATEOpcodes.json file. My thought at the moment is to store it in the `ui\eureka\` folder so it is included in Cactbot releases. This way it could be used as a local fallback if we decide to implement the option mentioned above, without many other changes. That being said, it isn't a file exclusive for the eureka overlay and so might be better suited somewhere else. 

Before a final merge the remote url will need updating to the final location, I've set it to a temporary repo just for initial testing.