### PR TITLE
oopsy: Add summary table

### DIFF
--- a/ui/oopsyraidsy/damage_tracker.ts
+++ b/ui/oopsyraidsy/damage_tracker.ts
@@ -36,6 +36,7 @@ import {
   kShiftFlagValues,
   playerDamageFields,
   ShortNamify,
+  Translate,
   UnscrambleDamage,
 } from './oopsy_common';
 import { OopsyOptions } from './oopsy_options';
@@ -212,7 +213,7 @@ export class DamageTracker {
       return;
     this.lastDamage[obj.name] = {
       target: obj.name,
-      ability: this.collector.Translate(obj.text),
+      ability: Translate(this.options.DisplayLanguage, obj.text),
       flags: kFlagInstantDeath,
       damage: '0',
     };

--- a/ui/oopsyraidsy/mistake_collector.ts
+++ b/ui/oopsyraidsy/mistake_collector.ts
@@ -1,14 +1,13 @@
 import { EventResponses } from '../../types/event';
 import { NetMatches } from '../../types/net_matches';
 import { OopsyMistake } from '../../types/oopsy';
-import { LocaleText } from '../../types/trigger';
 
 import { MistakeObserver } from './mistake_observer';
 import {
   IsPlayerId,
   IsTriggerEnabled,
   kFlagInstantDeath,
-  ShortNamify,
+  Translate,
   UnscrambleDamage,
 } from './oopsy_common';
 import { OopsyOptions } from './oopsy_options';
@@ -49,7 +48,6 @@ const kEarlyPullId = 'General Early Pull';
 export class MistakeCollector {
   private inACTCombat = false;
   private inGameCombat = false;
-  private baseTime?: number;
   private startTime?: number;
   private stopTime?: number;
   private engageTime?: number;
@@ -69,17 +67,6 @@ export class MistakeCollector {
     this.stopTime = undefined;
     this.firstPuller = undefined;
     this.engageTime = undefined;
-  }
-
-  GetFormattedTime(time?: number): string {
-    if (!this.baseTime)
-      return '';
-    if (!time)
-      time = Date.now();
-    const totalSeconds = Math.floor((time - this.baseTime) / 1000);
-    const seconds = totalSeconds % 60;
-    const minutes = Math.floor(totalSeconds / 60);
-    return `${minutes}:${seconds < 10 ? `0${seconds}` : seconds}`;
   }
 
   StartCombat(): void {
@@ -111,24 +98,11 @@ export class MistakeCollector {
     this.engageTime = undefined;
   }
 
-  Translate(obj: LocaleText | string | undefined): string | undefined {
-    if (typeof obj !== 'object')
-      return obj;
-    return obj[this.options.DisplayLanguage] ?? obj['en'];
-  }
-
   OnMistakeObj(m?: OopsyMistake): void {
     if (!m)
       return;
-    this.OnMistakeText(m.type, m.name || m.blame, this.Translate(m.text));
-  }
-
-  OnMistakeText(type: string, blame?: string, text?: string, time?: number): void {
-    if (!text)
-      return;
-    const blameText = blame ? ShortNamify(blame, this.options.PlayerNicks) + ': ' : '';
     for (const observer of this.observers)
-      observer.AddLine(type, blameText + text, this.GetFormattedTime(time));
+      observer.OnMistakeObj(m);
   }
 
   AddEngage(): void {
@@ -142,9 +116,17 @@ export class MistakeCollector {
     }
     const seconds = ((Date.now() - this.startTime) / 1000);
     if (this.firstPuller && seconds >= this.options.MinimumTimeForPullMistake) {
-      const text = `${this.Translate(kEarlyPullText) ?? ''} (${seconds.toFixed(1)}s)`;
-      if (IsTriggerEnabled(this.options, kEarlyPullId))
-        this.OnMistakeText('pull', this.firstPuller, text);
+      const text = `${Translate(this.options.DisplayLanguage, kEarlyPullText) ?? ''} (${
+        seconds.toFixed(1)
+      }s)`;
+      if (IsTriggerEnabled(this.options, kEarlyPullId)) {
+        this.OnMistakeObj({
+          type: 'pull',
+          name: this.firstPuller,
+          blame: this.firstPuller,
+          text: text,
+        });
+      }
     }
   }
 
@@ -161,16 +143,24 @@ export class MistakeCollector {
       if (this.engageTime) {
         const seconds = ((Date.now() - this.engageTime) / 1000);
         if (seconds >= this.options.MinimumTimeForPullMistake) {
-          const text = `${this.Translate(kLatePullText) ?? ''} (${seconds.toFixed(1)}s)`;
-          if (IsTriggerEnabled(this.options, kEarlyPullId))
-            this.OnMistakeText('pull', this.firstPuller, text);
+          const text = `${Translate(this.options.DisplayLanguage, kLatePullText) ?? ''} (${
+            seconds.toFixed(1)
+          }s)`;
+          if (IsTriggerEnabled(this.options, kEarlyPullId)) {
+            this.OnMistakeObj({
+              type: 'pull',
+              name: this.firstPuller,
+              blame: this.firstPuller,
+              text: text,
+            });
+          }
         }
       }
     }
   }
 
   AddDeath(name: string, matches: Partial<NetMatches['Ability']>): void {
-    let text;
+    let text = '';
     if (matches) {
       // Note: ACT just evaluates independently what the hp of everybody
       // is and so may be out of date modulo one hp regen tick with
@@ -189,7 +179,11 @@ export class MistakeCollector {
       }
       text = `${matches?.ability ?? '???'}${hp}`;
     }
-    this.OnMistakeText('death', name, text);
+    this.OnMistakeObj({
+      type: 'death',
+      name: name,
+      text: text,
+    });
 
     // TODO: some things don't have abilities, e.g. jumping off titan ex.
     // This will just show the last thing that hit you before you were
@@ -201,7 +195,10 @@ export class MistakeCollector {
     // wipe then (to make post-wipe deaths more obvious), however this
     // requires making liveList be able to insert items in a sorted
     // manner instead of just being append only.
-    this.OnMistakeText('wipe', undefined, this.Translate(kPartyWipeText));
+    this.OnMistakeObj({
+      type: 'wipe',
+      text: kPartyWipeText,
+    });
     // Party wipe usually comes a few seconds after everybody dies
     // so this will clobber any late damage.
     this.StopCombat();
@@ -236,7 +233,6 @@ export class MistakeCollector {
         // TODO: This message should probably include the timestamp
         // for when combat started.  Starting here is not the right
         // time if this plugin is loaded while ACT is already in combat.
-        this.baseTime = Date.now();
         for (const observer of this.observers)
           observer.StartNewACTCombat();
       }

--- a/ui/oopsyraidsy/mistake_collector.ts
+++ b/ui/oopsyraidsy/mistake_collector.ts
@@ -3,6 +3,7 @@ import { NetMatches } from '../../types/net_matches';
 import { OopsyMistake } from '../../types/oopsy';
 import { LocaleText } from '../../types/trigger';
 
+import { MistakeObserver } from './mistake_observer';
 import {
   IsPlayerId,
   IsTriggerEnabled,
@@ -10,7 +11,6 @@ import {
   ShortNamify,
   UnscrambleDamage,
 } from './oopsy_common';
-import { OopsyListView } from './oopsy_list_view';
 import { OopsyOptions } from './oopsy_options';
 
 const kEarlyPullText = {
@@ -55,7 +55,7 @@ export class MistakeCollector {
   private engageTime?: number;
   public firstPuller?: string;
 
-  constructor(private options: OopsyOptions, private listView: OopsyListView) {
+  constructor(private options: OopsyOptions, private mistakeObserver: MistakeObserver) {
     this.Reset();
   }
 
@@ -89,7 +89,7 @@ export class MistakeCollector {
     // period of time.  Gross.
     //
     // Because damage comes before in combat (regardless of where engage
-    // occurs), StartCombat has to be responsible for clearing the listView
+    // occurs), StartCombat has to be responsible for clearing the mistakeObserver
     // list.
     const now = Date.now();
     const kMinimumSecondsAfterWipe = 5;
@@ -122,7 +122,7 @@ export class MistakeCollector {
     if (!text)
       return;
     const blameText = blame ? ShortNamify(blame, this.options.PlayerNicks) + ': ' : '';
-    this.listView.AddLine(type, blameText + text, this.GetFormattedTime(time));
+    this.mistakeObserver.AddLine(type, blameText + text, this.GetFormattedTime(time));
   }
 
   AddEngage(): void {
@@ -219,7 +219,7 @@ export class MistakeCollector {
       else
         this.StopCombat();
 
-      this.listView.SetInCombat(this.inGameCombat);
+      this.mistakeObserver.SetInCombat(this.inGameCombat);
     }
 
     const inACTCombat = e.detail.inACTCombat;
@@ -230,7 +230,7 @@ export class MistakeCollector {
         // for when combat started.  Starting here is not the right
         // time if this plugin is loaded while ACT is already in combat.
         this.baseTime = Date.now();
-        this.listView.StartNewACTCombat();
+        this.mistakeObserver.StartNewACTCombat();
       }
     }
   }

--- a/ui/oopsyraidsy/mistake_observer.ts
+++ b/ui/oopsyraidsy/mistake_observer.ts
@@ -1,6 +1,6 @@
 import { EventResponses } from '../../types/event';
 
-export interface OopsyListView {
+export interface MistakeObserver {
   SetInCombat: (inCombat: boolean) => void;
   AddLine: (iconClass: string, text: string, time: string) => void;
   StartNewACTCombat: () => void;

--- a/ui/oopsyraidsy/mistake_observer.ts
+++ b/ui/oopsyraidsy/mistake_observer.ts
@@ -1,8 +1,9 @@
 import { EventResponses } from '../../types/event';
+import { OopsyMistake } from '../../types/oopsy';
 
 export interface MistakeObserver {
   SetInCombat: (inCombat: boolean) => void;
-  AddLine: (iconClass: string, text: string, time: string) => void;
+  OnMistakeObj: (m: OopsyMistake) => void;
   StartNewACTCombat: () => void;
   OnChangeZone: (e: EventResponses['ChangeZone']) => void;
 }

--- a/ui/oopsyraidsy/oopsy_common.ts
+++ b/ui/oopsyraidsy/oopsy_common.ts
@@ -1,3 +1,6 @@
+import { Lang } from '../../resources/languages';
+import { LocaleText } from '../../types/trigger';
+
 import { OopsyOptions } from './oopsy_options';
 
 // Fields for net log ability lines.
@@ -96,6 +99,21 @@ export const ShortNamify = (
 
   const idx = name.indexOf(' ');
   return idx < 0 ? name : name.substr(0, idx);
+};
+
+export const Translate = (lang: Lang, obj?: LocaleText | string): string | undefined => {
+  if (typeof obj !== 'object')
+    return obj;
+  return obj[lang] ?? obj['en'];
+};
+
+export const GetFormattedTime = (baseTime: number | undefined, time: number): string => {
+  if (!baseTime)
+    return '';
+  const totalSeconds = Math.floor((time - baseTime) / 1000);
+  const seconds = totalSeconds % 60;
+  const minutes = Math.floor(totalSeconds / 60);
+  return `${minutes}:${seconds < 10 ? `0${seconds}` : seconds}`;
 };
 
 // Turns a scrambled string damage field into an integer.

--- a/ui/oopsyraidsy/oopsy_live_list.ts
+++ b/ui/oopsyraidsy/oopsy_live_list.ts
@@ -1,7 +1,7 @@
 import { UnreachableCode } from '../../resources/not_reached';
 import { EventResponses } from '../../types/event';
 
-import { OopsyListView } from './oopsy_list_view';
+import { MistakeObserver } from './mistake_observer';
 import { OopsyOptions } from './oopsy_options';
 
 const kCopiedMessage = {
@@ -13,7 +13,7 @@ const kCopiedMessage = {
   ko: '복사 완료!',
 };
 
-export class OopsyLiveList implements OopsyListView {
+export class OopsyLiveList implements MistakeObserver {
   private container: Element;
   private inCombat = false;
   private numItems = 0;

--- a/ui/oopsyraidsy/oopsy_live_list.ts
+++ b/ui/oopsyraidsy/oopsy_live_list.ts
@@ -1,7 +1,9 @@
 import { UnreachableCode } from '../../resources/not_reached';
 import { EventResponses } from '../../types/event';
+import { OopsyMistake } from '../../types/oopsy';
 
 import { MistakeObserver } from './mistake_observer';
+import { GetFormattedTime, ShortNamify, Translate } from './oopsy_common';
 import { OopsyOptions } from './oopsy_options';
 
 const kCopiedMessage = {
@@ -18,6 +20,7 @@ export class OopsyLiveList implements MistakeObserver {
   private inCombat = false;
   private numItems = 0;
   private items: HTMLElement[] = [];
+  private baseTime?: number;
 
   constructor(private options: OopsyOptions, private scroller: HTMLElement) {
     const container = this.scroller.children[0];
@@ -41,6 +44,16 @@ export class OopsyLiveList implements MistakeObserver {
       this.container.classList.add('out-of-combat');
       this.ShowAllItems();
     }
+  }
+
+  OnMistakeObj(m: OopsyMistake): void {
+    const iconClass = m.type;
+    const blame = m.name ?? m.blame;
+    const blameText = blame ? ShortNamify(blame, this.options.PlayerNicks) + ': ' : '';
+    const text = Translate(this.options.DisplayLanguage, m.text);
+    if (!text)
+      return;
+    this.AddLine(iconClass, `${blameText} ${text}`, GetFormattedTime(this.baseTime, Date.now()));
   }
 
   AddLine(iconClass: string, text: string, time: string): void {
@@ -130,6 +143,7 @@ export class OopsyLiveList implements MistakeObserver {
 
   StartNewACTCombat(): void {
     this.Reset();
+    this.baseTime = Date.now();
   }
 
   OnChangeZone(_e: EventResponses['ChangeZone']): void {

--- a/ui/oopsyraidsy/oopsy_summary.css
+++ b/ui/oopsyraidsy/oopsy_summary.css
@@ -71,6 +71,7 @@ html {
 /* first row */
 .mistake-table .header {
   border-bottom: solid black 2px;
+  order: -1;
 }
 
 /* first row, not first column */

--- a/ui/oopsyraidsy/oopsy_summary.css
+++ b/ui/oopsyraidsy/oopsy_summary.css
@@ -1,3 +1,7 @@
+:root {
+  --table-cols: 5;
+}
+
 html {
   overflow: visible !important;
 }
@@ -7,7 +11,7 @@ html {
   align-items: center;
 }
 
-.mistake-icon {
+.mistake-row .mistake-icon {
   order: 2;
   margin-right: 3px;
   font-size: 20px;
@@ -46,4 +50,45 @@ html {
 .section-rows {
   padding-left: 10px;
   max-width: 500px;
+}
+
+.mistake-table {
+  display: grid;
+  grid-template-columns: repeat(var(--table-cols), max-content);
+  margin: 20px;
+}
+
+.mistake-table div {
+  padding-top: 3px;
+  padding-bottom: 3px;
+  text-align: right;
+  box-sizing: border-box;
+
+  /* give all columns a light border, override first column below */
+  border-right: solid grey 1px;
+}
+
+/* first row */
+.mistake-table .header {
+  border-bottom: solid black 2px;
+}
+
+/* first row, not first column */
+.mistake-table .mistake-icon {
+  text-align: center;
+  min-width: 30px;
+  width: 100%;
+}
+
+/* first column */
+.mistake-table .name {
+  padding-right: 5px;
+  border-right: solid black 2px;
+}
+
+/* not first column, not first row */
+.mistake-table .number {
+  /* numbers are aligned right, but "centered" a little with padding */
+  padding-left: 12px;
+  padding-right: 12px;
 }

--- a/ui/oopsyraidsy/oopsy_summary.html
+++ b/ui/oopsyraidsy/oopsy_summary.html
@@ -5,7 +5,9 @@
 </head>
 <body>
 <div id="container">
-  <div id="summary" class="summary hide"></div>
+  <div id="summary" class="summary hide">
+    <div id="mistake-table" class="mistake-table"></div>
+  </div>
 </div>
 </body>
 </html>

--- a/ui/oopsyraidsy/oopsy_summary_list.ts
+++ b/ui/oopsyraidsy/oopsy_summary_list.ts
@@ -1,9 +1,9 @@
 import { EventResponses } from '../../types/event';
 
-import { OopsyListView } from './oopsy_list_view';
+import { MistakeObserver } from './mistake_observer';
 import { OopsyOptions } from './oopsy_options';
 
-export class OopsySummaryList implements OopsyListView {
+export class OopsySummaryList implements MistakeObserver {
   private pullIdx = 0;
   private zoneName?: string;
   private currentDiv: HTMLElement | null = null;

--- a/ui/oopsyraidsy/oopsyraidsy.ts
+++ b/ui/oopsyraidsy/oopsyraidsy.ts
@@ -1,18 +1,42 @@
 import { UnreachableCode } from '../../resources/not_reached';
 import { addOverlayListener, callOverlayHandler } from '../../resources/overlay_plugin_api';
 import UserConfig from '../../resources/user_config';
+import { OopsyMistakeType } from '../../types/oopsy';
 
 import { DamageTracker } from './damage_tracker';
 import oopsyFileData from './data/oopsy_manifest.txt';
 import { MistakeCollector } from './mistake_collector';
 import { OopsyLiveList } from './oopsy_live_list';
 import defaultOptions from './oopsy_options';
-import { OopsySummaryList } from './oopsy_summary_list';
+import { OopsySummaryList, OopsySummaryTable } from './oopsy_summary_list';
 
 import './oopsyraidsy_config';
 
 import '../../resources/defaults.css';
 import './oopsy_common.css';
+
+export const addDebugInfo = (collector: MistakeCollector, numMistakes: number): void => {
+  // TODO: maybe this should use the fake_name_generator.
+  const names = [
+    'Tini Poutini',
+    'Potato Chippy',
+    'Papas Fritas',
+    'Tater Tot',
+    'Hash Brown',
+    'French Fry',
+  ];
+  const types: OopsyMistakeType[] = ['death', 'fail', 'warn', 'pull'];
+
+  // TODO: this should probably start/stop combat too for the summary page?
+  collector.StartCombat();
+  for (let i = 0; i < numMistakes; ++i) {
+    collector.OnMistakeObj({
+      type: types[Math.floor(Math.random() * types.length)] ?? 'good',
+      blame: names[Math.floor(Math.random() * names.length)],
+      text: 'stuff',
+    });
+  }
+};
 
 UserConfig.getUserConfigLocation('oopsyraidsy', defaultOptions, () => {
   const options = { ...defaultOptions };
@@ -26,12 +50,23 @@ UserConfig.getUserConfigLocation('oopsyraidsy', defaultOptions, () => {
   if (summaryElement) {
     const listView = new OopsySummaryList(options, summaryElement);
     mistakeCollector.AddObserver(listView);
+
+    const tableElement = document.getElementById('mistake-table');
+    if (!tableElement)
+      throw new UnreachableCode();
+    const table = new OopsySummaryTable(options, tableElement);
+    mistakeCollector.AddObserver(table);
   } else if (liveListElement) {
     const listView = new OopsyLiveList(options, liveListElement);
     mistakeCollector.AddObserver(listView);
   } else {
     throw new UnreachableCode();
   }
+
+  // NOTE: add "debug=1" url parameter to add extra events.
+  const params = new URLSearchParams(window.location.search);
+  if (params.get('debug'))
+    addDebugInfo(mistakeCollector, 2200);
 
   const damageTracker = new DamageTracker(options, mistakeCollector, oopsyFileData);
 

--- a/ui/oopsyraidsy/oopsyraidsy.ts
+++ b/ui/oopsyraidsy/oopsyraidsy.ts
@@ -5,7 +5,6 @@ import UserConfig from '../../resources/user_config';
 import { DamageTracker } from './damage_tracker';
 import oopsyFileData from './data/oopsy_manifest.txt';
 import { MistakeCollector } from './mistake_collector';
-import { MistakeObserver } from './mistake_observer';
 import { OopsyLiveList } from './oopsy_live_list';
 import defaultOptions from './oopsy_options';
 import { OopsySummaryList } from './oopsy_summary_list';
@@ -17,26 +16,23 @@ import './oopsy_common.css';
 
 UserConfig.getUserConfigLocation('oopsyraidsy', defaultOptions, () => {
   const options = { ...defaultOptions };
-  let initListView: MistakeObserver;
-  let initMistakeCollector: MistakeCollector;
 
+  const mistakeCollector = new MistakeCollector(options);
   const summaryElement = document.getElementById('summary');
   const liveListElement = document.getElementById('livelist');
 
   // Choose the ui based on whether this is the summary view or the live list.
   // They have different elements in the file.
   if (summaryElement) {
-    initListView = new OopsySummaryList(options, summaryElement);
-    initMistakeCollector = new MistakeCollector(options, initListView);
+    const listView = new OopsySummaryList(options, summaryElement);
+    mistakeCollector.AddObserver(listView);
   } else if (liveListElement) {
-    initListView = new OopsyLiveList(options, liveListElement);
-    initMistakeCollector = new MistakeCollector(options, initListView);
+    const listView = new OopsyLiveList(options, liveListElement);
+    mistakeCollector.AddObserver(listView);
   } else {
     throw new UnreachableCode();
   }
 
-  const listView = initListView;
-  const mistakeCollector = initMistakeCollector;
   const damageTracker = new DamageTracker(options, mistakeCollector, oopsyFileData);
 
   addOverlayListener('LogLine', (e) => damageTracker.OnNetLog(e));
@@ -45,7 +41,6 @@ UserConfig.getUserConfigLocation('oopsyraidsy', defaultOptions, () => {
   addOverlayListener('ChangeZone', (e) => {
     damageTracker.OnChangeZone(e);
     mistakeCollector.OnChangeZone(e);
-    listView.OnChangeZone(e);
   });
   addOverlayListener('onInCombatChangedEvent', (e) => {
     damageTracker.OnInCombatChangedEvent(e);

--- a/ui/oopsyraidsy/oopsyraidsy.ts
+++ b/ui/oopsyraidsy/oopsyraidsy.ts
@@ -5,7 +5,7 @@ import UserConfig from '../../resources/user_config';
 import { DamageTracker } from './damage_tracker';
 import oopsyFileData from './data/oopsy_manifest.txt';
 import { MistakeCollector } from './mistake_collector';
-import { OopsyListView } from './oopsy_list_view';
+import { MistakeObserver } from './mistake_observer';
 import { OopsyLiveList } from './oopsy_live_list';
 import defaultOptions from './oopsy_options';
 import { OopsySummaryList } from './oopsy_summary_list';
@@ -17,7 +17,7 @@ import './oopsy_common.css';
 
 UserConfig.getUserConfigLocation('oopsyraidsy', defaultOptions, () => {
   const options = { ...defaultOptions };
-  let initListView: OopsyListView;
+  let initListView: MistakeObserver;
   let initMistakeCollector: MistakeCollector;
 
   const summaryElement = document.getElementById('summary');


### PR DESCRIPTION
This is a bunch of refactoring commits with some functional changes at the end.  The end result is that the summary page gets a table that looks something like this:

![image](https://user-images.githubusercontent.com/462317/130370957-814c1ee2-7178-4b2b-8ca5-82d08986ef0f.png)