### PR TITLE
Refactor(jobs): consist custom element property type

### DIFF
--- a/resources/timerbar.ts
+++ b/resources/timerbar.ts
@@ -73,32 +73,39 @@ export default class TimerBar extends HTMLElement {
   }
 
   // The total length of time to count down.
-  set duration(s: string) {
-    this.attributeChangedCallback('duration', this.duration, s);
+  set duration(s: number | null) {
+    if (s === null)
+      this.removeAttribute('duration');
+    else
+      this.setAttribute('duration', s.toString());
   }
-  get duration(): string {
-    return this._duration.toString();
+  get duration(): number | null {
+    const s = this.getAttribute('duration');
+    if (s === null)
+      return null;
+    return parseFloat(s);
   }
 
   // The length remaining in the count down.
-  set value(s: string) {
-    this.attributeChangedCallback('value', this.value, s);
+  set value(s: number) {
+    this.setAttribute('value', s.toString());
   }
-  get value(): string {
+
+  get value(): number {
     if (!this._start)
-      return this._duration.toString();
+      return this._duration;
     const elapsedMs = new Date().getTime() - this._start;
-    return Math.max(0, this._duration - (elapsedMs / 1000)).toString();
+    return Math.max(0, this._duration - (elapsedMs / 1000));
   }
 
   // The elapsed time.
-  set elapsed(s: string) {
-    this.attributeChangedCallback('elapsed', this.elapsed, s);
+  set elapsed(s: number) {
+    this.setAttribute('elapsed', s.toString());
   }
-  get elapsed(): string {
+  get elapsed(): number {
     if (!this._start)
-      return '0';
-    return ((new Date().getTime() - this._start) / 1000).toString();
+      return 0;
+    return (new Date().getTime() - this._start) / 1000;
   }
 
   // If "right" then animates left-to-right (the default). If "left"
@@ -125,16 +132,19 @@ export default class TimerBar extends HTMLElement {
     return this.getAttribute('stylefill') as 'empty' | 'fill';
   }
 
-  // When the bar reaches 0, it is hidden after this many seconds. If ""
+  // When the bar reaches 0, it is hidden after this many seconds. If null
   // then it is not hidden.
-  set hideafter(h: string | null) {
+  set hideafter(h: number | null) {
     if (h === null)
       this.removeAttribute('hideafter');
     else
-      this.setAttribute('hideafter', h);
+      this.setAttribute('hideafter', h.toString());
   }
-  get hideafter(): string | null {
-    return this.getAttribute('hideafter');
+  get hideafter(): number | null {
+    const h = this.getAttribute('hideafter');
+    if (h === null)
+      return null;
+    return parseInt(h);
   }
 
   // Chooses what should be shown in the text field in each area of
@@ -393,8 +403,8 @@ export default class TimerBar extends HTMLElement {
       if (update)
         this.updateText();
     } else if (name === 'hideafter') {
-      this._hideAfter = Math.max(parseFloat(this.hideafter ?? '0'), 0);
-      if (this.value === '0') {
+      this._hideAfter = Math.max(this.hideafter ?? 0, 0);
+      if (this.value === 0) {
         if (this._hideAfter >= 0)
           this.hide();
         else

--- a/resources/timerbox.ts
+++ b/resources/timerbox.ts
@@ -40,47 +40,59 @@ export default class TimerBox extends HTMLElement {
   // The full duration of the current countdown. When this is changed,
   // the countdown restarts at the new value. If set to 0 then countdowns
   // are stopped.
-  set duration(d: string | null) {
+  set duration(d: number | null) {
     if (d === null)
       this.removeAttribute('duration');
     else
-      this.setAttribute('duration', d);
+      this.setAttribute('duration', d.toString());
   }
-  get duration(): string | null {
-    return this.getAttribute('duration');
+  get duration(): number | null {
+    const s = this.getAttribute('duration');
+    if (s === null)
+      return null;
+    return parseFloat(s);
   }
 
   // Below this a large box is shown, above it a small box is shown.
-  set threshold(t: string | null) {
+  set threshold(t: number | null) {
     if (t === null)
       this.removeAttribute('threshold');
     else
-      this.setAttribute('threshold', t);
+      this.setAttribute('threshold', t.toString());
   }
-  get threshold(): string | null {
-    return this.getAttribute('threshold');
+  get threshold(): number | null {
+    const t = this.getAttribute('threshold');
+    if (t === null)
+      return null;
+    return parseFloat(t);
   }
 
   // All visual dimensions are scaled by this.
-  set scale(s: string | null) {
+  set scale(s: number | null) {
     if (s === null)
       this.removeAttribute('scale');
     else
-      this.setAttribute('scale', s);
+      this.setAttribute('scale', s.toString());
   }
-  get scale(): string | null {
-    return this.getAttribute('scale');
+  get scale(): number | null {
+    const s = this.getAttribute('scale');
+    if (s === null)
+      return null;
+    return parseFloat(s);
   }
 
   // The displayed value is scaled by this.
-  set valuescale(s: string | null) {
+  set valuescale(s: number | null) {
     if (s === null)
       this.removeAttribute('valuescale');
     else
-      this.setAttribute('valuescale', s);
+      this.setAttribute('valuescale', s.toString());
   }
-  get valuescale(): string | null {
-    return this.getAttribute('valuescale');
+  get valuescale(): number | null {
+    const v = this.getAttribute('valuescale');
+    if (v === null)
+      return null;
+    return parseFloat(v);
   }
 
   // Background color.
@@ -126,16 +138,19 @@ export default class TimerBox extends HTMLElement {
     return this.getAttribute('stylefill') as 'fill' | 'empty';
   }
 
-  // When the timer reaches 0, it is hidden after this many seconds. If ""
+  // When the timer reaches 0, it is hidden after this many seconds. If `null`
   // then it is not hidden.
-  set hideafter(h: string | null) {
+  set hideafter(h: number | null) {
     if (h === null)
       this.removeAttribute('hideafter');
     else
-      this.setAttribute('hideafter', h);
+      this.setAttribute('hideafter', h.toString());
   }
-  get hideafter(): string | null {
-    return this.getAttribute('hideafter');
+  get hideafter(): number | null {
+    const h = this.getAttribute('duration');
+    if (h === null)
+      return null;
+    return parseFloat(h);
   }
 
   // When the timer reaches 0, it is big if this is true.
@@ -147,18 +162,18 @@ export default class TimerBox extends HTMLElement {
   }
 
   // The length remaining in the count down.
-  get value(): string {
+  get value(): number {
     if (!this._start)
-      return this._duration.toString();
+      return this._duration;
     const elapsedMs = new Date().getTime() - this._start;
-    return Math.max(0, this._duration - (elapsedMs / 1000)).toString();
+    return Math.max(0, this._duration - (elapsedMs / 1000));
   }
 
   // The elapsed time.
-  get elapsed(): string {
+  get elapsed(): number {
     if (!this._start)
-      return '0';
-    return ((new Date().getTime() - this._start) / 1000).toString();
+      return 0;
+    return (new Date().getTime() - this._start) / 1000;
   }
 
   // Whether to round up the value to the nearest integer before thresholding.
@@ -215,21 +230,21 @@ export default class TimerBox extends HTMLElement {
     this._notifyThresholdCallbacks = true;
 
     if (this.duration !== null)
-      this._duration = Math.max(parseFloat(this.duration), 0);
+      this._duration = Math.max(this.duration, 0);
     if (this.threshold !== null)
-      this._threshold = parseFloat(this.threshold);
+      this._threshold = this.threshold;
     if (this.bg !== null)
       this._bg = this.bg;
     if (this.fg !== null)
       this._fg = this.fg;
     if (this.scale !== null)
-      this._scale = Math.max(parseFloat(this.scale), 0.01);
+      this._scale = Math.max(this.scale, 0.01);
     if (this.toward !== null)
       this._towardTop = this.toward !== 'bottom';
     if (this.stylefill !== null)
       this._fill = this.stylefill !== 'empty';
-    if (this.hideafter !== null && this.hideafter !== '')
-      this._hideAfter = Math.max(parseFloat(this.hideafter), 0);
+    if (this.hideafter !== null && this.hideafter !== null)
+      this._hideAfter = Math.max(this.hideafter, 0);
   }
 
   init(root: ShadowRoot): void {
@@ -300,7 +315,7 @@ export default class TimerBox extends HTMLElement {
       this._fg = newValue;
       this.layout();
     } else if (name === 'hideafter') {
-      this._hideAfter = Math.max(parseFloat(this.hideafter ?? '0'), 0);
+      this._hideAfter = Math.max(this.hideafter ?? 0, 0);
       if (this._duration === 0 && this._hideAfter >= 0)
         this.hide();
       else if (this._hideAfter < 0)

--- a/resources/timericon.ts
+++ b/resources/timericon.ts
@@ -29,14 +29,17 @@ export default class TimerIcon extends HTMLElement {
   }
 
   // All visual dimensions are scaled by this.
-  set scale(s: string | null) {
+  set scale(s: number | null) {
     if (s === null)
       this.removeAttribute('scale');
     else
-      this.setAttribute('scale', s);
+      this.setAttribute('scale', s.toString());
   }
-  get scale(): string | null {
-    return this.getAttribute('scale');
+  get scale(): number | null {
+    const s = this.getAttribute('scale');
+    if (s === null)
+      return null;
+    return parseFloat(s);
   }
 
   // Border color.
@@ -84,26 +87,32 @@ export default class TimerIcon extends HTMLElement {
   }
 
   // The length of time to count down.
-  set duration(s: string | null) {
+  set duration(s: number | null) {
     if (s === null)
       this.removeAttribute('duration');
     else
-      this.setAttribute('duration', s);
+      this.setAttribute('duration', s.toString());
   }
-  get duration(): string | null {
-    return this.getAttribute('duration');
+  get duration(): number | null {
+    const s = this.getAttribute('duration');
+    if (s === null)
+      return null;
+    return parseFloat(s);
   }
 
-  // When the timer reaches 0, it is hidden after this many seconds. If ""
+  // When the timer reaches 0, it is hidden after this many seconds. If null
   // then it is not hidden.
-  set hideafter(h: string | null) {
+  set hideafter(h: number | null) {
     if (h === null)
       this.removeAttribute('hideafter');
     else
-      this.setAttribute('hideafter', h);
+      this.setAttribute('hideafter', h.toString());
   }
-  get hideafter(): string | null {
-    return this.getAttribute('hideafter');
+  get hideafter(): number | null {
+    const s = this.getAttribute('hideafter');
+    if (s === null)
+      return null;
+    return parseFloat(s);
   }
 
   // Sets the path to the image to show in the icon.
@@ -119,14 +128,17 @@ export default class TimerIcon extends HTMLElement {
 
   // Sets the number of pixels to zoom the icon. The image will be
   // grown by this amount and cropped to the widget.
-  set zoom(p: string | null) {
+  set zoom(p: number | null) {
     if (p === null)
       this.removeAttribute('zoom');
     else
-      this.setAttribute('zoom', p);
+      this.setAttribute('zoom', p.toString());
   }
-  get zoom(): string | null {
-    return this.getAttribute('zoom');
+  get zoom(): number | null {
+    const s = this.getAttribute('zoom');
+    if (s === null)
+      return null;
+    return parseFloat(s);
   }
 
   // Sets what text should be shown in the icon. If empty, no text.
@@ -191,7 +203,7 @@ export default class TimerIcon extends HTMLElement {
     this._hideTimer = 0;
 
     if (this.duration !== null)
-      this._duration = Math.max(parseFloat(this.duration), 0);
+      this._duration = Math.max(this.duration, 0);
     if (this.width !== null)
       this._width = Math.max(parseInt(this.width), 1);
     if (this.height !== null)
@@ -201,13 +213,13 @@ export default class TimerIcon extends HTMLElement {
     if (this.bordersize !== null)
       this._colorBorderSize = Math.max(parseInt(this.bordersize), 0);
     if (this.scale !== null)
-      this._scale = Math.max(parseFloat(this.scale), 0.01);
-    if (this.hideafter !== null && this.hideafter !== '')
-      this._hideAfter = Math.max(parseFloat(this.hideafter), 0);
+      this._scale = Math.max(this.scale, 0.01);
+    if (this.hideafter !== null)
+      this._hideAfter = Math.max(this.hideafter, 0);
     if (this.icon !== null)
       this._icon = this.icon;
     if (this.zoom !== null)
-      this._zoom = Math.max(parseInt(this.zoom), 0);
+      this._zoom = Math.max(this.zoom, 0);
     if (this.text !== null)
       this._text = this.text;
     if (this.textcolor !== null)

--- a/resources/widget_list.ts
+++ b/resources/widget_list.ts
@@ -3,6 +3,10 @@
 // just switch over to using CSS grid.
 type Sorter = () => number;
 
+type LeftRight = `${'left' | 'right'}`;
+type UpDown = `${'up' | 'down'}`;
+type Toward = `${LeftRight} ${UpDown}` | `${UpDown} ${LeftRight}`;
+
 const getRandomInt = (max: number) => Math.floor(Math.random() * Math.floor(max));
 
 export default class WidgetList extends HTMLElement {
@@ -26,14 +30,17 @@ export default class WidgetList extends HTMLElement {
   }
 
   // All visual dimensions are scaled by this.
-  set scale(s: string | null) {
+  set scale(s: number | null) {
     if (s === null)
       this.removeAttribute('scale');
     else
-      this.setAttribute('scale', s);
+      this.setAttribute('scale', s.toString());
   }
-  get scale(): string | null {
-    return this.getAttribute('scale');
+  get scale(): number | null {
+    const s = this.getAttribute('scale');
+    if (s === null)
+      return null;
+    return parseFloat(s);
   }
 
   // The direction that the list should grow. It can specify two
@@ -42,14 +49,14 @@ export default class WidgetList extends HTMLElement {
   // and the second being the direction is wraps for the next
   // row/column. eg. "left down" will grow a list toward the left,
   // and subsequent rows will be below the first.
-  set toward(s: string | null) {
+  set toward(s: Toward | null) {
     if (s === null)
       this.removeAttribute('toward');
     else
       this.setAttribute('toward', s);
   }
-  get toward(): string | null {
-    return this.getAttribute('toward');
+  get toward(): Toward | null {
+    return this.getAttribute('toward') as Toward;
   }
 
   // The elementwidth of each element in the list.
@@ -76,25 +83,31 @@ export default class WidgetList extends HTMLElement {
 
   // The number of elements to show before wrapping to a new
   // row/column.
-  set rowcolsize(w: string | null) {
+  set rowcolsize(w: number | null) {
     if (w === null)
       this.removeAttribute('rowcolsize');
     else
-      this.setAttribute('rowcolsize', w);
+      this.setAttribute('rowcolsize', w.toString());
   }
-  get rowcolsize(): string | null {
-    return this.getAttribute('rowcolsize');
+  get rowcolsize(): number | null {
+    const w = this.getAttribute('rowcolsize');
+    if (w === null)
+      return null;
+    return parseInt(w);
   }
 
   // The maximum number of widgets to show at a time.
-  set maxnumber(w: string | null) {
+  set maxnumber(w: number | null) {
     if (w === null)
       this.removeAttribute('maxnumber');
     else
-      this.setAttribute('maxnumber', w);
+      this.setAttribute('maxnumber', w.toString());
   }
-  get maxnumber(): string | null {
-    return this.getAttribute('maxnumber');
+  get maxnumber(): number | null {
+    const w = this.getAttribute('maxnumber');
+    if (w === null)
+      return null;
+    return parseInt(w);
   }
 
   // This would be used with window.customElements.

--- a/resources/widget_list.ts
+++ b/resources/widget_list.ts
@@ -3,8 +3,8 @@
 // just switch over to using CSS grid.
 type Sorter = () => number;
 
-type LeftRight = `${'left' | 'right'}`;
-type UpDown = `${'up' | 'down'}`;
+type LeftRight = 'left' | 'right';
+type UpDown = 'up' | 'down';
 type Toward = `${LeftRight} ${UpDown}` | `${UpDown} ${LeftRight}`;
 
 const getRandomInt = (max: number) => Math.floor(Math.random() * Math.floor(max));

--- a/ui/jobs/components/drk.ts
+++ b/ui/jobs/components/drk.ts
@@ -35,10 +35,10 @@ export const setup = (bars: Bars): void => {
       }
     }
 
-    const oldSeconds = parseFloat(darksideBox.duration ?? '0') - parseFloat(darksideBox.elapsed);
+    const oldSeconds = darksideBox.duration ?? 0 - darksideBox.elapsed;
     const seconds = jobDetail.darksideMilliseconds / 1000.0;
     if (!darksideBox.duration || seconds > oldSeconds)
-      darksideBox.duration = seconds.toString();
+      darksideBox.duration = seconds;
   });
 
   const comboTimer = bars.addTimerBar({
@@ -47,11 +47,11 @@ export const setup = (bars: Bars): void => {
   });
 
   bars.onCombo((skill) => {
-    comboTimer.duration = '0';
+    comboTimer.duration = 0;
     if (bars.combo.isFinalSkill)
       return;
     if (skill)
-      comboTimer.duration = '15';
+      comboTimer.duration = 15;
   });
 
   const bloodWeapon = bars.addProcBox({
@@ -59,12 +59,12 @@ export const setup = (bars: Bars): void => {
     fgColor: 'drk-color-bloodweapon',
   });
   bars.onUseAbility(kAbility.BloodWeapon, () => {
-    bloodWeapon.duration = '10';
-    bloodWeapon.threshold = '10';
+    bloodWeapon.duration = 10;
+    bloodWeapon.threshold = 10;
     bloodWeapon.fg = computeBackgroundColorFrom(bloodWeapon, 'drk-color-bloodweapon.active');
     tid1 = window.setTimeout(() => {
-      bloodWeapon.duration = '50';
-      bloodWeapon.threshold = (bars.gcdSkill * 2).toString();
+      bloodWeapon.duration = 50;
+      bloodWeapon.threshold = bars.gcdSkill * 2;
       bloodWeapon.fg = computeBackgroundColorFrom(bloodWeapon, 'drk-color-bloodweapon');
     }, 10000);
   });
@@ -74,12 +74,12 @@ export const setup = (bars: Bars): void => {
     fgColor: 'drk-color-delirium',
   });
   bars.onUseAbility(kAbility.Delirium, () => {
-    delirium.duration = '10.5';
-    delirium.threshold = '20';
+    delirium.duration = 10.5;
+    delirium.threshold = 20;
     delirium.fg = computeBackgroundColorFrom(delirium, 'drk-color-delirium.active');
     tid2 = window.setTimeout(() => {
-      delirium.duration = '79.5';
-      delirium.threshold = (bars.gcdSkill * 2).toString();
+      delirium.duration = 79.5;
+      delirium.threshold = bars.gcdSkill * 2;
       delirium.fg = computeBackgroundColorFrom(delirium, 'drk-color-delirium');
     }, 10000);
   });
@@ -89,28 +89,28 @@ export const setup = (bars: Bars): void => {
     fgColor: 'drk-color-livingshadow',
   });
   bars.onUseAbility(kAbility.LivingShadow, () => {
-    livingShadow.duration = '24';
-    livingShadow.threshold = '24';
+    livingShadow.duration = 24;
+    livingShadow.threshold = 24;
     livingShadow.fg = computeBackgroundColorFrom(livingShadow, 'drk-color-livingshadow.active');
     tid3 = window.setTimeout(() => {
-      livingShadow.duration = '96';
-      livingShadow.threshold = (bars.gcdSkill * 4).toString();
+      livingShadow.duration = 96;
+      livingShadow.threshold = bars.gcdSkill * 4;
       livingShadow.fg = computeBackgroundColorFrom(livingShadow, 'drk-color-livingshadow');
     }, 24000);
   });
 
   resetFunc = (bars: { gcdSkill: number }) => {
-    comboTimer.duration = '0';
-    bloodWeapon.duration = '0';
-    bloodWeapon.threshold = (bars.gcdSkill * 2).toString();
+    comboTimer.duration = 0;
+    bloodWeapon.duration = 0;
+    bloodWeapon.threshold = bars.gcdSkill * 2;
     bloodWeapon.fg = computeBackgroundColorFrom(bloodWeapon, 'drk-color-bloodweapon');
-    delirium.duration = '0';
-    delirium.threshold = (bars.gcdSkill * 2).toString();
+    delirium.duration = 0;
+    delirium.threshold = bars.gcdSkill * 2;
     delirium.fg = computeBackgroundColorFrom(delirium, 'drk-color-delirium');
-    livingShadow.duration = '0';
-    livingShadow.threshold = (bars.gcdSkill * 4).toString();
+    livingShadow.duration = 0;
+    livingShadow.threshold = bars.gcdSkill * 4;
     livingShadow.fg = computeBackgroundColorFrom(livingShadow, 'drk-color-livingshadow');
-    darksideBox.duration = '0';
+    darksideBox.duration = 0;
     clearTimeout(tid1);
     clearTimeout(tid2);
     clearTimeout(tid3);

--- a/ui/jobs/components/gnb.ts
+++ b/ui/jobs/components/gnb.ts
@@ -16,12 +16,12 @@ export const setup = (bars: Bars): void => {
     fgColor: 'gnb-color-nomercy',
   });
   bars.onUseAbility(kAbility.NoMercy, () => {
-    noMercyBox.duration = '20';
-    noMercyBox.threshold = '1000';
+    noMercyBox.duration = 20;
+    noMercyBox.threshold = 1000;
     noMercyBox.fg = computeBackgroundColorFrom(noMercyBox, 'gnb-color-nomercy.active');
     tid1 = window.setTimeout(() => {
-      noMercyBox.duration = '40';
-      noMercyBox.threshold = (bars.gcdSkill + 1).toString();
+      noMercyBox.duration = 40;
+      noMercyBox.threshold = bars.gcdSkill + 1;
       noMercyBox.fg = computeBackgroundColorFrom(noMercyBox, 'gnb-color-nomercy');
     }, 20000);
   });
@@ -31,15 +31,15 @@ export const setup = (bars: Bars): void => {
     fgColor: 'gnb-color-bloodfest',
   });
   bars.onUseAbility(kAbility.Bloodfest, () => {
-    bloodfestBox.duration = '90';
+    bloodfestBox.duration = 90;
   });
 
   bars.onStatChange('GNB', () => {
-    gnashingFangBox.valuescale = bars.gcdSkill.toString();
-    gnashingFangBox.threshold = (bars.gcdSkill * 3).toString();
-    noMercyBox.valuescale = bars.gcdSkill.toString();
-    bloodfestBox.valuescale = bars.gcdSkill.toString();
-    bloodfestBox.threshold = (bars.gcdSkill * 2 + 1).toString();
+    gnashingFangBox.valuescale = bars.gcdSkill;
+    gnashingFangBox.threshold = bars.gcdSkill * 3;
+    noMercyBox.valuescale = bars.gcdSkill;
+    bloodfestBox.valuescale = bars.gcdSkill;
+    bloodfestBox.threshold = bars.gcdSkill * 2 + 1;
   });
   // Combos
   const gnashingFangBox = bars.addProcBox({
@@ -55,24 +55,24 @@ export const setup = (bars: Bars): void => {
     fgColor: 'gnb-color-gnashingfang',
   });
   bars.onUseAbility(kAbility.GnashingFang, () => {
-    gnashingFangBox.duration = calcGCDFromStat(bars, bars.skillSpeed, 30000).toString();
-    cartridgeComboTimer.duration = '0';
-    cartridgeComboTimer.duration = '15';
+    gnashingFangBox.duration = calcGCDFromStat(bars, bars.skillSpeed, 30000);
+    cartridgeComboTimer.duration = 0;
+    cartridgeComboTimer.duration = 15;
   });
   bars.onUseAbility(kAbility.SavageClaw, () => {
-    cartridgeComboTimer.duration = '0';
-    cartridgeComboTimer.duration = '15';
+    cartridgeComboTimer.duration = 0;
+    cartridgeComboTimer.duration = 15;
   });
   bars.onUseAbility(kAbility.WickedTalon, () => {
-    cartridgeComboTimer.duration = '0';
+    cartridgeComboTimer.duration = 0;
   });
   bars.onCombo((skill) => {
-    comboTimer.duration = '0';
-    cartridgeComboTimer.duration = '0';
+    comboTimer.duration = 0;
+    cartridgeComboTimer.duration = 0;
     if (bars.combo.isFinalSkill)
       return;
     if (skill)
-      comboTimer.duration = '15';
+      comboTimer.duration = 15;
   });
 
   bars.onJobDetailUpdate((jobDetail: JobDetail['GNB']) => {
@@ -84,13 +84,13 @@ export const setup = (bars: Bars): void => {
   });
 
   resetFunc = (bars) => {
-    noMercyBox.duration = '0';
-    noMercyBox.threshold = (bars.gcdSkill + 1).toString();
+    noMercyBox.duration = 0;
+    noMercyBox.threshold = bars.gcdSkill + 1;
     noMercyBox.fg = computeBackgroundColorFrom(noMercyBox, 'gnb-color-nomercy');
-    bloodfestBox.duration = '0';
-    gnashingFangBox.duration = '0';
-    cartridgeComboTimer.duration = '0';
-    comboTimer.duration = '0';
+    bloodfestBox.duration = 0;
+    gnashingFangBox.duration = 0;
+    cartridgeComboTimer.duration = 0;
+    comboTimer.duration = 0;
     clearTimeout(tid1);
   };
 };

--- a/ui/jobs/components/mnk.js
+++ b/ui/jobs/components/mnk.js
@@ -64,7 +64,7 @@ export function setup(bars) {
 
   bars.onYouGainEffect(EffectId.TwinSnakes, (name, matches) => {
     // -0.5 for logline delay
-    twinSnakesBox.duration = (parseFloat(matches.duration) - 0.5).toString();
+    twinSnakesBox.duration = parseFloat(matches.duration) - 0.5;
   });
   bars.onYouLoseEffect(EffectId.TwinSnakes, () => twinSnakesBox.duration = 0);
 
@@ -83,7 +83,7 @@ export function setup(bars) {
   bars.onYouGainEffect(EffectId.PerfectBalance, (name, matches) => {
     if (!perfectBalanceActive) {
       formTimer.duration = 0;
-      formTimer.duration = parseFloat(matches.duration).toString();
+      formTimer.duration = parseFloat(matches.duration);
       formTimer.fg = computeBackgroundColorFrom(formTimer, 'mnk-color-pb');
       perfectBalanceActive = true;
     }

--- a/ui/jobs/jobs.js
+++ b/ui/jobs/jobs.js
@@ -236,7 +236,7 @@ class Bars {
     this.o.pullCountdown.height = window.getComputedStyle(pullCountdownContainer).height;
     this.o.pullCountdown.lefttext = kPullText[this.options.DisplayLanguage] || kPullText['en'];
     this.o.pullCountdown.righttext = 'remain';
-    this.o.pullCountdown.hideafter = '0';
+    this.o.pullCountdown.hideafter = 0;
     this.o.pullCountdown.fg = 'rgb(255, 120, 120)';
     this.o.pullCountdown.classList.add('lang-' + this.options.DisplayLanguage);
 
@@ -247,8 +247,8 @@ class Bars {
     this.o.rightBuffsList = document.createElement('widget-list');
     this.o.rightBuffsContainer.appendChild(this.o.rightBuffsList);
 
-    this.o.rightBuffsList.rowcolsize = '7';
-    this.o.rightBuffsList.maxnumber = '7';
+    this.o.rightBuffsList.rowcolsize = 7;
+    this.o.rightBuffsList.maxnumber = 7;
     this.o.rightBuffsList.toward = 'right down';
     this.o.rightBuffsList.elementwidth = (this.options.BigBuffIconWidth + 2).toString();
 
@@ -256,8 +256,8 @@ class Bars {
       // Just alias these two together so the rest of the code doesn't have
       // to care that they're the same thing.
       this.o.leftBuffsList = this.o.rightBuffsList;
-      this.o.rightBuffsList.rowcolsize = '20';
-      this.o.rightBuffsList.maxnumber = '20';
+      this.o.rightBuffsList.rowcolsize = 20;
+      this.o.rightBuffsList.maxnumber = 20;
       // Hoist the buffs up to hide everything else.
       barsLayoutContainer.appendChild(this.o.rightBuffsContainer);
       barsLayoutContainer.classList.add('justbuffs');
@@ -269,8 +269,8 @@ class Bars {
       this.o.leftBuffsList = document.createElement('widget-list');
       this.o.leftBuffsContainer.appendChild(this.o.leftBuffsList);
 
-      this.o.leftBuffsList.rowcolsize = '7';
-      this.o.leftBuffsList.maxnumber = '7';
+      this.o.leftBuffsList.rowcolsize = 7;
+      this.o.leftBuffsList.maxnumber = 7;
       this.o.leftBuffsList.toward = 'left down';
       this.o.leftBuffsList.elementwidth = (this.options.BigBuffIconWidth + 2).toString();
     }
@@ -453,10 +453,10 @@ class Bars {
       timerBox.fg = computeBackgroundColorFrom(timerBox, fgColor);
     timerBox.bg = 'black';
     timerBox.toward = 'bottom';
-    timerBox.threshold = `${threshold ? threshold : 0}`;
-    timerBox.hideafter = '';
+    timerBox.threshold = threshold ? threshold : 0;
+    timerBox.hideafter = null;
     timerBox.roundupthreshold = false;
-    timerBox.valuescale = `${scale ? scale : 1}`;
+    timerBox.valuescale = scale ? scale : 1;
     if (id) {
       timerBox.id = id;
       timerBox.classList.add('timer-box');
@@ -620,7 +620,7 @@ class Bars {
 
     // Hide out of combat if requested
     if (!this.options.ShowMPTickerOutOfCombat && !this.inCombat) {
-      this.o.mpTicker.duration = '0';
+      this.o.mpTicker.duration = 0;
       this.o.mpTicker.stylefill = 'empty';
       return;
     }
@@ -637,7 +637,7 @@ class Bars {
 
     const mpTick = Math.floor(this.maxMP * baseTick) + Math.floor(this.maxMP * umbralTick);
     if (delta === mpTick && this.umbralStacks <= 0) // MP ticks disabled in AF
-      this.o.mpTicker.duration = kMPTickInterval.toString();
+      this.o.mpTicker.duration = kMPTickInterval;
 
     // Update color based on the astral fire/ice state
     let colorTag = 'mp-tick-color';
@@ -653,8 +653,8 @@ class Bars {
 
     if (!this.o.manaBar)
       return;
-    this.o.manaBar.value = this.mp.toString();
-    this.o.manaBar.maxvalue = this.maxMP.toString();
+    this.o.manaBar.value = this.mp;
+    this.o.manaBar.maxvalue = this.maxMP;
     let lowMP = -1;
     let mediumMP = -1;
     let far = -1;
@@ -686,15 +686,15 @@ class Bars {
   _updateCp() {
     if (!this.o.cpBar)
       return;
-    this.o.cpBar.value = this.cp.toString();
-    this.o.cpBar.maxvalue = this.maxCP.toString();
+    this.o.cpBar.value = this.cp;
+    this.o.cpBar.maxvalue = this.maxCP;
   }
 
   _updateGp() {
     if (!this.o.gpBar)
       return;
-    this.o.gpBar.value = this.gp.toString();
-    this.o.gpBar.maxvalue = this.maxGP.toString();
+    this.o.gpBar.value = this.gp;
+    this.o.gpBar.maxvalue = this.maxGP;
 
     // GP Alarm
     if (this.gp < this.options.GpAlarmPoint) {
@@ -814,7 +814,7 @@ class Bars {
     const inCountdown = seconds > 0;
     const showingCountdown = parseFloat(this.o.pullCountdown.duration) > 0;
     if (inCountdown !== showingCountdown) {
-      this.o.pullCountdown.duration = seconds.toString();
+      this.o.pullCountdown.duration = seconds;
       if (inCountdown && this.options.PlayCountdownSound) {
         const audio = new Audio('../../resources/sounds/freesound/sonar.ogg');
         audio.volume = 0.3;

--- a/ui/jobs/utils.ts
+++ b/ui/jobs/utils.ts
@@ -179,7 +179,7 @@ export const makeAuraTimerIcon = (
     bar.width = iconWidth.toString();
     bar.height = barHeight.toString();
     bar.fg = barColor;
-    bar.duration = seconds.toString();
+    bar.duration = seconds;
     barDiv.appendChild(bar);
   }
 
@@ -207,7 +207,7 @@ export const makeAuraTimerIcon = (
     icon.text = iconText;
   icon.bordercolor = borderColor;
   icon.icon = auraIcon;
-  icon.duration = seconds.toString();
+  icon.duration = seconds;
 
   return div;
 };

--- a/ui/raidboss/timeline.ts
+++ b/ui/raidboss/timeline.ts
@@ -897,8 +897,8 @@ export class TimelineUI {
     const bar = document.createElement('timer-bar');
     div.classList.add('timer-bar');
     div.appendChild(bar);
-    bar.duration = `${channeling ? e.time - fightNow : this.options.ShowTimerBarsAtSeconds}`;
-    bar.value = `${e.time - fightNow}`;
+    bar.duration = channeling ? e.time - fightNow : this.options.ShowTimerBarsAtSeconds;
+    bar.value = e.time - fightNow;
     bar.righttext = 'remain';
     bar.lefttext = e.text;
     bar.toward = 'right';
@@ -1018,7 +1018,7 @@ export class TimelineUI {
       this.debugFightTimer = document.createElement('timer-bar');
       this.debugFightTimer.width = '100px';
       this.debugFightTimer.height = '17px';
-      this.debugFightTimer.duration = `${kBig}`;
+      this.debugFightTimer.duration = kBig;
       this.debugFightTimer.lefttext = 'elapsed';
       this.debugFightTimer.toward = 'right';
       this.debugFightTimer.stylefill = 'fill';
@@ -1028,8 +1028,8 @@ export class TimelineUI {
     }
 
     // Force this to be reset.
-    this.debugFightTimer.elapsed = '0';
-    this.debugFightTimer.elapsed = fightNow.toString();
+    this.debugFightTimer.elapsed = 0;
+    this.debugFightTimer.elapsed = fightNow;
   }
 }
 

--- a/ui/test/timerbar_test.ts
+++ b/ui/test/timerbar_test.ts
@@ -8,7 +8,7 @@ if (!only || only === 1) {
   bar = document.createElement('timer-bar');
   bar.lefttext = 'remain';
   bar.stylefill = 'fill';
-  bar.duration = '2';
+  bar.duration = 2;
   document.getElementById('d1')?.appendChild(bar);
   const div = document.createElement('p');
   div.innerHTML = 'test';
@@ -19,8 +19,8 @@ if (!only || only === 2) {
   bar = document.createElement('timer-bar');
   bar.lefttext = 'remain';
   bar.stylefill = 'fill';
-  bar.duration = '2';
-  bar.hideafter = '0.5';
+  bar.duration = 2;
+  bar.hideafter = 0.5;
   document.getElementById('d2')?.appendChild(bar);
 }
 
@@ -28,12 +28,12 @@ if (!only || only === 13) {
   bar = document.createElement('timer-bar');
   bar.lefttext = 'remain';
   bar.stylefill = 'fill';
-  bar.duration = '2';
+  bar.duration = 2;
   document.getElementById('d13')?.appendChild(bar);
   (function() {
     const hideBar = bar;
     window.setTimeout(() => {
-      hideBar.hideafter = '0';
+      hideBar.hideafter = 0;
     }, 2500);
   })();
 }
@@ -42,14 +42,14 @@ if (!only || only === 3) {
   bar = document.createElement('timer-bar');
   bar.lefttext = 'remain';
   bar.stylefill = 'fill';
-  bar.duration = '2';
-  bar.hideafter = '0';
+  bar.duration = 2;
+  bar.hideafter = 0;
   document.getElementById('d3')?.appendChild(bar);
   (function() {
     const repeatingBar = bar;
     const repeat = function() {
       // Setting value after duration ends does nothing.
-      repeatingBar.value = '2';
+      repeatingBar.value = 2;
       window.setTimeout(repeat, 3000);
     };
     repeat();
@@ -64,7 +64,7 @@ if (!only || only === 4) {
   (function() {
     const repeatingBar = bar;
     const repeat = function() {
-      repeatingBar.duration = '2';
+      repeatingBar.duration = 2;
       window.setTimeout(repeat, 3000);
     };
     repeat();
@@ -75,9 +75,9 @@ if (!only || only === 5) {
   bar = document.createElement('timer-bar');
   bar.lefttext = 'remain';
   bar.stylefill = 'fill';
-  bar.hideafter = '0';
-  bar.value = '0';
-  bar.duration = '2';
+  bar.hideafter = 0;
+  bar.value = 0;
+  bar.duration = 2;
   document.getElementById('d5')?.appendChild(bar);
 }
 
@@ -85,19 +85,19 @@ if (!only || only === 6) {
   bar = document.createElement('timer-bar');
   bar.lefttext = 'remain';
   bar.stylefill = 'fill';
-  bar.hideafter = '0';
+  bar.hideafter = 0;
   document.getElementById('d6')?.appendChild(bar);
-  bar.value = '0';
-  bar.duration = '2';
+  bar.value = 0;
+  bar.duration = 2;
 }
 
 if (!only || only === 7) {
   bar = document.createElement('timer-bar');
   bar.lefttext = 'remain';
   bar.stylefill = 'fill';
-  bar.hideafter = '0';
-  bar.duration = '6';
-  bar.value = '2';
+  bar.hideafter = 0;
+  bar.duration = 6;
+  bar.value = 2;
   document.getElementById('d7')?.appendChild(bar);
 }
 
@@ -105,17 +105,17 @@ if (!only || only === 8) {
   bar = document.createElement('timer-bar');
   bar.lefttext = 'remain';
   bar.stylefill = 'fill';
-  bar.hideafter = '0';
-  bar.duration = '6';
+  bar.hideafter = 0;
+  bar.duration = 6;
   document.getElementById('d8')?.appendChild(bar);
-  bar.value = '2';
+  bar.value = 2;
 }
 
 if (!only || only === 9) {
   bar = document.createElement('timer-bar');
   bar.lefttext = 'remain';
   bar.stylefill = 'empty';
-  bar.duration = '0';
+  bar.duration = 0;
   document.getElementById('d9')?.appendChild(bar);
 }
 
@@ -123,9 +123,9 @@ if (!only || only === 10) {
   bar = document.createElement('timer-bar');
   bar.lefttext = 'remain';
   bar.stylefill = 'empty';
-  bar.hideafter = '0';
-  bar.duration = '1';
-  bar.value = '0';
+  bar.hideafter = 0;
+  bar.duration = 1;
+  bar.value = 0;
   document.getElementById('d10')?.appendChild(bar);
 }
 
@@ -133,13 +133,13 @@ if (!only || only === 11) {
   bar = document.createElement('timer-bar');
   bar.lefttext = 'remain';
   bar.stylefill = 'fill';
-  bar.hideafter = '0';
+  bar.hideafter = 0;
   document.getElementById('d11')?.appendChild(bar);
-  bar.duration = '2';
+  bar.duration = 2;
   (function() {
     const repeatingBar = bar;
     window.setTimeout(() => {
-      repeatingBar.duration = '2';
+      repeatingBar.duration = 2;
     }, 1000);
   })();
 }
@@ -148,13 +148,13 @@ if (!only || only === 12) {
   bar = document.createElement('timer-bar');
   bar.lefttext = 'remain';
   bar.stylefill = 'fill';
-  bar.hideafter = '0';
+  bar.hideafter = 0;
   document.getElementById('d12')?.appendChild(bar);
-  bar.duration = '2';
+  bar.duration = 2;
   (function() {
     const repeatingBar = bar;
     window.setTimeout(() => {
-      repeatingBar.value = '2';
+      repeatingBar.value = 2;
     }, 1000);
   })();
 }
@@ -163,7 +163,7 @@ if (!only || only === 'b1') {
   bar = document.createElement('timer-bar');
   bar.lefttext = 'remain';
   bar.stylefill = 'fill';
-  bar.duration = '2';
+  bar.duration = 2;
   document.getElementById('b1')?.appendChild(bar);
 }
 
@@ -171,8 +171,8 @@ if (!only || only === 'b2') {
   bar = document.createElement('timer-bar');
   bar.lefttext = 'remain';
   bar.stylefill = 'fill';
-  bar.duration = '2';
-  bar.hideafter = '0.5';
+  bar.duration = 2;
+  bar.hideafter = 0.5;
   document.getElementById('b2')?.appendChild(bar);
 }
 
@@ -180,12 +180,12 @@ if (!only || only === 'b13') {
   bar = document.createElement('timer-bar');
   bar.lefttext = 'remain';
   bar.stylefill = 'fill';
-  bar.duration = '2';
+  bar.duration = 2;
   document.getElementById('b13')?.appendChild(bar);
   (function() {
     const hideBar = bar;
     window.setTimeout(() => {
-      hideBar.hideafter = '0';
+      hideBar.hideafter = 0;
     }, 2500);
   })();
 }
@@ -194,14 +194,14 @@ if (!only || only === 'b3') {
   bar = document.createElement('timer-bar');
   bar.lefttext = 'remain';
   bar.stylefill = 'fill';
-  bar.duration = '2';
-  bar.hideafter = '0';
+  bar.duration = 2;
+  bar.hideafter = 0;
   document.getElementById('b3')?.appendChild(bar);
   (function() {
     const repeatingBar = bar;
     const repeat = function() {
       // Setting elapsed after duration ends does nothing.
-      repeatingBar.elapsed = '0';
+      repeatingBar.elapsed = 0;
       window.setTimeout(repeat, 3000);
     };
     repeat();
@@ -216,7 +216,7 @@ if (!only || only === 'b4') {
   (function() {
     const repeatingBar = bar;
     const repeat = function() {
-      repeatingBar.duration = '2';
+      repeatingBar.duration = 2;
       window.setTimeout(repeat, 3000);
     };
     repeat();
@@ -227,9 +227,9 @@ if (!only || only === 'b5') {
   bar = document.createElement('timer-bar');
   bar.lefttext = 'remain';
   bar.stylefill = 'fill';
-  bar.hideafter = '0';
-  bar.elapsed = '2';
-  bar.duration = '2';
+  bar.hideafter = 0;
+  bar.elapsed = 2;
+  bar.duration = 2;
   document.getElementById('b5')?.appendChild(bar);
 }
 
@@ -237,19 +237,19 @@ if (!only || only === 'b6') {
   bar = document.createElement('timer-bar');
   bar.lefttext = 'remain';
   bar.stylefill = 'fill';
-  bar.hideafter = '0';
+  bar.hideafter = 0;
   document.getElementById('b6')?.appendChild(bar);
-  bar.elapsed = '2';
-  bar.duration = '2';
+  bar.elapsed = 2;
+  bar.duration = 2;
 }
 
 if (!only || only === 'b7') {
   bar = document.createElement('timer-bar');
   bar.lefttext = 'remain';
   bar.stylefill = 'fill';
-  bar.hideafter = '0';
-  bar.duration = '6';
-  bar.elapsed = '4';
+  bar.hideafter = 0;
+  bar.duration = 6;
+  bar.elapsed = 4;
   document.getElementById('b7')?.appendChild(bar);
 }
 
@@ -257,17 +257,17 @@ if (!only || only === 'b8') {
   bar = document.createElement('timer-bar');
   bar.lefttext = 'remain';
   bar.stylefill = 'fill';
-  bar.hideafter = '0';
-  bar.duration = '6';
+  bar.hideafter = 0;
+  bar.duration = 6;
   document.getElementById('b8')?.appendChild(bar);
-  bar.elapsed = '4';
+  bar.elapsed = 4;
 }
 
 if (!only || only === 'b9') {
   bar = document.createElement('timer-bar');
   bar.lefttext = 'remain';
   bar.stylefill = 'empty';
-  bar.duration = '0';
+  bar.duration = 0;
   document.getElementById('b9')?.appendChild(bar);
 }
 
@@ -275,9 +275,9 @@ if (!only || only === 'b10') {
   bar = document.createElement('timer-bar');
   bar.lefttext = 'remain';
   bar.stylefill = 'empty';
-  bar.hideafter = '0';
-  bar.duration = '1';
-  bar.elapsed = '1';
+  bar.hideafter = 0;
+  bar.duration = 1;
+  bar.elapsed = 1;
   document.getElementById('b10')?.appendChild(bar);
 }
 
@@ -285,13 +285,13 @@ if (!only || only === 'b11') {
   bar = document.createElement('timer-bar');
   bar.lefttext = 'remain';
   bar.stylefill = 'fill';
-  bar.hideafter = '0';
+  bar.hideafter = 0;
   document.getElementById('b11')?.appendChild(bar);
-  bar.duration = '2';
+  bar.duration = 2;
   (function() {
     const repeatingBar = bar;
     window.setTimeout(() => {
-      repeatingBar.duration = '2';
+      repeatingBar.duration = 2;
     }, 1000);
   })();
 }
@@ -300,29 +300,29 @@ if (!only || only === 'b12') {
   bar = document.createElement('timer-bar');
   bar.lefttext = 'remain';
   bar.stylefill = 'fill';
-  bar.hideafter = '0';
+  bar.hideafter = 0;
   document.getElementById('b12')?.appendChild(bar);
-  bar.duration = '2';
+  bar.duration = 2;
   (function() {
     const repeatingBar = bar;
     window.setTimeout(() => {
-      repeatingBar.elapsed = '0';
+      repeatingBar.elapsed = 0;
     }, 1000);
   })();
 }
 
 if (!only || only === 'c1') {
   bar = document.createElement('timer-bar');
-  bar.duration = '10000';
-  bar.value = '9000';
+  bar.duration = 10000;
+  bar.value = 9000;
   document.getElementById('c1')?.appendChild(bar);
   bar.fg = 'green';
 }
 
 if (!only || only === 'c2') {
   bar = document.createElement('timer-bar');
-  bar.duration = '10000';
-  bar.value = '9000';
+  bar.duration = 10000;
+  bar.value = 9000;
   document.getElementById('c2')?.appendChild(bar);
   bar.bg = 'green';
   bar.fg = 'grey';
@@ -330,8 +330,8 @@ if (!only || only === 'c2') {
 
 if (!only || only === 'c3') {
   bar = document.createElement('timer-bar');
-  bar.duration = '10000';
-  bar.value = '9000';
+  bar.duration = 10000;
+  bar.value = 9000;
   document.getElementById('c3')?.appendChild(bar);
   bar.lefttext = 'remain';
   bar.centertext = 'elapsed';
@@ -340,8 +340,8 @@ if (!only || only === 'c3') {
 
 if (!only || only === 'c4') {
   bar = document.createElement('timer-bar');
-  bar.duration = '10000';
-  bar.value = '9000';
+  bar.duration = 10000;
+  bar.value = 9000;
   document.getElementById('c4')?.appendChild(bar);
   bar.lefttext = 'elapsed';
   bar.centertext = 'percent';
@@ -350,8 +350,8 @@ if (!only || only === 'c4') {
 
 if (!only || only === 'c5') {
   bar = document.createElement('timer-bar');
-  bar.duration = '10000';
-  bar.value = '9000';
+  bar.duration = 10000;
+  bar.value = 9000;
   document.getElementById('c5')?.appendChild(bar);
   bar.lefttext = 'percent';
   bar.centertext = 'duration';
@@ -360,8 +360,8 @@ if (!only || only === 'c5') {
 
 if (!only || only === 'c6') {
   bar = document.createElement('timer-bar');
-  bar.duration = '10000';
-  bar.value = '9000';
+  bar.duration = 10000;
+  bar.value = 9000;
   document.getElementById('c6')?.appendChild(bar);
   bar.lefttext = 'duration';
   bar.centertext = 'fixed';
@@ -370,8 +370,8 @@ if (!only || only === 'c6') {
 
 if (!only || only === 'c7') {
   bar = document.createElement('timer-bar');
-  bar.duration = '10000';
-  bar.value = '9000';
+  bar.duration = 10000;
+  bar.value = 9000;
   document.getElementById('c7')?.appendChild(bar);
   bar.lefttext = 'fixed';
   bar.centertext = 'remain';
@@ -380,8 +380,8 @@ if (!only || only === 'c7') {
 
 if (!only || only === 'c8') {
   bar = document.createElement('timer-bar');
-  bar.duration = '10000';
-  bar.value = '9000';
+  bar.duration = 10000;
+  bar.value = 9000;
   document.getElementById('c8')?.appendChild(bar);
   bar.width = '50px';
   bar.height = '10px';
@@ -389,8 +389,8 @@ if (!only || only === 'c8') {
 
 if (!only || only === 'c9') {
   bar = document.createElement('timer-bar');
-  bar.duration = '10000';
-  bar.value = '9000';
+  bar.duration = 10000;
+  bar.value = 9000;
   document.getElementById('c9')?.appendChild(bar);
   bar.width = '50%';
   bar.height = '50%';
@@ -398,8 +398,8 @@ if (!only || only === 'c9') {
 
 if (!only || only === 'c10') {
   bar = document.createElement('timer-bar');
-  bar.duration = '100';
-  bar.value = '90';
+  bar.duration = 100;
+  bar.value = 90;
   document.getElementById('c10')?.appendChild(bar);
   bar.stylefill = 'empty';
   bar.toward = 'left';
@@ -407,8 +407,8 @@ if (!only || only === 'c10') {
 
 if (!only || only === 'c11') {
   bar = document.createElement('timer-bar');
-  bar.duration = '100';
-  bar.value = '90';
+  bar.duration = 100;
+  bar.value = 90;
   document.getElementById('c11')?.appendChild(bar);
   bar.stylefill = 'fill';
   bar.toward = 'left';
@@ -416,8 +416,8 @@ if (!only || only === 'c11') {
 
 if (!only || only === 'c12') {
   bar = document.createElement('timer-bar');
-  bar.duration = '100';
-  bar.value = '90';
+  bar.duration = 100;
+  bar.value = 90;
   document.getElementById('c12')?.appendChild(bar);
   bar.stylefill = 'empty';
   bar.toward = 'right';
@@ -425,8 +425,8 @@ if (!only || only === 'c12') {
 
 if (!only || only === 'c13') {
   bar = document.createElement('timer-bar');
-  bar.duration = '100';
-  bar.value = '90';
+  bar.duration = 100;
+  bar.value = 90;
   document.getElementById('c13')?.appendChild(bar);
   bar.stylefill = 'fill';
   bar.toward = 'right';


### PR DESCRIPTION
It is really weird to always `.toString()` before assigning to those properties that are actually numbers inside the component,
so it is better to put the conversion inside the component.

And I change the assigning style of all components to make them consistent.