### PR TITLE
Build: turn on babel cache & use babel for TS building

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1024,6 +1024,15 @@
         "@babel/helper-plugin-utils": "^7.14.5"
       }
     },
+    "@babel/plugin-syntax-typescript": {
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.14.5.tgz",
+      "integrity": "sha512-u6OXzDaIXjEstBRRoBCQ/uKQKlbuaeE5in0RvWdA4pN6AhqxTIwUsnHPU1CFZA/amYObMsuWhYfRl3Ch90HD0Q==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.14.5"
+      }
+    },
     "@babel/plugin-transform-arrow-functions": {
       "version": "7.14.5",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.14.5.tgz",
@@ -1325,6 +1334,33 @@
         "@babel/helper-plugin-utils": "^7.14.5"
       }
     },
+    "@babel/plugin-transform-typescript": {
+      "version": "7.14.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.14.6.tgz",
+      "integrity": "sha512-XlTdBq7Awr4FYIzqhmYY80WN0V0azF74DMPyFqVHBvf81ZUgc4X7ZOpx6O8eLDK6iM5cCQzeyJw0ynTaefixRA==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-create-class-features-plugin": "^7.14.6",
+        "@babel/helper-plugin-utils": "^7.14.5",
+        "@babel/plugin-syntax-typescript": "^7.14.5"
+      },
+      "dependencies": {
+        "@babel/helper-create-class-features-plugin": {
+          "version": "7.14.6",
+          "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.14.6.tgz",
+          "integrity": "sha512-Z6gsfGofTxH/+LQXqYEK45kxmcensbzmk/oi8DmaQytlQCgqNZt9XQF8iqlI/SeXWVjaMNxvYvzaYw+kh42mDg==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-annotate-as-pure": "^7.14.5",
+            "@babel/helper-function-name": "^7.14.5",
+            "@babel/helper-member-expression-to-functions": "^7.14.5",
+            "@babel/helper-optimise-call-expression": "^7.14.5",
+            "@babel/helper-replace-supers": "^7.14.5",
+            "@babel/helper-split-export-declaration": "^7.14.5"
+          }
+        }
+      }
+    },
     "@babel/plugin-transform-unicode-escapes": {
       "version": "7.14.5",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-escapes/-/plugin-transform-unicode-escapes-7.14.5.tgz",
@@ -1460,6 +1496,17 @@
         "@babel/plugin-transform-dotall-regex": "^7.4.4",
         "@babel/types": "^7.4.4",
         "esutils": "^2.0.2"
+      }
+    },
+    "@babel/preset-typescript": {
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/preset-typescript/-/preset-typescript-7.14.5.tgz",
+      "integrity": "sha512-u4zO6CdbRKbS9TypMqrlGH7sd2TAJppZwn3c/ZRLeO/wGsbddxgbPDUZVNrie3JWYLQ9vpineKlsrWFvO6Pwkw==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.14.5",
+        "@babel/helper-validator-option": "^7.14.5",
+        "@babel/plugin-transform-typescript": "^7.14.5"
       }
     },
     "@babel/runtime": {

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "@actions/http-client": "^1.0.11",
     "@babel/core": "^7.14.5",
     "@babel/preset-env": "^7.14.5",
+    "@babel/preset-typescript": "^7.14.5",
     "@babel/types": "7.12.*",
     "@types/argparse": "^1.0.10",
     "@types/copy-webpack-plugin": "^8.0.0",

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -6,10 +6,9 @@
         "after": true
       }
     ],
-    // nullish coalescing operator not supported in OverlayPlugin's Chrome M75
-    // TODO: change to ES2020 once OverlayPlugin rolls CEF past M80.
-    "target": "ES2019",
-    "module": "ES2020",
+    // Thanks to babel-loader, we don't need to set it as ES2019.
+    "target": "ESNext",
+    "module": "ESNext",
     "allowJs": true,
     "strict": true,
     "declaration": false,

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -7,7 +7,8 @@
       }
     ],
     // Thanks to babel-loader, we don't need to set it as ES2019.
