### PR TITLE
raidemulator/docs: Fix issues with timestamp timezones

### DIFF
--- a/docs/LogGuide.md
+++ b/docs/LogGuide.md
@@ -548,12 +548,12 @@ Network Log Line Examples:
 03|2021-06-16T21:35:11.4020000-07:00|4000b36a|Catastrophe|0|46|0|0||5631|6358|57250|57250|0|10000|0|0|0|0|0|-4.792213E-05||b3b3b4f926bcadd8b6ef008232d58922
 
 ACT Log Line Examples:
-[23:46:38.545] 03:10FF0001:Added new combatant Tini Poutini(Jenova).  Job: BLU Level: 46 Max HP: 30460 Max MP: 10000 Pos: (-0.76,15.896,0).
-[00:35:11.306] 03:4000B364:Added new combatant Catastrophe.  Job: NONE Level: 46 Max HP: 57250 Max MP: 10000 Pos: (0,0,0) (56310000006358).
-[00:35:11.306] 03:4000B363:Added new combatant Catastrophe.  Job: NONE Level: 46 Max HP: 57250 Max MP: 10000 Pos: (0,0,0) (56310000006358).
-[00:35:11.306] 03:4000B362:Added new combatant Catastrophe.  Job: NONE Level: 46 Max HP: 13165210 Max MP: 10000 Pos: (0,-15,0) (56310000007305).
-[00:35:11.402] 03:4000B365:Added new combatant Catastrophe.  Job: NONE Level: 46 Max HP: 57250 Max MP: 10000 Pos: (0,0,0) (56310000006358).
-[00:35:11.402] 03:4000B36A:Added new combatant Catastrophe.  Job: NONE Level: 46 Max HP: 57250 Max MP: 10000 Pos: (0,0,0) (56310000006358).
+[20:46:38.545] 03:10FF0001:Added new combatant Tini Poutini(Jenova).  Job: BLU Level: 46 Max HP: 30460 Max MP: 10000 Pos: (-0.76,15.896,0).
+[21:35:11.306] 03:4000B364:Added new combatant Catastrophe.  Job: NONE Level: 46 Max HP: 57250 Max MP: 10000 Pos: (0,0,0) (56310000006358).
+[21:35:11.306] 03:4000B363:Added new combatant Catastrophe.  Job: NONE Level: 46 Max HP: 57250 Max MP: 10000 Pos: (0,0,0) (56310000006358).
+[21:35:11.306] 03:4000B362:Added new combatant Catastrophe.  Job: NONE Level: 46 Max HP: 13165210 Max MP: 10000 Pos: (0,-15,0) (56310000007305).
+[21:35:11.402] 03:4000B365:Added new combatant Catastrophe.  Job: NONE Level: 46 Max HP: 57250 Max MP: 10000 Pos: (0,0,0) (56310000006358).
+[21:35:11.402] 03:4000B36A:Added new combatant Catastrophe.  Job: NONE Level: 46 Max HP: 57250 Max MP: 10000 Pos: (0,0,0) (56310000006358).
 ```
 
 <!-- AUTO-GENERATED-CONTENT:END -->
@@ -607,8 +607,8 @@ Network Log Line Examples:
 04|2021-06-16T21:37:36.0740000-07:00|4000b39c|Petrosphere|0|46|0|0||6712|7308|0|57250|0|10000|0|0|-16.00671|-0.01531982|0|1.53875||980552ad636f06249f1b5c7a6e675aad
 
 ACT Log Line Examples:
-[02:01:27.548] 04:10FF0001:Removing combatant Tini Poutini. Max MP: 10000. Pos: (-66.24337,-292.0904,20.06466)
-[00:37:36.074] 04:4000B39C:Removing combatant Petrosphere. Max MP: 10000. Pos: (-16.00671,-0.01531982,0)
+[23:01:27.548] 04:10FF0001:Removing combatant Tini Poutini. Max MP: 10000. Pos: (-66.24337,-292.0904,20.06466)
+[21:37:36.074] 04:4000B39C:Removing combatant Petrosphere. Max MP: 10000. Pos: (-16.00671,-0.01531982,0)
 ```
 
 <!-- AUTO-GENERATED-CONTENT:END -->
