### PR TITLE
raidboss: add trigger for Bloody Sweep

### DIFF
--- a/ui/raidboss/data/05-shb/alliance/the_tower_at_paradigms_breach.ts
+++ b/ui/raidboss/data/05-shb/alliance/the_tower_at_paradigms_breach.ts
@@ -427,12 +427,8 @@ const triggerSet: TriggerSet<Data> = {
         return output.north!();
       },
       outputStrings: {
-        north: {
-          en: 'Go North',
-        },
-        south: {
-          en: 'Go South',
-        },
+        north: Outputs.north,
+        south: Outputs.south,
       },
     },
     {

--- a/ui/raidboss/data/05-shb/alliance/the_tower_at_paradigms_breach.ts
+++ b/ui/raidboss/data/05-shb/alliance/the_tower_at_paradigms_breach.ts
@@ -24,7 +24,6 @@ export interface Data extends RaidbossData {
 
 // TODO:
 //   Update Knave knockback directions to instead use cardinals
-//   Hansel and Gretel Bloody Sweep
 //   Hansel and Gretel Stronger Together Tethered
 //   Hansel & Gretel Passing Lance
 //   Hansel & Gretel Breakthrough
@@ -401,6 +400,40 @@ const triggerSet: TriggerSet<Data> = {
       netRegexCn: NetRegexes.startsUsing({ id: '5C7[34]', source: ['韩塞尔', '格雷特'], capture: false }),
       netRegexKo: NetRegexes.startsUsing({ id: '5C7[34]', source: ['헨젤', '그레텔'], capture: false }),
       response: Responses.aoe(),
+    },
+    {
+      id: 'Paradigm Hansel/Gretel Bloody Sweep',
+      type: 'StartsUsing',
+      netRegex: NetRegexes.startsUsing({ id: '5C5[4567]', source: ['Hansel', 'Gretel'] }),
+      delaySeconds: (_data, matches) => parseFloat(matches.castTime) - 5,
+      durationSeconds: 5,
+      suppressSeconds: 1,
+      alertText: (_data, matches, output) => {
+        if (matches.id === '5C54' || matches.id === '5C55') {
+          // Hansel is West and Gretel is East
+          if (parseFloat(matches.castTime) > 12) {
+            // Hansel and Gretel will switch places
+            return output.north!();
+          }
+          // Hansel and Gretel stay in same position
+          return output.south!();
+        }
+        // Gretel is West and Hansel is East
+        if (parseFloat(matches.castTime) > 12) {
+          // Hansel and Gretel will switch places
+          return output.south!();
+        }
+        // Hansel and Gretel stay in same position
+        return output.north!();
+      },
+      outputStrings: {
+        north: {
+          en: 'Go North',
+        },
+        south: {
+          en: 'Go South',
+        },
+      },
     },
     {
       id: 'Paradigm Red Girl Cruelty',

--- a/ui/raidboss/data/05-shb/alliance/the_tower_at_paradigms_breach.ts
+++ b/ui/raidboss/data/05-shb/alliance/the_tower_at_paradigms_breach.ts
@@ -408,6 +408,15 @@ const triggerSet: TriggerSet<Data> = {
       durationSeconds: 5,
       suppressSeconds: 1,
       alertText: (_data, matches, output) => {
+        // Hansel and Gretel each have unique abilities which indicate which
+        // side of the arena they're hitting. 5C54 and 5C55 indicate that
+        // Hansel is West and Gretel is East. Hansel is left handed, and
+        // Gretel is right handed. This allows us to identify the safe area
+        // as north or south based on ID. However, the two may swap places
+        // using Transference. If this is going to happen, the cast time of
+        // the ability will be extended from 7.7 seconds to 12.7 seconds.
+        // Use an average of 10 to decide which ability we're seeing in case
+        // values are slightly adjusted in the future.
         if (matches.id === '5C54' || matches.id === '5C55') {
           // Hansel is West and Gretel is East
           if (parseFloat(matches.castTime) > 10) {

--- a/ui/raidboss/data/05-shb/alliance/the_tower_at_paradigms_breach.ts
+++ b/ui/raidboss/data/05-shb/alliance/the_tower_at_paradigms_breach.ts
@@ -411,7 +411,7 @@ const triggerSet: TriggerSet<Data> = {
       alertText: (_data, matches, output) => {
         if (matches.id === '5C54' || matches.id === '5C55') {
           // Hansel is West and Gretel is East
-          if (parseFloat(matches.castTime) > 12) {
+          if (parseFloat(matches.castTime) > 10) {
             // Hansel and Gretel will switch places
             return output.north!();
           }
@@ -419,7 +419,7 @@ const triggerSet: TriggerSet<Data> = {
           return output.south!();
         }
         // Gretel is West and Hansel is East
-        if (parseFloat(matches.castTime) > 12) {
+        if (parseFloat(matches.castTime) > 10) {
           // Hansel and Gretel will switch places
           return output.south!();
         }

--- a/ui/raidboss/data/05-shb/alliance/the_tower_at_paradigms_breach.ts
+++ b/ui/raidboss/data/05-shb/alliance/the_tower_at_paradigms_breach.ts
@@ -405,7 +405,6 @@ const triggerSet: TriggerSet<Data> = {
       id: 'Paradigm Hansel/Gretel Bloody Sweep',
       type: 'StartsUsing',
       netRegex: NetRegexes.startsUsing({ id: '5C5[4567]', source: ['Hansel', 'Gretel'] }),
-      delaySeconds: (_data, matches) => parseFloat(matches.castTime) - 5,
       durationSeconds: 5,
       suppressSeconds: 1,
       alertText: (_data, matches, output) => {


### PR DESCRIPTION
Hansel and Gretel use "Tandem Assault: Bloody Sweep" as a combo move
which will either sweep the outsides and mainly the south half of the
arena, or sweep the insides hitting mainly the north half of the arena.
Players need to move south or north depending on the position of Hansel
and Gretel. Sometimes, the two bosses will use "Transference" and switch
places.

Add a trigger which detects the relevant IDs and issues an alert on
whether ot move south or north. We can be clever by using a few facts:

* Hansel is left handed, and Gretel is right handed
* The ID indicates which position Hansel or Gretel will be at start
* The cast time can determine whether or not they switch places

Using this information we can use a single strigger which determines the
side of the arena which is safe.

Signed-off-by: Jacob Keller <jacob.keller@gmail.com>