### PR TITLE
ci: bump actions/checkout to v2

### DIFF
--- a/.github/workflows/build-artifact.yml
+++ b/.github/workflows/build-artifact.yml
@@ -28,7 +28,7 @@ jobs:
     runs-on: windows-latest
 
     steps:
-      - uses: actions/checkout@v2
+    - uses: actions/checkout@v2
 
     - name: Set artifact name
       shell: bash

--- a/.github/workflows/build-artifact.yml
+++ b/.github/workflows/build-artifact.yml
@@ -28,7 +28,7 @@ jobs:
     runs-on: windows-latest
 
     steps:
-    - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
 
     - name: Set artifact name
       shell: bash

--- a/.github/workflows/css-lint.yml
+++ b/.github/workflows/css-lint.yml
@@ -18,7 +18,7 @@ jobs:
   stylelint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
 
       - uses: actions/setup-node@v2
         with:

--- a/.github/workflows/javascript-lint.yml
+++ b/.github/workflows/javascript-lint.yml
@@ -24,7 +24,7 @@ jobs:
   eslint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
 
       - uses: actions/setup-node@v2
         with:

--- a/.github/workflows/markdown-lint.yml
+++ b/.github/workflows/markdown-lint.yml
@@ -18,7 +18,7 @@ jobs:
   markdownlint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
 
       - uses: actions/setup-node@v2
         with:

--- a/.github/workflows/post-process.yml
+++ b/.github/workflows/post-process.yml
@@ -22,7 +22,7 @@ jobs:
   postprocess:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
 
       - uses: actions/setup-node@v2
         with:

--- a/.github/workflows/python-lint.yml
+++ b/.github/workflows/python-lint.yml
@@ -18,7 +18,7 @@ jobs:
   black:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
 
       - uses: actions/setup-python@v2
         with:
@@ -49,7 +49,7 @@ jobs:
   pylint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
 
       - uses: actions/setup-python@v2
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,7 +24,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
 
       - uses: actions/setup-node@v2
         with:

--- a/.github/workflows/update-triggers-branch.yml
+++ b/.github/workflows/update-triggers-branch.yml
@@ -26,7 +26,7 @@ jobs:
     needs: check-triggers
     if: needs.check-triggers.outputs.found == 'true'
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
         with:
           node-version: '14'


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/13553903/143318648-8a992d95-c48b-4d83-a4b2-6f72acf005b5.png)

![image](https://user-images.githubusercontent.com/13553903/143318703-8bcec689-ad9b-4bad-a5e6-432b107c6d82.png)

`actions/checkout@v1` will fetch all history commits and tags, and it's very slow.

test ci takes only 1m37s with v2