### PR TITLE
oopsy: add id field to deathReason

### DIFF
--- a/docs/OopsyraidsyGuide.md
+++ b/docs/OopsyraidsyGuide.md
@@ -120,6 +120,7 @@ mistake: (data, matches) => {
 
 ### `deathReason` format
 
+* `id` is the player id to override the death reason for.
 * `name` is the full player name to override the next death reason for.
 * `reason` is the string to use.
 
@@ -128,7 +129,8 @@ If this following trigger is used, then if a player dies without taking any othe
 ```javascript
 deathReason: (data, matches) => {
   return {
-    name: event.targetName,
+    id: matches.targetId,
+    name: matches.targetName,
     text: 'Doom Debuff',
   },
 },

--- a/types/oopsy.d.ts
+++ b/types/oopsy.d.ts
@@ -34,6 +34,7 @@ export type OopsyMistake = {
 };
 
 export type OopsyDeathReason = {
+  id: string;
   name: string;
   text: string | LocaleText;
 };

--- a/ui/oopsyraidsy/data/02-arr/trial/levi-ex.ts
+++ b/ui/oopsyraidsy/data/02-arr/trial/levi-ex.ts
@@ -41,7 +41,7 @@ const triggerSet: OopsyTriggerSet<Data> = {
       netRegex: NetRegexes.ability({ id: '82A' }),
       deathReason: (_data, matches) => {
         return {
-          type: 'fail',
+          id: matches.targetId,
           name: matches.target,
           text: {
             en: 'Knocked off',

--- a/ui/oopsyraidsy/data/03-hw/alliance/weeping_city.ts
+++ b/ui/oopsyraidsy/data/03-hw/alliance/weeping_city.ts
@@ -135,7 +135,7 @@ const triggerSet: OopsyTriggerSet<Data> = {
       netRegex: NetRegexes.ability({ id: '182E' }),
       deathReason: (_data, matches) => {
         return {
-          type: 'fail',
+          id: matches.targetId,
           name: matches.target,
           text: {
             en: 'Slid off!',

--- a/ui/oopsyraidsy/data/04-sb/dungeon/swallows_compass.ts
+++ b/ui/oopsyraidsy/data/04-sb/dungeon/swallows_compass.ts
@@ -50,7 +50,7 @@ const triggerSet: OopsyTriggerSet<Data> = {
       netRegex: NetRegexes.gainsEffect({ effectId: '237' }),
       deathReason: (_data, matches) => {
         return {
-          type: 'fail',
+          id: matches.targetId,
           name: matches.target,
           text: matches.effect,
         };

--- a/ui/oopsyraidsy/data/04-sb/raid/o12n.ts
+++ b/ui/oopsyraidsy/data/04-sb/raid/o12n.ts
@@ -32,7 +32,7 @@ const triggerSet: OopsyTriggerSet<Data> = {
       netRegex: NetRegexes.ability({ id: '32F6' }),
       deathReason: (_data, matches) => {
         return {
-          type: 'fail',
+          id: matches.targetId,
           name: matches.target,
           text: {
             en: 'Knocked off',

--- a/ui/oopsyraidsy/data/04-sb/raid/o12s.ts
+++ b/ui/oopsyraidsy/data/04-sb/raid/o12s.ts
@@ -51,7 +51,7 @@ const triggerSet: OopsyTriggerSet<Data> = {
       netRegex: NetRegexes.ability({ id: '3327' }),
       deathReason: (_data, matches) => {
         return {
-          type: 'fail',
+          id: matches.targetId,
           name: matches.target,
           text: {
             en: 'Knocked off',

--- a/ui/oopsyraidsy/data/04-sb/raid/o4n.ts
+++ b/ui/oopsyraidsy/data/04-sb/raid/o4n.ts
@@ -33,7 +33,7 @@ const triggerSet: OopsyTriggerSet<Data> = {
       netRegex: NetRegexes.gainsEffect({ effectId: '38E' }),
       deathReason: (_data, matches) => {
         return {
-          type: 'fail',
+          id: matches.targetId,
           name: matches.target,
           text: {
             en: 'Cleansers missed Doom!',
@@ -53,7 +53,7 @@ const triggerSet: OopsyTriggerSet<Data> = {
       netRegex: NetRegexes.abilityFull({ id: '24B8', ...playerDamageFields }),
       deathReason: (_data, matches) => {
         return {
-          type: 'fail',
+          id: matches.targetId,
           name: matches.target,
           text: {
             en: 'Pushed off!',

--- a/ui/oopsyraidsy/data/04-sb/raid/o4s.ts
+++ b/ui/oopsyraidsy/data/04-sb/raid/o4s.ts
@@ -132,6 +132,7 @@ const triggerSet: OopsyTriggerSet<Data> = {
         if (!data.hasBeyondDeath[matches.target])
           return;
         return {
+          id: matches.targetId,
           name: matches.target,
           text: matches.effect,
         };

--- a/ui/oopsyraidsy/data/04-sb/raid/o5n.ts
+++ b/ui/oopsyraidsy/data/04-sb/raid/o5n.ts
@@ -33,8 +33,13 @@ const triggerSet: OopsyTriggerSet<Data> = {
       netRegex: NetRegexes.gainsEffect({ effectId: '3AA' }),
       delaySeconds: (_data, matches) => parseFloat(matches.duration) - 1,
       deathReason: (data, matches) => {
-        if (data.hasThrottle?.[matches.target])
-          return { name: matches.target, text: matches.effect };
+        if (!data.hasThrottle?.[matches.target])
+          return;
+        return {
+          id: matches.targetId,
+          name: matches.target,
+          text: matches.effect,
+        };
       },
     },
     {

--- a/ui/oopsyraidsy/data/04-sb/raid/o5s.ts
+++ b/ui/oopsyraidsy/data/04-sb/raid/o5s.ts
@@ -30,8 +30,13 @@ const triggerSet: OopsyTriggerSet<Data> = {
       netRegex: NetRegexes.gainsEffect({ effectId: '3AA' }),
       delaySeconds: (_data, matches) => parseFloat(matches.duration) - 1,
       deathReason: (data, matches) => {
-        if (data.hasThrottle?.[matches.target])
-          return { name: matches.target, text: matches.effect };
+        if (!data.hasThrottle?.[matches.target])
+          return;
+        return {
+          id: matches.targetId,
+          name: matches.target,
+          text: matches.effect,
+        };
       },
     },
     {

--- a/ui/oopsyraidsy/data/04-sb/raid/o8n.ts
+++ b/ui/oopsyraidsy/data/04-sb/raid/o8n.ts
@@ -53,7 +53,7 @@ const triggerSet: OopsyTriggerSet<Data> = {
       netRegex: NetRegexes.ability({ id: '2927' }),
       deathReason: (_data, matches) => {
         return {
-          type: 'fail',
+          id: matches.targetId,
           name: matches.target,
           text: {
             en: 'Knocked off',
@@ -72,7 +72,7 @@ const triggerSet: OopsyTriggerSet<Data> = {
       netRegex: NetRegexes.ability({ id: '2924' }),
       deathReason: (_data, matches) => {
         return {
-          type: 'fail',
+          id: matches.targetId,
           name: matches.target,
           text: {
             en: 'Knocked off',

--- a/ui/oopsyraidsy/data/04-sb/raid/o8s.ts
+++ b/ui/oopsyraidsy/data/04-sb/raid/o8s.ts
@@ -84,7 +84,7 @@ const triggerSet: OopsyTriggerSet<Data> = {
       netRegex: NetRegexes.ability({ id: '28DB' }),
       deathReason: (_data, matches) => {
         return {
-          type: 'fail',
+          id: matches.targetId,
           name: matches.target,
           text: {
             en: 'Knocked off',
@@ -103,7 +103,7 @@ const triggerSet: OopsyTriggerSet<Data> = {
       netRegex: NetRegexes.ability({ id: '28D6' }),
       deathReason: (_data, matches) => {
         return {
-          type: 'fail',
+          id: matches.targetId,
           name: matches.target,
           text: {
             en: 'Knocked off',

--- a/ui/oopsyraidsy/data/04-sb/raid/o9s.ts
+++ b/ui/oopsyraidsy/data/04-sb/raid/o9s.ts
@@ -26,7 +26,7 @@ const triggerSet: OopsyTriggerSet<Data> = {
       netRegex: NetRegexes.ability({ id: '318F' }),
       deathReason: (_data, matches) => {
         return {
-          type: 'fail',
+          id: matches.targetId,
           name: matches.target,
           text: {
             en: 'Knocked off',

--- a/ui/oopsyraidsy/data/04-sb/trial/lakshmi-ex.ts
+++ b/ui/oopsyraidsy/data/04-sb/trial/lakshmi-ex.ts
@@ -42,7 +42,7 @@ const triggerSet: OopsyTriggerSet<Data> = {
       netRegex: NetRegexes.abilityFull({ id: '2149', ...playerDamageFields }),
       deathReason: (_data, matches) => {
         return {
-          type: 'fail',
+          id: matches.targetId,
           name: matches.target,
           text: {
             en: 'Knocked off',

--- a/ui/oopsyraidsy/data/04-sb/trial/lakshmi.ts
+++ b/ui/oopsyraidsy/data/04-sb/trial/lakshmi.ts
@@ -36,7 +36,7 @@ const triggerSet: OopsyTriggerSet<Data> = {
       netRegex: NetRegexes.abilityFull({ id: '2485', ...playerDamageFields }),
       deathReason: (_data, matches) => {
         return {
-          type: 'fail',
+          id: matches.targetId,
           name: matches.target,
           text: {
             en: 'Knocked off',

--- a/ui/oopsyraidsy/data/04-sb/trial/shinryu-ex.ts
+++ b/ui/oopsyraidsy/data/04-sb/trial/shinryu-ex.ts
@@ -46,7 +46,7 @@ const triggerSet: OopsyTriggerSet<Data> = {
       netRegex: NetRegexes.gainsEffect({ effectId: '38F' }),
       deathReason: (_data, matches) => {
         return {
-          type: 'fail',
+          id: matches.targetId,
           name: matches.target,
           text: {
             en: 'Slid off!',
@@ -65,7 +65,7 @@ const triggerSet: OopsyTriggerSet<Data> = {
       netRegex: NetRegexes.abilityFull({ id: '25DA', ...playerDamageFields }),
       deathReason: (_data, matches) => {
         return {
-          type: 'fail',
+          id: matches.targetId,
           name: matches.target,
           text: {
             en: 'Pushed off!',
@@ -85,7 +85,7 @@ const triggerSet: OopsyTriggerSet<Data> = {
       netRegex: NetRegexes.abilityFull({ id: '25DF', ...playerDamageFields }),
       deathReason: (_data, matches) => {
         return {
-          type: 'fail',
+          id: matches.targetId,
           name: matches.target,
           text: {
             en: 'Pushed off!',

--- a/ui/oopsyraidsy/data/04-sb/trial/shinryu.ts
+++ b/ui/oopsyraidsy/data/04-sb/trial/shinryu.ts
@@ -31,7 +31,7 @@ const triggerSet: OopsyTriggerSet<Data> = {
       netRegex: NetRegexes.gainsEffect({ effectId: '38F' }),
       deathReason: (_data, matches) => {
         return {
-          type: 'fail',
+          id: matches.targetId,
           name: matches.target,
           text: {
             en: 'Slid off!',
@@ -50,7 +50,7 @@ const triggerSet: OopsyTriggerSet<Data> = {
       netRegex: NetRegexes.abilityFull({ id: '1F8B', ...playerDamageFields }),
       deathReason: (_data, matches) => {
         return {
-          type: 'fail',
+          id: matches.targetId,
           name: matches.target,
           text: {
             en: 'Pushed off!',
@@ -70,7 +70,7 @@ const triggerSet: OopsyTriggerSet<Data> = {
       netRegex: NetRegexes.abilityFull({ id: '1F90', ...playerDamageFields }),
       deathReason: (_data, matches) => {
         return {
-          type: 'fail',
+          id: matches.targetId,
           name: matches.target,
           text: {
             en: 'Pushed off!',

--- a/ui/oopsyraidsy/data/04-sb/trial/suzaku-ex.ts
+++ b/ui/oopsyraidsy/data/04-sb/trial/suzaku-ex.ts
@@ -42,7 +42,7 @@ const triggerSet: OopsyTriggerSet<Data> = {
       netRegex: NetRegexes.abilityFull({ id: '32DB', ...playerDamageFields }),
       deathReason: (_data, matches) => {
         return {
-          type: 'fail',
+          id: matches.targetId,
           name: matches.target,
           text: {
             en: 'Knocked off',
@@ -61,7 +61,7 @@ const triggerSet: OopsyTriggerSet<Data> = {
       netRegex: NetRegexes.abilityFull({ id: '32DA', ...playerDamageFields }),
       deathReason: (_data, matches) => {
         return {
-          type: 'fail',
+          id: matches.targetId,
           name: matches.target,
           text: {
             en: 'Knocked off',

--- a/ui/oopsyraidsy/data/04-sb/trial/suzaku.ts
+++ b/ui/oopsyraidsy/data/04-sb/trial/suzaku.ts
@@ -29,7 +29,7 @@ const triggerSet: OopsyTriggerSet<Data> = {
       netRegex: NetRegexes.abilityFull({ id: '3230', ...playerDamageFields }),
       deathReason: (_data, matches) => {
         return {
-          type: 'fail',
+          id: matches.targetId,
           name: matches.target,
           text: {
             en: 'Pushed off!',

--- a/ui/oopsyraidsy/data/04-sb/ultimate/unending_coil_ultimate.ts
+++ b/ui/oopsyraidsy/data/04-sb/ultimate/unending_coil_ultimate.ts
@@ -143,7 +143,11 @@ const triggerSet: OopsyTriggerSet<Data> = {
           text = matches.effect + ' #2';
         else
           text = matches.effect + ' #3';
-        return { name: matches.target, text: text };
+        return {
+          id: matches.targetId,
+          name: matches.target,
+          text: text,
+        };
       },
     },
   ],

--- a/ui/oopsyraidsy/data/05-shb/alliance/the_tower_at_paradigms_breach.ts
+++ b/ui/oopsyraidsy/data/05-shb/alliance/the_tower_at_paradigms_breach.ts
@@ -93,7 +93,7 @@ const triggerSet: OopsyTriggerSet<Data> = {
       netRegex: NetRegexes.ability({ id: ['5EB1', '5BF2'] }),
       deathReason: (_data, matches) => {
         return {
-          type: 'fail',
+          id: matches.targetId,
           name: matches.target,
           text: {
             en: 'Knocked off',

--- a/ui/oopsyraidsy/data/05-shb/raid/e11n.ts
+++ b/ui/oopsyraidsy/data/05-shb/raid/e11n.ts
@@ -35,7 +35,7 @@ const triggerSet: OopsyTriggerSet<Data> = {
       netRegex: NetRegexes.ability({ id: ['562D', '5644'] }),
       deathReason: (_data, matches) => {
         return {
-          type: 'fail',
+          id: matches.targetId,
           name: matches.target,
           text: {
             en: 'Knocked off',

--- a/ui/oopsyraidsy/data/05-shb/raid/e11s.ts
+++ b/ui/oopsyraidsy/data/05-shb/raid/e11s.ts
@@ -61,7 +61,7 @@ const triggerSet: OopsyTriggerSet<Data> = {
       netRegex: NetRegexes.ability({ id: ['5653', '567A', '568F'] }),
       deathReason: (_data, matches) => {
         return {
-          type: 'fail',
+          id: matches.targetId,
           name: matches.target,
           text: {
             en: 'Knocked off',

--- a/ui/oopsyraidsy/data/05-shb/raid/e12s.ts
+++ b/ui/oopsyraidsy/data/05-shb/raid/e12s.ts
@@ -438,7 +438,7 @@ const triggerSet: OopsyTriggerSet<Data> = {
       netRegex: NetRegexes.ability({ id: ['589A', '58B6', '58B7', '58C1'] }),
       deathReason: (_data, matches) => {
         return {
-          type: 'fail',
+          id: matches.targetId,
           name: matches.target,
           text: {
             en: 'Knocked off',

--- a/ui/oopsyraidsy/data/05-shb/raid/e7s.ts
+++ b/ui/oopsyraidsy/data/05-shb/raid/e7s.ts
@@ -143,7 +143,7 @@ const triggerSet: OopsyTriggerSet<Data> = {
       netRegex: NetRegexes.abilityFull({ id: '4C76', ...playerDamageFields }),
       deathReason: (_data, matches) => {
         return {
-          type: 'fail',
+          id: matches.targetId,
           name: matches.target,
           text: {
             en: 'Knocked off',

--- a/ui/oopsyraidsy/data/05-shb/raid/e8n.ts
+++ b/ui/oopsyraidsy/data/05-shb/raid/e8n.ts
@@ -37,7 +37,7 @@ const triggerSet: OopsyTriggerSet<Data> = {
       netRegex: NetRegexes.abilityFull({ id: '4DD8', ...playerDamageFields }),
       deathReason: (_data, matches) => {
         return {
-          type: 'fail',
+          id: matches.targetId,
           name: matches.target,
           text: {
             en: 'Pushed off!',
@@ -57,7 +57,7 @@ const triggerSet: OopsyTriggerSet<Data> = {
       netRegex: NetRegexes.gainsEffect({ effectId: '38F' }),
       deathReason: (_data, matches) => {
         return {
-          type: 'fail',
+          id: matches.targetId,
           name: matches.target,
           text: {
             en: 'Slid off!',

--- a/ui/oopsyraidsy/data/05-shb/trial/diamond_weapon-ex.ts
+++ b/ui/oopsyraidsy/data/05-shb/trial/diamond_weapon-ex.ts
@@ -44,7 +44,7 @@ const triggerSet: OopsyTriggerSet<Data> = {
       netRegex: NetRegexes.ability({ id: '5FD0' }),
       deathReason: (_data, matches) => {
         return {
-          type: 'fail',
+          id: matches.targetId,
           name: matches.target,
           text: {
             en: 'Knocked off',

--- a/ui/oopsyraidsy/data/05-shb/trial/diamond_weapon.ts
+++ b/ui/oopsyraidsy/data/05-shb/trial/diamond_weapon.ts
@@ -32,7 +32,7 @@ const triggerSet: OopsyTriggerSet<Data> = {
       netRegex: NetRegexes.ability({ id: '5FE5' }),
       deathReason: (_data, matches) => {
         return {
-          type: 'fail',
+          id: matches.targetId,
           name: matches.target,
           text: {
             en: 'Knocked off',

--- a/ui/oopsyraidsy/data/05-shb/trial/emerald_weapon.ts
+++ b/ui/oopsyraidsy/data/05-shb/trial/emerald_weapon.ts
@@ -40,7 +40,7 @@ const triggerSet: OopsyTriggerSet<Data> = {
       netRegex: NetRegexes.ability({ id: '553E' }),
       deathReason: (_data, matches) => {
         return {
-          type: 'fail',
+          id: matches.targetId,
           name: matches.target,
           text: {
             en: 'Knocked off',
@@ -60,7 +60,7 @@ const triggerSet: OopsyTriggerSet<Data> = {
       netRegex: NetRegexes.ability({ id: ['5563', '5564'] }),
       deathReason: (_data, matches) => {
         return {
-          type: 'fail',
+          id: matches.targetId,
           name: matches.target,
           text: {
             en: 'Pushed into wall',

--- a/ui/oopsyraidsy/data/05-shb/trial/hades-ex.ts
+++ b/ui/oopsyraidsy/data/05-shb/trial/hades-ex.ts
@@ -118,6 +118,7 @@ const triggerSet: OopsyTriggerSet<Data> = {
         if (!data.hasBeyondDeath[matches.target])
           return;
         return {
+          id: matches.targetId,
           name: matches.target,
           text: matches.effect,
         };
@@ -152,6 +153,7 @@ const triggerSet: OopsyTriggerSet<Data> = {
         if (!data.hasDoom[matches.target])
           return;
         return {
+          id: matches.targetId,
           name: matches.target,
           text: matches.effect,
         };

--- a/ui/oopsyraidsy/data/05-shb/trial/levi-un.ts
+++ b/ui/oopsyraidsy/data/05-shb/trial/levi-un.ts
@@ -42,7 +42,7 @@ const triggerSet: OopsyTriggerSet<Data> = {
       netRegex: NetRegexes.ability({ id: '5CD2' }),
       deathReason: (_data, matches) => {
         return {
-          type: 'fail',
+          id: matches.targetId,
           name: matches.target,
           text: {
             en: 'Knocked off',

--- a/ui/oopsyraidsy/data/05-shb/trial/ruby_weapon-ex.ts
+++ b/ui/oopsyraidsy/data/05-shb/trial/ruby_weapon-ex.ts
@@ -72,7 +72,7 @@ const triggerSet: OopsyTriggerSet<Data> = {
       netRegex: NetRegexes.ability({ id: '4AEE' }),
       deathReason: (_data, matches) => {
         return {
-          type: 'fail',
+          id: matches.targetId,
           name: matches.target,
           text: {
             en: 'Knocked into wall',

--- a/ui/oopsyraidsy/data/05-shb/trial/wol-ex.ts
+++ b/ui/oopsyraidsy/data/05-shb/trial/wol-ex.ts
@@ -42,7 +42,11 @@ const triggerSet: OopsyTriggerSet<Data> = {
       netRegex: NetRegexes.gainsEffect({ effectId: '8FF' }),
       delaySeconds: (_data, matches) => parseFloat(matches.duration) - 0.5,
       deathReason: (_data, matches) => {
-        return { type: 'fail', name: matches.target, text: matches.effect };
+        return {
+          id: matches.targetId,
+          name: matches.target,
+          text: matches.effect,
+        };
       },
     },
     {

--- a/ui/oopsyraidsy/data/05-shb/trial/wol.ts
+++ b/ui/oopsyraidsy/data/05-shb/trial/wol.ts
@@ -38,7 +38,11 @@ const triggerSet: OopsyTriggerSet<Data> = {
       netRegex: NetRegexes.gainsEffect({ effectId: '38E' }),
       delaySeconds: (_data, matches) => parseFloat(matches.duration) - 0.5,
       deathReason: (_data, matches) => {
-        return { type: 'fail', name: matches.target, text: matches.effect };
+        return {
+          id: matches.targetId,
+          name: matches.target,
+          text: matches.effect,
+        };
       },
     },
   ],

--- a/ui/oopsyraidsy/data/05-shb/ultimate/the_epic_of_alexander.ts
+++ b/ui/oopsyraidsy/data/05-shb/ultimate/the_epic_of_alexander.ts
@@ -158,6 +158,7 @@ const triggerSet: OopsyTriggerSet<Data> = {
         if (!data.hasThrottle[matches.target])
           return;
         return {
+          id: matches.targetId,
           name: matches.target,
           text: matches.effect,
         };


### PR DESCRIPTION
The effect_tracker buff tracking code and forthcoming "death report"
feature all use ids rather than names, and so having ids here will
make it easier to incorporate this feature there.

Also, remove unnecessary/incorrect "type" field from many death
reason entries.