### PR TITLE
Raidboss: Remove "timeline needs work" flag from Dun Scaith

### DIFF
--- a/ui/raidboss/data/03-hw/alliance/dun_scaith.ts
+++ b/ui/raidboss/data/03-hw/alliance/dun_scaith.ts
@@ -14,7 +14,6 @@ export interface Data extends RaidbossData {
 
 const triggerSet: TriggerSet<Data> = {
   zoneId: ZoneId.DunScaith,
-  timelineNeedsFixing: true,
   timelineFile: 'dun_scaith.txt',
   timelineTriggers: [
     {


### PR DESCRIPTION
It looks like this was marked as needing work on [June 20](https://github.com/quisquous/cactbot/commit/163304c63e16a3bbafd9818b7fce12b448235540) last year, and I missed that flag's existence when I updated the timeline last [August](https://github.com/quisquous/cactbot/pull/1650). Sorry about that!