### PR TITLE
util: Alpha Python timeline utility updates

### DIFF
--- a/util/encounter_tools.py
+++ b/util/encounter_tools.py
@@ -263,7 +263,7 @@ def is_tl_line_begincast(poss_match):
 
 def is_tl_line_buff(poss_match):
     return re.search(
-        r"\s1A:(?P<effectId>(?:\.\{0,4\}|.{0,4})):(?P<effect>(?:[^:]*?|\[\^:\]\*?)):\[\^:\](?:\+|\*):\.\{8\}:(?P<source>(?:[^:]*?)):\.\{8\}:(?P<target>(?:[^:]*))",
+        r"\s1A:(?P<effectId>(?:[^:]*?|\[\^:\]\*?)):(?P<effect>(?:[^:]*?|\[\^:\]\*?)):(?P<duration>(?:\[\^:\]\*|[^:]*)):(?P<sourceId>(?:\[\^:\]\*|[^:]*)):(?P<source>(?:\[\^:\]\*|[^:]*)):(?P<targetId>(?:\[\^:\]\*|[^:]*)):(?P<target>(?:\[\^:\]\*|[^:]*)):?",
         poss_match,
     )
 

--- a/util/encounter_tools.py
+++ b/util/encounter_tools.py
@@ -256,23 +256,34 @@ def is_tl_line_syncmatch(line):
 
 
 def is_tl_line_begincast(poss_match):
-    return re.search(r"^:([0-9A-F\[\]\(\)\|]+):([^:]+)", poss_match)
+    return re.search(r"\s14:(?P<source>[^:]+):(?P<id>[0-9A-F\(\)\|]+)", poss_match)
 
 
 def is_tl_line_buff(poss_match):
-    return re.search(r"1A:.......:(.+) gains the effect of (.+)( from)?", poss_match)
+    return re.search(
+        r"\s1A:(?P<effectId>(?:\.\{0,4\}|.{0,4})):(?P<effect>(?:[^:]*?|\[\^:\]\*?)):\[\^:\](?:\+|\*):\.\{8\}:(?P<source>(?:[^:]*?)):\.\{8\}:(?P<target>(?:[^:]*))",
+        poss_match,
+    )
 
 
 def is_tl_line_cast(poss_match):
-    return re.search(r"^:([^:]+):([0-9A-F\(\)\|]+)", poss_match)
+    return re.search(r"\s1(?:[56]|\[56\]):(?P<source>[^:]+):(?P<id>[0-9A-F\(\)\|]+)", poss_match)
 
 
 def is_tl_line_log(poss_match):
-    return re.search(r"^\s*00:([0-9]*):(.*$)", poss_match)
+    return re.search(
+        r"\s00:(?P<id>[0-9]*):(?P<entity>[^:]*):(?P<message>[^\/]*)\s?\/\s", poss_match
+    )
 
 
 def is_tl_line_adds(poss_match):
-    return re.search(r"Added new combatant (.*$)", poss_match)
+    return re.search(r"\s*03:........:(?P<entity>[^:]*):", poss_match)
+
+
+def is_tl_line_headmarker(poss_match):
+    return re.search(
+        r"\s*22:........:(?P<target>[^:]*):....:....:(?P<id>[0-9A-F\(\)\|]+)", poss_match
+    )
 
 
 def colorize(input_text, color_code):

--- a/util/encounter_tools.py
+++ b/util/encounter_tools.py
@@ -286,7 +286,7 @@ def is_tl_line_adds(poss_match):
 
 def is_tl_line_headmarker(poss_match):
     return re.search(
-        r"\s*1B:........:(?P<target>[^:]*):....:....:(?P<id>[0-9A-F\(\)\|]+)", poss_match
+        r"\s1B:........:(?P<target>[^:]*):....:....:(?P<id>[0-9A-F\(\)\|]+)", poss_match
     )
 
 

--- a/util/encounter_tools.py
+++ b/util/encounter_tools.py
@@ -256,7 +256,9 @@ def is_tl_line_syncmatch(line):
 
 
 def is_tl_line_begincast(poss_match):
