### PR TITLE
raidemulator: Add support for watchCombatant

### DIFF
--- a/resources/util.ts
+++ b/resources/util.ts
@@ -90,7 +90,7 @@ export type WatchCombatantParams = {
   maxDuration?: number;
 };
 
-type WatchCombatantFunc = (
+export type WatchCombatantFunc = (
   params: WatchCombatantParams,
   func: (ret: OverlayHandlerResponseTypes['getCombatants']) => boolean,
 ) => Promise<void>;

--- a/resources/util.ts
+++ b/resources/util.ts
@@ -82,7 +82,7 @@ const jobToRoleMap: Map<Job, Role> = (() => {
   return map;
 })();
 
-type WatchCombatantParams = {
+export type WatchCombatantParams = {
   ids?: number[];
   names?: string[];
   props?: string[];
@@ -113,7 +113,7 @@ const shouldCancelWatch = (
   return false;
 };
 
-const watchCombatant: WatchCombatantFunc = (params, func) => {
+const defaultWatchCombatant: WatchCombatantFunc = (params, func) => {
   return new Promise<void>((res, rej) => {
     const delay = params.delay ?? 1000;
 
@@ -158,6 +158,24 @@ const watchCombatant: WatchCombatantFunc = (params, func) => {
   });
 };
 
+let watchCombatantOverride: WatchCombatantFunc | undefined;
+let clearCombatantsOverride: () => void | undefined;
+
+const defaultClearCombatants = () => {
+  while (watchCombatantMap.length > 0) {
+    const watch = watchCombatantMap.pop();
+    if (watch)
+      watch.cancel = true;
+  }
+};
+
+const watchCombatant: WatchCombatantFunc = (params, func) => {
+  if (watchCombatantOverride)
+    return watchCombatantOverride(params, func);
+
+  return defaultWatchCombatant(params, func);
+};
+
 const Util = {
   jobEnumToJob: (id: number) => {
     const job = allJobs.find((job: Job) => nameToJobEnum[job] === id);
@@ -188,11 +206,14 @@ const Util = {
   canAddle: (job: Job) => addleJobs.includes(job),
   watchCombatant: watchCombatant,
   clearWatchCombatants: () => {
-    while (watchCombatantMap.length > 0) {
-      const watch = watchCombatantMap.pop();
-      if (watch)
-        watch.cancel = true;
-    }
+    if (clearCombatantsOverride)
+      clearCombatantsOverride();
+    else
+      defaultClearCombatants();
+  },
+  setWatchCombatantOverride: (watchFunc: WatchCombatantFunc, clearFunc: () => void) => {
+    watchCombatantOverride = watchFunc;
+    clearCombatantsOverride = clearFunc;
   },
 } as const;
 

--- a/ui/raidboss/emulator/data/AnalyzedEncounter.ts
+++ b/ui/raidboss/emulator/data/AnalyzedEncounter.ts
@@ -238,7 +238,7 @@ export default class AnalyzedEncounter extends EventBus {
       if (combatant && combatant.hasState(log.timestamp))
         this.updateState(combatant, log.timestamp, popupText);
 
-      this.watchCombatantsOverride.tick(this, this.encounter.combatantTracker, log.timestamp);
+      this.watchCombatantsOverride.tick(log.timestamp);
       await popupText.onEmulatorLog([log], getCurLogLine);
       timelineController.onEmulatorLogEvent([log]);
     }

--- a/ui/raidboss/emulator/data/AnalyzedEncounter.ts
+++ b/ui/raidboss/emulator/data/AnalyzedEncounter.ts
@@ -10,6 +10,7 @@ import EventBus from '../EventBus';
 import RaidEmulatorAnalysisTimelineUI from '../overrides/RaidEmulatorAnalysisTimelineUI';
 import RaidEmulatorPopupText from '../overrides/RaidEmulatorPopupText';
 import RaidEmulatorTimelineController from '../overrides/RaidEmulatorTimelineController';
+import RaidEmulatorWatchCombatantsOverride from '../overrides/RaidEmulatorWatchCombatantsOverride';
 
 import Combatant from './Combatant';
 import Encounter from './Encounter';
@@ -36,6 +37,7 @@ export default class AnalyzedEncounter extends EventBus {
     public options: RaidbossOptions,
     public encounter: Encounter,
     public emulator: RaidEmulator,
+    public watchCombatantsOverride: RaidEmulatorWatchCombatantsOverride,
   ) {
     super();
   }
@@ -122,6 +124,13 @@ export default class AnalyzedEncounter extends EventBus {
     let currentLogIndex = 0;
     const partyMember = this.encounter.combatantTracker.combatants[id];
 
+    const getCurLogLine = (): LineEvent => {
+      const line = this.encounter.logLines[currentLogIndex];
+      if (!line)
+        throw new UnreachableCode();
+      return line;
+    };
+
     if (!partyMember)
       return;
 
@@ -178,11 +187,14 @@ export default class AnalyzedEncounter extends EventBus {
         popupText.OnTrigger(trigger, matches, currentLine.timestamp);
 
         resolver.setFinal(() => {
+          // Get the current log line when the callback is executed instead of the line
+          // when the trigger initially fires
+          const resolvedLine = getCurLogLine();
           resolver.status.finalData = EmulatorCommon.cloneData(popupText.getData());
           delete resolver.triggerHelper?.resolver;
           if (popupText.callback) {
             popupText.callback(
-              currentLine,
+              resolvedLine,
               resolver.triggerHelper,
               resolver.status,
               popupText.getData(),
@@ -226,9 +238,12 @@ export default class AnalyzedEncounter extends EventBus {
       if (combatant && combatant.hasState(log.timestamp))
         this.updateState(combatant, log.timestamp, popupText);
 
-      await popupText.onEmulatorLog([log]);
+      this.watchCombatantsOverride.tick(this, this.encounter.combatantTracker, log.timestamp);
+      await popupText.onEmulatorLog([log], getCurLogLine);
       timelineController.onEmulatorLogEvent([log]);
     }
+
+    this.watchCombatantsOverride.clear();
     timelineUI.stop();
   }
 }

--- a/ui/raidboss/emulator/data/RaidEmulator.ts
+++ b/ui/raidboss/emulator/data/RaidEmulator.ts
@@ -29,8 +29,10 @@ export default class RaidEmulator extends EventBus {
     this.encounters.push(encounter);
   }
 
-  private setCurrent(enc: Encounter,
-      watchCombatantsOverride: RaidEmulatorWatchCombatantsOverride): void {
+  private setCurrent(
+    enc: Encounter,
+    watchCombatantsOverride: RaidEmulatorWatchCombatantsOverride,
+  ): void {
     // If language was autodetected from the encounter, set the current ParserLanguage
     // appropriately
     if (enc.language)
@@ -43,8 +45,10 @@ export default class RaidEmulator extends EventBus {
     });
   }
 
-  setCurrentByID(id: number,
-      watchCombatantsOverride: RaidEmulatorWatchCombatantsOverride): boolean {
+  setCurrentByID(
+    id: number,
+    watchCombatantsOverride: RaidEmulatorWatchCombatantsOverride,
+  ): boolean {
     const enc = this.encounters.find((v) => v.id === id);
     if (!enc)
       return false;

--- a/ui/raidboss/emulator/data/RaidEmulator.ts
+++ b/ui/raidboss/emulator/data/RaidEmulator.ts
@@ -2,6 +2,7 @@ import { UnreachableCode } from '../../../../resources/not_reached';
 import { RaidbossOptions } from '../../raidboss_options';
 import EventBus from '../EventBus';
 import RaidEmulatorPopupText from '../overrides/RaidEmulatorPopupText';
+import RaidEmulatorWatchCombatantsOverride from '../overrides/RaidEmulatorWatchCombatantsOverride';
 
 import AnalyzedEncounter from './AnalyzedEncounter';
 import Encounter from './Encounter';
@@ -28,25 +29,27 @@ export default class RaidEmulator extends EventBus {
     this.encounters.push(encounter);
   }
 
-  private setCurrent(enc: Encounter): void {
+  private setCurrent(enc: Encounter,
+      watchCombatantsOverride: RaidEmulatorWatchCombatantsOverride): void {
     // If language was autodetected from the encounter, set the current ParserLanguage
     // appropriately
     if (enc.language)
       this.options.ParserLanguage = enc.language;
 
-    this.currentEncounter = new AnalyzedEncounter(this.options, enc, this);
+    this.currentEncounter = new AnalyzedEncounter(this.options, enc, this, watchCombatantsOverride);
     void this.dispatch('preCurrentEncounterChanged', this.currentEncounter);
     void this.currentEncounter.analyze().then(() => {
       void this.dispatch('currentEncounterChanged', this.currentEncounter);
     });
   }
 
-  setCurrentByID(id: number): boolean {
+  setCurrentByID(id: number,
+      watchCombatantsOverride: RaidEmulatorWatchCombatantsOverride): boolean {
     const enc = this.encounters.find((v) => v.id === id);
     if (!enc)
       return false;
 
-    this.setCurrent(enc);
+    this.setCurrent(enc, watchCombatantsOverride);
     return true;
   }
 

--- a/ui/raidboss/emulator/overrides/RaidEmulatorWatchCombatantsOverride.ts
+++ b/ui/raidboss/emulator/overrides/RaidEmulatorWatchCombatantsOverride.ts
@@ -1,0 +1,89 @@
+import Util, { WatchCombatantParams } from '../../../../resources/util';
+import { OverlayHandlerRequests, OverlayHandlerResponseTypes } from '../../../../types/event';
+import AnalyzedEncounter from '../data/AnalyzedEncounter';
+import CombatantTracker from '../data/CombatantTracker';
+import RaidEmulator from '../data/RaidEmulator';
+
+import RaidEmulatorOverlayApiHook from './RaidEmulatorOverlayApiHook';
+
+type Watch = {
+  lastCheck: number;
+  params: WatchCombatantParams;
+  msg: OverlayHandlerRequests['getCombatants'];
+  cancel: boolean;
+  start: number;
+  promise: Promise<void>;
+  res: () => void;
+  rej: () => void;
+  func: (ret: OverlayHandlerResponseTypes['getCombatants']) => boolean;
+};
+
+export default class RaidEmulatorWatchCombatantsOverride {
+  private watches: Watch[] = [];
+
+  constructor(private emulator: RaidEmulator, private overlayHook: RaidEmulatorOverlayApiHook) {
+    Util.setWatchCombatantOverride((params, func) => {
+      // To avoid having to undefined-check the params declare watch as partial here and just cast
+      // to non-partial when pushing to array since all props are set here properly but can't be
+      // set in the initializer
+      const watch: Partial<Watch> = {
+        lastCheck: 0,
+        params: params,
+        cancel: false,
+        start: 0,
+        func: func,
+        msg: {
+          call: 'getCombatants',
+          ...params,
+        },
+      };
+
+      watch.promise = new Promise<void>((res, rej) => {
+        watch.res = res;
+        watch.rej = rej;
+      });
+      this.watches.push(watch as Watch);
+      return watch.promise;
+    }, this.clear.bind(this));
+
+    this.emulator.on('tick', () => {
+      const curEnc = this.emulator.currentEncounter;
+      const tracker = curEnc?.encounter.combatantTracker;
+      const timestamp = this.emulator.currentLogTime;
+
+      if (!curEnc || !tracker || !timestamp)
+        return;
+
+      this.tick(curEnc, tracker, timestamp);
+    });
+  }
+
+  public tick(
+      curEnc: AnalyzedEncounter,
+      tracker: CombatantTracker,
+      timestamp: number,
+  ): void {
+    for (const watch of this.watches) {
+      if (watch.cancel)
+        continue;
+      if (watch.lastCheck + 1000 > timestamp)
+        continue;
+      watch.lastCheck = timestamp;
+      this.overlayHook.getCombatantsFor((e) => {
+        if (watch.func(e)) {
+          watch.res();
+          watch.cancel = true;
+        }
+      }, watch.msg, curEnc, tracker, timestamp);
+    }
+    this.watches = this.watches.filter((w) => !w.cancel);
+  }
+
+  public clear(): void {
+    for (const watch of this.watches) {
+      watch.rej();
+      watch.cancel = true;
+    }
+    this.watches = [];
+  }
+}

--- a/ui/raidboss/raidemulator.ts
+++ b/ui/raidboss/raidemulator.ts
@@ -197,8 +197,10 @@ const raidEmulatorOnLoad = async () => {
 
   emulator.setPopupText(popupText);
 
-  const emulatorWatchCombatantsOverride =
-    new RaidEmulatorWatchCombatantsOverride(emulator, emulatedWebSocket);
+  const emulatorWatchCombatantsOverride = new RaidEmulatorWatchCombatantsOverride(
+    emulator,
+    emulatedWebSocket,
+  );
 
   // Listen for the user to click a player in the party list on the right
   // and persist that over to the emulator

--- a/ui/raidboss/raidemulator.ts
+++ b/ui/raidboss/raidemulator.ts
@@ -22,6 +22,7 @@ import RaidEmulatorOverlayApiHook from './emulator/overrides/RaidEmulatorOverlay
 import RaidEmulatorPopupText from './emulator/overrides/RaidEmulatorPopupText';
 import RaidEmulatorTimelineController from './emulator/overrides/RaidEmulatorTimelineController';
 import RaidEmulatorTimelineUI from './emulator/overrides/RaidEmulatorTimelineUI';
+import RaidEmulatorWatchCombatantsOverride from './emulator/overrides/RaidEmulatorWatchCombatantsOverride';
 import {
   emulatorTemplateTranslations,
   emulatorTooltipTranslations,
@@ -52,6 +53,7 @@ declare global {
       emulatedPartyInfo: EmulatedPartyInfo;
       emulatedWebSocket: RaidEmulatorOverlayApiHook;
       timelineUI: RaidEmulatorTimelineUI;
+      emulatorWatchCombatantsOverride: RaidEmulatorWatchCombatantsOverride;
     };
   }
 }
@@ -195,6 +197,9 @@ const raidEmulatorOnLoad = async () => {
 
   emulator.setPopupText(popupText);
 
+  const emulatorWatchCombatantsOverride =
+    new RaidEmulatorWatchCombatantsOverride(emulator, emulatedWebSocket);
+
   // Listen for the user to click a player in the party list on the right
   // and persist that over to the emulator
   emulatedPartyInfo.on('selectPerspective', (id: string) => {
@@ -213,12 +218,12 @@ const raidEmulatorOnLoad = async () => {
   // Listen for the user to attempt to load an encounter from the encounters pane
   encounterTab.on('load', (id: number) => {
     // Attempt to set the current emulated encounter
-    if (!emulator.setCurrentByID(id)) {
+    if (!emulator.setCurrentByID(id, emulatorWatchCombatantsOverride)) {
       // If that encounter isn't loaded, load it
       void persistor.loadEncounter(id).then((enc?: Encounter) => {
         if (enc) {
           emulator.addEncounter(enc);
-          emulator.setCurrentByID(id);
+          emulator.setCurrentByID(id, emulatorWatchCombatantsOverride);
         }
       });
     }
@@ -534,6 +539,7 @@ const raidEmulatorOnLoad = async () => {
     emulatedPartyInfo: emulatedPartyInfo,
     emulatedWebSocket: emulatedWebSocket,
     timelineUI: timelineUI,
+    emulatorWatchCombatantsOverride: emulatorWatchCombatantsOverride,
   };
 };
 


### PR DESCRIPTION
This one ended up being significantly more complicated than I was hoping.

This PR:

- Adds an override for watchCombatant for raidemulator to use
- Modifies the way PopupTextAnalysis tracks trigger promise resolution to not block waiting for a promise to resolve
- Refactors the way RaidEmulatorOverlayApiHook handles getCombatants to let other classes call it
- Adds a new class to override watchCombatant

Technically these 4 could be separate sequential PRs but considering how small 1/2/3 would be, I didn't think it was really worth splitting them up.

~~There's some sort of bug with resolved timestamp display, e.g. this trigger actually resolved at 1:05 into the pull:~~

![image](https://user-images.githubusercontent.com/6119598/125141695-bf808100-e0e3-11eb-8e63-542fb07e11bb.png)

~~So this isn't quite ready to merge yet (or that bug can be fixed in a later PR), I just wanted to get it open for feedback.~~

**edit**

Issue with resolved offset should be fixed now.