### PR TITLE
util: remove duplicate declaration

### DIFF
--- a/types/data.d.ts
+++ b/types/data.d.ts
@@ -36,7 +36,6 @@ export interface RaidbossData {
   CanCleanse: () => boolean;
   CanFeint: () => boolean;
   CanAddle: () => boolean;
-  StopCombat: () => void;
 }
 
 export interface OopsyData {


### PR DESCRIPTION
in line 30 there is a same declaration already

Besides, there is no `scope` for a type only change.