### PR TITLE
raidboss: fix TEA type error

### DIFF
--- a/ui/raidboss/data/05-shb/ultimate/the_epic_of_alexander.ts
+++ b/ui/raidboss/data/05-shb/ultimate/the_epic_of_alexander.ts
@@ -491,16 +491,16 @@ const triggerSet: TriggerSet<Data> = {
       alertText: (data, matches, output) => {
         // data.puddle is set by 'TEA Wormhole TPS Strat' (or by some user trigger).
         // If that's disabled, this will still just call out puddle counts.
-        if (matches[1] === data.puddle)
+        if (matches[1] && parseInt(matches[1]) === data.puddle)
           return output.soakThisPuddle!({ num: matches[1] });
       },
       infoText: (data, matches, output) => {
-        if (matches[1] === data.puddle)
+        if (matches[1] && parseInt(matches[1]) === data.puddle)
           return;
         return output.puddle!({ num: matches[1] });
       },
       tts: (data, matches, output) => {
-        if (matches[1] === data.puddle)
+        if (matches[1] && parseInt(matches[1]) === data.puddle)
           return output.soakThisPuddleTTS!();
       },
       outputStrings: {


### PR DESCRIPTION
Found in #3613 that cause `process-triggers` failed.

EDIT:
Looks like this configuration
https://github.com/quisquous/cactbot/blob/e617b03118893f68b875f94968e819c13b06696e/tsconfig.json#L18
that cause this error not report by `npm run tsc-no-emit`,
If I comment this line and run `tsc`, errors in this PR would be reported normally,
But from [the description of this parameter in typescript official website](https://www.typescriptlang.org/tsconfig#noUncheckedIndexedAccess), I didn't found any related information that cause the problem.