### PR TITLE
jobs: fix japanese countdown regex

### DIFF
--- a/resources/translations.ts
+++ b/resources/translations.ts
@@ -10,7 +10,7 @@ const localeLines = {
     en: 'Battle commencing in (?<time>\\y{Float}) seconds! \\((?<player>.*?)\\)',
     de: 'Noch (?<time>\\y{Float}) Sekunden bis Kampfbeginn! \\((?<player>.*?)\\)',
     fr: 'Début du combat dans (?<time>\\y{Float}) secondes[ ]?! \\((?<player>.*?)\\)',
-    ja: '戦闘開始まで(?<time>\\y{Float})秒！ \\((?<player>.*?)\\)',
+    ja: '戦闘開始まで(?<time>\\y{Float})秒！ （(?<player>.*?)）',
     cn: '距离战斗开始还有(?<time>\\y{Float})秒！ （(?<player>.*?)）',
     ko: '전투 시작 (?<time>\\y{Float})초 전! \\((?<player>.*?)\\)',
   },


### PR DESCRIPTION
The brackets around the player name in jp are full-width, same with cn, for example:
```log
00|2021-09-17T17:34:13.0000000+08:00|00b9||戦闘開始まで10秒！ （Maiko Tan）
```