### PR TITLE
build: add failure exit code for tsc in process-triggers (#3640)

### DIFF
--- a/ui/config/general_config.ts
+++ b/ui/config/general_config.ts
@@ -1,3 +1,4 @@
+import { isLang } from '../../resources/languages';
 import UserConfig from '../../resources/user_config';
 
 UserConfig.registerOptions('general', {
@@ -98,9 +99,12 @@ UserConfig.registerOptions('general', {
       default: 'default',
       debug: true,
       setterFunc: (options, value) => {
+        if (typeof value !== 'string')
+          return;
         if (value === 'default')
           return;
-        options['DisplayLanguage'] = value;
+        if (isLang(value))
+          options['DisplayLanguage'] = value;
       },
     },
   ],

--- a/util/process_triggers_folder.ts
+++ b/util/process_triggers_folder.ts
@@ -133,7 +133,13 @@ const processAllFiles = async (root: string, tscCmd: string) => {
 
   // Generate javascript from typescript.
   // TODO: replace this with programatic use of TypeScript API.
-  execSync(tscCmd);
+  try {
+    execSync(tscCmd);
+  } catch (e) {
+    console.error(`Failed to run ${tscCmd}`);
+    console.error(e);
+    process.exit(6);
+  }
 
   // Process files.
   await walkDirAsync(root, async (filename) => processFile(filename));


### PR DESCRIPTION
See:
https://github.com/quisquous/cactbot/runs/4196260990?check_suite_focus=true

This caused #3613 to appear as if it was passing, when it did not.