### PR TITLE
util: Add type checking for NetRegexes parseHelper fields

### DIFF
--- a/resources/netregexes.ts
+++ b/resources/netregexes.ts
@@ -28,34 +28,17 @@ const keysThatRequireTranslation = [
 ];
 
 type ParseHelperField<
-  T extends TriggerTypes,
-  T2 extends NetFieldsReverse[T],
-  field extends keyof T2
+  Type extends TriggerTypes,
+  Fields extends NetFieldsReverse[Type],
+  Field extends keyof Fields
 > = {
-  field: T2[field] extends string ? T2[field] : never;
+  field: Fields[Field] extends string ? Fields[Field] : never;
   value?: string;
 };
 
 type ParseHelperFields<T extends TriggerTypes> = {
   [field in keyof NetFieldsReverse[T]]: ParseHelperField<T, NetFieldsReverse[T], field>;
 };
-
-const test: ParseHelperFields<'StartsUsing'> = {
-  0: { field: 'type', value: '20' },
-  1: { field: 'timestamp' },
-  2: { field: 'sourceId' },
-  3: { field: 'source' },
-  4: { field: 'id' },
-  5: { field: 'ability' },
-  6: { field: 'targetId' },
-  7: { field: 'target' },
-  8: { field: 'castTime' },
-  9: { field: 'x' },
-  10: { field: 'y' },
-  11: { field: 'z' },
-  12: { field: 'heading' },
-};
-test;
 
 const parseHelper = <T extends TriggerTypes>(
   params: { timestamp?: string; capture?: boolean } | undefined,
@@ -76,21 +59,21 @@ const parseHelper = <T extends TriggerTypes>(
   // Find the last key we care about, so we can shorten the regex if needed.
   const capture = Regexes.trueIfUndefined(params.capture);
   const fieldKeys = Object.keys(fields);
-  let _maxKey: string;
+  let maxKeyStr: string;
   if (capture) {
-    _maxKey = fieldKeys[fieldKeys.length - 1] ?? '0';
+    maxKeyStr = fieldKeys[fieldKeys.length - 1] ?? '0';
   } else {
-    _maxKey = '0';
+    maxKeyStr = '0';
     for (const key in fields) {
       const value = fields[key] ?? {};
       if (typeof value !== 'object')
         continue;
       const fieldName = fields[key]?.field;
       if (fieldName && fieldName in params)
-        _maxKey = key;
+        maxKeyStr = key;
     }
   }
-  const maxKey = parseInt(_maxKey);
+  const maxKey = parseInt(maxKeyStr);
 
   // For testing, it's useful to know if this is a regex that requires
   // translation.  We test this by seeing if there are any specified
@@ -104,8 +87,8 @@ const parseHelper = <T extends TriggerTypes>(
   // Build the regex from the fields.
   let str = needsTranslations ? magicTranslationString : '^';
   let lastKey = -1;
-  for (const _key in fields) {
-    const key = parseInt(_key);
+  for (const keyStr in fields) {
+    const key = parseInt(keyStr);
     // Fill in blanks.
     const missingFields = key - lastKey - 1;
     if (missingFields === 1)
@@ -114,12 +97,12 @@ const parseHelper = <T extends TriggerTypes>(
       str += `\\y{NetField}{${missingFields}}`;
     lastKey = key;
 
-    const value = fields[_key];
+    const value = fields[keyStr];
     if (typeof value !== 'object')
       throw new Error(`${funcName}: invalid value: ${JSON.stringify(value)}`);
 
-    const fieldName = fields[_key]?.field;
-    const fieldValue = fields[_key]?.value?.toString() ?? matchDefault;
+    const fieldName = fields[keyStr]?.field;
+    const fieldValue = fields[keyStr]?.value?.toString() ?? matchDefault;
 
     if (fieldName) {
       str += Regexes.maybeCapture(

--- a/types/net_fields.d.ts
+++ b/types/net_fields.d.ts
@@ -312,6 +312,10 @@ export type NetFields = {
   'None': Fields;
 };
 
+// This type helper reverses the keys and values of a given type, e.g this:
+// {1: 'a'}
+// becomes this:
+// {a: 1}
 type Reverse<T> = {
   [P in T[keyof T]]: {
     [K in keyof T]: T[K] extends P ? K : never

--- a/types/net_fields.d.ts
+++ b/types/net_fields.d.ts
@@ -77,6 +77,10 @@ type NetStartsUsingFields = Fields & {
   targetId: 6;
   target: 7;
   castTime: 8;
+  x: 9;
+  y: 10;
+  z: 11;
+  heading: 12;
 };
 
 // 0x15
@@ -306,6 +310,16 @@ export type NetFields = {
   'ActionSync': NetActionSyncFields;
   'StatusEffect': NetStatusEffectFields;
   'None': Fields;
-}
+};
+
+type Reverse<T> = {
+  [P in T[keyof T]]: {
+    [K in keyof T]: T[K] extends P ? K : never
+  }[keyof T];
+};
+
+export type NetFieldsReverse = {
+  [K in keyof NetFields]: Reverse<NetFields[K]>;
+};
 
 export type NetAnyFields = NetFields[keyof NetFields];


### PR DESCRIPTION
I noticed when writing the example UWU trigger in #3338 that when support for the position/heading fields for startsUsing were added in #3355, the underlying type backing NetRegexes weren't updated.

This PR adds the fields to the type, and also adds proper typing of the `fields` parameter for `parseHelper` so that if new field properties are added in the future, they'll need to be added to the underlying type.