### PR TITLE
raidboss: add basic triggers for Angra Mainyu

### DIFF
--- a/ui/raidboss/data/02-arr/alliance/the_world_of_darkness.ts
+++ b/ui/raidboss/data/02-arr/alliance/the_world_of_darkness.ts
@@ -64,7 +64,6 @@ const triggerSet: TriggerSet<Data> = {
           // Stand in white half to switch to Sullen
           return output.white!();
         }
-        return output.vision!();
       },
       outputStrings: {
         red: {
@@ -72,9 +71,6 @@ const triggerSet: TriggerSet<Data> = {
         },
         white: {
           en: 'Stand in White Half',
-        },
-        vision: {
-          en: 'Double Vision',
         },
       },
     },

--- a/ui/raidboss/data/02-arr/alliance/the_world_of_darkness.ts
+++ b/ui/raidboss/data/02-arr/alliance/the_world_of_darkness.ts
@@ -1,0 +1,103 @@
+import Conditions from '../../../../../resources/conditions';
+import NetRegexes from '../../../../../resources/netregexes';
+import { Responses } from '../../../../../resources/responses';
+import ZoneId from '../../../../../resources/zone_id';
+import { RaidbossData } from '../../../../../types/data';
+import { TriggerSet } from '../../../../../types/trigger';
+
+export interface Data extends RaidbossData {
+  sullenDebuff?: boolean;
+  irefulDebuff?: boolean;
+}
+
+// TODO:
+//  Angra Mainyu
+//    Add Level 100 Flare
+//    Add Level 150 Doom
+//    Add Roulette?
+//    Add info text for add spawns?
+//  Five-Headed Dragon
+//  Howling Atomos
+//  Cerberus
+//  Cloud of Darkness
+
+const triggerSet: TriggerSet<Data> = {
+  zoneId: ZoneId.TheWorldOfDarkness,
+  triggers: [
+    {
+      id: 'Angra Mainyu Gain Sullen',
+      type: 'GainsEffect',
+      netRegex: NetRegexes.gainsEffect({ effectId: '27c' }),
+      condition: Conditions.targetIsYou(),
+      run: (data) => data.sullenDebuff = true,
+    },
+    {
+      id: 'Angra Mainyu Lose Sullen',
+      type: 'LosesEffect',
+      netRegex: NetRegexes.losesEffect({ effectId: '27c' }),
+      condition: Conditions.targetIsYou(),
+      run: (data) => data.sullenDebuff = false,
+    },
+    {
+      id: 'Angra Mainyu Gain Ireful',
+      type: 'GainsEffect',
+      netRegex: NetRegexes.gainsEffect({ effectId: '27d' }),
+      condition: Conditions.targetIsYou(),
+      run: (data) => data.irefulDebuff = true,
+    },
+    {
+      id: 'Angra Mainyu Lose Ireful',
+      type: 'LosesEffect',
+      netRegex: NetRegexes.losesEffect({ effectId: '27d' }),
+      condition: Conditions.targetIsYou(),
+      run: (data) => data.irefulDebuff = false,
+    },
+    {
+      id: 'Angra Mainyu Double Vision',
+      type: 'StartsUsing',
+      netRegex: NetRegexes.startsUsing({ id: 'CC8', source: 'Angra Mainyu', capture: false }),
+      alertText: (data, _matches, output) => {
+        if (data.sullenDebuff) {
+          // Stand in red half to switch to Ireful
+          return output.red!();
+        } else if (data.irefulDebuff) {
+          // Stand in white half to switch to Sullen
+          return output.white!();
+        }
+        return output.vision!();
+      },
+      outputStrings: {
+        red: {
+          en: 'Stand in Red Half',
+        },
+        white: {
+          en: 'Stand in White Half',
+        },
+        vision: {
+          en: 'Double Vision',
+        },
+      },
+    },
+    {
+      id: 'Angra Mainyu Mortal Gaze',
+      type: 'StartsUsing',
+      netRegex: NetRegexes.startsUsing({ id: ['CD1', 'DAB'], source: 'Angra Mainyu', capture: false }),
+      suppressSeconds: 0.1,
+      response: Responses.lookAway('alert'),
+    },
+    {
+      id: 'Angra Mainyu Gain Doom',
+      type: 'LosesEffect',
+      netRegex: NetRegexes.losesEffect({ effectId: 'd2' }),
+      condition: Conditions.targetIsYou(),
+      alarmText: (_data, _matches, output) => output.cleanse!(),
+      outputStrings: {
+        cleanse: {
+          en: 'Run to Cleanse Circle',
+        },
+      },
+    },
+  ],
+};
+
+export default triggerSet;

--- a/ui/raidboss/data/02-arr/alliance/the_world_of_darkness.ts
+++ b/ui/raidboss/data/02-arr/alliance/the_world_of_darkness.ts
@@ -6,7 +6,6 @@ import { RaidbossData } from '../../../../../types/data';
 import { TriggerSet } from '../../../../../types/trigger';
 
 export interface Data extends RaidbossData {
-  mainTank?: string;
   sullenDebuff?: boolean;
   irefulDebuff?: boolean;
 }
