### PR TITLE
resources: fix ZoneId name collision

### DIFF
--- a/resources/content_list.ts
+++ b/resources/content_list.ts
@@ -1,3 +1,5 @@
+import { ZoneIdType } from '../types/trigger';
+
 import ZoneId from './zone_id';
 
 // Ordered as per duty finder.  This is intended to be used as ordering for
@@ -6,7 +8,7 @@ import ZoneId from './zone_id';
 // These are not things that cactbot necessarily supports, but things that it
 // theoretically could be supporting in the future with raidboss and oopsy.
 
-const contentList: (number | null)[] = [
+const contentList: (ZoneIdType)[] = [
   // General (cactbot custom zone id)
   ZoneId.MatchAll,
 

--- a/types/oopsy.d.ts
+++ b/types/oopsy.d.ts
@@ -3,7 +3,7 @@ import { Lang } from '../resources/languages';
 import { OopsyData } from './data';
 import { NetAnyMatches, NetMatches } from './net_matches';
 import { CactbotBaseRegExp, TriggerTypes } from './net_trigger';
-import { LocaleText, ZoneId } from './trigger';
+import { LocaleText, ZoneIdType } from './trigger';
 
 export type OopsyMistakeType =
   | 'pull'
@@ -80,7 +80,7 @@ export type OopsyTrigger<Data extends OopsyData> =
 type MistakeMap = { [mistakeId: string]: string };
 
 type SimpleOopsyTriggerSet = {
-  zoneId: ZoneId | ZoneId[];
+  zoneId: ZoneIdType | ZoneIdType[];
   damageWarn?: MistakeMap;
   damageFail?: MistakeMap;
   gainsEffectWarn?: MistakeMap;

--- a/types/trigger.d.ts
+++ b/types/trigger.d.ts
@@ -29,7 +29,7 @@ export type LocaleObject<T> =
 
 export type LocaleText = LocaleObject<string>;
 
-export type ZoneId = number | null;
+export type ZoneIdType = number | null;
 
 export type OutputStrings = { [outputKey: string]: LocaleText | string };
 
@@ -181,7 +181,7 @@ type RequiredFieldsAsUnion<Type> = {
 
 export type BaseTriggerSet<Data extends RaidbossData> = {
   // ZoneId.MatchAll (aka null) is not supported in array form.
-  zoneId: ZoneId | number[];
+  zoneId: ZoneIdType | number[];
   timelineNeedsFixing?: boolean;
   resetWhenOutOfCombat?: boolean;
   overrideTimelineFile?: boolean;

--- a/ui/oopsyraidsy/damage_tracker.ts
+++ b/ui/oopsyraidsy/damage_tracker.ts
@@ -23,7 +23,7 @@ import {
   OopsyTrigger,
   OopsyTriggerField,
 } from '../../types/oopsy';
-import { ZoneId as ZoneIdType } from '../../types/trigger';
+import { ZoneIdType } from '../../types/trigger';
 
 import { OopsyFileData } from './data/oopsy_manifest.txt';
 import { MistakeCollector } from './mistake_collector';

--- a/ui/oopsyraidsy/oopsy_options.ts
+++ b/ui/oopsyraidsy/oopsy_options.ts
@@ -3,9 +3,7 @@ import UserConfig from '../../resources/user_config';
 import ZoneId from '../../resources/zone_id';
 import { BaseOptions } from '../../types/data';
 import { LooseOopsyTriggerSet } from '../../types/oopsy';
-// TODO: do we need a different name for this?
-// TODO: Should zone_id.ts export this type??
-import { ZoneId as ZoneIdType } from '../../types/trigger';
+import { ZoneIdType } from '../../types/trigger';
 
 import { abilityNameMap } from './ability_name_map';
 


### PR DESCRIPTION
It's awkward to have ZoneId (the map) and ZoneId (the type) have
the same name.  Some of the issue is that maybe ZoneId (the map,
or all maps really) be capitalized and so they conflict with type
names, but that's a larger issue (whoops).