### PR TITLE
util: Fix the return type of watchCombatant helper

### DIFF
--- a/resources/util.ts
+++ b/resources/util.ts
@@ -89,7 +89,7 @@ type WatchCombatantParams = {
 };
 
 type WatchCombatantFunc = (params: WatchCombatantParams,
-  func: (ret: GetCombatantsRet) => boolean) => Promise<boolean>;
+  func: (ret: GetCombatantsRet) => boolean) => Promise<void>;
 
 type WatchCombatantMapEntry = {
   cancel: boolean;
@@ -108,7 +108,7 @@ const shouldCancelWatch =
   };
 
 const watchCombatant: WatchCombatantFunc = (params, func) => {
-  return new Promise<boolean>((res, rej) => {
+  return new Promise<void>((res, rej) => {
     const delay = params.delay ?? 1000;
 
     const call: GetCombatantsCall = {
@@ -142,7 +142,7 @@ const watchCombatant: WatchCombatantFunc = (params, func) => {
           return;
         }
         if (func(response))
-          res(true);
+          res();
         else
           window.setTimeout(checkFunc, delay);
       });


### PR DESCRIPTION
As mentioned on #3186, update the return type of `Util.watchCombatants` to be `Promise<void>`