### PR TITLE
lint: add no-extra-parens rule

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -138,6 +138,9 @@ const rules = {
   'no-duplicate-imports': 'error',
   'no-else-return': 'error',
   'no-eval': 'error',
+  'no-extra-parens': ['error', 'all', {
+    'nestedBinaryExpressions': false,
+  }],
   'no-implied-eval': 'error',
   'no-sequences': 'error',
   'no-undef': 'off',
@@ -236,12 +239,16 @@ const tsOverrides = {
     }],
     '@typescript-eslint/method-signature-style': ['error', 'property'],
     '@typescript-eslint/no-explicit-any': 'error',
+    '@typescript-eslint/no-extra-parens': ['error', 'all', {
+      'nestedBinaryExpressions': false,
+    }],
     '@typescript-eslint/no-non-null-assertion': 'error',
     '@typescript-eslint/no-unused-vars': ['error', { 'argsIgnorePattern': '^_\\w+' }],
     '@typescript-eslint/object-curly-spacing': ['error', 'always'],
     'func-style': ['error', 'expression', { 'allowArrowFunctions': true }],
     'import/order': ['error', { 'alphabetize': { 'caseInsensitive': true, 'order': 'asc' }, 'newlines-between': 'always' }],
     'indent': 'off',
+    'no-extra-parens': 'off',
     'object-shorthand': ['error', 'consistent'],
   },
 };

