### PR TITLE
ci: shorten PR title lint message

### DIFF
--- a/.github/scripts/lint-pr-title.cjs
+++ b/.github/scripts/lint-pr-title.cjs
@@ -45,16 +45,14 @@ const thanksComment = (userName) => {
   let userStr = '';
   if (userName)
     userStr = `@${userName} `;
-  return `${userStr}Thanks for your contribution!🚀`;
+  return `${userStr}Thanks for your contribution! 🌵🚀`;
 };
 
 const getComment = (title, userName) => `${thanksComment(userName)}
 
-Currently your title is: ${title},
-but it should be in the format of \`scope: description\`.
+Currently your title is: \`${title}\`, but it should be in the format of \`scope: description\`.
 
-\`scope\` can be any of the following:
-${validScope.map((s) => `  - ${s}`).join('\n')}
+\`scope\` can be any of the following: ${validScope.map((s) => `\`${s}\``).join(', ')}.
 
 ------
 This comment is created and updated by a bot.
@@ -119,7 +117,7 @@ const checkTitle = async (octokit, owner, repo, pullNumber) => {
     owner,
     repo,
     'issue_number': pullNumber,
-    'body': getComment(title),
+    'body': getComment(title, userName),
   });
 
   return false;

--- a/.github/scripts/lint-pr-title.cjs
+++ b/.github/scripts/lint-pr-title.cjs
@@ -52,7 +52,21 @@ const getComment = (title, userName) => `${thanksComment(userName)}
 
 Currently your title is: \`${title}\`, but it should be in the format of \`scope: description\`.
 
-\`scope\` can be any of the following: ${validScope.map((s) => `\`${s}\``).join(', ')}.
+<details>
+<summary>More Information</summary>
+
+\`scope\` can be any of the following:
+${[...validScope].sort().map((s) => `- \`${s}\``).join('\n')}
+
+Valid Title Examples:
+- \`i18n: translating a bunch of new stuff\`
+- \`raidboss: fix bug in New Ultimate Fight\`
+- \`plugin: update Bozja CE code for patch 6.34\`
+- \`lint: change @typescript/irritating-lint warning\`
+
+Drafts can also use \`[wip]\` as a prefix to show that they are a "work in progress", e.g. \`[wip] plugin: refactoring everything\`.
+
+</details>
 
 ------
 This comment is created and updated by a bot.


### PR DESCRIPTION
This message was really tall, so make it a lot shorter.

Also, fix a bug where the username wasn't being passed to the
message function.