### PR TITLE
util: Fix encounter_tools after Typescriptification

### DIFF
--- a/util/logtools/split_log.js
+++ b/util/logtools/split_log.js
@@ -190,7 +190,7 @@ const printCollectedFights = (collector) => {
   for (const fight of collector.fights) {
     // Add a zone name row when there's seal messages for clarity.
     if (!seenSeal && fight.sealName) {
-      outputRows.push(['', '', '', '', '~' + fight.name + '~', '']);
+      outputRows.push(['', '', '', '', '~' + fight.zoneName + '~', '']);
       seenSeal = true;
     } else if (seenSeal && !fight.sealName) {
       seenSeal = false;


### PR DESCRIPTION
Sorry this is so extensive! It turns out I didn't do anywhere near enough investigation on how the JS version of the utility actually *worked* before converting it. This restores it to (presumably) exact parity with the pre-Typescript version. Comparing output from this against the JS version, it's exactly the same for all More Than One logs I tried.

One thing that I think we should do in future is extract the various different operation points of `process()` out into helper functions. It's *really* long, and I found myself constantly scrolling up and down to verify what had or hadn't yet happened.

Perhaps the most significant change I made here was mostly eliminating the distinction between the data properties of `Finder` vs `Collector`. Thus, all functions, overridden or not, will refer to `current(Zone|Fight)` rather than `last(Zone|Fight)`. This eliminates a source of annoying bugs in the `process()` function, where there are references to one or the other, which leads to initialization functions hitting the wrong properties, or just not activating at all.

I noted it in-line, but if we don't explicitly check for seals when ending combat, stuff gets really weird. If there are seals present in the current zone, we want to use *only* seals for starting/stopping combat, since those are the only encounters we care about.

When assembling the `sealRegexes` array, we have to explicitly add in the check for whether `s.seal` is defined. This match is an element of the bare regex itself, and is *not* present in the `netLog` definition:
`/^(?<type>(?:00))\|(?<timestamp>(?:[^|]*))\|(?<code>(?:0839))\|(?<name>(?:[^|]*))\|(?<line>(?:(?<seal>.*?) will be sealed off.*?))\|/i`
 (The `name` property in the `netLog` definition is always the empty string.) This is less than ideal, but it's what we have to work with for now.

There's definitely more to be done, but I think this is a good stopping point in terms of "fix it but try not to make too many actual changes".