--- a/eslint/cactbot-output-strings.js
+++ b/eslint/cactbot-output-strings.js
@@ -108,7 +108,7 @@ const ruleModule = {
           stack.outputTemplates = extractTemplate(outputValue);
           stack.outputProperties =
             t.isIdentifier(outputValue)
-              ? (globalVars.get(outputValue.name) || [])
+              ? globalVars.get(outputValue.name) || []
               : getAllKeys(outputValue.properties);
           stack.triggerID = node.parent.parent.properties.find((prop) => prop.key && prop.key.name === 'id')?.value?.value;
           return;

--- a/resources/regexes.ts
+++ b/resources/regexes.ts
@@ -735,12 +735,12 @@ export default class Regexes {
     const regex = Regexes.parse(regexpString);
     let modifiers = 'gi';
     if (regexpString instanceof RegExp)
-      modifiers += (regexpString.multiline ? 'm' : '');
+      modifiers += regexpString.multiline ? 'm' : '';
     return new RegExp(regex.source, modifiers);
   }
 
   static trueIfUndefined(value?: boolean): boolean {
-    if (typeof (value) === 'undefined')
+    if (typeof value === 'undefined')
       return true;
     return !!value;
   }

--- a/resources/resourcebar.ts
+++ b/resources/resourcebar.ts
@@ -412,7 +412,7 @@ export default class ResourceBar extends HTMLElement {
     updateBar(extraOverStyle);
 
     const halfHeight = (this._height - this.kBorderSize * 2) * this._scale * 0.5;
-    extraOverStyle.height = (halfHeight).toString();
+    extraOverStyle.height = halfHeight.toString();
     extraOverStyle.top = (halfHeight + (this.kBorderSize * this._scale)).toString();
 
     const widthPadding = this.kBorderSize * 4 + this.kTextLeftRightEdgePadding * 2;

--- a/resources/timericon.ts
+++ b/resources/timericon.ts
@@ -364,7 +364,7 @@ export default class TimerIcon extends HTMLElement {
     if (!this._connected)
       return;
 
-    this.startTimeMs = +new Date();
+    this.startTimeMs = Date.now();
 
     this.rootElement.style.display = 'block';
     clearTimeout(this._hideTimer ?? 0);

--- a/ui/dps/rdmty/dps.js
+++ b/ui/dps/rdmty/dps.js
@@ -600,7 +600,7 @@ function onOverlayDataUpdate(e) {
       }),
       container,
   );
-  // console.log('rendered in ' + (+new Date() - start) + 'ms');
+  // console.log('rendered in ' + (Date.now() - start) + 'ms');
 }
 
 function hideOverlay() {

--- a/ui/eureka/eureka.js
+++ b/ui/eureka/eureka.js
@@ -4164,7 +4164,7 @@ class EurekaTracker {
     let respawnTimeMs = 120 * 60 * 1000;
     if ('respawnMinutes' in nm)
       respawnTimeMs = nm.respawnMinutes * 60 * 1000;
-    return respawnTimeMs + (+new Date());
+    return respawnTimeMs + (Date.now());
   }
 
   DebugPrint(str) {
@@ -4245,7 +4245,7 @@ class EurekaTracker {
   }
 
   UpdateTimes() {
-    const nowMs = +new Date();
+    const nowMs = Date.now();
 
     const primaryWeatherList = this.zoneInfo.primaryWeather;
     if (primaryWeatherList) {
@@ -4409,7 +4409,7 @@ class EurekaTracker {
       const time = m[2];
       const nm = trackerToNM[name.toLowerCase()];
       if (nm)
-        nm.respawnTimeMsTracker = (time * 60 * 1000) + (+new Date());
+        nm.respawnTimeMsTracker = (time * 60 * 1000) + (Date.now());
       else
         console.error('Invalid NM Import: ' + name);
     }

--- a/ui/eureka/eureka.js
+++ b/ui/eureka/eureka.js
@@ -4164,7 +4164,7 @@ class EurekaTracker {
     let respawnTimeMs = 120 * 60 * 1000;
     if ('respawnMinutes' in nm)
       respawnTimeMs = nm.respawnMinutes * 60 * 1000;
-    return respawnTimeMs + (Date.now());
+    return respawnTimeMs + Date.now();
   }
 
   DebugPrint(str) {
@@ -4409,7 +4409,7 @@ class EurekaTracker {
       const time = m[2];
       const nm = trackerToNM[name.toLowerCase()];
       if (nm)
-        nm.respawnTimeMsTracker = (time * 60 * 1000) + (Date.now());
+        nm.respawnTimeMsTracker = (time * 60 * 1000) + Date.now();
       else
         console.error('Invalid NM Import: ' + name);
     }

--- a/ui/fisher/fisher-ui.js
+++ b/ui/fisher/fisher-ui.js
@@ -34,7 +34,7 @@ export default class FisherUI {
   }
 
   draw() {
-    const timeMs = (new Date() - this.castStart);
+    const timeMs = new Date() - this.castStart;
     const time = (timeMs / 1000).toFixed(1);
 
     this.timeEl.innerHTML = time;
@@ -87,7 +87,7 @@ export default class FisherUI {
           bar.duration = (max - min) / 1000;
           timeouts.push(setTimeout(() => {
             row.style.opacity = 0.5;
-          }, (max - min)));
+          }, max - min));
         }, min));
       } else {
         bar.duration = 0;

--- a/ui/fisher/fisher.js
+++ b/ui/fisher/fisher.js
@@ -160,9 +160,9 @@ class Fisher {
   updateFishData() {
     // We can only know data for both of these
     if (!this.place || !this.getActiveBait()) {
-      return new Promise(((resolve, reject) => {
+      return new Promise((resolve, reject) => {
         resolve();
-      }));
+      });
     }
 
     const _this = this;
@@ -175,7 +175,7 @@ class Fisher {
     // We should update twice for each fish, one for hook times and one for tugs
     let queue = this.placeFish.length * 2;
 
-    return new Promise(((resolve, reject) => {
+    return new Promise((resolve, reject) => {
       for (const index in _this.placeFish) {
         const fish = _this.placeFish[index];
 
@@ -200,7 +200,7 @@ class Fisher {
           }
         });
       }
-    }));
+    });
   }
 
   handleBait(bait) {
@@ -266,8 +266,8 @@ class Fisher {
         'bait': this.getActiveBait().id,
         'place': this.place.id,
         'castTimestamp': +this.castStart,
-        'hookTime': (this.castEnd - this.castStart),
-        'reelTime': (this.castGet - this.castEnd),
+        'hookTime': this.castEnd - this.castStart,
+        'reelTime': this.castGet - this.castEnd,
         'chum': this.chumOnCatch ? 1 : 0,
         'snagging': this.snagging,
       });

--- a/ui/jobs/components/dnc.js
+++ b/ui/jobs/components/dnc.js
@@ -87,7 +87,7 @@ export function setup(bars) {
     EffectId.FlourishingWindmill,
     EffectId.FlourishingFanDance,
   ], (effect) => {
-    if (!(flourishEffect.includes(effect)))
+    if (!flourishEffect.includes(effect))
       flourishEffect.push(effect);
     if (flourishEffect.length === 5 && flourishIsActive) {
       flourish.duration = 60 - flourish.elapsed;

--- a/ui/jobs/components/rdm.js
+++ b/ui/jobs/components/rdm.js
@@ -10,7 +10,7 @@ export function setup(bars) {
   for (let i = 0; i < 100; i += incs) {
     const marker = document.createElement('div');
     marker.classList.add('marker');
-    marker.classList.add((i % 40 === 0) ? 'odd' : 'even');
+    marker.classList.add(i % 40 === 0 ? 'odd' : 'even');
     container.appendChild(marker);
     marker.style.left = i + '%';
     marker.style.width = incs + '%';

--- a/ui/oopsyraidsy/oopsyraidsy.js
+++ b/ui/oopsyraidsy/oopsyraidsy.js
@@ -582,7 +582,7 @@ class MistakeCollector {
       this.StartCombat();
       return;
     }
-    const seconds = ((Date.now() - this.startTime) / 1000);
+    const seconds = (Date.now() - this.startTime) / 1000;
     if (this.firstPuller && seconds >= this.options.MinimumTimeForPullMistake) {
       const text = this.Translate(kEarlyPullText) + ' (' + seconds.toFixed(1) + 's)';
       if (IsTriggerEnabled(this.options, kEarlyPullId))
@@ -600,7 +600,7 @@ class MistakeCollector {
         this.firstPuller = '???';
 
       this.StartCombat();
-      const seconds = ((Date.now() - this.engageTime) / 1000);
+      const seconds = (Date.now() - this.engageTime) / 1000;
       if (this.engageTime && seconds >= this.options.MinimumTimeForPullMistake) {
         const text = this.Translate(kLatePullText) + ' (' + seconds.toFixed(1) + 's)';
         if (IsTriggerEnabled(this.options, kEarlyPullId))
@@ -965,7 +965,7 @@ class DamageTracker {
     }
 
     const ValueOrFunction = (f, events, matches) => {
-      return (typeof f === 'function') ? f(events, this.data, matches) : f;
+      return typeof f === 'function' ? f(events, this.data, matches) : f;
     };
 
     const collectSeconds = 'collectSeconds' in trigger ? ValueOrFunction(trigger.collectSeconds, matches) : 0;
@@ -985,7 +985,7 @@ class DamageTracker {
     if (trigger.id && suppress > 0)
       this.triggerSuppress[trigger.id] = triggerTime + (suppress * 1000);
 
-    const f = (function() {
+    const f = function() {
       let eventParam = evt;
       let matchesParam = matches;
       if (collectMultipleEvents) {
@@ -1012,7 +1012,7 @@ class DamageTracker {
       }
       if ('run' in trigger)
         ValueOrFunction(trigger.run, eventParam, matchesParam);
-    }).bind(this);
+    }.bind(this);
 
     // Even if delay = 0, if collectMultipleEvents is specified,
     // then set this here so that events can be passed as an array for consistency.

--- a/ui/radar/radar.ts
+++ b/ui/radar/radar.ts
@@ -120,7 +120,7 @@ class Point2D {
 
   // Calculates vector length (magnitude)
   length() {
-    return Math.sqrt((this.x) * (this.x) + (this.y) * (this.y));
+    return Math.sqrt(this.x * this.x + this.y * this.y);
   }
 
   // Calculate delta vector

--- a/ui/raidboss/data/04-sb/alliance/royal_city_of_rabanastre.js
+++ b/ui/raidboss/data/04-sb/alliance/royal_city_of_rabanastre.js
@@ -41,7 +41,7 @@ export default {
       },
       infoText: (data, _matches, output) => {
         if (data.breathless >= 7)
-          return output.breathless({ num: (data.breathless + 1) });
+          return output.breathless({ num: data.breathless + 1 });
       },
       tts: (data, _matches, output) => {
         if (data.breathless === 6)

--- a/ui/raidboss/data/04-sb/raid/o3n.js
+++ b/ui/raidboss/data/04-sb/raid/o3n.js
@@ -98,7 +98,7 @@ export default {
         if (data.phaseNumber < 3)
           return false;
         data.holyCounter = data.holyCounter || 0;
-        return (data.holyCounter % 2 === 0);
+        return data.holyCounter % 2 === 0;
       },
       response: Responses.stackMarkerOn(),
       run: (data) => {

--- a/ui/raidboss/data/04-sb/trial/susano-ex.js
+++ b/ui/raidboss/data/04-sb/trial/susano-ex.js
@@ -192,7 +192,7 @@ export default {
       netRegex: NetRegexes.headMarker({ id: '006E' }),
       condition: (data, matches) => {
         data.levinbolt = matches.target;
-        return (matches.target !== data.me);
+        return matches.target !== data.me;
       },
     },
     {

--- a/ui/raidboss/data/05-shb/raid/e12s.js
+++ b/ui/raidboss/data/05-shb/raid/e12s.js
@@ -236,7 +236,7 @@ const matchedPositionToDir = (matches) => {
   // Advanced Relativity party splits.
   // Map NW = 0, N = 1, ..., W = 7
 
-  return (Math.round(5 - 4 * Math.atan2(x, y) / Math.PI) % 8);
+  return Math.round(5 - 4 * Math.atan2(x, y) / Math.PI) % 8;
 };
 
 // Convert dir to Output
@@ -251,7 +251,7 @@ const dirToOutput = (dir, output) => {
     6: output.southwest(),
     7: output.west(),
   };
-  return (dirs[dir]);
+  return dirs[dir];
 };
 
 export default {

--- a/ui/raidboss/data/05-shb/ultimate/the_epic_of_alexander.js
+++ b/ui/raidboss/data/05-shb/ultimate/the_epic_of_alexander.js
@@ -2446,7 +2446,7 @@ export default {
         const x = matches.x - 100;
         const y = 100 - matches.y;
         // 0 = N, 1 = E, 2 = S, 3 = W
-        const idx = Math.round((Math.atan2(x, y) / Math.PI * 2 + 4)) % 4;
+        const idx = Math.round(Math.atan2(x, y) / Math.PI * 2 + 4) % 4;
         data.radiantOutputStringKey = {
           // North shouldn't be possible.
           // But, leaving this here in case my math is wrong.

--- a/ui/raidboss/emulator/EventBus.ts
+++ b/ui/raidboss/emulator/EventBus.ts
@@ -36,7 +36,7 @@ export default class EventBus {
       const events: EventMapEntry[] = this.listeners[event] ??= [];
       if (callback !== undefined)
         events.push({ event: event, scope: scope, callback: callback });
-      ret.push(...(this.listeners[event] ?? []));
+      ret.push(...this.listeners[event] ?? []);
     }
     return ret;
   }

--- a/ui/raidboss/emulator/data/NetworkLogConverter.ts
+++ b/ui/raidboss/emulator/data/NetworkLogConverter.ts
@@ -27,7 +27,7 @@ export default class NetworkLogConverter extends EventBus {
     });
     // Sort the lines based on `${timestamp}_${index}` to handle out-of-order lines properly
     // @TODO: Remove this once underlying CombatantTracker update issues are resolved
-    return lineEvents.sort((l, r) => (`${l.timestamp}_${l.index}`).localeCompare(`${r.timestamp}_${r.index}`));
+    return lineEvents.sort((l, r) => `${l.timestamp}_${l.index}`.localeCompare(`${r.timestamp}_${r.index}`));
   }
 
   static lineSplitRegex = /\r?\n/gm;

--- a/ui/raidboss/emulator/data/network_log_converter/LineEvent.ts
+++ b/ui/raidboss/emulator/data/network_log_converter/LineEvent.ts
@@ -28,7 +28,7 @@ export default class LineEvent {
     this.timestamp = new Date(parts[fields.timestamp] ?? '0').getTime();
     this.checksum = parts.slice(-1)[0] ?? '';
     repo.updateTimestamp(this.timestamp);
-    this.convertedLine = this.prefix() + (parts.join(':')).replace('|', ':');
+    this.convertedLine = this.prefix() + parts.join(':').replace('|', ':');
   }
 
   prefix(): string {

--- a/ui/raidboss/emulator/data/network_log_converter/LineEvent0x19.ts
+++ b/ui/raidboss/emulator/data/network_log_converter/LineEvent0x19.ts
@@ -49,8 +49,8 @@ export class LineEvent0x19 extends LineEvent {
     if (this.targetId !== '00')
       resolvedTargetName = repo.resolveName(this.targetId, this.targetName);
 
-    const defeatedName = (resolvedName ?? this.name);
-    const killerName = (resolvedTargetName ?? this.targetName);
+    const defeatedName = resolvedName ?? this.name;
+    const killerName = resolvedTargetName ?? this.targetName;
     this.convertedLine = this.prefix() + defeatedName +
       ' was defeated by ' + killerName + '.';
     this.properCaseConvertedLine = this.prefix() + EmulatorCommon.properCase(defeatedName) +

--- a/ui/raidboss/emulator/data/network_log_converter/LineEvent0x1F.ts
+++ b/ui/raidboss/emulator/data/network_log_converter/LineEvent0x1F.ts
@@ -62,7 +62,7 @@ export class LineEvent0x1F extends LineEvent {
       ':' + this.dataBytes3 +
       ':' + this.dataBytes4;
     this.properCaseConvertedLine = this.prefix() +
-      this.id + ':' + (EmulatorCommon.properCase(this.name)) +
+      this.id + ':' + EmulatorCommon.properCase(this.name) +
       ':' + this.dataBytes1 +
       ':' + this.dataBytes2 +
       ':' + this.dataBytes3 +

--- a/ui/raidboss/emulator/ui/EmulatedPartyInfo.js
+++ b/ui/raidboss/emulator/ui/EmulatedPartyInfo.js
@@ -292,14 +292,14 @@ export default class EmulatedPartyInfo extends EventBus {
   getTriggerLabelText(trigger) {
     let ret = trigger.status.responseLabel;
 
-    if (typeof (ret) === 'object')
+    if (typeof ret === 'object')
       ret = trigger.triggerHelper.valueOrFunction(ret);
 
-    if (typeof (ret) === 'boolean')
+    if (typeof ret === 'boolean')
       ret = undefined;
-    else if (typeof (ret) === 'undefined')
+    else if (typeof ret === 'undefined')
       ret = undefined;
-    else if (typeof (ret) !== 'string')
+    else if (typeof ret !== 'string')
       ret = 'Invalid Result?';
 
     if (ret === '')
@@ -385,7 +385,7 @@ export default class EmulatedPartyInfo extends EventBus {
         $wrapper.classList.remove('d-none');
       else
         $wrapper.classList.add('d-none');
-      typeof (params.onclick) === 'function' && params.onclick();
+      typeof params.onclick === 'function' && params.onclick();
     });
     $wrapper.append(params.$obj);
     return $ret;

--- a/ui/raidboss/popup-text.ts
+++ b/ui/raidboss/popup-text.ts
@@ -567,7 +567,7 @@ export class PopupText {
 
     // Recursively/iteratively process timeline entries for triggers.
     // Functions get called with data, arrays get iterated, strings get appended.
-    const addTimeline = (function(this: PopupText, obj: TimelineField | TimelineFunc | undefined) {
+    const addTimeline = function(this: PopupText, obj: TimelineField | TimelineFunc | undefined) {
       if (Array.isArray(obj)) {
         for (const objVal of obj)
           addTimeline(objVal);
@@ -576,7 +576,7 @@ export class PopupText {
       } else if (obj) {
         timelines.push(obj);
       }
-    }).bind(this);
+    }.bind(this);
 
     // construct something like regexDe or regexFr.
     const langSuffix = this.parserLang.charAt(0).toUpperCase() + this.parserLang.slice(1);

--- a/ui/raidboss/popup-text.ts
+++ b/ui/raidboss/popup-text.ts
@@ -839,7 +839,7 @@ export class PopupText {
   OnLog(e: LogEvent): void {
     // This could conceivably be determined based on the line's contents as well, but
     // not sure if that's worth the effort
-    const currentTime = +new Date();
+    const currentTime = Date.now();
     for (const log of e.detail.logs) {
       if (log.includes('00:0038:cactbot wipe'))
         this.SetInCombat(false);
@@ -856,7 +856,7 @@ export class PopupText {
     const log = e.rawLine;
     // This could conceivably be determined based on `new Date(e.line[1])` as well, but
     // not sure if that's worth the effort
-    const currentTime = +new Date();
+    const currentTime = Date.now();
     for (const trigger of this.netTriggers) {
       const r = trigger.localNetRegex?.exec(log);
       if (r)

--- a/ui/raidboss/raidboss_config.js
+++ b/ui/raidboss/raidboss_config.js
@@ -627,7 +627,7 @@ class RaidbossConfigurator {
 
   // This duplicates the raidboss function of the same name.
   valueOrFunction(f, data, matches, output) {
-    const result = (typeof f === 'function') ? f(data, matches, output) : f;
+    const result = typeof f === 'function' ? f(data, matches, output) : f;
     if (result !== Object(result))
       return result;
     if (result[this.alertsLang])

--- a/ui/raidboss/raidemulator.js
+++ b/ui/raidboss/raidemulator.js
@@ -353,7 +353,7 @@ document.addEventListener('DOMContentLoaded', async () => {
       // Offer download to user
       const a = document.createElement('a');
       a.href = URL.createObjectURL(blob);
-      a.setAttribute('download', 'RaidEmulator_DBExport_' + (Date.now()) + '.json');
+      a.setAttribute('download', 'RaidEmulator_DBExport_' + Date.now() + '.json');
       a.click();
       // After a second (so after user accepts/declines)
       // remove the object URL to avoid memory issues

--- a/ui/raidboss/raidemulator.js
+++ b/ui/raidboss/raidemulator.js
@@ -353,7 +353,7 @@ document.addEventListener('DOMContentLoaded', async () => {
       // Offer download to user
       const a = document.createElement('a');
       a.href = URL.createObjectURL(blob);
-      a.setAttribute('download', 'RaidEmulator_DBExport_' + (+new Date()) + '.json');
+      a.setAttribute('download', 'RaidEmulator_DBExport_' + (Date.now()) + '.json');
       a.click();
       // After a second (so after user accepts/declines)
       // remove the object URL to avoid memory issues

--- a/ui/test/test.ts
+++ b/ui/test/test.ts
@@ -11,7 +11,7 @@ addOverlayListener('ChangeZone', (e) => {
 addOverlayListener('onInCombatChangedEvent', (e) => {
   const inCombat = document.getElementById('inCombat');
   if (inCombat)
-    inCombat.innerText = `inCombat: act: ${e.detail.inACTCombat ? 'yes' : 'no'} game: ${(e.detail.inGameCombat ? 'yes' : 'no')}`;
+    inCombat.innerText = `inCombat: act: ${e.detail.inACTCombat ? 'yes' : 'no'} game: ${e.detail.inGameCombat ? 'yes' : 'no'}`;
 });
 
 addOverlayListener('onPlayerChangedEvent', (e) => {

--- a/util/logtools/split_log.js
+++ b/util/logtools/split_log.js
@@ -225,7 +225,7 @@ const printCollectedFights = (collector) => {
       leftExtendStr(row, lengths, 2) + ' ' +
       leftExtendStr(row, lengths, 3) + ' ' +
       rightExtendStr(row, lengths, 4) +
-      (row[5] ? (' ' + '[' + row[5] + ']') : ''));
+      (row[5] ? ' ' + '[' + row[5] + ']' : ''));
   }
 };
 


### PR DESCRIPTION
In playing around with prettier, if we don't want prettier to add parens everywhere, we probably want this rule to maintain (most of) the current behavior.