### PR TITLE
i18n: (raidboss) add and fix kr translations

### DIFF
--- a/ui/raidboss/data/00-misc/test.ts
+++ b/ui/raidboss/data/00-misc/test.ts
@@ -421,6 +421,13 @@ const triggerSet: TriggerSet<Data> = {
         'You bid farewell to the striking dummy': '.*나무인형에게 작별 인사를 합니다',
         'You bow courteously to the striking dummy': '.*나무인형에게 공손하게 인사합니다',
         'test sync': '테스트 싱크',
+        'You burst out laughing at the striking dummy': '.*나무인형을 보고 폭소를 터뜨립니다',
+        'cactbot lang': 'cactbot 언어',
+        'cactbot test response': 'cactbot 응답 테스트',
+        'cactbot test watch': 'cactbot 탐지 테스트',
+        'You clap for the striking dummy': '.*나무인형에게 박수를 보냅니다',
+        'You psych yourself up alongside the striking dummy': '.*나무인형에게 힘을 불어넣습니다',
+        'You poke the striking dummy': '.*나무인형을 쿡쿡 찌릅니다',
       },
       replaceText: {
         'Final Sting': '마지막 벌침',

--- a/ui/raidboss/data/02-arr/trial/titan-ex.ts
+++ b/ui/raidboss/data/02-arr/trial/titan-ex.ts
@@ -230,7 +230,6 @@ const triggerSet: TriggerSet<Data> = {
     },
     {
       'locale': 'ko',
-      'missingTranslations': true,
       'replaceSync': {
         'Bomb Boulder': '바위폭탄',
         'Granite Gaoler': '화강암 감옥',
@@ -246,6 +245,9 @@ const triggerSet: TriggerSet<Data> = {
         'Burst': '대폭발',
         'Bury': '충격',
         'Earthen Fury': '대지의 분노',
+        'Gaoler Adds': '화강암 감옥 등장',
+        'Gaoler Landslide': '화강암 감옥 산사태',
+        'Gaoler Tumult': '화강암 감옥 격진',
         'Geocrush': '대지 붕괴',
         '(?<! )Landslide': '산사태',
         'Mountain Buster': '산 쪼개기',

--- a/ui/raidboss/data/03-hw/alliance/dun_scaith.ts
+++ b/ui/raidboss/data/03-hw/alliance/dun_scaith.ts
@@ -1157,7 +1157,7 @@ const triggerSet: TriggerSet<Data> = {
         'Scathach': '스카하크',
         'Shadow Limb': '그림자 손',
         'Shadowcourt Jester': '여왕의 어릿광대',
-        'Shadows gather on the floor': '影之力正在向地面聚集',
+        'Shadows gather on the floor': '바닥에 그림자의 힘이 모여듭니다',
         'The Queen\'s Graces': '여왕의 방',
         'The Queen\'s Pride': '여왕의 사열 광장',
         'The Rostrum': '광대의 무대',

--- a/ui/raidboss/data/03-hw/dungeon/baelsars_wall.ts
+++ b/ui/raidboss/data/03-hw/dungeon/baelsars_wall.ts
@@ -291,7 +291,6 @@ const triggerSet: TriggerSet<Data> = {
     },
     {
       'locale': 'ko',
-      'missingTranslations': true,
       'replaceSync': {
         'Armored Weapon': '무장 병기',
         'Blade Of The Griffin': '그리핀의 검',
@@ -304,6 +303,7 @@ const triggerSet: TriggerSet<Data> = {
         'Via Praetoria': '근위대의 길',
       },
       'replaceText': {
+        '--teleport': '--순간 이동',
         'Assault Cannon': '맹공포',
         'Beak Of The Griffin': '그리핀의 부리',
         'Big Boot': '걷어차기',

--- a/ui/raidboss/data/03-hw/dungeon/gubal_library_hard.ts
+++ b/ui/raidboss/data/03-hw/dungeon/gubal_library_hard.ts
@@ -459,7 +459,6 @@ const triggerSet: TriggerSet<Data> = {
     },
     {
       'locale': 'ko',
-      'missingTranslations': true,
       'replaceSync': {
         'Behemoth Ward': '고서의 베히모스',
         'Demon of the Tome': '고서의 악마',

--- a/ui/raidboss/data/03-hw/dungeon/sohm_al_hard.ts
+++ b/ui/raidboss/data/03-hw/dungeon/sohm_al_hard.ts
@@ -331,6 +331,7 @@ const triggerSet: TriggerSet<Data> = {
     {
       'locale': 'ko',
       'replaceSync': {
+        'Gowrow': '가우로우',
         'The Wound': '영봉의 상처',
         'The Lava Tube': '대용암굴',
         'The Leightonward': '레이튼워드',

--- a/ui/raidboss/data/03-hw/dungeon/xelphatol.ts
+++ b/ui/raidboss/data/03-hw/dungeon/xelphatol.ts
@@ -261,7 +261,6 @@ const triggerSet: TriggerSet<Data> = {
     },
     {
       'locale': 'ko',
-      'missingTranslations': true,
       'replaceSync': {
         'Abalathian Hornbill': '아발라시아 뿔부리',
         'Dotoli Ciloc': '선풍의 도톨리 실록',
@@ -271,6 +270,7 @@ const triggerSet: TriggerSet<Data> = {
         'The Tlachtli': '타팍솔리 투기장',
         'The Vortex': '접신 제단',
         'Tozol Huatotl': '청풍의 토졸 후아토틀',
+        'Floating Turret': '기구 포탑',
       },
       'replaceText': {
         'Aerial Blast': '대기 폭발',

--- a/ui/raidboss/data/03-hw/trial/sephirot-ex.ts
+++ b/ui/raidboss/data/03-hw/trial/sephirot-ex.ts
@@ -135,13 +135,13 @@ const triggerSet: TriggerSet<Data> = {
     },
     {
       'locale': 'ko',
-      'missingTranslations': true,
       'replaceSync': {
         'Coronal Wind': '관상기류',
         'Sephirot': '세피로트',
         'Storm Of Words': '신언의 폭풍',
       },
       'replaceText': {
+        'Adds Spawn': '쫄 등장',
         'Ascension': '승천',
         'Chesed': '헤세드',
         'Da\'at': '다아트',

--- a/ui/raidboss/data/04-sb/alliance/orbonne_monastery.ts
+++ b/ui/raidboss/data/04-sb/alliance/orbonne_monastery.ts
@@ -1227,7 +1227,6 @@ const triggerSet: TriggerSet<Data> = {
     },
     {
       'locale': 'ko',
-      'missingTranslations': true,
       'replaceSync': {
         'Agrias': '성기사 아그리아스',
         'Aspersory': '성운의 물병',

--- a/ui/raidboss/data/04-sb/alliance/ridorana_lighthouse.ts
+++ b/ui/raidboss/data/04-sb/alliance/ridorana_lighthouse.ts
@@ -841,12 +841,11 @@ const triggerSet: TriggerSet<Data> = {
     },
     {
       'locale': 'ko',
-      'missingTranslations': true,
       'replaceSync': {
         'Archaeodemon': '원시 악마',
         'Belias, The Gigas': '마인 벨리아스',
         'Construct 7': '노동 7호',
-        'Dark Rain': '암운의 빗물',
+        'Dark Rain': '암흑의 빗물',
         'Echoes from Time\'s Garden': '아득한 시간의 정원',
         'Famfrit, The Darkening Cloud': '암흑의 구름 팜프리트',
         '(?<! )Gigas': '마인병',

--- a/ui/raidboss/data/04-sb/alliance/royal_city_of_rabanastre.ts
+++ b/ui/raidboss/data/04-sb/alliance/royal_city_of_rabanastre.ts
@@ -763,7 +763,6 @@ const triggerSet: TriggerSet<Data> = {
     },
     {
       'locale': 'ko',
-      'missingTranslations': true,
       'replaceSync': {
         'Aqua Sphere': '물 구체',
         'Archaeodemon': '원시 악마',
@@ -790,6 +789,8 @@ const triggerSet: TriggerSet<Data> = {
       'replaceText': {
         '--invulnerable--': '--무적--',
         '--lock out--': '--지역 분리--',
+        '--Shade Adds--': '--쫄 등장--',
+        '--Shard Adds--': '--결정 등장--',
         'Aqua Sphere Adds': '물 구체 생성',
         'Archaeodemon Adds': '원시 악마 생성',
         'Azure Guard Adds': '푸른 파수꾼 생성',

--- a/ui/raidboss/data/04-sb/dungeon/ala_mhigo.ts
+++ b/ui/raidboss/data/04-sb/dungeon/ala_mhigo.ts
@@ -298,7 +298,6 @@ const triggerSet: TriggerSet<Data> = {
     },
     {
       'locale': 'ko',
-      'missingTranslations': true,
       'replaceSync': {
         'Aulus Mal Asina': '아울루스 말 아시나',
         'Magitek Scorpion': '경비 전갈',
@@ -329,6 +328,7 @@ const triggerSet: TriggerSet<Data> = {
         'Storm, Swell, Sword': '비검 풍뇌요',
         'Storm\\?/Swell\\?(?!/Sword)': '뇌절?/풍단?',
         'Storm\\?/Swell\\?/Sword\\?': '뇌절?/풍단?/요도?',
+        'Swell/Sword': '풍단/요도',
         'Tail Laser': '꼬리 레이저',
         'Target Search': '대상 찾기',
         'Unmoving Troika': '부동삼단',

--- a/ui/raidboss/data/04-sb/dungeon/castrum_abania.ts
+++ b/ui/raidboss/data/04-sb/dungeon/castrum_abania.ts
@@ -295,7 +295,6 @@ const triggerSet: TriggerSet<Data> = {
     },
     {
       'locale': 'ko',
-      'missingTranslations': true,
       'replaceSync': {
         'Inferno': '인페르노',
         'Magna Roader': '마도 마그나로더',

--- a/ui/raidboss/data/04-sb/dungeon/doma_castle.ts
+++ b/ui/raidboss/data/04-sb/dungeon/doma_castle.ts
@@ -195,7 +195,6 @@ const triggerSet: TriggerSet<Data> = {
     },
     {
       'locale': 'ko',
-      'missingTranslations': true,
       'replaceSync': {
         'Hexadrone Bit': '헥사롤러 비트',
         'Hypertuned Grynewaht': '강화된 그륀바트',

--- a/ui/raidboss/data/04-sb/dungeon/ghimlyt_dark.ts
+++ b/ui/raidboss/data/04-sb/dungeon/ghimlyt_dark.ts
@@ -399,7 +399,6 @@ const triggerSet: TriggerSet<Data> = {
     },
     {
       'locale': 'ko',
-      'missingTranslations': true,
       'replaceSync': {
         'Annia Quo Soranus': '안니아 쿠오 소라누스',
         'Ceruleum Tank': '청린수 탱크',

--- a/ui/raidboss/data/04-sb/dungeon/kugane_castle.ts
+++ b/ui/raidboss/data/04-sb/dungeon/kugane_castle.ts
@@ -250,7 +250,6 @@ const triggerSet: TriggerSet<Data> = {
     },
     {
       'locale': 'ko',
-      'missingTranslations': true,
       'replaceSync': {
         'Daigoro': '다이고로',
         'Dojun-Maru': '도우준마루',

--- a/ui/raidboss/data/04-sb/dungeon/shisui_of_the_violet_tides.ts
+++ b/ui/raidboss/data/04-sb/dungeon/shisui_of_the_violet_tides.ts
@@ -205,7 +205,6 @@ const triggerSet: TriggerSet<Data> = {
     },
     {
       'locale': 'ko',
-      'missingTranslations': true,
       'replaceSync': {
         'Amikiri': '아미키리',
         'Naishi-No-Kami': '시스이 상궁',
@@ -216,6 +215,8 @@ const triggerSet: TriggerSet<Data> = {
         'The Harutsuge Gate': '하루츠게 문',
       },
       'replaceText': {
+        '--add--': '--쫄--',
+        '--adds--': '--쫄--',
         'Abyssal Volcano': '해저 화산',
         'Black Tide': '검은 파도',
         'Coriolis Kick': '태풍차기',

--- a/ui/raidboss/data/04-sb/dungeon/st_mocianne_hard.ts
+++ b/ui/raidboss/data/04-sb/dungeon/st_mocianne_hard.ts
@@ -386,7 +386,6 @@ const triggerSet: TriggerSet<Data> = {
     },
     {
       'locale': 'ko',
-      'missingTranslations': true,
       'replaceSync': {
         'Kingsloam': '진흙왕의 알현실',
         'Lakhamu': '라하무',

--- a/ui/raidboss/data/04-sb/dungeon/temple_of_the_fist.ts
+++ b/ui/raidboss/data/04-sb/dungeon/temple_of_the_fist.ts
@@ -370,7 +370,6 @@ const triggerSet: TriggerSet<Data> = {
     },
     {
       'locale': 'ko',
-      'missingTranslations': true,
       'replaceSync': {
         'Arbuda': '아부다',
         'Coeurl Smriti': '커얼 스므리티',
@@ -378,8 +377,10 @@ const triggerSet: TriggerSet<Data> = {
         'Guidance': '도령전',
         'Harmony': '음양원',
         'Ivon Coeurlfist': '쌍표범 이본',
+        'Tourmaline Pond': '물이끼 연못',
       },
       'replaceText': {
+        '--Smriti Appears--': '--스므리티 등장--',
         'Basic Instinct': '투쟁 본능',
         'Cardinal Shift': '사중 대회전',
         'Coeurl Whisper': '쌍표범 소환',

--- a/ui/raidboss/data/04-sb/eureka/eureka_hydatos.ts
+++ b/ui/raidboss/data/04-sb/eureka/eureka_hydatos.ts
@@ -84,7 +84,7 @@ const triggerSet: TriggerSet<Data> = {
       netRegexFr: NetRegexes.gameLog({ line: 'Votre personnage est inactif depuis 7 minutes.*?', capture: false }),
       netRegexJa: NetRegexes.gameLog({ line: '操作がない状態になってから7分が経過しました。.*?', capture: false }),
       netRegexCn: NetRegexes.gameLog({ line: '已经7分钟没有进行任何操作.*?', capture: false }),
-      netRegexKo: NetRegexes.gameLog({ line: '7분 동안 아무 조작을 하지 않았습니다..*?', capture: false }),
+      netRegexKo: NetRegexes.gameLog({ line: '7분 동안 아무 조작을 하지 않았습니다.*?', capture: false }),
       response: Responses.wakeUp(),
     },
     {
@@ -311,6 +311,7 @@ const triggerSet: TriggerSet<Data> = {
       netRegexFr: NetRegexes.dialog({ line: '[^:]*:Oui... Munderg, sens le feu embraser nos âmes.*?', capture: false }),
       netRegexJa: NetRegexes.dialog({ line: '[^:]*:白の妖槍「ムンジャルグ」、燃え上がれ！.*?', capture: false }),
       netRegexCn: NetRegexes.dialog({ line: '[^:]*:红颈妖枪，点燃一切！.*?', capture: false }),
+      netRegexKo: NetRegexes.dialog({ line: '[^:]*:하얀 요창 \'문데르크\'여, 불타올라라!.*?', capture: false }),
       condition: (data) => data.side === 'east',
       alertText: (_data, _matches, output) => output.getToIce!(),
       infoText: (_data, _matches, output) => output.switchMagia!(),
@@ -341,6 +342,7 @@ const triggerSet: TriggerSet<Data> = {
       netRegexFr: NetRegexes.dialog({ line: '[^:]*:C\'est bien, Munderg... Glace le sang de mes ennemis.*?', capture: false }),
       netRegexJa: NetRegexes.dialog({ line: '[^:]*:白の妖槍「ムンジャルグ」、震え凍れよ！.*?', capture: false }),
       netRegexCn: NetRegexes.dialog({ line: '[^:]*:红颈妖枪，冻结万物！.*?', capture: false }),
+      netRegexKo: NetRegexes.dialog({ line: '[^:]*:하얀 요창 \'문데르크\'여, 얼어붙어라!.*?', capture: false }),
       condition: (data) => data.side === 'east',
       alertText: (_data, _matches, output) => output.getToFire!(),
       infoText: (_data, _matches, output) => output.switchMagia!(),
@@ -1423,7 +1425,7 @@ const triggerSet: TriggerSet<Data> = {
     {
       'locale': 'ko',
       'replaceSync': {
-        '7 minutes have elapsed since your last activity..*?': '7분 동안 아무 조작을 하지 않았습니다..*?',
+        '7 minutes have elapsed since your last activity..*?': '7분 동안 아무 조작을 하지 않았습니다',
         'Absolute Virtue': '절대미덕',
         'Arsenal Centaur': '무기고 켄타우로스',
         'Art': '아르트',
@@ -1439,6 +1441,8 @@ const triggerSet: TriggerSet<Data> = {
         'Relative Virtue': '상대미덕',
         'Shadow': '프로토 오즈마의 그림자',
         'Streak Lightning': '연쇄 번개',
+        'Munderg, turn flesh to ash': '하얀 요창 \'문데르크\'여, 불타올라라!',
+        'Munderg, turn blood to ice': '하얀 요창 \'문데르크\'여, 얼어붙어라!',
         'The Lance of Virtue Containment Unit': '미덕의 창 봉인 구역',
         'The Shin-Zantetsuken Containment Unit': '진 참철검 봉인 구역',
         'The Proto Ozma Containment Unit': '프로토 오즈마 봉인 구역',

--- a/ui/raidboss/data/04-sb/trial/byakko-ex.ts
+++ b/ui/raidboss/data/04-sb/trial/byakko-ex.ts
@@ -443,12 +443,16 @@ const triggerSet: TriggerSet<Data> = {
     },
     {
       'locale': 'ko',
-      'missingTranslations': true,
       'replaceSync': {
         'Byakko': '백호',
         'Hakutei': '하얀 제왕',
+        'Twofold is my wrath, twice-cursed my foes!': '달려라! 나의 반신이여! 맞서는 자들에게 이빨과 발톱을 찔러넣어라!',
       },
       'replaceText': {
+        '--Hakutei Add--': '--하얀 제왕 등장--',
+        '--leap north--': '--보스 북쪽으로 이동--',
+        '--tiger targetable--': '--호랑이 타겟가능--',
+        '--tiger untargetable--': '--호랑이 타겟불가--',
         'Answer On High': '하늘의 번개',
         'Bombogenesis': '폭탄 저기압',
         'Clutch': '장악',
@@ -470,8 +474,6 @@ const triggerSet: TriggerSet<Data> = {
         'The Voice Of Thunder': '뇌성',
         'Unrelenting Anguish': '무간지옥',
         'White Herald': '제왕의 충격',
-        'leap north': '보스 북쪽으로 이동',
-        'tiger untargetable': '호랑이 타겟 불가',
       },
     },
   ],

--- a/ui/raidboss/data/04-sb/trial/byakko.ts
+++ b/ui/raidboss/data/04-sb/trial/byakko.ts
@@ -185,7 +185,6 @@ const triggerSet: TriggerSet<Data> = {
     },
     {
       'locale': 'ko',
-      'missingTranslations': true,
       'replaceSync': {
         'Aratama Force': '아라미타마 탄환',
         'Byakko': '백호',

--- a/ui/raidboss/data/04-sb/trial/shinryu-ex.ts
+++ b/ui/raidboss/data/04-sb/trial/shinryu-ex.ts
@@ -890,8 +890,8 @@ const triggerSet: TriggerSet<Data> = {
     },
     {
       'locale': 'ko',
-      'missingTranslations': true,
       'replaceSync': {
+        'Hakkinryu': '백금룡',
         'Left Wing': '왼쪽 날개',
         'Right Wing': '오른쪽 날개',
         'Shinryu': '신룡',
@@ -924,7 +924,7 @@ const triggerSet: TriggerSet<Data> = {
         'Meteor Impact': '운석 낙하',
         'Phase': '페이즈',
         'Protostar': '원시별',
-        'Reiyu Adds': '영룡 쫄',
+        'Reiryu Adds': '영룡 등장',
         'Second Wing': '두번째 날개',
         'Summon Icicle': '고드름 소환',
         'TAP BUTTON OR ELSE': '긴 급 조 작',

--- a/ui/raidboss/data/04-sb/trial/susano-ex.ts
+++ b/ui/raidboss/data/04-sb/trial/susano-ex.ts
@@ -372,7 +372,7 @@ const triggerSet: TriggerSet<Data> = {
       'replaceSync': {
         'Ame-No-Murakumo(?! )': '아메노무라쿠모',
         'Susano': '스사노오',
-        'Thunderhead': '번개 머리',
+        'Thunderhead': '번개구름',
         'Ama-No-Iwato': '신의 바위',
       },
       'replaceText': {

--- a/ui/raidboss/data/04-sb/trial/suzaku.ts
+++ b/ui/raidboss/data/04-sb/trial/suzaku.ts
@@ -47,6 +47,7 @@ const triggerSet: TriggerSet<Data> = {
           de: 'Verbindung auf DIR',
           fr: 'Lien sur VOUS',
           cn: '连线点名',
+          ko: '화염조 대상자',
         },
       },
     },

--- a/ui/raidboss/data/04-sb/trial/tsukuyomi-ex.ts
+++ b/ui/raidboss/data/04-sb/trial/tsukuyomi-ex.ts
@@ -501,7 +501,6 @@ const triggerSet: TriggerSet<Data> = {
     },
     {
       'locale': 'ko',
-      'missingTranslations': true,
       'replaceSync': {
         'Dancing Fan': '춤추는 부채',
         'Moondust': '달조각',

--- a/ui/raidboss/data/04-sb/trial/tsukuyomi.ts
+++ b/ui/raidboss/data/04-sb/trial/tsukuyomi.ts
@@ -297,7 +297,6 @@ const triggerSet: TriggerSet<Data> = {
     },
     {
       'locale': 'ko',
-      'missingTranslations': true,
       'replaceSync': {
         'Dancing Fan': '춤추는 부채',
         'Moonlight': '월광',
@@ -308,6 +307,8 @@ const triggerSet: TriggerSet<Data> = {
         'Tsukuyomi': '츠쿠요미',
       },
       'replaceText': {
+        '--Patriarch/Matriarch Adds--': '--양아버지/양어머니 등장--',
+        '--Empire/Homeland Adds--': '--제국 병사/도마인 등장--',
         'Antitwilight': '월하미인',
         'Bright Blade': '하현달 베기',
         'Concentrativity': '압축 검기',

--- a/ui/raidboss/data/04-sb/ultimate/ultima_weapon_ultimate.ts
+++ b/ui/raidboss/data/04-sb/ultimate/ultima_weapon_ultimate.ts
@@ -804,7 +804,7 @@ const triggerSet: TriggerSet<Data> = {
     {
       'locale': 'ko',
       'replaceSync': {
-        'Bomb Boulder': '화강암 감옥',
+        'Bomb Boulder': '바위폭탄',
         'Chirada': '치라다',
         'Garuda': '가루다',
         'Heehee HAHA hahaha HEEHEE haha HEEEEEE': '시작하자, 버러지들아',

--- a/ui/raidboss/data/05-shb/alliance/the_copied_factory.ts
+++ b/ui/raidboss/data/05-shb/alliance/the_copied_factory.ts
@@ -1239,6 +1239,12 @@ const triggerSet: TriggerSet<Data> = {
         'Warehouse A': '창고 A',
         'Warehouse B': '창고 B',
         'Warehouse C': '창고 C',
+        'The wall-mounted right arm begins to move': '벽면의 오른팔이 움직이기 시작합니다……!',
+        'The wall-mounted flamethrowers activate\.': '벽면의 화염 방사기가 가동되었습니다……!',
+        'The wall-mounted left arm begins to move': '벽면의 왼팔이 움직이기 시작합니다……!',
+        'You hear frenzied movement from machines beneath': '바닥 아래의 기계생명체가 수상한 움직임을 보입니다……!',
+        'The conveyer belts whirr to life!': '바닥의 컨베이어가 움직이기 시작합니다……!',
+        'Flammable oil is leaking from the floor': '바닥 밑에 가연성 액체가 차오릅니다……!',
       },
       'replaceText': {
         'Front(?!al)': '앞',

--- a/ui/raidboss/data/05-shb/dungeon/mt_gulg.ts
+++ b/ui/raidboss/data/05-shb/dungeon/mt_gulg.ts
@@ -402,9 +402,9 @@ const triggerSet: TriggerSet<Data> = {
     {
       'locale': 'ko',
       'replaceSync': {
-        'Forgiven Revelry': '得到宽恕的放纵',
-        'Forgiven Ambition': '得到宽恕的奢望',
-        'Forgiven Prejudice': '得到宽恕的偏见',
+        'Forgiven Revelry': '면죄된 환락',
+        'Forgiven Ambition': '면죄된 야망',
+        'Forgiven Prejudice': '면죄된 편견',
         'Forgiven Obscenity': '면죄된 외설',
         'Forgiven Cruelty': '면죄된 잔혹',
         'Forgiven Whimsy': '면죄된 변덕',

--- a/ui/raidboss/data/05-shb/eureka/bozjan_southern_front.ts
+++ b/ui/raidboss/data/05-shb/eureka/bozjan_southern_front.ts
@@ -177,7 +177,7 @@ const triggerSet: TriggerSet<Data> = {
       netRegexFr: NetRegexes.gameLog({ line: 'Votre personnage est inactif depuis 7 minutes.*?', capture: false }),
       netRegexJa: NetRegexes.gameLog({ line: '操作がない状態になってから7分が経過しました。.*?', capture: false }),
       netRegexCn: NetRegexes.gameLog({ line: '已经7分钟没有进行任何操作.*?', capture: false }),
-      netRegexKo: NetRegexes.gameLog({ line: '7분 동안 아무 조작을 하지 않았습니다..*?', capture: false }),
+      netRegexKo: NetRegexes.gameLog({ line: '7분 동안 아무 조작을 하지 않았습니다.*?', capture: false }),
       response: Responses.wakeUp(),
     },
     {
@@ -795,7 +795,7 @@ const triggerSet: TriggerSet<Data> = {
       netRegexFr: NetRegexes.gameLog({ line: 'Lyon attend des adversaires à sa taille sur la tribune des Souverains.*?', capture: false }),
       netRegexJa: NetRegexes.gameLog({ line: '獣王ライアンは、王者の円壇での戦いを望んでいるようだ.*?', capture: false }),
       netRegexCn: NetRegexes.gameLog({ line: '兽王莱昂似乎很期待在王者圆坛战斗！.*?', capture: false }),
-      netRegexKo: NetRegexes.gameLog({ line: '마수왕 라이언이 왕의 단상에서 싸우려고 합니다!', capture: false }),
+      netRegexKo: NetRegexes.gameLog({ line: '마수왕 라이언이 왕의 단상에서 싸우려고 합니다!.*?', capture: false }),
       alertText: (_data, _matches, output) => output.text!(),
       outputStrings: {
         text: {
@@ -1200,7 +1200,7 @@ const triggerSet: TriggerSet<Data> = {
         'Albeleo\'s Monstrosity': '알비레오의 야수',
         'Albeleo\'s Hrodvitnir': '알비레오의 흐로드비트니르',
         'Electric Charge': '번개기운',
-        '7 minutes have elapsed since your last activity..*?': '7분 동안 아무 조작을 하지 않았습니다..*?',
+        '7 minutes have elapsed since your last activity..*?': '7분 동안 아무 조작을 하지 않았습니다',
         '4Th Legion Helldiver': 'IV군단 헬다이버',
         'Adrammelech': '아드람멜렉',
         'Bladesmeet': '검들의 대광장',

--- a/ui/raidboss/data/05-shb/eureka/delubrum_reginae.ts
+++ b/ui/raidboss/data/05-shb/eureka/delubrum_reginae.ts
@@ -2072,7 +2072,6 @@ const triggerSet: TriggerSet<Data> = {
     },
     {
       'locale': 'ko',
-      'missingTranslations': true,
       'replaceSync': {
         'Seeker Avatar': '탐구의 분열체',
         'Aetherial Bolt': '마탄',

--- a/ui/raidboss/data/05-shb/eureka/delubrum_reginae_savage.ts
+++ b/ui/raidboss/data/05-shb/eureka/delubrum_reginae_savage.ts
@@ -3839,7 +3839,6 @@ const triggerSet: TriggerSet<Data> = {
     },
     {
       'locale': 'ko',
-      'missingTranslations': true,
       'replaceSync': {
         '(?<!Crowned )Marchosias': '마르코시아스',
         'Aetherial Bolt': '마탄',
@@ -3849,7 +3848,7 @@ const triggerSet: TriggerSet<Data> = {
         'Aetherial Ward': '마법 장벽',
         'Automatic Turret': '자동포탑',
         'Avowed Avatar': '맹세의 분열체',
-        'Ball Lightning': '전기 구체',
+        'Ball Lightning': '뇌구',
         'Ball Of Fire': '화염구',
         'Bicolor Golem': '두 빛깔 골렘',
         'Bozjan Phantom': '보즈야 유령',

--- a/ui/raidboss/data/05-shb/trial/emerald_weapon-ex.ts
+++ b/ui/raidboss/data/05-shb/trial/emerald_weapon-ex.ts
@@ -676,7 +676,6 @@ const triggerSet: TriggerSet<Data> = {
     },
     {
       'locale': 'ko',
-      'missingTranslations': true,
       'replaceSync': {
         'bitblade': '건블레이드 비트',
         'Black Wolf\'s Image': '가이우스의 환영',

--- a/ui/raidboss/data/05-shb/trial/hades-ex.ts
+++ b/ui/raidboss/data/05-shb/trial/hades-ex.ts
@@ -1132,6 +1132,7 @@ const triggerSet: TriggerSet<Data> = {
     {
       'locale': 'ko',
       'replaceSync': {
+        'Aetherial Gaol': '에테르 감옥',
         'Arcane Font': '입체 마법진',
         'Arcane Globe': '구체 마법진',
         'Ascian Prime\'s Shade': '아씨엔 프라임의 그림자',

--- a/ui/raidboss/data/05-shb/trial/ruby_weapon-ex.ts
+++ b/ui/raidboss/data/05-shb/trial/ruby_weapon-ex.ts
@@ -380,6 +380,7 @@ const triggerSet: TriggerSet<Data> = {
             de: '${dir} (${suffix})',
             ja: '${dir} (${suffix})',
             cn: '${dir} (${suffix})',
+            ko: '${dir} (${suffix})',
           },
           out: Outputs.out,
           in: Outputs.in,
@@ -950,6 +951,9 @@ const triggerSet: TriggerSet<Data> = {
         'Ruby Bit': '루비 비트',
         'Raven\'s Image': '넬의 환영',
         'Meteor': '메테오',
+        'Comet': '혜성',
+        'White Agony': '넬의 비탄',
+        'White Fury': '넬의 분노',
       },
       'replaceText': {
         '--cutscene--': '--컷신--',

--- a/ui/raidboss/data/05-shb/trial/titania-ex.ts
+++ b/ui/raidboss/data/05-shb/trial/titania-ex.ts
@@ -608,10 +608,10 @@ const triggerSet: TriggerSet<Data> = {
     },
     {
       'locale': 'ko',
-      'missingTranslations': true,
       'replaceSync': {
         'Spirit Of Dew': '물의 정령',
         'Spirit of Flame': '불의 정령',
+        'Spirit of Wood': '나무의 정령',
         'Titania': '티타니아',
         'Puck': '요정의 권속',
         'Peaseblossom': '콩나무',

--- a/ui/raidboss/data/05-shb/ultimate/the_epic_of_alexander.ts
+++ b/ui/raidboss/data/05-shb/ultimate/the_epic_of_alexander.ts
@@ -3359,6 +3359,7 @@ const triggerSet: TriggerSet<Data> = {
         'Brute Justice': '포악한 심판자',
         'Cruise Chaser': '순항추격기',
         'Jagd Doll': '인형 수렵병',
+        'Judgment Crystal': '심판의 결정체',
         'Liquid Hand': '액체 손',
         'Liquid Rage': '분노한 액체',
         'Living Liquid': '살아있는 액체',


### PR DESCRIPTION
<details>
<summary>Changed files</summary>

- 00-misc\test.ts
- 02-arr\trial\titan-ex.ts
- 03-hw
     - alliance\dun_scaith.ts
     - dungeon
         - baelsars_wall.ts
         - gubal_library_hard.ts
         - sohm_al_hard.ts
         - xelphatol.ts
     - trial\sephirot-ex.ts
- 04-sb
     - alliance
         - orbonne_monastery.ts
         - ridorana_lighthouse.ts
         - royal_city_of_rabanastre.ts
     - dungeon
         - ala_mhigo.ts
         - castrum_abania.ts
         - doma_castle.ts
         - ghimlyt_dark.ts
         - kugane_castle.ts
         - st_mocianne_hard.ts
         - temple_of_the_fist.ts
         - shisui_of_the_violet_tides.ts
     - trial
         - byakko-ex.ts
         - byakko.ts
         - shinryu-ex.ts
         - suzaku.ts
         - susano-ex.ts
         - tsukuyomi-ex.ts
         - tsukuyomi.ts
     - eureka\eureka_hydatos.ts
     - ultimate\ultima_weapon_ultimate.ts
- 05-shb
     - alliance\the_copied_factory.ts
     - dungeon\mt_gulg.ts
     - eureka
         - bozjan_southern_front.ts
         - delubrum_reginae.ts
         - delubrum_reginae_savage.ts
     - trial
         - emerald_weapon-ex.ts
         - hades-ex.ts
         - ruby_weapon-ex.ts
         - titania-ex.ts
     - ultimate\the_epic_of_alexander.ts

</details>

Now only raids and emulator remain.