### PR TITLE
util: fix type of id in PlayerChangedEvent

### DIFF
--- a/types/event.d.ts
+++ b/types/event.d.ts
@@ -298,9 +298,9 @@ type PlayerChangedJobDetails<T> = {
 };
 
 type PlayerChangedBase = {
-  // Decimal player id, as a string.
-  // TODO: should the plugin emit a decimal number or a hex string instead?
-  id: string;
+  // Decimal player id.
+  // TODO: should the plugin emit a hex string instead?
+  id: number;
   name: string;
   level: number;
   currentHP: number;

--- a/ui/oopsyraidsy/damage_tracker.ts
+++ b/ui/oopsyraidsy/damage_tracker.ts
@@ -699,7 +699,7 @@ export class DamageTracker {
     this.job = e.detail.job;
     this.role = Util.jobToRole(this.job);
     this.ReloadTriggers();
-    this.playerStateTracker.SetPlayerId(parseInt(e.detail.id).toString(16));
+    this.playerStateTracker.SetPlayerId(e.detail.id.toString(16));
   }
 
   ProcessDataFiles(): void {

--- a/ui/raidboss/emulator/data/AnalyzedEncounter.ts
+++ b/ui/raidboss/emulator/data/AnalyzedEncounter.ts
@@ -80,7 +80,7 @@ export default class AnalyzedEncounter extends EventBus {
     const state = combatant.getState(timestamp);
     popupText?.OnPlayerChange({
       detail: {
-        id: combatant.id,
+        id: parseInt(combatant.id),
         name: combatant.name,
         job: job,
         level: combatant.level ?? 0,

--- a/ui/test/test.ts
+++ b/ui/test/test.ts
@@ -23,7 +23,7 @@ addOverlayListener('onPlayerChangedEvent', (e) => {
     name.innerText = e.detail.name;
   const playerId = document.getElementById('playerId');
   if (playerId)
-    playerId.innerText = parseInt(e.detail.id).toString(16);
+    playerId.innerText = e.detail.id.toString(16);
   const hp = document.getElementById('hp');
   if (hp)
     hp.innerText = `${e.detail.currentHP}/${e.detail.maxHP} (${e.detail.currentShield})`;


### PR DESCRIPTION
The comment says it is a decimal in string, but in my result, it outputs a number. Is it forgotten to change the type after changing the plugin side?

output
```js
{
    "id": 270203476, // <- number
    "level": 76,
    "name": "***",
    "job": "SAM",
    "currentHP": 63929,
    "maxHP": 63929,
    "currentMP": 10000,
    "maxMP": 10000,
    "currentTP": 0,
    "maxTP": 1000,
    "currentGP": 0,
    "maxGP": 0,
    "currentCP": 0,
    "maxCP": 0,
    "debugJob": " 00 00 00 00 00 00 00 00",
    "currentShield": 0,
    "pos": {
        "x": -548.21405,
        "y": -740.6234,
        "z": 56
    },
    "rotation": -1.58878767,
    "bait": 0,
    "jobDetail": {
        "kenki": 0,
        "meditationStacks": 0,
        "setsu": false,
        "getsu": false,
        "ka": false
    }
}
```