### PR TITLE
build: fix triggers branch target back to ES2019

### DIFF
--- a/tsconfig.triggers.json
+++ b/tsconfig.triggers.json
@@ -4,6 +4,9 @@
     "compiler": "ttypescript"
   },
   "compilerOptions": {
+    // nullish coalescing operator not supported in OverlayPlugin's Chrome M75
+    // TODO: change to ES2020 once OverlayPlugin rolls CEF past M80.
+    "target": "ES2019",
     "outDir": "./dist/triggers"
   },
   "include": [


### PR DESCRIPTION
This was broken in #3315 when babel was added.  Even though babel is
used with webpack, babel is not used for the triggers branch which is
referenced directly by users who are writing their own triggers.