### PR TITLE
build: set disableHostCheck in webpack config

### DIFF
--- a/webpack/webpack.config.ts
+++ b/webpack/webpack.config.ts
@@ -77,6 +77,7 @@ export default (
     devServer: {
       contentBase: path.join(__dirname, '../dist'),
       writeToDisk: true,
+      disableHostCheck: true,
     },
     resolve: {
       extensions: ['.ts', '.js'],


### PR DESCRIPTION
This fixes constant errors on the config page when upgrading to CEF M95:
  [11/20/2021 11:14:48 AM] Info: OverlayControl: Invalid Host/Origin header
  [11/20/2021 11:14:48 AM] Info: OverlayControl: [WDS] Disconnected!