### PR TITLE
eureka: Fix flagRegex ignoring certain lines

### DIFF
--- a/ui/eureka/eureka.ts
+++ b/ui/eureka/eureka.ts
@@ -764,8 +764,8 @@ class EurekaTracker {
         this.AddFlag(
           parseFloat(match[2]),
           parseFloat(match[3]),
-          match[1] as string,
-          match[4] as string,
+          match[1] ?? '',
+          match[4] ?? '',
         );
       }
 

--- a/ui/eureka/eureka.ts
+++ b/ui/eureka/eureka.ts
@@ -760,7 +760,7 @@ class EurekaTracker {
     for (const log of e.detail.logs) {
       const flagRegex = this.TransObjectByParserLang(this.options.Regex, 'gFlagRegex');
       let match = flagRegex.exec(log);
-      if (match && match[1] && match[2] && match[3] && match[4])
+      if (match && match[2] && match[3])
         this.AddFlag(parseFloat(match[2]), parseFloat(match[3]), match[1], match[4]);
 
       if (this.fairyRegex) {

--- a/ui/eureka/eureka.ts
+++ b/ui/eureka/eureka.ts
@@ -761,7 +761,7 @@ class EurekaTracker {
       const flagRegex = this.TransObjectByParserLang(this.options.Regex, 'gFlagRegex');
       let match = flagRegex.exec(log);
       if (match && match[2] && match[3])
-        this.AddFlag(parseFloat(match[2]), parseFloat(match[3]), match[1], match[4]);
+        this.AddFlag(parseFloat(match[2]), parseFloat(match[3]), match[1] as string, match[4] as string);
 
       if (this.fairyRegex) {
         if (log.includes(' 03:') || log.includes('00:0839:')) {

--- a/ui/eureka/eureka.ts
+++ b/ui/eureka/eureka.ts
@@ -761,7 +761,8 @@ class EurekaTracker {
       const flagRegex = this.TransObjectByParserLang(this.options.Regex, 'gFlagRegex');
       let match = flagRegex.exec(log);
       if (match && match[2] && match[3])
-        this.AddFlag(parseFloat(match[2]), parseFloat(match[3]), match[1] as string, match[4] as string);
+        this.AddFlag(parseFloat(match[2]), parseFloat(match[3]),
+          match[1] as string, match[4] as string);
 
       if (this.fairyRegex) {
         if (log.includes(' 03:') || log.includes('00:0839:')) {

--- a/ui/eureka/eureka.ts
+++ b/ui/eureka/eureka.ts
@@ -760,9 +760,14 @@ class EurekaTracker {
     for (const log of e.detail.logs) {
       const flagRegex = this.TransObjectByParserLang(this.options.Regex, 'gFlagRegex');
       let match = flagRegex.exec(log);
-      if (match && match[2] && match[3])
-        this.AddFlag(parseFloat(match[2]), parseFloat(match[3]),
-          match[1] as string, match[4] as string);
+      if (match && match[2] && match[3]) {
+        this.AddFlag(
+          parseFloat(match[2]),
+          parseFloat(match[3]),
+          match[1] as string,
+          match[4] as string,
+        );
+      }
 
       if (this.fairyRegex) {
         if (log.includes(' 03:') || log.includes('00:0839:')) {


### PR DESCRIPTION
The current implementation only allows lines that have text both before and after the map link to be shown on the map, match[1] and match[4] should be allowed to be empty.

Examples that currently don't show flags: 
```
00:000b:Player NameServer:Eureka Pagos ( 10.3  , 25.4 ) rez plz
00:000b:Player NameServer:pop Eureka Pagos ( 14.5  , 18.5 )
```