### PR TITLE
ci: trigger lint-pr-title when pr edited/reopened

### DIFF
--- a/.github/workflows/lint-pr-title.yaml
+++ b/.github/workflows/lint-pr-title.yaml
@@ -2,7 +2,7 @@ name: Lint PR Title
 
 on:
   pull_request_target:
-    types: [ opened, synchronize ]
+    types: [ edited, opened, reopened, synchronize ]
 
 jobs:
   main:


### PR DESCRIPTION
Noticed in #3356 that the bot didn't run the workflow again when I successfully changed the title.