### PR TITLE
raidboss: trigger on gain doom, not losing doom

### DIFF
--- a/ui/raidboss/data/02-arr/alliance/the_world_of_darkness.ts
+++ b/ui/raidboss/data/02-arr/alliance/the_world_of_darkness.ts
@@ -87,8 +87,8 @@ const triggerSet: TriggerSet<Data> = {
     },
     {
       id: 'Angra Mainyu Gain Doom',
-      type: 'LosesEffect',
-      netRegex: NetRegexes.losesEffect({ effectId: 'd2' }),
+      type: 'GainsEffect',
+      netRegex: NetRegexes.gainsEffect({ effectId: 'd2' }),
       condition: Conditions.targetIsYou(),
       alarmText: (_data, _matches, output) => output.cleanse!(),
       outputStrings: {


### PR DESCRIPTION
The trigger for Angra Mainyu's doom effect accidentally was set to
trigger when the player *lost* the doom effect. This should have been
a gainsEffect trigger. This way, the alert happens and warns the player
to properly cleanse the debuff. Fix this.

Fixes: 09d04fdb3d47 ("raidboss: add basic triggers for Angra Mainyu (#3614)")
Signed-off-by: Jacob Keller <jacob.keller@gmail.com>
