### PR TITLE
ci: Only Run Workflows On Push to Main

### DIFF
--- a/.github/workflows/build-artifact.yml
+++ b/.github/workflows/build-artifact.yml
@@ -2,6 +2,8 @@ name: Build artifact
 
 on:
   push:
+    branches:
+      - main
     paths:
       - '.github/workflows/build-artifact.yml'
       - 'plugin/**'

--- a/.github/workflows/css-lint.yml
+++ b/.github/workflows/css-lint.yml
@@ -2,6 +2,8 @@ name: CSS Lint
 
 on:
   push:
+    branches:
+      - main
     paths:
       - '*.json'
       - '**/*.css'

--- a/.github/workflows/javascript-lint.yml
+++ b/.github/workflows/javascript-lint.yml
@@ -2,6 +2,8 @@ name: JavaScript Lint
 
 on:
   push:
+    branches:
+      - main
     paths:
       - '**/*.js'
       - '**/*.ts'

--- a/.github/workflows/markdown-lint.yml
+++ b/.github/workflows/markdown-lint.yml
@@ -2,6 +2,8 @@ name: Markdown Lint
 
 on:
   push:
+    branches:
+      - main
     paths:
       - '*.json'
       - '**/*.md'

--- a/.github/workflows/post-process.yml
+++ b/.github/workflows/post-process.yml
@@ -2,6 +2,8 @@ name: Post-Process Test
 
 on:
   push:
+    branches:
+      - main
     paths:
       - 'resources/**'
       - 'ui/raidboss/**'

--- a/.github/workflows/python-lint.yml
+++ b/.github/workflows/python-lint.yml
@@ -2,6 +2,8 @@ name: Python Lint
 
 on:
   push:
+    branches:
+      - main
     paths:
       - '**/*.py'
       - '.github/workflows/python-lint.yml'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,6 +2,8 @@ name: Test
 
 on:
   push:
+    branches:
+      - main
     paths:
       - '**/*.js'
       - '**/*.ts'


### PR DESCRIPTION
Stop running GitHub workflows twice for pushes to branches other than
main that also result in a pull request.