### PR TITLE
docs: update README to not mention HP option

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,10 +84,6 @@ and enable it in the list of plugins.
 
 ![startup wizard download screenshot](screenshots/ffxiv_plugin_parsing_plugin.png)
 
-Additionally, you must enable parsing from the network and make sure that ACT is not firewalled.
-Make sure the settings for the FFXIV plugin have the "Include HP for Triggers" button checked.
-This is under `Plugins` ->`FFXIV Settings` -> `Options`.
-
 Alternative FFXIV Plugin Guides:
 
 * [fflogs video guide](https://www.fflogs.com/help/start/)

--- a/docs/ko-KR/README.md
+++ b/docs/ko-KR/README.md
@@ -86,10 +86,6 @@ Startup Wizard에서,
 
 ![startup wizard 다운로드 스크린샷](../../screenshots/ffxiv_plugin_parsing_plugin.png)
 
-더해서, 네트워크를 통해 파싱해야 하기 때문에 ACT가 방화벽에서 차단되어 있지 않도록 하세요.
-FFXIV plugin 설정에 "Include HP for Triggers" 버튼이 체크되어 있는지 확인하세요.
-이 설정은 `Plugins` ->`FFXIV Settings` -> `Options`에 있습니다.
-
 다른 FFXIV Plugin 가이드:
 
 * [fflogs 동영상 가이드](https://www.fflogs.com/help/start/)

--- a/docs/zh-CN/README.md
+++ b/docs/zh-CN/README.md
@@ -73,8 +73,6 @@ cactbot提供以下模块：
 
 ![开始向导下载屏幕截图](../../screenshots/ffxiv_plugin_parsing_plugin.png)
 
-此外，您必须启用网络解析方式，并确保为ACT开启防火墙准入。 请确保FFXIV解析插件的设置中已勾选“包含HP用于触发器”按钮。 此选项在 `插件列表` ->`FFXIV Settings` -> `Options`中。
-
 其他FFXIV插件指南：
 
 * [fflogs video guide](https://www.fflogs.com/help/start/)


### PR DESCRIPTION
All of the triggers have been updated to not use this setting
any more, and so the recommendation to use it can be removed.