### PR TITLE
oopsy: fix off-center live list icons

### DIFF
--- a/ui/oopsyraidsy/oopsy_live.css
+++ b/ui/oopsyraidsy/oopsy_live.css
@@ -102,6 +102,7 @@ div {
 .mistake-icon {
   flex: 0 0 auto;
   order: 1;
+  justify-content: center;
 }
 
 .mistake-text {


### PR DESCRIPTION
This is a fixup for #3574, which caused these to be offcenter.