### PR TITLE
resources: Refactor netregexes to use netlog_defs

### DIFF
--- a/resources/netlog_defs.ts
+++ b/resources/netlog_defs.ts
@@ -26,7 +26,6 @@ export type LogDefinition = {
 };
 export type LogDefinitionMap = { [name: string]: LogDefinition };
 
-// TODO: build NetRegexes out of this, or somehow deduplicate.
 const logDefinitions = {
   GameLog: {
     type: '00',

--- a/resources/netlog_defs.ts
+++ b/resources/netlog_defs.ts
@@ -28,7 +28,7 @@ export type LogDefinitionMap = { [name: string]: LogDefinition };
 
 // TODO: build NetRegexes out of this, or somehow deduplicate.
 const logDefinitions = {
-  gameLog: {
+  GameLog: {
     type: '00',
     name: 'GameLog',
     fields: {
@@ -59,7 +59,7 @@ const logDefinitions = {
       },
     },
   },
-  changeZone: {
+  ChangeZone: {
     type: '01',
     name: 'ChangeZone',
     fields: {
@@ -71,7 +71,7 @@ const logDefinitions = {
     lastInclude: true,
     canAnonymize: true,
   },
-  changePrimaryPlayer: {
+  ChangedPlayer: {
     type: '02',
     name: 'ChangePrimaryPlayer',
     fields: {
@@ -86,7 +86,7 @@ const logDefinitions = {
     lastInclude: true,
     canAnonymize: true,
   },
-  addCombatant: {
+  AddedCombatant: {
     type: '03',
     name: 'AddCombatant',
     fields: {
@@ -118,7 +118,7 @@ const logDefinitions = {
     },
     canAnonymize: true,
   },
-  removeCombatant: {
+  RemovedCombatant: {
     type: '04',
     name: 'RemoveCombatant',
     fields: {
@@ -147,26 +147,46 @@ const logDefinitions = {
   addBuff: {
     type: '05',
     name: 'AddBuff',
+    fields: {
+      type: 0,
+      timestamp: 1,
+    },
     isUnknown: true,
   },
   removeBuff: {
     type: '06',
     name: 'RemoveBuff',
+    fields: {
+      type: 0,
+      timestamp: 1,
+    },
     isUnknown: true,
   },
   flyingText: {
     type: '07',
     name: 'FlyingText',
+    fields: {
+      type: 0,
+      timestamp: 1,
+    },
     isUnknown: true,
   },
   outgoingAbility: {
     type: '08',
     name: 'OutgoingAbility',
+    fields: {
+      type: 0,
+      timestamp: 1,
+    },
     isUnknown: true,
   },
   incomingAbility: {
     type: '09',
     name: 'IncomingAbility',
+    fields: {
+      type: 0,
+      timestamp: 1,
+    },
     isUnknown: true,
   },
   partyList: {
@@ -256,7 +276,7 @@ const logDefinitions = {
     canAnonymize: true,
     lastInclude: true,
   },
-  playerStats: {
+  PlayerStats: {
     type: '12',
     name: 'PlayerStats',
     fields: {
@@ -285,9 +305,13 @@ const logDefinitions = {
   combatantHP: {
     type: '13',
     name: 'CombatantHP',
+    fields: {
+      type: 0,
+      timestamp: 1,
+    },
     isUnknown: true,
   },
-  networkStartsCasting: {
+  StartsUsing: {
     type: '20',
     name: 'NetworkStartsCasting',
     fields: {
@@ -312,7 +336,7 @@ const logDefinitions = {
     },
     canAnonymize: true,
   },
-  networkAbility: {
+  Ability: {
     type: '21',
     name: 'NetworkAbility',
     fields: {
@@ -425,7 +449,7 @@ const logDefinitions = {
     },
     canAnonymize: true,
   },
-  networkDeath: {
+  WasDefeated: {
     type: '25',
     name: 'NetworkDeath',
     fields: {
@@ -442,7 +466,7 @@ const logDefinitions = {
     },
     canAnonymize: true,
   },
-  networkBuff: {
+  GainsEffect: {
     type: '26',
     name: 'NetworkBuff',
     fields: {
@@ -465,7 +489,7 @@ const logDefinitions = {
     },
     canAnonymize: true,
   },
-  networkTargetIcon: {
+  HeadMarker: {
     type: '27',
     name: 'NetworkTargetIcon',
     fields: {
@@ -514,7 +538,7 @@ const logDefinitions = {
       5: null,
     },
   },
-  networkBuffRemove: {
+  LosesEffect: {
     type: '30',
     name: 'NetworkBuffRemove',
     fields: {
@@ -557,9 +581,13 @@ const logDefinitions = {
   networkWorld: {
     type: '32',
     name: 'NetworkWorld',
+    fields: {
+      type: 0,
+      timestamp: 1,
+    },
     isUnknown: true,
   },
-  network6d: {
+  ActorControl: {
     type: '33',
     name: 'Network6D',
     fields: {
@@ -574,7 +602,7 @@ const logDefinitions = {
     },
     canAnonymize: true,
   },
-  networkNameToggle: {
+  NameToggle: {
     type: '34',
     name: 'NetworkNameToggle',
     fields: {
@@ -592,7 +620,7 @@ const logDefinitions = {
     },
     canAnonymize: true,
   },
-  networkTether: {
+  Tether: {
     type: '35',
     name: 'NetworkTether',
     fields: {
@@ -648,7 +676,7 @@ const logDefinitions = {
     firstUnknownField: 22,
     canAnonymize: true,
   },
-  networkStatusEffects: {
+  StatusEffect: {
     type: '38',
     name: 'NetworkStatusEffects',
     fields: {
@@ -701,7 +729,7 @@ const logDefinitions = {
     },
     canAnonymize: true,
   },
-  map: {
+  Map: {
     type: '40',
     name: 'Map',
     fields: {
@@ -717,40 +745,68 @@ const logDefinitions = {
   parserInfo: {
     type: '249',
     name: 'ParserInfo',
+    fields: {
+      type: 0,
+      timestamp: 1,
+    },
     globalInclude: true,
     canAnonymize: true,
   },
   processInfo: {
     type: '250',
     name: 'ProcessInfo',
+    fields: {
+      type: 0,
+      timestamp: 1,
+    },
     globalInclude: true,
     canAnonymize: true,
   },
   debug: {
     type: '251',
     name: 'Debug',
+    fields: {
+      type: 0,
+      timestamp: 1,
+    },
     globalInclude: true,
     canAnonymize: false,
   },
   packetDump: {
     type: '252',
     name: 'PacketDump',
+    fields: {
+      type: 0,
+      timestamp: 1,
+    },
     canAnonymize: false,
   },
   version: {
     type: '253',
     name: 'Version',
+    fields: {
+      type: 0,
+      timestamp: 1,
+    },
     globalInclude: true,
     canAnonymize: true,
   },
   error: {
     type: '254',
     name: 'Error',
+    fields: {
+      type: 0,
+      timestamp: 1,
+    },
     canAnonymize: false,
   },
   timer: {
     type: '255',
     name: 'Timer',
+    fields: {
+      type: 0,
+      timestamp: 1,
+    },
     isUnknown: true,
   },
 } as const;
@@ -758,5 +814,22 @@ const logDefinitions = {
 // Verify that this has the right type, but export `as const`.
 const assertLogDefinitions: LogDefinitionMap = logDefinitions;
 console.assert(assertLogDefinitions);
+
+export type LogDefinitions = typeof logDefinitions;
+export type LogDefinitionTypes = keyof LogDefinitions;
+
+// This type helper reverses the keys and values of a given type, e.g this:
+// {1: 'a'}
+// becomes this:
+// {a: 1}
+type Reverse<T extends { [f: string]: number }> = {
+  [P in T[keyof T]]: {
+    [K in keyof T]: T[K] extends P ? K : never;
+  }[keyof T];
+};
+
+export type LogDefinitionsReverse = {
+  [type in keyof LogDefinitions]: Reverse<LogDefinitions[type]['fields']>;
+};
 
 export default logDefinitions;

--- a/resources/netlog_defs.ts
+++ b/resources/netlog_defs.ts
@@ -808,6 +808,15 @@ const logDefinitions = {
     },
     isUnknown: true,
   },
+  None: {
+    type: '[0-9]+',
+    name: 'None',
+    fields: {
+      type: 0,
+      timestamp: 1,
+    },
+    isUnknown: true,
+  },
 } as const;
 
 // Verify that this has the right type, but export `as const`.
@@ -816,19 +825,5 @@ console.assert(assertLogDefinitions);
 
 export type LogDefinitions = typeof logDefinitions;
 export type LogDefinitionTypes = keyof LogDefinitions;
-
-// This type helper reverses the keys and values of a given type, e.g this:
-// {1: 'a'}
-// becomes this:
-// {a: 1}
-type Reverse<T extends { [f: string]: number }> = {
-  [P in T[keyof T]]: {
-    [K in keyof T]: T[K] extends P ? K : never;
-  }[keyof T];
-};
-
-export type LogDefinitionsReverse = {
-  [type in keyof LogDefinitions]: Reverse<LogDefinitions[type]['fields']>;
-};
 
 export default logDefinitions;

--- a/resources/netregexes.ts
+++ b/resources/netregexes.ts
@@ -1,7 +1,8 @@
+import { NetFieldsReverse } from '../types/net_fields';
 import { NetParams } from '../types/net_props';
 import { CactbotBaseRegExp } from '../types/net_trigger';
 
-import logDefinitions, { LogDefinitionsReverse, LogDefinitionTypes } from './netlog_defs';
+import logDefinitions, { LogDefinitionTypes } from './netlog_defs';
 import Regexes from './regexes';
 
 // Differences from Regexes:
@@ -29,7 +30,7 @@ const keysThatRequireTranslation = [
 
 type ParseHelperField<
   Type extends LogDefinitionTypes,
-  Fields extends LogDefinitionsReverse[Type],
+  Fields extends NetFieldsReverse[Type],
   Field extends keyof Fields,
 > = {
   field: Fields[Field] extends string ? Fields[Field] : never;
@@ -37,7 +38,7 @@ type ParseHelperField<
 };
 
 type ParseHelperFields<T extends LogDefinitionTypes> = {
-  [field in keyof LogDefinitionsReverse[T]]: ParseHelperField<T, LogDefinitionsReverse[T], field>;
+  [field in keyof NetFieldsReverse[T]]: ParseHelperField<T, NetFieldsReverse[T], field>;
 };
 
 const defaultParams = <

--- a/resources/netregexes.ts
+++ b/resources/netregexes.ts
@@ -40,6 +40,27 @@ type ParseHelperFields<T extends LogDefinitionTypes> = {
   [field in keyof LogDefinitionsReverse[T]]: ParseHelperField<T, LogDefinitionsReverse[T], field>;
 };
 
+const defaultParams = <
+  T extends keyof typeof logDefinitions,
+>(type: T, include?: string[]): Partial<ParseHelperFields<T>> => {
+  include ??= Object.keys(logDefinitions[type].fields);
+  const params: { [index: number]: { field: string; value?: string } } = {};
+
+  for (const [prop, index] of Object.entries(logDefinitions[type].fields)) {
+    if (!include.includes(prop))
+      continue;
+    const param: { field: string; value?: string } = {
+      field: prop,
+    };
+    if (prop === 'type')
+      param.value = logDefinitions[type].type;
+
+    params[index] = param;
+  }
+
+  return params as unknown as Partial<ParseHelperFields<T>>;
+};
+
 const parseHelper = <T extends LogDefinitionTypes>(
   params: { timestamp?: string; capture?: boolean } | undefined,
   funcName: string,
@@ -141,7 +162,7 @@ export default class NetRegexes {
    * matches: https://github.com/quisquous/cactbot/blob/main/docs/LogGuide.md#14-networkstartscasting
    */
   static startsUsing(params?: NetParams['StartsUsing']): CactbotBaseRegExp<'StartsUsing'> {
-    return parseHelper(params, 'startsUsing', this.defaultParams('StartsUsing'));
+    return parseHelper(params, 'startsUsing', defaultParams('StartsUsing'));
   }
 
   /**
@@ -150,7 +171,7 @@ export default class NetRegexes {
    */
   static ability(params?: NetParams['Ability']): CactbotBaseRegExp<'Ability'> {
     return parseHelper(params, 'ability', {
-      ...this.defaultParams('Ability', [
+      ...defaultParams('Ability', [
         'type',
         'timestamp',
         'sourceId',
@@ -171,7 +192,7 @@ export default class NetRegexes {
    */
   static abilityFull(params?: NetParams['Ability']): CactbotBaseRegExp<'Ability'> {
     return parseHelper(params, 'abilityFull', {
-      ...this.defaultParams('Ability'),
+      ...defaultParams('Ability'),
       // Override type
       0: { field: 'type', value: '2[12]' },
     });
@@ -181,7 +202,7 @@ export default class NetRegexes {
    * matches: https://github.com/quisquous/cactbot/blob/main/docs/LogGuide.md#1b-networktargeticon-head-markers
    */
   static headMarker(params?: NetParams['HeadMarker']): CactbotBaseRegExp<'HeadMarker'> {
-    return parseHelper(params, 'headMarker', this.defaultParams('HeadMarker'));
+    return parseHelper(params, 'headMarker', defaultParams('HeadMarker'));
   }
 
   /**
@@ -191,7 +212,7 @@ export default class NetRegexes {
     return parseHelper(
       params,
       'addedCombatant',
-      this.defaultParams('AddedCombatant', [
+      defaultParams('AddedCombatant', [
         'type',
         'timestamp',
         'id',
@@ -206,7 +227,7 @@ export default class NetRegexes {
   static addedCombatantFull(
     params?: NetParams['AddedCombatant'],
   ): CactbotBaseRegExp<'AddedCombatant'> {
-    return parseHelper(params, 'addedCombatantFull', this.defaultParams('AddedCombatant'));
+    return parseHelper(params, 'addedCombatantFull', defaultParams('AddedCombatant'));
   }
 
   /**
@@ -215,14 +236,14 @@ export default class NetRegexes {
   static removingCombatant(
     params?: NetParams['RemovedCombatant'],
   ): CactbotBaseRegExp<'RemovedCombatant'> {
-    return parseHelper(params, 'removingCombatant', this.defaultParams('RemovedCombatant'));
+    return parseHelper(params, 'removingCombatant', defaultParams('RemovedCombatant'));
   }
 
   /**
    * matches: https://github.com/quisquous/cactbot/blob/main/docs/LogGuide.md#1a-networkbuff
    */
   static gainsEffect(params?: NetParams['GainsEffect']): CactbotBaseRegExp<'GainsEffect'> {
-    return parseHelper(params, 'gainsEffect', this.defaultParams('GainsEffect'));
+    return parseHelper(params, 'gainsEffect', defaultParams('GainsEffect'));
   }
 
   /**
@@ -232,21 +253,21 @@ export default class NetRegexes {
   static statusEffectExplicit(
     params?: NetParams['StatusEffect'],
   ): CactbotBaseRegExp<'StatusEffect'> {
-    return parseHelper(params, 'statusEffectExplicit', this.defaultParams('StatusEffect'));
+    return parseHelper(params, 'statusEffectExplicit', defaultParams('StatusEffect'));
   }
 
   /**
    * matches: https://github.com/quisquous/cactbot/blob/main/docs/LogGuide.md#1e-networkbuffremove
    */
   static losesEffect(params?: NetParams['LosesEffect']): CactbotBaseRegExp<'LosesEffect'> {
-    return parseHelper(params, 'losesEffect', this.defaultParams('LosesEffect'));
+    return parseHelper(params, 'losesEffect', defaultParams('LosesEffect'));
   }
 
   /**
    * matches: https://github.com/quisquous/cactbot/blob/main/docs/LogGuide.md#23-networktether
    */
   static tether(params?: NetParams['Tether']): CactbotBaseRegExp<'Tether'> {
-    return parseHelper(params, 'tether', this.defaultParams('Tether'));
+    return parseHelper(params, 'tether', defaultParams('Tether'));
   }
 
   /**
@@ -254,7 +275,7 @@ export default class NetRegexes {
    * matches: https://github.com/quisquous/cactbot/blob/main/docs/LogGuide.md#19-networkdeath
    */
   static wasDefeated(params?: NetParams['WasDefeated']): CactbotBaseRegExp<'WasDefeated'> {
-    return parseHelper(params, 'wasDefeated', this.defaultParams('WasDefeated'));
+    return parseHelper(params, 'wasDefeated', defaultParams('WasDefeated'));
   }
 
   /**
@@ -307,7 +328,7 @@ export default class NetRegexes {
    * matches: https://github.com/quisquous/cactbot/blob/main/docs/LogGuide.md#00-logline
    */
   static gameLog(params?: NetParams['GameLog']): CactbotBaseRegExp<'GameLog'> {
-    return parseHelper(params, 'gameLog', this.defaultParams('GameLog'));
+    return parseHelper(params, 'gameLog', defaultParams('GameLog'));
   }
 
   /**
@@ -322,52 +343,31 @@ export default class NetRegexes {
    * matches: https://github.com/quisquous/cactbot/blob/main/docs/LogGuide.md#0c-playerstats
    */
   static statChange(params?: NetParams['PlayerStats']): CactbotBaseRegExp<'PlayerStats'> {
-    return parseHelper(params, 'statChange', this.defaultParams('PlayerStats'));
+    return parseHelper(params, 'statChange', defaultParams('PlayerStats'));
   }
 
   /**
    * matches: https://github.com/quisquous/cactbot/blob/main/docs/LogGuide.md#01-changezone
    */
   static changeZone(params?: NetParams['ChangeZone']): CactbotBaseRegExp<'ChangeZone'> {
-    return parseHelper(params, 'changeZone', this.defaultParams('ChangeZone'));
+    return parseHelper(params, 'changeZone', defaultParams('ChangeZone'));
   }
 
   /**
    * matches: https://github.com/quisquous/cactbot/blob/main/docs/LogGuide.md#21-network6d-actor-control-lines
    */
   static network6d(params?: NetParams['ActorControl']): CactbotBaseRegExp<'ActorControl'> {
-    return parseHelper(params, 'network6d', this.defaultParams('ActorControl'));
+    return parseHelper(params, 'network6d', defaultParams('ActorControl'));
   }
 
   /**
    * matches: https://github.com/quisquous/cactbot/blob/main/docs/LogGuide.md#22-networknametoggle
    */
   static nameToggle(params?: NetParams['NameToggle']): CactbotBaseRegExp<'NameToggle'> {
-    return parseHelper(params, 'nameToggle', this.defaultParams('NameToggle'));
+    return parseHelper(params, 'nameToggle', defaultParams('NameToggle'));
   }
 
   static map(params?: NetParams['Map']): CactbotBaseRegExp<'Map'> {
-    return parseHelper(params, 'map', this.defaultParams('Map'));
-  }
-
-  static defaultParams<
-    T extends keyof typeof logDefinitions,
-  >(type: T, include?: string[]): Partial<ParseHelperFields<T>> {
-    include ??= Object.keys(logDefinitions[type].fields);
-    const params: { [index: number]: { field: string; value?: string } } = {};
-
-    for (const [prop, index] of Object.entries(logDefinitions[type].fields)) {
-      if (!include.includes(prop))
-        continue;
-      const param: { field: string; value?: string } = {
-        field: prop,
-      };
-      if (prop === 'type')
-        param.value = logDefinitions[type].type;
-
-      params[index] = param;
-    }
-
-    return params as unknown as Partial<ParseHelperFields<T>>;
+    return parseHelper(params, 'map', defaultParams('Map'));
   }
 }

--- a/types/net_fields.d.ts
+++ b/types/net_fields.d.ts
@@ -5,48 +5,12 @@ type Fields = {
   timestamp: 1;
 };
 
-// TODO: add a netFieldsName to netlog_defs so this can be generated generically?
-export type NetFields = {
-  'GameLog': typeof logDefinitions.gameLog.fields;
-  'ChangeZone': typeof logDefinitions.changeZone.fields;
-  'ChangedPlayer': typeof logDefinitions.changePrimaryPlayer.fields;
-  'AddedCombatant': typeof logDefinitions.addCombatant.fields;
-  'RemovedCombatant': typeof logDefinitions.removeCombatant.fields;
-  'PlayerStats': typeof logDefinitions.playerStats.fields;
-  'StartsUsing': typeof logDefinitions.networkStartsCasting.fields;
-  'Ability': typeof logDefinitions.networkAbility.fields;
-  'AOEAbility': typeof logDefinitions.networkAbility.fields;
-  'CancelAbility': typeof logDefinitions.networkCancelAbility.fields;
-  'DoTHoT': typeof logDefinitions.networkDoT.fields;
-  'WasDefeated': typeof logDefinitions.networkDeath.fields;
-  'GainsEffect': typeof logDefinitions.networkBuff.fields;
-  'HeadMarker': typeof logDefinitions.networkTargetIcon.fields;
-  'FloorWaymarker': typeof logDefinitions.networkRaidMarker.fields;
-  'CombatantWaymarker': typeof logDefinitions.networkTargetMarker.fields;
-  'LosesEffect': typeof logDefinitions.networkBuffRemove.fields;
-  'JobGauge': typeof logDefinitions.networkGauge.fields;
-  'ActorControl': typeof logDefinitions.network6d.fields;
-  'NameToggle': typeof logDefinitions.networkNameToggle.fields;
-  'Tether': typeof logDefinitions.networkTether.fields;
-  'LimitGauge': typeof logDefinitions.limitBreak.fields;
-  'ActionSync': typeof logDefinitions.networkEffectResult.fields;
-  'StatusEffect': typeof logDefinitions.networkStatusEffects.fields;
-  'Map': typeof logDefinitions.map.fields;
-  'None': Fields;
-};
-
-// This type helper reverses the keys and values of a given type, e.g this:
-// {1: 'a'}
-// becomes this:
-// {a: 1}
-type Reverse<T> = {
-  [P in T[keyof T]]: {
-    [K in keyof T]: T[K] extends P ? K : never;
-  }[keyof T];
-};
-
-export type NetFieldsReverse = {
-  [K in keyof NetFields]: Reverse<NetFields[K]>;
-};
+export type NetFields =
+  & {
+    [Key in keyof typeof logDefinitions]: (typeof logDefinitions[Key])['fields'];
+  }
+  & {
+    'None': Fields;
+  };
 
 export type NetAnyFields = NetFields[keyof NetFields];

--- a/types/net_fields.d.ts
+++ b/types/net_fields.d.ts
@@ -1,16 +1,21 @@
-import logDefinitions from '../resources/netlog_defs';
+import { LogDefinitions } from '../resources/netlog_defs';
 
-type Fields = {
-  type: 0;
-  timestamp: 1;
+// This type helper reverses the keys and values of a given type, e.g this:
+// {1: 'a'}
+// becomes this:
+// {a: 1}
+type Reverse<T extends { [f: string]: number }> = {
+  [P in T[keyof T]]: {
+    [K in keyof T]: T[K] extends P ? K : never;
+  }[keyof T];
 };
 
-export type NetFields =
-  & {
-    [Key in keyof typeof logDefinitions]: (typeof logDefinitions[Key])['fields'];
-  }
-  & {
-    'None': Fields;
-  };
+export type NetFields = {
+  [type in keyof LogDefinitions]: LogDefinitions[type]['fields'];
+};
+
+export type NetFieldsReverse = {
+  [type in keyof LogDefinitions]: Reverse<LogDefinitions[type]['fields']>;
+};
 
 export type NetAnyFields = NetFields[keyof NetFields];

--- a/ui/raidboss/emulator/data/network_log_converter/LineEvent0x00.ts
+++ b/ui/raidboss/emulator/data/network_log_converter/LineEvent0x00.ts
@@ -3,7 +3,7 @@ import logDefinitions from '../../../../../resources/netlog_defs';
 import LineEvent from './LineEvent';
 import LogRepository from './LogRepository';
 
-const fields = logDefinitions.gameLog.fields;
+const fields = logDefinitions.GameLog.fields;
 
 // Chat event
 export class LineEvent0x00 extends LineEvent {

--- a/ui/raidboss/emulator/data/network_log_converter/LineEvent0x01.ts
+++ b/ui/raidboss/emulator/data/network_log_converter/LineEvent0x01.ts
@@ -4,7 +4,7 @@ import EmulatorCommon from '../../EmulatorCommon';
 import LineEvent from './LineEvent';
 import LogRepository from './LogRepository';
 
-const fields = logDefinitions.changeZone.fields;
+const fields = logDefinitions.ChangeZone.fields;
 
 // Zone change event
 export class LineEvent0x01 extends LineEvent {

--- a/ui/raidboss/emulator/data/network_log_converter/LineEvent0x02.ts
+++ b/ui/raidboss/emulator/data/network_log_converter/LineEvent0x02.ts
@@ -3,7 +3,7 @@ import logDefinitions from '../../../../../resources/netlog_defs';
 import LineEvent from './LineEvent';
 import LogRepository from './LogRepository';
 
-const fields = logDefinitions.changePrimaryPlayer.fields;
+const fields = logDefinitions.ChangedPlayer.fields;
 
 // Player change event
 export class LineEvent0x02 extends LineEvent {

--- a/ui/raidboss/emulator/data/network_log_converter/LineEvent0x03.ts
+++ b/ui/raidboss/emulator/data/network_log_converter/LineEvent0x03.ts
@@ -6,7 +6,7 @@ import EmulatorCommon from '../../EmulatorCommon';
 import LineEvent, { LineEventJobLevel, LineEventSource } from './LineEvent';
 import LogRepository from './LogRepository';
 
-const fields = logDefinitions.addCombatant.fields;
+const fields = logDefinitions.AddedCombatant.fields;
 
 // Added combatant event
 export class LineEvent0x03 extends LineEvent implements LineEventSource, LineEventJobLevel {

--- a/ui/raidboss/emulator/data/network_log_converter/LineEvent0x0C.ts
+++ b/ui/raidboss/emulator/data/network_log_converter/LineEvent0x0C.ts
@@ -3,7 +3,7 @@ import logDefinitions from '../../../../../resources/netlog_defs';
 import LineEvent from './LineEvent';
 import LogRepository from './LogRepository';
 
-const fields = logDefinitions.playerStats.fields;
+const fields = logDefinitions.PlayerStats.fields;
 
 // Player stats event
 export class LineEvent0x0C extends LineEvent {

--- a/ui/raidboss/emulator/data/network_log_converter/LineEvent0x14.ts
+++ b/ui/raidboss/emulator/data/network_log_converter/LineEvent0x14.ts
@@ -4,7 +4,7 @@ import EmulatorCommon from '../../EmulatorCommon';
 import LineEvent, { LineEventAbility, LineEventSource, LineEventTarget } from './LineEvent';
 import LogRepository from './LogRepository';
 
-const fields = logDefinitions.networkStartsCasting.fields;
+const fields = logDefinitions.StartsUsing.fields;
 
 // Shorten a few types so dprint doesn't complain when the line gets too long.
 type LESource = LineEventSource;

--- a/ui/raidboss/emulator/data/network_log_converter/LineEvent0x15.ts
+++ b/ui/raidboss/emulator/data/network_log_converter/LineEvent0x15.ts
@@ -3,7 +3,7 @@ import logDefinitions from '../../../../../resources/netlog_defs';
 import LineEvent, { LineEventAbility, LineEventSource, LineEventTarget } from './LineEvent';
 import LogRepository from './LogRepository';
 
-const fields = logDefinitions.networkAbility.fields;
+const fields = logDefinitions.Ability.fields;
 
 // Shorten a few types so dprint doesn't complain when the line gets too long.
 type LESource = LineEventSource;

--- a/ui/raidboss/emulator/data/network_log_converter/LineEvent0x19.ts
+++ b/ui/raidboss/emulator/data/network_log_converter/LineEvent0x19.ts
@@ -4,7 +4,7 @@ import EmulatorCommon from '../../EmulatorCommon';
 import LineEvent from './LineEvent';
 import LogRepository from './LogRepository';
 
-const fields = logDefinitions.networkDeath.fields;
+const fields = logDefinitions.WasDefeated.fields;
 
 // Combatant defeated event
 export class LineEvent0x19 extends LineEvent {

--- a/ui/raidboss/emulator/data/network_log_converter/LineEvent0x1A.ts
+++ b/ui/raidboss/emulator/data/network_log_converter/LineEvent0x1A.ts
@@ -4,7 +4,7 @@ import EmulatorCommon from '../../EmulatorCommon';
 import LineEvent from './LineEvent';
 import LogRepository from './LogRepository';
 
-const fields = logDefinitions.networkBuff.fields;
+const fields = logDefinitions.GainsEffect.fields;
 
 // Gain status effect event
 // Deliberately don't flag this as LineEventSource or LineEventTarget

--- a/ui/raidboss/emulator/data/network_log_converter/LineEvent0x1B.ts
+++ b/ui/raidboss/emulator/data/network_log_converter/LineEvent0x1B.ts
@@ -3,7 +3,7 @@ import logDefinitions from '../../../../../resources/netlog_defs';
 import LineEvent, { LineEventSource } from './LineEvent';
 import LogRepository from './LogRepository';
 
-const fields = logDefinitions.networkTargetIcon.fields;
+const fields = logDefinitions.HeadMarker.fields;
 
 // Head marker event
 export class LineEvent0x1B extends LineEvent implements LineEventSource {

--- a/ui/raidboss/emulator/data/network_log_converter/LineEvent0x22.ts
+++ b/ui/raidboss/emulator/data/network_log_converter/LineEvent0x22.ts
@@ -3,7 +3,7 @@ import logDefinitions from '../../../../../resources/netlog_defs';
 import LineEvent, { LineEventSource } from './LineEvent';
 import LogRepository from './LogRepository';
 
-const fields = logDefinitions.networkNameToggle.fields;
+const fields = logDefinitions.NameToggle.fields;
 
 // Nameplate toggle
 export class LineEvent0x22 extends LineEvent implements LineEventSource {

--- a/ui/raidboss/emulator/data/network_log_converter/LineEvent0x23.ts
+++ b/ui/raidboss/emulator/data/network_log_converter/LineEvent0x23.ts
@@ -3,7 +3,7 @@ import logDefinitions from '../../../../../resources/netlog_defs';
 import LineEvent from './LineEvent';
 import LogRepository from './LogRepository';
 
-const fields = logDefinitions.networkTether.fields;
+const fields = logDefinitions.Tether.fields;
 
 // Tether event
 export class LineEvent0x23 extends LineEvent {

--- a/ui/raidboss/emulator/data/network_log_converter/LineEvent0x26.ts
+++ b/ui/raidboss/emulator/data/network_log_converter/LineEvent0x26.ts
@@ -6,7 +6,7 @@ import EmulatorCommon from '../../EmulatorCommon';
 import LineEvent, { LineEventJobLevel, LineEventSource } from './LineEvent';
 import LogRepository from './LogRepository';
 
-const fields = logDefinitions.networkStatusEffects.fields;
+const fields = logDefinitions.StatusEffect.fields;
 
 // Network status effect event
 export class LineEvent0x26 extends LineEvent implements LineEventSource, LineEventJobLevel {


### PR DESCRIPTION
As discussed in #3371, this PR refactors `NetRegexes` to use `logDefinitions` entries, and uses a `defaultParams` helper to initiate the default params automatically.

I wasn't able to get the helper to work without the typecasting at some point, I tried 6 different variations but no matter how I arranged and typed things it always required a `... as unknown as ...` typecast at one location or another.

Additionally, I only renamed the `logDefinitions` entries that were currently in use via `NetFields`. Probably the rest should be renamed to match, or the renaming should go in the other direction, but if it were in the other direction it would require updating 3021 lines across 168 files in triggers, plus a few spots here and there that are using current `NetFields` names