### PR TITLE
plugin: Change ACT plugin ToProperCase to C# ToTitleCase

### DIFF
--- a/plugin/CactbotEventSource/FFXIVProcessCn.cs
+++ b/plugin/CactbotEventSource/FFXIVProcessCn.cs
@@ -182,7 +182,7 @@ namespace Cactbot {
 
         // dump '\0' string terminators
         var memoryName = System.Text.Encoding.UTF8.GetString(mem.Name, EntityMemory.nameBytes).Split(new[] { '\0' }, 2)[0];
-        var capitalizedName = FFXIV_ACT_Plugin.Common.StringHelper.ToProperCase(memoryName);
+        var capitalizedName = System.Globalization.CultureInfo.InvariantCulture.TextInfo.ToTitleCase(memoryName);
 
         EntityData entity = new EntityData() {
           name = capitalizedName,

--- a/plugin/CactbotEventSource/FFXIVProcessIntl.cs
+++ b/plugin/CactbotEventSource/FFXIVProcessIntl.cs
@@ -179,7 +179,7 @@ namespace Cactbot {
 
         // dump '\0' string terminators
         var memoryName = System.Text.Encoding.UTF8.GetString(mem.Name, EntityMemory.nameBytes).Split(new[] { '\0' }, 2)[0];
-        var capitalizedName = FFXIV_ACT_Plugin.Common.StringHelper.ToProperCase(memoryName);
+        var capitalizedName = System.Globalization.CultureInfo.InvariantCulture.TextInfo.ToTitleCase(memoryName);
 
         EntityData entity = new EntityData() {
           name = capitalizedName,

--- a/plugin/CactbotEventSource/FFXIVProcessKo.cs
+++ b/plugin/CactbotEventSource/FFXIVProcessKo.cs
@@ -183,7 +183,7 @@ namespace Cactbot {
 
         // dump '\0' string terminators
         var memoryName = System.Text.Encoding.UTF8.GetString(mem.Name, EntityMemory.nameBytes).Split(new[] { '\0' }, 2)[0];
-        var capitalizedName = FFXIV_ACT_Plugin.Common.StringHelper.ToProperCase(memoryName);
+        var capitalizedName = System.Globalization.CultureInfo.InvariantCulture.TextInfo.ToTitleCase(memoryName);
 
         EntityData entity = new EntityData() {
           name = capitalizedName,


### PR DESCRIPTION
This function is going away in a future version of the FFXIV
ACT plugin, and so remove it from cactbot now.  The plugin
version also handles capitalization of roman numerals.
Since we are only using this for player names, ignore this.

See:
https://discord.com/channels/551474815727304704/816017800723955792/894766881888669767

It's not clear to me why we need to capitalize these at all.
It was added in c73a19a37e638ec542bc34c1e344c374c044e333,
but without any comments.