### PR TITLE
raidemulator: Performance optimizations

### DIFF
--- a/ui/raidboss/emulator/data/Combatant.ts
+++ b/ui/raidboss/emulator/data/Combatant.ts
@@ -72,9 +72,17 @@ export default class Combatant {
   pushPartialState(timestamp: number, props: Partial<CombatantState>): void {
     if (this.states[timestamp] === undefined) {
       // Clone the last state before this timestamp
-      const stateTimestamp = this.significantStates
-        .filter((s) => s < timestamp)
-        .sort((a, b) => b - a)[0] ?? this.significantStates[0];
+      let stateTimestamp = this.significantStates[0] ?? timestamp;
+      // It's faster to start at the last timestamp and work our way backwards
+      // since realistically timestamp skew is only a couple ms at most
+      // Additionally, because cloning a 3000+ element array a few thousand times is slow,
+      // don't for-in over a reverse of the array
+      for (let i = this.significantStates.length - 1; i >= 0; --i) {
+        const ts = this.significantStates[i] ?? 0;
+        if (ts <= timestamp)
+          stateTimestamp = ts;
+      }
+
       if (stateTimestamp === undefined)
         throw new UnreachableCode();
       const state = this.states[stateTimestamp];
@@ -93,10 +101,8 @@ export default class Combatant {
       this.significantStates[this.significantStates.length - 1];
     if (!lastSignificantStateTimestamp)
       throw new UnreachableCode();
-    const oldStateJSON = JSON.stringify(this.states[lastSignificantStateTimestamp]);
-    const newStateJSON = JSON.stringify(this.states[timestamp]);
 
-    if (lastSignificantStateTimestamp !== timestamp && newStateJSON !== oldStateJSON)
+    if (lastSignificantStateTimestamp !== timestamp)
       this.significantStates.push(timestamp);
   }
 

--- a/ui/raidboss/emulator/data/CombatantTracker.ts
+++ b/ui/raidboss/emulator/data/CombatantTracker.ts
@@ -16,59 +16,36 @@ export default class CombatantTracker {
   others: string[] = [];
   pets: string[] = [];
   mainCombatantID?: string;
-  initialStates: { [id: string]: Partial<CombatantState> } = {};
   constructor(logLines: LineEvent[], language: Lang) {
     this.language = language;
     this.firstTimestamp = Number.MAX_SAFE_INTEGER;
     this.lastTimestamp = 0;
     this.initialize(logLines);
-    // Clear initialStates after we initialize, we don't need it anymore
-    this.initialStates = {};
   }
 
   initialize(logLines: LineEvent[]): void {
-    // First pass: Get list of combatants, figure out where they
-    // start at if possible
+    this.firstTimestamp = logLines[0]?.timestamp ?? 0;
+    this.lastTimestamp = logLines.slice(-1)[0]?.timestamp ?? 0;
+
+    const eventTracker: { [key: string]: number } = {};
+
     for (const line of logLines) {
       this.firstTimestamp = Math.min(this.firstTimestamp, line.timestamp);
       this.lastTimestamp = Math.max(this.lastTimestamp, line.timestamp);
 
-      if (isLineEventSource(line))
-        this.addCombatantFromLine(line);
-
-      if (isLineEventTarget(line))
-        this.addCombatantFromTargetLine(line);
-    }
-
-    // Between passes: Create our initial combatant states
-    for (const id in this.initialStates) {
-      const state = this.initialStates[id] ?? {};
-      this.combatants[id]?.pushState(this.firstTimestamp, new CombatantState(
-          Number(state.posX),
-          Number(state.posY),
-          Number(state.posZ),
-          Number(state.heading),
-          state.targetable ?? false,
-          Number(state.hp),
-          Number(state.maxHp),
-          Number(state.mp),
-          Number(state.maxMp),
-      ));
-    }
-
-    // Second pass: Analyze combatant information for tracking
-    const eventTracker: { [key: string]: number } = {};
-    for (const line of logLines) {
       if (isLineEventSource(line)) {
         const state = this.extractStateFromLine(line);
+        this.addCombatantFromLine(line, state);
         if (state) {
           eventTracker[line.id] = eventTracker[line.id] ?? 0;
           ++eventTracker[line.id];
           this.combatants[line.id]?.pushPartialState(line.timestamp, state);
         }
       }
+
       if (isLineEventTarget(line)) {
         const state = this.extractStateFromTargetLine(line);
+        this.addCombatantFromTargetLine(line, state);
         if (state) {
           eventTracker[line.targetId] = eventTracker[line.targetId] ?? 0;
           ++eventTracker[line.targetId];
@@ -101,11 +78,9 @@ export default class CombatantTracker {
     })[0];
   }
 
-  addCombatantFromLine(line: LineEventSource): void {
-    const combatant = this.initCombatant(line.id, line.name);
-    const initState = this.initialStates[line.id] ?? {};
-
-    const extractedState = this.extractStateFromLine(line) ?? {};
+  addCombatantFromLine(line: LineEventSource, extractedState: Partial<CombatantState>): void {
+    const combatant = this.combatants[line.id] ?? this.initCombatant(line.id, line.name);
+    const initState: Partial<CombatantState> = combatant.states[this.firstTimestamp] ?? {};
 
     initState.posX = initState.posX ?? extractedState.posX;
     initState.posY = initState.posY ?? extractedState.posY;
@@ -116,6 +91,7 @@ export default class CombatantTracker {
     initState.maxHp = initState.maxHp ?? extractedState.maxHp;
     initState.mp = initState.mp ?? extractedState.mp;
     initState.maxMp = initState.maxMp ?? extractedState.maxMp;
+    initState.targetable = initState.targetable ?? extractedState.targetable ?? true;
 
     if (isLineEventJobLevel(line)) {
       combatant.job = this.combatants[line.id]?.job ?? line.job;
@@ -126,13 +102,28 @@ export default class CombatantTracker {
       if (!combatant.job && !line.id.startsWith('4') && line.abilityId !== undefined)
         combatant.job = CombatantJobSearch.getJob(line.abilityId);
     }
+
+    if (!combatant.states[this.firstTimestamp]) {
+      combatant.pushState(this.firstTimestamp, new CombatantState(
+          Number(initState.posX),
+          Number(initState.posY),
+          Number(initState.posZ),
+          Number(initState.heading),
+          initState.targetable ?? true,
+          Number(initState.hp),
+          Number(initState.maxHp),
+          Number(initState.mp),
+          Number(initState.maxMp),
+      ));
+    } else {
+      combatant.pushPartialState(this.firstTimestamp, initState);
+    }
   }
 
-  addCombatantFromTargetLine(line: LineEventTarget): void {
-    this.initCombatant(line.targetId, line.targetName);
-    const initState = this.initialStates[line.targetId] ?? {};
-
-    const extractedState = this.extractStateFromTargetLine(line) ?? {};
+  addCombatantFromTargetLine(line: LineEventTarget, extractedState: Partial<CombatantState>): void {
+    const combatant = this.combatants[line.targetId] ??
+      this.initCombatant(line.targetId, line.targetName);
+    const initState: Partial<CombatantState> = combatant.states[this.firstTimestamp] ?? {};
 
     initState.posX = initState.posX ?? extractedState.posX;
     initState.posY = initState.posY ?? extractedState.posY;
@@ -142,6 +133,23 @@ export default class CombatantTracker {
     initState.maxHp = initState.maxHp ?? extractedState.maxHp;
     initState.mp = initState.mp ?? extractedState.mp;
     initState.maxMp = initState.maxMp ?? extractedState.maxMp;
+    initState.targetable = initState.targetable ?? extractedState.targetable ?? true;
+
+    if (!combatant.states[this.firstTimestamp]) {
+      combatant.pushState(this.firstTimestamp, new CombatantState(
+          Number(initState.posX),
+          Number(initState.posY),
+          Number(initState.posZ),
+          Number(initState.heading),
+          initState.targetable ?? true,
+          Number(initState.hp),
+          Number(initState.maxHp),
+          Number(initState.mp),
+          Number(initState.maxMp),
+      ));
+    } else {
+      combatant.pushPartialState(this.firstTimestamp, initState);
+    }
   }
 
   extractStateFromLine(line: LineEventSource): Partial<CombatantState> {
@@ -197,9 +205,6 @@ export default class CombatantTracker {
     if (combatant === undefined) {
       combatant = this.combatants[id] = new Combatant(id, name);
       this.others.push(id);
-      this.initialStates[id] = {
-        targetable: true,
-      };
     } else if (combatant.name === '') {
       combatant.setName(name);
     }

--- a/ui/raidboss/emulator/data/Encounter.ts
+++ b/ui/raidboss/emulator/data/Encounter.ts
@@ -56,14 +56,14 @@ export default class Encounter {
   initialize(): void {
     const startStatuses = new Set<string>();
 
-    this.logLines.forEach((line, i) => {
+    for (const line of this.logLines) {
       if (!line)
         throw new UnreachableCode();
 
       let res: MatchStartInfo | MatchEndInfo | undefined =
           EmulatorCommon.matchStart(line.networkLine);
       if (res) {
-        this.firstLineIndex = i;
+        this.firstLineIndex = this.logLines.indexOf(line);
         if (res.StartType)
           startStatuses.add(res.StartType);
         const startIn = parseInt(res.StartIn);
@@ -94,7 +94,7 @@ export default class Encounter {
       const matchedLang = res?.language;
       if (isLang(matchedLang))
         this.language = matchedLang;
-    });
+    }
 
     this.combatantTracker = new CombatantTracker(this.logLines, this.language);
     this.startTimestamp = this.combatantTracker.firstTimestamp;

--- a/ui/raidboss/emulator/data/Persistor.ts
+++ b/ui/raidboss/emulator/data/Persistor.ts
@@ -37,9 +37,8 @@ export default class Persistor extends Dexie {
 
                   Object.setPrototypeOf(obj, Encounter.prototype);
 
-                  obj.logLines.forEach((l) => {
-                    Object.setPrototypeOf(l, LineEvent.prototype);
-                  });
+                  for (const line of obj.logLines)
+                    Object.setPrototypeOf(line, LineEvent.prototype);
 
                   // Check for encounter upgrade, re-save encounter if it's upgraded.
                   if (obj.upgrade(obj.version)) {


### PR DESCRIPTION
As discussed in #3275, there are a few different ways that performance for raidemulator's encounter analysis can be improved, mostly surrounding the sheer number of regexes that need to be executed.

This PR goes for a different option than the ones discussed in that issue, instead choosing to cache the results of a regex execution against a given line so that it can be looked up on subsequent analysis. This results in a noticeable performance improvement, 5-20%.

Additional improvements to other components have increased that performance gain to 10-30% on average, mainly consisting of switching from `forEach` to `for ... of`, and eliminating pointless excess looping over log lines.

The DRS Trinity Avowed encounter is a statistical outlier, going on average from 2m 42s to load for me, down to on average 1m 9s.

I'm opening this as draft since it's still a bit untested (in particular I haven't tested anything related to importing logs, which is potentially impacted due to the change in `Encounter.ts`).