### PR TITLE
raidemulator: Add map

### DIFF
--- a/ui/raidboss/emulator/data/Combatant.ts
+++ b/ui/raidboss/emulator/data/Combatant.ts
@@ -43,8 +43,10 @@ export default class Combatant {
   pushState(timestamp: number, state: CombatantState): void {
     this.states[timestamp] = state;
     this.latestTimestamp = timestamp;
-    if (!this.significantStates.includes(timestamp))
+    if (!this.significantStates.includes(timestamp)) {
       this.significantStates.push(timestamp);
+      this.significantStates = this.significantStates.sort();
+    }
   }
 
   nextSignificantState(timestamp: number): CombatantState {
@@ -96,8 +98,10 @@ export default class Combatant {
     const oldStateJSON = JSON.stringify(this.states[lastSignificantStateTimestamp]);
     const newStateJSON = JSON.stringify(this.states[timestamp]);
 
-    if (lastSignificantStateTimestamp !== timestamp && newStateJSON !== oldStateJSON)
+    if (lastSignificantStateTimestamp !== timestamp && newStateJSON !== oldStateJSON) {
       this.significantStates.push(timestamp);
+      this.significantStates = this.significantStates.sort();
+    }
   }
 
   getState(timestamp: number): CombatantState {

--- a/ui/raidboss/emulator/ui/EmulatorMap.ts
+++ b/ui/raidboss/emulator/ui/EmulatorMap.ts
@@ -1,0 +1,315 @@
+import { UnreachableCode } from '../../../../resources/not_reached';
+import Util from '../../../../resources/util';
+import AnalyzedEncounter from '../data/AnalyzedEncounter';
+import Combatant from '../data/Combatant';
+import LineEvent from '../data/network_log_converter/LineEvent';
+import { LineEvent0x01 } from '../data/network_log_converter/LineEvent0x01';
+import { LineEvent0x1C } from '../data/network_log_converter/LineEvent0x1C';
+import RaidEmulator from '../data/RaidEmulator';
+import { cloneSafe, getTemplateChild, querySelectorSafe } from '../EmulatorCommon';
+
+import Tooltip from './Tooltip';
+
+// This is a partial definition, only pulling in what we need
+type TerritoryType = {
+  Map?: {
+    MapFilename?: string;
+    SizeFactor?: string;
+    OffsetX?: string;
+    OffsetY?: string;
+  };
+};
+
+type Map = {
+  element: HTMLElement;
+  territoryType: TerritoryType;
+  waymarkers: { [id: number]: HTMLElement };
+};
+
+type MapCombatant = {
+  combatant: Combatant;
+  element: HTMLElement;
+  firstSignificantState: number;
+  lastSignificantState: number;
+  tooltip?: Tooltip;
+};
+
+const xivapiBaseUrl = 'https://xivapi.com/';
+
+const scaleMap = (map: Map): void => {
+  const mapSubContainer = querySelectorSafe(map.element, '.subContainer');
+  const offsetX = parseInt(map.territoryType?.Map?.OffsetX ?? '0');
+  const mapContainerWidth = window.innerWidth * 0.166666667;
+  const mapWidth = Math.abs((offsetX) * 2);
+  const mapScale = mapContainerWidth / mapWidth;
+  mapSubContainer.style.transform = `scale(${mapScale})`;
+};
+
+const coordToOffset = (map: Map, coord: number): number => {
+  const offsetX = parseInt(map.territoryType?.Map?.OffsetX ?? '0');
+  const mapScale = parseInt(map.territoryType.Map?.SizeFactor ?? '100') / 100.0;
+  const coordOffset = offsetX + coord;
+  return 1024.0 + (coordOffset * mapScale);
+};
+
+const waymarkIdMap = [
+  3, // 1
+  4, // 2
+  5, // 3
+  7, // 4
+  0, // A
+  1, // B
+  2, // C
+  6, // D
+];
+
+const waymarkerUrl = (id: number) => {
+  id = waymarkIdMap[id] ?? id;
+  return `https://xivapi.com/i/061000/06124${id + 1}_hr1.png`;
+};
+
+export class EmulatorMap {
+  private loadedMaps: { [id: number]: Map } = {};
+  private loadingMaps: { [id: number]: true } = {};
+
+  private currentMap?: Map;
+
+  private combatantMap: MapCombatant[] = [];
+
+  private mapContainer: HTMLElement;
+  private mapEntryTemplate: HTMLElement;
+
+  private mapEnemyTemplate: HTMLElement;
+  private mapPlayerTemplate: HTMLElement;
+  private mapWaymarkerTemplate: HTMLElement;
+
+  constructor(private emulator: RaidEmulator) {
+    this.mapContainer = querySelectorSafe(document, '.map');
+    this.mapEntryTemplate = getTemplateChild(document, 'template.mapEntry');
+    this.mapEnemyTemplate = getTemplateChild(document, 'template.mapEnemy');
+    this.mapPlayerTemplate = getTemplateChild(document, 'template.mapPlayer');
+    this.mapWaymarkerTemplate = getTemplateChild(document, 'template.mapWaymarker');
+
+    this.emulator.on('currentEncounterChanged', async (enc: AnalyzedEncounter) => {
+      this.clearCombatants();
+
+      const encZoneId = parseInt(enc.encounter.encounterZoneId, 16);
+
+      await this.loadMap(encZoneId).then(() => {
+        this.setMap(encZoneId, 1);
+      });
+
+      for (const line of enc.encounter.logLines.filter((l) => l.decEvent === 1)) {
+        const lineCast = line as LineEvent0x01;
+        const zoneId = parseInt(lineCast.zoneId, 16);
+        void this.loadMap(zoneId);
+      }
+    });
+
+    emulator.on('emitLogs', (event: { logs: LineEvent[] }) => {
+      for (const line of event.logs) {
+        if (line.decEvent === 1) {
+          const lineCast = line as LineEvent0x01;
+          this.setMap(parseInt(lineCast.zoneId, 16), line.timestamp);
+        } else {
+          // Put this in `else` to avoid doubling up on combatant updates since setMap updates them
+          this.updateCombatants(line.timestamp);
+          if (line.decEvent === 28) {
+            const lineCast = line as LineEvent0x1C;
+            const waymarkId = parseInt(lineCast.waymark);
+            if (waymarkId >= 0 && waymarkId <= 7) {
+              const map = this.currentMap;
+              const waymark = this.currentMap?.waymarkers[waymarkId];
+              if (map && waymark) {
+                if (lineCast.operation === 'Add')
+                  waymark.classList.remove('d-none');
+                else
+                  waymark.classList.add('d-none');
+                waymark.style.left = coordToOffset(map, parseFloat(lineCast.x)).toString() + 'px';
+                waymark.style.top = coordToOffset(map, parseFloat(lineCast.y)).toString() + 'px';
+              }
+            }
+          }
+        }
+      }
+    });
+    // @TODO: Maybe there's a better way to auto-scale this so we don't have to listen to resize?
+    window.addEventListener('resize', () => {
+      for (const map of Object.values(this.loadedMaps))
+        scaleMap(map);
+    });
+  }
+  private clearCombatants() {
+    const map = this.currentMap;
+    if (!map)
+      return;
+    const mapSubContainer = querySelectorSafe(map.element, '.subContainer');
+    for (const combatant of this.combatantMap) {
+      mapSubContainer.removeChild(combatant.element);
+      combatant.tooltip?.delete();
+    }
+    this.combatantMap = [];
+  }
+
+  public initCombatants(map: Map): void {
+    const combatantTracker = this.emulator.currentEncounter?.encounter.combatantTracker;
+
+    if (!combatantTracker || !map)
+      throw new UnreachableCode();
+
+    const mapSubContainer = querySelectorSafe(map.element, '.subContainer');
+
+    for (const [id, entry] of Object.entries(combatantTracker.combatants)) {
+      // If the combatant doesn't have a name, don't display
+      if (entry.name === '')
+        continue;
+
+      let combatant: MapCombatant;
+      const firstSigState = entry.significantStates.slice(0)[0] ?? 0;
+      const lastSigState = entry.significantStates.slice(-1)[0] ?? 0;
+      if (combatantTracker.enemies.includes(id)) {
+        combatant = {
+          combatant: entry,
+          element: cloneSafe(this.mapEnemyTemplate),
+          firstSignificantState: firstSigState,
+          lastSignificantState: lastSigState,
+        };
+      } else {
+        combatant = {
+          combatant: entry,
+          element: cloneSafe(this.mapPlayerTemplate),
+          firstSignificantState: firstSigState,
+          lastSignificantState: lastSigState,
+        };
+        combatant.element.classList.add(Util.jobToRole(entry.job ?? 'NONE'));
+      }
+      combatant.tooltip = new Tooltip(querySelectorSafe(combatant.element, '.inner'), 'left', combatant.combatant.name);
+
+      // @TODO: Also mark current perspective as primary
+      if (combatantTracker.mainCombatantID === id)
+        combatant.element.classList.add('primary');
+
+      mapSubContainer.appendChild(combatant.element);
+      this.combatantMap.push(combatant);
+
+      this.updateCombatant(combatant, 0);
+    }
+  }
+
+  private updateCombatants(timestamp: number) {
+    if (this.currentMap) {
+      for (const combatant of this.combatantMap)
+        this.updateCombatant(combatant, timestamp);
+    }
+  }
+  private updateCombatant(combatant: MapCombatant, timestamp: number): void {
+    if (this.currentMap) {
+      const state = combatant.combatant.getState(timestamp);
+
+      if (combatant.combatant.significantStates.includes(timestamp)) {
+        combatant.element.style.left = coordToOffset(this.currentMap, state.posX).toString() + 'px';
+        combatant.element.style.top = coordToOffset(this.currentMap, state.posY).toString() + 'px';
+        combatant.element.style.transform = `rotate(${state.heading * -1}rad)`;
+      }
+
+      // @TODO: state.targetable is unreliable?
+      if (timestamp < combatant.firstSignificantState ||
+        combatant.lastSignificantState < timestamp)
+        combatant.element.classList.add('d-none');
+      else
+        combatant.element.classList.remove('d-none');
+    }
+  }
+
+  public setMap(zone: number, timestamp: number): void {
+    const map = this.loadedMaps[zone];
+    if (!map || !map.element) {
+      console.error(`Attempted to set map that is not loaded: ${zone}`);
+      return;
+    }
+
+    this.currentMap = map;
+
+    for (const otherMap of Object.values(this.loadedMaps)) {
+      if (otherMap.element)
+        otherMap.element.classList.add('d-none');
+    }
+
+    map.element.classList.remove('d-none');
+
+    if (timestamp)
+      this.updateCombatants(timestamp);
+  }
+
+  private async loadMap(zone: number): Promise<void> {
+    if (this.loadedMaps[zone] || this.loadingMaps[zone])
+      return;
+
+    this.loadingMaps[zone] = true;
+
+    return await this.cacheMap(zone).then((content) => {
+      const map: Map = {
+        territoryType: content,
+        element: cloneSafe(this.mapEntryTemplate),
+        waymarkers: {
+          0: this.cloneWaymarker(0),
+          1: this.cloneWaymarker(1),
+          2: this.cloneWaymarker(2),
+          3: this.cloneWaymarker(3),
+          4: this.cloneWaymarker(4),
+          5: this.cloneWaymarker(5),
+          6: this.cloneWaymarker(6),
+          7: this.cloneWaymarker(7),
+        },
+      };
+      this.initMap(map);
+      this.loadedMaps[zone] = map;
+      delete this.loadingMaps[zone];
+    });
+  }
+
+  private initMap(map: Map): void {
+    const mapObj = map.element;
+    const img = querySelectorSafe(mapObj, 'img') as HTMLImageElement;
+    const mapUrl = map.territoryType?.Map?.MapFilename;
+    if (!mapUrl)
+      throw new UnreachableCode(); // This might not be the best choice?
+    img.src = xivapiBaseUrl + mapUrl;
+    map.element = mapObj;
+    scaleMap(map);
+
+    const mapSubContainer = querySelectorSafe(map.element, '.subContainer');
+
+    Object.values(map.waymarkers).forEach((wm) => {
+      mapSubContainer.appendChild(wm);
+    });
+
+    this.mapContainer.appendChild(mapObj);
+    this.initCombatants(map);
+  }
+
+  private async cacheMap(zone: number): Promise<TerritoryType> {
+    return new Promise<TerritoryType>((res) => {
+      void fetch(`${xivapiBaseUrl}TerritoryType/${zone.toString()}`, {
+        'credentials': 'omit',
+        'method': 'GET',
+        'mode': 'cors',
+      }).then(async (resp) => {
+        const json = await resp.text();
+        const instanceContent = JSON.parse(json) as TerritoryType;
+        res(instanceContent);
+      });
+    });
+  }
+
+  private cloneWaymarker(id: number): HTMLElement {
+    const elem = cloneSafe(this.mapWaymarkerTemplate);
+    const img = querySelectorSafe(elem, 'img');
+    if (!(img instanceof HTMLImageElement))
+      throw new UnreachableCode();
+
+    img.src = waymarkerUrl(id);
+
+    return elem;
+  }
+}

--- a/ui/raidboss/raidemulator.css
+++ b/ui/raidboss/raidemulator.css
@@ -656,6 +656,93 @@ template {
   z-index: 1070;
 }
 
+.map {
+  overflow: hidden;
+  position: relative;
+}
+
+.map .mapEntry {
+  width: 2048px;
+  height: 2048px;
+  left: -1024px;
+  top: -1024px;
+  position: relative;
+}
+
+.map .mapEntry .subContainer {
+  transform-origin: center;
+  left: calc((16.666667vw - 30px) * 0.5);
+  top: calc((16.666667vw - 30px) * 0.5);
+  position: relative;
+}
+
+.map .mapEntry .subContainer img {
+  width: 100%;
+  height: 100%;
+}
+
+.mapObject {
+  position: absolute;
+  transform-origin: 0 0 0;
+  transition: 0.25s linear;
+}
+
+.mapObject .outer {
+  border: 5px solid transparent;
+  border-radius: 50% 50% 50% 0;
+  transform-origin: center;
+  transform: translate(-50%, -50%) rotate(-45deg);
+}
+
+.mapObject.enemy .outer,
+.mapObject.waymarker .outer {
+  transform: translate(-50%, -50%) scale(0.25) rotate(-45deg);
+}
+
+.mapObject.enemy .inner,
+.mapObject.waymarker .inner {
+  transform: rotate(45deg);
+}
+
+.mapObject.primary .outer {
+  border-color: pink;
+}
+
+.mapObject.player .inner {
+  width: 5px;
+  height: 5px;
+  border: 5px solid transparent;
+  border-radius: 50% 50% 50% 0;
+}
+
+.mapObject.tank .inner {
+  background: rgba(71, 94, 206, 0.8);
+}
+
+.mapObject.healer .inner {
+  background: rgba(60, 105, 41, 0.8);
+}
+
+.mapObject.dps .inner {
+  background: rgba(104, 53, 53, 0.8);
+}
+
+.mapObject.enemy {
+  z-index: 1;
+}
+
+.mapObject.enemy.primary {
+  z-index: 2;
+}
+
+.mapObject.player {
+  z-index: 3;
+}
+
+.mapObject.player.primary {
+  z-index: 4;
+}
+
 @media (min-width: 576px) {
   .modal-dialog {
     max-width: calc(100vw - (1.75rem * 2));

--- a/ui/raidboss/raidemulator.html
+++ b/ui/raidboss/raidemulator.html
@@ -314,6 +314,40 @@
           <div class="tooltip-inner"></div>
         </div>
       </template>
+      <template id="mapEntryTemplate" class="mapEntry">
+        <div class="mapEntry d-none">
+          <div class="subContainer">
+            <img alt="map"></img>
+          </div>
+        </div>
+      </template>
+      <template id="mapEnemyTemplate" class="mapEnemy">
+        <div class="enemy mapObject">
+          <div class="outer">
+            <div class="inner">
+              <img alt="enemy" src="https://xivapi.com/c/BNpcName.png"></img>
+            </div>
+          </div>
+        </div>
+      </template>
     </div>
+    <template id="mapPlayerTemplate" class="mapPlayer">
+      <div class="player mapObject">
+        <div class="outer">
+          <div class="inner">
+          </div>
+        </div>
+      </div>
+    </template>
+    <template id="mapWaymarkerTemplate" class="mapWaymarker">
+      <div class="waymarker mapObject d-none">
+        <div class="outer">
+          <div class="inner">
+            <img alt="waymarker"></img>
+          </div>
+        </div>
+      </div>
+    </template>
+  </div>
   </body>
 </html>

--- a/ui/raidboss/raidemulator.ts
+++ b/ui/raidboss/raidemulator.ts
@@ -20,6 +20,7 @@ import RaidEmulatorTimelineController from './emulator/overrides/RaidEmulatorTim
 import RaidEmulatorTimelineUI from './emulator/overrides/RaidEmulatorTimelineUI';
 import { translate, emulatorTranslations, emulatorTooltipTranslations, lookupEndStatus, lookupStartStatuses, emulatorTemplateTranslations } from './emulator/translations';
 import EmulatedPartyInfo from './emulator/ui/EmulatedPartyInfo';
+import { EmulatorMap } from './emulator/ui/EmulatorMap';
 import EncounterTab from './emulator/ui/EncounterTab';
 import ProgressBar from './emulator/ui/ProgressBar';
 import Tooltip from './emulator/ui/Tooltip';
@@ -41,6 +42,7 @@ declare global {
       emulatedPartyInfo: EmulatedPartyInfo;
       emulatedWebSocket: RaidEmulatorOverlayApiHook;
       timelineUI: RaidEmulatorTimelineUI;
+      emulatorMap: EmulatorMap;
     };
   }
 }
@@ -152,6 +154,7 @@ const raidEmulatorOnLoad = async () => {
     applyTranslation(options.DisplayLanguage);
 
   const emulator = new RaidEmulator(options);
+  const emulatorMap = new EmulatorMap(emulator);
   const progressBar = new ProgressBar(emulator);
   const encounterTab = new EncounterTab(persistor);
   const emulatedPartyInfo = new EmulatedPartyInfo(emulator);
@@ -504,6 +507,7 @@ const raidEmulatorOnLoad = async () => {
     emulatedPartyInfo: emulatedPartyInfo,
     emulatedWebSocket: emulatedWebSocket,
     timelineUI: timelineUI,
+    emulatorMap: emulatorMap,
   };
 };
 


### PR DESCRIPTION
This WIP PR adds the map to raidemulator. I've opened it as a WIP PR to solicit feedback/thoughts.

There are some outstanding issues that still need addressed, as follows:

- [ ] Waymarkers are only processed if they were set in the current encounter, need to carry waymarker lines forward
- [ ] Any encounters that have a map change are completely untested and will probably break or the map area won't change
- [x] Need to pause map playback during seek and then skip to last valid state at the end of seek
- [ ] Animation for rotation is really weird. Might be best to just only animate the movement, not rotation?
- [ ] Additional enemies flicker in and out, I think due to log line timestamps not lining up, need to debug more
- [ ] Changing encounters breaks the map currently, need to debug more
- [ ] Tooltips are shown when hovering over items in the map, but they're a bit wonky on detection currently, I think due to the rotation/translation transforms
- [ ] Currently uses a pink border for the primary enemy combatant, need a better color but not sure what color to use
- [ ] Currently selected player should have the same border, but there's not a way currently to get that info from map, need to adjust things upstream

Example from E8S:
![2021-07-14 19-19-41](https://user-images.githubusercontent.com/6119598/125705493-58f34a1e-f535-4415-9fcc-36bc46faed69.gif)
