### PR TITLE
resources: change export type of resources/util.ts as named

### DIFF
--- a/resources/party.ts
+++ b/resources/party.ts
@@ -1,7 +1,7 @@
 import { Party } from '../types/event';
 import { Job, Role } from '../types/job';
 
-import Util from './util';
+import { jobEnumToJob, jobToRole } from './util';
 
 const emptyRoleToPartyNames = () => {
   return {
@@ -35,8 +35,8 @@ export default class PartyTracker {
     for (const p of e.party) {
       this.allianceIds_.push(p.id);
       this.allianceNames_.push(p.name);
-      const jobName = Util.jobEnumToJob(p.job);
-      const role = Util.jobToRole(jobName);
+      const jobName = jobEnumToJob(p.job);
+      const role = jobToRole(jobName);
       this.idToName_[p.id] = p.name;
       this.nameToRole_[p.name] = role;
       if (p.inParty) {
@@ -148,7 +148,7 @@ export default class PartyTracker {
   jobName(name: string): Job | undefined {
     const partyIndex = this.partyNames.indexOf(name);
     if (partyIndex >= 0)
-      return Util.jobEnumToJob(this.details[partyIndex]?.job as number);
+      return jobEnumToJob(this.details[partyIndex]?.job as number);
   }
 
   nameFromId(id: string): string | undefined {

--- a/resources/player_override.ts
+++ b/resources/player_override.ts
@@ -3,7 +3,7 @@ import { Party, PlayerChangedRet } from '../types/event';
 import { Job } from '../types/job';
 
 import { addOverlayListener } from './overlay_plugin_api';
-import Util from './util';
+import { jobEnumToJob } from './util';
 
 // Will redirect calls from `onPlayerChangedEvent` to |func| overriding with
 // |playerName| and their job.  Job is important for raidboss.
@@ -51,7 +51,7 @@ export const addPlayerChangedOverrideListener = (
     if (!player)
       return;
 
-    const newJob = Util.jobEnumToJob(player.job);
+    const newJob = jobEnumToJob(player.job);
     if (newJob === lastPlayerJob)
       return;
 

--- a/resources/user_config.ts
+++ b/resources/user_config.ts
@@ -26,7 +26,7 @@ import { Responses as _Responses } from './responses';
 const Responses = _Responses;
 import _Outputs from './outputs';
 const Outputs = _Outputs;
-import _Util from './util';
+import * as _Util from './util';
 const Util = _Util;
 import _ZoneId from './zone_id';
 const ZoneId = _ZoneId;

--- a/resources/user_config.ts
+++ b/resources/user_config.ts
@@ -26,8 +26,52 @@ import { Responses as _Responses } from './responses';
 const Responses = _Responses;
 import _Outputs from './outputs';
 const Outputs = _Outputs;
-import * as _Util from './util';
-const Util = _Util;
+import {
+  canAddle,
+  canCleanse,
+  canFeint,
+  canSilence,
+  canSleep,
+  canStun,
+  clearWatchCombatants,
+  getAllRoles,
+  isCasterDpsJob,
+  isCombatJob,
+  isCraftingJob,
+  isDpsJob,
+  isGatheringJob,
+  isHealerJob,
+  isMeleeDpsJob,
+  isRangedDpsJob,
+  isTankJob,
+  jobEnumToJob,
+  jobToJobEnum,
+  jobToRole,
+  watchCombatant,
+} from './util';
+const Util = {
+  canAddle,
+  canCleanse,
+  canFeint,
+  canSilence,
+  canSleep,
+  canStun,
+  clearWatchCombatants,
+  getAllRoles,
+  isCasterDpsJob,
+  isCombatJob,
+  isCraftingJob,
+  isDpsJob,
+  isGatheringJob,
+  isHealerJob,
+  isMeleeDpsJob,
+  isRangedDpsJob,
+  isTankJob,
+  jobEnumToJob,
+  jobToJobEnum,
+  jobToRole,
+  watchCombatant,
+} as const;
 import _ZoneId from './zone_id';
 const ZoneId = _ZoneId;
 import _ZoneInfo from './zone_info';

--- a/resources/util.ts
+++ b/resources/util.ts
@@ -111,7 +111,7 @@ const shouldCancelWatch = (
   return false;
 };
 
-const watchCombatant: WatchCombatantFunc = (params, func) => {
+export const watchCombatant: WatchCombatantFunc = (params, func) => {
   return new Promise<void>((res, rej) => {
     const delay = params.delay ?? 1000;
 
@@ -156,42 +156,38 @@ const watchCombatant: WatchCombatantFunc = (params, func) => {
   });
 };
 
-const Util = {
-  jobEnumToJob: (id: number) => {
-    const job = allJobs.find((job: Job) => nameToJobEnum[job] === id);
-    return job ?? 'NONE';
-  },
-  jobToJobEnum: (job: Job) => nameToJobEnum[job],
-  jobToRole: (job: Job) => {
-    const role = jobToRoleMap.get(job);
-    return role ?? 'none';
-  },
-  getAllRoles: (): readonly Role[] => allRoles,
-  isTankJob: (job: Job) => tankJobs.includes(job),
-  isHealerJob: (job: Job) => healerJobs.includes(job),
-  isMeleeDpsJob: (job: Job) => meleeDpsJobs.includes(job),
-  isRangedDpsJob: (job: Job) => rangedDpsJobs.includes(job),
-  isCasterDpsJob: (job: Job) => casterDpsJobs.includes(job),
-  isDpsJob: (job: Job) => dpsJobs.includes(job),
-  isCraftingJob: (job: Job) => craftingJobs.includes(job),
-  isGatheringJob: (job: Job) => gatheringJobs.includes(job),
-  isCombatJob: (job: Job) => {
-    return !craftingJobs.includes(job) && !gatheringJobs.includes(job);
-  },
-  canStun: (job: Job) => stunJobs.includes(job),
-  canSilence: (job: Job) => silenceJobs.includes(job),
-  canSleep: (job: Job) => sleepJobs.includes(job),
-  canCleanse: (job: Job) => cleanseJobs.includes(job),
-  canFeint: (job: Job) => feintJobs.includes(job),
-  canAddle: (job: Job) => addleJobs.includes(job),
-  watchCombatant: watchCombatant,
-  clearWatchCombatants: () => {
-    while (watchCombatantMap.length > 0) {
-      const watch = watchCombatantMap.pop();
-      if (watch)
-        watch.cancel = true;
-    }
-  },
-} as const;
+export const clearWatchCombatants = (): void => {
+  while (watchCombatantMap.length > 0) {
+    const watch = watchCombatantMap.pop();
+    if (watch)
+      watch.cancel = true;
+  }
+};
 
-export default Util;
+export const jobEnumToJob = (id: number): Job => {
+  const job = allJobs.find((job: Job) => nameToJobEnum[job] === id);
+  return job ?? 'NONE';
+};
+export const jobToJobEnum = (job: Job): number => nameToJobEnum[job];
+export const jobToRole = (job: Job): Role => {
+  const role = jobToRoleMap.get(job);
+  return role ?? 'none';
+};
+export const getAllRoles = (): readonly Role[] => allRoles;
+export const isTankJob = (job: Job): boolean => tankJobs.includes(job);
+export const isHealerJob = (job: Job): boolean => healerJobs.includes(job);
+export const isMeleeDpsJob = (job: Job): boolean => meleeDpsJobs.includes(job);
+export const isRangedDpsJob = (job: Job): boolean => rangedDpsJobs.includes(job);
+export const isCasterDpsJob = (job: Job): boolean => casterDpsJobs.includes(job);
+export const isDpsJob = (job: Job): boolean => dpsJobs.includes(job);
+export const isCraftingJob = (job: Job): boolean => craftingJobs.includes(job);
+export const isGatheringJob = (job: Job): boolean => gatheringJobs.includes(job);
+export const isCombatJob = (job: Job): boolean => {
+  return !craftingJobs.includes(job) && !gatheringJobs.includes(job);
+};
+export const canStun = (job: Job): boolean => stunJobs.includes(job);
+export const canSilence = (job: Job): boolean => silenceJobs.includes(job);
+export const canSleep = (job: Job): boolean => sleepJobs.includes(job);
+export const canCleanse = (job: Job): boolean => cleanseJobs.includes(job);
+export const canFeint = (job: Job): boolean => feintJobs.includes(job);
+export const canAddle = (job: Job): boolean => addleJobs.includes(job);

--- a/test/unittests/util_test.js
+++ b/test/unittests/util_test.js
@@ -1,4 +1,4 @@
-import Util from '../../resources/util';
+import * as Util from '../../resources/util';
 import chai from 'chai';
 
 const { assert } = chai;

--- a/ui/dps/dps_common.js
+++ b/ui/dps/dps_common.js
@@ -1,7 +1,7 @@
 import { addOverlayListener } from '../../resources/overlay_plugin_api';
 
 import ContentType from '../../resources/content_type';
-import Util from '../../resources/util';
+import { isCombatJob } from '../../resources/util';
 import ZoneInfo from '../../resources/zone_info';
 
 export const defaultOptions = {
@@ -61,7 +61,7 @@ export const InitDpsModule = function(options, updateFunc, hideFunc) {
     if (job === gCurrentJob)
       return;
     gCurrentJob = job;
-    if (Util.isCombatJob(job)) {
+    if (isCombatJob(job)) {
       gIgnoreCurrentJob = false;
       return;
     }

--- a/ui/jobs/jobs.js
+++ b/ui/jobs/jobs.js
@@ -4,7 +4,13 @@ import EffectId from '../../resources/effect_id';
 import ContentType from '../../resources/content_type';
 import Regexes from '../../resources/regexes';
 import UserConfig from '../../resources/user_config';
-import Util from '../../resources/util';
+import {
+  isCraftingJob,
+  isDpsJob,
+  isGatheringJob,
+  isHealerJob,
+  isTankJob,
+} from '../../resources/util';
 import ZoneInfo from '../../resources/zone_info';
 import ZoneId from '../../resources/zone_id';
 import {
@@ -195,15 +201,15 @@ class Bars {
     container.appendChild(barsLayoutContainer);
 
     barsLayoutContainer.classList.add(this.job.toLowerCase());
-    if (Util.isTankJob(this.job))
+    if (isTankJob(this.job))
       barsLayoutContainer.classList.add('tank');
-    else if (Util.isHealerJob(this.job))
+    else if (isHealerJob(this.job))
       barsLayoutContainer.classList.add('healer');
-    else if (Util.isDpsJob(this.job))
+    else if (isDpsJob(this.job))
       barsLayoutContainer.classList.add('dps');
-    else if (Util.isCraftingJob(this.job))
+    else if (isCraftingJob(this.job))
       barsLayoutContainer.classList.add('crafting');
-    else if (Util.isGatheringJob(this.job))
+    else if (isGatheringJob(this.job))
       barsLayoutContainer.classList.add('gathering');
 
     const pullCountdownContainer = document.createElement('div');
@@ -265,7 +271,7 @@ class Bars {
       this.o.leftBuffsList.elementwidth = (this.options.BigBuffIconWidth + 2).toString();
     }
 
-    if (Util.isCraftingJob(this.job)) {
+    if (isCraftingJob(this.job)) {
       this.o.cpContainer = document.createElement('div');
       this.o.cpContainer.id = 'cp-bar';
       barsContainer.appendChild(this.o.cpContainer);
@@ -278,7 +284,7 @@ class Bars {
       this.o.cpBar.fg = computeBackgroundColorFrom(this.o.cpBar, 'cp-color');
       container.classList.add('hide');
       return;
-    } else if (Util.isGatheringJob(this.job)) {
+    } else if (isGatheringJob(this.job)) {
       this.o.gpContainer = document.createElement('div');
       this.o.gpContainer.id = 'gp-bar';
       barsContainer.appendChild(this.o.gpContainer);
@@ -703,7 +709,7 @@ class Bars {
       return;
     if (
       this.inCombat || !this.options.LowerOpacityOutOfCombat ||
-      Util.isCraftingJob(this.job) || Util.isGatheringJob(this.job)
+      isCraftingJob(this.job) || isGatheringJob(this.job)
     )
       opacityContainer.style.opacity = '1.0';
     else
@@ -877,7 +883,7 @@ class Bars {
       this.umbralStacks = 0;
       this._updateMPTicker();
       updateJob = updateHp = updateMp = updateCp = updateGp = true;
-      if (!Util.isGatheringJob(this.job))
+      if (!isGatheringJob(this.job))
         this.gpAlarmReady = false;
     }
     if (e.detail.level !== this.level) {
@@ -981,7 +987,7 @@ class Bars {
           this._setPullCountdown(0);
         if (/:test:jobs:/.test(log))
           this._test();
-        if (Util.isCraftingJob(this.job))
+        if (isCraftingJob(this.job))
           this._onCraftingLog(log);
         break;
       }

--- a/ui/jobs/utils.ts
+++ b/ui/jobs/utils.ts
@@ -2,7 +2,7 @@ import { Lang } from '../../resources/languages';
 import NetRegexes from '../../resources/netregexes';
 import { UnreachableCode } from '../../resources/not_reached';
 import { LocaleNetRegex } from '../../resources/translations';
-import Util from '../../resources/util';
+import { isCasterDpsJob, isHealerJob } from '../../resources/util';
 import { Job } from '../../types/job';
 import { NetAnyFields } from '../../types/net_fields';
 import { CactbotBaseRegExp } from '../../types/net_trigger';
@@ -76,7 +76,7 @@ export class RegexesHolder {
 }
 
 export const doesJobNeedMPBar = (job: Job): boolean =>
-  Util.isCasterDpsJob(job) || Util.isHealerJob(job) || kMeleeWithMpJobs.includes(job);
+  isCasterDpsJob(job) || isHealerJob(job) || kMeleeWithMpJobs.includes(job);
 
 /** compute greased lightning stacks by player's level */
 const getLightningStacksByLevel = (level: number): number =>

--- a/ui/oopsyraidsy/damage_tracker.ts
+++ b/ui/oopsyraidsy/damage_tracker.ts
@@ -5,7 +5,7 @@ import PartyTracker from '../../resources/party';
 import { PlayerChangedDetail } from '../../resources/player_override';
 import Regexes from '../../resources/regexes';
 import { LocaleNetRegex } from '../../resources/translations';
-import Util from '../../resources/util';
+import { jobToRole } from '../../resources/util';
 import ZoneId from '../../resources/zone_id';
 import ZoneInfo from '../../resources/zone_info';
 import { OopsyData } from '../../types/data';
@@ -559,7 +559,7 @@ export class DamageTracker {
 
     this.me = e.detail.name;
     this.job = e.detail.job;
-    this.role = Util.jobToRole(this.job);
+    this.role = jobToRole(this.job);
     this.ReloadTriggers();
   }
 

--- a/ui/raidboss/data/00-misc/test.ts
+++ b/ui/raidboss/data/00-misc/test.ts
@@ -1,6 +1,6 @@
 import NetRegexes from '../../../../resources/netregexes';
 import outputs from '../../../../resources/outputs';
-import Util from '../../../../resources/util';
+import { watchCombatant } from '../../../../resources/util';
 import ZoneId from '../../../../resources/zone_id';
 import { RaidbossData } from '../../../../types/data';
 import { LocaleText, TriggerSet } from '../../../../types/trigger';
@@ -274,7 +274,7 @@ const triggerSet: TriggerSet<Data> = {
       netRegex: NetRegexes.echo({ line: 'cactbot test watch.*?', capture: false }),
       netRegexDe: NetRegexes.echo({ line: 'cactbot test beobachten.*?', capture: false }),
       promise: (data) =>
-        Util.watchCombatant({
+        watchCombatant({
           names: [
             data.me,
             strikingDummyNames[data.lang] ?? strikingDummyNames['en'],

--- a/ui/raidboss/data/02-arr/raid/t11.ts
+++ b/ui/raidboss/data/02-arr/raid/t11.ts
@@ -1,7 +1,7 @@
 import Conditions from '../../../../../resources/conditions';
 import NetRegexes from '../../../../../resources/netregexes';
 import { Responses } from '../../../../../resources/responses';
-import Util from '../../../../../resources/util';
+import { watchCombatant } from '../../../../../resources/util';
 import ZoneId from '../../../../../resources/zone_id';
 import { RaidbossData } from '../../../../../types/data';
 import { TriggerSet } from '../../../../../types/trigger';
@@ -111,7 +111,7 @@ const triggerSet: TriggerSet<Data> = {
       condition: (data) => !data.beganMonitoringHp,
       preRun: (data) => data.beganMonitoringHp = true,
       promise: (_data, matches) =>
-        Util.watchCombatant({
+        watchCombatant({
           ids: [parseInt(matches.sourceId, 16)],
         }, (ret) => {
           return ret.combatants.some((c) => {

--- a/ui/raidboss/data/02-arr/raid/t5.ts
+++ b/ui/raidboss/data/02-arr/raid/t5.ts
@@ -1,7 +1,7 @@
 import Conditions from '../../../../../resources/conditions';
 import NetRegexes from '../../../../../resources/netregexes';
 import { Responses } from '../../../../../resources/responses';
-import Util from '../../../../../resources/util';
+import { watchCombatant } from '../../../../../resources/util';
 import ZoneId from '../../../../../resources/zone_id';
 import { RaidbossData } from '../../../../../types/data';
 import { TriggerSet } from '../../../../../types/trigger';
@@ -35,7 +35,7 @@ const triggerSet: TriggerSet<Data> = {
       condition: (data) => !data.monitoringHP && data.hpThresholds[data.currentPhase] !== undefined,
       preRun: (data) => data.monitoringHP = true,
       promise: (data, matches) =>
-        Util.watchCombatant({
+        watchCombatant({
           ids: [parseInt(matches.sourceId, 16)],
         }, (ret) => {
           const twintaniaBelowGivenHP = ret.combatants.some((c) => {

--- a/ui/raidboss/data/02-arr/raid/t6.ts
+++ b/ui/raidboss/data/02-arr/raid/t6.ts
@@ -1,7 +1,7 @@
 import Conditions from '../../../../../resources/conditions';
 import NetRegexes from '../../../../../resources/netregexes';
 import { Responses } from '../../../../../resources/responses';
-import Util from '../../../../../resources/util';
+import { watchCombatant } from '../../../../../resources/util';
 import ZoneId from '../../../../../resources/zone_id';
 import { RaidbossData } from '../../../../../types/data';
 import { TriggerSet } from '../../../../../types/trigger';
@@ -30,7 +30,7 @@ const triggerSet: TriggerSet<Data> = {
       condition: (data) => !data.beganMonitoringHp,
       preRun: (data) => data.beganMonitoringHp = true,
       promise: (_data, matches) =>
-        Util.watchCombatant({
+        watchCombatant({
           ids: [parseInt(matches.sourceId, 16)],
         }, (ret) => {
           return ret.combatants.some((c) => {

--- a/ui/raidboss/data/02-arr/raid/t7.ts
+++ b/ui/raidboss/data/02-arr/raid/t7.ts
@@ -1,7 +1,7 @@
 import Conditions from '../../../../../resources/conditions';
 import NetRegexes from '../../../../../resources/netregexes';
 import { Responses } from '../../../../../resources/responses';
-import Util from '../../../../../resources/util';
+import { watchCombatant } from '../../../../../resources/util';
 import ZoneId from '../../../../../resources/zone_id';
 import { RaidbossData } from '../../../../../types/data';
 import { TriggerSet } from '../../../../../types/trigger';
@@ -36,7 +36,7 @@ const triggerSet: TriggerSet<Data> = {
       condition: (data) => !data.monitoringHP && data.hpThresholds[data.currentPhase] !== undefined,
       preRun: (data) => data.monitoringHP = true,
       promise: (data, matches) =>
-        Util.watchCombatant({
+        watchCombatant({
           ids: [parseInt(matches.sourceId, 16)],
         }, (ret) => {
           return ret.combatants.some((c) => {

--- a/ui/raidboss/data/02-arr/raid/t9.ts
+++ b/ui/raidboss/data/02-arr/raid/t9.ts
@@ -2,7 +2,7 @@ import Conditions from '../../../../../resources/conditions';
 import NetRegexes from '../../../../../resources/netregexes';
 import Outputs from '../../../../../resources/outputs';
 import { Responses } from '../../../../../resources/responses';
-import Util from '../../../../../resources/util';
+import { watchCombatant } from '../../../../../resources/util';
 import ZoneId from '../../../../../resources/zone_id';
 import { RaidbossData } from '../../../../../types/data';
 import { TriggerSet } from '../../../../../types/trigger';
@@ -170,7 +170,7 @@ const triggerSet: TriggerSet<Data> = {
       condition: (data) => !data.beganMonitoringHp,
       preRun: (data) => data.beganMonitoringHp = true,
       promise: (_data, matches) =>
-        Util.watchCombatant({
+        watchCombatant({
           ids: [parseInt(matches.sourceId, 16)],
         }, (ret) => {
           return ret.combatants.some((c) => {

--- a/ui/raidboss/data/02-arr/trial/levi-ex.ts
+++ b/ui/raidboss/data/02-arr/trial/levi-ex.ts
@@ -1,7 +1,7 @@
 import NetRegexes from '../../../../../resources/netregexes';
 import Outputs from '../../../../../resources/outputs';
 import { callOverlayHandler } from '../../../../../resources/overlay_plugin_api';
-import Util from '../../../../../resources/util';
+import { isCasterDpsJob, isHealerJob, isRangedDpsJob } from '../../../../../resources/util';
 import ZoneId from '../../../../../resources/zone_id';
 import { RaidbossData } from '../../../../../types/data';
 import { PluginCombatantState } from '../../../../../types/event';
@@ -131,7 +131,7 @@ const triggerSet: TriggerSet<Data> = {
       netRegexJa: NetRegexes.ability({ source: 'リヴァイアサン', id: '875', capture: false }),
       netRegexCn: NetRegexes.ability({ source: '利维亚桑', id: '875', capture: false }),
       netRegexKo: NetRegexes.ability({ source: '리바이어선', id: '875', capture: false }),
-      condition: (data) => Util.isCasterDpsJob(data.job) || Util.isHealerJob(data.job),
+      condition: (data) => isCasterDpsJob(data.job) || isHealerJob(data.job),
       suppressSeconds: 9999,
       infoText: (_data, _matches, output) => output.text!(),
       outputStrings: {
@@ -154,7 +154,7 @@ const triggerSet: TriggerSet<Data> = {
       netRegexJa: NetRegexes.ability({ source: 'リヴァイアサン・テール', id: '874', capture: false }),
       netRegexCn: NetRegexes.ability({ source: '利维亚桑的尾巴', id: '874', capture: false }),
       netRegexKo: NetRegexes.ability({ source: '리바이어선 꼬리', id: '874', capture: false }),
-      condition: (data) => Util.isRangedDpsJob(data.job),
+      condition: (data) => isRangedDpsJob(data.job),
       suppressSeconds: 9999,
       infoText: (_data, _matches, output) => output.text!(),
       outputStrings: {

--- a/ui/raidboss/data/04-sb/ultimate/unending_coil_ultimate.ts
+++ b/ui/raidboss/data/04-sb/ultimate/unending_coil_ultimate.ts
@@ -2,7 +2,7 @@ import Conditions from '../../../../../resources/conditions';
 import NetRegexes from '../../../../../resources/netregexes';
 import Outputs from '../../../../../resources/outputs';
 import { Responses } from '../../../../../resources/responses';
-import Util from '../../../../../resources/util';
+import { watchCombatant } from '../../../../../resources/util';
 import ZoneId from '../../../../../resources/zone_id';
 import { RaidbossData } from '../../../../../types/data';
 import { TriggerSet } from '../../../../../types/trigger';
@@ -456,7 +456,7 @@ const triggerSet: TriggerSet<Data> = {
       condition: (data) => !data.monitoringHP && data.hpThresholds[data.currentPhase] !== undefined,
       preRun: (data) => data.monitoringHP = true,
       promise: (data, matches) =>
-        Util.watchCombatant({
+        watchCombatant({
           ids: [parseInt(matches.sourceId, 16)],
         }, (ret) => {
           return ret.combatants.some((c) => {

--- a/ui/raidboss/data/05-shb/raid/e10s.ts
+++ b/ui/raidboss/data/05-shb/raid/e10s.ts
@@ -2,7 +2,7 @@ import Conditions from '../../../../../resources/conditions';
 import NetRegexes from '../../../../../resources/netregexes';
 import Outputs from '../../../../../resources/outputs';
 import { Responses } from '../../../../../resources/responses';
-import Util from '../../../../../resources/util';
+import { jobToJobEnum } from '../../../../../resources/util';
 import ZoneId from '../../../../../resources/zone_id';
 import { RaidbossData } from '../../../../../types/data';
 import { TriggerSet } from '../../../../../types/trigger';
@@ -426,7 +426,7 @@ const triggerSet: TriggerSet<Data> = {
       run: (data, matches) => {
         data.myClone ??= [];
         const clonesJob = parseInt(matches.job, 16);
-        if (clonesJob === Util.jobToJobEnum(data.job))
+        if (clonesJob === jobToJobEnum(data.job))
           data.myClone.push(matches.id.toUpperCase());
       },
     },

--- a/ui/raidboss/data/05-shb/trial/levi-un.ts
+++ b/ui/raidboss/data/05-shb/trial/levi-un.ts
@@ -1,7 +1,7 @@
 import NetRegexes from '../../../../../resources/netregexes';
 import Outputs from '../../../../../resources/outputs';
 import { callOverlayHandler } from '../../../../../resources/overlay_plugin_api';
-import Util from '../../../../../resources/util';
+import { isCasterDpsJob, isHealerJob, isRangedDpsJob } from '../../../../../resources/util';
 import ZoneId from '../../../../../resources/zone_id';
 import { RaidbossData } from '../../../../../types/data';
 import { PluginCombatantState } from '../../../../../types/event';
@@ -126,7 +126,7 @@ const triggerSet: TriggerSet<Data> = {
       netRegexJa: NetRegexes.ability({ source: 'リヴァイアサン', id: '5CE5', capture: false }),
       netRegexCn: NetRegexes.ability({ source: '利维亚桑', id: '5CE5', capture: false }),
       netRegexKo: NetRegexes.ability({ source: '리바이어선', id: '5CE5', capture: false }),
-      condition: (data) => Util.isCasterDpsJob(data.job) || Util.isHealerJob(data.job),
+      condition: (data) => isCasterDpsJob(data.job) || isHealerJob(data.job),
       suppressSeconds: 9999,
       infoText: (_data, _matches, output) => output.text!(),
       outputStrings: {
@@ -149,7 +149,7 @@ const triggerSet: TriggerSet<Data> = {
       netRegexJa: NetRegexes.ability({ source: 'リヴァイアサン・テール', id: '5CE4', capture: false }),
       netRegexCn: NetRegexes.ability({ source: '利维亚桑的尾巴', id: '5CE4', capture: false }),
       netRegexKo: NetRegexes.ability({ source: '리바이어선 꼬리', id: '5CE4', capture: false }),
-      condition: (data) => Util.isRangedDpsJob(data.job),
+      condition: (data) => isRangedDpsJob(data.job),
       suppressSeconds: 9999,
       infoText: (_data, _matches, output) => output.text!(),
       outputStrings: {

--- a/ui/raidboss/emulator/data/AnalyzedEncounter.ts
+++ b/ui/raidboss/emulator/data/AnalyzedEncounter.ts
@@ -1,5 +1,5 @@
 import { UnreachableCode } from '../../../../resources/not_reached';
-import Util from '../../../../resources/util';
+import { jobToJobEnum } from '../../../../resources/util';
 import { LooseTrigger } from '../../../../types/trigger';
 import raidbossFileData from '../../data/raidboss_manifest.txt';
 import { PopupTextGenerator, TriggerHelper } from '../../popup-text';
@@ -55,7 +55,7 @@ export default class AnalyzedEncounter extends EventBus {
             id: id,
             worldId: 0,
             name: partyMember.name,
-            job: Util.jobToJobEnum(partyMember.job ?? 'NONE'),
+            job: jobToJobEnum(partyMember.job ?? 'NONE'),
             inParty: true,
           };
         }),

--- a/ui/raidboss/emulator/data/network_log_converter/LineEvent0x03.ts
+++ b/ui/raidboss/emulator/data/network_log_converter/LineEvent0x03.ts
@@ -1,5 +1,5 @@
 import logDefinitions from '../../../../../resources/netlog_defs';
-import Util from '../../../../../resources/util';
+import { jobEnumToJob } from '../../../../../resources/util';
 import { Job } from '../../../../../types/job';
 import EmulatorCommon from '../../EmulatorCommon';
 
@@ -45,7 +45,7 @@ export class LineEvent0x03 extends LineEvent implements LineEventSource, LineEve
     this.name = parts[fields.name] ?? '';
     this.jobIdHex = parts[fields.job]?.toUpperCase() ?? '';
     this.jobId = parseInt(this.jobIdHex, 16);
-    this.job = Util.jobEnumToJob(this.jobId);
+    this.job = jobEnumToJob(this.jobId);
     this.levelString = parts[fields.level] ?? '';
     this.level = parseInt(this.levelString, 16);
     this.ownerId = parts[fields.ownerId]?.toUpperCase() ?? '';

--- a/ui/raidboss/emulator/data/network_log_converter/LineEvent0x26.ts
+++ b/ui/raidboss/emulator/data/network_log_converter/LineEvent0x26.ts
@@ -1,5 +1,5 @@
 import logDefinitions from '../../../../../resources/netlog_defs';
-import Util from '../../../../../resources/util';
+import { jobEnumToJob } from '../../../../../resources/util';
 import { Job } from '../../../../../types/job';
 import EmulatorCommon from '../../EmulatorCommon';
 
@@ -49,7 +49,7 @@ export class LineEvent0x26 extends LineEvent implements LineEventSource, LineEve
 
     this.jobIdHex = padded.substr(6, 2).toUpperCase();
     this.jobId = parseInt(this.jobIdHex, 16);
-    this.job = Util.jobEnumToJob(this.jobId);
+    this.job = jobEnumToJob(this.jobId);
 
     this.level = parseInt(padded.substr(4, 2), 16);
   }

--- a/ui/raidboss/emulator/ui/EmulatedPartyInfo.ts
+++ b/ui/raidboss/emulator/ui/EmulatedPartyInfo.ts
@@ -1,5 +1,5 @@
 import { UnreachableCode } from '../../../../resources/not_reached';
-import Util from '../../../../resources/util';
+import { jobToRole } from '../../../../resources/util';
 import AnalyzedEncounter, { PerspectiveTrigger } from '../data/AnalyzedEncounter';
 import RaidEmulator from '../data/RaidEmulator';
 import EmulatorCommon, { cloneSafe, getTemplateChild, querySelectorSafe } from '../EmulatorCommon';
@@ -212,7 +212,7 @@ export default class EmulatedPartyInfo extends EventBus {
       bar.classList.remove('dps');
       if (combatant.job) {
         bar.classList.add(
-          Util.jobToRole(combatant.job),
+          jobToRole(combatant.job),
         );
       }
 

--- a/ui/raidboss/popup-text.ts
+++ b/ui/raidboss/popup-text.ts
@@ -4,7 +4,16 @@ import { callOverlayHandler, addOverlayListener } from '../../resources/overlay_
 import PartyTracker from '../../resources/party';
 import { addPlayerChangedOverrideListener, PlayerChangedDetail } from '../../resources/player_override';
 import Regexes from '../../resources/regexes';
-import Util from '../../resources/util';
+import {
+  canAddle,
+  canCleanse,
+  canFeint,
+  canSilence,
+  canSleep,
+  canStun,
+  clearWatchCombatants,
+  jobToRole,
+} from '../../resources/util';
 import ZoneId from '../../resources/zone_id';
 import { RaidbossData } from '../../types/data';
 import { EventResponses, LogEvent } from '../../types/event';
@@ -768,7 +777,7 @@ export class PopupText {
   OnJobChange(e: PlayerChangedDetail): void {
     this.me = e.detail.name;
     this.job = e.detail.job;
-    this.role = Util.jobToRole(this.job);
+    this.role = jobToRole(this.job);
     this.ReloadTimelines();
   }
 
@@ -816,7 +825,7 @@ export class PopupText {
   }
 
   Reset(): void {
-    Util.clearWatchCombatants();
+    clearWatchCombatants();
     this.data = this.getDataObject();
     this.StopTimers();
     this.triggerSuppress = {};
@@ -1392,12 +1401,12 @@ export class PopupText {
       ShortName: this.ShortNamify.bind(this),
       StopCombat: () => this.SetInCombat(false),
       ParseLocaleFloat: parseFloat,
-      CanStun: () => Util.canStun(this.job),
-      CanSilence: () => Util.canSilence(this.job),
-      CanSleep: () => Util.canSleep(this.job),
-      CanCleanse: () => Util.canCleanse(this.job),
-      CanFeint: () => Util.canFeint(this.job),
-      CanAddle: () => Util.canAddle(this.job),
+      CanStun: () => canStun(this.job),
+      CanSilence: () => canSilence(this.job),
+      CanSleep: () => canSleep(this.job),
+      CanCleanse: () => canCleanse(this.job),
+      CanFeint: () => canFeint(this.job),
+      CanAddle: () => canAddle(this.job),
     };
   }
 }

--- a/ui/raidboss/raidboss_config.js
+++ b/ui/raidboss/raidboss_config.js
@@ -2,7 +2,14 @@ import PartyTracker from '../../resources/party';
 import Regexes from '../../resources/regexes';
 import { triggerOutputFunctions } from '../../resources/responses';
 import UserConfig from '../../resources/user_config';
-import Util from '../../resources/util';
+import {
+  canAddle,
+  canCleanse,
+  canFeint,
+  canSilence,
+  canSleep,
+  canStun,
+} from '../../resources/util';
 import raidbossFileData from './data/raidboss_manifest.txt';
 import raidbossOptions from './raidboss_options';
 
@@ -665,12 +672,12 @@ class RaidbossConfigurator {
       ShortName: (x) => x,
       StopCombat: () => {},
       ParseLocaleFloat: parseFloat,
-      CanStun: () => Util.canStun(this.job),
-      CanSilence: () => Util.canSilence(this.job),
-      CanSleep: () => Util.canSleep(this.job),
-      CanCleanse: () => Util.canCleanse(this.job),
-      CanFeint: () => Util.canFeint(this.job),
-      CanAddle: () => Util.canAddle(this.job),
+      CanStun: () => canStun(this.job),
+      CanSilence: () => canSilence(this.job),
+      CanSleep: () => canSleep(this.job),
+      CanCleanse: () => canCleanse(this.job),
+      CanFeint: () => canFeint(this.job),
+      CanAddle: () => canAddle(this.job),
     };
 
     const kFakeData = [


### PR DESCRIPTION
as named export

There are two export approaches in an es module:
1. Named export
2. Default export

Currently `resources/util.ts` use the 2. default export,
although the statement `import Util from 'path/to/util.ts'` is clean
and easy to recognize,
to export an object makes webpack cannot `tree-shake` it correctly.

Therefore, I think we should change it to named export style,
perhaps also the `resources/condition.ts` file

BREAKING CHANGES:
`import Util from 'path/to/resources/util'` is not available anymore,
should change to `import * as Util from 'path/to/resources/util'`,
or `import { xxx } from 'path/to/resources/util'`