### PR TITLE
raidemulator: Force combatant sig states for line events

### DIFF
--- a/ui/raidboss/emulator/data/CombatantTracker.ts
+++ b/ui/raidboss/emulator/data/CombatantTracker.ts
@@ -1,4 +1,5 @@
 import { Lang } from '../../../../resources/languages';
+import { UnreachableCode } from '../../../../resources/not_reached';
 import PetNamesByLang from '../../../../resources/pet_names';
 
 import Combatant from './Combatant';
@@ -111,6 +112,22 @@ export default class CombatantTracker {
     this.mainCombatantID = this.enemies.sort((l, r) => {
       return (eventTracker[r] ?? 0) - (eventTracker[l] ?? 0);
     })[0];
+
+    // Always treat the last line involving a combatant as a significant state
+    for (const id in this.combatants) {
+      const combatant = this.combatants[id];
+
+      if (!combatant)
+        throw new UnreachableCode();
+
+      // Get the last state timestamp
+      const state = combatant.latestTimestamp;
+
+      if (state === -1 || combatant.significantStates.includes(state))
+        continue;
+
+      combatant.significantStates.push(state);
+    }
   }
 
   addCombatantFromLine(line: LineEventSource): void {


### PR DESCRIPTION
Fixes #3349

Might also fix the second issue mentioned, at least it's not returning `???` anymore, but I've never done this fight and have no idea if the callouts are correct.

I had to add multiple line events to the 'force significant states' mapping, the `20` event only fixed the original `4000478C` combatant. I included logic for target line events though I'm not sure of any specific cases where they would apply yet.