@@ -718,8 +718,8 @@ Network Log Line Examples:
 11|2021-06-16T21:47:56.7170000-07:00|4|10FF0002|10FF0001|10FF0003|10FF0004|
 
 ACT Log Line Examples:
-[23:46:38.545] 0B:8:10FF0002:10FF0003:10FF0004:10FF0001:10FF0005:10FF0006:10FF0007:10FF0008:
-[00:47:56.717] 0B:4:10FF0002:10FF0001:10FF0003:10FF0004:
+[20:46:38.545] 0B:8:10FF0002:10FF0003:10FF0004:10FF0001:10FF0005:10FF0006:10FF0007:10FF0008:
+[21:47:56.717] 0B:4:10FF0002:10FF0001:10FF0003:10FF0004:
 ```
 
 <!-- AUTO-GENERATED-CONTENT:END -->
@@ -1208,12 +1208,12 @@ ACT Log Line Regex:
 Network Log Line Examples:
 26|2021-04-26T14:36:09.4340000-04:00|35|Physical Damage Up|15.00|400009D5|Dark General|400009D5|Dark General|00|48865|48865||cbcfac4df1554b8f59f343f017ebd793
 26|2021-04-26T14:23:38.7560000-04:00|13b|Whispering Dawn|21.00|4000B283|Selene|10FF0002|Potato Chippy|4000016E|00|51893|49487||c7400f0eed1fe9d29834369affc22d3b
-+26|2021-07-02T21:57:07.9110000-04:00|d2|Doom|9.97|40003D9F||10FF0001|Tini Poutini|00|26396|26396||86ff6bf4cfdd68491274fce1db5677e8
+26|2021-07-02T21:57:07.9110000-04:00|d2|Doom|9.97|40003D9F||10FF0001|Tini Poutini|00|26396|26396||86ff6bf4cfdd68491274fce1db5677e8
 
 ACT Log Line Examples:
-[11:36:09.434] 1A:400009D5:Dark General gains the effect of Physical Damage Up from Dark General for 15.00 Seconds.
-[11:23:38.756] 1A:10FF0002:Potato Chippy gains the effect of Whispering Dawn from Selene for 21.00 Seconds.
-[18:57:07.911] 1A:10FF0001:Tini Poutini gains the effect of Doom from  for 9.97 Seconds.
+[14:36:09.434] 1A:400009D5:Dark General gains the effect of Physical Damage Up from Dark General for 15.00 Seconds.
+[14:23:38.756] 1A:10FF0002:Potato Chippy gains the effect of Whispering Dawn from Selene for 21.00 Seconds.
+[21:57:07.911] 1A:10FF0001:Tini Poutini gains the effect of Doom from  for 9.97 Seconds.
 ```
 
 <!-- AUTO-GENERATED-CONTENT:END -->
@@ -1266,8 +1266,8 @@ Network Log Line Examples:
 27|2021-05-11T13:48:45.3370000-04:00|40000950|Copied Knave|0000|0000|0117|0000|0000|0000||fa2e93fccf397a41aac73a3a38aa7410
 
 ACT Log Line Examples:
-[11:17:31.698] 1B:10FF0001:Tini Poutini:0000:A9B9:0057:0000:0000:0000::4fb326d8899ffbd4cbfeb29bbc3080f8
-[10:48:45.337] 1B:40000950:Copied Knave:0000:0000:0117:0000:0000:0000::fa2e93fccf397a41aac73a3a38aa7410
+[14:17:31.698] 1B:10FF0001:Tini Poutini:0000:A9B9:0057:0000:0000:0000::4fb326d8899ffbd4cbfeb29bbc3080f8
+[13:48:45.337] 1B:40000950:Copied Knave:0000:0000:0117:0000:0000:0000::fa2e93fccf397a41aac73a3a38aa7410
 ```
 
 <!-- AUTO-GENERATED-CONTENT:END -->
@@ -1943,9 +1943,9 @@ Network Log Line Regex:
 
 ```log
 Network Log Line Examples:
-40|2021-07-30T19:43:08.6270000-04:00|578|Norvrandt|The Copied Factory|Upper Stratum|ee5b5fc06ab4610ef6b4f030fc95c90c
-40|2021-07-30T19:46:49.3830000-04:00|575|Norvrandt|Excavation Tunnels||41e6dae1ab1a3fe18ce3754d7c45a5d0
-40|2021-07-30T19:49:19.8180000-04:00|192|La Noscea|Mist|Mist Subdivision|f3506f063945500b5e7df2172e2ca4d3
+40|2021-07-30T19:43:08.6270000-07:00|578|Norvrandt|The Copied Factory|Upper Stratum|ee5b5fc06ab4610ef6b4f030fc95c90c
+40|2021-07-30T19:46:49.3830000-07:00|575|Norvrandt|Excavation Tunnels||41e6dae1ab1a3fe18ce3754d7c45a5d0
+40|2021-07-30T19:49:19.8180000-07:00|192|La Noscea|Mist|Mist Subdivision|f3506f063945500b5e7df2172e2ca4d3
 
 ACT Log Line Examples:
 [19:43:08.627] 28:

--- a/ui/raidboss/emulator/EmulatorCommon.ts
+++ b/ui/raidboss/emulator/EmulatorCommon.ts
@@ -58,6 +58,33 @@ export const cloneSafe = (node: HTMLElement): HTMLElement => {
   return cloned;
 };
 
