### PR TITLE
raidboss: add config/testing early out for e12s lion tethers

### DIFF
--- a/ui/raidboss/data/05-shb/raid/e12s.ts
+++ b/ui/raidboss/data/05-shb/raid/e12s.ts
@@ -1038,6 +1038,9 @@ const triggerSet: TriggerSet<Data> = {
             en: 'SW Lion Tether',
           },
         };
+        if (!data.smallLions || data.smallLions.length === 0)
+          return;
+
         const lion = data.smallLions?.find((l) => l.id.toUpperCase() === matches.sourceId.toUpperCase());
         if (!lion) {
           console.error('Unable to locate a valid lion.');


### PR DESCRIPTION
The cactbot config UI calls all response functions in order to get
the output strings to display.  However, it doesn't have any state
at all, and so all response functions should be able to be called
with nothing in `data` and have no errors or output.

This prevents "Unable to locate a valid lion" from appearing when
starting cactbot. This is a fixup for #3571.