### PR TITLE
ci: temporarily stop using cache@v2 for release.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,8 @@ jobs:
           key: modules-${{ hashFiles('package-lock.json') }}
 
       - name: Fetch NPM Dependencies
-        if: steps.npm-cache.outputs.cache-hit != 'true'
+        # TODO: fix cache@v2 to cache node_modules
+        # if: steps.npm-cache.outputs.cache-hit != 'true'
         run: |
           npm ci --ignore-scripts
 


### PR DESCRIPTION
This is using ~/.npm to cache when it should be using node_modules,
causing the release to fail if it ever gets a cache hit.

We should audit all of our caching lines to make sure they are
consistent and handle OS and the correct path.