+// For performance reasons to prevent re-calculating this every single line,
+// store already calculated values
+const tzOffsetMap: { [key: string]: number } = {};
+
+export const getTimezoneOffsetMillis = (timeString: string): number => {
+  const timezoneOffsetString = timeString.substr(-6);
+  const mappedValue = tzOffsetMap[timezoneOffsetString];
+  if (mappedValue)
+    return mappedValue;
+  const defaultOffset = new Date().getTimezoneOffset() * 1000;
+  if (timezoneOffsetString === undefined)
+    return defaultOffset;
+  const operator = timezoneOffsetString.substr(0, 1);
+  if (operator !== '+' && operator !== '-')
+    return defaultOffset;
+  const timezoneOffsetParts = timezoneOffsetString.substr(1).split(':');
+  const hoursString = timezoneOffsetParts[0];
+  const minutesString = timezoneOffsetParts[1];
+  if (hoursString === undefined || minutesString === undefined)
+    return defaultOffset;
+  const hours = parseInt(hoursString);
+  const minutes = parseInt(minutesString);
+  const tzOffset = (((hours * 60) + minutes) * 60 * 1000) * (operator === '-' ? -1 : 1);
+  tzOffsetMap[timezoneOffsetString] = tzOffset;
+  return tzOffset;
+};
+
 export default class EmulatorCommon {
   static cloneData(data: DataType, exclude = ['options', 'party']): DataType {
     const ret: DataType = {};
@@ -125,28 +152,30 @@ export default class EmulatorCommon {
     return negative + mins + ':' + secs + (includeMillis ? '.' + millis : '');
   }
 
-  static timeToDateString(time: number): string {
-    return this.dateObjectToDateString(new Date(time));
+  static timeToDateString(time: number, tzOffsetMillis: number): string {
+    return this.dateObjectToDateString(new Date(time), tzOffsetMillis);
   }
 
-  static dateObjectToDateString(date: Date): string {
-    const year = date.getFullYear();
-    const month = EmulatorCommon.zeroPad((date.getMonth() + 1).toString());
-    const day = EmulatorCommon.zeroPad(date.getDate().toString());
+  static dateObjectToDateString(date: Date, tzOffsetMillis: number): string {
+    const convDate = new Date(date.getTime() + tzOffsetMillis);
+    const year = convDate.getUTCFullYear();
+    const month = EmulatorCommon.zeroPad((convDate.getUTCMonth() + 1).toString());
+    const day = EmulatorCommon.zeroPad(convDate.getUTCDate().toString());
     return `${year}-${month}-${day}`;
   }
 
-  static timeToTimeString(time: number, includeMillis = false): string {
-    return this.dateObjectToTimeString(new Date(time), includeMillis);
+  static timeToTimeString(time: number, tzOffsetMillis: number, includeMillis = false): string {
+    return this.dateObjectToTimeString(new Date(time), tzOffsetMillis, includeMillis);
   }
 
-  static dateObjectToTimeString(date: Date, includeMillis = false): string {
-    const hour = EmulatorCommon.zeroPad(date.getHours().toString());
-    const minute = EmulatorCommon.zeroPad(date.getMinutes().toString());
-    const second = EmulatorCommon.zeroPad(date.getSeconds().toString());
+  static dateObjectToTimeString(date: Date, tzOffsetMillis: number, includeMillis = false): string {
+    const convDate = new Date(date.getTime() + tzOffsetMillis);
+    const hour = EmulatorCommon.zeroPad(convDate.getUTCHours().toString());
+    const minute = EmulatorCommon.zeroPad(convDate.getUTCMinutes().toString());
+    const second = EmulatorCommon.zeroPad(convDate.getUTCSeconds().toString());
     let ret = `${hour}:${minute}:${second}`;
     if (includeMillis)
-      ret = ret + `.${EmulatorCommon.zeroPad(date.getMilliseconds().toString(), 3)}`;
+      ret = ret + `.${EmulatorCommon.zeroPad(convDate.getUTCMilliseconds().toString(), 3)}`;
 
     return ret;
   }
@@ -156,11 +185,11 @@ export default class EmulatorCommon {
     return tmp.replace(':', 'm') + 's';
   }
 
-  static dateTimeToString(time: number, includeMillis = false): string {
+  static dateTimeToString(time: number, tzOffsetMillis: number, includeMillis = false): string {
     const date = new Date(time);
-    return `${this.dateObjectToDateString(date)} ${
-      this.dateObjectToTimeString(date, includeMillis)
-    }`;
+    const dateString = this.dateObjectToDateString(date, tzOffsetMillis);
+    const timeString = this.dateObjectToTimeString(date, tzOffsetMillis, includeMillis);
+    return dateString + ' ' + timeString;
   }
 
   static zeroPad(str: string, len = 2): string {

--- a/ui/raidboss/emulator/data/Encounter.ts
+++ b/ui/raidboss/emulator/data/Encounter.ts
@@ -27,7 +27,7 @@ const isValidTimestamp = (timestamp: number) => {
 };
 
 export default class Encounter {
-  private static readonly encounterVersion = 1;
+  private static readonly encounterVersion = 2;
   public id?: number;
   version: number;
   initialOffset = Number.MAX_SAFE_INTEGER;
@@ -41,6 +41,7 @@ export default class Encounter {
   startTimestamp = 0;
   endTimestamp = 0;
   duration = 0;
+  tzOffsetMillis = 0;
   playbackOffset = 0;
   language: Lang = 'en';
   initialTimestamp = Number.MAX_SAFE_INTEGER;
@@ -60,6 +61,8 @@ export default class Encounter {
     this.logLines.forEach((line, i) => {
       if (!line)
         throw new UnreachableCode();
+
+      this.tzOffsetMillis = line.tzOffsetMillis;
 
       let res: MatchStartInfo | MatchEndInfo | undefined = EmulatorCommon.matchStart(
         line.networkLine,

--- a/ui/raidboss/emulator/data/PersistorEncounter.ts
+++ b/ui/raidboss/emulator/data/PersistorEncounter.ts
@@ -7,6 +7,7 @@ export default class PersistorEncounter {
   name: string;
   start: number;
   offset: number;
+  tzOffsetMillis: number;
   startStatus: string;
   endStatus: string;
   zoneId: string;
@@ -20,6 +21,7 @@ export default class PersistorEncounter {
     this.name = encounter.combatantTracker.getMainCombatantName();
     this.start = encounter.startTimestamp;
     this.offset = encounter.initialOffset;
+    this.tzOffsetMillis = encounter.tzOffsetMillis;
     this.startStatus = encounter.startStatus;
     this.endStatus = encounter.endStatus;
     this.zoneId = encounter.encounterZoneId;

--- a/ui/raidboss/emulator/data/PopupTextAnalysis.ts
+++ b/ui/raidboss/emulator/data/PopupTextAnalysis.ts
@@ -118,13 +118,11 @@ export default class PopupTextAnalysis extends StubbedPopupText {
 
   async onEmulatorLog(logs: LineEvent[]): Promise<void> {
     for (const logObj of logs) {
-      const log = logObj.properCaseConvertedLine ?? logObj.convertedLine;
-
-      if (log.includes('00:0038:cactbot wipe'))
+      if (logObj.convertedLine.includes('00:0038:cactbot wipe'))
         this.SetInCombat(false);
 
       for (const trigger of this.triggers) {
-        const r = trigger.localRegex?.exec(log);
+        const r = trigger.localRegex?.exec(logObj.convertedLine);
         if (!r)
           continue;
 

--- a/ui/raidboss/emulator/data/network_log_converter/LineEvent.ts
+++ b/ui/raidboss/emulator/data/network_log_converter/LineEvent.ts
@@ -20,7 +20,6 @@ export default class LineEvent {
   public readonly hexEvent: string;
   public readonly timestamp: number;
   public readonly checksum: string;
-  public readonly properCaseConvertedLine?: string;
 
   constructor(repo: LogRepository, public networkLine: string, parts: string[]) {
     this.decEvent = parseInt(parts[fields.event] ?? '0');

--- a/ui/raidboss/emulator/data/network_log_converter/LineEvent.ts
+++ b/ui/raidboss/emulator/data/network_log_converter/LineEvent.ts
@@ -1,5 +1,5 @@
 import { Job } from '../../../../../types/job';
-import EmulatorCommon from '../../EmulatorCommon';
+import EmulatorCommon, { getTimezoneOffsetMillis } from '../../EmulatorCommon';
 
 import LogRepository from './LogRepository';
 
@@ -20,18 +20,22 @@ export default class LineEvent {
   public readonly hexEvent: string;
   public readonly timestamp: number;
   public readonly checksum: string;
+  public readonly tzOffsetMillis: number;
 
   constructor(repo: LogRepository, public networkLine: string, parts: string[]) {
+    const timestampString = parts[fields.timestamp] ?? '0';
+    this.tzOffsetMillis = getTimezoneOffsetMillis(timestampString);
     this.decEvent = parseInt(parts[fields.event] ?? '0');
     this.hexEvent = EmulatorCommon.zeroPad(this.decEvent.toString(16).toUpperCase());
-    this.timestamp = new Date(parts[fields.timestamp] ?? '0').getTime();
+    this.timestamp = new Date(timestampString).getTime();
     this.checksum = parts.slice(-1)[0] ?? '';
     repo.updateTimestamp(this.timestamp);
     this.convertedLine = this.prefix() + (parts.slice(2).join(':')).replace('|', ':');
   }
 
   prefix(): string {
-    return '[' + EmulatorCommon.timeToTimeString(this.timestamp, true) + '] ' + this.hexEvent + ':';
+    const timeString = EmulatorCommon.timeToTimeString(this.timestamp, this.tzOffsetMillis, true);
+    return '[' + timeString + '] ' + this.hexEvent + ':';
   }
 
   static isDamageHallowed(damage: string): boolean {

--- a/ui/raidboss/emulator/data/network_log_converter/LineEvent0x01.ts
+++ b/ui/raidboss/emulator/data/network_log_converter/LineEvent0x01.ts
@@ -8,8 +8,6 @@ const fields = logDefinitions.ChangeZone.fields;
 
 // Zone change event
 export class LineEvent0x01 extends LineEvent {
-  public override readonly properCaseConvertedLine: string;
-
   public readonly zoneId: string;
   public readonly zoneName: string;
   public readonly zoneNameProperCase: string;
@@ -22,8 +20,6 @@ export class LineEvent0x01 extends LineEvent {
     this.zoneNameProperCase = EmulatorCommon.properCase(this.zoneName);
 
     this.convertedLine = this.prefix() +
-      'Changed Zone to ' + this.zoneName + '.';
-    this.properCaseConvertedLine = this.prefix() +
       'Changed Zone to ' + this.zoneNameProperCase + '.';
   }
 }

--- a/ui/raidboss/emulator/data/network_log_converter/LineEvent0x14.ts
+++ b/ui/raidboss/emulator/data/network_log_converter/LineEvent0x14.ts
@@ -13,8 +13,6 @@ type LEAbility = LineEventAbility;
 
 // Ability use event
 export class LineEvent0x14 extends LineEvent implements LESource, LETarget, LEAbility {
-  public override readonly properCaseConvertedLine: string;
-
   public readonly id: string;
   public readonly name: string;
   public readonly abilityId: number;
@@ -64,10 +62,6 @@ export class LineEvent0x14 extends LineEvent implements LESource, LETarget, LEAb
     const target = this.targetName.length === 0 ? 'Unknown' : this.targetName;
 
     this.convertedLine = this.prefix() + this.abilityIdHex +
-      ':' + this.name +
-      ' starts using ' + this.abilityName +
-      ' on ' + target + '.';
-    this.properCaseConvertedLine = this.prefix() + this.abilityIdHex +
       ':' + EmulatorCommon.properCase(this.name) +
       ' starts using ' + this.abilityName +
       ' on ' + EmulatorCommon.properCase(target) + '.';

--- a/ui/raidboss/emulator/data/network_log_converter/LineEvent0x18.ts
+++ b/ui/raidboss/emulator/data/network_log_converter/LineEvent0x18.ts
@@ -8,8 +8,6 @@ const fields = logDefinitions.NetworkDoT.fields;
 
 // DoT/HoT event
 export class LineEvent0x18 extends LineEvent implements LineEventSource {
-  public override readonly properCaseConvertedLine: string;
-
   public readonly id: string;
   public readonly name: string;
   public readonly type: string;
@@ -65,10 +63,6 @@ export class LineEvent0x18 extends LineEvent implements LineEventSource {
     const damageStringConverted = isNaN(this.damage) ? damageString : this.damage.toString();
 
     this.convertedLine = this.prefix() + effectPart + this.type +
-      ' Tick on ' + resolvedName +
-      ' for ' + damageStringConverted + ' damage.';
-
-    this.properCaseConvertedLine = this.prefix() + effectPart + this.type +
       ' Tick on ' + EmulatorCommon.properCase(resolvedName) +
       ' for ' + damageStringConverted + ' damage.';
   }
@@ -87,4 +81,4 @@ export class LineEvent0x18 extends LineEvent implements LineEventSource {
   };
 }
 
-export class LineEvent24 extends LineEvent0x18 { }
+export class LineEvent24 extends LineEvent0x18 {}

--- a/ui/raidboss/emulator/data/network_log_converter/LineEvent0x19.ts
+++ b/ui/raidboss/emulator/data/network_log_converter/LineEvent0x19.ts
@@ -8,7 +8,6 @@ const fields = logDefinitions.WasDefeated.fields;
 
 // Combatant defeated event
 export class LineEvent0x19 extends LineEvent {
-  public override readonly properCaseConvertedLine: string;
   public readonly targetId: string;
   public readonly targetName: string;
   public readonly sourceId: string;
@@ -47,11 +46,9 @@ export class LineEvent0x19 extends LineEvent {
 
     const defeatedName = (resolvedTargetName ?? this.sourceName);
     const killerName = (resolvedSourceName ?? this.sourceName);
-    this.convertedLine = this.prefix() + defeatedName +
-      ' was defeated by ' + killerName + '.';
-    this.properCaseConvertedLine = this.prefix() + EmulatorCommon.properCase(defeatedName) +
+    this.convertedLine = this.prefix() + EmulatorCommon.properCase(defeatedName) +
       ' was defeated by ' + EmulatorCommon.properCase(killerName) + '.';
   }
 }
 
-export class LineEvent25 extends LineEvent0x19 { }
+export class LineEvent25 extends LineEvent0x19 {}

--- a/ui/raidboss/emulator/data/network_log_converter/LineEvent0x1A.ts
+++ b/ui/raidboss/emulator/data/network_log_converter/LineEvent0x1A.ts
@@ -13,7 +13,6 @@ export class LineEvent0x1A extends LineEvent {
   public readonly resolvedName: string;
   public readonly resolvedTargetName: string;
   public readonly fallbackResolvedTargetName: string;
-  public override readonly properCaseConvertedLine: string;
 
   public readonly effectId: number;
   public readonly effect: string;
@@ -59,21 +58,21 @@ export class LineEvent0x1A extends LineEvent {
     this.resolvedName = repo.resolveName(this.id, this.name);
     this.resolvedTargetName = repo.resolveName(this.targetId, this.targetName);
 
-    this.fallbackResolvedTargetName =
-      repo.resolveName(this.id, this.name, this.targetId, this.targetName);
+    this.fallbackResolvedTargetName = repo.resolveName(
+      this.id,
+      this.name,
+      this.targetId,
+      this.targetName,
+    );
 
     let stackCountText = '';
-    if (this.stacks > 0 && this.stacks < 20 &&
-      LineEvent0x1A.showStackCountFor.includes(this.effectId))
+    if (
+      this.stacks > 0 && this.stacks < 20 &&
+      LineEvent0x1A.showStackCountFor.includes(this.effectId)
+    )
       stackCountText = ' (' + this.stacks.toString() + ')';
 
     this.convertedLine = this.prefix() + this.targetId +
-      ':' + this.targetName +
-      ' gains the effect of ' + this.effect +
-      ' from ' + this.fallbackResolvedTargetName +
-      ' for ' + this.durationString + ' Seconds.' + stackCountText;
-
-    this.properCaseConvertedLine = this.prefix() + this.targetId +
       ':' + EmulatorCommon.properCase(this.targetName) +
       ' gains the effect of ' + this.effect +
       ' from ' + EmulatorCommon.properCase(this.fallbackResolvedTargetName) +

--- a/ui/raidboss/emulator/data/network_log_converter/LineEvent0x1E.ts
+++ b/ui/raidboss/emulator/data/network_log_converter/LineEvent0x1E.ts
@@ -7,23 +7,17 @@ import LogRepository from './LogRepository';
 // Extend the gain status event to reduce duplicate code since they're
 // the same from a data perspective
 export class LineEvent0x1E extends LineEvent0x1A {
-  public override readonly properCaseConvertedLine: string;
-
   constructor(repo: LogRepository, line: string, parts: string[]) {
     super(repo, line, parts);
 
     let stackCountText = '';
-    if (this.stacks > 0 && this.stacks < 20 &&
-      LineEvent0x1A.showStackCountFor.includes(this.effectId))
+    if (
+      this.stacks > 0 && this.stacks < 20 &&
+      LineEvent0x1A.showStackCountFor.includes(this.effectId)
+    )
       stackCountText = ' (' + this.stacks.toString() + ')';
 
     this.convertedLine = this.prefix() + this.targetId +
-      ':' + this.targetName +
-      ' loses the effect of ' + this.effect +
-      ' from ' + this.fallbackResolvedTargetName +
-      ' for ' + this.durationString + ' Seconds.' + stackCountText;
-
-    this.properCaseConvertedLine = this.prefix() + this.targetId +
       ':' + EmulatorCommon.properCase(this.targetName) +
       ' loses the effect of ' + this.effect +
       ' from ' + EmulatorCommon.properCase(this.fallbackResolvedTargetName) +
@@ -31,4 +25,4 @@ export class LineEvent0x1E extends LineEvent0x1A {
   }
 }
 
-export class LineEvent30 extends LineEvent0x1E { }
+export class LineEvent30 extends LineEvent0x1E {}

--- a/ui/raidboss/emulator/data/network_log_converter/LineEvent0x1F.ts
+++ b/ui/raidboss/emulator/data/network_log_converter/LineEvent0x1F.ts
@@ -17,7 +17,6 @@ const fields = logDefinitions.NetworkGauge.fields;
 export class LineEvent0x1F extends LineEvent {
   public readonly jobGaugeBytes: string[];
   public readonly name: string;
-  public override readonly properCaseConvertedLine: string;
 
   public readonly id: string;
   public readonly dataBytes1: string;
@@ -51,12 +50,6 @@ export class LineEvent0x1F extends LineEvent {
     });
 
     this.convertedLine = this.prefix() +
-      this.id + ':' + this.name +
-      ':' + this.dataBytes1 +
-      ':' + this.dataBytes2 +
-      ':' + this.dataBytes3 +
-      ':' + this.dataBytes4;
-    this.properCaseConvertedLine = this.prefix() +
       this.id + ':' + (EmulatorCommon.properCase(this.name)) +
       ':' + this.dataBytes1 +
       ':' + this.dataBytes2 +

--- a/ui/raidboss/emulator/overrides/RaidEmulatorPopupText.ts
+++ b/ui/raidboss/emulator/overrides/RaidEmulatorPopupText.ts
@@ -106,13 +106,12 @@ export default class RaidEmulatorPopupText extends StubbedPopupText {
 
   onEmulatorLog(logs: LineEvent[]): void {
     for (const l of logs) {
-      const log = l.properCaseConvertedLine || l.convertedLine;
       const currentTime = l.timestamp;
-      if (log.includes('00:0038:cactbot wipe'))
+      if (l.convertedLine.includes('00:0038:cactbot wipe'))
         this.SetInCombat(false);
 
       for (const trigger of this.triggers) {
-        const r = trigger.localRegex?.exec(log);
+        const r = trigger.localRegex?.exec(l.convertedLine);
         if (r)
           this.OnTrigger(trigger, r, currentTime);
       }

--- a/ui/raidboss/emulator/overrides/RaidEmulatorTimelineController.ts
+++ b/ui/raidboss/emulator/overrides/RaidEmulatorTimelineController.ts
@@ -56,9 +56,7 @@ export default class RaidEmulatorTimelineController extends TimelineController {
       return;
 
     for (const line of logs) {
-      this.activeTimeline.OnLogLine(
-        line.properCaseConvertedLine || line.convertedLine,
-        line.timestamp);
+      this.activeTimeline.OnLogLine(line.convertedLine, line.timestamp);
       // Only call _OnUpdateTimer if we have a timebase from the previous call to OnLogLine
       // This avoids spamming the console with a ton of messages
       if (this.activeTimeline.timebase)

--- a/ui/raidboss/emulator/ui/EncounterTab.ts
+++ b/ui/raidboss/emulator/ui/EncounterTab.ts
@@ -56,8 +56,9 @@ export default class EncounterTab extends EventBus {
     void this.persistor.encounterSummaries.toArray().then((encounters: PersistorEncounter[]) => {
       for (const enc of encounters) {
         const zone = enc.zoneName;
-        const encDate = EmulatorCommon.timeToDateString(enc.start);
-        const encTime = EmulatorCommon.timeToTimeString(enc.start);
+        // ?? operator here to account for old encounters that don't have the property
+        const encDate = EmulatorCommon.timeToDateString(enc.start, enc.tzOffsetMillis ?? 0);
+        const encTime = EmulatorCommon.timeToTimeString(enc.start, enc.tzOffsetMillis ?? 0);
         const encDuration = EmulatorCommon.msToDuration(enc.duration);
         const zoneObj = this.encounters[zone] = this.encounters[zone] || {};
         const dateObj = zoneObj[encDate] = zoneObj[encDate] || [];
@@ -253,8 +254,9 @@ export default class EncounterTab extends EventBus {
       void this.dispatch('delete', enc.id);
     });
     querySelectorSafe($info, '.encounterZone .label').textContent = enc.zoneName;
+    // ?? operator here to account for old encounters that don't have the property
     querySelectorSafe($info, '.encounterStart .label').textContent = EmulatorCommon
-      .dateTimeToString(enc.start);
+      .dateTimeToString(enc.start, enc.tzOffsetMillis ?? 0);
     querySelectorSafe($info, '.encounterDuration .label').textContent = EmulatorCommon.timeToString(
       enc.duration,
       false,

--- a/util/gen_log_guide.ts
+++ b/util/gen_log_guide.ts
@@ -407,8 +407,7 @@ const config: markdownMagic.Configuration = {
 
       let structureNetwork = structureNetworkArray.join('|');
       const structureLogLine = ParseLine.parse(logRepo, structureNetwork);
-      let structureLog = structureLogLine?.properCaseConvertedLine ??
-        structureLogLine?.convertedLine;
+      let structureLog = structureLogLine?.convertedLine;
 
       if (!structureLog)
         throw new UnreachableCode();
@@ -429,7 +428,7 @@ const config: markdownMagic.Configuration = {
         const line = ParseLine.parse(logRepo, e);
         if (!line)
           throw new UnreachableCode();
-        return line?.properCaseConvertedLine ?? line?.convertedLine;
+        return line?.convertedLine;
       }).join('\n') ?? '';
 
       const regexes = lineDoc.regexes;


### PR DESCRIPTION
Fixes #3389

I also included the change to remove `properCaseConvertedLine` from `LineEvent` and subclasses, since the non-proper-case version is unused.

Both changes require a bump to encounter version number, so I figured it would be best to include both in the same PR to avoid people having to re-parse encounters twice depending on their timing. As such, I made sure to make these changes in their own commits to make it easier to determine what code change corresponds to which functional change.