### PR TITLE
Raidboss/Oopsy: Add Drowned City of  Skalla dungeon package

### DIFF
--- a/ui/oopsyraidsy/data/04-sb/dungeon/drowned_city_of_skalla.ts
+++ b/ui/oopsyraidsy/data/04-sb/dungeon/drowned_city_of_skalla.ts
@@ -1,0 +1,46 @@
+import ZoneId from '../../../../../resources/zone_id';
+import { OopsyData } from '../../../../../types/data';
+import { OopsyTriggerSet } from '../../../../../types/oopsy';
+
+export type Data = OopsyData;
+
+const triggerSet: OopsyTriggerSet<Data> = {
+  zoneId: ZoneId.TheDrownedCityOfSkalla,
+  damageWarn: {
+    'Hydrocannon': '2697', // Line AoE, Salt Swallow trash, before boss 1
+    'Stagnant Spray': '2699', // Conal AoE, Skalla Nanka trash, before boss 1
+
+    'Bubble Burst': '261B', // Bubble explosion, Hydrosphere, boss 1
+
+    'Plain Pound': '269A', // Large circle AoE, Dhara Sentinel trash, before boss 2
+    'Boulder Toss': '269B', // Small circle AoE, Stone Phoebad trash, before boss 2
+    'Landslip': '269C', // Conal AoE, Stone Phoebad trash, before boss 2
+
+    'Mystic Light': '2657', // Conal AoE, The Old One, boss 2
+    'Mystic Flame': '2659', // Large circle AoE, The Old One, boss 2. 2658 is the cast-time ability.
+
+    'Dark II': '110E', // Thin cone AoE, Lightless Homunculus trash, after boss 2
+    'Implosive Curse': '269E', // Conal AoE, Zangbeto trash, after boss 2
+    'Undying FIre': '269F', // Circle AoE, Zangbeto trash, after boss 2
+    'Fire II': '26A0', // Circle AoE, Accursed Idol trash, after boss 2
+
+    'Rusting Claw': '2661', // Frontal cleave, Hrodric Poisontongue, boss 3
+    'Words Of Woe': '2662', // Eye lasers, Hrodric Poisontongue, boss 3
+    'Tail Drive': '2663', // Rear cleave, Hrodric Poisontongue, boss 3
+    'Ring Of Chaos': '2667', // Ring headmarker, Hrodric Poisontongue, boss 3
+  },
+  damageFail: {
+    'Self-Detonate': '265C', // Roomwide explosion, Subservient, boss 2
+  },
+  gainsEffectWarn: {
+    'Dropsy': '11B', // Standing in Bloody Puddles, or being knocked outside the arena, boss 1
+    'Confused': '0B', // Failing the gaze attack, boss 3
+  },
+  shareWarn: {
+    'Bloody Puddle': '2655', // Large watery spread circles, Kelpie, boss 1
+    'Cross Of Chaos': '2668', // Cross headmarker, Hrodric Poisontongue, boss 3
+    'Circle Of Chaos': '2669', // Spread circle headmarker, Hrodric Poisontongue, boss 3
+  },
+};
+
+export default triggerSet;

--- a/ui/oopsyraidsy/data/oopsy_manifest.txt
+++ b/ui/oopsyraidsy/data/oopsy_manifest.txt
@@ -16,6 +16,7 @@
 03-hw/raid/a12n.ts
 04-sb/dungeon/ala_mhigo.ts
 04-sb/dungeon/bardams_mettle.ts
+04-sb/dungeon/drowned_city_of_skalla.ts
 04-sb/dungeon/kugane_castle.ts
 04-sb/dungeon/st_mocianne_hard.ts
 04-sb/dungeon/swallows_compass.ts

--- a/ui/raidboss/data/04-sb/dungeon/drowned_city_of_skalla.ts
+++ b/ui/raidboss/data/04-sb/dungeon/drowned_city_of_skalla.ts
@@ -1,3 +1,4 @@
+import conditions from '../../../../../resources/conditions';
 import NetRegexes from '../../../../../resources/netregexes';
 import { Responses } from '../../../../../resources/responses';
 import ZoneId from '../../../../../resources/zone_id';
