### PR TITLE
raidboss: improve alerts for "Formation: Sharp Turn"

### DIFF
--- a/ui/raidboss/data/05-shb/alliance/the_puppets_bunker.ts
+++ b/ui/raidboss/data/05-shb/alliance/the_puppets_bunker.ts
@@ -329,26 +329,26 @@ const triggerSet: TriggerSet<Data> = {
       },
     },
     {
-      id: 'Puppet Superior Sharp Turn Front/Inside',
+      id: 'Puppet Superior Sharp Turn Inside',
       type: 'StartsUsing',
       netRegex: NetRegexes.startsUsing({ id: ['4FA9', '5511', '5513'], capture: false }),
       suppressSeconds: 5,
       alertText: (_data, _matches, output) => output.text!(),
       outputStrings: {
         text: {
-          en: 'Move to Front/Inside',
+          en: 'Move to Inside',
         },
       },
     },
     {
-      id: 'Puppet Superior Sharp Turn Rear/Outside',
+      id: 'Puppet Superior Sharp Turn Outside',
       type: 'StartsUsing',
       netRegex: NetRegexes.startsUsing({ id: ['4FAA', '5512', '5514'], capture: false }),
       suppressSeconds: 5,
       alertText: (_data, _matches, output) => output.text!(),
       outputStrings: {
         text: {
-          en: 'Move to Rear/Outside',
+          en: 'Move to Outside',
         },
       },
     },


### PR DESCRIPTION
During Operated Superior Flight Units fight of The Puppets Bunker, the
units use a formation attack called "Formation: Sharp Turn" This attack
consists of the 3 units moving into a triangle formation, and then
charging across the screen. The first part of the attack consists of
a single setup skill, 4FAB which cactbot already has a trigger for.
After this resolves, the units then use a separate set of skills that
will be either a left-side based strike or a right-side based strike
charge.

Add triggers for these two abilities to allow alerting where the safe
spot is. For the 5513/5511/4FA9 set of abilities, the safe spot will be
to stand in the center of the arena between all 3 units. For the
5514/5512/4FAA abilities, the safe spot is to stand behind the units.

Fixes #3581

## TODO

I believe this is working properly, at least in the emulator against a network logs I have. I need to confirm again in a real fight. (Not sure best way to get this change into the real version I have loaded though).

- [ ] More live tests to verify things work and timing is good
- [ ] Check more log files