### PR TITLE
test: Temporarily permit old/new seal formats in timelines

### DIFF
--- a/test/helper/test_timeline.js
+++ b/test/helper/test_timeline.js
@@ -309,7 +309,7 @@ const testTimelineFiles = (timelineFiles) => {
             // we should come back here and make the doubled colon non-optional.
             if (regex.includes('is no longer sealed')) {
               assert(
-                /00:0839::?\.\*is no longer sealed/.exec(regex),
+                /00:0839::?.*is no longer sealed/.exec(regex),
                 `${timelineFile}:${sync.lineNumber} 'is no longer sealed' sync must be exactly '00:0839::.*is no longer sealed'`,
               );
             } else if (regex.includes('will be sealed')) {

--- a/test/helper/test_timeline.js
+++ b/test/helper/test_timeline.js
@@ -303,15 +303,19 @@ const testTimelineFiles = (timelineFiles) => {
         it('should have proper sealed sync', () => {
           for (const sync of timeline.syncStarts) {
             const regex = sync.regex.source;
+            // FIXME: This test will currently accept log lines with or without a second colon,
+            // as "0839:" or "0839::".
+            // Once we have completely converted things for 6.0,
+            // we should come back here and make the doubled colon non-optional.
             if (regex.includes('is no longer sealed')) {
               assert(
-                regex.includes('00:0839:.*is no longer sealed'),
-                `${timelineFile}:${sync.lineNumber} 'is no longer sealed' sync must be exactly '00:0839:.*is no longer sealed'`,
+                /00:0839::?\.\*is no longer sealed/.exec(regex),
+                `${timelineFile}:${sync.lineNumber} 'is no longer sealed' sync must be exactly '00:0839::.*is no longer sealed'`,
               );
             } else if (regex.includes('will be sealed')) {
               assert(
-                regex.match('00:0839:.*will be sealed'),
-                `${timelineFile}:${sync.lineNumber} 'will be sealed' sync must be preceded by '00:0839:'`,
+                /00:0839::?.*will be sealed/.exec(regex),
+                `${timelineFile}:${sync.lineNumber} 'will be sealed' sync must be preceded by '00:0839::'`,
               );
             }
           }

--- a/test/helper/test_timeline.js
+++ b/test/helper/test_timeline.js
@@ -309,7 +309,7 @@ const testTimelineFiles = (timelineFiles) => {
             // we should come back here and make the doubled colon non-optional.
             if (regex.includes('is no longer sealed')) {
               assert(
-                /00:0839::?.*is no longer sealed/.exec(regex),
+                /00:0839::?\.\*is no longer sealed/.exec(regex),
                 `${timelineFile}:${sync.lineNumber} 'is no longer sealed' sync must be exactly '00:0839::.*is no longer sealed'`,
               );
             } else if (regex.includes('will be sealed')) {

--- a/ui/raidboss/common_replacement.ts
+++ b/ui/raidboss/common_replacement.ts
@@ -5,7 +5,11 @@ import { Lang, NonEnLang } from '../../resources/languages';
 // It's awkward to refer to these string keys, so name them as replaceSync[keys.sealKey].
 export const syncKeys = {
   // Match Regexes, NetRegexes, and timeline constructions of seal log lines.
-  seal: '(?<=00:0839:|00\\|[^|]*\\|0839\\|\\|)(.*) will be sealed off(?: in (?:[0-9]+ seconds)?)?',
+  // FIXME: This seal regex includes an optional second colon, as "0839::?"".
+  // Once we have completely converted things for 6.0,
+  // we should come back here and make the doubled colon non-optional.
+  seal:
+    '(?<=00:0839::?|00\\|[^|]*\\|0839\\|\\|)(.*) will be sealed off(?: in (?:[0-9]+ seconds)?)?',
   unseal: 'is no longer sealed',
   engage: 'Engage!',
 };


### PR DESCRIPTION
Per <https://github.com/quisquous/cactbot/pull/3673#issuecomment-980494383>, this should permit passing tests for all timeline seal/unseal entries that use the new log line format. Note the error message doesn't include the old format, since we shouldn't be using it for any new work.