### PR TITLE
util: disable lint on coverage report

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -40,6 +40,9 @@ const settings = {
     'plugin/',
     'publish/',
     'resources/lib/',
+    // dprint+eslint is exceptionally slow on this generated file so skip it
+    // if somebody has generated it locally.
+    'util/coverage/coverage_report.ts',
   ],
   'parserOptions': {
     'ecmaVersion': 2020,

--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -40,9 +40,6 @@ const settings = {
     'plugin/',
     'publish/',
     'resources/lib/',
-    // dprint+eslint is exceptionally slow on this generated file so skip it
-    // if somebody has generated it locally.
-    'util/coverage/coverage_report.ts',
   ],
   'parserOptions': {
     'ecmaVersion': 2020,

--- a/util/gen_coverage_report.js
+++ b/util/gen_coverage_report.js
@@ -1,6 +1,5 @@
 import fs from 'fs';
 import path from 'path';
-import eslint from 'eslint';
 import ZoneInfo from '../resources/zone_info';
 import contentList from '../resources/content_list';
 import ZoneId from '../resources/zone_id';
@@ -231,15 +230,10 @@ const writeCoverageReport = async (outputFileName, coverage, totals) => {
     `export const coverage = ${JSON.stringify(coverage, undefined, 2)};\n\n` +
     `export const coverageTotals = ${JSON.stringify(totals, undefined, 2)};\n`;
 
-  const linter = new eslint.ESLint({ fix: true });
-  const results = await linter.lintText(str, { filePath: outputFileName });
-
-  // There's only one result from lintText, as per documentation.
-  const lintResult = results[0];
-  if (lintResult.errorCount > 0 || lintResult.warningCount > 0) {
-    console.error('Lint ran with errors, aborting.');
-    process.exit(2);
-  }
+  // FIXME: It would be nice to programatically run eslint (as we have in the past)
+  // but dprint + eslint takes about 20 minutes to run on this file, and so is
+  // unreasonable to run.  So, don't run lint, just verify that it loads below.
+  // Maybe there's some rule that's particularly bad?
 
   // Overwrite the file, if it already exists.
   const flags = 'w';
@@ -249,7 +243,22 @@ const writeCoverageReport = async (outputFileName, coverage, totals) => {
     process.exit(-1);
   });
 
-  writer.write(lintResult.output);
+  writer.end(str);
+  writer.close();
+
+  // Verify that the file can be imported without errors, as this is the only
+  // check that the coverage report will load properly.
+  try {
+    // FIXME: why does this need an explicit extension in order for the loader to find it?
+    const exports = await import(`./${outputFileName.replace('.ts', '.js')}`);
+    if (!exports.coverage || !exports.coverageTotals) {
+      console.error(`Failed to write properly.`);
+      process.exit(-2);
+    }
+  } catch (e) {
+    console.error(e);
+    process.exit(-3);
+  }
 };
 
 (async () => {


### PR DESCRIPTION
Coverage report went from 2m to 20m when adding dprint.

An initial attempt to just add an "eslint-disable dprint/dprint"
line to the coverage report made it take 60m to complete (!!!).

For simplicity, just disable lint on this generated file.