-    "target": "ESNext",
+    // But we need to set it as ES2020 to ensure mocha can run correctly.
+    "target": "ES2020",
     "module": "ESNext",
     "allowJs": true,
     "strict": true,

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -9,7 +9,7 @@
     // Thanks to babel-loader, we don't need to set it as ES2019.
     // But we need to set it as ES2020 to ensure mocha can run correctly.
     "target": "ES2020",
-    "module": "ESNext",
+    "module": "ES2020",
     "allowJs": true,
     "strict": true,
     "declaration": false,

--- a/webpack/webpack.config.ts
+++ b/webpack/webpack.config.ts
@@ -103,10 +103,29 @@ export default (
         },
         {
           test: /\.ts$/,
-          loader: 'ts-loader',
-          options: {
-            transpileOnly: true,
-          },
+          use: [
+            {
+              loader: 'babel-loader',
+              options: {
+                cacheDirectory: true,
+                cacheCompression: false,
+                presets: [
+                  [
+                    '@babel/preset-env',
+                    {
+                      targets: { chrome: '75' },
+                    },
+                  ],
+                ],
+              },
+            },
+            {
+              loader: 'ts-loader',
+              options: {
+                transpileOnly: true,
+              },
+            },
+          ],
         },
         {
           test: /\.css$/,

--- a/webpack/webpack.config.ts
+++ b/webpack/webpack.config.ts
@@ -80,7 +80,9 @@ export default (
       rules: [
         {
           // this will allow importing without extension in js files.
-          test: /\.m?js$/,
+          // Use babel to transform TypeScript files, but babel has no
+          // type checking, so we need ForkTsCheckerWebpackPlugin.
+          test: /\.(m?j|t)s$/,
           exclude: /(node_modules|bower_components)/,
           use: {
             loader: 'babel-loader',
@@ -94,38 +96,15 @@ export default (
                     targets: { chrome: '75' },
                   },
                 ],
+                [
+                  '@babel/preset-typescript',
+                ],
               ],
             },
           },
           resolve: {
             fullySpecified: false,
           },
-        },
-        {
-          test: /\.ts$/,
-          use: [
-            {
-              loader: 'babel-loader',
-              options: {
-                cacheDirectory: true,
-                cacheCompression: false,
-                presets: [
-                  [
-                    '@babel/preset-env',
-                    {
-                      targets: { chrome: '75' },
-                    },
-                  ],
-                ],
-              },
-            },
-            {
-              loader: 'ts-loader',
-              options: {
-                transpileOnly: true,
-              },
-            },
-          ],
         },
         {
           test: /\.css$/,

--- a/webpack/webpack.config.ts
+++ b/webpack/webpack.config.ts
@@ -85,6 +85,8 @@ export default (
           use: {
             loader: 'babel-loader',
             options: {
+              cacheDirectory: true,
+              cacheCompression: false,
               presets: [
                 [
                   '@babel/preset-env',


### PR DESCRIPTION
- Turn on babel cache

It is helpful to enable babel cache when in rebuilding (e.g. running webpack-dev-server), which would significantly decrease the building time.

- Use babel for TypeScript building

Although `ts-loader` (`tsc` inside) and `babel-loader` (`babel` inside) would basically do the same thing in TypeScript transform, `babel-loader` removes type notations only, and doesn't do the type-checking things, so it would be faster than `ts-loader` (even with `transpileOnly` flag) in most cases. Additionally, we now need `babel-loader` to ensure code available always in Chrome v75 of current CEF, so why not combine them in one loader?

- How is TypeScript type checking now

Nowadays we are using `fork-ts-checker-webpack-plugin` for type checking, which runs `tsc` in a separated process and report errors asynchronously (in production mode), that would not block webpack building (that `ts-loader` will).