### PR TITLE
refactor(jobs): direct compute MNK lightning stack

### DIFF
--- a/ui/jobs/bar.d.ts
+++ b/ui/jobs/bar.d.ts
@@ -22,7 +22,6 @@ export interface Bars {
     circleOfPower: boolean;
     presenceOfMind: boolean;
     paeonStacks: number;
-    lightningStacks: number;
     huton: boolean;
     shifu: boolean;
     museStacks: 1 | 2 | 3 | 4;

--- a/ui/jobs/components/mnk.js
+++ b/ui/jobs/components/mnk.js
@@ -15,17 +15,6 @@ export function setup(bars) {
     classList: ['mnk-color-chakra'],
   });
 
-  const getLightningStacksViaLevel = (level) => {
-    if (level < 20)
-      return 1;
-    else if (level < 40)
-      return 2;
-    else if (level < 76)
-      return 3;
-    return 4;
-  };
-
-
   bars.onJobDetailUpdate((jobDetail) => {
     const chakra = jobDetail.chakraStacks;
     if (textBox.innerText !== chakra) {
@@ -36,10 +25,6 @@ export function setup(bars) {
       else
         p.classList.remove('dim');
     }
-
-    // After the 5.4 changes, we just assign bars.speedBuffs.lightningStacks
-    // as corresponding stacks via current level
-    bars.speedBuffs.lightningStacks = getLightningStacksViaLevel(bars.level);
   });
 
   const dragonKickBox = bars.addProcBox({

--- a/ui/jobs/jobs.js
+++ b/ui/jobs/jobs.js
@@ -104,7 +104,6 @@ class Bars {
       presenceOfMind: 0,
       shifu: 0,
       huton: 0,
-      lightningStacks: 0,
       paeonStacks: 0,
       museStacks: 0,
       circleOfPower: 0,

--- a/ui/jobs/utils.ts
+++ b/ui/jobs/utils.ts
@@ -77,7 +77,7 @@ export class RegexesHolder {
 export const doesJobNeedMPBar = (job: Job): boolean =>
   Util.isCasterDpsJob(job) || Util.isHealerJob(job) || kMeleeWithMpJobs.includes(job);
 
-/** compute lightning stacks by player's level */
+/** compute greased lightning stacks by player's level */
 const getLightningStacksByLevel = (level: number): number =>
   level < 20 ? 1 : level < 40 ? 2 : level < 76 ? 3 : 4;
 

--- a/ui/jobs/utils.ts
+++ b/ui/jobs/utils.ts
@@ -77,6 +77,10 @@ export class RegexesHolder {
 export const doesJobNeedMPBar = (job: Job): boolean =>
   Util.isCasterDpsJob(job) || Util.isHealerJob(job) || kMeleeWithMpJobs.includes(job);
 
+/** compute lightning stacks by player's level */
+const getLightningStacksByLevel = (level: number): number =>
+  level < 20 ? 1 : level < 40 ? 2 : level < 76 ? 3 : 4;
+
 // Source: http://theoryjerks.akhmorning.com/guide/speed/
 export const calcGCDFromStat = (bars: Bars, stat: number, actionDelay = 2500): number => {
   // If stats haven't been updated, use a reasonable default value.
@@ -102,7 +106,7 @@ export const calcGCDFromStat = (bars: Bars, stat: number, actionDelay = 2500): n
   if (bars.job === 'NIN') {
     type2Buffs += bars.speedBuffs.huton ? 15 : 0;
   } else if (bars.job === 'MNK') {
-    type2Buffs += 5 * bars.speedBuffs.lightningStacks;
+    type2Buffs += 5 * getLightningStacksByLevel(bars.level);
   } else if (bars.job === 'BRD') {
     type2Buffs += 4 * bars.speedBuffs.paeonStacks;
     switch (bars.speedBuffs.museStacks) {


### PR DESCRIPTION
After patch 5.4 update, MNK's Greased Lightning is not
binding on GCD/Combo anymore.
Nowadays it is traits which only be affected by player's current level,
we can directly compute the corresponding `stacks`, so
move the computing code into `calcGCDFromStat` function.

------
By the way, @quisquous should/can I remove the related code from `FFXIVProcessIntl.cs`, etc?
For example, like this?
```diff
-   [StructLayout(LayoutKind.Explicit)]
-   public struct PugilistJobMemory {
-     [FieldOffset(0x00)]
-     public ushort lightningMilliseconds;
-
-     [FieldOffset(0x02)]
-     public byte lightningStacks;
-   };
-
    [StructLayout(LayoutKind.Explicit)]
    public struct MonkJobMemory {
-     [FieldOffset(0x00)]
-     public ushort lightningMilliseconds;
- 
-     [FieldOffset(0x02)]
-     public byte lightningStacks;
      // I don't know if this `Offset` is correct though
      [FieldOffset(0x03)]
      public byte chakraStacks;

-     [NonSerialized]
-     [FieldOffset(0x04)]
-     private byte _lightningTimerState;
-
-     public bool lightningTimerFrozen {
-       get {
-         return (_lightningTimerState > 0);
-       }
-     }
    };
```