@@ -25,12 +24,6 @@ export interface Data extends RaidbossData {
 const triggerSet: TriggerSet<Data> = {
   zoneId: ZoneId.TheWorldOfDarkness,
   triggers: [
-    {
-      id: 'Angra Mainyu Auto',
-      type: 'Ability',
-      netRegex: NetRegexes.ability({ id: 'DB4', source: 'Angra Mainyu' }),
-      run: (data, matches) => data.mainTank = matches.target,
-    },
     {
       id: 'Angra Mainyu Gain Sullen',
       type: 'GainsEffect',
@@ -70,12 +63,7 @@ const triggerSet: TriggerSet<Data> = {
         } else if (data.irefulDebuff) {
           // Stand in front of boss in the white half to switch to Sullen
           return output.white!();
-        } else if (data.mainTank === data.me) {
-          // Main tank should stand in front
-          return output.white!();
         }
-        // Everyone else generally stand behind
-        return output.red!();
       },
       outputStrings: {
         red: {

--- a/ui/raidboss/data/02-arr/alliance/the_world_of_darkness.ts
+++ b/ui/raidboss/data/02-arr/alliance/the_world_of_darkness.ts
@@ -58,19 +58,19 @@ const triggerSet: TriggerSet<Data> = {
       netRegex: NetRegexes.startsUsing({ id: 'CC8', source: 'Angra Mainyu', capture: false }),
       alertText: (data, _matches, output) => {
         if (data.sullenDebuff) {
-          // Stand in red half to switch to Ireful
+          // Stand behind boss in the red half to switch to Ireful
           return output.red!();
         } else if (data.irefulDebuff) {
-          // Stand in white half to switch to Sullen
+          // Stand in front of boss in the white half to switch to Sullen
           return output.white!();
         }
       },
       outputStrings: {
         red: {
-          en: 'Stand in Red Half',
+          en: 'Get Behind (Red)',
         },
         white: {
-          en: 'Stand in White Half',
+          en: 'Get in Front (White)',
         },
       },
     },

--- a/ui/raidboss/data/02-arr/alliance/the_world_of_darkness.ts
+++ b/ui/raidboss/data/02-arr/alliance/the_world_of_darkness.ts
@@ -6,6 +6,7 @@ import { RaidbossData } from '../../../../../types/data';
 import { TriggerSet } from '../../../../../types/trigger';
 
 export interface Data extends RaidbossData {
+  mainTank?: string;
   sullenDebuff?: boolean;
   irefulDebuff?: boolean;
 }
@@ -24,6 +25,12 @@ export interface Data extends RaidbossData {
 const triggerSet: TriggerSet<Data> = {
   zoneId: ZoneId.TheWorldOfDarkness,
   triggers: [
+    {
+      id: 'Angra Mainyu Auto',
+      type: 'Ability',
+      netRegex: NetRegexes.ability({ id: 'DB4', source: 'Angra Mainyu' }),
+      run: (data, matches) => data.mainTank = matches.target,
+    },
     {
       id: 'Angra Mainyu Gain Sullen',
       type: 'GainsEffect',
@@ -63,7 +70,12 @@ const triggerSet: TriggerSet<Data> = {
         } else if (data.irefulDebuff) {
           // Stand in front of boss in the white half to switch to Sullen
           return output.white!();
+        } else if (data.mainTank === data.me) {
+          // Main tank should stand in front
+          return output.white!();
         }
+        // Everyone else generally stand behind
+        return output.red!();
       },
       outputStrings: {
         red: {

--- a/ui/raidboss/data/raidboss_manifest.txt
+++ b/ui/raidboss/data/raidboss_manifest.txt
@@ -1,6 +1,7 @@
 00-misc/general.ts
 00-misc/test.ts
 00-misc/test.txt
+02-arr/alliance/the_world_of_darkness.ts
 02-arr/dungeon/brayfloxs_longstop.ts
 02-arr/dungeon/haukke_manor.ts
 02-arr/raid/t1.ts


### PR DESCRIPTION
Angra Mainyu is the first boss of The World of Darkness alliance raid.
This boss has a few instant-death mechanics, including some basic
mechanics that are very easy to add triggers for.

Add a trigger for the "Mortal Gaze" mechanic. When this is cast, players
should look away. If they fail to look away, they acquire the Doom
debuff and will die in 10 seconds unless they reach a cleansing circle.
Add an alert for the look away, and an alarm for when doom is acquired.

Add a trigger for the "Double Vision" attack. This attack is cast
periodically, and damages players based on their debuff. The whole arena
lights up half red and half white. If the player is hit by the red area
they gain Ireful, and if they are hit by the white area they gain
Sullen. Repeated hits of the same color do increasing damage until it is
fatal. Keep track of the current debuff and warn the player of which
color to stand in based on this.

In the future, it would be nice to add some alerts for Level 100 Flare,
Level 150 Doom, and possibly the roulette mechanic. These are more
complex and have been skipped for now.

Signed-off-by: Jacob Keller <jacob.keller@gmail.com>