### PR TITLE
oopsy: add current hp to death reports

### DIFF
--- a/ui/oopsyraidsy/death_report.ts
+++ b/ui/oopsyraidsy/death_report.ts
@@ -227,6 +227,10 @@ export class DeathReport {
     const splitLine = event.splitLine;
     const ability = processAbilityLine(splitLine);
 
+    // Zero damage abilities can be noisy and don't contribute much information, so skip.
+    if (ability.amount === 0)
+      return;
+
     let amount;
 
     let amountClass: string | undefined;

--- a/ui/oopsyraidsy/death_report.ts
+++ b/ui/oopsyraidsy/death_report.ts
@@ -12,7 +12,6 @@ import {
 } from './oopsy_common';
 
 // TODO: lots of things left to do with death reports
-// * include current hp on each line and then display that somewhere/somehow?
 // * probably include max hp as well?
 // * handle DeathReason (right now it is not shown, other than in the summary line)
 // * include other mistakes (simple / triggers)
@@ -23,7 +22,6 @@ import {
 //   * also need to track effects that are active prior to the set of events passed in
 //   * also need to handle effects lost (and gained?!) after death
 // * consolidate multiple damage that killed (e.g. Solemn Confiteor x4) into summary text
-// * maybe show death icon on damage we believe killed the player?
 // * maybe if a player is fully healed, trim abilities before that?
 
 const processAbilityLine = (splitLine: string[]) => {
@@ -51,7 +49,9 @@ export type ParsedDeathReportLine = {
   timestamp: number;
   timestampStr: string;
   type: TrackedLineEventType;
-  amount?: string;
+  currentHp?: number;
+  amount?: number;
+  amountStr?: string;
   amountClass?: string;
   icon?: string;
   text?: string;
@@ -138,6 +138,9 @@ export class DeathReport {
 
     this.parsedReportLines = [];
 
+    let lastCertainHp: number | undefined = undefined;
+    let currentHp: number | undefined = undefined;
+
     for (const event of this.events) {
       let parsed: ParsedDeathReportLine | undefined = undefined;
       if (event.type === 'Ability')
@@ -147,8 +150,37 @@ export class DeathReport {
       else if (event.type === 'MissedAbility' || event.type === 'MissedEffect')
         parsed = this.processMissedBuff(event);
 
-      if (parsed)
-        this.parsedReportLines.push(parsed);
+      if (!parsed)
+        continue;
+
+      // Touch up the hp so it looks more valid.  There are only hp fields on certain
+      // log lines, and more importantly it is polled from memory.  Therefore, if a
+      // player takes a bunch of attacks simultaneously, the hp will be the same on
+      // every line.  This looks incorrect, so do our best to fix this up.
+      if (currentHp === undefined || lastCertainHp === undefined) {
+        // If we haven't seen any log lines with hp yet, try to set it as an initial guess.
+        currentHp = parsed.currentHp;
+        lastCertainHp = parsed.currentHp;
+      } else if (parsed.currentHp !== lastCertainHp) {
+        // If we see a new hp value, then this is likely valid.
+        currentHp = lastCertainHp = parsed.currentHp;
+      } else {
+        // For log lines that don't have a hitpoints line, fill in our best guess.
+        // Or, we're seeing an identical hp value, so use previously adjusted amount.
+        parsed.currentHp = currentHp;
+      }
+
+      if (currentHp !== undefined && parsed.amount !== undefined) {
+        // If this attack killed somebody (or this is overkill), set an icon unless there's
+        // already a mistake icon set.  Don't do this for belated heals because it looks weird.
+        if (currentHp <= 0 || currentHp <= parsed.amount && parsed.amount > 0)
+          parsed.icon ??= 'death';
+      }
+
+      this.parsedReportLines.push(parsed);
+
+      if (currentHp !== undefined && parsed.amount !== undefined)
+        currentHp -= parsed.amount;
     }
 
     return this.parsedReportLines;
@@ -192,10 +224,7 @@ export class DeathReport {
 
   private processAbility(event: TrackedLineEvent): ParsedDeathReportLine | undefined {
     const splitLine = event.splitLine;
-
-    const ability = processAbilityLine(event.splitLine);
-    if (ability.amount === 0)
-      return;
+    const ability = processAbilityLine(splitLine);
 
     let amountClass: string | undefined;
     let amountStr: string | undefined;
@@ -213,11 +242,15 @@ export class DeathReport {
       return;
 
     const abilityName = splitLine[logDefinitions.Ability.fields.ability] ?? '???';
+    const currentHpStr = splitLine[logDefinitions.Ability.fields.targetCurrentHp];
+    const currentHp = currentHpStr !== undefined ? parseInt(currentHpStr) : 0;
     return {
       timestamp: event.timestamp,
       timestampStr: this.makeRelativeTimeString(event.timestamp),
       type: event.type,
-      amount: amountStr,
+      currentHp: currentHp,
+      amount: ability.amount,
+      amountStr: amountStr,
       amountClass: amountClass,
       icon: event.mistake,
       text: abilityName,
@@ -243,6 +276,9 @@ export class DeathReport {
       amountStr = amount > 0 ? `-${amount.toString()}` : amount.toString();
     }
 
+    const currentHpStr = event.splitLine[logDefinitions.NetworkDoT.fields.currentHp];
+    const currentHp = currentHpStr !== undefined ? parseInt(currentHpStr) : 0;
+
     // TODO: this line has an effect id, but we don't have an id -> string mapping for all ids.
     // We could consider looking this up in effects to try to find a name, but common ones
     // like Regen or Asylum aren't mapped there.
@@ -250,7 +286,9 @@ export class DeathReport {
       timestamp: event.timestamp,
       timestampStr: this.makeRelativeTimeString(event.timestamp),
       type: event.type,
-      amount: amountStr,
+      currentHp: currentHp,
+      amount: amount,
+      amountStr: amountStr,
       amountClass: amountClass,
       text: which,
     };

--- a/ui/oopsyraidsy/oopsy_live.css
+++ b/ui/oopsyraidsy/oopsy_live.css
@@ -170,7 +170,11 @@ div {
 
 .death-details {
   display: grid;
-  grid-template-columns: minmax(50px, max-content) minmax(10px, max-content) auto auto;
+  grid-template-columns: max-content minmax(50px, max-content) minmax(10px, max-content) auto auto;
+}
+
+.death-row-hp {
+  text-align: right;
 }
 
 .death-row-amount {
@@ -196,6 +200,10 @@ div {
 
 .death-row-text {
   text-align: left;
+}
+
+.death-row-time {
+  text-align: right;
 }
 
 @keyframes fadeOut {

--- a/ui/oopsyraidsy/oopsy_live_list.ts
+++ b/ui/oopsyraidsy/oopsy_live_list.ts
@@ -119,7 +119,8 @@ export class DeathReportLive {
       this.AppendDetails(
         detailsDiv,
         event.timestampStr,
-        event.amount,
+        event.currentHp?.toString(),
+        event.amountStr,
         event.amountClass,
         event.icon,
         event.text,
@@ -130,11 +131,18 @@ export class DeathReportLive {
   private AppendDetails(
     detailsDiv: HTMLElement,
     timestampStr: string,
+    currentHp?: string,
     amount?: string,
     amountClass?: string,
     icon?: string,
     text?: string,
   ): void {
+    const hpElem = document.createElement('div');
+    hpElem.classList.add('death-row-hp');
+    if (currentHp !== undefined)
+      hpElem.innerText = currentHp;
+    detailsDiv.appendChild(hpElem);
+
     const damageElem = document.createElement('div');
     damageElem.classList.add('death-row-amount');
     if (amountClass)

--- a/ui/oopsyraidsy/oopsy_summary.css
+++ b/ui/oopsyraidsy/oopsy_summary.css
@@ -123,7 +123,11 @@ html {
 .death-details.expanded {
   margin-left: 40px;
   display: grid;
-  grid-template-columns: minmax(50px, max-content) minmax(10px, max-content) max-content max-content;
+  grid-template-columns: max-content minmax(50px, max-content) minmax(10px, max-content) max-content max-content;
+}
+
+.death-row-hp {
+  text-align: right;
 }
 
 .death-row-amount {

--- a/ui/oopsyraidsy/oopsy_summary_list.ts
+++ b/ui/oopsyraidsy/oopsy_summary_list.ts
@@ -255,12 +255,18 @@ export class OopsySummaryList implements MistakeObserver {
     });
 
     for (const event of m.report.parseReportLines()) {
+      const hpElem = document.createElement('div');
+      hpElem.classList.add('death-row-hp');
+      if (event.currentHp !== undefined)
+        hpElem.innerText = event.currentHp.toString();
+      detailsDiv.appendChild(hpElem);
+
       const damageElem = document.createElement('div');
       damageElem.classList.add('death-row-amount');
       if (event.amountClass)
         damageElem.classList.add(event.amountClass);
-      if (event.amount !== undefined)
-        damageElem.innerText = event.amount;
+      if (event.amountStr !== undefined)
+        damageElem.innerText = event.amountStr;
       detailsDiv.appendChild(damageElem);
 
       const iconElem = document.createElement('div');

--- a/ui/oopsyraidsy/oopsyraidsy.html
+++ b/ui/oopsyraidsy/oopsyraidsy.html
@@ -25,47 +25,56 @@
             <input class="death-title-close" type="button" value="X"></input>
           </div>
           <div class="death-details">
+            <div class="death-row-hp">32000</div>
             <div class="death-row-amount damage">-3450</div>
             <div class="death-row-icon"></div>
             <div class="death-row-text">Attack</div>
             <div class="death-row-time">0:12</div>
 
+            <div class="death-row-hp">28550</div>
             <div class="death-row-amount heal">+15398</div>
             <div class="death-row-icon"></div>
             <div class="death-row-text">Adlo</div>
             <div class="death-row-time">0:14</div>
 
+            <div class="death-row-hp">43948</div>
             <div class="death-row-amount damage">-3237</div>
             <div class="death-row-icon"></div>
             <div class="death-row-text">Attack</div>
             <div class="death-row-time">0:16</div>
 
+            <div class="death-row-hp">40711</div>
             <div class="death-row-amount"></div>
             <div class="death-row-icon mistake-icon heal"></div>
             <div class="death-row-text">Missed: Divine Veil</div>
             <div class="death-row-time">0:20</div>
 
+            <div class="death-row-hp">40711</div>
             <div class="death-row-amount damage">-3891</div>
             <div class="death-row-icon"></div>
             <div class="death-row-text">Attack</div>
             <div class="death-row-time">0:22</div>
 
+            <div class="death-row-hp">36820</div>
             <div class="death-row-amount"></div>
             <div class="death-row-icon"></div>
             <div class="death-row-text">Gain: Vengeance</div>
             <div class="death-row-time">0:24</div>
 
+            <div class="death-row-hp">36820</div>
             <div class="death-row-amount damage">-14039</div>
             <div class="death-row-icon mistake-icon warn"></div>
             <div class="death-row-text">Glower</div>
             <div class="death-row-time">0:30</div>
 
-            <div class="death-row-amount damage">-40205</div>
+            <div class="death-row-hp">22781</div>
+            <div class="death-row-amount damage">-20205</div>
             <div class="death-row-icon"></div>
             <div class="death-row-text">Meteor</div>
             <div class="death-row-time">0:42</div>
 
-            <div class="death-row-amount damage">-40123</div>
+            <div class="death-row-hp">2576</div>
+            <div class="death-row-amount damage">-20123</div>
             <div class="death-row-icon"></div>
             <div class="death-row-text">Meteor</div>
             <div class="death-row-time">0:42</div>


### PR DESCRIPTION
This shows the current hp in the death report on each line prior
to taking damage.  Because current hp is polled from memory, this
value can be incorrect if the player takes a bunch of damage in
a row and so duplicate hp values try to estimate the correct value
by applying damage amounts.  This seems to be ~ok in practice,
but is a bit sketchy.