### PR TITLE
Raidboss: Reduce annoyance in A8n

### DIFF
--- a/ui/raidboss/data/03-hw/raid/a8n.ts
+++ b/ui/raidboss/data/03-hw/raid/a8n.ts
@@ -20,14 +20,22 @@ const triggerSet: TriggerSet<Data> = {
     {
       id: 'A8N Hydrothermal Missile',
       regex: /Hydrothermal Missile/,
-      beforeSeconds: 3,
+      beforeSeconds: 4,
+      suppressSeconds: 5,
       response: Responses.tankCleave(),
     },
     {
       id: 'A8N Flarethrower',
       regex: /Flarethrower/,
-      beforeSeconds: 3,
+      beforeSeconds: 4,
       response: Responses.tankCleave(),
+    },
+    {
+      id: 'A8N Short Needle',
+      regex: /Short Needle/,
+      beforeSeconds: 4,
+      condition: Conditions.caresAboutAOE(),
+      response: Responses.aoe(),
     },
     {
       id: 'A8N Super Jump Soon',
@@ -262,18 +270,6 @@ const triggerSet: TriggerSet<Data> = {
           ko: '산개하기! (광역 탱버)',
         },
       },
-    },
-    {
-      id: 'A8N Short Needle',
-      type: 'Ability',
-      netRegex: NetRegexes.ability({ source: 'Brute Justice', id: '1753', capture: false }),
-      netRegexDe: NetRegexes.ability({ source: 'Brutalus', id: '1753', capture: false }),
-      netRegexFr: NetRegexes.ability({ source: 'Justicier', id: '1753', capture: false }),
-      netRegexJa: NetRegexes.ability({ source: 'ブルートジャスティス', id: '1753', capture: false }),
-      netRegexCn: NetRegexes.ability({ source: '残暴正义号', id: '1753', capture: false }),
-      netRegexKo: NetRegexes.ability({ source: '포악한 심판자', id: '1753', capture: false }),
-      condition: Conditions.caresAboutAOE(),
-      response: Responses.aoe(),
     },
     {
       id: 'A8N Apocalyptic Ray',

--- a/ui/raidboss/data/03-hw/raid/a8n.txt
+++ b/ui/raidboss/data/03-hw/raid/a8n.txt
@@ -21,8 +21,8 @@ hideall "Brute Force"
 12.6 "Mega Beam" sync /:Onslaughter:1732:/
 
 18.8 "Perpetual Ray" sync /:Onslaughter:1730:/
-24.0 "Hydrothermal Missile" sync /:Onslaughter:172F:/
-27.1 "Hydrothermal Missile" sync /:Onslaughter:172F:/
+24.0 "Hydrothermal Missile" # sync /:Onslaughter:172F:/
+27.1 "Hydrothermal Missile" # sync /:Onslaughter:172F:/
 33.2 "Execution" sync /:Onslaughter:1632:/
 37.3 "Hydrothermal Missile" sync /:Onslaughter:172F:/
 45.5 "Seed Of The Sky" sync /:Onslaughter:1731:/
@@ -30,8 +30,8 @@ hideall "Brute Force"
 55.2 "--regulator check--" # sync /:Steam Regulator B:1735:/
 55.6 "Hydrothermal Missile" sync /:Onslaughter:172F:/
 61.8 "Perpetual Ray" sync /:Onslaughter:1730:/
-67.0 "Hydrothermal Missile" sync /:Onslaughter:172F:/
-70.1 "Hydrothermal Missile" sync /:Onslaughter:172F:/
+67.0 "Hydrothermal Missile" # sync /:Onslaughter:172F:/
+70.1 "Hydrothermal Missile" # sync /:Onslaughter:172F:/
 75.2 "Discoid" sync /:Onslaughter:162F:/
 79.3 "Hydrothermal Missile" sync /:Onslaughter:172F:/
 90.5 "Seed Of The Sky" sync /:Onslaughter:1731:/


### PR DESCRIPTION
(This will conflict with and possibly replace #3303.)

As I noted on Valarnin's pull request, this is one of those things I kept meaning to do and kept forgetting. I wasn't able to get a group for this to test, but I did run it through solo, and it didn't *feel* annoying. Short Needle and Hydrothermal Missile correctly called only once for each position on the timeline.

I went ahead and commented out the Hydrothermal syncs that were within 4 seconds of each other. Technically they should have been okay, but I figured it was best to be safe.

No idea what's going on with the end-of-file newline. I would have said it was a Unix-vs-Windows thing, but I'm the only person who's touched this file. Regardless, it shouldn't be a serious issue.