### PR TITLE
raidboss: Automated alpha conversion of ARR timelines

### DIFF
--- a/ui/raidboss/data/02-arr/raid/t10.txt
+++ b/ui/raidboss/data/02-arr/raid/t10.txt
@@ -4,7 +4,7 @@
 hideall "--Reset--"
 hideall "--sync--"
 
-0.0 "--reset--" sync / 21:........:40000010:/ window 100000 jump 0
+0.0 "--Reset--" sync / 21:........:40000010:/ window 100000 jump 0
 
 # Initial Phase: Tankbuster, Charge, Repeat
 0.0 "Start"

--- a/ui/raidboss/data/02-arr/raid/t10.txt
+++ b/ui/raidboss/data/02-arr/raid/t10.txt
@@ -4,20 +4,20 @@
 hideall "--Reset--"
 hideall "--sync--"
 
-0.0 "--Reset--" sync / 21:........:40000010:/ window 10000 jump 0
+0 "--Reset--" sync / 21:........:40000010:/ window 100000 jump 0
 
 # Initial Phase: Tankbuster, Charge, Repeat
 0.0 "Start"
 0.0 "--sync--" sync /:Engage!/ window 0,1
-0.0 "--sync--" sync / 00:0839:The Alpha Concourse will be sealed off/ window 5,5
-8.0 "Crackle Hiss" sync /:Imdugud:B55:/
-16.0 "Critical Rip" sync /:Imdugud:B56:/
-20.0 "Crackle Hiss" sync /:Imdugud:B55:/
-32.0 "Wild Charge" sync /:Imdugud:B5B:/ window 8,8
-36.0 "Crackle Hiss" sync /:Imdugud:B55:/
-51.0 "Spike Flail" #sync /:Imdugud:B57:/
-56.0 "Crackle Hiss" sync /:Imdugud:B55:/
-64.0 "Critical Rip" sync /:Imdugud:B56:/ window 20,20 jump 20
+0.0 "--sync--" sync / 00:0839::The Alpha Concourse will be sealed off/ window 5,5
+8.0 "Crackle Hiss" sync / 1[56]:Imdugud:B55:/
+16.0 "Critical Rip" sync / 1[56]:Imdugud:B56:/
+20.0 "Crackle Hiss" sync / 1[56]:Imdugud:B55:/
+32.0 "Wild Charge" sync / 1[56]:Imdugud:B5B:/ window 8,8
+36.0 "Crackle Hiss" sync / 1[56]:Imdugud:B55:/
+51.0 "Spike Flail" #sync / 1[56]:Imdugud:B57:/
+56.0 "Crackle Hiss" sync / 1[56]:Imdugud:B55:/
+64.0 "Critical Rip" sync / 1[56]:Imdugud:B56:/ window 20,20 jump 20
 # fake lookahead loop
 68.0 "Crackle Hiss"
 80.0 "Wild Charge"
@@ -25,48 +25,48 @@ hideall "--sync--"
 89.0 "Spike Flail"
 
 # 85% push into Adds Phase #1
-196.0 "--sync--" sync /:B5D:Imdugud/ window 200,0
-200.0 "Electrocharge" sync /:Imdugud:B5D:/ window 200,0
+196.0 "--sync--" sync / 14:Imdugud:B5D:/ window 200,0
+200.0 "Electrocharge" sync / 1[56]:Imdugud:B5D:/ window 200,0
 201.0 "2x Son / 2x Daughter Adds"
 
 # Mid Phase: Alternates Heat Lightning, Heat Lightning+Charge, Tankbuster, Repeat
-497.0 "--sync--" sync /:B5E:Imdugud/ window 500,0
-500.0 "Electric Burst" sync /:Imdugud:B5E:/ window 500,0
-509.2 "Heat Lightning" sync /:Imdugud:B5F:/
-528.1 "Crackle Hiss" sync /:Imdugud:B55:/
-535.2 "Heat Lightning" sync /:Imdugud:B5F:/
-541.9 "Wild Charge" sync /:Imdugud:B5B:/ window 8,8
-545.3 "Crackle Hiss" sync /:Imdugud:B55:/
-558.3 "Critical Rip" sync /:Imdugud:B56:/
-561.5 "Crackle Hiss" sync /:Imdugud:B55:/
+497.0 "--sync--" sync / 14:Imdugud:B5E:/ window 500,0
+500.0 "Electric Burst" sync / 1[56]:Imdugud:B5E:/ window 500,0
+509.2 "Heat Lightning" sync / 1[56]:Imdugud:B5F:/
+528.1 "Crackle Hiss" sync / 1[56]:Imdugud:B55:/
+535.2 "Heat Lightning" sync / 1[56]:Imdugud:B5F:/
+541.9 "Wild Charge" sync / 1[56]:Imdugud:B5B:/ window 8,8
+545.3 "Crackle Hiss" sync / 1[56]:Imdugud:B55:/
+558.3 "Critical Rip" sync / 1[56]:Imdugud:B56:/
+561.5 "Crackle Hiss" sync / 1[56]:Imdugud:B55:/
 # fake lookahead loop
-569.8 "Heat Lightning" sync /:Imdugud:B5F:/ window 20,20 jump 509.2
+569.8 "Heat Lightning" sync / 1[56]:Imdugud:B5F:/ window 20,20 jump 509.2
 588.7 "Crackle Hiss"
 595.8 "Heat Lightning"
 602.5 "Wild Charge"
 
 # 53% push into Adds Phase #2
-696.0 "--sync--" sync /:B5D:Imdugud/ window 200,0
-700.0 "Electrocharge" sync /:Imdugud:B5D:/ window 400,0
+696.0 "--sync--" sync / 14:Imdugud:B5D:/ window 200,0
+700.0 "Electrocharge" sync / 1[56]:Imdugud:B5D:/ window 400,0
 701.0 "2x Son / 2x Daughter Adds"
 736.0 "1x Son / 1x Daughter Adds"
 
 # Final Phase: Heat+Tether, Buster, Random Mechanic, Repeat
-997.0 "--sync--" sync /:B5E:Imdugud/ window 400,0
-1000.0 "Electric Burst" sync /:Imdugud:B5E:/ window 400,0
+997.0 "--sync--" sync / 14:Imdugud:B5E:/ window 400,0
+1000.0 "Electric Burst" sync / 1[56]:Imdugud:B5E:/ window 400,0
 
-1009.3 "Heat Lightning" sync /:Imdugud:B5F:/
-1013.5 "Cyclonic Chaos" sync /:Imdugud:B61:/
-1028.5 "Crackle Hiss" sync /:Imdugud:B55:/
+1009.3 "Heat Lightning" sync / 1[56]:Imdugud:B5F:/
+1013.5 "Cyclonic Chaos" sync / 1[56]:Imdugud:B61:/
+1028.5 "Crackle Hiss" sync / 1[56]:Imdugud:B55:/
 
-1035.8 "Critical Rip" sync /:Imdugud:B56:/ window 20,20
-1042.0 "Crackle Hiss" sync /:Imdugud:B55:/
+1035.8 "Critical Rip" sync / 1[56]:Imdugud:B56:/ window 20,20
+1042.0 "Crackle Hiss" sync / 1[56]:Imdugud:B55:/
 
 # Heat + Charge, OR Tether + Charge
 1058.0 "Random + Charge"
 
-1061.2 "Crackle Hiss" sync /:Imdugud:B55:/
-1089.2 "Heat Lightning" sync /:Imdugud:B5F:/ window 20,20 jump 1009.3
+1061.2 "Crackle Hiss" sync / 1[56]:Imdugud:B55:/
+1089.2 "Heat Lightning" sync / 1[56]:Imdugud:B5F:/ window 20,20 jump 1009.3
 1093.4 "Cyclonic Chaos"
 1108.4 "Crackle Hiss"
 1115.7 "Critical Rip"

--- a/ui/raidboss/data/02-arr/raid/t10.txt
+++ b/ui/raidboss/data/02-arr/raid/t10.txt
@@ -4,7 +4,7 @@
 hideall "--Reset--"
 hideall "--sync--"
 
-0 "--Reset--" sync / 21:........:40000010:/ window 100000 jump 0
+0.0 "--reset--" sync / 21:........:40000010:/ window 100000 jump 0
 
 # Initial Phase: Tankbuster, Charge, Repeat
 0.0 "Start"

--- a/ui/raidboss/data/02-arr/raid/t11.txt
+++ b/ui/raidboss/data/02-arr/raid/t11.txt
@@ -4,7 +4,7 @@
 hideall "--Reset--"
 hideall "--sync--"
 
-0.0 "--reset--" sync / 00:0839::.*is no longer sealed/ window 100000 jump 0
+0.0 "--Reset--" sync / 00:0839::.*is no longer sealed/ window 100000 jump 0
 
 ### Phase 1
 0.0 "Start"

--- a/ui/raidboss/data/02-arr/raid/t11.txt
+++ b/ui/raidboss/data/02-arr/raid/t11.txt
@@ -4,20 +4,20 @@
 hideall "--Reset--"
 hideall "--sync--"
 
-0.0 "--Reset--" sync / 00:0839:.*is no longer sealed/ window 10000 jump 0
+0 "--reset--" sync / 00:0839::.*is no longer sealed/ window 100000 jump 0
 
 ### Phase 1
 0.0 "Start"
 0.0 "--sync--" sync /:Engage!/ window 0,1
-0.0 "--sync--" sync / 00:0839:The Core Override will be sealed off/ window 10,10
-2.5 "--sync--" sync /:Kaliya:B6A:/ window 3,0
-9.4 "Resonance" sync /:Kaliya:B6B:/
+0.0 "--sync--" sync / 00:0839::The Core Override will be sealed off/ window 10,10
+2.5 "--sync--" sync / 1[56]:Kaliya:B6A:/ window 3,0
+9.4 "Resonance" sync / 1[56]:Kaliya:B6B:/
 
 19.7 "Nerve Gas"
 24.9 "Nerve Gas"
 30.1 "Nerve Gas"
-33.4 "Resonance" sync /:Kaliya:B6B:/
-38.6 "Resonance" sync /:Kaliya:B6B:/
+33.4 "Resonance" sync / 1[56]:Kaliya:B6B:/
+38.6 "Resonance" sync / 1[56]:Kaliya:B6B:/
 
 48.9 "Nerve Gas"
 54.1 "Nerve Gas"
@@ -26,23 +26,23 @@ hideall "--sync--"
 67.8 "Resonance"
 
 ### Phase 2 (90%)
-200.0 "Barofield" sync /:Kaliya:B6F:/ window 200,0
+200.0 "Barofield" sync / 1[56]:Kaliya:B6F:/ window 200,0
 
-208.0 "Seed Of The Sea/Rivers" sync /:Kaliya:B7[67]:/
-213.3 "Seed Of The Rivers/Sea" sync /:Kaliya:B7[67]:/
-217.5 "Resonance" sync /:Kaliya:B6B:/
-220.7 "Secondary Head Stun" sync /:Kaliya:B73:/
-225.8 "Secondary Head" sync /:Kaliya:B72:/
-226.9 "Main Head" sync /:Kaliya:B71:/
-231.1 "Resonance" sync /:Kaliya:B6B:/
+208.0 "Seed Of The Sea/Rivers" sync / 1[56]:Kaliya:B7[67]:/
+213.3 "Seed Of The Rivers/Sea" sync / 1[56]:Kaliya:B7[67]:/
+217.5 "Resonance" sync / 1[56]:Kaliya:B6B:/
+220.7 "Secondary Head Stun" sync / 1[56]:Kaliya:B73:/
+225.8 "Secondary Head" sync / 1[56]:Kaliya:B72:/
+226.9 "Main Head" sync / 1[56]:Kaliya:B71:/
+231.1 "Resonance" sync / 1[56]:Kaliya:B6B:/
 237.4 "Nerve Gas"
 242.5 "Nerve Gas"
 247.5 "Nerve Gas"
-250.8 "Resonance" sync /:Kaliya:B6B:/
+250.8 "Resonance" sync / 1[56]:Kaliya:B6B:/
 
-258.0 "Seed Of The Sea/Rivers" sync /:Kaliya:B7[67]:/
-263.3 "Seed Of The Rivers/Sea" sync /:Kaliya:B7[67]:/
-267.5 "Resonance" sync /:Kaliya:B6B:/ window 10,10 jump 217.5
+258.0 "Seed Of The Sea/Rivers" sync / 1[56]:Kaliya:B7[67]:/
+263.3 "Seed Of The Rivers/Sea" sync / 1[56]:Kaliya:B7[67]:/
+267.5 "Resonance" sync / 1[56]:Kaliya:B6B:/ window 10,10 jump 217.5
 270.7 "Secondary Head Stun"
 275.8 "Secondary Head"
 276.9 "Main Head"
@@ -59,108 +59,108 @@ hideall "--sync--"
 ### Phase 4 (nodes defeated)
 # this phase has different timings if you are soloing, sorry.
 # it's possible resonance timings are not reliable either.
-595.0 "--sync--" sync /:B78:Kaliya/ window 600,600
-600.0 "Emergency Mode" sync /:Kaliya:B78:/
+595.0 "--sync--" sync / 14:Kaliya:B78:/ window 600,600
+600.0 "Emergency Mode" sync / 1[56]:Kaliya:B78:/
 
-606.1 "Nerve Cloud" sync /:Kaliya:B79:/ window 100,100
-617.3 "Nanospore Jet" sync /:Kaliya:B7B:/ window 50,50
-625.4 "Resonance" sync /:Kaliya:B6B:/
-634.9 "Seed Of The Sea/Rivers" sync /:Kaliya:B7[67]:/
-639.7 "Seed Of The Rivers/Sea" sync /:Kaliya:B7[67]:/
+606.1 "Nerve Cloud" sync / 1[56]:Kaliya:B79:/ window 100,100
+617.3 "Nanospore Jet" sync / 1[56]:Kaliya:B7B:/ window 50,50
+625.4 "Resonance" sync / 1[56]:Kaliya:B6B:/
+634.9 "Seed Of The Sea/Rivers" sync / 1[56]:Kaliya:B7[67]:/
+639.7 "Seed Of The Rivers/Sea" sync / 1[56]:Kaliya:B7[67]:/
 644.1 "Nerve Gas"
 649.2 "Nerve Gas"
 654.3 "Nerve Gas"
-658.6 "Secondary Head Stun" sync /:Kaliya:B73:/
-663.7 "Secondary Head" sync /:Kaliya:B72:/
-664.8 "Main Head" sync /:Kaliya:B71:/
-668.1 "Resonance" sync /:Kaliya:B6B:/
+658.6 "Secondary Head Stun" sync / 1[56]:Kaliya:B73:/
+663.7 "Secondary Head" sync / 1[56]:Kaliya:B72:/
+664.8 "Main Head" sync / 1[56]:Kaliya:B71:/
+668.1 "Resonance" sync / 1[56]:Kaliya:B6B:/
 
-677.2 "Nanospore Jet" sync /:Kaliya:B7B:/ window 50,50
-685.3 "Resonance" sync /:Kaliya:B6B:/
-694.6 "Seed Of The Sea/Rivers" sync /:Kaliya:B7[67]:/
-699.6 "Seed Of The Rivers/Sea" sync /:Kaliya:B7[67]:/
+677.2 "Nanospore Jet" sync / 1[56]:Kaliya:B7B:/ window 50,50
+685.3 "Resonance" sync / 1[56]:Kaliya:B6B:/
+694.6 "Seed Of The Sea/Rivers" sync / 1[56]:Kaliya:B7[67]:/
+699.6 "Seed Of The Rivers/Sea" sync / 1[56]:Kaliya:B7[67]:/
 704.0 "Nerve Gas"
 709.0 "Nerve Gas"
 714.1 "Nerve Gas"
-718.4 "Secondary Head Stun" sync /:Kaliya:B73:/
-723.6 "Secondary Head" sync /:Kaliya:B72:/
-724.7 "Main Head" sync /:Kaliya:B71:/
-727.9 "Resonance" sync /:Kaliya:B6B:/
+718.4 "Secondary Head Stun" sync / 1[56]:Kaliya:B73:/
+723.6 "Secondary Head" sync / 1[56]:Kaliya:B72:/
+724.7 "Main Head" sync / 1[56]:Kaliya:B71:/
+727.9 "Resonance" sync / 1[56]:Kaliya:B6B:/
 
-733.9 "Nerve Cloud" sync /:Kaliya:B79:/ window 100,100
-745.1 "Nanospore Jet" sync /:Kaliya:B7B:/ window 50,50
+733.9 "Nerve Cloud" sync / 1[56]:Kaliya:B79:/ window 100,100
+745.1 "Nanospore Jet" sync / 1[56]:Kaliya:B7B:/ window 50,50
 756.2 "Nerve Gas"
 761.3 "Nerve Gas"
 766.4 "Nerve Gas"
-768.6 "Resonance" sync /:Kaliya:B6B:/
-779.7 "Seed Of The Sea/Rivers" sync /:Kaliya:B7[67]:/
-784.8 "Seed Of The Rivers/Sea" sync /:Kaliya:B7[67]:/
-785.0 "Resonance" sync /:Kaliya:B6B:/
-787.1 "Secondary Head Stun" sync /:Kaliya:B73:/
-792.2 "Secondary Head" sync /:Kaliya:B72:/
-793.3 "Main Head" sync /:Kaliya:B71:/
+768.6 "Resonance" sync / 1[56]:Kaliya:B6B:/
+779.7 "Seed Of The Sea/Rivers" sync / 1[56]:Kaliya:B7[67]:/
+784.8 "Seed Of The Rivers/Sea" sync / 1[56]:Kaliya:B7[67]:/
+785.0 "Resonance" sync / 1[56]:Kaliya:B6B:/
+787.1 "Secondary Head Stun" sync / 1[56]:Kaliya:B73:/
+792.2 "Secondary Head" sync / 1[56]:Kaliya:B72:/
+793.3 "Main Head" sync / 1[56]:Kaliya:B71:/
 
-804.7 "Nanospore Jet" sync /:Kaliya:B7B:/ window 50,50
+804.7 "Nanospore Jet" sync / 1[56]:Kaliya:B7B:/ window 50,50
 815.9 "Nerve Gas"
 821.0 "Nerve Gas"
 826.1 "Nerve Gas"
-828.2 "Resonance" sync /:Kaliya:B6B:/
-839.4 "Seed Of The Sea/Rivers" sync /:Kaliya:B7[67]:/
-844.5 "Seed Of The Rivers/Sea" sync /:Kaliya:B7[67]:/
-844.7 "Resonance" sync /:Kaliya:B6B:/
-846.8 "Secondary Head Stun" sync /:Kaliya:B73:/
-851.9 "Secondary Head" sync /:Kaliya:B72:/
-853.0 "Main Head" sync /:Kaliya:B71:/
+828.2 "Resonance" sync / 1[56]:Kaliya:B6B:/
+839.4 "Seed Of The Sea/Rivers" sync / 1[56]:Kaliya:B7[67]:/
+844.5 "Seed Of The Rivers/Sea" sync / 1[56]:Kaliya:B7[67]:/
+844.7 "Resonance" sync / 1[56]:Kaliya:B6B:/
+846.8 "Secondary Head Stun" sync / 1[56]:Kaliya:B73:/
+851.9 "Secondary Head" sync / 1[56]:Kaliya:B72:/
+853.0 "Main Head" sync / 1[56]:Kaliya:B71:/
 
-861.3 "Nerve Cloud" sync /:Kaliya:B79:/ window 100,100
-872.5 "Nanospore Jet" sync /:Kaliya:B7B:/ window 50,50
-880.6 "Resonance" sync /:Kaliya:B6B:/
-889.8 "Seed Of The Sea/Rivers" sync /:Kaliya:B7[67]:/
-894.7 "Seed Of The Rivers/Sea" sync /:Kaliya:B7[67]:/
+861.3 "Nerve Cloud" sync / 1[56]:Kaliya:B79:/ window 100,100
+872.5 "Nanospore Jet" sync / 1[56]:Kaliya:B7B:/ window 50,50
+880.6 "Resonance" sync / 1[56]:Kaliya:B6B:/
+889.8 "Seed Of The Sea/Rivers" sync / 1[56]:Kaliya:B7[67]:/
+894.7 "Seed Of The Rivers/Sea" sync / 1[56]:Kaliya:B7[67]:/
 899.2 "Nerve Gas"
 904.4 "Nerve Gas"
 909.5 "Nerve Gas"
-913.7 "Secondary Head Stun" sync /:Kaliya:B73:/
-918.8 "Secondary Head" sync /:Kaliya:B72:/
-920.0 "Main Head" sync /:Kaliya:B71:/
-923.2 "Resonance" sync /:Kaliya:B6B:/
+913.7 "Secondary Head Stun" sync / 1[56]:Kaliya:B73:/
+918.8 "Secondary Head" sync / 1[56]:Kaliya:B72:/
+920.0 "Main Head" sync / 1[56]:Kaliya:B71:/
+923.2 "Resonance" sync / 1[56]:Kaliya:B6B:/
 
-932.4 "Nanospore Jet" sync /:Kaliya:B7B:/ window 50,50
+932.4 "Nanospore Jet" sync / 1[56]:Kaliya:B7B:/ window 50,50
 943.6 "Nerve Gas"
 948.7 "Nerve Gas"
 953.7 "Nerve Gas"
-955.8 "Resonance" sync /:Kaliya:B6B:/
-967.0 "Seed Of The Sea/Rivers" sync /:Kaliya:B7[67]:/
-972.0 "Seed Of The Rivers/Sea" sync /:Kaliya:B7[67]:/
-972.2 "Resonance" sync /:Kaliya:B6B:/
-974.3 "Secondary Head" sync /:Kaliya:B73:/
-979.4 "Secondary Head" sync /:Kaliya:B72:/
-980.5 "Main Head" sync /:Kaliya:B71:/
+955.8 "Resonance" sync / 1[56]:Kaliya:B6B:/
+967.0 "Seed Of The Sea/Rivers" sync / 1[56]:Kaliya:B7[67]:/
+972.0 "Seed Of The Rivers/Sea" sync / 1[56]:Kaliya:B7[67]:/
+972.2 "Resonance" sync / 1[56]:Kaliya:B6B:/
+974.3 "Secondary Head" sync / 1[56]:Kaliya:B73:/
+979.4 "Secondary Head" sync / 1[56]:Kaliya:B72:/
+980.5 "Main Head" sync / 1[56]:Kaliya:B71:/
 
-988.8 "Nerve Cloud" sync /:Kaliya:B79:/ window 100,100
-1000.0 "Nanospore Jet" sync /:Kaliya:B7B:/ window 50,50
+988.8 "Nerve Cloud" sync / 1[56]:Kaliya:B79:/ window 100,100
+1000.0 "Nanospore Jet" sync / 1[56]:Kaliya:B7B:/ window 50,50
 1011.2 "Nerve Gas"
 1016.2 "Nerve Gas"
 1021.3 "Nerve Gas"
-1023.5 "Resonance" sync /:Kaliya:B6B:/
-1034.7 "Seed Of The Sea/Rivers" sync /:Kaliya:B7[67]:/
-1039.7 "Seed Of The Rivers/Sea" sync /:Kaliya:B7[67]:/
-1039.9 "Resonance" sync /:Kaliya:B6B:/
-1042.0 "Secondary Head" sync /:Kaliya:B73:/
-1047.1 "Secondary Head" sync /:Kaliya:B72:/
-1048.2 "Main Head" sync /:Kaliya:B71:/
+1023.5 "Resonance" sync / 1[56]:Kaliya:B6B:/
+1034.7 "Seed Of The Sea/Rivers" sync / 1[56]:Kaliya:B7[67]:/
+1039.7 "Seed Of The Rivers/Sea" sync / 1[56]:Kaliya:B7[67]:/
+1039.9 "Resonance" sync / 1[56]:Kaliya:B6B:/
+1042.0 "Secondary Head" sync / 1[56]:Kaliya:B73:/
+1047.1 "Secondary Head" sync / 1[56]:Kaliya:B72:/
+1048.2 "Main Head" sync / 1[56]:Kaliya:B71:/
 
-1059.6 "Nanospore Jet" sync /:Kaliya:B7B:/ window 50,50
-1067.8 "Resonance" sync /:Kaliya:B6B:/
-1077.2 "Seed Of The Sea/Rivers" sync /:Kaliya:B7[67]:/
-1082.2 "Seed Of The Rivers/Sea" sync /:Kaliya:B7[67]:/
+1059.6 "Nanospore Jet" sync / 1[56]:Kaliya:B7B:/ window 50,50
+1067.8 "Resonance" sync / 1[56]:Kaliya:B6B:/
+1077.2 "Seed Of The Sea/Rivers" sync / 1[56]:Kaliya:B7[67]:/
+1082.2 "Seed Of The Rivers/Sea" sync / 1[56]:Kaliya:B7[67]:/
 1086.5 "Nerve Gas"
 1091.7 "Nerve Gas"
 1096.9 "Nerve Gas"
 
 
 ### Phase 5 (enrage)
-1200.0 "--sync--" sync /:Kaliya:B7A/ window 1200,1200
+1200.0 "--sync--" sync / 1[56]:Kaliya:B7A/ window 1200,1200
 1208.0 "Nerve Cloud Enrage"
 1220.2 "Nerve Cloud Enrage"
 1232.4 "Nerve Cloud Enrage"

--- a/ui/raidboss/data/02-arr/raid/t11.txt
+++ b/ui/raidboss/data/02-arr/raid/t11.txt
@@ -4,7 +4,7 @@
 hideall "--Reset--"
 hideall "--sync--"
 
-0 "--reset--" sync / 00:0839::.*is no longer sealed/ window 100000 jump 0
+0.0 "--reset--" sync / 00:0839::.*is no longer sealed/ window 100000 jump 0
 
 ### Phase 1
 0.0 "Start"

--- a/ui/raidboss/data/02-arr/raid/t12.txt
+++ b/ui/raidboss/data/02-arr/raid/t12.txt
@@ -6,7 +6,7 @@ hideall "--sync--"
 hideall "Summon"
 hideall "Scorched Pinion"
 
-0 "--Reset--" sync / 21:........:40000010:/ window 100000 jump 0
+0.0 "--reset--" sync / 21:........:40000010:/ window 100000 jump 0
 
 ### Phase 1: Blackfire/Whitefire
 0.0 "Start"

--- a/ui/raidboss/data/02-arr/raid/t12.txt
+++ b/ui/raidboss/data/02-arr/raid/t12.txt
@@ -6,7 +6,7 @@ hideall "--sync--"
 hideall "Summon"
 hideall "Scorched Pinion"
 
-0.0 "--reset--" sync / 21:........:40000010:/ window 100000 jump 0
+0.0 "--Reset--" sync / 21:........:40000010:/ window 100000 jump 0
 
 ### Phase 1: Blackfire/Whitefire
 0.0 "Start"

--- a/ui/raidboss/data/02-arr/raid/t12.txt
+++ b/ui/raidboss/data/02-arr/raid/t12.txt
@@ -6,38 +6,38 @@ hideall "--sync--"
 hideall "Summon"
 hideall "Scorched Pinion"
 
-0.0 "--Reset--" sync / 21:........:40000010:/ window 10000 jump 0
+0 "--Reset--" sync / 21:........:40000010:/ window 100000 jump 0
 
 ### Phase 1: Blackfire/Whitefire
 0.0 "Start"
 0.0 "--sync--" sync /:Engage!/ window 0,1
-2.5 "--sync--" sync /:Phoenix:368:/ window 3,0
+2.5 "--sync--" sync / 1[56]:Phoenix:368:/ window 3,0
 9.0 "Bennu Add"
-18.0 "Revelation" sync /:Phoenix:B87:/
-32.1 "Blackfire" sync /:Phoenix:B8C:/
-42.1 "--sync--" sync /:Phoenix:B8F:/
-43.6 "Whitefire" sync /:Phoenix:B90:/
+18.0 "Revelation" sync / 1[56]:Phoenix:B87:/
+32.1 "Blackfire" sync / 1[56]:Phoenix:B8C:/
+42.1 "--sync--" sync / 1[56]:Phoenix:B8F:/
+43.6 "Whitefire" sync / 1[56]:Phoenix:B90:/
 
-77.0 "Revelation" sync /:Phoenix:B87:/ window 20,20 jump 18
+77.0 "Revelation" sync / 1[56]:Phoenix:B87:/ window 20,20 jump 18
 91.1 "Blackfire"
 101.1 "--sync--"
 102.6 "Whitefire"
 
 
 ### Phase 2: Bluefire/Redfire
-200.0 "Brand Of Purgatory" sync /:Phoenix:B88:/ window 200,0
+200.0 "Brand Of Purgatory" sync / 1[56]:Phoenix:B88:/ window 200,0
 
-210.6 "Bluefire" sync /:Phoenix:B91:/ duration 4.1
-223.6 "Flames Of Unforgiveness" sync /:Phoenix:B8B:/
-231.0 "Redfire" sync /:Phoenix:B93:/
-237.1 "Revelation" sync /:Phoenix:B87:/
+210.6 "Bluefire" sync / 1[56]:Phoenix:B91:/ duration 4.1
+223.6 "Flames Of Unforgiveness" sync / 1[56]:Phoenix:B8B:/
+231.0 "Redfire" sync / 1[56]:Phoenix:B93:/
+237.1 "Revelation" sync / 1[56]:Phoenix:B87:/
 
-248.2 "Bluefire" sync /:Phoenix:B91:/ duration 4.1
-261.3 "Flames Of Unforgiveness" sync /:Phoenix:B8B:/
-268.3 "Redfire" sync /:Phoenix:B93:/
+248.2 "Bluefire" sync / 1[56]:Phoenix:B91:/ duration 4.1
+261.3 "Flames Of Unforgiveness" sync / 1[56]:Phoenix:B8B:/
+268.3 "Redfire" sync / 1[56]:Phoenix:B93:/
 
-280.6 "Bluefire" sync /:Phoenix:B91:/ duration 4.1
-293.6 "Flames Of Unforgiveness" sync /:Phoenix:B8B:/ jump 223.6 window 20,20
+280.6 "Bluefire" sync / 1[56]:Phoenix:B91:/ duration 4.1
+293.6 "Flames Of Unforgiveness" sync / 1[56]:Phoenix:B8B:/ jump 223.6 window 20,20
 301.0 "Redfire"
 307.1 "Revelation"
 
@@ -47,81 +47,81 @@ hideall "Scorched Pinion"
 
 
 ### Phase 3: So Many Bennies
-400.0 "--sync--" sync /:Phoenix:B96:/ window 400,0
-404.1 "--sync--" sync /:Phoenix:B97:/ window 404,5
-407.1 "Flames Of Rebirth" sync /:Phoenix:B98:/
-421.3 "Flames Of Rebirth" sync /:Phoenix:B99:/
-435.5 "Flames Of Rebirth" sync /:Phoenix:B99:/ window 8,8 jump 421.3
+400.0 "--sync--" sync / 1[56]:Phoenix:B96:/ window 400,0
+404.1 "--sync--" sync / 1[56]:Phoenix:B97:/ window 404,5
+407.1 "Flames Of Rebirth" sync / 1[56]:Phoenix:B98:/
+421.3 "Flames Of Rebirth" sync / 1[56]:Phoenix:B99:/
+435.5 "Flames Of Rebirth" sync / 1[56]:Phoenix:B99:/ window 8,8 jump 421.3
 449.7 "Flames Of Rebirth"
 463.9 "Flames Of Rebirth"
 478.1 "Flames Of Rebirth"
 
 
 ### Phase 4: Fountains of Life and Death
-996.0 "--sync--" sync /:C88:Phoenix/ window 1000,0
-1000.0 "Rebirth" sync /:Phoenix:C88:/
-1005.8 "Brand Of Purgatory" sync /:Phoenix:B88:/
+996.0 "--sync--" sync / 14:Phoenix:C88:/ window 1000,0
+1000.0 "Rebirth" sync / 1[56]:Phoenix:C88:/
+1005.8 "Brand Of Purgatory" sync / 1[56]:Phoenix:B88:/
 
 # Fountain 1
-1011.0 "Fountain Of Fire" sync /:Phoenix:B9C:/
-1014.1 "Summon" sync /:Phoenix:B9F:/
+1011.0 "Fountain Of Fire" sync / 1[56]:Phoenix:B9C:/
+1014.1 "Summon" sync / 1[56]:Phoenix:B9F:/
 1019.1 "Fountain Tick 1"
-1020.3 "Scorched Pinion" sync /:Phoenix-Egi:BA0:/
-1022.1 "Revelation" sync /:Phoenix:B87:/ window 10,10
+1020.3 "Scorched Pinion" sync / 1[56]:Phoenix-Egi:BA0:/
+1022.1 "Revelation" sync / 1[56]:Phoenix:B87:/ window 10,10
 1024.3 "Fountain Tick 2"
-1026.4 "Scorched Pinion" #sync /:Phoenix-Egi:BA0:/
+1026.4 "Scorched Pinion" #sync / 1[56]:Phoenix-Egi:BA0:/
 1029.3 "Fountain Tick 3"
-1032.8 "Scorched Pinion" #sync /:Phoenix-Egi:BA1:/
+1032.8 "Scorched Pinion" #sync / 1[56]:Phoenix-Egi:BA1:/
 1034.3 "Fountain Tick 4"
-1038.2 "Scorched Pinion" #sync /:Phoenix-Egi:BA0:/
+1038.2 "Scorched Pinion" #sync / 1[56]:Phoenix-Egi:BA0:/
 1039.3 "Fountain Tick 5"
-1044.2 "Scorched Pinion" #sync /:Phoenix-Egi:BA0:/
-1044.2 "Flames Of Unforgiveness" sync /:Phoenix:B8B:/ window 10,10
+1044.2 "Scorched Pinion" #sync / 1[56]:Phoenix-Egi:BA0:/
+1044.2 "Flames Of Unforgiveness" sync / 1[56]:Phoenix:B8B:/ window 10,10
 1044.4 "Fountain Tick 6"
 1049.5 "Fountain Tick 7"
-1050.8 "Scorched Pinion" #sync /:Phoenix-Egi:BA1:/
+1050.8 "Scorched Pinion" #sync / 1[56]:Phoenix-Egi:BA1:/
 1054.6 "Fountain Tick 8"
-1059.4 "Flames Of Rebirth" sync /:Phoenix:B9A:/ window 10,10
+1059.4 "Flames Of Rebirth" sync / 1[56]:Phoenix:B9A:/ window 10,10
 
 # Fountain 2
-1066.6 "Fountain Of Fire" sync /:Phoenix:B9C:/
-1069.6 "Summon" sync /:Phoenix:B9F:/
+1066.6 "Fountain Of Fire" sync / 1[56]:Phoenix:B9C:/
+1069.6 "Summon" sync / 1[56]:Phoenix:B9F:/
 1074.8 "Fountain Tick 1"
-1075.8 "Scorched Pinion" #sync /:Phoenix-Egi:BA0:/
-1077.7 "Revelation" sync /:Phoenix:B87:/ window 10,10
+1075.8 "Scorched Pinion" #sync / 1[56]:Phoenix-Egi:BA0:/
+1077.7 "Revelation" sync / 1[56]:Phoenix:B87:/ window 10,10
 1079.9 "Fountain Tick 2"
-1081.8 "Scorched Pinion" #sync /:Phoenix-Egi:BA0:/
+1081.8 "Scorched Pinion" #sync / 1[56]:Phoenix-Egi:BA0:/
 1085.1 "Fountain Tick 3"
-1088.4 "Scorched Pinion" #sync /:Phoenix-Egi:BA1:/
+1088.4 "Scorched Pinion" #sync / 1[56]:Phoenix-Egi:BA1:/
 1090.2 "Fountain Tick 4"
-1093.8 "Scorched Pinion" #sync /:Phoenix-Egi:BA0:/
+1093.8 "Scorched Pinion" #sync / 1[56]:Phoenix-Egi:BA0:/
 1095.2 "Fountain Tick 5"
-1099.8 "Scorched Pinion" #sync /:Phoenix-Egi:BA0:/
-1099.8 "Flames Of Unforgiveness" sync /:Phoenix:B8B:/
+1099.8 "Scorched Pinion" #sync / 1[56]:Phoenix-Egi:BA0:/
+1099.8 "Flames Of Unforgiveness" sync / 1[56]:Phoenix:B8B:/
 1100.3 "Fountain Tick 6"
 1105.4 "Fountain Tick 7"
-1106.3 "Scorched Pinion" #sync /:Phoenix-Egi:BA1:/
+1106.3 "Scorched Pinion" #sync / 1[56]:Phoenix-Egi:BA1:/
 1110.4 "Fountain Tick 8"
-1115.0 "Flames Of Rebirth" sync /:Phoenix:B9A:/
+1115.0 "Flames Of Rebirth" sync / 1[56]:Phoenix:B9A:/
 
 # Dance Minigame
-1117.2 "--sync--" sync /:Phoenix:BA2:/
-1118.3 "--sync--" sync /:Phoenix:B96:/
-1119.0 "Scorched Pinion" #sync /:Phoenix-Egi:BA0:/
-1121.1 "Scorched Pinion" #sync /:Phoenix-Egi:BA0:/
-1121.2 "Redfire Plume" #sync /:Phoenix:BA3:/
-1123.0 "Scorched Pinion" #sync /:Phoenix-Egi:BA0:/
-1125.1 "Scorched Pinion" #sync /:Phoenix-Egi:BA0:/
-1125.7 "Scorched Pinion" #sync /:Phoenix-Egi:BA1:/
-1127.2 "Scorched Pinion" #sync /:Phoenix-Egi:BA0:/
-1127.8 "Scorched Pinion" #sync /:Phoenix-Egi:BA1:/
-1129.7 "Scorched Pinion" #sync /:Phoenix-Egi:BA1:/
-1131.8 "Scorched Pinion" #sync /:Phoenix-Egi:BA1:/
-1133.9 "Scorched Pinion" #sync /:Phoenix-Egi:BA1:/
-1137.9 "--sync--" sync /:Phoenix:B97:/ window 20,20
+1117.2 "--sync--" sync / 1[56]:Phoenix:BA2:/
+1118.3 "--sync--" sync / 1[56]:Phoenix:B96:/
+1119.0 "Scorched Pinion" #sync / 1[56]:Phoenix-Egi:BA0:/
+1121.1 "Scorched Pinion" #sync / 1[56]:Phoenix-Egi:BA0:/
+1121.2 "Redfire Plume" #sync / 1[56]:Phoenix:BA3:/
+1123.0 "Scorched Pinion" #sync / 1[56]:Phoenix-Egi:BA0:/
+1125.1 "Scorched Pinion" #sync / 1[56]:Phoenix-Egi:BA0:/
+1125.7 "Scorched Pinion" #sync / 1[56]:Phoenix-Egi:BA1:/
+1127.2 "Scorched Pinion" #sync / 1[56]:Phoenix-Egi:BA0:/
+1127.8 "Scorched Pinion" #sync / 1[56]:Phoenix-Egi:BA1:/
+1129.7 "Scorched Pinion" #sync / 1[56]:Phoenix-Egi:BA1:/
+1131.8 "Scorched Pinion" #sync / 1[56]:Phoenix-Egi:BA1:/
+1133.9 "Scorched Pinion" #sync / 1[56]:Phoenix-Egi:BA1:/
+1137.9 "--sync--" sync / 1[56]:Phoenix:B97:/ window 20,20
 
 # Loop
-1143.1 "Fountain Of Fire" sync /:Phoenix:B9C:/ window 50,50 jump 1011.1
+1143.1 "Fountain Of Fire" sync / 1[56]:Phoenix:B9C:/ window 50,50 jump 1011.1
 1146.2 "Summon"
 1151.2 "Fountain Tick 1"
 1152.4 "Scorched Pinion"

--- a/ui/raidboss/data/02-arr/raid/t13.txt
+++ b/ui/raidboss/data/02-arr/raid/t13.txt
@@ -4,7 +4,7 @@
 hideall "--Reset--"
 hideall "--sync--"
 
-0 "--Reset--" sync / 21:........:40000010:/ window 100000 jump 0
+0.0 "--reset--" sync / 21:........:40000010:/ window 100000 jump 0
 
 ### Phase 1: Megaflare Warmup
 0.0 "Start"

--- a/ui/raidboss/data/02-arr/raid/t13.txt
+++ b/ui/raidboss/data/02-arr/raid/t13.txt
@@ -4,7 +4,7 @@
 hideall "--Reset--"
 hideall "--sync--"
 
-0.0 "--reset--" sync / 21:........:40000010:/ window 100000 jump 0
+0.0 "--Reset--" sync / 21:........:40000010:/ window 100000 jump 0
 
 ### Phase 1: Megaflare Warmup
 0.0 "Start"

--- a/ui/raidboss/data/02-arr/raid/t13.txt
+++ b/ui/raidboss/data/02-arr/raid/t13.txt
@@ -4,25 +4,25 @@
 hideall "--Reset--"
 hideall "--sync--"
 
-0.0 "--Reset--" sync / 21:........:40000010:/ window 10000 jump 0
+0 "--Reset--" sync / 21:........:40000010:/ window 100000 jump 0
 
 ### Phase 1: Megaflare Warmup
 0.0 "Start"
 0.0 "--sync--" sync /:Engage!/ window 0,1
-1.0 "--sync--" sync /:Bahamut Prime:BAC:/ window 2,1
-7.0 "Flare Breath" sync /:Bahamut Prime:BAD:/ window 7,10
-15.1 "Megaflare" sync /:Bahamut Prime:BAF:/ window 80,80
-18.8 "MF Spread" #sync /:Bahamut Prime:BB0:/
-20.5 "MF Pepperoni" #sync /:Bahamut Prime:BB1:/
-22.6 "MF Share" sync /:Bahamut Prime:BB2:/
-25.1 "Flare Breath" sync /:Bahamut Prime:BAD:/ window 10,5
-33.1 "Flatten" sync /:Bahamut Prime:BAE:/ window 30,30
+1.0 "--sync--" sync / 1[56]:Bahamut Prime:BAC:/ window 2,1
+7.0 "Flare Breath" sync / 1[56]:Bahamut Prime:BAD:/ window 7,10
+15.1 "Megaflare" sync / 1[56]:Bahamut Prime:BAF:/ window 80,80
+18.8 "MF Spread" #sync / 1[56]:Bahamut Prime:BB0:/
+20.5 "MF Pepperoni" #sync / 1[56]:Bahamut Prime:BB1:/
+22.6 "MF Share" sync / 1[56]:Bahamut Prime:BB2:/
+25.1 "Flare Breath" sync / 1[56]:Bahamut Prime:BAD:/ window 10,5
+33.1 "Flatten" sync / 1[56]:Bahamut Prime:BAE:/ window 30,30
 35.2 "Flare Breath x3" duration 4
 45.4 "Earth Shaker Marker"
 50.4 "Earth Shaker x3" duration 4
 
-56.6 "Flare Breath" sync /:Bahamut Prime:BAD:/
-64.7 "Megaflare" sync /:Bahamut Prime:BAF:/ window 80,80
+56.6 "Flare Breath" sync / 1[56]:Bahamut Prime:BAD:/
+64.7 "Megaflare" sync / 1[56]:Bahamut Prime:BAF:/ window 80,80
 68.4 "MF Spread"
 70.1 "MF Pepperoni"
 72.2 "MF Share"
@@ -34,59 +34,59 @@ hideall "--sync--"
 
 
 ### Phase 2 (75%): Flare Star, Rage of Bahamut, Dragons
-195.0 "--sync--" sync /:BB9:Bahamut Prime/ window 200,0
-200.0 "Gigaflare" sync /:Bahamut Prime:BB9:/ window 200,5
+195.0 "--sync--" sync / 14:Bahamut Prime:BB9:/ window 200,0
+200.0 "Gigaflare" sync / 1[56]:Bahamut Prime:BB9:/ window 200,5
 
 203.0 "Shadow Add (N)"
-212.3 "Flare Star" sync /:Bahamut Prime:BBB:/
+212.3 "Flare Star" sync / 1[56]:Bahamut Prime:BBB:/
 214.1 "(1x Dark Aether Orb)"
-220.5 "Flare Breath" sync /:Bahamut Prime:BAD:/
+220.5 "Flare Breath" sync / 1[56]:Bahamut Prime:BAD:/
 226.6 "(3x Dark Aether Orbs)"
-234.5 "Flatten" sync /:Bahamut Prime:BAE:/
-237.8 "Flare Breath" sync /:Bahamut Prime:BAD:/
+234.5 "Flatten" sync / 1[56]:Bahamut Prime:BAE:/
+237.8 "Flare Breath" sync / 1[56]:Bahamut Prime:BAD:/
 238.4 "(3x Dark Aether Orbs)"
-252.8 "Megaflare" sync /:Bahamut Prime:BAF:/
+252.8 "Megaflare" sync / 1[56]:Bahamut Prime:BAF:/
 256.0 "MF Spread"
 258.0 "MF Pepperoni"
 260.3 "MF Share"
-261.9 "MF Tower" sync /:Bahamut Prime:BB3:/
-263.0 "Flare Breath" sync /:Bahamut Prime:BAD:/
-269.1 "Rage Of Bahamut" sync /:Bahamut Prime:BBD:/
+261.9 "MF Tower" sync / 1[56]:Bahamut Prime:BB3:/
+263.0 "Flare Breath" sync / 1[56]:Bahamut Prime:BAD:/
+269.1 "Rage Of Bahamut" sync / 1[56]:Bahamut Prime:BBD:/
 
 270.1 "Shadow Add (SW)"
-278.3 "Flare Star" sync /:Bahamut Prime:BBB:/
+278.3 "Flare Star" sync / 1[56]:Bahamut Prime:BBB:/
 280.1 "(3x Dark Aether Orbs)"
-286.5 "Flare Breath" sync /:Bahamut Prime:BAD:/
+286.5 "Flare Breath" sync / 1[56]:Bahamut Prime:BAD:/
 292.1 "(3x Dark Aether Orbs)"
-300.5 "Flatten" sync /:Bahamut Prime:BAE:/
-303.8 "Flare Breath" sync /:Bahamut Prime:BAD:/
+300.5 "Flatten" sync / 1[56]:Bahamut Prime:BAE:/
+303.8 "Flare Breath" sync / 1[56]:Bahamut Prime:BAD:/
 304.6 "(2x Dark Aether Orbs)"
-318.8 "Megaflare" sync /:Bahamut Prime:BAF:/
+318.8 "Megaflare" sync / 1[56]:Bahamut Prime:BAF:/
 322.0 "MF Spread"
 324.0 "MF Pepperoni"
 326.3 "MF Share"
-327.9 "MF Tower" sync /:Bahamut Prime:BB3:/
-329.0 "Flare Breath" sync /:Bahamut Prime:BAD:/
-335.1 "Rage Of Bahamut" sync /:Bahamut Prime:BBD:/
+327.9 "MF Tower" sync / 1[56]:Bahamut Prime:BB3:/
+329.0 "Flare Breath" sync / 1[56]:Bahamut Prime:BAD:/
+335.1 "Rage Of Bahamut" sync / 1[56]:Bahamut Prime:BBD:/
 
 336.1 "Shadow Add (SE)"
-344.3 "Flare Star" sync /:Bahamut Prime:BBB:/
+344.3 "Flare Star" sync / 1[56]:Bahamut Prime:BBB:/
 346.1 "(3x Dark Aether Orbs)"
-352.5 "Flare Breath" sync /:Bahamut Prime:BAD:/
+352.5 "Flare Breath" sync / 1[56]:Bahamut Prime:BAD:/
 358.1 "(3x Dark Aether Orbs)"
-366.5 "Flatten" sync /:Bahamut Prime:BAE:/
-369.8 "Flare Breath" sync /:Bahamut Prime:BAD:/
+366.5 "Flatten" sync / 1[56]:Bahamut Prime:BAE:/
+369.8 "Flare Breath" sync / 1[56]:Bahamut Prime:BAD:/
 370.6 "(2x Dark Aether Orbs)"
-384.8 "Megaflare" sync /:Bahamut Prime:BAF:/
+384.8 "Megaflare" sync / 1[56]:Bahamut Prime:BAF:/
 388.0 "MF Spread"
 390.0 "MF Pepperoni"
 392.3 "MF Share"
-393.9 "MF Tower" sync /:Bahamut Prime:BB3:/
-395.0 "Flare Breath" sync /:Bahamut Prime:BAD:/
-401.1 "Rage Of Bahamut" sync /:Bahamut Prime:BBD:/
+393.9 "MF Tower" sync / 1[56]:Bahamut Prime:BB3:/
+395.0 "Flare Breath" sync / 1[56]:Bahamut Prime:BAD:/
+401.1 "Rage Of Bahamut" sync / 1[56]:Bahamut Prime:BBD:/
 
 402.1 "Shadow Add"
-410.3 "Flare Star" sync /:Bahamut Prime:BBB:/ window 50,50 jump 344.3
+410.3 "Flare Star" sync / 1[56]:Bahamut Prime:BBB:/ window 50,50 jump 344.3
 412.1 "(3x Dark Aether Orbs)"
 418.5 "Flare Breath"
 424.1 "(3x Dark Aether Orbs)"
@@ -103,23 +103,23 @@ hideall "--sync--"
 
 
 ### Phase 3 (52%): adds, adds, adds
-495.0 "--sync--" sync /:BB9:Bahamut Prime/ window 290,0
-500.0 "Gigaflare" sync /:Bahamut Prime:BB9:/
-505.4 "--sync--" sync /:Bahamut Prime:BBE:/
-508.5 "--sync--" sync /:Bahamut Prime:BBF:/
-514.7 "Megaflare Dive" sync /:Bahamut Prime:BC0:/
-516.6 "Double Dive" sync /:The Storm of Meracydia:BC8:/
-517.8 "--sync--" sync /:Bahamut Prime:BBE:/
+495.0 "--sync--" sync / 14:Bahamut Prime:BB9:/ window 290,0
+500.0 "Gigaflare" sync / 1[56]:Bahamut Prime:BB9:/
+505.4 "--sync--" sync / 1[56]:Bahamut Prime:BBE:/
+508.5 "--sync--" sync / 1[56]:Bahamut Prime:BBF:/
+514.7 "Megaflare Dive" sync / 1[56]:Bahamut Prime:BC0:/
+516.6 "Double Dive" sync / 1[56]:The Storm of Meracydia:BC8:/
+517.8 "--sync--" sync / 1[56]:Bahamut Prime:BBE:/
 518.7 "MF Spread"
 520.9 "MF Pepperoni"
 523.0 "MF Share"
 525.1 "Blood, Pain Adds (E/W)"
 545.5 "3x Gust Adds"
 571.2 "2x Sin Adds (N/S)"
-599.7 "--sync--" sync /:Bahamut Prime:BBF:/
-605.8 "Megaflare Dive" sync /:Bahamut Prime:BC0:/
-607.7 "Double Dive" sync /:The Storm of Meracydia:BC8:/
-608.9 "--sync--" sync /:Bahamut Prime:BBE:/
+599.7 "--sync--" sync / 1[56]:Bahamut Prime:BBF:/
+605.8 "Megaflare Dive" sync / 1[56]:Bahamut Prime:BC0:/
+607.7 "Double Dive" sync / 1[56]:The Storm of Meracydia:BC8:/
+608.9 "--sync--" sync / 1[56]:Bahamut Prime:BBE:/
 609.8 "MF Spread"
 612.0 "MF Pepperoni"
 614.1 "MF Share"
@@ -128,112 +128,112 @@ hideall "--sync--"
 641.1 "2x Gust Adds (S)"
 651.6 "Sin Add (E)"
 672.2 "Pain Add (W)"
-692.8 "--sync--" sync /:Bahamut Prime:BBF:/
-698.9 "Megaflare Dive" sync /:Bahamut Prime:BC0:/
-702.1 "--sync--" sync /:Bahamut Prime:BB  E:/
+692.8 "--sync--" sync / 1[56]:Bahamut Prime:BBF:/
+698.9 "Megaflare Dive" sync / 1[56]:Bahamut Prime:BC0:/
+702.1 "--sync--" sync / 1[56]:Bahamut Prime:BB  E:/
 702.9 "MF Spread"
 705.1 "MF Pepperoni"
 707.2 "MF Share"
-725.4 "Teraflare" sync /:Bahamut Prime:BC1:/ window 700,700
+725.4 "Teraflare" sync / 1[56]:Bahamut Prime:BC1:/ window 700,700
 
 
 ### Phase 4: Akh Morns, Tempest Wings
-735.6 "--sync--" sync /:Bahamut Prime:BBE:/
-737.8 "--sync--" sync /:Bahamut Prime:BBF:/
+735.6 "--sync--" sync / 1[56]:Bahamut Prime:BBE:/
+737.8 "--sync--" sync / 1[56]:Bahamut Prime:BBF:/
 
-745.1 "Akh Morn x2" sync /:Bahamut Prime:BC2:/ window 40,40 duration 2.1
-759.5 "Megaflare" sync /:Bahamut Prime:BAF:/
+745.1 "Akh Morn x2" sync / 1[56]:Bahamut Prime:BC2:/ window 40,40 duration 2.1
+759.5 "Megaflare" sync / 1[56]:Bahamut Prime:BAF:/
 764.6 "MF Pepperoni"
-766.6 "Tempest Wing" sync /:Bahamut Prime:BC4:/
-767.3 "MF Share" sync /:Bahamut Prime:BB2:/
-767.9 "--sync--" sync /:Bahamut Prime:C89:/ # Tempest Wing Gust?
-768.6 "MF Tower(s)" sync /:Bahamut Prime:BB3:/
+766.6 "Tempest Wing" sync / 1[56]:Bahamut Prime:BC4:/
+767.3 "MF Share" sync / 1[56]:Bahamut Prime:BB2:/
+767.9 "--sync--" sync / 1[56]:Bahamut Prime:C89:/ # Tempest Wing Gust?
+768.6 "MF Tower(s)" sync / 1[56]:Bahamut Prime:BB3:/
 781.7 "Earth Shaker Marker"
 786.7 "Earth Shaker x3" duration 4
 787.7 "Tempest Wing Tethers"
-793.7 "Tempest Wing" sync /:Bahamut Prime:BC4:/
-794.9 "--sync--" sync /:Bahamut Prime:C89:/
-795.9 "Flare Breath" sync /:Bahamut Prime:BAD:/
+793.7 "Tempest Wing" sync / 1[56]:Bahamut Prime:BC4:/
+794.9 "--sync--" sync / 1[56]:Bahamut Prime:C89:/
+795.9 "Flare Breath" sync / 1[56]:Bahamut Prime:BAD:/
 
-807.1 "Akh Morn x3" sync /:Bahamut Prime:BC2:/ window 40,40 duration 3.1
-822.3 "Megaflare" sync /:Bahamut Prime:BAF:/
+807.1 "Akh Morn x3" sync / 1[56]:Bahamut Prime:BC2:/ window 40,40 duration 3.1
+822.3 "Megaflare" sync / 1[56]:Bahamut Prime:BAF:/
 827.4 "MF Pepperoni"
-829.4 "Tempest Wing" sync /:Bahamut Prime:BC4:/
-830.1 "MF Share" sync /:Bahamut Prime:BB2:/
-830.7 "--sync--" sync /:Bahamut Prime:C89:/
-831.4 "MF Tower(s)" sync /:Bahamut Prime:BB3:/
+829.4 "Tempest Wing" sync / 1[56]:Bahamut Prime:BC4:/
+830.1 "MF Share" sync / 1[56]:Bahamut Prime:BB2:/
+830.7 "--sync--" sync / 1[56]:Bahamut Prime:C89:/
+831.4 "MF Tower(s)" sync / 1[56]:Bahamut Prime:BB3:/
 844.5 "Earth Shaker Marker"
 849.5 "Earth Shaker x3" duration 4
 850.5 "Tempest Wing Tethers"
-856.5 "Tempest Wing" sync /:Bahamut Prime:BC4:/
-857.7 "--sync--" sync /:Bahamut Prime:C89:/
-858.7 "Flare Breath" sync /:Bahamut Prime:BAD:/
+856.5 "Tempest Wing" sync / 1[56]:Bahamut Prime:BC4:/
+857.7 "--sync--" sync / 1[56]:Bahamut Prime:C89:/
+858.7 "Flare Breath" sync / 1[56]:Bahamut Prime:BAD:/
 
-871.4 "Gigaflare" sync /:Bahamut Prime:BB9:/ window 100,100
+871.4 "Gigaflare" sync / 1[56]:Bahamut Prime:BB9:/ window 100,100
 
-880.8 "Akh Morn x4" sync /:Bahamut Prime:BC2:/ window 40,40 duration 4.1
-897.2 "Megaflare" sync /:Bahamut Prime:BAF:/
+880.8 "Akh Morn x4" sync / 1[56]:Bahamut Prime:BC2:/ window 40,40 duration 4.1
+897.2 "Megaflare" sync / 1[56]:Bahamut Prime:BAF:/
 902.3 "MF Pepperoni"
-904.3 "Tempest Wing" sync /:Bahamut Prime:BC4:/
-905.0 "MF Share" sync /:Bahamut Prime:BB2:/
-905.6 "--sync--" sync /:Bahamut Prime:C89:/
-906.3 "MF Tower(s)" sync /:Bahamut Prime:BB3:/
+904.3 "Tempest Wing" sync / 1[56]:Bahamut Prime:BC4:/
+905.0 "MF Share" sync / 1[56]:Bahamut Prime:BB2:/
+905.6 "--sync--" sync / 1[56]:Bahamut Prime:C89:/
+906.3 "MF Tower(s)" sync / 1[56]:Bahamut Prime:BB3:/
 919.4 "Earth Shaker Marker"
 924.4 "Earth Shaker x3" duration 4
 925.4 "Tempest Wing Tethers"
-931.4 "Tempest Wing" sync /:Bahamut Prime:BC4:/
-932.6 "--sync--" sync /:Bahamut Prime:C89:/
-933.6 "Flare Breath" sync /:Bahamut Prime:BAD:/
+931.4 "Tempest Wing" sync / 1[56]:Bahamut Prime:BC4:/
+932.6 "--sync--" sync / 1[56]:Bahamut Prime:C89:/
+933.6 "Flare Breath" sync / 1[56]:Bahamut Prime:BAD:/
 
-944.8 "Akh Morn x5" sync /:Bahamut Prime:BC2:/ window 40,40 duration 5.1
-962.2 "Megaflare" sync /:Bahamut Prime:BAF:/
+944.8 "Akh Morn x5" sync / 1[56]:Bahamut Prime:BC2:/ window 40,40 duration 5.1
+962.2 "Megaflare" sync / 1[56]:Bahamut Prime:BAF:/
 967.3 "MF Pepperoni"
-969.3 "Tempest Wing" sync /:Bahamut Prime:BC4:/
-970.0 "MF Share" sync /:Bahamut Prime:BB2:/
-970.6 "--sync--" sync /:Bahamut Prime:C89:/
-971.3 "MF Tower(s)" sync /:Bahamut Prime:BB3:/
+969.3 "Tempest Wing" sync / 1[56]:Bahamut Prime:BC4:/
+970.0 "MF Share" sync / 1[56]:Bahamut Prime:BB2:/
+970.6 "--sync--" sync / 1[56]:Bahamut Prime:C89:/
+971.3 "MF Tower(s)" sync / 1[56]:Bahamut Prime:BB3:/
 984.4 "Earth Shaker Marker"
 989.4 "Earth Shaker x3" duration 4
 990.4 "Tempest Wing Tethers"
-996.4 "Tempest Wing" sync /:Bahamut Prime:BC4:/
-997.6 "--sync--" sync /:Bahamut Prime:C89:/
-998.6 "Flare Breath" sync /:Bahamut Prime:BAD:/
+996.4 "Tempest Wing" sync / 1[56]:Bahamut Prime:BC4:/
+997.6 "--sync--" sync / 1[56]:Bahamut Prime:C89:/
+998.6 "Flare Breath" sync / 1[56]:Bahamut Prime:BAD:/
 
-1011.3 "Gigaflare" sync /:Bahamut Prime:BB9:/ window 100,100
+1011.3 "Gigaflare" sync / 1[56]:Bahamut Prime:BB9:/ window 100,100
 
-1020.7 "Akh Morn x6" sync /:Bahamut Prime:BC2:/ window 40,40 duration 6.1
-1039.1 "Megaflare" sync /:Bahamut Prime:BAF:/
+1020.7 "Akh Morn x6" sync / 1[56]:Bahamut Prime:BC2:/ window 40,40 duration 6.1
+1039.1 "Megaflare" sync / 1[56]:Bahamut Prime:BAF:/
 1044.2 "MF Pepperoni"
-1046.2 "Tempest Wing" sync /:Bahamut Prime:BC4:/
-1046.9 "MF Share" sync /:Bahamut Prime:BB2:/
-1047.5 "--sync--" sync /:Bahamut Prime:C89:/
-1048.2 "MF Tower(s)" sync /:Bahamut Prime:BB3:/
+1046.2 "Tempest Wing" sync / 1[56]:Bahamut Prime:BC4:/
+1046.9 "MF Share" sync / 1[56]:Bahamut Prime:BB2:/
+1047.5 "--sync--" sync / 1[56]:Bahamut Prime:C89:/
+1048.2 "MF Tower(s)" sync / 1[56]:Bahamut Prime:BB3:/
 1061.3 "Earth Shaker Marker"
 1066.3 "Earth Shaker x3" duration 4
 1067.3 "Tempest Wing Tethers"
-1073.3 "Tempest Wing" sync /:Bahamut Prime:BC4:/
-1074.5 "--sync--" sync /:Bahamut Prime:C89:/
-1075.5 "Flare Breath" sync /:Bahamut Prime:BAD:/
+1073.3 "Tempest Wing" sync / 1[56]:Bahamut Prime:BC4:/
+1074.5 "--sync--" sync / 1[56]:Bahamut Prime:C89:/
+1075.5 "Flare Breath" sync / 1[56]:Bahamut Prime:BAD:/
 
-1086.7 "Akh Morn x7" sync /:Bahamut Prime:BC2:/ window 40,40 duration 7.1
-1106.1 "Megaflare" sync /:Bahamut Prime:BAF:/
+1086.7 "Akh Morn x7" sync / 1[56]:Bahamut Prime:BC2:/ window 40,40 duration 7.1
+1106.1 "Megaflare" sync / 1[56]:Bahamut Prime:BAF:/
 1111.2 "MF Pepperoni"
-1113.2 "Tempest Wing" sync /:Bahamut Prime:BC4:/
-1113.9 "MF Share" sync /:Bahamut Prime:BB2:/
-1114.5 "--sync--" sync /:Bahamut Prime:C89:/
-1115.2 "MF Tower(s)" sync /:Bahamut Prime:BB3:/
+1113.2 "Tempest Wing" sync / 1[56]:Bahamut Prime:BC4:/
+1113.9 "MF Share" sync / 1[56]:Bahamut Prime:BB2:/
+1114.5 "--sync--" sync / 1[56]:Bahamut Prime:C89:/
+1115.2 "MF Tower(s)" sync / 1[56]:Bahamut Prime:BB3:/
 1128.3 "Earth Shaker Marker"
 1133.3 "Earth Shaker x3" duration 4
 1134.3 "Tempest Wing Tethers"
-1140.3 "Tempest Wing" sync /:Bahamut Prime:BC4:/
-1141.5 "--sync--" sync /:Bahamut Prime:C89:/
-1142.5 "Flare Breath" sync /:Bahamut Prime:BAD:/
+1140.3 "Tempest Wing" sync / 1[56]:Bahamut Prime:BC4:/
+1141.5 "--sync--" sync / 1[56]:Bahamut Prime:C89:/
+1142.5 "Flare Breath" sync / 1[56]:Bahamut Prime:BAD:/
 
-1155.2 "Gigaflare" sync /:Bahamut Prime:BB9:/ window 100,100
+1155.2 "Gigaflare" sync / 1[56]:Bahamut Prime:BB9:/ window 100,100
 
 
 ### Enrage
-2000.0 "--sync--" sync /:BBA:Bahamut Prime/ window 2000,2000
+2000.0 "--sync--" sync / 14:Bahamut Prime:BBA:/ window 2000,2000
 2010.0 "Gigaflare Enrage"
 2025.2 "Gigaflare Enrage"
 2037.4 "Gigaflare Enrage"

--- a/ui/raidboss/data/02-arr/raid/t4.txt
+++ b/ui/raidboss/data/02-arr/raid/t4.txt
@@ -9,7 +9,7 @@
 123.0 "Dreadnaught (NW)" sync / 03:........:Clockwork Dreadnaught:/  window 130,0
 123.0 "4x Bug (S)"
 
-183.0 "2x Rook (E/W)"  sync/ 03:........:Spinner-rook:/  window 190,0
+183.0 "2x Rook (E/W)" sync / 03:........:Spinner-rook:/  window 190,0
 183.0 "4x Bug (outside)"
 
 243.0 "Dreadnaught (NE)" sync / 03:........:Clockwork Dreadnaught:/  window 115,0

--- a/ui/raidboss/data/02-arr/raid/t4.txt
+++ b/ui/raidboss/data/02-arr/raid/t4.txt
@@ -1,22 +1,22 @@
 ### T4
 # http://forum.square-enix.com/ffxiv/threads/103985-EXTREME-BINDING-COIL-OF-BAHAMUT-TURN-4-GUIDE
 
-0.0 "6x Bug" sync / 03:........:Clockwork Bug\.:/  window 0,1
+0.0 "6x Bug" sync / 03:........:Clockwork Bug:/  window 0,1
 
-63.0 "Knight + Soldier (NW)" sync / 03:........:Clockwork Knight\.:/  window 70,0
+63.0 "Knight + Soldier (NW)" sync / 03:........:Clockwork Knight:/  window 70,0
 63.0 "Knight + Soldier (NE)"
 
-123.0 "Dreadnaught (NW)" sync / 03:........:Clockwork Dreadnaught\.:/  window 130,0
+123.0 "Dreadnaught (NW)" sync / 03:........:Clockwork Dreadnaught:/  window 130,0
 123.0 "4x Bug (S)"
 
-183.0 "2x Rook (E/ 03:........:Spinner-rook\.:/  03:........:Added new combatant Spinner-rook\.
+183.0 "2x Rook (E/ 03:........:Spinner-rook:/  03:........:Added new combatant Spinner-rook\.
 183.0 "4x Bug (outside)"
 
-243.0 "Dreadnaught (NE)" sync / 03:........:Clockwork Dreadnaught\.:/  window 115,0
+243.0 "Dreadnaught (NE)" sync / 03:........:Clockwork Dreadnaught:/  window 115,0
 243.0 "Soldier (center)"
 243.0 "Knight (SE)"
 
-303.0 "Dreadnaught (NE)" sync / 03:........:Clockwork Dreadnaught\.:/  window 55,0
+303.0 "Dreadnaught (NE)" sync / 03:........:Clockwork Dreadnaught:/  window 55,0
 303.0 "Knight (center)"
 303.0 "Soldier (SW)"
 303.0 "Rook (NE)"

--- a/ui/raidboss/data/02-arr/raid/t4.txt
+++ b/ui/raidboss/data/02-arr/raid/t4.txt
@@ -1,28 +1,28 @@
 ### T4
 # http://forum.square-enix.com/ffxiv/threads/103985-EXTREME-BINDING-COIL-OF-BAHAMUT-TURN-4-GUIDE
 
-0.0 "6x Bug" sync / 03:........:Added new combatant Clockwork Bug\./ window 0,1
+0.0 "6x Bug" sync / 03:........:Clockwork Bug\.:/  window 0,1
 
-63.0 "Knight + Soldier (NW)" sync / 03:........:Added new combatant Clockwork Knight\./ window 70,0
+63.0 "Knight + Soldier (NW)" sync / 03:........:Clockwork Knight\.:/  window 70,0
 63.0 "Knight + Soldier (NE)"
 
-123.0 "Dreadnaught (NW)" sync / 03:........:Added new combatant Clockwork Dreadnaught\./ window 130,0
+123.0 "Dreadnaught (NW)" sync / 03:........:Clockwork Dreadnaught\.:/  window 130,0
 123.0 "4x Bug (S)"
 
-183.0 "2x Rook (E/W)" sync / 03:........:Added new combatant Spinner-rook\./ window 190,0
+183.0 "2x Rook (E/ 03:........:Spinner-rook\.:/  03:........:Added new combatant Spinner-rook\.
 183.0 "4x Bug (outside)"
 
-243.0 "Dreadnaught (NE)" sync / 03:........:Added new combatant Clockwork Dreadnaught\./ window 115,0
+243.0 "Dreadnaught (NE)" sync / 03:........:Clockwork Dreadnaught\.:/  window 115,0
 243.0 "Soldier (center)"
 243.0 "Knight (SE)"
 
-303.0 "Dreadnaught (NE)" sync / 03:........:Added new combatant Clockwork Dreadnaught\./ window 55,0
+303.0 "Dreadnaught (NE)" sync / 03:........:Clockwork Dreadnaught\.:/  window 55,0
 303.0 "Knight (center)"
 303.0 "Soldier (SW)"
 303.0 "Rook (NE)"
 303.0 "2x Bug (SE/NW)"
 
-423.0 "Emergency Override" sync /:Drive Cylinder:4EA:/ window 500,500
+423.0 "Emergency Override" sync / 1[56]:Drive Cylinder:4EA:/ window 500,500
 427.0 "Emergency Override"
 431.0 "Emergency Override"
 435.0 "Emergency Override"

--- a/ui/raidboss/data/02-arr/raid/t4.txt
+++ b/ui/raidboss/data/02-arr/raid/t4.txt
@@ -9,7 +9,7 @@
 123.0 "Dreadnaught (NW)" sync / 03:........:Clockwork Dreadnaught:/  window 130,0
 123.0 "4x Bug (S)"
 
-183.0 "2x Rook (E/ 03:........:Spinner-rook:/  03:........:Added new combatant Spinner-rook\.
+183.0 "2x Rook (E/W)"  sync/ 03:........:Spinner-rook:/  window 190,0
 183.0 "4x Bug (outside)"
 
 243.0 "Dreadnaught (NE)" sync / 03:........:Clockwork Dreadnaught:/  window 115,0

--- a/ui/raidboss/data/02-arr/raid/t5.txt
+++ b/ui/raidboss/data/02-arr/raid/t5.txt
@@ -8,7 +8,7 @@
 hideall "--Reset--"
 hideall "--sync--"
 
-0.0 "--reset--" sync / 00:0839::.*is no longer sealed/ window 100000 jump 0
+0.0 "--Reset--" sync / 00:0839::.*is no longer sealed/ window 100000 jump 0
 
 ### Phase 1
 0.0 "Start"

--- a/ui/raidboss/data/02-arr/raid/t5.txt
+++ b/ui/raidboss/data/02-arr/raid/t5.txt
@@ -8,7 +8,7 @@
 hideall "--Reset--"
 hideall "--sync--"
 
-0 "--reset--" sync / 00:0839::.*is no longer sealed/ window 100000 jump 0
+0.0 "--reset--" sync / 00:0839::.*is no longer sealed/ window 100000 jump 0
 
 ### Phase 1
 0.0 "Start"

--- a/ui/raidboss/data/02-arr/raid/t5.txt
+++ b/ui/raidboss/data/02-arr/raid/t5.txt
@@ -8,41 +8,41 @@
 hideall "--Reset--"
 hideall "--sync--"
 
-0.0 "--Reset--" sync / 00:0839:.*is no longer sealed/ window 10000 jump 0
+0 "--reset--" sync / 00:0839::.*is no longer sealed/ window 100000 jump 0
 
 ### Phase 1
 0.0 "Start"
 0.0 "--sync--" sync /:Engage!/ window 0,1
-0.0 "--sync--" sync / 00:0839:The Right Hand of Bahamut will be sealed off/ window 10,10
-7.5 "Plummet" sync /:Twintania:4D8:/ window 10,5
-21.6 "Death Sentence" sync /:Twintania:5B2:/ window 22,10
-25.7 "Plummet" sync /:Twintania:4D8:/
-38.4 "Plummet" sync /:Twintania:4D8:/
-51.8 "Plummet" sync /:Twintania:4D8:/
-57.9 "Death Sentence" sync /:Twintania:5B2:/ window 22,10
-65.3 "Plummet" sync /:Twintania:4D8:/
+0.0 "--sync--" sync / 00:0839::The Right Hand of Bahamut will be sealed off/ window 10,10
+7.5 "Plummet" sync / 1[56]:Twintania:4D8:/ window 10,5
+21.6 "Death Sentence" sync / 1[56]:Twintania:5B2:/ window 22,10
+25.7 "Plummet" sync / 1[56]:Twintania:4D8:/
+38.4 "Plummet" sync / 1[56]:Twintania:4D8:/
+51.8 "Plummet" sync / 1[56]:Twintania:4D8:/
+57.9 "Death Sentence" sync / 1[56]:Twintania:5B2:/ window 22,10
+65.3 "Plummet" sync / 1[56]:Twintania:4D8:/
 # ???
 
 
 ### Phase 2
-200.0 "--sync--" sync /:Twintania:5AC:/ window 200,0
-205.0 "Fireball" sync /:Twintania:4DE:/
-219.0 "Firestorm" sync /:Twintania:5AB:/
-229.3 "Fireball" sync /:Twintania:4DE:/
-254.9 "Fireball" sync /:Twintania:4DE:/
-257.4 "Firestorm" sync /:Twintania:5AB:/
-280.0 "Fireball" sync /:Twintania:4DE:/
+200.0 "--sync--" sync / 1[56]:Twintania:5AC:/ window 200,0
+205.0 "Fireball" sync / 1[56]:Twintania:4DE:/
+219.0 "Firestorm" sync / 1[56]:Twintania:5AB:/
+229.3 "Fireball" sync / 1[56]:Twintania:4DE:/
+254.9 "Fireball" sync / 1[56]:Twintania:4DE:/
+257.4 "Firestorm" sync / 1[56]:Twintania:5AB:/
+280.0 "Fireball" sync / 1[56]:Twintania:4DE:/
 # ???
 
 ### Phase 3
-400.0 "Divebomb" sync /:Twintania:5B0:/ window 400,0
-407.9 "Divebomb" sync /:Twintania:5B0:/
-415.6 "Divebomb" sync /:Twintania:5B0:/
+400.0 "Divebomb" sync / 1[56]:Twintania:5B0:/ window 400,0
+407.9 "Divebomb" sync / 1[56]:Twintania:5B0:/
+415.6 "Divebomb" sync / 1[56]:Twintania:5B0:/
 419.6 "1x Asclepius add"
 419.6 "2x Hygieia adds"
-465.3 "Divebomb" sync /:Twintania:5B0:/ window 30,5
-473.0 "Divebomb" sync /:Twintania:5B0:/
-480.9 "Divebomb" sync /:Twintania:5B0:/
+465.3 "Divebomb" sync / 1[56]:Twintania:5B0:/ window 30,5
+473.0 "Divebomb" sync / 1[56]:Twintania:5B0:/
+480.9 "Divebomb" sync / 1[56]:Twintania:5B0:/
 484.9 "2x Hygieia adds"
 
 
@@ -53,20 +53,20 @@ hideall "--sync--"
 # weird.  Having twister timers seems nice though, even if it's not perfect.
 
 546.0 "--targetable--"
-600.0 "Aetheric Profusion" sync /:Twintania:4E0:/ window 600,0
-616.0 "Unwoven Will" sync /:Twintania:4E3:/ window 50,20
-637.8 "Twister" sync /:Twintania:4E1:/
-656.2 "Unwoven Will" sync /:Twintania:4E3:/ window 30,30
-664.6 "Twister" sync /:Twintania:4E1:/
-685.8 "Twister" sync /:Twintania:4E1:/
+600.0 "Aetheric Profusion" sync / 1[56]:Twintania:4E0:/ window 600,0
+616.0 "Unwoven Will" sync / 1[56]:Twintania:4E3:/ window 50,20
+637.8 "Twister" sync / 1[56]:Twintania:4E1:/
+656.2 "Unwoven Will" sync / 1[56]:Twintania:4E3:/ window 30,30
+664.6 "Twister" sync / 1[56]:Twintania:4E1:/
+685.8 "Twister" sync / 1[56]:Twintania:4E1:/
 
-696.0 "Unwoven Will" sync /:Twintania:4E3:/ window 30,30
-711.0 "Twister" sync /:Twintania:4E1:/
-736.2 "Unwoven Will" sync /:Twintania:4E3:/ window 30,30
-744.6 "Twister" sync /:Twintania:4E1:/
-765.8 "Twister" sync /:Twintania:4E1:/
+696.0 "Unwoven Will" sync / 1[56]:Twintania:4E3:/ window 30,30
+711.0 "Twister" sync / 1[56]:Twintania:4E1:/
+736.2 "Unwoven Will" sync / 1[56]:Twintania:4E3:/ window 30,30
+744.6 "Twister" sync / 1[56]:Twintania:4E1:/
+765.8 "Twister" sync / 1[56]:Twintania:4E1:/
 
-776.0 "Unwoven Will" sync /:Twintania:4E3:/ window 30,30 jump 696
+776.0 "Unwoven Will" sync / 1[56]:Twintania:4E3:/ window 30,30 jump 696
 791.0 "Twister"
 816.2 "Unwoven Will"
 824.6 "Twister"
@@ -74,10 +74,10 @@ hideall "--sync--"
 
 
 ### Phase 5
-900.0 "Hatch" sync /:Twintania:5AD:/ window 900,0
-904.0 "Liquid Hell" sync /:Twintania:5B1:/ duration 8 window 200,200
-912.5 "Hatch" sync /:Twintania:5AD:/
-921.0 "Hatch" sync /:Twintania:5AD:/
+900.0 "Hatch" sync / 1[56]:Twintania:5AD:/ window 900,0
+904.0 "Liquid Hell" sync / 1[56]:Twintania:5B1:/ duration 8 window 200,200
+912.5 "Hatch" sync / 1[56]:Twintania:5AD:/
+921.0 "Hatch" sync / 1[56]:Twintania:5AD:/
 922.0 "Liquid Hell"
 930.5 "Hatch"
 939.0 "Hatch"
@@ -88,7 +88,7 @@ hideall "--sync--"
 
 ### Enrage
 # There's also plummets in here on a different timer.
-1000 "Aetheric Profusion" sync /:Twintania:4E0:/ window 399,100
+1000 "Aetheric Profusion" sync / 1[56]:Twintania:4E0:/ window 399,100
 1006 "Aetheric Profusion"
 1012 "Aetheric Profusion"
 1018 "Aetheric Profusion"

--- a/ui/raidboss/data/02-arr/raid/t6.txt
+++ b/ui/raidboss/data/02-arr/raid/t6.txt
@@ -4,7 +4,7 @@
 hideall "--Reset--"
 hideall "--sync--"
 
-0.0 "--reset--" sync / 00:0839::.*is no longer sealed/ window 100000 jump 0
+0.0 "--Reset--" sync / 00:0839::.*is no longer sealed/ window 100000 jump 0
 
 ### Phase 1
 0.0 "Start"

--- a/ui/raidboss/data/02-arr/raid/t6.txt
+++ b/ui/raidboss/data/02-arr/raid/t6.txt
@@ -4,7 +4,7 @@
 hideall "--Reset--"
 hideall "--sync--"
 
-0 "--reset--" sync / 00:0839::.*is no longer sealed/ window 100000 jump 0
+0.0 "--reset--" sync / 00:0839::.*is no longer sealed/ window 100000 jump 0
 
 ### Phase 1
 0.0 "Start"

--- a/ui/raidboss/data/02-arr/raid/t6.txt
+++ b/ui/raidboss/data/02-arr/raid/t6.txt
@@ -4,33 +4,33 @@
 hideall "--Reset--"
 hideall "--sync--"
 
-0.0 "--Reset--" sync / 00:0839:.*is no longer sealed/ window 10000 jump 0
+0 "--reset--" sync / 00:0839::.*is no longer sealed/ window 100000 jump 0
 
 ### Phase 1
 0.0 "Start"
 0.0 "--sync--" sync /:Engage!/ window 0,1
-0.0 "--sync--" sync / 00:0839:Scar's Edge will be sealed off/ window 10,10
-7.5 "Bloody Caress" sync /:Rafflesia:797:/ window 8,8
-11.5 "Thorn Whip" sync /:Rafflesia:879:/
-18.5 "Briary Growth" sync /:Rafflesia:884:/ window 20,20
-20.6 "Bloody Caress" sync /:Rafflesia:797:/
-28.6 "Thorn Whip" sync /:Rafflesia:879:/
-35.3 "Floral Trap" sync /:Rafflesia:799:/
-37.4 "Devour" sync /:Rafflesia:79A:/
-42.5 "Spit" sync /:Rafflesia:79B:/
-46.6 "Bloody Caress" sync /:Rafflesia:797:/
-55.6 "Thorn Whip" sync /:Rafflesia:879:/
-58.7 "Bloody Caress" sync /:Rafflesia:797:/
-63.6 "Briary Growth" sync /:Rafflesia:884:/ window 20,20
-70.8 "Bloody Caress" sync /:Rafflesia:797:/
-73.7 "Thorn Whip" sync /:Rafflesia:879:/
-80.5 "Floral Trap" sync /:Rafflesia:799:/
-82.5 "Devour" sync /:Rafflesia:79A:/
-87.6 "Spit" sync /:Rafflesia:79B:/
+0.0 "--sync--" sync / 00:0839::Scar's Edge will be sealed off/ window 10,10
+7.5 "Bloody Caress" sync / 1[56]:Rafflesia:797:/ window 8,8
+11.5 "Thorn Whip" sync / 1[56]:Rafflesia:879:/
+18.5 "Briary Growth" sync / 1[56]:Rafflesia:884:/ window 20,20
+20.6 "Bloody Caress" sync / 1[56]:Rafflesia:797:/
+28.6 "Thorn Whip" sync / 1[56]:Rafflesia:879:/
+35.3 "Floral Trap" sync / 1[56]:Rafflesia:799:/
+37.4 "Devour" sync / 1[56]:Rafflesia:79A:/
+42.5 "Spit" sync / 1[56]:Rafflesia:79B:/
+46.6 "Bloody Caress" sync / 1[56]:Rafflesia:797:/
+55.6 "Thorn Whip" sync / 1[56]:Rafflesia:879:/
+58.7 "Bloody Caress" sync / 1[56]:Rafflesia:797:/
+63.6 "Briary Growth" sync / 1[56]:Rafflesia:884:/ window 20,20
+70.8 "Bloody Caress" sync / 1[56]:Rafflesia:797:/
+73.7 "Thorn Whip" sync / 1[56]:Rafflesia:879:/
+80.5 "Floral Trap" sync / 1[56]:Rafflesia:799:/
+82.5 "Devour" sync / 1[56]:Rafflesia:79A:/
+87.6 "Spit" sync / 1[56]:Rafflesia:79B:/
 
-96.9 "Bloody Caress" sync /:Rafflesia:797:/
-100.9 "Thorn Whip" sync /:Rafflesia:879:/
-107.9 "Briary Growth" sync /:Rafflesia:884:/ window 20,20 jump 18.5
+96.9 "Bloody Caress" sync / 1[56]:Rafflesia:797:/
+100.9 "Thorn Whip" sync / 1[56]:Rafflesia:879:/
+107.9 "Briary Growth" sync / 1[56]:Rafflesia:884:/ window 20,20 jump 18.5
 110.0 "Bloody Caress"
 118.0 "Thorn Whip"
 124.7 "Floral Trap"
@@ -41,29 +41,29 @@ hideall "--sync--"
 ### Phase 2
 # There is a Bloody Caress (often?) right at the start of this phase before blighted.
 # But it's hard to sync to it properly, sorry.
-200.0 "--sync--" sync /:79D:Rafflesia/ window 200,0
-204.0 "Blighted Bouquet" sync /:Rafflesia:79D:/
-209.0 "Briary Growth" sync /:Rafflesia:884:/ window 20,20
-214.1 "Bloody Caress" sync /:Rafflesia:797:/
-219.0 "Thorn Whip" sync /:Rafflesia:879:/
-225.8 "Floral Trap" sync /:Rafflesia:799:/
-227.8 "Devour" sync /:Rafflesia:79A:/
-232.8 "Spit" sync /:Rafflesia:79B:/
-235.8 "Viscid Emission" sync /:Rafflesia:79C:/
-240.9 "Bloody Caress" sync /:Rafflesia:797:/
-244.9 "Thorn Whip" sync /:Rafflesia:879:/
-254.0 "Blighted Bouquet" sync /:Rafflesia:79D:/
-258.2 "Bloody Caress" sync /:Rafflesia:797:/
-260.1 "Briary Growth" sync /:Rafflesia:884:/ window 20,20
-269.2 "Thorn Whip" sync /:Rafflesia:879:/
-275.5 "Floral Trap" sync /:Rafflesia:799:/
-277.5 "Devour" sync /:Rafflesia:79A:/
-282.5 "Spit" sync /:Rafflesia:79B:/
-285.3 "Bloody Caress" sync /:Rafflesia:797:/
-294.2 "Thorn Whip" sync /:Rafflesia:879:/
-297.5 "Bloody Caress" sync /:Rafflesia:797:/
+200.0 "--sync--" sync / 14:Rafflesia:79D:/ window 200,0
+204.0 "Blighted Bouquet" sync / 1[56]:Rafflesia:79D:/
+209.0 "Briary Growth" sync / 1[56]:Rafflesia:884:/ window 20,20
+214.1 "Bloody Caress" sync / 1[56]:Rafflesia:797:/
+219.0 "Thorn Whip" sync / 1[56]:Rafflesia:879:/
+225.8 "Floral Trap" sync / 1[56]:Rafflesia:799:/
+227.8 "Devour" sync / 1[56]:Rafflesia:79A:/
+232.8 "Spit" sync / 1[56]:Rafflesia:79B:/
+235.8 "Viscid Emission" sync / 1[56]:Rafflesia:79C:/
+240.9 "Bloody Caress" sync / 1[56]:Rafflesia:797:/
+244.9 "Thorn Whip" sync / 1[56]:Rafflesia:879:/
+254.0 "Blighted Bouquet" sync / 1[56]:Rafflesia:79D:/
+258.2 "Bloody Caress" sync / 1[56]:Rafflesia:797:/
+260.1 "Briary Growth" sync / 1[56]:Rafflesia:884:/ window 20,20
+269.2 "Thorn Whip" sync / 1[56]:Rafflesia:879:/
+275.5 "Floral Trap" sync / 1[56]:Rafflesia:799:/
+277.5 "Devour" sync / 1[56]:Rafflesia:79A:/
+282.5 "Spit" sync / 1[56]:Rafflesia:79B:/
+285.3 "Bloody Caress" sync / 1[56]:Rafflesia:797:/
+294.2 "Thorn Whip" sync / 1[56]:Rafflesia:879:/
+297.5 "Bloody Caress" sync / 1[56]:Rafflesia:797:/
 
-304.4 "Blighted Bouquet" sync /:Rafflesia:79D:/ window 30,30 jump 204
+304.4 "Blighted Bouquet" sync / 1[56]:Rafflesia:79D:/ window 30,30 jump 204
 309.4 "Briary Growth"
 314.5 "Bloody Caress"
 319.4 "Thorn Whip"
@@ -75,32 +75,32 @@ hideall "--sync--"
 ### Phase 3
 # This ignores dinky leafstorms that do like 200 damage.
 
-400.0 "--sync--" sync /:79E:Rafflesia/ window 400,0
-403.0 "Leafstorm" sync /:Rafflesia:79E:/
-413.1 "Acid Rain" sync /:Rafflesia:86C:/
-420.3 "Thorn Whip" sync /:Rafflesia:879:/
-432.4 "Swarm" sync /:Rafflesia:7A0:/
-445.5 "Thorn Whip" sync /:Rafflesia:879:/
-450.3 "Rotten Stench" sync /:Rafflesia:7A2:/
-465.5 "Swarm" sync /:Rafflesia:7A0:/
-478.5 "Thorn Whip" sync /:Rafflesia:879:/
-490.7 "Swarm" sync /:Rafflesia:7A0:/
-495.6 "Thorn Whip" sync /:Rafflesia:879:/
-500.1 "Rotten Stench" sync /:Rafflesia:7A2:/
+400.0 "--sync--" sync / 14:Rafflesia:79E:/ window 400,0
+403.0 "Leafstorm" sync / 1[56]:Rafflesia:79E:/
+413.1 "Acid Rain" sync / 1[56]:Rafflesia:86C:/
+420.3 "Thorn Whip" sync / 1[56]:Rafflesia:879:/
+432.4 "Swarm" sync / 1[56]:Rafflesia:7A0:/
+445.5 "Thorn Whip" sync / 1[56]:Rafflesia:879:/
+450.3 "Rotten Stench" sync / 1[56]:Rafflesia:7A2:/
+465.5 "Swarm" sync / 1[56]:Rafflesia:7A0:/
+478.5 "Thorn Whip" sync / 1[56]:Rafflesia:879:/
+490.7 "Swarm" sync / 1[56]:Rafflesia:7A0:/
+495.6 "Thorn Whip" sync / 1[56]:Rafflesia:879:/
+500.1 "Rotten Stench" sync / 1[56]:Rafflesia:7A2:/
 
 # looping leafstorm (the first one has swarm later)
-523.2 "Leafstorm" sync /:Rafflesia:79E:/ window 100,300
-528.4 "Swarm" sync /:Rafflesia:7A0:/
-537.3 "Acid Rain" sync /:Rafflesia:86C:/
-544.4 "Thorn Whip" sync /:Rafflesia:879:/
-556.7 "Swarm" sync /:Rafflesia:7A0:/
-569.6 "Thorn Whip" sync /:Rafflesia:879:/
-574.4 "Rotten Stench" sync /:Rafflesia:7A2:/
-589.7 "Swarm" sync /:Rafflesia:7A0:/
-602.7 "Thorn Whip" sync /:Rafflesia:879:/
-614.8 "Swarm" sync /:Rafflesia:7A0:/
-619.7 "Thorn Whip" sync /:Rafflesia:879:/
-624.5 "Rotten Stench" sync /:Rafflesia:7A2:/
+523.2 "Leafstorm" sync / 1[56]:Rafflesia:79E:/ window 100,300
+528.4 "Swarm" sync / 1[56]:Rafflesia:7A0:/
+537.3 "Acid Rain" sync / 1[56]:Rafflesia:86C:/
+544.4 "Thorn Whip" sync / 1[56]:Rafflesia:879:/
+556.7 "Swarm" sync / 1[56]:Rafflesia:7A0:/
+569.6 "Thorn Whip" sync / 1[56]:Rafflesia:879:/
+574.4 "Rotten Stench" sync / 1[56]:Rafflesia:7A2:/
+589.7 "Swarm" sync / 1[56]:Rafflesia:7A0:/
+602.7 "Thorn Whip" sync / 1[56]:Rafflesia:879:/
+614.8 "Swarm" sync / 1[56]:Rafflesia:7A0:/
+619.7 "Thorn Whip" sync / 1[56]:Rafflesia:879:/
+624.5 "Rotten Stench" sync / 1[56]:Rafflesia:7A2:/
 
 647.6 "Leafstorm"
 652.8 "Swarm"
@@ -119,8 +119,8 @@ hideall "--sync--"
 # This does like 60k damage so probably will kill you
 # if you are so slow to see it, but just for completeness
 # it repeats every five seconds.
-1000.0 "--sync--" sync /:87A:Rafflesia/ window 1000,1000
-1003.0 "Leafstorm" sync /:Rafflesia:87A:/
+1000.0 "--sync--" sync / 14:Rafflesia:87A:/ window 1000,1000
+1003.0 "Leafstorm" sync / 1[56]:Rafflesia:87A:/
 1008.0 "Leafstorm"
 1013.0 "Leafstorm"
 1018.0 "Leafstorm"

--- a/ui/raidboss/data/02-arr/raid/t7.txt
+++ b/ui/raidboss/data/02-arr/raid/t7.txt
@@ -4,274 +4,274 @@
 hideall "--Reset--"
 hideall "--sync--"
 
-0.0 "--Reset--" sync / 00:0839:.*is no longer sealed/ window 10000 jump 0
+0 "--reset--" sync / 00:0839::.*is no longer sealed/ window 100000 jump 0
 
 ### Phase 1 (100%)
 0.0 "Start"
 0.0 "--sync--" sync /:Engage!/ window 0,1
-0.0 "--sync--" sync / 00:0839:Bioweapon Storage will be sealed off/ window 10,10
-6.4 "Tail Slap" sync /:Melusine:7A8:/ window 7,0
-12.3 "Cursed Voice" sync /:Melusine:7AC:/
-14.3 "Circle Of Flames x2" #sync /:Melusine:7AA:/
-24.8 "Circle Blade" sync /:Melusine:7AB:/
-26.5 "Tail Slap" sync /:Melusine:7A8:/
-30.3 "Circle Of Flames x2" #sync /:Melusine:7AA:/
-36.4 "Cursed Voice" sync /:Melusine:7AC:/
-42.5 "Tail Slap" sync /:Melusine:7A8:/
-48.8 "Circle Blade" sync /:Melusine:7AB:/
-50.5 "Circle Of Flames x2" #sync /:Melusine:7AA:/
-60.4 "Cursed Voice" sync /:Melusine:7AC:/
-61.5 "Tail Slap" sync /:Melusine:7A8:/
-66.3 "Circle Of Flames x2" #sync /:Melusine:7AA:/
-72.7 "Circle Blade" sync /:Melusine:7AB:/
-77.5 "Tail Slap" sync /:Melusine:7A8:/
-82.3 "Circle Of Flames x2" #sync /:Melusine:7AA:/
-86.6 "Cursed Voice" sync /:Melusine:7AC:/
-93.6 "Tail Slap" sync /:Melusine:7A8:/
-97.1 "Circle Blade" sync /:Melusine:7AB:/
-99.1 "Circle Of Flames x2" #sync /:Melusine:7AA:/
-110.7 "Cursed Voice" sync /:Melusine:7AC:/
-111.8 "Tail Slap" sync /:Melusine:7A8:/
-114.8 "Circle Of Flames x2" #sync /:Melusine:7AA:/
-121.2 "Circle Blade" sync /:Melusine:7AB:/
-127.8 "Tail Slap" sync /:Melusine:7A8:/
-130.8 "Circle Of Flames x2" #sync /:Melusine:7AA:/
-135.1 "Cursed Voice" sync /:Melusine:7AC:/
-145.3 "Circle Blade" sync /:Melusine:7AB:/
-147.3 "Tail Slap" sync /:Melusine:7A8:/
-148.4 "Circle Of Flames x2" #sync /:Melusine:7AA:/
-159.2 "Cursed Voice" sync /:Melusine:7AC:/
-163.1 "Tail Slap" sync /:Melusine:7A8:/
-164.2 "Circle Of Flames x2" #sync /:Melusine:7AA:/
-169.1 "Circle Blade" sync /:Melusine:7AB:/
-179.1 "Tail Slap" sync /:Melusine:7A8:/
-180.2 "Circle Of Flames x2" #sync /:Melusine:7AA:/
-184.5 "Cursed Voice" sync /:Melusine:7AC:/
-193.3 "Circle Blade" sync /:Melusine:7AB:/
-195.2 "Tail Slap" sync /:Melusine:7A8:/
-196.6 "Circle Of Flames x2" #sync /:Melusine:7AA:/
+0.0 "--sync--" sync / 00:0839::Bioweapon Storage will be sealed off/ window 10,10
+6.4 "Tail Slap" sync / 1[56]:Melusine:7A8:/ window 7,0
+12.3 "Cursed Voice" sync / 1[56]:Melusine:7AC:/
+14.3 "Circle Of Flames x2" #sync / 1[56]:Melusine:7AA:/
+24.8 "Circle Blade" sync / 1[56]:Melusine:7AB:/
+26.5 "Tail Slap" sync / 1[56]:Melusine:7A8:/
+30.3 "Circle Of Flames x2" #sync / 1[56]:Melusine:7AA:/
+36.4 "Cursed Voice" sync / 1[56]:Melusine:7AC:/
+42.5 "Tail Slap" sync / 1[56]:Melusine:7A8:/
+48.8 "Circle Blade" sync / 1[56]:Melusine:7AB:/
+50.5 "Circle Of Flames x2" #sync / 1[56]:Melusine:7AA:/
+60.4 "Cursed Voice" sync / 1[56]:Melusine:7AC:/
+61.5 "Tail Slap" sync / 1[56]:Melusine:7A8:/
+66.3 "Circle Of Flames x2" #sync / 1[56]:Melusine:7AA:/
+72.7 "Circle Blade" sync / 1[56]:Melusine:7AB:/
+77.5 "Tail Slap" sync / 1[56]:Melusine:7A8:/
+82.3 "Circle Of Flames x2" #sync / 1[56]:Melusine:7AA:/
+86.6 "Cursed Voice" sync / 1[56]:Melusine:7AC:/
+93.6 "Tail Slap" sync / 1[56]:Melusine:7A8:/
+97.1 "Circle Blade" sync / 1[56]:Melusine:7AB:/
+99.1 "Circle Of Flames x2" #sync / 1[56]:Melusine:7AA:/
+110.7 "Cursed Voice" sync / 1[56]:Melusine:7AC:/
+111.8 "Tail Slap" sync / 1[56]:Melusine:7A8:/
+114.8 "Circle Of Flames x2" #sync / 1[56]:Melusine:7AA:/
+121.2 "Circle Blade" sync / 1[56]:Melusine:7AB:/
+127.8 "Tail Slap" sync / 1[56]:Melusine:7A8:/
+130.8 "Circle Of Flames x2" #sync / 1[56]:Melusine:7AA:/
+135.1 "Cursed Voice" sync / 1[56]:Melusine:7AC:/
+145.3 "Circle Blade" sync / 1[56]:Melusine:7AB:/
+147.3 "Tail Slap" sync / 1[56]:Melusine:7A8:/
+148.4 "Circle Of Flames x2" #sync / 1[56]:Melusine:7AA:/
+159.2 "Cursed Voice" sync / 1[56]:Melusine:7AC:/
+163.1 "Tail Slap" sync / 1[56]:Melusine:7A8:/
+164.2 "Circle Of Flames x2" #sync / 1[56]:Melusine:7AA:/
+169.1 "Circle Blade" sync / 1[56]:Melusine:7AB:/
+179.1 "Tail Slap" sync / 1[56]:Melusine:7A8:/
+180.2 "Circle Of Flames x2" #sync / 1[56]:Melusine:7AA:/
+184.5 "Cursed Voice" sync / 1[56]:Melusine:7AC:/
+193.3 "Circle Blade" sync / 1[56]:Melusine:7AB:/
+195.2 "Tail Slap" sync / 1[56]:Melusine:7A8:/
+196.6 "Circle Of Flames x2" #sync / 1[56]:Melusine:7AA:/
 
 ### Phase 2 (80%): shriek, 3 adds 30 seconds apart
 300.0 "--sync--" sync /:Melusine HP at 79%/ window 300,0
-306.6 "Tail Slap" sync /:Melusine:7A8:/ window 10,10
-345.6 "Cursed Voice" sync /:Melusine:7AC:/
-314.6 "Circle Of Flames x2" #sync /:Melusine:7AA:/
-319.0 "Cursed Shriek" sync /:Melusine:7AF:/ window 300,30 duration 11
-322.6 "Tail Slap" sync /:Melusine:7A8:/
-328.2 "Circle Blade" sync /:Melusine:7AB:/
+306.6 "Tail Slap" sync / 1[56]:Melusine:7A8:/ window 10,10
+345.6 "Cursed Voice" sync / 1[56]:Melusine:7AC:/
+314.6 "Circle Of Flames x2" #sync / 1[56]:Melusine:7AA:/
+319.0 "Cursed Shriek" sync / 1[56]:Melusine:7AF:/ window 300,30 duration 11
+322.6 "Tail Slap" sync / 1[56]:Melusine:7A8:/
+328.2 "Circle Blade" sync / 1[56]:Melusine:7AB:/
 330.0 "Deathdancer Add (NE)"
-330.7 "Circle Of Flames x2" #sync /:Melusine:7AA:/
-336.6 "Cursed Voice" sync /:Melusine:7AC:/
-338.8 "Tail Slap" sync /:Melusine:7A8:/
-346.7 "Circle Of Flames x2" #sync /:Melusine:7AA:/
+330.7 "Circle Of Flames x2" #sync / 1[56]:Melusine:7AA:/
+336.6 "Cursed Voice" sync / 1[56]:Melusine:7AC:/
+338.8 "Tail Slap" sync / 1[56]:Melusine:7A8:/
+346.7 "Circle Of Flames x2" #sync / 1[56]:Melusine:7AA:/
 
-354.6 "Tail Slap" sync /:Melusine:7A8:/
+354.6 "Tail Slap" sync / 1[56]:Melusine:7A8:/
 360.0 "Deathdancer Add (NW)"
-360.8 "Cursed Voice" sync /:Melusine:7AC:/
-362.6 "Circle Of Flames x2" #sync /:Melusine:7AA:/
-366.8 "Cursed Shriek" sync /:Melusine:7AF:/ duration 11
-370.7 "Tail Slap" sync /:Melusine:7A8:/
-374.5 "Circle Blade" sync /:Melusine:7AB:/
-378.8 "Circle Of Flames x2" #sync /:Melusine:7AA:/
-384.8 "Cursed Voice" sync /:Melusine:7AC:/
-386.8 "Tail Slap" sync /:Melusine:7A8:/
-394.7 "Circle Of Flames x2" #sync /:Melusine:7AA:/
+360.8 "Cursed Voice" sync / 1[56]:Melusine:7AC:/
+362.6 "Circle Of Flames x2" #sync / 1[56]:Melusine:7AA:/
+366.8 "Cursed Shriek" sync / 1[56]:Melusine:7AF:/ duration 11
+370.7 "Tail Slap" sync / 1[56]:Melusine:7A8:/
+374.5 "Circle Blade" sync / 1[56]:Melusine:7AB:/
+378.8 "Circle Of Flames x2" #sync / 1[56]:Melusine:7AA:/
+384.8 "Cursed Voice" sync / 1[56]:Melusine:7AC:/
+386.8 "Tail Slap" sync / 1[56]:Melusine:7A8:/
+394.7 "Circle Of Flames x2" #sync / 1[56]:Melusine:7AA:/
 
-402.8 "Tail Slap" sync /:Melusine:7A8:/
-408.8 "Cursed Voice" sync /:Melusine:7AC:/
-410.8 "Circle Of Flames x2" #sync /:Melusine:7AA:/
-415.0 "Cursed Shriek" sync /:Melusine:7AF:/ duration 11
-420.3 "Circle Blade" sync /:Melusine:7AB:/
-422.1 "Tail Slap" sync /:Melusine:7A8:/
-426.8 "Circle Of Flames x2" #sync /:Melusine:7AA:/
-432.8 "Cursed Voice" sync /:Melusine:7AC:/
-438.0 "Tail Slap" sync /:Melusine:7A8:/
-442.8 "Circle Of Flames x2" #sync /:Melusine:7AA:/
+402.8 "Tail Slap" sync / 1[56]:Melusine:7A8:/
+408.8 "Cursed Voice" sync / 1[56]:Melusine:7AC:/
+410.8 "Circle Of Flames x2" #sync / 1[56]:Melusine:7AA:/
+415.0 "Cursed Shriek" sync / 1[56]:Melusine:7AF:/ duration 11
+420.3 "Circle Blade" sync / 1[56]:Melusine:7AB:/
+422.1 "Tail Slap" sync / 1[56]:Melusine:7A8:/
+426.8 "Circle Of Flames x2" #sync / 1[56]:Melusine:7AA:/
+432.8 "Cursed Voice" sync / 1[56]:Melusine:7AC:/
+438.0 "Tail Slap" sync / 1[56]:Melusine:7A8:/
+442.8 "Circle Of Flames x2" #sync / 1[56]:Melusine:7AA:/
 
-454.2 "Tail Slap" sync /:Melusine:7A8:/
-457.3 "Cursed Voice" sync /:Melusine:7AC:/
-459.0 "Circle Of Flames x2" #sync /:Melusine:7AA:/
-463.2 "Cursed Shriek" sync /:Melusine:7AF:/ duration 11
-466.9 "Circle Blade" sync /:Melusine:7AB:/
-470.2 "Tail Slap" sync /:Melusine:7A8:/
-475.0 "Circle Of Flames x2" #sync /:Melusine:7AA:/
-481.4 "Cursed Voice" sync /:Melusine:7AC:/
-486.2 "Tail Slap" sync /:Melusine:7A8:/
-491.1 "Circle Of Flames x2" #sync /:Melusine:7AA:/
+454.2 "Tail Slap" sync / 1[56]:Melusine:7A8:/
+457.3 "Cursed Voice" sync / 1[56]:Melusine:7AC:/
+459.0 "Circle Of Flames x2" #sync / 1[56]:Melusine:7AA:/
+463.2 "Cursed Shriek" sync / 1[56]:Melusine:7AF:/ duration 11
+466.9 "Circle Blade" sync / 1[56]:Melusine:7AB:/
+470.2 "Tail Slap" sync / 1[56]:Melusine:7A8:/
+475.0 "Circle Of Flames x2" #sync / 1[56]:Melusine:7AA:/
+481.4 "Cursed Voice" sync / 1[56]:Melusine:7AC:/
+486.2 "Tail Slap" sync / 1[56]:Melusine:7A8:/
+491.1 "Circle Of Flames x2" #sync / 1[56]:Melusine:7AA:/
 
-502.2 "Tail Slap" sync /:Melusine:7A8:/
-505.5 "Cursed Voice" sync /:Melusine:7AC:/
-507.2 "Circle Of Flames x2" #sync /:Melusine:7AA:/
-511.4 "Cursed Shriek" sync /:Melusine:7AF:/ duration 11
-515.1 "Circle Blade" sync /:Melusine:7AB:/
-518.3 "Tail Slap" sync /:Melusine:7A8:/
-523.2 "Circle Of Flames x2" #sync /:Melusine:7AA:/
-529.5 "Cursed Voice" sync /:Melusine:7AC:/
-534.4 "Tail Slap" sync /:Melusine:7A8:/
-539.2 "Circle Of Flames x2" #sync /:Melusine:7AA:/
+502.2 "Tail Slap" sync / 1[56]:Melusine:7A8:/
+505.5 "Cursed Voice" sync / 1[56]:Melusine:7AC:/
+507.2 "Circle Of Flames x2" #sync / 1[56]:Melusine:7AA:/
+511.4 "Cursed Shriek" sync / 1[56]:Melusine:7AF:/ duration 11
+515.1 "Circle Blade" sync / 1[56]:Melusine:7AB:/
+518.3 "Tail Slap" sync / 1[56]:Melusine:7A8:/
+523.2 "Circle Of Flames x2" #sync / 1[56]:Melusine:7AA:/
+529.5 "Cursed Voice" sync / 1[56]:Melusine:7AC:/
+534.4 "Tail Slap" sync / 1[56]:Melusine:7A8:/
+539.2 "Circle Of Flames x2" #sync / 1[56]:Melusine:7AA:/
 
 
 ### Phase 3 (59%): 4 archer adds, exploding floor
 800.0 "--sync--" sync /:Melusine HP at 59%/ window 800,0
-812.0 "Cursed Voice" sync /:Melusine:7AC:/ window 12,10
-814.0 "Circle Of Flames x2" #sync /:Melusine:7AA:/
+812.0 "Cursed Voice" sync / 1[56]:Melusine:7AC:/ window 12,10
+814.0 "Circle Of Flames x2" #sync / 1[56]:Melusine:7AA:/
 
-820.1 "Red Lotus Blade" sync /:Melusine:7A9:/ window 820,20
-822.1 "Tail Slap" sync /:Melusine:7A8:/
-830.2 "Circle Of Flames x2" #sync /:Melusine:7AA:/
-836.1 "Cursed Voice" sync /:Melusine:7AC:/
-840.2 "Tail Slap" sync /:Melusine:7A8:/
-843.3 "Cursed Shriek" sync /:Melusine:7AF:/
-846.3 "Circle Of Flames x2" #sync /:Melusine:7AA:/
+820.1 "Red Lotus Blade" sync / 1[56]:Melusine:7A9:/ window 820,20
+822.1 "Tail Slap" sync / 1[56]:Melusine:7A8:/
+830.2 "Circle Of Flames x2" #sync / 1[56]:Melusine:7AA:/
+836.1 "Cursed Voice" sync / 1[56]:Melusine:7AC:/
+840.2 "Tail Slap" sync / 1[56]:Melusine:7A8:/
+843.3 "Cursed Shriek" sync / 1[56]:Melusine:7AF:/
+846.3 "Circle Of Flames x2" #sync / 1[56]:Melusine:7AA:/
 
-852.2 "Red Lotus Blade" sync /:Melusine:7A9:/
-854.3 "Tail Slap" sync /:Melusine:7A8:/
-860.2 "Cursed Voice" sync /:Melusine:7AC:/
-862.2 "Circle Of Flames x2" #sync /:Melusine:7AA:/
-870.3 "Tail Slap" sync /:Melusine:7A8:/
-878.4 "Circle Of Flames x2" #sync /:Melusine:7AA:/
-884.3 "Cursed Voice" sync /:Melusine:7AC:/
+852.2 "Red Lotus Blade" sync / 1[56]:Melusine:7A9:/
+854.3 "Tail Slap" sync / 1[56]:Melusine:7A8:/
+860.2 "Cursed Voice" sync / 1[56]:Melusine:7AC:/
+862.2 "Circle Of Flames x2" #sync / 1[56]:Melusine:7AA:/
+870.3 "Tail Slap" sync / 1[56]:Melusine:7A8:/
+878.4 "Circle Of Flames x2" #sync / 1[56]:Melusine:7AA:/
+884.3 "Cursed Voice" sync / 1[56]:Melusine:7AC:/
 
-885.4 "Red Lotus Blade" sync /:Melusine:7A9:/
-886.5 "Tail Slap" sync /:Melusine:7A8:/
-890.5 "Cursed Shriek" sync /:Melusine:7AF:/
-894.4 "Circle Of Flames x2" #sync /:Melusine:7AA:/
-902.8 "Tail Slap" sync /:Melusine:7A8:/
-908.3 "Cursed Voice" sync /:Melusine:7AC:/
-910.5 "Circle Of Flames x2" #sync /:Melusine:7AA:/
+885.4 "Red Lotus Blade" sync / 1[56]:Melusine:7A9:/
+886.5 "Tail Slap" sync / 1[56]:Melusine:7A8:/
+890.5 "Cursed Shriek" sync / 1[56]:Melusine:7AF:/
+894.4 "Circle Of Flames x2" #sync / 1[56]:Melusine:7AA:/
+902.8 "Tail Slap" sync / 1[56]:Melusine:7A8:/
+908.3 "Cursed Voice" sync / 1[56]:Melusine:7AC:/
+910.5 "Circle Of Flames x2" #sync / 1[56]:Melusine:7AA:/
 
-917.5 "Red Lotus Blade" sync /:Melusine:7A9:/
-918.7 "Tail Slap" sync /:Melusine:7A8:/
-926.6 "Circle Of Flames x2" #sync /:Melusine:7AA:/
-932.5 "Cursed Voice" sync /:Melusine:7AC:/
-934.8 "Tail Slap" sync /:Melusine:7A8:/
-937.8 "Cursed Shriek" sync /:Melusine:7AF:/
-942.7 "Circle Of Flames x2" #sync /:Melusine:7AA:/
+917.5 "Red Lotus Blade" sync / 1[56]:Melusine:7A9:/
+918.7 "Tail Slap" sync / 1[56]:Melusine:7A8:/
+926.6 "Circle Of Flames x2" #sync / 1[56]:Melusine:7AA:/
+932.5 "Cursed Voice" sync / 1[56]:Melusine:7AC:/
+934.8 "Tail Slap" sync / 1[56]:Melusine:7A8:/
+937.8 "Cursed Shriek" sync / 1[56]:Melusine:7AF:/
+942.7 "Circle Of Flames x2" #sync / 1[56]:Melusine:7AA:/
 
-949.4 "Red Lotus Blade" sync /:Melusine:7A9:/
-950.6 "Tail Slap" sync /:Melusine:7A8:/
-956.2 "Cursed Voice" sync /:Melusine:7AC:/
-958.4 "Circle Of Flames x2" #sync sync /:Melusine:7AA:/
-966.4 "Tail Slap" sync /:Melusine:7A8:/
-974.4 "Circle Of Flames x2" #sync sync /:Melusine:7AA:/
-980.2 "Cursed Voice" sync /:Melusine:7AC:/
+949.4 "Red Lotus Blade" sync / 1[56]:Melusine:7A9:/
+950.6 "Tail Slap" sync / 1[56]:Melusine:7A8:/
+956.2 "Cursed Voice" sync / 1[56]:Melusine:7AC:/
+958.4 "Circle Of Flames x2" #sync sync / 1[56]:Melusine:7AA:/
+966.4 "Tail Slap" sync / 1[56]:Melusine:7A8:/
+974.4 "Circle Of Flames x2" #sync sync / 1[56]:Melusine:7AA:/
+980.2 "Cursed Voice" sync / 1[56]:Melusine:7AC:/
 
-981.5 "Red Lotus Blade" sync /:Melusine:7A9:/
-982.6 "Tail Slap" sync /:Melusine:7A8:/
-985.7 "Cursed Shriek" sync /:Melusine:7AF:/
-990.4 "Circle Of Flames x2" #sync sync /:Melusine:7AA:/
-998.6 "Tail Slap" sync /:Melusine:7A8:/
-1004.2 "Cursed Voice" sync /:Melusine:7AC:/
-1006.4 "Circle Of Flames x2" #sync sync /:Melusine:7AA:/
+981.5 "Red Lotus Blade" sync / 1[56]:Melusine:7A9:/
+982.6 "Tail Slap" sync / 1[56]:Melusine:7A8:/
+985.7 "Cursed Shriek" sync / 1[56]:Melusine:7AF:/
+990.4 "Circle Of Flames x2" #sync sync / 1[56]:Melusine:7AA:/
+998.6 "Tail Slap" sync / 1[56]:Melusine:7A8:/
+1004.2 "Cursed Voice" sync / 1[56]:Melusine:7AC:/
+1006.4 "Circle Of Flames x2" #sync sync / 1[56]:Melusine:7AA:/
 
-1013.3 "Red Lotus Blade" sync /:Melusine:7A9:/
-1014.6 "Tail Slap" sync /:Melusine:7A8:/
-1022.5 "Circle Of Flames x2" #sync sync /:Melusine:7AA:/
-1028.3 "Cursed Voice" sync /:Melusine:7AC:/
-1030.7 "Tail Slap" sync /:Melusine:7A8:/
-1033.8 "Cursed Shriek" sync /:Melusine:7AF:/
-1038.5 "Circle Of Flames x2" #sync sync /:Melusine:7AA:/
+1013.3 "Red Lotus Blade" sync / 1[56]:Melusine:7A9:/
+1014.6 "Tail Slap" sync / 1[56]:Melusine:7A8:/
+1022.5 "Circle Of Flames x2" #sync sync / 1[56]:Melusine:7AA:/
+1028.3 "Cursed Voice" sync / 1[56]:Melusine:7AC:/
+1030.7 "Tail Slap" sync / 1[56]:Melusine:7A8:/
+1033.8 "Cursed Shriek" sync / 1[56]:Melusine:7AF:/
+1038.5 "Circle Of Flames x2" #sync sync / 1[56]:Melusine:7AA:/
 
-1045.4 "Red Lotus Blade" sync /:Melusine:7A9:/
-1046.7 "Tail Slap" sync /:Melusine:7A8:/
-1052.3 "Cursed Voice" sync /:Melusine:7AC:/
-1054.5 "Circle Of Flames x2" #sync sync /:Melusine:7AA:/
-1062.7 "Tail Slap" sync /:Melusine:7A8:/
-1070.5 "Circle Of Flames x2" #sync sync /:Melusine:7AA:/
-1076.3 "Cursed Voice" sync /:Melusine:7AC:/
+1045.4 "Red Lotus Blade" sync / 1[56]:Melusine:7A9:/
+1046.7 "Tail Slap" sync / 1[56]:Melusine:7A8:/
+1052.3 "Cursed Voice" sync / 1[56]:Melusine:7AC:/
+1054.5 "Circle Of Flames x2" #sync sync / 1[56]:Melusine:7AA:/
+1062.7 "Tail Slap" sync / 1[56]:Melusine:7A8:/
+1070.5 "Circle Of Flames x2" #sync sync / 1[56]:Melusine:7AA:/
+1076.3 "Cursed Voice" sync / 1[56]:Melusine:7AC:/
 
-1077.4 "Red Lotus Blade" sync /:Melusine:7A9:/
-1078.7 "Tail Slap" sync /:Melusine:7A8:/
-1081.8 "Cursed Shriek" sync /:Melusine:7AF:/
-1086.7 "Circle Of Flames x2" #sync sync /:Melusine:7AA:/
-1094.8 "Tail Slap" sync /:Melusine:7A8:/
-1100.4 "Cursed Voice" sync /:Melusine:7AC:/
-1102.6 "Circle Of Flames x2" #sync sync /:Melusine:7AA:/
+1077.4 "Red Lotus Blade" sync / 1[56]:Melusine:7A9:/
+1078.7 "Tail Slap" sync / 1[56]:Melusine:7A8:/
+1081.8 "Cursed Shriek" sync / 1[56]:Melusine:7AF:/
+1086.7 "Circle Of Flames x2" #sync sync / 1[56]:Melusine:7AA:/
+1094.8 "Tail Slap" sync / 1[56]:Melusine:7A8:/
+1100.4 "Cursed Voice" sync / 1[56]:Melusine:7AC:/
+1102.6 "Circle Of Flames x2" #sync sync / 1[56]:Melusine:7AA:/
 
-1109.5 "Red Lotus Blade" sync /:Melusine:7A9:/
-1110.9 "Tail Slap" sync /:Melusine:7A8:/
-1118.6 "Circle Of Flames x2" #sync sync /:Melusine:7AA:/
-1124.3 "Cursed Voice" sync /:Melusine:7AC:/
-1126.7 "Tail Slap" sync /:Melusine:7A8:/
-1129.8 "Cursed Shriek" sync /:Melusine:7AF:/
-1134.6 "Circle Of Flames x2" #sync sync /:Melusine:7AA:/
+1109.5 "Red Lotus Blade" sync / 1[56]:Melusine:7A9:/
+1110.9 "Tail Slap" sync / 1[56]:Melusine:7A8:/
+1118.6 "Circle Of Flames x2" #sync sync / 1[56]:Melusine:7AA:/
+1124.3 "Cursed Voice" sync / 1[56]:Melusine:7AC:/
+1126.7 "Tail Slap" sync / 1[56]:Melusine:7A8:/
+1129.8 "Cursed Shriek" sync / 1[56]:Melusine:7AF:/
+1134.6 "Circle Of Flames x2" #sync sync / 1[56]:Melusine:7AA:/
 
-1141.4 "Red Lotus Blade" sync /:Melusine:7A9:/
-1142.7 "Tail Slap" sync /:Melusine:7A8:/
-1148.4 "Cursed Voice" sync /:Melusine:7AC:/
-1150.6 "Circle Of Flames x2" #sync sync /:Melusine:7AA:/
-1158.7 "Tail Slap" sync /:Melusine:7A8:/
-1166.6 "Circle Of Flames x2" #sync sync /:Melusine:7AA:/
-1172.3 "Cursed Voice" sync /:Melusine:7AC:/
+1141.4 "Red Lotus Blade" sync / 1[56]:Melusine:7A9:/
+1142.7 "Tail Slap" sync / 1[56]:Melusine:7A8:/
+1148.4 "Cursed Voice" sync / 1[56]:Melusine:7AC:/
+1150.6 "Circle Of Flames x2" #sync sync / 1[56]:Melusine:7AA:/
+1158.7 "Tail Slap" sync / 1[56]:Melusine:7A8:/
+1166.6 "Circle Of Flames x2" #sync sync / 1[56]:Melusine:7AA:/
+1172.3 "Cursed Voice" sync / 1[56]:Melusine:7AC:/
 
-1173.4 "Red Lotus Blade" sync /:Melusine:7A9:/
-1174.7 "Tail Slap" sync /:Melusine:7A8:/
-1177.8 "Cursed Shriek" sync /:Melusine:7AF:/
-1182.6 "Circle Of Flames x2" #sync sync /:Melusine:7AA:/
-1190.9 "Tail Slap" sync /:Melusine:7A8:/
-1196.2 "Cursed Voice" sync /:Melusine:7AC:/
-1198.6 "Circle Of Flames x2" #sync sync /:Melusine:7AA:/
+1173.4 "Red Lotus Blade" sync / 1[56]:Melusine:7A9:/
+1174.7 "Tail Slap" sync / 1[56]:Melusine:7A8:/
+1177.8 "Cursed Shriek" sync / 1[56]:Melusine:7AF:/
+1182.6 "Circle Of Flames x2" #sync sync / 1[56]:Melusine:7AA:/
+1190.9 "Tail Slap" sync / 1[56]:Melusine:7A8:/
+1196.2 "Cursed Voice" sync / 1[56]:Melusine:7AC:/
+1198.6 "Circle Of Flames x2" #sync sync / 1[56]:Melusine:7AA:/
 
 
 ### Phase 5 (post-prosecutor): venomous tail
-1600.0 "Sacrifice" sync /:Lamia Prosector:86E:/ window 1600,0
-1601.0 "Frenzy" sync /:Melusine:86D:/
+1600.0 "Sacrifice" sync / 1[56]:Lamia Prosector:86E:/ window 1600,0
+1601.0 "Frenzy" sync / 1[56]:Melusine:86D:/
 
-1608.1 "Petrifaction" sync /:Melusine:7B1:/ window 1610,5
-1611.3 "Tail Slap" sync /:Melusine:7A8:/
-1617.9 "Circle Of Flames x2" #sync /:Melusine:7AA:/
-1624.0 "Cursed Voice" sync /:Melusine:7AC:/
-1627.1 "Tail Slap" sync /:Melusine:7A8:/
-1630.1 "Cursed Shriek" sync /:Melusine:7AF:/
-1634.1 "Circle Of Flames x2" #sync /:Melusine:7AA:/
-1638.9 "Red Lotus Blade" sync /:Melusine:7A9:/
-1643.0 "Venomous Tail" sync /:Melusine:7B2:/
-1644.1 "Tail Slap" sync /:Melusine:7A8:/
-1647.9 "Cursed Voice" sync /:Melusine:7AC:/
-1650.1 "Circle Of Flames x2" #sync /:Melusine:7AA:/
+1608.1 "Petrifaction" sync / 1[56]:Melusine:7B1:/ window 1610,5
+1611.3 "Tail Slap" sync / 1[56]:Melusine:7A8:/
+1617.9 "Circle Of Flames x2" #sync / 1[56]:Melusine:7AA:/
+1624.0 "Cursed Voice" sync / 1[56]:Melusine:7AC:/
+1627.1 "Tail Slap" sync / 1[56]:Melusine:7A8:/
+1630.1 "Cursed Shriek" sync / 1[56]:Melusine:7AF:/
+1634.1 "Circle Of Flames x2" #sync / 1[56]:Melusine:7AA:/
+1638.9 "Red Lotus Blade" sync / 1[56]:Melusine:7A9:/
+1643.0 "Venomous Tail" sync / 1[56]:Melusine:7B2:/
+1644.1 "Tail Slap" sync / 1[56]:Melusine:7A8:/
+1647.9 "Cursed Voice" sync / 1[56]:Melusine:7AC:/
+1650.1 "Circle Of Flames x2" #sync / 1[56]:Melusine:7AA:/
 
-1655.3 "Petrifaction" sync /:Melusine:7B1:/
-1660.2 "Tail Slap" sync /:Melusine:7A8:/
-1666.2 "Circle Of Flames x2" #sync /:Melusine:7AA:/
-1672.1 "Cursed Voice" sync /:Melusine:7AC:/
-1673.3 "Red Lotus Blade" sync /:Melusine:7A9:/
-1677.2 "Cursed Shriek" sync /:Melusine:7AF:/
-1678.5 "Tail Slap" sync /:Melusine:7A8:/
-1682.2 "Circle Of Flames x2" #sync /:Melusine:7AA:/
-1690.2 "Venomous Tail" sync /:Melusine:7B2:/
-1696.1 "Cursed Voice" sync /:Melusine:7AC:/
-1697.4 "Tail Slap" sync /:Melusine:7A8:/
-1698.4 "Circle Of Flames x2" #sync /:Melusine:7AA:/
+1655.3 "Petrifaction" sync / 1[56]:Melusine:7B1:/
+1660.2 "Tail Slap" sync / 1[56]:Melusine:7A8:/
+1666.2 "Circle Of Flames x2" #sync / 1[56]:Melusine:7AA:/
+1672.1 "Cursed Voice" sync / 1[56]:Melusine:7AC:/
+1673.3 "Red Lotus Blade" sync / 1[56]:Melusine:7A9:/
+1677.2 "Cursed Shriek" sync / 1[56]:Melusine:7AF:/
+1678.5 "Tail Slap" sync / 1[56]:Melusine:7A8:/
+1682.2 "Circle Of Flames x2" #sync / 1[56]:Melusine:7AA:/
+1690.2 "Venomous Tail" sync / 1[56]:Melusine:7B2:/
+1696.1 "Cursed Voice" sync / 1[56]:Melusine:7AC:/
+1697.4 "Tail Slap" sync / 1[56]:Melusine:7A8:/
+1698.4 "Circle Of Flames x2" #sync / 1[56]:Melusine:7AA:/
 
-1703.5 "Petrifaction" sync /:Melusine:7B1:/
-1705.3 "Red Lotus Blade" sync /:Melusine:7A9:/
-1713.3 "Tail Slap" sync /:Melusine:7A8:/
-1714.4 "Circle Of Flames x2" #sync /:Melusine:7AA:/
-1720.2 "Cursed Voice" sync /:Melusine:7AC:/
-1724.1 "Cursed Shriek" sync /:Melusine:7AF:/
-1729.2 "Tail Slap" sync /:Melusine:7A8:/
-1730.5 "Circle Of Flames x2" #sync /:Melusine:7AA:/
-1737.2 "Venomous Tail" sync /:Melusine:7B2:/
-1740.4 "Red Lotus Blade" sync /:Melusine:7A9:/
-1744.2 "Cursed Voice" sync /:Melusine:7AC:/
-1746.8 "Tail Slap" sync /:Melusine:7A8:/
-1747.9 "Circle Of Flames x2" #sync /:Melusine:7AA:/
+1703.5 "Petrifaction" sync / 1[56]:Melusine:7B1:/
+1705.3 "Red Lotus Blade" sync / 1[56]:Melusine:7A9:/
+1713.3 "Tail Slap" sync / 1[56]:Melusine:7A8:/
+1714.4 "Circle Of Flames x2" #sync / 1[56]:Melusine:7AA:/
+1720.2 "Cursed Voice" sync / 1[56]:Melusine:7AC:/
+1724.1 "Cursed Shriek" sync / 1[56]:Melusine:7AF:/
+1729.2 "Tail Slap" sync / 1[56]:Melusine:7A8:/
+1730.5 "Circle Of Flames x2" #sync / 1[56]:Melusine:7AA:/
+1737.2 "Venomous Tail" sync / 1[56]:Melusine:7B2:/
+1740.4 "Red Lotus Blade" sync / 1[56]:Melusine:7A9:/
+1744.2 "Cursed Voice" sync / 1[56]:Melusine:7AC:/
+1746.8 "Tail Slap" sync / 1[56]:Melusine:7A8:/
+1747.9 "Circle Of Flames x2" #sync / 1[56]:Melusine:7AA:/
 
-1752.9 "Petrifaction" sync /:Melusine:7B1:/
-1761.4 "Tail Slap" sync /:Melusine:7A8:/
-1763.8 "Circle Of Flames x2" #sync /:Melusine:7AA:/
-1768.4 "Cursed Voice" sync /:Melusine:7AC:/
-1771.5 "Cursed Shriek" sync /:Melusine:7AF:/
-1772.8 "Red Lotus Blade" sync /:Melusine:7A9:/
-1777.6 "Tail Slap" sync /:Melusine:7A8:/
-1780.0 "Circle Of Flames x2" #sync /:Melusine:7AA:/
-1785.2 "Venomous Tail" sync /:Melusine:7B2:/
-1792.4 "Cursed Voice" sync /:Melusine:7AC:/
-1795.9 "Tail Slap" sync /:Melusine:7A8:/
-1796.9 "Circle Of Flames x2" #sync /:Melusine:7AA:/
+1752.9 "Petrifaction" sync / 1[56]:Melusine:7B1:/
+1761.4 "Tail Slap" sync / 1[56]:Melusine:7A8:/
+1763.8 "Circle Of Flames x2" #sync / 1[56]:Melusine:7AA:/
+1768.4 "Cursed Voice" sync / 1[56]:Melusine:7AC:/
+1771.5 "Cursed Shriek" sync / 1[56]:Melusine:7AF:/
+1772.8 "Red Lotus Blade" sync / 1[56]:Melusine:7A9:/
+1777.6 "Tail Slap" sync / 1[56]:Melusine:7A8:/
+1780.0 "Circle Of Flames x2" #sync / 1[56]:Melusine:7AA:/
+1785.2 "Venomous Tail" sync / 1[56]:Melusine:7B2:/
+1792.4 "Cursed Voice" sync / 1[56]:Melusine:7AC:/
+1795.9 "Tail Slap" sync / 1[56]:Melusine:7A8:/
+1796.9 "Circle Of Flames x2" #sync / 1[56]:Melusine:7AA:/
 
-1802.1 "Petrifaction" sync /:Melusine:7B1:/
-1804.9 "Red Lotus Blade" sync /:Melusine:7A9:/
-1809.7 "Tail Slap" sync /:Melusine:7A8:/
-1813.0 "Circle Of Flames x2" #sync /:Melusine:7AA:/
-1817.2 "Cursed Voice" sync /:Melusine:7AC:/
+1802.1 "Petrifaction" sync / 1[56]:Melusine:7B1:/
+1804.9 "Red Lotus Blade" sync / 1[56]:Melusine:7A9:/
+1809.7 "Tail Slap" sync / 1[56]:Melusine:7A8:/
+1813.0 "Circle Of Flames x2" #sync / 1[56]:Melusine:7AA:/
+1817.2 "Cursed Voice" sync / 1[56]:Melusine:7AC:/

--- a/ui/raidboss/data/02-arr/raid/t7.txt
+++ b/ui/raidboss/data/02-arr/raid/t7.txt
@@ -4,7 +4,7 @@
 hideall "--Reset--"
 hideall "--sync--"
 
-0 "--reset--" sync / 00:0839::.*is no longer sealed/ window 100000 jump 0
+0.0 "--reset--" sync / 00:0839::.*is no longer sealed/ window 100000 jump 0
 
 ### Phase 1 (100%)
 0.0 "Start"

--- a/ui/raidboss/data/02-arr/raid/t7.txt
+++ b/ui/raidboss/data/02-arr/raid/t7.txt
@@ -4,7 +4,7 @@
 hideall "--Reset--"
 hideall "--sync--"
 
-0.0 "--reset--" sync / 00:0839::.*is no longer sealed/ window 100000 jump 0
+0.0 "--Reset--" sync / 00:0839::.*is no longer sealed/ window 100000 jump 0
 
 ### Phase 1 (100%)
 0.0 "Start"

--- a/ui/raidboss/data/02-arr/raid/t8.txt
+++ b/ui/raidboss/data/02-arr/raid/t8.txt
@@ -7,7 +7,7 @@
 hideall "--Reset--"
 hideall "--sync--"
 
-0.0 "--reset--" sync / 00:0839::.*is no longer sealed/ window 100000 jump 0
+0.0 "--Reset--" sync / 00:0839::.*is no longer sealed/ window 100000 jump 0
 
 ### Phase 1: introduction to towers
 0.0 "Start"

--- a/ui/raidboss/data/02-arr/raid/t8.txt
+++ b/ui/raidboss/data/02-arr/raid/t8.txt
@@ -7,7 +7,7 @@
 hideall "--Reset--"
 hideall "--sync--"
 
-0 "--reset--" sync / 00:0839::.*is no longer sealed/ window 100000 jump 0
+0.0 "--reset--" sync / 00:0839::.*is no longer sealed/ window 100000 jump 0
 
 ### Phase 1: introduction to towers
 0.0 "Start"

--- a/ui/raidboss/data/02-arr/raid/t8.txt
+++ b/ui/raidboss/data/02-arr/raid/t8.txt
@@ -7,69 +7,69 @@
 hideall "--Reset--"
 hideall "--sync--"
 
-0.0 "--Reset--" sync / 00:0839:.*is no longer sealed/ window 10000 jump 0
+0 "--reset--" sync / 00:0839::.*is no longer sealed/ window 100000 jump 0
 
 ### Phase 1: introduction to towers
 0.0 "Start"
 0.0 "--sync--" sync /:Engage!/ window 0,1
-0.0 "--sync--" sync / 00:0839:The central bow will be sealed off/ window 10,10
-3.5 "--sync--" sync /:The Avatar:7C[01]:/ window 3.5,0
-6.1 "Diffusion Ray" sync /:The Avatar:7C2:/ window 7,10
-26.0 "Homing Missile" sync /:The Avatar:7C7:/
-27.2 "Diffusion Ray" sync /:The Avatar:7C2:/
-34.9 "Gaseous Bomb" sync /:The Avatar:7C6:/
-42.2 "Diffusion Ray" sync /:The Avatar:7C2:/
-57.3 "Diffusion Ray" sync /:The Avatar:7C2:/
-65.9 "Homing Missile" sync /:The Avatar:7C7:/
-75.0 "Gaseous Bomb" sync /:The Avatar:7C6:/
-76.2 "Diffusion Ray" sync /:The Avatar:7C2:/
-91.2 "Diffusion Ray" sync /:The Avatar:7C2:/
-106.0 "Homing Missile" sync /:The Avatar:7C7:/
-107.2 "Diffusion Ray" sync /:The Avatar:7C2:/
-115.0 "Gaseous Bomb" sync /:The Avatar:7C6:/
-122.2 "Diffusion Ray" sync /:The Avatar:7C2:/
-137.2 "Diffusion Ray" sync /:The Avatar:7C2:/
-146.0 "Homing Missile" sync /:The Avatar:7C7:/
-155.0 "Gaseous Bomb" sync /:The Avatar:7C6:/
-156.2 "Diffusion Ray" sync /:The Avatar:7C2:/
+0.0 "--sync--" sync / 00:0839::The central bow will be sealed off/ window 10,10
+3.5 "--sync--" sync / 1[56]:The Avatar:7C[01]:/ window 3.5,0
+6.1 "Diffusion Ray" sync / 1[56]:The Avatar:7C2:/ window 7,10
+26.0 "Homing Missile" sync / 1[56]:The Avatar:7C7:/
+27.2 "Diffusion Ray" sync / 1[56]:The Avatar:7C2:/
+34.9 "Gaseous Bomb" sync / 1[56]:The Avatar:7C6:/
+42.2 "Diffusion Ray" sync / 1[56]:The Avatar:7C2:/
+57.3 "Diffusion Ray" sync / 1[56]:The Avatar:7C2:/
+65.9 "Homing Missile" sync / 1[56]:The Avatar:7C7:/
+75.0 "Gaseous Bomb" sync / 1[56]:The Avatar:7C6:/
+76.2 "Diffusion Ray" sync / 1[56]:The Avatar:7C2:/
+91.2 "Diffusion Ray" sync / 1[56]:The Avatar:7C2:/
+106.0 "Homing Missile" sync / 1[56]:The Avatar:7C7:/
+107.2 "Diffusion Ray" sync / 1[56]:The Avatar:7C2:/
+115.0 "Gaseous Bomb" sync / 1[56]:The Avatar:7C6:/
+122.2 "Diffusion Ray" sync / 1[56]:The Avatar:7C2:/
+137.2 "Diffusion Ray" sync / 1[56]:The Avatar:7C2:/
+146.0 "Homing Missile" sync / 1[56]:The Avatar:7C7:/
+155.0 "Gaseous Bomb" sync / 1[56]:The Avatar:7C6:/
+156.2 "Diffusion Ray" sync / 1[56]:The Avatar:7C2:/
 
 ### Phase 2 (75%): brainjack + ballistic missile
 # Inertia Stream hits twice 1 second apart.
 # Only sync backwards for this first of three.
-162.6 "Inertia Stream" sync /:The Avatar:7C9:/ window 170,0
-168.9 "Ballistic Missile" sync /:The Avatar:7CA:/
-176.6 "Diffusion Ray" sync /:The Avatar:7C2:/
-184.5 "Brainjack" sync /:The Avatar:7C3:/ duration 11
-191.6 "Diffusion Ray" sync /:The Avatar:7C2:/
-199.5 "Homing Missile" sync /:The Avatar:7C7:/
-206.6 "Diffusion Ray" sync /:The Avatar:7C2:/
-215.5 "Gaseous Bomb" sync /:The Avatar:7C6:/
-224.6 "Brainjack" sync /:The Avatar:7C3:/ duration 11
-225.8 "Diffusion Ray" sync /:The Avatar:7C2:/
-239.6 "Homing Missile" sync /:The Avatar:7C7:/
-240.9 "Diffusion Ray" sync /:The Avatar:7C2:/
+162.6 "Inertia Stream" sync / 1[56]:The Avatar:7C9:/ window 170,0
+168.9 "Ballistic Missile" sync / 1[56]:The Avatar:7CA:/
+176.6 "Diffusion Ray" sync / 1[56]:The Avatar:7C2:/
+184.5 "Brainjack" sync / 1[56]:The Avatar:7C3:/ duration 11
+191.6 "Diffusion Ray" sync / 1[56]:The Avatar:7C2:/
+199.5 "Homing Missile" sync / 1[56]:The Avatar:7C7:/
+206.6 "Diffusion Ray" sync / 1[56]:The Avatar:7C2:/
+215.5 "Gaseous Bomb" sync / 1[56]:The Avatar:7C6:/
+224.6 "Brainjack" sync / 1[56]:The Avatar:7C3:/ duration 11
+225.8 "Diffusion Ray" sync / 1[56]:The Avatar:7C2:/
+239.6 "Homing Missile" sync / 1[56]:The Avatar:7C7:/
+240.9 "Diffusion Ray" sync / 1[56]:The Avatar:7C2:/
 242.0 "Inertia Stream"
-248.3 "Ballistic Missile" sync /:The Avatar:7CA:/
-255.6 "Gaseous Bomb" sync /:The Avatar:7C6:/
-256.8 "Diffusion Ray" sync /:The Avatar:7C2:/
-264.7 "Brainjack" sync /:The Avatar:7C3:/ duration 11
-271.7 "Diffusion Ray" sync /:The Avatar:7C2:/
-279.6 "Homing Missile" sync /:The Avatar:7C7:/
-286.8 "Diffusion Ray" sync /:The Avatar:7C2:/
-295.7 "Gaseous Bomb" sync /:The Avatar:7C6:/
-304.8 "Brainjack" sync /:The Avatar:7C3:/ duration 11
-306.0 "Diffusion Ray" sync /:The Avatar:7C2:/
-319.7 "Homing Missile" sync /:The Avatar:7C7:/
-321.0 "Diffusion Ray" sync /:The Avatar:7C2:/
+248.3 "Ballistic Missile" sync / 1[56]:The Avatar:7CA:/
+255.6 "Gaseous Bomb" sync / 1[56]:The Avatar:7C6:/
+256.8 "Diffusion Ray" sync / 1[56]:The Avatar:7C2:/
+264.7 "Brainjack" sync / 1[56]:The Avatar:7C3:/ duration 11
+271.7 "Diffusion Ray" sync / 1[56]:The Avatar:7C2:/
+279.6 "Homing Missile" sync / 1[56]:The Avatar:7C7:/
+286.8 "Diffusion Ray" sync / 1[56]:The Avatar:7C2:/
+295.7 "Gaseous Bomb" sync / 1[56]:The Avatar:7C6:/
+304.8 "Brainjack" sync / 1[56]:The Avatar:7C3:/ duration 11
+306.0 "Diffusion Ray" sync / 1[56]:The Avatar:7C2:/
+319.7 "Homing Missile" sync / 1[56]:The Avatar:7C7:/
+321.0 "Diffusion Ray" sync / 1[56]:The Avatar:7C2:/
 322.2 "Inertia Stream"
-328.4 "Ballistic Missile" sync /:The Avatar:7CA:/
-335.8 "Gaseous Bomb" sync /:The Avatar:7C6:/
-337.0 "Diffusion Ray" sync /:The Avatar:7C2:/
-344.9 "Brainjack" sync /:The Avatar:7C3:/ duration 11
-352.0 "Diffusion Ray" sync /:The Avatar:7C2:/
-359.8 "Homing Missile" sync /:The Avatar:7C7:/
-367.1 "Diffusion Ray" sync /:The Avatar:7C2:/
-375.9 "Gaseous Bomb" sync /:The Avatar:7C6:/
+328.4 "Ballistic Missile" sync / 1[56]:The Avatar:7CA:/
+335.8 "Gaseous Bomb" sync / 1[56]:The Avatar:7C6:/
+337.0 "Diffusion Ray" sync / 1[56]:The Avatar:7C2:/
+344.9 "Brainjack" sync / 1[56]:The Avatar:7C3:/ duration 11
+352.0 "Diffusion Ray" sync / 1[56]:The Avatar:7C2:/
+359.8 "Homing Missile" sync / 1[56]:The Avatar:7C7:/
+367.1 "Diffusion Ray" sync / 1[56]:The Avatar:7C2:/
+375.9 "Gaseous Bomb" sync / 1[56]:The Avatar:7C6:/
 
 ### Phase 3 (45%): allagan field
 # NOTE: there seems to be two different last phase timings
@@ -80,38 +80,38 @@ hideall "--sync--"
 # can instead be the 380/460 pattern, with a different diffusion ray.
 # The field/missile/bomb/surge timings are all roughly the same, so this
 # just removes the ray syncs and hopes for the best.
-377.0 "--sync--" sync /:7C4:The Avatar/ window 400,0
-380.0 "Allagan Field" sync /:The Avatar:7C4:/ duration 31 window 400,10
-386.3 "Homing Missile" sync /:The Avatar:7C7:/
-387.6 "Diffusion Ray" #sync /:The Avatar:7C2:/
-394.2 "Gaseous Bomb" sync /:The Avatar:7C6:/
-402.5 "Diffusion Ray" #sync /:The Avatar:7C2:/
-410.9 "Critical Surge" sync /:Allagan Field:7C5:/
+377.0 "--sync--" sync / 14:The Avatar:7C4:/ window 400,0
+380.0 "Allagan Field" sync / 1[56]:The Avatar:7C4:/ duration 31 window 400,10
+386.3 "Homing Missile" sync / 1[56]:The Avatar:7C7:/
+387.6 "Diffusion Ray" #sync / 1[56]:The Avatar:7C2:/
+394.2 "Gaseous Bomb" sync / 1[56]:The Avatar:7C6:/
+402.5 "Diffusion Ray" #sync / 1[56]:The Avatar:7C2:/
+410.9 "Critical Surge" sync / 1[56]:Allagan Field:7C5:/
 
-420.0 "Allagan Field" sync /:The Avatar:7C4:/ duration 31
-421.2 "Diffusion Ray" #sync /:The Avatar:7C2:/
-427.2 "Homing Missile" sync /:The Avatar:7C7:/
-434.2 "Gaseous Bomb" sync /:The Avatar:7C6:/
-436.2 "Diffusion Ray" #sync /:The Avatar:7C2:/
-450.8 "Critical Surge" sync /:Allagan Field:7C5:/
-451.2 "Diffusion Ray" #sync /:The Avatar:7C2:/
+420.0 "Allagan Field" sync / 1[56]:The Avatar:7C4:/ duration 31
+421.2 "Diffusion Ray" #sync / 1[56]:The Avatar:7C2:/
+427.2 "Homing Missile" sync / 1[56]:The Avatar:7C7:/
+434.2 "Gaseous Bomb" sync / 1[56]:The Avatar:7C6:/
+436.2 "Diffusion Ray" #sync / 1[56]:The Avatar:7C2:/
+450.8 "Critical Surge" sync / 1[56]:Allagan Field:7C5:/
+451.2 "Diffusion Ray" #sync / 1[56]:The Avatar:7C2:/
 
-460.1 "Allagan Field" sync /:The Avatar:7C4:/ duration 31
-467.3 "Homing Missile" sync /:The Avatar:7C7:/
-468.5 "Diffusion Ray" #sync /:The Avatar:7C2:/
-474.3 "Gaseous Bomb" sync /:The Avatar:7C6:/
-483.6 "Diffusion Ray" #sync /:The Avatar:7C2:/
-490.9 "Critical Surge" sync /:Allagan Field:7C5:/
+460.1 "Allagan Field" sync / 1[56]:The Avatar:7C4:/ duration 31
+467.3 "Homing Missile" sync / 1[56]:The Avatar:7C7:/
+468.5 "Diffusion Ray" #sync / 1[56]:The Avatar:7C2:/
+474.3 "Gaseous Bomb" sync / 1[56]:The Avatar:7C6:/
+483.6 "Diffusion Ray" #sync / 1[56]:The Avatar:7C2:/
+490.9 "Critical Surge" sync / 1[56]:Allagan Field:7C5:/
 
-500.0 "Allagan Field" sync /:The Avatar:7C4:/ duration 31
-501.2 "Diffusion Ray" #sync /:The Avatar:7C2:/
-507.3 "Homing Missile" sync /:The Avatar:7C7:/
-514.3 "Gaseous Bomb" sync /:The Avatar:7C6:/
-516.2 "Diffusion Ray" #sync /:The Avatar:7C2:/
-530.9 "Critical Surge" sync /:Allagan Field:7C5:/
-531.2 "Diffusion Ray" #sync /:The Avatar:7C2:/
+500.0 "Allagan Field" sync / 1[56]:The Avatar:7C4:/ duration 31
+501.2 "Diffusion Ray" #sync / 1[56]:The Avatar:7C2:/
+507.3 "Homing Missile" sync / 1[56]:The Avatar:7C7:/
+514.3 "Gaseous Bomb" sync / 1[56]:The Avatar:7C6:/
+516.2 "Diffusion Ray" #sync / 1[56]:The Avatar:7C2:/
+530.9 "Critical Surge" sync / 1[56]:Allagan Field:7C5:/
+531.2 "Diffusion Ray" #sync / 1[56]:The Avatar:7C2:/
 
-540.1 "Allagan Field" sync /:The Avatar:7C4:/ duration 31 jump 460.1
+540.1 "Allagan Field" sync / 1[56]:The Avatar:7C4:/ duration 31 jump 460.1
 547.3 "Homing Missile"
 548.5 "Diffusion Ray"
 554.3 "Gaseous Bomb"
@@ -120,7 +120,7 @@ hideall "--sync--"
 
 
 ### Phase 4: Enrage
-800.0 "Atomic Ray" sync /:The Avatar:7C8:/ window 800,800
+800.0 "Atomic Ray" sync / 1[56]:The Avatar:7C8:/ window 800,800
 805.1 "Atomic Ray"
 810.2 "Atomic Ray"
 815.3 "Atomic Ray"

--- a/ui/raidboss/data/02-arr/raid/t9.txt
+++ b/ui/raidboss/data/02-arr/raid/t9.txt
@@ -4,105 +4,105 @@
 hideall "--Reset--"
 hideall "--sync--"
 
-0.0 "--Reset--" sync / 21:........:40000010:/ window 10000 jump 0
+0 "--Reset--" sync / 21:........:40000010:/ window 100000 jump 0
 
 ### Phase 1
 # This phase really doesn't seem to loop anywhere.
 0.0 "Start"
 0.0 "--sync--" sync /:Engage!/ window 0,1
-2.5 "--sync--" sync /:Nael deus Darnus:367:/ window 3,0
-5.5 "Ravensclaw" sync /:Nael deus Darnus:7D5:/ window 6,5
-16.6 "Ravensclaw" sync /:Nael deus Darnus:7D5:/
+2.5 "--sync--" sync / 1[56]:Nael deus Darnus:367:/ window 3,0
+5.5 "Ravensclaw" sync / 1[56]:Nael deus Darnus:7D5:/ window 6,5
+16.6 "Ravensclaw" sync / 1[56]:Nael deus Darnus:7D5:/
 
-21.8 "Stardust" sync /:Nael deus Darnus:877:/ duration 9
-30.8 "--sync--" sync /:(Astral Debris|Umbral Debris|):7E9:/
-30.9 "Ravensbeak" sync /:Nael deus Darnus:7D6:/ duration 13
-36.2 "Raven Dive" sync /:Nael deus Darnus:7DD:/
-40.8 "Iron Chariot" sync /:Nael deus Darnus:7D8:/
-42.6 "Thermionic Beam" sync /:Nael deus Darnus:7DF:/
-43.6 "Raven Dive" sync /:Nael deus Darnus:7DD:/
-44.0 "--sync--" sync /:Nael deus Darnus:7D7:/
-48.3 "Ravensclaw" sync /:Nael deus Darnus:7D5:/
+21.8 "Stardust" sync / 1[56]:Nael deus Darnus:877:/ duration 9
+30.8 "--sync--" sync / 1[56]:(Astral Debris|Umbral Debris|):7E9:/
+30.9 "Ravensbeak" sync / 1[56]:Nael deus Darnus:7D6:/ duration 13
+36.2 "Raven Dive" sync / 1[56]:Nael deus Darnus:7DD:/
+40.8 "Iron Chariot" sync / 1[56]:Nael deus Darnus:7D8:/
+42.6 "Thermionic Beam" sync / 1[56]:Nael deus Darnus:7DF:/
+43.6 "Raven Dive" sync / 1[56]:Nael deus Darnus:7DD:/
+44.0 "--sync--" sync / 1[56]:Nael deus Darnus:7D7:/
+48.3 "Ravensclaw" sync / 1[56]:Nael deus Darnus:7D5:/
 
-58.6 "Stardust" sync /:Nael deus Darnus:877:/ duration 9
-63.4 "Ravensclaw" sync /:Nael deus Darnus:7D5:/
-67.6 "--sync--" sync /:(Astral Debris|Umbral Debris|):7E9:/
-69.4 "Lunar Dynamo" sync /:Nael deus Darnus:7DA:/
-71.8 "Meteor Stream" sync /:Nael Geminus:7DE:/
-74.9 "Dalamud Dive" sync /:Nael deus Darnus:7DC:/
-83.7 "Ravensbeak" sync /:Nael deus Darnus:7D6:/ duration 13
-89.5 "Ravensclaw" sync /:Nael deus Darnus:7D5:/
+58.6 "Stardust" sync / 1[56]:Nael deus Darnus:877:/ duration 9
+63.4 "Ravensclaw" sync / 1[56]:Nael deus Darnus:7D5:/
+67.6 "--sync--" sync / 1[56]:(Astral Debris|Umbral Debris|):7E9:/
+69.4 "Lunar Dynamo" sync / 1[56]:Nael deus Darnus:7DA:/
+71.8 "Meteor Stream" sync / 1[56]:Nael Geminus:7DE:/
+74.9 "Dalamud Dive" sync / 1[56]:Nael deus Darnus:7DC:/
+83.7 "Ravensbeak" sync / 1[56]:Nael deus Darnus:7D6:/ duration 13
+89.5 "Ravensclaw" sync / 1[56]:Nael deus Darnus:7D5:/
 
-95.0 "Stardust" sync /:Nael deus Darnus:877:/ duration 9
-96.6 "--sync--" sync /:Nael deus Darnus:7D7:/
-104.0 "--sync--" sync /:(Astral Debris|Umbral Debris|):7E9:/
-107.2 "Meteor Stream" #sync /:Nael Geminus:7DE:/
-112.3 "Meteor Stream" #sync /:Nael Geminus:7DE:/
-115.4 "Dalamud Dive" sync /:Nael deus Darnus:7DC:/
-119.7 "Ravensclaw" sync /:Nael deus Darnus:7D5:/
-130.2 "Ravensbeak" sync /:Nael deus Darnus:7D6:/ duration 13
+95.0 "Stardust" sync / 1[56]:Nael deus Darnus:877:/ duration 9
+96.6 "--sync--" sync / 1[56]:Nael deus Darnus:7D7:/
+104.0 "--sync--" sync / 1[56]:(Astral Debris|Umbral Debris|):7E9:/
+107.2 "Meteor Stream" #sync / 1[56]:Nael Geminus:7DE:/
+112.3 "Meteor Stream" #sync / 1[56]:Nael Geminus:7DE:/
+115.4 "Dalamud Dive" sync / 1[56]:Nael deus Darnus:7DC:/
+119.7 "Ravensclaw" sync / 1[56]:Nael deus Darnus:7D5:/
+130.2 "Ravensbeak" sync / 1[56]:Nael deus Darnus:7D6:/ duration 13
 
-135.5 "Stardust" sync /:Nael deus Darnus:877:/ duration 9
-140.0 "Ravensclaw" sync /:Nael deus Darnus:7D5:/
-143.2 "--sync--" sync /:Nael deus Darnus:7D7:/
-144.6 "--sync--" sync /:(Astral Debris|Umbral Debris|):7E9:/
-146.1 "Raven Dive" sync /:Nael deus Darnus:7DD:/
-150.7 "Iron Chariot" sync /:Nael deus Darnus:7D8:/
-152.6 "Thermionic Beam" sync /:Nael deus Darnus:7DF:/
-153.6 "Raven Dive" sync /:Nael deus Darnus:7DD:/
-162.6 "Ravensclaw" sync /:Nael deus Darnus:7D5:/
+135.5 "Stardust" sync / 1[56]:Nael deus Darnus:877:/ duration 9
+140.0 "Ravensclaw" sync / 1[56]:Nael deus Darnus:7D5:/
+143.2 "--sync--" sync / 1[56]:Nael deus Darnus:7D7:/
+144.6 "--sync--" sync / 1[56]:(Astral Debris|Umbral Debris|):7E9:/
+146.1 "Raven Dive" sync / 1[56]:Nael deus Darnus:7DD:/
+150.7 "Iron Chariot" sync / 1[56]:Nael deus Darnus:7D8:/
+152.6 "Thermionic Beam" sync / 1[56]:Nael deus Darnus:7DF:/
+153.6 "Raven Dive" sync / 1[56]:Nael deus Darnus:7DD:/
+162.6 "Ravensclaw" sync / 1[56]:Nael deus Darnus:7D5:/
 
-168.6 "Stardust" sync /:Nael deus Darnus:877:/ duration 9
-177.4 "Ravensbeak" sync /:Nael deus Darnus:7D6:/ duration 13
-177.7 "--sync--" sync /:(Astral Debris|Umbral Debris|):7E9:/
-183.9 "Lunar Dynamo" sync /:Nael deus Darnus:7DA:/
-186.2 "Meteor Stream" sync /:Nael Geminus:7DE:/
-189.3 "Dalamud Dive" sync /:Nael deus Darnus:7DC:/
-190.4 "--sync--" sync /:Nael deus Darnus:7D7:/
-192.9 "Ravensclaw" sync /:Nael deus Darnus:7D5:/
+168.6 "Stardust" sync / 1[56]:Nael deus Darnus:877:/ duration 9
+177.4 "Ravensbeak" sync / 1[56]:Nael deus Darnus:7D6:/ duration 13
+177.7 "--sync--" sync / 1[56]:(Astral Debris|Umbral Debris|):7E9:/
+183.9 "Lunar Dynamo" sync / 1[56]:Nael deus Darnus:7DA:/
+186.2 "Meteor Stream" sync / 1[56]:Nael Geminus:7DE:/
+189.3 "Dalamud Dive" sync / 1[56]:Nael deus Darnus:7DC:/
+190.4 "--sync--" sync / 1[56]:Nael deus Darnus:7D7:/
+192.9 "Ravensclaw" sync / 1[56]:Nael deus Darnus:7D5:/
 
-203.9 "Stardust" sync /:Nael deus Darnus:877:/ duration 9
-208.0 "Ravensclaw" sync /:Nael deus Darnus:7D5:/
-213.0 "--sync--" sync /:(Astral Debris|Umbral Debris|):7E9:/
-217.5 "Meteor Stream" #sync /:Nael Geminus:7DE:/
-222.6 "Meteor Stream" #sync /:Nael Geminus:7DE:/
-225.8 "Dalamud Dive" sync /:Nael deus Darnus:7DC:/
-234.2 "Ravensbeak" sync /:Nael deus Darnus:7D6:/ duration 13
-239.6 "Ravensclaw" sync /:Nael deus Darnus:7D5:/
+203.9 "Stardust" sync / 1[56]:Nael deus Darnus:877:/ duration 9
+208.0 "Ravensclaw" sync / 1[56]:Nael deus Darnus:7D5:/
+213.0 "--sync--" sync / 1[56]:(Astral Debris|Umbral Debris|):7E9:/
+217.5 "Meteor Stream" #sync / 1[56]:Nael Geminus:7DE:/
+222.6 "Meteor Stream" #sync / 1[56]:Nael Geminus:7DE:/
+225.8 "Dalamud Dive" sync / 1[56]:Nael deus Darnus:7DC:/
+234.2 "Ravensbeak" sync / 1[56]:Nael deus Darnus:7D6:/ duration 13
+239.6 "Ravensclaw" sync / 1[56]:Nael deus Darnus:7D5:/
 
-245.8 "Stardust" sync /:Nael deus Darnus:877:/ duration 9
-254.8 "--sync--" sync /:(Astral Debris|Umbral Debris|):7E9:/
-255.5 "Raven Dive" sync /:Nael deus Darnus:7DD:/
-260.1 "Iron Chariot" sync /:Nael deus Darnus:7D8:/
-262.1 "Thermionic Beam" sync /:Nael deus Darnus:7DF:/
-263.1 "Raven Dive" sync /:Nael deus Darnus:7DD:/
-266.4 "Ravensclaw" sync /:Nael deus Darnus:7D5:/
-277.3 "Ravensbeak" sync /:Nael deus Darnus:7D6:/ duration 13
+245.8 "Stardust" sync / 1[56]:Nael deus Darnus:877:/ duration 9
+254.8 "--sync--" sync / 1[56]:(Astral Debris|Umbral Debris|):7E9:/
+255.5 "Raven Dive" sync / 1[56]:Nael deus Darnus:7DD:/
+260.1 "Iron Chariot" sync / 1[56]:Nael deus Darnus:7D8:/
+262.1 "Thermionic Beam" sync / 1[56]:Nael deus Darnus:7DF:/
+263.1 "Raven Dive" sync / 1[56]:Nael deus Darnus:7DD:/
+266.4 "Ravensclaw" sync / 1[56]:Nael deus Darnus:7D5:/
+277.3 "Ravensbeak" sync / 1[56]:Nael deus Darnus:7D6:/ duration 13
 
-283.0 "Stardust" sync /:Nael deus Darnus:877:/ duration 9
-286.8 "Ravensclaw" sync /:Nael deus Darnus:7D5:/
-292.0 "--sync--" sync /:(Astral Debris|Umbral Debris|):7E9:/
-294.3 "Lunar Dynamo" sync /:Nael deus Darnus:7DA:/
-296.7 "Meteor Stream" sync /:Nael Geminus:7DE:/
-299.9 "Dalamud Dive" sync /:Nael deus Darnus:7DC:/
-307.9 "Ravensclaw" sync /:Nael deus Darnus:7D5:/
+283.0 "Stardust" sync / 1[56]:Nael deus Darnus:877:/ duration 9
+286.8 "Ravensclaw" sync / 1[56]:Nael deus Darnus:7D5:/
+292.0 "--sync--" sync / 1[56]:(Astral Debris|Umbral Debris|):7E9:/
+294.3 "Lunar Dynamo" sync / 1[56]:Nael deus Darnus:7DA:/
+296.7 "Meteor Stream" sync / 1[56]:Nael Geminus:7DE:/
+299.9 "Dalamud Dive" sync / 1[56]:Nael deus Darnus:7DC:/
+307.9 "Ravensclaw" sync / 1[56]:Nael deus Darnus:7D5:/
 
-314.3 "Stardust" sync /:Nael deus Darnus:877:/ duration 9
-322.8 "Ravensbeak" sync /:Nael deus Darnus:7D6:/
-323.3 "--sync--" sync /:(Astral Debris|Umbral Debris|):7E9:/
-332.0 "Meteor Stream" sync /:Nael Geminus:7DE:/
-335.9 "--sync--" sync /:Nael deus Darnus:7D7:/
-337.0 "Meteor Stream" sync /:Nael Geminus:7DE:/
-340.2 "Dalamud Dive" sync /:Nael deus Darnus:7DC:/
-343.2 "Ravensclaw" sync /:Nael deus Darnus:7D5:/
+314.3 "Stardust" sync / 1[56]:Nael deus Darnus:877:/ duration 9
+322.8 "Ravensbeak" sync / 1[56]:Nael deus Darnus:7D6:/
+323.3 "--sync--" sync / 1[56]:(Astral Debris|Umbral Debris|):7E9:/
+332.0 "Meteor Stream" sync / 1[56]:Nael Geminus:7DE:/
+335.9 "--sync--" sync / 1[56]:Nael deus Darnus:7D7:/
+337.0 "Meteor Stream" sync / 1[56]:Nael Geminus:7DE:/
+340.2 "Dalamud Dive" sync / 1[56]:Nael deus Darnus:7DC:/
+343.2 "Ravensclaw" sync / 1[56]:Nael deus Darnus:7D5:/
 
-355.0 "Stardust" sync /:Nael deus Darnus:877:/ duration 9
-358.5 "Ravensclaw" sync /:Nael deus Darnus:7D5:/
-364.0 "--sync--" sync /:(Astral Debris|Umbral Debris|):7E9:/
-366.0 "Raven Dive" sync /:Nael deus Darnus:7DD:/
-370.5 "Iron Chariot" sync /:Nael deus Darnus:7D8:/
-372.7 "Thermionic Beam" sync /:Nael deus Darnus:7DF:/
-373.7 "Raven Dive" sync /:Nael deus Darnus:7DD:/
+355.0 "Stardust" sync / 1[56]:Nael deus Darnus:877:/ duration 9
+358.5 "Ravensclaw" sync / 1[56]:Nael deus Darnus:7D5:/
+364.0 "--sync--" sync / 1[56]:(Astral Debris|Umbral Debris|):7E9:/
+366.0 "Raven Dive" sync / 1[56]:Nael deus Darnus:7DD:/
+370.5 "Iron Chariot" sync / 1[56]:Nael deus Darnus:7D8:/
+372.7 "Thermionic Beam" sync / 1[56]:Nael deus Darnus:7DF:/
+373.7 "Raven Dive" sync / 1[56]:Nael deus Darnus:7DD:/
 
 # Meteors just start exploding here no matter how far away you put them.
 
@@ -110,7 +110,7 @@ hideall "--sync--"
 ### Phase 2: Golem Adds
 500.0 "--untargetable--"
 503.3 "Golem Meteors" sync /1B:........:[^:]*:....:....:0007:/ duration 11 window 505,0
-514.3 "--sync--" sync /:(Dalamud Fragment|):7EB:/
+514.3 "--sync--" sync / 1[56]:(Dalamud Fragment|):7EB:/
 582.3 "Meteor 1/6" duration 7 sync /1B:........:[^:]*:....:....:000[9A]:/ window 83,0
 584.3 "Meteor 2/6" duration 7
 586.3 "Meteor 3/6" duration 7
@@ -118,51 +118,51 @@ hideall "--sync--"
 590.5 "Meteor 5/6" duration 7
 592.5 "Meteor 6/6" duration 7
 598.3 "Golem Meteors" sync /1B:........:[^:]*:....:....:0007:/ duration 11 window 80,80
-609.3 "--sync--" sync /:(Dalamud Fragment|):7EB:/
-683.5 "Megaflare" sync /:Nael deus Darnus:7E7:/ window 700,700
+609.3 "--sync--" sync / 1[56]:(Dalamud Fragment|):7EB:/
+683.5 "Megaflare" sync / 1[56]:Nael deus Darnus:7E7:/ window 700,700
 
 
 ### Phase 3: Heavensfall
 # Phase 3 is on a 54 second nael rotation and a 60 second dragon rotation.
 # This unrolls the loop for the first few dragons.
-693.6 "Dalamud Dive" sync /:Nael deus Darnus:7DC:/ window 300,300
+693.6 "Dalamud Dive" sync / 1[56]:Nael deus Darnus:7DC:/ window 300,300
 695.6 "--targetable--"
 
-699.2 "--sync--" sync /:Nael deus Darnus:83B:/
-701.9 "Heavensfall" sync /:Ragnarok:7E4:/ window 702,10
-714.3 "Bahamut's Claw x2" #sync /:Nael deus Darnus:871:/
+699.2 "--sync--" sync / 1[56]:Nael deus Darnus:83B:/
+701.9 "Heavensfall" sync / 1[56]:Ragnarok:7E4:/ window 702,10
+714.3 "Bahamut's Claw x2" #sync / 1[56]:Nael deus Darnus:871:/
 716.0 "Ghost Add 1 (North)"
-721.8 "Binding Coil" sync /:Nael deus Darnus:7E2:/
-737.0 "Bahamut's Claw x2" #sync /:Nael deus Darnus:871:/
-744.4 "Binding Coil" sync /:Nael deus Darnus:7E2:/
+721.8 "Binding Coil" sync / 1[56]:Nael deus Darnus:7E2:/
+737.0 "Bahamut's Claw x2" #sync / 1[56]:Nael deus Darnus:871:/
+744.4 "Binding Coil" sync / 1[56]:Nael deus Darnus:7E2:/
 
-749.5 "--sync--" sync /:Nael deus Darnus:83B:/
-752.2 "Heavensfall" sync /:Ragnarok:7E4:/ window 40,40
-755.9 "Super Nova x2" duration 2.3 #sync /:Nael deus Darnus:7E0:/
-768.7 "Bahamut's Claw x2" #sync /:Nael deus Darnus:871:/
-775.9 "Binding Coil" sync /:Nael deus Darnus:7E2:/
+749.5 "--sync--" sync / 1[56]:Nael deus Darnus:83B:/
+752.2 "Heavensfall" sync / 1[56]:Ragnarok:7E4:/ window 40,40
+755.9 "Super Nova x2" duration 2.3 #sync / 1[56]:Nael deus Darnus:7E0:/
+768.7 "Bahamut's Claw x2" #sync / 1[56]:Nael deus Darnus:871:/
+775.9 "Binding Coil" sync / 1[56]:Nael deus Darnus:7E2:/
 776.0 "Ghost Add 2 (East)"
-791.3 "Bahamut's Claw x2" #sync /:Nael deus Darnus:871:/
-798.5 "Binding Coil" sync /:Nael deus Darnus:7E2:/
+791.3 "Bahamut's Claw x2" #sync / 1[56]:Nael deus Darnus:871:/
+798.5 "Binding Coil" sync / 1[56]:Nael deus Darnus:7E2:/
 
-803.5 "--sync--" sync /:Nael deus Darnus:83B:/
-806.2 "Heavensfall" sync /:Ragnarok:7E4:/ window 40,40
-809.9 "Super Nova x2" duration 2.3 #sync /:Nael deus Darnus:7E0:/
-822.7 "Bahamut's Claw x2" #sync /:Nael deus Darnus:871:/
-829.9 "Binding Coil" sync /:Nael deus Darnus:7E2:/
+803.5 "--sync--" sync / 1[56]:Nael deus Darnus:83B:/
+806.2 "Heavensfall" sync / 1[56]:Ragnarok:7E4:/ window 40,40
+809.9 "Super Nova x2" duration 2.3 #sync / 1[56]:Nael deus Darnus:7E0:/
+822.7 "Bahamut's Claw x2" #sync / 1[56]:Nael deus Darnus:871:/
+829.9 "Binding Coil" sync / 1[56]:Nael deus Darnus:7E2:/
 836.0 "Ghost Add 3 (South)"
-845.3 "Bahamut's Claw x2" #sync /:Nael deus Darnus:871:/
-852.5 "Binding Coil" sync /:Nael deus Darnus:7E2:/
+845.3 "Bahamut's Claw x2" #sync / 1[56]:Nael deus Darnus:871:/
+852.5 "Binding Coil" sync / 1[56]:Nael deus Darnus:7E2:/
 
-857.5 "--sync--" sync /:Nael deus Darnus:83B:/
-860.2 "Heavensfall" sync /:Ragnarok:7E4:/ window 40,40
-863.9 "Super Nova x2" duration 2.3 #sync /:Nael deus Darnus:7E0:
-876.7 "Bahamut's Claw x2" #sync /:Nael deus Darnus:871:/
-883.9 "Binding Coil" sync /:Nael deus Darnus:7E2:/
-899.3 "Bahamut's Claw x2" #sync /:Nael deus Darnus:871:/
-906.5 "Binding Coil" sync /:Nael deus Darnus:7E2:/
+857.5 "--sync--" sync / 1[56]:Nael deus Darnus:83B:/
+860.2 "Heavensfall" sync / 1[56]:Ragnarok:7E4:/ window 40,40
+863.9 "Super Nova x2" duration 2.3 #sync / 1[56]:Nael deus Darnus:7E0:
+876.7 "Bahamut's Claw x2" #sync / 1[56]:Nael deus Darnus:871:/
+883.9 "Binding Coil" sync / 1[56]:Nael deus Darnus:7E2:/
+899.3 "Bahamut's Claw x2" #sync / 1[56]:Nael deus Darnus:871:/
+906.5 "Binding Coil" sync / 1[56]:Nael deus Darnus:7E2:/
 
-911.5 "--sync--" sync /:Nael deus Darnus:83B:/ window 40,40 jump 857.5
+911.5 "--sync--" sync / 1[56]:Nael deus Darnus:83B:/ window 40,40 jump 857.5
 914.2 "Heavensfall"
 917.9 "Super Nova x2"
 930.7 "Bahamut's Claw x2"
@@ -172,79 +172,79 @@ hideall "--sync--"
 
 
 ### Phase 4: Divebombs and Dances
-1000.0 "Bahamut's Favor" sync /:Nael deus Darnus:7E6:/ window 1000,80
-1003.1 "Bahamut's Claw x5" duration 2.9 #sync /:Nael deus Darnus:871:/
-1013.9 "Chain Lightning" sync /:Thunderwing:7FD:/ duration 6
-1014.4 "Raven Dive" sync /:Nael deus Darnus:7DD:/
-1014.9 "Fireball (Out)" sync /:Firehorn:7FB:/
-1019.0 "Lunar Dynamo" sync /:Nael deus Darnus:7DA:/
-1025.9 "Chain Lightning" sync /:Thunderwing:7FD:/ duration 6
-1026.9 "Fireball (In)" sync /:Firehorn:7FB:/
-1038.0 "Chain Lightning" sync /:Thunderwing:7FD:/ duration 6
-1039.0 "Fireball (Out)" sync /:Firehorn:7FB:/
-1040.2 "Iron Chariot" sync /:Nael deus Darnus:7D8:/
-1041.9 "Super Nova x3" duration 3 #sync /:Nael deus Darnus:7E0:/
-1047.4 "Thermionic Beam" sync /:Nael deus Darnus:7DF:/
-1050.0 "Chain Lightning" sync /:Thunderwing:7FD:/ duration 6
-1051.2 "Fireball (In)" sync /:Firehorn:7FB:/
-1054.2 "Bahamut's Claw x5" duration 2.9 #sync /:Nael deus Darnus:871:/
+1000.0 "Bahamut's Favor" sync / 1[56]:Nael deus Darnus:7E6:/ window 1000,80
+1003.1 "Bahamut's Claw x5" duration 2.9 #sync / 1[56]:Nael deus Darnus:871:/
+1013.9 "Chain Lightning" sync / 1[56]:Thunderwing:7FD:/ duration 6
+1014.4 "Raven Dive" sync / 1[56]:Nael deus Darnus:7DD:/
+1014.9 "Fireball (Out)" sync / 1[56]:Firehorn:7FB:/
+1019.0 "Lunar Dynamo" sync / 1[56]:Nael deus Darnus:7DA:/
+1025.9 "Chain Lightning" sync / 1[56]:Thunderwing:7FD:/ duration 6
+1026.9 "Fireball (In)" sync / 1[56]:Firehorn:7FB:/
+1038.0 "Chain Lightning" sync / 1[56]:Thunderwing:7FD:/ duration 6
+1039.0 "Fireball (Out)" sync / 1[56]:Firehorn:7FB:/
+1040.2 "Iron Chariot" sync / 1[56]:Nael deus Darnus:7D8:/
+1041.9 "Super Nova x3" duration 3 #sync / 1[56]:Nael deus Darnus:7E0:/
+1047.4 "Thermionic Beam" sync / 1[56]:Nael deus Darnus:7DF:/
+1050.0 "Chain Lightning" sync / 1[56]:Thunderwing:7FD:/ duration 6
+1051.2 "Fireball (In)" sync / 1[56]:Firehorn:7FB:/
+1054.2 "Bahamut's Claw x5" duration 2.9 #sync / 1[56]:Nael deus Darnus:871:/
 1061.2 "Divebomb Mark A" duration 5
 1067.3 "Divebomb Mark B" duration 5
-1070.5 "Cauterize x2" sync /:Thunderwing:801:/
-1070.6 "Meteor Stream" sync /:Nael Geminus:7DE:/
-1076.6 "Cauterize x1" sync /:Firehorn:7FF:/
-1076.7 "Meteor Stream" sync /:Nael Geminus:7DE:/
-1080.8 "Dalamud Dive" sync /:Nael deus Darnus:7DC:/
+1070.5 "Cauterize x2" sync / 1[56]:Thunderwing:801:/
+1070.6 "Meteor Stream" sync / 1[56]:Nael Geminus:7DE:/
+1076.6 "Cauterize x1" sync / 1[56]:Firehorn:7FF:/
+1076.7 "Meteor Stream" sync / 1[56]:Nael Geminus:7DE:/
+1080.8 "Dalamud Dive" sync / 1[56]:Nael deus Darnus:7DC:/
 
-1096.6 "Bahamut's Favor" sync /:Nael deus Darnus:7E6:/ window 80,80
-1099.7 "Bahamut's Claw x5" duration 2.9 #sync /:Nael deus Darnus:871:/
-1110.4 "Raven Dive" sync /:Nael deus Darnus:7DD:/
-1110.4 "Chain Lightning" sync /:Thunderwing:7FD:/ duration 6
-1111.3 "Fireball (Out)" sync /:Firehorn:7FB:/
-1114.9 "Lunar Dynamo" sync /:Nael deus Darnus:7DA:/
-1122.5 "Chain Lightning" sync /:Thunderwing:7FD:/ duration 6
-1123.4 "Fireball (In)" sync /:Firehorn:7FB:/
-1134.4 "Chain Lightning" sync /:Thunderwing:7FD:/ duration 6
-1135.5 "Fireball (Out)" sync /:Firehorn:7FB:/
-1136.0 "Iron Chariot" sync /:Nael deus Darnus:7D8:/
-1137.8 "Super Nova x3" duration 3 #sync /:Nael deus Darnus:7E0:/
-1143.8 "Thermionic Beam" sync /:Nael deus Darnus:7DF:/
-1146.6 "Chain Lightning" sync /:Thunderwing:7FD:/ duration 6
-1147.7 "Fireball (In)" sync /:Firehorn:7FB:/
-1150.6 "Bahamut's Claw x5" duration 2.9 #sync /:Nael deus Darnus:871:/
+1096.6 "Bahamut's Favor" sync / 1[56]:Nael deus Darnus:7E6:/ window 80,80
+1099.7 "Bahamut's Claw x5" duration 2.9 #sync / 1[56]:Nael deus Darnus:871:/
+1110.4 "Raven Dive" sync / 1[56]:Nael deus Darnus:7DD:/
+1110.4 "Chain Lightning" sync / 1[56]:Thunderwing:7FD:/ duration 6
+1111.3 "Fireball (Out)" sync / 1[56]:Firehorn:7FB:/
+1114.9 "Lunar Dynamo" sync / 1[56]:Nael deus Darnus:7DA:/
+1122.5 "Chain Lightning" sync / 1[56]:Thunderwing:7FD:/ duration 6
+1123.4 "Fireball (In)" sync / 1[56]:Firehorn:7FB:/
+1134.4 "Chain Lightning" sync / 1[56]:Thunderwing:7FD:/ duration 6
+1135.5 "Fireball (Out)" sync / 1[56]:Firehorn:7FB:/
+1136.0 "Iron Chariot" sync / 1[56]:Nael deus Darnus:7D8:/
+1137.8 "Super Nova x3" duration 3 #sync / 1[56]:Nael deus Darnus:7E0:/
+1143.8 "Thermionic Beam" sync / 1[56]:Nael deus Darnus:7DF:/
+1146.6 "Chain Lightning" sync / 1[56]:Thunderwing:7FD:/ duration 6
+1147.7 "Fireball (In)" sync / 1[56]:Firehorn:7FB:/
+1150.6 "Bahamut's Claw x5" duration 2.9 #sync / 1[56]:Nael deus Darnus:871:/
 1157.8 "Divebomb Mark A" duration 5
 1163.9 "Divebomb Mark B" duration 5
-1164.3 "Iron Chariot" sync /:Nael deus Darnus:7D8:/
-1167.1 "Cauterize x2" sync /:Firehorn:7FF:/
-1168.1 "Raven Dive" sync /:Nael deus Darnus:7DD:/
-1172.7 "Lunar Dynamo" sync /:Nael deus Darnus:7DA:/
-1173.2 "Cauterize x1" sync /:Iceclaw:800:/
+1164.3 "Iron Chariot" sync / 1[56]:Nael deus Darnus:7D8:/
+1167.1 "Cauterize x2" sync / 1[56]:Firehorn:7FF:/
+1168.1 "Raven Dive" sync / 1[56]:Nael deus Darnus:7DD:/
+1172.7 "Lunar Dynamo" sync / 1[56]:Nael deus Darnus:7DA:/
+1173.2 "Cauterize x1" sync / 1[56]:Iceclaw:800:/
 
-1193.1 "Bahamut's Favor" sync /:Nael deus Darnus:7E6:/ window 80,80
-1196.1 "Bahamut's Claw x5" duration 2.9 #sync /:Nael deus Darnus:871:/
-1206.9 "Raven Dive" sync /:Nael deus Darnus:7DD:/
-1207.0 "Chain Lightning" sync /:Thunderwing:7FD:/ duration 6
-1207.9 "Fireball (Out)" sync /:Firehorn:7FB:/
-1211.4 "Lunar Dynamo" sync /:Nael deus Darnus:7DA:/
-1219.0 "Chain Lightning" sync /:Thunderwing:7FD:/ duration 6
-1219.9 "Fireball (In)" sync /:Firehorn:7FB:/
-1231.0 "Chain Lightning" sync /:Thunderwing:7FD:/ duration 6
-1232.1 "Fireball (Out)" sync /:Firehorn:7FB:/
-1232.6 "Iron Chariot" sync /:Nael deus Darnus:7D8:/
-1234.4 "Super Nova x3" duration 3 #sync /:Nael deus Darnus:7E0:/
-1240.5 "Thermionic Beam" sync /:Nael deus Darnus:7DF:/
-1243.1 "Chain Lightning" sync /:Thunderwing:7FD:/ duration 6
-1244.4 "Fireball (In)" sync /:Firehorn:7FB:/
-1247.4 "Bahamut's Claw x5" duration 2.9 #sync /:Nael deus Darnus:871:/
+1193.1 "Bahamut's Favor" sync / 1[56]:Nael deus Darnus:7E6:/ window 80,80
+1196.1 "Bahamut's Claw x5" duration 2.9 #sync / 1[56]:Nael deus Darnus:871:/
+1206.9 "Raven Dive" sync / 1[56]:Nael deus Darnus:7DD:/
+1207.0 "Chain Lightning" sync / 1[56]:Thunderwing:7FD:/ duration 6
+1207.9 "Fireball (Out)" sync / 1[56]:Firehorn:7FB:/
+1211.4 "Lunar Dynamo" sync / 1[56]:Nael deus Darnus:7DA:/
+1219.0 "Chain Lightning" sync / 1[56]:Thunderwing:7FD:/ duration 6
+1219.9 "Fireball (In)" sync / 1[56]:Firehorn:7FB:/
+1231.0 "Chain Lightning" sync / 1[56]:Thunderwing:7FD:/ duration 6
+1232.1 "Fireball (Out)" sync / 1[56]:Firehorn:7FB:/
+1232.6 "Iron Chariot" sync / 1[56]:Nael deus Darnus:7D8:/
+1234.4 "Super Nova x3" duration 3 #sync / 1[56]:Nael deus Darnus:7E0:/
+1240.5 "Thermionic Beam" sync / 1[56]:Nael deus Darnus:7DF:/
+1243.1 "Chain Lightning" sync / 1[56]:Thunderwing:7FD:/ duration 6
+1244.4 "Fireball (In)" sync / 1[56]:Firehorn:7FB:/
+1247.4 "Bahamut's Claw x5" duration 2.9 #sync / 1[56]:Nael deus Darnus:871:/
 1254.4 "Divebomb Mark A" duration 5
 1260.3 "Divebomb Mark B" duration 5
-1263.7 "Cauterize x2" sync /:Thunderwing:801:/
-1263.8 "Meteor Stream" sync /:Nael Geminus:7DE:/
-1269.6 "Cauterize x1" sync /:Firehorn:7FF:/
-1269.9 "Meteor Stream" sync /:Nael Geminus:7DE:/
-1274.5 "Dalamud Dive" sync /:Nael deus Darnus:7DC:/
+1263.7 "Cauterize x2" sync / 1[56]:Thunderwing:801:/
+1263.8 "Meteor Stream" sync / 1[56]:Nael Geminus:7DE:/
+1269.6 "Cauterize x1" sync / 1[56]:Firehorn:7FF:/
+1269.9 "Meteor Stream" sync / 1[56]:Nael Geminus:7DE:/
+1274.5 "Dalamud Dive" sync / 1[56]:Nael deus Darnus:7DC:/
 
-1289.7 "Bahamut's Favor" sync /:Nael deus Darnus:7E6:/ window 80,800 jump 1096.6
+1289.7 "Bahamut's Favor" sync / 1[56]:Nael deus Darnus:7E6:/ window 80,800 jump 1096.6
 1292.8 "Bahamut's Claw x5"
 1303.5 "Raven Dive"
 1303.5 "Chain Lightning"
@@ -270,7 +270,7 @@ hideall "--sync--"
 
 
 ### Phase 5: What Took You So Long
-2000.0 "Megaflare Enrage" sync /:Nael deus Darnus:7E8:/ window 2000,2000
+2000.0 "Megaflare Enrage" sync / 1[56]:Nael deus Darnus:7E8:/ window 2000,2000
 2008.5 "Megaflare Enrage"
 2017.0 "Megaflare Enrage"
 2025.5 "Megaflare Enrage"

--- a/ui/raidboss/data/02-arr/raid/t9.txt
+++ b/ui/raidboss/data/02-arr/raid/t9.txt
@@ -4,7 +4,7 @@
 hideall "--Reset--"
 hideall "--sync--"
 
-0.0 "--reset--" sync / 21:........:40000010:/ window 100000 jump 0
+0.0 "--Reset--" sync / 21:........:40000010:/ window 100000 jump 0
 
 ### Phase 1
 # This phase really doesn't seem to loop anywhere.

--- a/ui/raidboss/data/02-arr/raid/t9.txt
+++ b/ui/raidboss/data/02-arr/raid/t9.txt
@@ -4,7 +4,7 @@
 hideall "--Reset--"
 hideall "--sync--"
 
-0 "--Reset--" sync / 21:........:40000010:/ window 100000 jump 0
+0.0 "--reset--" sync / 21:........:40000010:/ window 100000 jump 0
 
 ### Phase 1
 # This phase really doesn't seem to loop anywhere.

--- a/ui/raidboss/data/02-arr/trial/cape_westwind.txt
+++ b/ui/raidboss/data/02-arr/trial/cape_westwind.txt
@@ -4,7 +4,7 @@
 hideall "--Reset--"
 hideall "--sync--"
 
-0.0 "--reset--" sync / 21:........:40000010:/ window 100000 jump 0
+0.0 "--Reset--" sync / 21:........:40000010:/ window 100000 jump 0
 
 ### Phase 1: skewers and stuns
 0 "Start"
@@ -26,7 +26,7 @@ hideall "--sync--"
 
 
 ### Phase 2 (80%): firebombs
-199.0 "--sync--" sync /00:0044:[^:]*:My shields are impregnable/ window 200,0
+199.0 "--sync--" sync / 00:0044:[^:]*:My shields are impregnable/ window 200,0
 200.0 "Shield Skewer" sync / 1[56]:Rhitahtyn sas Arvina:471:/
 204.3 "Shrapnel Shell" sync / 1[56]:Rhitahtyn sas Arvina:474:/ window 205,10
 208.8 "Winds Of Tartarus" sync / 1[56]:Rhitahtyn sas Arvina:472:/
@@ -76,7 +76,7 @@ hideall "--sync--"
 
 
 ### Phase 4 (40%): magitek missiles
-584.3 "--sync--" sync /00:0044:[^:]*:Your defeat will bring/ window 600,0
+584.3 "--sync--" sync / 00:0044:[^:]*:Your defeat will bring/ window 600,0
 
 600.0 "Shrapnel Shell" sync / 1[56]:Rhitahtyn sas Arvina:474:/
 604.5 "Firebomb" sync / 1[56]:Rhitahtyn sas Arvina:476:/

--- a/ui/raidboss/data/02-arr/trial/cape_westwind.txt
+++ b/ui/raidboss/data/02-arr/trial/cape_westwind.txt
@@ -4,20 +4,20 @@
 hideall "--Reset--"
 hideall "--sync--"
 
-0.0 "--Reset--" sync / 21:........:40000010:/ window 10000 jump 0
+0 "--Reset--" sync / 21:........:40000010:/ window 100000 jump 0
 
 ### Phase 1: skewers and stuns
 0 "Start"
 0.0 "--sync--" sync /:Engage!/ window 0,1
-2.0 "Shield Skewer" sync /:Rhitahtyn sas Arvina:471:/
-10.6 "Shield Skewer" sync /:Rhitahtyn sas Arvina:471:/
-19.0 "Shield Skewer" sync /:Rhitahtyn sas Arvina:471:/
-24.4 "Gate Of Tartarus" sync /:Rhitahtyn sas Arvina:473:/ window 30,10
+2.0 "Shield Skewer" sync / 1[56]:Rhitahtyn sas Arvina:471:/
+10.6 "Shield Skewer" sync / 1[56]:Rhitahtyn sas Arvina:471:/
+19.0 "Shield Skewer" sync / 1[56]:Rhitahtyn sas Arvina:471:/
+24.4 "Gate Of Tartarus" sync / 1[56]:Rhitahtyn sas Arvina:473:/ window 30,10
 
-29.8 "Shield Skewer" sync /:Rhitahtyn sas Arvina:471:/
-38.4 "Shield Skewer" sync /:Rhitahtyn sas Arvina:471:/
-46.8 "Shield Skewer" sync /:Rhitahtyn sas Arvina:471:/
-52.2 "Gate Of Tartarus" sync /:Rhitahtyn sas Arvina:473:/ window 10,100 jump 24.4
+29.8 "Shield Skewer" sync / 1[56]:Rhitahtyn sas Arvina:471:/
+38.4 "Shield Skewer" sync / 1[56]:Rhitahtyn sas Arvina:471:/
+46.8 "Shield Skewer" sync / 1[56]:Rhitahtyn sas Arvina:471:/
+52.2 "Gate Of Tartarus" sync / 1[56]:Rhitahtyn sas Arvina:473:/ window 10,100 jump 24.4
 
 57.6 "Shield Skewer"
 66.2 "Shield Skewer"
@@ -27,18 +27,18 @@ hideall "--sync--"
 
 ### Phase 2 (80%): firebombs
 199.0 "--sync--" sync /00:0044:[^:]*:My shields are impregnable/ window 200,0
-200.0 "Shield Skewer" sync /:Rhitahtyn sas Arvina:471:/
-204.3 "Shrapnel Shell" sync /:Rhitahtyn sas Arvina:474:/ window 205,10
-208.8 "Winds Of Tartarus" sync /:Rhitahtyn sas Arvina:472:/
-213.1 "Firebomb" sync /:Rhitahtyn sas Arvina:476:/
+200.0 "Shield Skewer" sync / 1[56]:Rhitahtyn sas Arvina:471:/
+204.3 "Shrapnel Shell" sync / 1[56]:Rhitahtyn sas Arvina:474:/ window 205,10
+208.8 "Winds Of Tartarus" sync / 1[56]:Rhitahtyn sas Arvina:472:/
+213.1 "Firebomb" sync / 1[56]:Rhitahtyn sas Arvina:476:/
 
-217.4 "Shield Skewer" sync /:Rhitahtyn sas Arvina:471:/
-221.7 "Drill Shot" sync /:Rhitahtyn sas Arvina:475:/
-226.0 "Winds Of Tartarus" sync /:Rhitahtyn sas Arvina:472:/
-230.3 "Firebomb" sync /:Rhitahtyn sas Arvina:476:/
+217.4 "Shield Skewer" sync / 1[56]:Rhitahtyn sas Arvina:471:/
+221.7 "Drill Shot" sync / 1[56]:Rhitahtyn sas Arvina:475:/
+226.0 "Winds Of Tartarus" sync / 1[56]:Rhitahtyn sas Arvina:472:/
+230.3 "Firebomb" sync / 1[56]:Rhitahtyn sas Arvina:476:/
 
-234.6 "Shield Skewer" sync /:Rhitahtyn sas Arvina:471:/
-238.9 "Shrapnel Shell" sync /:Rhitahtyn sas Arvina:474:/ window 20,100 jump 204.3
+234.6 "Shield Skewer" sync / 1[56]:Rhitahtyn sas Arvina:471:/
+238.9 "Shrapnel Shell" sync / 1[56]:Rhitahtyn sas Arvina:474:/ window 20,100 jump 204.3
 243.4 "Winds Of Tartarus"
 247.7 "Firebomb"
 
@@ -49,23 +49,23 @@ hideall "--sync--"
 
 
 ### Phase 3 (60%): Adds
-400.0 "Gate Of Tartarus" sync /:Rhitahtyn sas Arvina:473:/ window 200,20
-403.5 "Shield Skewer" sync /:Rhitahtyn sas Arvina:471:/
+400.0 "Gate Of Tartarus" sync / 1[56]:Rhitahtyn sas Arvina:473:/ window 200,20
+403.5 "Shield Skewer" sync / 1[56]:Rhitahtyn sas Arvina:471:/
 
 407.7 "Adds"
 # FIXME: sometimes this shield skewer doesn't happen???
-408.7 "Shield Skewer" sync /:Rhitahtyn sas Arvina:471:/
-413.2 "Shrapnel Shell" sync /:Rhitahtyn sas Arvina:474:/ window 20,20
-417.9 "Winds Of Tartarus" sync /:Rhitahtyn sas Arvina:472:/
-422.4 "Firebomb" sync /:Rhitahtyn sas Arvina:476:/
+408.7 "Shield Skewer" sync / 1[56]:Rhitahtyn sas Arvina:471:/
+413.2 "Shrapnel Shell" sync / 1[56]:Rhitahtyn sas Arvina:474:/ window 20,20
+417.9 "Winds Of Tartarus" sync / 1[56]:Rhitahtyn sas Arvina:472:/
+422.4 "Firebomb" sync / 1[56]:Rhitahtyn sas Arvina:476:/
 
-426.9 "Shield Skewer" sync /:Rhitahtyn sas Arvina:471:/
-431.4 "Drill Shot" sync /:Rhitahtyn sas Arvina:475:/
-435.9 "Winds Of Tartarus" sync /:Rhitahtyn sas Arvina:472:/
-440.4 "Firebomb" sync /:Rhitahtyn sas Arvina:476:/
+426.9 "Shield Skewer" sync / 1[56]:Rhitahtyn sas Arvina:471:/
+431.4 "Drill Shot" sync / 1[56]:Rhitahtyn sas Arvina:475:/
+435.9 "Winds Of Tartarus" sync / 1[56]:Rhitahtyn sas Arvina:472:/
+440.4 "Firebomb" sync / 1[56]:Rhitahtyn sas Arvina:476:/
 
-445.0 "Shield Skewer" sync /:Rhitahtyn sas Arvina:471:/
-449.5 "Shrapnel Shell" sync /:Rhitahtyn sas Arvina:474:/ window 20,100 jump 413.2
+445.0 "Shield Skewer" sync / 1[56]:Rhitahtyn sas Arvina:471:/
+449.5 "Shrapnel Shell" sync / 1[56]:Rhitahtyn sas Arvina:474:/ window 20,100 jump 413.2
 454.2 "Winds Of Tartarus"
 458.7 "Firebomb"
 
@@ -78,19 +78,19 @@ hideall "--sync--"
 ### Phase 4 (40%): magitek missiles
 584.3 "--sync--" sync /00:0044:[^:]*:Your defeat will bring/ window 600,0
 
-600.0 "Shrapnel Shell" sync /:Rhitahtyn sas Arvina:474:/
-604.5 "Firebomb" sync /:Rhitahtyn sas Arvina:476:/
-608.8 "Winds Of Tartarus" sync /:Rhitahtyn sas Arvina:472:/
+600.0 "Shrapnel Shell" sync / 1[56]:Rhitahtyn sas Arvina:474:/
+604.5 "Firebomb" sync / 1[56]:Rhitahtyn sas Arvina:476:/
+608.8 "Winds Of Tartarus" sync / 1[56]:Rhitahtyn sas Arvina:472:/
 
-610.0 "Magitek Missiles" sync /:Rhitahtyn sas Arvina:478:/ window 610,30
-615.1 "Drill Shot" sync /:Rhitahtyn sas Arvina:475:/
-619.4 "Firebomb" sync /:Rhitahtyn sas Arvina:476:/
-623.7 "Winds Of Tartarus" sync /:Rhitahtyn sas Arvina:472:/
-640.2 "Shrapnel Shell" sync /:Rhitahtyn sas Arvina:474:/
-644.7 "Firebomb" sync /:Rhitahtyn sas Arvina:476:/
-649.0 "Winds Of Tartarus" sync /:Rhitahtyn sas Arvina:472:/
+610.0 "Magitek Missiles" sync / 1[56]:Rhitahtyn sas Arvina:478:/ window 610,30
+615.1 "Drill Shot" sync / 1[56]:Rhitahtyn sas Arvina:475:/
+619.4 "Firebomb" sync / 1[56]:Rhitahtyn sas Arvina:476:/
+623.7 "Winds Of Tartarus" sync / 1[56]:Rhitahtyn sas Arvina:472:/
+640.2 "Shrapnel Shell" sync / 1[56]:Rhitahtyn sas Arvina:474:/
+644.7 "Firebomb" sync / 1[56]:Rhitahtyn sas Arvina:476:/
+649.0 "Winds Of Tartarus" sync / 1[56]:Rhitahtyn sas Arvina:472:/
 
-650.2 "Magitek Missiles" sync /:Rhitahtyn sas Arvina:478:/ window 20,100 jump 610.0
+650.2 "Magitek Missiles" sync / 1[56]:Rhitahtyn sas Arvina:478:/ window 20,100 jump 610.0
 655.3 "Drill Shot"
 659.6 "Firebomb"
 663.9 "Winds Of Tartarus"

--- a/ui/raidboss/data/02-arr/trial/cape_westwind.txt
+++ b/ui/raidboss/data/02-arr/trial/cape_westwind.txt
@@ -4,7 +4,7 @@
 hideall "--Reset--"
 hideall "--sync--"
 
-0 "--Reset--" sync / 21:........:40000010:/ window 100000 jump 0
+0.0 "--reset--" sync / 21:........:40000010:/ window 100000 jump 0
 
 ### Phase 1: skewers and stuns
 0 "Start"

--- a/ui/raidboss/data/02-arr/trial/ifrit-nm.txt
+++ b/ui/raidboss/data/02-arr/trial/ifrit-nm.txt
@@ -4,7 +4,7 @@
 hideall "--Reset--"
 hideall "--sync--"
 
-0.0 "--reset--" sync / 21:........:40000010:/ window 100000 jump 0
+0.0 "--Reset--" sync / 21:........:40000010:/ window 100000 jump 0
 
 # 0%
 0.0 "Start"
@@ -26,7 +26,7 @@ hideall "--sync--"
 126.1 "Incinerate"
 
 # 70%
-200.0 "--sync--" sync /00:0044:Ifrit:Succumb to the inferno/ window 200,0
+200.0 "--sync--" sync / 00:0044:Ifrit:Succumb to the inferno/ window 200,0
 201.0 "Incinerate" sync / 1[56]:Ifrit:1C5:/
 209.0 "Eruption" sync / 1[56]:Ifrit:1C7:/ window 210,5
 213.5 "Vulcan Burst" sync / 1[56]:Ifrit:1C6:/
@@ -41,7 +41,7 @@ hideall "--sync--"
 278.6 "Eruption"
 
 # 50%
-300.0 "--sync--" sync /00:0044:Ifrit:Surrender thyself to the fires of judgment/ window 300,0
+300.0 "--sync--" sync / 00:0044:Ifrit:Surrender thyself to the fires of judgment/ window 300,0
 305.0 "Nail Add"
 306.7 "Incinerate" sync / 1[56]:Ifrit:1C5:/
 314.4 "Vulcan Burst" sync / 1[56]:Ifrit:1C6:/

--- a/ui/raidboss/data/02-arr/trial/ifrit-nm.txt
+++ b/ui/raidboss/data/02-arr/trial/ifrit-nm.txt
@@ -4,7 +4,7 @@
 hideall "--Reset--"
 hideall "--sync--"
 
-0 "--Reset--" sync / 21:........:40000010:/ window 100000 jump 0
+0.0 "--reset--" sync / 21:........:40000010:/ window 100000 jump 0
 
 # 0%
 0.0 "Start"

--- a/ui/raidboss/data/02-arr/trial/ifrit-nm.txt
+++ b/ui/raidboss/data/02-arr/trial/ifrit-nm.txt
@@ -4,18 +4,18 @@
 hideall "--Reset--"
 hideall "--sync--"
 
-0.0 "--Reset--" sync / 21:........:40000010:/ window 10000 jump 0
+0 "--Reset--" sync / 21:........:40000010:/ window 100000 jump 0
 
 # 0%
 0.0 "Start"
 0.0 "--sync--" sync /:Engage!/ window 0,1
-1.2 "Incinerate" sync /:Ifrit:1C5:/ window 10,10
-9.1 "Vulcan Burst" sync /:Ifrit:1C6:/
-17.1 "Incinerate" sync /:Ifrit:1C5:/
-30.0 "Incinerate" sync /:Ifrit:1C5:/
-42.9 "Incinerate" sync /:Ifrit:1C5:/
+1.2 "Incinerate" sync / 1[56]:Ifrit:1C5:/ window 10,10
+9.1 "Vulcan Burst" sync / 1[56]:Ifrit:1C6:/
+17.1 "Incinerate" sync / 1[56]:Ifrit:1C5:/
+30.0 "Incinerate" sync / 1[56]:Ifrit:1C5:/
+42.9 "Incinerate" sync / 1[56]:Ifrit:1C5:/
 
-50.7 "Vulcan Burst" sync /:Ifrit:1C6:/ window 30,30 jump 9.1
+50.7 "Vulcan Burst" sync / 1[56]:Ifrit:1C6:/ window 30,30 jump 9.1
 58.7 "Incinerate"
 71.6 "Incinerate"
 84.5 "Incinerate"
@@ -27,13 +27,13 @@ hideall "--sync--"
 
 # 70%
 200.0 "--sync--" sync /00:0044:Ifrit:Succumb to the inferno/ window 200,0
-201.0 "Incinerate" sync /:Ifrit:1C5:/
-209.0 "Eruption" sync /:Ifrit:1C7:/ window 210,5
-213.5 "Vulcan Burst" sync /:Ifrit:1C6:/
+201.0 "Incinerate" sync / 1[56]:Ifrit:1C5:/
+209.0 "Eruption" sync / 1[56]:Ifrit:1C7:/ window 210,5
+213.5 "Vulcan Burst" sync / 1[56]:Ifrit:1C6:/
 
-220.4 "Incinerate" sync /:Ifrit:1C5:/
-228.5 "Eruption" sync /:Ifrit:1C7:/
-237.1 "Incinerate" sync /:Ifrit:1C5:/ window 10,10 jump 220.4
+220.4 "Incinerate" sync / 1[56]:Ifrit:1C5:/
+228.5 "Eruption" sync / 1[56]:Ifrit:1C7:/
+237.1 "Incinerate" sync / 1[56]:Ifrit:1C5:/ window 10,10 jump 220.4
 245.2 "Eruption"
 253.8 "Incinerate"
 261.9 "Eruption"
@@ -43,22 +43,22 @@ hideall "--sync--"
 # 50%
 300.0 "--sync--" sync /00:0044:Ifrit:Surrender thyself to the fires of judgment/ window 300,0
 305.0 "Nail Add"
-306.7 "Incinerate" sync /:Ifrit:1C5:/
-314.4 "Vulcan Burst" sync /:Ifrit:1C6:/
-322.3 "Incinerate" sync /:Ifrit:1C5:/
-335.1 "Incinerate" sync /:Ifrit:1C5:/
+306.7 "Incinerate" sync / 1[56]:Ifrit:1C5:/
+314.4 "Vulcan Burst" sync / 1[56]:Ifrit:1C6:/
+322.3 "Incinerate" sync / 1[56]:Ifrit:1C5:/
+335.1 "Incinerate" sync / 1[56]:Ifrit:1C5:/
 
 341.7 "--untargetable--"
-344.3 "--sync--" sync /:1CA:Ifrit/ window 500,0
-346.3 "Hellfire" sync /:Ifrit:1CA:/
+344.3 "--sync--" sync / 14:Ifrit:1CA:/ window 500,0
+346.3 "Hellfire" sync / 1[56]:Ifrit:1CA:/
 350.7 "--targetable--"
 
-352.6 "Incinerate" sync /:Ifrit:1C5:/
-361.7 "Eruption" sync /:Ifrit:1C7:/
-370.4 "Radiant Plume (inner)" sync /:Ifrit:1C8:/
-378.8 "Radiant Plume (outer)" sync /:Ifrit:1C8:/
+352.6 "Incinerate" sync / 1[56]:Ifrit:1C5:/
+361.7 "Eruption" sync / 1[56]:Ifrit:1C7:/
+370.4 "Radiant Plume (inner)" sync / 1[56]:Ifrit:1C8:/
+378.8 "Radiant Plume (outer)" sync / 1[56]:Ifrit:1C8:/
 
-385.0 "Incinerate" sync /:Ifrit:1C5:/ window 20,20 jump 352.6
+385.0 "Incinerate" sync / 1[56]:Ifrit:1C5:/ window 20,20 jump 352.6
 394.1 "Eruption"
 402.8 "Radiant Plume (inner)"
 411.2 "Radiant Plume (outer)"

--- a/ui/raidboss/data/02-arr/trial/levi-ex.txt
+++ b/ui/raidboss/data/02-arr/trial/levi-ex.txt
@@ -35,156 +35,156 @@
 hideall "--Reset--"
 hideall "--sync--"
 
-0.0 "--Reset--" sync / 21:........:40000010:/ window 10000 jump 0
+0 "--Reset--" sync / 21:........:40000010:/ window 100000 jump 0
 
 ### Phase 1: Literally Just Autos (100% -> 90%)
 0.0 "Start"
 0.0 "--sync--" sync /:Engage!/ window 0,1
-2.7 "--sync--" sync /:Leviathan:822:/ window 3,1
+2.7 "--sync--" sync / 1[56]:Leviathan:822:/ window 3,1
 25.8 "--untargetable--" sync / 22:........:Leviathan:........:Leviathan:00/ window 30,10
 
 ### Phase 2: One Set of Orbs (90% -> 50%?)
 33.0 "--targetable--"
-33.1 "Body Slam" sync /:Leviathan:82A:/ window 40,10
-38.3 "Veil Of The Whorl" sync /:Leviathan:875:/ window 40,10
-43.3 "Mantle Of The Whorl" sync /:Leviathan's Tail:874:/
+33.1 "Body Slam" sync / 1[56]:Leviathan:82A:/ window 40,10
+38.3 "Veil Of The Whorl" sync / 1[56]:Leviathan:875:/ window 40,10
+43.3 "Mantle Of The Whorl" sync / 1[56]:Leviathan's Tail:874:/
 45.6 "--2x Wavespine Sahagin (N)--"
-53.2 "Aqua Breath" sync /:Leviathan:826:/
-59.3 "Tail Whip" sync /:Leviathan's Tail:827:/
-60.4 "Waterspout" sync /:Leviathan:742:/
-73.8 "Dread Tide" sync /:Leviathan:754:/
-77.9 "Tidal Roar" sync /:Leviathan:74B:/ window 30,30
+53.2 "Aqua Breath" sync / 1[56]:Leviathan:826:/
+59.3 "Tail Whip" sync / 1[56]:Leviathan's Tail:827:/
+60.4 "Waterspout" sync / 1[56]:Leviathan:742:/
+73.8 "Dread Tide" sync / 1[56]:Leviathan:754:/
+77.9 "Tidal Roar" sync / 1[56]:Leviathan:74B:/ window 30,30
 
 85.2 "--untargetable--"
-88.3 "Grand Fall" sync /:Leviathan:82F:/
-90.8 "Spinning Dive" sync /:Leviathan:82C:/
-94.3 "Grand Fall" sync /:Leviathan:82F:/
-95.8 "Spinning Dive" sync /:Leviathan:82C:/
+88.3 "Grand Fall" sync / 1[56]:Leviathan:82F:/
+90.8 "Spinning Dive" sync / 1[56]:Leviathan:82C:/
+94.3 "Grand Fall" sync / 1[56]:Leviathan:82F:/
+95.8 "Spinning Dive" sync / 1[56]:Leviathan:82C:/
 101.5 "--targetable--"
 
-101.6 "Body Slam" sync /:Leviathan:82A:/ window 30,30
-106.0 "Briny Veil" sync /:Leviathan:831:/
+101.6 "Body Slam" sync / 1[56]:Leviathan:82A:/ window 30,30
+106.0 "Briny Veil" sync / 1[56]:Leviathan:831:/
 110.7 "--Wavetooth Sahagin (E)--"
-121.0 "Dread Tide" sync /:Leviathan:754:/
-125.1 "Aqua Breath" sync /:Leviathan:826:/
-126.0 "Tail Whip" sync /:Leviathan's Tail:827:/
-132.3 "Waterspout" sync /:Leviathan:742:/
-145.7 "Dread Tide" sync /:Leviathan:754:/
-149.8 "Tidal Roar" sync /:Leviathan:74B:/ window 30,30
+121.0 "Dread Tide" sync / 1[56]:Leviathan:754:/
+125.1 "Aqua Breath" sync / 1[56]:Leviathan:826:/
+126.0 "Tail Whip" sync / 1[56]:Leviathan's Tail:827:/
+132.3 "Waterspout" sync / 1[56]:Leviathan:742:/
+145.7 "Dread Tide" sync / 1[56]:Leviathan:754:/
+149.8 "Tidal Roar" sync / 1[56]:Leviathan:74B:/ window 30,30
 
 154.9 "--untargetable--"
-158.0 "Grand Fall x3" #sync /:Leviathan:82F:/
-160.5 "Spinning Dive" sync /:Leviathan:82C:/
-165.4 "Spinning Dive" sync /:Leviathan:82C:/
+158.0 "Grand Fall x3" #sync / 1[56]:Leviathan:82F:/
+160.5 "Spinning Dive" sync / 1[56]:Leviathan:82C:/
+165.4 "Spinning Dive" sync / 1[56]:Leviathan:82C:/
 171.1 "--targetable--"
 
-171.2 "Body Slam" sync /:Leviathan:82A:/ window 30,30
+171.2 "Body Slam" sync / 1[56]:Leviathan:82A:/ window 30,30
 180.8 "--4x Gyre Spume--"
-192.7 "Dread Tide" sync /:Leviathan:754:/
-196.3 "Tail Whip" #sync /:Leviathan's Tail:827:/
-196.8 "Aqua Breath" sync /:Leviathan:826:/
-204.0 "Waterspout" sync /:Leviathan:742:/
-217.3 "Dread Tide" sync /:Leviathan:754:/
-221.4 "Tidal Roar" sync /:Leviathan:74B:/ window 30,30
+192.7 "Dread Tide" sync / 1[56]:Leviathan:754:/
+196.3 "Tail Whip" #sync / 1[56]:Leviathan's Tail:827:/
+196.8 "Aqua Breath" sync / 1[56]:Leviathan:826:/
+204.0 "Waterspout" sync / 1[56]:Leviathan:742:/
+217.3 "Dread Tide" sync / 1[56]:Leviathan:754:/
+221.4 "Tidal Roar" sync / 1[56]:Leviathan:74B:/ window 30,30
 
 228.9 "--untargetable--"
-232.0 "Grand Fall x3" #sync /:Leviathan:82F:/
-234.5 "Spinning Dive" sync /:Leviathan:82C:/
-239.4 "Spinning Dive" sync /:Leviathan:82C:/
+232.0 "Grand Fall x3" #sync / 1[56]:Leviathan:82F:/
+234.5 "Spinning Dive" sync / 1[56]:Leviathan:82C:/
+239.4 "Spinning Dive" sync / 1[56]:Leviathan:82C:/
 245.1 "--targetable--"
 
-245.2 "Body Slam" sync /:Leviathan:82A:/ window 30,30
-267.5 "Dread Tide" sync /:Leviathan:754:/
+245.2 "Body Slam" sync / 1[56]:Leviathan:82A:/ window 30,30
+267.5 "Dread Tide" sync / 1[56]:Leviathan:754:/
 
 275.2 "--untargetable--"
-278.3 "Grand Fall" sync /:Leviathan:82F:/
-280.8 "Spinning Dive" sync /:Leviathan:82C:/
+278.3 "Grand Fall" sync / 1[56]:Leviathan:82F:/
+280.8 "Spinning Dive" sync / 1[56]:Leviathan:82C:/
 280.8 "--untargetable--"
-286.5 "Tidal Wave" sync /:Leviathan:82E:/ window 300,100
+286.5 "Tidal Wave" sync / 1[56]:Leviathan:82E:/ window 300,100
 
 
 ### Phase 3: Two Sets of Orbs (50% -> 20%?)
 299.2 "--targetable--"
-299.3 "Body Slam" sync /:Leviathan:82A:/ window 30,30
+299.3 "Body Slam" sync / 1[56]:Leviathan:82A:/ window 30,30
 301.3 "--2x Wavespine Sahagin (S)--"
-318.6 "Aqua Breath" sync /:Leviathan:826:/
-318.6 "Tail Whip" #sync /:Leviathan's Tail:827:/
-322.7 "Waterspout" sync /:Leviathan:742:/
-329.9 "Dread Tide" sync /:Leviathan:754:/
-338.1 "Tidal Roar" sync /:Leviathan:74B:/
+318.6 "Aqua Breath" sync / 1[56]:Leviathan:826:/
+318.6 "Tail Whip" #sync / 1[56]:Leviathan's Tail:827:/
+322.7 "Waterspout" sync / 1[56]:Leviathan:742:/
+329.9 "Dread Tide" sync / 1[56]:Leviathan:754:/
+338.1 "Tidal Roar" sync / 1[56]:Leviathan:74B:/
 
 347.3 "--untargetable--"
-350.4 "Grand Fall" sync /:Leviathan:82F:/
-352.9 "Spinning Dive" sync /:Leviathan:82C:/
-357.8 "Spinning Dive" sync /:Leviathan:82C:/
+350.4 "Grand Fall" sync / 1[56]:Leviathan:82F:/
+352.9 "Spinning Dive" sync / 1[56]:Leviathan:82C:/
+357.8 "Spinning Dive" sync / 1[56]:Leviathan:82C:/
 
 363.5 "--targetable--"
-363.6 "Body Slam" sync /:Leviathan:82A:/ window 30,30
+363.6 "Body Slam" sync / 1[56]:Leviathan:82A:/ window 30,30
 364.9 "--4x Gyre Spume--"
-382.9 "Aqua Breath" sync /:Leviathan:826:/
-385.0 "Tail Whip" #sync /:Leviathan's Tail:827:/
-387.1 "Waterspout" sync /:Leviathan:742:/
-394.3 "Dread Tide" sync /:Leviathan:754:/
+382.9 "Aqua Breath" sync / 1[56]:Leviathan:826:/
+385.0 "Tail Whip" #sync / 1[56]:Leviathan's Tail:827:/
+387.1 "Waterspout" sync / 1[56]:Leviathan:742:/
+394.3 "Dread Tide" sync / 1[56]:Leviathan:754:/
 402.4 "--4x Wave Spume--"
-402.5 "Tidal Roar" sync /:Leviathan:74B:/
+402.5 "Tidal Roar" sync / 1[56]:Leviathan:74B:/
 
 413.8 "--untargetable--"
-416.9 "Grand Fall x3" #sync /:Leviathan:82F:/
-419.4 "Spinning Dive" sync /:Leviathan:82C:/
+416.9 "Grand Fall x3" #sync / 1[56]:Leviathan:82F:/
+419.4 "Spinning Dive" sync / 1[56]:Leviathan:82C:/
 
 
 425.1 "--targetable--"
-425.2 "Body Slam" sync /:Leviathan:82A:/
-435.3 "Dread Tide" sync /:Leviathan:754:/
-439.6 "Aqua Burst" sync /:Wave Spume:888:/
-442.5 "Aqua Breath" sync /:Leviathan:826:/
-446.6 "Waterspout" sync /:Leviathan:742:/
-455.8 "Dread Tide" sync /:Leviathan:754:/
+425.2 "Body Slam" sync / 1[56]:Leviathan:82A:/
+435.3 "Dread Tide" sync / 1[56]:Leviathan:754:/
+439.6 "Aqua Burst" sync / 1[56]:Wave Spume:888:/
+442.5 "Aqua Breath" sync / 1[56]:Leviathan:826:/
+446.6 "Waterspout" sync / 1[56]:Leviathan:742:/
+455.8 "Dread Tide" sync / 1[56]:Leviathan:754:/
 462.5 "--untargetable--"
-465.6 "Grand Fall x3" #sync /:Leviathan:82F:/
-468.1 "Spinning Dive" sync /:Leviathan:82C:/
+465.6 "Grand Fall x3" #sync / 1[56]:Leviathan:82F:/
+468.1 "Spinning Dive" sync / 1[56]:Leviathan:82C:/
 468.1 "--untargetable--"
-473.9 "Tidal Wave" sync /:Leviathan:82E:/ window 150,100
+473.9 "Tidal Wave" sync / 1[56]:Leviathan:82E:/ window 150,100
 
 
 ### Phase 4: more adds, enrage
 486.6 "--targetable--"
-486.7 "Body Slam" sync /:Leviathan:82A:/ window 30,30
+486.7 "Body Slam" sync / 1[56]:Leviathan:82A:/ window 30,30
 488.2 "--Wavetooth Sahagin (NW)--"
-500.3 "Tidal Roar" sync /:Leviathan:74B:/
-508.5 "Aqua Breath" sync /:Leviathan:826:/
-512.6 "Waterspout" sync /:Leviathan:742:/
-512.6 "Tail Whip" #sync /:Leviathan's Tail:827:/
-519.8 "Dread Tide" sync /:Leviathan:754:/
-523.9 "Tidal Roar" sync /:Leviathan:74B:/
+500.3 "Tidal Roar" sync / 1[56]:Leviathan:74B:/
+508.5 "Aqua Breath" sync / 1[56]:Leviathan:826:/
+512.6 "Waterspout" sync / 1[56]:Leviathan:742:/
+512.6 "Tail Whip" #sync / 1[56]:Leviathan's Tail:827:/
+519.8 "Dread Tide" sync / 1[56]:Leviathan:754:/
+523.9 "Tidal Roar" sync / 1[56]:Leviathan:74B:/
 
 532.1 "--untargetable--"
-535.2 "Grand Fall x3" #sync /:Leviathan:82F:/
-537.7 "Spinning Dive" sync /:Leviathan:82C:/
-542.6 "Spinning Dive" sync /:Leviathan:82C:/
+535.2 "Grand Fall x3" #sync / 1[56]:Leviathan:82F:/
+537.7 "Spinning Dive" sync / 1[56]:Leviathan:82C:/
+542.6 "Spinning Dive" sync / 1[56]:Leviathan:82C:/
 
 548.3 "--targetable--"
-548.4 "Body Slam" sync /:Leviathan:82A:/ window 30,30
-563.6 "Dread Tide" sync /:Leviathan:754:/
-567.7 "Tidal Roar" sync /:Leviathan:74B:/
-581.1 "Dread Tide" sync /:Leviathan:754:/
-587.3 "Tidal Roar" sync /:Leviathan:74B:/
+548.4 "Body Slam" sync / 1[56]:Leviathan:82A:/ window 30,30
+563.6 "Dread Tide" sync / 1[56]:Leviathan:754:/
+567.7 "Tidal Roar" sync / 1[56]:Leviathan:74B:/
+581.1 "Dread Tide" sync / 1[56]:Leviathan:754:/
+587.3 "Tidal Roar" sync / 1[56]:Leviathan:74B:/
 600.9 "--2x Wavespine Sahagin--" # ? not sure where
-601.6 "Tidal Roar" sync /:Leviathan:74B:/
-609.8 "Aqua Breath" sync /:Leviathan:826:/
-613.9 "Waterspout" sync /:Leviathan:742:/
-614.8 "Tail Whip" #sync /:Leviathan's Tail:827:/
-621.1 "Dread Tide" sync /:Leviathan:754:/
-625.2 "Tidal Roar" sync /:Leviathan:74B:/
+601.6 "Tidal Roar" sync / 1[56]:Leviathan:74B:/
+609.8 "Aqua Breath" sync / 1[56]:Leviathan:826:/
+613.9 "Waterspout" sync / 1[56]:Leviathan:742:/
+614.8 "Tail Whip" #sync / 1[56]:Leviathan's Tail:827:/
+621.1 "Dread Tide" sync / 1[56]:Leviathan:754:/
+625.2 "Tidal Roar" sync / 1[56]:Leviathan:74B:/
 
 634.1 "--untargetable--"
-637.2 "Grand Fall x3" sync /:Leviathan:82F:/
-639.7 "Spinning Dive" sync /:Leviathan:82C:/
-644.6 "Spinning Dive" sync /:Leviathan:82C:/
+637.2 "Grand Fall x3" sync / 1[56]:Leviathan:82F:/
+639.7 "Spinning Dive" sync / 1[56]:Leviathan:82C:/
+644.6 "Spinning Dive" sync / 1[56]:Leviathan:82C:/
 
 650.3 "--targetable--"
-650.4 "Body Slam" sync /:Leviathan:82A:/ window 30,30
-665.6 "Dread Tide" sync /:Leviathan:754:/
+650.4 "Body Slam" sync / 1[56]:Leviathan:82A:/ window 30,30
+665.6 "Dread Tide" sync / 1[56]:Leviathan:754:/
 
 669.6 "--untargetable--"
-676.9 "Tidal Wave Enrage" sync /:Leviathan:82E:/
+676.9 "Tidal Wave Enrage" sync / 1[56]:Leviathan:82E:/

--- a/ui/raidboss/data/02-arr/trial/levi-ex.txt
+++ b/ui/raidboss/data/02-arr/trial/levi-ex.txt
@@ -35,7 +35,7 @@
 hideall "--Reset--"
 hideall "--sync--"
 
-0.0 "--reset--" sync / 21:........:40000010:/ window 100000 jump 0
+0.0 "--Reset--" sync / 21:........:40000010:/ window 100000 jump 0
 
 ### Phase 1: Literally Just Autos (100% -> 90%)
 0.0 "Start"

--- a/ui/raidboss/data/02-arr/trial/levi-ex.txt
+++ b/ui/raidboss/data/02-arr/trial/levi-ex.txt
@@ -35,7 +35,7 @@
 hideall "--Reset--"
 hideall "--sync--"
 
-0 "--Reset--" sync / 21:........:40000010:/ window 100000 jump 0
+0.0 "--reset--" sync / 21:........:40000010:/ window 100000 jump 0
 
 ### Phase 1: Literally Just Autos (100% -> 90%)
 0.0 "Start"

--- a/ui/raidboss/data/02-arr/trial/shiva-ex.txt
+++ b/ui/raidboss/data/02-arr/trial/shiva-ex.txt
@@ -34,7 +34,7 @@
 hideall "--sync--"
 hideall "--Reset--"
 
-0 "--Reset--" sync / 21:........:40000010:/ window 100000 jump 0
+0.0 "--reset--" sync / 21:........:40000010:/ window 100000 jump 0
 
 # Phase 1: Literally Just Autos (100% -> 95%)
 0.0 "--sync--" sync /:Engage!/ window 0,1
@@ -53,16 +53,16 @@ hideall "--Reset--"
 127.0 "Absolute Zero" sync / 1[56]:Shiva:BE6:/
 
 140.5 "Absolute Zero" sync / 1[56]:Shiva:BE6:/ window 8,8 jump 117.6
-149.9 "Absolute Zero" #sync / 1[56]:Shiva:BE6:/
+149.9 "Absolute Zero" # sync / 1[56]:Shiva:BE6:/
 
-163.4 "Absolute Zero" #sync / 1[56]:Shiva:BE6:/
-173.8 "Absolute Zero" #sync / 1[56]:Shiva:BE6:/
+163.4 "Absolute Zero" # sync / 1[56]:Shiva:BE6:/
+173.8 "Absolute Zero" # sync / 1[56]:Shiva:BE6:/
 
 
 # Phase 3a: Sword (90% -> 80%)
 200.0 "Melt" sync / 1[56]:Shiva:C7F:/ window 100,0
 # This rolls out x4 over 1.5 seconds, so don't sync
-207.2 "Icicle Impact" #sync / 1[56]:Shiva:BEB:/
+207.2 "Icicle Impact" # sync / 1[56]:Shiva:BEB:/
 212.3 "Dreams Of Ice" sync / 1[56]:Shiva:BEA:/
 
 225.0 "Frost Blade" sync / 1[56]:Shiva:993:/
@@ -77,12 +77,12 @@ hideall "--Reset--"
 284.5 "Whiteout" sync / 1[56]:Shiva:BEC:/
 
 292.8 "Heavenly Strike" sync / 1[56]:Shiva:BE8:/ window 20,20 jump 235.4
-302.4 "Glacier Bash" #sync / 1[56]:Shiva:BE9:/
-312.8 "Whiteout" #sync / 1[56]:Shiva:BEC:/
+302.4 "Glacier Bash" # sync / 1[56]:Shiva:BE9:/
+312.8 "Whiteout" # sync / 1[56]:Shiva:BEC:/
 
-321.3 "Heavenly Strike" #sync / 1[56]:Shiva:BE8:/
-330.9 "Glacier Bash" #sync / 1[56]:Shiva:BE9:/
-341.9 "Whiteout" #sync / 1[56]:Shiva:BEC:/
+321.3 "Heavenly Strike" # sync / 1[56]:Shiva:BE8:/
+330.9 "Glacier Bash" # sync / 1[56]:Shiva:BE9:/
+341.9 "Whiteout" # sync / 1[56]:Shiva:BEC:/
 
 
 # Jump to adds phase from 1a/2a
@@ -102,18 +102,18 @@ hideall "--Reset--"
 458.8 "Whiteout" sync / 1[56]:Shiva:BEC:/
 
 467.2 "Heavenly Strike" sync / 1[56]:Shiva:BE8:/ window 20,20 jump 410.3
-477.3 "Glacier Bash" #sync / 1[56]:Shiva:BE9:/
-487.7 "Whiteout" #sync / 1[56]:Shiva:BEC:/
+477.3 "Glacier Bash" # sync / 1[56]:Shiva:BE9:/
+487.7 "Whiteout" # sync / 1[56]:Shiva:BEC:/
 
-496.2 "Heavenly Strike" #sync / 1[56]:Shiva:BE8:/
-505.8 "Glacier Bash" #sync / 1[56]:Shiva:BE9:/
-516.8 "Whiteout" #sync / 1[56]:Shiva:BEC:/
+496.2 "Heavenly Strike" # sync / 1[56]:Shiva:BE8:/
+505.8 "Glacier Bash" # sync / 1[56]:Shiva:BE9:/
+516.8 "Whiteout" # sync / 1[56]:Shiva:BEC:/
 
 
 # Phase 3b: Staff (90% -> 80%)
 600.0 "Melt" sync / 1[56]:Shiva:994:/ window 200,0
 # This rolls out x4 over 1.5 seconds, so don't sync
-607.2 "Icicle Impact" #sync / 1[56]:Shiva:BEB:/
+607.2 "Icicle Impact" # sync / 1[56]:Shiva:BEB:/
 612.3 "Dreams Of Ice" sync / 1[56]:Shiva:BEA:/
 
 625.0 "Frost Staff" sync / 1[56]:Shiva:995:/
@@ -123,10 +123,10 @@ hideall "--Reset--"
 652.0 "Absolute Zero" sync / 1[56]:Shiva:BE6:/
 
 665.5 "Absolute Zero" sync / 1[56]:Shiva:BE6:/ window 8,8 jump 642.6
-674.9 "Absolute Zero" #sync / 1[56]:Shiva:BE6:/
+674.9 "Absolute Zero" # sync / 1[56]:Shiva:BE6:/
 
-688.4 "Absolute Zero" #sync / 1[56]:Shiva:BE6:/
-698.8 "Absolute Zero" #sync / 1[56]:Shiva:BE6:/
+688.4 "Absolute Zero" # sync / 1[56]:Shiva:BE6:/
+698.8 "Absolute Zero" # sync / 1[56]:Shiva:BE6:/
 
 
 # Jump to adds phase from 1b/2b
@@ -134,11 +134,11 @@ hideall "--Reset--"
 
 
 # Phase 4: Adds
-800.0 "--sync--" #sync / 1[56]:Shiva:994:/
-801.0 "--sync--" #sync / 1[56]:Shiva:C7F:/
+800.0 "--sync--" # sync / 1[56]:Shiva:994:/
+801.0 "--sync--" # sync / 1[56]:Shiva:C7F:/
 # If you push *really* fast and skip a 3a/3b weapon phase, you'll miss the melt jump.
 # So, fix that up with a combatant sync here.
-806.6 "--adds targetable--" sync / 03:........:Ice Soldier\.:/  window 807,10
+806.6 "--adds targetable--" sync / 03:........:Ice Soldier:/  window 807,10
 807.6 "Dreams Of Ice" sync / 1[56]:Shiva:BEA:/
 813.2 "Frost Blade" sync / 1[56]:Shiva:993:/
 818.5 "Icebrand" sync / 1[56]:Shiva:BE1:/
@@ -158,13 +158,13 @@ hideall "--Reset--"
 # Phase 5: Post-Cutscene Staff
 # Unlike phase 7a staff, this one can only have a single optional Permafrost.
 885.8 "Frost Staff" sync / 1[56]:Shiva:995:/
-888.1 "Icicle Impact (cross)" #sync / 1[56]:Shiva:BEB:/
+888.1 "Icicle Impact (cross)" # sync / 1[56]:Shiva:BEB:/
 893.9 "Hailstorm" sync / 1[56]:Shiva:997:/
-896.0 "Icicle Impact (cross)" #sync / 1[56]:Shiva:BEB:/
+896.0 "Icicle Impact (cross)" # sync / 1[56]:Shiva:BEB:/
 908.6 "Absolute Zero" sync / 1[56]:Shiva:BE6:/
 920.2 "Absolute Zero" sync / 1[56]:Shiva:BE6:/
 925.4 "Melt" sync / 1[56]:Shiva:C7F:/
-932.6 "Icicle Impact (circle)" duration 4 #sync / 1[56]:Shiva:BEB:/
+932.6 "Icicle Impact (circle)" duration 4 # sync / 1[56]:Shiva:BEB:/
 935.5 "Permafrost?" sync / 1[56]:Shiva:BE3:/
 939.7 "Dreams Of Ice" sync / 1[56]:Shiva:BEA:/ window 20,10
 
@@ -183,37 +183,37 @@ hideall "--Reset--"
 
 # Phase 7a: Staff
 1096.2 "Frost Staff" sync / 1[56]:Shiva:995:/
-1098.1 "Icicle Impact (cross)" #sync / 1[56]:Shiva:BEB:/
+1098.1 "Icicle Impact (cross)" # sync / 1[56]:Shiva:BEB:/
 1104.3 "Hailstorm" sync / 1[56]:Shiva:997:/
-1106.1 "Icicle Impact (cross)" #sync / 1[56]:Shiva:BEB:/
+1106.1 "Icicle Impact (cross)" # sync / 1[56]:Shiva:BEB:/
 1109.0 "Permafrost?" sync / 1[56]:Shiva:BE3:/
 1117.8 "Absolute Zero" sync / 1[56]:Shiva:BE6:/ window 20,2.5
 1125.6 "Absolute Zero" sync / 1[56]:Shiva:BE6:/
 1133.0 "Absolute Zero" sync / 1[56]:Shiva:BE6:/
 # Note: this last absolute zero can either happen at 1135.8 or 1140.4 depending on
 # where the permafrost shows up.  So, don't sync it.
-1138.0 "Absolute Zero" #sync / 1[56]:Shiva:BE6:/
+1138.0 "Absolute Zero" # sync / 1[56]:Shiva:BE6:/
 1140.0 "Permafrost?" sync / 1[56]:Shiva:BE3:/
 1149.4 "Melt" sync / 1[56]:Shiva:C7F:/ window 20,20
-1156.6 "Icicle Impact (circle)" duration 4 #sync / 1[56]:Shiva:BEB:/
+1156.6 "Icicle Impact (circle)" duration 4 # sync / 1[56]:Shiva:BEB:/
 1159.5 "Permafrost?" sync / 1[56]:Shiva:BE3:/
 1163.7 "Dreams Of Ice" sync / 1[56]:Shiva:BEA:/ window 20,20
 
 1166.9 "Frost Bow" sync / 1[56]:Shiva:BDD:/ window 100,20 jump 942.8
-1172.0 "Glass Dance" #sync / 1[56]:Shiva:BDF:/
-1194.6 "Avalanche" #sync / 1[56]:Shiva:BE0:/
-1198.7 "Permafrost?" #sync / 1[56]:Shiva:BE3:/
-1210.2 "Melt" #sync / 1[56]:Shiva:C7E:/ window 20,20
-1212.4 "Dreams Of Ice" #sync / 1[56]:Shiva:BEA:/
+1172.0 "Glass Dance" # sync / 1[56]:Shiva:BDF:/
+1194.6 "Avalanche" # sync / 1[56]:Shiva:BE0:/
+1198.7 "Permafrost?" # sync / 1[56]:Shiva:BE3:/
+1210.2 "Melt" # sync / 1[56]:Shiva:C7E:/ window 20,20
+1212.4 "Dreams Of Ice" # sync / 1[56]:Shiva:BEA:/
 
 
 
 
 # Phase 7b: Sword
 1296.2 "Frost Blade" sync / 1[56]:Shiva:993:/
-1298.5 "Icicle Impact (cross)" #sync / 1[56]:Shiva:BEB:/
+1298.5 "Icicle Impact (cross)" # sync / 1[56]:Shiva:BEB:/
 1302.3 "Icebrand" sync / 1[56]:Shiva:BE1:/
-1306.4 "Icicle Impact (cross)" #sync / 1[56]:Shiva:BEB:/
+1306.4 "Icicle Impact (cross)" # sync / 1[56]:Shiva:BEB:/
 1306.4 "Permafrost?" sync / 1[56]:Shiva:BE3:/
 1316.8 "--sync--" sync / 14:Shiva:BE9:/ window 10,10
 1319.0 "Glacier Bash" sync / 1[56]:Shiva:BE9:/
@@ -221,21 +221,21 @@ hideall "--Reset--"
 1334.7 "Heavenly Strike" sync / 1[56]:Shiva:BE8:/
 1338.8 "Permafrost?" sync / 1[56]:Shiva:BE3:/
 1350.7 "Melt" sync / 1[56]:Shiva:994:/ window 20,10
-1357.9 "Icicle Impact (circle)" duration 4 #sync / 1[56]:Shiva:BEB:/
+1357.9 "Icicle Impact (circle)" duration 4 # sync / 1[56]:Shiva:BEB:/
 1360.8 "Permafrost?" sync / 1[56]:Shiva:BE3:/
 1365.0 "Dreams Of Ice" sync / 1[56]:Shiva:BEA:/ window 20,20
 
 1368.2 "Frost Bow" sync / 1[56]:Shiva:BDD:/ window 100,20 jump 942.8
-1373.3 "Glass Dance" #sync / 1[56]:Shiva:BDF:/
-1395.9 "Avalanche" #sync / 1[56]:Shiva:BE0:/
-1400.0 "Permafrost?" #sync / 1[56]:Shiva:BE3:/
-1411.5 "Melt" #sync / 1[56]:Shiva:C7E:/ window 20,20
-1413.7 "Dreams Of Ice" #sync / 1[56]:Shiva:BEA:/
+1373.3 "Glass Dance" # sync / 1[56]:Shiva:BDF:/
+1395.9 "Avalanche" # sync / 1[56]:Shiva:BE0:/
+1400.0 "Permafrost?" # sync / 1[56]:Shiva:BE3:/
+1411.5 "Melt" # sync / 1[56]:Shiva:C7E:/ window 20,20
+1413.7 "Dreams Of Ice" # sync / 1[56]:Shiva:BEA:/
 
 
 
 # Enrage
-#1165.6 "--untargetable--"
-#1176.7 "--sync--" sync /:Shiva:C16:/
-#1176.7 "Diamond Dust" sync /:Shiva:9A2:/
-#1181.6 "Diamond Dust" sync /:Shiva:98A:/
+# 1165.6 "--untargetable--"
+# 1176.7 "--sync--" sync / 1[56]:Shiva:C16:/
+# 1176.7 "Diamond Dust" sync / 1[56]:Shiva:9A2:/
+# 1181.6 "Diamond Dust" sync / 1[56]:Shiva:98A:/

--- a/ui/raidboss/data/02-arr/trial/shiva-ex.txt
+++ b/ui/raidboss/data/02-arr/trial/shiva-ex.txt
@@ -34,7 +34,7 @@
 hideall "--sync--"
 hideall "--Reset--"
 
-0.0 "--reset--" sync / 21:........:40000010:/ window 100000 jump 0
+0.0 "--Reset--" sync / 21:........:40000010:/ window 100000 jump 0
 
 # Phase 1: Literally Just Autos (100% -> 95%)
 0.0 "--sync--" sync /:Engage!/ window 0,1
@@ -53,16 +53,16 @@ hideall "--Reset--"
 127.0 "Absolute Zero" sync / 1[56]:Shiva:BE6:/
 
 140.5 "Absolute Zero" sync / 1[56]:Shiva:BE6:/ window 8,8 jump 117.6
-149.9 "Absolute Zero" # sync / 1[56]:Shiva:BE6:/
+149.9 "Absolute Zero" #sync / 1[56]:Shiva:BE6:/
 
-163.4 "Absolute Zero" # sync / 1[56]:Shiva:BE6:/
-173.8 "Absolute Zero" # sync / 1[56]:Shiva:BE6:/
+163.4 "Absolute Zero" #sync / 1[56]:Shiva:BE6:/
+173.8 "Absolute Zero" #sync / 1[56]:Shiva:BE6:/
 
 
 # Phase 3a: Sword (90% -> 80%)
 200.0 "Melt" sync / 1[56]:Shiva:C7F:/ window 100,0
 # This rolls out x4 over 1.5 seconds, so don't sync
-207.2 "Icicle Impact" # sync / 1[56]:Shiva:BEB:/
+207.2 "Icicle Impact" #sync / 1[56]:Shiva:BEB:/
 212.3 "Dreams Of Ice" sync / 1[56]:Shiva:BEA:/
 
 225.0 "Frost Blade" sync / 1[56]:Shiva:993:/
@@ -77,12 +77,12 @@ hideall "--Reset--"
 284.5 "Whiteout" sync / 1[56]:Shiva:BEC:/
 
 292.8 "Heavenly Strike" sync / 1[56]:Shiva:BE8:/ window 20,20 jump 235.4
-302.4 "Glacier Bash" # sync / 1[56]:Shiva:BE9:/
-312.8 "Whiteout" # sync / 1[56]:Shiva:BEC:/
+302.4 "Glacier Bash" #sync / 1[56]:Shiva:BE9:/
+312.8 "Whiteout" #sync / 1[56]:Shiva:BEC:/
 
-321.3 "Heavenly Strike" # sync / 1[56]:Shiva:BE8:/
-330.9 "Glacier Bash" # sync / 1[56]:Shiva:BE9:/
-341.9 "Whiteout" # sync / 1[56]:Shiva:BEC:/
+321.3 "Heavenly Strike" #sync / 1[56]:Shiva:BE8:/
+330.9 "Glacier Bash" #sync / 1[56]:Shiva:BE9:/
+341.9 "Whiteout" #sync / 1[56]:Shiva:BEC:/
 
 
 # Jump to adds phase from 1a/2a
@@ -102,18 +102,18 @@ hideall "--Reset--"
 458.8 "Whiteout" sync / 1[56]:Shiva:BEC:/
 
 467.2 "Heavenly Strike" sync / 1[56]:Shiva:BE8:/ window 20,20 jump 410.3
-477.3 "Glacier Bash" # sync / 1[56]:Shiva:BE9:/
-487.7 "Whiteout" # sync / 1[56]:Shiva:BEC:/
+477.3 "Glacier Bash" #sync / 1[56]:Shiva:BE9:/
+487.7 "Whiteout" #sync / 1[56]:Shiva:BEC:/
 
-496.2 "Heavenly Strike" # sync / 1[56]:Shiva:BE8:/
-505.8 "Glacier Bash" # sync / 1[56]:Shiva:BE9:/
-516.8 "Whiteout" # sync / 1[56]:Shiva:BEC:/
+496.2 "Heavenly Strike" #sync / 1[56]:Shiva:BE8:/
+505.8 "Glacier Bash" #sync / 1[56]:Shiva:BE9:/
+516.8 "Whiteout" #sync / 1[56]:Shiva:BEC:/
 
 
 # Phase 3b: Staff (90% -> 80%)
 600.0 "Melt" sync / 1[56]:Shiva:994:/ window 200,0
 # This rolls out x4 over 1.5 seconds, so don't sync
-607.2 "Icicle Impact" # sync / 1[56]:Shiva:BEB:/
+607.2 "Icicle Impact" #sync / 1[56]:Shiva:BEB:/
 612.3 "Dreams Of Ice" sync / 1[56]:Shiva:BEA:/
 
 625.0 "Frost Staff" sync / 1[56]:Shiva:995:/
@@ -123,10 +123,10 @@ hideall "--Reset--"
 652.0 "Absolute Zero" sync / 1[56]:Shiva:BE6:/
 
 665.5 "Absolute Zero" sync / 1[56]:Shiva:BE6:/ window 8,8 jump 642.6
-674.9 "Absolute Zero" # sync / 1[56]:Shiva:BE6:/
+674.9 "Absolute Zero" #sync / 1[56]:Shiva:BE6:/
 
-688.4 "Absolute Zero" # sync / 1[56]:Shiva:BE6:/
-698.8 "Absolute Zero" # sync / 1[56]:Shiva:BE6:/
+688.4 "Absolute Zero" #sync / 1[56]:Shiva:BE6:/
+698.8 "Absolute Zero" #sync / 1[56]:Shiva:BE6:/
 
 
 # Jump to adds phase from 1b/2b
@@ -134,8 +134,8 @@ hideall "--Reset--"
 
 
 # Phase 4: Adds
-800.0 "--sync--" # sync / 1[56]:Shiva:994:/
-801.0 "--sync--" # sync / 1[56]:Shiva:C7F:/
+800.0 "--sync--" #sync / 1[56]:Shiva:994:/
+801.0 "--sync--" #sync / 1[56]:Shiva:C7F:/
 # If you push *really* fast and skip a 3a/3b weapon phase, you'll miss the melt jump.
 # So, fix that up with a combatant sync here.
 806.6 "--adds targetable--" sync / 03:........:Ice Soldier:/  window 807,10
@@ -158,13 +158,13 @@ hideall "--Reset--"
 # Phase 5: Post-Cutscene Staff
 # Unlike phase 7a staff, this one can only have a single optional Permafrost.
 885.8 "Frost Staff" sync / 1[56]:Shiva:995:/
-888.1 "Icicle Impact (cross)" # sync / 1[56]:Shiva:BEB:/
+888.1 "Icicle Impact (cross)" #sync / 1[56]:Shiva:BEB:/
 893.9 "Hailstorm" sync / 1[56]:Shiva:997:/
-896.0 "Icicle Impact (cross)" # sync / 1[56]:Shiva:BEB:/
+896.0 "Icicle Impact (cross)" #sync / 1[56]:Shiva:BEB:/
 908.6 "Absolute Zero" sync / 1[56]:Shiva:BE6:/
 920.2 "Absolute Zero" sync / 1[56]:Shiva:BE6:/
 925.4 "Melt" sync / 1[56]:Shiva:C7F:/
-932.6 "Icicle Impact (circle)" duration 4 # sync / 1[56]:Shiva:BEB:/
+932.6 "Icicle Impact (circle)" duration 4 #sync / 1[56]:Shiva:BEB:/
 935.5 "Permafrost?" sync / 1[56]:Shiva:BE3:/
 939.7 "Dreams Of Ice" sync / 1[56]:Shiva:BEA:/ window 20,10
 
@@ -183,37 +183,37 @@ hideall "--Reset--"
 
 # Phase 7a: Staff
 1096.2 "Frost Staff" sync / 1[56]:Shiva:995:/
-1098.1 "Icicle Impact (cross)" # sync / 1[56]:Shiva:BEB:/
+1098.1 "Icicle Impact (cross)" #sync / 1[56]:Shiva:BEB:/
 1104.3 "Hailstorm" sync / 1[56]:Shiva:997:/
-1106.1 "Icicle Impact (cross)" # sync / 1[56]:Shiva:BEB:/
+1106.1 "Icicle Impact (cross)" #sync / 1[56]:Shiva:BEB:/
 1109.0 "Permafrost?" sync / 1[56]:Shiva:BE3:/
 1117.8 "Absolute Zero" sync / 1[56]:Shiva:BE6:/ window 20,2.5
 1125.6 "Absolute Zero" sync / 1[56]:Shiva:BE6:/
 1133.0 "Absolute Zero" sync / 1[56]:Shiva:BE6:/
 # Note: this last absolute zero can either happen at 1135.8 or 1140.4 depending on
 # where the permafrost shows up.  So, don't sync it.
-1138.0 "Absolute Zero" # sync / 1[56]:Shiva:BE6:/
+1138.0 "Absolute Zero" #sync / 1[56]:Shiva:BE6:/
 1140.0 "Permafrost?" sync / 1[56]:Shiva:BE3:/
 1149.4 "Melt" sync / 1[56]:Shiva:C7F:/ window 20,20
-1156.6 "Icicle Impact (circle)" duration 4 # sync / 1[56]:Shiva:BEB:/
+1156.6 "Icicle Impact (circle)" duration 4 #sync / 1[56]:Shiva:BEB:/
 1159.5 "Permafrost?" sync / 1[56]:Shiva:BE3:/
 1163.7 "Dreams Of Ice" sync / 1[56]:Shiva:BEA:/ window 20,20
 
 1166.9 "Frost Bow" sync / 1[56]:Shiva:BDD:/ window 100,20 jump 942.8
-1172.0 "Glass Dance" # sync / 1[56]:Shiva:BDF:/
-1194.6 "Avalanche" # sync / 1[56]:Shiva:BE0:/
-1198.7 "Permafrost?" # sync / 1[56]:Shiva:BE3:/
-1210.2 "Melt" # sync / 1[56]:Shiva:C7E:/ window 20,20
-1212.4 "Dreams Of Ice" # sync / 1[56]:Shiva:BEA:/
+1172.0 "Glass Dance" #sync / 1[56]:Shiva:BDF:/
+1194.6 "Avalanche" #sync / 1[56]:Shiva:BE0:/
+1198.7 "Permafrost?" #sync / 1[56]:Shiva:BE3:/
+1210.2 "Melt" #sync / 1[56]:Shiva:C7E:/ window 20,20
+1212.4 "Dreams Of Ice" #sync / 1[56]:Shiva:BEA:/
 
 
 
 
 # Phase 7b: Sword
 1296.2 "Frost Blade" sync / 1[56]:Shiva:993:/
-1298.5 "Icicle Impact (cross)" # sync / 1[56]:Shiva:BEB:/
+1298.5 "Icicle Impact (cross)" #sync / 1[56]:Shiva:BEB:/
 1302.3 "Icebrand" sync / 1[56]:Shiva:BE1:/
-1306.4 "Icicle Impact (cross)" # sync / 1[56]:Shiva:BEB:/
+1306.4 "Icicle Impact (cross)" #sync / 1[56]:Shiva:BEB:/
 1306.4 "Permafrost?" sync / 1[56]:Shiva:BE3:/
 1316.8 "--sync--" sync / 14:Shiva:BE9:/ window 10,10
 1319.0 "Glacier Bash" sync / 1[56]:Shiva:BE9:/
@@ -221,21 +221,21 @@ hideall "--Reset--"
 1334.7 "Heavenly Strike" sync / 1[56]:Shiva:BE8:/
 1338.8 "Permafrost?" sync / 1[56]:Shiva:BE3:/
 1350.7 "Melt" sync / 1[56]:Shiva:994:/ window 20,10
-1357.9 "Icicle Impact (circle)" duration 4 # sync / 1[56]:Shiva:BEB:/
+1357.9 "Icicle Impact (circle)" duration 4 #sync / 1[56]:Shiva:BEB:/
 1360.8 "Permafrost?" sync / 1[56]:Shiva:BE3:/
 1365.0 "Dreams Of Ice" sync / 1[56]:Shiva:BEA:/ window 20,20
 
 1368.2 "Frost Bow" sync / 1[56]:Shiva:BDD:/ window 100,20 jump 942.8
-1373.3 "Glass Dance" # sync / 1[56]:Shiva:BDF:/
-1395.9 "Avalanche" # sync / 1[56]:Shiva:BE0:/
-1400.0 "Permafrost?" # sync / 1[56]:Shiva:BE3:/
-1411.5 "Melt" # sync / 1[56]:Shiva:C7E:/ window 20,20
-1413.7 "Dreams Of Ice" # sync / 1[56]:Shiva:BEA:/
+1373.3 "Glass Dance" #sync / 1[56]:Shiva:BDF:/
+1395.9 "Avalanche" #sync / 1[56]:Shiva:BE0:/
+1400.0 "Permafrost?" #sync / 1[56]:Shiva:BE3:/
+1411.5 "Melt" #sync / 1[56]:Shiva:C7E:/ window 20,20
+1413.7 "Dreams Of Ice" #sync / 1[56]:Shiva:BEA:/
 
 
 
 # Enrage
-# 1165.6 "--untargetable--"
-# 1176.7 "--sync--" sync / 1[56]:Shiva:C16:/
-# 1176.7 "Diamond Dust" sync / 1[56]:Shiva:9A2:/
-# 1181.6 "Diamond Dust" sync / 1[56]:Shiva:98A:/
+#1165.6 "--untargetable--"
+#1176.7 "--sync--" sync / 1[56]:Shiva:C16:/
+#1176.7 "Diamond Dust" sync / 1[56]:Shiva:9A2:/
+#1181.6 "Diamond Dust" sync / 1[56]:Shiva:98A:/

--- a/ui/raidboss/data/02-arr/trial/shiva-ex.txt
+++ b/ui/raidboss/data/02-arr/trial/shiva-ex.txt
@@ -34,203 +34,203 @@
 hideall "--sync--"
 hideall "--Reset--"
 
-0.0 "--Reset--" sync / 21:........:40000010:/ window 10000 jump 0
+0 "--Reset--" sync / 21:........:40000010:/ window 100000 jump 0
 
 # Phase 1: Literally Just Autos (100% -> 95%)
-0.0 "Start" sync /Engage!/ window 0,1
-2.0 "--sync--" sync /:Shiva:BE4:/ window 10,10
+0.0 "--sync--" sync /:Engage!/ window 0,1
+2.0 "--sync--" sync / 1[56]:Shiva:BE4:/ window 10,10
 
 # jump to staff
-10.0 "--sync--" sync /:Shiva:995:/ window 10,100 jump 100
+10.0 "--sync--" sync / 1[56]:Shiva:995:/ window 10,100 jump 100
 # jump to sword
-10.0 "--sync--" sync /:Shiva:993:/ window 10,100 jump 400
+10.0 "--sync--" sync / 1[56]:Shiva:993:/ window 10,100 jump 400
 
 # Phase 2a: Staff (95% -> 90%)
-100.0 "Frost Staff" sync /:Shiva:995:/
-108.1 "Hailstorm" sync /:Shiva:997:/
+100.0 "Frost Staff" sync / 1[56]:Shiva:995:/
+108.1 "Hailstorm" sync / 1[56]:Shiva:997:/
 
-117.6 "Absolute Zero" sync /:Shiva:BE6:/
-127.0 "Absolute Zero" sync /:Shiva:BE6:/
+117.6 "Absolute Zero" sync / 1[56]:Shiva:BE6:/
+127.0 "Absolute Zero" sync / 1[56]:Shiva:BE6:/
 
-140.5 "Absolute Zero" sync /:Shiva:BE6:/ window 8,8 jump 117.6
-149.9 "Absolute Zero" #sync /:Shiva:BE6:/
+140.5 "Absolute Zero" sync / 1[56]:Shiva:BE6:/ window 8,8 jump 117.6
+149.9 "Absolute Zero" #sync / 1[56]:Shiva:BE6:/
 
-163.4 "Absolute Zero" #sync /:Shiva:BE6:/
-173.8 "Absolute Zero" #sync /:Shiva:BE6:/
+163.4 "Absolute Zero" #sync / 1[56]:Shiva:BE6:/
+173.8 "Absolute Zero" #sync / 1[56]:Shiva:BE6:/
 
 
 # Phase 3a: Sword (90% -> 80%)
-200.0 "Melt" sync /:Shiva:C7F:/ window 100,0
+200.0 "Melt" sync / 1[56]:Shiva:C7F:/ window 100,0
 # This rolls out x4 over 1.5 seconds, so don't sync
-207.2 "Icicle Impact" #sync /:Shiva:BEB:/
-212.3 "Dreams Of Ice" sync /:Shiva:BEA:/
+207.2 "Icicle Impact" #sync / 1[56]:Shiva:BEB:/
+212.3 "Dreams Of Ice" sync / 1[56]:Shiva:BEA:/
 
-225.0 "Frost Blade" sync /:Shiva:993:/
-230.1 "Icebrand" sync /:Shiva:BE1:/
+225.0 "Frost Blade" sync / 1[56]:Shiva:993:/
+230.1 "Icebrand" sync / 1[56]:Shiva:BE1:/
 
-235.4 "Heavenly Strike" sync /:Shiva:BE8:/
-245.0 "Glacier Bash" sync /:Shiva:BE9:/
-255.4 "Whiteout" sync /:Shiva:BEC:/
+235.4 "Heavenly Strike" sync / 1[56]:Shiva:BE8:/
+245.0 "Glacier Bash" sync / 1[56]:Shiva:BE9:/
+255.4 "Whiteout" sync / 1[56]:Shiva:BEC:/
 
-263.9 "Heavenly Strike" sync /:Shiva:BE8:/
-273.5 "Glacier Bash" sync /:Shiva:BE9:/
-284.5 "Whiteout" sync /:Shiva:BEC:/
+263.9 "Heavenly Strike" sync / 1[56]:Shiva:BE8:/
+273.5 "Glacier Bash" sync / 1[56]:Shiva:BE9:/
+284.5 "Whiteout" sync / 1[56]:Shiva:BEC:/
 
-292.8 "Heavenly Strike" sync /:Shiva:BE8:/ window 20,20 jump 235.4
-302.4 "Glacier Bash" #sync /:Shiva:BE9:/
-312.8 "Whiteout" #sync /:Shiva:BEC:/
+292.8 "Heavenly Strike" sync / 1[56]:Shiva:BE8:/ window 20,20 jump 235.4
+302.4 "Glacier Bash" #sync / 1[56]:Shiva:BE9:/
+312.8 "Whiteout" #sync / 1[56]:Shiva:BEC:/
 
-321.3 "Heavenly Strike" #sync /:Shiva:BE8:/
-330.9 "Glacier Bash" #sync /:Shiva:BE9:/
-341.9 "Whiteout" #sync /:Shiva:BEC:/
+321.3 "Heavenly Strike" #sync / 1[56]:Shiva:BE8:/
+330.9 "Glacier Bash" #sync / 1[56]:Shiva:BE9:/
+341.9 "Whiteout" #sync / 1[56]:Shiva:BEC:/
 
 
 # Jump to adds phase from 1a/2a
-350.0 "--sync--" sync /:Shiva:994:/ window 350,0 jump 800
+350.0 "--sync--" sync / 1[56]:Shiva:994:/ window 350,0 jump 800
 
 
 # Phase 2b: Sword (95% -> 90%)
-400.0 "Frost Blade" sync /:Shiva:993:/
-405.1 "Icebrand" sync /:Shiva:BE1:/
+400.0 "Frost Blade" sync / 1[56]:Shiva:993:/
+405.1 "Icebrand" sync / 1[56]:Shiva:BE1:/
 
-410.3 "Heavenly Strike" sync /:Shiva:BE8:/
-419.9 "Glacier Bash" sync /:Shiva:BE9:/
-430.3 "Whiteout" sync /:Shiva:BEC:/
+410.3 "Heavenly Strike" sync / 1[56]:Shiva:BE8:/
+419.9 "Glacier Bash" sync / 1[56]:Shiva:BE9:/
+430.3 "Whiteout" sync / 1[56]:Shiva:BEC:/
 
-438.8 "Heavenly Strike" sync /:Shiva:BE8:/
-448.4 "Glacier Bash" sync /:Shiva:BE9:/
-458.8 "Whiteout" sync /:Shiva:BEC:/
+438.8 "Heavenly Strike" sync / 1[56]:Shiva:BE8:/
+448.4 "Glacier Bash" sync / 1[56]:Shiva:BE9:/
+458.8 "Whiteout" sync / 1[56]:Shiva:BEC:/
 
-467.2 "Heavenly Strike" sync /:Shiva:BE8:/ window 20,20 jump 410.3
-477.3 "Glacier Bash" #sync /:Shiva:BE9:/
-487.7 "Whiteout" #sync /:Shiva:BEC:/
+467.2 "Heavenly Strike" sync / 1[56]:Shiva:BE8:/ window 20,20 jump 410.3
+477.3 "Glacier Bash" #sync / 1[56]:Shiva:BE9:/
+487.7 "Whiteout" #sync / 1[56]:Shiva:BEC:/
 
-496.2 "Heavenly Strike" #sync /:Shiva:BE8:/
-505.8 "Glacier Bash" #sync /:Shiva:BE9:/
-516.8 "Whiteout" #sync /:Shiva:BEC:/
+496.2 "Heavenly Strike" #sync / 1[56]:Shiva:BE8:/
+505.8 "Glacier Bash" #sync / 1[56]:Shiva:BE9:/
+516.8 "Whiteout" #sync / 1[56]:Shiva:BEC:/
 
 
 # Phase 3b: Staff (90% -> 80%)
-600.0 "Melt" sync /:Shiva:994:/ window 200,0
+600.0 "Melt" sync / 1[56]:Shiva:994:/ window 200,0
 # This rolls out x4 over 1.5 seconds, so don't sync
-607.2 "Icicle Impact" #sync /:Shiva:BEB:/
-612.3 "Dreams Of Ice" sync /:Shiva:BEA:/
+607.2 "Icicle Impact" #sync / 1[56]:Shiva:BEB:/
+612.3 "Dreams Of Ice" sync / 1[56]:Shiva:BEA:/
 
-625.0 "Frost Staff" sync /:Shiva:995:/
-633.1 "Hailstorm" sync /:Shiva:997:/
+625.0 "Frost Staff" sync / 1[56]:Shiva:995:/
+633.1 "Hailstorm" sync / 1[56]:Shiva:997:/
 
-642.6 "Absolute Zero" sync /:Shiva:BE6:/
-652.0 "Absolute Zero" sync /:Shiva:BE6:/
+642.6 "Absolute Zero" sync / 1[56]:Shiva:BE6:/
+652.0 "Absolute Zero" sync / 1[56]:Shiva:BE6:/
 
-665.5 "Absolute Zero" sync /:Shiva:BE6:/ window 8,8 jump 642.6
-674.9 "Absolute Zero" #sync /:Shiva:BE6:/
+665.5 "Absolute Zero" sync / 1[56]:Shiva:BE6:/ window 8,8 jump 642.6
+674.9 "Absolute Zero" #sync / 1[56]:Shiva:BE6:/
 
-688.4 "Absolute Zero" #sync /:Shiva:BE6:/
-698.8 "Absolute Zero" #sync /:Shiva:BE6:/
+688.4 "Absolute Zero" #sync / 1[56]:Shiva:BE6:/
+698.8 "Absolute Zero" #sync / 1[56]:Shiva:BE6:/
 
 
 # Jump to adds phase from 1b/2b
-750.0 "--sync--" sync /:Shiva:C7F:/ window 350,0 jump 801
+750.0 "--sync--" sync / 1[56]:Shiva:C7F:/ window 350,0 jump 801
 
 
 # Phase 4: Adds
-800.0 "--sync--" #sync /:Shiva:994:/
-801.0 "--sync--" #sync /:Shiva:C7F:/
+800.0 "--sync--" #sync / 1[56]:Shiva:994:/
+801.0 "--sync--" #sync / 1[56]:Shiva:C7F:/
 # If you push *really* fast and skip a 3a/3b weapon phase, you'll miss the melt jump.
 # So, fix that up with a combatant sync here.
-806.6 "--adds targetable--" sync / 03:........:Added new combatant Ice Soldier\./ window 807,10
-807.6 "Dreams Of Ice" sync /:Shiva:BEA:/
-813.2 "Frost Blade" sync /:Shiva:993:/
-818.5 "Icebrand" sync /:Shiva:BE1:/
-828.0 "Glacier Bash" sync /:Shiva:BE9:/
-837.5 "Heavenly Strike" sync /:Shiva:BE8:/
+806.6 "--adds targetable--" sync / 03:........:Ice Soldier\.:/  window 807,10
+807.6 "Dreams Of Ice" sync / 1[56]:Shiva:BEA:/
+813.2 "Frost Blade" sync / 1[56]:Shiva:993:/
+818.5 "Icebrand" sync / 1[56]:Shiva:BE1:/
+828.0 "Glacier Bash" sync / 1[56]:Shiva:BE9:/
+837.5 "Heavenly Strike" sync / 1[56]:Shiva:BE8:/
 
 
 # Diamond Dust Cutscene
-854.4 "Melt" sync /:Shiva:994:/ window 60,10
+854.4 "Melt" sync / 1[56]:Shiva:994:/ window 60,10
 855.5 "--untargetable--"
-866.7 "--frozen--" sync /:Shiva:C16:/ window 900,50
-871.6 "Diamond Dust" sync /:Shiva:98A:/
+866.7 "--frozen--" sync / 1[56]:Shiva:C16:/ window 900,50
+871.6 "Diamond Dust" sync / 1[56]:Shiva:98A:/
 878.7 "--targetable--"
-878.9 "Dreams Of Ice" sync /:Shiva:BEA:/
+878.9 "Dreams Of Ice" sync / 1[56]:Shiva:BEA:/
 
 
 # Phase 5: Post-Cutscene Staff
 # Unlike phase 7a staff, this one can only have a single optional Permafrost.
-885.8 "Frost Staff" sync /:Shiva:995:/
-888.1 "Icicle Impact (cross)" #sync /:Shiva:BEB:/
-893.9 "Hailstorm" sync /:Shiva:997:/
-896.0 "Icicle Impact (cross)" #sync /:Shiva:BEB:/
-908.6 "Absolute Zero" sync /:Shiva:BE6:/
-920.2 "Absolute Zero" sync /:Shiva:BE6:/
-925.4 "Melt" sync /:Shiva:C7F:/
-932.6 "Icicle Impact (circle)" duration 4 #sync /:Shiva:BEB:/
-935.5 "Permafrost?" sync /:Shiva:BE3:/
-939.7 "Dreams Of Ice" sync /:Shiva:BEA:/ window 20,10
+885.8 "Frost Staff" sync / 1[56]:Shiva:995:/
+888.1 "Icicle Impact (cross)" #sync / 1[56]:Shiva:BEB:/
+893.9 "Hailstorm" sync / 1[56]:Shiva:997:/
+896.0 "Icicle Impact (cross)" #sync / 1[56]:Shiva:BEB:/
+908.6 "Absolute Zero" sync / 1[56]:Shiva:BE6:/
+920.2 "Absolute Zero" sync / 1[56]:Shiva:BE6:/
+925.4 "Melt" sync / 1[56]:Shiva:C7F:/
+932.6 "Icicle Impact (circle)" duration 4 #sync / 1[56]:Shiva:BEB:/
+935.5 "Permafrost?" sync / 1[56]:Shiva:BE3:/
+939.7 "Dreams Of Ice" sync / 1[56]:Shiva:BEA:/ window 20,10
 
 
 # Phase 6: Bow
-942.8 "Frost Bow" sync /:Shiva:BDD:/
-947.9 "Glass Dance" sync /:Shiva:BDF:/
-970.5 "Avalanche" sync /:Shiva:BE0:/
-974.6 "Permafrost?" sync /:Shiva:BE3:/
-986.1 "Melt" sync /:Shiva:C7E:/ window 20,20
-988.3 "Dreams Of Ice" sync /:Shiva:BEA:/
+942.8 "Frost Bow" sync / 1[56]:Shiva:BDD:/
+947.9 "Glass Dance" sync / 1[56]:Shiva:BDF:/
+970.5 "Avalanche" sync / 1[56]:Shiva:BE0:/
+974.6 "Permafrost?" sync / 1[56]:Shiva:BE3:/
+986.1 "Melt" sync / 1[56]:Shiva:C7E:/ window 20,20
+988.3 "Dreams Of Ice" sync / 1[56]:Shiva:BEA:/
 
-996.2 "Frost Staff?" sync /:Shiva:995:/ window 100,50 jump 1096.2
-996.2 "Frost Blade?" sync /:Shiva:993:/ window 100,50 jump 1296.2
+996.2 "Frost Staff?" sync / 1[56]:Shiva:995:/ window 100,50 jump 1096.2
+996.2 "Frost Blade?" sync / 1[56]:Shiva:993:/ window 100,50 jump 1296.2
 
 
 # Phase 7a: Staff
-1096.2 "Frost Staff" sync /:Shiva:995:/
-1098.1 "Icicle Impact (cross)" #sync /:Shiva:BEB:/
-1104.3 "Hailstorm" sync /:Shiva:997:/
-1106.1 "Icicle Impact (cross)" #sync /:Shiva:BEB:/
-1109.0 "Permafrost?" sync /:Shiva:BE3:/
-1117.8 "Absolute Zero" sync /:Shiva:BE6:/ window 20,2.5
-1125.6 "Absolute Zero" sync /:Shiva:BE6:/
-1133.0 "Absolute Zero" sync /:Shiva:BE6:/
+1096.2 "Frost Staff" sync / 1[56]:Shiva:995:/
+1098.1 "Icicle Impact (cross)" #sync / 1[56]:Shiva:BEB:/
+1104.3 "Hailstorm" sync / 1[56]:Shiva:997:/
+1106.1 "Icicle Impact (cross)" #sync / 1[56]:Shiva:BEB:/
+1109.0 "Permafrost?" sync / 1[56]:Shiva:BE3:/
+1117.8 "Absolute Zero" sync / 1[56]:Shiva:BE6:/ window 20,2.5
+1125.6 "Absolute Zero" sync / 1[56]:Shiva:BE6:/
+1133.0 "Absolute Zero" sync / 1[56]:Shiva:BE6:/
 # Note: this last absolute zero can either happen at 1135.8 or 1140.4 depending on
 # where the permafrost shows up.  So, don't sync it.
-1138.0 "Absolute Zero" #sync /:Shiva:BE6:/
-1140.0 "Permafrost?" sync /:Shiva:BE3:/
-1149.4 "Melt" sync /:Shiva:C7F:/ window 20,20
-1156.6 "Icicle Impact (circle)" duration 4 #sync /:Shiva:BEB:/
-1159.5 "Permafrost?" sync /:Shiva:BE3:/
-1163.7 "Dreams Of Ice" sync /:Shiva:BEA:/ window 20,20
+1138.0 "Absolute Zero" #sync / 1[56]:Shiva:BE6:/
+1140.0 "Permafrost?" sync / 1[56]:Shiva:BE3:/
+1149.4 "Melt" sync / 1[56]:Shiva:C7F:/ window 20,20
+1156.6 "Icicle Impact (circle)" duration 4 #sync / 1[56]:Shiva:BEB:/
+1159.5 "Permafrost?" sync / 1[56]:Shiva:BE3:/
+1163.7 "Dreams Of Ice" sync / 1[56]:Shiva:BEA:/ window 20,20
 
-1166.9 "Frost Bow" sync /:Shiva:BDD:/ window 100,20 jump 942.8
-1172.0 "Glass Dance" #sync /:Shiva:BDF:/
-1194.6 "Avalanche" #sync /:Shiva:BE0:/
-1198.7 "Permafrost?" #sync /:Shiva:BE3:/
-1210.2 "Melt" #sync /:Shiva:C7E:/ window 20,20
-1212.4 "Dreams Of Ice" #sync /:Shiva:BEA:/
+1166.9 "Frost Bow" sync / 1[56]:Shiva:BDD:/ window 100,20 jump 942.8
+1172.0 "Glass Dance" #sync / 1[56]:Shiva:BDF:/
+1194.6 "Avalanche" #sync / 1[56]:Shiva:BE0:/
+1198.7 "Permafrost?" #sync / 1[56]:Shiva:BE3:/
+1210.2 "Melt" #sync / 1[56]:Shiva:C7E:/ window 20,20
+1212.4 "Dreams Of Ice" #sync / 1[56]:Shiva:BEA:/
 
 
 
 
 # Phase 7b: Sword
-1296.2 "Frost Blade" sync /:Shiva:993:/
-1298.5 "Icicle Impact (cross)" #sync /:Shiva:BEB:/
-1302.3 "Icebrand" sync /:Shiva:BE1:/
-1306.4 "Icicle Impact (cross)" #sync /:Shiva:BEB:/
-1306.4 "Permafrost?" sync /:Shiva:BE3:/
-1316.8 "--sync--" sync /:BE9:Shiva/ window 10,10
-1319.0 "Glacier Bash" sync /:Shiva:BE9:/
-1329.4 "Whiteout" sync /:Shiva:BEC:/
-1334.7 "Heavenly Strike" sync /:Shiva:BE8:/
-1338.8 "Permafrost?" sync /:Shiva:BE3:/
-1350.7 "Melt" sync /:Shiva:994:/ window 20,10
-1357.9 "Icicle Impact (circle)" duration 4 #sync /:Shiva:BEB:/
-1360.8 "Permafrost?" sync /:Shiva:BE3:/
-1365.0 "Dreams Of Ice" sync /:Shiva:BEA:/ window 20,20
+1296.2 "Frost Blade" sync / 1[56]:Shiva:993:/
+1298.5 "Icicle Impact (cross)" #sync / 1[56]:Shiva:BEB:/
+1302.3 "Icebrand" sync / 1[56]:Shiva:BE1:/
+1306.4 "Icicle Impact (cross)" #sync / 1[56]:Shiva:BEB:/
+1306.4 "Permafrost?" sync / 1[56]:Shiva:BE3:/
+1316.8 "--sync--" sync / 14:Shiva:BE9:/ window 10,10
+1319.0 "Glacier Bash" sync / 1[56]:Shiva:BE9:/
+1329.4 "Whiteout" sync / 1[56]:Shiva:BEC:/
+1334.7 "Heavenly Strike" sync / 1[56]:Shiva:BE8:/
+1338.8 "Permafrost?" sync / 1[56]:Shiva:BE3:/
+1350.7 "Melt" sync / 1[56]:Shiva:994:/ window 20,10
+1357.9 "Icicle Impact (circle)" duration 4 #sync / 1[56]:Shiva:BEB:/
+1360.8 "Permafrost?" sync / 1[56]:Shiva:BE3:/
+1365.0 "Dreams Of Ice" sync / 1[56]:Shiva:BEA:/ window 20,20
 
-1368.2 "Frost Bow" sync /:Shiva:BDD:/ window 100,20 jump 942.8
-1373.3 "Glass Dance" #sync /:Shiva:BDF:/
-1395.9 "Avalanche" #sync /:Shiva:BE0:/
-1400.0 "Permafrost?" #sync /:Shiva:BE3:/
-1411.5 "Melt" #sync /:Shiva:C7E:/ window 20,20
-1413.7 "Dreams Of Ice" #sync /:Shiva:BEA:/
+1368.2 "Frost Bow" sync / 1[56]:Shiva:BDD:/ window 100,20 jump 942.8
+1373.3 "Glass Dance" #sync / 1[56]:Shiva:BDF:/
+1395.9 "Avalanche" #sync / 1[56]:Shiva:BE0:/
+1400.0 "Permafrost?" #sync / 1[56]:Shiva:BE3:/
+1411.5 "Melt" #sync / 1[56]:Shiva:C7E:/ window 20,20
+1413.7 "Dreams Of Ice" #sync / 1[56]:Shiva:BEA:/
 
 
 

--- a/ui/raidboss/data/02-arr/trial/shiva-hm.txt
+++ b/ui/raidboss/data/02-arr/trial/shiva-hm.txt
@@ -29,142 +29,142 @@
 hideall "--sync--"
 hideall "--Reset--"
 
-0.0 "--Reset--" sync / 21:........:40000010:/ window 10000 jump 0
+0 "--Reset--" sync / 21:........:40000010:/ window 100000 jump 0
 
 # Phase 1: Literally Just Autos (100% -> 95%)
-0.0 "Start" sync /Engage!/ window 0,1
-2.0 "--sync--" sync /:Shiva:99A:/ window 10,10
+0.0 "--sync--" sync /:Engage!/ window 0,1
+2.0 "--sync--" sync / 1[56]:Shiva:99A:/ window 10,10
 
 # jump to staff
-10.0 "--sync--" sync /:Shiva:995:/ window 10,100 jump 200
+10.0 "--sync--" sync / 1[56]:Shiva:995:/ window 10,100 jump 200
 
 
 # Phase 2: Staff (95% -> 85%)
-200.0 "Frost Staff" sync /:Shiva:995:/
-208.1 "Hailstorm" sync /:Shiva:997:/
+200.0 "Frost Staff" sync / 1[56]:Shiva:995:/
+208.1 "Hailstorm" sync / 1[56]:Shiva:997:/
 
-221.7 "Absolute Zero" sync /:Shiva:99C:/ window 30,30 jump 221.7
-244.7 "Absolute Zero" #sync /:Shiva:99C:/
-267.7 "Absolute Zero" #sync /:Shiva:99C:/
+221.7 "Absolute Zero" sync / 1[56]:Shiva:99C:/ window 30,30 jump 221.7
+244.7 "Absolute Zero" #sync / 1[56]:Shiva:99C:/
+267.7 "Absolute Zero" #sync / 1[56]:Shiva:99C:/
 
 
 # Phase 3: Sword (85% -> 65%)
-400.0 "Melt" sync /:Shiva:C7F:/ window 200,0
-409.2 "Icicle Impact (cross)" sync /:Shiva:99E:/
-417.3 "Dreams Of Ice" sync /:Shiva:99D:/
+400.0 "Melt" sync / 1[56]:Shiva:C7F:/ window 200,0
+409.2 "Icicle Impact (cross)" sync / 1[56]:Shiva:99E:/
+417.3 "Dreams Of Ice" sync / 1[56]:Shiva:99D:/
 
-427.9 "Frost Blade" sync /:Shiva:993:/
-433.0 "Icebrand" sync /:Shiva:996:/
-439.3 "Heavenly Strike" sync /:Shiva:9A0:/
+427.9 "Frost Blade" sync / 1[56]:Shiva:993:/
+433.0 "Icebrand" sync / 1[56]:Shiva:996:/
+439.3 "Heavenly Strike" sync / 1[56]:Shiva:9A0:/
 
-451.9 "Glacier Bash" sync /:Shiva:9A1:/
-468.7 "Heavenly Strike" sync /:Shiva:9A0:/
+451.9 "Glacier Bash" sync / 1[56]:Shiva:9A1:/
+468.7 "Heavenly Strike" sync / 1[56]:Shiva:9A0:/
 
-481.1 "Glacier Bash" sync /:Shiva:9A1:/ window 20,20 jump 451.9
-497.9 "Heavenly Strike" #sync /:Shiva:9A0:/
+481.1 "Glacier Bash" sync / 1[56]:Shiva:9A1:/ window 20,20 jump 451.9
+497.9 "Heavenly Strike" #sync / 1[56]:Shiva:9A0:/
 
 
 # Phase 4: Adds
-800.0 "Melt" sync /:Shiva:994:/ window 800,0
+800.0 "Melt" sync / 1[56]:Shiva:994:/ window 800,0
 # If you push *really* fast and skip a weapon phase, you'll miss the melt jump.
 # So, fix that up with a combatant sync here.
-806.2 "--adds targetable--" sync /03:........:Added new combatant Ice Soldier\./ window 807,2.5
-809.9 "Dreams Of Ice" sync /:Shiva:99D:/
+806.2 "--adds targetable--" sync / 03:........:Ice Soldier\.:/  window 807,2.5
+809.9 "Dreams Of Ice" sync / 1[56]:Shiva:99D:/
 
 # Note: Yes, really.  These times are different.
-823.6 "Frost Staff?" sync /:Shiva:995:/ window 100,100 jump 1023.6
-825.4 "Frost Blade?" sync /:Shiva:993:/ window 100,100 jump 1225.4
+823.6 "Frost Staff?" sync / 1[56]:Shiva:995:/ window 100,100 jump 1023.6
+825.4 "Frost Blade?" sync / 1[56]:Shiva:993:/ window 100,100 jump 1225.4
 
 
 # Phase 4a: Adds (Staff)
-1023.6 "Frost Staff" sync /:Shiva:995:/
-1031.7 "Hailstorm" sync /:Shiva:997:/
-1044.3 "Absolute Zero" sync /:Shiva:99C:/
+1023.6 "Frost Staff" sync / 1[56]:Shiva:995:/
+1031.7 "Hailstorm" sync / 1[56]:Shiva:997:/
+1044.3 "Absolute Zero" sync / 1[56]:Shiva:99C:/
 
-1051.6 "Melt" sync /:Shiva:C7F:/ window 100,10
+1051.6 "Melt" sync / 1[56]:Shiva:C7F:/ window 100,10
 1052.7 "--untargetable--"
-1063.9 "--frozen--" sync /:Shiva:C16:/ window 1100,10
-1068.8 "Diamond Dust" sync /:Shiva:98A:/
+1063.9 "--frozen--" sync / 1[56]:Shiva:C16:/ window 1100,10
+1068.8 "Diamond Dust" sync / 1[56]:Shiva:98A:/
 1076.0 "--targetable--"
-1079.1 "Dreams Of Ice" sync /:Shiva:99D:/
-1088.3 "Icicle Impact (circle)" duration 4 #sync /:Shiva:99E:/
+1079.1 "Dreams Of Ice" sync / 1[56]:Shiva:99D:/
+1088.3 "Icicle Impact (circle)" duration 4 #sync / 1[56]:Shiva:99E:/
 
-1095.3 "Frost Staff?" sync /:Shiva:995:/ jump 1400 window 50,90
-1095.3 "Frost Blade?" sync /:Shiva:993:/ jump 1600 window 50,90
+1095.3 "Frost Staff?" sync / 1[56]:Shiva:995:/ jump 1400 window 50,90
+1095.3 "Frost Blade?" sync / 1[56]:Shiva:993:/ jump 1600 window 50,90
 
 
 # Phase 4b: Adds (Blade)
-1225.4 "Frost Blade" sync /:Shiva:993:/
-1230.5 "Icebrand" sync /:Shiva:996:/
-1236.8 "Heavenly Strike" sync /:Shiva:9A0:/
-1249.2 "Glacier Bash" sync /:Shiva:9A1:/
+1225.4 "Frost Blade" sync / 1[56]:Shiva:993:/
+1230.5 "Icebrand" sync / 1[56]:Shiva:996:/
+1236.8 "Heavenly Strike" sync / 1[56]:Shiva:9A0:/
+1249.2 "Glacier Bash" sync / 1[56]:Shiva:9A1:/
 
 # You get 5 extra seconds to kill the adds if it's Blade.
-1256.6 "Melt" sync /:Shiva:994:/ window 100,10
+1256.6 "Melt" sync / 1[56]:Shiva:994:/ window 100,10
 1257.7 "--untargetable--"
-1268.9 "--frozen--" sync /:Shiva:C16:/
-1273.8 "Diamond Dust" sync /:Shiva:98A:/
+1268.9 "--frozen--" sync / 1[56]:Shiva:C16:/
+1273.8 "Diamond Dust" sync / 1[56]:Shiva:98A:/
 1281.0 "--targetable--"
-1284.2 "Dreams Of Ice" sync /:Shiva:99D:/
-1293.4 "Icicle Impact (circle)" duration 4 #sync /:Shiva:99E:/
+1284.2 "Dreams Of Ice" sync / 1[56]:Shiva:99D:/
+1293.4 "Icicle Impact (circle)" duration 4 #sync / 1[56]:Shiva:99E:/
 
-1300.6 "Frost Staff?" sync /:Shiva:995:/ jump 1400 window 50,90
-1300.6 "Frost Blade?" sync /:Shiva:993:/ jump 1600 window 50,90
+1300.6 "Frost Staff?" sync / 1[56]:Shiva:995:/ jump 1400 window 50,90
+1300.6 "Frost Blade?" sync / 1[56]:Shiva:993:/ jump 1600 window 50,90
 
 
 # Phase 5a: Staff
 # Note: only one absolute zero here.
-1400.0 "Frost Staff" sync /:Shiva:995:/
-1408.1 "Hailstorm" sync /:Shiva:997:/
-1421.7 "Absolute Zero" sync /:Shiva:99C:/
-1432.2 "Melt" sync /:Shiva:C7F:/
-1434.3 "Permafrost" sync /:Shiva:999:/
-1440.5 "Dreams Of Ice" sync /:Shiva:99D:/
-1450.7 "Icicle Impact" sync /:Shiva:99E:/
+1400.0 "Frost Staff" sync / 1[56]:Shiva:995:/
+1408.1 "Hailstorm" sync / 1[56]:Shiva:997:/
+1421.7 "Absolute Zero" sync / 1[56]:Shiva:99C:/
+1432.2 "Melt" sync / 1[56]:Shiva:C7F:/
+1434.3 "Permafrost" sync / 1[56]:Shiva:999:/
+1440.5 "Dreams Of Ice" sync / 1[56]:Shiva:99D:/
+1450.7 "Icicle Impact" sync / 1[56]:Shiva:99E:/
 
-1454.7 "Frost Staff?" sync /:Shiva:995:/ jump 1800 window 50,90
-1454.7 "Frost Blade?" sync /:Shiva:993:/ jump 2000 window 50,90
+1454.7 "Frost Staff?" sync / 1[56]:Shiva:995:/ jump 1800 window 50,90
+1454.7 "Frost Blade?" sync / 1[56]:Shiva:993:/ jump 2000 window 50,90
 
 
 # Phase 5b: Blade
 # Note: this has the same abilities as 6b, but slightly different timings,
 # e.g. Heavenly Strike is ~1611 instead of ~1614.
-1600.0 "Frost Blade" sync /:Shiva:993:/
-1605.3 "Icebrand" sync /:Shiva:996:/
-1611.7 "Heavenly Strike" sync /:Shiva:9A0:/ window 10,10
-1624.2 "Glacier Bash" sync /:Shiva:9A1:/
-1634.8 "Melt" sync /:Shiva:994:/
-1636.9 "Permafrost" sync /:Shiva:999:/
-1643.1 "Dreams Of Ice" sync /:Shiva:99D:/
-1653.3 "Icicle Impact" #sync /:Shiva:99E:/
+1600.0 "Frost Blade" sync / 1[56]:Shiva:993:/
+1605.3 "Icebrand" sync / 1[56]:Shiva:996:/
+1611.7 "Heavenly Strike" sync / 1[56]:Shiva:9A0:/ window 10,10
+1624.2 "Glacier Bash" sync / 1[56]:Shiva:9A1:/
+1634.8 "Melt" sync / 1[56]:Shiva:994:/
+1636.9 "Permafrost" sync / 1[56]:Shiva:999:/
+1643.1 "Dreams Of Ice" sync / 1[56]:Shiva:99D:/
+1653.3 "Icicle Impact" #sync / 1[56]:Shiva:99E:/
 
-1657.6 "Frost Staff?" sync /:Shiva:995:/ jump 1800 window 90,90
-1657.6 "Frost Blade?" sync /:Shiva:993:/ jump 2000 window 90,90
+1657.6 "Frost Staff?" sync / 1[56]:Shiva:995:/ jump 1800 window 90,90
+1657.6 "Frost Blade?" sync / 1[56]:Shiva:993:/ jump 2000 window 90,90
 
 
 # Phase 6a: Staff
-1800.0 "Frost Staff" sync /:Shiva:995:/
-1808.1 "Hailstorm" sync /:Shiva:997:/
-1818.6 "Absolute Zero" sync /:Shiva:99C:/
-1823.9 "Absolute Zero" sync /:Shiva:99C:/
-1829.2 "Melt" sync /:Shiva:C7F:/
-1831.3 "Permafrost" sync /:Shiva:999:/
-1837.5 "Dreams Of Ice" sync /:Shiva:99D:/
-1847.8 "Icicle Impact" sync /:Shiva:99E:/
+1800.0 "Frost Staff" sync / 1[56]:Shiva:995:/
+1808.1 "Hailstorm" sync / 1[56]:Shiva:997:/
+1818.6 "Absolute Zero" sync / 1[56]:Shiva:99C:/
+1823.9 "Absolute Zero" sync / 1[56]:Shiva:99C:/
+1829.2 "Melt" sync / 1[56]:Shiva:C7F:/
+1831.3 "Permafrost" sync / 1[56]:Shiva:999:/
+1837.5 "Dreams Of Ice" sync / 1[56]:Shiva:99D:/
+1847.8 "Icicle Impact" sync / 1[56]:Shiva:99E:/
 
-1851.8 "Frost Staff?" sync /:Shiva:995:/ jump 1800 window 90,90
-1851.8 "Frost Blade?" sync /:Shiva:993:/ jump 2000 window 90,90
+1851.8 "Frost Staff?" sync / 1[56]:Shiva:995:/ jump 1800 window 90,90
+1851.8 "Frost Blade?" sync / 1[56]:Shiva:993:/ jump 2000 window 90,90
 
 
 # Phase 6b: Blade
-2000.0 "Frost Blade" sync /:Shiva:993:/
-2005.1 "Icebrand" sync /:Shiva:996:/ window 5,5
-2014.5 "Heavenly Strike" sync /:Shiva:9A0:/ window 5,5
-2024.9 "Glacier Bash" sync /:Shiva:9A1:/
-2030.2 "Melt" sync /:Shiva:994:/
-2032.3 "Permafrost" sync /:Shiva:999:/
-2038.5 "Dreams Of Ice" sync /:Shiva:99D:/
-2048.7 "Icicle Impact" #sync /:Shiva:99E:/
+2000.0 "Frost Blade" sync / 1[56]:Shiva:993:/
+2005.1 "Icebrand" sync / 1[56]:Shiva:996:/ window 5,5
+2014.5 "Heavenly Strike" sync / 1[56]:Shiva:9A0:/ window 5,5
+2024.9 "Glacier Bash" sync / 1[56]:Shiva:9A1:/
+2030.2 "Melt" sync / 1[56]:Shiva:994:/
+2032.3 "Permafrost" sync / 1[56]:Shiva:999:/
+2038.5 "Dreams Of Ice" sync / 1[56]:Shiva:99D:/
+2048.7 "Icicle Impact" #sync / 1[56]:Shiva:99E:/
 
-2053.5 "Frost Staff?" sync /:Shiva:995:/ jump 1800 window 90,90
-2053.5 "Frost Blade?" sync /:Shiva:993:/ jump 2000 window 90,90
+2053.5 "Frost Staff?" sync / 1[56]:Shiva:995:/ jump 1800 window 90,90
+2053.5 "Frost Blade?" sync / 1[56]:Shiva:993:/ jump 2000 window 90,90

--- a/ui/raidboss/data/02-arr/trial/shiva-hm.txt
+++ b/ui/raidboss/data/02-arr/trial/shiva-hm.txt
@@ -29,7 +29,7 @@
 hideall "--sync--"
 hideall "--Reset--"
 
-0.0 "--reset--" sync / 21:........:40000010:/ window 100000 jump 0
+0.0 "--Reset--" sync / 21:........:40000010:/ window 100000 jump 0
 
 # Phase 1: Literally Just Autos (100% -> 95%)
 0.0 "--sync--" sync /:Engage!/ window 0,1

--- a/ui/raidboss/data/02-arr/trial/shiva-hm.txt
+++ b/ui/raidboss/data/02-arr/trial/shiva-hm.txt
@@ -29,7 +29,7 @@
 hideall "--sync--"
 hideall "--Reset--"
 
-0 "--Reset--" sync / 21:........:40000010:/ window 100000 jump 0
+0.0 "--reset--" sync / 21:........:40000010:/ window 100000 jump 0
 
 # Phase 1: Literally Just Autos (100% -> 95%)
 0.0 "--sync--" sync /:Engage!/ window 0,1
@@ -68,7 +68,7 @@ hideall "--Reset--"
 800.0 "Melt" sync / 1[56]:Shiva:994:/ window 800,0
 # If you push *really* fast and skip a weapon phase, you'll miss the melt jump.
 # So, fix that up with a combatant sync here.
-806.2 "--adds targetable--" sync / 03:........:Ice Soldier\.:/  window 807,2.5
+806.2 "--adds targetable--" sync / 03:........:Ice Soldier:/  window 807,2.5
 809.9 "Dreams Of Ice" sync / 1[56]:Shiva:99D:/
 
 # Note: Yes, really.  These times are different.

--- a/ui/raidboss/data/02-arr/trial/titan-ex.txt
+++ b/ui/raidboss/data/02-arr/trial/titan-ex.txt
@@ -8,25 +8,25 @@
 hideall "--Reset--"
 hideall "--sync--"
 
-0.0 "--Reset--" sync / 21:........:40000010:/ window 10000 jump 0
+0 "--Reset--" sync / 21:........:40000010:/ window 100000 jump 0
 
 ### Phase 1: 100->85%
 0.0 "Start"
 0.0 "--sync--" sync /:Engage!/ window 0,1
 
-10.0 "Landslide" sync /:Titan:5BB:/ window 10,10
-18.7 "Weight Of The Land" sync /:Titan:5BE:/ window 20,5
-22.3 "Mountain Buster" sync /:Titan:5B8:/
-27.5 "Tumult x4" duration 3.5 #sync /:Titan:5B9:/
-37.3 "Landslide" sync /:Titan:5BB:/
-41.4 "Mountain Buster" sync /:Titan:5B8:/
-48.0 "Weight Of The Land" sync /:Titan:5BE:/
-55.7 "Mountain Buster" sync /:Titan:5B8:/
+10.0 "Landslide" sync / 1[56]:Titan:5BB:/ window 10,10
+18.7 "Weight Of The Land" sync / 1[56]:Titan:5BE:/ window 20,5
+22.3 "Mountain Buster" sync / 1[56]:Titan:5B8:/
+27.5 "Tumult x4" duration 3.5 #sync / 1[56]:Titan:5B9:/
+37.3 "Landslide" sync / 1[56]:Titan:5BB:/
+41.4 "Mountain Buster" sync / 1[56]:Titan:5B8:/
+48.0 "Weight Of The Land" sync / 1[56]:Titan:5BE:/
+55.7 "Mountain Buster" sync / 1[56]:Titan:5B8:/
 
-62.0 "Landslide" sync /:Titan:5BB:/ window 15,15 jump 10
+62.0 "Landslide" sync / 1[56]:Titan:5BB:/ window 15,15 jump 10
 70.2 "Weight Of The Land"
 74.3 "Mountain Buster"
-79.5 "Tumult x4" duration 3.5 #sync /:Titan:5B9:/
+79.5 "Tumult x4" duration 3.5 #sync / 1[56]:Titan:5B9:/
 89.3 "Landslide"
 93.4 "Mountain Buster"
 99.5 "Weight Of The Land"
@@ -34,38 +34,38 @@ hideall "--sync--"
 
 
 # Phase 2: 85%->55%
-200.0 "--sync--" sync /:5C0:Titan/ window 200,0
-203.0 "Geocrush" sync /:Titan:5C0:/
+200.0 "--sync--" sync / 14:Titan:5C0:/ window 200,0
+203.0 "Geocrush" sync / 1[56]:Titan:5C0:/
 
-212.6 "Landslide" sync /:Titan:5BB:/
-216.7 "Rock Throw" sync /:Titan:285:/ duration 21.5
-220.8 "Mountain Buster" sync /:Titan:5B8:/
-229.8 "Upheaval" sync /:Titan:5BA:/
-234.8 "Landslide" sync /:Titan:5BB:/
-242.0 "Tumult x4" duration 3.5 # sync /:Titan:5B9:/
-251.0 "Weight Of The Land" sync /:Titan:5BE:/ window 15,15
-254.6 "Mountain Buster" sync /:Titan:5B8:/
-262.0 "Landslide" sync /:Titan:5BB:/
-271.7 "Weight Of The Land" sync /:Titan:5BE:/
-276.8 "Bury (one side)" sync /:Bomb Boulder:41B:/
-278.0 "Mountain Buster" sync /:Titan:5B8:/
-287.4 "Burst" sync /:Bomb Boulder:5BF:/
+212.6 "Landslide" sync / 1[56]:Titan:5BB:/
+216.7 "Rock Throw" sync / 1[56]:Titan:285:/ duration 21.5
+220.8 "Mountain Buster" sync / 1[56]:Titan:5B8:/
+229.8 "Upheaval" sync / 1[56]:Titan:5BA:/
+234.8 "Landslide" sync / 1[56]:Titan:5BB:/
+242.0 "Tumult x4" duration 3.5 # sync / 1[56]:Titan:5B9:/
+251.0 "Weight Of The Land" sync / 1[56]:Titan:5BE:/ window 15,15
+254.6 "Mountain Buster" sync / 1[56]:Titan:5B8:/
+262.0 "Landslide" sync / 1[56]:Titan:5BB:/
+271.7 "Weight Of The Land" sync / 1[56]:Titan:5BE:/
+276.8 "Bury (one side)" sync / 1[56]:Bomb Boulder:41B:/
+278.0 "Mountain Buster" sync / 1[56]:Titan:5B8:/
+287.4 "Burst" sync / 1[56]:Bomb Boulder:5BF:/
 
-288.1 "Landslide" sync /:Titan:5BB:/
-292.2 "Rock Throw" sync /:Titan:285:/ duration 21.5
-296.3 "Mountain Buster" sync /:Titan:5B8:/
-305.4 "Upheaval" sync /:Titan:5BA:/
-310.4 "Landslide" sync /:Titan:5BB:/
-317.5 "Tumult x4" duration 3.5 #sync /:Titan:5B9:/
-326.5 "Weight Of The Land" sync /:Titan:5BE:/ window 15,15
-330.1 "Mountain Buster" sync /:Titan:5B8:/
-337.3 "Landslide" sync /:Titan:5BB:/
-347.0 "Weight Of The Land" sync /:Titan:5BE:/
-351.7 "Bury (clock)" duration 4.2 #sync /:Bomb Boulder:41B:/
-353.6 "Mountain Buster" sync /:Titan:5B8:/
-360.9 "Burst" duration 4.2 #sync /:Bomb Boulder:5BF:/
+288.1 "Landslide" sync / 1[56]:Titan:5BB:/
+292.2 "Rock Throw" sync / 1[56]:Titan:285:/ duration 21.5
+296.3 "Mountain Buster" sync / 1[56]:Titan:5B8:/
+305.4 "Upheaval" sync / 1[56]:Titan:5BA:/
+310.4 "Landslide" sync / 1[56]:Titan:5BB:/
+317.5 "Tumult x4" duration 3.5 #sync / 1[56]:Titan:5B9:/
+326.5 "Weight Of The Land" sync / 1[56]:Titan:5BE:/ window 15,15
+330.1 "Mountain Buster" sync / 1[56]:Titan:5B8:/
+337.3 "Landslide" sync / 1[56]:Titan:5BB:/
+347.0 "Weight Of The Land" sync / 1[56]:Titan:5BE:/
+351.7 "Bury (clock)" duration 4.2 #sync / 1[56]:Bomb Boulder:41B:/
+353.6 "Mountain Buster" sync / 1[56]:Titan:5B8:/
+360.9 "Burst" duration 4.2 #sync / 1[56]:Bomb Boulder:5BF:/
 
-363.9 "Landslide" sync /:Titan:5BB:/ window 20,20 jump 212.6
+363.9 "Landslide" sync / 1[56]:Titan:5BB:/ window 20,20 jump 212.6
 368.0 "Rock Throw"
 372.1 "Mountain Buster"
 381.1 "Upheaval"
@@ -80,71 +80,71 @@ hideall "--sync--"
 
 
 ### Phase 3: Heart Phase (at 55%)
-500.0 "--sync--" sync /:5C0:Titan/ window 299,0
-503.0 "Geocrush" sync /:Titan:5C0:/
-515.6 "Weight Of The Land" sync /:Titan:5BE:/
-521.2 "Rock Throw" sync /:Titan:285:/ duration 21.5
-526.0 "Rock Buster" sync /:Titan:5B7:/
-533.0 "Upheaval" sync /:Titan:5BA:/
-538.0 "Landslide" sync /:Titan:5BB:/
-544.0 "Tumult x4" duration 3.5 #sync /:Titan:5B9:/
-553.1 "Weight Of The Land" sync /:Titan:5BE:/ window 15,15
-561.8 "Rock Buster" sync /:Titan:5B7:/
-563.8 "Bury (clock)" duration 3 # sync /:Bomb Boulder:41B:/
-570.8 "Landslide" sync /:Titan:5BB:/
-572.9 "Burst" duration 3 # sync /:Bomb Boulder:5BF:/
-574.9 "Tumult x4" duration 3.5 #sync /:Titan:5B9:/
-583.0 "Weight Of The Land" sync /:Titan:5BE:/
+500.0 "--sync--" sync / 14:Titan:5C0:/ window 299,0
+503.0 "Geocrush" sync / 1[56]:Titan:5C0:/
+515.6 "Weight Of The Land" sync / 1[56]:Titan:5BE:/
+521.2 "Rock Throw" sync / 1[56]:Titan:285:/ duration 21.5
+526.0 "Rock Buster" sync / 1[56]:Titan:5B7:/
+533.0 "Upheaval" sync / 1[56]:Titan:5BA:/
+538.0 "Landslide" sync / 1[56]:Titan:5BB:/
+544.0 "Tumult x4" duration 3.5 #sync / 1[56]:Titan:5B9:/
+553.1 "Weight Of The Land" sync / 1[56]:Titan:5BE:/ window 15,15
+561.8 "Rock Buster" sync / 1[56]:Titan:5B7:/
+563.8 "Bury (clock)" duration 3 # sync / 1[56]:Bomb Boulder:41B:/
+570.8 "Landslide" sync / 1[56]:Titan:5BB:/
+572.9 "Burst" duration 3 # sync / 1[56]:Bomb Boulder:5BF:/
+574.9 "Tumult x4" duration 3.5 #sync / 1[56]:Titan:5B9:/
+583.0 "Weight Of The Land" sync / 1[56]:Titan:5BE:/
 593.0 "--untargetable--"
 
 
 ### Phase 4
-700.0 "Earthen Fury" sync /:Titan:5C1:/ window 700,0
+700.0 "Earthen Fury" sync / 1[56]:Titan:5C1:/ window 700,0
 713.1 "Gaoler Adds (E/W)"
-715.8 "Gaoler Tumult" #sync /:Granite Gaoler:5C4:/
-716.3 "Mountain Buster" sync /:Titan:5B8:/
+715.8 "Gaoler Tumult" #sync / 1[56]:Granite Gaoler:5C4:/
+716.3 "Mountain Buster" sync / 1[56]:Titan:5B8:/
 
-723.3 "Bury x4" #sync /:Bomb Boulder:41B:/
-725.8 "Bury x4" #sync /:Bomb Boulder:41B:/
-730.2 "Landslide" sync /:Titan:5BB:/
-732.5 "Burst x4" #sync /:Bomb Boulder:5BF:/
-734.9 "Burst x4" #sync /:Bomb Boulder:5BF:/
-735.4 "Mountain Buster" sync /:Titan:5B8:/
-739.8 "Gaoler Landslide?" #sync /:Granite Gaoler:5C3:/
-744.0 "Weight Of The Land" sync /:Titan:5BE:/
+723.3 "Bury x4" #sync / 1[56]:Bomb Boulder:41B:/
+725.8 "Bury x4" #sync / 1[56]:Bomb Boulder:41B:/
+730.2 "Landslide" sync / 1[56]:Titan:5BB:/
+732.5 "Burst x4" #sync / 1[56]:Bomb Boulder:5BF:/
+734.9 "Burst x4" #sync / 1[56]:Bomb Boulder:5BF:/
+735.4 "Mountain Buster" sync / 1[56]:Titan:5B8:/
+739.8 "Gaoler Landslide?" #sync / 1[56]:Granite Gaoler:5C3:/
+744.0 "Weight Of The Land" sync / 1[56]:Titan:5BE:/
 
-749.7 "Rock Throw" sync /:Titan:285:/ duration 21.5
-753.9 "Mountain Buster" sync /:Titan:5B8:/
-762.9 "Upheaval" sync /:Titan:5BA:/
-767.9 "Landslide" sync /:Titan:5BB:/
-779.0 "Mountain Buster" sync /:Titan:5B8:/ window 15,15
-783.2 "Tumult x4" duration 3.5 #sync /:Titan:5B9:/
-792.2 "Weight Of The Land 1" #sync /:Titan:5BE:/
-794.7 "Weight Of The Land 2" #sync /:Titan:5BE:/
-799.9 "Mountain Buster" sync /:Titan:5B8:/
+749.7 "Rock Throw" sync / 1[56]:Titan:285:/ duration 21.5
+753.9 "Mountain Buster" sync / 1[56]:Titan:5B8:/
+762.9 "Upheaval" sync / 1[56]:Titan:5BA:/
+767.9 "Landslide" sync / 1[56]:Titan:5BB:/
+779.0 "Mountain Buster" sync / 1[56]:Titan:5B8:/ window 15,15
+783.2 "Tumult x4" duration 3.5 #sync / 1[56]:Titan:5B9:/
+792.2 "Weight Of The Land 1" #sync / 1[56]:Titan:5BE:/
+794.7 "Weight Of The Land 2" #sync / 1[56]:Titan:5BE:/
+799.9 "Mountain Buster" sync / 1[56]:Titan:5B8:/
 
-804.1 "Bury (row 1)" #sync /:Bomb Boulder:41B:/
-805.0 "Bury (row 2)" #sync /:Bomb Boulder:41B:/
-806.1 "Bury (row 3)" #sync /:Bomb Boulder:41B:/
-811.0 "Landslide" sync /:Titan:5BB:/
-813.1 "Burst 1" #sync /:Bomb Boulder:5BF:/
-814.6 "Burst 2" #sync /:Bomb Boulder:5BF:/
-816.1 "Burst 3" #sync /:Bomb Boulder:5BF:/
-819.2 "Mountain Buster" sync /:Titan:5B8:/
+804.1 "Bury (row 1)" #sync / 1[56]:Bomb Boulder:41B:/
+805.0 "Bury (row 2)" #sync / 1[56]:Bomb Boulder:41B:/
+806.1 "Bury (row 3)" #sync / 1[56]:Bomb Boulder:41B:/
+811.0 "Landslide" sync / 1[56]:Titan:5BB:/
+813.1 "Burst 1" #sync / 1[56]:Bomb Boulder:5BF:/
+814.6 "Burst 2" #sync / 1[56]:Bomb Boulder:5BF:/
+816.1 "Burst 3" #sync / 1[56]:Bomb Boulder:5BF:/
+819.2 "Mountain Buster" sync / 1[56]:Titan:5B8:/
 
-832.7 "Bury (all)" sync /:Bomb Boulder:41B:/
-837.0 "Tumult x4" duration 3.5 #sync /:Titan:5B9:/
-845.9 "Weight Of The Land" sync /:Titan:5BE:/
+832.7 "Bury (all)" sync / 1[56]:Bomb Boulder:41B:/
+837.0 "Tumult x4" duration 3.5 #sync / 1[56]:Titan:5B9:/
+845.9 "Weight Of The Land" sync / 1[56]:Titan:5BE:/
 852.5 "--untargetable--"
-855.1 "Burst" sync /:Bomb Boulder:5BF:/
-856.7 "Geocrush" sync /:Titan:5C0:/
+855.1 "Burst" sync / 1[56]:Bomb Boulder:5BF:/
+856.7 "Geocrush" sync / 1[56]:Titan:5C0:/
 857.1 "--targetable--"
-862.4 "Landslide" sync /:Titan:5BB:/
+862.4 "Landslide" sync / 1[56]:Titan:5BB:/
 
 # loop
 874.0 "Gaoler Adds (E/W)"
-876.7 "Gaoler Tumult" #sync /:Granite Gaoler:5C4:/
-877.2 "Mountain Buster" sync /:Titan:5B8:/ window 40,40 jump 716.3
+876.7 "Gaoler Tumult" #sync / 1[56]:Granite Gaoler:5C4:/
+877.2 "Mountain Buster" sync / 1[56]:Titan:5B8:/ window 40,40 jump 716.3
 
 884.2 "Bury x4"
 886.7 "Bury x4"
@@ -157,8 +157,8 @@ hideall "--sync--"
 
 
 ### Enrage
-1000.0 "--sync--" sync /:5C2:Titan/ window 1000,1000
-1010.0 "Upheaval Enrage" #sync /:Titan:5C2:/
-1022.0 "Upheaval Enrage" #sync /:Titan:5C2:/
-1034.0 "Upheaval Enrage" #sync /:Titan:5C2:/
-1046.0 "Upheaval Enrage" #sync /:Titan:5C2:/
+1000.0 "--sync--" sync / 14:Titan:5C2:/ window 1000,1000
+1010.0 "Upheaval Enrage" #sync / 1[56]:Titan:5C2:/
+1022.0 "Upheaval Enrage" #sync / 1[56]:Titan:5C2:/
+1034.0 "Upheaval Enrage" #sync / 1[56]:Titan:5C2:/
+1046.0 "Upheaval Enrage" #sync / 1[56]:Titan:5C2:/

--- a/ui/raidboss/data/02-arr/trial/titan-ex.txt
+++ b/ui/raidboss/data/02-arr/trial/titan-ex.txt
@@ -8,7 +8,7 @@
 hideall "--Reset--"
 hideall "--sync--"
 
-0 "--Reset--" sync / 21:........:40000010:/ window 100000 jump 0
+0.0 "--reset--" sync / 21:........:40000010:/ window 100000 jump 0
 
 ### Phase 1: 100->85%
 0.0 "Start"

--- a/ui/raidboss/data/02-arr/trial/titan-ex.txt
+++ b/ui/raidboss/data/02-arr/trial/titan-ex.txt
@@ -8,7 +8,7 @@
 hideall "--Reset--"
 hideall "--sync--"
 
-0.0 "--reset--" sync / 21:........:40000010:/ window 100000 jump 0
+0.0 "--Reset--" sync / 21:........:40000010:/ window 100000 jump 0
 
 ### Phase 1: 100->85%
 0.0 "Start"

--- a/ui/raidboss/data/02-arr/trial/titan-hm.txt
+++ b/ui/raidboss/data/02-arr/trial/titan-hm.txt
@@ -11,185 +11,185 @@
 hideall "--Reset--"
 hideall "--sync--"
 
-0.0 "--Reset--" sync / 21:........:40000010:/ window 10000 jump 0
+0 "--Reset--" sync / 21:........:40000010:/ window 100000 jump 0
 
 ### Phase 1: 100->90%
 0.0 "Start"
 0.0 "--sync--" sync /:Engage!/ window 0,1
-2.0 "--sync--" sync /:Titan:368:/ window 2,0
+2.0 "--sync--" sync / 1[56]:Titan:368:/ window 2,0
 
-5.0 "Rock Buster" sync /:Titan:550:/ window 5,50
-11.2 "Landslide" sync /:Titan:554:/
-17.4 "Tumult x2" duration 1.2 #sync /:Titan:551:/
+5.0 "Rock Buster" sync / 1[56]:Titan:550:/ window 5,50
+11.2 "Landslide" sync / 1[56]:Titan:554:/
+17.4 "Tumult x2" duration 1.2 #sync / 1[56]:Titan:551:/
 
-23.7 "Rock Buster" #sync /:Titan:550:/
-29.9 "Landslide" #sync /:Titan:554:/
-36.1 "Tumult x2" duration 1.2 #sync /:Titan:551:/
+23.7 "Rock Buster" #sync / 1[56]:Titan:550:/
+29.9 "Landslide" #sync / 1[56]:Titan:554:/
+36.1 "Tumult x2" duration 1.2 #sync / 1[56]:Titan:551:/
 
-42.4 "Rock Buster" #sync /:Titan:550:/
-48.6 "Landslide" #sync /:Titan:554:/
-54.8 "Tumult x2" duration 1.2 #sync /:Titan:551:/
+42.4 "Rock Buster" #sync / 1[56]:Titan:550:/
+48.6 "Landslide" #sync / 1[56]:Titan:554:/
+54.8 "Tumult x2" duration 1.2 #sync / 1[56]:Titan:551:/
 
 
 # Phase 2: 90%->80%
-200.0 "--sync--" sync /:555:Titan/ window 200,0
-203.0 "Geocrush" sync /:Titan:555:/
+200.0 "--sync--" sync / 14:Titan:555:/ window 200,0
+203.0 "Geocrush" sync / 1[56]:Titan:555:/
 
-211.4 "Weight Of The Land" sync /:Titan:552:/
-217.6 "Rock Buster" sync /:Titan:550:/
-221.8 "Landslide" sync /:Titan:554:/
-229.9 "Tumult x3" duration 2.4 #sync /:Titan:551:/
+211.4 "Weight Of The Land" sync / 1[56]:Titan:552:/
+217.6 "Rock Buster" sync / 1[56]:Titan:550:/
+221.8 "Landslide" sync / 1[56]:Titan:554:/
+229.9 "Tumult x3" duration 2.4 #sync / 1[56]:Titan:551:/
 
-239.4 "Weight Of The Land" sync /:Titan:552:/ window 40,40 jump 211.4
-245.6 "Rock Buster" #sync /:Titan:550:/
-249.8 "Landslide" #sync /:Titan:554:/
-257.9 "Tumult x3" duration 2.4 #sync /:Titan:551:/
+239.4 "Weight Of The Land" sync / 1[56]:Titan:552:/ window 40,40 jump 211.4
+245.6 "Rock Buster" #sync / 1[56]:Titan:550:/
+249.8 "Landslide" #sync / 1[56]:Titan:554:/
+257.9 "Tumult x3" duration 2.4 #sync / 1[56]:Titan:551:/
 
-267.4 "Weight Of The Land" #sync /:Titan:552:/
-273.6 "Rock Buster" #sync /:Titan:550:/
-277.8 "Landslide" #sync /:Titan:554:/
-285.9 "Tumult x3" duration 2.4 #sync /:Titan:551:/
+267.4 "Weight Of The Land" #sync / 1[56]:Titan:552:/
+273.6 "Rock Buster" #sync / 1[56]:Titan:550:/
+277.8 "Landslide" #sync / 1[56]:Titan:554:/
+285.9 "Tumult x3" duration 2.4 #sync / 1[56]:Titan:551:/
 
 
 # Phase 3: 80%->60%
-400.0 "--sync--" sync /:555:Titan/ window 199,0
-403.0 "Geocrush" sync /:Titan:555:/
-411.9 "Landslide" sync /:Titan:554:/
-420.0 "Weight Of The Land" sync /:Titan:552:/
+400.0 "--sync--" sync / 14:Titan:555:/ window 199,0
+403.0 "Geocrush" sync / 1[56]:Titan:555:/
+411.9 "Landslide" sync / 1[56]:Titan:554:/
+420.0 "Weight Of The Land" sync / 1[56]:Titan:552:/
 
-425.1 "Bury (clock)" duration 4 #sync /:Bomb Boulder:41B:/
-429.9 "Rock Buster" sync /:Titan:550:/
-434.3 "Burst" duration 4 #sync /:Bomb Boulder:41C:/
+425.1 "Bury (clock)" duration 4 #sync / 1[56]:Bomb Boulder:41B:/
+429.9 "Rock Buster" sync / 1[56]:Titan:550:/
+434.3 "Burst" duration 4 #sync / 1[56]:Bomb Boulder:41C:/
 
-439.5 "Landslide" sync /:Titan:554:/
-445.6 "Weight Of The Land" sync /:Titan:552:/
-449.7 "Rock Throw" sync /:Titan:285:/
-456.8 "Rock Buster" sync /:Titan:550:/
-459.8 "Tumult x3" duration 2.4 #sync /:Titan:551:/
-469.5 "Landslide" sync /:Titan:554:/
-477.6 "Weight Of The Land" sync /:Titan:552:/
+439.5 "Landslide" sync / 1[56]:Titan:554:/
+445.6 "Weight Of The Land" sync / 1[56]:Titan:552:/
+449.7 "Rock Throw" sync / 1[56]:Titan:285:/
+456.8 "Rock Buster" sync / 1[56]:Titan:550:/
+459.8 "Tumult x3" duration 2.4 #sync / 1[56]:Titan:551:/
+469.5 "Landslide" sync / 1[56]:Titan:554:/
+477.6 "Weight Of The Land" sync / 1[56]:Titan:552:/
 
-482.7 "Bury (diamond)" duration 2 #sync /:Bomb Boulder:41B:/
-487.5 "Rock Buster" sync /:Titan:550:/
-491.9 "Burst" duration 3 #sync /:Bomb Boulder:41C:/
+482.7 "Bury (diamond)" duration 2 #sync / 1[56]:Bomb Boulder:41B:/
+487.5 "Rock Buster" sync / 1[56]:Titan:550:/
+491.9 "Burst" duration 3 #sync / 1[56]:Bomb Boulder:41C:/
 
-497.2 "Landslide" sync /:Titan:554:/
-503.3 "Weight Of The Land" sync /:Titan:552:/
-507.6 "Rock Throw" sync /:Titan:285:/
-514.8 "Rock Buster" sync /:Titan:550:/
-517.8 "Tumult x3" duration 2.4 #sync /:Titan:551:/
-528.1 "Landslide" sync /:Titan:554:/
-536.2 "Weight Of The Land" sync /:Titan:552:/ window 30,30 jump 420.0
+497.2 "Landslide" sync / 1[56]:Titan:554:/
+503.3 "Weight Of The Land" sync / 1[56]:Titan:552:/
+507.6 "Rock Throw" sync / 1[56]:Titan:285:/
+514.8 "Rock Buster" sync / 1[56]:Titan:550:/
+517.8 "Tumult x3" duration 2.4 #sync / 1[56]:Titan:551:/
+528.1 "Landslide" sync / 1[56]:Titan:554:/
+536.2 "Weight Of The Land" sync / 1[56]:Titan:552:/ window 30,30 jump 420.0
 
-541.3 "Bury (clock)" duration 4 #sync /:Bomb Boulder:41B:/
-546.1 "Rock Buster" #sync /:Titan:550:/
-550.5 "Burst" duration 4 #sync /:Bomb Boulder:41C:/
+541.3 "Bury (clock)" duration 4 #sync / 1[56]:Bomb Boulder:41B:/
+546.1 "Rock Buster" #sync / 1[56]:Titan:550:/
+550.5 "Burst" duration 4 #sync / 1[56]:Bomb Boulder:41C:/
 
-555.7 "Landslide" #sync /:Titan:554:/
-561.8 "Weight Of The Land" #sync /:Titan:552:/
-565.9 "Rock Throw" #sync /:Titan:285:/
-573.0 "Rock Buster" #sync /:Titan:550:/
-576.0 "Tumult x3" duration 2.4 #sync /:Titan:551:/
-585.7 "Landslide" #sync /:Titan:554:/
-593.8 "Weight Of The Land" #sync /:Titan:552:/
+555.7 "Landslide" #sync / 1[56]:Titan:554:/
+561.8 "Weight Of The Land" #sync / 1[56]:Titan:552:/
+565.9 "Rock Throw" #sync / 1[56]:Titan:285:/
+573.0 "Rock Buster" #sync / 1[56]:Titan:550:/
+576.0 "Tumult x3" duration 2.4 #sync / 1[56]:Titan:551:/
+585.7 "Landslide" #sync / 1[56]:Titan:554:/
+593.8 "Weight Of The Land" #sync / 1[56]:Titan:552:/
 
 
 # Phase 4: Heart
-800.0 "--sync--" sync /:555:Titan/ window 399,0
-803.0 "Geocrush" sync /:Titan:555:/
+800.0 "--sync--" sync / 14:Titan:555:/ window 399,0
+803.0 "Geocrush" sync / 1[56]:Titan:555:/
 805.3 "--targetable--"
 
-812.3 "Rock Throw" sync /:Titan:285:/
-816.4 "Rock Buster" sync /:Titan:550:/
-820.6 "Landslide" sync /:Titan:554:/
-828.7 "Weight Of The Land" sync /:Titan:552:/
+812.3 "Rock Throw" sync / 1[56]:Titan:285:/
+816.4 "Rock Buster" sync / 1[56]:Titan:550:/
+820.6 "Landslide" sync / 1[56]:Titan:554:/
+828.7 "Weight Of The Land" sync / 1[56]:Titan:552:/
 
-834.8 "Tumult x3" duration 2.4 #sync /:Titan:551:/
+834.8 "Tumult x3" duration 2.4 #sync / 1[56]:Titan:551:/
 
-842.5 "Rock Throw" sync /:Titan:285:/
-846.6 "Rock Buster" sync /:Titan:550:/
-850.8 "Landslide" sync /:Titan:554:/
-858.9 "Weight Of The Land" sync /:Titan:552:/
+842.5 "Rock Throw" sync / 1[56]:Titan:285:/
+846.6 "Rock Buster" sync / 1[56]:Titan:550:/
+850.8 "Landslide" sync / 1[56]:Titan:554:/
+858.9 "Weight Of The Land" sync / 1[56]:Titan:552:/
 
 868.2 "--untargetable--"
 
 
 # Phase 5: 60%->0%
-873.7 "Earthen Fury" sync /:Titan:556:/ window 1000,30
+873.7 "Earthen Fury" sync / 1[56]:Titan:556:/ window 1000,30
 878.4 "--targetable--"
-882.5 "Mountain Buster" sync /:Titan:283:/
-886.6 "Tumult x4" duration 3.6 sync /:Titan:551:/
-895.3 "Weight Of The Land" sync /:Titan:552:/
+882.5 "Mountain Buster" sync / 1[56]:Titan:283:/
+886.6 "Tumult x4" duration 3.6 sync / 1[56]:Titan:551:/
+895.3 "Weight Of The Land" sync / 1[56]:Titan:552:/
 
-900.4 "Bury (line)" duration 2 #sync /:Bomb Boulder:41B:/
-908.4 "Landslide" sync /:Titan:554:/
-909.4 "Burst" duration 3 #sync /:Bomb Boulder:41C:/
+900.4 "Bury (line)" duration 2 #sync / 1[56]:Bomb Boulder:41B:/
+908.4 "Landslide" sync / 1[56]:Titan:554:/
+909.4 "Burst" duration 3 #sync / 1[56]:Bomb Boulder:41C:/
 
-912.6 "Rock Buster" sync /:Titan:550:/
-916.6 "Mountain Buster" sync /:Titan:283:/
-922.7 "Weight Of The Land" sync /:Titan:552:/
-927.2 "Rock Throw" sync /:Titan:285:/
-937.5 "Landslide" sync /:Titan:554:/
-941.6 "Rock Buster" sync /:Titan:550:/
-945.6 "Mountain Buster" sync /:Titan:283:/
-949.7 "Tumult x4" duration 3.6 #sync /:Titan:551:/
-958.4 "Weight Of The Land" sync /:Titan:552:/
+912.6 "Rock Buster" sync / 1[56]:Titan:550:/
+916.6 "Mountain Buster" sync / 1[56]:Titan:283:/
+922.7 "Weight Of The Land" sync / 1[56]:Titan:552:/
+927.2 "Rock Throw" sync / 1[56]:Titan:285:/
+937.5 "Landslide" sync / 1[56]:Titan:554:/
+941.6 "Rock Buster" sync / 1[56]:Titan:550:/
+945.6 "Mountain Buster" sync / 1[56]:Titan:283:/
+949.7 "Tumult x4" duration 3.6 #sync / 1[56]:Titan:551:/
+958.4 "Weight Of The Land" sync / 1[56]:Titan:552:/
 
-963.5 "Bury (clock)" duration 4 #sync /:Bomb Boulder:41B:/
-972.0 "Landslide" sync /:Titan:554:/
-972.7 "Burst" duration 4 #sync /:Bomb Boulder:41C:/
+963.5 "Bury (clock)" duration 4 #sync / 1[56]:Bomb Boulder:41B:/
+972.0 "Landslide" sync / 1[56]:Titan:554:/
+972.7 "Burst" duration 4 #sync / 1[56]:Bomb Boulder:41C:/
 
-976.2 "Rock Buster" sync /:Titan:550:/
-980.2 "Mountain Buster" sync /:Titan:283:/
-986.3 "Weight Of The Land" sync /:Titan:552:/
-990.9 "Rock Throw" sync /:Titan:285:/
-1001.1 "Landslide" sync /:Titan:554:/
-1005.2 "Rock Buster" sync /:Titan:550:/
-1009.2 "Mountain Buster" sync /:Titan:283:/
-1013.3 "Tumult x4" duration 3.6 #sync /:Titan:551:/
-1022.0 "Weight Of The Land" sync /:Titan:552:/
+976.2 "Rock Buster" sync / 1[56]:Titan:550:/
+980.2 "Mountain Buster" sync / 1[56]:Titan:283:/
+986.3 "Weight Of The Land" sync / 1[56]:Titan:552:/
+990.9 "Rock Throw" sync / 1[56]:Titan:285:/
+1001.1 "Landslide" sync / 1[56]:Titan:554:/
+1005.2 "Rock Buster" sync / 1[56]:Titan:550:/
+1009.2 "Mountain Buster" sync / 1[56]:Titan:283:/
+1013.3 "Tumult x4" duration 3.6 #sync / 1[56]:Titan:551:/
+1022.0 "Weight Of The Land" sync / 1[56]:Titan:552:/
 
-1027.1 "Bury (line)" duration 2 #sync /:Bomb Boulder:41B:/
-1035.4 "Landslide" sync /:Titan:554:/
-1036.2 "Burst" duration 3 #sync /:Bomb Boulder:41C:/
+1027.1 "Bury (line)" duration 2 #sync / 1[56]:Bomb Boulder:41B:/
+1035.4 "Landslide" sync / 1[56]:Titan:554:/
+1036.2 "Burst" duration 3 #sync / 1[56]:Bomb Boulder:41C:/
 
-1039.6 "Rock Buster" sync /:Titan:550:/
-1043.6 "Mountain Buster" sync /:Titan:283:/
-1049.7 "Weight Of The Land" sync /:Titan:552:/
-1054.5 "Rock Throw" sync /:Titan:285:/
-1064.8 "Landslide" sync /:Titan:554:/
-1068.9 "Rock Buster" sync /:Titan:550:/
-1072.9 "Mountain Buster" sync /:Titan:283:/
-1077.0 "Tumult x4" duration 3.6 #sync /:Titan:551:/
-1085.7 "Weight Of The Land" sync /:Titan:552:/
+1039.6 "Rock Buster" sync / 1[56]:Titan:550:/
+1043.6 "Mountain Buster" sync / 1[56]:Titan:283:/
+1049.7 "Weight Of The Land" sync / 1[56]:Titan:552:/
+1054.5 "Rock Throw" sync / 1[56]:Titan:285:/
+1064.8 "Landslide" sync / 1[56]:Titan:554:/
+1068.9 "Rock Buster" sync / 1[56]:Titan:550:/
+1072.9 "Mountain Buster" sync / 1[56]:Titan:283:/
+1077.0 "Tumult x4" duration 3.6 #sync / 1[56]:Titan:551:/
+1085.7 "Weight Of The Land" sync / 1[56]:Titan:552:/
 
-1090.8 "Bury (diamond)" duration 2 #sync /:Bomb Boulder:41B:/
-1099.3 "Landslide" sync /:Titan:554:/
-1100.0 "Burst" duration 3 #sync /:Bomb Boulder:41C:/
+1090.8 "Bury (diamond)" duration 2 #sync / 1[56]:Bomb Boulder:41B:/
+1099.3 "Landslide" sync / 1[56]:Titan:554:/
+1100.0 "Burst" duration 3 #sync / 1[56]:Bomb Boulder:41C:/
 
-1103.5 "Rock Buster" sync /:Titan:550:/
-1107.5 "Mountain Buster" sync /:Titan:283:/
-1113.6 "Weight Of The Land" sync /:Titan:552:/
-1118.2 "Rock Throw" sync /:Titan:285:/
-1128.5 "Landslide" sync /:Titan:554:/
-1132.6 "Rock Buster" sync /:Titan:550:/
-1136.6 "Mountain Buster" sync /:Titan:283:/
+1103.5 "Rock Buster" sync / 1[56]:Titan:550:/
+1107.5 "Mountain Buster" sync / 1[56]:Titan:283:/
+1113.6 "Weight Of The Land" sync / 1[56]:Titan:552:/
+1118.2 "Rock Throw" sync / 1[56]:Titan:285:/
+1128.5 "Landslide" sync / 1[56]:Titan:554:/
+1132.6 "Rock Buster" sync / 1[56]:Titan:550:/
+1136.6 "Mountain Buster" sync / 1[56]:Titan:283:/
 
-1140.7 "Tumult x5" duration 4.8 #sync /:Titan:551:/
+1140.7 "Tumult x5" duration 4.8 #sync / 1[56]:Titan:551:/
 
-1150.6 "Weight Of The Land" sync /:Titan:552:/ window 20,20 jump 895.3
+1150.6 "Weight Of The Land" sync / 1[56]:Titan:552:/ window 20,20 jump 895.3
 
-1155.7 "Bury (line)" #duration 2 #sync /:Bomb Boulder:41B:/
-1163.7 "Landslide" #sync /:Titan:554:/
-1164.7 "Burst" duration 3 #sync /:Bomb Boulder:41C:/
+1155.7 "Bury (line)" #duration 2 #sync / 1[56]:Bomb Boulder:41B:/
+1163.7 "Landslide" #sync / 1[56]:Titan:554:/
+1164.7 "Burst" duration 3 #sync / 1[56]:Bomb Boulder:41C:/
 
-1167.9 "Rock Buster" #sync /:Titan:550:/
-1171.9 "Mountain Buster" #sync /:Titan:283:/
-1178.0 "Weight Of The Land" #sync /:Titan:552:/
-1182.5 "Rock Throw" #sync /:Titan:285:/
-1192.8 "Landslide" #sync /:Titan:554:/
-1196.9 "Rock Buster" #sync /:Titan:550:/
-1200.9 "Mountain Buster" #sync /:Titan:283:/
-1205.0 "Tumult x4" duration 3.6 #sync /:Titan:551:/
-1213.7 "Weight Of The Land" #sync /:Titan:552:/
+1167.9 "Rock Buster" #sync / 1[56]:Titan:550:/
+1171.9 "Mountain Buster" #sync / 1[56]:Titan:283:/
+1178.0 "Weight Of The Land" #sync / 1[56]:Titan:552:/
+1182.5 "Rock Throw" #sync / 1[56]:Titan:285:/
+1192.8 "Landslide" #sync / 1[56]:Titan:554:/
+1196.9 "Rock Buster" #sync / 1[56]:Titan:550:/
+1200.9 "Mountain Buster" #sync / 1[56]:Titan:283:/
+1205.0 "Tumult x4" duration 3.6 #sync / 1[56]:Titan:551:/
+1213.7 "Weight Of The Land" #sync / 1[56]:Titan:552:/
 

--- a/ui/raidboss/data/02-arr/trial/titan-hm.txt
+++ b/ui/raidboss/data/02-arr/trial/titan-hm.txt
@@ -11,7 +11,7 @@
 hideall "--Reset--"
 hideall "--sync--"
 
-0.0 "--reset--" sync / 21:........:40000010:/ window 100000 jump 0
+0.0 "--Reset--" sync / 21:........:40000010:/ window 100000 jump 0
 
 ### Phase 1: 100->90%
 0.0 "Start"

--- a/ui/raidboss/data/02-arr/trial/titan-hm.txt
+++ b/ui/raidboss/data/02-arr/trial/titan-hm.txt
@@ -11,7 +11,7 @@
 hideall "--Reset--"
 hideall "--sync--"
 
-0 "--Reset--" sync / 21:........:40000010:/ window 100000 jump 0
+0.0 "--reset--" sync / 21:........:40000010:/ window 100000 jump 0
 
 ### Phase 1: 100->90%
 0.0 "Start"

--- a/ui/raidboss/data/02-arr/trial/titan-nm.txt
+++ b/ui/raidboss/data/02-arr/trial/titan-nm.txt
@@ -4,23 +4,23 @@
 hideall "--Reset--"
 hideall "--sync--"
 
-0.0 "--Reset--" sync / 21:........:40000010:/ window 10000 jump 0
+0 "--Reset--" sync / 21:........:40000010:/ window 100000 jump 0
 
 ### Phase 1 100 -> 85%
 0.0 "Start"
-0.0 "--sync--" sync /Engage!/ window 0,1
-2.0 "--sync--" sync /:Titan:368:/ window 2,0
-5.0 "Rock Buster" sync /:Titan:281:/ window 5,5
-7.0 "Tumult" sync /:Titan:282:/
-16.1 "Tumult" sync /:Titan:282:/
-19.2 "Rock Buster" sync /:Titan:281:/
-25.2 "Tumult" sync /:Titan:282:/ window 8,8
+0.0 "--sync--" sync /:Engage!/ window 0,1
+2.0 "--sync--" sync / 1[56]:Titan:368:/ window 2,0
+5.0 "Rock Buster" sync / 1[56]:Titan:281:/ window 5,5
+7.0 "Tumult" sync / 1[56]:Titan:282:/
+16.1 "Tumult" sync / 1[56]:Titan:282:/
+19.2 "Rock Buster" sync / 1[56]:Titan:281:/
+25.2 "Tumult" sync / 1[56]:Titan:282:/ window 8,8
 
-32.3 "Rock Buster" sync /:Titan:281:/
-34.3 "Tumult" sync /:Titan:282:/
-43.4 "Tumult" sync /:Titan:282:/
-46.5 "Rock Buster" sync /:Titan:281:/
-52.5 "Tumult" sync /:Titan:282:/ window 8,8 jump 25.2
+32.3 "Rock Buster" sync / 1[56]:Titan:281:/
+34.3 "Tumult" sync / 1[56]:Titan:282:/
+43.4 "Tumult" sync / 1[56]:Titan:282:/
+46.5 "Rock Buster" sync / 1[56]:Titan:281:/
+52.5 "Tumult" sync / 1[56]:Titan:282:/ window 8,8 jump 25.2
 
 59.6 "Rock Buster"
 61.6 "Tumult"
@@ -29,70 +29,70 @@ hideall "--sync--"
 79.8 "Tumult"
 
 ### Phase 2 85 -> 55%
-200.0 "--sync--" sync /:28B:Titan/ window 200,0
-203.0 "Geocrush" sync /:Titan:28B:/
+200.0 "--sync--" sync / 14:Titan:28B:/ window 200,0
+203.0 "Geocrush" sync / 1[56]:Titan:28B:/
 
-211.6 "Landslide" sync /:Titan:28A:/ window 211,17
-217.8 "Rock Buster" sync /:Titan:281:/
-221.8 "Tumult" sync /:Titan:282:/
-229.1 "Landslide" sync /:Titan:28A:/
-235.3 "Rock Buster" sync /:Titan:281:/
-239.3 "Tumult" sync /:Titan:282:/ window 17,16
+211.6 "Landslide" sync / 1[56]:Titan:28A:/ window 211,17
+217.8 "Rock Buster" sync / 1[56]:Titan:281:/
+221.8 "Tumult" sync / 1[56]:Titan:282:/
+229.1 "Landslide" sync / 1[56]:Titan:28A:/
+235.3 "Rock Buster" sync / 1[56]:Titan:281:/
+239.3 "Tumult" sync / 1[56]:Titan:282:/ window 17,16
 
-246.6 "Landslide" sync /:Titan:28A:/
-252.8 "Rock Buster" sync /:Titan:281:/
-256.8 "Tumult" sync /:Titan:282:/ window 15,17
-264.1 "Landslide" sync /:Titan:28A:/
-270.2 "Rock Buster" sync /:Titan:281:/
-274.2 "Tumult" sync /:Titan:282:/ window 17,16 jump 239.3
+246.6 "Landslide" sync / 1[56]:Titan:28A:/
+252.8 "Rock Buster" sync / 1[56]:Titan:281:/
+256.8 "Tumult" sync / 1[56]:Titan:282:/ window 15,17
+264.1 "Landslide" sync / 1[56]:Titan:28A:/
+270.2 "Rock Buster" sync / 1[56]:Titan:281:/
+274.2 "Tumult" sync / 1[56]:Titan:282:/ window 17,16 jump 239.3
 
 ### including syncs until a decision is made to keep or remove them. Potential FIX ME!
-281.6 "Landslide" sync /:Titan:28A:/
-287.8 "Rock Buster" sync /:Titan:281:/
-291.8 "Tumult" sync /:Titan:282:/ window 15,17
-299.1 "Landslide" sync /:Titan:28A:/
-305.2 "Rock Buster" sync /:Titan:281:/
-309.2 "Tumult" sync /:Titan:282:/
+281.6 "Landslide" sync / 1[56]:Titan:28A:/
+287.8 "Rock Buster" sync / 1[56]:Titan:281:/
+291.8 "Tumult" sync / 1[56]:Titan:282:/ window 15,17
+299.1 "Landslide" sync / 1[56]:Titan:28A:/
+305.2 "Rock Buster" sync / 1[56]:Titan:281:/
+309.2 "Tumult" sync / 1[56]:Titan:282:/
 
 ### Phase 3 Heart Phase (55%)
-400.0 "--sync--" sync /:28B:Titan/ window 196,0
-403.0 "Geocrush" sync /:Titan:28B:/
-413.6 "Rock Throw" sync /:Titan:285:/
-421.5 "Landslide" sync /:Titan:28A:/
-427.6 "Rock Buster" sync /:Titan:281:/ window 20,15
-431.6 "Tumult" sync /:Titan:282:/
-435.1 "Rock Throw" sync /:Titan:285:/
-442.9 "Landslide" sync /:Titan:28A:/
-449.1 "Rock Buster" sync /:Titan:281:/
-453.1 "Tumult" sync /:Titan:282:/ window 16,25
-464.6 "Landslide" sync /:Titan:28A:/
+400.0 "--sync--" sync / 14:Titan:28B:/ window 196,0
+403.0 "Geocrush" sync / 1[56]:Titan:28B:/
+413.6 "Rock Throw" sync / 1[56]:Titan:285:/
+421.5 "Landslide" sync / 1[56]:Titan:28A:/
+427.6 "Rock Buster" sync / 1[56]:Titan:281:/ window 20,15
+431.6 "Tumult" sync / 1[56]:Titan:282:/
+435.1 "Rock Throw" sync / 1[56]:Titan:285:/
+442.9 "Landslide" sync / 1[56]:Titan:28A:/
+449.1 "Rock Buster" sync / 1[56]:Titan:281:/
+453.1 "Tumult" sync / 1[56]:Titan:282:/ window 16,25
+464.6 "Landslide" sync / 1[56]:Titan:28A:/
 473.6 "Enrage"
 
 ### Phase 4 55 -> 0%
-600.0 "--sync--" sync /:28C:Earthen Fury/ window 600,0 
-601.1 "Earthen Fury" sync /:Titan:28C:/
+600.0 "--sync--" sync / 14:Earthen Fury:28C:/ window 600,0 
+601.1 "Earthen Fury" sync / 1[56]:Titan:28C:/
 
-614.1 "Landslide" sync /:Titan:28A:/
-620.2 "Rock Buster" sync /:Titan:281:/
-624.2 "Weight Of The Land" sync /:Titan:284:/ window 626,23
-630.3 "Tumult x2" duration 2.5 #sync /:Titan:282:/
-636.5 "Rock Throw" sync /:Titan:285:/
-643.6 "Landslide" sync /:Titan:28A:/
-649.7 "Rock Buster" sync /:Titan:281:/
-653.7 "Weight Of The Land" sync /:Titan:284:/ window 23,26
-659.8 "Tumult x2" duration 2.5 #sync /:Titan:282:/
-667.0 "Rock Throw" sync /:Titan:285:/
+614.1 "Landslide" sync / 1[56]:Titan:28A:/
+620.2 "Rock Buster" sync / 1[56]:Titan:281:/
+624.2 "Weight Of The Land" sync / 1[56]:Titan:284:/ window 626,23
+630.3 "Tumult x2" duration 2.5 #sync / 1[56]:Titan:282:/
+636.5 "Rock Throw" sync / 1[56]:Titan:285:/
+643.6 "Landslide" sync / 1[56]:Titan:28A:/
+649.7 "Rock Buster" sync / 1[56]:Titan:281:/
+653.7 "Weight Of The Land" sync / 1[56]:Titan:284:/ window 23,26
+659.8 "Tumult x2" duration 2.5 #sync / 1[56]:Titan:282:/
+667.0 "Rock Throw" sync / 1[56]:Titan:285:/
 
-674.1 "Landslide" sync /:Titan:28A:/
-680.2 "Rock Buster" sync /:Titan:281:/
-684.2 "Weight Of The Land" sync /:Titan:284:/ window 26,24
-690.3 "Tumult x2" duration 2.5 #sync /:Titan:282:/
-696.5 "Rock Throw" sync /:Titan:285:/
+674.1 "Landslide" sync / 1[56]:Titan:28A:/
+680.2 "Rock Buster" sync / 1[56]:Titan:281:/
+684.2 "Weight Of The Land" sync / 1[56]:Titan:284:/ window 26,24
+690.3 "Tumult x2" duration 2.5 #sync / 1[56]:Titan:282:/
+696.5 "Rock Throw" sync / 1[56]:Titan:285:/
 703.6 "Landslide" sync /Titan:285:/
-709.7 "Rock Buster" sync /:Titan:281:/
-713.7 "Weight Of The Land" sync /:Titan:284:/
-719.8 "Tumult x2" duration 2.5 #sync /:Titan:282:/ window 28,23
-727.0 "Rock Throw" sync /:Titan:285:/ window 29,28 jump 667.0
+709.7 "Rock Buster" sync / 1[56]:Titan:281:/
+713.7 "Weight Of The Land" sync / 1[56]:Titan:284:/
+719.8 "Tumult x2" duration 2.5 #sync / 1[56]:Titan:282:/ window 28,23
+727.0 "Rock Throw" sync / 1[56]:Titan:285:/ window 29,28 jump 667.0
  
 734.1 "Landslide"
 740.2 "Rock Buster"

--- a/ui/raidboss/data/02-arr/trial/titan-nm.txt
+++ b/ui/raidboss/data/02-arr/trial/titan-nm.txt
@@ -4,7 +4,7 @@
 hideall "--Reset--"
 hideall "--sync--"
 
-0.0 "--reset--" sync / 21:........:40000010:/ window 100000 jump 0
+0.0 "--Reset--" sync / 21:........:40000010:/ window 100000 jump 0
 
 ### Phase 1 100 -> 85%
 0.0 "Start"

--- a/ui/raidboss/data/02-arr/trial/titan-nm.txt
+++ b/ui/raidboss/data/02-arr/trial/titan-nm.txt
@@ -4,7 +4,7 @@
 hideall "--Reset--"
 hideall "--sync--"
 
-0 "--Reset--" sync / 21:........:40000010:/ window 100000 jump 0
+0.0 "--reset--" sync / 21:........:40000010:/ window 100000 jump 0
 
 ### Phase 1 100 -> 85%
 0.0 "Start"


### PR DESCRIPTION
Overall I'm fairly happy with this. I'll need to update the script to strip the trailing dot from `addedCombatant` lines, but apart from that it looks relatively clean on a 15-second inspection.

The following errors were encountered and will be fixed manually: 

```
t7: [
    '300.0 "--sync--" sync /:Melusine HP at 79%/ window 300,0',
    '800.0 "--sync--" sync /:Melusine HP at 59%/ window 800,0'
  ],
  t9: [
    '503.3 "Golem Meteors" sync /1B:........:[^:]*:....:....:0007:/ duration 11
window 505,0',
    '582.3 "Meteor 1/6" duration 7 sync /1B:........:[^:]*:....:....:000[9A]:/ w
indow 83,0',
    '598.3 "Golem Meteors" sync /1B:........:[^:]*:....:....:0007:/ duration 11
window 80,80'
  ],
  cape_westwind: [
    '199.0 "--sync--" sync /00:0044:[^:]*:My shields are impregnable/ window 200
,0',
    '584.3 "--sync--" sync /00:0044:[^:]*:Your defeat will bring/ window 600,0'
  ],
  'ifrit-nm': [
    '200.0 "--sync--" sync /00:0044:Ifrit:Succumb to the inferno/ window 200,0',
    '300.0 "--sync--" sync /00:0044:Ifrit:Surrender thyself to the fires of judg
ment/ window 300,0'
  ],
  'titan-nm': [ '703.6 "Landslide" sync /Titan:285:/' ]
```