### PR TITLE
oopsy: remove event field from all triggers

### DIFF
--- a/docs/OopsyraidsyGuide.md
+++ b/docs/OopsyraidsyGuide.md
@@ -140,7 +140,7 @@ mistake: (data, matches) => {
 If this following trigger is used, then if a player dies without taking any other damage, the log would show ":skull: Chippy: Doom Debuff" instead of assigning it to the last damage the player took before this trigger, which might incorrectly look more like ":skull: Chippy: Auto (3034/38471)".
 
 ```javascript
-deathReason: function(event, data, matches) {
+deathReason: (data, matches) => {
   return {
     name: event.targetName,
     reason: 'Doom Debuff',
@@ -185,7 +185,7 @@ For example, if you want to store a map of which players have doom or not, that 
 ```javascript
 {
   netRegex: NetRegexes.gainsEffect({ effect: 'Doom' }),
-  run: function(data, matches) {
+  run: (data, matches) => {
     data.hasDoom[matches.target] = true;
   },
 },

--- a/docs/OopsyraidsyGuide.md
+++ b/docs/OopsyraidsyGuide.md
@@ -111,10 +111,10 @@ Each trigger is an object with the following fields.  All fields are optional.
 This will print ":no_entry_sign: Latke: Dynamo" in the live log.
 
 ```javascript
-mistake: (event, data, matches) => {
+mistake: (data, matches) => {
   return {
     type: 'fail',
-    blame: e.targetName,
+    blame: matches.target,
     text: 'Dynamo'
   };
 },
@@ -123,10 +123,10 @@ mistake: (event, data, matches) => {
 This will print ":warning: WHOOPS" in the live log, even though a player was blamed.
 
 ```javascript
-mistake: (event, data, matches) => {
+mistake: (data, matches) => {
   return {
     type: 'warn',
-    blame: e.targetName,
+    blame: matches.target,
     fullText: 'WHOOPS',
   };
 },
@@ -150,63 +150,15 @@ deathReason: function(event, data, matches) {
 
 ## Oopsy Trigger Function Parameters
 
-Every function in an oopsy trigger gets three parameters: `event`, `data`, `matches` in that order.
-
-### Event Fields
-
-Every function specified in a trigger gets an event (or events) object.
-This object has different fields depending on which type of regex was used to match the trigger.
-Events are deprecated and will be removed shortly.
-
-#### All Events
-
-* `event.line`: string, representing the entire log line.
-
-#### Effect Events (gainsEffectRegex, losesEffectRegex)
-
-* `event.targetName`: string, the target's full name.
-* `event.effectName`: string, the buff name gained, e.g. 'Beyond Death'.
-* `event.gains`: bool, true if the buff was gained, false if the buff was lost.
-* `event.attackerName`: string, the full name of the attacker that gave the target this buff.
-* `event.durationSeconds`: float, the duration this buff was gained for.  undefined if the buff was lost.
-
-#### Ability Events (healRegex, damageRegex, abilityRegex)
-
-* `event.type`: hex string of the log line type (e.g. '1B' for head markers).
-* `event.attackerId`: hex string of the attacker's id
-* `event.attackerName`: string, full name of the target.
-* `event.targetId`: hex string of the target's id.
-* `event.targetName`: string, full name of the target.
-* `event.flags`: hex string of flags for this damage value (see comments in **oopsyraidsy.js** for more information).
-* `event.damage`: float, damage or heal value
-* `event.damageStr`: string, nicer looking version of `event.damage` with ! and !! for crits.
-* `event.targetCurrentHp`: int string, target's hp at the time of this ability.
-* `event.targetMaxHp`: int string, target's max hp at the time of this ability.
-* `event.targetCurrentMp`: int string, target's mp at the time of this ability.
-* `event.targetMaxMp`: int string, target's max mp at the time of this ability.
-* `event.targetCurrentTp`: int string, target's tp at the time of this ability.
-* `event.targetMaxTp`: int string, target's max tp at the time of this ability.
-* `event.targetX`: x position of the target when this ability was used.
-* `event.targetY`: y position of the target when this ability was used.
-* `event.targetZ`: z position of the target when this ability was used.
-* `event.attackerX`: x position of the attacker when this ability was used.
-* `event.attackerY`: y position of the attacker when this ability was used.
-* `event.attackerZ`: z position of the attacker when this ability was used.
-
-`data.IsPlayerId(id)` can be used against the `attackerId` or the `targetId` to determine if that id represents a player.
+Every function in an oopsy trigger gets two parameters: `data` and `matches` in that order.
 
 Current hp/mp/tp values are not 100% precise.  ACT polls these values periodically and so it may be out of date by one HoT/DoT tick.  The most important consideration is that damage that does more than current hp may not actually be fatal, and vice versa that damage that does less than current hp may turn out to be fatal.  There's no way to know until the 'was defeated' message shows up two seconds later.
-
-### Single Event Example
-
-In most cases, a single event will be passed to every function.
-This happens for triggers that are in the `triggers` object.
 
 ```javascript
 {
   // 26BB is the ability id for Nael's Iron Chariot.
   netRegex: NetRegexes.ability({ id: '26BB' }),
-  mistake: (_e_, _data, matches) => {
+  mistake: (_data, matches) => {
     // matches here is a single matches object
     console.log(matches.target);
   },
@@ -233,7 +185,7 @@ For example, if you want to store a map of which players have doom or not, that 
 ```javascript
 {
   netRegex: NetRegexes.gainsEffect({ effect: 'Doom' }),
-  run: function(_e, data, matches) {
+  run: function(data, matches) {
     data.hasDoom[matches.target] = true;
   },
 },

--- a/types/oopsy.d.ts
+++ b/types/oopsy.d.ts
@@ -5,8 +5,6 @@ import { NetAnyMatches, NetMatches } from './net_matches';
 import { CactbotBaseRegExp, TriggerTypes } from './net_trigger';
 import { LocaleText, ZoneId } from './trigger';
 
-export type OopsyEvent = { line: string };
-
 export type OopsyMistakeType = 'pull' | 'warn' | 'fail' | 'potion' | 'death' | 'wipe';
 
 export type OopsyField = boolean | number | string |
@@ -28,7 +26,7 @@ export type OopsyDeathReason = {
 }
 
 export type OopsyFunc<Data extends OopsyData, MatchType extends NetAnyMatches, Return> =
-    (evt: OopsyEvent, data: Data, matches: MatchType) => Return;
+    (data: Data, matches: MatchType) => Return;
 
 export type OopsyTriggerField<Data extends OopsyData,
     MatchType extends NetAnyMatches, Return> =

--- a/ui/oopsyraidsy/data/00-misc/buffs.js
+++ b/ui/oopsyraidsy/data/00-misc/buffs.js
@@ -6,7 +6,7 @@ const abilityCollectSeconds = 0.5;
 // Observation: up to ~1.2 seconds for a buff to roll through the party.
 const effectCollectSeconds = 2.0;
 
-const isInPartyConditionFunc = (_evt, data, matches) => {
+const isInPartyConditionFunc = (data, matches) => {
   const sourceId = matches.sourceId.toUpperCase();
   if (data.party.partyIds.includes(sourceId))
     return true;
@@ -27,7 +27,7 @@ const missedFunc = (args) => [
     id: `Buff ${args.triggerId} Collect`,
     netRegex: args.netRegex,
     condition: isInPartyConditionFunc,
-    run: (_e, data, matches) => {
+    run: (data, matches) => {
       data.generalBuffCollection = data.generalBuffCollection || {};
       data.generalBuffCollection[args.triggerId] = data.generalBuffCollection[args.triggerId] || [];
       data.generalBuffCollection[args.triggerId].push(matches);
@@ -39,7 +39,7 @@ const missedFunc = (args) => [
     condition: isInPartyConditionFunc,
     delaySeconds: args.collectSeconds,
     suppressSeconds: args.collectSeconds,
-    mistake: (_e, data, _matches) => {
+    mistake: (data, _matches) => {
       if (!data.generalBuffCollection)
         return;
       const allMatches = data.generalBuffCollection[args.triggerId];
@@ -170,7 +170,7 @@ export default {
     {
       id: 'Buff Pet To Owner Mapper',
       netRegex: NetRegexes.addedCombatantFull(),
-      run: (_e, data, matches) => {
+      run: (data, matches) => {
         if (matches.ownerId === '0')
           return;
 
@@ -182,7 +182,7 @@ export default {
     {
       id: 'Buff Pet To Owner Clearer',
       netRegex: NetRegexes.changeZone(),
-      run: (_e, data) => {
+      run: (data) => {
         // Clear this hash periodically so it doesn't have false positives.
         data.petIdToOwnerId = {};
       },

--- a/ui/oopsyraidsy/data/00-misc/buffs.js
+++ b/ui/oopsyraidsy/data/00-misc/buffs.js
@@ -117,7 +117,7 @@ const missedFunc = (args) => [
         },
       };
     },
-    run: (_e, data) => {
+    run: (data) => {
       if (data.generalBuffCollection)
         delete data.generalBuffCollection[args.triggerId];
     },

--- a/ui/oopsyraidsy/data/00-misc/general.js
+++ b/ui/oopsyraidsy/data/00-misc/general.js
@@ -13,11 +13,11 @@ export default {
       id: 'General Food Buff',
       // Well Fed
       netRegex: NetRegexes.losesEffect({ effectId: '48' }),
-      condition: (_e, _data, matches) => {
+      condition: (_data, matches) => {
         // Prevent "Eos loses the effect of Well Fed from Critlo Mcgee"
         return matches.target === matches.source;
       },
-      mistake: (_e, data, matches) => {
+      mistake: (data, matches) => {
         data.lostFood = data.lostFood || {};
         // Well Fed buff happens repeatedly when it falls off (WHY),
         // so suppress multiple occurrences.
@@ -41,7 +41,7 @@ export default {
     {
       id: 'General Well Fed',
       netRegex: NetRegexes.gainsEffect({ effectId: '48' }),
-      run: (_e, data, matches) => {
+      run: (data, matches) => {
         if (!data.lostFood)
           return;
         delete data.lostFood[matches.target];
@@ -50,8 +50,8 @@ export default {
     {
       id: 'General Rabbit Medium',
       netRegex: NetRegexes.ability({ id: '8E0' }),
-      condition: (_e, data, matches) => data.IsPlayerId(matches.sourceId),
-      mistake: (_e, _data, matches) => {
+      condition: (data, matches) => data.IsPlayerId(matches.sourceId),
+      mistake: (_data, matches) => {
         return {
           type: 'warn',
           blame: matches.source,

--- a/ui/oopsyraidsy/data/00-misc/test.js
+++ b/ui/oopsyraidsy/data/00-misc/test.js
@@ -12,7 +12,7 @@ export default {
       netRegexJa: NetRegexes.gameNameLog({ line: '.*は木人にお辞儀した.*?' }),
       netRegexCn: NetRegexes.gameNameLog({ line: '.*恭敬地对木人行礼.*?' }),
       netRegexKo: NetRegexes.gameNameLog({ line: '.*나무인형에게 공손하게 인사합니다.*?' }),
-      mistake: (_e, data) => {
+      mistake: (data) => {
         return {
           type: 'pull',
           blame: data.me,
@@ -34,7 +34,7 @@ export default {
       netRegexJa: NetRegexes.gameNameLog({ line: '.*は木人に別れの挨拶をした.*?' }),
       netRegexCn: NetRegexes.gameNameLog({ line: '.*向木人告别.*?' }),
       netRegexKo: NetRegexes.gameNameLog({ line: '.*나무인형에게 작별 인사를 합니다.*?' }),
-      mistake: (_e, data) => {
+      mistake: (data) => {
         return {
           type: 'wipe',
           blame: data.me,
@@ -52,7 +52,7 @@ export default {
     {
       id: 'Test Bootshine',
       netRegex: NetRegexes.abilityFull({ id: '35' }),
-      condition: (_e, data, matches) => {
+      condition: (data, matches) => {
         if (matches.source !== data.me)
           return false;
         const strikingDummyByLocale = {
@@ -65,7 +65,7 @@ export default {
         const strikingDummyNames = Object.values(strikingDummyByLocale);
         return strikingDummyNames.includes(matches.target);
       },
-      mistake: (_e, data, matches) => {
+      mistake: (data, matches) => {
         data.bootCount = data.bootCount || 0;
         data.bootCount++;
         const text = `${matches.ability} (${data.bootCount}): ${data.DamageFromMatches(matches)}`;
@@ -75,8 +75,8 @@ export default {
     {
       id: 'Test Leaden Fist',
       netRegex: NetRegexes.gainsEffect({ effectId: '745' }),
-      condition: (_e, data, matches) => matches.source === data.me,
-      mistake: (_e, data, matches) => {
+      condition: (data, matches) => matches.source === data.me,
+      mistake: (data, matches) => {
         return { type: 'good', blame: data.me, text: matches.effect };
       },
     },
@@ -84,7 +84,7 @@ export default {
       id: 'Test Oops',
       netRegex: NetRegexes.echo({ line: '.*oops.*' }),
       suppressSeconds: 10,
-      mistake: (_e, data, matches) => {
+      mistake: (data, matches) => {
         return { type: 'fail', blame: data.me, text: matches.line };
       },
     },
@@ -95,7 +95,7 @@ export default {
       netRegexJa: NetRegexes.gameNameLog({ line: '.*は木人をつついた.*?' }),
       netRegexCn: NetRegexes.gameNameLog({ line: '.*用手指戳向木人.*?' }),
       netRegexKo: NetRegexes.gameNameLog({ line: '.*나무인형을 쿡쿡 찌릅니다.*?' }),
-      run: (_e, data) => {
+      run: (data) => {
         data.pokeCount = (data.pokeCount || 0) + 1;
       },
     },
@@ -107,7 +107,7 @@ export default {
       netRegexCn: NetRegexes.gameNameLog({ line: '.*用手指戳向木人.*?' }),
       netRegexKo: NetRegexes.gameNameLog({ line: '.*나무인형을 쿡쿡 찌릅니다.*?' }),
       delaySeconds: 5,
-      mistake: (_e, data) => {
+      mistake: (data) => {
         // 1 poke at a time is fine, but more than one in 5 seconds is (OBVIOUSLY) a mistake.
         if (!data.pokeCount || data.pokeCount <= 1)
           return;
@@ -124,7 +124,7 @@ export default {
           },
         };
       },
-      run: (_e, data) => delete data.pokeCount,
+      run: (data) => delete data.pokeCount,
     },
   ],
 };

--- a/ui/oopsyraidsy/data/02-arr/trial/levi-ex.js
+++ b/ui/oopsyraidsy/data/02-arr/trial/levi-ex.js
@@ -34,7 +34,7 @@ export default {
     {
       id: 'LeviEx Body Slam Knocked Off',
       netRegex: NetRegexes.ability({ id: '82A' }),
-      deathReason: (_e, _data, matches) => {
+      deathReason: (_data, matches) => {
         return {
           type: 'fail',
           name: matches.target,

--- a/ui/oopsyraidsy/data/02-arr/trial/shiva-ex.js
+++ b/ui/oopsyraidsy/data/02-arr/trial/shiva-ex.js
@@ -34,11 +34,11 @@ export default {
       // Shiva also uses ability C8A on you, but it has the untranslated name
       // 透明：シヴァ：凍結レクト：ノックバック用/ヒロイック. So, use the effect instead for free translation.
       netRegex: NetRegexes.gainsEffect({ effectId: '1E7' }),
-      condition: (_e, _data, matches) => {
+      condition: (_data, matches) => {
         // The intermission also gets this effect, but for a shorter duration.
         return parseFloat(matches.duration) > 20;
       },
-      mistake: (_e, _data, matches) => {
+      mistake: (_data, matches) => {
         return { type: 'fail', blame: matches.target, text: matches.effect };
       },
     },

--- a/ui/oopsyraidsy/data/02-arr/trial/shiva-hm.js
+++ b/ui/oopsyraidsy/data/02-arr/trial/shiva-hm.js
@@ -33,12 +33,12 @@ export default {
       // Shiva also uses ability 9A3 on you, but it has the untranslated name
       // 透明：シヴァ：凍結レクト：ノックバック用. So, use the effect instead for free translation.
       netRegex: NetRegexes.gainsEffect({ effectId: '1E7' }),
-      condition: (_e, data) => {
+      condition: (data) => {
         // The intermission also gets this effect, so only a mistake after that.
         // Unlike extreme, this has the same 20 second duration as the intermission.
         return data.seenDiamondDust;
       },
-      mistake: (_e, _data, matches) => {
+      mistake: (_data, matches) => {
         return { type: 'fail', blame: matches.target, text: matches.effect };
       },
     },

--- a/ui/oopsyraidsy/data/03-hw/alliance/weeping_city.js
+++ b/ui/oopsyraidsy/data/03-hw/alliance/weeping_city.js
@@ -51,7 +51,7 @@ export default {
     {
       id: 'Weeping Forgall Gradual Zombification Gain',
       netRegex: NetRegexes.gainsEffect({ effectId: '415' }),
-      run: (_e, data, matches) => {
+      run: (data, matches) => {
         data.zombie = data.zombie || {};
         data.zombie[matches.target] = true;
       },
@@ -59,7 +59,7 @@ export default {
     {
       id: 'Weeping Forgall Gradual Zombification Lose',
       netRegex: NetRegexes.losesEffect({ effectId: '415' }),
-      run: (_e, data, matches) => {
+      run: (data, matches) => {
         data.zombie = data.zombie || {};
         data.zombie[matches.target] = false;
       },
@@ -67,15 +67,15 @@ export default {
     {
       id: 'Weeping Forgall Mega Death',
       netRegex: NetRegexes.ability({ id: '17CA' }),
-      condition: (_e, data, matches) => data.zombie && !data.zombie[matches.target],
-      mistake: (_e, _data, matches) => {
+      condition: (data, matches) => data.zombie && !data.zombie[matches.target],
+      mistake: (_data, matches) => {
         return { type: 'fail', blame: matches.target, text: matches.ability };
       },
     },
     {
       id: 'Weeping Headstone Shield Gain',
       netRegex: NetRegexes.gainsEffect({ effectId: '15E' }),
-      run: (_e, data, matches) => {
+      run: (data, matches) => {
         data.shield = data.shield || {};
         data.shield[matches.target] = true;
       },
@@ -83,7 +83,7 @@ export default {
     {
       id: 'Weeping Headstone Shield Lose',
       netRegex: NetRegexes.losesEffect({ effectId: '15E' }),
-      run: (_e, data, matches) => {
+      run: (data, matches) => {
         data.shield = data.shield || {};
         data.shield[matches.target] = false;
       },
@@ -91,8 +91,8 @@ export default {
     {
       id: 'Weeping Flaring Epigraph',
       netRegex: NetRegexes.ability({ id: '1856' }),
-      condition: (_e, data, matches) => data.shield && !data.shield[matches.target],
-      mistake: (_e, _data, matches) => {
+      condition: (data, matches) => data.shield && !data.shield[matches.target],
+      mistake: (_data, matches) => {
         return { type: 'fail', blame: matches.target, text: matches.ability };
       },
     },
@@ -100,7 +100,7 @@ export default {
       // This ability name is helpfully called "Attack" so name it something else.
       id: 'Weeping Ozma Tank Laser',
       netRegex: NetRegexes.ability({ type: '22', id: '1831' }),
-      mistake: (_e, _data, matches) => {
+      mistake: (_data, matches) => {
         return {
           type: 'warn',
           blame: matches.target,
@@ -118,7 +118,7 @@ export default {
     {
       id: 'Weeping Ozma Holy',
       netRegex: NetRegexes.ability({ id: '182E' }),
-      deathReason: (_e, _data, matches) => {
+      deathReason: (_data, matches) => {
         return {
           type: 'fail',
           name: matches.target,

--- a/ui/oopsyraidsy/data/03-hw/dungeon/aetherochemical_research_facility.js
+++ b/ui/oopsyraidsy/data/03-hw/dungeon/aetherochemical_research_facility.js
@@ -41,7 +41,7 @@ export default {
     {
       id: 'ARF Petrifaction',
       netRegex: NetRegexes.gainsEffect({ effectId: '01' }),
-      mistake: (_e, _data, matches) => {
+      mistake: (_data, matches) => {
         return { type: 'warn', blame: matches.target, text: matches.effect };
       },
     },

--- a/ui/oopsyraidsy/data/03-hw/dungeon/gubal_library_hard.js
+++ b/ui/oopsyraidsy/data/03-hw/dungeon/gubal_library_hard.js
@@ -42,7 +42,7 @@ export default {
       // Fire gate in hallway to boss 2, magnet failure on boss 2
       id: 'GubalHm Burns',
       netRegex: NetRegexes.gainsEffect({ effectId: '10B' }),
-      mistake: (_e, _data, matches) => {
+      mistake: (_data, matches) => {
         return { type: 'warn', blame: matches.target, text: matches.effect };
       },
     },
@@ -50,7 +50,7 @@ export default {
       // Helper for Thunder 3 failures
       id: 'GubalHm Imp Gain',
       netRegex: NetRegexes.gainsEffect({ effectId: '46E' }),
-      run: (_e, data, matches) => {
+      run: (data, matches) => {
         data.hasImp = data.hasImp || {};
         data.hasImp[matches.target] = true;
       },
@@ -58,7 +58,7 @@ export default {
     {
       id: 'GubalHm Imp Lose',
       netRegex: NetRegexes.losesEffect({ effectId: '46E' }),
-      run: (_e, data, matches) => {
+      run: (data, matches) => {
         data.hasImp = data.hasImp || {};
         data.hasImp[matches.target] = false;
       },
@@ -67,8 +67,8 @@ export default {
       // Targets with Imp when Thunder III resolves receive a vulnerability stack and brief stun
       id: 'GubalHm Imp Thunder',
       netRegex: NetRegexes.abilityFull({ id: '195[AB]', ...playerDamageFields }),
-      condition: (_e, data, matches) => data.hasImp[matches.target],
-      mistake: (_e, _data, matches) => {
+      condition: (data, matches) => data.hasImp[matches.target],
+      mistake: (_data, matches) => {
         return {
           type: 'warn',
           blame: matches.target,
@@ -85,8 +85,8 @@ export default {
       id: 'GubalHm Quake',
       netRegex: NetRegexes.abilityFull({ id: '1956', ...playerDamageFields }),
       // Always hits target, but if correctly resolved will deal 0 damage
-      condition: (_e, data, matches) => data.DamageFromMatches(matches) > 0,
-      mistake: (_e, _data, matches) => {
+      condition: (data, matches) => data.DamageFromMatches(matches) > 0,
+      mistake: (_data, matches) => {
         return { type: 'warn', blame: matches.target, text: matches.ability };
       },
     },
@@ -94,8 +94,8 @@ export default {
       id: 'GubalHm Tornado',
       netRegex: NetRegexes.abilityFull({ id: '195[78]', ...playerDamageFields }),
       // Always hits target, but if correctly resolved will deal 0 damage
-      condition: (_e, data, matches) => data.DamageFromMatches(matches) > 0,
-      mistake: (_e, _data, matches) => {
+      condition: (data, matches) => data.DamageFromMatches(matches) > 0,
+      mistake: (_data, matches) => {
         return { type: 'warn', blame: matches.target, text: matches.ability };
       },
     },

--- a/ui/oopsyraidsy/data/03-hw/dungeon/sohm_al_hard.js
+++ b/ui/oopsyraidsy/data/03-hw/dungeon/sohm_al_hard.js
@@ -34,7 +34,7 @@ export default {
       // Warns if players step into the lava puddles. There is unfortunately no direct damage event.
       id: 'SohmAlHm Burns',
       netRegex: NetRegexes.gainsEffect({ effectId: '11C' }),
-      mistake: (_e, _data, matches) => {
+      mistake: (_data, matches) => {
         return { type: 'warn', blame: matches.target, text: matches.effect };
       },
     },

--- a/ui/oopsyraidsy/data/03-hw/raid/a12n.js
+++ b/ui/oopsyraidsy/data/03-hw/raid/a12n.js
@@ -19,7 +19,7 @@ export default {
     {
       id: 'A12N Assault Collect',
       netRegex: NetRegexes.gainsEffect({ effectId: '461' }),
-      run: (_e, data, matches) => {
+      run: (data, matches) => {
         data.assault = data.assault || [];
         data.assault.push(matches.target);
       },
@@ -28,8 +28,8 @@ export default {
       // It is a failure for a Severity marker to stack with the Solidarity group.
       id: 'A12N Assault Failure',
       netRegex: NetRegexes.abilityFull({ id: '1AF2', ...playerDamageFields }),
-      condition: (_e, data, matches) => data.assault.includes(matches.target),
-      mistake: (_e, _data, matches) => {
+      condition: (data, matches) => data.assault.includes(matches.target),
+      mistake: (_data, matches) => {
         return {
           type: 'fail',
           blame: matches.target,
@@ -48,7 +48,7 @@ export default {
       netRegex: NetRegexes.gainsEffect({ effectId: '461' }),
       delaySeconds: 20,
       suppressSeconds: 5,
-      run: (_e, data) => {
+      run: (data) => {
         delete data.assault;
       },
     },

--- a/ui/oopsyraidsy/data/04-sb/dungeon/ala_mhigo.js
+++ b/ui/oopsyraidsy/data/04-sb/dungeon/ala_mhigo.js
@@ -35,7 +35,7 @@ export default {
       id: 'Ala Mhigo Art Of The Swell',
       // Damage Down
       netRegex: NetRegexes.gainsEffect({ effectId: '2B8' }),
-      mistake: (_e, _data, matches) => {
+      mistake: (_data, matches) => {
         return { type: 'warn', blame: matches.target, text: matches.effect };
       },
     },

--- a/ui/oopsyraidsy/data/04-sb/dungeon/bardams_mettle.js
+++ b/ui/oopsyraidsy/data/04-sb/dungeon/bardams_mettle.js
@@ -16,8 +16,8 @@ const abilityWarn = (args) => {
   return {
     id: args.id,
     netRegex: NetRegexes.abilityFull({ id: args.abilityId }),
-    condition: (_e, _data, matches) => matches.flags.substr(-2) === '0E',
-    mistake: (_e, _data, matches) => {
+    condition: (_data, matches) => matches.flags.substr(-2) === '0E',
+    mistake: (_data, matches) => {
       return { type: 'warn', blame: matches.target, text: matches.ability };
     },
   };

--- a/ui/oopsyraidsy/data/04-sb/dungeon/kugane_castle.js
+++ b/ui/oopsyraidsy/data/04-sb/dungeon/kugane_castle.js
@@ -35,8 +35,8 @@ export default {
       // Stack marker, Zuiko Maru, boss 1
       id: 'Kugane Castle Helm Crack',
       netRegex: NetRegexes.ability({ id: '1E94' }),
-      condition: (_e, _data, matches) => matches.type === '21', // Taking the stack solo is *probably* a mistake.
-      mistake: (_e, _data, matches) => {
+      condition: (_data, matches) => matches.type === '21', // Taking the stack solo is *probably* a mistake.
+      mistake: (_data, matches) => {
         return {
           type: 'fail',
           blame: matches.target,

--- a/ui/oopsyraidsy/data/04-sb/dungeon/swallows_compass.js
+++ b/ui/oopsyraidsy/data/04-sb/dungeon/swallows_compass.js
@@ -43,7 +43,7 @@ export default {
       // Standing in the lake, Diadarabotchi, boss 2
       id: 'Swallows Compass Six Fulms Under',
       netRegex: NetRegexes.gainsEffect({ effectId: '237' }),
-      deathReason: (_e, _data, matches) => {
+      deathReason: (_data, matches) => {
         return {
           type: 'fail',
           name: matches.target,
@@ -56,7 +56,7 @@ export default {
       id: 'Swallows Compass Five Fingered Punishment',
       netRegex: NetRegexes.ability({ id: ['2BAB', '2BB0'], source: ['Qitian Dasheng', 'Shadow Of The Sage'] }),
       condition: (_data, matches) => matches.type === '21', // Taking the stack solo is *probably* a mistake.
-      mistake: (_e, _data, matches) => {
+      mistake: (_data, matches) => {
         return {
           type: 'fail',
           blame: matches.target,

--- a/ui/oopsyraidsy/data/04-sb/raid/o12s.js
+++ b/ui/oopsyraidsy/data/04-sb/raid/o12s.js
@@ -43,7 +43,7 @@ export default {
     {
       id: 'O12S1 Discharger Knocked Off',
       netRegex: NetRegexes.ability({ id: '3327' }),
-      deathReason: (_e, _data, matches) => {
+      deathReason: (_data, matches) => {
         return {
           type: 'fail',
           name: matches.target,
@@ -61,7 +61,7 @@ export default {
     {
       id: 'O12S1 Magic Vulnerability Up Gain',
       netRegex: NetRegexes.gainsEffect({ effectId: '472' }),
-      run: (_e, data, matches) => {
+      run: (data, matches) => {
         data.vuln = data.vuln || {};
         data.vuln[matches.target] = true;
       },
@@ -69,7 +69,7 @@ export default {
     {
       id: 'O12S1 Magic Vulnerability Up Lose',
       netRegex: NetRegexes.losesEffect({ effectId: '472' }),
-      run: (_e, data, matches) => {
+      run: (data, matches) => {
         data.vuln = data.vuln || {};
         data.vuln[matches.target] = false;
       },
@@ -80,8 +80,8 @@ export default {
       // 333E = Electric Slide (Omega-M square 1-4 dashes)
       // 333F = Electric Slide (Omega-F triangle 1-4 dashes)
       netRegex: NetRegexes.abilityFull({ id: ['332E', '333E', '333F'], ...playerDamageFields }),
-      condition: (_e, data, matches) => data.vuln && data.vuln[matches.target],
-      mistake: (_e, _data, matches) => {
+      condition: (data, matches) => data.vuln && data.vuln[matches.target],
+      mistake: (_data, matches) => {
         return {
           type: 'fail',
           blame: matches.target,

--- a/ui/oopsyraidsy/data/04-sb/raid/o2n.js
+++ b/ui/oopsyraidsy/data/04-sb/raid/o2n.js
@@ -22,7 +22,7 @@ export default {
       // The user might get hit by another petrifying ability before the effect ends.
       // There's no point in notifying for that.
       suppressSeconds: 10,
-      mistake: (_e, _data, matches) => {
+      mistake: (_data, matches) => {
         return { type: 'warn', blame: matches.target, text: matches.effect };
       },
     },
@@ -30,8 +30,8 @@ export default {
       id: 'O2N Earthquake',
       netRegex: NetRegexes.abilityFull({ id: '2515', ...playerDamageFields }),
       // This deals damage only to non-floating targets.
-      condition: (_e, data, matches) => data.DamageFromMatches(matches) > 0,
-      mistake: (_e, _data, matches) => {
+      condition: (data, matches) => data.DamageFromMatches(matches) > 0,
+      mistake: (_data, matches) => {
         return { type: 'warn', blame: matches.target, text: matches.ability };
       },
     },

--- a/ui/oopsyraidsy/data/04-sb/raid/o3n.js
+++ b/ui/oopsyraidsy/data/04-sb/raid/o3n.js
@@ -28,7 +28,7 @@ export default {
       netRegexJa: NetRegexes.startsUsing({ id: '2304', source: 'ハリカルナッソス', capture: false }),
       netRegexCn: NetRegexes.startsUsing({ id: '2304', source: '哈利卡纳苏斯', capture: false }),
       netRegexKo: NetRegexes.startsUsing({ id: '2304', source: '할리카르나소스', capture: false }),
-      run: (_e, data) => {
+      run: (data) => {
         data.phaseNumber += 1;
       },
     },
@@ -42,8 +42,8 @@ export default {
       netRegexJa: NetRegexes.ability({ id: '367', source: 'ハリカルナッソス', capture: false }),
       netRegexCn: NetRegexes.ability({ id: '367', source: '哈利卡纳苏斯', capture: false }),
       netRegexKo: NetRegexes.ability({ id: '367', source: '할리카르나소스', capture: false }),
-      condition: (_e, data) => !data.initialized,
-      run: (_e, data) => {
+      condition: (data) => !data.initialized,
+      run: (data) => {
         data.gameCount = 0;
         // Indexing phases at 1 so as to make phases match what humans expect.
         // 1: We start here.
@@ -56,12 +56,12 @@ export default {
     {
       id: 'O3N Ribbit',
       netRegex: NetRegexes.ability({ id: '2466' }),
-      condition: (_e, data, matches) => {
+      condition: (data, matches) => {
         // We DO want to be hit by Toad/Ribbit if the next cast of The Game
         // is 4x toad panels.
         return !(data.phaseNumber === 3 && data.gameCount % 2 === 0) && matches.targetId !== 'E0000000';
       },
-      mistake: (_e, _data, matches) => {
+      mistake: (_data, matches) => {
         return { type: 'warn', blame: matches.target, text: matches.ability };
       },
     },
@@ -72,11 +72,11 @@ export default {
       // Guess what you just lost?
       netRegex: NetRegexes.ability({ id: '246D' }),
       // If the player takes no damage, they did the mechanic correctly.
-      condition: (_e, data, matches) => data.DamageFromMatches(matches) > 0,
-      mistake: (_e, _data, matches) => {
+      condition: (data, matches) => data.DamageFromMatches(matches) > 0,
+      mistake: (_data, matches) => {
         return { type: 'warn', blame: matches.target, text: matches.ability };
       },
-      run: (_e, data) => {
+      run: (data) => {
         data.gameCount += 1;
       },
     },

--- a/ui/oopsyraidsy/data/04-sb/raid/o4n.js
+++ b/ui/oopsyraidsy/data/04-sb/raid/o4n.js
@@ -25,7 +25,7 @@ export default {
     {
       id: 'O4N Doom', // Kills target if not cleansed
       netRegex: NetRegexes.gainsEffect({ effectId: '38E' }),
-      deathReason: (_e, _data, matches) => {
+      deathReason: (_data, matches) => {
         return {
           type: 'fail',
           name: matches.target,
@@ -43,7 +43,7 @@ export default {
       // Short knockback from Exdeath
       id: 'O4N Vacuum Wave',
       netRegex: NetRegexes.abilityFull({ id: '24B8', ...playerDamageFields }),
-      deathReason: (_e, _data, matches) => {
+      deathReason: (_data, matches) => {
         return {
           type: 'fail',
           name: matches.target,
@@ -60,7 +60,7 @@ export default {
     {
       id: 'O4N Empowered Blizzard', // Room-wide AoE, freezes non-moving targets
       netRegex: NetRegexes.gainsEffect({ effectId: '4E6' }),
-      mistake: (_e, _data, matches) => {
+      mistake: (_data, matches) => {
         return { type: 'warn', blame: matches.target, text: matches.effect };
       },
     },

--- a/ui/oopsyraidsy/data/04-sb/raid/o4s.js
+++ b/ui/oopsyraidsy/data/04-sb/raid/o4s.js
@@ -18,21 +18,21 @@ export default {
     {
       id: 'O4S2 Decisive Battle',
       netRegex: NetRegexes.ability({ id: '2408', capture: false }),
-      run: (_e, data) => {
+      run: (data) => {
         data.isDecisiveBattleElement = true;
       },
     },
     {
       id: 'O4S1 Vacuum Wave',
       netRegex: NetRegexes.ability({ id: '23FE', capture: false }),
-      run: (_e, data) => {
+      run: (data) => {
         data.isDecisiveBattleElement = false;
       },
     },
     {
       id: 'O4S2 Almagest',
       netRegex: NetRegexes.ability({ id: '2417', capture: false }),
-      run: (_e, data) => {
+      run: (data) => {
         data.isNeoExdeath = true;
       },
     },
@@ -40,8 +40,8 @@ export default {
       id: 'O4S2 Blizzard III',
       netRegex: NetRegexes.abilityFull({ id: '23F8', ...playerDamageFields }),
       // Ignore unavoidable raid aoe Blizzard III.
-      condition: (_e, data) => !data.isDecisiveBattleElement,
-      mistake: (_e, _data, matches) => {
+      condition: (data) => !data.isDecisiveBattleElement,
+      mistake: (_data, matches) => {
         return { type: 'warn', blame: matches.target, text: matches.abilityName };
       },
     },
@@ -49,15 +49,15 @@ export default {
       id: 'O4S2 Thunder III',
       netRegex: NetRegexes.abilityFull({ id: '23FD', ...playerDamageFields }),
       // Only consider this during random mechanic after decisive battle.
-      condition: (_e, data) => data.isDecisiveBattleElement,
-      mistake: (_e, _data, matches) => {
+      condition: (data) => data.isDecisiveBattleElement,
+      mistake: (_data, matches) => {
         return { type: 'warn', blame: matches.target, text: matches.abilityName };
       },
     },
     {
       id: 'O4S2 Petrified',
       netRegex: NetRegexes.gainsEffect({ effectId: '262' }),
-      mistake: (_e, data, matches) => {
+      mistake: (data, matches) => {
         // On Neo, being petrified is because you looked at Shriek, so your fault.
         if (data.isNeoExdeath)
           return { type: 'fail', blame: matches.target, text: matches.effect };
@@ -68,14 +68,14 @@ export default {
     {
       id: 'O4S2 Forked Lightning',
       netRegex: NetRegexes.abilityFull({ id: '242E', ...playerDamageFields }),
-      mistake: (_e, _data, matches) => {
+      mistake: (_data, matches) => {
         return { type: 'fail', blame: matches.target, text: matches.ability };
       },
     },
     {
       id: 'O4S2 Beyond Death Gain',
       netRegex: NetRegexes.gainsEffect({ effectId: '566' }),
-      run: (_e, data, matches) => {
+      run: (data, matches) => {
         data.hasBeyondDeath = data.hasBeyondDeath || {};
         data.hasBeyondDeath[matches.target] = true;
       },
@@ -83,7 +83,7 @@ export default {
     {
       id: 'O4S2 Beyond Death Lose',
       netRegex: NetRegexes.losesEffect({ effectId: '566' }),
-      run: (_e, data, matches) => {
+      run: (data, matches) => {
         data.hasBeyondDeath = data.hasBeyondDeath || {};
         data.hasBeyondDeath[matches.target] = false;
       },
@@ -91,8 +91,8 @@ export default {
     {
       id: 'O4S2 Beyond Death',
       netRegex: NetRegexes.gainsEffect({ effectId: '566' }),
-      delaySeconds: (_e, _data, matches) => parseFloat(matches.duration) - 0.5,
-      deathReason: (_e, data, matches) => {
+      delaySeconds: (_data, matches) => parseFloat(matches.duration) - 0.5,
+      deathReason: (data, matches) => {
         if (!data.hasBeyondDeath)
           return;
         if (!data.hasBeyondDeath[matches.target])
@@ -106,7 +106,7 @@ export default {
     {
       id: 'O4S2 Double Attack Collect',
       netRegex: NetRegexes.abilityFull({ id: '241C', ...playerDamageFields }),
-      run: (_e, data, matches) => {
+      run: (data, matches) => {
         data.doubleAttackMatches = data.doubleAttackMatches || [];
         data.doubleAttackMatches.push(matches);
       },
@@ -114,7 +114,7 @@ export default {
     {
       id: 'O4S2 Double Attack',
       netRegex: NetRegexes.abilityFull({ id: '241C', ...playerDamageFields }),
-      mistake: (_e, data) => {
+      mistake: (data) => {
         const arr = data.doubleAttackMatches;
         if (!arr)
           return;
@@ -124,7 +124,7 @@ export default {
         // it should never hit 3 people.
         return { type: 'fail', fullText: `${arr[0].ability} x ${arr.length}` };
       },
-      run: (_e, data) => delete data.doubleAttackMatches,
+      run: (data) => delete data.doubleAttackMatches,
     },
   ],
 };

--- a/ui/oopsyraidsy/data/04-sb/raid/o7s.js
+++ b/ui/oopsyraidsy/data/04-sb/raid/o7s.js
@@ -15,7 +15,7 @@ export default {
     {
       id: 'O7S Stoneskin',
       netRegex: NetRegexes.ability({ id: '2AB5' }),
-      mistake: (_e, _data, matches) => {
+      mistake: (_data, matches) => {
         return { type: 'fail', blame: matches.source, text: matches.ability };
       },
     },

--- a/ui/oopsyraidsy/data/04-sb/trial/byakko-ex.js
+++ b/ui/oopsyraidsy/data/04-sb/trial/byakko-ex.js
@@ -27,7 +27,7 @@ export default {
       // Pink bubble collision
       id: 'ByaEx Ominous Wind',
       netRegex: NetRegexes.abilityFull({ id: '27EC', ...playerDamageFields }),
-      mistake: (_e, _data, matches) => {
+      mistake: (_data, matches) => {
         return {
           type: 'warn',
           blame: matches.target,

--- a/ui/oopsyraidsy/data/04-sb/trial/shinryu.js
+++ b/ui/oopsyraidsy/data/04-sb/trial/shinryu.js
@@ -26,7 +26,7 @@ export default {
       id: 'Shinryu Diamond Dust',
       // Thin Ice
       netRegex: NetRegexes.gainsEffect({ effectId: '38F' }),
-      deathReason: (_e, _data, matches) => {
+      deathReason: (_data, matches) => {
         return {
           type: 'fail',
           name: matches.target,
@@ -43,7 +43,7 @@ export default {
     {
       id: 'Shinryu Tidal Wave',
       netRegex: NetRegexes.abilityFull({ id: '1F8B', ...playerDamageFields }),
-      deathReason: (_e, _data, matches) => {
+      deathReason: (_data, matches) => {
         return {
           type: 'fail',
           name: matches.target,
@@ -61,7 +61,7 @@ export default {
       // Knockback from center.
       id: 'Shinryu Aerial Blast',
       netRegex: NetRegexes.abilityFull({ id: '1F90', ...playerDamageFields }),
-      deathReason: (_e, _data, matches) => {
+      deathReason: (_data, matches) => {
         return {
           type: 'fail',
           name: matches.target,

--- a/ui/oopsyraidsy/data/04-sb/ultimate/ultima_weapon_ultimate.js
+++ b/ui/oopsyraidsy/data/04-sb/ultimate/ultima_weapon_ultimate.js
@@ -24,7 +24,7 @@ export default {
       id: 'UWU Windburn',
       netRegex: NetRegexes.gainsEffect({ effectId: 'EB' }),
       suppressSeconds: 2,
-      mistake: (_e, _data, matches) => {
+      mistake: (_data, matches) => {
         return { type: 'warn', blame: matches.target, text: matches.effect };
       },
     },
@@ -34,7 +34,7 @@ export default {
       id: 'UWU Featherlance',
       netRegex: NetRegexes.abilityFull({ id: '2B43', ...playerDamageFields }),
       suppressSeconds: 5,
-      mistake: (_e, _data, matches) => {
+      mistake: (_data, matches) => {
         return { type: 'fail', blame: matches.target, text: matches.source };
       },
     },

--- a/ui/oopsyraidsy/data/04-sb/ultimate/unending_coil_ultimate.js
+++ b/ui/oopsyraidsy/data/04-sb/ultimate/unending_coil_ultimate.js
@@ -19,7 +19,7 @@ export default {
       // from the explosion damage you take when somebody else
       // pops one.
       netRegex: NetRegexes.abilityFull({ id: '26AB', ...playerDamageFields, flags: kFlagInstantDeath }),
-      mistake: (_e, _data, matches) => {
+      mistake: (_data, matches) => {
         return {
           type: 'fail',
           blame: matches.target,
@@ -37,7 +37,7 @@ export default {
     {
       id: 'UCU Thermionic Burst',
       netRegex: NetRegexes.abilityFull({ id: '26B9', ...playerDamageFields }),
-      mistake: (_e, _data, matches) => {
+      mistake: (_data, matches) => {
         return {
           type: 'fail',
           blame: matches.target,
@@ -55,7 +55,7 @@ export default {
     {
       id: 'UCU Chain Lightning',
       netRegex: NetRegexes.abilityFull({ id: '26C8', ...playerDamageFields }),
-      mistake: (_e, _data, matches) => {
+      mistake: (_data, matches) => {
         // It's hard to assign blame for lightning.  The debuffs
         // go out and then explode in order, but the attacker is
         // the dragon and not the player.
@@ -76,21 +76,21 @@ export default {
     {
       id: 'UCU Burns',
       netRegex: NetRegexes.gainsEffect({ effectId: 'FA' }),
-      mistake: (_e, _data, matches) => {
+      mistake: (_data, matches) => {
         return { type: 'warn', blame: matches.target, text: matches.effect };
       },
     },
     {
       id: 'UCU Sludge',
       netRegex: NetRegexes.gainsEffect({ effectId: '11F' }),
-      mistake: (_e, _data, matches) => {
+      mistake: (_data, matches) => {
         return { type: 'fail', blame: matches.target, text: matches.effect };
       },
     },
     {
       id: 'UCU Doom Gain',
       netRegex: NetRegexes.gainsEffect({ effectId: 'D2' }),
-      run: (_e, data, matches) => {
+      run: (data, matches) => {
         data.hasDoom = data.hasDoom || {};
         data.hasDoom[matches.target] = true;
       },
@@ -98,7 +98,7 @@ export default {
     {
       id: 'UCU Doom Lose',
       netRegex: NetRegexes.losesEffect({ effectId: 'D2' }),
-      run: (_e, data, matches) => {
+      run: (data, matches) => {
         data.hasDoom = data.hasDoom || {};
         data.hasDoom[matches.target] = false;
       },
@@ -118,8 +118,8 @@ export default {
       // but what can you do.
       id: 'UCU Doom Death',
       netRegex: NetRegexes.gainsEffect({ effectId: 'D2' }),
-      delaySeconds: (_e, _data, matches) => parseFloat(matches.duration) - 1,
-      deathReason: (_e, data, matches) => {
+      delaySeconds: (_data, matches) => parseFloat(matches.duration) - 1,
+      deathReason: (data, matches) => {
         if (!data.hasDoom || !data.hasDoom[matches.target])
           return;
         let reason;

--- a/ui/oopsyraidsy/data/05-shb/alliance/the_tower_at_paradigms_breach.js
+++ b/ui/oopsyraidsy/data/05-shb/alliance/the_tower_at_paradigms_breach.js
@@ -86,7 +86,7 @@ export default {
       // 5EB1 = Knave Lunge
       // 5BF2 = Her Infloresence Shockwave
       netRegex: NetRegexes.ability({ id: ['5EB1', '5BF2'] }),
-      deathReason: (_e, _data, matches) => {
+      deathReason: (_data, matches) => {
         return {
           type: 'fail',
           name: matches.target,

--- a/ui/oopsyraidsy/data/05-shb/dungeon/dohn_mheg.js
+++ b/ui/oopsyraidsy/data/05-shb/dungeon/dohn_mheg.js
@@ -24,21 +24,21 @@ export default {
     {
       id: 'Dohn Mheg Imp Choir',
       netRegex: NetRegexes.gainsEffect({ effectId: '46E' }),
-      mistake: (_e, _data, matches) => {
+      mistake: (_data, matches) => {
         return { type: 'warn', blame: matches.target, text: matches.effect };
       },
     },
     {
       id: 'Dohn Mheg Toad Choir',
       netRegex: NetRegexes.gainsEffect({ effectId: '1B7' }),
-      mistake: (_e, _data, matches) => {
+      mistake: (_data, matches) => {
         return { type: 'warn', blame: matches.target, text: matches.effect };
       },
     },
     {
       id: 'Dohn Mheg Fool\'s Tumble',
       netRegex: NetRegexes.gainsEffect({ effectId: '183' }),
-      mistake: (_e, _data, matches) => {
+      mistake: (_data, matches) => {
         return { type: 'warn', blame: matches.target, text: matches.effect };
       },
     },

--- a/ui/oopsyraidsy/data/05-shb/dungeon/heroes_gauntlet.js
+++ b/ui/oopsyraidsy/data/05-shb/dungeon/heroes_gauntlet.js
@@ -57,8 +57,8 @@ export default {
       id: 'THG Wild Rampage',
       netRegex: NetRegexes.abilityFull({ id: '5207', ...playerDamageFields }),
       // This is zero damage if you are in the crater.
-      condition: (_e, data, matches) => data.DamageFromMatches(matches) > 0,
-      mistake: (_e, _data, matches) => {
+      condition: (data, matches) => data.DamageFromMatches(matches) > 0,
+      mistake: (_data, matches) => {
         return { type: 'fail', blame: matches.target, text: matches.ability };
       },
     },

--- a/ui/oopsyraidsy/data/05-shb/eureka/delubrum_reginae.js
+++ b/ui/oopsyraidsy/data/05-shb/eureka/delubrum_reginae.js
@@ -80,8 +80,8 @@ export default {
       // and the first explosion "hits" everyone, although with "1B" flags.
       id: 'Delubrum Lots Cast',
       netRegex: NetRegexes.abilityFull({ id: ['565A', '565B', '57FD', '57FE', '5B86', '5B87', '59D2', '5D93'], ...playerDamageFields }),
-      condition: (_e, _data, matches) => matches.flags.slice(-2) === '03',
-      mistake: (_e, _data, matches) => {
+      condition: (_data, matches) => matches.flags.slice(-2) === '03',
+      mistake: (_data, matches) => {
         return { type: 'warn', blame: matches.target, text: matches.ability };
       },
     },

--- a/ui/oopsyraidsy/data/05-shb/eureka/delubrum_reginae_savage.js
+++ b/ui/oopsyraidsy/data/05-shb/eureka/delubrum_reginae_savage.js
@@ -135,22 +135,22 @@ export default {
       // These ability ids can be ordered differently and "hit" people when levitating.
       id: 'DelubrumSav Guard Lots Cast',
       netRegex: NetRegexes.abilityFull({ id: ['5827', '5828', '5B6C', '5B6D', '5BB6', '5BB7', '5B88', '5B89'], ...playerDamageFields }),
-      condition: (_e, _data, matches) => matches.flags.slice(-2) === '03',
-      mistake: (_e, _data, matches) => {
+      condition: (_data, matches) => matches.flags.slice(-2) === '03',
+      mistake: (_data, matches) => {
         return { type: 'warn', blame: matches.target, text: matches.ability };
       },
     },
     {
       id: 'DelubrumSav Golem Compaction',
       netRegex: NetRegexes.ability({ id: '5746' }),
-      mistake: (_e, _data, matches) => {
+      mistake: (_data, matches) => {
         return { type: 'fail', fullText: `${matches.source}: ${matches.ability}` };
       },
     },
     {
       id: 'DelubrumSav Slime Sanguine Fusion',
       netRegex: NetRegexes.ability({ id: '554D' }),
-      mistake: (_e, _data, matches) => {
+      mistake: (_data, matches) => {
         return { type: 'fail', fullText: `${matches.source}: ${matches.ability}` };
       },
     },

--- a/ui/oopsyraidsy/data/05-shb/raid/e10s.js
+++ b/ui/oopsyraidsy/data/05-shb/raid/e10s.js
@@ -44,7 +44,7 @@ export default {
       netRegexDe: NetRegexes.gainsEffect({ source: 'Schattenflamme', effectId: '82C' }),
       netRegexFr: NetRegexes.gainsEffect({ source: 'Flamme ombrale', effectId: '82C' }),
       netRegexJa: NetRegexes.gainsEffect({ source: 'シャドウフレイム', effectId: '82C' }),
-      mistake: (_e, _data, matches) => {
+      mistake: (_data, matches) => {
         return { type: 'damage', blame: matches.target, text: `${matches.effect} (partial stack)` };
       },
     },
@@ -58,7 +58,7 @@ export default {
       netRegexDe: NetRegexes.gainsEffect({ source: 'Schattenkönig', effectId: '82C' }),
       netRegexFr: NetRegexes.gainsEffect({ source: 'Roi De L\'Ombre', effectId: '82C' }),
       netRegexJa: NetRegexes.gainsEffect({ source: '影の王', effectId: '82C' }),
-      mistake: (_e, _data, matches) => {
+      mistake: (_data, matches) => {
         return { type: 'damage', blame: matches.target, text: `${matches.effect}` };
       },
     },
@@ -67,8 +67,8 @@ export default {
       // This can be mitigated by the whole group, so add a damage condition.
       id: 'E10S Barbs Of Agony',
       netRegex: NetRegexes.abilityFull({ id: ['572A', '5B27'], ...playerDamageFields }),
-      condition: (_e, data, matches) => data.DamageFromMatches(matches) > 0,
-      mistake: (_e, _data, matches) => {
+      condition: (data, matches) => data.DamageFromMatches(matches) > 0,
+      mistake: (_data, matches) => {
         return { type: 'warn', blame: matches.target, text: matches.ability };
       },
     },

--- a/ui/oopsyraidsy/data/05-shb/raid/e11n.js
+++ b/ui/oopsyraidsy/data/05-shb/raid/e11n.js
@@ -28,7 +28,7 @@ export default {
       // 562D = Burnt Strike fire followup during most of the fight
       // 5644 = same thing, but from Fatebreaker's Image
       netRegex: NetRegexes.ability({ id: ['562D', '5644'] }),
-      deathReason: (_e, _data, matches) => {
+      deathReason: (_data, matches) => {
         return {
           type: 'fail',
           name: matches.target,

--- a/ui/oopsyraidsy/data/05-shb/raid/e11s.js
+++ b/ui/oopsyraidsy/data/05-shb/raid/e11s.js
@@ -54,7 +54,7 @@ export default {
       // 567A = same thing, but from Fatebreaker's Image
       // 568F = same thing, but during Cycle of Faith
       netRegex: NetRegexes.ability({ id: ['5653', '567A', '568F'] }),
-      deathReason: (_e, _data, matches) => {
+      deathReason: (_data, matches) => {
         return {
           type: 'fail',
           name: matches.target,

--- a/ui/oopsyraidsy/data/05-shb/raid/e12s.js
+++ b/ui/oopsyraidsy/data/05-shb/raid/e12s.js
@@ -70,15 +70,15 @@ export default {
       // This can be shielded through as long as that person doesn't stack.
       id: 'E12S Icicle Impact',
       netRegex: NetRegexes.abilityFull({ id: '4E5A', ...playerDamageFields }),
-      condition: (_e, data, matches) => data.DamageFromMatches(matches) > 0,
-      mistake: (_e, _data, matches) => {
+      condition: (data, matches) => data.DamageFromMatches(matches) > 0,
+      mistake: (_data, matches) => {
         return { type: 'warn', blame: matches.target, text: matches.ability };
       },
     },
     {
       id: 'E12S Headmarker',
       netRegex: NetRegexes.headMarker({}),
-      run: (_e, data, matches) => {
+      run: (data, matches) => {
         const id = getHeadmarkerId(data, matches);
         const firstLaserMarker = '0091';
         const lastLaserMarker = '0098';
@@ -97,7 +97,7 @@ export default {
       // use the "Classical Sculpture" ability and end up on the arena for real.
       id: 'E12S Promise Chiseled Sculpture Classical Sculpture',
       netRegex: NetRegexes.abilityFull({ source: 'Chiseled Sculpture', id: '58B2' }),
-      run: (_e, data, matches) => {
+      run: (data, matches) => {
         // This will run per person that gets hit by the same sculpture, but that's fine.
         // Record the y position of each sculpture so we can use it for better text later.
         data.sculptureYPositions = data.sculptureYPositions || {};
@@ -108,7 +108,7 @@ export default {
       // The source of the tether is the player, the target is the sculpture.
       id: 'E12S Promise Chiseled Sculpture Tether',
       netRegex: NetRegexes.tether({ target: 'Chiseled Sculpture', id: '0011' }),
-      run: (_e, data, matches) => {
+      run: (data, matches) => {
         data.sculptureTetherNameToId = data.sculptureTetherNameToId || {};
         data.sculptureTetherNameToId[matches.source] = matches.targetId.toUpperCase();
       },
@@ -118,7 +118,7 @@ export default {
       netRegex: NetRegexes.ability({ source: 'Chiseled Sculpture', id: '58B3' }),
       delaySeconds: 1,
       suppressSeconds: 1,
-      run: (_e, data) => {
+      run: (data) => {
         data.bladeOfFlameCount = data.bladeOfFlameCount || 0;
         data.bladeOfFlameCount++;
       },
@@ -127,7 +127,7 @@ export default {
       // This is the Chiseled Sculpture laser with the limit cut dots.
       id: 'E12S Promise Blade Of Flame',
       netRegex: NetRegexes.ability({ type: '22', source: 'Chiseled Sculpture', id: '58B3' }),
-      mistake: (_e, data, matches) => {
+      mistake: (data, matches) => {
         if (!data.laserNameToNum || !data.sculptureTetherNameToId || !data.sculptureYPositions)
           return;
 
@@ -204,7 +204,7 @@ export default {
     {
       id: 'E12S Promise Ice Pillar Tracker',
       netRegex: NetRegexes.tether({ source: 'Ice Pillar', id: ['0001', '0039'] }),
-      run: (_e, data, matches) => {
+      run: (data, matches) => {
         data.pillarIdToOwner = data.pillarIdToOwner || {};
         data.pillarIdToOwner[matches.sourceId] = matches.target;
       },
@@ -212,12 +212,12 @@ export default {
     {
       id: 'E12S Promise Ice Pillar Mistake',
       netRegex: NetRegexes.ability({ source: 'Ice Pillar', id: '589B' }),
-      condition: (_e, data, matches) => {
+      condition: (data, matches) => {
         if (!data.pillarIdToOwner)
           return false;
         return matches.target !== data.pillarIdToOwner[matches.sourceId];
       },
-      mistake: (_e, data, matches) => {
+      mistake: (data, matches) => {
         const pillarOwner = data.ShortName(data.pillarIdToOwner[matches.sourceId]);
         return {
           type: 'fail',
@@ -237,7 +237,7 @@ export default {
       id: 'E12S Promise Gain Fire Resistance Down II',
       // The Beastly Sculpture gives a 3 second debuff, the Regal Sculpture gives a 14s one.
       netRegex: NetRegexes.gainsEffect({ effectId: '832' }),
-      run: (_e, data, matches) => {
+      run: (data, matches) => {
         data.fire = data.fire || {};
         data.fire[matches.target] = true;
       },
@@ -245,7 +245,7 @@ export default {
     {
       id: 'E12S Promise Lose Fire Resistance Down II',
       netRegex: NetRegexes.losesEffect({ effectId: '832' }),
-      run: (_e, data, matches) => {
+      run: (data, matches) => {
         data.fire = data.fire || {};
         data.fire[matches.target] = false;
       },
@@ -256,7 +256,7 @@ export default {
       netRegexDe: NetRegexes.tether({ source: 'Abbild Eines Löwen', id: '0011' }),
       netRegexFr: NetRegexes.tether({ source: 'Création Léonine', id: '0011' }),
       netRegexJa: NetRegexes.tether({ source: '創られた獅子', id: '0011' }),
-      run: (_e, data, matches) => {
+      run: (data, matches) => {
         data.smallLionIdToOwner = data.smallLionIdToOwner || {};
         data.smallLionIdToOwner[matches.sourceId.toUpperCase()] = matches.target;
         data.smallLionOwners = data.smallLionOwners || [];
@@ -269,7 +269,7 @@ export default {
       netRegexDe: NetRegexes.abilityFull({ source: 'Abbild Eines Löwen', id: '58B9' }),
       netRegexFr: NetRegexes.abilityFull({ source: 'Création Léonine', id: '58B9' }),
       netRegexJa: NetRegexes.abilityFull({ source: '創られた獅子', id: '58B9' }),
-      mistake: (_e, data, matches) => {
+      mistake: (data, matches) => {
         // Folks baiting the big lion second can take the first small lion hit,
         // so it's not sufficient to check only the owner.
         if (!data.smallLionOwners)
@@ -323,7 +323,7 @@ export default {
     {
       id: 'E12S Promise North Big Lion',
       netRegex: NetRegexes.addedCombatantFull({ name: 'Regal Sculpture' }),
-      run: (_e, data, matches) => {
+      run: (data, matches) => {
         const y = parseFloat(matches.y);
         const centerY = -75;
         if (y < centerY)
@@ -336,7 +336,7 @@ export default {
       netRegexDe: NetRegexes.ability({ source: 'Abbild eines großen Löwen', id: '4F9E' }),
       netRegexFr: NetRegexes.ability({ source: 'création léonine royale', id: '4F9E' }),
       netRegexJa: NetRegexes.ability({ source: '創られた獅子王', id: '4F9E' }),
-      mistake: (_e, data, matches) => {
+      mistake: (data, matches) => {
         const singleTarget = matches.type === '21';
         const hasFireDebuff = data.fire && data.fire[matches.target];
 
@@ -401,7 +401,7 @@ export default {
       // 58B7 = Laser Eye (promise lion phase)
       // 58C1 = Darkest Dance (oracle tank jump + knockback in beginning and triple apoc)
       netRegex: NetRegexes.ability({ id: ['589A', '58B6', '58B7', '58C1'] }),
-      deathReason: (_e, _data, matches) => {
+      deathReason: (_data, matches) => {
         return {
           type: 'fail',
           name: matches.target,
@@ -419,8 +419,8 @@ export default {
     {
       id: 'E12S Oracle Shadoweye',
       netRegex: NetRegexes.abilityFull({ id: '58D2', ...playerDamageFields }),
-      condition: (_e, data, matches) => data.DamageFromMatches(matches) > 0,
-      mistake: (_e, _data, matches) => {
+      condition: (data, matches) => data.DamageFromMatches(matches) > 0,
+      mistake: (_data, matches) => {
         return { type: 'fail', blame: matches.target, text: matches.ability };
       },
     },

--- a/ui/oopsyraidsy/data/05-shb/raid/e2n.js
+++ b/ui/oopsyraidsy/data/05-shb/raid/e2n.js
@@ -18,7 +18,7 @@ export default {
     {
       id: 'E2N Nyx',
       netRegex: NetRegexes.abilityFull({ id: '3E3D', ...playerDamageFields }),
-      mistake: (_e, _data, matches) => {
+      mistake: (_data, matches) => {
         return {
           type: 'warn',
           blame: matches.target,

--- a/ui/oopsyraidsy/data/05-shb/raid/e2s.js
+++ b/ui/oopsyraidsy/data/05-shb/raid/e2s.js
@@ -23,14 +23,14 @@ export default {
       id: 'E2S Shadoweye',
       // Stone Curse
       netRegex: NetRegexes.gainsEffect({ effectId: '589' }),
-      mistake: (_e, _data, matches) => {
+      mistake: (_data, matches) => {
         return { type: 'fail', blame: matches.target, text: matches.effect };
       },
     },
     {
       id: 'E2S Nyx',
       netRegex: NetRegexes.abilityFull({ id: '3E51', ...playerDamageFields }),
-      mistake: (_e, _data, matches) => {
+      mistake: (_data, matches) => {
         return {
           type: 'warn',
           blame: matches.target,

--- a/ui/oopsyraidsy/data/05-shb/raid/e4s.js
+++ b/ui/oopsyraidsy/data/05-shb/raid/e4s.js
@@ -37,15 +37,15 @@ export default {
       netRegexJa: NetRegexes.startsUsing({ id: '411E', source: 'タイタン' }),
       netRegexCn: NetRegexes.startsUsing({ id: '411E', source: '泰坦' }),
       netRegexKo: NetRegexes.startsUsing({ id: '411E', source: '타이탄' }),
-      run: (_e, data, matches) => {
+      run: (data, matches) => {
         data.faultLineTarget = matches.target;
       },
     },
     {
       id: 'E4S Fault Line',
       netRegex: NetRegexes.abilityFull({ id: '411E', ...playerDamageFields }),
-      condition: (_e, data, matches) => data.faultLineTarget !== matches.target,
-      mistake: (_e, _data, matches) => {
+      condition: (data, matches) => data.faultLineTarget !== matches.target,
+      mistake: (_data, matches) => {
         return {
           type: 'fail',
           blame: matches.target,

--- a/ui/oopsyraidsy/data/05-shb/raid/e5n.js
+++ b/ui/oopsyraidsy/data/05-shb/raid/e5n.js
@@ -20,7 +20,7 @@ export default {
       // This happens when a player gets 4+ stacks of orbs. Don't be greedy!
       id: 'E5N Static Condensation',
       netRegex: NetRegexes.gainsEffect({ effectId: '8B5' }),
-      mistake: (_e, _data, matches) => {
+      mistake: (_data, matches) => {
         return { type: 'warn', blame: matches.target, text: matches.effect };
       },
     },
@@ -28,7 +28,7 @@ export default {
       // Helper for orb pickup failures
       id: 'E5N Orb Gain',
       netRegex: NetRegexes.gainsEffect({ effectId: '8B4' }),
-      run: (_e, data, matches) => {
+      run: (data, matches) => {
         data.hasOrb = data.hasOrb || {};
         data.hasOrb[matches.target] = true;
       },
@@ -36,7 +36,7 @@ export default {
     {
       id: 'E5N Orb Lose',
       netRegex: NetRegexes.losesEffect({ effectId: '8B4' }),
-      run: (_e, data, matches) => {
+      run: (data, matches) => {
         data.hasOrb = data.hasOrb || {};
         data.hasOrb[matches.target] = false;
       },
@@ -44,8 +44,8 @@ export default {
     {
       id: 'E5N Divine Judgement Volts',
       netRegex: NetRegexes.abilityFull({ id: '4B9A', ...playerDamageFields }),
-      condition: (_e, data, matches) => !data.hasOrb[matches.target],
-      mistake: (_e, _data, matches) => {
+      condition: (data, matches) => !data.hasOrb[matches.target],
+      mistake: (_data, matches) => {
         return {
           type: 'fail',
           blame: matches.target,
@@ -62,7 +62,7 @@ export default {
     {
       id: 'E5N Stormcloud Target Tracking',
       netRegex: NetRegexes.headMarker({ id: '006E' }),
-      run: (_e, data, matches) => {
+      run: (data, matches) => {
         data.cloudMarkers = data.cloudMarkers || [];
         data.cloudMarkers.push(matches.target);
       },
@@ -72,7 +72,7 @@ export default {
       id: 'E5N The Parting Clouds',
       netRegex: NetRegexes.abilityFull({ id: '4B9D', ...playerDamageFields }),
       suppressSeconds: 30,
-      mistake: (_e, data, matches) => {
+      mistake: (data, matches) => {
         for (const m of data.cloudMarkers) {
           return {
             type: 'fail',
@@ -92,7 +92,7 @@ export default {
       id: 'E5N Stormcloud cleanup',
       netRegex: NetRegexes.headMarker({ id: '006E' }),
       delaySeconds: 30, // Stormclouds resolve well before this.
-      run: (_e, data) => {
+      run: (data) => {
         delete data.cloudMarkers;
       },
     },

--- a/ui/oopsyraidsy/data/05-shb/raid/e5s.js
+++ b/ui/oopsyraidsy/data/05-shb/raid/e5s.js
@@ -41,7 +41,7 @@ export default {
       // Helper for orb pickup failures
       id: 'E5S Orb Gain',
       netRegex: NetRegexes.gainsEffect({ effectId: '8B4' }),
-      run: (_e, data, matches) => {
+      run: (data, matches) => {
         data.hasOrb = data.hasOrb || {};
         data.hasOrb[matches.target] = true;
       },
@@ -49,7 +49,7 @@ export default {
     {
       id: 'E5S Orb Lose',
       netRegex: NetRegexes.losesEffect({ effectId: '8B4' }),
-      run: (_e, data, matches) => {
+      run: (data, matches) => {
         data.hasOrb = data.hasOrb || {};
         data.hasOrb[matches.target] = false;
       },
@@ -57,31 +57,31 @@ export default {
     {
       id: 'E5S Divine Judgement Volts',
       netRegex: NetRegexes.abilityFull({ id: '4BB7', ...playerDamageFields }),
-      condition: (_e, data, matches) => !data.hasOrb || !data.hasOrb[matches.target],
-      mistake: (_e, _data, matches) => {
+      condition: (data, matches) => !data.hasOrb || !data.hasOrb[matches.target],
+      mistake: (_data, matches) => {
         return { type: 'fail', blame: matches.target, text: noOrb(matches.ability) };
       },
     },
     {
       id: 'E5S Volt Strike Orb',
       netRegex: NetRegexes.abilityFull({ id: '4BC3', ...playerDamageFields }),
-      condition: (_e, data, matches) => !data.hasOrb || !data.hasOrb[matches.target],
-      mistake: (_e, _data, matches) => {
+      condition: (data, matches) => !data.hasOrb || !data.hasOrb[matches.target],
+      mistake: (_data, matches) => {
         return { type: 'fail', blame: matches.target, text: noOrb(matches.ability) };
       },
     },
     {
       id: 'E5S Deadly Discharge Big Knockback',
       netRegex: NetRegexes.abilityFull({ id: '4BB2', ...playerDamageFields }),
-      condition: (_e, data, matches) => !data.hasOrb || !data.hasOrb[matches.target],
-      mistake: (_e, _data, matches) => {
+      condition: (data, matches) => !data.hasOrb || !data.hasOrb[matches.target],
+      mistake: (_data, matches) => {
         return { type: 'fail', blame: matches.target, text: noOrb(matches.ability) };
       },
     },
     {
       id: 'E5S Lightning Bolt',
       netRegex: NetRegexes.abilityFull({ id: '4BB9', ...playerDamageFields }),
-      condition: (_e, data, matches) => {
+      condition: (data, matches) => {
         // Having a non-idempotent condition function is a bit <_<
         // Only consider lightning bolt damage if you have a debuff to clear.
         if (!data.hated || !data.hated[matches.target])
@@ -90,14 +90,14 @@ export default {
         delete data.hated[matches.target];
         return false;
       },
-      mistake: (_e, _data, matches) => {
+      mistake: (_data, matches) => {
         return { type: 'warn', blame: matches.target, text: matches.ability };
       },
     },
     {
       id: 'E5S Hated of Levin',
       netRegex: NetRegexes.headMarker({ id: '00D2' }),
-      run: (_e, data, matches) => {
+      run: (data, matches) => {
         data.hated = data.hated || {};
         data.hated[matches.target] = true;
       },
@@ -105,7 +105,7 @@ export default {
     {
       id: 'E5S Stormcloud Target Tracking',
       netRegex: NetRegexes.headMarker({ id: '006E' }),
-      run: (_e, data, matches) => {
+      run: (data, matches) => {
         data.cloudMarkers = data.cloudMarkers || [];
         data.cloudMarkers.push(matches.target);
       },
@@ -115,7 +115,7 @@ export default {
       id: 'E5S The Parting Clouds',
       netRegex: NetRegexes.abilityFull({ id: '4BBA', ...playerDamageFields }),
       suppressSeconds: 30,
-      mistake: (_e, data, matches) => {
+      mistake: (data, matches) => {
         for (const m of data.cloudMarkers) {
           return {
             type: 'fail',
@@ -136,7 +136,7 @@ export default {
       netRegex: NetRegexes.headMarker({ id: '006E' }),
       // Stormclouds resolve well before this.
       delaySeconds: 30,
-      run: (_e, data) => {
+      run: (data) => {
         delete data.cloudMarkers;
         delete data.hated;
       },

--- a/ui/oopsyraidsy/data/05-shb/raid/e7n.js
+++ b/ui/oopsyraidsy/data/05-shb/raid/e7n.js
@@ -40,7 +40,7 @@ export default {
     {
       id: 'E7N Astral Effect Gain',
       netRegex: NetRegexes.gainsEffect({ effectId: '8BE' }),
-      run: (_e, data, matches) => {
+      run: (data, matches) => {
         data.hasAstral = data.hasAstral || {};
         data.hasAstral[matches.target] = true;
       },
@@ -48,7 +48,7 @@ export default {
     {
       id: 'E7N Astral Effect Lose',
       netRegex: NetRegexes.losesEffect({ effectId: '8BE' }),
-      run: (_e, data, matches) => {
+      run: (data, matches) => {
         data.hasAstral = data.hasAstral || {};
         data.hasAstral[matches.target] = false;
       },
@@ -56,7 +56,7 @@ export default {
     {
       id: 'E7N Umbral Effect Gain',
       netRegex: NetRegexes.gainsEffect({ effectId: '8BF' }),
-      run: (_e, data, matches) => {
+      run: (data, matches) => {
         data.hasUmbral = data.hasUmbral || {};
         data.hasUmbral[matches.target] = true;
       },
@@ -64,7 +64,7 @@ export default {
     {
       id: 'E7N Umbral Effect Lose',
       netRegex: NetRegexes.losesEffect({ effectId: '8BF' }),
-      run: (_e, data, matches) => {
+      run: (data, matches) => {
         data.hasUmbral = data.hasUmbral || {};
         data.hasUmbral[matches.target] = false;
       },
@@ -72,10 +72,10 @@ export default {
     {
       id: 'E7N Light\'s Course',
       netRegex: NetRegexes.abilityFull({ id: ['4C3E', '4C40', '4C22', '4C3C', '4E63'], ...playerDamageFields }),
-      condition: (_e, data, matches) => {
+      condition: (data, matches) => {
         return !data.hasUmbral || !data.hasUmbral[matches.target];
       },
-      mistake: (_e, data, matches) => {
+      mistake: (data, matches) => {
         if (data.hasAstral && data.hasAstral[matches.target])
           return { type: 'fail', blame: matches.target, text: wrongBuff(matches.ability) };
         return { type: 'warn', blame: matches.target, text: noBuff(matches.ability) };
@@ -84,10 +84,10 @@ export default {
     {
       id: 'E7N Darks\'s Course',
       netRegex: NetRegexes.abilityFull({ id: ['4C3D', '4C23', '4C41', '4C43'], ...playerDamageFields }),
-      condition: (_e, data, matches) => {
+      condition: (data, matches) => {
         return !data.hasAstral || !data.hasAstral[matches.target];
       },
-      mistake: (_e, data, matches) => {
+      mistake: (data, matches) => {
         if (data.hasUmbral && data.hasUmbral[matches.target])
           return { type: 'fail', blame: matches.target, text: wrongBuff(matches.ability) };
         // This case is probably impossible, as the debuff ticks after death,

--- a/ui/oopsyraidsy/data/05-shb/raid/e7s.ts
+++ b/ui/oopsyraidsy/data/05-shb/raid/e7s.ts
@@ -66,7 +66,7 @@ const triggerSet: OopsyTriggerSet<Data> = {
       id: 'E7S Advent Of Light',
       type: 'Ability',
       netRegex: NetRegexes.ability({ id: '4C6E' }),
-      mistake: (_e, _data, matches) => {
+      mistake: (_data, matches) => {
         // TODO: is this blame correct? does this have a target?
         return { type: 'fail', blame: matches.target, text: matches.ability };
       },
@@ -75,7 +75,7 @@ const triggerSet: OopsyTriggerSet<Data> = {
       id: 'E7S Astral Effect Gain',
       type: 'GainsEffect',
       netRegex: NetRegexes.gainsEffect({ effectId: '8BE' }),
-      run: (_e, data, matches) => {
+      run: (data, matches) => {
         data.hasAstral = data.hasAstral || {};
         data.hasAstral[matches.target] = true;
       },
@@ -84,7 +84,7 @@ const triggerSet: OopsyTriggerSet<Data> = {
       id: 'E7S Astral Effect Lose',
       type: 'LosesEffect',
       netRegex: NetRegexes.losesEffect({ effectId: '8BE' }),
-      run: (_e, data, matches) => {
+      run: (data, matches) => {
         data.hasAstral = data.hasAstral || {};
         data.hasAstral[matches.target] = false;
       },
@@ -93,7 +93,7 @@ const triggerSet: OopsyTriggerSet<Data> = {
       id: 'E7S Umbral Effect Gain',
       type: 'GainsEffect',
       netRegex: NetRegexes.gainsEffect({ effectId: '8BF' }),
-      run: (_e, data, matches) => {
+      run: (data, matches) => {
         data.hasUmbral = data.hasUmbral || {};
         data.hasUmbral[matches.target] = true;
       },
@@ -102,7 +102,7 @@ const triggerSet: OopsyTriggerSet<Data> = {
       id: 'E7S Umbral Effect Lose',
       type: 'LosesEffect',
       netRegex: NetRegexes.losesEffect({ effectId: '8BF' }),
-      run: (_e, data, matches) => {
+      run: (data, matches) => {
         data.hasUmbral = data.hasUmbral || {};
         data.hasUmbral[matches.target] = false;
       },
@@ -111,10 +111,10 @@ const triggerSet: OopsyTriggerSet<Data> = {
       id: 'E7S Light\'s Course',
       type: 'Ability',
       netRegex: NetRegexes.abilityFull({ id: ['4C62', '4C63', '4C64', '4C5B', '4C5F'], ...playerDamageFields }),
-      condition: (_e, data, matches) => {
+      condition: (data, matches) => {
         return !data.hasUmbral || !data.hasUmbral[matches.target];
       },
-      mistake: (_e, data, matches) => {
+      mistake: (data, matches) => {
         if (data.hasAstral && data.hasAstral[matches.target])
           return { type: 'fail', blame: matches.target, text: wrongBuff(matches.ability) };
         return { type: 'warn', blame: matches.target, text: noBuff(matches.ability) };
@@ -124,10 +124,10 @@ const triggerSet: OopsyTriggerSet<Data> = {
       id: 'E7S Darks\'s Course',
       type: 'Ability',
       netRegex: NetRegexes.abilityFull({ id: ['4C65', '4C66', '4C67', '4C5A', '4C60'], ...playerDamageFields }),
-      condition: (_e, data, matches) => {
+      condition: (data, matches) => {
         return !data.hasAstral || !data.hasAstral[matches.target];
       },
-      mistake: (_e, data, matches) => {
+      mistake: (data, matches) => {
         if (data.hasUmbral && data.hasUmbral[matches.target])
           return { type: 'fail', blame: matches.target, text: wrongBuff(matches.ability) };
         // This case is probably impossible, as the debuff ticks after death,
@@ -141,7 +141,7 @@ const triggerSet: OopsyTriggerSet<Data> = {
       type: 'Ability',
       // 4C76 is the knockback damage, 4C58 is the damage for standing on the puck.
       netRegex: NetRegexes.abilityFull({ id: '4C76', ...playerDamageFields }),
-      deathReason: (_e, _data, matches) => {
+      deathReason: (_data, matches) => {
         return {
           type: 'fail',
           name: matches.target,

--- a/ui/oopsyraidsy/data/05-shb/raid/e8n.js
+++ b/ui/oopsyraidsy/data/05-shb/raid/e8n.js
@@ -24,14 +24,14 @@ export default {
     {
       id: 'E8N Shining Armor',
       netRegex: NetRegexes.gainsEffect({ effectId: '95' }),
-      mistake: (_e, _data, matches) => {
+      mistake: (_data, matches) => {
         return { type: 'warn', blame: matches.target, text: matches.effect };
       },
     },
     {
       id: 'E8N Heavenly Strike',
       netRegex: NetRegexes.abilityFull({ id: '4DD8', ...playerDamageFields }),
-      deathReason: (_e, _data, matches) => {
+      deathReason: (_data, matches) => {
         return {
           type: 'fail',
           name: matches.target,
@@ -50,7 +50,7 @@ export default {
       id: 'E8N Frost Armor',
       // Thin Ice
       netRegex: NetRegexes.gainsEffect({ effectId: '38F' }),
-      deathReason: (_e, _data, matches) => {
+      deathReason: (_data, matches) => {
         return {
           type: 'fail',
           name: matches.target,

--- a/ui/oopsyraidsy/data/05-shb/raid/e8s.js
+++ b/ui/oopsyraidsy/data/05-shb/raid/e8s.js
@@ -62,7 +62,7 @@ export default {
       id: 'E8S Shining Armor',
       // Stun
       netRegex: NetRegexes.gainsEffect({ effectId: '95' }),
-      mistake: (_e, _data, matches) => {
+      mistake: (_data, matches) => {
         return { type: 'fail', blame: matches.target, text: matches.effect };
       },
     },
@@ -70,7 +70,7 @@ export default {
       // Interrupt
       id: 'E8S Stoneskin',
       netRegex: NetRegexes.ability({ id: '4D85' }),
-      mistake: (_e, _data, matches) => {
+      mistake: (_data, matches) => {
         return { type: 'fail', blame: matches.target, text: matches.ability };
       },
     },

--- a/ui/oopsyraidsy/data/05-shb/raid/e9s.js
+++ b/ui/oopsyraidsy/data/05-shb/raid/e9s.js
@@ -50,8 +50,8 @@ export default {
       // it's ok to still show as a warning??
       id: 'E9S Condensed Anti-Air Particle Beam',
       netRegex: NetRegexes.abilityFull({ type: '22', id: '5615', ...playerDamageFields }),
-      condition: (_e, data, matches) => data.DamageFromMatches(matches) > 0,
-      mistake: (_e, _data, matches) => {
+      condition: (data, matches) => data.DamageFromMatches(matches) > 0,
+      mistake: (_data, matches) => {
         return { type: 'fail', blame: matches.target, text: matches.ability };
       },
     },
@@ -59,8 +59,8 @@ export default {
       // Anti-air "out".  This can be invulned by a tank along with the spread above.
       id: 'E9S Anti-Air Phaser Unlimited',
       netRegex: NetRegexes.abilityFull({ id: '5612', ...playerDamageFields }),
-      condition: (_e, data, matches) => data.DamageFromMatches(matches) > 0,
-      mistake: (_e, _data, matches) => {
+      condition: (data, matches) => data.DamageFromMatches(matches) > 0,
+      mistake: (_data, matches) => {
         return { type: 'warn', blame: matches.target, text: matches.ability };
       },
     },

--- a/ui/oopsyraidsy/data/05-shb/trial/diamond_weapon-ex.js
+++ b/ui/oopsyraidsy/data/05-shb/trial/diamond_weapon-ex.js
@@ -37,7 +37,7 @@ export default {
     {
       id: 'DiamondEx Vertical Cleave Knocked Off',
       netRegex: NetRegexes.ability({ id: '5FD0' }),
-      deathReason: (_e, _data, matches) => {
+      deathReason: (_data, matches) => {
         return {
           type: 'fail',
           name: matches.target,

--- a/ui/oopsyraidsy/data/05-shb/trial/diamond_weapon.js
+++ b/ui/oopsyraidsy/data/05-shb/trial/diamond_weapon.js
@@ -25,7 +25,7 @@ export default {
     {
       id: 'Diamond Weapon Vertical Cleave Knocked Off',
       netRegex: NetRegexes.ability({ id: '5FE5' }),
-      deathReason: (_e, _data, matches) => {
+      deathReason: (_data, matches) => {
         return {
           type: 'fail',
           name: matches.target,

--- a/ui/oopsyraidsy/data/05-shb/trial/emerald_weapon.js
+++ b/ui/oopsyraidsy/data/05-shb/trial/emerald_weapon.js
@@ -33,7 +33,7 @@ export default {
     {
       id: 'Emerald Weapon Emerald Crusher Knocked Off',
       netRegex: NetRegexes.ability({ id: '553E' }),
-      deathReason: (_e, _data, matches) => {
+      deathReason: (_data, matches) => {
         return {
           type: 'fail',
           name: matches.target,
@@ -52,7 +52,7 @@ export default {
       // Getting knocked into a wall from the arrow headmarker.
       id: 'Emerald Weapon Primus Terminus Est Wall',
       netRegex: NetRegexes.ability({ id: ['5563', '5564'] }),
-      deathReason: (_e, _data, matches) => {
+      deathReason: (_data, matches) => {
         return {
           type: 'fail',
           name: matches.target,

--- a/ui/oopsyraidsy/data/05-shb/trial/hades-ex.js
+++ b/ui/oopsyraidsy/data/05-shb/trial/hades-ex.js
@@ -41,7 +41,7 @@ export default {
     {
       id: 'HadesEx Dark II Tether',
       netRegex: NetRegexes.tether({ source: 'Shadow of the Ancients', id: '0011' }),
-      run: (_e, data, matches) => {
+      run: (data, matches) => {
         data.hasDark = data.hasDark || [];
         data.hasDark.push(matches.target);
       },
@@ -50,8 +50,8 @@ export default {
       id: 'HadesEx Dark II',
       netRegex: NetRegexes.abilityFull({ type: '22', id: '47BA', ...playerDamageFields }),
       // Don't blame people who don't have tethers.
-      condition: (_e, data, matches) => data.hasDark && data.hasDark.includes(matches.target),
-      mistake: (_e, _data, matches) => {
+      condition: (data, matches) => data.hasDark && data.hasDark.includes(matches.target),
+      mistake: (_data, matches) => {
         return { type: 'fail', blame: matches.target, text: matches.ability };
       },
     },
@@ -73,15 +73,15 @@ export default {
     {
       id: 'HadesEx Death Shriek',
       netRegex: NetRegexes.abilityFull({ id: '47CB', ...playerDamageFields }),
-      condition: (_e, data, matches) => data.DamageFromMatches(matches) > 0,
-      mistake: (_e, _data, matches) => {
+      condition: (data, matches) => data.DamageFromMatches(matches) > 0,
+      mistake: (_data, matches) => {
         return { type: 'warn', blame: matches.target, text: matches.ability };
       },
     },
     {
       id: 'HadesEx Beyond Death Gain',
       netRegex: NetRegexes.gainsEffect({ effectId: '566' }),
-      run: (_e, data, matches) => {
+      run: (data, matches) => {
         data.hasBeyondDeath = data.hasBeyondDeath || {};
         data.hasBeyondDeath[matches.target] = true;
       },
@@ -89,7 +89,7 @@ export default {
     {
       id: 'HadesEx Beyond Death Lose',
       netRegex: NetRegexes.losesEffect({ effectId: '566' }),
-      run: (_e, data, matches) => {
+      run: (data, matches) => {
         data.hasBeyondDeath = data.hasBeyondDeath || {};
         data.hasBeyondDeath[matches.target] = false;
       },
@@ -97,8 +97,8 @@ export default {
     {
       id: 'HadesEx Beyond Death',
       netRegex: NetRegexes.gainsEffect({ effectId: '566' }),
-      delaySeconds: (_e, _data, matches) => parseFloat(matches.duration) - 0.5,
-      deathReason: (_e, data, matches) => {
+      delaySeconds: (_data, matches) => parseFloat(matches.duration) - 0.5,
+      deathReason: (data, matches) => {
         if (!data.hasBeyondDeath)
           return;
         if (!data.hasBeyondDeath[matches.target])
@@ -112,7 +112,7 @@ export default {
     {
       id: 'HadesEx Doom Gain',
       netRegex: NetRegexes.gainsEffect({ effectId: '6E9' }),
-      run: (_e, data, matches) => {
+      run: (data, matches) => {
         data.hasDoom = data.hasDoom || {};
         data.hasDoom[matches.target] = true;
       },
@@ -120,7 +120,7 @@ export default {
     {
       id: 'HadesEx Doom Lose',
       netRegex: NetRegexes.losesEffect({ effectId: '6E9' }),
-      run: (_e, data, matches) => {
+      run: (data, matches) => {
         data.hasDoom = data.hasDoom || {};
         data.hasDoom[matches.target] = false;
       },
@@ -128,8 +128,8 @@ export default {
     {
       id: 'HadesEx Doom',
       netRegex: NetRegexes.gainsEffect({ effectId: '6E9' }),
-      delaySeconds: (_e, _data, matches) => parseFloat(matches.duration) - 0.5,
-      deathReason: (_e, data, matches) => {
+      delaySeconds: (_data, matches) => parseFloat(matches.duration) - 0.5,
+      deathReason: (data, matches) => {
         if (!data.hasDoom)
           return;
         if (!data.hasDoom[matches.target])

--- a/ui/oopsyraidsy/data/05-shb/trial/levi-un.js
+++ b/ui/oopsyraidsy/data/05-shb/trial/levi-un.js
@@ -35,7 +35,7 @@ export default {
     {
       id: 'LeviUn Body Slam Knocked Off',
       netRegex: NetRegexes.ability({ id: '5CD2' }),
-      deathReason: (_e, _data, matches) => {
+      deathReason: (_data, matches) => {
         return {
           type: 'fail',
           name: matches.target,

--- a/ui/oopsyraidsy/data/05-shb/trial/ruby_weapon-ex.js
+++ b/ui/oopsyraidsy/data/05-shb/trial/ruby_weapon-ex.js
@@ -65,7 +65,7 @@ export default {
     {
       id: 'RubyEx Screech',
       netRegex: NetRegexes.ability({ id: '4AEE' }),
-      deathReason: (_e, _data, matches) => {
+      deathReason: (_data, matches) => {
         return {
           type: 'fail',
           name: matches.target,

--- a/ui/oopsyraidsy/data/05-shb/trial/shiva-un.js
+++ b/ui/oopsyraidsy/data/05-shb/trial/shiva-un.js
@@ -34,11 +34,11 @@ export default {
       // Shiva also uses ability 537A on you, but it has an unknown name.
       // So, use the effect instead for free translation.
       netRegex: NetRegexes.gainsEffect({ effectId: '1E7' }),
-      condition: (_e, _data, matches) => {
+      condition: (_data, matches) => {
         // The intermission also gets this effect, but for a shorter duration.
         return parseFloat(matches.duration) > 20;
       },
-      mistake: (_e, _data, matches) => {
+      mistake: (_data, matches) => {
         return { type: 'fail', blame: matches.target, text: matches.effect };
       },
     },

--- a/ui/oopsyraidsy/data/05-shb/trial/varis-ex.js
+++ b/ui/oopsyraidsy/data/05-shb/trial/varis-ex.js
@@ -35,7 +35,7 @@ export default {
       id: 'VarisEx Terminus Est',
       netRegex: NetRegexes.abilityFull({ id: '4CB4', ...playerDamageFields }),
       suppressSeconds: 1,
-      mistake: (_e, _data, matches) => {
+      mistake: (_data, matches) => {
         return { type: 'warn', blame: matches.target, text: matches.ability };
       },
     },

--- a/ui/oopsyraidsy/data/05-shb/trial/wol-ex.js
+++ b/ui/oopsyraidsy/data/05-shb/trial/wol-ex.js
@@ -35,8 +35,8 @@ export default {
     {
       id: 'WOLEx True Walking Dead',
       netRegex: NetRegexes.gainsEffect({ effectId: '8FF' }),
-      delaySeconds: (_e, _data, matches) => parseFloat(matches.duration) - 0.5,
-      deathReason: (_e, _data, matches) => {
+      delaySeconds: (_data, matches) => parseFloat(matches.duration) - 0.5,
+      deathReason: (_data, matches) => {
         return { type: 'fail', name: matches.target, reason: matches.effect };
       },
     },
@@ -58,7 +58,7 @@ export default {
     {
       id: 'WOLEx True Hallowed Ground',
       netRegex: NetRegexes.ability({ id: '4F44' }),
-      mistake: (_e, _data, matches) => {
+      mistake: (_data, matches) => {
         return { type: 'fail', reason: matches.ability };
       },
     },
@@ -66,7 +66,7 @@ export default {
       // For Berserk and Deep Darkside
       id: 'WOLEx Missed Interrupt',
       netRegex: NetRegexes.ability({ id: ['5156', '5158'] }),
-      mistake: (_e, _data, matches) => {
+      mistake: (_data, matches) => {
         return { type: 'fail', reason: matches.ability };
       },
     },

--- a/ui/oopsyraidsy/data/05-shb/trial/wol.js
+++ b/ui/oopsyraidsy/data/05-shb/trial/wol.js
@@ -31,8 +31,8 @@ export default {
     {
       id: 'WOL True Walking Dead',
       netRegex: NetRegexes.gainsEffect({ effectId: '38E' }),
-      delaySeconds: (_e, _data, matches) => parseFloat(matches.duration) - 0.5,
-      deathReason: (_e, _data, matches) => {
+      delaySeconds: (_data, matches) => parseFloat(matches.duration) - 0.5,
+      deathReason: (_data, matches) => {
         return { type: 'fail', name: matches.target, reason: matches.effect };
       },
     },

--- a/ui/oopsyraidsy/data/05-shb/ultimate/the_epic_of_alexander.js
+++ b/ui/oopsyraidsy/data/05-shb/ultimate/the_epic_of_alexander.js
@@ -62,8 +62,8 @@ export default {
       // but also themselves.
       id: 'TEA Exhaust',
       netRegex: NetRegexes.abilityFull({ id: '481F', ...playerDamageFields }),
-      condition: (_e, _data, matches) => matches.target === matches.source,
-      mistake: (_e, _data, matches) => {
+      condition: (_data, matches) => matches.target === matches.source,
+      mistake: (_data, matches) => {
         return {
           type: 'fail',
           blame: matches.target,
@@ -80,14 +80,14 @@ export default {
     {
       id: 'TEA Dropsy',
       netRegex: NetRegexes.gainsEffect({ effectId: '121' }),
-      mistake: (_e, _data, matches) => {
+      mistake: (_data, matches) => {
         return { type: 'warn', blame: matches.target, text: matches.effect };
       },
     },
     {
       id: 'TEA Tether Tracking',
       netRegex: NetRegexes.tether({ source: 'Jagd Doll', id: '0011' }),
-      run: (_e, data, matches) => {
+      run: (data, matches) => {
         data.jagdTether = data.jagdTether || {};
         data.jagdTether[matches.sourceId] = matches.target;
       },
@@ -95,7 +95,7 @@ export default {
     {
       id: 'TEA Reducible Complexity',
       netRegex: NetRegexes.abilityFull({ id: '4821', ...playerDamageFields }),
-      mistake: (_e, data, matches) => {
+      mistake: (data, matches) => {
         return {
           type: 'fail',
           // This may be undefined, which is fine.
@@ -113,15 +113,15 @@ export default {
     {
       id: 'TEA Drainage',
       netRegex: NetRegexes.abilityFull({ id: '4827', ...playerDamageFields }),
-      condition: (_e, data, matches) => !data.party.isTank(matches.target),
-      mistake: (_e, _data, matches) => {
+      condition: (data, matches) => !data.party.isTank(matches.target),
+      mistake: (_data, matches) => {
         return { type: 'fail', name: matches.target, text: matches.ability };
       },
     },
     {
       id: 'TEA Throttle Gain',
       netRegex: NetRegexes.gainsEffect({ effectId: '2BC' }),
-      run: (_e, data, matches) => {
+      run: (data, matches) => {
         data.hasThrottle = data.hasThrottle || {};
         data.hasThrottle[matches.target] = true;
       },
@@ -129,7 +129,7 @@ export default {
     {
       id: 'TEA Throttle Lose',
       netRegex: NetRegexes.losesEffect({ effectId: '2BC' }),
-      run: (_e, data, matches) => {
+      run: (data, matches) => {
         data.hasThrottle = data.hasThrottle || {};
         data.hasThrottle[matches.target] = false;
       },
@@ -137,8 +137,8 @@ export default {
     {
       id: 'TEA Throttle',
       netRegex: NetRegexes.gainsEffect({ effectId: '2BC' }),
-      delaySeconds: (_e, _data, matches) => parseFloat(matches.duration) - 0.5,
-      deathReason: (_e, data, matches) => {
+      delaySeconds: (_data, matches) => parseFloat(matches.duration) - 0.5,
+      deathReason: (data, matches) => {
         if (!data.hasThrottle)
           return;
         if (!data.hasThrottle[matches.target])
@@ -155,7 +155,7 @@ export default {
       id: 'TEA Outburst',
       netRegex: NetRegexes.abilityFull({ id: '482A', ...playerDamageFields }),
       suppressSeconds: 5,
-      mistake: (_e, _data, matches) => {
+      mistake: (_data, matches) => {
         return { type: 'fail', blame: matches.target, text: matches.source };
       },
     },


### PR DESCRIPTION
The event types came before NetRegexes and named match groups
and were trying to do similar things.  Now that we have them,
they're redundant and make the code a lot more complicated.
They also have different names for the fields, which creates
confusions and errors.

This will also make oopsy code more consistent with raidboss.

Obviously, this is a breaking change for user triggers.