### PR TITLE
oopsy: remove fullText

### DIFF
--- a/docs/OopsyraidsyGuide.md
+++ b/docs/OopsyraidsyGuide.md
@@ -106,8 +106,6 @@ Each trigger is an object with the following fields.  All fields are optional.
 * `name` is an optional full player name to list as this mistake happening to.  This will prepend their name in the live list.
 * `blame` is an optional full player name (or array of full player names) to blame for this mistake.  If `name` is not specified, then the `name` will be the `blame` player.
 * `text` is an optional reason for the mistake.  It will be prepended by the blamed player's short name (if it exists).
-* `fullText` if it exists will be the entire text of the line, regardless of who is blamed.
-
 This will print ":no_entry_sign: Latke: Dynamo" in the live log.
 
 ```javascript
@@ -116,18 +114,6 @@ mistake: (data, matches) => {
     type: 'fail',
     blame: matches.target,
     text: 'Dynamo'
-  };
-},
-```
-
-This will print ":warning: WHOOPS" in the live log, even though a player was blamed.
-
-```javascript
-mistake: (data, matches) => {
-  return {
-    type: 'warn',
-    blame: matches.target,
-    fullText: 'WHOOPS',
   };
 },
 ```

--- a/types/oopsy.d.ts
+++ b/types/oopsy.d.ts
@@ -16,8 +16,6 @@ export type OopsyMistake = {
   // TODO: docs say blame can be an array but the code does not support that.
   blame?: string;
   text?: string | LocaleText;
-  // TODO: remove fullText.
-  fullText?: string | LocaleText;
 };
 
 export type OopsyDeathReason = {

--- a/ui/oopsyraidsy/data/00-misc/test.js
+++ b/ui/oopsyraidsy/data/00-misc/test.js
@@ -16,7 +16,7 @@ export default {
         return {
           type: 'pull',
           blame: data.me,
-          fullText: {
+          text: {
             en: 'Bow',
             de: 'Bogen',
             fr: 'Saluer',
@@ -38,7 +38,7 @@ export default {
         return {
           type: 'wipe',
           blame: data.me,
-          fullText: {
+          text: {
             en: 'Party Wipe',
             de: 'Gruppenwipe',
             fr: 'Party Wipe',

--- a/ui/oopsyraidsy/data/04-sb/raid/o4s.js
+++ b/ui/oopsyraidsy/data/04-sb/raid/o4s.js
@@ -122,7 +122,7 @@ export default {
           return;
         // Hard to know who should be in this and who shouldn't, but
         // it should never hit 3 people.
-        return { type: 'fail', fullText: `${arr[0].ability} x ${arr.length}` };
+        return { type: 'fail', text: `${arr[0].ability} x ${arr.length}` };
       },
       run: (data) => delete data.doubleAttackMatches,
     },

--- a/ui/oopsyraidsy/data/05-shb/eureka/delubrum_reginae_savage.js
+++ b/ui/oopsyraidsy/data/05-shb/eureka/delubrum_reginae_savage.js
@@ -144,14 +144,14 @@ export default {
       id: 'DelubrumSav Golem Compaction',
       netRegex: NetRegexes.ability({ id: '5746' }),
       mistake: (_data, matches) => {
-        return { type: 'fail', fullText: `${matches.source}: ${matches.ability}` };
+        return { type: 'fail', text: `${matches.source}: ${matches.ability}` };
       },
     },
     {
       id: 'DelubrumSav Slime Sanguine Fusion',
       netRegex: NetRegexes.ability({ id: '554D' }),
       mistake: (_data, matches) => {
-        return { type: 'fail', fullText: `${matches.source}: ${matches.ability}` };
+        return { type: 'fail', text: `${matches.source}: ${matches.ability}` };
       },
     },
   ],

--- a/ui/oopsyraidsy/mistake_collector.ts
+++ b/ui/oopsyraidsy/mistake_collector.ts
@@ -109,10 +109,7 @@ export class MistakeCollector {
   OnMistakeObj(m?: OopsyMistake): void {
     if (!m)
       return;
-    if (m.fullText)
-      this.OnFullMistakeText(m.type, m.blame, this.Translate(m.fullText));
-    else
-      this.OnMistakeText(m.type, m.name || m.blame, this.Translate(m.text));
+    this.OnMistakeText(m.type, m.name || m.blame, this.Translate(m.text));
   }
 
   OnMistakeText(type: string, blame?: string, text?: string, time?: number): void {
@@ -120,12 +117,6 @@ export class MistakeCollector {
       return;
     const blameText = blame ? ShortNamify(blame, this.options.PlayerNicks) + ': ' : '';
     this.listView.AddLine(type, blameText + text, this.GetFormattedTime(time));
-  }
-
-  OnFullMistakeText(type: string, blame?: string, text?: string, time?: number): void {
-    if (!text)
-      return;
-    this.listView.AddLine(type, text, this.GetFormattedTime(time));
   }
 
   AddEngage(): void {
@@ -198,7 +189,7 @@ export class MistakeCollector {
     // wipe then (to make post-wipe deaths more obvious), however this
     // requires making liveList be able to insert items in a sorted
     // manner instead of just being append only.
-    this.OnFullMistakeText('wipe', undefined, this.Translate(kPartyWipeText));
+    this.OnMistakeText('wipe', undefined, this.Translate(kPartyWipeText));
     // Party wipe usually comes a few seconds after everybody dies
     // so this will clobber any late damage.
     this.StopCombat();


### PR DESCRIPTION
This is the same as `text` but with no `blame` at this point, so just
remove this extra option.

This is (also) a breaking oopsy user trigger change.  I'm trying to
bunch them all together into a single release and make all the
changes at once.