### PR TITLE
Fix spelling error in Yiazmat fight

### DIFF
--- a/ui/raidboss/data/04-sb/alliance/ridorana_lighthouse.ts
+++ b/ui/raidboss/data/04-sb/alliance/ridorana_lighthouse.ts
@@ -482,7 +482,7 @@ const triggerSet: TriggerSet<Data> = {
       infoText: (_data, _matches, output) => output.text!(),
       outputStrings: {
         text: {
-          en: 'Move to Postive',
+          en: 'Move to Positive',
           de: 'Ins Positive laufen',
           fr: 'Allez sur le plus',
           ja: 'プラス（＋）へ',


### PR DESCRIPTION
While hilarious, this does result in the TTS saying "move to pose-tive" which is confusing.