### PR TITLE
Network Event: Added combatant - level fix

### DIFF
--- a/ui/raidboss/emulator/data/network_log_converter/LineEvent0x03.ts
+++ b/ui/raidboss/emulator/data/network_log_converter/LineEvent0x03.ts
@@ -68,7 +68,7 @@ export class LineEvent0x03 extends LineEvent implements LineEventSource, LineEve
     this.jobId = parseInt(this.jobIdHex, 16);
     this.job = Util.jobEnumToJob(this.jobId);
     this.levelString = parts[fields.levelString] ?? '';
-    this.level = parseFloat(this.levelString);
+    this.level = parseInt(this.levelString, 16);
     this.ownerId = parts[fields.ownerId]?.toUpperCase() ?? '';
     this.worldId = parts[fields.worldId] ?? '';
     this.worldName = parts[fields.worldName] ?? '';


### PR DESCRIPTION
Level is not an number, its passed as hex instead, confirmed it in game