### PR TITLE
raidboss: Fix trigger regex with no matching groups not being passed as matches

### DIFF
--- a/ui/raidboss/popup-text.ts
+++ b/ui/raidboss/popup-text.ts
@@ -887,6 +887,10 @@ export class PopupText {
     // so triggers can do things like matches.target.
     if (matches && matches.groups)
       groups = matches.groups;
+    // If there are no matching groups, reproduce the old js logic where
+    // groups ended up as the original RegExpExecArray object
+    else if (matches)
+      groups = { 0: matches.input };
 
     // Set up a helper object so we don't have to throw
     // a ton of info back and forth between subfunctions

--- a/ui/raidboss/popup-text.ts
+++ b/ui/raidboss/popup-text.ts
@@ -885,12 +885,15 @@ export class PopupText {
     let groups: Matches = {};
     // If using named groups, treat matches.groups as matches
     // so triggers can do things like matches.target.
-    if (matches && matches.groups)
+    if (matches && matches.groups) {
       groups = matches.groups;
-    // If there are no matching groups, reproduce the old js logic where
-    // groups ended up as the original RegExpExecArray object
-    else if (matches)
-      groups = { 0: matches.input };
+    } else if (matches) {
+      // If there are no matching groups, reproduce the old js logic where
+      // groups ended up as the original RegExpExecArray object
+      matches.forEach((value, idx) => {
+        groups[idx] = value;
+      });
+    }
 
     // Set up a helper object so we don't have to throw
     // a ton of info back and forth between subfunctions


### PR DESCRIPTION
Fixes #3203
The old pre-typescript logic was:

```ts
if (matches.groups)
  matches = matches.groups;
```

`matches` was then passed to triggers. When converting to typescript, after hard types were added for these, this exact logic was no longer possible and was erroneously dropped instead of reproduced.