### PR TITLE
oopsy: replace damageRegex with netRegex

### DIFF
--- a/ui/oopsyraidsy/data/00-misc/test.js
+++ b/ui/oopsyraidsy/data/00-misc/test.js
@@ -51,23 +51,24 @@ export default {
     },
     {
       id: 'Test Bootshine',
-      damageRegex: '35',
-      condition: (e, data) => {
-        if (e.attackerName !== data.me)
+      netRegex: NetRegexes.abilityFull({ id: '35' }),
+      condition: (_e, data, matches) => {
+        if (matches.source !== data.me)
           return false;
-        const strikingDummyNames = [
-          'Striking Dummy',
-          'Mannequin d\'entraînement',
-          '木人', // Striking Dummy called `木人` in CN as well as JA
-          '나무인형',
-          // FIXME: add other languages here
-        ];
-        return strikingDummyNames.includes(e.targetName);
+        const strikingDummyByLocale = {
+          en: 'Striking Dummy',
+          fr: 'Mannequin d\'entraînement',
+          ja: '木人',
+          cn: '木人',
+          ko: '나무인형',
+        };
+        const strikingDummyNames = Object.values(strikingDummyByLocale);
+        return strikingDummyNames.includes(matches.target);
       },
-      mistake: (e, data) => {
+      mistake: (_e, data, matches) => {
         data.bootCount = data.bootCount || 0;
         data.bootCount++;
-        const text = e.abilityName + ' (' + data.bootCount + '): ' + e.damageStr;
+        const text = `${matches.ability} (${data.bootCount}): ${data.DamageFromMatches(matches)}`;
         return { type: 'warn', blame: data.me, text: text };
       },
     },

--- a/ui/oopsyraidsy/data/03-hw/dungeon/aetherochemical_research_facility.js
+++ b/ui/oopsyraidsy/data/03-hw/dungeon/aetherochemical_research_facility.js
@@ -41,8 +41,8 @@ export default {
     {
       id: 'ARF Petrifaction',
       netRegex: NetRegexes.gainsEffect({ effectId: '01' }),
-      mistake: (e) => {
-        return { type: 'warn', blame: e.target, text: e.effect };
+      mistake: (_e, _data, matches) => {
+        return { type: 'warn', blame: matches.target, text: matches.effect };
       },
     },
   ],

--- a/ui/oopsyraidsy/data/03-hw/dungeon/gubal_library_hard.js
+++ b/ui/oopsyraidsy/data/03-hw/dungeon/gubal_library_hard.js
@@ -1,6 +1,8 @@
 import NetRegexes from '../../../../../resources/netregexes';
 import ZoneId from '../../../../../resources/zone_id';
 
+import { playerDamageFields } from '../../../oopsy_common';
+
 export default {
   zoneId: ZoneId.TheGreatGubalLibraryHard,
   damageWarn: {
@@ -40,8 +42,8 @@ export default {
       // Fire gate in hallway to boss 2, magnet failure on boss 2
       id: 'GubalHm Burns',
       netRegex: NetRegexes.gainsEffect({ effectId: '10B' }),
-      mistake: (e) => {
-        return { type: 'warn', blame: e.target, text: e.effect };
+      mistake: (_e, _data, matches) => {
+        return { type: 'warn', blame: matches.target, text: matches.effect };
       },
     },
     {
@@ -64,12 +66,12 @@ export default {
     {
       // Targets with Imp when Thunder III resolves receive a vulnerability stack and brief stun
       id: 'GubalHm Imp Thunder',
-      damageRegex: '195[AB]',
-      condition: (e, data) => data.hasImp[e.targetName],
-      mistake: (e) => {
+      netRegex: NetRegexes.abilityFull({ id: '195[AB]', ...playerDamageFields }),
+      condition: (_e, data, matches) => data.hasImp[matches.target],
+      mistake: (_e, _data, matches) => {
         return {
           type: 'warn',
-          blame: e.targetName,
+          blame: matches.target,
           text: {
             en: 'Shocked Imp',
             de: 'Schockierter Imp',
@@ -81,24 +83,20 @@ export default {
     },
     {
       id: 'GubalHm Quake',
-      damageRegex: '1956',
-      condition: (e) => {
-        // Always hits target, but if correctly resolved will deal 0 damage
-        return e.damage > 0;
-      },
-      mistake: (e) => {
-        return { type: 'warn', blame: e.targetName, text: e.abilityName };
+      netRegex: NetRegexes.abilityFull({ id: '1956', ...playerDamageFields }),
+      // Always hits target, but if correctly resolved will deal 0 damage
+      condition: (_e, data, matches) => data.DamageFromMatches(matches) > 0,
+      mistake: (_e, _data, matches) => {
+        return { type: 'warn', blame: matches.target, text: matches.ability };
       },
     },
     {
       id: 'GubalHm Tornado',
-      damageRegex: '195[78]',
-      condition: (e) => {
-        // Always hits target, but if correctly resolved will deal 0 damage
-        return e.damage > 0;
-      },
-      mistake: (e) => {
-        return { type: 'warn', blame: e.targetName, text: e.abilityName };
+      netRegex: NetRegexes.abilityFull({ id: '195[78]', ...playerDamageFields }),
+      // Always hits target, but if correctly resolved will deal 0 damage
+      condition: (_e, data, matches) => data.DamageFromMatches(matches) > 0,
+      mistake: (_e, _data, matches) => {
+        return { type: 'warn', blame: matches.target, text: matches.ability };
       },
     },
   ],

--- a/ui/oopsyraidsy/data/03-hw/raid/a12n.js
+++ b/ui/oopsyraidsy/data/03-hw/raid/a12n.js
@@ -1,6 +1,8 @@
 import NetRegexes from '../../../../../resources/netregexes';
 import ZoneId from '../../../../../resources/zone_id';
 
+import { playerDamageFields } from '../../../oopsy_common';
+
 export default {
   zoneId: ZoneId.AlexanderTheSoulOfTheCreator,
   damageWarn: {
@@ -25,7 +27,7 @@ export default {
     {
       // It is a failure for a Severity marker to stack with the Solidarity group.
       id: 'A12N Assault Failure',
-      damageRegex: '1AF2',
+      netRegex: NetRegexes.abilityFull({ id: '1AF2', ...playerDamageFields }),
       condition: (_e, data, matches) => data.assault.includes(matches.target),
       mistake: (_e, _data, matches) => {
         return {

--- a/ui/oopsyraidsy/data/04-sb/dungeon/ala_mhigo.js
+++ b/ui/oopsyraidsy/data/04-sb/dungeon/ala_mhigo.js
@@ -35,8 +35,8 @@ export default {
       id: 'Ala Mhigo Art Of The Swell',
       // Damage Down
       netRegex: NetRegexes.gainsEffect({ effectId: '2B8' }),
-      mistake: (e) => {
-        return { type: 'warn', blame: e.target, text: e.effect };
+      mistake: (_e, _data, matches) => {
+        return { type: 'warn', blame: matches.target, text: matches.effect };
       },
     },
   ],

--- a/ui/oopsyraidsy/data/04-sb/raid/o12s.js
+++ b/ui/oopsyraidsy/data/04-sb/raid/o12s.js
@@ -1,6 +1,8 @@
 import NetRegexes from '../../../../../resources/netregexes';
 import ZoneId from '../../../../../resources/zone_id';
 
+import { playerDamageFields } from '../../../oopsy_common';
+
 // TODO: could add Patch warnings for double/unbroken tethers
 // TODO: Hello World could have any warnings (sorry)
 
@@ -77,7 +79,7 @@ export default {
       // 332E = Pile Pitch stack
       // 333E = Electric Slide (Omega-M square 1-4 dashes)
       // 333F = Electric Slide (Omega-F triangle 1-4 dashes)
-      damageRegex: ['332E', '333E', '333F'],
+      netRegex: NetRegexes.abilityFull({ id: ['332E', '333E', '333F'], ...playerDamageFields }),
       condition: (_e, data, matches) => data.vuln && data.vuln[matches.target],
       mistake: (_e, _data, matches) => {
         return {

--- a/ui/oopsyraidsy/data/04-sb/raid/o2n.js
+++ b/ui/oopsyraidsy/data/04-sb/raid/o2n.js
@@ -1,6 +1,8 @@
 import NetRegexes from '../../../../../resources/netregexes';
 import ZoneId from '../../../../../resources/zone_id';
 
+import { playerDamageFields } from '../../../oopsy_common';
+
 // O2N - Deltascape 2.0 Normal
 export default {
   zoneId: ZoneId.DeltascapeV20,
@@ -20,19 +22,17 @@ export default {
       // The user might get hit by another petrifying ability before the effect ends.
       // There's no point in notifying for that.
       suppressSeconds: 10,
-      mistake: (e) => {
-        return { type: 'warn', blame: e.target, text: e.effect };
+      mistake: (_e, _data, matches) => {
+        return { type: 'warn', blame: matches.target, text: matches.effect };
       },
     },
     {
       id: 'O2N Earthquake',
-      damageRegex: '2515',
-      condition: (e) => {
-        // This deals damage only to non-floating targets.
-        return e.damage > 0;
-      },
-      mistake: (e) => {
-        return { type: 'warn', name: e.targetName, text: e.abilityName };
+      netRegex: NetRegexes.abilityFull({ id: '2515', ...playerDamageFields }),
+      // This deals damage only to non-floating targets.
+      condition: (_e, data, matches) => data.DamageFromMatches(matches) > 0,
+      mistake: (_e, _data, matches) => {
+        return { type: 'warn', blame: matches.target, text: matches.ability };
       },
     },
   ],

--- a/ui/oopsyraidsy/data/04-sb/raid/o3n.js
+++ b/ui/oopsyraidsy/data/04-sb/raid/o3n.js
@@ -71,10 +71,8 @@ export default {
       id: 'O3N The Game',
       // Guess what you just lost?
       netRegex: NetRegexes.ability({ id: '246D' }),
-      condition: (_e, data, matches) => {
-        // If the player takes no damage, they did the mechanic correctly.
-        return data.DamageFromMatches(matches) > 0;
-      },
+      // If the player takes no damage, they did the mechanic correctly.
+      condition: (_e, data, matches) => data.DamageFromMatches(matches) > 0,
       mistake: (_e, _data, matches) => {
         return { type: 'warn', blame: matches.target, text: matches.ability };
       },

--- a/ui/oopsyraidsy/data/04-sb/raid/o4n.js
+++ b/ui/oopsyraidsy/data/04-sb/raid/o4n.js
@@ -1,5 +1,6 @@
 import NetRegexes from '../../../../../resources/netregexes';
 import ZoneId from '../../../../../resources/zone_id';
+import { playerDamageFields } from '../../../oopsy_common';
 
 // O4N - Deltascape 4.0 Normal
 export default {
@@ -24,10 +25,10 @@ export default {
     {
       id: 'O4N Doom', // Kills target if not cleansed
       netRegex: NetRegexes.gainsEffect({ effectId: '38E' }),
-      deathReason: (e) => {
+      deathReason: (_e, _data, matches) => {
         return {
           type: 'fail',
-          name: e.target,
+          name: matches.target,
           reason: {
             en: 'Cleansers missed Doom!',
             de: 'Doom-Reinigung vergessen!',
@@ -39,12 +40,13 @@ export default {
       },
     },
     {
-      id: 'O4N Vacuum Wave', // Short knockback from Exdeath
-      damageRegex: '24B8',
-      deathReason: (e) => {
+      // Short knockback from Exdeath
+      id: 'O4N Vacuum Wave',
+      netRegex: NetRegexes.abilityFull({ id: '24B8', ...playerDamageFields }),
+      deathReason: (_e, _data, matches) => {
         return {
           type: 'fail',
-          name: e.targetName,
+          name: matches.target,
           reason: {
             en: 'Pushed off!',
             de: 'Runter geschubst!',
@@ -58,8 +60,8 @@ export default {
     {
       id: 'O4N Empowered Blizzard', // Room-wide AoE, freezes non-moving targets
       netRegex: NetRegexes.gainsEffect({ effectId: '4E6' }),
-      mistake: (e) => {
-        return { type: 'warn', blame: e.target, text: e.effect };
+      mistake: (_e, _data, matches) => {
+        return { type: 'warn', blame: matches.target, text: matches.effect };
       },
     },
   ],

--- a/ui/oopsyraidsy/data/04-sb/raid/o4s.js
+++ b/ui/oopsyraidsy/data/04-sb/raid/o4s.js
@@ -1,6 +1,8 @@
 import NetRegexes from '../../../../../resources/netregexes';
 import ZoneId from '../../../../../resources/zone_id';
 
+import { playerDamageFields } from '../../../oopsy_common';
+
 // O4S - Deltascape 4.0 Savage
 export default {
   zoneId: ZoneId.DeltascapeV40Savage,
@@ -36,24 +38,20 @@ export default {
     },
     {
       id: 'O4S2 Blizzard III',
-      damageRegex: '23F8',
-      condition: (e, data) => {
-        // Ignore unavoidable raid aoe Blizzard III.
-        return data.IsPlayerId(e.targetId) && !data.isDecisiveBattleElement;
-      },
-      mistake: (e) => {
-        return { type: 'warn', blame: e.targetName, text: e.abilityName };
+      netRegex: NetRegexes.abilityFull({ id: '23F8', ...playerDamageFields }),
+      // Ignore unavoidable raid aoe Blizzard III.
+      condition: (_e, data) => !data.isDecisiveBattleElement,
+      mistake: (_e, _data, matches) => {
+        return { type: 'warn', blame: matches.target, text: matches.abilityName };
       },
     },
     {
       id: 'O4S2 Thunder III',
-      damageRegex: '23FD',
-      condition: (e, data) => {
-        // Only consider this during random mechanic after decisive battle.
-        return data.IsPlayerId(e.targetId) && data.isDecisiveBattleElement;
-      },
-      mistake: (e) => {
-        return { type: 'warn', blame: e.targetName, text: e.abilityName };
+      netRegex: NetRegexes.abilityFull({ id: '23FD', ...playerDamageFields }),
+      // Only consider this during random mechanic after decisive battle.
+      condition: (_e, data) => data.isDecisiveBattleElement,
+      mistake: (_e, _data, matches) => {
+        return { type: 'warn', blame: matches.target, text: matches.abilityName };
       },
     },
     {
@@ -69,17 +67,14 @@ export default {
     },
     {
       id: 'O4S2 Forked Lightning',
-      damageRegex: '242E',
-      condition: (e, data) => data.IsPlayerId(e.targetId),
-      mistake: (e, data) => {
-        const text = e.abilityName + ' => ' + data.ShortName(e.targetName);
-        return { type: 'fail', blame: e.attackerName, text: text };
+      netRegex: NetRegexes.abilityFull({ id: '242E', ...playerDamageFields }),
+      mistake: (_e, _data, matches) => {
+        return { type: 'fail', blame: matches.target, text: matches.ability };
       },
     },
     {
       id: 'O4S2 Double Attack',
-      damageRegex: '241C',
-      condition: (e, data) => data.IsPlayerId(e.targetId),
+      netRegex: NetRegexes.abilityFull({ id: '241C', ...playerDamageFields }),
       collectSeconds: 0.5,
       mistake: (e) => {
         if (e.length <= 2)

--- a/ui/oopsyraidsy/data/04-sb/trial/byakko-ex.js
+++ b/ui/oopsyraidsy/data/04-sb/trial/byakko-ex.js
@@ -1,4 +1,7 @@
+import NetRegexes from '../../../../../resources/netregexes';
 import ZoneId from '../../../../../resources/zone_id';
+
+import { playerDamageFields } from '../../../oopsy_common';
 
 // Byakko Extreme
 export default {
@@ -23,12 +26,11 @@ export default {
     {
       // Pink bubble collision
       id: 'ByaEx Ominous Wind',
-      damageRegex: '27EC',
-      condition: (e, data) => data.IsPlayerId(e.targetId),
-      mistake: (e) => {
+      netRegex: NetRegexes.abilityFull({ id: '27EC', ...playerDamageFields }),
+      mistake: (_e, _data, matches) => {
         return {
           type: 'warn',
-          blame: e.targetName,
+          blame: matches.target,
           text: {
             en: 'bubble collision',
             de: 'Blasen sind zusammengestoßen',

--- a/ui/oopsyraidsy/data/04-sb/trial/shinryu.js
+++ b/ui/oopsyraidsy/data/04-sb/trial/shinryu.js
@@ -68,7 +68,7 @@ export default {
           reason: {
             en: 'Pushed off!',
             de: 'Runter geschubst!',
-            fr: 'A été poussé(e) !',
+            fr: 'A été pousser !',
             ja: '落ちた',
             cn: '击退坠落',
           },

--- a/ui/oopsyraidsy/data/04-sb/trial/shinryu.js
+++ b/ui/oopsyraidsy/data/04-sb/trial/shinryu.js
@@ -1,6 +1,8 @@
 import NetRegexes from '../../../../../resources/netregexes';
 import ZoneId from '../../../../../resources/zone_id';
 
+import { playerDamageFields } from '../../../oopsy_common';
+
 // Shinryu Normal
 
 export default {
@@ -40,11 +42,11 @@ export default {
     },
     {
       id: 'Shinryu Tidal Wave',
-      damageRegex: '1F8B',
-      deathReason: (e) => {
+      netRegex: NetRegexes.abilityFull({ id: '1F8B', ...playerDamageFields }),
+      deathReason: (_e, _data, matches) => {
         return {
           type: 'fail',
-          name: e.targetName,
+          name: matches.target,
           reason: {
             en: 'Pushed off!',
             de: 'Runter geschubst!',
@@ -58,15 +60,15 @@ export default {
     {
       // Knockback from center.
       id: 'Shinryu Aerial Blast',
-      damageRegex: '1F90',
-      deathReason: (e) => {
+      netRegex: NetRegexes.abilityFull({ id: '1F90', ...playerDamageFields }),
+      deathReason: (_e, _data, matches) => {
         return {
           type: 'fail',
-          name: e.targetName,
+          name: matches.target,
           reason: {
             en: 'Pushed off!',
             de: 'Runter geschubst!',
-            fr: 'A été pousser !',
+            fr: 'A été poussé(e) !',
             ja: '落ちた',
             cn: '击退坠落',
           },

--- a/ui/oopsyraidsy/data/04-sb/ultimate/ultima_weapon_ultimate.js
+++ b/ui/oopsyraidsy/data/04-sb/ultimate/ultima_weapon_ultimate.js
@@ -1,6 +1,8 @@
 import NetRegexes from '../../../../../resources/netregexes';
 import ZoneId from '../../../../../resources/zone_id';
 
+import { playerDamageFields } from '../../../oopsy_common';
+
 // Ultima Weapon Ultimate
 export default {
   zoneId: ZoneId.TheWeaponsRefrainUltimate,
@@ -22,19 +24,19 @@ export default {
       id: 'UWU Windburn',
       netRegex: NetRegexes.gainsEffect({ effectId: 'EB' }),
       suppressSeconds: 2,
-      mistake: (e) => {
-        return { type: 'warn', blame: e.target, text: e.effect };
+      mistake: (_e, _data, matches) => {
+        return { type: 'warn', blame: matches.target, text: matches.effect };
       },
     },
     {
       // Featherlance explosion.  It seems like the person who pops it is the
       // first person listed damage-wise, so they are likely the culprit.
       id: 'UWU Featherlance',
-      damageRegex: '2B43',
+      netRegex: NetRegexes.abilityFull({ id: '2B43', ...playerDamageFields }),
       collectSeconds: 0.5,
       suppressSeconds: 5,
-      mistake: (e) => {
-        return { type: 'fail', blame: e[0].targetName, text: e[0].attackerName };
+      mistake: (_e, _data, matches) => {
+        return { type: 'fail', blame: matches[0].target, text: matches[0].source };
       },
     },
   ],

--- a/ui/oopsyraidsy/data/05-shb/dungeon/heroes_gauntlet.js
+++ b/ui/oopsyraidsy/data/05-shb/dungeon/heroes_gauntlet.js
@@ -1,4 +1,7 @@
+import NetRegexes from '../../../../../resources/netregexes';
 import ZoneId from '../../../../../resources/zone_id';
+
+import { playerDamageFields } from '../../../oopsy_common';
 
 // TODO: Berserker 2nd/3rd wild anguish should be shared with just a rock
 
@@ -52,9 +55,9 @@ export default {
   triggers: [
     {
       id: 'THG Wild Rampage',
-      damageRegex: '5207',
+      netRegex: NetRegexes.abilityFull({ id: '5207', ...playerDamageFields }),
       // This is zero damage if you are in the crater.
-      condition: (e) => e.damage > 0,
+      condition: (_e, data, matches) => data.DamageFromMatches(matches) > 0,
       mistake: (_e, _data, matches) => {
         return { type: 'fail', blame: matches.target, text: matches.ability };
       },

--- a/ui/oopsyraidsy/data/05-shb/eureka/delubrum_reginae.js
+++ b/ui/oopsyraidsy/data/05-shb/eureka/delubrum_reginae.js
@@ -1,4 +1,7 @@
+import NetRegexes from '../../../../../resources/netregexes';
 import ZoneId from '../../../../../resources/zone_id';
+
+import { playerDamageFields } from '../../../oopsy_common';
 
 // TODO: Dead Iron 5AB0 (earthshakers, but only if you take two?)
 
@@ -76,8 +79,8 @@ export default {
       // At least during The Queen, these ability ids can be ordered differently,
       // and the first explosion "hits" everyone, although with "1B" flags.
       id: 'Delubrum Lots Cast',
-      damageRegex: ['565A', '565B', '57FD', '57FE', '5B86', '5B87', '59D2', '5D93'],
-      condition: (e) => e.flags.slice(-2) === '03',
+      netRegex: NetRegexes.abilityFull({ id: ['565A', '565B', '57FD', '57FE', '5B86', '5B87', '59D2', '5D93'], ...playerDamageFields }),
+      condition: (_e, _data, matches) => matches.flags.slice(-2) === '03',
       mistake: (_e, _data, matches) => {
         return { type: 'warn', blame: matches.target, text: matches.ability };
       },

--- a/ui/oopsyraidsy/data/05-shb/eureka/delubrum_reginae_savage.js
+++ b/ui/oopsyraidsy/data/05-shb/eureka/delubrum_reginae_savage.js
@@ -1,6 +1,8 @@
 import NetRegexes from '../../../../../resources/netregexes';
 import ZoneId from '../../../../../resources/zone_id';
 
+import { playerDamageFields } from '../../../oopsy_common';
+
 // TODO: Dahu 5776 Spit Flame should always hit a Marchosias
 // TODO: hitting phantom with ice spikes with anything but dispel?
 // TODO: failing icy/fiery portent (guard and queen)
@@ -132,8 +134,8 @@ export default {
     {
       // These ability ids can be ordered differently and "hit" people when levitating.
       id: 'DelubrumSav Guard Lots Cast',
-      damageRegex: ['5827', '5828', '5B6C', '5B6D', '5BB6', '5BB7', '5B88', '5B89'],
-      condition: (e) => e.flags.slice(-2) === '03',
+      netRegex: NetRegexes.abilityFull({ id: ['5827', '5828', '5B6C', '5B6D', '5BB6', '5BB7', '5B88', '5B89'], ...playerDamageFields }),
+      condition: (_e, _data, matches) => matches.flags.slice(-2) === '03',
       mistake: (_e, _data, matches) => {
         return { type: 'warn', blame: matches.target, text: matches.ability };
       },

--- a/ui/oopsyraidsy/data/05-shb/raid/e10s.js
+++ b/ui/oopsyraidsy/data/05-shb/raid/e10s.js
@@ -1,6 +1,8 @@
 import NetRegexes from '../../../../../resources/netregexes';
 import ZoneId from '../../../../../resources/zone_id';
 
+import { playerDamageFields } from '../../../oopsy_common';
+
 // TODO: hitting shadow of the hero with abilities can cause you to take damage, list those?
 //       e.g. picking up your first pitch bog puddle will cause you to die to the damage
 //       your shadow takes from Deepshadow Nova or Distant Scream.
@@ -64,8 +66,8 @@ export default {
       // Shadow Warrior 4 dog room cleave
       // This can be mitigated by the whole group, so add a damage condition.
       id: 'E10S Barbs Of Agony',
-      damageRegex: ['572A', '5B27'],
-      condition: (e) => e.damage > 0,
+      netRegex: NetRegexes.abilityFull({ id: ['572A', '5B27'], ...playerDamageFields }),
+      condition: (_e, data, matches) => data.DamageFromMatches(matches) > 0,
       mistake: (_e, _data, matches) => {
         return { type: 'warn', blame: matches.target, text: matches.ability };
       },

--- a/ui/oopsyraidsy/data/05-shb/raid/e12s.js
+++ b/ui/oopsyraidsy/data/05-shb/raid/e12s.js
@@ -2,6 +2,8 @@ import NetRegexes from '../../../../../resources/netregexes';
 import Outputs from '../../../../../resources/outputs';
 import ZoneId from '../../../../../resources/zone_id';
 
+import { playerDamageFields } from '../../../oopsy_common';
+
 // TODO: add separate damageWarn-esque icon for damage downs?
 // TODO: 58A6 Under The Weight / 58B2 Classical Sculpture missing somebody in party warning?
 // TODO: 58CA Dark Water III / 58C5 Shell Crusher should hit everyone in party
@@ -67,8 +69,8 @@ export default {
       // Big circle ground aoes during Shiva junction.
       // This can be shielded through as long as that person doesn't stack.
       id: 'E12S Icicle Impact',
-      damageRegex: '4E5A',
-      condition: (e) => e.damage > 0,
+      netRegex: NetRegexes.abilityFull({ id: '4E5A', ...playerDamageFields }),
+      condition: (_e, data, matches) => data.DamageFromMatches(matches) > 0,
       mistake: (_e, _data, matches) => {
         return { type: 'warn', blame: matches.target, text: matches.ability };
       },
@@ -416,8 +418,8 @@ export default {
     },
     {
       id: 'E12S Oracle Shadoweye',
-      damageRegex: '58D2',
-      condition: (e) => e.damage > 0,
+      netRegex: NetRegexes.abilityFull({ id: '58D2', ...playerDamageFields }),
+      condition: (_e, data, matches) => data.DamageFromMatches(matches) > 0,
       mistake: (_e, _data, matches) => {
         return { type: 'fail', blame: matches.target, text: matches.ability };
       },

--- a/ui/oopsyraidsy/data/05-shb/raid/e2n.js
+++ b/ui/oopsyraidsy/data/05-shb/raid/e2n.js
@@ -1,4 +1,7 @@
+import NetRegexes from '../../../../../resources/netregexes';
 import ZoneId from '../../../../../resources/zone_id';
+
+import { playerDamageFields } from '../../../oopsy_common';
 
 // TODO: shadoweye failure (top line fail, bottom line success, effect there too)
 // [16:17:35.966] 16:400110FE:Voidwalker:40B7:Shadoweye:10612345:Tini Poutini:F:10000:100190F:
@@ -14,17 +17,17 @@ export default {
   triggers: [
     {
       id: 'E2N Nyx',
-      damageRegex: '3E3D',
-      mistake: (e) => {
+      netRegex: NetRegexes.abilityFull({ id: '3E3D', ...playerDamageFields }),
+      mistake: (_e, _data, matches) => {
         return {
           type: 'warn',
-          blame: e.targetName,
+          blame: matches.target,
           text: {
             en: 'Booped',
-            de: e.abilityName,
+            de: matches.ability, // FIXME
             fr: 'Malus de dégâts',
-            ja: e.abilityName,
-            cn: e.abilityName,
+            ja: matches.ability, // FIXME
+            cn: matches.ability, // FIXME
             ko: '닉스',
           },
         };

--- a/ui/oopsyraidsy/data/05-shb/raid/e2s.js
+++ b/ui/oopsyraidsy/data/05-shb/raid/e2s.js
@@ -1,6 +1,8 @@
 import NetRegexes from '../../../../../resources/netregexes';
 import ZoneId from '../../../../../resources/zone_id';
 
+import { playerDamageFields } from '../../../oopsy_common';
+
 // TODO: shadoweye failure
 // TODO: Empty Hate (3E59/3E5A) hits everybody, so hard to tell about knockback
 // TODO: maybe mark hell wind people who got clipped by stack?
@@ -27,17 +29,17 @@ export default {
     },
     {
       id: 'E2S Nyx',
-      damageRegex: '3E51',
-      mistake: (e) => {
+      netRegex: NetRegexes.abilityFull({ id: '3E51', ...playerDamageFields }),
+      mistake: (_e, _data, matches) => {
         return {
           type: 'warn',
-          blame: e.targetName,
+          blame: matches.target,
           text: {
             en: 'Booped',
-            de: e.abilityName,
+            de: matches.ability, // FIXME
             fr: 'Malus de dégâts',
-            ja: e.abilityName,
-            cn: '攻击伤害降低',
+            ja: matches.ability, // FIXME
+            cn: matches.ability, // FIXME
             ko: '닉스',
           },
         };

--- a/ui/oopsyraidsy/data/05-shb/raid/e4s.js
+++ b/ui/oopsyraidsy/data/05-shb/raid/e4s.js
@@ -1,6 +1,8 @@
 import NetRegexes from '../../../../../resources/netregexes';
 import ZoneId from '../../../../../resources/zone_id';
 
+import { playerDamageFields } from '../../../oopsy_common';
+
 // TODO: could track people get hitting by markers they shouldn't
 // TODO: could track non-tanks getting hit by tankbusters, megaliths
 // TODO: could track non-target getting hit by tankbuster
@@ -41,19 +43,19 @@ export default {
     },
     {
       id: 'E4S Fault Line',
-      damageRegex: '411E',
-      condition: (e, data) => data.faultLineTarget !== e.targetName,
-      mistake: (e) => {
+      netRegex: NetRegexes.abilityFull({ id: '411E', ...playerDamageFields }),
+      condition: (_e, data, matches) => data.faultLineTarget !== matches.target,
+      mistake: (_e, _data, matches) => {
         return {
           type: 'fail',
-          blame: e.targetName,
+          blame: matches.target,
           text: {
             en: 'Run Over',
-            de: e.abilityName,
+            de: matches.ability, // FIXME
             fr: 'A été écrasé(e)',
-            ja: e.abilityName,
-            cn: e.abilityName,
-            ko: e.abilityName,
+            ja: matches.ability, // FIXME
+            cn: matches.ability, // FIXME
+            ko: matches.ability, // FIXME
           },
         };
       },

--- a/ui/oopsyraidsy/data/05-shb/raid/e5n.js
+++ b/ui/oopsyraidsy/data/05-shb/raid/e5n.js
@@ -1,6 +1,8 @@
 import NetRegexes from '../../../../../resources/netregexes';
 import ZoneId from '../../../../../resources/zone_id';
 
+import { playerDamageFields } from '../../../oopsy_common';
+
 export default {
   zoneId: ZoneId.EdensVerseFulmination,
   damageWarn: {
@@ -41,18 +43,18 @@ export default {
     },
     {
       id: 'E5N Divine Judgement Volts',
-      damageRegex: '4B9A',
-      condition: (e, data) => !data.hasOrb[e.targetName],
-      mistake: (e) => {
+      netRegex: NetRegexes.abilityFull({ id: '4B9A', ...playerDamageFields }),
+      condition: (_e, data, matches) => !data.hasOrb[matches.target],
+      mistake: (_e, _data, matches) => {
         return {
           type: 'fail',
-          blame: e.targetName,
+          blame: matches.target,
           text: {
-            en: e.abilityName + ' (no orb)',
-            de: e.abilityName + ' (kein Orb)',
-            fr: e.abilityName + '(pas d\'orbe)',
-            ja: e.abilityName + '(雷玉無し)',
-            cn: e.abilityName + '(没吃球)',
+            en: `${matches.ability} (no orb)`,
+            de: `${matches.ability} (kein Orb)`,
+            fr: `${matches.ability} (pas d'orbe)`,
+            ja: `${matches.ability} (雷玉無し)`,
+            cn: `${matches.ability} (没吃球)`,
           },
         };
       },
@@ -68,19 +70,19 @@ export default {
     {
       // This ability is seen only if players stacked the clouds instead of spreading them.
       id: 'E5N The Parting Clouds',
-      damageRegex: '4B9D',
+      netRegex: NetRegexes.abilityFull({ id: '4B9D', ...playerDamageFields }),
       suppressSeconds: 30,
-      mistake: (e, data) => {
+      mistake: (_e, data, matches) => {
         for (const m of data.cloudMarkers) {
           return {
             type: 'fail',
             blame: data.cloudMarkers[m],
             text: {
-              en: e.abilityName + '(clouds too close)',
-              de: e.abilityName + '(Wolken zu nahe)',
-              fr: e.abilityName + '(nuages trop proches)',
-              ja: e.abilityName + '(雲近すぎ)',
-              cn: e.abilityName + '(雷云重叠)',
+              en: `${matches.ability} (clouds too close)`,
+              de: `${matches.ability} (Wolken zu nahe)`,
+              fr: `${matches.ability} (nuages trop proches)`,
+              ja: `${matches.ability} (雲近すぎ)`,
+              cn: `${matches.ability} (雷云重叠)`,
             },
           };
         }

--- a/ui/oopsyraidsy/data/05-shb/raid/e5s.js
+++ b/ui/oopsyraidsy/data/05-shb/raid/e5s.js
@@ -1,6 +1,8 @@
 import NetRegexes from '../../../../../resources/netregexes';
 import ZoneId from '../../../../../resources/zone_id';
 
+import { playerDamageFields } from '../../../oopsy_common';
+
 // TODO: is there a different ability if the shield duty action isn't used properly?
 // TODO: is there an ability from Raiden (the bird) if you get eaten?
 // TODO: maybe chain lightning warning if you get hit while you have system shock (8B8)
@@ -54,42 +56,42 @@ export default {
     },
     {
       id: 'E5S Divine Judgement Volts',
-      damageRegex: '4BB7',
-      condition: (e, data) => !data.hasOrb || !data.hasOrb[e.targetName],
-      mistake: (e) => {
-        return { type: 'fail', blame: e.targetName, text: noOrb(e.abilityName) };
+      netRegex: NetRegexes.abilityFull({ id: '4BB7', ...playerDamageFields }),
+      condition: (_e, data, matches) => !data.hasOrb || !data.hasOrb[matches.target],
+      mistake: (_e, _data, matches) => {
+        return { type: 'fail', blame: matches.target, text: noOrb(matches.ability) };
       },
     },
     {
       id: 'E5S Volt Strike Orb',
-      damageRegex: '4BC3',
-      condition: (e, data) => !data.hasOrb || !data.hasOrb[e.targetName],
-      mistake: (e) => {
-        return { type: 'fail', blame: e.targetName, text: noOrb(e.abilityName) };
+      netRegex: NetRegexes.abilityFull({ id: '4BC3', ...playerDamageFields }),
+      condition: (_e, data, matches) => !data.hasOrb || !data.hasOrb[matches.target],
+      mistake: (_e, _data, matches) => {
+        return { type: 'fail', blame: matches.target, text: noOrb(matches.ability) };
       },
     },
     {
       id: 'E5S Deadly Discharge Big Knockback',
-      damageRegex: '4BB2',
-      condition: (e, data) => !data.hasOrb || !data.hasOrb[e.targetName],
-      mistake: (e) => {
-        return { type: 'fail', blame: e.targetName, text: noOrb(e.abilityName) };
+      netRegex: NetRegexes.abilityFull({ id: '4BB2', ...playerDamageFields }),
+      condition: (_e, data, matches) => !data.hasOrb || !data.hasOrb[matches.target],
+      mistake: (_e, _data, matches) => {
+        return { type: 'fail', blame: matches.target, text: noOrb(matches.ability) };
       },
     },
     {
       id: 'E5S Lightning Bolt',
-      damageRegex: '4BB9',
-      condition: (e, data) => {
+      netRegex: NetRegexes.abilityFull({ id: '4BB9', ...playerDamageFields }),
+      condition: (_e, data, matches) => {
         // Having a non-idempotent condition function is a bit <_<
         // Only consider lightning bolt damage if you have a debuff to clear.
-        if (!data.hated || !data.hated[e.targetName])
+        if (!data.hated || !data.hated[matches.target])
           return true;
 
-        delete data.hated[e.targetName];
+        delete data.hated[matches.target];
         return false;
       },
-      mistake: (e) => {
-        return { type: 'warn', blame: e.targetName, text: e.abilityName };
+      mistake: (_e, _data, matches) => {
+        return { type: 'warn', blame: matches.target, text: matches.ability };
       },
     },
     {
@@ -111,19 +113,19 @@ export default {
     {
       // This ability is seen only if players stacked the clouds instead of spreading them.
       id: 'E5S The Parting Clouds',
-      damageRegex: '4BBA',
+      netRegex: NetRegexes.abilityFull({ id: '4BBA', ...playerDamageFields }),
       suppressSeconds: 30,
-      mistake: (e, data) => {
+      mistake: (_e, data, matches) => {
         for (const m of data.cloudMarkers) {
           return {
             type: 'fail',
             blame: data.cloudMarkers[m],
             text: {
-              en: e.abilityName + '(clouds too close)',
-              de: e.abilityName + '(Wolken zu nahe)',
-              fr: e.abilityName + '(nuages trop proches)',
-              ja: e.abilityName + '(雲近すぎ)',
-              cn: e.abilityName + '(雷云重叠)',
+              en: `${matches.ability} (clouds too close)`,
+              de: `${matches.ability} (Wolken zu nahe)`,
+              fr: `${matches.ability} (nuages trop proches)`,
+              ja: `${matches.ability} (雲近すぎ)`,
+              cn: `${matches.ability} (雷云重叠)`,
             },
           };
         }

--- a/ui/oopsyraidsy/data/05-shb/raid/e7n.js
+++ b/ui/oopsyraidsy/data/05-shb/raid/e7n.js
@@ -1,6 +1,8 @@
 import NetRegexes from '../../../../../resources/netregexes';
 import ZoneId from '../../../../../resources/zone_id';
 
+import { playerDamageFields } from '../../../oopsy_common';
+
 const wrongBuff = (str) => {
   return {
     en: str + ' (wrong buff)',
@@ -69,29 +71,29 @@ export default {
     },
     {
       id: 'E7N Light\'s Course',
-      damageRegex: ['4C3E', '4C40', '4C22', '4C3C', '4E63'],
-      condition: (e, data) => {
-        return !data.hasUmbral || !data.hasUmbral[e.targetName];
+      netRegex: NetRegexes.abilityFull({ id: ['4C3E', '4C40', '4C22', '4C3C', '4E63'], ...playerDamageFields }),
+      condition: (_e, data, matches) => {
+        return !data.hasUmbral || !data.hasUmbral[matches.target];
       },
-      mistake: (e, data) => {
-        if (data.hasAstral && data.hasAstral[e.targetName])
-          return { type: 'fail', blame: e.targetName, text: wrongBuff(e.abilityName) };
-        return { type: 'warn', blame: e.targetName, text: noBuff(e.abilityName) };
+      mistake: (_e, data, matches) => {
+        if (data.hasAstral && data.hasAstral[matches.target])
+          return { type: 'fail', blame: matches.target, text: wrongBuff(matches.ability) };
+        return { type: 'warn', blame: matches.target, text: noBuff(matches.ability) };
       },
     },
     {
       id: 'E7N Darks\'s Course',
-      damageRegex: ['4C3D', '4C23', '4C41', '4C43'],
-      condition: (e, data) => {
-        return !data.hasAstral || !data.hasAstral[e.targetName];
+      netRegex: NetRegexes.abilityFull({ id: ['4C3D', '4C23', '4C41', '4C43'], ...playerDamageFields }),
+      condition: (_e, data, matches) => {
+        return !data.hasAstral || !data.hasAstral[matches.target];
       },
-      mistake: (e, data) => {
-        if (data.hasUmbral && data.hasUmbral[e.targetName])
-          return { type: 'fail', blame: e.targetName, text: wrongBuff(e.abilityName) };
+      mistake: (_e, data, matches) => {
+        if (data.hasUmbral && data.hasUmbral[matches.target])
+          return { type: 'fail', blame: matches.target, text: wrongBuff(matches.ability) };
         // This case is probably impossible, as the debuff ticks after death,
         // but leaving it here in case there's some rez or disconnect timing
         // that could lead to this.
-        return { type: 'warn', blame: e.targetName, text: noBuff(e.abilityName) };
+        return { type: 'warn', blame: matches.target, text: noBuff(matches.ability) };
       },
     },
   ],

--- a/ui/oopsyraidsy/data/05-shb/raid/e7s.js
+++ b/ui/oopsyraidsy/data/05-shb/raid/e7s.js
@@ -1,6 +1,8 @@
 import NetRegexes from '../../../../../resources/netregexes';
 import ZoneId from '../../../../../resources/zone_id';
 
+import { playerDamageFields } from '../../../oopsy_common';
+
 // TODO: missing an orb during tornado phase
 // TODO: jumping in the tornado damage??
 // TODO: taking sungrace(4C80) or moongrace(4C82) with wrong debuff
@@ -96,39 +98,39 @@ export default {
     },
     {
       id: 'E7S Light\'s Course',
-      damageRegex: ['4C62', '4C63', '4C64', '4C5B', '4C5F'],
-      condition: (e, data) => {
-        return !data.hasUmbral || !data.hasUmbral[e.targetName];
+      netRegex: NetRegexes.abilityFull({ id: ['4C62', '4C63', '4C64', '4C5B', '4C5F'], ...playerDamageFields }),
+      condition: (_e, data, matches) => {
+        return !data.hasUmbral || !data.hasUmbral[matches.target];
       },
-      mistake: (e, data) => {
-        if (data.hasAstral && data.hasAstral[e.targetName])
-          return { type: 'fail', blame: e.targetName, text: wrongBuff(e.abilityName) };
-        return { type: 'warn', blame: e.targetName, text: noBuff(e.abilityName) };
+      mistake: (_e, data, matches) => {
+        if (data.hasAstral && data.hasAstral[matches.target])
+          return { type: 'fail', blame: matches.target, text: wrongBuff(matches.ability) };
+        return { type: 'warn', blame: matches.target, text: noBuff(matches.ability) };
       },
     },
     {
       id: 'E7S Darks\'s Course',
-      damageRegex: ['4C65', '4C66', '4C67', '4C5A', '4C60'],
-      condition: (e, data) => {
-        return !data.hasAstral || !data.hasAstral[e.targetName];
+      netRegex: NetRegexes.abilityFull({ id: ['4C65', '4C66', '4C67', '4C5A', '4C60'], ...playerDamageFields }),
+      condition: (_e, data, matches) => {
+        return !data.hasAstral || !data.hasAstral[matches.target];
       },
-      mistake: (e, data) => {
-        if (data.hasUmbral && data.hasUmbral[e.targetName])
-          return { type: 'fail', blame: e.targetName, text: wrongBuff(e.abilityName) };
+      mistake: (_e, data, matches) => {
+        if (data.hasUmbral && data.hasUmbral[matches.target])
+          return { type: 'fail', blame: matches.target, text: wrongBuff(matches.ability) };
         // This case is probably impossible, as the debuff ticks after death,
         // but leaving it here in case there's some rez or disconnect timing
         // that could lead to this.
-        return { type: 'warn', blame: e.targetName, text: noBuff(e.abilityName) };
+        return { type: 'warn', blame: matches.target, text: noBuff(matches.ability) };
       },
     },
     {
       id: 'E7S Crusade Knockback',
       // 4C76 is the knockback damage, 4C58 is the damage for standing on the puck.
-      damageRegex: '4C76',
-      deathReason: (e) => {
+      netRegex: NetRegexes.abilityFull({ id: '4C76', ...playerDamageFields }),
+      deathReason: (_e, _data, matches) => {
         return {
           type: 'fail',
-          name: e.targetName,
+          name: matches.target,
           reason: {
             en: 'Knocked off',
             de: 'Runtergefallen',

--- a/ui/oopsyraidsy/data/05-shb/raid/e8n.js
+++ b/ui/oopsyraidsy/data/05-shb/raid/e8n.js
@@ -1,6 +1,8 @@
 import NetRegexes from '../../../../../resources/netregexes';
 import ZoneId from '../../../../../resources/zone_id';
 
+import { playerDamageFields } from '../../../oopsy_common';
+
 export default {
   zoneId: ZoneId.EdensVerseRefulgence,
   damageWarn: {
@@ -28,11 +30,11 @@ export default {
     },
     {
       id: 'E8N Heavenly Strike',
-      damageRegex: '4DD8',
-      deathReason: (e) => {
+      netRegex: NetRegexes.abilityFull({ id: '4DD8', ...playerDamageFields }),
+      deathReason: (_e, _data, matches) => {
         return {
           type: 'fail',
-          name: e.targetName,
+          name: matches.target,
           reason: {
             en: 'Pushed off!',
             de: 'Runter gestoßen!',

--- a/ui/oopsyraidsy/data/05-shb/raid/e9s.js
+++ b/ui/oopsyraidsy/data/05-shb/raid/e9s.js
@@ -1,4 +1,7 @@
+import NetRegexes from '../../../../../resources/netregexes';
 import ZoneId from '../../../../../resources/zone_id';
+
+import { playerDamageFields } from '../../../oopsy_common';
 
 // TODO: 561D Evil Seed hits everyone, hard to know if there's a double tap
 // TODO: falling through panel just does damage with no ability name, like a death wall
@@ -46,8 +49,8 @@ export default {
       // arguably a healer might need to do something about that, so maybe
       // it's ok to still show as a warning??
       id: 'E9S Condensed Anti-Air Particle Beam',
-      damageRegex: '5615',
-      condition: (e) => e.type !== '15' && e.damage > 0,
+      netRegex: NetRegexes.abilityFull({ type: '22', id: '5615', ...playerDamageFields }),
+      condition: (_e, data, matches) => data.DamageFromMatches(matches) > 0,
       mistake: (_e, _data, matches) => {
         return { type: 'fail', blame: matches.target, text: matches.ability };
       },
@@ -55,8 +58,8 @@ export default {
     {
       // Anti-air "out".  This can be invulned by a tank along with the spread above.
       id: 'E9S Anti-Air Phaser Unlimited',
-      damageRegex: '5612',
-      condition: (e) => e.damage > 0,
+      netRegex: NetRegexes.abilityFull({ id: '5612', ...playerDamageFields }),
+      condition: (_e, data, matches) => data.DamageFromMatches(matches) > 0,
       mistake: (_e, _data, matches) => {
         return { type: 'warn', blame: matches.target, text: matches.ability };
       },

--- a/ui/oopsyraidsy/data/05-shb/trial/hades-ex.js
+++ b/ui/oopsyraidsy/data/05-shb/trial/hades-ex.js
@@ -1,6 +1,8 @@
 import NetRegexes from '../../../../../resources/netregexes';
 import ZoneId from '../../../../../resources/zone_id';
 
+import { playerDamageFields } from '../../../oopsy_common';
+
 // Hades Ex
 export default {
   zoneId: ZoneId.TheMinstrelsBalladHadessElegy,
@@ -46,13 +48,11 @@ export default {
     },
     {
       id: 'HadesEx Dark II',
-      damageRegex: '47BA',
-      condition: (e, data) => {
-        // Don't blame people who don't have tethers.
-        return e.type !== '15' && data.me in data.hasDark;
-      },
-      mistake: (e) => {
-        return { type: 'fail', blame: e.targetName, text: e.abilityName };
+      netRegex: NetRegexes.abilityFull({ type: '22', id: '47BA', ...playerDamageFields }),
+      // Don't blame people who don't have tethers.
+      condition: (_e, data, matches) => data.hasDark && data.hasDark.includes(matches.target),
+      mistake: (_e, _data, matches) => {
+        return { type: 'fail', blame: matches.target, text: matches.ability };
       },
     },
     {
@@ -72,10 +72,10 @@ export default {
     },
     {
       id: 'HadesEx Death Shriek',
-      damageRegex: '47CB',
-      condition: (e) => e.damage > 0,
-      mistake: (e) => {
-        return { type: 'warn', blame: e.targetName, text: e.abilityName };
+      netRegex: NetRegexes.abilityFull({ id: '47CB', ...playerDamageFields }),
+      condition: (_e, data, matches) => data.DamageFromMatches(matches) > 0,
+      mistake: (_e, _data, matches) => {
+        return { type: 'warn', blame: matches.target, text: matches.ability };
       },
     },
     {

--- a/ui/oopsyraidsy/data/05-shb/trial/varis-ex.js
+++ b/ui/oopsyraidsy/data/05-shb/trial/varis-ex.js
@@ -1,4 +1,7 @@
+import NetRegexes from '../../../../../resources/netregexes';
 import ZoneId from '../../../../../resources/zone_id';
+
+import { playerDamageFields } from '../../../oopsy_common';
 
 export default {
   zoneId: ZoneId.MemoriaMiseraExtreme,
@@ -30,10 +33,10 @@ export default {
   triggers: [
     {
       id: 'VarisEx Terminus Est',
-      damageRegex: '4CB4',
+      netRegex: NetRegexes.abilityFull({ id: '4CB4', ...playerDamageFields }),
       suppressSeconds: 1,
-      mistake: (e) => {
-        return { type: 'warn', blame: e.targetName, text: e.abilityName };
+      mistake: (_e, _data, matches) => {
+        return { type: 'warn', blame: matches.target, text: matches.ability };
       },
     },
   ],

--- a/ui/oopsyraidsy/data/05-shb/trial/wol-ex.js
+++ b/ui/oopsyraidsy/data/05-shb/trial/wol-ex.js
@@ -36,8 +36,8 @@ export default {
       id: 'WOLEx True Walking Dead',
       netRegex: NetRegexes.gainsEffect({ effectId: '8FF' }),
       delaySeconds: (_e, _data, matches) => parseFloat(matches.duration) - 0.5,
-      deathReason: (e, _data, matches) => {
-        return { type: 'fail', name: e.target, reason: matches.effect };
+      deathReason: (_e, _data, matches) => {
+        return { type: 'fail', name: matches.target, reason: matches.effect };
       },
     },
     {

--- a/ui/oopsyraidsy/data/05-shb/trial/wol.js
+++ b/ui/oopsyraidsy/data/05-shb/trial/wol.js
@@ -32,8 +32,8 @@ export default {
       id: 'WOL True Walking Dead',
       netRegex: NetRegexes.gainsEffect({ effectId: '38E' }),
       delaySeconds: (_e, _data, matches) => parseFloat(matches.duration) - 0.5,
-      deathReason: (e, _data, matches) => {
-        return { type: 'fail', name: e.target, reason: matches.effect };
+      deathReason: (_e, _data, matches) => {
+        return { type: 'fail', name: matches.target, reason: matches.effect };
       },
     },
   ],

--- a/ui/oopsyraidsy/data/05-shb/ultimate/the_epic_of_alexander.js
+++ b/ui/oopsyraidsy/data/05-shb/ultimate/the_epic_of_alexander.js
@@ -1,6 +1,8 @@
 import NetRegexes from '../../../../../resources/netregexes';
 import ZoneId from '../../../../../resources/zone_id';
 
+import { playerDamageFields } from '../../../oopsy_common';
+
 // TODO: FIX luminous aetheroplasm warning not working
 // TODO: FIX doll death not working
 // TODO: failing hand of pain/parting (check for high damage?)
@@ -58,11 +60,11 @@ export default {
       // Balloon Popping.  It seems like the person who pops it is the
       // first person listed damage-wise, so they are likely the culprit.
       id: 'TEA Outburst',
-      damageRegex: '482A',
+      netRegex: NetRegexes.abilityFull({ id: '482A', ...playerDamageFields }),
       collectSeconds: 0.5,
       suppressSeconds: 5,
-      mistake: (e) => {
-        return { type: 'fail', blame: e[0].targetName, text: e[0].attackerName };
+      mistake: (_e, _data, matches) => {
+        return { type: 'fail', blame: matches[0].target, text: matches[0].source };
       },
     },
     {
@@ -70,12 +72,12 @@ export default {
       // When this happens, the target explodes, hitting nearby people
       // but also themselves.
       id: 'TEA Exhaust',
-      damageRegex: '481F',
-      condition: (e) => e.targetName === e.attackerName,
-      mistake: (e) => {
+      netRegex: NetRegexes.abilityFull({ id: '481F', ...playerDamageFields }),
+      condition: (_e, _data, matches) => matches.target === matches.source,
+      mistake: (_e, _data, matches) => {
         return {
           type: 'fail',
-          blame: e.targetName,
+          blame: matches.target,
           text: {
             en: 'luminous aetheroplasm',
             de: 'Luminiszentes Ätheroplasma',
@@ -103,12 +105,12 @@ export default {
     },
     {
       id: 'TEA Reducible Complexity',
-      damageRegex: '4821',
-      mistake: (e, data) => {
+      netRegex: NetRegexes.abilityFull({ id: '4821', ...playerDamageFields }),
+      mistake: (_e, data, matches) => {
         return {
           type: 'fail',
           // This may be undefined, which is fine.
-          name: data.jagdTether ? data.jagdTether[e.attackerId] : undefined,
+          name: data.jagdTether ? data.jagdTether[matches.sourceId] : undefined,
           text: {
             en: 'Doll Death',
             de: 'Puppe Tot',
@@ -121,16 +123,10 @@ export default {
     },
     {
       id: 'TEA Drainage',
-      damageRegex: '4827',
-      condition: (e, data) => {
-        // TODO: remove this when ngld overlayplugin is the default
-        if (!data.party.partyNames.length)
-          return false;
-
-        return data.IsPlayerId(e.targetId) && !data.party.isTank(e.targetName);
-      },
-      mistake: (e) => {
-        return { type: 'fail', name: e.targetName, text: e.abilityName };
+      netRegex: NetRegexes.abilityFull({ id: '4827', ...playerDamageFields }),
+      condition: (_e, data, matches) => !data.party.isTank(matches.target),
+      mistake: (_e, _data, matches) => {
+        return { type: 'fail', name: matches.target, text: matches.ability };
       },
     },
     {

--- a/ui/oopsyraidsy/oopsy_common.ts
+++ b/ui/oopsyraidsy/oopsy_common.ts
@@ -14,7 +14,7 @@ export const kAttackFlags = ['01', '03', '05', '06', kFlagInstantDeath];
 
 // TODO: should we include damage != 0 here?
 export const damageFields = {
-  flags: `(?:${kAttackFlags.join('|')})(?=\\|)`,
+  flags: `(?:[^|]*${kAttackFlags.join('|')})(?=\\|)`,
 };
 
 export const playerDamageFields = {

--- a/ui/oopsyraidsy/oopsy_common.ts
+++ b/ui/oopsyraidsy/oopsy_common.ts
@@ -12,6 +12,16 @@ export const kFlagInstantDeath = '36'; // Always 36 ?
 // miss, damage, block, parry, instant death
 export const kAttackFlags = ['01', '03', '05', '06', kFlagInstantDeath];
 
+// TODO: should we include damage != 0 here?
+export const damageFields = {
+  flags: `(?:${kAttackFlags.join('|')})(?=\\|)`,
+};
+
+export const playerDamageFields = {
+  targetId: '[^4].......',
+  ...damageFields,
+};
+
 /* eslint-disable max-len */
 
 /*


### PR DESCRIPTION
The difference between damageRegex and abilityRegex is that damageRegex
verifies that a particular ability usage results in flag fields that
look like damage.  So, to replace this we use some `playerDamageFields`
that can be added to `NetRegexes.abilityFull`.

Subtle behavior change note: while we're here, this also checks to make
sure that the target is a player, since we (generally) only care about
mistakes where damage hits a player.  Usually cases where we care about
abilities going off (like interrupts) are done with `abilityRegex`.
However, keep a close eye that all converted triggers are of this type.

Possibly in the future we could also make `playerDamageFields` check
that damage > 0, but this seemed like even more change than was needed.

This PR should remove the last uses of oopsy events outside of oopsy
code itself, and ideally in the future we can just remove them.