-    return re.search(r"\s14:(?P<source>[^:]+):(?P<id>[0-9A-F\(\)\|]+)", poss_match)
+    return re.search(
+        r"\s14:(?:\[\^:\]\*|[^:]*):(?P<source>[^:]+):(?P<id>[0-9A-F\(\)\|]+)", poss_match
+    )
 
 
 def is_tl_line_buff(poss_match):
@@ -267,12 +269,14 @@ def is_tl_line_buff(poss_match):
 
 
 def is_tl_line_cast(poss_match):
-    return re.search(r"\s1(?:[56]|\[56\]):(?P<source>[^:]+):(?P<id>[0-9A-F\(\)\|]+)", poss_match)
+    return re.search(
+        r"\s1(?:[56]|\[56\]):(?:\[\^:\]\*|[^:]*):(?P<source>[^:]+):(?P<id>[^:]+)", poss_match,
+    )
 
 
 def is_tl_line_log(poss_match):
     return re.search(
-        r"\s00:(?P<id>[0-9]*):(?P<entity>[^:]*):(?P<message>[^\/]*)\s?\/\s", poss_match
+        r"\s00:(?P<id>(?:\[\^:\]\*)|[^:]*):(?P<entity>[^:]*):(?P<message>[^\/]*)\s?", poss_match
     )
 
 
@@ -282,7 +286,7 @@ def is_tl_line_adds(poss_match):
 
 def is_tl_line_headmarker(poss_match):
     return re.search(
-        r"\s*22:........:(?P<target>[^:]*):....:....:(?P<id>[0-9A-F\(\)\|]+)", poss_match
+        r"\s*1B:........:(?P<target>[^:]*):....:....:(?P<id>[0-9A-F\(\)\|]+)", poss_match
     )
 
 

--- a/util/make_timeline.py
+++ b/util/make_timeline.py
@@ -371,7 +371,7 @@ def main(args):
         if entry["line_type"] == "34":
             output_entry = '{position:.1f} "{targetable}"'.format(**entry)
         else:
