### PR TITLE
raidemulator: Fix 2 issues with importing with Dexie

### DIFF
--- a/ui/raidboss/emulator/data/Persistor.ts
+++ b/ui/raidboss/emulator/data/Persistor.ts
@@ -57,18 +57,16 @@ export default class Persistor extends Dexie {
     });
   }
 
-  persistEncounter(baseEncounter: Encounter): Promise<[number, number]> {
+  async persistEncounter(baseEncounter: Encounter): Promise<unknown> {
     const summary = new PersistorEncounter(baseEncounter);
     if (baseEncounter.id !== undefined) {
-      return Promise.all([
-        this.encounterSummaries.put(summary, baseEncounter.id),
-        this.encounters.put(baseEncounter, baseEncounter.id),
-      ]);
+      await this.encounterSummaries.put(summary, baseEncounter.id);
+      return this.encounters.put(baseEncounter, baseEncounter.id);
     }
-    return Promise.all([
-      this.encounterSummaries.add(summary, baseEncounter.id),
-      this.encounters.add(baseEncounter, baseEncounter.id),
-    ]);
+    const id = await this.encounters.add(baseEncounter);
+    baseEncounter.id = id;
+    summary.id = id;
+    return this.encounterSummaries.add(summary, id);
   }
 
   async clearDB(): Promise<void> {

--- a/ui/raidboss/raidemulator.js
+++ b/ui/raidboss/raidemulator.js
@@ -27,6 +27,7 @@ import defaultOptions from './raidboss_options';
 
 import '../../resources/defaults.css';
 import './raidemulator.css';
+import CombatantTracker from './emulator/data/CombatantTracker';
 
 
 function showModal(selector) {
@@ -270,9 +271,8 @@ document.addEventListener('DOMContentLoaded', async () => {
             End Status: ${enc.endStatus}
             Line Count: ${enc.logLines.length}
             `;
-            // Objects sent via message are raw objects, not typed.
-            // Need to get the name another way and override for Persistor.
-            enc.combatantTracker.getMainCombatantName = () => msg.data.name;
+            // Objects sent via message are raw objects, not typed. Apply prototype chain
+            Object.setPrototypeOf(enc.combatantTracker, CombatantTracker.prototype);
             if (promise) {
               promise.then(() => {
                 promise = persistor.persistEncounter(enc);


### PR DESCRIPTION
Fixes #3220

There were two bugs with the import process:
 
1. `combatantTracker` wasn't getting a prototype properly and the old logic of stubbing the getter for combatant name wasn't working with Dexie. Applied the correct prototype so that workaround isn't required anymore
2. Issue with potential desync between IDs in the two tables. Changed the persistor code to await the add for encounter and use that ID always for the add for summary