### PR TITLE
util: Typescriptify encounter_tools

### DIFF
--- a/resources/zone_info.ts
+++ b/resources/zone_info.ts
@@ -7437,4 +7437,4 @@ const data: ZoneInfoType = {
   },
 } as const;
 
-export default data;
+export { data, ZoneInfoType };

--- a/resources/zone_info.ts
+++ b/resources/zone_info.ts
@@ -7437,4 +7437,4 @@ const data: ZoneInfoType = {
   },
 } as const;
 
-export { data, ZoneInfoType };
+export default data;

--- a/util/logtools/encounter_tools.ts
+++ b/util/logtools/encounter_tools.ts
@@ -90,7 +90,7 @@ export class EncounterFinder {
 
   skipZone(): boolean {
     // We don't want combat from the overworld or from solo instanced duties.
-  // However, if we can't find zone info, we explicitly don't skip it.
+    // However, if we can't find zone info, we explicitly don't skip it.
     if (!this.currentZone.zoneId || !this.zoneInfo)
       return false;
     const content = this.zoneInfo.contentType;

--- a/util/logtools/encounter_tools.ts
+++ b/util/logtools/encounter_tools.ts
@@ -89,8 +89,6 @@ export class EncounterFinder {
   skipZone(): boolean {
     if (!this.currentZone.zoneId || !this.zoneInfo)
       return false;
-    if (!this.zoneInfo.contentType)
-      return false;
     const content = this.zoneInfo.contentType;
     if (!content)
       return false;

--- a/util/logtools/encounter_tools.ts
+++ b/util/logtools/encounter_tools.ts
@@ -1,6 +1,6 @@
 import ContentType from '../../resources/content_type';
 import NetRegexes from '../../resources/netregexes';
-import { data as ZoneInfo } from '../../resources/zone_info';
+import { default as ZoneInfo } from '../../resources/zone_info';
 import { CactbotBaseRegExp } from '../../types/net_trigger';
 import { LocaleText } from '../../types/trigger';
 import { commonReplacement, syncKeys } from '../../ui/raidboss/common_replacement';

--- a/util/logtools/encounter_tools.ts
+++ b/util/logtools/encounter_tools.ts
@@ -9,22 +9,22 @@ import { commonReplacement, syncKeys } from '../../ui/raidboss/common_replacemen
 // This can happen on partial logs.
 
 type ZoneEncInfo = {
-  name?: string | null;
-  zoneId?: number | null;
-  startLine?: string | null;
-  endLine?: string | null;
-  startTime?: Date | null;
-  endTime?: Date | null;
+  name?: string;
+  zoneId?: number;
+  startLine?: string;
+  endLine?: string;
+  startTime?: Date;
+  endTime?: Date;
 };
 
 type FightEncInfo = {
-  name?: string | null;
-  zoneId?: number | null;
-  startLine?: string | null;
-  endLine?: string | null;
-  startTime?: Date | null;
-  endTime?: Date | null;
-  endType?: string | null;
+  name?: string;
+  zoneId?: number;
+  startLine?: string;
+  endLine?: string;
+  startTime?: Date;
+  endTime?: Date;
+  endType?: string;
   sealName?: string;
 };
 
@@ -59,40 +59,14 @@ export class EncounterFinder {
   unsealRegexes: Array<CactbotBaseRegExp<'GameLog'>>;
 
   initializeZone(): void {
-    this.currentZone = {
-      name: null,
-      zoneId: null,
-      startLine: null,
-      endLine: null,
-      startTime: null,
-      endTime: null,
-    };
+    this.currentZone = {};
   }
   initializeFight(): void {
-    this.currentFight = {
-      name: null,
-      startLine: null,
-      endLine: null,
-      startTime: null,
-      endTime: null,
-    };
+    this.currentFight = {};
   }
   constructor() {
-    this.currentZone = {
-      name: null,
-      zoneId: null,
-      startLine: null,
-      endLine: null,
-      startTime: null,
-      endTime: null,
-    };
-    this.currentFight = {
-      name: null,
-      startLine: null,
-      endLine: null,
-      startTime: null,
-      endTime: null,
-    };
+    this.currentZone = {};
+    this.currentFight = {};
     this.currentSeal = null;
     // May be null for some zones.
     this.zoneInfo = null;
@@ -133,10 +107,10 @@ export class EncounterFinder {
   }
 
   skipZone(): boolean {
-    if (this?.currentZone?.zoneId === null || this.zoneInfo === null)
+    if (!this?.currentZone?.zoneId || this.zoneInfo === null)
       return false;
     const info = this.zoneInfo;
-    if ((info?.contentType) === null)
+    if (!(info?.contentType))
       return false;
     const content = info?.contentType;
     if (!content)
@@ -167,9 +141,9 @@ export class EncounterFinder {
 
       // If we changed zones, we have definitely stopped fighting.
       // Therefore we can safely initialize everything.
-      if (this.currentFight !== null)
+      if (this.currentFight.startTime)
         this.initializeFight();
-      if (this.currentZone !== null)
+      if (this.currentZone.startTime)
         this.initializeZone();
 
       this.haveWon = false;
@@ -190,33 +164,32 @@ export class EncounterFinder {
 
     const cW = this.regex.cactbotWipe.exec(line);
     if (cW?.groups) {
-      if (this.currentFight !== null)
+      if (this.currentFight.startTime)
         this.initializeFight();
       return;
     }
 
     const wipe = this.regex.wipe.exec(line);
     if (wipe?.groups) {
-      if (this.currentFight !== null)
+      if (this.currentFight.startTime)
         this.initializeFight();
       return;
     }
 
     const win = this.regex.win.exec(line);
     if (win?.groups) {
-      if (this.currentFight !== null) {
+      if (this.currentFight.startTime) {
         this.haveWon = true;
         this.initializeFight();
       }
       return;
     }
 
-    if (this.currentFight === null && !this.haveWon && !this.haveSeenSeals) {
+    if (!(this.currentFight.startTime || this.haveWon || this.haveSeenSeals)) {
       let a = this.regex.playerAttackingMob.exec(line);
       if (!a)
         a = this.regex.mobAttackingPlayer.exec(line);
       if (a?.groups) {
-        // TODO: maybe we should come up with a better name here?
         this.onStartFight(line, this.currentZone.name, a.groups);
         return;
       }
@@ -327,8 +300,8 @@ export class EncounterCollector extends EncounterFinder {
       this.lastFight.sealName = this.lastSeal;
   }
 
-  onUnseal(line: string, name: string, matches: RegExpMatchArray): void {
-    this.onEndFight(line, name, matches);
+  onUnseal(line: string, matches: RegExpMatchArray): void {
+    this.onEndFight(line, matches);
     this.lastSeal = null;
   }
 }

--- a/util/logtools/encounter_tools.ts
+++ b/util/logtools/encounter_tools.ts
@@ -88,10 +88,9 @@ export class EncounterFinder {
   skipZone(): boolean {
     if (!this.currentZone.zoneId || !this.zoneInfo)
       return false;
-    const info = this.zoneInfo;
-    if (!(info?.contentType))
+    if (!(this.zoneInfo.contentType))
       return false;
-    const content = info?.contentType;
+    const content = this.zoneInfo.contentType;
     if (!content)
       return false;
 
@@ -110,9 +109,9 @@ export class EncounterFinder {
   }
 
   process(line: string): void {
-    const cZ = this.regex.changeZone.exec(line);
-    if (cZ?.groups) {
-      if (this.currentZone.name === cZ.groups.name) {
+    const cZ = this.regex.changeZone.exec(line)?.groups;
+    if (cZ) {
+      if (this.currentZone.name === cZ.name) {
         // Zoning into the same zone, possibly a d/c situation.
         // Don't stop anything?
         return;
@@ -127,14 +126,14 @@ export class EncounterFinder {
 
       this.haveWon = false;
       this.haveSeenSeals = false;
-      this.zoneInfo = ZoneInfo[parseInt(cZ.groups.id, 16)];
+      this.zoneInfo = ZoneInfo[parseInt(cZ.id, 16)];
       if (this.skipZone()) {
         this.initializeZone();
         return;
       }
 
-      this.currentZone.name = cZ.groups.name;
-      this.onStartZone(line, this.currentZone.name, cZ.groups);
+      this.currentZone.name = cZ.name;
+      this.onStartZone(line, this.currentZone.name, cZ);
       return;
     }
 
@@ -142,21 +141,21 @@ export class EncounterFinder {
       return;
 
     const cW = this.regex.cactbotWipe.exec(line);
-    if (cW?.groups) {
+    if (cW) {
       if (this.currentFight.startTime)
         this.initializeFight();
       return;
     }
 
     const wipe = this.regex.wipe.exec(line);
-    if (wipe?.groups) {
+    if (wipe) {
       if (this.currentFight.startTime)
         this.initializeFight();
       return;
     }
 
     const win = this.regex.win.exec(line);
-    if (win?.groups) {
+    if (win) {
       if (this.currentFight.startTime) {
         this.haveWon = true;
         this.initializeFight();
@@ -175,11 +174,11 @@ export class EncounterFinder {
     }
 
     for (const regex of this.sealRegexes) {
-      const s = regex.exec(line);
-      if (s?.groups?.name) {
+      const s = regex.exec(line)?.groups;
+      if (s) {
         this.haveSeenSeals = true;
-        this.currentSeal = s.groups?.name;
-        this.onStartFight(line, this.currentSeal, s.groups);
+        this.currentSeal = s.name;
+        this.onStartFight(line, this.currentSeal, s);
         return;
       }
     }

--- a/util/logtools/encounter_tools.ts
+++ b/util/logtools/encounter_tools.ts
@@ -250,7 +250,7 @@ export class EncounterCollector extends EncounterFinder {
   }
 
   override onStartFight(line: string, name: string, matches: NetMatches['Ability' | 'GameLog']): void {
-    const id = this.lastZone.zoneId || 0;
+    const id = this.lastZone.zoneId ?? 0;
     this.lastFight = {
       name: name,
       startLine: line,

--- a/util/logtools/encounter_tools.ts
+++ b/util/logtools/encounter_tools.ts
@@ -89,6 +89,8 @@ export class EncounterFinder {
   }
 
   skipZone(): boolean {
+    // We don't want combat from the overworld or from solo instanced duties.
+  // However, if we can't find zone info, we explicitly don't skip it.
     if (!this.currentZone.zoneId || !this.zoneInfo)
       return false;
     const content = this.zoneInfo.contentType;
@@ -136,9 +138,12 @@ export class EncounterFinder {
       return;
     }
 
+    // If no zone change is found, we next verify that we are inside a combat zone.
     if (this.skipZone() || !this.currentZone.name)
       return;
 
+    // We are in a combat zone, so we next check for victory/defeat.
+    // If either is found, end the current encounter.
     const cW = this.regex.cactbotWipe.exec(line);
     if (cW) {
       if (this.currentFight.startTime)
@@ -162,6 +167,8 @@ export class EncounterFinder {
       return;
     }
 
+    // Most dungeons and some older raid content have zone zeals that indicate encounters.
+    // If they don't, we need to start encounters by looking for combat.
     if (!(this.currentFight.startTime || this.haveWon || this.haveSeenSeals)) {
       let a = this.regex.playerAttackingMob.exec(line);
       if (!a)
@@ -172,6 +179,7 @@ export class EncounterFinder {
       }
     }
 
+    // Once we see a seal, we know that we will be falling through to here throughout the zone.
     for (const regex of this.sealRegexes) {
       const s = regex.exec(line)?.groups;
       if (s) {

--- a/util/logtools/encounter_tools.ts
+++ b/util/logtools/encounter_tools.ts
@@ -86,7 +86,7 @@ export class EncounterFinder {
   }
 
   skipZone(): boolean {
-    if (!this?.currentZone?.zoneId || !this.zoneInfo)
+    if (!this.currentZone.zoneId || !this.zoneInfo)
       return false;
     const info = this.zoneInfo;
     if (!(info?.contentType))
@@ -112,7 +112,7 @@ export class EncounterFinder {
   process(line: string): void {
     const cZ = this.regex.changeZone.exec(line);
     if (cZ?.groups) {
-      if (this?.currentZone?.name === cZ.groups.name) {
+      if (this.currentZone.name === cZ.groups.name) {
         // Zoning into the same zone, possibly a d/c situation.
         // Don't stop anything?
         return;

--- a/util/logtools/encounter_tools.ts
+++ b/util/logtools/encounter_tools.ts
@@ -88,7 +88,7 @@ export class EncounterFinder {
   skipZone(): boolean {
     if (!this.currentZone.zoneId || !this.zoneInfo)
       return false;
-    if (!(this.zoneInfo.contentType))
+    if (!this.zoneInfo.contentType)
       return false;
     const content = this.zoneInfo.contentType;
     if (!content)

--- a/util/logtools/encounter_tools.ts
+++ b/util/logtools/encounter_tools.ts
@@ -54,6 +54,8 @@ export class EncounterFinder {
   initializeZone(): void {
     this.currentZone = {};
     this.zoneInfo = undefined;
+    this.haveWon = false;
+    this.haveSeenSeals = false;
   }
   initializeFight(): void {
     this.currentFight = {};
@@ -123,8 +125,6 @@ export class EncounterFinder {
       if (this.currentZone.startTime)
         this.initializeZone();
 
-      this.haveWon = false;
-      this.haveSeenSeals = false;
       this.zoneInfo = ZoneInfo[parseInt(cZ.id, 16)];
       if (this.skipZone()) {
         this.initializeZone();

--- a/util/logtools/encounter_tools.ts
+++ b/util/logtools/encounter_tools.ts
@@ -1,7 +1,7 @@
 import ContentType from '../../resources/content_type';
 import NetRegexes from '../../resources/netregexes';
 import { UnreachableCode } from '../../resources/not_reached';
-import { default as ZoneInfo } from '../../resources/zone_info';
+import ZoneInfo from '../../resources/zone_info';
 import { NetMatches, NetAnyMatches } from '../../types/net_matches';
 import { CactbotBaseRegExp } from '../../types/net_trigger';
 import { commonReplacement, syncKeys } from '../../ui/raidboss/common_replacement';

--- a/util/logtools/encounter_tools.ts
+++ b/util/logtools/encounter_tools.ts
@@ -53,6 +53,7 @@ export class EncounterFinder {
 
   initializeZone(): void {
     this.currentZone = {};
+    this.zoneInfo = undefined;
   }
   initializeFight(): void {
     this.currentFight = {};

--- a/util/logtools/encounter_tools.ts
+++ b/util/logtools/encounter_tools.ts
@@ -30,13 +30,13 @@ type FightEncInfo = {
 };
 
 export class EncounterFinder {
-  currentZone: ZoneEncInfo;
-  currentFight: FightEncInfo;
+  currentZone: ZoneEncInfo = {};
+  currentFight: FightEncInfo = {};
   currentSeal?: string;
   zoneInfo?: typeof ZoneInfo[number];
 
-  haveWon: boolean;
-  haveSeenSeals: boolean;
+  haveWon = false;
+  haveSeenSeals = false;
 
   regex: {
     changeZone: CactbotBaseRegExp<'ChangeZone'>;
@@ -48,8 +48,8 @@ export class EncounterFinder {
     mobAttackingPlayer: CactbotBaseRegExp<'Ability'>;
   };
 
-  sealRegexes: Array<CactbotBaseRegExp<'GameLog'>>;
-  unsealRegexes: Array<CactbotBaseRegExp<'GameLog'>>;
+  sealRegexes: Array<CactbotBaseRegExp<'GameLog'>> = [];
+  unsealRegexes: Array<CactbotBaseRegExp<'GameLog'>> = [];
 
   initializeZone(): void {
     this.currentZone = {};
@@ -58,16 +58,8 @@ export class EncounterFinder {
     this.currentFight = {};
   }
   constructor() {
-    this.currentZone = {};
-    this.currentFight = {};
-    this.currentSeal;
-    this.zoneInfo;
-
-    this.haveWon = false;
-    this.haveSeenSeals = false;
-
     this.regex = {
-      changeZone: NetRegexes.changeZone({ id: '*' }),
+      changeZone: NetRegexes.changeZone(),
       cactbotWipe: NetRegexes.echo({ line: 'cactbot wipe.*?' }),
       win: NetRegexes.network6d({ command: '40000003' }),
       wipe: NetRegexes.network6d({ command: '40000010' }),
@@ -75,11 +67,6 @@ export class EncounterFinder {
       playerAttackingMob: NetRegexes.ability({ sourceId: '1.{7}', targetId: '4.{7}' }),
       mobAttackingPlayer: NetRegexes.ability({ sourceId: '4.{7}', targetId: '1.{7}' }),
     };
-
-    // TODO: consider also doing this with lang? But lang only deals with Regexes???
-    // Sorry, this is quite a bit of a hack.
-    this.sealRegexes = [];
-    this.unsealRegexes = [];
 
     const sealReplace = commonReplacement.replaceSync[syncKeys.seal];
     if (!sealReplace)
@@ -238,19 +225,13 @@ export class EncounterFinder {
 }
 
 export class EncounterCollector extends EncounterFinder {
-  zones: Array<ZoneEncInfo>;
-  fights: Array<FightEncInfo>;
-  lastZone: ZoneEncInfo;
-  lastFight: FightEncInfo;
+  zones: Array<ZoneEncInfo> = [];
+  fights: Array<FightEncInfo> = [];
+  lastZone: ZoneEncInfo = {};
+  lastFight: FightEncInfo = {};
   lastSeal?: string;
   constructor() {
     super();
-    this.zones = [];
-    this.fights = [];
-
-    this.lastZone = {};
-    this.lastFight = {};
-    this.lastSeal;
   }
 
   override onStartZone(line: string, name: string, matches: NetMatches['ChangeZone']): void {


### PR DESCRIPTION
This is the first in a series of changes to our timeline generation/testing ecosystem that will (or at least we hope) unify those utilities with the rest of the project. Rather than using naively re-implemented Python parsing for log lines, we can just drop the existing Typescript definitions in and use those to implement `make/test_timeline`.

I'm still not completely sure what I'm doing with Typescript here, but I did at least manage to clear the lint errors. I was mostly trying to convert the existing `encounter_tools.js` prototype for this particular PR. This isn't in any way intended to be final or polished, simply at a point where I've changed what I can and now need some input for what might need further changes and additions before an actual release.

I'm a little annoyed that we have to import `ZoneInfo` for just one check, but I'm not sure there's a better way to ensure "yes, we are in a combat instance".