@@ -8,9 +9,57 @@ export type Data = RaidbossData;
 
 const triggerSet: TriggerSet<Data> = {
   zoneId: ZoneId.TheDrownedCityOfSkalla,
+  timelineFile: 'drowned_city_of_skalla.txt',
+  timelineTriggers: [
+    {
+      // There is a startsUsing line, but the cast time is under 3 seconds.
+      id: 'Skalla Torpedo',
+      regex: /Torpedo/,
+      beforeSeconds: 4,
+      condition: conditions.caresAboutPhysical(),
+      response: Responses.tankBuster(),
+    },
+    {
+      id: 'Skalla Bubble Burst',
+      regex: /Bubble Burst/,
+      beforeSeconds: 3,
+      infoText: (_data, _matches, output) => output.text!(),
+      outputStrings: {
+        text: {
+          en: 'Avoid Bubble Explosions',
+        },
+      },
+    },
+  ],
   triggers: [
     {
-      id: 'Hrodric Tank',
+      id: 'Skalla Rising Seas',
+      type: 'StartsUsing',
+      netRegex: NetRegexes.startsUsing({ id: '2650', source: 'Kelpie', capture: false }),
+      condition: conditions.caresAboutMagical(),
+      response: Responses.aoe(),
+    },
+    {
+      id: 'Skalla Hydro Pull',
+      type: 'StartsUsing',
+      netRegex: NetRegexes.startsUsing({ id: '2651', source: 'Kelpie', capture: false }),
+      response: Responses.getOut(),
+    },
+    {
+      id: 'Skalla Hydro Push',
+      type: 'StartsUsing',
+      netRegex: NetRegexes.startsUsing({ id: '2652', source: 'Kelpie', capture: false }),
+      response: Responses.knockback(),
+    },
+    {
+      id: 'Skalla Bloody Puddle',
+      type: 'HeadMarker',
+      netRegex: NetRegexes.headMarker({ id: '002B' }),
+      condition: conditions.targetIsYou(),
+      response: Responses.spread(),
+    },
+    {
+      id: 'Skalla Rusting Claw',
       type: 'StartsUsing',
       netRegex: NetRegexes.startsUsing({ id: '2661', source: 'Hrodric Poisontongue' }),
       netRegexDe: NetRegexes.startsUsing({ id: '2661', source: 'Hrodric Giftzunge' }),
@@ -21,7 +70,7 @@ const triggerSet: TriggerSet<Data> = {
       response: Responses.tankCleave(),
     },
     {
-      id: 'Hrodric Tail',
+      id: 'Skalla Tail Drive',
       type: 'StartsUsing',
       netRegex: NetRegexes.startsUsing({ id: '2663', source: 'Hrodric Poisontongue', capture: false }),
       netRegexDe: NetRegexes.startsUsing({ id: '2663', source: 'Hrodric Giftzunge', capture: false }),
@@ -42,7 +91,44 @@ const triggerSet: TriggerSet<Data> = {
       },
     },
     {
-      id: 'Hrodric Eye',
+      id: 'Skalla The Spin',
+      type: 'StartsUsing',
+      netRegex: NetRegexes.startsUsing({ id: '2664', source: 'Hrodric Poisontongue', capture: false }),
+      response: Responses.getOut(),
+    },
+    {
+      id: 'Skalla Ring Of Chaos',
+      type: 'HeadMarker',
+      netRegex: NetRegexes.headMarker({ id: '0079' }),
+      condition: conditions.targetIsYou(),
+      infoText: (_data, _matches, output) => output.text!(),
+      outputStrings: {
+        text: {
+          en: 'Ring on YOU',
+        },
+      },
+    },
+    {
+      id: 'Skalla Cross Of Chaos',
+      type: 'HeadMarker',
+      netRegex: NetRegexes.headMarker({ id: '007A' }),
+      condition: conditions.targetIsYou(),
+      infoText: (_data, _matches, output) => output.text!(),
+      outputStrings: {
+        text: {
+          en: 'Cross on YOU',
+        },
+      },
+    },
+    {
+      id: 'Skalla Circle Of Chaos',
+      type: 'HeadMarker',
+      netRegex: NetRegexes.headMarker({ id: '001C' }),
+      condition: conditions.targetIsYou(),
+      response: Responses.spread(),
+    },
+    {
+      id: 'Skalla Eye Of The Fire',
       type: 'StartsUsing',
       netRegex: NetRegexes.startsUsing({ id: '2665', source: 'Hrodric Poisontongue', capture: false }),
       netRegexDe: NetRegexes.startsUsing({ id: '2665', source: 'Hrodric Giftzunge', capture: false }),
@@ -53,7 +139,7 @@ const triggerSet: TriggerSet<Data> = {
       response: Responses.lookAway(),
     },
     {
-      id: 'Hrodric Words',
+      id: 'Skalla Words Of Woe',
       type: 'StartsUsing',
       netRegex: NetRegexes.startsUsing({ id: '2662', source: 'Hrodric Poisontongue', capture: false }),
       netRegexDe: NetRegexes.startsUsing({ id: '2662', source: 'Hrodric Giftzunge', capture: false }),
@@ -71,6 +157,18 @@ const triggerSet: TriggerSet<Data> = {
           cn: '避开眼部激光',
           ko: '레이저 피하기',
         },
+      },
+    },
+  ],
+  timelineReplace: [
+    {
+      'locale': 'en',
+      'replaceText': {
+        'Cross Of Chaos/Circle Of Chaos': 'Circle/Cross',
+        'Ring Of Chaos/Cross Of Chaos': 'Cross/Ring',
+        'Ring Of Chaos/Circle Of Chaos': 'Circle/Ring',
+        'Hydro Pull/Hydro Push': 'Hydro Pull/Push',
+        'Order To Detonate \\(cast\\)': 'Order To Detonate',
       },
     },
   ],

--- a/ui/raidboss/data/04-sb/dungeon/drowned_city_of_skalla.ts
+++ b/ui/raidboss/data/04-sb/dungeon/drowned_city_of_skalla.ts
@@ -1,4 +1,4 @@
-import conditions from '../../../../../resources/conditions';
+import Conditions from '../../../../../resources/conditions';
 import NetRegexes from '../../../../../resources/netregexes';
 import { Responses } from '../../../../../resources/responses';
 import ZoneId from '../../../../../resources/zone_id';
@@ -16,7 +16,7 @@ const triggerSet: TriggerSet<Data> = {
       id: 'Skalla Torpedo',
       regex: /Torpedo/,
       beforeSeconds: 4,
-      condition: conditions.caresAboutPhysical(),
+      condition: Conditions.caresAboutPhysical(),
       response: Responses.tankBuster(),
     },
     {
@@ -36,7 +36,7 @@ const triggerSet: TriggerSet<Data> = {
       id: 'Skalla Rising Seas',
       type: 'StartsUsing',
       netRegex: NetRegexes.startsUsing({ id: '2650', source: 'Kelpie', capture: false }),
-      condition: conditions.caresAboutMagical(),
+      condition: Conditions.caresAboutMagical(),
       response: Responses.aoe(),
     },
     {
@@ -55,7 +55,7 @@ const triggerSet: TriggerSet<Data> = {
       id: 'Skalla Bloody Puddle',
       type: 'HeadMarker',
       netRegex: NetRegexes.headMarker({ id: '002B' }),
-      condition: conditions.targetIsYou(),
+      condition: Conditions.targetIsYou(),
       response: Responses.spread(),
     },
     {
@@ -100,7 +100,7 @@ const triggerSet: TriggerSet<Data> = {
       id: 'Skalla Ring Of Chaos',
       type: 'HeadMarker',
       netRegex: NetRegexes.headMarker({ id: '0079' }),
-      condition: conditions.targetIsYou(),
+      condition: Conditions.targetIsYou(),
       infoText: (_data, _matches, output) => output.text!(),
       outputStrings: {
         text: {
@@ -112,7 +112,7 @@ const triggerSet: TriggerSet<Data> = {
       id: 'Skalla Cross Of Chaos',
       type: 'HeadMarker',
       netRegex: NetRegexes.headMarker({ id: '007A' }),
-      condition: conditions.targetIsYou(),
+      condition: Conditions.targetIsYou(),
       infoText: (_data, _matches, output) => output.text!(),
       outputStrings: {
         text: {
@@ -124,7 +124,7 @@ const triggerSet: TriggerSet<Data> = {
       id: 'Skalla Circle Of Chaos',
       type: 'HeadMarker',
       netRegex: NetRegexes.headMarker({ id: '001C' }),
-      condition: conditions.targetIsYou(),
+      condition: Conditions.targetIsYou(),
       response: Responses.spread(),
     },
     {

--- a/ui/raidboss/data/04-sb/dungeon/drowned_city_of_skalla.txt
+++ b/ui/raidboss/data/04-sb/dungeon/drowned_city_of_skalla.txt
@@ -1,0 +1,141 @@
+#Drowned City of Skalla
+hideall "--Reset--"
+hideall "--sync--"
+
+0.0 "--Reset--" sync / 00:0839:.*is no longer sealed/ window 5000 jump 0
+
+#~~~~~~~~#
+# Kelpie #
+#~~~~~~~~#
+
+# -ii 2655
+
+0 "Start" sync /00:0839:The Green Screams will be sealed off/ window 0,1
+7.4 "Torpedo" sync /:Kelpie:264F:/ window 7.4,5
+15.0 "Rising Seas" sync /:Kelpie:2650:/
+26.7 "Gallop" sync /:Kelpie:2653:/
+37.0 "Hydro Pull/Hydro Push" sync /:Kelpie:(2651|2652):/
+43.5 "Torpedo" sync /:Kelpie:264F:/
+51.1 "Rising Seas" sync /:Kelpie:2650:/
+62.7 "Bloody Puddle" sync /:Kelpie:2654:/
+65.9 "Gallop" sync /:Kelpie:2653:/ window 20,20
+73.9 "Bubble Burst" sync /:Hydrosphere:261B:/
+76.2 "Hydro Pull/Hydro Push" sync /:Kelpie:(2651|2652):/
+92.6 "Rising Seas" sync /:Kelpie:2650:/
+
+# A near-perfect 50-second rotation
+102.2 "Torpedo" sync /:Kelpie:264F:/ window 20,20
+107.8 "Rising Seas" sync /:Kelpie:2650:/
+117.3 "Bloody Puddle" sync /:Kelpie:2654:/
+120.5 "Gallop" sync /:Kelpie:2653:/
+128.6 "Bubble Burst" sync /:Hydrosphere:261B:/
+130.7 "Hydro Pull/Hydro Push" sync /:Kelpie:(2651|2652):/
+
+152.2 "Torpedo" sync /:Kelpie:264F:/ window 20,20 jump 102.2
+157.8 "Rising Seas"
+167.3 "Bloody Puddle"
+170.5 "Gallop"
+178.6 "Bubble Burst"
+180.7 "Hydro Push/Hydro Pull"
+
+#~~~~~~~~~~~~~#
+# The Old One #
+#~~~~~~~~~~~~~#
+
+# -ii 2659
+
+
+
+1000.0 "Start" sync /00:0839:A Door Unopened will be sealed off/ window 1000,5
+1009.2 "Mystic Light" sync /:The Old One:2657:/
+1015.0 "Mystic Flame" sync /:The Old One:2658:/
+1018.1 "Order To Detonate (cast)" sync /:265B:The Old One/ window 18.1,5 duration 19.7
+1037.8 "Order To Detonate?" # sync /:The Old One:265B:/
+1040.6 "Self-Detonate?" # sync /:Subservient:265C:/
+1047.7 "Mystic Flame" sync /:The Old One:2658:/ window 20,20
+1058.8 "Mystic Light" sync /:The Old One:2657:/
+1074.7 "Mystic Flame" sync /:The Old One:2658:/ jump 1047.7
+1085.8 "Mystic Light"
+1101.7 "Mystic Flame"
+1112.8 "Mystic Light"
+1128.7 "Mystic Flame"
+1139.8 "Mystic Light"
+
+1200.0 "--sync--" sync /:265A:The Old One/ window 200,10
+1202.7 "Shifting Light" sync /:The Old One:265A:/
+1205.8 "Order To Detonate (cast)" sync /:265B:The Old One/ duration 19.7
+# 1225.5 "Order To Detonate?" sync /:The Old One:265B:/
+1228.3 "Self-Detonate?" # sync /:Subservient:265C:/
+1232.6 "--sync--" sync /:2657:The Old One/ window 32.6,5
+1236.3 "Mystic Light" sync /:The Old One:2657:/
+1244.1 "Mystic Flame" sync /:The Old One:2658:/
+1252.2 "Mystic Light" sync /:The Old One:2657:/
+1269.0 "Mystic Light" sync /:The Old One:2657:/ jump 1236.3
+1276.8 "Mystic Flame"
+1284.9 "Mystic Light"
+1301.7 "Mystic Light"
+1309.5 "Mystic Flame"
+1317.6 "Mystic Light"
+
+1400.0 "--sync--" sync /:265A:The Old One/ window 190,5
+1402.7 "Shifting Light" sync /:The Old One:265A:/
+1405.8 "Order To Detonate (cast)" sync /:265B:The Old One/ duration 19.7
+# 1425.5 "Order To Detonate?" sync /:The Old One:265B:/
+1428.3 "Self-Detonate?" # sync /:Subservient:265C:/
+1432.6 "--sync--" sync /:2657:The Old One/ window 32.6,5
+1436.3 "Mystic Light" sync /:The Old One:2657:/
+1444.1 "Mystic Flame" sync /:The Old One:2658:/
+1452.2 "Mystic Light" sync /:The Old One:2657:/
+1469.0 "Mystic Light" sync /:The Old One:2657:/ jump 1436.3
+1476.8 "Mystic Flame"
+1484.9 "Mystic Light"
+1501.7 "Mystic Light"
+1509.5 "Mystic Flame"
+1517.6 "Mystic Light"
+
+#~~~~~~~~~~~~~~~~~~~~~~#
+# Hrodric Poisontongue #
+#~~~~~~~~~~~~~~~~~~~~~~#
+
+2000.0 "Start" sync /00:0839:The Golden Walls Of Ruin will be sealed off/ window 2000,5
+2012.6 "Rusting Claw" sync /:Hrodric Poisontongue:2661:/ window 2012.6
+2026.2 "Tail Drive" sync /:Hrodric Poisontongue:2663:/
+2035.9 "The Spin" sync /:Hrodric Poisontongue:2664:/ window 35.9,5
+2041.6 "--sync--" sync /:Hrodric Poisontongue:2666:/
+2046.7 "Ring Of Chaos" sync /:Hrodric Poisontongue:2667:/
+2052.2 "Eye Of The Fire" sync /:Hrodric Poisontongue:2665:/ window 2052.2,10
+2057.9 "--sync--" sync /:Hrodric Poisontongue:2666:/
+2063.0 "Cross Of Chaos/Circle Of Chaos" sync /:Hrodric Poisontongue:(2668|2669):/
+2068.7 "Words Of Woe" sync /:Hrodric Poisontongue:2662:/
+2074.4 "Words Of Woe" sync /:Hrodric Poisontongue:2662:/
+2080.2 "Words Of Woe" sync /:Hrodric Poisontongue:2662:/
+2087.9 "--sync--" sync /:Hrodric Poisontongue:2666:/ window 15,2.5 # Solo/duo runners will see only one or two lasers
+
+2093.0 "Ring Of Chaos/Cross Of Chaos" sync /:Hrodric Poisontongue:(2667|2668):/
+2095.5 "--sync--" sync /:Hrodric Poisontongue:2666:/
+2100.6 "Ring Of Chaos" sync /:Hrodric Poisontongue:2667:/
+2103.0 "Tail Drive" sync /:Hrodric Poisontongue:2663:/
+2115.6 "The Spin" sync /:Hrodric Poisontongue:2664:/ window 30,30
+2126.3 "Rusting Claw" sync /:Hrodric Poisontongue:2661:/
+2132.0 "--sync--" sync /:Hrodric Poisontongue:2666:/
+2137.1 "Cross Of Chaos/Circle Of Chaos" sync /:Hrodric Poisontongue:(2668|2669):/
+2139.6 "--sync--" sync /:Hrodric Poisontongue:2666:/
+2144.7 "Ring Of Chaos" sync /:Hrodric Poisontongue:2667:/
+2145.2 "Eye Of The Fire" sync /:Hrodric Poisontongue:2665:/ window 30,30
+2155.8 "Rusting Claw" sync /:Hrodric Poisontongue:2661:/
+2166.4 "Tail Drive" sync /:Hrodric Poisontongue:2663:/
+2174.1 "--sync--" sync /:Hrodric Poisontongue:2666:/
+2179.2 "Ring Of Chaos/Circle Of Chaos" sync /:Hrodric Poisontongue:(2667|2669):/
+2181.7 "--sync--" sync /:Hrodric Poisontongue:2666:/
+2186.8 "Cross Of Chaos" sync /:Hrodric Poisontongue:2668:/
+2187.5 "Words Of Woe" sync /:Hrodric Poisontongue:2662:/
+2195.2 "--sync--" sync /:Hrodric Poisontongue:2666:/
+
+2200.3 "Ring Of Chaos/Cross Of Chaos" sync /:Hrodric Poisontongue:(2667|2668):/ jump 2093.0
+2202.8 "--sync--"
+2207.9 "Ring Of Chaos"
+2210.3 "Tail Drive"
+2222.9 "The Spin"
+2233.6 "Rusting Claw"
+
+

--- a/ui/raidboss/data/raidboss_manifest.txt
+++ b/ui/raidboss/data/raidboss_manifest.txt
@@ -107,6 +107,7 @@
 04-sb/dungeon/doma_castle.ts
 04-sb/dungeon/doma_castle.txt
 04-sb/dungeon/drowned_city_of_skalla.ts
+04-sb/dungeon/drowned_city_of_skalla.txt
 04-sb/dungeon/fractal_continuum_hard.ts
 04-sb/dungeon/fractal_continuum_hard.txt
 04-sb/dungeon/ghimlyt_dark.ts


### PR DESCRIPTION
Nothing particularly interesting on this one. We could probably eliminate the last block on boss 2, and instead do a forward and back sync against timestamp 1200, but I figured explicit was better to start with.

It's possible we could do a better set of triggers to account for interactions between the boss 3 head markers, but I don't think it's really worth the effort. "You have X" is standard enough anyway.