### PR TITLE
raidemulator: Switch Encounter.initialTimestamp from getter to property

### DIFF
--- a/ui/raidboss/emulator/data/Encounter.ts
+++ b/ui/raidboss/emulator/data/Encounter.ts
@@ -42,6 +42,7 @@ export default class Encounter {
   duration = 0;
   playbackOffset = 0;
   language: Lang = 'en';
+  initialTimestamp = Number.MAX_SAFE_INTEGER;
 
   constructor(
     public encounterDay: string,
@@ -110,16 +111,14 @@ export default class Encounter {
         this.initialOffset = 0;
     }
 
+    this.initialTimestamp = this.startTimestamp + this.initialOffset;
+
     const firstLine = this.logLines[this.firstLineIndex];
 
     if (firstLine && firstLine.offset)
       this.playbackOffset = firstLine.offset;
 
     this.startStatus = [...startStatuses].sort().join(', ');
-  }
-
-  public get initialTimestamp() : number {
-    return this.startTimestamp + this.initialOffset;
   }
 
   shouldPersistFight(): boolean {


### PR DESCRIPTION
Fixes #3163, caused due to the getter not transferring properly through the websocket API