### PR TITLE
build: add suo-parser for webpack load timeline

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13313,6 +13313,12 @@
         }
       }
     },
+    "suo-parser": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/suo-parser/-/suo-parser-0.1.5.tgz",
+      "integrity": "sha512-NDKFv+evsyFXqwFvJ08HE61HotRwaQBOMBpmZn1342Pm1FN126XRpMQldI5qt8kR5Dl8C8/e0Se5G7Zj71VIuQ==",
+      "dev": true
+    },
     "supports-color": {
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",

--- a/package.json
+++ b/package.json
@@ -87,6 +87,7 @@
     "style-loader": "^2.0.0",
     "stylelint": "^13.8.0",
     "stylelint-config-standard": "^19.0.0",
+    "suo-parser": "^0.1.5",
     "tar-fs": "^2.1.1",
     "ts-loader": "^8.0.17",
     "ts-node": "^9.1.1",


### PR DESCRIPTION
Import [suo-parser](https://www.npmjs.com/package/suo-parser) for parsing timeline.

`suo-parser` is written by me about half a year ago, but I didn't have time until now to clean up the code and publish it to npm.
Unsurprisingly, `suo-parser` supports `cactbot` style timeline syntax only now (except deprecated `infotext`, `alerttext` and `alarmtext`).
It will accelerate the build step for about 5 sec in my test.

------

Additionally, I have thought about how the raidboss module loads timeline in runtime:

Currently, raidboss reads and processes the timeline when the player enters a new zone and some timelines match the zone id.
But because we use webpack to pack them into a bundle, the timeline won't be changed in runtime, so why don't we just provide a processed timeline **object** in the bundle? Additionally, we can make this **object** uglified/simplified, decreasing the release size but didn't affect the function. However, the processing code that reads timeline should be still in the release, we'll use it to process custom timeline text that the user provides.