### PR TITLE
fisher: switch to using net log lines

### DIFF
--- a/ui/fisher/fisher.js
+++ b/ui/fisher/fisher.js
@@ -1,3 +1,5 @@
+import logDefinitions from '../../resources/netlog_defs';
+import NetRegexes from '../../resources/netregexes';
 import { addOverlayListener } from '../../resources/overlay_plugin_api';
 
 import FisherUI from './fisher-ui';
@@ -44,6 +46,15 @@ class Fisher {
     this.castEnd = null;
     this.castGet = null;
 
+    this.gainEffectRegex = {
+      chum: NetRegexes.gainsEffect({ effectId: '2FB', capture: false }),
+      snag: NetRegexes.gainsEffect({ effectId: '2F9', capture: false }),
+    };
+    this.loseEffectRegex = {
+      chum: NetRegexes.losesEffect({ effectId: '2FB', capture: false }),
+      snag: NetRegexes.losesEffect({ effectId: '2F9', capture: false }),
+    };
+
     this.regex = {
       // Localized strings from: https://xivapi.com/LogMessage?pretty=1&columns=ID,Text_de,Text_en,Text_fr,Text_ja&ids=1110,1111,1112,1113,1115,1116,1117,1118,1119,1120,1121,1127,1129,3511,3512,3515,3516,3525
       // 1110: cast
@@ -65,109 +76,194 @@ class Fisher {
       // 3516: nocatch (anti-bot)
       // 3525: nocatch (inventory full)
 
-      'de': {
+      en: {
+        undiscovered: /undiscovered fishing hole/,
+        cast: NetRegexes.gameLog({
+          code: '08c3',
+          line:
+            '(?:[\\w\']\\.?)(?:[\\w\'\\s]+\\.?)? cast(?:s?) (?:your|his|her) line (?:on|in|at) (?:the )?(?<place>[\\w\\s\'&()]+)\\..*?',
+        }),
+        bite: NetRegexes.gameLog({ code: '08c3', line: 'Something bites!.*?' }),
+        catch: NetRegexes.gameLog({
+          code: '0843',
+          line:
+            '(?:[\\w\']\\.?)(?:[\\w\'\\s]+\\.?)? land(?:s?) (?:a|an|[\\d]+ )?.+?(?<fish>[\\w\\s\\-\'\\#\\d]{3,})(?: | [^\\w] |[^\\w\\s].+ )measuring \\d.*?',
+        }),
+        nocatch: NetRegexes.gameLog({
+          code: '08c3',
+          line:
+            '(?:Nothing bites\.|You reel in your line|You lose your bait|The fish gets away|You lose your |Your line breaks|The fish sense something amiss|You cannot carry any more).*?',
+        }),
+        mooch: NetRegexes.gameLog({
+          code: '08c3',
+          line:
+            '(?:[\\w\']\\.?)(?:[\\w\'\\s]+\\.?)? recast(?:s?) (?:your|his|her)? line with the fish still hooked\\..*?',
+        }),
+        quit: NetRegexes.gameLog({
+          code: '08c3',
+          line:
+            '(?:(?:[\\w\']\\.?)(?:[\\w\'\\s]+\\.?)? put(?:s?) away (?:your|his|her) rod\\.|Fishing canceled).*?',
+        }),
+        discovered: NetRegexes.gameLog({
+          code: '08c3',
+          line: '(?:Data on (?<place>[\\w\\s\'&()]+)) is added to your fishing log\\..*?',
+        }),
+      },
+      de: {
         // Note, the preposition in German is stored in the cast string, so is ignored here.
         // We could attempt to trim prepositions in the fishing data and then include all
         // potential prepositions here, but I don't know German that well.
-        'undiscovered': /unerforschten Angelplatz/,
-        'cast': /00:08c3:Du hast mit dem Fischen (.+) begonnen\./,
-        'bite': /00:08c3:Etwas hat angebissen!/,
-        'catch':
-          /00:0843:Du (?:hast eine?n? |ziehst \d+ )?.+?\s?([\w\s\-\'\.\d\u00c4-\u00fc]{3,})(?: | [^\w] |[^\w\s\-\'\u00c4-\u00fc].+ )(?:\(\d|mit ein)/,
-        'nocatch':
-          /00:08c3:(?:Der Fisch hat den Köder vom Haken gefressen|.+ ist davongeschwommen|Der Fisch konnte sich vom Haken reißen|Die Leine ist gerissen|Nichts beißt an|Du hast nichts gefangen|Du hast das Fischen abgebrochen|Deine Beute hat sich aus dem Staub gemacht und du hast|Die Fische sind misstrauisch und kommen keinen Ilm näher|Du hast .+ geangelt, musst deinen Fang aber wieder freilassen, weil du nicht mehr davon besitzen kannst)/,
-        'mooch': /00:08c3:Du hast die Leine mit/,
-        'chumgain': /00:08ae:You gain the effect of Streuköder/,
-        'chumfade': /00:08b0:You lose the effect of Streuköder/,
-        'snaggain': /00:08ae:⇒ You gain the effect of Reißen/,
-        'snagfade': /00:08b0:You lose the effect of Reßien/,
-        'quit': /00:08c3:(?:Du hast das Fischen beendet\.|Das Fischen wurde abgebrochen)/,
-        'discovered':
-          /00:08c3:Die neue Angelstelle ([^\w\s\-\'\u00c4-\u00fc].+ ) wurde in deinem Fischer-Notizbuch vermerkt\./,
+        undiscovered: /unerforschten Angelplatz/,
+        cast: NetRegexes.gameLog({
+          code: '08c3',
+          line: 'Du hast mit dem Fischen (?<place>.+) begonnen\\..*?',
+        }),
+        bite: NetRegexes.gameLog({ code: '08c3', line: 'Etwas hat angebissen!.*?' }),
+        catch: NetRegexes.gameLog({
+          code: '0843',
+          line:
+            'Du (?:hast eine?n? |ziehst \\d+ )?.+?\\s?(?<fish>[\\w\\s\\-\'\\.\\d\u00c4-\u00fc]{3,})(?: | [^\\w] |[^\\w\\s\\-\'\u00c4-\u00fc].+ )(?:\\(\\d|mit ein).*?',
+        }),
+        nocatch: NetRegexes.gameLog({
+          code: '08c3',
+          line:
+            '(?:Der Fisch hat den Köder vom Haken gefressen|.+ ist davongeschwommen|Der Fisch konnte sich vom Haken reißen|Die Leine ist gerissen|Nichts beißt an|Du hast nichts gefangen|Du hast das Fischen abgebrochen|Deine Beute hat sich aus dem Staub gemacht und du hast|Die Fische sind misstrauisch und kommen keinen Ilm näher|Du hast .+ geangelt, musst deinen Fang aber wieder freilassen, weil du nicht mehr davon besitzen kannst).*?',
+        }),
+        mooch: NetRegexes.gameLog({ code: '08c3', line: 'Du hast die Leine mit.*?' }),
+        quit: NetRegexes.gameLog({
+          code: '08c3',
+          line: '(?:Du hast das Fischen beendet\\.|Das Fischen wurde abgebrochen).*?',
+        }),
+        discovered: NetRegexes.gameLog({
+          code: '08c3',
+          line:
+            'Die neue Angelstelle (?<place>[^\\w\\s\\-\'\u00c4-\u00fc].+ ) wurde in deinem Fischer-Notizbuch vermerkt\\..*?',
+        }),
       },
-      'en': {
-        'undiscovered': /undiscovered fishing hole/,
-        'cast':
-          /00:08c3:(?:[\w']\.?)(?:[\w'\s]+\.?)? cast(?:s?) (?:your|his|her) line (?:on|in|at) (?:the )?([\w\s'&()]+)\./,
-        'bite': /00:08c3:Something bites!/,
-        'catch':
-          /00:0843:(?:[\w']\.?)(?:[\w'\s]+\.?)? land(?:s?) (?:a|an|[\d]+ )?.+?([\w\s\-\'\#\d]{3,})(?: | [^\w] |[^\w\s].+ )measuring \d/,
-        'nocatch':
-          /00:08c3:(Nothing bites\.|You reel in your line|You lose your bait|The fish gets away|You lose your |Your line breaks|The fish sense something amiss|You cannot carry any more)/,
-        'mooch':
-          /00:08c3:(?:[\w']\.?)(?:[\w'\s]+\.?)? recast(?:s?) (?:your|his|her)? line with the fish still hooked./,
-        'chumgain': /00:08ae:You gain the effect of Chum/,
-        'chumfade': /00:08b0:You lose the effect of Chum/,
-        'snaggain': /00:08ae:⇒ You gain the effect of Snagging/,
-        'snagfade': /00:08b0:You lose the effect of Snagging/,
-        'quit':
-          /00:08c3:(?:(?:[\w']\.?)(?:[\w'\s]+\.?)? put(?:s?) away (?:your|his|her) rod\.|Fishing canceled)/,
-        'discovered': /00:08c3:(?:Data on ([\w\s'&()]+)) is added to your fishing log\./,
+      fr: {
+        undiscovered: /Zone de pêche inconnue/,
+        cast: NetRegexes.gameLog({
+          code: '08c3',
+          line:
+            'Vous commencez à pêcher. Point de pêche: (?<place>[\\w\\s\\-\'\\(\\)\u00b0\u00c0-\u017f]+).*?',
+        }),
+        bite: NetRegexes.gameLog({ code: '08c3', line: 'Vous avez une touche!.*?' }),
+        catch: NetRegexes.gameLog({
+          code: '0843',
+          line:
+            'Vous avez pêché (?:un |une )?.+?\\s?(?<fish>[\\w\\s\\-\'\\(\\)\u00b0\u00c0-\u017f]{3,})\ue03c?.+de \\d.*?',
+        }),
+        nocatch: NetRegexes.gameLog({
+          code: '08c3',
+          line:
+            '(?:L\'appât a disparu|Vous avez perdu votre|L\'appât a disparu|Le poisson a réussi à se défaire de l\'hameçon|Le fil s\'est cassé|Vous n\'avez pas eu de touche|Vous n\'avez pas réussi à ferrer le poisson|Vous arrêtez de pêcher|Le poisson s\'est enfui et a emporté avec lui votre|Les poissons sont devenus méfiants|Vous avez pêché .+, mais ne pouvez en posséder davantage et l\'avez donc relâché).*?',
+        }),
+        mooch: NetRegexes.gameLog({ code: '08c3', line: 'Vous essayez de pêcher au vif avec.*?' }),
+        quit: NetRegexes.gameLog(
+          { code: '08c3', line: '(?:Vous arrêtez de pêcher\\.|Pêche interrompue).*?' },
+        ),
+        discovered: NetRegexes.gameLog({
+          code: '08c3',
+          line:
+            'Vous notez le banc de poissons “(?<place>[\\w\\s\\-\'\\(\\)\u00b0\u00c0-\u017f]+)” dans votre carnet\\..*?',
+        }),
       },
-      'fr': {
-        'undiscovered': /Zone de pêche inconnue/,
-        'cast':
-          /00:08c3:Vous commencez à pêcher. Point de pêche: ([\w\s\-\'\(\)\u00b0\u00c0-\u017f]+)/,
-        'bite': /00:08c3:Vous avez une touche!/,
-        'catch':
-          /00:0843:Vous avez pêché (?:un |une )?.+?\s?([\w\s\-\'\(\)\u00b0\u00c0-\u017f]{3,})\ue03c?.+de \d/,
-        'nocatch':
-          /00:08c3:(?:L'appât a disparu|Vous avez perdu votre|L'appât a disparu|Le poisson a réussi à se défaire de l'hameçon|Le fil s'est cassé|Vous n'avez pas eu de touche|Vous n'avez pas réussi à ferrer le poisson|Vous arrêtez de pêcher|Le poisson s'est enfui et a emporté avec lui votre|Les poissons sont devenus méfiants|Vous avez pêché .+, mais ne pouvez en posséder davantage et l'avez donc relâché)/,
-        'mooch': /00:08c3:Vous essayez de pêcher au vif avec/,
-        'quit': /00:08c3:(?:Vous arrêtez de pêcher\.|Pêche interrompue)/,
-        'discovered':
-          /00:08c3:Vous notez le banc de poissons “([\w\s\-\'\(\)\u00b0\u00c0-\u017f]+)” dans votre carnet\./,
+      ja: {
+        undiscovered: /未知の釣り場/,
+        cast: NetRegexes.gameLog({
+          code: '08c3',
+          line:
+            '(?:[\\w\\s-\']+)\u306f(?<place>[\u3000-\u30ff\u3400-\u4dbf\u4e00-\u9faf\d\uff1a]+)で釣りを開始した。.*?',
+        }),
+        bite: NetRegexes.gameLog({ code: '08c3', line: '魚をフッキングした！.*?' }),
+        catch: NetRegexes.gameLog({
+          code: '0843',
+          line:
+            '(?:[\\w\\s-\']+)\u306f.+?(?<fish>[\u3000-\u30ff\u3400-\u4dbf\u4e00-\u9faf\d\uff1a]+)(?:[^\u3000-\u30ff\u3400-\u4dbf\u4e00-\u9faf]+)?（\\d+\\.\\dイルム）を釣り上げた。.*?',
+        }),
+        nocatch: NetRegexes.gameLog({
+          code: '08c3',
+          line:
+            '(?:[\\w\\s-\']+)?(?:いつの間にか釣り餌をとられてしまった……。|いつの間にか.+をロストしてしまった！|いつの間にか釣り餌をとられてしまった……。|釣り針にかかった魚に逃げられてしまった……。|ラインブレイク！！|何もかからなかった……。\n\n釣り餌が釣り場にあってないようだ。|何もかからなかった……。|.+は釣りを中断した。|魚に逃げられ、.+をロストしてしまった……。|魚たちに警戒されてしまったようだ……|.+を釣り上げたが、これ以上持てないためリリースした。).*?',
+        }),
+        mooch: NetRegexes.gameLog({
+          code: '08c3',
+          line: '(?:[\\w\\s-\']+)は釣り上げた.+を慎重に投げ込み、泳がせ釣りを試みた。.*?',
+        }),
+        quit: NetRegexes.gameLog({
+          code: '08c3',
+          line:
+            '(?:[\\w\\s-\']+)?(?:は釣りを終えた。|戦闘不能になったため、釣りが中断されました。|は釣りを終えた。|敵から攻撃を受けたため、釣りが中断されました。).*?',
+        }),
+        discovered: NetRegexes.gameLog({
+          code: '08c3',
+          line:
+            '釣り手帳に新しい釣り場「(?<place>[\u3000-\u30ff\u3400-\u4dbf\u4e00-\u9faf\\d\uff1a]+)」の情報を記録した！.*?',
+        }),
       },
-      'ja': {
-        'undiscovered': /未知の釣り場/,
-        'cast':
-          /00:08c3:(?:[\w\s-']+)\u306f([\u3000-\u30ff\u3400-\u4dbf\u4e00-\u9faf\d\uff1a]+)で釣りを開始した。/,
-        'bite': /00:08c3:魚をフッキングした！/,
-        'catch':
-          /00:0843:(?:[\w\s-']+)\u306f.+?([\u3000-\u30ff\u3400-\u4dbf\u4e00-\u9faf\d\uff1a]+)(?:[^\u3000-\u30ff\u3400-\u4dbf\u4e00-\u9faf]+)?（\d+\.\dイルム）を釣り上げた。/,
-        'nocatch':
-          /00:08c3:([\w\s-']+)?(?:いつの間にか釣り餌をとられてしまった……。|いつの間にか.+をロストしてしまった！|いつの間にか釣り餌をとられてしまった……。|釣り針にかかった魚に逃げられてしまった……。|ラインブレイク！！|何もかからなかった……。\n\n釣り餌が釣り場にあってないようだ。|何もかからなかった……。|.+は釣りを中断した。|魚に逃げられ、.+をロストしてしまった……。|魚たちに警戒されてしまったようだ……|.+を釣り上げたが、これ以上持てないためリリースした。)/,
-        'mooch': /00:08c3:(?:[\w\s-']+)は釣り上げた.+を慎重に投げ込み、泳がせ釣りを試みた。/,
-        'quit':
-          /00:08c3:(?:[\w\s-']+)?(?:は釣りを終えた。|戦闘不能になったため、釣りが中断されました。|は釣りを終えた。|敵から攻撃を受けたため、釣りが中断されました。)/,
-        'discovered':
-          /00:08c3:釣り手帳に新しい釣り場「([\u3000-\u30ff\u3400-\u4dbf\u4e00-\u9faf\d\uff1a]+)」の情報を記録した！/,
+      cn: {
+        undiscovered: /未知钓场/,
+        cast: NetRegexes.gameLog({
+          code: '08c3',
+          line:
+            '(?:[\\w\\s-\'\u4e00-\u9fa5·]+)在(?<place>[\\w\\s-\'\u4e00-\u9fa5·\uff08\uff09]+)甩出了鱼线开始钓鱼。.*?',
+        }),
+        bite: NetRegexes.gameLog({ code: '08c3', line: '有鱼上钩了！.*?' }),
+        catch: NetRegexes.gameLog({
+          code: '0843',
+          line:
+            '(?:[\\w\\s-\'\u4e00-\u9fa5·]+)?成功钓上了.*?(?<fish>[\u3000-\u30ff\u3400-\u4dbf\u4e00-\u9faf·]+\\d*).*（\\d+\\.\\d星寸）。.*?',
+        }),
+        nocatch: NetRegexes.gameLog({
+          code: '08c3',
+          line:
+            '(?:[\\w\\s-\'\u4e00-\u9fa5·]+)?(?:不经意间鱼饵被吃掉了……|不经意间丢掉了.+……|不经意间.+不见了……|不经意间鱼饵被吃掉了……|上钩的鱼逃走了……|鱼线断了！|没有钓到任何东西……\n\n现在使用的鱼饵可能不太适合这片钓场。|没有钓到任何东西……|.+收竿停止了钓鱼。|鱼带着.+逃走了……|这里的鱼现在警惕性很高，看来还是换个地点比较好。|无法持有更多的.+，(?:[\\w\\s-\'\u4e00-\u9fa5·]+)?将刚钓上的东西放生了。).*?',
+        }),
+        mooch: NetRegexes.gameLog({
+          code: '08c3',
+          line:
+            '(?:[\\w\\s-\'\u4e00-\u9fa5·]+)开始利用上钩的.*?([\u3000-\u30ff\u3400-\u4dbf\u4e00-\u9faf·]+\\d*).*尝试以小钓大。.*?',
+        }),
+        quit: NetRegexes.gameLog({
+          code: '08c3',
+          line:
+            '(?:[\\w\\s-\'\u4e00-\u9fa5·]+)?(?:收回了鱼线。|陷入了战斗不能状态，钓鱼中断。|收回了鱼线。|受到了敌人的攻击，钓鱼中断。).*?',
+        }),
+        discovered: NetRegexes.gameLog({
+          code: '08c3',
+          line: '将新钓场.*(?<place>[\u3000-\u30ff\u3400-\u4dbf\u4e00-\u9faf·]+\\d*).*记录到了钓鱼笔记中！.*?',
+        }),
       },
-      'cn': {
-        'undiscovered': /未知钓场/,
-        'cast':
-          /00:08c3:(?:[\w\s-'\u4e00-\u9fa5·]+)在([\w\s-'\u4e00-\u9fa5·\uff08\uff09]+)甩出了鱼线开始钓鱼。/,
-        'bite': /00:08c3:有鱼上钩了！/,
-        'catch':
-          /00:0843:(?:[\w\s-'\u4e00-\u9fa5·]+)?成功钓上了.*?([\u3000-\u30ff\u3400-\u4dbf\u4e00-\u9faf·]+\d*).*（\d+\.\d星寸）。/,
-        'nocatch':
-          /00:08c3:([\w\s-'\u4e00-\u9fa5·]+)?(?:不经意间鱼饵被吃掉了……|不经意间丢掉了.+……|不经意间.+不见了……|不经意间鱼饵被吃掉了……|上钩的鱼逃走了……|鱼线断了！|没有钓到任何东西……\n\n现在使用的鱼饵可能不太适合这片钓场。|没有钓到任何东西……|.+收竿停止了钓鱼。|鱼带着.+逃走了……|这里的鱼现在警惕性很高，看来还是换个地点比较好。|无法持有更多的.+，(?:[\w\s-'\u4e00-\u9fa5·]+)?将刚钓上的东西放生了。)/,
-        'mooch':
-          /00:08c3:(?:[\w\s-'\u4e00-\u9fa5·]+)开始利用上钩的.*?([\u3000-\u30ff\u3400-\u4dbf\u4e00-\u9faf·]+\d*).*尝试以小钓大。/,
-        'chumgain': /00:08ae:(?:[\w\s-'\u4e00-\u9fa5·]+)附加了“.*撒饵.*”效果。/,
-        'chumfade': /00:08b0:(?:[\w\s-'\u4e00-\u9fa5·]+)的“.*撒饵.*”状态效果消失了。/,
-        'snaggain': /00:08ae:(⇒ )?(?:[\w\s-'\u4e00-\u9fa5·]+)附加了“.*钓组.*”效果。/,
-        'snagfade': /00:08b0:(?:[\w\s-'\u4e00-\u9fa5·]+)的“.*钓组.*”状态效果消失了。/,
-        'quit':
-          /00:08c3:(?:[\w\s-'\u4e00-\u9fa5·]+)?(?:收回了鱼线。|陷入了战斗不能状态，钓鱼中断。|收回了鱼线。|受到了敌人的攻击，钓鱼中断。)/,
-        'discovered': /00:08c3:将新钓场.*([\u3000-\u30ff\u3400-\u4dbf\u4e00-\u9faf·]+\d*).*记录到了钓鱼笔记中！/,
-      },
-      'ko': {
-        'undiscovered': /미지의 낚시터/,
-        'cast': /00:08c3:(?:[\w'가-힣]+) 님이 ([\s\d':가-힣]+)에서 낚시를 시작합니다\./,
-        'bite': /00:08c3:낚싯대를 낚아챘습니다!/,
-        'catch': /00:0843:(?:[\w'가-힣]+) 님이 (?:[\s\d':가-힣]+)\(\d+\.\d일름\)(?:을|를) 낚았습니다./,
-        'nocatch':
-          /00:08c3:(?:어느새 미끼만 먹고 도망간 것 같습니다……\.|물고기가 도망갔습니다……\.|낚싯줄이 끊어졌습니다!!|아무것도 낚이지 않았습니다\.|이곳에는 물고기가 없는 것 같습니다……\.|물고기는 있는 것 같지만,|.+놓쳐버렸습니다!|물고기를 놓치고 .+도 잃었습니다……\.|물고기들이 경계하기 시작했습니다\.|소지품에 공간이 부족하여)/,
-        'mooch':
-          /00:08c3:(?:[\w'가-힣]+) 님이 방금 낚은 (?:[\s\d':가-힣]+)(?:을|를) 조심스럽게 물에 넣고 생미끼 낚시를 시도합니다\./,
-        'chumgain': /00:08ae:(?:[\w'가-힣]+)(?:이|가) 밑밥 효과를 받았습니다\./,
-        'chumfade': /00:08b0:(?:[\w'가-힣]+)의 밑밥 효과가 사라졌습니다\./,
-        'snaggain': /00:08ae:(?:⇒ [\w'가-힣]+)(?:이|가) 갈고리 낚시 효과를 받았습니다\./,
-        'snagfade': /00:08b0:(?:[\w'가-힣]+)의 갈고리 낚시 효과가 사라졌습니다\./,
-        'quit':
-          /00:08c3:(?:(?:[\w'가-힣]+) 님이 낚시를 마쳤습니다.|전투불능이 되어 낚시가 중단되었습니다\.|적의 공격을 받아 낚시가 중단되었습니다\.)/,
-        'discovered': /00:08c3:낚시 수첩에 새로운 낚시터 (?:[\s\d':가-힣]+)의 정보를 기록했습니다!/,
+      ko: {
+        undiscovered: /미지의 낚시터/,
+        cast: NetRegexes.gameLog({
+          code: '08c3',
+          line: '(?:[\\w\'가-힣]+) 님이 (?<place>[\\s\\d\':가-힣]+)에서 낚시를 시작합니다\\..*?',
+        }),
+        bite: NetRegexes.gameLog({ code: '08c3', line: '낚싯대를 낚아챘습니다!.*?' }),
+        catch: NetRegexes.gameLog({
+          code: '0843',
+          line: '(?:[\\w\'가-힣]+) 님이 (?<fish>[\\s\\d\':가-힣]+)\\(?:\\d+\\.\\d일름\\)(?:을|를) 낚았습니다.*?',
+        }),
+        nocatch: NetRegexes.gameLog({
+          code: '08c3',
+          line:
+            '(?:어느새 미끼만 먹고 도망간 것 같습니다……\\.|물고기가 도망갔습니다……\\.|낚싯줄이 끊어졌습니다!!|아무것도 낚이지 않았습니다\\.|이곳에는 물고기가 없는 것 같습니다……\\.|물고기는 있는 것 같지만,|.+놓쳐버렸습니다!|물고기를 놓치고 .+도 잃었습니다……\\.|물고기들이 경계하기 시작했습니다\.|소지품에 공간이 부족하여).*?',
+        }),
+        mooch: NetRegexes.gameLog({
+          code: '08c3',
+          line:
+            '(?:[\\w\'가-힣]+) 님이 방금 낚은 (?:[\\s\\d\':가-힣]+)(?:을|를) 조심스럽게 물에 넣고 생미끼 낚시를 시도합니다\\..*?',
+        }),
+        quit: NetRegexes.gameLog({
+          code: '08c3',
+          line:
+            '(?:(?:[\\w\'가-힣]+) 님이 낚시를 마쳤습니다.|전투불능이 되어 낚시가 중단되었습니다\.|적의 공격을 받아 낚시가 중단되었습니다\.).*?',
+        }),
+        discovered: NetRegexes.gameLog({
+          code: '08c3',
+          line: '낚시 수첩에 새로운 낚시터 (?<place>[\\s\\d\':가-힣]+)의 정보를 기록했습니다!.*?',
+        }),
       },
     };
 
@@ -367,22 +463,37 @@ class Fisher {
     this.updateFishData();
   }
 
-  parseLine(log) {
-    let result = null;
+  parseLine(e) {
+    const log = e.rawLine;
+    const type = e.line[0];
+
+    if (type === logDefinitions.GainsEffect.type) {
+      if (this.gainEffectRegex.chum.test(log))
+        this.handleChumGain();
+      else if (this.gainEffectRegex.snag.test(log))
+        this.handleSnagGain();
+    } else if (type === logDefinitions.LosesEffect.type) {
+      if (this.loseEffectRegex.chum.test(log))
+        this.handleChumFade();
+      else if (this.loseEffectRegex.snag.test(log))
+        this.handleSnagFade();
+    }
+    if (type !== logDefinitions.GameLog.type)
+      return;
 
     for (const type in this.regex[this.options.ParserLanguage]) {
-      result = this.regex[this.options.ParserLanguage][type].exec(log);
+      const result = this.regex[this.options.ParserLanguage][type].exec(log);
       if (result) {
         switch (type) {
           // case 'bait': this.handleBait(result[1]); break;
           case 'cast':
-            this.handleCast(result[1]);
+            this.handleCast(result.groups?.place);
             break;
           case 'bite':
             this.handleBite();
             break;
           case 'catch':
-            this.handleCatch(result[1]);
+            this.handleCatch(result.groups?.fish);
             break;
           case 'nocatch':
             this.handleNoCatch();
@@ -390,32 +501,20 @@ class Fisher {
           case 'mooch':
             this.handleMooch();
             break;
-          case 'snaggain':
-            this.handleSnagGain();
-            break;
-          case 'snagfade':
-            this.handleSnagFade();
-            break;
-          case 'chumgain':
-            this.handleChumGain();
-            break;
-          case 'chumfade':
-            this.handleChumFade();
-            break;
           case 'quit':
             this.handleQuit();
             break;
           case 'discovered':
-            this.handleDiscover(result[1]);
+            this.handleDiscover(result.groups?.place);
             break;
         }
       }
     }
   }
 
-  OnLogEvent(e) {
+  OnNetLog(e) {
     if (this.job === 'FSH')
-      e.detail.logs.forEach(this.parseLine, this);
+      this.parseLine(e);
   }
 
   OnChangeZone(e) {
@@ -440,8 +539,8 @@ UserConfig.getUserConfigLocation('fisher', defaultOptions, () => {
   const options = { ...defaultOptions };
   const fisher = new Fisher(options, document.getElementById('fisher'));
 
-  addOverlayListener('onLogEvent', (e) => {
-    fisher.OnLogEvent(e);
+  addOverlayListener('LogLine', (e) => {
+    fisher.OnNetLog(e);
   });
 
   addOverlayListener('ChangeZone', (e) => {


### PR DESCRIPTION
The chum and snagging effect lines were incorrect and did not trigger
for English, at least.  These are switched to be gains effect lines.

Regexes should be identical except:
* added capturing group for cast/catch/discovered
* changed some groups to be non-capturing in other regexes
* adjusted the capturing group in Korean catch/discovered as it seemed
  wrong