-            output_entry = '{position:.1f} "{ability_name}" sync / 1[56]:{combatant}:{ability_id}:/'.format(
+            output_entry = '{position:.1f} "{ability_name}" sync / 1[56]:[^:]*:{combatant}:{ability_id}:/'.format(
                 **entry
             )
 

--- a/util/make_timeline.py
+++ b/util/make_timeline.py
@@ -286,13 +286,13 @@ def main(args):
     output = []
     if entries[0]["line_type"] and entries[0]["line_type"] == "zone_seal":
         output.append(
-            '0 "Start" sync /00:0839:{} will be sealed off/ window 0,1'.format(
+            '0.0 "--sync--" sync / 00:0839:{} will be sealed off/ window 0,1'.format(
                 entries[0]["zone_message"].title()
             )
         )
         entries.pop(0)
     else:
-        output.append('0 "Start" sync /Engage!/ window 0,1')
+        output.append('0.0 "--sync--" sync /Engage!/ window 0,1')
 
     for entry in entries:
 
@@ -371,7 +371,7 @@ def main(args):
         if entry["line_type"] == "34":
             output_entry = '{position:.1f} "{targetable}"'.format(**entry)
         else:
-            output_entry = '{position:.1f} "{ability_name}" sync /:{combatant}:{ability_id}:/'.format(
+            output_entry = '{position:.1f} "{ability_name}" sync / 1[56]:{combatant}:{ability_id}:/'.format(
                 **entry
             )
 

--- a/util/make_timeline.py
+++ b/util/make_timeline.py
@@ -286,7 +286,7 @@ def main(args):
     output = []
     if entries[0]["line_type"] and entries[0]["line_type"] == "zone_seal":
         output.append(
-            '0.0 "--sync--" sync / 00:0839:{} will be sealed off/ window 0,1'.format(
+            '0.0 "--sync--" sync / 00:0839::{} will be sealed off/ window 0,1'.format(
                 entries[0]["zone_message"].title()
             )
         )

--- a/util/test_timeline.py
+++ b/util/test_timeline.py
@@ -67,7 +67,7 @@ def load_timeline(timeline):
                 entry["buff_name"] = buff_match.group("effect")
                 entry[
                     "regex"
-                ] = "26\|[^\|]*\|{}\|{}\|[^\|]*\|........\|[^\|]*\|.........\|{}\|".format(
+                ] = "26\|[^\|]*\|{}\|{}\|[^\|]*\|........\|[^\|]*\|........\|{}\|".format(
                     buff_match.group("effectId"),
                     buff_match.group("effect"),
                     buff_match.group("target"),
@@ -244,9 +244,7 @@ def test_match(event, entry):
     if isinstance(event, str) and entry["special_type"]:
         # Begincast case
         if entry["special_type"] == "begincast" and event.startswith(entry["special_line"]):
-            begincast_match = re.search(
-                "\|{}\|{}\|".format(entry["caster_name"], entry["cast_id"]), event
-            )
+            begincast_match = re.search(entry["regex"], event)
             if begincast_match:
                 return True
             else:
@@ -256,9 +254,7 @@ def test_match(event, entry):
         elif entry["special_type"] == "applydebuff" and event.startswith(entry["special_line"]):
             # Matching this format generically:
             # |Dadaluma Simulation|0.00|E0000000||4000AE96|Guardian
-            buff_match = re.search(
-                "\|{}\|([^\|]*\|){{4}}{}".format(entry["buff_name"], entry["buff_target"]), event
-            )
+            buff_match = re.search(entry["regex"], event)
             if buff_match:
                 return True
             else:
@@ -268,11 +264,7 @@ def test_match(event, entry):
         elif entry["special_type"] == "battlelog" and event.startswith(entry["special_line"]):
             # Matching this format generically:
             # 00|2019-01-12T18:08:14.0000000-05:00|0839||The Realm of the Machinists will be sealed off in 15 seconds!|
-            log_match = re.search(
-                "^00\|[^\|]*\|{}\|[^\|]*\|{}".format(entry["logid"], entry["line"]),
-                event,
-                re.IGNORECASE,
-            )
+            log_match = re.search(entry["regex"], event, re.IGNORECASE,)
             if log_match:
                 return True
             else:
@@ -282,8 +274,16 @@ def test_match(event, entry):
         elif entry["special_type"] == "addlog" and event.startswith(entry["special_line"]):
             # Matching this format generically:
             # 03|2019-01-12T18:07:46.6390000-05:00|40002269|Mustadio|0|46|dfa2|2ee0|0|0||dc029b852788abdd6056147620d2193c
-            add_match = re.search("^03\|[^\|]*\|[^\|]*\|{}\|".format(entry["name"]), event)
+            add_match = re.search(entry["regex"], event)
             if add_match:
+                return True
+            else:
+                return False
+
+        # Head marker case
+        elif entry["special_type"] == "headmarker" and event.startswith(entry["special_line"]):
+            marker_match = re.search(entry["regex"], event,)
+            if marker_match:
                 return True
             else:
                 return False

--- a/util/test_timeline.py
+++ b/util/test_timeline.py
@@ -65,9 +65,7 @@ def load_timeline(timeline):
                 entry["special_line"] = "26"
                 entry["buff_target"] = buff_match.group("target")
                 entry["buff_name"] = buff_match.group("effect")
-                entry[
-                    "regex"
-                ] = "26\|[^\|]*\|{}\|{}\|[^\|]*\|........\|[^\|]*\|........\|{}\|".format(
+                entry["regex"] = "26\|[^\|]*\|{}\|{}\|[^\|]*\|[^\|]*\|[^\|]*\|[^\|]*\|{}\|".format(
                     buff_match.group("effectId"),
                     buff_match.group("effect"),
                     buff_match.group("target"),
@@ -254,7 +252,7 @@ def test_match(event, entry):
         elif entry["special_type"] == "applydebuff" and event.startswith(entry["special_line"]):
             # Matching this format generically:
             # |Dadaluma Simulation|0.00|E0000000||4000AE96|Guardian
-            buff_match = re.search(entry["regex"], event)
+            buff_match = re.search(entry["regex"], event, re.IGNORECASE)
             if buff_match:
                 return True
             else:


### PR DESCRIPTION
It's all bad, but it seemed to work on the alpha logs I was given. I'm not particularly attached to anything I've implemented here, this was mostly an attempt to get *something* in place for later improvement.

For consistency with converted old logs, I figured it made most sense to format `make_timeline` output the same way, as `1[56]`.