### PR TITLE
raidboss: Fix a8n aoe callout spam

### DIFF
--- a/ui/raidboss/data/03-hw/raid/a8n.ts
+++ b/ui/raidboss/data/03-hw/raid/a8n.ts
@@ -273,6 +273,7 @@ const triggerSet: TriggerSet<Data> = {
       netRegexCn: NetRegexes.ability({ source: '残暴正义号', id: '1753', capture: false }),
       netRegexKo: NetRegexes.ability({ source: '포악한 심판자', id: '1753', capture: false }),
       condition: Conditions.caresAboutAOE(),
+      suppressSeconds: 1,
       response: Responses.aoe(),
     },
     {


### PR DESCRIPTION
I've gotten this one a couple times in roulette the last week, and when the aoe fires it's certainly noticeable because it fires once for each player that's alive 🙃 

There's no `startsUsing` line for this one so I added `suppressSeconds` instead. I'm not sure if any of the other `ability` triggers here have the same problem, since I've never seen most of them in roulettes.