### PR TITLE
oopsy: change icons to fontawesome

### DIFF
--- a/ui/oopsyraidsy/oopsy_common.css
+++ b/ui/oopsyraidsy/oopsy_common.css
@@ -5,8 +5,20 @@
 
 .mistake-icon {
   text-align: center;
-  text-shadow: -1px 0 1px grey, 0 1px 1px grey;
+  text-shadow: -1px 0 2px grey, 0 1px 2px grey;
   width: 20px;
+}
+
+.mistake-icon::before {
+  display: inline-block;
+  font-style: normal;
+  font-variant: normal;
+  text-rendering: auto;
+
+  /* these are icon fonts, so there's no fallback for this */
+  /* stylelint-disable-next-line font-family-no-missing-generic-family-keyword */
+  font-family: 'Font Awesome 5 Free';
+  font-weight: 900;
 }
 
 .mistake-text {
@@ -17,48 +29,47 @@
 
 .mistake-icon.pull::before {
   color: green;
-  content: '\25B6';
+  content: '\f04b';
 }
 
 .mistake-icon.death::before {
   color: red;
-  content: '\1F480';
+  content: '\f54c';
 }
 
 .mistake-icon.warn::before {
   color: yellow;
-  content: '\26A0';
+  content: '\f071';
 }
 
 .mistake-icon.fail::before {
   color: red;
-  content: '\1F6AB';
+  content: '\f05e';
 }
 
 .mistake-icon.wipe::before {
   color: blue;
-  content: '\1F6BD';
+  content: '\f2ed';
 }
 
 .mistake-icon.potion::before {
   color: purple;
-  content: '\1F378';
+  content: '\f000';
 }
 
 .mistake-icon.good::before {
   color: green;
-  content: '\2714';
+  content: '\f00c';
 }
 
 .mistake-icon.damage::before {
   color: white;
-  content: '\1F52A';
-  font-weight: bold;
+  content: '\f102';
 }
 
 .mistake-icon.heal::before {
   color: cyan;
-  content: '\1F3E5';
+  content: '\f0fe';
 }
 
 .copied-msg {

--- a/ui/oopsyraidsy/oopsy_summary.html
+++ b/ui/oopsyraidsy/oopsy_summary.html
@@ -2,6 +2,10 @@
 <head>
   <meta charset="utf-8" />
   <title>Oopsy Summary</title>
+  <link
+    rel="stylesheet"
+    href="https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free@5.15.4/css/solid.min.css"
+  />
 </head>
 <body>
 <div id="container">

--- a/ui/oopsyraidsy/oopsyraidsy.html
+++ b/ui/oopsyraidsy/oopsyraidsy.html
@@ -2,6 +2,10 @@
 <head>
   <meta charset="utf-8" />
   <title>Cactbot Oopsyraidsy</title>
+  <link
+    rel="stylesheet"
+    href="https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free@5.15.4/css/solid.min.css"
+  />
 </head>
 <body>
 <div id="container">


### PR DESCRIPTION
I wanted to try to get back to the original flavor of (colored) win7 emoji with oopsy icons.  I find it very hard to parse the win10 colored emoji when I glance over sometimes.

Original win7 icons:
![image](https://user-images.githubusercontent.com/462317/130561861-a1ed3e57-e3a4-433d-b7b7-c74af3520b48.png)

Current win10 icons: (death, fail, warn, pull, potion, wipe, good, damage, heal)
![image](https://user-images.githubusercontent.com/462317/130560714-ac648674-7715-4cee-99e0-aad0a85d62a1.png)

Proposed fontawesome icons:
![image](https://user-images.githubusercontent.com/462317/130560729-dd7d6a89-cd93-46d6-bf71-283a0ce97bc4.png)

Feel free to counterpropose from https://fontawesome.com/v5.15/icons?d=gallery&p=9&m=free or with some other license compatible svg icon.