### PR TITLE
raidboss: Require initData if data type contains non-optional properties

### DIFF
--- a/types/trigger.d.ts
+++ b/types/trigger.d.ts
@@ -143,7 +143,11 @@ export type DataInitializeFunc<Data extends RaidbossData> = () => Omit<Data, key
 
 export type DisabledTrigger = { id: string; disabled: true };
 
-type Required<Type> =
+// This helper takes all of the properties in Type and checks to see if they can be assigned to a
+// blank object, and if so excludes them from the returned union. The `-?` syntax removes the
+// optional modifier from the attribute which prevents `undefined` from being included in the union
+// See also: https://www.typescriptlang.org/docs/handbook/2/mapped-types.html#mapping-modifiers
+type RequiredFieldsAsUnion<Type> =
   {
     [key in keyof Type]-?: Record<string, never> extends Pick<Type, key> ? never : key
   }[keyof Type];
@@ -163,11 +167,9 @@ export type BaseTriggerSet<Data extends RaidbossData> = {
 
 // If Data contains required properties that are not on RaidbossData, require initData
 export type TriggerSet<Data extends RaidbossData> = BaseTriggerSet<Data> &
-  (Required<RaidbossData> extends Required<Data> ? Required<Data> extends Required<RaidbossData> ?
+  (RequiredFieldsAsUnion<Data> extends RequiredFieldsAsUnion<RaidbossData> ?
   {
     initData?: DataInitializeFunc<Data>;
-  } : {
-    initData: DataInitializeFunc<Data>;
   } : {
     initData: DataInitializeFunc<Data>;
   });

--- a/types/trigger.d.ts
+++ b/types/trigger.d.ts
@@ -143,7 +143,12 @@ export type DataInitializeFunc<Data extends RaidbossData> = () => Omit<Data, key
 
 export type DisabledTrigger = { id: string; disabled: true };
 
-export type TriggerSet<Data extends RaidbossData> = {
+type Required<Type> =
+  {
+    [key in keyof Type]-?: Record<string, never> extends Pick<Type, key> ? never : key
+  }[keyof Type];
+
+export type BaseTriggerSet<Data extends RaidbossData> = {
   // ZoneId.MatchAll (aka null) is not supported in array form.
   zoneId: ZoneId | number[];
   resetWhenOutOfCombat?: boolean;
@@ -154,8 +159,18 @@ export type TriggerSet<Data extends RaidbossData> = {
   timelineTriggers?: (TimelineTrigger<Data> | DisabledTrigger)[];
   timelineReplace?: TimelineReplacement[];
   timelineStyles?: TimelineStyle[];
-  initData?: DataInitializeFunc<Data>;
 }
+
+// If Data contains required properties that are not on RaidbossData, require initData
+export type TriggerSet<Data extends RaidbossData> = BaseTriggerSet<Data> &
+  (Required<RaidbossData> extends Required<Data> ? Required<Data> extends Required<RaidbossData> ?
+  {
+    initData?: DataInitializeFunc<Data>;
+  } : {
+    initData: DataInitializeFunc<Data>;
+  } : {
+    initData: DataInitializeFunc<Data>;
+  });
 
 // Less strict type for user triggers + built-in triggers, including deprecated fields.
 export type LooseTimelineTrigger = Partial<TimelineTrigger<RaidbossData>>;


### PR DESCRIPTION
This PR changes TriggerSet to require initData if the data type passed in contains non-optional properties that are not part of the RaidbossData type.

Example:

![image](https://user-images.githubusercontent.com/6119598/123723306-1a021d80-d858-11eb-9279-0a148a92448f.png)
