### PR TITLE
eureka: fix bug in flag/refresh config settings

### DIFF
--- a/ui/eureka/eureka_config.ts
+++ b/ui/eureka/eureka_config.ts
@@ -29,9 +29,14 @@ UserConfig.registerOptions('eureka', {
       type: 'float',
       default: 90,
       setterFunc: (options, value) => {
-        if (typeof value !== 'number')
+        let seconds: number;
+        if (typeof value === 'string')
+          seconds = parseFloat(value);
+        else if (typeof value === 'number')
+          seconds = value;
+        else
           return;
-        options['FlagTimeoutMs'] = value * 1000;
+        options['FlagTimeoutMs'] = seconds * 1000;
       },
     },
     {
@@ -187,9 +192,14 @@ UserConfig.registerOptions('eureka', {
       type: 'float',
       default: 1,
       setterFunc: (options, value) => {
-        if (typeof value !== 'number')
+        let seconds: number;
+        if (typeof value === 'string')
+          seconds = parseFloat(value);
+        else if (typeof value === 'number')
+          seconds = value;
+        else
           return;
-        options['RefreshRateMs'] = value * 1000;
+        options['RefreshRateMs'] = seconds * 1000;
       },
     },
   ],


### PR DESCRIPTION
This was causing flags to disappear instantly if you had ever
attempted to set a different time.

Fixes #3524.