### PR TITLE
set `locale` of TimelineReplacement to `Lang`

### DIFF
--- a/ui/raidboss/timeline.ts
+++ b/ui/raidboss/timeline.ts
@@ -75,7 +75,7 @@ const activeText = {
 };
 
 export type TimelineReplacement = {
-  locale: string;
+  locale: Lang;
   missingTranslations?: boolean;
   replaceSync?: { [regexString: string]: string };
   replaceText?: { [timelineText: string]: string };


### PR DESCRIPTION
```diff
diff --git a/ui/raidboss/timeline.ts b/ui/raidboss/timeline.ts
index 0746284360..809210bd7e 100644
--- a/ui/raidboss/timeline.ts
+++ b/ui/raidboss/timeline.ts
@@ -75,7 +75,7 @@ const activeText = {
 };
 
 export type TimelineReplacement = {
-  locale: string;
+  locale: Lang;
   missingTranslations?: boolean;
   replaceSync?: { [regexString: string]: string };
   replaceText?: { [timelineText: string]: string };
```