### PR TITLE
raidboss: autoplay_helper non-blink engines fix

### DIFF
--- a/ui/raidboss/autoplay_helper.ts
+++ b/ui/raidboss/autoplay_helper.ts
@@ -1,21 +1,30 @@
 export default class AutoplayHelper {
-  static Check(): boolean {
+  static CheckIfAlreadyRunning(): boolean {
+    // This check will only ever succeed on running Chromium passing
+    //  --autoplay-policy=no-user-gesture-required
+    // as command line argument or configuring CEF the correct way.
+    // Once https://bugs.chromium.org/p/chromium/issues/detail?id=1106380
+    // is fixed this function will return false on every (up-to-date) browser
     const context = new AudioContext();
-    return context.state === 'suspended';
+    return context.state === 'running';
   }
 
   static Prompt(): void {
+    const context = new AudioContext();
     const button = document.createElement('button');
     button.innerText = 'Click to enable audio';
     button.classList.add('autoplay-helper-button');
     button.onclick = function() {
+      void context.resume();
+    };
+    context.onstatechange = function() {
       button.remove();
     };
     document.body.appendChild(button);
   }
 
   static CheckAndPrompt(): void {
-    if (AutoplayHelper.Check())
+    if (!AutoplayHelper.CheckIfAlreadyRunning())
       AutoplayHelper.Prompt();
   }
 }


### PR DESCRIPTION
When running raidboss in an OverlayPlugin-like view the `Click to enable audio` button does not disappear on any other engine than Blink