### PR TITLE
oopsy: add `(share)` suffix on shareWarn/shareFail

### DIFF
--- a/ui/oopsyraidsy/damage_tracker.ts
+++ b/ui/oopsyraidsy/damage_tracker.ts
@@ -432,7 +432,18 @@ export class DamageTracker {
         type: 'Ability',
         netRegex: NetRegexes.abilityFull({ type: '22', id: id, ...playerDamageFields }),
         mistake: (_data, matches) => {
-          return { type: type, blame: matches.target, text: matches.ability };
+          return {
+            type: type,
+            blame: matches.target,
+            text: {
+              en: `${matches.ability} (share)`,
+              de: `${matches.ability}`, // FIXME
+              fr: `${matches.ability}`, // FIXME
+              ja: `${matches.ability}`, // FIXME
+              cn: `${matches.ability}`, // FIXME
+              ko: `${matches.ability}`, // FIXME
+            },
+          };
         },
       };
       this.ProcessTrigger(trigger);


### PR DESCRIPTION
This matches the (alone) suffix for soloWarn/soloFail
and should help differentiate whether damage should
not be taken at all, or just not with another person.