### PR TITLE
raidemulator: Move query and clone helper methods to EmulatorCommon to de-duplicate code

### DIFF
--- a/ui/raidboss/emulator/EmulatorCommon.ts
+++ b/ui/raidboss/emulator/EmulatorCommon.ts
@@ -1,5 +1,6 @@
 import { Lang } from '../../../resources/languages';
 import NetRegexes from '../../../resources/netregexes';
+import { UnreachableCode } from '../../../resources/not_reached';
 import { LocaleNetRegex } from '../../../resources/translations';
 import { CactbotBaseRegExp, CactbotRegExpExecArray, TriggerTypes } from '../../../types/net_trigger';
 
@@ -16,6 +17,41 @@ export type MatchStartInfo = {
 export type MatchEndInfo = {
   EndType: string;
   language?: string | undefined;
+};
+
+export const querySelectorSafe = (node: ParentNode, sel: string): HTMLElement => {
+  const ret = node.querySelector(sel);
+  if (!(ret instanceof HTMLElement))
+    throw new UnreachableCode();
+  return ret;
+};
+
+export const querySelectorAllSafe = (node: ParentNode, sel: string): HTMLElement[] => {
+  const ret = [...node.querySelectorAll(sel)].map((elem) => {
+    if (!(elem instanceof HTMLElement))
+      throw new UnreachableCode();
+    return elem;
+  });
+  return ret;
+};
+
+export const getTemplateChild = (node: ParentNode, sel: string): HTMLElement => {
+  const template = querySelectorSafe(node, sel);
+  if (!(template instanceof HTMLTemplateElement))
+    throw new UnreachableCode();
+  const ret = template.content.firstElementChild;
+  if (!ret)
+    throw new UnreachableCode();
+  if (!(ret instanceof HTMLElement))
+    throw new UnreachableCode();
+  return ret;
+};
+
+export const cloneSafe = (node: HTMLElement): HTMLElement => {
+  const cloned = node.cloneNode(true);
+  if (!(cloned instanceof HTMLElement))
+    throw new UnreachableCode();
+  return cloned;
 };
 
 export default class EmulatorCommon {

--- a/ui/raidboss/emulator/ui/EmulatedPartyInfo.ts
+++ b/ui/raidboss/emulator/ui/EmulatedPartyInfo.ts
@@ -2,7 +2,7 @@ import { UnreachableCode } from '../../../../resources/not_reached';
 import Util from '../../../../resources/util';
 import AnalyzedEncounter, { PerspectiveTrigger } from '../data/AnalyzedEncounter';
 import RaidEmulator from '../data/RaidEmulator';
-import EmulatorCommon from '../EmulatorCommon';
+import EmulatorCommon, { cloneSafe, getTemplateChild, querySelectorSafe } from '../EmulatorCommon';
 import EventBus from '../EventBus';
 
 import Tooltip from './Tooltip';
@@ -47,32 +47,6 @@ type CollapseParams = {
   icon?: string;
   text?: string;
   onclick?: CallableFunction;
-};
-
-const querySelectorSafe = (node: ParentNode, sel: string): HTMLElement => {
-  const ret = node.querySelector(sel);
-  if (!(ret instanceof HTMLElement))
-    throw new UnreachableCode();
-  return ret;
-};
-
-const getTemplateChild = (node: ParentNode, sel: string): HTMLElement => {
-  const template = querySelectorSafe(node, sel);
-  if (!(template instanceof HTMLTemplateElement))
-    throw new UnreachableCode();
-  const ret = template.content.firstElementChild;
-  if (!ret)
-    throw new UnreachableCode();
-  if (!(ret instanceof HTMLElement))
-    throw new UnreachableCode();
-  return ret;
-};
-
-const cloneSafe = (node: HTMLElement): HTMLElement => {
-  const cloned = node.cloneNode(true);
-  if (!(cloned instanceof HTMLElement))
-    throw new UnreachableCode();
-  return cloned;
 };
 
 export default class EmulatedPartyInfo extends EventBus {

--- a/ui/raidboss/emulator/ui/EncounterTab.ts
+++ b/ui/raidboss/emulator/ui/EncounterTab.ts
@@ -1,7 +1,7 @@
 import { UnreachableCode } from '../../../../resources/not_reached';
 import Persistor from '../data/Persistor';
 import PersistorEncounter from '../data/PersistorEncounter';
-import EmulatorCommon from '../EmulatorCommon';
+import EmulatorCommon, { getTemplateChild, querySelectorAllSafe, querySelectorSafe } from '../EmulatorCommon';
 import EventBus from '../EventBus';
 
 type DateMap = {
@@ -17,34 +17,6 @@ type ZoneMap = {
 
 type EncounterMap = {
   [zone: string]: ZoneMap;
-};
-
-const querySelectorSafe = (node: ParentNode, sel: string): HTMLElement => {
-  const ret = node.querySelector(sel);
-  if (!(ret instanceof HTMLElement))
-    throw new UnreachableCode();
-  return ret;
-};
-
-const querySelectorAllSafe = (node: ParentNode, sel: string): HTMLElement[] => {
-  const ret = [...node.querySelectorAll(sel)].map((elem) => {
-    if (!(elem instanceof HTMLElement))
-      throw new UnreachableCode();
-    return elem;
-  });
-  return ret;
-};
-
-const getTemplateChild = (node: ParentNode, sel: string): HTMLElement => {
-  const template = querySelectorSafe(node, sel);
-  if (!(template instanceof HTMLTemplateElement))
-    throw new UnreachableCode();
-  const ret = template.content.firstElementChild;
-  if (!ret)
-    throw new UnreachableCode();
-  if (!(ret instanceof HTMLElement))
-    throw new UnreachableCode();
-  return ret;
 };
 
 export default class EncounterTab extends EventBus {

--- a/ui/raidboss/emulator/ui/ProgressBar.ts
+++ b/ui/raidboss/emulator/ui/ProgressBar.ts
@@ -1,16 +1,9 @@
 import { UnreachableCode } from '../../../../resources/not_reached';
 import AnalyzedEncounter from '../data/AnalyzedEncounter';
 import RaidEmulator from '../data/RaidEmulator';
-import EmulatorCommon from '../EmulatorCommon';
+import EmulatorCommon, { querySelectorSafe } from '../EmulatorCommon';
 
 import Tooltip from './Tooltip';
-
-const querySelectorSafe = (node: ParentNode, sel: string): HTMLElement => {
-  const ret = node.querySelector(sel);
-  if (!(ret instanceof HTMLElement))
-    throw new UnreachableCode();
-  return ret;
-};
 
 export default class ProgressBar {
   $progressBarTooltip: Tooltip;


### PR DESCRIPTION
This PR is a cleanup PR after the last three typescript conversions were merged, to de-duplicate code.

After this PR lands, I'll be converting the main `raidemulator.js` file, then I'll just be waiting on #3173 for the last typescript conversion for raidemulator.