### PR TITLE
util: coinach add helper function that sorts keys

### DIFF
--- a/util/coinach.ts
+++ b/util/coinach.ts
@@ -154,6 +154,23 @@ export class CoinachWriter {
     return '.';
   }
 
+  sortObjByKeys(_obj: unknown): unknown {
+    const obj = _obj as Record<string, unknown>;
+    const out = Object
+      .keys((obj))
+      .sort()
+      .reduce((acc: Record<string, unknown>, key) => {
+        const nested = obj[key] as Record<string, unknown>;
+        if (nested && typeof nested === 'object' && !Array.isArray(nested))
+          acc[key] = this.sortObjByKeys(nested);
+        else
+          acc[key] = nested;
+
+        return acc;
+      }, {});
+    return out;
+  }
+
   async write(
     filename: string,
     scriptname: string,
@@ -162,7 +179,7 @@ export class CoinachWriter {
   ): Promise<void> {
     const fullPath = path.join(this.cactbotPath, filename);
 
-    let str = JSON.stringify(d, Object.keys(d).sort(), 2);
+    let str = JSON.stringify(this.sortObjByKeys(d), null, 2);
 
     // # make keys integers, remove leading zeroes.
     str = str.replace(/\'0*([0-9]+)\': {/, '$1: {');
@@ -206,7 +223,7 @@ export default ${str}`;
   ): Promise<void> {
     const fullPath = path.join(this.cactbotPath, filename);
 
-    let str = JSON.stringify(data, Object.keys(data).sort(), 2);
+    let str = JSON.stringify(this.sortObjByKeys(data), null, 2);
 
     // # make keys integers, remove leading zeroes.
     str = str.replace(/\'0*([0-9]+)\': {/, '$1: {');

--- a/util/coinach.ts
+++ b/util/coinach.ts
@@ -23,6 +23,10 @@ const defaultFfxivPaths = [
 if (process.env['CACTBOT_DEFAULT_FFXIV_PATH'])
   defaultFfxivPaths.push(process.env['CACTBOT_DEFAULT_FFXIV_PATH']);
 
+
+const isObject = (obj: unknown): obj is { [key: string]: unknown } =>
+  obj !== null && typeof obj === 'object' && !Array.isArray(obj);
+
 class CoinachError extends Error {
   constructor(message?: string, cmd?: string, output?: string) {
     const errorMessage = `message: ${message ?? ''}
@@ -154,14 +158,16 @@ export class CoinachWriter {
     return '.';
   }
 
-  sortObjByKeys(_obj: unknown): unknown {
-    const obj = _obj as Record<string, unknown>;
+  sortObjByKeys(obj: unknown): unknown {
+    if (!isObject(obj) || Array.isArray(obj))
+      return obj;
+
     const out = Object
       .keys((obj))
       .sort()
-      .reduce((acc: Record<string, unknown>, key) => {
-        const nested = obj[key] as Record<string, unknown>;
-        if (nested && typeof nested === 'object' && !Array.isArray(nested))
+      .reduce((acc: typeof obj, key) => {
+        const nested = obj[key];
+        if (isObject(nested))
           acc[key] = this.sortObjByKeys(nested);
         else
           acc[key] = nested;

--- a/util/coinach.ts
+++ b/util/coinach.ts
@@ -23,7 +23,6 @@ const defaultFfxivPaths = [
 if (process.env['CACTBOT_DEFAULT_FFXIV_PATH'])
   defaultFfxivPaths.push(process.env['CACTBOT_DEFAULT_FFXIV_PATH']);
 
-
 const isObject = (obj: unknown): obj is { [key: string]: unknown } =>
   obj !== null && typeof obj === 'object' && !Array.isArray(obj);
 


### PR DESCRIPTION
The original approach that calls
`JSON.stringify(data, Object.keys(data).sort(), 2)` works well
 in some situation, but it would
only sort the first dimention of the object,
and the worst thing is that it would drop nested object.
For example, call the function above with a object
like `{ foo: { bar: 1 } }`, the actual output would be
'{"foo":{}}' that lost nested object.

So the ideal way is to recursively sort keys before passing
to `JSON.stringify` function.