### PR TITLE
raidemulator: Remove line sorting on convert

### DIFF
--- a/ui/raidboss/emulator/data/NetworkLogConverter.ts
+++ b/ui/raidboss/emulator/data/NetworkLogConverter.ts
@@ -19,15 +19,12 @@ export default class NetworkLogConverter extends EventBus {
   }
 
   convertLines(lines: string[], repo: LogRepository): LineEvent[] {
-    let lineEvents = lines.map((l) => ParseLine.parse(repo, l)).filter(isLineEvent);
+    const lineEvents = lines.map((l) => ParseLine.parse(repo, l)).filter(isLineEvent);
     // Call `convert` to convert the network line to non-network format and update indexing values
-    lineEvents = lineEvents.map((l, i) => {
+    return lineEvents.map((l, i) => {
       l.index = i;
       return l;
     });
-    // Sort the lines based on `${timestamp}_${index}` to handle out-of-order lines properly
-    // @TODO: Remove this once underlying CombatantTracker update issues are resolved
-    return lineEvents.sort((l, r) => (`${l.timestamp}_${l.index}`).localeCompare(`${r.timestamp}_${r.index}`));
   }
 
   static lineSplitRegex = /\r?\n/gm;


### PR DESCRIPTION
Now that the combatant state tracking keys off of the line event type and not just blindly updates states based on if a line has `id/targetId`, we don't need the sort anymore.