### PR TITLE
raidboss: Fix typing of timeline property on trigger sets

### DIFF
--- a/types/trigger.d.ts
+++ b/types/trigger.d.ts
@@ -136,7 +136,8 @@ export type TimelineTrigger<Data extends RaidbossData> = BaseTrigger<Data, 'None
 };
 
 // Because timeline functions run during loading, they only support the base RaidbossData.
-export type TimelineFunc = string | string[] | ((data: RaidbossData) => TimelineFunc);
+export type TimelineFunc = (data: RaidbossData) => TimelineField | undefined;
+export type TimelineField = string | (string | TimelineFunc)[];
 
 export type DataInitializeFunc<Data extends RaidbossData> = () => Omit<Data, keyof RaidbossData>;
 
@@ -146,7 +147,7 @@ export type TriggerSet<Data extends RaidbossData> = {
   resetWhenOutOfCombat?: boolean;
   overrideTimelineFile?: boolean;
   timelineFile?: string;
-  timeline?: TimelineFunc;
+  timeline?: TimelineField;
   triggers?: NetRegexTrigger<Data>[];
   timelineTriggers?: TimelineTrigger<Data>[];
   timelineReplace?: TimelineReplacement[];

--- a/types/trigger.d.ts
+++ b/types/trigger.d.ts
@@ -136,8 +136,8 @@ export type TimelineTrigger<Data extends RaidbossData> = BaseTrigger<Data, 'None
 };
 
 // Because timeline functions run during loading, they only support the base RaidbossData.
-export type TimelineFunc = (data: RaidbossData) => TimelineField | undefined;
-export type TimelineField = string | (string | TimelineFunc)[];
+export type TimelineFunc = (data: RaidbossData) => TimelineField;
+export type TimelineField = string | (string | TimelineFunc)[] | TimelineFunc | undefined;
 
 export type DataInitializeFunc<Data extends RaidbossData> = () => Omit<Data, keyof RaidbossData>;
 

--- a/ui/raidboss/popup-text.ts
+++ b/ui/raidboss/popup-text.ts
@@ -11,7 +11,7 @@ import { EventResponses, LogEvent } from '../../types/event';
 import { Job, Role } from '../../types/job';
 import { Matches } from '../../types/net_matches';
 import {
-  LooseTrigger, OutputStrings, TriggerSet, TimelineFunc, LooseTriggerSet,
+  LooseTrigger, OutputStrings, TriggerSet, TimelineField, TimelineFunc, LooseTriggerSet,
   ResponseField, TriggerAutoConfig, TriggerField, TriggerOutput,
   Output, ResponseOutput, PartialTriggerOutput, DataInitializeFunc,
   GeneralNetRegexTrigger, RegexTrigger,
@@ -567,7 +567,7 @@ export class PopupText {
 
     // Recursively/iteratively process timeline entries for triggers.
     // Functions get called with data, arrays get iterated, strings get appended.
-    const addTimeline = (function(this: PopupText, obj: TimelineFunc) {
+    const addTimeline = (function(this: PopupText, obj: TimelineField | TimelineFunc | undefined) {
       if (Array.isArray(obj)) {
         for (const objVal of obj)
           addTimeline(objVal);


### PR DESCRIPTION
This PR fixes some issues with the typing of the `timeline` property on trigger sets, which I encountered while converting `00-misc/test.js` to typescript.