### PR TITLE
raidboss: add object ids to alpha timelines

### DIFF
--- a/ui/raidboss/data/02-arr/raid/t10.txt
+++ b/ui/raidboss/data/02-arr/raid/t10.txt
@@ -10,14 +10,14 @@ hideall "--sync--"
 0.0 "Start"
 0.0 "--sync--" sync /:Engage!/ window 0,1
 0.0 "--sync--" sync / 00:0839::The Alpha Concourse will be sealed off/ window 5,5
-8.0 "Crackle Hiss" sync / 1[56]:Imdugud:B55:/
-16.0 "Critical Rip" sync / 1[56]:Imdugud:B56:/
-20.0 "Crackle Hiss" sync / 1[56]:Imdugud:B55:/
-32.0 "Wild Charge" sync / 1[56]:Imdugud:B5B:/ window 8,8
-36.0 "Crackle Hiss" sync / 1[56]:Imdugud:B55:/
-51.0 "Spike Flail" #sync / 1[56]:Imdugud:B57:/
-56.0 "Crackle Hiss" sync / 1[56]:Imdugud:B55:/
-64.0 "Critical Rip" sync / 1[56]:Imdugud:B56:/ window 20,20 jump 20
+8.0 "Crackle Hiss" sync / 1[56]:[^:]*:Imdugud:B55:/
+16.0 "Critical Rip" sync / 1[56]:[^:]*:Imdugud:B56:/
+20.0 "Crackle Hiss" sync / 1[56]:[^:]*:Imdugud:B55:/
+32.0 "Wild Charge" sync / 1[56]:[^:]*:Imdugud:B5B:/ window 8,8
+36.0 "Crackle Hiss" sync / 1[56]:[^:]*:Imdugud:B55:/
+51.0 "Spike Flail" #sync / 1[56]:[^:]*:Imdugud:B57:/
+56.0 "Crackle Hiss" sync / 1[56]:[^:]*:Imdugud:B55:/
+64.0 "Critical Rip" sync / 1[56]:[^:]*:Imdugud:B56:/ window 20,20 jump 20
 # fake lookahead loop
 68.0 "Crackle Hiss"
 80.0 "Wild Charge"
@@ -25,48 +25,48 @@ hideall "--sync--"
 89.0 "Spike Flail"
 
 # 85% push into Adds Phase #1
-196.0 "--sync--" sync / 14:Imdugud:B5D:/ window 200,0
-200.0 "Electrocharge" sync / 1[56]:Imdugud:B5D:/ window 200,0
+196.0 "--sync--" sync / 14:[^:]*:Imdugud:B5D:/ window 200,0
+200.0 "Electrocharge" sync / 1[56]:[^:]*:Imdugud:B5D:/ window 200,0
 201.0 "2x Son / 2x Daughter Adds"
 
 # Mid Phase: Alternates Heat Lightning, Heat Lightning+Charge, Tankbuster, Repeat
-497.0 "--sync--" sync / 14:Imdugud:B5E:/ window 500,0
-500.0 "Electric Burst" sync / 1[56]:Imdugud:B5E:/ window 500,0
-509.2 "Heat Lightning" sync / 1[56]:Imdugud:B5F:/
-528.1 "Crackle Hiss" sync / 1[56]:Imdugud:B55:/
-535.2 "Heat Lightning" sync / 1[56]:Imdugud:B5F:/
-541.9 "Wild Charge" sync / 1[56]:Imdugud:B5B:/ window 8,8
-545.3 "Crackle Hiss" sync / 1[56]:Imdugud:B55:/
-558.3 "Critical Rip" sync / 1[56]:Imdugud:B56:/
-561.5 "Crackle Hiss" sync / 1[56]:Imdugud:B55:/
+497.0 "--sync--" sync / 14:[^:]*:Imdugud:B5E:/ window 500,0
+500.0 "Electric Burst" sync / 1[56]:[^:]*:Imdugud:B5E:/ window 500,0
+509.2 "Heat Lightning" sync / 1[56]:[^:]*:Imdugud:B5F:/
+528.1 "Crackle Hiss" sync / 1[56]:[^:]*:Imdugud:B55:/
+535.2 "Heat Lightning" sync / 1[56]:[^:]*:Imdugud:B5F:/
+541.9 "Wild Charge" sync / 1[56]:[^:]*:Imdugud:B5B:/ window 8,8
+545.3 "Crackle Hiss" sync / 1[56]:[^:]*:Imdugud:B55:/
+558.3 "Critical Rip" sync / 1[56]:[^:]*:Imdugud:B56:/
+561.5 "Crackle Hiss" sync / 1[56]:[^:]*:Imdugud:B55:/
 # fake lookahead loop
-569.8 "Heat Lightning" sync / 1[56]:Imdugud:B5F:/ window 20,20 jump 509.2
+569.8 "Heat Lightning" sync / 1[56]:[^:]*:Imdugud:B5F:/ window 20,20 jump 509.2
 588.7 "Crackle Hiss"
 595.8 "Heat Lightning"
 602.5 "Wild Charge"
 
 # 53% push into Adds Phase #2
-696.0 "--sync--" sync / 14:Imdugud:B5D:/ window 200,0
-700.0 "Electrocharge" sync / 1[56]:Imdugud:B5D:/ window 400,0
+696.0 "--sync--" sync / 14:[^:]*:Imdugud:B5D:/ window 200,0
+700.0 "Electrocharge" sync / 1[56]:[^:]*:Imdugud:B5D:/ window 400,0
 701.0 "2x Son / 2x Daughter Adds"
 736.0 "1x Son / 1x Daughter Adds"
 
 # Final Phase: Heat+Tether, Buster, Random Mechanic, Repeat
-997.0 "--sync--" sync / 14:Imdugud:B5E:/ window 400,0
-1000.0 "Electric Burst" sync / 1[56]:Imdugud:B5E:/ window 400,0
+997.0 "--sync--" sync / 14:[^:]*:Imdugud:B5E:/ window 400,0
+1000.0 "Electric Burst" sync / 1[56]:[^:]*:Imdugud:B5E:/ window 400,0
 
-1009.3 "Heat Lightning" sync / 1[56]:Imdugud:B5F:/
-1013.5 "Cyclonic Chaos" sync / 1[56]:Imdugud:B61:/
-1028.5 "Crackle Hiss" sync / 1[56]:Imdugud:B55:/
+1009.3 "Heat Lightning" sync / 1[56]:[^:]*:Imdugud:B5F:/
+1013.5 "Cyclonic Chaos" sync / 1[56]:[^:]*:Imdugud:B61:/
+1028.5 "Crackle Hiss" sync / 1[56]:[^:]*:Imdugud:B55:/
 
-1035.8 "Critical Rip" sync / 1[56]:Imdugud:B56:/ window 20,20
-1042.0 "Crackle Hiss" sync / 1[56]:Imdugud:B55:/
+1035.8 "Critical Rip" sync / 1[56]:[^:]*:Imdugud:B56:/ window 20,20
+1042.0 "Crackle Hiss" sync / 1[56]:[^:]*:Imdugud:B55:/
 
 # Heat + Charge, OR Tether + Charge
 1058.0 "Random + Charge"
 
-1061.2 "Crackle Hiss" sync / 1[56]:Imdugud:B55:/
-1089.2 "Heat Lightning" sync / 1[56]:Imdugud:B5F:/ window 20,20 jump 1009.3
+1061.2 "Crackle Hiss" sync / 1[56]:[^:]*:Imdugud:B55:/
+1089.2 "Heat Lightning" sync / 1[56]:[^:]*:Imdugud:B5F:/ window 20,20 jump 1009.3
 1093.4 "Cyclonic Chaos"
 1108.4 "Crackle Hiss"
 1115.7 "Critical Rip"

--- a/ui/raidboss/data/02-arr/raid/t11.txt
+++ b/ui/raidboss/data/02-arr/raid/t11.txt
@@ -160,7 +160,7 @@ hideall "--sync--"
 
 
 ### Phase 5 (enrage)
-1200.0 "--sync--" sync / 1[56]:Kaliya:B7A/ window 1200,1200
+1200.0 "--sync--" sync / 1[56]:Kaliya:B7A:/ window 1200,1200
 1208.0 "Nerve Cloud Enrage"
 1220.2 "Nerve Cloud Enrage"
 1232.4 "Nerve Cloud Enrage"

--- a/ui/raidboss/data/02-arr/raid/t11.txt
+++ b/ui/raidboss/data/02-arr/raid/t11.txt
@@ -10,14 +10,14 @@ hideall "--sync--"
 0.0 "Start"
 0.0 "--sync--" sync /:Engage!/ window 0,1
 0.0 "--sync--" sync / 00:0839::The Core Override will be sealed off/ window 10,10
-2.5 "--sync--" sync / 1[56]:Kaliya:B6A:/ window 3,0
-9.4 "Resonance" sync / 1[56]:Kaliya:B6B:/
+2.5 "--sync--" sync / 1[56]:[^:]*:Kaliya:B6A:/ window 3,0
+9.4 "Resonance" sync / 1[56]:[^:]*:Kaliya:B6B:/
 
 19.7 "Nerve Gas"
 24.9 "Nerve Gas"
 30.1 "Nerve Gas"
-33.4 "Resonance" sync / 1[56]:Kaliya:B6B:/
-38.6 "Resonance" sync / 1[56]:Kaliya:B6B:/
+33.4 "Resonance" sync / 1[56]:[^:]*:Kaliya:B6B:/
+38.6 "Resonance" sync / 1[56]:[^:]*:Kaliya:B6B:/
 
 48.9 "Nerve Gas"
 54.1 "Nerve Gas"
@@ -26,23 +26,23 @@ hideall "--sync--"
 67.8 "Resonance"
 
 ### Phase 2 (90%)
-200.0 "Barofield" sync / 1[56]:Kaliya:B6F:/ window 200,0
+200.0 "Barofield" sync / 1[56]:[^:]*:Kaliya:B6F:/ window 200,0
 
-208.0 "Seed Of The Sea/Rivers" sync / 1[56]:Kaliya:B7[67]:/
-213.3 "Seed Of The Rivers/Sea" sync / 1[56]:Kaliya:B7[67]:/
-217.5 "Resonance" sync / 1[56]:Kaliya:B6B:/
-220.7 "Secondary Head Stun" sync / 1[56]:Kaliya:B73:/
-225.8 "Secondary Head" sync / 1[56]:Kaliya:B72:/
-226.9 "Main Head" sync / 1[56]:Kaliya:B71:/
-231.1 "Resonance" sync / 1[56]:Kaliya:B6B:/
+208.0 "Seed Of The Sea/Rivers" sync / 1[56]:[^:]*:Kaliya:B7[67]:/
+213.3 "Seed Of The Rivers/Sea" sync / 1[56]:[^:]*:Kaliya:B7[67]:/
+217.5 "Resonance" sync / 1[56]:[^:]*:Kaliya:B6B:/
+220.7 "Secondary Head Stun" sync / 1[56]:[^:]*:Kaliya:B73:/
+225.8 "Secondary Head" sync / 1[56]:[^:]*:Kaliya:B72:/
+226.9 "Main Head" sync / 1[56]:[^:]*:Kaliya:B71:/
+231.1 "Resonance" sync / 1[56]:[^:]*:Kaliya:B6B:/
 237.4 "Nerve Gas"
 242.5 "Nerve Gas"
 247.5 "Nerve Gas"
-250.8 "Resonance" sync / 1[56]:Kaliya:B6B:/
+250.8 "Resonance" sync / 1[56]:[^:]*:Kaliya:B6B:/
 
-258.0 "Seed Of The Sea/Rivers" sync / 1[56]:Kaliya:B7[67]:/
-263.3 "Seed Of The Rivers/Sea" sync / 1[56]:Kaliya:B7[67]:/
-267.5 "Resonance" sync / 1[56]:Kaliya:B6B:/ window 10,10 jump 217.5
+258.0 "Seed Of The Sea/Rivers" sync / 1[56]:[^:]*:Kaliya:B7[67]:/
+263.3 "Seed Of The Rivers/Sea" sync / 1[56]:[^:]*:Kaliya:B7[67]:/
+267.5 "Resonance" sync / 1[56]:[^:]*:Kaliya:B6B:/ window 10,10 jump 217.5
 270.7 "Secondary Head Stun"
 275.8 "Secondary Head"
 276.9 "Main Head"
@@ -59,108 +59,108 @@ hideall "--sync--"
 ### Phase 4 (nodes defeated)
 # this phase has different timings if you are soloing, sorry.
 # it's possible resonance timings are not reliable either.
-595.0 "--sync--" sync / 14:Kaliya:B78:/ window 600,600
-600.0 "Emergency Mode" sync / 1[56]:Kaliya:B78:/
+595.0 "--sync--" sync / 14:[^:]*:Kaliya:B78:/ window 600,600
+600.0 "Emergency Mode" sync / 1[56]:[^:]*:Kaliya:B78:/
 
-606.1 "Nerve Cloud" sync / 1[56]:Kaliya:B79:/ window 100,100
-617.3 "Nanospore Jet" sync / 1[56]:Kaliya:B7B:/ window 50,50
-625.4 "Resonance" sync / 1[56]:Kaliya:B6B:/
-634.9 "Seed Of The Sea/Rivers" sync / 1[56]:Kaliya:B7[67]:/
-639.7 "Seed Of The Rivers/Sea" sync / 1[56]:Kaliya:B7[67]:/
+606.1 "Nerve Cloud" sync / 1[56]:[^:]*:Kaliya:B79:/ window 100,100
+617.3 "Nanospore Jet" sync / 1[56]:[^:]*:Kaliya:B7B:/ window 50,50
+625.4 "Resonance" sync / 1[56]:[^:]*:Kaliya:B6B:/
+634.9 "Seed Of The Sea/Rivers" sync / 1[56]:[^:]*:Kaliya:B7[67]:/
+639.7 "Seed Of The Rivers/Sea" sync / 1[56]:[^:]*:Kaliya:B7[67]:/
 644.1 "Nerve Gas"
 649.2 "Nerve Gas"
 654.3 "Nerve Gas"
-658.6 "Secondary Head Stun" sync / 1[56]:Kaliya:B73:/
-663.7 "Secondary Head" sync / 1[56]:Kaliya:B72:/
-664.8 "Main Head" sync / 1[56]:Kaliya:B71:/
-668.1 "Resonance" sync / 1[56]:Kaliya:B6B:/
+658.6 "Secondary Head Stun" sync / 1[56]:[^:]*:Kaliya:B73:/
+663.7 "Secondary Head" sync / 1[56]:[^:]*:Kaliya:B72:/
+664.8 "Main Head" sync / 1[56]:[^:]*:Kaliya:B71:/
+668.1 "Resonance" sync / 1[56]:[^:]*:Kaliya:B6B:/
 
-677.2 "Nanospore Jet" sync / 1[56]:Kaliya:B7B:/ window 50,50
-685.3 "Resonance" sync / 1[56]:Kaliya:B6B:/
-694.6 "Seed Of The Sea/Rivers" sync / 1[56]:Kaliya:B7[67]:/
-699.6 "Seed Of The Rivers/Sea" sync / 1[56]:Kaliya:B7[67]:/
+677.2 "Nanospore Jet" sync / 1[56]:[^:]*:Kaliya:B7B:/ window 50,50
+685.3 "Resonance" sync / 1[56]:[^:]*:Kaliya:B6B:/
+694.6 "Seed Of The Sea/Rivers" sync / 1[56]:[^:]*:Kaliya:B7[67]:/
+699.6 "Seed Of The Rivers/Sea" sync / 1[56]:[^:]*:Kaliya:B7[67]:/
 704.0 "Nerve Gas"
 709.0 "Nerve Gas"
 714.1 "Nerve Gas"
-718.4 "Secondary Head Stun" sync / 1[56]:Kaliya:B73:/
-723.6 "Secondary Head" sync / 1[56]:Kaliya:B72:/
-724.7 "Main Head" sync / 1[56]:Kaliya:B71:/
-727.9 "Resonance" sync / 1[56]:Kaliya:B6B:/
+718.4 "Secondary Head Stun" sync / 1[56]:[^:]*:Kaliya:B73:/
+723.6 "Secondary Head" sync / 1[56]:[^:]*:Kaliya:B72:/
+724.7 "Main Head" sync / 1[56]:[^:]*:Kaliya:B71:/
+727.9 "Resonance" sync / 1[56]:[^:]*:Kaliya:B6B:/
 
-733.9 "Nerve Cloud" sync / 1[56]:Kaliya:B79:/ window 100,100
-745.1 "Nanospore Jet" sync / 1[56]:Kaliya:B7B:/ window 50,50
+733.9 "Nerve Cloud" sync / 1[56]:[^:]*:Kaliya:B79:/ window 100,100
+745.1 "Nanospore Jet" sync / 1[56]:[^:]*:Kaliya:B7B:/ window 50,50
 756.2 "Nerve Gas"
 761.3 "Nerve Gas"
 766.4 "Nerve Gas"
-768.6 "Resonance" sync / 1[56]:Kaliya:B6B:/
-779.7 "Seed Of The Sea/Rivers" sync / 1[56]:Kaliya:B7[67]:/
-784.8 "Seed Of The Rivers/Sea" sync / 1[56]:Kaliya:B7[67]:/
-785.0 "Resonance" sync / 1[56]:Kaliya:B6B:/
-787.1 "Secondary Head Stun" sync / 1[56]:Kaliya:B73:/
-792.2 "Secondary Head" sync / 1[56]:Kaliya:B72:/
-793.3 "Main Head" sync / 1[56]:Kaliya:B71:/
+768.6 "Resonance" sync / 1[56]:[^:]*:Kaliya:B6B:/
+779.7 "Seed Of The Sea/Rivers" sync / 1[56]:[^:]*:Kaliya:B7[67]:/
+784.8 "Seed Of The Rivers/Sea" sync / 1[56]:[^:]*:Kaliya:B7[67]:/
+785.0 "Resonance" sync / 1[56]:[^:]*:Kaliya:B6B:/
+787.1 "Secondary Head Stun" sync / 1[56]:[^:]*:Kaliya:B73:/
+792.2 "Secondary Head" sync / 1[56]:[^:]*:Kaliya:B72:/
+793.3 "Main Head" sync / 1[56]:[^:]*:Kaliya:B71:/
 
-804.7 "Nanospore Jet" sync / 1[56]:Kaliya:B7B:/ window 50,50
+804.7 "Nanospore Jet" sync / 1[56]:[^:]*:Kaliya:B7B:/ window 50,50
 815.9 "Nerve Gas"
 821.0 "Nerve Gas"
 826.1 "Nerve Gas"
-828.2 "Resonance" sync / 1[56]:Kaliya:B6B:/
-839.4 "Seed Of The Sea/Rivers" sync / 1[56]:Kaliya:B7[67]:/
-844.5 "Seed Of The Rivers/Sea" sync / 1[56]:Kaliya:B7[67]:/
-844.7 "Resonance" sync / 1[56]:Kaliya:B6B:/
-846.8 "Secondary Head Stun" sync / 1[56]:Kaliya:B73:/
-851.9 "Secondary Head" sync / 1[56]:Kaliya:B72:/
-853.0 "Main Head" sync / 1[56]:Kaliya:B71:/
+828.2 "Resonance" sync / 1[56]:[^:]*:Kaliya:B6B:/
+839.4 "Seed Of The Sea/Rivers" sync / 1[56]:[^:]*:Kaliya:B7[67]:/
+844.5 "Seed Of The Rivers/Sea" sync / 1[56]:[^:]*:Kaliya:B7[67]:/
+844.7 "Resonance" sync / 1[56]:[^:]*:Kaliya:B6B:/
+846.8 "Secondary Head Stun" sync / 1[56]:[^:]*:Kaliya:B73:/
+851.9 "Secondary Head" sync / 1[56]:[^:]*:Kaliya:B72:/
+853.0 "Main Head" sync / 1[56]:[^:]*:Kaliya:B71:/
 
-861.3 "Nerve Cloud" sync / 1[56]:Kaliya:B79:/ window 100,100
-872.5 "Nanospore Jet" sync / 1[56]:Kaliya:B7B:/ window 50,50
-880.6 "Resonance" sync / 1[56]:Kaliya:B6B:/
-889.8 "Seed Of The Sea/Rivers" sync / 1[56]:Kaliya:B7[67]:/
-894.7 "Seed Of The Rivers/Sea" sync / 1[56]:Kaliya:B7[67]:/
+861.3 "Nerve Cloud" sync / 1[56]:[^:]*:Kaliya:B79:/ window 100,100
+872.5 "Nanospore Jet" sync / 1[56]:[^:]*:Kaliya:B7B:/ window 50,50
+880.6 "Resonance" sync / 1[56]:[^:]*:Kaliya:B6B:/
+889.8 "Seed Of The Sea/Rivers" sync / 1[56]:[^:]*:Kaliya:B7[67]:/
+894.7 "Seed Of The Rivers/Sea" sync / 1[56]:[^:]*:Kaliya:B7[67]:/
 899.2 "Nerve Gas"
 904.4 "Nerve Gas"
 909.5 "Nerve Gas"
-913.7 "Secondary Head Stun" sync / 1[56]:Kaliya:B73:/
-918.8 "Secondary Head" sync / 1[56]:Kaliya:B72:/
-920.0 "Main Head" sync / 1[56]:Kaliya:B71:/
-923.2 "Resonance" sync / 1[56]:Kaliya:B6B:/
+913.7 "Secondary Head Stun" sync / 1[56]:[^:]*:Kaliya:B73:/
+918.8 "Secondary Head" sync / 1[56]:[^:]*:Kaliya:B72:/
+920.0 "Main Head" sync / 1[56]:[^:]*:Kaliya:B71:/
+923.2 "Resonance" sync / 1[56]:[^:]*:Kaliya:B6B:/
 
-932.4 "Nanospore Jet" sync / 1[56]:Kaliya:B7B:/ window 50,50
+932.4 "Nanospore Jet" sync / 1[56]:[^:]*:Kaliya:B7B:/ window 50,50
 943.6 "Nerve Gas"
 948.7 "Nerve Gas"
 953.7 "Nerve Gas"
-955.8 "Resonance" sync / 1[56]:Kaliya:B6B:/
-967.0 "Seed Of The Sea/Rivers" sync / 1[56]:Kaliya:B7[67]:/
-972.0 "Seed Of The Rivers/Sea" sync / 1[56]:Kaliya:B7[67]:/
-972.2 "Resonance" sync / 1[56]:Kaliya:B6B:/
-974.3 "Secondary Head" sync / 1[56]:Kaliya:B73:/
-979.4 "Secondary Head" sync / 1[56]:Kaliya:B72:/
-980.5 "Main Head" sync / 1[56]:Kaliya:B71:/
+955.8 "Resonance" sync / 1[56]:[^:]*:Kaliya:B6B:/
+967.0 "Seed Of The Sea/Rivers" sync / 1[56]:[^:]*:Kaliya:B7[67]:/
+972.0 "Seed Of The Rivers/Sea" sync / 1[56]:[^:]*:Kaliya:B7[67]:/
+972.2 "Resonance" sync / 1[56]:[^:]*:Kaliya:B6B:/
+974.3 "Secondary Head" sync / 1[56]:[^:]*:Kaliya:B73:/
+979.4 "Secondary Head" sync / 1[56]:[^:]*:Kaliya:B72:/
+980.5 "Main Head" sync / 1[56]:[^:]*:Kaliya:B71:/
 
-988.8 "Nerve Cloud" sync / 1[56]:Kaliya:B79:/ window 100,100
-1000.0 "Nanospore Jet" sync / 1[56]:Kaliya:B7B:/ window 50,50
+988.8 "Nerve Cloud" sync / 1[56]:[^:]*:Kaliya:B79:/ window 100,100
+1000.0 "Nanospore Jet" sync / 1[56]:[^:]*:Kaliya:B7B:/ window 50,50
 1011.2 "Nerve Gas"
 1016.2 "Nerve Gas"
 1021.3 "Nerve Gas"
-1023.5 "Resonance" sync / 1[56]:Kaliya:B6B:/
-1034.7 "Seed Of The Sea/Rivers" sync / 1[56]:Kaliya:B7[67]:/
-1039.7 "Seed Of The Rivers/Sea" sync / 1[56]:Kaliya:B7[67]:/
-1039.9 "Resonance" sync / 1[56]:Kaliya:B6B:/
-1042.0 "Secondary Head" sync / 1[56]:Kaliya:B73:/
-1047.1 "Secondary Head" sync / 1[56]:Kaliya:B72:/
-1048.2 "Main Head" sync / 1[56]:Kaliya:B71:/
+1023.5 "Resonance" sync / 1[56]:[^:]*:Kaliya:B6B:/
+1034.7 "Seed Of The Sea/Rivers" sync / 1[56]:[^:]*:Kaliya:B7[67]:/
+1039.7 "Seed Of The Rivers/Sea" sync / 1[56]:[^:]*:Kaliya:B7[67]:/
+1039.9 "Resonance" sync / 1[56]:[^:]*:Kaliya:B6B:/
+1042.0 "Secondary Head" sync / 1[56]:[^:]*:Kaliya:B73:/
+1047.1 "Secondary Head" sync / 1[56]:[^:]*:Kaliya:B72:/
+1048.2 "Main Head" sync / 1[56]:[^:]*:Kaliya:B71:/
 
-1059.6 "Nanospore Jet" sync / 1[56]:Kaliya:B7B:/ window 50,50
-1067.8 "Resonance" sync / 1[56]:Kaliya:B6B:/
-1077.2 "Seed Of The Sea/Rivers" sync / 1[56]:Kaliya:B7[67]:/
-1082.2 "Seed Of The Rivers/Sea" sync / 1[56]:Kaliya:B7[67]:/
+1059.6 "Nanospore Jet" sync / 1[56]:[^:]*:Kaliya:B7B:/ window 50,50
+1067.8 "Resonance" sync / 1[56]:[^:]*:Kaliya:B6B:/
+1077.2 "Seed Of The Sea/Rivers" sync / 1[56]:[^:]*:Kaliya:B7[67]:/
+1082.2 "Seed Of The Rivers/Sea" sync / 1[56]:[^:]*:Kaliya:B7[67]:/
 1086.5 "Nerve Gas"
 1091.7 "Nerve Gas"
 1096.9 "Nerve Gas"
 
 
 ### Phase 5 (enrage)
-1200.0 "--sync--" sync / 1[56]:Kaliya:B7A:/ window 1200,1200
+1200.0 "--sync--" sync / 1[56]:[^:]*:Kaliya:B7A:/ window 1200,1200
 1208.0 "Nerve Cloud Enrage"
 1220.2 "Nerve Cloud Enrage"
 1232.4 "Nerve Cloud Enrage"

--- a/ui/raidboss/data/02-arr/raid/t12.txt
+++ b/ui/raidboss/data/02-arr/raid/t12.txt
@@ -11,33 +11,33 @@ hideall "Scorched Pinion"
 ### Phase 1: Blackfire/Whitefire
 0.0 "Start"
 0.0 "--sync--" sync /:Engage!/ window 0,1
-2.5 "--sync--" sync / 1[56]:Phoenix:368:/ window 3,0
+2.5 "--sync--" sync / 1[56]:[^:]*:Phoenix:368:/ window 3,0
 9.0 "Bennu Add"
-18.0 "Revelation" sync / 1[56]:Phoenix:B87:/
-32.1 "Blackfire" sync / 1[56]:Phoenix:B8C:/
-42.1 "--sync--" sync / 1[56]:Phoenix:B8F:/
-43.6 "Whitefire" sync / 1[56]:Phoenix:B90:/
+18.0 "Revelation" sync / 1[56]:[^:]*:Phoenix:B87:/
+32.1 "Blackfire" sync / 1[56]:[^:]*:Phoenix:B8C:/
+42.1 "--sync--" sync / 1[56]:[^:]*:Phoenix:B8F:/
+43.6 "Whitefire" sync / 1[56]:[^:]*:Phoenix:B90:/
 
-77.0 "Revelation" sync / 1[56]:Phoenix:B87:/ window 20,20 jump 18
+77.0 "Revelation" sync / 1[56]:[^:]*:Phoenix:B87:/ window 20,20 jump 18
 91.1 "Blackfire"
 101.1 "--sync--"
 102.6 "Whitefire"
 
 
 ### Phase 2: Bluefire/Redfire
-200.0 "Brand Of Purgatory" sync / 1[56]:Phoenix:B88:/ window 200,0
+200.0 "Brand Of Purgatory" sync / 1[56]:[^:]*:Phoenix:B88:/ window 200,0
 
-210.6 "Bluefire" sync / 1[56]:Phoenix:B91:/ duration 4.1
-223.6 "Flames Of Unforgiveness" sync / 1[56]:Phoenix:B8B:/
-231.0 "Redfire" sync / 1[56]:Phoenix:B93:/
-237.1 "Revelation" sync / 1[56]:Phoenix:B87:/
+210.6 "Bluefire" sync / 1[56]:[^:]*:Phoenix:B91:/ duration 4.1
+223.6 "Flames Of Unforgiveness" sync / 1[56]:[^:]*:Phoenix:B8B:/
+231.0 "Redfire" sync / 1[56]:[^:]*:Phoenix:B93:/
+237.1 "Revelation" sync / 1[56]:[^:]*:Phoenix:B87:/
 
-248.2 "Bluefire" sync / 1[56]:Phoenix:B91:/ duration 4.1
-261.3 "Flames Of Unforgiveness" sync / 1[56]:Phoenix:B8B:/
-268.3 "Redfire" sync / 1[56]:Phoenix:B93:/
+248.2 "Bluefire" sync / 1[56]:[^:]*:Phoenix:B91:/ duration 4.1
+261.3 "Flames Of Unforgiveness" sync / 1[56]:[^:]*:Phoenix:B8B:/
+268.3 "Redfire" sync / 1[56]:[^:]*:Phoenix:B93:/
 
-280.6 "Bluefire" sync / 1[56]:Phoenix:B91:/ duration 4.1
-293.6 "Flames Of Unforgiveness" sync / 1[56]:Phoenix:B8B:/ jump 223.6 window 20,20
+280.6 "Bluefire" sync / 1[56]:[^:]*:Phoenix:B91:/ duration 4.1
+293.6 "Flames Of Unforgiveness" sync / 1[56]:[^:]*:Phoenix:B8B:/ jump 223.6 window 20,20
 301.0 "Redfire"
 307.1 "Revelation"
 
@@ -47,81 +47,81 @@ hideall "Scorched Pinion"
 
 
 ### Phase 3: So Many Bennies
-400.0 "--sync--" sync / 1[56]:Phoenix:B96:/ window 400,0
-404.1 "--sync--" sync / 1[56]:Phoenix:B97:/ window 404,5
-407.1 "Flames Of Rebirth" sync / 1[56]:Phoenix:B98:/
-421.3 "Flames Of Rebirth" sync / 1[56]:Phoenix:B99:/
-435.5 "Flames Of Rebirth" sync / 1[56]:Phoenix:B99:/ window 8,8 jump 421.3
+400.0 "--sync--" sync / 1[56]:[^:]*:Phoenix:B96:/ window 400,0
+404.1 "--sync--" sync / 1[56]:[^:]*:Phoenix:B97:/ window 404,5
+407.1 "Flames Of Rebirth" sync / 1[56]:[^:]*:Phoenix:B98:/
+421.3 "Flames Of Rebirth" sync / 1[56]:[^:]*:Phoenix:B99:/
+435.5 "Flames Of Rebirth" sync / 1[56]:[^:]*:Phoenix:B99:/ window 8,8 jump 421.3
 449.7 "Flames Of Rebirth"
 463.9 "Flames Of Rebirth"
 478.1 "Flames Of Rebirth"
 
 
 ### Phase 4: Fountains of Life and Death
-996.0 "--sync--" sync / 14:Phoenix:C88:/ window 1000,0
-1000.0 "Rebirth" sync / 1[56]:Phoenix:C88:/
-1005.8 "Brand Of Purgatory" sync / 1[56]:Phoenix:B88:/
+996.0 "--sync--" sync / 14:[^:]*:Phoenix:C88:/ window 1000,0
+1000.0 "Rebirth" sync / 1[56]:[^:]*:Phoenix:C88:/
+1005.8 "Brand Of Purgatory" sync / 1[56]:[^:]*:Phoenix:B88:/
 
 # Fountain 1
-1011.0 "Fountain Of Fire" sync / 1[56]:Phoenix:B9C:/
-1014.1 "Summon" sync / 1[56]:Phoenix:B9F:/
+1011.0 "Fountain Of Fire" sync / 1[56]:[^:]*:Phoenix:B9C:/
+1014.1 "Summon" sync / 1[56]:[^:]*:Phoenix:B9F:/
 1019.1 "Fountain Tick 1"
-1020.3 "Scorched Pinion" sync / 1[56]:Phoenix-Egi:BA0:/
-1022.1 "Revelation" sync / 1[56]:Phoenix:B87:/ window 10,10
+1020.3 "Scorched Pinion" sync / 1[56]:[^:]*:Phoenix-Egi:BA0:/
+1022.1 "Revelation" sync / 1[56]:[^:]*:Phoenix:B87:/ window 10,10
 1024.3 "Fountain Tick 2"
-1026.4 "Scorched Pinion" #sync / 1[56]:Phoenix-Egi:BA0:/
+1026.4 "Scorched Pinion" #sync / 1[56]:[^:]*:Phoenix-Egi:BA0:/
 1029.3 "Fountain Tick 3"
-1032.8 "Scorched Pinion" #sync / 1[56]:Phoenix-Egi:BA1:/
+1032.8 "Scorched Pinion" #sync / 1[56]:[^:]*:Phoenix-Egi:BA1:/
 1034.3 "Fountain Tick 4"
-1038.2 "Scorched Pinion" #sync / 1[56]:Phoenix-Egi:BA0:/
+1038.2 "Scorched Pinion" #sync / 1[56]:[^:]*:Phoenix-Egi:BA0:/
 1039.3 "Fountain Tick 5"
-1044.2 "Scorched Pinion" #sync / 1[56]:Phoenix-Egi:BA0:/
-1044.2 "Flames Of Unforgiveness" sync / 1[56]:Phoenix:B8B:/ window 10,10
+1044.2 "Scorched Pinion" #sync / 1[56]:[^:]*:Phoenix-Egi:BA0:/
+1044.2 "Flames Of Unforgiveness" sync / 1[56]:[^:]*:Phoenix:B8B:/ window 10,10
 1044.4 "Fountain Tick 6"
 1049.5 "Fountain Tick 7"
-1050.8 "Scorched Pinion" #sync / 1[56]:Phoenix-Egi:BA1:/
+1050.8 "Scorched Pinion" #sync / 1[56]:[^:]*:Phoenix-Egi:BA1:/
 1054.6 "Fountain Tick 8"
-1059.4 "Flames Of Rebirth" sync / 1[56]:Phoenix:B9A:/ window 10,10
+1059.4 "Flames Of Rebirth" sync / 1[56]:[^:]*:Phoenix:B9A:/ window 10,10
 
 # Fountain 2
-1066.6 "Fountain Of Fire" sync / 1[56]:Phoenix:B9C:/
-1069.6 "Summon" sync / 1[56]:Phoenix:B9F:/
+1066.6 "Fountain Of Fire" sync / 1[56]:[^:]*:Phoenix:B9C:/
+1069.6 "Summon" sync / 1[56]:[^:]*:Phoenix:B9F:/
 1074.8 "Fountain Tick 1"
-1075.8 "Scorched Pinion" #sync / 1[56]:Phoenix-Egi:BA0:/
-1077.7 "Revelation" sync / 1[56]:Phoenix:B87:/ window 10,10
+1075.8 "Scorched Pinion" #sync / 1[56]:[^:]*:Phoenix-Egi:BA0:/
+1077.7 "Revelation" sync / 1[56]:[^:]*:Phoenix:B87:/ window 10,10
 1079.9 "Fountain Tick 2"
-1081.8 "Scorched Pinion" #sync / 1[56]:Phoenix-Egi:BA0:/
+1081.8 "Scorched Pinion" #sync / 1[56]:[^:]*:Phoenix-Egi:BA0:/
 1085.1 "Fountain Tick 3"
-1088.4 "Scorched Pinion" #sync / 1[56]:Phoenix-Egi:BA1:/
+1088.4 "Scorched Pinion" #sync / 1[56]:[^:]*:Phoenix-Egi:BA1:/
 1090.2 "Fountain Tick 4"
-1093.8 "Scorched Pinion" #sync / 1[56]:Phoenix-Egi:BA0:/
+1093.8 "Scorched Pinion" #sync / 1[56]:[^:]*:Phoenix-Egi:BA0:/
 1095.2 "Fountain Tick 5"
-1099.8 "Scorched Pinion" #sync / 1[56]:Phoenix-Egi:BA0:/
-1099.8 "Flames Of Unforgiveness" sync / 1[56]:Phoenix:B8B:/
+1099.8 "Scorched Pinion" #sync / 1[56]:[^:]*:Phoenix-Egi:BA0:/
+1099.8 "Flames Of Unforgiveness" sync / 1[56]:[^:]*:Phoenix:B8B:/
 1100.3 "Fountain Tick 6"
 1105.4 "Fountain Tick 7"
-1106.3 "Scorched Pinion" #sync / 1[56]:Phoenix-Egi:BA1:/
+1106.3 "Scorched Pinion" #sync / 1[56]:[^:]*:Phoenix-Egi:BA1:/
 1110.4 "Fountain Tick 8"
-1115.0 "Flames Of Rebirth" sync / 1[56]:Phoenix:B9A:/
+1115.0 "Flames Of Rebirth" sync / 1[56]:[^:]*:Phoenix:B9A:/
 
 # Dance Minigame
-1117.2 "--sync--" sync / 1[56]:Phoenix:BA2:/
-1118.3 "--sync--" sync / 1[56]:Phoenix:B96:/
-1119.0 "Scorched Pinion" #sync / 1[56]:Phoenix-Egi:BA0:/
-1121.1 "Scorched Pinion" #sync / 1[56]:Phoenix-Egi:BA0:/
-1121.2 "Redfire Plume" #sync / 1[56]:Phoenix:BA3:/
-1123.0 "Scorched Pinion" #sync / 1[56]:Phoenix-Egi:BA0:/
-1125.1 "Scorched Pinion" #sync / 1[56]:Phoenix-Egi:BA0:/
-1125.7 "Scorched Pinion" #sync / 1[56]:Phoenix-Egi:BA1:/
-1127.2 "Scorched Pinion" #sync / 1[56]:Phoenix-Egi:BA0:/
-1127.8 "Scorched Pinion" #sync / 1[56]:Phoenix-Egi:BA1:/
-1129.7 "Scorched Pinion" #sync / 1[56]:Phoenix-Egi:BA1:/
-1131.8 "Scorched Pinion" #sync / 1[56]:Phoenix-Egi:BA1:/
-1133.9 "Scorched Pinion" #sync / 1[56]:Phoenix-Egi:BA1:/
-1137.9 "--sync--" sync / 1[56]:Phoenix:B97:/ window 20,20
+1117.2 "--sync--" sync / 1[56]:[^:]*:Phoenix:BA2:/
+1118.3 "--sync--" sync / 1[56]:[^:]*:Phoenix:B96:/
+1119.0 "Scorched Pinion" #sync / 1[56]:[^:]*:Phoenix-Egi:BA0:/
+1121.1 "Scorched Pinion" #sync / 1[56]:[^:]*:Phoenix-Egi:BA0:/
+1121.2 "Redfire Plume" #sync / 1[56]:[^:]*:Phoenix:BA3:/
+1123.0 "Scorched Pinion" #sync / 1[56]:[^:]*:Phoenix-Egi:BA0:/
+1125.1 "Scorched Pinion" #sync / 1[56]:[^:]*:Phoenix-Egi:BA0:/
+1125.7 "Scorched Pinion" #sync / 1[56]:[^:]*:Phoenix-Egi:BA1:/
+1127.2 "Scorched Pinion" #sync / 1[56]:[^:]*:Phoenix-Egi:BA0:/
+1127.8 "Scorched Pinion" #sync / 1[56]:[^:]*:Phoenix-Egi:BA1:/
+1129.7 "Scorched Pinion" #sync / 1[56]:[^:]*:Phoenix-Egi:BA1:/
+1131.8 "Scorched Pinion" #sync / 1[56]:[^:]*:Phoenix-Egi:BA1:/
+1133.9 "Scorched Pinion" #sync / 1[56]:[^:]*:Phoenix-Egi:BA1:/
+1137.9 "--sync--" sync / 1[56]:[^:]*:Phoenix:B97:/ window 20,20
 
 # Loop
-1143.1 "Fountain Of Fire" sync / 1[56]:Phoenix:B9C:/ window 50,50 jump 1011.1
+1143.1 "Fountain Of Fire" sync / 1[56]:[^:]*:Phoenix:B9C:/ window 50,50 jump 1011.1
 1146.2 "Summon"
 1151.2 "Fountain Tick 1"
 1152.4 "Scorched Pinion"

--- a/ui/raidboss/data/02-arr/raid/t13.txt
+++ b/ui/raidboss/data/02-arr/raid/t13.txt
@@ -9,20 +9,20 @@ hideall "--sync--"
 ### Phase 1: Megaflare Warmup
 0.0 "Start"
 0.0 "--sync--" sync /:Engage!/ window 0,1
-1.0 "--sync--" sync / 1[56]:Bahamut Prime:BAC:/ window 2,1
-7.0 "Flare Breath" sync / 1[56]:Bahamut Prime:BAD:/ window 7,10
-15.1 "Megaflare" sync / 1[56]:Bahamut Prime:BAF:/ window 80,80
-18.8 "MF Spread" #sync / 1[56]:Bahamut Prime:BB0:/
-20.5 "MF Pepperoni" #sync / 1[56]:Bahamut Prime:BB1:/
-22.6 "MF Share" sync / 1[56]:Bahamut Prime:BB2:/
-25.1 "Flare Breath" sync / 1[56]:Bahamut Prime:BAD:/ window 10,5
-33.1 "Flatten" sync / 1[56]:Bahamut Prime:BAE:/ window 30,30
+1.0 "--sync--" sync / 1[56]:[^:]*:Bahamut Prime:BAC:/ window 2,1
+7.0 "Flare Breath" sync / 1[56]:[^:]*:Bahamut Prime:BAD:/ window 7,10
+15.1 "Megaflare" sync / 1[56]:[^:]*:Bahamut Prime:BAF:/ window 80,80
+18.8 "MF Spread" #sync / 1[56]:[^:]*:Bahamut Prime:BB0:/
+20.5 "MF Pepperoni" #sync / 1[56]:[^:]*:Bahamut Prime:BB1:/
+22.6 "MF Share" sync / 1[56]:[^:]*:Bahamut Prime:BB2:/
+25.1 "Flare Breath" sync / 1[56]:[^:]*:Bahamut Prime:BAD:/ window 10,5
+33.1 "Flatten" sync / 1[56]:[^:]*:Bahamut Prime:BAE:/ window 30,30
 35.2 "Flare Breath x3" duration 4
 45.4 "Earth Shaker Marker"
 50.4 "Earth Shaker x3" duration 4
 
-56.6 "Flare Breath" sync / 1[56]:Bahamut Prime:BAD:/
-64.7 "Megaflare" sync / 1[56]:Bahamut Prime:BAF:/ window 80,80
+56.6 "Flare Breath" sync / 1[56]:[^:]*:Bahamut Prime:BAD:/
+64.7 "Megaflare" sync / 1[56]:[^:]*:Bahamut Prime:BAF:/ window 80,80
 68.4 "MF Spread"
 70.1 "MF Pepperoni"
 72.2 "MF Share"
@@ -34,59 +34,59 @@ hideall "--sync--"
 
 
 ### Phase 2 (75%): Flare Star, Rage of Bahamut, Dragons
-195.0 "--sync--" sync / 14:Bahamut Prime:BB9:/ window 200,0
-200.0 "Gigaflare" sync / 1[56]:Bahamut Prime:BB9:/ window 200,5
+195.0 "--sync--" sync / 14:[^:]*:Bahamut Prime:BB9:/ window 200,0
+200.0 "Gigaflare" sync / 1[56]:[^:]*:Bahamut Prime:BB9:/ window 200,5
 
 203.0 "Shadow Add (N)"
-212.3 "Flare Star" sync / 1[56]:Bahamut Prime:BBB:/
+212.3 "Flare Star" sync / 1[56]:[^:]*:Bahamut Prime:BBB:/
 214.1 "(1x Dark Aether Orb)"
-220.5 "Flare Breath" sync / 1[56]:Bahamut Prime:BAD:/
+220.5 "Flare Breath" sync / 1[56]:[^:]*:Bahamut Prime:BAD:/
 226.6 "(3x Dark Aether Orbs)"
-234.5 "Flatten" sync / 1[56]:Bahamut Prime:BAE:/
-237.8 "Flare Breath" sync / 1[56]:Bahamut Prime:BAD:/
+234.5 "Flatten" sync / 1[56]:[^:]*:Bahamut Prime:BAE:/
+237.8 "Flare Breath" sync / 1[56]:[^:]*:Bahamut Prime:BAD:/
 238.4 "(3x Dark Aether Orbs)"
-252.8 "Megaflare" sync / 1[56]:Bahamut Prime:BAF:/
+252.8 "Megaflare" sync / 1[56]:[^:]*:Bahamut Prime:BAF:/
 256.0 "MF Spread"
 258.0 "MF Pepperoni"
 260.3 "MF Share"
-261.9 "MF Tower" sync / 1[56]:Bahamut Prime:BB3:/
-263.0 "Flare Breath" sync / 1[56]:Bahamut Prime:BAD:/
-269.1 "Rage Of Bahamut" sync / 1[56]:Bahamut Prime:BBD:/
+261.9 "MF Tower" sync / 1[56]:[^:]*:Bahamut Prime:BB3:/
+263.0 "Flare Breath" sync / 1[56]:[^:]*:Bahamut Prime:BAD:/
+269.1 "Rage Of Bahamut" sync / 1[56]:[^:]*:Bahamut Prime:BBD:/
 
 270.1 "Shadow Add (SW)"
-278.3 "Flare Star" sync / 1[56]:Bahamut Prime:BBB:/
+278.3 "Flare Star" sync / 1[56]:[^:]*:Bahamut Prime:BBB:/
 280.1 "(3x Dark Aether Orbs)"
-286.5 "Flare Breath" sync / 1[56]:Bahamut Prime:BAD:/
+286.5 "Flare Breath" sync / 1[56]:[^:]*:Bahamut Prime:BAD:/
 292.1 "(3x Dark Aether Orbs)"
-300.5 "Flatten" sync / 1[56]:Bahamut Prime:BAE:/
-303.8 "Flare Breath" sync / 1[56]:Bahamut Prime:BAD:/
+300.5 "Flatten" sync / 1[56]:[^:]*:Bahamut Prime:BAE:/
+303.8 "Flare Breath" sync / 1[56]:[^:]*:Bahamut Prime:BAD:/
 304.6 "(2x Dark Aether Orbs)"
-318.8 "Megaflare" sync / 1[56]:Bahamut Prime:BAF:/
+318.8 "Megaflare" sync / 1[56]:[^:]*:Bahamut Prime:BAF:/
 322.0 "MF Spread"
 324.0 "MF Pepperoni"
 326.3 "MF Share"
-327.9 "MF Tower" sync / 1[56]:Bahamut Prime:BB3:/
-329.0 "Flare Breath" sync / 1[56]:Bahamut Prime:BAD:/
-335.1 "Rage Of Bahamut" sync / 1[56]:Bahamut Prime:BBD:/
+327.9 "MF Tower" sync / 1[56]:[^:]*:Bahamut Prime:BB3:/
+329.0 "Flare Breath" sync / 1[56]:[^:]*:Bahamut Prime:BAD:/
+335.1 "Rage Of Bahamut" sync / 1[56]:[^:]*:Bahamut Prime:BBD:/
 
 336.1 "Shadow Add (SE)"
-344.3 "Flare Star" sync / 1[56]:Bahamut Prime:BBB:/
+344.3 "Flare Star" sync / 1[56]:[^:]*:Bahamut Prime:BBB:/
 346.1 "(3x Dark Aether Orbs)"
-352.5 "Flare Breath" sync / 1[56]:Bahamut Prime:BAD:/
+352.5 "Flare Breath" sync / 1[56]:[^:]*:Bahamut Prime:BAD:/
 358.1 "(3x Dark Aether Orbs)"
-366.5 "Flatten" sync / 1[56]:Bahamut Prime:BAE:/
-369.8 "Flare Breath" sync / 1[56]:Bahamut Prime:BAD:/
+366.5 "Flatten" sync / 1[56]:[^:]*:Bahamut Prime:BAE:/
+369.8 "Flare Breath" sync / 1[56]:[^:]*:Bahamut Prime:BAD:/
 370.6 "(2x Dark Aether Orbs)"
-384.8 "Megaflare" sync / 1[56]:Bahamut Prime:BAF:/
+384.8 "Megaflare" sync / 1[56]:[^:]*:Bahamut Prime:BAF:/
 388.0 "MF Spread"
 390.0 "MF Pepperoni"
 392.3 "MF Share"
-393.9 "MF Tower" sync / 1[56]:Bahamut Prime:BB3:/
-395.0 "Flare Breath" sync / 1[56]:Bahamut Prime:BAD:/
-401.1 "Rage Of Bahamut" sync / 1[56]:Bahamut Prime:BBD:/
+393.9 "MF Tower" sync / 1[56]:[^:]*:Bahamut Prime:BB3:/
+395.0 "Flare Breath" sync / 1[56]:[^:]*:Bahamut Prime:BAD:/
+401.1 "Rage Of Bahamut" sync / 1[56]:[^:]*:Bahamut Prime:BBD:/
 
 402.1 "Shadow Add"
-410.3 "Flare Star" sync / 1[56]:Bahamut Prime:BBB:/ window 50,50 jump 344.3
+410.3 "Flare Star" sync / 1[56]:[^:]*:Bahamut Prime:BBB:/ window 50,50 jump 344.3
 412.1 "(3x Dark Aether Orbs)"
 418.5 "Flare Breath"
 424.1 "(3x Dark Aether Orbs)"
@@ -103,23 +103,23 @@ hideall "--sync--"
 
 
 ### Phase 3 (52%): adds, adds, adds
-495.0 "--sync--" sync / 14:Bahamut Prime:BB9:/ window 290,0
-500.0 "Gigaflare" sync / 1[56]:Bahamut Prime:BB9:/
-505.4 "--sync--" sync / 1[56]:Bahamut Prime:BBE:/
-508.5 "--sync--" sync / 1[56]:Bahamut Prime:BBF:/
-514.7 "Megaflare Dive" sync / 1[56]:Bahamut Prime:BC0:/
-516.6 "Double Dive" sync / 1[56]:The Storm of Meracydia:BC8:/
-517.8 "--sync--" sync / 1[56]:Bahamut Prime:BBE:/
+495.0 "--sync--" sync / 14:[^:]*:Bahamut Prime:BB9:/ window 290,0
+500.0 "Gigaflare" sync / 1[56]:[^:]*:Bahamut Prime:BB9:/
+505.4 "--sync--" sync / 1[56]:[^:]*:Bahamut Prime:BBE:/
+508.5 "--sync--" sync / 1[56]:[^:]*:Bahamut Prime:BBF:/
+514.7 "Megaflare Dive" sync / 1[56]:[^:]*:Bahamut Prime:BC0:/
+516.6 "Double Dive" sync / 1[56]:[^:]*:The Storm of Meracydia:BC8:/
+517.8 "--sync--" sync / 1[56]:[^:]*:Bahamut Prime:BBE:/
 518.7 "MF Spread"
 520.9 "MF Pepperoni"
 523.0 "MF Share"
 525.1 "Blood, Pain Adds (E/W)"
 545.5 "3x Gust Adds"
 571.2 "2x Sin Adds (N/S)"
-599.7 "--sync--" sync / 1[56]:Bahamut Prime:BBF:/
-605.8 "Megaflare Dive" sync / 1[56]:Bahamut Prime:BC0:/
-607.7 "Double Dive" sync / 1[56]:The Storm of Meracydia:BC8:/
-608.9 "--sync--" sync / 1[56]:Bahamut Prime:BBE:/
+599.7 "--sync--" sync / 1[56]:[^:]*:Bahamut Prime:BBF:/
+605.8 "Megaflare Dive" sync / 1[56]:[^:]*:Bahamut Prime:BC0:/
+607.7 "Double Dive" sync / 1[56]:[^:]*:The Storm of Meracydia:BC8:/
+608.9 "--sync--" sync / 1[56]:[^:]*:Bahamut Prime:BBE:/
 609.8 "MF Spread"
 612.0 "MF Pepperoni"
 614.1 "MF Share"
@@ -128,112 +128,112 @@ hideall "--sync--"
 641.1 "2x Gust Adds (S)"
 651.6 "Sin Add (E)"
 672.2 "Pain Add (W)"
-692.8 "--sync--" sync / 1[56]:Bahamut Prime:BBF:/
-698.9 "Megaflare Dive" sync / 1[56]:Bahamut Prime:BC0:/
-702.1 "--sync--" sync / 1[56]:Bahamut Prime:BB  E:/
+692.8 "--sync--" sync / 1[56]:[^:]*:Bahamut Prime:BBF:/
+698.9 "Megaflare Dive" sync / 1[56]:[^:]*:Bahamut Prime:BC0:/
+702.1 "--sync--" sync / 1[56]:[^:]*:Bahamut Prime:BB  E:/
 702.9 "MF Spread"
 705.1 "MF Pepperoni"
 707.2 "MF Share"
-725.4 "Teraflare" sync / 1[56]:Bahamut Prime:BC1:/ window 700,700
+725.4 "Teraflare" sync / 1[56]:[^:]*:Bahamut Prime:BC1:/ window 700,700
 
 
 ### Phase 4: Akh Morns, Tempest Wings
-735.6 "--sync--" sync / 1[56]:Bahamut Prime:BBE:/
-737.8 "--sync--" sync / 1[56]:Bahamut Prime:BBF:/
+735.6 "--sync--" sync / 1[56]:[^:]*:Bahamut Prime:BBE:/
+737.8 "--sync--" sync / 1[56]:[^:]*:Bahamut Prime:BBF:/
 
-745.1 "Akh Morn x2" sync / 1[56]:Bahamut Prime:BC2:/ window 40,40 duration 2.1
-759.5 "Megaflare" sync / 1[56]:Bahamut Prime:BAF:/
+745.1 "Akh Morn x2" sync / 1[56]:[^:]*:Bahamut Prime:BC2:/ window 40,40 duration 2.1
+759.5 "Megaflare" sync / 1[56]:[^:]*:Bahamut Prime:BAF:/
 764.6 "MF Pepperoni"
-766.6 "Tempest Wing" sync / 1[56]:Bahamut Prime:BC4:/
-767.3 "MF Share" sync / 1[56]:Bahamut Prime:BB2:/
-767.9 "--sync--" sync / 1[56]:Bahamut Prime:C89:/ # Tempest Wing Gust?
-768.6 "MF Tower(s)" sync / 1[56]:Bahamut Prime:BB3:/
+766.6 "Tempest Wing" sync / 1[56]:[^:]*:Bahamut Prime:BC4:/
+767.3 "MF Share" sync / 1[56]:[^:]*:Bahamut Prime:BB2:/
+767.9 "--sync--" sync / 1[56]:[^:]*:Bahamut Prime:C89:/ # Tempest Wing Gust?
+768.6 "MF Tower(s)" sync / 1[56]:[^:]*:Bahamut Prime:BB3:/
 781.7 "Earth Shaker Marker"
 786.7 "Earth Shaker x3" duration 4
 787.7 "Tempest Wing Tethers"
-793.7 "Tempest Wing" sync / 1[56]:Bahamut Prime:BC4:/
-794.9 "--sync--" sync / 1[56]:Bahamut Prime:C89:/
-795.9 "Flare Breath" sync / 1[56]:Bahamut Prime:BAD:/
+793.7 "Tempest Wing" sync / 1[56]:[^:]*:Bahamut Prime:BC4:/
+794.9 "--sync--" sync / 1[56]:[^:]*:Bahamut Prime:C89:/
+795.9 "Flare Breath" sync / 1[56]:[^:]*:Bahamut Prime:BAD:/
 
-807.1 "Akh Morn x3" sync / 1[56]:Bahamut Prime:BC2:/ window 40,40 duration 3.1
-822.3 "Megaflare" sync / 1[56]:Bahamut Prime:BAF:/
+807.1 "Akh Morn x3" sync / 1[56]:[^:]*:Bahamut Prime:BC2:/ window 40,40 duration 3.1
+822.3 "Megaflare" sync / 1[56]:[^:]*:Bahamut Prime:BAF:/
 827.4 "MF Pepperoni"
-829.4 "Tempest Wing" sync / 1[56]:Bahamut Prime:BC4:/
-830.1 "MF Share" sync / 1[56]:Bahamut Prime:BB2:/
-830.7 "--sync--" sync / 1[56]:Bahamut Prime:C89:/
-831.4 "MF Tower(s)" sync / 1[56]:Bahamut Prime:BB3:/
+829.4 "Tempest Wing" sync / 1[56]:[^:]*:Bahamut Prime:BC4:/
+830.1 "MF Share" sync / 1[56]:[^:]*:Bahamut Prime:BB2:/
+830.7 "--sync--" sync / 1[56]:[^:]*:Bahamut Prime:C89:/
+831.4 "MF Tower(s)" sync / 1[56]:[^:]*:Bahamut Prime:BB3:/
 844.5 "Earth Shaker Marker"
 849.5 "Earth Shaker x3" duration 4
 850.5 "Tempest Wing Tethers"
-856.5 "Tempest Wing" sync / 1[56]:Bahamut Prime:BC4:/
-857.7 "--sync--" sync / 1[56]:Bahamut Prime:C89:/
-858.7 "Flare Breath" sync / 1[56]:Bahamut Prime:BAD:/
+856.5 "Tempest Wing" sync / 1[56]:[^:]*:Bahamut Prime:BC4:/
+857.7 "--sync--" sync / 1[56]:[^:]*:Bahamut Prime:C89:/
+858.7 "Flare Breath" sync / 1[56]:[^:]*:Bahamut Prime:BAD:/
 
-871.4 "Gigaflare" sync / 1[56]:Bahamut Prime:BB9:/ window 100,100
+871.4 "Gigaflare" sync / 1[56]:[^:]*:Bahamut Prime:BB9:/ window 100,100
 
-880.8 "Akh Morn x4" sync / 1[56]:Bahamut Prime:BC2:/ window 40,40 duration 4.1
-897.2 "Megaflare" sync / 1[56]:Bahamut Prime:BAF:/
+880.8 "Akh Morn x4" sync / 1[56]:[^:]*:Bahamut Prime:BC2:/ window 40,40 duration 4.1
+897.2 "Megaflare" sync / 1[56]:[^:]*:Bahamut Prime:BAF:/
 902.3 "MF Pepperoni"
-904.3 "Tempest Wing" sync / 1[56]:Bahamut Prime:BC4:/
-905.0 "MF Share" sync / 1[56]:Bahamut Prime:BB2:/
-905.6 "--sync--" sync / 1[56]:Bahamut Prime:C89:/
-906.3 "MF Tower(s)" sync / 1[56]:Bahamut Prime:BB3:/
+904.3 "Tempest Wing" sync / 1[56]:[^:]*:Bahamut Prime:BC4:/
+905.0 "MF Share" sync / 1[56]:[^:]*:Bahamut Prime:BB2:/
+905.6 "--sync--" sync / 1[56]:[^:]*:Bahamut Prime:C89:/
+906.3 "MF Tower(s)" sync / 1[56]:[^:]*:Bahamut Prime:BB3:/
 919.4 "Earth Shaker Marker"
 924.4 "Earth Shaker x3" duration 4
 925.4 "Tempest Wing Tethers"
-931.4 "Tempest Wing" sync / 1[56]:Bahamut Prime:BC4:/
-932.6 "--sync--" sync / 1[56]:Bahamut Prime:C89:/
-933.6 "Flare Breath" sync / 1[56]:Bahamut Prime:BAD:/
+931.4 "Tempest Wing" sync / 1[56]:[^:]*:Bahamut Prime:BC4:/
+932.6 "--sync--" sync / 1[56]:[^:]*:Bahamut Prime:C89:/
+933.6 "Flare Breath" sync / 1[56]:[^:]*:Bahamut Prime:BAD:/
 
-944.8 "Akh Morn x5" sync / 1[56]:Bahamut Prime:BC2:/ window 40,40 duration 5.1
-962.2 "Megaflare" sync / 1[56]:Bahamut Prime:BAF:/
+944.8 "Akh Morn x5" sync / 1[56]:[^:]*:Bahamut Prime:BC2:/ window 40,40 duration 5.1
+962.2 "Megaflare" sync / 1[56]:[^:]*:Bahamut Prime:BAF:/
 967.3 "MF Pepperoni"
-969.3 "Tempest Wing" sync / 1[56]:Bahamut Prime:BC4:/
-970.0 "MF Share" sync / 1[56]:Bahamut Prime:BB2:/
-970.6 "--sync--" sync / 1[56]:Bahamut Prime:C89:/
-971.3 "MF Tower(s)" sync / 1[56]:Bahamut Prime:BB3:/
+969.3 "Tempest Wing" sync / 1[56]:[^:]*:Bahamut Prime:BC4:/
+970.0 "MF Share" sync / 1[56]:[^:]*:Bahamut Prime:BB2:/
+970.6 "--sync--" sync / 1[56]:[^:]*:Bahamut Prime:C89:/
+971.3 "MF Tower(s)" sync / 1[56]:[^:]*:Bahamut Prime:BB3:/
 984.4 "Earth Shaker Marker"
 989.4 "Earth Shaker x3" duration 4
 990.4 "Tempest Wing Tethers"
-996.4 "Tempest Wing" sync / 1[56]:Bahamut Prime:BC4:/
-997.6 "--sync--" sync / 1[56]:Bahamut Prime:C89:/
-998.6 "Flare Breath" sync / 1[56]:Bahamut Prime:BAD:/
+996.4 "Tempest Wing" sync / 1[56]:[^:]*:Bahamut Prime:BC4:/
+997.6 "--sync--" sync / 1[56]:[^:]*:Bahamut Prime:C89:/
+998.6 "Flare Breath" sync / 1[56]:[^:]*:Bahamut Prime:BAD:/
 
-1011.3 "Gigaflare" sync / 1[56]:Bahamut Prime:BB9:/ window 100,100
+1011.3 "Gigaflare" sync / 1[56]:[^:]*:Bahamut Prime:BB9:/ window 100,100
 
-1020.7 "Akh Morn x6" sync / 1[56]:Bahamut Prime:BC2:/ window 40,40 duration 6.1
-1039.1 "Megaflare" sync / 1[56]:Bahamut Prime:BAF:/
+1020.7 "Akh Morn x6" sync / 1[56]:[^:]*:Bahamut Prime:BC2:/ window 40,40 duration 6.1
+1039.1 "Megaflare" sync / 1[56]:[^:]*:Bahamut Prime:BAF:/
 1044.2 "MF Pepperoni"
-1046.2 "Tempest Wing" sync / 1[56]:Bahamut Prime:BC4:/
-1046.9 "MF Share" sync / 1[56]:Bahamut Prime:BB2:/
-1047.5 "--sync--" sync / 1[56]:Bahamut Prime:C89:/
-1048.2 "MF Tower(s)" sync / 1[56]:Bahamut Prime:BB3:/
+1046.2 "Tempest Wing" sync / 1[56]:[^:]*:Bahamut Prime:BC4:/
+1046.9 "MF Share" sync / 1[56]:[^:]*:Bahamut Prime:BB2:/
+1047.5 "--sync--" sync / 1[56]:[^:]*:Bahamut Prime:C89:/
+1048.2 "MF Tower(s)" sync / 1[56]:[^:]*:Bahamut Prime:BB3:/
 1061.3 "Earth Shaker Marker"
 1066.3 "Earth Shaker x3" duration 4
 1067.3 "Tempest Wing Tethers"
-1073.3 "Tempest Wing" sync / 1[56]:Bahamut Prime:BC4:/
-1074.5 "--sync--" sync / 1[56]:Bahamut Prime:C89:/
-1075.5 "Flare Breath" sync / 1[56]:Bahamut Prime:BAD:/
+1073.3 "Tempest Wing" sync / 1[56]:[^:]*:Bahamut Prime:BC4:/
+1074.5 "--sync--" sync / 1[56]:[^:]*:Bahamut Prime:C89:/
+1075.5 "Flare Breath" sync / 1[56]:[^:]*:Bahamut Prime:BAD:/
 
-1086.7 "Akh Morn x7" sync / 1[56]:Bahamut Prime:BC2:/ window 40,40 duration 7.1
-1106.1 "Megaflare" sync / 1[56]:Bahamut Prime:BAF:/
+1086.7 "Akh Morn x7" sync / 1[56]:[^:]*:Bahamut Prime:BC2:/ window 40,40 duration 7.1
+1106.1 "Megaflare" sync / 1[56]:[^:]*:Bahamut Prime:BAF:/
 1111.2 "MF Pepperoni"
-1113.2 "Tempest Wing" sync / 1[56]:Bahamut Prime:BC4:/
-1113.9 "MF Share" sync / 1[56]:Bahamut Prime:BB2:/
-1114.5 "--sync--" sync / 1[56]:Bahamut Prime:C89:/
-1115.2 "MF Tower(s)" sync / 1[56]:Bahamut Prime:BB3:/
+1113.2 "Tempest Wing" sync / 1[56]:[^:]*:Bahamut Prime:BC4:/
+1113.9 "MF Share" sync / 1[56]:[^:]*:Bahamut Prime:BB2:/
+1114.5 "--sync--" sync / 1[56]:[^:]*:Bahamut Prime:C89:/
+1115.2 "MF Tower(s)" sync / 1[56]:[^:]*:Bahamut Prime:BB3:/
 1128.3 "Earth Shaker Marker"
 1133.3 "Earth Shaker x3" duration 4
 1134.3 "Tempest Wing Tethers"
-1140.3 "Tempest Wing" sync / 1[56]:Bahamut Prime:BC4:/
-1141.5 "--sync--" sync / 1[56]:Bahamut Prime:C89:/
-1142.5 "Flare Breath" sync / 1[56]:Bahamut Prime:BAD:/
+1140.3 "Tempest Wing" sync / 1[56]:[^:]*:Bahamut Prime:BC4:/
+1141.5 "--sync--" sync / 1[56]:[^:]*:Bahamut Prime:C89:/
+1142.5 "Flare Breath" sync / 1[56]:[^:]*:Bahamut Prime:BAD:/
 
-1155.2 "Gigaflare" sync / 1[56]:Bahamut Prime:BB9:/ window 100,100
+1155.2 "Gigaflare" sync / 1[56]:[^:]*:Bahamut Prime:BB9:/ window 100,100
 
 
 ### Enrage
-2000.0 "--sync--" sync / 14:Bahamut Prime:BBA:/ window 2000,2000
+2000.0 "--sync--" sync / 14:[^:]*:Bahamut Prime:BBA:/ window 2000,2000
 2010.0 "Gigaflare Enrage"
 2025.2 "Gigaflare Enrage"
 2037.4 "Gigaflare Enrage"

--- a/ui/raidboss/data/02-arr/raid/t4.txt
+++ b/ui/raidboss/data/02-arr/raid/t4.txt
@@ -22,7 +22,7 @@
 303.0 "Rook (NE)"
 303.0 "2x Bug (SE/NW)"
 
-423.0 "Emergency Override" sync / 1[56]:Drive Cylinder:4EA:/ window 500,500
+423.0 "Emergency Override" sync / 1[56]:[^:]*:Drive Cylinder:4EA:/ window 500,500
 427.0 "Emergency Override"
 431.0 "Emergency Override"
 435.0 "Emergency Override"

--- a/ui/raidboss/data/02-arr/raid/t5.txt
+++ b/ui/raidboss/data/02-arr/raid/t5.txt
@@ -14,35 +14,35 @@ hideall "--sync--"
 0.0 "Start"
 0.0 "--sync--" sync /:Engage!/ window 0,1
 0.0 "--sync--" sync / 00:0839::The Right Hand of Bahamut will be sealed off/ window 10,10
-7.5 "Plummet" sync / 1[56]:Twintania:4D8:/ window 10,5
-21.6 "Death Sentence" sync / 1[56]:Twintania:5B2:/ window 22,10
-25.7 "Plummet" sync / 1[56]:Twintania:4D8:/
-38.4 "Plummet" sync / 1[56]:Twintania:4D8:/
-51.8 "Plummet" sync / 1[56]:Twintania:4D8:/
-57.9 "Death Sentence" sync / 1[56]:Twintania:5B2:/ window 22,10
-65.3 "Plummet" sync / 1[56]:Twintania:4D8:/
+7.5 "Plummet" sync / 1[56]:[^:]*:Twintania:4D8:/ window 10,5
+21.6 "Death Sentence" sync / 1[56]:[^:]*:Twintania:5B2:/ window 22,10
+25.7 "Plummet" sync / 1[56]:[^:]*:Twintania:4D8:/
+38.4 "Plummet" sync / 1[56]:[^:]*:Twintania:4D8:/
+51.8 "Plummet" sync / 1[56]:[^:]*:Twintania:4D8:/
+57.9 "Death Sentence" sync / 1[56]:[^:]*:Twintania:5B2:/ window 22,10
+65.3 "Plummet" sync / 1[56]:[^:]*:Twintania:4D8:/
 # ???
 
 
 ### Phase 2
-200.0 "--sync--" sync / 1[56]:Twintania:5AC:/ window 200,0
-205.0 "Fireball" sync / 1[56]:Twintania:4DE:/
-219.0 "Firestorm" sync / 1[56]:Twintania:5AB:/
-229.3 "Fireball" sync / 1[56]:Twintania:4DE:/
-254.9 "Fireball" sync / 1[56]:Twintania:4DE:/
-257.4 "Firestorm" sync / 1[56]:Twintania:5AB:/
-280.0 "Fireball" sync / 1[56]:Twintania:4DE:/
+200.0 "--sync--" sync / 1[56]:[^:]*:Twintania:5AC:/ window 200,0
+205.0 "Fireball" sync / 1[56]:[^:]*:Twintania:4DE:/
+219.0 "Firestorm" sync / 1[56]:[^:]*:Twintania:5AB:/
+229.3 "Fireball" sync / 1[56]:[^:]*:Twintania:4DE:/
+254.9 "Fireball" sync / 1[56]:[^:]*:Twintania:4DE:/
+257.4 "Firestorm" sync / 1[56]:[^:]*:Twintania:5AB:/
+280.0 "Fireball" sync / 1[56]:[^:]*:Twintania:4DE:/
 # ???
 
 ### Phase 3
-400.0 "Divebomb" sync / 1[56]:Twintania:5B0:/ window 400,0
-407.9 "Divebomb" sync / 1[56]:Twintania:5B0:/
-415.6 "Divebomb" sync / 1[56]:Twintania:5B0:/
+400.0 "Divebomb" sync / 1[56]:[^:]*:Twintania:5B0:/ window 400,0
+407.9 "Divebomb" sync / 1[56]:[^:]*:Twintania:5B0:/
+415.6 "Divebomb" sync / 1[56]:[^:]*:Twintania:5B0:/
 419.6 "1x Asclepius add"
 419.6 "2x Hygieia adds"
-465.3 "Divebomb" sync / 1[56]:Twintania:5B0:/ window 30,5
-473.0 "Divebomb" sync / 1[56]:Twintania:5B0:/
-480.9 "Divebomb" sync / 1[56]:Twintania:5B0:/
+465.3 "Divebomb" sync / 1[56]:[^:]*:Twintania:5B0:/ window 30,5
+473.0 "Divebomb" sync / 1[56]:[^:]*:Twintania:5B0:/
+480.9 "Divebomb" sync / 1[56]:[^:]*:Twintania:5B0:/
 484.9 "2x Hygieia adds"
 
 
@@ -53,20 +53,20 @@ hideall "--sync--"
 # weird.  Having twister timers seems nice though, even if it's not perfect.
 
 546.0 "--targetable--"
-600.0 "Aetheric Profusion" sync / 1[56]:Twintania:4E0:/ window 600,0
-616.0 "Unwoven Will" sync / 1[56]:Twintania:4E3:/ window 50,20
-637.8 "Twister" sync / 1[56]:Twintania:4E1:/
-656.2 "Unwoven Will" sync / 1[56]:Twintania:4E3:/ window 30,30
-664.6 "Twister" sync / 1[56]:Twintania:4E1:/
-685.8 "Twister" sync / 1[56]:Twintania:4E1:/
+600.0 "Aetheric Profusion" sync / 1[56]:[^:]*:Twintania:4E0:/ window 600,0
+616.0 "Unwoven Will" sync / 1[56]:[^:]*:Twintania:4E3:/ window 50,20
+637.8 "Twister" sync / 1[56]:[^:]*:Twintania:4E1:/
+656.2 "Unwoven Will" sync / 1[56]:[^:]*:Twintania:4E3:/ window 30,30
+664.6 "Twister" sync / 1[56]:[^:]*:Twintania:4E1:/
+685.8 "Twister" sync / 1[56]:[^:]*:Twintania:4E1:/
 
-696.0 "Unwoven Will" sync / 1[56]:Twintania:4E3:/ window 30,30
-711.0 "Twister" sync / 1[56]:Twintania:4E1:/
-736.2 "Unwoven Will" sync / 1[56]:Twintania:4E3:/ window 30,30
-744.6 "Twister" sync / 1[56]:Twintania:4E1:/
-765.8 "Twister" sync / 1[56]:Twintania:4E1:/
+696.0 "Unwoven Will" sync / 1[56]:[^:]*:Twintania:4E3:/ window 30,30
+711.0 "Twister" sync / 1[56]:[^:]*:Twintania:4E1:/
+736.2 "Unwoven Will" sync / 1[56]:[^:]*:Twintania:4E3:/ window 30,30
+744.6 "Twister" sync / 1[56]:[^:]*:Twintania:4E1:/
+765.8 "Twister" sync / 1[56]:[^:]*:Twintania:4E1:/
 
-776.0 "Unwoven Will" sync / 1[56]:Twintania:4E3:/ window 30,30 jump 696
+776.0 "Unwoven Will" sync / 1[56]:[^:]*:Twintania:4E3:/ window 30,30 jump 696
 791.0 "Twister"
 816.2 "Unwoven Will"
 824.6 "Twister"
@@ -74,10 +74,10 @@ hideall "--sync--"
 
 
 ### Phase 5
-900.0 "Hatch" sync / 1[56]:Twintania:5AD:/ window 900,0
-904.0 "Liquid Hell" sync / 1[56]:Twintania:5B1:/ duration 8 window 200,200
-912.5 "Hatch" sync / 1[56]:Twintania:5AD:/
-921.0 "Hatch" sync / 1[56]:Twintania:5AD:/
+900.0 "Hatch" sync / 1[56]:[^:]*:Twintania:5AD:/ window 900,0
+904.0 "Liquid Hell" sync / 1[56]:[^:]*:Twintania:5B1:/ duration 8 window 200,200
+912.5 "Hatch" sync / 1[56]:[^:]*:Twintania:5AD:/
+921.0 "Hatch" sync / 1[56]:[^:]*:Twintania:5AD:/
 922.0 "Liquid Hell"
 930.5 "Hatch"
 939.0 "Hatch"
@@ -88,7 +88,7 @@ hideall "--sync--"
 
 ### Enrage
 # There's also plummets in here on a different timer.
-1000 "Aetheric Profusion" sync / 1[56]:Twintania:4E0:/ window 399,100
+1000 "Aetheric Profusion" sync / 1[56]:[^:]*:Twintania:4E0:/ window 399,100
 1006 "Aetheric Profusion"
 1012 "Aetheric Profusion"
 1018 "Aetheric Profusion"

--- a/ui/raidboss/data/02-arr/raid/t6.txt
+++ b/ui/raidboss/data/02-arr/raid/t6.txt
@@ -10,27 +10,27 @@ hideall "--sync--"
 0.0 "Start"
 0.0 "--sync--" sync /:Engage!/ window 0,1
 0.0 "--sync--" sync / 00:0839::Scar's Edge will be sealed off/ window 10,10
-7.5 "Bloody Caress" sync / 1[56]:Rafflesia:797:/ window 8,8
-11.5 "Thorn Whip" sync / 1[56]:Rafflesia:879:/
-18.5 "Briary Growth" sync / 1[56]:Rafflesia:884:/ window 20,20
-20.6 "Bloody Caress" sync / 1[56]:Rafflesia:797:/
-28.6 "Thorn Whip" sync / 1[56]:Rafflesia:879:/
-35.3 "Floral Trap" sync / 1[56]:Rafflesia:799:/
-37.4 "Devour" sync / 1[56]:Rafflesia:79A:/
-42.5 "Spit" sync / 1[56]:Rafflesia:79B:/
-46.6 "Bloody Caress" sync / 1[56]:Rafflesia:797:/
-55.6 "Thorn Whip" sync / 1[56]:Rafflesia:879:/
-58.7 "Bloody Caress" sync / 1[56]:Rafflesia:797:/
-63.6 "Briary Growth" sync / 1[56]:Rafflesia:884:/ window 20,20
-70.8 "Bloody Caress" sync / 1[56]:Rafflesia:797:/
-73.7 "Thorn Whip" sync / 1[56]:Rafflesia:879:/
-80.5 "Floral Trap" sync / 1[56]:Rafflesia:799:/
-82.5 "Devour" sync / 1[56]:Rafflesia:79A:/
-87.6 "Spit" sync / 1[56]:Rafflesia:79B:/
+7.5 "Bloody Caress" sync / 1[56]:[^:]*:Rafflesia:797:/ window 8,8
+11.5 "Thorn Whip" sync / 1[56]:[^:]*:Rafflesia:879:/
+18.5 "Briary Growth" sync / 1[56]:[^:]*:Rafflesia:884:/ window 20,20
+20.6 "Bloody Caress" sync / 1[56]:[^:]*:Rafflesia:797:/
+28.6 "Thorn Whip" sync / 1[56]:[^:]*:Rafflesia:879:/
+35.3 "Floral Trap" sync / 1[56]:[^:]*:Rafflesia:799:/
+37.4 "Devour" sync / 1[56]:[^:]*:Rafflesia:79A:/
+42.5 "Spit" sync / 1[56]:[^:]*:Rafflesia:79B:/
+46.6 "Bloody Caress" sync / 1[56]:[^:]*:Rafflesia:797:/
+55.6 "Thorn Whip" sync / 1[56]:[^:]*:Rafflesia:879:/
+58.7 "Bloody Caress" sync / 1[56]:[^:]*:Rafflesia:797:/
+63.6 "Briary Growth" sync / 1[56]:[^:]*:Rafflesia:884:/ window 20,20
+70.8 "Bloody Caress" sync / 1[56]:[^:]*:Rafflesia:797:/
+73.7 "Thorn Whip" sync / 1[56]:[^:]*:Rafflesia:879:/
+80.5 "Floral Trap" sync / 1[56]:[^:]*:Rafflesia:799:/
+82.5 "Devour" sync / 1[56]:[^:]*:Rafflesia:79A:/
+87.6 "Spit" sync / 1[56]:[^:]*:Rafflesia:79B:/
 
-96.9 "Bloody Caress" sync / 1[56]:Rafflesia:797:/
-100.9 "Thorn Whip" sync / 1[56]:Rafflesia:879:/
-107.9 "Briary Growth" sync / 1[56]:Rafflesia:884:/ window 20,20 jump 18.5
+96.9 "Bloody Caress" sync / 1[56]:[^:]*:Rafflesia:797:/
+100.9 "Thorn Whip" sync / 1[56]:[^:]*:Rafflesia:879:/
+107.9 "Briary Growth" sync / 1[56]:[^:]*:Rafflesia:884:/ window 20,20 jump 18.5
 110.0 "Bloody Caress"
 118.0 "Thorn Whip"
 124.7 "Floral Trap"
@@ -41,29 +41,29 @@ hideall "--sync--"
 ### Phase 2
 # There is a Bloody Caress (often?) right at the start of this phase before blighted.
 # But it's hard to sync to it properly, sorry.
-200.0 "--sync--" sync / 14:Rafflesia:79D:/ window 200,0
-204.0 "Blighted Bouquet" sync / 1[56]:Rafflesia:79D:/
-209.0 "Briary Growth" sync / 1[56]:Rafflesia:884:/ window 20,20
-214.1 "Bloody Caress" sync / 1[56]:Rafflesia:797:/
-219.0 "Thorn Whip" sync / 1[56]:Rafflesia:879:/
-225.8 "Floral Trap" sync / 1[56]:Rafflesia:799:/
-227.8 "Devour" sync / 1[56]:Rafflesia:79A:/
-232.8 "Spit" sync / 1[56]:Rafflesia:79B:/
-235.8 "Viscid Emission" sync / 1[56]:Rafflesia:79C:/
-240.9 "Bloody Caress" sync / 1[56]:Rafflesia:797:/
-244.9 "Thorn Whip" sync / 1[56]:Rafflesia:879:/
-254.0 "Blighted Bouquet" sync / 1[56]:Rafflesia:79D:/
-258.2 "Bloody Caress" sync / 1[56]:Rafflesia:797:/
-260.1 "Briary Growth" sync / 1[56]:Rafflesia:884:/ window 20,20
-269.2 "Thorn Whip" sync / 1[56]:Rafflesia:879:/
-275.5 "Floral Trap" sync / 1[56]:Rafflesia:799:/
-277.5 "Devour" sync / 1[56]:Rafflesia:79A:/
-282.5 "Spit" sync / 1[56]:Rafflesia:79B:/
-285.3 "Bloody Caress" sync / 1[56]:Rafflesia:797:/
-294.2 "Thorn Whip" sync / 1[56]:Rafflesia:879:/
-297.5 "Bloody Caress" sync / 1[56]:Rafflesia:797:/
+200.0 "--sync--" sync / 14:[^:]*:Rafflesia:79D:/ window 200,0
+204.0 "Blighted Bouquet" sync / 1[56]:[^:]*:Rafflesia:79D:/
+209.0 "Briary Growth" sync / 1[56]:[^:]*:Rafflesia:884:/ window 20,20
+214.1 "Bloody Caress" sync / 1[56]:[^:]*:Rafflesia:797:/
+219.0 "Thorn Whip" sync / 1[56]:[^:]*:Rafflesia:879:/
+225.8 "Floral Trap" sync / 1[56]:[^:]*:Rafflesia:799:/
+227.8 "Devour" sync / 1[56]:[^:]*:Rafflesia:79A:/
+232.8 "Spit" sync / 1[56]:[^:]*:Rafflesia:79B:/
+235.8 "Viscid Emission" sync / 1[56]:[^:]*:Rafflesia:79C:/
+240.9 "Bloody Caress" sync / 1[56]:[^:]*:Rafflesia:797:/
+244.9 "Thorn Whip" sync / 1[56]:[^:]*:Rafflesia:879:/
+254.0 "Blighted Bouquet" sync / 1[56]:[^:]*:Rafflesia:79D:/
+258.2 "Bloody Caress" sync / 1[56]:[^:]*:Rafflesia:797:/
+260.1 "Briary Growth" sync / 1[56]:[^:]*:Rafflesia:884:/ window 20,20
+269.2 "Thorn Whip" sync / 1[56]:[^:]*:Rafflesia:879:/
+275.5 "Floral Trap" sync / 1[56]:[^:]*:Rafflesia:799:/
+277.5 "Devour" sync / 1[56]:[^:]*:Rafflesia:79A:/
+282.5 "Spit" sync / 1[56]:[^:]*:Rafflesia:79B:/
+285.3 "Bloody Caress" sync / 1[56]:[^:]*:Rafflesia:797:/
+294.2 "Thorn Whip" sync / 1[56]:[^:]*:Rafflesia:879:/
+297.5 "Bloody Caress" sync / 1[56]:[^:]*:Rafflesia:797:/
 
-304.4 "Blighted Bouquet" sync / 1[56]:Rafflesia:79D:/ window 30,30 jump 204
+304.4 "Blighted Bouquet" sync / 1[56]:[^:]*:Rafflesia:79D:/ window 30,30 jump 204
 309.4 "Briary Growth"
 314.5 "Bloody Caress"
 319.4 "Thorn Whip"
@@ -75,32 +75,32 @@ hideall "--sync--"
 ### Phase 3
 # This ignores dinky leafstorms that do like 200 damage.
 
-400.0 "--sync--" sync / 14:Rafflesia:79E:/ window 400,0
-403.0 "Leafstorm" sync / 1[56]:Rafflesia:79E:/
-413.1 "Acid Rain" sync / 1[56]:Rafflesia:86C:/
-420.3 "Thorn Whip" sync / 1[56]:Rafflesia:879:/
-432.4 "Swarm" sync / 1[56]:Rafflesia:7A0:/
-445.5 "Thorn Whip" sync / 1[56]:Rafflesia:879:/
-450.3 "Rotten Stench" sync / 1[56]:Rafflesia:7A2:/
-465.5 "Swarm" sync / 1[56]:Rafflesia:7A0:/
-478.5 "Thorn Whip" sync / 1[56]:Rafflesia:879:/
-490.7 "Swarm" sync / 1[56]:Rafflesia:7A0:/
-495.6 "Thorn Whip" sync / 1[56]:Rafflesia:879:/
-500.1 "Rotten Stench" sync / 1[56]:Rafflesia:7A2:/
+400.0 "--sync--" sync / 14:[^:]*:Rafflesia:79E:/ window 400,0
+403.0 "Leafstorm" sync / 1[56]:[^:]*:Rafflesia:79E:/
+413.1 "Acid Rain" sync / 1[56]:[^:]*:Rafflesia:86C:/
+420.3 "Thorn Whip" sync / 1[56]:[^:]*:Rafflesia:879:/
+432.4 "Swarm" sync / 1[56]:[^:]*:Rafflesia:7A0:/
+445.5 "Thorn Whip" sync / 1[56]:[^:]*:Rafflesia:879:/
+450.3 "Rotten Stench" sync / 1[56]:[^:]*:Rafflesia:7A2:/
+465.5 "Swarm" sync / 1[56]:[^:]*:Rafflesia:7A0:/
+478.5 "Thorn Whip" sync / 1[56]:[^:]*:Rafflesia:879:/
+490.7 "Swarm" sync / 1[56]:[^:]*:Rafflesia:7A0:/
+495.6 "Thorn Whip" sync / 1[56]:[^:]*:Rafflesia:879:/
+500.1 "Rotten Stench" sync / 1[56]:[^:]*:Rafflesia:7A2:/
 
 # looping leafstorm (the first one has swarm later)
-523.2 "Leafstorm" sync / 1[56]:Rafflesia:79E:/ window 100,300
-528.4 "Swarm" sync / 1[56]:Rafflesia:7A0:/
-537.3 "Acid Rain" sync / 1[56]:Rafflesia:86C:/
-544.4 "Thorn Whip" sync / 1[56]:Rafflesia:879:/
-556.7 "Swarm" sync / 1[56]:Rafflesia:7A0:/
-569.6 "Thorn Whip" sync / 1[56]:Rafflesia:879:/
-574.4 "Rotten Stench" sync / 1[56]:Rafflesia:7A2:/
-589.7 "Swarm" sync / 1[56]:Rafflesia:7A0:/
-602.7 "Thorn Whip" sync / 1[56]:Rafflesia:879:/
-614.8 "Swarm" sync / 1[56]:Rafflesia:7A0:/
-619.7 "Thorn Whip" sync / 1[56]:Rafflesia:879:/
-624.5 "Rotten Stench" sync / 1[56]:Rafflesia:7A2:/
+523.2 "Leafstorm" sync / 1[56]:[^:]*:Rafflesia:79E:/ window 100,300
+528.4 "Swarm" sync / 1[56]:[^:]*:Rafflesia:7A0:/
+537.3 "Acid Rain" sync / 1[56]:[^:]*:Rafflesia:86C:/
+544.4 "Thorn Whip" sync / 1[56]:[^:]*:Rafflesia:879:/
+556.7 "Swarm" sync / 1[56]:[^:]*:Rafflesia:7A0:/
+569.6 "Thorn Whip" sync / 1[56]:[^:]*:Rafflesia:879:/
+574.4 "Rotten Stench" sync / 1[56]:[^:]*:Rafflesia:7A2:/
+589.7 "Swarm" sync / 1[56]:[^:]*:Rafflesia:7A0:/
+602.7 "Thorn Whip" sync / 1[56]:[^:]*:Rafflesia:879:/
+614.8 "Swarm" sync / 1[56]:[^:]*:Rafflesia:7A0:/
+619.7 "Thorn Whip" sync / 1[56]:[^:]*:Rafflesia:879:/
+624.5 "Rotten Stench" sync / 1[56]:[^:]*:Rafflesia:7A2:/
 
 647.6 "Leafstorm"
 652.8 "Swarm"
@@ -119,8 +119,8 @@ hideall "--sync--"
 # This does like 60k damage so probably will kill you
 # if you are so slow to see it, but just for completeness
 # it repeats every five seconds.
-1000.0 "--sync--" sync / 14:Rafflesia:87A:/ window 1000,1000
-1003.0 "Leafstorm" sync / 1[56]:Rafflesia:87A:/
+1000.0 "--sync--" sync / 14:[^:]*:Rafflesia:87A:/ window 1000,1000
+1003.0 "Leafstorm" sync / 1[56]:[^:]*:Rafflesia:87A:/
 1008.0 "Leafstorm"
 1013.0 "Leafstorm"
 1018.0 "Leafstorm"

--- a/ui/raidboss/data/02-arr/raid/t7.txt
+++ b/ui/raidboss/data/02-arr/raid/t7.txt
@@ -9,268 +9,268 @@ hideall "--sync--"
 ### Phase 1 (100%)
 0.0 "--sync--" sync /:Engage!/ window 0,1
 0.0 "--sync--" sync / 00:0839::Bioweapon Storage will be sealed off/ window 10,10
-6.4 "Tail Slap" sync / 1[56]:Melusine:7A8:/ window 7,0
-12.3 "Cursed Voice" sync / 1[56]:Melusine:7AC:/
-14.3 "Circle Of Flames x2" #sync / 1[56]:Melusine:7AA:/
-24.8 "Circle Blade" sync / 1[56]:Melusine:7AB:/
-26.5 "Tail Slap" sync / 1[56]:Melusine:7A8:/
-30.3 "Circle Of Flames x2" #sync / 1[56]:Melusine:7AA:/
-36.4 "Cursed Voice" sync / 1[56]:Melusine:7AC:/
-42.5 "Tail Slap" sync / 1[56]:Melusine:7A8:/
-48.8 "Circle Blade" sync / 1[56]:Melusine:7AB:/
-50.5 "Circle Of Flames x2" #sync / 1[56]:Melusine:7AA:/
-60.4 "Cursed Voice" sync / 1[56]:Melusine:7AC:/
-61.5 "Tail Slap" sync / 1[56]:Melusine:7A8:/
-66.3 "Circle Of Flames x2" #sync / 1[56]:Melusine:7AA:/
-72.7 "Circle Blade" sync / 1[56]:Melusine:7AB:/
-77.5 "Tail Slap" sync / 1[56]:Melusine:7A8:/
-82.3 "Circle Of Flames x2" #sync / 1[56]:Melusine:7AA:/
-86.6 "Cursed Voice" sync / 1[56]:Melusine:7AC:/
-93.6 "Tail Slap" sync / 1[56]:Melusine:7A8:/
-97.1 "Circle Blade" sync / 1[56]:Melusine:7AB:/
-99.1 "Circle Of Flames x2" #sync / 1[56]:Melusine:7AA:/
-110.7 "Cursed Voice" sync / 1[56]:Melusine:7AC:/
-111.8 "Tail Slap" sync / 1[56]:Melusine:7A8:/
-114.8 "Circle Of Flames x2" #sync / 1[56]:Melusine:7AA:/
-121.2 "Circle Blade" sync / 1[56]:Melusine:7AB:/
-127.8 "Tail Slap" sync / 1[56]:Melusine:7A8:/
-130.8 "Circle Of Flames x2" #sync / 1[56]:Melusine:7AA:/
-135.1 "Cursed Voice" sync / 1[56]:Melusine:7AC:/
-145.3 "Circle Blade" sync / 1[56]:Melusine:7AB:/
-147.3 "Tail Slap" sync / 1[56]:Melusine:7A8:/
-148.4 "Circle Of Flames x2" #sync / 1[56]:Melusine:7AA:/
-159.2 "Cursed Voice" sync / 1[56]:Melusine:7AC:/
-163.1 "Tail Slap" sync / 1[56]:Melusine:7A8:/
-164.2 "Circle Of Flames x2" #sync / 1[56]:Melusine:7AA:/
-169.1 "Circle Blade" sync / 1[56]:Melusine:7AB:/
-179.1 "Tail Slap" sync / 1[56]:Melusine:7A8:/
-180.2 "Circle Of Flames x2" #sync / 1[56]:Melusine:7AA:/
-184.5 "Cursed Voice" sync / 1[56]:Melusine:7AC:/
-193.3 "Circle Blade" sync / 1[56]:Melusine:7AB:/
-195.2 "Tail Slap" sync / 1[56]:Melusine:7A8:/
-196.6 "Circle Of Flames x2" #sync / 1[56]:Melusine:7AA:/
+6.4 "Tail Slap" sync / 1[56]:[^:]*:Melusine:7A8:/ window 7,0
+12.3 "Cursed Voice" sync / 1[56]:[^:]*:Melusine:7AC:/
+14.3 "Circle Of Flames x2" #sync / 1[56]:[^:]*:Melusine:7AA:/
+24.8 "Circle Blade" sync / 1[56]:[^:]*:Melusine:7AB:/
+26.5 "Tail Slap" sync / 1[56]:[^:]*:Melusine:7A8:/
+30.3 "Circle Of Flames x2" #sync / 1[56]:[^:]*:Melusine:7AA:/
+36.4 "Cursed Voice" sync / 1[56]:[^:]*:Melusine:7AC:/
+42.5 "Tail Slap" sync / 1[56]:[^:]*:Melusine:7A8:/
+48.8 "Circle Blade" sync / 1[56]:[^:]*:Melusine:7AB:/
+50.5 "Circle Of Flames x2" #sync / 1[56]:[^:]*:Melusine:7AA:/
+60.4 "Cursed Voice" sync / 1[56]:[^:]*:Melusine:7AC:/
+61.5 "Tail Slap" sync / 1[56]:[^:]*:Melusine:7A8:/
+66.3 "Circle Of Flames x2" #sync / 1[56]:[^:]*:Melusine:7AA:/
+72.7 "Circle Blade" sync / 1[56]:[^:]*:Melusine:7AB:/
+77.5 "Tail Slap" sync / 1[56]:[^:]*:Melusine:7A8:/
+82.3 "Circle Of Flames x2" #sync / 1[56]:[^:]*:Melusine:7AA:/
+86.6 "Cursed Voice" sync / 1[56]:[^:]*:Melusine:7AC:/
+93.6 "Tail Slap" sync / 1[56]:[^:]*:Melusine:7A8:/
+97.1 "Circle Blade" sync / 1[56]:[^:]*:Melusine:7AB:/
+99.1 "Circle Of Flames x2" #sync / 1[56]:[^:]*:Melusine:7AA:/
+110.7 "Cursed Voice" sync / 1[56]:[^:]*:Melusine:7AC:/
+111.8 "Tail Slap" sync / 1[56]:[^:]*:Melusine:7A8:/
+114.8 "Circle Of Flames x2" #sync / 1[56]:[^:]*:Melusine:7AA:/
+121.2 "Circle Blade" sync / 1[56]:[^:]*:Melusine:7AB:/
+127.8 "Tail Slap" sync / 1[56]:[^:]*:Melusine:7A8:/
+130.8 "Circle Of Flames x2" #sync / 1[56]:[^:]*:Melusine:7AA:/
+135.1 "Cursed Voice" sync / 1[56]:[^:]*:Melusine:7AC:/
+145.3 "Circle Blade" sync / 1[56]:[^:]*:Melusine:7AB:/
+147.3 "Tail Slap" sync / 1[56]:[^:]*:Melusine:7A8:/
+148.4 "Circle Of Flames x2" #sync / 1[56]:[^:]*:Melusine:7AA:/
+159.2 "Cursed Voice" sync / 1[56]:[^:]*:Melusine:7AC:/
+163.1 "Tail Slap" sync / 1[56]:[^:]*:Melusine:7A8:/
+164.2 "Circle Of Flames x2" #sync / 1[56]:[^:]*:Melusine:7AA:/
+169.1 "Circle Blade" sync / 1[56]:[^:]*:Melusine:7AB:/
+179.1 "Tail Slap" sync / 1[56]:[^:]*:Melusine:7A8:/
+180.2 "Circle Of Flames x2" #sync / 1[56]:[^:]*:Melusine:7AA:/
+184.5 "Cursed Voice" sync / 1[56]:[^:]*:Melusine:7AC:/
+193.3 "Circle Blade" sync / 1[56]:[^:]*:Melusine:7AB:/
+195.2 "Tail Slap" sync / 1[56]:[^:]*:Melusine:7A8:/
+196.6 "Circle Of Flames x2" #sync / 1[56]:[^:]*:Melusine:7AA:/
 
 ### Phase 2 (80%): shriek, 3 adds 30 seconds apart
 # Note: This used to be synced from a HP% log line that is no longer present.
-306.6 "Tail Slap" sync / 1[56]:Melusine:7A8:/ window 10,10
-345.6 "Cursed Voice" sync / 1[56]:Melusine:7AC:/ window 155,10
-314.6 "Circle Of Flames x2" #sync / 1[56]:Melusine:7AA:/
-319.0 "Cursed Shriek" sync / 1[56]:Melusine:7AF:/ window 319,30 duration 11
-322.6 "Tail Slap" sync / 1[56]:Melusine:7A8:/
-328.2 "Circle Blade" sync / 1[56]:Melusine:7AB:/
+306.6 "Tail Slap" sync / 1[56]:[^:]*:Melusine:7A8:/ window 10,10
+345.6 "Cursed Voice" sync / 1[56]:[^:]*:Melusine:7AC:/ window 155,10
+314.6 "Circle Of Flames x2" #sync / 1[56]:[^:]*:Melusine:7AA:/
+319.0 "Cursed Shriek" sync / 1[56]:[^:]*:Melusine:7AF:/ window 319,30 duration 11
+322.6 "Tail Slap" sync / 1[56]:[^:]*:Melusine:7A8:/
+328.2 "Circle Blade" sync / 1[56]:[^:]*:Melusine:7AB:/
 330.0 "Deathdancer Add (NE)"
-330.7 "Circle Of Flames x2" #sync / 1[56]:Melusine:7AA:/
-336.6 "Cursed Voice" sync / 1[56]:Melusine:7AC:/
-338.8 "Tail Slap" sync / 1[56]:Melusine:7A8:/
-346.7 "Circle Of Flames x2" #sync / 1[56]:Melusine:7AA:/
+330.7 "Circle Of Flames x2" #sync / 1[56]:[^:]*:Melusine:7AA:/
+336.6 "Cursed Voice" sync / 1[56]:[^:]*:Melusine:7AC:/
+338.8 "Tail Slap" sync / 1[56]:[^:]*:Melusine:7A8:/
+346.7 "Circle Of Flames x2" #sync / 1[56]:[^:]*:Melusine:7AA:/
 
-354.6 "Tail Slap" sync / 1[56]:Melusine:7A8:/
+354.6 "Tail Slap" sync / 1[56]:[^:]*:Melusine:7A8:/
 360.0 "Deathdancer Add (NW)"
-360.8 "Cursed Voice" sync / 1[56]:Melusine:7AC:/
-362.6 "Circle Of Flames x2" #sync / 1[56]:Melusine:7AA:/
-366.8 "Cursed Shriek" sync / 1[56]:Melusine:7AF:/ duration 11
-370.7 "Tail Slap" sync / 1[56]:Melusine:7A8:/
-374.5 "Circle Blade" sync / 1[56]:Melusine:7AB:/
-378.8 "Circle Of Flames x2" #sync / 1[56]:Melusine:7AA:/
-384.8 "Cursed Voice" sync / 1[56]:Melusine:7AC:/
-386.8 "Tail Slap" sync / 1[56]:Melusine:7A8:/
-394.7 "Circle Of Flames x2" #sync / 1[56]:Melusine:7AA:/
+360.8 "Cursed Voice" sync / 1[56]:[^:]*:Melusine:7AC:/
+362.6 "Circle Of Flames x2" #sync / 1[56]:[^:]*:Melusine:7AA:/
+366.8 "Cursed Shriek" sync / 1[56]:[^:]*:Melusine:7AF:/ duration 11
+370.7 "Tail Slap" sync / 1[56]:[^:]*:Melusine:7A8:/
+374.5 "Circle Blade" sync / 1[56]:[^:]*:Melusine:7AB:/
+378.8 "Circle Of Flames x2" #sync / 1[56]:[^:]*:Melusine:7AA:/
+384.8 "Cursed Voice" sync / 1[56]:[^:]*:Melusine:7AC:/
+386.8 "Tail Slap" sync / 1[56]:[^:]*:Melusine:7A8:/
+394.7 "Circle Of Flames x2" #sync / 1[56]:[^:]*:Melusine:7AA:/
 
-402.8 "Tail Slap" sync / 1[56]:Melusine:7A8:/
-408.8 "Cursed Voice" sync / 1[56]:Melusine:7AC:/
-410.8 "Circle Of Flames x2" #sync / 1[56]:Melusine:7AA:/
-415.0 "Cursed Shriek" sync / 1[56]:Melusine:7AF:/ duration 11
-420.3 "Circle Blade" sync / 1[56]:Melusine:7AB:/
-422.1 "Tail Slap" sync / 1[56]:Melusine:7A8:/
-426.8 "Circle Of Flames x2" #sync / 1[56]:Melusine:7AA:/
-432.8 "Cursed Voice" sync / 1[56]:Melusine:7AC:/
-438.0 "Tail Slap" sync / 1[56]:Melusine:7A8:/
-442.8 "Circle Of Flames x2" #sync / 1[56]:Melusine:7AA:/
+402.8 "Tail Slap" sync / 1[56]:[^:]*:Melusine:7A8:/
+408.8 "Cursed Voice" sync / 1[56]:[^:]*:Melusine:7AC:/
+410.8 "Circle Of Flames x2" #sync / 1[56]:[^:]*:Melusine:7AA:/
+415.0 "Cursed Shriek" sync / 1[56]:[^:]*:Melusine:7AF:/ duration 11
+420.3 "Circle Blade" sync / 1[56]:[^:]*:Melusine:7AB:/
+422.1 "Tail Slap" sync / 1[56]:[^:]*:Melusine:7A8:/
+426.8 "Circle Of Flames x2" #sync / 1[56]:[^:]*:Melusine:7AA:/
+432.8 "Cursed Voice" sync / 1[56]:[^:]*:Melusine:7AC:/
+438.0 "Tail Slap" sync / 1[56]:[^:]*:Melusine:7A8:/
+442.8 "Circle Of Flames x2" #sync / 1[56]:[^:]*:Melusine:7AA:/
 
-454.2 "Tail Slap" sync / 1[56]:Melusine:7A8:/
-457.3 "Cursed Voice" sync / 1[56]:Melusine:7AC:/
-459.0 "Circle Of Flames x2" #sync / 1[56]:Melusine:7AA:/
-463.2 "Cursed Shriek" sync / 1[56]:Melusine:7AF:/ duration 11
-466.9 "Circle Blade" sync / 1[56]:Melusine:7AB:/
-470.2 "Tail Slap" sync / 1[56]:Melusine:7A8:/
-475.0 "Circle Of Flames x2" #sync / 1[56]:Melusine:7AA:/
-481.4 "Cursed Voice" sync / 1[56]:Melusine:7AC:/
-486.2 "Tail Slap" sync / 1[56]:Melusine:7A8:/
-491.1 "Circle Of Flames x2" #sync / 1[56]:Melusine:7AA:/
+454.2 "Tail Slap" sync / 1[56]:[^:]*:Melusine:7A8:/
+457.3 "Cursed Voice" sync / 1[56]:[^:]*:Melusine:7AC:/
+459.0 "Circle Of Flames x2" #sync / 1[56]:[^:]*:Melusine:7AA:/
+463.2 "Cursed Shriek" sync / 1[56]:[^:]*:Melusine:7AF:/ duration 11
+466.9 "Circle Blade" sync / 1[56]:[^:]*:Melusine:7AB:/
+470.2 "Tail Slap" sync / 1[56]:[^:]*:Melusine:7A8:/
+475.0 "Circle Of Flames x2" #sync / 1[56]:[^:]*:Melusine:7AA:/
+481.4 "Cursed Voice" sync / 1[56]:[^:]*:Melusine:7AC:/
+486.2 "Tail Slap" sync / 1[56]:[^:]*:Melusine:7A8:/
+491.1 "Circle Of Flames x2" #sync / 1[56]:[^:]*:Melusine:7AA:/
 
-502.2 "Tail Slap" sync / 1[56]:Melusine:7A8:/
-505.5 "Cursed Voice" sync / 1[56]:Melusine:7AC:/
-507.2 "Circle Of Flames x2" #sync / 1[56]:Melusine:7AA:/
-511.4 "Cursed Shriek" sync / 1[56]:Melusine:7AF:/ duration 11
-515.1 "Circle Blade" sync / 1[56]:Melusine:7AB:/
-518.3 "Tail Slap" sync / 1[56]:Melusine:7A8:/
-523.2 "Circle Of Flames x2" #sync / 1[56]:Melusine:7AA:/
-529.5 "Cursed Voice" sync / 1[56]:Melusine:7AC:/
-534.4 "Tail Slap" sync / 1[56]:Melusine:7A8:/
-539.2 "Circle Of Flames x2" #sync / 1[56]:Melusine:7AA:/
+502.2 "Tail Slap" sync / 1[56]:[^:]*:Melusine:7A8:/
+505.5 "Cursed Voice" sync / 1[56]:[^:]*:Melusine:7AC:/
+507.2 "Circle Of Flames x2" #sync / 1[56]:[^:]*:Melusine:7AA:/
+511.4 "Cursed Shriek" sync / 1[56]:[^:]*:Melusine:7AF:/ duration 11
+515.1 "Circle Blade" sync / 1[56]:[^:]*:Melusine:7AB:/
+518.3 "Tail Slap" sync / 1[56]:[^:]*:Melusine:7A8:/
+523.2 "Circle Of Flames x2" #sync / 1[56]:[^:]*:Melusine:7AA:/
+529.5 "Cursed Voice" sync / 1[56]:[^:]*:Melusine:7AC:/
+534.4 "Tail Slap" sync / 1[56]:[^:]*:Melusine:7A8:/
+539.2 "Circle Of Flames x2" #sync / 1[56]:[^:]*:Melusine:7AA:/
 
 
 ### Phase 3 (59%): 4 archer adds, exploding floor
 # Note: This used to be synced from a HP% log line that is no longer present.
-812.0 "Cursed Voice" sync / 1[56]:Melusine:7AC:/ window 12,10
-814.0 "Circle Of Flames x2" #sync / 1[56]:Melusine:7AA:/
+812.0 "Cursed Voice" sync / 1[56]:[^:]*:Melusine:7AC:/ window 12,10
+814.0 "Circle Of Flames x2" #sync / 1[56]:[^:]*:Melusine:7AA:/
 
-820.1 "Red Lotus Blade" sync / 1[56]:Melusine:7A9:/ window 820,20
-822.1 "Tail Slap" sync / 1[56]:Melusine:7A8:/
-830.2 "Circle Of Flames x2" #sync / 1[56]:Melusine:7AA:/
-836.1 "Cursed Voice" sync / 1[56]:Melusine:7AC:/
-840.2 "Tail Slap" sync / 1[56]:Melusine:7A8:/
-843.3 "Cursed Shriek" sync / 1[56]:Melusine:7AF:/
-846.3 "Circle Of Flames x2" #sync / 1[56]:Melusine:7AA:/
+820.1 "Red Lotus Blade" sync / 1[56]:[^:]*:Melusine:7A9:/ window 820,20
+822.1 "Tail Slap" sync / 1[56]:[^:]*:Melusine:7A8:/
+830.2 "Circle Of Flames x2" #sync / 1[56]:[^:]*:Melusine:7AA:/
+836.1 "Cursed Voice" sync / 1[56]:[^:]*:Melusine:7AC:/
+840.2 "Tail Slap" sync / 1[56]:[^:]*:Melusine:7A8:/
+843.3 "Cursed Shriek" sync / 1[56]:[^:]*:Melusine:7AF:/
+846.3 "Circle Of Flames x2" #sync / 1[56]:[^:]*:Melusine:7AA:/
 
-852.2 "Red Lotus Blade" sync / 1[56]:Melusine:7A9:/
-854.3 "Tail Slap" sync / 1[56]:Melusine:7A8:/
-860.2 "Cursed Voice" sync / 1[56]:Melusine:7AC:/
-862.2 "Circle Of Flames x2" #sync / 1[56]:Melusine:7AA:/
-870.3 "Tail Slap" sync / 1[56]:Melusine:7A8:/
-878.4 "Circle Of Flames x2" #sync / 1[56]:Melusine:7AA:/
-884.3 "Cursed Voice" sync / 1[56]:Melusine:7AC:/
+852.2 "Red Lotus Blade" sync / 1[56]:[^:]*:Melusine:7A9:/
+854.3 "Tail Slap" sync / 1[56]:[^:]*:Melusine:7A8:/
+860.2 "Cursed Voice" sync / 1[56]:[^:]*:Melusine:7AC:/
+862.2 "Circle Of Flames x2" #sync / 1[56]:[^:]*:Melusine:7AA:/
+870.3 "Tail Slap" sync / 1[56]:[^:]*:Melusine:7A8:/
+878.4 "Circle Of Flames x2" #sync / 1[56]:[^:]*:Melusine:7AA:/
+884.3 "Cursed Voice" sync / 1[56]:[^:]*:Melusine:7AC:/
 
-885.4 "Red Lotus Blade" sync / 1[56]:Melusine:7A9:/
-886.5 "Tail Slap" sync / 1[56]:Melusine:7A8:/
-890.5 "Cursed Shriek" sync / 1[56]:Melusine:7AF:/
-894.4 "Circle Of Flames x2" #sync / 1[56]:Melusine:7AA:/
-902.8 "Tail Slap" sync / 1[56]:Melusine:7A8:/
-908.3 "Cursed Voice" sync / 1[56]:Melusine:7AC:/
-910.5 "Circle Of Flames x2" #sync / 1[56]:Melusine:7AA:/
+885.4 "Red Lotus Blade" sync / 1[56]:[^:]*:Melusine:7A9:/
+886.5 "Tail Slap" sync / 1[56]:[^:]*:Melusine:7A8:/
+890.5 "Cursed Shriek" sync / 1[56]:[^:]*:Melusine:7AF:/
+894.4 "Circle Of Flames x2" #sync / 1[56]:[^:]*:Melusine:7AA:/
+902.8 "Tail Slap" sync / 1[56]:[^:]*:Melusine:7A8:/
+908.3 "Cursed Voice" sync / 1[56]:[^:]*:Melusine:7AC:/
+910.5 "Circle Of Flames x2" #sync / 1[56]:[^:]*:Melusine:7AA:/
 
-917.5 "Red Lotus Blade" sync / 1[56]:Melusine:7A9:/
-918.7 "Tail Slap" sync / 1[56]:Melusine:7A8:/
-926.6 "Circle Of Flames x2" #sync / 1[56]:Melusine:7AA:/
-932.5 "Cursed Voice" sync / 1[56]:Melusine:7AC:/
-934.8 "Tail Slap" sync / 1[56]:Melusine:7A8:/
-937.8 "Cursed Shriek" sync / 1[56]:Melusine:7AF:/
-942.7 "Circle Of Flames x2" #sync / 1[56]:Melusine:7AA:/
+917.5 "Red Lotus Blade" sync / 1[56]:[^:]*:Melusine:7A9:/
+918.7 "Tail Slap" sync / 1[56]:[^:]*:Melusine:7A8:/
+926.6 "Circle Of Flames x2" #sync / 1[56]:[^:]*:Melusine:7AA:/
+932.5 "Cursed Voice" sync / 1[56]:[^:]*:Melusine:7AC:/
+934.8 "Tail Slap" sync / 1[56]:[^:]*:Melusine:7A8:/
+937.8 "Cursed Shriek" sync / 1[56]:[^:]*:Melusine:7AF:/
+942.7 "Circle Of Flames x2" #sync / 1[56]:[^:]*:Melusine:7AA:/
 
-949.4 "Red Lotus Blade" sync / 1[56]:Melusine:7A9:/
-950.6 "Tail Slap" sync / 1[56]:Melusine:7A8:/
-956.2 "Cursed Voice" sync / 1[56]:Melusine:7AC:/
-958.4 "Circle Of Flames x2" #sync sync / 1[56]:Melusine:7AA:/
-966.4 "Tail Slap" sync / 1[56]:Melusine:7A8:/
-974.4 "Circle Of Flames x2" #sync sync / 1[56]:Melusine:7AA:/
-980.2 "Cursed Voice" sync / 1[56]:Melusine:7AC:/
+949.4 "Red Lotus Blade" sync / 1[56]:[^:]*:Melusine:7A9:/
+950.6 "Tail Slap" sync / 1[56]:[^:]*:Melusine:7A8:/
+956.2 "Cursed Voice" sync / 1[56]:[^:]*:Melusine:7AC:/
+958.4 "Circle Of Flames x2" #sync sync / 1[56]:[^:]*:Melusine:7AA:/
+966.4 "Tail Slap" sync / 1[56]:[^:]*:Melusine:7A8:/
+974.4 "Circle Of Flames x2" #sync sync / 1[56]:[^:]*:Melusine:7AA:/
+980.2 "Cursed Voice" sync / 1[56]:[^:]*:Melusine:7AC:/
 
-981.5 "Red Lotus Blade" sync / 1[56]:Melusine:7A9:/
-982.6 "Tail Slap" sync / 1[56]:Melusine:7A8:/
-985.7 "Cursed Shriek" sync / 1[56]:Melusine:7AF:/
-990.4 "Circle Of Flames x2" #sync sync / 1[56]:Melusine:7AA:/
-998.6 "Tail Slap" sync / 1[56]:Melusine:7A8:/
-1004.2 "Cursed Voice" sync / 1[56]:Melusine:7AC:/
-1006.4 "Circle Of Flames x2" #sync sync / 1[56]:Melusine:7AA:/
+981.5 "Red Lotus Blade" sync / 1[56]:[^:]*:Melusine:7A9:/
+982.6 "Tail Slap" sync / 1[56]:[^:]*:Melusine:7A8:/
+985.7 "Cursed Shriek" sync / 1[56]:[^:]*:Melusine:7AF:/
+990.4 "Circle Of Flames x2" #sync sync / 1[56]:[^:]*:Melusine:7AA:/
+998.6 "Tail Slap" sync / 1[56]:[^:]*:Melusine:7A8:/
+1004.2 "Cursed Voice" sync / 1[56]:[^:]*:Melusine:7AC:/
+1006.4 "Circle Of Flames x2" #sync sync / 1[56]:[^:]*:Melusine:7AA:/
 
-1013.3 "Red Lotus Blade" sync / 1[56]:Melusine:7A9:/
-1014.6 "Tail Slap" sync / 1[56]:Melusine:7A8:/
-1022.5 "Circle Of Flames x2" #sync sync / 1[56]:Melusine:7AA:/
-1028.3 "Cursed Voice" sync / 1[56]:Melusine:7AC:/
-1030.7 "Tail Slap" sync / 1[56]:Melusine:7A8:/
-1033.8 "Cursed Shriek" sync / 1[56]:Melusine:7AF:/
-1038.5 "Circle Of Flames x2" #sync sync / 1[56]:Melusine:7AA:/
+1013.3 "Red Lotus Blade" sync / 1[56]:[^:]*:Melusine:7A9:/
+1014.6 "Tail Slap" sync / 1[56]:[^:]*:Melusine:7A8:/
+1022.5 "Circle Of Flames x2" #sync sync / 1[56]:[^:]*:Melusine:7AA:/
+1028.3 "Cursed Voice" sync / 1[56]:[^:]*:Melusine:7AC:/
+1030.7 "Tail Slap" sync / 1[56]:[^:]*:Melusine:7A8:/
+1033.8 "Cursed Shriek" sync / 1[56]:[^:]*:Melusine:7AF:/
+1038.5 "Circle Of Flames x2" #sync sync / 1[56]:[^:]*:Melusine:7AA:/
 
-1045.4 "Red Lotus Blade" sync / 1[56]:Melusine:7A9:/
-1046.7 "Tail Slap" sync / 1[56]:Melusine:7A8:/
-1052.3 "Cursed Voice" sync / 1[56]:Melusine:7AC:/
-1054.5 "Circle Of Flames x2" #sync sync / 1[56]:Melusine:7AA:/
-1062.7 "Tail Slap" sync / 1[56]:Melusine:7A8:/
-1070.5 "Circle Of Flames x2" #sync sync / 1[56]:Melusine:7AA:/
-1076.3 "Cursed Voice" sync / 1[56]:Melusine:7AC:/
+1045.4 "Red Lotus Blade" sync / 1[56]:[^:]*:Melusine:7A9:/
+1046.7 "Tail Slap" sync / 1[56]:[^:]*:Melusine:7A8:/
+1052.3 "Cursed Voice" sync / 1[56]:[^:]*:Melusine:7AC:/
+1054.5 "Circle Of Flames x2" #sync sync / 1[56]:[^:]*:Melusine:7AA:/
+1062.7 "Tail Slap" sync / 1[56]:[^:]*:Melusine:7A8:/
+1070.5 "Circle Of Flames x2" #sync sync / 1[56]:[^:]*:Melusine:7AA:/
+1076.3 "Cursed Voice" sync / 1[56]:[^:]*:Melusine:7AC:/
 
-1077.4 "Red Lotus Blade" sync / 1[56]:Melusine:7A9:/
-1078.7 "Tail Slap" sync / 1[56]:Melusine:7A8:/
-1081.8 "Cursed Shriek" sync / 1[56]:Melusine:7AF:/
-1086.7 "Circle Of Flames x2" #sync sync / 1[56]:Melusine:7AA:/
-1094.8 "Tail Slap" sync / 1[56]:Melusine:7A8:/
-1100.4 "Cursed Voice" sync / 1[56]:Melusine:7AC:/
-1102.6 "Circle Of Flames x2" #sync sync / 1[56]:Melusine:7AA:/
+1077.4 "Red Lotus Blade" sync / 1[56]:[^:]*:Melusine:7A9:/
+1078.7 "Tail Slap" sync / 1[56]:[^:]*:Melusine:7A8:/
+1081.8 "Cursed Shriek" sync / 1[56]:[^:]*:Melusine:7AF:/
+1086.7 "Circle Of Flames x2" #sync sync / 1[56]:[^:]*:Melusine:7AA:/
+1094.8 "Tail Slap" sync / 1[56]:[^:]*:Melusine:7A8:/
+1100.4 "Cursed Voice" sync / 1[56]:[^:]*:Melusine:7AC:/
+1102.6 "Circle Of Flames x2" #sync sync / 1[56]:[^:]*:Melusine:7AA:/
 
-1109.5 "Red Lotus Blade" sync / 1[56]:Melusine:7A9:/
-1110.9 "Tail Slap" sync / 1[56]:Melusine:7A8:/
-1118.6 "Circle Of Flames x2" #sync sync / 1[56]:Melusine:7AA:/
-1124.3 "Cursed Voice" sync / 1[56]:Melusine:7AC:/
-1126.7 "Tail Slap" sync / 1[56]:Melusine:7A8:/
-1129.8 "Cursed Shriek" sync / 1[56]:Melusine:7AF:/
-1134.6 "Circle Of Flames x2" #sync sync / 1[56]:Melusine:7AA:/
+1109.5 "Red Lotus Blade" sync / 1[56]:[^:]*:Melusine:7A9:/
+1110.9 "Tail Slap" sync / 1[56]:[^:]*:Melusine:7A8:/
+1118.6 "Circle Of Flames x2" #sync sync / 1[56]:[^:]*:Melusine:7AA:/
+1124.3 "Cursed Voice" sync / 1[56]:[^:]*:Melusine:7AC:/
+1126.7 "Tail Slap" sync / 1[56]:[^:]*:Melusine:7A8:/
+1129.8 "Cursed Shriek" sync / 1[56]:[^:]*:Melusine:7AF:/
+1134.6 "Circle Of Flames x2" #sync sync / 1[56]:[^:]*:Melusine:7AA:/
 
-1141.4 "Red Lotus Blade" sync / 1[56]:Melusine:7A9:/
-1142.7 "Tail Slap" sync / 1[56]:Melusine:7A8:/
-1148.4 "Cursed Voice" sync / 1[56]:Melusine:7AC:/
-1150.6 "Circle Of Flames x2" #sync sync / 1[56]:Melusine:7AA:/
-1158.7 "Tail Slap" sync / 1[56]:Melusine:7A8:/
-1166.6 "Circle Of Flames x2" #sync sync / 1[56]:Melusine:7AA:/
-1172.3 "Cursed Voice" sync / 1[56]:Melusine:7AC:/
+1141.4 "Red Lotus Blade" sync / 1[56]:[^:]*:Melusine:7A9:/
+1142.7 "Tail Slap" sync / 1[56]:[^:]*:Melusine:7A8:/
+1148.4 "Cursed Voice" sync / 1[56]:[^:]*:Melusine:7AC:/
+1150.6 "Circle Of Flames x2" #sync sync / 1[56]:[^:]*:Melusine:7AA:/
+1158.7 "Tail Slap" sync / 1[56]:[^:]*:Melusine:7A8:/
+1166.6 "Circle Of Flames x2" #sync sync / 1[56]:[^:]*:Melusine:7AA:/
+1172.3 "Cursed Voice" sync / 1[56]:[^:]*:Melusine:7AC:/
 
-1173.4 "Red Lotus Blade" sync / 1[56]:Melusine:7A9:/
-1174.7 "Tail Slap" sync / 1[56]:Melusine:7A8:/
-1177.8 "Cursed Shriek" sync / 1[56]:Melusine:7AF:/
-1182.6 "Circle Of Flames x2" #sync sync / 1[56]:Melusine:7AA:/
-1190.9 "Tail Slap" sync / 1[56]:Melusine:7A8:/
-1196.2 "Cursed Voice" sync / 1[56]:Melusine:7AC:/
-1198.6 "Circle Of Flames x2" #sync sync / 1[56]:Melusine:7AA:/
+1173.4 "Red Lotus Blade" sync / 1[56]:[^:]*:Melusine:7A9:/
+1174.7 "Tail Slap" sync / 1[56]:[^:]*:Melusine:7A8:/
+1177.8 "Cursed Shriek" sync / 1[56]:[^:]*:Melusine:7AF:/
+1182.6 "Circle Of Flames x2" #sync sync / 1[56]:[^:]*:Melusine:7AA:/
+1190.9 "Tail Slap" sync / 1[56]:[^:]*:Melusine:7A8:/
+1196.2 "Cursed Voice" sync / 1[56]:[^:]*:Melusine:7AC:/
+1198.6 "Circle Of Flames x2" #sync sync / 1[56]:[^:]*:Melusine:7AA:/
 
 
 ### Phase 5 (post-prosecutor): venomous tail
-1600.0 "Sacrifice" sync / 1[56]:Lamia Prosector:86E:/ window 1600,0
-1601.0 "Frenzy" sync / 1[56]:Melusine:86D:/
+1600.0 "Sacrifice" sync / 1[56]:[^:]*:Lamia Prosector:86E:/ window 1600,0
+1601.0 "Frenzy" sync / 1[56]:[^:]*:Melusine:86D:/
 
-1608.1 "Petrifaction" sync / 1[56]:Melusine:7B1:/ window 1610,5
-1611.3 "Tail Slap" sync / 1[56]:Melusine:7A8:/
-1617.9 "Circle Of Flames x2" #sync / 1[56]:Melusine:7AA:/
-1624.0 "Cursed Voice" sync / 1[56]:Melusine:7AC:/
-1627.1 "Tail Slap" sync / 1[56]:Melusine:7A8:/
-1630.1 "Cursed Shriek" sync / 1[56]:Melusine:7AF:/
-1634.1 "Circle Of Flames x2" #sync / 1[56]:Melusine:7AA:/
-1638.9 "Red Lotus Blade" sync / 1[56]:Melusine:7A9:/
-1643.0 "Venomous Tail" sync / 1[56]:Melusine:7B2:/
-1644.1 "Tail Slap" sync / 1[56]:Melusine:7A8:/
-1647.9 "Cursed Voice" sync / 1[56]:Melusine:7AC:/
-1650.1 "Circle Of Flames x2" #sync / 1[56]:Melusine:7AA:/
+1608.1 "Petrifaction" sync / 1[56]:[^:]*:Melusine:7B1:/ window 1610,5
+1611.3 "Tail Slap" sync / 1[56]:[^:]*:Melusine:7A8:/
+1617.9 "Circle Of Flames x2" #sync / 1[56]:[^:]*:Melusine:7AA:/
+1624.0 "Cursed Voice" sync / 1[56]:[^:]*:Melusine:7AC:/
+1627.1 "Tail Slap" sync / 1[56]:[^:]*:Melusine:7A8:/
+1630.1 "Cursed Shriek" sync / 1[56]:[^:]*:Melusine:7AF:/
+1634.1 "Circle Of Flames x2" #sync / 1[56]:[^:]*:Melusine:7AA:/
+1638.9 "Red Lotus Blade" sync / 1[56]:[^:]*:Melusine:7A9:/
+1643.0 "Venomous Tail" sync / 1[56]:[^:]*:Melusine:7B2:/
+1644.1 "Tail Slap" sync / 1[56]:[^:]*:Melusine:7A8:/
+1647.9 "Cursed Voice" sync / 1[56]:[^:]*:Melusine:7AC:/
+1650.1 "Circle Of Flames x2" #sync / 1[56]:[^:]*:Melusine:7AA:/
 
-1655.3 "Petrifaction" sync / 1[56]:Melusine:7B1:/
-1660.2 "Tail Slap" sync / 1[56]:Melusine:7A8:/
-1666.2 "Circle Of Flames x2" #sync / 1[56]:Melusine:7AA:/
-1672.1 "Cursed Voice" sync / 1[56]:Melusine:7AC:/
-1673.3 "Red Lotus Blade" sync / 1[56]:Melusine:7A9:/
-1677.2 "Cursed Shriek" sync / 1[56]:Melusine:7AF:/
-1678.5 "Tail Slap" sync / 1[56]:Melusine:7A8:/
-1682.2 "Circle Of Flames x2" #sync / 1[56]:Melusine:7AA:/
-1690.2 "Venomous Tail" sync / 1[56]:Melusine:7B2:/
-1696.1 "Cursed Voice" sync / 1[56]:Melusine:7AC:/
-1697.4 "Tail Slap" sync / 1[56]:Melusine:7A8:/
-1698.4 "Circle Of Flames x2" #sync / 1[56]:Melusine:7AA:/
+1655.3 "Petrifaction" sync / 1[56]:[^:]*:Melusine:7B1:/
+1660.2 "Tail Slap" sync / 1[56]:[^:]*:Melusine:7A8:/
+1666.2 "Circle Of Flames x2" #sync / 1[56]:[^:]*:Melusine:7AA:/
+1672.1 "Cursed Voice" sync / 1[56]:[^:]*:Melusine:7AC:/
+1673.3 "Red Lotus Blade" sync / 1[56]:[^:]*:Melusine:7A9:/
+1677.2 "Cursed Shriek" sync / 1[56]:[^:]*:Melusine:7AF:/
+1678.5 "Tail Slap" sync / 1[56]:[^:]*:Melusine:7A8:/
+1682.2 "Circle Of Flames x2" #sync / 1[56]:[^:]*:Melusine:7AA:/
+1690.2 "Venomous Tail" sync / 1[56]:[^:]*:Melusine:7B2:/
+1696.1 "Cursed Voice" sync / 1[56]:[^:]*:Melusine:7AC:/
+1697.4 "Tail Slap" sync / 1[56]:[^:]*:Melusine:7A8:/
+1698.4 "Circle Of Flames x2" #sync / 1[56]:[^:]*:Melusine:7AA:/
 
-1703.5 "Petrifaction" sync / 1[56]:Melusine:7B1:/
-1705.3 "Red Lotus Blade" sync / 1[56]:Melusine:7A9:/
-1713.3 "Tail Slap" sync / 1[56]:Melusine:7A8:/
-1714.4 "Circle Of Flames x2" #sync / 1[56]:Melusine:7AA:/
-1720.2 "Cursed Voice" sync / 1[56]:Melusine:7AC:/
-1724.1 "Cursed Shriek" sync / 1[56]:Melusine:7AF:/
-1729.2 "Tail Slap" sync / 1[56]:Melusine:7A8:/
-1730.5 "Circle Of Flames x2" #sync / 1[56]:Melusine:7AA:/
-1737.2 "Venomous Tail" sync / 1[56]:Melusine:7B2:/
-1740.4 "Red Lotus Blade" sync / 1[56]:Melusine:7A9:/
-1744.2 "Cursed Voice" sync / 1[56]:Melusine:7AC:/
-1746.8 "Tail Slap" sync / 1[56]:Melusine:7A8:/
-1747.9 "Circle Of Flames x2" #sync / 1[56]:Melusine:7AA:/
+1703.5 "Petrifaction" sync / 1[56]:[^:]*:Melusine:7B1:/
+1705.3 "Red Lotus Blade" sync / 1[56]:[^:]*:Melusine:7A9:/
+1713.3 "Tail Slap" sync / 1[56]:[^:]*:Melusine:7A8:/
+1714.4 "Circle Of Flames x2" #sync / 1[56]:[^:]*:Melusine:7AA:/
+1720.2 "Cursed Voice" sync / 1[56]:[^:]*:Melusine:7AC:/
+1724.1 "Cursed Shriek" sync / 1[56]:[^:]*:Melusine:7AF:/
+1729.2 "Tail Slap" sync / 1[56]:[^:]*:Melusine:7A8:/
+1730.5 "Circle Of Flames x2" #sync / 1[56]:[^:]*:Melusine:7AA:/
+1737.2 "Venomous Tail" sync / 1[56]:[^:]*:Melusine:7B2:/
+1740.4 "Red Lotus Blade" sync / 1[56]:[^:]*:Melusine:7A9:/
+1744.2 "Cursed Voice" sync / 1[56]:[^:]*:Melusine:7AC:/
+1746.8 "Tail Slap" sync / 1[56]:[^:]*:Melusine:7A8:/
+1747.9 "Circle Of Flames x2" #sync / 1[56]:[^:]*:Melusine:7AA:/
 
-1752.9 "Petrifaction" sync / 1[56]:Melusine:7B1:/
-1761.4 "Tail Slap" sync / 1[56]:Melusine:7A8:/
-1763.8 "Circle Of Flames x2" #sync / 1[56]:Melusine:7AA:/
-1768.4 "Cursed Voice" sync / 1[56]:Melusine:7AC:/
-1771.5 "Cursed Shriek" sync / 1[56]:Melusine:7AF:/
-1772.8 "Red Lotus Blade" sync / 1[56]:Melusine:7A9:/
-1777.6 "Tail Slap" sync / 1[56]:Melusine:7A8:/
-1780.0 "Circle Of Flames x2" #sync / 1[56]:Melusine:7AA:/
-1785.2 "Venomous Tail" sync / 1[56]:Melusine:7B2:/
-1792.4 "Cursed Voice" sync / 1[56]:Melusine:7AC:/
-1795.9 "Tail Slap" sync / 1[56]:Melusine:7A8:/
-1796.9 "Circle Of Flames x2" #sync / 1[56]:Melusine:7AA:/
+1752.9 "Petrifaction" sync / 1[56]:[^:]*:Melusine:7B1:/
+1761.4 "Tail Slap" sync / 1[56]:[^:]*:Melusine:7A8:/
+1763.8 "Circle Of Flames x2" #sync / 1[56]:[^:]*:Melusine:7AA:/
+1768.4 "Cursed Voice" sync / 1[56]:[^:]*:Melusine:7AC:/
+1771.5 "Cursed Shriek" sync / 1[56]:[^:]*:Melusine:7AF:/
+1772.8 "Red Lotus Blade" sync / 1[56]:[^:]*:Melusine:7A9:/
+1777.6 "Tail Slap" sync / 1[56]:[^:]*:Melusine:7A8:/
+1780.0 "Circle Of Flames x2" #sync / 1[56]:[^:]*:Melusine:7AA:/
+1785.2 "Venomous Tail" sync / 1[56]:[^:]*:Melusine:7B2:/
+1792.4 "Cursed Voice" sync / 1[56]:[^:]*:Melusine:7AC:/
+1795.9 "Tail Slap" sync / 1[56]:[^:]*:Melusine:7A8:/
+1796.9 "Circle Of Flames x2" #sync / 1[56]:[^:]*:Melusine:7AA:/
 
-1802.1 "Petrifaction" sync / 1[56]:Melusine:7B1:/
-1804.9 "Red Lotus Blade" sync / 1[56]:Melusine:7A9:/
-1809.7 "Tail Slap" sync / 1[56]:Melusine:7A8:/
-1813.0 "Circle Of Flames x2" #sync / 1[56]:Melusine:7AA:/
-1817.2 "Cursed Voice" sync / 1[56]:Melusine:7AC:/
+1802.1 "Petrifaction" sync / 1[56]:[^:]*:Melusine:7B1:/
+1804.9 "Red Lotus Blade" sync / 1[56]:[^:]*:Melusine:7A9:/
+1809.7 "Tail Slap" sync / 1[56]:[^:]*:Melusine:7A8:/
+1813.0 "Circle Of Flames x2" #sync / 1[56]:[^:]*:Melusine:7AA:/
+1817.2 "Cursed Voice" sync / 1[56]:[^:]*:Melusine:7AC:/

--- a/ui/raidboss/data/02-arr/raid/t8.txt
+++ b/ui/raidboss/data/02-arr/raid/t8.txt
@@ -13,63 +13,63 @@ hideall "--sync--"
 0.0 "Start"
 0.0 "--sync--" sync /:Engage!/ window 0,1
 0.0 "--sync--" sync / 00:0839::The central bow will be sealed off/ window 10,10
-3.5 "--sync--" sync / 1[56]:The Avatar:7C[01]:/ window 3.5,0
-6.1 "Diffusion Ray" sync / 1[56]:The Avatar:7C2:/ window 7,10
-26.0 "Homing Missile" sync / 1[56]:The Avatar:7C7:/
-27.2 "Diffusion Ray" sync / 1[56]:The Avatar:7C2:/
-34.9 "Gaseous Bomb" sync / 1[56]:The Avatar:7C6:/
-42.2 "Diffusion Ray" sync / 1[56]:The Avatar:7C2:/
-57.3 "Diffusion Ray" sync / 1[56]:The Avatar:7C2:/
-65.9 "Homing Missile" sync / 1[56]:The Avatar:7C7:/
-75.0 "Gaseous Bomb" sync / 1[56]:The Avatar:7C6:/
-76.2 "Diffusion Ray" sync / 1[56]:The Avatar:7C2:/
-91.2 "Diffusion Ray" sync / 1[56]:The Avatar:7C2:/
-106.0 "Homing Missile" sync / 1[56]:The Avatar:7C7:/
-107.2 "Diffusion Ray" sync / 1[56]:The Avatar:7C2:/
-115.0 "Gaseous Bomb" sync / 1[56]:The Avatar:7C6:/
-122.2 "Diffusion Ray" sync / 1[56]:The Avatar:7C2:/
-137.2 "Diffusion Ray" sync / 1[56]:The Avatar:7C2:/
-146.0 "Homing Missile" sync / 1[56]:The Avatar:7C7:/
-155.0 "Gaseous Bomb" sync / 1[56]:The Avatar:7C6:/
-156.2 "Diffusion Ray" sync / 1[56]:The Avatar:7C2:/
+3.5 "--sync--" sync / 1[56]:[^:]*:The Avatar:7C[01]:/ window 3.5,0
+6.1 "Diffusion Ray" sync / 1[56]:[^:]*:The Avatar:7C2:/ window 7,10
+26.0 "Homing Missile" sync / 1[56]:[^:]*:The Avatar:7C7:/
+27.2 "Diffusion Ray" sync / 1[56]:[^:]*:The Avatar:7C2:/
+34.9 "Gaseous Bomb" sync / 1[56]:[^:]*:The Avatar:7C6:/
+42.2 "Diffusion Ray" sync / 1[56]:[^:]*:The Avatar:7C2:/
+57.3 "Diffusion Ray" sync / 1[56]:[^:]*:The Avatar:7C2:/
+65.9 "Homing Missile" sync / 1[56]:[^:]*:The Avatar:7C7:/
+75.0 "Gaseous Bomb" sync / 1[56]:[^:]*:The Avatar:7C6:/
+76.2 "Diffusion Ray" sync / 1[56]:[^:]*:The Avatar:7C2:/
+91.2 "Diffusion Ray" sync / 1[56]:[^:]*:The Avatar:7C2:/
+106.0 "Homing Missile" sync / 1[56]:[^:]*:The Avatar:7C7:/
+107.2 "Diffusion Ray" sync / 1[56]:[^:]*:The Avatar:7C2:/
+115.0 "Gaseous Bomb" sync / 1[56]:[^:]*:The Avatar:7C6:/
+122.2 "Diffusion Ray" sync / 1[56]:[^:]*:The Avatar:7C2:/
+137.2 "Diffusion Ray" sync / 1[56]:[^:]*:The Avatar:7C2:/
+146.0 "Homing Missile" sync / 1[56]:[^:]*:The Avatar:7C7:/
+155.0 "Gaseous Bomb" sync / 1[56]:[^:]*:The Avatar:7C6:/
+156.2 "Diffusion Ray" sync / 1[56]:[^:]*:The Avatar:7C2:/
 
 ### Phase 2 (75%): brainjack + ballistic missile
 # Inertia Stream hits twice 1 second apart.
 # Only sync backwards for this first of three.
-162.6 "Inertia Stream" sync / 1[56]:The Avatar:7C9:/ window 170,0
-168.9 "Ballistic Missile" sync / 1[56]:The Avatar:7CA:/
-176.6 "Diffusion Ray" sync / 1[56]:The Avatar:7C2:/
-184.5 "Brainjack" sync / 1[56]:The Avatar:7C3:/ duration 11
-191.6 "Diffusion Ray" sync / 1[56]:The Avatar:7C2:/
-199.5 "Homing Missile" sync / 1[56]:The Avatar:7C7:/
-206.6 "Diffusion Ray" sync / 1[56]:The Avatar:7C2:/
-215.5 "Gaseous Bomb" sync / 1[56]:The Avatar:7C6:/
-224.6 "Brainjack" sync / 1[56]:The Avatar:7C3:/ duration 11
-225.8 "Diffusion Ray" sync / 1[56]:The Avatar:7C2:/
-239.6 "Homing Missile" sync / 1[56]:The Avatar:7C7:/
-240.9 "Diffusion Ray" sync / 1[56]:The Avatar:7C2:/
+162.6 "Inertia Stream" sync / 1[56]:[^:]*:The Avatar:7C9:/ window 170,0
+168.9 "Ballistic Missile" sync / 1[56]:[^:]*:The Avatar:7CA:/
+176.6 "Diffusion Ray" sync / 1[56]:[^:]*:The Avatar:7C2:/
+184.5 "Brainjack" sync / 1[56]:[^:]*:The Avatar:7C3:/ duration 11
+191.6 "Diffusion Ray" sync / 1[56]:[^:]*:The Avatar:7C2:/
+199.5 "Homing Missile" sync / 1[56]:[^:]*:The Avatar:7C7:/
+206.6 "Diffusion Ray" sync / 1[56]:[^:]*:The Avatar:7C2:/
+215.5 "Gaseous Bomb" sync / 1[56]:[^:]*:The Avatar:7C6:/
+224.6 "Brainjack" sync / 1[56]:[^:]*:The Avatar:7C3:/ duration 11
+225.8 "Diffusion Ray" sync / 1[56]:[^:]*:The Avatar:7C2:/
+239.6 "Homing Missile" sync / 1[56]:[^:]*:The Avatar:7C7:/
+240.9 "Diffusion Ray" sync / 1[56]:[^:]*:The Avatar:7C2:/
 242.0 "Inertia Stream"
-248.3 "Ballistic Missile" sync / 1[56]:The Avatar:7CA:/
-255.6 "Gaseous Bomb" sync / 1[56]:The Avatar:7C6:/
-256.8 "Diffusion Ray" sync / 1[56]:The Avatar:7C2:/
-264.7 "Brainjack" sync / 1[56]:The Avatar:7C3:/ duration 11
-271.7 "Diffusion Ray" sync / 1[56]:The Avatar:7C2:/
-279.6 "Homing Missile" sync / 1[56]:The Avatar:7C7:/
-286.8 "Diffusion Ray" sync / 1[56]:The Avatar:7C2:/
-295.7 "Gaseous Bomb" sync / 1[56]:The Avatar:7C6:/
-304.8 "Brainjack" sync / 1[56]:The Avatar:7C3:/ duration 11
-306.0 "Diffusion Ray" sync / 1[56]:The Avatar:7C2:/
-319.7 "Homing Missile" sync / 1[56]:The Avatar:7C7:/
-321.0 "Diffusion Ray" sync / 1[56]:The Avatar:7C2:/
+248.3 "Ballistic Missile" sync / 1[56]:[^:]*:The Avatar:7CA:/
+255.6 "Gaseous Bomb" sync / 1[56]:[^:]*:The Avatar:7C6:/
+256.8 "Diffusion Ray" sync / 1[56]:[^:]*:The Avatar:7C2:/
+264.7 "Brainjack" sync / 1[56]:[^:]*:The Avatar:7C3:/ duration 11
+271.7 "Diffusion Ray" sync / 1[56]:[^:]*:The Avatar:7C2:/
+279.6 "Homing Missile" sync / 1[56]:[^:]*:The Avatar:7C7:/
+286.8 "Diffusion Ray" sync / 1[56]:[^:]*:The Avatar:7C2:/
+295.7 "Gaseous Bomb" sync / 1[56]:[^:]*:The Avatar:7C6:/
+304.8 "Brainjack" sync / 1[56]:[^:]*:The Avatar:7C3:/ duration 11
+306.0 "Diffusion Ray" sync / 1[56]:[^:]*:The Avatar:7C2:/
+319.7 "Homing Missile" sync / 1[56]:[^:]*:The Avatar:7C7:/
+321.0 "Diffusion Ray" sync / 1[56]:[^:]*:The Avatar:7C2:/
 322.2 "Inertia Stream"
-328.4 "Ballistic Missile" sync / 1[56]:The Avatar:7CA:/
-335.8 "Gaseous Bomb" sync / 1[56]:The Avatar:7C6:/
-337.0 "Diffusion Ray" sync / 1[56]:The Avatar:7C2:/
-344.9 "Brainjack" sync / 1[56]:The Avatar:7C3:/ duration 11
-352.0 "Diffusion Ray" sync / 1[56]:The Avatar:7C2:/
-359.8 "Homing Missile" sync / 1[56]:The Avatar:7C7:/
-367.1 "Diffusion Ray" sync / 1[56]:The Avatar:7C2:/
-375.9 "Gaseous Bomb" sync / 1[56]:The Avatar:7C6:/
+328.4 "Ballistic Missile" sync / 1[56]:[^:]*:The Avatar:7CA:/
+335.8 "Gaseous Bomb" sync / 1[56]:[^:]*:The Avatar:7C6:/
+337.0 "Diffusion Ray" sync / 1[56]:[^:]*:The Avatar:7C2:/
+344.9 "Brainjack" sync / 1[56]:[^:]*:The Avatar:7C3:/ duration 11
+352.0 "Diffusion Ray" sync / 1[56]:[^:]*:The Avatar:7C2:/
+359.8 "Homing Missile" sync / 1[56]:[^:]*:The Avatar:7C7:/
+367.1 "Diffusion Ray" sync / 1[56]:[^:]*:The Avatar:7C2:/
+375.9 "Gaseous Bomb" sync / 1[56]:[^:]*:The Avatar:7C6:/
 
 ### Phase 3 (45%): allagan field
 # NOTE: there seems to be two different last phase timings
@@ -80,38 +80,38 @@ hideall "--sync--"
 # can instead be the 380/460 pattern, with a different diffusion ray.
 # The field/missile/bomb/surge timings are all roughly the same, so this
 # just removes the ray syncs and hopes for the best.
-377.0 "--sync--" sync / 14:The Avatar:7C4:/ window 400,0
-380.0 "Allagan Field" sync / 1[56]:The Avatar:7C4:/ duration 31 window 400,10
-386.3 "Homing Missile" sync / 1[56]:The Avatar:7C7:/
-387.6 "Diffusion Ray" #sync / 1[56]:The Avatar:7C2:/
-394.2 "Gaseous Bomb" sync / 1[56]:The Avatar:7C6:/
-402.5 "Diffusion Ray" #sync / 1[56]:The Avatar:7C2:/
-410.9 "Critical Surge" sync / 1[56]:Allagan Field:7C5:/
+377.0 "--sync--" sync / 14:[^:]*:The Avatar:7C4:/ window 400,0
+380.0 "Allagan Field" sync / 1[56]:[^:]*:The Avatar:7C4:/ duration 31 window 400,10
+386.3 "Homing Missile" sync / 1[56]:[^:]*:The Avatar:7C7:/
+387.6 "Diffusion Ray" #sync / 1[56]:[^:]*:The Avatar:7C2:/
+394.2 "Gaseous Bomb" sync / 1[56]:[^:]*:The Avatar:7C6:/
+402.5 "Diffusion Ray" #sync / 1[56]:[^:]*:The Avatar:7C2:/
+410.9 "Critical Surge" sync / 1[56]:[^:]*:Allagan Field:7C5:/
 
-420.0 "Allagan Field" sync / 1[56]:The Avatar:7C4:/ duration 31
-421.2 "Diffusion Ray" #sync / 1[56]:The Avatar:7C2:/
-427.2 "Homing Missile" sync / 1[56]:The Avatar:7C7:/
-434.2 "Gaseous Bomb" sync / 1[56]:The Avatar:7C6:/
-436.2 "Diffusion Ray" #sync / 1[56]:The Avatar:7C2:/
-450.8 "Critical Surge" sync / 1[56]:Allagan Field:7C5:/
-451.2 "Diffusion Ray" #sync / 1[56]:The Avatar:7C2:/
+420.0 "Allagan Field" sync / 1[56]:[^:]*:The Avatar:7C4:/ duration 31
+421.2 "Diffusion Ray" #sync / 1[56]:[^:]*:The Avatar:7C2:/
+427.2 "Homing Missile" sync / 1[56]:[^:]*:The Avatar:7C7:/
+434.2 "Gaseous Bomb" sync / 1[56]:[^:]*:The Avatar:7C6:/
+436.2 "Diffusion Ray" #sync / 1[56]:[^:]*:The Avatar:7C2:/
+450.8 "Critical Surge" sync / 1[56]:[^:]*:Allagan Field:7C5:/
+451.2 "Diffusion Ray" #sync / 1[56]:[^:]*:The Avatar:7C2:/
 
-460.1 "Allagan Field" sync / 1[56]:The Avatar:7C4:/ duration 31
-467.3 "Homing Missile" sync / 1[56]:The Avatar:7C7:/
-468.5 "Diffusion Ray" #sync / 1[56]:The Avatar:7C2:/
-474.3 "Gaseous Bomb" sync / 1[56]:The Avatar:7C6:/
-483.6 "Diffusion Ray" #sync / 1[56]:The Avatar:7C2:/
-490.9 "Critical Surge" sync / 1[56]:Allagan Field:7C5:/
+460.1 "Allagan Field" sync / 1[56]:[^:]*:The Avatar:7C4:/ duration 31
+467.3 "Homing Missile" sync / 1[56]:[^:]*:The Avatar:7C7:/
+468.5 "Diffusion Ray" #sync / 1[56]:[^:]*:The Avatar:7C2:/
+474.3 "Gaseous Bomb" sync / 1[56]:[^:]*:The Avatar:7C6:/
+483.6 "Diffusion Ray" #sync / 1[56]:[^:]*:The Avatar:7C2:/
+490.9 "Critical Surge" sync / 1[56]:[^:]*:Allagan Field:7C5:/
 
-500.0 "Allagan Field" sync / 1[56]:The Avatar:7C4:/ duration 31
-501.2 "Diffusion Ray" #sync / 1[56]:The Avatar:7C2:/
-507.3 "Homing Missile" sync / 1[56]:The Avatar:7C7:/
-514.3 "Gaseous Bomb" sync / 1[56]:The Avatar:7C6:/
-516.2 "Diffusion Ray" #sync / 1[56]:The Avatar:7C2:/
-530.9 "Critical Surge" sync / 1[56]:Allagan Field:7C5:/
-531.2 "Diffusion Ray" #sync / 1[56]:The Avatar:7C2:/
+500.0 "Allagan Field" sync / 1[56]:[^:]*:The Avatar:7C4:/ duration 31
+501.2 "Diffusion Ray" #sync / 1[56]:[^:]*:The Avatar:7C2:/
+507.3 "Homing Missile" sync / 1[56]:[^:]*:The Avatar:7C7:/
+514.3 "Gaseous Bomb" sync / 1[56]:[^:]*:The Avatar:7C6:/
+516.2 "Diffusion Ray" #sync / 1[56]:[^:]*:The Avatar:7C2:/
+530.9 "Critical Surge" sync / 1[56]:[^:]*:Allagan Field:7C5:/
+531.2 "Diffusion Ray" #sync / 1[56]:[^:]*:The Avatar:7C2:/
 
-540.1 "Allagan Field" sync / 1[56]:The Avatar:7C4:/ duration 31 jump 460.1
+540.1 "Allagan Field" sync / 1[56]:[^:]*:The Avatar:7C4:/ duration 31 jump 460.1
 547.3 "Homing Missile"
 548.5 "Diffusion Ray"
 554.3 "Gaseous Bomb"
@@ -120,7 +120,7 @@ hideall "--sync--"
 
 
 ### Phase 4: Enrage
-800.0 "Atomic Ray" sync / 1[56]:The Avatar:7C8:/ window 800,800
+800.0 "Atomic Ray" sync / 1[56]:[^:]*:The Avatar:7C8:/ window 800,800
 805.1 "Atomic Ray"
 810.2 "Atomic Ray"
 815.3 "Atomic Ray"

--- a/ui/raidboss/data/02-arr/raid/t9.txt
+++ b/ui/raidboss/data/02-arr/raid/t9.txt
@@ -156,7 +156,7 @@ hideall "--sync--"
 
 857.5 "--sync--" sync / 1[56]:Nael deus Darnus:83B:/
 860.2 "Heavensfall" sync / 1[56]:Ragnarok:7E4:/ window 40,40
-863.9 "Super Nova x2" duration 2.3 #sync / 1[56]:Nael deus Darnus:7E0:
+863.9 "Super Nova x2" duration 2.3 #sync / 1[56]:Nael deus Darnus:7E0:/
 876.7 "Bahamut's Claw x2" #sync / 1[56]:Nael deus Darnus:871:/
 883.9 "Binding Coil" sync / 1[56]:Nael deus Darnus:7E2:/
 899.3 "Bahamut's Claw x2" #sync / 1[56]:Nael deus Darnus:871:/

--- a/ui/raidboss/data/02-arr/raid/t9.txt
+++ b/ui/raidboss/data/02-arr/raid/t9.txt
@@ -10,99 +10,99 @@ hideall "--sync--"
 # This phase really doesn't seem to loop anywhere.
 0.0 "Start"
 0.0 "--sync--" sync /:Engage!/ window 0,1
-2.5 "--sync--" sync / 1[56]:Nael deus Darnus:367:/ window 3,0
-5.5 "Ravensclaw" sync / 1[56]:Nael deus Darnus:7D5:/ window 6,5
-16.6 "Ravensclaw" sync / 1[56]:Nael deus Darnus:7D5:/
+2.5 "--sync--" sync / 1[56]:[^:]*:Nael deus Darnus:367:/ window 3,0
+5.5 "Ravensclaw" sync / 1[56]:[^:]*:Nael deus Darnus:7D5:/ window 6,5
+16.6 "Ravensclaw" sync / 1[56]:[^:]*:Nael deus Darnus:7D5:/
 
-21.8 "Stardust" sync / 1[56]:Nael deus Darnus:877:/ duration 9
-30.8 "--sync--" sync / 1[56]:(Astral Debris|Umbral Debris):7E9:/
-30.9 "Ravensbeak" sync / 1[56]:Nael deus Darnus:7D6:/ duration 13
-36.2 "Raven Dive" sync / 1[56]:Nael deus Darnus:7DD:/
-40.8 "Iron Chariot" sync / 1[56]:Nael deus Darnus:7D8:/
-42.6 "Thermionic Beam" sync / 1[56]:Nael deus Darnus:7DF:/
-43.6 "Raven Dive" sync / 1[56]:Nael deus Darnus:7DD:/
-44.0 "--sync--" sync / 1[56]:Nael deus Darnus:7D7:/
-48.3 "Ravensclaw" sync / 1[56]:Nael deus Darnus:7D5:/
+21.8 "Stardust" sync / 1[56]:[^:]*:Nael deus Darnus:877:/ duration 9
+30.8 "--sync--" sync / 1[56]:[^:]*:(Astral Debris|Umbral Debris):7E9:/
+30.9 "Ravensbeak" sync / 1[56]:[^:]*:Nael deus Darnus:7D6:/ duration 13
+36.2 "Raven Dive" sync / 1[56]:[^:]*:Nael deus Darnus:7DD:/
+40.8 "Iron Chariot" sync / 1[56]:[^:]*:Nael deus Darnus:7D8:/
+42.6 "Thermionic Beam" sync / 1[56]:[^:]*:Nael deus Darnus:7DF:/
+43.6 "Raven Dive" sync / 1[56]:[^:]*:Nael deus Darnus:7DD:/
+44.0 "--sync--" sync / 1[56]:[^:]*:Nael deus Darnus:7D7:/
+48.3 "Ravensclaw" sync / 1[56]:[^:]*:Nael deus Darnus:7D5:/
 
-58.6 "Stardust" sync / 1[56]:Nael deus Darnus:877:/ duration 9
-63.4 "Ravensclaw" sync / 1[56]:Nael deus Darnus:7D5:/
-67.6 "--sync--" sync / 1[56]:(Astral Debris|Umbral Debris):7E9:/
-69.4 "Lunar Dynamo" sync / 1[56]:Nael deus Darnus:7DA:/
-71.8 "Meteor Stream" sync / 1[56]:Nael Geminus:7DE:/
-74.9 "Dalamud Dive" sync / 1[56]:Nael deus Darnus:7DC:/
-83.7 "Ravensbeak" sync / 1[56]:Nael deus Darnus:7D6:/ duration 13
-89.5 "Ravensclaw" sync / 1[56]:Nael deus Darnus:7D5:/
+58.6 "Stardust" sync / 1[56]:[^:]*:Nael deus Darnus:877:/ duration 9
+63.4 "Ravensclaw" sync / 1[56]:[^:]*:Nael deus Darnus:7D5:/
+67.6 "--sync--" sync / 1[56]:[^:]*:(Astral Debris|Umbral Debris):7E9:/
+69.4 "Lunar Dynamo" sync / 1[56]:[^:]*:Nael deus Darnus:7DA:/
+71.8 "Meteor Stream" sync / 1[56]:[^:]*:Nael Geminus:7DE:/
+74.9 "Dalamud Dive" sync / 1[56]:[^:]*:Nael deus Darnus:7DC:/
+83.7 "Ravensbeak" sync / 1[56]:[^:]*:Nael deus Darnus:7D6:/ duration 13
+89.5 "Ravensclaw" sync / 1[56]:[^:]*:Nael deus Darnus:7D5:/
 
-95.0 "Stardust" sync / 1[56]:Nael deus Darnus:877:/ duration 9
-96.6 "--sync--" sync / 1[56]:Nael deus Darnus:7D7:/
-104.0 "--sync--" sync / 1[56]:(Astral Debris|Umbral Debris):7E9:/
-107.2 "Meteor Stream" #sync / 1[56]:Nael Geminus:7DE:/
-112.3 "Meteor Stream" #sync / 1[56]:Nael Geminus:7DE:/
-115.4 "Dalamud Dive" sync / 1[56]:Nael deus Darnus:7DC:/
-119.7 "Ravensclaw" sync / 1[56]:Nael deus Darnus:7D5:/
-130.2 "Ravensbeak" sync / 1[56]:Nael deus Darnus:7D6:/ duration 13
+95.0 "Stardust" sync / 1[56]:[^:]*:Nael deus Darnus:877:/ duration 9
+96.6 "--sync--" sync / 1[56]:[^:]*:Nael deus Darnus:7D7:/
+104.0 "--sync--" sync / 1[56]:[^:]*:(Astral Debris|Umbral Debris):7E9:/
+107.2 "Meteor Stream" #sync / 1[56]:[^:]*:Nael Geminus:7DE:/
+112.3 "Meteor Stream" #sync / 1[56]:[^:]*:Nael Geminus:7DE:/
+115.4 "Dalamud Dive" sync / 1[56]:[^:]*:Nael deus Darnus:7DC:/
+119.7 "Ravensclaw" sync / 1[56]:[^:]*:Nael deus Darnus:7D5:/
+130.2 "Ravensbeak" sync / 1[56]:[^:]*:Nael deus Darnus:7D6:/ duration 13
 
-135.5 "Stardust" sync / 1[56]:Nael deus Darnus:877:/ duration 9
-140.0 "Ravensclaw" sync / 1[56]:Nael deus Darnus:7D5:/
-143.2 "--sync--" sync / 1[56]:Nael deus Darnus:7D7:/
-144.6 "--sync--" sync / 1[56]:(Astral Debris|Umbral Debris):7E9:/
-146.1 "Raven Dive" sync / 1[56]:Nael deus Darnus:7DD:/
-150.7 "Iron Chariot" sync / 1[56]:Nael deus Darnus:7D8:/
-152.6 "Thermionic Beam" sync / 1[56]:Nael deus Darnus:7DF:/
-153.6 "Raven Dive" sync / 1[56]:Nael deus Darnus:7DD:/
-162.6 "Ravensclaw" sync / 1[56]:Nael deus Darnus:7D5:/
+135.5 "Stardust" sync / 1[56]:[^:]*:Nael deus Darnus:877:/ duration 9
+140.0 "Ravensclaw" sync / 1[56]:[^:]*:Nael deus Darnus:7D5:/
+143.2 "--sync--" sync / 1[56]:[^:]*:Nael deus Darnus:7D7:/
+144.6 "--sync--" sync / 1[56]:[^:]*:(Astral Debris|Umbral Debris):7E9:/
+146.1 "Raven Dive" sync / 1[56]:[^:]*:Nael deus Darnus:7DD:/
+150.7 "Iron Chariot" sync / 1[56]:[^:]*:Nael deus Darnus:7D8:/
+152.6 "Thermionic Beam" sync / 1[56]:[^:]*:Nael deus Darnus:7DF:/
+153.6 "Raven Dive" sync / 1[56]:[^:]*:Nael deus Darnus:7DD:/
+162.6 "Ravensclaw" sync / 1[56]:[^:]*:Nael deus Darnus:7D5:/
 
-168.6 "Stardust" sync / 1[56]:Nael deus Darnus:877:/ duration 9
-177.4 "Ravensbeak" sync / 1[56]:Nael deus Darnus:7D6:/ duration 13
-177.7 "--sync--" sync / 1[56]:(Astral Debris|Umbral Debris):7E9:/
-183.9 "Lunar Dynamo" sync / 1[56]:Nael deus Darnus:7DA:/
-186.2 "Meteor Stream" sync / 1[56]:Nael Geminus:7DE:/
-189.3 "Dalamud Dive" sync / 1[56]:Nael deus Darnus:7DC:/
-190.4 "--sync--" sync / 1[56]:Nael deus Darnus:7D7:/
-192.9 "Ravensclaw" sync / 1[56]:Nael deus Darnus:7D5:/
+168.6 "Stardust" sync / 1[56]:[^:]*:Nael deus Darnus:877:/ duration 9
+177.4 "Ravensbeak" sync / 1[56]:[^:]*:Nael deus Darnus:7D6:/ duration 13
+177.7 "--sync--" sync / 1[56]:[^:]*:(Astral Debris|Umbral Debris):7E9:/
+183.9 "Lunar Dynamo" sync / 1[56]:[^:]*:Nael deus Darnus:7DA:/
+186.2 "Meteor Stream" sync / 1[56]:[^:]*:Nael Geminus:7DE:/
+189.3 "Dalamud Dive" sync / 1[56]:[^:]*:Nael deus Darnus:7DC:/
+190.4 "--sync--" sync / 1[56]:[^:]*:Nael deus Darnus:7D7:/
+192.9 "Ravensclaw" sync / 1[56]:[^:]*:Nael deus Darnus:7D5:/
 
-203.9 "Stardust" sync / 1[56]:Nael deus Darnus:877:/ duration 9
-208.0 "Ravensclaw" sync / 1[56]:Nael deus Darnus:7D5:/
-213.0 "--sync--" sync / 1[56]:(Astral Debris|Umbral Debris):7E9:/
-217.5 "Meteor Stream" #sync / 1[56]:Nael Geminus:7DE:/
-222.6 "Meteor Stream" #sync / 1[56]:Nael Geminus:7DE:/
-225.8 "Dalamud Dive" sync / 1[56]:Nael deus Darnus:7DC:/
-234.2 "Ravensbeak" sync / 1[56]:Nael deus Darnus:7D6:/ duration 13
-239.6 "Ravensclaw" sync / 1[56]:Nael deus Darnus:7D5:/
+203.9 "Stardust" sync / 1[56]:[^:]*:Nael deus Darnus:877:/ duration 9
+208.0 "Ravensclaw" sync / 1[56]:[^:]*:Nael deus Darnus:7D5:/
+213.0 "--sync--" sync / 1[56]:[^:]*:(Astral Debris|Umbral Debris):7E9:/
+217.5 "Meteor Stream" #sync / 1[56]:[^:]*:Nael Geminus:7DE:/
+222.6 "Meteor Stream" #sync / 1[56]:[^:]*:Nael Geminus:7DE:/
+225.8 "Dalamud Dive" sync / 1[56]:[^:]*:Nael deus Darnus:7DC:/
+234.2 "Ravensbeak" sync / 1[56]:[^:]*:Nael deus Darnus:7D6:/ duration 13
+239.6 "Ravensclaw" sync / 1[56]:[^:]*:Nael deus Darnus:7D5:/
 
-245.8 "Stardust" sync / 1[56]:Nael deus Darnus:877:/ duration 9
-254.8 "--sync--" sync / 1[56]:(Astral Debris|Umbral Debris):7E9:/
-255.5 "Raven Dive" sync / 1[56]:Nael deus Darnus:7DD:/
-260.1 "Iron Chariot" sync / 1[56]:Nael deus Darnus:7D8:/
-262.1 "Thermionic Beam" sync / 1[56]:Nael deus Darnus:7DF:/
-263.1 "Raven Dive" sync / 1[56]:Nael deus Darnus:7DD:/
-266.4 "Ravensclaw" sync / 1[56]:Nael deus Darnus:7D5:/
-277.3 "Ravensbeak" sync / 1[56]:Nael deus Darnus:7D6:/ duration 13
+245.8 "Stardust" sync / 1[56]:[^:]*:Nael deus Darnus:877:/ duration 9
+254.8 "--sync--" sync / 1[56]:[^:]*:(Astral Debris|Umbral Debris):7E9:/
+255.5 "Raven Dive" sync / 1[56]:[^:]*:Nael deus Darnus:7DD:/
+260.1 "Iron Chariot" sync / 1[56]:[^:]*:Nael deus Darnus:7D8:/
+262.1 "Thermionic Beam" sync / 1[56]:[^:]*:Nael deus Darnus:7DF:/
+263.1 "Raven Dive" sync / 1[56]:[^:]*:Nael deus Darnus:7DD:/
+266.4 "Ravensclaw" sync / 1[56]:[^:]*:Nael deus Darnus:7D5:/
+277.3 "Ravensbeak" sync / 1[56]:[^:]*:Nael deus Darnus:7D6:/ duration 13
 
-283.0 "Stardust" sync / 1[56]:Nael deus Darnus:877:/ duration 9
-286.8 "Ravensclaw" sync / 1[56]:Nael deus Darnus:7D5:/
-292.0 "--sync--" sync / 1[56]:(Astral Debris|Umbral Debris):7E9:/
-294.3 "Lunar Dynamo" sync / 1[56]:Nael deus Darnus:7DA:/
-296.7 "Meteor Stream" sync / 1[56]:Nael Geminus:7DE:/
-299.9 "Dalamud Dive" sync / 1[56]:Nael deus Darnus:7DC:/
-307.9 "Ravensclaw" sync / 1[56]:Nael deus Darnus:7D5:/
+283.0 "Stardust" sync / 1[56]:[^:]*:Nael deus Darnus:877:/ duration 9
+286.8 "Ravensclaw" sync / 1[56]:[^:]*:Nael deus Darnus:7D5:/
+292.0 "--sync--" sync / 1[56]:[^:]*:(Astral Debris|Umbral Debris):7E9:/
+294.3 "Lunar Dynamo" sync / 1[56]:[^:]*:Nael deus Darnus:7DA:/
+296.7 "Meteor Stream" sync / 1[56]:[^:]*:Nael Geminus:7DE:/
+299.9 "Dalamud Dive" sync / 1[56]:[^:]*:Nael deus Darnus:7DC:/
+307.9 "Ravensclaw" sync / 1[56]:[^:]*:Nael deus Darnus:7D5:/
 
-314.3 "Stardust" sync / 1[56]:Nael deus Darnus:877:/ duration 9
-322.8 "Ravensbeak" sync / 1[56]:Nael deus Darnus:7D6:/
-323.3 "--sync--" sync / 1[56]:(Astral Debris|Umbral Debris):7E9:/
-332.0 "Meteor Stream" sync / 1[56]:Nael Geminus:7DE:/
-335.9 "--sync--" sync / 1[56]:Nael deus Darnus:7D7:/
-337.0 "Meteor Stream" sync / 1[56]:Nael Geminus:7DE:/
-340.2 "Dalamud Dive" sync / 1[56]:Nael deus Darnus:7DC:/
-343.2 "Ravensclaw" sync / 1[56]:Nael deus Darnus:7D5:/
+314.3 "Stardust" sync / 1[56]:[^:]*:Nael deus Darnus:877:/ duration 9
+322.8 "Ravensbeak" sync / 1[56]:[^:]*:Nael deus Darnus:7D6:/
+323.3 "--sync--" sync / 1[56]:[^:]*:(Astral Debris|Umbral Debris):7E9:/
+332.0 "Meteor Stream" sync / 1[56]:[^:]*:Nael Geminus:7DE:/
+335.9 "--sync--" sync / 1[56]:[^:]*:Nael deus Darnus:7D7:/
+337.0 "Meteor Stream" sync / 1[56]:[^:]*:Nael Geminus:7DE:/
+340.2 "Dalamud Dive" sync / 1[56]:[^:]*:Nael deus Darnus:7DC:/
+343.2 "Ravensclaw" sync / 1[56]:[^:]*:Nael deus Darnus:7D5:/
 
-355.0 "Stardust" sync / 1[56]:Nael deus Darnus:877:/ duration 9
-358.5 "Ravensclaw" sync / 1[56]:Nael deus Darnus:7D5:/
-364.0 "--sync--" sync / 1[56]:(Astral Debris|Umbral Debris):7E9:/
-366.0 "Raven Dive" sync / 1[56]:Nael deus Darnus:7DD:/
-370.5 "Iron Chariot" sync / 1[56]:Nael deus Darnus:7D8:/
-372.7 "Thermionic Beam" sync / 1[56]:Nael deus Darnus:7DF:/
-373.7 "Raven Dive" sync / 1[56]:Nael deus Darnus:7DD:/
+355.0 "Stardust" sync / 1[56]:[^:]*:Nael deus Darnus:877:/ duration 9
+358.5 "Ravensclaw" sync / 1[56]:[^:]*:Nael deus Darnus:7D5:/
+364.0 "--sync--" sync / 1[56]:[^:]*:(Astral Debris|Umbral Debris):7E9:/
+366.0 "Raven Dive" sync / 1[56]:[^:]*:Nael deus Darnus:7DD:/
+370.5 "Iron Chariot" sync / 1[56]:[^:]*:Nael deus Darnus:7D8:/
+372.7 "Thermionic Beam" sync / 1[56]:[^:]*:Nael deus Darnus:7DF:/
+373.7 "Raven Dive" sync / 1[56]:[^:]*:Nael deus Darnus:7DD:/
 
 # Meteors just start exploding here no matter how far away you put them.
 
@@ -110,7 +110,7 @@ hideall "--sync--"
 ### Phase 2: Golem Adds
 500.0 "--untargetable--"
 503.3 "Golem Meteors" sync / 1B:........:[^:]*:....:....:0007:/ duration 11 window 505,0
-514.3 "--sync--" sync / 1[56]:Dalamud Fragment:7EB:/
+514.3 "--sync--" sync / 1[56]:[^:]*:Dalamud Fragment:7EB:/
 582.3 "Meteor 1/6" duration 7 sync / 1B:........:[^:]*:....:....:000[9A]:/ window 83,0
 584.3 "Meteor 2/6" duration 7
 586.3 "Meteor 3/6" duration 7
@@ -118,51 +118,51 @@ hideall "--sync--"
 590.5 "Meteor 5/6" duration 7
 592.5 "Meteor 6/6" duration 7
 598.3 "Golem Meteors" sync / 1B:........:[^:]*:....:....:0007:/ duration 11 window 80,80
-609.3 "--sync--" sync / 1[56]:Dalamud Fragment:7EB:/
-683.5 "Megaflare" sync / 1[56]:Nael deus Darnus:7E7:/ window 700,700
+609.3 "--sync--" sync / 1[56]:[^:]*:Dalamud Fragment:7EB:/
+683.5 "Megaflare" sync / 1[56]:[^:]*:Nael deus Darnus:7E7:/ window 700,700
 
 
 ### Phase 3: Heavensfall
 # Phase 3 is on a 54 second nael rotation and a 60 second dragon rotation.
 # This unrolls the loop for the first few dragons.
-693.6 "Dalamud Dive" sync / 1[56]:Nael deus Darnus:7DC:/ window 300,300
+693.6 "Dalamud Dive" sync / 1[56]:[^:]*:Nael deus Darnus:7DC:/ window 300,300
 695.6 "--targetable--"
 
-699.2 "--sync--" sync / 1[56]:Nael deus Darnus:83B:/
-701.9 "Heavensfall" sync / 1[56]:Ragnarok:7E4:/ window 702,10
-714.3 "Bahamut's Claw x2" #sync / 1[56]:Nael deus Darnus:871:/
+699.2 "--sync--" sync / 1[56]:[^:]*:Nael deus Darnus:83B:/
+701.9 "Heavensfall" sync / 1[56]:[^:]*:Ragnarok:7E4:/ window 702,10
+714.3 "Bahamut's Claw x2" #sync / 1[56]:[^:]*:Nael deus Darnus:871:/
 716.0 "Ghost Add 1 (North)"
-721.8 "Binding Coil" sync / 1[56]:Nael deus Darnus:7E2:/
-737.0 "Bahamut's Claw x2" #sync / 1[56]:Nael deus Darnus:871:/
-744.4 "Binding Coil" sync / 1[56]:Nael deus Darnus:7E2:/
+721.8 "Binding Coil" sync / 1[56]:[^:]*:Nael deus Darnus:7E2:/
+737.0 "Bahamut's Claw x2" #sync / 1[56]:[^:]*:Nael deus Darnus:871:/
+744.4 "Binding Coil" sync / 1[56]:[^:]*:Nael deus Darnus:7E2:/
 
-749.5 "--sync--" sync / 1[56]:Nael deus Darnus:83B:/
-752.2 "Heavensfall" sync / 1[56]:Ragnarok:7E4:/ window 40,40
-755.9 "Super Nova x2" duration 2.3 #sync / 1[56]:Nael deus Darnus:7E0:/
-768.7 "Bahamut's Claw x2" #sync / 1[56]:Nael deus Darnus:871:/
-775.9 "Binding Coil" sync / 1[56]:Nael deus Darnus:7E2:/
+749.5 "--sync--" sync / 1[56]:[^:]*:Nael deus Darnus:83B:/
+752.2 "Heavensfall" sync / 1[56]:[^:]*:Ragnarok:7E4:/ window 40,40
+755.9 "Super Nova x2" duration 2.3 #sync / 1[56]:[^:]*:Nael deus Darnus:7E0:/
+768.7 "Bahamut's Claw x2" #sync / 1[56]:[^:]*:Nael deus Darnus:871:/
+775.9 "Binding Coil" sync / 1[56]:[^:]*:Nael deus Darnus:7E2:/
 776.0 "Ghost Add 2 (East)"
-791.3 "Bahamut's Claw x2" #sync / 1[56]:Nael deus Darnus:871:/
-798.5 "Binding Coil" sync / 1[56]:Nael deus Darnus:7E2:/
+791.3 "Bahamut's Claw x2" #sync / 1[56]:[^:]*:Nael deus Darnus:871:/
+798.5 "Binding Coil" sync / 1[56]:[^:]*:Nael deus Darnus:7E2:/
 
-803.5 "--sync--" sync / 1[56]:Nael deus Darnus:83B:/
-806.2 "Heavensfall" sync / 1[56]:Ragnarok:7E4:/ window 40,40
-809.9 "Super Nova x2" duration 2.3 #sync / 1[56]:Nael deus Darnus:7E0:/
-822.7 "Bahamut's Claw x2" #sync / 1[56]:Nael deus Darnus:871:/
-829.9 "Binding Coil" sync / 1[56]:Nael deus Darnus:7E2:/
+803.5 "--sync--" sync / 1[56]:[^:]*:Nael deus Darnus:83B:/
+806.2 "Heavensfall" sync / 1[56]:[^:]*:Ragnarok:7E4:/ window 40,40
+809.9 "Super Nova x2" duration 2.3 #sync / 1[56]:[^:]*:Nael deus Darnus:7E0:/
+822.7 "Bahamut's Claw x2" #sync / 1[56]:[^:]*:Nael deus Darnus:871:/
+829.9 "Binding Coil" sync / 1[56]:[^:]*:Nael deus Darnus:7E2:/
 836.0 "Ghost Add 3 (South)"
-845.3 "Bahamut's Claw x2" #sync / 1[56]:Nael deus Darnus:871:/
-852.5 "Binding Coil" sync / 1[56]:Nael deus Darnus:7E2:/
+845.3 "Bahamut's Claw x2" #sync / 1[56]:[^:]*:Nael deus Darnus:871:/
+852.5 "Binding Coil" sync / 1[56]:[^:]*:Nael deus Darnus:7E2:/
 
-857.5 "--sync--" sync / 1[56]:Nael deus Darnus:83B:/
-860.2 "Heavensfall" sync / 1[56]:Ragnarok:7E4:/ window 40,40
-863.9 "Super Nova x2" duration 2.3 #sync / 1[56]:Nael deus Darnus:7E0:/
-876.7 "Bahamut's Claw x2" #sync / 1[56]:Nael deus Darnus:871:/
-883.9 "Binding Coil" sync / 1[56]:Nael deus Darnus:7E2:/
-899.3 "Bahamut's Claw x2" #sync / 1[56]:Nael deus Darnus:871:/
-906.5 "Binding Coil" sync / 1[56]:Nael deus Darnus:7E2:/
+857.5 "--sync--" sync / 1[56]:[^:]*:Nael deus Darnus:83B:/
+860.2 "Heavensfall" sync / 1[56]:[^:]*:Ragnarok:7E4:/ window 40,40
+863.9 "Super Nova x2" duration 2.3 #sync / 1[56]:[^:]*:Nael deus Darnus:7E0:/
+876.7 "Bahamut's Claw x2" #sync / 1[56]:[^:]*:Nael deus Darnus:871:/
+883.9 "Binding Coil" sync / 1[56]:[^:]*:Nael deus Darnus:7E2:/
+899.3 "Bahamut's Claw x2" #sync / 1[56]:[^:]*:Nael deus Darnus:871:/
+906.5 "Binding Coil" sync / 1[56]:[^:]*:Nael deus Darnus:7E2:/
 
-911.5 "--sync--" sync / 1[56]:Nael deus Darnus:83B:/ window 40,40 jump 857.5
+911.5 "--sync--" sync / 1[56]:[^:]*:Nael deus Darnus:83B:/ window 40,40 jump 857.5
 914.2 "Heavensfall"
 917.9 "Super Nova x2"
 930.7 "Bahamut's Claw x2"
@@ -172,79 +172,79 @@ hideall "--sync--"
 
 
 ### Phase 4: Divebombs and Dances
-1000.0 "Bahamut's Favor" sync / 1[56]:Nael deus Darnus:7E6:/ window 1000,80
-1003.1 "Bahamut's Claw x5" duration 2.9 #sync / 1[56]:Nael deus Darnus:871:/
-1013.9 "Chain Lightning" sync / 1[56]:Thunderwing:7FD:/ duration 6
-1014.4 "Raven Dive" sync / 1[56]:Nael deus Darnus:7DD:/
-1014.9 "Fireball (Out)" sync / 1[56]:Firehorn:7FB:/
-1019.0 "Lunar Dynamo" sync / 1[56]:Nael deus Darnus:7DA:/
-1025.9 "Chain Lightning" sync / 1[56]:Thunderwing:7FD:/ duration 6
-1026.9 "Fireball (In)" sync / 1[56]:Firehorn:7FB:/
-1038.0 "Chain Lightning" sync / 1[56]:Thunderwing:7FD:/ duration 6
-1039.0 "Fireball (Out)" sync / 1[56]:Firehorn:7FB:/
-1040.2 "Iron Chariot" sync / 1[56]:Nael deus Darnus:7D8:/
-1041.9 "Super Nova x3" duration 3 #sync / 1[56]:Nael deus Darnus:7E0:/
-1047.4 "Thermionic Beam" sync / 1[56]:Nael deus Darnus:7DF:/
-1050.0 "Chain Lightning" sync / 1[56]:Thunderwing:7FD:/ duration 6
-1051.2 "Fireball (In)" sync / 1[56]:Firehorn:7FB:/
-1054.2 "Bahamut's Claw x5" duration 2.9 #sync / 1[56]:Nael deus Darnus:871:/
+1000.0 "Bahamut's Favor" sync / 1[56]:[^:]*:Nael deus Darnus:7E6:/ window 1000,80
+1003.1 "Bahamut's Claw x5" duration 2.9 #sync / 1[56]:[^:]*:Nael deus Darnus:871:/
+1013.9 "Chain Lightning" sync / 1[56]:[^:]*:Thunderwing:7FD:/ duration 6
+1014.4 "Raven Dive" sync / 1[56]:[^:]*:Nael deus Darnus:7DD:/
+1014.9 "Fireball (Out)" sync / 1[56]:[^:]*:Firehorn:7FB:/
+1019.0 "Lunar Dynamo" sync / 1[56]:[^:]*:Nael deus Darnus:7DA:/
+1025.9 "Chain Lightning" sync / 1[56]:[^:]*:Thunderwing:7FD:/ duration 6
+1026.9 "Fireball (In)" sync / 1[56]:[^:]*:Firehorn:7FB:/
+1038.0 "Chain Lightning" sync / 1[56]:[^:]*:Thunderwing:7FD:/ duration 6
+1039.0 "Fireball (Out)" sync / 1[56]:[^:]*:Firehorn:7FB:/
+1040.2 "Iron Chariot" sync / 1[56]:[^:]*:Nael deus Darnus:7D8:/
+1041.9 "Super Nova x3" duration 3 #sync / 1[56]:[^:]*:Nael deus Darnus:7E0:/
+1047.4 "Thermionic Beam" sync / 1[56]:[^:]*:Nael deus Darnus:7DF:/
+1050.0 "Chain Lightning" sync / 1[56]:[^:]*:Thunderwing:7FD:/ duration 6
+1051.2 "Fireball (In)" sync / 1[56]:[^:]*:Firehorn:7FB:/
+1054.2 "Bahamut's Claw x5" duration 2.9 #sync / 1[56]:[^:]*:Nael deus Darnus:871:/
 1061.2 "Divebomb Mark A" duration 5
 1067.3 "Divebomb Mark B" duration 5
-1070.5 "Cauterize x2" sync / 1[56]:Thunderwing:801:/
-1070.6 "Meteor Stream" sync / 1[56]:Nael Geminus:7DE:/
-1076.6 "Cauterize x1" sync / 1[56]:Firehorn:7FF:/
-1076.7 "Meteor Stream" sync / 1[56]:Nael Geminus:7DE:/
-1080.8 "Dalamud Dive" sync / 1[56]:Nael deus Darnus:7DC:/
+1070.5 "Cauterize x2" sync / 1[56]:[^:]*:Thunderwing:801:/
+1070.6 "Meteor Stream" sync / 1[56]:[^:]*:Nael Geminus:7DE:/
+1076.6 "Cauterize x1" sync / 1[56]:[^:]*:Firehorn:7FF:/
+1076.7 "Meteor Stream" sync / 1[56]:[^:]*:Nael Geminus:7DE:/
+1080.8 "Dalamud Dive" sync / 1[56]:[^:]*:Nael deus Darnus:7DC:/
 
-1096.6 "Bahamut's Favor" sync / 1[56]:Nael deus Darnus:7E6:/ window 80,80
-1099.7 "Bahamut's Claw x5" duration 2.9 #sync / 1[56]:Nael deus Darnus:871:/
-1110.4 "Raven Dive" sync / 1[56]:Nael deus Darnus:7DD:/
-1110.4 "Chain Lightning" sync / 1[56]:Thunderwing:7FD:/ duration 6
-1111.3 "Fireball (Out)" sync / 1[56]:Firehorn:7FB:/
-1114.9 "Lunar Dynamo" sync / 1[56]:Nael deus Darnus:7DA:/
-1122.5 "Chain Lightning" sync / 1[56]:Thunderwing:7FD:/ duration 6
-1123.4 "Fireball (In)" sync / 1[56]:Firehorn:7FB:/
-1134.4 "Chain Lightning" sync / 1[56]:Thunderwing:7FD:/ duration 6
-1135.5 "Fireball (Out)" sync / 1[56]:Firehorn:7FB:/
-1136.0 "Iron Chariot" sync / 1[56]:Nael deus Darnus:7D8:/
-1137.8 "Super Nova x3" duration 3 #sync / 1[56]:Nael deus Darnus:7E0:/
-1143.8 "Thermionic Beam" sync / 1[56]:Nael deus Darnus:7DF:/
-1146.6 "Chain Lightning" sync / 1[56]:Thunderwing:7FD:/ duration 6
-1147.7 "Fireball (In)" sync / 1[56]:Firehorn:7FB:/
-1150.6 "Bahamut's Claw x5" duration 2.9 #sync / 1[56]:Nael deus Darnus:871:/
+1096.6 "Bahamut's Favor" sync / 1[56]:[^:]*:Nael deus Darnus:7E6:/ window 80,80
+1099.7 "Bahamut's Claw x5" duration 2.9 #sync / 1[56]:[^:]*:Nael deus Darnus:871:/
+1110.4 "Raven Dive" sync / 1[56]:[^:]*:Nael deus Darnus:7DD:/
+1110.4 "Chain Lightning" sync / 1[56]:[^:]*:Thunderwing:7FD:/ duration 6
+1111.3 "Fireball (Out)" sync / 1[56]:[^:]*:Firehorn:7FB:/
+1114.9 "Lunar Dynamo" sync / 1[56]:[^:]*:Nael deus Darnus:7DA:/
+1122.5 "Chain Lightning" sync / 1[56]:[^:]*:Thunderwing:7FD:/ duration 6
+1123.4 "Fireball (In)" sync / 1[56]:[^:]*:Firehorn:7FB:/
+1134.4 "Chain Lightning" sync / 1[56]:[^:]*:Thunderwing:7FD:/ duration 6
+1135.5 "Fireball (Out)" sync / 1[56]:[^:]*:Firehorn:7FB:/
+1136.0 "Iron Chariot" sync / 1[56]:[^:]*:Nael deus Darnus:7D8:/
+1137.8 "Super Nova x3" duration 3 #sync / 1[56]:[^:]*:Nael deus Darnus:7E0:/
+1143.8 "Thermionic Beam" sync / 1[56]:[^:]*:Nael deus Darnus:7DF:/
+1146.6 "Chain Lightning" sync / 1[56]:[^:]*:Thunderwing:7FD:/ duration 6
+1147.7 "Fireball (In)" sync / 1[56]:[^:]*:Firehorn:7FB:/
+1150.6 "Bahamut's Claw x5" duration 2.9 #sync / 1[56]:[^:]*:Nael deus Darnus:871:/
 1157.8 "Divebomb Mark A" duration 5
 1163.9 "Divebomb Mark B" duration 5
-1164.3 "Iron Chariot" sync / 1[56]:Nael deus Darnus:7D8:/
-1167.1 "Cauterize x2" sync / 1[56]:Firehorn:7FF:/
-1168.1 "Raven Dive" sync / 1[56]:Nael deus Darnus:7DD:/
-1172.7 "Lunar Dynamo" sync / 1[56]:Nael deus Darnus:7DA:/
-1173.2 "Cauterize x1" sync / 1[56]:Iceclaw:800:/
+1164.3 "Iron Chariot" sync / 1[56]:[^:]*:Nael deus Darnus:7D8:/
+1167.1 "Cauterize x2" sync / 1[56]:[^:]*:Firehorn:7FF:/
+1168.1 "Raven Dive" sync / 1[56]:[^:]*:Nael deus Darnus:7DD:/
+1172.7 "Lunar Dynamo" sync / 1[56]:[^:]*:Nael deus Darnus:7DA:/
+1173.2 "Cauterize x1" sync / 1[56]:[^:]*:Iceclaw:800:/
 
-1193.1 "Bahamut's Favor" sync / 1[56]:Nael deus Darnus:7E6:/ window 80,80
-1196.1 "Bahamut's Claw x5" duration 2.9 #sync / 1[56]:Nael deus Darnus:871:/
-1206.9 "Raven Dive" sync / 1[56]:Nael deus Darnus:7DD:/
-1207.0 "Chain Lightning" sync / 1[56]:Thunderwing:7FD:/ duration 6
-1207.9 "Fireball (Out)" sync / 1[56]:Firehorn:7FB:/
-1211.4 "Lunar Dynamo" sync / 1[56]:Nael deus Darnus:7DA:/
-1219.0 "Chain Lightning" sync / 1[56]:Thunderwing:7FD:/ duration 6
-1219.9 "Fireball (In)" sync / 1[56]:Firehorn:7FB:/
-1231.0 "Chain Lightning" sync / 1[56]:Thunderwing:7FD:/ duration 6
-1232.1 "Fireball (Out)" sync / 1[56]:Firehorn:7FB:/
-1232.6 "Iron Chariot" sync / 1[56]:Nael deus Darnus:7D8:/
-1234.4 "Super Nova x3" duration 3 #sync / 1[56]:Nael deus Darnus:7E0:/
-1240.5 "Thermionic Beam" sync / 1[56]:Nael deus Darnus:7DF:/
-1243.1 "Chain Lightning" sync / 1[56]:Thunderwing:7FD:/ duration 6
-1244.4 "Fireball (In)" sync / 1[56]:Firehorn:7FB:/
-1247.4 "Bahamut's Claw x5" duration 2.9 #sync / 1[56]:Nael deus Darnus:871:/
+1193.1 "Bahamut's Favor" sync / 1[56]:[^:]*:Nael deus Darnus:7E6:/ window 80,80
+1196.1 "Bahamut's Claw x5" duration 2.9 #sync / 1[56]:[^:]*:Nael deus Darnus:871:/
+1206.9 "Raven Dive" sync / 1[56]:[^:]*:Nael deus Darnus:7DD:/
+1207.0 "Chain Lightning" sync / 1[56]:[^:]*:Thunderwing:7FD:/ duration 6
+1207.9 "Fireball (Out)" sync / 1[56]:[^:]*:Firehorn:7FB:/
+1211.4 "Lunar Dynamo" sync / 1[56]:[^:]*:Nael deus Darnus:7DA:/
+1219.0 "Chain Lightning" sync / 1[56]:[^:]*:Thunderwing:7FD:/ duration 6
+1219.9 "Fireball (In)" sync / 1[56]:[^:]*:Firehorn:7FB:/
+1231.0 "Chain Lightning" sync / 1[56]:[^:]*:Thunderwing:7FD:/ duration 6
+1232.1 "Fireball (Out)" sync / 1[56]:[^:]*:Firehorn:7FB:/
+1232.6 "Iron Chariot" sync / 1[56]:[^:]*:Nael deus Darnus:7D8:/
+1234.4 "Super Nova x3" duration 3 #sync / 1[56]:[^:]*:Nael deus Darnus:7E0:/
+1240.5 "Thermionic Beam" sync / 1[56]:[^:]*:Nael deus Darnus:7DF:/
+1243.1 "Chain Lightning" sync / 1[56]:[^:]*:Thunderwing:7FD:/ duration 6
+1244.4 "Fireball (In)" sync / 1[56]:[^:]*:Firehorn:7FB:/
+1247.4 "Bahamut's Claw x5" duration 2.9 #sync / 1[56]:[^:]*:Nael deus Darnus:871:/
 1254.4 "Divebomb Mark A" duration 5
 1260.3 "Divebomb Mark B" duration 5
-1263.7 "Cauterize x2" sync / 1[56]:Thunderwing:801:/
-1263.8 "Meteor Stream" sync / 1[56]:Nael Geminus:7DE:/
-1269.6 "Cauterize x1" sync / 1[56]:Firehorn:7FF:/
-1269.9 "Meteor Stream" sync / 1[56]:Nael Geminus:7DE:/
-1274.5 "Dalamud Dive" sync / 1[56]:Nael deus Darnus:7DC:/
+1263.7 "Cauterize x2" sync / 1[56]:[^:]*:Thunderwing:801:/
+1263.8 "Meteor Stream" sync / 1[56]:[^:]*:Nael Geminus:7DE:/
+1269.6 "Cauterize x1" sync / 1[56]:[^:]*:Firehorn:7FF:/
+1269.9 "Meteor Stream" sync / 1[56]:[^:]*:Nael Geminus:7DE:/
+1274.5 "Dalamud Dive" sync / 1[56]:[^:]*:Nael deus Darnus:7DC:/
 
-1289.7 "Bahamut's Favor" sync / 1[56]:Nael deus Darnus:7E6:/ window 80,800 jump 1096.6
+1289.7 "Bahamut's Favor" sync / 1[56]:[^:]*:Nael deus Darnus:7E6:/ window 80,800 jump 1096.6
 1292.8 "Bahamut's Claw x5"
 1303.5 "Raven Dive"
 1303.5 "Chain Lightning"
@@ -270,7 +270,7 @@ hideall "--sync--"
 
 
 ### Phase 5: What Took You So Long
-2000.0 "Megaflare Enrage" sync / 1[56]:Nael deus Darnus:7E8:/ window 2000,2000
+2000.0 "Megaflare Enrage" sync / 1[56]:[^:]*:Nael deus Darnus:7E8:/ window 2000,2000
 2008.5 "Megaflare Enrage"
 2017.0 "Megaflare Enrage"
 2025.5 "Megaflare Enrage"

--- a/ui/raidboss/data/02-arr/trial/cape_westwind.txt
+++ b/ui/raidboss/data/02-arr/trial/cape_westwind.txt
@@ -9,15 +9,15 @@ hideall "--sync--"
 ### Phase 1: skewers and stuns
 0 "Start"
 0.0 "--sync--" sync /:Engage!/ window 0,1
-2.0 "Shield Skewer" sync / 1[56]:Rhitahtyn sas Arvina:471:/
-10.6 "Shield Skewer" sync / 1[56]:Rhitahtyn sas Arvina:471:/
-19.0 "Shield Skewer" sync / 1[56]:Rhitahtyn sas Arvina:471:/
-24.4 "Gate Of Tartarus" sync / 1[56]:Rhitahtyn sas Arvina:473:/ window 30,10
+2.0 "Shield Skewer" sync / 1[56]:[^:]*:Rhitahtyn sas Arvina:471:/
+10.6 "Shield Skewer" sync / 1[56]:[^:]*:Rhitahtyn sas Arvina:471:/
+19.0 "Shield Skewer" sync / 1[56]:[^:]*:Rhitahtyn sas Arvina:471:/
+24.4 "Gate Of Tartarus" sync / 1[56]:[^:]*:Rhitahtyn sas Arvina:473:/ window 30,10
 
-29.8 "Shield Skewer" sync / 1[56]:Rhitahtyn sas Arvina:471:/
-38.4 "Shield Skewer" sync / 1[56]:Rhitahtyn sas Arvina:471:/
-46.8 "Shield Skewer" sync / 1[56]:Rhitahtyn sas Arvina:471:/
-52.2 "Gate Of Tartarus" sync / 1[56]:Rhitahtyn sas Arvina:473:/ window 10,100 jump 24.4
+29.8 "Shield Skewer" sync / 1[56]:[^:]*:Rhitahtyn sas Arvina:471:/
+38.4 "Shield Skewer" sync / 1[56]:[^:]*:Rhitahtyn sas Arvina:471:/
+46.8 "Shield Skewer" sync / 1[56]:[^:]*:Rhitahtyn sas Arvina:471:/
+52.2 "Gate Of Tartarus" sync / 1[56]:[^:]*:Rhitahtyn sas Arvina:473:/ window 10,100 jump 24.4
 
 57.6 "Shield Skewer"
 66.2 "Shield Skewer"
@@ -27,18 +27,18 @@ hideall "--sync--"
 
 ### Phase 2 (80%): firebombs
 199.0 "--sync--" sync / 00:0044:[^:]*:My shields are impregnable/ window 200,0
-200.0 "Shield Skewer" sync / 1[56]:Rhitahtyn sas Arvina:471:/
-204.3 "Shrapnel Shell" sync / 1[56]:Rhitahtyn sas Arvina:474:/ window 205,10
-208.8 "Winds Of Tartarus" sync / 1[56]:Rhitahtyn sas Arvina:472:/
-213.1 "Firebomb" sync / 1[56]:Rhitahtyn sas Arvina:476:/
+200.0 "Shield Skewer" sync / 1[56]:[^:]*:Rhitahtyn sas Arvina:471:/
+204.3 "Shrapnel Shell" sync / 1[56]:[^:]*:Rhitahtyn sas Arvina:474:/ window 205,10
+208.8 "Winds Of Tartarus" sync / 1[56]:[^:]*:Rhitahtyn sas Arvina:472:/
+213.1 "Firebomb" sync / 1[56]:[^:]*:Rhitahtyn sas Arvina:476:/
 
-217.4 "Shield Skewer" sync / 1[56]:Rhitahtyn sas Arvina:471:/
-221.7 "Drill Shot" sync / 1[56]:Rhitahtyn sas Arvina:475:/
-226.0 "Winds Of Tartarus" sync / 1[56]:Rhitahtyn sas Arvina:472:/
-230.3 "Firebomb" sync / 1[56]:Rhitahtyn sas Arvina:476:/
+217.4 "Shield Skewer" sync / 1[56]:[^:]*:Rhitahtyn sas Arvina:471:/
+221.7 "Drill Shot" sync / 1[56]:[^:]*:Rhitahtyn sas Arvina:475:/
+226.0 "Winds Of Tartarus" sync / 1[56]:[^:]*:Rhitahtyn sas Arvina:472:/
+230.3 "Firebomb" sync / 1[56]:[^:]*:Rhitahtyn sas Arvina:476:/
 
-234.6 "Shield Skewer" sync / 1[56]:Rhitahtyn sas Arvina:471:/
-238.9 "Shrapnel Shell" sync / 1[56]:Rhitahtyn sas Arvina:474:/ window 20,100 jump 204.3
+234.6 "Shield Skewer" sync / 1[56]:[^:]*:Rhitahtyn sas Arvina:471:/
+238.9 "Shrapnel Shell" sync / 1[56]:[^:]*:Rhitahtyn sas Arvina:474:/ window 20,100 jump 204.3
 243.4 "Winds Of Tartarus"
 247.7 "Firebomb"
 
@@ -49,23 +49,23 @@ hideall "--sync--"
 
 
 ### Phase 3 (60%): Adds
-400.0 "Gate Of Tartarus" sync / 1[56]:Rhitahtyn sas Arvina:473:/ window 200,20
-403.5 "Shield Skewer" sync / 1[56]:Rhitahtyn sas Arvina:471:/
+400.0 "Gate Of Tartarus" sync / 1[56]:[^:]*:Rhitahtyn sas Arvina:473:/ window 200,20
+403.5 "Shield Skewer" sync / 1[56]:[^:]*:Rhitahtyn sas Arvina:471:/
 
 407.7 "Adds"
 # FIXME: sometimes this shield skewer doesn't happen???
-408.7 "Shield Skewer" sync / 1[56]:Rhitahtyn sas Arvina:471:/
-413.2 "Shrapnel Shell" sync / 1[56]:Rhitahtyn sas Arvina:474:/ window 20,20
-417.9 "Winds Of Tartarus" sync / 1[56]:Rhitahtyn sas Arvina:472:/
-422.4 "Firebomb" sync / 1[56]:Rhitahtyn sas Arvina:476:/
+408.7 "Shield Skewer" sync / 1[56]:[^:]*:Rhitahtyn sas Arvina:471:/
+413.2 "Shrapnel Shell" sync / 1[56]:[^:]*:Rhitahtyn sas Arvina:474:/ window 20,20
+417.9 "Winds Of Tartarus" sync / 1[56]:[^:]*:Rhitahtyn sas Arvina:472:/
+422.4 "Firebomb" sync / 1[56]:[^:]*:Rhitahtyn sas Arvina:476:/
 
-426.9 "Shield Skewer" sync / 1[56]:Rhitahtyn sas Arvina:471:/
-431.4 "Drill Shot" sync / 1[56]:Rhitahtyn sas Arvina:475:/
-435.9 "Winds Of Tartarus" sync / 1[56]:Rhitahtyn sas Arvina:472:/
-440.4 "Firebomb" sync / 1[56]:Rhitahtyn sas Arvina:476:/
+426.9 "Shield Skewer" sync / 1[56]:[^:]*:Rhitahtyn sas Arvina:471:/
+431.4 "Drill Shot" sync / 1[56]:[^:]*:Rhitahtyn sas Arvina:475:/
+435.9 "Winds Of Tartarus" sync / 1[56]:[^:]*:Rhitahtyn sas Arvina:472:/
+440.4 "Firebomb" sync / 1[56]:[^:]*:Rhitahtyn sas Arvina:476:/
 
-445.0 "Shield Skewer" sync / 1[56]:Rhitahtyn sas Arvina:471:/
-449.5 "Shrapnel Shell" sync / 1[56]:Rhitahtyn sas Arvina:474:/ window 20,100 jump 413.2
+445.0 "Shield Skewer" sync / 1[56]:[^:]*:Rhitahtyn sas Arvina:471:/
+449.5 "Shrapnel Shell" sync / 1[56]:[^:]*:Rhitahtyn sas Arvina:474:/ window 20,100 jump 413.2
 454.2 "Winds Of Tartarus"
 458.7 "Firebomb"
 
@@ -78,19 +78,19 @@ hideall "--sync--"
 ### Phase 4 (40%): magitek missiles
 584.3 "--sync--" sync / 00:0044:[^:]*:Your defeat will bring/ window 600,0
 
-600.0 "Shrapnel Shell" sync / 1[56]:Rhitahtyn sas Arvina:474:/
-604.5 "Firebomb" sync / 1[56]:Rhitahtyn sas Arvina:476:/
-608.8 "Winds Of Tartarus" sync / 1[56]:Rhitahtyn sas Arvina:472:/
+600.0 "Shrapnel Shell" sync / 1[56]:[^:]*:Rhitahtyn sas Arvina:474:/
+604.5 "Firebomb" sync / 1[56]:[^:]*:Rhitahtyn sas Arvina:476:/
+608.8 "Winds Of Tartarus" sync / 1[56]:[^:]*:Rhitahtyn sas Arvina:472:/
 
-610.0 "Magitek Missiles" sync / 1[56]:Rhitahtyn sas Arvina:478:/ window 610,30
-615.1 "Drill Shot" sync / 1[56]:Rhitahtyn sas Arvina:475:/
-619.4 "Firebomb" sync / 1[56]:Rhitahtyn sas Arvina:476:/
-623.7 "Winds Of Tartarus" sync / 1[56]:Rhitahtyn sas Arvina:472:/
-640.2 "Shrapnel Shell" sync / 1[56]:Rhitahtyn sas Arvina:474:/
-644.7 "Firebomb" sync / 1[56]:Rhitahtyn sas Arvina:476:/
-649.0 "Winds Of Tartarus" sync / 1[56]:Rhitahtyn sas Arvina:472:/
+610.0 "Magitek Missiles" sync / 1[56]:[^:]*:Rhitahtyn sas Arvina:478:/ window 610,30
+615.1 "Drill Shot" sync / 1[56]:[^:]*:Rhitahtyn sas Arvina:475:/
+619.4 "Firebomb" sync / 1[56]:[^:]*:Rhitahtyn sas Arvina:476:/
+623.7 "Winds Of Tartarus" sync / 1[56]:[^:]*:Rhitahtyn sas Arvina:472:/
+640.2 "Shrapnel Shell" sync / 1[56]:[^:]*:Rhitahtyn sas Arvina:474:/
+644.7 "Firebomb" sync / 1[56]:[^:]*:Rhitahtyn sas Arvina:476:/
+649.0 "Winds Of Tartarus" sync / 1[56]:[^:]*:Rhitahtyn sas Arvina:472:/
 
-650.2 "Magitek Missiles" sync / 1[56]:Rhitahtyn sas Arvina:478:/ window 20,100 jump 610.0
+650.2 "Magitek Missiles" sync / 1[56]:[^:]*:Rhitahtyn sas Arvina:478:/ window 20,100 jump 610.0
 655.3 "Drill Shot"
 659.6 "Firebomb"
 663.9 "Winds Of Tartarus"

--- a/ui/raidboss/data/02-arr/trial/ifrit-nm.txt
+++ b/ui/raidboss/data/02-arr/trial/ifrit-nm.txt
@@ -9,13 +9,13 @@ hideall "--sync--"
 # 0%
 0.0 "Start"
 0.0 "--sync--" sync /:Engage!/ window 0,1
-1.2 "Incinerate" sync / 1[56]:Ifrit:1C5:/ window 10,10
-9.1 "Vulcan Burst" sync / 1[56]:Ifrit:1C6:/
-17.1 "Incinerate" sync / 1[56]:Ifrit:1C5:/
-30.0 "Incinerate" sync / 1[56]:Ifrit:1C5:/
-42.9 "Incinerate" sync / 1[56]:Ifrit:1C5:/
+1.2 "Incinerate" sync / 1[56]:[^:]*:Ifrit:1C5:/ window 10,10
+9.1 "Vulcan Burst" sync / 1[56]:[^:]*:Ifrit:1C6:/
+17.1 "Incinerate" sync / 1[56]:[^:]*:Ifrit:1C5:/
+30.0 "Incinerate" sync / 1[56]:[^:]*:Ifrit:1C5:/
+42.9 "Incinerate" sync / 1[56]:[^:]*:Ifrit:1C5:/
 
-50.7 "Vulcan Burst" sync / 1[56]:Ifrit:1C6:/ window 30,30 jump 9.1
+50.7 "Vulcan Burst" sync / 1[56]:[^:]*:Ifrit:1C6:/ window 30,30 jump 9.1
 58.7 "Incinerate"
 71.6 "Incinerate"
 84.5 "Incinerate"
@@ -27,13 +27,13 @@ hideall "--sync--"
 
 # 70%
 200.0 "--sync--" sync / 00:0044:Ifrit:Succumb to the inferno/ window 200,0
-201.0 "Incinerate" sync / 1[56]:Ifrit:1C5:/
-209.0 "Eruption" sync / 1[56]:Ifrit:1C7:/ window 210,5
-213.5 "Vulcan Burst" sync / 1[56]:Ifrit:1C6:/
+201.0 "Incinerate" sync / 1[56]:[^:]*:Ifrit:1C5:/
+209.0 "Eruption" sync / 1[56]:[^:]*:Ifrit:1C7:/ window 210,5
+213.5 "Vulcan Burst" sync / 1[56]:[^:]*:Ifrit:1C6:/
 
-220.4 "Incinerate" sync / 1[56]:Ifrit:1C5:/
-228.5 "Eruption" sync / 1[56]:Ifrit:1C7:/
-237.1 "Incinerate" sync / 1[56]:Ifrit:1C5:/ window 10,10 jump 220.4
+220.4 "Incinerate" sync / 1[56]:[^:]*:Ifrit:1C5:/
+228.5 "Eruption" sync / 1[56]:[^:]*:Ifrit:1C7:/
+237.1 "Incinerate" sync / 1[56]:[^:]*:Ifrit:1C5:/ window 10,10 jump 220.4
 245.2 "Eruption"
 253.8 "Incinerate"
 261.9 "Eruption"
@@ -43,22 +43,22 @@ hideall "--sync--"
 # 50%
 300.0 "--sync--" sync / 00:0044:Ifrit:Surrender thyself to the fires of judgment/ window 300,0
 305.0 "Nail Add"
-306.7 "Incinerate" sync / 1[56]:Ifrit:1C5:/
-314.4 "Vulcan Burst" sync / 1[56]:Ifrit:1C6:/
-322.3 "Incinerate" sync / 1[56]:Ifrit:1C5:/
-335.1 "Incinerate" sync / 1[56]:Ifrit:1C5:/
+306.7 "Incinerate" sync / 1[56]:[^:]*:Ifrit:1C5:/
+314.4 "Vulcan Burst" sync / 1[56]:[^:]*:Ifrit:1C6:/
+322.3 "Incinerate" sync / 1[56]:[^:]*:Ifrit:1C5:/
+335.1 "Incinerate" sync / 1[56]:[^:]*:Ifrit:1C5:/
 
 341.7 "--untargetable--"
-344.3 "--sync--" sync / 14:Ifrit:1CA:/ window 500,0
-346.3 "Hellfire" sync / 1[56]:Ifrit:1CA:/
+344.3 "--sync--" sync / 14:[^:]*:Ifrit:1CA:/ window 500,0
+346.3 "Hellfire" sync / 1[56]:[^:]*:Ifrit:1CA:/
 350.7 "--targetable--"
 
-352.6 "Incinerate" sync / 1[56]:Ifrit:1C5:/
-361.7 "Eruption" sync / 1[56]:Ifrit:1C7:/
-370.4 "Radiant Plume (inner)" sync / 1[56]:Ifrit:1C8:/
-378.8 "Radiant Plume (outer)" sync / 1[56]:Ifrit:1C8:/
+352.6 "Incinerate" sync / 1[56]:[^:]*:Ifrit:1C5:/
+361.7 "Eruption" sync / 1[56]:[^:]*:Ifrit:1C7:/
+370.4 "Radiant Plume (inner)" sync / 1[56]:[^:]*:Ifrit:1C8:/
+378.8 "Radiant Plume (outer)" sync / 1[56]:[^:]*:Ifrit:1C8:/
 
-385.0 "Incinerate" sync / 1[56]:Ifrit:1C5:/ window 20,20 jump 352.6
+385.0 "Incinerate" sync / 1[56]:[^:]*:Ifrit:1C5:/ window 20,20 jump 352.6
 394.1 "Eruption"
 402.8 "Radiant Plume (inner)"
 411.2 "Radiant Plume (outer)"

--- a/ui/raidboss/data/02-arr/trial/levi-ex.txt
+++ b/ui/raidboss/data/02-arr/trial/levi-ex.txt
@@ -40,151 +40,151 @@ hideall "--sync--"
 ### Phase 1: Literally Just Autos (100% -> 90%)
 0.0 "Start"
 0.0 "--sync--" sync /:Engage!/ window 0,1
-2.7 "--sync--" sync / 1[56]:Leviathan:822:/ window 3,1
+2.7 "--sync--" sync / 1[56]:[^:]*:Leviathan:822:/ window 3,1
 25.8 "--untargetable--" sync / 22:........:Leviathan:........:Leviathan:00/ window 30,10
 
 ### Phase 2: One Set of Orbs (90% -> 50%?)
 33.0 "--targetable--"
-33.1 "Body Slam" sync / 1[56]:Leviathan:82A:/ window 40,10
-38.3 "Veil Of The Whorl" sync / 1[56]:Leviathan:875:/ window 40,10
-43.3 "Mantle Of The Whorl" sync / 1[56]:Leviathan's Tail:874:/
+33.1 "Body Slam" sync / 1[56]:[^:]*:Leviathan:82A:/ window 40,10
+38.3 "Veil Of The Whorl" sync / 1[56]:[^:]*:Leviathan:875:/ window 40,10
+43.3 "Mantle Of The Whorl" sync / 1[56]:[^:]*:Leviathan's Tail:874:/
 45.6 "--2x Wavespine Sahagin (N)--"
-53.2 "Aqua Breath" sync / 1[56]:Leviathan:826:/
-59.3 "Tail Whip" sync / 1[56]:Leviathan's Tail:827:/
-60.4 "Waterspout" sync / 1[56]:Leviathan:742:/
-73.8 "Dread Tide" sync / 1[56]:Leviathan:754:/
-77.9 "Tidal Roar" sync / 1[56]:Leviathan:74B:/ window 30,30
+53.2 "Aqua Breath" sync / 1[56]:[^:]*:Leviathan:826:/
+59.3 "Tail Whip" sync / 1[56]:[^:]*:Leviathan's Tail:827:/
+60.4 "Waterspout" sync / 1[56]:[^:]*:Leviathan:742:/
+73.8 "Dread Tide" sync / 1[56]:[^:]*:Leviathan:754:/
+77.9 "Tidal Roar" sync / 1[56]:[^:]*:Leviathan:74B:/ window 30,30
 
 85.2 "--untargetable--"
-88.3 "Grand Fall" sync / 1[56]:Leviathan:82F:/
-90.8 "Spinning Dive" sync / 1[56]:Leviathan:82C:/
-94.3 "Grand Fall" sync / 1[56]:Leviathan:82F:/
-95.8 "Spinning Dive" sync / 1[56]:Leviathan:82C:/
+88.3 "Grand Fall" sync / 1[56]:[^:]*:Leviathan:82F:/
+90.8 "Spinning Dive" sync / 1[56]:[^:]*:Leviathan:82C:/
+94.3 "Grand Fall" sync / 1[56]:[^:]*:Leviathan:82F:/
+95.8 "Spinning Dive" sync / 1[56]:[^:]*:Leviathan:82C:/
 101.5 "--targetable--"
 
-101.6 "Body Slam" sync / 1[56]:Leviathan:82A:/ window 30,30
-106.0 "Briny Veil" sync / 1[56]:Leviathan:831:/
+101.6 "Body Slam" sync / 1[56]:[^:]*:Leviathan:82A:/ window 30,30
+106.0 "Briny Veil" sync / 1[56]:[^:]*:Leviathan:831:/
 110.7 "--Wavetooth Sahagin (E)--"
-121.0 "Dread Tide" sync / 1[56]:Leviathan:754:/
-125.1 "Aqua Breath" sync / 1[56]:Leviathan:826:/
-126.0 "Tail Whip" sync / 1[56]:Leviathan's Tail:827:/
-132.3 "Waterspout" sync / 1[56]:Leviathan:742:/
-145.7 "Dread Tide" sync / 1[56]:Leviathan:754:/
-149.8 "Tidal Roar" sync / 1[56]:Leviathan:74B:/ window 30,30
+121.0 "Dread Tide" sync / 1[56]:[^:]*:Leviathan:754:/
+125.1 "Aqua Breath" sync / 1[56]:[^:]*:Leviathan:826:/
+126.0 "Tail Whip" sync / 1[56]:[^:]*:Leviathan's Tail:827:/
+132.3 "Waterspout" sync / 1[56]:[^:]*:Leviathan:742:/
+145.7 "Dread Tide" sync / 1[56]:[^:]*:Leviathan:754:/
+149.8 "Tidal Roar" sync / 1[56]:[^:]*:Leviathan:74B:/ window 30,30
 
 154.9 "--untargetable--"
-158.0 "Grand Fall x3" #sync / 1[56]:Leviathan:82F:/
-160.5 "Spinning Dive" sync / 1[56]:Leviathan:82C:/
-165.4 "Spinning Dive" sync / 1[56]:Leviathan:82C:/
+158.0 "Grand Fall x3" #sync / 1[56]:[^:]*:Leviathan:82F:/
+160.5 "Spinning Dive" sync / 1[56]:[^:]*:Leviathan:82C:/
+165.4 "Spinning Dive" sync / 1[56]:[^:]*:Leviathan:82C:/
 171.1 "--targetable--"
 
-171.2 "Body Slam" sync / 1[56]:Leviathan:82A:/ window 30,30
+171.2 "Body Slam" sync / 1[56]:[^:]*:Leviathan:82A:/ window 30,30
 180.8 "--4x Gyre Spume--"
-192.7 "Dread Tide" sync / 1[56]:Leviathan:754:/
-196.3 "Tail Whip" #sync / 1[56]:Leviathan's Tail:827:/
-196.8 "Aqua Breath" sync / 1[56]:Leviathan:826:/
-204.0 "Waterspout" sync / 1[56]:Leviathan:742:/
-217.3 "Dread Tide" sync / 1[56]:Leviathan:754:/
-221.4 "Tidal Roar" sync / 1[56]:Leviathan:74B:/ window 30,30
+192.7 "Dread Tide" sync / 1[56]:[^:]*:Leviathan:754:/
+196.3 "Tail Whip" #sync / 1[56]:[^:]*:Leviathan's Tail:827:/
+196.8 "Aqua Breath" sync / 1[56]:[^:]*:Leviathan:826:/
+204.0 "Waterspout" sync / 1[56]:[^:]*:Leviathan:742:/
+217.3 "Dread Tide" sync / 1[56]:[^:]*:Leviathan:754:/
+221.4 "Tidal Roar" sync / 1[56]:[^:]*:Leviathan:74B:/ window 30,30
 
 228.9 "--untargetable--"
-232.0 "Grand Fall x3" #sync / 1[56]:Leviathan:82F:/
-234.5 "Spinning Dive" sync / 1[56]:Leviathan:82C:/
-239.4 "Spinning Dive" sync / 1[56]:Leviathan:82C:/
+232.0 "Grand Fall x3" #sync / 1[56]:[^:]*:Leviathan:82F:/
+234.5 "Spinning Dive" sync / 1[56]:[^:]*:Leviathan:82C:/
+239.4 "Spinning Dive" sync / 1[56]:[^:]*:Leviathan:82C:/
 245.1 "--targetable--"
 
-245.2 "Body Slam" sync / 1[56]:Leviathan:82A:/ window 30,30
-267.5 "Dread Tide" sync / 1[56]:Leviathan:754:/
+245.2 "Body Slam" sync / 1[56]:[^:]*:Leviathan:82A:/ window 30,30
+267.5 "Dread Tide" sync / 1[56]:[^:]*:Leviathan:754:/
 
 275.2 "--untargetable--"
-278.3 "Grand Fall" sync / 1[56]:Leviathan:82F:/
-280.8 "Spinning Dive" sync / 1[56]:Leviathan:82C:/
+278.3 "Grand Fall" sync / 1[56]:[^:]*:Leviathan:82F:/
+280.8 "Spinning Dive" sync / 1[56]:[^:]*:Leviathan:82C:/
 280.8 "--untargetable--"
-286.5 "Tidal Wave" sync / 1[56]:Leviathan:82E:/ window 300,100
+286.5 "Tidal Wave" sync / 1[56]:[^:]*:Leviathan:82E:/ window 300,100
 
 
 ### Phase 3: Two Sets of Orbs (50% -> 20%?)
 299.2 "--targetable--"
-299.3 "Body Slam" sync / 1[56]:Leviathan:82A:/ window 30,30
+299.3 "Body Slam" sync / 1[56]:[^:]*:Leviathan:82A:/ window 30,30
 301.3 "--2x Wavespine Sahagin (S)--"
-318.6 "Aqua Breath" sync / 1[56]:Leviathan:826:/
-318.6 "Tail Whip" #sync / 1[56]:Leviathan's Tail:827:/
-322.7 "Waterspout" sync / 1[56]:Leviathan:742:/
-329.9 "Dread Tide" sync / 1[56]:Leviathan:754:/
-338.1 "Tidal Roar" sync / 1[56]:Leviathan:74B:/
+318.6 "Aqua Breath" sync / 1[56]:[^:]*:Leviathan:826:/
+318.6 "Tail Whip" #sync / 1[56]:[^:]*:Leviathan's Tail:827:/
+322.7 "Waterspout" sync / 1[56]:[^:]*:Leviathan:742:/
+329.9 "Dread Tide" sync / 1[56]:[^:]*:Leviathan:754:/
+338.1 "Tidal Roar" sync / 1[56]:[^:]*:Leviathan:74B:/
 
 347.3 "--untargetable--"
-350.4 "Grand Fall" sync / 1[56]:Leviathan:82F:/
-352.9 "Spinning Dive" sync / 1[56]:Leviathan:82C:/
-357.8 "Spinning Dive" sync / 1[56]:Leviathan:82C:/
+350.4 "Grand Fall" sync / 1[56]:[^:]*:Leviathan:82F:/
+352.9 "Spinning Dive" sync / 1[56]:[^:]*:Leviathan:82C:/
+357.8 "Spinning Dive" sync / 1[56]:[^:]*:Leviathan:82C:/
 
 363.5 "--targetable--"
-363.6 "Body Slam" sync / 1[56]:Leviathan:82A:/ window 30,30
+363.6 "Body Slam" sync / 1[56]:[^:]*:Leviathan:82A:/ window 30,30
 364.9 "--4x Gyre Spume--"
-382.9 "Aqua Breath" sync / 1[56]:Leviathan:826:/
-385.0 "Tail Whip" #sync / 1[56]:Leviathan's Tail:827:/
-387.1 "Waterspout" sync / 1[56]:Leviathan:742:/
-394.3 "Dread Tide" sync / 1[56]:Leviathan:754:/
+382.9 "Aqua Breath" sync / 1[56]:[^:]*:Leviathan:826:/
+385.0 "Tail Whip" #sync / 1[56]:[^:]*:Leviathan's Tail:827:/
+387.1 "Waterspout" sync / 1[56]:[^:]*:Leviathan:742:/
+394.3 "Dread Tide" sync / 1[56]:[^:]*:Leviathan:754:/
 402.4 "--4x Wave Spume--"
-402.5 "Tidal Roar" sync / 1[56]:Leviathan:74B:/
+402.5 "Tidal Roar" sync / 1[56]:[^:]*:Leviathan:74B:/
 
 413.8 "--untargetable--"
-416.9 "Grand Fall x3" #sync / 1[56]:Leviathan:82F:/
-419.4 "Spinning Dive" sync / 1[56]:Leviathan:82C:/
+416.9 "Grand Fall x3" #sync / 1[56]:[^:]*:Leviathan:82F:/
+419.4 "Spinning Dive" sync / 1[56]:[^:]*:Leviathan:82C:/
 
 
 425.1 "--targetable--"
-425.2 "Body Slam" sync / 1[56]:Leviathan:82A:/
-435.3 "Dread Tide" sync / 1[56]:Leviathan:754:/
-439.6 "Aqua Burst" sync / 1[56]:Wave Spume:888:/
-442.5 "Aqua Breath" sync / 1[56]:Leviathan:826:/
-446.6 "Waterspout" sync / 1[56]:Leviathan:742:/
-455.8 "Dread Tide" sync / 1[56]:Leviathan:754:/
+425.2 "Body Slam" sync / 1[56]:[^:]*:Leviathan:82A:/
+435.3 "Dread Tide" sync / 1[56]:[^:]*:Leviathan:754:/
+439.6 "Aqua Burst" sync / 1[56]:[^:]*:Wave Spume:888:/
+442.5 "Aqua Breath" sync / 1[56]:[^:]*:Leviathan:826:/
+446.6 "Waterspout" sync / 1[56]:[^:]*:Leviathan:742:/
+455.8 "Dread Tide" sync / 1[56]:[^:]*:Leviathan:754:/
 462.5 "--untargetable--"
-465.6 "Grand Fall x3" #sync / 1[56]:Leviathan:82F:/
-468.1 "Spinning Dive" sync / 1[56]:Leviathan:82C:/
+465.6 "Grand Fall x3" #sync / 1[56]:[^:]*:Leviathan:82F:/
+468.1 "Spinning Dive" sync / 1[56]:[^:]*:Leviathan:82C:/
 468.1 "--untargetable--"
-473.9 "Tidal Wave" sync / 1[56]:Leviathan:82E:/ window 150,100
+473.9 "Tidal Wave" sync / 1[56]:[^:]*:Leviathan:82E:/ window 150,100
 
 
 ### Phase 4: more adds, enrage
 486.6 "--targetable--"
-486.7 "Body Slam" sync / 1[56]:Leviathan:82A:/ window 30,30
+486.7 "Body Slam" sync / 1[56]:[^:]*:Leviathan:82A:/ window 30,30
 488.2 "--Wavetooth Sahagin (NW)--"
-500.3 "Tidal Roar" sync / 1[56]:Leviathan:74B:/
-508.5 "Aqua Breath" sync / 1[56]:Leviathan:826:/
-512.6 "Waterspout" sync / 1[56]:Leviathan:742:/
-512.6 "Tail Whip" #sync / 1[56]:Leviathan's Tail:827:/
-519.8 "Dread Tide" sync / 1[56]:Leviathan:754:/
-523.9 "Tidal Roar" sync / 1[56]:Leviathan:74B:/
+500.3 "Tidal Roar" sync / 1[56]:[^:]*:Leviathan:74B:/
+508.5 "Aqua Breath" sync / 1[56]:[^:]*:Leviathan:826:/
+512.6 "Waterspout" sync / 1[56]:[^:]*:Leviathan:742:/
+512.6 "Tail Whip" #sync / 1[56]:[^:]*:Leviathan's Tail:827:/
+519.8 "Dread Tide" sync / 1[56]:[^:]*:Leviathan:754:/
+523.9 "Tidal Roar" sync / 1[56]:[^:]*:Leviathan:74B:/
 
 532.1 "--untargetable--"
-535.2 "Grand Fall x3" #sync / 1[56]:Leviathan:82F:/
-537.7 "Spinning Dive" sync / 1[56]:Leviathan:82C:/
-542.6 "Spinning Dive" sync / 1[56]:Leviathan:82C:/
+535.2 "Grand Fall x3" #sync / 1[56]:[^:]*:Leviathan:82F:/
+537.7 "Spinning Dive" sync / 1[56]:[^:]*:Leviathan:82C:/
+542.6 "Spinning Dive" sync / 1[56]:[^:]*:Leviathan:82C:/
 
 548.3 "--targetable--"
-548.4 "Body Slam" sync / 1[56]:Leviathan:82A:/ window 30,30
-563.6 "Dread Tide" sync / 1[56]:Leviathan:754:/
-567.7 "Tidal Roar" sync / 1[56]:Leviathan:74B:/
-581.1 "Dread Tide" sync / 1[56]:Leviathan:754:/
-587.3 "Tidal Roar" sync / 1[56]:Leviathan:74B:/
+548.4 "Body Slam" sync / 1[56]:[^:]*:Leviathan:82A:/ window 30,30
+563.6 "Dread Tide" sync / 1[56]:[^:]*:Leviathan:754:/
+567.7 "Tidal Roar" sync / 1[56]:[^:]*:Leviathan:74B:/
+581.1 "Dread Tide" sync / 1[56]:[^:]*:Leviathan:754:/
+587.3 "Tidal Roar" sync / 1[56]:[^:]*:Leviathan:74B:/
 600.9 "--2x Wavespine Sahagin--" # ? not sure where
-601.6 "Tidal Roar" sync / 1[56]:Leviathan:74B:/
-609.8 "Aqua Breath" sync / 1[56]:Leviathan:826:/
-613.9 "Waterspout" sync / 1[56]:Leviathan:742:/
-614.8 "Tail Whip" #sync / 1[56]:Leviathan's Tail:827:/
-621.1 "Dread Tide" sync / 1[56]:Leviathan:754:/
-625.2 "Tidal Roar" sync / 1[56]:Leviathan:74B:/
+601.6 "Tidal Roar" sync / 1[56]:[^:]*:Leviathan:74B:/
+609.8 "Aqua Breath" sync / 1[56]:[^:]*:Leviathan:826:/
+613.9 "Waterspout" sync / 1[56]:[^:]*:Leviathan:742:/
+614.8 "Tail Whip" #sync / 1[56]:[^:]*:Leviathan's Tail:827:/
+621.1 "Dread Tide" sync / 1[56]:[^:]*:Leviathan:754:/
+625.2 "Tidal Roar" sync / 1[56]:[^:]*:Leviathan:74B:/
 
 634.1 "--untargetable--"
-637.2 "Grand Fall x3" sync / 1[56]:Leviathan:82F:/
-639.7 "Spinning Dive" sync / 1[56]:Leviathan:82C:/
-644.6 "Spinning Dive" sync / 1[56]:Leviathan:82C:/
+637.2 "Grand Fall x3" sync / 1[56]:[^:]*:Leviathan:82F:/
+639.7 "Spinning Dive" sync / 1[56]:[^:]*:Leviathan:82C:/
+644.6 "Spinning Dive" sync / 1[56]:[^:]*:Leviathan:82C:/
 
 650.3 "--targetable--"
-650.4 "Body Slam" sync / 1[56]:Leviathan:82A:/ window 30,30
-665.6 "Dread Tide" sync / 1[56]:Leviathan:754:/
+650.4 "Body Slam" sync / 1[56]:[^:]*:Leviathan:82A:/ window 30,30
+665.6 "Dread Tide" sync / 1[56]:[^:]*:Leviathan:754:/
 
 669.6 "--untargetable--"
-676.9 "Tidal Wave Enrage" sync / 1[56]:Leviathan:82E:/
+676.9 "Tidal Wave Enrage" sync / 1[56]:[^:]*:Leviathan:82E:/

--- a/ui/raidboss/data/02-arr/trial/shiva-ex.txt
+++ b/ui/raidboss/data/02-arr/trial/shiva-ex.txt
@@ -38,204 +38,204 @@ hideall "--Reset--"
 
 # Phase 1: Literally Just Autos (100% -> 95%)
 0.0 "--sync--" sync /:Engage!/ window 0,1
-2.0 "--sync--" sync / 1[56]:Shiva:BE4:/ window 10,10
+2.0 "--sync--" sync / 1[56]:[^:]*:Shiva:BE4:/ window 10,10
 
 # jump to staff
-10.0 "--sync--" sync / 1[56]:Shiva:995:/ window 10,100 jump 100
+10.0 "--sync--" sync / 1[56]:[^:]*:Shiva:995:/ window 10,100 jump 100
 # jump to sword
-10.0 "--sync--" sync / 1[56]:Shiva:993:/ window 10,100 jump 400
+10.0 "--sync--" sync / 1[56]:[^:]*:Shiva:993:/ window 10,100 jump 400
 
 # Phase 2a: Staff (95% -> 90%)
-100.0 "Frost Staff" sync / 1[56]:Shiva:995:/
-108.1 "Hailstorm" sync / 1[56]:Shiva:997:/
+100.0 "Frost Staff" sync / 1[56]:[^:]*:Shiva:995:/
+108.1 "Hailstorm" sync / 1[56]:[^:]*:Shiva:997:/
 
-117.6 "Absolute Zero" sync / 1[56]:Shiva:BE6:/
-127.0 "Absolute Zero" sync / 1[56]:Shiva:BE6:/
+117.6 "Absolute Zero" sync / 1[56]:[^:]*:Shiva:BE6:/
+127.0 "Absolute Zero" sync / 1[56]:[^:]*:Shiva:BE6:/
 
-140.5 "Absolute Zero" sync / 1[56]:Shiva:BE6:/ window 8,8 jump 117.6
-149.9 "Absolute Zero" #sync / 1[56]:Shiva:BE6:/
+140.5 "Absolute Zero" sync / 1[56]:[^:]*:Shiva:BE6:/ window 8,8 jump 117.6
+149.9 "Absolute Zero" #sync / 1[56]:[^:]*:Shiva:BE6:/
 
-163.4 "Absolute Zero" #sync / 1[56]:Shiva:BE6:/
-173.8 "Absolute Zero" #sync / 1[56]:Shiva:BE6:/
+163.4 "Absolute Zero" #sync / 1[56]:[^:]*:Shiva:BE6:/
+173.8 "Absolute Zero" #sync / 1[56]:[^:]*:Shiva:BE6:/
 
 
 # Phase 3a: Sword (90% -> 80%)
-200.0 "Melt" sync / 1[56]:Shiva:C7F:/ window 100,0
+200.0 "Melt" sync / 1[56]:[^:]*:Shiva:C7F:/ window 100,0
 # This rolls out x4 over 1.5 seconds, so don't sync
-207.2 "Icicle Impact" #sync / 1[56]:Shiva:BEB:/
-212.3 "Dreams Of Ice" sync / 1[56]:Shiva:BEA:/
+207.2 "Icicle Impact" #sync / 1[56]:[^:]*:Shiva:BEB:/
+212.3 "Dreams Of Ice" sync / 1[56]:[^:]*:Shiva:BEA:/
 
-225.0 "Frost Blade" sync / 1[56]:Shiva:993:/
-230.1 "Icebrand" sync / 1[56]:Shiva:BE1:/
+225.0 "Frost Blade" sync / 1[56]:[^:]*:Shiva:993:/
+230.1 "Icebrand" sync / 1[56]:[^:]*:Shiva:BE1:/
 
-235.4 "Heavenly Strike" sync / 1[56]:Shiva:BE8:/
-245.0 "Glacier Bash" sync / 1[56]:Shiva:BE9:/
-255.4 "Whiteout" sync / 1[56]:Shiva:BEC:/
+235.4 "Heavenly Strike" sync / 1[56]:[^:]*:Shiva:BE8:/
+245.0 "Glacier Bash" sync / 1[56]:[^:]*:Shiva:BE9:/
+255.4 "Whiteout" sync / 1[56]:[^:]*:Shiva:BEC:/
 
-263.9 "Heavenly Strike" sync / 1[56]:Shiva:BE8:/
-273.5 "Glacier Bash" sync / 1[56]:Shiva:BE9:/
-284.5 "Whiteout" sync / 1[56]:Shiva:BEC:/
+263.9 "Heavenly Strike" sync / 1[56]:[^:]*:Shiva:BE8:/
+273.5 "Glacier Bash" sync / 1[56]:[^:]*:Shiva:BE9:/
+284.5 "Whiteout" sync / 1[56]:[^:]*:Shiva:BEC:/
 
-292.8 "Heavenly Strike" sync / 1[56]:Shiva:BE8:/ window 20,20 jump 235.4
-302.4 "Glacier Bash" #sync / 1[56]:Shiva:BE9:/
-312.8 "Whiteout" #sync / 1[56]:Shiva:BEC:/
+292.8 "Heavenly Strike" sync / 1[56]:[^:]*:Shiva:BE8:/ window 20,20 jump 235.4
+302.4 "Glacier Bash" #sync / 1[56]:[^:]*:Shiva:BE9:/
+312.8 "Whiteout" #sync / 1[56]:[^:]*:Shiva:BEC:/
 
-321.3 "Heavenly Strike" #sync / 1[56]:Shiva:BE8:/
-330.9 "Glacier Bash" #sync / 1[56]:Shiva:BE9:/
-341.9 "Whiteout" #sync / 1[56]:Shiva:BEC:/
+321.3 "Heavenly Strike" #sync / 1[56]:[^:]*:Shiva:BE8:/
+330.9 "Glacier Bash" #sync / 1[56]:[^:]*:Shiva:BE9:/
+341.9 "Whiteout" #sync / 1[56]:[^:]*:Shiva:BEC:/
 
 
 # Jump to adds phase from 1a/2a
-350.0 "--sync--" sync / 1[56]:Shiva:994:/ window 350,0 jump 800
+350.0 "--sync--" sync / 1[56]:[^:]*:Shiva:994:/ window 350,0 jump 800
 
 
 # Phase 2b: Sword (95% -> 90%)
-400.0 "Frost Blade" sync / 1[56]:Shiva:993:/
-405.1 "Icebrand" sync / 1[56]:Shiva:BE1:/
+400.0 "Frost Blade" sync / 1[56]:[^:]*:Shiva:993:/
+405.1 "Icebrand" sync / 1[56]:[^:]*:Shiva:BE1:/
 
-410.3 "Heavenly Strike" sync / 1[56]:Shiva:BE8:/
-419.9 "Glacier Bash" sync / 1[56]:Shiva:BE9:/
-430.3 "Whiteout" sync / 1[56]:Shiva:BEC:/
+410.3 "Heavenly Strike" sync / 1[56]:[^:]*:Shiva:BE8:/
+419.9 "Glacier Bash" sync / 1[56]:[^:]*:Shiva:BE9:/
+430.3 "Whiteout" sync / 1[56]:[^:]*:Shiva:BEC:/
 
-438.8 "Heavenly Strike" sync / 1[56]:Shiva:BE8:/
-448.4 "Glacier Bash" sync / 1[56]:Shiva:BE9:/
-458.8 "Whiteout" sync / 1[56]:Shiva:BEC:/
+438.8 "Heavenly Strike" sync / 1[56]:[^:]*:Shiva:BE8:/
+448.4 "Glacier Bash" sync / 1[56]:[^:]*:Shiva:BE9:/
+458.8 "Whiteout" sync / 1[56]:[^:]*:Shiva:BEC:/
 
-467.2 "Heavenly Strike" sync / 1[56]:Shiva:BE8:/ window 20,20 jump 410.3
-477.3 "Glacier Bash" #sync / 1[56]:Shiva:BE9:/
-487.7 "Whiteout" #sync / 1[56]:Shiva:BEC:/
+467.2 "Heavenly Strike" sync / 1[56]:[^:]*:Shiva:BE8:/ window 20,20 jump 410.3
+477.3 "Glacier Bash" #sync / 1[56]:[^:]*:Shiva:BE9:/
+487.7 "Whiteout" #sync / 1[56]:[^:]*:Shiva:BEC:/
 
-496.2 "Heavenly Strike" #sync / 1[56]:Shiva:BE8:/
-505.8 "Glacier Bash" #sync / 1[56]:Shiva:BE9:/
-516.8 "Whiteout" #sync / 1[56]:Shiva:BEC:/
+496.2 "Heavenly Strike" #sync / 1[56]:[^:]*:Shiva:BE8:/
+505.8 "Glacier Bash" #sync / 1[56]:[^:]*:Shiva:BE9:/
+516.8 "Whiteout" #sync / 1[56]:[^:]*:Shiva:BEC:/
 
 
 # Phase 3b: Staff (90% -> 80%)
-600.0 "Melt" sync / 1[56]:Shiva:994:/ window 200,0
+600.0 "Melt" sync / 1[56]:[^:]*:Shiva:994:/ window 200,0
 # This rolls out x4 over 1.5 seconds, so don't sync
-607.2 "Icicle Impact" #sync / 1[56]:Shiva:BEB:/
-612.3 "Dreams Of Ice" sync / 1[56]:Shiva:BEA:/
+607.2 "Icicle Impact" #sync / 1[56]:[^:]*:Shiva:BEB:/
+612.3 "Dreams Of Ice" sync / 1[56]:[^:]*:Shiva:BEA:/
 
-625.0 "Frost Staff" sync / 1[56]:Shiva:995:/
-633.1 "Hailstorm" sync / 1[56]:Shiva:997:/
+625.0 "Frost Staff" sync / 1[56]:[^:]*:Shiva:995:/
+633.1 "Hailstorm" sync / 1[56]:[^:]*:Shiva:997:/
 
-642.6 "Absolute Zero" sync / 1[56]:Shiva:BE6:/
-652.0 "Absolute Zero" sync / 1[56]:Shiva:BE6:/
+642.6 "Absolute Zero" sync / 1[56]:[^:]*:Shiva:BE6:/
+652.0 "Absolute Zero" sync / 1[56]:[^:]*:Shiva:BE6:/
 
-665.5 "Absolute Zero" sync / 1[56]:Shiva:BE6:/ window 8,8 jump 642.6
-674.9 "Absolute Zero" #sync / 1[56]:Shiva:BE6:/
+665.5 "Absolute Zero" sync / 1[56]:[^:]*:Shiva:BE6:/ window 8,8 jump 642.6
+674.9 "Absolute Zero" #sync / 1[56]:[^:]*:Shiva:BE6:/
 
-688.4 "Absolute Zero" #sync / 1[56]:Shiva:BE6:/
-698.8 "Absolute Zero" #sync / 1[56]:Shiva:BE6:/
+688.4 "Absolute Zero" #sync / 1[56]:[^:]*:Shiva:BE6:/
+698.8 "Absolute Zero" #sync / 1[56]:[^:]*:Shiva:BE6:/
 
 
 # Jump to adds phase from 1b/2b
-750.0 "--sync--" sync / 1[56]:Shiva:C7F:/ window 350,0 jump 801
+750.0 "--sync--" sync / 1[56]:[^:]*:Shiva:C7F:/ window 350,0 jump 801
 
 
 # Phase 4: Adds
-800.0 "--sync--" #sync / 1[56]:Shiva:994:/
-801.0 "--sync--" #sync / 1[56]:Shiva:C7F:/
+800.0 "--sync--" #sync / 1[56]:[^:]*:Shiva:994:/
+801.0 "--sync--" #sync / 1[56]:[^:]*:Shiva:C7F:/
 # If you push *really* fast and skip a 3a/3b weapon phase, you'll miss the melt jump.
 # So, fix that up with a combatant sync here.
 806.6 "--adds targetable--" sync / 03:........:Ice Soldier:/  window 807,10
-807.6 "Dreams Of Ice" sync / 1[56]:Shiva:BEA:/
-813.2 "Frost Blade" sync / 1[56]:Shiva:993:/
-818.5 "Icebrand" sync / 1[56]:Shiva:BE1:/
-828.0 "Glacier Bash" sync / 1[56]:Shiva:BE9:/
-837.5 "Heavenly Strike" sync / 1[56]:Shiva:BE8:/
+807.6 "Dreams Of Ice" sync / 1[56]:[^:]*:Shiva:BEA:/
+813.2 "Frost Blade" sync / 1[56]:[^:]*:Shiva:993:/
+818.5 "Icebrand" sync / 1[56]:[^:]*:Shiva:BE1:/
+828.0 "Glacier Bash" sync / 1[56]:[^:]*:Shiva:BE9:/
+837.5 "Heavenly Strike" sync / 1[56]:[^:]*:Shiva:BE8:/
 
 
 # Diamond Dust Cutscene
-854.4 "Melt" sync / 1[56]:Shiva:994:/ window 60,10
+854.4 "Melt" sync / 1[56]:[^:]*:Shiva:994:/ window 60,10
 855.5 "--untargetable--"
-866.7 "--frozen--" sync / 1[56]:Shiva:C16:/ window 900,50
-871.6 "Diamond Dust" sync / 1[56]:Shiva:98A:/
+866.7 "--frozen--" sync / 1[56]:[^:]*:Shiva:C16:/ window 900,50
+871.6 "Diamond Dust" sync / 1[56]:[^:]*:Shiva:98A:/
 878.7 "--targetable--"
-878.9 "Dreams Of Ice" sync / 1[56]:Shiva:BEA:/
+878.9 "Dreams Of Ice" sync / 1[56]:[^:]*:Shiva:BEA:/
 
 
 # Phase 5: Post-Cutscene Staff
 # Unlike phase 7a staff, this one can only have a single optional Permafrost.
-885.8 "Frost Staff" sync / 1[56]:Shiva:995:/
-888.1 "Icicle Impact (cross)" #sync / 1[56]:Shiva:BEB:/
-893.9 "Hailstorm" sync / 1[56]:Shiva:997:/
-896.0 "Icicle Impact (cross)" #sync / 1[56]:Shiva:BEB:/
-908.6 "Absolute Zero" sync / 1[56]:Shiva:BE6:/
-920.2 "Absolute Zero" sync / 1[56]:Shiva:BE6:/
-925.4 "Melt" sync / 1[56]:Shiva:C7F:/
-932.6 "Icicle Impact (circle)" duration 4 #sync / 1[56]:Shiva:BEB:/
-935.5 "Permafrost?" sync / 1[56]:Shiva:BE3:/
-939.7 "Dreams Of Ice" sync / 1[56]:Shiva:BEA:/ window 20,10
+885.8 "Frost Staff" sync / 1[56]:[^:]*:Shiva:995:/
+888.1 "Icicle Impact (cross)" #sync / 1[56]:[^:]*:Shiva:BEB:/
+893.9 "Hailstorm" sync / 1[56]:[^:]*:Shiva:997:/
+896.0 "Icicle Impact (cross)" #sync / 1[56]:[^:]*:Shiva:BEB:/
+908.6 "Absolute Zero" sync / 1[56]:[^:]*:Shiva:BE6:/
+920.2 "Absolute Zero" sync / 1[56]:[^:]*:Shiva:BE6:/
+925.4 "Melt" sync / 1[56]:[^:]*:Shiva:C7F:/
+932.6 "Icicle Impact (circle)" duration 4 #sync / 1[56]:[^:]*:Shiva:BEB:/
+935.5 "Permafrost?" sync / 1[56]:[^:]*:Shiva:BE3:/
+939.7 "Dreams Of Ice" sync / 1[56]:[^:]*:Shiva:BEA:/ window 20,10
 
 
 # Phase 6: Bow
-942.8 "Frost Bow" sync / 1[56]:Shiva:BDD:/
-947.9 "Glass Dance" sync / 1[56]:Shiva:BDF:/
-970.5 "Avalanche" sync / 1[56]:Shiva:BE0:/
-974.6 "Permafrost?" sync / 1[56]:Shiva:BE3:/
-986.1 "Melt" sync / 1[56]:Shiva:C7E:/ window 20,20
-988.3 "Dreams Of Ice" sync / 1[56]:Shiva:BEA:/
+942.8 "Frost Bow" sync / 1[56]:[^:]*:Shiva:BDD:/
+947.9 "Glass Dance" sync / 1[56]:[^:]*:Shiva:BDF:/
+970.5 "Avalanche" sync / 1[56]:[^:]*:Shiva:BE0:/
+974.6 "Permafrost?" sync / 1[56]:[^:]*:Shiva:BE3:/
+986.1 "Melt" sync / 1[56]:[^:]*:Shiva:C7E:/ window 20,20
+988.3 "Dreams Of Ice" sync / 1[56]:[^:]*:Shiva:BEA:/
 
-996.2 "Frost Staff?" sync / 1[56]:Shiva:995:/ window 100,50 jump 1096.2
-996.2 "Frost Blade?" sync / 1[56]:Shiva:993:/ window 100,50 jump 1296.2
+996.2 "Frost Staff?" sync / 1[56]:[^:]*:Shiva:995:/ window 100,50 jump 1096.2
+996.2 "Frost Blade?" sync / 1[56]:[^:]*:Shiva:993:/ window 100,50 jump 1296.2
 
 
 # Phase 7a: Staff
-1096.2 "Frost Staff" sync / 1[56]:Shiva:995:/
-1098.1 "Icicle Impact (cross)" #sync / 1[56]:Shiva:BEB:/
-1104.3 "Hailstorm" sync / 1[56]:Shiva:997:/
-1106.1 "Icicle Impact (cross)" #sync / 1[56]:Shiva:BEB:/
-1109.0 "Permafrost?" sync / 1[56]:Shiva:BE3:/
-1117.8 "Absolute Zero" sync / 1[56]:Shiva:BE6:/ window 20,2.5
-1125.6 "Absolute Zero" sync / 1[56]:Shiva:BE6:/
-1133.0 "Absolute Zero" sync / 1[56]:Shiva:BE6:/
+1096.2 "Frost Staff" sync / 1[56]:[^:]*:Shiva:995:/
+1098.1 "Icicle Impact (cross)" #sync / 1[56]:[^:]*:Shiva:BEB:/
+1104.3 "Hailstorm" sync / 1[56]:[^:]*:Shiva:997:/
+1106.1 "Icicle Impact (cross)" #sync / 1[56]:[^:]*:Shiva:BEB:/
+1109.0 "Permafrost?" sync / 1[56]:[^:]*:Shiva:BE3:/
+1117.8 "Absolute Zero" sync / 1[56]:[^:]*:Shiva:BE6:/ window 20,2.5
+1125.6 "Absolute Zero" sync / 1[56]:[^:]*:Shiva:BE6:/
+1133.0 "Absolute Zero" sync / 1[56]:[^:]*:Shiva:BE6:/
 # Note: this last absolute zero can either happen at 1135.8 or 1140.4 depending on
 # where the permafrost shows up.  So, don't sync it.
-1138.0 "Absolute Zero" #sync / 1[56]:Shiva:BE6:/
-1140.0 "Permafrost?" sync / 1[56]:Shiva:BE3:/
-1149.4 "Melt" sync / 1[56]:Shiva:C7F:/ window 20,20
-1156.6 "Icicle Impact (circle)" duration 4 #sync / 1[56]:Shiva:BEB:/
-1159.5 "Permafrost?" sync / 1[56]:Shiva:BE3:/
-1163.7 "Dreams Of Ice" sync / 1[56]:Shiva:BEA:/ window 20,20
+1138.0 "Absolute Zero" #sync / 1[56]:[^:]*:Shiva:BE6:/
+1140.0 "Permafrost?" sync / 1[56]:[^:]*:Shiva:BE3:/
+1149.4 "Melt" sync / 1[56]:[^:]*:Shiva:C7F:/ window 20,20
+1156.6 "Icicle Impact (circle)" duration 4 #sync / 1[56]:[^:]*:Shiva:BEB:/
+1159.5 "Permafrost?" sync / 1[56]:[^:]*:Shiva:BE3:/
+1163.7 "Dreams Of Ice" sync / 1[56]:[^:]*:Shiva:BEA:/ window 20,20
 
-1166.9 "Frost Bow" sync / 1[56]:Shiva:BDD:/ window 100,20 jump 942.8
-1172.0 "Glass Dance" #sync / 1[56]:Shiva:BDF:/
-1194.6 "Avalanche" #sync / 1[56]:Shiva:BE0:/
-1198.7 "Permafrost?" #sync / 1[56]:Shiva:BE3:/
-1210.2 "Melt" #sync / 1[56]:Shiva:C7E:/ window 20,20
-1212.4 "Dreams Of Ice" #sync / 1[56]:Shiva:BEA:/
+1166.9 "Frost Bow" sync / 1[56]:[^:]*:Shiva:BDD:/ window 100,20 jump 942.8
+1172.0 "Glass Dance" #sync / 1[56]:[^:]*:Shiva:BDF:/
+1194.6 "Avalanche" #sync / 1[56]:[^:]*:Shiva:BE0:/
+1198.7 "Permafrost?" #sync / 1[56]:[^:]*:Shiva:BE3:/
+1210.2 "Melt" #sync / 1[56]:[^:]*:Shiva:C7E:/ window 20,20
+1212.4 "Dreams Of Ice" #sync / 1[56]:[^:]*:Shiva:BEA:/
 
 
 
 
 # Phase 7b: Sword
-1296.2 "Frost Blade" sync / 1[56]:Shiva:993:/
-1298.5 "Icicle Impact (cross)" #sync / 1[56]:Shiva:BEB:/
-1302.3 "Icebrand" sync / 1[56]:Shiva:BE1:/
-1306.4 "Icicle Impact (cross)" #sync / 1[56]:Shiva:BEB:/
-1306.4 "Permafrost?" sync / 1[56]:Shiva:BE3:/
-1316.8 "--sync--" sync / 14:Shiva:BE9:/ window 10,10
-1319.0 "Glacier Bash" sync / 1[56]:Shiva:BE9:/
-1329.4 "Whiteout" sync / 1[56]:Shiva:BEC:/
-1334.7 "Heavenly Strike" sync / 1[56]:Shiva:BE8:/
-1338.8 "Permafrost?" sync / 1[56]:Shiva:BE3:/
-1350.7 "Melt" sync / 1[56]:Shiva:994:/ window 20,10
-1357.9 "Icicle Impact (circle)" duration 4 #sync / 1[56]:Shiva:BEB:/
-1360.8 "Permafrost?" sync / 1[56]:Shiva:BE3:/
-1365.0 "Dreams Of Ice" sync / 1[56]:Shiva:BEA:/ window 20,20
+1296.2 "Frost Blade" sync / 1[56]:[^:]*:Shiva:993:/
+1298.5 "Icicle Impact (cross)" #sync / 1[56]:[^:]*:Shiva:BEB:/
+1302.3 "Icebrand" sync / 1[56]:[^:]*:Shiva:BE1:/
+1306.4 "Icicle Impact (cross)" #sync / 1[56]:[^:]*:Shiva:BEB:/
+1306.4 "Permafrost?" sync / 1[56]:[^:]*:Shiva:BE3:/
+1316.8 "--sync--" sync / 14:[^:]*:Shiva:BE9:/ window 10,10
+1319.0 "Glacier Bash" sync / 1[56]:[^:]*:Shiva:BE9:/
+1329.4 "Whiteout" sync / 1[56]:[^:]*:Shiva:BEC:/
+1334.7 "Heavenly Strike" sync / 1[56]:[^:]*:Shiva:BE8:/
+1338.8 "Permafrost?" sync / 1[56]:[^:]*:Shiva:BE3:/
+1350.7 "Melt" sync / 1[56]:[^:]*:Shiva:994:/ window 20,10
+1357.9 "Icicle Impact (circle)" duration 4 #sync / 1[56]:[^:]*:Shiva:BEB:/
+1360.8 "Permafrost?" sync / 1[56]:[^:]*:Shiva:BE3:/
+1365.0 "Dreams Of Ice" sync / 1[56]:[^:]*:Shiva:BEA:/ window 20,20
 
-1368.2 "Frost Bow" sync / 1[56]:Shiva:BDD:/ window 100,20 jump 942.8
-1373.3 "Glass Dance" #sync / 1[56]:Shiva:BDF:/
-1395.9 "Avalanche" #sync / 1[56]:Shiva:BE0:/
-1400.0 "Permafrost?" #sync / 1[56]:Shiva:BE3:/
-1411.5 "Melt" #sync / 1[56]:Shiva:C7E:/ window 20,20
-1413.7 "Dreams Of Ice" #sync / 1[56]:Shiva:BEA:/
+1368.2 "Frost Bow" sync / 1[56]:[^:]*:Shiva:BDD:/ window 100,20 jump 942.8
+1373.3 "Glass Dance" #sync / 1[56]:[^:]*:Shiva:BDF:/
+1395.9 "Avalanche" #sync / 1[56]:[^:]*:Shiva:BE0:/
+1400.0 "Permafrost?" #sync / 1[56]:[^:]*:Shiva:BE3:/
+1411.5 "Melt" #sync / 1[56]:[^:]*:Shiva:C7E:/ window 20,20
+1413.7 "Dreams Of Ice" #sync / 1[56]:[^:]*:Shiva:BEA:/
 
 
 
 # Enrage
 #1165.6 "--untargetable--"
-#1176.7 "--sync--" sync / 1[56]:Shiva:C16:/
-#1176.7 "Diamond Dust" sync / 1[56]:Shiva:9A2:/
-#1181.6 "Diamond Dust" sync / 1[56]:Shiva:98A:/
+#1176.7 "--sync--" sync / 1[56]:[^:]*:Shiva:C16:/
+#1176.7 "Diamond Dust" sync / 1[56]:[^:]*:Shiva:9A2:/
+#1181.6 "Diamond Dust" sync / 1[56]:[^:]*:Shiva:98A:/

--- a/ui/raidboss/data/02-arr/trial/shiva-hm.txt
+++ b/ui/raidboss/data/02-arr/trial/shiva-hm.txt
@@ -33,138 +33,138 @@ hideall "--Reset--"
 
 # Phase 1: Literally Just Autos (100% -> 95%)
 0.0 "--sync--" sync /:Engage!/ window 0,1
-2.0 "--sync--" sync / 1[56]:Shiva:99A:/ window 10,10
+2.0 "--sync--" sync / 1[56]:[^:]*:Shiva:99A:/ window 10,10
 
 # jump to staff
-10.0 "--sync--" sync / 1[56]:Shiva:995:/ window 10,100 jump 200
+10.0 "--sync--" sync / 1[56]:[^:]*:Shiva:995:/ window 10,100 jump 200
 
 
 # Phase 2: Staff (95% -> 85%)
-200.0 "Frost Staff" sync / 1[56]:Shiva:995:/
-208.1 "Hailstorm" sync / 1[56]:Shiva:997:/
+200.0 "Frost Staff" sync / 1[56]:[^:]*:Shiva:995:/
+208.1 "Hailstorm" sync / 1[56]:[^:]*:Shiva:997:/
 
-221.7 "Absolute Zero" sync / 1[56]:Shiva:99C:/ window 30,30 jump 221.7
-244.7 "Absolute Zero" #sync / 1[56]:Shiva:99C:/
-267.7 "Absolute Zero" #sync / 1[56]:Shiva:99C:/
+221.7 "Absolute Zero" sync / 1[56]:[^:]*:Shiva:99C:/ window 30,30 jump 221.7
+244.7 "Absolute Zero" #sync / 1[56]:[^:]*:Shiva:99C:/
+267.7 "Absolute Zero" #sync / 1[56]:[^:]*:Shiva:99C:/
 
 
 # Phase 3: Sword (85% -> 65%)
-400.0 "Melt" sync / 1[56]:Shiva:C7F:/ window 200,0
-409.2 "Icicle Impact (cross)" sync / 1[56]:Shiva:99E:/
-417.3 "Dreams Of Ice" sync / 1[56]:Shiva:99D:/
+400.0 "Melt" sync / 1[56]:[^:]*:Shiva:C7F:/ window 200,0
+409.2 "Icicle Impact (cross)" sync / 1[56]:[^:]*:Shiva:99E:/
+417.3 "Dreams Of Ice" sync / 1[56]:[^:]*:Shiva:99D:/
 
-427.9 "Frost Blade" sync / 1[56]:Shiva:993:/
-433.0 "Icebrand" sync / 1[56]:Shiva:996:/
-439.3 "Heavenly Strike" sync / 1[56]:Shiva:9A0:/
+427.9 "Frost Blade" sync / 1[56]:[^:]*:Shiva:993:/
+433.0 "Icebrand" sync / 1[56]:[^:]*:Shiva:996:/
+439.3 "Heavenly Strike" sync / 1[56]:[^:]*:Shiva:9A0:/
 
-451.9 "Glacier Bash" sync / 1[56]:Shiva:9A1:/
-468.7 "Heavenly Strike" sync / 1[56]:Shiva:9A0:/
+451.9 "Glacier Bash" sync / 1[56]:[^:]*:Shiva:9A1:/
+468.7 "Heavenly Strike" sync / 1[56]:[^:]*:Shiva:9A0:/
 
-481.1 "Glacier Bash" sync / 1[56]:Shiva:9A1:/ window 20,20 jump 451.9
-497.9 "Heavenly Strike" #sync / 1[56]:Shiva:9A0:/
+481.1 "Glacier Bash" sync / 1[56]:[^:]*:Shiva:9A1:/ window 20,20 jump 451.9
+497.9 "Heavenly Strike" #sync / 1[56]:[^:]*:Shiva:9A0:/
 
 
 # Phase 4: Adds
-800.0 "Melt" sync / 1[56]:Shiva:994:/ window 800,0
+800.0 "Melt" sync / 1[56]:[^:]*:Shiva:994:/ window 800,0
 # If you push *really* fast and skip a weapon phase, you'll miss the melt jump.
 # So, fix that up with a combatant sync here.
 806.2 "--adds targetable--" sync / 03:........:Ice Soldier:/  window 807,2.5
-809.9 "Dreams Of Ice" sync / 1[56]:Shiva:99D:/
+809.9 "Dreams Of Ice" sync / 1[56]:[^:]*:Shiva:99D:/
 
 # Note: Yes, really.  These times are different.
-823.6 "Frost Staff?" sync / 1[56]:Shiva:995:/ window 100,100 jump 1023.6
-825.4 "Frost Blade?" sync / 1[56]:Shiva:993:/ window 100,100 jump 1225.4
+823.6 "Frost Staff?" sync / 1[56]:[^:]*:Shiva:995:/ window 100,100 jump 1023.6
+825.4 "Frost Blade?" sync / 1[56]:[^:]*:Shiva:993:/ window 100,100 jump 1225.4
 
 
 # Phase 4a: Adds (Staff)
-1023.6 "Frost Staff" sync / 1[56]:Shiva:995:/
-1031.7 "Hailstorm" sync / 1[56]:Shiva:997:/
-1044.3 "Absolute Zero" sync / 1[56]:Shiva:99C:/
+1023.6 "Frost Staff" sync / 1[56]:[^:]*:Shiva:995:/
+1031.7 "Hailstorm" sync / 1[56]:[^:]*:Shiva:997:/
+1044.3 "Absolute Zero" sync / 1[56]:[^:]*:Shiva:99C:/
 
-1051.6 "Melt" sync / 1[56]:Shiva:C7F:/ window 100,10
+1051.6 "Melt" sync / 1[56]:[^:]*:Shiva:C7F:/ window 100,10
 1052.7 "--untargetable--"
-1063.9 "--frozen--" sync / 1[56]:Shiva:C16:/ window 1100,10
-1068.8 "Diamond Dust" sync / 1[56]:Shiva:98A:/
+1063.9 "--frozen--" sync / 1[56]:[^:]*:Shiva:C16:/ window 1100,10
+1068.8 "Diamond Dust" sync / 1[56]:[^:]*:Shiva:98A:/
 1076.0 "--targetable--"
-1079.1 "Dreams Of Ice" sync / 1[56]:Shiva:99D:/
-1088.3 "Icicle Impact (circle)" duration 4 #sync / 1[56]:Shiva:99E:/
+1079.1 "Dreams Of Ice" sync / 1[56]:[^:]*:Shiva:99D:/
+1088.3 "Icicle Impact (circle)" duration 4 #sync / 1[56]:[^:]*:Shiva:99E:/
 
-1095.3 "Frost Staff?" sync / 1[56]:Shiva:995:/ jump 1400 window 50,90
-1095.3 "Frost Blade?" sync / 1[56]:Shiva:993:/ jump 1600 window 50,90
+1095.3 "Frost Staff?" sync / 1[56]:[^:]*:Shiva:995:/ jump 1400 window 50,90
+1095.3 "Frost Blade?" sync / 1[56]:[^:]*:Shiva:993:/ jump 1600 window 50,90
 
 
 # Phase 4b: Adds (Blade)
-1225.4 "Frost Blade" sync / 1[56]:Shiva:993:/
-1230.5 "Icebrand" sync / 1[56]:Shiva:996:/
-1236.8 "Heavenly Strike" sync / 1[56]:Shiva:9A0:/
-1249.2 "Glacier Bash" sync / 1[56]:Shiva:9A1:/
+1225.4 "Frost Blade" sync / 1[56]:[^:]*:Shiva:993:/
+1230.5 "Icebrand" sync / 1[56]:[^:]*:Shiva:996:/
+1236.8 "Heavenly Strike" sync / 1[56]:[^:]*:Shiva:9A0:/
+1249.2 "Glacier Bash" sync / 1[56]:[^:]*:Shiva:9A1:/
 
 # You get 5 extra seconds to kill the adds if it's Blade.
-1256.6 "Melt" sync / 1[56]:Shiva:994:/ window 100,10
+1256.6 "Melt" sync / 1[56]:[^:]*:Shiva:994:/ window 100,10
 1257.7 "--untargetable--"
-1268.9 "--frozen--" sync / 1[56]:Shiva:C16:/
-1273.8 "Diamond Dust" sync / 1[56]:Shiva:98A:/
+1268.9 "--frozen--" sync / 1[56]:[^:]*:Shiva:C16:/
+1273.8 "Diamond Dust" sync / 1[56]:[^:]*:Shiva:98A:/
 1281.0 "--targetable--"
-1284.2 "Dreams Of Ice" sync / 1[56]:Shiva:99D:/
-1293.4 "Icicle Impact (circle)" duration 4 #sync / 1[56]:Shiva:99E:/
+1284.2 "Dreams Of Ice" sync / 1[56]:[^:]*:Shiva:99D:/
+1293.4 "Icicle Impact (circle)" duration 4 #sync / 1[56]:[^:]*:Shiva:99E:/
 
-1300.6 "Frost Staff?" sync / 1[56]:Shiva:995:/ jump 1400 window 50,90
-1300.6 "Frost Blade?" sync / 1[56]:Shiva:993:/ jump 1600 window 50,90
+1300.6 "Frost Staff?" sync / 1[56]:[^:]*:Shiva:995:/ jump 1400 window 50,90
+1300.6 "Frost Blade?" sync / 1[56]:[^:]*:Shiva:993:/ jump 1600 window 50,90
 
 
 # Phase 5a: Staff
 # Note: only one absolute zero here.
-1400.0 "Frost Staff" sync / 1[56]:Shiva:995:/
-1408.1 "Hailstorm" sync / 1[56]:Shiva:997:/
-1421.7 "Absolute Zero" sync / 1[56]:Shiva:99C:/
-1432.2 "Melt" sync / 1[56]:Shiva:C7F:/
-1434.3 "Permafrost" sync / 1[56]:Shiva:999:/
-1440.5 "Dreams Of Ice" sync / 1[56]:Shiva:99D:/
-1450.7 "Icicle Impact" sync / 1[56]:Shiva:99E:/
+1400.0 "Frost Staff" sync / 1[56]:[^:]*:Shiva:995:/
+1408.1 "Hailstorm" sync / 1[56]:[^:]*:Shiva:997:/
+1421.7 "Absolute Zero" sync / 1[56]:[^:]*:Shiva:99C:/
+1432.2 "Melt" sync / 1[56]:[^:]*:Shiva:C7F:/
+1434.3 "Permafrost" sync / 1[56]:[^:]*:Shiva:999:/
+1440.5 "Dreams Of Ice" sync / 1[56]:[^:]*:Shiva:99D:/
+1450.7 "Icicle Impact" sync / 1[56]:[^:]*:Shiva:99E:/
 
-1454.7 "Frost Staff?" sync / 1[56]:Shiva:995:/ jump 1800 window 50,90
-1454.7 "Frost Blade?" sync / 1[56]:Shiva:993:/ jump 2000 window 50,90
+1454.7 "Frost Staff?" sync / 1[56]:[^:]*:Shiva:995:/ jump 1800 window 50,90
+1454.7 "Frost Blade?" sync / 1[56]:[^:]*:Shiva:993:/ jump 2000 window 50,90
 
 
 # Phase 5b: Blade
 # Note: this has the same abilities as 6b, but slightly different timings,
 # e.g. Heavenly Strike is ~1611 instead of ~1614.
-1600.0 "Frost Blade" sync / 1[56]:Shiva:993:/
-1605.3 "Icebrand" sync / 1[56]:Shiva:996:/
-1611.7 "Heavenly Strike" sync / 1[56]:Shiva:9A0:/ window 10,10
-1624.2 "Glacier Bash" sync / 1[56]:Shiva:9A1:/
-1634.8 "Melt" sync / 1[56]:Shiva:994:/
-1636.9 "Permafrost" sync / 1[56]:Shiva:999:/
-1643.1 "Dreams Of Ice" sync / 1[56]:Shiva:99D:/
-1653.3 "Icicle Impact" #sync / 1[56]:Shiva:99E:/
+1600.0 "Frost Blade" sync / 1[56]:[^:]*:Shiva:993:/
+1605.3 "Icebrand" sync / 1[56]:[^:]*:Shiva:996:/
+1611.7 "Heavenly Strike" sync / 1[56]:[^:]*:Shiva:9A0:/ window 10,10
+1624.2 "Glacier Bash" sync / 1[56]:[^:]*:Shiva:9A1:/
+1634.8 "Melt" sync / 1[56]:[^:]*:Shiva:994:/
+1636.9 "Permafrost" sync / 1[56]:[^:]*:Shiva:999:/
+1643.1 "Dreams Of Ice" sync / 1[56]:[^:]*:Shiva:99D:/
+1653.3 "Icicle Impact" #sync / 1[56]:[^:]*:Shiva:99E:/
 
-1657.6 "Frost Staff?" sync / 1[56]:Shiva:995:/ jump 1800 window 90,90
-1657.6 "Frost Blade?" sync / 1[56]:Shiva:993:/ jump 2000 window 90,90
+1657.6 "Frost Staff?" sync / 1[56]:[^:]*:Shiva:995:/ jump 1800 window 90,90
+1657.6 "Frost Blade?" sync / 1[56]:[^:]*:Shiva:993:/ jump 2000 window 90,90
 
 
 # Phase 6a: Staff
-1800.0 "Frost Staff" sync / 1[56]:Shiva:995:/
-1808.1 "Hailstorm" sync / 1[56]:Shiva:997:/
-1818.6 "Absolute Zero" sync / 1[56]:Shiva:99C:/
-1823.9 "Absolute Zero" sync / 1[56]:Shiva:99C:/
-1829.2 "Melt" sync / 1[56]:Shiva:C7F:/
-1831.3 "Permafrost" sync / 1[56]:Shiva:999:/
-1837.5 "Dreams Of Ice" sync / 1[56]:Shiva:99D:/
-1847.8 "Icicle Impact" sync / 1[56]:Shiva:99E:/
+1800.0 "Frost Staff" sync / 1[56]:[^:]*:Shiva:995:/
+1808.1 "Hailstorm" sync / 1[56]:[^:]*:Shiva:997:/
+1818.6 "Absolute Zero" sync / 1[56]:[^:]*:Shiva:99C:/
+1823.9 "Absolute Zero" sync / 1[56]:[^:]*:Shiva:99C:/
+1829.2 "Melt" sync / 1[56]:[^:]*:Shiva:C7F:/
+1831.3 "Permafrost" sync / 1[56]:[^:]*:Shiva:999:/
+1837.5 "Dreams Of Ice" sync / 1[56]:[^:]*:Shiva:99D:/
+1847.8 "Icicle Impact" sync / 1[56]:[^:]*:Shiva:99E:/
 
-1851.8 "Frost Staff?" sync / 1[56]:Shiva:995:/ jump 1800 window 90,90
-1851.8 "Frost Blade?" sync / 1[56]:Shiva:993:/ jump 2000 window 90,90
+1851.8 "Frost Staff?" sync / 1[56]:[^:]*:Shiva:995:/ jump 1800 window 90,90
+1851.8 "Frost Blade?" sync / 1[56]:[^:]*:Shiva:993:/ jump 2000 window 90,90
 
 
 # Phase 6b: Blade
-2000.0 "Frost Blade" sync / 1[56]:Shiva:993:/
-2005.1 "Icebrand" sync / 1[56]:Shiva:996:/ window 5,5
-2014.5 "Heavenly Strike" sync / 1[56]:Shiva:9A0:/ window 5,5
-2024.9 "Glacier Bash" sync / 1[56]:Shiva:9A1:/
-2030.2 "Melt" sync / 1[56]:Shiva:994:/
-2032.3 "Permafrost" sync / 1[56]:Shiva:999:/
-2038.5 "Dreams Of Ice" sync / 1[56]:Shiva:99D:/
-2048.7 "Icicle Impact" #sync / 1[56]:Shiva:99E:/
+2000.0 "Frost Blade" sync / 1[56]:[^:]*:Shiva:993:/
+2005.1 "Icebrand" sync / 1[56]:[^:]*:Shiva:996:/ window 5,5
+2014.5 "Heavenly Strike" sync / 1[56]:[^:]*:Shiva:9A0:/ window 5,5
+2024.9 "Glacier Bash" sync / 1[56]:[^:]*:Shiva:9A1:/
+2030.2 "Melt" sync / 1[56]:[^:]*:Shiva:994:/
+2032.3 "Permafrost" sync / 1[56]:[^:]*:Shiva:999:/
+2038.5 "Dreams Of Ice" sync / 1[56]:[^:]*:Shiva:99D:/
+2048.7 "Icicle Impact" #sync / 1[56]:[^:]*:Shiva:99E:/
 
-2053.5 "Frost Staff?" sync / 1[56]:Shiva:995:/ jump 1800 window 90,90
-2053.5 "Frost Blade?" sync / 1[56]:Shiva:993:/ jump 2000 window 90,90
+2053.5 "Frost Staff?" sync / 1[56]:[^:]*:Shiva:995:/ jump 1800 window 90,90
+2053.5 "Frost Blade?" sync / 1[56]:[^:]*:Shiva:993:/ jump 2000 window 90,90

--- a/ui/raidboss/data/02-arr/trial/titan-ex.txt
+++ b/ui/raidboss/data/02-arr/trial/titan-ex.txt
@@ -14,19 +14,19 @@ hideall "--sync--"
 0.0 "Start"
 0.0 "--sync--" sync /:Engage!/ window 0,1
 
-10.0 "Landslide" sync / 1[56]:Titan:5BB:/ window 10,10
-18.7 "Weight Of The Land" sync / 1[56]:Titan:5BE:/ window 20,5
-22.3 "Mountain Buster" sync / 1[56]:Titan:5B8:/
-27.5 "Tumult x4" duration 3.5 #sync / 1[56]:Titan:5B9:/
-37.3 "Landslide" sync / 1[56]:Titan:5BB:/
-41.4 "Mountain Buster" sync / 1[56]:Titan:5B8:/
-48.0 "Weight Of The Land" sync / 1[56]:Titan:5BE:/
-55.7 "Mountain Buster" sync / 1[56]:Titan:5B8:/
+10.0 "Landslide" sync / 1[56]:[^:]*:Titan:5BB:/ window 10,10
+18.7 "Weight Of The Land" sync / 1[56]:[^:]*:Titan:5BE:/ window 20,5
+22.3 "Mountain Buster" sync / 1[56]:[^:]*:Titan:5B8:/
+27.5 "Tumult x4" duration 3.5 #sync / 1[56]:[^:]*:Titan:5B9:/
+37.3 "Landslide" sync / 1[56]:[^:]*:Titan:5BB:/
+41.4 "Mountain Buster" sync / 1[56]:[^:]*:Titan:5B8:/
+48.0 "Weight Of The Land" sync / 1[56]:[^:]*:Titan:5BE:/
+55.7 "Mountain Buster" sync / 1[56]:[^:]*:Titan:5B8:/
 
-62.0 "Landslide" sync / 1[56]:Titan:5BB:/ window 15,15 jump 10
+62.0 "Landslide" sync / 1[56]:[^:]*:Titan:5BB:/ window 15,15 jump 10
 70.2 "Weight Of The Land"
 74.3 "Mountain Buster"
-79.5 "Tumult x4" duration 3.5 #sync / 1[56]:Titan:5B9:/
+79.5 "Tumult x4" duration 3.5 #sync / 1[56]:[^:]*:Titan:5B9:/
 89.3 "Landslide"
 93.4 "Mountain Buster"
 99.5 "Weight Of The Land"
@@ -34,38 +34,38 @@ hideall "--sync--"
 
 
 # Phase 2: 85%->55%
-200.0 "--sync--" sync / 14:Titan:5C0:/ window 200,0
-203.0 "Geocrush" sync / 1[56]:Titan:5C0:/
+200.0 "--sync--" sync / 14:[^:]*:Titan:5C0:/ window 200,0
+203.0 "Geocrush" sync / 1[56]:[^:]*:Titan:5C0:/
 
-212.6 "Landslide" sync / 1[56]:Titan:5BB:/
-216.7 "Rock Throw" sync / 1[56]:Titan:285:/ duration 21.5
-220.8 "Mountain Buster" sync / 1[56]:Titan:5B8:/
-229.8 "Upheaval" sync / 1[56]:Titan:5BA:/
-234.8 "Landslide" sync / 1[56]:Titan:5BB:/
-242.0 "Tumult x4" duration 3.5 # sync / 1[56]:Titan:5B9:/
-251.0 "Weight Of The Land" sync / 1[56]:Titan:5BE:/ window 15,15
-254.6 "Mountain Buster" sync / 1[56]:Titan:5B8:/
-262.0 "Landslide" sync / 1[56]:Titan:5BB:/
-271.7 "Weight Of The Land" sync / 1[56]:Titan:5BE:/
-276.8 "Bury (one side)" sync / 1[56]:Bomb Boulder:41B:/
-278.0 "Mountain Buster" sync / 1[56]:Titan:5B8:/
-287.4 "Burst" sync / 1[56]:Bomb Boulder:5BF:/
+212.6 "Landslide" sync / 1[56]:[^:]*:Titan:5BB:/
+216.7 "Rock Throw" sync / 1[56]:[^:]*:Titan:285:/ duration 21.5
+220.8 "Mountain Buster" sync / 1[56]:[^:]*:Titan:5B8:/
+229.8 "Upheaval" sync / 1[56]:[^:]*:Titan:5BA:/
+234.8 "Landslide" sync / 1[56]:[^:]*:Titan:5BB:/
+242.0 "Tumult x4" duration 3.5 # sync / 1[56]:[^:]*:Titan:5B9:/
+251.0 "Weight Of The Land" sync / 1[56]:[^:]*:Titan:5BE:/ window 15,15
+254.6 "Mountain Buster" sync / 1[56]:[^:]*:Titan:5B8:/
+262.0 "Landslide" sync / 1[56]:[^:]*:Titan:5BB:/
+271.7 "Weight Of The Land" sync / 1[56]:[^:]*:Titan:5BE:/
+276.8 "Bury (one side)" sync / 1[56]:[^:]*:Bomb Boulder:41B:/
+278.0 "Mountain Buster" sync / 1[56]:[^:]*:Titan:5B8:/
+287.4 "Burst" sync / 1[56]:[^:]*:Bomb Boulder:5BF:/
 
-288.1 "Landslide" sync / 1[56]:Titan:5BB:/
-292.2 "Rock Throw" sync / 1[56]:Titan:285:/ duration 21.5
-296.3 "Mountain Buster" sync / 1[56]:Titan:5B8:/
-305.4 "Upheaval" sync / 1[56]:Titan:5BA:/
-310.4 "Landslide" sync / 1[56]:Titan:5BB:/
-317.5 "Tumult x4" duration 3.5 #sync / 1[56]:Titan:5B9:/
-326.5 "Weight Of The Land" sync / 1[56]:Titan:5BE:/ window 15,15
-330.1 "Mountain Buster" sync / 1[56]:Titan:5B8:/
-337.3 "Landslide" sync / 1[56]:Titan:5BB:/
-347.0 "Weight Of The Land" sync / 1[56]:Titan:5BE:/
-351.7 "Bury (clock)" duration 4.2 #sync / 1[56]:Bomb Boulder:41B:/
-353.6 "Mountain Buster" sync / 1[56]:Titan:5B8:/
-360.9 "Burst" duration 4.2 #sync / 1[56]:Bomb Boulder:5BF:/
+288.1 "Landslide" sync / 1[56]:[^:]*:Titan:5BB:/
+292.2 "Rock Throw" sync / 1[56]:[^:]*:Titan:285:/ duration 21.5
+296.3 "Mountain Buster" sync / 1[56]:[^:]*:Titan:5B8:/
+305.4 "Upheaval" sync / 1[56]:[^:]*:Titan:5BA:/
+310.4 "Landslide" sync / 1[56]:[^:]*:Titan:5BB:/
+317.5 "Tumult x4" duration 3.5 #sync / 1[56]:[^:]*:Titan:5B9:/
+326.5 "Weight Of The Land" sync / 1[56]:[^:]*:Titan:5BE:/ window 15,15
+330.1 "Mountain Buster" sync / 1[56]:[^:]*:Titan:5B8:/
+337.3 "Landslide" sync / 1[56]:[^:]*:Titan:5BB:/
+347.0 "Weight Of The Land" sync / 1[56]:[^:]*:Titan:5BE:/
+351.7 "Bury (clock)" duration 4.2 #sync / 1[56]:[^:]*:Bomb Boulder:41B:/
+353.6 "Mountain Buster" sync / 1[56]:[^:]*:Titan:5B8:/
+360.9 "Burst" duration 4.2 #sync / 1[56]:[^:]*:Bomb Boulder:5BF:/
 
-363.9 "Landslide" sync / 1[56]:Titan:5BB:/ window 20,20 jump 212.6
+363.9 "Landslide" sync / 1[56]:[^:]*:Titan:5BB:/ window 20,20 jump 212.6
 368.0 "Rock Throw"
 372.1 "Mountain Buster"
 381.1 "Upheaval"
@@ -80,71 +80,71 @@ hideall "--sync--"
 
 
 ### Phase 3: Heart Phase (at 55%)
-500.0 "--sync--" sync / 14:Titan:5C0:/ window 299,0
-503.0 "Geocrush" sync / 1[56]:Titan:5C0:/
-515.6 "Weight Of The Land" sync / 1[56]:Titan:5BE:/
-521.2 "Rock Throw" sync / 1[56]:Titan:285:/ duration 21.5
-526.0 "Rock Buster" sync / 1[56]:Titan:5B7:/
-533.0 "Upheaval" sync / 1[56]:Titan:5BA:/
-538.0 "Landslide" sync / 1[56]:Titan:5BB:/
-544.0 "Tumult x4" duration 3.5 #sync / 1[56]:Titan:5B9:/
-553.1 "Weight Of The Land" sync / 1[56]:Titan:5BE:/ window 15,15
-561.8 "Rock Buster" sync / 1[56]:Titan:5B7:/
-563.8 "Bury (clock)" duration 3 # sync / 1[56]:Bomb Boulder:41B:/
-570.8 "Landslide" sync / 1[56]:Titan:5BB:/
-572.9 "Burst" duration 3 # sync / 1[56]:Bomb Boulder:5BF:/
-574.9 "Tumult x4" duration 3.5 #sync / 1[56]:Titan:5B9:/
-583.0 "Weight Of The Land" sync / 1[56]:Titan:5BE:/
+500.0 "--sync--" sync / 14:[^:]*:Titan:5C0:/ window 299,0
+503.0 "Geocrush" sync / 1[56]:[^:]*:Titan:5C0:/
+515.6 "Weight Of The Land" sync / 1[56]:[^:]*:Titan:5BE:/
+521.2 "Rock Throw" sync / 1[56]:[^:]*:Titan:285:/ duration 21.5
+526.0 "Rock Buster" sync / 1[56]:[^:]*:Titan:5B7:/
+533.0 "Upheaval" sync / 1[56]:[^:]*:Titan:5BA:/
+538.0 "Landslide" sync / 1[56]:[^:]*:Titan:5BB:/
+544.0 "Tumult x4" duration 3.5 #sync / 1[56]:[^:]*:Titan:5B9:/
+553.1 "Weight Of The Land" sync / 1[56]:[^:]*:Titan:5BE:/ window 15,15
+561.8 "Rock Buster" sync / 1[56]:[^:]*:Titan:5B7:/
+563.8 "Bury (clock)" duration 3 # sync / 1[56]:[^:]*:Bomb Boulder:41B:/
+570.8 "Landslide" sync / 1[56]:[^:]*:Titan:5BB:/
+572.9 "Burst" duration 3 # sync / 1[56]:[^:]*:Bomb Boulder:5BF:/
+574.9 "Tumult x4" duration 3.5 #sync / 1[56]:[^:]*:Titan:5B9:/
+583.0 "Weight Of The Land" sync / 1[56]:[^:]*:Titan:5BE:/
 593.0 "--untargetable--"
 
 
 ### Phase 4
-700.0 "Earthen Fury" sync / 1[56]:Titan:5C1:/ window 700,0
+700.0 "Earthen Fury" sync / 1[56]:[^:]*:Titan:5C1:/ window 700,0
 713.1 "Gaoler Adds (E/W)"
-715.8 "Gaoler Tumult" #sync / 1[56]:Granite Gaoler:5C4:/
-716.3 "Mountain Buster" sync / 1[56]:Titan:5B8:/
+715.8 "Gaoler Tumult" #sync / 1[56]:[^:]*:Granite Gaoler:5C4:/
+716.3 "Mountain Buster" sync / 1[56]:[^:]*:Titan:5B8:/
 
-723.3 "Bury x4" #sync / 1[56]:Bomb Boulder:41B:/
-725.8 "Bury x4" #sync / 1[56]:Bomb Boulder:41B:/
-730.2 "Landslide" sync / 1[56]:Titan:5BB:/
-732.5 "Burst x4" #sync / 1[56]:Bomb Boulder:5BF:/
-734.9 "Burst x4" #sync / 1[56]:Bomb Boulder:5BF:/
-735.4 "Mountain Buster" sync / 1[56]:Titan:5B8:/
-739.8 "Gaoler Landslide?" #sync / 1[56]:Granite Gaoler:5C3:/
-744.0 "Weight Of The Land" sync / 1[56]:Titan:5BE:/
+723.3 "Bury x4" #sync / 1[56]:[^:]*:Bomb Boulder:41B:/
+725.8 "Bury x4" #sync / 1[56]:[^:]*:Bomb Boulder:41B:/
+730.2 "Landslide" sync / 1[56]:[^:]*:Titan:5BB:/
+732.5 "Burst x4" #sync / 1[56]:[^:]*:Bomb Boulder:5BF:/
+734.9 "Burst x4" #sync / 1[56]:[^:]*:Bomb Boulder:5BF:/
+735.4 "Mountain Buster" sync / 1[56]:[^:]*:Titan:5B8:/
+739.8 "Gaoler Landslide?" #sync / 1[56]:[^:]*:Granite Gaoler:5C3:/
+744.0 "Weight Of The Land" sync / 1[56]:[^:]*:Titan:5BE:/
 
-749.7 "Rock Throw" sync / 1[56]:Titan:285:/ duration 21.5
-753.9 "Mountain Buster" sync / 1[56]:Titan:5B8:/
-762.9 "Upheaval" sync / 1[56]:Titan:5BA:/
-767.9 "Landslide" sync / 1[56]:Titan:5BB:/
-779.0 "Mountain Buster" sync / 1[56]:Titan:5B8:/ window 15,15
-783.2 "Tumult x4" duration 3.5 #sync / 1[56]:Titan:5B9:/
-792.2 "Weight Of The Land 1" #sync / 1[56]:Titan:5BE:/
-794.7 "Weight Of The Land 2" #sync / 1[56]:Titan:5BE:/
-799.9 "Mountain Buster" sync / 1[56]:Titan:5B8:/
+749.7 "Rock Throw" sync / 1[56]:[^:]*:Titan:285:/ duration 21.5
+753.9 "Mountain Buster" sync / 1[56]:[^:]*:Titan:5B8:/
+762.9 "Upheaval" sync / 1[56]:[^:]*:Titan:5BA:/
+767.9 "Landslide" sync / 1[56]:[^:]*:Titan:5BB:/
+779.0 "Mountain Buster" sync / 1[56]:[^:]*:Titan:5B8:/ window 15,15
+783.2 "Tumult x4" duration 3.5 #sync / 1[56]:[^:]*:Titan:5B9:/
+792.2 "Weight Of The Land 1" #sync / 1[56]:[^:]*:Titan:5BE:/
+794.7 "Weight Of The Land 2" #sync / 1[56]:[^:]*:Titan:5BE:/
+799.9 "Mountain Buster" sync / 1[56]:[^:]*:Titan:5B8:/
 
-804.1 "Bury (row 1)" #sync / 1[56]:Bomb Boulder:41B:/
-805.0 "Bury (row 2)" #sync / 1[56]:Bomb Boulder:41B:/
-806.1 "Bury (row 3)" #sync / 1[56]:Bomb Boulder:41B:/
-811.0 "Landslide" sync / 1[56]:Titan:5BB:/
-813.1 "Burst 1" #sync / 1[56]:Bomb Boulder:5BF:/
-814.6 "Burst 2" #sync / 1[56]:Bomb Boulder:5BF:/
-816.1 "Burst 3" #sync / 1[56]:Bomb Boulder:5BF:/
-819.2 "Mountain Buster" sync / 1[56]:Titan:5B8:/
+804.1 "Bury (row 1)" #sync / 1[56]:[^:]*:Bomb Boulder:41B:/
+805.0 "Bury (row 2)" #sync / 1[56]:[^:]*:Bomb Boulder:41B:/
+806.1 "Bury (row 3)" #sync / 1[56]:[^:]*:Bomb Boulder:41B:/
+811.0 "Landslide" sync / 1[56]:[^:]*:Titan:5BB:/
+813.1 "Burst 1" #sync / 1[56]:[^:]*:Bomb Boulder:5BF:/
+814.6 "Burst 2" #sync / 1[56]:[^:]*:Bomb Boulder:5BF:/
+816.1 "Burst 3" #sync / 1[56]:[^:]*:Bomb Boulder:5BF:/
+819.2 "Mountain Buster" sync / 1[56]:[^:]*:Titan:5B8:/
 
-832.7 "Bury (all)" sync / 1[56]:Bomb Boulder:41B:/
-837.0 "Tumult x4" duration 3.5 #sync / 1[56]:Titan:5B9:/
-845.9 "Weight Of The Land" sync / 1[56]:Titan:5BE:/
+832.7 "Bury (all)" sync / 1[56]:[^:]*:Bomb Boulder:41B:/
+837.0 "Tumult x4" duration 3.5 #sync / 1[56]:[^:]*:Titan:5B9:/
+845.9 "Weight Of The Land" sync / 1[56]:[^:]*:Titan:5BE:/
 852.5 "--untargetable--"
-855.1 "Burst" sync / 1[56]:Bomb Boulder:5BF:/
-856.7 "Geocrush" sync / 1[56]:Titan:5C0:/
+855.1 "Burst" sync / 1[56]:[^:]*:Bomb Boulder:5BF:/
+856.7 "Geocrush" sync / 1[56]:[^:]*:Titan:5C0:/
 857.1 "--targetable--"
-862.4 "Landslide" sync / 1[56]:Titan:5BB:/
+862.4 "Landslide" sync / 1[56]:[^:]*:Titan:5BB:/
 
 # loop
 874.0 "Gaoler Adds (E/W)"
-876.7 "Gaoler Tumult" #sync / 1[56]:Granite Gaoler:5C4:/
-877.2 "Mountain Buster" sync / 1[56]:Titan:5B8:/ window 40,40 jump 716.3
+876.7 "Gaoler Tumult" #sync / 1[56]:[^:]*:Granite Gaoler:5C4:/
+877.2 "Mountain Buster" sync / 1[56]:[^:]*:Titan:5B8:/ window 40,40 jump 716.3
 
 884.2 "Bury x4"
 886.7 "Bury x4"
@@ -157,8 +157,8 @@ hideall "--sync--"
 
 
 ### Enrage
-1000.0 "--sync--" sync / 14:Titan:5C2:/ window 1000,1000
-1010.0 "Upheaval Enrage" #sync / 1[56]:Titan:5C2:/
-1022.0 "Upheaval Enrage" #sync / 1[56]:Titan:5C2:/
-1034.0 "Upheaval Enrage" #sync / 1[56]:Titan:5C2:/
-1046.0 "Upheaval Enrage" #sync / 1[56]:Titan:5C2:/
+1000.0 "--sync--" sync / 14:[^:]*:Titan:5C2:/ window 1000,1000
+1010.0 "Upheaval Enrage" #sync / 1[56]:[^:]*:Titan:5C2:/
+1022.0 "Upheaval Enrage" #sync / 1[56]:[^:]*:Titan:5C2:/
+1034.0 "Upheaval Enrage" #sync / 1[56]:[^:]*:Titan:5C2:/
+1046.0 "Upheaval Enrage" #sync / 1[56]:[^:]*:Titan:5C2:/

--- a/ui/raidboss/data/02-arr/trial/titan-hm.txt
+++ b/ui/raidboss/data/02-arr/trial/titan-hm.txt
@@ -16,180 +16,180 @@ hideall "--sync--"
 ### Phase 1: 100->90%
 0.0 "Start"
 0.0 "--sync--" sync /:Engage!/ window 0,1
-2.0 "--sync--" sync / 1[56]:Titan:368:/ window 2,0
+2.0 "--sync--" sync / 1[56]:[^:]*:Titan:368:/ window 2,0
 
-5.0 "Rock Buster" sync / 1[56]:Titan:550:/ window 5,50
-11.2 "Landslide" sync / 1[56]:Titan:554:/
-17.4 "Tumult x2" duration 1.2 #sync / 1[56]:Titan:551:/
+5.0 "Rock Buster" sync / 1[56]:[^:]*:Titan:550:/ window 5,50
+11.2 "Landslide" sync / 1[56]:[^:]*:Titan:554:/
+17.4 "Tumult x2" duration 1.2 #sync / 1[56]:[^:]*:Titan:551:/
 
-23.7 "Rock Buster" #sync / 1[56]:Titan:550:/
-29.9 "Landslide" #sync / 1[56]:Titan:554:/
-36.1 "Tumult x2" duration 1.2 #sync / 1[56]:Titan:551:/
+23.7 "Rock Buster" #sync / 1[56]:[^:]*:Titan:550:/
+29.9 "Landslide" #sync / 1[56]:[^:]*:Titan:554:/
+36.1 "Tumult x2" duration 1.2 #sync / 1[56]:[^:]*:Titan:551:/
 
-42.4 "Rock Buster" #sync / 1[56]:Titan:550:/
-48.6 "Landslide" #sync / 1[56]:Titan:554:/
-54.8 "Tumult x2" duration 1.2 #sync / 1[56]:Titan:551:/
+42.4 "Rock Buster" #sync / 1[56]:[^:]*:Titan:550:/
+48.6 "Landslide" #sync / 1[56]:[^:]*:Titan:554:/
+54.8 "Tumult x2" duration 1.2 #sync / 1[56]:[^:]*:Titan:551:/
 
 
 # Phase 2: 90%->80%
-200.0 "--sync--" sync / 14:Titan:555:/ window 200,0
-203.0 "Geocrush" sync / 1[56]:Titan:555:/
+200.0 "--sync--" sync / 14:[^:]*:Titan:555:/ window 200,0
+203.0 "Geocrush" sync / 1[56]:[^:]*:Titan:555:/
 
-211.4 "Weight Of The Land" sync / 1[56]:Titan:552:/
-217.6 "Rock Buster" sync / 1[56]:Titan:550:/
-221.8 "Landslide" sync / 1[56]:Titan:554:/
-229.9 "Tumult x3" duration 2.4 #sync / 1[56]:Titan:551:/
+211.4 "Weight Of The Land" sync / 1[56]:[^:]*:Titan:552:/
+217.6 "Rock Buster" sync / 1[56]:[^:]*:Titan:550:/
+221.8 "Landslide" sync / 1[56]:[^:]*:Titan:554:/
+229.9 "Tumult x3" duration 2.4 #sync / 1[56]:[^:]*:Titan:551:/
 
-239.4 "Weight Of The Land" sync / 1[56]:Titan:552:/ window 40,40 jump 211.4
-245.6 "Rock Buster" #sync / 1[56]:Titan:550:/
-249.8 "Landslide" #sync / 1[56]:Titan:554:/
-257.9 "Tumult x3" duration 2.4 #sync / 1[56]:Titan:551:/
+239.4 "Weight Of The Land" sync / 1[56]:[^:]*:Titan:552:/ window 40,40 jump 211.4
+245.6 "Rock Buster" #sync / 1[56]:[^:]*:Titan:550:/
+249.8 "Landslide" #sync / 1[56]:[^:]*:Titan:554:/
+257.9 "Tumult x3" duration 2.4 #sync / 1[56]:[^:]*:Titan:551:/
 
-267.4 "Weight Of The Land" #sync / 1[56]:Titan:552:/
-273.6 "Rock Buster" #sync / 1[56]:Titan:550:/
-277.8 "Landslide" #sync / 1[56]:Titan:554:/
-285.9 "Tumult x3" duration 2.4 #sync / 1[56]:Titan:551:/
+267.4 "Weight Of The Land" #sync / 1[56]:[^:]*:Titan:552:/
+273.6 "Rock Buster" #sync / 1[56]:[^:]*:Titan:550:/
+277.8 "Landslide" #sync / 1[56]:[^:]*:Titan:554:/
+285.9 "Tumult x3" duration 2.4 #sync / 1[56]:[^:]*:Titan:551:/
 
 
 # Phase 3: 80%->60%
-400.0 "--sync--" sync / 14:Titan:555:/ window 199,0
-403.0 "Geocrush" sync / 1[56]:Titan:555:/
-411.9 "Landslide" sync / 1[56]:Titan:554:/
-420.0 "Weight Of The Land" sync / 1[56]:Titan:552:/
+400.0 "--sync--" sync / 14:[^:]*:Titan:555:/ window 199,0
+403.0 "Geocrush" sync / 1[56]:[^:]*:Titan:555:/
+411.9 "Landslide" sync / 1[56]:[^:]*:Titan:554:/
+420.0 "Weight Of The Land" sync / 1[56]:[^:]*:Titan:552:/
 
-425.1 "Bury (clock)" duration 4 #sync / 1[56]:Bomb Boulder:41B:/
-429.9 "Rock Buster" sync / 1[56]:Titan:550:/
-434.3 "Burst" duration 4 #sync / 1[56]:Bomb Boulder:41C:/
+425.1 "Bury (clock)" duration 4 #sync / 1[56]:[^:]*:Bomb Boulder:41B:/
+429.9 "Rock Buster" sync / 1[56]:[^:]*:Titan:550:/
+434.3 "Burst" duration 4 #sync / 1[56]:[^:]*:Bomb Boulder:41C:/
 
-439.5 "Landslide" sync / 1[56]:Titan:554:/
-445.6 "Weight Of The Land" sync / 1[56]:Titan:552:/
-449.7 "Rock Throw" sync / 1[56]:Titan:285:/
-456.8 "Rock Buster" sync / 1[56]:Titan:550:/
-459.8 "Tumult x3" duration 2.4 #sync / 1[56]:Titan:551:/
-469.5 "Landslide" sync / 1[56]:Titan:554:/
-477.6 "Weight Of The Land" sync / 1[56]:Titan:552:/
+439.5 "Landslide" sync / 1[56]:[^:]*:Titan:554:/
+445.6 "Weight Of The Land" sync / 1[56]:[^:]*:Titan:552:/
+449.7 "Rock Throw" sync / 1[56]:[^:]*:Titan:285:/
+456.8 "Rock Buster" sync / 1[56]:[^:]*:Titan:550:/
+459.8 "Tumult x3" duration 2.4 #sync / 1[56]:[^:]*:Titan:551:/
+469.5 "Landslide" sync / 1[56]:[^:]*:Titan:554:/
+477.6 "Weight Of The Land" sync / 1[56]:[^:]*:Titan:552:/
 
-482.7 "Bury (diamond)" duration 2 #sync / 1[56]:Bomb Boulder:41B:/
-487.5 "Rock Buster" sync / 1[56]:Titan:550:/
-491.9 "Burst" duration 3 #sync / 1[56]:Bomb Boulder:41C:/
+482.7 "Bury (diamond)" duration 2 #sync / 1[56]:[^:]*:Bomb Boulder:41B:/
+487.5 "Rock Buster" sync / 1[56]:[^:]*:Titan:550:/
+491.9 "Burst" duration 3 #sync / 1[56]:[^:]*:Bomb Boulder:41C:/
 
-497.2 "Landslide" sync / 1[56]:Titan:554:/
-503.3 "Weight Of The Land" sync / 1[56]:Titan:552:/
-507.6 "Rock Throw" sync / 1[56]:Titan:285:/
-514.8 "Rock Buster" sync / 1[56]:Titan:550:/
-517.8 "Tumult x3" duration 2.4 #sync / 1[56]:Titan:551:/
-528.1 "Landslide" sync / 1[56]:Titan:554:/
-536.2 "Weight Of The Land" sync / 1[56]:Titan:552:/ window 30,30 jump 420.0
+497.2 "Landslide" sync / 1[56]:[^:]*:Titan:554:/
+503.3 "Weight Of The Land" sync / 1[56]:[^:]*:Titan:552:/
+507.6 "Rock Throw" sync / 1[56]:[^:]*:Titan:285:/
+514.8 "Rock Buster" sync / 1[56]:[^:]*:Titan:550:/
+517.8 "Tumult x3" duration 2.4 #sync / 1[56]:[^:]*:Titan:551:/
+528.1 "Landslide" sync / 1[56]:[^:]*:Titan:554:/
+536.2 "Weight Of The Land" sync / 1[56]:[^:]*:Titan:552:/ window 30,30 jump 420.0
 
-541.3 "Bury (clock)" duration 4 #sync / 1[56]:Bomb Boulder:41B:/
-546.1 "Rock Buster" #sync / 1[56]:Titan:550:/
-550.5 "Burst" duration 4 #sync / 1[56]:Bomb Boulder:41C:/
+541.3 "Bury (clock)" duration 4 #sync / 1[56]:[^:]*:Bomb Boulder:41B:/
+546.1 "Rock Buster" #sync / 1[56]:[^:]*:Titan:550:/
+550.5 "Burst" duration 4 #sync / 1[56]:[^:]*:Bomb Boulder:41C:/
 
-555.7 "Landslide" #sync / 1[56]:Titan:554:/
-561.8 "Weight Of The Land" #sync / 1[56]:Titan:552:/
-565.9 "Rock Throw" #sync / 1[56]:Titan:285:/
-573.0 "Rock Buster" #sync / 1[56]:Titan:550:/
-576.0 "Tumult x3" duration 2.4 #sync / 1[56]:Titan:551:/
-585.7 "Landslide" #sync / 1[56]:Titan:554:/
-593.8 "Weight Of The Land" #sync / 1[56]:Titan:552:/
+555.7 "Landslide" #sync / 1[56]:[^:]*:Titan:554:/
+561.8 "Weight Of The Land" #sync / 1[56]:[^:]*:Titan:552:/
+565.9 "Rock Throw" #sync / 1[56]:[^:]*:Titan:285:/
+573.0 "Rock Buster" #sync / 1[56]:[^:]*:Titan:550:/
+576.0 "Tumult x3" duration 2.4 #sync / 1[56]:[^:]*:Titan:551:/
+585.7 "Landslide" #sync / 1[56]:[^:]*:Titan:554:/
+593.8 "Weight Of The Land" #sync / 1[56]:[^:]*:Titan:552:/
 
 
 # Phase 4: Heart
-800.0 "--sync--" sync / 14:Titan:555:/ window 399,0
-803.0 "Geocrush" sync / 1[56]:Titan:555:/
+800.0 "--sync--" sync / 14:[^:]*:Titan:555:/ window 399,0
+803.0 "Geocrush" sync / 1[56]:[^:]*:Titan:555:/
 805.3 "--targetable--"
 
-812.3 "Rock Throw" sync / 1[56]:Titan:285:/
-816.4 "Rock Buster" sync / 1[56]:Titan:550:/
-820.6 "Landslide" sync / 1[56]:Titan:554:/
-828.7 "Weight Of The Land" sync / 1[56]:Titan:552:/
+812.3 "Rock Throw" sync / 1[56]:[^:]*:Titan:285:/
+816.4 "Rock Buster" sync / 1[56]:[^:]*:Titan:550:/
+820.6 "Landslide" sync / 1[56]:[^:]*:Titan:554:/
+828.7 "Weight Of The Land" sync / 1[56]:[^:]*:Titan:552:/
 
-834.8 "Tumult x3" duration 2.4 #sync / 1[56]:Titan:551:/
+834.8 "Tumult x3" duration 2.4 #sync / 1[56]:[^:]*:Titan:551:/
 
-842.5 "Rock Throw" sync / 1[56]:Titan:285:/
-846.6 "Rock Buster" sync / 1[56]:Titan:550:/
-850.8 "Landslide" sync / 1[56]:Titan:554:/
-858.9 "Weight Of The Land" sync / 1[56]:Titan:552:/
+842.5 "Rock Throw" sync / 1[56]:[^:]*:Titan:285:/
+846.6 "Rock Buster" sync / 1[56]:[^:]*:Titan:550:/
+850.8 "Landslide" sync / 1[56]:[^:]*:Titan:554:/
+858.9 "Weight Of The Land" sync / 1[56]:[^:]*:Titan:552:/
 
 868.2 "--untargetable--"
 
 
 # Phase 5: 60%->0%
-873.7 "Earthen Fury" sync / 1[56]:Titan:556:/ window 1000,30
+873.7 "Earthen Fury" sync / 1[56]:[^:]*:Titan:556:/ window 1000,30
 878.4 "--targetable--"
-882.5 "Mountain Buster" sync / 1[56]:Titan:283:/
-886.6 "Tumult x4" duration 3.6 sync / 1[56]:Titan:551:/
-895.3 "Weight Of The Land" sync / 1[56]:Titan:552:/
+882.5 "Mountain Buster" sync / 1[56]:[^:]*:Titan:283:/
+886.6 "Tumult x4" duration 3.6 sync / 1[56]:[^:]*:Titan:551:/
+895.3 "Weight Of The Land" sync / 1[56]:[^:]*:Titan:552:/
 
-900.4 "Bury (line)" duration 2 #sync / 1[56]:Bomb Boulder:41B:/
-908.4 "Landslide" sync / 1[56]:Titan:554:/
-909.4 "Burst" duration 3 #sync / 1[56]:Bomb Boulder:41C:/
+900.4 "Bury (line)" duration 2 #sync / 1[56]:[^:]*:Bomb Boulder:41B:/
+908.4 "Landslide" sync / 1[56]:[^:]*:Titan:554:/
+909.4 "Burst" duration 3 #sync / 1[56]:[^:]*:Bomb Boulder:41C:/
 
-912.6 "Rock Buster" sync / 1[56]:Titan:550:/
-916.6 "Mountain Buster" sync / 1[56]:Titan:283:/
-922.7 "Weight Of The Land" sync / 1[56]:Titan:552:/
-927.2 "Rock Throw" sync / 1[56]:Titan:285:/
-937.5 "Landslide" sync / 1[56]:Titan:554:/
-941.6 "Rock Buster" sync / 1[56]:Titan:550:/
-945.6 "Mountain Buster" sync / 1[56]:Titan:283:/
-949.7 "Tumult x4" duration 3.6 #sync / 1[56]:Titan:551:/
-958.4 "Weight Of The Land" sync / 1[56]:Titan:552:/
+912.6 "Rock Buster" sync / 1[56]:[^:]*:Titan:550:/
+916.6 "Mountain Buster" sync / 1[56]:[^:]*:Titan:283:/
+922.7 "Weight Of The Land" sync / 1[56]:[^:]*:Titan:552:/
+927.2 "Rock Throw" sync / 1[56]:[^:]*:Titan:285:/
+937.5 "Landslide" sync / 1[56]:[^:]*:Titan:554:/
+941.6 "Rock Buster" sync / 1[56]:[^:]*:Titan:550:/
+945.6 "Mountain Buster" sync / 1[56]:[^:]*:Titan:283:/
+949.7 "Tumult x4" duration 3.6 #sync / 1[56]:[^:]*:Titan:551:/
+958.4 "Weight Of The Land" sync / 1[56]:[^:]*:Titan:552:/
 
-963.5 "Bury (clock)" duration 4 #sync / 1[56]:Bomb Boulder:41B:/
-972.0 "Landslide" sync / 1[56]:Titan:554:/
-972.7 "Burst" duration 4 #sync / 1[56]:Bomb Boulder:41C:/
+963.5 "Bury (clock)" duration 4 #sync / 1[56]:[^:]*:Bomb Boulder:41B:/
+972.0 "Landslide" sync / 1[56]:[^:]*:Titan:554:/
+972.7 "Burst" duration 4 #sync / 1[56]:[^:]*:Bomb Boulder:41C:/
 
-976.2 "Rock Buster" sync / 1[56]:Titan:550:/
-980.2 "Mountain Buster" sync / 1[56]:Titan:283:/
-986.3 "Weight Of The Land" sync / 1[56]:Titan:552:/
-990.9 "Rock Throw" sync / 1[56]:Titan:285:/
-1001.1 "Landslide" sync / 1[56]:Titan:554:/
-1005.2 "Rock Buster" sync / 1[56]:Titan:550:/
-1009.2 "Mountain Buster" sync / 1[56]:Titan:283:/
-1013.3 "Tumult x4" duration 3.6 #sync / 1[56]:Titan:551:/
-1022.0 "Weight Of The Land" sync / 1[56]:Titan:552:/
+976.2 "Rock Buster" sync / 1[56]:[^:]*:Titan:550:/
+980.2 "Mountain Buster" sync / 1[56]:[^:]*:Titan:283:/
+986.3 "Weight Of The Land" sync / 1[56]:[^:]*:Titan:552:/
+990.9 "Rock Throw" sync / 1[56]:[^:]*:Titan:285:/
+1001.1 "Landslide" sync / 1[56]:[^:]*:Titan:554:/
+1005.2 "Rock Buster" sync / 1[56]:[^:]*:Titan:550:/
+1009.2 "Mountain Buster" sync / 1[56]:[^:]*:Titan:283:/
+1013.3 "Tumult x4" duration 3.6 #sync / 1[56]:[^:]*:Titan:551:/
+1022.0 "Weight Of The Land" sync / 1[56]:[^:]*:Titan:552:/
 
-1027.1 "Bury (line)" duration 2 #sync / 1[56]:Bomb Boulder:41B:/
-1035.4 "Landslide" sync / 1[56]:Titan:554:/
-1036.2 "Burst" duration 3 #sync / 1[56]:Bomb Boulder:41C:/
+1027.1 "Bury (line)" duration 2 #sync / 1[56]:[^:]*:Bomb Boulder:41B:/
+1035.4 "Landslide" sync / 1[56]:[^:]*:Titan:554:/
+1036.2 "Burst" duration 3 #sync / 1[56]:[^:]*:Bomb Boulder:41C:/
 
-1039.6 "Rock Buster" sync / 1[56]:Titan:550:/
-1043.6 "Mountain Buster" sync / 1[56]:Titan:283:/
-1049.7 "Weight Of The Land" sync / 1[56]:Titan:552:/
-1054.5 "Rock Throw" sync / 1[56]:Titan:285:/
-1064.8 "Landslide" sync / 1[56]:Titan:554:/
-1068.9 "Rock Buster" sync / 1[56]:Titan:550:/
-1072.9 "Mountain Buster" sync / 1[56]:Titan:283:/
-1077.0 "Tumult x4" duration 3.6 #sync / 1[56]:Titan:551:/
-1085.7 "Weight Of The Land" sync / 1[56]:Titan:552:/
+1039.6 "Rock Buster" sync / 1[56]:[^:]*:Titan:550:/
+1043.6 "Mountain Buster" sync / 1[56]:[^:]*:Titan:283:/
+1049.7 "Weight Of The Land" sync / 1[56]:[^:]*:Titan:552:/
+1054.5 "Rock Throw" sync / 1[56]:[^:]*:Titan:285:/
+1064.8 "Landslide" sync / 1[56]:[^:]*:Titan:554:/
+1068.9 "Rock Buster" sync / 1[56]:[^:]*:Titan:550:/
+1072.9 "Mountain Buster" sync / 1[56]:[^:]*:Titan:283:/
+1077.0 "Tumult x4" duration 3.6 #sync / 1[56]:[^:]*:Titan:551:/
+1085.7 "Weight Of The Land" sync / 1[56]:[^:]*:Titan:552:/
 
-1090.8 "Bury (diamond)" duration 2 #sync / 1[56]:Bomb Boulder:41B:/
-1099.3 "Landslide" sync / 1[56]:Titan:554:/
-1100.0 "Burst" duration 3 #sync / 1[56]:Bomb Boulder:41C:/
+1090.8 "Bury (diamond)" duration 2 #sync / 1[56]:[^:]*:Bomb Boulder:41B:/
+1099.3 "Landslide" sync / 1[56]:[^:]*:Titan:554:/
+1100.0 "Burst" duration 3 #sync / 1[56]:[^:]*:Bomb Boulder:41C:/
 
-1103.5 "Rock Buster" sync / 1[56]:Titan:550:/
-1107.5 "Mountain Buster" sync / 1[56]:Titan:283:/
-1113.6 "Weight Of The Land" sync / 1[56]:Titan:552:/
-1118.2 "Rock Throw" sync / 1[56]:Titan:285:/
-1128.5 "Landslide" sync / 1[56]:Titan:554:/
-1132.6 "Rock Buster" sync / 1[56]:Titan:550:/
-1136.6 "Mountain Buster" sync / 1[56]:Titan:283:/
+1103.5 "Rock Buster" sync / 1[56]:[^:]*:Titan:550:/
+1107.5 "Mountain Buster" sync / 1[56]:[^:]*:Titan:283:/
+1113.6 "Weight Of The Land" sync / 1[56]:[^:]*:Titan:552:/
+1118.2 "Rock Throw" sync / 1[56]:[^:]*:Titan:285:/
+1128.5 "Landslide" sync / 1[56]:[^:]*:Titan:554:/
+1132.6 "Rock Buster" sync / 1[56]:[^:]*:Titan:550:/
+1136.6 "Mountain Buster" sync / 1[56]:[^:]*:Titan:283:/
 
-1140.7 "Tumult x5" duration 4.8 #sync / 1[56]:Titan:551:/
+1140.7 "Tumult x5" duration 4.8 #sync / 1[56]:[^:]*:Titan:551:/
 
-1150.6 "Weight Of The Land" sync / 1[56]:Titan:552:/ window 20,20 jump 895.3
+1150.6 "Weight Of The Land" sync / 1[56]:[^:]*:Titan:552:/ window 20,20 jump 895.3
 
-1155.7 "Bury (line)" #duration 2 #sync / 1[56]:Bomb Boulder:41B:/
-1163.7 "Landslide" #sync / 1[56]:Titan:554:/
-1164.7 "Burst" duration 3 #sync / 1[56]:Bomb Boulder:41C:/
+1155.7 "Bury (line)" #duration 2 #sync / 1[56]:[^:]*:Bomb Boulder:41B:/
+1163.7 "Landslide" #sync / 1[56]:[^:]*:Titan:554:/
+1164.7 "Burst" duration 3 #sync / 1[56]:[^:]*:Bomb Boulder:41C:/
 
-1167.9 "Rock Buster" #sync / 1[56]:Titan:550:/
-1171.9 "Mountain Buster" #sync / 1[56]:Titan:283:/
-1178.0 "Weight Of The Land" #sync / 1[56]:Titan:552:/
-1182.5 "Rock Throw" #sync / 1[56]:Titan:285:/
-1192.8 "Landslide" #sync / 1[56]:Titan:554:/
-1196.9 "Rock Buster" #sync / 1[56]:Titan:550:/
-1200.9 "Mountain Buster" #sync / 1[56]:Titan:283:/
-1205.0 "Tumult x4" duration 3.6 #sync / 1[56]:Titan:551:/
-1213.7 "Weight Of The Land" #sync / 1[56]:Titan:552:/
+1167.9 "Rock Buster" #sync / 1[56]:[^:]*:Titan:550:/
+1171.9 "Mountain Buster" #sync / 1[56]:[^:]*:Titan:283:/
+1178.0 "Weight Of The Land" #sync / 1[56]:[^:]*:Titan:552:/
+1182.5 "Rock Throw" #sync / 1[56]:[^:]*:Titan:285:/
+1192.8 "Landslide" #sync / 1[56]:[^:]*:Titan:554:/
+1196.9 "Rock Buster" #sync / 1[56]:[^:]*:Titan:550:/
+1200.9 "Mountain Buster" #sync / 1[56]:[^:]*:Titan:283:/
+1205.0 "Tumult x4" duration 3.6 #sync / 1[56]:[^:]*:Titan:551:/
+1213.7 "Weight Of The Land" #sync / 1[56]:[^:]*:Titan:552:/
 

--- a/ui/raidboss/data/02-arr/trial/titan-nm.txt
+++ b/ui/raidboss/data/02-arr/trial/titan-nm.txt
@@ -9,18 +9,18 @@ hideall "--sync--"
 ### Phase 1 100 -> 85%
 0.0 "Start"
 0.0 "--sync--" sync /:Engage!/ window 0,1
-2.0 "--sync--" sync / 1[56]:Titan:368:/ window 2,0
-5.0 "Rock Buster" sync / 1[56]:Titan:281:/ window 5,5
-7.0 "Tumult" sync / 1[56]:Titan:282:/
-16.1 "Tumult" sync / 1[56]:Titan:282:/
-19.2 "Rock Buster" sync / 1[56]:Titan:281:/
-25.2 "Tumult" sync / 1[56]:Titan:282:/ window 8,8
+2.0 "--sync--" sync / 1[56]:[^:]*:Titan:368:/ window 2,0
+5.0 "Rock Buster" sync / 1[56]:[^:]*:Titan:281:/ window 5,5
+7.0 "Tumult" sync / 1[56]:[^:]*:Titan:282:/
+16.1 "Tumult" sync / 1[56]:[^:]*:Titan:282:/
+19.2 "Rock Buster" sync / 1[56]:[^:]*:Titan:281:/
+25.2 "Tumult" sync / 1[56]:[^:]*:Titan:282:/ window 8,8
 
-32.3 "Rock Buster" sync / 1[56]:Titan:281:/
-34.3 "Tumult" sync / 1[56]:Titan:282:/
-43.4 "Tumult" sync / 1[56]:Titan:282:/
-46.5 "Rock Buster" sync / 1[56]:Titan:281:/
-52.5 "Tumult" sync / 1[56]:Titan:282:/ window 8,8 jump 25.2
+32.3 "Rock Buster" sync / 1[56]:[^:]*:Titan:281:/
+34.3 "Tumult" sync / 1[56]:[^:]*:Titan:282:/
+43.4 "Tumult" sync / 1[56]:[^:]*:Titan:282:/
+46.5 "Rock Buster" sync / 1[56]:[^:]*:Titan:281:/
+52.5 "Tumult" sync / 1[56]:[^:]*:Titan:282:/ window 8,8 jump 25.2
 
 59.6 "Rock Buster"
 61.6 "Tumult"
@@ -29,70 +29,70 @@ hideall "--sync--"
 79.8 "Tumult"
 
 ### Phase 2 85 -> 55%
-200.0 "--sync--" sync / 14:Titan:28B:/ window 200,0
-203.0 "Geocrush" sync / 1[56]:Titan:28B:/
+200.0 "--sync--" sync / 14:[^:]*:Titan:28B:/ window 200,0
+203.0 "Geocrush" sync / 1[56]:[^:]*:Titan:28B:/
 
-211.6 "Landslide" sync / 1[56]:Titan:28A:/ window 211,17
-217.8 "Rock Buster" sync / 1[56]:Titan:281:/
-221.8 "Tumult" sync / 1[56]:Titan:282:/
-229.1 "Landslide" sync / 1[56]:Titan:28A:/
-235.3 "Rock Buster" sync / 1[56]:Titan:281:/
-239.3 "Tumult" sync / 1[56]:Titan:282:/ window 17,16
+211.6 "Landslide" sync / 1[56]:[^:]*:Titan:28A:/ window 211,17
+217.8 "Rock Buster" sync / 1[56]:[^:]*:Titan:281:/
+221.8 "Tumult" sync / 1[56]:[^:]*:Titan:282:/
+229.1 "Landslide" sync / 1[56]:[^:]*:Titan:28A:/
+235.3 "Rock Buster" sync / 1[56]:[^:]*:Titan:281:/
+239.3 "Tumult" sync / 1[56]:[^:]*:Titan:282:/ window 17,16
 
-246.6 "Landslide" sync / 1[56]:Titan:28A:/
-252.8 "Rock Buster" sync / 1[56]:Titan:281:/
-256.8 "Tumult" sync / 1[56]:Titan:282:/ window 15,17
-264.1 "Landslide" sync / 1[56]:Titan:28A:/
-270.2 "Rock Buster" sync / 1[56]:Titan:281:/
-274.2 "Tumult" sync / 1[56]:Titan:282:/ window 17,16 jump 239.3
+246.6 "Landslide" sync / 1[56]:[^:]*:Titan:28A:/
+252.8 "Rock Buster" sync / 1[56]:[^:]*:Titan:281:/
+256.8 "Tumult" sync / 1[56]:[^:]*:Titan:282:/ window 15,17
+264.1 "Landslide" sync / 1[56]:[^:]*:Titan:28A:/
+270.2 "Rock Buster" sync / 1[56]:[^:]*:Titan:281:/
+274.2 "Tumult" sync / 1[56]:[^:]*:Titan:282:/ window 17,16 jump 239.3
 
 ### including syncs until a decision is made to keep or remove them. Potential FIX ME!
-281.6 "Landslide" sync / 1[56]:Titan:28A:/
-287.8 "Rock Buster" sync / 1[56]:Titan:281:/
-291.8 "Tumult" sync / 1[56]:Titan:282:/ window 15,17
-299.1 "Landslide" sync / 1[56]:Titan:28A:/
-305.2 "Rock Buster" sync / 1[56]:Titan:281:/
-309.2 "Tumult" sync / 1[56]:Titan:282:/
+281.6 "Landslide" sync / 1[56]:[^:]*:Titan:28A:/
+287.8 "Rock Buster" sync / 1[56]:[^:]*:Titan:281:/
+291.8 "Tumult" sync / 1[56]:[^:]*:Titan:282:/ window 15,17
+299.1 "Landslide" sync / 1[56]:[^:]*:Titan:28A:/
+305.2 "Rock Buster" sync / 1[56]:[^:]*:Titan:281:/
+309.2 "Tumult" sync / 1[56]:[^:]*:Titan:282:/
 
 ### Phase 3 Heart Phase (55%)
-400.0 "--sync--" sync / 14:Titan:28B:/ window 196,0
-403.0 "Geocrush" sync / 1[56]:Titan:28B:/
-413.6 "Rock Throw" sync / 1[56]:Titan:285:/
-421.5 "Landslide" sync / 1[56]:Titan:28A:/
-427.6 "Rock Buster" sync / 1[56]:Titan:281:/ window 20,15
-431.6 "Tumult" sync / 1[56]:Titan:282:/
-435.1 "Rock Throw" sync / 1[56]:Titan:285:/
-442.9 "Landslide" sync / 1[56]:Titan:28A:/
-449.1 "Rock Buster" sync / 1[56]:Titan:281:/
-453.1 "Tumult" sync / 1[56]:Titan:282:/ window 16,25
-464.6 "Landslide" sync / 1[56]:Titan:28A:/
+400.0 "--sync--" sync / 14:[^:]*:Titan:28B:/ window 196,0
+403.0 "Geocrush" sync / 1[56]:[^:]*:Titan:28B:/
+413.6 "Rock Throw" sync / 1[56]:[^:]*:Titan:285:/
+421.5 "Landslide" sync / 1[56]:[^:]*:Titan:28A:/
+427.6 "Rock Buster" sync / 1[56]:[^:]*:Titan:281:/ window 20,15
+431.6 "Tumult" sync / 1[56]:[^:]*:Titan:282:/
+435.1 "Rock Throw" sync / 1[56]:[^:]*:Titan:285:/
+442.9 "Landslide" sync / 1[56]:[^:]*:Titan:28A:/
+449.1 "Rock Buster" sync / 1[56]:[^:]*:Titan:281:/
+453.1 "Tumult" sync / 1[56]:[^:]*:Titan:282:/ window 16,25
+464.6 "Landslide" sync / 1[56]:[^:]*:Titan:28A:/
 473.6 "Enrage"
 
 ### Phase 4 55 -> 0%
-600.0 "--sync--" sync / 14:Earthen Fury:28C:/ window 600,0
-601.1 "Earthen Fury" sync / 1[56]:Titan:28C:/
+600.0 "--sync--" sync / 14:[^:]*:Earthen Fury:28C:/ window 600,0
+601.1 "Earthen Fury" sync / 1[56]:[^:]*:Titan:28C:/
 
-614.1 "Landslide" sync / 1[56]:Titan:28A:/
-620.2 "Rock Buster" sync / 1[56]:Titan:281:/
-624.2 "Weight Of The Land" sync / 1[56]:Titan:284:/ window 626,23
-630.3 "Tumult x2" duration 2.5 #sync / 1[56]:Titan:282:/
-636.5 "Rock Throw" sync / 1[56]:Titan:285:/
-643.6 "Landslide" sync / 1[56]:Titan:28A:/
-649.7 "Rock Buster" sync / 1[56]:Titan:281:/
-653.7 "Weight Of The Land" sync / 1[56]:Titan:284:/ window 23,26
-659.8 "Tumult x2" duration 2.5 #sync / 1[56]:Titan:282:/
-667.0 "Rock Throw" sync / 1[56]:Titan:285:/
+614.1 "Landslide" sync / 1[56]:[^:]*:Titan:28A:/
+620.2 "Rock Buster" sync / 1[56]:[^:]*:Titan:281:/
+624.2 "Weight Of The Land" sync / 1[56]:[^:]*:Titan:284:/ window 626,23
+630.3 "Tumult x2" duration 2.5 #sync / 1[56]:[^:]*:Titan:282:/
+636.5 "Rock Throw" sync / 1[56]:[^:]*:Titan:285:/
+643.6 "Landslide" sync / 1[56]:[^:]*:Titan:28A:/
+649.7 "Rock Buster" sync / 1[56]:[^:]*:Titan:281:/
+653.7 "Weight Of The Land" sync / 1[56]:[^:]*:Titan:284:/ window 23,26
+659.8 "Tumult x2" duration 2.5 #sync / 1[56]:[^:]*:Titan:282:/
+667.0 "Rock Throw" sync / 1[56]:[^:]*:Titan:285:/
 
-674.1 "Landslide" sync / 1[56]:Titan:28A:/
-680.2 "Rock Buster" sync / 1[56]:Titan:281:/
-684.2 "Weight Of The Land" sync / 1[56]:Titan:284:/ window 26,24
-690.3 "Tumult x2" duration 2.5 #sync / 1[56]:Titan:282:/
-696.5 "Rock Throw" sync / 1[56]:Titan:285:/
-703.6 "Landslide" sync / 1[56]:Titan:28A:/
-709.7 "Rock Buster" sync / 1[56]:Titan:281:/
-713.7 "Weight Of The Land" sync / 1[56]:Titan:284:/
-719.8 "Tumult x2" duration 2.5 #sync / 1[56]:Titan:282:/ window 28,23
-727.0 "Rock Throw" sync / 1[56]:Titan:285:/ window 29,28 jump 667.0
+674.1 "Landslide" sync / 1[56]:[^:]*:Titan:28A:/
+680.2 "Rock Buster" sync / 1[56]:[^:]*:Titan:281:/
+684.2 "Weight Of The Land" sync / 1[56]:[^:]*:Titan:284:/ window 26,24
+690.3 "Tumult x2" duration 2.5 #sync / 1[56]:[^:]*:Titan:282:/
+696.5 "Rock Throw" sync / 1[56]:[^:]*:Titan:285:/
+703.6 "Landslide" sync / 1[56]:[^:]*:Titan:28A:/
+709.7 "Rock Buster" sync / 1[56]:[^:]*:Titan:281:/
+713.7 "Weight Of The Land" sync / 1[56]:[^:]*:Titan:284:/
+719.8 "Tumult x2" duration 2.5 #sync / 1[56]:[^:]*:Titan:282:/ window 28,23
+727.0 "Rock Throw" sync / 1[56]:[^:]*:Titan:285:/ window 29,28 jump 667.0
 
 734.1 "Landslide"
 740.2 "Rock Buster"

--- a/ui/raidboss/data/03-hw/alliance/dun_scaith.txt
+++ b/ui/raidboss/data/03-hw/alliance/dun_scaith.txt
@@ -12,102 +12,102 @@ hideall "--sync--"
 # -ii 1C90 1ABC -ic "Fierce Wind" "Void Sprite"
 
 0 "--sync--" sync / 00:0839::The main deck will be sealed off/ window 0,5
-6.7 "Spike Of Darkness" sync / 1[56]:Deathgaze Hollow:1E51:/
-11.8 "--sync--" sync / 1[56]:Deathgaze Hollow:1C91:/
-16.6 "--sync--" sync / 1[56]:Deathgaze Hollow:1C92:/
-19.0 "Void Death" sync / 1[56]:Deathgaze Hollow:1C7F:/
-23.6 "Spike Of Darkness" sync / 1[56]:Deathgaze Hollow:1E51:/
-31.6 "Void Aero II" sync / 1[56]:Deathgaze Hollow:1C79:/
-32.4 "--sync--" sync / 1[56]:Deathgaze Hollow:1C8C:/
-34.6 "Spike Of Darkness" sync / 1[56]:Deathgaze Hollow:1E51:/
-39.1 "Void Blizzard III" sync / 1[56]:Deathgaze Hollow:1C75:/
-39.6 "--sync--" sync / 1[56]:Deathgaze Hollow:1C8A:/
-48.1 "Void Aero III" sync / 1[56]:Deathgaze Hollow:1C7B:/
-54.1 "--sync--" sync / 1[56]:Deathgaze Hollow:1C8E:/
-54.1 "Void Aero III" sync / 1[56]:Deathgaze Hollow:1C8D:/
-56.1 "Spike Of Darkness" sync / 1[56]:Deathgaze Hollow:1E51:/
-62.1 "Doomsay" sync / 1[56]:Deathgaze Hollow:1C8[45]:/
+6.7 "Spike Of Darkness" sync / 1[56]:[^:]*:Deathgaze Hollow:1E51:/
+11.8 "--sync--" sync / 1[56]:[^:]*:Deathgaze Hollow:1C91:/
+16.6 "--sync--" sync / 1[56]:[^:]*:Deathgaze Hollow:1C92:/
+19.0 "Void Death" sync / 1[56]:[^:]*:Deathgaze Hollow:1C7F:/
+23.6 "Spike Of Darkness" sync / 1[56]:[^:]*:Deathgaze Hollow:1E51:/
+31.6 "Void Aero II" sync / 1[56]:[^:]*:Deathgaze Hollow:1C79:/
+32.4 "--sync--" sync / 1[56]:[^:]*:Deathgaze Hollow:1C8C:/
+34.6 "Spike Of Darkness" sync / 1[56]:[^:]*:Deathgaze Hollow:1E51:/
+39.1 "Void Blizzard III" sync / 1[56]:[^:]*:Deathgaze Hollow:1C75:/
+39.6 "--sync--" sync / 1[56]:[^:]*:Deathgaze Hollow:1C8A:/
+48.1 "Void Aero III" sync / 1[56]:[^:]*:Deathgaze Hollow:1C7B:/
+54.1 "--sync--" sync / 1[56]:[^:]*:Deathgaze Hollow:1C8E:/
+54.1 "Void Aero III" sync / 1[56]:[^:]*:Deathgaze Hollow:1C8D:/
+56.1 "Spike Of Darkness" sync / 1[56]:[^:]*:Deathgaze Hollow:1E51:/
+62.1 "Doomsay" sync / 1[56]:[^:]*:Deathgaze Hollow:1C8[45]:/
 
 # Logs exist where this section is skipped? HP push?
-74.3 "Spike Of Darkness" sync / 1[56]:Deathgaze Hollow:1E51:/
-77.6 "--sync--" sync / 1[56]:Deathgaze Hollow:1C91:/
-82.4 "--sync--" sync / 1[56]:Deathgaze Hollow:1C92:/
-84.9 "Void Death" sync / 1[56]:Deathgaze Hollow:1C7F:/
+74.3 "Spike Of Darkness" sync / 1[56]:[^:]*:Deathgaze Hollow:1E51:/
+77.6 "--sync--" sync / 1[56]:[^:]*:Deathgaze Hollow:1C91:/
+82.4 "--sync--" sync / 1[56]:[^:]*:Deathgaze Hollow:1C92:/
+84.9 "Void Death" sync / 1[56]:[^:]*:Deathgaze Hollow:1C7F:/
 
-87.8 "--sync--" sync / 1[56]:Deathgaze Hollow:1C81:/ window 30,5
-94.8 "Void Blizzard IV" sync / 1[56]:Deathgaze Hollow:1C77:/
-99.8 "Void Blizzard IV" sync / 1[56]:Deathgaze Hollow:1C8B:/
-103.8 "Void Aero IV" sync / 1[56]:Deathgaze Hollow:1C7C:/
-104.3 "--sync--" sync / 1[56]:Deathgaze Hollow:1C8F:/
-113.8 "Spike Of Darkness" sync / 1[56]:Deathgaze Hollow:1E51:/
-123.8 "Void Aero II" sync / 1[56]:Deathgaze Hollow:1C78:/
-124.6 "--sync--" sync / 1[56]:Deathgaze Hollow:1C8C:/
-129.8 "Void Aero III" sync / 1[56]:Deathgaze Hollow:1C7A:/
-139.8 "--sync--" sync / 1[56]:Deathgaze Hollow:1C8E:/
-139.8 "Void Aero III" sync / 1[56]:Deathgaze Hollow:1C8D:/
-139.8 "Bolt Of Darkness" sync / 1[56]:Deathgaze Hollow:1C8[67]:/
-140.6 "--sync--" sync / 1[56]:Deathgaze Hollow:1C93:/
-145.8 "Void Death IV" sync / 1[56]:Deathgaze Hollow:1C8[23]:/
-149.8 "Spike Of Darkness" sync / 1[56]:Deathgaze Hollow:1E51:/
-154.8 "Doomsay" sync / 1[56]:Deathgaze Hollow:1C8[45]:/
-159.8 "Spike Of Darkness" sync / 1[56]:Deathgaze Hollow:1E51:/
-168.8 "Void Aero II" sync / 1[56]:Deathgaze Hollow:1C78:/
-169.6 "--sync--" sync / 1[56]:Deathgaze Hollow:1C8C:/
-172.8 "Spike Of Darkness" sync / 1[56]:Deathgaze Hollow:1E51:/
-178.3 "Void Blizzard III" sync / 1[56]:Deathgaze Hollow:1C74:/
-178.8 "--sync--" sync / 1[56]:Deathgaze Hollow:1C8A:/
-184.3 "Spike Of Darkness" sync / 1[56]:Deathgaze Hollow:1E51:/
-189.3 "Void Death IV" sync / 1[56]:Deathgaze Hollow:1C8[23]:/
-194.3 "--sync--" sync / 1[56]:Deathgaze Hollow:1C91:/
-199.3 "--sync--" sync / 1[56]:Deathgaze Hollow:1C92:/
-201.7 "Void Death" sync / 1[56]:Deathgaze Hollow:1C7E:/
-204.3 "Spike Of Darkness" sync / 1[56]:Deathgaze Hollow:1E51:/
-209.3 "Doomsay" sync / 1[56]:Deathgaze Hollow:1C8[45]:/
-218.3 "Void Aero II" sync / 1[56]:Deathgaze Hollow:1C78:/
-219.1 "--sync--" sync / 1[56]:Deathgaze Hollow:1C8C:/
-228.3 "Void Blizzard IV" sync / 1[56]:Deathgaze Hollow:1C76:/
-233.3 "Void Blizzard IV" sync / 1[56]:Deathgaze Hollow:1C8B:/
-237.3 "Void Aero IV" sync / 1[56]:Deathgaze Hollow:1C7D:/
-237.8 "--sync--" sync / 1[56]:Deathgaze Hollow:1C8F:/
-247.3 "Spike Of Darkness" sync / 1[56]:Deathgaze Hollow:1E51:/
-257.3 "Void Aero II" sync / 1[56]:Deathgaze Hollow:1C79:/
-258.1 "--sync--" sync / 1[56]:Deathgaze Hollow:1C8C:/
-263.3 "Void Aero III" sync / 1[56]:Deathgaze Hollow:1C7B:/
-273.3 "--sync--" sync / 1[56]:Deathgaze Hollow:1C8E:/
-273.3 "Void Aero III" sync / 1[56]:Deathgaze Hollow:1C8D:/
-273.3 "Bolt Of Darkness" sync / 1[56]:Deathgaze Hollow:1C8[67]:/
-274.1 "--sync--" sync / 1[56]:Deathgaze Hollow:1C93:/
-279.3 "Void Death IV" sync / 1[56]:Deathgaze Hollow:1C8[23]:/
-283.3 "Spike Of Darkness" sync / 1[56]:Deathgaze Hollow:1E51:/
-288.3 "Doomsay" sync / 1[56]:Deathgaze Hollow:1C8[45]:/
-293.3 "Spike Of Darkness" sync / 1[56]:Deathgaze Hollow:1E51:/
-302.3 "Void Aero II" sync / 1[56]:Deathgaze Hollow:1C79:/
-303.1 "--sync--" sync / 1[56]:Deathgaze Hollow:1C8C:/
-306.3 "Spike Of Darkness" sync / 1[56]:Deathgaze Hollow:1E51:/
-311.8 "Void Blizzard III" sync / 1[56]:Deathgaze Hollow:1C75:/
-312.3 "--sync--" sync / 1[56]:Deathgaze Hollow:1C8A:/
-317.8 "Spike Of Darkness" sync / 1[56]:Deathgaze Hollow:1E51:/
-322.8 "Void Death IV" sync / 1[56]:Deathgaze Hollow:1C8[23]:/
-327.8 "--sync--" sync / 1[56]:Deathgaze Hollow:1C91:/
-332.8 "--sync--" sync / 1[56]:Deathgaze Hollow:1C92:/
-335.2 "Void Death" sync / 1[56]:Deathgaze Hollow:1C7F:/
-337.8 "Spike Of Darkness" sync / 1[56]:Deathgaze Hollow:1E51:/
-342.8 "Doomsay" sync / 1[56]:Deathgaze Hollow:1C8[45]:/
-351.8 "Void Aero II" sync / 1[56]:Deathgaze Hollow:1C79:/
-352.6 "--sync--" sync / 1[56]:Deathgaze Hollow:1C8C:/
-361.8 "Void Blizzard IV" sync / 1[56]:Deathgaze Hollow:1C77:/
-366.8 "Void Blizzard IV" sync / 1[56]:Deathgaze Hollow:1C8B:/
-370.8 "Void Aero IV" sync / 1[56]:Deathgaze Hollow:1C7C:/
-371.3 "--sync--" sync / 1[56]:Deathgaze Hollow:1C8F:/
-380.8 "Spike Of Darkness" sync / 1[56]:Deathgaze Hollow:1E51:/
-390.8 "Void Aero II" sync / 1[56]:Deathgaze Hollow:1C78:/
-391.6 "--sync--" sync / 1[56]:Deathgaze Hollow:1C8C:/
-396.8 "Void Aero III" sync / 1[56]:Deathgaze Hollow:1C7A:/
-406.8 "--sync--" sync / 1[56]:Deathgaze Hollow:1C8E:/
-406.8 "Void Aero III" sync / 1[56]:Deathgaze Hollow:1C8D:/
-406.8 "Bolt Of Darkness" sync / 1[56]:Deathgaze Hollow:1C8[67]:/
-407.6 "--sync--" sync / 1[56]:Deathgaze Hollow:1C93:/
-412.8 "Void Death IV" sync / 1[56]:Deathgaze Hollow:1C8[23]:/
+87.8 "--sync--" sync / 1[56]:[^:]*:Deathgaze Hollow:1C81:/ window 30,5
+94.8 "Void Blizzard IV" sync / 1[56]:[^:]*:Deathgaze Hollow:1C77:/
+99.8 "Void Blizzard IV" sync / 1[56]:[^:]*:Deathgaze Hollow:1C8B:/
+103.8 "Void Aero IV" sync / 1[56]:[^:]*:Deathgaze Hollow:1C7C:/
+104.3 "--sync--" sync / 1[56]:[^:]*:Deathgaze Hollow:1C8F:/
+113.8 "Spike Of Darkness" sync / 1[56]:[^:]*:Deathgaze Hollow:1E51:/
+123.8 "Void Aero II" sync / 1[56]:[^:]*:Deathgaze Hollow:1C78:/
+124.6 "--sync--" sync / 1[56]:[^:]*:Deathgaze Hollow:1C8C:/
+129.8 "Void Aero III" sync / 1[56]:[^:]*:Deathgaze Hollow:1C7A:/
+139.8 "--sync--" sync / 1[56]:[^:]*:Deathgaze Hollow:1C8E:/
+139.8 "Void Aero III" sync / 1[56]:[^:]*:Deathgaze Hollow:1C8D:/
+139.8 "Bolt Of Darkness" sync / 1[56]:[^:]*:Deathgaze Hollow:1C8[67]:/
+140.6 "--sync--" sync / 1[56]:[^:]*:Deathgaze Hollow:1C93:/
+145.8 "Void Death IV" sync / 1[56]:[^:]*:Deathgaze Hollow:1C8[23]:/
+149.8 "Spike Of Darkness" sync / 1[56]:[^:]*:Deathgaze Hollow:1E51:/
+154.8 "Doomsay" sync / 1[56]:[^:]*:Deathgaze Hollow:1C8[45]:/
+159.8 "Spike Of Darkness" sync / 1[56]:[^:]*:Deathgaze Hollow:1E51:/
+168.8 "Void Aero II" sync / 1[56]:[^:]*:Deathgaze Hollow:1C78:/
+169.6 "--sync--" sync / 1[56]:[^:]*:Deathgaze Hollow:1C8C:/
+172.8 "Spike Of Darkness" sync / 1[56]:[^:]*:Deathgaze Hollow:1E51:/
+178.3 "Void Blizzard III" sync / 1[56]:[^:]*:Deathgaze Hollow:1C74:/
+178.8 "--sync--" sync / 1[56]:[^:]*:Deathgaze Hollow:1C8A:/
+184.3 "Spike Of Darkness" sync / 1[56]:[^:]*:Deathgaze Hollow:1E51:/
+189.3 "Void Death IV" sync / 1[56]:[^:]*:Deathgaze Hollow:1C8[23]:/
+194.3 "--sync--" sync / 1[56]:[^:]*:Deathgaze Hollow:1C91:/
+199.3 "--sync--" sync / 1[56]:[^:]*:Deathgaze Hollow:1C92:/
+201.7 "Void Death" sync / 1[56]:[^:]*:Deathgaze Hollow:1C7E:/
+204.3 "Spike Of Darkness" sync / 1[56]:[^:]*:Deathgaze Hollow:1E51:/
+209.3 "Doomsay" sync / 1[56]:[^:]*:Deathgaze Hollow:1C8[45]:/
+218.3 "Void Aero II" sync / 1[56]:[^:]*:Deathgaze Hollow:1C78:/
+219.1 "--sync--" sync / 1[56]:[^:]*:Deathgaze Hollow:1C8C:/
+228.3 "Void Blizzard IV" sync / 1[56]:[^:]*:Deathgaze Hollow:1C76:/
+233.3 "Void Blizzard IV" sync / 1[56]:[^:]*:Deathgaze Hollow:1C8B:/
+237.3 "Void Aero IV" sync / 1[56]:[^:]*:Deathgaze Hollow:1C7D:/
+237.8 "--sync--" sync / 1[56]:[^:]*:Deathgaze Hollow:1C8F:/
+247.3 "Spike Of Darkness" sync / 1[56]:[^:]*:Deathgaze Hollow:1E51:/
+257.3 "Void Aero II" sync / 1[56]:[^:]*:Deathgaze Hollow:1C79:/
+258.1 "--sync--" sync / 1[56]:[^:]*:Deathgaze Hollow:1C8C:/
+263.3 "Void Aero III" sync / 1[56]:[^:]*:Deathgaze Hollow:1C7B:/
+273.3 "--sync--" sync / 1[56]:[^:]*:Deathgaze Hollow:1C8E:/
+273.3 "Void Aero III" sync / 1[56]:[^:]*:Deathgaze Hollow:1C8D:/
+273.3 "Bolt Of Darkness" sync / 1[56]:[^:]*:Deathgaze Hollow:1C8[67]:/
+274.1 "--sync--" sync / 1[56]:[^:]*:Deathgaze Hollow:1C93:/
+279.3 "Void Death IV" sync / 1[56]:[^:]*:Deathgaze Hollow:1C8[23]:/
+283.3 "Spike Of Darkness" sync / 1[56]:[^:]*:Deathgaze Hollow:1E51:/
+288.3 "Doomsay" sync / 1[56]:[^:]*:Deathgaze Hollow:1C8[45]:/
+293.3 "Spike Of Darkness" sync / 1[56]:[^:]*:Deathgaze Hollow:1E51:/
+302.3 "Void Aero II" sync / 1[56]:[^:]*:Deathgaze Hollow:1C79:/
+303.1 "--sync--" sync / 1[56]:[^:]*:Deathgaze Hollow:1C8C:/
+306.3 "Spike Of Darkness" sync / 1[56]:[^:]*:Deathgaze Hollow:1E51:/
+311.8 "Void Blizzard III" sync / 1[56]:[^:]*:Deathgaze Hollow:1C75:/
+312.3 "--sync--" sync / 1[56]:[^:]*:Deathgaze Hollow:1C8A:/
+317.8 "Spike Of Darkness" sync / 1[56]:[^:]*:Deathgaze Hollow:1E51:/
+322.8 "Void Death IV" sync / 1[56]:[^:]*:Deathgaze Hollow:1C8[23]:/
+327.8 "--sync--" sync / 1[56]:[^:]*:Deathgaze Hollow:1C91:/
+332.8 "--sync--" sync / 1[56]:[^:]*:Deathgaze Hollow:1C92:/
+335.2 "Void Death" sync / 1[56]:[^:]*:Deathgaze Hollow:1C7F:/
+337.8 "Spike Of Darkness" sync / 1[56]:[^:]*:Deathgaze Hollow:1E51:/
+342.8 "Doomsay" sync / 1[56]:[^:]*:Deathgaze Hollow:1C8[45]:/
+351.8 "Void Aero II" sync / 1[56]:[^:]*:Deathgaze Hollow:1C79:/
+352.6 "--sync--" sync / 1[56]:[^:]*:Deathgaze Hollow:1C8C:/
+361.8 "Void Blizzard IV" sync / 1[56]:[^:]*:Deathgaze Hollow:1C77:/
+366.8 "Void Blizzard IV" sync / 1[56]:[^:]*:Deathgaze Hollow:1C8B:/
+370.8 "Void Aero IV" sync / 1[56]:[^:]*:Deathgaze Hollow:1C7C:/
+371.3 "--sync--" sync / 1[56]:[^:]*:Deathgaze Hollow:1C8F:/
+380.8 "Spike Of Darkness" sync / 1[56]:[^:]*:Deathgaze Hollow:1E51:/
+390.8 "Void Aero II" sync / 1[56]:[^:]*:Deathgaze Hollow:1C78:/
+391.6 "--sync--" sync / 1[56]:[^:]*:Deathgaze Hollow:1C8C:/
+396.8 "Void Aero III" sync / 1[56]:[^:]*:Deathgaze Hollow:1C7A:/
+406.8 "--sync--" sync / 1[56]:[^:]*:Deathgaze Hollow:1C8E:/
+406.8 "Void Aero III" sync / 1[56]:[^:]*:Deathgaze Hollow:1C8D:/
+406.8 "Bolt Of Darkness" sync / 1[56]:[^:]*:Deathgaze Hollow:1C8[67]:/
+407.6 "--sync--" sync / 1[56]:[^:]*:Deathgaze Hollow:1C93:/
+412.8 "Void Death IV" sync / 1[56]:[^:]*:Deathgaze Hollow:1C8[23]:/
 
 
 #~~~~~~~~~~~~~~~~#
@@ -118,25 +118,25 @@ hideall "--sync--"
 # -ic "Ferdiad's Fool"
 
 1000.0 "--sync--" sync / 00:0839::The Rostrum will be sealed off/ window 1000,5
-1014.2 "Black Wind x3" # sync / 1[56]:Ferdiad Hollow:1CAC:/
-1020.3 "Sleight" sync / 1[56]:Ferdiad Hollow:1C99:/
-1028.0 "Wormhole" sync / 1[56]:Ferdiad Hollow:1C9A:/
-1028.3 "--sync--" sync / 1[56]:(Cursing Atomos|Wailing Atomos):1C49:/
-1028.5 "Juggling Sphere" sync / 1[56]:(Aether|Aetherial Chakram):1C(9F|A0):/
-1030.0 "--sync--" sync / 1[56]:(Cursing Atomos|Wailing Atomos):1C9[CD]:/
-1033.2 "Explosion" sync / 1[56]:(Aether|Aetherial Chakram):1CA[12]:/
-1039.2 "Jester's Reap" sync / 1[56]:Ferdiad Hollow:1E41:/
-1047.2 "Jongleur's X" sync / 1[56]:Ferdiad Hollow:1C98:/
-1052.2 "Sleight" sync / 1[56]:Ferdiad Hollow:1C99:/
-1060.5 "Wormhole" sync / 1[56]:Ferdiad Hollow:1C9A:/
-1060.8 "--sync--" sync / 1[56]:(Cursing Atomos|Wailing Atomos):1C49:/
-1061.0 "Juggling Sphere" sync / 1[56]:(Aether|Aetherial Chakram):1C(9F|A0):/
-1062.5 "--sync--" sync / 1[56]:(Cursing Atomos|Wailing Atomos):1C9[CD]:/
-1065.7 "Explosion" sync / 1[56]:(Aether|Aetherial Chakram):1CA[12]:/
-1069.7 "Debilitator" sync / 1[56]:Ferdiad Hollow:1CA6:/
-1079.9 "Jongleur's X" sync / 1[56]:Ferdiad Hollow:1C98:/
-1087.4 "Flameflow" sync / 1[56]:Ferdiad Hollow:1CA7:/
-1089.9 "Sleight" sync / 1[56]:Ferdiad Hollow:1C99:/
+1014.2 "Black Wind x3" # sync / 1[56]:[^:]*:Ferdiad Hollow:1CAC:/
+1020.3 "Sleight" sync / 1[56]:[^:]*:Ferdiad Hollow:1C99:/
+1028.0 "Wormhole" sync / 1[56]:[^:]*:Ferdiad Hollow:1C9A:/
+1028.3 "--sync--" sync / 1[56]:[^:]*:(Cursing Atomos|Wailing Atomos):1C49:/
+1028.5 "Juggling Sphere" sync / 1[56]:[^:]*:(Aether|Aetherial Chakram):1C(9F|A0):/
+1030.0 "--sync--" sync / 1[56]:[^:]*:(Cursing Atomos|Wailing Atomos):1C9[CD]:/
+1033.2 "Explosion" sync / 1[56]:[^:]*:(Aether|Aetherial Chakram):1CA[12]:/
+1039.2 "Jester's Reap" sync / 1[56]:[^:]*:Ferdiad Hollow:1E41:/
+1047.2 "Jongleur's X" sync / 1[56]:[^:]*:Ferdiad Hollow:1C98:/
+1052.2 "Sleight" sync / 1[56]:[^:]*:Ferdiad Hollow:1C99:/
+1060.5 "Wormhole" sync / 1[56]:[^:]*:Ferdiad Hollow:1C9A:/
+1060.8 "--sync--" sync / 1[56]:[^:]*:(Cursing Atomos|Wailing Atomos):1C49:/
+1061.0 "Juggling Sphere" sync / 1[56]:[^:]*:(Aether|Aetherial Chakram):1C(9F|A0):/
+1062.5 "--sync--" sync / 1[56]:[^:]*:(Cursing Atomos|Wailing Atomos):1C9[CD]:/
+1065.7 "Explosion" sync / 1[56]:[^:]*:(Aether|Aetherial Chakram):1CA[12]:/
+1069.7 "Debilitator" sync / 1[56]:[^:]*:Ferdiad Hollow:1CA6:/
+1079.9 "Jongleur's X" sync / 1[56]:[^:]*:Ferdiad Hollow:1C98:/
+1087.4 "Flameflow" sync / 1[56]:[^:]*:Ferdiad Hollow:1CA7:/
+1089.9 "Sleight" sync / 1[56]:[^:]*:Ferdiad Hollow:1C99:/
 
 
 # The intermission is extremely complex to figure out.
@@ -144,32 +144,32 @@ hideall "--sync--"
 # The Fool actions don't seem to have strict timers.
 # It's all a mess, but Ferdiad is guaranteed to do his half-circle on time.
 1089.9 "--untargetable--"
-1095.9 "--sync--" sync / 1[56]:Wailing Atomos:1C9E:/ window 95.9,5
-1131.1 "Jester's Reward" sync / 1[56]:Ferdiad Hollow:1CA3:/
+1095.9 "--sync--" sync / 1[56]:[^:]*:Wailing Atomos:1C9E:/ window 95.9,5
+1131.1 "Jester's Reward" sync / 1[56]:[^:]*:Ferdiad Hollow:1CA3:/
 
 
 
-1300.0 "--sync--" sync / 14:Ferdiad Hollow:1CA4:/ window 300,5
-1304.7 "Jester's Jig" sync / 1[56]:Ferdiad Hollow:1CA4:/
-1306.7 "--sync--" sync / 1[56]:Ferdiad Hollow:1CA5:/
+1300.0 "--sync--" sync / 14:[^:]*:Ferdiad Hollow:1CA4:/ window 300,5
+1304.7 "Jester's Jig" sync / 1[56]:[^:]*:Ferdiad Hollow:1CA4:/
+1306.7 "--sync--" sync / 1[56]:[^:]*:Ferdiad Hollow:1CA5:/
 
-1319.0 "Sleight" sync / 1[56]:Ferdiad Hollow:1C99:/
-1327.5 "Wormhole" sync / 1[56]:Ferdiad Hollow:1C9A:/
-1327.8 "--sync--" sync / 1[56]:(Cursing Atomos|Wailing Atomos):1C49:/
-1328.0 "Juggling Sphere" sync / 1[56]:(Aether|Aetherial Chakram):1C(9F|A0):/
-1329.6 "--sync--" sync / 1[56]:(Cursing Atomos|Wailing Atomos):1C9[CD]:/
-1333.0 "Explosion" sync / 1[56]:(Aether|Aetherial Chakram):1CA[12]:/ window 15,15
-1338.1 "Jester's Reap" sync / 1[56]:Ferdiad Hollow:1E41:/
-1348.8 "Black Wind" # sync / 1[56]:Ferdiad Hollow:1CAC:/
-1362.4 "Blackfire" sync / 1[56]:Ferdiad Hollow:1CAA:/
-1372.7 "Jester's Reap" sync / 1[56]:Ferdiad Hollow:1E41:/
-1380.9 "Jongleur's X" sync / 1[56]:Ferdiad Hollow:1C98:/ window 15,15
-1387.2 "Debilitator" sync / 1[56]:Ferdiad Hollow:1CA6:/
-1394.7 "Blackbolt" sync / 1[56]:Ferdiad Hollow:1CAD:/
-1405.2 "Flameflow" sync / 1[56]:Ferdiad Hollow:1CA7:/
-1411.4 "Jester's Reap" sync / 1[56]:Ferdiad Hollow:1E41:/
+1319.0 "Sleight" sync / 1[56]:[^:]*:Ferdiad Hollow:1C99:/
+1327.5 "Wormhole" sync / 1[56]:[^:]*:Ferdiad Hollow:1C9A:/
+1327.8 "--sync--" sync / 1[56]:[^:]*:(Cursing Atomos|Wailing Atomos):1C49:/
+1328.0 "Juggling Sphere" sync / 1[56]:[^:]*:(Aether|Aetherial Chakram):1C(9F|A0):/
+1329.6 "--sync--" sync / 1[56]:[^:]*:(Cursing Atomos|Wailing Atomos):1C9[CD]:/
+1333.0 "Explosion" sync / 1[56]:[^:]*:(Aether|Aetherial Chakram):1CA[12]:/ window 15,15
+1338.1 "Jester's Reap" sync / 1[56]:[^:]*:Ferdiad Hollow:1E41:/
+1348.8 "Black Wind" # sync / 1[56]:[^:]*:Ferdiad Hollow:1CAC:/
+1362.4 "Blackfire" sync / 1[56]:[^:]*:Ferdiad Hollow:1CAA:/
+1372.7 "Jester's Reap" sync / 1[56]:[^:]*:Ferdiad Hollow:1E41:/
+1380.9 "Jongleur's X" sync / 1[56]:[^:]*:Ferdiad Hollow:1C98:/ window 15,15
+1387.2 "Debilitator" sync / 1[56]:[^:]*:Ferdiad Hollow:1CA6:/
+1394.7 "Blackbolt" sync / 1[56]:[^:]*:Ferdiad Hollow:1CAD:/
+1405.2 "Flameflow" sync / 1[56]:[^:]*:Ferdiad Hollow:1CA7:/
+1411.4 "Jester's Reap" sync / 1[56]:[^:]*:Ferdiad Hollow:1E41:/
 
-1420.4 "Sleight" sync / 1[56]:Ferdiad Hollow:1C99:/ window 15,15 jump 1319.0
+1420.4 "Sleight" sync / 1[56]:[^:]*:Ferdiad Hollow:1C99:/ window 15,15 jump 1319.0
 1428.9 "Wormhole"
 1429.4 "Juggling Sphere"
 1434.4 "Explosion"
@@ -190,54 +190,54 @@ hideall "--sync--"
 
 2000.0 "--sync--" sync / 00:0839::The Queen's Pride will be sealed off/ window 2000,5
 
-2007.8 "Aether Bend" sync / 1[56]:Proto Ultima:1D99:/
-2018.4 "Aetherochemical Laser 1" sync / 1[56]:Proto Ultima:1D96:/
-2022.4 "Aetherochemical Laser 2" sync / 1[56]:Proto Ultima:1D98:/
-2026.4 "Aetherochemical Laser 3" sync / 1[56]:Proto Ultima:1D97:/
-2033.4 "Aetherochemical Flare" sync / 1[56]:Proto Ultima:1E52:/
-2034.6 "Diffractive Laser" # sync / 1[56]:Proto Ultima:1DAA:/
-2036.6 "--sync--" sync / 1[56]:Proto Ultima:1D9A:/ window 36,5 # Logs exist where this is first.
-2042.6 "Light Pillar x8" duration 10 # sync / 1[56]:Proto Ultima:1DA8:/
-2053.4 "Aetherochemical Flare" sync / 1[56]:Proto Ultima:1E52:/
+2007.8 "Aether Bend" sync / 1[56]:[^:]*:Proto Ultima:1D99:/
+2018.4 "Aetherochemical Laser 1" sync / 1[56]:[^:]*:Proto Ultima:1D96:/
+2022.4 "Aetherochemical Laser 2" sync / 1[56]:[^:]*:Proto Ultima:1D98:/
+2026.4 "Aetherochemical Laser 3" sync / 1[56]:[^:]*:Proto Ultima:1D97:/
+2033.4 "Aetherochemical Flare" sync / 1[56]:[^:]*:Proto Ultima:1E52:/
+2034.6 "Diffractive Laser" # sync / 1[56]:[^:]*:Proto Ultima:1DAA:/
+2036.6 "--sync--" sync / 1[56]:[^:]*:Proto Ultima:1D9A:/ window 36,5 # Logs exist where this is first.
+2042.6 "Light Pillar x8" duration 10 # sync / 1[56]:[^:]*:Proto Ultima:1DA8:/
+2053.4 "Aetherochemical Flare" sync / 1[56]:[^:]*:Proto Ultima:1E52:/
 
 # We don't know about this part. Maybe it does this?
 # Timing might be a little different?
-2060.0 "Aether Bend" sync / 1[56]:Proto Ultima:1D99:/ window 30,15 jump 2007.8
+2060.0 "Aether Bend" sync / 1[56]:[^:]*:Proto Ultima:1D99:/ window 30,15 jump 2007.8
 2070.6 "Aetherochemical Laser 1"
 2074.6 "Aetherochemical Laser 2" 
 2078.6 "Aetherochemical Laser 3"
 2079.8 "Diffractive Laser"
 2085.8 "Light Pillar x8"
 
-2100.0 "--untargetable--" sync / 1[56]:Proto Ultima:1DA0:/ window 100,5
-2110.6 "--sync--" sync / 1[56]:Proto Ultima:1DAC:/
-2110.6 "Eikonizer" sync / 1[56]:Proto Ultima:1DAD:/
-2117.5 "Aetherial Pool" sync / 1[56]:Proto Ultima:1DA3:/
-2119.1 "Flare Star" sync / 1[56]:Proto Ultima:1DA4:/
-2125.5 "Aetherial Pool" sync / 1[56]:Proto Ultima:1DA3:/
-2126.2 "--sync--" sync / 1[56]:Proto Ultima:1DA2:/
-2127.1 "Flare Star" sync / 1[56]:Proto Ultima:1DA4:/
-2131.2 "Citadel Buster" sync / 1[56]:Proto Ultima:1DAB:/
-2139.3 "Touchdown" sync / 1[56]:Proto Ultima:1D9C:/
+2100.0 "--untargetable--" sync / 1[56]:[^:]*:Proto Ultima:1DA0:/ window 100,5
+2110.6 "--sync--" sync / 1[56]:[^:]*:Proto Ultima:1DAC:/
+2110.6 "Eikonizer" sync / 1[56]:[^:]*:Proto Ultima:1DAD:/
+2117.5 "Aetherial Pool" sync / 1[56]:[^:]*:Proto Ultima:1DA3:/
+2119.1 "Flare Star" sync / 1[56]:[^:]*:Proto Ultima:1DA4:/
+2125.5 "Aetherial Pool" sync / 1[56]:[^:]*:Proto Ultima:1DA3:/
+2126.2 "--sync--" sync / 1[56]:[^:]*:Proto Ultima:1DA2:/
+2127.1 "Flare Star" sync / 1[56]:[^:]*:Proto Ultima:1DA4:/
+2131.2 "Citadel Buster" sync / 1[56]:[^:]*:Proto Ultima:1DAB:/
+2139.3 "Touchdown" sync / 1[56]:[^:]*:Proto Ultima:1D9C:/
 2139.3 "--targetable--"
 
-2147.4 "Supernova" sync / 1[56]:Proto Ultima:1D9D:/
-2156.6 "--sync--" sync / 1[56]:Proto Ultima:1D9A:/
-2160.7 "Light Pillar x10" # sync / 1[56]:Proto Ultima:1DA5:/
-2194.7 "Aether Bend" sync / 1[56]:Proto Ultima:1D99:/ window 30,5
-2200.7 "Aetherochemical Flare" sync / 1[56]:Proto Ultima:1E52:/
-2204.4 "Aetherochemical Laser 1" sync / 1[56]:Proto Ultima:1D96:/ window 45,5
-2208.4 "Aetherochemical Laser 2" sync / 1[56]:Proto Ultima:1D97:/
-2213.4 "Aetherochemical Laser 3" sync / 1[56]:Proto Ultima:1D98:/
-2214.4 "Diffractive Laser" # sync / 1[56]:Proto Ultima:1DAA:/
+2147.4 "Supernova" sync / 1[56]:[^:]*:Proto Ultima:1D9D:/
+2156.6 "--sync--" sync / 1[56]:[^:]*:Proto Ultima:1D9A:/
+2160.7 "Light Pillar x10" # sync / 1[56]:[^:]*:Proto Ultima:1DA5:/
+2194.7 "Aether Bend" sync / 1[56]:[^:]*:Proto Ultima:1D99:/ window 30,5
+2200.7 "Aetherochemical Flare" sync / 1[56]:[^:]*:Proto Ultima:1E52:/
+2204.4 "Aetherochemical Laser 1" sync / 1[56]:[^:]*:Proto Ultima:1D96:/ window 45,5
+2208.4 "Aetherochemical Laser 2" sync / 1[56]:[^:]*:Proto Ultima:1D97:/
+2213.4 "Aetherochemical Laser 3" sync / 1[56]:[^:]*:Proto Ultima:1D98:/
+2214.4 "Diffractive Laser" # sync / 1[56]:[^:]*:Proto Ultima:1DAA:/
 
 # We don't know, but it seems likely.
-2216.4 "--sync--" sync / 1[56]:Proto Ultima:1D9A:/ window 30,30 jump 2156.6
+2216.4 "--sync--" sync / 1[56]:[^:]*:Proto Ultima:1D9A:/ window 30,30 jump 2156.6
 2220.5 "Light Pillar x10"
 
 # Enrage is a LOOOONG cast alongside Aether Collectors.
-2500.0 "--sync--" sync / 14:Proto Ultima:1DA9:/ window 2500,5
-2559.7 "Supernova Enrage" sync / 1[56]:Proto Ultima:1DA9:/
+2500.0 "--sync--" sync / 14:[^:]*:Proto Ultima:1DA9:/ window 2500,5
+2559.7 "Supernova Enrage" sync / 1[56]:[^:]*:Proto Ultima:1DA9:/
 
 
 #~~~~~~~~~~#
@@ -248,35 +248,35 @@ hideall "--sync--"
 # -ic Shadowcourt Jester" "Chimera Poppet"
 
 3000.0 "--sync--" sync / 00:0839::The Queen's Graces will be sealed off/ window 3000,5
-3013.1 "Thirty Thorns" sync / 1[56]:Scathach:1D2B:/
-3030.2 "Thirty Arrows" sync / 1[56]:Scathach:1D2F:/ window 30,5
-3037.4 "Manos" sync / 1[56]:Scathach:1CD3:/ window 30,5
-3047.7 "--sync--" sync / 1[56]:Scathach:(1D1[EF]):/
-3049.0 "Shadespin" sync / 1[56]:Scathach:1D20:/
-3052.8 "Thirty Sickles" sync / 1[56]:Scathach:1D31:/
-3056.0 "Soar" sync / 1[56]:Scathach:1D1B:/
-3060.0 "--sync--" sync / 1[56]:Scathach:1D1C:/
-3061.0 "Shadesmite" sync / 1[56]:Scathach:1D1D:/
+3013.1 "Thirty Thorns" sync / 1[56]:[^:]*:Scathach:1D2B:/
+3030.2 "Thirty Arrows" sync / 1[56]:[^:]*:Scathach:1D2F:/ window 30,5
+3037.4 "Manos" sync / 1[56]:[^:]*:Scathach:1CD3:/ window 30,5
+3047.7 "--sync--" sync / 1[56]:[^:]*:Scathach:(1D1[EF]):/
+3049.0 "Shadespin" sync / 1[56]:[^:]*:Scathach:1D20:/
+3052.8 "Thirty Sickles" sync / 1[56]:[^:]*:Scathach:1D31:/
+3056.0 "Soar" sync / 1[56]:[^:]*:Scathach:1D1B:/
+3060.0 "--sync--" sync / 1[56]:[^:]*:Scathach:1D1C:/
+3061.0 "Shadesmite" sync / 1[56]:[^:]*:Scathach:1D1D:/
 
 3070.8 "--shadows gather--"
-3084.8 "Thirty Souls" sync / 1[56]:Scathach:1D32:/ window 30,5
-3088.0 "Shadow Release" sync / 1[56]:Scathach:1CD4:/ window 90,5
-3095.1 "--sync--" sync / 1[56]:Connla:1CD0:/
-3095.1 "Pitfall" sync / 1[56]:Connla:1CD1:/
-3101.1 "Thirty Thorns" sync / 1[56]:Scathach:1D2B:/
-3117.3 "Thirty Arrows" sync / 1[56]:Scathach:1D2F:/
-3130.4 "Thirty Souls" sync / 1[56]:Scathach:1D32:/ window 30,5
-3133.6 "Manos" sync / 1[56]:Scathach:1CD3:/ window 30,5
-3143.7 "--sync--" sync / 1[56]:Scathach:1D1[EF]:/
-3144.9 "Shadespin" sync / 1[56]:Scathach:1D20:/
-3151.9 "Nox x5" sync / 1[56]:Scathach:1D22:/
-3164.1 "Shadethrust" sync / 1[56]:Scathach:1D23:/
-3182.2 "Thirty Souls" sync / 1[56]:Scathach:1D32:/
-3197.4 "Thirty Sickles" sync / 1[56]:Scathach:1D31:/ window 45,5
+3084.8 "Thirty Souls" sync / 1[56]:[^:]*:Scathach:1D32:/ window 30,5
+3088.0 "Shadow Release" sync / 1[56]:[^:]*:Scathach:1CD4:/ window 90,5
+3095.1 "--sync--" sync / 1[56]:[^:]*:Connla:1CD0:/
+3095.1 "Pitfall" sync / 1[56]:[^:]*:Connla:1CD1:/
+3101.1 "Thirty Thorns" sync / 1[56]:[^:]*:Scathach:1D2B:/
+3117.3 "Thirty Arrows" sync / 1[56]:[^:]*:Scathach:1D2F:/
+3130.4 "Thirty Souls" sync / 1[56]:[^:]*:Scathach:1D32:/ window 30,5
+3133.6 "Manos" sync / 1[56]:[^:]*:Scathach:1CD3:/ window 30,5
+3143.7 "--sync--" sync / 1[56]:[^:]*:Scathach:1D1[EF]:/
+3144.9 "Shadespin" sync / 1[56]:[^:]*:Scathach:1D20:/
+3151.9 "Nox x5" sync / 1[56]:[^:]*:Scathach:1D22:/
+3164.1 "Shadethrust" sync / 1[56]:[^:]*:Scathach:1D23:/
+3182.2 "Thirty Souls" sync / 1[56]:[^:]*:Scathach:1D32:/
+3197.4 "Thirty Sickles" sync / 1[56]:[^:]*:Scathach:1D31:/ window 45,5
 3199.4 "--shadows gather--"
-3203.6 "Soar" sync / 1[56]:Scathach:1D1B:/
-3207.8 "--sync--" sync / 1[56]:Scathach:1D1C:/
-3208.7 "Shadesmite" sync / 1[56]:Scathach:1D1D:/ window 30,30 jump 3061.0
+3203.6 "Soar" sync / 1[56]:[^:]*:Scathach:1D1B:/
+3207.8 "--sync--" sync / 1[56]:[^:]*:Scathach:1D1C:/
+3208.7 "Shadesmite" sync / 1[56]:[^:]*:Scathach:1D1D:/ window 30,30 jump 3061.0
 
 # We don't know 100% that this is the correct rotation,
 # but based on the available logs and video, it seems likely.
@@ -291,53 +291,53 @@ hideall "--sync--"
 3300.0 "--untargetable--" sync / 22:........:Scathach:........:Scathach:00/ window 300,5
 3302.2 "--sync--" sync / 03:........:Shadowcourt Jester:/  window 300,5
 3323.6 "--towers appear--"
-3333.6 "Particle Beam" sync / 1[56]:Scathach:1D2[78]:/
+3333.6 "Particle Beam" sync / 1[56]:[^:]*:Scathach:1D2[78]:/
 
 
-3400.5 "--sync--" sync / 14:Scathach:1D34:/ window 100,5
-# 3405.2 "Blinding Shadow" sync / 1[56]:Scathach:1D34:/
-3409.2 "Blinding Shadow" sync / 1[56]:Scathach:1DAE:/
+3400.5 "--sync--" sync / 14:[^:]*:Scathach:1D34:/ window 100,5
+# 3405.2 "Blinding Shadow" sync / 1[56]:[^:]*:Scathach:1D34:/
+3409.2 "Blinding Shadow" sync / 1[56]:[^:]*:Scathach:1DAE:/
 
 # A very long rotation, approximately 192 seconds.
 # Add spawns and shadows gathering are approximate,
 # as nothing shows up for them in the log.
-3411.4 "Shadow Release" sync / 1[56]:Scathach:1CD4:/
-3421.5 "Thirty Souls" sync / 1[56]:Scathach:1D32:/
-3428.6 "Thirty Arrows" sync / 1[56]:Scathach:1D2F:/
-3435.6 "Particle Beam" sync / 1[56]:Scathach:1D2[78]:/
-3444.8 "Thirty Souls" sync / 1[56]:Scathach:1D32:/
-3453.1 "Thirty Souls" sync / 1[56]:Scathach:1D32:/
-3459.1 "Thirty Arrows" sync / 1[56]:Scathach:1D2F:/
-3469.4 "Thirty Cries" sync / 1[56]:Scathach:1D33:/
-3471.5 "Particle Beam" sync / 1[56]:Scathach:1D2[78]:/
-3480.7 "--sync--" sync / 1[56]:Connla:1CD0:/
-3480.7 "Pitfall" sync / 1[56]:Connla:1CD1:/
-3491.8 "Thirty Cries" sync / 1[56]:Scathach:1D33:/
-3494.9 "Thirty Thorns" sync / 1[56]:Scathach:1D2B:/
-3506.1 "Thirty Souls" sync / 1[56]:Scathach:1D32:/
-3510.4 "Manos" sync / 1[56]:Scathach:1CD3:/
-3520.5 "--sync--" sync / 1[56]:Scathach:1D1[EF]:/
-3521.6 "Shadespin" sync / 1[56]:Scathach:1D20:/
+3411.4 "Shadow Release" sync / 1[56]:[^:]*:Scathach:1CD4:/
+3421.5 "Thirty Souls" sync / 1[56]:[^:]*:Scathach:1D32:/
+3428.6 "Thirty Arrows" sync / 1[56]:[^:]*:Scathach:1D2F:/
+3435.6 "Particle Beam" sync / 1[56]:[^:]*:Scathach:1D2[78]:/
+3444.8 "Thirty Souls" sync / 1[56]:[^:]*:Scathach:1D32:/
+3453.1 "Thirty Souls" sync / 1[56]:[^:]*:Scathach:1D32:/
+3459.1 "Thirty Arrows" sync / 1[56]:[^:]*:Scathach:1D2F:/
+3469.4 "Thirty Cries" sync / 1[56]:[^:]*:Scathach:1D33:/
+3471.5 "Particle Beam" sync / 1[56]:[^:]*:Scathach:1D2[78]:/
+3480.7 "--sync--" sync / 1[56]:[^:]*:Connla:1CD0:/
+3480.7 "Pitfall" sync / 1[56]:[^:]*:Connla:1CD1:/
+3491.8 "Thirty Cries" sync / 1[56]:[^:]*:Scathach:1D33:/
+3494.9 "Thirty Thorns" sync / 1[56]:[^:]*:Scathach:1D2B:/
+3506.1 "Thirty Souls" sync / 1[56]:[^:]*:Scathach:1D32:/
+3510.4 "Manos" sync / 1[56]:[^:]*:Scathach:1CD3:/
+3520.5 "--sync--" sync / 1[56]:[^:]*:Scathach:1D1[EF]:/
+3521.6 "Shadespin" sync / 1[56]:[^:]*:Scathach:1D20:/
 3523.6 "--shadows gather--"
-3526.7 "Thirty Sickles" sync / 1[56]:Scathach:1D31:/
+3526.7 "Thirty Sickles" sync / 1[56]:[^:]*:Scathach:1D31:/
 3528.7 "--adds spawn--"
-3535.9 "Nox x5" sync / 1[56]:Scathach:1D22:/
-3544.1 "Shadethrust" sync / 1[56]:Scathach:1D23:/
-3552.2 "Thirty Souls" sync / 1[56]:Scathach:1D32:/
+3535.9 "Nox x5" sync / 1[56]:[^:]*:Scathach:1D22:/
+3544.1 "Shadethrust" sync / 1[56]:[^:]*:Scathach:1D23:/
+3552.2 "Thirty Souls" sync / 1[56]:[^:]*:Scathach:1D32:/
 3553.2 "--shadows gather--"
-3557.4 "Soar" sync / 1[56]:Scathach:1D1B:/
-3561.4 "--sync--" sync / 1[56]:Scathach:1D1C:/
-3562.4 "Shadesmite" sync / 1[56]:Scathach:1D1D:/
-3571.5 "Shadethrust" sync / 1[56]:Scathach:1D23:/
+3557.4 "Soar" sync / 1[56]:[^:]*:Scathach:1D1B:/
+3561.4 "--sync--" sync / 1[56]:[^:]*:Scathach:1D1C:/
+3562.4 "Shadesmite" sync / 1[56]:[^:]*:Scathach:1D1D:/
+3571.5 "Shadethrust" sync / 1[56]:[^:]*:Scathach:1D23:/
 3575.5 "--shadows gather--"
-3580.6 "--sync--" sync / 1[56]:Scathach:1D1[EF]:/
-3581.7 "Shadespin" sync / 1[56]:Scathach:1D20:/
-3588.8 "Thirty Souls" sync / 1[56]:Scathach:1D32:/
-3599.0 "Thirty Souls" sync / 1[56]:Scathach:1D32:/
+3580.6 "--sync--" sync / 1[56]:[^:]*:Scathach:1D1[EF]:/
+3581.7 "Shadespin" sync / 1[56]:[^:]*:Scathach:1D20:/
+3588.8 "Thirty Souls" sync / 1[56]:[^:]*:Scathach:1D32:/
+3599.0 "Thirty Souls" sync / 1[56]:[^:]*:Scathach:1D32:/
 
 # Again, this is presumed based on what we have.
 # There might be extra adds/shadows.
-3603.3 "Shadow Release" sync / 1[56]:Scathach:1CD4:/ window 30,30 jump 3409.2
+3603.3 "Shadow Release" sync / 1[56]:[^:]*:Scathach:1CD4:/ window 30,30 jump 3409.2
 3613.4 "Thirty Souls"
 3620.5 "Thirty Arrows"
 3627.5 "Particle Beam"
@@ -355,42 +355,42 @@ hideall "--sync--"
 # Also, tons of possible micro-skips before and after Ruinous Omen.
 
 # We sync off an attack from Diabolos because there are two encounters in The Lunar.
-4000.0 "--sync--" sync / 1[56]:Diabolos:1C0C:/ window 4000,1
-4009.9 "Camisado" sync / 1[56]:Diabolos:1C0D:/
-4022.1 "Nightmare" sync / 1[56]:Diabolos:1C0E:/
-4032.3 "Ultimate Terror" sync / 1[56]:Diabolos:1C12:/ window 15,5
-4050.5 "Camisado" sync / 1[56]:Diabolos:1C0D:/
-4053.5 "Noctoshield" sync / 1[56]:Diabolos:1C0F:/ window 10,5
-4058.7 "Nightmare" sync / 1[56]:Diabolos:1C0E:/ window 10,5
+4000.0 "--sync--" sync / 1[56]:[^:]*:Diabolos:1C0C:/ window 4000,1
+4009.9 "Camisado" sync / 1[56]:[^:]*:Diabolos:1C0D:/
+4022.1 "Nightmare" sync / 1[56]:[^:]*:Diabolos:1C0E:/
+4032.3 "Ultimate Terror" sync / 1[56]:[^:]*:Diabolos:1C12:/ window 15,5
+4050.5 "Camisado" sync / 1[56]:[^:]*:Diabolos:1C0D:/
+4053.5 "Noctoshield" sync / 1[56]:[^:]*:Diabolos:1C0F:/ window 10,5
+4058.7 "Nightmare" sync / 1[56]:[^:]*:Diabolos:1C0E:/ window 10,5
 
 # This seems like a possible rotation? Maybe?
-4064.9 "Camisado" sync / 1[56]:Diabolos:1C0D:/
-4075.2 "Camisado" sync / 1[56]:Diabolos:1C0D:/
-4078.4 "Noctoshield" sync / 1[56]:Diabolos:1C0F:/
-4083.4 "Nightmare" sync / 1[56]:Diabolos:1C0E:/ window 10,5 jump 4058.7
+4064.9 "Camisado" sync / 1[56]:[^:]*:Diabolos:1C0D:/
+4075.2 "Camisado" sync / 1[56]:[^:]*:Diabolos:1C0D:/
+4078.4 "Noctoshield" sync / 1[56]:[^:]*:Diabolos:1C0F:/
+4083.4 "Nightmare" sync / 1[56]:[^:]*:Diabolos:1C0E:/ window 10,5 jump 4058.7
 
 4089.6 "Camisado"
 4099.9 "Camisado"
 4103.1 "Noctoshield"
 4108.1 "Nightmare"
 
-4149.0 "--sync--" sync / 14:Diabolos:1C10:/ window 150,5
-4163.7 "Ruinous Omen" sync / 1[56]:Diabolos:1C10:/
-4164.7 "Ruinous Omen" sync / 1[56]:Diabolos:1C11:/
+4149.0 "--sync--" sync / 14:[^:]*:Diabolos:1C10:/ window 150,5
+4163.7 "Ruinous Omen" sync / 1[56]:[^:]*:Diabolos:1C10:/
+4164.7 "Ruinous Omen" sync / 1[56]:[^:]*:Diabolos:1C11:/
 
-4170.3 "Camisado" sync / 1[56]:Diabolos:1C0D:/
-4178.7 "Night Terror" sync / 1[56]:Diabolos:1C13:/
-4185.8 "Ultimate Terror" sync / 1[56]:Diabolos:1C12:/
-4190.0 "Camisado" sync / 1[56]:Diabolos:1C0D:/
-4195.1 "Camisado" sync / 1[56]:Diabolos:1C0D:/
-4203.5 "Nightmare" sync / 1[56]:Diabolos:1C0E:/
-4206.6 "Camisado" sync / 1[56]:Diabolos:1C0D:/
-4213.1 "Camisado" sync / 1[56]:Diabolos:1C0D:/
-4216.2 "Noctoshield" sync / 1[56]:Diabolos:1C0F:/
-4219.3 "Camisado" sync / 1[56]:Diabolos:1C0D:/
-4225.8 "Camisado" sync / 1[56]:Diabolos:1C0D:/
+4170.3 "Camisado" sync / 1[56]:[^:]*:Diabolos:1C0D:/
+4178.7 "Night Terror" sync / 1[56]:[^:]*:Diabolos:1C13:/
+4185.8 "Ultimate Terror" sync / 1[56]:[^:]*:Diabolos:1C12:/
+4190.0 "Camisado" sync / 1[56]:[^:]*:Diabolos:1C0D:/
+4195.1 "Camisado" sync / 1[56]:[^:]*:Diabolos:1C0D:/
+4203.5 "Nightmare" sync / 1[56]:[^:]*:Diabolos:1C0E:/
+4206.6 "Camisado" sync / 1[56]:[^:]*:Diabolos:1C0D:/
+4213.1 "Camisado" sync / 1[56]:[^:]*:Diabolos:1C0D:/
+4216.2 "Noctoshield" sync / 1[56]:[^:]*:Diabolos:1C0F:/
+4219.3 "Camisado" sync / 1[56]:[^:]*:Diabolos:1C0D:/
+4225.8 "Camisado" sync / 1[56]:[^:]*:Diabolos:1C0D:/
 
-4233.8 "Ultimate Terror" sync / 1[56]:Diabolos:1C12:/ window 15,15 jump 4185.8
+4233.8 "Ultimate Terror" sync / 1[56]:[^:]*:Diabolos:1C12:/ window 15,15 jump 4185.8
 4238.9 "Camisado"
 4244.0 "Camisado"
 4252.4 "Nightmare"
@@ -402,11 +402,11 @@ hideall "--sync--"
 
 4274.0 "--sync--" sync / 22:........:Diabolos:........:Diabolos:00/ window 100,5
 4286.2 "--lifegate spawn--" sync / 03:........:Lifegate:/  window 300,5
-4300.0 "--sync--" sync / 1[56]:Diabolos:1C16:/ window 300,5
+4300.0 "--sync--" sync / 1[56]:[^:]*:Diabolos:1C16:/ window 300,5
 4320.0 "--deathgate spawn--" sync / 03:........:Deathgate:/  window 50,5
-4477.1 "--sync--" sync / 1[56]:Diabolos:1AFB:/ window 177,5
-4488.5 "--sync--" sync / 1[56]:Diabolos:1AFD:/
-4494.6 "Dream Shroud" sync / 1[56]:Diabolos Hollow:1DB1:/ window 194,5
+4477.1 "--sync--" sync / 1[56]:[^:]*:Diabolos:1AFB:/ window 177,5
+4488.5 "--sync--" sync / 1[56]:[^:]*:Diabolos:1AFD:/
+4494.6 "Dream Shroud" sync / 1[56]:[^:]*:Diabolos Hollow:1DB1:/ window 194,5
 
 
 #~~~~~~~~~~~~~~~~~#
@@ -426,13 +426,13 @@ hideall "--sync--"
 # so we sync with wider windows than normal.
 
 # This first rotation block last until the initial zero-damage shield breaks.
-4500.9 "--sync--" sync / 1[56]:Diabolos Hollow:1E3E:/ window 4501,1
-4507.9 "Hollow Camisado" sync / 1[56]:Diabolos Hollow:1C19:/ window 5,5
-4516.2 "Shadethrust" sync / 1[56]:Diabolos Hollow:1C1A:/ window 5,5
-4523.6 "Hollow Camisado" sync / 1[56]:Diabolos Hollow:1C19:/ window 5,5
-4530.8 "Shadethrust" sync / 1[56]:Diabolos Hollow:1C1A:/ window 5,5
+4500.9 "--sync--" sync / 1[56]:[^:]*:Diabolos Hollow:1E3E:/ window 4501,1
+4507.9 "Hollow Camisado" sync / 1[56]:[^:]*:Diabolos Hollow:1C19:/ window 5,5
+4516.2 "Shadethrust" sync / 1[56]:[^:]*:Diabolos Hollow:1C1A:/ window 5,5
+4523.6 "Hollow Camisado" sync / 1[56]:[^:]*:Diabolos Hollow:1C19:/ window 5,5
+4530.8 "Shadethrust" sync / 1[56]:[^:]*:Diabolos Hollow:1C1A:/ window 5,5
 
-4540.1 "Hollow Camisado" sync / 1[56]:Diabolos Hollow:1C19:/ window 5,5 jump 4507.9
+4540.1 "Hollow Camisado" sync / 1[56]:[^:]*:Diabolos Hollow:1C19:/ window 5,5 jump 4507.9
 4547.2 "Shadethrust"
 4554.6 "Hollow Camisado"
 4561.8 "Shadethrust"
@@ -445,47 +445,47 @@ hideall "--sync--"
 
 # Lots of possible pushes here, unknown what triggers them.
 # If not pushed, it *appears* this section flows naturally.
-4600.0 "Nox x5" sync / 1[56]:Diabolos Hollow:1C1C:/ window 100,5
-4604.2 "Hollow Night" sync / 1[56]:Diabolos Hollow:1C1D:/
-4613.6 "Shadethrust" sync / 1[56]:Diabolos Hollow:1C1A:/
-4620.4 "Particle Beam" sync / 1[56]:Diabolos Hollow:1C2[456]:/
-4620.8 "Hollow Camisado" sync / 1[56]:Diabolos Hollow:1C19:/
+4600.0 "Nox x5" sync / 1[56]:[^:]*:Diabolos Hollow:1C1C:/ window 100,5
+4604.2 "Hollow Night" sync / 1[56]:[^:]*:Diabolos Hollow:1C1D:/
+4613.6 "Shadethrust" sync / 1[56]:[^:]*:Diabolos Hollow:1C1A:/
+4620.4 "Particle Beam" sync / 1[56]:[^:]*:Diabolos Hollow:1C2[456]:/
+4620.8 "Hollow Camisado" sync / 1[56]:[^:]*:Diabolos Hollow:1C19:/
 4624.1 "--deathgate spawn--" sync / 03:........:Deathgate:/  window 25,5
-4627.1 "Hollowshield" sync / 1[56]:Diabolos Hollow:1C1E:/ window 27.1,5
-4637.5 "Hollow Camisado" sync / 1[56]:Diabolos Hollow:1C19:/
-4646.8 "Shadethrust" sync / 1[56]:Diabolos Hollow:1C1A:/ window 20,10
+4627.1 "Hollowshield" sync / 1[56]:[^:]*:Diabolos Hollow:1C1E:/ window 27.1,5
+4637.5 "Hollow Camisado" sync / 1[56]:[^:]*:Diabolos Hollow:1C19:/
+4646.8 "Shadethrust" sync / 1[56]:[^:]*:Diabolos Hollow:1C1A:/ window 20,10
 
-4654.9 "Pavor Inanis" sync / 1[56]:Diabolos Hollow:1C1F:/ window 55,5
-4665.3 "Hollow Night" sync / 1[56]:Diabolos Hollow:1C1D:/
-4677.4 "Hollow Nightmare" sync / 1[56]:Diabolos Hollow:1C20:/
-4690.9 "Hollow Camisado" sync / 1[56]:Diabolos Hollow:1C19:/ window 30,5
-4700.2 "Nox x5" sync / 1[56]:Diabolos Hollow:1C1C:/ window 30,5
-4705.2 "Hollow Nightmare" sync / 1[56]:Diabolos Hollow:1C20:/
-4718.4 "Hollow Camisado" sync / 1[56]:Diabolos Hollow:1C19:/
-4727.6 "Hollow Terror" sync / 1[56]:Diabolos Hollow:1C21:/
-4737.2 "Shadethrust" sync / 1[56]:Diabolos Hollow:1C1A:/ window 20,5
-4751.0 "Shadethrust" sync / 1[56]:Diabolos Hollow:1C1A:/
-4753.5 "Particle Beam" sync / 1[56]:Diabolos Hollow:1C2[456]:/
-4760.3 "Pavor Inanis" sync / 1[56]:Diabolos Hollow:1C1F:/ window 30,30
-4766.6 "Hollow Camisado" sync / 1[56]:Diabolos Hollow:1C19:/
-4774.9 "Nightmare/Terror" sync / 1[56]:Diabolos Hollow:1C2[01]:/
+4654.9 "Pavor Inanis" sync / 1[56]:[^:]*:Diabolos Hollow:1C1F:/ window 55,5
+4665.3 "Hollow Night" sync / 1[56]:[^:]*:Diabolos Hollow:1C1D:/
+4677.4 "Hollow Nightmare" sync / 1[56]:[^:]*:Diabolos Hollow:1C20:/
+4690.9 "Hollow Camisado" sync / 1[56]:[^:]*:Diabolos Hollow:1C19:/ window 30,5
+4700.2 "Nox x5" sync / 1[56]:[^:]*:Diabolos Hollow:1C1C:/ window 30,5
+4705.2 "Hollow Nightmare" sync / 1[56]:[^:]*:Diabolos Hollow:1C20:/
+4718.4 "Hollow Camisado" sync / 1[56]:[^:]*:Diabolos Hollow:1C19:/
+4727.6 "Hollow Terror" sync / 1[56]:[^:]*:Diabolos Hollow:1C21:/
+4737.2 "Shadethrust" sync / 1[56]:[^:]*:Diabolos Hollow:1C1A:/ window 20,5
+4751.0 "Shadethrust" sync / 1[56]:[^:]*:Diabolos Hollow:1C1A:/
+4753.5 "Particle Beam" sync / 1[56]:[^:]*:Diabolos Hollow:1C2[456]:/
+4760.3 "Pavor Inanis" sync / 1[56]:[^:]*:Diabolos Hollow:1C1F:/ window 30,30
+4766.6 "Hollow Camisado" sync / 1[56]:[^:]*:Diabolos Hollow:1C19:/
+4774.9 "Nightmare/Terror" sync / 1[56]:[^:]*:Diabolos Hollow:1C2[01]:/
 
 
 # Can push early at 50% HP
-4785.3 "--sync--" sync / 1[56]:Diabolos Hollow:1C18:/ window 785,5
-4804.1 "--sync--" sync / 1[56]:Diabolos Hollow:1C22:/
-4809.2 "Hollow Omen" sync / 1[56]:Diabolos Hollow:1C23:/
-4818.3 "Double Edge" sync / 1[56]:Diabolos Hollow:1C2B:/
+4785.3 "--sync--" sync / 1[56]:[^:]*:Diabolos Hollow:1C18:/ window 785,5
+4804.1 "--sync--" sync / 1[56]:[^:]*:Diabolos Hollow:1C22:/
+4809.2 "Hollow Omen" sync / 1[56]:[^:]*:Diabolos Hollow:1C23:/
+4818.3 "Double Edge" sync / 1[56]:[^:]*:Diabolos Hollow:1C2B:/
 
-4825.6 "Blindside" sync / 1[56]:Diabolos Hollow:1C28:/
-4828.7 "--sync--" sync / 1[56]:Diabolos Hollow:1C18:/
-4836.0 "Earth Shaker" sync / 1[56]:Diabolos Hollow:1C29:/ window 15,15
-4844.0 "Blindside" sync / 1[56]:Diabolos Hollow:1C28:/
-4852.2 "Blindside" sync / 1[56]:Diabolos Hollow:1C28:/
-4855.4 "--sync--" sync / 1[56]:Diabolos Hollow:1C18:/
-4862.7 "Earth Shaker" sync / 1[56]:Diabolos Hollow:1C29:/
+4825.6 "Blindside" sync / 1[56]:[^:]*:Diabolos Hollow:1C28:/
+4828.7 "--sync--" sync / 1[56]:[^:]*:Diabolos Hollow:1C18:/
+4836.0 "Earth Shaker" sync / 1[56]:[^:]*:Diabolos Hollow:1C29:/ window 15,15
+4844.0 "Blindside" sync / 1[56]:[^:]*:Diabolos Hollow:1C28:/
+4852.2 "Blindside" sync / 1[56]:[^:]*:Diabolos Hollow:1C28:/
+4855.4 "--sync--" sync / 1[56]:[^:]*:Diabolos Hollow:1C18:/
+4862.7 "Earth Shaker" sync / 1[56]:[^:]*:Diabolos Hollow:1C29:/
 
-4870.8 "Blindside" sync / 1[56]:Diabolos Hollow:1C28:/ window 10,5 jump 4825.6
+4870.8 "Blindside" sync / 1[56]:[^:]*:Diabolos Hollow:1C28:/ window 10,5 jump 4825.6
 4881.2 "Earth Shaker"
 4889.2 "Blindside"
 4897.4 "Blindside"

--- a/ui/raidboss/data/03-hw/alliance/weeping_city.txt
+++ b/ui/raidboss/data/03-hw/alliance/weeping_city.txt
@@ -13,115 +13,115 @@ hideall "--sync--"
 # -ic "Webmaiden" "Spitting Spider" "Skittering Spider" "Earth Aether"
 
 0 "--sync--" sync / 00:0839::The Queen's Room will be sealed off/
-9.8 "Dark Spike" sync / 1[56]:Arachne Eve:1823:/
-21.6 "Silken Spray" sync / 1[56]:Arachne Eve:1824:/
-30.4 "Arachne Web x3" duration 5 # sync / 1[56]:Arachne Eve:185E:/
+9.8 "Dark Spike" sync / 1[56]:[^:]*:Arachne Eve:1823:/
+21.6 "Silken Spray" sync / 1[56]:[^:]*:Arachne Eve:1824:/
+30.4 "Arachne Web x3" duration 5 # sync / 1[56]:[^:]*:Arachne Eve:185E:/
 36.8 "--untargetable--"
-41.9 "Tremblor x3" sync / 1[56]:Arachne Eve:1837:/ # 3 separate abilities, 1837/1836/1835
-48.4 "--sync--" sync / 1[56]:Arachne Eve:1889:/
-49.9 "Pitfall" sync / 1[56]:Arachne Eve:1825:/
+41.9 "Tremblor x3" sync / 1[56]:[^:]*:Arachne Eve:1837:/ # 3 separate abilities, 1837/1836/1835
+48.4 "--sync--" sync / 1[56]:[^:]*:Arachne Eve:1889:/
+49.9 "Pitfall" sync / 1[56]:[^:]*:Arachne Eve:1825:/
 51.9 "--targetable--"
-52.1 "--sync--" sync / 1[56]:Arachne Eve:1847:/ # Sticky Wicket head markers
-55.7 "Sticky Wicket x3" # sync / 1[56]:Arachne Eve:183F:/
-64.1 "Silken Spray" sync / 1[56]:Arachne Eve:1824:/
+52.1 "--sync--" sync / 1[56]:[^:]*:Arachne Eve:1847:/ # Sticky Wicket head markers
+55.7 "Sticky Wicket x3" # sync / 1[56]:[^:]*:Arachne Eve:183F:/
+64.1 "Silken Spray" sync / 1[56]:[^:]*:Arachne Eve:1824:/
 
 # Intermission up in her web. There's a LOT of stuff going on here,
 # but the add spawns and abilities are dependent on what the team kills.
 # Implosion is the only real consistency we have through the intermission.
-95.7 "Implosion" sync / 1[56]:Arachne Eve:1833:/ window 95.7,2.5
-113.9 "Implosion" sync / 1[56]:Arachne Eve:1833:/
-132.1 "Implosion" sync / 1[56]:Arachne Eve:1833:/
-150.3 "Implosion" sync / 1[56]:Arachne Eve:1833:/ jump 95.7
+95.7 "Implosion" sync / 1[56]:[^:]*:Arachne Eve:1833:/ window 95.7,2.5
+113.9 "Implosion" sync / 1[56]:[^:]*:Arachne Eve:1833:/
+132.1 "Implosion" sync / 1[56]:[^:]*:Arachne Eve:1833:/
+150.3 "Implosion" sync / 1[56]:[^:]*:Arachne Eve:1833:/ jump 95.7
 168.5 "Implosion"
 186.7 "Implosion"
 
 # Back on the ground for a relatively short bridge block
 # We sync to a 14/20 startsUsing log line instead of a 15/21 ability line.
 # This lets us jump out of the intermission slightly earlier.
-197.3 "Dark Spike" sync / 14:Arachne Eve:1823:/ window 100,5
-206.3 "--sync--" sync / 1[56]:Arachne Eve:1847:/
-210.5 "Sticky Wicket x3" # sync / 1[56]:Arachne Eve:183F:/
+197.3 "Dark Spike" sync / 14:[^:]*:Arachne Eve:1823:/ window 100,5
+206.3 "--sync--" sync / 1[56]:[^:]*:Arachne Eve:1847:/
+210.5 "Sticky Wicket x3" # sync / 1[56]:[^:]*:Arachne Eve:183F:/
 212.1 "--untargetable--"
-216.7 "Tremblor x3" sync / 1[56]:Arachne Eve:1837:/
-223.9 "--sync--" sync / 1[56]:Arachne Eve:1889:/
-225.5 "Pitfall" sync / 1[56]:Arachne Eve:1825:/
+216.7 "Tremblor x3" sync / 1[56]:[^:]*:Arachne Eve:1837:/
+223.9 "--sync--" sync / 1[56]:[^:]*:Arachne Eve:1889:/
+225.5 "Pitfall" sync / 1[56]:[^:]*:Arachne Eve:1825:/
 227.5 "--targetable--"
-233.2 "Arachne Web x3" duration 5 # sync / 1[56]:Arachne Eve:185E:/
-246.3 "Shadow Burst" sync / 1[56]:Arachne Eve:1838:/
-253.0 "Dark Spike" sync / 1[56]:Arachne Eve:1823:/
-264.4 "Frond Affeared" sync / 1[56]:Arachne Eve:183A:/ window 30,30
-271.1 "Silken Spray" sync / 1[56]:Arachne Eve:1824:/
-277.9 "Dark Spike" sync / 1[56]:Arachne Eve:1823:/
-287.7 "Arachne Web x3" duration 5 # sync / 1[56]:Arachne Eve:185E:/
+233.2 "Arachne Web x3" duration 5 # sync / 1[56]:[^:]*:Arachne Eve:185E:/
+246.3 "Shadow Burst" sync / 1[56]:[^:]*:Arachne Eve:1838:/
+253.0 "Dark Spike" sync / 1[56]:[^:]*:Arachne Eve:1823:/
+264.4 "Frond Affeared" sync / 1[56]:[^:]*:Arachne Eve:183A:/ window 30,30
+271.1 "Silken Spray" sync / 1[56]:[^:]*:Arachne Eve:1824:/
+277.9 "Dark Spike" sync / 1[56]:[^:]*:Arachne Eve:1823:/
+287.7 "Arachne Web x3" duration 5 # sync / 1[56]:[^:]*:Arachne Eve:185E:/
 294.2 "--untargetable--"
-297.9 "The Widow's Kiss" duration 5 # sync / 1[56]:Arachne Eve:1842:/
-305.9 "The Widow's Embrace" sync / 1[56]:Arachne Eve:1888:/
-308.5 "Pitfall" sync / 1[56]:Arachne Eve:1845:/
+297.9 "The Widow's Kiss" duration 5 # sync / 1[56]:[^:]*:Arachne Eve:1842:/
+305.9 "The Widow's Embrace" sync / 1[56]:[^:]*:Arachne Eve:1888:/
+308.5 "Pitfall" sync / 1[56]:[^:]*:Arachne Eve:1845:/
 310.5 "--targetable--"
-317.2 "Dark Spike" sync / 1[56]:Arachne Eve:1823:/
+317.2 "Dark Spike" sync / 1[56]:[^:]*:Arachne Eve:1823:/
 
 # And up we go again.
-347.2 "Implosion" sync / 1[56]:Arachne Eve:1833:/ window 147,5
-365.4 "Implosion" sync / 1[56]:Arachne Eve:1833:/
-383.6 "Implosion" sync / 1[56]:Arachne Eve:1833:/ jump 347.2
+347.2 "Implosion" sync / 1[56]:[^:]*:Arachne Eve:1833:/ window 147,5
+365.4 "Implosion" sync / 1[56]:[^:]*:Arachne Eve:1833:/
+383.6 "Implosion" sync / 1[56]:[^:]*:Arachne Eve:1833:/ jump 347.2
 401.8 "Implosion"
 420.0 "Implosion"
 
 # Back down again for another bridge block
-464.9 "Dark Spike" sync / 1[56]:Arachne Eve:1823:/ window 120,5
-476.4 "Arachne Web x3" duration 5 # sync / 1[56]:Arachne Eve:185E:/
-483.8 "--sync--" sync / 1[56]:Arachne Eve:1847:/
-487.4 "Sticky Wicket x3" # sync / 1[56]:Arachne Eve:183F:/
+464.9 "Dark Spike" sync / 1[56]:[^:]*:Arachne Eve:1823:/ window 120,5
+476.4 "Arachne Web x3" duration 5 # sync / 1[56]:[^:]*:Arachne Eve:185E:/
+483.8 "--sync--" sync / 1[56]:[^:]*:Arachne Eve:1847:/
+487.4 "Sticky Wicket x3" # sync / 1[56]:[^:]*:Arachne Eve:183F:/
 489.8 "--untargetable--"
-494.4 "Tremblor x3" sync / 1[56]:Arachne Eve:1837:/
-501.3 "The Widow's Kiss x3" duration 5 # sync / 1[56]:Arachne Eve:1842:/
-509.3 "The Widow's Embrace" sync / 1[56]:Arachne Eve:1888:/
-511.9 "Pitfall" sync / 1[56]:Arachne Eve:1845:/
+494.4 "Tremblor x3" sync / 1[56]:[^:]*:Arachne Eve:1837:/
+501.3 "The Widow's Kiss x3" duration 5 # sync / 1[56]:[^:]*:Arachne Eve:1842:/
+509.3 "The Widow's Embrace" sync / 1[56]:[^:]*:Arachne Eve:1888:/
+511.9 "Pitfall" sync / 1[56]:[^:]*:Arachne Eve:1845:/
 513.9 "--targetable--"
-520.6 "Dark Spike" sync / 1[56]:Arachne Eve:1823:/
-526.4 "Silken Spray" sync / 1[56]:Arachne Eve:1824:/
-535.0 "Dark Spike" sync / 1[56]:Arachne Eve:1823:/
-546.3 "Frond Affeared" sync / 1[56]:Arachne Eve:183A:/ window 30,30
-559.7 "Shadow Burst" sync / 1[56]:Arachne Eve:1838:/
-565.2 "Dark Spike" sync / 1[56]:Arachne Eve:1823:/
-572.2 "--sync--" sync / 1[56]:Arachne Eve:1847:/
-575.9 "Sticky Wicket x3" # sync / 1[56]:Arachne Eve:183F:/
+520.6 "Dark Spike" sync / 1[56]:[^:]*:Arachne Eve:1823:/
+526.4 "Silken Spray" sync / 1[56]:[^:]*:Arachne Eve:1824:/
+535.0 "Dark Spike" sync / 1[56]:[^:]*:Arachne Eve:1823:/
+546.3 "Frond Affeared" sync / 1[56]:[^:]*:Arachne Eve:183A:/ window 30,30
+559.7 "Shadow Burst" sync / 1[56]:[^:]*:Arachne Eve:1838:/
+565.2 "Dark Spike" sync / 1[56]:[^:]*:Arachne Eve:1823:/
+572.2 "--sync--" sync / 1[56]:[^:]*:Arachne Eve:1847:/
+575.9 "Sticky Wicket x3" # sync / 1[56]:[^:]*:Arachne Eve:183F:/
 578.3 "--untargetable--"
-582.9 "Tremblor x3" sync / 1[56]:Arachne Eve:1837:/
+582.9 "Tremblor x3" sync / 1[56]:[^:]*:Arachne Eve:1837:/
 
 # And *finally* we get to rotation blocks!
 # It may not be necessary to sync so widely, but it's probably a safe bet,
 # since we don't have any network logs that get this far to verify.
-589.4 "--sync--" sync / 1[56]:Arachne Eve:1889:/ window 100,5
-590.9 "Pitfall" sync / 1[56]:Arachne Eve:1825:/
+589.4 "--sync--" sync / 1[56]:[^:]*:Arachne Eve:1889:/ window 100,5
+590.9 "Pitfall" sync / 1[56]:[^:]*:Arachne Eve:1825:/
 592.9 "--targetable--"
-604.6 "Arachne Web x3" duration 5 # sync / 1[56]:Arachne Eve:185E:/
-617.8 "Dark Spike" sync / 1[56]:Arachne Eve:1823:/
-623.3 "Silken Spray" sync / 1[56]:Arachne Eve:1824:/
-631.8 "Dark Spike" sync / 1[56]:Arachne Eve:1823:/
-642.8 "Frond Affeared" sync / 1[56]:Arachne Eve:183A:/ window 30,30
-656.5 "Shadow Burst" sync / 1[56]:Arachne Eve:1838:/
-662.0 "Dark Spike" sync / 1[56]:Arachne Eve:1823:/
-677.0 "Arachne Web x3" duration 5 # sync / 1[56]:Arachne Eve:185E:/
+604.6 "Arachne Web x3" duration 5 # sync / 1[56]:[^:]*:Arachne Eve:185E:/
+617.8 "Dark Spike" sync / 1[56]:[^:]*:Arachne Eve:1823:/
+623.3 "Silken Spray" sync / 1[56]:[^:]*:Arachne Eve:1824:/
+631.8 "Dark Spike" sync / 1[56]:[^:]*:Arachne Eve:1823:/
+642.8 "Frond Affeared" sync / 1[56]:[^:]*:Arachne Eve:183A:/ window 30,30
+656.5 "Shadow Burst" sync / 1[56]:[^:]*:Arachne Eve:1838:/
+662.0 "Dark Spike" sync / 1[56]:[^:]*:Arachne Eve:1823:/
+677.0 "Arachne Web x3" duration 5 # sync / 1[56]:[^:]*:Arachne Eve:185E:/
 681.2 "--untargetable--"
-684.9 "The Widow's Kiss x3" duration 5 # sync / 1[56]:Arachne Eve:1842:/
-692.9 "The Widow's Embrace" sync / 1[56]:Arachne Eve:1888:/
-695.4 "Pitfall" sync / 1[56]:Arachne Eve:1845:/
+684.9 "The Widow's Kiss x3" duration 5 # sync / 1[56]:[^:]*:Arachne Eve:1842:/
+692.9 "The Widow's Embrace" sync / 1[56]:[^:]*:Arachne Eve:1888:/
+695.4 "Pitfall" sync / 1[56]:[^:]*:Arachne Eve:1845:/
 697.4 "--targetable--"
-703.4 "--sync--" sync / 1[56]:Arachne Eve:1847:/
-707.1 "Sticky Wicket x3" # sync / 1[56]:Arachne Eve:183F:/
-716.1 "Dark Spike" sync / 1[56]:Arachne Eve:1823:/
-721.6 "Silken Spray" sync / 1[56]:Arachne Eve:1824:/
-730.1 "Dark Spike" sync / 1[56]:Arachne Eve:1823:/
-741.1 "Frond Affeared" sync / 1[56]:Arachne Eve:183A:/ window 30,30
-754.7 "Shadow Burst" sync / 1[56]:Arachne Eve:1838:/
-760.2 "Dark Spike" sync / 1[56]:Arachne Eve:1823:/
-767.2 "--sync--" sync / 1[56]:Arachne Eve:1847:/
-770.8 "Sticky Wicket x3" # sync / 1[56]:Arachne Eve:183F:/
+703.4 "--sync--" sync / 1[56]:[^:]*:Arachne Eve:1847:/
+707.1 "Sticky Wicket x3" # sync / 1[56]:[^:]*:Arachne Eve:183F:/
+716.1 "Dark Spike" sync / 1[56]:[^:]*:Arachne Eve:1823:/
+721.6 "Silken Spray" sync / 1[56]:[^:]*:Arachne Eve:1824:/
+730.1 "Dark Spike" sync / 1[56]:[^:]*:Arachne Eve:1823:/
+741.1 "Frond Affeared" sync / 1[56]:[^:]*:Arachne Eve:183A:/ window 30,30
+754.7 "Shadow Burst" sync / 1[56]:[^:]*:Arachne Eve:1838:/
+760.2 "Dark Spike" sync / 1[56]:[^:]*:Arachne Eve:1823:/
+767.2 "--sync--" sync / 1[56]:[^:]*:Arachne Eve:1847:/
+770.8 "Sticky Wicket x3" # sync / 1[56]:[^:]*:Arachne Eve:183F:/
 773.0 "--untargetable--"
-777.6 "Tremblor x3" # sync / 1[56]:Arachne Eve:1837:/
+777.6 "Tremblor x3" # sync / 1[56]:[^:]*:Arachne Eve:1837:/
 
-784.1 "--sync--" sync / 1[56]:Arachne Eve:1889:/ jump 589.4
+784.1 "--sync--" sync / 1[56]:[^:]*:Arachne Eve:1889:/ jump 589.4
 785.6 "Pitfall"
 787.6 "--targetable--"
 799.3 "Arachne Web"
@@ -135,20 +135,20 @@ hideall "--sync--"
 # -ii 366 17D5 17C1 17D6
 
 1000.0 "--sync--" sync / 00:0839::The Shrine Of The Goetic will be sealed off/ window 1000,5
-1014.2 "Necropurge" sync / 1[56]:Shriveled Talon:17D7:/
-1024.4 "Megiddo Flame" sync / 1[56]:Forgall:17C0:/
-1032.4 "Necropurge" sync / 1[56]:Forgall:17BE:/
-1060.7 "Megiddo Flame" sync / 1[56]:Forgall:17C0:/
-1066.7 "Punishing Ray" sync / 1[56]:Forgall:17C4:/
-1081.0 "Brand of the Fallen" sync / 1[56]:Forgall:17CC:/ window 20,20
-1090.3 "Evil Mist" sync / 1[56]:Forgall:17C5:/
-1101.3 "Necropurge" sync / 1[56]:Shriveled Talon:17D7:/
-1118.3 "Necropurge" sync / 1[56]:Forgall:17BE:/
-1131.6 "Necropurge" sync / 1[56]:Forgall:17BF:/
-1132.8 "Brand of the Fallen" sync / 1[56]:Forgall:17CC:/ window 20,20
-1141.1 "--sync--" sync / 1[56]:Forgall:17C2:/ # Dark Eruption markers go out.
-1146.3 "Dark Eruption x3" # sync / 1[56]:Forgall:17C3:/
-1163.2 "--sync--" sync / 1[56]:Forgall:17C7:/ window 163.2 # Pushes at 50% HP.
+1014.2 "Necropurge" sync / 1[56]:[^:]*:Shriveled Talon:17D7:/
+1024.4 "Megiddo Flame" sync / 1[56]:[^:]*:Forgall:17C0:/
+1032.4 "Necropurge" sync / 1[56]:[^:]*:Forgall:17BE:/
+1060.7 "Megiddo Flame" sync / 1[56]:[^:]*:Forgall:17C0:/
+1066.7 "Punishing Ray" sync / 1[56]:[^:]*:Forgall:17C4:/
+1081.0 "Brand of the Fallen" sync / 1[56]:[^:]*:Forgall:17CC:/ window 20,20
+1090.3 "Evil Mist" sync / 1[56]:[^:]*:Forgall:17C5:/
+1101.3 "Necropurge" sync / 1[56]:[^:]*:Shriveled Talon:17D7:/
+1118.3 "Necropurge" sync / 1[56]:[^:]*:Forgall:17BE:/
+1131.6 "Necropurge" sync / 1[56]:[^:]*:Forgall:17BF:/
+1132.8 "Brand of the Fallen" sync / 1[56]:[^:]*:Forgall:17CC:/ window 20,20
+1141.1 "--sync--" sync / 1[56]:[^:]*:Forgall:17C2:/ # Dark Eruption markers go out.
+1146.3 "Dark Eruption x3" # sync / 1[56]:[^:]*:Forgall:17C3:/
+1163.2 "--sync--" sync / 1[56]:[^:]*:Forgall:17C7:/ window 163.2 # Pushes at 50% HP.
 
 # We don't know how long the intermission goes.
 # There's no data available to tell us what, if anything,
@@ -156,25 +156,25 @@ hideall "--sync--"
 # It could even be nothing.
 # If the intermission goes longer than 3 minutes, something is WRONG.
 
-1350.0 "Mana Explosion" sync / 1[56]:Forgall:17C8:/ window 350,5
+1350.0 "Mana Explosion" sync / 1[56]:[^:]*:Forgall:17C8:/ window 350,5
 
-1360.2 "Necropurge" sync / 1[56]:Forgall:17BE:/ window 200,5
-1373.4 "Necropurge" sync / 1[56]:Forgall:17BF:/
-1373.4 "--sync--" sync / 1[56]:Poison Mist:17D8:/
-1377.5 "Mega Death" sync / 1[56]:Forgall:17CA:/ window 20,20
-1388.5 "--sync--" sync / 1[56]:Forgall:17C2:/
-1393.7 "Dark Eruption x3" # sync / 1[56]:Forgall:17C3:/
-1395.7 "Megiddo Flame" sync / 1[56]:Forgall:17C0:/
-1400.9 "Evil Mist" sync / 1[56]:Forgall:17C5:/
-1414.9 "Necropurge" sync / 1[56]:Forgall:17BF:/
-1414.9 "--sync--" sync / 1[56]:Poison Mist:17D8:/
-1419.1 "Mega Death" sync / 1[56]:Forgall:17CA:/ window 20,20
-1439.2 "Hell Wind" sync / 1[56]:Forgall:17CB:/
-1453.3 "Brand of the Fallen" sync / 1[56]:Forgall:17CC:/
-1459.5 "Punishing Ray" sync / 1[56]:Forgall:17C4:/
-1465.6 "Brand of the Fallen" sync / 1[56]:Forgall:17CC:/
+1360.2 "Necropurge" sync / 1[56]:[^:]*:Forgall:17BE:/ window 200,5
+1373.4 "Necropurge" sync / 1[56]:[^:]*:Forgall:17BF:/
+1373.4 "--sync--" sync / 1[56]:[^:]*:Poison Mist:17D8:/
+1377.5 "Mega Death" sync / 1[56]:[^:]*:Forgall:17CA:/ window 20,20
+1388.5 "--sync--" sync / 1[56]:[^:]*:Forgall:17C2:/
+1393.7 "Dark Eruption x3" # sync / 1[56]:[^:]*:Forgall:17C3:/
+1395.7 "Megiddo Flame" sync / 1[56]:[^:]*:Forgall:17C0:/
+1400.9 "Evil Mist" sync / 1[56]:[^:]*:Forgall:17C5:/
+1414.9 "Necropurge" sync / 1[56]:[^:]*:Forgall:17BF:/
+1414.9 "--sync--" sync / 1[56]:[^:]*:Poison Mist:17D8:/
+1419.1 "Mega Death" sync / 1[56]:[^:]*:Forgall:17CA:/ window 20,20
+1439.2 "Hell Wind" sync / 1[56]:[^:]*:Forgall:17CB:/
+1453.3 "Brand of the Fallen" sync / 1[56]:[^:]*:Forgall:17CC:/
+1459.5 "Punishing Ray" sync / 1[56]:[^:]*:Forgall:17C4:/
+1465.6 "Brand of the Fallen" sync / 1[56]:[^:]*:Forgall:17CC:/
 
-1481.9 "Necropurge" sync / 1[56]:Forgall:17BE:/ jump 1360.2
+1481.9 "Necropurge" sync / 1[56]:[^:]*:Forgall:17BE:/ jump 1360.2
 1495.1 "Necropurge"
 1499.1 "Mega Death"
 1515.4 "Dark Eruption x3"
@@ -196,10 +196,10 @@ hideall "--sync--"
 
 2000.0 "--sync--" sync / 00:0839::The Gloriole will be sealed off/ window 2000,5
 2015.0 "Meteor Headmarkers"
-2024.0 "Meteor Impact" sync / 1[56]:Singularity Fragment:1935:/
+2024.0 "Meteor Impact" sync / 1[56]:[^:]*:Singularity Fragment:1935:/
 
-2045.5 "Transfiguration (Pyramid/Cube?)" sync / 1[56]:Ozma:1826:/ jump 2150.0
-2045.5 "--sync--" sync / 1[56]:Ozma:1803:/ jump 2250.0
+2045.5 "Transfiguration (Pyramid/Cube?)" sync / 1[56]:[^:]*:Ozma:1826:/ jump 2150.0
+2045.5 "--sync--" sync / 1[56]:[^:]*:Ozma:1803:/ jump 2250.0
 2052.6 "Execration?"
 2052.6 "Flare Star?"
 2059.0 "Explosion x5?"
@@ -207,21 +207,21 @@ hideall "--sync--"
 
 # Pyramid-first path
 
-2150.0 "Transfiguration (Pyramid)" sync / 1[56]:Ozma:1826:/
-2157.1 "Execration" sync / 1[56]:Ozma:1828:/
-2178.4 "Acceleration Bomb" sync / 1[56]:Ozma:182F:/
-2195.7 "Transfiguration (Sphere)" sync / 1[56]:Ozma:1827:/
-2199.1 "--sync--" sync / 14:Ozma:1800:/ window 48.8,5
-2203.8 "Black Hole" sync / 1[56]:Ozma:1800:/ window 53,5 jump 2400.0
+2150.0 "Transfiguration (Pyramid)" sync / 1[56]:[^:]*:Ozma:1826:/
+2157.1 "Execration" sync / 1[56]:[^:]*:Ozma:1828:/
+2178.4 "Acceleration Bomb" sync / 1[56]:[^:]*:Ozma:182F:/
+2195.7 "Transfiguration (Sphere)" sync / 1[56]:[^:]*:Ozma:1827:/
+2199.1 "--sync--" sync / 14:[^:]*:Ozma:1800:/ window 48.8,5
+2203.8 "Black Hole" sync / 1[56]:[^:]*:Ozma:1800:/ window 53,5 jump 2400.0
 
 # Cube-first path
 
-2250.0 "Transfiguration (Cube)" sync / 1[56]:Ozma:1803:/
-2257.0 "Flare Star" sync / 1[56]:Ozma:1805:/
-2288.0 "Holy" sync / 1[56]:Ozma:182E:/
-2300.0 "Transfiguration (Sphere)" sync / 1[56]:Ozma:1804:/
-2303.3 "--sync--" sync / 14:Ozma:1800:/ window 53.3,5
-2308.0 "Black Hole" sync / 1[56]:Ozma:1800:/ window 58,5 jump 2400.0
+2250.0 "Transfiguration (Cube)" sync / 1[56]:[^:]*:Ozma:1803:/
+2257.0 "Flare Star" sync / 1[56]:[^:]*:Ozma:1805:/
+2288.0 "Holy" sync / 1[56]:[^:]*:Ozma:182E:/
+2300.0 "Transfiguration (Sphere)" sync / 1[56]:[^:]*:Ozma:1804:/
+2303.3 "--sync--" sync / 14:[^:]*:Ozma:1800:/ window 53.3,5
+2308.0 "Black Hole" sync / 1[56]:[^:]*:Ozma:1800:/ window 58,5 jump 2400.0
 
 # Intermission
 
@@ -232,9 +232,9 @@ hideall "--sync--"
 # Instead, we just let the timeline play on dead space.
 # The intermission's enrage is probably under 3 minutes, but we have no way to know.
 
-2594.4 "--sync--" sync / 1[56]:Ozma:182D:/ window 194.4,0
-2600.0 "--sync--" sync / 1[56]:Ozma:1826:/ window 200,5 jump 2700.0
-2600.0 "--sync--" sync / 1[56]:Ozma:1803:/ window 200,5 jump 3000.0
+2594.4 "--sync--" sync / 1[56]:[^:]*:Ozma:182D:/ window 194.4,0
+2600.0 "--sync--" sync / 1[56]:[^:]*:Ozma:1826:/ window 200,5 jump 2700.0
+2600.0 "--sync--" sync / 1[56]:[^:]*:Ozma:1803:/ window 200,5 jump 3000.0
 
 # The continuation from the intermission is dependent on whichever was first.
 # Each has its own bridge block, each one leading into a pair of rotation blocks.
@@ -243,14 +243,14 @@ hideall "--sync--"
 
 
 # Cube-first continued
-2700.0 "Transfiguration (Pyramid)" sync / 1[56]:Ozma:1826:/
-2707.0 "Execration" sync / 1[56]:Ozma:1828:/
-2728.0 "Acceleration Bomb" sync / 1[56]:Ozma:182F:/
-2745.0 "Transfiguration (Sphere)" sync / 1[56]:Ozma:1827:/ window 45,5
-2763.0 "Meteor Impact" sync / 1[56]:Singularity Fragment:1935:/
+2700.0 "Transfiguration (Pyramid)" sync / 1[56]:[^:]*:Ozma:1826:/
+2707.0 "Execration" sync / 1[56]:[^:]*:Ozma:1828:/
+2728.0 "Acceleration Bomb" sync / 1[56]:[^:]*:Ozma:182F:/
+2745.0 "Transfiguration (Sphere)" sync / 1[56]:[^:]*:Ozma:1827:/ window 45,5
+2763.0 "Meteor Impact" sync / 1[56]:[^:]*:Singularity Fragment:1935:/
 
-2790.8 "Transfiguration (Cube/Pyramid?)" sync / 1[56]:Ozma:1826:/ window 50,5 jump 3200
-2790.8 "--sync--" sync / 1[56]:Ozma:1803:/ window 50,5 jump 3400
+2790.8 "Transfiguration (Cube/Pyramid?)" sync / 1[56]:[^:]*:Ozma:1826:/ window 50,5 jump 3200
+2790.8 "--sync--" sync / 1[56]:[^:]*:Ozma:1803:/ window 50,5 jump 3400
 2797.8 "Execration?"
 2797.8 "Flare Star?"
 2809.8 "Holy?"
@@ -260,14 +260,14 @@ hideall "--sync--"
 
 # Pyramid-first continued
 
-3000.0 "Transfiguration (Cube)" sync / 1[56]:Ozma:1803:/
-3007.0 "Flare Star" sync / 1[56]:Ozma:1805:/
-3011.0 "Tank Lasers" # sync / 1[56]:Ozma:1831:/
-3029.7 "Transfiguration (Sphere)" sync / 1[56]:Ozma:1804:/
-3047.9 "Meteor Impact" sync / 1[56]:Singularity Fragment:1935:/
+3000.0 "Transfiguration (Cube)" sync / 1[56]:[^:]*:Ozma:1803:/
+3007.0 "Flare Star" sync / 1[56]:[^:]*:Ozma:1805:/
+3011.0 "Tank Lasers" # sync / 1[56]:[^:]*:Ozma:1831:/
+3029.7 "Transfiguration (Sphere)" sync / 1[56]:[^:]*:Ozma:1804:/
+3047.9 "Meteor Impact" sync / 1[56]:[^:]*:Singularity Fragment:1935:/
 
-3080.8 "Transfiguration (Cube/Pyramid?)" sync / 1[56]:Ozma:1826:/ window 50,5 jump 3200
-3080.8 "--sync--" sync / 1[56]:Ozma:1803:/ window 50,5 jump 3400
+3080.8 "Transfiguration (Cube/Pyramid?)" sync / 1[56]:[^:]*:Ozma:1826:/ window 50,5 jump 3200
+3080.8 "--sync--" sync / 1[56]:[^:]*:Ozma:1803:/ window 50,5 jump 3400
 3087.8 "Execration?"
 3087.8 "Flare Star?"
 3091.8 "Tank Lasers?"
@@ -277,16 +277,16 @@ hideall "--sync--"
 
 # Pyramid standard rotation
 
-3200.0 "Transfiguration (Pyramid)" sync / 1[56]:Ozma:1826:/
-3207.0 "Execration" sync / 1[56]:Ozma:1828:/
-3223.0 "Acceleration Bomb" sync / 1[56]:Ozma:182F:/
-3226.0 "Meteor Impact" sync / 1[56]:Singularity Fragment:1935:/
-3246.5 "Meteor" # sync / 1[56]:Ozma:182D:/
-3261.0 "Acceleration Bomb" sync / 1[56]:Ozma:182F:/
-3263.0 "Transfiguration (Sphere)" sync / 1[56]:Ozma:1827:/ window 50,5
+3200.0 "Transfiguration (Pyramid)" sync / 1[56]:[^:]*:Ozma:1826:/
+3207.0 "Execration" sync / 1[56]:[^:]*:Ozma:1828:/
+3223.0 "Acceleration Bomb" sync / 1[56]:[^:]*:Ozma:182F:/
+3226.0 "Meteor Impact" sync / 1[56]:[^:]*:Singularity Fragment:1935:/
+3246.5 "Meteor" # sync / 1[56]:[^:]*:Ozma:182D:/
+3261.0 "Acceleration Bomb" sync / 1[56]:[^:]*:Ozma:182F:/
+3263.0 "Transfiguration (Sphere)" sync / 1[56]:[^:]*:Ozma:1827:/ window 50,5
 
-3275.0 "Transfiguration (Cube/Pyramid?)" sync / 1[56]:Ozma:1826:/ window 50,5 jump 3200
-3275.0 "--sync--" sync / 1[56]:Ozma:1803:/ jump 3400
+3275.0 "Transfiguration (Cube/Pyramid?)" sync / 1[56]:[^:]*:Ozma:1826:/ window 50,5 jump 3200
+3275.0 "--sync--" sync / 1[56]:[^:]*:Ozma:1803:/ jump 3400
 3282.0 "Execration?"
 3282.0 "Flare Star?"
 3286.0 "Tank Lasers?"
@@ -296,17 +296,17 @@ hideall "--sync--"
 
 # Cube standard rotation
 
-3400.0 "Transfiguration (Cube)" sync / 1[56]:Ozma:1803:/
-3407.0 "Flare Star" sync / 1[56]:Ozma:1805:/
-3411.0 "Tank Lasers" # sync / 1[56]:Ozma:1831:/
-3419.2 "Holy" sync / 1[56]:Ozma:182E:/
-3435.1 "Meteor Impact" sync / 1[56]:Singularity Fragment:1935:/
-3441.3 "Holy" sync / 1[56]:Ozma:182E:/
-3456.6 "Meteor" # sync / 1[56]:Ozma:182D:/
-3463.2 "Transfiguration (Sphere)" sync / 1[56]:Ozma:1804:/ window 50,5
+3400.0 "Transfiguration (Cube)" sync / 1[56]:[^:]*:Ozma:1803:/
+3407.0 "Flare Star" sync / 1[56]:[^:]*:Ozma:1805:/
+3411.0 "Tank Lasers" # sync / 1[56]:[^:]*:Ozma:1831:/
+3419.2 "Holy" sync / 1[56]:[^:]*:Ozma:182E:/
+3435.1 "Meteor Impact" sync / 1[56]:[^:]*:Singularity Fragment:1935:/
+3441.3 "Holy" sync / 1[56]:[^:]*:Ozma:182E:/
+3456.6 "Meteor" # sync / 1[56]:[^:]*:Ozma:182D:/
+3463.2 "Transfiguration (Sphere)" sync / 1[56]:[^:]*:Ozma:1804:/ window 50,5
 
-3475.2 "Transfiguration (Cube/Pyramid?)" sync / 1[56]:Ozma:1826:/ window 50,5 jump 3200
-3475.2 "--sync--" sync / 1[56]:Ozma:1803:/ window 50,5 jump 3400
+3475.2 "Transfiguration (Cube/Pyramid?)" sync / 1[56]:[^:]*:Ozma:1826:/ window 50,5 jump 3200
+3475.2 "--sync--" sync / 1[56]:[^:]*:Ozma:1803:/ window 50,5 jump 3400
 3482.2 "Execration?"
 3482.2 "Flare Star?"
 3486.2 "Tank Lasers?"
@@ -325,33 +325,33 @@ hideall "--sync--"
 # 1811 and 180D are releasing hair after Haircut and Split End cleaves
 
 4000.0 "--sync--" sync / 00:0839::The Tomb Of The Nullstone will be sealed off/ window 4000,5
-4004.1 "Bloodied Nail x4" # sync / 1[56]:Calofisteri:181F:/
-4018.8 "Coif Change" sync / 1[56]:Calofisteri:180[AE]:/ window 18.8,5
-4027.8 "Haircut" sync / 1[56]:Calofisteri:180[BF]:/
-4030.8 "Split End" sync / 1[56]:Calofisteri:18(0C|10):/
-4035.8 "Split End" sync / 1[56]:Calofisteri:18(0C|10):/
-4040.8 "Extension" sync / 1[56]:Calofisteri:1812:/
-4043.8 "Split End" sync / 1[56]:Calofisteri:18(0C|10):/
-4047.8 "Split End" sync / 1[56]:Calofisteri:18(0C|10):/
-4051.9 "--sync--" sync / 1[56]:Calofisteri:18(0D|11):/ window 51,5
-4054.9 "Coif Change" sync / 1[56]:Calofisteri:180[AE]:/
-4063.9 "Haircut" sync / 1[56]:Calofisteri:180[BF]:/
-4066.9 "Split End" sync / 1[56]:Calofisteri:18(0C|10):/
-4071.9 "Split End" sync / 1[56]:Calofisteri:18(0C|10):/
-4076.9 "Extension" sync / 1[56]:Calofisteri:1812:/
-4079.9 "Split End" sync / 1[56]:Calofisteri:18(0C|10):/
-4083.9 "Split End" sync / 1[56]:Calofisteri:18(0C|10):/
-4090.9 "Haircut" sync / 1[56]:Calofisteri:180[BF]:/
-4093.9 "Split End" sync / 1[56]:Calofisteri:18(0C|10):/
-4096.9 "Aura Burst" sync / 1[56]:Calofisteri:1821:/
-4099.8 "--sync--" sync / 1[56]:Calofisteri:18(0D|11):/ window 40,5
+4004.1 "Bloodied Nail x4" # sync / 1[56]:[^:]*:Calofisteri:181F:/
+4018.8 "Coif Change" sync / 1[56]:[^:]*:Calofisteri:180[AE]:/ window 18.8,5
+4027.8 "Haircut" sync / 1[56]:[^:]*:Calofisteri:180[BF]:/
+4030.8 "Split End" sync / 1[56]:[^:]*:Calofisteri:18(0C|10):/
+4035.8 "Split End" sync / 1[56]:[^:]*:Calofisteri:18(0C|10):/
+4040.8 "Extension" sync / 1[56]:[^:]*:Calofisteri:1812:/
+4043.8 "Split End" sync / 1[56]:[^:]*:Calofisteri:18(0C|10):/
+4047.8 "Split End" sync / 1[56]:[^:]*:Calofisteri:18(0C|10):/
+4051.9 "--sync--" sync / 1[56]:[^:]*:Calofisteri:18(0D|11):/ window 51,5
+4054.9 "Coif Change" sync / 1[56]:[^:]*:Calofisteri:180[AE]:/
+4063.9 "Haircut" sync / 1[56]:[^:]*:Calofisteri:180[BF]:/
+4066.9 "Split End" sync / 1[56]:[^:]*:Calofisteri:18(0C|10):/
+4071.9 "Split End" sync / 1[56]:[^:]*:Calofisteri:18(0C|10):/
+4076.9 "Extension" sync / 1[56]:[^:]*:Calofisteri:1812:/
+4079.9 "Split End" sync / 1[56]:[^:]*:Calofisteri:18(0C|10):/
+4083.9 "Split End" sync / 1[56]:[^:]*:Calofisteri:18(0C|10):/
+4090.9 "Haircut" sync / 1[56]:[^:]*:Calofisteri:180[BF]:/
+4093.9 "Split End" sync / 1[56]:[^:]*:Calofisteri:18(0C|10):/
+4096.9 "Aura Burst" sync / 1[56]:[^:]*:Calofisteri:1821:/
+4099.8 "--sync--" sync / 1[56]:[^:]*:Calofisteri:18(0D|11):/ window 40,5
 4101.4 "--untargetable--"
-4103.8 "Dancing Mad" sync / 1[56]:Calofisteri:1818:/ window 103.8,5
+4103.8 "Dancing Mad" sync / 1[56]:[^:]*:Calofisteri:1818:/ window 103.8,5
 
 # An intermission full of SKY LASERS
-4112.3 "Feint Particle Beam x16" sync / 1[56]:Calofisteri:1927:/ duration 10
-4131.6 "Feint Particle Beam x16" sync / 1[56]:Calofisteri:1927:/ duration 10
-4140.9 "Feint Particle Beam x16" sync / 1[56]:Calofisteri:1927:/ jump 4112.3
+4112.3 "Feint Particle Beam x16" sync / 1[56]:[^:]*:Calofisteri:1927:/ duration 10
+4131.6 "Feint Particle Beam x16" sync / 1[56]:[^:]*:Calofisteri:1927:/ duration 10
+4140.9 "Feint Particle Beam x16" sync / 1[56]:[^:]*:Calofisteri:1927:/ jump 4112.3
 4160.8 "Feint Particle Beam x16"
 
 
@@ -359,60 +359,60 @@ hideall "--sync--"
 # It doesn't look like time taken on the intermission affects how many times
 # Dancing Mad strikes.
 
-4200.0 "Mana Drain" sync / 1[56]:Calofisteri:1819:/ window 80,5
-4204.0 "Dancing Mad" sync / 1[56]:Calofisteri:181A:/
+4200.0 "Mana Drain" sync / 1[56]:[^:]*:Calofisteri:1819:/ window 80,5
+4204.0 "Dancing Mad" sync / 1[56]:[^:]*:Calofisteri:181A:/
 4212.9 "--targetable--"
-4215.0 "Coif Change" sync / 1[56]:Calofisteri:180[AE]:/
-4224.0 "Haircut" sync / 1[56]:Calofisteri:180[BF]:/
-4227.0 "--sync--" sync / 1[56]:Calofisteri:18(0D|11):/
-4232.0 "Extension" sync / 1[56]:Calofisteri:1812:/
-4237.0 "--sync--" sync / 1[56]:Calofisteri:1813:/
-4238.0 "Bloodied Nail x3" # sync / 1[56]:Calofisteri:181F:/
-4249.0 "Evil Curl/Evil Tress" sync / 1[56]:Living Lock:181[67]:/
-4251.5 "Extension" sync / 1[56]:Calofisteri:1812:/
-4253.5 "Coif Change" sync / 1[56]:Calofisteri:180[AE]:/ window 15,15
+4215.0 "Coif Change" sync / 1[56]:[^:]*:Calofisteri:180[AE]:/
+4224.0 "Haircut" sync / 1[56]:[^:]*:Calofisteri:180[BF]:/
+4227.0 "--sync--" sync / 1[56]:[^:]*:Calofisteri:18(0D|11):/
+4232.0 "Extension" sync / 1[56]:[^:]*:Calofisteri:1812:/
+4237.0 "--sync--" sync / 1[56]:[^:]*:Calofisteri:1813:/
+4238.0 "Bloodied Nail x3" # sync / 1[56]:[^:]*:Calofisteri:181F:/
+4249.0 "Evil Curl/Evil Tress" sync / 1[56]:[^:]*:Living Lock:181[67]:/
+4251.5 "Extension" sync / 1[56]:[^:]*:Calofisteri:1812:/
+4253.5 "Coif Change" sync / 1[56]:[^:]*:Calofisteri:180[AE]:/ window 15,15
 
 # This section of the bridge may be skipped depending on DPS. HP% for push is unknown.
-4262.5 "Haircut" sync / 1[56]:Calofisteri:180[BF]:/
-4268.5 "Aura Burst" sync / 1[56]:Calofisteri:1821:/
-4273.5 "Split End" sync / 1[56]:Calofisteri:18(0C|10):/
-4278.5 "Split End" sync / 1[56]:Calofisteri:18(0C|10):/
+4262.5 "Haircut" sync / 1[56]:[^:]*:Calofisteri:180[BF]:/
+4268.5 "Aura Burst" sync / 1[56]:[^:]*:Calofisteri:1821:/
+4273.5 "Split End" sync / 1[56]:[^:]*:Calofisteri:18(0C|10):/
+4278.5 "Split End" sync / 1[56]:[^:]*:Calofisteri:18(0C|10):/
 
-4280.5 "--sync--" sync / 1[56]:Calofisteri:18(0D|11):/ window 27,15
-4285.5 "Extension" sync / 1[56]:Calofisteri:1812:/
-4290.5 "--sync--" sync / 1[56]:Calofisteri:1813:/
-4293.4 "Penetration" sync / 1[56]:Calofisteri:1822:/
+4280.5 "--sync--" sync / 1[56]:[^:]*:Calofisteri:18(0D|11):/ window 27,15
+4285.5 "Extension" sync / 1[56]:[^:]*:Calofisteri:1812:/
+4290.5 "--sync--" sync / 1[56]:[^:]*:Calofisteri:1813:/
+4293.4 "Penetration" sync / 1[56]:[^:]*:Calofisteri:1822:/
 
 # Rotation block to 0%
-4296.9 "Coif Change" sync / 1[56]:Calofisteri:180[AE]:/ window 15,15
-4307.2 "Depth Charge" sync / 1[56]:Calofisteri:1820:/
-4311.2 "Haircut" sync / 1[56]:Calofisteri:180[BF]:/
-4317.2 "--sync--" sync / 1[56]:Calofisteri:18(0D|11):/
-4322.2 "Extension" sync / 1[56]:Calofisteri:1812:/
-4325.2 "Bloodied Nail x3" # sync / 1[56]:Calofisteri:181F:/
-4332.2 "Aura Burst" sync / 1[56]:Calofisteri:1821:/
-4338.7 "Coif Change" sync / 1[56]:Calofisteri:180[AE]:/ window 15,15
-4339.2 "Evil Switch" sync / 1[56]:Living Lock:1815:/
-4345.7 "Haircut" sync / 1[56]:Calofisteri:180[BF]:/
-4351.7 "Extension" sync / 1[56]:Calofisteri:1812:/
-4356.7 "Split End" sync / 1[56]:Calofisteri:18(0C|10):/
-4358.7 "--sync--" sync / 1[56]:Calofisteri:18(0D|11):/
-4363.7 "Extension" sync / 1[56]:Calofisteri:1812:/
-4367.7 "Bloodied Nail x3" # sync / 1[56]:Calofisteri:181F:/
-4377.2 "Aura Burst" sync / 1[56]:Calofisteri:1821:/
-4379.2 "Coif Change" sync / 1[56]:Calofisteri:180[AE]:/ window 15,15
-4380.7 "Evil Curl/Evil Tress" sync / 1[56]:Living Lock:181[67]:/
-4386.3 "Haircut" sync / 1[56]:Calofisteri:180[BF]:/
-4392.3 "Split End" sync / 1[56]:Calofisteri:18(0C|10):/
-4397.3 "Split End" sync / 1[56]:Calofisteri:18(0C|10):/
-4402.3 "Aura Burst" sync / 1[56]:Calofisteri:1821:/
-4404.3 "--sync--" sync / 1[56]:Calofisteri:18(0D|11):/
-4409.3 "Extension" sync / 1[56]:Calofisteri:1812:/
-4414.3 "--sync--" sync / 1[56]:Calofisteri:1813:/
-4417.7 "Penetration" sync / 1[56]:Calofisteri:1822:/
-4421.2 "Evil Curl/Evil Tress" sync / 1[56]:Living Lock:181[67]:/
+4296.9 "Coif Change" sync / 1[56]:[^:]*:Calofisteri:180[AE]:/ window 15,15
+4307.2 "Depth Charge" sync / 1[56]:[^:]*:Calofisteri:1820:/
+4311.2 "Haircut" sync / 1[56]:[^:]*:Calofisteri:180[BF]:/
+4317.2 "--sync--" sync / 1[56]:[^:]*:Calofisteri:18(0D|11):/
+4322.2 "Extension" sync / 1[56]:[^:]*:Calofisteri:1812:/
+4325.2 "Bloodied Nail x3" # sync / 1[56]:[^:]*:Calofisteri:181F:/
+4332.2 "Aura Burst" sync / 1[56]:[^:]*:Calofisteri:1821:/
+4338.7 "Coif Change" sync / 1[56]:[^:]*:Calofisteri:180[AE]:/ window 15,15
+4339.2 "Evil Switch" sync / 1[56]:[^:]*:Living Lock:1815:/
+4345.7 "Haircut" sync / 1[56]:[^:]*:Calofisteri:180[BF]:/
+4351.7 "Extension" sync / 1[56]:[^:]*:Calofisteri:1812:/
+4356.7 "Split End" sync / 1[56]:[^:]*:Calofisteri:18(0C|10):/
+4358.7 "--sync--" sync / 1[56]:[^:]*:Calofisteri:18(0D|11):/
+4363.7 "Extension" sync / 1[56]:[^:]*:Calofisteri:1812:/
+4367.7 "Bloodied Nail x3" # sync / 1[56]:[^:]*:Calofisteri:181F:/
+4377.2 "Aura Burst" sync / 1[56]:[^:]*:Calofisteri:1821:/
+4379.2 "Coif Change" sync / 1[56]:[^:]*:Calofisteri:180[AE]:/ window 15,15
+4380.7 "Evil Curl/Evil Tress" sync / 1[56]:[^:]*:Living Lock:181[67]:/
+4386.3 "Haircut" sync / 1[56]:[^:]*:Calofisteri:180[BF]:/
+4392.3 "Split End" sync / 1[56]:[^:]*:Calofisteri:18(0C|10):/
+4397.3 "Split End" sync / 1[56]:[^:]*:Calofisteri:18(0C|10):/
+4402.3 "Aura Burst" sync / 1[56]:[^:]*:Calofisteri:1821:/
+4404.3 "--sync--" sync / 1[56]:[^:]*:Calofisteri:18(0D|11):/
+4409.3 "Extension" sync / 1[56]:[^:]*:Calofisteri:1812:/
+4414.3 "--sync--" sync / 1[56]:[^:]*:Calofisteri:1813:/
+4417.7 "Penetration" sync / 1[56]:[^:]*:Calofisteri:1822:/
+4421.2 "Evil Curl/Evil Tress" sync / 1[56]:[^:]*:Living Lock:181[67]:/
 
-4421.2 "Coif Change" sync / 1[56]:Calofisteri:180[AE]:/ window 15,15 jump 4296.9
+4421.2 "Coif Change" sync / 1[56]:[^:]*:Calofisteri:180[AE]:/ window 15,15 jump 4296.9
 4431.5 "Depth Charge"
 4435.5 "Haircut"
 4446.5 "Extension"

--- a/ui/raidboss/data/03-hw/dungeon/aetherochemical_research_facility.txt
+++ b/ui/raidboss/data/03-hw/dungeon/aetherochemical_research_facility.txt
@@ -9,18 +9,18 @@ hideall "--sync--"
 
 # -ii 10E1
 0.0 "--sync--" sync / 00:0839::Analysis and Proving will be sealed off/
-2.9 "--sync--" sync / 1[56]:Regula van Hydrus:366:/
-6.3 "Bastardbluss" sync / 1[56]:Regula van Hydrus:10DA:/ window 6.3,5
+2.9 "--sync--" sync / 1[56]:[^:]*:Regula van Hydrus:366:/
+6.3 "Bastardbluss" sync / 1[56]:[^:]*:Regula van Hydrus:10DA:/ window 6.3,5
 
-13.4 "Judgment" sync / 1[56]:Regula van Hydrus:10DD:/ window 13.4,2.5
-18.6 "Judgment" sync / 1[56]:Regula van Hydrus:10DE:/
-25.5 "Bastardbluss" sync / 1[56]:Regula van Hydrus:10DA:/
-37.8 "Bastardbluss" sync / 1[56]:Regula van Hydrus:10DA:/
+13.4 "Judgment" sync / 1[56]:[^:]*:Regula van Hydrus:10DD:/ window 13.4,2.5
+18.6 "Judgment" sync / 1[56]:[^:]*:Regula van Hydrus:10DE:/
+25.5 "Bastardbluss" sync / 1[56]:[^:]*:Regula van Hydrus:10DA:/
+37.8 "Bastardbluss" sync / 1[56]:[^:]*:Regula van Hydrus:10DA:/
 
-44.9 "Judgment" sync / 1[56]:Regula van Hydrus:10DD:/ window 15,3
-50.1 "Judgment" sync / 1[56]:Regula van Hydrus:10DE:/
-57.0 "Bastardbluss" sync / 1[56]:Regula van Hydrus:10DA:/
-69.3 "Bastardbluss" sync / 1[56]:Regula van Hydrus:10DA:/ jump 37.8
+44.9 "Judgment" sync / 1[56]:[^:]*:Regula van Hydrus:10DD:/ window 15,3
+50.1 "Judgment" sync / 1[56]:[^:]*:Regula van Hydrus:10DE:/
+57.0 "Bastardbluss" sync / 1[56]:[^:]*:Regula van Hydrus:10DA:/
+69.3 "Bastardbluss" sync / 1[56]:[^:]*:Regula van Hydrus:10DA:/ jump 37.8
 
 76.4 "Judgment"
 81.6 "Judgment"
@@ -28,32 +28,32 @@ hideall "--sync--"
 100.8 "Bastardbluss"
 
 # First turrets at HP < 80%
-150.0 "Magitek Turret" sync / 1[56]:Regula van Hydrus:10E0:/ window 150,5
-152.4 "--sync--" sync / 1[56]:Regula van Hydrus:10DF:/
-157.8 "Magitek Slug" sync / 1[56]:Regula van Hydrus:10DB:/
-161.4 "Magitek Slug" sync / 1[56]:Regula van Hydrus:10DB:/
-165.1 "Magitek Slug" sync / 1[56]:Regula van Hydrus:10DB:/
-166.4 "--sync--" sync / 1[56]:Regula van Hydrus:10DF:/
-171.6 "Magitek Slug" sync / 1[56]:Regula van Hydrus:10DB:/
-175.5 "Magitek Slug" sync / 1[56]:Regula van Hydrus:10DB:/
-179.2 "Magitek Slug" sync / 1[56]:Regula van Hydrus:10DB:/
-180.5 "--sync--" sync / 1[56]:Regula van Hydrus:10DF:/
-185.4 "Magitek Slug" sync / 1[56]:Regula van Hydrus:10DB:/
-188.8 "Self-detonate?" sync / 1[56]:Magitek Turret I:10E3:/
-189.2 "Magitek Slug" sync / 1[56]:Regula van Hydrus:10DB:/
-193.0 "Magitek Slug" sync / 1[56]:Regula van Hydrus:10DB:/
+150.0 "Magitek Turret" sync / 1[56]:[^:]*:Regula van Hydrus:10E0:/ window 150,5
+152.4 "--sync--" sync / 1[56]:[^:]*:Regula van Hydrus:10DF:/
+157.8 "Magitek Slug" sync / 1[56]:[^:]*:Regula van Hydrus:10DB:/
+161.4 "Magitek Slug" sync / 1[56]:[^:]*:Regula van Hydrus:10DB:/
+165.1 "Magitek Slug" sync / 1[56]:[^:]*:Regula van Hydrus:10DB:/
+166.4 "--sync--" sync / 1[56]:[^:]*:Regula van Hydrus:10DF:/
+171.6 "Magitek Slug" sync / 1[56]:[^:]*:Regula van Hydrus:10DB:/
+175.5 "Magitek Slug" sync / 1[56]:[^:]*:Regula van Hydrus:10DB:/
+179.2 "Magitek Slug" sync / 1[56]:[^:]*:Regula van Hydrus:10DB:/
+180.5 "--sync--" sync / 1[56]:[^:]*:Regula van Hydrus:10DF:/
+185.4 "Magitek Slug" sync / 1[56]:[^:]*:Regula van Hydrus:10DB:/
+188.8 "Self-detonate?" sync / 1[56]:[^:]*:Magitek Turret I:10E3:/
+189.2 "Magitek Slug" sync / 1[56]:[^:]*:Regula van Hydrus:10DB:/
+193.0 "Magitek Slug" sync / 1[56]:[^:]*:Regula van Hydrus:10DB:/
 
 # Rotation resumes here whether or not turrets are successful
-199.3 "Bastardbluss" sync / 1[56]:Regula van Hydrus:10DA:/ window 50,1
-202.4 "Bastardbluss" sync / 1[56]:Regula van Hydrus:10DA:/
-209.7 "Judgment" sync / 1[56]:Regula van Hydrus:10DD:/ window 15,2.5
-215.0 "Judgment" sync / 1[56]:Regula van Hydrus:10DE:/
+199.3 "Bastardbluss" sync / 1[56]:[^:]*:Regula van Hydrus:10DA:/ window 50,1
+202.4 "Bastardbluss" sync / 1[56]:[^:]*:Regula van Hydrus:10DA:/
+209.7 "Judgment" sync / 1[56]:[^:]*:Regula van Hydrus:10DD:/ window 15,2.5
+215.0 "Judgment" sync / 1[56]:[^:]*:Regula van Hydrus:10DE:/
 
-221.9 "Bastardbluss" sync / 1[56]:Regula van Hydrus:10DA:/ window 10,10
-234.2 "Bastardbluss" sync / 1[56]:Regula van Hydrus:10DA:/
-237.5 "Bastardbluss" sync / 1[56]:Regula van Hydrus:10DA:/
-244.7 "Judgment" sync / 1[56]:Regula van Hydrus:10DD:/
-249.9 "Judgment" sync / 1[56]:Regula van Hydrus:10DE:/ jump 215.0
+221.9 "Bastardbluss" sync / 1[56]:[^:]*:Regula van Hydrus:10DA:/ window 10,10
+234.2 "Bastardbluss" sync / 1[56]:[^:]*:Regula van Hydrus:10DA:/
+237.5 "Bastardbluss" sync / 1[56]:[^:]*:Regula van Hydrus:10DA:/
+244.7 "Judgment" sync / 1[56]:[^:]*:Regula van Hydrus:10DD:/
+249.9 "Judgment" sync / 1[56]:[^:]*:Regula van Hydrus:10DE:/ jump 215.0
 
 256.8 "Bastardbluss"
 269.1 "Bastardbluss"
@@ -62,40 +62,40 @@ hideall "--sync--"
 284.8 "Judgment"
 
 # Second turrets at HP < 50%
-330.1 "Magitek Turret" sync / 1[56]:Regula van Hydrus:10E0:/ window 130,5
-332.5 "--sync--" sync / 1[56]:Regula van Hydrus:10DF:/
-337.8 "Magitek Slug" sync / 1[56]:Regula van Hydrus:10DB:/
-340.7 "Aetherochemical Grenado" sync / 1[56]:Magitek Turret II:10E2:/
-341.4 "Magitek Slug" sync / 1[56]:Regula van Hydrus:10DB:/
-345.0 "Magitek Slug" sync / 1[56]:Regula van Hydrus:10DB:/
-345.7 "Aetherochemical Grenado" sync / 1[56]:Magitek Turret II:10E2:/
-346.2 "--sync--" sync / 1[56]:Regula van Hydrus:10DF:/
-350.9 "Aetherochemical Grenado" sync / 1[56]:Magitek Turret II:10E2:/
-351.4 "Magitek Slug" sync / 1[56]:Regula van Hydrus:10DB:/
-355.1 "Magitek Slug" sync / 1[56]:Regula van Hydrus:10DB:/
-356.1 "Aetherochemical Grenado" sync / 1[56]:Magitek Turret II:10E2:/
-358.8 "Magitek Slug" sync / 1[56]:Regula van Hydrus:10DB:/
-360.0 "--sync--" sync / 1[56]:Regula van Hydrus:10DF:/
-361.3 "Aetherochemical Grenado" sync / 1[56]:Magitek Turret II:10E2:/
-365.0 "Magitek Slug" sync / 1[56]:Regula van Hydrus:10DB:/
-368.0 "Self-detonate?" sync / 1[56]:(Magitek Turret I|Magitek Turret II):10E3:/
-368.7 "Magitek Slug" sync / 1[56]:Regula van Hydrus:10DB:/
-372.5 "Magitek Slug" sync / 1[56]:Regula van Hydrus:10DB:/
-373.7 "--sync--" sync / 1[56]:Regula van Hydrus:10DF:/
+330.1 "Magitek Turret" sync / 1[56]:[^:]*:Regula van Hydrus:10E0:/ window 130,5
+332.5 "--sync--" sync / 1[56]:[^:]*:Regula van Hydrus:10DF:/
+337.8 "Magitek Slug" sync / 1[56]:[^:]*:Regula van Hydrus:10DB:/
+340.7 "Aetherochemical Grenado" sync / 1[56]:[^:]*:Magitek Turret II:10E2:/
+341.4 "Magitek Slug" sync / 1[56]:[^:]*:Regula van Hydrus:10DB:/
+345.0 "Magitek Slug" sync / 1[56]:[^:]*:Regula van Hydrus:10DB:/
+345.7 "Aetherochemical Grenado" sync / 1[56]:[^:]*:Magitek Turret II:10E2:/
+346.2 "--sync--" sync / 1[56]:[^:]*:Regula van Hydrus:10DF:/
+350.9 "Aetherochemical Grenado" sync / 1[56]:[^:]*:Magitek Turret II:10E2:/
+351.4 "Magitek Slug" sync / 1[56]:[^:]*:Regula van Hydrus:10DB:/
+355.1 "Magitek Slug" sync / 1[56]:[^:]*:Regula van Hydrus:10DB:/
+356.1 "Aetherochemical Grenado" sync / 1[56]:[^:]*:Magitek Turret II:10E2:/
+358.8 "Magitek Slug" sync / 1[56]:[^:]*:Regula van Hydrus:10DB:/
+360.0 "--sync--" sync / 1[56]:[^:]*:Regula van Hydrus:10DF:/
+361.3 "Aetherochemical Grenado" sync / 1[56]:[^:]*:Magitek Turret II:10E2:/
+365.0 "Magitek Slug" sync / 1[56]:[^:]*:Regula van Hydrus:10DB:/
+368.0 "Self-detonate?" sync / 1[56]:[^:]*:(Magitek Turret I|Magitek Turret II):10E3:/
+368.7 "Magitek Slug" sync / 1[56]:[^:]*:Regula van Hydrus:10DB:/
+372.5 "Magitek Slug" sync / 1[56]:[^:]*:Regula van Hydrus:10DB:/
+373.7 "--sync--" sync / 1[56]:[^:]*:Regula van Hydrus:10DF:/
 
 # Brief rotation block
-379.3 "Magitek Spread" sync / 1[56]:Regula van Hydrus:10DC:/ window 150,5
-386.5 "Bastardbluss" sync / 1[56]:Regula van Hydrus:10DA:/
-389.6 "Bastardbluss" sync / 1[56]:Regula van Hydrus:10DA:/
-392.7 "Bastardbluss" sync / 1[56]:Regula van Hydrus:10DA:/
-399.8 "Judgment" sync / 1[56]:Regula van Hydrus:10DD:/
-405.0 "Judgment" sync / 1[56]:Regula van Hydrus:10DE:/
-414.9 "Magitek Spread" sync / 1[56]:Regula van Hydrus:10DC:/ window 15,15
-422.0 "Bastardbluss" sync / 1[56]:Regula van Hydrus:10DA:/
+379.3 "Magitek Spread" sync / 1[56]:[^:]*:Regula van Hydrus:10DC:/ window 150,5
+386.5 "Bastardbluss" sync / 1[56]:[^:]*:Regula van Hydrus:10DA:/
+389.6 "Bastardbluss" sync / 1[56]:[^:]*:Regula van Hydrus:10DA:/
+392.7 "Bastardbluss" sync / 1[56]:[^:]*:Regula van Hydrus:10DA:/
+399.8 "Judgment" sync / 1[56]:[^:]*:Regula van Hydrus:10DD:/
+405.0 "Judgment" sync / 1[56]:[^:]*:Regula van Hydrus:10DE:/
+414.9 "Magitek Spread" sync / 1[56]:[^:]*:Regula van Hydrus:10DC:/ window 15,15
+422.0 "Bastardbluss" sync / 1[56]:[^:]*:Regula van Hydrus:10DA:/
 
 # More turrets, same as the second set
 # Clean loop to HP = 0
-429.1 "Magitek Turret" sync / 1[56]:Regula van Hydrus:10E0:/ window 50,5 jump 330.1
+429.1 "Magitek Turret" sync / 1[56]:[^:]*:Regula van Hydrus:10E0:/ window 50,5 jump 330.1
 436.8 "Magitek Slug"
 439.7 "Aetherochemical Grenado"
 440.4 "Magitek Slug"
@@ -119,41 +119,41 @@ hideall "--sync--"
 1000.0 "--sync--" sync / 00:0839::Evaluation and Authentication will be sealed off/ window 1000,5
 
 # Cobra is immediate
-1001.4 "--sync--" sync / 1[56]:Harmachis:366:/ window 2,2
-1008.6 "Weighing of the Heart" sync / 1[56]:Harmachis:10E8:/
-1011.7 "Steel Scales" sync / 1[56]:Harmachis:10EA:/
-1014.8 "Hood Swing" sync / 1[56]:Harmachis:10E9:/
-1019.0 "Weighing of the Heart" sync / 1[56]:Harmachis:138F:/
+1001.4 "--sync--" sync / 1[56]:[^:]*:Harmachis:366:/ window 2,2
+1008.6 "Weighing of the Heart" sync / 1[56]:[^:]*:Harmachis:10E8:/
+1011.7 "Steel Scales" sync / 1[56]:[^:]*:Harmachis:10EA:/
+1014.8 "Hood Swing" sync / 1[56]:[^:]*:Harmachis:10E9:/
+1019.0 "Weighing of the Heart" sync / 1[56]:[^:]*:Harmachis:138F:/
 
 # Base rotation after Cobra
-1024.6 "Chthonic Hush" sync / 1[56]:Harmachis:10E7:/
-1033.3 "Riddle of The Sphinx" sync / 1[56]:Harmachis:10E4:/
-1040.3 "Chthonic Hush" sync / 1[56]:Harmachis:10E7:/
-1049.0 "Riddle of The Sphinx" sync / 1[56]:Harmachis:10E4:/
+1024.6 "Chthonic Hush" sync / 1[56]:[^:]*:Harmachis:10E7:/
+1033.3 "Riddle of The Sphinx" sync / 1[56]:[^:]*:Harmachis:10E4:/
+1040.3 "Chthonic Hush" sync / 1[56]:[^:]*:Harmachis:10E7:/
+1049.0 "Riddle of The Sphinx" sync / 1[56]:[^:]*:Harmachis:10E4:/
 
-1056.0 "Chthonic Hush" sync / 1[56]:Harmachis:10E7:/
-1064.7 "Riddle of The Sphinx" sync / 1[56]:Harmachis:10E4:/
-1071.7 "Chthonic Hush" sync / 1[56]:Harmachis:10E7:/
-1080.4 "Riddle of The Sphinx" sync / 1[56]:Harmachis:10E4:/ jump 1049.0
+1056.0 "Chthonic Hush" sync / 1[56]:[^:]*:Harmachis:10E7:/
+1064.7 "Riddle of The Sphinx" sync / 1[56]:[^:]*:Harmachis:10E4:/
+1071.7 "Chthonic Hush" sync / 1[56]:[^:]*:Harmachis:10E7:/
+1080.4 "Riddle of The Sphinx" sync / 1[56]:[^:]*:Harmachis:10E4:/ jump 1049.0
 
 1087.4 "Chthonic Hush"
 1096.1 "Riddle of The Sphinx"
 1103.1 "Chthonic Hush"
 
 # Naga form at HP < 80%
-1133.5 "Weighing of the Heart" sync / 1[56]:Harmachis:ECE:/ window 130,5
-1139.6 "Petrifaction" sync / 1[56]:Harmachis:10EB:/
+1133.5 "Weighing of the Heart" sync / 1[56]:[^:]*:Harmachis:ECE:/ window 130,5
+1139.6 "Petrifaction" sync / 1[56]:[^:]*:Harmachis:10EB:/
 1142.8 "Circle of Flames x2" # Same ID for both, syncing breaks things
-1145.9 "Weighing of the Heart" sync / 1[56]:Harmachis:138F:/
+1145.9 "Weighing of the Heart" sync / 1[56]:[^:]*:Harmachis:138F:/
 
 # Modified rotation after Naga
-1151.5 "Chthonic Hush" sync / 1[56]:Harmachis:10E7:/ window 10,10
-1160.1 "Riddle of The Sphinx" sync / 1[56]:Harmachis:10E4:/
-1169.4 "Ka" sync / 1[56]:Harmachis:10E6:/
+1151.5 "Chthonic Hush" sync / 1[56]:[^:]*:Harmachis:10E7:/ window 10,10
+1160.1 "Riddle of The Sphinx" sync / 1[56]:[^:]*:Harmachis:10E4:/
+1169.4 "Ka" sync / 1[56]:[^:]*:Harmachis:10E6:/
 
-1177.0 "Chthonic Hush" sync / 1[56]:Harmachis:10E7:/ window 10,10
-1185.6 "Riddle of The Sphinx" sync / 1[56]:Harmachis:10E4:/
-1194.9 "Ka" sync / 1[56]:Harmachis:10E6:/ jump 1169.4
+1177.0 "Chthonic Hush" sync / 1[56]:[^:]*:Harmachis:10E7:/ window 10,10
+1185.6 "Riddle of The Sphinx" sync / 1[56]:[^:]*:Harmachis:10E4:/
+1194.9 "Ka" sync / 1[56]:[^:]*:Harmachis:10E6:/ jump 1169.4
 
 1202.5 "Chthonic Hush"
 1211.1 "Riddle of The Sphinx"
@@ -161,33 +161,33 @@ hideall "--sync--"
 1228.0 "Chthonic Hush"
 
 # Machina at HP < 50%
-1250.0 "Weighing of the Heart" sync / 1[56]:Harmachis:ED0:/ window 250,5
-1253.2 "Inertia Stream" sync / 1[56]:Harmachis:10ED:/
-1258.3 "Ballistic Missile 1" sync / 1[56]:Harmachis:10EE:/
-1259.3 "Ballistic Missile 2" sync / 1[56]:Harmachis:12A3:/
-1260.4 "Ballistic Missile 3" sync / 1[56]:Harmachis:10EF:/
-1265.6 "Gaseous Bomb" sync / 1[56]:Harmachis:10F0:/ window 10,10
-1269.7 "Weighing of the Heart" sync / 1[56]:Harmachis:138F:/
+1250.0 "Weighing of the Heart" sync / 1[56]:[^:]*:Harmachis:ED0:/ window 250,5
+1253.2 "Inertia Stream" sync / 1[56]:[^:]*:Harmachis:10ED:/
+1258.3 "Ballistic Missile 1" sync / 1[56]:[^:]*:Harmachis:10EE:/
+1259.3 "Ballistic Missile 2" sync / 1[56]:[^:]*:Harmachis:12A3:/
+1260.4 "Ballistic Missile 3" sync / 1[56]:[^:]*:Harmachis:10EF:/
+1265.6 "Gaseous Bomb" sync / 1[56]:[^:]*:Harmachis:10F0:/ window 10,10
+1269.7 "Weighing of the Heart" sync / 1[56]:[^:]*:Harmachis:138F:/
 
 # Rotation resumes to HP = 0
 # Single rotation block is alternated with random form shift blocks
-1275.2 "Chthonic Hush" sync / 1[56]:Harmachis:10E7:/
-1283.8 "Riddle of The Sphinx" sync / 1[56]:Harmachis:10E4:/
-1293.1 "Ka" sync / 1[56]:Harmachis:10E6:/
+1275.2 "Chthonic Hush" sync / 1[56]:[^:]*:Harmachis:10E7:/
+1283.8 "Riddle of The Sphinx" sync / 1[56]:[^:]*:Harmachis:10E4:/
+1293.1 "Ka" sync / 1[56]:[^:]*:Harmachis:10E6:/
 1300.4 "Weighing of the Heart"
-1300.4 "--sync--" sync / 1[56]:Harmachis:ED0:/ jump 1250.0 # Machina
-1300.4 "--sync--" sync / 1[56]:Harmachis:10E8:/ jump 1350.0 # Cobra
-1300.4 "--sync--" sync / 1[56]:Harmachis:ECE:/ jump 1400.0 # Naga
+1300.4 "--sync--" sync / 1[56]:[^:]*:Harmachis:ED0:/ jump 1250.0 # Machina
+1300.4 "--sync--" sync / 1[56]:[^:]*:Harmachis:10E8:/ jump 1350.0 # Cobra
+1300.4 "--sync--" sync / 1[56]:[^:]*:Harmachis:ECE:/ jump 1400.0 # Naga
 1303.5 "Steel Scales?"
 1303.6 "Inertia Stream?"
 1306.5 "Petrifaction?"
 
 # Random shift Cobra
-1350.0 "Weighing of the Heart" sync / 1[56]:Harmachis:10E8:/
-1353.3 "Steel Scales" sync / 1[56]:Harmachis:10EA:/ window 10,10
-1356.5 "Hood Swing" sync / 1[56]:Harmachis:10E9:/
-1360.5 "Weighing of the Heart" sync / 1[56]:Harmachis:138F:/
-1366.2 "Chthonic Hush" sync / 1[56]:Harmachis:10E7:/ window 10,10 jump 1275.2
+1350.0 "Weighing of the Heart" sync / 1[56]:[^:]*:Harmachis:10E8:/
+1353.3 "Steel Scales" sync / 1[56]:[^:]*:Harmachis:10EA:/ window 10,10
+1356.5 "Hood Swing" sync / 1[56]:[^:]*:Harmachis:10E9:/
+1360.5 "Weighing of the Heart" sync / 1[56]:[^:]*:Harmachis:138F:/
+1366.2 "Chthonic Hush" sync / 1[56]:[^:]*:Harmachis:10E7:/ window 10,10 jump 1275.2
 1374.8 "Riddle of The Sphinx"
 1384.1 "Ka"
 1391.4 "Weighing of the Heart"
@@ -196,11 +196,11 @@ hideall "--sync--"
 1397.5 "Petrifaction?"
 
 # Random shift Naga
-1400.0 "Weighing of the Heart" sync / 1[56]:Harmachis:ECE:/
-1406.1 "Petrifaction" sync / 1[56]:Harmachis:10EB:/
+1400.0 "Weighing of the Heart" sync / 1[56]:[^:]*:Harmachis:ECE:/
+1406.1 "Petrifaction" sync / 1[56]:[^:]*:Harmachis:10EB:/
 1409.3 "Circle of Flames x2" # Same ID for both, syncing breaks things
-1412.4 "Weighing of the Heart" sync / 1[56]:Harmachis:138F:/
-1418.0 "Chthonic Hush" sync / 1[56]:Harmachis:10E8:/ window 10,10 jump 1275.2
+1412.4 "Weighing of the Heart" sync / 1[56]:[^:]*:Harmachis:138F:/
+1418.0 "Chthonic Hush" sync / 1[56]:[^:]*:Harmachis:10E8:/ window 10,10 jump 1275.2
 1426.6 "Riddle of The Sphinx"
 1435.9 "Ka"
 1443.2 "Weighing of the Heart"
@@ -215,23 +215,23 @@ hideall "--sync--"
 # -ii 10F1 10F3 10F6 10F8 10F9 12DE
 # We can't sync to the zone seal message because it's a two-part battle
 
-2000.5 "--sync--" sync / 1[56]:Igeyorhm:10F1:/ window 2000.5,0
-2008.6 "Dark Orb" sync / 1[56]:Igeyorhm:10FC:/ window 9,5
+2000.5 "--sync--" sync / 1[56]:[^:]*:Igeyorhm:10F1:/ window 2000.5,0
+2008.6 "Dark Orb" sync / 1[56]:[^:]*:Igeyorhm:10FC:/ window 9,5
 
-2009.0 "End Of Days" sync / 1[56]:Lahabrea:10FD:/
-2015.8 "Dark Orb" sync / 1[56]:Igeyorhm:10FC:/
-2020.9 "Sea Of Pitch" sync / 1[56]:Igeyorhm:10FB:/ window 15,15
-2023.4 "End Of Days" sync / 1[56]:Lahabrea:10FD:/
-2024.5 "Sea Of Pitch" sync / 1[56]:Igeyorhm:12DE:/
-2029.0 "Dark Orb" sync / 1[56]:Igeyorhm:10FC:/
-2037.2 "Dark Orb" sync / 1[56]:Igeyorhm:10FC:/
+2009.0 "End Of Days" sync / 1[56]:[^:]*:Lahabrea:10FD:/
+2015.8 "Dark Orb" sync / 1[56]:[^:]*:Igeyorhm:10FC:/
+2020.9 "Sea Of Pitch" sync / 1[56]:[^:]*:Igeyorhm:10FB:/ window 15,15
+2023.4 "End Of Days" sync / 1[56]:[^:]*:Lahabrea:10FD:/
+2024.5 "Sea Of Pitch" sync / 1[56]:[^:]*:Igeyorhm:12DE:/
+2029.0 "Dark Orb" sync / 1[56]:[^:]*:Igeyorhm:10FC:/
+2037.2 "Dark Orb" sync / 1[56]:[^:]*:Igeyorhm:10FC:/
 
-2037.7 "End Of Days" sync / 1[56]:Lahabrea:10FD:/
-2044.3 "Dark Orb" sync / 1[56]:Igeyorhm:10FC:/
-2049.5 "Sea Of Pitch" sync / 1[56]:Igeyorhm:10FB:/ window 15,15
-2052.2 "End Of Days" sync / 1[56]:Lahabrea:10FD:/
-2057.7 "Dark Orb" sync / 1[56]:Igeyorhm:10FC:/
-2066.0 "Dark Orb" sync / 1[56]:Igeyorhm:10FC:/ jump 2037.2
+2037.7 "End Of Days" sync / 1[56]:[^:]*:Lahabrea:10FD:/
+2044.3 "Dark Orb" sync / 1[56]:[^:]*:Igeyorhm:10FC:/
+2049.5 "Sea Of Pitch" sync / 1[56]:[^:]*:Igeyorhm:10FB:/ window 15,15
+2052.2 "End Of Days" sync / 1[56]:[^:]*:Lahabrea:10FD:/
+2057.7 "Dark Orb" sync / 1[56]:[^:]*:Igeyorhm:10FC:/
+2066.0 "Dark Orb" sync / 1[56]:[^:]*:Igeyorhm:10FC:/ jump 2037.2
 
 2066.5 "End Of Days"
 2073.1 "Dark Orb"
@@ -241,67 +241,67 @@ hideall "--sync--"
 2094.8 "Dark Orb"
 
 # Special attack at HP < 75%
-2100.0 "Blizzard Sphere" sync / 1[56]:Igeyorhm:10F5:/ window 100,5
-2105.2 "Blizzard Burst" sync / 1[56]:Blizzardsphere:10FE:/
-2108.3 "Fire Burst" sync / 1[56]:Firesphere:10FF:/
-2115.4 "Blizzard Burst" sync / 1[56]:Blizzardsphere:10FE:/
-2118.5 "Fire Burst" sync / 1[56]:Firesphere:10FF:/
+2100.0 "Blizzard Sphere" sync / 1[56]:[^:]*:Igeyorhm:10F5:/ window 100,5
+2105.2 "Blizzard Burst" sync / 1[56]:[^:]*:Blizzardsphere:10FE:/
+2108.3 "Fire Burst" sync / 1[56]:[^:]*:Firesphere:10FF:/
+2115.4 "Blizzard Burst" sync / 1[56]:[^:]*:Blizzardsphere:10FE:/
+2118.5 "Fire Burst" sync / 1[56]:[^:]*:Firesphere:10FF:/
 
 # Modified rotation to HP < 50%
 # The two Ascians de-sync here. This section
 # is super-long to avoid any possibility of choppiness.
 
-2122.6 "Dark Blizzard II" sync / 1[56]:Igeyorhm:10F2:/ window 20,20
-2123.8 "End Of Days" sync / 1[56]:Lahabrea:10FD:/
-2131.7 "Shadow Flare" sync / 1[56]:Igeyorhm:10FA:/
-2137.4 "Dark Fire II" sync / 1[56]:Lahabrea:10F7:/
-2142.9 "Dark Orb" sync / 1[56]:Igeyorhm:10FC:/
-2148.1 "Sea Of Pitch" sync / 1[56]:Igeyorhm:10FB:/ window 20,20
-2151.9 "End Of Days" sync / 1[56]:Lahabrea:10FD:/
-2156.3 "Dark Orb" sync / 1[56]:Igeyorhm:10FC:/
-2163.5 "Dark Blizzard II" sync / 1[56]:Igeyorhm:10F2:/ window 20,20
-2165.3 "Dark Fire II" sync / 1[56]:Lahabrea:10F7:/
-2172.5 "Shadow Flare" sync / 1[56]:Igeyorhm:10FA:/
-2179.7 "End Of Days" sync / 1[56]:Lahabrea:10FD:/
-2183.6 "Dark Orb" sync / 1[56]:Igeyorhm:10FC:/
-2188.8 "Sea Of Pitch" sync / 1[56]:Igeyorhm:10FB:/ window 20,20
-2193.0 "Dark Fire II" sync / 1[56]:Lahabrea:10F7:/
-2197.0 "Dark Orb" sync / 1[56]:Igeyorhm:10FC:/
+2122.6 "Dark Blizzard II" sync / 1[56]:[^:]*:Igeyorhm:10F2:/ window 20,20
+2123.8 "End Of Days" sync / 1[56]:[^:]*:Lahabrea:10FD:/
+2131.7 "Shadow Flare" sync / 1[56]:[^:]*:Igeyorhm:10FA:/
+2137.4 "Dark Fire II" sync / 1[56]:[^:]*:Lahabrea:10F7:/
+2142.9 "Dark Orb" sync / 1[56]:[^:]*:Igeyorhm:10FC:/
+2148.1 "Sea Of Pitch" sync / 1[56]:[^:]*:Igeyorhm:10FB:/ window 20,20
+2151.9 "End Of Days" sync / 1[56]:[^:]*:Lahabrea:10FD:/
+2156.3 "Dark Orb" sync / 1[56]:[^:]*:Igeyorhm:10FC:/
+2163.5 "Dark Blizzard II" sync / 1[56]:[^:]*:Igeyorhm:10F2:/ window 20,20
+2165.3 "Dark Fire II" sync / 1[56]:[^:]*:Lahabrea:10F7:/
+2172.5 "Shadow Flare" sync / 1[56]:[^:]*:Igeyorhm:10FA:/
+2179.7 "End Of Days" sync / 1[56]:[^:]*:Lahabrea:10FD:/
+2183.6 "Dark Orb" sync / 1[56]:[^:]*:Igeyorhm:10FC:/
+2188.8 "Sea Of Pitch" sync / 1[56]:[^:]*:Igeyorhm:10FB:/ window 20,20
+2193.0 "Dark Fire II" sync / 1[56]:[^:]*:Lahabrea:10F7:/
+2197.0 "Dark Orb" sync / 1[56]:[^:]*:Igeyorhm:10FC:/
 
-2204.2 "Dark Blizzard II" sync / 1[56]:Igeyorhm:10F2:/ window 20,20
-2207.4 "End Of Days" sync / 1[56]:Lahabrea:10FD:/
-2213.2 "Shadow Flare" sync / 1[56]:Igeyorhm:10FA:/
-2220.8 "Dark Fire II" sync / 1[56]:Lahabrea:10F7:/
-2224.4 "Dark Orb" sync / 1[56]:Igeyorhm:10FC:/
-2229.6 "Sea Of Pitch" sync / 1[56]:Igeyorhm:10FB:/ window 20,20
-2235.3 "End Of Days" sync / 1[56]:Lahabrea:10FD:/
-2237.9 "Dark Orb" sync / 1[56]:Igeyorhm:10FC:/
-2245.0 "Dark Blizzard II" sync / 1[56]:Igeyorhm:10F2:/ window 20,20
-2248.7 "Dark Fire II" sync / 1[56]:Lahabrea:10F7:/
-2254.1 "Shadow Flare" sync / 1[56]:Igeyorhm:10FA:/
-2263.0 "End Of Days" sync / 1[56]:Lahabrea:10FD:/
-2265.5 "Dark Orb" sync / 1[56]:Igeyorhm:10FC:/
-2270.6 "Sea Of Pitch" sync / 1[56]:Igeyorhm:10FB:/ window 20,20
-2276.4 "Dark Fire II" sync / 1[56]:Lahabrea:10F7:/
-2278.8 "Dark Orb" sync / 1[56]:Igeyorhm:10FC:/
+2204.2 "Dark Blizzard II" sync / 1[56]:[^:]*:Igeyorhm:10F2:/ window 20,20
+2207.4 "End Of Days" sync / 1[56]:[^:]*:Lahabrea:10FD:/
+2213.2 "Shadow Flare" sync / 1[56]:[^:]*:Igeyorhm:10FA:/
+2220.8 "Dark Fire II" sync / 1[56]:[^:]*:Lahabrea:10F7:/
+2224.4 "Dark Orb" sync / 1[56]:[^:]*:Igeyorhm:10FC:/
+2229.6 "Sea Of Pitch" sync / 1[56]:[^:]*:Igeyorhm:10FB:/ window 20,20
+2235.3 "End Of Days" sync / 1[56]:[^:]*:Lahabrea:10FD:/
+2237.9 "Dark Orb" sync / 1[56]:[^:]*:Igeyorhm:10FC:/
+2245.0 "Dark Blizzard II" sync / 1[56]:[^:]*:Igeyorhm:10F2:/ window 20,20
+2248.7 "Dark Fire II" sync / 1[56]:[^:]*:Lahabrea:10F7:/
+2254.1 "Shadow Flare" sync / 1[56]:[^:]*:Igeyorhm:10FA:/
+2263.0 "End Of Days" sync / 1[56]:[^:]*:Lahabrea:10FD:/
+2265.5 "Dark Orb" sync / 1[56]:[^:]*:Igeyorhm:10FC:/
+2270.6 "Sea Of Pitch" sync / 1[56]:[^:]*:Igeyorhm:10FB:/ window 20,20
+2276.4 "Dark Fire II" sync / 1[56]:[^:]*:Lahabrea:10F7:/
+2278.8 "Dark Orb" sync / 1[56]:[^:]*:Igeyorhm:10FC:/
 
 #Lahabrea de-syncs from here, so we just sync to Igeyorhm now
-2285.9 "Dark Blizzard II" sync / 1[56]:Igeyorhm:10F2:/ window 15,15
-2295.0 "Shadow Flare" sync / 1[56]:Igeyorhm:10FA:/
-2306.2 "Dark Orb" sync / 1[56]:Igeyorhm:10FC:/
-2311.3 "Sea Of Pitch" sync / 1[56]:Igeyorhm:10FB:/
-2319.6 "Dark Orb" sync / 1[56]:Igeyorhm:10FC:/
-2326.7 "Dark Blizzard II" sync / 1[56]:Igeyorhm:10F2:/ window 15,15
-2335.8 "Shadow Flare" sync / 1[56]:Igeyorhm:10FA:/
-2346.9 "Dark Orb" sync / 1[56]:Igeyorhm:10FC:/
-2352.1 "Sea Of Pitch" sync / 1[56]:Igeyorhm:10FB:/
-2360.3 "Dark Orb" sync / 1[56]:Igeyorhm:10FC:/
+2285.9 "Dark Blizzard II" sync / 1[56]:[^:]*:Igeyorhm:10F2:/ window 15,15
+2295.0 "Shadow Flare" sync / 1[56]:[^:]*:Igeyorhm:10FA:/
+2306.2 "Dark Orb" sync / 1[56]:[^:]*:Igeyorhm:10FC:/
+2311.3 "Sea Of Pitch" sync / 1[56]:[^:]*:Igeyorhm:10FB:/
+2319.6 "Dark Orb" sync / 1[56]:[^:]*:Igeyorhm:10FC:/
+2326.7 "Dark Blizzard II" sync / 1[56]:[^:]*:Igeyorhm:10F2:/ window 15,15
+2335.8 "Shadow Flare" sync / 1[56]:[^:]*:Igeyorhm:10FA:/
+2346.9 "Dark Orb" sync / 1[56]:[^:]*:Igeyorhm:10FC:/
+2352.1 "Sea Of Pitch" sync / 1[56]:[^:]*:Igeyorhm:10FB:/
+2360.3 "Dark Orb" sync / 1[56]:[^:]*:Igeyorhm:10FC:/
 
-2367.4 "Dark Blizzard II" sync / 1[56]:Igeyorhm:10F2:/ window 15,15
-2376.6 "Shadow Flare" sync / 1[56]:Igeyorhm:10FA:/
-2387.8 "Dark Orb" sync / 1[56]:Igeyorhm:10FC:/
-2392.9 "Sea Of Pitch" sync / 1[56]:Igeyorhm:10FB:/
-2401.2 "Dark Orb" sync / 1[56]:Igeyorhm:10FC:/ jump 2360.3
+2367.4 "Dark Blizzard II" sync / 1[56]:[^:]*:Igeyorhm:10F2:/ window 15,15
+2376.6 "Shadow Flare" sync / 1[56]:[^:]*:Igeyorhm:10FA:/
+2387.8 "Dark Orb" sync / 1[56]:[^:]*:Igeyorhm:10FC:/
+2392.9 "Sea Of Pitch" sync / 1[56]:[^:]*:Igeyorhm:10FB:/
+2401.2 "Dark Orb" sync / 1[56]:[^:]*:Igeyorhm:10FC:/ jump 2360.3
 # Jump here and hope for the best. This should never happen
 2408.4 "Dark Blizzard II"
 2417.5 "Shadow Flare"
@@ -311,19 +311,19 @@ hideall "--sync--"
 
 # Ascians swap roles at Igeyorhm HP <= 50%
 
-2500.0 "End Of Days" sync / 1[56]:Igeyorhm:10FD:/ window 400,5
-2505.1 "Dark Orb" sync / 1[56]:Lahabrea:10FC:/
-2510.2 "Sea Of Pitch" sync / 1[56]:Lahabrea:10FB:/
-2514.5 "End Of Days" sync / 1[56]:Igeyorhm:10FD:/
-2517.3 "Dark Fire II" sync / 1[56]:Lahabrea:10F7:/ window 20,20
-2524.4 "Dark Orb" sync / 1[56]:Lahabrea:10FC:/
+2500.0 "End Of Days" sync / 1[56]:[^:]*:Igeyorhm:10FD:/ window 400,5
+2505.1 "Dark Orb" sync / 1[56]:[^:]*:Lahabrea:10FC:/
+2510.2 "Sea Of Pitch" sync / 1[56]:[^:]*:Lahabrea:10FB:/
+2514.5 "End Of Days" sync / 1[56]:[^:]*:Igeyorhm:10FD:/
+2517.3 "Dark Fire II" sync / 1[56]:[^:]*:Lahabrea:10F7:/ window 20,20
+2524.4 "Dark Orb" sync / 1[56]:[^:]*:Lahabrea:10FC:/
 
-2528.9 "End Of Days" sync / 1[56]:Igeyorhm:10FD:/
-2534.0 "Dark Orb" sync / 1[56]:Lahabrea:10FC:/
-2539.1 "Sea Of Pitch" sync / 1[56]:Lahabrea:10FB:/
-2543.4 "End Of Days" sync / 1[56]:Igeyorhm:10FD:/
-2546.2 "Dark Fire II" sync / 1[56]:Lahabrea:10F7:/ window 20,20
-2553.3 "Dark Orb" sync / 1[56]:Lahabrea:10FC:/ jump 2274.4
+2528.9 "End Of Days" sync / 1[56]:[^:]*:Igeyorhm:10FD:/
+2534.0 "Dark Orb" sync / 1[56]:[^:]*:Lahabrea:10FC:/
+2539.1 "Sea Of Pitch" sync / 1[56]:[^:]*:Lahabrea:10FB:/
+2543.4 "End Of Days" sync / 1[56]:[^:]*:Igeyorhm:10FD:/
+2546.2 "Dark Fire II" sync / 1[56]:[^:]*:Lahabrea:10F7:/ window 20,20
+2553.3 "Dark Orb" sync / 1[56]:[^:]*:Lahabrea:10FC:/ jump 2274.4
 
 2557.8 "End Of Days"
 2562.9 "Dark Orb"
@@ -333,59 +333,59 @@ hideall "--sync--"
 2582.2 "Dark Orb"
 
 # Special attack at HP < 75%
-2600.0 "Permafrost" sync / 1[56]:Igeyorhm:10F4:/ window 500,5
-2604.0 "Dark Fire II" sync / 1[56]:Lahabrea:10F7:/
-2609.1 "Dark Fire II" sync / 1[56]:Lahabrea:10F7:/
-2614.2 "Dark Fire II" sync / 1[56]:Lahabrea:10F7:/
-2623.4 "Dark Fire II" sync / 1[56]:Lahabrea:10F7:/
+2600.0 "Permafrost" sync / 1[56]:[^:]*:Igeyorhm:10F4:/ window 500,5
+2604.0 "Dark Fire II" sync / 1[56]:[^:]*:Lahabrea:10F7:/
+2609.1 "Dark Fire II" sync / 1[56]:[^:]*:Lahabrea:10F7:/
+2614.2 "Dark Fire II" sync / 1[56]:[^:]*:Lahabrea:10F7:/
+2623.4 "Dark Fire II" sync / 1[56]:[^:]*:Lahabrea:10F7:/
 
 # Modified rotation to HP < 50%
-2624.6 "End Of Days" sync / 1[56]:Igeyorhm:10FD:/
-2632.4 "Shadow Flare" sync / 1[56]:Lahabrea:1381:/ window 20,20
-2638.0 "Dark Blizzard II" sync / 1[56]:Igeyorhm:10F2:/
-2643.5 "Dark Orb" sync / 1[56]:Lahabrea:10FC:/
-2648.7 "Sea Of Pitch" sync / 1[56]:Lahabrea:10FB:/ window 20,20
-2652.8 "End Of Days" sync / 1[56]:Igeyorhm:10FD:/
-2657.0 "Dark Orb" sync / 1[56]:Lahabrea:10FC:/
-2664.1 "Dark Fire II" sync / 1[56]:Lahabrea:10F7:/ window 20,20
-2666.3 "Dark Blizzard II" sync / 1[56]:Igeyorhm:10F2:/
-2673.4 "Shadow Flare" sync / 1[56]:Lahabrea:1381:/
-2680.9 "End Of Days" sync / 1[56]:Igeyorhm:10FD:/
-2684.5 "Dark Orb" sync / 1[56]:Lahabrea:10FC:/
-2689.8 "Sea Of Pitch" sync / 1[56]:Lahabrea:10FB:/ window 20,20
-2694.3 "Dark Blizzard II" sync / 1[56]:Igeyorhm:10F2:/
-2697.9 "Dark Orb" sync / 1[56]:Lahabrea:10FC:/
-2705.1 "Dark Fire II" sync / 1[56]:Lahabrea:10F7:/
+2624.6 "End Of Days" sync / 1[56]:[^:]*:Igeyorhm:10FD:/
+2632.4 "Shadow Flare" sync / 1[56]:[^:]*:Lahabrea:1381:/ window 20,20
+2638.0 "Dark Blizzard II" sync / 1[56]:[^:]*:Igeyorhm:10F2:/
+2643.5 "Dark Orb" sync / 1[56]:[^:]*:Lahabrea:10FC:/
+2648.7 "Sea Of Pitch" sync / 1[56]:[^:]*:Lahabrea:10FB:/ window 20,20
+2652.8 "End Of Days" sync / 1[56]:[^:]*:Igeyorhm:10FD:/
+2657.0 "Dark Orb" sync / 1[56]:[^:]*:Lahabrea:10FC:/
+2664.1 "Dark Fire II" sync / 1[56]:[^:]*:Lahabrea:10F7:/ window 20,20
+2666.3 "Dark Blizzard II" sync / 1[56]:[^:]*:Igeyorhm:10F2:/
+2673.4 "Shadow Flare" sync / 1[56]:[^:]*:Lahabrea:1381:/
+2680.9 "End Of Days" sync / 1[56]:[^:]*:Igeyorhm:10FD:/
+2684.5 "Dark Orb" sync / 1[56]:[^:]*:Lahabrea:10FC:/
+2689.8 "Sea Of Pitch" sync / 1[56]:[^:]*:Lahabrea:10FB:/ window 20,20
+2694.3 "Dark Blizzard II" sync / 1[56]:[^:]*:Igeyorhm:10F2:/
+2697.9 "Dark Orb" sync / 1[56]:[^:]*:Lahabrea:10FC:/
+2705.1 "Dark Fire II" sync / 1[56]:[^:]*:Lahabrea:10F7:/
 
-2708.8 "End Of Days" sync / 1[56]:Igeyorhm:10FD:/
-2714.3 "Shadow Flare" sync / 1[56]:Lahabrea:1381:/ window 20,20
-2722.3 "Dark Blizzard II" sync / 1[56]:Igeyorhm:10F2:/
-2725.4 "Dark Orb" sync / 1[56]:Lahabrea:10FC:/
-2730.5 "Sea Of Pitch" sync / 1[56]:Lahabrea:10FB:/ window 20,20
-2736.9 "End Of Days" sync / 1[56]:Igeyorhm:10FD:/
-2738.7 "Dark Orb" sync / 1[56]:Lahabrea:10FC:/
-2745.9 "Dark Fire II" sync / 1[56]:Lahabrea:10F7:/ window 20,20
-2750.4 "Dark Blizzard II" sync / 1[56]:Igeyorhm:10F2:/
-2755.1 "Shadow Flare" sync / 1[56]:Lahabrea:1381:/
-2765.1 "End Of Days" sync / 1[56]:Igeyorhm:10FD:/
-2766.4 "Dark Orb" sync / 1[56]:Lahabrea:10FC:/
-2771.5 "Sea Of Pitch" sync / 1[56]:Lahabrea:10FB:/ window 20,20
-2778.6 "Dark Blizzard II" sync / 1[56]:Igeyorhm:10F2:/
-2779.6 "Dark Orb" sync / 1[56]:Lahabrea:10FC:/
-2786.8 "Dark Fire II" sync / 1[56]:Lahabrea:10F7:/
+2708.8 "End Of Days" sync / 1[56]:[^:]*:Igeyorhm:10FD:/
+2714.3 "Shadow Flare" sync / 1[56]:[^:]*:Lahabrea:1381:/ window 20,20
+2722.3 "Dark Blizzard II" sync / 1[56]:[^:]*:Igeyorhm:10F2:/
+2725.4 "Dark Orb" sync / 1[56]:[^:]*:Lahabrea:10FC:/
+2730.5 "Sea Of Pitch" sync / 1[56]:[^:]*:Lahabrea:10FB:/ window 20,20
+2736.9 "End Of Days" sync / 1[56]:[^:]*:Igeyorhm:10FD:/
+2738.7 "Dark Orb" sync / 1[56]:[^:]*:Lahabrea:10FC:/
+2745.9 "Dark Fire II" sync / 1[56]:[^:]*:Lahabrea:10F7:/ window 20,20
+2750.4 "Dark Blizzard II" sync / 1[56]:[^:]*:Igeyorhm:10F2:/
+2755.1 "Shadow Flare" sync / 1[56]:[^:]*:Lahabrea:1381:/
+2765.1 "End Of Days" sync / 1[56]:[^:]*:Igeyorhm:10FD:/
+2766.4 "Dark Orb" sync / 1[56]:[^:]*:Lahabrea:10FC:/
+2771.5 "Sea Of Pitch" sync / 1[56]:[^:]*:Lahabrea:10FB:/ window 20,20
+2778.6 "Dark Blizzard II" sync / 1[56]:[^:]*:Igeyorhm:10F2:/
+2779.6 "Dark Orb" sync / 1[56]:[^:]*:Lahabrea:10FC:/
+2786.8 "Dark Fire II" sync / 1[56]:[^:]*:Lahabrea:10F7:/
 
 # Same as before, just sync to Lahabrea now
-2795.9 "Shadow Flare" sync / 1[56]:Lahabrea:1381:/
-2807.2 "Dark Orb" sync / 1[56]:Lahabrea:10FC:/
-2812.3 "Sea Of Pitch" sync / 1[56]:Lahabrea:10FB:/ window 20,20
-2820.7 "Dark Orb" sync / 1[56]:Lahabrea:10FC:/
-2827.8 "Dark Fire II" sync / 1[56]:Lahabrea:10F7:/
+2795.9 "Shadow Flare" sync / 1[56]:[^:]*:Lahabrea:1381:/
+2807.2 "Dark Orb" sync / 1[56]:[^:]*:Lahabrea:10FC:/
+2812.3 "Sea Of Pitch" sync / 1[56]:[^:]*:Lahabrea:10FB:/ window 20,20
+2820.7 "Dark Orb" sync / 1[56]:[^:]*:Lahabrea:10FC:/
+2827.8 "Dark Fire II" sync / 1[56]:[^:]*:Lahabrea:10F7:/
 
-2837.0 "Shadow Flare" sync / 1[56]:Lahabrea:1381:/
-2848.3 "Dark Orb" sync / 1[56]:Lahabrea:10FC:/
-2853.4 "Sea Of Pitch" sync / 1[56]:Lahabrea:10FB:/ window 20,20
-2861.8 "Dark Orb" sync / 1[56]:Lahabrea:10FC:/
-2868.9 "Dark Fire II" sync / 1[56]:Lahabrea:10F7:/ jump 2827.8
+2837.0 "Shadow Flare" sync / 1[56]:[^:]*:Lahabrea:1381:/
+2848.3 "Dark Orb" sync / 1[56]:[^:]*:Lahabrea:10FC:/
+2853.4 "Sea Of Pitch" sync / 1[56]:[^:]*:Lahabrea:10FB:/ window 20,20
+2861.8 "Dark Orb" sync / 1[56]:[^:]*:Lahabrea:10FC:/
+2868.9 "Dark Fire II" sync / 1[56]:[^:]*:Lahabrea:10F7:/ jump 2827.8
 
 2878.1 "Shadow Flare"
 2889.4 "Dark Orb"
@@ -400,16 +400,16 @@ hideall "--sync--"
 # -ii 1104 1108 -ic "Aetherial Tear" "Chaosphere"
 # We can't sync to the zone seal message because it's a two-part battle
 
-3002.3 "--sync--" sync / 1[56]:Ascian Prime:1100:/ window 3003,2
-3005.8 "Height Of Chaos" sync / 1[56]:Ascian Prime:1101:/ window 5.8,5
-3013.0 "Ancient Eruption" sync / 1[56]:Ascian Prime:1103:/
-3022.1 "Shadow Flare" sync / 1[56]:Ascian Prime:1109:/ window 15,15
-3028.2 "Height Of Chaos" sync / 1[56]:Ascian Prime:1101:/
+3002.3 "--sync--" sync / 1[56]:[^:]*:Ascian Prime:1100:/ window 3003,2
+3005.8 "Height Of Chaos" sync / 1[56]:[^:]*:Ascian Prime:1101:/ window 5.8,5
+3013.0 "Ancient Eruption" sync / 1[56]:[^:]*:Ascian Prime:1103:/
+3022.1 "Shadow Flare" sync / 1[56]:[^:]*:Ascian Prime:1109:/ window 15,15
+3028.2 "Height Of Chaos" sync / 1[56]:[^:]*:Ascian Prime:1101:/
 
-3038.0 "Height Of Chaos" sync / 1[56]:Ascian Prime:1101:/
-3045.2 "Ancient Eruption" sync / 1[56]:Ascian Prime:1103:/
-3054.3 "Shadow Flare" sync / 1[56]:Ascian Prime:1109:/ window 15,15
-3060.4 "Height Of Chaos" sync / 1[56]:Ascian Prime:1101:/ jump 3028.2
+3038.0 "Height Of Chaos" sync / 1[56]:[^:]*:Ascian Prime:1101:/
+3045.2 "Ancient Eruption" sync / 1[56]:[^:]*:Ascian Prime:1103:/
+3054.3 "Shadow Flare" sync / 1[56]:[^:]*:Ascian Prime:1109:/ window 15,15
+3060.4 "Height Of Chaos" sync / 1[56]:[^:]*:Ascian Prime:1101:/ jump 3028.2
 
 3070.2 "Height Of Chaos"
 3077.4 "Ancient Eruption"
@@ -420,22 +420,22 @@ hideall "--sync--"
 3100.0 "--sync--" sync / 03:........:Firesphere:/  window 100,5
 
 3110.0 "Ancient Circle Appears"
-3115.1 "Ancient Circle" sync / 1[56]:Ascian Prime:1102:/
-3123.1 "Annihilation" sync / 1[56]:Ascian Prime:110A:/ window 25,5
-3132.1 "Ancient Eruption" sync / 1[56]:Ascian Prime:1103:/
-3147.3 "Universal Manipulation" sync / 1[56]:Ascian Prime:1105:/
+3115.1 "Ancient Circle" sync / 1[56]:[^:]*:Ascian Prime:1102:/
+3123.1 "Annihilation" sync / 1[56]:[^:]*:Ascian Prime:110A:/ window 25,5
+3132.1 "Ancient Eruption" sync / 1[56]:[^:]*:Ascian Prime:1103:/
+3147.3 "Universal Manipulation" sync / 1[56]:[^:]*:Ascian Prime:1105:/
 
-3156.4 "Height Of Chaos" sync / 1[56]:Ascian Prime:1101:/ window 50,5
-3163.5 "Entropic Flame" sync / 1[56]:Ascian Prime:1107:/
-3168.6 "Height Of Chaos" sync / 1[56]:Ascian Prime:1101:/
-3175.7 "Ancient Eruption" sync / 1[56]:Ascian Prime:1103:/ window 15,15
-3184.8 "Shadow Flare" sync / 1[56]:Ascian Prime:1109:/
+3156.4 "Height Of Chaos" sync / 1[56]:[^:]*:Ascian Prime:1101:/ window 50,5
+3163.5 "Entropic Flame" sync / 1[56]:[^:]*:Ascian Prime:1107:/
+3168.6 "Height Of Chaos" sync / 1[56]:[^:]*:Ascian Prime:1101:/
+3175.7 "Ancient Eruption" sync / 1[56]:[^:]*:Ascian Prime:1103:/ window 15,15
+3184.8 "Shadow Flare" sync / 1[56]:[^:]*:Ascian Prime:1109:/
 
-3194.0 "Height Of Chaos" sync / 1[56]:Ascian Prime:1101:/
-3201.1 "Entropic Flame" sync / 1[56]:Ascian Prime:1107:/ window 30,30
-3206.2 "Height Of Chaos" sync / 1[56]:Ascian Prime:1101:/
-3213.3 "Ancient Eruption" sync / 1[56]:Ascian Prime:1103:/
-3222.4 "Shadow Flare" sync / 1[56]:Ascian Prime:1109:/ window 15,15 jump 3184.8
+3194.0 "Height Of Chaos" sync / 1[56]:[^:]*:Ascian Prime:1101:/
+3201.1 "Entropic Flame" sync / 1[56]:[^:]*:Ascian Prime:1107:/ window 30,30
+3206.2 "Height Of Chaos" sync / 1[56]:[^:]*:Ascian Prime:1101:/
+3213.3 "Ancient Eruption" sync / 1[56]:[^:]*:Ascian Prime:1103:/
+3222.4 "Shadow Flare" sync / 1[56]:[^:]*:Ascian Prime:1109:/ window 15,15 jump 3184.8
 
 3231.6 "Height Of Chaos"
 3238.7 "Entropic Flame"
@@ -447,29 +447,29 @@ hideall "--sync--"
 3300.0 "--sync--" sync / 03:........:Firesphere:/  window 200,5
 
 3304.6 "Ancient Circle Appears"
-3309.7 "Ancient Circle" sync / 1[56]:Ascian Prime:1102:/
+3309.7 "Ancient Circle" sync / 1[56]:[^:]*:Ascian Prime:1102:/
 3314.7 "Ancient Circle Appears"
-3319.8 "Ancient Circle" sync / 1[56]:Ascian Prime:1102:/
-3322.8 "Annihilation" sync / 1[56]:Ascian Prime:110A:/ window 30,30
-3331.8 "Ancient Eruption" sync / 1[56]:Ascian Prime:1103:/
-3347.0 "Universal Manipulation" sync / 1[56]:Ascian Prime:1105:/
+3319.8 "Ancient Circle" sync / 1[56]:[^:]*:Ascian Prime:1102:/
+3322.8 "Annihilation" sync / 1[56]:[^:]*:Ascian Prime:110A:/ window 30,30
+3331.8 "Ancient Eruption" sync / 1[56]:[^:]*:Ascian Prime:1103:/
+3347.0 "Universal Manipulation" sync / 1[56]:[^:]*:Ascian Prime:1105:/
 
-3356.2 "Height Of Chaos" sync / 1[56]:Ascian Prime:1101:/ window 50,5
-3363.3 "Entropic Flame" sync / 1[56]:Ascian Prime:1107:/
-3368.5 "Height Of Chaos" sync / 1[56]:Ascian Prime:1101:/
-3375.6 "Ancient Eruption" sync / 1[56]:Ascian Prime:1103:/ window 15,15
-3384.8 "Shadow Flare" sync / 1[56]:Ascian Prime:1109:/
+3356.2 "Height Of Chaos" sync / 1[56]:[^:]*:Ascian Prime:1101:/ window 50,5
+3363.3 "Entropic Flame" sync / 1[56]:[^:]*:Ascian Prime:1107:/
+3368.5 "Height Of Chaos" sync / 1[56]:[^:]*:Ascian Prime:1101:/
+3375.6 "Ancient Eruption" sync / 1[56]:[^:]*:Ascian Prime:1103:/ window 15,15
+3384.8 "Shadow Flare" sync / 1[56]:[^:]*:Ascian Prime:1109:/
 3390.9 "Height Of Chaos x3" duration 5.0
 
-3402.7 "Height Of Chaos" sync / 1[56]:Ascian Prime:1101:/
-3409.8 "Entropic Flame" sync / 1[56]:Ascian Prime:1107:/
-3415.0 "Height Of Chaos" sync / 1[56]:Ascian Prime:1101:/
-3422.1 "Ancient Eruption" sync / 1[56]:Ascian Prime:1103:/ window 15,15
-3431.3 "Shadow Flare" sync / 1[56]:Ascian Prime:1109:/
+3402.7 "Height Of Chaos" sync / 1[56]:[^:]*:Ascian Prime:1101:/
+3409.8 "Entropic Flame" sync / 1[56]:[^:]*:Ascian Prime:1107:/
+3415.0 "Height Of Chaos" sync / 1[56]:[^:]*:Ascian Prime:1101:/
+3422.1 "Ancient Eruption" sync / 1[56]:[^:]*:Ascian Prime:1103:/ window 15,15
+3431.3 "Shadow Flare" sync / 1[56]:[^:]*:Ascian Prime:1109:/
 3437.4 "Height Of Chaos x3" duration 5.0
 
 # Jumping from a following block to avoid sync issues with Height Of Chaos x3
-3449.2 "Height Of Chaos" sync / 1[56]:Ascian Prime:1101:/ jump 3402.7
+3449.2 "Height Of Chaos" sync / 1[56]:[^:]*:Ascian Prime:1101:/ jump 3402.7
 3456.3 "Entropic Flame"
 3461.5 "Height Of Chaos"
 3468.6 "Ancient Eruption"

--- a/ui/raidboss/data/03-hw/dungeon/aetherochemical_research_facility.txt
+++ b/ui/raidboss/data/03-hw/dungeon/aetherochemical_research_facility.txt
@@ -9,7 +9,7 @@ hideall "--sync--"
 
 # -ii 10E1
 0.0 "--sync--" sync / 00:0839::Analysis and Proving will be sealed off/
-2.9 "--sync--" sync / 1[56]:Regula van Hydrus:366/
+2.9 "--sync--" sync / 1[56]:Regula van Hydrus:366:/
 6.3 "Bastardbluss" sync / 1[56]:Regula van Hydrus:10DA:/ window 6.3,5
 
 13.4 "Judgment" sync / 1[56]:Regula van Hydrus:10DD:/ window 13.4,2.5

--- a/ui/raidboss/data/03-hw/dungeon/baelsars_wall.txt
+++ b/ui/raidboss/data/03-hw/dungeon/baelsars_wall.txt
@@ -18,17 +18,17 @@ hideall "--sync--"
 # We sync on Magitek Ray and hope for the best. It's all bad.
 
 0 "Start" sync / 00:0839::Via Praetoria will be sealed off/ window 0,1
-10.5 "Magitek Claw" sync / 1[56]:Magitek Predator:1CB2:/
-26.8 "Magitek Ray" sync / 1[56]:Magitek Predator:1CB3:/
-34.1 "Magitek Missile" sync / 1[56]:Magitek Predator:1CB4:/
+10.5 "Magitek Claw" sync / 1[56]:[^:]*:Magitek Predator:1CB2:/
+26.8 "Magitek Ray" sync / 1[56]:[^:]*:Magitek Predator:1CB3:/
+34.1 "Magitek Missile" sync / 1[56]:[^:]*:Magitek Predator:1CB4:/
 
-44.4 "Magitek Ray" sync / 1[56]:Magitek Predator:1CB3:/
-54.5 "Magitek Claw" sync / 1[56]:Magitek Predator:1CB2:/ window 5,5
-68.7 "Magitek Missile" sync / 1[56]:Magitek Predator:1CB4:/
-70.8 "Magitek Missile" sync / 1[56]:Magitek Predator:1CB4:/
+44.4 "Magitek Ray" sync / 1[56]:[^:]*:Magitek Predator:1CB3:/
+54.5 "Magitek Claw" sync / 1[56]:[^:]*:Magitek Predator:1CB2:/ window 5,5
+68.7 "Magitek Missile" sync / 1[56]:[^:]*:Magitek Predator:1CB4:/
+70.8 "Magitek Missile" sync / 1[56]:[^:]*:Magitek Predator:1CB4:/
 
-73.2 "--sync--"   sync / 14:Magitek Predator:1CB3:/ window 10,10
-75.9 "Magitek Ray" sync / 1[56]:Magitek Predator:1CB3:/ jump 44.4
+73.2 "--sync--"   sync / 14:[^:]*:Magitek Predator:1CB3:/ window 10,10
+75.9 "Magitek Ray" sync / 1[56]:[^:]*:Magitek Predator:1CB3:/ jump 44.4
 89.0 "Magitek Claw"
 98.4 "Magitek Missile"
 100.6 "Magitek Missile"
@@ -40,39 +40,39 @@ hideall "--sync--"
 # -ii 1CB7 1CBA
 
 1000.0 "Start" sync / 00:0839::The Magitek Installation will be sealed off/ window 1000,5
-1007.1 "Magitek Cannon" sync / 1[56]:Armored Weapon:1CB8:/ window 7.1,5
-1013.2 "Launcher" sync / 1[56]:Armored Weapon:1CBC:/
-1019.4 "Dynamic Sensory Jammer" sync / 1[56]:Armored Weapon:1CB9:/ duration 6
-1033.7 "Diffractive Laser" sync / 1[56]:Armored Weapon:1CBB:/
+1007.1 "Magitek Cannon" sync / 1[56]:[^:]*:Armored Weapon:1CB8:/ window 7.1,5
+1013.2 "Launcher" sync / 1[56]:[^:]*:Armored Weapon:1CBC:/
+1019.4 "Dynamic Sensory Jammer" sync / 1[56]:[^:]*:Armored Weapon:1CB9:/ duration 6
+1033.7 "Diffractive Laser" sync / 1[56]:[^:]*:Armored Weapon:1CBB:/
 
-1039.9 "Distress Beacon?" sync / 1[56]:Armored Weapon:1CBE:/ window 39.9,5 jump 1100
-1039.9 "Magitek Bit?" sync / 1[56]:Armored Weapon:1CBD:/ window 39.9,5 jump 1155.6
+1039.9 "Distress Beacon?" sync / 1[56]:[^:]*:Armored Weapon:1CBE:/ window 39.9,5 jump 1100
+1039.9 "Magitek Bit?" sync / 1[56]:[^:]*:Armored Weapon:1CBD:/ window 39.9,5 jump 1155.6
 1049.1 "Launcher?"
 1051.8 "Assault Cannon?"
 1053.2 "Magitek Cannon?"
 1054.1 "Diffractive Laser?"
 
 
-1100.0 "Distress Beacon" sync / 1[56]:Armored Weapon:1CBE:/
-1109.2 "Launcher" sync / 1[56]:Armored Weapon:1CBC:/
-1113.3 "Magitek Cannon" sync / 1[56]:Armored Weapon:1CB8:/
-1120.4 "Launcher" sync / 1[56]:Armored Weapon:1CBC:/
-1125.5 "Dynamic Sensory Jammer" sync / 1[56]:Armored Weapon:1CB9:/ duration 6
-1133.3 "Diffractive Laser" sync / 1[56]:Armored Weapon:1CBB:/ window 10,10
-1137.4 "Magitek Cannon" sync / 1[56]:Armored Weapon:1CB8:/
-1144.4 "Launcher" sync / 1[56]:Armored Weapon:1CBC:/
+1100.0 "Distress Beacon" sync / 1[56]:[^:]*:Armored Weapon:1CBE:/
+1109.2 "Launcher" sync / 1[56]:[^:]*:Armored Weapon:1CBC:/
+1113.3 "Magitek Cannon" sync / 1[56]:[^:]*:Armored Weapon:1CB8:/
+1120.4 "Launcher" sync / 1[56]:[^:]*:Armored Weapon:1CBC:/
+1125.5 "Dynamic Sensory Jammer" sync / 1[56]:[^:]*:Armored Weapon:1CB9:/ duration 6
+1133.3 "Diffractive Laser" sync / 1[56]:[^:]*:Armored Weapon:1CBB:/ window 10,10
+1137.4 "Magitek Cannon" sync / 1[56]:[^:]*:Armored Weapon:1CB8:/
+1144.4 "Launcher" sync / 1[56]:[^:]*:Armored Weapon:1CBC:/
 
-1155.6 "Magitek Bit" sync / 1[56]:Armored Weapon:1CBD:/ window 30,30
-1161.5 "--sync--" sync / 1[56]:Magitek Bit:1CBF:/
-1167.5 "Assault Cannon" sync / 1[56]:Magitek Bit:1CC0:/
-1169.8 "Diffractive Laser" sync / 1[56]:Armored Weapon:1CBB:/ window 10,10
-1175.9 "Launcher" sync / 1[56]:Armored Weapon:1CBC:/
-1181.0 "Dynamic Sensory Jammer" sync / 1[56]:Armored Weapon:1CB9:/ duration 6
-1188.9 "Diffractive Laser" sync / 1[56]:Armored Weapon:1CBB:/
-1193.0 "Magitek Cannon" sync / 1[56]:Armored Weapon:1CB8:/
-1200.0 "Launcher" sync / 1[56]:Armored Weapon:1CBC:/
+1155.6 "Magitek Bit" sync / 1[56]:[^:]*:Armored Weapon:1CBD:/ window 30,30
+1161.5 "--sync--" sync / 1[56]:[^:]*:Magitek Bit:1CBF:/
+1167.5 "Assault Cannon" sync / 1[56]:[^:]*:Magitek Bit:1CC0:/
+1169.8 "Diffractive Laser" sync / 1[56]:[^:]*:Armored Weapon:1CBB:/ window 10,10
+1175.9 "Launcher" sync / 1[56]:[^:]*:Armored Weapon:1CBC:/
+1181.0 "Dynamic Sensory Jammer" sync / 1[56]:[^:]*:Armored Weapon:1CB9:/ duration 6
+1188.9 "Diffractive Laser" sync / 1[56]:[^:]*:Armored Weapon:1CBB:/
+1193.0 "Magitek Cannon" sync / 1[56]:[^:]*:Armored Weapon:1CB8:/
+1200.0 "Launcher" sync / 1[56]:[^:]*:Armored Weapon:1CBC:/
 
-1211.2 "Distress Beacon" sync / 1[56]:Armored Weapon:1CBE:/ window 30,30 jump 1100
+1211.2 "Distress Beacon" sync / 1[56]:[^:]*:Armored Weapon:1CBE:/ window 30,30 jump 1100
 1220.4 "Launcher"
 1224.5 "Magitek Cannon"
 1231.6 "Launcher"
@@ -85,31 +85,31 @@ hideall "--sync--"
 
 
 2000.0 "Start" sync / 00:0839::The Airship Landing will be sealed off/ window 2000,5
-2006.1 "Dull Blade" sync / 1[56]:The Griffin:1CC1:/ window 6.1,5
-2012.2 "Beak Of The Griffin" sync / 1[56]:The Griffin:1CC3:/
-2019.3 "Flash Powder" sync / 1[56]:The Griffin:1CC4:/
-2021.4 "--teleport--" sync / 1[56]:The Griffin:1CC6:/
-2026.9 "Sanguine Blade" sync / 1[56]:The Griffin:1CC5:/
+2006.1 "Dull Blade" sync / 1[56]:[^:]*:The Griffin:1CC1:/ window 6.1,5
+2012.2 "Beak Of The Griffin" sync / 1[56]:[^:]*:The Griffin:1CC3:/
+2019.3 "Flash Powder" sync / 1[56]:[^:]*:The Griffin:1CC4:/
+2021.4 "--teleport--" sync / 1[56]:[^:]*:The Griffin:1CC6:/
+2026.9 "Sanguine Blade" sync / 1[56]:[^:]*:The Griffin:1CC5:/
 
-2036.0 "Claw Of The Griffin" sync / 1[56]:The Griffin:1CC2:/ window 36,6
-2046.2 "Gull Dive x7" duration 5.6 # sync / 1[56]:Blade Of The Griffin:1CCB:/
-2053.1 "Lionshead" sync / 1[56]:The Griffin:1CCA:/
-2060.3 "Dull Blade" sync / 1[56]:The Griffin:1CC1:/
-2066.4 "Flash Powder" sync / 1[56]:The Griffin:1CC4:/ window 30,30
-2071.6 "Big Boot" sync / 1[56]:The Griffin:1CC7:/
-2077.7 "Corrosion" sync / 1[56]:Blade Of The Griffin:1CCC:/ window 30,30
-2077.8 "--teleport--" sync / 1[56]:The Griffin:1CC6:/
-2083.3 "Sanguine Blade" sync / 1[56]:The Griffin:1CC5:/
-2088.5 "Dull Blade" sync / 1[56]:The Griffin:1CC1:/
-2095.6 "Restraint Collar" sync / 1[56]:The Griffin:1CC8:/ window 30,30
-2104.7 "Beak Of The Griffin" sync / 1[56]:The Griffin:1CC3:/
-2108.8 "Dull Blade" sync / 1[56]:The Griffin:1CC1:/
-2111.9 "--teleport 1--" # sync / 1[56]:The Griffin:1CC6:/
-2112.7 "--teleport 2--" # sync / 1[56]:The Griffin:1CC6:/
-2118.2 "Sanguine Blade" sync / 1[56]:The Griffin:1CC5:/
-2125.3 "Beak Of The Griffin" sync / 1[56]:The Griffin:1CC3:/
+2036.0 "Claw Of The Griffin" sync / 1[56]:[^:]*:The Griffin:1CC2:/ window 36,6
+2046.2 "Gull Dive x7" duration 5.6 # sync / 1[56]:[^:]*:Blade Of The Griffin:1CCB:/
+2053.1 "Lionshead" sync / 1[56]:[^:]*:The Griffin:1CCA:/
+2060.3 "Dull Blade" sync / 1[56]:[^:]*:The Griffin:1CC1:/
+2066.4 "Flash Powder" sync / 1[56]:[^:]*:The Griffin:1CC4:/ window 30,30
+2071.6 "Big Boot" sync / 1[56]:[^:]*:The Griffin:1CC7:/
+2077.7 "Corrosion" sync / 1[56]:[^:]*:Blade Of The Griffin:1CCC:/ window 30,30
+2077.8 "--teleport--" sync / 1[56]:[^:]*:The Griffin:1CC6:/
+2083.3 "Sanguine Blade" sync / 1[56]:[^:]*:The Griffin:1CC5:/
+2088.5 "Dull Blade" sync / 1[56]:[^:]*:The Griffin:1CC1:/
+2095.6 "Restraint Collar" sync / 1[56]:[^:]*:The Griffin:1CC8:/ window 30,30
+2104.7 "Beak Of The Griffin" sync / 1[56]:[^:]*:The Griffin:1CC3:/
+2108.8 "Dull Blade" sync / 1[56]:[^:]*:The Griffin:1CC1:/
+2111.9 "--teleport 1--" # sync / 1[56]:[^:]*:The Griffin:1CC6:/
+2112.7 "--teleport 2--" # sync / 1[56]:[^:]*:The Griffin:1CC6:/
+2118.2 "Sanguine Blade" sync / 1[56]:[^:]*:The Griffin:1CC5:/
+2125.3 "Beak Of The Griffin" sync / 1[56]:[^:]*:The Griffin:1CC3:/
 
-2133.4 "Claw Of The Griffin" sync / 1[56]:The Griffin:1CC2:/ jump 2036.0 window 30,30
+2133.4 "Claw Of The Griffin" sync / 1[56]:[^:]*:The Griffin:1CC2:/ jump 2036.0 window 30,30
 2139.6 "Gull Dive"
 2146.5 "Lionshead"
 2153.7 "Dull Blade"

--- a/ui/raidboss/data/03-hw/dungeon/fractal_continuum.txt
+++ b/ui/raidboss/data/03-hw/dungeon/fractal_continuum.txt
@@ -8,39 +8,39 @@ hideall "--sync--"
 #-ii F7D -p F7F:100
 
 0.0 "--sync--" sync / 00:0839::Exhibit level III will be sealed off/ window 0,1
-10.3 "Rapid Sever" sync / 1[56]:Phantom Ray:F7A:/ window 15,15
-16.6 "Atmospheric Displacement" sync / 1[56]:Phantom Ray:F7E:/
-21.4 "Double Sever 1" sync / 1[56]:Phantom Ray:F7[BC]:/
-25.6 "Double Sever 2" sync / 1[56]:Phantom Ray:F7[BC]:/
-27.4 "Atmospheric Displacement" sync / 1[56]:Phantom Ray:F7E:/
+10.3 "Rapid Sever" sync / 1[56]:[^:]*:Phantom Ray:F7A:/ window 15,15
+16.6 "Atmospheric Displacement" sync / 1[56]:[^:]*:Phantom Ray:F7E:/
+21.4 "Double Sever 1" sync / 1[56]:[^:]*:Phantom Ray:F7[BC]:/
+25.6 "Double Sever 2" sync / 1[56]:[^:]*:Phantom Ray:F7[BC]:/
+27.4 "Atmospheric Displacement" sync / 1[56]:[^:]*:Phantom Ray:F7E:/
 
-41.5 "Rapid Sever" sync / 1[56]:Phantom Ray:F7A:/ window 15,15
-47.7 "Atmospheric Displacement" sync / 1[56]:Phantom Ray:F7E:/
-52.5 "Double Sever 1" sync / 1[56]:Phantom Ray:F7[BC]:/
-56.5 "Double Sever 2" sync / 1[56]:Phantom Ray:F7[BC]:/
-58.3 "Atmospheric Displacement" sync / 1[56]:Phantom Ray:F7E:/
+41.5 "Rapid Sever" sync / 1[56]:[^:]*:Phantom Ray:F7A:/ window 15,15
+47.7 "Atmospheric Displacement" sync / 1[56]:[^:]*:Phantom Ray:F7E:/
+52.5 "Double Sever 1" sync / 1[56]:[^:]*:Phantom Ray:F7[BC]:/
+56.5 "Double Sever 2" sync / 1[56]:[^:]*:Phantom Ray:F7[BC]:/
+58.3 "Atmospheric Displacement" sync / 1[56]:[^:]*:Phantom Ray:F7E:/
 
-72.4 "Rapid Sever" sync / 1[56]:Phantom Ray:F7A:/  window 15,15 jump 41.5
+72.4 "Rapid Sever" sync / 1[56]:[^:]*:Phantom Ray:F7A:/  window 15,15 jump 41.5
 78.6 "Atmospheric Displacement"
 83.3 "Double Sever 1"
 87.4 "Double Sever 2"
 89.2 "Atmospheric Displacement"
 # Phase 2 at < 75% HP
 
-100.0 "Damage Up" sync / 1[56]:Phantom Ray:F7F:/  window 100,30 #Overclock
-104.8 "Double Sever 1" sync / 1[56]:Phantom Ray:F7[BC]:/
-107.6 "Atmospheric Compression" sync / 1[56]:Phantom Ray:F80:/
-109.0 "Double Sever 2" sync / 1[56]:Phantom Ray:F7[BC]:/
-111.8 "Atmospheric Displacement" sync / 1[56]:Phantom Ray:F7E:/
-118.9 "Rapid Sever" sync / 1[56]:Phantom Ray:F7A:/
-124.0 "Rapid Sever" sync / 1[56]:Phantom Ray:F7A:/
-128.2 "Atmospheric Displacement" sync / 1[56]:Phantom Ray:F7E:/
-133.1 "Double Sever 1" sync / 1[56]:Phantom Ray:F7[BC]:/
-137.3 "Double Sever 2" sync / 1[56]:Phantom Ray:F7[BC]:/
-139.0 "Atmospheric Displacement" sync / 1[56]:Phantom Ray:F7E:/
-146.1 "Atmospheric Displacement" sync / 1[56]:Phantom Ray:F7E:/
+100.0 "Damage Up" sync / 1[56]:[^:]*:Phantom Ray:F7F:/  window 100,30 #Overclock
+104.8 "Double Sever 1" sync / 1[56]:[^:]*:Phantom Ray:F7[BC]:/
+107.6 "Atmospheric Compression" sync / 1[56]:[^:]*:Phantom Ray:F80:/
+109.0 "Double Sever 2" sync / 1[56]:[^:]*:Phantom Ray:F7[BC]:/
+111.8 "Atmospheric Displacement" sync / 1[56]:[^:]*:Phantom Ray:F7E:/
+118.9 "Rapid Sever" sync / 1[56]:[^:]*:Phantom Ray:F7A:/
+124.0 "Rapid Sever" sync / 1[56]:[^:]*:Phantom Ray:F7A:/
+128.2 "Atmospheric Displacement" sync / 1[56]:[^:]*:Phantom Ray:F7E:/
+133.1 "Double Sever 1" sync / 1[56]:[^:]*:Phantom Ray:F7[BC]:/
+137.3 "Double Sever 2" sync / 1[56]:[^:]*:Phantom Ray:F7[BC]:/
+139.0 "Atmospheric Displacement" sync / 1[56]:[^:]*:Phantom Ray:F7E:/
+146.1 "Atmospheric Displacement" sync / 1[56]:[^:]*:Phantom Ray:F7E:/
 
-148.4 "Damage Up" sync / 1[56]:Phantom Ray:F7F:/ window 15,15 jump 100.0
+148.4 "Damage Up" sync / 1[56]:[^:]*:Phantom Ray:F7F:/ window 15,15 jump 100.0
 153.2 "Double Sever 1"
 156.0 "Atmospheric Compression"
 157.4 "Double Sever 2"
@@ -51,38 +51,38 @@ hideall "--sync--"
 
 ###Minotaur
 1000.0 "--sync--" sync / 00:0839::The high-level incubation bay will be sealed off/ window 1999,5
-1003.4 "--sync--" sync / 1[56]:Minotaur:366:/ window 3.4,0
-1008.8 "11-Tonze Swipe" sync / 1[56]:Minotaur:F81:/
-1019.0 "111-Tonze Swing" sync / 1[56]:Minotaur:F82:/ window 20,20
-1028.2 "Disorienting Groan" sync / 1[56]:Minotaur:F84:/
-1029.4 "Zoom In x3" sync / 1[56]:Minotaur:F86:/ duration 3.7
-1034.3 "10-Tonze Slash" sync / 1[56]:Minotaur:F83:/ window 20,20
-1043.5 "11-Tonze Swipe" sync / 1[56]:Minotaur:F81:/
+1003.4 "--sync--" sync / 1[56]:[^:]*:Minotaur:366:/ window 3.4,0
+1008.8 "11-Tonze Swipe" sync / 1[56]:[^:]*:Minotaur:F81:/
+1019.0 "111-Tonze Swing" sync / 1[56]:[^:]*:Minotaur:F82:/ window 20,20
+1028.2 "Disorienting Groan" sync / 1[56]:[^:]*:Minotaur:F84:/
+1029.4 "Zoom In x3" sync / 1[56]:[^:]*:Minotaur:F86:/ duration 3.7
+1034.3 "10-Tonze Slash" sync / 1[56]:[^:]*:Minotaur:F83:/ window 20,20
+1043.5 "11-Tonze Swipe" sync / 1[56]:[^:]*:Minotaur:F81:/
 
 # Rotation desyncs here due to timing on cage use
 1048.0  "--sync--" sync / 1B:........:Minotaur:....:....:0036:/ window 45,15 jump 1151.0
 1064.2 "Feast?"
-1064.3 "1111-Tonze Swing?" sync / 1[56]:Minotaur:F87:/ window 1,10 jump 1167.3
+1064.3 "1111-Tonze Swing?" sync / 1[56]:[^:]*:Minotaur:F87:/ window 1,10 jump 1167.3
 
 1076.4 "11-Tonze Swipe"
 1086.7 "111-Tonze Swing"
 
 # Second rotation landing spots
 1151.0 "--sync--" #landing for correct cage use
-1167.2 "Feast" sync / 1[56]:Minotaur:F88:/ window 15,15
+1167.2 "Feast" sync / 1[56]:[^:]*:Minotaur:F88:/ window 15,15
 1167.3 "--sync--" #landing for missed cage
 
 # Second rotation, same as the first
 # Necessary for a clean landing after cages
-1179.4 "11-Tonze Swipe" sync / 1[56]:Minotaur:F81:/ window 15,15
-1189.7 "111-Tonze Swing" sync / 1[56]:Minotaur:F82:/ window 20,20
-1199.0 "Disorienting Groan" sync / 1[56]:Minotaur:F84:/
-1200.1 "Zoom In x3" sync / 1[56]:Minotaur:F86:/ duration 3.7
-1204.7 "10-Tonze Slash" sync / 1[56]:Minotaur:F83:/ window 20,20
-1214.0 "11-Tonze Swipe" sync / 1[56]:Minotaur:F81:/
+1179.4 "11-Tonze Swipe" sync / 1[56]:[^:]*:Minotaur:F81:/ window 15,15
+1189.7 "111-Tonze Swing" sync / 1[56]:[^:]*:Minotaur:F82:/ window 20,20
+1199.0 "Disorienting Groan" sync / 1[56]:[^:]*:Minotaur:F84:/
+1200.1 "Zoom In x3" sync / 1[56]:[^:]*:Minotaur:F86:/ duration 3.7
+1204.7 "10-Tonze Slash" sync / 1[56]:[^:]*:Minotaur:F83:/ window 20,20
+1214.0 "11-Tonze Swipe" sync / 1[56]:[^:]*:Minotaur:F81:/
 1219.0 "--sync--" sync / 1B:........:Minotaur:....:....:0036:/ window 45,15 jump 1151.0
 1235.2 "Feast?"
-1235.3 "1111-Tonze Swing?" sync / 1[56]:Minotaur:F87:/ window 1,10 jump 1167.3
+1235.3 "1111-Tonze Swing?" sync / 1[56]:[^:]*:Minotaur:F87:/ window 1,10 jump 1167.3
 
 1247.4 "11-Tonze Swipe"
 1263.6 "111-Tonze Swing"
@@ -96,30 +96,30 @@ hideall "--sync--"
 # Phase length is the same regardless of added abilities.
 
 2000 "--sync--" sync / 00:0839::The reality augmentation bay will be sealed off/ window 2000,0
-2003.0 "--sync--" sync / 1[56]:The Curator:368:/ window 3,2
-2006.2 "Sanctification" sync / 1[56]:The Curator:F89:/
-2011.4 "Unholy" sync / 1[56]:The Curator:F8A:/
-2020.6 "Sanctification" sync / 1[56]:The Curator:F89:/
-2028.8 "Aetherochemical Explosive" sync / 1[56]:The Curator:F8B:/ window 15,15
-2033.0 "Unholy" sync / 1[56]:The Curator:F8A:/
-2035.8 "Sanctification" sync / 1[56]:The Curator:F89:/
-2042.0 "Unholy" sync / 1[56]:The Curator:F8A:/
-2044.1 "Sanctification" sync / 1[56]:The Curator:F89:/
-2053.2 "Aetherochemical Explosive" sync / 1[56]:The Curator:F8B:/
-2066.4 "The Educator" sync / 1[56]:The Curator:F8D:/ window 30,30
+2003.0 "--sync--" sync / 1[56]:[^:]*:The Curator:368:/ window 3,2
+2006.2 "Sanctification" sync / 1[56]:[^:]*:The Curator:F89:/
+2011.4 "Unholy" sync / 1[56]:[^:]*:The Curator:F8A:/
+2020.6 "Sanctification" sync / 1[56]:[^:]*:The Curator:F89:/
+2028.8 "Aetherochemical Explosive" sync / 1[56]:[^:]*:The Curator:F8B:/ window 15,15
+2033.0 "Unholy" sync / 1[56]:[^:]*:The Curator:F8A:/
+2035.8 "Sanctification" sync / 1[56]:[^:]*:The Curator:F89:/
+2042.0 "Unholy" sync / 1[56]:[^:]*:The Curator:F8A:/
+2044.1 "Sanctification" sync / 1[56]:[^:]*:The Curator:F89:/
+2053.2 "Aetherochemical Explosive" sync / 1[56]:[^:]*:The Curator:F8B:/
+2066.4 "The Educator" sync / 1[56]:[^:]*:The Curator:F8D:/ window 30,30
 
-2073.2 "Sanctification" sync / 1[56]:The Curator:F89:/
-2078.4 "Unholy" sync / 1[56]:The Curator:F8A:/
-2087.6 "Sanctification" sync / 1[56]:The Curator:F89:/
-2095.8 "Aetherochemical Explosive" sync / 1[56]:The Curator:F8B:/
-2100.0 "Unholy" sync / 1[56]:The Curator:F8A:/
-2102.8 "Sanctification" sync / 1[56]:The Curator:F89:/
-2109.0 "Unholy" sync / 1[56]:The Curator:F8A:/
-2111.1 "Sanctification" sync / 1[56]:The Curator:F89:/
-2120.2 "Aetherochemical Explosive" sync / 1[56]:The Curator:F8B:/
-2133.4 "The Educator" sync / 1[56]:The Curator:F8D:/ window 30,30
+2073.2 "Sanctification" sync / 1[56]:[^:]*:The Curator:F89:/
+2078.4 "Unholy" sync / 1[56]:[^:]*:The Curator:F8A:/
+2087.6 "Sanctification" sync / 1[56]:[^:]*:The Curator:F89:/
+2095.8 "Aetherochemical Explosive" sync / 1[56]:[^:]*:The Curator:F8B:/
+2100.0 "Unholy" sync / 1[56]:[^:]*:The Curator:F8A:/
+2102.8 "Sanctification" sync / 1[56]:[^:]*:The Curator:F89:/
+2109.0 "Unholy" sync / 1[56]:[^:]*:The Curator:F8A:/
+2111.1 "Sanctification" sync / 1[56]:[^:]*:The Curator:F89:/
+2120.2 "Aetherochemical Explosive" sync / 1[56]:[^:]*:The Curator:F8B:/
+2133.4 "The Educator" sync / 1[56]:[^:]*:The Curator:F8D:/ window 30,30
 
-2140.2 "Sanctification" sync / 1[56]:The Curator:F89:/ window 15,15 jump 2073.2
+2140.2 "Sanctification" sync / 1[56]:[^:]*:The Curator:F89:/ window 15,15 jump 2073.2
 2145.4 "Unholy"
 2154.6 "Sanctification"
 2162.8 "Aetherochemical Explosive"
@@ -128,21 +128,21 @@ hideall "--sync--"
 
 # Phase 2 after first Educator. Maybe HP threshold?
 
-2200.0 "Sanctification" sync / 1[56]:The Curator:F89:/
-2203.9 "Aetherochemical Mine" sync / 1[56]:Repository Node:F8F:/ window 2200,10
-2205.2 "Unholy" sync / 1[56]:The Curator:F8A:/
-2214.6 "Sanctification" sync / 1[56]:The Curator:F89:/
-2222.7 "Aetherochemical Explosive" sync / 1[56]:The Curator:F8B:/
-2225.0 "Aetherochemical Mine" sync / 1[56]:Repository Node:F8F:/ window 10,10
-2226.8 "Unholy" sync / 1[56]:The Curator:F8A:/
-2229.0 "Sanctification" sync / 1[56]:The Curator:F89:/
-2235.0 "Unholy" sync / 1[56]:The Curator:F8A:/
-2237.4 "Sanctification" sync / 1[56]:The Curator:F89:/
-2242.0 "Aetherochemical Mine" sync / 1[56]:Repository Node:F8F:/
-2246.5 "Aetherochemical Explosive" sync / 1[56]:The Curator:F8B:/ window 10,10
-2259.7 "The Educator" sync / 1[56]:The Curator:F8D:/
+2200.0 "Sanctification" sync / 1[56]:[^:]*:The Curator:F89:/
+2203.9 "Aetherochemical Mine" sync / 1[56]:[^:]*:Repository Node:F8F:/ window 2200,10
+2205.2 "Unholy" sync / 1[56]:[^:]*:The Curator:F8A:/
+2214.6 "Sanctification" sync / 1[56]:[^:]*:The Curator:F89:/
+2222.7 "Aetherochemical Explosive" sync / 1[56]:[^:]*:The Curator:F8B:/
+2225.0 "Aetherochemical Mine" sync / 1[56]:[^:]*:Repository Node:F8F:/ window 10,10
+2226.8 "Unholy" sync / 1[56]:[^:]*:The Curator:F8A:/
+2229.0 "Sanctification" sync / 1[56]:[^:]*:The Curator:F89:/
+2235.0 "Unholy" sync / 1[56]:[^:]*:The Curator:F8A:/
+2237.4 "Sanctification" sync / 1[56]:[^:]*:The Curator:F89:/
+2242.0 "Aetherochemical Mine" sync / 1[56]:[^:]*:Repository Node:F8F:/
+2246.5 "Aetherochemical Explosive" sync / 1[56]:[^:]*:The Curator:F8B:/ window 10,10
+2259.7 "The Educator" sync / 1[56]:[^:]*:The Curator:F8D:/
 
-2267.0 "Sanctification" sync / 1[56]:The Curator:F89:/ window 15,15 jump 2196.1
+2267.0 "Sanctification" sync / 1[56]:[^:]*:The Curator:F89:/ window 15,15 jump 2196.1
 2270.9 "Aetherochemical Mine"
 2272.2 "Unholy"
 2281.6 "Sanctification"

--- a/ui/raidboss/data/03-hw/dungeon/gubal_library_hard.txt
+++ b/ui/raidboss/data/03-hw/dungeon/gubal_library_hard.txt
@@ -7,34 +7,34 @@ hideall "--sync--"
 # -ii 1951 1952
 
 0 "--sync--" sync / 00:0839::The Hall of Magicks will be sealed off/
-6.1 "Triclip" sync / 1[56]:Demon of the Tome:193A:/ window 6.1,5
-17.3 "Folio" sync / 1[56]:Demon of the Tome:193C:/
-23.4 "--sync--" sync / 1[56]:Top Shelf Tome:193D:/
-24.0 "Book Drop" sync / 1[56]:Top Shelf Tome:193E:/
+6.1 "Triclip" sync / 1[56]:[^:]*:Demon of the Tome:193A:/ window 6.1,5
+17.3 "Folio" sync / 1[56]:[^:]*:Demon of the Tome:193C:/
+23.4 "--sync--" sync / 1[56]:[^:]*:Top Shelf Tome:193D:/
+24.0 "Book Drop" sync / 1[56]:[^:]*:Top Shelf Tome:193E:/
 
-29.5 "Triclip" sync / 1[56]:Demon of the Tome:193A:/ window 15,15
-38.7 "Folio" sync / 1[56]:Demon of the Tome:193C:/
-44.8 "--sync--" sync / 1[56]:Top Shelf Tome:193D:/
-45.4 "Book Drop" sync / 1[56]:Top Shelf Tome:193E:/
-47.0 "Issue" sync / 1[56]:Middle Shelf Tome:193F:/ window 15,15
-52.6 "Discontinue" sync / 1[56]:Middle Shelf Tome:1940:/
-58.3 "Frightful Roar" sync / 1[56]:Demon of the Tome:193B:/
-63.5 "Triclip" sync / 1[56]:Demon of the Tome:193A:/ window 15,15
-71.5 "Folio" sync / 1[56]:Demon of the Tome:193C:/
+29.5 "Triclip" sync / 1[56]:[^:]*:Demon of the Tome:193A:/ window 15,15
+38.7 "Folio" sync / 1[56]:[^:]*:Demon of the Tome:193C:/
+44.8 "--sync--" sync / 1[56]:[^:]*:Top Shelf Tome:193D:/
+45.4 "Book Drop" sync / 1[56]:[^:]*:Top Shelf Tome:193E:/
+47.0 "Issue" sync / 1[56]:[^:]*:Middle Shelf Tome:193F:/ window 15,15
+52.6 "Discontinue" sync / 1[56]:[^:]*:Middle Shelf Tome:1940:/
+58.3 "Frightful Roar" sync / 1[56]:[^:]*:Demon of the Tome:193B:/
+63.5 "Triclip" sync / 1[56]:[^:]*:Demon of the Tome:193A:/ window 15,15
+71.5 "Folio" sync / 1[56]:[^:]*:Demon of the Tome:193C:/
 77.6 "Issue"
 82.2 "Discontinue"
 83.6 "Issue"
 84.2 "Discontinue x3"
 
-102.7 "Triclip" sync / 1[56]:Demon of the Tome:193A:/ window 15,15
-111.9 "Folio" sync / 1[56]:Demon of the Tome:193C:/
-118.0 "--sync--" sync / 1[56]:Top Shelf Tome:193D:/
-118.6 "Book Drop" sync / 1[56]:Top Shelf Tome:193E:/
-120.2 "Issue" sync / 1[56]:Middle Shelf Tome:193F:/ window 15,15
-125.8 "Discontinue" sync / 1[56]:Middle Shelf Tome:1940:/
-131.5 "Frightful Roar" sync / 1[56]:Demon of the Tome:193B:/
-136.7 "Triclip" sync / 1[56]:Demon of the Tome:193A:/
-144.7 "Folio" sync / 1[56]:Demon of the Tome:193C:/
+102.7 "Triclip" sync / 1[56]:[^:]*:Demon of the Tome:193A:/ window 15,15
+111.9 "Folio" sync / 1[56]:[^:]*:Demon of the Tome:193C:/
+118.0 "--sync--" sync / 1[56]:[^:]*:Top Shelf Tome:193D:/
+118.6 "Book Drop" sync / 1[56]:[^:]*:Top Shelf Tome:193E:/
+120.2 "Issue" sync / 1[56]:[^:]*:Middle Shelf Tome:193F:/ window 15,15
+125.8 "Discontinue" sync / 1[56]:[^:]*:Middle Shelf Tome:1940:/
+131.5 "Frightful Roar" sync / 1[56]:[^:]*:Demon of the Tome:193B:/
+136.7 "Triclip" sync / 1[56]:[^:]*:Demon of the Tome:193A:/
+144.7 "Folio" sync / 1[56]:[^:]*:Demon of the Tome:193C:/
 150.8 "Issue"
 155.4 "Discontinue"
 156.8 "Issue"
@@ -42,7 +42,7 @@ hideall "--sync--"
 
 # Ordinarily we would sync from the end of the last block
 # However, this tends to break due to multiple identical mechanics close together
-175.9 "Triclip" sync / 1[56]:Demon of the Tome:193A:/ window 15,15 jump 102.7
+175.9 "Triclip" sync / 1[56]:[^:]*:Demon of the Tome:193A:/ window 15,15 jump 102.7
 185.1 "Folio"
 191.8 "Book Drop"
 193.4 "Issue"
@@ -55,48 +55,48 @@ hideall "--sync--"
 # Whichever intermission comes second ends up with phantom "Gains Effect" lines
 
 1000.0 "--sync--"  sync / 00:0839::The Astrology and Astromancy Camera will be sealed off/ window 1000,0
-1007.3 "Searing Wind" sync / 1[56]:Liquid Flame:1944:/ window 7.3,5
-1014.3 "Bibliocide" sync / 1[56]:Liquid Flame:1945:/
+1007.3 "Searing Wind" sync / 1[56]:[^:]*:Liquid Flame:1944:/ window 7.3,5
+1014.3 "Bibliocide" sync / 1[56]:[^:]*:Liquid Flame:1945:/
 1025.7 "Sea Of Flames x3"
-1030.5 "Slosh" sync / 1[56]:Liquid Flame:1947:/ window 10,10
-1034.6 "Searing Wind" sync / 1[56]:Liquid Flame:1944:/
-1042.7 "Bibliocide" sync / 1[56]:Liquid Flame:1945:/
+1030.5 "Slosh" sync / 1[56]:[^:]*:Liquid Flame:1947:/ window 10,10
+1034.6 "Searing Wind" sync / 1[56]:[^:]*:Liquid Flame:1944:/
+1042.7 "Bibliocide" sync / 1[56]:[^:]*:Liquid Flame:1945:/
 1054.3 "Hand/Tornado?"
 
 # Hand Form
 1100.0 "--sync--" sync /00:....:The liquid flame gains the effect of Chiromorph/ window 100,250
-1108.4 "Seal Of Night And Day" sync / 1[56]:Liquid Flame:1949:/ window 10,10
-1112.5 "Searing Wind" sync / 1[56]:Liquid Flame:1948:/
-1116.4 "Searing Wind" sync / 1[56]:Liquid Flame:1948:/
-1126.5 "Seal Of Night And Day" sync / 1[56]:Liquid Flame:1949:/ window 10,10
-1130.6 "Searing Wind" sync / 1[56]:Liquid Flame:1948:/
-1134.7 "Searing Wind" sync / 1[56]:Liquid Flame:1948:/
-1138.9 "Searing Wind" sync / 1[56]:Liquid Flame:1948:/
+1108.4 "Seal Of Night And Day" sync / 1[56]:[^:]*:Liquid Flame:1949:/ window 10,10
+1112.5 "Searing Wind" sync / 1[56]:[^:]*:Liquid Flame:1948:/
+1116.4 "Searing Wind" sync / 1[56]:[^:]*:Liquid Flame:1948:/
+1126.5 "Seal Of Night And Day" sync / 1[56]:[^:]*:Liquid Flame:1949:/ window 10,10
+1130.6 "Searing Wind" sync / 1[56]:[^:]*:Liquid Flame:1948:/
+1134.7 "Searing Wind" sync / 1[56]:[^:]*:Liquid Flame:1948:/
+1138.9 "Searing Wind" sync / 1[56]:[^:]*:Liquid Flame:1948:/
 1149.1 "Form Shift"
 
 # Tornado Form
 1200.0 "--sync--" sync /00:....:The liquid flame gains the effect of Anemomorph/ window 200,0
-1204.5 "Bibliocide" sync / 1[56]:Liquid Flame:1945:/ window 10,10
-1215.4 "Magnetism/Repel?" sync / 1[56]:Liquid Flame:194[CD]:/
-1226.9 "Bibliocide" sync / 1[56]:Liquid Flame:1945:/
-1237.8 "Magnetism/Repel" sync / 1[56]:Liquid Flame:194[CD]:/
+1204.5 "Bibliocide" sync / 1[56]:[^:]*:Liquid Flame:1945:/ window 10,10
+1215.4 "Magnetism/Repel?" sync / 1[56]:[^:]*:Liquid Flame:194[CD]:/
+1226.9 "Bibliocide" sync / 1[56]:[^:]*:Liquid Flame:1945:/
+1237.8 "Magnetism/Repel" sync / 1[56]:[^:]*:Liquid Flame:194[CD]:/
 1246.1 "Form Shift"
 
 # Human Form
 1300.0 "--sync--" sync /00:....:The liquid flame gains the effect of Anthropomorph/ window 300,10
-1307.5 "Searing Wind" sync / 1[56]:Liquid Flame:1944:/ window 10,20
-1314.7 "Bibliocide" sync / 1[56]:Liquid Flame:1945:/
+1307.5 "Searing Wind" sync / 1[56]:[^:]*:Liquid Flame:1944:/ window 10,20
+1314.7 "Bibliocide" sync / 1[56]:[^:]*:Liquid Flame:1945:/
 1326.0 "Sea Of Flames x3"
-1331.3 "Slosh" sync / 1[56]:Liquid Flame:1947:/ window 10,10
-1335.5 "Searing Wind" sync / 1[56]:Liquid Flame:1944:/
-1343.8 "Bibliocide" sync / 1[56]:Liquid Flame:1945:/
+1331.3 "Slosh" sync / 1[56]:[^:]*:Liquid Flame:1947:/ window 10,10
+1335.5 "Searing Wind" sync / 1[56]:[^:]*:Liquid Flame:1944:/
+1343.8 "Bibliocide" sync / 1[56]:[^:]*:Liquid Flame:1945:/
 
-1355.2 "Searing Wind" sync / 1[56]:Liquid Flame:1944:/ window 10,20
-1362.4 "Bibliocide" sync / 1[56]:Liquid Flame:1945:/
+1355.2 "Searing Wind" sync / 1[56]:[^:]*:Liquid Flame:1944:/ window 10,20
+1362.4 "Bibliocide" sync / 1[56]:[^:]*:Liquid Flame:1945:/
 1373.8 "Sea Of Flames x3"
-1379.0 "Slosh" sync / 1[56]:Liquid Flame:1947:/ window 10,10
-1383.2 "Searing Wind" sync / 1[56]:Liquid Flame:1944:/
-1391.5 "Bibliocide" sync / 1[56]:Liquid Flame:1945:/ jump 1343.8
+1379.0 "Slosh" sync / 1[56]:[^:]*:Liquid Flame:1947:/ window 10,10
+1383.2 "Searing Wind" sync / 1[56]:[^:]*:Liquid Flame:1944:/
+1391.5 "Bibliocide" sync / 1[56]:[^:]*:Liquid Flame:1945:/ jump 1343.8
 
 1402.9 "Searing Wind"
 1410.1 "Bibliocide"
@@ -108,47 +108,47 @@ hideall "--sync--"
 # -ii 194F 1950 1958 195B 1969
 
 2000.0 "--sync--" sync / 00:0839::The Rare Tomes Room will be sealed off/ window 2000,5
-2009.2 "Check Out" sync / 1[56]:Strix:194E:/ window 9.2,10
-2017.5 "Properties Of Darkness (buster)" sync / 1[56]:Strix:1954:/
-2029.6 "Properties Of Quakes" sync / 1[56]:Strix:1956:/
-2033.8 "Properties Of Darkness (buster)" sync / 1[56]:Strix:1954:/
-2040.1 "Check Out" sync / 1[56]:Strix:194E:/ window 10,10
-2048.4 "Properties Of Darkness (buster)" sync / 1[56]:Strix:1954:/
-2056.7 "Properties Of Darkness II" sync / 1[56]:Strix:1955:/
-2069.9 "Properties Of Tornados" sync / 1[56]:Strix:1957:/
-2074.2 "Properties Of Darkness (buster)" sync / 1[56]:Strix:1954:/
-2082.4 "Properties Of Imps" sync / 1[56]:Strix:1959:/ window 30,30
-2085.5 "Properties Of Darkness" sync / 1[56]:Strix:1954:/
-2094.7 "Properties Of Thunder III" sync / 1[56]:Strix:195A:/
+2009.2 "Check Out" sync / 1[56]:[^:]*:Strix:194E:/ window 9.2,10
+2017.5 "Properties Of Darkness (buster)" sync / 1[56]:[^:]*:Strix:1954:/
+2029.6 "Properties Of Quakes" sync / 1[56]:[^:]*:Strix:1956:/
+2033.8 "Properties Of Darkness (buster)" sync / 1[56]:[^:]*:Strix:1954:/
+2040.1 "Check Out" sync / 1[56]:[^:]*:Strix:194E:/ window 10,10
+2048.4 "Properties Of Darkness (buster)" sync / 1[56]:[^:]*:Strix:1954:/
+2056.7 "Properties Of Darkness II" sync / 1[56]:[^:]*:Strix:1955:/
+2069.9 "Properties Of Tornados" sync / 1[56]:[^:]*:Strix:1957:/
+2074.2 "Properties Of Darkness (buster)" sync / 1[56]:[^:]*:Strix:1954:/
+2082.4 "Properties Of Imps" sync / 1[56]:[^:]*:Strix:1959:/ window 30,30
+2085.5 "Properties Of Darkness" sync / 1[56]:[^:]*:Strix:1954:/
+2094.7 "Properties Of Thunder III" sync / 1[56]:[^:]*:Strix:195A:/
 
 # Intermission
-2109.2 "Check Out" sync / 1[56]:Strix:194E:/
-2125.6 "Properties Of Darkness (buster)" sync / 1[56]:Strix:1954:/
-2126.1 "--sync--" sync / 1[56]:Meteor:1A6A:/
-2126.7 "Meteor Impact" sync / 1[56]:Behemoth Ward:195E:/
-2133.8 "Properties Of Darkness (buster)" sync / 1[56]:Strix:1954:/
-2135.1 "--sync--" sync / 1[56]:Meteor:1A6A:/
-2135.6 "Meteor Impact" sync / 1[56]:Behemoth Ward:195E:/
-2143.7 "Ecliptic Meteor" sync / 1[56]:Behemoth Ward:195D:/
-2144.7 "--sync--" sync / 1[56]:Behemoth Ward:195C:/
+2109.2 "Check Out" sync / 1[56]:[^:]*:Strix:194E:/
+2125.6 "Properties Of Darkness (buster)" sync / 1[56]:[^:]*:Strix:1954:/
+2126.1 "--sync--" sync / 1[56]:[^:]*:Meteor:1A6A:/
+2126.7 "Meteor Impact" sync / 1[56]:[^:]*:Behemoth Ward:195E:/
+2133.8 "Properties Of Darkness (buster)" sync / 1[56]:[^:]*:Strix:1954:/
+2135.1 "--sync--" sync / 1[56]:[^:]*:Meteor:1A6A:/
+2135.6 "Meteor Impact" sync / 1[56]:[^:]*:Behemoth Ward:195E:/
+2143.7 "Ecliptic Meteor" sync / 1[56]:[^:]*:Behemoth Ward:195D:/
+2144.7 "--sync--" sync / 1[56]:[^:]*:Behemoth Ward:195C:/
 
-2155.0 "Check Out" sync / 1[56]:Strix:194E:/ window 20,20
-2172.3 "Quakes/Tornados" sync / 1[56]:Strix:195[67]:/
-2178.6 "Properties Of Darkness II" sync / 1[56]:Strix:1955:/
-2181.8 "Properties Of Darkness (buster)" sync / 1[56]:Strix:1954:/
-2188.1 "Properties Of Imps" sync / 1[56]:Strix:1959:/ window 30,25
-2196.3 "Properties Of Thunder III" sync / 1[56]:Strix:195A:/
-2203.5 "Properties Of Darkness II" sync / 1[56]:Strix:1955:/
-2207.7 "Properties Of Darkness (buster)" sync / 1[56]:Strix:1954:/
+2155.0 "Check Out" sync / 1[56]:[^:]*:Strix:194E:/ window 20,20
+2172.3 "Quakes/Tornados" sync / 1[56]:[^:]*:Strix:195[67]:/
+2178.6 "Properties Of Darkness II" sync / 1[56]:[^:]*:Strix:1955:/
+2181.8 "Properties Of Darkness (buster)" sync / 1[56]:[^:]*:Strix:1954:/
+2188.1 "Properties Of Imps" sync / 1[56]:[^:]*:Strix:1959:/ window 30,25
+2196.3 "Properties Of Thunder III" sync / 1[56]:[^:]*:Strix:195A:/
+2203.5 "Properties Of Darkness II" sync / 1[56]:[^:]*:Strix:1955:/
+2207.7 "Properties Of Darkness (buster)" sync / 1[56]:[^:]*:Strix:1954:/
 
-2214.9 "Check Out" sync / 1[56]:Strix:194E:/ window 20,20
-2232.3 "Quakes/Tornados" sync / 1[56]:Strix:195[67]:/
-2238.6 "Properties Of Darkness II" sync / 1[56]:Strix:1955:/
-2241.8 "Properties Of Darkness (buster)" sync / 1[56]:Strix:1954:/
-2248.1 "Properties Of Imps" sync / 1[56]:Strix:1959:/ window 30,25
-2256.3 "Properties Of Thunder III" sync / 1[56]:Strix:195A:/
-2263.5 "Properties Of Darkness II" sync / 1[56]:Strix:1955:/
-2267.7 "Properties Of Darkness (buster)" sync / 1[56]:Strix:1954:/ jump 2207.7
+2214.9 "Check Out" sync / 1[56]:[^:]*:Strix:194E:/ window 20,20
+2232.3 "Quakes/Tornados" sync / 1[56]:[^:]*:Strix:195[67]:/
+2238.6 "Properties Of Darkness II" sync / 1[56]:[^:]*:Strix:1955:/
+2241.8 "Properties Of Darkness (buster)" sync / 1[56]:[^:]*:Strix:1954:/
+2248.1 "Properties Of Imps" sync / 1[56]:[^:]*:Strix:1959:/ window 30,25
+2256.3 "Properties Of Thunder III" sync / 1[56]:[^:]*:Strix:195A:/
+2263.5 "Properties Of Darkness II" sync / 1[56]:[^:]*:Strix:1955:/
+2267.7 "Properties Of Darkness (buster)" sync / 1[56]:[^:]*:Strix:1954:/ jump 2207.7
 
 2274.9 "Check Out"
 2292.2 "Quakes/Tornados"

--- a/ui/raidboss/data/03-hw/dungeon/sohm_al.txt
+++ b/ui/raidboss/data/03-hw/dungeon/sohm_al.txt
@@ -10,63 +10,63 @@ hideall "--Reset--"
 # -p ED1:6.2
 
 0 "Start" sync / 00:0839::Greenlinn will be sealed off/ window 0,1
-6.2 "Bloody Caress" sync / 1[56]:Raskovnik:ED1:/ window 6.2,0
-12.3 "--sync--" sync / 1[56]:Raskovnik:ED2:/
-17.9 "Acid Rain" sync / 1[56]:Raskovnik:ED7:/
-26.4 "Phytobeam" sync / 1[56]:Raskovnik:ED5:/
-33.6 "Bloody Caress" sync / 1[56]:Raskovnik:ED1:/ jump 6.2
-39.7 "--sync--" # sync / 1[56]:Raskovnik:ED2:/
-45.3 "Acid Rain" # sync / 1[56]:Raskovnik:ED7:/
-53.9 "Phytobeam" # sync / 1[56]:Raskovnik:ED5:/
-61.1 "Bloody Caress" # sync / 1[56]:Raskovnik:ED1:/
+6.2 "Bloody Caress" sync / 1[56]:[^:]*:Raskovnik:ED1:/ window 6.2,0
+12.3 "--sync--" sync / 1[56]:[^:]*:Raskovnik:ED2:/
+17.9 "Acid Rain" sync / 1[56]:[^:]*:Raskovnik:ED7:/
+26.4 "Phytobeam" sync / 1[56]:[^:]*:Raskovnik:ED5:/
+33.6 "Bloody Caress" sync / 1[56]:[^:]*:Raskovnik:ED1:/ jump 6.2
+39.7 "--sync--" # sync / 1[56]:[^:]*:Raskovnik:ED2:/
+45.3 "Acid Rain" # sync / 1[56]:[^:]*:Raskovnik:ED7:/
+53.9 "Phytobeam" # sync / 1[56]:[^:]*:Raskovnik:ED5:/
+61.1 "Bloody Caress" # sync / 1[56]:[^:]*:Raskovnik:ED1:/
 
 # HP push?
 # Looks like there are two loop groups of skills used repeatly?
 
 # Group 1
-100.0 "--sync--" sync / 14:Raskovnik:1395:/ window 100,0
-103.0 "Sweet Scent" sync / 1[56]:Raskovnik:1395:/ window 103,0
-114.6 "Floral Trap" sync / 1[56]:Raskovnik:1391:/
-119.6 "Flower Devour" sync / 1[56]:Raskovnik:1392:/
-125.4 "Spit" sync / 1[56]:Raskovnik:1393:/
-126.5 "--sync--" sync / 1[56]:Raskovnik:1394:/
+100.0 "--sync--" sync / 14:[^:]*:Raskovnik:1395:/ window 100,0
+103.0 "Sweet Scent" sync / 1[56]:[^:]*:Raskovnik:1395:/ window 103,0
+114.6 "Floral Trap" sync / 1[56]:[^:]*:Raskovnik:1391:/
+119.6 "Flower Devour" sync / 1[56]:[^:]*:Raskovnik:1392:/
+125.4 "Spit" sync / 1[56]:[^:]*:Raskovnik:1393:/
+126.5 "--sync--" sync / 1[56]:[^:]*:Raskovnik:1394:/
 # Inside Loop
 # Raskovnik would use this loop 4 times?
-136.0 "Floral Trap" sync / 1[56]:Raskovnik:1391:/ jump 114.6
-141.0 "Flower Devour" # sync / 1[56]:Raskovnik:1392:/
-146.8 "Spit" # sync / 1[56]:Raskovnik:1393:/
-147.9 "--sync--" # sync / 1[56]:Raskovnik:1394:/
-157.1 "Floral Trap" # sync / 1[56]:Raskovnik:1391:/
-162.1 "Flower Devour" # sync / 1[56]:Raskovnik:1392:/
-167.9 "Spit" # sync / 1[56]:Raskovnik:1393:/
+136.0 "Floral Trap" sync / 1[56]:[^:]*:Raskovnik:1391:/ jump 114.6
+141.0 "Flower Devour" # sync / 1[56]:[^:]*:Raskovnik:1392:/
+146.8 "Spit" # sync / 1[56]:[^:]*:Raskovnik:1393:/
+147.9 "--sync--" # sync / 1[56]:[^:]*:Raskovnik:1394:/
+157.1 "Floral Trap" # sync / 1[56]:[^:]*:Raskovnik:1391:/
+162.1 "Flower Devour" # sync / 1[56]:[^:]*:Raskovnik:1392:/
+167.9 "Spit" # sync / 1[56]:[^:]*:Raskovnik:1393:/
 # Inside Loop
 
 # Loop
-200.0 "--sync--" sync / 14:Raskovnik:1395:/ window 97,0 jump 100.0
-203.0 "Sweet Scent" sync / 1[56]:Raskovnik:1395:/ window 97,0 jump 103.0
-214.8 "Floral Trap" # sync / 1[56]:Raskovnik:1391:/
-219.8 "Flower Devour" # sync / 1[56]:Raskovnik:1392:/
-225.6 "Spit" # sync / 1[56]:Raskovnik:1393:/
-226.7 "--sync--" # sync / 1[56]:Raskovnik:1394:/
+200.0 "--sync--" sync / 14:[^:]*:Raskovnik:1395:/ window 97,0 jump 100.0
+203.0 "Sweet Scent" sync / 1[56]:[^:]*:Raskovnik:1395:/ window 97,0 jump 103.0
+214.8 "Floral Trap" # sync / 1[56]:[^:]*:Raskovnik:1391:/
+219.8 "Flower Devour" # sync / 1[56]:[^:]*:Raskovnik:1392:/
+225.6 "Spit" # sync / 1[56]:[^:]*:Raskovnik:1393:/
+226.7 "--sync--" # sync / 1[56]:[^:]*:Raskovnik:1394:/
 
 # Group 2
-300.0 "--sync--" sync / 14:Raskovnik:ED6:/ window 300,0
-303.0 "Leafstorm" sync / 1[56]:Raskovnik:ED6:/
-308.2 "Bloody Caress" sync / 1[56]:Raskovnik:ED1:/
-314.3 "--sync--" sync / 1[56]:Raskovnik:ED2:/
-319.9 "Acid Rain" sync / 1[56]:Raskovnik:ED7:/
-328.5 "Phytobeam" sync / 1[56]:Raskovnik:ED5:/
-333.7 "Bloody Caress" sync / 1[56]:Raskovnik:ED1:/
+300.0 "--sync--" sync / 14:[^:]*:Raskovnik:ED6:/ window 300,0
+303.0 "Leafstorm" sync / 1[56]:[^:]*:Raskovnik:ED6:/
+308.2 "Bloody Caress" sync / 1[56]:[^:]*:Raskovnik:ED1:/
+314.3 "--sync--" sync / 1[56]:[^:]*:Raskovnik:ED2:/
+319.9 "Acid Rain" sync / 1[56]:[^:]*:Raskovnik:ED7:/
+328.5 "Phytobeam" sync / 1[56]:[^:]*:Raskovnik:ED5:/
+333.7 "Bloody Caress" sync / 1[56]:[^:]*:Raskovnik:ED1:/
 # Loop
-342.8 "Leafstorm" sync / 1[56]:Raskovnik:ED6:/ jump 303.0
-348.0 "Bloody Caress" # sync / 1[56]:Raskovnik:ED1:/
-354.1 "--sync--" # sync / 1[56]:Raskovnik:ED2:/
-359.7 "Acid Rain" # sync / 1[56]:Raskovnik:ED7:/
-368.2 "Phytobeam" # sync / 1[56]:Raskovnik:ED5:/
-373.4 "Bloody Caress" # sync / 1[56]:Raskovnik:ED1:/
+342.8 "Leafstorm" sync / 1[56]:[^:]*:Raskovnik:ED6:/ jump 303.0
+348.0 "Bloody Caress" # sync / 1[56]:[^:]*:Raskovnik:ED1:/
+354.1 "--sync--" # sync / 1[56]:[^:]*:Raskovnik:ED2:/
+359.7 "Acid Rain" # sync / 1[56]:[^:]*:Raskovnik:ED7:/
+368.2 "Phytobeam" # sync / 1[56]:[^:]*:Raskovnik:ED5:/
+373.4 "Bloody Caress" # sync / 1[56]:[^:]*:Raskovnik:ED1:/
 
 # jump back to group 1
-500.0 "--sync--" sync / 14:Raskovnik:1395:/ window 500,0 jump 100.0
+500.0 "--sync--" sync / 14:[^:]*:Raskovnik:1395:/ window 500,0 jump 100.0
 
 
 ### Myath
@@ -75,41 +75,41 @@ hideall "--Reset--"
 
 1000.0 "Start" sync / 00:0839::The Wound will be sealed off/ window 1000,1
 
-1006.1 "Third Leg Forward" sync / 1[56]:Myath:1382:/
-1011.2 "Overbite" sync / 1[56]:Myath:EDB:/
-1019.3 "Razor Scales" sync / 1[56]:Myath:EDC:/
-1024.5 "Third Leg Forward" sync / 1[56]:Myath:1382:/
-1031.6 "Third Leg Forward" sync / 1[56]:Myath:1382:/
-1036.7 "Overbite" sync / 1[56]:Myath:EDB:/
+1006.1 "Third Leg Forward" sync / 1[56]:[^:]*:Myath:1382:/
+1011.2 "Overbite" sync / 1[56]:[^:]*:Myath:EDB:/
+1019.3 "Razor Scales" sync / 1[56]:[^:]*:Myath:EDC:/
+1024.5 "Third Leg Forward" sync / 1[56]:[^:]*:Myath:1382:/
+1031.6 "Third Leg Forward" sync / 1[56]:[^:]*:Myath:1382:/
+1036.7 "Overbite" sync / 1[56]:[^:]*:Myath:EDB:/
 # Loop
-1044.8 "Razor Scales" sync / 1[56]:Myath:EDC:/ jump 1019.3
-1050.0 "Third Leg Forward" # sync / 1[56]:Myath:1382:/
-1057.1 "Third Leg Forward" # sync / 1[56]:Myath:1382:/
-1062.2 "Overbite" # sync / 1[56]:Myath:EDB:/
-1070.3 "Razor Scales" # sync / 1[56]:Myath:EDC:/
-1075.5 "Third Leg Forward" # sync / 1[56]:Myath:1382:/
+1044.8 "Razor Scales" sync / 1[56]:[^:]*:Myath:EDC:/ jump 1019.3
+1050.0 "Third Leg Forward" # sync / 1[56]:[^:]*:Myath:1382:/
+1057.1 "Third Leg Forward" # sync / 1[56]:[^:]*:Myath:1382:/
+1062.2 "Overbite" # sync / 1[56]:[^:]*:Myath:EDB:/
+1070.3 "Razor Scales" # sync / 1[56]:[^:]*:Myath:EDC:/
+1075.5 "Third Leg Forward" # sync / 1[56]:[^:]*:Myath:1382:/
 
 # Myath would use Primordial Roar twice:
 # 1. HP < 90%?
 # 2. HP < 50%? also summon Chyme Of The Mountain
-1200.0 "Primordial Roar" sync / 1[56]:Myath:EE2:/ window 200,0
-1207.1 "Third Leg Forward" sync / 1[56]:Myath:1382:/
-1214.2 "Ensnare" sync / 1[56]:Myath:EDD:/
-1219.2 "Mad Dash" sync / 1[56]:Myath:EE[01]:/
-1221.5 "Ensnare" sync / 1[56]:Myath:EDD:/
-1226.5 "Mad Dash" sync / 1[56]:Myath:EE[01]:/
-1229.0 "Ensnare" sync / 1[56]:Myath:EDD:/
-1236.1 "Mad Dash" sync / 1[56]:Myath:EE[01]:/
-1238.4 "Ensnare" sync / 1[56]:Myath:EDD:/
-1245.4 "Mad Dash" sync / 1[56]:Myath:EE[01]:/
+1200.0 "Primordial Roar" sync / 1[56]:[^:]*:Myath:EE2:/ window 200,0
+1207.1 "Third Leg Forward" sync / 1[56]:[^:]*:Myath:1382:/
+1214.2 "Ensnare" sync / 1[56]:[^:]*:Myath:EDD:/
+1219.2 "Mad Dash" sync / 1[56]:[^:]*:Myath:EE[01]:/
+1221.5 "Ensnare" sync / 1[56]:[^:]*:Myath:EDD:/
+1226.5 "Mad Dash" sync / 1[56]:[^:]*:Myath:EE[01]:/
+1229.0 "Ensnare" sync / 1[56]:[^:]*:Myath:EDD:/
+1236.1 "Mad Dash" sync / 1[56]:[^:]*:Myath:EE[01]:/
+1238.4 "Ensnare" sync / 1[56]:[^:]*:Myath:EDD:/
+1245.4 "Mad Dash" sync / 1[56]:[^:]*:Myath:EE[01]:/
 
 # Jump back to loop
-1249.8 "Third Leg Forward" sync / 1[56]:Myath:1382:/ window 30,5 jump 1006.1
-1254.9 "Overbite" # sync / 1[56]:Myath:EDB:/
-1263.0 "Razor Scales" # sync / 1[56]:Myath:EDC:/
-1268.2 "Third Leg Forward" # sync / 1[56]:Myath:1382:/
-1275.3 "Third Leg Forward" # sync / 1[56]:Myath:1382:/
-1280.4 "Overbite" # sync / 1[56]:Myath:EDB:/
+1249.8 "Third Leg Forward" sync / 1[56]:[^:]*:Myath:1382:/ window 30,5 jump 1006.1
+1254.9 "Overbite" # sync / 1[56]:[^:]*:Myath:EDB:/
+1263.0 "Razor Scales" # sync / 1[56]:[^:]*:Myath:EDC:/
+1268.2 "Third Leg Forward" # sync / 1[56]:[^:]*:Myath:1382:/
+1275.3 "Third Leg Forward" # sync / 1[56]:[^:]*:Myath:1382:/
+1280.4 "Overbite" # sync / 1[56]:[^:]*:Myath:EDB:/
 
 
 ### Tioman
@@ -118,35 +118,35 @@ hideall "--Reset--"
 
 2000.0 "Start" sync / 00:0839::Hess Afah will be sealed off/ window 2000,1
 
-2006.0 "Abyssic Buster" sync / 1[56]:Tioman:EE3:/
-2013.2 "Chaos Blast" sync / 1[56]:Tioman:EE5:/
-2016.5 "--sync--" sync / 1[56]:Tioman:EEB:/
-2020.4 "Abyssic Buster" sync / 1[56]:Tioman:EE3:/
-2030.0 "Comet" sync / 1[56]:Tioman:EE6:/
-2043.7 "Meteor Impact" sync / 1[56]:Tioman:1387:/
+2006.0 "Abyssic Buster" sync / 1[56]:[^:]*:Tioman:EE3:/
+2013.2 "Chaos Blast" sync / 1[56]:[^:]*:Tioman:EE5:/
+2016.5 "--sync--" sync / 1[56]:[^:]*:Tioman:EEB:/
+2020.4 "Abyssic Buster" sync / 1[56]:[^:]*:Tioman:EE3:/
+2030.0 "Comet" sync / 1[56]:[^:]*:Tioman:EE6:/
+2043.7 "Meteor Impact" sync / 1[56]:[^:]*:Tioman:1387:/
 # Loop
-2047.3 "Abyssic Buster" sync / 1[56]:Tioman:EE3:/ jump 2006.0
-2054.5 "Chaos Blast" # sync / 1[56]:Tioman:EE5:/
-2057.8 "--sync--" # sync / 1[56]:Tioman:EEB:/
-2061.7 "Abyssic Buster" # sync / 1[56]:Tioman:EE3:/
-2071.3 "Comet" # sync / 1[56]:Tioman:EE6:/
-2084.9 "Meteor Impact" # sync / 1[56]:Tioman:1387:/
+2047.3 "Abyssic Buster" sync / 1[56]:[^:]*:Tioman:EE3:/ jump 2006.0
+2054.5 "Chaos Blast" # sync / 1[56]:[^:]*:Tioman:EE5:/
+2057.8 "--sync--" # sync / 1[56]:[^:]*:Tioman:EEB:/
+2061.7 "Abyssic Buster" # sync / 1[56]:[^:]*:Tioman:EE3:/
+2071.3 "Comet" # sync / 1[56]:[^:]*:Tioman:EE6:/
+2084.9 "Meteor Impact" # sync / 1[56]:[^:]*:Tioman:1387:/
 
 # 00:0044:Tioman:Arrogant insects! Be crushed beneath the weight of my fury!
-2200.0 "Heavensfall" sync / 1[56]:Tioman:EE7:/ window 200,0
-2223.5 "Dark Star" sync / 1[56]:Tioman:EE4:/ window 5,5
-2246.9 "Dark Star" sync / 1[56]:Tioman:EE4:/ window 5,5
-2270.4 "Dark Star" sync / 1[56]:Tioman:EE4:/ window 5,5 jump 2223.5
-2293.8 "Dark Star" sync / 1[56]:Tioman:EE4:/ window 5,5
-2317.3 "Dark Star" sync / 1[56]:Tioman:EE4:/ window 5,5
+2200.0 "Heavensfall" sync / 1[56]:[^:]*:Tioman:EE7:/ window 200,0
+2223.5 "Dark Star" sync / 1[56]:[^:]*:Tioman:EE4:/ window 5,5
+2246.9 "Dark Star" sync / 1[56]:[^:]*:Tioman:EE4:/ window 5,5
+2270.4 "Dark Star" sync / 1[56]:[^:]*:Tioman:EE4:/ window 5,5 jump 2223.5
+2293.8 "Dark Star" sync / 1[56]:[^:]*:Tioman:EE4:/ window 5,5
+2317.3 "Dark Star" sync / 1[56]:[^:]*:Tioman:EE4:/ window 5,5
 # Tioman keeps using Dark Star every 23.5 seconds,
 # increasing Damage Up stacks, maximum is 16.
 
 # Jump back to normal loop
-2300.0 "--sync--" sync / 1[56]:Tioman:366:/ window 100,0
-2305.6 "Abyssic Buster" sync / 1[56]:Tioman:EE3:/ window 101,5 jump 2006.0
-2312.8 "Chaos Blast" # sync / 1[56]:Tioman:EE5:/
-2316.1 "--sync--" # sync / 1[56]:Tioman:EEB:/
-2320.0 "Abyssic Buster" # sync / 1[56]:Tioman:EE3:/
-2329.6 "Comet" # sync / 1[56]:Tioman:EE6:/
-2343.2 "Meteor Impact" # sync / 1[56]:Tioman:1387:/
+2300.0 "--sync--" sync / 1[56]:[^:]*:Tioman:366:/ window 100,0
+2305.6 "Abyssic Buster" sync / 1[56]:[^:]*:Tioman:EE3:/ window 101,5 jump 2006.0
+2312.8 "Chaos Blast" # sync / 1[56]:[^:]*:Tioman:EE5:/
+2316.1 "--sync--" # sync / 1[56]:[^:]*:Tioman:EEB:/
+2320.0 "Abyssic Buster" # sync / 1[56]:[^:]*:Tioman:EE3:/
+2329.6 "Comet" # sync / 1[56]:[^:]*:Tioman:EE6:/
+2343.2 "Meteor Impact" # sync / 1[56]:[^:]*:Tioman:1387:/

--- a/ui/raidboss/data/03-hw/dungeon/sohm_al_hard.txt
+++ b/ui/raidboss/data/03-hw/dungeon/sohm_al_hard.txt
@@ -13,35 +13,35 @@ hideall "--Reset--"
 # -ic "Spore Sac"
 
 0.0 "--sync--" sync / 00:0839::The Wound will be sealed off/ window 0,1
-2.4 "--sync--" sync / 1[56]:The Leightonward:5B5:/ window 2.4,1
-6.1 "Wild Horn" sync / 1[56]:The Leightonward:1C2D:/ window 6.1,5
-13.2 "Inflammable Fumes (Readies)" sync / 1[56]:The Leightonward:1C30:/
-17.2 "Inflammable Fumes" sync / 1[56]:The Leightonward:1C31:/ window 15,15
-22.4 "Wild Horn" sync / 1[56]:The Leightonward:1C2D:/
-27.5 "Spore Sac" sync / 1[56]:The Leightonward:1C2F:/
-33.6 "Inflammable Fumes (Readies)" sync / 1[56]:The Leightonward:1C30:/
-37.6 "Inflammable Fumes" sync / 1[56]:The Leightonward:1C31:/ window 15,15
-40.7 "Glorious Blaze" sync / 1[56]:Small Spore Sac:1C33:/
-44.9 "Excretion" sync / 1[56]:The Leightonward:1C2E:/
-49.0 "Wild Horn" sync / 1[56]:The Leightonward:1C2D:/
-55.1 "Wild Horn" sync / 1[56]:The Leightonward:1C2D:/
-60.2 "Spore Sac" sync / 1[56]:The Leightonward:1C2F:/
-66.3 "Inflammable Fumes (Readies)" sync / 1[56]:The Leightonward:1C30:/
-70.3 "Inflammable Fumes" sync / 1[56]:The Leightonward:1C31:/ window 15,15
-73.3 "Glorious Blaze" sync / 1[56]:Small Spore Sac:1C33:/
-84.6 "Wild Horn" sync / 1[56]:The Leightonward:1C2D:/
+2.4 "--sync--" sync / 1[56]:[^:]*:The Leightonward:5B5:/ window 2.4,1
+6.1 "Wild Horn" sync / 1[56]:[^:]*:The Leightonward:1C2D:/ window 6.1,5
+13.2 "Inflammable Fumes (Readies)" sync / 1[56]:[^:]*:The Leightonward:1C30:/
+17.2 "Inflammable Fumes" sync / 1[56]:[^:]*:The Leightonward:1C31:/ window 15,15
+22.4 "Wild Horn" sync / 1[56]:[^:]*:The Leightonward:1C2D:/
+27.5 "Spore Sac" sync / 1[56]:[^:]*:The Leightonward:1C2F:/
+33.6 "Inflammable Fumes (Readies)" sync / 1[56]:[^:]*:The Leightonward:1C30:/
+37.6 "Inflammable Fumes" sync / 1[56]:[^:]*:The Leightonward:1C31:/ window 15,15
+40.7 "Glorious Blaze" sync / 1[56]:[^:]*:Small Spore Sac:1C33:/
+44.9 "Excretion" sync / 1[56]:[^:]*:The Leightonward:1C2E:/
+49.0 "Wild Horn" sync / 1[56]:[^:]*:The Leightonward:1C2D:/
+55.1 "Wild Horn" sync / 1[56]:[^:]*:The Leightonward:1C2D:/
+60.2 "Spore Sac" sync / 1[56]:[^:]*:The Leightonward:1C2F:/
+66.3 "Inflammable Fumes (Readies)" sync / 1[56]:[^:]*:The Leightonward:1C30:/
+70.3 "Inflammable Fumes" sync / 1[56]:[^:]*:The Leightonward:1C31:/ window 15,15
+73.3 "Glorious Blaze" sync / 1[56]:[^:]*:Small Spore Sac:1C33:/
+84.6 "Wild Horn" sync / 1[56]:[^:]*:The Leightonward:1C2D:/
 
-92.9 "Excretion" sync / 1[56]:The Leightonward:1C2E:/
-98.0 "Spore Sac" sync / 1[56]:The Leightonward:1C2F:/
-104.2 "Inflammable Fumes (Readies)" sync / 1[56]:The Leightonward:1C30:/
-108.2 "Inflammable Fumes" sync / 1[56]:The Leightonward:1C31:/ window 15,15
-111.2 "Glorious Blaze" sync / 1[56]:Small Spore Sac:1C33:/
-124.4 "Wild Horn" sync / 1[56]:The Leightonward:1C2D:/
-130.5 "Wild Horn" sync / 1[56]:The Leightonward:1C2D:/
-137.6 "Inflammable Fumes (Readies)" sync / 1[56]:The Leightonward:1C30:/
-141.6 "Inflammable Fumes" sync / 1[56]:The Leightonward:1C31:/ window 15,15
-143.8 "Wild Horn" sync / 1[56]:The Leightonward:1C2D:/
-150.0 "Wild Horn" sync / 1[56]:The Leightonward:1C2D:/ jump 84.6
+92.9 "Excretion" sync / 1[56]:[^:]*:The Leightonward:1C2E:/
+98.0 "Spore Sac" sync / 1[56]:[^:]*:The Leightonward:1C2F:/
+104.2 "Inflammable Fumes (Readies)" sync / 1[56]:[^:]*:The Leightonward:1C30:/
+108.2 "Inflammable Fumes" sync / 1[56]:[^:]*:The Leightonward:1C31:/ window 15,15
+111.2 "Glorious Blaze" sync / 1[56]:[^:]*:Small Spore Sac:1C33:/
+124.4 "Wild Horn" sync / 1[56]:[^:]*:The Leightonward:1C2D:/
+130.5 "Wild Horn" sync / 1[56]:[^:]*:The Leightonward:1C2D:/
+137.6 "Inflammable Fumes (Readies)" sync / 1[56]:[^:]*:The Leightonward:1C30:/
+141.6 "Inflammable Fumes" sync / 1[56]:[^:]*:The Leightonward:1C31:/ window 15,15
+143.8 "Wild Horn" sync / 1[56]:[^:]*:The Leightonward:1C2D:/
+150.0 "Wild Horn" sync / 1[56]:[^:]*:The Leightonward:1C2D:/ jump 84.6
 
 # The timing from Wild Horn to Excretion is the same no matter
 # whether the lead block is the opener or the rotation block.
@@ -65,41 +65,41 @@ hideall "--Reset--"
 # -ii 1C3F
 
 2000.0 "--sync--" sync / 00:0839::The Lava Tube will be sealed off/ window 2000,1
-2001.2 "--sync--" sync / 1[56]:Lava Scorpion:366:/ window 1.2,2
-2012.0 "Molten Silk (Front)" sync / 1[56]:Lava Scorpion:1C43:/ window 12,5
-2022.2 "Flying Press" sync / 1[56]:Lava Scorpion:1C3E:/
-2038.4 "Deadly Thrust" sync / 1[56]:Lava Scorpion:1C40:/
-2045.6 "Hiss (Adds x2)" sync / 1[56]:Lava Scorpion:1C45:/ window 15,15
-2068.8 "Realm Shaker" sync / 1[56]:Lava Scorpion:1C41:/
-2079.4 "Flying Press" sync / 1[56]:Lava Scorpion:1C3E:/
-2091.6 "Deadly Thrust" sync / 1[56]:Lava Scorpion:1C40:/
-2101.8 "Molten Silk (Front)" sync / 1[56]:Lava Scorpion:1C43:/
-2106.9 "Molten Silk (Back)" sync / 1[56]:Lava Scorpion:1C44:/
-2118.6 "Hiss (Adds x4)" sync / 1[56]:Lava Scorpion:1C45:/ window 15,15
-2123.7 "Molten Silk (Ring)" sync / 1[56]:Lava Scorpion:1C42:/
-2129.8 "Deadly Thrust" sync / 1[56]:Lava Scorpion:1C40:/
-2150.0 "Flying Press" sync / 1[56]:Lava Scorpion:1C3E:/
-2156.1 "Flying Press" sync / 1[56]:Lava Scorpion:1C3E:/
-2167.3 "Molten Silk (Front)" sync / 1[56]:Lava Scorpion:1C43:/
-2172.4 "Molten Silk (Back)" sync / 1[56]:Lava Scorpion:1C44:/
-2182.0 "Deadly Thrust" sync / 1[56]:Lava Scorpion:1C40:/
-2187.1 "Flying Press" sync / 1[56]:Lava Scorpion:1C3E:/
+2001.2 "--sync--" sync / 1[56]:[^:]*:Lava Scorpion:366:/ window 1.2,2
+2012.0 "Molten Silk (Front)" sync / 1[56]:[^:]*:Lava Scorpion:1C43:/ window 12,5
+2022.2 "Flying Press" sync / 1[56]:[^:]*:Lava Scorpion:1C3E:/
+2038.4 "Deadly Thrust" sync / 1[56]:[^:]*:Lava Scorpion:1C40:/
+2045.6 "Hiss (Adds x2)" sync / 1[56]:[^:]*:Lava Scorpion:1C45:/ window 15,15
+2068.8 "Realm Shaker" sync / 1[56]:[^:]*:Lava Scorpion:1C41:/
+2079.4 "Flying Press" sync / 1[56]:[^:]*:Lava Scorpion:1C3E:/
+2091.6 "Deadly Thrust" sync / 1[56]:[^:]*:Lava Scorpion:1C40:/
+2101.8 "Molten Silk (Front)" sync / 1[56]:[^:]*:Lava Scorpion:1C43:/
+2106.9 "Molten Silk (Back)" sync / 1[56]:[^:]*:Lava Scorpion:1C44:/
+2118.6 "Hiss (Adds x4)" sync / 1[56]:[^:]*:Lava Scorpion:1C45:/ window 15,15
+2123.7 "Molten Silk (Ring)" sync / 1[56]:[^:]*:Lava Scorpion:1C42:/
+2129.8 "Deadly Thrust" sync / 1[56]:[^:]*:Lava Scorpion:1C40:/
+2150.0 "Flying Press" sync / 1[56]:[^:]*:Lava Scorpion:1C3E:/
+2156.1 "Flying Press" sync / 1[56]:[^:]*:Lava Scorpion:1C3E:/
+2167.3 "Molten Silk (Front)" sync / 1[56]:[^:]*:Lava Scorpion:1C43:/
+2172.4 "Molten Silk (Back)" sync / 1[56]:[^:]*:Lava Scorpion:1C44:/
+2182.0 "Deadly Thrust" sync / 1[56]:[^:]*:Lava Scorpion:1C40:/
+2187.1 "Flying Press" sync / 1[56]:[^:]*:Lava Scorpion:1C3E:/
 
-2196.3 "Realm Shaker" sync / 1[56]:Lava Scorpion:1C41:/ window 15,15
-2202.0 "Molten Silk (Ring)" sync / 1[56]:Lava Scorpion:1C42:/
-2211.2 "Hiss (Adds x2)" sync / 1[56]:Lava Scorpion:1C45:/
-2221.3 "Deadly Thrust" sync / 1[56]:Lava Scorpion:1C40:/
-2231.5 "Molten Silk (Back)" sync / 1[56]:Lava Scorpion:1C44:/
-2237.1 "Molten Silk (Front)" sync / 1[56]:Lava Scorpion:1C43:/
-2246.3 "Deadly Thrust" sync / 1[56]:Lava Scorpion:1C40:/
+2196.3 "Realm Shaker" sync / 1[56]:[^:]*:Lava Scorpion:1C41:/ window 15,15
+2202.0 "Molten Silk (Ring)" sync / 1[56]:[^:]*:Lava Scorpion:1C42:/
+2211.2 "Hiss (Adds x2)" sync / 1[56]:[^:]*:Lava Scorpion:1C45:/
+2221.3 "Deadly Thrust" sync / 1[56]:[^:]*:Lava Scorpion:1C40:/
+2231.5 "Molten Silk (Back)" sync / 1[56]:[^:]*:Lava Scorpion:1C44:/
+2237.1 "Molten Silk (Front)" sync / 1[56]:[^:]*:Lava Scorpion:1C43:/
+2246.3 "Deadly Thrust" sync / 1[56]:[^:]*:Lava Scorpion:1C40:/
 
-2254.5 "Realm Shaker" sync / 1[56]:Lava Scorpion:1C41:/ window 15,15
-2260.2 "Molten Silk (Ring)" sync / 1[56]:Lava Scorpion:1C42:/
-2269.4 "Hiss (Adds x2)" sync / 1[56]:Lava Scorpion:1C45:/
-2279.5 "Deadly Thrust" sync / 1[56]:Lava Scorpion:1C40:/
-2289.7 "Molten Silk (Back)" sync / 1[56]:Lava Scorpion:1C44:/
-2295.3 "Molten Silk (Front)" sync / 1[56]:Lava Scorpion:1C43:/
-2304.5 "Deadly Thrust" sync / 1[56]:Lava Scorpion:1C40:/ jump 2246.3
+2254.5 "Realm Shaker" sync / 1[56]:[^:]*:Lava Scorpion:1C41:/ window 15,15
+2260.2 "Molten Silk (Ring)" sync / 1[56]:[^:]*:Lava Scorpion:1C42:/
+2269.4 "Hiss (Adds x2)" sync / 1[56]:[^:]*:Lava Scorpion:1C45:/
+2279.5 "Deadly Thrust" sync / 1[56]:[^:]*:Lava Scorpion:1C40:/
+2289.7 "Molten Silk (Back)" sync / 1[56]:[^:]*:Lava Scorpion:1C44:/
+2295.3 "Molten Silk (Front)" sync / 1[56]:[^:]*:Lava Scorpion:1C43:/
+2304.5 "Deadly Thrust" sync / 1[56]:[^:]*:Lava Scorpion:1C40:/ jump 2246.3
 
 2312.7 "Realm Shaker"
 2318.4 "Molten Silk (Ring)"

--- a/ui/raidboss/data/03-hw/dungeon/the_vault.txt
+++ b/ui/raidboss/data/03-hw/dungeon/the_vault.txt
@@ -10,14 +10,14 @@ hideall "--sync--"
 # Barely worth including, but oh well.
 
 0.0 "--sync--" sync / 00:0839::The Quire will be sealed off/ window 0,1
-5.4 "Fast Blade" sync / 1[56]:Ser Adelphel Brightblade:2CD:/ window 5.4,5
-12.5 "Bloodstain" sync / 1[56]:Ser Adelphel Brightblade:44B:/
-15.8 "Fast Blade" sync / 1[56]:Ser Adelphel Brightblade:2CD:/
-26.5 "Fast Blade" sync / 1[56]:Ser Adelphel Brightblade:2CD:/
+5.4 "Fast Blade" sync / 1[56]:[^:]*:Ser Adelphel Brightblade:2CD:/ window 5.4,5
+12.5 "Bloodstain" sync / 1[56]:[^:]*:Ser Adelphel Brightblade:44B:/
+15.8 "Fast Blade" sync / 1[56]:[^:]*:Ser Adelphel Brightblade:2CD:/
+26.5 "Fast Blade" sync / 1[56]:[^:]*:Ser Adelphel Brightblade:2CD:/
 
-33.6 "Bloodstain" sync / 1[56]:Ser Adelphel Brightblade:44B:/ window 10,10
-36.8 "Fast Blade" sync / 1[56]:Ser Adelphel Brightblade:2CD:/
-47.5 "Fast Blade" sync / 1[56]:Ser Adelphel Brightblade:2CD:/ jump 26.5
+33.6 "Bloodstain" sync / 1[56]:[^:]*:Ser Adelphel Brightblade:44B:/ window 10,10
+36.8 "Fast Blade" sync / 1[56]:[^:]*:Ser Adelphel Brightblade:2CD:/
+47.5 "Fast Blade" sync / 1[56]:[^:]*:Ser Adelphel Brightblade:2CD:/ jump 26.5
 
 54.7 "Bloodstain"
 57.8 "Fast Blade"
@@ -25,20 +25,20 @@ hideall "--sync--"
 
 # Phase 1
 
-100.0 "Advent" sync / 1[56]:Ser Adelphel Brightblade:1373:/ window 100,30
-102.1 "Advent" sync / 1[56]:Ser Adelphel Brightblade:101A:/
+100.0 "Advent" sync / 1[56]:[^:]*:Ser Adelphel Brightblade:1373:/ window 100,30
+102.1 "Advent" sync / 1[56]:[^:]*:Ser Adelphel Brightblade:101A:/
 
-110.3 "Holiest Of Holy" sync / 1[56]:Ser Adelphel:101E:/
-114.5 "Heavenly Slash" sync / 1[56]:Ser Adelphel:101D:/
-122.8 "Holy Shield Bash" sync / 1[56]:Ser Adelphel:101F:/ window 10,10
-123.9 "Solid Ascension x2" sync / 1[56]:Ser Adelphel:1020:/
-131.8 "Heavenly Slash" sync / 1[56]:Ser Adelphel:101D:/
+110.3 "Holiest Of Holy" sync / 1[56]:[^:]*:Ser Adelphel:101E:/
+114.5 "Heavenly Slash" sync / 1[56]:[^:]*:Ser Adelphel:101D:/
+122.8 "Holy Shield Bash" sync / 1[56]:[^:]*:Ser Adelphel:101F:/ window 10,10
+123.9 "Solid Ascension x2" sync / 1[56]:[^:]*:Ser Adelphel:1020:/
+131.8 "Heavenly Slash" sync / 1[56]:[^:]*:Ser Adelphel:101D:/
 
-140.0 "Holiest Of Holy" sync / 1[56]:Ser Adelphel:101E:/
-144.2 "Heavenly Slash" sync / 1[56]:Ser Adelphel:101D:/
-152.5 "Holy Shield Bash" sync / 1[56]:Ser Adelphel:101F:/ window 10,10
-153.6 "Solid Ascension x2" sync / 1[56]:Ser Adelphel:1020:/
-161.5 "Heavenly Slash" sync / 1[56]:Ser Adelphel:101D:/ window 10,5 jump 131.8
+140.0 "Holiest Of Holy" sync / 1[56]:[^:]*:Ser Adelphel:101E:/
+144.2 "Heavenly Slash" sync / 1[56]:[^:]*:Ser Adelphel:101D:/
+152.5 "Holy Shield Bash" sync / 1[56]:[^:]*:Ser Adelphel:101F:/ window 10,10
+153.6 "Solid Ascension x2" sync / 1[56]:[^:]*:Ser Adelphel:1020:/
+161.5 "Heavenly Slash" sync / 1[56]:[^:]*:Ser Adelphel:101D:/ window 10,5 jump 131.8
 
 169.7 "Holiest Of Holy"
 173.9 "Heavenly Slash"
@@ -48,33 +48,33 @@ hideall "--sync--"
 
 # Phase 2 at < 70% HP
 
-300.0 "Shining Blade 1" sync / 1[56]:Ser Adelphel:1022:/ window 300,0
-302.4 "Shining Blade 2" sync / 1[56]:Ser Adelphel:1022:/ window 2,2
-304.6 "Shining Blade 3" sync / 1[56]:Ser Adelphel:1022:/ window 2,2
-307.0 "Shining Blade 4" sync / 1[56]:Ser Adelphel:1022:/ window 2,2
+300.0 "Shining Blade 1" sync / 1[56]:[^:]*:Ser Adelphel:1022:/ window 300,0
+302.4 "Shining Blade 2" sync / 1[56]:[^:]*:Ser Adelphel:1022:/ window 2,2
+304.6 "Shining Blade 3" sync / 1[56]:[^:]*:Ser Adelphel:1022:/ window 2,2
+307.0 "Shining Blade 4" sync / 1[56]:[^:]*:Ser Adelphel:1022:/ window 2,2
 309.0 "--Untargetable--"
 311.7 "--Targetable--"
-311.7 "Execution" sync / 1[56]:Ser Adelphel:1023:/
-322.8 "Holiest Of Holy" sync / 1[56]:Ser Adelphel:101E:/
-328.0 "Heavenly Slash" sync / 1[56]:Ser Adelphel:101D:/
-337.2 "Holy Shield Bash" sync / 1[56]:Ser Adelphel:101F:/ window 15,15
-338.3 "Solid Ascension x2" sync / 1[56]:Ser Adelphel:1020:/
-349.1 "Holiest Of Holy" sync / 1[56]:Ser Adelphel:101E:/
-353.3 "Heavenly Slash" sync / 1[56]:Ser Adelphel:101D:/
+311.7 "Execution" sync / 1[56]:[^:]*:Ser Adelphel:1023:/
+322.8 "Holiest Of Holy" sync / 1[56]:[^:]*:Ser Adelphel:101E:/
+328.0 "Heavenly Slash" sync / 1[56]:[^:]*:Ser Adelphel:101D:/
+337.2 "Holy Shield Bash" sync / 1[56]:[^:]*:Ser Adelphel:101F:/ window 15,15
+338.3 "Solid Ascension x2" sync / 1[56]:[^:]*:Ser Adelphel:1020:/
+349.1 "Holiest Of Holy" sync / 1[56]:[^:]*:Ser Adelphel:101E:/
+353.3 "Heavenly Slash" sync / 1[56]:[^:]*:Ser Adelphel:101D:/
 
-357.4 "Shining Blade 1" sync / 1[56]:Ser Adelphel:1022:/ window 2,2
-359.8 "Shining Blade 2" sync / 1[56]:Ser Adelphel:1022:/ window 2,2
-362.0 "Shining Blade 3" sync / 1[56]:Ser Adelphel:1022:/ window 2,2 
-364.4 "Shining Blade 4" sync / 1[56]:Ser Adelphel:1022:/ window 2,2
+357.4 "Shining Blade 1" sync / 1[56]:[^:]*:Ser Adelphel:1022:/ window 2,2
+359.8 "Shining Blade 2" sync / 1[56]:[^:]*:Ser Adelphel:1022:/ window 2,2
+362.0 "Shining Blade 3" sync / 1[56]:[^:]*:Ser Adelphel:1022:/ window 2,2 
+364.4 "Shining Blade 4" sync / 1[56]:[^:]*:Ser Adelphel:1022:/ window 2,2
 366.4 "--Untargetable--"
 369.0 "--Targetable--"
-369.1 "Execution" sync / 1[56]:Ser Adelphel:1023:/
-380.2 "Holiest Of Holy" sync / 1[56]:Ser Adelphel:101E:/
-385.4 "Heavenly Slash" sync / 1[56]:Ser Adelphel:101D:/
-394.6 "Holy Shield Bash" sync / 1[56]:Ser Adelphel:101F:/ window 15,15
-395.7 "Solid Ascension x2" sync / 1[56]:Ser Adelphel:1020:/
-406.5 "Holiest Of Holy" sync / 1[56]:Ser Adelphel:101E:/
-410.7 "Heavenly Slash" sync / 1[56]:Ser Adelphel:101D:/ window 15,15 jump 353.3
+369.1 "Execution" sync / 1[56]:[^:]*:Ser Adelphel:1023:/
+380.2 "Holiest Of Holy" sync / 1[56]:[^:]*:Ser Adelphel:101E:/
+385.4 "Heavenly Slash" sync / 1[56]:[^:]*:Ser Adelphel:101D:/
+394.6 "Holy Shield Bash" sync / 1[56]:[^:]*:Ser Adelphel:101F:/ window 15,15
+395.7 "Solid Ascension x2" sync / 1[56]:[^:]*:Ser Adelphel:1020:/
+406.5 "Holiest Of Holy" sync / 1[56]:[^:]*:Ser Adelphel:101E:/
+410.7 "Heavenly Slash" sync / 1[56]:[^:]*:Ser Adelphel:101D:/ window 15,15 jump 353.3
 
 414.8 "Shining Blade 1"
 417.2 "Shining Blade 2"
@@ -84,90 +84,90 @@ hideall "--sync--"
 437.6 "Holiest Of Holy"
 
 # Closing sequence
-441.9 "--sync--" sync / 1[56]:Ser Adelphel Brightblade:10A0:/ window 450,0
+441.9 "--sync--" sync / 1[56]:[^:]*:Ser Adelphel Brightblade:10A0:/ window 450,0
 442.0 "Retreating" duration 8.0
-450 "Retreat" sync / 1[56]:Ser Adelphel Brightblade:10A1:/
+450 "Retreat" sync / 1[56]:[^:]*:Ser Adelphel Brightblade:10A1:/
 
 ###Ser Grinneaux the Bull
 # -ii 101A
 
 # Pre-phase
 1000 "--sync--" sync / 00:0839::The chapter house will be sealed off/ window 1000,1
-1006.7 "Overpower" sync / 1[56]:Ser Grinnaux the Bull:88C:/ window 6.7,5
-1015.6 "Rive" sync / 1[56]:Ser Grinnaux the Bull:46F:/
-1018.9 "Overpower" sync / 1[56]:Ser Grinnaux the Bull:88C:/
-1031.2 "Overpower" sync / 1[56]:Ser Grinnaux the Bull:88C:/
-1039.9 "Rive" sync / 1[56]:Ser Grinnaux the Bull:46F:/
+1006.7 "Overpower" sync / 1[56]:[^:]*:Ser Grinnaux the Bull:88C:/ window 6.7,5
+1015.6 "Rive" sync / 1[56]:[^:]*:Ser Grinnaux the Bull:46F:/
+1018.9 "Overpower" sync / 1[56]:[^:]*:Ser Grinnaux the Bull:88C:/
+1031.2 "Overpower" sync / 1[56]:[^:]*:Ser Grinnaux the Bull:88C:/
+1039.9 "Rive" sync / 1[56]:[^:]*:Ser Grinnaux the Bull:46F:/
 
-1043.2 "Overpower" sync / 1[56]:Ser Grinnaux the Bull:88C:/
-1055.5 "Overpower" sync / 1[56]:Ser Grinnaux the Bull:88C:/
-1064.2 "Rive" sync / 1[56]:Ser Grinnaux the Bull:46F:/ window 15,15 jump 1039.9
+1043.2 "Overpower" sync / 1[56]:[^:]*:Ser Grinnaux the Bull:88C:/
+1055.5 "Overpower" sync / 1[56]:[^:]*:Ser Grinnaux the Bull:88C:/
+1064.2 "Rive" sync / 1[56]:[^:]*:Ser Grinnaux the Bull:46F:/ window 15,15 jump 1039.9
 
 1067.5 "Overpower"
 1079.8 "Overpower"
 1088.5 "Rive"
 
 # Phase transition
-1100.0 "Advent" sync / 1[56]:Ser Grinnaux the Bull:1373:/ window 100,5
-1101.0 "Advent" sync / 1[56]:Ser Grinnaux:1374:/
-1101.9 "--sync--" sync / 1[56]:Ser Grinnaux:101B:/
+1100.0 "Advent" sync / 1[56]:[^:]*:Ser Grinnaux the Bull:1373:/ window 100,5
+1101.0 "Advent" sync / 1[56]:[^:]*:Ser Grinnaux:1374:/
+1101.9 "--sync--" sync / 1[56]:[^:]*:Ser Grinnaux:101B:/
 
 # Main Phase
-1109.6 "Dimensional Collapse" sync / 1[56]:Ser Grinnaux:1028:/
-1113.7 "Heavy Swing" sync / 1[56]:Ser Grinnaux:1025:/
-1118.0 "Heavy Swing" sync / 1[56]:Ser Grinnaux:1025:/
-1125.1 "Hyperdimensional Slash" sync / 1[56]:Ser Grinnaux:1026:/
-1130.3 "Hyperdimensional Slash" sync / 1[56]:Ser Grinnaux:1026:/
-1134.4 "Heavy Swing" sync / 1[56]:Ser Grinnaux:1025:/
-1139.4 "Faith Unmoving" sync / 1[56]:Ser Grinnaux:1027:/ window 15,15
+1109.6 "Dimensional Collapse" sync / 1[56]:[^:]*:Ser Grinnaux:1028:/
+1113.7 "Heavy Swing" sync / 1[56]:[^:]*:Ser Grinnaux:1025:/
+1118.0 "Heavy Swing" sync / 1[56]:[^:]*:Ser Grinnaux:1025:/
+1125.1 "Hyperdimensional Slash" sync / 1[56]:[^:]*:Ser Grinnaux:1026:/
+1130.3 "Hyperdimensional Slash" sync / 1[56]:[^:]*:Ser Grinnaux:1026:/
+1134.4 "Heavy Swing" sync / 1[56]:[^:]*:Ser Grinnaux:1025:/
+1139.4 "Faith Unmoving" sync / 1[56]:[^:]*:Ser Grinnaux:1027:/ window 15,15
 
-1144.1 "Dimensional Collapse" sync / 1[56]:Ser Grinnaux:1028:/
-1152.3 "Dimensional Rip" sync / 1[56]:Ser Grinnaux:102C:/
-1155.5 "Heavy Swing" sync / 1[56]:Ser Grinnaux:1025:/
-1161.6 "Hyperdimensional Slash" sync / 1[56]:Ser Grinnaux:1026:/
-1166.8 "Hyperdimensional Slash" sync / 1[56]:Ser Grinnaux:1026:/
-1170.8 "Heavy Swing" sync / 1[56]:Ser Grinnaux:1025:/
-1177.4 "Dimensional Collapse" sync / 1[56]:Ser Grinnaux:1028:/ window 15,15
-1182.5 "Faith Unmoving" sync / 1[56]:Ser Grinnaux:1027:/ 
+1144.1 "Dimensional Collapse" sync / 1[56]:[^:]*:Ser Grinnaux:1028:/
+1152.3 "Dimensional Rip" sync / 1[56]:[^:]*:Ser Grinnaux:102C:/
+1155.5 "Heavy Swing" sync / 1[56]:[^:]*:Ser Grinnaux:1025:/
+1161.6 "Hyperdimensional Slash" sync / 1[56]:[^:]*:Ser Grinnaux:1026:/
+1166.8 "Hyperdimensional Slash" sync / 1[56]:[^:]*:Ser Grinnaux:1026:/
+1170.8 "Heavy Swing" sync / 1[56]:[^:]*:Ser Grinnaux:1025:/
+1177.4 "Dimensional Collapse" sync / 1[56]:[^:]*:Ser Grinnaux:1028:/ window 15,15
+1182.5 "Faith Unmoving" sync / 1[56]:[^:]*:Ser Grinnaux:1027:/ 
 
-1192.7 "Dimensional Rip" sync / 1[56]:Ser Grinnaux:102C:/ window 15,15
-1195.9 "Heavy Swing" sync / 1[56]:Ser Grinnaux:1025:/
-1202.1 "Hyperdimensional Slash" sync / 1[56]:Ser Grinnaux:1026:/
-1207.9 "Hyperdimensional Slash" sync / 1[56]:Ser Grinnaux:1026:/
-1212.1 "Heavy Swing" sync / 1[56]:Ser Grinnaux:1025:/
-1218.7 "Dimensional Collapse" sync / 1[56]:Ser Grinnaux:1028:/ window 15,15
-1223.8 "Faith Unmoving" sync / 1[56]:Ser Grinnaux:1027:/
+1192.7 "Dimensional Rip" sync / 1[56]:[^:]*:Ser Grinnaux:102C:/ window 15,15
+1195.9 "Heavy Swing" sync / 1[56]:[^:]*:Ser Grinnaux:1025:/
+1202.1 "Hyperdimensional Slash" sync / 1[56]:[^:]*:Ser Grinnaux:1026:/
+1207.9 "Hyperdimensional Slash" sync / 1[56]:[^:]*:Ser Grinnaux:1026:/
+1212.1 "Heavy Swing" sync / 1[56]:[^:]*:Ser Grinnaux:1025:/
+1218.7 "Dimensional Collapse" sync / 1[56]:[^:]*:Ser Grinnaux:1028:/ window 15,15
+1223.8 "Faith Unmoving" sync / 1[56]:[^:]*:Ser Grinnaux:1027:/
 
-1234.0 "Dimensional Rip" sync / 1[56]:Ser Grinnaux:102C:/ window 15,15
-1237.1 "Heavy Swing" sync / 1[56]:Ser Grinnaux:1025:/
-1243.3 "Hyperdimensional Slash" sync / 1[56]:Ser Grinnaux:1026:/
-1248.8 "Hyperdimensional Slash" sync / 1[56]:Ser Grinnaux:1026:/
-1253.0 "Heavy Swing" sync / 1[56]:Ser Grinnaux:1025:/
-1259.6 "Dimensional Collapse" sync / 1[56]:Ser Grinnaux:1028:/ window 15,15
-1264.7 "Faith Unmoving" sync / 1[56]:Ser Grinnaux:1027:/ jump 1182.5
+1234.0 "Dimensional Rip" sync / 1[56]:[^:]*:Ser Grinnaux:102C:/ window 15,15
+1237.1 "Heavy Swing" sync / 1[56]:[^:]*:Ser Grinnaux:1025:/
+1243.3 "Hyperdimensional Slash" sync / 1[56]:[^:]*:Ser Grinnaux:1026:/
+1248.8 "Hyperdimensional Slash" sync / 1[56]:[^:]*:Ser Grinnaux:1026:/
+1253.0 "Heavy Swing" sync / 1[56]:[^:]*:Ser Grinnaux:1025:/
+1259.6 "Dimensional Collapse" sync / 1[56]:[^:]*:Ser Grinnaux:1028:/ window 15,15
+1264.7 "Faith Unmoving" sync / 1[56]:[^:]*:Ser Grinnaux:1027:/ jump 1182.5
 
 # Closing sequence
-1441.9 "--sync--" sync / 1[56]:Ser Grinnaux the Bull:10A0:/ window 500,10
+1441.9 "--sync--" sync / 1[56]:[^:]*:Ser Grinnaux the Bull:10A0:/ window 500,10
 1442.0 "Retreating" duration 8
-1450.0 "Retreat" sync / 1[56]:Ser Grinnaux the Bull:10A1:/
+1450.0 "Retreat" sync / 1[56]:[^:]*:Ser Grinnaux the Bull:10A1:/
 
 
 ###Ser Charibert
 
 2000.0 "--sync--" sync / 00:0839::The Chancel will be sealed off/ window 2000,0
-2006.3 "Altar Candle" sync / 1[56]:Ser Charibert:1030:/ window 6.3,5
-2015.0 "Heavensflame" sync / 1[56]:Ser Charibert:1031:/
-2019.2 "Holy Chain" sync / 1[56]:Ser Charibert:1033:/ window 15,15
-2024.4 "Altar Candle" sync / 1[56]:Ser Charibert:1030:/
+2006.3 "Altar Candle" sync / 1[56]:[^:]*:Ser Charibert:1030:/ window 6.3,5
+2015.0 "Heavensflame" sync / 1[56]:[^:]*:Ser Charibert:1031:/
+2019.2 "Holy Chain" sync / 1[56]:[^:]*:Ser Charibert:1033:/ window 15,15
+2024.4 "Altar Candle" sync / 1[56]:[^:]*:Ser Charibert:1030:/
 2028.7 "Knights Appear"
-2037.6 "Altar Pyre" sync / 1[56]:Ser Charibert:1035:/ window 15,15
+2037.6 "Altar Pyre" sync / 1[56]:[^:]*:Ser Charibert:1035:/ window 15,15
 
-2046.6 "Altar Candle" sync / 1[56]:Ser Charibert:1030:/
-2055.3 "Heavensflame" sync / 1[56]:Ser Charibert:1031:/
-2059.5 "Holy Chain" sync / 1[56]:Ser Charibert:1033:/ window 15,15
-2064.7 "Altar Candle" sync / 1[56]:Ser Charibert:1030:/
+2046.6 "Altar Candle" sync / 1[56]:[^:]*:Ser Charibert:1030:/
+2055.3 "Heavensflame" sync / 1[56]:[^:]*:Ser Charibert:1031:/
+2059.5 "Holy Chain" sync / 1[56]:[^:]*:Ser Charibert:1033:/ window 15,15
+2064.7 "Altar Candle" sync / 1[56]:[^:]*:Ser Charibert:1030:/
 2068.8 "Knights Appear"
-2077.9 "Altar Pyre" sync / 1[56]:Ser Charibert:1035:/ window 15,15 jump 2037.6
+2077.9 "Altar Pyre" sync / 1[56]:[^:]*:Ser Charibert:1035:/ window 15,15 jump 2037.6
 
 2086.9 "Altar Candle"
 2095.6 "Heavensflame"
@@ -176,36 +176,36 @@ hideall "--sync--"
 
 # Intermission at < 60% HP
 
-2200.0 "--sync--" sync / 1[56]:Ser Charibert:1019:/ window 200,5
-2205.1 "--sync--" sync / 1[56]:Ser Charibert:1018:/
-2207.2 "--sync--" sync / 1[56]:Ser Charibert:1036:/
-2218.4 "Black Knight's Tour" sync / 1[56]:Dusk Knight:1039:/
-2218.5 "White Knight's Tour" sync / 1[56]:Dawn Knight:1038:/
-2231.7 "Black Knight's Tour" sync / 1[56]:Dusk Knight:1039:/
-2231.9 "White Knight's Tour" sync / 1[56]:Dawn Knight:1038:/
-2245.0 "Black Knight's Tour" sync / 1[56]:Dusk Knight:1039:/
-2245.2 "White Knight's Tour" sync / 1[56]:Dawn Knight:1038:/
+2200.0 "--sync--" sync / 1[56]:[^:]*:Ser Charibert:1019:/ window 200,5
+2205.1 "--sync--" sync / 1[56]:[^:]*:Ser Charibert:1018:/
+2207.2 "--sync--" sync / 1[56]:[^:]*:Ser Charibert:1036:/
+2218.4 "Black Knight's Tour" sync / 1[56]:[^:]*:Dusk Knight:1039:/
+2218.5 "White Knight's Tour" sync / 1[56]:[^:]*:Dawn Knight:1038:/
+2231.7 "Black Knight's Tour" sync / 1[56]:[^:]*:Dusk Knight:1039:/
+2231.9 "White Knight's Tour" sync / 1[56]:[^:]*:Dawn Knight:1038:/
+2245.0 "Black Knight's Tour" sync / 1[56]:[^:]*:Dusk Knight:1039:/
+2245.2 "White Knight's Tour" sync / 1[56]:[^:]*:Dawn Knight:1038:/
 2254.5 "Sacred Flame Enrage?"
 
-2294.0 "--sync--" sync / 1[56]:Ser Charibert:1037:/ window 2294,0
+2294.0 "--sync--" sync / 1[56]:[^:]*:Ser Charibert:1037:/ window 2294,0
 
 # The party might survive an intermission enrage.
 # This wide window on Candle allows for that.
-2300.0 "Altar Candle" sync / 1[56]:Ser Charibert:1030:/ window 100,20
-2309.0 "Altar Pyre" sync / 1[56]:Ser Charibert:1035:/
+2300.0 "Altar Candle" sync / 1[56]:[^:]*:Ser Charibert:1030:/ window 100,20
+2309.0 "Altar Pyre" sync / 1[56]:[^:]*:Ser Charibert:1035:/
 2316.3 "Knights Appear"
-2318.6 "Heavensflame" sync / 1[56]:Ser Charibert:1031:/ window 15,15
-2322.8 "Holy Chain" sync / 1[56]:Ser Charibert:1033:/
-2332.0 "Altar Pyre" sync / 1[56]:Ser Charibert:1035:/
-2336.1 "Altar Candle" sync / 1[56]:Ser Charibert:1030:/
+2318.6 "Heavensflame" sync / 1[56]:[^:]*:Ser Charibert:1031:/ window 15,15
+2322.8 "Holy Chain" sync / 1[56]:[^:]*:Ser Charibert:1033:/
+2332.0 "Altar Pyre" sync / 1[56]:[^:]*:Ser Charibert:1035:/
+2336.1 "Altar Candle" sync / 1[56]:[^:]*:Ser Charibert:1030:/
 
-2345.3 "Altar Candle" sync / 1[56]:Ser Charibert:1030:/
-2354.3 "Altar Pyre" sync / 1[56]:Ser Charibert:1035:/
+2345.3 "Altar Candle" sync / 1[56]:[^:]*:Ser Charibert:1030:/
+2354.3 "Altar Pyre" sync / 1[56]:[^:]*:Ser Charibert:1035:/
 2356.6 "Knights Appear"
-2363.9 "Heavensflame" sync / 1[56]:Ser Charibert:1031:/ window 15,15
-2368.1 "Holy Chain" sync / 1[56]:Ser Charibert:1033:/
-2377.3 "Altar Pyre" sync / 1[56]:Ser Charibert:1035:/
-2381.4 "Altar Candle" sync / 1[56]:Ser Charibert:1030:/ window 15,5 jump 2336.1
+2363.9 "Heavensflame" sync / 1[56]:[^:]*:Ser Charibert:1031:/ window 15,15
+2368.1 "Holy Chain" sync / 1[56]:[^:]*:Ser Charibert:1033:/
+2377.3 "Altar Pyre" sync / 1[56]:[^:]*:Ser Charibert:1035:/
+2381.4 "Altar Candle" sync / 1[56]:[^:]*:Ser Charibert:1030:/ window 15,5 jump 2336.1
 
 2390.6 "Altar Candle"
 2399.6 "Altar Pyre"

--- a/ui/raidboss/data/03-hw/dungeon/xelphatol.txt
+++ b/ui/raidboss/data/03-hw/dungeon/xelphatol.txt
@@ -13,26 +13,26 @@ hideall "--sync--"
 # -ic "Ixali Stitcher" "Airstone"
 
 0 "Start" sync / 00:0839::The Cage will be sealed off/ window 0,1
-7.0 "Short Burst" sync / 1[56]:Nuzal Hueloc:19C6:/ window 7,5
-15.1 "Wind Blast" sync / 1[56]:Nuzal Hueloc:19C7:/
-19.2 "Short Burst" sync / 1[56]:Nuzal Hueloc:19C6:/
-24.3 "Lift" sync / 1[56]:Nuzal Hueloc:19C9:/ window 24.3,5
+7.0 "Short Burst" sync / 1[56]:[^:]*:Nuzal Hueloc:19C6:/ window 7,5
+15.1 "Wind Blast" sync / 1[56]:[^:]*:Nuzal Hueloc:19C7:/
+19.2 "Short Burst" sync / 1[56]:[^:]*:Nuzal Hueloc:19C6:/
+24.3 "Lift" sync / 1[56]:[^:]*:Nuzal Hueloc:19C9:/ window 24.3,5
 24.8 "--untargetable--"
 
-28.5 "Air Raid" sync / 1[56]:Nuzal Hueloc:19CA:/ window 5,6
-36.6 "Air Raid" sync / 1[56]:Nuzal Hueloc:19CA:/
-48.1 "Air Raid" sync / 1[56]:Nuzal Hueloc:19CA:/
-59.6 "Air Raid" sync / 1[56]:Nuzal Hueloc:19CA:/ jump 36.6
+28.5 "Air Raid" sync / 1[56]:[^:]*:Nuzal Hueloc:19CA:/ window 5,6
+36.6 "Air Raid" sync / 1[56]:[^:]*:Nuzal Hueloc:19CA:/
+48.1 "Air Raid" sync / 1[56]:[^:]*:Nuzal Hueloc:19CA:/
+59.6 "Air Raid" sync / 1[56]:[^:]*:Nuzal Hueloc:19CA:/ jump 36.6
 71.1 "Air Raid" 
 82.6 "Air Raid"
 94.1 "Air Raid"
 
 100.0 "--sync--" sync / 22:........:Nuzal Hueloc:........:Nuzal Hueloc:01/ window 100,5
-121.3 "Wind Blast" sync / 1[56]:Nuzal Hueloc:19C7:/ window 21.3,5
-129.5 "Long Burst" sync / 1[56]:Nuzal Hueloc:19C8:/
-132.7 "Short Burst" sync / 1[56]:Nuzal Hueloc:19C6:/
+121.3 "Wind Blast" sync / 1[56]:[^:]*:Nuzal Hueloc:19C7:/ window 21.3,5
+129.5 "Long Burst" sync / 1[56]:[^:]*:Nuzal Hueloc:19C8:/
+132.7 "Short Burst" sync / 1[56]:[^:]*:Nuzal Hueloc:19C6:/
 
-139.8 "Wind Blast" sync / 1[56]:Nuzal Hueloc:19C7:/ jump 121.3
+139.8 "Wind Blast" sync / 1[56]:[^:]*:Nuzal Hueloc:19C7:/ jump 121.3
 148.0 "Long Burst"
 151.2 "Short Burst"
 158.3 "Wind Blast"
@@ -40,24 +40,24 @@ hideall "--sync--"
 169.7 "Short Burst"
 
 # syncing to a 14/20 line to give the user a little extra warning.
-200.0 "--sync--" sync / 14:Nuzal Hueloc:19C9:/ window 100,5
-202.7 "Lift" sync / 1[56]:Nuzal Hueloc:19C9:/
+200.0 "--sync--" sync / 14:[^:]*:Nuzal Hueloc:19C9:/ window 100,5
+202.7 "Lift" sync / 1[56]:[^:]*:Nuzal Hueloc:19C9:/
 203.2 "--untargetable--"
-206.9 "Air Raid" sync / 1[56]:Nuzal Hueloc:19CA:/
-214.6 "Air Raid" sync / 1[56]:Nuzal Hueloc:19CA:/
-226.1 "Air Raid" sync / 1[56]:Nuzal Hueloc:19CA:/
-237.6 "Air Raid" sync / 1[56]:Nuzal Hueloc:19CA:/ jump 206.9
+206.9 "Air Raid" sync / 1[56]:[^:]*:Nuzal Hueloc:19CA:/
+214.6 "Air Raid" sync / 1[56]:[^:]*:Nuzal Hueloc:19CA:/
+226.1 "Air Raid" sync / 1[56]:[^:]*:Nuzal Hueloc:19CA:/
+237.6 "Air Raid" sync / 1[56]:[^:]*:Nuzal Hueloc:19CA:/ jump 206.9
 249.1 "Air Raid"
 260.6 "Air Raid"
 272.1 "Air Raid"
 
 
 300.0 "--sync--" sync / 22:........:Nuzal Hueloc:........:Nuzal Hueloc:01/ window 100,5
-305.3 "Short Burst" sync / 1[56]:Nuzal Hueloc:19C6:/ window 5,10
-314.4 "Wind Blast" sync / 1[56]:Nuzal Hueloc:19C7:/
-323.5 "Long Burst" sync / 1[56]:Nuzal Hueloc:19C8:/
+305.3 "Short Burst" sync / 1[56]:[^:]*:Nuzal Hueloc:19C6:/ window 5,10
+314.4 "Wind Blast" sync / 1[56]:[^:]*:Nuzal Hueloc:19C7:/
+323.5 "Long Burst" sync / 1[56]:[^:]*:Nuzal Hueloc:19C8:/
 
-330.7 "Short Burst" sync / 1[56]:Nuzal Hueloc:19C6:/ jump 305.3
+330.7 "Short Burst" sync / 1[56]:[^:]*:Nuzal Hueloc:19C6:/ jump 305.3
 339.8 "Wind Blast"
 348.9 "Long Burst"
 356.1 "Short Burst"
@@ -72,18 +72,18 @@ hideall "--sync--"
 # -ii 19D2
 
 1000.0 "Start" sync / 00:0839::The Tlachtli will be sealed off/ window 1000,5
-1012.4 "On Low" sync / 1[56]:Dotoli Ciloc:19CE:/
-1024.5 "On High" sync / 1[56]:Dotoli Ciloc:19CF:/ window 24.5,10
+1012.4 "On Low" sync / 1[56]:[^:]*:Dotoli Ciloc:19CE:/
+1024.5 "On High" sync / 1[56]:[^:]*:Dotoli Ciloc:19CF:/ window 24.5,10
 
-1036.7 "On Low" sync / 1[56]:Dotoli Ciloc:19CE:/
-1045.2 "Dark Wings" sync / 1[56]:Dotoli Ciloc:19D0:/
-1055.2 "Swiftfeather" sync / 1[56]:Dotoli Ciloc:19D1:/
-1057.6 "On Low" sync / 1[56]:Dotoli Ciloc:19CE:/
-1068.0 "Dark Wings" sync / 1[56]:Dotoli Ciloc:19D0:/
-1074.6 "On High" sync / 1[56]:Dotoli Ciloc:19CF:/ window 20,20
-1076.8 "Dark Wings" sync / 1[56]:Dotoli Ciloc:19D0:/
+1036.7 "On Low" sync / 1[56]:[^:]*:Dotoli Ciloc:19CE:/
+1045.2 "Dark Wings" sync / 1[56]:[^:]*:Dotoli Ciloc:19D0:/
+1055.2 "Swiftfeather" sync / 1[56]:[^:]*:Dotoli Ciloc:19D1:/
+1057.6 "On Low" sync / 1[56]:[^:]*:Dotoli Ciloc:19CE:/
+1068.0 "Dark Wings" sync / 1[56]:[^:]*:Dotoli Ciloc:19D0:/
+1074.6 "On High" sync / 1[56]:[^:]*:Dotoli Ciloc:19CF:/ window 20,20
+1076.8 "Dark Wings" sync / 1[56]:[^:]*:Dotoli Ciloc:19D0:/
 
-1091.8 "On Low" sync / 1[56]:Dotoli Ciloc:19CE:/ jump 1036.7
+1091.8 "On Low" sync / 1[56]:[^:]*:Dotoli Ciloc:19CE:/ jump 1036.7
 1100.3 "Dark Wings"
 1110.3 "Swiftfeather"
 1112.7 "On Low"
@@ -97,40 +97,40 @@ hideall "--sync--"
 # -ii 19D8
 
 2000.0 "Start" sync / 00:0839::The Vortex will be sealed off/ window 2000,5
-2007.1 "Ixali Aero (buster)" sync / 1[56]:Tozol Huatotl:19D3:/ window 7.1,5
-2014.2 "Ixali Aero III (aoe)" sync / 1[56]:Tozol Huatotl:19D5:/
-2023.7 "Bill" sync / 1[56]:Abalathian Hornbill:19DA:/
-2028.5 "Ixali Aero (buster)" sync / 1[56]:Tozol Huatotl:19D3:/
-2035.6 "Ixali Aero II (line)" sync / 1[56]:Tozol Huatotl:19D4:/
-2045.3 "Ingurgitate" sync / 1[56]:Abalathian Hornbill:19D9:/ window 10,10
-2050.9 "Ixali Aero III (aoe)" sync / 1[56]:Tozol Huatotl:19D5:/
-2055.0 "Ixali Aero (buster)" sync / 1[56]:Tozol Huatotl:19D3:/
+2007.1 "Ixali Aero (buster)" sync / 1[56]:[^:]*:Tozol Huatotl:19D3:/ window 7.1,5
+2014.2 "Ixali Aero III (aoe)" sync / 1[56]:[^:]*:Tozol Huatotl:19D5:/
+2023.7 "Bill" sync / 1[56]:[^:]*:Abalathian Hornbill:19DA:/
+2028.5 "Ixali Aero (buster)" sync / 1[56]:[^:]*:Tozol Huatotl:19D3:/
+2035.6 "Ixali Aero II (line)" sync / 1[56]:[^:]*:Tozol Huatotl:19D4:/
+2045.3 "Ingurgitate" sync / 1[56]:[^:]*:Abalathian Hornbill:19D9:/ window 10,10
+2050.9 "Ixali Aero III (aoe)" sync / 1[56]:[^:]*:Tozol Huatotl:19D5:/
+2055.0 "Ixali Aero (buster)" sync / 1[56]:[^:]*:Tozol Huatotl:19D3:/
 
-2063.1 "Summon Garuda" sync / 1[56]:Tozol Huatotl:19D7:/ window 63.1,10
-2072.7 "Bill" sync / 1[56]:Abalathian Hornbill:19DA:/
-2072.9 "Eye Of The Storm" sync / 1[56]:Garuda:19DB:/
-2074.8 "Mistral Song" sync / 1[56]:Garuda:19DC:/ window 20,20
-2078.5 "Ixali Aero II (line)" sync / 1[56]:Tozol Huatotl:19D4:/
-2084.7 "Ixali Aero (buster)" sync / 1[56]:Tozol Huatotl:19D3:/
-2091.8 "Ixali Aero III (aoe)" sync / 1[56]:Tozol Huatotl:19D5:/
-2102.5 "Ingurgitate" sync / 1[56]:Abalathian Hornbill:19D9:/
-2107.1 "Ixali Aero II (line)" sync / 1[56]:Tozol Huatotl:19D4:/
-2112.2 "Ixali Aero III (aoe)" sync / 1[56]:Tozol Huatotl:19D5:/
-2115.4 "Ixali Aero (buster)" sync / 1[56]:Tozol Huatotl:19D3:/
-2127.3 "Summon Garuda" sync / 1[56]:Tozol Huatotl:19D7:/ window 30,30
-2136.7 "Bill" sync / 1[56]:Abalathian Hornbill:19DA:/
-2139.0 "Eye Of The Storm" sync / 1[56]:Garuda:19DB:/
-2139.0 "Wicked Wheel" sync / 1[56]:Garuda:19DD:/
-2145.2 "Aerial Blast" sync / 1[56]:Garuda:19DE:/
-2150.7 "Ixali Aero III (aoe)" sync / 1[56]:Tozol Huatotl:19D5:/
-2161.0 "Ixali Aero (buster)" sync / 1[56]:Tozol Huatotl:19D3:/
-2168.1 "Ixali Aero III (aoe)" sync / 1[56]:Tozol Huatotl:19D5:/
-2178.8 "Ingurgitate" sync / 1[56]:Abalathian Hornbill:19D9:/ window 30,30
-2183.4 "Ixali Aero II (line)" sync / 1[56]:Tozol Huatotl:19D4:/
-2188.5 "Ixali Aero III (aoe)" sync / 1[56]:Tozol Huatotl:19D5:/
-2191.7 "Ixali Aero (buster)" sync / 1[56]:Tozol Huatotl:19D3:/
+2063.1 "Summon Garuda" sync / 1[56]:[^:]*:Tozol Huatotl:19D7:/ window 63.1,10
+2072.7 "Bill" sync / 1[56]:[^:]*:Abalathian Hornbill:19DA:/
+2072.9 "Eye Of The Storm" sync / 1[56]:[^:]*:Garuda:19DB:/
+2074.8 "Mistral Song" sync / 1[56]:[^:]*:Garuda:19DC:/ window 20,20
+2078.5 "Ixali Aero II (line)" sync / 1[56]:[^:]*:Tozol Huatotl:19D4:/
+2084.7 "Ixali Aero (buster)" sync / 1[56]:[^:]*:Tozol Huatotl:19D3:/
+2091.8 "Ixali Aero III (aoe)" sync / 1[56]:[^:]*:Tozol Huatotl:19D5:/
+2102.5 "Ingurgitate" sync / 1[56]:[^:]*:Abalathian Hornbill:19D9:/
+2107.1 "Ixali Aero II (line)" sync / 1[56]:[^:]*:Tozol Huatotl:19D4:/
+2112.2 "Ixali Aero III (aoe)" sync / 1[56]:[^:]*:Tozol Huatotl:19D5:/
+2115.4 "Ixali Aero (buster)" sync / 1[56]:[^:]*:Tozol Huatotl:19D3:/
+2127.3 "Summon Garuda" sync / 1[56]:[^:]*:Tozol Huatotl:19D7:/ window 30,30
+2136.7 "Bill" sync / 1[56]:[^:]*:Abalathian Hornbill:19DA:/
+2139.0 "Eye Of The Storm" sync / 1[56]:[^:]*:Garuda:19DB:/
+2139.0 "Wicked Wheel" sync / 1[56]:[^:]*:Garuda:19DD:/
+2145.2 "Aerial Blast" sync / 1[56]:[^:]*:Garuda:19DE:/
+2150.7 "Ixali Aero III (aoe)" sync / 1[56]:[^:]*:Tozol Huatotl:19D5:/
+2161.0 "Ixali Aero (buster)" sync / 1[56]:[^:]*:Tozol Huatotl:19D3:/
+2168.1 "Ixali Aero III (aoe)" sync / 1[56]:[^:]*:Tozol Huatotl:19D5:/
+2178.8 "Ingurgitate" sync / 1[56]:[^:]*:Abalathian Hornbill:19D9:/ window 30,30
+2183.4 "Ixali Aero II (line)" sync / 1[56]:[^:]*:Tozol Huatotl:19D4:/
+2188.5 "Ixali Aero III (aoe)" sync / 1[56]:[^:]*:Tozol Huatotl:19D5:/
+2191.7 "Ixali Aero (buster)" sync / 1[56]:[^:]*:Tozol Huatotl:19D3:/
 
-2202.5 "Summon Garuda" sync / 1[56]:Tozol Huatotl:19D7:/ jump 2063.1
+2202.5 "Summon Garuda" sync / 1[56]:[^:]*:Tozol Huatotl:19D7:/ jump 2063.1
 2212.1 "Bill"
 2212.3 "Eye Of The Storm"
 2214.2 "Mistral Song"

--- a/ui/raidboss/data/03-hw/raid/a10s.txt
+++ b/ui/raidboss/data/03-hw/raid/a10s.txt
@@ -12,201 +12,201 @@ hideall "--sync--"
 ### Phase 1
 0.0 "--sync--" sync /:Engage!/ window 0,1
 0.0 "--sync--" sync / 00:0839::The Excruciationator will be sealed off/ window 10000,10000
-6.5 "Goblin Rush" sync / 1[56]:Lamebrix Strikebocks:1A16:/ window 7,2.5
-9.6 "Gobsway Rumblerocks" sync / 1[56]:Lamebrix Strikebocks:1AA0:/
-14.7 "Gobsway Rumblerocks" sync / 1[56]:Lamebrix Strikebocks:1AA0:/
-18.8 "--sync--" sync / 1[56]:Lamebrix Strikebocks:1AB[AB]:/
-22.1 "Single Charge" sync / 1[56]:Lamebrix Strikebocks:1A97:/
-22.9 "--spread/stack--" sync / 1[56]:Lamebrix Strikebocks:1A9[CE]:/
+6.5 "Goblin Rush" sync / 1[56]:[^:]*:Lamebrix Strikebocks:1A16:/ window 7,2.5
+9.6 "Gobsway Rumblerocks" sync / 1[56]:[^:]*:Lamebrix Strikebocks:1AA0:/
+14.7 "Gobsway Rumblerocks" sync / 1[56]:[^:]*:Lamebrix Strikebocks:1AA0:/
+18.8 "--sync--" sync / 1[56]:[^:]*:Lamebrix Strikebocks:1AB[AB]:/
+22.1 "Single Charge" sync / 1[56]:[^:]*:Lamebrix Strikebocks:1A97:/
+22.9 "--spread/stack--" sync / 1[56]:[^:]*:Lamebrix Strikebocks:1A9[CE]:/
 
 # trap 1: hp ??%
-30.3 "Floor Trap" sync / 1[56]:Lamebrix Strikebocks:1AB2:/ window 31,5
-31.6 "--jump--" sync / 1[56]:Lamebrix Strikebocks:1AA2:/
-35.7 "--sync--" sync / 1[56]:Lamebrix Strikebocks:1AB[AB]:/
-39.0 "Single Charge (Stack/Spread)" sync / 1[56]:Lamebrix Strikebocks:1A97:/
-39.8 "--stack/spread--" sync / 1[56]:Lamebrix Strikebocks:1A9[CE]:/
-50.0 "Gobslash Slicetops" sync / 1[56]:Lamebrix Strikebocks:1AA1:/
-53.1 "Goblin Rush" sync / 1[56]:Lamebrix Strikebocks:1A16:/
-61.2 "Gobrush Rushgob" sync / 1[56]:Lamebrix Strikebocks:1A9F:/
-64.4 "--sync--" sync / 1[56]:Lamebrix Strikebocks:1AA6:/ # discharge puddles appear
-67.6 "Gobsway Rumblerocks" sync / 1[56]:Lamebrix Strikebocks:1AA0:/
+30.3 "Floor Trap" sync / 1[56]:[^:]*:Lamebrix Strikebocks:1AB2:/ window 31,5
+31.6 "--jump--" sync / 1[56]:[^:]*:Lamebrix Strikebocks:1AA2:/
+35.7 "--sync--" sync / 1[56]:[^:]*:Lamebrix Strikebocks:1AB[AB]:/
+39.0 "Single Charge (Stack/Spread)" sync / 1[56]:[^:]*:Lamebrix Strikebocks:1A97:/
+39.8 "--stack/spread--" sync / 1[56]:[^:]*:Lamebrix Strikebocks:1A9[CE]:/
+50.0 "Gobslash Slicetops" sync / 1[56]:[^:]*:Lamebrix Strikebocks:1AA1:/
+53.1 "Goblin Rush" sync / 1[56]:[^:]*:Lamebrix Strikebocks:1A16:/
+61.2 "Gobrush Rushgob" sync / 1[56]:[^:]*:Lamebrix Strikebocks:1A9F:/
+64.4 "--sync--" sync / 1[56]:[^:]*:Lamebrix Strikebocks:1AA6:/ # discharge puddles appear
+67.6 "Gobsway Rumblerocks" sync / 1[56]:[^:]*:Lamebrix Strikebocks:1AA0:/
 
 # trap 2: hp 85%
-73.6 "Frost Trap" sync / 1[56]:Lamebrix Strikebocks:1AB1:/ window 75,5
-74.9 "--jump--" sync / 1[56]:Lamebrix Strikebocks:1AA2:/
-76.5 "Discharge" sync / 1[56]:Lamebrix Strikebocks:1AA7:/
-78.5 "Frostbite" sync / 1[56]:Lamebrix Strikebocks:1A8E:/
-88.0 "Gobsnick Leghops" sync / 1[56]:Lamebrix Strikebocks:1AA4:/
+73.6 "Frost Trap" sync / 1[56]:[^:]*:Lamebrix Strikebocks:1AB1:/ window 75,5
+74.9 "--jump--" sync / 1[56]:[^:]*:Lamebrix Strikebocks:1AA2:/
+76.5 "Discharge" sync / 1[56]:[^:]*:Lamebrix Strikebocks:1AA7:/
+78.5 "Frostbite" sync / 1[56]:[^:]*:Lamebrix Strikebocks:1A8E:/
+88.0 "Gobsnick Leghops" sync / 1[56]:[^:]*:Lamebrix Strikebocks:1AA4:/
 90.2 "Clone Add"
-90.2 "--jump--" sync / 1[56]:Lamebrix Strikebocks:1AA2:/
-92.5 "--sync--" sync / 1[56]:Lamebrix Strikebocks:1AB8:/
-95.8 "Single Charge" sync / 1[56]:Lamebrix Strikebocks:1A97:/
-96.6 "--in--" sync / 1[56]:Lamebrix Strikebocks:1A9A:/
-103.7 "Gobsway Rumblerocks" sync / 1[56]:Lamebrix Strikebocks:1AA0:/
-105.3 "Gobswish Spraymops" sync / 1[56]:Lameprix Strikedocks:1AA3:/
-113.9 "Gobrush Rushgob" sync / 1[56]:Lamebrix Strikebocks:1A9F:/
-118.5 "Goblin Rush" sync / 1[56]:Lamebrix Strikebocks:1A16:/
-119.5 "Gobswish Spraymops" sync / 1[56]:Lameprix Strikedocks:1AA3:/
-120.7 "--sync--" sync / 1[56]:Lamebrix Strikebocks:1AA6:/ # discharge puddles appear
+90.2 "--jump--" sync / 1[56]:[^:]*:Lamebrix Strikebocks:1AA2:/
+92.5 "--sync--" sync / 1[56]:[^:]*:Lamebrix Strikebocks:1AB8:/
+95.8 "Single Charge" sync / 1[56]:[^:]*:Lamebrix Strikebocks:1A97:/
+96.6 "--in--" sync / 1[56]:[^:]*:Lamebrix Strikebocks:1A9A:/
+103.7 "Gobsway Rumblerocks" sync / 1[56]:[^:]*:Lamebrix Strikebocks:1AA0:/
+105.3 "Gobswish Spraymops" sync / 1[56]:[^:]*:Lameprix Strikedocks:1AA3:/
+113.9 "Gobrush Rushgob" sync / 1[56]:[^:]*:Lamebrix Strikebocks:1A9F:/
+118.5 "Goblin Rush" sync / 1[56]:[^:]*:Lamebrix Strikebocks:1A16:/
+119.5 "Gobswish Spraymops" sync / 1[56]:[^:]*:Lameprix Strikedocks:1AA3:/
+120.7 "--sync--" sync / 1[56]:[^:]*:Lamebrix Strikebocks:1AA6:/ # discharge puddles appear
 
 # trap 3: hp ??%
-126.6 "Weight Trap" sync / 1[56]:Lamebrix Strikebocks:1AB0:/ window 127,5
-128.0 "--jump--" sync / 1[56]:Lamebrix Strikebocks:1AA2:/
-131.6 "Impact" sync / 1[56]:Weight Of The World:1A8B:/
-135.7 "Discharge" sync / 1[56]:Lamebrix Strikebocks:1AA7:/
-144.3 "Gobslash Slicetops" sync / 1[56]:Lamebrix Strikebocks:1AA1:/
-147.4 "Gobsway Rumblerocks" sync / 1[56]:Lamebrix Strikebocks:1AA0:/
-151.6 "Gobsway Rumblerocks" sync / 1[56]:Lamebrix Strikebocks:1AA0:/
-159.7 "--sync--" #sync / 1[56]:Lamebrix Strikebocks:1AB[89]:/
-161.7 "--sync--" #sync / 1[56]:Lamebrix Strikebocks:1AB[89]:/
-165.0 "Double Charge" sync / 1[56]:Lamebrix Strikebocks:1A98:/
-165.8 "--in/out--" sync / 1[56]:Lamebrix Strikebocks:1A9[AB]:/
-168.8 "--out/in--" sync / 1[56]:Lamebrix Strikebocks:1A9[AB]:/
-171.9 "--jump--" sync / 1[56]:Lamebrix Strikebocks:1AA2:/
+126.6 "Weight Trap" sync / 1[56]:[^:]*:Lamebrix Strikebocks:1AB0:/ window 127,5
+128.0 "--jump--" sync / 1[56]:[^:]*:Lamebrix Strikebocks:1AA2:/
+131.6 "Impact" sync / 1[56]:[^:]*:Weight Of The World:1A8B:/
+135.7 "Discharge" sync / 1[56]:[^:]*:Lamebrix Strikebocks:1AA7:/
+144.3 "Gobslash Slicetops" sync / 1[56]:[^:]*:Lamebrix Strikebocks:1AA1:/
+147.4 "Gobsway Rumblerocks" sync / 1[56]:[^:]*:Lamebrix Strikebocks:1AA0:/
+151.6 "Gobsway Rumblerocks" sync / 1[56]:[^:]*:Lamebrix Strikebocks:1AA0:/
+159.7 "--sync--" #sync / 1[56]:[^:]*:Lamebrix Strikebocks:1AB[89]:/
+161.7 "--sync--" #sync / 1[56]:[^:]*:Lamebrix Strikebocks:1AB[89]:/
+165.0 "Double Charge" sync / 1[56]:[^:]*:Lamebrix Strikebocks:1A98:/
+165.8 "--in/out--" sync / 1[56]:[^:]*:Lamebrix Strikebocks:1A9[AB]:/
+168.8 "--out/in--" sync / 1[56]:[^:]*:Lamebrix Strikebocks:1A9[AB]:/
+171.9 "--jump--" sync / 1[56]:[^:]*:Lamebrix Strikebocks:1AA2:/
 178.2 "Leghops?/Charge (In)?"
-184.0 "Gobsway Rumblerocks" sync / 1[56]:Lamebrix Strikebocks:1AA0:/
-187.2 "Goblin Rush" sync / 1[56]:Lamebrix Strikebocks:1A16:/
-195.3 "Gobrush Rushgob" sync / 1[56]:Lamebrix Strikebocks:1A9F:/
-199.5 "Goblin Rush" sync / 1[56]:Lamebrix Strikebocks:1A16:/
+184.0 "Gobsway Rumblerocks" sync / 1[56]:[^:]*:Lamebrix Strikebocks:1AA0:/
+187.2 "Goblin Rush" sync / 1[56]:[^:]*:Lamebrix Strikebocks:1A16:/
+195.3 "Gobrush Rushgob" sync / 1[56]:[^:]*:Lamebrix Strikebocks:1A9F:/
+199.5 "Goblin Rush" sync / 1[56]:[^:]*:Lamebrix Strikebocks:1A16:/
 
 
 ### Phase 2: Steam Roller (60%)
 200.5 "--untargetable--" sync / 22:........:Lamebrix Strikebocks:........:Lamebrix Strikebocks:00/ window 201,5
-201.6 "--jump--" sync / 1[56]:Lamebrix Strikebocks:1AA2:/ window 20,5
-207.0 "Brighteyes Markers" sync / 1[56]:Lamebrix Strikebocks:1AA9:/ window 210,5
-212.0 "Brighteyes" sync / 1[56]:Lamebrix Strikebocks:1AAA:/
-212.1 "Illuminati Hand Cannon" sync / 1[56]:Lamebrix Strikebocks:1AA8:/
-216.3 "Brighteyes Markers" sync / 1[56]:Lamebrix Strikebocks:1AA9:/
-221.2 "Steam Roller" sync / 1[56]:Gobpress R-VI:1A95:/
-221.2 "Brighteyes" sync / 1[56]:Lamebrix Strikebocks:1AAA:/
-231.5 "Illuminati Hand Cannon" sync / 1[56]:Lamebrix Strikebocks:1AA8:/
-234.7 "Gobsway Rumblerocks" sync / 1[56]:Lamebrix Strikebocks:1AA0:/
-238.9 "Gobsway Rumblerocks" sync / 1[56]:Lamebrix Strikebocks:1AA0:/
-240.5 "Steam Roller" sync / 1[56]:Gobpress R-VI:1A95:/
-241.6 "Brighteyes Markers" sync / 1[56]:Lamebrix Strikebocks:1AA9:/
-246.6 "Brighteyes" sync / 1[56]:Lamebrix Strikebocks:1AAA:/
-246.7 "Illuminati Hand Cannon" sync / 1[56]:Lamebrix Strikebocks:1AA8:/
-250.9 "Brighteyes Markers" sync / 1[56]:Lamebrix Strikebocks:1AA9:/
-255.9 "Brighteyes" sync / 1[56]:Lamebrix Strikebocks:1AAA:/
-259.8 "Steam Roller" sync / 1[56]:Gobpress R-VI:1A95:/
-268.1 "Illuminati Hand Cannon" sync / 1[56]:Lamebrix Strikebocks:1AA8:/
-271.3 "Gobsway Rumblerocks" sync / 1[56]:Lamebrix Strikebocks:1AA0:/
-275.5 "Gobsway Rumblerocks" sync / 1[56]:Lamebrix Strikebocks:1AA0:/
-279.1 "Steam Roller" sync / 1[56]:Gobpress R-VI:1A95:/
-285.8 "Gobsway Rumblerocks" sync / 1[56]:Lamebrix Strikebocks:1AA0:/
-289.9 "Gobsway Rumblerocks" sync / 1[56]:Lamebrix Strikebocks:1AA0:/
-294.1 "Gobsway Rumblerocks" sync / 1[56]:Lamebrix Strikebocks:1AA0:/
-298.2 "Gobsway Rumblerocks" sync / 1[56]:Lamebrix Strikebocks:1AA0:/
-298.4 "Steam Roller Enrage" sync / 1[56]:Gobpress R-VI:1A95:/
-302.4 "Gobsway Rumblerocks" sync / 1[56]:Lamebrix Strikebocks:1AA0:/
+201.6 "--jump--" sync / 1[56]:[^:]*:Lamebrix Strikebocks:1AA2:/ window 20,5
+207.0 "Brighteyes Markers" sync / 1[56]:[^:]*:Lamebrix Strikebocks:1AA9:/ window 210,5
+212.0 "Brighteyes" sync / 1[56]:[^:]*:Lamebrix Strikebocks:1AAA:/
+212.1 "Illuminati Hand Cannon" sync / 1[56]:[^:]*:Lamebrix Strikebocks:1AA8:/
+216.3 "Brighteyes Markers" sync / 1[56]:[^:]*:Lamebrix Strikebocks:1AA9:/
+221.2 "Steam Roller" sync / 1[56]:[^:]*:Gobpress R-VI:1A95:/
+221.2 "Brighteyes" sync / 1[56]:[^:]*:Lamebrix Strikebocks:1AAA:/
+231.5 "Illuminati Hand Cannon" sync / 1[56]:[^:]*:Lamebrix Strikebocks:1AA8:/
+234.7 "Gobsway Rumblerocks" sync / 1[56]:[^:]*:Lamebrix Strikebocks:1AA0:/
+238.9 "Gobsway Rumblerocks" sync / 1[56]:[^:]*:Lamebrix Strikebocks:1AA0:/
+240.5 "Steam Roller" sync / 1[56]:[^:]*:Gobpress R-VI:1A95:/
+241.6 "Brighteyes Markers" sync / 1[56]:[^:]*:Lamebrix Strikebocks:1AA9:/
+246.6 "Brighteyes" sync / 1[56]:[^:]*:Lamebrix Strikebocks:1AAA:/
+246.7 "Illuminati Hand Cannon" sync / 1[56]:[^:]*:Lamebrix Strikebocks:1AA8:/
+250.9 "Brighteyes Markers" sync / 1[56]:[^:]*:Lamebrix Strikebocks:1AA9:/
+255.9 "Brighteyes" sync / 1[56]:[^:]*:Lamebrix Strikebocks:1AAA:/
+259.8 "Steam Roller" sync / 1[56]:[^:]*:Gobpress R-VI:1A95:/
+268.1 "Illuminati Hand Cannon" sync / 1[56]:[^:]*:Lamebrix Strikebocks:1AA8:/
+271.3 "Gobsway Rumblerocks" sync / 1[56]:[^:]*:Lamebrix Strikebocks:1AA0:/
+275.5 "Gobsway Rumblerocks" sync / 1[56]:[^:]*:Lamebrix Strikebocks:1AA0:/
+279.1 "Steam Roller" sync / 1[56]:[^:]*:Gobpress R-VI:1A95:/
+285.8 "Gobsway Rumblerocks" sync / 1[56]:[^:]*:Lamebrix Strikebocks:1AA0:/
+289.9 "Gobsway Rumblerocks" sync / 1[56]:[^:]*:Lamebrix Strikebocks:1AA0:/
+294.1 "Gobsway Rumblerocks" sync / 1[56]:[^:]*:Lamebrix Strikebocks:1AA0:/
+298.2 "Gobsway Rumblerocks" sync / 1[56]:[^:]*:Lamebrix Strikebocks:1AA0:/
+298.4 "Steam Roller Enrage" sync / 1[56]:[^:]*:Gobpress R-VI:1A95:/
+302.4 "Gobsway Rumblerocks" sync / 1[56]:[^:]*:Lamebrix Strikebocks:1AA0:/
 
 ### Phase 3
 500.0 "--targetable--" sync / 22:........:Lamebrix Strikebocks:........:Lamebrix Strikebocks:01/ window 500,0
-509.0 "Goblin Rush" sync / 1[56]:Lamebrix Strikebocks:1A16:/ window 305,5
-517.1 "Gobrush Rushgob" sync / 1[56]:Lamebrix Strikebocks:1A9F:/
-521.3 "--sync--" #sync / 1[56]:Lamebrix Strikebocks:1AB[89AB]:/
-523.3 "--sync--" #sync / 1[56]:Lamebrix Strikebocks:1AB[89AB]:/
-525.3 "--sync--" #sync / 1[56]:Lamebrix Strikebocks:1AB[89AB]:/
+509.0 "Goblin Rush" sync / 1[56]:[^:]*:Lamebrix Strikebocks:1A16:/ window 305,5
+517.1 "Gobrush Rushgob" sync / 1[56]:[^:]*:Lamebrix Strikebocks:1A9F:/
+521.3 "--sync--" #sync / 1[56]:[^:]*:Lamebrix Strikebocks:1AB[89AB]:/
+523.3 "--sync--" #sync / 1[56]:[^:]*:Lamebrix Strikebocks:1AB[89AB]:/
+525.3 "--sync--" #sync / 1[56]:[^:]*:Lamebrix Strikebocks:1AB[89AB]:/
 
-528.5 "Triple Charge" sync / 1[56]:Lamebrix Strikebocks:1A99:/ window 530,10
-529.3 "--mechanic 1--" sync / 1[56]:Lamebrix Strikebocks:1A9[ABCE]:/
-532.4 "--mechanic 2--" sync / 1[56]:Lamebrix Strikebocks:1A9[ABCE]:/
-536.9 "--mechanic 3--" sync / 1[56]:Lamebrix Strikebocks:1A9[ABCE]:/
-542.0 "Goblin Rush" sync / 1[56]:Lamebrix Strikebocks:1A16:/
-546.1 "Gobsway Rumblerocks" sync / 1[56]:Lamebrix Strikebocks:1AA0:/
-550.2 "Goblin Rush" sync / 1[56]:Lamebrix Strikebocks:1A16:/
-554.3 "Gobsway Rumblerocks" sync / 1[56]:Lamebrix Strikebocks:1AA0:/
-559.4 "--jump--" sync / 1[56]:Lamebrix Strikebocks:1AA2:/
-561.7 "--sync--" sync / 1[56]:Lamebrix Strikebocks:1AB8:/
-565.0 "Single Charge" sync / 1[56]:Lamebrix Strikebocks:1A97:/
-565.8 "--in--" sync / 1[56]:Lamebrix Strikebocks:1A9A:/
+528.5 "Triple Charge" sync / 1[56]:[^:]*:Lamebrix Strikebocks:1A99:/ window 530,10
+529.3 "--mechanic 1--" sync / 1[56]:[^:]*:Lamebrix Strikebocks:1A9[ABCE]:/
+532.4 "--mechanic 2--" sync / 1[56]:[^:]*:Lamebrix Strikebocks:1A9[ABCE]:/
+536.9 "--mechanic 3--" sync / 1[56]:[^:]*:Lamebrix Strikebocks:1A9[ABCE]:/
+542.0 "Goblin Rush" sync / 1[56]:[^:]*:Lamebrix Strikebocks:1A16:/
+546.1 "Gobsway Rumblerocks" sync / 1[56]:[^:]*:Lamebrix Strikebocks:1AA0:/
+550.2 "Goblin Rush" sync / 1[56]:[^:]*:Lamebrix Strikebocks:1A16:/
+554.3 "Gobsway Rumblerocks" sync / 1[56]:[^:]*:Lamebrix Strikebocks:1AA0:/
+559.4 "--jump--" sync / 1[56]:[^:]*:Lamebrix Strikebocks:1AA2:/
+561.7 "--sync--" sync / 1[56]:[^:]*:Lamebrix Strikebocks:1AB8:/
+565.0 "Single Charge" sync / 1[56]:[^:]*:Lamebrix Strikebocks:1A97:/
+565.8 "--in--" sync / 1[56]:[^:]*:Lamebrix Strikebocks:1A9A:/
 
-575.0 "Gobspin Zoomdrops" sync / 1[56]:Lamebrix Strikebocks:1A8F:/
+575.0 "Gobspin Zoomdrops" sync / 1[56]:[^:]*:Lamebrix Strikebocks:1A8F:/
 576.9 "Stoneskin"
-580.2 "Gobspin Zoomdrops" sync / 1[56]:Lamebrix Strikebocks:1A91:/
-586.2 "Gobspin Zoomdrops" sync / 1[56]:Lamebrix Strikebocks:1A91:/
-592.2 "Gobspin Zoomdrops" sync / 1[56]:Lamebrix Strikebocks:1A91:/ window 3,100
-594.2 "Gobspin Zoomdrops" #sync / 1[56]:Lamebrix Strikebocks:1A91:/
-596.2 "Gobspin Zoomdrops" #sync / 1[56]:Lamebrix Strikebocks:1A91:/
-598.2 "Gobspin Zoomdrops" #sync / 1[56]:Lamebrix Strikebocks:1A91:/
-600.2 "Gobspin Zoomdrops" #sync / 1[56]:Lamebrix Strikebocks:1A91:/
-602.2 "Gobspin Zoomdrops" #sync / 1[56]:Lamebrix Strikebocks:1A91:/
-604.2 "Gobspin Zoomdrops" #sync / 1[56]:Lamebrix Strikebocks:1A91:/
-606.2 "Gobspin Zoomdrops" #sync / 1[56]:Lamebrix Strikebocks:1A91:/
-608.2 "Gobspin Zoomdrops" #sync / 1[56]:Lamebrix Strikebocks:1A91:/
-610.2 "Gobspin Zoomdrops" #sync / 1[56]:Lamebrix Strikebocks:1A91:/
-612.2 "Gobspin Zoomdrops" #sync / 1[56]:Lamebrix Strikebocks:1A91:/
-614.2 "Gobspin Zoomdrops" #sync / 1[56]:Lamebrix Strikebocks:1A91:/
-616.2 "Gobspin Zoomdrops" #sync / 1[56]:Lamebrix Strikebocks:1A91:/
-618.2 "Gobspin Zoomdrops" #sync / 1[56]:Lamebrix Strikebocks:1A91:/
-620.2 "Gobspin Zoomdrops" #sync / 1[56]:Lamebrix Strikebocks:1A91:/
-622.2 "Gobspin Zoomdrops" #sync / 1[56]:Lamebrix Strikebocks:1A91:/
-624.2 "Gobspin Zoomdrops" #sync / 1[56]:Lamebrix Strikebocks:1A91:/
-626.2 "Gobspin Zoomdrops" #sync / 1[56]:Lamebrix Strikebocks:1A91:/
-628.2 "Gobspin Zoomdrops" #sync / 1[56]:Lamebrix Strikebocks:1A91:/
+580.2 "Gobspin Zoomdrops" sync / 1[56]:[^:]*:Lamebrix Strikebocks:1A91:/
+586.2 "Gobspin Zoomdrops" sync / 1[56]:[^:]*:Lamebrix Strikebocks:1A91:/
+592.2 "Gobspin Zoomdrops" sync / 1[56]:[^:]*:Lamebrix Strikebocks:1A91:/ window 3,100
+594.2 "Gobspin Zoomdrops" #sync / 1[56]:[^:]*:Lamebrix Strikebocks:1A91:/
+596.2 "Gobspin Zoomdrops" #sync / 1[56]:[^:]*:Lamebrix Strikebocks:1A91:/
+598.2 "Gobspin Zoomdrops" #sync / 1[56]:[^:]*:Lamebrix Strikebocks:1A91:/
+600.2 "Gobspin Zoomdrops" #sync / 1[56]:[^:]*:Lamebrix Strikebocks:1A91:/
+602.2 "Gobspin Zoomdrops" #sync / 1[56]:[^:]*:Lamebrix Strikebocks:1A91:/
+604.2 "Gobspin Zoomdrops" #sync / 1[56]:[^:]*:Lamebrix Strikebocks:1A91:/
+606.2 "Gobspin Zoomdrops" #sync / 1[56]:[^:]*:Lamebrix Strikebocks:1A91:/
+608.2 "Gobspin Zoomdrops" #sync / 1[56]:[^:]*:Lamebrix Strikebocks:1A91:/
+610.2 "Gobspin Zoomdrops" #sync / 1[56]:[^:]*:Lamebrix Strikebocks:1A91:/
+612.2 "Gobspin Zoomdrops" #sync / 1[56]:[^:]*:Lamebrix Strikebocks:1A91:/
+614.2 "Gobspin Zoomdrops" #sync / 1[56]:[^:]*:Lamebrix Strikebocks:1A91:/
+616.2 "Gobspin Zoomdrops" #sync / 1[56]:[^:]*:Lamebrix Strikebocks:1A91:/
+618.2 "Gobspin Zoomdrops" #sync / 1[56]:[^:]*:Lamebrix Strikebocks:1A91:/
+620.2 "Gobspin Zoomdrops" #sync / 1[56]:[^:]*:Lamebrix Strikebocks:1A91:/
+622.2 "Gobspin Zoomdrops" #sync / 1[56]:[^:]*:Lamebrix Strikebocks:1A91:/
+624.2 "Gobspin Zoomdrops" #sync / 1[56]:[^:]*:Lamebrix Strikebocks:1A91:/
+626.2 "Gobspin Zoomdrops" #sync / 1[56]:[^:]*:Lamebrix Strikebocks:1A91:/
+628.2 "Gobspin Zoomdrops" #sync / 1[56]:[^:]*:Lamebrix Strikebocks:1A91:/
 
-700.0 "Frostbite" sync / 1[56]:Lamebrix Strikebocks:1A8E:/ window 125,0
-712.8 "Gobsway Rumblerocks" sync / 1[56]:Lamebrix Strikebocks:1AA0:/
-720.9 "Gobrush Rushgob" sync / 1[56]:Lamebrix Strikebocks:1A9F:/
-724.1 "--jump--" sync / 1[56]:Lamebrix Strikebocks:1AA2:/
-735.3 "Gobslice Mooncrops" sync / 1[56]:Lamebrix Strikebocks:1A92:/
-739.4 "--jump--" sync / 1[56]:Lamebrix Strikebocks:1AA2:/
+700.0 "Frostbite" sync / 1[56]:[^:]*:Lamebrix Strikebocks:1A8E:/ window 125,0
+712.8 "Gobsway Rumblerocks" sync / 1[56]:[^:]*:Lamebrix Strikebocks:1AA0:/
+720.9 "Gobrush Rushgob" sync / 1[56]:[^:]*:Lamebrix Strikebocks:1A9F:/
+724.1 "--jump--" sync / 1[56]:[^:]*:Lamebrix Strikebocks:1AA2:/
+735.3 "Gobslice Mooncrops" sync / 1[56]:[^:]*:Lamebrix Strikebocks:1A92:/
+739.4 "--jump--" sync / 1[56]:[^:]*:Lamebrix Strikebocks:1AA2:/
 745.7 "Leghops?/Charge (In)?"
-749.9 "Gobsway Rumblerocks" sync / 1[56]:Lamebrix Strikebocks:1AA0:/
-754.0 "Gobsway Rumblerocks" sync / 1[56]:Lamebrix Strikebocks:1AA0:/
-758.1 "Goblin Rush" sync / 1[56]:Lamebrix Strikebocks:1A16:/
-762.2 "Goblin Rush" sync / 1[56]:Lamebrix Strikebocks:1A16:/
+749.9 "Gobsway Rumblerocks" sync / 1[56]:[^:]*:Lamebrix Strikebocks:1AA0:/
+754.0 "Gobsway Rumblerocks" sync / 1[56]:[^:]*:Lamebrix Strikebocks:1AA0:/
+758.1 "Goblin Rush" sync / 1[56]:[^:]*:Lamebrix Strikebocks:1A16:/
+762.2 "Goblin Rush" sync / 1[56]:[^:]*:Lamebrix Strikebocks:1A16:/
 
 # Sawblade phase
-765.3 "Brighteyes Markers" sync / 1[56]:Lamebrix Strikebocks:1AA9:/
-769.2 "Laceration" #sync / 1[56]:Buzzsaw:1A94:/
-770.3 "Brighteyes" sync / 1[56]:Lamebrix Strikebocks:1AAA:/
-770.9 "Illuminati Hand Cannon" sync / 1[56]:Lamebrix Strikebocks:1AA8:/
-772.3 "Laceration" #sync / 1[56]:Buzzsaw:1A94:/
-775.1 "Brighteyes Markers" sync / 1[56]:Lamebrix Strikebocks:1AA9:/
-775.4 "Laceration" #sync / 1[56]:Buzzsaw:1A94:/
-778.2 "--sync--" sync / 1[56]:Lamebrix Strikebocks:1AB9:/
-778.4 "Laceration" #sync / 1[56]:Buzzsaw:1A94:/
-780.1 "Brighteyes" sync / 1[56]:Lamebrix Strikebocks:1AAA:/
-781.5 "Single Charge" sync / 1[56]:Lamebrix Strikebocks:1A97:/
-782.3 "--out--" sync / 1[56]:Lamebrix Strikebocks:1A9B:/
-786.4 "Goblin Rush" sync / 1[56]:Lamebrix Strikebocks:1A16:/
-795.6 "Gobslash Slicetops" sync / 1[56]:Lamebrix Strikebocks:1AA1:/
-803.7 "Gobrush Rushgob" sync / 1[56]:Lamebrix Strikebocks:1A9F:/
+765.3 "Brighteyes Markers" sync / 1[56]:[^:]*:Lamebrix Strikebocks:1AA9:/
+769.2 "Laceration" #sync / 1[56]:[^:]*:Buzzsaw:1A94:/
+770.3 "Brighteyes" sync / 1[56]:[^:]*:Lamebrix Strikebocks:1AAA:/
+770.9 "Illuminati Hand Cannon" sync / 1[56]:[^:]*:Lamebrix Strikebocks:1AA8:/
+772.3 "Laceration" #sync / 1[56]:[^:]*:Buzzsaw:1A94:/
+775.1 "Brighteyes Markers" sync / 1[56]:[^:]*:Lamebrix Strikebocks:1AA9:/
+775.4 "Laceration" #sync / 1[56]:[^:]*:Buzzsaw:1A94:/
+778.2 "--sync--" sync / 1[56]:[^:]*:Lamebrix Strikebocks:1AB9:/
+778.4 "Laceration" #sync / 1[56]:[^:]*:Buzzsaw:1A94:/
+780.1 "Brighteyes" sync / 1[56]:[^:]*:Lamebrix Strikebocks:1AAA:/
+781.5 "Single Charge" sync / 1[56]:[^:]*:Lamebrix Strikebocks:1A97:/
+782.3 "--out--" sync / 1[56]:[^:]*:Lamebrix Strikebocks:1A9B:/
+786.4 "Goblin Rush" sync / 1[56]:[^:]*:Lamebrix Strikebocks:1A16:/
+795.6 "Gobslash Slicetops" sync / 1[56]:[^:]*:Lamebrix Strikebocks:1AA1:/
+803.7 "Gobrush Rushgob" sync / 1[56]:[^:]*:Lamebrix Strikebocks:1A9F:/
 
 # Adds phase
-806.9 "--sync--" sync / 1[56]:Lamebrix Strikebocks:1AA6:/ # discharge puddles appear
-811.8 "Frost Trap" sync / 1[56]:Lamebrix Strikebocks:1AB1:/
-814.9 "Discharge" sync / 1[56]:Lamebrix Strikebocks:1AA7:/
-815.9 "Weight Trap" sync / 1[56]:Lamebrix Strikebocks:1AB0:/
-816.8 "Frostbite" sync / 1[56]:Lamebrix Strikebocks:1A8E:/
-820.8 "Impact" sync / 1[56]:Weight Of The World:1A8B:/
-817.2 "--jump--" sync / 1[56]:Lamebrix Strikebocks:1AA2:/
-824.9 "Discharge" sync / 1[56]:Lamebrix Strikebocks:1AA7:/
+806.9 "--sync--" sync / 1[56]:[^:]*:Lamebrix Strikebocks:1AA6:/ # discharge puddles appear
+811.8 "Frost Trap" sync / 1[56]:[^:]*:Lamebrix Strikebocks:1AB1:/
+814.9 "Discharge" sync / 1[56]:[^:]*:Lamebrix Strikebocks:1AA7:/
+815.9 "Weight Trap" sync / 1[56]:[^:]*:Lamebrix Strikebocks:1AB0:/
+816.8 "Frostbite" sync / 1[56]:[^:]*:Lamebrix Strikebocks:1A8E:/
+820.8 "Impact" sync / 1[56]:[^:]*:Weight Of The World:1A8B:/
+817.2 "--jump--" sync / 1[56]:[^:]*:Lamebrix Strikebocks:1AA2:/
+824.9 "Discharge" sync / 1[56]:[^:]*:Lamebrix Strikebocks:1AA7:/
 827.1 "Gobbie Adds x3 (NE)"
-828.4 "Gobsway Rumblerocks" sync / 1[56]:Lamebrix Strikebocks:1AA0:/
-832.5 "Gobsway Rumblerocks" sync / 1[56]:Lamebrix Strikebocks:1AA0:/
-840.7 "Gobsnick Leghops" sync / 1[56]:Lamebrix Strikebocks:1AA4:/
-845.6 "Laceration" #sync / 1[56]:Buzzsaw:1A94:/
-847.8 "Goblin Rush" sync / 1[56]:Lamebrix Strikebocks:1A16:/
-848.6 "Laceration" #sync / 1[56]:Buzzsaw:1A94:/
-851.6 "Laceration" #sync / 1[56]:Buzzsaw:1A94:/
-855.9 "Gobrush Rushgob" sync / 1[56]:Lamebrix Strikebocks:1A9F:/
-860.0 "Goblin Rush" sync / 1[56]:Lamebrix Strikebocks:1A16:/
+828.4 "Gobsway Rumblerocks" sync / 1[56]:[^:]*:Lamebrix Strikebocks:1AA0:/
+832.5 "Gobsway Rumblerocks" sync / 1[56]:[^:]*:Lamebrix Strikebocks:1AA0:/
+840.7 "Gobsnick Leghops" sync / 1[56]:[^:]*:Lamebrix Strikebocks:1AA4:/
+845.6 "Laceration" #sync / 1[56]:[^:]*:Buzzsaw:1A94:/
+847.8 "Goblin Rush" sync / 1[56]:[^:]*:Lamebrix Strikebocks:1A16:/
+848.6 "Laceration" #sync / 1[56]:[^:]*:Buzzsaw:1A94:/
+851.6 "Laceration" #sync / 1[56]:[^:]*:Buzzsaw:1A94:/
+855.9 "Gobrush Rushgob" sync / 1[56]:[^:]*:Lamebrix Strikebocks:1A9F:/
+860.0 "Goblin Rush" sync / 1[56]:[^:]*:Lamebrix Strikebocks:1A16:/
 
 # Loop
-868.1 "--sync--" #sync / 1[56]:Lamebrix Strikebocks:1AB[89AB]:/
-870.1 "--sync--" #sync / 1[56]:Lamebrix Strikebocks:1AB[89AB]:/
-872.1 "--sync--" #sync / 1[56]:Lamebrix Strikebocks:1AB[89AB]:/
-875.3 "Triple Charge" sync / 1[56]:Lamebrix Strikebocks:1A99:/ window 300,300 jump 528.5
-876.1 "--mechanic 1--" #sync / 1[56]:Lamebrix Strikebocks:1A9[ABCE]:/
-879.2 "--mechanic 2--" #sync / 1[56]:Lamebrix Strikebocks:1A9[ABCE]:/
-883.7 "--mechanic 3--" #sync / 1[56]:Lamebrix Strikebocks:1A9[ABCE]:/
-888.8 "Goblin Rush" #sync / 1[56]:Lamebrix Strikebocks:1A16:/
-892.9 "Gobsway Rumblerocks" #sync / 1[56]:Lamebrix Strikebocks:1AA0:/
-897.0 "Goblin Rush" #sync / 1[56]:Lamebrix Strikebocks:1A16:/
-901.1 "Gobsway Rumblerocks" #sync / 1[56]:Lamebrix Strikebocks:1AA0:/
-906.2 "--jump--" #sync / 1[56]:Lamebrix Strikebocks:1AA2:/
-908.5 "--sync--" #sync / 1[56]:Lamebrix Strikebocks:1AB8:/
-911.8 "Single Charge" #sync / 1[56]:Lamebrix Strikebocks:1A97:/
-912.6 "--in--" #sync / 1[56]:Lamebrix Strikebocks:1A9A:/
+868.1 "--sync--" #sync / 1[56]:[^:]*:Lamebrix Strikebocks:1AB[89AB]:/
+870.1 "--sync--" #sync / 1[56]:[^:]*:Lamebrix Strikebocks:1AB[89AB]:/
+872.1 "--sync--" #sync / 1[56]:[^:]*:Lamebrix Strikebocks:1AB[89AB]:/
+875.3 "Triple Charge" sync / 1[56]:[^:]*:Lamebrix Strikebocks:1A99:/ window 300,300 jump 528.5
+876.1 "--mechanic 1--" #sync / 1[56]:[^:]*:Lamebrix Strikebocks:1A9[ABCE]:/
+879.2 "--mechanic 2--" #sync / 1[56]:[^:]*:Lamebrix Strikebocks:1A9[ABCE]:/
+883.7 "--mechanic 3--" #sync / 1[56]:[^:]*:Lamebrix Strikebocks:1A9[ABCE]:/
+888.8 "Goblin Rush" #sync / 1[56]:[^:]*:Lamebrix Strikebocks:1A16:/
+892.9 "Gobsway Rumblerocks" #sync / 1[56]:[^:]*:Lamebrix Strikebocks:1AA0:/
+897.0 "Goblin Rush" #sync / 1[56]:[^:]*:Lamebrix Strikebocks:1A16:/
+901.1 "Gobsway Rumblerocks" #sync / 1[56]:[^:]*:Lamebrix Strikebocks:1AA0:/
+906.2 "--jump--" #sync / 1[56]:[^:]*:Lamebrix Strikebocks:1AA2:/
+908.5 "--sync--" #sync / 1[56]:[^:]*:Lamebrix Strikebocks:1AB8:/
+911.8 "Single Charge" #sync / 1[56]:[^:]*:Lamebrix Strikebocks:1A97:/
+912.6 "--in--" #sync / 1[56]:[^:]*:Lamebrix Strikebocks:1A9A:/

--- a/ui/raidboss/data/03-hw/raid/a11s.txt
+++ b/ui/raidboss/data/03-hw/raid/a11s.txt
@@ -15,15 +15,15 @@ hideall "--sync--"
 
 0.0 "--sync--" sync /:Engage!/ window 0,1
 0.0 "--sync--" sync / 00:0839::The Main Generators will be sealed off in 15 seconds/ window 10,10
-6.2 "--sync--" sync / 14:Cruise Chaser:1A7[A9]:/ window 7,5
-9.2 "Left/Right Laser Sword" sync / 1[56]:Cruise Chaser:1A7[A9]:/
+6.2 "--sync--" sync / 14:[^:]*:Cruise Chaser:1A7[A9]:/ window 7,5
+9.2 "Left/Right Laser Sword" sync / 1[56]:[^:]*:Cruise Chaser:1A7[A9]:/
 
 # skippable
-17.3 "Optical Sight (clock/out)" sync / 1[56]:Cruise Chaser:1A6[CD]:/
+17.3 "Optical Sight (clock/out)" sync / 1[56]:[^:]*:Cruise Chaser:1A6[CD]:/
 
 # skippable
-33.4 "Whirlwind" sync / 1[56]:Cruise Chaser:1A84:/
-40.6 "Spin Crusher" sync / 1[56]:Cruise Chaser:1A85:/
+33.4 "Whirlwind" sync / 1[56]:[^:]*:Cruise Chaser:1A84:/
+40.6 "Spin Crusher" sync / 1[56]:[^:]*:Cruise Chaser:1A85:/
 
 # skippable
 45.8 "E.D.D. Add" sync / 03:........:E\.D\.D\.:/ window 50,5
@@ -31,195 +31,195 @@ hideall "--sync--"
 # If we jump to this laser sword immediately after first, the timing is:
 # 9.2 (first sword) 21.7 (second sword)
 # Sync to somewhere that will catch t=18.7 - 2.5 seconds = ~36 window (at least)
-51.8 "--sync--" sync / 14:Cruise Chaser:1A7[A9]:/ window 40,5
-54.8 "Left/Right Laser Sword" sync / 1[56]:Cruise Chaser:1A7[A9]:/
+51.8 "--sync--" sync / 14:[^:]*:Cruise Chaser:1A7[A9]:/ window 40,5
+54.8 "Left/Right Laser Sword" sync / 1[56]:[^:]*:Cruise Chaser:1A7[A9]:/
 55.8 "E.D.D. Armored Pauldron"
-64.0 "Spin Crusher" sync / 1[56]:Cruise Chaser:1A85:/
-81.2 "Whirlwind" sync / 1[56]:Cruise Chaser:1A84:/
+64.0 "Spin Crusher" sync / 1[56]:[^:]*:Cruise Chaser:1A85:/
+81.2 "Whirlwind" sync / 1[56]:[^:]*:Cruise Chaser:1A84:/
 
-85.3 "--sync--" sync / 14:Cruise Chaser:1A7[A9]:/ window 30,5
-88.3 "Left/Right Laser Sword" sync / 1[56]:Cruise Chaser:1A7[A9]:/
+85.3 "--sync--" sync / 14:[^:]*:Cruise Chaser:1A7[A9]:/ window 30,5
+88.3 "Left/Right Laser Sword" sync / 1[56]:[^:]*:Cruise Chaser:1A7[A9]:/
 
 # GA-100 in the first phase.  WHO KNEW?
 # There's a question mark because nobody should ever see this.
-101.6 "GA-100?" sync / 1[56]:Cruise Chaser:1A76:/
+101.6 "GA-100?" sync / 1[56]:[^:]*:Cruise Chaser:1A76:/
 
 # can skip add and jump here
-112.7 "--sync--" sync / 14:Cruise Chaser:1A6E:/ window 113,5
-114.7 "Optical Sight (bait)" sync / 1[56]:Cruise Chaser:1A6E:/
-119.9 "Hawk Blaster" sync / 1[56]:Cruise Chaser:1A6F:/
+112.7 "--sync--" sync / 14:[^:]*:Cruise Chaser:1A6E:/ window 113,5
+114.7 "Optical Sight (bait)" sync / 1[56]:[^:]*:Cruise Chaser:1A6E:/
+119.9 "Hawk Blaster" sync / 1[56]:[^:]*:Cruise Chaser:1A6F:/
 
-129.8 "Optical Sight (clock/out)" sync / 1[56]:Cruise Chaser:1A6[CD]:/
-137.9 "Super Hawk Blaster" sync / 1[56]:Cruise Chaser:1A71:/
+129.8 "Optical Sight (clock/out)" sync / 1[56]:[^:]*:Cruise Chaser:1A6[CD]:/
+137.9 "Super Hawk Blaster" sync / 1[56]:[^:]*:Cruise Chaser:1A71:/
 
-143.9 "Optical Sight (out/clock)" sync / 1[56]:Cruise Chaser:1A6[CD]:/
-150.9 "Super Hawk Blaster" sync / 1[56]:Cruise Chaser:1A71:/
+143.9 "Optical Sight (out/clock)" sync / 1[56]:[^:]*:Cruise Chaser:1A6[CD]:/
+150.9 "Super Hawk Blaster" sync / 1[56]:[^:]*:Cruise Chaser:1A71:/
 
-159.9 "Whirlwind" sync / 1[56]:Cruise Chaser:1A84:/
-168.1 "Left/Right Laser Sword" sync / 1[56]:Cruise Chaser:1A7[A9]:/
+159.9 "Whirlwind" sync / 1[56]:[^:]*:Cruise Chaser:1A84:/
+168.1 "Left/Right Laser Sword" sync / 1[56]:[^:]*:Cruise Chaser:1A7[A9]:/
 
 ### Limit Cut Numbers
-177.3 "--sync--" sync / 14:Cruise Chaser:1A80:/ window 180,5
-179.3 "Limit Cut (numbers)" sync / 1[56]:Cruise Chaser:1A80:/
+177.3 "--sync--" sync / 14:[^:]*:Cruise Chaser:1A80:/ window 180,5
+179.3 "Limit Cut (numbers)" sync / 1[56]:[^:]*:Cruise Chaser:1A80:/
 179.9 "--invincible--"
 183.5 "Markers"
-192.1 "Sword 1" sync / 1[56]:Cruise Chaser:1A81:/
-193.2 "Charge 2" sync / 1[56]:Cruise Chaser:1A82:/
-195.4 "Sword 3" sync / 1[56]:Cruise Chaser:1A81:/
-196.5 "Charge 4" sync / 1[56]:Cruise Chaser:1A82:/
-198.7 "Sword 5" sync / 1[56]:Cruise Chaser:1A81:/
-199.8 "Charge 6" sync / 1[56]:Cruise Chaser:1A82:/
-202.0 "Sword 7" sync / 1[56]:Cruise Chaser:1A81:/
-203.1 "Charge 8" sync / 1[56]:Cruise Chaser:1A82:/
+192.1 "Sword 1" sync / 1[56]:[^:]*:Cruise Chaser:1A81:/
+193.2 "Charge 2" sync / 1[56]:[^:]*:Cruise Chaser:1A82:/
+195.4 "Sword 3" sync / 1[56]:[^:]*:Cruise Chaser:1A81:/
+196.5 "Charge 4" sync / 1[56]:[^:]*:Cruise Chaser:1A82:/
+198.7 "Sword 5" sync / 1[56]:[^:]*:Cruise Chaser:1A81:/
+199.8 "Charge 6" sync / 1[56]:[^:]*:Cruise Chaser:1A82:/
+202.0 "Sword 7" sync / 1[56]:[^:]*:Cruise Chaser:1A81:/
+203.1 "Charge 8" sync / 1[56]:[^:]*:Cruise Chaser:1A82:/
 205.2 "--targetable--"
 
-215.3 "Photon" sync / 1[56]:Cruise Chaser:1A73:/
-222.4 "Whirlwind" sync / 1[56]:Cruise Chaser:1A84:/
-229.6 "Left/Right Laser Sword" sync / 1[56]:Cruise Chaser:1A7[A9]:/
-237.1 "Blastoff" sync / 1[56]:Cruise Chaser:1A66:/ window 240,10
+215.3 "Photon" sync / 1[56]:[^:]*:Cruise Chaser:1A73:/
+222.4 "Whirlwind" sync / 1[56]:[^:]*:Cruise Chaser:1A84:/
+229.6 "Left/Right Laser Sword" sync / 1[56]:[^:]*:Cruise Chaser:1A7[A9]:/
+237.1 "Blastoff" sync / 1[56]:[^:]*:Cruise Chaser:1A66:/ window 240,10
 237.9 "--untargetable--"
 
 
 ### Cutscene
-240.2 "Transform" sync / 1[56]:Cruise Chaser:1A49:/
-247.9 "--sync--" sync / 1[56]:Cruise Chaser:1A4A:/
-252.8 "Blassty Blaster" sync / 1[56]:Cruise Chaser:1A69:/
-258.8 "Transform" sync / 1[56]:Cruise Chaser:1A4E:/
-264.8 "Perfect Landing" sync / 1[56]:Cruise Chaser:1A6B:/
+240.2 "Transform" sync / 1[56]:[^:]*:Cruise Chaser:1A49:/
+247.9 "--sync--" sync / 1[56]:[^:]*:Cruise Chaser:1A4A:/
+252.8 "Blassty Blaster" sync / 1[56]:[^:]*:Cruise Chaser:1A69:/
+258.8 "Transform" sync / 1[56]:[^:]*:Cruise Chaser:1A4E:/
+264.8 "Perfect Landing" sync / 1[56]:[^:]*:Cruise Chaser:1A6B:/
 
 
 ### ORBS
 268.0 "--targetable--"
-270.1 "Limit Cut (orbs)" sync / 1[56]:Cruise Chaser:1A80:/
+270.1 "Limit Cut (orbs)" sync / 1[56]:[^:]*:Cruise Chaser:1A80:/
 270.7 "--invincible--"
 273.2 "Lapis Lazuli x4"
-276.3 "--sync--" sync / 1[56]:Cruise Chaser:1A7B:/
+276.3 "--sync--" sync / 1[56]:[^:]*:Cruise Chaser:1A7B:/
 276.8 "Plasmasphere x1"
-283.4 "Whirlwind" sync / 1[56]:Cruise Chaser:1A84:/
-287.6 "--sync--" sync / 1[56]:Cruise Chaser:1A5A:/
-292.7 "--sync--" sync / 1[56]:Claster:1A5B:/
-295.7 "--sync--" sync / 1[56]:Cruise Chaser:1A7B:/
+283.4 "Whirlwind" sync / 1[56]:[^:]*:Cruise Chaser:1A84:/
+287.6 "--sync--" sync / 1[56]:[^:]*:Cruise Chaser:1A5A:/
+292.7 "--sync--" sync / 1[56]:[^:]*:Claster:1A5B:/
+295.7 "--sync--" sync / 1[56]:[^:]*:Cruise Chaser:1A7B:/
 296.4 "Plasmasphere x2"
-297.4 "Assault Cannon" #sync / 1[56]:Claster:1A78:/
-308.0 "Laser X Sword" sync / 1[56]:Cruise Chaser:1A7F:/
-308.9 "--sync--" sync / 1[56]:Claster:1A5B:/
-313.7 "Assault Cannon" #sync / 1[56]:Claster:1A78:/
-315.1 "--sync--" sync / 1[56]:Cruise Chaser:1A7B:/
+297.4 "Assault Cannon" #sync / 1[56]:[^:]*:Claster:1A78:/
+308.0 "Laser X Sword" sync / 1[56]:[^:]*:Cruise Chaser:1A7F:/
+308.9 "--sync--" sync / 1[56]:[^:]*:Claster:1A5B:/
+313.7 "Assault Cannon" #sync / 1[56]:[^:]*:Claster:1A78:/
+315.1 "--sync--" sync / 1[56]:[^:]*:Cruise Chaser:1A7B:/
 315.7 "Plasmasphere x2"
-321.7 "Assault Cannon" #sync / 1[56]:Claster:1A78:/
-326.2 "Left/Right Laser Sword" sync / 1[56]:Cruise Chaser:1A7[A9]:/
-338.3 "Whirlwind" sync / 1[56]:Cruise Chaser:1A84:/
+321.7 "Assault Cannon" #sync / 1[56]:[^:]*:Claster:1A78:/
+326.2 "Left/Right Laser Sword" sync / 1[56]:[^:]*:Cruise Chaser:1A7[A9]:/
+338.3 "Whirlwind" sync / 1[56]:[^:]*:Cruise Chaser:1A84:/
 
 
 ### Eternal Darkness
 344.4 "--targetable--"
-344.5 "--sync--" sync / 14:Cruise Chaser:1A19:/ window 350,10
-352.5 "Eternal Darkness" sync / 1[56]:Cruise Chaser:1A19:/
-361.7 "Left/Right Laser Sword" sync / 1[56]:Cruise Chaser:1A7[A9]:/
-370.8 "Whirlwind" sync / 1[56]:Cruise Chaser:1A84:/
-378.9 "Spin Crusher" sync / 1[56]:Cruise Chaser:1A85:/
+344.5 "--sync--" sync / 14:[^:]*:Cruise Chaser:1A19:/ window 350,10
+352.5 "Eternal Darkness" sync / 1[56]:[^:]*:Cruise Chaser:1A19:/
+361.7 "Left/Right Laser Sword" sync / 1[56]:[^:]*:Cruise Chaser:1A7[A9]:/
+370.8 "Whirlwind" sync / 1[56]:[^:]*:Cruise Chaser:1A84:/
+378.9 "Spin Crusher" sync / 1[56]:[^:]*:Cruise Chaser:1A85:/
 
 # skippable
-386.0 "Optical Sight (bait)" sync / 1[56]:Cruise Chaser:1A6E:/
-391.2 "Hawk Blaster" sync / 1[56]:Cruise Chaser:1A6F:/
-396.1 "Super Hawk Blaster" sync / 1[56]:Cruise Chaser:1A71:/
+386.0 "Optical Sight (bait)" sync / 1[56]:[^:]*:Cruise Chaser:1A6E:/
+391.2 "Hawk Blaster" sync / 1[56]:[^:]*:Cruise Chaser:1A6F:/
+396.1 "Super Hawk Blaster" sync / 1[56]:[^:]*:Cruise Chaser:1A71:/
 
 # also skippable
-399.2 "--sync--" sync / 14:Cruise Chaser:1A80:/ window 50,10
-401.2 "Limit Cut (shield)" sync / 1[56]:Cruise Chaser:1A80:/
+399.2 "--sync--" sync / 14:[^:]*:Cruise Chaser:1A80:/ window 50,10
+401.2 "Limit Cut (shield)" sync / 1[56]:[^:]*:Cruise Chaser:1A80:/
 401.8 "--invincible--"
 406.6 "Plasma Shield"
 431.2 "Plasma Shield Enrage"
-431.2 "--sync--" sync / 14:Cruise Chaser:1A83:/ window 40,30
-435.2 "Blassty Charge" sync / 1[56]:Cruise Chaser:1A83:/
+431.2 "--sync--" sync / 14:[^:]*:Cruise Chaser:1A83:/ window 40,30
+435.2 "Blassty Charge" sync / 1[56]:[^:]*:Cruise Chaser:1A83:/
 437.3 "--targetable--"
 
-439.5 "--sync--" sync / 14:Cruise Chaser:1A73:/ window 40,10
-442.5 "Photon (offtank)" sync / 1[56]:Cruise Chaser:1A73:/
-450.9 "Laser X Sword" sync / 1[56]:Cruise Chaser:1A7F:/
+439.5 "--sync--" sync / 14:[^:]*:Cruise Chaser:1A73:/ window 40,10
+442.5 "Photon (offtank)" sync / 1[56]:[^:]*:Cruise Chaser:1A73:/
+450.9 "Laser X Sword" sync / 1[56]:[^:]*:Cruise Chaser:1A7F:/
 
 # maybe skippable
 458.7 "E.D.D. Add" sync / 03:........:E\.D\.D\.:/
-462.0 "Photon (dps)" sync / 1[56]:Cruise Chaser:1A73:/
-470.2 "Whirlwind" sync / 1[56]:Cruise Chaser:1A84:/
+462.0 "Photon (dps)" sync / 1[56]:[^:]*:Cruise Chaser:1A73:/
+470.2 "Whirlwind" sync / 1[56]:[^:]*:Cruise Chaser:1A84:/
 
-478.4 "--sync--" sync / 14:Cruise Chaser:1A7[A9]:/ window 80,5
-481.4 "Left/Right Laser Sword" sync / 1[56]:Cruise Chaser:1A7[A9]:/
-487.5 "Photon (healer)" sync / 1[56]:Cruise Chaser:1A73:/
-495.6 "Whirlwind" sync / 1[56]:Cruise Chaser:1A84:/
-502.1 "Blastoff" sync / 1[56]:Cruise Chaser:1A66:/ window 260,10
+478.4 "--sync--" sync / 14:[^:]*:Cruise Chaser:1A7[A9]:/ window 80,5
+481.4 "Left/Right Laser Sword" sync / 1[56]:[^:]*:Cruise Chaser:1A7[A9]:/
+487.5 "Photon (healer)" sync / 1[56]:[^:]*:Cruise Chaser:1A73:/
+495.6 "Whirlwind" sync / 1[56]:[^:]*:Cruise Chaser:1A84:/
+502.1 "Blastoff" sync / 1[56]:[^:]*:Cruise Chaser:1A66:/ window 260,10
 502.9 "--untargetable--"
 
 
 ### Cutscene 2
-505.2 "Transform" sync / 1[56]:Cruise Chaser:1A49:/
-513.0 "--sync--" sync / 1[56]:Cruise Chaser:1A4A:/
-517.8 "Blassty Blaster" sync / 1[56]:Cruise Chaser:1A69:/
+505.2 "Transform" sync / 1[56]:[^:]*:Cruise Chaser:1A49:/
+513.0 "--sync--" sync / 1[56]:[^:]*:Cruise Chaser:1A4A:/
+517.8 "Blassty Blaster" sync / 1[56]:[^:]*:Cruise Chaser:1A69:/
 520.8 "Multifield x3" sync / 03:........:Multifield:/
-523.9 "Transform" sync / 1[56]:Cruise Chaser:1A4E:/
-529.9 "Perfect Landing" sync / 1[56]:Cruise Chaser:1A6B:/
+523.9 "Transform" sync / 1[56]:[^:]*:Cruise Chaser:1A4E:/
+529.9 "Perfect Landing" sync / 1[56]:[^:]*:Cruise Chaser:1A6B:/
 
 
 ### Final phase
 532.7 "--targetable--"
-551.3 "GA-100" sync / 1[56]:Cruise Chaser:1A76:/
-558.4 "Optical Sight (clock/out)" sync / 1[56]:Cruise Chaser:1A6[CD]:/
-565.5 "Super Hawk Blaster" sync / 1[56]:Cruise Chaser:1A71:/
-573.6 "Optical Sight (out/clock)" sync / 1[56]:Cruise Chaser:1A6[CD]:/
-581.7 "Super Hawk Blaster" sync / 1[56]:Cruise Chaser:1A71:/
-586.7 "Whirlwind" sync / 1[56]:Cruise Chaser:1A84:/
-595.9 "Whirlwind" sync / 1[56]:Cruise Chaser:1A84:/
-605.1 "Laser X Sword" sync / 1[56]:Cruise Chaser:1A7F:/
-612.2 "Optical Sight (bait)" sync / 1[56]:Cruise Chaser:1A6E:/
-617.4 "Hawk Blaster" sync / 1[56]:Cruise Chaser:1A6F:/
-622.3 "Super Hawk Blaster" sync / 1[56]:Cruise Chaser:1A71:/
-622.4 "--sync--" sync / 1[56]:Cruise Chaser:1A5A:/
-626.6 "--sync--" sync / 1[56]:Claster:1A5B:/
+551.3 "GA-100" sync / 1[56]:[^:]*:Cruise Chaser:1A76:/
+558.4 "Optical Sight (clock/out)" sync / 1[56]:[^:]*:Cruise Chaser:1A6[CD]:/
+565.5 "Super Hawk Blaster" sync / 1[56]:[^:]*:Cruise Chaser:1A71:/
+573.6 "Optical Sight (out/clock)" sync / 1[56]:[^:]*:Cruise Chaser:1A6[CD]:/
+581.7 "Super Hawk Blaster" sync / 1[56]:[^:]*:Cruise Chaser:1A71:/
+586.7 "Whirlwind" sync / 1[56]:[^:]*:Cruise Chaser:1A84:/
+595.9 "Whirlwind" sync / 1[56]:[^:]*:Cruise Chaser:1A84:/
+605.1 "Laser X Sword" sync / 1[56]:[^:]*:Cruise Chaser:1A7F:/
+612.2 "Optical Sight (bait)" sync / 1[56]:[^:]*:Cruise Chaser:1A6E:/
+617.4 "Hawk Blaster" sync / 1[56]:[^:]*:Cruise Chaser:1A6F:/
+622.3 "Super Hawk Blaster" sync / 1[56]:[^:]*:Cruise Chaser:1A71:/
+622.4 "--sync--" sync / 1[56]:[^:]*:Cruise Chaser:1A5A:/
+626.6 "--sync--" sync / 1[56]:[^:]*:Claster:1A5B:/
 # Well, really everyone but the main tank.  But that's too long to write out.
-628.6 "Photon (everyone)" sync / 1[56]:Cruise Chaser:1A73:/
-633.1 "Assault Cannon" #sync / 1[56]:Claster:1A78:/
-635.8 "Whirlwind" sync / 1[56]:Cruise Chaser:1A84:/
-640.3 "Assault Cannon" #sync / 1[56]:Claster:1A78:/
-647.4 "Assault Cannon" #sync / 1[56]:Claster:1A78:/
-651.8 "Propeller Wind" sync / 1[56]:Cruise Chaser:1A75:/
+628.6 "Photon (everyone)" sync / 1[56]:[^:]*:Cruise Chaser:1A73:/
+633.1 "Assault Cannon" #sync / 1[56]:[^:]*:Claster:1A78:/
+635.8 "Whirlwind" sync / 1[56]:[^:]*:Cruise Chaser:1A84:/
+640.3 "Assault Cannon" #sync / 1[56]:[^:]*:Claster:1A78:/
+647.4 "Assault Cannon" #sync / 1[56]:[^:]*:Claster:1A78:/
+651.8 "Propeller Wind" sync / 1[56]:[^:]*:Cruise Chaser:1A75:/
 
-655.0 "--sync--" sync / 14:Cruise Chaser:1A80:/ window 100,20
-657.0 "Limit Cut (numbers)" sync / 1[56]:Cruise Chaser:1A80:/
+655.0 "--sync--" sync / 14:[^:]*:Cruise Chaser:1A80:/ window 100,20
+657.0 "Limit Cut (numbers)" sync / 1[56]:[^:]*:Cruise Chaser:1A80:/
 657.6 "--invincible--"
 661.2 "Markers"
-669.9 "Sword 1" sync / 1[56]:Cruise Chaser:1A81:/
-671.0 "Charge 2" sync / 1[56]:Cruise Chaser:1A82:/
-673.2 "Sword 3" sync / 1[56]:Cruise Chaser:1A81:/
-674.3 "Charge 4" sync / 1[56]:Cruise Chaser:1A82:/
-676.5 "Sword 5" sync / 1[56]:Cruise Chaser:1A81:/
-677.6 "Charge 6" sync / 1[56]:Cruise Chaser:1A82:/
-679.8 "Sword 7" sync / 1[56]:Cruise Chaser:1A81:/
-680.9 "Charge 8" sync / 1[56]:Cruise Chaser:1A82:/
+669.9 "Sword 1" sync / 1[56]:[^:]*:Cruise Chaser:1A81:/
+671.0 "Charge 2" sync / 1[56]:[^:]*:Cruise Chaser:1A82:/
+673.2 "Sword 3" sync / 1[56]:[^:]*:Cruise Chaser:1A81:/
+674.3 "Charge 4" sync / 1[56]:[^:]*:Cruise Chaser:1A82:/
+676.5 "Sword 5" sync / 1[56]:[^:]*:Cruise Chaser:1A81:/
+677.6 "Charge 6" sync / 1[56]:[^:]*:Cruise Chaser:1A82:/
+679.8 "Sword 7" sync / 1[56]:[^:]*:Cruise Chaser:1A81:/
+680.9 "Charge 8" sync / 1[56]:[^:]*:Cruise Chaser:1A82:/
 683.0 "--targetable--"
 
-693.2 "Laser X Sword" sync / 1[56]:Cruise Chaser:1A7F:/
+693.2 "Laser X Sword" sync / 1[56]:[^:]*:Cruise Chaser:1A7F:/
 697.2 "E.D.D. Add" sync / 03:........:E\.D\.D\.:/
-705.4 "Photon (dps)" sync / 1[56]:Cruise Chaser:1A73:/
-714.6 "Left/Right Laser Sword" sync / 1[56]:Cruise Chaser:1A7[A9]:/
-722.7 "Photon (healer)" sync / 1[56]:Cruise Chaser:1A73:/
-730.8 "Whirlwind" sync / 1[56]:Cruise Chaser:1A84:/
+705.4 "Photon (dps)" sync / 1[56]:[^:]*:Cruise Chaser:1A73:/
+714.6 "Left/Right Laser Sword" sync / 1[56]:[^:]*:Cruise Chaser:1A7[A9]:/
+722.7 "Photon (healer)" sync / 1[56]:[^:]*:Cruise Chaser:1A73:/
+730.8 "Whirlwind" sync / 1[56]:[^:]*:Cruise Chaser:1A84:/
 
-733.7 "--sync--" sync / 14:Cruise Chaser:1A80:/ window 70,20
-735.7 "Limit Cut (shield)" sync / 1[56]:Cruise Chaser:1A80:/
+733.7 "--sync--" sync / 14:[^:]*:Cruise Chaser:1A80:/ window 70,20
+735.7 "Limit Cut (shield)" sync / 1[56]:[^:]*:Cruise Chaser:1A80:/
 736.3 "--invincible--"
 741.1 "Plasma Shield"
 765.7 "Plasma Shield Enrage"
-765.7 "--sync--" sync / 14:Cruise Chaser:1A83:/ window 40,30
-769.7 "Blassty Charge" sync / 1[56]:Cruise Chaser:1A83:/
+765.7 "--sync--" sync / 14:[^:]*:Cruise Chaser:1A83:/ window 40,30
+769.7 "Blassty Charge" sync / 1[56]:[^:]*:Cruise Chaser:1A83:/
 771.8 "--targetable--"
 
-779.7 "Spin Crusher" sync / 1[56]:Cruise Chaser:1A85:/
-789.7 "Whirlwind" sync / 1[56]:Cruise Chaser:1A84:/
-806.4 "Laser X Sword" sync / 1[56]:Cruise Chaser:1A7F:/
+779.7 "Spin Crusher" sync / 1[56]:[^:]*:Cruise Chaser:1A85:/
+789.7 "Whirlwind" sync / 1[56]:[^:]*:Cruise Chaser:1A84:/
+806.4 "Laser X Sword" sync / 1[56]:[^:]*:Cruise Chaser:1A7F:/
 
 # If you destroy a tower with the first GA-100, this is enrage.
 # FIXME: Guessing that this loops, but unclear.
-829.4 "GA-100" sync / 1[56]:Cruise Chaser:1A76:/ window 100,100 jump 551.3
+829.4 "GA-100" sync / 1[56]:[^:]*:Cruise Chaser:1A76:/ window 100,100 jump 551.3
 836.5 "Optical Sight (clock/out)"
 843.6 "Super Hawk Blaster"
 851.7 "Optical Sight (out/clock)"

--- a/ui/raidboss/data/03-hw/raid/a12n.txt
+++ b/ui/raidboss/data/03-hw/raid/a12n.txt
@@ -9,72 +9,72 @@ hideall "--sync--"
 0.0 "--Reset--" sync / 21:........:40000010:/ window 100000 jump 0
 
 0.0 "--sync--" sync /:Engage!/ window 0,1
-0.7 "--sync--" sync / 1[56]:Alexander Prime:1AE2:/ window 0.7,2
-6.4 "Divine Spear" sync / 1[56]:Alexander Prime:1AE3:/ window 6.4,5
-14.5 "Mega Holy" sync / 1[56]:Alexander Prime:1AE7:/
-22.6 "Punishing Heat" sync / 1[56]:Alexander Prime:1AE4:/
-31.8 "Sacrament" sync / 1[56]:Alexander Prime:1AE5:/ window 30,30
-36.0 "Divine Spear" sync / 1[56]:Alexander Prime:1AE3:/
-44.1 "Mega Holy" sync / 1[56]:Alexander Prime:1AE7:/
-51.2 "--sync--" sync / 1[56]:Alexander Prime:1AE8:/
-53.3 "Blazing Scourge" sync / 1[56]:Alexander Prime:1AE9:/
-56.4 "Divine Spear" sync / 1[56]:Alexander Prime:1AE3:/
+0.7 "--sync--" sync / 1[56]:[^:]*:Alexander Prime:1AE2:/ window 0.7,2
+6.4 "Divine Spear" sync / 1[56]:[^:]*:Alexander Prime:1AE3:/ window 6.4,5
+14.5 "Mega Holy" sync / 1[56]:[^:]*:Alexander Prime:1AE7:/
+22.6 "Punishing Heat" sync / 1[56]:[^:]*:Alexander Prime:1AE4:/
+31.8 "Sacrament" sync / 1[56]:[^:]*:Alexander Prime:1AE5:/ window 30,30
+36.0 "Divine Spear" sync / 1[56]:[^:]*:Alexander Prime:1AE3:/
+44.1 "Mega Holy" sync / 1[56]:[^:]*:Alexander Prime:1AE7:/
+51.2 "--sync--" sync / 1[56]:[^:]*:Alexander Prime:1AE8:/
+53.3 "Blazing Scourge" sync / 1[56]:[^:]*:Alexander Prime:1AE9:/
+56.4 "Divine Spear" sync / 1[56]:[^:]*:Alexander Prime:1AE3:/
 
 # The intermission can be pushed early at ~75% HP.
 61.4 "--untargetable--" sync / 22:........:Alexander Prime:........:Alexander Prime:00/ window 61.4,5
-161.9 "--sync--" sync / 1[56]:Alexander:1A18:/ window 161.9,5
-171.6 "Divine Judgment" sync / 1[56]:Alexander:1AEF:/
+161.9 "--sync--" sync / 1[56]:[^:]*:Alexander:1A18:/ window 161.9,5
+171.6 "Divine Judgment" sync / 1[56]:[^:]*:Alexander:1AEF:/
 
 # Bridge block to Timegate.
 182.4 "--targetable--"
-185.4 "Chronofoil" sync / 1[56]:Alexander Prime:19FA:/ window 185.4,5
-199.6 "Temporal Stasis" sync / 1[56]:Alexander Prime:1AF0:/
+185.4 "Chronofoil" sync / 1[56]:[^:]*:Alexander Prime:19FA:/ window 185.4,5
+199.6 "Temporal Stasis" sync / 1[56]:[^:]*:Alexander Prime:1AF0:/
 203.7 "--untargetable--"
-203.7 "Plaint Of Solidarity" sync / 1[56]:Alexander Prime:1AF2:/
+203.7 "Plaint Of Solidarity" sync / 1[56]:[^:]*:Alexander Prime:1AF2:/
 206.9 "--targetable--"
-212.0 "Sacrament" sync / 1[56]:Alexander Prime:1AE5:/
-217.2 "Divine Spear" sync / 1[56]:Alexander Prime:1AE3:/
-223.3 "Mega Holy" sync / 1[56]:Alexander Prime:1AE7:/
-229.6 "Punishing Heat" sync / 1[56]:Alexander Prime:1AE4:/
-234.8 "Divine Spear" sync / 1[56]:Alexander Prime:1AE3:/
-244.9 "Temporal Stasis" sync / 1[56]:Alexander Prime:1AF0:/ window 30,30
+212.0 "Sacrament" sync / 1[56]:[^:]*:Alexander Prime:1AE5:/
+217.2 "Divine Spear" sync / 1[56]:[^:]*:Alexander Prime:1AE3:/
+223.3 "Mega Holy" sync / 1[56]:[^:]*:Alexander Prime:1AE7:/
+229.6 "Punishing Heat" sync / 1[56]:[^:]*:Alexander Prime:1AE4:/
+234.8 "Divine Spear" sync / 1[56]:[^:]*:Alexander Prime:1AE3:/
+244.9 "Temporal Stasis" sync / 1[56]:[^:]*:Alexander Prime:1AF0:/ window 30,30
 249.0 "--untargetable--"
-249.0 "Plaint Of Solidarity" sync / 1[56]:Alexander Prime:1AF2:/
+249.0 "Plaint Of Solidarity" sync / 1[56]:[^:]*:Alexander Prime:1AF2:/
 252.2 "--targetable--"
-257.3 "Sacrament" sync / 1[56]:Alexander Prime:1AE5:/
-266.5 "--sync--" sync / 1[56]:Alexander Prime:1AE8:/
-268.7 "Blazing Scourge" sync / 1[56]:Alexander Prime:1AE9:/
-274.6 "Mega Holy" sync / 1[56]:Alexander Prime:1AE7:/
-278.8 "Divine Spear" sync / 1[56]:Alexander Prime:1AE3:/
+257.3 "Sacrament" sync / 1[56]:[^:]*:Alexander Prime:1AE5:/
+266.5 "--sync--" sync / 1[56]:[^:]*:Alexander Prime:1AE8:/
+268.7 "Blazing Scourge" sync / 1[56]:[^:]*:Alexander Prime:1AE9:/
+274.6 "Mega Holy" sync / 1[56]:[^:]*:Alexander Prime:1AE7:/
+278.8 "Divine Spear" sync / 1[56]:[^:]*:Alexander Prime:1AE3:/
 
 # Timegates seem to push at 50% HP.
 # Push timings during Timegate seem inconsistent, so we include plenty of windows.
 # We don't sync to the 22 log line here because Alexander uses it twice in the bridge block.
 282.8 "--untargetable--"
 286.1 "--targetable--"
-290.1 "Timegate" sync / 1[56]:Alexander Prime:1A03:/ window 290,5
-309.7 "Divine Spear" sync / 1[56]:Alexander Prime:1AE3:/
-318.8 "Punishing Heat" sync / 1[56]:Alexander Prime:1AE4:/
-325.9 "--sync--" sync / 1[56]:Alexander Prime:1AE8:/
-328.0 "Blazing Scourge" sync / 1[56]:Alexander Prime:1AE9:/ window 30,5
-332.9 "Sacrament" sync / 1[56]:Alexander Prime:1AE5:/
-342.1 "Mega Holy" sync / 1[56]:Alexander Prime:1AE7:/ window 50,5
-346.2 "Divine Spear" sync / 1[56]:Alexander Prime:1AE3:/
-354.3 "Punishing Heat" sync / 1[56]:Alexander Prime:1AE4:/
-369.5 "--sync--" sync / 1[56]:Alexander Prime:1AEA:/
-374.6 "--sync--" sync / 1[56]:Alexander Prime:1AE8:/
-375.5 "Gravitational Anomaly" sync / 1[56]:Alexander Prime:1AEB:/ window 100,10
-376.8 "Blazing Scourge" sync / 1[56]:Alexander Prime:1AE9:/
-378.8 "Divine Spear" sync / 1[56]:Alexander Prime:1AE3:/
-386.9 "Mega Holy" sync / 1[56]:Alexander Prime:1AE7:/
-395.0 "Punishing Heat" sync / 1[56]:Alexander Prime:1AE4:/
-399.2 "Divine Spear" sync / 1[56]:Alexander Prime:1AE3:/
-408.3 "Temporal Stasis" sync / 1[56]:Alexander Prime:1AF0:/
-412.4 "Plaint Of Solidarity" sync / 1[56]:Alexander Prime:1AF2:/
-415.4 "--sync--" sync / 1[56]:Alexander Prime:1AEA:/
-421.4 "Gravitational Anomaly" sync / 1[56]:Alexander Prime:1AEB:/
-422.6 "Sacrament" sync / 1[56]:Alexander Prime:1AE5:/
-429.8 "Incinerating Heat" sync / 1[56]:Alexander Prime:1AF3:/
+290.1 "Timegate" sync / 1[56]:[^:]*:Alexander Prime:1A03:/ window 290,5
+309.7 "Divine Spear" sync / 1[56]:[^:]*:Alexander Prime:1AE3:/
+318.8 "Punishing Heat" sync / 1[56]:[^:]*:Alexander Prime:1AE4:/
+325.9 "--sync--" sync / 1[56]:[^:]*:Alexander Prime:1AE8:/
+328.0 "Blazing Scourge" sync / 1[56]:[^:]*:Alexander Prime:1AE9:/ window 30,5
+332.9 "Sacrament" sync / 1[56]:[^:]*:Alexander Prime:1AE5:/
+342.1 "Mega Holy" sync / 1[56]:[^:]*:Alexander Prime:1AE7:/ window 50,5
+346.2 "Divine Spear" sync / 1[56]:[^:]*:Alexander Prime:1AE3:/
+354.3 "Punishing Heat" sync / 1[56]:[^:]*:Alexander Prime:1AE4:/
+369.5 "--sync--" sync / 1[56]:[^:]*:Alexander Prime:1AEA:/
+374.6 "--sync--" sync / 1[56]:[^:]*:Alexander Prime:1AE8:/
+375.5 "Gravitational Anomaly" sync / 1[56]:[^:]*:Alexander Prime:1AEB:/ window 100,10
+376.8 "Blazing Scourge" sync / 1[56]:[^:]*:Alexander Prime:1AE9:/
+378.8 "Divine Spear" sync / 1[56]:[^:]*:Alexander Prime:1AE3:/
+386.9 "Mega Holy" sync / 1[56]:[^:]*:Alexander Prime:1AE7:/
+395.0 "Punishing Heat" sync / 1[56]:[^:]*:Alexander Prime:1AE4:/
+399.2 "Divine Spear" sync / 1[56]:[^:]*:Alexander Prime:1AE3:/
+408.3 "Temporal Stasis" sync / 1[56]:[^:]*:Alexander Prime:1AF0:/
+412.4 "Plaint Of Solidarity" sync / 1[56]:[^:]*:Alexander Prime:1AF2:/
+415.4 "--sync--" sync / 1[56]:[^:]*:Alexander Prime:1AEA:/
+421.4 "Gravitational Anomaly" sync / 1[56]:[^:]*:Alexander Prime:1AEB:/
+422.6 "Sacrament" sync / 1[56]:[^:]*:Alexander Prime:1AE5:/
+429.8 "Incinerating Heat" sync / 1[56]:[^:]*:Alexander Prime:1AF3:/
 
 # Summon Alexander seems to push at 30% HP.
 # It appears that Alexander has to complete at least a part of the Timegate section first?
@@ -82,21 +82,21 @@ hideall "--sync--"
 # Enrage happens after loop 4 if there have been no phase pushes.
 # Whether this is the case with pushes is unknown.
 
-436.0 "Summon Alexander" sync / 1[56]:Alexander Prime:1A0A:/ window 412.8,5
-446.2 "Divine Spear" sync / 1[56]:Alexander Prime:1AE3:/
-454.3 "Mega Holy" sync / 1[56]:Alexander Prime:1AE7:/
-461.2 "Communion x4" # sync / 1[56]:Alexander:1AFC:/
-470.6 "Temporal Stasis" sync / 1[56]:Alexander Prime:1AF0:/ window 30,30
+436.0 "Summon Alexander" sync / 1[56]:[^:]*:Alexander Prime:1A0A:/ window 412.8,5
+446.2 "Divine Spear" sync / 1[56]:[^:]*:Alexander Prime:1AE3:/
+454.3 "Mega Holy" sync / 1[56]:[^:]*:Alexander Prime:1AE7:/
+461.2 "Communion x4" # sync / 1[56]:[^:]*:Alexander:1AFC:/
+470.6 "Temporal Stasis" sync / 1[56]:[^:]*:Alexander Prime:1AF0:/ window 30,30
 474.7 "--untargetable--"
-474.7 "Plaint Of Solidarity" sync / 1[56]:Alexander Prime:1AF2:/
+474.7 "Plaint Of Solidarity" sync / 1[56]:[^:]*:Alexander Prime:1AF2:/
 477.9 "--targetable--"
-481.4 "Communion x4" # sync / 1[56]:Alexander:1AFC:/
-483.0 "Sacrament" sync / 1[56]:Alexander Prime:1AE5:/
-499.2 "Punishing Heat" sync / 1[56]:Alexander Prime:1AE4:/ window 30,30
-503.4 "Divine Spear" sync / 1[56]:Alexander Prime:1AE3:/
-511.5 "Mega Holy" sync / 1[56]:Alexander Prime:1AE7:/
+481.4 "Communion x4" # sync / 1[56]:[^:]*:Alexander:1AFC:/
+483.0 "Sacrament" sync / 1[56]:[^:]*:Alexander Prime:1AE5:/
+499.2 "Punishing Heat" sync / 1[56]:[^:]*:Alexander Prime:1AE4:/ window 30,30
+503.4 "Divine Spear" sync / 1[56]:[^:]*:Alexander Prime:1AE3:/
+511.5 "Mega Holy" sync / 1[56]:[^:]*:Alexander Prime:1AE7:/
 
-521.7 "Divine Spear" sync / 1[56]:Alexander Prime:1AE3:/ jump 446.2
+521.7 "Divine Spear" sync / 1[56]:[^:]*:Alexander Prime:1AE3:/ jump 446.2
 529.8 "Mega Holy"
 536.7 "Communion x4"
 546.1 "Temporal Stasis"

--- a/ui/raidboss/data/03-hw/raid/a12s.txt
+++ b/ui/raidboss/data/03-hw/raid/a12s.txt
@@ -13,19 +13,19 @@ hideall "--sync--"
 
 ### Phase 1
 0.0 "--sync--" sync /:Engage!/ window 0,1
-1.0 "--sync--" sync / 1[56]:Alexander Prime:19E7:/ window 1,0
-7.0 "Divine Spear" sync / 1[56]:Alexander Prime:19E8:/ window 7,10
-14.1 "Punishing Heat" sync / 1[56]:Alexander Prime:19E9:/
-17.3 "Divine Spear" sync / 1[56]:Alexander Prime:19E8:/
-23.4 "Blazing Scourge" sync / 1[56]:Alexander Prime:19EF:/ duration 6.3
-30.5 "Incinerating Heat" sync / 1[56]:Alexander Prime:19EA:/
-35.7 "Mega Holy" sync / 1[56]:Alexander Prime:19EE:/
-40.8 "Mega Holy" sync / 1[56]:Alexander Prime:19EE:/
-45.9 "--sync--" sync / 1[56]:Alexander Prime:19F1:/
-51.9 "Gravitational Anomaly" sync / 1[56]:Alexander Prime:19F2:/
-54.0 "(Radiant?) Sacrament" sync / 1[56]:Alexander Prime:19E[BD]:/
-58.1 "Divine Spear" sync / 1[56]:Alexander Prime:19E8:/
-65.2 "Punishing Heat" sync / 1[56]:Alexander Prime:19E9:/
+1.0 "--sync--" sync / 1[56]:[^:]*:Alexander Prime:19E7:/ window 1,0
+7.0 "Divine Spear" sync / 1[56]:[^:]*:Alexander Prime:19E8:/ window 7,10
+14.1 "Punishing Heat" sync / 1[56]:[^:]*:Alexander Prime:19E9:/
+17.3 "Divine Spear" sync / 1[56]:[^:]*:Alexander Prime:19E8:/
+23.4 "Blazing Scourge" sync / 1[56]:[^:]*:Alexander Prime:19EF:/ duration 6.3
+30.5 "Incinerating Heat" sync / 1[56]:[^:]*:Alexander Prime:19EA:/
+35.7 "Mega Holy" sync / 1[56]:[^:]*:Alexander Prime:19EE:/
+40.8 "Mega Holy" sync / 1[56]:[^:]*:Alexander Prime:19EE:/
+45.9 "--sync--" sync / 1[56]:[^:]*:Alexander Prime:19F1:/
+51.9 "Gravitational Anomaly" sync / 1[56]:[^:]*:Alexander Prime:19F2:/
+54.0 "(Radiant?) Sacrament" sync / 1[56]:[^:]*:Alexander Prime:19E[BD]:/
+58.1 "Divine Spear" sync / 1[56]:[^:]*:Alexander Prime:19E8:/
+65.2 "Punishing Heat" sync / 1[56]:[^:]*:Alexander Prime:19E9:/
 67.2 "--untargetable--" sync / 22:........:Alexander Prime:........:Alexander Prime:00/ window 70,5
 
 
@@ -34,131 +34,131 @@ hideall "--sync--"
 70.4 "Arrhidaeus's Lanner x8"
 
 105.5 "The General's Wing x4"
-113.7 "--sync--" sync / 14:The General's Wing:19F7:/ window 114,3
-116.7 "Almost Holy" sync / 1[56]:The General's Wing:19F7:/
-124.9 "Almost Holy" sync / 1[56]:The General's Wing:19F7:/
-133.2 "Almost Holy" sync / 1[56]:The General's Wing:19F7:/
+113.7 "--sync--" sync / 14:[^:]*:The General's Wing:19F7:/ window 114,3
+116.7 "Almost Holy" sync / 1[56]:[^:]*:The General's Wing:19F7:/
+124.9 "Almost Holy" sync / 1[56]:[^:]*:The General's Wing:19F7:/
+133.2 "Almost Holy" sync / 1[56]:[^:]*:The General's Wing:19F7:/
 
 139.2 "The General's Might (W)" sync / 03:........:The General's Might:/  window 150,5
 139.2 "The General's Time (E)"
-141.6 "Almost Holy?" sync / 1[56]:The General's Wing:19F7:/
-150.4 "Smash" sync / 1[56]:The General's Might:19F3:/ window 151,3
-154.4 "Half Gravity" sync / 1[56]:The General's Time:19F5:/
-158.7 "Smash" sync / 1[56]:The General's Might:19F3:/
-163.7 "Half Gravity" sync / 1[56]:The General's Time:19F5:/
-167.0 "Smash" sync / 1[56]:The General's Might:19F3:/
-172.9 "Half Gravity" sync / 1[56]:The General's Time:19F5:/
-175.3 "Smash" sync / 1[56]:The General's Might:19F3:/
-182.2 "Half Gravity" sync / 1[56]:The General's Time:19F5:/
-183.6 "Smash" sync / 1[56]:The General's Might:19F3:/
-191.5 "Half Gravity" sync / 1[56]:The General's Time:19F5:/
-191.9 "Smash" sync / 1[56]:The General's Might:19F3:/
-200.2 "Smash" sync / 1[56]:The General's Might:19F3:/
-200.8 "Half Gravity" sync / 1[56]:The General's Time:19F5:/
-208.5 "Smash" sync / 1[56]:The General's Might:19F3:/
-210.1 "Half Gravity" sync / 1[56]:The General's Time:19F5:/
-216.8 "Smash" sync / 1[56]:The General's Might:19F3:/
-219.4 "Half Gravity" sync / 1[56]:The General's Time:19F5:/
-225.1 "Smash" sync / 1[56]:The General's Might:19F3:/
-228.8 "Half Gravity" sync / 1[56]:The General's Time:19F5:/
-233.4 "Smash" sync / 1[56]:The General's Might:19F3:/
-238.1 "Half Gravity" sync / 1[56]:The General's Time:19F5:/
-241.7 "Smash" sync / 1[56]:The General's Might:19F3:/
-247.4 "Half Gravity" sync / 1[56]:The General's Time:19F5:/
-250.0 "Smash" sync / 1[56]:The General's Might:19F3:/
-256.7 "Half Gravity" sync / 1[56]:The General's Time:19F5:/
-258.3 "Smash" sync / 1[56]:The General's Might:19F3:/
+141.6 "Almost Holy?" sync / 1[56]:[^:]*:The General's Wing:19F7:/
+150.4 "Smash" sync / 1[56]:[^:]*:The General's Might:19F3:/ window 151,3
+154.4 "Half Gravity" sync / 1[56]:[^:]*:The General's Time:19F5:/
+158.7 "Smash" sync / 1[56]:[^:]*:The General's Might:19F3:/
+163.7 "Half Gravity" sync / 1[56]:[^:]*:The General's Time:19F5:/
+167.0 "Smash" sync / 1[56]:[^:]*:The General's Might:19F3:/
+172.9 "Half Gravity" sync / 1[56]:[^:]*:The General's Time:19F5:/
+175.3 "Smash" sync / 1[56]:[^:]*:The General's Might:19F3:/
+182.2 "Half Gravity" sync / 1[56]:[^:]*:The General's Time:19F5:/
+183.6 "Smash" sync / 1[56]:[^:]*:The General's Might:19F3:/
+191.5 "Half Gravity" sync / 1[56]:[^:]*:The General's Time:19F5:/
+191.9 "Smash" sync / 1[56]:[^:]*:The General's Might:19F3:/
+200.2 "Smash" sync / 1[56]:[^:]*:The General's Might:19F3:/
+200.8 "Half Gravity" sync / 1[56]:[^:]*:The General's Time:19F5:/
+208.5 "Smash" sync / 1[56]:[^:]*:The General's Might:19F3:/
+210.1 "Half Gravity" sync / 1[56]:[^:]*:The General's Time:19F5:/
+216.8 "Smash" sync / 1[56]:[^:]*:The General's Might:19F3:/
+219.4 "Half Gravity" sync / 1[56]:[^:]*:The General's Time:19F5:/
+225.1 "Smash" sync / 1[56]:[^:]*:The General's Might:19F3:/
+228.8 "Half Gravity" sync / 1[56]:[^:]*:The General's Time:19F5:/
+233.4 "Smash" sync / 1[56]:[^:]*:The General's Might:19F3:/
+238.1 "Half Gravity" sync / 1[56]:[^:]*:The General's Time:19F5:/
+241.7 "Smash" sync / 1[56]:[^:]*:The General's Might:19F3:/
+247.4 "Half Gravity" sync / 1[56]:[^:]*:The General's Time:19F5:/
+250.0 "Smash" sync / 1[56]:[^:]*:The General's Might:19F3:/
+256.7 "Half Gravity" sync / 1[56]:[^:]*:The General's Time:19F5:/
+258.3 "Smash" sync / 1[56]:[^:]*:The General's Might:19F3:/
 
 ### Phase 3: Temporal Stasis
-265.5 "--sync--" sync / 1[56]:Alexander:1A18:/ window 300,300
-275.2 "Divine Judgment" sync / 1[56]:Alexander:19F9:/
+265.5 "--sync--" sync / 1[56]:[^:]*:Alexander:1A18:/ window 300,300
+275.2 "Divine Judgment" sync / 1[56]:[^:]*:Alexander:19F9:/
 286.0 "--targetable--"
-289.0 "Chronofoil" sync / 1[56]:Alexander Prime:19FA:/
+289.0 "Chronofoil" sync / 1[56]:[^:]*:Alexander Prime:19FA:/
 
-308.1 "Temporal Stasis" sync / 1[56]:Alexander Prime:19FB:/ window 350,10
+308.1 "Temporal Stasis" sync / 1[56]:[^:]*:Alexander Prime:19FB:/ window 350,10
 309.1 "--timestop--" duration 9
-316.2 "--sync--" sync / 1[56]:Alexander Prime:19F1:/
-322.2 "Gravitational Anomaly" sync / 1[56]:Alexander Prime:19F2:/
-324.3 "(Radiant?) Sacrament" sync / 1[56]:Alexander Prime:19E[BD]:/
-329.4 "Mega Holy" sync / 1[56]:Alexander Prime:19EE:/
-335.6 "Divine Spear" sync / 1[56]:Alexander Prime:19E8:/
-342.7 "Punishing Heat" sync / 1[56]:Alexander Prime:19E9:/
-345.9 "Divine Spear" sync / 1[56]:Alexander Prime:19E8:/
+316.2 "--sync--" sync / 1[56]:[^:]*:Alexander Prime:19F1:/
+322.2 "Gravitational Anomaly" sync / 1[56]:[^:]*:Alexander Prime:19F2:/
+324.3 "(Radiant?) Sacrament" sync / 1[56]:[^:]*:Alexander Prime:19E[BD]:/
+329.4 "Mega Holy" sync / 1[56]:[^:]*:Alexander Prime:19EE:/
+335.6 "Divine Spear" sync / 1[56]:[^:]*:Alexander Prime:19E8:/
+342.7 "Punishing Heat" sync / 1[56]:[^:]*:Alexander Prime:19E9:/
+345.9 "Divine Spear" sync / 1[56]:[^:]*:Alexander Prime:19E8:/
 
-361.1 "Temporal Stasis" sync / 1[56]:Alexander Prime:19FB:/ window 30,30
+361.1 "Temporal Stasis" sync / 1[56]:[^:]*:Alexander Prime:19FB:/ window 30,30
 362.1 "--timestop--" duration 9
-369.2 "--sync--" sync / 1[56]:Alexander Prime:19F1:/
-375.2 "Gravitational Anomaly" sync / 1[56]:Alexander Prime:19F2:/
-377.3 "(Radiant?) Sacrament" sync / 1[56]:Alexander Prime:19E[BD]:/
-382.4 "Mega Holy" sync / 1[56]:Alexander Prime:19EE:/
-388.5 "Divine Spear" sync / 1[56]:Alexander Prime:19E8:/
-395.6 "Punishing Heat" sync / 1[56]:Alexander Prime:19E9:/
-398.8 "Divine Spear" sync / 1[56]:Alexander Prime:19E8:/
+369.2 "--sync--" sync / 1[56]:[^:]*:Alexander Prime:19F1:/
+375.2 "Gravitational Anomaly" sync / 1[56]:[^:]*:Alexander Prime:19F2:/
+377.3 "(Radiant?) Sacrament" sync / 1[56]:[^:]*:Alexander Prime:19E[BD]:/
+382.4 "Mega Holy" sync / 1[56]:[^:]*:Alexander Prime:19EE:/
+388.5 "Divine Spear" sync / 1[56]:[^:]*:Alexander Prime:19E8:/
+395.6 "Punishing Heat" sync / 1[56]:[^:]*:Alexander Prime:19E9:/
+398.8 "Divine Spear" sync / 1[56]:[^:]*:Alexander Prime:19E8:/
 
 
 ### Phase 4: Timegates, Judgment Crystals
 # FIXME: Add targetable/untargetable precise times here
-409.1 "Timegate" sync / 1[56]:Alexander Prime:1A03:/ window 450,30
+409.1 "Timegate" sync / 1[56]:[^:]*:Alexander Prime:1A03:/ window 450,30
 # FIXME: make this precise
 415.1 "--timegates active--"
-430.2 "Judgment Crystal 1" sync / 1[56]:Alexander Prime:1A04:/
-443.8 "Judgment Crystal 2" sync / 1[56]:Alexander Prime:1A04:/
-451.9 "(Radiant?) Sacrament" sync / 1[56]:Alexander Prime:19E[BD]:/
-464.6 "Judgment Crystal 3" sync / 1[56]:Alexander Prime:1A04:/
-470.7 "Punishing Heat" sync / 1[56]:Alexander Prime:19E9:/
-484.3 "Judgment Crystal 4" sync / 1[56]:Alexander Prime:1A04:/
+430.2 "Judgment Crystal 1" sync / 1[56]:[^:]*:Alexander Prime:1A04:/
+443.8 "Judgment Crystal 2" sync / 1[56]:[^:]*:Alexander Prime:1A04:/
+451.9 "(Radiant?) Sacrament" sync / 1[56]:[^:]*:Alexander Prime:19E[BD]:/
+464.6 "Judgment Crystal 3" sync / 1[56]:[^:]*:Alexander Prime:1A04:/
+470.7 "Punishing Heat" sync / 1[56]:[^:]*:Alexander Prime:19E9:/
+484.3 "Judgment Crystal 4" sync / 1[56]:[^:]*:Alexander Prime:1A04:/
 
 
 ### Phase 5: Inception
 501.4 "--untargetable--"
-501.4 "Inception" sync / 1[56]:Alexander Prime:1A08:/ window 540,30
-507.6 "Tetrashatter" sync / 1[56]:Judgment Crystal:1A06:/
+501.4 "Inception" sync / 1[56]:[^:]*:Alexander Prime:1A08:/ window 540,30
+507.6 "Tetrashatter" sync / 1[56]:[^:]*:Judgment Crystal:1A06:/
 508.7 "--targetable--"
-508.7 "Sacrament" sync / 1[56]:Alexander Prime:1A09:/
-516.8 "Radiant Sacrament" sync / 1[56]:Alexander Prime:19ED:/
-527.9 "Punishing Heat" sync / 1[56]:Alexander Prime:19E9:/
-532.1 "Divine Spear" sync / 1[56]:Alexander Prime:19E8:/
-539.2 "--sync--" sync / 1[56]:Alexander Prime:19F1:/
-545.2 "Gravitational Anomaly" sync / 1[56]:Alexander Prime:19F2:/
-546.4 "Incinerating Heat" sync / 1[56]:Alexander Prime:19EA:/
+508.7 "Sacrament" sync / 1[56]:[^:]*:Alexander Prime:1A09:/
+516.8 "Radiant Sacrament" sync / 1[56]:[^:]*:Alexander Prime:19ED:/
+527.9 "Punishing Heat" sync / 1[56]:[^:]*:Alexander Prime:19E9:/
+532.1 "Divine Spear" sync / 1[56]:[^:]*:Alexander Prime:19E8:/
+539.2 "--sync--" sync / 1[56]:[^:]*:Alexander Prime:19F1:/
+545.2 "Gravitational Anomaly" sync / 1[56]:[^:]*:Alexander Prime:19F2:/
+546.4 "Incinerating Heat" sync / 1[56]:[^:]*:Alexander Prime:19EA:/
 
 557.6 "--untargetable--"
-557.6 "Inception" sync / 1[56]:Alexander Prime:1A08:/ window 30,30
-563.7 "Tetrashatter" sync / 1[56]:Judgment Crystal:1A06:/
+557.6 "Inception" sync / 1[56]:[^:]*:Alexander Prime:1A08:/ window 30,30
+563.7 "Tetrashatter" sync / 1[56]:[^:]*:Judgment Crystal:1A06:/
 564.9 "--targetable--"
-564.9 "Sacrament" sync / 1[56]:Alexander Prime:1A09:/
-573.0 "Radiant Sacrament" sync / 1[56]:Alexander Prime:19ED:/
-584.1 "Punishing Heat" sync / 1[56]:Alexander Prime:19E9:/
-588.3 "Divine Spear" sync / 1[56]:Alexander Prime:19E8:/
-595.4 "--sync--" sync / 1[56]:Alexander Prime:19F1:/
-601.4 "Gravitational Anomaly" sync / 1[56]:Alexander Prime:19F2:/
-602.6 "Incinerating Heat" sync / 1[56]:Alexander Prime:19EA:/
+564.9 "Sacrament" sync / 1[56]:[^:]*:Alexander Prime:1A09:/
+573.0 "Radiant Sacrament" sync / 1[56]:[^:]*:Alexander Prime:19ED:/
+584.1 "Punishing Heat" sync / 1[56]:[^:]*:Alexander Prime:19E9:/
+588.3 "Divine Spear" sync / 1[56]:[^:]*:Alexander Prime:19E8:/
+595.4 "--sync--" sync / 1[56]:[^:]*:Alexander Prime:19F1:/
+601.4 "Gravitational Anomaly" sync / 1[56]:[^:]*:Alexander Prime:19F2:/
+602.6 "Incinerating Heat" sync / 1[56]:[^:]*:Alexander Prime:19EA:/
 
 
 ### Phase 6: Voids of Repentence
-611.8 "Summon Alexander" sync / 1[56]:Alexander Prime:1A0A:/ window 650,10
-620.9 "Void Of Repentance" sync / 1[56]:Alexander Prime:1A0E:/
-632.0 "Confession 1" sync / 1[56]:Alexander Prime:1A12:/ window 2,2
-636.0 "Confession 2" sync / 1[56]:Alexander Prime:1A12:/ window 2,2
-640.0 "Confession 3" sync / 1[56]:Alexander Prime:1A12:/ window 2,2
-643.1 "Incinerating Heat" sync / 1[56]:Alexander Prime:19EA:/ window 30,30
-648.9 "Holy Bleed" sync / 1[56]:Alexander:1A13:/
-659.3 "Holy Scourge x4" sync / 1[56]:Alexander Prime:1A0B:/ duration 5.9
-667.5 "Chastening Heat" sync / 1[56]:Alexander Prime:1A0D:/
+611.8 "Summon Alexander" sync / 1[56]:[^:]*:Alexander Prime:1A0A:/ window 650,10
+620.9 "Void Of Repentance" sync / 1[56]:[^:]*:Alexander Prime:1A0E:/
+632.0 "Confession 1" sync / 1[56]:[^:]*:Alexander Prime:1A12:/ window 2,2
+636.0 "Confession 2" sync / 1[56]:[^:]*:Alexander Prime:1A12:/ window 2,2
+640.0 "Confession 3" sync / 1[56]:[^:]*:Alexander Prime:1A12:/ window 2,2
+643.1 "Incinerating Heat" sync / 1[56]:[^:]*:Alexander Prime:19EA:/ window 30,30
+648.9 "Holy Bleed" sync / 1[56]:[^:]*:Alexander:1A13:/
+659.3 "Holy Scourge x4" sync / 1[56]:[^:]*:Alexander Prime:1A0B:/ duration 5.9
+667.5 "Chastening Heat" sync / 1[56]:[^:]*:Alexander Prime:1A0D:/
 
 # loop until enrage
-673.7 "Void Of Repentance" sync / 1[56]:Alexander Prime:1A0E:/
-679.4 "Communion x6" sync / 1[56]:Alexander:1A15:/ duration 13 window 2,2
-684.8 "Confession 1" sync / 1[56]:Alexander Prime:1A12:/ window 2,2
-686.0 "Sacrament" sync / 1[56]:Alexander Prime:19EB:/
-688.8 "Confession 2" sync / 1[56]:Alexander Prime:1A12:/ window 2,2
-692.8 "Confession 3" sync / 1[56]:Alexander Prime:1A12:/ window 2,2
-695.9 "Incinerating Heat" sync / 1[56]:Alexander Prime:19EA:/ window 30,30
-701.7 "Holy Bleed" sync / 1[56]:Alexander:1A13:/
-712.1 "Holy Scourge x4" sync / 1[56]:Alexander Prime:1A0B:/ duration 5.9
-720.3 "Chastening Heat" sync / 1[56]:Alexander Prime:1A0D:/
+673.7 "Void Of Repentance" sync / 1[56]:[^:]*:Alexander Prime:1A0E:/
+679.4 "Communion x6" sync / 1[56]:[^:]*:Alexander:1A15:/ duration 13 window 2,2
+684.8 "Confession 1" sync / 1[56]:[^:]*:Alexander Prime:1A12:/ window 2,2
+686.0 "Sacrament" sync / 1[56]:[^:]*:Alexander Prime:19EB:/
+688.8 "Confession 2" sync / 1[56]:[^:]*:Alexander Prime:1A12:/ window 2,2
+692.8 "Confession 3" sync / 1[56]:[^:]*:Alexander Prime:1A12:/ window 2,2
+695.9 "Incinerating Heat" sync / 1[56]:[^:]*:Alexander Prime:19EA:/ window 30,30
+701.7 "Holy Bleed" sync / 1[56]:[^:]*:Alexander:1A13:/
+712.1 "Holy Scourge x4" sync / 1[56]:[^:]*:Alexander Prime:1A0B:/ duration 5.9
+720.3 "Chastening Heat" sync / 1[56]:[^:]*:Alexander Prime:1A0D:/
 
-726.5 "Void Of Repentance" sync / 1[56]:Alexander Prime:1A0E:/ window 40,40 jump 673.7
+726.5 "Void Of Repentance" sync / 1[56]:[^:]*:Alexander Prime:1A0E:/ window 40,40 jump 673.7
 732.2 "Communion x6"
 737.6 "Confession 1"
 738.8 "Sacrament"

--- a/ui/raidboss/data/03-hw/raid/a1s.txt
+++ b/ui/raidboss/data/03-hw/raid/a1s.txt
@@ -10,39 +10,39 @@ hideall "--sync--"
 ### Faust
 # -p E3C:1006 -ii E3E
 1000.0 "--sync--" sync / 00:0839::Machinery Bay 44 will be sealed off/ window 1000,0
-1006.0 "Kaltstrahl" sync / 1[56]:Faust:E3C:/ window 1006,5
+1006.0 "Kaltstrahl" sync / 1[56]:[^:]*:Faust:E3C:/ window 1006,5
 1009.7 "Sturm Doll Add"
-1016.0 "Kaltstrahl" sync / 1[56]:Faust:E3C:/
-1019.0 "Pressure Increase 1" sync / 1[56]:Faust:E3D:/
-1026.0 "Kaltstrahl" sync / 1[56]:Faust:E3C:/
+1016.0 "Kaltstrahl" sync / 1[56]:[^:]*:Faust:E3C:/
+1019.0 "Pressure Increase 1" sync / 1[56]:[^:]*:Faust:E3D:/
+1026.0 "Kaltstrahl" sync / 1[56]:[^:]*:Faust:E3C:/
 1029.7 "Sturm Doll Add"
-1036.0 "Kaltstrahl" sync / 1[56]:Faust:E3C:/
-1039.0 "Pressure Increase 2" sync / 1[56]:Faust:E3D:/
-1046.0 "Kaltstrahl" sync / 1[56]:Faust:E3C:/
+1036.0 "Kaltstrahl" sync / 1[56]:[^:]*:Faust:E3C:/
+1039.0 "Pressure Increase 2" sync / 1[56]:[^:]*:Faust:E3D:/
+1046.0 "Kaltstrahl" sync / 1[56]:[^:]*:Faust:E3C:/
 1049.7 "Sturm Doll Add"
-1056.0 "Kaltstrahl" sync / 1[56]:Faust:E3C:/
-1059.0 "Pressure Increase 3" sync / 1[56]:Faust:E3D:/
-1066.0 "Kaltstrahl" sync / 1[56]:Faust:E3C:/
+1056.0 "Kaltstrahl" sync / 1[56]:[^:]*:Faust:E3C:/
+1059.0 "Pressure Increase 3" sync / 1[56]:[^:]*:Faust:E3D:/
+1066.0 "Kaltstrahl" sync / 1[56]:[^:]*:Faust:E3C:/
 1069.7 "Sturm Doll Add"
-1076.0 "Kaltstrahl" sync / 1[56]:Faust:E3C:/
-1079.0 "Pressure Increase 4" sync / 1[56]:Faust:E3D:/
-1086.0 "Kaltstrahl" sync / 1[56]:Faust:E3C:/
+1076.0 "Kaltstrahl" sync / 1[56]:[^:]*:Faust:E3C:/
+1079.0 "Pressure Increase 4" sync / 1[56]:[^:]*:Faust:E3D:/
+1086.0 "Kaltstrahl" sync / 1[56]:[^:]*:Faust:E3C:/
 1069.7 "Sturm Doll Add"
-1096.0 "Kaltstrahl" sync / 1[56]:Faust:E3C:/
-1099.0 "Pressure Increase 5" sync / 1[56]:Faust:E3D:/
-1106.0 "Kaltstrahl" sync / 1[56]:Faust:E3C:/
+1096.0 "Kaltstrahl" sync / 1[56]:[^:]*:Faust:E3C:/
+1099.0 "Pressure Increase 5" sync / 1[56]:[^:]*:Faust:E3D:/
+1106.0 "Kaltstrahl" sync / 1[56]:[^:]*:Faust:E3C:/
 1109.7 "Sturm Doll Add"
-1116.0 "Kaltstrahl" sync / 1[56]:Faust:E3C:/
-1119.0 "Pressure Increase 6" sync / 1[56]:Faust:E3D:/
-1126.0 "Kaltstrahl" sync / 1[56]:Faust:E3C:/
+1116.0 "Kaltstrahl" sync / 1[56]:[^:]*:Faust:E3C:/
+1119.0 "Pressure Increase 6" sync / 1[56]:[^:]*:Faust:E3D:/
+1126.0 "Kaltstrahl" sync / 1[56]:[^:]*:Faust:E3C:/
 1129.7 "Sturm Doll Add"
-1136.0 "Kaltstrahl" sync / 1[56]:Faust:E3C:/
-1139.0 "Pressure Increase 7" sync / 1[56]:Faust:E3D:/
-1146.0 "Kaltstrahl" sync / 1[56]:Faust:E3C:/
+1136.0 "Kaltstrahl" sync / 1[56]:[^:]*:Faust:E3C:/
+1139.0 "Pressure Increase 7" sync / 1[56]:[^:]*:Faust:E3D:/
+1146.0 "Kaltstrahl" sync / 1[56]:[^:]*:Faust:E3C:/
 1149.7 "Sturm Doll Add"
-1152.0 "Pressure Increase 16" sync / 1[56]:Faust:E7E:/
-1159.0 "Kaltstrahl Enrage" sync / 1[56]:Faust:E7D:/
-1164.0 "Kaltstrahl Enrage" sync / 1[56]:Faust:E7D:/
+1152.0 "Pressure Increase 16" sync / 1[56]:[^:]*:Faust:E7E:/
+1159.0 "Kaltstrahl Enrage" sync / 1[56]:[^:]*:Faust:E7D:/
+1164.0 "Kaltstrahl Enrage" sync / 1[56]:[^:]*:Faust:E7D:/
 # etc
 
 
@@ -52,60 +52,60 @@ hideall "--sync--"
 # -ic "Oppressor 0.5"
 
 2000.0 "--sync--" sync / 00:0839::Hangar 8 will be sealed off in 15 seconds/ window 2000,0
-2007.0 "Royal Fount" sync / 1[56]:Oppressor:E40:/ window 2010,5
-2011.1 "Gunnery Pod" sync / 1[56]:Oppressor:E41:/
-2016.2 "Hydrothermal Missile" sync / 1[56]:Oppressor:E43:/ duration 8
-2018.3 "Gunnery Pod" sync / 1[56]:Oppressor:E41:/
-2024.1 "Photon Spaser" sync / 1[56]:Oppressor:E42:/
-2028.2 "Royal Fount" sync / 1[56]:Oppressor:E40:/
-2036.3 "Resin Bomb" sync / 1[56]:Oppressor:E46:/
-2038.4 "Royal Fount" sync / 1[56]:Oppressor:E40:/
-2044.2 "Photon Spaser" sync / 1[56]:Oppressor:E42:/
-2046.3 "Gunnery Pod" sync / 1[56]:Oppressor:E41:/
-2049.1 "Royal Fount" sync / 1[56]:Oppressor:E40:/
-2054.2 "Emergency Deployment" sync / 1[56]:Oppressor:E45:/
+2007.0 "Royal Fount" sync / 1[56]:[^:]*:Oppressor:E40:/ window 2010,5
+2011.1 "Gunnery Pod" sync / 1[56]:[^:]*:Oppressor:E41:/
+2016.2 "Hydrothermal Missile" sync / 1[56]:[^:]*:Oppressor:E43:/ duration 8
+2018.3 "Gunnery Pod" sync / 1[56]:[^:]*:Oppressor:E41:/
+2024.1 "Photon Spaser" sync / 1[56]:[^:]*:Oppressor:E42:/
+2028.2 "Royal Fount" sync / 1[56]:[^:]*:Oppressor:E40:/
+2036.3 "Resin Bomb" sync / 1[56]:[^:]*:Oppressor:E46:/
+2038.4 "Royal Fount" sync / 1[56]:[^:]*:Oppressor:E40:/
+2044.2 "Photon Spaser" sync / 1[56]:[^:]*:Oppressor:E42:/
+2046.3 "Gunnery Pod" sync / 1[56]:[^:]*:Oppressor:E41:/
+2049.1 "Royal Fount" sync / 1[56]:[^:]*:Oppressor:E40:/
+2054.2 "Emergency Deployment" sync / 1[56]:[^:]*:Oppressor:E45:/
 2054.5 "--targetable--"
-2061.3 "Hydrothermal Missile" sync / 1[56]:Oppressor:E43:/ duration 8
-2063.4 "Gunnery Pod" sync / 1[56]:Oppressor:E41:/
-2066.5 "Royal Fount" sync / 1[56]:Oppressor:E40:/
-2069.6 "Gunnery Pod" sync / 1[56]:Oppressor:E41:/
-2075.2 "Photon Spaser" sync / 1[56]:Oppressor:E42:/
-2077.3 "Gunnery Pod" #sync / 1[56]:Oppressor:E41:/
-2079.4 "Gunnery Pod" #sync / 1[56]:Oppressor:E41:/
-2083.5 "Royal Fount" sync / 1[56]:Oppressor:E40:/
-2085.6 "Distress Beacon" sync / 1[56]:Oppressor:E48:/
+2061.3 "Hydrothermal Missile" sync / 1[56]:[^:]*:Oppressor:E43:/ duration 8
+2063.4 "Gunnery Pod" sync / 1[56]:[^:]*:Oppressor:E41:/
+2066.5 "Royal Fount" sync / 1[56]:[^:]*:Oppressor:E40:/
+2069.6 "Gunnery Pod" sync / 1[56]:[^:]*:Oppressor:E41:/
+2075.2 "Photon Spaser" sync / 1[56]:[^:]*:Oppressor:E42:/
+2077.3 "Gunnery Pod" #sync / 1[56]:[^:]*:Oppressor:E41:/
+2079.4 "Gunnery Pod" #sync / 1[56]:[^:]*:Oppressor:E41:/
+2083.5 "Royal Fount" sync / 1[56]:[^:]*:Oppressor:E40:/
+2085.6 "Distress Beacon" sync / 1[56]:[^:]*:Oppressor:E48:/
 2096.3 "--targetable--"
 
-2106.4 "3000-Tonze Missile" sync / 1[56]:Oppressor:E4B:/
-2112.6 "Gunnery Pod" sync / 1[56]:Oppressor:E41:/
-2117.7 "Emergency Deployment" sync / 1[56]:Oppressor:E45:/
+2106.4 "3000-Tonze Missile" sync / 1[56]:[^:]*:Oppressor:E4B:/
+2112.6 "Gunnery Pod" sync / 1[56]:[^:]*:Oppressor:E41:/
+2117.7 "Emergency Deployment" sync / 1[56]:[^:]*:Oppressor:E45:/
 2118.0 "--targetable--"
-2125.8 "Resin Bomb" sync / 1[56]:Oppressor:E46:/
-2128.0 "Royal Fount" sync / 1[56]:Oppressor:E40:/
-2133.7 "Photon Spaser" sync / 1[56]:Oppressor:E42:/
-2136.9 "Gunnery Pod" sync / 1[56]:Oppressor:E41:/
-2143.0 "Hydrothermal Missile" sync / 1[56]:Oppressor:E43:/
-2148.2 "Royal Fount" sync / 1[56]:Oppressor:E40:/
-2156.3 "Hypercompressed Plasma" sync / 1[56]:Oppressor:E4A:/
-2159.9 "Missile Impact" #sync / 1[56]:3000-Tonze Missile:E4[DE]:/
+2125.8 "Resin Bomb" sync / 1[56]:[^:]*:Oppressor:E46:/
+2128.0 "Royal Fount" sync / 1[56]:[^:]*:Oppressor:E40:/
+2133.7 "Photon Spaser" sync / 1[56]:[^:]*:Oppressor:E42:/
+2136.9 "Gunnery Pod" sync / 1[56]:[^:]*:Oppressor:E41:/
+2143.0 "Hydrothermal Missile" sync / 1[56]:[^:]*:Oppressor:E43:/
+2148.2 "Royal Fount" sync / 1[56]:[^:]*:Oppressor:E40:/
+2156.3 "Hypercompressed Plasma" sync / 1[56]:[^:]*:Oppressor:E4A:/
+2159.9 "Missile Impact" #sync / 1[56]:[^:]*:3000-Tonze Missile:E4[DE]:/
 
-2166.5 "Photon Spaser" sync / 1[56]:Oppressor:E42:/
-2173.7 "Gunnery Pod" sync / 1[56]:Oppressor:E41:/
-2182.8 "Royal Fount" sync / 1[56]:Oppressor:E40:/
+2166.5 "Photon Spaser" sync / 1[56]:[^:]*:Oppressor:E42:/
+2173.7 "Gunnery Pod" sync / 1[56]:[^:]*:Oppressor:E41:/
+2182.8 "Royal Fount" sync / 1[56]:[^:]*:Oppressor:E40:/
 2188.9 "--untargetable--"
-2189.0 "Emergency Liftoff" sync / 1[56]:Oppressor:E4F:/
-2203.7 "Resin Bomb 1" #sync / 1[56]:Oppressor 0.5:E52:/
-2204.7 "Resin Bomb 2" #sync / 1[56]:Oppressor:E52:/
-2205.7 "Resin Bomb 3" #sync / 1[56]:Oppressor:E52:/
-2206.7 "Resin Bomb 4" #sync / 1[56]:Oppressor 0.5:E52:/
-2207.7 "Resin Bomb 5" #sync / 1[56]:Oppressor:E52:/
-2208.7 "Resin Bomb 6" #sync / 1[56]:Oppressor:E52:/
-2209.7 "Resin Bomb 7" #sync / 1[56]:Oppressor 0.5:E52:/
-2210.7 "Resin Bomb 8" #sync / 1[56]:Oppressor 0.5:E52:/
-2210.7 "Quick Landing" sync / 1[56]:Oppressor:E51:/
+2189.0 "Emergency Liftoff" sync / 1[56]:[^:]*:Oppressor:E4F:/
+2203.7 "Resin Bomb 1" #sync / 1[56]:[^:]*:Oppressor 0.5:E52:/
+2204.7 "Resin Bomb 2" #sync / 1[56]:[^:]*:Oppressor:E52:/
+2205.7 "Resin Bomb 3" #sync / 1[56]:[^:]*:Oppressor:E52:/
+2206.7 "Resin Bomb 4" #sync / 1[56]:[^:]*:Oppressor 0.5:E52:/
+2207.7 "Resin Bomb 5" #sync / 1[56]:[^:]*:Oppressor:E52:/
+2208.7 "Resin Bomb 6" #sync / 1[56]:[^:]*:Oppressor:E52:/
+2209.7 "Resin Bomb 7" #sync / 1[56]:[^:]*:Oppressor 0.5:E52:/
+2210.7 "Resin Bomb 8" #sync / 1[56]:[^:]*:Oppressor 0.5:E52:/
+2210.7 "Quick Landing" sync / 1[56]:[^:]*:Oppressor:E51:/
 
 2215.8 "--targetable--"
-2226.7 "3000-Tonze Missile" sync / 1[56]:Oppressor:E4B:/ window 100,100 jump 2106.4
+2226.7 "3000-Tonze Missile" sync / 1[56]:[^:]*:Oppressor:E4B:/ window 100,100 jump 2106.4
 2232.9 "Gunnery Pod"
 2238.0 "Emergency Deployment"
 2238.3 "--targetable--"
@@ -121,6 +121,6 @@ hideall "--sync--"
 
 
 ## Enrage
-3000.0 "--sync--" sync / 14:Oppressor:E49:/ window 3000,0
-3000.0 "--sync--" sync / 14:Oppressor 0\.5:E49:/ window 3000,0
-3010.0 "Self-Destruct Enrage" sync / 1[56]:Oppressor:E49:/
+3000.0 "--sync--" sync / 14:[^:]*:Oppressor:E49:/ window 3000,0
+3000.0 "--sync--" sync / 14:[^:]*:Oppressor 0\.5:E49:/ window 3000,0
+3010.0 "Self-Destruct Enrage" sync / 1[56]:[^:]*:Oppressor:E49:/

--- a/ui/raidboss/data/03-hw/raid/a2s.txt
+++ b/ui/raidboss/data/03-hw/raid/a2s.txt
@@ -24,7 +24,7 @@ hideall "--sync--"
 20.3 "Sniper, Soldier x2 (NW)"
 20.3 "Hardmind (SW)"
 
-42.0 "Brainhurt Breakblock" sync / 1[56]:Gordian Hardmind:FCC:/
+42.0 "Brainhurt Breakblock" sync / 1[56]:[^:]*:Gordian Hardmind:FCC:/
 
 
 # Wave 3 (timed push)
@@ -32,8 +32,8 @@ hideall "--sync--"
 80.2 "Hardhelm, Soldier (SW)"
 80.2 "Hardmind, Sniper, Soldier 2x (N)"
 
-101.9 "Brainhurt Breakblock" sync / 1[56]:Gordian Hardmind:FCC:/
-101.9 "Bodyhurt Breakblock" sync / 1[56]:Gordian Hardhelm:FCB:/
+101.9 "Brainhurt Breakblock" sync / 1[56]:[^:]*:Gordian Hardmind:FCC:/
+101.9 "Bodyhurt Breakblock" sync / 1[56]:[^:]*:Gordian Hardhelm:FCB:/
 
 
 # Wave 4 (triggered push)
@@ -41,10 +41,10 @@ hideall "--sync--"
 2000.0 "Gobwalker (NE)"
 2000.0 "Sniper x2, Soldier x2 (mid)"
 
-2012.3 "Carpet Bomb 1" sync / 1[56]:King Gobtank G-IV:FDA:/
-2032.5 "Explosion" #sync / 1[56]:Bomb:FDC:/
-2040.8 "Carpet Bomb 2" sync / 1[56]:King Gobtank G-IV:FDA:/
-2061.0 "Explosion" #sync / 1[56]:Bomb:FDC:/
+2012.3 "Carpet Bomb 1" sync / 1[56]:[^:]*:King Gobtank G-IV:FDA:/
+2032.5 "Explosion" #sync / 1[56]:[^:]*:Bomb:FDC:/
+2040.8 "Carpet Bomb 2" sync / 1[56]:[^:]*:King Gobtank G-IV:FDA:/
+2061.0 "Explosion" #sync / 1[56]:[^:]*:Bomb:FDC:/
 
 
 # Wave 5 (timed push)
@@ -53,14 +53,14 @@ hideall "--sync--"
 2095.5 "Gobwidow (S)"
 2095.5 "Soldier x2 (SW)"
 
-2105.1 "Carpet Bomb 1" sync / 1[56]:King Gobtank G-IV:FDA:/
-2107.0 "--sync--" sync / 1[56]:Magitek Gobwidow G-IX:1413:/
-2114.6 "Boomcannon" sync / 1[56]:Magitek Gobwidow G-IX:FD8:/
-2125.3 "Explosion" #sync / 1[56]:Bomb:FDC:/
-2126.2 "Carpet Bomb 2" sync / 1[56]:King Gobtank G-IV:FDA:/
-2138.3 "--sync--" sync / 1[56]:Magitek Gobwidow G-IX:1413:/
-2146.0 "Boomcannon" sync / 1[56]:Magitek Gobwidow G-IX:FD8:/
-2146.5 "Explosion" #sync / 1[56]:Bomb:FDC:/
+2105.1 "Carpet Bomb 1" sync / 1[56]:[^:]*:King Gobtank G-IV:FDA:/
+2107.0 "--sync--" sync / 1[56]:[^:]*:Magitek Gobwidow G-IX:1413:/
+2114.6 "Boomcannon" sync / 1[56]:[^:]*:Magitek Gobwidow G-IX:FD8:/
+2125.3 "Explosion" #sync / 1[56]:[^:]*:Bomb:FDC:/
+2126.2 "Carpet Bomb 2" sync / 1[56]:[^:]*:King Gobtank G-IV:FDA:/
+2138.3 "--sync--" sync / 1[56]:[^:]*:Magitek Gobwidow G-IX:1413:/
+2146.0 "Boomcannon" sync / 1[56]:[^:]*:Magitek Gobwidow G-IX:FD8:/
+2146.5 "Explosion" #sync / 1[56]:[^:]*:Bomb:FDC:/
 
 
 # Wave 6 (timed push)
@@ -69,20 +69,20 @@ hideall "--sync--"
 2168.0 "Gobwalker (N)"
 2168.0 "Hardhelm (SW)"
 
-2176.3 "Kaltstrahl" sync / 1[56]:Jagd Doll:FD4:/
-2177.3 "Carpet Bomb" sync / 1[56]:King Gobtank G-IV:FDA:/
-2187.4 "Blitzstrahl" sync / 1[56]:Jagd Doll:FD6:/
-2190.0 "Bodyhurt Breakblock" sync / 1[56]:Gordian Hardhelm:FCB:/
-2195.7 "Explosion" #sync / 1[56]:Bomb:FDC:/
-2196.5 "Kaltstrahl" sync / 1[56]:Jagd Doll:FD4:/
-2198.3 "Carpet Bomb" sync / 1[56]:King Gobtank G-IV:FDA:/
-2218.3 "Explosion" #sync / 1[56]:Bomb:FDC:/
+2176.3 "Kaltstrahl" sync / 1[56]:[^:]*:Jagd Doll:FD4:/
+2177.3 "Carpet Bomb" sync / 1[56]:[^:]*:King Gobtank G-IV:FDA:/
+2187.4 "Blitzstrahl" sync / 1[56]:[^:]*:Jagd Doll:FD6:/
+2190.0 "Bodyhurt Breakblock" sync / 1[56]:[^:]*:Gordian Hardhelm:FCB:/
+2195.7 "Explosion" #sync / 1[56]:[^:]*:Bomb:FDC:/
+2196.5 "Kaltstrahl" sync / 1[56]:[^:]*:Jagd Doll:FD4:/
+2198.3 "Carpet Bomb" sync / 1[56]:[^:]*:King Gobtank G-IV:FDA:/
+2218.3 "Explosion" #sync / 1[56]:[^:]*:Bomb:FDC:/
 
-2227.7 "Blitzstrahl" sync / 1[56]:Jagd Doll:FD6:/
-2230.9 "Kaltstrahl" sync / 1[56]:Jagd Doll:FD4:/
-2239.1 "Kaltstrahl" sync / 1[56]:Jagd Doll:FD4:/
+2227.7 "Blitzstrahl" sync / 1[56]:[^:]*:Jagd Doll:FD6:/
+2230.9 "Kaltstrahl" sync / 1[56]:[^:]*:Jagd Doll:FD4:/
+2239.1 "Kaltstrahl" sync / 1[56]:[^:]*:Jagd Doll:FD4:/
 
-2250.2 "Blitzstrahl" sync / 1[56]:Jagd Doll:FD6:/ window 10,10 jump 2227.7
+2250.2 "Blitzstrahl" sync / 1[56]:[^:]*:Jagd Doll:FD6:/ window 10,10 jump 2227.7
 2253.4 "Kaltstrahl"
 2261.6 "Kaltstrahl"
 
@@ -99,17 +99,17 @@ hideall "--sync--"
 3000.0 "--Wave 7--" sync / 03:........:Jagd Doll:/  window 825,0
 3000.0 "Jagd Doll x4 (mid)"
 
-3006.2 "Kaltstrahl" #sync / 1[56]:Jagd Doll:FD4:/
-3010.8 "Carpet Bomb 1" sync / 1[56]:King Gobtank G-IV:FDA:/
-3017.4 "Blitzstrahl" #sync / 1[56]:Jagd Doll:FD6:/
-3029.1 "Kaltstrahl" #sync / 1[56]:Jagd Doll:FD4:/
-3029.5 "Explosion" #sync / 1[56]:Bomb:FDC:/
-3033.8 "Carpet Bomb 2" sync / 1[56]:King Gobtank G-IV:FDA:/
-3040.1 "Blitzstrahl" #sync / 1[56]:Jagd Doll:FD6:/
-3043.3 "Kaltstrahl" #sync / 1[56]:Jagd Doll:FD4:/
-3051.5 "Explosion" #sync / 1[56]:Bomb:FDC:/
-3062.6 "Blitzstrahl" #sync / 1[56]:Jagd Doll:FD6:/
-3065.8 "Kaltstrahl" #sync / 1[56]:Jagd Doll:FD4:/
+3006.2 "Kaltstrahl" #sync / 1[56]:[^:]*:Jagd Doll:FD4:/
+3010.8 "Carpet Bomb 1" sync / 1[56]:[^:]*:King Gobtank G-IV:FDA:/
+3017.4 "Blitzstrahl" #sync / 1[56]:[^:]*:Jagd Doll:FD6:/
+3029.1 "Kaltstrahl" #sync / 1[56]:[^:]*:Jagd Doll:FD4:/
+3029.5 "Explosion" #sync / 1[56]:[^:]*:Bomb:FDC:/
+3033.8 "Carpet Bomb 2" sync / 1[56]:[^:]*:King Gobtank G-IV:FDA:/
+3040.1 "Blitzstrahl" #sync / 1[56]:[^:]*:Jagd Doll:FD6:/
+3043.3 "Kaltstrahl" #sync / 1[56]:[^:]*:Jagd Doll:FD4:/
+3051.5 "Explosion" #sync / 1[56]:[^:]*:Bomb:FDC:/
+3062.6 "Blitzstrahl" #sync / 1[56]:[^:]*:Jagd Doll:FD6:/
+3065.8 "Kaltstrahl" #sync / 1[56]:[^:]*:Jagd Doll:FD4:/
 
 
 # Wave 8 (timed push)
@@ -119,12 +119,12 @@ hideall "--sync--"
 3080.7 "Hardmind (N)"
 3080.7 "Hardhelm (SE)"
 
-3090.8 "Carpet Bomb 1" sync / 1[56]:King Gobtank G-IV:FDA:/
-3104.0 "Bodyhurt Breakblock" sync / 1[56]:Gordian Hardhelm:FCB:/
-3104.0 "Brainhurt Breakblock" sync / 1[56]:Gordian Hardmind:FCC:/
-3111.0 "Explosion" #sync / 1[56]:Bomb:FDC:/
-3113.9 "Carpet Bomb 2" sync / 1[56]:King Gobtank G-IV:FDA:/
-3134.2 "Explosion" #sync / 1[56]:Bomb:FDC:/
+3090.8 "Carpet Bomb 1" sync / 1[56]:[^:]*:King Gobtank G-IV:FDA:/
+3104.0 "Bodyhurt Breakblock" sync / 1[56]:[^:]*:Gordian Hardhelm:FCB:/
+3104.0 "Brainhurt Breakblock" sync / 1[56]:[^:]*:Gordian Hardmind:FCC:/
+3111.0 "Explosion" #sync / 1[56]:[^:]*:Bomb:FDC:/
+3113.9 "Carpet Bomb 2" sync / 1[56]:[^:]*:King Gobtank G-IV:FDA:/
+3134.2 "Explosion" #sync / 1[56]:[^:]*:Bomb:FDC:/
 
 
 # Wave 9 (triggered push)
@@ -134,41 +134,41 @@ hideall "--sync--"
 4000.0 "Gobwalker (NE)"
 4000.0 "Sniper x2, Soldier x2 (SE)"
 
-4014.4 "--sync--" #sync / 1[56]:Magitek Gobwidow G-IX:1413:/
-4016.3 "Blitzstrahl" sync / 1[56]:Jagd Doll:FD6:/
-4019.4 "Kaltstrahl" sync / 1[56]:Jagd Doll:FD4:/
-4022.1 "Boomcannon" #sync / 1[56]:Magitek Gobwidow G-IX:FD8:/
-4027.6 "Kaltstrahl" sync / 1[56]:Jagd Doll:FD4:/
+4014.4 "--sync--" #sync / 1[56]:[^:]*:Magitek Gobwidow G-IX:1413:/
+4016.3 "Blitzstrahl" sync / 1[56]:[^:]*:Jagd Doll:FD6:/
+4019.4 "Kaltstrahl" sync / 1[56]:[^:]*:Jagd Doll:FD4:/
+4022.1 "Boomcannon" #sync / 1[56]:[^:]*:Magitek Gobwidow G-IX:FD8:/
+4027.6 "Kaltstrahl" sync / 1[56]:[^:]*:Jagd Doll:FD4:/
 
-4042.6 "--sync--" #sync / 1[56]:Magitek Gobwidow G-IX:1413:/
-4038.8 "Blitzstrahl" sync / 1[56]:Jagd Doll:FD6:/
-4041.9 "Kaltstrahl" sync / 1[56]:Jagd Doll:FD4:/
-4050.1 "Kaltstrahl" sync / 1[56]:Jagd Doll:FD4:/
-4050.3 "Boomcannon" #sync / 1[56]:Magitek Gobwidow G-IX:FD8:/
+4042.6 "--sync--" #sync / 1[56]:[^:]*:Magitek Gobwidow G-IX:1413:/
+4038.8 "Blitzstrahl" sync / 1[56]:[^:]*:Jagd Doll:FD6:/
+4041.9 "Kaltstrahl" sync / 1[56]:[^:]*:Jagd Doll:FD4:/
+4050.1 "Kaltstrahl" sync / 1[56]:[^:]*:Jagd Doll:FD4:/
+4050.3 "Boomcannon" #sync / 1[56]:[^:]*:Magitek Gobwidow G-IX:FD8:/
 
-4061.3 "Blitzstrahl" sync / 1[56]:Jagd Doll:FD6:/
-4064.4 "Kaltstrahl" sync / 1[56]:Jagd Doll:FD4:/
-4070.8 "--sync--" #sync / 1[56]:Magitek Gobwidow G-IX:1413:/
-4072.6 "Kaltstrahl" sync / 1[56]:Jagd Doll:FD4:/
-4078.5 "Boomcannon" #sync / 1[56]:Magitek Gobwidow G-IX:FD8:/
+4061.3 "Blitzstrahl" sync / 1[56]:[^:]*:Jagd Doll:FD6:/
+4064.4 "Kaltstrahl" sync / 1[56]:[^:]*:Jagd Doll:FD4:/
+4070.8 "--sync--" #sync / 1[56]:[^:]*:Magitek Gobwidow G-IX:1413:/
+4072.6 "Kaltstrahl" sync / 1[56]:[^:]*:Jagd Doll:FD4:/
+4078.5 "Boomcannon" #sync / 1[56]:[^:]*:Magitek Gobwidow G-IX:FD8:/
 
-4083.8 "Blitzstrahl" sync / 1[56]:Jagd Doll:FD6:/
-4086.9 "Kaltstrahl" sync / 1[56]:Jagd Doll:FD4:/
-4095.1 "Kaltstrahl" sync / 1[56]:Jagd Doll:FD4:/
-4099.0 "--sync--" #sync / 1[56]:Magitek Gobwidow G-IX:1413:/
-4106.3 "Blitzstrahl" sync / 1[56]:Jagd Doll:FD6:/
-4106.7 "Boomcannon" #sync / 1[56]:Magitek Gobwidow G-IX:FD8:/
+4083.8 "Blitzstrahl" sync / 1[56]:[^:]*:Jagd Doll:FD6:/
+4086.9 "Kaltstrahl" sync / 1[56]:[^:]*:Jagd Doll:FD4:/
+4095.1 "Kaltstrahl" sync / 1[56]:[^:]*:Jagd Doll:FD4:/
+4099.0 "--sync--" #sync / 1[56]:[^:]*:Magitek Gobwidow G-IX:1413:/
+4106.3 "Blitzstrahl" sync / 1[56]:[^:]*:Jagd Doll:FD6:/
+4106.7 "Boomcannon" #sync / 1[56]:[^:]*:Magitek Gobwidow G-IX:FD8:/
 
-4109.4 "Kaltstrahl" sync / 1[56]:Jagd Doll:FD4:/
-4117.6 "Kaltstrahl" sync / 1[56]:Jagd Doll:FD4:/
-4127.2 "--sync--" #sync / 1[56]:Magitek Gobwidow G-IX:1413:/
-4134.9 "Boomcannon" #sync / 1[56]:Magitek Gobwidow G-IX:FD8:/
+4109.4 "Kaltstrahl" sync / 1[56]:[^:]*:Jagd Doll:FD4:/
+4117.6 "Kaltstrahl" sync / 1[56]:[^:]*:Jagd Doll:FD4:/
+4127.2 "--sync--" #sync / 1[56]:[^:]*:Magitek Gobwidow G-IX:1413:/
+4134.9 "Boomcannon" #sync / 1[56]:[^:]*:Magitek Gobwidow G-IX:FD8:/
 
 
 
 # Enrage
 5000.0 "--sync--" sync / 03:........:Giant Bomb:/  window 5000,0
-5010.0 "Massive Explosion Enrage" sync / 1[56]:Giant Bomb:FDD:/
+5010.0 "Massive Explosion Enrage" sync / 1[56]:[^:]*:Giant Bomb:FDD:/
 
 # Technically this loops, and has a special dialog where Quickthinx says:
 # "Uplanders are stubborn, need lesson teachings! Illuminati─reload and fire!"

--- a/ui/raidboss/data/03-hw/raid/a3s.txt
+++ b/ui/raidboss/data/03-hw/raid/a3s.txt
@@ -17,174 +17,174 @@ hideall "--sync--"
 ### Phase 1: Jiggly
 0.0 "--sync--" sync /:Engage!/ window 0,1
 0.0 "--sync--" sync / 00:0839::Condensate Demineralizer .9 will be sealed off/ window 10000,10000
-7.0 "Fluid Swing" sync / 1[56]:Living Liquid:EF3:/
-17.2 "Protean Wave" sync / 1[56]:Living Liquid:EF5:/
-18.8 "Protean Wave" sync / 1[56]:Living Liquid:EF6:/
-21.9 "Fluid Swing" sync / 1[56]:Living Liquid:EF3:/
-25.0 "Splash x3" #sync / 1[56]:Living Liquid:EF4:/ duration 2.2
-32.3 "Fluid Swing" sync / 1[56]:Living Liquid:EF3:/
-44.4 "Sluice" sync / 1[56]:Living Liquid:EFA:/
-49.6 "Splash x3" #sync / 1[56]:Living Liquid:EF4:/ duration 2.2
-54.9 "Fluid Swing" sync / 1[56]:Living Liquid:EF3:/
+7.0 "Fluid Swing" sync / 1[56]:[^:]*:Living Liquid:EF3:/
+17.2 "Protean Wave" sync / 1[56]:[^:]*:Living Liquid:EF5:/
+18.8 "Protean Wave" sync / 1[56]:[^:]*:Living Liquid:EF6:/
+21.9 "Fluid Swing" sync / 1[56]:[^:]*:Living Liquid:EF3:/
+25.0 "Splash x3" #sync / 1[56]:[^:]*:Living Liquid:EF4:/ duration 2.2
+32.3 "Fluid Swing" sync / 1[56]:[^:]*:Living Liquid:EF3:/
+44.4 "Sluice" sync / 1[56]:[^:]*:Living Liquid:EFA:/
+49.6 "Splash x3" #sync / 1[56]:[^:]*:Living Liquid:EF4:/ duration 2.2
+54.9 "Fluid Swing" sync / 1[56]:[^:]*:Living Liquid:EF3:/
 56.8 "--untargetable--"
-58.9 "--sync--" sync / 1[56]:Hydrate Core:F28:/
-60.0 "--sync--" sync / 1[56]:Living Liquid:F22:/
+58.9 "--sync--" sync / 1[56]:[^:]*:Hydrate Core:F28:/
+60.0 "--sync--" sync / 1[56]:[^:]*:Living Liquid:F22:/
 
 
 ### Phase 2: Sound of Two Hands Cleaving
-60.4 "Hydromorph" sync / 1[56]:Hydrate Core:F29:/
-62.4 "--sync--" sync / 1[56]:Hydrate Core:1040:/
+60.4 "Hydromorph" sync / 1[56]:[^:]*:Hydrate Core:F29:/
+62.4 "--sync--" sync / 1[56]:[^:]*:Hydrate Core:1040:/
 63.9 "--targetable--"
-70.0 "Fluid Strike" sync / 1[56]:Living Liquid:F05:/
-77.1 "Wash Away" sync / 1[56]:Living Liquid:F07:/
-85.2 "Digititis" sync / 1[56]:Living Liquid:F08:/
-90.4 "Fluid Strike" sync / 1[56]:Living Liquid:F05:/
-100.5 "Fluid Strike" sync / 1[56]:Living Liquid:F05:/
-107.6 "Wash Away" sync / 1[56]:Living Liquid:F07:/
+70.0 "Fluid Strike" sync / 1[56]:[^:]*:Living Liquid:F05:/
+77.1 "Wash Away" sync / 1[56]:[^:]*:Living Liquid:F07:/
+85.2 "Digititis" sync / 1[56]:[^:]*:Living Liquid:F08:/
+90.4 "Fluid Strike" sync / 1[56]:[^:]*:Living Liquid:F05:/
+100.5 "Fluid Strike" sync / 1[56]:[^:]*:Living Liquid:F05:/
+107.6 "Wash Away" sync / 1[56]:[^:]*:Living Liquid:F07:/
 109.6 "--split--"
-115.8 "Fluid Strike" sync / 1[56]:Living Liquid:F06:/
-125.0 "Hand Of Prayer/Parting" sync / 1[56]:(Living Liquid|Liquid Limb):F0[BC]:/
-136.9 "Digititis" sync / 1[56]:Living Liquid:F08:/
-137.1 "Equal Concentration" sync / 1[56]:Liquid Limb:F09:/
+115.8 "Fluid Strike" sync / 1[56]:[^:]*:Living Liquid:F06:/
+125.0 "Hand Of Prayer/Parting" sync / 1[56]:[^:]*:(Living Liquid|Liquid Limb):F0[BC]:/
+136.9 "Digititis" sync / 1[56]:[^:]*:Living Liquid:F08:/
+137.1 "Equal Concentration" sync / 1[56]:[^:]*:Liquid Limb:F09:/
 137.1 "--dps burn--" duration 27.4
 # Limb's cleaves are slightly desynced here, so only include the main one.
-141.1 "Fluid Strike x2" sync / 1[56]:Living Liquid:F06:/
-149.2 "Fluid Strike x2" sync / 1[56]:Living Liquid:F06:/
-157.4 "Fluid Strike x2" sync / 1[56]:Living Liquid:F06:/
-164.5 "Hand Of Pain" sync / 1[56]:Living Liquid:F0A:/
-174.7 "Hand Of Prayer/Parting" sync / 1[56]:(Living Liquid|Liquid Limb):F0[BC]:/
-178.8 "Fluid Strike x2" sync / 1[56]:Living Liquid:F06:/
-183.8 "--sync--" sync / 1[56]:Hydrate Core:F28:/
-184.9 "--sync--" sync / 1[56]:Living Liquid:F24:/
+141.1 "Fluid Strike x2" sync / 1[56]:[^:]*:Living Liquid:F06:/
+149.2 "Fluid Strike x2" sync / 1[56]:[^:]*:Living Liquid:F06:/
+157.4 "Fluid Strike x2" sync / 1[56]:[^:]*:Living Liquid:F06:/
+164.5 "Hand Of Pain" sync / 1[56]:[^:]*:Living Liquid:F0A:/
+174.7 "Hand Of Prayer/Parting" sync / 1[56]:[^:]*:(Living Liquid|Liquid Limb):F0[BC]:/
+178.8 "Fluid Strike x2" sync / 1[56]:[^:]*:Living Liquid:F06:/
+183.8 "--sync--" sync / 1[56]:[^:]*:Hydrate Core:F28:/
+184.9 "--sync--" sync / 1[56]:[^:]*:Living Liquid:F24:/
 
 
 ### Phase 3: Tornado
-185.3 "Hydromorph" sync / 1[56]:Hydrate Core:F29:/
-187.3 "--sync--" sync / 1[56]:Hydrate Core:1040:/
+185.3 "Hydromorph" sync / 1[56]:[^:]*:Hydrate Core:F29:/
+187.3 "--sync--" sync / 1[56]:[^:]*:Hydrate Core:1040:/
 192.0 "Piston Lubricant x2"
 201.1 "Gear Lubricant x3"
 # These happen about 1s apart, so don't sync.
-208.4 "Drainage x2" #sync / 1[56]:Living Liquid:F10:/
+208.4 "Drainage x2" #sync / 1[56]:[^:]*:Living Liquid:F10:/
 214.8 "Gear Lubricant x2"
 214.8 "Piston Lubricant x1"
-227.2 "Ferrofluid" sync / 1[56]:Living Liquid:F12:/
-227.7 "Magnetism/Repel" sync / 1[56]:Living Liquid:F1[35]:/
+227.2 "Ferrofluid" sync / 1[56]:[^:]*:Living Liquid:F12:/
+227.7 "Magnetism/Repel" sync / 1[56]:[^:]*:Living Liquid:F1[35]:/
 230.3 "Gear Lubricant x4"
-237.5 "Drainage x2" #sync / 1[56]:Living Liquid:F10:/
+237.5 "Drainage x2" #sync / 1[56]:[^:]*:Living Liquid:F10:/
 243.6 "Gear Lubricant x3"
-252.0 "Ferrofluid" sync / 1[56]:Living Liquid:F12:/
-252.5 "Magnetism/Repel" sync / 1[56]:Living Liquid:F1[35]:/
+252.0 "Ferrofluid" sync / 1[56]:[^:]*:Living Liquid:F12:/
+252.5 "Magnetism/Repel" sync / 1[56]:[^:]*:Living Liquid:F1[35]:/
 254.8 "Piston Lubricant x4"
-279.4 "--sync--" sync / 1[56]:Hydrate Core:F28:/
-280.5 "--sync--" sync / 1[56]:Living Liquid:F26:/
-280.9 "Hydromorph" sync / 1[56]:Hydrate Core:F29:/
-282.9 "--sync--" sync / 1[56]:Hydrate Core:1040:/
+279.4 "--sync--" sync / 1[56]:[^:]*:Hydrate Core:F28:/
+280.5 "--sync--" sync / 1[56]:[^:]*:Living Liquid:F26:/
+280.9 "Hydromorph" sync / 1[56]:[^:]*:Hydrate Core:F29:/
+282.9 "--sync--" sync / 1[56]:[^:]*:Hydrate Core:1040:/
 
 ### Phase 4: Jiggly Again
 284.5 "--targetable--"
-284.5 "--sync--" sync / 1[56]:Living Liquid:EFD:/
+284.5 "--sync--" sync / 1[56]:[^:]*:Living Liquid:EFD:/
 
-294.6 "Cascade 1" sync / 1[56]:Living Liquid:EFE:/ window 300,10
-304.8 "Ferrofluid" sync / 1[56]:Living Liquid:F01:/
-306.0 "Magnetism/Repel" sync / 1[56]:Living Liquid:F1[35]:/
-310.0 "Splash x3" #sync / 1[56]:Living Liquid:EF4:/ duration 2.2
-315.3 "Fluid Swing" sync / 1[56]:Living Liquid:EFC:/
-325.4 "Sluice" sync / 1[56]:Living Liquid:EFA:/
-328.6 "Protean Wave" sync / 1[56]:Living Liquid:EF5:/
-330.3 "Protean Wave" sync / 1[56]:Living Liquid:EF6:/
-334.4 "Fluid Swing" sync / 1[56]:Living Liquid:EFC:/
-340.5 "Splash x3" #sync / 1[56]:Living Liquid:EF4:/ duration 2.2
-345.8 "Fluid Swing" sync / 1[56]:Living Liquid:EFC:/
-355.9 "Sluice" sync / 1[56]:Living Liquid:EFA:/
-361.0 "Digititis" sync / 1[56]:Living Liquid:F00:/
-364.2 "Fluid Swing" sync / 1[56]:Living Liquid:EFC:/
+294.6 "Cascade 1" sync / 1[56]:[^:]*:Living Liquid:EFE:/ window 300,10
+304.8 "Ferrofluid" sync / 1[56]:[^:]*:Living Liquid:F01:/
+306.0 "Magnetism/Repel" sync / 1[56]:[^:]*:Living Liquid:F1[35]:/
+310.0 "Splash x3" #sync / 1[56]:[^:]*:Living Liquid:EF4:/ duration 2.2
+315.3 "Fluid Swing" sync / 1[56]:[^:]*:Living Liquid:EFC:/
+325.4 "Sluice" sync / 1[56]:[^:]*:Living Liquid:EFA:/
+328.6 "Protean Wave" sync / 1[56]:[^:]*:Living Liquid:EF5:/
+330.3 "Protean Wave" sync / 1[56]:[^:]*:Living Liquid:EF6:/
+334.4 "Fluid Swing" sync / 1[56]:[^:]*:Living Liquid:EFC:/
+340.5 "Splash x3" #sync / 1[56]:[^:]*:Living Liquid:EF4:/ duration 2.2
+345.8 "Fluid Swing" sync / 1[56]:[^:]*:Living Liquid:EFC:/
+355.9 "Sluice" sync / 1[56]:[^:]*:Living Liquid:EFA:/
+361.0 "Digititis" sync / 1[56]:[^:]*:Living Liquid:F00:/
+364.2 "Fluid Swing" sync / 1[56]:[^:]*:Living Liquid:EFC:/
 
-370.3 "Cascade 2" sync / 1[56]:Living Liquid:EFE:/ window 40,40
-380.1 "Throttle" #sync / 1[56]:Living Liquid:F02:/
-384.0 "Fluid Claw" sync / 1[56]:Liquid Limb:F0D:/
+370.3 "Cascade 2" sync / 1[56]:[^:]*:Living Liquid:EFE:/ window 40,40
+380.1 "Throttle" #sync / 1[56]:[^:]*:Living Liquid:F02:/
+384.0 "Fluid Claw" sync / 1[56]:[^:]*:Liquid Limb:F0D:/
 385.0 "--targetable--"
-385.3 "Splash x3" #sync / 1[56]:Living Liquid:EF4:/ duration 2.2
-390.6 "Fluid Swing" sync / 1[56]:Living Liquid:EFC:/
-398.7 "Fluid Swing" sync / 1[56]:Living Liquid:EFC:/
-402.8 "Splash x3" #sync / 1[56]:Living Liquid:EF4:/ duration 2.2
-418.1 "Digititis" sync / 1[56]:Living Liquid:F00:/
-422.3 "Fluid Swing" sync / 1[56]:Living Liquid:EFC:/
+385.3 "Splash x3" #sync / 1[56]:[^:]*:Living Liquid:EF4:/ duration 2.2
+390.6 "Fluid Swing" sync / 1[56]:[^:]*:Living Liquid:EFC:/
+398.7 "Fluid Swing" sync / 1[56]:[^:]*:Living Liquid:EFC:/
+402.8 "Splash x3" #sync / 1[56]:[^:]*:Living Liquid:EF4:/ duration 2.2
+418.1 "Digititis" sync / 1[56]:[^:]*:Living Liquid:F00:/
+422.3 "Fluid Swing" sync / 1[56]:[^:]*:Living Liquid:EFC:/
 426.4 "Splash x6" #sync /:Living Liquid::EF4:/ duration 5.5
-435.0 "Fluid Swing" sync / 1[56]:Living Liquid:EFC:/
+435.0 "Fluid Swing" sync / 1[56]:[^:]*:Living Liquid:EFC:/
 
-441.1 "Cascade 3" sync / 1[56]:Living Liquid:EFE:/ window 40,40
-450.3 "Fluid Swing" sync / 1[56]:Living Liquid:EFC:/
-453.5 "Throttle" #sync / 1[56]:Liquid Rage:F1A:/
-455.5 "Protean Wave" sync / 1[56]:Liquid Rage:F19:/
-455.6 "Throttle" #sync / 1[56]:Liquid Rage:F1A:/
-459.4 "Drainage" sync / 1[56]:Liquid Rage:F18:/
-461.6 "Protean Wave" sync / 1[56]:Liquid Rage:F19:/
-463.3 "Ferrofluid" sync / 1[56]:Living Liquid:F01:/
-464.5 "Magnetism/Repel" sync / 1[56]:Living Liquid:F1[35]:/
-471.5 "Fluid Swing" sync / 1[56]:Living Liquid:EFC:/
-476.6 "Throttle" #sync / 1[56]:Liquid Rage:F1A:/
-478.7 "Embolus" sync / 1[56]:Liquid Rage:F1B:/
-478.8 "Throttle" #sync / 1[56]:Liquid Rage:F1A:/
-488.7 "Fluid Swing" sync / 1[56]:Living Liquid:EFC:/
-496.9 "Embolus" sync / 1[56]:Liquid Rage:F1B:/
-496.9 "Protean Wave" sync / 1[56]:Liquid Rage:F19:/
-500.8 "Sluice" sync / 1[56]:Living Liquid:EFA:/
-500.8 "Drainage" sync / 1[56]:Liquid Rage:F18:/
-503.2 "Protean Wave" sync / 1[56]:Liquid Rage:F19:/
-508.9 "Fluid Swing" sync / 1[56]:Living Liquid:EFC:/
+441.1 "Cascade 3" sync / 1[56]:[^:]*:Living Liquid:EFE:/ window 40,40
+450.3 "Fluid Swing" sync / 1[56]:[^:]*:Living Liquid:EFC:/
+453.5 "Throttle" #sync / 1[56]:[^:]*:Liquid Rage:F1A:/
+455.5 "Protean Wave" sync / 1[56]:[^:]*:Liquid Rage:F19:/
+455.6 "Throttle" #sync / 1[56]:[^:]*:Liquid Rage:F1A:/
+459.4 "Drainage" sync / 1[56]:[^:]*:Liquid Rage:F18:/
+461.6 "Protean Wave" sync / 1[56]:[^:]*:Liquid Rage:F19:/
+463.3 "Ferrofluid" sync / 1[56]:[^:]*:Living Liquid:F01:/
+464.5 "Magnetism/Repel" sync / 1[56]:[^:]*:Living Liquid:F1[35]:/
+471.5 "Fluid Swing" sync / 1[56]:[^:]*:Living Liquid:EFC:/
+476.6 "Throttle" #sync / 1[56]:[^:]*:Liquid Rage:F1A:/
+478.7 "Embolus" sync / 1[56]:[^:]*:Liquid Rage:F1B:/
+478.8 "Throttle" #sync / 1[56]:[^:]*:Liquid Rage:F1A:/
+488.7 "Fluid Swing" sync / 1[56]:[^:]*:Living Liquid:EFC:/
+496.9 "Embolus" sync / 1[56]:[^:]*:Liquid Rage:F1B:/
+496.9 "Protean Wave" sync / 1[56]:[^:]*:Liquid Rage:F19:/
+500.8 "Sluice" sync / 1[56]:[^:]*:Living Liquid:EFA:/
+500.8 "Drainage" sync / 1[56]:[^:]*:Liquid Rage:F18:/
+503.2 "Protean Wave" sync / 1[56]:[^:]*:Liquid Rage:F19:/
+508.9 "Fluid Swing" sync / 1[56]:[^:]*:Living Liquid:EFC:/
 
-516.1 "Cascade 4" sync / 1[56]:Living Liquid:EFE:/ window 40,40
-526.3 "Ferrofluid" sync / 1[56]:Living Liquid:F01:/
-527.5 "Magnetism/Repel" sync / 1[56]:Living Liquid:F1[35]:/
-531.5 "Splash x3" #sync / 1[56]:Living Liquid:EF4:/ duration 2.2
-537.0 "Fluid Swing" sync / 1[56]:Living Liquid:EFC:/
-547.1 "Sluice" sync / 1[56]:Living Liquid:EFA:/
-550.4 "Protean Wave" sync / 1[56]:Living Liquid:EF5:/
-552.1 "Protean Wave" sync / 1[56]:Living Liquid:EF6:/
-556.2 "Fluid Swing" sync / 1[56]:Living Liquid:EFC:/
-562.3 "Splash x3" #sync / 1[56]:Living Liquid:EF4:/ duration 2.2
-567.6 "Fluid Swing" sync / 1[56]:Living Liquid:EFC:/
-577.7 "Sluice" sync / 1[56]:Living Liquid:EFA:/
-582.8 "Digititis" sync / 1[56]:Living Liquid:F00:/
-586.0 "Fluid Swing" sync / 1[56]:Living Liquid:EFC:/
+516.1 "Cascade 4" sync / 1[56]:[^:]*:Living Liquid:EFE:/ window 40,40
+526.3 "Ferrofluid" sync / 1[56]:[^:]*:Living Liquid:F01:/
+527.5 "Magnetism/Repel" sync / 1[56]:[^:]*:Living Liquid:F1[35]:/
+531.5 "Splash x3" #sync / 1[56]:[^:]*:Living Liquid:EF4:/ duration 2.2
+537.0 "Fluid Swing" sync / 1[56]:[^:]*:Living Liquid:EFC:/
+547.1 "Sluice" sync / 1[56]:[^:]*:Living Liquid:EFA:/
+550.4 "Protean Wave" sync / 1[56]:[^:]*:Living Liquid:EF5:/
+552.1 "Protean Wave" sync / 1[56]:[^:]*:Living Liquid:EF6:/
+556.2 "Fluid Swing" sync / 1[56]:[^:]*:Living Liquid:EFC:/
+562.3 "Splash x3" #sync / 1[56]:[^:]*:Living Liquid:EF4:/ duration 2.2
+567.6 "Fluid Swing" sync / 1[56]:[^:]*:Living Liquid:EFC:/
+577.7 "Sluice" sync / 1[56]:[^:]*:Living Liquid:EFA:/
+582.8 "Digititis" sync / 1[56]:[^:]*:Living Liquid:F00:/
+586.0 "Fluid Swing" sync / 1[56]:[^:]*:Living Liquid:EFC:/
 
-592.1 "Cascade 5" sync / 1[56]:Living Liquid:EFE:/ window 40,40
-602.0 "Throttle" #sync / 1[56]:Living Liquid:F02:/
-605.9 "Fluid Claw" sync / 1[56]:Liquid Limb:F0D:/
+592.1 "Cascade 5" sync / 1[56]:[^:]*:Living Liquid:EFE:/ window 40,40
+602.0 "Throttle" #sync / 1[56]:[^:]*:Living Liquid:F02:/
+605.9 "Fluid Claw" sync / 1[56]:[^:]*:Liquid Limb:F0D:/
 606.9 "--targetable--"
-607.1 "Splash x3" #sync / 1[56]:Living Liquid:EF4:/ duration 2.2
-612.4 "Fluid Swing" sync / 1[56]:Living Liquid:EFC:/
-620.5 "Fluid Swing" sync / 1[56]:Living Liquid:EFC:/
-624.6 "Splash x3" #sync / 1[56]:Living Liquid:EF4:/ duration 2.2
-639.9 "Digititis" sync / 1[56]:Living Liquid:F00:/
-644.0 "Fluid Swing" sync / 1[56]:Living Liquid:EFC:/
+607.1 "Splash x3" #sync / 1[56]:[^:]*:Living Liquid:EF4:/ duration 2.2
+612.4 "Fluid Swing" sync / 1[56]:[^:]*:Living Liquid:EFC:/
+620.5 "Fluid Swing" sync / 1[56]:[^:]*:Living Liquid:EFC:/
+624.6 "Splash x3" #sync / 1[56]:[^:]*:Living Liquid:EF4:/ duration 2.2
+639.9 "Digititis" sync / 1[56]:[^:]*:Living Liquid:F00:/
+644.0 "Fluid Swing" sync / 1[56]:[^:]*:Living Liquid:EFC:/
 648.1 "Splash x6" #sync /:Living Liquid::EF4:/ duration 5.5
-656.7 "Fluid Swing" sync / 1[56]:Living Liquid:EFC:/
+656.7 "Fluid Swing" sync / 1[56]:[^:]*:Living Liquid:EFC:/
 
-662.8 "Cascade 6" sync / 1[56]:Living Liquid:EFE:/ window 40,40
-672.0 "Fluid Swing" sync / 1[56]:Living Liquid:EFC:/
-675.2 "Throttle" #sync / 1[56]:Liquid Rage:F1A:/
-677.2 "Protean Wave" sync / 1[56]:Liquid Rage:F19:/
-677.4 "Throttle" #sync / 1[56]:Liquid Rage:F1A:/
-681.2 "Drainage" sync / 1[56]:Liquid Rage:F18:/
-683.4 "Protean Wave" sync / 1[56]:Liquid Rage:F19:/
-685.2 "Ferrofluid" sync / 1[56]:Living Liquid:F01:/
-686.4 "Magnetism/Repel" sync / 1[56]:Living Liquid:F1[35]:/
-693.4 "Fluid Swing" sync / 1[56]:Living Liquid:EFC:/
-698.6 "Throttle" #sync / 1[56]:Liquid Rage:F1A:/
-700.6 "Embolus" sync / 1[56]:Liquid Rage:F1B:/
-700.7 "Throttle" #sync / 1[56]:Liquid Rage:F1A:/
-710.5 "Fluid Swing" sync / 1[56]:Living Liquid:EFC:/
-718.7 "Protean Wave" sync / 1[56]:Liquid Rage:F19:/
-718.7 "Embolus" sync / 1[56]:Liquid Rage:F1B:/
-722.6 "Sluice" sync / 1[56]:Living Liquid:EFA:/
-722.6 "Drainage" sync / 1[56]:Liquid Rage:F18:/
-725.3 "Protean Wave" sync / 1[56]:Liquid Rage:F19:/
-730.7 "Fluid Swing" sync / 1[56]:Living Liquid:EFC:/
+662.8 "Cascade 6" sync / 1[56]:[^:]*:Living Liquid:EFE:/ window 40,40
+672.0 "Fluid Swing" sync / 1[56]:[^:]*:Living Liquid:EFC:/
+675.2 "Throttle" #sync / 1[56]:[^:]*:Liquid Rage:F1A:/
+677.2 "Protean Wave" sync / 1[56]:[^:]*:Liquid Rage:F19:/
+677.4 "Throttle" #sync / 1[56]:[^:]*:Liquid Rage:F1A:/
+681.2 "Drainage" sync / 1[56]:[^:]*:Liquid Rage:F18:/
+683.4 "Protean Wave" sync / 1[56]:[^:]*:Liquid Rage:F19:/
+685.2 "Ferrofluid" sync / 1[56]:[^:]*:Living Liquid:F01:/
+686.4 "Magnetism/Repel" sync / 1[56]:[^:]*:Living Liquid:F1[35]:/
+693.4 "Fluid Swing" sync / 1[56]:[^:]*:Living Liquid:EFC:/
+698.6 "Throttle" #sync / 1[56]:[^:]*:Liquid Rage:F1A:/
+700.6 "Embolus" sync / 1[56]:[^:]*:Liquid Rage:F1B:/
+700.7 "Throttle" #sync / 1[56]:[^:]*:Liquid Rage:F1A:/
+710.5 "Fluid Swing" sync / 1[56]:[^:]*:Living Liquid:EFC:/
+718.7 "Protean Wave" sync / 1[56]:[^:]*:Liquid Rage:F19:/
+718.7 "Embolus" sync / 1[56]:[^:]*:Liquid Rage:F1B:/
+722.6 "Sluice" sync / 1[56]:[^:]*:Living Liquid:EFA:/
+722.6 "Drainage" sync / 1[56]:[^:]*:Liquid Rage:F18:/
+725.3 "Protean Wave" sync / 1[56]:[^:]*:Liquid Rage:F19:/
+730.7 "Fluid Swing" sync / 1[56]:[^:]*:Living Liquid:EFC:/
 
-737.8 "Cascade 7" sync / 1[56]:Living Liquid:EFE:/ window 40,40
-748.0 "Ferrofluid" sync / 1[56]:Living Liquid:F01:/
-749.2 "Magnetism/Repel" sync / 1[56]:Living Liquid:F1[35]:/
+737.8 "Cascade 7" sync / 1[56]:[^:]*:Living Liquid:EFE:/ window 40,40
+748.0 "Ferrofluid" sync / 1[56]:[^:]*:Living Liquid:F01:/
+749.2 "Magnetism/Repel" sync / 1[56]:[^:]*:Living Liquid:F1[35]:/
 
-751.2 "--sync--" sync / 14:Living Liquid:EFF:/ window 1000,1000
-761.2 "Cascade Enrage" sync / 1[56]:Living Liquid:EFF:/
+751.2 "--sync--" sync / 14:[^:]*:Living Liquid:EFF:/ window 1000,1000
+761.2 "Cascade Enrage" sync / 1[56]:[^:]*:Living Liquid:EFF:/

--- a/ui/raidboss/data/03-hw/raid/a4s.txt
+++ b/ui/raidboss/data/03-hw/raid/a4s.txt
@@ -13,217 +13,217 @@
 
 ### Leg 1
 0.0 "--sync--" sync /:Engage!/ window 0,1
-3.0 "Hydrothermal Missile" sync / 1[56]:The Manipulator:F5B:/ window 3,13
-14.1 "Discoid" sync / 1[56]:The Manipulator:F61:/
-21.2 "Seed Of The Sky" sync / 1[56]:The Manipulator:13D0:/
-21.2 "Hydrothermal Missile" sync / 1[56]:The Manipulator:F5B:/
-26.3 "Seed Of The Sky" sync / 1[56]:The Manipulator:13D0:/
+3.0 "Hydrothermal Missile" sync / 1[56]:[^:]*:The Manipulator:F5B:/ window 3,13
+14.1 "Discoid" sync / 1[56]:[^:]*:The Manipulator:F61:/
+21.2 "Seed Of The Sky" sync / 1[56]:[^:]*:The Manipulator:13D0:/
+21.2 "Hydrothermal Missile" sync / 1[56]:[^:]*:The Manipulator:F5B:/
+26.3 "Seed Of The Sky" sync / 1[56]:[^:]*:The Manipulator:13D0:/
 26.4 "--stun--" duration 5
-32.2 "Perpetual Ray x2" #sync / 1[56]:The Manipulator:F5F:/
-41.3 "Emergency Quarantine" sync / 1[56]:The Manipulator:F62:/
+32.2 "Perpetual Ray x2" #sync / 1[56]:[^:]*:The Manipulator:F5F:/
+41.3 "Emergency Quarantine" sync / 1[56]:[^:]*:The Manipulator:F62:/
 
-43.4 "Hydrothermal Missile" sync / 1[56]:The Manipulator:F5B:/
-48.5 "Discoid" sync / 1[56]:The Manipulator:F61:/
-53.6 "Seed Of The Sky" sync / 1[56]:The Manipulator:13D0:/
-58.6 "Seed Of The Sky" sync / 1[56]:The Manipulator:13D0:/
+43.4 "Hydrothermal Missile" sync / 1[56]:[^:]*:The Manipulator:F5B:/
+48.5 "Discoid" sync / 1[56]:[^:]*:The Manipulator:F61:/
+53.6 "Seed Of The Sky" sync / 1[56]:[^:]*:The Manipulator:13D0:/
+58.6 "Seed Of The Sky" sync / 1[56]:[^:]*:The Manipulator:13D0:/
 55.6 "--stun--" duration 5
-61.4 "Perpetual Ray x2" #sync / 1[56]:The Manipulator:F5F:/
-71.5 "Hydrothermal Missile" sync / 1[56]:The Manipulator:F5B:/
+61.4 "Perpetual Ray x2" #sync / 1[56]:[^:]*:The Manipulator:F5F:/
+71.5 "Hydrothermal Missile" sync / 1[56]:[^:]*:The Manipulator:F5B:/
 
-85.6 "Hydrothermal Missile" sync / 1[56]:The Manipulator:F5B:/
-96.7 "Discoid" sync / 1[56]:The Manipulator:F61:/ window 20,20 jump 14.1
-103.8 "Seed Of The Sky" #sync / 1[56]:The Manipulator:13D0:/
-103.8 "Hydrothermal Missile" #sync / 1[56]:The Manipulator:F5B:/
-108.9 "Seed Of The Sky" #sync / 1[56]:The Manipulator:13D0:/
+85.6 "Hydrothermal Missile" sync / 1[56]:[^:]*:The Manipulator:F5B:/
+96.7 "Discoid" sync / 1[56]:[^:]*:The Manipulator:F61:/ window 20,20 jump 14.1
+103.8 "Seed Of The Sky" #sync / 1[56]:[^:]*:The Manipulator:13D0:/
+103.8 "Hydrothermal Missile" #sync / 1[56]:[^:]*:The Manipulator:F5B:/
+108.9 "Seed Of The Sky" #sync / 1[56]:[^:]*:The Manipulator:13D0:/
 109.0 "--stun--" duration 5
-114.8 "Perpetual Ray x2" #sync / 1[56]:The Manipulator:F5F:/
-123.9 "Emergency Quarantine" #sync / 1[56]:The Manipulator:F62:/
+114.8 "Perpetual Ray x2" #sync / 1[56]:[^:]*:The Manipulator:F5F:/
+123.9 "Emergency Quarantine" #sync / 1[56]:[^:]*:The Manipulator:F62:/
 
-126.0 "Hydrothermal Missile" #sync / 1[56]:The Manipulator:F5B:/
-131.1 "Discoid" #sync / 1[56]:The Manipulator:F61:/
-136.2 "Seed Of The Sky" #sync / 1[56]:The Manipulator:13D0:/
-141.2 "Seed Of The Sky" #sync / 1[56]:The Manipulator:13D0:/
+126.0 "Hydrothermal Missile" #sync / 1[56]:[^:]*:The Manipulator:F5B:/
+131.1 "Discoid" #sync / 1[56]:[^:]*:The Manipulator:F61:/
+136.2 "Seed Of The Sky" #sync / 1[56]:[^:]*:The Manipulator:13D0:/
+141.2 "Seed Of The Sky" #sync / 1[56]:[^:]*:The Manipulator:13D0:/
 138.2 "--stun--" duration 5
-144.0 "Perpetual Ray x2" #sync / 1[56]:The Manipulator:F5F:/
-154.1 "Hydrothermal Missile" #sync / 1[56]:The Manipulator:F5B:/
+144.0 "Perpetual Ray x2" #sync / 1[56]:[^:]*:The Manipulator:F5F:/
+154.1 "Hydrothermal Missile" #sync / 1[56]:[^:]*:The Manipulator:F5B:/
 
 
 ### Leg 2
 500.0 "--sync--" sync / 22:........:The Manipulator:........:The Manipulator:01/ window 500,0
 512.1 "--untargetable--"
-516.2 "--sync--" sync / 14:The Manipulator:13E7:/ window 517,5
-522.2 "Mortal Revolution" sync / 1[56]:The Manipulator:13E7:/
+516.2 "--sync--" sync / 14:[^:]*:The Manipulator:13E7:/ window 517,5
+522.2 "Mortal Revolution" sync / 1[56]:[^:]*:The Manipulator:13E7:/
 524.2 "--targetable--"
-532.3 "Emergency Quarantine" sync / 1[56]:The Manipulator:F62:/
-543.4 "Carnage" sync / 1[56]:The Manipulator:F63:/
-545.5 "Hydrothermal Missile" sync / 1[56]:The Manipulator:F5B:/
+532.3 "Emergency Quarantine" sync / 1[56]:[^:]*:The Manipulator:F62:/
+543.4 "Carnage" sync / 1[56]:[^:]*:The Manipulator:F63:/
+545.5 "Hydrothermal Missile" sync / 1[56]:[^:]*:The Manipulator:F5B:/
 547.6 "--stun--" duration 5
-553.4 "Perpetual Ray x2" #sync / 1[56]:The Manipulator:F5F:/
-564.5 "Carnage" sync / 1[56]:The Manipulator:F63:/
-566.6 "Hydrothermal Missile" sync / 1[56]:The Manipulator:F5B:/
-569.6 "Seed Of The Sky" sync / 1[56]:The Manipulator:13D0:/
+553.4 "Perpetual Ray x2" #sync / 1[56]:[^:]*:The Manipulator:F5F:/
+564.5 "Carnage" sync / 1[56]:[^:]*:The Manipulator:F63:/
+566.6 "Hydrothermal Missile" sync / 1[56]:[^:]*:The Manipulator:F5B:/
+569.6 "Seed Of The Sky" sync / 1[56]:[^:]*:The Manipulator:13D0:/
 
-578.7 "Emergency Quarantine" sync / 1[56]:The Manipulator:F62:/
+578.7 "Emergency Quarantine" sync / 1[56]:[^:]*:The Manipulator:F62:/
 580.8 "--stun--" duration 5
-586.6 "Perpetual Ray x2" #sync / 1[56]:The Manipulator:F5F:/
-590.7 "Hydrothermal Missile" sync / 1[56]:The Manipulator:F5B:/
-597.8 "Carnage" sync / 1[56]:The Manipulator:F63:/
-602.9 "Seed Of The Sky" sync / 1[56]:The Manipulator:13D0:/
-612.9 "Hydrothermal Missile" sync / 1[56]:The Manipulator:F5B:/
+586.6 "Perpetual Ray x2" #sync / 1[56]:[^:]*:The Manipulator:F5F:/
+590.7 "Hydrothermal Missile" sync / 1[56]:[^:]*:The Manipulator:F5B:/
+597.8 "Carnage" sync / 1[56]:[^:]*:The Manipulator:F63:/
+602.9 "Seed Of The Sky" sync / 1[56]:[^:]*:The Manipulator:13D0:/
+612.9 "Hydrothermal Missile" sync / 1[56]:[^:]*:The Manipulator:F5B:/
 
-625.0 "Emergency Quarantine" sync / 1[56]:The Manipulator:F62:/ window 30,30 jump 532.3
-636.1 "Carnage" #sync / 1[56]:The Manipulator:F63:/
-638.2 "Hydrothermal Missile" #sync / 1[56]:The Manipulator:F5B:/
+625.0 "Emergency Quarantine" sync / 1[56]:[^:]*:The Manipulator:F62:/ window 30,30 jump 532.3
+636.1 "Carnage" #sync / 1[56]:[^:]*:The Manipulator:F63:/
+638.2 "Hydrothermal Missile" #sync / 1[56]:[^:]*:The Manipulator:F5B:/
 640.3 "--stun--" duration 5
-646.1 "Perpetual Ray x2" #sync / 1[56]:The Manipulator:F5F:/
-657.2 "Carnage" #sync / 1[56]:The Manipulator:F63:/
-659.3 "Hydrothermal Missile" #sync / 1[56]:The Manipulator:F5B:/
-662.3 "Seed Of The Sky" #sync / 1[56]:The Manipulator:13D0:/
+646.1 "Perpetual Ray x2" #sync / 1[56]:[^:]*:The Manipulator:F5F:/
+657.2 "Carnage" #sync / 1[56]:[^:]*:The Manipulator:F63:/
+659.3 "Hydrothermal Missile" #sync / 1[56]:[^:]*:The Manipulator:F5B:/
+662.3 "Seed Of The Sky" #sync / 1[56]:[^:]*:The Manipulator:13D0:/
 
-671.4 "Emergency Quarantine" #sync / 1[56]:The Manipulator:F62:/
+671.4 "Emergency Quarantine" #sync / 1[56]:[^:]*:The Manipulator:F62:/
 673.5 "--stun--" duration 5
-679.3 "Perpetual Ray x2" #sync / 1[56]:The Manipulator:F5F:/
-683.4 "Hydrothermal Missile" #sync / 1[56]:The Manipulator:F5B:/
-690.5 "Carnage" #sync / 1[56]:The Manipulator:F63:/
-695.6 "Seed Of The Sky" #sync / 1[56]:The Manipulator:13D0:/
-705.6 "Hydrothermal Missile" #sync / 1[56]:The Manipulator:F5B:/
+679.3 "Perpetual Ray x2" #sync / 1[56]:[^:]*:The Manipulator:F5F:/
+683.4 "Hydrothermal Missile" #sync / 1[56]:[^:]*:The Manipulator:F5B:/
+690.5 "Carnage" #sync / 1[56]:[^:]*:The Manipulator:F63:/
+695.6 "Seed Of The Sky" #sync / 1[56]:[^:]*:The Manipulator:13D0:/
+705.6 "Hydrothermal Missile" #sync / 1[56]:[^:]*:The Manipulator:F5B:/
 
 
 ### Leg 3
 1000.0 "--sync--"  sync / 22:........:The Manipulator:........:The Manipulator:01/ window 490,0
 1012.1 "--untargetable--"
-1016.2 "--sync--" sync / 14:The Manipulator:13E7:/ window 490,5
-1022.2 "Mortal Revolution" sync / 1[56]:The Manipulator:13E7:/
+1016.2 "--sync--" sync / 14:[^:]*:The Manipulator:13E7:/ window 490,5
+1022.2 "Mortal Revolution" sync / 1[56]:[^:]*:The Manipulator:13E7:/
 1024.2 "--targetable--"
-1027.4 "Hydrothermal Missile" sync / 1[56]:The Manipulator:F5B:/ window 10,10
-1034.5 "Carnage" sync / 1[56]:The Manipulator:F63:/
+1027.4 "Hydrothermal Missile" sync / 1[56]:[^:]*:The Manipulator:F5B:/ window 10,10
+1034.5 "Carnage" sync / 1[56]:[^:]*:The Manipulator:F63:/
 1040.2 "Straf Doll x1"
 1040.2 "Jagd Doll x3"
 1044.6 "--stun--" duration 5
-1050.4 "Perpetual Ray x2" #sync / 1[56]:The Manipulator:F5F:/
-1057.6 "Seed Of The Sky" sync / 1[56]:The Manipulator:13D0:/
-1062.6 "Hydrothermal Missile" sync / 1[56]:The Manipulator:F5B:/
-1071.7 "Carnage" sync / 1[56]:The Manipulator:F63:/
+1050.4 "Perpetual Ray x2" #sync / 1[56]:[^:]*:The Manipulator:F5F:/
+1057.6 "Seed Of The Sky" sync / 1[56]:[^:]*:The Manipulator:13D0:/
+1062.6 "Hydrothermal Missile" sync / 1[56]:[^:]*:The Manipulator:F5B:/
+1071.7 "Carnage" sync / 1[56]:[^:]*:The Manipulator:F63:/
 1075.4 "--stun--" duration 5
-1081.2 "Perpetual Ray x2" #sync / 1[56]:The Manipulator:F5D:/
+1081.2 "Perpetual Ray x2" #sync / 1[56]:[^:]*:The Manipulator:F5D:/
 
-1098.9 "Hydrothermal Missile" sync / 1[56]:The Manipulator:F5B:/ window 10,10
+1098.9 "Hydrothermal Missile" sync / 1[56]:[^:]*:The Manipulator:F5B:/ window 10,10
 1107.5 "Straf Doll x1"
 1107.5 "Jagd Doll x3"
 1108.0 "--stun--" duration 5
-1113.8 "Perpetual Ray x2" #sync / 1[56]:The Manipulator:F5F:/
-1120.8 "Seed Of The Sky" sync / 1[56]:The Manipulator:13D0:/
-1124.8 "Carnage" sync / 1[56]:The Manipulator:F63:/
-1129.9 "Seed Of The Sky" sync / 1[56]:The Manipulator:13D0:/
-1129.9 "Hydrothermal Missile" sync / 1[56]:The Manipulator:F5B:/
+1113.8 "Perpetual Ray x2" #sync / 1[56]:[^:]*:The Manipulator:F5F:/
+1120.8 "Seed Of The Sky" sync / 1[56]:[^:]*:The Manipulator:13D0:/
+1124.8 "Carnage" sync / 1[56]:[^:]*:The Manipulator:F63:/
+1129.9 "Seed Of The Sky" sync / 1[56]:[^:]*:The Manipulator:13D0:/
+1129.9 "Hydrothermal Missile" sync / 1[56]:[^:]*:The Manipulator:F5B:/
 1135.6 "--stun--" duration 5
-1141.4 "Perpetual Ray x2" #sync / 1[56]:The Manipulator:F5D:/
+1141.4 "Perpetual Ray x2" #sync / 1[56]:[^:]*:The Manipulator:F5D:/
 
-1160.2 "Hydrothermal Missile" sync / 1[56]:The Manipulator:F5B:/ window 10,10
-1167.3 "Carnage" sync / 1[56]:The Manipulator:F63:/ window 20,20 jump 1034.5
+1160.2 "Hydrothermal Missile" sync / 1[56]:[^:]*:The Manipulator:F5B:/ window 10,10
+1167.3 "Carnage" sync / 1[56]:[^:]*:The Manipulator:F63:/ window 20,20 jump 1034.5
 1173.0 "Straf Doll x1"
 1173.0 "Jagd Doll x3"
 1177.4 "--stun--" duration 5
-1183.2 "Perpetual Ray x2" #sync / 1[56]:The Manipulator:F5F:/
-1190.4 "Seed Of The Sky" #sync / 1[56]:The Manipulator:13D0:/
-1195.4 "Hydrothermal Missile" #sync / 1[56]:The Manipulator:F5B:/
-1204.5 "Carnage" #sync / 1[56]:The Manipulator:F63:/
+1183.2 "Perpetual Ray x2" #sync / 1[56]:[^:]*:The Manipulator:F5F:/
+1190.4 "Seed Of The Sky" #sync / 1[56]:[^:]*:The Manipulator:13D0:/
+1195.4 "Hydrothermal Missile" #sync / 1[56]:[^:]*:The Manipulator:F5B:/
+1204.5 "Carnage" #sync / 1[56]:[^:]*:The Manipulator:F63:/
 1208.2 "--stun--" duration 5
-1214.0 "Perpetual Ray x2" #sync / 1[56]:The Manipulator:F5D:/
+1214.0 "Perpetual Ray x2" #sync / 1[56]:[^:]*:The Manipulator:F5D:/
 
-1231.7 "Hydrothermal Missile" #sync / 1[56]:The Manipulator:F5B:/
+1231.7 "Hydrothermal Missile" #sync / 1[56]:[^:]*:The Manipulator:F5B:/
 1240.3 "Straf Doll x1"
 1240.3 "Jagd Doll x3"
 1240.8 "--stun--" duration 5
-1246.6 "Perpetual Ray x2" #sync / 1[56]:The Manipulator:F5F:/
-1253.6 "Seed Of The Sky" #sync / 1[56]:The Manipulator:13D0:/
-1257.6 "Carnage" #sync / 1[56]:The Manipulator:F63:/
-1262.7 "Seed Of The Sky" #sync / 1[56]:The Manipulator:13D0:/
-1262.7 "Hydrothermal Missile" #sync / 1[56]:The Manipulator:F5B:/
+1246.6 "Perpetual Ray x2" #sync / 1[56]:[^:]*:The Manipulator:F5F:/
+1253.6 "Seed Of The Sky" #sync / 1[56]:[^:]*:The Manipulator:13D0:/
+1257.6 "Carnage" #sync / 1[56]:[^:]*:The Manipulator:F63:/
+1262.7 "Seed Of The Sky" #sync / 1[56]:[^:]*:The Manipulator:13D0:/
+1262.7 "Hydrothermal Missile" #sync / 1[56]:[^:]*:The Manipulator:F5B:/
 1268.4 "--stun--" duration 5
-1274.2 "Perpetual Ray x2" #sync / 1[56]:The Manipulator:F5D:/
+1274.2 "Perpetual Ray x2" #sync / 1[56]:[^:]*:The Manipulator:F5D:/
 
 
 ### Leg 4
 1500.0 "--sync--"  sync / 22:........:The Manipulator:........:The Manipulator:01/ window 490,0
 1512.1 "--untargetable--"
-1516.2 "--sync--" sync / 14:The Manipulator:13E7:/ window 490,5
-1522.2 "Mortal Revolution" sync / 1[56]:The Manipulator:13E7:/
+1516.2 "--sync--" sync / 14:[^:]*:The Manipulator:13E7:/ window 490,5
+1522.2 "Mortal Revolution" sync / 1[56]:[^:]*:The Manipulator:13E7:/
 1524.2 "--targetable--"
-1528.4 "Judgment Nisi" sync / 1[56]:The Manipulator:F64:/
+1528.4 "Judgment Nisi" sync / 1[56]:[^:]*:The Manipulator:F64:/
 1535.9 "Straf Doll x1"
 1535.9 "Jagd Doll x3"
 1540.6 "--stun--" duration 5
-1546.4 "Perpetual Ray x2" #sync / 1[56]:The Manipulator:F5F:/
-1556.5 "Seed Of The Sky" sync / 1[56]:The Manipulator:13D0:/
-1563.5 "Hydrothermal Missile" sync / 1[56]:The Manipulator:F5B:/ window 10,10
+1546.4 "Perpetual Ray x2" #sync / 1[56]:[^:]*:The Manipulator:F5F:/
+1556.5 "Seed Of The Sky" sync / 1[56]:[^:]*:The Manipulator:13D0:/
+1563.5 "Hydrothermal Missile" sync / 1[56]:[^:]*:The Manipulator:F5B:/ window 10,10
 
-1573.6 "Discoid" sync / 1[56]:The Manipulator:F61:/
-1582.8 "Seed Of The Sky" sync / 1[56]:The Manipulator:13D0:/
-1587.8 "Seed Of The Sky" sync / 1[56]:The Manipulator:13D0:/
-1589.8 "Hydrothermal Missile" sync / 1[56]:The Manipulator:F5B:/ window 10,10
+1573.6 "Discoid" sync / 1[56]:[^:]*:The Manipulator:F61:/
+1582.8 "Seed Of The Sky" sync / 1[56]:[^:]*:The Manipulator:13D0:/
+1587.8 "Seed Of The Sky" sync / 1[56]:[^:]*:The Manipulator:13D0:/
+1589.8 "Hydrothermal Missile" sync / 1[56]:[^:]*:The Manipulator:F5B:/ window 10,10
 1598.0 "Straf Doll x1"
 1598.0 "Jagd Doll x3"
 1605.0 "--stun--" duration 5
-1610.8 "Perpetual Ray x2" #sync / 1[56]:The Manipulator:F5F:/
-1615.9 "Hydrothermal Missile" sync / 1[56]:The Manipulator:F5B:/ window 10,10
+1610.8 "Perpetual Ray x2" #sync / 1[56]:[^:]*:The Manipulator:F5F:/
+1615.9 "Hydrothermal Missile" sync / 1[56]:[^:]*:The Manipulator:F5B:/ window 10,10
 
 # ??? Guessing at this loop.
-1621.0 "Discoid" sync / 1[56]:The Manipulator:F61:/ window 30,30 jump 1573.6
-1630.2 "Seed Of The Sky" #sync / 1[56]:The Manipulator:13D0:/
-1635.2 "Seed Of The Sky" #sync / 1[56]:The Manipulator:13D0:/
-1637.2 "Hydrothermal Missile" #sync / 1[56]:The Manipulator:F5B:/ window 10,10
+1621.0 "Discoid" sync / 1[56]:[^:]*:The Manipulator:F61:/ window 30,30 jump 1573.6
+1630.2 "Seed Of The Sky" #sync / 1[56]:[^:]*:The Manipulator:13D0:/
+1635.2 "Seed Of The Sky" #sync / 1[56]:[^:]*:The Manipulator:13D0:/
+1637.2 "Hydrothermal Missile" #sync / 1[56]:[^:]*:The Manipulator:F5B:/ window 10,10
 1645.4 "Straf Doll x1"
 1645.4 "Jagd Doll x3"
 1652.4 "--stun--" duration 5
-1658.2 "Perpetual Ray x2" #sync / 1[56]:The Manipulator:F5F:/
+1658.2 "Perpetual Ray x2" #sync / 1[56]:[^:]*:The Manipulator:F5F:/
 
 
 ### Final Phase
 2000.0 "--sync--"  sync / 22:........:The Manipulator:........:The Manipulator:01/ window 490,0
 2012.1 "--untargetable--"
-2016.2 "--sync--" sync / 14:The Manipulator:13E7:/ window 490,5
-2022.2 "Mortal Revolution" sync / 1[56]:The Manipulator:13E7:/
+2016.2 "--sync--" sync / 14:[^:]*:The Manipulator:13E7:/ window 490,5
+2022.2 "Mortal Revolution" sync / 1[56]:[^:]*:The Manipulator:13E7:/
 2024.2 "--targetable--"
 
-2033.3 "Carnage Zero" sync / 1[56]:The Manipulator:F5E:/
-2041.4 "Discoid" sync / 1[56]:The Manipulator:F61:/
-2052.5 "Seed Of The Sky" sync / 1[56]:The Manipulator:13D0:/
-2053.5 "Hydrothermal Missile" sync / 1[56]:The Manipulator:F5B:/
-2058.6 "Carnage Zero" sync / 1[56]:The Manipulator:F5E:/
+2033.3 "Carnage Zero" sync / 1[56]:[^:]*:The Manipulator:F5E:/
+2041.4 "Discoid" sync / 1[56]:[^:]*:The Manipulator:F61:/
+2052.5 "Seed Of The Sky" sync / 1[56]:[^:]*:The Manipulator:13D0:/
+2053.5 "Hydrothermal Missile" sync / 1[56]:[^:]*:The Manipulator:F5B:/
+2058.6 "Carnage Zero" sync / 1[56]:[^:]*:The Manipulator:F5E:/
 
-2072.8 "Royal Pentacle" sync / 1[56]:The Manipulator:F66:/
-2074.9 "Perpetual Ray x5" duration 8.4 #sync / 1[56]:The Manipulator:13B6:/
-2085.4 "Hydrothermal Missile" sync / 1[56]:The Manipulator:F5B:/
-2105.6 "Carnage" sync / 1[56]:The Manipulator:F63:/
+2072.8 "Royal Pentacle" sync / 1[56]:[^:]*:The Manipulator:F66:/
+2074.9 "Perpetual Ray x5" duration 8.4 #sync / 1[56]:[^:]*:The Manipulator:13B6:/
+2085.4 "Hydrothermal Missile" sync / 1[56]:[^:]*:The Manipulator:F5B:/
+2105.6 "Carnage" sync / 1[56]:[^:]*:The Manipulator:F63:/
 2114.6 "Straf Doll x1"
 2114.6 "Jagd Doll x3"
-2116.8 "Hydrothermal Missile" sync / 1[56]:The Manipulator:F5B:/
-2122.9 "Carnage Zero" sync / 1[56]:The Manipulator:F5E:/
-2122.9 "Seed Of The Sky" sync / 1[56]:The Manipulator:13D0:/
-2128.0 "Seed Of The Sky" sync / 1[56]:The Manipulator:13D0:/
-2140.0 "Carnage Zero" sync / 1[56]:The Manipulator:F5E:/
-2148.2 "Hydrothermal Missile" sync / 1[56]:The Manipulator:F5B:/
+2116.8 "Hydrothermal Missile" sync / 1[56]:[^:]*:The Manipulator:F5B:/
+2122.9 "Carnage Zero" sync / 1[56]:[^:]*:The Manipulator:F5E:/
+2122.9 "Seed Of The Sky" sync / 1[56]:[^:]*:The Manipulator:13D0:/
+2128.0 "Seed Of The Sky" sync / 1[56]:[^:]*:The Manipulator:13D0:/
+2140.0 "Carnage Zero" sync / 1[56]:[^:]*:The Manipulator:F5E:/
+2148.2 "Hydrothermal Missile" sync / 1[56]:[^:]*:The Manipulator:F5B:/
 
-2161.3 "Carnage Zero" sync / 1[56]:The Manipulator:F5E:/
-2169.5 "Discoid" sync / 1[56]:The Manipulator:F61:/
-2180.6 "Seed Of The Sky" sync / 1[56]:The Manipulator:13D0:/
-2181.6 "Hydrothermal Missile" sync / 1[56]:The Manipulator:F5B:/
-2186.7 "Carnage Zero" sync / 1[56]:The Manipulator:F5E:/
+2161.3 "Carnage Zero" sync / 1[56]:[^:]*:The Manipulator:F5E:/
+2169.5 "Discoid" sync / 1[56]:[^:]*:The Manipulator:F61:/
+2180.6 "Seed Of The Sky" sync / 1[56]:[^:]*:The Manipulator:13D0:/
+2181.6 "Hydrothermal Missile" sync / 1[56]:[^:]*:The Manipulator:F5B:/
+2186.7 "Carnage Zero" sync / 1[56]:[^:]*:The Manipulator:F5E:/
 
-2200.9 "Royal Pentacle" sync / 1[56]:The Manipulator:F66:/ window 40,40 jump 2072.8
-2203.0 "Perpetual Ray x5" duration 8.4 #sync / 1[56]:The Manipulator:13B6:/
-2213.5 "Hydrothermal Missile" #sync / 1[56]:The Manipulator:F5B:/
-2233.7 "Carnage" #sync / 1[56]:The Manipulator:F63:/
-2244.9 "Hydrothermal Missile" #sync / 1[56]:The Manipulator:F5B:/
-2251.0 "Carnage Zero" #sync / 1[56]:The Manipulator:F5E:/
-2251.0 "Seed Of The Sky" #sync / 1[56]:The Manipulator:13D0:/
-2256.1 "Seed Of The Sky" #sync / 1[56]:The Manipulator:13D0:/
-2268.1 "Carnage Zero" #sync / 1[56]:The Manipulator:F5E:/
-2276.3 "Hydrothermal Missile" #sync / 1[56]:The Manipulator:F5B:/
+2200.9 "Royal Pentacle" sync / 1[56]:[^:]*:The Manipulator:F66:/ window 40,40 jump 2072.8
+2203.0 "Perpetual Ray x5" duration 8.4 #sync / 1[56]:[^:]*:The Manipulator:13B6:/
+2213.5 "Hydrothermal Missile" #sync / 1[56]:[^:]*:The Manipulator:F5B:/
+2233.7 "Carnage" #sync / 1[56]:[^:]*:The Manipulator:F63:/
+2244.9 "Hydrothermal Missile" #sync / 1[56]:[^:]*:The Manipulator:F5B:/
+2251.0 "Carnage Zero" #sync / 1[56]:[^:]*:The Manipulator:F5E:/
+2251.0 "Seed Of The Sky" #sync / 1[56]:[^:]*:The Manipulator:13D0:/
+2256.1 "Seed Of The Sky" #sync / 1[56]:[^:]*:The Manipulator:13D0:/
+2268.1 "Carnage Zero" #sync / 1[56]:[^:]*:The Manipulator:F5E:/
+2276.3 "Hydrothermal Missile" #sync / 1[56]:[^:]*:The Manipulator:F5B:/
 
 
 ### Enrage
 # Note: Manipulator won't enrage until all legs have been killed.
-2500.0 "--sync--" sync / 14:The Manipulator:13E7:/ window 480,480
-2506.0 "Mortal Revolution Enrage" sync / 1[56]:The Manipulator:13E7:/
+2500.0 "--sync--" sync / 14:[^:]*:The Manipulator:13E7:/ window 480,480
+2506.0 "Mortal Revolution Enrage" sync / 1[56]:[^:]*:The Manipulator:13E7:/

--- a/ui/raidboss/data/03-hw/raid/a5s.txt
+++ b/ui/raidboss/data/03-hw/raid/a5s.txt
@@ -11,167 +11,167 @@ hideall "Relaxant"
 
 ### Hummel and Friends
 1000.0 "--sync--" sync / 00:0839::The Clevering will be sealed off/ window 1000,0
-1001.8 "--sync--" sync / 1[56]:Faust:367:/ window 1002,0.5
-1009.8 "Kaltstrahl x1" sync / 1[56]:Faust:16CC:/
-1018.9 "Kaltstrahl x2" duration 2.1 sync / 1[56]:Faust:16CC:/ window 5,0.5
-#1021.0 "Kaltstrahl" sync / 1[56]:Faust:16CC:/
-1032.1 "Kaltstrahl x3" duration 4.2 sync / 1[56]:Faust:16CC:/ window 5,0.5
-#1034.2 "Kaltstrahl" sync / 1[56]:Faust:16CC:/
-#1036.3 "Kaltstrahl" sync / 1[56]:Faust:16CC:/
-1043.4 "Kaltstrahl x3" duration 4.2 sync / 1[56]:Faust:16CC:/ window 5,0.5
-#1045.5 "Kaltstrahl" sync / 1[56]:Faust:16CC:/
-#1047.6 "Kaltstrahl" sync / 1[56]:Faust:16CC:/
+1001.8 "--sync--" sync / 1[56]:[^:]*:Faust:367:/ window 1002,0.5
+1009.8 "Kaltstrahl x1" sync / 1[56]:[^:]*:Faust:16CC:/
+1018.9 "Kaltstrahl x2" duration 2.1 sync / 1[56]:[^:]*:Faust:16CC:/ window 5,0.5
+#1021.0 "Kaltstrahl" sync / 1[56]:[^:]*:Faust:16CC:/
+1032.1 "Kaltstrahl x3" duration 4.2 sync / 1[56]:[^:]*:Faust:16CC:/ window 5,0.5
+#1034.2 "Kaltstrahl" sync / 1[56]:[^:]*:Faust:16CC:/
+#1036.3 "Kaltstrahl" sync / 1[56]:[^:]*:Faust:16CC:/
+1043.4 "Kaltstrahl x3" duration 4.2 sync / 1[56]:[^:]*:Faust:16CC:/ window 5,0.5
+#1045.5 "Kaltstrahl" sync / 1[56]:[^:]*:Faust:16CC:/
+#1047.6 "Kaltstrahl" sync / 1[56]:[^:]*:Faust:16CC:/
 
-1051.6 "--sync--" sync / 14:Hummelfaust:16D2:/ window 52,10
-1056.6 "Panzer Vor" sync / 1[56]:Hummelfaust:16D2:/
+1051.6 "--sync--" sync / 14:[^:]*:Hummelfaust:16D2:/ window 52,10
+1056.6 "Panzer Vor" sync / 1[56]:[^:]*:Hummelfaust:16D2:/
 
 # Note: if previous Fausts haven't been destroyed,
 # There's a 3.7 second delay for Reducible Complexity + Pressure Increase.
 # These two have been adjusted backwards in time by this to re-sync for it.
 # Assume this will not happen in general though.
-1053.4 "--sync--" sync / 1[56]:Faust:16CF:/ window 10,10 # Reducible Complexity
-1056.0 "--sync--" sync / 1[56]:Hummelfaust:16CD:/ window 10,10 # Pressure Increase.
+1053.4 "--sync--" sync / 1[56]:[^:]*:Faust:16CF:/ window 10,10 # Reducible Complexity
+1056.0 "--sync--" sync / 1[56]:[^:]*:Hummelfaust:16CD:/ window 10,10 # Pressure Increase.
 
-1065.2 "Kaltstrahl x2" duration 2.1 sync / 1[56]:Hummelfaust:16CE:/ window 5,0.5
-#1067.3 "Kaltstrahl" sync / 1[56]:Hummelfaust:16CE:/
-1085.4 "Kaltstrahl x3" duration 4.2 sync / 1[56]:Hummelfaust:16CE:/ window 5,0.5
-#1087.5 "Kaltstrahl" sync / 1[56]:Hummelfaust:16CE:/
-#1089.6 "Kaltstrahl" sync / 1[56]:Hummelfaust:16CE:/
-1101.7 "Panzerschreck" sync / 1[56]:Hummelfaust:16D0:/ window 15,15
-1110.9 "Kaltstrahl x4" duration 6.3 sync / 1[56]:Hummelfaust:16CE:/ window 5,0.5
-#1113.0 "Kaltstrahl" sync / 1[56]:Hummelfaust:16CE:/
-#1115.1 "Kaltstrahl" sync / 1[56]:Hummelfaust:16CE:/
-#1117.2 "Kaltstrahl" sync / 1[56]:Hummelfaust:16CE:/
-1128.3 "Panzerschreck" sync / 1[56]:Hummelfaust:16D0:/
-1134.4 "Panzerschreck" sync / 1[56]:Hummelfaust:16D0:/
-1138.5 "Kaltstrahl x4" duration 6.3 sync / 1[56]:Hummelfaust:16CE:/ window 5,0.5
-#1140.6 "Kaltstrahl" sync / 1[56]:Hummelfaust:16CE:/
-#1142.7 "Kaltstrahl" sync / 1[56]:Hummelfaust:16CE:/
-#1144.8 "Kaltstrahl" sync / 1[56]:Hummelfaust:16CE:/
+1065.2 "Kaltstrahl x2" duration 2.1 sync / 1[56]:[^:]*:Hummelfaust:16CE:/ window 5,0.5
+#1067.3 "Kaltstrahl" sync / 1[56]:[^:]*:Hummelfaust:16CE:/
+1085.4 "Kaltstrahl x3" duration 4.2 sync / 1[56]:[^:]*:Hummelfaust:16CE:/ window 5,0.5
+#1087.5 "Kaltstrahl" sync / 1[56]:[^:]*:Hummelfaust:16CE:/
+#1089.6 "Kaltstrahl" sync / 1[56]:[^:]*:Hummelfaust:16CE:/
+1101.7 "Panzerschreck" sync / 1[56]:[^:]*:Hummelfaust:16D0:/ window 15,15
+1110.9 "Kaltstrahl x4" duration 6.3 sync / 1[56]:[^:]*:Hummelfaust:16CE:/ window 5,0.5
+#1113.0 "Kaltstrahl" sync / 1[56]:[^:]*:Hummelfaust:16CE:/
+#1115.1 "Kaltstrahl" sync / 1[56]:[^:]*:Hummelfaust:16CE:/
+#1117.2 "Kaltstrahl" sync / 1[56]:[^:]*:Hummelfaust:16CE:/
+1128.3 "Panzerschreck" sync / 1[56]:[^:]*:Hummelfaust:16D0:/
+1134.4 "Panzerschreck" sync / 1[56]:[^:]*:Hummelfaust:16D0:/
+1138.5 "Kaltstrahl x4" duration 6.3 sync / 1[56]:[^:]*:Hummelfaust:16CE:/ window 5,0.5
+#1140.6 "Kaltstrahl" sync / 1[56]:[^:]*:Hummelfaust:16CE:/
+#1142.7 "Kaltstrahl" sync / 1[56]:[^:]*:Hummelfaust:16CE:/
+#1144.8 "Kaltstrahl" sync / 1[56]:[^:]*:Hummelfaust:16CE:/
 # FIXME: maybe more abilities if Fausts are pushed quickly?
 
 # Time-based enrage.
-1150.7 "--sync--" sync / 14:Hummelfaust:16D1:/ window 151,20
-1154.7 "Panzerschreck Enrage" sync / 1[56]:Hummelfaust:16D1:/
+1150.7 "--sync--" sync / 14:[^:]*:Hummelfaust:16D1:/ window 151,20
+1154.7 "Panzerschreck Enrage" sync / 1[56]:[^:]*:Hummelfaust:16D1:/
 
 
 
 ### Ratfinx Twinkledinks
 # This happens so quickly, no need for "Advanced Clevering will be sealed off".
 2000.0 "Start"
-2001.0 "Guzzle" sync / 1[56]:Ratfinx Twinkledinks:1598:/ window 2001,30
+2001.0 "Guzzle" sync / 1[56]:[^:]*:Ratfinx Twinkledinks:1598:/ window 2001,30
 
-2005.6 "--big--" sync / 1[56]:Ratfinx Twinkledinks:1599:/
-2009.1 "Gobjab 1" sync / 1[56]:Ratfinx Twinkledinks:16A9:/
-2013.2 "Gobjab 2" sync / 1[56]:Ratfinx Twinkledinks:16A9:/
-2017.3 "Gobjab 3" sync / 1[56]:Ratfinx Twinkledinks:16A9:/
-2021.4 "Gobjab 4" sync / 1[56]:Ratfinx Twinkledinks:16A9:/
-2028.5 "Gobstraight/Cut" sync / 1[56]:Ratfinx Twinkledinks:16A[AC]:/
-2041.1 "Gobdash" sync / 1[56]:Ratfinx Twinkledinks:16AF:/
+2005.6 "--big--" sync / 1[56]:[^:]*:Ratfinx Twinkledinks:1599:/
+2009.1 "Gobjab 1" sync / 1[56]:[^:]*:Ratfinx Twinkledinks:16A9:/
+2013.2 "Gobjab 2" sync / 1[56]:[^:]*:Ratfinx Twinkledinks:16A9:/
+2017.3 "Gobjab 3" sync / 1[56]:[^:]*:Ratfinx Twinkledinks:16A9:/
+2021.4 "Gobjab 4" sync / 1[56]:[^:]*:Ratfinx Twinkledinks:16A9:/
+2028.5 "Gobstraight/Cut" sync / 1[56]:[^:]*:Ratfinx Twinkledinks:16A[AC]:/
+2041.1 "Gobdash" sync / 1[56]:[^:]*:Ratfinx Twinkledinks:16AF:/
 
 # will push at 90%
-2047.3 "Relaxant" sync / 1[56]:Ratfinx Twinkledinks:159B:/ window 50,20
-2049.4 "--small--" sync / 1[56]:Ratfinx Twinkledinks:1687:/
-2058.9 "Glupgloop" sync / 1[56]:Ratfinx Twinkledinks:16AE:/
+2047.3 "Relaxant" sync / 1[56]:[^:]*:Ratfinx Twinkledinks:159B:/ window 50,20
+2049.4 "--small--" sync / 1[56]:[^:]*:Ratfinx Twinkledinks:1687:/
+2058.9 "Glupgloop" sync / 1[56]:[^:]*:Ratfinx Twinkledinks:16AE:/
 2068.0 "Cobra x2 (NE/SE)"
-2069.0 "Glupgloop" sync / 1[56]:Ratfinx Twinkledinks:16AE:/
-2074.1 "Shock Therapy" sync / 1[56]:Ratfinx Twinkledinks:159C:/
-2077.3 "Steel Scales" #sync / 1[56]:Glassy-Eyed Cobra:16A2:/
-2078.5 "Regorge" #sync / 1[56]:Glassy-Eyed Cobra:16A1:/
-2085.3 "Shock Therapy" sync / 1[56]:Ratfinx Twinkledinks:159C:/
+2069.0 "Glupgloop" sync / 1[56]:[^:]*:Ratfinx Twinkledinks:16AE:/
+2074.1 "Shock Therapy" sync / 1[56]:[^:]*:Ratfinx Twinkledinks:159C:/
+2077.3 "Steel Scales" #sync / 1[56]:[^:]*:Glassy-Eyed Cobra:16A2:/
+2078.5 "Regorge" #sync / 1[56]:[^:]*:Glassy-Eyed Cobra:16A1:/
+2085.3 "Shock Therapy" sync / 1[56]:[^:]*:Ratfinx Twinkledinks:159C:/
 
-2098.5 "Bomb's Away" sync / 1[56]:Ratfinx Twinkledinks:1590:/
-2112.4 "Tetra Burst" sync / 1[56]:Bomb:16A3:/
-2112.6 "Big Burst" sync / 1[56]:Smartbomb:16A5:/
-2118.6 "Shock Therapy" sync / 1[56]:Ratfinx Twinkledinks:159C:/
+2098.5 "Bomb's Away" sync / 1[56]:[^:]*:Ratfinx Twinkledinks:1590:/
+2112.4 "Tetra Burst" sync / 1[56]:[^:]*:Bomb:16A3:/
+2112.6 "Big Burst" sync / 1[56]:[^:]*:Smartbomb:16A5:/
+2118.6 "Shock Therapy" sync / 1[56]:[^:]*:Ratfinx Twinkledinks:159C:/
 
-2123.8 "Guzzle" sync / 1[56]:Ratfinx Twinkledinks:1598:/ window 110,20
-2128.4 "--big--" sync / 1[56]:Ratfinx Twinkledinks:1599:/
-2135.9 "Boost" sync / 1[56]:Ratfinx Twinkledinks:16A6:/
-2139.1 "Gobswing x4" duration 6.3 #sync / 1[56]:Ratfinx Twinkledinks:16A7:/
-2144.9 "Tetra Burst 1" #sync / 1[56]:Bomb:16A3:/
-2145.9 "Tetra Burst 2" #sync / 1[56]:Bomb:16A3:/
-2146.9 "Tetra Burst 3" #sync / 1[56]:Bomb:16A3:/
-2147.9 "Tetra Burst 4" #sync / 1[56]:Bomb:16A3:/
-2158.1 "Gobdash" sync / 1[56]:Ratfinx Twinkledinks:16AF:/
-2164.2 "Gobhook" sync / 1[56]:Ratfinx Twinkledinks:15A0:/
-2171.4 "Gobjab 1" sync / 1[56]:Ratfinx Twinkledinks:16A9:/
-2175.5 "Gobjab 2" sync / 1[56]:Ratfinx Twinkledinks:16A9:/
-2179.6 "Gobjab 3" sync / 1[56]:Ratfinx Twinkledinks:16A9:/
-2183.7 "Gobjab 4" sync / 1[56]:Ratfinx Twinkledinks:16A9:/
-2191.8 "Gobcut/Straight" sync / 1[56]:Ratfinx Twinkledinks:16A[AC]:/
+2123.8 "Guzzle" sync / 1[56]:[^:]*:Ratfinx Twinkledinks:1598:/ window 110,20
+2128.4 "--big--" sync / 1[56]:[^:]*:Ratfinx Twinkledinks:1599:/
+2135.9 "Boost" sync / 1[56]:[^:]*:Ratfinx Twinkledinks:16A6:/
+2139.1 "Gobswing x4" duration 6.3 #sync / 1[56]:[^:]*:Ratfinx Twinkledinks:16A7:/
+2144.9 "Tetra Burst 1" #sync / 1[56]:[^:]*:Bomb:16A3:/
+2145.9 "Tetra Burst 2" #sync / 1[56]:[^:]*:Bomb:16A3:/
+2146.9 "Tetra Burst 3" #sync / 1[56]:[^:]*:Bomb:16A3:/
+2147.9 "Tetra Burst 4" #sync / 1[56]:[^:]*:Bomb:16A3:/
+2158.1 "Gobdash" sync / 1[56]:[^:]*:Ratfinx Twinkledinks:16AF:/
+2164.2 "Gobhook" sync / 1[56]:[^:]*:Ratfinx Twinkledinks:15A0:/
+2171.4 "Gobjab 1" sync / 1[56]:[^:]*:Ratfinx Twinkledinks:16A9:/
+2175.5 "Gobjab 2" sync / 1[56]:[^:]*:Ratfinx Twinkledinks:16A9:/
+2179.6 "Gobjab 3" sync / 1[56]:[^:]*:Ratfinx Twinkledinks:16A9:/
+2183.7 "Gobjab 4" sync / 1[56]:[^:]*:Ratfinx Twinkledinks:16A9:/
+2191.8 "Gobcut/Straight" sync / 1[56]:[^:]*:Ratfinx Twinkledinks:16A[AC]:/
 
-2201.0 "Relaxant" sync / 1[56]:Ratfinx Twinkledinks:159B:/ window 140,20
-2203.1 "--small--" sync / 1[56]:Ratfinx Twinkledinks:1687:/
+2201.0 "Relaxant" sync / 1[56]:[^:]*:Ratfinx Twinkledinks:159B:/ window 140,20
+2203.1 "--small--" sync / 1[56]:[^:]*:Ratfinx Twinkledinks:1687:/
 2203.6 "Gobbledygroper Add"
-2214.1 "The Lion's Breath" #sync / 1[56]:Gobbledygroper:16A8:/
-2230.6 "Glupgloop" sync / 1[56]:Ratfinx Twinkledinks:16AE:/
-2237.7 "Bomb's Away" sync / 1[56]:Ratfinx Twinkledinks:1590:/
-2242.8 "Shock Therapy" sync / 1[56]:Ratfinx Twinkledinks:159C:/
-2243.0 "Tetra Burst" sync / 1[56]:Bomb:16A3:/
-2250.9 "Shock Therapy" sync / 1[56]:Ratfinx Twinkledinks:159C:/
-2251.8 "Big Burst" sync / 1[56]:Smartbomb:16A5:/
-2252.0 "Tetra Burst" sync / 1[56]:Bomb:16A3:/
-2259.0 "Shock Therapy" sync / 1[56]:Ratfinx Twinkledinks:159C:/
-2267.1 "Shock Therapy" sync / 1[56]:Ratfinx Twinkledinks:159C:/
-2275.3 "Shock Therapy" sync / 1[56]:Ratfinx Twinkledinks:159C:/
+2214.1 "The Lion's Breath" #sync / 1[56]:[^:]*:Gobbledygroper:16A8:/
+2230.6 "Glupgloop" sync / 1[56]:[^:]*:Ratfinx Twinkledinks:16AE:/
+2237.7 "Bomb's Away" sync / 1[56]:[^:]*:Ratfinx Twinkledinks:1590:/
+2242.8 "Shock Therapy" sync / 1[56]:[^:]*:Ratfinx Twinkledinks:159C:/
+2243.0 "Tetra Burst" sync / 1[56]:[^:]*:Bomb:16A3:/
+2250.9 "Shock Therapy" sync / 1[56]:[^:]*:Ratfinx Twinkledinks:159C:/
+2251.8 "Big Burst" sync / 1[56]:[^:]*:Smartbomb:16A5:/
+2252.0 "Tetra Burst" sync / 1[56]:[^:]*:Bomb:16A3:/
+2259.0 "Shock Therapy" sync / 1[56]:[^:]*:Ratfinx Twinkledinks:159C:/
+2267.1 "Shock Therapy" sync / 1[56]:[^:]*:Ratfinx Twinkledinks:159C:/
+2275.3 "Shock Therapy" sync / 1[56]:[^:]*:Ratfinx Twinkledinks:159C:/
 
-2277.5 "Guzzle" sync / 1[56]:Ratfinx Twinkledinks:1598:/ window 140,20
-2282.1 "--big--" sync / 1[56]:Ratfinx Twinkledinks:1599:/
-2289.6 "Boost" sync / 1[56]:Ratfinx Twinkledinks:16A6:/
-2292.8 "Gobswing x4" duration 6.3 #sync / 1[56]:Ratfinx Twinkledinks:16A7:/
-2298.7 "Tetra Burst x4" sync / 1[56]:Bomb:16A3:/
-2321.2 "Gobstraight/Cut" sync / 1[56]:Ratfinx Twinkledinks:16A[AC]:/
-2325.5 "Gobdash" sync / 1[56]:Ratfinx Twinkledinks:16AF:/
-2329.2 "Gobdash" sync / 1[56]:Ratfinx Twinkledinks:16AF:/
-2336.0 "Gobhook" sync / 1[56]:Ratfinx Twinkledinks:15A0:/
+2277.5 "Guzzle" sync / 1[56]:[^:]*:Ratfinx Twinkledinks:1598:/ window 140,20
+2282.1 "--big--" sync / 1[56]:[^:]*:Ratfinx Twinkledinks:1599:/
+2289.6 "Boost" sync / 1[56]:[^:]*:Ratfinx Twinkledinks:16A6:/
+2292.8 "Gobswing x4" duration 6.3 #sync / 1[56]:[^:]*:Ratfinx Twinkledinks:16A7:/
+2298.7 "Tetra Burst x4" sync / 1[56]:[^:]*:Bomb:16A3:/
+2321.2 "Gobstraight/Cut" sync / 1[56]:[^:]*:Ratfinx Twinkledinks:16A[AC]:/
+2325.5 "Gobdash" sync / 1[56]:[^:]*:Ratfinx Twinkledinks:16AF:/
+2329.2 "Gobdash" sync / 1[56]:[^:]*:Ratfinx Twinkledinks:16AF:/
+2336.0 "Gobhook" sync / 1[56]:[^:]*:Ratfinx Twinkledinks:15A0:/
 
-2343.5 "Gobjab 1" sync / 1[56]:Ratfinx Twinkledinks:16A9:/
-2347.6 "Gobjab 2" sync / 1[56]:Ratfinx Twinkledinks:16A9:/
-2351.7 "Gobjab 3" sync / 1[56]:Ratfinx Twinkledinks:16A9:/
-2355.8 "Gobjab 4" sync / 1[56]:Ratfinx Twinkledinks:16A9:/
-2362.9 "Gobcut/Straight" sync / 1[56]:Ratfinx Twinkledinks:16A[AC]:/
+2343.5 "Gobjab 1" sync / 1[56]:[^:]*:Ratfinx Twinkledinks:16A9:/
+2347.6 "Gobjab 2" sync / 1[56]:[^:]*:Ratfinx Twinkledinks:16A9:/
+2351.7 "Gobjab 3" sync / 1[56]:[^:]*:Ratfinx Twinkledinks:16A9:/
+2355.8 "Gobjab 4" sync / 1[56]:[^:]*:Ratfinx Twinkledinks:16A9:/
+2362.9 "Gobcut/Straight" sync / 1[56]:[^:]*:Ratfinx Twinkledinks:16A[AC]:/
 
-2381.1 "Relaxant" sync / 1[56]:Ratfinx Twinkledinks:159B:/ window 170,20
-2383.2 "--small--" sync / 1[56]:Ratfinx Twinkledinks:1687:/
+2381.1 "Relaxant" sync / 1[56]:[^:]*:Ratfinx Twinkledinks:159B:/ window 170,20
+2383.2 "--small--" sync / 1[56]:[^:]*:Ratfinx Twinkledinks:1687:/
 2386.7 "Minotaur (NW)"
 2386.7 "Yorn Pig x6 (NE)"
 2390.8 "Gobbledygawker x2 (SE/SW)"
-2398.1 "10-Tonze Slash" #sync / 1[56]:Glassy-Eyed Minotaur:16A0:/
-2399.2 "Oogle" #sync / 1[56]:Gobbledygawker:169C:/
+2398.1 "10-Tonze Slash" #sync / 1[56]:[^:]*:Glassy-Eyed Minotaur:16A0:/
+2399.2 "Oogle" #sync / 1[56]:[^:]*:Gobbledygawker:169C:/
 2407.6 "Yorn Pig x3 (NW)"
-2410.8 "Glupgloop" sync / 1[56]:Ratfinx Twinkledinks:16AE:/
+2410.8 "Glupgloop" sync / 1[56]:[^:]*:Ratfinx Twinkledinks:16AE:/
 2411.8 "Cobra (NE)"
 2414.4 "Shabti (SE)"
-2415.3 "Feast" #sync / 1[56]:Glassy-Eyed Minotaur:169A:/
-2420.4 "Disorienting Groan" #sync / 1[56]:Glassy-Eyed Minotaur:169B:/
-2433.5 "10-Tonze Slash" #sync / 1[56]:Glassy-Eyed Minotaur:16A0:/
-2435.0 "Shock Therapy" sync / 1[56]:Ratfinx Twinkledinks:159C:/
-2443.2 "Shock Therapy" sync / 1[56]:Ratfinx Twinkledinks:159C:/
-2451.4 "Shock Therapy" sync / 1[56]:Ratfinx Twinkledinks:159C:/
-2459.5 "Shock Therapy" sync / 1[56]:Ratfinx Twinkledinks:159C:/
-2467.7 "Shock Therapy" sync / 1[56]:Ratfinx Twinkledinks:159C:/
+2415.3 "Feast" #sync / 1[56]:[^:]*:Glassy-Eyed Minotaur:169A:/
+2420.4 "Disorienting Groan" #sync / 1[56]:[^:]*:Glassy-Eyed Minotaur:169B:/
+2433.5 "10-Tonze Slash" #sync / 1[56]:[^:]*:Glassy-Eyed Minotaur:16A0:/
+2435.0 "Shock Therapy" sync / 1[56]:[^:]*:Ratfinx Twinkledinks:159C:/
+2443.2 "Shock Therapy" sync / 1[56]:[^:]*:Ratfinx Twinkledinks:159C:/
+2451.4 "Shock Therapy" sync / 1[56]:[^:]*:Ratfinx Twinkledinks:159C:/
+2459.5 "Shock Therapy" sync / 1[56]:[^:]*:Ratfinx Twinkledinks:159C:/
+2467.7 "Shock Therapy" sync / 1[56]:[^:]*:Ratfinx Twinkledinks:159C:/
 
-2472.9 "Guzzle" sync / 1[56]:Ratfinx Twinkledinks:1598:/ window 190,20
-2477.5 "--big--" sync / 1[56]:Ratfinx Twinkledinks:1599:/
-2485.0 "Gobjab 1" sync / 1[56]:Ratfinx Twinkledinks:16A9:/
-2489.1 "Gobjab 2" sync / 1[56]:Ratfinx Twinkledinks:16A9:/
-2493.2 "Gobjab 3" sync / 1[56]:Ratfinx Twinkledinks:16A9:/
-2497.3 "Gobjab 4" sync / 1[56]:Ratfinx Twinkledinks:16A9:/
-2505.4 "Gobstraight/Cut" sync / 1[56]:Ratfinx Twinkledinks:16A[AC]:/
+2472.9 "Guzzle" sync / 1[56]:[^:]*:Ratfinx Twinkledinks:1598:/ window 190,20
+2477.5 "--big--" sync / 1[56]:[^:]*:Ratfinx Twinkledinks:1599:/
+2485.0 "Gobjab 1" sync / 1[56]:[^:]*:Ratfinx Twinkledinks:16A9:/
+2489.1 "Gobjab 2" sync / 1[56]:[^:]*:Ratfinx Twinkledinks:16A9:/
+2493.2 "Gobjab 3" sync / 1[56]:[^:]*:Ratfinx Twinkledinks:16A9:/
+2497.3 "Gobjab 4" sync / 1[56]:[^:]*:Ratfinx Twinkledinks:16A9:/
+2505.4 "Gobstraight/Cut" sync / 1[56]:[^:]*:Ratfinx Twinkledinks:16A[AC]:/
 
-2513.6 "Relaxant" sync / 1[56]:Ratfinx Twinkledinks:159B:/ window 180,20
-2515.7 "--small--" sync / 1[56]:Ratfinx Twinkledinks:1687:/
+2513.6 "Relaxant" sync / 1[56]:[^:]*:Ratfinx Twinkledinks:159B:/ window 180,20
+2515.7 "--small--" sync / 1[56]:[^:]*:Ratfinx Twinkledinks:1687:/
 2516.4 "Gobbledygroper Add"
-2526.7 "The Lion's Breath" #sync / 1[56]:Gobbledygroper:16A8:/
-2532.9 "The Lion's Breath" #sync / 1[56]:Gobbledygroper:16A8:/
-2543.3 "Glupgloop" sync / 1[56]:Ratfinx Twinkledinks:16AE:/
-2555.7 "Tetra Burst" sync / 1[56]:Bomb:16A3:/
+2526.7 "The Lion's Breath" #sync / 1[56]:[^:]*:Gobbledygroper:16A8:/
+2532.9 "The Lion's Breath" #sync / 1[56]:[^:]*:Gobbledygroper:16A8:/
+2543.3 "Glupgloop" sync / 1[56]:[^:]*:Ratfinx Twinkledinks:16AE:/
+2555.7 "Tetra Burst" sync / 1[56]:[^:]*:Bomb:16A3:/
 # TODO: Maybe there are more mechanics here if you pushed the first phase quickly?
 
 
 ### Enrage (time-based)
 # We could sync down here on an 16A4 ability, which is the damage,
 # but that point you're dead.
-2700.0 "--sync--" sync / 14:Ratfinx Twinkledinks:159C:/ window 200,200
-2703.0 "Shock Therapy Enrage" sync / 1[56]:Ratfinx Twinkledinks:159C:/
+2700.0 "--sync--" sync / 14:[^:]*:Ratfinx Twinkledinks:159C:/ window 200,200
+2703.0 "Shock Therapy Enrage" sync / 1[56]:[^:]*:Ratfinx Twinkledinks:159C:/

--- a/ui/raidboss/data/03-hw/raid/a6n.txt
+++ b/ui/raidboss/data/03-hw/raid/a6n.txt
@@ -8,18 +8,18 @@
 
 # -ii 170E
 0.0 "--sync--" sync / 00:0839::Machinery Bay 67 will be sealed off/ window 1,0
-6.8 "Brute Force" sync / 1[56]:Blaster:170A:/ window 6.8,5
-10.9 "Mind Blast" sync / 1[56]:Blaster:170B:/
-15.0 "Ballistic Missile" sync / 1[56]:Blaster:15F4:/
-19.1 "Brute Force" sync / 1[56]:Blaster:170A:/
-20.0 "Minefield" sync / 1[56]:Blaster:170D:/
-29.2 "Brute Force" sync / 1[56]:Blaster:170A:/
-33.3 "Mind Blast" sync / 1[56]:Blaster:170B:/
-42.5 "Mirage" sync / 1[56]:Blaster Mirage:1712:/ window 15,15
-48.7 "Supercharge" # sync / 1[56]:Blaster Mirage:1713:/
-53.8 "Mind Blast" sync / 1[56]:Blaster:170B:/
+6.8 "Brute Force" sync / 1[56]:[^:]*:Blaster:170A:/ window 6.8,5
+10.9 "Mind Blast" sync / 1[56]:[^:]*:Blaster:170B:/
+15.0 "Ballistic Missile" sync / 1[56]:[^:]*:Blaster:15F4:/
+19.1 "Brute Force" sync / 1[56]:[^:]*:Blaster:170A:/
+20.0 "Minefield" sync / 1[56]:[^:]*:Blaster:170D:/
+29.2 "Brute Force" sync / 1[56]:[^:]*:Blaster:170A:/
+33.3 "Mind Blast" sync / 1[56]:[^:]*:Blaster:170B:/
+42.5 "Mirage" sync / 1[56]:[^:]*:Blaster Mirage:1712:/ window 15,15
+48.7 "Supercharge" # sync / 1[56]:[^:]*:Blaster Mirage:1713:/
+53.8 "Mind Blast" sync / 1[56]:[^:]*:Blaster:170B:/
 
-61.9 "Brute Force" sync / 1[56]:Blaster:170A:/ jump 6.8
+61.9 "Brute Force" sync / 1[56]:[^:]*:Blaster:170A:/ jump 6.8
 66.0 "Mind Blast"
 70.1 "Ballistic Missile"
 74.2 "Brute Force"
@@ -29,15 +29,15 @@
 
 ### Brawler
 1000.0 "--sync--" sync / 00:0839::Machinery Bay 68 will be sealed off/ window 1000,0
-1008.7 "Magicked Mark" sync / 1[56]:Brawler:1715:/ window 8.7,5
-1010.8 "Attachment" sync / 1[56]:Brawler:1601:/
-1017.0 "Single Buster/Double Buster/Rocket Drill" sync / 1[56]:Brawler:(1717|1718|1719):/
+1008.7 "Magicked Mark" sync / 1[56]:[^:]*:Brawler:1715:/ window 8.7,5
+1010.8 "Attachment" sync / 1[56]:[^:]*:Brawler:1601:/
+1017.0 "Single Buster/Double Buster/Rocket Drill" sync / 1[56]:[^:]*:Brawler:(1717|1718|1719):/
 
-1022.1 "Magicked Mark" sync / 1[56]:Brawler:1715:/
-1024.2 "Attachment" sync / 1[56]:Brawler:1601:/ window 5,5
-1030.3 "Single Buster/Double Buster/Rocket Drill" sync / 1[56]:Brawler:(1717|1718|1719):/
+1022.1 "Magicked Mark" sync / 1[56]:[^:]*:Brawler:1715:/
+1024.2 "Attachment" sync / 1[56]:[^:]*:Brawler:1601:/ window 5,5
+1030.3 "Single Buster/Double Buster/Rocket Drill" sync / 1[56]:[^:]*:Brawler:(1717|1718|1719):/
 
-1035.4 "Magicked Mark" sync / 1[56]:Brawler:1715:/ jump 1022.1
+1035.4 "Magicked Mark" sync / 1[56]:[^:]*:Brawler:1715:/ jump 1022.1
 1037.5 "Attachment"
 1043.6 "Single Buster/Double Buster/Rocket Drill"
 1048.7 "Magicked Mark"
@@ -48,16 +48,16 @@
 ### Swindler
 # -ii 171D
 2000.0 "--sync--" sync / 00:0839::Machinery Bay 69 will be sealed off/ window 2000,0
-2006.5 "Magicked Mark" sync / 1[56]:Swindler:171B:/
-2015.6 "Height" sync / 1[56]:Swindler:171C:/ window 15.6,20
-2018.8 "Magicked Mark" sync / 1[56]:Swindler:171B:/
-2026.9 "Bio-Arithmeticks" sync / 1[56]:Swindler:171F:/
-2029.0 "Magicked Mark" sync / 1[56]:Swindler:171B:/
-2034.0 "Enumeration" sync / 1[56]:Swindler:171E:/ window 20,20
-2039.1 "Magicked Mark" sync / 1[56]:Swindler:171B:/
-2044.2 "Bio-Arithmeticks" sync / 1[56]:Swindler:171F:/
+2006.5 "Magicked Mark" sync / 1[56]:[^:]*:Swindler:171B:/
+2015.6 "Height" sync / 1[56]:[^:]*:Swindler:171C:/ window 15.6,20
+2018.8 "Magicked Mark" sync / 1[56]:[^:]*:Swindler:171B:/
+2026.9 "Bio-Arithmeticks" sync / 1[56]:[^:]*:Swindler:171F:/
+2029.0 "Magicked Mark" sync / 1[56]:[^:]*:Swindler:171B:/
+2034.0 "Enumeration" sync / 1[56]:[^:]*:Swindler:171E:/ window 20,20
+2039.1 "Magicked Mark" sync / 1[56]:[^:]*:Swindler:171B:/
+2044.2 "Bio-Arithmeticks" sync / 1[56]:[^:]*:Swindler:171F:/
 
-2052.4 "Magicked Mark" sync / 1[56]:Swindler:171B:/ jump 2006.5
+2052.4 "Magicked Mark" sync / 1[56]:[^:]*:Swindler:171B:/ jump 2006.5
 2061.5 "Height"
 2064.7 "Magicked Mark"
 2072.8 "Bio-Arithmeticks"
@@ -67,21 +67,21 @@
 
 ### Vortexer
 3000.0 "--sync--" sync / 00:0839::Machinery Bay 70 will be sealed off/ window 3000,0
-3007.3 "Brute Force" sync / 1[56]:Vortexer:1721:/ window 7.3,5
-3017.4 "Elemental Jammer" sync / 1[56]:Vortexer:161B:/
-3019.5 "Ballistic Missile" sync / 1[56]:Vortexer:1622:/
-3023.6 "Brute Force" sync / 1[56]:Vortexer:1721:/
-3025.5 "Earth Missile" sync / 1[56]:Vortexer:1726:/
-3031.7 "Super Cyclone" sync / 1[56]:Vortexer:1728:/ window 15,15
-3039.1 "Crashing Wave" sync / 1[56]:Vortexer:1724:/
-3040.9 "Brute Force" sync / 1[56]:Vortexer:1721:/
-3047.0 "Ballistic Missile" sync / 1[56]:Vortexer:1622:/
-3052.3 "Ice Missile" sync / 1[56]:Vortexer:1727:/
-3059.1 "Super Cyclone" sync / 1[56]:Vortexer:1728:/
-3065.3 "Brute Force" sync / 1[56]:Vortexer:1721:/
-3080.4 "Ultra Flash" sync / 1[56]:Vortexer:1722:/ window 30,30
+3007.3 "Brute Force" sync / 1[56]:[^:]*:Vortexer:1721:/ window 7.3,5
+3017.4 "Elemental Jammer" sync / 1[56]:[^:]*:Vortexer:161B:/
+3019.5 "Ballistic Missile" sync / 1[56]:[^:]*:Vortexer:1622:/
+3023.6 "Brute Force" sync / 1[56]:[^:]*:Vortexer:1721:/
+3025.5 "Earth Missile" sync / 1[56]:[^:]*:Vortexer:1726:/
+3031.7 "Super Cyclone" sync / 1[56]:[^:]*:Vortexer:1728:/ window 15,15
+3039.1 "Crashing Wave" sync / 1[56]:[^:]*:Vortexer:1724:/
+3040.9 "Brute Force" sync / 1[56]:[^:]*:Vortexer:1721:/
+3047.0 "Ballistic Missile" sync / 1[56]:[^:]*:Vortexer:1622:/
+3052.3 "Ice Missile" sync / 1[56]:[^:]*:Vortexer:1727:/
+3059.1 "Super Cyclone" sync / 1[56]:[^:]*:Vortexer:1728:/
+3065.3 "Brute Force" sync / 1[56]:[^:]*:Vortexer:1721:/
+3080.4 "Ultra Flash" sync / 1[56]:[^:]*:Vortexer:1722:/ window 30,30
 
-3082.5 "Brute Force" sync / 1[56]:Vortexer:1721:/ jump 3007.3
+3082.5 "Brute Force" sync / 1[56]:[^:]*:Vortexer:1721:/ jump 3007.3
 3092.6 "Elemental Jammer"
 3094.7 "Ballistic Missile"
 3098.8 "Brute Force"

--- a/ui/raidboss/data/03-hw/raid/a6s.txt
+++ b/ui/raidboss/data/03-hw/raid/a6s.txt
@@ -11,53 +11,53 @@ hideall "Ballistic Missile"
 
 ### Blaster
 0.0 "--sync--" sync / 00:0839::Machinery Bay 67 will be sealed off/ window 1,0
-7.0 "Brute Force" sync / 1[56]:Blaster:15F2:/ window 10,10
-14.1 "Mind Blast" sync / 1[56]:Blaster:15F3:/
-18.2 "Ballistic Missile" sync / 1[56]:Blaster:15F4:/
-23.2 "Hidden Minefield" sync / 1[56]:Blaster:15F7:/
-31.4 "Mirage" sync / 1[56]:Blaster Mirage:15FA:/
-39.6 "Brute Force" #sync / 1[56]:Blaster:15F2:/
-43.7 "Brute Force" #sync / 1[56]:Blaster:15F2:/
+7.0 "Brute Force" sync / 1[56]:[^:]*:Blaster:15F2:/ window 10,10
+14.1 "Mind Blast" sync / 1[56]:[^:]*:Blaster:15F3:/
+18.2 "Ballistic Missile" sync / 1[56]:[^:]*:Blaster:15F4:/
+23.2 "Hidden Minefield" sync / 1[56]:[^:]*:Blaster:15F7:/
+31.4 "Mirage" sync / 1[56]:[^:]*:Blaster Mirage:15FA:/
+39.6 "Brute Force" #sync / 1[56]:[^:]*:Blaster:15F2:/
+43.7 "Brute Force" #sync / 1[56]:[^:]*:Blaster:15F2:/
 
 # add phase
 46.7 "--untargetable--"
 49.9 "--targetable--"
-78.0 "Mind Blast" sync / 1[56]:Blaster Mirage:15FE:/
+78.0 "Mind Blast" sync / 1[56]:[^:]*:Blaster Mirage:15FE:/
 
-85.2 "Mirage" sync / 1[56]:Blaster:15FA:/ window 40,40
+85.2 "Mirage" sync / 1[56]:[^:]*:Blaster:15FA:/ window 40,40
 86.2 "--targetable--"
-91.3 "Mind Blast" sync / 1[56]:Blaster:15F3:/
-94.5 "Brute Force" sync / 1[56]:Blaster:15F2:/
+91.3 "Mind Blast" sync / 1[56]:[^:]*:Blaster:15F3:/
+94.5 "Brute Force" sync / 1[56]:[^:]*:Blaster:15F2:/
 
-97.6 "Ballistic Missile" sync / 1[56]:Blaster:15F4:/
-101.7 "Brute Force" sync / 1[56]:Blaster:15F2:/
-102.6 "Hidden Minefield" sync / 1[56]:Blaster:15F7:/
-110.9 "Mirage" sync / 1[56]:Blaster Mirage:15FA:/
-120.2 "Brute Force" sync / 1[56]:Blaster:15F2:/
-128.3 "Mind Blast" sync / 1[56]:Blaster:15F3:/
+97.6 "Ballistic Missile" sync / 1[56]:[^:]*:Blaster:15F4:/
+101.7 "Brute Force" sync / 1[56]:[^:]*:Blaster:15F2:/
+102.6 "Hidden Minefield" sync / 1[56]:[^:]*:Blaster:15F7:/
+110.9 "Mirage" sync / 1[56]:[^:]*:Blaster Mirage:15FA:/
+120.2 "Brute Force" sync / 1[56]:[^:]*:Blaster:15F2:/
+128.3 "Mind Blast" sync / 1[56]:[^:]*:Blaster:15F3:/
 
-130.4 "Ballistic Missile" sync / 1[56]:Blaster:15F4:/
-134.5 "Brute Force" sync / 1[56]:Blaster:15F2:/
-135.4 "Hidden Minefield" sync / 1[56]:Blaster:15F7:/
-143.6 "Mirage" sync / 1[56]:Blaster Mirage:15FA:/
-151.8 "Brute Force" sync / 1[56]:Blaster:15F2:/
-162.9 "Mind Blast" sync / 1[56]:Blaster:15F3:/
-166.1 "Brute Force" sync / 1[56]:Blaster:15F2:/
+130.4 "Ballistic Missile" sync / 1[56]:[^:]*:Blaster:15F4:/
+134.5 "Brute Force" sync / 1[56]:[^:]*:Blaster:15F2:/
+135.4 "Hidden Minefield" sync / 1[56]:[^:]*:Blaster:15F7:/
+143.6 "Mirage" sync / 1[56]:[^:]*:Blaster Mirage:15FA:/
+151.8 "Brute Force" sync / 1[56]:[^:]*:Blaster:15F2:/
+162.9 "Mind Blast" sync / 1[56]:[^:]*:Blaster:15F3:/
+166.1 "Brute Force" sync / 1[56]:[^:]*:Blaster:15F2:/
 
-169.2 "Ballistic Missile" sync / 1[56]:Blaster:15F4:/ window 20,20 jump 97.6
-173.3 "Brute Force" #sync / 1[56]:Blaster:15F2:/
-174.2 "Hidden Minefield" #sync / 1[56]:Blaster:15F7:/
-182.5 "Mirage" #sync / 1[56]:Blaster Mirage:15FA:/
-191.8 "Brute Force" #sync / 1[56]:Blaster:15F2:/
-199.9 "Mind Blast" #sync / 1[56]:Blaster:15F3:/
+169.2 "Ballistic Missile" sync / 1[56]:[^:]*:Blaster:15F4:/ window 20,20 jump 97.6
+173.3 "Brute Force" #sync / 1[56]:[^:]*:Blaster:15F2:/
+174.2 "Hidden Minefield" #sync / 1[56]:[^:]*:Blaster:15F7:/
+182.5 "Mirage" #sync / 1[56]:[^:]*:Blaster Mirage:15FA:/
+191.8 "Brute Force" #sync / 1[56]:[^:]*:Blaster:15F2:/
+199.9 "Mind Blast" #sync / 1[56]:[^:]*:Blaster:15F3:/
 
-202.0 "Ballistic Missile" #sync / 1[56]:Blaster:15F4:/
-206.1 "Brute Force" #sync / 1[56]:Blaster:15F2:/
-207.0 "Hidden Minefield" #sync / 1[56]:Blaster:15F7:/
-215.2 "Mirage" #sync / 1[56]:Blaster Mirage:15FA:/
-223.4 "Brute Force" #sync / 1[56]:Blaster:15F2:/
-234.5 "Mind Blast" #sync / 1[56]:Blaster:15F3:/
-237.7 "Brute Force" #sync / 1[56]:Blaster:15F2:/
+202.0 "Ballistic Missile" #sync / 1[56]:[^:]*:Blaster:15F4:/
+206.1 "Brute Force" #sync / 1[56]:[^:]*:Blaster:15F2:/
+207.0 "Hidden Minefield" #sync / 1[56]:[^:]*:Blaster:15F7:/
+215.2 "Mirage" #sync / 1[56]:[^:]*:Blaster Mirage:15FA:/
+223.4 "Brute Force" #sync / 1[56]:[^:]*:Blaster:15F2:/
+234.5 "Mind Blast" #sync / 1[56]:[^:]*:Blaster:15F3:/
+237.7 "Brute Force" #sync / 1[56]:[^:]*:Blaster:15F2:/
 
 
 
@@ -65,29 +65,29 @@ hideall "Ballistic Missile"
 # Note: "Brawler Mechanic" drifts relative to attachment depending on type.
 # Brawler Mechanics seem entirely/mostly random?
 1000.0 "--sync--" sync / 00:0839::Machinery Bay 68 will be sealed off/ window 1000,0
-1008.8 "Magicked Mark" sync / 1[56]:Brawler:1600:/ window 100,100
-1011.0 "Attachment" sync / 1[56]:Brawler:1601:/
-1017.2 "Brawler Mechanic" #sync / 1[56]:Brawler:160[2345]:/
+1008.8 "Magicked Mark" sync / 1[56]:[^:]*:Brawler:1600:/ window 100,100
+1011.0 "Attachment" sync / 1[56]:[^:]*:Brawler:1601:/
+1017.2 "Brawler Mechanic" #sync / 1[56]:[^:]*:Brawler:160[2345]:/
 
-1022.2 "Magicked Mark" #sync / 1[56]:Brawler:1600:/
-1024.4 "Attachment" #sync / 1[56]:Brawler:1601:/
-1030.6 "Brawler Mechanic" #sync / 1[56]:Brawler:160[2345]:/
+1022.2 "Magicked Mark" #sync / 1[56]:[^:]*:Brawler:1600:/
+1024.4 "Attachment" #sync / 1[56]:[^:]*:Brawler:1601:/
+1030.6 "Brawler Mechanic" #sync / 1[56]:[^:]*:Brawler:160[2345]:/
 
-1035.6 "Magicked Mark" #sync / 1[56]:Brawler:1600:/
-1037.8 "Attachment" #sync / 1[56]:Brawler:1601:/
-1044.0 "Brawler Mechanic" #sync / 1[56]:Brawler:160[2345]:/
+1035.6 "Magicked Mark" #sync / 1[56]:[^:]*:Brawler:1600:/
+1037.8 "Attachment" #sync / 1[56]:[^:]*:Brawler:1601:/
+1044.0 "Brawler Mechanic" #sync / 1[56]:[^:]*:Brawler:160[2345]:/
 
-1049.0 "Magicked Mark" #sync / 1[56]:Brawler:1600:/
-1051.2 "Attachment" #sync / 1[56]:Brawler:1601:/
-1057.4 "Brawler Mechanic" #sync / 1[56]:Brawler:160[2345]:/
+1049.0 "Magicked Mark" #sync / 1[56]:[^:]*:Brawler:1600:/
+1051.2 "Attachment" #sync / 1[56]:[^:]*:Brawler:1601:/
+1057.4 "Brawler Mechanic" #sync / 1[56]:[^:]*:Brawler:160[2345]:/
 
 ## Brawler Orb Phase
 1500.0 "--sync--" sync / 22:........:Brawler:........:Brawler:00/ window 500,0
 1503.4 "Power Plasma Alpha x2" sync / 03:........:Power Plasma Alpha:/  window 500,5
 1503.4 "Power Plasma Gamma x2"
 
-1508.6 "Attachment" sync / 1[56]:Brawler:1601:/
-1514.7 "Brawler Mechanic" #sync / 1[56]:Brawler:160[2345]:/
+1508.6 "Attachment" sync / 1[56]:[^:]*:Brawler:1601:/
+1514.7 "Brawler Mechanic" #sync / 1[56]:[^:]*:Brawler:160[2345]:/
 
 1517.5 "Power Plasma Alpha x2"
 1517.5 "Power Plasma Beta x2"
@@ -96,24 +96,24 @@ hideall "Ballistic Missile"
 1529.6 "Power Plasma Alpha x2"
 1529.6 "Power Plasma Gamma x1"
 
-1534.0 "Attachment" sync / 1[56]:Brawler:1601:/
-1540.1 "Brawler Mechanic" #sync / 1[56]:Brawler:160[2345]:/
+1534.0 "Attachment" sync / 1[56]:[^:]*:Brawler:1601:/
+1540.1 "Brawler Mechanic" #sync / 1[56]:[^:]*:Brawler:160[2345]:/
 
 1548.6 "Power Plasma Alpha x3"
 1548.6 "Power Plasma Gamma x1"
 
-1551.6 "Attachment" sync / 1[56]:Brawler:1601:/
-1557.7 "Brawler Mechanic" #sync / 1[56]:Brawler:160[2345]:/
+1551.6 "Attachment" sync / 1[56]:[^:]*:Brawler:1601:/
+1557.7 "Brawler Mechanic" #sync / 1[56]:[^:]*:Brawler:160[2345]:/
 
 1561.2 "--unseal--"
 
 
 ### Swindler
 2000.0 "--sync--" sync / 00:0839::Machinery Bay 69 will be sealed off/ window 2000,0
-2007.0 "--sync--" sync / 1[56]:Swindler:160C:/ window 7,3
-2021.2 "Height" sync / 1[56]:Swindler:160D:/
-2021.2 "Enumeration" sync / 1[56]:Swindler:160F:/
-2029.3 "Bio-Arithmeticks" sync / 1[56]:Swindler:1610:/
+2007.0 "--sync--" sync / 1[56]:[^:]*:Swindler:160C:/ window 7,3
+2021.2 "Height" sync / 1[56]:[^:]*:Swindler:160D:/
+2021.2 "Enumeration" sync / 1[56]:[^:]*:Swindler:160F:/
+2029.3 "Bio-Arithmeticks" sync / 1[56]:[^:]*:Swindler:1610:/
 
 # Add phase 1
 2031.4 "Gobwalker x1"
@@ -121,82 +121,82 @@ hideall "Ballistic Missile"
 2031.4 "Midan Hardmind x1"
 2031.4 "Midan Soldier x9"
 
-2040.6 "Auxiliary Power" sync / 1[56]:Swindler:1611:/
+2040.6 "Auxiliary Power" sync / 1[56]:[^:]*:Swindler:1611:/
 
-2051.8 "Height" sync / 1[56]:Swindler:160D:/
-2061.0 "Enumeration" sync / 1[56]:Swindler:160F:/
-2070.1 "Bio-Arithmeticks" sync / 1[56]:Swindler:1610:/
+2051.8 "Height" sync / 1[56]:[^:]*:Swindler:160D:/
+2061.0 "Enumeration" sync / 1[56]:[^:]*:Swindler:160F:/
+2070.1 "Bio-Arithmeticks" sync / 1[56]:[^:]*:Swindler:1610:/
 
 # Add phase 2
 2072.1 "Midan Gunner x4"
 
-2077.4 "Snipethoom" #sync / 1[56]:Midan Gunner:1617:/
-2078.3 "Auxiliary Power" sync / 1[56]:Swindler:1611:/
-2086.4 "Height" sync / 1[56]:Swindler:160D:/
-2087.5 "Snipethoom" #sync / 1[56]:Midan Gunner:1617:/
-2088.6 "Auxiliary Power" sync / 1[56]:Swindler:1611:/
+2077.4 "Snipethoom" #sync / 1[56]:[^:]*:Midan Gunner:1617:/
+2078.3 "Auxiliary Power" sync / 1[56]:[^:]*:Swindler:1611:/
+2086.4 "Height" sync / 1[56]:[^:]*:Swindler:160D:/
+2087.5 "Snipethoom" #sync / 1[56]:[^:]*:Midan Gunner:1617:/
+2088.6 "Auxiliary Power" sync / 1[56]:[^:]*:Swindler:1611:/
 
-2095.7 "Height" sync / 1[56]:Swindler:160D:/
-2095.7 "Enumeration" sync / 1[56]:Swindler:160F:/
-2102.9 "Bio-Arithmeticks" sync / 1[56]:Swindler:1610:/
+2095.7 "Height" sync / 1[56]:[^:]*:Swindler:160D:/
+2095.7 "Enumeration" sync / 1[56]:[^:]*:Swindler:160F:/
+2102.9 "Bio-Arithmeticks" sync / 1[56]:[^:]*:Swindler:1610:/
 
 # Final loop
-2111.1 "Bio-Arithmeticks" sync / 1[56]:Swindler:1610:/
-2133.5 "Height" sync / 1[56]:Swindler:160D:/
-2133.5 "Enumeration" sync / 1[56]:Swindler:160F:/
+2111.1 "Bio-Arithmeticks" sync / 1[56]:[^:]*:Swindler:1610:/
+2133.5 "Height" sync / 1[56]:[^:]*:Swindler:160D:/
+2133.5 "Enumeration" sync / 1[56]:[^:]*:Swindler:160F:/
 
-2141.7 "Bio-Arithmeticks" sync / 1[56]:Swindler:1610:/ window 20,20 jump 2111.1
-2164.1 "Height" #sync / 1[56]:Swindler:160D:/
-2164.1 "Enumeration" #sync / 1[56]:Swindler:160F:/
+2141.7 "Bio-Arithmeticks" sync / 1[56]:[^:]*:Swindler:1610:/ window 20,20 jump 2111.1
+2164.1 "Height" #sync / 1[56]:[^:]*:Swindler:160D:/
+2164.1 "Enumeration" #sync / 1[56]:[^:]*:Swindler:160F:/
 
-2172.3 "Bio-Arithmeticks" #sync / 1[56]:Swindler:1610:/
-2194.7 "Height" #sync / 1[56]:Swindler:160D:/
-2194.7 "Enumeration" #sync / 1[56]:Swindler:160F:/
+2172.3 "Bio-Arithmeticks" #sync / 1[56]:[^:]*:Swindler:1610:/
+2194.7 "Height" #sync / 1[56]:[^:]*:Swindler:160D:/
+2194.7 "Enumeration" #sync / 1[56]:[^:]*:Swindler:160F:/
 
 
 ### Vortexer
 3000.0 "--sync--" sync / 00:0839::Machinery Bay 70 will be sealed off/ window 3000,0
-3002.0 "--sync--" sync / 1[56]:Vortexer:1618:/ window 2,1
-3006.7 "Brute Force" sync / 1[56]:Vortexer:1619:/ window 10,10
-3016.8 "Elemental Jammer" sync / 1[56]:Vortexer:161B:/
-3022.0 "Ballistic Missile" sync / 1[56]:Vortexer:1622:/
-3028.0 "Earth Missile x4" sync / 1[56]:Vortexer:1623:/
-3028.0 "Fire Beam x4" sync / 1[56]:Vortexer:1625:/
-3032.2 "Brute Force" sync / 1[56]:Vortexer:1619:/
-3038.4 "Crashing Thunder" sync / 1[56]:Vortexer:161D:/
-3038.4 "Crashing Wave" sync / 1[56]:Vortexer:161C:/
-3041.3 "Ballistic Missile" sync / 1[56]:Vortexer:1622:/
-3046.3 "Ice Missile x2" #sync / 1[56]:Vortexer:1624:/
-3054.3 "Brute Force" sync / 1[56]:Vortexer:1619:/
-3060.1 "Crashing Thunder" sync / 1[56]:Vortexer:161D:/
-3060.2 "Crashing Wave" sync / 1[56]:Vortexer:161C:/
-3066.4 "Ballistic Missile" sync / 1[56]:Vortexer:1622:/
-3072.4 "Earth Missile x4" sync / 1[56]:Vortexer:1623:/
-3072.4 "Fire Beam x4" sync / 1[56]:Vortexer:1625:/
-3077.6 "Super Cyclone" sync / 1[56]:Vortexer:1627:/
-3082.1 "Crashing Thunder" sync / 1[56]:Vortexer:161D:/
-3082.2 "Crashing Wave" sync / 1[56]:Vortexer:161C:/
-3084.8 "Brute Force" sync / 1[56]:Vortexer:1619:/
-3096.9 "Ultra Flash" sync / 1[56]:Vortexer:161A:/
+3002.0 "--sync--" sync / 1[56]:[^:]*:Vortexer:1618:/ window 2,1
+3006.7 "Brute Force" sync / 1[56]:[^:]*:Vortexer:1619:/ window 10,10
+3016.8 "Elemental Jammer" sync / 1[56]:[^:]*:Vortexer:161B:/
+3022.0 "Ballistic Missile" sync / 1[56]:[^:]*:Vortexer:1622:/
+3028.0 "Earth Missile x4" sync / 1[56]:[^:]*:Vortexer:1623:/
+3028.0 "Fire Beam x4" sync / 1[56]:[^:]*:Vortexer:1625:/
+3032.2 "Brute Force" sync / 1[56]:[^:]*:Vortexer:1619:/
+3038.4 "Crashing Thunder" sync / 1[56]:[^:]*:Vortexer:161D:/
+3038.4 "Crashing Wave" sync / 1[56]:[^:]*:Vortexer:161C:/
+3041.3 "Ballistic Missile" sync / 1[56]:[^:]*:Vortexer:1622:/
+3046.3 "Ice Missile x2" #sync / 1[56]:[^:]*:Vortexer:1624:/
+3054.3 "Brute Force" sync / 1[56]:[^:]*:Vortexer:1619:/
+3060.1 "Crashing Thunder" sync / 1[56]:[^:]*:Vortexer:161D:/
+3060.2 "Crashing Wave" sync / 1[56]:[^:]*:Vortexer:161C:/
+3066.4 "Ballistic Missile" sync / 1[56]:[^:]*:Vortexer:1622:/
+3072.4 "Earth Missile x4" sync / 1[56]:[^:]*:Vortexer:1623:/
+3072.4 "Fire Beam x4" sync / 1[56]:[^:]*:Vortexer:1625:/
+3077.6 "Super Cyclone" sync / 1[56]:[^:]*:Vortexer:1627:/
+3082.1 "Crashing Thunder" sync / 1[56]:[^:]*:Vortexer:161D:/
+3082.2 "Crashing Wave" sync / 1[56]:[^:]*:Vortexer:161C:/
+3084.8 "Brute Force" sync / 1[56]:[^:]*:Vortexer:1619:/
+3096.9 "Ultra Flash" sync / 1[56]:[^:]*:Vortexer:161A:/
 
-3099.7 "Brute Force" #sync / 1[56]:Vortexer:1619:/
-3109.8 "Elemental Jammer" sync / 1[56]:Vortexer:161B:/ window 50,50 jump 3016.8
-3115.0 "Ballistic Missile" #sync / 1[56]:Vortexer:1622:/
-3121.0 "Earth Missile" #sync / 1[56]:Vortexer:1623:/
-3121.0 "Fire Beam" #sync / 1[56]:Vortexer:1625:/
-3125.2 "Brute Force" #sync / 1[56]:Vortexer:1619:/
-3131.4 "Crashing Thunder" #sync / 1[56]:Vortexer:161D:/
-3131.4 "Crashing Wave" #sync / 1[56]:Vortexer:161C:/
-3134.3 "Ballistic Missile" #sync / 1[56]:Vortexer:1622:/
-3139.3 "Ice Missile" #sync / 1[56]:Vortexer:1624:/
-3147.3 "Brute Force" #sync / 1[56]:Vortexer:1619:/
-3153.1 "Crashing Thunder" #sync / 1[56]:Vortexer:161D:/
-3153.2 "Crashing Wave" #sync / 1[56]:Vortexer:161C:/
-3159.4 "Ballistic Missile" #sync / 1[56]:Vortexer:1622:/
-3165.4 "Earth Missile" #sync / 1[56]:Vortexer:1623:/
-3165.4 "Fire Beam" #sync / 1[56]:Vortexer:1625:/
-3170.6 "Super Cyclone" #sync / 1[56]:Vortexer:1627:/
-3175.1 "Crashing Thunder" #sync / 1[56]:Vortexer:161D:/
-3175.2 "Crashing Wave" #sync / 1[56]:Vortexer:161C:/
-3177.8 "Brute Force" #sync / 1[56]:Vortexer:1619:/
-3189.9 "Ultra Flash" #sync / 1[56]:Vortexer:161A:/
+3099.7 "Brute Force" #sync / 1[56]:[^:]*:Vortexer:1619:/
+3109.8 "Elemental Jammer" sync / 1[56]:[^:]*:Vortexer:161B:/ window 50,50 jump 3016.8
+3115.0 "Ballistic Missile" #sync / 1[56]:[^:]*:Vortexer:1622:/
+3121.0 "Earth Missile" #sync / 1[56]:[^:]*:Vortexer:1623:/
+3121.0 "Fire Beam" #sync / 1[56]:[^:]*:Vortexer:1625:/
+3125.2 "Brute Force" #sync / 1[56]:[^:]*:Vortexer:1619:/
+3131.4 "Crashing Thunder" #sync / 1[56]:[^:]*:Vortexer:161D:/
+3131.4 "Crashing Wave" #sync / 1[56]:[^:]*:Vortexer:161C:/
+3134.3 "Ballistic Missile" #sync / 1[56]:[^:]*:Vortexer:1622:/
+3139.3 "Ice Missile" #sync / 1[56]:[^:]*:Vortexer:1624:/
+3147.3 "Brute Force" #sync / 1[56]:[^:]*:Vortexer:1619:/
+3153.1 "Crashing Thunder" #sync / 1[56]:[^:]*:Vortexer:161D:/
+3153.2 "Crashing Wave" #sync / 1[56]:[^:]*:Vortexer:161C:/
+3159.4 "Ballistic Missile" #sync / 1[56]:[^:]*:Vortexer:1622:/
+3165.4 "Earth Missile" #sync / 1[56]:[^:]*:Vortexer:1623:/
+3165.4 "Fire Beam" #sync / 1[56]:[^:]*:Vortexer:1625:/
+3170.6 "Super Cyclone" #sync / 1[56]:[^:]*:Vortexer:1627:/
+3175.1 "Crashing Thunder" #sync / 1[56]:[^:]*:Vortexer:161D:/
+3175.2 "Crashing Wave" #sync / 1[56]:[^:]*:Vortexer:161C:/
+3177.8 "Brute Force" #sync / 1[56]:[^:]*:Vortexer:1619:/
+3189.9 "Ultra Flash" #sync / 1[56]:[^:]*:Vortexer:161A:/

--- a/ui/raidboss/data/03-hw/raid/a7s.txt
+++ b/ui/raidboss/data/03-hw/raid/a7s.txt
@@ -61,25 +61,25 @@ hideall "--sync--"
 ################# Version 1 - Phase 1
 59 "Bomb x1"
 66 "Jails" #White Prey & Green Tether
-68 "Zoomdoom" sync / 1[56]:Quickthinx Allthoughts:15BE:/ window 60
+68 "Zoomdoom" sync / 1[56]:[^:]*:Quickthinx Allthoughts:15BE:/ window 60
 69 "Doll"
 84 "Resync" sync / 1A:[^:]*:Pyretic:[^:]*:[^:]*:[^:]*:[^:]*:[^:]*:/ window 20 jump 384
 103 "Sizzlespark"
 116 "Uplander Doom"
 130 "Bomb x1"
 137 "Jails - Get Tether" #Red Prey & Purple Tether
-139 "Zoomdoom" sync / 1[56]:Quickthinx Allthoughts:15BE:/ window 60
+139 "Zoomdoom" sync / 1[56]:[^:]*:Quickthinx Allthoughts:15BE:/ window 60
 140 "Small Doll"
 178 "Sizzlebeam"
 190 "Sizzlespark"
 
 ################# Version 1 - Phase 2
-194 "Uplander Doom" sync / 1[56]:Quickthinx Allthoughts:15F0:/ window 65,0
-204 "Kill Heart" sync / 14:Shanoa:15EC:/ window 145,10
+194 "Uplander Doom" sync / 1[56]:[^:]*:Quickthinx Allthoughts:15F0:/ window 65,0
+204 "Kill Heart" sync / 14:[^:]*:Shanoa:15EC:/ window 145,10
 219 "Stun Heart"
 219 "Sizzlespark"
-229 "Flamethrower" sync / 1[56]:Quickthinx Allthoughts:1CFA:/ window 20
-234 "Kill Heart" sync / 14:Shanoa:15EC:/ window 20
+229 "Flamethrower" sync / 1[56]:[^:]*:Quickthinx Allthoughts:1CFA:/ window 20
+234 "Kill Heart" sync / 14:[^:]*:Shanoa:15EC:/ window 20
 249 "Stun Heart"
 249 "Sizzlebeam"
 258 "Sizzlespark" #can be skipped
@@ -99,7 +99,7 @@ hideall "--sync--"
 ################# Version 2 - Phase 1
 359 "Bomb x1"
 366 "Jails" #Purple Tether, Red Prey
-368 "Zoomdoom" sync / 1[56]:Quickthinx Allthoughts:15BE:/ window 60
+368 "Zoomdoom" sync / 1[56]:[^:]*:Quickthinx Allthoughts:15BE:/ window 60
 369 "Doll"
 397 "Uplander Doom"
 409 "Sizzlebeam"
@@ -111,12 +111,12 @@ hideall "--sync--"
 485 "Sizzlespark"
 
 ################# Version 2 - Phase 2
-489 "Uplander Doom" sync / 1[56]:Quickthinx Allthoughts:15F0:/ window 78,0
-499 "Kill Heart" sync / 14:Shanoa:15EC:/ window 130,10
+489 "Uplander Doom" sync / 1[56]:[^:]*:Quickthinx Allthoughts:15F0:/ window 78,0
+499 "Kill Heart" sync / 14:[^:]*:Shanoa:15EC:/ window 130,10
 514 "Stun Heart"
 514 "Sizzlespark"
-524 "Flamethrower" sync / 1[56]:Quickthinx Allthoughts:1CFA:/ window 20
-529 "Kill Heart" sync / 14:Shanoa:15EC:/ window 10
+524 "Flamethrower" sync / 1[56]:[^:]*:Quickthinx Allthoughts:1CFA:/ window 20
+529 "Kill Heart" sync / 14:[^:]*:Shanoa:15EC:/ window 10
 544 "Stun Heart"
 544 "Sizzlebeam"
 553 "Sizzlespark" #can be skipped
@@ -125,7 +125,7 @@ hideall "--sync--"
 ################# Version 1 - Phase 3
 561 "Bomb x1" sync / 03:........:Bomb:/  window 50,20
 567 "Jails" #Green Prey & Red Tether
-570 "Zoomdoom" sync / 1[56]:Quickthinx Allthoughts:15BE:/ window 60
+570 "Zoomdoom" sync / 1[56]:[^:]*:Quickthinx Allthoughts:15BE:/ window 60
 570 "Doll"
 582 "Resync" sync / 1A:[^:]*:Frostbite:[^:]*:[^:]*:[^:]*:[^:]*:[^:]*:/ window 20 jump 983
 596 "Uplander Doom"
@@ -133,19 +133,19 @@ hideall "--sync--"
 621 "Sizzlespark"
 628 "Bomb x1"
 636 "Jails - Get Prey" #Purple Prey & White Tether
-640 "Zoomdoom" sync / 1[56]:Quickthinx Allthoughts:15BE:/ window 60
+640 "Zoomdoom" sync / 1[56]:[^:]*:Quickthinx Allthoughts:15BE:/ window 60
 640 "Small Dolls x2"
 678 "Sizzlebeam"
 
 ################# Phase 4
-686 "Sizzlespark" sync / 1[56]:Quickthinx Allthoughts:16F8:/ window 63,0
+686 "Sizzlespark" sync / 1[56]:[^:]*:Quickthinx Allthoughts:16F8:/ window 63,0
 694 "Sizzlespark"
-707 "Sizzlebeam" sync / 1[56]:Quickthinx Allthoughts:15EE:/ window 20
+707 "Sizzlebeam" sync / 1[56]:[^:]*:Quickthinx Allthoughts:15EE:/ window 20
 711 "Bombs x8"
 740 "Sizzlespark"
 748 "Sizzlespark"
 755 "Uplander Doom"
-773 "Flamethrower" sync / 1[56]:Quickthinx Allthoughts:1CFA:/ window 30
+773 "Flamethrower" sync / 1[56]:[^:]*:Quickthinx Allthoughts:1CFA:/ window 30
 779 "Hammertime x4"
 790 "Sizzlespark"
 793 "Hammertime x4"
@@ -157,19 +157,19 @@ hideall "--sync--"
 842 "Sizzlespark"
 
 ################# Phase 5
-854 "Flamethrower" sync / 1[56]:Quickthinx Allthoughts:1CFA:/ window 60,10
-858 "Kill Heart" sync / 14:Shanoa:15EC:/ window 200,10
+854 "Flamethrower" sync / 1[56]:[^:]*:Quickthinx Allthoughts:1CFA:/ window 60,10
+858 "Kill Heart" sync / 14:[^:]*:Shanoa:15EC:/ window 200,10
 865 "Uplander Doom"
 873 "Stun Heart"
 879 "Sizzlebeam"
 888 "Flamethrower"
-888 "Kill Heart" sync / 14:Shanoa:15EC:/ window 10
+888 "Kill Heart" sync / 14:[^:]*:Shanoa:15EC:/ window 10
 901 "Sizzlespark"
 903 "Stun Heart"
 909 "Sizzlespark"
 917 "Sizzlespark"
 923 "Bombs / Sizzlebeam" sync / 03:........:Bomb:/  window 20 jump 1326
-924 "" sync / 1[56]:Quickthinx Allthoughts:15EE:/ window 20 jump 1526
+924 "" sync / 1[56]:[^:]*:Quickthinx Allthoughts:15EE:/ window 20 jump 1526
 924 ""
 924 ""
 924 ""
@@ -186,24 +186,24 @@ hideall "--sync--"
 970 "Jails" #White Tether, Purple Prey
 972 "Zoomdoom"
 972 "Doll"
-1011 "Sizzlebeam" sync / 1[56]:Quickthinx Allthoughts:15EE:/ window 10
+1011 "Sizzlebeam" sync / 1[56]:[^:]*:Quickthinx Allthoughts:15EE:/ window 10
 1019 "Sizzlespark"
 1027 "Sizzlespark"
 1034 "Bomb x1"
 1041 "Jails" #Red Tether, Green Prey
-1043 "Zoomdoom" sync / 1[56]:Quickthinx Allthoughts:15BE:/ window 60
+1043 "Zoomdoom" sync / 1[56]:[^:]*:Quickthinx Allthoughts:15BE:/ window 60
 1043 "Big Doll"
 1071 "Uplander Doom"
 
 ################# Phase 4
 1087 "Sizzlespark"
 1095 "Sizzlespark"
-1108 "Sizzlebeam" sync / 1[56]:Quickthinx Allthoughts:15EE:/ window 20
+1108 "Sizzlebeam" sync / 1[56]:[^:]*:Quickthinx Allthoughts:15EE:/ window 20
 1111 "Bombs x8"
 1141 "Sizzlespark"
 1149 "Sizzlespark"
 1156 "Uplander Doom"
-1174 "Flamethrower" sync / 1[56]:Quickthinx Allthoughts:1CFA:/ window 30
+1174 "Flamethrower" sync / 1[56]:[^:]*:Quickthinx Allthoughts:1CFA:/ window 30
 1180 "Hammertime x4"
 1191 "Sizzlespark"
 1194 "Hammertime x4"
@@ -216,13 +216,13 @@ hideall "--sync--"
 
 ############################################
 ################# Phase 5
-1253 "Flamethrower" sync / 1[56]:Quickthinx Allthoughts:1CFA:/ window 60,10
-1258 "Kill Heart" sync / 14:Shanoa:15EC:/ window 200,10
+1253 "Flamethrower" sync / 1[56]:[^:]*:Quickthinx Allthoughts:1CFA:/ window 60,10
+1258 "Kill Heart" sync / 14:[^:]*:Shanoa:15EC:/ window 200,10
 1263 "Uplander Doom"
 1273 "Stun Heart"
 1280 "Sizzlebeam"
 1288 "Flamethrower"
-1288 "Kill Heart" sync / 14:Shanoa:15EC:/ window 10
+1288 "Kill Heart" sync / 14:[^:]*:Shanoa:15EC:/ window 10
 1301 "Sizzlespark"
 1303 "Stun Heart"
 1308 "Sizzlespark"
@@ -230,10 +230,10 @@ hideall "--sync--"
 
 ############################################
 ################# Version 1 - Phase 6
-1326 "Bombs x2" sync / 1[56]:Quickthinx Allthoughts:15EE:/ window 40,10 jump 1526
+1326 "Bombs x2" sync / 1[56]:[^:]*:Quickthinx Allthoughts:15EE:/ window 40,10 jump 1526
 1333 "Jails" #Green Tether, Purple Prey
 1335 "Small Doll"
-1336 "Zoomdoom" sync / 1[56]:Quickthinx Allthoughts:15BE:/ window 55
+1336 "Zoomdoom" sync / 1[56]:[^:]*:Quickthinx Allthoughts:15BE:/ window 55
 1344 "Big Doll"
 1348 "Resync" sync /suffers the effect of Pyretic/ window 20 jump 1548
 1348 "Resync" sync /suffer the effect of Pyretic/ window 20 jump 1548
@@ -241,7 +241,7 @@ hideall "--sync--"
 1381 "Sizzlespark"
 1392 "Sizzlebeam"
 1396 "Jails" #Red Tether, White Prey
-1398 "Zoomdoom" sync / 1[56]:Quickthinx Allthoughts:15BE:/ window 55
+1398 "Zoomdoom" sync / 1[56]:[^:]*:Quickthinx Allthoughts:15BE:/ window 55
 1398 "Small Dolls x2"
 1426 "Sizzlespark"
 1433 "Sizzlebeam"
@@ -253,7 +253,7 @@ hideall "--sync--"
 ################# Version 2 - Phase 6
 1526 "Sizzlebeam"
 1530 "Jails" #White Prey & Red Tether
-1532 "Zoomdoom" sync / 1[56]:Quickthinx Allthoughts:15BE:/ window 55
+1532 "Zoomdoom" sync / 1[56]:[^:]*:Quickthinx Allthoughts:15BE:/ window 55
 1533 "Small Dolls x2"
 1560 "Sizzlespark"
 1568 "Sizzlebeam"
@@ -262,7 +262,7 @@ hideall "--sync--"
 1590 "Sizzlespark"
 1595 "Bombs x2"
 1601 "Jails - Get Prey" #Purple Prey & Green Tether
-1603 "Zoomdoom" sync / 1[56]:Quickthinx Allthoughts:15BE:/ window 55
+1603 "Zoomdoom" sync / 1[56]:[^:]*:Quickthinx Allthoughts:15BE:/ window 55
 1603 "Small Doll"
 1612 "Big Doll"
 1630 "Uplander Doom"

--- a/ui/raidboss/data/03-hw/raid/a8n.txt
+++ b/ui/raidboss/data/03-hw/raid/a8n.txt
@@ -16,29 +16,29 @@ hideall "Brute Force"
 
 # ONSLAUGHTER
 0.0 "--sync--" sync /:Engage!/ window 0,1
-2.7 "--sync--" sync / 1[56]:Onslaughter:172E:/ window 2.7,1
-5.4 "Hydrothermal Missile" sync / 1[56]:Onslaughter:172F:/ window 5.4,5
-12.6 "Mega Beam" sync / 1[56]:Onslaughter:1732:/
+2.7 "--sync--" sync / 1[56]:[^:]*:Onslaughter:172E:/ window 2.7,1
+5.4 "Hydrothermal Missile" sync / 1[56]:[^:]*:Onslaughter:172F:/ window 5.4,5
+12.6 "Mega Beam" sync / 1[56]:[^:]*:Onslaughter:1732:/
 
-18.8 "Perpetual Ray" sync / 1[56]:Onslaughter:1730:/
-24.0 "Hydrothermal Missile" # sync / 1[56]:Onslaughter:172F:/
-27.1 "Hydrothermal Missile" # sync / 1[56]:Onslaughter:172F:/
-33.2 "Execution" sync / 1[56]:Onslaughter:1632:/
-37.3 "Hydrothermal Missile" sync / 1[56]:Onslaughter:172F:/
-45.5 "Seed Of The Sky" sync / 1[56]:Onslaughter:1731:/
-52.5 "Mega Beam" sync / 1[56]:Onslaughter:1732:/
-55.2 "--regulator check--" # sync / 1[56]:Steam Regulator B:1735:/
-55.6 "Hydrothermal Missile" sync / 1[56]:Onslaughter:172F:/
-61.8 "Perpetual Ray" sync / 1[56]:Onslaughter:1730:/
-67.0 "Hydrothermal Missile" # sync / 1[56]:Onslaughter:172F:/
-70.1 "Hydrothermal Missile" # sync / 1[56]:Onslaughter:172F:/
-75.2 "Discoid" sync / 1[56]:Onslaughter:162F:/
-79.3 "Hydrothermal Missile" sync / 1[56]:Onslaughter:172F:/
-90.5 "Seed Of The Sky" sync / 1[56]:Onslaughter:1731:/
-95.5 "Mega Beam" sync / 1[56]:Onslaughter:1732:/
-98.6 "Hydrothermal Missile" sync / 1[56]:Onslaughter:172F:/
+18.8 "Perpetual Ray" sync / 1[56]:[^:]*:Onslaughter:1730:/
+24.0 "Hydrothermal Missile" # sync / 1[56]:[^:]*:Onslaughter:172F:/
+27.1 "Hydrothermal Missile" # sync / 1[56]:[^:]*:Onslaughter:172F:/
+33.2 "Execution" sync / 1[56]:[^:]*:Onslaughter:1632:/
+37.3 "Hydrothermal Missile" sync / 1[56]:[^:]*:Onslaughter:172F:/
+45.5 "Seed Of The Sky" sync / 1[56]:[^:]*:Onslaughter:1731:/
+52.5 "Mega Beam" sync / 1[56]:[^:]*:Onslaughter:1732:/
+55.2 "--regulator check--" # sync / 1[56]:[^:]*:Steam Regulator B:1735:/
+55.6 "Hydrothermal Missile" sync / 1[56]:[^:]*:Onslaughter:172F:/
+61.8 "Perpetual Ray" sync / 1[56]:[^:]*:Onslaughter:1730:/
+67.0 "Hydrothermal Missile" # sync / 1[56]:[^:]*:Onslaughter:172F:/
+70.1 "Hydrothermal Missile" # sync / 1[56]:[^:]*:Onslaughter:172F:/
+75.2 "Discoid" sync / 1[56]:[^:]*:Onslaughter:162F:/
+79.3 "Hydrothermal Missile" sync / 1[56]:[^:]*:Onslaughter:172F:/
+90.5 "Seed Of The Sky" sync / 1[56]:[^:]*:Onslaughter:1731:/
+95.5 "Mega Beam" sync / 1[56]:[^:]*:Onslaughter:1732:/
+98.6 "Hydrothermal Missile" sync / 1[56]:[^:]*:Onslaughter:172F:/
 
-104.7 "Perpetual Ray" sync / 1[56]:Onslaughter:1730:/ jump 18.8
+104.7 "Perpetual Ray" sync / 1[56]:[^:]*:Onslaughter:1730:/ jump 18.8
 109.9 "Hydrothermal Missile"
 113.0 "Hydrothermal Missile"
 119.1 "Execution"
@@ -52,34 +52,34 @@ hideall "Brute Force"
 200.0 "--sync--" sync / 22:........:Onslaughter:........:Onslaughter:00/ window 200,0
 203.8 "--sync--" sync / 03:........:Brawler:/  window 150,30
 206.2 "--targetable--"
-214.3 "Magicked Mark" sync / 1[56]:Brawler:173B:/
-214.3 "Brute Force" sync / 1[56]:Vortexer:1744:/
-218.5 "Ballistic Missile" sync / 1[56]:Vortexer:1650:/ window 18,10
-223.7 "Ice Missile" sync / 1[56]:Vortexer:1746:/
-224.5 "Earth Missile" sync / 1[56]:Vortexer:1745:/
-226.5 "Magicked Mark" sync / 1[56]:Brawler:173B:/
-226.6 "Brute Force" sync / 1[56]:Vortexer:1744:/
+214.3 "Magicked Mark" sync / 1[56]:[^:]*:Brawler:173B:/
+214.3 "Brute Force" sync / 1[56]:[^:]*:Vortexer:1744:/
+218.5 "Ballistic Missile" sync / 1[56]:[^:]*:Vortexer:1650:/ window 18,10
+223.7 "Ice Missile" sync / 1[56]:[^:]*:Vortexer:1746:/
+224.5 "Earth Missile" sync / 1[56]:[^:]*:Vortexer:1745:/
+226.5 "Magicked Mark" sync / 1[56]:[^:]*:Brawler:173B:/
+226.6 "Brute Force" sync / 1[56]:[^:]*:Vortexer:1744:/
 
-229.6 "Attachment" sync / 1[56]:Brawler:163C:/
-235.7 "Single Buster/Double Buster" sync / 1[56]:Brawler:173D:/ window 30,30
-238.7 "Brute Force" sync / 1[56]:Vortexer:1744:/
-241.8 "Ballistic Missile" sync / 1[56]:Vortexer:1650:/ window 15,15
-242.8 "Magicked Mark" sync / 1[56]:Brawler:173B:/
-246.8 "Ice Missile" sync / 1[56]:Vortexer:1746:/
-247.8 "Earth Missile" sync / 1[56]:Vortexer:1745:/
-253.9 "Super Cyclone" sync / 1[56]:Vortexer:1747:/
-255.9 "Attachment" sync / 1[56]:Brawler:163C:/
-258.0 "Brute Force" sync / 1[56]:Vortexer:1744:/
-262.4 "Single Buster/Double Buster" sync / 1[56]:Brawler:173C:/ window 30,30
-269.1 "Brute Force" sync / 1[56]:Vortexer:1744:/
-269.5 "Magicked Mark" sync / 1[56]:Brawler:173B:/
-273.2 "Ballistic Missile" sync / 1[56]:Vortexer:1650:/ window 15,15
-278.2 "Ice Missile" sync / 1[56]:Vortexer:1746:/
-279.2 "Earth Missile" sync / 1[56]:Vortexer:1745:/
-281.3 "Brute Force" sync / 1[56]:Vortexer:1744:/
-281.7 "Magicked Mark" sync / 1[56]:Brawler:173B:/
+229.6 "Attachment" sync / 1[56]:[^:]*:Brawler:163C:/
+235.7 "Single Buster/Double Buster" sync / 1[56]:[^:]*:Brawler:173D:/ window 30,30
+238.7 "Brute Force" sync / 1[56]:[^:]*:Vortexer:1744:/
+241.8 "Ballistic Missile" sync / 1[56]:[^:]*:Vortexer:1650:/ window 15,15
+242.8 "Magicked Mark" sync / 1[56]:[^:]*:Brawler:173B:/
+246.8 "Ice Missile" sync / 1[56]:[^:]*:Vortexer:1746:/
+247.8 "Earth Missile" sync / 1[56]:[^:]*:Vortexer:1745:/
+253.9 "Super Cyclone" sync / 1[56]:[^:]*:Vortexer:1747:/
+255.9 "Attachment" sync / 1[56]:[^:]*:Brawler:163C:/
+258.0 "Brute Force" sync / 1[56]:[^:]*:Vortexer:1744:/
+262.4 "Single Buster/Double Buster" sync / 1[56]:[^:]*:Brawler:173C:/ window 30,30
+269.1 "Brute Force" sync / 1[56]:[^:]*:Vortexer:1744:/
+269.5 "Magicked Mark" sync / 1[56]:[^:]*:Brawler:173B:/
+273.2 "Ballistic Missile" sync / 1[56]:[^:]*:Vortexer:1650:/ window 15,15
+278.2 "Ice Missile" sync / 1[56]:[^:]*:Vortexer:1746:/
+279.2 "Earth Missile" sync / 1[56]:[^:]*:Vortexer:1745:/
+281.3 "Brute Force" sync / 1[56]:[^:]*:Vortexer:1744:/
+281.7 "Magicked Mark" sync / 1[56]:[^:]*:Brawler:173B:/
 
-284.9 "Attachment" sync / 1[56]:Brawler:163C:/
+284.9 "Attachment" sync / 1[56]:[^:]*:Brawler:163C:/
 291.0 "Single Buster/Double Buster"
 297.1 "Ballistic Missile"
 302.1 "Ice Missile"
@@ -91,30 +91,30 @@ hideall "Brute Force"
 # One full rotation plus a tail again, for the same reasons. Don't be slow!
 500.0 "--sync--" sync / 03:........:Blaster:/  window 300,30
 502.1 "--targetable--"
-510.3 "Magicked Mark" sync / 1[56]:Swindler:173F:/
-510.3 "Brute Force" sync / 1[56]:Blaster:1738:/
-520.4 "Height" sync / 1[56]:Swindler:1740:/ window 20.4,20
-523.4 "Brute Force" sync / 1[56]:Blaster:1738:/
-523.6 "Magicked Mark" sync / 1[56]:Swindler:173F:/
-526.5 "Mind Blast" sync / 1[56]:Blaster:1739:/
+510.3 "Magicked Mark" sync / 1[56]:[^:]*:Swindler:173F:/
+510.3 "Brute Force" sync / 1[56]:[^:]*:Blaster:1738:/
+520.4 "Height" sync / 1[56]:[^:]*:Swindler:1740:/ window 20.4,20
+523.4 "Brute Force" sync / 1[56]:[^:]*:Blaster:1738:/
+523.6 "Magicked Mark" sync / 1[56]:[^:]*:Swindler:173F:/
+526.5 "Mind Blast" sync / 1[56]:[^:]*:Blaster:1739:/
 
-537.7 "Mirage" sync / 1[56]:Blaster Mirage:1748:/
-543.8 "Supercharge" # sync / 1[56]:Blaster Mirage:1749:/
-545.7 "Magicked Mark" sync / 1[56]:Swindler:173F:/
-546.0 "Brute Force" sync / 1[56]:Blaster:1738:/
-549.2 "Mind Blast" sync / 1[56]:Blaster:1739:/
-555.9 "Magicked Mark" sync / 1[56]:Swindler:173F:/
-556.3 "Brute Force" sync / 1[56]:Blaster:1738:/
-558.8 "Enumeration" sync / 1[56]:Swindler:1742:/
-563.4 "Mind Blast" sync / 1[56]:Blaster:1739:/
-565.0 "Magicked Mark" sync / 1[56]:Swindler:173F:/
-565.5 "Brute Force" sync / 1[56]:Blaster:1738:/
-575.1 "Height" sync / 1[56]:Swindler:1740:/
-578.3 "Magicked Mark" sync / 1[56]:Swindler:173F:/
-578.7 "Brute Force" sync / 1[56]:Blaster:1738:/
-581.8 "Mind Blast" sync / 1[56]:Blaster:1739:/
+537.7 "Mirage" sync / 1[56]:[^:]*:Blaster Mirage:1748:/
+543.8 "Supercharge" # sync / 1[56]:[^:]*:Blaster Mirage:1749:/
+545.7 "Magicked Mark" sync / 1[56]:[^:]*:Swindler:173F:/
+546.0 "Brute Force" sync / 1[56]:[^:]*:Blaster:1738:/
+549.2 "Mind Blast" sync / 1[56]:[^:]*:Blaster:1739:/
+555.9 "Magicked Mark" sync / 1[56]:[^:]*:Swindler:173F:/
+556.3 "Brute Force" sync / 1[56]:[^:]*:Blaster:1738:/
+558.8 "Enumeration" sync / 1[56]:[^:]*:Swindler:1742:/
+563.4 "Mind Blast" sync / 1[56]:[^:]*:Blaster:1739:/
+565.0 "Magicked Mark" sync / 1[56]:[^:]*:Swindler:173F:/
+565.5 "Brute Force" sync / 1[56]:[^:]*:Blaster:1738:/
+575.1 "Height" sync / 1[56]:[^:]*:Swindler:1740:/
+578.3 "Magicked Mark" sync / 1[56]:[^:]*:Swindler:173F:/
+578.7 "Brute Force" sync / 1[56]:[^:]*:Blaster:1738:/
+581.8 "Mind Blast" sync / 1[56]:[^:]*:Blaster:1739:/
 
-593.0 "Mirage" sync / 1[56]:Blaster Mirage:1748:/
+593.0 "Mirage" sync / 1[56]:[^:]*:Blaster Mirage:1748:/
 599.1 "Supercharge"
 604.5 "Mind Blast"
 614.1 "Enumeration"
@@ -122,57 +122,57 @@ hideall "Brute Force"
 
 # GO, GO, MEGAZORD MODE (BRUTE JUSTICE)
 800.0 "--sync--" sync / 03:........:Brute Justice:/  window 300,30
-810.3 "--sync--" sync / 1[56]:Brute Justice:1758:/ window 610.3,30
+810.3 "--sync--" sync / 1[56]:[^:]*:Brute Justice:1758:/ window 610.3,30
 813.0 "--targetable--"
-826.9 "Double Rocket Punch" sync / 1[56]:Brute Justice:174E:/ window 26,30
-829.0 "Missile Command" sync / 1[56]:Brute Justice:1668:/
-832.4 "Flarethrower" sync / 1[56]:Brute Justice:174D:/
-833.0 "Long Needle" sync / 1[56]:Brute Justice:1754:/
-840.5 "Apocalyptic Ray" sync / 1[56]:Brute Justice:1751:/ window 30,30 duration 5
-852.4 "Super Jump" sync / 1[56]:Brute Justice:1750:/
-858.6 "Flarethrower" sync / 1[56]:Brute Justice:174D:/
-863.7 "Missile Command" sync / 1[56]:Brute Justice:1668:/
-865.7 "Short Needle x3" duration 6 # sync / 1[56]:Brute Justice:1753:/
-871.8 "Double Rocket Punch" sync / 1[56]:Brute Justice:174E:/ window 30,30
-879.0 "Flarethrower" sync / 1[56]:Brute Justice:174D:/
-885.1 "Missile Command" sync / 1[56]:Brute Justice:1668:/
-889.1 "Long Needle" sync / 1[56]:Brute Justice:1754:/
-897.1 "Mega Beam" sync / 1[56]:Brute Justice:174F:/ window 30,30
+826.9 "Double Rocket Punch" sync / 1[56]:[^:]*:Brute Justice:174E:/ window 26,30
+829.0 "Missile Command" sync / 1[56]:[^:]*:Brute Justice:1668:/
+832.4 "Flarethrower" sync / 1[56]:[^:]*:Brute Justice:174D:/
+833.0 "Long Needle" sync / 1[56]:[^:]*:Brute Justice:1754:/
+840.5 "Apocalyptic Ray" sync / 1[56]:[^:]*:Brute Justice:1751:/ window 30,30 duration 5
+852.4 "Super Jump" sync / 1[56]:[^:]*:Brute Justice:1750:/
+858.6 "Flarethrower" sync / 1[56]:[^:]*:Brute Justice:174D:/
+863.7 "Missile Command" sync / 1[56]:[^:]*:Brute Justice:1668:/
+865.7 "Short Needle x3" duration 6 # sync / 1[56]:[^:]*:Brute Justice:1753:/
+871.8 "Double Rocket Punch" sync / 1[56]:[^:]*:Brute Justice:174E:/ window 30,30
+879.0 "Flarethrower" sync / 1[56]:[^:]*:Brute Justice:174D:/
+885.1 "Missile Command" sync / 1[56]:[^:]*:Brute Justice:1668:/
+889.1 "Long Needle" sync / 1[56]:[^:]*:Brute Justice:1754:/
+897.1 "Mega Beam" sync / 1[56]:[^:]*:Brute Justice:174F:/ window 30,30
 899.2 "--untargetable--"
 
 # ABBREVIATED INTERMISSION
-902.4 "J Kick" sync / 1[56]:Brute Justice:1756:/
-914.7 "Minefield" sync / 1[56]:Hidden Mine:174A:/
-915.7 "Ice Missile" sync / 1[56]:Vortexer:1746:/
-916.7 "Earth Missile" sync / 1[56]:Vortexer:1745:/
-919.9 "Attachment" sync / 1[56]:Brawler:163C:/
-926.1 "Single Buster/Double Buster" sync / 1[56]:Brawler:173D:/
-932.0 "--sync--" sync / 1[56]:Brute Justice:1636:/
-933.1 "100-Megatonze Shock" sync / 1[56]:Onslaughter:1736:/
-936.9 "Height" sync / 1[56]:Swindler:1740:/
-939.4 "Mega Beam" sync / 1[56]:Onslaughter:1732:/
+902.4 "J Kick" sync / 1[56]:[^:]*:Brute Justice:1756:/
+914.7 "Minefield" sync / 1[56]:[^:]*:Hidden Mine:174A:/
+915.7 "Ice Missile" sync / 1[56]:[^:]*:Vortexer:1746:/
+916.7 "Earth Missile" sync / 1[56]:[^:]*:Vortexer:1745:/
+919.9 "Attachment" sync / 1[56]:[^:]*:Brawler:163C:/
+926.1 "Single Buster/Double Buster" sync / 1[56]:[^:]*:Brawler:173D:/
+932.0 "--sync--" sync / 1[56]:[^:]*:Brute Justice:1636:/
+933.1 "100-Megatonze Shock" sync / 1[56]:[^:]*:Onslaughter:1736:/
+936.9 "Height" sync / 1[56]:[^:]*:Swindler:1740:/
+939.4 "Mega Beam" sync / 1[56]:[^:]*:Onslaughter:1732:/
 
 # FOR GREAT JUSTICE
 947.8 "--targetable--"
-957.9 "Double Rocket Punch" sync / 1[56]:Brute Justice:174E:/ window 30,30
-960.1 "Missile Command" sync / 1[56]:Brute Justice:1668:/
-964.0 "Flarethrower" sync / 1[56]:Brute Justice:174D:/
-964.0 "Long Needle" sync / 1[56]:Brute Justice:1754:/
-972.2 "Apocalyptic Ray" sync / 1[56]:Brute Justice:1751:/ duration 5 window 30,30
-984.1 "Super Jump" sync / 1[56]:Brute Justice:1750:/
-990.3 "Flarethrower" sync / 1[56]:Brute Justice:174D:/
-995.4 "Missile Command" sync / 1[56]:Brute Justice:1668:/
-997.4 "Short Needle x3" duration 6 # sync / 1[56]:Brute Justice:1753:/
-1003.4 "Double Rocket Punch" sync / 1[56]:Brute Justice:174E:/ window 30,30
-1010.6 "Flarethrower" sync / 1[56]:Brute Justice:174D:/
-1016.7 "Missile Command" sync / 1[56]:Brute Justice:1668:/
-1020.7 "Long Needle" sync / 1[56]:Brute Justice:1754:/
-1028.8 "Mega Beam" sync / 1[56]:Brute Justice:174F:/ window 30,30
+957.9 "Double Rocket Punch" sync / 1[56]:[^:]*:Brute Justice:174E:/ window 30,30
+960.1 "Missile Command" sync / 1[56]:[^:]*:Brute Justice:1668:/
+964.0 "Flarethrower" sync / 1[56]:[^:]*:Brute Justice:174D:/
+964.0 "Long Needle" sync / 1[56]:[^:]*:Brute Justice:1754:/
+972.2 "Apocalyptic Ray" sync / 1[56]:[^:]*:Brute Justice:1751:/ duration 5 window 30,30
+984.1 "Super Jump" sync / 1[56]:[^:]*:Brute Justice:1750:/
+990.3 "Flarethrower" sync / 1[56]:[^:]*:Brute Justice:174D:/
+995.4 "Missile Command" sync / 1[56]:[^:]*:Brute Justice:1668:/
+997.4 "Short Needle x3" duration 6 # sync / 1[56]:[^:]*:Brute Justice:1753:/
+1003.4 "Double Rocket Punch" sync / 1[56]:[^:]*:Brute Justice:174E:/ window 30,30
+1010.6 "Flarethrower" sync / 1[56]:[^:]*:Brute Justice:174D:/
+1016.7 "Missile Command" sync / 1[56]:[^:]*:Brute Justice:1668:/
+1020.7 "Long Needle" sync / 1[56]:[^:]*:Brute Justice:1754:/
+1028.8 "Mega Beam" sync / 1[56]:[^:]*:Brute Justice:174F:/ window 30,30
 1030.9 "--untargetable--"
-1034.1 "J Kick" sync / 1[56]:Brute Justice:1756:/
+1034.1 "J Kick" sync / 1[56]:[^:]*:Brute Justice:1756:/
 
 1037.1 "--targetable--"
-1047.2 "Double Rocket Punch" sync / 1[56]:Brute Justice:174E:/ jump 957.9
+1047.2 "Double Rocket Punch" sync / 1[56]:[^:]*:Brute Justice:174E:/ jump 957.9
 1049.4 "Missile Command"
 1053.3 "Flarethrower"
 1053.3 "Long Needle"

--- a/ui/raidboss/data/03-hw/raid/a8s.txt
+++ b/ui/raidboss/data/03-hw/raid/a8s.txt
@@ -13,48 +13,48 @@ hideall "Brute Force"
 
 ### Phase 1: Onslaughter: Execution and Legislation
 0.0 "--sync--" sync /:Engage!/ window 0,1
-1.0 "--sync--" sync / 1[56]:Onslaughter:1629:/ window 1,0
-6.7 "Hydrothermal Missile" sync / 1[56]:Onslaughter:162A:/ window 7,5
-15.9 "Seed Of The Sky" sync / 1[56]:Onslaughter:162D:/
-17.9 "Mega Beam" sync / 1[56]:Onslaughter:162E:/
-22.1 "Hydrothermal Missile" sync / 1[56]:Onslaughter:162A:/
+1.0 "--sync--" sync / 1[56]:[^:]*:Onslaughter:1629:/ window 1,0
+6.7 "Hydrothermal Missile" sync / 1[56]:[^:]*:Onslaughter:162A:/ window 7,5
+15.9 "Seed Of The Sky" sync / 1[56]:[^:]*:Onslaughter:162D:/
+17.9 "Mega Beam" sync / 1[56]:[^:]*:Onslaughter:162E:/
+22.1 "Hydrothermal Missile" sync / 1[56]:[^:]*:Onslaughter:162A:/
 
-29.3 "Execution" sync / 1[56]:Onslaughter:1632:/
+29.3 "Execution" sync / 1[56]:[^:]*:Onslaughter:1632:/
 31.5 "--targetable--"
-31.5 "Hydrothermal Missile" sync / 1[56]:Onslaughter:162A:/
-38.7 "Seed Of The Sky" sync / 1[56]:Onslaughter:162D:/
-40.7 "Mega Beam" sync / 1[56]:Onslaughter:162E:/
-47.9 "Perpetual Ray" sync / 1[56]:Onslaughter:162B:/ duration 3.3
-51.5 "--regulator check--" #sync / 1[56]:Steam Regulator B:1634:/
-54.7 "Hydrothermal Missile" sync / 1[56]:Onslaughter:162A:/
-61.8 "Mega Beam" sync / 1[56]:Onslaughter:162E:/
-66.0 "Hydrothermal Missile" sync / 1[56]:Onslaughter:162A:/
+31.5 "Hydrothermal Missile" sync / 1[56]:[^:]*:Onslaughter:162A:/
+38.7 "Seed Of The Sky" sync / 1[56]:[^:]*:Onslaughter:162D:/
+40.7 "Mega Beam" sync / 1[56]:[^:]*:Onslaughter:162E:/
+47.9 "Perpetual Ray" sync / 1[56]:[^:]*:Onslaughter:162B:/ duration 3.3
+51.5 "--regulator check--" #sync / 1[56]:[^:]*:Steam Regulator B:1634:/
+54.7 "Hydrothermal Missile" sync / 1[56]:[^:]*:Onslaughter:162A:/
+61.8 "Mega Beam" sync / 1[56]:[^:]*:Onslaughter:162E:/
+66.0 "Hydrothermal Missile" sync / 1[56]:[^:]*:Onslaughter:162A:/
 
-73.2 "Legislation" sync / 1[56]:Onslaughter:1631:/
-78.3 "Discoid" sync / 1[56]:Onslaughter:162F:/
+73.2 "Legislation" sync / 1[56]:[^:]*:Onslaughter:1631:/
+78.3 "Discoid" sync / 1[56]:[^:]*:Onslaughter:162F:/
 79.9 "--orbs--"
-80.5 "Hydrothermal Missile" sync / 1[56]:Onslaughter:162A:/
-90.7 "Seed Of The Sky" sync / 1[56]:Onslaughter:162D:/
-93.0 "Mega Beam" sync / 1[56]:Onslaughter:162E:/
-95.4 "Hydrothermal Missile" sync / 1[56]:Onslaughter:162A:/
+80.5 "Hydrothermal Missile" sync / 1[56]:[^:]*:Onslaughter:162A:/
+90.7 "Seed Of The Sky" sync / 1[56]:[^:]*:Onslaughter:162D:/
+93.0 "Mega Beam" sync / 1[56]:[^:]*:Onslaughter:162E:/
+95.4 "Hydrothermal Missile" sync / 1[56]:[^:]*:Onslaughter:162A:/
 
-102.5 "Perpetual Ray" sync / 1[56]:Onslaughter:162B:/ duration 3.3
-106.9 "Hydrothermal Missile" sync / 1[56]:Onslaughter:162A:/
-117.1 "Hydrothermal Missile" sync / 1[56]:Onslaughter:162A:/
-126.3 "Seed Of The Sky" sync / 1[56]:Onslaughter:162D:/
-127.4 "Mega Beam" sync / 1[56]:Onslaughter:162E:/
-132.6 "Hydrothermal Missile" sync / 1[56]:Onslaughter:162A:/
-138.7 "Hydrothermal Missile" sync / 1[56]:Onslaughter:162A:/
+102.5 "Perpetual Ray" sync / 1[56]:[^:]*:Onslaughter:162B:/ duration 3.3
+106.9 "Hydrothermal Missile" sync / 1[56]:[^:]*:Onslaughter:162A:/
+117.1 "Hydrothermal Missile" sync / 1[56]:[^:]*:Onslaughter:162A:/
+126.3 "Seed Of The Sky" sync / 1[56]:[^:]*:Onslaughter:162D:/
+127.4 "Mega Beam" sync / 1[56]:[^:]*:Onslaughter:162E:/
+132.6 "Hydrothermal Missile" sync / 1[56]:[^:]*:Onslaughter:162A:/
+138.7 "Hydrothermal Missile" sync / 1[56]:[^:]*:Onslaughter:162A:/
 
-145.8 "Perpetual Ray" sync / 1[56]:Onslaughter:162B:/ duration 3.3
-150.2 "Hydrothermal Missile" sync / 1[56]:Onslaughter:162A:/
-155.3 "Hydrothermal Missile" sync / 1[56]:Onslaughter:162A:/
-164.5 "Seed Of The Sky" sync / 1[56]:Onslaughter:162D:/
-165.6 "Mega Beam" sync / 1[56]:Onslaughter:162E:/
-170.8 "Hydrothermal Missile" sync / 1[56]:Onslaughter:162A:/
-176.9 "Hydrothermal Missile" sync / 1[56]:Onslaughter:162A:/
+145.8 "Perpetual Ray" sync / 1[56]:[^:]*:Onslaughter:162B:/ duration 3.3
+150.2 "Hydrothermal Missile" sync / 1[56]:[^:]*:Onslaughter:162A:/
+155.3 "Hydrothermal Missile" sync / 1[56]:[^:]*:Onslaughter:162A:/
+164.5 "Seed Of The Sky" sync / 1[56]:[^:]*:Onslaughter:162D:/
+165.6 "Mega Beam" sync / 1[56]:[^:]*:Onslaughter:162E:/
+170.8 "Hydrothermal Missile" sync / 1[56]:[^:]*:Onslaughter:162A:/
+176.9 "Hydrothermal Missile" sync / 1[56]:[^:]*:Onslaughter:162A:/
 
-184.0 "Perpetual Ray" sync / 1[56]:Onslaughter:162B:/ duration 3.3 window 30,30 jump 145.8
+184.0 "Perpetual Ray" sync / 1[56]:[^:]*:Onslaughter:162B:/ duration 3.3 window 30,30 jump 145.8
 188.4 "Hydrothermal Missile"
 193.5 "Hydrothermal Missile"
 202.7 "Seed Of The Sky"
@@ -69,200 +69,200 @@ hideall "Brute Force"
 304.0 "Blaster (north)"
 304.0 "Brawler (middle)"
 306.2 "--targetable--"
-313.5 "Magicked Mark" sync / 1[56]:Brawler:163B:/ window 314,5
-314.5 "Brute Force" sync / 1[56]:Blaster:1638:/
-316.6 "Auxiliary Power" sync / 1[56]:Brawler:164B:/
+313.5 "Magicked Mark" sync / 1[56]:[^:]*:Brawler:163B:/ window 314,5
+314.5 "Brute Force" sync / 1[56]:[^:]*:Blaster:1638:/
+316.6 "Auxiliary Power" sync / 1[56]:[^:]*:Brawler:164B:/
 
-319.8 "Attachment" sync / 1[56]:Brawler:163C:/
-322.4 "Mind Blast?" #sync / 1[56]:Blaster:1639:/ # 3 second cast, interruptible
-324.5 "Brute Force" #sync / 1[56]:Blaster Mirage:1638:/
-325.6 "Brute Force" sync / 1[56]:Blaster:1638:/
-326.0 "Brawler Mechanic" sync / 1[56]:Brawler:(163D|163E|163F|1640):/
+319.8 "Attachment" sync / 1[56]:[^:]*:Brawler:163C:/
+322.4 "Mind Blast?" #sync / 1[56]:[^:]*:Blaster:1639:/ # 3 second cast, interruptible
+324.5 "Brute Force" #sync / 1[56]:[^:]*:Blaster Mirage:1638:/
+325.6 "Brute Force" sync / 1[56]:[^:]*:Blaster:1638:/
+326.0 "Brawler Mechanic" sync / 1[56]:[^:]*:Brawler:(163D|163E|163F|1640):/
 
 329.4 "Swindler (east)" #sync / 22:........:Swindler:........:Swindler:01/
-330.1 "Auxiliary Power" sync / 1[56]:Brawler:164B:/
-333.7 "Brute Force" sync / 1[56]:Blaster:1638:/
-334.2 "Magicked Mark" sync / 1[56]:Brawler:163B:/
-334.6 "Brute Force" #sync / 1[56]:Blaster Mirage:1638:/
-337.5 "Magicked Mark" sync / 1[56]:Swindler:1646:/
-341.7 "Brute Force" sync / 1[56]:Blaster:1638:/
-343.2 "Magicked Mark" sync / 1[56]:Brawler:163B:/
-346.3 "Auxiliary Power" sync / 1[56]:Brawler:164B:/
-348.5 "Height" sync / 1[56]:Swindler:1647:/
-349.4 "Attachment" sync / 1[56]:Brawler:163C:/
+330.1 "Auxiliary Power" sync / 1[56]:[^:]*:Brawler:164B:/
+333.7 "Brute Force" sync / 1[56]:[^:]*:Blaster:1638:/
+334.2 "Magicked Mark" sync / 1[56]:[^:]*:Brawler:163B:/
+334.6 "Brute Force" #sync / 1[56]:[^:]*:Blaster Mirage:1638:/
+337.5 "Magicked Mark" sync / 1[56]:[^:]*:Swindler:1646:/
+341.7 "Brute Force" sync / 1[56]:[^:]*:Blaster:1638:/
+343.2 "Magicked Mark" sync / 1[56]:[^:]*:Brawler:163B:/
+346.3 "Auxiliary Power" sync / 1[56]:[^:]*:Brawler:164B:/
+348.5 "Height" sync / 1[56]:[^:]*:Swindler:1647:/
+349.4 "Attachment" sync / 1[56]:[^:]*:Brawler:163C:/
 
 352.4 "Vortexer (south)" #sync / 22:........:Vortexer:........:Vortexer:01/
-354.6 "Magicked Mark" sync / 1[56]:Swindler:1646:/
-355.5 "Brawler Mechanic" sync / 1[56]:Brawler:(163D|163E|163F|1640):/
-359.6 "Auxiliary Power" sync / 1[56]:Brawler:164B:/
-360.4 "Brute Force" sync / 1[56]:Vortexer:164D:/
-363.7 "Magicked Mark" sync / 1[56]:Brawler:163B:/
-370.4 "Brute Force" sync / 1[56]:Vortexer:164D:/
-372.8 "Magicked Mark" sync / 1[56]:Brawler:163B:/
-375.9 "Auxiliary Power" sync / 1[56]:Brawler:164B:/
-379.0 "Attachment" sync / 1[56]:Brawler:163C:/
-380.5 "Brute Force" sync / 1[56]:Vortexer:164D:/
-385.0 "Brawler Mechanic" sync / 1[56]:Brawler:(163D|163E|163F|1640):/
-390.2 "Auxiliary Power" sync / 1[56]:Brawler:164B:/
-390.6 "Brute Force" sync / 1[56]:Vortexer:164D:/
-393.4 "Attachment" sync / 1[56]:Brawler:163C:/
-399.5 "Brawler Mechanic" sync / 1[56]:Brawler:(163D|163E|163F|1640):/
-400.7 "Brute Force" sync / 1[56]:Vortexer:164D:/
-403.6 "Auxiliary Power" sync / 1[56]:Brawler:164B:/
-407.7 "Magicked Mark" sync / 1[56]:Brawler:163B:/
+354.6 "Magicked Mark" sync / 1[56]:[^:]*:Swindler:1646:/
+355.5 "Brawler Mechanic" sync / 1[56]:[^:]*:Brawler:(163D|163E|163F|1640):/
+359.6 "Auxiliary Power" sync / 1[56]:[^:]*:Brawler:164B:/
+360.4 "Brute Force" sync / 1[56]:[^:]*:Vortexer:164D:/
+363.7 "Magicked Mark" sync / 1[56]:[^:]*:Brawler:163B:/
+370.4 "Brute Force" sync / 1[56]:[^:]*:Vortexer:164D:/
+372.8 "Magicked Mark" sync / 1[56]:[^:]*:Brawler:163B:/
+375.9 "Auxiliary Power" sync / 1[56]:[^:]*:Brawler:164B:/
+379.0 "Attachment" sync / 1[56]:[^:]*:Brawler:163C:/
+380.5 "Brute Force" sync / 1[56]:[^:]*:Vortexer:164D:/
+385.0 "Brawler Mechanic" sync / 1[56]:[^:]*:Brawler:(163D|163E|163F|1640):/
+390.2 "Auxiliary Power" sync / 1[56]:[^:]*:Brawler:164B:/
+390.6 "Brute Force" sync / 1[56]:[^:]*:Vortexer:164D:/
+393.4 "Attachment" sync / 1[56]:[^:]*:Brawler:163C:/
+399.5 "Brawler Mechanic" sync / 1[56]:[^:]*:Brawler:(163D|163E|163F|1640):/
+400.7 "Brute Force" sync / 1[56]:[^:]*:Vortexer:164D:/
+403.6 "Auxiliary Power" sync / 1[56]:[^:]*:Brawler:164B:/
+407.7 "Magicked Mark" sync / 1[56]:[^:]*:Brawler:163B:/
 
 
 # All of the robots have their own rotation <50%
 # Messing up thunder seems the most punishing, so here's Vortexer.
-600.0 "--sync--" sync / 14:Vortexer:1657:/ window 600,0
-603.0 "Super Cyclone" sync / 1[56]:Vortexer:1657:/
-608.1 "Elemental Jammer" sync / 1[56]:Vortexer:167E:/
-615.4 "Ballistic Missile" sync / 1[56]:Vortexer:1650:/
-621.4 "Earth Missile" sync / 1[56]:Vortexer:1651:/
-645.8 "Ballistic Missile" sync / 1[56]:Vortexer:1650:/
-650.0 "Crashing Thunder" sync / 1[56]:Vortexer:164E:/
-651.7 "Earth Missile" sync / 1[56]:Vortexer:1651:/
-671.6 "Crashing Thunder" sync / 1[56]:Vortexer:164E:/
-676.1 "Ballistic Missile" sync / 1[56]:Vortexer:1650:/
-682.1 "Earth Missile" sync / 1[56]:Vortexer:1651:/
+600.0 "--sync--" sync / 14:[^:]*:Vortexer:1657:/ window 600,0
+603.0 "Super Cyclone" sync / 1[56]:[^:]*:Vortexer:1657:/
+608.1 "Elemental Jammer" sync / 1[56]:[^:]*:Vortexer:167E:/
+615.4 "Ballistic Missile" sync / 1[56]:[^:]*:Vortexer:1650:/
+621.4 "Earth Missile" sync / 1[56]:[^:]*:Vortexer:1651:/
+645.8 "Ballistic Missile" sync / 1[56]:[^:]*:Vortexer:1650:/
+650.0 "Crashing Thunder" sync / 1[56]:[^:]*:Vortexer:164E:/
+651.7 "Earth Missile" sync / 1[56]:[^:]*:Vortexer:1651:/
+671.6 "Crashing Thunder" sync / 1[56]:[^:]*:Vortexer:164E:/
+676.1 "Ballistic Missile" sync / 1[56]:[^:]*:Vortexer:1650:/
+682.1 "Earth Missile" sync / 1[56]:[^:]*:Vortexer:1651:/
 
 
 ### Phase 3: Brute Justice
-800.0 "Transform" sync / 1[56]:Brute Justice:167C:/ window 800,0
+800.0 "Transform" sync / 1[56]:[^:]*:Brute Justice:167C:/ window 800,0
 802.7 "--targetable--"
-810.9 "Flarethrower" sync / 1[56]:Brute Justice:1662:/
-818.0 "Double Rocket Punch" sync / 1[56]:Brute Justice:1663:/
-821.2 "Missile Command" sync / 1[56]:Brute Justice:1668:/
-824.2 "Short Needle" sync / 1[56]:Brute Justice:1669:/
-825.3 "Flarethrower" sync / 1[56]:Brute Justice:1662:/
+810.9 "Flarethrower" sync / 1[56]:[^:]*:Brute Justice:1662:/
+818.0 "Double Rocket Punch" sync / 1[56]:[^:]*:Brute Justice:1663:/
+821.2 "Missile Command" sync / 1[56]:[^:]*:Brute Justice:1668:/
+824.2 "Short Needle" sync / 1[56]:[^:]*:Brute Justice:1669:/
+825.3 "Flarethrower" sync / 1[56]:[^:]*:Brute Justice:1662:/
 # 166A (ground), 166B (prey), 166C (stack)
-828.2 "Long Needle" sync / 1[56]:Brute Justice:166C:/
-831.1 "Short Needle" sync / 1[56]:Brute Justice:1669:/
-831.6 "Mega Beam" sync / 1[56]:Brute Justice:1664:/
-837.0 "Super Jump" sync / 1[56]:Brute Justice:1665:/
-841.6 "Apocalyptic Ray" sync / 1[56]:Brute Justice:1666:/ duration 5
-850.9 "Flarethrower" sync / 1[56]:Brute Justice:1662:/
-857.0 "Double Rocket Punch" sync / 1[56]:Brute Justice:1663:/
-859.1 "Flarethrower" sync / 1[56]:Brute Justice:1662:/
-862.2 "Missile Command" sync / 1[56]:Brute Justice:1668:/
-865.2 "Short Needle" sync / 1[56]:Brute Justice:1669:/
-866.3 "Flarethrower" sync / 1[56]:Brute Justice:1662:/
-869.2 "Long Needle" sync / 1[56]:Brute Justice:166C:/
-872.2 "Short Needle" sync / 1[56]:Brute Justice:1669:/
-872.9 "Mega Beam" sync / 1[56]:Brute Justice:1664:/
-878.1 "Super Jump" sync / 1[56]:Brute Justice:1665:/
+828.2 "Long Needle" sync / 1[56]:[^:]*:Brute Justice:166C:/
+831.1 "Short Needle" sync / 1[56]:[^:]*:Brute Justice:1669:/
+831.6 "Mega Beam" sync / 1[56]:[^:]*:Brute Justice:1664:/
+837.0 "Super Jump" sync / 1[56]:[^:]*:Brute Justice:1665:/
+841.6 "Apocalyptic Ray" sync / 1[56]:[^:]*:Brute Justice:1666:/ duration 5
+850.9 "Flarethrower" sync / 1[56]:[^:]*:Brute Justice:1662:/
+857.0 "Double Rocket Punch" sync / 1[56]:[^:]*:Brute Justice:1663:/
+859.1 "Flarethrower" sync / 1[56]:[^:]*:Brute Justice:1662:/
+862.2 "Missile Command" sync / 1[56]:[^:]*:Brute Justice:1668:/
+865.2 "Short Needle" sync / 1[56]:[^:]*:Brute Justice:1669:/
+866.3 "Flarethrower" sync / 1[56]:[^:]*:Brute Justice:1662:/
+869.2 "Long Needle" sync / 1[56]:[^:]*:Brute Justice:166C:/
+872.2 "Short Needle" sync / 1[56]:[^:]*:Brute Justice:1669:/
+872.9 "Mega Beam" sync / 1[56]:[^:]*:Brute Justice:1664:/
+878.1 "Super Jump" sync / 1[56]:[^:]*:Brute Justice:1665:/
 881.2 "--untargetable--"
 
 
 ### Phase 4: First Intermission
-884.4 "J Kick" sync / 1[56]:Brute Justice:166D:/ window 890,5
-892.7 "--sync--" sync / 1[56]:Brute Justice:1636:/
-893.9 "100-Megatonze Shock" sync / 1[56]:Onslaughter:1635:/
-894.7 "Mirage" sync / 1[56]:Blaster Mirage:1658:/
-895.7 "Attachment" sync / 1[56]:Brawler:163C:/
-899.7 "Supercharge" #sync / 1[56]:Blaster Mirage:1659:/
-901.9 "Double Buster" sync / 1[56]:Brawler:163E:/
-906.2 "Mega Beam" sync / 1[56]:Onslaughter:162E:/
-906.5 "Eye Of The Chakram" sync / 1[56]:Steam Chakram:1654:/
-914.0 "Attachment" sync / 1[56]:Brawler:163C:/
-915.5 "Height" sync / 1[56]:Swindler:1647:/
-915.6 "Ice Missile" #sync / 1[56]:Vortexer:1655:/
-916.4 "Earth Missile" sync / 1[56]:Vortexer:1651:/
-919.5 "Mega Beam" sync / 1[56]:Onslaughter:162E:/
-920.6 "Single Buster" sync / 1[56]:Brawler:163D:/
+884.4 "J Kick" sync / 1[56]:[^:]*:Brute Justice:166D:/ window 890,5
+892.7 "--sync--" sync / 1[56]:[^:]*:Brute Justice:1636:/
+893.9 "100-Megatonze Shock" sync / 1[56]:[^:]*:Onslaughter:1635:/
+894.7 "Mirage" sync / 1[56]:[^:]*:Blaster Mirage:1658:/
+895.7 "Attachment" sync / 1[56]:[^:]*:Brawler:163C:/
+899.7 "Supercharge" #sync / 1[56]:[^:]*:Blaster Mirage:1659:/
+901.9 "Double Buster" sync / 1[56]:[^:]*:Brawler:163E:/
+906.2 "Mega Beam" sync / 1[56]:[^:]*:Onslaughter:162E:/
+906.5 "Eye Of The Chakram" sync / 1[56]:[^:]*:Steam Chakram:1654:/
+914.0 "Attachment" sync / 1[56]:[^:]*:Brawler:163C:/
+915.5 "Height" sync / 1[56]:[^:]*:Swindler:1647:/
+915.6 "Ice Missile" #sync / 1[56]:[^:]*:Vortexer:1655:/
+916.4 "Earth Missile" sync / 1[56]:[^:]*:Vortexer:1651:/
+919.5 "Mega Beam" sync / 1[56]:[^:]*:Onslaughter:162E:/
+920.6 "Single Buster" sync / 1[56]:[^:]*:Brawler:163D:/
 
 
 ### Phase 5: Round 2, Fighto!
 933.1 "--targetable--"
-936.2 "Flarethrower" sync / 1[56]:Brute Justice:1662:/
-943.3 "Double Rocket Punch" sync / 1[56]:Brute Justice:1663:/
-946.5 "Missile Command" sync / 1[56]:Brute Justice:1668:/
-949.5 "Short Needle" sync / 1[56]:Brute Justice:1669:/
-950.6 "Flarethrower" sync / 1[56]:Brute Justice:1662:/
-953.5 "Long Needle" sync / 1[56]:Brute Justice:166C:/
-956.4 "Short Needle" sync / 1[56]:Brute Justice:1669:/
-956.9 "Mega Beam" sync / 1[56]:Brute Justice:1664:/
-962.3 "Super Jump" sync / 1[56]:Brute Justice:1665:/
-966.9 "Apocalyptic Ray" sync / 1[56]:Brute Justice:1666:/ duration 5
-976.2 "Flarethrower" sync / 1[56]:Brute Justice:1662:/
-982.3 "Double Rocket Punch" sync / 1[56]:Brute Justice:1663:/
-984.4 "Flarethrower" sync / 1[56]:Brute Justice:1662:/
-987.5 "Missile Command" sync / 1[56]:Brute Justice:1668:/
-990.5 "Short Needle" sync / 1[56]:Brute Justice:1669:/
-991.6 "Flarethrower" sync / 1[56]:Brute Justice:1662:/
-994.5 "Long Needle" sync / 1[56]:Brute Justice:166C:/
-997.5 "Short Needle" sync / 1[56]:Brute Justice:1669:/
-998.2 "Mega Beam" sync / 1[56]:Brute Justice:1664:/
-1003.4 "Super Jump" sync / 1[56]:Brute Justice:1665:/
+936.2 "Flarethrower" sync / 1[56]:[^:]*:Brute Justice:1662:/
+943.3 "Double Rocket Punch" sync / 1[56]:[^:]*:Brute Justice:1663:/
+946.5 "Missile Command" sync / 1[56]:[^:]*:Brute Justice:1668:/
+949.5 "Short Needle" sync / 1[56]:[^:]*:Brute Justice:1669:/
+950.6 "Flarethrower" sync / 1[56]:[^:]*:Brute Justice:1662:/
+953.5 "Long Needle" sync / 1[56]:[^:]*:Brute Justice:166C:/
+956.4 "Short Needle" sync / 1[56]:[^:]*:Brute Justice:1669:/
+956.9 "Mega Beam" sync / 1[56]:[^:]*:Brute Justice:1664:/
+962.3 "Super Jump" sync / 1[56]:[^:]*:Brute Justice:1665:/
+966.9 "Apocalyptic Ray" sync / 1[56]:[^:]*:Brute Justice:1666:/ duration 5
+976.2 "Flarethrower" sync / 1[56]:[^:]*:Brute Justice:1662:/
+982.3 "Double Rocket Punch" sync / 1[56]:[^:]*:Brute Justice:1663:/
+984.4 "Flarethrower" sync / 1[56]:[^:]*:Brute Justice:1662:/
+987.5 "Missile Command" sync / 1[56]:[^:]*:Brute Justice:1668:/
+990.5 "Short Needle" sync / 1[56]:[^:]*:Brute Justice:1669:/
+991.6 "Flarethrower" sync / 1[56]:[^:]*:Brute Justice:1662:/
+994.5 "Long Needle" sync / 1[56]:[^:]*:Brute Justice:166C:/
+997.5 "Short Needle" sync / 1[56]:[^:]*:Brute Justice:1669:/
+998.2 "Mega Beam" sync / 1[56]:[^:]*:Brute Justice:1664:/
+1003.4 "Super Jump" sync / 1[56]:[^:]*:Brute Justice:1665:/
 1006.5 "--untargetable--"
-1009.7 "J Kick" sync / 1[56]:Brute Justice:166D:/
+1009.7 "J Kick" sync / 1[56]:[^:]*:Brute Justice:166D:/
 # FIXME: some pause here, before looping back to targetable?
 1012.0 "--targetable--"
 
 
 ### Phase 6: Second Intermission
 1200.0 "--untargetable--"
-1203.2 "J Kick" sync / 1[56]:Brute Justice:166D:/
-1211.5 "Attachment" sync / 1[56]:Brawler:163C:/ window 291.5,5
-1211.5 "--sync--" sync / 1[56]:Brute Justice:1636:/
-1212.6 "100-Megatonze Shock" sync / 1[56]:Onslaughter:1635:/
+1203.2 "J Kick" sync / 1[56]:[^:]*:Brute Justice:166D:/
+1211.5 "Attachment" sync / 1[56]:[^:]*:Brawler:163C:/ window 291.5,5
+1211.5 "--sync--" sync / 1[56]:[^:]*:Brute Justice:1636:/
+1212.6 "100-Megatonze Shock" sync / 1[56]:[^:]*:Onslaughter:1635:/
 # First Intermission can be skipped, but this is the first different ability.
-1217.5 "Hidden Minefield" sync / 1[56]:Hidden Mine:165E:/ window 1220,5 duration 9
-1217.6 "Double Drill Crush" sync / 1[56]:Brawler:1640:/
-1218.6 "Drill Drive" sync / 1[56]:Brawler:1641:/
-1222.1 "Mega Beam" sync / 1[56]:Onslaughter:162E:/
-1223.7 "Attachment" sync / 1[56]:Brawler:163C:/
-1228.5 "Mirage" sync / 1[56]:Blaster Mirage:1658:/
-1229.8 "Rocket Drill" sync / 1[56]:Brawler:163F:/
-1232.6 "Mega Beam" sync / 1[56]:Onslaughter:162E:/
-1232.6 "Eye Of The Chakram" sync / 1[56]:Steam Chakram:1654:/
-1233.6 "Power Tackle" #sync / 1[56]:Blaster Mirage:165B:/
-1233.6 "Blinder" #sync / 1[56]:Blaster Mirage:165A:/
-1241.4 "Enumeration" sync / 1[56]:Swindler:1649:/
-1241.4 "Ultra Flash" sync / 1[56]:Vortexer:1656:/
+1217.5 "Hidden Minefield" sync / 1[56]:[^:]*:Hidden Mine:165E:/ window 1220,5 duration 9
+1217.6 "Double Drill Crush" sync / 1[56]:[^:]*:Brawler:1640:/
+1218.6 "Drill Drive" sync / 1[56]:[^:]*:Brawler:1641:/
+1222.1 "Mega Beam" sync / 1[56]:[^:]*:Onslaughter:162E:/
+1223.7 "Attachment" sync / 1[56]:[^:]*:Brawler:163C:/
+1228.5 "Mirage" sync / 1[56]:[^:]*:Blaster Mirage:1658:/
+1229.8 "Rocket Drill" sync / 1[56]:[^:]*:Brawler:163F:/
+1232.6 "Mega Beam" sync / 1[56]:[^:]*:Onslaughter:162E:/
+1232.6 "Eye Of The Chakram" sync / 1[56]:[^:]*:Steam Chakram:1654:/
+1233.6 "Power Tackle" #sync / 1[56]:[^:]*:Blaster Mirage:165B:/
+1233.6 "Blinder" #sync / 1[56]:[^:]*:Blaster Mirage:165A:/
+1241.4 "Enumeration" sync / 1[56]:[^:]*:Swindler:1649:/
+1241.4 "Ultra Flash" sync / 1[56]:[^:]*:Vortexer:1656:/
 
 
 ### Phase 7: Gavel
-1252.1 "--targetable--" sync / 14:Brute Justice:166E:/ window 1255,100
-1257.1 "Justice" sync / 1[56]:Brute Justice:166E:/
-1264.2 "Verdict" sync / 1[56]:Brute Justice:166F:/
-1296.3 "Gavel" sync / 1[56]:Brute Justice:1670:/
+1252.1 "--targetable--" sync / 14:[^:]*:Brute Justice:166E:/ window 1255,100
+1257.1 "Justice" sync / 1[56]:[^:]*:Brute Justice:166E:/
+1264.2 "Verdict" sync / 1[56]:[^:]*:Brute Justice:166F:/
+1296.3 "Gavel" sync / 1[56]:[^:]*:Brute Justice:1670:/
 1304.4 "--untargetable--"
 
 
 ### Phase 8: Final Justice
-1307.6 "J Kick" sync / 1[56]:Brute Justice:166D:/
+1307.6 "J Kick" sync / 1[56]:[^:]*:Brute Justice:166D:/
 1310.6 "--targetable--"
-1313.7 "Link-Up" sync / 1[56]:Brute Justice:1673:/
-1324.8 "Final Punch" sync / 1[56]:Brute Justice:170C:/
-1326.0 "Final Apocalypse" sync / 1[56]:Brute Justice:1716:/
-1332.1 "Final Beam" sync / 1[56]:Brute Justice:1725:/
-1335.2 "Missile Command" sync / 1[56]:Brute Justice:1668:/
-1339.2 "Hidden Minefield" sync / 1[56]:Hidden Mine:165E:/ duration 9
-1340.3 "Flarethrower" sync / 1[56]:Brute Justice:1662:/
-1341.4 "Long Needle" sync / 1[56]:Brute Justice:166C:/
-1353.6 "Eye Of The Chakram" sync / 1[56]:Steam Chakram:1654:/
-1354.6 "Enumeration" sync / 1[56]:Brute Justice:1649:/
-1360.0 "Mega Beam" sync / 1[56]:Brute Justice:1664:/
-1365.1 "Super Jump" sync / 1[56]:Brute Justice:1665:/
-1371.3 "Flarethrower" sync / 1[56]:Brute Justice:1662:/
-1376.4 "Missile Command" sync / 1[56]:Brute Justice:1668:/
-1383.5 "Final Punch" sync / 1[56]:Brute Justice:170C:/
-1385.0 "Final Apocalypse" sync / 1[56]:Brute Justice:1716:/
-1391.1 "Final Beam" sync / 1[56]:Brute Justice:1725:/
+1313.7 "Link-Up" sync / 1[56]:[^:]*:Brute Justice:1673:/
+1324.8 "Final Punch" sync / 1[56]:[^:]*:Brute Justice:170C:/
+1326.0 "Final Apocalypse" sync / 1[56]:[^:]*:Brute Justice:1716:/
+1332.1 "Final Beam" sync / 1[56]:[^:]*:Brute Justice:1725:/
+1335.2 "Missile Command" sync / 1[56]:[^:]*:Brute Justice:1668:/
+1339.2 "Hidden Minefield" sync / 1[56]:[^:]*:Hidden Mine:165E:/ duration 9
+1340.3 "Flarethrower" sync / 1[56]:[^:]*:Brute Justice:1662:/
+1341.4 "Long Needle" sync / 1[56]:[^:]*:Brute Justice:166C:/
+1353.6 "Eye Of The Chakram" sync / 1[56]:[^:]*:Steam Chakram:1654:/
+1354.6 "Enumeration" sync / 1[56]:[^:]*:Brute Justice:1649:/
+1360.0 "Mega Beam" sync / 1[56]:[^:]*:Brute Justice:1664:/
+1365.1 "Super Jump" sync / 1[56]:[^:]*:Brute Justice:1665:/
+1371.3 "Flarethrower" sync / 1[56]:[^:]*:Brute Justice:1662:/
+1376.4 "Missile Command" sync / 1[56]:[^:]*:Brute Justice:1668:/
+1383.5 "Final Punch" sync / 1[56]:[^:]*:Brute Justice:170C:/
+1385.0 "Final Apocalypse" sync / 1[56]:[^:]*:Brute Justice:1716:/
+1391.1 "Final Beam" sync / 1[56]:[^:]*:Brute Justice:1725:/
 1398.2 "--untargetable--"
 
 
 ### Phase 9: J-Storm
-1401.4 "J Storm" sync / 1[56]:Brute Justice:1674:/ window 1500,1000
+1401.4 "J Storm" sync / 1[56]:[^:]*:Brute Justice:1674:/ window 1500,1000
 1403.4 "--targetable--"
-1407.5 "J Wave" sync / 1[56]:Brute Justice:1675:/ window 100,100
-1412.5 "J Wave" sync / 1[56]:Brute Justice:1675:/
-1417.5 "J Wave" sync / 1[56]:Brute Justice:1675:/
-1422.5 "J Wave" sync / 1[56]:Brute Justice:1675:/
-1427.5 "J Wave" sync / 1[56]:Brute Justice:1675:/
-1432.5 "J Wave" sync / 1[56]:Brute Justice:1675:/
-1437.5 "J Wave" sync / 1[56]:Brute Justice:1675:/
-1442.5 "J Wave" sync / 1[56]:Brute Justice:1675:/
-1447.5 "J Wave" sync / 1[56]:Brute Justice:1675:/
-1452.5 "J Wave" sync / 1[56]:Brute Justice:1675:/
+1407.5 "J Wave" sync / 1[56]:[^:]*:Brute Justice:1675:/ window 100,100
+1412.5 "J Wave" sync / 1[56]:[^:]*:Brute Justice:1675:/
+1417.5 "J Wave" sync / 1[56]:[^:]*:Brute Justice:1675:/
+1422.5 "J Wave" sync / 1[56]:[^:]*:Brute Justice:1675:/
+1427.5 "J Wave" sync / 1[56]:[^:]*:Brute Justice:1675:/
+1432.5 "J Wave" sync / 1[56]:[^:]*:Brute Justice:1675:/
+1437.5 "J Wave" sync / 1[56]:[^:]*:Brute Justice:1675:/
+1442.5 "J Wave" sync / 1[56]:[^:]*:Brute Justice:1675:/
+1447.5 "J Wave" sync / 1[56]:[^:]*:Brute Justice:1675:/
+1452.5 "J Wave" sync / 1[56]:[^:]*:Brute Justice:1675:/

--- a/ui/raidboss/data/03-hw/raid/a9s.txt
+++ b/ui/raidboss/data/03-hw/raid/a9s.txt
@@ -11,30 +11,30 @@ hideall "--sync--"
 ### Faust Z
 # -p 1A2B:1006.5
 1000.0	"--sync--"	sync / 00:0839::The Cranial Plate will be sealed off/ window 10000
-1006.5 "Kaltstrahl" sync / 1[56]:Faust Z:1A2B:/ window 1007,2.5
-1013.6 "Kaltstrahl" sync / 1[56]:Faust Z:1A2B:/
-1020.7 "Kaltstrahl" sync / 1[56]:Faust Z:1A2B:/
-1027.8 "Kaltstrahl" sync / 1[56]:Faust Z:1A2B:/
-1030.9 "Panzerschreck" sync / 1[56]:Faust Z:1A2C:/
-1038.0 "Kaltstrahl" sync / 1[56]:Faust Z:1A2B:/
-1045.1 "Kaltstrahl" sync / 1[56]:Faust Z:1A2B:/
-1052.2 "Kaltstrahl" sync / 1[56]:Faust Z:1A2B:/
-1055.3 "Panzerschreck x2" duration 2.1 #sync / 1[56]:Faust Z:1A2C:/
-1059.5 "Kaltstrahl" sync / 1[56]:Faust Z:1A2B:/
-1066.6 "Kaltstrahl" sync / 1[56]:Faust Z:1A2B:/
-1073.7 "Kaltstrahl" sync / 1[56]:Faust Z:1A2B:/
-1080.8 "Panzerschreck x2" duration 2.1 #sync / 1[56]:Faust Z:1A2C:/
-1085.0 "Kaltstrahl" sync / 1[56]:Faust Z:1A2B:/
-1092.2 "Kaltstrahl" sync / 1[56]:Faust Z:1A2B:/
-1099.3 "Kaltstrahl" sync / 1[56]:Faust Z:1A2B:/
-1106.4 "Panzerschreck x2" duration 2.1 #sync / 1[56]:Faust Z:1A2C:/
-1110.6 "Kaltstrahl" sync / 1[56]:Faust Z:1A2B:/
-1117.7 "Kaltstrahl" sync / 1[56]:Faust Z:1A2B:/
-1126.1 "Panzerschreck Enrage" sync / 1[56]:Faust Z:1A2D:/ window 1200,100
-1136.3 "Panzerschreck Enrage" #sync / 1[56]:Faust Z:1A2D:/
-1146.5 "Panzerschreck Enrage" #sync / 1[56]:Faust Z:1A2D:/
-1156.7 "Panzerschreck Enrage" #sync / 1[56]:Faust Z:1A2D:/
-1166.9 "Panzerschreck Enrage" #sync / 1[56]:Faust Z:1A2D:/
+1006.5 "Kaltstrahl" sync / 1[56]:[^:]*:Faust Z:1A2B:/ window 1007,2.5
+1013.6 "Kaltstrahl" sync / 1[56]:[^:]*:Faust Z:1A2B:/
+1020.7 "Kaltstrahl" sync / 1[56]:[^:]*:Faust Z:1A2B:/
+1027.8 "Kaltstrahl" sync / 1[56]:[^:]*:Faust Z:1A2B:/
+1030.9 "Panzerschreck" sync / 1[56]:[^:]*:Faust Z:1A2C:/
+1038.0 "Kaltstrahl" sync / 1[56]:[^:]*:Faust Z:1A2B:/
+1045.1 "Kaltstrahl" sync / 1[56]:[^:]*:Faust Z:1A2B:/
+1052.2 "Kaltstrahl" sync / 1[56]:[^:]*:Faust Z:1A2B:/
+1055.3 "Panzerschreck x2" duration 2.1 #sync / 1[56]:[^:]*:Faust Z:1A2C:/
+1059.5 "Kaltstrahl" sync / 1[56]:[^:]*:Faust Z:1A2B:/
+1066.6 "Kaltstrahl" sync / 1[56]:[^:]*:Faust Z:1A2B:/
+1073.7 "Kaltstrahl" sync / 1[56]:[^:]*:Faust Z:1A2B:/
+1080.8 "Panzerschreck x2" duration 2.1 #sync / 1[56]:[^:]*:Faust Z:1A2C:/
+1085.0 "Kaltstrahl" sync / 1[56]:[^:]*:Faust Z:1A2B:/
+1092.2 "Kaltstrahl" sync / 1[56]:[^:]*:Faust Z:1A2B:/
+1099.3 "Kaltstrahl" sync / 1[56]:[^:]*:Faust Z:1A2B:/
+1106.4 "Panzerschreck x2" duration 2.1 #sync / 1[56]:[^:]*:Faust Z:1A2C:/
+1110.6 "Kaltstrahl" sync / 1[56]:[^:]*:Faust Z:1A2B:/
+1117.7 "Kaltstrahl" sync / 1[56]:[^:]*:Faust Z:1A2B:/
+1126.1 "Panzerschreck Enrage" sync / 1[56]:[^:]*:Faust Z:1A2D:/ window 1200,100
+1136.3 "Panzerschreck Enrage" #sync / 1[56]:[^:]*:Faust Z:1A2D:/
+1146.5 "Panzerschreck Enrage" #sync / 1[56]:[^:]*:Faust Z:1A2D:/
+1156.7 "Panzerschreck Enrage" #sync / 1[56]:[^:]*:Faust Z:1A2D:/
+1166.9 "Panzerschreck Enrage" #sync / 1[56]:[^:]*:Faust Z:1A2D:/
 
 
 ### Refurbisher Zero
@@ -50,147 +50,147 @@ hideall "--sync--"
 
 # Phase 1
 2000.0	"--sync--"	sync / 00:0839::Life Support will be sealed off/ window 10000
-2010.0 "Stockpile" sync / 1[56]:Refurbisher 0:1A38:/ window 2010,5
-2012.1 "Right Arm Reassembly" sync / 1[56]:Refurbisher 0:1A2E:/
+2010.0 "Stockpile" sync / 1[56]:[^:]*:Refurbisher 0:1A38:/ window 2010,5
+2012.1 "Right Arm Reassembly" sync / 1[56]:[^:]*:Refurbisher 0:1A2E:/
 2014.3 "Power Generator x2 (NE)"
 2014.3 "Lava (NE)" duration 42
-2023.4 "Scrap" sync / 1[56]:Refurbisher 0:1A39:/
+2023.4 "Scrap" sync / 1[56]:[^:]*:Refurbisher 0:1A39:/
 2034.4 "--rocks fall--" #sync / 03:........:Scrap:/ 
-2039.6 "Scrap Burst" sync / 1[56]:Refurbisher 0:1A3A:/
-2048.8 "Scrap" sync / 1[56]:Refurbisher 0:1A39:/
-2055.9 "Scrap" sync / 1[56]:Refurbisher 0:1A39:/
+2039.6 "Scrap Burst" sync / 1[56]:[^:]*:Refurbisher 0:1A3A:/
+2048.8 "Scrap" sync / 1[56]:[^:]*:Refurbisher 0:1A39:/
+2055.9 "Scrap" sync / 1[56]:[^:]*:Refurbisher 0:1A39:/
 
 # Phase 2
-2066.0 "Stockpile" sync / 1[56]:Refurbisher 0:1A38:/
-2074.2 "Scrapline" sync / 1[56]:Refurbisher 0:1A3[CD]:/ window 30,30
+2066.0 "Stockpile" sync / 1[56]:[^:]*:Refurbisher 0:1A38:/
+2074.2 "Scrapline" sync / 1[56]:[^:]*:Refurbisher 0:1A3[CD]:/ window 30,30
 2078.2 "Power Generator x2 (SE)"
 2078.2 "Lava (SE)" duration 42
-2087.5 "Scrap" sync / 1[56]:Refurbisher 0:1A39:/
-2099.7 "Acid Rain" #sync / 1[56]:Refurbisher 0:1C0A:/
-2099.7 "Scrap" sync / 1[56]:Refurbisher 0:1A39:/
-2106.8 "Scrap" sync / 1[56]:Refurbisher 0:1A39:/
-2121.0 "Scrap Bomb" sync / 1[56]:Refurbisher 0:1A3E:/
+2087.5 "Scrap" sync / 1[56]:[^:]*:Refurbisher 0:1A39:/
+2099.7 "Acid Rain" #sync / 1[56]:[^:]*:Refurbisher 0:1C0A:/
+2099.7 "Scrap" sync / 1[56]:[^:]*:Refurbisher 0:1A39:/
+2106.8 "Scrap" sync / 1[56]:[^:]*:Refurbisher 0:1A39:/
+2121.0 "Scrap Bomb" sync / 1[56]:[^:]*:Refurbisher 0:1A3E:/
 
 # Phase 3
-2133.2 "Stockpile" sync / 1[56]:Refurbisher 0:1A38:/
-2141.4 "Scrapline" sync / 1[56]:Refurbisher 0:1A3[CD]:/ window 30,30
+2133.2 "Stockpile" sync / 1[56]:[^:]*:Refurbisher 0:1A38:/
+2141.4 "Scrapline" sync / 1[56]:[^:]*:Refurbisher 0:1A3[CD]:/ window 30,30
 2145.4 "Lava (NW)" duration 15
 2146.6 "Full-Metal Faust Add"
-2152.7 "Panzer Vor" sync / 1[56]:Full-Metal Faust:1C05:/
+2152.7 "Panzer Vor" sync / 1[56]:[^:]*:Full-Metal Faust:1C05:/
 2152.7 "--targetable--"
 2160.7 "Lava (NE)" duration 15
-2164.9 "Scrapline" sync / 1[56]:Refurbisher 0:1A3C:/
+2164.9 "Scrapline" sync / 1[56]:[^:]*:Refurbisher 0:1A3C:/
 2173.9 "Lava (SW)" duration 15
-2180.2 "Acid Rain" #sync / 1[56]:Refurbisher 0:1C0A:/
+2180.2 "Acid Rain" #sync / 1[56]:[^:]*:Refurbisher 0:1C0A:/
 2189.3 "Lava (SE)" duration 15
 2195.1 "--rocks fall--" #sync / 03:........:Scrap:/ 
-2200.3 "Scrap Burst" sync / 1[56]:Refurbisher 0:1A3A:/
+2200.3 "Scrap Burst" sync / 1[56]:[^:]*:Refurbisher 0:1A3A:/
 
 # Phase 4
-2215.5 "Stockpile" sync / 1[56]:Refurbisher 0:1A38:/
+2215.5 "Stockpile" sync / 1[56]:[^:]*:Refurbisher 0:1A38:/
 2226.5 "Power Generator x1 (SW)"
 2226.5 "Alarum x1 (SW)"
 2226.5 "Lava (SW)" duration 42
 2238.7 "--rocks fall--" #sync / 03:........:Scrap:/ 
-2243.9 "Scrap Burst" sync / 1[56]:Refurbisher 0:1A3A:/
-2253.1 "Scrap" sync / 1[56]:Refurbisher 0:1A39:/
-2260.2 "Scrap" sync / 1[56]:Refurbisher 0:1A39:/
-2269.4 "Scrap Bomb" sync / 1[56]:Refurbisher 0:1A3E:/
+2243.9 "Scrap Burst" sync / 1[56]:[^:]*:Refurbisher 0:1A3A:/
+2253.1 "Scrap" sync / 1[56]:[^:]*:Refurbisher 0:1A39:/
+2260.2 "Scrap" sync / 1[56]:[^:]*:Refurbisher 0:1A39:/
+2269.4 "Scrap Bomb" sync / 1[56]:[^:]*:Refurbisher 0:1A3E:/
 
 # Phase 5
-2281.6 "Stockpile" sync / 1[56]:Refurbisher 0:1A38:/
-2283.7 "Left Arm Reassembly" sync / 1[56]:Refurbisher 0:1A2F:/
-2294.9 "Double Scrapline" sync / 1[56]:Refurbisher 0:1A3[CD]:/ window 40,40
+2281.6 "Stockpile" sync / 1[56]:[^:]*:Refurbisher 0:1A38:/
+2283.7 "Left Arm Reassembly" sync / 1[56]:[^:]*:Refurbisher 0:1A2F:/
+2294.9 "Double Scrapline" sync / 1[56]:[^:]*:Refurbisher 0:1A3[CD]:/ window 40,40
 2298.9 "Power Generator x2 (NW)"
 2298.9 "Alarum x1 (NW)"
 2298.9 "Bomb x2 (NE)"
 2298.9 "Lava (NW)" duration 42
-2306.2 "Scrap" sync / 1[56]:Refurbisher 0:1A39:/
-2313.3 "Scrap" sync / 1[56]:Refurbisher 0:1A39:/
-2320.5 "Acid Rain" #sync / 1[56]:Refurbisher 0:1C0A:/
-2325.5 "Scrap" sync / 1[56]:Refurbisher 0:1A39:/
-2332.6 "Scrap" sync / 1[56]:Refurbisher 0:1A39:/
-2337.1 "Explosion (NE)" sync / 1[56]:Bomb:1A35:/
-2339.7 "Scrap" sync / 1[56]:Refurbisher 0:1A39:/
-2344.7 "Acid Rain" #sync / 1[56]:Refurbisher 0:1C0A:/
+2306.2 "Scrap" sync / 1[56]:[^:]*:Refurbisher 0:1A39:/
+2313.3 "Scrap" sync / 1[56]:[^:]*:Refurbisher 0:1A39:/
+2320.5 "Acid Rain" #sync / 1[56]:[^:]*:Refurbisher 0:1C0A:/
+2325.5 "Scrap" sync / 1[56]:[^:]*:Refurbisher 0:1A39:/
+2332.6 "Scrap" sync / 1[56]:[^:]*:Refurbisher 0:1A39:/
+2337.1 "Explosion (NE)" sync / 1[56]:[^:]*:Bomb:1A35:/
+2339.7 "Scrap" sync / 1[56]:[^:]*:Refurbisher 0:1A39:/
+2344.7 "Acid Rain" #sync / 1[56]:[^:]*:Refurbisher 0:1C0A:/
 
 # Phase 6
-2350.8 "Stockpile" sync / 1[56]:Refurbisher 0:1A38:/
-2361.0 "Double Scrapline" sync / 1[56]:Refurbisher 0:1A3[CD]:/ window 40,40
+2350.8 "Stockpile" sync / 1[56]:[^:]*:Refurbisher 0:1A38:/
+2361.0 "Double Scrapline" sync / 1[56]:[^:]*:Refurbisher 0:1A3[CD]:/ window 40,40
 2365.0 "Power Generator x1 (SW)"
 2365.0 "Alarum x1 (SW)"
 2365.0 "Bomb x2 (NW/SE)"
 2365.0 "Lava (NE/SW)" duration 42
-2376.4 "Scrap Bomb" sync / 1[56]:Refurbisher 0:1A3E:/
-2384.6 "Scrap" sync / 1[56]:Refurbisher 0:1A39:/
-2403.3 "Explosion (NW/SE)" sync / 1[56]:Bomb:1A35:/
+2376.4 "Scrap Bomb" sync / 1[56]:[^:]*:Refurbisher 0:1A3E:/
+2384.6 "Scrap" sync / 1[56]:[^:]*:Refurbisher 0:1A39:/
+2403.3 "Explosion (NW/SE)" sync / 1[56]:[^:]*:Bomb:1A35:/
 2398.5 "--rocks fall--" #sync / 03:........:Scrap:/ 
-2403.7 "Scrap Burst" sync / 1[56]:Refurbisher 0:1A3A:/
+2403.7 "Scrap Burst" sync / 1[56]:[^:]*:Refurbisher 0:1A3A:/
 
 # Phase 7
-2418.9 "Stockpile" sync / 1[56]:Refurbisher 0:1A38:/
-2429.1 "Double Scrapline" sync / 1[56]:Refurbisher 0:1A3[CD]:/ window 40,40
+2418.9 "Stockpile" sync / 1[56]:[^:]*:Refurbisher 0:1A38:/
+2429.1 "Double Scrapline" sync / 1[56]:[^:]*:Refurbisher 0:1A3[CD]:/ window 40,40
 2433.1 "Power Generator x2 (NW)"
 2433.1 "Alarum (NW)"
 2433.1 "Bomb x2 (NE)"
 2433.1 "Lava (NW)" duration 42
-2440.4 "Scrap" sync / 1[56]:Refurbisher 0:1A39:/
-2447.5 "Scrap" sync / 1[56]:Refurbisher 0:1A39:/
-2454.7 "Acid Rain" #sync / 1[56]:Refurbisher 0:1C0A:/
-2459.7 "Scrap" sync / 1[56]:Refurbisher 0:1A39:/
-2466.9 "Scrap" sync / 1[56]:Refurbisher 0:1A39:/
-2471.4 "Explosion (NE)" sync / 1[56]:Bomb:1A35:/
-2474.1 "Scrap" sync / 1[56]:Refurbisher 0:1A39:/
-2479.1 "Acid Rain" #sync / 1[56]:Refurbisher 0:1C0A:/
+2440.4 "Scrap" sync / 1[56]:[^:]*:Refurbisher 0:1A39:/
+2447.5 "Scrap" sync / 1[56]:[^:]*:Refurbisher 0:1A39:/
+2454.7 "Acid Rain" #sync / 1[56]:[^:]*:Refurbisher 0:1C0A:/
+2459.7 "Scrap" sync / 1[56]:[^:]*:Refurbisher 0:1A39:/
+2466.9 "Scrap" sync / 1[56]:[^:]*:Refurbisher 0:1A39:/
+2471.4 "Explosion (NE)" sync / 1[56]:[^:]*:Bomb:1A35:/
+2474.1 "Scrap" sync / 1[56]:[^:]*:Refurbisher 0:1A39:/
+2479.1 "Acid Rain" #sync / 1[56]:[^:]*:Refurbisher 0:1C0A:/
 
 # Phase 8
 # TODO: double check this phase timings against a clean pull
-2485.2 "Stockpile" sync / 1[56]:Refurbisher 0:1A38:/
-2495.4 "Double Scrapline" sync / 1[56]:Refurbisher 0:1A3[CD]:/ window 40,40
+2485.2 "Stockpile" sync / 1[56]:[^:]*:Refurbisher 0:1A38:/
+2495.4 "Double Scrapline" sync / 1[56]:[^:]*:Refurbisher 0:1A3[CD]:/ window 40,40
 2499.4 "Power Generator x1 (SW)"
 2499.4 "Alarum x1 (SW)"
 2499.4 "Bomb x2 (NW/SE)"
 2499.4 "Lava (NE/SW)" duration 42
-2510.8 "Scrap Bomb" sync / 1[56]:Refurbisher 0:1A3E:/
-2524.9 "Scrap" sync / 1[56]:Refurbisher 0:1A39:/
-2537.7 "Explosion (NW/SE)" sync / 1[56]:Bomb:1A35:/
-2546.1 "Scrap Storm" sync / 1[56]:Refurbisher 0:1A3B:/
+2510.8 "Scrap Bomb" sync / 1[56]:[^:]*:Refurbisher 0:1A3E:/
+2524.9 "Scrap" sync / 1[56]:[^:]*:Refurbisher 0:1A39:/
+2537.7 "Explosion (NW/SE)" sync / 1[56]:[^:]*:Bomb:1A35:/
+2546.1 "Scrap Storm" sync / 1[56]:[^:]*:Refurbisher 0:1A3B:/
 
 ### Enrage
-2554.3 "Stockpile" sync / 1[56]:Refurbisher 0:1A38:/
-2556.5 "Heat Shielding Reassembly" sync / 1[56]:Refurbisher 0:1A30:/
-2562.6 "Scrap Storm Enrage" sync / 1[56]:Refurbisher 0:1A3B:/
+2554.3 "Stockpile" sync / 1[56]:[^:]*:Refurbisher 0:1A38:/
+2556.5 "Heat Shielding Reassembly" sync / 1[56]:[^:]*:Refurbisher 0:1A30:/
+2562.6 "Scrap Storm Enrage" sync / 1[56]:[^:]*:Refurbisher 0:1A3B:/
 
 
 ### Post-enrage timeline science
-2572.7 "Double Scrapline" sync / 1[56]:Refurbisher 0:1A3[CD]:/ window 40,40
+2572.7 "Double Scrapline" sync / 1[56]:[^:]*:Refurbisher 0:1A3[CD]:/ window 40,40
 2576.7 "Power Generator x1 (NW)"
 2576.7 "Alarum x1 (NW)"
 2576.7 "Bomb x2 (NE)"
 2576.7 "Lava (NW)" duration 42
-2584.0 "Scrap" sync / 1[56]:Refurbisher 0:1A39:/
-2591.1 "Scrap" sync / 1[56]:Refurbisher 0:1A39:/
-2598.3 "Acid Rain" #sync / 1[56]:Refurbisher 0:1C0A:/
-2603.3 "Scrap" sync / 1[56]:Refurbisher 0:1A39:/
-2610.5 "Scrap" sync / 1[56]:Refurbisher 0:1A39:/
-2615.0 "Explosion (NE)" sync / 1[56]:Bomb:1A35:/
-2617.6 "Scrap" sync / 1[56]:Refurbisher 0:1A39:/
-2622.6 "Acid Rain" #sync / 1[56]:Refurbisher 0:1C0A:/
+2584.0 "Scrap" sync / 1[56]:[^:]*:Refurbisher 0:1A39:/
+2591.1 "Scrap" sync / 1[56]:[^:]*:Refurbisher 0:1A39:/
+2598.3 "Acid Rain" #sync / 1[56]:[^:]*:Refurbisher 0:1C0A:/
+2603.3 "Scrap" sync / 1[56]:[^:]*:Refurbisher 0:1A39:/
+2610.5 "Scrap" sync / 1[56]:[^:]*:Refurbisher 0:1A39:/
+2615.0 "Explosion (NE)" sync / 1[56]:[^:]*:Bomb:1A35:/
+2617.6 "Scrap" sync / 1[56]:[^:]*:Refurbisher 0:1A39:/
+2622.6 "Acid Rain" #sync / 1[56]:[^:]*:Refurbisher 0:1C0A:/
 
-2628.7 "Stockpile" sync / 1[56]:Refurbisher 0:1A38:/
-2638.9 "Double Scrapline" sync / 1[56]:Refurbisher 0:1A3[CD]:/ window 40,40
+2628.7 "Stockpile" sync / 1[56]:[^:]*:Refurbisher 0:1A38:/
+2638.9 "Double Scrapline" sync / 1[56]:[^:]*:Refurbisher 0:1A3[CD]:/ window 40,40
 2642.9 "Power Generator x1 (SW)"
 2642.9 "Alarum x1 (SW)"
 2642.9 "Bomb x2 (NW/SE)"
 2642.9 "Lava (NE/SW)" duration 42
-2654.4 "Scrap Bomb" sync / 1[56]:Refurbisher 0:1A3E:/
+2654.4 "Scrap Bomb" sync / 1[56]:[^:]*:Refurbisher 0:1A3E:/
 
 # 11 minute less soft enrage, in case you weren't killed by previous enrage.
-2659.2 "--sync--" sync / 14:Refurbisher 0:1A3B:/ window 50,10000
-2659.5 "Scrap Storm Enrage" sync / 1[56]:Refurbisher 0:1A3B:/
-2659.5 "Scrap Storm Enrage" #sync / 1[56]:Refurbisher 0:1A3B:/
-2667.7 "Scrap Storm Enrage" #sync / 1[56]:Refurbisher 0:1A3B:/
-2675.9 "Scrap Storm Enrage" #sync / 1[56]:Refurbisher 0:1A3B:/
-2684.1 "Scrap Storm Enrage" #sync / 1[56]:Refurbisher 0:1A3B:/
-2692.3 "Scrap Storm Enrage" #sync / 1[56]:Refurbisher 0:1A3B:/
+2659.2 "--sync--" sync / 14:[^:]*:Refurbisher 0:1A3B:/ window 50,10000
+2659.5 "Scrap Storm Enrage" sync / 1[56]:[^:]*:Refurbisher 0:1A3B:/
+2659.5 "Scrap Storm Enrage" #sync / 1[56]:[^:]*:Refurbisher 0:1A3B:/
+2667.7 "Scrap Storm Enrage" #sync / 1[56]:[^:]*:Refurbisher 0:1A3B:/
+2675.9 "Scrap Storm Enrage" #sync / 1[56]:[^:]*:Refurbisher 0:1A3B:/
+2684.1 "Scrap Storm Enrage" #sync / 1[56]:[^:]*:Refurbisher 0:1A3B:/
+2692.3 "Scrap Storm Enrage" #sync / 1[56]:[^:]*:Refurbisher 0:1A3B:/
 # &c &c &c

--- a/ui/raidboss/data/03-hw/trial/ravana-ex.txt
+++ b/ui/raidboss/data/03-hw/trial/ravana-ex.txt
@@ -12,24 +12,24 @@ hideall "--sync--"
 # Any displayed phase lengths are the maximum that could occur with no "extra" Bloodlust.
 
 0.0 "--sync--" sync /:Engage!/ window 0,1
-1.2 "--sync--" sync / 1[56]:Ravana:13E4:/ window 1.2,1
-7.1 "Blinding Blade" sync / 1[56]:Ravana:E9F:/ window 7.1,10
-11.9 "The Seeing" sync / 1[56]:Ravana:EA[012]:/
-16.0 "Atma-Linga" sync / 1[56]:Ravana:EA6:/
-22.2 "Tapasya x3" sync / 1[56]:Ravana:EA4:/ window 20,20
-29.4 "Atma-Linga" sync / 1[56]:Ravana:EA6:/
-32.5 "Blinding Blade" sync / 1[56]:Ravana:E9F:/
-37.3 "The Seeing" sync / 1[56]:Ravana:EA[012]:/
-42.5 "Atma-Linga" sync / 1[56]:Ravana:EA6:/
+1.2 "--sync--" sync / 1[56]:[^:]*:Ravana:13E4:/ window 1.2,1
+7.1 "Blinding Blade" sync / 1[56]:[^:]*:Ravana:E9F:/ window 7.1,10
+11.9 "The Seeing" sync / 1[56]:[^:]*:Ravana:EA[012]:/
+16.0 "Atma-Linga" sync / 1[56]:[^:]*:Ravana:EA6:/
+22.2 "Tapasya x3" sync / 1[56]:[^:]*:Ravana:EA4:/ window 20,20
+29.4 "Atma-Linga" sync / 1[56]:[^:]*:Ravana:EA6:/
+32.5 "Blinding Blade" sync / 1[56]:[^:]*:Ravana:E9F:/
+37.3 "The Seeing" sync / 1[56]:[^:]*:Ravana:EA[012]:/
+42.5 "Atma-Linga" sync / 1[56]:[^:]*:Ravana:EA6:/
 
-51.7 "Blinding Blade" sync / 1[56]:Ravana:E9F:/
-56.5 "The Seeing" sync / 1[56]:Ravana:EA[012]:/
-60.6 "Atma-Linga" sync / 1[56]:Ravana:EA6:/
-66.8 "Tapasya x3" sync / 1[56]:Ravana:EA4:/ window 20,20
-74.0 "Atma-Linga" sync / 1[56]:Ravana:EA6:/
-77.1 "Blinding Blade" sync / 1[56]:Ravana:E9F:/
-81.9 "The Seeing" sync / 1[56]:Ravana:EA[012]:/
-87.1 "Atma-Linga" sync / 1[56]:Ravana:EA6:/ jump 42.5
+51.7 "Blinding Blade" sync / 1[56]:[^:]*:Ravana:E9F:/
+56.5 "The Seeing" sync / 1[56]:[^:]*:Ravana:EA[012]:/
+60.6 "Atma-Linga" sync / 1[56]:[^:]*:Ravana:EA6:/
+66.8 "Tapasya x3" sync / 1[56]:[^:]*:Ravana:EA4:/ window 20,20
+74.0 "Atma-Linga" sync / 1[56]:[^:]*:Ravana:EA6:/
+77.1 "Blinding Blade" sync / 1[56]:[^:]*:Ravana:E9F:/
+81.9 "The Seeing" sync / 1[56]:[^:]*:Ravana:EA[012]:/
+87.1 "Atma-Linga" sync / 1[56]:[^:]*:Ravana:EA6:/ jump 42.5
 
 96.3 "Blinding Blade"
 101.1 "The Seeing"
@@ -40,138 +40,138 @@ hideall "--sync--"
 126.5 "The Seeing"
 
 # Block initiates at 100 bloodlust. Loosely linked to HP%, exact connection unknown.
-150.0 "Scorpion Avatar" sync / 1[56]:Ravana:E81:/ window 150,5
-155.2 "Blades Of Carnage And Liberation" sync / 1[56]:Ravana:137A:/
-175.3 "Prelude To Liberation" sync / 1[56]:Ravana:EBC:/
+150.0 "Scorpion Avatar" sync / 1[56]:[^:]*:Ravana:E81:/ window 150,5
+155.2 "Blades Of Carnage And Liberation" sync / 1[56]:[^:]*:Ravana:137A:/
+175.3 "Prelude To Liberation" sync / 1[56]:[^:]*:Ravana:EBC:/
 175.3 "--untargetable--"
-182.4 "Prelude To Liberation (Flames)" sync / 1[56]:Ravana:EBD:/
-183.4 "--sync--" sync / 1[56]:Ravana:13BC:/
-189.6 "Prelude To Liberation (Circles)" sync / 1[56]:Ravana:EBF:/
+182.4 "Prelude To Liberation (Flames)" sync / 1[56]:[^:]*:Ravana:EBD:/
+183.4 "--sync--" sync / 1[56]:[^:]*:Ravana:13BC:/
+189.6 "Prelude To Liberation (Circles)" sync / 1[56]:[^:]*:Ravana:EBF:/
 194.8 "--targetable--"
-195.0 "Blades Of Carnage And Liberation" sync / 1[56]:Ravana:137A:/
-215.6 "Liberation" sync / 1[56]:Ravana:EC0:/
+195.0 "Blades Of Carnage And Liberation" sync / 1[56]:[^:]*:Ravana:137A:/
+215.6 "Liberation" sync / 1[56]:[^:]*:Ravana:EC0:/
 215.6 "--untargetable--"
-219.8 "Clone Spawn 1" # sync / 1[56]:Ravana:EC1:/
-220.8 "Clone Spawn 2" # sync / 1[56]:Ravana:EC1:/
-221.8 "Clone Spawn 3" # sync / 1[56]:Ravana:EC1:/
-222.8 "Clone Spawn 4" # sync / 1[56]:Ravana:EC1:/
-226.9 "Clone Dash 1" # sync / 1[56]:Ravana:EC2:/
-228.4 "Clone Dash 2" # sync / 1[56]:Ravana:EC2:/
-229.9 "Clone Dash 3" # sync / 1[56]:Ravana:EC2:/
-231.4 "Clone Dash 4" # sync / 1[56]:Ravana:EC2:/
+219.8 "Clone Spawn 1" # sync / 1[56]:[^:]*:Ravana:EC1:/
+220.8 "Clone Spawn 2" # sync / 1[56]:[^:]*:Ravana:EC1:/
+221.8 "Clone Spawn 3" # sync / 1[56]:[^:]*:Ravana:EC1:/
+222.8 "Clone Spawn 4" # sync / 1[56]:[^:]*:Ravana:EC1:/
+226.9 "Clone Dash 1" # sync / 1[56]:[^:]*:Ravana:EC2:/
+228.4 "Clone Dash 2" # sync / 1[56]:[^:]*:Ravana:EC2:/
+229.9 "Clone Dash 3" # sync / 1[56]:[^:]*:Ravana:EC2:/
+231.4 "Clone Dash 4" # sync / 1[56]:[^:]*:Ravana:EC2:/
 235.6 "--targetable--"
 
 # Initiates immediately following Liberation block.
-235.7 "Dragonfly Avatar" sync / 1[56]:Ravana:E80:/
-242.8 "Warlord Shell" sync / 1[56]:Ravana:EB1:/
-247.6 "The Seeing" sync / 1[56]:Ravana:EA[012]:/
-255.4 "The Seeing" sync / 1[56]:Ravana:EA[012]:/
-264.6 "Warlord Flame?" sync / 1[56]:Ravana:EB2:/ # Skipped if Ravana's shield is burned.
-267.8 "--sync--" sync / 1[56]:Ravana:EB0:/
-272.0 "Tapasya x3" sync / 1[56]:Ravana:EA4:/ window 30,5
-279.1 "Atma-Linga" sync / 1[56]:Ravana:EA6:/
-286.8 "The Seeing" sync / 1[56]:Ravana:EA[012]:/
-290.9 "Atma-Linga" sync / 1[56]:Ravana:EA6:/
-296.2 "Tapasya x3" sync / 1[56]:Ravana:EA4:/
-303.3 "Atma-Linga" sync / 1[56]:Ravana:EA6:/
-306.4 "Blinding Blade" sync / 1[56]:Ravana:E9F:/
-309.5 "Atma-Linga" sync / 1[56]:Ravana:EA6:/
-312.7 "Tapasya x3" sync / 1[56]:Ravana:EA4:/
-320.8 "Blinding Blade" sync / 1[56]:Ravana:E9F:/
-325.5 "The Seeing" sync / 1[56]:Ravana:EA[012]:/
-330.7 "Atma-Linga x2" # sync / 1[56]:Ravana:EA6:/
+235.7 "Dragonfly Avatar" sync / 1[56]:[^:]*:Ravana:E80:/
+242.8 "Warlord Shell" sync / 1[56]:[^:]*:Ravana:EB1:/
+247.6 "The Seeing" sync / 1[56]:[^:]*:Ravana:EA[012]:/
+255.4 "The Seeing" sync / 1[56]:[^:]*:Ravana:EA[012]:/
+264.6 "Warlord Flame?" sync / 1[56]:[^:]*:Ravana:EB2:/ # Skipped if Ravana's shield is burned.
+267.8 "--sync--" sync / 1[56]:[^:]*:Ravana:EB0:/
+272.0 "Tapasya x3" sync / 1[56]:[^:]*:Ravana:EA4:/ window 30,5
+279.1 "Atma-Linga" sync / 1[56]:[^:]*:Ravana:EA6:/
+286.8 "The Seeing" sync / 1[56]:[^:]*:Ravana:EA[012]:/
+290.9 "Atma-Linga" sync / 1[56]:[^:]*:Ravana:EA6:/
+296.2 "Tapasya x3" sync / 1[56]:[^:]*:Ravana:EA4:/
+303.3 "Atma-Linga" sync / 1[56]:[^:]*:Ravana:EA6:/
+306.4 "Blinding Blade" sync / 1[56]:[^:]*:Ravana:E9F:/
+309.5 "Atma-Linga" sync / 1[56]:[^:]*:Ravana:EA6:/
+312.7 "Tapasya x3" sync / 1[56]:[^:]*:Ravana:EA4:/
+320.8 "Blinding Blade" sync / 1[56]:[^:]*:Ravana:E9F:/
+325.5 "The Seeing" sync / 1[56]:[^:]*:Ravana:EA[012]:/
+330.7 "Atma-Linga x2" # sync / 1[56]:[^:]*:Ravana:EA6:/
 
 # The intermission can have 0-10 Laughing Moon charges before Ravana uses the Chandrahas ultimate.
 # The number is dependent on how many Gana are able to finish their Falling Laughter casts.
 # More than 1-2 is typically a wipe, as each inflicts a Vulnerability Up stack to the party.
-336.8 "Bloody Fuller" sync / 14:Ravana:EB3:/ duration 4.7 window 336.8,5
+336.8 "Bloody Fuller" sync / 14:[^:]*:Ravana:EB3:/ duration 4.7 window 336.8,5
 341.1 "--untargetable--"
 
-400.0 "Chandrahas" sync / 1[56]:Ravana:EB5:/ window 400,5
-413.9 "Beetle Avatar" sync / 1[56]:Ravana:E82:/ window 15,15
+400.0 "Chandrahas" sync / 1[56]:[^:]*:Ravana:EB5:/ window 400,5
+413.9 "Beetle Avatar" sync / 1[56]:[^:]*:Ravana:E82:/ window 15,15
 414.0 "--targetable--" # Technically slightly before, but invulnerability drops here.
-422.0 "Pillars Of Heaven" sync / 1[56]:Ravana:EB8:/
-429.1 "--sync--" sync / 1[56]:Ravana:EB9:/
+422.0 "Pillars Of Heaven" sync / 1[56]:[^:]*:Ravana:EB8:/
+429.1 "--sync--" sync / 1[56]:[^:]*:Ravana:EB9:/
 429.8 "Laughing Rose" # The EB9 skill resolves well before the damage displays
-445.4 "Surpanakha x4" # sync / 1[56]:Ravana:EBA:/
-453.1 "The Rose Of Conviction" sync / 1[56]:Ravana:EB6:/
-460.2 "The Rose Of Hate" sync / 1[56]:Ravana:EBB:/
-465.4 "Surpanakha x7" # sync / 1[56]:Ravana:EBA:/
-466.3 "The Rose Of Conquest" sync / 1[56]:Ravana's Will:EB7:/
-485.8 "Pillars Of Heaven" sync / 1[56]:Ravana:EB8:/
-493.0 "--sync--" sync / 1[56]:Ravana:EB9:/
+445.4 "Surpanakha x4" # sync / 1[56]:[^:]*:Ravana:EBA:/
+453.1 "The Rose Of Conviction" sync / 1[56]:[^:]*:Ravana:EB6:/
+460.2 "The Rose Of Hate" sync / 1[56]:[^:]*:Ravana:EBB:/
+465.4 "Surpanakha x7" # sync / 1[56]:[^:]*:Ravana:EBA:/
+466.3 "The Rose Of Conquest" sync / 1[56]:[^:]*:Ravana's Will:EB7:/
+485.8 "Pillars Of Heaven" sync / 1[56]:[^:]*:Ravana:EB8:/
+493.0 "--sync--" sync / 1[56]:[^:]*:Ravana:EB9:/
 493.7 "Laughing Rose"
-506.2 "Surpanakha x7?" # sync / 1[56]:Ravana:EBA:/
+506.2 "Surpanakha x7?" # sync / 1[56]:[^:]*:Ravana:EBA:/
 # This phase ends at 100 Bloodlust.
 
-514.0 "Scorpion Avatar" sync / 1[56]:Ravana:E81:/ window 114,5
-514.1 "--sync--" sync / 1[56]:Ravana:13BF:/
-519.2 "Blades Of Carnage And Liberation" sync / 1[56]:Ravana:137A:/
-540.4 "Swift Liberation" sync / 1[56]:Ravana:EA7:/
+514.0 "Scorpion Avatar" sync / 1[56]:[^:]*:Ravana:E81:/ window 114,5
+514.1 "--sync--" sync / 1[56]:[^:]*:Ravana:13BF:/
+519.2 "Blades Of Carnage And Liberation" sync / 1[56]:[^:]*:Ravana:137A:/
+540.4 "Swift Liberation" sync / 1[56]:[^:]*:Ravana:EA7:/
 540.4 "--untargetable--"
-540.5 "Swift Liberation Dash 1" # sync / 1[56]:Ravana:EA8:/
-543.5 "Swift Liberation Dash 2" # sync / 1[56]:Ravana:EA8:/
-546.5 "Swift Liberation Dash 3" # sync / 1[56]:Ravana:EA8:/
-549.5 "Swift Liberation Dash 4" # sync / 1[56]:Ravana:EA8:/
-552.7 "Swift Liberation (Flames)" # sync / 1[56]:Ravana:EA9:/
-556.9 "Swift Liberation (Circles)" # sync / 1[56]:Ravana:EAB:/
+540.5 "Swift Liberation Dash 1" # sync / 1[56]:[^:]*:Ravana:EA8:/
+543.5 "Swift Liberation Dash 2" # sync / 1[56]:[^:]*:Ravana:EA8:/
+546.5 "Swift Liberation Dash 3" # sync / 1[56]:[^:]*:Ravana:EA8:/
+549.5 "Swift Liberation Dash 4" # sync / 1[56]:[^:]*:Ravana:EA8:/
+552.7 "Swift Liberation (Flames)" # sync / 1[56]:[^:]*:Ravana:EA9:/
+556.9 "Swift Liberation (Circles)" # sync / 1[56]:[^:]*:Ravana:EAB:/
 562.1 "--targetable--"
-562.3 "Blades Of Carnage And Liberation" sync / 1[56]:Ravana:137A:/ window 20,20
-583.5 "Final Liberation" sync / 1[56]:Ravana:EAC:/
+562.3 "Blades Of Carnage And Liberation" sync / 1[56]:[^:]*:Ravana:137A:/ window 20,20
+583.5 "Final Liberation" sync / 1[56]:[^:]*:Ravana:EAC:/
 583.5 "--untargetable--"
-583.6 "Final Liberation (1st Double Prey)" sync / 1[56]:Ravana:EAD:/
-591.6 "Final Liberation (2nd Double Prey)" sync / 1[56]:Ravana:EAD:/
-597.7 "--sync--" sync / 1[56]:Ravana:13C4:/
-597.7 "Final Liberation (Outer AoE)" sync / 1[56]:Ravana:EAE:/
+583.6 "Final Liberation (1st Double Prey)" sync / 1[56]:[^:]*:Ravana:EAD:/
+591.6 "Final Liberation (2nd Double Prey)" sync / 1[56]:[^:]*:Ravana:EAD:/
+597.7 "--sync--" sync / 1[56]:[^:]*:Ravana:13C4:/
+597.7 "Final Liberation (Outer AoE)" sync / 1[56]:[^:]*:Ravana:EAE:/
 598.9 "--targetable--"
-603.9 "Final Liberation (Inner AoE)" sync / 1[56]:Ravana:EAF:/
+603.9 "Final Liberation (Inner AoE)" sync / 1[56]:[^:]*:Ravana:EAF:/
 603.9 "--untargetable--"
 610.1 "--targetable--"
 
-610.2 "Dragonfly Avatar" sync / 1[56]:Ravana:E80:/ window 96,20
-610.3 "--sync--" sync / 1[56]:Ravana:1299:/
-617.3 "Warlord Shell" sync / 1[56]:Ravana:EB1:/
-622.5 "The Seeing" sync / 1[56]:Ravana:EA[012]:/
-626.7 "Atma-Linga" sync / 1[56]:Ravana:EA6:/
-631.0 "The Seeing" sync / 1[56]:Ravana:EA[012]:/
+610.2 "Dragonfly Avatar" sync / 1[56]:[^:]*:Ravana:E80:/ window 96,20
+610.3 "--sync--" sync / 1[56]:[^:]*:Ravana:1299:/
+617.3 "Warlord Shell" sync / 1[56]:[^:]*:Ravana:EB1:/
+622.5 "The Seeing" sync / 1[56]:[^:]*:Ravana:EA[012]:/
+626.7 "Atma-Linga" sync / 1[56]:[^:]*:Ravana:EA6:/
+631.0 "The Seeing" sync / 1[56]:[^:]*:Ravana:EA[012]:/
 
 # If Blessing of Earth is not damaged off Ravana, he uses Warlord Flame at 640.2.
 # If it is, Flame is skipped and things go directly to Blinding Blade.
 # We assume the skip, and re-sync if it doesn't happen.
-636.4 "--sync--" sync / 1[56]:Ravana:EB2:/ window 15,15
-640.2 "Blinding Blade/Warlord Flame?" sync / 1[56]:Ravana:E9F:/ window 30,2.5
-643.3 "Atma-Linga" sync / 1[56]:Ravana:EA6:/
-646.1 "Tapasya x3" sync / 1[56]:Ravana:EA4:/
-652.2 "Atma-Linga" sync / 1[56]:Ravana:EA6:/
-655.3 "Blinding Blade" sync / 1[56]:Ravana:E9F:/
-658.4 "Atma-Linga x2" # sync / 1[56]:Ravana:EA6:/
-663.1 "Tapasya x3" sync / 1[56]:Ravana:EA4:/
-669.2 "Blinding Blade" sync / 1[56]:Ravana:E9F:/
-672.3 "Atma-Linga" sync / 1[56]:Ravana:EA6:/
+636.4 "--sync--" sync / 1[56]:[^:]*:Ravana:EB2:/ window 15,15
+640.2 "Blinding Blade/Warlord Flame?" sync / 1[56]:[^:]*:Ravana:E9F:/ window 30,2.5
+643.3 "Atma-Linga" sync / 1[56]:[^:]*:Ravana:EA6:/
+646.1 "Tapasya x3" sync / 1[56]:[^:]*:Ravana:EA4:/
+652.2 "Atma-Linga" sync / 1[56]:[^:]*:Ravana:EA6:/
+655.3 "Blinding Blade" sync / 1[56]:[^:]*:Ravana:E9F:/
+658.4 "Atma-Linga x2" # sync / 1[56]:[^:]*:Ravana:EA6:/
+663.1 "Tapasya x3" sync / 1[56]:[^:]*:Ravana:EA4:/
+669.2 "Blinding Blade" sync / 1[56]:[^:]*:Ravana:E9F:/
+672.3 "Atma-Linga" sync / 1[56]:[^:]*:Ravana:EA6:/
 
-679.5 "Blinding Blade" sync / 1[56]:Ravana:E9F:/
-682.6 "Atma-Linga" sync / 1[56]:Ravana:EA6:/
-685.0 "Tapasya x3" sync / 1[56]:Ravana:EA4:/
-691.2 "Atma-Linga" sync / 1[56]:Ravana:EA6:/
-694.3 "Blinding Blade" sync / 1[56]:Ravana:E9F:/
-697.4 "Atma-Linga x2" # sync / 1[56]:Ravana:EA6:/
-701.7 "Tapasya x3" sync / 1[56]:Ravana:EA4:/
-708.1 "Blinding Blade" sync / 1[56]:Ravana:E9F:/
-711.2 "Atma-Linga" sync / 1[56]:Ravana:EA6:/
-718.3 "Blinding Blade" sync / 1[56]:Ravana:E9F:/
+679.5 "Blinding Blade" sync / 1[56]:[^:]*:Ravana:E9F:/
+682.6 "Atma-Linga" sync / 1[56]:[^:]*:Ravana:EA6:/
+685.0 "Tapasya x3" sync / 1[56]:[^:]*:Ravana:EA4:/
+691.2 "Atma-Linga" sync / 1[56]:[^:]*:Ravana:EA6:/
+694.3 "Blinding Blade" sync / 1[56]:[^:]*:Ravana:E9F:/
+697.4 "Atma-Linga x2" # sync / 1[56]:[^:]*:Ravana:EA6:/
+701.7 "Tapasya x3" sync / 1[56]:[^:]*:Ravana:EA4:/
+708.1 "Blinding Blade" sync / 1[56]:[^:]*:Ravana:E9F:/
+711.2 "Atma-Linga" sync / 1[56]:[^:]*:Ravana:EA6:/
+718.3 "Blinding Blade" sync / 1[56]:[^:]*:Ravana:E9F:/
 
-721.4 "Atma-Linga" sync / 1[56]:Ravana:EA6:/
-723.9 "Tapasya x3" sync / 1[56]:Ravana:EA4:/
-730.0 "Atma-Linga" sync / 1[56]:Ravana:EA6:/
+721.4 "Atma-Linga" sync / 1[56]:[^:]*:Ravana:EA6:/
+723.9 "Tapasya x3" sync / 1[56]:[^:]*:Ravana:EA4:/
+730.0 "Atma-Linga" sync / 1[56]:[^:]*:Ravana:EA6:/
 
-736.5 "Beetle Avatar" sync / 1[56]:Ravana:E82:/ window 130,10 jump 413.9
+736.5 "Beetle Avatar" sync / 1[56]:[^:]*:Ravana:E82:/ window 130,10 jump 413.9
 744.6 "Pillars Of Heaven"
 751.7 "Laughing Rose"
 768.0 "Surpanakha x4"
 
 # Enrage follows this sequence, but unfortunately there's no way to sync to it.
-# 1781.6 "Dragonfly Avatar" sync / 1[56]:Ravana:E80:/
-# 1781.7 "--sync--" sync / 1[56]:Ravana:1299:/
+# 1781.6 "Dragonfly Avatar" sync / 1[56]:[^:]*:Ravana:E80:/
+# 1781.7 "--sync--" sync / 1[56]:[^:]*:Ravana:1299:/
 # 1786.7 "--untargetable--"
-# 1791.8 "Bloody Fuller" sync / 1[56]:Ravana:EB3:/
+# 1791.8 "Bloody Fuller" sync / 1[56]:[^:]*:Ravana:EB3:/
 # Laughing Moon until wipe

--- a/ui/raidboss/data/03-hw/trial/sephirot-ex.txt
+++ b/ui/raidboss/data/03-hw/trial/sephirot-ex.txt
@@ -10,43 +10,43 @@ hideall "--sync--"
 0.0 "--Reset--" sync / 21:........:40000010:/ window 100000 jump 0
 
 0.0 "--sync--" sync /:Engage!/ window 0,1
-2.5 "--sync--" sync / 1[56]:Sephirot:368:/ window 2.5,1
-7.1 "Triple Trial" sync / 1[56]:Sephirot:1566:/ window 7.1,5
-11.2 "Tiferet" sync / 1[56]:Sephirot:1568:/
-17.4 "Tiferet" sync / 1[56]:Sephirot:1568:/
+2.5 "--sync--" sync / 1[56]:[^:]*:Sephirot:368:/ window 2.5,1
+7.1 "Triple Trial" sync / 1[56]:[^:]*:Sephirot:1566:/ window 7.1,5
+11.2 "Tiferet" sync / 1[56]:[^:]*:Sephirot:1568:/
+17.4 "Tiferet" sync / 1[56]:[^:]*:Sephirot:1568:/
 
 # Phase 1 rotation block, 76.3 seconds
-21.6 "Triple Trial" sync / 1[56]:Sephirot:1566:/
-25.6 "Ein Sof" sync / 1[56]:Sephirot:156E:/
-29.7 "Tiferet" sync / 1[56]:Sephirot:1568:/
-38.3 "Fiendish Rage 1" sync / 1[56]:Sephirot:156D:/
-42.0 "Fiendish Rage 2" sync / 1[56]:Sephirot:156D:/
-49.2 "Tiferet" sync / 1[56]:Sephirot:1568:/
-53.3 "Tiferet" sync / 1[56]:Sephirot:1568:/
-59.4 "Chesed" sync / 1[56]:Sephirot:1567:/ window 20,20
-61.6 "Triple Trial" sync / 1[56]:Sephirot:1566:/
-67.7 "Ein Sof" sync / 1[56]:Sephirot:156E:/
-70.9 "Tiferet" sync / 1[56]:Sephirot:1568:/
-81.3 "Ratzon" # sync / 1[56]:Sephirot:156B:/
-85.5 "Tiferet" sync / 1[56]:Sephirot:1568:/
-89.6 "Tiferet" sync / 1[56]:Sephirot:1568:/
-95.7 "Chesed" sync / 1[56]:Sephirot:1567:/ window 20,20
+21.6 "Triple Trial" sync / 1[56]:[^:]*:Sephirot:1566:/
+25.6 "Ein Sof" sync / 1[56]:[^:]*:Sephirot:156E:/
+29.7 "Tiferet" sync / 1[56]:[^:]*:Sephirot:1568:/
+38.3 "Fiendish Rage 1" sync / 1[56]:[^:]*:Sephirot:156D:/
+42.0 "Fiendish Rage 2" sync / 1[56]:[^:]*:Sephirot:156D:/
+49.2 "Tiferet" sync / 1[56]:[^:]*:Sephirot:1568:/
+53.3 "Tiferet" sync / 1[56]:[^:]*:Sephirot:1568:/
+59.4 "Chesed" sync / 1[56]:[^:]*:Sephirot:1567:/ window 20,20
+61.6 "Triple Trial" sync / 1[56]:[^:]*:Sephirot:1566:/
+67.7 "Ein Sof" sync / 1[56]:[^:]*:Sephirot:156E:/
+70.9 "Tiferet" sync / 1[56]:[^:]*:Sephirot:1568:/
+81.3 "Ratzon" # sync / 1[56]:[^:]*:Sephirot:156B:/
+85.5 "Tiferet" sync / 1[56]:[^:]*:Sephirot:1568:/
+89.6 "Tiferet" sync / 1[56]:[^:]*:Sephirot:1568:/
+95.7 "Chesed" sync / 1[56]:[^:]*:Sephirot:1567:/ window 20,20
 
-97.9 "Triple Trial" sync / 1[56]:Sephirot:1566:/
-101.9 "Ein Sof" sync / 1[56]:Sephirot:156E:/
-106.0 "Tiferet" sync / 1[56]:Sephirot:1568:/
-114.6 "Fiendish Rage 1" sync / 1[56]:Sephirot:156D:/
-118.3 "Fiendish Rage 2" sync / 1[56]:Sephirot:156D:/
-125.5 "Tiferet" sync / 1[56]:Sephirot:1568:/
-129.6 "Tiferet" sync / 1[56]:Sephirot:1568:/
-135.7 "Chesed" sync / 1[56]:Sephirot:1567:/ window 20,20
-137.9 "Triple Trial" sync / 1[56]:Sephirot:1566:/
-144.0 "Ein Sof" sync / 1[56]:Sephirot:156E:/
-147.2 "Tiferet" sync / 1[56]:Sephirot:1568:/
-157.6 "Ratzon" # sync / 1[56]:Sephirot:156B:/
-161.8 "Tiferet" sync / 1[56]:Sephirot:1568:/
-165.9 "Tiferet" sync / 1[56]:Sephirot:1568:/
-172.0 "Chesed" sync / 1[56]:Sephirot:1567:/ window 20,20 jump 95.7
+97.9 "Triple Trial" sync / 1[56]:[^:]*:Sephirot:1566:/
+101.9 "Ein Sof" sync / 1[56]:[^:]*:Sephirot:156E:/
+106.0 "Tiferet" sync / 1[56]:[^:]*:Sephirot:1568:/
+114.6 "Fiendish Rage 1" sync / 1[56]:[^:]*:Sephirot:156D:/
+118.3 "Fiendish Rage 2" sync / 1[56]:[^:]*:Sephirot:156D:/
+125.5 "Tiferet" sync / 1[56]:[^:]*:Sephirot:1568:/
+129.6 "Tiferet" sync / 1[56]:[^:]*:Sephirot:1568:/
+135.7 "Chesed" sync / 1[56]:[^:]*:Sephirot:1567:/ window 20,20
+137.9 "Triple Trial" sync / 1[56]:[^:]*:Sephirot:1566:/
+144.0 "Ein Sof" sync / 1[56]:[^:]*:Sephirot:156E:/
+147.2 "Tiferet" sync / 1[56]:[^:]*:Sephirot:1568:/
+157.6 "Ratzon" # sync / 1[56]:[^:]*:Sephirot:156B:/
+161.8 "Tiferet" sync / 1[56]:[^:]*:Sephirot:1568:/
+165.9 "Tiferet" sync / 1[56]:[^:]*:Sephirot:1568:/
+172.0 "Chesed" sync / 1[56]:[^:]*:Sephirot:1567:/ window 20,20 jump 95.7
 
 174.2 "Triple Trial"
 178.2 "Ein Sof"
@@ -60,96 +60,96 @@ hideall "--sync--"
 # The intermission doesn't have anything worthwhile to sync.
 # Instead we just go straight for the ultimate cast.
 
-1000.0 "Ein Sof Ohr" sync / 1[56]:Sephirot:1571:/ window 1000,5
+1000.0 "Ein Sof Ohr" sync / 1[56]:[^:]*:Sephirot:1571:/ window 1000,5
 
 # Phase 2 rotation block, 197.3 seconds
-1010.3 "Yesod" sync / 1[56]:Sephirot:157E:/
-1016.2 "Force Field" sync / 1[56]:Sephirot:1587:/
-1028.4 "Chesed Gevurah" sync / 1[56]:Sephirot:157[89]:/
-1029.0 "Life Force" sync / 1[56]:Sephirot:157A:/
-1029.0 "Spirit" sync / 1[56]:Sephirot:157B:/
-1034.6 "Fiendish Wail" sync / 1[56]:Sephirot:1576:/
-1042.7 "Da'at Tethers" # sync / 1[56]:Sephirot:1574:/ duration 3.2
-1053.3 "Fiendish Wail" sync / 1[56]:Sephirot:1576:/
-1060.3 "Chesed Gevurah" sync / 1[56]:Sephirot:157[89]:/
-1060.9 "Life Force" sync / 1[56]:Sephirot:157A:/
-1060.9 "Spirit" sync / 1[56]:Sephirot:157B:/
-1068.4 "Earth Shaker" sync / 1[56]:Sephirot:157D:/
-1070.1 "Yesod" sync / 1[56]:Sephirot:157E:/
-1077.7 "Da'at spread" # sync / 1[56]:Sephirot:1573:/
-1085.1 "Fiendish Wail" sync / 1[56]:Sephirot:1576:/
-1092.2 "Chesed Gevurah" sync / 1[56]:Sephirot:157[89]:/
-1092.9 "Spirit" sync / 1[56]:Sephirot:157B:/
-1101.0 "Pillar of Mercy" sync / 1[56]:Sephirot:1580:/
-1101.3 "Yesod" sync / 1[56]:Sephirot:157E:/
-1106.2 "Pillar of Mercy" sync / 1[56]:Sephirot:1580:/
-1110.1 "Pillar of Mercy" sync / 1[56]:Sephirot:1580:/
-1119.3 "Earth Shaker" sync / 1[56]:Sephirot:157D:/
-1128.8 "Da'at spread" # sync / 1[56]:Sephirot:1573:/
-1129.7 "Yesod" sync / 1[56]:Sephirot:157E:/
-1136.1 "Fiendish Wail" sync / 1[56]:Sephirot:1576:/
-1143.2 "Chesed Gevurah" sync / 1[56]:Sephirot:157[89]:/
-1143.8 "Life Force" sync / 1[56]:Sephirot:157A:/
-1143.8 "Spirit" sync / 1[56]:Sephirot:157B:/
-1149.4 "Malkuth" sync / 1[56]:Sephirot:1582:/
+1010.3 "Yesod" sync / 1[56]:[^:]*:Sephirot:157E:/
+1016.2 "Force Field" sync / 1[56]:[^:]*:Sephirot:1587:/
+1028.4 "Chesed Gevurah" sync / 1[56]:[^:]*:Sephirot:157[89]:/
+1029.0 "Life Force" sync / 1[56]:[^:]*:Sephirot:157A:/
+1029.0 "Spirit" sync / 1[56]:[^:]*:Sephirot:157B:/
+1034.6 "Fiendish Wail" sync / 1[56]:[^:]*:Sephirot:1576:/
+1042.7 "Da'at Tethers" # sync / 1[56]:[^:]*:Sephirot:1574:/ duration 3.2
+1053.3 "Fiendish Wail" sync / 1[56]:[^:]*:Sephirot:1576:/
+1060.3 "Chesed Gevurah" sync / 1[56]:[^:]*:Sephirot:157[89]:/
+1060.9 "Life Force" sync / 1[56]:[^:]*:Sephirot:157A:/
+1060.9 "Spirit" sync / 1[56]:[^:]*:Sephirot:157B:/
+1068.4 "Earth Shaker" sync / 1[56]:[^:]*:Sephirot:157D:/
+1070.1 "Yesod" sync / 1[56]:[^:]*:Sephirot:157E:/
+1077.7 "Da'at spread" # sync / 1[56]:[^:]*:Sephirot:1573:/
+1085.1 "Fiendish Wail" sync / 1[56]:[^:]*:Sephirot:1576:/
+1092.2 "Chesed Gevurah" sync / 1[56]:[^:]*:Sephirot:157[89]:/
+1092.9 "Spirit" sync / 1[56]:[^:]*:Sephirot:157B:/
+1101.0 "Pillar of Mercy" sync / 1[56]:[^:]*:Sephirot:1580:/
+1101.3 "Yesod" sync / 1[56]:[^:]*:Sephirot:157E:/
+1106.2 "Pillar of Mercy" sync / 1[56]:[^:]*:Sephirot:1580:/
+1110.1 "Pillar of Mercy" sync / 1[56]:[^:]*:Sephirot:1580:/
+1119.3 "Earth Shaker" sync / 1[56]:[^:]*:Sephirot:157D:/
+1128.8 "Da'at spread" # sync / 1[56]:[^:]*:Sephirot:1573:/
+1129.7 "Yesod" sync / 1[56]:[^:]*:Sephirot:157E:/
+1136.1 "Fiendish Wail" sync / 1[56]:[^:]*:Sephirot:1576:/
+1143.2 "Chesed Gevurah" sync / 1[56]:[^:]*:Sephirot:157[89]:/
+1143.8 "Life Force" sync / 1[56]:[^:]*:Sephirot:157A:/
+1143.8 "Spirit" sync / 1[56]:[^:]*:Sephirot:157B:/
+1149.4 "Malkuth" sync / 1[56]:[^:]*:Sephirot:1582:/
 1150.5 "Adds Spawn" sync / 03:........:Storm Of Words:/ 
-1158.7 "Chesed Gevurah" sync / 1[56]:Sephirot:157[89]:/
-1159.3 "Spirit" sync / 1[56]:Sephirot:157B:/
-1159.3 "Life Force" sync / 1[56]:Sephirot:157A:/
-1164.9 "Fiendish Wail" sync / 1[56]:Sephirot:1576:/
-1166.5 "Yesod" sync / 1[56]:Sephirot:157E:/
-1172.2 "Chesed Gevurah" sync / 1[56]:Sephirot:157[89]:/
-1172.8 "Life Force" sync / 1[56]:Sephirot:157A:/
-1172.8 "Spirit" sync / 1[56]:Sephirot:157B:/
-1188.4 "Chesed Gevurah" sync / 1[56]:Sephirot:157[89]:/
-1189.0 "Life Force" sync / 1[56]:Sephirot:157A:/
-1189.0 "Spirit" sync / 1[56]:Sephirot:157B:/
-1191.6 "Pillar of Severity" sync / 1[56]:Sephirot:1585:/
-1195.3 "Impact of Hod" sync / 1[56]:Sephirot:172C:/
-1199.7 "Ascension" sync / 1[56]:Coronal Wind:1584:/
+1158.7 "Chesed Gevurah" sync / 1[56]:[^:]*:Sephirot:157[89]:/
+1159.3 "Spirit" sync / 1[56]:[^:]*:Sephirot:157B:/
+1159.3 "Life Force" sync / 1[56]:[^:]*:Sephirot:157A:/
+1164.9 "Fiendish Wail" sync / 1[56]:[^:]*:Sephirot:1576:/
+1166.5 "Yesod" sync / 1[56]:[^:]*:Sephirot:157E:/
+1172.2 "Chesed Gevurah" sync / 1[56]:[^:]*:Sephirot:157[89]:/
+1172.8 "Life Force" sync / 1[56]:[^:]*:Sephirot:157A:/
+1172.8 "Spirit" sync / 1[56]:[^:]*:Sephirot:157B:/
+1188.4 "Chesed Gevurah" sync / 1[56]:[^:]*:Sephirot:157[89]:/
+1189.0 "Life Force" sync / 1[56]:[^:]*:Sephirot:157A:/
+1189.0 "Spirit" sync / 1[56]:[^:]*:Sephirot:157B:/
+1191.6 "Pillar of Severity" sync / 1[56]:[^:]*:Sephirot:1585:/
+1195.3 "Impact of Hod" sync / 1[56]:[^:]*:Sephirot:172C:/
+1199.7 "Ascension" sync / 1[56]:[^:]*:Coronal Wind:1584:/
 
-1207.6 "Yesod" sync / 1[56]:Sephirot:157E:/ window 30,30
-1213.5 "Force Field" sync / 1[56]:Sephirot:1587:/
-1225.7 "Chesed Gevurah" sync / 1[56]:Sephirot:157[89]:/
-1226.3 "Life Force" sync / 1[56]:Sephirot:157A:/
-1226.3 "Spirit" sync / 1[56]:Sephirot:157B:/
-1231.9 "Fiendish Wail" sync / 1[56]:Sephirot:1576:/
-1240.0 "Da'at Tethers" # sync / 1[56]:Sephirot:1574:/ duration 3.2
-1250.6 "Fiendish Wail" sync / 1[56]:Sephirot:1576:/
-1257.6 "Chesed Gevurah" sync / 1[56]:Sephirot:157[89]:/
-1258.2 "Life Force" sync / 1[56]:Sephirot:157A:/
-1258.2 "Spirit" sync / 1[56]:Sephirot:157B:/
-1265.7 "Earth Shaker" sync / 1[56]:Sephirot:157D:/
-1267.4 "Yesod" sync / 1[56]:Sephirot:157E:/
-1275.0 "Da'at spread" # sync / 1[56]:Sephirot:1573:/
-1282.4 "Fiendish Wail" sync / 1[56]:Sephirot:1576:/
-1289.5 "Chesed Gevurah" sync / 1[56]:Sephirot:157[89]:/
-1290.2 "Spirit" sync / 1[56]:Sephirot:157B:/
-1298.3 "Pillar of Mercy" sync / 1[56]:Sephirot:1580:/
-1298.6 "Yesod" sync / 1[56]:Sephirot:157E:/
-1303.5 "Pillar of Mercy" sync / 1[56]:Sephirot:1580:/
-1307.4 "Pillar of Mercy" sync / 1[56]:Sephirot:1580:/
-1316.6 "Earth Shaker" sync / 1[56]:Sephirot:157D:/
-1326.1 "Da'at spread" # sync / 1[56]:Sephirot:1573:/
-1327.0 "Yesod" sync / 1[56]:Sephirot:157E:/
-1333.4 "Fiendish Wail" sync / 1[56]:Sephirot:1576:/
-1340.5 "Chesed Gevurah" sync / 1[56]:Sephirot:157[89]:/
-1341.1 "Life Force" sync / 1[56]:Sephirot:157A:/
-1341.1 "Spirit" sync / 1[56]:Sephirot:157B:/
-1346.7 "Malkuth" sync / 1[56]:Sephirot:1582:/
+1207.6 "Yesod" sync / 1[56]:[^:]*:Sephirot:157E:/ window 30,30
+1213.5 "Force Field" sync / 1[56]:[^:]*:Sephirot:1587:/
+1225.7 "Chesed Gevurah" sync / 1[56]:[^:]*:Sephirot:157[89]:/
+1226.3 "Life Force" sync / 1[56]:[^:]*:Sephirot:157A:/
+1226.3 "Spirit" sync / 1[56]:[^:]*:Sephirot:157B:/
+1231.9 "Fiendish Wail" sync / 1[56]:[^:]*:Sephirot:1576:/
+1240.0 "Da'at Tethers" # sync / 1[56]:[^:]*:Sephirot:1574:/ duration 3.2
+1250.6 "Fiendish Wail" sync / 1[56]:[^:]*:Sephirot:1576:/
+1257.6 "Chesed Gevurah" sync / 1[56]:[^:]*:Sephirot:157[89]:/
+1258.2 "Life Force" sync / 1[56]:[^:]*:Sephirot:157A:/
+1258.2 "Spirit" sync / 1[56]:[^:]*:Sephirot:157B:/
+1265.7 "Earth Shaker" sync / 1[56]:[^:]*:Sephirot:157D:/
+1267.4 "Yesod" sync / 1[56]:[^:]*:Sephirot:157E:/
+1275.0 "Da'at spread" # sync / 1[56]:[^:]*:Sephirot:1573:/
+1282.4 "Fiendish Wail" sync / 1[56]:[^:]*:Sephirot:1576:/
+1289.5 "Chesed Gevurah" sync / 1[56]:[^:]*:Sephirot:157[89]:/
+1290.2 "Spirit" sync / 1[56]:[^:]*:Sephirot:157B:/
+1298.3 "Pillar of Mercy" sync / 1[56]:[^:]*:Sephirot:1580:/
+1298.6 "Yesod" sync / 1[56]:[^:]*:Sephirot:157E:/
+1303.5 "Pillar of Mercy" sync / 1[56]:[^:]*:Sephirot:1580:/
+1307.4 "Pillar of Mercy" sync / 1[56]:[^:]*:Sephirot:1580:/
+1316.6 "Earth Shaker" sync / 1[56]:[^:]*:Sephirot:157D:/
+1326.1 "Da'at spread" # sync / 1[56]:[^:]*:Sephirot:1573:/
+1327.0 "Yesod" sync / 1[56]:[^:]*:Sephirot:157E:/
+1333.4 "Fiendish Wail" sync / 1[56]:[^:]*:Sephirot:1576:/
+1340.5 "Chesed Gevurah" sync / 1[56]:[^:]*:Sephirot:157[89]:/
+1341.1 "Life Force" sync / 1[56]:[^:]*:Sephirot:157A:/
+1341.1 "Spirit" sync / 1[56]:[^:]*:Sephirot:157B:/
+1346.7 "Malkuth" sync / 1[56]:[^:]*:Sephirot:1582:/
 1347.8 "Adds Spawn" sync / 03:........:Storm Of Words:/ 
-1356.0 "Chesed Gevurah" sync / 1[56]:Sephirot:157[89]:/
-1356.6 "Spirit" sync / 1[56]:Sephirot:157B:/
-1356.6 "Life Force" sync / 1[56]:Sephirot:157A:/
-1362.2 "Fiendish Wail" sync / 1[56]:Sephirot:1576:/
-1363.8 "Yesod" sync / 1[56]:Sephirot:157E:/
-1369.5 "Chesed Gevurah" sync / 1[56]:Sephirot:157[89]:/
-1370.1 "Life Force" sync / 1[56]:Sephirot:157A:/
-1370.1 "Spirit" sync / 1[56]:Sephirot:157B:/
-1385.7 "Chesed Gevurah" sync / 1[56]:Sephirot:157[89]:/
-1386.3 "Life Force" sync / 1[56]:Sephirot:157A:/
-1386.3 "Spirit" sync / 1[56]:Sephirot:157B:/
-1388.9 "Pillar of Severity" sync / 1[56]:Sephirot:1585:/
-1392.6 "Impact of Hod" sync / 1[56]:Sephirot:172C:/
-1397.0 "Ascension" sync / 1[56]:Coronal Wind:1584:/
-1403.9 "Pillar of Severity Enrage" sync / 1[56]:Sephirot:1585:/
+1356.0 "Chesed Gevurah" sync / 1[56]:[^:]*:Sephirot:157[89]:/
+1356.6 "Spirit" sync / 1[56]:[^:]*:Sephirot:157B:/
+1356.6 "Life Force" sync / 1[56]:[^:]*:Sephirot:157A:/
+1362.2 "Fiendish Wail" sync / 1[56]:[^:]*:Sephirot:1576:/
+1363.8 "Yesod" sync / 1[56]:[^:]*:Sephirot:157E:/
+1369.5 "Chesed Gevurah" sync / 1[56]:[^:]*:Sephirot:157[89]:/
+1370.1 "Life Force" sync / 1[56]:[^:]*:Sephirot:157A:/
+1370.1 "Spirit" sync / 1[56]:[^:]*:Sephirot:157B:/
+1385.7 "Chesed Gevurah" sync / 1[56]:[^:]*:Sephirot:157[89]:/
+1386.3 "Life Force" sync / 1[56]:[^:]*:Sephirot:157A:/
+1386.3 "Spirit" sync / 1[56]:[^:]*:Sephirot:157B:/
+1388.9 "Pillar of Severity" sync / 1[56]:[^:]*:Sephirot:1585:/
+1392.6 "Impact of Hod" sync / 1[56]:[^:]*:Sephirot:172C:/
+1397.0 "Ascension" sync / 1[56]:[^:]*:Coronal Wind:1584:/
+1403.9 "Pillar of Severity Enrage" sync / 1[56]:[^:]*:Sephirot:1585:/

--- a/ui/raidboss/data/03-hw/trial/sophia-ex.txt
+++ b/ui/raidboss/data/03-hw/trial/sophia-ex.txt
@@ -15,109 +15,109 @@ hideall "--sync--"
 0.0 "--Reset--" sync / 21:........:40000010:/ window 100000 jump 0
 
 0.0 "--sync--" sync /:Engage!/ window 0,1
-1.8 "--sync--" sync / 1[56]:Sophia:19C3:/ window 1.8,2
-12.0 "Thunder II" sync / 1[56]:Sophia:19B0:/ window 12,5
-22.4 "Gnosis" sync / 1[56]:Barbelo:19C2:/
-41.4 "Arms Of Wisdom?" sync / 1[56]:Sophia:19C4:/ # May be skipped depending on DPS
+1.8 "--sync--" sync / 1[56]:[^:]*:Sophia:19C3:/ window 1.8,2
+12.0 "Thunder II" sync / 1[56]:[^:]*:Sophia:19B0:/ window 12,5
+22.4 "Gnosis" sync / 1[56]:[^:]*:Barbelo:19C2:/
+41.4 "Arms Of Wisdom?" sync / 1[56]:[^:]*:Sophia:19C4:/ # May be skipped depending on DPS
 
 # This section will be reached either at 56.0, or at the time she is pushed to 90%
 56.0 "--clones appear--" sync / 03:........:Aion Teleos:/  window 56,5
-63.6 "Thunder II/III" sync / 1[56]:Sophia:19(AC|B0):/
-63.6 "--sync--" sync / 1[56]:Aion Teleos:19AB:/ window 30,2.5
-69.7 "Aero III" sync / 1[56]:Sophia:19AE:/
-69.7 "--sync--" sync / 1[56]:Aion Teleos:19AB:/
-79.8 "Execute" sync / 1[56]:Sophia:19AA:/
-#79.8 "Execute" sync / 1[56]:Aion Teleos:19AF:/
-90.2 "Arms Of Wisdom" sync / 1[56]:Sophia:19C4:/
+63.6 "Thunder II/III" sync / 1[56]:[^:]*:Sophia:19(AC|B0):/
+63.6 "--sync--" sync / 1[56]:[^:]*:Aion Teleos:19AB:/ window 30,2.5
+69.7 "Aero III" sync / 1[56]:[^:]*:Sophia:19AE:/
+69.7 "--sync--" sync / 1[56]:[^:]*:Aion Teleos:19AB:/
+79.8 "Execute" sync / 1[56]:[^:]*:Sophia:19AA:/
+#79.8 "Execute" sync / 1[56]:[^:]*:Aion Teleos:19AF:/
+90.2 "Arms Of Wisdom" sync / 1[56]:[^:]*:Sophia:19C4:/
 
 # Intermission.
 # Divine Spark can be pushed and thus is not synced.
 # Gnostic Rant and Infusion are purely HP-based pushes.
-110.6 "Cloudy Heavens" sync / 1[56]:Sophia:19BE:/ window 110.6
+110.6 "Cloudy Heavens" sync / 1[56]:[^:]*:Sophia:19BE:/ window 110.6
 111.6 "--untargetable--"
 111.6 "--adds spawn--"
-120.9 "Horizontal Kenoma/Vertical Kenoma" sync / 1[56]:The First Demiurge:19B[BC]:/
-121.9 "Gnostic Spear" sync / 1[56]:The Third Demiurge:19B9:/
-125.9 "Divine Spark" # sync / 1[56]:The Second Demiurge:19B6:/
-129.0 "Ring Of Pain" sync / 1[56]:The Third Demiurge:19BA:/
-135.1 "Horizontal Kenoma/Vertical Kenoma" sync / 1[56]:The First Demiurge:19B[BC]:/
-147.3 "Gnostic Spear?" sync / 1[56]:The Third Demiurge:19B9:/
-149.2 "Horizontal Kenoma/Vertical Kenoma" sync / 1[56]:The First Demiurge:19B[BC]:/
+120.9 "Horizontal Kenoma/Vertical Kenoma" sync / 1[56]:[^:]*:The First Demiurge:19B[BC]:/
+121.9 "Gnostic Spear" sync / 1[56]:[^:]*:The Third Demiurge:19B9:/
+125.9 "Divine Spark" # sync / 1[56]:[^:]*:The Second Demiurge:19B6:/
+129.0 "Ring Of Pain" sync / 1[56]:[^:]*:The Third Demiurge:19BA:/
+135.1 "Horizontal Kenoma/Vertical Kenoma" sync / 1[56]:[^:]*:The First Demiurge:19B[BC]:/
+147.3 "Gnostic Spear?" sync / 1[56]:[^:]*:The Third Demiurge:19B9:/
+149.2 "Horizontal Kenoma/Vertical Kenoma" sync / 1[56]:[^:]*:The First Demiurge:19B[BC]:/
 191.6 "Zombification Enrage?"
 
 # There's an introductory block leading into a rotation.
-250.0 "The Scales Of Wisdom" sync / 1[56]:Sophia:1981:/ window 250,5
-267.5 "The Scales Of Wisdom" sync / 1[56]:Sophia:1AE1:/
+250.0 "The Scales Of Wisdom" sync / 1[56]:[^:]*:Sophia:1981:/ window 250,5
+267.5 "The Scales Of Wisdom" sync / 1[56]:[^:]*:Sophia:1AE1:/
 272.9 "--targetable--"
-280.8 "Quasar (Snapshot)" sync / 1[56]:Sophia:19(6E|A7):/
-286.8 "Quasar (Meteor Detonate)" sync / 1[56]:Sophia:1A87:/
-291.3 "Aero III/Thunder II/Thunder III" sync / 1[56]:Sophia:19(A[CE]|BC):/ window 41.3,5
-297.1 "Quasar Tethers" sync / 1[56]:Sophia:196E:/
-305.7 "Quasar (Tilt)" sync / 1[56]:Sophia:1A4C:/
-310.7 "Cintamani x2" duration 3 # sync / 1[56]:Sophia:19C5:/
-318.8 "Arms Of Wisdom" sync / 1[56]:Sophia:19C4:/
+280.8 "Quasar (Snapshot)" sync / 1[56]:[^:]*:Sophia:19(6E|A7):/
+286.8 "Quasar (Meteor Detonate)" sync / 1[56]:[^:]*:Sophia:1A87:/
+291.3 "Aero III/Thunder II/Thunder III" sync / 1[56]:[^:]*:Sophia:19(A[CE]|BC):/ window 41.3,5
+297.1 "Quasar Tethers" sync / 1[56]:[^:]*:Sophia:196E:/
+305.7 "Quasar (Tilt)" sync / 1[56]:[^:]*:Sophia:1A4C:/
+310.7 "Cintamani x2" duration 3 # sync / 1[56]:[^:]*:Sophia:19C5:/
+318.8 "Arms Of Wisdom" sync / 1[56]:[^:]*:Sophia:19C4:/
  
  # Potential landing point if DPS is high. Push seems to be 70%?
-328.3 "Thunder II" sync / 1[56]:Sophia:19B0:/ window 68.8,5
-334.0 "Quasar Tethers" sync / 1[56]:Sophia:19A7:/
+328.3 "Thunder II" sync / 1[56]:[^:]*:Sophia:19B0:/ window 68.8,5
+334.0 "Quasar Tethers" sync / 1[56]:[^:]*:Sophia:19A7:/
 335.0 "--untargetable--"
-341.2 "Onrush" sync / 1[56]:Sophia:19C1:/
-341.8 "Quasar (Tilt)" # sync / 1[56]:Sophia:1A4C:/
+341.2 "Onrush" sync / 1[56]:[^:]*:Sophia:19C1:/
+341.8 "Quasar (Tilt)" # sync / 1[56]:[^:]*:Sophia:1A4C:/
 345.4 "--targetable--"
-361.5 "Dischordant Cleansing" # sync / 1[56]:Sophia:19B[35]:/
-361.5 "Cintamani x2" duration 3 # sync / 1[56]:Sophia:19C5:/
-370.8 "Arms Of Wisdom" sync / 1[56]:Sophia:19C4:/ window 30,5
+361.5 "Dischordant Cleansing" # sync / 1[56]:[^:]*:Sophia:19B[35]:/
+361.5 "Cintamani x2" duration 3 # sync / 1[56]:[^:]*:Sophia:19C5:/
+370.8 "Arms Of Wisdom" sync / 1[56]:[^:]*:Sophia:19C4:/ window 30,5
 379.0 "--clones appear--" sync / 03:........:Aion Teleos:/  window 60,20
-382.0 "Cintamani x3" duration 6 # sync / 1[56]:Sophia:19C5:/
-393.3 "--sync--" sync / 1[56]:Aion Teleos:19AB:/
-393.3 "Thunder II/III" sync / 1[56]:Sophia:19(AC|B0):/
-399.4 "--sync--" sync / 1[56]:Aion Teleos:19AB:/
-399.4 "Aero III" sync / 1[56]:Sophia:19AE:/ window 30,5
-408.5 "Arms Of Wisdom" sync / 1[56]:Sophia:19C4:/
-419.8 "Light Dew" sync / 1[56]:Barbelo:19BF:/
-420.5 "Execute" sync / 1[56]:Sophia:19AA:/ window 10,10
+382.0 "Cintamani x3" duration 6 # sync / 1[56]:[^:]*:Sophia:19C5:/
+393.3 "--sync--" sync / 1[56]:[^:]*:Aion Teleos:19AB:/
+393.3 "Thunder II/III" sync / 1[56]:[^:]*:Sophia:19(AC|B0):/
+399.4 "--sync--" sync / 1[56]:[^:]*:Aion Teleos:19AB:/
+399.4 "Aero III" sync / 1[56]:[^:]*:Sophia:19AE:/ window 30,5
+408.5 "Arms Of Wisdom" sync / 1[56]:[^:]*:Sophia:19C4:/
+419.8 "Light Dew" sync / 1[56]:[^:]*:Barbelo:19BF:/
+420.5 "Execute" sync / 1[56]:[^:]*:Sophia:19AA:/ window 10,10
 
 # Rotation block.
 # Technically it can loop, but unless party DPS is VERY high,
 # enrage will occur long before the second loop completes.
-429.3 "Cintamani x3" duration 6 # sync / 1[56]:Sophia:19C5:/ duration 5
-440.7 "Arms Of Wisdom" sync / 1[56]:Sophia:19C4:/
-446.5 "Quasar Tethers" sync / 1[56]:Sophia:196E:/
-455.2 "Quasar (Tilt)" sync / 1[56]:Sophia:1A4C:/
-457.7 "Light Dew" sync / 1[56]:Barbelo:19BF:/ window 30,10
-470.0 "Thunder III" sync / 1[56]:Sophia:19AC:/
-478.3 "Arms Of Wisdom" sync / 1[56]:Sophia:19C4:/
-484.5 "Quasar Tethers" sync / 1[56]:Sophia:19A7:/
+429.3 "Cintamani x3" duration 6 # sync / 1[56]:[^:]*:Sophia:19C5:/ duration 5
+440.7 "Arms Of Wisdom" sync / 1[56]:[^:]*:Sophia:19C4:/
+446.5 "Quasar Tethers" sync / 1[56]:[^:]*:Sophia:196E:/
+455.2 "Quasar (Tilt)" sync / 1[56]:[^:]*:Sophia:1A4C:/
+457.7 "Light Dew" sync / 1[56]:[^:]*:Barbelo:19BF:/ window 30,10
+470.0 "Thunder III" sync / 1[56]:[^:]*:Sophia:19AC:/
+478.3 "Arms Of Wisdom" sync / 1[56]:[^:]*:Sophia:19C4:/
+484.5 "Quasar Tethers" sync / 1[56]:[^:]*:Sophia:19A7:/
 485.5 "--untargetable--"
-493.2 "Quasar (Tilt)" sync / 1[56]:Sophia:1A4C:/
-494.7 "Onrush" sync / 1[56]:Sophia:19C1:/
-495.7 "Light Dew" sync / 1[56]:Barbelo:19C0:/
+493.2 "Quasar (Tilt)" sync / 1[56]:[^:]*:Sophia:1A4C:/
+494.7 "Onrush" sync / 1[56]:[^:]*:Sophia:19C1:/
+495.7 "Light Dew" sync / 1[56]:[^:]*:Barbelo:19C0:/
 499.0 "--targetable--"
-507.1 "Cintamani x3" duration 6 # sync / 1[56]:Sophia:19C5:/
-518.3 "Arms Of Wisdom" sync / 1[56]:Sophia:19C4:/
-525.4 "Thunder II" sync / 1[56]:Sophia:19B0:/
-535.9 "Dischordant Cleansing" # sync / 1[56]:Sophia:19B[35]:/
-539.7 "Gnosis" sync / 1[56]:Barbelo:19C2:/ window 30,5
-552.2 "Arms Of Wisdom" sync / 1[56]:Sophia:19C4:/
-567.0 "Quasar Tethers" sync / 1[56]:Sophia:196E:/
-568.3 "Dischordant Cleansing" # sync / 1[56]:Sophia:19B[35]:/
-575.7 "Quasar (Tilt)" # sync / 1[56]:Sophia:1A4C:/
-581.5 "Cintamani x3" duration 6 # sync / 1[56]:Sophia:19C5:/
+507.1 "Cintamani x3" duration 6 # sync / 1[56]:[^:]*:Sophia:19C5:/
+518.3 "Arms Of Wisdom" sync / 1[56]:[^:]*:Sophia:19C4:/
+525.4 "Thunder II" sync / 1[56]:[^:]*:Sophia:19B0:/
+535.9 "Dischordant Cleansing" # sync / 1[56]:[^:]*:Sophia:19B[35]:/
+539.7 "Gnosis" sync / 1[56]:[^:]*:Barbelo:19C2:/ window 30,5
+552.2 "Arms Of Wisdom" sync / 1[56]:[^:]*:Sophia:19C4:/
+567.0 "Quasar Tethers" sync / 1[56]:[^:]*:Sophia:196E:/
+568.3 "Dischordant Cleansing" # sync / 1[56]:[^:]*:Sophia:19B[35]:/
+575.7 "Quasar (Tilt)" # sync / 1[56]:[^:]*:Sophia:1A4C:/
+581.5 "Cintamani x3" duration 6 # sync / 1[56]:[^:]*:Sophia:19C5:/
 577.5 "--clones appear--" sync / 03:........:Aion Teleos:/  window 60,5
-592.8 "Arms Of Wisdom" sync / 1[56]:Sophia:19C4:/
-599.9 "--sync--" sync / 1[56]:Aion Teleos:19AB:/ window 10,2.5
-599.9 "Thunder II/III" sync / 1[56]:Sophia:19(AC|B0):/
-606.1 "--sync--" sync / 1[56]:Aion Teleos:19AB:/
-606.1 "Aero III" sync / 1[56]:Sophia:19AE:/
-611.9 "Quasar (Snapshot)" sync / 1[56]:Sophia:19(6E|A7):/
-617.9 "Quasar (Meteor Detonate)" sync / 1[56]:Sophia:1A87:/
-624.4 "Arms Of Wisdom" sync / 1[56]:Sophia:19C4:/
-636.6 "Dischordant Cleansing" # sync / 1[56]:Sophia:19B[35]:/
-639.0 "Execute" sync / 1[56]:Sophia:19AA:/
+592.8 "Arms Of Wisdom" sync / 1[56]:[^:]*:Sophia:19C4:/
+599.9 "--sync--" sync / 1[56]:[^:]*:Aion Teleos:19AB:/ window 10,2.5
+599.9 "Thunder II/III" sync / 1[56]:[^:]*:Sophia:19(AC|B0):/
+606.1 "--sync--" sync / 1[56]:[^:]*:Aion Teleos:19AB:/
+606.1 "Aero III" sync / 1[56]:[^:]*:Sophia:19AE:/
+611.9 "Quasar (Snapshot)" sync / 1[56]:[^:]*:Sophia:19(6E|A7):/
+617.9 "Quasar (Meteor Detonate)" sync / 1[56]:[^:]*:Sophia:1A87:/
+624.4 "Arms Of Wisdom" sync / 1[56]:[^:]*:Sophia:19C4:/
+636.6 "Dischordant Cleansing" # sync / 1[56]:[^:]*:Sophia:19B[35]:/
+639.0 "Execute" sync / 1[56]:[^:]*:Sophia:19AA:/
 
-650.9 "Cintamani x3" duration 6 # sync / 1[56]:Sophia:19C5:/
-662.3 "Arms Of Wisdom" sync / 1[56]:Sophia:19C4:/
-668.1 "Quasar Tethers" sync / 1[56]:Sophia:196E:/ jump 446.5
+650.9 "Cintamani x3" duration 6 # sync / 1[56]:[^:]*:Sophia:19C5:/
+662.3 "Arms Of Wisdom" sync / 1[56]:[^:]*:Sophia:19C4:/
+668.1 "Quasar Tethers" sync / 1[56]:[^:]*:Sophia:196E:/ jump 446.5
 676.9 "Quasar (Tilt)"
 679.3 "Light Dew"
 691.6 "Thunder III"

--- a/ui/raidboss/data/04-sb/alliance/orbonne_monastery.txt
+++ b/ui/raidboss/data/04-sb/alliance/orbonne_monastery.txt
@@ -13,76 +13,76 @@ hideall "--sync--"
 
 ### Phase 1
 1000.0 "--sync--" sync / 00:0839::The Realm of the Machinists will be sealed off/ window 1000,0
-1012.0 "Energy Burst" sync / 1[56]:Mustadio:373B:/
-1022.7 "Arm Shot" sync / 1[56]:Mustadio:3739:/
-1033.2 "L/R Handgonne" sync / 1[56]:Mustadio:373[EF]:/
-1042.5 "L/R Handgonne" sync / 1[56]:Mustadio:373[EF]:/
-1058.6 "Maintenance" sync / 1[56]:Mustadio:3734:/
-1065.1 "Compress" sync / 1[56]:Iron Construct:3740:/
-1066.2 "Searchlight" sync / 1[56]:Mustadio:373D:/
-1078.9 "Energy Burst" sync / 1[56]:Mustadio:373B:/
-1085.6 "Arm Shot" sync / 1[56]:Mustadio:3739:/
-1099.3 "Analysis" sync / 1[56]:Mustadio:3735:/
-1100.8 "Ballistic Impact" sync / 1[56]:Mustadio:3745:/
+1012.0 "Energy Burst" sync / 1[56]:[^:]*:Mustadio:373B:/
+1022.7 "Arm Shot" sync / 1[56]:[^:]*:Mustadio:3739:/
+1033.2 "L/R Handgonne" sync / 1[56]:[^:]*:Mustadio:373[EF]:/
+1042.5 "L/R Handgonne" sync / 1[56]:[^:]*:Mustadio:373[EF]:/
+1058.6 "Maintenance" sync / 1[56]:[^:]*:Mustadio:3734:/
+1065.1 "Compress" sync / 1[56]:[^:]*:Iron Construct:3740:/
+1066.2 "Searchlight" sync / 1[56]:[^:]*:Mustadio:373D:/
+1078.9 "Energy Burst" sync / 1[56]:[^:]*:Mustadio:373B:/
+1085.6 "Arm Shot" sync / 1[56]:[^:]*:Mustadio:3739:/
+1099.3 "Analysis" sync / 1[56]:[^:]*:Mustadio:3735:/
+1100.8 "Ballistic Impact" sync / 1[56]:[^:]*:Mustadio:3745:/
 1099.5 "--untargetable--"
 
 ### DRAMATIC CUTSCENE~!
-1105.0 "--sync--" sync / 1[56]:Mustadio:3746:/ window 100,100
-1117.8 "--sync--" sync / 1[56]:Mustadio:376C:/
-1123.8 "Last Testament" sync / 1[56]:Mustadio:3737:/
+1105.0 "--sync--" sync / 1[56]:[^:]*:Mustadio:3746:/ window 100,100
+1117.8 "--sync--" sync / 1[56]:[^:]*:Mustadio:376C:/
+1123.8 "Last Testament" sync / 1[56]:[^:]*:Mustadio:3737:/
 1131.5 "--targetable--"
-1141.4 "Leg Shot" sync / 1[56]:Mustadio:3738:/ duration 20
-1151.1 "L/R Handgonne" sync / 1[56]:Mustadio:373[EF]:/
-1161.7 "Energy Burst" sync / 1[56]:Mustadio:373B:/
-1178.0 "Maintenance" sync / 1[56]:Mustadio:3734:/
-1184.7 "Satellite Beam" sync / 1[56]:Early Turret:3741:/
-1190.7 "Ballistic Missile" sync / 1[56]:Mustadio:373C:/
-1197.6 "L/R Handgonne" sync / 1[56]:Mustadio:373[EF]:/
-1198.7 "Ballistic Impact" sync / 1[56]:Mustadio:3743:/
-1204.0 "L/R Handgonne" sync / 1[56]:Mustadio:373[EF]:/
-1213.4 "Arm Shot" sync / 1[56]:Mustadio:3739:/
-1230.3 "Maintenance" sync / 1[56]:Mustadio:3734:/
-1236.9 "Satellite Beam" sync / 1[56]:Early Turret:3741:/
-1236.9 "Compress" sync / 1[56]:Iron Construct:3740:/
-1241.1 "Ballistic Missile" sync / 1[56]:Mustadio:373C:/
-1249.0 "Ballistic Impact" sync / 1[56]:Mustadio:3743:/
-1256.4 "Maintenance" sync / 1[56]:Mustadio:3734:/
-1263.0 "Satellite Beam" sync / 1[56]:Early Turret:3741:/
-1263.0 "Compress" sync / 1[56]:Iron Construct:3740:/
-1270.1 "Energy Burst" sync / 1[56]:Mustadio:373B:/
+1141.4 "Leg Shot" sync / 1[56]:[^:]*:Mustadio:3738:/ duration 20
+1151.1 "L/R Handgonne" sync / 1[56]:[^:]*:Mustadio:373[EF]:/
+1161.7 "Energy Burst" sync / 1[56]:[^:]*:Mustadio:373B:/
+1178.0 "Maintenance" sync / 1[56]:[^:]*:Mustadio:3734:/
+1184.7 "Satellite Beam" sync / 1[56]:[^:]*:Early Turret:3741:/
+1190.7 "Ballistic Missile" sync / 1[56]:[^:]*:Mustadio:373C:/
+1197.6 "L/R Handgonne" sync / 1[56]:[^:]*:Mustadio:373[EF]:/
+1198.7 "Ballistic Impact" sync / 1[56]:[^:]*:Mustadio:3743:/
+1204.0 "L/R Handgonne" sync / 1[56]:[^:]*:Mustadio:373[EF]:/
+1213.4 "Arm Shot" sync / 1[56]:[^:]*:Mustadio:3739:/
+1230.3 "Maintenance" sync / 1[56]:[^:]*:Mustadio:3734:/
+1236.9 "Satellite Beam" sync / 1[56]:[^:]*:Early Turret:3741:/
+1236.9 "Compress" sync / 1[56]:[^:]*:Iron Construct:3740:/
+1241.1 "Ballistic Missile" sync / 1[56]:[^:]*:Mustadio:373C:/
+1249.0 "Ballistic Impact" sync / 1[56]:[^:]*:Mustadio:3743:/
+1256.4 "Maintenance" sync / 1[56]:[^:]*:Mustadio:3734:/
+1263.0 "Satellite Beam" sync / 1[56]:[^:]*:Early Turret:3741:/
+1263.0 "Compress" sync / 1[56]:[^:]*:Iron Construct:3740:/
+1270.1 "Energy Burst" sync / 1[56]:[^:]*:Mustadio:373B:/
 
 ### Phase 3 Loop
-1281.0 "Searchlight" sync / 1[56]:Mustadio:373D:/
-1287.9 "Analysis" sync / 1[56]:Mustadio:3735:/
+1281.0 "Searchlight" sync / 1[56]:[^:]*:Mustadio:373D:/
+1287.9 "Analysis" sync / 1[56]:[^:]*:Mustadio:3735:/
 1288.5 "--untargetable--"
-1291.2 "--sync--" sync / 1[56]:Mustadio:3736:/
-1295.3 "--sync--" sync / 1[56]:Mustadio:376C:/
-1301.3 "Last Testament" sync / 1[56]:Mustadio:3737:/ window 100,100
+1291.2 "--sync--" sync / 1[56]:[^:]*:Mustadio:3736:/
+1295.3 "--sync--" sync / 1[56]:[^:]*:Mustadio:376C:/
+1301.3 "Last Testament" sync / 1[56]:[^:]*:Mustadio:3737:/ window 100,100
 1308.8 "--targetable--"
-1315.0 "Energy Burst" sync / 1[56]:Mustadio:373B:/
-1327.9 "Leg Shot" sync / 1[56]:Mustadio:3738:/ duration 20
-1337.5 "L/R Handgonne" sync / 1[56]:Mustadio:373[EF]:/
-1344.1 "L/R Handgonne" sync / 1[56]:Mustadio:373[EF]:/
-1354.7 "Energy Burst" sync / 1[56]:Mustadio:373B:/
-1361.5 "Arm Shot" sync / 1[56]:Mustadio:3739:/
-1378.7 "Maintenance" sync / 1[56]:Mustadio:3734:/
-1385.2 "Satellite Beam" sync / 1[56]:Early Turret:3741:/
-1385.2 "Compress" sync / 1[56]:Iron Construct:3740:/
-1389.3 "Ballistic Missile" sync / 1[56]:Mustadio:373C:/
-1397.1 "Ballistic Impact" sync / 1[56]:Mustadio:3743:/
-1403.8 "Maintenance" sync / 1[56]:Mustadio:3734:/
-1410.4 "Satellite Beam" sync / 1[56]:Early Turret:3741:/
-1410.4 "Compress" sync / 1[56]:Iron Construct:3740:/
-1417.5 "Energy Burst" sync / 1[56]:Mustadio:373B:/
-1428.4 "Arm Shot" sync / 1[56]:Mustadio:3739:/
-1438.1 "Ballistic Missile" sync / 1[56]:Mustadio:373C:/
-1445.0 "L/R Handgonne" sync / 1[56]:Mustadio:373[EF]:/
-1446.0 "Ballistic Impact" sync / 1[56]:Mustadio:3743:/
-1451.5 "L/R Handgonne" sync / 1[56]:Mustadio:373[EF]:/
-1462.1 "Energy Burst" sync / 1[56]:Mustadio:373B:/
+1315.0 "Energy Burst" sync / 1[56]:[^:]*:Mustadio:373B:/
+1327.9 "Leg Shot" sync / 1[56]:[^:]*:Mustadio:3738:/ duration 20
+1337.5 "L/R Handgonne" sync / 1[56]:[^:]*:Mustadio:373[EF]:/
+1344.1 "L/R Handgonne" sync / 1[56]:[^:]*:Mustadio:373[EF]:/
+1354.7 "Energy Burst" sync / 1[56]:[^:]*:Mustadio:373B:/
+1361.5 "Arm Shot" sync / 1[56]:[^:]*:Mustadio:3739:/
+1378.7 "Maintenance" sync / 1[56]:[^:]*:Mustadio:3734:/
+1385.2 "Satellite Beam" sync / 1[56]:[^:]*:Early Turret:3741:/
+1385.2 "Compress" sync / 1[56]:[^:]*:Iron Construct:3740:/
+1389.3 "Ballistic Missile" sync / 1[56]:[^:]*:Mustadio:373C:/
+1397.1 "Ballistic Impact" sync / 1[56]:[^:]*:Mustadio:3743:/
+1403.8 "Maintenance" sync / 1[56]:[^:]*:Mustadio:3734:/
+1410.4 "Satellite Beam" sync / 1[56]:[^:]*:Early Turret:3741:/
+1410.4 "Compress" sync / 1[56]:[^:]*:Iron Construct:3740:/
+1417.5 "Energy Burst" sync / 1[56]:[^:]*:Mustadio:373B:/
+1428.4 "Arm Shot" sync / 1[56]:[^:]*:Mustadio:3739:/
+1438.1 "Ballistic Missile" sync / 1[56]:[^:]*:Mustadio:373C:/
+1445.0 "L/R Handgonne" sync / 1[56]:[^:]*:Mustadio:373[EF]:/
+1446.0 "Ballistic Impact" sync / 1[56]:[^:]*:Mustadio:3743:/
+1451.5 "L/R Handgonne" sync / 1[56]:[^:]*:Mustadio:373[EF]:/
+1462.1 "Energy Burst" sync / 1[56]:[^:]*:Mustadio:373B:/
 
 # fake loop
-1465.0 "Searchlight" sync / 1[56]:Mustadio:373D:/ jump 1281 window 100,100
+1465.0 "Searchlight" sync / 1[56]:[^:]*:Mustadio:373D:/ jump 1281 window 100,100
 1471.9 "Analysis"
 1475.2 "--sync--"
 1479.3 "--sync--"
@@ -95,57 +95,57 @@ hideall "--sync--"
 
 ### Phase 1
 2000.0 "--sync--" sync / 00:0839::The Realm of the Templars will be sealed off/ window 2000,0
-2012.8 "Divine Light" sync / 1[56]:Agrias:3867:/
-2023.3 "Thunder Slash" sync / 1[56]:Agrias:3866:/
-2043.5 "Judgment Blade" sync / 1[56]:Agrias:3857:/
-2054.9 "Divine Light" sync / 1[56]:Agrias:3867:/
-2065.4 "Thunder Slash" sync / 1[56]:Agrias:3866:/
-2076.4 "Cleansing Flame" sync / 1[56]:Agrias:3864:/
+2012.8 "Divine Light" sync / 1[56]:[^:]*:Agrias:3867:/
+2023.3 "Thunder Slash" sync / 1[56]:[^:]*:Agrias:3866:/
+2043.5 "Judgment Blade" sync / 1[56]:[^:]*:Agrias:3857:/
+2054.9 "Divine Light" sync / 1[56]:[^:]*:Agrias:3867:/
+2065.4 "Thunder Slash" sync / 1[56]:[^:]*:Agrias:3866:/
+2076.4 "Cleansing Flame" sync / 1[56]:[^:]*:Agrias:3864:/
 2085.0 "--ghost stun--"
-2091.0 "Cleansing Strike" sync / 1[56]:Agrias:3854:/
-2106.2 "Consecration" sync / 1[56]:Agrias:3850:/
+2091.0 "Cleansing Strike" sync / 1[56]:[^:]*:Agrias:3854:/
+2106.2 "Consecration" sync / 1[56]:[^:]*:Agrias:3850:/
 2106.2 "--crystal stun--"
-2123.9 "Northswain's Strike" sync / 1[56]:Agrias:3A86:/
-2131.1 "Divine Light" sync / 1[56]:Agrias:3867:/
-2136.6 "Thunder Slash" sync / 1[56]:Agrias:3866:/
-2147.6 "Hallowed Bolt Marks" sync / 1[56]:Agrias:385A:/
-2151.6 "Hallowed Bolt In/Out" sync / 1[56]:Agrias:385[BC]:/
-2156.1 "Hallowed Bolt Out/In" sync / 1[56]:Agrias:385[BC]:/
-2166.8 "Cleansing Flame" sync / 1[56]:Agrias:3864:/ window 50,50 # extra sync for folks inside
-2183.4 "Judgment Blade" sync / 1[56]:Agrias:3857:/
-2189.8 "Divine Light" sync / 1[56]:Agrias:3867:/
+2123.9 "Northswain's Strike" sync / 1[56]:[^:]*:Agrias:3A86:/
+2131.1 "Divine Light" sync / 1[56]:[^:]*:Agrias:3867:/
+2136.6 "Thunder Slash" sync / 1[56]:[^:]*:Agrias:3866:/
+2147.6 "Hallowed Bolt Marks" sync / 1[56]:[^:]*:Agrias:385A:/
+2151.6 "Hallowed Bolt In/Out" sync / 1[56]:[^:]*:Agrias:385[BC]:/
+2156.1 "Hallowed Bolt Out/In" sync / 1[56]:[^:]*:Agrias:385[BC]:/
+2166.8 "Cleansing Flame" sync / 1[56]:[^:]*:Agrias:3864:/ window 50,50 # extra sync for folks inside
+2183.4 "Judgment Blade" sync / 1[56]:[^:]*:Agrias:3857:/
+2189.8 "Divine Light" sync / 1[56]:[^:]*:Agrias:3867:/
 
 ### Adds Phase
-2196.6 "--sync--" sync / 1[56]:Agrias:385D:/
-2222.3 "Mortal Blow" sync / 1[56]:Sword Knight:385E:/
+2196.6 "--sync--" sync / 1[56]:[^:]*:Agrias:385D:/
+2222.3 "Mortal Blow" sync / 1[56]:[^:]*:Sword Knight:385E:/
 2262.6 "Enrage"
-2500.0 "--sync--" sync / 14:Agrias:3861:/ window 500,0
-2508.0 "Heavenly Judgment" sync / 1[56]:Agrias:3861:/ window 10,10
+2500.0 "--sync--" sync / 14:[^:]*:Agrias:3861:/ window 500,0
+2508.0 "Heavenly Judgment" sync / 1[56]:[^:]*:Agrias:3861:/ window 10,10
 
 ### Phase 3 Loop
-2524.4 "Divine Ruination" sync / 1[56]:Agrias:3858:/
-2535.6 "Divine Light" sync / 1[56]:Agrias:3867:/
-2546.1 "Thunder Slash" sync / 1[56]:Agrias:3866:/
-2558.1 "Cleansing Flame" sync / 1[56]:Agrias:3864:/
+2524.4 "Divine Ruination" sync / 1[56]:[^:]*:Agrias:3858:/
+2535.6 "Divine Light" sync / 1[56]:[^:]*:Agrias:3867:/
+2546.1 "Thunder Slash" sync / 1[56]:[^:]*:Agrias:3866:/
+2558.1 "Cleansing Flame" sync / 1[56]:[^:]*:Agrias:3864:/
 2567.6 "--ghost stun--"
-2573.6 "Cleansing Strike" sync / 1[56]:Agrias:3854:/
-2581.8 "Consecration" sync / 1[56]:Agrias:3850:/
+2573.6 "Cleansing Strike" sync / 1[56]:[^:]*:Agrias:3854:/
+2581.8 "Consecration" sync / 1[56]:[^:]*:Agrias:3850:/
 2581.8 "--crystal stun--"
-2599.5 "Northswain's Strike" sync / 1[56]:Agrias:3A86:/
-2606.7 "Divine Light" sync / 1[56]:Agrias:3867:/
-2617.2 "Hallowed Bolt Marks" sync / 1[56]:Agrias:385A:/
-2621.2 "Hallowed Bolt In/Out" sync / 1[56]:Agrias:385[BC]:/
-2624.4 "Cleansing Flame" sync / 1[56]:Agrias:3864:/
-2625.7 "Hallowed Bolt Out/In" sync / 1[56]:Agrias:385[BC]:/
+2599.5 "Northswain's Strike" sync / 1[56]:[^:]*:Agrias:3A86:/
+2606.7 "Divine Light" sync / 1[56]:[^:]*:Agrias:3867:/
+2617.2 "Hallowed Bolt Marks" sync / 1[56]:[^:]*:Agrias:385A:/
+2621.2 "Hallowed Bolt In/Out" sync / 1[56]:[^:]*:Agrias:385[BC]:/
+2624.4 "Cleansing Flame" sync / 1[56]:[^:]*:Agrias:3864:/
+2625.7 "Hallowed Bolt Out/In" sync / 1[56]:[^:]*:Agrias:385[BC]:/
 # Ask me how I know that this can desync if everybody who is alive has
 # been vacuumed up to deal with ghosts and Agrias is left by her lonesome.
-2636.6 "Thunder Slash" sync / 1[56]:Agrias:3866:/ window 40,40
-2647.6 "Divine Light" sync / 1[56]:Agrias:3867:/ window 30,5
-2653.1 "Divine Light" sync / 1[56]:Agrias:3867:/
-2667.7 "Judgment Blade" sync / 1[56]:Agrias:3857:/ window 50,50
+2636.6 "Thunder Slash" sync / 1[56]:[^:]*:Agrias:3866:/ window 40,40
+2647.6 "Divine Light" sync / 1[56]:[^:]*:Agrias:3867:/ window 30,5
+2653.1 "Divine Light" sync / 1[56]:[^:]*:Agrias:3867:/
+2667.7 "Judgment Blade" sync / 1[56]:[^:]*:Agrias:3857:/ window 50,50
 
 # fake loop lookahead
-2689.6 "Divine Ruination" sync / 1[56]:Agrias:3858:/ window 30,30 jump 2524.4
+2689.6 "Divine Ruination" sync / 1[56]:[^:]*:Agrias:3858:/ window 30,30 jump 2524.4
 2700.8 "Divine Light"
 2711.3 "Thunder Slash"
 2723.3 "Cleansing Flame"
@@ -155,23 +155,23 @@ hideall "--sync--"
 #######################
 # -p 377F:3500 -ii 3780
 3000.0 "--sync--" sync / 00:0839::The lifeless alley will be sealed off/ window 3000,0
-3491.0 "--sync--" sync / 14:Dark Crusader:377F:/ window 500,0
-3500.0 "Dark Rite" sync / 1[56]:Dark Crusader:377F:/
-3509.0 "Noahionto" sync / 1[56]:Dark Crusader:377E:/
-3520.0 "Infernal Wave" #sync / 1[56]:Dark Crusader:3781:/
-3523.5 "Infernal Wave" #sync / 1[56]:Dark Crusader:3781:/
-3528.0 "Noahionto" sync / 1[56]:Dark Crusader:377E:/
-3537.0 "Noahionto" sync / 1[56]:Dark Crusader:377E:/
-3544.0 "Noahionto" sync / 1[56]:Dark Crusader:377E:/
+3491.0 "--sync--" sync / 14:[^:]*:Dark Crusader:377F:/ window 500,0
+3500.0 "Dark Rite" sync / 1[56]:[^:]*:Dark Crusader:377F:/
+3509.0 "Noahionto" sync / 1[56]:[^:]*:Dark Crusader:377E:/
+3520.0 "Infernal Wave" #sync / 1[56]:[^:]*:Dark Crusader:3781:/
+3523.5 "Infernal Wave" #sync / 1[56]:[^:]*:Dark Crusader:3781:/
+3528.0 "Noahionto" sync / 1[56]:[^:]*:Dark Crusader:377E:/
+3537.0 "Noahionto" sync / 1[56]:[^:]*:Dark Crusader:377E:/
+3544.0 "Noahionto" sync / 1[56]:[^:]*:Dark Crusader:377E:/
 
-3566.0 "Dark Rite" sync / 1[56]:Dark Crusader:377F:/
-3575.0 "Noahionto" sync / 1[56]:Dark Crusader:377E:/
-3584.0 "Infernal Wave" #sync / 1[56]:Dark Crusader:3781:/
-3588.5 "Infernal Wave" #sync / 1[56]:Dark Crusader:3781:/
-3594.0 "Noahionto" sync / 1[56]:Dark Crusader:377E:/
-3603.0 "Noahionto" sync / 1[56]:Dark Crusader:377E:/
-3610.5 "Noahionto" sync / 1[56]:Dark Crusader:377E:/
-3625.5 "Noahionto" sync / 1[56]:Dark Crusader:377E:/
+3566.0 "Dark Rite" sync / 1[56]:[^:]*:Dark Crusader:377F:/
+3575.0 "Noahionto" sync / 1[56]:[^:]*:Dark Crusader:377E:/
+3584.0 "Infernal Wave" #sync / 1[56]:[^:]*:Dark Crusader:3781:/
+3588.5 "Infernal Wave" #sync / 1[56]:[^:]*:Dark Crusader:3781:/
+3594.0 "Noahionto" sync / 1[56]:[^:]*:Dark Crusader:377E:/
+3603.0 "Noahionto" sync / 1[56]:[^:]*:Dark Crusader:377E:/
+3610.5 "Noahionto" sync / 1[56]:[^:]*:Dark Crusader:377E:/
+3625.5 "Noahionto" sync / 1[56]:[^:]*:Dark Crusader:377E:/
 
 # FIXME: not sure what happens after this?
 # This isn't really a loop as there's 4x Noahionto in round 2.
@@ -183,51 +183,51 @@ hideall "--sync--"
 
 ### Phase 1
 4000.0 "--sync--" sync / 00:0839::The Realm of the Thunder God will be sealed off/ window 4000,0
-4015.0 "Cleansing Strike" sync / 1[56]:The Thunder God:3751:/
-4032.5 "Sword L/R" sync / 1[56]:The Thunder God:374[9A]:/
-4042.5 "Sword In/Out" sync / 1[56]:The Thunder God:37(50|4F):/
-4057.0 "Shadowblade" sync / 1[56]:The Thunder God:375D:/
+4015.0 "Cleansing Strike" sync / 1[56]:[^:]*:The Thunder God:3751:/
+4032.5 "Sword L/R" sync / 1[56]:[^:]*:The Thunder God:374[9A]:/
+4042.5 "Sword In/Out" sync / 1[56]:[^:]*:The Thunder God:37(50|4F):/
+4057.0 "Shadowblade" sync / 1[56]:[^:]*:The Thunder God:375D:/
 4062.6 "Crush Helm" duration 7
-4069.6 "--sync--" sync / 1[56]:The Thunder God:3754:/
-4080.1 "Sword L/R" sync / 1[56]:The Thunder God:374[9A]:/
-4090.1 "Sword Out/In" sync / 1[56]:The Thunder God:37(50|4F):/
-4110.2 "Duskblade" sync / 1[56]:The Thunder God:3761:/ # drift -0.045
-4123.2 "Crush Weapon" sync / 1[56]:The Thunder God:3755:/ # drift 0.046
+4069.6 "--sync--" sync / 1[56]:[^:]*:The Thunder God:3754:/
+4080.1 "Sword L/R" sync / 1[56]:[^:]*:The Thunder God:374[9A]:/
+4090.1 "Sword Out/In" sync / 1[56]:[^:]*:The Thunder God:37(50|4F):/
+4110.2 "Duskblade" sync / 1[56]:[^:]*:The Thunder God:3761:/ # drift -0.045
+4123.2 "Crush Weapon" sync / 1[56]:[^:]*:The Thunder God:3755:/ # drift 0.046
 
 ### Adds Phase
 4136.0 "--untargetable--"
-4136.0 "Colosseum" sync / 1[56]:The Thunder God:3762:/
+4136.0 "Colosseum" sync / 1[56]:[^:]*:The Thunder God:3762:/
 4143.4 "--targetable--"
-4163.0 "Hallowed Bolt" sync / 1[56]:Ephemeral Knight:3765:/
-4173.0 "Stack" sync / 1[56]:Ephemeral Knight:3768:/
-4191.0 "Hallowed Bolt" sync / 1[56]:Ephemeral Knight:3765:/
-4201.0 "Divine Ruination" sync / 1[56]:Ephemeral Knight:3763:/
-4219.0 "Hallowed Bolt" sync / 1[56]:Ephemeral Knight:3765:/
+4163.0 "Hallowed Bolt" sync / 1[56]:[^:]*:Ephemeral Knight:3765:/
+4173.0 "Stack" sync / 1[56]:[^:]*:Ephemeral Knight:3768:/
+4191.0 "Hallowed Bolt" sync / 1[56]:[^:]*:Ephemeral Knight:3765:/
+4201.0 "Divine Ruination" sync / 1[56]:[^:]*:Ephemeral Knight:3763:/
+4219.0 "Hallowed Bolt" sync / 1[56]:[^:]*:Ephemeral Knight:3765:/
 4239.0 "Enrage"
 
-4400.0 "--sync--" sync / 1[56]:The Thunder God:36EB:/ window 400,0
-4401.0 "--sync--" sync / 1[56]:The Thunder God:3824:/ window 400,5
-4403.0 "Balance Asunder" sync / 1[56]:The Thunder God:376A:/
+4400.0 "--sync--" sync / 1[56]:[^:]*:The Thunder God:36EB:/ window 400,0
+4401.0 "--sync--" sync / 1[56]:[^:]*:The Thunder God:3824:/ window 400,5
+4403.0 "Balance Asunder" sync / 1[56]:[^:]*:The Thunder God:376A:/
 4420.0 "--targetable--"
 
 ### Phase 3 Loop
-4438.5 "Sword L/R" sync / 1[56]:The Thunder God:374[9A]:/
-4448.5 "Sword In/Out" sync / 1[56]:The Thunder God:37(50|4F):/
-4462.5 "Crush Weapon" sync / 1[56]:The Thunder God:3755:/
+4438.5 "Sword L/R" sync / 1[56]:[^:]*:The Thunder God:374[9A]:/
+4448.5 "Sword In/Out" sync / 1[56]:[^:]*:The Thunder God:37(50|4F):/
+4462.5 "Crush Weapon" sync / 1[56]:[^:]*:The Thunder God:3755:/
 4465.6 "Crush Helm" duration 7
-4472.6 "--sync--" sync / 1[56]:The Thunder God:3754:/
-4483.1 "Sword Out/In" sync / 1[56]:The Thunder God:37(50|4F):/
-4495.2 "Sword Three In A Row" sync / 1[56]:The Thunder God:374[CD]:/
-4509.7 "Cleansing Strike" sync / 1[56]:The Thunder God:3751:/
-4526.2 "Crush Armor" sync / 1[56]:The Thunder God:3758:/
-4560.8 "Shadowblade" sync / 1[56]:The Thunder God:375D:/
+4472.6 "--sync--" sync / 1[56]:[^:]*:The Thunder God:3754:/
+4483.1 "Sword Out/In" sync / 1[56]:[^:]*:The Thunder God:37(50|4F):/
+4495.2 "Sword Three In A Row" sync / 1[56]:[^:]*:The Thunder God:374[CD]:/
+4509.7 "Cleansing Strike" sync / 1[56]:[^:]*:The Thunder God:3751:/
+4526.2 "Crush Armor" sync / 1[56]:[^:]*:The Thunder God:3758:/
+4560.8 "Shadowblade" sync / 1[56]:[^:]*:The Thunder God:375D:/
 4566.4 "Crush Helm" duration 7
-4573.4 "--sync--" sync / 1[56]:The Thunder God:3754:/
-4587.9 "Duskblade" sync / 1[56]:The Thunder God:3761:/
-4601.4 "Crush Accessory" sync / 1[56]:The Thunder God:375A:/
+4573.4 "--sync--" sync / 1[56]:[^:]*:The Thunder God:3754:/
+4587.9 "Duskblade" sync / 1[56]:[^:]*:The Thunder God:3761:/
+4601.4 "Crush Accessory" sync / 1[56]:[^:]*:The Thunder God:375A:/
 
 # fake loop
-4641.2 "Sword L/R" sync / 1[56]:The Thunder God:374[9A]:/ jump 4438.5
+4641.2 "Sword L/R" sync / 1[56]:[^:]*:The Thunder God:374[9A]:/ jump 4438.5
 4651.2 "Sword In/Out"
 4665.2 "Crush Weapon"
 4668.3 "Crush Helm"
@@ -239,57 +239,57 @@ hideall "--sync--"
 
 ### Phase 1: Throwbacks
 5000.0 "--sync--" sync / 00:0839::The Crystalline Gaol will be sealed off/ window 5000,0
-5015.0 "Holy IV Ground" sync / 1[56]:Ultima, the High Seraph:3899:/
-5029.2 "Auralight" sync / 1[56]:Ultima, the High Seraph:3898:/
-5035.7 "Holy IV" sync / 1[56]:Ultima, the High Seraph:389B:/
-5045.4 "Grand Cross" sync / 1[56]:Ultima, the High Seraph:38AC:/ duration 15.5
+5015.0 "Holy IV Ground" sync / 1[56]:[^:]*:Ultima, the High Seraph:3899:/
+5029.2 "Auralight" sync / 1[56]:[^:]*:Ultima, the High Seraph:3898:/
+5035.7 "Holy IV" sync / 1[56]:[^:]*:Ultima, the High Seraph:389B:/
+5045.4 "Grand Cross" sync / 1[56]:[^:]*:Ultima, the High Seraph:38AC:/ duration 15.5
 
-5071.8 "Demi-Aquarius" sync / 1[56]:Ultima, the High Seraph:38BF:/
-5080.3 "Dark Ewer" sync / 1[56]:Demi-Famfrit:38CA:/
-5083.5 "Materialize" sync / 1[56]:Aspersory:38CB:/
-5089.1 "Auralight" sync / 1[56]:Ultima, the High Seraph:3898:/
-5095.5 "Holy IV" sync / 1[56]:Ultima, the High Seraph:389B:/
+5071.8 "Demi-Aquarius" sync / 1[56]:[^:]*:Ultima, the High Seraph:38BF:/
+5080.3 "Dark Ewer" sync / 1[56]:[^:]*:Demi-Famfrit:38CA:/
+5083.5 "Materialize" sync / 1[56]:[^:]*:Aspersory:38CB:/
+5089.1 "Auralight" sync / 1[56]:[^:]*:Ultima, the High Seraph:3898:/
+5095.5 "Holy IV" sync / 1[56]:[^:]*:Ultima, the High Seraph:389B:/
 
-5102.2 "Demi-Aries" sync / 1[56]:Ultima, the High Seraph:38C0:/
-5116.7 "Time Eruption" sync / 1[56]:Demi-Belias:38D0:/
-5119.5 "Holy IV" sync / 1[56]:Ultima, the High Seraph:389B:/
-5119.7 "Time Eruption" sync / 1[56]:Demi-Belias:38D1:/
+5102.2 "Demi-Aries" sync / 1[56]:[^:]*:Ultima, the High Seraph:38C0:/
+5116.7 "Time Eruption" sync / 1[56]:[^:]*:Demi-Belias:38D0:/
+5119.5 "Holy IV" sync / 1[56]:[^:]*:Ultima, the High Seraph:389B:/
+5119.7 "Time Eruption" sync / 1[56]:[^:]*:Demi-Belias:38D1:/
 
-5127.7 "Demi-Leo" sync / 1[56]:Ultima, the High Seraph:38C1:/
-5136.1 "Control Tower" sync / 1[56]:Demi-Hashmal:38D4:/
-5137.1 "Control Tower" sync / 1[56]:Demi-Hashmal:38D5:/
-5139.2 "Sanction" sync / 1[56]:Demi-Hashmal:38D6:/
-5144.9 "Holy IV Ground" sync / 1[56]:Ultima, the High Seraph:3899:/
-5146.7 "Towerfall" sync / 1[56]:Demi-Hashmal:38D7:/
-5147.5 "Holy IV" sync / 1[56]:Ultima, the High Seraph:389B:/
+5127.7 "Demi-Leo" sync / 1[56]:[^:]*:Ultima, the High Seraph:38C1:/
+5136.1 "Control Tower" sync / 1[56]:[^:]*:Demi-Hashmal:38D4:/
+5137.1 "Control Tower" sync / 1[56]:[^:]*:Demi-Hashmal:38D5:/
+5139.2 "Sanction" sync / 1[56]:[^:]*:Demi-Hashmal:38D6:/
+5144.9 "Holy IV Ground" sync / 1[56]:[^:]*:Ultima, the High Seraph:3899:/
+5146.7 "Towerfall" sync / 1[56]:[^:]*:Demi-Hashmal:38D7:/
+5147.5 "Holy IV" sync / 1[56]:[^:]*:Ultima, the High Seraph:389B:/
 
-5160.3 "Grand Cross" sync / 1[56]:Ultima, the High Seraph:38AC:/ duration 15.5
-5189.6 "Auralight" sync / 1[56]:Ultima, the High Seraph:3898:/
-5196.1 "Holy IV" sync / 1[56]:Ultima, the High Seraph:389B:/
-5207.8 "Flare IV" sync / 1[56]:Ultima, the High Seraph:389C:/
-5208.3 "Flare IV" sync / 1[56]:Ultima, the High Seraph:389D:/
+5160.3 "Grand Cross" sync / 1[56]:[^:]*:Ultima, the High Seraph:38AC:/ duration 15.5
+5189.6 "Auralight" sync / 1[56]:[^:]*:Ultima, the High Seraph:3898:/
+5196.1 "Holy IV" sync / 1[56]:[^:]*:Ultima, the High Seraph:389B:/
+5207.8 "Flare IV" sync / 1[56]:[^:]*:Ultima, the High Seraph:389C:/
+5208.3 "Flare IV" sync / 1[56]:[^:]*:Ultima, the High Seraph:389D:/
 
 ### Phase 2: 50% Push Remix "Death awaits defiance!"
 5400.0 "--sync--" sync / 03:........:Mustadio:/  window 400,0
-5413.0 "Earth Hammer" sync / 1[56]:Demi-Hashmal:38D8:/ window 400,5
-5415.9 "Time Eruption" sync / 1[56]:Demi-Belias:38D0:/
-5418.9 "Time Eruption" sync / 1[56]:Demi-Belias:38D1:/
-5421.3 "Dark Ewer" sync / 1[56]:Demi-Famfrit:38CA:/
-5422.6 "Dark Cannonade" sync / 1[56]:Demi-Famfrit:38CE:/
-5424.3 "Materialize" sync / 1[56]:Aspersory:38CB:/
-5424.4 "Hammerfall" sync / 1[56]:Demi-Hashmal:38D9:/
-5430.4 "Eruption" sync / 1[56]:Demi-Belias:3C77:/
-5433.6 "Extreme Edge" sync / 1[56]:Demi-Hashmal:38DA:/
+5413.0 "Earth Hammer" sync / 1[56]:[^:]*:Demi-Hashmal:38D8:/ window 400,5
+5415.9 "Time Eruption" sync / 1[56]:[^:]*:Demi-Belias:38D0:/
+5418.9 "Time Eruption" sync / 1[56]:[^:]*:Demi-Belias:38D1:/
+5421.3 "Dark Ewer" sync / 1[56]:[^:]*:Demi-Famfrit:38CA:/
+5422.6 "Dark Cannonade" sync / 1[56]:[^:]*:Demi-Famfrit:38CE:/
+5424.3 "Materialize" sync / 1[56]:[^:]*:Aspersory:38CB:/
+5424.4 "Hammerfall" sync / 1[56]:[^:]*:Demi-Hashmal:38D9:/
+5430.4 "Eruption" sync / 1[56]:[^:]*:Demi-Belias:3C77:/
+5433.6 "Extreme Edge" sync / 1[56]:[^:]*:Demi-Hashmal:38DA:/
 
-#5446.5 "Crush Weapon" sync / 1[56]:The Thunder God:38B3:/
-#5449.6 "Hallowed Bolt" sync / 1[56]:Agrias:38B2:/
-#5452.6 "Searchlight" sync / 1[56]:Mustadio:38B1:/
-5482.0 "Ultimate Illusion" sync / 1[56]:Ultima, the High Seraph:3895:/
+#5446.5 "Crush Weapon" sync / 1[56]:[^:]*:The Thunder God:38B3:/
+#5449.6 "Hallowed Bolt" sync / 1[56]:[^:]*:Agrias:38B2:/
+#5452.6 "Searchlight" sync / 1[56]:[^:]*:Mustadio:38B1:/
+5482.0 "Ultimate Illusion" sync / 1[56]:[^:]*:Ultima, the High Seraph:3895:/
 5505.5 "--targetable--"
 5523.0 "Enrage"
 
-5963.4 "--sync--" sync / 1[56]:Mustadio:3A79:/ window 1000,0
-5971.0 "--sync--" sync / 1[56]:Ramza:38B5:/ window 1000,5
+5963.4 "--sync--" sync / 1[56]:[^:]*:Mustadio:3A79:/ window 1000,0
+5971.0 "--sync--" sync / 1[56]:[^:]*:Ramza:38B5:/ window 1000,5
 # 5991.0 "Few can claim to have endured the might of my will."
 5995.6 "--targetable--"
 
@@ -298,51 +298,51 @@ hideall "--sync--"
 #################
 
 ### Phase 1: March
-6004.0 "--sync--" sync / 14:Ultima, the High Seraph:38C2:/ window 1000,0
-6007.0 "Demi-Virgo Line" sync / 1[56]:Ultima, the High Seraph:38C2:/
-6016.0 "East/West March" sync / 1[56]:Ultima, the High Seraph:38A[01]:/
-6018.0 "Ray of Light" sync / 1[56]:Dominion:38B7:/
-6026.4 "Redemption" sync / 1[56]:Ultima, the High Seraph:38AA:/
-6035.5 "Grand Cross" sync / 1[56]:Ultima, the High Seraph:38C8:/ duration 15.5
-6043.4 "East/West March" sync / 1[56]:Ultima, the High Seraph:38A[01]:/
+6004.0 "--sync--" sync / 14:[^:]*:Ultima, the High Seraph:38C2:/ window 1000,0
+6007.0 "Demi-Virgo Line" sync / 1[56]:[^:]*:Ultima, the High Seraph:38C2:/
+6016.0 "East/West March" sync / 1[56]:[^:]*:Ultima, the High Seraph:38A[01]:/
+6018.0 "Ray of Light" sync / 1[56]:[^:]*:Dominion:38B7:/
+6026.4 "Redemption" sync / 1[56]:[^:]*:Ultima, the High Seraph:38AA:/
+6035.5 "Grand Cross" sync / 1[56]:[^:]*:Ultima, the High Seraph:38C8:/ duration 15.5
+6043.4 "East/West March" sync / 1[56]:[^:]*:Ultima, the High Seraph:38A[01]:/
 
-6062.0 "Demi-Virgo Feet" sync / 1[56]:Ultima, the High Seraph:38C2:/
-6073.2 "Redemption" sync / 1[56]:Ultima, the High Seraph:38AA:/
+6062.0 "Demi-Virgo Feet" sync / 1[56]:[^:]*:Ultima, the High Seraph:38C2:/
+6073.2 "Redemption" sync / 1[56]:[^:]*:Ultima, the High Seraph:38AA:/
 
-6082.4 "Demi-Virgo Tether" sync / 1[56]:Ultima, the High Seraph:38C2:/
-6087.5 "Embrace" sync / 1[56]:Dominion:38B8:/
-6098.6 "Holy IV Ground" sync / 1[56]:Ultima, the High Seraph:38C6:/
-6101.1 "Holy IV" sync / 1[56]:Ultima, the High Seraph:389B:/
+6082.4 "Demi-Virgo Tether" sync / 1[56]:[^:]*:Ultima, the High Seraph:38C2:/
+6087.5 "Embrace" sync / 1[56]:[^:]*:Dominion:38B8:/
+6098.6 "Holy IV Ground" sync / 1[56]:[^:]*:Ultima, the High Seraph:38C6:/
+6101.1 "Holy IV" sync / 1[56]:[^:]*:Ultima, the High Seraph:389B:/
 
 ### Phase 2: Maze Loop
-6124.9 "Cataclysm" sync / 1[56]:Ultima, the High Seraph:38A4:/
-6126.8 "Shockwave" sync / 1[56]:Ultima, the High Seraph:3894:/
-6143.4 "East/West March" sync / 1[56]:Ultima, the High Seraph:38A[01]:/
-6157.8 "Holy IV" sync / 1[56]:Ultima, the High Seraph:389B:/
-6170.8 "Flare IV" sync / 1[56]:Ultima, the High Seraph:389D:/
+6124.9 "Cataclysm" sync / 1[56]:[^:]*:Ultima, the High Seraph:38A4:/
+6126.8 "Shockwave" sync / 1[56]:[^:]*:Ultima, the High Seraph:3894:/
+6143.4 "East/West March" sync / 1[56]:[^:]*:Ultima, the High Seraph:38A[01]:/
+6157.8 "Holy IV" sync / 1[56]:[^:]*:Ultima, the High Seraph:389B:/
+6170.8 "Flare IV" sync / 1[56]:[^:]*:Ultima, the High Seraph:389D:/
 
-6186.6 "Demi-Virgo Feet" sync / 1[56]:Ultima, the High Seraph:38C2:/
-6205.7 "Grand Cross" sync / 1[56]:Ultima, the High Seraph:38C8:/ duration 15.5
-6213.5 "East/West March" sync / 1[56]:Ultima, the High Seraph:38A[01]:/
-6228.2 "Redemption" sync / 1[56]:Ultima, the High Seraph:38AA:/
-6229.7 "Holy IV" sync / 1[56]:Ultima, the High Seraph:389B:/
+6186.6 "Demi-Virgo Feet" sync / 1[56]:[^:]*:Ultima, the High Seraph:38C2:/
+6205.7 "Grand Cross" sync / 1[56]:[^:]*:Ultima, the High Seraph:38C8:/ duration 15.5
+6213.5 "East/West March" sync / 1[56]:[^:]*:Ultima, the High Seraph:38A[01]:/
+6228.2 "Redemption" sync / 1[56]:[^:]*:Ultima, the High Seraph:38AA:/
+6229.7 "Holy IV" sync / 1[56]:[^:]*:Ultima, the High Seraph:389B:/
 
-6241.3 "Demi-Virgo Tether" sync / 1[56]:Ultima, the High Seraph:38C2:/
-6246.5 "Embrace" sync / 1[56]:Dominion:38B8:/
+6241.3 "Demi-Virgo Tether" sync / 1[56]:[^:]*:Ultima, the High Seraph:38C2:/
+6246.5 "Embrace" sync / 1[56]:[^:]*:Dominion:38B8:/
 
-6253.6 "Demi-Virgo Line" sync / 1[56]:Ultima, the High Seraph:38C2:/
-6262.5 "East/West March" sync / 1[56]:Ultima, the High Seraph:38A[01]:/
-6264.7 "Ray of Light" sync / 1[56]:Dominion:38B7:/
-6271.1 "Redemption" sync / 1[56]:Ultima, the High Seraph:38AA:/
-6272.5 "Holy IV" sync / 1[56]:Ultima, the High Seraph:389B:/
+6253.6 "Demi-Virgo Line" sync / 1[56]:[^:]*:Ultima, the High Seraph:38C2:/
+6262.5 "East/West March" sync / 1[56]:[^:]*:Ultima, the High Seraph:38A[01]:/
+6264.7 "Ray of Light" sync / 1[56]:[^:]*:Dominion:38B7:/
+6271.1 "Redemption" sync / 1[56]:[^:]*:Ultima, the High Seraph:38AA:/
+6272.5 "Holy IV" sync / 1[56]:[^:]*:Ultima, the High Seraph:389B:/
 
-6280.3 "Demi-Virgo Feet" sync / 1[56]:Ultima, the High Seraph:38C2:/
-6290.0 "Holy IV" sync / 1[56]:Ultima, the High Seraph:389B:/
-6299.5 "Grand Cross" sync / 1[56]:Ultima, the High Seraph:38C8:/ duration 15.5
-6307.3 "East/West March" sync / 1[56]:Ultima, the High Seraph:38A[01]:/
+6280.3 "Demi-Virgo Feet" sync / 1[56]:[^:]*:Ultima, the High Seraph:38C2:/
+6290.0 "Holy IV" sync / 1[56]:[^:]*:Ultima, the High Seraph:389B:/
+6299.5 "Grand Cross" sync / 1[56]:[^:]*:Ultima, the High Seraph:38C8:/ duration 15.5
+6307.3 "East/West March" sync / 1[56]:[^:]*:Ultima, the High Seraph:38A[01]:/
 
 # fake loop
-6325.4 "Cataclysm" sync / 1[56]:Ultima, the High Seraph:38A4:/ window 200,100 jump 6124.9
+6325.4 "Cataclysm" sync / 1[56]:[^:]*:Ultima, the High Seraph:38A4:/ window 200,100 jump 6124.9
 6327.3 "Shockwave"
 6343.9 "East/West March"
 6358.3 "Holy IV"
@@ -351,19 +351,19 @@ hideall "--sync--"
 ### Phase 3: 15% off Demi-Virgo Combo Platter
 6500.0 "--sync--" sync / 00:0044:[^:]*:I see it now/ window 500,0
 
-6503.0 "Demi-Virgo Line/Tether" sync / 1[56]:Ultima, the High Seraph:38C2:/ window 8,8
-6509.1 "Redemption" sync / 1[56]:Ultima, the High Seraph:38AA:/
-6510.4 "Holy IV" sync / 1[56]:Ultima, the High Seraph:389B:/
-6513.9 "Ray of Light" sync / 1[56]:Dominion:38B7:/ # drift -0.044
+6503.0 "Demi-Virgo Line/Tether" sync / 1[56]:[^:]*:Ultima, the High Seraph:38C2:/ window 8,8
+6509.1 "Redemption" sync / 1[56]:[^:]*:Ultima, the High Seraph:38AA:/
+6510.4 "Holy IV" sync / 1[56]:[^:]*:Ultima, the High Seraph:389B:/
+6513.9 "Ray of Light" sync / 1[56]:[^:]*:Dominion:38B7:/ # drift -0.044
 
-6516.3 "Demi-Virgo Tether/Feet" sync / 1[56]:Ultima, the High Seraph:38C2:/ window 8,8
-6518.8 "Holy IV" sync / 1[56]:Ultima, the High Seraph:389B:/
-6524.6 "Redemption" sync / 1[56]:Ultima, the High Seraph:38AA:/
-6526.1 "Holy IV" sync / 1[56]:Ultima, the High Seraph:389B:/
-6532.8 "Redemption" sync / 1[56]:Ultima, the High Seraph:38AA:/
+6516.3 "Demi-Virgo Tether/Feet" sync / 1[56]:[^:]*:Ultima, the High Seraph:38C2:/ window 8,8
+6518.8 "Holy IV" sync / 1[56]:[^:]*:Ultima, the High Seraph:389B:/
+6524.6 "Redemption" sync / 1[56]:[^:]*:Ultima, the High Seraph:38AA:/
+6526.1 "Holy IV" sync / 1[56]:[^:]*:Ultima, the High Seraph:389B:/
+6532.8 "Redemption" sync / 1[56]:[^:]*:Ultima, the High Seraph:38AA:/
 
 # fake loop
-6540.0 "Demi-Virgo Line/Tether" sync / 1[56]:Ultima, the High Seraph:38C2:/ window 20,20 jump 6503
+6540.0 "Demi-Virgo Line/Tether" sync / 1[56]:[^:]*:Ultima, the High Seraph:38C2:/ window 20,20 jump 6503
 6546.1 "Redemption"
 6547.4 "Holy IV"
 6550.9 "Ray of Light"

--- a/ui/raidboss/data/04-sb/alliance/ridorana_lighthouse.txt
+++ b/ui/raidboss/data/04-sb/alliance/ridorana_lighthouse.txt
@@ -10,50 +10,50 @@ hideall "--sync--"
 # Famfrit #
 ###########
 0 "Start" sync / 00:0839::Echoes from Time's Garden will be sealed off/ window 0,1
-13 "Tide Pod" sync / 1[56]:Famfrit, The Darkening Cloud:2C3E:/ window 13,1
-26 "Water IV" sync / 1[56]:Famfrit, The Darkening Cloud:2C3D:/
-35 "Briny Cannonade" sync / 1[56]:Famfrit, The Darkening Cloud:2C45:/
-47 "Tsunami" sync / 1[56]:Famfrit, The Darkening Cloud:2C50:/
+13 "Tide Pod" sync / 1[56]:[^:]*:Famfrit, The Darkening Cloud:2C3E:/ window 13,1
+26 "Water IV" sync / 1[56]:[^:]*:Famfrit, The Darkening Cloud:2C3D:/
+35 "Briny Cannonade" sync / 1[56]:[^:]*:Famfrit, The Darkening Cloud:2C45:/
+47 "Tsunami" sync / 1[56]:[^:]*:Famfrit, The Darkening Cloud:2C50:/
 54 "Tsunami" duration 3
 66 "Tsunami" duration 3
 78 "Tsunami" duration 3
-86 "Water IV" sync / 1[56]:Famfrit, The Darkening Cloud:2C3D:/
-97 "Dark Ewer (cross)" sync / 1[56]:Famfrit, The Darkening Cloud:2C43:/
-110 "Tide Pod" sync / 1[56]:Famfrit, The Darkening Cloud:2C3E:/
-118 "Briny Cannonade" sync / 1[56]:Famfrit, The Darkening Cloud:2C41:/
-119 "Briny Cannonade" sync / 1[56]:Famfrit, The Darkening Cloud:2C45:/
-124 "Dark Ewer (orbit)" sync / 1[56]:Famfrit, The Darkening Cloud:2C43:/
-139 "Dark Rain" sync / 1[56]:Famfrit, The Darkening Cloud:2C40:/
+86 "Water IV" sync / 1[56]:[^:]*:Famfrit, The Darkening Cloud:2C3D:/
+97 "Dark Ewer (cross)" sync / 1[56]:[^:]*:Famfrit, The Darkening Cloud:2C43:/
+110 "Tide Pod" sync / 1[56]:[^:]*:Famfrit, The Darkening Cloud:2C3E:/
+118 "Briny Cannonade" sync / 1[56]:[^:]*:Famfrit, The Darkening Cloud:2C41:/
+119 "Briny Cannonade" sync / 1[56]:[^:]*:Famfrit, The Darkening Cloud:2C45:/
+124 "Dark Ewer (orbit)" sync / 1[56]:[^:]*:Famfrit, The Darkening Cloud:2C43:/
+139 "Dark Rain" sync / 1[56]:[^:]*:Famfrit, The Darkening Cloud:2C40:/
 
 # Begin loop
-151 "Water IV" sync / 1[56]:Famfrit, The Darkening Cloud:2C3D:/
-164 "Darkening Rainfall" sync / 1[56]:Famfrit, The Darkening Cloud:2C3F:/
-169 "Darkening Deluge" sync / 1[56]:Famfrit, The Darkening Cloud:2C56:/
-176 "Dark Cannonade" sync / 1[56]:Famfrit, The Darkening Cloud:2C42:/
-200 "Water IV" sync / 1[56]:Famfrit, The Darkening Cloud:2C3D:/
-208 "Tsunami" sync / 1[56]:Famfrit, The Darkening Cloud:2C50:/
+151 "Water IV" sync / 1[56]:[^:]*:Famfrit, The Darkening Cloud:2C3D:/
+164 "Darkening Rainfall" sync / 1[56]:[^:]*:Famfrit, The Darkening Cloud:2C3F:/
+169 "Darkening Deluge" sync / 1[56]:[^:]*:Famfrit, The Darkening Cloud:2C56:/
+176 "Dark Cannonade" sync / 1[56]:[^:]*:Famfrit, The Darkening Cloud:2C42:/
+200 "Water IV" sync / 1[56]:[^:]*:Famfrit, The Darkening Cloud:2C3D:/
+208 "Tsunami" sync / 1[56]:[^:]*:Famfrit, The Darkening Cloud:2C50:/
 215 "Tsunami" duration 3
 227 "Tsunami" duration 3
-228 "Briny Cannonade" sync / 1[56]:Famfrit, The Darkening Cloud:2C45:/
+228 "Briny Cannonade" sync / 1[56]:[^:]*:Famfrit, The Darkening Cloud:2C45:/
 239 "Tsunami" duration 3
-247 "Water IV" sync / 1[56]:Famfrit, The Darkening Cloud:2C3D:/
-259 "Tide Pod" sync / 1[56]:Famfrit, The Darkening Cloud:2C3E:/
-272 "Water IV" sync / 1[56]:Famfrit, The Darkening Cloud:2C3D:/
-279 "Tide Pod" sync / 1[56]:Famfrit, The Darkening Cloud:2C3E:/
-291 "Dark Ewer (cross)" sync / 1[56]:Famfrit, The Darkening Cloud:2C43:/
-302 "Water IV" sync / 1[56]:Famfrit, The Darkening Cloud:2C3D:/
-311 "Briny Cannonade" sync / 1[56]:Famfrit, The Darkening Cloud:2C45:/
-318 "Dark Ewer (orbit)" sync / 1[56]:Famfrit, The Darkening Cloud:2C43:/
-324 "Tsunami" sync / 1[56]:Famfrit, The Darkening Cloud:2C48:/
+247 "Water IV" sync / 1[56]:[^:]*:Famfrit, The Darkening Cloud:2C3D:/
+259 "Tide Pod" sync / 1[56]:[^:]*:Famfrit, The Darkening Cloud:2C3E:/
+272 "Water IV" sync / 1[56]:[^:]*:Famfrit, The Darkening Cloud:2C3D:/
+279 "Tide Pod" sync / 1[56]:[^:]*:Famfrit, The Darkening Cloud:2C3E:/
+291 "Dark Ewer (cross)" sync / 1[56]:[^:]*:Famfrit, The Darkening Cloud:2C43:/
+302 "Water IV" sync / 1[56]:[^:]*:Famfrit, The Darkening Cloud:2C3D:/
+311 "Briny Cannonade" sync / 1[56]:[^:]*:Famfrit, The Darkening Cloud:2C45:/
+318 "Dark Ewer (orbit)" sync / 1[56]:[^:]*:Famfrit, The Darkening Cloud:2C43:/
+324 "Tsunami" sync / 1[56]:[^:]*:Famfrit, The Darkening Cloud:2C48:/
 331 "Tsunami" duration 3
 343 "Tsunami" duration 3
 355 "Tsunami" duration 3
-357 "Briny Cannonade" sync / 1[56]:Famfrit, The Darkening Cloud:2C45:/
-364 "Water IV" sync / 1[56]:Famfrit, The Darkening Cloud:2C3D:/
-371 "Water IV" sync / 1[56]:Famfrit, The Darkening Cloud:2C3D:/
-386 "Tide Pod" sync / 1[56]:Famfrit, The Darkening Cloud:2C3E:/
-397 "Tide Pod" sync / 1[56]:Famfrit, The Darkening Cloud:2C3E:/
-404 "Water IV" sync / 1[56]:Famfrit, The Darkening Cloud:2C3D:/ jump 151
+357 "Briny Cannonade" sync / 1[56]:[^:]*:Famfrit, The Darkening Cloud:2C45:/
+364 "Water IV" sync / 1[56]:[^:]*:Famfrit, The Darkening Cloud:2C3D:/
+371 "Water IV" sync / 1[56]:[^:]*:Famfrit, The Darkening Cloud:2C3D:/
+386 "Tide Pod" sync / 1[56]:[^:]*:Famfrit, The Darkening Cloud:2C3E:/
+397 "Tide Pod" sync / 1[56]:[^:]*:Famfrit, The Darkening Cloud:2C3E:/
+404 "Water IV" sync / 1[56]:[^:]*:Famfrit, The Darkening Cloud:2C3D:/ jump 151
 # End loop
 
 # Dummy loop future
@@ -66,53 +66,53 @@ hideall "--sync--"
 ##########
 
 1000 "Start" sync / 00:0839::The Spire's Bounds will be sealed off/ window 1000,0
-1012 "Fire" sync / 1[56]:Belias, the Gigas:2CDB:/ window 1012,5
-1024 "Fire IV" sync / 1[56]:Belias, the Gigas:2CDC:/
-1033 "Time Eruption" sync / 1[56]:Belias, the Gigas:2CDE:/
-1038 "Fast Hands" sync / 1[56]:Belias, the Gigas:2CDF:/
-1041 "Slow Hands" sync / 1[56]:Belias, the Gigas:2CE0:/
+1012 "Fire" sync / 1[56]:[^:]*:Belias, the Gigas:2CDB:/ window 1012,5
+1024 "Fire IV" sync / 1[56]:[^:]*:Belias, the Gigas:2CDC:/
+1033 "Time Eruption" sync / 1[56]:[^:]*:Belias, the Gigas:2CDE:/
+1038 "Fast Hands" sync / 1[56]:[^:]*:Belias, the Gigas:2CDF:/
+1041 "Slow Hands" sync / 1[56]:[^:]*:Belias, the Gigas:2CE0:/
 1041 "--untargetable--"
-1048 "Crimson Cyclone" sync / 1[56]:Belias, the Gigas:2CE2:/
-1051 "Crimson Cyclone" sync / 1[56]:Belias, the Gigas:2D5F:/
+1048 "Crimson Cyclone" sync / 1[56]:[^:]*:Belias, the Gigas:2CE2:/
+1051 "Crimson Cyclone" sync / 1[56]:[^:]*:Belias, the Gigas:2D5F:/
 1054 "--targetable--"
-1062 "Fire" sync / 1[56]:Belias, the Gigas:2CDB:/
-1070 "Fire IV" sync / 1[56]:Belias, the Gigas:2CDC:/
-1079 "The Hand Of Time" sync / 1[56]:Belias, the Gigas:2CE5:/
-1089 "Fire IV" sync / 1[56]:Belias, the Gigas:2CDC:/
+1062 "Fire" sync / 1[56]:[^:]*:Belias, the Gigas:2CDB:/
+1070 "Fire IV" sync / 1[56]:[^:]*:Belias, the Gigas:2CDC:/
+1079 "The Hand Of Time" sync / 1[56]:[^:]*:Belias, the Gigas:2CE5:/
+1089 "Fire IV" sync / 1[56]:[^:]*:Belias, the Gigas:2CDC:/
 1095 "Eruption" duration 4
-1100 "Fire" sync / 1[56]:Belias, the Gigas:2CDB:/
-1110 "Fire IV" sync / 1[56]:Belias, the Gigas:2CDC:/
+1100 "Fire" sync / 1[56]:[^:]*:Belias, the Gigas:2CDB:/
+1110 "Fire IV" sync / 1[56]:[^:]*:Belias, the Gigas:2CDC:/
 1118 "Gigas spawns"
 
 # Adds dead
-1300 "Hellfire" sync / 1[56]:Belias, the Gigas:2CE8:/ window 5000,700
+1300 "Hellfire" sync / 1[56]:[^:]*:Belias, the Gigas:2CE8:/ window 5000,700
 1313 "Time Bomb" duration 15
-1322 "Fire" sync / 1[56]:Belias, the Gigas:2CDB:/
+1322 "Fire" sync / 1[56]:[^:]*:Belias, the Gigas:2CDB:/
 
 # Begin loop
-1342 "The Hand Of Time" sync / 1[56]:Belias, the Gigas:2CE5:/
+1342 "The Hand Of Time" sync / 1[56]:[^:]*:Belias, the Gigas:2CE5:/
 1345 "--untargetable--"
-1352 "Crimson Cyclone" sync / 1[56]:Belias, the Gigas:2CE2:/
-1355 "Crimson Cyclone" sync / 1[56]:Belias, the Gigas:2D5F:/
+1352 "Crimson Cyclone" sync / 1[56]:[^:]*:Belias, the Gigas:2CE2:/
+1355 "Crimson Cyclone" sync / 1[56]:[^:]*:Belias, the Gigas:2D5F:/
 1358 "--targetable--"
-1365 "Fire IV" sync / 1[56]:Belias, the Gigas:2CDC:/
-1375 "Time Eruption" sync / 1[56]:Belias, the Gigas:2CDE:/
-1380 "Fast Hands" sync / 1[56]:Belias, the Gigas:2CDF:/
+1365 "Fire IV" sync / 1[56]:[^:]*:Belias, the Gigas:2CDC:/
+1375 "Time Eruption" sync / 1[56]:[^:]*:Belias, the Gigas:2CDE:/
+1380 "Fast Hands" sync / 1[56]:[^:]*:Belias, the Gigas:2CDF:/
 1380 "Time Bomb" duration 15
-1383 "Slow Hands" sync / 1[56]:Belias, the Gigas:2CE0:/
-1396 "Fire" sync / 1[56]:Belias, the Gigas:2CDB:/
-1411 "The Hand Of Time" sync / 1[56]:Belias, the Gigas:2CE5:/
-1421 "Fire IV" sync / 1[56]:Belias, the Gigas:2CDC:/
+1383 "Slow Hands" sync / 1[56]:[^:]*:Belias, the Gigas:2CE0:/
+1396 "Fire" sync / 1[56]:[^:]*:Belias, the Gigas:2CDB:/
+1411 "The Hand Of Time" sync / 1[56]:[^:]*:Belias, the Gigas:2CE5:/
+1421 "Fire IV" sync / 1[56]:[^:]*:Belias, the Gigas:2CDC:/
 1422 "Eruption" duration 4
 1436 "Time Bomb" duration 15
 1442 "--untargetable--"
-1449 "Crimson Cyclone" sync / 1[56]:Belias, the Gigas:2CE2:/
-1451 "Crimson Cyclone" sync / 1[56]:Belias, the Gigas:2D5F:/
+1449 "Crimson Cyclone" sync / 1[56]:[^:]*:Belias, the Gigas:2CE2:/
+1451 "Crimson Cyclone" sync / 1[56]:[^:]*:Belias, the Gigas:2D5F:/
 1454 "--targetable--"
-1466 "Time Eruption" sync / 1[56]:Belias, the Gigas:2CDE:/
-1471 "Fast Hands" sync / 1[56]:Belias, the Gigas:2CDF:/
-1474 "Slow Hands" sync / 1[56]:Belias, the Gigas:2CE0:/
-1486 "The Hand Of Time" sync / 1[56]:Belias, the Gigas:2CE5:/ jump 1342
+1466 "Time Eruption" sync / 1[56]:[^:]*:Belias, the Gigas:2CDE:/
+1471 "Fast Hands" sync / 1[56]:[^:]*:Belias, the Gigas:2CDF:/
+1474 "Slow Hands" sync / 1[56]:[^:]*:Belias, the Gigas:2CE0:/
+1486 "The Hand Of Time" sync / 1[56]:[^:]*:Belias, the Gigas:2CE5:/ jump 1342
 # End loop
 
 # Dummy loop future
@@ -126,59 +126,59 @@ hideall "--sync--"
 # Construct 7 #
 ###############
 2000 "Start" sync / 00:0839::The Cleft of Profaning Wind will be sealed off/ window 2000,0
-2016 "Destroy" sync / 1[56]:Construct 7:2C5A:/ window 2016,0
-2026 "Ignite" sync / 1[56]:Construct 7:2C67:/
-2029 "Accelerate" sync / 1[56]:Construct 7:2C65:/
-2043 "Pulverize (close)" sync / 1[56]:Construct 7:2C61:/
-2048 "Pulverize (far)" sync / 1[56]:Construct 7:2C62:/
-2049 "Compress" sync / 1[56]:Construct 7:2C5C:/
-2057 "--untargetable--" sync / 1[56]:Construct 7:2C66:/
-2072 "Ignite" sync / 1[56]:Construct 7:2C67:/
-2074 "Lithobrake" sync / 1[56]:Construct 7:2C68:/
+2016 "Destroy" sync / 1[56]:[^:]*:Construct 7:2C5A:/ window 2016,0
+2026 "Ignite" sync / 1[56]:[^:]*:Construct 7:2C67:/
+2029 "Accelerate" sync / 1[56]:[^:]*:Construct 7:2C65:/
+2043 "Pulverize (close)" sync / 1[56]:[^:]*:Construct 7:2C61:/
+2048 "Pulverize (far)" sync / 1[56]:[^:]*:Construct 7:2C62:/
+2049 "Compress" sync / 1[56]:[^:]*:Construct 7:2C5C:/
+2057 "--untargetable--" sync / 1[56]:[^:]*:Construct 7:2C66:/
+2072 "Ignite" sync / 1[56]:[^:]*:Construct 7:2C67:/
+2074 "Lithobrake" sync / 1[56]:[^:]*:Construct 7:2C68:/
 2083 "Dispose" duration 5
-2101 "Incinerate" sync / 1[56]:Construct 7:2C64:/
-2113 "Computation Mode" sync / 1[56]:Construct 7:2C57:/ # drift -0.356
-2120 "Subtract" sync / 1[56]:Construct 7:2C6C:/ # drift 0.204
-2138 "Division" sync / 1[56]:Construct 7:2CC(A|C|D|E):/ # drift 0.246
-2153 "Division" sync / 1[56]:Construct 7:2CC(A|C|D|E):/ # drift 0.355
-2168 "Incinerate" sync / 1[56]:Construct 7:2CC8:/
-2176 "Tartarus Mode" sync / 1[56]:Construct 7:2C58:/
-2178 "--untargetable--" sync / 1[56]:Construct 7:2C63:/
+2101 "Incinerate" sync / 1[56]:[^:]*:Construct 7:2C64:/
+2113 "Computation Mode" sync / 1[56]:[^:]*:Construct 7:2C57:/ # drift -0.356
+2120 "Subtract" sync / 1[56]:[^:]*:Construct 7:2C6C:/ # drift 0.204
+2138 "Division" sync / 1[56]:[^:]*:Construct 7:2CC(A|C|D|E):/ # drift 0.246
+2153 "Division" sync / 1[56]:[^:]*:Construct 7:2CC(A|C|D|E):/ # drift 0.355
+2168 "Incinerate" sync / 1[56]:[^:]*:Construct 7:2CC8:/
+2176 "Tartarus Mode" sync / 1[56]:[^:]*:Construct 7:2C58:/
+2178 "--untargetable--" sync / 1[56]:[^:]*:Construct 7:2C63:/
 
 # Adds. This doesn't currently show because of combat dropping
 2230 "Area Lockdown"
 
 # After adds
-2244 "--sync--" sync / 14:Construct 7:2C59:/ window 5000,766
-2254 "Annihilation Mode" sync / 1[56]:Construct 7:2C59:/ window 5000,756
-2264 "Destroy" sync / 1[56]:Construct 7:2C71:/
-2274 "Ignite" sync / 1[56]:Construct 7:2C67:/
-2277 "Accelerate" sync / 1[56]:Construct 7:2C65:/ window 150,150
-2291 "Pulverize (close)" sync / 1[56]:Construct 7:2C61:/
+2244 "--sync--" sync / 14:[^:]*:Construct 7:2C59:/ window 5000,766
+2254 "Annihilation Mode" sync / 1[56]:[^:]*:Construct 7:2C59:/ window 5000,756
+2264 "Destroy" sync / 1[56]:[^:]*:Construct 7:2C71:/
+2274 "Ignite" sync / 1[56]:[^:]*:Construct 7:2C67:/
+2277 "Accelerate" sync / 1[56]:[^:]*:Construct 7:2C65:/ window 150,150
+2291 "Pulverize (close)" sync / 1[56]:[^:]*:Construct 7:2C61:/
 2296 "Pulverize (far)" duration 4
-2297 "Compress" sync / 1[56]:Construct 7:2C5D:/
-2310 "Incinerate" sync / 1[56]:Construct 7:2D5C:/
-2322 "Computation Mode" sync / 1[56]:Construct 7:2C57:/
-2329 "Subtract" sync / 1[56]:Construct 7:2C6C:/
-2347 "Division" sync / 1[56]:Construct 7:2CC(A|C|D|E):/
-2362 "Division" sync / 1[56]:Construct 7:2CC(A|C|D|E):/
-2377 "Incinerate" sync / 1[56]:Construct 7:2D5D:/
+2297 "Compress" sync / 1[56]:[^:]*:Construct 7:2C5D:/
+2310 "Incinerate" sync / 1[56]:[^:]*:Construct 7:2D5C:/
+2322 "Computation Mode" sync / 1[56]:[^:]*:Construct 7:2C57:/
+2329 "Subtract" sync / 1[56]:[^:]*:Construct 7:2C6C:/
+2347 "Division" sync / 1[56]:[^:]*:Construct 7:2CC(A|C|D|E):/
+2362 "Division" sync / 1[56]:[^:]*:Construct 7:2CC(A|C|D|E):/
+2377 "Incinerate" sync / 1[56]:[^:]*:Construct 7:2D5D:/
 2383 "--untargetable--"
 
 # Begin loop
-2392 "Ignite" sync / 1[56]:Construct 7:2C66:/
-2401 "Lithobrake" sync / 1[56]:Construct 7:2D1E:/
+2392 "Ignite" sync / 1[56]:[^:]*:Construct 7:2C66:/
+2401 "Lithobrake" sync / 1[56]:[^:]*:Construct 7:2D1E:/
 2410 "Dispose" duration 9
-2431 "Incinerate" sync / 1[56]:Construct 7:2D5C:/
-2444 "Ventilate" sync / 1[56]:Construct 7:2C69:/
-2454 "Destroy" sync / 1[56]:Construct 7:2C71:/
-2464 "Ignite" sync / 1[56]:Construct 7:2C67:/
-2467 "Accelerate" sync / 1[56]:Construct 7:2C65:/
-2481 "Pulverize (close)" sync / 1[56]:Construct 7:2C61:/
+2431 "Incinerate" sync / 1[56]:[^:]*:Construct 7:2D5C:/
+2444 "Ventilate" sync / 1[56]:[^:]*:Construct 7:2C69:/
+2454 "Destroy" sync / 1[56]:[^:]*:Construct 7:2C71:/
+2464 "Ignite" sync / 1[56]:[^:]*:Construct 7:2C67:/
+2467 "Accelerate" sync / 1[56]:[^:]*:Construct 7:2C65:/
+2481 "Pulverize (close)" sync / 1[56]:[^:]*:Construct 7:2C61:/
 2486 "Pulverize (far)" duration 4
-2487 "Compress" sync / 1[56]:Construct 7:2C5D:/
+2487 "Compress" sync / 1[56]:[^:]*:Construct 7:2C5D:/
 2495 "--untargetable--"
-2504 "Ignite" sync / 1[56]:Construct 7:2C66:/ jump 2392
+2504 "Ignite" sync / 1[56]:[^:]*:Construct 7:2C66:/ jump 2392
 # End loop
 
 # Dummy loop future
@@ -188,67 +188,67 @@ hideall "--sync--"
 
 ### Yiazmat
 3000 "Start" sync / 00:0839::The Clockwork Coliseum will be sealed off/ window 3000,0
-3016 "Rake (single)" sync / 1[56]:Yiazmat:2C26:/ window 3016,0
+3016 "Rake (single)" sync / 1[56]:[^:]*:Yiazmat:2C26:/ window 3016,0
 3026 "Gust Front" duration 4
-3034 "Stone Breath" sync / 1[56]:Yiazmat:2C29:/
-3046 "Dust Storm" sync / 1[56]:Yiazmat:2C36:/
-3059 "White Breath" sync / 1[56]:Yiazmat:2C31:/
-3074 "Magnetic Lysis" sync / 1[56]:Yiazmat:2C2A:/
-3082 "Dust Storm" sync / 1[56]:Yiazmat:2C36:/
+3034 "Stone Breath" sync / 1[56]:[^:]*:Yiazmat:2C29:/
+3046 "Dust Storm" sync / 1[56]:[^:]*:Yiazmat:2C36:/
+3059 "White Breath" sync / 1[56]:[^:]*:Yiazmat:2C31:/
+3074 "Magnetic Lysis" sync / 1[56]:[^:]*:Yiazmat:2C2A:/
+3082 "Dust Storm" sync / 1[56]:[^:]*:Yiazmat:2C36:/
 3088 "Gust Front" duration 4
-3092 "Stone Breath" sync / 1[56]:Yiazmat:2C29:/
-3098 "Dust Storm" sync / 1[56]:Yiazmat:2C36:/
-3101 "Magnetic Genesis" sync / 1[56]:Yiazmat:2C2B:/
+3092 "Stone Breath" sync / 1[56]:[^:]*:Yiazmat:2C29:/
+3098 "Dust Storm" sync / 1[56]:[^:]*:Yiazmat:2C36:/
+3101 "Magnetic Genesis" sync / 1[56]:[^:]*:Yiazmat:2C2B:/
 3114 "Rake (combo)" duration 14
-3134 "White Breath" sync / 1[56]:Yiazmat:2C31:/
-3149 "Rake (single)" sync / 1[56]:Yiazmat:2C26:/
+3134 "White Breath" sync / 1[56]:[^:]*:Yiazmat:2C31:/
+3149 "Rake (single)" sync / 1[56]:[^:]*:Yiazmat:2C26:/
 3160 "Gust Front" duration 4
-3162 "Stone Breath" sync / 1[56]:Yiazmat:2C29:/
-3175 "Summon" sync / 1[56]:Yiazmat:2C37:/
-3186 "Magnetic Lysis" sync / 1[56]:Yiazmat:2C2A:/
-3194 "White Breath" sync / 1[56]:Yiazmat:2C31:/
-3201 "Dust Storm" sync / 1[56]:Yiazmat:2C36:/
-3208 "Death Strike" sync / 1[56]:Yiazmat:2C34:/
-3213 "Magnetic Genesis" sync / 1[56]:Yiazmat:2C2B:/
-3222 "Cyclone" sync / 1[56]:Yiazmat:2C23:/ duration 4
+3162 "Stone Breath" sync / 1[56]:[^:]*:Yiazmat:2C29:/
+3175 "Summon" sync / 1[56]:[^:]*:Yiazmat:2C37:/
+3186 "Magnetic Lysis" sync / 1[56]:[^:]*:Yiazmat:2C2A:/
+3194 "White Breath" sync / 1[56]:[^:]*:Yiazmat:2C31:/
+3201 "Dust Storm" sync / 1[56]:[^:]*:Yiazmat:2C36:/
+3208 "Death Strike" sync / 1[56]:[^:]*:Yiazmat:2C34:/
+3213 "Magnetic Genesis" sync / 1[56]:[^:]*:Yiazmat:2C2B:/
+3222 "Cyclone" sync / 1[56]:[^:]*:Yiazmat:2C23:/ duration 4
 
 # Adds
 3241 "Archaeodemon spawn"
 3248 "Gust Front" duration 4
 3250 "Karma/Unholy Darkness"
-3258 "Death Strike" sync / 1[56]:Yiazmat:2C33:/
+3258 "Death Strike" sync / 1[56]:[^:]*:Yiazmat:2C33:/
 3262 "Karma/Unholy Darkness"
 3301 "Enrage"
 
 # Adds complete
-3400 "Solar Storm" sync / 1[56]:Yiazmat:2C2C:/ window 5000,600
+3400 "Solar Storm" sync / 1[56]:[^:]*:Yiazmat:2C2C:/ window 5000,600
 3420 "Rake (combo)" duration 14
 3425 "Gust Front" duration 4
-3439 "White Breath" sync / 1[56]:Yiazmat:2C31:/
-3450 "Rake (single)" sync / 1[56]:Yiazmat:2C26:/
+3439 "White Breath" sync / 1[56]:[^:]*:Yiazmat:2C31:/
+3450 "Rake (single)" sync / 1[56]:[^:]*:Yiazmat:2C26:/
 
 # Begin loop
-3456 "Magnetic Lysis" sync / 1[56]:Yiazmat:2C2A:/
+3456 "Magnetic Lysis" sync / 1[56]:[^:]*:Yiazmat:2C2A:/
 3463 "Rake (combo)" duration 14
-3481 "Dust Storm" sync / 1[56]:Yiazmat:2C36:/
-3483 "Magnetic Genesis" sync / 1[56]:Yiazmat:2C2B:/
-3493 "Cyclone" sync / 1[56]:Yiazmat:2C23:/ duration 4
-3505 "Death Strike" sync / 1[56]:Yiazmat:2C34:/
+3481 "Dust Storm" sync / 1[56]:[^:]*:Yiazmat:2C36:/
+3483 "Magnetic Genesis" sync / 1[56]:[^:]*:Yiazmat:2C2B:/
+3493 "Cyclone" sync / 1[56]:[^:]*:Yiazmat:2C23:/ duration 4
+3505 "Death Strike" sync / 1[56]:[^:]*:Yiazmat:2C34:/
 3510 "Gust Front" duration 4
-3520 "White Breath" sync / 1[56]:Yiazmat:2C31:/
-3531 "Rake (single)" sync / 1[56]:Yiazmat:2C26:/
-3537 "Magnetic Lysis" sync / 1[56]:Yiazmat:2C2A:/
-3544 "Dust Storm" sync / 1[56]:Yiazmat:2C36:/
-3551 "White Breath" sync / 1[56]:Yiazmat:2C31:/
+3520 "White Breath" sync / 1[56]:[^:]*:Yiazmat:2C31:/
+3531 "Rake (single)" sync / 1[56]:[^:]*:Yiazmat:2C26:/
+3537 "Magnetic Lysis" sync / 1[56]:[^:]*:Yiazmat:2C2A:/
+3544 "Dust Storm" sync / 1[56]:[^:]*:Yiazmat:2C36:/
+3551 "White Breath" sync / 1[56]:[^:]*:Yiazmat:2C31:/
 3553 "Gust Front" duration 4
-3561 "Dust Storm" sync / 1[56]:Yiazmat:2C36:/
-3565 "Magnetic Genesis" sync / 1[56]:Yiazmat:2C2B:/
-3577 "Gale Gaol" sync / 1[56]:Yiazmat:2C2D:/
+3561 "Dust Storm" sync / 1[56]:[^:]*:Yiazmat:2C36:/
+3565 "Magnetic Genesis" sync / 1[56]:[^:]*:Yiazmat:2C2B:/
+3577 "Gale Gaol" sync / 1[56]:[^:]*:Yiazmat:2C2D:/
 3584 "Gust Front" duration 4
-3587 "Stone Breath" sync / 1[56]:Yiazmat:2C29:/
-3595 "Rake (single)" sync / 1[56]:Yiazmat:2C26:/
-3600 "Dust Storm" sync / 1[56]:Yiazmat:2C36:/
-3610 "Magnetic Lysis" sync / 1[56]:Yiazmat:2C2A:/ jump 3456
+3587 "Stone Breath" sync / 1[56]:[^:]*:Yiazmat:2C29:/
+3595 "Rake (single)" sync / 1[56]:[^:]*:Yiazmat:2C26:/
+3600 "Dust Storm" sync / 1[56]:[^:]*:Yiazmat:2C36:/
+3610 "Magnetic Lysis" sync / 1[56]:[^:]*:Yiazmat:2C2A:/ jump 3456
 # End loop
 
 # Dummy loop future
@@ -256,13 +256,13 @@ hideall "--sync--"
 3634 "Dust Storm"
 
 # 9.99% push
-3694 "--sync--" sync / 14:Yiazmat:2C32:/ window 5000,306
-3700 "Growing Threat" sync / 1[56]:Yiazmat:2C32:/ window 5000,300
+3694 "--sync--" sync / 14:[^:]*:Yiazmat:2C32:/ window 5000,306
+3700 "Growing Threat" sync / 1[56]:[^:]*:Yiazmat:2C32:/ window 5000,300
 3707 "Rake (combo)" duration 14
-3727 "White Breath" sync / 1[56]:Yiazmat:2C31:/
-3734 "Dust Storm" sync / 1[56]:Yiazmat:2C36:/
+3727 "White Breath" sync / 1[56]:[^:]*:Yiazmat:2C31:/
+3734 "Dust Storm" sync / 1[56]:[^:]*:Yiazmat:2C36:/
 3740 "Rake (combo)" duration 14
 3752 "Gust Front" duration 4
-3761 "Stone Breath" sync / 1[56]:Yiazmat:2C29:/
-3767 "Dust Storm" sync / 1[56]:Yiazmat:2C36:/
+3761 "Stone Breath" sync / 1[56]:[^:]*:Yiazmat:2C29:/
+3767 "Dust Storm" sync / 1[56]:[^:]*:Yiazmat:2C36:/
 # more?

--- a/ui/raidboss/data/04-sb/alliance/royal_city_of_rabanastre.txt
+++ b/ui/raidboss/data/04-sb/alliance/royal_city_of_rabanastre.txt
@@ -14,47 +14,47 @@ hideall "--start--"
 
 0.0 "--start--" sync / 00:0839::The Crumbling Bridge will be sealed off/ window 0,1
 # TODO: does this only start when the adds are dead?
-22.6 "--sync--" sync / 14:Mateus, The Corrupt:2633:/ window 30,10
+22.6 "--sync--" sync / 14:[^:]*:Mateus, The Corrupt:2633:/ window 30,10
 
 # Ice phase
-27.6 "Unbind" sync / 1[56]:Mateus, The Corrupt:2633:/
-33.6 "--sync--" sync / 1[56]:Mateus, The Corrupt:26A2:/
+27.6 "Unbind" sync / 1[56]:[^:]*:Mateus, The Corrupt:2633:/
+33.6 "--sync--" sync / 1[56]:[^:]*:Mateus, The Corrupt:26A2:/
 34.3 "--Aqua Sphere Adds--" sync / 03:........:Aqua Sphere:/ 
-57.5 "Flash-Freeze" sync / 1[56]:Mateus, The Corrupt:2647:/
-66.7 "--sync--" sync / 1[56]:Mateus, The Corrupt:2637:/
-74.6 "Flash-Freeze" sync / 1[56]:Mateus, The Corrupt:2647:/
-91.8 "Flash-Freeze" sync / 1[56]:Mateus, The Corrupt:2647:/
+57.5 "Flash-Freeze" sync / 1[56]:[^:]*:Mateus, The Corrupt:2647:/
+66.7 "--sync--" sync / 1[56]:[^:]*:Mateus, The Corrupt:2637:/
+74.6 "Flash-Freeze" sync / 1[56]:[^:]*:Mateus, The Corrupt:2647:/
+91.8 "Flash-Freeze" sync / 1[56]:[^:]*:Mateus, The Corrupt:2647:/
 
 # Frog phase
-114.1 "Rebind" sync / 1[56]:Mateus, The Corrupt:2635:/ window 120,20
-124.5 "Dualcast" sync / 1[56]:Mateus, The Corrupt:263C:/
-127.8 "--sync--" sync / 1[56]:Mateus, The Corrupt:263B:/
-139.9 "Blizzard IV" sync / 1[56]:Mateus, The Corrupt:263D:/
-152.1 "Flash-Freeze" sync / 1[56]:Mateus, The Corrupt:2647:/
+114.1 "Rebind" sync / 1[56]:[^:]*:Mateus, The Corrupt:2635:/ window 120,20
+124.5 "Dualcast" sync / 1[56]:[^:]*:Mateus, The Corrupt:263C:/
+127.8 "--sync--" sync / 1[56]:[^:]*:Mateus, The Corrupt:263B:/
+139.9 "Blizzard IV" sync / 1[56]:[^:]*:Mateus, The Corrupt:263D:/
+152.1 "Flash-Freeze" sync / 1[56]:[^:]*:Mateus, The Corrupt:2647:/
 165.4 "--Flume Toad Adds--" sync / 03:........:Flume Toad:/ 
-192.5 "Snowpierce 1" sync / 1[56]:Icicle:2640:/
+192.5 "Snowpierce 1" sync / 1[56]:[^:]*:Icicle:2640:/
 # ??? More flume toads, hard to tell from logs
-214.6 "Snowpierce 2" sync / 1[56]:Icicle:2640:/
-225.6 "Dendrite" sync / 1[56]:Mateus, The Corrupt:2645:/
+214.6 "Snowpierce 2" sync / 1[56]:[^:]*:Icicle:2640:/
+225.6 "Dendrite" sync / 1[56]:[^:]*:Mateus, The Corrupt:2645:/
 227.5 "--Blizzard Sphere Adds--"
 
 # Adds
 259.2 "--untargetable--" # ??? from video
-259.8 "--sync--" sync / 1[56]:Mateus, The Corrupt:266C:/ window 260,20
+259.8 "--sync--" sync / 1[56]:[^:]*:Mateus, The Corrupt:266C:/ window 260,20
 262.9 "--Azure Guard Adds--" sync / 03:........:Azure Guard:/ 
 333.2 "--enrage--" # ??? estimating from video
 
 # End of add phase aoe
-500.0 "Frostwave" sync / 1[56]:Mateus, The Corrupt:2641:/
+500.0 "Frostwave" sync / 1[56]:[^:]*:Mateus, The Corrupt:2641:/
 
 # loop
-524.3 "Unbind" sync / 1[56]:Mateus, The Corrupt:2633:/ window 200,200 jump 27.6
-530.3 "--sync--" #sync / 1[56]:Mateus, The Corrupt:26A2:/
+524.3 "Unbind" sync / 1[56]:[^:]*:Mateus, The Corrupt:2633:/ window 200,200 jump 27.6
+530.3 "--sync--" #sync / 1[56]:[^:]*:Mateus, The Corrupt:26A2:/
 531.0 "--Aqua Sphere Adds--" #sync / 03:........:Aqua Sphere:/ 
-554.2 "Flash-Freeze" #sync / 1[56]:Mateus, The Corrupt:2647:/
-563.4 "--sync--" #sync / 1[56]:Mateus, The Corrupt:2637:/
-571.3 "Flash-Freeze" #sync / 1[56]:Mateus, The Corrupt:2647:/
-588.5 "Flash-Freeze" #sync / 1[56]:Mateus, The Corrupt:2647:/
+554.2 "Flash-Freeze" #sync / 1[56]:[^:]*:Mateus, The Corrupt:2647:/
+563.4 "--sync--" #sync / 1[56]:[^:]*:Mateus, The Corrupt:2637:/
+571.3 "Flash-Freeze" #sync / 1[56]:[^:]*:Mateus, The Corrupt:2647:/
+588.5 "Flash-Freeze" #sync / 1[56]:[^:]*:Mateus, The Corrupt:2647:/
 
 
 ### Hashmal, Bringer of Order
@@ -63,108 +63,108 @@ hideall "--start--"
 # -it "Hashmal, Bringer of Order"
 
 1000.0 "--start--" sync / 00:0839::The Palace Square will be sealed off/ window 10000,0
-1011.0 "--sync--" sync / 14:Hashmal, Bringer of Order:25D8:/ window 20,20
-1015.0 "Quake IV" sync / 1[56]:Hashmal, Bringer of Order:25D8:/
-1020.4 "Jagged Edge 1" #sync / 1[56]:Hashmal, Bringer of Order:25CD:/
-1022.5 "Jagged Edge 2" #sync / 1[56]:Hashmal, Bringer of Order:25CD:/
-1024.6 "Jagged Edge 3" #sync / 1[56]:Hashmal, Bringer of Order:25CD:/
+1011.0 "--sync--" sync / 14:[^:]*:Hashmal, Bringer of Order:25D8:/ window 20,20
+1015.0 "Quake IV" sync / 1[56]:[^:]*:Hashmal, Bringer of Order:25D8:/
+1020.4 "Jagged Edge 1" #sync / 1[56]:[^:]*:Hashmal, Bringer of Order:25CD:/
+1022.5 "Jagged Edge 2" #sync / 1[56]:[^:]*:Hashmal, Bringer of Order:25CD:/
+1024.6 "Jagged Edge 3" #sync / 1[56]:[^:]*:Hashmal, Bringer of Order:25CD:/
 
-1028.6 "Control Tower x1" sync / 1[56]:Hashmal, Bringer of Order:25C1:/
-1031.8 "Sanction" sync / 1[56]:Hashmal, Bringer of Order:25C3:/
+1028.6 "Control Tower x1" sync / 1[56]:[^:]*:Hashmal, Bringer of Order:25C1:/
+1031.8 "Sanction" sync / 1[56]:[^:]*:Hashmal, Bringer of Order:25C3:/
 1038.1 "--untargetable--" # ??? from video
-1039.4 "Towerfall" sync / 1[56]:Control Tower:25C4:/
-1046.2 "Extreme Edge" sync / 1[56]:Hashmal, Bringer of Order:(25CE|25D0):/
+1039.4 "Towerfall" sync / 1[56]:[^:]*:Control Tower:25C4:/
+1046.2 "Extreme Edge" sync / 1[56]:[^:]*:Hashmal, Bringer of Order:(25CE|25D0):/
 1050.1 "--targetable--" # ??? from video
 
-1056.1 "Earth Hammer" sync / 1[56]:Hashmal, Bringer of Order:25CB:/
-1064.3 "Hammerfall" sync / 1[56]:Hashmal, Bringer of Order:25CC:/
-1073.3 "Quake IV" sync / 1[56]:Hashmal, Bringer of Order:25D8:/
-1082.6 "Rock Cutter" sync / 1[56]:Hashmal, Bringer of Order:25D7:/
+1056.1 "Earth Hammer" sync / 1[56]:[^:]*:Hashmal, Bringer of Order:25CB:/
+1064.3 "Hammerfall" sync / 1[56]:[^:]*:Hashmal, Bringer of Order:25CC:/
+1073.3 "Quake IV" sync / 1[56]:[^:]*:Hashmal, Bringer of Order:25D8:/
+1082.6 "Rock Cutter" sync / 1[56]:[^:]*:Hashmal, Bringer of Order:25D7:/
 
 # This can push early.
-1087.0 "--sync--" sync / 14:Hashmal, Bringer of Order:25BC:/ window 100,20
-1090.0 "Command Tower" sync / 1[56]:Hashmal, Bringer of Order:25BC:/
-1101.3 "Earth Shaker" sync / 1[56]:Command Tower:25C8:/
-1106.2 "Earth Shaker" sync / 1[56]:Command Tower:25C8:/
-1106.6 "Jagged Edge 1" #sync / 1[56]:Hashmal, Bringer of Order:25CD:/
-1108.4 "Impact" sync / 1[56]:Command Tower:25C7:/ window 30,3
-1108.7 "Jagged Edge 2" #sync / 1[56]:Hashmal, Bringer of Order:25CD:/
-1110.7 "Jagged Edge 3" #sync / 1[56]:Hashmal, Bringer of Order:25CD:/
+1087.0 "--sync--" sync / 14:[^:]*:Hashmal, Bringer of Order:25BC:/ window 100,20
+1090.0 "Command Tower" sync / 1[56]:[^:]*:Hashmal, Bringer of Order:25BC:/
+1101.3 "Earth Shaker" sync / 1[56]:[^:]*:Command Tower:25C8:/
+1106.2 "Earth Shaker" sync / 1[56]:[^:]*:Command Tower:25C8:/
+1106.6 "Jagged Edge 1" #sync / 1[56]:[^:]*:Hashmal, Bringer of Order:25CD:/
+1108.4 "Impact" sync / 1[56]:[^:]*:Command Tower:25C7:/ window 30,3
+1108.7 "Jagged Edge 2" #sync / 1[56]:[^:]*:Hashmal, Bringer of Order:25CD:/
+1110.7 "Jagged Edge 3" #sync / 1[56]:[^:]*:Hashmal, Bringer of Order:25CD:/
 1113.2 "--Sand Sphere Adds--"
-1128.5 "Falling Boulder" sync / 1[56]:Hashmal, Bringer of Order:25D2:/
-1135.8 "Impact" sync / 1[56]:Command Tower:25C7:/ window 24,3 # can push early and skip Sand Spheres
-1145.7 "Earth Shaker" #sync / 1[56]:Command Tower:25C8:/
-1147.8 "Earth Shaker" #sync / 1[56]:Command Tower:25C8:/
-1149.8 "Falling Rock" sync / 1[56]:Hashmal, Bringer of Order:25D3:/
+1128.5 "Falling Boulder" sync / 1[56]:[^:]*:Hashmal, Bringer of Order:25D2:/
+1135.8 "Impact" sync / 1[56]:[^:]*:Command Tower:25C7:/ window 24,3 # can push early and skip Sand Spheres
+1145.7 "Earth Shaker" #sync / 1[56]:[^:]*:Command Tower:25C8:/
+1147.8 "Earth Shaker" #sync / 1[56]:[^:]*:Command Tower:25C8:/
+1149.8 "Falling Rock" sync / 1[56]:[^:]*:Hashmal, Bringer of Order:25D3:/
 # ??? more earth shaker, more jagged edge (seen on video, but no logs)
 
-1300.0 "--sync--" sync / 14:Hashmal, Bringer of Order:25C5:/ window 300,0
-1305.0 "Landwaster" sync / 1[56]:Hashmal, Bringer of Order:25C5:/
+1300.0 "--sync--" sync / 14:[^:]*:Hashmal, Bringer of Order:25C5:/ window 300,0
+1305.0 "Landwaster" sync / 1[56]:[^:]*:Hashmal, Bringer of Order:25C5:/
 
-1314.4 "Control Tower x2" sync / 1[56]:Hashmal, Bringer of Order:25C1:/
-1317.6 "Sanction" sync / 1[56]:Hashmal, Bringer of Order:25C3:/
-1325.1 "Towerfall" sync / 1[56]:Control Tower:25C4:/
-1326.0 "Jagged Edge 1" #sync / 1[56]:Hashmal, Bringer of Order:25CD:/
-1328.1 "Jagged Edge 2" #sync / 1[56]:Hashmal, Bringer of Order:25CD:/
-1330.2 "Jagged Edge 3" #sync / 1[56]:Hashmal, Bringer of Order:25CD:/
+1314.4 "Control Tower x2" sync / 1[56]:[^:]*:Hashmal, Bringer of Order:25C1:/
+1317.6 "Sanction" sync / 1[56]:[^:]*:Hashmal, Bringer of Order:25C3:/
+1325.1 "Towerfall" sync / 1[56]:[^:]*:Control Tower:25C4:/
+1326.0 "Jagged Edge 1" #sync / 1[56]:[^:]*:Hashmal, Bringer of Order:25CD:/
+1328.1 "Jagged Edge 2" #sync / 1[56]:[^:]*:Hashmal, Bringer of Order:25CD:/
+1330.2 "Jagged Edge 3" #sync / 1[56]:[^:]*:Hashmal, Bringer of Order:25CD:/
 
-1330.9 "Control Tower x2" sync / 1[56]:Hashmal, Bringer of Order:25C1:/
-1334.1 "Sanction" sync / 1[56]:Hashmal, Bringer of Order:25C3:/
-1341.7 "Towerfall" sync / 1[56]:Control Tower:25C4:/
+1330.9 "Control Tower x2" sync / 1[56]:[^:]*:Hashmal, Bringer of Order:25C1:/
+1334.1 "Sanction" sync / 1[56]:[^:]*:Hashmal, Bringer of Order:25C3:/
+1341.7 "Towerfall" sync / 1[56]:[^:]*:Control Tower:25C4:/
 1343.9 "--untargetable--" # ??? from video
-1348.2 "Jagged Edge 1" #sync / 1[56]:Hashmal, Bringer of Order:25CD:/
-1348.5 "Extreme Edge" sync / 1[56]:Hashmal, Bringer of Order:(25CE|25D0):/
-1350.3 "Jagged Edge 2" #sync / 1[56]:Hashmal, Bringer of Order:25CD:/
-1352.3 "Jagged Edge 3" #sync / 1[56]:Hashmal, Bringer of Order:25CD:/
+1348.2 "Jagged Edge 1" #sync / 1[56]:[^:]*:Hashmal, Bringer of Order:25CD:/
+1348.5 "Extreme Edge" sync / 1[56]:[^:]*:Hashmal, Bringer of Order:(25CE|25D0):/
+1350.3 "Jagged Edge 2" #sync / 1[56]:[^:]*:Hashmal, Bringer of Order:25CD:/
+1352.3 "Jagged Edge 3" #sync / 1[56]:[^:]*:Hashmal, Bringer of Order:25CD:/
 1355.4 "--targetable--" # ??? from video
 
-1360.3 "Quake IV" sync / 1[56]:Hashmal, Bringer of Order:25D8:/
-1369.5 "Quake IV" sync / 1[56]:Hashmal, Bringer of Order:25D8:/
-1378.9 "Rock Cutter" sync / 1[56]:Hashmal, Bringer of Order:25D7:/
-1387.1 "Earth Hammer" sync / 1[56]:Hashmal, Bringer of Order:25CB:/
-1395.3 "Hammerfall x3" sync / 1[56]:Hashmal, Bringer of Order:25CC:/
+1360.3 "Quake IV" sync / 1[56]:[^:]*:Hashmal, Bringer of Order:25D8:/
+1369.5 "Quake IV" sync / 1[56]:[^:]*:Hashmal, Bringer of Order:25D8:/
+1378.9 "Rock Cutter" sync / 1[56]:[^:]*:Hashmal, Bringer of Order:25D7:/
+1387.1 "Earth Hammer" sync / 1[56]:[^:]*:Hashmal, Bringer of Order:25CB:/
+1395.3 "Hammerfall x3" sync / 1[56]:[^:]*:Hashmal, Bringer of Order:25CC:/
 
-1398.3 "Summon" sync / 1[56]:Hashmal, Bringer of Order:25D4:/
+1398.3 "Summon" sync / 1[56]:[^:]*:Hashmal, Bringer of Order:25D4:/
 1399.1 "--Golem Adds--"
-1398.6 "Jagged Edge 1" #sync / 1[56]:Hashmal, Bringer of Order:25CD:/
-1400.7 "Jagged Edge 2" #sync / 1[56]:Hashmal, Bringer of Order:25CD:/
-1402.8 "Jagged Edge 3" #sync / 1[56]:Hashmal, Bringer of Order:25CD:/
-1411.3 "Demolish" sync / 1[56]:Pennantstone Golem:25D6:/
-1414.5 "Might" sync / 1[56]:Pennantstone Golem:25D5:/
-1415.8 "Rock Cutter" sync / 1[56]:Hashmal, Bringer of Order:25D7:/
-1428.2 "Rock Cutter" sync / 1[56]:Hashmal, Bringer of Order:25D7:/
-1437.3 "Quake IV" sync / 1[56]:Hashmal, Bringer of Order:25D8:/
+1398.6 "Jagged Edge 1" #sync / 1[56]:[^:]*:Hashmal, Bringer of Order:25CD:/
+1400.7 "Jagged Edge 2" #sync / 1[56]:[^:]*:Hashmal, Bringer of Order:25CD:/
+1402.8 "Jagged Edge 3" #sync / 1[56]:[^:]*:Hashmal, Bringer of Order:25CD:/
+1411.3 "Demolish" sync / 1[56]:[^:]*:Pennantstone Golem:25D6:/
+1414.5 "Might" sync / 1[56]:[^:]*:Pennantstone Golem:25D5:/
+1415.8 "Rock Cutter" sync / 1[56]:[^:]*:Hashmal, Bringer of Order:25D7:/
+1428.2 "Rock Cutter" sync / 1[56]:[^:]*:Hashmal, Bringer of Order:25D7:/
+1437.3 "Quake IV" sync / 1[56]:[^:]*:Hashmal, Bringer of Order:25D8:/
 
-1447.8 "Submission Tower" sync / 1[56]:Hashmal, Bringer of Order:266D:/
-1451.0 "Sanction" sync / 1[56]:Hashmal, Bringer of Order:2703:/
+1447.8 "Submission Tower" sync / 1[56]:[^:]*:Hashmal, Bringer of Order:266D:/
+1451.0 "Sanction" sync / 1[56]:[^:]*:Hashmal, Bringer of Order:2703:/
 1454.1 "--Sand Sphere Adds--"
-# 1459.1 "--sync--" sync / 14:Sand Sphere:25C9:/ # To Dust starts casting, probably the phase over when 20s cast complete
-1460.9 "Towerfall" sync / 1[56]:Submission Tower:25CA:/
-1469.7 "Falling Boulder" sync / 1[56]:Hashmal, Bringer of Order:25D2:/
+# 1459.1 "--sync--" sync / 14:[^:]*:Sand Sphere:25C9:/ # To Dust starts casting, probably the phase over when 20s cast complete
+1460.9 "Towerfall" sync / 1[56]:[^:]*:Submission Tower:25CA:/
+1469.7 "Falling Boulder" sync / 1[56]:[^:]*:Hashmal, Bringer of Order:25D2:/
 
 # Starts roughly after Sand Sphere adds are dead, guessing at this natural time if To Dust goes off
-1480.6 "--sync--" sync / 14:Hashmal, Bringer of Order:(25CE|25D0):/ window 40,40
-1486.6 "Extreme Edge" sync / 1[56]:Hashmal, Bringer of Order:(25CE|25D0):/
-1489.1 "Falling Rock" sync / 1[56]:Hashmal, Bringer of Order:25D3:/
-1499.3 "Quake IV" sync / 1[56]:Hashmal, Bringer of Order:25D8:/
-1508.5 "Rock Cutter" sync / 1[56]:Hashmal, Bringer of Order:25D7:/
+1480.6 "--sync--" sync / 14:[^:]*:Hashmal, Bringer of Order:(25CE|25D0):/ window 40,40
+1486.6 "Extreme Edge" sync / 1[56]:[^:]*:Hashmal, Bringer of Order:(25CE|25D0):/
+1489.1 "Falling Rock" sync / 1[56]:[^:]*:Hashmal, Bringer of Order:25D3:/
+1499.3 "Quake IV" sync / 1[56]:[^:]*:Hashmal, Bringer of Order:25D8:/
+1508.5 "Rock Cutter" sync / 1[56]:[^:]*:Hashmal, Bringer of Order:25D7:/
 
 # loop
-1515.8 "Control Tower x2" sync / 1[56]:Hashmal, Bringer of Order:25C1:/ window 100,100 jump 1314.4
-1519.0 "Sanction" #sync / 1[56]:Hashmal, Bringer of Order:25C3:/
-1526.5 "Towerfall" #sync / 1[56]:Control Tower:25C4:/
-1527.4 "Jagged Edge 1" #sync / 1[56]:Hashmal, Bringer of Order:25CD:/
-1529.5 "Jagged Edge 2" #sync / 1[56]:Hashmal, Bringer of Order:25CD:/
-1531.6 "Jagged Edge 3" #sync / 1[56]:Hashmal, Bringer of Order:25CD:/
+1515.8 "Control Tower x2" sync / 1[56]:[^:]*:Hashmal, Bringer of Order:25C1:/ window 100,100 jump 1314.4
+1519.0 "Sanction" #sync / 1[56]:[^:]*:Hashmal, Bringer of Order:25C3:/
+1526.5 "Towerfall" #sync / 1[56]:[^:]*:Control Tower:25C4:/
+1527.4 "Jagged Edge 1" #sync / 1[56]:[^:]*:Hashmal, Bringer of Order:25CD:/
+1529.5 "Jagged Edge 2" #sync / 1[56]:[^:]*:Hashmal, Bringer of Order:25CD:/
+1531.6 "Jagged Edge 3" #sync / 1[56]:[^:]*:Hashmal, Bringer of Order:25CD:/
 
-1532.3 "Control Tower x2" #sync / 1[56]:Hashmal, Bringer of Order:25C1:/
-1535.5 "Sanction" #sync / 1[56]:Hashmal, Bringer of Order:25C3:/
-1543.1 "Towerfall" #sync / 1[56]:Control Tower:25C4:/
+1532.3 "Control Tower x2" #sync / 1[56]:[^:]*:Hashmal, Bringer of Order:25C1:/
+1535.5 "Sanction" #sync / 1[56]:[^:]*:Hashmal, Bringer of Order:25C3:/
+1543.1 "Towerfall" #sync / 1[56]:[^:]*:Control Tower:25C4:/
 1545.3 "--untargetable--" # ??? from video
-1549.6 "Jagged Edge 1" #sync / 1[56]:Hashmal, Bringer of Order:25CD:/
-1549.9 "Extreme Edge" #sync / 1[56]:Hashmal, Bringer of Order:(25CE|25D0):/
-1551.7 "Jagged Edge 2" #sync / 1[56]:Hashmal, Bringer of Order:25CD:/
-1553.7 "Jagged Edge 3" #sync / 1[56]:Hashmal, Bringer of Order:25CD:/
+1549.6 "Jagged Edge 1" #sync / 1[56]:[^:]*:Hashmal, Bringer of Order:25CD:/
+1549.9 "Extreme Edge" #sync / 1[56]:[^:]*:Hashmal, Bringer of Order:(25CE|25D0):/
+1551.7 "Jagged Edge 2" #sync / 1[56]:[^:]*:Hashmal, Bringer of Order:25CD:/
+1553.7 "Jagged Edge 3" #sync / 1[56]:[^:]*:Hashmal, Bringer of Order:25CD:/
 1556.8 "--targetable--" # ??? from video
 
 
@@ -174,22 +174,22 @@ hideall "--start--"
 # -it "Rofocale"
 
 2000.0 "--start--" sync / 00:0839::The Lesalia Garden Ruins will be sealed off/ window 10000,0
-2012.8 "--sync--" sync / 14:Rofocale:2680:/ window 20,20
-2015.8 "Crush Helm" sync / 1[56]:Rofocale:2680:/ duration 3.4
-2035.5 "Chariot" sync / 1[56]:Rofocale:2674:/
-2040.8 "Cry Of Victory" sync / 1[56]:Rofocale:2675:/
-2052.5 "Crush Weapon x3" sync / 1[56]:Rofocale:2683:/
-2073.4 "Trample" sync / 1[56]:Rofocale:2676:/ duration 3.2
-2093.9 "Maverick" sync / 1[56]:Rofocale:2689:/
-2104.8 "Crush Helm" sync / 1[56]:Rofocale:2680:/ duration 3.4
-2117.7 "Crush Weapon x3" sync / 1[56]:Rofocale:2683:/
-2124.5 "Trample" sync / 1[56]:Rofocale:2676:/
-2142.5 "Chariot" sync / 1[56]:Rofocale:2674:/
-2147.8 "Cry Of Victory" sync / 1[56]:Rofocale:2675:/
-2154.6 "Trample" sync / 1[56]:Rofocale:2676:/ duration 3.2
-2165.8 "Crush Weapon x3" sync / 1[56]:Rofocale:2683:/
-2178.5 "Maverick" sync / 1[56]:Rofocale:2689:/
-2189.4 "Crush Helm" sync / 1[56]:Rofocale:2680:/ duration 3.4
+2012.8 "--sync--" sync / 14:[^:]*:Rofocale:2680:/ window 20,20
+2015.8 "Crush Helm" sync / 1[56]:[^:]*:Rofocale:2680:/ duration 3.4
+2035.5 "Chariot" sync / 1[56]:[^:]*:Rofocale:2674:/
+2040.8 "Cry Of Victory" sync / 1[56]:[^:]*:Rofocale:2675:/
+2052.5 "Crush Weapon x3" sync / 1[56]:[^:]*:Rofocale:2683:/
+2073.4 "Trample" sync / 1[56]:[^:]*:Rofocale:2676:/ duration 3.2
+2093.9 "Maverick" sync / 1[56]:[^:]*:Rofocale:2689:/
+2104.8 "Crush Helm" sync / 1[56]:[^:]*:Rofocale:2680:/ duration 3.4
+2117.7 "Crush Weapon x3" sync / 1[56]:[^:]*:Rofocale:2683:/
+2124.5 "Trample" sync / 1[56]:[^:]*:Rofocale:2676:/
+2142.5 "Chariot" sync / 1[56]:[^:]*:Rofocale:2674:/
+2147.8 "Cry Of Victory" sync / 1[56]:[^:]*:Rofocale:2675:/
+2154.6 "Trample" sync / 1[56]:[^:]*:Rofocale:2676:/ duration 3.2
+2165.8 "Crush Weapon x3" sync / 1[56]:[^:]*:Rofocale:2683:/
+2178.5 "Maverick" sync / 1[56]:[^:]*:Rofocale:2689:/
+2189.4 "Crush Helm" sync / 1[56]:[^:]*:Rofocale:2680:/ duration 3.4
 
 2199.3 "--invulnerable--" # ??? from video, no debuff in logs, can push to this by hp%
 2201.3 "Archaeodemon Adds" sync / 03:........:Archaeodemon:/  window 300,300
@@ -197,83 +197,83 @@ hideall "--start--"
 
 # TODO: could trigger instead off of Rofocale losing Sprint which happens ~here
 2400.0 "--sync--" sync / 00:0044:[^:]*:The heavens tremble in my wake/ window 500,0
-2417.6 "--sync--" sync / 14:Rofocale:268A:/ window 500,10
+2417.6 "--sync--" sync / 14:[^:]*:Rofocale:268A:/ window 500,10
 2421.1 "Heavenly Subjugation"
-2433.5 "Embrace" sync / 1[56]:Rofocale:2685:/
-2450.8 "Chariot" sync / 1[56]:Rofocale:2674:/
-2456.0 "Cry Of Victory" sync / 1[56]:Rofocale:2675:/
-2466.7 "Trample" sync / 1[56]:Rofocale:2676:/ duration 3.2
-2473.5 "Cry Of Victory" sync / 1[56]:Rofocale:274C:/
-2484.6 "Pomp And Circumstance" sync / 1[56]:Rofocale:268D:/
-2492.8 "Embrace" sync / 1[56]:Rofocale:2685:/
-2500.4 "Crush Weapon x4" sync / 1[56]:Rofocale:2683:/
-2512.6 "Maverick" sync / 1[56]:Rofocale:2689:/ # targetable Maverick
-2519.6 "Crush Helm" sync / 1[56]:Rofocale:2680:/
-2531.0 "Embrace" sync / 1[56]:Rofocale:2685:/
-2539.2 "Pomp And Circumstance" sync / 1[56]:Rofocale:268D:/
-2545.4 "Dark Geas" sync / 1[56]:Rofocale:2688:/
+2433.5 "Embrace" sync / 1[56]:[^:]*:Rofocale:2685:/
+2450.8 "Chariot" sync / 1[56]:[^:]*:Rofocale:2674:/
+2456.0 "Cry Of Victory" sync / 1[56]:[^:]*:Rofocale:2675:/
+2466.7 "Trample" sync / 1[56]:[^:]*:Rofocale:2676:/ duration 3.2
+2473.5 "Cry Of Victory" sync / 1[56]:[^:]*:Rofocale:274C:/
+2484.6 "Pomp And Circumstance" sync / 1[56]:[^:]*:Rofocale:268D:/
+2492.8 "Embrace" sync / 1[56]:[^:]*:Rofocale:2685:/
+2500.4 "Crush Weapon x4" sync / 1[56]:[^:]*:Rofocale:2683:/
+2512.6 "Maverick" sync / 1[56]:[^:]*:Rofocale:2689:/ # targetable Maverick
+2519.6 "Crush Helm" sync / 1[56]:[^:]*:Rofocale:2680:/
+2531.0 "Embrace" sync / 1[56]:[^:]*:Rofocale:2685:/
+2539.2 "Pomp And Circumstance" sync / 1[56]:[^:]*:Rofocale:268D:/
+2545.4 "Dark Geas" sync / 1[56]:[^:]*:Rofocale:2688:/
 # => variable time turning off the lights
 
 # Seen 2734 only once in the loop fflogs link below.
-2700.0 "--sync--" sync / 14:Rofocale:(2734|2726):/ window 160,0
-2706.0 "Maverick" sync / 1[56]:Rofocale:(2734|2726):/
-2716.9 "Crush Helm" sync / 1[56]:Rofocale:2680:/
-2726.3 "Embrace" sync / 1[56]:Rofocale:2685:/
-2735.5 "Maverick" sync / 1[56]:Rofocale:2689:/
-2736.5 "Chariot" sync / 1[56]:Rofocale:2674:/
-2741.7 "Cry Of Victory" sync / 1[56]:Rofocale:2675:/
-2751.0 "Maverick" sync / 1[56]:Rofocale:2689:/
-2753.5 "Trample" sync / 1[56]:Rofocale:2676:/
-2760.3 "Cry Of Victory" sync / 1[56]:Rofocale:274C:/
-2774.0 "Crush Weapon x4" sync / 1[56]:Rofocale:2683:/
-2779.1 "Dark Geas" sync / 1[56]:Rofocale:2688:/
+2700.0 "--sync--" sync / 14:[^:]*:Rofocale:(2734|2726):/ window 160,0
+2706.0 "Maverick" sync / 1[56]:[^:]*:Rofocale:(2734|2726):/
+2716.9 "Crush Helm" sync / 1[56]:[^:]*:Rofocale:2680:/
+2726.3 "Embrace" sync / 1[56]:[^:]*:Rofocale:2685:/
+2735.5 "Maverick" sync / 1[56]:[^:]*:Rofocale:2689:/
+2736.5 "Chariot" sync / 1[56]:[^:]*:Rofocale:2674:/
+2741.7 "Cry Of Victory" sync / 1[56]:[^:]*:Rofocale:2675:/
+2751.0 "Maverick" sync / 1[56]:[^:]*:Rofocale:2689:/
+2753.5 "Trample" sync / 1[56]:[^:]*:Rofocale:2676:/
+2760.3 "Cry Of Victory" sync / 1[56]:[^:]*:Rofocale:274C:/
+2774.0 "Crush Weapon x4" sync / 1[56]:[^:]*:Rofocale:2683:/
+2779.1 "Dark Geas" sync / 1[56]:[^:]*:Rofocale:2688:/
 # => variable time turning off the lights
 
-2900.0 "--sync--" sync / 14:Rofocale:(2734|2726):/ window 160,0
-2906.0 "Maverick" sync / 1[56]:Rofocale:(2734|2726):/
-2917.3 "Crush Weapon x4" sync / 1[56]:Rofocale:2683:/
-2924.2 "Trample" sync / 1[56]:Rofocale:2676:/
-2931.0 "Cry Of Victory" sync / 1[56]:Rofocale:274C:/
-2937.2 "Crush Helm" sync / 1[56]:Rofocale:2680:/
-2948.6 "Embrace" sync / 1[56]:Rofocale:2685:/
-2958.9 "Chariot" sync / 1[56]:Rofocale:2674:/
-2964.3 "Cry Of Victory" sync / 1[56]:Rofocale:2675:/
-2971.4 "Pomp And Circumstance" sync / 1[56]:Rofocale:268D:/
-2983.0 "Crush Weapon x4" sync / 1[56]:Rofocale:2683:/
-2990.1 "Pomp And Circumstance" sync / 1[56]:Rofocale:268D:/
-3006.3 "Crush Helm" sync / 1[56]:Rofocale:2680:/
-3015.8 "Embrace" sync / 1[56]:Rofocale:2685:/
-3022.7 "Trample" sync / 1[56]:Rofocale:2676:/
-3029.5 "Cry Of Victory" sync / 1[56]:Rofocale:274C:/
-3036.4 "Trample" sync / 1[56]:Rofocale:2676:/
-3043.1 "Cry Of Victory" sync / 1[56]:Rofocale:274C:/
-3056.8 "Crush Weapon x3" sync / 1[56]:Rofocale:2683:/
+2900.0 "--sync--" sync / 14:[^:]*:Rofocale:(2734|2726):/ window 160,0
+2906.0 "Maverick" sync / 1[56]:[^:]*:Rofocale:(2734|2726):/
+2917.3 "Crush Weapon x4" sync / 1[56]:[^:]*:Rofocale:2683:/
+2924.2 "Trample" sync / 1[56]:[^:]*:Rofocale:2676:/
+2931.0 "Cry Of Victory" sync / 1[56]:[^:]*:Rofocale:274C:/
+2937.2 "Crush Helm" sync / 1[56]:[^:]*:Rofocale:2680:/
+2948.6 "Embrace" sync / 1[56]:[^:]*:Rofocale:2685:/
+2958.9 "Chariot" sync / 1[56]:[^:]*:Rofocale:2674:/
+2964.3 "Cry Of Victory" sync / 1[56]:[^:]*:Rofocale:2675:/
+2971.4 "Pomp And Circumstance" sync / 1[56]:[^:]*:Rofocale:268D:/
+2983.0 "Crush Weapon x4" sync / 1[56]:[^:]*:Rofocale:2683:/
+2990.1 "Pomp And Circumstance" sync / 1[56]:[^:]*:Rofocale:268D:/
+3006.3 "Crush Helm" sync / 1[56]:[^:]*:Rofocale:2680:/
+3015.8 "Embrace" sync / 1[56]:[^:]*:Rofocale:2685:/
+3022.7 "Trample" sync / 1[56]:[^:]*:Rofocale:2676:/
+3029.5 "Cry Of Victory" sync / 1[56]:[^:]*:Rofocale:274C:/
+3036.4 "Trample" sync / 1[56]:[^:]*:Rofocale:2676:/
+3043.1 "Cry Of Victory" sync / 1[56]:[^:]*:Rofocale:274C:/
+3056.8 "Crush Weapon x3" sync / 1[56]:[^:]*:Rofocale:2683:/
 
 # begin loop
 # Thanks to https://www.fflogs.com/reports/zpg2CQNMqFBmawcW#fight=8 for this loop.  @_@;;;
-3068.0 "Maverick" sync / 1[56]:Rofocale:2689:/
-3069.2 "Chariot" sync / 1[56]:Rofocale:2674:/
-3074.5 "Cry of Victory" sync / 1[56]:Rofocale:2675:/
-3083.6 "Crush Helm" sync / 1[56]:Rofocale:2680:/
-3094.8 "Embrace" sync / 1[56]:Rofocale:2685:/
-3102.8 "Pomp and Circumstance" sync / 1[56]:Rofocale:268D:/
-3104.8 "Maverick" sync / 1[56]:Rofocale:2689:/
-3119.3 "Crush Weapon" sync / 1[56]:Rofocale:2683:/
-3126.3 "Pomp and Circumstance" sync / 1[56]:Rofocale:268D:/
-3142.3 "Crush Helm" sync / 1[56]:Rofocale:2680:/
-3149.5 "Embrace" sync / 1[56]:Rofocale:2685:/
-3156.1 "Trample" sync / 1[56]:Rofocale:2676:/
-3162.9 "Cry of Victory" sync / 1[56]:Rofocale:274C:/
-3169.6 "Trample" sync / 1[56]:Rofocale:2676:/
-3176.4 "Cry of Victory" sync / 1[56]:Rofocale:274C:/
-3189.9 "Crush Weapon" sync / 1[56]:Rofocale:2683:/
+3068.0 "Maverick" sync / 1[56]:[^:]*:Rofocale:2689:/
+3069.2 "Chariot" sync / 1[56]:[^:]*:Rofocale:2674:/
+3074.5 "Cry of Victory" sync / 1[56]:[^:]*:Rofocale:2675:/
+3083.6 "Crush Helm" sync / 1[56]:[^:]*:Rofocale:2680:/
+3094.8 "Embrace" sync / 1[56]:[^:]*:Rofocale:2685:/
+3102.8 "Pomp and Circumstance" sync / 1[56]:[^:]*:Rofocale:268D:/
+3104.8 "Maverick" sync / 1[56]:[^:]*:Rofocale:2689:/
+3119.3 "Crush Weapon" sync / 1[56]:[^:]*:Rofocale:2683:/
+3126.3 "Pomp and Circumstance" sync / 1[56]:[^:]*:Rofocale:268D:/
+3142.3 "Crush Helm" sync / 1[56]:[^:]*:Rofocale:2680:/
+3149.5 "Embrace" sync / 1[56]:[^:]*:Rofocale:2685:/
+3156.1 "Trample" sync / 1[56]:[^:]*:Rofocale:2676:/
+3162.9 "Cry of Victory" sync / 1[56]:[^:]*:Rofocale:274C:/
+3169.6 "Trample" sync / 1[56]:[^:]*:Rofocale:2676:/
+3176.4 "Cry of Victory" sync / 1[56]:[^:]*:Rofocale:274C:/
+3189.9 "Crush Weapon" sync / 1[56]:[^:]*:Rofocale:2683:/
 
 # loop
-3200.9 "Maverick" sync / 1[56]:Rofocale:2689:/ window 80,80 jump 3068
-3202.1 "Chariot" #sync / 1[56]:Rofocale:2674:/
-3207.4 "Cry of Victory" #sync / 1[56]:Rofocale:2675:/
-3216.5 "Crush Helm" #sync / 1[56]:Rofocale:2680:/
-3227.7 "Embrace" #sync / 1[56]:Rofocale:2685:/
+3200.9 "Maverick" sync / 1[56]:[^:]*:Rofocale:2689:/ window 80,80 jump 3068
+3202.1 "Chariot" #sync / 1[56]:[^:]*:Rofocale:2674:/
+3207.4 "Cry of Victory" #sync / 1[56]:[^:]*:Rofocale:2675:/
+3216.5 "Crush Helm" #sync / 1[56]:[^:]*:Rofocale:2680:/
+3227.7 "Embrace" #sync / 1[56]:[^:]*:Rofocale:2685:/
 
 
 ### Argath Thadalfus
@@ -289,142 +289,142 @@ hideall "--start--"
 
 ## Phase 1
 4000.0 "--start--" sync / 00:0839::The Lesalia Temple Ruins will be sealed off/ window 10000,0
-4006.7 "--sync--" sync / 14:Argath Thadalfus:262D:/ window 20,20
-4009.7 "Crippling Blow" sync / 1[56]:Argath Thadalfus:262D:/
-4017.9 "Crush Weapon x3" sync / 1[56]:Argath Thadalfus:2628:/
-4023.9 "Soulfix" sync / 1[56]:Argath Thadalfus:262A:/
-4030.0 "Mask Of Truth" sync / 1[56]:Argath Thadalfus:261A:/
-4038.0 "The Word" sync / 1[56]:Argath Thadalfus:24A0:/
-4049.8 "Fire IV" sync / 1[56]:Argath Thadalfus:262E:/
-4058.1 "Crippling Blow" sync / 1[56]:Argath Thadalfus:262D:/
+4006.7 "--sync--" sync / 14:[^:]*:Argath Thadalfus:262D:/ window 20,20
+4009.7 "Crippling Blow" sync / 1[56]:[^:]*:Argath Thadalfus:262D:/
+4017.9 "Crush Weapon x3" sync / 1[56]:[^:]*:Argath Thadalfus:2628:/
+4023.9 "Soulfix" sync / 1[56]:[^:]*:Argath Thadalfus:262A:/
+4030.0 "Mask Of Truth" sync / 1[56]:[^:]*:Argath Thadalfus:261A:/
+4038.0 "The Word" sync / 1[56]:[^:]*:Argath Thadalfus:24A0:/
+4049.8 "Fire IV" sync / 1[56]:[^:]*:Argath Thadalfus:262E:/
+4058.1 "Crippling Blow" sync / 1[56]:[^:]*:Argath Thadalfus:262D:/
 
 # Note: adding a larger sync in case there's a push here just to be safe.
-4064.3 "--sync--" sync / 14:Argath Thadalfus:2622:/ window 100,10
-4067.3 "Trepidation" sync / 1[56]:Argath Thadalfus:2622:/
-4075.8 "Unrelenting" sync / 1[56]:Argath Thadalfus:262B:/
-4077.3 "Rail Of The Rat 1" sync / 1[56]:Argath Thadalfus:2624:/
-4080.3 "Rail Of The Rat 2" sync / 1[56]:Argath Thadalfus:2624:/
-4083.5 "Rail Of The Rat 3" sync / 1[56]:Argath Thadalfus:2624:/
-4084.1 "Crippling Blow" sync / 1[56]:Argath Thadalfus:262D:/
-4086.8 "Mask Of Truth" sync / 1[56]:Argath Thadalfus:261A:/
-4094.9 "The Word" sync / 1[56]:Argath Thadalfus:24A0:/
+4064.3 "--sync--" sync / 14:[^:]*:Argath Thadalfus:2622:/ window 100,10
+4067.3 "Trepidation" sync / 1[56]:[^:]*:Argath Thadalfus:2622:/
+4075.8 "Unrelenting" sync / 1[56]:[^:]*:Argath Thadalfus:262B:/
+4077.3 "Rail Of The Rat 1" sync / 1[56]:[^:]*:Argath Thadalfus:2624:/
+4080.3 "Rail Of The Rat 2" sync / 1[56]:[^:]*:Argath Thadalfus:2624:/
+4083.5 "Rail Of The Rat 3" sync / 1[56]:[^:]*:Argath Thadalfus:2624:/
+4084.1 "Crippling Blow" sync / 1[56]:[^:]*:Argath Thadalfus:262D:/
+4086.8 "Mask Of Truth" sync / 1[56]:[^:]*:Argath Thadalfus:261A:/
+4094.9 "The Word" sync / 1[56]:[^:]*:Argath Thadalfus:24A0:/
 
 # Can early push (before Trepidation) to Judgment Blade.
 # TODO: is this an HP push? or is this a bug? I see this in <5% of logs atmost.
-4099.0 "--sync--" sync / 14:Argath Thadalfus:2629:/ window 100,10
-4102.0 "Judgment Blade" sync / 1[56]:Argath Thadalfus:2629:/
-4108.3 "Crippling Blow" sync / 1[56]:Argath Thadalfus:262D:/
-4110.4 "--sync--" sync / 1[56]:Argath Thadalfus:2625:/
-4117.7 "Heartless" sync / 1[56]:Heartless:2632:/
-4120.4 "Coldblood" sync / 1[56]:Argath Thadalfus:2627:/
-4129.2 "Royal Blood" #sync / 1[56]:Argath Thadalfus:261E:/
+4099.0 "--sync--" sync / 14:[^:]*:Argath Thadalfus:2629:/ window 100,10
+4102.0 "Judgment Blade" sync / 1[56]:[^:]*:Argath Thadalfus:2629:/
+4108.3 "Crippling Blow" sync / 1[56]:[^:]*:Argath Thadalfus:262D:/
+4110.4 "--sync--" sync / 1[56]:[^:]*:Argath Thadalfus:2625:/
+4117.7 "Heartless" sync / 1[56]:[^:]*:Heartless:2632:/
+4120.4 "Coldblood" sync / 1[56]:[^:]*:Argath Thadalfus:2627:/
+4129.2 "Royal Blood" #sync / 1[56]:[^:]*:Argath Thadalfus:261E:/
 
 ## Phase 2: Shades and Shards (percentage push to this, 72%?)
-4500.0 "--sync--" sync / 14:Argath Thadalfus:261E:/ window 500,0
-4505.0 "Royal Blood" sync / 1[56]:Argath Thadalfus:261E:/
+4500.0 "--sync--" sync / 14:[^:]*:Argath Thadalfus:261E:/ window 500,0
+4505.0 "Royal Blood" sync / 1[56]:[^:]*:Argath Thadalfus:261E:/
 4505.3 "--Shade Adds--"
-4515.2 "Crippling Blow" sync / 1[56]:Argath Thadalfus:262D:/
-4525.4 "Unrelenting" sync / 1[56]:Argath Thadalfus:262B:/
+4515.2 "Crippling Blow" sync / 1[56]:[^:]*:Argath Thadalfus:262D:/
+4525.4 "Unrelenting" sync / 1[56]:[^:]*:Argath Thadalfus:262B:/
 # => variable amount of time until all shades are dead or explode
 
-4600.0 "--sync--" sync / 14:Argath Thadalfus:261F:/ window 600,0
-4605.0 "Empty Soul" sync / 1[56]:Argath Thadalfus:261F:/
+4600.0 "--sync--" sync / 14:[^:]*:Argath Thadalfus:261F:/ window 600,0
+4605.0 "Empty Soul" sync / 1[56]:[^:]*:Argath Thadalfus:261F:/
 4605.9 "--Shard Adds--"
-4607.1 "--sync--" sync / 1[56]:Argath Thadalfus:270B:/
+4607.1 "--sync--" sync / 1[56]:[^:]*:Argath Thadalfus:270B:/
 # => variable amount of time until all shards are dead or you wipe
 
-4700.0 "--sync--" sync / 14:Argath Thadalfus:2620:/ window 700,0
-4702.5 "Dark Ultima" sync / 1[56]:Argath Thadalfus:2620:/
-4715.4 "Mask Of Lies" sync / 1[56]:Argath Thadalfus:2619:/
-4723.4 "The Word" sync / 1[56]:Argath Thadalfus:24A0:/
-4732.5 "Gnawing Dread" sync / 1[56]:Argath Thadalfus:2621:/
-4740.7 "Soulfix" sync / 1[56]:Argath Thadalfus:262A:/
-4746.6 "Unrelenting" sync / 1[56]:Argath Thadalfus:262B:/
-4756.5 "Crippling Blow" sync / 1[56]:Argath Thadalfus:262D:/
-4762.7 "Soulfix" sync / 1[56]:Argath Thadalfus:262A:/
-4771.9 "Crush Weapon" sync / 1[56]:Argath Thadalfus:2628:/
-4777.2 "Unrelenting" sync / 1[56]:Argath Thadalfus:262B:/
-4786.4 "Fire IV" sync / 1[56]:Argath Thadalfus:262E:/
+4700.0 "--sync--" sync / 14:[^:]*:Argath Thadalfus:2620:/ window 700,0
+4702.5 "Dark Ultima" sync / 1[56]:[^:]*:Argath Thadalfus:2620:/
+4715.4 "Mask Of Lies" sync / 1[56]:[^:]*:Argath Thadalfus:2619:/
+4723.4 "The Word" sync / 1[56]:[^:]*:Argath Thadalfus:24A0:/
+4732.5 "Gnawing Dread" sync / 1[56]:[^:]*:Argath Thadalfus:2621:/
+4740.7 "Soulfix" sync / 1[56]:[^:]*:Argath Thadalfus:262A:/
+4746.6 "Unrelenting" sync / 1[56]:[^:]*:Argath Thadalfus:262B:/
+4756.5 "Crippling Blow" sync / 1[56]:[^:]*:Argath Thadalfus:262D:/
+4762.7 "Soulfix" sync / 1[56]:[^:]*:Argath Thadalfus:262A:/
+4771.9 "Crush Weapon" sync / 1[56]:[^:]*:Argath Thadalfus:2628:/
+4777.2 "Unrelenting" sync / 1[56]:[^:]*:Argath Thadalfus:262B:/
+4786.4 "Fire IV" sync / 1[56]:[^:]*:Argath Thadalfus:262E:/
 # => natural push into phase 3
 # (probably, based on https://www.fflogs.com/reports/8Wmfp6FZ72DtcjKn#fight=last at hp=67%)
 
 ## Phase 3: ~45% (can push early)
-4795.0 "Mask Of Truth/Mask Of Lies" sync / 1[56]:Argath Thadalfus:(2619|261A):/ window 100,10
-4803.0 "The Word" sync / 1[56]:Argath Thadalfus:24A0:/
-4813.6 "Mask Of Truth/Mask Of Lies" sync / 1[56]:Argath Thadalfus:(2619|261A):/
-4821.8 "The Word" sync / 1[56]:Argath Thadalfus:24A0:/
-4828.8 "Judgment Blade?" sync / 1[56]:Argath Thadalfus:2629:/ window 100,100 jump 5000
-4830.7 "Gnawing Dread?" sync / 1[56]:Argath Thadalfus:2621:/ window 100,100 jump 5300
+4795.0 "Mask Of Truth/Mask Of Lies" sync / 1[56]:[^:]*:Argath Thadalfus:(2619|261A):/ window 100,10
+4803.0 "The Word" sync / 1[56]:[^:]*:Argath Thadalfus:24A0:/
+4813.6 "Mask Of Truth/Mask Of Lies" sync / 1[56]:[^:]*:Argath Thadalfus:(2619|261A):/
+4821.8 "The Word" sync / 1[56]:[^:]*:Argath Thadalfus:24A0:/
+4828.8 "Judgment Blade?" sync / 1[56]:[^:]*:Argath Thadalfus:2629:/ window 100,100 jump 5000
+4830.7 "Gnawing Dread?" sync / 1[56]:[^:]*:Argath Thadalfus:2621:/ window 100,100 jump 5300
 
 ## Phase 4a: Judgment blade first
-5000.0 "Judgment Blade" sync / 1[56]:Argath Thadalfus:2629:/
-5006.1 "Unrelenting" sync / 1[56]:Argath Thadalfus:262B:/
-5008.2 "--sync--" sync / 1[56]:Argath Thadalfus:2625:/
-5015.9 "Heartless" sync / 1[56]:Heartless:2632:/
-5018.2 "Coldblood" sync / 1[56]:Argath Thadalfus:2627:/
-5032.2 "Fire IV" sync / 1[56]:Argath Thadalfus:262E:/
-5040.4 "Crippling Blow" sync / 1[56]:Argath Thadalfus:262D:/
-5045.5 "Trepidation" sync / 1[56]:Argath Thadalfus:2622:/
-5050.6 "Crush Weapon" sync / 1[56]:Argath Thadalfus:2628:/
-5055.6 "Rail Of The Rat 1" sync / 1[56]:Argath Thadalfus:2624:/
-5058.6 "Rail Of The Rat 2" sync / 1[56]:Argath Thadalfus:2624:/
-5061.6 "Rail Of The Rat 3" sync / 1[56]:Argath Thadalfus:2624:/
-5065.8 "Soulfix" sync / 1[56]:Argath Thadalfus:262A:/
-5076.4 "Mask Of Truth/Mask Of Lies" sync / 1[56]:Argath Thadalfus:(2619|261A):/
-5084.5 "The Word" sync / 1[56]:Argath Thadalfus:24A0:/
-5095.0 "Mask Of Truth/Mask Of Lies" sync / 1[56]:Argath Thadalfus:(2619|261A):/
-5103.1 "The Word" sync / 1[56]:Argath Thadalfus:24A0:/
-5112.0 "Gnawing Dread" sync / 1[56]:Argath Thadalfus:2621:/
-5114.1 "--sync--" sync / 1[56]:Argath Thadalfus:2625:/
-5128.1 "Coldblood (Hole In One)" sync / 1[56]:Argath Thadalfus:2626:/
-5135.3 "Soulfix" sync / 1[56]:Argath Thadalfus:262A:/
-5148.2 "Crippling Blow" sync / 1[56]:Argath Thadalfus:262D:/
-5159.5 "Gnawing Dread" sync / 1[56]:Argath Thadalfus:2621:/
-5168.7 "Crush Weapon" sync / 1[56]:Argath Thadalfus:2628:/
-5173.9 "Unrelenting" sync / 1[56]:Argath Thadalfus:262B:/
-5180.0 "Fire IV" sync / 1[56]:Argath Thadalfus:262E:/
-5189.1 "Fire IV" sync / 1[56]:Argath Thadalfus:262E:/
-5197.1 "Crippling Blow" sync / 1[56]:Argath Thadalfus:262D:/
+5000.0 "Judgment Blade" sync / 1[56]:[^:]*:Argath Thadalfus:2629:/
+5006.1 "Unrelenting" sync / 1[56]:[^:]*:Argath Thadalfus:262B:/
+5008.2 "--sync--" sync / 1[56]:[^:]*:Argath Thadalfus:2625:/
+5015.9 "Heartless" sync / 1[56]:[^:]*:Heartless:2632:/
+5018.2 "Coldblood" sync / 1[56]:[^:]*:Argath Thadalfus:2627:/
+5032.2 "Fire IV" sync / 1[56]:[^:]*:Argath Thadalfus:262E:/
+5040.4 "Crippling Blow" sync / 1[56]:[^:]*:Argath Thadalfus:262D:/
+5045.5 "Trepidation" sync / 1[56]:[^:]*:Argath Thadalfus:2622:/
+5050.6 "Crush Weapon" sync / 1[56]:[^:]*:Argath Thadalfus:2628:/
+5055.6 "Rail Of The Rat 1" sync / 1[56]:[^:]*:Argath Thadalfus:2624:/
+5058.6 "Rail Of The Rat 2" sync / 1[56]:[^:]*:Argath Thadalfus:2624:/
+5061.6 "Rail Of The Rat 3" sync / 1[56]:[^:]*:Argath Thadalfus:2624:/
+5065.8 "Soulfix" sync / 1[56]:[^:]*:Argath Thadalfus:262A:/
+5076.4 "Mask Of Truth/Mask Of Lies" sync / 1[56]:[^:]*:Argath Thadalfus:(2619|261A):/
+5084.5 "The Word" sync / 1[56]:[^:]*:Argath Thadalfus:24A0:/
+5095.0 "Mask Of Truth/Mask Of Lies" sync / 1[56]:[^:]*:Argath Thadalfus:(2619|261A):/
+5103.1 "The Word" sync / 1[56]:[^:]*:Argath Thadalfus:24A0:/
+5112.0 "Gnawing Dread" sync / 1[56]:[^:]*:Argath Thadalfus:2621:/
+5114.1 "--sync--" sync / 1[56]:[^:]*:Argath Thadalfus:2625:/
+5128.1 "Coldblood (Hole In One)" sync / 1[56]:[^:]*:Argath Thadalfus:2626:/
+5135.3 "Soulfix" sync / 1[56]:[^:]*:Argath Thadalfus:262A:/
+5148.2 "Crippling Blow" sync / 1[56]:[^:]*:Argath Thadalfus:262D:/
+5159.5 "Gnawing Dread" sync / 1[56]:[^:]*:Argath Thadalfus:2621:/
+5168.7 "Crush Weapon" sync / 1[56]:[^:]*:Argath Thadalfus:2628:/
+5173.9 "Unrelenting" sync / 1[56]:[^:]*:Argath Thadalfus:262B:/
+5180.0 "Fire IV" sync / 1[56]:[^:]*:Argath Thadalfus:262E:/
+5189.1 "Fire IV" sync / 1[56]:[^:]*:Argath Thadalfus:262E:/
+5197.1 "Crippling Blow" sync / 1[56]:[^:]*:Argath Thadalfus:262D:/
 
 # loop
-5207.2 "Mask Of Truth/Mask Of Lies" sync / 1[56]:Argath Thadalfus:(2619|261A):/ window 100,100 jump 4795
-5215.3 "The Word" #sync / 1[56]:Argath Thadalfus:24A0:/
-5225.6 "Mask Of Truth/Mask Of Lies" #sync / 1[56]:Argath Thadalfus:(2619|261A):/
-5233.7 "The Word" #sync / 1[56]:Argath Thadalfus:24A0:/
+5207.2 "Mask Of Truth/Mask Of Lies" sync / 1[56]:[^:]*:Argath Thadalfus:(2619|261A):/ window 100,100 jump 4795
+5215.3 "The Word" #sync / 1[56]:[^:]*:Argath Thadalfus:24A0:/
+5225.6 "Mask Of Truth/Mask Of Lies" #sync / 1[56]:[^:]*:Argath Thadalfus:(2619|261A):/
+5233.7 "The Word" #sync / 1[56]:[^:]*:Argath Thadalfus:24A0:/
 
 
 ## Phase 4b: Putt Putt first
-5300.0 "Gnawing Dread" sync / 1[56]:Argath Thadalfus:2621:/
-5302.1 "--sync--" sync / 1[56]:Argath Thadalfus:2625:/
-5316.0 "Coldblood (Hole In One)" sync / 1[56]:Argath Thadalfus:2626:/
-5323.2 "Soulfix" sync / 1[56]:Argath Thadalfus:262A:/
-5337.2 "Fire IV" sync / 1[56]:Argath Thadalfus:262E:/
-5345.5 "Crippling Blow" sync / 1[56]:Argath Thadalfus:262D:/
-5350.7 "Trepidation" sync / 1[56]:Argath Thadalfus:2622:/
-5355.8 "Crush Weapon" sync / 1[56]:Argath Thadalfus:2628:/
-5360.8 "Rail Of The Rat 1" sync / 1[56]:Argath Thadalfus:2624:/
-5363.8 "Rail Of The Rat 2" sync / 1[56]:Argath Thadalfus:2624:/
-5366.9 "Rail Of The Rat 3" sync / 1[56]:Argath Thadalfus:2624:/
-5371.1 "Soulfix" sync / 1[56]:Argath Thadalfus:262A:/
-5384.3 "Mask Of Truth/Mask Of Lies" sync / 1[56]:Argath Thadalfus:(2619|261A):/
-5392.3 "The Word" sync / 1[56]:Argath Thadalfus:24A0:/
-5402.9 "Mask Of Truth/Mask Of Lies" sync / 1[56]:Argath Thadalfus:(2619|261A):/
-5411.1 "The Word" sync / 1[56]:Argath Thadalfus:24A0:/
-5418.0 "Judgment Blade" sync / 1[56]:Argath Thadalfus:2629:/
-5424.4 "Unrelenting" sync / 1[56]:Argath Thadalfus:262B:/
-5426.5 "--sync--" sync / 1[56]:Argath Thadalfus:2625:/
-5433.9 "Heartless" sync / 1[56]:Heartless:2632:/
-5436.6 "Coldblood" sync / 1[56]:Argath Thadalfus:2627:/
-5449.5 "Crippling Blow" sync / 1[56]:Argath Thadalfus:262D:/
-5460.7 "Gnawing Dread" sync / 1[56]:Argath Thadalfus:2621:/
-5469.9 "Crush Weapon" sync / 1[56]:Argath Thadalfus:2628:/
-5475.1 "Unrelenting" sync / 1[56]:Argath Thadalfus:262B:/
-5481.2 "Fire IV" sync / 1[56]:Argath Thadalfus:262E:/
-5490.3 "Fire IV" sync / 1[56]:Argath Thadalfus:262E:/
-5498.3 "Crippling Blow" sync / 1[56]:Argath Thadalfus:262D:/
+5300.0 "Gnawing Dread" sync / 1[56]:[^:]*:Argath Thadalfus:2621:/
+5302.1 "--sync--" sync / 1[56]:[^:]*:Argath Thadalfus:2625:/
+5316.0 "Coldblood (Hole In One)" sync / 1[56]:[^:]*:Argath Thadalfus:2626:/
+5323.2 "Soulfix" sync / 1[56]:[^:]*:Argath Thadalfus:262A:/
+5337.2 "Fire IV" sync / 1[56]:[^:]*:Argath Thadalfus:262E:/
+5345.5 "Crippling Blow" sync / 1[56]:[^:]*:Argath Thadalfus:262D:/
+5350.7 "Trepidation" sync / 1[56]:[^:]*:Argath Thadalfus:2622:/
+5355.8 "Crush Weapon" sync / 1[56]:[^:]*:Argath Thadalfus:2628:/
+5360.8 "Rail Of The Rat 1" sync / 1[56]:[^:]*:Argath Thadalfus:2624:/
+5363.8 "Rail Of The Rat 2" sync / 1[56]:[^:]*:Argath Thadalfus:2624:/
+5366.9 "Rail Of The Rat 3" sync / 1[56]:[^:]*:Argath Thadalfus:2624:/
+5371.1 "Soulfix" sync / 1[56]:[^:]*:Argath Thadalfus:262A:/
+5384.3 "Mask Of Truth/Mask Of Lies" sync / 1[56]:[^:]*:Argath Thadalfus:(2619|261A):/
+5392.3 "The Word" sync / 1[56]:[^:]*:Argath Thadalfus:24A0:/
+5402.9 "Mask Of Truth/Mask Of Lies" sync / 1[56]:[^:]*:Argath Thadalfus:(2619|261A):/
+5411.1 "The Word" sync / 1[56]:[^:]*:Argath Thadalfus:24A0:/
+5418.0 "Judgment Blade" sync / 1[56]:[^:]*:Argath Thadalfus:2629:/
+5424.4 "Unrelenting" sync / 1[56]:[^:]*:Argath Thadalfus:262B:/
+5426.5 "--sync--" sync / 1[56]:[^:]*:Argath Thadalfus:2625:/
+5433.9 "Heartless" sync / 1[56]:[^:]*:Heartless:2632:/
+5436.6 "Coldblood" sync / 1[56]:[^:]*:Argath Thadalfus:2627:/
+5449.5 "Crippling Blow" sync / 1[56]:[^:]*:Argath Thadalfus:262D:/
+5460.7 "Gnawing Dread" sync / 1[56]:[^:]*:Argath Thadalfus:2621:/
+5469.9 "Crush Weapon" sync / 1[56]:[^:]*:Argath Thadalfus:2628:/
+5475.1 "Unrelenting" sync / 1[56]:[^:]*:Argath Thadalfus:262B:/
+5481.2 "Fire IV" sync / 1[56]:[^:]*:Argath Thadalfus:262E:/
+5490.3 "Fire IV" sync / 1[56]:[^:]*:Argath Thadalfus:262E:/
+5498.3 "Crippling Blow" sync / 1[56]:[^:]*:Argath Thadalfus:262D:/
 
 # loop
-5508.4 "Mask Of Truth/Mask Of Lies" sync / 1[56]:Argath Thadalfus:(2619|261A):/ window 100,100 jump 4795
-5516.5 "The Word" #sync / 1[56]:Argath Thadalfus:24A0:/
-5526.8 "Mask Of Truth/Mask Of Lies" #sync / 1[56]:Argath Thadalfus:(2619|261A):/
-5534.9 "The Word" #sync / 1[56]:Argath Thadalfus:24A0:/
+5508.4 "Mask Of Truth/Mask Of Lies" sync / 1[56]:[^:]*:Argath Thadalfus:(2619|261A):/ window 100,100 jump 4795
+5516.5 "The Word" #sync / 1[56]:[^:]*:Argath Thadalfus:24A0:/
+5526.8 "Mask Of Truth/Mask Of Lies" #sync / 1[56]:[^:]*:Argath Thadalfus:(2619|261A):/
+5534.9 "The Word" #sync / 1[56]:[^:]*:Argath Thadalfus:24A0:/

--- a/ui/raidboss/data/04-sb/dungeon/ala_mhigo.txt
+++ b/ui/raidboss/data/04-sb/dungeon/ala_mhigo.txt
@@ -6,21 +6,21 @@ hideall "--sync--"
 # Guard Scorpion
 # -ii 2049 204A 204B 204C
 0.0 "--Start--" sync / 00:0839::Rhalgr's Gate will be sealed off/
-4.1 "--sync--" sync / 1[56]:Magitek Scorpion:2457:/ window 3,1
-9.6 "Electromagnetic Field" sync / 1[56]:Magitek Scorpion:204D:/
-18.8 "Target Search" sync / 1[56]:Magitek Scorpion:2046:/
-29.4 "Lock On" sync / 1[56]:Magitek Scorpion:2047:/
-31.5 "Tail Laser" sync / 1[56]:Magitek Scorpion:2048:/
-56.7 "Electromagnetic Field" sync / 1[56]:Magitek Scorpion:204D:/
+4.1 "--sync--" sync / 1[56]:[^:]*:Magitek Scorpion:2457:/ window 3,1
+9.6 "Electromagnetic Field" sync / 1[56]:[^:]*:Magitek Scorpion:204D:/
+18.8 "Target Search" sync / 1[56]:[^:]*:Magitek Scorpion:2046:/
+29.4 "Lock On" sync / 1[56]:[^:]*:Magitek Scorpion:2047:/
+31.5 "Tail Laser" sync / 1[56]:[^:]*:Magitek Scorpion:2048:/
+56.7 "Electromagnetic Field" sync / 1[56]:[^:]*:Magitek Scorpion:204D:/
 
-64.9 "Target Search" sync / 1[56]:Magitek Scorpion:2046:/
-72.2 "Tail Laser" sync / 1[56]:Magitek Scorpion:2048:/
-75.5 "Lock On" sync / 1[56]:Magitek Scorpion:2047:/
-85.5 "Tail Laser" sync / 1[56]:Magitek Scorpion:2048:/
-93.9 "Lock On" sync / 1[56]:Magitek Scorpion:2047:/
-101.6 "Electromagnetic Field" sync / 1[56]:Magitek Scorpion:204D:/
-111.8 "Electromagnetic Field" sync / 1[56]:Magitek Scorpion:204D:/
-126.0 "Electromagnetic Field" sync / 1[56]:Magitek Scorpion:204D:/ jump 56.7
+64.9 "Target Search" sync / 1[56]:[^:]*:Magitek Scorpion:2046:/
+72.2 "Tail Laser" sync / 1[56]:[^:]*:Magitek Scorpion:2048:/
+75.5 "Lock On" sync / 1[56]:[^:]*:Magitek Scorpion:2047:/
+85.5 "Tail Laser" sync / 1[56]:[^:]*:Magitek Scorpion:2048:/
+93.9 "Lock On" sync / 1[56]:[^:]*:Magitek Scorpion:2047:/
+101.6 "Electromagnetic Field" sync / 1[56]:[^:]*:Magitek Scorpion:204D:/
+111.8 "Electromagnetic Field" sync / 1[56]:[^:]*:Magitek Scorpion:204D:/
+126.0 "Electromagnetic Field" sync / 1[56]:[^:]*:Magitek Scorpion:204D:/ jump 56.7
 
 134.2 "Target Search"
 141.5 "Tail Laser"
@@ -31,53 +31,53 @@ hideall "--sync--"
 # Aulus Mal Asina
 # -ii 2051 2052 205E
 1000.0 "--Start--" sync / 00:0839::The Chamber of Knowledge will be sealed off/ window 1000,5
-1002.7 "--sync--" sync / 1[56]:Aulus Mal Asina:2458:/ window 3,1
-1013.2 "Mana Burst" sync / 1[56]:Aulus Mal Asina:204F:/
-1019.4 "Order To Charge" sync / 1[56]:Aulus Mal Asina:2057:/
-1020.2 "--sync--" sync / 1[56]:Prototype Bit:2053:/
-1025.6 "Order To Fire" sync / 1[56]:Aulus Mal Asina:2058:/
-1029.2 "Aetherochemical Grenado" sync / 1[56]:Prototype Bit:205A:/
-1033.8 "Integrated Aetheromodulator" sync / 1[56]:Prototype Bit:205B:/
-1035.9 "--sync--" sync / 1[56]:Prototype Bit:2053:/
-1050.6 "Magitek Disruptor" sync / 1[56]:Aulus Mal Asina:2050:/
-1055.7 "Mindjack" sync / 1[56]:Aulus Mal Asina:204E:/ window 50,10
+1002.7 "--sync--" sync / 1[56]:[^:]*:Aulus Mal Asina:2458:/ window 3,1
+1013.2 "Mana Burst" sync / 1[56]:[^:]*:Aulus Mal Asina:204F:/
+1019.4 "Order To Charge" sync / 1[56]:[^:]*:Aulus Mal Asina:2057:/
+1020.2 "--sync--" sync / 1[56]:[^:]*:Prototype Bit:2053:/
+1025.6 "Order To Fire" sync / 1[56]:[^:]*:Aulus Mal Asina:2058:/
+1029.2 "Aetherochemical Grenado" sync / 1[56]:[^:]*:Prototype Bit:205A:/
+1033.8 "Integrated Aetheromodulator" sync / 1[56]:[^:]*:Prototype Bit:205B:/
+1035.9 "--sync--" sync / 1[56]:[^:]*:Prototype Bit:2053:/
+1050.6 "Magitek Disruptor" sync / 1[56]:[^:]*:Aulus Mal Asina:2050:/
+1055.7 "Mindjack" sync / 1[56]:[^:]*:Aulus Mal Asina:204E:/ window 50,10
 
 # Intermission.
-1056.9 "--sync--" sync / 1[56]:Prototype Bit:2053:/ window 50,5
-1067.8 "Magitek Ray" sync / 1[56]:Prototype Bit:2054:/
-1073.8 "Magitek Ray" sync / 1[56]:Prototype Bit:2054:/ jump 1067.8
+1056.9 "--sync--" sync / 1[56]:[^:]*:Prototype Bit:2053:/ window 50,5
+1067.8 "Magitek Ray" sync / 1[56]:[^:]*:Prototype Bit:2054:/
+1073.8 "Magitek Ray" sync / 1[56]:[^:]*:Prototype Bit:2054:/ jump 1067.8
 1079.8 "Magitek Ray"
 1085.8 "Magitek Ray"
 1091.8 "Magitek Ray"
 1097.8 "Magitek Ray"
 
 # Intermission closing
-1200.0 "--sync--" sync / 1[56]:Aulus Mal Asina:2056:/ window 200,5
-1201.5 "--sync--" sync / 1[56]:Prototype Bit:2053:/
-1216.5 "Mana Burst" sync / 1[56]:Aulus Mal Asina:204F:/
+1200.0 "--sync--" sync / 1[56]:[^:]*:Aulus Mal Asina:2056:/ window 200,5
+1201.5 "--sync--" sync / 1[56]:[^:]*:Prototype Bit:2053:/
+1216.5 "Mana Burst" sync / 1[56]:[^:]*:Aulus Mal Asina:204F:/
 
 # Main rotation resumes
-1222.7 "Order To Charge" sync / 1[56]:Aulus Mal Asina:2057:/ window 150,30
-1223.5 "--sync--" sync / 1[56]:Prototype Bit:2053:/
-1228.9 "Order To Fire" sync / 1[56]:Aulus Mal Asina:2058:/
-1231.8 "Integrated Aetheromodulator" sync / 1[56]:Prototype Bit:205B:/
-1232.5 "Aetherochemical Grenado" sync / 1[56]:Prototype Bit:205A:/
-1237.1 "Demimagicks" sync / 1[56]:Aulus Mal Asina:205D:/
-1237.1 "Integrated Aetheromodulator" sync / 1[56]:Prototype Bit:205B:/
-1239.2 "--sync--" sync / 1[56]:Prototype Bit:2053:/
-1247.2 "Mana Burst" sync / 1[56]:Aulus Mal Asina:204F:/
-1260.3 "Mana Burst" sync / 1[56]:Aulus Mal Asina:204F:/
+1222.7 "Order To Charge" sync / 1[56]:[^:]*:Aulus Mal Asina:2057:/ window 150,30
+1223.5 "--sync--" sync / 1[56]:[^:]*:Prototype Bit:2053:/
+1228.9 "Order To Fire" sync / 1[56]:[^:]*:Aulus Mal Asina:2058:/
+1231.8 "Integrated Aetheromodulator" sync / 1[56]:[^:]*:Prototype Bit:205B:/
+1232.5 "Aetherochemical Grenado" sync / 1[56]:[^:]*:Prototype Bit:205A:/
+1237.1 "Demimagicks" sync / 1[56]:[^:]*:Aulus Mal Asina:205D:/
+1237.1 "Integrated Aetheromodulator" sync / 1[56]:[^:]*:Prototype Bit:205B:/
+1239.2 "--sync--" sync / 1[56]:[^:]*:Prototype Bit:2053:/
+1247.2 "Mana Burst" sync / 1[56]:[^:]*:Aulus Mal Asina:204F:/
+1260.3 "Mana Burst" sync / 1[56]:[^:]*:Aulus Mal Asina:204F:/
 
-1266.5 "Order To Charge" sync / 1[56]:Aulus Mal Asina:2057:/ window 15,15
-1267.3 "--sync--" sync / 1[56]:Prototype Bit:2053:/
-1272.7 "Order To Fire" sync / 1[56]:Aulus Mal Asina:2058:/
-1275.6 "Integrated Aetheromodulator" sync / 1[56]:Prototype Bit:205B:/
-1276.3 "Aetherochemical Grenado" sync / 1[56]:Prototype Bit:205A:/
-1280.9 "Demimagicks" sync / 1[56]:Aulus Mal Asina:205D:/
-1280.9 "Integrated Aetheromodulator" sync / 1[56]:Prototype Bit:205B:/
-1283.0 "--sync--" sync / 1[56]:Prototype Bit:2053:/
-1291.0 "Mana Burst" sync / 1[56]:Aulus Mal Asina:204F:/
-1304.1 "Mana Burst" sync / 1[56]:Aulus Mal Asina:204F:/ jump 1141.7
+1266.5 "Order To Charge" sync / 1[56]:[^:]*:Aulus Mal Asina:2057:/ window 15,15
+1267.3 "--sync--" sync / 1[56]:[^:]*:Prototype Bit:2053:/
+1272.7 "Order To Fire" sync / 1[56]:[^:]*:Aulus Mal Asina:2058:/
+1275.6 "Integrated Aetheromodulator" sync / 1[56]:[^:]*:Prototype Bit:205B:/
+1276.3 "Aetherochemical Grenado" sync / 1[56]:[^:]*:Prototype Bit:205A:/
+1280.9 "Demimagicks" sync / 1[56]:[^:]*:Aulus Mal Asina:205D:/
+1280.9 "Integrated Aetheromodulator" sync / 1[56]:[^:]*:Prototype Bit:205B:/
+1283.0 "--sync--" sync / 1[56]:[^:]*:Prototype Bit:2053:/
+1291.0 "Mana Burst" sync / 1[56]:[^:]*:Aulus Mal Asina:204F:/
+1304.1 "Mana Burst" sync / 1[56]:[^:]*:Aulus Mal Asina:204F:/ jump 1141.7
 
 1310.3 "Order To Charge"
 1316.5 "Order To Fire"
@@ -91,21 +91,21 @@ hideall "--sync--"
 # -ii 2061 2062 2064 2067 2069 2589
 
 2000.0 "--Start--" sync / 00:0839::The Hall of the Griffin will be sealed off/ window 2000,5
-2003.5 "--sync--" sync / 1[56]:Zenos Yae Galvus:366:/ window 3,1
-2009.7 "--sync--" sync / 1[56]:Zenos Yae Galvus:205F:/
-2023.4 "Art of the Swell" sync / 1[56]:Zenos Yae Galvus:2065:/
+2003.5 "--sync--" sync / 1[56]:[^:]*:Zenos Yae Galvus:366:/ window 3,1
+2009.7 "--sync--" sync / 1[56]:[^:]*:Zenos Yae Galvus:205F:/
+2023.4 "Art of the Swell" sync / 1[56]:[^:]*:Zenos Yae Galvus:2065:/
 
-2032.8 "Unmoving Troika" sync / 1[56]:Zenos Yae Galvus:2060:/
-2050.6 "Art of the Storm" sync / 1[56]:Zenos Yae Galvus:2066:/
-2059.3 "Art of the Sword" sync / 1[56]:Zenos Yae Galvus:2068:/
-2068.5 "Unmoving Troika" sync / 1[56]:Zenos Yae Galvus:2060:/
+2032.8 "Unmoving Troika" sync / 1[56]:[^:]*:Zenos Yae Galvus:2060:/
+2050.6 "Art of the Storm" sync / 1[56]:[^:]*:Zenos Yae Galvus:2066:/
+2059.3 "Art of the Sword" sync / 1[56]:[^:]*:Zenos Yae Galvus:2068:/
+2068.5 "Unmoving Troika" sync / 1[56]:[^:]*:Zenos Yae Galvus:2060:/
 
-2088.4 "Art of the Swell" sync / 1[56]:Zenos Yae Galvus:2065:/
-2097.1 "Art of the Sword" sync / 1[56]:Zenos Yae Galvus:2068:/
-2106.4 "Unmoving Troika" sync / 1[56]:Zenos Yae Galvus:2060:/
-2126.2 "Art of the Storm" sync / 1[56]:Zenos Yae Galvus:2066:/
-2134.9 "Art of the Sword" sync / 1[56]:Zenos Yae Galvus:2068:/
-2144.2 "Unmoving Troika" sync / 1[56]:Zenos Yae Galvus:2060:/ jump 2068.5
+2088.4 "Art of the Swell" sync / 1[56]:[^:]*:Zenos Yae Galvus:2065:/
+2097.1 "Art of the Sword" sync / 1[56]:[^:]*:Zenos Yae Galvus:2068:/
+2106.4 "Unmoving Troika" sync / 1[56]:[^:]*:Zenos Yae Galvus:2060:/
+2126.2 "Art of the Storm" sync / 1[56]:[^:]*:Zenos Yae Galvus:2066:/
+2134.9 "Art of the Sword" sync / 1[56]:[^:]*:Zenos Yae Galvus:2068:/
+2144.2 "Unmoving Troika" sync / 1[56]:[^:]*:Zenos Yae Galvus:2060:/ jump 2068.5
 
 2164.0 "Art of the Swell"
 2172.7 "Art of the Sword"
@@ -115,20 +115,20 @@ hideall "--sync--"
 2219.8 "Unmoving Troika"
 
 # Phase 2 at <= 65% HP
-2300.0 "--sync--" sync / 1[56]:Zenos Yae Galvus:239F:/ window 300,5
-2307.5 "Vein Splitter" sync / 1[56]:Zenos Yae Galvus:24B6:/
-2310.1 "Vein Splitter" sync / 1[56]:Zenos Yae Galvus:206C:/
-2323.3 "Lightless Spark" sync / 1[56]:Zenos Yae Galvus:206B:/
-2331.6 "Unmoving Troika" sync / 1[56]:Zenos Yae Galvus:2060:/
-2341.7 "Concentrativity" sync / 1[56]:Zenos Yae Galvus:206D:/
-2354.4 "Storm?/Swell?" sync / 1[56]:Zenos Yae Galvus:206[56]:/
-2366.5 "Concentrativity" sync / 1[56]:Zenos Yae Galvus:206D:/
-2371.7 "--sync--" sync / 1[56]:Zenos Yae Galvus:239F:/
+2300.0 "--sync--" sync / 1[56]:[^:]*:Zenos Yae Galvus:239F:/ window 300,5
+2307.5 "Vein Splitter" sync / 1[56]:[^:]*:Zenos Yae Galvus:24B6:/
+2310.1 "Vein Splitter" sync / 1[56]:[^:]*:Zenos Yae Galvus:206C:/
+2323.3 "Lightless Spark" sync / 1[56]:[^:]*:Zenos Yae Galvus:206B:/
+2331.6 "Unmoving Troika" sync / 1[56]:[^:]*:Zenos Yae Galvus:2060:/
+2341.7 "Concentrativity" sync / 1[56]:[^:]*:Zenos Yae Galvus:206D:/
+2354.4 "Storm?/Swell?" sync / 1[56]:[^:]*:Zenos Yae Galvus:206[56]:/
+2366.5 "Concentrativity" sync / 1[56]:[^:]*:Zenos Yae Galvus:206D:/
+2371.7 "--sync--" sync / 1[56]:[^:]*:Zenos Yae Galvus:239F:/
 
 # Paths diverge into Storm/Swell blocks
 # Blocks loop at random to 20% HP
-2379.3 "Art of the Swell?" sync / 1[56]:Zenos Yae Galvus:2065:/ jump 2600.0
-2379.3 "Art of the Storm?" sync / 1[56]:Zenos Yae Galvus:2066:/ jump 2500.0
+2379.3 "Art of the Swell?" sync / 1[56]:[^:]*:Zenos Yae Galvus:2065:/ jump 2600.0
+2379.3 "Art of the Storm?" sync / 1[56]:[^:]*:Zenos Yae Galvus:2066:/ jump 2500.0
 2381.8 "Vein Splitter"
 2385.3 "Lightless Spark?"
 2388.0 "Art of the Sword"
@@ -136,17 +136,17 @@ hideall "--sync--"
 2406.3 "Concentrativity"
 
 # Storm block
-2500.0 "Art of the Storm" sync / 1[56]:Zenos Yae Galvus:2066:/
-2502.5 "Vein Splitter" sync / 1[56]:Zenos Yae Galvus:206C:/
-2508.7 "Art of the Sword" sync / 1[56]:Zenos Yae Galvus:2068:/
-2517.0 "Unmoving Troika" sync / 1[56]:Zenos Yae Galvus:2060:/
-2527.0 "Concentrativity" sync / 1[56]:Zenos Yae Galvus:206D:/
-2539.3 "Storm?/Swell?/Sword?" sync / 1[56]:Zenos Yae Galvus:206[568]:/
-2551.4 "Concentrativity" sync / 1[56]:Zenos Yae Galvus:206D:/
-2556.4 "--sync--" sync / 1[56]:Zenos Yae Galvus:239F:/ window 20,20
+2500.0 "Art of the Storm" sync / 1[56]:[^:]*:Zenos Yae Galvus:2066:/
+2502.5 "Vein Splitter" sync / 1[56]:[^:]*:Zenos Yae Galvus:206C:/
+2508.7 "Art of the Sword" sync / 1[56]:[^:]*:Zenos Yae Galvus:2068:/
+2517.0 "Unmoving Troika" sync / 1[56]:[^:]*:Zenos Yae Galvus:2060:/
+2527.0 "Concentrativity" sync / 1[56]:[^:]*:Zenos Yae Galvus:206D:/
+2539.3 "Storm?/Swell?/Sword?" sync / 1[56]:[^:]*:Zenos Yae Galvus:206[568]:/
+2551.4 "Concentrativity" sync / 1[56]:[^:]*:Zenos Yae Galvus:206D:/
+2556.4 "--sync--" sync / 1[56]:[^:]*:Zenos Yae Galvus:239F:/ window 20,20
 
-2564.0 "Art of the Swell?" sync / 1[56]:Zenos Yae Galvus:2065:/ jump 2600.0
-2564.0 "Art of the Storm?" sync / 1[56]:Zenos Yae Galvus:2066:/ jump 2500.0
+2564.0 "Art of the Swell?" sync / 1[56]:[^:]*:Zenos Yae Galvus:2065:/ jump 2600.0
+2564.0 "Art of the Storm?" sync / 1[56]:[^:]*:Zenos Yae Galvus:2066:/ jump 2500.0
 2566.5 "Vein Splitter"
 2570.0 "Lightless Spark?"
 2572.7 "Art of the Sword"
@@ -154,18 +154,18 @@ hideall "--sync--"
 2591.0 "Concentrativity"
 
 # Swell block
-2600.0 "Art of the Swell" sync / 1[56]:Zenos Yae Galvus:2065:/
-2602.5 "Vein Splitter" sync / 1[56]:Zenos Yae Galvus:206C:/
-2606.0 "Lightless Spark" sync / 1[56]:Zenos Yae Galvus:206B:/
-2608.7 "Art of the Sword" sync / 1[56]:Zenos Yae Galvus:2068:/
-2617.0 "Unmoving Troika" sync / 1[56]:Zenos Yae Galvus:2060:/
-2627.0 "Concentrativity" sync / 1[56]:Zenos Yae Galvus:206D:/
-2639.8 "Storm?/Swell?/Sword?" sync / 1[56]:Zenos Yae Galvus:206[568]:/
-2651.8 "Concentrativity" sync / 1[56]:Zenos Yae Galvus:206D:/
-2656.8 "--sync--" sync / 1[56]:Zenos Yae Galvus:239F:/ window 20,20
+2600.0 "Art of the Swell" sync / 1[56]:[^:]*:Zenos Yae Galvus:2065:/
+2602.5 "Vein Splitter" sync / 1[56]:[^:]*:Zenos Yae Galvus:206C:/
+2606.0 "Lightless Spark" sync / 1[56]:[^:]*:Zenos Yae Galvus:206B:/
+2608.7 "Art of the Sword" sync / 1[56]:[^:]*:Zenos Yae Galvus:2068:/
+2617.0 "Unmoving Troika" sync / 1[56]:[^:]*:Zenos Yae Galvus:2060:/
+2627.0 "Concentrativity" sync / 1[56]:[^:]*:Zenos Yae Galvus:206D:/
+2639.8 "Storm?/Swell?/Sword?" sync / 1[56]:[^:]*:Zenos Yae Galvus:206[568]:/
+2651.8 "Concentrativity" sync / 1[56]:[^:]*:Zenos Yae Galvus:206D:/
+2656.8 "--sync--" sync / 1[56]:[^:]*:Zenos Yae Galvus:239F:/ window 20,20
 
-2664.4 "Art of the Storm?" sync / 1[56]:Zenos Yae Galvus:2066:/ jump 2500.0
-2664.4 "Art of the Swell?" sync / 1[56]:Zenos Yae Galvus:2065:/ jump 2600.0
+2664.4 "Art of the Storm?" sync / 1[56]:[^:]*:Zenos Yae Galvus:2066:/ jump 2500.0
+2664.4 "Art of the Swell?" sync / 1[56]:[^:]*:Zenos Yae Galvus:2065:/ jump 2600.0
 2666.9 "Vein Splitter"
 2670.4 "Lightless Spark?"
 2673.1 "Art of the Sword"
@@ -173,33 +173,33 @@ hideall "--sync--"
 2691.4 "Concentrativity"
 
 # Intermission at < 20% HP
-2700.0 "--sync--" sync / 1[56]:Zenos Yae Galvus:206E:/ window 700,5
-2706.0 "--sync--" sync / 1[56]:Zenos Yae Galvus:239F:/
-2712.7 "Swell/Sword" sync / 1[56]:Zenos Yae Galvus:258[68]:/
-2715.1 "Art of the Storm" sync / 1[56]:Zenos Yae Galvus:2587:/
-2732.0 "--sync--" sync / 1[56]:Zenos Yae Galvus:239F:/
-2739.1 "Swell/Sword" sync / 1[56]:Zenos Yae Galvus:258[68]:/
-2741.1 "Art of the Storm" sync / 1[56]:Zenos Yae Galvus:2587:/
-2763.0 "--sync--" sync / 1[56]:Zenos Yae Galvus:239F:/
-2769.6 "Swell/Sword" sync / 1[56]:Zenos Yae Galvus:258[68]:/
-2772.0 "Art of the Storm" sync / 1[56]:Zenos Yae Galvus:2587:/
-2789.0 "--sync--" sync / 1[56]:Zenos Yae Galvus:239F:/
-2796.0 "Swell/Sword" sync / 1[56]:Zenos Yae Galvus:258[68]:/
-2798.0 "Art of the Storm" sync / 1[56]:Zenos Yae Galvus:2587:/
-2815.0 "--sync--" sync / 1[56]:Zenos Yae Galvus:239F:/
-2822.0 "Swell/Sword" sync / 1[56]:Zenos Yae Galvus:258[68]:/
-2824.0 "Art of the Storm" sync / 1[56]:Zenos Yae Galvus:2587:/
+2700.0 "--sync--" sync / 1[56]:[^:]*:Zenos Yae Galvus:206E:/ window 700,5
+2706.0 "--sync--" sync / 1[56]:[^:]*:Zenos Yae Galvus:239F:/
+2712.7 "Swell/Sword" sync / 1[56]:[^:]*:Zenos Yae Galvus:258[68]:/
+2715.1 "Art of the Storm" sync / 1[56]:[^:]*:Zenos Yae Galvus:2587:/
+2732.0 "--sync--" sync / 1[56]:[^:]*:Zenos Yae Galvus:239F:/
+2739.1 "Swell/Sword" sync / 1[56]:[^:]*:Zenos Yae Galvus:258[68]:/
+2741.1 "Art of the Storm" sync / 1[56]:[^:]*:Zenos Yae Galvus:2587:/
+2763.0 "--sync--" sync / 1[56]:[^:]*:Zenos Yae Galvus:239F:/
+2769.6 "Swell/Sword" sync / 1[56]:[^:]*:Zenos Yae Galvus:258[68]:/
+2772.0 "Art of the Storm" sync / 1[56]:[^:]*:Zenos Yae Galvus:2587:/
+2789.0 "--sync--" sync / 1[56]:[^:]*:Zenos Yae Galvus:239F:/
+2796.0 "Swell/Sword" sync / 1[56]:[^:]*:Zenos Yae Galvus:258[68]:/
+2798.0 "Art of the Storm" sync / 1[56]:[^:]*:Zenos Yae Galvus:2587:/
+2815.0 "--sync--" sync / 1[56]:[^:]*:Zenos Yae Galvus:239F:/
+2822.0 "Swell/Sword" sync / 1[56]:[^:]*:Zenos Yae Galvus:258[68]:/
+2824.0 "Art of the Storm" sync / 1[56]:[^:]*:Zenos Yae Galvus:2587:/
 
 # The intermission closes here regardless.
 # Parties reaching here naturally will die to a full boss gauge.
-2836.1 "Storm, Swell, Sword" sync / 1[56]:Zenos Yae Galvus:206F:/ window 135,10
-2839.0 "--sync--" sync / 1[56]:The Storm:239E:/
-2843.1 "Storm, Swell, Sword" sync / 1[56]:Zenos Yae Galvus:2070:/
+2836.1 "Storm, Swell, Sword" sync / 1[56]:[^:]*:Zenos Yae Galvus:206F:/ window 135,10
+2839.0 "--sync--" sync / 1[56]:[^:]*:The Storm:239E:/
+2843.1 "Storm, Swell, Sword" sync / 1[56]:[^:]*:Zenos Yae Galvus:2070:/
 
-2855.9 "Concentrativity" sync / 1[56]:Zenos Yae Galvus:206D:/ window 20,5
-2866.1 "Concentrativity" sync / 1[56]:Zenos Yae Galvus:206D:/
-2876.3 "Concentrativity" sync / 1[56]:Zenos Yae Galvus:206D:/
-2886.5 "Concentrativity" sync / 1[56]:Zenos Yae Galvus:206D:/ jump 2855.9
+2855.9 "Concentrativity" sync / 1[56]:[^:]*:Zenos Yae Galvus:206D:/ window 20,5
+2866.1 "Concentrativity" sync / 1[56]:[^:]*:Zenos Yae Galvus:206D:/
+2876.3 "Concentrativity" sync / 1[56]:[^:]*:Zenos Yae Galvus:206D:/
+2886.5 "Concentrativity" sync / 1[56]:[^:]*:Zenos Yae Galvus:206D:/ jump 2855.9
 2896.7 "Concentrativity"
 2906.9 "Concentrativity"
 2917.1 "Concentrativity"

--- a/ui/raidboss/data/04-sb/dungeon/bardams_mettle.txt
+++ b/ui/raidboss/data/04-sb/dungeon/bardams_mettle.txt
@@ -12,17 +12,17 @@ hideall "Reconstruct"
 # -ic "Steppe Coeurl" "Steppe Sheep" "Steppe Yamaa"
 
 0 "Start" sync / 00:0839::Bardam's Hunt will be sealed off/
-11.7 "Heave" sync / 1[56]:Garula:1EF7:/ window 11.7,5
-20.9 "--sync--" sync / 1[56]:Garula:1EF8:/
-22.4 "Crumbling Crust" sync / 1[56]:Garula:1F13:/
-34.1 "Rush" sync / 1[56]:Garula:1EF9:/
-36.2 "War Cry" sync / 1[56]:Garula:1EFA:/
-38.9 "Earthquake" sync / 1[56]:Garula:1EFB:/ window 15,15
-49.5 "Heave" sync / 1[56]:Garula:1EF7:/
-58.7 "--sync--" sync / 1[56]:Garula:1EF8:/
-60.2 "Crumbling Crust" sync / 1[56]:Garula:1F13:/
+11.7 "Heave" sync / 1[56]:[^:]*:Garula:1EF7:/ window 11.7,5
+20.9 "--sync--" sync / 1[56]:[^:]*:Garula:1EF8:/
+22.4 "Crumbling Crust" sync / 1[56]:[^:]*:Garula:1F13:/
+34.1 "Rush" sync / 1[56]:[^:]*:Garula:1EF9:/
+36.2 "War Cry" sync / 1[56]:[^:]*:Garula:1EFA:/
+38.9 "Earthquake" sync / 1[56]:[^:]*:Garula:1EFB:/ window 15,15
+49.5 "Heave" sync / 1[56]:[^:]*:Garula:1EF7:/
+58.7 "--sync--" sync / 1[56]:[^:]*:Garula:1EF8:/
+60.2 "Crumbling Crust" sync / 1[56]:[^:]*:Garula:1F13:/
 
-66.6 "Heave" sync / 1[56]:Garula:1EF7:/ jump 11.7
+66.6 "Heave" sync / 1[56]:[^:]*:Garula:1EF7:/ jump 11.7
 77.3 "Crumbling Crust"
 89.0 "Rush"
 91.1 "War Cry"
@@ -35,35 +35,35 @@ hideall "Reconstruct"
 # -ii 1EFE 2578 2579 257A 257E 257B
 
 1000.0 "Start" sync / 00:0839::.*Rebirth of Bardam the Brave will be sealed off/ window 1000,5
-1007.8 "Travail" sync / 1[56]:Bardam:1EFF:/ window 7.8,5
-1014.1 "Magnetism" sync / 1[56]:Hunter Of Bardam:1F08:/
-1020.3 "Tremblor" sync / 1[56]:Bardam:257C:/
-1022.8 "Empty Gaze" sync / 1[56]:Hunter Of Bardam:1F04:/
-1025.0 "Travail" sync / 1[56]:Bardam:1EFF:/
-1029.8 "Charge x3" # sync / 1[56]:Throwing Spear:257F:/
-1038.8 "Empty Gaze" sync / 1[56]:Hunter Of Bardam:1F04:/
-1038.9 "Charge" sync / 1[56]:Throwing Spear:257F:/
-1044.6 "--sync--" sync / 1[56]:Bardam:24EA:/ window 15,15
-1052.3 "Travail" sync / 1[56]:Bardam:1EFF:/
-1060.5 "Sacrifice" sync / 1[56]:Bardam:1F01:/
-1060.7 "Travail" sync / 1[56]:Bardam:1EFF:/
-1065.5 "Bardam's Ring" sync / 1[56]:Bardam:2581:/
-1066.2 "Travail" sync / 1[56]:Bardam:1EFF:/
-1076.4 "Comet x8" duration 12 # sync / 1[56]:Bardam:257D:/
-1093.4 "Heavy Strike x3" sync / 1[56]:Hunter Of Bardam:2577:/ duration 4
-1099.0 "Travail" sync / 1[56]:Bardam:1EFF:/
-1105.3 "Comet Impact" sync / 1[56]:Star Shard:2580:/
-1109.3 "--sync--" sync / 1[56]:Bardam:24EA:/ window 15,15
-1116.9 "Travail" sync / 1[56]:Bardam:1EFF:/
-1125.3 "Reconstruct" sync / 1[56]:Bardam:1EFD:/
-1126.7 "--sync--" sync / 1[56]:Star Shard:258B:/
-1128.3 "Travail" sync / 1[56]:Bardam:1EFF:/
-1133.1 "Charge" sync / 1[56]:Throwing Spear:257F:/
-1133.9 "Magnetism" sync / 1[56]:Hunter Of Bardam:1F08:/
-1139.5 "Tremblor" sync / 1[56]:Hunter Of Bardam:2585:/
-1140.0 "Heavy Strike x3" sync / 1[56]:Warrior Of Bardam:2577:/ duration 4
-1153.0 "Meteor Impact" sync / 1[56]:Looming Shadow:2582:/
-1153.4 "--sync--" sync / 1[56]:Star Shard:258B:/
+1007.8 "Travail" sync / 1[56]:[^:]*:Bardam:1EFF:/ window 7.8,5
+1014.1 "Magnetism" sync / 1[56]:[^:]*:Hunter Of Bardam:1F08:/
+1020.3 "Tremblor" sync / 1[56]:[^:]*:Bardam:257C:/
+1022.8 "Empty Gaze" sync / 1[56]:[^:]*:Hunter Of Bardam:1F04:/
+1025.0 "Travail" sync / 1[56]:[^:]*:Bardam:1EFF:/
+1029.8 "Charge x3" # sync / 1[56]:[^:]*:Throwing Spear:257F:/
+1038.8 "Empty Gaze" sync / 1[56]:[^:]*:Hunter Of Bardam:1F04:/
+1038.9 "Charge" sync / 1[56]:[^:]*:Throwing Spear:257F:/
+1044.6 "--sync--" sync / 1[56]:[^:]*:Bardam:24EA:/ window 15,15
+1052.3 "Travail" sync / 1[56]:[^:]*:Bardam:1EFF:/
+1060.5 "Sacrifice" sync / 1[56]:[^:]*:Bardam:1F01:/
+1060.7 "Travail" sync / 1[56]:[^:]*:Bardam:1EFF:/
+1065.5 "Bardam's Ring" sync / 1[56]:[^:]*:Bardam:2581:/
+1066.2 "Travail" sync / 1[56]:[^:]*:Bardam:1EFF:/
+1076.4 "Comet x8" duration 12 # sync / 1[56]:[^:]*:Bardam:257D:/
+1093.4 "Heavy Strike x3" sync / 1[56]:[^:]*:Hunter Of Bardam:2577:/ duration 4
+1099.0 "Travail" sync / 1[56]:[^:]*:Bardam:1EFF:/
+1105.3 "Comet Impact" sync / 1[56]:[^:]*:Star Shard:2580:/
+1109.3 "--sync--" sync / 1[56]:[^:]*:Bardam:24EA:/ window 15,15
+1116.9 "Travail" sync / 1[56]:[^:]*:Bardam:1EFF:/
+1125.3 "Reconstruct" sync / 1[56]:[^:]*:Bardam:1EFD:/
+1126.7 "--sync--" sync / 1[56]:[^:]*:Star Shard:258B:/
+1128.3 "Travail" sync / 1[56]:[^:]*:Bardam:1EFF:/
+1133.1 "Charge" sync / 1[56]:[^:]*:Throwing Spear:257F:/
+1133.9 "Magnetism" sync / 1[56]:[^:]*:Hunter Of Bardam:1F08:/
+1139.5 "Tremblor" sync / 1[56]:[^:]*:Hunter Of Bardam:2585:/
+1140.0 "Heavy Strike x3" sync / 1[56]:[^:]*:Warrior Of Bardam:2577:/ duration 4
+1153.0 "Meteor Impact" sync / 1[56]:[^:]*:Looming Shadow:2582:/
+1153.4 "--sync--" sync / 1[56]:[^:]*:Star Shard:258B:/
 
 #~~~~~#
 # YOL #
@@ -72,27 +72,27 @@ hideall "Reconstruct"
 # -ii 1F0B 1F0E
 
 2000.0 "Start" sync / 00:0839::.*Voiceless Muse will be sealed off/ window 2000,5
-2008.1 "Feathercut" sync / 1[56]:Yol:1F09:/
-2015.2 "Wind Unbound" sync / 1[56]:Yol:1F0A:/
-2023.9 "Pinion" sync / 1[56]:Yol Feather:1F11:/
-2025.8 "Flutterfall" sync / 1[56]:Yol:1F0C:/
-2027.2 "Feathercut" sync / 1[56]:Yol:1F09:/
-2033.9 "Pinion" sync / 1[56]:Yol Feather:1F11:/
-2034.7 "Flutterfall" sync / 1[56]:Yol:1F0C:/
-2042.2 "Wind Unbound" sync / 1[56]:Yol:1F0A:/ window 15,15
-2046.4 "Feathercut" sync / 1[56]:Yol:1F09:/
-2050.9 "Pinion" sync / 1[56]:Yol Feather:1F11:/
-2054.0 "Eye Of The Fierce" sync / 1[56]:Yol:1F0D:/
-2059.2 "Feathercut" sync / 1[56]:Yol:1F09:/
-2060.9 "Pinion" sync / 1[56]:Yol Feather:1F11:/
-2069.3 "Wind Unbound" sync / 1[56]:Yol:1F0A:/
+2008.1 "Feathercut" sync / 1[56]:[^:]*:Yol:1F09:/
+2015.2 "Wind Unbound" sync / 1[56]:[^:]*:Yol:1F0A:/
+2023.9 "Pinion" sync / 1[56]:[^:]*:Yol Feather:1F11:/
+2025.8 "Flutterfall" sync / 1[56]:[^:]*:Yol:1F0C:/
+2027.2 "Feathercut" sync / 1[56]:[^:]*:Yol:1F09:/
+2033.9 "Pinion" sync / 1[56]:[^:]*:Yol Feather:1F11:/
+2034.7 "Flutterfall" sync / 1[56]:[^:]*:Yol:1F0C:/
+2042.2 "Wind Unbound" sync / 1[56]:[^:]*:Yol:1F0A:/ window 15,15
+2046.4 "Feathercut" sync / 1[56]:[^:]*:Yol:1F09:/
+2050.9 "Pinion" sync / 1[56]:[^:]*:Yol Feather:1F11:/
+2054.0 "Eye Of The Fierce" sync / 1[56]:[^:]*:Yol:1F0D:/
+2059.2 "Feathercut" sync / 1[56]:[^:]*:Yol:1F09:/
+2060.9 "Pinion" sync / 1[56]:[^:]*:Yol Feather:1F11:/
+2069.3 "Wind Unbound" sync / 1[56]:[^:]*:Yol:1F0A:/
 2071.4 "--untargetable--"
 2071.4 "--adds spawn--" sync / 03:........:Corpsecleaner Eagle:/  window 71.4,5
-2078.0 "Pinion" sync / 1[56]:Yol Feather:1F11:/
-2088.0 "Pinion" sync / 1[56]:Yol Feather:1F11:/
-2098.0 "Pinion" sync / 1[56]:Yol Feather:1F11:/
-2108.0 "Pinion" sync / 1[56]:Yol Feather:1F11:/
-2118.0 "Pinion" sync / 1[56]:Yol Feather:1F11:/ jump 2078.0
+2078.0 "Pinion" sync / 1[56]:[^:]*:Yol Feather:1F11:/
+2088.0 "Pinion" sync / 1[56]:[^:]*:Yol Feather:1F11:/
+2098.0 "Pinion" sync / 1[56]:[^:]*:Yol Feather:1F11:/
+2108.0 "Pinion" sync / 1[56]:[^:]*:Yol Feather:1F11:/
+2118.0 "Pinion" sync / 1[56]:[^:]*:Yol Feather:1F11:/ jump 2078.0
 2128.0 "Pinion"
 2138.0 "Pinion"
 2148.0 "Pinion"
@@ -100,32 +100,32 @@ hideall "Reconstruct"
 # Unfortunately, because there are two Corpsecleaner Eagles,
 # we can't just sync to a 04 log line.
 2189.7 "--targetable--" sync / 22:........:Yol:........:Yol:01/ window 120,5
-2196.8 "Feathercut" sync / 1[56]:Yol:1F09:/ window 125,5
-2204.0 "Wind Unbound" sync / 1[56]:Yol:1F0A:/
-2212.7 "Pinion" sync / 1[56]:Yol Feather:1F11:/
-2214.5 "Flutterfall" sync / 1[56]:Yol:1F0C:/
-2215.8 "Feathercut" sync / 1[56]:Yol:1F09:/
-2222.6 "Pinion" sync / 1[56]:Yol Feather:1F11:/
-2223.3 "Flutterfall" sync / 1[56]:Yol:1F0C:/
-2230.7 "Wind Unbound" sync / 1[56]:Yol:1F0A:/ window 15,15
-2234.9 "Feathercut" sync / 1[56]:Yol:1F09:/
-2239.4 "Pinion" sync / 1[56]:Yol Feather:1F11:/
-2242.5 "Eye Of The Fierce" sync / 1[56]:Yol:1F0D:/
-2247.7 "Feathercut" sync / 1[56]:Yol:1F09:/
-2249.4 "Pinion" sync / 1[56]:Yol Feather:1F11:/
+2196.8 "Feathercut" sync / 1[56]:[^:]*:Yol:1F09:/ window 125,5
+2204.0 "Wind Unbound" sync / 1[56]:[^:]*:Yol:1F0A:/
+2212.7 "Pinion" sync / 1[56]:[^:]*:Yol Feather:1F11:/
+2214.5 "Flutterfall" sync / 1[56]:[^:]*:Yol:1F0C:/
+2215.8 "Feathercut" sync / 1[56]:[^:]*:Yol:1F09:/
+2222.6 "Pinion" sync / 1[56]:[^:]*:Yol Feather:1F11:/
+2223.3 "Flutterfall" sync / 1[56]:[^:]*:Yol:1F0C:/
+2230.7 "Wind Unbound" sync / 1[56]:[^:]*:Yol:1F0A:/ window 15,15
+2234.9 "Feathercut" sync / 1[56]:[^:]*:Yol:1F09:/
+2239.4 "Pinion" sync / 1[56]:[^:]*:Yol Feather:1F11:/
+2242.5 "Eye Of The Fierce" sync / 1[56]:[^:]*:Yol:1F0D:/
+2247.7 "Feathercut" sync / 1[56]:[^:]*:Yol:1F09:/
+2249.4 "Pinion" sync / 1[56]:[^:]*:Yol Feather:1F11:/
 
 2253.8 "--untargetable--" sync / 22:........:Yol:........:Yol:00/ window 60,5
-2260.3 "Flutterfall" sync / 1[56]:Yol:1F10:/ window 60,5
-2267.5 "Wingbeat" sync / 1[56]:Yol:1F0F:/
-2276.9 "Flutterfall" sync / 1[56]:Yol:1F0C:/
-2284.3 "Wingbeat" sync / 1[56]:Yol:1F0F:/
-2284.7 "Pinion" sync / 1[56]:Yol Feather:2593:/
-2293.8 "Flutterfall" sync / 1[56]:Yol:1F0C:/
-2301.2 "Wingbeat" sync / 1[56]:Yol:1F0F:/
-2301.6 "Pinion" sync / 1[56]:Yol Feather:2593:/
-2310.7 "Flutterfall" sync / 1[56]:Yol:1F0C:/
-2318.2 "Wingbeat" sync / 1[56]:Yol:1F0F:/
-2318.6 "Pinion" sync / 1[56]:Yol Feather:2593:/ jump 2284.7
+2260.3 "Flutterfall" sync / 1[56]:[^:]*:Yol:1F10:/ window 60,5
+2267.5 "Wingbeat" sync / 1[56]:[^:]*:Yol:1F0F:/
+2276.9 "Flutterfall" sync / 1[56]:[^:]*:Yol:1F0C:/
+2284.3 "Wingbeat" sync / 1[56]:[^:]*:Yol:1F0F:/
+2284.7 "Pinion" sync / 1[56]:[^:]*:Yol Feather:2593:/
+2293.8 "Flutterfall" sync / 1[56]:[^:]*:Yol:1F0C:/
+2301.2 "Wingbeat" sync / 1[56]:[^:]*:Yol:1F0F:/
+2301.6 "Pinion" sync / 1[56]:[^:]*:Yol Feather:2593:/
+2310.7 "Flutterfall" sync / 1[56]:[^:]*:Yol:1F0C:/
+2318.2 "Wingbeat" sync / 1[56]:[^:]*:Yol:1F0F:/
+2318.6 "Pinion" sync / 1[56]:[^:]*:Yol Feather:2593:/ jump 2284.7
 2327.7 "Flutterfall"
 2335.1 "Wingbeat"
 2335.5 "Pinion"
@@ -135,32 +135,32 @@ hideall "Reconstruct"
 
 
 2361.7 "--targetable--" sync / 22:........:Yol:........:Yol:01/ window 110,5
-2368.8 "Feathercut" sync / 1[56]:Yol:1F09:/ window 110,5
-2376.0 "Wind Unbound" sync / 1[56]:Yol:1F0A:/
-2384.7 "Pinion" sync / 1[56]:Yol Feather:1F11:/
-2386.6 "Flutterfall" sync / 1[56]:Yol:1F0C:/
-2388.0 "Feathercut" sync / 1[56]:Yol:1F09:/
-2394.7 "Pinion" sync / 1[56]:Yol Feather:1F11:/
-2395.5 "Flutterfall" sync / 1[56]:Yol:1F0C:/
-2402.9 "Wind Unbound" sync / 1[56]:Yol:1F0A:/ window 15,15
-2407.1 "Feathercut" sync / 1[56]:Yol:1F09:/
-2411.6 "Pinion" sync / 1[56]:Yol Feather:1F11:/
-2414.7 "Eye Of The Fierce" sync / 1[56]:Yol:1F0D:/
-2419.9 "Feathercut" sync / 1[56]:Yol:1F09:/
-2421.5 "Pinion" sync / 1[56]:Yol Feather:1F11:/
-2433.1 "Feathercut" sync / 1[56]:Yol:1F09:/
-2440.2 "Wind Unbound" sync / 1[56]:Yol:1F0A:/ window 15,15
-2448.9 "Pinion" sync / 1[56]:Yol Feather:1F11:/
-2450.7 "Flutterfall" sync / 1[56]:Yol:1F0C:/
-2452.1 "Feathercut" sync / 1[56]:Yol:1F09:/
-2458.9 "Pinion" sync / 1[56]:Yol Feather:1F11:/
-2459.6 "Flutterfall" sync / 1[56]:Yol:1F0C:/
-2467.0 "Wind Unbound" sync / 1[56]:Yol:1F0A:/ window 15,15
-2471.1 "Feathercut" sync / 1[56]:Yol:1F09:/
-2475.7 "Pinion" sync / 1[56]:Yol Feather:1F11:/
-2478.7 "Eye Of The Fierce" sync / 1[56]:Yol:1F0D:/
-2483.9 "Feathercut" sync / 1[56]:Yol:1F09:/
-2485.7 "Pinion" sync / 1[56]:Yol Feather:1F11:/
+2368.8 "Feathercut" sync / 1[56]:[^:]*:Yol:1F09:/ window 110,5
+2376.0 "Wind Unbound" sync / 1[56]:[^:]*:Yol:1F0A:/
+2384.7 "Pinion" sync / 1[56]:[^:]*:Yol Feather:1F11:/
+2386.6 "Flutterfall" sync / 1[56]:[^:]*:Yol:1F0C:/
+2388.0 "Feathercut" sync / 1[56]:[^:]*:Yol:1F09:/
+2394.7 "Pinion" sync / 1[56]:[^:]*:Yol Feather:1F11:/
+2395.5 "Flutterfall" sync / 1[56]:[^:]*:Yol:1F0C:/
+2402.9 "Wind Unbound" sync / 1[56]:[^:]*:Yol:1F0A:/ window 15,15
+2407.1 "Feathercut" sync / 1[56]:[^:]*:Yol:1F09:/
+2411.6 "Pinion" sync / 1[56]:[^:]*:Yol Feather:1F11:/
+2414.7 "Eye Of The Fierce" sync / 1[56]:[^:]*:Yol:1F0D:/
+2419.9 "Feathercut" sync / 1[56]:[^:]*:Yol:1F09:/
+2421.5 "Pinion" sync / 1[56]:[^:]*:Yol Feather:1F11:/
+2433.1 "Feathercut" sync / 1[56]:[^:]*:Yol:1F09:/
+2440.2 "Wind Unbound" sync / 1[56]:[^:]*:Yol:1F0A:/ window 15,15
+2448.9 "Pinion" sync / 1[56]:[^:]*:Yol Feather:1F11:/
+2450.7 "Flutterfall" sync / 1[56]:[^:]*:Yol:1F0C:/
+2452.1 "Feathercut" sync / 1[56]:[^:]*:Yol:1F09:/
+2458.9 "Pinion" sync / 1[56]:[^:]*:Yol Feather:1F11:/
+2459.6 "Flutterfall" sync / 1[56]:[^:]*:Yol:1F0C:/
+2467.0 "Wind Unbound" sync / 1[56]:[^:]*:Yol:1F0A:/ window 15,15
+2471.1 "Feathercut" sync / 1[56]:[^:]*:Yol:1F09:/
+2475.7 "Pinion" sync / 1[56]:[^:]*:Yol Feather:1F11:/
+2478.7 "Eye Of The Fierce" sync / 1[56]:[^:]*:Yol:1F0D:/
+2483.9 "Feathercut" sync / 1[56]:[^:]*:Yol:1F09:/
+2485.7 "Pinion" sync / 1[56]:[^:]*:Yol Feather:1F11:/
 2490.0 "--untargetable--" sync / 22:........:Yol:........:Yol:00/ jump 2253.8 window 130,5
 
 2496.5 "Flutterfall"

--- a/ui/raidboss/data/04-sb/dungeon/castrum_abania.txt
+++ b/ui/raidboss/data/04-sb/dungeon/castrum_abania.txt
@@ -10,74 +10,74 @@ hideall "--sync--"
 
 # initial
 0 "Start" sync / 00:0839::Terrestrial Weaponry will be sealed off/ window 10000,0
-9.4 "Wheel" sync / 1[56]:Magna Roader:1F14:/ window 10,10
-16.9 "Magitek Fire II" sync / 1[56]:Magna Roader:1F15:/
-22.0 "Magitek Fire II" sync / 1[56]:Magna Roader:1F15:/
-29.1 "Magitek Fire III" sync / 1[56]:Magna Roader:1F16:/
+9.4 "Wheel" sync / 1[56]:[^:]*:Magna Roader:1F14:/ window 10,10
+16.9 "Magitek Fire II" sync / 1[56]:[^:]*:Magna Roader:1F15:/
+22.0 "Magitek Fire II" sync / 1[56]:[^:]*:Magna Roader:1F15:/
+29.1 "Magitek Fire III" sync / 1[56]:[^:]*:Magna Roader:1F16:/
 
 # Wild Speed Loop (until stunned)
 40.4 "--untargetable--"
-40.4 "--sync--" sync / 1[56]:Magna Roader:207E:/
-40.5 "Wild Speed 1" #sync / 1[56]:Magna Roader:1FF8:/
-41.5 "Wild Speed 2" #sync / 1[56]:Magna Roader:1FF8:/
-42.5 "Wild Speed 3" #sync / 1[56]:Magna Roader:1FF8:/
-43.5 "Wild Speed 4" #sync / 1[56]:Magna Roader:1FF8:/
+40.4 "--sync--" sync / 1[56]:[^:]*:Magna Roader:207E:/
+40.5 "Wild Speed 1" #sync / 1[56]:[^:]*:Magna Roader:1FF8:/
+41.5 "Wild Speed 2" #sync / 1[56]:[^:]*:Magna Roader:1FF8:/
+42.5 "Wild Speed 3" #sync / 1[56]:[^:]*:Magna Roader:1FF8:/
+43.5 "Wild Speed 4" #sync / 1[56]:[^:]*:Magna Roader:1FF8:/
 
-50.6 "--sync--" sync / 1[56]:Magna Roader:207E:/
-50.7 "Wild Speed 1" #sync / 1[56]:Magna Roader:1FF8:/
-51.7 "Wild Speed 2" #sync / 1[56]:Magna Roader:1FF8:/
-52.7 "Wild Speed 3" #sync / 1[56]:Magna Roader:1FF8:/
-53.7 "Wild Speed 4" #sync / 1[56]:Magna Roader:1FF8:/
+50.6 "--sync--" sync / 1[56]:[^:]*:Magna Roader:207E:/
+50.7 "Wild Speed 1" #sync / 1[56]:[^:]*:Magna Roader:1FF8:/
+51.7 "Wild Speed 2" #sync / 1[56]:[^:]*:Magna Roader:1FF8:/
+52.7 "Wild Speed 3" #sync / 1[56]:[^:]*:Magna Roader:1FF8:/
+53.7 "Wild Speed 4" #sync / 1[56]:[^:]*:Magna Roader:1FF8:/
 
-60.8 "--sync--" sync / 1[56]:Magna Roader:207E:/
-60.9 "Wild Speed 1" #sync / 1[56]:Magna Roader:1FF8:/
-61.9 "Wild Speed 2" #sync / 1[56]:Magna Roader:1FF8:/
-62.9 "Wild Speed 3" #sync / 1[56]:Magna Roader:1FF8:/
-63.9 "Wild Speed 4" #sync / 1[56]:Magna Roader:1FF8:/
+60.8 "--sync--" sync / 1[56]:[^:]*:Magna Roader:207E:/
+60.9 "Wild Speed 1" #sync / 1[56]:[^:]*:Magna Roader:1FF8:/
+61.9 "Wild Speed 2" #sync / 1[56]:[^:]*:Magna Roader:1FF8:/
+62.9 "Wild Speed 3" #sync / 1[56]:[^:]*:Magna Roader:1FF8:/
+63.9 "Wild Speed 4" #sync / 1[56]:[^:]*:Magna Roader:1FF8:/
 
-71.0 "--sync--" sync / 1[56]:Magna Roader:207E:/
-71.1 "Wild Speed 1" #sync / 1[56]:Magna Roader:1FF8:/
-72.1 "Wild Speed 2" #sync / 1[56]:Magna Roader:1FF8:/
-73.1 "Wild Speed 3" #sync / 1[56]:Magna Roader:1FF8:/
-74.1 "Wild Speed 4" #sync / 1[56]:Magna Roader:1FF8:/
+71.0 "--sync--" sync / 1[56]:[^:]*:Magna Roader:207E:/
+71.1 "Wild Speed 1" #sync / 1[56]:[^:]*:Magna Roader:1FF8:/
+72.1 "Wild Speed 2" #sync / 1[56]:[^:]*:Magna Roader:1FF8:/
+73.1 "Wild Speed 3" #sync / 1[56]:[^:]*:Magna Roader:1FF8:/
+74.1 "Wild Speed 4" #sync / 1[56]:[^:]*:Magna Roader:1FF8:/
 
-81.2 "--sync--" sync / 1[56]:Magna Roader:207E:/ window 5,30 jump 50.6
-81.3 "Wild Speed 1" #sync / 1[56]:Magna Roader:1FF8:/
-82.3 "Wild Speed 2" #sync / 1[56]:Magna Roader:1FF8:/
-83.3 "Wild Speed 3" #sync / 1[56]:Magna Roader:1FF8:/
-84.3 "Wild Speed 4" #sync / 1[56]:Magna Roader:1FF8:/
+81.2 "--sync--" sync / 1[56]:[^:]*:Magna Roader:207E:/ window 5,30 jump 50.6
+81.3 "Wild Speed 1" #sync / 1[56]:[^:]*:Magna Roader:1FF8:/
+82.3 "Wild Speed 2" #sync / 1[56]:[^:]*:Magna Roader:1FF8:/
+83.3 "Wild Speed 3" #sync / 1[56]:[^:]*:Magna Roader:1FF8:/
+84.3 "Wild Speed 4" #sync / 1[56]:[^:]*:Magna Roader:1FF8:/
 
 # Post Wild Speed loop -> back into Wild Speed loop
 100.0 "--targetable--"
-105.8 "--sync--" sync / 14:Magna Roader:1F16:/ window 70,10
-108.8 "Magitek Fire III" sync / 1[56]:Magna Roader:1F16:/
-112.9 "Wheel" sync / 1[56]:Magna Roader:1F14:/
-120.4 "Magitek Fire II" sync / 1[56]:Magna Roader:1F15:/
-125.5 "Magitek Fire II" sync / 1[56]:Magna Roader:1F15:/
-129.7 "Wheel" sync / 1[56]:Magna Roader:1F14:/
-137.2 "Magitek Fire III" sync / 1[56]:Magna Roader:1F16:/
-141.3 "Wheel" sync / 1[56]:Magna Roader:1F14:/
-148.8 "Magitek Fire II" sync / 1[56]:Magna Roader:1F15:/
-154.0 "Magitek Fire II" sync / 1[56]:Magna Roader:1F15:/
+105.8 "--sync--" sync / 14:[^:]*:Magna Roader:1F16:/ window 70,10
+108.8 "Magitek Fire III" sync / 1[56]:[^:]*:Magna Roader:1F16:/
+112.9 "Wheel" sync / 1[56]:[^:]*:Magna Roader:1F14:/
+120.4 "Magitek Fire II" sync / 1[56]:[^:]*:Magna Roader:1F15:/
+125.5 "Magitek Fire II" sync / 1[56]:[^:]*:Magna Roader:1F15:/
+129.7 "Wheel" sync / 1[56]:[^:]*:Magna Roader:1F14:/
+137.2 "Magitek Fire III" sync / 1[56]:[^:]*:Magna Roader:1F16:/
+141.3 "Wheel" sync / 1[56]:[^:]*:Magna Roader:1F14:/
+148.8 "Magitek Fire II" sync / 1[56]:[^:]*:Magna Roader:1F15:/
+154.0 "Magitek Fire II" sync / 1[56]:[^:]*:Magna Roader:1F15:/
 
 166.9 "--untargetable--"
-166.9 "--sync--" sync / 1[56]:Magna Roader:207E:/ window 60,60 jump 40.4
-167.0 "Wild Speed 1" #sync / 1[56]:Magna Roader:1FF8:/
-168.0 "Wild Speed 2" #sync / 1[56]:Magna Roader:1FF8:/
-169.0 "Wild Speed 3" #sync / 1[56]:Magna Roader:1FF8:/
-170.0 "Wild Speed 4" #sync / 1[56]:Magna Roader:1FF8:/
+166.9 "--sync--" sync / 1[56]:[^:]*:Magna Roader:207E:/ window 60,60 jump 40.4
+167.0 "Wild Speed 1" #sync / 1[56]:[^:]*:Magna Roader:1FF8:/
+168.0 "Wild Speed 2" #sync / 1[56]:[^:]*:Magna Roader:1FF8:/
+169.0 "Wild Speed 3" #sync / 1[56]:[^:]*:Magna Roader:1FF8:/
+170.0 "Wild Speed 4" #sync / 1[56]:[^:]*:Magna Roader:1FF8:/
 
-177.1 "--sync--" #sync / 1[56]:Magna Roader:207E:/
-177.2 "Wild Speed 1" #sync / 1[56]:Magna Roader:1FF8:/
-178.2 "Wild Speed 2" #sync / 1[56]:Magna Roader:1FF8:/
-179.2 "Wild Speed 3" #sync / 1[56]:Magna Roader:1FF8:/
-180.2 "Wild Speed 4" #sync / 1[56]:Magna Roader:1FF8:/
+177.1 "--sync--" #sync / 1[56]:[^:]*:Magna Roader:207E:/
+177.2 "Wild Speed 1" #sync / 1[56]:[^:]*:Magna Roader:1FF8:/
+178.2 "Wild Speed 2" #sync / 1[56]:[^:]*:Magna Roader:1FF8:/
+179.2 "Wild Speed 3" #sync / 1[56]:[^:]*:Magna Roader:1FF8:/
+180.2 "Wild Speed 4" #sync / 1[56]:[^:]*:Magna Roader:1FF8:/
 
-187.3 "--sync--" #sync / 1[56]:Magna Roader:207E:/
-187.4 "Wild Speed 1" #sync / 1[56]:Magna Roader:1FF8:/
-188.4 "Wild Speed 2" #sync / 1[56]:Magna Roader:1FF8:/
-189.4 "Wild Speed 3" #sync / 1[56]:Magna Roader:1FF8:/
-190.4 "Wild Speed 4" #sync / 1[56]:Magna Roader:1FF8:/
+187.3 "--sync--" #sync / 1[56]:[^:]*:Magna Roader:207E:/
+187.4 "Wild Speed 1" #sync / 1[56]:[^:]*:Magna Roader:1FF8:/
+188.4 "Wild Speed 2" #sync / 1[56]:[^:]*:Magna Roader:1FF8:/
+189.4 "Wild Speed 3" #sync / 1[56]:[^:]*:Magna Roader:1FF8:/
+190.4 "Wild Speed 4" #sync / 1[56]:[^:]*:Magna Roader:1FF8:/
 
 
 ### Number XXIV
@@ -86,35 +86,35 @@ hideall "--sync--"
 
 # Note: "Towers" here means Fire II (1F1D) / Blizzard II (1F1E) / Thunder II (1F1F)
 1000.0 "Start" sync / 00:0839::Project Aegis will be sealed off/ window 10000,0
-1011.4 "Stab" sync / 1[56]:Number XXIV:1F1B:/
-1019.9 "Gale Cut" sync / 1[56]:Number XXIV:1F1C:/
-1030.1 "Stab" sync / 1[56]:Number XXIV:1F1B:/
+1011.4 "Stab" sync / 1[56]:[^:]*:Number XXIV:1F1B:/
+1019.9 "Gale Cut" sync / 1[56]:[^:]*:Number XXIV:1F1C:/
+1030.1 "Stab" sync / 1[56]:[^:]*:Number XXIV:1F1B:/
 
-1033.1 "Towers" sync / 1[56]:Number XXIV:1F1[DEF]:/
-1044.6 "Barrier Shift" sync / 1[56]:Number XXIV:1F2[123]:/
-1053.7 "Gale Cut" sync / 1[56]:Number XXIV:1F1C:/
-1060.8 "Stab" sync / 1[56]:Number XXIV:1F1B:/
-1069.2 "Gale Cut" sync / 1[56]:Number XXIV:1F1C:/
+1033.1 "Towers" sync / 1[56]:[^:]*:Number XXIV:1F1[DEF]:/
+1044.6 "Barrier Shift" sync / 1[56]:[^:]*:Number XXIV:1F2[123]:/
+1053.7 "Gale Cut" sync / 1[56]:[^:]*:Number XXIV:1F1C:/
+1060.8 "Stab" sync / 1[56]:[^:]*:Number XXIV:1F1B:/
+1069.2 "Gale Cut" sync / 1[56]:[^:]*:Number XXIV:1F1C:/
 
 # loop begins
-1082.4 "Towers" sync / 1[56]:Number XXIV:1F1[DEF]:/
-1087.4 "Barrier Shift" sync / 1[56]:Number XXIV:1F2[123]:/
-1096.6 "Gale Cut" sync / 1[56]:Number XXIV:1F1C:/
-1103.8 "Stab" sync / 1[56]:Number XXIV:1F1B:/
-1112.3 "Gale Cut" sync / 1[56]:Number XXIV:1F1C:/
-1122.5 "Gale Cut" sync / 1[56]:Number XXIV:1F1C:/
+1082.4 "Towers" sync / 1[56]:[^:]*:Number XXIV:1F1[DEF]:/
+1087.4 "Barrier Shift" sync / 1[56]:[^:]*:Number XXIV:1F2[123]:/
+1096.6 "Gale Cut" sync / 1[56]:[^:]*:Number XXIV:1F1C:/
+1103.8 "Stab" sync / 1[56]:[^:]*:Number XXIV:1F1B:/
+1112.3 "Gale Cut" sync / 1[56]:[^:]*:Number XXIV:1F1C:/
+1122.5 "Gale Cut" sync / 1[56]:[^:]*:Number XXIV:1F1C:/
 
-1125.5 "Towers" sync / 1[56]:Number XXIV:1F1[DEF]:/
-1131.6 "Barrier Shift" sync / 1[56]:Number XXIV:1F2[123]:/
-1140.8 "Gale Cut" sync / 1[56]:Number XXIV:1F1C:/
-1148.0 "Stab" sync / 1[56]:Number XXIV:1F1B:/
+1125.5 "Towers" sync / 1[56]:[^:]*:Number XXIV:1F1[DEF]:/
+1131.6 "Barrier Shift" sync / 1[56]:[^:]*:Number XXIV:1F2[123]:/
+1140.8 "Gale Cut" sync / 1[56]:[^:]*:Number XXIV:1F1C:/
+1148.0 "Stab" sync / 1[56]:[^:]*:Number XXIV:1F1B:/
 
-1161.5 "Towers" sync / 1[56]:Number XXIV:1F1[DEF]:/ window 20,20 jump 1082.4
-1166.5 "Barrier Shift" #sync / 1[56]:Number XXIV:1F2[123]:/
-1175.7 "Gale Cut" #sync / 1[56]:Number XXIV:1F1C:/
-1182.9 "Stab" #sync / 1[56]:Number XXIV:1F1B:/
-1191.4 "Gale Cut" #sync / 1[56]:Number XXIV:1F1C:/
-1201.6 "Gale Cut" #sync / 1[56]:Number XXIV:1F1C:/
+1161.5 "Towers" sync / 1[56]:[^:]*:Number XXIV:1F1[DEF]:/ window 20,20 jump 1082.4
+1166.5 "Barrier Shift" #sync / 1[56]:[^:]*:Number XXIV:1F2[123]:/
+1175.7 "Gale Cut" #sync / 1[56]:[^:]*:Number XXIV:1F1C:/
+1182.9 "Stab" #sync / 1[56]:[^:]*:Number XXIV:1F1B:/
+1191.4 "Gale Cut" #sync / 1[56]:[^:]*:Number XXIV:1F1C:/
+1201.6 "Gale Cut" #sync / 1[56]:[^:]*:Number XXIV:1F1C:/
 
 
 ### Inferno
@@ -138,61 +138,61 @@ hideall "--sync--"
 # * Ketu Cutter (1F27): 180/360 degree pinwheel
 # * Ketu Cut (2086) / Rahu Cut (2087) is powering up.
 2000.0 "Start" sync / 00:0839::The Assessment Grounds will be sealed off/ window 10000,0
-2010.4 "Ketu Slash" sync / 1[56]:Inferno:1F26:/
-2017.9 "Rahu Blaster" sync / 1[56]:Inferno:1F29:/
-2028.8 "Ketu & Rahu" sync / 1[56]:Inferno:1F25:/
+2010.4 "Ketu Slash" sync / 1[56]:[^:]*:Inferno:1F26:/
+2017.9 "Rahu Blaster" sync / 1[56]:[^:]*:Inferno:1F29:/
+2028.8 "Ketu & Rahu" sync / 1[56]:[^:]*:Inferno:1F25:/
 
-2045.0 "Ketu Cut 1" sync / 1[56]:Inferno:2086:/ window 50,50
-2054.7 "Ketu Slash" sync / 1[56]:Inferno:208B:/
-2062.3 "Rahu Blaster" sync / 1[56]:Inferno:1F29:/
-2069.8 "Ketu Slash" sync / 1[56]:Inferno:208B:/
-2079.9 "Ketu & Rahu" sync / 1[56]:Inferno:1F25:/
-2087.9 "Ketu & Rahu" sync / 1[56]:Inferno:1F25:/
-2096.8 "Rahu Blaster" sync / 1[56]:Inferno:1F29:/
-2104.3 "Ketu Slash" sync / 1[56]:Inferno:208B:/
+2045.0 "Ketu Cut 1" sync / 1[56]:[^:]*:Inferno:2086:/ window 50,50
+2054.7 "Ketu Slash" sync / 1[56]:[^:]*:Inferno:208B:/
+2062.3 "Rahu Blaster" sync / 1[56]:[^:]*:Inferno:1F29:/
+2069.8 "Ketu Slash" sync / 1[56]:[^:]*:Inferno:208B:/
+2079.9 "Ketu & Rahu" sync / 1[56]:[^:]*:Inferno:1F25:/
+2087.9 "Ketu & Rahu" sync / 1[56]:[^:]*:Inferno:1F25:/
+2096.8 "Rahu Blaster" sync / 1[56]:[^:]*:Inferno:1F29:/
+2104.3 "Ketu Slash" sync / 1[56]:[^:]*:Inferno:208B:/
 
-2119.2 "Rahu Cut 1" sync / 1[56]:Inferno:2087:/ window 50,50
+2119.2 "Rahu Cut 1" sync / 1[56]:[^:]*:Inferno:2087:/ window 50,50
 2123.3 "--adds--"
-2128.8 "Ketu Slash" sync / 1[56]:Inferno:208B:/
-2136.3 "Rahu Blaster" sync / 1[56]:Inferno:208E:/
-2143.9 "Ketu Slash" sync / 1[56]:Inferno:208B:/
-2151.4 "Rahu Blaster" sync / 1[56]:Inferno:208E:/
+2128.8 "Ketu Slash" sync / 1[56]:[^:]*:Inferno:208B:/
+2136.3 "Rahu Blaster" sync / 1[56]:[^:]*:Inferno:208E:/
+2143.9 "Ketu Slash" sync / 1[56]:[^:]*:Inferno:208B:/
+2151.4 "Rahu Blaster" sync / 1[56]:[^:]*:Inferno:208E:/
 # 2159 Quick Charge can go off here, which delays Ketu & Rahu by 30s, throws off timeline.
 # Hopefully the large sync on Rahu Cut below will get it sorted again.
-2159.8 "Ketu & Rahu" sync / 1[56]:Inferno:1F25:/
-2167.8 "Ketu & Rahu" sync / 1[56]:Inferno:1F25:/
-2175.6 "Rahu Blaster" sync / 1[56]:Inferno:208E:/
-2183.1 "Ketu Slash" sync / 1[56]:Inferno:208B:/
+2159.8 "Ketu & Rahu" sync / 1[56]:[^:]*:Inferno:1F25:/
+2167.8 "Ketu & Rahu" sync / 1[56]:[^:]*:Inferno:1F25:/
+2175.6 "Rahu Blaster" sync / 1[56]:[^:]*:Inferno:208E:/
+2183.1 "Ketu Slash" sync / 1[56]:[^:]*:Inferno:208B:/
 
-2197.9 "Ketu Cut 2" sync / 1[56]:Inferno:2086:/ window 50,50
+2197.9 "Ketu Cut 2" sync / 1[56]:[^:]*:Inferno:2086:/ window 50,50
 2201.8 "--adds--"
-2207.7 "Ketu Slash" sync / 1[56]:Inferno:208C:/
-2215.3 "Rahu Blaster" sync / 1[56]:Inferno:208E:/
-2222.9 "Ketu Slash" sync / 1[56]:Inferno:208C:/
-2230.4 "Rahu Blaster" sync / 1[56]:Inferno:208E:/
+2207.7 "Ketu Slash" sync / 1[56]:[^:]*:Inferno:208C:/
+2215.3 "Rahu Blaster" sync / 1[56]:[^:]*:Inferno:208E:/
+2222.9 "Ketu Slash" sync / 1[56]:[^:]*:Inferno:208C:/
+2230.4 "Rahu Blaster" sync / 1[56]:[^:]*:Inferno:208E:/
 # 2237.5 Quick Charge?
-2238.5 "Ketu & Rahu" sync / 1[56]:Inferno:1F25:/
-2246.5 "Ketu & Rahu" sync / 1[56]:Inferno:1F25:/
-2254.3 "Rahu Blaster" sync / 1[56]:Inferno:208E:/
-2261.9 "Ketu Slash" sync / 1[56]:Inferno:208C:/
+2238.5 "Ketu & Rahu" sync / 1[56]:[^:]*:Inferno:1F25:/
+2246.5 "Ketu & Rahu" sync / 1[56]:[^:]*:Inferno:1F25:/
+2254.3 "Rahu Blaster" sync / 1[56]:[^:]*:Inferno:208E:/
+2261.9 "Ketu Slash" sync / 1[56]:[^:]*:Inferno:208C:/
 
 # Once we get to this Rahu Cut, then it is fully powered.
-2276.8 "Rahu Cut 2" sync / 1[56]:Inferno:2087:/ window 150,150
-2286.4 "Ketu Slash" sync / 1[56]:Inferno:208C:/
-2294.0 "Rahu Blaster" sync / 1[56]:Inferno:208F:/
-2301.5 "Ketu Slash" sync / 1[56]:Inferno:208C:/
-2309.0 "Rahu Blaster" sync / 1[56]:Inferno:208F:/
-2317.3 "Ketu & Rahu" sync / 1[56]:Inferno:1F25:/
-2325.4 "Ketu & Rahu" sync / 1[56]:Inferno:1F25:/
-2333.2 "Rahu Blaster" sync / 1[56]:Inferno:208F:/
+2276.8 "Rahu Cut 2" sync / 1[56]:[^:]*:Inferno:2087:/ window 150,150
+2286.4 "Ketu Slash" sync / 1[56]:[^:]*:Inferno:208C:/
+2294.0 "Rahu Blaster" sync / 1[56]:[^:]*:Inferno:208F:/
+2301.5 "Ketu Slash" sync / 1[56]:[^:]*:Inferno:208C:/
+2309.0 "Rahu Blaster" sync / 1[56]:[^:]*:Inferno:208F:/
+2317.3 "Ketu & Rahu" sync / 1[56]:[^:]*:Inferno:1F25:/
+2325.4 "Ketu & Rahu" sync / 1[56]:[^:]*:Inferno:1F25:/
+2333.2 "Rahu Blaster" sync / 1[56]:[^:]*:Inferno:208F:/
 
 # loop
-2340.7 "Ketu Slash" sync / 1[56]:Inferno:208C:/
-2351.6 "Ketu & Rahu" sync / 1[56]:Inferno:1F25:/
-2359.7 "Ketu & Rahu" sync / 1[56]:Inferno:1F25:/
-2367.6 "Rahu Blaster" sync / 1[56]:Inferno:208F:/
+2340.7 "Ketu Slash" sync / 1[56]:[^:]*:Inferno:208C:/
+2351.6 "Ketu & Rahu" sync / 1[56]:[^:]*:Inferno:1F25:/
+2359.7 "Ketu & Rahu" sync / 1[56]:[^:]*:Inferno:1F25:/
+2367.6 "Rahu Blaster" sync / 1[56]:[^:]*:Inferno:208F:/
 
-2375.2 "Ketu Slash" sync / 1[56]:Inferno:208C:/ window 20,200 jump 2340.7
-2386.1 "Ketu & Rahu" #sync / 1[56]:Inferno:1F25:/
-2394.2 "Ketu & Rahu" #sync / 1[56]:Inferno:1F25:/
-2402.1 "Rahu Blaster" #sync / 1[56]:Inferno:208F:/
+2375.2 "Ketu Slash" sync / 1[56]:[^:]*:Inferno:208C:/ window 20,200 jump 2340.7
+2386.1 "Ketu & Rahu" #sync / 1[56]:[^:]*:Inferno:1F25:/
+2394.2 "Ketu & Rahu" #sync / 1[56]:[^:]*:Inferno:1F25:/
+2402.1 "Rahu Blaster" #sync / 1[56]:[^:]*:Inferno:208F:/

--- a/ui/raidboss/data/04-sb/dungeon/doma_castle.txt
+++ b/ui/raidboss/data/04-sb/dungeon/doma_castle.txt
@@ -6,36 +6,36 @@ hideall "--sync--"
 ### Magitek Rearguard 
 # -ii 209F 20A0
 0 "Start" sync / 00:0839::The Third Armory will be sealed off/
-7.4 "Cermet Pile" sync / 1[56]:Magitek Rearguard:209D:/
-15.0 "Garlean Fire" sync / 1[56]:Magitek Rearguard:209E:/
-30.6 "Magitek Ray" sync / 1[56]:Rearguard Bit:20A1:/
+7.4 "Cermet Pile" sync / 1[56]:[^:]*:Magitek Rearguard:209D:/
+15.0 "Garlean Fire" sync / 1[56]:[^:]*:Magitek Rearguard:209E:/
+30.6 "Magitek Ray" sync / 1[56]:[^:]*:Rearguard Bit:20A1:/
 35.6 "Rearguard Mines" #sync / 03:........:Rearguard Mine:/ 
-37.8 "Cermet Pile" sync / 1[56]:Magitek Rearguard:209D:/
-40.8 "Magitek Ray" sync / 1[56]:Rearguard Bit:20A1:/
-43.4 "Garlean Fire" sync / 1[56]:Magitek Rearguard:209E:/
-48.9 "Magitek Ray" sync / 1[56]:Rearguard Bit:20A1:/
-53.9 "Magitek Ray" sync / 1[56]:Rearguard Bit:20A1:/
-60.9 "Cermet Pile" sync / 1[56]:Magitek Rearguard:209D:/
+37.8 "Cermet Pile" sync / 1[56]:[^:]*:Magitek Rearguard:209D:/
+40.8 "Magitek Ray" sync / 1[56]:[^:]*:Rearguard Bit:20A1:/
+43.4 "Garlean Fire" sync / 1[56]:[^:]*:Magitek Rearguard:209E:/
+48.9 "Magitek Ray" sync / 1[56]:[^:]*:Rearguard Bit:20A1:/
+53.9 "Magitek Ray" sync / 1[56]:[^:]*:Rearguard Bit:20A1:/
+60.9 "Cermet Pile" sync / 1[56]:[^:]*:Magitek Rearguard:209D:/
 68.5 "Rearguard Mines" #sync / 03:........:Rearguard Mine:/ 
 
-70.7 "Cermet Pile" sync / 1[56]:Magitek Rearguard:209D:/
-73.7 "Magitek Ray" sync / 1[56]:Rearguard Bit:20A1:/
-76.4 "Garlean Fire" sync / 1[56]:Magitek Rearguard:209E:/
-81.9 "Magitek Ray" sync / 1[56]:Rearguard Bit:20A1:/
-86.0 "Cermet Pile" sync / 1[56]:Magitek Rearguard:209D:/
-88.9 "Magitek Ray" sync / 1[56]:Rearguard Bit:20A1:/
-91.6 "Garlean Fire" sync / 1[56]:Magitek Rearguard:209E:/
-97.2 "Magitek Ray" sync / 1[56]:Rearguard Bit:20A1:/
+70.7 "Cermet Pile" sync / 1[56]:[^:]*:Magitek Rearguard:209D:/
+73.7 "Magitek Ray" sync / 1[56]:[^:]*:Rearguard Bit:20A1:/
+76.4 "Garlean Fire" sync / 1[56]:[^:]*:Magitek Rearguard:209E:/
+81.9 "Magitek Ray" sync / 1[56]:[^:]*:Rearguard Bit:20A1:/
+86.0 "Cermet Pile" sync / 1[56]:[^:]*:Magitek Rearguard:209D:/
+88.9 "Magitek Ray" sync / 1[56]:[^:]*:Rearguard Bit:20A1:/
+91.6 "Garlean Fire" sync / 1[56]:[^:]*:Magitek Rearguard:209E:/
+97.2 "Magitek Ray" sync / 1[56]:[^:]*:Rearguard Bit:20A1:/
 98.7 "Rearguard Mines" #sync / 03:........:Rearguard Mine:/ 
-101.3 "Cermet Pile" sync / 1[56]:Magitek Rearguard:209D:/
-104.3 "Magitek Ray" sync / 1[56]:Rearguard Bit:20A1:/
-107.0 "Garlean Fire" sync / 1[56]:Magitek Rearguard:209E:/
-112.5 "Magitek Ray" sync / 1[56]:Rearguard Bit:20A1:/
-115.6 "Cermet Pile" sync / 1[56]:Magitek Rearguard:209D:/
-118.6 "Magitek Ray" sync / 1[56]:Rearguard Bit:20A1:/
+101.3 "Cermet Pile" sync / 1[56]:[^:]*:Magitek Rearguard:209D:/
+104.3 "Magitek Ray" sync / 1[56]:[^:]*:Rearguard Bit:20A1:/
+107.0 "Garlean Fire" sync / 1[56]:[^:]*:Magitek Rearguard:209E:/
+112.5 "Magitek Ray" sync / 1[56]:[^:]*:Rearguard Bit:20A1:/
+115.6 "Cermet Pile" sync / 1[56]:[^:]*:Magitek Rearguard:209D:/
+118.6 "Magitek Ray" sync / 1[56]:[^:]*:Rearguard Bit:20A1:/
 131.3 "Rearguard Mines" #sync / 03:........:Rearguard Mine:/ 
 
-133.2 "Cermet Pile" sync / 1[56]:Magitek Rearguard:209D:/ jump 70.7
+133.2 "Cermet Pile" sync / 1[56]:[^:]*:Magitek Rearguard:209D:/ jump 70.7
 136.2 "Magitek Ray"
 138.9 "Garlean Fire"
 144.4 "Magitek Ray"
@@ -48,37 +48,37 @@ hideall "--sync--"
 ### Magitek Hexadrone
 # -ii 20A4 20A6 20A7 2447
 1000 "Start" sync / 00:0839::The Training Grounds will be sealed off/ window 1000,0
-1010.6 "Circle Of Death" sync / 1[56]:Magitek Hexadrone:20A2:/
-1018.9 "2-Tonze Magitek Missile" sync / 1[56]:Magitek Hexadrone:20A3:/
+1010.6 "Circle Of Death" sync / 1[56]:[^:]*:Magitek Hexadrone:20A2:/
+1018.9 "2-Tonze Magitek Missile" sync / 1[56]:[^:]*:Magitek Hexadrone:20A3:/
 1024.1 "Hexadrone Bits" sync / 03:........:Hexadrone Bit:/ 
 1029.6 "Bits Activate"
-1039.6 "Circle Of Death" sync / 1[56]:Magitek Hexadrone:20A2:/
+1039.6 "Circle Of Death" sync / 1[56]:[^:]*:Magitek Hexadrone:20A2:/
 1045.7 "Hexadrone Bits" sync / 03:........:Hexadrone Bit:/ 
 1051.2 "Bits Activate"
-1049.8 "Circle Of Death" sync / 1[56]:Magitek Hexadrone:20A2:/
-1064.5 "Magitek Missiles" sync / 1[56]:Magitek Hexadrone:20A5:/
+1049.8 "Circle Of Death" sync / 1[56]:[^:]*:Magitek Hexadrone:20A2:/
+1064.5 "Magitek Missiles" sync / 1[56]:[^:]*:Magitek Hexadrone:20A5:/
 1068.9 "Hexadrone Bits" sync / 03:........:Hexadrone Bit:/ 
 1074.4 "Bits Activate"
-1077.3 "2-Tonze Magitek Missile" sync / 1[56]:Magitek Hexadrone:20A3:/
+1077.3 "2-Tonze Magitek Missile" sync / 1[56]:[^:]*:Magitek Hexadrone:20A3:/
 
-1083.9 "Circle Of Death" sync / 1[56]:Magitek Hexadrone:20A2:/
+1083.9 "Circle Of Death" sync / 1[56]:[^:]*:Magitek Hexadrone:20A2:/
 1090.0 "Hexadrone Bits" sync / 03:........:Hexadrone Bit:/ 
 1095.5 "Bits Activate"
-1098.6 "Magitek Missiles" sync / 1[56]:Magitek Hexadrone:20A5:/
-1106.4 "2-Tonze Magitek Missile" sync / 1[56]:Magitek Hexadrone:20A3:/
+1098.6 "Magitek Missiles" sync / 1[56]:[^:]*:Magitek Hexadrone:20A5:/
+1106.4 "2-Tonze Magitek Missile" sync / 1[56]:[^:]*:Magitek Hexadrone:20A3:/
 1117.9 "Hexadrone Bits" sync / 03:........:Hexadrone Bit:/ 
 1123.4 "Bits Activate"
-1119.6 "Magitek Missiles" sync / 1[56]:Magitek Hexadrone:20A5:/
-1132.3 "Circle Of Death" sync / 1[56]:Magitek Hexadrone:20A2:/
+1119.6 "Magitek Missiles" sync / 1[56]:[^:]*:Magitek Hexadrone:20A5:/
+1132.3 "Circle Of Death" sync / 1[56]:[^:]*:Magitek Hexadrone:20A2:/
 1138.7 "Hexadrone Bits" sync / 03:........:Hexadrone Bit:/ 
 1144.2 "Bits Activate"
-1146.7 "2-Tonze Magitek Missile" sync / 1[56]:Magitek Hexadrone:20A3:/
-1156.8 "Magitek Missiles" sync / 1[56]:Magitek Hexadrone:20A5:/
+1146.7 "2-Tonze Magitek Missile" sync / 1[56]:[^:]*:Magitek Hexadrone:20A3:/
+1156.8 "Magitek Missiles" sync / 1[56]:[^:]*:Magitek Hexadrone:20A5:/
 1166.2 "Hexadrone Bits" sync / 03:........:Hexadrone Bit:/ 
 1171.7 "Bits Activate"
-1174.7 "2-Tonze Magitek Missile" sync / 1[56]:Magitek Hexadrone:20A3:/
+1174.7 "2-Tonze Magitek Missile" sync / 1[56]:[^:]*:Magitek Hexadrone:20A3:/
 
-1181.3 "Circle Of Death" sync / 1[56]:Magitek Hexadrone:20A2:/ jump 1083.9
+1181.3 "Circle Of Death" sync / 1[56]:[^:]*:Magitek Hexadrone:20A2:/ jump 1083.9
 1187.4 "Hexadrone Bits"
 1192.9 "Bits Activate"
 1196.0 "Magitek Missiles"
@@ -88,51 +88,51 @@ hideall "--sync--"
 ### Hypertuned Grynewaht
 # -ii 20A9 20AB 20AC 20AE 20A7 2447
 2000 "Start" sync / 00:0839::The Hall Of The Scarlet Swallow will be sealed off/ window 2000,0
-2009.4 "Chainsaw" duration 5.5 sync / 1[56]:Hypertuned Grynewaht:20A8:/
-2022.7 "Delay-Action Charge" sync / 1[56]:Hypertuned Grynewaht:20AD:/
-2023.1 "Gunsaw" duration 5.0  sync / 1[56]:Hypertuned Grynewaht:20AA:/
-2045.4 "Thermobaric Charge" sync / 1[56]:Hypertuned Grynewaht:20AF:/
-2048.8 "--sync--" sync / 1[56]:Hypertuned Grynewaht:20B0:/
-2057.0 "Gunsaw" duration 5.0  sync / 1[56]:Hypertuned Grynewaht:20AA:/
-2070.3 "Delay-Action Charge" sync / 1[56]:Hypertuned Grynewaht:20AD:/
-2070.3 "Clean Cut" #sync / 1[56]:Magitek Chakram:20B1:/
-2071.7 "--sync--" sync / 1[56]:Hypertuned Grynewaht:20B0:/
-2079.9 "Gunsaw" duration 5.0  sync / 1[56]:Hypertuned Grynewaht:20AA:/
-2093.2 "Delay-Action Charge" sync / 1[56]:Hypertuned Grynewaht:20AD:/
-2093.2 "Clean Cut" #sync / 1[56]:Magitek Chakram:20B1:/
+2009.4 "Chainsaw" duration 5.5 sync / 1[56]:[^:]*:Hypertuned Grynewaht:20A8:/
+2022.7 "Delay-Action Charge" sync / 1[56]:[^:]*:Hypertuned Grynewaht:20AD:/
+2023.1 "Gunsaw" duration 5.0  sync / 1[56]:[^:]*:Hypertuned Grynewaht:20AA:/
+2045.4 "Thermobaric Charge" sync / 1[56]:[^:]*:Hypertuned Grynewaht:20AF:/
+2048.8 "--sync--" sync / 1[56]:[^:]*:Hypertuned Grynewaht:20B0:/
+2057.0 "Gunsaw" duration 5.0  sync / 1[56]:[^:]*:Hypertuned Grynewaht:20AA:/
+2070.3 "Delay-Action Charge" sync / 1[56]:[^:]*:Hypertuned Grynewaht:20AD:/
+2070.3 "Clean Cut" #sync / 1[56]:[^:]*:Magitek Chakram:20B1:/
+2071.7 "--sync--" sync / 1[56]:[^:]*:Hypertuned Grynewaht:20B0:/
+2079.9 "Gunsaw" duration 5.0  sync / 1[56]:[^:]*:Hypertuned Grynewaht:20AA:/
+2093.2 "Delay-Action Charge" sync / 1[56]:[^:]*:Hypertuned Grynewaht:20AD:/
+2093.2 "Clean Cut" #sync / 1[56]:[^:]*:Magitek Chakram:20B1:/
 2097.6 "Hexadrone Bits" sync / 03:........:Hexadrone Bit:/ 
 2103.1 "Bits Activate"
-2108.2 "Chainsaw" duration 5.5 sync / 1[56]:Hypertuned Grynewaht:20A8:/
-2115.9 "Thermobaric Charge" sync / 1[56]:Hypertuned Grynewaht:20AF:/
-2118.4 "--sync--" sync / 1[56]:Hypertuned Grynewaht:20B0:/
-2124.7 "Gunsaw" duration 5.0 sync / 1[56]:Hypertuned Grynewaht:20AA:/
-2138.0 "Delay-Action Charge" sync / 1[56]:Hypertuned Grynewaht:20AD:/
-2140.0 "Clean Cut" sync / 1[56]:Magitek Chakram:20B1:/
-2141.4 "--sync--" sync / 1[56]:Hypertuned Grynewaht:20B0:/
-2149.6 "Gunsaw" duration 5.0 sync / 1[56]:Hypertuned Grynewaht:20AA:/
-2162.9 "Delay-Action Charge" sync / 1[56]:Hypertuned Grynewaht:20AD:/
-2162.9 "Clean Cut" #sync / 1[56]:Magitek Chakram:20B1:/
-2167.4 "--sync--" sync / 1[56]:Hypertuned Grynewaht:20B0:/
+2108.2 "Chainsaw" duration 5.5 sync / 1[56]:[^:]*:Hypertuned Grynewaht:20A8:/
+2115.9 "Thermobaric Charge" sync / 1[56]:[^:]*:Hypertuned Grynewaht:20AF:/
+2118.4 "--sync--" sync / 1[56]:[^:]*:Hypertuned Grynewaht:20B0:/
+2124.7 "Gunsaw" duration 5.0 sync / 1[56]:[^:]*:Hypertuned Grynewaht:20AA:/
+2138.0 "Delay-Action Charge" sync / 1[56]:[^:]*:Hypertuned Grynewaht:20AD:/
+2140.0 "Clean Cut" sync / 1[56]:[^:]*:Magitek Chakram:20B1:/
+2141.4 "--sync--" sync / 1[56]:[^:]*:Hypertuned Grynewaht:20B0:/
+2149.6 "Gunsaw" duration 5.0 sync / 1[56]:[^:]*:Hypertuned Grynewaht:20AA:/
+2162.9 "Delay-Action Charge" sync / 1[56]:[^:]*:Hypertuned Grynewaht:20AD:/
+2162.9 "Clean Cut" #sync / 1[56]:[^:]*:Magitek Chakram:20B1:/
+2167.4 "--sync--" sync / 1[56]:[^:]*:Hypertuned Grynewaht:20B0:/
 2168.5 "Hexadrone Bits" sync / 03:........:Hexadrone Bit:/ 
 2174.0 "Bits Activate"
-2180.0 "Chainsaw" duration 5.5 sync / 1[56]:Hypertuned Grynewaht:20A8:/
-2187.7 "Thermobaric Charge" sync / 1[56]:Hypertuned Grynewaht:20AF:/
-2189.0 "Clean Cut" sync / 1[56]:Magitek Chakram:20B1:/
+2180.0 "Chainsaw" duration 5.5 sync / 1[56]:[^:]*:Hypertuned Grynewaht:20A8:/
+2187.7 "Thermobaric Charge" sync / 1[56]:[^:]*:Hypertuned Grynewaht:20AF:/
+2189.0 "Clean Cut" sync / 1[56]:[^:]*:Magitek Chakram:20B1:/
 
-2194.2 "--sync--" sync / 1[56]:Hypertuned Grynewaht:20B0:/
-2202.4 "Gunsaw" duration 5.0 sync / 1[56]:Hypertuned Grynewaht:20AA:/
-2215.7 "Delay-Action Charge" sync / 1[56]:Hypertuned Grynewaht:20AD:/
-2215.7 "Clean Cut" #sync / 1[56]:Magitek Chakram:20B1:/
+2194.2 "--sync--" sync / 1[56]:[^:]*:Hypertuned Grynewaht:20B0:/
+2202.4 "Gunsaw" duration 5.0 sync / 1[56]:[^:]*:Hypertuned Grynewaht:20AA:/
+2215.7 "Delay-Action Charge" sync / 1[56]:[^:]*:Hypertuned Grynewaht:20AD:/
+2215.7 "Clean Cut" #sync / 1[56]:[^:]*:Magitek Chakram:20B1:/
 2218.2 "Hexadrone Bits" sync / 03:........:Hexadrone Bit:/ 
 2223.7 "Bits Activate"
-2228.7 "Chainsaw" duration 5.5 sync / 1[56]:Hypertuned Grynewaht:20A8:/
-2236.4 "Thermobaric Charge" sync / 1[56]:Hypertuned Grynewaht:20AF:/
-2242.8 "Chainsaw" duration 5.5 sync / 1[56]:Hypertuned Grynewaht:20A8:/
+2228.7 "Chainsaw" duration 5.5 sync / 1[56]:[^:]*:Hypertuned Grynewaht:20A8:/
+2236.4 "Thermobaric Charge" sync / 1[56]:[^:]*:Hypertuned Grynewaht:20AF:/
+2242.8 "Chainsaw" duration 5.5 sync / 1[56]:[^:]*:Hypertuned Grynewaht:20A8:/
 
-2257.0 "--sync--" sync / 1[56]:Hypertuned Grynewaht:20B0:/
+2257.0 "--sync--" sync / 1[56]:[^:]*:Hypertuned Grynewaht:20B0:/
 # Loop begins here, but the jump is attached to the Delay-Action Charge to preserve the duration timer for Gunsaw
-2265.2 "Gunsaw" duration 5.0 sync / 1[56]:Hypertuned Grynewaht:20AA:/ 
-2278.5 "Delay-Action Charge" sync / 1[56]:Hypertuned Grynewaht:20AD:/ jump 2215.7
+2265.2 "Gunsaw" duration 5.0 sync / 1[56]:[^:]*:Hypertuned Grynewaht:20AA:/ 
+2278.5 "Delay-Action Charge" sync / 1[56]:[^:]*:Hypertuned Grynewaht:20AD:/ jump 2215.7
 2278.5 "Clean Cut"
 2281.0 "Hexadrone Bits"
 2286.5 "Bits Activate"

--- a/ui/raidboss/data/04-sb/dungeon/drowned_city_of_skalla.txt
+++ b/ui/raidboss/data/04-sb/dungeon/drowned_city_of_skalla.txt
@@ -11,27 +11,27 @@ hideall "--sync--"
 # -ii 2655
 
 0 "Start" sync / 00:0839::The Green Screams will be sealed off/ window 0,1
-7.4 "Torpedo" sync / 1[56]:Kelpie:264F:/ window 7.4,5
-15.0 "Rising Seas" sync / 1[56]:Kelpie:2650:/
-26.7 "Gallop" sync / 1[56]:Kelpie:2653:/
-37.0 "Hydro Pull/Hydro Push" sync / 1[56]:Kelpie:(2651|2652):/
-43.5 "Torpedo" sync / 1[56]:Kelpie:264F:/
-51.1 "Rising Seas" sync / 1[56]:Kelpie:2650:/
-62.7 "Bloody Puddle" sync / 1[56]:Kelpie:2654:/
-65.9 "Gallop" sync / 1[56]:Kelpie:2653:/ window 20,20
-73.9 "Bubble Burst" sync / 1[56]:Hydrosphere:261B:/
-76.2 "Hydro Pull/Hydro Push" sync / 1[56]:Kelpie:(2651|2652):/
-92.6 "Rising Seas" sync / 1[56]:Kelpie:2650:/
+7.4 "Torpedo" sync / 1[56]:[^:]*:Kelpie:264F:/ window 7.4,5
+15.0 "Rising Seas" sync / 1[56]:[^:]*:Kelpie:2650:/
+26.7 "Gallop" sync / 1[56]:[^:]*:Kelpie:2653:/
+37.0 "Hydro Pull/Hydro Push" sync / 1[56]:[^:]*:Kelpie:(2651|2652):/
+43.5 "Torpedo" sync / 1[56]:[^:]*:Kelpie:264F:/
+51.1 "Rising Seas" sync / 1[56]:[^:]*:Kelpie:2650:/
+62.7 "Bloody Puddle" sync / 1[56]:[^:]*:Kelpie:2654:/
+65.9 "Gallop" sync / 1[56]:[^:]*:Kelpie:2653:/ window 20,20
+73.9 "Bubble Burst" sync / 1[56]:[^:]*:Hydrosphere:261B:/
+76.2 "Hydro Pull/Hydro Push" sync / 1[56]:[^:]*:Kelpie:(2651|2652):/
+92.6 "Rising Seas" sync / 1[56]:[^:]*:Kelpie:2650:/
 
 # A near-perfect 50-second rotation
-102.2 "Torpedo" sync / 1[56]:Kelpie:264F:/ window 20,20
-107.8 "Rising Seas" sync / 1[56]:Kelpie:2650:/
-117.3 "Bloody Puddle" sync / 1[56]:Kelpie:2654:/
-120.5 "Gallop" sync / 1[56]:Kelpie:2653:/
-128.6 "Bubble Burst" sync / 1[56]:Hydrosphere:261B:/
-130.7 "Hydro Pull/Hydro Push" sync / 1[56]:Kelpie:(2651|2652):/
+102.2 "Torpedo" sync / 1[56]:[^:]*:Kelpie:264F:/ window 20,20
+107.8 "Rising Seas" sync / 1[56]:[^:]*:Kelpie:2650:/
+117.3 "Bloody Puddle" sync / 1[56]:[^:]*:Kelpie:2654:/
+120.5 "Gallop" sync / 1[56]:[^:]*:Kelpie:2653:/
+128.6 "Bubble Burst" sync / 1[56]:[^:]*:Hydrosphere:261B:/
+130.7 "Hydro Pull/Hydro Push" sync / 1[56]:[^:]*:Kelpie:(2651|2652):/
 
-152.2 "Torpedo" sync / 1[56]:Kelpie:264F:/ window 20,20 jump 102.2
+152.2 "Torpedo" sync / 1[56]:[^:]*:Kelpie:264F:/ window 20,20 jump 102.2
 157.8 "Rising Seas"
 167.3 "Bloody Puddle"
 170.5 "Gallop"
@@ -47,46 +47,46 @@ hideall "--sync--"
 
 
 1000.0 "Start" sync / 00:0839::A Door Unopened will be sealed off/ window 1000,5
-1009.2 "Mystic Light" sync / 1[56]:The Old One:2657:/
-1015.0 "Mystic Flame" sync / 1[56]:The Old One:2658:/
-1018.1 "Order To Detonate (cast)" sync / 14:The Old One:265B:/ window 18.1,5 duration 19.7
-1037.8 "Order To Detonate?" # sync / 1[56]:The Old One:265B:/
-1040.6 "Self-Detonate?" # sync / 1[56]:Subservient:265C:/
-1047.7 "Mystic Flame" sync / 1[56]:The Old One:2658:/ window 20,20
-1058.8 "Mystic Light" sync / 1[56]:The Old One:2657:/
-1074.7 "Mystic Flame" sync / 1[56]:The Old One:2658:/ jump 1047.7
+1009.2 "Mystic Light" sync / 1[56]:[^:]*:The Old One:2657:/
+1015.0 "Mystic Flame" sync / 1[56]:[^:]*:The Old One:2658:/
+1018.1 "Order To Detonate (cast)" sync / 14:[^:]*:The Old One:265B:/ window 18.1,5 duration 19.7
+1037.8 "Order To Detonate?" # sync / 1[56]:[^:]*:The Old One:265B:/
+1040.6 "Self-Detonate?" # sync / 1[56]:[^:]*:Subservient:265C:/
+1047.7 "Mystic Flame" sync / 1[56]:[^:]*:The Old One:2658:/ window 20,20
+1058.8 "Mystic Light" sync / 1[56]:[^:]*:The Old One:2657:/
+1074.7 "Mystic Flame" sync / 1[56]:[^:]*:The Old One:2658:/ jump 1047.7
 1085.8 "Mystic Light"
 1101.7 "Mystic Flame"
 1112.8 "Mystic Light"
 1128.7 "Mystic Flame"
 1139.8 "Mystic Light"
 
-1200.0 "--sync--" sync / 14:The Old One:265A:/ window 200,10
-1202.7 "Shifting Light" sync / 1[56]:The Old One:265A:/
-1205.8 "Order To Detonate (cast)" sync / 14:The Old One:265B:/ duration 19.7
-# 1225.5 "Order To Detonate?" sync / 1[56]:The Old One:265B:/
-1228.3 "Self-Detonate?" # sync / 1[56]:Subservient:265C:/
-1232.6 "--sync--" sync / 14:The Old One:2657:/ window 32.6,5
-1236.3 "Mystic Light" sync / 1[56]:The Old One:2657:/
-1244.1 "Mystic Flame" sync / 1[56]:The Old One:2658:/
-1252.2 "Mystic Light" sync / 1[56]:The Old One:2657:/
-1269.0 "Mystic Light" sync / 1[56]:The Old One:2657:/ jump 1236.3
+1200.0 "--sync--" sync / 14:[^:]*:The Old One:265A:/ window 200,10
+1202.7 "Shifting Light" sync / 1[56]:[^:]*:The Old One:265A:/
+1205.8 "Order To Detonate (cast)" sync / 14:[^:]*:The Old One:265B:/ duration 19.7
+# 1225.5 "Order To Detonate?" sync / 1[56]:[^:]*:The Old One:265B:/
+1228.3 "Self-Detonate?" # sync / 1[56]:[^:]*:Subservient:265C:/
+1232.6 "--sync--" sync / 14:[^:]*:The Old One:2657:/ window 32.6,5
+1236.3 "Mystic Light" sync / 1[56]:[^:]*:The Old One:2657:/
+1244.1 "Mystic Flame" sync / 1[56]:[^:]*:The Old One:2658:/
+1252.2 "Mystic Light" sync / 1[56]:[^:]*:The Old One:2657:/
+1269.0 "Mystic Light" sync / 1[56]:[^:]*:The Old One:2657:/ jump 1236.3
 1276.8 "Mystic Flame"
 1284.9 "Mystic Light"
 1301.7 "Mystic Light"
 1309.5 "Mystic Flame"
 1317.6 "Mystic Light"
 
-1400.0 "--sync--" sync / 14:The Old One:265A:/ window 190,5
-1402.7 "Shifting Light" sync / 1[56]:The Old One:265A:/
-1405.8 "Order To Detonate (cast)" sync / 14:The Old One:265B:/ duration 19.7
-# 1425.5 "Order To Detonate?" sync / 1[56]:The Old One:265B:/
-1428.3 "Self-Detonate?" # sync / 1[56]:Subservient:265C:/
-1432.6 "--sync--" sync / 14:The Old One:2657:/ window 32.6,5
-1436.3 "Mystic Light" sync / 1[56]:The Old One:2657:/
-1444.1 "Mystic Flame" sync / 1[56]:The Old One:2658:/
-1452.2 "Mystic Light" sync / 1[56]:The Old One:2657:/
-1469.0 "Mystic Light" sync / 1[56]:The Old One:2657:/ jump 1436.3
+1400.0 "--sync--" sync / 14:[^:]*:The Old One:265A:/ window 190,5
+1402.7 "Shifting Light" sync / 1[56]:[^:]*:The Old One:265A:/
+1405.8 "Order To Detonate (cast)" sync / 14:[^:]*:The Old One:265B:/ duration 19.7
+# 1425.5 "Order To Detonate?" sync / 1[56]:[^:]*:The Old One:265B:/
+1428.3 "Self-Detonate?" # sync / 1[56]:[^:]*:Subservient:265C:/
+1432.6 "--sync--" sync / 14:[^:]*:The Old One:2657:/ window 32.6,5
+1436.3 "Mystic Light" sync / 1[56]:[^:]*:The Old One:2657:/
+1444.1 "Mystic Flame" sync / 1[56]:[^:]*:The Old One:2658:/
+1452.2 "Mystic Light" sync / 1[56]:[^:]*:The Old One:2657:/
+1469.0 "Mystic Light" sync / 1[56]:[^:]*:The Old One:2657:/ jump 1436.3
 1476.8 "Mystic Flame"
 1484.9 "Mystic Light"
 1501.7 "Mystic Light"
@@ -98,40 +98,40 @@ hideall "--sync--"
 #~~~~~~~~~~~~~~~~~~~~~~#
 
 2000.0 "Start" sync / 00:0839::The Golden Walls Of Ruin will be sealed off/ window 2000,5
-2012.6 "Rusting Claw" sync / 1[56]:Hrodric Poisontongue:2661:/ window 2012.6
-2026.2 "Tail Drive" sync / 1[56]:Hrodric Poisontongue:2663:/
-2035.9 "The Spin" sync / 1[56]:Hrodric Poisontongue:2664:/ window 35.9,5
-2041.6 "--sync--" sync / 1[56]:Hrodric Poisontongue:2666:/
-2046.7 "Ring Of Chaos" sync / 1[56]:Hrodric Poisontongue:2667:/
-2052.2 "Eye Of The Fire" sync / 1[56]:Hrodric Poisontongue:2665:/ window 2052.2,10
-2057.9 "--sync--" sync / 1[56]:Hrodric Poisontongue:2666:/
-2063.0 "Cross Of Chaos/Circle Of Chaos" sync / 1[56]:Hrodric Poisontongue:(2668|2669):/
-2068.7 "Words Of Woe" sync / 1[56]:Hrodric Poisontongue:2662:/
-2074.4 "Words Of Woe" sync / 1[56]:Hrodric Poisontongue:2662:/
-2080.2 "Words Of Woe" sync / 1[56]:Hrodric Poisontongue:2662:/
-2087.9 "--sync--" sync / 1[56]:Hrodric Poisontongue:2666:/ window 15,2.5 # Solo/duo runners will see only one or two lasers
+2012.6 "Rusting Claw" sync / 1[56]:[^:]*:Hrodric Poisontongue:2661:/ window 2012.6
+2026.2 "Tail Drive" sync / 1[56]:[^:]*:Hrodric Poisontongue:2663:/
+2035.9 "The Spin" sync / 1[56]:[^:]*:Hrodric Poisontongue:2664:/ window 35.9,5
+2041.6 "--sync--" sync / 1[56]:[^:]*:Hrodric Poisontongue:2666:/
+2046.7 "Ring Of Chaos" sync / 1[56]:[^:]*:Hrodric Poisontongue:2667:/
+2052.2 "Eye Of The Fire" sync / 1[56]:[^:]*:Hrodric Poisontongue:2665:/ window 2052.2,10
+2057.9 "--sync--" sync / 1[56]:[^:]*:Hrodric Poisontongue:2666:/
+2063.0 "Cross Of Chaos/Circle Of Chaos" sync / 1[56]:[^:]*:Hrodric Poisontongue:(2668|2669):/
+2068.7 "Words Of Woe" sync / 1[56]:[^:]*:Hrodric Poisontongue:2662:/
+2074.4 "Words Of Woe" sync / 1[56]:[^:]*:Hrodric Poisontongue:2662:/
+2080.2 "Words Of Woe" sync / 1[56]:[^:]*:Hrodric Poisontongue:2662:/
+2087.9 "--sync--" sync / 1[56]:[^:]*:Hrodric Poisontongue:2666:/ window 15,2.5 # Solo/duo runners will see only one or two lasers
 
-2093.0 "Ring Of Chaos/Cross Of Chaos" sync / 1[56]:Hrodric Poisontongue:(2667|2668):/
-2095.5 "--sync--" sync / 1[56]:Hrodric Poisontongue:2666:/
-2100.6 "Ring Of Chaos" sync / 1[56]:Hrodric Poisontongue:2667:/
-2103.0 "Tail Drive" sync / 1[56]:Hrodric Poisontongue:2663:/
-2115.6 "The Spin" sync / 1[56]:Hrodric Poisontongue:2664:/ window 30,30
-2126.3 "Rusting Claw" sync / 1[56]:Hrodric Poisontongue:2661:/
-2132.0 "--sync--" sync / 1[56]:Hrodric Poisontongue:2666:/
-2137.1 "Cross Of Chaos/Circle Of Chaos" sync / 1[56]:Hrodric Poisontongue:(2668|2669):/
-2139.6 "--sync--" sync / 1[56]:Hrodric Poisontongue:2666:/
-2144.7 "Ring Of Chaos" sync / 1[56]:Hrodric Poisontongue:2667:/
-2145.2 "Eye Of The Fire" sync / 1[56]:Hrodric Poisontongue:2665:/ window 30,30
-2155.8 "Rusting Claw" sync / 1[56]:Hrodric Poisontongue:2661:/
-2166.4 "Tail Drive" sync / 1[56]:Hrodric Poisontongue:2663:/
-2174.1 "--sync--" sync / 1[56]:Hrodric Poisontongue:2666:/
-2179.2 "Ring Of Chaos/Circle Of Chaos" sync / 1[56]:Hrodric Poisontongue:(2667|2669):/
-2181.7 "--sync--" sync / 1[56]:Hrodric Poisontongue:2666:/
-2186.8 "Cross Of Chaos" sync / 1[56]:Hrodric Poisontongue:2668:/
-2187.5 "Words Of Woe" sync / 1[56]:Hrodric Poisontongue:2662:/
-2195.2 "--sync--" sync / 1[56]:Hrodric Poisontongue:2666:/
+2093.0 "Ring Of Chaos/Cross Of Chaos" sync / 1[56]:[^:]*:Hrodric Poisontongue:(2667|2668):/
+2095.5 "--sync--" sync / 1[56]:[^:]*:Hrodric Poisontongue:2666:/
+2100.6 "Ring Of Chaos" sync / 1[56]:[^:]*:Hrodric Poisontongue:2667:/
+2103.0 "Tail Drive" sync / 1[56]:[^:]*:Hrodric Poisontongue:2663:/
+2115.6 "The Spin" sync / 1[56]:[^:]*:Hrodric Poisontongue:2664:/ window 30,30
+2126.3 "Rusting Claw" sync / 1[56]:[^:]*:Hrodric Poisontongue:2661:/
+2132.0 "--sync--" sync / 1[56]:[^:]*:Hrodric Poisontongue:2666:/
+2137.1 "Cross Of Chaos/Circle Of Chaos" sync / 1[56]:[^:]*:Hrodric Poisontongue:(2668|2669):/
+2139.6 "--sync--" sync / 1[56]:[^:]*:Hrodric Poisontongue:2666:/
+2144.7 "Ring Of Chaos" sync / 1[56]:[^:]*:Hrodric Poisontongue:2667:/
+2145.2 "Eye Of The Fire" sync / 1[56]:[^:]*:Hrodric Poisontongue:2665:/ window 30,30
+2155.8 "Rusting Claw" sync / 1[56]:[^:]*:Hrodric Poisontongue:2661:/
+2166.4 "Tail Drive" sync / 1[56]:[^:]*:Hrodric Poisontongue:2663:/
+2174.1 "--sync--" sync / 1[56]:[^:]*:Hrodric Poisontongue:2666:/
+2179.2 "Ring Of Chaos/Circle Of Chaos" sync / 1[56]:[^:]*:Hrodric Poisontongue:(2667|2669):/
+2181.7 "--sync--" sync / 1[56]:[^:]*:Hrodric Poisontongue:2666:/
+2186.8 "Cross Of Chaos" sync / 1[56]:[^:]*:Hrodric Poisontongue:2668:/
+2187.5 "Words Of Woe" sync / 1[56]:[^:]*:Hrodric Poisontongue:2662:/
+2195.2 "--sync--" sync / 1[56]:[^:]*:Hrodric Poisontongue:2666:/
 
-2200.3 "Ring Of Chaos/Cross Of Chaos" sync / 1[56]:Hrodric Poisontongue:(2667|2668):/ jump 2093.0
+2200.3 "Ring Of Chaos/Cross Of Chaos" sync / 1[56]:[^:]*:Hrodric Poisontongue:(2667|2668):/ jump 2093.0
 2202.8 "--sync--"
 2207.9 "Ring Of Chaos"
 2210.3 "Tail Drive"

--- a/ui/raidboss/data/04-sb/dungeon/fractal_continuum_hard.txt
+++ b/ui/raidboss/data/04-sb/dungeon/fractal_continuum_hard.txt
@@ -13,19 +13,19 @@ hideall "--sync--"
 
 0 "Start" sync / 00:0839::The reality augmentation bay will be sealed off/
 
-10.1 "Electrochemical Transfer" sync / 1[56]:Motherbit:27A4:/ window 11,5
-15.7 "--sync--" sync / 1[56]:Prototype Bit:27AB:/
-18.8 "Aetherochemical Laser" # sync / 1[56]:Prototype Bit:27AA:/
-20.1 "Diffractive Laser" sync / 1[56]:Prototype Bit:27A8:/
-20.7 "--sync--" sync / 1[56]:Prototype Bit:27AB:/
-22.8 "Aetherochemical Laser" # sync / 1[56]:Prototype Bit:27AA:/
-29.8 "Allagan Gravity" sync / 1[56]:Motherbit:27A6:/
+10.1 "Electrochemical Transfer" sync / 1[56]:[^:]*:Motherbit:27A4:/ window 11,5
+15.7 "--sync--" sync / 1[56]:[^:]*:Prototype Bit:27AB:/
+18.8 "Aetherochemical Laser" # sync / 1[56]:[^:]*:Prototype Bit:27AA:/
+20.1 "Diffractive Laser" sync / 1[56]:[^:]*:Prototype Bit:27A8:/
+20.7 "--sync--" sync / 1[56]:[^:]*:Prototype Bit:27AB:/
+22.8 "Aetherochemical Laser" # sync / 1[56]:[^:]*:Prototype Bit:27AA:/
+29.8 "Allagan Gravity" sync / 1[56]:[^:]*:Motherbit:27A6:/
 
-37.9 "Electrochemical Transfer" sync / 1[56]:Motherbit:27A4:/
-43.5 "--sync--" sync / 1[56]:Prototype Bit:27AB:/
-54.2 "Citadel Buster" sync / 1[56]:Motherbit:27A5:/ window 30,30
+37.9 "Electrochemical Transfer" sync / 1[56]:[^:]*:Motherbit:27A4:/
+43.5 "--sync--" sync / 1[56]:[^:]*:Prototype Bit:27AB:/
+54.2 "Citadel Buster" sync / 1[56]:[^:]*:Motherbit:27A5:/ window 30,30
 
-77.9 "Electrochemical Transfer" sync / 1[56]:Motherbit:27A4:/ jump 10.1
+77.9 "Electrochemical Transfer" sync / 1[56]:[^:]*:Motherbit:27A4:/ jump 10.1
 86.6 "Aetherochemical Laser"
 87.9 "Diffractive Laser"
 90.6 "Aetherochemical Laser"
@@ -52,10 +52,10 @@ hideall "--sync--"
 # regardless of whether X is followed by Y or by Z.
 
 1000.0 "Start" sync / 00:0839::Exhibit level VIII will be sealed off/ window 1000,5
-1008.5 "Aetheroplasm" sync / 1[56]:The Ultima Warrior:2793:/ window 8.5,5
-1018.9 "Citadel Buster" sync / 1[56]:The Ultima Warrior:2792:/
-1029.8 "Ceruleum Vent" sync / 1[56]:The Ultima Warrior:2794:/
-1042.0 "Aetheroplasm" sync / 1[56]:The Ultima Warrior:2793:/ # skipped if boss is at or below 95% HP
+1008.5 "Aetheroplasm" sync / 1[56]:[^:]*:The Ultima Warrior:2793:/ window 8.5,5
+1018.9 "Citadel Buster" sync / 1[56]:[^:]*:The Ultima Warrior:2792:/
+1029.8 "Ceruleum Vent" sync / 1[56]:[^:]*:The Ultima Warrior:2794:/
+1042.0 "Aetheroplasm" sync / 1[56]:[^:]*:The Ultima Warrior:2793:/ # skipped if boss is at or below 95% HP
 
 1053.4 "--sync--" sync / 00:0044:Vocal Guidance System:This humanoid prototype can perfectly replicate/ window 53.4,10 jump 1100.0
 1053.4 "--sync--" sync / 00:0044:Vocal Guidance System:Utilizing our data on Sophia/ window 53.4,10 jump 1200.0
@@ -72,12 +72,12 @@ hideall "--sync--"
 # Sephirot's block
 
 1100.0 "--sync--" sync / 00:0044:Vocal Guidance System:This humanoid prototype can perfectly replicate/
-1107.5 "Primordial Aether" sync / 1[56]:The Ultima Warrior:2796:/ window 10,10
-1119.1 "Citadel Buster" sync / 1[56]:The Ultima Warrior:2792:/
-1120.1 "Ratzon" sync / 1[56]:The Ultima Warrior:2797:/
-1125.2 "Citadel Buster" sync / 1[56]:The Ultima Warrior:2792:/
-1139.2 "Mass Aetheroplasm" sync / 1[56]:The Ultima Warrior:2795:/
-1149.7 "Aetheroplasm" sync / 1[56]:The Ultima Warrior:2793:/
+1107.5 "Primordial Aether" sync / 1[56]:[^:]*:The Ultima Warrior:2796:/ window 10,10
+1119.1 "Citadel Buster" sync / 1[56]:[^:]*:The Ultima Warrior:2792:/
+1120.1 "Ratzon" sync / 1[56]:[^:]*:The Ultima Warrior:2797:/
+1125.2 "Citadel Buster" sync / 1[56]:[^:]*:The Ultima Warrior:2792:/
+1139.2 "Mass Aetheroplasm" sync / 1[56]:[^:]*:The Ultima Warrior:2795:/
+1149.7 "Aetheroplasm" sync / 1[56]:[^:]*:The Ultima Warrior:2793:/
 
 1154.8 "--sync--" sync / 00:0044:Vocal Guidance System:This humanoid prototype can perfectly replicate/ window 50,10 jump 1100.0
 1154.8 "--sync--" sync / 00:0044:Vocal Guidance System:Utilizing our data on Sophia/ window 50,10 jump 1200.0
@@ -94,13 +94,13 @@ hideall "--sync--"
 # Sophia's Block
 
 1200.0 "--sync--" sync / 00:0044:Vocal Guidance System:Utilizing our data on Sophia/
-1207.5 "Primordial Aether" sync / 1[56]:The Ultima Warrior:2796:/ window 10,10
-1218.1 "Ceruleum Vent" sync / 1[56]:The Ultima Warrior:2794:/
-1225.3 "Citadel Buster" sync / 1[56]:The Ultima Warrior:2792:/
-1226.3 "Dischordant Cleansing" sync / 1[56]:The Ultima Warrior:279C:/
-1231.4 "Citadel Buster" sync / 1[56]:The Ultima Warrior:2792:/
-1232.3 "Dischordant Cleansing" sync / 1[56]:The Ultima Warrior:279A:/
-1242.3 "Aetheroplasm" sync / 1[56]:The Ultima Warrior:2793:/
+1207.5 "Primordial Aether" sync / 1[56]:[^:]*:The Ultima Warrior:2796:/ window 10,10
+1218.1 "Ceruleum Vent" sync / 1[56]:[^:]*:The Ultima Warrior:2794:/
+1225.3 "Citadel Buster" sync / 1[56]:[^:]*:The Ultima Warrior:2792:/
+1226.3 "Dischordant Cleansing" sync / 1[56]:[^:]*:The Ultima Warrior:279C:/
+1231.4 "Citadel Buster" sync / 1[56]:[^:]*:The Ultima Warrior:2792:/
+1232.3 "Dischordant Cleansing" sync / 1[56]:[^:]*:The Ultima Warrior:279A:/
+1242.3 "Aetheroplasm" sync / 1[56]:[^:]*:The Ultima Warrior:2793:/
 
 1248.5 "--sync--" sync / 00:0044:Vocal Guidance System:This humanoid prototype can perfectly replicate/ window 50,10 jump 1100.0
 1248.5 "--sync--" sync / 00:0044:Vocal Guidance System:Utilizing our data on Sophia/ window 50,10 jump 1200.0
@@ -117,13 +117,13 @@ hideall "--sync--"
 # Zurvan's Block
 
 1300.0 "--sync--" sync / 00:0044:Vocal Guidance System:Successfully mimicking the Demon Zurvan/
-1308.5 "Primordial Aether" sync / 1[56]:The Ultima Warrior:2796:/ window 10,10
-1311.1 "Infinite Fire/Infinite Ice" sync / 1[56]:The Ultima Warrior:279[DE]:/
-1319.1 "Ceruleum Vent" sync / 1[56]:The Ultima Warrior:2794:/
-1330.3 "Northern Star/Southern Star" sync / 1[56]:The Ultima Warrior:27A[01]:/
-1336.4 "Mass Aetheroplasm" sync / 1[56]:The Ultima Warrior:2795:/
-1343.0 "Citadel Buster" sync / 1[56]:The Ultima Warrior:2792:/
-1354.0 "Aetheroplasm" sync / 1[56]:The Ultima Warrior:2793:/
+1308.5 "Primordial Aether" sync / 1[56]:[^:]*:The Ultima Warrior:2796:/ window 10,10
+1311.1 "Infinite Fire/Infinite Ice" sync / 1[56]:[^:]*:The Ultima Warrior:279[DE]:/
+1319.1 "Ceruleum Vent" sync / 1[56]:[^:]*:The Ultima Warrior:2794:/
+1330.3 "Northern Star/Southern Star" sync / 1[56]:[^:]*:The Ultima Warrior:27A[01]:/
+1336.4 "Mass Aetheroplasm" sync / 1[56]:[^:]*:The Ultima Warrior:2795:/
+1343.0 "Citadel Buster" sync / 1[56]:[^:]*:The Ultima Warrior:2792:/
+1354.0 "Aetheroplasm" sync / 1[56]:[^:]*:The Ultima Warrior:2793:/
 
 1365.5 "--sync--" sync / 00:0044:Vocal Guidance System:This humanoid prototype can perfectly replicate/ window 50,10 jump 1100.0
 1365.5 "--sync--" sync / 00:0044:Vocal Guidance System:Utilizing our data on Sophia/ window 50,10 jump 1200.0
@@ -144,31 +144,31 @@ hideall "--sync--"
 # -ii 27B9 27BC 27BA 27BB
 
 2000.0 "Start" sync / 00:0839::The Genesis Engine will be sealed off/ window 2000,5
-2012.0 "Death Spin" sync / 1[56]:The Ultima Beast:27AD:/ window 12,5
-2025.6 "Aether Bend" sync / 1[56]:The Ultima Beast:27AF:/
-2035.2 "--sync--" sync / 1[56]:The Ultima Beast:27B6:/
-2044.1 "Flare Star" sync / 1[56]:The Ultima Beast:27BD:/
-2044.3 "Allagan Gravity" sync / 1[56]:The Ultima Beast:27B5:/ window 30,30
-2057.9 "Light Pillar" sync / 1[56]:The Ultima Beast:27B7:/
-2076.5 "Forborn Beast" sync / 1[56]:The Ultima Beast:27B1:/ window 76.5,5
-2085.0 "Demi Ultima" sync / 1[56]:The Ultima Beast:27B2:/
-2102.9 "Aether Bend/Death Spin" sync / 1[56]:The Ultima Beast:27(AD|B0):/
-2113.4 "--sync--" sync / 1[56]:The Ultima Beast:27B4:/
-2115.4 "Allagan Flare" sync / 1[56]:The Ultima Beast:27B8:/
+2012.0 "Death Spin" sync / 1[56]:[^:]*:The Ultima Beast:27AD:/ window 12,5
+2025.6 "Aether Bend" sync / 1[56]:[^:]*:The Ultima Beast:27AF:/
+2035.2 "--sync--" sync / 1[56]:[^:]*:The Ultima Beast:27B6:/
+2044.1 "Flare Star" sync / 1[56]:[^:]*:The Ultima Beast:27BD:/
+2044.3 "Allagan Gravity" sync / 1[56]:[^:]*:The Ultima Beast:27B5:/ window 30,30
+2057.9 "Light Pillar" sync / 1[56]:[^:]*:The Ultima Beast:27B7:/
+2076.5 "Forborn Beast" sync / 1[56]:[^:]*:The Ultima Beast:27B1:/ window 76.5,5
+2085.0 "Demi Ultima" sync / 1[56]:[^:]*:The Ultima Beast:27B2:/
+2102.9 "Aether Bend/Death Spin" sync / 1[56]:[^:]*:The Ultima Beast:27(AD|B0):/
+2113.4 "--sync--" sync / 1[56]:[^:]*:The Ultima Beast:27B4:/
+2115.4 "Allagan Flare" sync / 1[56]:[^:]*:The Ultima Beast:27B8:/
 
-2128.0 "--sync--" sync / 1[56]:The Ultima Beast:27B6:/ window 30,30
-2136.9 "Flare Star" sync / 1[56]:The Ultima Beast:27BD:/
-2141.5 "--sync--" sync / 1[56]:The Ultima Beast:27B4:/
-2143.5 "Allagan Flare" sync / 1[56]:The Ultima Beast:27B8:/
-2158.1 "Aether Bend/Death Spin" sync / 1[56]:The Ultima Beast:27(AD|B0):/
-2168.7 "Light Pillar" sync / 1[56]:The Ultima Beast:27B7:/
-2176.7 "Allagan Gravity" sync / 1[56]:The Ultima Beast:27B5:/
+2128.0 "--sync--" sync / 1[56]:[^:]*:The Ultima Beast:27B6:/ window 30,30
+2136.9 "Flare Star" sync / 1[56]:[^:]*:The Ultima Beast:27BD:/
+2141.5 "--sync--" sync / 1[56]:[^:]*:The Ultima Beast:27B4:/
+2143.5 "Allagan Flare" sync / 1[56]:[^:]*:The Ultima Beast:27B8:/
+2158.1 "Aether Bend/Death Spin" sync / 1[56]:[^:]*:The Ultima Beast:27(AD|B0):/
+2168.7 "Light Pillar" sync / 1[56]:[^:]*:The Ultima Beast:27B7:/
+2176.7 "Allagan Gravity" sync / 1[56]:[^:]*:The Ultima Beast:27B5:/
 
-2196.2 "--sync--" sync / 1[56]:The Ultima Beast:27B6:/ window 30,30 jump 2128.0
+2196.2 "--sync--" sync / 1[56]:[^:]*:The Ultima Beast:27B6:/ window 30,30 jump 2128.0
 2205.1 "Flare Star"
 2211.7 "Allagan Flare"
 2226.3 "Aether Bend/Death Spin"
 
 
-3000.0 "--sync--" sync / 14:The Ultima Beast:27B3:/ window 1000,5
-3039.7 "Demi Ultima (Enrage)" sync / 1[56]:The Ultima Beast:27B3:/
+3000.0 "--sync--" sync / 14:[^:]*:The Ultima Beast:27B3:/ window 1000,5
+3039.7 "Demi Ultima (Enrage)" sync / 1[56]:[^:]*:The Ultima Beast:27B3:/

--- a/ui/raidboss/data/04-sb/dungeon/ghimlyt_dark.txt
+++ b/ui/raidboss/data/04-sb/dungeon/ghimlyt_dark.txt
@@ -12,28 +12,28 @@ hideall "--sync--"
 # -ii 394F 3775
 
 0 "Start" sync / 00:0839::The Field Of Dust will be sealed off/ window 0,1
-12.9 "Jarring Blow" sync / 1[56]:Mark III-B Magitek Colossus:376E:/
-15.0 "--sync--" sync / 1[56]:Mark III-B Magitek Colossus:3771:/
-22.1 "Wild Fire Beam" sync / 1[56]:Mark III-B Magitek Colossus:3772:/ window 30,30
-28.8 "Magitek Slash x5" sync / 1[56]:Mark III-B Magitek Colossus:3774:/ duration 8
-45.5 "Exhaust" sync / 1[56]:Mark III-B Magitek Colossus:3770:/
-55.7 "Ceruleum Vent" sync / 1[56]:Mark III-B Magitek Colossus:3773:/
+12.9 "Jarring Blow" sync / 1[56]:[^:]*:Mark III-B Magitek Colossus:376E:/
+15.0 "--sync--" sync / 1[56]:[^:]*:Mark III-B Magitek Colossus:3771:/
+22.1 "Wild Fire Beam" sync / 1[56]:[^:]*:Mark III-B Magitek Colossus:3772:/ window 30,30
+28.8 "Magitek Slash x5" sync / 1[56]:[^:]*:Mark III-B Magitek Colossus:3774:/ duration 8
+45.5 "Exhaust" sync / 1[56]:[^:]*:Mark III-B Magitek Colossus:3770:/
+55.7 "Ceruleum Vent" sync / 1[56]:[^:]*:Mark III-B Magitek Colossus:3773:/
 
-68.0 "Magitek Slash x5" sync / 1[56]:Mark III-B Magitek Colossus:3774:/ duration 8
-80.2 "Magitek Slash x5" sync / 1[56]:Mark III-B Magitek Colossus:3774:/ duration 8
-97.4 "Magitek Ray" sync / 1[56]:Mark III-B Magitek Colossus:376F:/
-102.6 "Exhaust" sync / 1[56]:Mark III-B Magitek Colossus:3770:/
-116.8 "Ceruleum Vent" sync / 1[56]:Mark III-B Magitek Colossus:3773:/ window 20,20
-120.0 "--sync--" sync / 1[56]:Mark III-B Magitek Colossus:3771:/
-127.1 "Wild Fire Beam" sync / 1[56]:Mark III-B Magitek Colossus:3772:/
-133.1 "Magitek Ray" sync / 1[56]:Mark III-B Magitek Colossus:376F:/
-138.3 "Exhaust" sync / 1[56]:Mark III-B Magitek Colossus:3770:/
-143.7 "Exhaust" sync / 1[56]:Mark III-B Magitek Colossus:3770:/
-156.0 "Jarring Blow" sync / 1[56]:Mark III-B Magitek Colossus:376E:/ window 30,30
-162.1 "Ceruleum Vent" sync / 1[56]:Mark III-B Magitek Colossus:3773:/
-169.3 "Ceruleum Vent" sync / 1[56]:Mark III-B Magitek Colossus:3773:/
+68.0 "Magitek Slash x5" sync / 1[56]:[^:]*:Mark III-B Magitek Colossus:3774:/ duration 8
+80.2 "Magitek Slash x5" sync / 1[56]:[^:]*:Mark III-B Magitek Colossus:3774:/ duration 8
+97.4 "Magitek Ray" sync / 1[56]:[^:]*:Mark III-B Magitek Colossus:376F:/
+102.6 "Exhaust" sync / 1[56]:[^:]*:Mark III-B Magitek Colossus:3770:/
+116.8 "Ceruleum Vent" sync / 1[56]:[^:]*:Mark III-B Magitek Colossus:3773:/ window 20,20
+120.0 "--sync--" sync / 1[56]:[^:]*:Mark III-B Magitek Colossus:3771:/
+127.1 "Wild Fire Beam" sync / 1[56]:[^:]*:Mark III-B Magitek Colossus:3772:/
+133.1 "Magitek Ray" sync / 1[56]:[^:]*:Mark III-B Magitek Colossus:376F:/
+138.3 "Exhaust" sync / 1[56]:[^:]*:Mark III-B Magitek Colossus:3770:/
+143.7 "Exhaust" sync / 1[56]:[^:]*:Mark III-B Magitek Colossus:3770:/
+156.0 "Jarring Blow" sync / 1[56]:[^:]*:Mark III-B Magitek Colossus:376E:/ window 30,30
+162.1 "Ceruleum Vent" sync / 1[56]:[^:]*:Mark III-B Magitek Colossus:3773:/
+169.3 "Ceruleum Vent" sync / 1[56]:[^:]*:Mark III-B Magitek Colossus:3773:/
 
-176.5 "Magitek Slash x5" sync / 1[56]:Mark III-B Magitek Colossus:3774:/ jump 68.0
+176.5 "Magitek Slash x5" sync / 1[56]:[^:]*:Mark III-B Magitek Colossus:3774:/ jump 68.0
 188.7 "Magitek Slash x5"
 205.9 "Magitek Ray"
 211.1 "Exhaust"
@@ -48,25 +48,25 @@ hideall "--sync--"
 # -ii 3AC6
 
 1000.0 "Start" sync / 00:0839::The Impact Crater will be sealed off/ window 1000,1
-1012.2 "Nitrospin" sync / 1[56]:Prometheus:3455:/
-1023.4 "Needle Gun" sync / 1[56]:Prometheus:345A:/
+1012.2 "Nitrospin" sync / 1[56]:[^:]*:Prometheus:3455:/
+1023.4 "Needle Gun" sync / 1[56]:[^:]*:Prometheus:345A:/
 1031.1 "--untargetable--"
-1031.2 "Tunnel" sync / 1[56]:Prometheus:3457:/ window 31.2,5
-1042.8 "Heat" duration 4 # sync / 1[56]:Prometheus:3458:/
+1031.2 "Tunnel" sync / 1[56]:[^:]*:Prometheus:3457:/ window 31.2,5
+1042.8 "Heat" duration 4 # sync / 1[56]:[^:]*:Prometheus:3458:/
 1048.0 "--targetable--"
 
-1056.2 "Unbreakable Cermet Drill" sync / 1[56]:Prometheus:3459:/ window 30,30
-1068.3 "Needle Gun" sync / 1[56]:Prometheus:345A:/
-1075.4 "Needle Gun/Oil Shower" sync / 1[56]:Prometheus:(345A|3456):/
-1086.4 "Nitrospin" sync / 1[56]:Prometheus:3455:/
-1097.8 "Freezing Missile (windup)" sync / 1[56]:Prometheus:345B:/
+1056.2 "Unbreakable Cermet Drill" sync / 1[56]:[^:]*:Prometheus:3459:/ window 30,30
+1068.3 "Needle Gun" sync / 1[56]:[^:]*:Prometheus:345A:/
+1075.4 "Needle Gun/Oil Shower" sync / 1[56]:[^:]*:Prometheus:(345A|3456):/
+1086.4 "Nitrospin" sync / 1[56]:[^:]*:Prometheus:3455:/
+1097.8 "Freezing Missile (windup)" sync / 1[56]:[^:]*:Prometheus:345B:/
 1100.4 "--untargetable--"
-1100.5 "Tunnel" sync / 1[56]:Prometheus:3457:/ window 30,30
-1108.9 "Freezing Missile (cast)" sync / 1[56]:Prometheus:345C:/
-1113.1 "Heat" duration 4 # sync / 1[56]:Prometheus:3458:/
+1100.5 "Tunnel" sync / 1[56]:[^:]*:Prometheus:3457:/ window 30,30
+1108.9 "Freezing Missile (cast)" sync / 1[56]:[^:]*:Prometheus:345C:/
+1113.1 "Heat" duration 4 # sync / 1[56]:[^:]*:Prometheus:3458:/
 1118.2 "--targetable--"
 
-1131.5 "Unbreakable Cermet Drill" sync / 1[56]:Prometheus:3459:/ jump 1056.2
+1131.5 "Unbreakable Cermet Drill" sync / 1[56]:[^:]*:Prometheus:3459:/ jump 1056.2
 1143.6 "Needle Gun"
 1150.7 "Needle Gun/Oil Shower"
 1161.9 "Nitrospin"
@@ -77,8 +77,8 @@ hideall "--sync--"
 #~~~~~~~~~~~~~#
 
 2000.0 "Start" sync / 00:0839::The Provisional Imperial Landing will be sealed off/ window 2000,5
-2000.4 "--sync--" sync / 1[56]:Annia Quo Soranus:370F:/ jump 2097.0
-2000.4 "--sync--" sync / 1[56]:Julia Quo Soranus:370E:/ jump 2297.0
+2000.4 "--sync--" sync / 1[56]:[^:]*:Annia Quo Soranus:370F:/ jump 2097.0
+2000.4 "--sync--" sync / 1[56]:[^:]*:Julia Quo Soranus:370E:/ jump 2297.0
 2003.4 "Artificial Plasma?"
 2010.6 "Heirsbane?"
 2011.6 "Angry Salamander?"
@@ -90,46 +90,46 @@ hideall "--sync--"
 
 # Julia active
 
-2097.0 "--sync--" sync / 1[56]:Annia Quo Soranus:370F:/
-2100.0 "Artificial Plasma" sync / 1[56]:Julia Quo Soranus:3727:/
-2108.2 "Angry Salamander" # sync / 1[56]:Annia Quo Soranus:372C:/
-2108.4 "Innocence" sync / 1[56]:Julia Quo Soranus:3729:/
-2117.5 "Commence Air Strike" sync / 1[56]:Julia Quo Soranus:3716:/
-2119.3 "--sync--" sync / 1[56]:Julia Quo Soranus:370E:/
-2121.8 "Roundhouse" sync / 1[56]:Annia Quo Soranus:3718:/
+2097.0 "--sync--" sync / 1[56]:[^:]*:Annia Quo Soranus:370F:/
+2100.0 "Artificial Plasma" sync / 1[56]:[^:]*:Julia Quo Soranus:3727:/
+2108.2 "Angry Salamander" # sync / 1[56]:[^:]*:Annia Quo Soranus:372C:/
+2108.4 "Innocence" sync / 1[56]:[^:]*:Julia Quo Soranus:3729:/
+2117.5 "Commence Air Strike" sync / 1[56]:[^:]*:Julia Quo Soranus:3716:/
+2119.3 "--sync--" sync / 1[56]:[^:]*:Julia Quo Soranus:370E:/
+2121.8 "Roundhouse" sync / 1[56]:[^:]*:Annia Quo Soranus:3718:/
 
 # We have to sync widely here because if Julia is first she skips one Aglaia Bite.
-2124.7 "Heirsbane" sync / 1[56]:Julia Quo Soranus:3719:/ window 15,15
-2127.6 "Burst x5" duration 8 # sync / 1[56]:Ceruleum Tank:371A:/
-2132.3 "Angry Salamander" sync / 1[56]:Annia Quo Soranus:372C:/
-2145.2 "Artificial Plasma" sync / 1[56]:Julia Quo Soranus:3727:/
-2147.9 "Angry Salamander" sync / 1[56]:Annia Quo Soranus:372C:/
-2151.4 "--sync--" sync / 1[56]:Julia Quo Soranus:370E:/
+2124.7 "Heirsbane" sync / 1[56]:[^:]*:Julia Quo Soranus:3719:/ window 15,15
+2127.6 "Burst x5" duration 8 # sync / 1[56]:[^:]*:Ceruleum Tank:371A:/
+2132.3 "Angry Salamander" sync / 1[56]:[^:]*:Annia Quo Soranus:372C:/
+2145.2 "Artificial Plasma" sync / 1[56]:[^:]*:Julia Quo Soranus:3727:/
+2147.9 "Angry Salamander" sync / 1[56]:[^:]*:Annia Quo Soranus:372C:/
+2151.4 "--sync--" sync / 1[56]:[^:]*:Julia Quo Soranus:370E:/
 
 # During the rotation block, we can't sync Aglaia Bite,
 # since the double usage is just too close together.
-2153.2 "The Order" sync / 1[56]:Julia Quo Soranus:3713:/ window 30,30
-2158.3 "Order To Fire" sync / 1[56]:Annia Quo Soranus:372D:/
-2158.3 "Missile Impact" sync / 1[56]:Annia Quo Soranus:372E:/
-2159.3 "The Order" sync / 1[56]:Julia Quo Soranus:39BA:/
-2159.3 "Quaternity" sync / 1[56]:Soranus Duo:3989:/
-2164.6 "Artificial Plasma" sync / 1[56]:Julia Quo Soranus:3727:/
-2168.8 "Angry Salamander" sync / 1[56]:Annia Quo Soranus:372C:/
-2174.9 "Artificial Plasma" sync / 1[56]:Julia Quo Soranus:3727:/
-2182.2 "Angry Salamander" sync / 1[56]:Annia Quo Soranus:372C:/
-2183.2 "Innocence" sync / 1[56]:Julia Quo Soranus:3729:/
-2192.5 "Commence Air Strike" sync / 1[56]:Julia Quo Soranus:3716:/ window 30,30
-2194.1 "--sync--" sync / 1[56]:Julia Quo Soranus:370E:/
-2194.8 "Aglaia Bite" # sync / 1[56]:Annia Quo Soranus:3717:/
-2196.9 "Aglaia Bite/Roundhouse" # sync / 1[56]:Annia Quo Soranus:371[78]:/
-2199.6 "Heirsbane" sync / 1[56]:Julia Quo Soranus:3719:/
-2202.5 "Burst x5" duration 12 # sync / 1[56]:Ceruleum Tank:371A:/
-2207.2 "Angry Salamander" sync / 1[56]:Annia Quo Soranus:372C:/
-2220.2 "Artificial Plasma" sync / 1[56]:Julia Quo Soranus:3727:/
-2222.8 "Angry Salamander" sync / 1[56]:Annia Quo Soranus:372C:/
-2226.3 "--sync--" sync / 1[56]:Julia Quo Soranus:370E:/
+2153.2 "The Order" sync / 1[56]:[^:]*:Julia Quo Soranus:3713:/ window 30,30
+2158.3 "Order To Fire" sync / 1[56]:[^:]*:Annia Quo Soranus:372D:/
+2158.3 "Missile Impact" sync / 1[56]:[^:]*:Annia Quo Soranus:372E:/
+2159.3 "The Order" sync / 1[56]:[^:]*:Julia Quo Soranus:39BA:/
+2159.3 "Quaternity" sync / 1[56]:[^:]*:Soranus Duo:3989:/
+2164.6 "Artificial Plasma" sync / 1[56]:[^:]*:Julia Quo Soranus:3727:/
+2168.8 "Angry Salamander" sync / 1[56]:[^:]*:Annia Quo Soranus:372C:/
+2174.9 "Artificial Plasma" sync / 1[56]:[^:]*:Julia Quo Soranus:3727:/
+2182.2 "Angry Salamander" sync / 1[56]:[^:]*:Annia Quo Soranus:372C:/
+2183.2 "Innocence" sync / 1[56]:[^:]*:Julia Quo Soranus:3729:/
+2192.5 "Commence Air Strike" sync / 1[56]:[^:]*:Julia Quo Soranus:3716:/ window 30,30
+2194.1 "--sync--" sync / 1[56]:[^:]*:Julia Quo Soranus:370E:/
+2194.8 "Aglaia Bite" # sync / 1[56]:[^:]*:Annia Quo Soranus:3717:/
+2196.9 "Aglaia Bite/Roundhouse" # sync / 1[56]:[^:]*:Annia Quo Soranus:371[78]:/
+2199.6 "Heirsbane" sync / 1[56]:[^:]*:Julia Quo Soranus:3719:/
+2202.5 "Burst x5" duration 12 # sync / 1[56]:[^:]*:Ceruleum Tank:371A:/
+2207.2 "Angry Salamander" sync / 1[56]:[^:]*:Annia Quo Soranus:372C:/
+2220.2 "Artificial Plasma" sync / 1[56]:[^:]*:Julia Quo Soranus:3727:/
+2222.8 "Angry Salamander" sync / 1[56]:[^:]*:Annia Quo Soranus:372C:/
+2226.3 "--sync--" sync / 1[56]:[^:]*:Julia Quo Soranus:370E:/
 
-2228.1 "The Order" sync / 1[56]:Julia Quo Soranus:3713:/ window 30,30 jump 2153.2
+2228.1 "The Order" sync / 1[56]:[^:]*:Julia Quo Soranus:3713:/ window 30,30 jump 2153.2
 2233.2 "Order To Fire"
 2233.2 "Missile Impact"
 2234.2 "The Order"
@@ -142,32 +142,32 @@ hideall "--sync--"
 
 # Annia active
 
-2297.0 "--sync--" sync / 1[56]:Julia Quo Soranus:370E:/
-2307.2 "Heirsbane" sync / 1[56]:Julia Quo Soranus:372B:/
-2310.3 "Delta Trance" sync / 1[56]:Annia Quo Soranus:372A:/
-2314.9 "Heirsbane" sync / 1[56]:Julia Quo Soranus:372B:/
-2321.3 "The Order" sync / 1[56]:Julia Quo Soranus:3713:/
-2325.1 "Order To Bombard" sync / 1[56]:Annia Quo Soranus:3710:/
-2327.5 "--sync--" sync / 1[56]:Annia Quo Soranus:370F:/
+2297.0 "--sync--" sync / 1[56]:[^:]*:Julia Quo Soranus:370E:/
+2307.2 "Heirsbane" sync / 1[56]:[^:]*:Julia Quo Soranus:372B:/
+2310.3 "Delta Trance" sync / 1[56]:[^:]*:Annia Quo Soranus:372A:/
+2314.9 "Heirsbane" sync / 1[56]:[^:]*:Julia Quo Soranus:372B:/
+2321.3 "The Order" sync / 1[56]:[^:]*:Julia Quo Soranus:3713:/
+2325.1 "Order To Bombard" sync / 1[56]:[^:]*:Annia Quo Soranus:3710:/
+2327.5 "--sync--" sync / 1[56]:[^:]*:Annia Quo Soranus:370F:/
 
-2329.5 "The Order" sync / 1[56]:Julia Quo Soranus:3714:/ window 30,30
-2329.7 "Crossbones" sync / 1[56]:Soranus Duo:3C80:/
-2331.6 "Angry Salamander" sync / 1[56]:Annia Quo Soranus:372C:/
-2332.4 "Bombardment" sync / 1[56]:Annia Quo Soranus:3711:/
-2340.5 "The Order" sync / 1[56]:Julia Quo Soranus:3713:/
-2341.9 "Artificial Plasma" sync / 1[56]:Annia Quo Soranus:3728:/
-2347.1 "Quaternity" sync / 1[56]:Soranus Duo:3733:/
-2347.1 "The Order" sync / 1[56]:Julia Quo Soranus:39BA:/ window 30,30
-2351.7 "Delta Trance" sync / 1[56]:Annia Quo Soranus:372A:/
-2355.8 "Heirsbane" sync / 1[56]:Julia Quo Soranus:372B:/
-2361.8 "Stunning Sweep" sync / 1[56]:Annia Quo Soranus:3712:/
-2363.1 "Heirsbane" sync / 1[56]:Julia Quo Soranus:372B:/
-2370.8 "Artificial Plasma" sync / 1[56]:Annia Quo Soranus:3728:/
-2382.3 "The Order" sync / 1[56]:Julia Quo Soranus:3713:/
-2386.1 "Order To Bombard" sync / 1[56]:Annia Quo Soranus:3710:/
-2388.5 "--sync--" sync / 1[56]:Annia Quo Soranus:370F:/
+2329.5 "The Order" sync / 1[56]:[^:]*:Julia Quo Soranus:3714:/ window 30,30
+2329.7 "Crossbones" sync / 1[56]:[^:]*:Soranus Duo:3C80:/
+2331.6 "Angry Salamander" sync / 1[56]:[^:]*:Annia Quo Soranus:372C:/
+2332.4 "Bombardment" sync / 1[56]:[^:]*:Annia Quo Soranus:3711:/
+2340.5 "The Order" sync / 1[56]:[^:]*:Julia Quo Soranus:3713:/
+2341.9 "Artificial Plasma" sync / 1[56]:[^:]*:Annia Quo Soranus:3728:/
+2347.1 "Quaternity" sync / 1[56]:[^:]*:Soranus Duo:3733:/
+2347.1 "The Order" sync / 1[56]:[^:]*:Julia Quo Soranus:39BA:/ window 30,30
+2351.7 "Delta Trance" sync / 1[56]:[^:]*:Annia Quo Soranus:372A:/
+2355.8 "Heirsbane" sync / 1[56]:[^:]*:Julia Quo Soranus:372B:/
+2361.8 "Stunning Sweep" sync / 1[56]:[^:]*:Annia Quo Soranus:3712:/
+2363.1 "Heirsbane" sync / 1[56]:[^:]*:Julia Quo Soranus:372B:/
+2370.8 "Artificial Plasma" sync / 1[56]:[^:]*:Annia Quo Soranus:3728:/
+2382.3 "The Order" sync / 1[56]:[^:]*:Julia Quo Soranus:3713:/
+2386.1 "Order To Bombard" sync / 1[56]:[^:]*:Annia Quo Soranus:3710:/
+2388.5 "--sync--" sync / 1[56]:[^:]*:Annia Quo Soranus:370F:/
 
-2390.5 "The Order" sync / 1[56]:Julia Quo Soranus:3714:/ jump 2329.5 window 30,30
+2390.5 "The Order" sync / 1[56]:[^:]*:Julia Quo Soranus:3714:/ jump 2329.5 window 30,30
 2390.7 "Crossbones"
 2392.6 "Angry Salamander"
 2393.4 "Bombardment"
@@ -183,29 +183,29 @@ hideall "--sync--"
 # Order To Support and Covering Fire are only on the second intermission.
 
 
-2494.3 "Order To Support" sync / 1[56]:Annia Quo Soranus:371B:/ window 494.3,5
-2500.0 "Crosshatch" sync / 1[56]:Soranus Duo:3721:/ window 500,5
-2506.6 "--sync--" sync / 1[56]:Annia Quo Soranus:3723:/
-2506.8 "--sync--" sync / 1[56]:Julia Quo Soranus:384B:/
-2507.1 "--sync--" sync / 1[56]:Annia Quo Soranus:384C:/
-2507.4 "--sync--" sync / 1[56]:Julia Quo Soranus:3724:/
-2508.2 "--sync--" sync / 1[56]:Annia Quo Soranus:396A:/
-2508.6 "--sync--" sync / 1[56]:Julia Quo Soranus:3969:/
-2508.7 "Crosshatch 1" # sync / 1[56]:Annia Quo Soranus:3722:/
-2508.9 "Crosshatch 2" # sync / 1[56]:Julia Quo Soranus:3722:/
-2509.0 "--sync--" sync / 1[56]:Annia Quo Soranus:384D:/
-2509.4 "Covering Fire?" sync / 1[56]:Annia Quo Soranus:371C:/
-2509.4 "Crosshatch 3" # sync / 1[56]:Annia Quo Soranus:3722:/
-2509.6 "--sync--" sync / 1[56]:Julia Quo Soranus:396B:/
-2509.9 "Crosshatch 4" # sync / 1[56]:Julia Quo Soranus:3722:/
-2511.1 "Crosshatch 5" # sync / 1[56]:Annia Quo Soranus:3722:/
-2511.8 "Crosshatch 6" # sync / 1[56]:Julia Quo Soranus:3722:/
-2512.3 "Crosshatch 7" # sync / 1[56]:Annia Quo Soranus:3722:/
-2512.8 "Crosshatch 8" # sync / 1[56]:Julia Quo Soranus:3722:/
-2515.9 "--sync--" sync / 1[56]:Julia Quo Soranus:3726:/
-2516.0 "--sync--" sync / 1[56]:Annia Quo Soranus:3725:/
-2519.0 "--sync--" sync / 1[56]:Annia Quo Soranus:370F:/ window 10,10 jump 2097.0
-2519.0 "--sync--" sync / 1[56]:Julia Quo Soranus:370E:/ window 10,10 jump 2297.0
+2494.3 "Order To Support" sync / 1[56]:[^:]*:Annia Quo Soranus:371B:/ window 494.3,5
+2500.0 "Crosshatch" sync / 1[56]:[^:]*:Soranus Duo:3721:/ window 500,5
+2506.6 "--sync--" sync / 1[56]:[^:]*:Annia Quo Soranus:3723:/
+2506.8 "--sync--" sync / 1[56]:[^:]*:Julia Quo Soranus:384B:/
+2507.1 "--sync--" sync / 1[56]:[^:]*:Annia Quo Soranus:384C:/
+2507.4 "--sync--" sync / 1[56]:[^:]*:Julia Quo Soranus:3724:/
+2508.2 "--sync--" sync / 1[56]:[^:]*:Annia Quo Soranus:396A:/
+2508.6 "--sync--" sync / 1[56]:[^:]*:Julia Quo Soranus:3969:/
+2508.7 "Crosshatch 1" # sync / 1[56]:[^:]*:Annia Quo Soranus:3722:/
+2508.9 "Crosshatch 2" # sync / 1[56]:[^:]*:Julia Quo Soranus:3722:/
+2509.0 "--sync--" sync / 1[56]:[^:]*:Annia Quo Soranus:384D:/
+2509.4 "Covering Fire?" sync / 1[56]:[^:]*:Annia Quo Soranus:371C:/
+2509.4 "Crosshatch 3" # sync / 1[56]:[^:]*:Annia Quo Soranus:3722:/
+2509.6 "--sync--" sync / 1[56]:[^:]*:Julia Quo Soranus:396B:/
+2509.9 "Crosshatch 4" # sync / 1[56]:[^:]*:Julia Quo Soranus:3722:/
+2511.1 "Crosshatch 5" # sync / 1[56]:[^:]*:Annia Quo Soranus:3722:/
+2511.8 "Crosshatch 6" # sync / 1[56]:[^:]*:Julia Quo Soranus:3722:/
+2512.3 "Crosshatch 7" # sync / 1[56]:[^:]*:Annia Quo Soranus:3722:/
+2512.8 "Crosshatch 8" # sync / 1[56]:[^:]*:Julia Quo Soranus:3722:/
+2515.9 "--sync--" sync / 1[56]:[^:]*:Julia Quo Soranus:3726:/
+2516.0 "--sync--" sync / 1[56]:[^:]*:Annia Quo Soranus:3725:/
+2519.0 "--sync--" sync / 1[56]:[^:]*:Annia Quo Soranus:370F:/ window 10,10 jump 2097.0
+2519.0 "--sync--" sync / 1[56]:[^:]*:Julia Quo Soranus:370E:/ window 10,10 jump 2297.0
 2522.4 "Artificial Plasma?"
 2529.6 "Heirsbane?"
 2530.6 "Angry Salamander?"
@@ -216,10 +216,10 @@ hideall "--sync--"
 
 # Enrage after two intermissions.
 
-# 2597.3 "--sync--" sync / 14:Julia Quo Soranus:372F:/ window 597.3
-2597.3 "Artificial Boost" sync / 14:Annia Quo Soranus:3730:/ window 597.3
-# 2600.0 "--sync--" sync / 1[56]:Julia Quo Soranus:372F:/ window 600,5
-2600.0 "Artificial Boost" sync / 1[56]:Annia Quo Soranus:3730:/ window 600,5
-# 2603.2 "--sync--" sync / 14:Julia Quo Soranus:3731:/
-2603.2 "Imperial Authority" sync / 14:Annia Quo Soranus:3732:/ duration 39.7
-2642.9 "Imperial Authority Enrage" sync / 1[56]:Annia Quo Soranus:3732:/ 
+# 2597.3 "--sync--" sync / 14:[^:]*:Julia Quo Soranus:372F:/ window 597.3
+2597.3 "Artificial Boost" sync / 14:[^:]*:Annia Quo Soranus:3730:/ window 597.3
+# 2600.0 "--sync--" sync / 1[56]:[^:]*:Julia Quo Soranus:372F:/ window 600,5
+2600.0 "Artificial Boost" sync / 1[56]:[^:]*:Annia Quo Soranus:3730:/ window 600,5
+# 2603.2 "--sync--" sync / 14:[^:]*:Julia Quo Soranus:3731:/
+2603.2 "Imperial Authority" sync / 14:[^:]*:Annia Quo Soranus:3732:/ duration 39.7
+2642.9 "Imperial Authority Enrage" sync / 1[56]:[^:]*:Annia Quo Soranus:3732:/ 

--- a/ui/raidboss/data/04-sb/dungeon/hells_lid.txt
+++ b/ui/raidboss/data/04-sb/dungeon/hells_lid.txt
@@ -13,32 +13,32 @@ hideall "--sync--"
 
 
 0 "Start" sync / 00:0839::Demonsgate will be sealed off/ window 0,1
-3.0 "--sync--" sync / 1[56]:Otake-Maru:368:/ window 3,0
-19.7 "100-Tonze Swing" sync / 1[56]:Otake-Maru:27BE:/ window 19.7,5
-27.3 "Volcanic Debris x8" # sync / 1[56]:Volcanic Debris:27C5:/
-28.3 "10-Tonze Slash" sync / 1[56]:Otake-Maru:27BF:/
-39.4 "100-Tonze Swing" sync / 1[56]:Otake-Maru:27BE:/ window 20,20
-56.2 "Eruptive Leap" sync / 1[56]:Otake-Maru:27C4:/
-57.3 "Disrobe 1" sync / 1[56]:Otake-Maru:27C1:/
-62.1 "Disrobe 2" sync / 1[56]:Otake-Maru:27C2:/
-69.3 "Eruptive Leap" sync / 1[56]:Otake-Maru:27C4:/
-70.4 "Stone Cudgel" sync / 1[56]:Otake-Maru:27C3:/
-73.1 "Eruptive Leap" sync / 1[56]:Otake-Maru:27C4:/
-74.2 "Stone Cudgel" sync / 1[56]:Otake-Maru:27C3:/
-79.9 "10-Tonze Slash" sync / 1[56]:Otake-Maru:27BF:/
+3.0 "--sync--" sync / 1[56]:[^:]*:Otake-Maru:368:/ window 3,0
+19.7 "100-Tonze Swing" sync / 1[56]:[^:]*:Otake-Maru:27BE:/ window 19.7,5
+27.3 "Volcanic Debris x8" # sync / 1[56]:[^:]*:Volcanic Debris:27C5:/
+28.3 "10-Tonze Slash" sync / 1[56]:[^:]*:Otake-Maru:27BF:/
+39.4 "100-Tonze Swing" sync / 1[56]:[^:]*:Otake-Maru:27BE:/ window 20,20
+56.2 "Eruptive Leap" sync / 1[56]:[^:]*:Otake-Maru:27C4:/
+57.3 "Disrobe 1" sync / 1[56]:[^:]*:Otake-Maru:27C1:/
+62.1 "Disrobe 2" sync / 1[56]:[^:]*:Otake-Maru:27C2:/
+69.3 "Eruptive Leap" sync / 1[56]:[^:]*:Otake-Maru:27C4:/
+70.4 "Stone Cudgel" sync / 1[56]:[^:]*:Otake-Maru:27C3:/
+73.1 "Eruptive Leap" sync / 1[56]:[^:]*:Otake-Maru:27C4:/
+74.2 "Stone Cudgel" sync / 1[56]:[^:]*:Otake-Maru:27C3:/
+79.9 "10-Tonze Slash" sync / 1[56]:[^:]*:Otake-Maru:27BF:/
 
-101.1 "100-Tonze Swing" sync / 1[56]:Otake-Maru:27BE:/ window 20,20
-108.8 "Eruptive Leap" sync / 1[56]:Otake-Maru:27C4:/
-109.9 "Disrobe 1" sync / 1[56]:Otake-Maru:27C1:/
-114.6 "Disrobe 2" sync / 1[56]:Otake-Maru:27C2:/
-115.7 "Volcanic Debris x14" # sync / 1[56]:Volcanic Debris:27C5:/
-121.9 "Eruptive Leap" sync / 1[56]:Otake-Maru:27C4:/
-123.0 "Stone Cudgel" sync / 1[56]:Otake-Maru:27C3:/
-125.6 "Eruptive Leap" sync / 1[56]:Otake-Maru:27C4:/
-126.7 "Stone Cudgel" sync / 1[56]:Otake-Maru:27C3:/
-132.4 "10-Tonze Slash" sync / 1[56]:Otake-Maru:27BF:/
+101.1 "100-Tonze Swing" sync / 1[56]:[^:]*:Otake-Maru:27BE:/ window 20,20
+108.8 "Eruptive Leap" sync / 1[56]:[^:]*:Otake-Maru:27C4:/
+109.9 "Disrobe 1" sync / 1[56]:[^:]*:Otake-Maru:27C1:/
+114.6 "Disrobe 2" sync / 1[56]:[^:]*:Otake-Maru:27C2:/
+115.7 "Volcanic Debris x14" # sync / 1[56]:[^:]*:Volcanic Debris:27C5:/
+121.9 "Eruptive Leap" sync / 1[56]:[^:]*:Otake-Maru:27C4:/
+123.0 "Stone Cudgel" sync / 1[56]:[^:]*:Otake-Maru:27C3:/
+125.6 "Eruptive Leap" sync / 1[56]:[^:]*:Otake-Maru:27C4:/
+126.7 "Stone Cudgel" sync / 1[56]:[^:]*:Otake-Maru:27C3:/
+132.4 "10-Tonze Slash" sync / 1[56]:[^:]*:Otake-Maru:27BF:/
 
-168.6 "100-Tonze Swing" sync / 1[56]:Otake-Maru:27BE:/ window 20,20 jump 101.1
+168.6 "100-Tonze Swing" sync / 1[56]:[^:]*:Otake-Maru:27BE:/ window 20,20 jump 101.1
 176.3 "Eruptive Leap"
 177.4 "Disrobe1 "
 182.1 "Disrobe 2"
@@ -57,31 +57,31 @@ hideall "--sync--"
 # -ic "Tsumuji-Kaze"
 
 1000.0  "Start" sync / 00:0839::The Furnace will be sealed off/ window 1000,1
-1002.6  "--sync--" sync / 1[56]:Kamaitachi:366:/ window 2.6,1
-1011.5 "Whipping Whittret" sync / 1[56]:Kamaitachi:27C6:/ window 11.5,5
-1024.1 "Circling Winds" sync / 1[56]:Kamaitachi:27C8:/
-1037.8 "The Patient Blade" sync / 1[56]:Kamaitachi:27C7:/
-1050.5 "Rolling Winds" sync / 1[56]:Kamaitachi:27C9:/
-1064.2 "Whisper In The Wind" sync / 1[56]:Kamaitachi:27CA:/
+1002.6  "--sync--" sync / 1[56]:[^:]*:Kamaitachi:366:/ window 2.6,1
+1011.5 "Whipping Whittret" sync / 1[56]:[^:]*:Kamaitachi:27C6:/ window 11.5,5
+1024.1 "Circling Winds" sync / 1[56]:[^:]*:Kamaitachi:27C8:/
+1037.8 "The Patient Blade" sync / 1[56]:[^:]*:Kamaitachi:27C7:/
+1050.5 "Rolling Winds" sync / 1[56]:[^:]*:Kamaitachi:27C9:/
+1064.2 "Whisper In The Wind" sync / 1[56]:[^:]*:Kamaitachi:27CA:/
 1066.3 "--untargetable--"
 
-1066.4 "--sync--" sync / 1[56]:Kamaitachi:284F:/ window 66.4,5
-1084.2 "Late Harvest" sync / 1[56]:Kamaitachi:27CC:/ window 30,0
-1084.8 "Late Harvest" # sync / 1[56]:Kamaitachi:27CC:/
-1085.4 "Late Harvest" # sync / 1[56]:Kamaitachi:27CC:/
-1092.2 "Late Harvest" sync / 1[56]:Kamaitachi:27CC:/ window 5,0
-1092.8 "Late Harvest" # sync / 1[56]:Kamaitachi:27CC:/
-1093.4 "Late Harvest" # sync / 1[56]:Kamaitachi:27CC:/
-1099.2 "Reaper's Gale" sync / 1[56]:Kamaitachi:27CB:/
-1099.3 "--sync--" sync / 1[56]:Kamaitachi:2967:/
+1066.4 "--sync--" sync / 1[56]:[^:]*:Kamaitachi:284F:/ window 66.4,5
+1084.2 "Late Harvest" sync / 1[56]:[^:]*:Kamaitachi:27CC:/ window 30,0
+1084.8 "Late Harvest" # sync / 1[56]:[^:]*:Kamaitachi:27CC:/
+1085.4 "Late Harvest" # sync / 1[56]:[^:]*:Kamaitachi:27CC:/
+1092.2 "Late Harvest" sync / 1[56]:[^:]*:Kamaitachi:27CC:/ window 5,0
+1092.8 "Late Harvest" # sync / 1[56]:[^:]*:Kamaitachi:27CC:/
+1093.4 "Late Harvest" # sync / 1[56]:[^:]*:Kamaitachi:27CC:/
+1099.2 "Reaper's Gale" sync / 1[56]:[^:]*:Kamaitachi:27CB:/
+1099.3 "--sync--" sync / 1[56]:[^:]*:Kamaitachi:2967:/
 1105.6 "--targetable--"
 
-1110.9 "The Patient Blade" sync / 1[56]:Kamaitachi:27C7:/ window 50,5
-1116.6 "Whipping Whittret" sync / 1[56]:Kamaitachi:27C6:/
-1127.2 "Circling Winds" sync / 1[56]:Kamaitachi:27C8:/
-1138.9 "Rolling Winds" sync / 1[56]:Kamaitachi:27C9:/
+1110.9 "The Patient Blade" sync / 1[56]:[^:]*:Kamaitachi:27C7:/ window 50,5
+1116.6 "Whipping Whittret" sync / 1[56]:[^:]*:Kamaitachi:27C6:/
+1127.2 "Circling Winds" sync / 1[56]:[^:]*:Kamaitachi:27C8:/
+1138.9 "Rolling Winds" sync / 1[56]:[^:]*:Kamaitachi:27C9:/
 
-1151.6 "The Patient Blade" sync / 1[56]:Kamaitachi:27C7:/ window 30,30 jump 1110.9
+1151.6 "The Patient Blade" sync / 1[56]:[^:]*:Kamaitachi:27C7:/ window 30,30 jump 1110.9
 1157.3 "Whipping Whittret"
 1167.9 "Circling Winds"
 1179.6 "Rolling Winds"
@@ -94,36 +94,36 @@ hideall "--sync--"
 # -ii 27D2 27D5
 
 2000.0 "Start" sync / 00:0839::The Polished Shell will be sealed off/ window 2000,1
-2005.0 "Caduceus" sync / 1[56]:Genbu:27CF:/ window 5,5
-2013.1 "Hell Of Water" sync / 1[56]:Genbu:27D0:/
-2021.9 "Hell Of Waste" sync / 1[56]:Genbu:27D1:/
-2033.6 "Sinister Tide" sync / 1[56]:Genbu:27D4:/
-2050.7 "Caduceus" sync / 1[56]:Genbu:27CF:/ window 20,20
-2055.8 "Sinister Tide" sync / 1[56]:Genbu:27D4:/
-2079.0 "Hell Of Water" sync / 1[56]:Genbu:27D0:/
-2085.7 "Sinister Tide" sync / 1[56]:Genbu:27D4:/
-2092.9 "Hell Of Waste" sync / 1[56]:Genbu:27D1:/
-2103.6 "Caduceus" sync / 1[56]:Genbu:27CF:/ window 20,20
+2005.0 "Caduceus" sync / 1[56]:[^:]*:Genbu:27CF:/ window 5,5
+2013.1 "Hell Of Water" sync / 1[56]:[^:]*:Genbu:27D0:/
+2021.9 "Hell Of Waste" sync / 1[56]:[^:]*:Genbu:27D1:/
+2033.6 "Sinister Tide" sync / 1[56]:[^:]*:Genbu:27D4:/
+2050.7 "Caduceus" sync / 1[56]:[^:]*:Genbu:27CF:/ window 20,20
+2055.8 "Sinister Tide" sync / 1[56]:[^:]*:Genbu:27D4:/
+2079.0 "Hell Of Water" sync / 1[56]:[^:]*:Genbu:27D0:/
+2085.7 "Sinister Tide" sync / 1[56]:[^:]*:Genbu:27D4:/
+2092.9 "Hell Of Waste" sync / 1[56]:[^:]*:Genbu:27D1:/
+2103.6 "Caduceus" sync / 1[56]:[^:]*:Genbu:27CF:/ window 20,20
 2109.7 "--untargetable--"
 
 # This intermission has a boss limit break charging.
 # Its progress determines how powerful Divine Cataract will be.
 # This timeline is the maximum the intermission will run.
-2113.9 "Hell Of Waves" sync / 1[56]:Genbu:27D3:/ window 113.9,5
-2125.4 "Shell Shower" sync / 1[56]:Genbu:2850:/
-2140.5 "Shell Shower" sync / 1[56]:Genbu:2850:/
-2155.6 "Shell Shower" sync / 1[56]:Genbu:2850:/
-2170.6 "Shell Shower" sync / 1[56]:Genbu:2850:/
-2175.3 "Divine Cataract" sync / 1[56]:Genbu:27D7:/ window 61.4,10
+2113.9 "Hell Of Waves" sync / 1[56]:[^:]*:Genbu:27D3:/ window 113.9,5
+2125.4 "Shell Shower" sync / 1[56]:[^:]*:Genbu:2850:/
+2140.5 "Shell Shower" sync / 1[56]:[^:]*:Genbu:2850:/
+2155.6 "Shell Shower" sync / 1[56]:[^:]*:Genbu:2850:/
+2170.6 "Shell Shower" sync / 1[56]:[^:]*:Genbu:2850:/
+2175.3 "Divine Cataract" sync / 1[56]:[^:]*:Genbu:27D7:/ window 61.4,10
 2178.3 "--targetable--"
 
 # Extra-aggressive syncs here, since Waste/Wave timings can drift.
-2182.4 "Sinister Tide" sync / 1[56]:Genbu:27D4:/ window 20,20
-2189.5 "Hell Of Waste/Hell Of Waves" sync / 1[56]:Genbu:27(D1|7E):/
-2202.6 "Hell Of Water" sync / 1[56]:Genbu:27D0:/ window 15,15
-2208.3 "Caduceus" sync / 1[56]:Genbu:27CF:/ window 15,15
+2182.4 "Sinister Tide" sync / 1[56]:[^:]*:Genbu:27D4:/ window 20,20
+2189.5 "Hell Of Waste/Hell Of Waves" sync / 1[56]:[^:]*:Genbu:27(D1|7E):/
+2202.6 "Hell Of Water" sync / 1[56]:[^:]*:Genbu:27D0:/ window 15,15
+2208.3 "Caduceus" sync / 1[56]:[^:]*:Genbu:27CF:/ window 15,15
 
-2214.4 "Sinister Tide" sync / 1[56]:Genbu:27D4:/ window 20,20 jump 2182.4
+2214.4 "Sinister Tide" sync / 1[56]:[^:]*:Genbu:27D4:/ window 20,20 jump 2182.4
 2221.5 "Hell Of Waste/Hell Of Waves"
 2234.6 "Hell Of Water"
 2240.3 "Caduceus"

--- a/ui/raidboss/data/04-sb/dungeon/kugane_castle.txt
+++ b/ui/raidboss/data/04-sb/dungeon/kugane_castle.txt
@@ -14,21 +14,21 @@ hideall "--sync--"
 # The Harakiri Kosho adds seem to be on a separate timer and thus aren't included here.
 
 0 "Start" sync / 00:0839::The Keisen Garden will be sealed off/ window 0,1
-9.6 "Clearout" sync / 1[56]:Zuiko-Maru:1E92:/ window 9.6,5
-21.8 "Kenki Release" sync / 1[56]:Zuiko-Maru:1E93:/ window 21.8,10
-30.9 "Clearout" sync / 1[56]:Zuiko-Maru:1E92:/
+9.6 "Clearout" sync / 1[56]:[^:]*:Zuiko-Maru:1E92:/ window 9.6,5
+21.8 "Kenki Release" sync / 1[56]:[^:]*:Zuiko-Maru:1E93:/ window 21.8,10
+30.9 "Clearout" sync / 1[56]:[^:]*:Zuiko-Maru:1E92:/
 
-40.0 "Kenki Release" sync / 1[56]:Zuiko-Maru:1E93:/
-50.2 "Clearout" sync / 1[56]:Zuiko-Maru:1E92:/
-60.4 "Helm Crack" sync / 1[56]:Zuiko-Maru:1E94:/ window 15,15
-65.5 "Kenki Release" sync / 1[56]:Zuiko-Maru:1E93:/
-75.8 "Clearout" sync / 1[56]:Zuiko-Maru:1E92:/
-86.0 "Kenki Release" sync / 1[56]:Zuiko-Maru:1E93:/
-98.2 "Helm Crack" sync / 1[56]:Zuiko-Maru:1E94:/ window 15,15
-103.4 "Clearout" sync / 1[56]:Zuiko-Maru:1E92:/
-113.6 "Kenki Release" sync / 1[56]:Zuiko-Maru:1E93:/
+40.0 "Kenki Release" sync / 1[56]:[^:]*:Zuiko-Maru:1E93:/
+50.2 "Clearout" sync / 1[56]:[^:]*:Zuiko-Maru:1E92:/
+60.4 "Helm Crack" sync / 1[56]:[^:]*:Zuiko-Maru:1E94:/ window 15,15
+65.5 "Kenki Release" sync / 1[56]:[^:]*:Zuiko-Maru:1E93:/
+75.8 "Clearout" sync / 1[56]:[^:]*:Zuiko-Maru:1E92:/
+86.0 "Kenki Release" sync / 1[56]:[^:]*:Zuiko-Maru:1E93:/
+98.2 "Helm Crack" sync / 1[56]:[^:]*:Zuiko-Maru:1E94:/ window 15,15
+103.4 "Clearout" sync / 1[56]:[^:]*:Zuiko-Maru:1E92:/
+113.6 "Kenki Release" sync / 1[56]:[^:]*:Zuiko-Maru:1E93:/
 
-121.7 "Kenki Release" sync / 1[56]:Zuiko-Maru:1E93:/ jump 40
+121.7 "Kenki Release" sync / 1[56]:[^:]*:Zuiko-Maru:1E93:/ jump 40
 131.9 "Clearout"
 142.1 "Helm Crack"
 147.2 "Kenki Release"
@@ -43,31 +43,31 @@ hideall "--sync--"
 # -ii 1E9C 1E9E
 
 1000.0 "Start" sync / 00:0839::The Budokan Training Grounds will be sealed off/ window 1000,5
-1006.5 "Issen" sync / 1[56]:Dojun-Maru:1E97:/ window 1006.5,5
-1016.6 "Clockwork Medium" sync / 1[56]:Dojun-Maru:1E99:/
-1019.8 "Issen" sync / 1[56]:Dojun-Maru:1E97:/
-1025.5 "Tatami-Gaeshi" sync / 1[56]:Elite Onmitsu:1E9D:/
-1027.6 "--sync--" sync / 1[56]:Elite Onmitsu:1E9A:/
-1028.9 "Clockwork Raiton" sync / 1[56]:Dojun-Maru:1E9B:/ window 1028.9,10
+1006.5 "Issen" sync / 1[56]:[^:]*:Dojun-Maru:1E97:/ window 1006.5,5
+1016.6 "Clockwork Medium" sync / 1[56]:[^:]*:Dojun-Maru:1E99:/
+1019.8 "Issen" sync / 1[56]:[^:]*:Dojun-Maru:1E97:/
+1025.5 "Tatami-Gaeshi" sync / 1[56]:[^:]*:Elite Onmitsu:1E9D:/
+1027.6 "--sync--" sync / 1[56]:[^:]*:Elite Onmitsu:1E9A:/
+1028.9 "Clockwork Raiton" sync / 1[56]:[^:]*:Dojun-Maru:1E9B:/ window 1028.9,10
 
-1036.1 "Issen" sync / 1[56]:Dojun-Maru:1E97:/
-1042.2 "Clockwork Medium" sync / 1[56]:Dojun-Maru:1E99:/
-1051.0 "Juji Shuriken" sync / 1[56]:Dojun-Maru:1E98:/
-1056.7 "Issen" sync / 1[56]:Dojun-Maru:1E97:/
-1061.8 "Issen" sync / 1[56]:Dojun-Maru:1E97:/
-1068.2 "Harakiri?" # sync / 1[56]:Elite Onmitsu:1E9F:/
-1070.1 "Juji Shuriken" sync / 1[56]:Dojun-Maru:1E98:/
-1079.3 "Clockwork Medium" sync / 1[56]:Dojun-Maru:1E99:/ window 15,15
-1088.1 "Tatami-Gaeshi 1" sync / 1[56]:Elite Onmitsu:1E9D:/
-1091.5 "Clockwork Raiton" sync / 1[56]:Dojun-Maru:1E9B:/
-1092.1 "Tatami-Gaeshi 2" sync / 1[56]:Elite Onmitsu:1E9D:/
-1093.4 "Juji Shuriken" sync / 1[56]:Elite Onmitsu:1EA0:/
-1095.5 "--adds spawn--" sync / 1[56]:Elite Onmitsu:1E9A:/
-1096.7 "Juji Shuriken" sync / 1[56]:Dojun-Maru:1E98:/
-1099.4 "--sync--" sync / 1[56]:Elite Onmitsu:1E9A:/
-1103.8 "Issen" sync / 1[56]:Dojun-Maru:1E97:/ window 30,2.5
+1036.1 "Issen" sync / 1[56]:[^:]*:Dojun-Maru:1E97:/
+1042.2 "Clockwork Medium" sync / 1[56]:[^:]*:Dojun-Maru:1E99:/
+1051.0 "Juji Shuriken" sync / 1[56]:[^:]*:Dojun-Maru:1E98:/
+1056.7 "Issen" sync / 1[56]:[^:]*:Dojun-Maru:1E97:/
+1061.8 "Issen" sync / 1[56]:[^:]*:Dojun-Maru:1E97:/
+1068.2 "Harakiri?" # sync / 1[56]:[^:]*:Elite Onmitsu:1E9F:/
+1070.1 "Juji Shuriken" sync / 1[56]:[^:]*:Dojun-Maru:1E98:/
+1079.3 "Clockwork Medium" sync / 1[56]:[^:]*:Dojun-Maru:1E99:/ window 15,15
+1088.1 "Tatami-Gaeshi 1" sync / 1[56]:[^:]*:Elite Onmitsu:1E9D:/
+1091.5 "Clockwork Raiton" sync / 1[56]:[^:]*:Dojun-Maru:1E9B:/
+1092.1 "Tatami-Gaeshi 2" sync / 1[56]:[^:]*:Elite Onmitsu:1E9D:/
+1093.4 "Juji Shuriken" sync / 1[56]:[^:]*:Elite Onmitsu:1EA0:/
+1095.5 "--adds spawn--" sync / 1[56]:[^:]*:Elite Onmitsu:1E9A:/
+1096.7 "Juji Shuriken" sync / 1[56]:[^:]*:Dojun-Maru:1E98:/
+1099.4 "--sync--" sync / 1[56]:[^:]*:Elite Onmitsu:1E9A:/
+1103.8 "Issen" sync / 1[56]:[^:]*:Dojun-Maru:1E97:/ window 30,2.5
 
-1111.1 "Issen" sync / 1[56]:Dojun-Maru:1E97:/ jump 1036.1
+1111.1 "Issen" sync / 1[56]:[^:]*:Dojun-Maru:1E97:/ jump 1036.1
 1117.2 "Clockwork Medium"
 1126.0 "Juji Shuriken"
 1131.7 "Issen"
@@ -82,70 +82,70 @@ hideall "--sync--"
 
 # Short opener
 2000.0 "Start" sync / 00:0839::The Noh Theater will be sealed off/ window 2000,5
-2009.5 "Iai-Giri" sync / 1[56]:Yojimbo:1EA2:/ window 2009.5,5
-2012.7 "Wakizashi" sync / 1[56]:Yojimbo:1EA1:/
-2018.9 "Wakizashi" sync / 1[56]:Yojimbo:1EA1:/
+2009.5 "Iai-Giri" sync / 1[56]:[^:]*:Yojimbo:1EA2:/ window 2009.5,5
+2012.7 "Wakizashi" sync / 1[56]:[^:]*:Yojimbo:1EA1:/
+2018.9 "Wakizashi" sync / 1[56]:[^:]*:Yojimbo:1EA1:/
 2024.9 "--untargetable--"
 
 # Intermission 1
-2028.9 "--sync--" sync / 1[56]:Kageyama:2517:/ window 2028.9,5
-2031.0 "Gratuity" sync / 1[56]:Kageyama:1EAE:/
-2037.1 "Gratuity" sync / 1[56]:Kageyama:1EAE:/
-2039.1 "Zeni Masshigura x4" sync / 1[56]:Daigoro:1EA7:/
-2043.1 "--sync--" sync / 1[56]:Kageyama:2517:/
-2047.7 "Zeni Masshigura x4" sync / 1[56]:Daigoro:1EA7:/
-2059.2 "Zanmato" sync / 1[56]:Yojimbo:2072:/ window 2059.2,10
+2028.9 "--sync--" sync / 1[56]:[^:]*:Kageyama:2517:/ window 2028.9,5
+2031.0 "Gratuity" sync / 1[56]:[^:]*:Kageyama:1EAE:/
+2037.1 "Gratuity" sync / 1[56]:[^:]*:Kageyama:1EAE:/
+2039.1 "Zeni Masshigura x4" sync / 1[56]:[^:]*:Daigoro:1EA7:/
+2043.1 "--sync--" sync / 1[56]:[^:]*:Kageyama:2517:/
+2047.7 "Zeni Masshigura x4" sync / 1[56]:[^:]*:Daigoro:1EA7:/
+2059.2 "Zanmato" sync / 1[56]:[^:]*:Yojimbo:2072:/ window 2059.2,10
 
 # Bridge
 2062.2 "--targetable--"
-2074.7 "Wakizashi" sync / 1[56]:Yojimbo:1EA1:/
-2079.8 "Metta-Giri" sync / 1[56]:Yojimbo:1EA3:/
-2091.0 "Inoshikacho" sync / 1[56]:Yojimbo:1EA5:/ window 30,30
-2096.2 "Wakizashi" sync / 1[56]:Yojimbo:1EA1:/
-2100.2 "Fragility (inner)" # sync / 1[56]:Inoshikacho:1EAA:/
-2104.2 "Fragility (outer)" # sync / 1[56]:Inoshikacho:1EAA:/
-2106.2 "Iai-Giri" sync / 1[56]:Yojimbo:1EA2:/
-2115.1 "Dragon's Lair" sync / 1[56]:Yojimbo:1EA6:/
+2074.7 "Wakizashi" sync / 1[56]:[^:]*:Yojimbo:1EA1:/
+2079.8 "Metta-Giri" sync / 1[56]:[^:]*:Yojimbo:1EA3:/
+2091.0 "Inoshikacho" sync / 1[56]:[^:]*:Yojimbo:1EA5:/ window 30,30
+2096.2 "Wakizashi" sync / 1[56]:[^:]*:Yojimbo:1EA1:/
+2100.2 "Fragility (inner)" # sync / 1[56]:[^:]*:Inoshikacho:1EAA:/
+2104.2 "Fragility (outer)" # sync / 1[56]:[^:]*:Inoshikacho:1EAA:/
+2106.2 "Iai-Giri" sync / 1[56]:[^:]*:Yojimbo:1EA2:/
+2115.1 "Dragon's Lair" sync / 1[56]:[^:]*:Yojimbo:1EA6:/
 2117.2 "--untargetable--"
 
 # Intermission 2
-2121.2 "--sync--" sync / 1[56]:Kageyama:2517:/
-2123.3 "Gratuity" sync / 1[56]:Kageyama:1EAE:/
-2125.3 "Dragonfire" # sync / 1[56]:Dragon's Head:1EAB:/
-2129.4 "Gratuity" sync / 1[56]:Kageyama:1EAE:/
-2131.4 "Zeni Masshigura x4" sync / 1[56]:Daigoro:1EA7:/ window 30,2.5
-2135.4 "Gratuity" sync / 1[56]:Kageyama:1EAE:/
-2135.8 "Dragonfire" # sync / 1[56]:Dragon's Head:1EAB:/
-2138.6 "--sync--" sync / 1[56]:Kageyama:2517:/
-2140.1 "Zeni Masshigura x4" sync / 1[56]:Daigoro:1EA7:/
-2146.2 "Dragonfire" # sync / 1[56]:Dragon's Head:1EAB:/
-2148.8 "Zeni Masshigura x4" sync / 1[56]:Daigoro:1EA7:/
-2155.1 "Dragonstrike?" # sync / 1[56]:Dragon's Head:1EAD:/
-2159.5 "Zanmato" sync / 1[56]:Yojimbo:2072:/ window 90,10 # Making sure of no overlap with previous use.
+2121.2 "--sync--" sync / 1[56]:[^:]*:Kageyama:2517:/
+2123.3 "Gratuity" sync / 1[56]:[^:]*:Kageyama:1EAE:/
+2125.3 "Dragonfire" # sync / 1[56]:[^:]*:Dragon's Head:1EAB:/
+2129.4 "Gratuity" sync / 1[56]:[^:]*:Kageyama:1EAE:/
+2131.4 "Zeni Masshigura x4" sync / 1[56]:[^:]*:Daigoro:1EA7:/ window 30,2.5
+2135.4 "Gratuity" sync / 1[56]:[^:]*:Kageyama:1EAE:/
+2135.8 "Dragonfire" # sync / 1[56]:[^:]*:Dragon's Head:1EAB:/
+2138.6 "--sync--" sync / 1[56]:[^:]*:Kageyama:2517:/
+2140.1 "Zeni Masshigura x4" sync / 1[56]:[^:]*:Daigoro:1EA7:/
+2146.2 "Dragonfire" # sync / 1[56]:[^:]*:Dragon's Head:1EAB:/
+2148.8 "Zeni Masshigura x4" sync / 1[56]:[^:]*:Daigoro:1EA7:/
+2155.1 "Dragonstrike?" # sync / 1[56]:[^:]*:Dragon's Head:1EAD:/
+2159.5 "Zanmato" sync / 1[56]:[^:]*:Yojimbo:2072:/ window 90,10 # Making sure of no overlap with previous use.
 
 # Rotation
 2162.4 "--targetable--"
-2176.9 "Metta-Giri" sync / 1[56]:Yojimbo:1EA3:/
-2184.1 "Wakizashi" sync / 1[56]:Yojimbo:1EA1:/
-2189.2 "Inoshikacho" sync / 1[56]:Yojimbo:1EA5:/ window 30,30
-2194.3 "Metta-Giri" sync / 1[56]:Yojimbo:1EA3:/
-2198.4 "Fragility (inner)" # sync / 1[56]:Inoshikacho:1EAA:/
-2202.4 "Fragility (outer)" # sync / 1[56]:Inoshikacho:1EAA:/
-2205.5 "Iai-Giri" sync / 1[56]:Yojimbo:1EA2:/
-2215.7 "Dragon's Lair" sync / 1[56]:Yojimbo:1EA6:/
-2224.9 "Iai-Giri" sync / 1[56]:Yojimbo:1EA2:/
-2225.9 "Dragonfire" # sync / 1[56]:Dragon's Head:1EAB:/
-2232.0 "Wakizashi" sync / 1[56]:Yojimbo:1EA1:/
-2236.4 "Dragonfire" # sync / 1[56]:Dragon's Head:1EAB:/
-2238.0 "Wakizashi" sync / 1[56]:Yojimbo:1EA1:/
-2245.1 "Iai-Giri" sync / 1[56]:Yojimbo:1EA2:/ window 15,15
-2247.2 "Dragonfire" # sync / 1[56]:Dragon's Head:1EAB:/
-2255.2 "Metta-Giri" sync / 1[56]:Yojimbo:1EA3:/
-2255.8 "Dragonstrike?" # sync / 1[56]:Dragon's Head:1EAD:/
-2262.4 "Wakizashi" sync / 1[56]:Yojimbo:1EA1:/
-2268.5 "Wakizashi" sync / 1[56]:Yojimbo:1EA1:/
+2176.9 "Metta-Giri" sync / 1[56]:[^:]*:Yojimbo:1EA3:/
+2184.1 "Wakizashi" sync / 1[56]:[^:]*:Yojimbo:1EA1:/
+2189.2 "Inoshikacho" sync / 1[56]:[^:]*:Yojimbo:1EA5:/ window 30,30
+2194.3 "Metta-Giri" sync / 1[56]:[^:]*:Yojimbo:1EA3:/
+2198.4 "Fragility (inner)" # sync / 1[56]:[^:]*:Inoshikacho:1EAA:/
+2202.4 "Fragility (outer)" # sync / 1[56]:[^:]*:Inoshikacho:1EAA:/
+2205.5 "Iai-Giri" sync / 1[56]:[^:]*:Yojimbo:1EA2:/
+2215.7 "Dragon's Lair" sync / 1[56]:[^:]*:Yojimbo:1EA6:/
+2224.9 "Iai-Giri" sync / 1[56]:[^:]*:Yojimbo:1EA2:/
+2225.9 "Dragonfire" # sync / 1[56]:[^:]*:Dragon's Head:1EAB:/
+2232.0 "Wakizashi" sync / 1[56]:[^:]*:Yojimbo:1EA1:/
+2236.4 "Dragonfire" # sync / 1[56]:[^:]*:Dragon's Head:1EAB:/
+2238.0 "Wakizashi" sync / 1[56]:[^:]*:Yojimbo:1EA1:/
+2245.1 "Iai-Giri" sync / 1[56]:[^:]*:Yojimbo:1EA2:/ window 15,15
+2247.2 "Dragonfire" # sync / 1[56]:[^:]*:Dragon's Head:1EAB:/
+2255.2 "Metta-Giri" sync / 1[56]:[^:]*:Yojimbo:1EA3:/
+2255.8 "Dragonstrike?" # sync / 1[56]:[^:]*:Dragon's Head:1EAD:/
+2262.4 "Wakizashi" sync / 1[56]:[^:]*:Yojimbo:1EA1:/
+2268.5 "Wakizashi" sync / 1[56]:[^:]*:Yojimbo:1EA1:/
 
-2278.7 "Metta-Giri" sync / 1[56]:Yojimbo:1EA3:/ jump 2176.9
+2278.7 "Metta-Giri" sync / 1[56]:[^:]*:Yojimbo:1EA3:/ jump 2176.9
 2285.9 "Wakizashi"
 2291.0 "Inoshikacho"
 2296.1 "Metta-Giri"

--- a/ui/raidboss/data/04-sb/dungeon/shisui_of_the_violet_tides.txt
+++ b/ui/raidboss/data/04-sb/dungeon/shisui_of_the_violet_tides.txt
@@ -10,33 +10,33 @@ hideall "--sync--"
 
 # Phase 1: 100% -> 90%, autos + mini busters
 0.0 "Start" sync / 00:0839::The Harutsuge Gate will be sealed off/ window 10000,0
-4.5 "Sharp Strike" sync / 1[56]:Amikiri:1F72:/ window 20,20
-12.7 "Sharp Strike" #sync / 1[56]:Amikiri:1F72:/
-20.9 "Sharp Strike" #sync / 1[56]:Amikiri:1F72:/
-29.1 "Sharp Strike" #sync / 1[56]:Amikiri:1F72:/
-37.3 "Sharp Strike" #sync / 1[56]:Amikiri:1F72:/
+4.5 "Sharp Strike" sync / 1[56]:[^:]*:Amikiri:1F72:/ window 20,20
+12.7 "Sharp Strike" #sync / 1[56]:[^:]*:Amikiri:1F72:/
+20.9 "Sharp Strike" #sync / 1[56]:[^:]*:Amikiri:1F72:/
+29.1 "Sharp Strike" #sync / 1[56]:[^:]*:Amikiri:1F72:/
+37.3 "Sharp Strike" #sync / 1[56]:[^:]*:Amikiri:1F72:/
 
 # Phase 2: 90% -> 0%
 # Ignoring Sharp Strike (1F72) at this point, as timing is odd depending on Shuck failure.
 # There's also Sharp Strikes from the Kamikiri add as well, with its own inconsistent timing.
 # Also, there's no 0x14 lines for any of these things but Shuck.
-100.0 "Mucal Glob" sync / 1[56]:Amikiri:1F73:/ window 100,0
-132.2 "Shuck?" sync / 1[56]:Amikiri:1F75:/
+100.0 "Mucal Glob" sync / 1[56]:[^:]*:Amikiri:1F73:/ window 100,0
+132.2 "Shuck?" sync / 1[56]:[^:]*:Amikiri:1F75:/
 149.1 "--add--"
-161.8 "Digest" sync / 1[56]:Amikiri:1F79:/
+161.8 "Digest" sync / 1[56]:[^:]*:Amikiri:1F79:/
 
 # TODO: is there another phase push in here that makes this Mucal Glob come earlier?
 181.7 "--add--"
-182.2 "Mucal Glob" sync / 1[56]:Amikiri:1F73:/ window 30,30
-194.4 "Digest" sync / 1[56]:Amikiri:1F79:/
-214.4 "Shuck?" sync / 1[56]:Amikiri:1F75:/
-229.5 "Digest" sync / 1[56]:Amikiri:1F79:/
+182.2 "Mucal Glob" sync / 1[56]:[^:]*:Amikiri:1F73:/ window 30,30
+194.4 "Digest" sync / 1[56]:[^:]*:Amikiri:1F79:/
+214.4 "Shuck?" sync / 1[56]:[^:]*:Amikiri:1F75:/
+229.5 "Digest" sync / 1[56]:[^:]*:Amikiri:1F79:/
 
 249.4 "--add--"
-249.9 "Mucal Glob" sync / 1[56]:Amikiri:1F73:/ window 30,30 jump 182.2
-262.1 "Digest" #sync / 1[56]:Amikiri:1F79:/
-282.1 "Shuck?" #sync / 1[56]:Amikiri:1F75:/
-292.2 "Digest" #sync / 1[56]:Amikiri:1F79:/
+249.9 "Mucal Glob" sync / 1[56]:[^:]*:Amikiri:1F73:/ window 30,30 jump 182.2
+262.1 "Digest" #sync / 1[56]:[^:]*:Amikiri:1F79:/
+282.1 "Shuck?" #sync / 1[56]:[^:]*:Amikiri:1F75:/
+292.2 "Digest" #sync / 1[56]:[^:]*:Amikiri:1F79:/
 
 
 ### Ruby Princess
@@ -45,71 +45,71 @@ hideall "--sync--"
 
 # Phase 1: 100 -> 90%, autos + mini busters
 1000.0 "Start" sync / 00:0839::The Akashio Hall will be sealed off/ window 10000,0
-1006.4 "Tornadogenesis" sync / 1[56]:Ruby Princess:1F7F:/ window 20,20
-1013.5 "Tornadogenesis" #sync / 1[56]:Ruby Princess:1F7F:/
-1020.6 "Tornadogenesis" #sync / 1[56]:Ruby Princess:1F7F:/
-1027.7 "Tornadogenesis" #sync / 1[56]:Ruby Princess:1F7F:/
-1034.8 "Tornadogenesis" #sync / 1[56]:Ruby Princess:1F7F:/
-1041.9 "Tornadogenesis" #sync / 1[56]:Ruby Princess:1F7F:/
+1006.4 "Tornadogenesis" sync / 1[56]:[^:]*:Ruby Princess:1F7F:/ window 20,20
+1013.5 "Tornadogenesis" #sync / 1[56]:[^:]*:Ruby Princess:1F7F:/
+1020.6 "Tornadogenesis" #sync / 1[56]:[^:]*:Ruby Princess:1F7F:/
+1027.7 "Tornadogenesis" #sync / 1[56]:[^:]*:Ruby Princess:1F7F:/
+1034.8 "Tornadogenesis" #sync / 1[56]:[^:]*:Ruby Princess:1F7F:/
+1041.9 "Tornadogenesis" #sync / 1[56]:[^:]*:Ruby Princess:1F7F:/
 
 # Phase 2: 90% -> 75%, one seduce, more mini busters
-1100.0 "--sync--" sync / 14:Ruby Princess:1F7A:/ window 100,0
-1107.0 "Seduce" sync / 1[56]:Ruby Princess:1F7A:/
-1115.1 "Coriolis Kick" sync / 1[56]:Ruby Princess:1F7B:/
-1121.3 "Tornadogenesis" sync / 1[56]:Ruby Princess:1F7F:/ window 20,20
-1126.4 "Tornadogenesis" #sync / 1[56]:Ruby Princess:1F7F:/
-1131.5 "Tornadogenesis" #sync / 1[56]:Ruby Princess:1F7F:/
-1136.6 "Tornadogenesis" #sync / 1[56]:Ruby Princess:1F7F:/
-1141.7 "Tornadogenesis" #sync / 1[56]:Ruby Princess:1F7F:/
-1146.8 "Tornadogenesis" #sync / 1[56]:Ruby Princess:1F7F:/
+1100.0 "--sync--" sync / 14:[^:]*:Ruby Princess:1F7A:/ window 100,0
+1107.0 "Seduce" sync / 1[56]:[^:]*:Ruby Princess:1F7A:/
+1115.1 "Coriolis Kick" sync / 1[56]:[^:]*:Ruby Princess:1F7B:/
+1121.3 "Tornadogenesis" sync / 1[56]:[^:]*:Ruby Princess:1F7F:/ window 20,20
+1126.4 "Tornadogenesis" #sync / 1[56]:[^:]*:Ruby Princess:1F7F:/
+1131.5 "Tornadogenesis" #sync / 1[56]:[^:]*:Ruby Princess:1F7F:/
+1136.6 "Tornadogenesis" #sync / 1[56]:[^:]*:Ruby Princess:1F7F:/
+1141.7 "Tornadogenesis" #sync / 1[56]:[^:]*:Ruby Princess:1F7F:/
+1146.8 "Tornadogenesis" #sync / 1[56]:[^:]*:Ruby Princess:1F7F:/
 
 # Phase 3: 75% -> 60%, introduction to chasing AOE
-1200.0 "--sync--" sync / 14:Ruby Princess:1F7C:/ window 200,0
-1203.0 "Abyssal Volcano" sync / 1[56]:Ruby Princess:1F7C:/
-1203.8 "Geothermal Flatulence x11" sync / 1[56]:Ruby Princess:24D7:/ duration 8.1
-1217.2 "Coriolis Kick" sync / 1[56]:Ruby Princess:1F7B:/
-1225.4 "Tornadogenesis" sync / 1[56]:Ruby Princess:1F7F:/
-1232.5 "Tornadogenesis" sync / 1[56]:Ruby Princess:1F7F:/
+1200.0 "--sync--" sync / 14:[^:]*:Ruby Princess:1F7C:/ window 200,0
+1203.0 "Abyssal Volcano" sync / 1[56]:[^:]*:Ruby Princess:1F7C:/
+1203.8 "Geothermal Flatulence x11" sync / 1[56]:[^:]*:Ruby Princess:24D7:/ duration 8.1
+1217.2 "Coriolis Kick" sync / 1[56]:[^:]*:Ruby Princess:1F7B:/
+1225.4 "Tornadogenesis" sync / 1[56]:[^:]*:Ruby Princess:1F7F:/
+1232.5 "Tornadogenesis" sync / 1[56]:[^:]*:Ruby Princess:1F7F:/
 
-1244.7 "Abyssal Volcano" sync / 1[56]:Ruby Princess:1F7C:/ window 30,30 jump 1203
-1245.5 "Geothermal Flatulence x11" #sync / 1[56]:Ruby Princess:24D7:/ duration 8.1
-1258.9 "Coriolis Kick" #sync / 1[56]:Ruby Princess:1F7B:/
-1267.1 "Tornadogenesis" #sync / 1[56]:Ruby Princess:1F7F:/
-1274.2 "Tornadogenesis" #sync / 1[56]:Ruby Princess:1F7F:/
+1244.7 "Abyssal Volcano" sync / 1[56]:[^:]*:Ruby Princess:1F7C:/ window 30,30 jump 1203
+1245.5 "Geothermal Flatulence x11" #sync / 1[56]:[^:]*:Ruby Princess:24D7:/ duration 8.1
+1258.9 "Coriolis Kick" #sync / 1[56]:[^:]*:Ruby Princess:1F7B:/
+1267.1 "Tornadogenesis" #sync / 1[56]:[^:]*:Ruby Princess:1F7F:/
+1274.2 "Tornadogenesis" #sync / 1[56]:[^:]*:Ruby Princess:1F7F:/
 
 # Phase 4: 60% -> 0%, seduce loop
-1400.0 "--sync--" sync / 14:Ruby Princess:1F7A:/ window 290,0
-1407.0 "Seduce" sync / 1[56]:Ruby Princess:1F7A:/
-1415.1 "Coriolis Kick" sync / 1[56]:Ruby Princess:1F7B:/
-1423.3 "Tornadogenesis" sync / 1[56]:Ruby Princess:1F7F:/
-1430.4 "Tornadogenesis" sync / 1[56]:Ruby Princess:1F7F:/
-1437.5 "Tornadogenesis" sync / 1[56]:Ruby Princess:1F7F:/
+1400.0 "--sync--" sync / 14:[^:]*:Ruby Princess:1F7A:/ window 290,0
+1407.0 "Seduce" sync / 1[56]:[^:]*:Ruby Princess:1F7A:/
+1415.1 "Coriolis Kick" sync / 1[56]:[^:]*:Ruby Princess:1F7B:/
+1423.3 "Tornadogenesis" sync / 1[56]:[^:]*:Ruby Princess:1F7F:/
+1430.4 "Tornadogenesis" sync / 1[56]:[^:]*:Ruby Princess:1F7F:/
+1437.5 "Tornadogenesis" sync / 1[56]:[^:]*:Ruby Princess:1F7F:/
 
-1449.7 "Abyssal Volcano" sync / 1[56]:Ruby Princess:1F7C:/
-1450.5 "Geothermal Flatulence x11" sync / 1[56]:Ruby Princess:24D7:/ duration 8.1
-1465.7 "Seduce" sync / 1[56]:Ruby Princess:1F7A:/
-1473.8 "Coriolis Kick" sync / 1[56]:Ruby Princess:1F7B:/
-1482.0 "Tornadogenesis" sync / 1[56]:Ruby Princess:1F7F:/
-1489.1 "Tornadogenesis" sync / 1[56]:Ruby Princess:1F7F:/
-1496.2 "Tornadogenesis" sync / 1[56]:Ruby Princess:1F7F:/
-1512.9 "Seduce" sync / 1[56]:Ruby Princess:1F7A:/
-1521.1 "Coriolis Kick" sync / 1[56]:Ruby Princess:1F7B:/
-1529.3 "Tornadogenesis" sync / 1[56]:Ruby Princess:1F7F:/
-1536.4 "Tornadogenesis" sync / 1[56]:Ruby Princess:1F7F:/
-1543.5 "Tornadogenesis" sync / 1[56]:Ruby Princess:1F7F:/
+1449.7 "Abyssal Volcano" sync / 1[56]:[^:]*:Ruby Princess:1F7C:/
+1450.5 "Geothermal Flatulence x11" sync / 1[56]:[^:]*:Ruby Princess:24D7:/ duration 8.1
+1465.7 "Seduce" sync / 1[56]:[^:]*:Ruby Princess:1F7A:/
+1473.8 "Coriolis Kick" sync / 1[56]:[^:]*:Ruby Princess:1F7B:/
+1482.0 "Tornadogenesis" sync / 1[56]:[^:]*:Ruby Princess:1F7F:/
+1489.1 "Tornadogenesis" sync / 1[56]:[^:]*:Ruby Princess:1F7F:/
+1496.2 "Tornadogenesis" sync / 1[56]:[^:]*:Ruby Princess:1F7F:/
+1512.9 "Seduce" sync / 1[56]:[^:]*:Ruby Princess:1F7A:/
+1521.1 "Coriolis Kick" sync / 1[56]:[^:]*:Ruby Princess:1F7B:/
+1529.3 "Tornadogenesis" sync / 1[56]:[^:]*:Ruby Princess:1F7F:/
+1536.4 "Tornadogenesis" sync / 1[56]:[^:]*:Ruby Princess:1F7F:/
+1543.5 "Tornadogenesis" sync / 1[56]:[^:]*:Ruby Princess:1F7F:/
 
-1555.6 "Abyssal Volcano" sync / 1[56]:Ruby Princess:1F7C:/ window 50,50 jump 1449.7
-1556.4 "Geothermal Flatulence x11" #sync / 1[56]:Ruby Princess:24D7:/ duration 8.1
-1571.4 "Seduce" #sync / 1[56]:Ruby Princess:1F7A:/
-1579.5 "Coriolis Kick" #sync / 1[56]:Ruby Princess:1F7B:/
-1587.7 "Tornadogenesis" #sync / 1[56]:Ruby Princess:1F7F:/
-1594.8 "Tornadogenesis" #sync / 1[56]:Ruby Princess:1F7F:/
-1602.0 "Tornadogenesis" #sync / 1[56]:Ruby Princess:1F7F:/
-1618.9 "Seduce" #sync / 1[56]:Ruby Princess:1F7A:/
-1627.0 "Coriolis Kick" #sync / 1[56]:Ruby Princess:1F7B:/
-1635.2 "Tornadogenesis" #sync / 1[56]:Ruby Princess:1F7F:/
-1642.3 "Tornadogenesis" #sync / 1[56]:Ruby Princess:1F7F:/
-1649.4 "Tornadogenesis" #sync / 1[56]:Ruby Princess:1F7F:/
+1555.6 "Abyssal Volcano" sync / 1[56]:[^:]*:Ruby Princess:1F7C:/ window 50,50 jump 1449.7
+1556.4 "Geothermal Flatulence x11" #sync / 1[56]:[^:]*:Ruby Princess:24D7:/ duration 8.1
+1571.4 "Seduce" #sync / 1[56]:[^:]*:Ruby Princess:1F7A:/
+1579.5 "Coriolis Kick" #sync / 1[56]:[^:]*:Ruby Princess:1F7B:/
+1587.7 "Tornadogenesis" #sync / 1[56]:[^:]*:Ruby Princess:1F7F:/
+1594.8 "Tornadogenesis" #sync / 1[56]:[^:]*:Ruby Princess:1F7F:/
+1602.0 "Tornadogenesis" #sync / 1[56]:[^:]*:Ruby Princess:1F7F:/
+1618.9 "Seduce" #sync / 1[56]:[^:]*:Ruby Princess:1F7A:/
+1627.0 "Coriolis Kick" #sync / 1[56]:[^:]*:Ruby Princess:1F7B:/
+1635.2 "Tornadogenesis" #sync / 1[56]:[^:]*:Ruby Princess:1F7F:/
+1642.3 "Tornadogenesis" #sync / 1[56]:[^:]*:Ruby Princess:1F7F:/
+1649.4 "Tornadogenesis" #sync / 1[56]:[^:]*:Ruby Princess:1F7F:/
 
 
 ### Shisui Yohi (and friends)
@@ -119,65 +119,65 @@ hideall "--sync--"
 
 # Phase 1: 100% -> 90%, autos and mini busters
 2000.0 "Start" sync / 00:0839::Shisui Gokagura will be sealed off/ window 10000,0
-2006.5 "Foul Nail" sync / 1[56]:Shisui Yohi:1F87:/
-2013.6 "Foul Nail" sync / 1[56]:Shisui Yohi:1F87:/
+2006.5 "Foul Nail" sync / 1[56]:[^:]*:Shisui Yohi:1F87:/
+2013.6 "Foul Nail" sync / 1[56]:[^:]*:Shisui Yohi:1F87:/
 
-2023.8 "Foul Nail" sync / 1[56]:Shisui Yohi:1F87:/ window 5,5 jump 2006.5
-2030.9 "Foul Nail" #sync / 1[56]:Shisui Yohi:1F87:/
+2023.8 "Foul Nail" sync / 1[56]:[^:]*:Shisui Yohi:1F87:/ window 5,5 jump 2006.5
+2030.9 "Foul Nail" #sync / 1[56]:[^:]*:Shisui Yohi:1F87:/
 
-2041.1 "Foul Nail" #sync / 1[56]:Shisui Yohi:1F87:/
-2048.2 "Foul Nail" #sync / 1[56]:Shisui Yohi:1F87:/
+2041.1 "Foul Nail" #sync / 1[56]:[^:]*:Shisui Yohi:1F87:/
+2048.2 "Foul Nail" #sync / 1[56]:[^:]*:Shisui Yohi:1F87:/
 
 # Phase 2: 90% -> 75%, one (1) thick fog
-2100.0 "--sync--" sync / 14:Shisui Yohi:1F80:/ window 100,0
-2105.0 "Thick Fog" sync / 1[56]:Shisui Yohi:1F80:/
+2100.0 "--sync--" sync / 14:[^:]*:Shisui Yohi:1F80:/ window 100,0
+2105.0 "Thick Fog" sync / 1[56]:[^:]*:Shisui Yohi:1F80:/
 2108.1 "--untargetable--"
-2128.3 "Black Tide" sync / 1[56]:Shisui Yohi:1F81:/ window 30,30
+2128.3 "Black Tide" sync / 1[56]:[^:]*:Shisui Yohi:1F81:/ window 30,30
 2131.3 "--targetable--"
 
-2136.4 "Foul Nail" sync / 1[56]:Shisui Yohi:1F87:/
-2146.5 "Mad Stare" sync / 1[56]:Shisui Yohi:1F82:/
-2153.7 "Foul Nail" sync / 1[56]:Shisui Yohi:1F87:/
-2160.8 "Foul Nail" sync / 1[56]:Shisui Yohi:1F87:/
+2136.4 "Foul Nail" sync / 1[56]:[^:]*:Shisui Yohi:1F87:/
+2146.5 "Mad Stare" sync / 1[56]:[^:]*:Shisui Yohi:1F82:/
+2153.7 "Foul Nail" sync / 1[56]:[^:]*:Shisui Yohi:1F87:/
+2160.8 "Foul Nail" sync / 1[56]:[^:]*:Shisui Yohi:1F87:/
 
-2170.9 "Mad Stare" sync / 1[56]:Shisui Yohi:1F82:/ window 10,10 jump 2146.5
-2178.1 "Foul Nail" #sync / 1[56]:Shisui Yohi:1F87:/
-2185.2 "Foul Nail" #sync / 1[56]:Shisui Yohi:1F87:/
+2170.9 "Mad Stare" sync / 1[56]:[^:]*:Shisui Yohi:1F82:/ window 10,10 jump 2146.5
+2178.1 "Foul Nail" #sync / 1[56]:[^:]*:Shisui Yohi:1F87:/
+2185.2 "Foul Nail" #sync / 1[56]:[^:]*:Shisui Yohi:1F87:/
 
-2195.3 "Mad Stare" #sync / 1[56]:Shisui Yohi:1F82:/
-2202.5 "Foul Nail" #sync / 1[56]:Shisui Yohi:1F87:/
-2209.6 "Foul Nail" #sync / 1[56]:Shisui Yohi:1F87:/
+2195.3 "Mad Stare" #sync / 1[56]:[^:]*:Shisui Yohi:1F82:/
+2202.5 "Foul Nail" #sync / 1[56]:[^:]*:Shisui Yohi:1F87:/
+2209.6 "Foul Nail" #sync / 1[56]:[^:]*:Shisui Yohi:1F87:/
 
 # Phase 3: 75% -> 60%, introduction to adds
 2300.0 "--adds--" sync / 03:........:Naishi-No-Kami:/  window 300,0
-2303.4 "Foul Nail" sync / 1[56]:Shisui Yohi:1F87:/
-2313.5 "Mad Stare" sync / 1[56]:Shisui Yohi:1F82:/
+2303.4 "Foul Nail" sync / 1[56]:[^:]*:Shisui Yohi:1F87:/
+2313.5 "Mad Stare" sync / 1[56]:[^:]*:Shisui Yohi:1F82:/
 
-2320.7 "Foul Nail" sync / 1[56]:Shisui Yohi:1F87:/ window 5,30
-2325.8 "Foul Nail" sync / 1[56]:Shisui Yohi:1F87:/
-2330.9 "Foul Nail" #sync / 1[56]:Shisui Yohi:1F87:/
-2336.0 "Foul Nail" #sync / 1[56]:Shisui Yohi:1F87:/
-2343.1 "Foul Nail" #sync / 1[56]:Shisui Yohi:1F87:/
-2350.2 "Foul Nail" #sync / 1[56]:Shisui Yohi:1F87:/
+2320.7 "Foul Nail" sync / 1[56]:[^:]*:Shisui Yohi:1F87:/ window 5,30
+2325.8 "Foul Nail" sync / 1[56]:[^:]*:Shisui Yohi:1F87:/
+2330.9 "Foul Nail" #sync / 1[56]:[^:]*:Shisui Yohi:1F87:/
+2336.0 "Foul Nail" #sync / 1[56]:[^:]*:Shisui Yohi:1F87:/
+2343.1 "Foul Nail" #sync / 1[56]:[^:]*:Shisui Yohi:1F87:/
+2350.2 "Foul Nail" #sync / 1[56]:[^:]*:Shisui Yohi:1F87:/
 
 # Phase 4: 60% -> 0%, thick fog and adds loop
-2400.0 "--sync--" sync / 14:Shisui Yohi:1F80:/ window 100,0
-2405.0 "Thick Fog" sync / 1[56]:Shisui Yohi:1F80:/
+2400.0 "--sync--" sync / 14:[^:]*:Shisui Yohi:1F80:/ window 100,0
+2405.0 "Thick Fog" sync / 1[56]:[^:]*:Shisui Yohi:1F80:/
 2408.1 "--untargetable--"
-2428.3 "Black Tide" sync / 1[56]:Shisui Yohi:1F81:/
+2428.3 "Black Tide" sync / 1[56]:[^:]*:Shisui Yohi:1F81:/
 2431.3 "--targetable--"
-2435.4 "Foul Nail" sync / 1[56]:Shisui Yohi:1F87:/
-2441.5 "Foul Nail" sync / 1[56]:Shisui Yohi:1F87:/
-2447.7 "Foul Nail" sync / 1[56]:Shisui Yohi:1F87:/
-2457.8 "Mad Stare" sync / 1[56]:Shisui Yohi:1F82:/
+2435.4 "Foul Nail" sync / 1[56]:[^:]*:Shisui Yohi:1F87:/
+2441.5 "Foul Nail" sync / 1[56]:[^:]*:Shisui Yohi:1F87:/
+2447.7 "Foul Nail" sync / 1[56]:[^:]*:Shisui Yohi:1F87:/
+2457.8 "Mad Stare" sync / 1[56]:[^:]*:Shisui Yohi:1F82:/
 2459.3 "--adds--"
 
-2477.0 "Thick Fog" sync / 1[56]:Shisui Yohi:1F80:/ window 30,30 jump 2405
+2477.0 "Thick Fog" sync / 1[56]:[^:]*:Shisui Yohi:1F80:/ window 30,30 jump 2405
 2480.1 "--untargetable--"
-2510.4 "Black Tide" #sync / 1[56]:Shisui Yohi:1F81:/
+2510.4 "Black Tide" #sync / 1[56]:[^:]*:Shisui Yohi:1F81:/
 2513.4 "--targetable--"
-2517.5 "Foul Nail" #sync / 1[56]:Shisui Yohi:1F87:/
-2523.6 "Foul Nail" #sync / 1[56]:Shisui Yohi:1F87:/
-2529.7 "Foul Nail" #sync / 1[56]:Shisui Yohi:1F87:/
-2539.8 "Mad Stare" #sync / 1[56]:Shisui Yohi:1F82:/
+2517.5 "Foul Nail" #sync / 1[56]:[^:]*:Shisui Yohi:1F87:/
+2523.6 "Foul Nail" #sync / 1[56]:[^:]*:Shisui Yohi:1F87:/
+2529.7 "Foul Nail" #sync / 1[56]:[^:]*:Shisui Yohi:1F87:/
+2539.8 "Mad Stare" #sync / 1[56]:[^:]*:Shisui Yohi:1F82:/
 2541.3 "--adds--"

--- a/ui/raidboss/data/04-sb/dungeon/sirensong_sea.txt
+++ b/ui/raidboss/data/04-sb/dungeon/sirensong_sea.txt
@@ -10,26 +10,26 @@ hideall "--sync--"
 # -ii 1F5A
 
 0.0 "Start" sync / 00:0839::Spae Rock will be sealed off/ window 0,1
-18.5 "Amorphous Applause" sync / 1[56]:Lugat:1F56:/
-29.6 "Hydroball" sync / 1[56]:Lugat:1F57:/
+18.5 "Amorphous Applause" sync / 1[56]:[^:]*:Lugat:1F56:/
+29.6 "Hydroball" sync / 1[56]:[^:]*:Lugat:1F57:/
 
-41.4 "Sea Swallows All" sync / 1[56]:Lugat:1F58:/
-47.1 "Concussive Oscillation" sync / 1[56]:Lugat:1F5B:/
-54.0 "Amorphous Applause" sync / 1[56]:Lugat:1F56:/
-70.2 "Amorphous Applause" sync / 1[56]:Lugat:1F56:/
-80.0 "Overtow" sync / 1[56]:Lugat:1F59:/
-87.3 "Hydroball" sync / 1[56]:Lugat:1F57:/
-94.5 "Amorphous Applause" sync / 1[56]:Lugat:1F56:/
-110.7 "Amorphous Applause" sync / 1[56]:Lugat:1F56:/
+41.4 "Sea Swallows All" sync / 1[56]:[^:]*:Lugat:1F58:/
+47.1 "Concussive Oscillation" sync / 1[56]:[^:]*:Lugat:1F5B:/
+54.0 "Amorphous Applause" sync / 1[56]:[^:]*:Lugat:1F56:/
+70.2 "Amorphous Applause" sync / 1[56]:[^:]*:Lugat:1F56:/
+80.0 "Overtow" sync / 1[56]:[^:]*:Lugat:1F59:/
+87.3 "Hydroball" sync / 1[56]:[^:]*:Lugat:1F57:/
+94.5 "Amorphous Applause" sync / 1[56]:[^:]*:Lugat:1F56:/
+110.7 "Amorphous Applause" sync / 1[56]:[^:]*:Lugat:1F56:/
 
-120.2 "Sea Swallows All" sync / 1[56]:Lugat:1F58:/ window 30,30 jump 41.4
-125.9 "Concussive Oscillation" #sync / 1[56]:Lugat:1F5B:/
-132.8 "Amorphous Applause" #sync / 1[56]:Lugat:1F56:/
-149.0 "Amorphous Applause" #sync / 1[56]:Lugat:1F56:/
-158.8 "Overtow" #sync / 1[56]:Lugat:1F59:/
-166.1 "Hydroball" #sync / 1[56]:Lugat:1F57:/
-173.3 "Amorphous Applause" #sync / 1[56]:Lugat:1F56:/
-189.5 "Amorphous Applause" #sync / 1[56]:Lugat:1F56:/
+120.2 "Sea Swallows All" sync / 1[56]:[^:]*:Lugat:1F58:/ window 30,30 jump 41.4
+125.9 "Concussive Oscillation" #sync / 1[56]:[^:]*:Lugat:1F5B:/
+132.8 "Amorphous Applause" #sync / 1[56]:[^:]*:Lugat:1F56:/
+149.0 "Amorphous Applause" #sync / 1[56]:[^:]*:Lugat:1F56:/
+158.8 "Overtow" #sync / 1[56]:[^:]*:Lugat:1F59:/
+166.1 "Hydroball" #sync / 1[56]:[^:]*:Lugat:1F57:/
+173.3 "Amorphous Applause" #sync / 1[56]:[^:]*:Lugat:1F56:/
+189.5 "Amorphous Applause" #sync / 1[56]:[^:]*:Lugat:1F56:/
 
 
 ### The Governor
@@ -37,32 +37,32 @@ hideall "--sync--"
 # -ii 1F5D
 
 1000.0 "Start" sync / 00:0839::Warden's Delight will be sealed off/ window 1000,5
-1017.5 "Shadowflow" sync / 1[56]:The Governor:1F5E:/
-1018.0 "--sync--" sync / 1[56]:The Governor:1F5F:/
-1034.6 "Bloodburst" sync / 1[56]:The Governor:1F5C:/
+1017.5 "Shadowflow" sync / 1[56]:[^:]*:The Governor:1F5E:/
+1018.0 "--sync--" sync / 1[56]:[^:]*:The Governor:1F5F:/
+1034.6 "Bloodburst" sync / 1[56]:[^:]*:The Governor:1F5C:/
 
-1042.8 "Enter Night" sync / 1[56]:The Governor:1F60:/ window 10,10
+1042.8 "Enter Night" sync / 1[56]:[^:]*:The Governor:1F60:/ window 10,10
 # Enter Night can take 12-17 seconds.  There is added delay when the mechanic
 # is failed due to Shadowstrike (1F5D) attacks.
-1055.9 "--sync--" sync / 14:The Governor:1F5C:/ window 10,10
-1059.9 "Bloodburst" sync / 1[56]:The Governor:1F5C:/
+1055.9 "--sync--" sync / 14:[^:]*:The Governor:1F5C:/ window 10,10
+1059.9 "Bloodburst" sync / 1[56]:[^:]*:The Governor:1F5C:/
 # There is potential delay before Shadow Split due to the boss moving to the middle.
-1065.0 "--sync--" sync / 14:The Governor:1F61:/ window 10,10
-1068.0 "Shadow Split" sync / 1[56]:The Governor:1F61:/
-1076.2 "Shadowflow" sync / 1[56]:The Governor:1F5E:/
-1076.7 "--sync--" sync / 1[56]:The Governor:1F5F:/
-1077.1 "Shadowflow" sync / 1[56]:The Groveller:1F62:/
-1093.4 "Bloodburst" sync / 1[56]:The Governor:1F5C:/
+1065.0 "--sync--" sync / 14:[^:]*:The Governor:1F61:/ window 10,10
+1068.0 "Shadow Split" sync / 1[56]:[^:]*:The Governor:1F61:/
+1076.2 "Shadowflow" sync / 1[56]:[^:]*:The Governor:1F5E:/
+1076.7 "--sync--" sync / 1[56]:[^:]*:The Governor:1F5F:/
+1077.1 "Shadowflow" sync / 1[56]:[^:]*:The Groveller:1F62:/
+1093.4 "Bloodburst" sync / 1[56]:[^:]*:The Governor:1F5C:/
 
-1102.6 "Enter Night" sync / 1[56]:The Governor:1F60:/ window 30,30 jump 1042.8
-1115.7 "--sync--" #sync / 14:The Governor:1F5C:/ window 10,10
-1119.7 "Bloodburst" #sync / 1[56]:The Governor:1F5C:/
-1124.8 "--sync--" #sync / 14:The Governor:1F61:/ window 10,10
-1127.8 "Shadow Split" #sync / 1[56]:The Governor:1F61:/
-1136.0 "Shadowflow" #sync / 1[56]:The Governor:1F5E:/
-1136.5 "--sync--" #sync / 1[56]:The Governor:1F5F:/
-1136.9 "Shadowflow" #sync / 1[56]:The Groveller:1F62:/
-1153.2 "Bloodburst" #sync / 1[56]:The Governor:1F5C:/
+1102.6 "Enter Night" sync / 1[56]:[^:]*:The Governor:1F60:/ window 30,30 jump 1042.8
+1115.7 "--sync--" #sync / 14:[^:]*:The Governor:1F5C:/ window 10,10
+1119.7 "Bloodburst" #sync / 1[56]:[^:]*:The Governor:1F5C:/
+1124.8 "--sync--" #sync / 14:[^:]*:The Governor:1F61:/ window 10,10
+1127.8 "Shadow Split" #sync / 1[56]:[^:]*:The Governor:1F61:/
+1136.0 "Shadowflow" #sync / 1[56]:[^:]*:The Governor:1F5E:/
+1136.5 "--sync--" #sync / 1[56]:[^:]*:The Governor:1F5F:/
+1136.9 "Shadowflow" #sync / 1[56]:[^:]*:The Groveller:1F62:/
+1153.2 "Bloodburst" #sync / 1[56]:[^:]*:The Governor:1F5C:/
 
 
 ### Lorelei
@@ -70,38 +70,38 @@ hideall "--sync--"
 # -ii 1F63
 
 2000.0 "Start" sync / 00:0839::Glowering Krautz will be sealed off/ window 2000,5
-2011.5 "Virgin Tears" sync / 1[56]:Lorelei:1F69:/
-2024.7 "Morbid Advance/Morbid Retreat" sync / 1[56]:Lorelei:1F6[56]:/
-2033.9 "Head Butt" sync / 1[56]:Lorelei:1F64:/
+2011.5 "Virgin Tears" sync / 1[56]:[^:]*:Lorelei:1F69:/
+2024.7 "Morbid Advance/Morbid Retreat" sync / 1[56]:[^:]*:Lorelei:1F6[56]:/
+2033.9 "Head Butt" sync / 1[56]:[^:]*:Lorelei:1F64:/
 
-2041.1 "Virgin Tears" sync / 1[56]:Lorelei:1F69:/
-2054.2 "Morbid Advance/Morbid Retreat" sync / 1[56]:Lorelei:1F6[56]:/
-2062.3 "Somber Melody" sync / 1[56]:Lorelei:1F67:/
-2066.0 "Head Butt" sync / 1[56]:Lorelei:1F64:/
+2041.1 "Virgin Tears" sync / 1[56]:[^:]*:Lorelei:1F69:/
+2054.2 "Morbid Advance/Morbid Retreat" sync / 1[56]:[^:]*:Lorelei:1F6[56]:/
+2062.3 "Somber Melody" sync / 1[56]:[^:]*:Lorelei:1F67:/
+2066.0 "Head Butt" sync / 1[56]:[^:]*:Lorelei:1F64:/
 
-2072.2 "Virgin Tears" sync / 1[56]:Lorelei:1F69:/
-2085.4 "Morbid Advance/Morbid Retreat" sync / 1[56]:Lorelei:1F6[56]:/
-2094.6 "Head Butt" sync / 1[56]:Lorelei:1F64:/
+2072.2 "Virgin Tears" sync / 1[56]:[^:]*:Lorelei:1F69:/
+2085.4 "Morbid Advance/Morbid Retreat" sync / 1[56]:[^:]*:Lorelei:1F6[56]:/
+2094.6 "Head Butt" sync / 1[56]:[^:]*:Lorelei:1F64:/
 
-2102.8 "Virgin Tears" sync / 1[56]:Lorelei:1F69:/ window 10,10
-2116.5 "Morbid Advance/Morbid Retreat" sync / 1[56]:Lorelei:1F6[56]:/
-2123.7 "Void Water III" sync / 1[56]:Lorelei:1F68:/
-2129.8 "Somber Melody" sync / 1[56]:Lorelei:1F67:/
-2135.0 "Head Butt" sync / 1[56]:Lorelei:1F64:/
-2143.6 "Void Water III" sync / 1[56]:Lorelei:1F68:/
+2102.8 "Virgin Tears" sync / 1[56]:[^:]*:Lorelei:1F69:/ window 10,10
+2116.5 "Morbid Advance/Morbid Retreat" sync / 1[56]:[^:]*:Lorelei:1F6[56]:/
+2123.7 "Void Water III" sync / 1[56]:[^:]*:Lorelei:1F68:/
+2129.8 "Somber Melody" sync / 1[56]:[^:]*:Lorelei:1F67:/
+2135.0 "Head Butt" sync / 1[56]:[^:]*:Lorelei:1F64:/
+2143.6 "Void Water III" sync / 1[56]:[^:]*:Lorelei:1F68:/
 
 # the first 2x void water section above has a slightly different timing
 # on advance/retreat (0.5s longer?) so extend this out one more loop.
-2155.9 "Virgin Tears" sync / 1[56]:Lorelei:1F69:/ window 10,10
-2169.1 "Morbid Advance/Morbid Retreat" sync / 1[56]:Lorelei:1F6[56]:/
-2176.4 "Void Water III" sync / 1[56]:Lorelei:1F68:/
-2182.5 "Somber Melody" sync / 1[56]:Lorelei:1F67:/
-2187.7 "Head Butt" sync / 1[56]:Lorelei:1F64:/
-2196.3 "Void Water III" sync / 1[56]:Lorelei:1F68:/
+2155.9 "Virgin Tears" sync / 1[56]:[^:]*:Lorelei:1F69:/ window 10,10
+2169.1 "Morbid Advance/Morbid Retreat" sync / 1[56]:[^:]*:Lorelei:1F6[56]:/
+2176.4 "Void Water III" sync / 1[56]:[^:]*:Lorelei:1F68:/
+2182.5 "Somber Melody" sync / 1[56]:[^:]*:Lorelei:1F67:/
+2187.7 "Head Butt" sync / 1[56]:[^:]*:Lorelei:1F64:/
+2196.3 "Void Water III" sync / 1[56]:[^:]*:Lorelei:1F68:/
 
-2208.5 "Virgin Tears" sync / 1[56]:Lorelei:1F69:/ window 30,30 jump 2155.9
-2221.7 "Morbid Advance/Morbid Retreat" #sync / 1[56]:Lorelei:1F6[56]:/
-2229.0 "Void Water III" #sync / 1[56]:Lorelei:1F68:/
-2235.1 "Somber Melody" #sync / 1[56]:Lorelei:1F67:/
-2240.3 "Head Butt" #sync / 1[56]:Lorelei:1F64:/
-2248.9 "Void Water III" #sync / 1[56]:Lorelei:1F68:/
+2208.5 "Virgin Tears" sync / 1[56]:[^:]*:Lorelei:1F69:/ window 30,30 jump 2155.9
+2221.7 "Morbid Advance/Morbid Retreat" #sync / 1[56]:[^:]*:Lorelei:1F6[56]:/
+2229.0 "Void Water III" #sync / 1[56]:[^:]*:Lorelei:1F68:/
+2235.1 "Somber Melody" #sync / 1[56]:[^:]*:Lorelei:1F67:/
+2240.3 "Head Butt" #sync / 1[56]:[^:]*:Lorelei:1F64:/
+2248.9 "Void Water III" #sync / 1[56]:[^:]*:Lorelei:1F68:/

--- a/ui/raidboss/data/04-sb/dungeon/st_mocianne_hard.txt
+++ b/ui/raidboss/data/04-sb/dungeon/st_mocianne_hard.txt
@@ -11,35 +11,35 @@ hideall "--sync--"
 # -ii 2E51 2E4C
 
 0 "Start" sync / 00:0839::Zymology will be sealed off/ window 0,1
-9.7 "Odious Air" sync / 1[56]:Nullchu:2E49:/ window 9.7,5
-21.8 "Vine Whip" sync / 1[56]:Nullchu:2E48:/
-33.9 "--sync--" sync / 1[56]:Nullchu:2E4D:/
-36.9 "Sludge Bomb" sync / 1[56]:Nullchu:2E4E:/
-42.4 "Fault Warren" sync / 1[56]:Nullchu:2E4A:/
+9.7 "Odious Air" sync / 1[56]:[^:]*:Nullchu:2E49:/ window 9.7,5
+21.8 "Vine Whip" sync / 1[56]:[^:]*:Nullchu:2E48:/
+33.9 "--sync--" sync / 1[56]:[^:]*:Nullchu:2E4D:/
+36.9 "Sludge Bomb" sync / 1[56]:[^:]*:Nullchu:2E4E:/
+42.4 "Fault Warren" sync / 1[56]:[^:]*:Nullchu:2E4A:/
 
-53.9 "Devour" sync / 1[56]:Nullchu:2E4F:/ window 53.9,10
-57.8 "Odious Atmosphere" sync / 1[56]:Nullchu:2E50:/ duration 6
-74.3 "Vine Whip" sync / 1[56]:Nullchu:2E48:/
-84.8 "Taproot" sync / 1[56]:Nullchu:2E4B:/
-95.3 "Devour" sync / 1[56]:Nullchu:2E4F:/ window 15,15
-99.2 "Odious Atmosphere" sync / 1[56]:Nullchu:2E50:/ duration 6
-116.7 "Vine Whip" sync / 1[56]:Nullchu:2E48:/
-122.7 "--sync--" sync / 1[56]:Nullchu:2E4D:/
-125.7 "Sludge Bomb" sync / 1[56]:Nullchu:2E4E:/
-130.2 "Devour" sync / 1[56]:Nullchu:2E4F:/ window 15,15
-134.1 "Odious Atmosphere" sync / 1[56]:Nullchu:2E50:/ duration 6
-146.9 "Odious Air" sync / 1[56]:Nullchu:2E49:/
-157.6 "--sync--" sync / 1[56]:Nullchu:2E4D:/
-160.6 "Sludge Bomb" sync / 1[56]:Nullchu:2E4E:/
-166.1 "Fault Warren" sync / 1[56]:Nullchu:2E4A:/ window 30,30
-174.6 "Devour" sync / 1[56]:Nullchu:2E4F:/
-178.3 "Odious Atmosphere" sync / 1[56]:Nullchu:2E50:/ duration 6
-190.8 "Taproot" sync / 1[56]:Nullchu:2E4B:/
-205.9 "--sync--" sync / 1[56]:Nullchu:2E4D:/
-208.9 "Sludge Bomb" sync / 1[56]:Nullchu:2E4E:/
-214.3 "Fault Warren" sync / 1[56]:Nullchu:2E4A:/
+53.9 "Devour" sync / 1[56]:[^:]*:Nullchu:2E4F:/ window 53.9,10
+57.8 "Odious Atmosphere" sync / 1[56]:[^:]*:Nullchu:2E50:/ duration 6
+74.3 "Vine Whip" sync / 1[56]:[^:]*:Nullchu:2E48:/
+84.8 "Taproot" sync / 1[56]:[^:]*:Nullchu:2E4B:/
+95.3 "Devour" sync / 1[56]:[^:]*:Nullchu:2E4F:/ window 15,15
+99.2 "Odious Atmosphere" sync / 1[56]:[^:]*:Nullchu:2E50:/ duration 6
+116.7 "Vine Whip" sync / 1[56]:[^:]*:Nullchu:2E48:/
+122.7 "--sync--" sync / 1[56]:[^:]*:Nullchu:2E4D:/
+125.7 "Sludge Bomb" sync / 1[56]:[^:]*:Nullchu:2E4E:/
+130.2 "Devour" sync / 1[56]:[^:]*:Nullchu:2E4F:/ window 15,15
+134.1 "Odious Atmosphere" sync / 1[56]:[^:]*:Nullchu:2E50:/ duration 6
+146.9 "Odious Air" sync / 1[56]:[^:]*:Nullchu:2E49:/
+157.6 "--sync--" sync / 1[56]:[^:]*:Nullchu:2E4D:/
+160.6 "Sludge Bomb" sync / 1[56]:[^:]*:Nullchu:2E4E:/
+166.1 "Fault Warren" sync / 1[56]:[^:]*:Nullchu:2E4A:/ window 30,30
+174.6 "Devour" sync / 1[56]:[^:]*:Nullchu:2E4F:/
+178.3 "Odious Atmosphere" sync / 1[56]:[^:]*:Nullchu:2E50:/ duration 6
+190.8 "Taproot" sync / 1[56]:[^:]*:Nullchu:2E4B:/
+205.9 "--sync--" sync / 1[56]:[^:]*:Nullchu:2E4D:/
+208.9 "Sludge Bomb" sync / 1[56]:[^:]*:Nullchu:2E4E:/
+214.3 "Fault Warren" sync / 1[56]:[^:]*:Nullchu:2E4A:/
 
-225.8 "Devour" sync / 1[56]:Nullchu:2E4F:/ window 30,30 jump 53.9
+225.8 "Devour" sync / 1[56]:[^:]*:Nullchu:2E4F:/ window 30,30 jump 53.9
 229.7 "Odious Atmosphere"
 246.2 "Vine Whip"
 256.7 "Taproot"
@@ -54,53 +54,53 @@ hideall "--sync--"
 
 
 1000.0 "Start" sync / 00:0839::The Soil Bed will be sealed off/ window 1000,5
-1008.9 "Stone II" sync / 1[56]:Lakhamu:312A:/ window 1008.9,10
-1019.5 "Tectonics" sync / 1[56]:Lakhamu:312C:/
-1039.1 "Landslip" sync / 1[56]:Lakhamu:3132:/
-1041.1 "Rockslide" sync / 1[56]:Silt Golem:3134:/ window 1041.1,10
-1049.2 "Earthquake (inner)" sync / 1[56]:Lakhamu:312E:/
-1051.8 "Earthquake (outer)" sync / 1[56]:Lakhamu:312F:/
-1062.3 "Earth Shaker" sync / 1[56]:Lakhamu:3130:/
-1074.0 "Empty Gaze" sync / 1[56]:Lakhamu:312B:/ window 1074.0,10
-1086.1 "Landslip" sync / 1[56]:Lakhamu:3132:/
-1088.2 "Rockslide" sync / 1[56]:Silt Golem:3134:/
+1008.9 "Stone II" sync / 1[56]:[^:]*:Lakhamu:312A:/ window 1008.9,10
+1019.5 "Tectonics" sync / 1[56]:[^:]*:Lakhamu:312C:/
+1039.1 "Landslip" sync / 1[56]:[^:]*:Lakhamu:3132:/
+1041.1 "Rockslide" sync / 1[56]:[^:]*:Silt Golem:3134:/ window 1041.1,10
+1049.2 "Earthquake (inner)" sync / 1[56]:[^:]*:Lakhamu:312E:/
+1051.8 "Earthquake (outer)" sync / 1[56]:[^:]*:Lakhamu:312F:/
+1062.3 "Earth Shaker" sync / 1[56]:[^:]*:Lakhamu:3130:/
+1074.0 "Empty Gaze" sync / 1[56]:[^:]*:Lakhamu:312B:/ window 1074.0,10
+1086.1 "Landslip" sync / 1[56]:[^:]*:Lakhamu:3132:/
+1088.2 "Rockslide" sync / 1[56]:[^:]*:Silt Golem:3134:/
 
-1091.3 "Earthquake (inner)?" sync / 1[56]:Lakhamu:312E:/ jump 1200
+1091.3 "Earthquake (inner)?" sync / 1[56]:[^:]*:Lakhamu:312E:/ jump 1200
 1093.8 "Earthquake (outer)?"
-1094.8 "Earth Shaker?" sync / 1[56]:Lakhamu:3130:/ jump 1400
+1094.8 "Earth Shaker?" sync / 1[56]:[^:]*:Lakhamu:3130:/ jump 1400
 1110.9 "Tectonics"
 1120.0 "Stone II"
 1132.7 "Empty Gaze"
 1144.8 "Landslip"
 
 
-1200.0 "Earthquake (inner)" sync / 1[56]:Lakhamu:312E:/
-1202.5 "Earthquake (outer)" sync / 1[56]:Lakhamu:312F:/
-1219.6 "Tectonics" sync / 1[56]:Lakhamu:312C:/ window 30,30
-1228.7 "Stone II" sync / 1[56]:Lakhamu:312A:/
-1241.4 "Empty Gaze" sync / 1[56]:Lakhamu:312B:/
-1253.5 "Landslip" sync / 1[56]:Lakhamu:3132:/ window 30,30
-1255.6 "Rockslide" sync / 1[56]:Silt Golem:3134:/
+1200.0 "Earthquake (inner)" sync / 1[56]:[^:]*:Lakhamu:312E:/
+1202.5 "Earthquake (outer)" sync / 1[56]:[^:]*:Lakhamu:312F:/
+1219.6 "Tectonics" sync / 1[56]:[^:]*:Lakhamu:312C:/ window 30,30
+1228.7 "Stone II" sync / 1[56]:[^:]*:Lakhamu:312A:/
+1241.4 "Empty Gaze" sync / 1[56]:[^:]*:Lakhamu:312B:/
+1253.5 "Landslip" sync / 1[56]:[^:]*:Lakhamu:3132:/ window 30,30
+1255.6 "Rockslide" sync / 1[56]:[^:]*:Silt Golem:3134:/
 
-1258.7 "Earthquake (inner)?" sync / 1[56]:Lakhamu:312E:/ jump 1200
+1258.7 "Earthquake (inner)?" sync / 1[56]:[^:]*:Lakhamu:312E:/ jump 1200
 1261.3 "Earthquake (outer)?"
-1261.3 "Earth Shaker?" sync / 1[56]:Lakhamu:3130:/ jump 1400
+1261.3 "Earth Shaker?" sync / 1[56]:[^:]*:Lakhamu:3130:/ jump 1400
 1278.4 "Tectonics"
 1287.4 "Stone II"
 1300.1 "Empty Gaze"
 1312.2 "Landslip"
 
 
-1400.0 "Earth Shaker" sync / 1[56]:Lakhamu:3130:/
-1414.7 "Tectonics" sync / 1[56]:Lakhamu:312C:/ window 30,30
-1423.8 "Stone II" sync / 1[56]:Lakhamu:312A:/
-1436.5 "Empty Gaze" sync / 1[56]:Lakhamu:312B:/
-1448.7 "Landslip" sync / 1[56]:Lakhamu:3132:/ window 30,30
-1450.7 "Rockslide" sync / 1[56]:Silt Golem:3134:/
+1400.0 "Earth Shaker" sync / 1[56]:[^:]*:Lakhamu:3130:/
+1414.7 "Tectonics" sync / 1[56]:[^:]*:Lakhamu:312C:/ window 30,30
+1423.8 "Stone II" sync / 1[56]:[^:]*:Lakhamu:312A:/
+1436.5 "Empty Gaze" sync / 1[56]:[^:]*:Lakhamu:312B:/
+1448.7 "Landslip" sync / 1[56]:[^:]*:Lakhamu:3132:/ window 30,30
+1450.7 "Rockslide" sync / 1[56]:[^:]*:Silt Golem:3134:/
 
-1453.8 "Earthquake (inner)?" sync / 1[56]:Lakhamu:312E:/ jump 1200
+1453.8 "Earthquake (inner)?" sync / 1[56]:[^:]*:Lakhamu:312E:/ jump 1200
 1455.8 "Earthquake (outer)?"
-1455.8 "Earth Shaker?" sync / 1[56]:Lakhamu:3130:/ jump 1400
+1455.8 "Earth Shaker?" sync / 1[56]:[^:]*:Lakhamu:3130:/ jump 1400
 1469.5 "Tectonics"
 1478.6 "Stone II"
 1491.2 "Empty Gaze"
@@ -114,30 +114,30 @@ hideall "--sync--"
 # -ii 3139 321C 33A0
 
 2000.0 "Start" sync / 00:0839::Kingsloam will be sealed off/ window 2000,5
-2008.6 "Mudsling" sync / 1[56]:Tokkapchi:3135:/
-2021.8 "Quickmire" sync / 1[56]:Tokkapchi:3136:/
-2028.8 "Quagmire" sync / 1[56]:Tokkapchi:3138:/
-2042.4 "Quickmire" sync / 1[56]:Tokkapchi:3136:/
-2043.7 "--center--" sync / 1[56]:Tokkapchi:313E:/ window 2043.7,10
-2048.5 "Mud Pie" sync / 1[56]:Tokkapchi:3137:/
-2060.7 "Quickmire" sync / 1[56]:Tokkapchi:3136:/
-2068.7 "Quagmire" sync / 1[56]:Tokkapchi:3138:/
-2084.3 "Quickmire" sync / 1[56]:Tokkapchi:3136:/
-2091.3 "Bog Bequest" sync / 1[56]:Tokkapchi:313B:/ window 2091.3,30
-2098.9 "From Mud" sync / 1[56]:Tokkapchi:313D:/
+2008.6 "Mudsling" sync / 1[56]:[^:]*:Tokkapchi:3135:/
+2021.8 "Quickmire" sync / 1[56]:[^:]*:Tokkapchi:3136:/
+2028.8 "Quagmire" sync / 1[56]:[^:]*:Tokkapchi:3138:/
+2042.4 "Quickmire" sync / 1[56]:[^:]*:Tokkapchi:3136:/
+2043.7 "--center--" sync / 1[56]:[^:]*:Tokkapchi:313E:/ window 2043.7,10
+2048.5 "Mud Pie" sync / 1[56]:[^:]*:Tokkapchi:3137:/
+2060.7 "Quickmire" sync / 1[56]:[^:]*:Tokkapchi:3136:/
+2068.7 "Quagmire" sync / 1[56]:[^:]*:Tokkapchi:3138:/
+2084.3 "Quickmire" sync / 1[56]:[^:]*:Tokkapchi:3136:/
+2091.3 "Bog Bequest" sync / 1[56]:[^:]*:Tokkapchi:313B:/ window 2091.3,30
+2098.9 "From Mud" sync / 1[56]:[^:]*:Tokkapchi:313D:/
 
-2106.3 "--center--" sync / 1[56]:Tokkapchi:313E:/ window 30,30
-2111.1 "Mud Pie" sync / 1[56]:Tokkapchi:3137:/
-2123.2 "Quickmire" sync / 1[56]:Tokkapchi:3136:/
-2133.2 "Quagmire" sync / 1[56]:Tokkapchi:3138:/
-2147.4 "Feculent Flood" sync / 1[56]:Tokkapchi:313C:/ window 30,30
-2157.5 "Quagmire" sync / 1[56]:Tokkapchi:3138:/
-2169.1 "Quickmire" sync / 1[56]:Tokkapchi:3136:/
-2174.1 "Bog Bequest" sync / 1[56]:Tokkapchi:313B:/ window 30,30
-2187.7 "Quickmire" sync / 1[56]:Tokkapchi:3136:/
-2190.7 "Mudsling" sync / 1[56]:Tokkapchi:3135:/
+2106.3 "--center--" sync / 1[56]:[^:]*:Tokkapchi:313E:/ window 30,30
+2111.1 "Mud Pie" sync / 1[56]:[^:]*:Tokkapchi:3137:/
+2123.2 "Quickmire" sync / 1[56]:[^:]*:Tokkapchi:3136:/
+2133.2 "Quagmire" sync / 1[56]:[^:]*:Tokkapchi:3138:/
+2147.4 "Feculent Flood" sync / 1[56]:[^:]*:Tokkapchi:313C:/ window 30,30
+2157.5 "Quagmire" sync / 1[56]:[^:]*:Tokkapchi:3138:/
+2169.1 "Quickmire" sync / 1[56]:[^:]*:Tokkapchi:3136:/
+2174.1 "Bog Bequest" sync / 1[56]:[^:]*:Tokkapchi:313B:/ window 30,30
+2187.7 "Quickmire" sync / 1[56]:[^:]*:Tokkapchi:3136:/
+2190.7 "Mudsling" sync / 1[56]:[^:]*:Tokkapchi:3135:/
 
-2195.0 "--center--" sync / 1[56]:Tokkapchi:313E:/ window 30,30 jump 2106.3
+2195.0 "--center--" sync / 1[56]:[^:]*:Tokkapchi:313E:/ window 30,30 jump 2106.3
 2199.8 "Mud Pie"
 2211.9 "Quickmire"
 2221.9 "Quagmire"

--- a/ui/raidboss/data/04-sb/dungeon/swallows_compass.txt
+++ b/ui/raidboss/data/04-sb/dungeon/swallows_compass.txt
@@ -12,25 +12,25 @@ hideall "--sync--"
 # -ii 2B99
 
 0 "Start" sync / 00:0839::The Heart Of The Dragon will be sealed off/ window 0,1
-11.6 "Clout Of The Tengu" sync / 1[56]:Otengu:2B95:/
-22.5 "Yama-Kagura" sync / 1[56]:Otengu:2B96:/ window 22.5,5
-33.1 "Might Of The Tengu" sync / 1[56]:Otengu:2B94:/
-53.1 "Yama-Kagura" sync / 1[56]:Otengu:2B96:/ window 20,20
-64.2 "Wile Of The Tengu" sync / 1[56]:Otengu:2B97:/
-76.7 "Clout Of The Tengu" sync / 1[56]:Otengu:2B95:/
-85.5 "Flames Of Hate" sync / 1[56]:Tengu Ember:2B98:/ window 85.5,5
-93.1 "Might Of The Tengu" sync / 1[56]:Otengu:2B94:/
-106.1 "Clout Of The Tengu" sync / 1[56]:Otengu:2B95:/
+11.6 "Clout Of The Tengu" sync / 1[56]:[^:]*:Otengu:2B95:/
+22.5 "Yama-Kagura" sync / 1[56]:[^:]*:Otengu:2B96:/ window 22.5,5
+33.1 "Might Of The Tengu" sync / 1[56]:[^:]*:Otengu:2B94:/
+53.1 "Yama-Kagura" sync / 1[56]:[^:]*:Otengu:2B96:/ window 20,20
+64.2 "Wile Of The Tengu" sync / 1[56]:[^:]*:Otengu:2B97:/
+76.7 "Clout Of The Tengu" sync / 1[56]:[^:]*:Otengu:2B95:/
+85.5 "Flames Of Hate" sync / 1[56]:[^:]*:Tengu Ember:2B98:/ window 85.5,5
+93.1 "Might Of The Tengu" sync / 1[56]:[^:]*:Otengu:2B94:/
+106.1 "Clout Of The Tengu" sync / 1[56]:[^:]*:Otengu:2B95:/
 
-125.0 "Yama-Kagura" sync / 1[56]:Otengu:2B96:/ window 30,30
-136.1 "Wile Of The Tengu" sync / 1[56]:Otengu:2B97:/
-148.6 "Clout Of The Tengu" sync / 1[56]:Otengu:2B95:/
-157.4 "Flames Of Hate" sync / 1[56]:Tengu Ember:2B98:/
-164.9 "Might Of The Tengu" sync / 1[56]:Otengu:2B94:/
-177.9 "Clout Of The Tengu" sync / 1[56]:Otengu:2B95:/
-189.8 "Yama-Kagura" sync / 1[56]:Otengu:2B96:/ window 30,10
+125.0 "Yama-Kagura" sync / 1[56]:[^:]*:Otengu:2B96:/ window 30,30
+136.1 "Wile Of The Tengu" sync / 1[56]:[^:]*:Otengu:2B97:/
+148.6 "Clout Of The Tengu" sync / 1[56]:[^:]*:Otengu:2B95:/
+157.4 "Flames Of Hate" sync / 1[56]:[^:]*:Tengu Ember:2B98:/
+164.9 "Might Of The Tengu" sync / 1[56]:[^:]*:Otengu:2B94:/
+177.9 "Clout Of The Tengu" sync / 1[56]:[^:]*:Otengu:2B95:/
+189.8 "Yama-Kagura" sync / 1[56]:[^:]*:Otengu:2B96:/ window 30,10
 
-211.2 "Yama-Kagura" sync / 1[56]:Otengu:2B96:/ jump 125.0
+211.2 "Yama-Kagura" sync / 1[56]:[^:]*:Otengu:2B96:/ jump 125.0
 222.3 "Wile Of The Tengu"
 234.8 "Clout Of The Tengu"
 243.6 "Flames Of Hate"
@@ -42,27 +42,27 @@ hideall "--sync--"
 # -ii 2CD1 2B9B 2B9C 2B9F
 
 1000.0 "Start" sync / 00:0839::The Dragon's Mouth will be sealed off/ window 1000,1
-1011.2 "Greater Palm" sync / 1[56]:Daidarabotchi:2B9[DE]:/ window 11.2,5
-1023.1 "Greater Palm" sync / 1[56]:Daidarabotchi:2B9[DE]:/
-1035.3 "Tributary" sync / 1[56]:Daidarabotchi:2BA0:/ window 35,0
-1035.5 "Mountain Falls" sync / 1[56]:Daidarabotchi:2BA5:/ window 35,5
-1051.4 "Mirage x5" sync / 1[56]:Daidarabotchi:2BA1:/ duration 5
+1011.2 "Greater Palm" sync / 1[56]:[^:]*:Daidarabotchi:2B9[DE]:/ window 11.2,5
+1023.1 "Greater Palm" sync / 1[56]:[^:]*:Daidarabotchi:2B9[DE]:/
+1035.3 "Tributary" sync / 1[56]:[^:]*:Daidarabotchi:2BA0:/ window 35,0
+1035.5 "Mountain Falls" sync / 1[56]:[^:]*:Daidarabotchi:2BA5:/ window 35,5
+1051.4 "Mirage x5" sync / 1[56]:[^:]*:Daidarabotchi:2BA1:/ duration 5
 
-1062.5 "--sync--" sync / 1[56]:Daidarabotchi:2BA3:/ window 62.5,10
-1067.5 "Mythmaker" sync / 1[56]:Daidarabotchi:2BA4:/
-1085.6 "Mountain Falls" sync / 1[56]:Daidarabotchi:2BA5:/
-1091.1 "Greater Palm" sync / 1[56]:Daidarabotchi:2B9[DE]:/ window 30,10
-1104.4 "Tributary" sync / 1[56]:Daidarabotchi:2BA0:/
-1121.4 "Mirage x5" sync / 1[56]:Daidarabotchi:2BA1:/ duration 5
-1131.9 "Greater Palm 1" sync / 1[56]:Daidarabotchi:2B9[DE]:/
-1138.7 "Greater Palm 2" sync / 1[56]:Daidarabotchi:2B9[DE]:/
-1151.9 "Tributary" sync / 1[56]:Daidarabotchi:2BA0:/
-1152.1 "Mountain Falls" sync / 1[56]:Daidarabotchi:2BA5:/ window 30,30
-1164.4 "Greater Palm" sync / 1[56]:Daidarabotchi:2B9[DE]:/
-1181.8 "Mirage x5" sync / 1[56]:Daidarabotchi:2BA1:/ duration 5
-1191.3 "Greater Palm" sync / 1[56]:Daidarabotchi:2B9[DE]:/
+1062.5 "--sync--" sync / 1[56]:[^:]*:Daidarabotchi:2BA3:/ window 62.5,10
+1067.5 "Mythmaker" sync / 1[56]:[^:]*:Daidarabotchi:2BA4:/
+1085.6 "Mountain Falls" sync / 1[56]:[^:]*:Daidarabotchi:2BA5:/
+1091.1 "Greater Palm" sync / 1[56]:[^:]*:Daidarabotchi:2B9[DE]:/ window 30,10
+1104.4 "Tributary" sync / 1[56]:[^:]*:Daidarabotchi:2BA0:/
+1121.4 "Mirage x5" sync / 1[56]:[^:]*:Daidarabotchi:2BA1:/ duration 5
+1131.9 "Greater Palm 1" sync / 1[56]:[^:]*:Daidarabotchi:2B9[DE]:/
+1138.7 "Greater Palm 2" sync / 1[56]:[^:]*:Daidarabotchi:2B9[DE]:/
+1151.9 "Tributary" sync / 1[56]:[^:]*:Daidarabotchi:2BA0:/
+1152.1 "Mountain Falls" sync / 1[56]:[^:]*:Daidarabotchi:2BA5:/ window 30,30
+1164.4 "Greater Palm" sync / 1[56]:[^:]*:Daidarabotchi:2B9[DE]:/
+1181.8 "Mirage x5" sync / 1[56]:[^:]*:Daidarabotchi:2BA1:/ duration 5
+1191.3 "Greater Palm" sync / 1[56]:[^:]*:Daidarabotchi:2B9[DE]:/
 
-1203.7 "--sync--" sync / 1[56]:Daidarabotchi:2BA3:/ window 100,10 jump 1062.5
+1203.7 "--sync--" sync / 1[56]:[^:]*:Daidarabotchi:2BA3:/ window 100,10 jump 1062.5
 1208.7 "Mythmaker"
 1226.8 "Mountain Falls"
 1232.3 "Greater Palm"
@@ -79,48 +79,48 @@ hideall "--sync--"
 # The opening block repeats without interrruption above 50% HP.
 # Note that Dasheng's abilities are not the same as those of the shadows!
 2000.0 "Start" sync / 00:0839::Serenity will be sealed off/ window 2000,5
-2011.8 "The Short End" sync / 1[56]:Qitian Dasheng:2BA6:/ window 11.8,5
-2025.5 "Both Ends" sync / 1[56]:Qitian Dasheng:2BA[89]:/
-2036.1 "Mount Huaguo" sync / 1[56]:Qitian Dasheng:2BAA:/ window 36.1,5
-2052.3 "Both Ends" sync / 1[56]:Qitian Dasheng:2BA[89]:/
-2069.2 "The Long End" sync / 1[56]:Qitian Dasheng:2BA7:/
-2076.3 "Five-Fingered Punishment" sync / 1[56]:Qitian Dasheng:2BAB:/ window 76.3,10
-2084.9 "Both Ends" sync / 1[56]:Qitian Dasheng:2BA[89]:/
+2011.8 "The Short End" sync / 1[56]:[^:]*:Qitian Dasheng:2BA6:/ window 11.8,5
+2025.5 "Both Ends" sync / 1[56]:[^:]*:Qitian Dasheng:2BA[89]:/
+2036.1 "Mount Huaguo" sync / 1[56]:[^:]*:Qitian Dasheng:2BAA:/ window 36.1,5
+2052.3 "Both Ends" sync / 1[56]:[^:]*:Qitian Dasheng:2BA[89]:/
+2069.2 "The Long End" sync / 1[56]:[^:]*:Qitian Dasheng:2BA7:/
+2076.3 "Five-Fingered Punishment" sync / 1[56]:[^:]*:Qitian Dasheng:2BAB:/ window 76.3,10
+2084.9 "Both Ends" sync / 1[56]:[^:]*:Qitian Dasheng:2BA[89]:/
 
-2102.7 "Both Ends" sync / 1[56]:Qitian Dasheng:2BA[89]:/
-2113.3 "Mount Huaguo" sync / 1[56]:Qitian Dasheng:2BAA:/
-2132.6 "Both Ends" sync / 1[56]:Qitian Dasheng:2BA[89]:/
-2143.2 "The Short End" sync / 1[56]:Qitian Dasheng:2BA6:/ window 30,30
+2102.7 "Both Ends" sync / 1[56]:[^:]*:Qitian Dasheng:2BA[89]:/
+2113.3 "Mount Huaguo" sync / 1[56]:[^:]*:Qitian Dasheng:2BAA:/
+2132.6 "Both Ends" sync / 1[56]:[^:]*:Qitian Dasheng:2BA[89]:/
+2143.2 "The Short End" sync / 1[56]:[^:]*:Qitian Dasheng:2BA6:/ window 30,30
 
-2162.2 "Both Ends" sync / 1[56]:Qitian Dasheng:2BA[89]:/ jump 2102.7
+2162.2 "Both Ends" sync / 1[56]:[^:]*:Qitian Dasheng:2BA[89]:/ jump 2102.7
 2172.8 "Mount Huaguo"
 2192.1 "Both Ends"
 2202.7 "The Short End"
 
 # Intermission at <50% HP.
-2300.0 "--sync--" sync / 1[56]:Qitian Dasheng:2CC7:/ window 300,5
-2310.3 "Equal Of Heaven" sync / 1[56]:Qitian Dasheng:2BB4:/
-2324.3 "Equal Of Heaven" sync / 1[56]:Qitian Dasheng:2BB4:/
-2338.3 "Equal Of Heaven" sync / 1[56]:Qitian Dasheng:2BB4:/
-2373.9 "Second Heaven" sync / 1[56]:Qitian Dasheng:2BB1:/ window 73.9,5
+2300.0 "--sync--" sync / 1[56]:[^:]*:Qitian Dasheng:2CC7:/ window 300,5
+2310.3 "Equal Of Heaven" sync / 1[56]:[^:]*:Qitian Dasheng:2BB4:/
+2324.3 "Equal Of Heaven" sync / 1[56]:[^:]*:Qitian Dasheng:2BB4:/
+2338.3 "Equal Of Heaven" sync / 1[56]:[^:]*:Qitian Dasheng:2BB4:/
+2373.9 "Second Heaven" sync / 1[56]:[^:]*:Qitian Dasheng:2BB1:/ window 73.9,5
 
 
 # An interruptible rotation continues to the end.
-2383.9 "Splitting Hairs" sync / 1[56]:Qitian Dasheng:2BB2:/
+2383.9 "Splitting Hairs" sync / 1[56]:[^:]*:Qitian Dasheng:2BB2:/
 
-2392.0 "Equal Of Heaven" sync / 1[56]:Qitian Dasheng:2BB4:/ window 30,15
-2396.0 "Both Ends" sync / 1[56]:Shadow Of The Sage:2BA[EF]:/
-2407.6 "Mount Huaguo" sync / 1[56]:Shadow Of The Sage:2D08:/
-2421.9 "Equal Of Heaven" sync / 1[56]:Qitian Dasheng:2BB4:/
-2424.0 "The Long End" sync / 1[56]:Shadow Of The Sage:2BAD:/ window 30,30
-2435.2 "The Short End" sync / 1[56]:Shadow Of The Sage:2D07:/
-2449.1 "Equal Of Heaven" sync / 1[56]:Qitian Dasheng:2BB4:/
-2451.1 "Five-Fingered Punishment" sync / 1[56]:Shadow Of The Sage:2BB0:/ window 30,30
-2453.1 "Both Ends" sync / 1[56]:Shadow Of The Sage:2BA[EF]:/
-2464.7 "Mount Huaguo" sync / 1[56]:Shadow Of The Sage:2D08:/
-2464.7 "The Short End" sync / 1[56]:Shadow Of The Sage:2D07:/
+2392.0 "Equal Of Heaven" sync / 1[56]:[^:]*:Qitian Dasheng:2BB4:/ window 30,15
+2396.0 "Both Ends" sync / 1[56]:[^:]*:Shadow Of The Sage:2BA[EF]:/
+2407.6 "Mount Huaguo" sync / 1[56]:[^:]*:Shadow Of The Sage:2D08:/
+2421.9 "Equal Of Heaven" sync / 1[56]:[^:]*:Qitian Dasheng:2BB4:/
+2424.0 "The Long End" sync / 1[56]:[^:]*:Shadow Of The Sage:2BAD:/ window 30,30
+2435.2 "The Short End" sync / 1[56]:[^:]*:Shadow Of The Sage:2D07:/
+2449.1 "Equal Of Heaven" sync / 1[56]:[^:]*:Qitian Dasheng:2BB4:/
+2451.1 "Five-Fingered Punishment" sync / 1[56]:[^:]*:Shadow Of The Sage:2BB0:/ window 30,30
+2453.1 "Both Ends" sync / 1[56]:[^:]*:Shadow Of The Sage:2BA[EF]:/
+2464.7 "Mount Huaguo" sync / 1[56]:[^:]*:Shadow Of The Sage:2D08:/
+2464.7 "The Short End" sync / 1[56]:[^:]*:Shadow Of The Sage:2D07:/
 
-2479.0 "Equal Of Heaven" sync / 1[56]:Qitian Dasheng:2BB4:/ window 15,15 jump 2392.0
+2479.0 "Equal Of Heaven" sync / 1[56]:[^:]*:Qitian Dasheng:2BB4:/ window 15,15 jump 2392.0
 2483.0 "Both Ends"
 2494.6 "Mount Huaguo"
 2508.9 "Equal Of Heaven"
@@ -136,9 +136,9 @@ hideall "--sync--"
 
 # This is a safe sync. The usage immediately after the intermission is 2BB2 from Dasheng.
 #
-2590.3 "--sync--" sync / 14:Shadow Of The Sage:2BB3:/ window 2590.3,10
-2600.0 "Splitting Hairs" sync / 1[56]:Shadow Of The Sage:2BB3:/ window 2600,5
-2608.0 "Equal Of Heaven" sync / 1[56]:Qitian Dasheng:2BB4:/
-2610.0 "Five-Fingered Punishment?" sync / 1[56]:Shadow Of The Sage:2BB0:/ jump 2451.1
-2610.0 "The Long End?" sync / 1[56]:Shadow Of The Sage:2BAD:/ jump 2424.0
-2612.0 "Both Ends?" sync / 1[56]:Shadow Of The Sage:2BA[EF]:/ jump 2396.0
+2590.3 "--sync--" sync / 14:[^:]*:Shadow Of The Sage:2BB3:/ window 2590.3,10
+2600.0 "Splitting Hairs" sync / 1[56]:[^:]*:Shadow Of The Sage:2BB3:/ window 2600,5
+2608.0 "Equal Of Heaven" sync / 1[56]:[^:]*:Qitian Dasheng:2BB4:/
+2610.0 "Five-Fingered Punishment?" sync / 1[56]:[^:]*:Shadow Of The Sage:2BB0:/ jump 2451.1
+2610.0 "The Long End?" sync / 1[56]:[^:]*:Shadow Of The Sage:2BAD:/ jump 2424.0
+2612.0 "Both Ends?" sync / 1[56]:[^:]*:Shadow Of The Sage:2BA[EF]:/ jump 2396.0

--- a/ui/raidboss/data/04-sb/dungeon/temple_of_the_fist.txt
+++ b/ui/raidboss/data/04-sb/dungeon/temple_of_the_fist.txt
@@ -7,21 +7,21 @@ hideall "--sync--"
 # -ii 1FD2 1FD8
 
 0.0 "--sync--" sync / 00:0839::Tourmaline Pond will be sealed off/
-3.3 "--sync--" sync / 1[56]:Coeurl Sruti:366:/ window 3,1
-6.4 "Pounce" sync / 1[56]:Coeurl Sruti:1FD1:/
-17.8 "Radial Blaster" sync / 1[56]:Coeurl Sruti:1FD3:/
-22.0 "Pounce" sync / 1[56]:Coeurl Sruti:1FD1:/
+3.3 "--sync--" sync / 1[56]:[^:]*:Coeurl Sruti:366:/ window 3,1
+6.4 "Pounce" sync / 1[56]:[^:]*:Coeurl Sruti:1FD1:/
+17.8 "Radial Blaster" sync / 1[56]:[^:]*:Coeurl Sruti:1FD3:/
+22.0 "Pounce" sync / 1[56]:[^:]*:Coeurl Sruti:1FD1:/
 
 38.5 "--Smriti Appears--" sync / 03:........:Coeurl Smriti:/  window 10,10
-46.5 "Wide Blaster" sync / 1[56]:Coeurl Smriti:1FD4:/ window 15,15
-46.5 "Radial Blaster" sync / 1[56]:Coeurl Sruti:1FD3:/
-52.6 "Pounce x2" sync / 1[56]:Coeurl Smriti:1FD1:/
-60.7 "Pounce x2" sync / 1[56]:Coeurl Smriti:1FD1:/
+46.5 "Wide Blaster" sync / 1[56]:[^:]*:Coeurl Smriti:1FD4:/ window 15,15
+46.5 "Radial Blaster" sync / 1[56]:[^:]*:Coeurl Sruti:1FD3:/
+52.6 "Pounce x2" sync / 1[56]:[^:]*:Coeurl Smriti:1FD1:/
+60.7 "Pounce x2" sync / 1[56]:[^:]*:Coeurl Smriti:1FD1:/
 
-72.3 "Wide Blaster" sync / 1[56]:Coeurl Smriti:1FD4:/ window 15,15
-72.3 "Radial Blaster" sync / 1[56]:Coeurl Sruti:1FD3:/
-78.4 "Pounce x2" sync / 1[56]:Coeurl Smriti:1FD1:/
-86.5 "Pounce x2" sync / 1[56]:Coeurl Smriti:1FD1:/ jump 60.7
+72.3 "Wide Blaster" sync / 1[56]:[^:]*:Coeurl Smriti:1FD4:/ window 15,15
+72.3 "Radial Blaster" sync / 1[56]:[^:]*:Coeurl Sruti:1FD3:/
+78.4 "Pounce x2" sync / 1[56]:[^:]*:Coeurl Smriti:1FD1:/
+86.5 "Pounce x2" sync / 1[56]:[^:]*:Coeurl Smriti:1FD1:/ jump 60.7
 
 98.1 "Wide Blaster"
 98.1 "Radial Blaster"
@@ -31,19 +31,19 @@ hideall "--sync--"
 123.9 "Radial Blaster"
 
 # Phase change after one dies
-150.0 "Basic Instinct" sync / 1[56]:(Coeurl Sruti|Coeurl Smriti):1FD5:/ window 150,10
+150.0 "Basic Instinct" sync / 1[56]:[^:]*:(Coeurl Sruti|Coeurl Smriti):1FD5:/ window 150,10
 
-156.2 "Electric Burst" sync / 1[56]:(Coeurl Sruti|Coeurl Smriti):1FD6:/
-160.3 "Pounce" sync / 1[56]:(Coeurl Sruti|Coeurl Smriti):1FD1:/
-167.8 "Heat Lightning" sync / 1[56]:Coeurl Sruti:1FD7:/
-175.2 "Radial/Wide Blaster" sync / 1[56]:(Coeurl Sruti|Coeurl Smriti):1FD[34]:/
-180.4 "Pounce" sync / 1[56]:(Coeurl Sruti|Coeurl Smriti):1FD1:/
+156.2 "Electric Burst" sync / 1[56]:[^:]*:(Coeurl Sruti|Coeurl Smriti):1FD6:/
+160.3 "Pounce" sync / 1[56]:[^:]*:(Coeurl Sruti|Coeurl Smriti):1FD1:/
+167.8 "Heat Lightning" sync / 1[56]:[^:]*:Coeurl Sruti:1FD7:/
+175.2 "Radial/Wide Blaster" sync / 1[56]:[^:]*:(Coeurl Sruti|Coeurl Smriti):1FD[34]:/
+180.4 "Pounce" sync / 1[56]:[^:]*:(Coeurl Sruti|Coeurl Smriti):1FD1:/
 
-191.6 "Electric Burst" sync / 1[56]:(Coeurl Sruti|Coeurl Smriti):1FD6:/ window 20,20
-195.7 "Pounce" sync / 1[56]:(Coeurl Sruti|Coeurl Smriti):1FD1:/
-203.2 "Heat Lightning" sync / 1[56]:(Coeurl Sruti|Coeurl Smriti):1FD7:/
-210.6 "Radial/Wide Blaster" sync / 1[56]:(Coeurl Sruti|Coeurl Smriti):1FD[34]:/
-215.8 "Pounce" sync / 1[56]:(Coeurl Sruti|Coeurl Smriti):1FD1:/ jump 180.4
+191.6 "Electric Burst" sync / 1[56]:[^:]*:(Coeurl Sruti|Coeurl Smriti):1FD6:/ window 20,20
+195.7 "Pounce" sync / 1[56]:[^:]*:(Coeurl Sruti|Coeurl Smriti):1FD1:/
+203.2 "Heat Lightning" sync / 1[56]:[^:]*:(Coeurl Sruti|Coeurl Smriti):1FD7:/
+210.6 "Radial/Wide Blaster" sync / 1[56]:[^:]*:(Coeurl Sruti|Coeurl Smriti):1FD[34]:/
+215.8 "Pounce" sync / 1[56]:[^:]*:(Coeurl Sruti|Coeurl Smriti):1FD1:/ jump 180.4
 
 227.0 "Electric Burst"
 231.1 "Pounce"
@@ -55,33 +55,33 @@ hideall "--sync--"
 # Arbuda
 
 1000.0 "--sync--" sync / 00:0839::Harmony will be sealed off/ window 1000,10
-1001.5 "--sync--" sync / 1[56]:Arbuda:366:/ window 2,1
-1006.5 "Cardinal Shift" sync / 1[56]:Arbuda:1FDA:/
-1014.6 "Fourfold Shear" sync / 1[56]:Arbuda:1FD9:/
-1022.6 "Front/Back?Sides?" sync / 1[56]:Arbuda:1FD[BC]:/
-1026.7 "Cardinal Shift" sync / 1[56]:Arbuda:1FDA:/
-1033.8 "Killer Instinct" sync / 1[56]:Arbuda:1FDE:/
-1046.8 "Front/Back?Sides?" sync / 1[56]:Arbuda:1FD[BC]:/
-1055.0 "Fourfold Shear" sync / 1[56]:Arbuda:1FD9:/
-1064.9 "Hellseal" sync / 1[56]:Arbuda:1FE1:/
-1071.5 "Front/Back?Sides?" sync / 1[56]:Arbuda:1FD[BC]:/
-1075.6 "Cardinal Shift" sync / 1[56]:Arbuda:1FDA:/
-1079.7 "Cardinal Shift" sync / 1[56]:Arbuda:1FDA:/
-1088.9 "Tapas" sync / 1[56]:Arbuda:1FE3:/
+1001.5 "--sync--" sync / 1[56]:[^:]*:Arbuda:366:/ window 2,1
+1006.5 "Cardinal Shift" sync / 1[56]:[^:]*:Arbuda:1FDA:/
+1014.6 "Fourfold Shear" sync / 1[56]:[^:]*:Arbuda:1FD9:/
+1022.6 "Front/Back?Sides?" sync / 1[56]:[^:]*:Arbuda:1FD[BC]:/
+1026.7 "Cardinal Shift" sync / 1[56]:[^:]*:Arbuda:1FDA:/
+1033.8 "Killer Instinct" sync / 1[56]:[^:]*:Arbuda:1FDE:/
+1046.8 "Front/Back?Sides?" sync / 1[56]:[^:]*:Arbuda:1FD[BC]:/
+1055.0 "Fourfold Shear" sync / 1[56]:[^:]*:Arbuda:1FD9:/
+1064.9 "Hellseal" sync / 1[56]:[^:]*:Arbuda:1FE1:/
+1071.5 "Front/Back?Sides?" sync / 1[56]:[^:]*:Arbuda:1FD[BC]:/
+1075.6 "Cardinal Shift" sync / 1[56]:[^:]*:Arbuda:1FDA:/
+1079.7 "Cardinal Shift" sync / 1[56]:[^:]*:Arbuda:1FDA:/
+1088.9 "Tapas" sync / 1[56]:[^:]*:Arbuda:1FE3:/
 
-1094.9 "Front/Back?Sides?" sync / 1[56]:Arbuda:1FD[BC]:/
-1099.0 "Cardinal Shift" sync / 1[56]:Arbuda:1FDA:/
-1107.2 "Fourfold Shear" sync / 1[56]:Arbuda:1FD9:/
-1115.2 "Front/Back?Sides?" sync / 1[56]:Arbuda:1FD[BC]:/
-1119.3 "Cardinal Shift" sync / 1[56]:Arbuda:1FDA:/
-1126.4 "Killer Instinct" sync / 1[56]:Arbuda:1FDE:/
-1139.4 "Front/Back?Sides?" sync / 1[56]:Arbuda:1FD[BC]:/
-1147.7 "Fourfold Shear" sync / 1[56]:Arbuda:1FD9:/
-1157.4 "Hellseal" sync / 1[56]:Arbuda:1FE1:/
-1163.5 "Front/Back?Sides?" sync / 1[56]:Arbuda:1FD[BC]:/
-1167.6 "Cardinal Shift" sync / 1[56]:Arbuda:1FDA:/
-1171.7 "Cardinal Shift" sync / 1[56]:Arbuda:1FDA:/
-1180.9 "Tapas" sync / 1[56]:Arbuda:1FE3:/
+1094.9 "Front/Back?Sides?" sync / 1[56]:[^:]*:Arbuda:1FD[BC]:/
+1099.0 "Cardinal Shift" sync / 1[56]:[^:]*:Arbuda:1FDA:/
+1107.2 "Fourfold Shear" sync / 1[56]:[^:]*:Arbuda:1FD9:/
+1115.2 "Front/Back?Sides?" sync / 1[56]:[^:]*:Arbuda:1FD[BC]:/
+1119.3 "Cardinal Shift" sync / 1[56]:[^:]*:Arbuda:1FDA:/
+1126.4 "Killer Instinct" sync / 1[56]:[^:]*:Arbuda:1FDE:/
+1139.4 "Front/Back?Sides?" sync / 1[56]:[^:]*:Arbuda:1FD[BC]:/
+1147.7 "Fourfold Shear" sync / 1[56]:[^:]*:Arbuda:1FD9:/
+1157.4 "Hellseal" sync / 1[56]:[^:]*:Arbuda:1FE1:/
+1163.5 "Front/Back?Sides?" sync / 1[56]:[^:]*:Arbuda:1FD[BC]:/
+1167.6 "Cardinal Shift" sync / 1[56]:[^:]*:Arbuda:1FDA:/
+1171.7 "Cardinal Shift" sync / 1[56]:[^:]*:Arbuda:1FDA:/
+1180.9 "Tapas" sync / 1[56]:[^:]*:Arbuda:1FE3:/
 
 1186.9 "Front/Back?Sides?"
 1191.0 "Cardinal Shift"
@@ -94,41 +94,41 @@ hideall "--sync--"
 # -ii 1FF0 1FE8 1FEC
 
 2000.0 "--sync--" sync / 00:0839::Guidance will be sealed off/ window 2000,10
-2010.9 "Spirit Wave" sync / 1[56]:Ivon Coeurlfist:1FE7:/
-2018.6 "Hurricane Kick" sync / 1[56]:Ivon Coeurlfist:1FE5:/
-2026.7 "Touch of Slaughter" sync / 1[56]:Ivon Coeurlfist:1FE6:/
-2030.9 "Coeurl Whisper" sync / 1[56]:Ivon Coeurlfist:1FE9:/
-2042.0 "Silent Roar" sync / 1[56]:Ivon Coeurlfist:1FEB:/
-2062.0 "Rhalgr's Piece" sync / 1[56]:Ivon Coeurlfist:1FED:/
-2069.1 "The Rose Of Destruction" sync / 1[56]:Ivon Coeurlfist:1FEE:/ window 20,20
-2073.7 "Hurricane Kick" sync / 1[56]:Ivon Coeurlfist:1FE5:/
+2010.9 "Spirit Wave" sync / 1[56]:[^:]*:Ivon Coeurlfist:1FE7:/
+2018.6 "Hurricane Kick" sync / 1[56]:[^:]*:Ivon Coeurlfist:1FE5:/
+2026.7 "Touch of Slaughter" sync / 1[56]:[^:]*:Ivon Coeurlfist:1FE6:/
+2030.9 "Coeurl Whisper" sync / 1[56]:[^:]*:Ivon Coeurlfist:1FE9:/
+2042.0 "Silent Roar" sync / 1[56]:[^:]*:Ivon Coeurlfist:1FEB:/
+2062.0 "Rhalgr's Piece" sync / 1[56]:[^:]*:Ivon Coeurlfist:1FED:/
+2069.1 "The Rose Of Destruction" sync / 1[56]:[^:]*:Ivon Coeurlfist:1FEE:/ window 20,20
+2073.7 "Hurricane Kick" sync / 1[56]:[^:]*:Ivon Coeurlfist:1FE5:/
 
 # Intermission happens here naturally, or at HP < 50%
-2086.1 "--sync--" sync / 1[56]:Ivon Coeurlfist:1FEC:/ window 80,5
-2106.2 "Furious Fists" sync / 1[56]:Ivon Coeurlfist:1FEF:/
-2114.6 "Impact" sync / 1[56]:Ivon Coeurlfist:1FF1:/ window 120,20
+2086.1 "--sync--" sync / 1[56]:[^:]*:Ivon Coeurlfist:1FEC:/ window 80,5
+2106.2 "Furious Fists" sync / 1[56]:[^:]*:Ivon Coeurlfist:1FEF:/
+2114.6 "Impact" sync / 1[56]:[^:]*:Ivon Coeurlfist:1FF1:/ window 120,20
 
-2125.3 "Spirit Wave" sync / 1[56]:Ivon Coeurlfist:1FE7:/
-2127.5 "Coeurl Whisper" sync / 1[56]:Ivon Coeurlfist:1FE9:/
-2137.4 "Rhalgr's Piece" sync / 1[56]:Ivon Coeurlfist:1FED:/
-2142.8 "Silent Roar" sync / 1[56]:Ivon Coeurlfist:1FEB:/
-2156.9 "Touch of Slaughter" sync / 1[56]:Ivon Coeurlfist:1FE6:/ window 30,30
-2161.6 "Hurricane Kick" sync / 1[56]:Ivon Coeurlfist:1FE5:/
-2175.8 "Spirit Wave" sync / 1[56]:Ivon Coeurlfist:1FE7:/
-2178.0 "Coeurl Whisper" sync / 1[56]:Ivon Coeurlfist:1FE9:/
-2187.2 "The Rose Of Destruction" sync / 1[56]:Ivon Coeurlfist:1FEE:/
-2192.3 "Silent Roar" sync / 1[56]:Ivon Coeurlfist:1FEB:/
+2125.3 "Spirit Wave" sync / 1[56]:[^:]*:Ivon Coeurlfist:1FE7:/
+2127.5 "Coeurl Whisper" sync / 1[56]:[^:]*:Ivon Coeurlfist:1FE9:/
+2137.4 "Rhalgr's Piece" sync / 1[56]:[^:]*:Ivon Coeurlfist:1FED:/
+2142.8 "Silent Roar" sync / 1[56]:[^:]*:Ivon Coeurlfist:1FEB:/
+2156.9 "Touch of Slaughter" sync / 1[56]:[^:]*:Ivon Coeurlfist:1FE6:/ window 30,30
+2161.6 "Hurricane Kick" sync / 1[56]:[^:]*:Ivon Coeurlfist:1FE5:/
+2175.8 "Spirit Wave" sync / 1[56]:[^:]*:Ivon Coeurlfist:1FE7:/
+2178.0 "Coeurl Whisper" sync / 1[56]:[^:]*:Ivon Coeurlfist:1FE9:/
+2187.2 "The Rose Of Destruction" sync / 1[56]:[^:]*:Ivon Coeurlfist:1FEE:/
+2192.3 "Silent Roar" sync / 1[56]:[^:]*:Ivon Coeurlfist:1FEB:/
 
-2210.5 "Spirit Wave" sync / 1[56]:Ivon Coeurlfist:1FE7:/ window 30,30
-2212.7 "Coeurl Whisper" sync / 1[56]:Ivon Coeurlfist:1FE9:/
-2222.6 "Rhalgr's Piece" sync / 1[56]:Ivon Coeurlfist:1FED:/
-2228.0 "Silent Roar" sync / 1[56]:Ivon Coeurlfist:1FEB:/
-2242.1 "Touch of Slaughter" sync / 1[56]:Ivon Coeurlfist:1FE6:/ window 30,30
-2246.8 "Hurricane Kick" sync / 1[56]:Ivon Coeurlfist:1FE5:/
-2261.0 "Spirit Wave" sync / 1[56]:Ivon Coeurlfist:1FE7:/
-2263.2 "Coeurl Whisper" sync / 1[56]:Ivon Coeurlfist:1FE9:/
-2272.4 "The Rose Of Destruction" sync / 1[56]:Ivon Coeurlfist:1FEE:/
-2277.5 "Silent Roar" sync / 1[56]:Ivon Coeurlfist:1FEB:/ jump 2192.3
+2210.5 "Spirit Wave" sync / 1[56]:[^:]*:Ivon Coeurlfist:1FE7:/ window 30,30
+2212.7 "Coeurl Whisper" sync / 1[56]:[^:]*:Ivon Coeurlfist:1FE9:/
+2222.6 "Rhalgr's Piece" sync / 1[56]:[^:]*:Ivon Coeurlfist:1FED:/
+2228.0 "Silent Roar" sync / 1[56]:[^:]*:Ivon Coeurlfist:1FEB:/
+2242.1 "Touch of Slaughter" sync / 1[56]:[^:]*:Ivon Coeurlfist:1FE6:/ window 30,30
+2246.8 "Hurricane Kick" sync / 1[56]:[^:]*:Ivon Coeurlfist:1FE5:/
+2261.0 "Spirit Wave" sync / 1[56]:[^:]*:Ivon Coeurlfist:1FE7:/
+2263.2 "Coeurl Whisper" sync / 1[56]:[^:]*:Ivon Coeurlfist:1FE9:/
+2272.4 "The Rose Of Destruction" sync / 1[56]:[^:]*:Ivon Coeurlfist:1FEE:/
+2277.5 "Silent Roar" sync / 1[56]:[^:]*:Ivon Coeurlfist:1FEB:/ jump 2192.3
 
 2295.7 "Spirit Wave"
 2297.9 "Coeurl Whisper"

--- a/ui/raidboss/data/04-sb/dungeon/the_burn.txt
+++ b/ui/raidboss/data/04-sb/dungeon/the_burn.txt
@@ -13,23 +13,23 @@ hideall "--sync--"
 # -ii 3198 3199
 
 0 "Start" sync / 00:0839::The Scorpion's Den will be sealed off/ window 0,1
-10.4 "Crystal Needle" sync / 1[56]:Hedetet:3193:/
-25.8 "Hailfire" sync / 1[56]:Hedetet:3194:/ window 25,30
-29.8 "Resonant Frequency" sync / 1[56]:Dim Crystal:3198:/
-39.8 "Shardstrike" sync / 1[56]:Hedetet:3195:/
-53.9 "Shardfall" sync / 1[56]:Hedetet:3191:/
-62.0 "Dissonance" sync / 1[56]:Hedetet:3192:/ window 30,30
-69.1 "Crystalline Fracture" sync / 1[56]:Dim Crystal:3197:/
+10.4 "Crystal Needle" sync / 1[56]:[^:]*:Hedetet:3193:/
+25.8 "Hailfire" sync / 1[56]:[^:]*:Hedetet:3194:/ window 25,30
+29.8 "Resonant Frequency" sync / 1[56]:[^:]*:Dim Crystal:3198:/
+39.8 "Shardstrike" sync / 1[56]:[^:]*:Hedetet:3195:/
+53.9 "Shardfall" sync / 1[56]:[^:]*:Hedetet:3191:/
+62.0 "Dissonance" sync / 1[56]:[^:]*:Hedetet:3192:/ window 30,30
+69.1 "Crystalline Fracture" sync / 1[56]:[^:]*:Dim Crystal:3197:/
 
-74.2 "Crystal Needle" sync / 1[56]:Hedetet:3193:/ window 20,20
-83.4 "--jump--" sync / 1[56]:Hedetet:3196:/
-92.8 "Hailfire" sync / 1[56]:Hedetet:3194:/ window 30,30
-103.9 "Shardstrike" sync / 1[56]:Hedetet:3195:/
-118.1 "Shardfall" sync / 1[56]:Hedetet:3191:/
-126.1 "Dissonance" sync / 1[56]:Hedetet:3192:/ window 30,30
-133.2 "Crystalline Fracture" sync / 1[56]:Dim Crystal:3197:/
+74.2 "Crystal Needle" sync / 1[56]:[^:]*:Hedetet:3193:/ window 20,20
+83.4 "--jump--" sync / 1[56]:[^:]*:Hedetet:3196:/
+92.8 "Hailfire" sync / 1[56]:[^:]*:Hedetet:3194:/ window 30,30
+103.9 "Shardstrike" sync / 1[56]:[^:]*:Hedetet:3195:/
+118.1 "Shardfall" sync / 1[56]:[^:]*:Hedetet:3191:/
+126.1 "Dissonance" sync / 1[56]:[^:]*:Hedetet:3192:/ window 30,30
+133.2 "Crystalline Fracture" sync / 1[56]:[^:]*:Dim Crystal:3197:/
 
-138.3 "Crystal Needle" sync / 1[56]:Hedetet:3193:/ window 20,20 jump 74.2
+138.3 "Crystal Needle" sync / 1[56]:[^:]*:Hedetet:3193:/ window 20,20 jump 74.2
 147.5 "--jump--"
 156.9 "Hailfire"
 168.0 "Shardstrike"
@@ -42,23 +42,23 @@ hideall "--sync--"
 # -ii 2D76 2D77 34D5 34D6 34D9
 
 1000.0 "Start" sync / 00:0839::The Gamma Segregate will be sealed off/ window 1000,5
-1012.7 "Aetherochemical Flame" sync / 1[56]:Defective Drone:2D73:/
-1026.7 "Aetherochemical Residue" sync / 1[56]:Defective Drone:2D74:/
+1012.7 "Aetherochemical Flame" sync / 1[56]:[^:]*:Defective Drone:2D73:/
+1026.7 "Aetherochemical Residue" sync / 1[56]:[^:]*:Defective Drone:2D74:/
 1030.9 "--untargetable--"
-1039.1 "Full Throttle" sync / 1[56]:Defective Drone:2D75:/ window 39,30
+1039.1 "Full Throttle" sync / 1[56]:[^:]*:Defective Drone:2D75:/ window 39,30
 1042.2 "--targetable--"
 
-1059.3 "Aetherochemical Coil" sync / 1[56]:Defective Drone:2D72:/ window 30,15
-1074.5 "Adit Driver" # sync / 1[56]:Rock Biter:2D78:/
-1080.4 "Aetherochemical Flame" sync / 1[56]:Defective Drone:2D73:/
-1094.5 "Aetherochemical Coil" sync / 1[56]:Defective Drone:2D72:/
-1111.7 "Aetherochemical Residue" sync / 1[56]:Defective Drone:2D74:/
+1059.3 "Aetherochemical Coil" sync / 1[56]:[^:]*:Defective Drone:2D72:/ window 30,15
+1074.5 "Adit Driver" # sync / 1[56]:[^:]*:Rock Biter:2D78:/
+1080.4 "Aetherochemical Flame" sync / 1[56]:[^:]*:Defective Drone:2D73:/
+1094.5 "Aetherochemical Coil" sync / 1[56]:[^:]*:Defective Drone:2D72:/
+1111.7 "Aetherochemical Residue" sync / 1[56]:[^:]*:Defective Drone:2D74:/
 1115.6 "--untargetable--"
-1123.8 "Full Throttle" sync / 1[56]:Defective Drone:2D75:/ window 30,30
-1123.8 "Adit Driver" # sync / 1[56]:Rock Biter:2D78:/
+1123.8 "Full Throttle" sync / 1[56]:[^:]*:Defective Drone:2D75:/ window 30,30
+1123.8 "Adit Driver" # sync / 1[56]:[^:]*:Rock Biter:2D78:/
 1126.9 "--targetable--"
 
-1144.0 "Aetherochemical Coil" sync / 1[56]:Defective Drone:2D72:/ window 30,15 jump 1059.3
+1144.0 "Aetherochemical Coil" sync / 1[56]:[^:]*:Defective Drone:2D72:/ window 30,15 jump 1059.3
 1159.2 "Adit Driver"
 1165.1 "Aetherochemical Flame"
 1179.2 "Aetherochemical Coil"
@@ -70,42 +70,42 @@ hideall "--sync--"
 # -ii 3142 3145 3146 3149
 
 2000.0 "Start" sync / 00:0839::The Aspersory will be sealed off/ window 2000,5
-2013.2 "Rime Wreath" sync / 1[56]:Mist Dragon:314B:/
-2021.4 "Frost Breath" sync / 1[56]:Mist Dragon:314C:/
-2030.7 "Fog Plume" sync / 1[56]:Mist Dragon:3144:/
-2050.9 "Rime Wreath" sync / 1[56]:Mist Dragon:314B:/
+2013.2 "Rime Wreath" sync / 1[56]:[^:]*:Mist Dragon:314B:/
+2021.4 "Frost Breath" sync / 1[56]:[^:]*:Mist Dragon:314C:/
+2030.7 "Fog Plume" sync / 1[56]:[^:]*:Mist Dragon:3144:/
+2050.9 "Rime Wreath" sync / 1[56]:[^:]*:Mist Dragon:314B:/
 
 
-2061.9 "Vaporize" sync / 1[56]:Mist Dragon:3140:/ window 62,30
+2061.9 "Vaporize" sync / 1[56]:[^:]*:Mist Dragon:3140:/ window 62,30
 2064.1 "--untargetable--"
 2073.1 "--targetable--"
-2093.1 "Cold Fog" sync / 1[56]:Mist Dragon:3141:/
-2104.4 "Chilling Aspiration" sync / 1[56]:Mist Dragon:314D:/
-2111.6 "Frost Breath" sync / 1[56]:Mist Dragon:314C:/
-2119.7 "Fog Plume" sync / 1[56]:Mist Dragon:3144:/
-2137.9 "Rime Wreath" sync / 1[56]:Mist Dragon:314B:/
-2152.2 "Deep Fog" sync / 1[56]:Mist Dragon:3147:/ window 150,30
+2093.1 "Cold Fog" sync / 1[56]:[^:]*:Mist Dragon:3141:/
+2104.4 "Chilling Aspiration" sync / 1[56]:[^:]*:Mist Dragon:314D:/
+2111.6 "Frost Breath" sync / 1[56]:[^:]*:Mist Dragon:314C:/
+2119.7 "Fog Plume" sync / 1[56]:[^:]*:Mist Dragon:3144:/
+2137.9 "Rime Wreath" sync / 1[56]:[^:]*:Mist Dragon:314B:/
+2152.2 "Deep Fog" sync / 1[56]:[^:]*:Mist Dragon:3147:/ window 150,30
 2157.3 "--untargetable--"
-2167.4 "Cauterize" sync / 1[56]:Mist Dragon:3148:/
-2178.0 "Cauterize" sync / 1[56]:Mist Dragon:3148:/
-2187.0 "--targetable--" sync / 1[56]:Mist Dragon:314A:/
-2196.2 "Rime Wreath" sync / 1[56]:Mist Dragon:314B:/
-2205.4 "Rime Wreath" sync / 1[56]:Mist Dragon:314B:/
-2214.6 "Rime Wreath" sync / 1[56]:Mist Dragon:314B:/
-2224.8 "Chilling Aspiration" sync / 1[56]:Mist Dragon:314D:/ window 30,30
-2232.0 "Frost Breath" sync / 1[56]:Mist Dragon:314C:/
-2240.1 "Fog Plume" sync / 1[56]:Mist Dragon:3144:/
-2254.3 "Rime Wreath" sync / 1[56]:Mist Dragon:314B:/
-2263.5 "Rime Wreath" sync / 1[56]:Mist Dragon:314B:/
-2273.7 "Deep Fog" sync / 1[56]:Mist Dragon:3147:/ window 30,30
+2167.4 "Cauterize" sync / 1[56]:[^:]*:Mist Dragon:3148:/
+2178.0 "Cauterize" sync / 1[56]:[^:]*:Mist Dragon:3148:/
+2187.0 "--targetable--" sync / 1[56]:[^:]*:Mist Dragon:314A:/
+2196.2 "Rime Wreath" sync / 1[56]:[^:]*:Mist Dragon:314B:/
+2205.4 "Rime Wreath" sync / 1[56]:[^:]*:Mist Dragon:314B:/
+2214.6 "Rime Wreath" sync / 1[56]:[^:]*:Mist Dragon:314B:/
+2224.8 "Chilling Aspiration" sync / 1[56]:[^:]*:Mist Dragon:314D:/ window 30,30
+2232.0 "Frost Breath" sync / 1[56]:[^:]*:Mist Dragon:314C:/
+2240.1 "Fog Plume" sync / 1[56]:[^:]*:Mist Dragon:3144:/
+2254.3 "Rime Wreath" sync / 1[56]:[^:]*:Mist Dragon:314B:/
+2263.5 "Rime Wreath" sync / 1[56]:[^:]*:Mist Dragon:314B:/
+2273.7 "Deep Fog" sync / 1[56]:[^:]*:Mist Dragon:3147:/ window 30,30
 2278.8 "--untargetable--"
-2288.9 "Cauterize" sync / 1[56]:Mist Dragon:3148:/
-2299.5 "Cauterize" sync / 1[56]:Mist Dragon:3148:/
-2308.5 "--targetable--" sync / 1[56]:Mist Dragon:314A:/
-2317.7 "Rime Wreath" sync / 1[56]:Mist Dragon:314B:/
+2288.9 "Cauterize" sync / 1[56]:[^:]*:Mist Dragon:3148:/
+2299.5 "Cauterize" sync / 1[56]:[^:]*:Mist Dragon:3148:/
+2308.5 "--targetable--" sync / 1[56]:[^:]*:Mist Dragon:314A:/
+2317.7 "Rime Wreath" sync / 1[56]:[^:]*:Mist Dragon:314B:/
 
 
-2329.8 "Vaporize" sync / 1[56]:Mist Dragon:3140:/ window 30,30 jump 2061.9
+2329.8 "Vaporize" sync / 1[56]:[^:]*:Mist Dragon:3140:/ window 30,30 jump 2061.9
 2332.0 "--untargetable--"
 2341.0 "--targetable--"
 2361.0 "Cold Fog"

--- a/ui/raidboss/data/04-sb/eureka/eureka_hydatos.txt
+++ b/ui/raidboss/data/04-sb/eureka/eureka_hydatos.txt
@@ -17,40 +17,40 @@ hideall "--sync--"
 # Note: This checks that Art's auto hits a target close enough for you to see.
 # You can see Owain's auto abilities, but the target is listed as empty.
 1002.5 "--sync--" sync / 15:........:Art:3956:[^:]*:........:[^:]/ window 1500,0
-1014.5 "Thricecull" sync / 1[56]:Art:3934:/
-1023.1 "Legendcarver" sync / 1[56]:Art:3928:/
-1030.7 "Legendspinner" sync / 1[56]:Art:3929:/
-1038.8 "Acallam Na Senorach" sync / 1[56]:Art:3935:/
-1047.5 "Mythcall" sync / 1[56]:Art:3927:/
-1058.1 "Carver/Spinner" sync / 1[56]:Art:392[89]:/
-1061.1 "Spear Copy" sync / 1[56]:Orlasrach:392[AB]:/
-1068.2 "Acallam Na Senorach" sync / 1[56]:Art:3935:/
-1075.3 "Thricecull" sync / 1[56]:Art:3934:/
-1081.7 "Mythcall" sync / 1[56]:Art:3927:/
-1092.3 "Carver/Spinner" sync / 1[56]:Art:392[89]:/
-1095.3 "Spear Copy" sync / 1[56]:Orlasrach:392B:/
-1102.4 "Legendary Geas" sync / 1[56]:Art:3932:/
-1109.2 "--sync--" sync / 1[56]:Art:3933:/
-1113.7 "Acallam Na Senorach" sync / 1[56]:Art:3935:/
+1014.5 "Thricecull" sync / 1[56]:[^:]*:Art:3934:/
+1023.1 "Legendcarver" sync / 1[56]:[^:]*:Art:3928:/
+1030.7 "Legendspinner" sync / 1[56]:[^:]*:Art:3929:/
+1038.8 "Acallam Na Senorach" sync / 1[56]:[^:]*:Art:3935:/
+1047.5 "Mythcall" sync / 1[56]:[^:]*:Art:3927:/
+1058.1 "Carver/Spinner" sync / 1[56]:[^:]*:Art:392[89]:/
+1061.1 "Spear Copy" sync / 1[56]:[^:]*:Orlasrach:392[AB]:/
+1068.2 "Acallam Na Senorach" sync / 1[56]:[^:]*:Art:3935:/
+1075.3 "Thricecull" sync / 1[56]:[^:]*:Art:3934:/
+1081.7 "Mythcall" sync / 1[56]:[^:]*:Art:3927:/
+1092.3 "Carver/Spinner" sync / 1[56]:[^:]*:Art:392[89]:/
+1095.3 "Spear Copy" sync / 1[56]:[^:]*:Orlasrach:392B:/
+1102.4 "Legendary Geas" sync / 1[56]:[^:]*:Art:3932:/
+1109.2 "--sync--" sync / 1[56]:[^:]*:Art:3933:/
+1113.7 "Acallam Na Senorach" sync / 1[56]:[^:]*:Art:3935:/
 1116.7 "--untargetable--"
-1123.3 "Orb x5" sync / 1[56]:Art:392C:/ duration 6
-1125.8 "Pitfall" sync / 1[56]:Art:392F:/
+1123.3 "Orb x5" sync / 1[56]:[^:]*:Art:392C:/ duration 6
+1125.8 "Pitfall" sync / 1[56]:[^:]*:Art:392F:/
 1126.8 "--targetable--"
-1138.3 "Thricecull" sync / 1[56]:Art:3934:/
-1145.4 "Acallam Na Senorach" sync / 1[56]:Art:3935:/
-1155.1 "Mythcall" sync / 1[56]:Art:3927:/
+1138.3 "Thricecull" sync / 1[56]:[^:]*:Art:3934:/
+1145.4 "Acallam Na Senorach" sync / 1[56]:[^:]*:Art:3935:/
+1155.1 "Mythcall" sync / 1[56]:[^:]*:Art:3927:/
 1155.1 "(Legendary Geas)"
-1165.6 "Carver/Spinner" sync / 1[56]:Art:392[89]:/
-1168.7 "Spear Copy" sync / 1[56]:Orlasrach:392[AB]:/
-1175.7 "Thricecull" sync / 1[56]:Art:3934:/
-1182.8 "Acallam Na Senorach" sync / 1[56]:Art:3935:/
-1189.2 "Mythcall" sync / 1[56]:Art:3927:/
-1197.8 "Piercing Dark" sync / 1[56]:Art:3930:/ duration 6.5
+1165.6 "Carver/Spinner" sync / 1[56]:[^:]*:Art:392[89]:/
+1168.7 "Spear Copy" sync / 1[56]:[^:]*:Orlasrach:392[AB]:/
+1175.7 "Thricecull" sync / 1[56]:[^:]*:Art:3934:/
+1182.8 "Acallam Na Senorach" sync / 1[56]:[^:]*:Art:3935:/
+1189.2 "Mythcall" sync / 1[56]:[^:]*:Art:3927:/
+1197.8 "Piercing Dark" sync / 1[56]:[^:]*:Art:3930:/ duration 6.5
 # FIXME: is this one always spinner because piercing dark?
-1203.9 "Carver/Spinner" sync / 1[56]:Art:392[89]:/
-1204.3 "--sync--" sync / 1[56]:Art:3931:/
-1206.9 "Spear Shade" sync / 1[56]:Orlasrach:392[AB]:/
-1218.0 "Legendary Geas" sync / 1[56]:Art:3932:/
+1203.9 "Carver/Spinner" sync / 1[56]:[^:]*:Art:392[89]:/
+1204.3 "--sync--" sync / 1[56]:[^:]*:Art:3931:/
+1206.9 "Spear Shade" sync / 1[56]:[^:]*:Orlasrach:392[AB]:/
+1218.0 "Legendary Geas" sync / 1[56]:[^:]*:Art:3932:/
 # FIXME: spiritcall somewhere in here, and then a loop?
 
 
@@ -60,47 +60,47 @@ hideall "--sync--"
 #######################
 # -ic Orlasrach Art -ii 3957 3941 3939 393C 393D 3938 -p 3945:2016.0
 2002.5 "--sync--" sync / 15:........:Owain:3957:[^:]*:........:[^:]/ window 2500,0
-2016.0 "Thricecull" sync / 1[56]:Owain:3945:/
-2028.1 "Acallam Na Senorach" sync / 1[56]:Owain:3946:/ #3:29
-2037.7 "Mythcall" sync / 1[56]:Owain:3936:/ #3:39
-2041.7 "Elemental Shift" sync / 1[56]:Owain:3937:/
-2052.8 "Elemental Magicks" sync / 1[56]:Owain:393[AB]:/
-2067.8 "Thricecull" sync / 1[56]:Owain:3945:/
-2079.9 "Acallam Na Senorach" sync / 1[56]:Owain:3946:/
-2089.3 "Elemental Shift" sync / 1[56]:Owain:3937:/
-2100.4 "Elemental Magicks" sync / 1[56]:Owain:393[AB]:/
-2116.4 "Thricecull" sync / 1[56]:Owain:3945:/
-2127.5 "Spiritcull" sync / 1[56]:Owain:393E:/
-2132.5 "Legendary Imbas" sync / 1[56]:Owain:3940:/
-2132.5 "Piercing Light" sync / 1[56]:Owain:393F:/
-2142.5 "Thricecull" sync / 1[56]:Owain:3945:/
-2153.6 "Acallam Na Senorach" sync / 1[56]:Owain:3946:/
+2016.0 "Thricecull" sync / 1[56]:[^:]*:Owain:3945:/
+2028.1 "Acallam Na Senorach" sync / 1[56]:[^:]*:Owain:3946:/ #3:29
+2037.7 "Mythcall" sync / 1[56]:[^:]*:Owain:3936:/ #3:39
+2041.7 "Elemental Shift" sync / 1[56]:[^:]*:Owain:3937:/
+2052.8 "Elemental Magicks" sync / 1[56]:[^:]*:Owain:393[AB]:/
+2067.8 "Thricecull" sync / 1[56]:[^:]*:Owain:3945:/
+2079.9 "Acallam Na Senorach" sync / 1[56]:[^:]*:Owain:3946:/
+2089.3 "Elemental Shift" sync / 1[56]:[^:]*:Owain:3937:/
+2100.4 "Elemental Magicks" sync / 1[56]:[^:]*:Owain:393[AB]:/
+2116.4 "Thricecull" sync / 1[56]:[^:]*:Owain:3945:/
+2127.5 "Spiritcull" sync / 1[56]:[^:]*:Owain:393E:/
+2132.5 "Legendary Imbas" sync / 1[56]:[^:]*:Owain:3940:/
+2132.5 "Piercing Light" sync / 1[56]:[^:]*:Owain:393F:/
+2142.5 "Thricecull" sync / 1[56]:[^:]*:Owain:3945:/
+2153.6 "Acallam Na Senorach" sync / 1[56]:[^:]*:Owain:3946:/
 2157.7 "--untargetable--"
-2164.7 "Piercing Light" sync / 1[56]:Owain:3944:/
-2165.7 "Pitfall" sync / 1[56]:Owain:394D:/
+2164.7 "Piercing Light" sync / 1[56]:[^:]*:Owain:3944:/
+2165.7 "Pitfall" sync / 1[56]:[^:]*:Owain:394D:/
 2166.0 "--targetable--"
-2180.3 "Acallam Na Senorach" sync / 1[56]:Owain:3946:/
-2190.3 "Acallam Na Senorach" sync / 1[56]:Owain:3946:/
-2199.9 "Elemental Shift" sync / 1[56]:Owain:3937:/
-2209.0 "Spiritcull" sync / 1[56]:Owain:393E:/
-2214.0 "Legendary Imbas" sync / 1[56]:Owain:3940:/
-2214.0 "Piercing Light" sync / 1[56]:Owain:393F:/
-2216.0 "Elemental Magicks" sync / 1[56]:Owain:393[AB]:/
-2230.0 "Thricecull" sync / 1[56]:Owain:3945:/
-2252.1 "Acallam Na Senorach" sync / 1[56]:Owain:3946:/
-2261.4 "Elemental Shift" sync / 1[56]:Owain:3937:/
-2267.5 "Ivory Palm Adds" # sync / 1[56]:Ivory Palm:3941:/
-2272.5 "Elemental Magicks" sync / 1[56]:Owain:393[AB]:/
+2180.3 "Acallam Na Senorach" sync / 1[56]:[^:]*:Owain:3946:/
+2190.3 "Acallam Na Senorach" sync / 1[56]:[^:]*:Owain:3946:/
+2199.9 "Elemental Shift" sync / 1[56]:[^:]*:Owain:3937:/
+2209.0 "Spiritcull" sync / 1[56]:[^:]*:Owain:393E:/
+2214.0 "Legendary Imbas" sync / 1[56]:[^:]*:Owain:3940:/
+2214.0 "Piercing Light" sync / 1[56]:[^:]*:Owain:393F:/
+2216.0 "Elemental Magicks" sync / 1[56]:[^:]*:Owain:393[AB]:/
+2230.0 "Thricecull" sync / 1[56]:[^:]*:Owain:3945:/
+2252.1 "Acallam Na Senorach" sync / 1[56]:[^:]*:Owain:3946:/
+2261.4 "Elemental Shift" sync / 1[56]:[^:]*:Owain:3937:/
+2267.5 "Ivory Palm Adds" # sync / 1[56]:[^:]*:Ivory Palm:3941:/
+2272.5 "Elemental Magicks" sync / 1[56]:[^:]*:Owain:393[AB]:/
 2290.5 "(Explosion Enrage)"
-2283.5 "Thricecull" sync / 1[56]:Owain:3945:/
-2291.6 "Spiritcull" sync / 1[56]:Owain:393E:/
-2296.6 "Legendary Imbas" sync / 1[56]:Owain:3940:/
-2296.6 "Piercing Light" sync / 1[56]:Owain:393F:/
-2306.6 "Thricecull" sync / 1[56]:Owain:3945:/
-2317.6 "Acallam Na Senorach" sync / 1[56]:Owain:3946:/
-2328.6 "Piercing Light" sync / 1[56]:Owain:3944:/
-2329.6 "Pitfall" sync / 1[56]:Owain:394D:/
-2344.2 "Acallam Na Senorach" sync / 1[56]:Owain:3946:/
+2283.5 "Thricecull" sync / 1[56]:[^:]*:Owain:3945:/
+2291.6 "Spiritcull" sync / 1[56]:[^:]*:Owain:393E:/
+2296.6 "Legendary Imbas" sync / 1[56]:[^:]*:Owain:3940:/
+2296.6 "Piercing Light" sync / 1[56]:[^:]*:Owain:393F:/
+2306.6 "Thricecull" sync / 1[56]:[^:]*:Owain:3945:/
+2317.6 "Acallam Na Senorach" sync / 1[56]:[^:]*:Owain:3946:/
+2328.6 "Piercing Light" sync / 1[56]:[^:]*:Owain:3944:/
+2329.6 "Pitfall" sync / 1[56]:[^:]*:Owain:394D:/
+2344.2 "Acallam Na Senorach" sync / 1[56]:[^:]*:Owain:3946:/
 
 
 
@@ -109,58 +109,58 @@ hideall "--sync--"
 ##########
 # -ii 39B9 3994 3996 3995 3997 3872 3871 3873 -p 387A:3013 386D:3091
 3000.0 "--sync--" sync / 00:0839::The Shin-Zantetsuken Containment Unit will be sealed off/ window 3000,0
-3013.0 "Spirits of the Fallen" sync / 1[56]:Raiden:387A:/ # drift -0.041
-3023.0 "Shingan" sync / 1[56]:Raiden:387B:/ # drift 0.05
-3034.1 "Thundercall" sync / 1[56]:Raiden:387F:/
-3044.2 "--sync--" sync / 14:Raiden:3868:/ window 10,10
-3048.7 "Ame-no-Sakahoko" sync / 1[56]:Raiden:3868:/
-3051.7 "--sync--" sync / 1[56]:Raiden:3869:/
-3058.3 "Whirling Zantetsuken" sync / 1[56]:Raiden:386A:/
-3065.4 "--sync--" sync / 14:Raiden:3868:/ window 10,10
-3069.9 "Ame-no-Sakahoko" sync / 1[56]:Raiden:3868:/
-3072.9 "--sync--" sync / 1[56]:Raiden:3869:/
-3079.5 "Whirling Zantetsuken" sync / 1[56]:Raiden:386A:/
+3013.0 "Spirits of the Fallen" sync / 1[56]:[^:]*:Raiden:387A:/ # drift -0.041
+3023.0 "Shingan" sync / 1[56]:[^:]*:Raiden:387B:/ # drift 0.05
+3034.1 "Thundercall" sync / 1[56]:[^:]*:Raiden:387F:/
+3044.2 "--sync--" sync / 14:[^:]*:Raiden:3868:/ window 10,10
+3048.7 "Ame-no-Sakahoko" sync / 1[56]:[^:]*:Raiden:3868:/
+3051.7 "--sync--" sync / 1[56]:[^:]*:Raiden:3869:/
+3058.3 "Whirling Zantetsuken" sync / 1[56]:[^:]*:Raiden:386A:/
+3065.4 "--sync--" sync / 14:[^:]*:Raiden:3868:/ window 10,10
+3069.9 "Ame-no-Sakahoko" sync / 1[56]:[^:]*:Raiden:3868:/
+3072.9 "--sync--" sync / 1[56]:[^:]*:Raiden:3869:/
+3079.5 "Whirling Zantetsuken" sync / 1[56]:[^:]*:Raiden:386A:/
 # FIXME: does this loop doing Ame forever or does it naturally go into Lateral?
 # FIXME: Are these always Whirling?
 
 # Adds Phase at 60%
-3095.0 "--sync--" sync / 1[56]:Ball Lightning:386D:/ window 100,10
-3099.1 "Lateral Zantetsuken" sync / 1[56]:Raiden:386[BC]:/
-3109.8 "Spirits of the Fallen" sync / 1[56]:Raiden:387A:/
-3118.9 "Lancing Bolt" sync / 1[56]:Raiden:3876:/
-3124.4 "Streak Lightning" #sync / 1[56]:Streak Lightning:3877:/
-3134.9 "Ultimate Zantetsuken" sync / 14:Raiden:3878:/ duration 20
+3095.0 "--sync--" sync / 1[56]:[^:]*:Ball Lightning:386D:/ window 100,10
+3099.1 "Lateral Zantetsuken" sync / 1[56]:[^:]*:Raiden:386[BC]:/
+3109.8 "Spirits of the Fallen" sync / 1[56]:[^:]*:Raiden:387A:/
+3118.9 "Lancing Bolt" sync / 1[56]:[^:]*:Raiden:3876:/
+3124.4 "Streak Lightning" #sync / 1[56]:[^:]*:Streak Lightning:3877:/
+3134.9 "Ultimate Zantetsuken" sync / 14:[^:]*:Raiden:3878:/ duration 20
 
 3154.9 "--sync--" sync / 17:........:Raiden:3878:/ window 40,0
-3164.9 "Spirits of the Fallen" sync / 1[56]:Raiden:387A:/ window 40,5
-3171.2 "Booming Lament" sync / 1[56]:Raiden:387D:/
-3177.3 "Cloud to Ground" sync / 1[56]:Raiden:3870:/
-3193.4 "Bitter Barbs" sync / 1[56]:Raiden:3874:/
-3210.5 "Whirling Zantetsuken" sync / 1[56]:Raiden:386A:/
-3220.5 "Spirits of the Fallen" sync / 1[56]:Raiden:387A:/
+3164.9 "Spirits of the Fallen" sync / 1[56]:[^:]*:Raiden:387A:/ window 40,5
+3171.2 "Booming Lament" sync / 1[56]:[^:]*:Raiden:387D:/
+3177.3 "Cloud to Ground" sync / 1[56]:[^:]*:Raiden:3870:/
+3193.4 "Bitter Barbs" sync / 1[56]:[^:]*:Raiden:3874:/
+3210.5 "Whirling Zantetsuken" sync / 1[56]:[^:]*:Raiden:386A:/
+3220.5 "Spirits of the Fallen" sync / 1[56]:[^:]*:Raiden:387A:/
 
-3233.6 "Cloud to Ground" sync / 1[56]:Raiden:3870:/
-3247.7 "Levinwhorl" sync / 1[56]:Raiden:386E:/
-3247.7 "--sync--" sync / 1[56]:Raiden:386F:/
-3266.3 "Ame-no-Sakahoko" sync / 1[56]:Raiden:3868:/
-3269.3 "--sync--" sync / 1[56]:Raiden:3869:/
-3275.9 "Whirling Zantetsuken" sync / 1[56]:Raiden:386A:/
-3283.1 "Booming Lament" sync / 1[56]:Raiden:387D:/
-3293.2 "Spirits of the Fallen" sync / 1[56]:Raiden:387A:/
+3233.6 "Cloud to Ground" sync / 1[56]:[^:]*:Raiden:3870:/
+3247.7 "Levinwhorl" sync / 1[56]:[^:]*:Raiden:386E:/
+3247.7 "--sync--" sync / 1[56]:[^:]*:Raiden:386F:/
+3266.3 "Ame-no-Sakahoko" sync / 1[56]:[^:]*:Raiden:3868:/
+3269.3 "--sync--" sync / 1[56]:[^:]*:Raiden:3869:/
+3275.9 "Whirling Zantetsuken" sync / 1[56]:[^:]*:Raiden:386A:/
+3283.1 "Booming Lament" sync / 1[56]:[^:]*:Raiden:387D:/
+3293.2 "Spirits of the Fallen" sync / 1[56]:[^:]*:Raiden:387A:/
 
-3308.5 "--sync--" sync / 1[56]:Ball Lightning:386D:/ window 100,10
-3310.7 "Streak Lightning" sync / 1[56]:Streak Lightning:3877:/ # drift 0.043
-3316.0 "Lateral Zantetsuken" sync / 1[56]:Raiden:386[BC]:/
-3321.7 "Ultimate Zantetsuken" sync / 14:Raiden:3878:/ duration 20
+3308.5 "--sync--" sync / 1[56]:[^:]*:Ball Lightning:386D:/ window 100,10
+3310.7 "Streak Lightning" sync / 1[56]:[^:]*:Streak Lightning:3877:/ # drift 0.043
+3316.0 "Lateral Zantetsuken" sync / 1[56]:[^:]*:Raiden:386[BC]:/
+3321.7 "Ultimate Zantetsuken" sync / 14:[^:]*:Raiden:3878:/ duration 20
 
 3341.7 "--sync--" sync / 17:........:Raiden:3878:/ window 40,0
-3347.7 "Spirits of the Fallen" sync / 1[56]:Raiden:387A:/ window 40,5
-3353.8 "Shingan" sync / 1[56]:Raiden:387B:/
-3365.4 "Ame-no-Sakahoko" sync / 1[56]:Raiden:3868:/
-3368.4 "--sync--" sync / 1[56]:Raiden:3869:/
-3373.9 "For Honor" sync / 1[56]:Raiden:387C:/
-3381.5 "Whirling Zantetsuken" sync / 1[56]:Raiden:386A:/ # drift -0.048
-3390.7 "Booming Lament" sync / 1[56]:Raiden:387D:/
+3347.7 "Spirits of the Fallen" sync / 1[56]:[^:]*:Raiden:387A:/ window 40,5
+3353.8 "Shingan" sync / 1[56]:[^:]*:Raiden:387B:/
+3365.4 "Ame-no-Sakahoko" sync / 1[56]:[^:]*:Raiden:3868:/
+3368.4 "--sync--" sync / 1[56]:[^:]*:Raiden:3869:/
+3373.9 "For Honor" sync / 1[56]:[^:]*:Raiden:387C:/
+3381.5 "Whirling Zantetsuken" sync / 1[56]:[^:]*:Raiden:386A:/ # drift -0.048
+3390.7 "Booming Lament" sync / 1[56]:[^:]*:Raiden:387D:/
 
 
 
@@ -169,73 +169,73 @@ hideall "--sync--"
 ###################
 # -p 3799:4016 -ii 38C4 378F 3791 3792 3954 378C
 4000.0 "--sync--" sync / 00:0839::The Lance of Virtue Containment Unit will be sealed off/ window 4000,0
-4016.0 "Meteor" sync / 1[56]:Absolute Virtue:3799:/
-4022.0 "Eidos" sync / 1[56]:Absolute Virtue:378[67]:/
-4033.6 "Hostile Aspect" sync / 1[56]:Absolute Virtue:378B:/
-4039.8 "Medusa Javelin" sync / 1[56]:Absolute Virtue:379B:/
-4046.8 "Eidos" sync / 1[56]:Absolute Virtue:378[67]:/
-4053.6 "Impact Stream" sync / 1[56]:Absolute Virtue:3788:/
-4064.6 "Auroral Wind" sync / 1[56]:Absolute Virtue:379A:/
-4078.7 "Eidos" sync / 1[56]:Absolute Virtue:378[67]:/
-4090.5 "Hostile Aspect" sync / 1[56]:Absolute Virtue:378B:/
-4108.5 "Meteor" sync / 1[56]:Absolute Virtue:3799:/
-4118.6 "Turbulent Aether" sync / 1[56]:Absolute Virtue:3790:/
-4126.9 "Medusa Javelin" sync / 1[56]:Absolute Virtue:379B:/
-4134.9 "Auroral Wind" sync / 1[56]:Absolute Virtue:379A:/
-4142.9 "Meteor" sync / 1[56]:Absolute Virtue:3799:/
-4151.9 "Meteor" sync / 1[56]:Absolute Virtue:3799:/
+4016.0 "Meteor" sync / 1[56]:[^:]*:Absolute Virtue:3799:/
+4022.0 "Eidos" sync / 1[56]:[^:]*:Absolute Virtue:378[67]:/
+4033.6 "Hostile Aspect" sync / 1[56]:[^:]*:Absolute Virtue:378B:/
+4039.8 "Medusa Javelin" sync / 1[56]:[^:]*:Absolute Virtue:379B:/
+4046.8 "Eidos" sync / 1[56]:[^:]*:Absolute Virtue:378[67]:/
+4053.6 "Impact Stream" sync / 1[56]:[^:]*:Absolute Virtue:3788:/
+4064.6 "Auroral Wind" sync / 1[56]:[^:]*:Absolute Virtue:379A:/
+4078.7 "Eidos" sync / 1[56]:[^:]*:Absolute Virtue:378[67]:/
+4090.5 "Hostile Aspect" sync / 1[56]:[^:]*:Absolute Virtue:378B:/
+4108.5 "Meteor" sync / 1[56]:[^:]*:Absolute Virtue:3799:/
+4118.6 "Turbulent Aether" sync / 1[56]:[^:]*:Absolute Virtue:3790:/
+4126.9 "Medusa Javelin" sync / 1[56]:[^:]*:Absolute Virtue:379B:/
+4134.9 "Auroral Wind" sync / 1[56]:[^:]*:Absolute Virtue:379A:/
+4142.9 "Meteor" sync / 1[56]:[^:]*:Absolute Virtue:3799:/
+4151.9 "Meteor" sync / 1[56]:[^:]*:Absolute Virtue:3799:/
 
 # Triple Stream
 4161.0 "--untargetable--"
-4166.5 "Explosive Impulse" sync / 1[56]:Relative Virtue:3793:/
+4166.5 "Explosive Impulse" sync / 1[56]:[^:]*:Relative Virtue:3793:/
 4174.5 "Impact Stream"
 4175.5 "Impact Stream"
 4184.5 "Impact Stream"
-4190.5 "Explosive Impulse" sync / 1[56]:Absolute Virtue:3794:/
+4190.5 "Explosive Impulse" sync / 1[56]:[^:]*:Absolute Virtue:3794:/
 4191.0 "--targetable--"
-4196.5 "Medusa Javelin" sync / 1[56]:Absolute Virtue:379B:/
-4208.5 "Auroral Wind" sync / 1[56]:Absolute Virtue:379A:/
-4216.5 "Meteor" sync / 1[56]:Absolute Virtue:3799:/
+4196.5 "Medusa Javelin" sync / 1[56]:[^:]*:Absolute Virtue:379B:/
+4208.5 "Auroral Wind" sync / 1[56]:[^:]*:Absolute Virtue:379A:/
+4216.5 "Meteor" sync / 1[56]:[^:]*:Absolute Virtue:3799:/
 
 # Wyvern Pair 1
-4225.6 "Call Wyvern" sync / 1[56]:Absolute Virtue:3798:/
-4231.6 "Turbulent Aether" sync / 1[56]:Absolute Virtue:3790:/
-4239.8 "Medusa Javelin" sync / 1[56]:Absolute Virtue:379B:/
+4225.6 "Call Wyvern" sync / 1[56]:[^:]*:Absolute Virtue:3798:/
+4231.6 "Turbulent Aether" sync / 1[56]:[^:]*:Absolute Virtue:3790:/
+4239.8 "Medusa Javelin" sync / 1[56]:[^:]*:Absolute Virtue:379B:/
 4241.6 "(Wyvern Explosion)"
-4247.8 "Auroral Wind" sync / 1[56]:Absolute Virtue:379A:/
-4264.8 "Meteor" sync / 1[56]:Absolute Virtue:3799:/
-4270.8 "Eidos" sync / 1[56]:Absolute Virtue:378[67]:/
-4283.0 "Hostile Aspect" sync / 1[56]:Absolute Virtue:378B:/
+4247.8 "Auroral Wind" sync / 1[56]:[^:]*:Absolute Virtue:379A:/
+4264.8 "Meteor" sync / 1[56]:[^:]*:Absolute Virtue:3799:/
+4270.8 "Eidos" sync / 1[56]:[^:]*:Absolute Virtue:378[67]:/
+4283.0 "Hostile Aspect" sync / 1[56]:[^:]*:Absolute Virtue:378B:/
 
 # Double Stream 1
-4286.9 "Explosive Impulse" sync / 1[56]:Relative Virtue:3793:/
-4294.1 "Eidos" sync / 1[56]:Absolute Virtue:378[67]:/
-4296.1 "Impact Stream" sync / 1[56]:Absolute Virtue:3797:/
-4300.8 "Impact Stream" sync / 1[56]:Absolute Virtue:3788:/
-4311.8 "Medusa Javelin" sync / 1[56]:Absolute Virtue:379B:/
-4318.8 "Meteor" sync / 1[56]:Absolute Virtue:3799:/
+4286.9 "Explosive Impulse" sync / 1[56]:[^:]*:Relative Virtue:3793:/
+4294.1 "Eidos" sync / 1[56]:[^:]*:Absolute Virtue:378[67]:/
+4296.1 "Impact Stream" sync / 1[56]:[^:]*:Absolute Virtue:3797:/
+4300.8 "Impact Stream" sync / 1[56]:[^:]*:Absolute Virtue:3788:/
+4311.8 "Medusa Javelin" sync / 1[56]:[^:]*:Absolute Virtue:379B:/
+4318.8 "Meteor" sync / 1[56]:[^:]*:Absolute Virtue:3799:/
 
 # Wyvern Pair 2
-4333.8 "Call Wyvern" sync / 1[56]:Absolute Virtue:3798:/
-4339.8 "Turbulent Aether" sync / 1[56]:Absolute Virtue:3790:/
-4348.1 "Medusa Javelin" sync / 1[56]:Absolute Virtue:379B:/
+4333.8 "Call Wyvern" sync / 1[56]:[^:]*:Absolute Virtue:3798:/
+4339.8 "Turbulent Aether" sync / 1[56]:[^:]*:Absolute Virtue:3790:/
+4348.1 "Medusa Javelin" sync / 1[56]:[^:]*:Absolute Virtue:379B:/
 4349.8 "(Wyvern Explosion)"
-4356.1 "Auroral Wind" sync / 1[56]:Absolute Virtue:379A:/
-4373.1 "Meteor" sync / 1[56]:Absolute Virtue:3799:/
-4379.1 "Eidos" sync / 1[56]:Absolute Virtue:378[67]:/
-4391.2 "Hostile Aspect" sync / 1[56]:Absolute Virtue:378B:/
+4356.1 "Auroral Wind" sync / 1[56]:[^:]*:Absolute Virtue:379A:/
+4373.1 "Meteor" sync / 1[56]:[^:]*:Absolute Virtue:3799:/
+4379.1 "Eidos" sync / 1[56]:[^:]*:Absolute Virtue:378[67]:/
+4391.2 "Hostile Aspect" sync / 1[56]:[^:]*:Absolute Virtue:378B:/
 
 # Double Stream 2
-4395.1 "Explosive Impulse" sync / 1[56]:Relative Virtue:3793:/
-4402.3 "Eidos" sync / 1[56]:Absolute Virtue:378[67]:/
-4404.3 "Impact Stream" sync / 1[56]:Absolute Virtue:3797:/
-4408.4 "Impact Stream" sync / 1[56]:Absolute Virtue:3788:/
-4419.6 "Medusa Javelin" sync / 1[56]:Absolute Virtue:379B:/
-4426.6 "Meteor" sync / 1[56]:Absolute Virtue:3799:/
+4395.1 "Explosive Impulse" sync / 1[56]:[^:]*:Relative Virtue:3793:/
+4402.3 "Eidos" sync / 1[56]:[^:]*:Absolute Virtue:378[67]:/
+4404.3 "Impact Stream" sync / 1[56]:[^:]*:Absolute Virtue:3797:/
+4408.4 "Impact Stream" sync / 1[56]:[^:]*:Absolute Virtue:3788:/
+4419.6 "Medusa Javelin" sync / 1[56]:[^:]*:Absolute Virtue:379B:/
+4426.6 "Meteor" sync / 1[56]:[^:]*:Absolute Virtue:3799:/
 
-4443.4 "Meteor Enrage" sync / 1[56]:Absolute Virtue:396C:/
-4446.4 "Meteor Enrage" sync / 1[56]:Absolute Virtue:396F:/
-4451.4 "Meteor Enrage" sync / 1[56]:Absolute Virtue:396F:/
+4443.4 "Meteor Enrage" sync / 1[56]:[^:]*:Absolute Virtue:396C:/
+4446.4 "Meteor Enrage" sync / 1[56]:[^:]*:Absolute Virtue:396F:/
+4451.4 "Meteor Enrage" sync / 1[56]:[^:]*:Absolute Virtue:396F:/
 
 
 
@@ -246,28 +246,28 @@ hideall "--sync--"
 5000.0 "--sync--" sync / 00:0839::The Proto Ozma Containment Unit will be sealed off/ window 5000,0
 
 ### Initial Star Form (no meteor)
-5021.5 "Star Form" sync / 1[56]:Proto Ozma:37B2:/
-5028.5 "--sync--" sync / 1[56]:Proto Ozma:37B4:/
-5029.5 "Mourning Star" sync / 1[56]:Ozma:37B5:/
+5021.5 "Star Form" sync / 1[56]:[^:]*:Proto Ozma:37B2:/
+5028.5 "--sync--" sync / 1[56]:[^:]*:Proto Ozma:37B4:/
+5029.5 "Mourning Star" sync / 1[56]:[^:]*:Ozma:37B5:/
 
-5032.5 "Soak Attack" sync / 1[56]:Ozma:37B6:/
-5038.5 "Soak Attack" sync / 1[56]:Ozma:37B6:/
-5044.5 "Soak Attack" sync / 1[56]:Ozma:37B6:/
+5032.5 "Soak Attack" sync / 1[56]:[^:]*:Ozma:37B6:/
+5038.5 "Soak Attack" sync / 1[56]:[^:]*:Ozma:37B6:/
+5044.5 "Soak Attack" sync / 1[56]:[^:]*:Ozma:37B6:/
 
-5051.5 "Shooting Star" sync / 1[56]:Proto Ozma:37B7:/
+5051.5 "Shooting Star" sync / 1[56]:[^:]*:Proto Ozma:37B7:/
 
-5056.5 "Soak Attack" sync / 1[56]:Ozma:37B6:/
-5062.5 "Soak Attack" sync / 1[56]:Ozma:37B6:/
-5068.5 "Soak Attack" sync / 1[56]:Ozma:37B6:/
+5056.5 "Soak Attack" sync / 1[56]:[^:]*:Ozma:37B6:/
+5062.5 "Soak Attack" sync / 1[56]:[^:]*:Ozma:37B6:/
+5068.5 "Soak Attack" sync / 1[56]:[^:]*:Ozma:37B6:/
 
-5070.5 "Sphere Form" sync / 1[56]:Proto Ozma:(37B3|37A5|379F):/
-5079.5 "Black Hole" sync / 1[56]:Proto Ozma:379D:/
+5070.5 "Sphere Form" sync / 1[56]:[^:]*:Proto Ozma:(37B3|37A5|379F):/
+5079.5 "Black Hole" sync / 1[56]:[^:]*:Proto Ozma:379D:/
 
-5092.5 "Random Shade" sync / 1[56]:Ozmashade:(37A4|37B2|379E):/
-5099.5 "--sync--" sync / 1[56]:Ozmashade:(37A6|37B4|37A0):/
-5101.0 "Shade Ability" # sync / 1[56]:Shadow:(37A7|37B5|37A1):/
+5092.5 "Random Shade" sync / 1[56]:[^:]*:Ozmashade:(37A4|37B2|379E):/
+5099.5 "--sync--" sync / 1[56]:[^:]*:Ozmashade:(37A6|37B4|37A0):/
+5101.0 "Shade Ability" # sync / 1[56]:[^:]*:Shadow:(37A7|37B5|37A1):/
 
-5121.5 "Random Shade" sync / 1[56]:Ozmashade:(37A4|37B2|379E):/
+5121.5 "Random Shade" sync / 1[56]:[^:]*:Ozmashade:(37A4|37B2|379E):/
 
 # fake loop
 5125.5 "Random Form"
@@ -285,33 +285,33 @@ hideall "--sync--"
 
 
 ### Pyramid Phase
-5300.0 "Pyramid Form" sync / 1[56]:Proto Ozma:37A4:/ window 800,800
-5303.0  "--sync--" sync / 1[56]:Ozmashade:(37A6|37B4|37A0):/
-5304.5 "Shade Ability" # sync / 1[56]:Shadow:(37A7|37B5|37A1):/
+5300.0 "Pyramid Form" sync / 1[56]:[^:]*:Proto Ozma:37A4:/ window 800,800
+5303.0  "--sync--" sync / 1[56]:[^:]*:Ozmashade:(37A6|37B4|37A0):/
+5304.5 "Shade Ability" # sync / 1[56]:[^:]*:Shadow:(37A7|37B5|37A1):/
 
-5307.0 "--sync--" sync / 1[56]:Proto Ozma:37A6:/
-5308.7 "Execration" sync / 1[56]:Ozma:37A7:/
+5307.0 "--sync--" sync / 1[56]:[^:]*:Proto Ozma:37A6:/
+5308.7 "Execration" sync / 1[56]:[^:]*:Ozma:37A7:/
 
-5311.0 "Acceleration Bomb" sync / 1[56]:Proto Ozma:37AA:/
-5313.0 "Bleed Attack" sync / 1[56]:Ozma:37AD:/
-5319.0 "Bleed Attack" sync / 1[56]:Ozma:37AD:/
+5311.0 "Acceleration Bomb" sync / 1[56]:[^:]*:Proto Ozma:37AA:/
+5313.0 "Bleed Attack" sync / 1[56]:[^:]*:Ozma:37AD:/
+5319.0 "Bleed Attack" sync / 1[56]:[^:]*:Ozma:37AD:/
 
-5332.0 "Meteor (Adds)" sync / 1[56]:Arsenal urolith:37B0:/
-5337.0 "Bleed Attack" sync / 1[56]:Ozma:37AD:/
-5343.0 "Bleed Attack" sync / 1[56]:Ozma:37AD:/
+5332.0 "Meteor (Adds)" sync / 1[56]:[^:]*:Arsenal urolith:37B0:/
+5337.0 "Bleed Attack" sync / 1[56]:[^:]*:Ozma:37AD:/
+5343.0 "Bleed Attack" sync / 1[56]:[^:]*:Ozma:37AD:/
 
-5346.0 "Random Shade" sync / 1[56]:Ozmashade:(37A4|37B2|379E):/
-5349.0 "Acceleration Bomb" sync / 1[56]:Proto Ozma:37AA:/
-5353.0 "--sync--" sync / 1[56]:Ozmashade:(37A6|37B4|37A0):/
-5354.5 "Shade Ability" # sync / 1[56]:Shadow:(37A7|37B5|37A1):/
+5346.0 "Random Shade" sync / 1[56]:[^:]*:Ozmashade:(37A4|37B2|379E):/
+5349.0 "Acceleration Bomb" sync / 1[56]:[^:]*:Proto Ozma:37AA:/
+5353.0 "--sync--" sync / 1[56]:[^:]*:Ozmashade:(37A6|37B4|37A0):/
+5354.5 "Shade Ability" # sync / 1[56]:[^:]*:Shadow:(37A7|37B5|37A1):/
 
-5364.0 "Meteor (Stack)" sync / 1[56]:Ozma:37A8:/
-5370.0 "Bleed Attack" sync / 1[56]:Ozma:37AD:/
+5364.0 "Meteor (Stack)" sync / 1[56]:[^:]*:Ozma:37A8:/
+5370.0 "Bleed Attack" sync / 1[56]:[^:]*:Ozma:37AD:/
 
-5373.0 "Sphere Form" sync / 1[56]:Proto Ozma:(37B3|37A5|379F):/
-5382.0 "Black Hole" sync / 1[56]:Proto Ozma:379D:/
+5373.0 "Sphere Form" sync / 1[56]:[^:]*:Proto Ozma:(37B3|37A5|379F):/
+5382.0 "Black Hole" sync / 1[56]:[^:]*:Proto Ozma:379D:/
 
-5395.0 "Random Shade" sync / 1[56]:Ozmashade:(37A4|37B2|379E):/
+5395.0 "Random Shade" sync / 1[56]:[^:]*:Ozmashade:(37A4|37B2|379E):/
 
 # fake loop
 5399.0 "Random Form"
@@ -329,27 +329,27 @@ hideall "--sync--"
 
 
 ### Cube Phase
-5600.0 "Cube Form" sync / 1[56]:Proto Ozma:379E:/ window 800,800
+5600.0 "Cube Form" sync / 1[56]:[^:]*:Proto Ozma:379E:/ window 800,800
 
-5603.0 "--sync--" sync / 1[56]:Ozmashade:(37A6|37B4|37A0):/
-5604.5 "Shade Ability" # sync / 1[56]:Shadow:(37A7|37B5|37A1):/
+5603.0 "--sync--" sync / 1[56]:[^:]*:Ozmashade:(37A6|37B4|37A0):/
+5604.5 "Shade Ability" # sync / 1[56]:[^:]*:Shadow:(37A7|37B5|37A1):/
 
-5607.0 "--sync--" sync / 1[56]:Proto Ozma:37A0:/
-5608.5 "Flare Star" sync / 1[56]:Ozma:37A1:/
+5607.0 "--sync--" sync / 1[56]:[^:]*:Proto Ozma:37A0:/
+5608.5 "Flare Star" sync / 1[56]:[^:]*:Ozma:37A1:/
 
-5619.0 "Meteor (Stack)" sync / 1[56]:Ozma:37A8:/
-5622.0 "Holy" sync / 1[56]:Proto Ozma:37A9:/
+5619.0 "Meteor (Stack)" sync / 1[56]:[^:]*:Ozma:37A8:/
+5622.0 "Holy" sync / 1[56]:[^:]*:Proto Ozma:37A9:/
 
-5649.0 "Random Shade" sync / 1[56]:Ozmashade:(37A4|37B2|379E):/
-5655.0 "Meteor (Stack)" sync / 1[56]:Ozma:37A8:/
-5656.0 "Holy" sync / 1[56]:Proto Ozma:37A9:/
-5656.0 "--sync--" sync / 1[56]:Ozmashade:(37A6|37B4|37A0):/
-5657.5 "Shade Ability" # sync / 1[56]:Shadow:(37A7|37B5|37A1):/
+5649.0 "Random Shade" sync / 1[56]:[^:]*:Ozmashade:(37A4|37B2|379E):/
+5655.0 "Meteor (Stack)" sync / 1[56]:[^:]*:Ozma:37A8:/
+5656.0 "Holy" sync / 1[56]:[^:]*:Proto Ozma:37A9:/
+5656.0 "--sync--" sync / 1[56]:[^:]*:Ozmashade:(37A6|37B4|37A0):/
+5657.5 "Shade Ability" # sync / 1[56]:[^:]*:Shadow:(37A7|37B5|37A1):/
 
-5673.0 "Sphere Form" sync / 1[56]:Proto Ozma:(37B3|37A5|379F):/
-5682.0 "Black Hole" sync / 1[56]:Proto Ozma:379D:/
+5673.0 "Sphere Form" sync / 1[56]:[^:]*:Proto Ozma:(37B3|37A5|379F):/
+5682.0 "Black Hole" sync / 1[56]:[^:]*:Proto Ozma:379D:/
 
-5695.0 "Random Shade" sync / 1[56]:Ozmashade:(37A4|37B2|379E):/
+5695.0 "Random Shade" sync / 1[56]:[^:]*:Ozmashade:(37A4|37B2|379E):/
 
 # fake loop
 5699.0 "Random Form"
@@ -367,30 +367,30 @@ hideall "--sync--"
 
 
 ### Star Phase
-5900.0 "Star Form" sync / 1[56]:Proto Ozma:37B2:/ window 800,800
-5903.0 "--sync--" sync / 1[56]:Ozmashade:(37A6|37B4|37A0):/
-5904.5 "Shade Ability" # sync / 1[56]:Shadow:(37A7|37B5|37A1):/
-5907.0 "--sync--" sync / 1[56]:Proto Ozma:37B4:/
-5908.0 "Mourning Star" sync / 1[56]:Ozma:37B5:/
-5911.0 "Soak Attack" sync / 1[56]:Ozma:37B6:/
+5900.0 "Star Form" sync / 1[56]:[^:]*:Proto Ozma:37B2:/ window 800,800
+5903.0 "--sync--" sync / 1[56]:[^:]*:Ozmashade:(37A6|37B4|37A0):/
+5904.5 "Shade Ability" # sync / 1[56]:[^:]*:Shadow:(37A7|37B5|37A1):/
+5907.0 "--sync--" sync / 1[56]:[^:]*:Proto Ozma:37B4:/
+5908.0 "Mourning Star" sync / 1[56]:[^:]*:Ozma:37B5:/
+5911.0 "Soak Attack" sync / 1[56]:[^:]*:Ozma:37B6:/
 #5917.1 "Shooting Star Enrage" (if this is the enrage)
-5926.0 "Meteor (Adds)" sync / 1[56]:Arsenal urolith:37B0:/
-5929.0 "Shooting Star" sync / 1[56]:Proto Ozma:37B7:/
-5938.0 "Soak Attack" sync / 1[56]:Ozma:37B6:/
-5944.0 "Soak Attack" sync / 1[56]:Ozma:37B6:/
+5926.0 "Meteor (Adds)" sync / 1[56]:[^:]*:Arsenal urolith:37B0:/
+5929.0 "Shooting Star" sync / 1[56]:[^:]*:Proto Ozma:37B7:/
+5938.0 "Soak Attack" sync / 1[56]:[^:]*:Ozma:37B6:/
+5944.0 "Soak Attack" sync / 1[56]:[^:]*:Ozma:37B6:/
 
-5949.0 "Random Shade" sync / 1[56]:Ozmashade:(37A4|37B2|379E):/
-5954.0 "Shooting Star" sync / 1[56]:Proto Ozma:37B7:/
-5956.0 "--sync--" sync / 1[56]:Ozmashade:(37A6|37B4|37A0):/
-5957.5 "Shade Ability" # sync / 1[56]:Shadow:(37A7|37B5|37A1):/
-5959.0 "Soak Attack" sync / 1[56]:Ozma:37B6:/
-5959.0 "Soak Attack" sync / 1[56]:Ozma:37B6:/
-5965.0 "Soak Attack" sync / 1[56]:Ozma:37B6:/
+5949.0 "Random Shade" sync / 1[56]:[^:]*:Ozmashade:(37A4|37B2|379E):/
+5954.0 "Shooting Star" sync / 1[56]:[^:]*:Proto Ozma:37B7:/
+5956.0 "--sync--" sync / 1[56]:[^:]*:Ozmashade:(37A6|37B4|37A0):/
+5957.5 "Shade Ability" # sync / 1[56]:[^:]*:Shadow:(37A7|37B5|37A1):/
+5959.0 "Soak Attack" sync / 1[56]:[^:]*:Ozma:37B6:/
+5959.0 "Soak Attack" sync / 1[56]:[^:]*:Ozma:37B6:/
+5965.0 "Soak Attack" sync / 1[56]:[^:]*:Ozma:37B6:/
 
-5973.0 "Sphere Form" sync / 1[56]:Proto Ozma:(37B3|37A5|379F):/
-5982.0 "Black Hole" sync / 1[56]:Proto Ozma:379D:/
+5973.0 "Sphere Form" sync / 1[56]:[^:]*:Proto Ozma:(37B3|37A5|379F):/
+5982.0 "Black Hole" sync / 1[56]:[^:]*:Proto Ozma:379D:/
 
-5995.0 "Random Shade" sync / 1[56]:Ozmashade:(37A4|37B2|379E):/
+5995.0 "Random Shade" sync / 1[56]:[^:]*:Ozmashade:(37A4|37B2|379E):/
 
 # fake loop
 5999.0 "Random Form"
@@ -408,5 +408,5 @@ hideall "--sync--"
 
 
 ### Star Form Enrage
-6200.0 "--sync--"  sync / 14:Proto Ozma:396D:/ window 300,0
-6210.0 "Shooting Star Enrage" sync / 1[56]:Proto Ozma:396D:/
+6200.0 "--sync--"  sync / 14:[^:]*:Proto Ozma:396D:/ window 300,0
+6210.0 "Shooting Star Enrage" sync / 1[56]:[^:]*:Proto Ozma:396D:/

--- a/ui/raidboss/data/04-sb/raid/o10n.txt
+++ b/ui/raidboss/data/04-sb/raid/o10n.txt
@@ -9,42 +9,42 @@ hideall "--sync--"
 ## Common start
 0.0 "Start"
 0.0 "--sync--" sync /:Engage!/ window 0,1
-1.6 "--sync--" sync / 1[56]:Midgardsormr:31F9:/ window 2,0
-13.1 "Spin" sync / 1[56]:Midgardsormr:31C7:/
-19.2 "Spin" sync / 1[56]:Midgardsormr:31C9:/
-22.9 "Out" sync / 1[56]:Midgardsormr:31CD:/
-31.6 "Spin" sync / 1[56]:Midgardsormr:31C7:/
-37.7 "Spin" sync / 1[56]:Midgardsormr:31C9:/
-41.3 "Out" sync / 1[56]:Midgardsormr:31CD:/
-45.8 "Earth Shaker" sync / 1[56]:Midgardsormr:31D1:/
-57.1 "Akh Morn" sync / 1[56]:Midgardsormr:31C6:/ duration 4
-62.5 "--sync--" sync / 1[56]:Midgardsormr:3249:/
-68.9 "Spin" sync / 1[56]:Midgardsormr:31C7:/
-75.0 "Flip" sync / 1[56]:Midgardsormr:31CB:/
-78.6 "In" sync / 1[56]:Midgardsormr:31CF:/
-87.3 "Spin" sync / 1[56]:Midgardsormr:31C7:/
-93.4 "Flip/Spin" sync / 1[56]:Midgardsormr:31C[B9]:/
-96.9 "In/Out" sync / 1[56]:Midgardsormr:31C[FD]:/
-100.4 "Thunderstorm" sync / 1[56]:Midgardsormr:31D2:/
-104.9 "Horrid Roar" sync / 1[56]:Midgardsormr:31D3:/
-117.3 "Flip" sync / 1[56]:Midgardsormr:31C8:/
-123.4 "Flip" sync / 1[56]:Midgardsormr:31CB:/
-127.5 "Corners" sync / 1[56]:Midgardsormr:31D0:/
-140.6 "Dry Ice" sync / 1[56]:Midgardsormr:3632:/
-142.8 "Flip" sync / 1[56]:Midgardsormr:31C8:/
-149.0 "Flip" sync / 1[56]:Midgardsormr:31CB:/
-151.4 "--sync--" sync / 1[56]:Midgardsormr:35BB:/
-153.1 "Corners" sync / 1[56]:Midgardsormr:31D0:/
+1.6 "--sync--" sync / 1[56]:[^:]*:Midgardsormr:31F9:/ window 2,0
+13.1 "Spin" sync / 1[56]:[^:]*:Midgardsormr:31C7:/
+19.2 "Spin" sync / 1[56]:[^:]*:Midgardsormr:31C9:/
+22.9 "Out" sync / 1[56]:[^:]*:Midgardsormr:31CD:/
+31.6 "Spin" sync / 1[56]:[^:]*:Midgardsormr:31C7:/
+37.7 "Spin" sync / 1[56]:[^:]*:Midgardsormr:31C9:/
+41.3 "Out" sync / 1[56]:[^:]*:Midgardsormr:31CD:/
+45.8 "Earth Shaker" sync / 1[56]:[^:]*:Midgardsormr:31D1:/
+57.1 "Akh Morn" sync / 1[56]:[^:]*:Midgardsormr:31C6:/ duration 4
+62.5 "--sync--" sync / 1[56]:[^:]*:Midgardsormr:3249:/
+68.9 "Spin" sync / 1[56]:[^:]*:Midgardsormr:31C7:/
+75.0 "Flip" sync / 1[56]:[^:]*:Midgardsormr:31CB:/
+78.6 "In" sync / 1[56]:[^:]*:Midgardsormr:31CF:/
+87.3 "Spin" sync / 1[56]:[^:]*:Midgardsormr:31C7:/
+93.4 "Flip/Spin" sync / 1[56]:[^:]*:Midgardsormr:31C[B9]:/
+96.9 "In/Out" sync / 1[56]:[^:]*:Midgardsormr:31C[FD]:/
+100.4 "Thunderstorm" sync / 1[56]:[^:]*:Midgardsormr:31D2:/
+104.9 "Horrid Roar" sync / 1[56]:[^:]*:Midgardsormr:31D3:/
+117.3 "Flip" sync / 1[56]:[^:]*:Midgardsormr:31C8:/
+123.4 "Flip" sync / 1[56]:[^:]*:Midgardsormr:31CB:/
+127.5 "Corners" sync / 1[56]:[^:]*:Midgardsormr:31D0:/
+140.6 "Dry Ice" sync / 1[56]:[^:]*:Midgardsormr:3632:/
+142.8 "Flip" sync / 1[56]:[^:]*:Midgardsormr:31C8:/
+149.0 "Flip" sync / 1[56]:[^:]*:Midgardsormr:31CB:/
+151.4 "--sync--" sync / 1[56]:[^:]*:Midgardsormr:35BB:/
+153.1 "Corners" sync / 1[56]:[^:]*:Midgardsormr:31D0:/
 156.3 "--untargetable--"
-159.4 "--sync--" sync / 1[56]:Midgardsormr:35BC:/
-167.2 "Cauterize" sync / 1[56]:Midgardsormr:3241:/
+159.4 "--sync--" sync / 1[56]:[^:]*:Midgardsormr:35BC:/
+167.2 "Cauterize" sync / 1[56]:[^:]*:Midgardsormr:3241:/
 
-183.5 "Frost Breath" sync / 1[56]:Ancient Dragon:33EE:/ window 30,30
+183.5 "Frost Breath" sync / 1[56]:[^:]*:Ancient Dragon:33EE:/ window 30,30
 195.5 "Frost Breath ready"
 
-500.0 "Protostar x4" sync / 1[56]:Midgardsormr:31C3:/ window 500,500 duration 12
+500.0 "Protostar x4" sync / 1[56]:[^:]*:Midgardsormr:31C3:/ window 500,500 duration 12
 523.4 "--targetable--"
-536.6 "Tail End" sync / 1[56]:Midgardsormr:31C5:/
+536.6 "Tail End" sync / 1[56]:[^:]*:Midgardsormr:31C5:/
 544.6 "Exaflare"
 547.6 "Exaflare"
 550.6 "Exaflare"
@@ -52,47 +52,47 @@ hideall "--sync--"
 556.6 "Exaflare"
 
 # Loop
-559.1 "Horrid Roar" sync / 1[56]:Midgardsormr:31D3:/
-570.6 "Northern Cross" sync / 1[56]:Midgardsormr:3629:/
-575.2 "Flip/Spin" sync / 1[56]:Midgardsormr:31C[78]:/
-581.2 "Flip/Spin" sync / 1[56]:Midgardsormr:31C[B9]:/
-584.7 "In/Out/Corners" sync / 1[56]:Midgardsormr:31(CF|CD|D0):/
-596.2 "Akh Rhai" sync / 1[56]:Midgardsormr:3622:/
-598.2 "Flip" sync / 1[56]:Midgardsormr:31C8:/
-604.2 "Flip" sync / 1[56]:Midgardsormr:31CB:/
-608.2 "Corners" sync / 1[56]:Midgardsormr:31D0:/
-611.2 "Thunderstorm" sync / 1[56]:Midgardsormr:31D2:/
+559.1 "Horrid Roar" sync / 1[56]:[^:]*:Midgardsormr:31D3:/
+570.6 "Northern Cross" sync / 1[56]:[^:]*:Midgardsormr:3629:/
+575.2 "Flip/Spin" sync / 1[56]:[^:]*:Midgardsormr:31C[78]:/
+581.2 "Flip/Spin" sync / 1[56]:[^:]*:Midgardsormr:31C[B9]:/
+584.7 "In/Out/Corners" sync / 1[56]:[^:]*:Midgardsormr:31(CF|CD|D0):/
+596.2 "Akh Rhai" sync / 1[56]:[^:]*:Midgardsormr:3622:/
+598.2 "Flip" sync / 1[56]:[^:]*:Midgardsormr:31C8:/
+604.2 "Flip" sync / 1[56]:[^:]*:Midgardsormr:31CB:/
+608.2 "Corners" sync / 1[56]:[^:]*:Midgardsormr:31D0:/
+611.2 "Thunderstorm" sync / 1[56]:[^:]*:Midgardsormr:31D2:/
 615.4 "--untargetable--"
 621.2 "Exaflare"
 624.2 "Exaflare"
-624.7 "Cauterize" sync / 1[56]:Midgardsormr:3241:/
+624.7 "Cauterize" sync / 1[56]:[^:]*:Midgardsormr:3241:/
 627.2 "Exaflare"
 630.2 "Exaflare"
 633.2 "Exaflare"
-635.3 "Cauterize" sync / 1[56]:Midgardsormr:3241:/
+635.3 "Cauterize" sync / 1[56]:[^:]*:Midgardsormr:3241:/
 642.7 "--targetable--"
-646.9 "Flip/Spin" sync / 1[56]:Midgardsormr:31C[78]:/
-652.9 "Flip/Spin" sync / 1[56]:Midgardsormr:31C[B9]:/
-656.9 "In/Out/Corners" sync / 1[56]:Midgardsormr:31(CF|CD|D0):/
-660.9 "Earth Shaker" sync / 1[56]:Midgardsormr:31D1:/
+646.9 "Flip/Spin" sync / 1[56]:[^:]*:Midgardsormr:31C[78]:/
+652.9 "Flip/Spin" sync / 1[56]:[^:]*:Midgardsormr:31C[B9]:/
+656.9 "In/Out/Corners" sync / 1[56]:[^:]*:Midgardsormr:31(CF|CD|D0):/
+660.9 "Earth Shaker" sync / 1[56]:[^:]*:Midgardsormr:31D1:/
 
-669.4 "Horrid Roar" sync / 1[56]:Midgardsormr:31D3:/
-671.1 "Akh Morn" sync / 1[56]:Midgardsormr:31C6:/ duration 4
-676.3 "--sync--" sync / 1[56]:Midgardsormr:3249:/
-687.3 "Tail End" sync / 1[56]:Midgardsormr:31C5:/
-698.3 "Northern Cross" sync / 1[56]:Midgardsormr:3629:/
-706.8 "Thunderstorm" sync / 1[56]:Midgardsormr:320F:/
-707.3 "Thunderstorm" sync / 1[56]:Midgardsormr:31D2:/
-713.8 "Dry Ice" sync / 1[56]:Midgardsormr:3632:/
+669.4 "Horrid Roar" sync / 1[56]:[^:]*:Midgardsormr:31D3:/
+671.1 "Akh Morn" sync / 1[56]:[^:]*:Midgardsormr:31C6:/ duration 4
+676.3 "--sync--" sync / 1[56]:[^:]*:Midgardsormr:3249:/
+687.3 "Tail End" sync / 1[56]:[^:]*:Midgardsormr:31C5:/
+698.3 "Northern Cross" sync / 1[56]:[^:]*:Midgardsormr:3629:/
+706.8 "Thunderstorm" sync / 1[56]:[^:]*:Midgardsormr:320F:/
+707.3 "Thunderstorm" sync / 1[56]:[^:]*:Midgardsormr:31D2:/
+713.8 "Dry Ice" sync / 1[56]:[^:]*:Midgardsormr:3632:/
 721.8 "Exaflare"
-724.4 "--sync--" sync / 1[56]:Midgardsormr:35BB:/
+724.4 "--sync--" sync / 1[56]:[^:]*:Midgardsormr:35BB:/
 724.8 "Exaflare"
 727.8 "Exaflare"
 730.8 "Exaflare"
-732.4 "--sync--" sync / 1[56]:Midgardsormr:35BC:/
+732.4 "--sync--" sync / 1[56]:[^:]*:Midgardsormr:35BC:/
 733.8 "Exaflare"
 
-736.3 "Horrid Roar" sync / 1[56]:Midgardsormr:31D3:/ window 50,50 jump 559.1
+736.3 "Horrid Roar" sync / 1[56]:[^:]*:Midgardsormr:31D3:/ window 50,50 jump 559.1
 747.8 "Northern Cross"
 752.4 "Flip/Spin"
 758.4 "Flip/Spin"

--- a/ui/raidboss/data/04-sb/raid/o10s.txt
+++ b/ui/raidboss/data/04-sb/raid/o10s.txt
@@ -20,7 +20,7 @@ hideall "--sync--"
 69.9 "Tail End" sync / 1[56]:Midgardsormr:31AA:/
 
 78.2 "Spin" sync / 1[56]:Midgardsormr:31AC:/ # drift 0.039
-89.4 "Flip/Spin" sync / 1[56]:Midgardsormr:31(AE|B0)/
+89.4 "Flip/Spin" sync / 1[56]:Midgardsormr:31(AE|B0):/
 92.9 "In/Out" sync / 1[56]:(Midgardsormr)?:31B(2|4):/ # Sometimes missing actor name
 92.9 "Earth Shaker" sync / 1[56]:Midgardsormr:31B6:/ # Missing actor name on all but one
 

--- a/ui/raidboss/data/04-sb/raid/o10s.txt
+++ b/ui/raidboss/data/04-sb/raid/o10s.txt
@@ -8,96 +8,96 @@ hideall "--sync--"
 
 0.0 "Start" sync / 00:0044:[^:]*:I am Midgardsormr/ window 0,1
 0.0 "--sync--" sync /:Engage!/ window 0,1
-2.2 "--sync--" sync / 1[56]:Midgardsormr:31F9:/ window 2.5,0 # first auto
-12.3 "Flip" sync / 1[56]:Midgardsormr:31AD:/
-23.5 "Spin" sync / 1[56]:Midgardsormr:31AE:/
+2.2 "--sync--" sync / 1[56]:[^:]*:Midgardsormr:31F9:/ window 2.5,0 # first auto
+12.3 "Flip" sync / 1[56]:[^:]*:Midgardsormr:31AD:/
+23.5 "Spin" sync / 1[56]:[^:]*:Midgardsormr:31AE:/
 27.4 "Cardinals" sync /::31B3:/ # X hit, not sure of sync yet
 
-35.9 "Spin" sync / 1[56]:Midgardsormr:31AC:/ # drift 0.029
-47.1 "Akh Morn" sync / 1[56]:Midgardsormr:31AB:/
-53.6 "Spin" sync / 1[56]:Midgardsormr:31AE:/
-57.2 "Out" sync / 1[56]:Midgardsormr:31B2:/
-69.9 "Tail End" sync / 1[56]:Midgardsormr:31AA:/
+35.9 "Spin" sync / 1[56]:[^:]*:Midgardsormr:31AC:/ # drift 0.029
+47.1 "Akh Morn" sync / 1[56]:[^:]*:Midgardsormr:31AB:/
+53.6 "Spin" sync / 1[56]:[^:]*:Midgardsormr:31AE:/
+57.2 "Out" sync / 1[56]:[^:]*:Midgardsormr:31B2:/
+69.9 "Tail End" sync / 1[56]:[^:]*:Midgardsormr:31AA:/
 
-78.2 "Spin" sync / 1[56]:Midgardsormr:31AC:/ # drift 0.039
-89.4 "Flip/Spin" sync / 1[56]:Midgardsormr:31(AE|B0):/
-92.9 "In/Out" sync / 1[56]:(Midgardsormr)?:31B(2|4):/ # Sometimes missing actor name
-92.9 "Earth Shaker" sync / 1[56]:Midgardsormr:31B6:/ # Missing actor name on all but one
+78.2 "Spin" sync / 1[56]:[^:]*:Midgardsormr:31AC:/ # drift 0.039
+89.4 "Flip/Spin" sync / 1[56]:[^:]*:Midgardsormr:31(AE|B0):/
+92.9 "In/Out" sync / 1[56]:[^:]*:(Midgardsormr)?:31B(2|4):/ # Sometimes missing actor name
+92.9 "Earth Shaker" sync / 1[56]:[^:]*:Midgardsormr:31B6:/ # Missing actor name on all but one
 
-101.8 "Flip" sync / 1[56]:Midgardsormr:31AD:/
-112.0 "Tail End" sync / 1[56]:Midgardsormr:31AA:/
-114.1 "Flip/Spin" sync / 1[56]:Midgardsormr:31(AE|B0):/
-118.1 "Corners/Cardinals" sync / 1[56]:Midgardsormr:31B(3|5):/
-118.7 "Thunderstorm" sync / 1[56]:Midgardsormr:31B8:/
+101.8 "Flip" sync / 1[56]:[^:]*:Midgardsormr:31AD:/
+112.0 "Tail End" sync / 1[56]:[^:]*:Midgardsormr:31AA:/
+114.1 "Flip/Spin" sync / 1[56]:[^:]*:Midgardsormr:31(AE|B0):/
+118.1 "Corners/Cardinals" sync / 1[56]:[^:]*:Midgardsormr:31B(3|5):/
+118.7 "Thunderstorm" sync / 1[56]:[^:]*:Midgardsormr:31B8:/
 
-131.2 "Time Immemorial" sync / 1[56]:Midgardsormr:32EF:/
-141.5 "Tail End" sync / 1[56]:Midgardsormr:31AA:/
-149.8 "Spin" sync / 1[56]:Midgardsormr:31AC:/ # drift 0.041
-158.9 "Northern Cross" sync / 1[56]:Midgardsormr:3625:/
-163.1 "Flip/Spin" sync / 1[56]:Midgardsormr:31AE:/ # drift 0.021
-166.6 "In/Out" sync / 1[56]:Midgardsormr:31B(2|4):/
-173.4 "Akh Rhai" sync / 1[56]:Midgardsormr:3622:/
-175.3 "Dry Ice" sync / 1[56]:Midgardsormr:3631:/
+131.2 "Time Immemorial" sync / 1[56]:[^:]*:Midgardsormr:32EF:/
+141.5 "Tail End" sync / 1[56]:[^:]*:Midgardsormr:31AA:/
+149.8 "Spin" sync / 1[56]:[^:]*:Midgardsormr:31AC:/ # drift 0.041
+158.9 "Northern Cross" sync / 1[56]:[^:]*:Midgardsormr:3625:/
+163.1 "Flip/Spin" sync / 1[56]:[^:]*:Midgardsormr:31AE:/ # drift 0.021
+166.6 "In/Out" sync / 1[56]:[^:]*:Midgardsormr:31B(2|4):/
+173.4 "Akh Rhai" sync / 1[56]:[^:]*:Midgardsormr:3622:/
+175.3 "Dry Ice" sync / 1[56]:[^:]*:Midgardsormr:3631:/
 
-179.7 "Spin" sync / 1[56]:Midgardsormr:31AC:/ # drift 0.036
-191.0 "Flip/Spin" sync / 1[56]:Midgardsormr:31(AE|B0):/
-194.5 "In/Out" sync / 1[56]:Midgardsormr:31B(2|4):/
-194.9 "Horrid Roar" sync / 1[56]:Midgardsormr:31B9:/
+179.7 "Spin" sync / 1[56]:[^:]*:Midgardsormr:31AC:/ # drift 0.036
+191.0 "Flip/Spin" sync / 1[56]:[^:]*:Midgardsormr:31(AE|B0):/
+194.5 "In/Out" sync / 1[56]:[^:]*:Midgardsormr:31B(2|4):/
+194.9 "Horrid Roar" sync / 1[56]:[^:]*:Midgardsormr:31B9:/
 202.9 "--untargetable--"
 
 # Add phase
-215.9 "Frost Breath" sync / 1[56]:Ancient Dragon:33F1:/ window 2.5,30
+215.9 "Frost Breath" sync / 1[56]:[^:]*:Ancient Dragon:33F1:/ window 2.5,30
 226.2 "Frost Breath ready"
 
-282.0 "--sync--" sync / 1[56]:Ancient Dragon:341A:/ window 80,10
-284.2 "Protostar" sync / 1[56]:Midgardsormr:31C3:/ window 500,500
+282.0 "--sync--" sync / 1[56]:[^:]*:Ancient Dragon:341A:/ window 80,10
+284.2 "Protostar" sync / 1[56]:[^:]*:Midgardsormr:31C3:/ window 500,500
 294.8 "Protostar" # Damage instances
 295.9 "Protostar"
 297.0 "Protostar"
 
-310.9 "Horrid Roar" sync / 1[56]:Midgardsormr:31B9:/
-312.5 "Thunderstorm" sync / 1[56]:Midgardsormr:31B8:/
-313.0 "Cauterize" sync / 1[56]:Midgardsormr:3240:/
-321.8 "Horrid Roar" sync / 1[56]:Midgardsormr:31B9:/
-323.3 "Thunderstorm" sync / 1[56]:Midgardsormr:31B8:/
-323.9 "Cauterize" sync / 1[56]:Midgardsormr:3240:/
-328.0 "Touchdown" sync / 1[56]:Midgardsormr:31BB:/
+310.9 "Horrid Roar" sync / 1[56]:[^:]*:Midgardsormr:31B9:/
+312.5 "Thunderstorm" sync / 1[56]:[^:]*:Midgardsormr:31B8:/
+313.0 "Cauterize" sync / 1[56]:[^:]*:Midgardsormr:3240:/
+321.8 "Horrid Roar" sync / 1[56]:[^:]*:Midgardsormr:31B9:/
+323.3 "Thunderstorm" sync / 1[56]:[^:]*:Midgardsormr:31B8:/
+323.9 "Cauterize" sync / 1[56]:[^:]*:Midgardsormr:3240:/
+328.0 "Touchdown" sync / 1[56]:[^:]*:Midgardsormr:31BB:/
 332.5 "--targetable--"
 
-339.2 "Time Immemorial" sync / 1[56]:Midgardsormr:31BF:/
-350.7 "Crimson Breath" sync / 1[56]:Midgardsormr:31BC:/
-357.9 "Crimson Breath" sync / 1[56]:Midgardsormr:31BC:/
-365.3 "Crimson Breath" sync / 1[56]:Midgardsormr:31BC:/
-372.5 "Crimson Breath" sync / 1[56]:Midgardsormr:31BC:/
-390.3 "Horrid Roar" sync / 1[56]:Midgardsormr:3414:/
+339.2 "Time Immemorial" sync / 1[56]:[^:]*:Midgardsormr:31BF:/
+350.7 "Crimson Breath" sync / 1[56]:[^:]*:Midgardsormr:31BC:/
+357.9 "Crimson Breath" sync / 1[56]:[^:]*:Midgardsormr:31BC:/
+365.3 "Crimson Breath" sync / 1[56]:[^:]*:Midgardsormr:31BC:/
+372.5 "Crimson Breath" sync / 1[56]:[^:]*:Midgardsormr:31BC:/
+390.3 "Horrid Roar" sync / 1[56]:[^:]*:Midgardsormr:3414:/
 390.3 "Flame Blast"
 392.9 "Flame Blast"
 395.3 "Flame Blast"
-396.9 "Hot Tail" sync / 1[56]:Midgardsormr:31BD:/
+396.9 "Hot Tail" sync / 1[56]:[^:]*:Midgardsormr:31BD:/
 
 408.1 "--untargetable--"
 412.3 "Exaflare"
-412.8 "Horrid Roar" sync / 1[56]:Midgardsormr:31B9:/
-414.9 "Cauterize" sync / 1[56]:Midgardsormr:3240:/
+412.8 "Horrid Roar" sync / 1[56]:[^:]*:Midgardsormr:31B9:/
+414.9 "Cauterize" sync / 1[56]:[^:]*:Midgardsormr:3240:/
 415.3 "Exaflare"
 418.3 "Exaflare"
 421.4 "Exaflare"
-423.7 "Horrid Roar" sync / 1[56]:Midgardsormr:31B9:/ # drift 0.033
+423.7 "Horrid Roar" sync / 1[56]:[^:]*:Midgardsormr:31B9:/ # drift 0.033
 424.4 "Exaflare"
-425.8 "Cauterize" sync / 1[56]:Midgardsormr:3240:/ # drift 0.048
+425.8 "Cauterize" sync / 1[56]:[^:]*:Midgardsormr:3240:/ # drift 0.048
 
 431.8 "--targetable--"
-444.8 "Tail End" sync / 1[56]:Midgardsormr:31AA:/
-456.0 "Akh Morn" sync / 1[56]:Midgardsormr:31AB:/ # drift -0.033
-466.0 "Horrid Roar" sync / 1[56]:Midgardsormr:31B9:/
-467.6 "Thunderstorm" sync / 1[56]:Midgardsormr:31B8:/
+444.8 "Tail End" sync / 1[56]:[^:]*:Midgardsormr:31AA:/
+456.0 "Akh Morn" sync / 1[56]:[^:]*:Midgardsormr:31AB:/ # drift -0.033
+466.0 "Horrid Roar" sync / 1[56]:[^:]*:Midgardsormr:31B9:/
+467.6 "Thunderstorm" sync / 1[56]:[^:]*:Midgardsormr:31B8:/
 
 ##################
 ## Branch point ##
 ##################
 
-474.4 "Flip/Spin" sync / 1[56]:Midgardsormr:31AC:/ jump 1474.4 # C means spin
-474.4 "--sync--" sync / 1[56]:Midgardsormr:31AD:/ jump 2474.4 # D means flip
+474.4 "Flip/Spin" sync / 1[56]:[^:]*:Midgardsormr:31AC:/ jump 1474.4 # C means spin
+474.4 "--sync--" sync / 1[56]:[^:]*:Midgardsormr:31AD:/ jump 2474.4 # D means flip
 484.5 "Tail End" # Cosmetic
 486.6 "Flip/Spin"
 490.6 "Signal?"
@@ -105,12 +105,12 @@ hideall "--sync--"
 
 ## Branch A1: Spin->Earthshaker
 
-1474.4 "Spin" sync / 1[56]:Midgardsormr:31AC:/
-1484.5 "Tail End" sync / 1[56]:Midgardsormr:31AA:/
-1486.6 "Flip/Spin" sync / 1[56]:Midgardsormr:31AE:/
-1490.6 "In/Out" sync / 1[56]:Midgardsormr:31B(2|4):/
-1490.6 "Earth Shaker" sync / 1[56]:Midgardsormr:31B6:/
-1502.3 "Time Immemorial" sync / 1[56]:Midgardsormr:32EF:/ jump 502.3
+1474.4 "Spin" sync / 1[56]:[^:]*:Midgardsormr:31AC:/
+1484.5 "Tail End" sync / 1[56]:[^:]*:Midgardsormr:31AA:/
+1486.6 "Flip/Spin" sync / 1[56]:[^:]*:Midgardsormr:31AE:/
+1490.6 "In/Out" sync / 1[56]:[^:]*:Midgardsormr:31B(2|4):/
+1490.6 "Earth Shaker" sync / 1[56]:[^:]*:Midgardsormr:31B6:/
+1502.3 "Time Immemorial" sync / 1[56]:[^:]*:Midgardsormr:32EF:/ jump 502.3
 1512.6 "Exaflare" # Cosmetic
 1513.7 "Dry Ice"
 1515.7 "Exaflare"
@@ -120,12 +120,12 @@ hideall "--sync--"
 
 ## Branch B1: Flip->Thunderstorm
 
-2474.4 "Flip" sync / 1[56]:Midgardsormr:31AD:/
-2484.5 "Tail End" sync / 1[56]:Midgardsormr:31AA:/
-2486.6 "Flip/Spin" sync / 1[56]:Midgardsormr:31AE:/
-2490.6 "Corners/Cardinals" sync / 1[56]:Midgardsormr:31B(3|5):/
-2492.1 "Thunderstorm" sync / 1[56]:Midgardsormr:31B8:/
-2502.3 "Time Immemorial" sync / 1[56]:Midgardsormr:32EF:/ jump 502.3
+2474.4 "Flip" sync / 1[56]:[^:]*:Midgardsormr:31AD:/
+2484.5 "Tail End" sync / 1[56]:[^:]*:Midgardsormr:31AA:/
+2486.6 "Flip/Spin" sync / 1[56]:[^:]*:Midgardsormr:31AE:/
+2490.6 "Corners/Cardinals" sync / 1[56]:[^:]*:Midgardsormr:31B(3|5):/
+2492.1 "Thunderstorm" sync / 1[56]:[^:]*:Midgardsormr:31B8:/
+2502.3 "Time Immemorial" sync / 1[56]:[^:]*:Midgardsormr:32EF:/ jump 502.3
 2512.6 "Exaflare" # Cosmetic
 2513.7 "Dry Ice"
 2515.7 "Exaflare"
@@ -137,12 +137,12 @@ hideall "--sync--"
 ## Branches A1/B1 converge back ##
 ##################################
 
-502.3 "Time Immemorial" sync / 1[56]:Midgardsormr:32EF:/
+502.3 "Time Immemorial" sync / 1[56]:[^:]*:Midgardsormr:32EF:/
 512.6 "Exaflare"
-513.7 "Dry Ice" sync / 1[56]:Midgardsormr:3631:/
+513.7 "Dry Ice" sync / 1[56]:[^:]*:Midgardsormr:3631:/
 515.7 "Exaflare"
 518.6 "Exaflare"
-520.8 "Akh Morn" sync / 1[56]:Midgardsormr:31AB:/
+520.8 "Akh Morn" sync / 1[56]:[^:]*:Midgardsormr:31AB:/
 521.7 "Exaflare"
 524.7 "Exaflare"
 
@@ -150,31 +150,31 @@ hideall "--sync--"
 ## Branch point ##
 ##################
 
-536.8 "Flip/Spin" sync / 1[56]:Midgardsormr:31AC:/ jump 1536.8 # C means spin->shaker
-536.8 "--sync--" sync / 1[56]:Midgardsormr:31AD:/ jump 2536.8 # D means flip->thunder
+536.8 "Flip/Spin" sync / 1[56]:[^:]*:Midgardsormr:31AC:/ jump 1536.8 # C means spin->shaker
+536.8 "--sync--" sync / 1[56]:[^:]*:Midgardsormr:31AD:/ jump 2536.8 # D means flip->thunder
 545.9 "Northern Cross" # Cosmetic
 550.1 "Spin/Flip"
 553.6 "Position"
 553.6 "Shaker/Thunder"
 
 ## Branch A2: Spin->Earthshaker
-1536.8 "Spin" sync / 1[56]:Midgardsormr:31AC:/
-1545.9 "Northern Cross" sync / 1[56]:Midgardsormr:3625:/
-1550.1 "Spin/Flip" sync / 1[56]:Midgardsormr:31AE:/
-1553.6 "In/Out" sync / 1[56]:Midgardsormr:31B(2|4):/
-1553.6 "Earth Shaker" sync / 1[56]:Midgardsormr:31B6:/
-1562.3 "Horrid Roar" sync / 1[56]:Midgardsormr:31B9:/ jump 562.3
+1536.8 "Spin" sync / 1[56]:[^:]*:Midgardsormr:31AC:/
+1545.9 "Northern Cross" sync / 1[56]:[^:]*:Midgardsormr:3625:/
+1550.1 "Spin/Flip" sync / 1[56]:[^:]*:Midgardsormr:31AE:/
+1553.6 "In/Out" sync / 1[56]:[^:]*:Midgardsormr:31B(2|4):/
+1553.6 "Earth Shaker" sync / 1[56]:[^:]*:Midgardsormr:31B6:/
+1562.3 "Horrid Roar" sync / 1[56]:[^:]*:Midgardsormr:31B9:/ jump 562.3
 1573.4 "Akh Rhai" # Cosmetic
 1579.6 "Tail End"
 1587.9 "Flip/Spin"
 
 ## Branch B2: Flip->Thunderstorm
-2536.8 "Flip" sync / 1[56]:Midgardsormr:31AD:/
-2545.9 "Northern Cross" sync / 1[56]:Midgardsormr:3625:/
-2550.1 "Spin/Flip" sync / 1[56]:Midgardsormr:31AE:/
-2553.6 "Corners/Cardinals" sync / 1[56]:Midgardsormr:31B(3|5):/
-2555.1 "Thunderstorm" sync / 1[56]:Midgardsormr:31B8:/
-2562.3 "Horrid Roar" sync / 1[56]:Midgardsormr:31B9:/ jump 562.3
+2536.8 "Flip" sync / 1[56]:[^:]*:Midgardsormr:31AD:/
+2545.9 "Northern Cross" sync / 1[56]:[^:]*:Midgardsormr:3625:/
+2550.1 "Spin/Flip" sync / 1[56]:[^:]*:Midgardsormr:31AE:/
+2553.6 "Corners/Cardinals" sync / 1[56]:[^:]*:Midgardsormr:31B(3|5):/
+2555.1 "Thunderstorm" sync / 1[56]:[^:]*:Midgardsormr:31B8:/
+2562.3 "Horrid Roar" sync / 1[56]:[^:]*:Midgardsormr:31B9:/ jump 562.3
 2573.4 "Akh Rhai" # Cosmetic
 2579.6 "Tail End"
 2587.9 "Flip/Spin"
@@ -183,17 +183,17 @@ hideall "--sync--"
 ## Branches A2/B2 converge back ##
 ##################################
 
-562.3 "Horrid Roar" sync / 1[56]:Midgardsormr:31B9:/
-573.4 "Akh Rhai" sync / 1[56]:Midgardsormr:3622:/
-579.6 "Tail End" sync / 1[56]:Midgardsormr:31AA:/ # drift 0.026
+562.3 "Horrid Roar" sync / 1[56]:[^:]*:Midgardsormr:31B9:/
+573.4 "Akh Rhai" sync / 1[56]:[^:]*:Midgardsormr:3622:/
+579.6 "Tail End" sync / 1[56]:[^:]*:Midgardsormr:31AA:/ # drift 0.026
 
 ##################
 ## Branch point ##
 ##################
 
 # Return to A1/B1
-587.9 "Flip/Spin" sync / 1[56]:Midgardsormr:31AC:/ jump 1474.4 # C means spin->shaker
-587.9 "--sync--" sync / 1[56]:Midgardsormr:31AD:/ jump 2474.4 # D means flip->thunder
+587.9 "Flip/Spin" sync / 1[56]:[^:]*:Midgardsormr:31AC:/ jump 1474.4 # C means spin->shaker
+587.9 "--sync--" sync / 1[56]:[^:]*:Midgardsormr:31AD:/ jump 2474.4 # D means flip->thunder
 598.0 "Tail End" # Cosmetic
 600.1 "Flip/Spin"
 604.1 "Signal?"
@@ -201,7 +201,7 @@ hideall "--sync--"
 615.8 "Time Immemorial"
 
 # Enrage
-700.0 "--sync--" sync / 14:Midgardsormr:3247:/ window 700,3000
+700.0 "--sync--" sync / 14:[^:]*:Midgardsormr:3247:/ window 700,3000
 704.9 "Enrage Hit 1"
 707.2 "Enrage Hit 2"
 708.5 "Enrage Hit 3"

--- a/ui/raidboss/data/04-sb/raid/o11n.txt
+++ b/ui/raidboss/data/04-sb/raid/o11n.txt
@@ -8,99 +8,99 @@ hideall "--sync--"
 ## Common start
 0.0 "Start"
 0.0 "--sync--" sync /:Engage!/ window 0,1
-1.5 "--sync--" sync / 1[56]:Omega:368:/ window 2,0
-12.8 "Atomic Ray" sync / 1[56]:Omega:3286:/ window 20,80
-24.9 "Mustard Bomb" sync / 1[56]:Omega:3287:/
-27.0 "Ballistic Missile?" sync / 1[56]:Omega:327E:/ window 30,40 jump 227.0
+1.5 "--sync--" sync / 1[56]:[^:]*:Omega:368:/ window 2,0
+12.8 "Atomic Ray" sync / 1[56]:[^:]*:Omega:3286:/ window 20,80
+24.9 "Mustard Bomb" sync / 1[56]:[^:]*:Omega:3287:/
+27.0 "Ballistic Missile?" sync / 1[56]:[^:]*:Omega:327E:/ window 30,40 jump 227.0
 37.1 "Flamethrower?"
-38.1 "Starboard/Larboard Cannon?" sync / 1[56]:Omega:328[13]:/ window 40,40 jump 138.1
+38.1 "Starboard/Larboard Cannon?" sync / 1[56]:[^:]*:Omega:328[13]:/ window 40,40 jump 138.1
 43.8 "Starboard/Larboard Cannon?"
 
 ## Starboard/Larboard first path
-138.1 "Starboard/Larboard Cannon" sync / 1[56]:Omega:328[13]:/
-143.8 "Starboard/Larboard Cannon" sync / 1[56]:Omega:328[24]:/
-146.5 "Ballistic Missile" sync / 1[56]:Omega:327E:/
-156.7 "Flamethrower" sync / 1[56]:Omega:327D:/
-156.7 "Ballistic Impact" sync / 1[56]:Omega:327F:/
-167.8 "Mustard Bomb" sync / 1[56]:Omega:3287:/ # drift 0.044
-178.7 "Peripheral Synthesis" sync / 1[56]:Omega:3270:/ window 50,10 jump 478.7
+138.1 "Starboard/Larboard Cannon" sync / 1[56]:[^:]*:Omega:328[13]:/
+143.8 "Starboard/Larboard Cannon" sync / 1[56]:[^:]*:Omega:328[24]:/
+146.5 "Ballistic Missile" sync / 1[56]:[^:]*:Omega:327E:/
+156.7 "Flamethrower" sync / 1[56]:[^:]*:Omega:327D:/
+156.7 "Ballistic Impact" sync / 1[56]:[^:]*:Omega:327F:/
+167.8 "Mustard Bomb" sync / 1[56]:[^:]*:Omega:3287:/ # drift 0.044
+178.7 "Peripheral Synthesis" sync / 1[56]:[^:]*:Omega:3270:/ window 50,10 jump 478.7
 203.5 "Peripheral Synthesis"
 217.6 "Flamethrower"
 227.8 "Atomic Ray"
 
 ## Ballistic Missile first path
-227.0 "Ballistic Missile" sync / 1[56]:Omega:327E:/
-237.1 "Flamethrower" sync / 1[56]:Omega:327D:/
-237.1 "Ballistic Impact" sync / 1[56]:Omega:327F:/
-248.2 "Mustard Bomb" sync / 1[56]:Omega:3287:/
-261.4 "Starboard/Larboard Cannon" sync / 1[56]:Omega:328[13]:/
-267.0 "Starboard/Larboard Cannon" sync / 1[56]:Omega:328[24]:/
-278.7 "Peripheral Synthesis" sync / 1[56]:Omega:3270:/ window 50,10 jump 478.7
+227.0 "Ballistic Missile" sync / 1[56]:[^:]*:Omega:327E:/
+237.1 "Flamethrower" sync / 1[56]:[^:]*:Omega:327D:/
+237.1 "Ballistic Impact" sync / 1[56]:[^:]*:Omega:327F:/
+248.2 "Mustard Bomb" sync / 1[56]:[^:]*:Omega:3287:/
+261.4 "Starboard/Larboard Cannon" sync / 1[56]:[^:]*:Omega:328[13]:/
+267.0 "Starboard/Larboard Cannon" sync / 1[56]:[^:]*:Omega:328[24]:/
+278.7 "Peripheral Synthesis" sync / 1[56]:[^:]*:Omega:3270:/ window 50,10 jump 478.7
 303.5 "Peripheral Synthesis"
 317.6 "Flamethrower"
 327.8 "Atomic Ray"
 
 ## Paths converge
-478.7 "Peripheral Synthesis" sync / 1[56]:Omega:3270:/
-503.5 "Peripheral Synthesis" sync / 1[56]:Omega:3270:/
-517.6 "Flamethrower" sync / 1[56]:Omega:327D:/
-527.8 "Atomic Ray" sync / 1[56]:Omega:3286:/
+478.7 "Peripheral Synthesis" sync / 1[56]:[^:]*:Omega:3270:/
+503.5 "Peripheral Synthesis" sync / 1[56]:[^:]*:Omega:3270:/
+517.6 "Flamethrower" sync / 1[56]:[^:]*:Omega:327D:/
+527.8 "Atomic Ray" sync / 1[56]:[^:]*:Omega:3286:/
 
 ## Midphase
-534.5 "Program Loop" sync / 1[56]:Omega:3273:/ window 150,150
+534.5 "Program Loop" sync / 1[56]:[^:]*:Omega:3273:/ window 150,150
 534.5 "--untargetable--"
-549.6 "Executable 1" sync / 1[56]:Level Checker:35A8:/
-570.6 "Executable 2" sync / 1[56]:Level Checker:35A8:/
-574.6 "Reset" sync / 1[56]:Level Checker:35AA:/
-578.6 "Reformat" sync / 1[56]:Level Checker:35A9:/
-587.6 "--sync--" sync / 14:Level Checker:327A:/
-611.6 "Force Quit" sync / 1[56]:Level Checker:327A:/
+549.6 "Executable 1" sync / 1[56]:[^:]*:Level Checker:35A8:/
+570.6 "Executable 2" sync / 1[56]:[^:]*:Level Checker:35A8:/
+574.6 "Reset" sync / 1[56]:[^:]*:Level Checker:35AA:/
+578.6 "Reformat" sync / 1[56]:[^:]*:Level Checker:35A9:/
+587.6 "--sync--" sync / 14:[^:]*:Level Checker:327A:/
+611.6 "Force Quit" sync / 1[56]:[^:]*:Level Checker:327A:/
 
 ## Delta Attack
 1000.0 "--sync--" sync / 00:0044:Omega:Program failure detected/ window 1500,100
-1007.0 "--sync--" sync / 14:Omega:327B:/ window 1500,100
-1037.0 "Delta Attack" sync / 1[56]:Omega:327B:/ window 1500,100
+1007.0 "--sync--" sync / 14:[^:]*:Omega:327B:/ window 1500,100
+1037.0 "Delta Attack" sync / 1[56]:[^:]*:Omega:327B:/ window 1500,100
 1048.4 "--targetable--"
 
 ## Loop
-1060.3 "Peripheral Synthesis" sync / 1[56]:Omega:3270:/ window 10,10
-1070.5 "Flamethrower" sync / 1[56]:Omega:327D:/
-1072.9 "Rush" sync / 1[56]:Rocket Punch:359C:/
-1078.7 "Peripheral Synthesis" sync / 1[56]:Omega:3270:/
-1081.8 "Ballistic Missile" sync / 1[56]:Omega:327E:/
-1091.3 "Rush" sync / 1[56]:Rocket Punch:359C:/ # drift -0.041999
-1091.9 "Ballistic Impact" sync / 1[56]:Omega:327F:/
-1101.0 "Electric Slide" sync / 1[56]:Omega:3285:/
-1115.3 "Mustard Bomb" sync / 1[56]:Omega:3287:/
-1117.6 "Blaster" sync / 1[56]:Omega:3280:/
-1127.7 "Starboard/Larboard Cannon" sync / 1[56]:Omega:328[13]:/
-1133.4 "Starboard/Larboard Cannon" sync / 1[56]:Omega:328[24]:/
-1140.1 "Atomic Ray" sync / 1[56]:Omega:3286:/
-1150.3 "Peripheral Synthesis" sync / 1[56]:Omega:3270:/ # drift 0.046
-1163.0 "Rush" sync / 1[56]:Rocket Punch:359C:/
-1175.1 "Peripheral Synthesis" sync / 1[56]:Omega:3270:/
-1185.3 "Flamethrower" sync / 1[56]:Omega:327D:/
-1187.6 "Rush" sync / 1[56]:Rocket Punch:359C:/
-1196.4 "Atomic Ray" sync / 1[56]:Omega:3286:/
-1204.5 "Ballistic Missile" sync / 1[56]:Omega:327E:/ # drift 0.042
-1214.6 "Flamethrower" sync / 1[56]:Omega:327D:/
-1214.6 "Ballistic Impact" sync / 1[56]:Omega:327F:/
-1221.7 "Starboard/Larboard Cannon" sync / 1[56]:Omega:328[13]:/
-1227.3 "Starboard/Larboard Cannon" sync / 1[56]:Omega:328[24]:/
-1237.1 "Peripheral Synthesis" sync / 1[56]:Omega:3270:/
-1249.8 "Rush" sync / 1[56]:Rocket Punch:359C:/
-1255.6 "Electric Slide" sync / 1[56]:Omega:3285:/ # drift -0.049
-1262.7 "Starboard/Larboard Cannon" sync / 1[56]:Omega:328[13]:/
-1268.4 "Starboard/Larboard Cannon" sync / 1[56]:Omega:328[24]:/
-1275.0 "Atomic Ray" sync / 1[56]:Omega:3286:/ # drift 0.042999
-1290.3 "Mustard Bomb" sync / 1[56]:Omega:3287:/
-1303.5 "Mustard Bomb" sync / 1[56]:Omega:3287:/
-1305.6 "Blaster" sync / 1[56]:Omega:3280:/ # drift 0.046001
-1314.8 "Atomic Ray" sync / 1[56]:Omega:3286:/
-1320.9 "Atomic Ray" sync / 1[56]:Omega:3286:/
+1060.3 "Peripheral Synthesis" sync / 1[56]:[^:]*:Omega:3270:/ window 10,10
+1070.5 "Flamethrower" sync / 1[56]:[^:]*:Omega:327D:/
+1072.9 "Rush" sync / 1[56]:[^:]*:Rocket Punch:359C:/
+1078.7 "Peripheral Synthesis" sync / 1[56]:[^:]*:Omega:3270:/
+1081.8 "Ballistic Missile" sync / 1[56]:[^:]*:Omega:327E:/
+1091.3 "Rush" sync / 1[56]:[^:]*:Rocket Punch:359C:/ # drift -0.041999
+1091.9 "Ballistic Impact" sync / 1[56]:[^:]*:Omega:327F:/
+1101.0 "Electric Slide" sync / 1[56]:[^:]*:Omega:3285:/
+1115.3 "Mustard Bomb" sync / 1[56]:[^:]*:Omega:3287:/
+1117.6 "Blaster" sync / 1[56]:[^:]*:Omega:3280:/
+1127.7 "Starboard/Larboard Cannon" sync / 1[56]:[^:]*:Omega:328[13]:/
+1133.4 "Starboard/Larboard Cannon" sync / 1[56]:[^:]*:Omega:328[24]:/
+1140.1 "Atomic Ray" sync / 1[56]:[^:]*:Omega:3286:/
+1150.3 "Peripheral Synthesis" sync / 1[56]:[^:]*:Omega:3270:/ # drift 0.046
+1163.0 "Rush" sync / 1[56]:[^:]*:Rocket Punch:359C:/
+1175.1 "Peripheral Synthesis" sync / 1[56]:[^:]*:Omega:3270:/
+1185.3 "Flamethrower" sync / 1[56]:[^:]*:Omega:327D:/
+1187.6 "Rush" sync / 1[56]:[^:]*:Rocket Punch:359C:/
+1196.4 "Atomic Ray" sync / 1[56]:[^:]*:Omega:3286:/
+1204.5 "Ballistic Missile" sync / 1[56]:[^:]*:Omega:327E:/ # drift 0.042
+1214.6 "Flamethrower" sync / 1[56]:[^:]*:Omega:327D:/
+1214.6 "Ballistic Impact" sync / 1[56]:[^:]*:Omega:327F:/
+1221.7 "Starboard/Larboard Cannon" sync / 1[56]:[^:]*:Omega:328[13]:/
+1227.3 "Starboard/Larboard Cannon" sync / 1[56]:[^:]*:Omega:328[24]:/
+1237.1 "Peripheral Synthesis" sync / 1[56]:[^:]*:Omega:3270:/
+1249.8 "Rush" sync / 1[56]:[^:]*:Rocket Punch:359C:/
+1255.6 "Electric Slide" sync / 1[56]:[^:]*:Omega:3285:/ # drift -0.049
+1262.7 "Starboard/Larboard Cannon" sync / 1[56]:[^:]*:Omega:328[13]:/
+1268.4 "Starboard/Larboard Cannon" sync / 1[56]:[^:]*:Omega:328[24]:/
+1275.0 "Atomic Ray" sync / 1[56]:[^:]*:Omega:3286:/ # drift 0.042999
+1290.3 "Mustard Bomb" sync / 1[56]:[^:]*:Omega:3287:/
+1303.5 "Mustard Bomb" sync / 1[56]:[^:]*:Omega:3287:/
+1305.6 "Blaster" sync / 1[56]:[^:]*:Omega:3280:/ # drift 0.046001
+1314.8 "Atomic Ray" sync / 1[56]:[^:]*:Omega:3286:/
+1320.9 "Atomic Ray" sync / 1[56]:[^:]*:Omega:3286:/
 
 # Loop lookahead
-1334.2 "Peripheral Synthesis" sync / 1[56]:Omega:3270:/ window 50,50 jump 1060.3
+1334.2 "Peripheral Synthesis" sync / 1[56]:[^:]*:Omega:3270:/ window 50,50 jump 1060.3
 1344.4 "Flamethrower"
 1346.8 "Rush"
 1352.6 "Peripheral Synthesis"

--- a/ui/raidboss/data/04-sb/raid/o11s.txt
+++ b/ui/raidboss/data/04-sb/raid/o11s.txt
@@ -11,108 +11,108 @@ hideall "--sync--"
 
 # Phase 1
 0.0 "--sync--" sync /:Engage!/ window 0,1
-2.5 "--sync--" sync / 1[56]:Omega:368:/ window 3,0
-8.0 "--sync--" sync / 14:Omega:326C:/ window 8,8
-12.0 "Atomic Ray" sync / 1[56]:Omega:326C:/
-24.0 "Mustard Bomb" sync / 1[56]:Omega:326D:/
-30.0 "Flamethrower" sync / 1[56]:Omega:325C:/
-32.0 "Afterburner" sync / 1[56]:Omega:325E:/
-39.5 "Starboard/Larboard Cannon" sync / 1[56]:Omega:326[24]:/
-45.0 "Starboard/Larboard Cannon" sync / 1[56]:Omega:326[35]:/
+2.5 "--sync--" sync / 1[56]:[^:]*:Omega:368:/ window 3,0
+8.0 "--sync--" sync / 14:[^:]*:Omega:326C:/ window 8,8
+12.0 "Atomic Ray" sync / 1[56]:[^:]*:Omega:326C:/
+24.0 "Mustard Bomb" sync / 1[56]:[^:]*:Omega:326D:/
+30.0 "Flamethrower" sync / 1[56]:[^:]*:Omega:325C:/
+32.0 "Afterburner" sync / 1[56]:[^:]*:Omega:325E:/
+39.5 "Starboard/Larboard Cannon" sync / 1[56]:[^:]*:Omega:326[24]:/
+45.0 "Starboard/Larboard Cannon" sync / 1[56]:[^:]*:Omega:326[35]:/
 # Note: this looks like it can push early.
-53.5 "--sync--" sync / 14:Omega:324A:/ window 60,10
-56.5 "Peripheral Synthesis" sync / 1[56]:Omega:324A:/
-72.5 "Mustard Bomb" sync / 1[56]:Omega:326D:/
+53.5 "--sync--" sync / 14:[^:]*:Omega:324A:/ window 60,10
+56.5 "Peripheral Synthesis" sync / 1[56]:[^:]*:Omega:324A:/
+72.5 "Mustard Bomb" sync / 1[56]:[^:]*:Omega:326D:/
 
 ### Phase 2: Tower Dance
-87.5 "--sync--" sync / 14:Omega:3251:/ window 90,10
+87.5 "--sync--" sync / 14:[^:]*:Omega:3251:/ window 90,10
 91.5 "--untargetable--"
-91.5 "Program Loop" sync / 1[56]:Omega:3251:/
+91.5 "Program Loop" sync / 1[56]:[^:]*:Omega:3251:/
 101.6 "--targetable--"
-106.5 "Executable" sync / 1[56]:Level Checker:3626:/
-115.5 "Ferrofluid" sync / 1[56]:Level Checker:3253:/
-116.5 "Magnetism" sync / 1[56]:Level Checker:3254:/
-116.5 "Repel" sync / 1[56]:Level Checker:3255:/
-116.5 "Magnetism" sync / 1[56]:Level Checker:3254:/
-118.5 "Dual Storage Violation" sync / 1[56]:Omega:3258:/
-128.5 "Executable" sync / 1[56]:Level Checker:3626:/
-139.5 "Dual Storage Violation" sync / 1[56]:Omega:3258:/
-145.5 "Storage Violation" sync / 1[56]:Omega:3256:/
-147.5 "Dual Storage Violation" sync / 1[56]:Omega:3258:/
-153.5 "Storage Violation" sync / 1[56]:Omega:3256:/
-155.5 "Dual Storage Violation" sync / 1[56]:Omega:3258:/
-158.4 "Reset" sync / 1[56]:Level Checker:3628:/
-161.4 "Storage Violation" sync / 1[56]:Omega:3256:/
-164.4 "Reformat" sync / 1[56]:Level Checker:3627:/
+106.5 "Executable" sync / 1[56]:[^:]*:Level Checker:3626:/
+115.5 "Ferrofluid" sync / 1[56]:[^:]*:Level Checker:3253:/
+116.5 "Magnetism" sync / 1[56]:[^:]*:Level Checker:3254:/
+116.5 "Repel" sync / 1[56]:[^:]*:Level Checker:3255:/
+116.5 "Magnetism" sync / 1[56]:[^:]*:Level Checker:3254:/
+118.5 "Dual Storage Violation" sync / 1[56]:[^:]*:Omega:3258:/
+128.5 "Executable" sync / 1[56]:[^:]*:Level Checker:3626:/
+139.5 "Dual Storage Violation" sync / 1[56]:[^:]*:Omega:3258:/
+145.5 "Storage Violation" sync / 1[56]:[^:]*:Omega:3256:/
+147.5 "Dual Storage Violation" sync / 1[56]:[^:]*:Omega:3258:/
+153.5 "Storage Violation" sync / 1[56]:[^:]*:Omega:3256:/
+155.5 "Dual Storage Violation" sync / 1[56]:[^:]*:Omega:3258:/
+158.4 "Reset" sync / 1[56]:[^:]*:Level Checker:3628:/
+161.4 "Storage Violation" sync / 1[56]:[^:]*:Omega:3256:/
+164.4 "Reformat" sync / 1[56]:[^:]*:Level Checker:3627:/
 185.9 "Force Quit Enrage"
 
 ### Phase 3
-300.0 "--sync--" sync / 14:Omega:325B:/ window 200,200
-310.0 "Delta Attack" sync / 1[56]:Omega:325B:/
+300.0 "--sync--" sync / 14:[^:]*:Omega:325B:/ window 200,200
+310.0 "Delta Attack" sync / 1[56]:[^:]*:Omega:325B:/
 321.4 "--targetable--"
-330.1 "Ballistic Missile" sync / 1[56]:Omega:325F:/
-337.2 "Flamethrower" sync / 1[56]:Omega:325C:/
-339.3 "Afterburner" sync / 1[56]:Omega:325E:/
-340.3 "Ballistic Impact" sync / 1[56]:Omega:3260:/
-346.8 "Starboard/Larboard Cannon" sync / 1[56]:Omega:326[24]:/
-352.3 "Starboard/Larboard Cannon" sync / 1[56]:Omega:326[35]:/
-366.8 "Mustard Bomb" sync / 1[56]:Omega:326D:/
-368.9 "Blaster" sync / 1[56]:Omega:3261:/
-377.0 "Atomic Ray" sync / 1[56]:Omega:326C:/
+330.1 "Ballistic Missile" sync / 1[56]:[^:]*:Omega:325F:/
+337.2 "Flamethrower" sync / 1[56]:[^:]*:Omega:325C:/
+339.3 "Afterburner" sync / 1[56]:[^:]*:Omega:325E:/
+340.3 "Ballistic Impact" sync / 1[56]:[^:]*:Omega:3260:/
+346.8 "Starboard/Larboard Cannon" sync / 1[56]:[^:]*:Omega:326[24]:/
+352.3 "Starboard/Larboard Cannon" sync / 1[56]:[^:]*:Omega:326[35]:/
+366.8 "Mustard Bomb" sync / 1[56]:[^:]*:Omega:326D:/
+368.9 "Blaster" sync / 1[56]:[^:]*:Omega:3261:/
+377.0 "Atomic Ray" sync / 1[56]:[^:]*:Omega:326C:/
 
-387.0 "--sync--" sync / 14:Omega:324A:/ window 90,10
-390.0 "Peripheral Synthesis" sync / 1[56]:Omega:324A:/
-403.0 "Rush" sync / 1[56]:Rocket Punch:3250:/
-410.0 "Electric Slide" sync / 1[56]:Omega:326B:/
-419.0 "Peripheral Synthesis" sync / 1[56]:Omega:324A:/
-432.0 "Rush" sync / 1[56]:Rocket Punch:3250:/
-438.0 "Starboard/Larboard Cannon" sync / 1[56]:Omega:326[24]:/
-443.5 "Starboard/Larboard Cannon" sync / 1[56]:Omega:326[35]:/
+387.0 "--sync--" sync / 14:[^:]*:Omega:324A:/ window 90,10
+390.0 "Peripheral Synthesis" sync / 1[56]:[^:]*:Omega:324A:/
+403.0 "Rush" sync / 1[56]:[^:]*:Rocket Punch:3250:/
+410.0 "Electric Slide" sync / 1[56]:[^:]*:Omega:326B:/
+419.0 "Peripheral Synthesis" sync / 1[56]:[^:]*:Omega:324A:/
+432.0 "Rush" sync / 1[56]:[^:]*:Rocket Punch:3250:/
+438.0 "Starboard/Larboard Cannon" sync / 1[56]:[^:]*:Omega:326[24]:/
+443.5 "Starboard/Larboard Cannon" sync / 1[56]:[^:]*:Omega:326[35]:/
 
 ### Phase 4: Updated Program Light Show
-457.0 "Update Program" sync / 1[56]:Omega:36FC:/
-469.0 "Flamethrower" sync / 1[56]:Omega:36FE:/
-471.0 "Afterburner" sync / 1[56]:Omega:3700:/
-477.5 "Starboard/Larboard Surge" sync / 1[56]:Omega:326[68]:/
-480.0 "Starboard/Larboard Surge" sync / 1[56]:Omega:326[79]:/
+457.0 "Update Program" sync / 1[56]:[^:]*:Omega:36FC:/
+469.0 "Flamethrower" sync / 1[56]:[^:]*:Omega:36FE:/
+471.0 "Afterburner" sync / 1[56]:[^:]*:Omega:3700:/
+477.5 "Starboard/Larboard Surge" sync / 1[56]:[^:]*:Omega:326[68]:/
+480.0 "Starboard/Larboard Surge" sync / 1[56]:[^:]*:Omega:326[79]:/
 
-496.0 "Pantokrator 1" sync / 1[56]:Omega:3702:/
+496.0 "Pantokrator 1" sync / 1[56]:[^:]*:Omega:3702:/
 500.0 "Ballistic Impact" duration 8
-510.1 "Condensed Wave Cannon Kyrios" sync / 1[56]:Omega:3704:/
-519.1 "Wave Cannon Kyrios 1" sync / 1[56]:Omega:3706:/
-526.2 "Wave Cannon Kyrios 2" sync / 1[56]:Omega:3706:/
-535.2 "Long Needle Kyrios" sync / 1[56]:Omega:370C:/
-544.6 "Blaster" sync / 1[56]:Omega:3261:/
-550.7 "Atomic Ray" sync / 1[56]:Omega:326C:/
+510.1 "Condensed Wave Cannon Kyrios" sync / 1[56]:[^:]*:Omega:3704:/
+519.1 "Wave Cannon Kyrios 1" sync / 1[56]:[^:]*:Omega:3706:/
+526.2 "Wave Cannon Kyrios 2" sync / 1[56]:[^:]*:Omega:3706:/
+535.2 "Long Needle Kyrios" sync / 1[56]:[^:]*:Omega:370C:/
+544.6 "Blaster" sync / 1[56]:[^:]*:Omega:3261:/
+550.7 "Atomic Ray" sync / 1[56]:[^:]*:Omega:326C:/
 
-561.8 "Peripheral Synthesis" sync / 1[56]:Omega:324A:/
-565.8 "Unmitigated Explosion" # sync / 1[56]:Omega:36F8:/ # no sync
-586.8 "Mustard Bomb" sync / 1[56]:Omega:326D:/
-598.8 "Atomic Ray" sync / 1[56]:Omega:326C:/
-600.8 "Ballistic Missile" sync / 1[56]:Omega:325F:/
-607.8 "Flamethrower" sync / 1[56]:Omega:36FE:/
-609.8 "Afterburner" sync / 1[56]:Omega:3700:/
-610.8 "Ballistic Impact" sync / 1[56]:Omega:3260:/
-616.3 "Starboard/Larboard Surge" sync / 1[56]:Omega:326[68]:/
-618.8 "Starboard/Larboard Surge" sync / 1[56]:Omega:326[79]:/
+561.8 "Peripheral Synthesis" sync / 1[56]:[^:]*:Omega:324A:/
+565.8 "Unmitigated Explosion" # sync / 1[56]:[^:]*:Omega:36F8:/ # no sync
+586.8 "Mustard Bomb" sync / 1[56]:[^:]*:Omega:326D:/
+598.8 "Atomic Ray" sync / 1[56]:[^:]*:Omega:326C:/
+600.8 "Ballistic Missile" sync / 1[56]:[^:]*:Omega:325F:/
+607.8 "Flamethrower" sync / 1[56]:[^:]*:Omega:36FE:/
+609.8 "Afterburner" sync / 1[56]:[^:]*:Omega:3700:/
+610.8 "Ballistic Impact" sync / 1[56]:[^:]*:Omega:3260:/
+616.3 "Starboard/Larboard Surge" sync / 1[56]:[^:]*:Omega:326[68]:/
+618.8 "Starboard/Larboard Surge" sync / 1[56]:[^:]*:Omega:326[79]:/
 
-634.7 "Pantokrator 2" sync / 1[56]:Omega:3702:/
+634.7 "Pantokrator 2" sync / 1[56]:[^:]*:Omega:3702:/
 639.7 "Ballistic Impact" duration 18 # +5
 642.7 "Flamethrower" duration 5.5 # +3
-646.7 "Guided Missile Kyrios" sync / 1[56]:Omega:3709:/ duration 6.5
-660.7 "Condensed Wave Cannon Kyrios" sync / 1[56]:Omega:3704:/
+646.7 "Guided Missile Kyrios" sync / 1[56]:[^:]*:Omega:3709:/ duration 6.5
+660.7 "Condensed Wave Cannon Kyrios" sync / 1[56]:[^:]*:Omega:3704:/
 662.7 "Diffuse Wave Cannon Kyrios" duration 16 # +2
-670.7 "Wave Cannon Kyrios 1" sync / 1[56]:Omega:3706:/
-677.7 "Wave Cannon Kyrios 2" sync / 1[56]:Omega:3706:/
-700.8 "Starboard/Larboard Surge" sync / 1[56]:Omega:326[68]:/
-703.3 "Starboard/Larboard Surge" sync / 1[56]:Omega:326[79]:/
-709.8 "Starboard/Larboard Surge" sync / 1[56]:Omega:326[68]:/
-712.3 "Starboard/Larboard Surge" sync / 1[56]:Omega:326[79]:/
+670.7 "Wave Cannon Kyrios 1" sync / 1[56]:[^:]*:Omega:3706:/
+677.7 "Wave Cannon Kyrios 2" sync / 1[56]:[^:]*:Omega:3706:/
+700.8 "Starboard/Larboard Surge" sync / 1[56]:[^:]*:Omega:326[68]:/
+703.3 "Starboard/Larboard Surge" sync / 1[56]:[^:]*:Omega:326[79]:/
+709.8 "Starboard/Larboard Surge" sync / 1[56]:[^:]*:Omega:326[68]:/
+712.3 "Starboard/Larboard Surge" sync / 1[56]:[^:]*:Omega:326[79]:/
 
-724.8 "Charybdis" sync / 1[56]:Omega:326E:/ window 10,10
-738.8 "Mustard Bomb" sync / 1[56]:Omega:326D:/
-740.9 "Blaster" sync / 1[56]:Omega:3261:/
-748.9 "Atomic Ray" sync / 1[56]:Omega:326A:/
-754.9 "Atomic Ray" sync / 1[56]:Omega:326A:/
-760.9 "Atomic Ray" sync / 1[56]:Omega:326A:/
+724.8 "Charybdis" sync / 1[56]:[^:]*:Omega:326E:/ window 10,10
+738.8 "Mustard Bomb" sync / 1[56]:[^:]*:Omega:326D:/
+740.9 "Blaster" sync / 1[56]:[^:]*:Omega:3261:/
+748.9 "Atomic Ray" sync / 1[56]:[^:]*:Omega:326A:/
+754.9 "Atomic Ray" sync / 1[56]:[^:]*:Omega:326A:/
+760.9 "Atomic Ray" sync / 1[56]:[^:]*:Omega:326A:/
 780.9 "Loop Enrage" # guessing at time

--- a/ui/raidboss/data/04-sb/raid/o12n.txt
+++ b/ui/raidboss/data/04-sb/raid/o12n.txt
@@ -9,41 +9,41 @@ hideall "--sync--"
 ### Phase 1 (loops until low%)
 0.0 "Start"
 0.0 "--sync--" sync /:Engage!/ window 0,1
-15.3 "Solar Ray" sync / 1[56]:Omega-M:330F:/ window 16,3
-20.4 "Program Alpha" sync / 1[56]:Omega-M:3308:/
-23.5 "Floodlight" sync / 1[56]:Omega-M:3309:/
-27.5 "Spotlight" sync / 1[56]:Omega-M:330A:/
-27.7 "Efficient Bladework" sync / 1[56]:Omega-M:32FF:/
-38.0 "Subject Simulation F" sync / 1[56]:Omega-M:32F1:/
-50.4 "Discharger" sync / 1[56]:Omega-M:32F6:/
-61.7 "Optimized Fire III" sync / 1[56]:Omega-M:330D:/
-66.9 "Optimized Blizzard III" sync / 1[56]:Omega-M:3303:/
-75.1 "Laser Shower" sync / 1[56]:Omega-M:3312:/
-92.5 "Synthetic Blades" sync / 1[56]:Omega-M:3301:/
-100.6 "Optimized Fire III" sync / 1[56]:Omega-M:330D:/
-105.9 "Superliminal Steel" sync / 1[56]:Omega-M:3305:/
-111.0 "Optimized Blizzard III" sync / 1[56]:Omega-M:3303:/
-122.3 "Subject Simulation M" sync / 1[56]:Omega-M:32F4:/
-134.7 "Efficient Bladework" sync / 1[56]:Omega-M:32F3:/
-141.0 "Synthetic Shield" sync / 1[56]:Omega-M:32FD:/
-149.1 "Program Alpha" sync / 1[56]:Omega-M:3308:/
-152.2 "Floodlight" sync / 1[56]:Omega-M:3309:/
-156.2 "Spotlight" sync / 1[56]:Omega-M:330A:/
-156.4 "Beyond Strength" sync / 1[56]:Omega-M:3300:/
-162.6 "Efficient Bladework" sync / 1[56]:Omega-M:32FF:/
-175.9 "Laser Shower" sync / 1[56]:Omega-M:3311:/
-184.2 "Solar Ray" sync / 1[56]:Omega-M:330F:/ # drift -0.047
-191.4 "Laser Shower" sync / 1[56]:Omega-M:3311:/ # drift 0.045
-196.7 "Subject Simulation F" sync / 1[56]:Omega-M:32F1:/
-209.1 "Discharger" sync / 1[56]:Omega-M:32F6:/
-215.3 "Synthetic Blades" sync / 1[56]:Omega-M:3301:/
-223.5 "Optimized Fire III" sync / 1[56]:Omega-M:330D:/ # drift -0.043001
-228.7 "Superliminal Steel" sync / 1[56]:Omega-M:3305:/ # drift -0.046
-233.8 "Optimized Blizzard III" sync / 1[56]:Omega-M:3303:/
-246.9 "Laser Shower" sync / 1[56]:Omega-M:3312:/
+15.3 "Solar Ray" sync / 1[56]:[^:]*:Omega-M:330F:/ window 16,3
+20.4 "Program Alpha" sync / 1[56]:[^:]*:Omega-M:3308:/
+23.5 "Floodlight" sync / 1[56]:[^:]*:Omega-M:3309:/
+27.5 "Spotlight" sync / 1[56]:[^:]*:Omega-M:330A:/
+27.7 "Efficient Bladework" sync / 1[56]:[^:]*:Omega-M:32FF:/
+38.0 "Subject Simulation F" sync / 1[56]:[^:]*:Omega-M:32F1:/
+50.4 "Discharger" sync / 1[56]:[^:]*:Omega-M:32F6:/
+61.7 "Optimized Fire III" sync / 1[56]:[^:]*:Omega-M:330D:/
+66.9 "Optimized Blizzard III" sync / 1[56]:[^:]*:Omega-M:3303:/
+75.1 "Laser Shower" sync / 1[56]:[^:]*:Omega-M:3312:/
+92.5 "Synthetic Blades" sync / 1[56]:[^:]*:Omega-M:3301:/
+100.6 "Optimized Fire III" sync / 1[56]:[^:]*:Omega-M:330D:/
+105.9 "Superliminal Steel" sync / 1[56]:[^:]*:Omega-M:3305:/
+111.0 "Optimized Blizzard III" sync / 1[56]:[^:]*:Omega-M:3303:/
+122.3 "Subject Simulation M" sync / 1[56]:[^:]*:Omega-M:32F4:/
+134.7 "Efficient Bladework" sync / 1[56]:[^:]*:Omega-M:32F3:/
+141.0 "Synthetic Shield" sync / 1[56]:[^:]*:Omega-M:32FD:/
+149.1 "Program Alpha" sync / 1[56]:[^:]*:Omega-M:3308:/
+152.2 "Floodlight" sync / 1[56]:[^:]*:Omega-M:3309:/
+156.2 "Spotlight" sync / 1[56]:[^:]*:Omega-M:330A:/
+156.4 "Beyond Strength" sync / 1[56]:[^:]*:Omega-M:3300:/
+162.6 "Efficient Bladework" sync / 1[56]:[^:]*:Omega-M:32FF:/
+175.9 "Laser Shower" sync / 1[56]:[^:]*:Omega-M:3311:/
+184.2 "Solar Ray" sync / 1[56]:[^:]*:Omega-M:330F:/ # drift -0.047
+191.4 "Laser Shower" sync / 1[56]:[^:]*:Omega-M:3311:/ # drift 0.045
+196.7 "Subject Simulation F" sync / 1[56]:[^:]*:Omega-M:32F1:/
+209.1 "Discharger" sync / 1[56]:[^:]*:Omega-M:32F6:/
+215.3 "Synthetic Blades" sync / 1[56]:[^:]*:Omega-M:3301:/
+223.5 "Optimized Fire III" sync / 1[56]:[^:]*:Omega-M:330D:/ # drift -0.043001
+228.7 "Superliminal Steel" sync / 1[56]:[^:]*:Omega-M:3305:/ # drift -0.046
+233.8 "Optimized Blizzard III" sync / 1[56]:[^:]*:Omega-M:3303:/
+246.9 "Laser Shower" sync / 1[56]:[^:]*:Omega-M:3312:/
 
 # Fake lookahead window before loop back to beginning
-282.2 "Solar Ray" sync / 1[56]:Omega-M:330F:/ window 20,20 jump 15.3
+282.2 "Solar Ray" sync / 1[56]:[^:]*:Omega-M:330F:/ window 20,20 jump 15.3
 287.3 "Program Alpha"
 290.4 "Floodlight"
 294.4 "Spotlight"
@@ -54,27 +54,27 @@ hideall "--sync--"
 
 ### Phase 2: Passage of Arms
 500.0 "--sync--" sync / 00:0044:Omega-M:\<blip\> Limits of single combatant/ window 500,0
-514.0 "Ground Zero" sync / 1[56]:Omega-M:3313:/ # drift 0.045001
-514.0 "Electric Slide" sync / 1[56]:Omega:3314:/
-522.0 "Efficient Bladework" sync / 1[56]:Omega-M:32F3:/ # drift -0.045
-522.0 "Discharger" sync / 1[56]:Omega:32F6:/
+514.0 "Ground Zero" sync / 1[56]:[^:]*:Omega-M:3313:/ # drift 0.045001
+514.0 "Electric Slide" sync / 1[56]:[^:]*:Omega:3314:/
+522.0 "Efficient Bladework" sync / 1[56]:[^:]*:Omega-M:32F3:/ # drift -0.045
+522.0 "Discharger" sync / 1[56]:[^:]*:Omega:32F6:/
 
-526.3 "Optimized Passage of Arms" sync / 1[56]:Omega-M:3316:/ window 550,50
+526.3 "Optimized Passage of Arms" sync / 1[56]:[^:]*:Omega-M:3316:/ window 550,50
 587.5 "Laser Shower Enrage"
 
 
 ### Phase 3: Everyone dies, loops forever
 # Post-passage of arms startup
-700.0 "--sync--" sync / 1[56]:Omega:3319:/ window 700,0
-711.0 "Ground Zero" sync / 1[56]:Omega-M:3313:/
-711.0 "Electric Slide" sync / 1[56]:Omega:3314:/
-719.1 "Efficient Bladework" sync / 1[56]:Omega-M:32F3:/ # drift -0.044
-719.1 "Discharger" sync / 1[56]:Omega:32F6:/
-725.1 "Firewall" sync / 1[56]:Omega-M:3392:/ window 100,10
+700.0 "--sync--" sync / 1[56]:[^:]*:Omega:3319:/ window 700,0
+711.0 "Ground Zero" sync / 1[56]:[^:]*:Omega-M:3313:/
+711.0 "Electric Slide" sync / 1[56]:[^:]*:Omega:3314:/
+719.1 "Efficient Bladework" sync / 1[56]:[^:]*:Omega-M:32F3:/ # drift -0.044
+719.1 "Discharger" sync / 1[56]:[^:]*:Omega:32F6:/
+725.1 "Firewall" sync / 1[56]:[^:]*:Omega-M:3392:/ window 100,10
 
 737.1 "Synthetic Blades/Shield" # branching
-737.1 "--sync--" sync / 1[56]:Omega-M:32FD:/ jump 937.1 window 20,20 # shield
-737.1 "--sync--" sync / 1[56]:Omega:3301:/ jump 1137.1 window 20,20 # blades
+737.1 "--sync--" sync / 1[56]:[^:]*:Omega-M:32FD:/ jump 937.1 window 20,20 # shield
+737.1 "--sync--" sync / 1[56]:[^:]*:Omega:3301:/ jump 1137.1 window 20,20 # blades
 739.1 "Laser Shower"
 
 # Two paths here.  The 1st Shield/Blades has a Solar Ray that the others don't.
@@ -83,21 +83,21 @@ hideall "--sync--"
 # PoA -> Firewall -> 1st Blades -> 2nd Shield -> 2nd Blades -> 2nd Shield -> etc
 
 # first time shield loop (with solar ray)
-937.1 "Synthetic Shield" sync / 1[56]:Omega-M:32FD:/
-939.1 "Laser Shower" sync / 1[56]:Omega:3312:/
-947.1 "Optimized Fire III" sync / 1[56]:Omega:330D:/
-947.1 "Beyond Strength" sync / 1[56]:Omega-M:3300:/
-952.1 "Optimized Blizzard III" sync / 1[56]:Omega:3303:/
-953.1 "Efficient Bladework" sync / 1[56]:Omega-M:32FF:/
-963.1 "Solar Ray" sync / 1[56]:Omega-M:330F:/
-985.4 "Cosmo Memory" sync / 1[56]:Omega-M:331B:/
-992.5 "Resonance" sync / 1[56]:Omega-M:3394:/ # drift -0.046001
-1008.6 "Suppression" sync / 1[56]:Omega-M:331E:/ # drift -0.044999
-1013.6 "Optical Laser" sync / 1[56]:Optical Unit:3320:/
-1016.6 "Optimized Meteor" sync / 1[56]:Omega-M:3325:/
-1016.8 "Optimized Sagittarius Arrow" sync / 1[56]:Omega-M:3323:/ # drift -0.044
-1027.7 "Optimized Blade Dance" sync / 1[56]:Omega:3322:/
-1035.7 "Synthetic Blades" sync / 1[56]:Omega:3301:/ window 20,20 jump 1478.4
+937.1 "Synthetic Shield" sync / 1[56]:[^:]*:Omega-M:32FD:/
+939.1 "Laser Shower" sync / 1[56]:[^:]*:Omega:3312:/
+947.1 "Optimized Fire III" sync / 1[56]:[^:]*:Omega:330D:/
+947.1 "Beyond Strength" sync / 1[56]:[^:]*:Omega-M:3300:/
+952.1 "Optimized Blizzard III" sync / 1[56]:[^:]*:Omega:3303:/
+953.1 "Efficient Bladework" sync / 1[56]:[^:]*:Omega-M:32FF:/
+963.1 "Solar Ray" sync / 1[56]:[^:]*:Omega-M:330F:/
+985.4 "Cosmo Memory" sync / 1[56]:[^:]*:Omega-M:331B:/
+992.5 "Resonance" sync / 1[56]:[^:]*:Omega-M:3394:/ # drift -0.046001
+1008.6 "Suppression" sync / 1[56]:[^:]*:Omega-M:331E:/ # drift -0.044999
+1013.6 "Optical Laser" sync / 1[56]:[^:]*:Optical Unit:3320:/
+1016.6 "Optimized Meteor" sync / 1[56]:[^:]*:Omega-M:3325:/
+1016.8 "Optimized Sagittarius Arrow" sync / 1[56]:[^:]*:Omega-M:3323:/ # drift -0.044
+1027.7 "Optimized Blade Dance" sync / 1[56]:[^:]*:Omega:3322:/
+1035.7 "Synthetic Blades" sync / 1[56]:[^:]*:Omega:3301:/ window 20,20 jump 1478.4
 
 # fake lookahead into 2nd blades loop
 1037.7 "Laser Shower"
@@ -110,24 +110,24 @@ hideall "--sync--"
 1056.1 "Optimized Blizzard III"
 
 # first time blades loop (with solar ray)
-1137.1 "Synthetic Blades" sync / 1[56]:Omega:3301:/
-1139.1 "Laser Shower" sync / 1[56]:Omega-M:3311:/
-1146.4 "Program Alpha" sync / 1[56]:Omega-M:3308:/
-1146.5 "Optimized Fire III" sync / 1[56]:Omega:330D:/
-1149.5 "Floodlight" sync / 1[56]:Omega-M:3309:/
-1152.9 "Superliminal Steel" sync / 1[56]:Omega:3305:/
-1153.5 "Spotlight" sync / 1[56]:Omega-M:331A:/ # drift -0.049001
-1157.6 "Efficient Bladework" sync / 1[56]:Omega-M:32FF:/
-1158.1 "Optimized Blizzard III" sync / 1[56]:Omega:3303:/
-1168.9 "Solar Ray" sync / 1[56]:Omega-M:330F:/
-1192.0 "Cosmo Memory" sync / 1[56]:Omega-M:331B:/
-1199.3 "Resonance" sync / 1[56]:Omega-M:3394:/
-1215.8 "Suppression" sync / 1[56]:Omega-M:331E:/
-1220.9 "Optical Laser" sync / 1[56]:Optical Unit:3320:/
-1224.1 "Optimized Meteor" sync / 1[56]:Omega-M:3325:/
-1224.3 "Optimized Sagittarius Arrow" sync / 1[56]:Omega-M:3323:/
-1235.4 "Optimized Blade Dance" sync / 1[56]:Omega:3322:/
-1243.6 "Synthetic Shield" sync / 1[56]:Omega-M:32FD:/ window 20,20 jump 1400
+1137.1 "Synthetic Blades" sync / 1[56]:[^:]*:Omega:3301:/
+1139.1 "Laser Shower" sync / 1[56]:[^:]*:Omega-M:3311:/
+1146.4 "Program Alpha" sync / 1[56]:[^:]*:Omega-M:3308:/
+1146.5 "Optimized Fire III" sync / 1[56]:[^:]*:Omega:330D:/
+1149.5 "Floodlight" sync / 1[56]:[^:]*:Omega-M:3309:/
+1152.9 "Superliminal Steel" sync / 1[56]:[^:]*:Omega:3305:/
+1153.5 "Spotlight" sync / 1[56]:[^:]*:Omega-M:331A:/ # drift -0.049001
+1157.6 "Efficient Bladework" sync / 1[56]:[^:]*:Omega-M:32FF:/
+1158.1 "Optimized Blizzard III" sync / 1[56]:[^:]*:Omega:3303:/
+1168.9 "Solar Ray" sync / 1[56]:[^:]*:Omega-M:330F:/
+1192.0 "Cosmo Memory" sync / 1[56]:[^:]*:Omega-M:331B:/
+1199.3 "Resonance" sync / 1[56]:[^:]*:Omega-M:3394:/
+1215.8 "Suppression" sync / 1[56]:[^:]*:Omega-M:331E:/
+1220.9 "Optical Laser" sync / 1[56]:[^:]*:Optical Unit:3320:/
+1224.1 "Optimized Meteor" sync / 1[56]:[^:]*:Omega-M:3325:/
+1224.3 "Optimized Sagittarius Arrow" sync / 1[56]:[^:]*:Omega-M:3323:/
+1235.4 "Optimized Blade Dance" sync / 1[56]:[^:]*:Omega:3322:/
+1243.6 "Synthetic Shield" sync / 1[56]:[^:]*:Omega-M:32FD:/ window 20,20 jump 1400
 
 # fake lookahead into 2nd shield loop
 1245.6 "Laser Shower"
@@ -139,40 +139,40 @@ hideall "--sync--"
 1277.8 "Resonance"
 
 # second time shield loop (no solar ray)
-1400.0 "Synthetic Shield" sync / 1[56]:Omega-M:32FD:/
-1402.0 "Laser Shower" sync / 1[56]:Omega:3312:/
-1410.5 "Optimized Fire III" sync / 1[56]:Omega:330D:/
-1410.6 "Beyond Strength" sync / 1[56]:Omega-M:3300:/
-1415.7 "Optimized Blizzard III" sync / 1[56]:Omega:3303:/
-1416.7 "Efficient Bladework" sync / 1[56]:Omega-M:32FF:/
-1427.0 "Cosmo Memory" sync / 1[56]:Omega-M:331B:/
-1434.2 "Resonance" sync / 1[56]:Omega-M:3394:/ # drift 0.045001
-1450.8 "Suppression" sync / 1[56]:Omega-M:331E:/
-1455.8 "Optical Laser" sync / 1[56]:Optical Unit:3320:/
-1459.0 "Optimized Meteor" sync / 1[56]:Omega-M:3325:/
-1459.2 "Optimized Sagittarius Arrow" sync / 1[56]:Omega-M:3323:/
-1470.3 "Optimized Blade Dance" sync / 1[56]:Omega:3322:/
+1400.0 "Synthetic Shield" sync / 1[56]:[^:]*:Omega-M:32FD:/
+1402.0 "Laser Shower" sync / 1[56]:[^:]*:Omega:3312:/
+1410.5 "Optimized Fire III" sync / 1[56]:[^:]*:Omega:330D:/
+1410.6 "Beyond Strength" sync / 1[56]:[^:]*:Omega-M:3300:/
+1415.7 "Optimized Blizzard III" sync / 1[56]:[^:]*:Omega:3303:/
+1416.7 "Efficient Bladework" sync / 1[56]:[^:]*:Omega-M:32FF:/
+1427.0 "Cosmo Memory" sync / 1[56]:[^:]*:Omega-M:331B:/
+1434.2 "Resonance" sync / 1[56]:[^:]*:Omega-M:3394:/ # drift 0.045001
+1450.8 "Suppression" sync / 1[56]:[^:]*:Omega-M:331E:/
+1455.8 "Optical Laser" sync / 1[56]:[^:]*:Optical Unit:3320:/
+1459.0 "Optimized Meteor" sync / 1[56]:[^:]*:Omega-M:3325:/
+1459.2 "Optimized Sagittarius Arrow" sync / 1[56]:[^:]*:Omega-M:3323:/
+1470.3 "Optimized Blade Dance" sync / 1[56]:[^:]*:Omega:3322:/
 
 # second time blades loop (no solar ray)
-1478.4 "Synthetic Blades" sync / 1[56]:Omega:3301:/
-1480.4 "Laser Shower" sync / 1[56]:Omega-M:3311:/
-1487.6 "Program Alpha" sync / 1[56]:Omega-M:3308:/
-1487.6 "Optimized Fire III" sync / 1[56]:Omega:330D:/
-1490.6 "Floodlight" sync / 1[56]:Omega-M:3309:/
-1493.8 "Superliminal Steel" sync / 1[56]:Omega:3305:/
-1494.6 "Spotlight" sync / 1[56]:Omega-M:331A:/
-1498.6 "Efficient Bladework" sync / 1[56]:Omega-M:32FF:/
-1498.8 "Optimized Blizzard III" sync / 1[56]:Omega:3303:/
-1509.8 "Cosmo Memory" sync / 1[56]:Omega-M:331B:/
-1516.8 "Resonance" sync / 1[56]:Omega-M:3394:/
-1532.9 "Suppression" sync / 1[56]:Omega-M:331E:/
-1537.9 "Optical Laser" sync / 1[56]:Optical Unit:3320:/
-1540.9 "Optimized Meteor" sync / 1[56]:Omega-M:3325:/
-1541.1 "Optimized Sagittarius Arrow" sync / 1[56]:Omega-M:3323:/
-1551.9 "Optimized Blade Dance" sync / 1[56]:Omega:3322:/
+1478.4 "Synthetic Blades" sync / 1[56]:[^:]*:Omega:3301:/
+1480.4 "Laser Shower" sync / 1[56]:[^:]*:Omega-M:3311:/
+1487.6 "Program Alpha" sync / 1[56]:[^:]*:Omega-M:3308:/
+1487.6 "Optimized Fire III" sync / 1[56]:[^:]*:Omega:330D:/
+1490.6 "Floodlight" sync / 1[56]:[^:]*:Omega-M:3309:/
+1493.8 "Superliminal Steel" sync / 1[56]:[^:]*:Omega:3305:/
+1494.6 "Spotlight" sync / 1[56]:[^:]*:Omega-M:331A:/
+1498.6 "Efficient Bladework" sync / 1[56]:[^:]*:Omega-M:32FF:/
+1498.8 "Optimized Blizzard III" sync / 1[56]:[^:]*:Omega:3303:/
+1509.8 "Cosmo Memory" sync / 1[56]:[^:]*:Omega-M:331B:/
+1516.8 "Resonance" sync / 1[56]:[^:]*:Omega-M:3394:/
+1532.9 "Suppression" sync / 1[56]:[^:]*:Omega-M:331E:/
+1537.9 "Optical Laser" sync / 1[56]:[^:]*:Optical Unit:3320:/
+1540.9 "Optimized Meteor" sync / 1[56]:[^:]*:Omega-M:3325:/
+1541.1 "Optimized Sagittarius Arrow" sync / 1[56]:[^:]*:Omega-M:3323:/
+1551.9 "Optimized Blade Dance" sync / 1[56]:[^:]*:Omega:3322:/
 
 # Loop with fake lookahead window
-1560.0 "Synthetic Shield" sync / 1[56]:Omega-M:32FD:/ window 20,20 jump 1400
+1560.0 "Synthetic Shield" sync / 1[56]:[^:]*:Omega-M:32FD:/ window 20,20 jump 1400
 1562.0 "Laser Shower"
 1570.5 "Optimized Fire III"
 1570.6 "Beyond Strength"
@@ -185,7 +185,7 @@ hideall "--sync--"
 ### Phase 4: Laser Show Forever
 1800.0 "Enrage" sync / 00:0044:[^:]*:\<blip\> Warning\. Calculations indicate/ window 1800,0
 
-1806.0 "Laser Shower Enrage" sync / 1[56]:(Omega-M:3311|Omega:3312):/ window 20,20
+1806.0 "Laser Shower Enrage" sync / 1[56]:[^:]*:(Omega-M:3311|Omega:3312):/ window 20,20
 1812.0 "Laser Shower Enrage"
 1818.0 "Laser Shower Enrage"
 1824.0 "Laser Shower Enrage"

--- a/ui/raidboss/data/04-sb/raid/o12s.txt
+++ b/ui/raidboss/data/04-sb/raid/o12s.txt
@@ -9,49 +9,49 @@ hideall "--sync--"
 0.0 "--Reset--" sync / 21:........:40000010:/ window 100000 jump 0
 
 0.0 "Start" sync / 00:0044:[^:]*:I am the Omega/ window 1,0
-2.4 "--sync--" sync / 1[56]:Omega-M:337D:/ window 2.4,0.5 # first auto
-11.7 "Synthetic Shield" sync / 1[56]:Omega-M:32FD:/ window 12,5
-19.7 "Suppression" sync / 1[56]:Omega-M:3345:/
-26.6 "Beyond Defense" sync / 1[56]:Omega-M:332B:/
-26.7 "Optical Laser" sync / 1[56]:Optical Unit:3347:/
-26.9 "Beyond Defense" sync / 1[56]:Omega-M:332C:/
-30.1 "Pile Pitch" sync / 1[56]:Omega-M:332E:/
+2.4 "--sync--" sync / 1[56]:[^:]*:Omega-M:337D:/ window 2.4,0.5 # first auto
+11.7 "Synthetic Shield" sync / 1[56]:[^:]*:Omega-M:32FD:/ window 12,5
+19.7 "Suppression" sync / 1[56]:[^:]*:Omega-M:3345:/
+26.6 "Beyond Defense" sync / 1[56]:[^:]*:Omega-M:332B:/
+26.7 "Optical Laser" sync / 1[56]:[^:]*:Optical Unit:3347:/
+26.9 "Beyond Defense" sync / 1[56]:[^:]*:Omega-M:332C:/
+30.1 "Pile Pitch" sync / 1[56]:[^:]*:Omega-M:332E:/
 
 # F phase
-49.1 "Subject Simulation F" sync / 1[56]:Omega-M:32F1:/
-61.2 "Discharger" sync / 1[56]:Omega-M:3327:/ # drift -0.044
-73.2 "Synthetic Blades" sync / 1[56]:Omega-M:3301:/
-81.2 "Advanced Suppression" sync / 1[56]:Omega-M:3349:/
-87.2 "Superliminal Motion" sync / 1[56]:Omega-M:3334:/
-88.2 "Advanced Optical Laser" sync / 1[56]:Optical Unit:334A:/
-90.3 "Optimized Fire III" sync / 1[56]:Omega-M:3335:/ # drift 0.047
+49.1 "Subject Simulation F" sync / 1[56]:[^:]*:Omega-M:32F1:/
+61.2 "Discharger" sync / 1[56]:[^:]*:Omega-M:3327:/ # drift -0.044
+73.2 "Synthetic Blades" sync / 1[56]:[^:]*:Omega-M:3301:/
+81.2 "Advanced Suppression" sync / 1[56]:[^:]*:Omega-M:3349:/
+87.2 "Superliminal Motion" sync / 1[56]:[^:]*:Omega-M:3334:/
+88.2 "Advanced Optical Laser" sync / 1[56]:[^:]*:Optical Unit:334A:/
+90.3 "Optimized Fire III" sync / 1[56]:[^:]*:Omega-M:3335:/ # drift 0.047
 
 # Twin phase
-102.6 "Subject Simulation M" sync / 1[56]:Omega-M:32F4:/ window 200,10
+102.6 "Subject Simulation M" sync / 1[56]:[^:]*:Omega-M:32F4:/ window 200,10
 108.9 "--untargetable--"
-114.1 "Electric Slide" sync / 1[56]:Omega:3354:/
-122.7 "Discharger" sync / 1[56]:Omega:3327:/
-122.7 "Efficient Bladework" sync / 1[56]:Omega-M:3329:/
+114.1 "Electric Slide" sync / 1[56]:[^:]*:Omega:3354:/
+122.7 "Discharger" sync / 1[56]:[^:]*:Omega:3327:/
+122.7 "Efficient Bladework" sync / 1[56]:[^:]*:Omega-M:3329:/
 125.7 "--targetable--"
-132.0 "Firewall" sync / 1[56]:Omega:3339:/ window 132.0
-141.2 "Resonance" sync / 1[56]:Omega:333B:/
-155.6 "Fundamental Synergy" sync / 1[56]:Omega:333D:/
+132.0 "Firewall" sync / 1[56]:[^:]*:Omega:3339:/ window 132.0
+141.2 "Resonance" sync / 1[56]:[^:]*:Omega:333B:/
+155.6 "Fundamental Synergy" sync / 1[56]:[^:]*:Omega:333D:/
 
 # Slides
-160.7 "Advanced Suppression" sync / 1[56]:Omega:3349:/
+160.7 "Advanced Suppression" sync / 1[56]:[^:]*:Omega:3349:/
 163.9 "--untargetable--"
 164.2 "Electric Slide 1"
 166.0 "Electric Slide 2"
 167.7 "Electric Slide 3"
-167.8 "Advanced Optical Laser" sync / 1[56]:Optical Unit:334A:/
+167.8 "Advanced Optical Laser" sync / 1[56]:[^:]*:Optical Unit:334A:/
 169.4 "Electric Slide 4"
 170.7 "--targetable--"
-180.1 "Laser Shower" sync / 1[56]:Omega:3353:/
-189.3 "Solar Ray" sync / 1[56]:Omega:3351:/
+180.1 "Laser Shower" sync / 1[56]:[^:]*:Omega:3353:/
+189.3 "Solar Ray" sync / 1[56]:[^:]*:Omega:3351:/
 
 # Branch point
-200.5 "Synthetic Blades/Synthetic Shield" sync / 1[56]:Omega-M:32FD:/ jump 1200.5  # shield -> blades path
-200.5 "--sync--" sync / 1[56]:Omega:3301:/ jump 2200.5 # blades -> shield path
+200.5 "Synthetic Blades/Synthetic Shield" sync / 1[56]:[^:]*:Omega-M:32FD:/ jump 1200.5  # shield -> blades path
+200.5 "--sync--" sync / 1[56]:[^:]*:Omega:3301:/ jump 2200.5 # blades -> shield path
 212.2 "Operational Synergy"
 218.2 "Beyond Defense?"
 218.2 "Superliminal Steel?"
@@ -60,40 +60,40 @@ hideall "--sync--"
 228.8 "Optimized Fire III"
 
 # Shield-first path
-1200.5 "Synthetic Shield" sync / 1[56]:Omega-M:32FD:/
-1212.2 "Operational Synergy" sync / 1[56]:Omega:3341:/
-1219.2 "Beyond Defense" sync / 1[56]:Omega-M:332B:/
-1219.4 "Optimized Blizzard III" sync / 1[56]:Omega:3333:/
-1222.7 "Pile Pitch" sync / 1[56]:Omega-M:332E:/
-1227.4 "Optimized Fire III" sync / 1[56]:Omega-F:3337:/
-1230.7 "Beyond Strength" sync / 1[56]:Omega-M:3328:/
-1233.7 "Efficient Bladework" sync / 1[56]:Omega-M:3329:/
-1234.4 "Laser Shower" sync / 1[56]:Omega:3353:/
-1241.4 "Laser Shower" sync / 1[56]:Omega:3353:/
-1250.9 "Firewall" sync / 1[56]:Omega:3339:/
-1260.1 "Resonance" sync / 1[56]:Omega:333B:/
-1274.5 "Fundamental Synergy" sync / 1[56]:Omega:333D:/
-1279.6 "Advanced Suppression" sync / 1[56]:Omega:3349:/
+1200.5 "Synthetic Shield" sync / 1[56]:[^:]*:Omega-M:32FD:/
+1212.2 "Operational Synergy" sync / 1[56]:[^:]*:Omega:3341:/
+1219.2 "Beyond Defense" sync / 1[56]:[^:]*:Omega-M:332B:/
+1219.4 "Optimized Blizzard III" sync / 1[56]:[^:]*:Omega:3333:/
+1222.7 "Pile Pitch" sync / 1[56]:[^:]*:Omega-M:332E:/
+1227.4 "Optimized Fire III" sync / 1[56]:[^:]*:Omega-F:3337:/
+1230.7 "Beyond Strength" sync / 1[56]:[^:]*:Omega-M:3328:/
+1233.7 "Efficient Bladework" sync / 1[56]:[^:]*:Omega-M:3329:/
+1234.4 "Laser Shower" sync / 1[56]:[^:]*:Omega:3353:/
+1241.4 "Laser Shower" sync / 1[56]:[^:]*:Omega:3353:/
+1250.9 "Firewall" sync / 1[56]:[^:]*:Omega:3339:/
+1260.1 "Resonance" sync / 1[56]:[^:]*:Omega:333B:/
+1274.5 "Fundamental Synergy" sync / 1[56]:[^:]*:Omega:333D:/
+1279.6 "Advanced Suppression" sync / 1[56]:[^:]*:Omega:3349:/
 1282.3 "--untargetable--"
-1282.6 "Electric Slide 1" #sync / 1[56]:Omega:333F:/
-1284.3 "Electric Slide 2" #sync / 1[56]:Omega:333F:/
-1286.0 "Electric Slide 3" #sync / 1[56]:Omega:333F:/
-1286.5 "Advanced Optical Laser" sync / 1[56]:Optical Unit:334A:/
-1287.7 "Electric Slide 4" #sync / 1[56]:Omega:333F:/
+1282.6 "Electric Slide 1" #sync / 1[56]:[^:]*:Omega:333F:/
+1284.3 "Electric Slide 2" #sync / 1[56]:[^:]*:Omega:333F:/
+1286.0 "Electric Slide 3" #sync / 1[56]:[^:]*:Omega:333F:/
+1286.5 "Advanced Optical Laser" sync / 1[56]:[^:]*:Optical Unit:334A:/
+1287.7 "Electric Slide 4" #sync / 1[56]:[^:]*:Omega:333F:/
 1289.0 "--targetable--"
-1298.4 "Laser Shower" sync / 1[56]:Omega:3353:/
-1307.4 "Solar Ray" sync / 1[56]:Omega:3351:/
-1318.4 "Synthetic Blades" sync / 1[56]:Omega:3301:/
-1329.4 "Operational Synergy" sync / 1[56]:Omega:3341:/
-1334.4 "Superliminal Steel" sync / 1[56]:Omega-F:3331:/
-1337.6 "Optimized Blizzard III" sync / 1[56]:Omega:3332:/
-1337.7 "Pile Pitch" sync / 1[56]:Omega-M:332E:/
-1343.8 "Superliminal Motion" sync / 1[56]:Omega:3334:/
-1347.0 "Optimized Fire III" sync / 1[56]:Omega-F:3337:/
-1348.2 "Efficient Bladework" sync / 1[56]:Omega-M:332A:/
-1356.4 "Laser Shower" sync / 1[56]:Omega-M:3352:/
-1363.4 "Laser Shower" sync / 1[56]:Omega:3353:/
-1378.0 "Suppression" sync / 1[56]:Omega:3346:/ jump 378.0
+1298.4 "Laser Shower" sync / 1[56]:[^:]*:Omega:3353:/
+1307.4 "Solar Ray" sync / 1[56]:[^:]*:Omega:3351:/
+1318.4 "Synthetic Blades" sync / 1[56]:[^:]*:Omega:3301:/
+1329.4 "Operational Synergy" sync / 1[56]:[^:]*:Omega:3341:/
+1334.4 "Superliminal Steel" sync / 1[56]:[^:]*:Omega-F:3331:/
+1337.6 "Optimized Blizzard III" sync / 1[56]:[^:]*:Omega:3332:/
+1337.7 "Pile Pitch" sync / 1[56]:[^:]*:Omega-M:332E:/
+1343.8 "Superliminal Motion" sync / 1[56]:[^:]*:Omega:3334:/
+1347.0 "Optimized Fire III" sync / 1[56]:[^:]*:Omega-F:3337:/
+1348.2 "Efficient Bladework" sync / 1[56]:[^:]*:Omega-M:332A:/
+1356.4 "Laser Shower" sync / 1[56]:[^:]*:Omega-M:3352:/
+1363.4 "Laser Shower" sync / 1[56]:[^:]*:Omega:3353:/
+1378.0 "Suppression" sync / 1[56]:[^:]*:Omega:3346:/ jump 378.0
 1385.1 "Optical Laser" # Cosmetic
 1385.4 "Optimized Meteor"
 1385.6 "Optimized Sagittarius Arrow"
@@ -101,39 +101,39 @@ hideall "--sync--"
 1404.4 "Laser Shower"
 
 # Blades-first path
-2200.5 "Synthetic Blades" sync / 1[56]:Omega:3301:/
-2212.2 "Operational Synergy" sync / 1[56]:Omega:3341:/
-2217.2 "Superliminal Steel" sync / 1[56]:Omega:332F:/
-2220.3 "Optimized Blizzard III" sync / 1[56]:Omega:3332:/
-2220.3 "Pile Pitch" sync / 1[56]:Omega-M:332E:/
-2226.2 "Superliminal Motion" sync / 1[56]:Omega:3334:/
-2229.2 "Optimized Fire III" sync / 1[56]:Omega:3335:/
-2230.4 "Efficient Bladework" sync / 1[56]:Omega-M:332A:/
-2238.2 "Laser Shower" sync / 1[56]:Omega:3353:/
-2250.4 "Firewall" sync / 1[56]:Omega:3339:/
-2259.4 "Resonance" sync / 1[56]:Omega:333B:/
-2273.4 "Fundamental Synergy" sync / 1[56]:Omega:333D:/
-2278.4 "Advanced Suppression" sync / 1[56]:Omega:3349:/
+2200.5 "Synthetic Blades" sync / 1[56]:[^:]*:Omega:3301:/
+2212.2 "Operational Synergy" sync / 1[56]:[^:]*:Omega:3341:/
+2217.2 "Superliminal Steel" sync / 1[56]:[^:]*:Omega:332F:/
+2220.3 "Optimized Blizzard III" sync / 1[56]:[^:]*:Omega:3332:/
+2220.3 "Pile Pitch" sync / 1[56]:[^:]*:Omega-M:332E:/
+2226.2 "Superliminal Motion" sync / 1[56]:[^:]*:Omega:3334:/
+2229.2 "Optimized Fire III" sync / 1[56]:[^:]*:Omega:3335:/
+2230.4 "Efficient Bladework" sync / 1[56]:[^:]*:Omega-M:332A:/
+2238.2 "Laser Shower" sync / 1[56]:[^:]*:Omega:3353:/
+2250.4 "Firewall" sync / 1[56]:[^:]*:Omega:3339:/
+2259.4 "Resonance" sync / 1[56]:[^:]*:Omega:333B:/
+2273.4 "Fundamental Synergy" sync / 1[56]:[^:]*:Omega:333D:/
+2278.4 "Advanced Suppression" sync / 1[56]:[^:]*:Omega:3349:/
 2281.6 "--untargetable--"
-2282.0 "Electric Slide 1" #sync / 1[56]:Omega:333F:/
-2283.9 "Electric Slide 2" #sync / 1[56]:Omega:333F:/
-2285.5 "Advanced Optical Laser" sync / 1[56]:Optical Unit:334A:/
-2285.8 "Electric Slide 3" #sync / 1[56]:Omega:333F:/
-2287.7 "Electric Slide 4" #sync / 1[56]:Omega:333F:/
+2282.0 "Electric Slide 1" #sync / 1[56]:[^:]*:Omega:333F:/
+2283.9 "Electric Slide 2" #sync / 1[56]:[^:]*:Omega:333F:/
+2285.5 "Advanced Optical Laser" sync / 1[56]:[^:]*:Optical Unit:334A:/
+2285.8 "Electric Slide 3" #sync / 1[56]:[^:]*:Omega:333F:/
+2287.7 "Electric Slide 4" #sync / 1[56]:[^:]*:Omega:333F:/
 2288.8 "--targetable--"
-2298.2 "Laser Shower" sync / 1[56]:Omega:3353:/
-2306.2 "Solar Ray" sync / 1[56]:Omega:3351:/
-2317.2 "Synthetic Shield" sync / 1[56]:Omega-M:32FD:/
-2328.2 "Operational Synergy" sync / 1[56]:Omega:3341:/
-2335.1 "Beyond Defense" sync / 1[56]:Omega-M:332B:/
-2335.4 "Optimized Blizzard III" sync / 1[56]:Omega:3333:/
-2338.6 "Pile Pitch" sync / 1[56]:Omega-M:332E:/
-2343.4 "Optimized Fire III" sync / 1[56]:Omega:3336:/
-2346.6 "Beyond Strength" sync / 1[56]:Omega-M:3328:/
-2349.6 "Efficient Bladework" sync / 1[56]:Omega-M:3329:/
-2350.4 "Laser Shower" sync / 1[56]:Omega:3353:/
-2357.4 "Laser Shower" sync / 1[56]:Omega:3353:/
-2375.7 "Suppression" sync / 1[56]:Omega:3346:/ jump 378.0
+2298.2 "Laser Shower" sync / 1[56]:[^:]*:Omega:3353:/
+2306.2 "Solar Ray" sync / 1[56]:[^:]*:Omega:3351:/
+2317.2 "Synthetic Shield" sync / 1[56]:[^:]*:Omega-M:32FD:/
+2328.2 "Operational Synergy" sync / 1[56]:[^:]*:Omega:3341:/
+2335.1 "Beyond Defense" sync / 1[56]:[^:]*:Omega-M:332B:/
+2335.4 "Optimized Blizzard III" sync / 1[56]:[^:]*:Omega:3333:/
+2338.6 "Pile Pitch" sync / 1[56]:[^:]*:Omega-M:332E:/
+2343.4 "Optimized Fire III" sync / 1[56]:[^:]*:Omega:3336:/
+2346.6 "Beyond Strength" sync / 1[56]:[^:]*:Omega-M:3328:/
+2349.6 "Efficient Bladework" sync / 1[56]:[^:]*:Omega-M:3329:/
+2350.4 "Laser Shower" sync / 1[56]:[^:]*:Omega:3353:/
+2357.4 "Laser Shower" sync / 1[56]:[^:]*:Omega:3353:/
+2375.7 "Suppression" sync / 1[56]:[^:]*:Omega:3346:/ jump 378.0
 2382.7 "Optical Laser" # Cosmetic
 2382.7 "Optimized Meteor"
 2382.8 "Optimized Sagittarius Arrow"
@@ -141,21 +141,21 @@ hideall "--sync--"
 2401.3 "Laser Shower"
 
 # Paths converge to enrage sequence
-378.0 "Suppression" sync / 1[56]:Omega:3346:/
-385.1 "Optical Laser" sync / 1[56]:Optical Unit:3347:/
-385.4 "Optimized Meteor" sync / 1[56]:Omega-F:334F:/
-385.6 "Optimized Sagittarius Arrow" sync / 1[56]:Omega-M:334D:/
-396.4 "Cosmo Memory" sync / 1[56]:Omega:3343:/
-404.4 "Laser Shower" sync / 1[56]:Omega:3353:/
-412.4 "Optimized Blade Dance" sync / 1[56]:Omega:334C:/
-430.4 "Advanced Suppression" sync / 1[56]:Omega:3349:/
-437.4 "Advanced Optical Laser" sync / 1[56]:Optical Unit:334A:/
-437.4 "Optimized Meteor" sync / 1[56]:Omega-F:334F:/
-437.4 "Optimized Sagittarius Arrow" sync / 1[56]:Omega-M:334D:/
-447.9 "Cosmo Memory" sync / 1[56]:Omega:3343:/
-455.9 "Laser Shower" sync / 1[56]:Omega:3353:/
-463.9 "Optimized Blade Dance" sync / 1[56]:Omega:334C:/
-479.4 "Cosmo Memory" sync / 1[56]:Omega:33EC:/
+378.0 "Suppression" sync / 1[56]:[^:]*:Omega:3346:/
+385.1 "Optical Laser" sync / 1[56]:[^:]*:Optical Unit:3347:/
+385.4 "Optimized Meteor" sync / 1[56]:[^:]*:Omega-F:334F:/
+385.6 "Optimized Sagittarius Arrow" sync / 1[56]:[^:]*:Omega-M:334D:/
+396.4 "Cosmo Memory" sync / 1[56]:[^:]*:Omega:3343:/
+404.4 "Laser Shower" sync / 1[56]:[^:]*:Omega:3353:/
+412.4 "Optimized Blade Dance" sync / 1[56]:[^:]*:Omega:334C:/
+430.4 "Advanced Suppression" sync / 1[56]:[^:]*:Omega:3349:/
+437.4 "Advanced Optical Laser" sync / 1[56]:[^:]*:Optical Unit:334A:/
+437.4 "Optimized Meteor" sync / 1[56]:[^:]*:Omega-F:334F:/
+437.4 "Optimized Sagittarius Arrow" sync / 1[56]:[^:]*:Omega-M:334D:/
+447.9 "Cosmo Memory" sync / 1[56]:[^:]*:Omega:3343:/
+455.9 "Laser Shower" sync / 1[56]:[^:]*:Omega:3353:/
+463.9 "Optimized Blade Dance" sync / 1[56]:[^:]*:Omega:334C:/
+479.4 "Cosmo Memory" sync / 1[56]:[^:]*:Omega:33EC:/
 
 # Final Omega - Alphascape V4.0 (Savage) - O12S+
 # -r ch1gtabdwN7QYDR6 -p 336C:3016 -ii 3380 3369 3366 335F 3377 336B 33B5
@@ -163,110 +163,110 @@ hideall "--sync--"
 0.0 "--Reset--" sync / 21:........:40000010:/ window 100000 jump 0
 
 3000.0 "Start"
-3002.5 "--sync--" sync / 1[56]:Omega:3380:/ window 3003,0
-3016.0 "Target Analysis" sync / 1[56]:Omega:336C:/
-3019.0 "Savage Wave Cannon" sync / 1[56]:Omega:336D:/
-3027.5 "Patch" sync / 1[56]:Omega:3376:/
-3034.5 "Diffuse Wave Cannon" sync / 1[56]:Omega:336[78]:/ # drift 0.046001
-3042.5 "Oversampled Wave Cannon" sync / 1[56]:Omega:336[45]:/
-3054.5 "Ion Efflux" sync / 1[56]:Omega:3357:/
-3062.6 "--sync--" sync / 1[56]:Omega:3381:/
-3069.9 "Hello, World" sync / 1[56]:Omega:336E:/
-3078.0 "Critical Synchronization Bug" #sync / 1[56]:Omega:336F:/
-3078.0 "Critical Overflow Bug" #sync / 1[56]:Omega:34E7:/
-3082.9 "Critical Synchronization Bug" #sync / 1[56]:Omega:336F:/
-3086.1 "Critical Overflow Bug" #sync / 1[56]:Omega:34E7:/
-3086.1 "Critical Synchronization Bug" #sync / 1[56]:Omega:336F:/
-3094.2 "Critical Overflow Bug" #sync / 1[56]:Omega:34E7:/
-3097.0 "Critical Error" sync / 1[56]:Omega:337E:/
-3105.1 "Critical Overflow Bug" #sync / 1[56]:Omega:34E7:/
-3105.1 "Critical Overflow Bug" #sync / 1[56]:Omega:34E7:/
-3113.1 "Ion Efflux" sync / 1[56]:Omega:3357:/
-3119.3 "--sync--" sync / 1[56]:Omega:3381:/
-3124.4 "Archive Peripheral" sync / 1[56]:Omega:3358:/ # drift -0.042999
-3140.5 "Hyper Pulse" sync / 1[56]:Right Arm Unit:335A:/
-3145.6 "Target Analysis" sync / 1[56]:Omega:336C:/
-3149.0 "Savage Wave Cannon" sync / 1[56]:Omega:336D:/
-3152.0 "--sync--" sync / 1[56]:Omega:3359:/ # drift 0.05
-3161.2 "Diffuse Wave Cannon" sync / 1[56]:Omega:336[78]:/
-3169.4 "Oversampled Wave Cannon" sync / 1[56]:Omega:336[45]:/
-3183.6 "Index and Archive Peripheral" sync / 1[56]:Omega:339A:/
-3188.8 "--sync--" sync / 1[56]:Omega:3381:/
-3197.8 "Hyper Pulse" sync / 1[56]:Right Arm Unit:335C:/ duration 6.5
-3198.0 "Wave Cannon" sync / 1[56]:Omega:336A:/
-3206.2 "Target Analysis" sync / 1[56]:Omega:336C:/
-3209.2 "Savage Wave Cannon" sync / 1[56]:Omega:336D:/ # drift 0.047
-3212.2 "--sync--" sync / 1[56]:Omega:3359:/
-3234.2 "Patch" sync / 1[56]:Omega:3376:/
-3241.2 "Diffuse Wave Cannon" sync / 1[56]:Omega:336[78]:/
-3249.4 "Oversampled Wave Cannon" sync / 1[56]:Omega:336[45]:/
-3261.5 "Ion Efflux" sync / 1[56]:Omega:3357:/ # drift -0.049001
-3269.8 "Archive All" sync / 1[56]:Omega:335D:/
-3283.0 "Electric Slide" sync / 1[56]:Omega:3363:/ # drift 0.05
-3289.1 "Delta Attack" sync / 1[56]:Omega:3378:/
-3292.2 "Floodlight" sync / 1[56]:Omega:337A:/
-3294.1 "Optimized Fire III" sync / 1[56]:Omega:3379:/ # drift 0.042001
-3294.1 "Spotlight" sync / 1[56]:Omega:337B:/
-3297.0 "Colossal Blow" sync / 1[56]:Left Arm Unit:3360:/
-3299.3 "--sync--" sync / 1[56]:Omega:335E:/
-3307.5 "Diffuse Wave Cannon" sync / 1[56]:Omega:336[78]:/
-3320.8 "--sync--" sync / 1[56]:Omega:3381:/
-3328.0 "Hello, World" sync / 1[56]:Omega:336E:/
-3336.1 "Critical Synchronization Bug" #sync / 1[56]:Omega:336F:/
-3336.1 "Critical Overflow Bug" #sync / 1[56]:Omega:34E7:/
-3341.1 "Critical Synchronization Bug" #sync / 1[56]:Omega:336F:/
-3343.2 "Critical Underflow Bug" #sync / 1[56]:Omega:3371:/
-3344.2 "Critical Overflow Bug" #sync / 1[56]:Omega:34E7:/
-3344.2 "Critical Synchronization Bug" #sync / 1[56]:Omega:336F:/
-3344.2 "Critical Overflow Bug" #sync / 1[56]:Omega:34E7:/
-3345.8 "Critical Underflow Bug" #sync / 1[56]:Omega:3371:/
-3349.2 "Critical Underflow Bug" #sync / 1[56]:Omega:3371:/
-3352.2 "Critical Overflow Bug" #sync / 1[56]:Omega:34E7:/
-3353.3 "Critical Underflow Bug" #sync / 1[56]:Omega:3371:/
-3355.3 "Critical Error" sync / 1[56]:Omega:337E:/
-3358.3 "Cascading Latent Defect" sync / 1[56]:Omega:3373:/
-3360.9 "Critical Underflow Bug" #sync / 1[56]:Omega:3371:/ # drift 0.042999
-3362.6 "Critical Underflow Bug" #sync / 1[56]:Omega:3371:/
-3362.8 "Critical Underflow Bug" #sync / 1[56]:Omega:3371:/
-3363.4 "Critical Overflow Bug" #sync / 1[56]:Omega:34E7:/ # drift -0.041
-3371.5 "Ion Efflux" sync / 1[56]:Omega:3357:/
-3377.7 "--sync--" sync / 1[56]:Omega:3381:/ # drift 0.042001
-3382.7 "Archive Peripheral" sync / 1[56]:Omega:3358:/
-3399.0 "Hyper Pulse" sync / 1[56]:Right Arm Unit:335A:/ duration 6.5
-3403.9 "Target Analysis" sync / 1[56]:Omega:336C:/
-3407.4 "Savage Wave Cannon" sync / 1[56]:Omega:336D:/ # drift 0.043999
-3410.5 "--sync--" sync / 1[56]:Omega:3359:/
-3419.6 "Diffuse Wave Cannon" sync / 1[56]:Omega:336[78]:/
-3427.8 "Oversampled Wave Cannon" sync / 1[56]:Omega:336[45]:/
-3442.0 "Index and Archive Peripheral" sync / 1[56]:Omega:339A:/
-3447.2 "--sync--" sync / 1[56]:Omega:3381:/
-3456.3 "Hyper Pulse" sync / 1[56]:Right Arm Unit:335C:/ duration 6.5
-3456.4 "Wave Cannon" sync / 1[56]:Omega:336A:/
-3464.5 "Target Analysis" sync / 1[56]:Omega:336C:/
-3467.8 "Savage Wave Cannon" sync / 1[56]:Omega:336D:/
-3470.9 "--sync--" sync / 1[56]:Omega:3359:/ # drift -0.047
-3493.1 "Patch" sync / 1[56]:Omega:3376:/
-3500.2 "Diffuse Wave Cannon" sync / 1[56]:Omega:336[78]:/
-3508.4 "Oversampled Wave Cannon" sync / 1[56]:Omega:336[45]:/
-3520.7 "Ion Efflux" sync / 1[56]:Omega:3357:/
-3529.0 "Archive All" sync / 1[56]:Omega:335D:/ # drift -0.045999
-3542.1 "Electric Slide" sync / 1[56]:Omega:3363:/
-3548.2 "Delta Attack" sync / 1[56]:Omega:3378:/
-3551.3 "Floodlight" sync / 1[56]:Omega:337A:/
-3553.3 "Optimized Fire III" sync / 1[56]:Omega:3379:/ # drift 0.043999
-3553.3 "Spotlight" sync / 1[56]:Omega:337B:/
-3556.1 "Colossal Blow" sync / 1[56]:Left Arm Unit:3360:/
-3558.3 "--sync--" sync / 1[56]:Omega:335E:/
-3566.5 "Diffuse Wave Cannon" sync / 1[56]:Omega:336[78]:/ # drift -0.042
-3579.8 "--sync--" sync / 1[56]:Omega:3381:/
-3585.2 "Program Omega" sync / 1[56]:Omega:360A:/
-3587.3 "Ion Efflux" sync / 1[56]:Omega:3355:/
+3002.5 "--sync--" sync / 1[56]:[^:]*:Omega:3380:/ window 3003,0
+3016.0 "Target Analysis" sync / 1[56]:[^:]*:Omega:336C:/
+3019.0 "Savage Wave Cannon" sync / 1[56]:[^:]*:Omega:336D:/
+3027.5 "Patch" sync / 1[56]:[^:]*:Omega:3376:/
+3034.5 "Diffuse Wave Cannon" sync / 1[56]:[^:]*:Omega:336[78]:/ # drift 0.046001
+3042.5 "Oversampled Wave Cannon" sync / 1[56]:[^:]*:Omega:336[45]:/
+3054.5 "Ion Efflux" sync / 1[56]:[^:]*:Omega:3357:/
+3062.6 "--sync--" sync / 1[56]:[^:]*:Omega:3381:/
+3069.9 "Hello, World" sync / 1[56]:[^:]*:Omega:336E:/
+3078.0 "Critical Synchronization Bug" #sync / 1[56]:[^:]*:Omega:336F:/
+3078.0 "Critical Overflow Bug" #sync / 1[56]:[^:]*:Omega:34E7:/
+3082.9 "Critical Synchronization Bug" #sync / 1[56]:[^:]*:Omega:336F:/
+3086.1 "Critical Overflow Bug" #sync / 1[56]:[^:]*:Omega:34E7:/
+3086.1 "Critical Synchronization Bug" #sync / 1[56]:[^:]*:Omega:336F:/
+3094.2 "Critical Overflow Bug" #sync / 1[56]:[^:]*:Omega:34E7:/
+3097.0 "Critical Error" sync / 1[56]:[^:]*:Omega:337E:/
+3105.1 "Critical Overflow Bug" #sync / 1[56]:[^:]*:Omega:34E7:/
+3105.1 "Critical Overflow Bug" #sync / 1[56]:[^:]*:Omega:34E7:/
+3113.1 "Ion Efflux" sync / 1[56]:[^:]*:Omega:3357:/
+3119.3 "--sync--" sync / 1[56]:[^:]*:Omega:3381:/
+3124.4 "Archive Peripheral" sync / 1[56]:[^:]*:Omega:3358:/ # drift -0.042999
+3140.5 "Hyper Pulse" sync / 1[56]:[^:]*:Right Arm Unit:335A:/
+3145.6 "Target Analysis" sync / 1[56]:[^:]*:Omega:336C:/
+3149.0 "Savage Wave Cannon" sync / 1[56]:[^:]*:Omega:336D:/
+3152.0 "--sync--" sync / 1[56]:[^:]*:Omega:3359:/ # drift 0.05
+3161.2 "Diffuse Wave Cannon" sync / 1[56]:[^:]*:Omega:336[78]:/
+3169.4 "Oversampled Wave Cannon" sync / 1[56]:[^:]*:Omega:336[45]:/
+3183.6 "Index and Archive Peripheral" sync / 1[56]:[^:]*:Omega:339A:/
+3188.8 "--sync--" sync / 1[56]:[^:]*:Omega:3381:/
+3197.8 "Hyper Pulse" sync / 1[56]:[^:]*:Right Arm Unit:335C:/ duration 6.5
+3198.0 "Wave Cannon" sync / 1[56]:[^:]*:Omega:336A:/
+3206.2 "Target Analysis" sync / 1[56]:[^:]*:Omega:336C:/
+3209.2 "Savage Wave Cannon" sync / 1[56]:[^:]*:Omega:336D:/ # drift 0.047
+3212.2 "--sync--" sync / 1[56]:[^:]*:Omega:3359:/
+3234.2 "Patch" sync / 1[56]:[^:]*:Omega:3376:/
+3241.2 "Diffuse Wave Cannon" sync / 1[56]:[^:]*:Omega:336[78]:/
+3249.4 "Oversampled Wave Cannon" sync / 1[56]:[^:]*:Omega:336[45]:/
+3261.5 "Ion Efflux" sync / 1[56]:[^:]*:Omega:3357:/ # drift -0.049001
+3269.8 "Archive All" sync / 1[56]:[^:]*:Omega:335D:/
+3283.0 "Electric Slide" sync / 1[56]:[^:]*:Omega:3363:/ # drift 0.05
+3289.1 "Delta Attack" sync / 1[56]:[^:]*:Omega:3378:/
+3292.2 "Floodlight" sync / 1[56]:[^:]*:Omega:337A:/
+3294.1 "Optimized Fire III" sync / 1[56]:[^:]*:Omega:3379:/ # drift 0.042001
+3294.1 "Spotlight" sync / 1[56]:[^:]*:Omega:337B:/
+3297.0 "Colossal Blow" sync / 1[56]:[^:]*:Left Arm Unit:3360:/
+3299.3 "--sync--" sync / 1[56]:[^:]*:Omega:335E:/
+3307.5 "Diffuse Wave Cannon" sync / 1[56]:[^:]*:Omega:336[78]:/
+3320.8 "--sync--" sync / 1[56]:[^:]*:Omega:3381:/
+3328.0 "Hello, World" sync / 1[56]:[^:]*:Omega:336E:/
+3336.1 "Critical Synchronization Bug" #sync / 1[56]:[^:]*:Omega:336F:/
+3336.1 "Critical Overflow Bug" #sync / 1[56]:[^:]*:Omega:34E7:/
+3341.1 "Critical Synchronization Bug" #sync / 1[56]:[^:]*:Omega:336F:/
+3343.2 "Critical Underflow Bug" #sync / 1[56]:[^:]*:Omega:3371:/
+3344.2 "Critical Overflow Bug" #sync / 1[56]:[^:]*:Omega:34E7:/
+3344.2 "Critical Synchronization Bug" #sync / 1[56]:[^:]*:Omega:336F:/
+3344.2 "Critical Overflow Bug" #sync / 1[56]:[^:]*:Omega:34E7:/
+3345.8 "Critical Underflow Bug" #sync / 1[56]:[^:]*:Omega:3371:/
+3349.2 "Critical Underflow Bug" #sync / 1[56]:[^:]*:Omega:3371:/
+3352.2 "Critical Overflow Bug" #sync / 1[56]:[^:]*:Omega:34E7:/
+3353.3 "Critical Underflow Bug" #sync / 1[56]:[^:]*:Omega:3371:/
+3355.3 "Critical Error" sync / 1[56]:[^:]*:Omega:337E:/
+3358.3 "Cascading Latent Defect" sync / 1[56]:[^:]*:Omega:3373:/
+3360.9 "Critical Underflow Bug" #sync / 1[56]:[^:]*:Omega:3371:/ # drift 0.042999
+3362.6 "Critical Underflow Bug" #sync / 1[56]:[^:]*:Omega:3371:/
+3362.8 "Critical Underflow Bug" #sync / 1[56]:[^:]*:Omega:3371:/
+3363.4 "Critical Overflow Bug" #sync / 1[56]:[^:]*:Omega:34E7:/ # drift -0.041
+3371.5 "Ion Efflux" sync / 1[56]:[^:]*:Omega:3357:/
+3377.7 "--sync--" sync / 1[56]:[^:]*:Omega:3381:/ # drift 0.042001
+3382.7 "Archive Peripheral" sync / 1[56]:[^:]*:Omega:3358:/
+3399.0 "Hyper Pulse" sync / 1[56]:[^:]*:Right Arm Unit:335A:/ duration 6.5
+3403.9 "Target Analysis" sync / 1[56]:[^:]*:Omega:336C:/
+3407.4 "Savage Wave Cannon" sync / 1[56]:[^:]*:Omega:336D:/ # drift 0.043999
+3410.5 "--sync--" sync / 1[56]:[^:]*:Omega:3359:/
+3419.6 "Diffuse Wave Cannon" sync / 1[56]:[^:]*:Omega:336[78]:/
+3427.8 "Oversampled Wave Cannon" sync / 1[56]:[^:]*:Omega:336[45]:/
+3442.0 "Index and Archive Peripheral" sync / 1[56]:[^:]*:Omega:339A:/
+3447.2 "--sync--" sync / 1[56]:[^:]*:Omega:3381:/
+3456.3 "Hyper Pulse" sync / 1[56]:[^:]*:Right Arm Unit:335C:/ duration 6.5
+3456.4 "Wave Cannon" sync / 1[56]:[^:]*:Omega:336A:/
+3464.5 "Target Analysis" sync / 1[56]:[^:]*:Omega:336C:/
+3467.8 "Savage Wave Cannon" sync / 1[56]:[^:]*:Omega:336D:/
+3470.9 "--sync--" sync / 1[56]:[^:]*:Omega:3359:/ # drift -0.047
+3493.1 "Patch" sync / 1[56]:[^:]*:Omega:3376:/
+3500.2 "Diffuse Wave Cannon" sync / 1[56]:[^:]*:Omega:336[78]:/
+3508.4 "Oversampled Wave Cannon" sync / 1[56]:[^:]*:Omega:336[45]:/
+3520.7 "Ion Efflux" sync / 1[56]:[^:]*:Omega:3357:/
+3529.0 "Archive All" sync / 1[56]:[^:]*:Omega:335D:/ # drift -0.045999
+3542.1 "Electric Slide" sync / 1[56]:[^:]*:Omega:3363:/
+3548.2 "Delta Attack" sync / 1[56]:[^:]*:Omega:3378:/
+3551.3 "Floodlight" sync / 1[56]:[^:]*:Omega:337A:/
+3553.3 "Optimized Fire III" sync / 1[56]:[^:]*:Omega:3379:/ # drift 0.043999
+3553.3 "Spotlight" sync / 1[56]:[^:]*:Omega:337B:/
+3556.1 "Colossal Blow" sync / 1[56]:[^:]*:Left Arm Unit:3360:/
+3558.3 "--sync--" sync / 1[56]:[^:]*:Omega:335E:/
+3566.5 "Diffuse Wave Cannon" sync / 1[56]:[^:]*:Omega:336[78]:/ # drift -0.042
+3579.8 "--sync--" sync / 1[56]:[^:]*:Omega:3381:/
+3585.2 "Program Omega" sync / 1[56]:[^:]*:Omega:360A:/
+3587.3 "Ion Efflux" sync / 1[56]:[^:]*:Omega:3355:/
 # Skipping the 3356 small explosions
-3596.4 "Ion Efflux" sync / 1[56]:Omega:35E1:/
-3599.6 "Ion Efflux" sync / 1[56]:Omega:3355:/
-3608.7 "Ion Efflux" sync / 1[56]:Omega:35E1:/
-3611.8 "Ion Efflux" sync / 1[56]:Omega:3355:/
-3620.9 "Ion Efflux" sync / 1[56]:Omega:35E1:/
-3624.1 "Ion Efflux" sync / 1[56]:Omega:3355:/
-3633.3 "Ion Efflux" sync / 1[56]:Omega:35E1:/
-3646.4 "Enrage" sync / 1[56]:Omega:337C:/
+3596.4 "Ion Efflux" sync / 1[56]:[^:]*:Omega:35E1:/
+3599.6 "Ion Efflux" sync / 1[56]:[^:]*:Omega:3355:/
+3608.7 "Ion Efflux" sync / 1[56]:[^:]*:Omega:35E1:/
+3611.8 "Ion Efflux" sync / 1[56]:[^:]*:Omega:3355:/
+3620.9 "Ion Efflux" sync / 1[56]:[^:]*:Omega:35E1:/
+3624.1 "Ion Efflux" sync / 1[56]:[^:]*:Omega:3355:/
+3633.3 "Ion Efflux" sync / 1[56]:[^:]*:Omega:35E1:/
+3646.4 "Enrage" sync / 1[56]:[^:]*:Omega:337C:/

--- a/ui/raidboss/data/04-sb/raid/o1n.txt
+++ b/ui/raidboss/data/04-sb/raid/o1n.txt
@@ -7,141 +7,141 @@
 0.0 "--Reset--" sync / 21:........:40000010:/ window 100000 jump 0
 
 0.0 "--sync--" sync /:Engage!/ window 0,1
-1.8 "--sync--" sync / 1[56]:Alte Roite:368:/ window 2,0
-6.6 "Wyrm Tail" sync / 1[56]:Alte Roite:23D6:/ window 6.6,2.5
-12.8 "Wyrm Tail" sync / 1[56]:Alte Roite:23D6:/
-19.0 "Flame" sync / 1[56]:Alte Roite:23DD:/ window 19,10
-29.1 "Roar" sync / 1[56]:Alte Roite:23DC:/
-37.3 "Flame" sync / 1[56]:Alte Roite:23DD:/
-38.1 "Burn" sync / 1[56]:Ball Of Fire:23D5:/
-52.6 "Breath Wing" sync / 1[56]:Alte Roite:23DE:/ window 30,30
-56.8 "Burn" sync / 1[56]:Ball Of Fire:23D5:/
-62.7 "Roar" sync / 1[56]:Alte Roite:23DC:/
-68.9 "Wyrm Tail" sync / 1[56]:Alte Roite:23D6:/
-75.0 "Wyrm Tail" sync / 1[56]:Alte Roite:23D6:/
-82.7 "Twin Bolt x2" # sync / 1[56]:Alte Roite:23D8:/
-87.2 "Clamp" sync / 1[56]:Alte Roite:23E2:/ window 30,30
-93.4 "Wyrm Tail" sync / 1[56]:Alte Roite:23D6:/
-99.5 "Flash Freeze" sync / 1[56]:Alte Roite:23DF:/
-112.7 "Levinbolt" sync / 1[56]:Alte Roite:23DA:/ window 30,30
-118.7 "Blaze" sync / 1[56]:Alte Roite:23E1:/
-125.9 "Wyrm Tail" sync / 1[56]:Alte Roite:23D6:/
+1.8 "--sync--" sync / 1[56]:[^:]*:Alte Roite:368:/ window 2,0
+6.6 "Wyrm Tail" sync / 1[56]:[^:]*:Alte Roite:23D6:/ window 6.6,2.5
+12.8 "Wyrm Tail" sync / 1[56]:[^:]*:Alte Roite:23D6:/
+19.0 "Flame" sync / 1[56]:[^:]*:Alte Roite:23DD:/ window 19,10
+29.1 "Roar" sync / 1[56]:[^:]*:Alte Roite:23DC:/
+37.3 "Flame" sync / 1[56]:[^:]*:Alte Roite:23DD:/
+38.1 "Burn" sync / 1[56]:[^:]*:Ball Of Fire:23D5:/
+52.6 "Breath Wing" sync / 1[56]:[^:]*:Alte Roite:23DE:/ window 30,30
+56.8 "Burn" sync / 1[56]:[^:]*:Ball Of Fire:23D5:/
+62.7 "Roar" sync / 1[56]:[^:]*:Alte Roite:23DC:/
+68.9 "Wyrm Tail" sync / 1[56]:[^:]*:Alte Roite:23D6:/
+75.0 "Wyrm Tail" sync / 1[56]:[^:]*:Alte Roite:23D6:/
+82.7 "Twin Bolt x2" # sync / 1[56]:[^:]*:Alte Roite:23D8:/
+87.2 "Clamp" sync / 1[56]:[^:]*:Alte Roite:23E2:/ window 30,30
+93.4 "Wyrm Tail" sync / 1[56]:[^:]*:Alte Roite:23D6:/
+99.5 "Flash Freeze" sync / 1[56]:[^:]*:Alte Roite:23DF:/
+112.7 "Levinbolt" sync / 1[56]:[^:]*:Alte Roite:23DA:/ window 30,30
+118.7 "Blaze" sync / 1[56]:[^:]*:Alte Roite:23E1:/
+125.9 "Wyrm Tail" sync / 1[56]:[^:]*:Alte Roite:23D6:/
 
-140.3 "The Classical Elements" sync / 1[56]:Alte Roite:23E0:/ window 30,30
-143.4 "Flame" sync / 1[56]:Alte Roite:23DD:/
-145.5 "Flash Freeze" sync / 1[56]:Alte Roite:23DF:/
-155.6 "Downburst" sync / 1[56]:Alte Roite:1ED8:/
-162.9 "Burn" sync / 1[56]:Ball Of Fire:23D5:/
-166.9 "Levinbolt" sync / 1[56]:Alte Roite:23DA:/ window 30,30
-171.9 "Wyrm Tail" sync / 1[56]:Alte Roite:23D6:/
-178.0 "Wyrm Tail" sync / 1[56]:Alte Roite:23D6:/
-185.7 "Twin Bolt x2" # sync / 1[56]:Alte Roite:23D8:/
-191.2 "Flame" sync / 1[56]:Alte Roite:23DD:/
-194.3 "Flame" sync / 1[56]:Alte Roite:23DD:/
-209.7 "Breath Wing" sync / 1[56]:Alte Roite:23DE:/ window 30,30
-210.4 "Burn" sync / 1[56]:Ball Of Fire:23D5:/
-213.8 "Burn" sync / 1[56]:Ball Of Fire:23D5:/
-216.8 "Roar" sync / 1[56]:Alte Roite:23DC:/
-223.0 "Wyrm Tail" sync / 1[56]:Alte Roite:23D6:/
-229.1 "Wyrm Tail" sync / 1[56]:Alte Roite:23D6:/
-236.2 "Charybdis" sync / 1[56]:Alte Roite:23DB:/ window 30,30
-243.3 "Roar" sync / 1[56]:Alte Roite:23DC:/
-249.4 "Wyrm Tail" sync / 1[56]:Alte Roite:23D6:/
-257.1 "Twin Bolt x2" # sync / 1[56]:Alte Roite:23D8:/
-261.6 "Clamp" sync / 1[56]:Alte Roite:23E2:/
-267.7 "Roar" sync / 1[56]:Alte Roite:23DC:/
+140.3 "The Classical Elements" sync / 1[56]:[^:]*:Alte Roite:23E0:/ window 30,30
+143.4 "Flame" sync / 1[56]:[^:]*:Alte Roite:23DD:/
+145.5 "Flash Freeze" sync / 1[56]:[^:]*:Alte Roite:23DF:/
+155.6 "Downburst" sync / 1[56]:[^:]*:Alte Roite:1ED8:/
+162.9 "Burn" sync / 1[56]:[^:]*:Ball Of Fire:23D5:/
+166.9 "Levinbolt" sync / 1[56]:[^:]*:Alte Roite:23DA:/ window 30,30
+171.9 "Wyrm Tail" sync / 1[56]:[^:]*:Alte Roite:23D6:/
+178.0 "Wyrm Tail" sync / 1[56]:[^:]*:Alte Roite:23D6:/
+185.7 "Twin Bolt x2" # sync / 1[56]:[^:]*:Alte Roite:23D8:/
+191.2 "Flame" sync / 1[56]:[^:]*:Alte Roite:23DD:/
+194.3 "Flame" sync / 1[56]:[^:]*:Alte Roite:23DD:/
+209.7 "Breath Wing" sync / 1[56]:[^:]*:Alte Roite:23DE:/ window 30,30
+210.4 "Burn" sync / 1[56]:[^:]*:Ball Of Fire:23D5:/
+213.8 "Burn" sync / 1[56]:[^:]*:Ball Of Fire:23D5:/
+216.8 "Roar" sync / 1[56]:[^:]*:Alte Roite:23DC:/
+223.0 "Wyrm Tail" sync / 1[56]:[^:]*:Alte Roite:23D6:/
+229.1 "Wyrm Tail" sync / 1[56]:[^:]*:Alte Roite:23D6:/
+236.2 "Charybdis" sync / 1[56]:[^:]*:Alte Roite:23DB:/ window 30,30
+243.3 "Roar" sync / 1[56]:[^:]*:Alte Roite:23DC:/
+249.4 "Wyrm Tail" sync / 1[56]:[^:]*:Alte Roite:23D6:/
+257.1 "Twin Bolt x2" # sync / 1[56]:[^:]*:Alte Roite:23D8:/
+261.6 "Clamp" sync / 1[56]:[^:]*:Alte Roite:23E2:/
+267.7 "Roar" sync / 1[56]:[^:]*:Alte Roite:23DC:/
 
-278.1 "The Classical Elements" sync / 1[56]:Alte Roite:23E0:/ window 30,30
-281.3 "Flame" sync / 1[56]:Alte Roite:23DD:/
-284.4 "Flame" sync / 1[56]:Alte Roite:23DD:/
-289.5 "Flash Freeze" sync / 1[56]:Alte Roite:23DF:/
-299.6 "Downburst" sync / 1[56]:Alte Roite:1ED8:/ window 30,30
-300.4 "Burn" sync / 1[56]:Ball Of Fire:23D5:/
-303.9 "Burn" sync / 1[56]:Ball Of Fire:23D5:/
-309.8 "Blaze" sync / 1[56]:Alte Roite:23E1:/
-322.0 "Charybdis" sync / 1[56]:Alte Roite:23DB:/ window 30,30
-329.1 "Roar" sync / 1[56]:Alte Roite:23DC:/
-331.2 "Flame" sync / 1[56]:Alte Roite:23DD:/
-333.3 "Flash Freeze" sync / 1[56]:Alte Roite:23DF:/
-343.4 "Downburst" sync / 1[56]:Alte Roite:1ED8:/
-350.7 "Burn" sync / 1[56]:Ball Of Fire:23D5:/
-354.7 "Levinbolt" sync / 1[56]:Alte Roite:23DA:/ window 30,30
-361.3 "Twin Bolt x2" # sync / 1[56]:Alte Roite:23D8:/
-366.8 "Wyrm Tail" sync / 1[56]:Alte Roite:23D6:/
-372.9 "Wyrm Tail" sync / 1[56]:Alte Roite:23D6:/
-380.6 "Twin Bolt x2" # sync / 1[56]:Alte Roite:23D8:/
-386.1 "Flame" sync / 1[56]:Alte Roite:23DD:/
-389.2 "Flame" sync / 1[56]:Alte Roite:23DD:/
-404.6 "Breath Wing" sync / 1[56]:Alte Roite:23DE:/ window 30,30
-405.3 "Burn" sync / 1[56]:Ball Of Fire:23D5:/
-408.7 "Burn" sync / 1[56]:Ball Of Fire:23D5:/
-411.7 "Roar" sync / 1[56]:Alte Roite:23DC:/
-417.9 "Wyrm Tail" sync / 1[56]:Alte Roite:23D6:/
-424.0 "Wyrm Tail" sync / 1[56]:Alte Roite:23D6:/
-431.1 "Charybdis" sync / 1[56]:Alte Roite:23DB:/
-438.2 "Roar" sync / 1[56]:Alte Roite:23DC:/
-444.3 "Wyrm Tail" sync / 1[56]:Alte Roite:23D6:/
-452.0 "Twin Bolt x2" # sync / 1[56]:Alte Roite:23D8:/
-456.5 "Clamp" sync / 1[56]:Alte Roite:23E2:/
-462.6 "Roar" sync / 1[56]:Alte Roite:23DC:/
+278.1 "The Classical Elements" sync / 1[56]:[^:]*:Alte Roite:23E0:/ window 30,30
+281.3 "Flame" sync / 1[56]:[^:]*:Alte Roite:23DD:/
+284.4 "Flame" sync / 1[56]:[^:]*:Alte Roite:23DD:/
+289.5 "Flash Freeze" sync / 1[56]:[^:]*:Alte Roite:23DF:/
+299.6 "Downburst" sync / 1[56]:[^:]*:Alte Roite:1ED8:/ window 30,30
+300.4 "Burn" sync / 1[56]:[^:]*:Ball Of Fire:23D5:/
+303.9 "Burn" sync / 1[56]:[^:]*:Ball Of Fire:23D5:/
+309.8 "Blaze" sync / 1[56]:[^:]*:Alte Roite:23E1:/
+322.0 "Charybdis" sync / 1[56]:[^:]*:Alte Roite:23DB:/ window 30,30
+329.1 "Roar" sync / 1[56]:[^:]*:Alte Roite:23DC:/
+331.2 "Flame" sync / 1[56]:[^:]*:Alte Roite:23DD:/
+333.3 "Flash Freeze" sync / 1[56]:[^:]*:Alte Roite:23DF:/
+343.4 "Downburst" sync / 1[56]:[^:]*:Alte Roite:1ED8:/
+350.7 "Burn" sync / 1[56]:[^:]*:Ball Of Fire:23D5:/
+354.7 "Levinbolt" sync / 1[56]:[^:]*:Alte Roite:23DA:/ window 30,30
+361.3 "Twin Bolt x2" # sync / 1[56]:[^:]*:Alte Roite:23D8:/
+366.8 "Wyrm Tail" sync / 1[56]:[^:]*:Alte Roite:23D6:/
+372.9 "Wyrm Tail" sync / 1[56]:[^:]*:Alte Roite:23D6:/
+380.6 "Twin Bolt x2" # sync / 1[56]:[^:]*:Alte Roite:23D8:/
+386.1 "Flame" sync / 1[56]:[^:]*:Alte Roite:23DD:/
+389.2 "Flame" sync / 1[56]:[^:]*:Alte Roite:23DD:/
+404.6 "Breath Wing" sync / 1[56]:[^:]*:Alte Roite:23DE:/ window 30,30
+405.3 "Burn" sync / 1[56]:[^:]*:Ball Of Fire:23D5:/
+408.7 "Burn" sync / 1[56]:[^:]*:Ball Of Fire:23D5:/
+411.7 "Roar" sync / 1[56]:[^:]*:Alte Roite:23DC:/
+417.9 "Wyrm Tail" sync / 1[56]:[^:]*:Alte Roite:23D6:/
+424.0 "Wyrm Tail" sync / 1[56]:[^:]*:Alte Roite:23D6:/
+431.1 "Charybdis" sync / 1[56]:[^:]*:Alte Roite:23DB:/
+438.2 "Roar" sync / 1[56]:[^:]*:Alte Roite:23DC:/
+444.3 "Wyrm Tail" sync / 1[56]:[^:]*:Alte Roite:23D6:/
+452.0 "Twin Bolt x2" # sync / 1[56]:[^:]*:Alte Roite:23D8:/
+456.5 "Clamp" sync / 1[56]:[^:]*:Alte Roite:23E2:/
+462.6 "Roar" sync / 1[56]:[^:]*:Alte Roite:23DC:/
 
-473.0 "The Classical Elements" sync / 1[56]:Alte Roite:23E0:/
-476.2 "Flame" sync / 1[56]:Alte Roite:23DD:/
-479.3 "Flame" sync / 1[56]:Alte Roite:23DD:/
-484.4 "Flash Freeze" sync / 1[56]:Alte Roite:23DF:/
-494.5 "Downburst" sync / 1[56]:Alte Roite:1ED8:/
-495.3 "Burn" sync / 1[56]:Ball Of Fire:23D5:/
-498.8 "Burn" sync / 1[56]:Ball Of Fire:23D5:/
-504.7 "Blaze" sync / 1[56]:Alte Roite:23E1:/
-516.8 "Charybdis" sync / 1[56]:Alte Roite:23DB:/ window 30,30
-523.9 "Roar" sync / 1[56]:Alte Roite:23DC:/
-526.0 "Flame" sync / 1[56]:Alte Roite:23DD:/
-528.1 "Flash Freeze" sync / 1[56]:Alte Roite:23DF:/
-538.2 "Downburst" sync / 1[56]:Alte Roite:1ED8:/
-545.5 "Burn" sync / 1[56]:Ball Of Fire:23D5:/
-549.6 "Levinbolt" sync / 1[56]:Alte Roite:23DA:/ window 30,30
-556.2 "Twin Bolt x2" # sync / 1[56]:Alte Roite:23D8:/
-561.7 "Wyrm Tail" sync / 1[56]:Alte Roite:23D6:/
-567.8 "Wyrm Tail" sync / 1[56]:Alte Roite:23D6:/
-575.5 "Twin Bolt x2" # sync / 1[56]:Alte Roite:23D8:/
-581.0 "Flame" sync / 1[56]:Alte Roite:23DD:/
-584.1 "Flame" sync / 1[56]:Alte Roite:23DD:/
-599.5 "Breath Wing" sync / 1[56]:Alte Roite:23DE:/ window 30,30
-600.2 "Burn" sync / 1[56]:Ball Of Fire:23D5:/
-603.6 "Burn" sync / 1[56]:Ball Of Fire:23D5:/
-606.6 "Roar" sync / 1[56]:Alte Roite:23DC:/
-612.8 "Wyrm Tail" sync / 1[56]:Alte Roite:23D6:/
-618.9 "Wyrm Tail" sync / 1[56]:Alte Roite:23D6:/
-626.0 "Charybdis" sync / 1[56]:Alte Roite:23DB:/ window 30,30
-633.1 "Roar" sync / 1[56]:Alte Roite:23DC:/
-639.2 "Wyrm Tail" sync / 1[56]:Alte Roite:23D6:/
-646.9 "Twin Bolt x2" # sync / 1[56]:Alte Roite:23D8:/
-651.4 "Clamp" sync / 1[56]:Alte Roite:23E2:/
-657.5 "Roar" sync / 1[56]:Alte Roite:23DC:/
+473.0 "The Classical Elements" sync / 1[56]:[^:]*:Alte Roite:23E0:/
+476.2 "Flame" sync / 1[56]:[^:]*:Alte Roite:23DD:/
+479.3 "Flame" sync / 1[56]:[^:]*:Alte Roite:23DD:/
+484.4 "Flash Freeze" sync / 1[56]:[^:]*:Alte Roite:23DF:/
+494.5 "Downburst" sync / 1[56]:[^:]*:Alte Roite:1ED8:/
+495.3 "Burn" sync / 1[56]:[^:]*:Ball Of Fire:23D5:/
+498.8 "Burn" sync / 1[56]:[^:]*:Ball Of Fire:23D5:/
+504.7 "Blaze" sync / 1[56]:[^:]*:Alte Roite:23E1:/
+516.8 "Charybdis" sync / 1[56]:[^:]*:Alte Roite:23DB:/ window 30,30
+523.9 "Roar" sync / 1[56]:[^:]*:Alte Roite:23DC:/
+526.0 "Flame" sync / 1[56]:[^:]*:Alte Roite:23DD:/
+528.1 "Flash Freeze" sync / 1[56]:[^:]*:Alte Roite:23DF:/
+538.2 "Downburst" sync / 1[56]:[^:]*:Alte Roite:1ED8:/
+545.5 "Burn" sync / 1[56]:[^:]*:Ball Of Fire:23D5:/
+549.6 "Levinbolt" sync / 1[56]:[^:]*:Alte Roite:23DA:/ window 30,30
+556.2 "Twin Bolt x2" # sync / 1[56]:[^:]*:Alte Roite:23D8:/
+561.7 "Wyrm Tail" sync / 1[56]:[^:]*:Alte Roite:23D6:/
+567.8 "Wyrm Tail" sync / 1[56]:[^:]*:Alte Roite:23D6:/
+575.5 "Twin Bolt x2" # sync / 1[56]:[^:]*:Alte Roite:23D8:/
+581.0 "Flame" sync / 1[56]:[^:]*:Alte Roite:23DD:/
+584.1 "Flame" sync / 1[56]:[^:]*:Alte Roite:23DD:/
+599.5 "Breath Wing" sync / 1[56]:[^:]*:Alte Roite:23DE:/ window 30,30
+600.2 "Burn" sync / 1[56]:[^:]*:Ball Of Fire:23D5:/
+603.6 "Burn" sync / 1[56]:[^:]*:Ball Of Fire:23D5:/
+606.6 "Roar" sync / 1[56]:[^:]*:Alte Roite:23DC:/
+612.8 "Wyrm Tail" sync / 1[56]:[^:]*:Alte Roite:23D6:/
+618.9 "Wyrm Tail" sync / 1[56]:[^:]*:Alte Roite:23D6:/
+626.0 "Charybdis" sync / 1[56]:[^:]*:Alte Roite:23DB:/ window 30,30
+633.1 "Roar" sync / 1[56]:[^:]*:Alte Roite:23DC:/
+639.2 "Wyrm Tail" sync / 1[56]:[^:]*:Alte Roite:23D6:/
+646.9 "Twin Bolt x2" # sync / 1[56]:[^:]*:Alte Roite:23D8:/
+651.4 "Clamp" sync / 1[56]:[^:]*:Alte Roite:23E2:/
+657.5 "Roar" sync / 1[56]:[^:]*:Alte Roite:23DC:/
 
-667.9 "The Classical Elements" sync / 1[56]:Alte Roite:23E0:/
-671.1 "Flame" sync / 1[56]:Alte Roite:23DD:/
-674.2 "Flame" sync / 1[56]:Alte Roite:23DD:/
-679.3 "Flash Freeze" sync / 1[56]:Alte Roite:23DF:/
-689.4 "Downburst" sync / 1[56]:Alte Roite:1ED8:/
-690.2 "Burn" sync / 1[56]:Ball Of Fire:23D5:/
-693.6 "Burn" sync / 1[56]:Ball Of Fire:23D5:/
-699.5 "Blaze" sync / 1[56]:Alte Roite:23E1:/
-711.7 "Charybdis" sync / 1[56]:Alte Roite:23DB:/ window 30,30
-718.8 "Roar" sync / 1[56]:Alte Roite:23DC:/
-720.9 "Flame" sync / 1[56]:Alte Roite:23DD:/
-723.0 "Flash Freeze" sync / 1[56]:Alte Roite:23DF:/
-733.1 "Downburst" sync / 1[56]:Alte Roite:1ED8:/
-740.4 "Burn" sync / 1[56]:Ball Of Fire:23D5:/
-744.5 "Levinbolt" sync / 1[56]:Alte Roite:23DA:/ window 30,30
-751.1 "Twin Bolt x2" # sync / 1[56]:Alte Roite:23D8:/
-756.6 "Wyrm Tail" sync / 1[56]:Alte Roite:23D6:/
-762.7 "Wyrm Tail" sync / 1[56]:Alte Roite:23D6:/
-769.8 "Charybdis" sync / 1[56]:Alte Roite:23DB:/
-776.9 "Roar" sync / 1[56]:Alte Roite:23DC:/ window 30,15
-783.0 "Wyrm Tail" sync / 1[56]:Alte Roite:23D6:/
-790.7 "Twin Bolt x2" # sync / 1[56]:Alte Roite:23D8:/
-795.2 "Clamp" sync / 1[56]:Alte Roite:23E2:/
-801.3 "Roar" sync / 1[56]:Alte Roite:23DC:/
-803.5 "Flame" sync / 1[56]:Alte Roite:23DD:/ window 50,5
-820.7 "Burn Enrage" sync / 1[56]:Ball Of Fire:23E4:/
+667.9 "The Classical Elements" sync / 1[56]:[^:]*:Alte Roite:23E0:/
+671.1 "Flame" sync / 1[56]:[^:]*:Alte Roite:23DD:/
+674.2 "Flame" sync / 1[56]:[^:]*:Alte Roite:23DD:/
+679.3 "Flash Freeze" sync / 1[56]:[^:]*:Alte Roite:23DF:/
+689.4 "Downburst" sync / 1[56]:[^:]*:Alte Roite:1ED8:/
+690.2 "Burn" sync / 1[56]:[^:]*:Ball Of Fire:23D5:/
+693.6 "Burn" sync / 1[56]:[^:]*:Ball Of Fire:23D5:/
+699.5 "Blaze" sync / 1[56]:[^:]*:Alte Roite:23E1:/
+711.7 "Charybdis" sync / 1[56]:[^:]*:Alte Roite:23DB:/ window 30,30
+718.8 "Roar" sync / 1[56]:[^:]*:Alte Roite:23DC:/
+720.9 "Flame" sync / 1[56]:[^:]*:Alte Roite:23DD:/
+723.0 "Flash Freeze" sync / 1[56]:[^:]*:Alte Roite:23DF:/
+733.1 "Downburst" sync / 1[56]:[^:]*:Alte Roite:1ED8:/
+740.4 "Burn" sync / 1[56]:[^:]*:Ball Of Fire:23D5:/
+744.5 "Levinbolt" sync / 1[56]:[^:]*:Alte Roite:23DA:/ window 30,30
+751.1 "Twin Bolt x2" # sync / 1[56]:[^:]*:Alte Roite:23D8:/
+756.6 "Wyrm Tail" sync / 1[56]:[^:]*:Alte Roite:23D6:/
+762.7 "Wyrm Tail" sync / 1[56]:[^:]*:Alte Roite:23D6:/
+769.8 "Charybdis" sync / 1[56]:[^:]*:Alte Roite:23DB:/
+776.9 "Roar" sync / 1[56]:[^:]*:Alte Roite:23DC:/ window 30,15
+783.0 "Wyrm Tail" sync / 1[56]:[^:]*:Alte Roite:23D6:/
+790.7 "Twin Bolt x2" # sync / 1[56]:[^:]*:Alte Roite:23D8:/
+795.2 "Clamp" sync / 1[56]:[^:]*:Alte Roite:23E2:/
+801.3 "Roar" sync / 1[56]:[^:]*:Alte Roite:23DC:/
+803.5 "Flame" sync / 1[56]:[^:]*:Alte Roite:23DD:/ window 50,5
+820.7 "Burn Enrage" sync / 1[56]:[^:]*:Ball Of Fire:23E4:/

--- a/ui/raidboss/data/04-sb/raid/o1s.txt
+++ b/ui/raidboss/data/04-sb/raid/o1s.txt
@@ -13,116 +13,116 @@ hideall "Flame"
 # spread: knockback => in => spread+lightning
 
 0.0 "--sync--" sync /:Engage!/ window 0,1
-2.5 "--sync--" sync / 1[56]:Alte Roite:368:/ window 2.5,0
-6.9 "Wyrm Tail" sync / 1[56]:Alte Roite:1ECE:/ window 7,3
-13.0 "Wyrm Tail" sync / 1[56]:Alte Roite:1ECE:/
-20.1 "Twin Bolt" sync / 1[56]:Alte Roite:1ECF:/
+2.5 "--sync--" sync / 1[56]:[^:]*:Alte Roite:368:/ window 2.5,0
+6.9 "Wyrm Tail" sync / 1[56]:[^:]*:Alte Roite:1ECE:/ window 7,3
+13.0 "Wyrm Tail" sync / 1[56]:[^:]*:Alte Roite:1ECE:/
+20.1 "Twin Bolt" sync / 1[56]:[^:]*:Alte Roite:1ECF:/
 
-34.6 "Classical (spread)" sync / 1[56]:Alte Roite:1EDC:/ window 80,80
-37.7 "Flame" sync / 1[56]:Alte Roite:1ED5:/
-41.8 "Flash Freeze" sync / 1[56]:Alte Roite:1ED7:/
-51.9 "Downburst" sync / 1[56]:Alte Roite:1ED8:/
-57.2 "Outer Fireballs" sync / 1[56]:Ball Of Fire:1ECB:/
-60.5 "Levinbolt" sync / 1[56]:Alte Roite:1ED1:/
-66.6 "Roar" sync / 1[56]:Alte Roite:1ED4:/
-72.8 "Wyrm Tail" sync / 1[56]:Alte Roite:1ECE:/
-78.9 "Wyrm Tail" sync / 1[56]:Alte Roite:1ECE:/
-90.0 "Twin Bolt" sync / 1[56]:Alte Roite:1ECF:/
-96.1 "Clamp" sync / 1[56]:Alte Roite:1EDE:/
-98.2 "Flame" sync / 1[56]:Alte Roite:1ED5:/
-103.3 "Flame" sync / 1[56]:Alte Roite:1ED5:/
-109.4 "Wyrm Tail" sync / 1[56]:Alte Roite:1ECE:/
-117.4 "Outer Fireballs" sync / 1[56]:Ball Of Fire:1ECB:/
-120.5 "Levinbolt" sync / 1[56]:Alte Roite:1ED1:/
-122.5 "Inner Fireballs" sync / 1[56]:Ball Of Fire:1ECB:/
-127.6 "Blaze" sync / 1[56]:Alte Roite:1EDD:/
-134.8 "Wyrm Tail" sync / 1[56]:Alte Roite:1ECE:/
-140.9 "Wyrm Tail" sync / 1[56]:Alte Roite:1ECE:/
-148.0 "Twin Bolt" sync / 1[56]:Alte Roite:1ECF:/
-158.1 "Roar" sync / 1[56]:Alte Roite:1ED4:/
-164.2 "Roar" sync / 1[56]:Alte Roite:1ED4:/
-170.4 "Wyrm Tail" sync / 1[56]:Alte Roite:1ECE:/
-177.5 "Charybdis" sync / 1[56]:Alte Roite:1ED3:/
-184.7 "Roar" sync / 1[56]:Alte Roite:1ED4:/
+34.6 "Classical (spread)" sync / 1[56]:[^:]*:Alte Roite:1EDC:/ window 80,80
+37.7 "Flame" sync / 1[56]:[^:]*:Alte Roite:1ED5:/
+41.8 "Flash Freeze" sync / 1[56]:[^:]*:Alte Roite:1ED7:/
+51.9 "Downburst" sync / 1[56]:[^:]*:Alte Roite:1ED8:/
+57.2 "Outer Fireballs" sync / 1[56]:[^:]*:Ball Of Fire:1ECB:/
+60.5 "Levinbolt" sync / 1[56]:[^:]*:Alte Roite:1ED1:/
+66.6 "Roar" sync / 1[56]:[^:]*:Alte Roite:1ED4:/
+72.8 "Wyrm Tail" sync / 1[56]:[^:]*:Alte Roite:1ECE:/
+78.9 "Wyrm Tail" sync / 1[56]:[^:]*:Alte Roite:1ECE:/
+90.0 "Twin Bolt" sync / 1[56]:[^:]*:Alte Roite:1ECF:/
+96.1 "Clamp" sync / 1[56]:[^:]*:Alte Roite:1EDE:/
+98.2 "Flame" sync / 1[56]:[^:]*:Alte Roite:1ED5:/
+103.3 "Flame" sync / 1[56]:[^:]*:Alte Roite:1ED5:/
+109.4 "Wyrm Tail" sync / 1[56]:[^:]*:Alte Roite:1ECE:/
+117.4 "Outer Fireballs" sync / 1[56]:[^:]*:Ball Of Fire:1ECB:/
+120.5 "Levinbolt" sync / 1[56]:[^:]*:Alte Roite:1ED1:/
+122.5 "Inner Fireballs" sync / 1[56]:[^:]*:Ball Of Fire:1ECB:/
+127.6 "Blaze" sync / 1[56]:[^:]*:Alte Roite:1EDD:/
+134.8 "Wyrm Tail" sync / 1[56]:[^:]*:Alte Roite:1ECE:/
+140.9 "Wyrm Tail" sync / 1[56]:[^:]*:Alte Roite:1ECE:/
+148.0 "Twin Bolt" sync / 1[56]:[^:]*:Alte Roite:1ECF:/
+158.1 "Roar" sync / 1[56]:[^:]*:Alte Roite:1ED4:/
+164.2 "Roar" sync / 1[56]:[^:]*:Alte Roite:1ED4:/
+170.4 "Wyrm Tail" sync / 1[56]:[^:]*:Alte Roite:1ECE:/
+177.5 "Charybdis" sync / 1[56]:[^:]*:Alte Roite:1ED3:/
+184.7 "Roar" sync / 1[56]:[^:]*:Alte Roite:1ED4:/
 
 
 ###### 2nd Classical Elements
 # safe: knockback safe spot => spread+lightning
 
-195.1 "Classical (safe)" sync / 1[56]:Alte Roite:1EDC:/ window 80,80
-198.2 "Flame" sync / 1[56]:Alte Roite:1ED5:/
-204.8 "Flash Freeze" sync / 1[56]:Alte Roite:1ED7:/
-213.9 "Downburst" sync / 1[56]:Alte Roite:1ED8:/
-217.7 "Outer Fireballs" sync / 1[56]:Ball Of Fire:1ECB:/
-223.0 "Levinbolt" sync / 1[56]:Alte Roite:1ED1:/
-225.2 "Flame" sync / 1[56]:Alte Roite:1ED5:/
-230.3 "Flash Freeze" sync / 1[56]:Alte Roite:1ED7:/
-240.7 "Breath Wing" sync / 1[56]:Alte Roite:1ED6:/
-244.8 "Inner Fireballs" sync / 1[56]:Ball Of Fire:1ECB:/
-248.6 "Clamp" sync / 1[56]:Alte Roite:1EDE:/
-255.7 "Blaze" sync / 1[56]:Alte Roite:1EDD:/
-262.8 "Roar" sync / 1[56]:Alte Roite:1ED4:/
-269.0 "Wyrm Tail" sync / 1[56]:Alte Roite:1ECE:/
-275.1 "Wyrm Tail" sync / 1[56]:Alte Roite:1ECE:/
-286.2 "Charybdis" sync / 1[56]:Alte Roite:1ED3:/
-294.3 "Twin Bolt" sync / 1[56]:Alte Roite:1ECF:/
-300.5 "Flame" sync / 1[56]:Alte Roite:1ED5:/
-308.6 "Flame" sync / 1[56]:Alte Roite:1ED5:/
-317.7 "Levinbolt" sync / 1[56]:Alte Roite:1ED1:/
-319.7 "Inner Fireballs" sync / 1[56]:Ball Of Fire:1ECB:/
-327.4 "Clamp" sync / 1[56]:Alte Roite:1EDE:/
-327.8 "Outer Fireballs" sync / 1[56]:Ball Of Fire:1ECB:/
-333.5 "Roar" sync / 1[56]:Alte Roite:1ED4:/
-339.6 "Roar" sync / 1[56]:Alte Roite:1ED4:/
+195.1 "Classical (safe)" sync / 1[56]:[^:]*:Alte Roite:1EDC:/ window 80,80
+198.2 "Flame" sync / 1[56]:[^:]*:Alte Roite:1ED5:/
+204.8 "Flash Freeze" sync / 1[56]:[^:]*:Alte Roite:1ED7:/
+213.9 "Downburst" sync / 1[56]:[^:]*:Alte Roite:1ED8:/
+217.7 "Outer Fireballs" sync / 1[56]:[^:]*:Ball Of Fire:1ECB:/
+223.0 "Levinbolt" sync / 1[56]:[^:]*:Alte Roite:1ED1:/
+225.2 "Flame" sync / 1[56]:[^:]*:Alte Roite:1ED5:/
+230.3 "Flash Freeze" sync / 1[56]:[^:]*:Alte Roite:1ED7:/
+240.7 "Breath Wing" sync / 1[56]:[^:]*:Alte Roite:1ED6:/
+244.8 "Inner Fireballs" sync / 1[56]:[^:]*:Ball Of Fire:1ECB:/
+248.6 "Clamp" sync / 1[56]:[^:]*:Alte Roite:1EDE:/
+255.7 "Blaze" sync / 1[56]:[^:]*:Alte Roite:1EDD:/
+262.8 "Roar" sync / 1[56]:[^:]*:Alte Roite:1ED4:/
+269.0 "Wyrm Tail" sync / 1[56]:[^:]*:Alte Roite:1ECE:/
+275.1 "Wyrm Tail" sync / 1[56]:[^:]*:Alte Roite:1ECE:/
+286.2 "Charybdis" sync / 1[56]:[^:]*:Alte Roite:1ED3:/
+294.3 "Twin Bolt" sync / 1[56]:[^:]*:Alte Roite:1ECF:/
+300.5 "Flame" sync / 1[56]:[^:]*:Alte Roite:1ED5:/
+308.6 "Flame" sync / 1[56]:[^:]*:Alte Roite:1ED5:/
+317.7 "Levinbolt" sync / 1[56]:[^:]*:Alte Roite:1ED1:/
+319.7 "Inner Fireballs" sync / 1[56]:[^:]*:Ball Of Fire:1ECB:/
+327.4 "Clamp" sync / 1[56]:[^:]*:Alte Roite:1EDE:/
+327.8 "Outer Fireballs" sync / 1[56]:[^:]*:Ball Of Fire:1ECB:/
+333.5 "Roar" sync / 1[56]:[^:]*:Alte Roite:1ED4:/
+339.6 "Roar" sync / 1[56]:[^:]*:Alte Roite:1ED4:/
 
 
 ###### 3rd Classical Elements
 # stack: knockback => in => blaze stack
 
-350.0 "Classical (stack)" sync / 1[56]:Alte Roite:1EDC:/ window 80,80
-353.1 "Flame" sync / 1[56]:Alte Roite:1ED5:/
-356.2 "Flame" sync / 1[56]:Alte Roite:1ED5:/
-361.3 "Flash Freeze" sync / 1[56]:Alte Roite:1ED7:/
-371.4 "Downburst" sync / 1[56]:Alte Roite:1ED8:/
-372.3 "Outer Fireballs" sync / 1[56]:Ball Of Fire:1ECB:/
-375.8 "Inner Fireballs" sync / 1[56]:Ball Of Fire:1ECB:/
-380.6 "Blaze" sync / 1[56]:Alte Roite:1EDD:/
-387.7 "Roar" sync / 1[56]:Alte Roite:1ED4:/
-393.9 "Wyrm Tail" sync / 1[56]:Alte Roite:1ECE:/
-400.0 "Wyrm Tail" sync / 1[56]:Alte Roite:1ECE:/
-411.1 "Twin Bolt" sync / 1[56]:Alte Roite:1ECF:/
-417.2 "Clamp" sync / 1[56]:Alte Roite:1EDE:/
-419.4 "Flame" sync / 1[56]:Alte Roite:1ED5:/
-424.5 "Flame" sync / 1[56]:Alte Roite:1ED5:/
-430.6 "Wyrm Tail" sync / 1[56]:Alte Roite:1ECE:/
-438.6 "Outer Fireballs" sync / 1[56]:Ball Of Fire:1ECB:/
-441.7 "Levinbolt" sync / 1[56]:Alte Roite:1ED1:/
-443.7 "Inner Fireballs" sync / 1[56]:Ball Of Fire:1ECB:/
-448.9 "Blaze" sync / 1[56]:Alte Roite:1EDD:/
+350.0 "Classical (stack)" sync / 1[56]:[^:]*:Alte Roite:1EDC:/ window 80,80
+353.1 "Flame" sync / 1[56]:[^:]*:Alte Roite:1ED5:/
+356.2 "Flame" sync / 1[56]:[^:]*:Alte Roite:1ED5:/
+361.3 "Flash Freeze" sync / 1[56]:[^:]*:Alte Roite:1ED7:/
+371.4 "Downburst" sync / 1[56]:[^:]*:Alte Roite:1ED8:/
+372.3 "Outer Fireballs" sync / 1[56]:[^:]*:Ball Of Fire:1ECB:/
+375.8 "Inner Fireballs" sync / 1[56]:[^:]*:Ball Of Fire:1ECB:/
+380.6 "Blaze" sync / 1[56]:[^:]*:Alte Roite:1EDD:/
+387.7 "Roar" sync / 1[56]:[^:]*:Alte Roite:1ED4:/
+393.9 "Wyrm Tail" sync / 1[56]:[^:]*:Alte Roite:1ECE:/
+400.0 "Wyrm Tail" sync / 1[56]:[^:]*:Alte Roite:1ECE:/
+411.1 "Twin Bolt" sync / 1[56]:[^:]*:Alte Roite:1ECF:/
+417.2 "Clamp" sync / 1[56]:[^:]*:Alte Roite:1EDE:/
+419.4 "Flame" sync / 1[56]:[^:]*:Alte Roite:1ED5:/
+424.5 "Flame" sync / 1[56]:[^:]*:Alte Roite:1ED5:/
+430.6 "Wyrm Tail" sync / 1[56]:[^:]*:Alte Roite:1ECE:/
+438.6 "Outer Fireballs" sync / 1[56]:[^:]*:Ball Of Fire:1ECB:/
+441.7 "Levinbolt" sync / 1[56]:[^:]*:Alte Roite:1ED1:/
+443.7 "Inner Fireballs" sync / 1[56]:[^:]*:Ball Of Fire:1ECB:/
+448.9 "Blaze" sync / 1[56]:[^:]*:Alte Roite:1EDD:/
 
 
 ##### 4th Classical Elements
 # spread: knockback => in => spread+lightning
 
-460.3 "Classical (spread)" sync / 1[56]:Alte Roite:1EDC:/ window 80,80
-463.4 "Flame" sync / 1[56]:Alte Roite:1ED5:/
-467.5 "Flash Freeze" sync / 1[56]:Alte Roite:1ED7:/
-477.6 "Downburst" sync / 1[56]:Alte Roite:1ED8:/
-483.0 "Outer Fireballs" sync / 1[56]:Ball Of Fire:1ECB:/
-486.3 "Levinbolt" sync / 1[56]:Alte Roite:1ED1:/
-492.4 "Roar" sync / 1[56]:Alte Roite:1ED4:/
-498.6 "Wyrm Tail" sync / 1[56]:Alte Roite:1ECE:/
-504.7 "Wyrm Tail" sync / 1[56]:Alte Roite:1ECE:/
-515.8 "Charybdis" sync / 1[56]:Alte Roite:1ED3:/
-523.9 "Twin Bolt" sync / 1[56]:Alte Roite:1ECF:/
-530.1 "Flame" sync / 1[56]:Alte Roite:1ED5:/
-538.3 "Flame" sync / 1[56]:Alte Roite:1ED5:/
-547.4 "Levinbolt" sync / 1[56]:Alte Roite:1ED1:/
-549.4 "Inner Fireballs" sync / 1[56]:Ball Of Fire:1ECB:/
-557.1 "Clamp" sync / 1[56]:Alte Roite:1EDE:/
-557.6 "Outer Fireballs" sync / 1[56]:Ball Of Fire:1ECB:/
-563.3 "Roar" sync / 1[56]:Alte Roite:1ED4:/
-569.5 "Roar" sync / 1[56]:Alte Roite:1ED4:/
+460.3 "Classical (spread)" sync / 1[56]:[^:]*:Alte Roite:1EDC:/ window 80,80
+463.4 "Flame" sync / 1[56]:[^:]*:Alte Roite:1ED5:/
+467.5 "Flash Freeze" sync / 1[56]:[^:]*:Alte Roite:1ED7:/
+477.6 "Downburst" sync / 1[56]:[^:]*:Alte Roite:1ED8:/
+483.0 "Outer Fireballs" sync / 1[56]:[^:]*:Ball Of Fire:1ECB:/
+486.3 "Levinbolt" sync / 1[56]:[^:]*:Alte Roite:1ED1:/
+492.4 "Roar" sync / 1[56]:[^:]*:Alte Roite:1ED4:/
+498.6 "Wyrm Tail" sync / 1[56]:[^:]*:Alte Roite:1ECE:/
+504.7 "Wyrm Tail" sync / 1[56]:[^:]*:Alte Roite:1ECE:/
+515.8 "Charybdis" sync / 1[56]:[^:]*:Alte Roite:1ED3:/
+523.9 "Twin Bolt" sync / 1[56]:[^:]*:Alte Roite:1ECF:/
+530.1 "Flame" sync / 1[56]:[^:]*:Alte Roite:1ED5:/
+538.3 "Flame" sync / 1[56]:[^:]*:Alte Roite:1ED5:/
+547.4 "Levinbolt" sync / 1[56]:[^:]*:Alte Roite:1ED1:/
+549.4 "Inner Fireballs" sync / 1[56]:[^:]*:Ball Of Fire:1ECB:/
+557.1 "Clamp" sync / 1[56]:[^:]*:Alte Roite:1EDE:/
+557.6 "Outer Fireballs" sync / 1[56]:[^:]*:Ball Of Fire:1ECB:/
+563.3 "Roar" sync / 1[56]:[^:]*:Alte Roite:1ED4:/
+569.5 "Roar" sync / 1[56]:[^:]*:Alte Roite:1ED4:/
 
-571.7 "Flame" sync / 1[56]:Alte Roite:1ED5:/
-589.0 "Enrage" sync / 1[56]:Ball Of Fire:23E4:/
+571.7 "Flame" sync / 1[56]:[^:]*:Alte Roite:1ED5:/
+589.0 "Enrage" sync / 1[56]:[^:]*:Ball Of Fire:23E4:/

--- a/ui/raidboss/data/04-sb/raid/o2n.txt
+++ b/ui/raidboss/data/04-sb/raid/o2n.txt
@@ -9,104 +9,104 @@ hideall "--sync--"
 0.0 "--Reset--" sync / 21:........:40000010:/ window 100000 jump 0
 
 0.0 "--sync--" sync /:Engage!/ window 0,1
-3.0 "--sync--" sync / 1[56]:Catastrophe:24E8:/ window 3,1
-5.6 "Tremblor" sync / 1[56]:Catastrophe:2511:/ window 5.6,2
-9.2 "Tremblor" sync / 1[56]:Catastrophe:2511:/
-17.8 "Earthquake" sync / 1[56]:Catastrophe:2512:/
-25.0 "100 Gs" sync / 1[56]:Catastrophe:24FB:/
-32.1 "Evilsphere" sync / 1[56]:Catastrophe:250F:/
-37.3 "Gravitational Distortion" sync / 1[56]:Catastrophe:250A:/
-53.4 "100 Gs" sync / 1[56]:Catastrophe:24FB:/
-65.5 "Gravitational Manipulation" sync / 1[56]:Catastrophe:2504:/
-72.7 "Gravitational Explosion" sync / 1[56]:Catastrophe:2506:/
-79.7 "Paranormal Wave" sync / 1[56]:Catastrophe:250E:/
-87.8 "100 Gs" sync / 1[56]:Catastrophe:24FB:/
-98.0 "Maniacal Probe" sync / 1[56]:Catastrophe:258F:/
-104.1 "Erosion" sync / 1[56]:Fleshy Member:2590:/ window 30,30
-108.2 "Epicenter" sync / 1[56]:Catastrophe:24A2:/
-116.3 "Gravitational Wave" sync / 1[56]:Catastrophe:2510:/
-126.3 "Main Quake" sync / 1[56]:Catastrophe:24A5:/
-133.4 "100 Gs" sync / 1[56]:Catastrophe:24FB:/
-141.5 "Antilight" sync / 1[56]:Catastrophe:2502:/
-153.6 "Demon Eye" sync / 1[56]:Catastrophe:250D:/
-154.6 "Explosion" sync / 1[56]:Petrosphere:2513:/
-156.8 "Paranormal Wave" sync / 1[56]:Catastrophe:250E:/
-165.9 "Evilsphere" sync / 1[56]:Catastrophe:250F:/
-171.1 "Paranormal Wave" sync / 1[56]:Catastrophe:250E:/
-179.3 "Antilight" sync / 1[56]:Catastrophe:2502:/
-189.4 "100 Gs" sync / 1[56]:Catastrophe:24FB:/
-# 192.5 "Explosion" sync / 1[56]:Petrosphere:2513:/
-192.5 "Explosion" sync / 1[56]:Potent Petrosphere:2503:/
-199.6 "Demon Eye" sync / 1[56]:Catastrophe:250D:/
-207.8 "Maniacal Probe" sync / 1[56]:Catastrophe:258F:/
-213.9 "Erosion" sync / 1[56]:Fleshy Member:2590:/ window 30,30
-218.0 "Epicenter" sync / 1[56]:Catastrophe:24A2:/
-236.2 "Main Quake" sync / 1[56]:Catastrophe:24A5:/
-243.1 "100 Gs" sync / 1[56]:Catastrophe:24FB:/
-257.3 " -100 Gs" sync / 1[56]:Catastrophe:24FF:/
-# 264.8 "Explosion" sync / 1[56]:Petrosphere:2513:/
-264.8 "Explosion" sync / 1[56]:Potent Petrosphere:2503:/
+3.0 "--sync--" sync / 1[56]:[^:]*:Catastrophe:24E8:/ window 3,1
+5.6 "Tremblor" sync / 1[56]:[^:]*:Catastrophe:2511:/ window 5.6,2
+9.2 "Tremblor" sync / 1[56]:[^:]*:Catastrophe:2511:/
+17.8 "Earthquake" sync / 1[56]:[^:]*:Catastrophe:2512:/
+25.0 "100 Gs" sync / 1[56]:[^:]*:Catastrophe:24FB:/
+32.1 "Evilsphere" sync / 1[56]:[^:]*:Catastrophe:250F:/
+37.3 "Gravitational Distortion" sync / 1[56]:[^:]*:Catastrophe:250A:/
+53.4 "100 Gs" sync / 1[56]:[^:]*:Catastrophe:24FB:/
+65.5 "Gravitational Manipulation" sync / 1[56]:[^:]*:Catastrophe:2504:/
+72.7 "Gravitational Explosion" sync / 1[56]:[^:]*:Catastrophe:2506:/
+79.7 "Paranormal Wave" sync / 1[56]:[^:]*:Catastrophe:250E:/
+87.8 "100 Gs" sync / 1[56]:[^:]*:Catastrophe:24FB:/
+98.0 "Maniacal Probe" sync / 1[56]:[^:]*:Catastrophe:258F:/
+104.1 "Erosion" sync / 1[56]:[^:]*:Fleshy Member:2590:/ window 30,30
+108.2 "Epicenter" sync / 1[56]:[^:]*:Catastrophe:24A2:/
+116.3 "Gravitational Wave" sync / 1[56]:[^:]*:Catastrophe:2510:/
+126.3 "Main Quake" sync / 1[56]:[^:]*:Catastrophe:24A5:/
+133.4 "100 Gs" sync / 1[56]:[^:]*:Catastrophe:24FB:/
+141.5 "Antilight" sync / 1[56]:[^:]*:Catastrophe:2502:/
+153.6 "Demon Eye" sync / 1[56]:[^:]*:Catastrophe:250D:/
+154.6 "Explosion" sync / 1[56]:[^:]*:Petrosphere:2513:/
+156.8 "Paranormal Wave" sync / 1[56]:[^:]*:Catastrophe:250E:/
+165.9 "Evilsphere" sync / 1[56]:[^:]*:Catastrophe:250F:/
+171.1 "Paranormal Wave" sync / 1[56]:[^:]*:Catastrophe:250E:/
+179.3 "Antilight" sync / 1[56]:[^:]*:Catastrophe:2502:/
+189.4 "100 Gs" sync / 1[56]:[^:]*:Catastrophe:24FB:/
+# 192.5 "Explosion" sync / 1[56]:[^:]*:Petrosphere:2513:/
+192.5 "Explosion" sync / 1[56]:[^:]*:Potent Petrosphere:2503:/
+199.6 "Demon Eye" sync / 1[56]:[^:]*:Catastrophe:250D:/
+207.8 "Maniacal Probe" sync / 1[56]:[^:]*:Catastrophe:258F:/
+213.9 "Erosion" sync / 1[56]:[^:]*:Fleshy Member:2590:/ window 30,30
+218.0 "Epicenter" sync / 1[56]:[^:]*:Catastrophe:24A2:/
+236.2 "Main Quake" sync / 1[56]:[^:]*:Catastrophe:24A5:/
+243.1 "100 Gs" sync / 1[56]:[^:]*:Catastrophe:24FB:/
+257.3 " -100 Gs" sync / 1[56]:[^:]*:Catastrophe:24FF:/
+# 264.8 "Explosion" sync / 1[56]:[^:]*:Petrosphere:2513:/
+264.8 "Explosion" sync / 1[56]:[^:]*:Potent Petrosphere:2503:/
 
 # A short intermission block after -100Gs
-268.4 "Gravitational Wave" sync / 1[56]:Catastrophe:2510:/ window 30,30
-280.5 "Evilsphere" sync / 1[56]:Catastrophe:250F:/
-290.7 "100 Gs" sync / 1[56]:Catastrophe:24FB:/
-298.8 "Antilight" sync / 1[56]:Catastrophe:2502:/
-308.0 "Gravitational Distortion" sync / 1[56]:Catastrophe:250A:/
-312.0 "Explosion" sync / 1[56]:Potent Petrosphere:2503:/
-329.1 "Maniacal Probe" sync / 1[56]:Catastrophe:258F:/
-335.2 "Erosion" sync / 1[56]:Fleshy Member:2590:/
-339.2 "Epicenter" sync / 1[56]:Catastrophe:24A2:/
-344.3 "100 Gs" sync / 1[56]:Catastrophe:24FB:/
-354.5 "Demon Eye" sync / 1[56]:Catastrophe:250D:/
-357.4 "Main Quake" sync / 1[56]:Catastrophe:24A5:/
+268.4 "Gravitational Wave" sync / 1[56]:[^:]*:Catastrophe:2510:/ window 30,30
+280.5 "Evilsphere" sync / 1[56]:[^:]*:Catastrophe:250F:/
+290.7 "100 Gs" sync / 1[56]:[^:]*:Catastrophe:24FB:/
+298.8 "Antilight" sync / 1[56]:[^:]*:Catastrophe:2502:/
+308.0 "Gravitational Distortion" sync / 1[56]:[^:]*:Catastrophe:250A:/
+312.0 "Explosion" sync / 1[56]:[^:]*:Potent Petrosphere:2503:/
+329.1 "Maniacal Probe" sync / 1[56]:[^:]*:Catastrophe:258F:/
+335.2 "Erosion" sync / 1[56]:[^:]*:Fleshy Member:2590:/
+339.2 "Epicenter" sync / 1[56]:[^:]*:Catastrophe:24A2:/
+344.3 "100 Gs" sync / 1[56]:[^:]*:Catastrophe:24FB:/
+354.5 "Demon Eye" sync / 1[56]:[^:]*:Catastrophe:250D:/
+357.4 "Main Quake" sync / 1[56]:[^:]*:Catastrophe:24A5:/
 
 # Rotation block
-362.7 "Gravitational Wave" sync / 1[56]:Catastrophe:2510:/ window 30,30
-372.8 "Antilight" sync / 1[56]:Catastrophe:2502:/
-379.9 "Tremblor" sync / 1[56]:Catastrophe:2511:/
-383.6 "Tremblor" sync / 1[56]:Catastrophe:2511:/
-386.0 "Explosion" sync / 1[56]:Potent Petrosphere:2503:/
-392.3 "Earthquake" sync / 1[56]:Catastrophe:2512:/ window 30,30
-400.5 "Gravitational Wave" sync / 1[56]:Catastrophe:2510:/
-410.6 "Antilight" sync / 1[56]:Catastrophe:2502:/
-415.7 "100 Gs" sync / 1[56]:Catastrophe:24FB:/
-# 423.7 "Explosion" sync / 1[56]:Petrosphere:2513:/
-423.7 "Explosion" sync / 1[56]:Potent Petrosphere:2503:/
-425.8 "Demon Eye" sync / 1[56]:Catastrophe:250D:/ window 30,30
-441.0 "100 Gs" sync / 1[56]:Catastrophe:24FB:/
-449.1 "Antilight" sync / 1[56]:Catastrophe:2502:/
-458.3 "Gravitational Distortion" sync / 1[56]:Catastrophe:250A:/
-462.3 "Explosion" sync / 1[56]:Potent Petrosphere:2503:/
-479.4 "Maniacal Probe" sync / 1[56]:Catastrophe:258F:/
-485.5 "Erosion" sync / 1[56]:Fleshy Member:2590:/
-489.5 "Epicenter" sync / 1[56]:Catastrophe:24A2:/
-494.7 "100 Gs" sync / 1[56]:Catastrophe:24FB:/
-504.9 "Demon Eye" sync / 1[56]:Catastrophe:250D:/
-507.8 "Main Quake" sync / 1[56]:Catastrophe:24A5:/ window 30,30
+362.7 "Gravitational Wave" sync / 1[56]:[^:]*:Catastrophe:2510:/ window 30,30
+372.8 "Antilight" sync / 1[56]:[^:]*:Catastrophe:2502:/
+379.9 "Tremblor" sync / 1[56]:[^:]*:Catastrophe:2511:/
+383.6 "Tremblor" sync / 1[56]:[^:]*:Catastrophe:2511:/
+386.0 "Explosion" sync / 1[56]:[^:]*:Potent Petrosphere:2503:/
+392.3 "Earthquake" sync / 1[56]:[^:]*:Catastrophe:2512:/ window 30,30
+400.5 "Gravitational Wave" sync / 1[56]:[^:]*:Catastrophe:2510:/
+410.6 "Antilight" sync / 1[56]:[^:]*:Catastrophe:2502:/
+415.7 "100 Gs" sync / 1[56]:[^:]*:Catastrophe:24FB:/
+# 423.7 "Explosion" sync / 1[56]:[^:]*:Petrosphere:2513:/
+423.7 "Explosion" sync / 1[56]:[^:]*:Potent Petrosphere:2503:/
+425.8 "Demon Eye" sync / 1[56]:[^:]*:Catastrophe:250D:/ window 30,30
+441.0 "100 Gs" sync / 1[56]:[^:]*:Catastrophe:24FB:/
+449.1 "Antilight" sync / 1[56]:[^:]*:Catastrophe:2502:/
+458.3 "Gravitational Distortion" sync / 1[56]:[^:]*:Catastrophe:250A:/
+462.3 "Explosion" sync / 1[56]:[^:]*:Potent Petrosphere:2503:/
+479.4 "Maniacal Probe" sync / 1[56]:[^:]*:Catastrophe:258F:/
+485.5 "Erosion" sync / 1[56]:[^:]*:Fleshy Member:2590:/
+489.5 "Epicenter" sync / 1[56]:[^:]*:Catastrophe:24A2:/
+494.7 "100 Gs" sync / 1[56]:[^:]*:Catastrophe:24FB:/
+504.9 "Demon Eye" sync / 1[56]:[^:]*:Catastrophe:250D:/
+507.8 "Main Quake" sync / 1[56]:[^:]*:Catastrophe:24A5:/ window 30,30
 
-513.1 "Gravitational Wave" sync / 1[56]:Catastrophe:2510:/ window 30,30
-523.2 "Antilight" sync / 1[56]:Catastrophe:2502:/
-530.3 "Tremblor" sync / 1[56]:Catastrophe:2511:/
-534.0 "Tremblor" sync / 1[56]:Catastrophe:2511:/
-536.4 "Explosion" sync / 1[56]:Potent Petrosphere:2503:/
-542.7 "Earthquake" sync / 1[56]:Catastrophe:2512:/ window 30,30
-550.9 "Gravitational Wave" sync / 1[56]:Catastrophe:2510:/
-561.0 "Antilight" sync / 1[56]:Catastrophe:2502:/
-566.1 "100 Gs" sync / 1[56]:Catastrophe:24FB:/
-# 574.1 "Explosion" sync / 1[56]:Petrosphere:2513:/
-574.1 "Explosion" sync / 1[56]:Potent Petrosphere:2503:/
-576.2 "Demon Eye" sync / 1[56]:Catastrophe:250D:/ window 30,30
-591.4 "100 Gs" sync / 1[56]:Catastrophe:24FB:/
-599.5 "Antilight" sync / 1[56]:Catastrophe:2502:/
-608.7 "Gravitational Distortion" sync / 1[56]:Catastrophe:250A:/ window 30,30
-612.7 "Explosion" sync / 1[56]:Potent Petrosphere:2503:/
-629.8 "Maniacal Probe" sync / 1[56]:Catastrophe:258F:/
-635.9 "Erosion" sync / 1[56]:Fleshy Member:2590:/
-639.9 "Epicenter" sync / 1[56]:Catastrophe:24A2:/
-645.1 "100 Gs" sync / 1[56]:Catastrophe:24FB:/
-655.3 "Demon Eye" sync / 1[56]:Catastrophe:250D:/ window 30,30
-658.2 "Main Quake" sync / 1[56]:Catastrophe:24A5:/ jump 507.8
+513.1 "Gravitational Wave" sync / 1[56]:[^:]*:Catastrophe:2510:/ window 30,30
+523.2 "Antilight" sync / 1[56]:[^:]*:Catastrophe:2502:/
+530.3 "Tremblor" sync / 1[56]:[^:]*:Catastrophe:2511:/
+534.0 "Tremblor" sync / 1[56]:[^:]*:Catastrophe:2511:/
+536.4 "Explosion" sync / 1[56]:[^:]*:Potent Petrosphere:2503:/
+542.7 "Earthquake" sync / 1[56]:[^:]*:Catastrophe:2512:/ window 30,30
+550.9 "Gravitational Wave" sync / 1[56]:[^:]*:Catastrophe:2510:/
+561.0 "Antilight" sync / 1[56]:[^:]*:Catastrophe:2502:/
+566.1 "100 Gs" sync / 1[56]:[^:]*:Catastrophe:24FB:/
+# 574.1 "Explosion" sync / 1[56]:[^:]*:Petrosphere:2513:/
+574.1 "Explosion" sync / 1[56]:[^:]*:Potent Petrosphere:2503:/
+576.2 "Demon Eye" sync / 1[56]:[^:]*:Catastrophe:250D:/ window 30,30
+591.4 "100 Gs" sync / 1[56]:[^:]*:Catastrophe:24FB:/
+599.5 "Antilight" sync / 1[56]:[^:]*:Catastrophe:2502:/
+608.7 "Gravitational Distortion" sync / 1[56]:[^:]*:Catastrophe:250A:/ window 30,30
+612.7 "Explosion" sync / 1[56]:[^:]*:Potent Petrosphere:2503:/
+629.8 "Maniacal Probe" sync / 1[56]:[^:]*:Catastrophe:258F:/
+635.9 "Erosion" sync / 1[56]:[^:]*:Fleshy Member:2590:/
+639.9 "Epicenter" sync / 1[56]:[^:]*:Catastrophe:24A2:/
+645.1 "100 Gs" sync / 1[56]:[^:]*:Catastrophe:24FB:/
+655.3 "Demon Eye" sync / 1[56]:[^:]*:Catastrophe:250D:/ window 30,30
+658.2 "Main Quake" sync / 1[56]:[^:]*:Catastrophe:24A5:/ jump 507.8
 
 663.5 "Gravitational Wave"
 673.6 "Antilight"

--- a/ui/raidboss/data/04-sb/raid/o2s.txt
+++ b/ui/raidboss/data/04-sb/raid/o2s.txt
@@ -11,130 +11,130 @@ hideall "--Reset--"
 0.0 "--Reset--" sync / 21:........:40000010:/ window 100000 jump 0
 
 0.0 "--sync--" sync /:Engage!/ window 0,1
-1.3 "--sync--" sync / 1[56]:Catastrophe:25B6:/ window 0,1.3
-5.0 "Tremblor" sync / 1[56]:Catastrophe:2373:/ window 5,2.5
-8.7 "Tremblor" sync / 1[56]:Catastrophe:2373:/
-17.4 "Earthquake" sync / 1[56]:Catastrophe:2374:/ window 18,10
-24.6 "100 Gs" sync / 1[56]:Catastrophe:2355:/
-32.8 "Antilight (center)" sync / 1[56]:Catastrophe:2361:/
-50.0 "Gravitational Wave" sync / 1[56]:Catastrophe:2372:/
-60.3 "Gravitational Manipulation" sync / 1[56]:Catastrophe:2363:/
-63.4 "Gravitational Distortion" sync / 1[56]:Catastrophe:2369:/
-67.5 "Gravitational Explosion" sync / 1[56]:Catastrophe:2367:/
+1.3 "--sync--" sync / 1[56]:[^:]*:Catastrophe:25B6:/ window 0,1.3
+5.0 "Tremblor" sync / 1[56]:[^:]*:Catastrophe:2373:/ window 5,2.5
+8.7 "Tremblor" sync / 1[56]:[^:]*:Catastrophe:2373:/
+17.4 "Earthquake" sync / 1[56]:[^:]*:Catastrophe:2374:/ window 18,10
+24.6 "100 Gs" sync / 1[56]:[^:]*:Catastrophe:2355:/
+32.8 "Antilight (center)" sync / 1[56]:[^:]*:Catastrophe:2361:/
+50.0 "Gravitational Wave" sync / 1[56]:[^:]*:Catastrophe:2372:/
+60.3 "Gravitational Manipulation" sync / 1[56]:[^:]*:Catastrophe:2363:/
+63.4 "Gravitational Distortion" sync / 1[56]:[^:]*:Catastrophe:2369:/
+67.5 "Gravitational Explosion" sync / 1[56]:[^:]*:Catastrophe:2367:/
 
-73.6 "Paranormal Wave 1" sync / 1[56]:Catastrophe:2370:/
-78.8 "Paranormal Wave 2" sync / 1[56]:Catastrophe:2370:/
-89.0 "Evilsphere" sync / 1[56]:Catastrophe:2371:/
-96.2 "Paranormal Wave 3" sync / 1[56]:Catastrophe:2370:/
+73.6 "Paranormal Wave 1" sync / 1[56]:[^:]*:Catastrophe:2370:/
+78.8 "Paranormal Wave 2" sync / 1[56]:[^:]*:Catastrophe:2370:/
+89.0 "Evilsphere" sync / 1[56]:[^:]*:Catastrophe:2371:/
+96.2 "Paranormal Wave 3" sync / 1[56]:[^:]*:Catastrophe:2370:/
 
-106.3 "Maniacal Probe (T/H)" sync / 1[56]:Catastrophe:235A:/
-116.4 "Erosion" sync / 1[56]:Fleshy Member:235B:/
-117.5 "Death's Gaze" sync / 1[56]:Catastrophe:236F:/
-122.7 "Epicenter" sync / 1[56]:Catastrophe:2357:/
-129.9 "Gravitational Wave" sync / 1[56]:Catastrophe:2372:/
-137.1 "100 Gs" sync / 1[56]:Catastrophe:2355:/
-140.9 "Main Quake" sync / 1[56]:Catastrophe:2359:/
-145.2 "Gravitational Wave" sync / 1[56]:Catastrophe:2372:/
+106.3 "Maniacal Probe (T/H)" sync / 1[56]:[^:]*:Catastrophe:235A:/
+116.4 "Erosion" sync / 1[56]:[^:]*:Fleshy Member:235B:/
+117.5 "Death's Gaze" sync / 1[56]:[^:]*:Catastrophe:236F:/
+122.7 "Epicenter" sync / 1[56]:[^:]*:Catastrophe:2357:/
+129.9 "Gravitational Wave" sync / 1[56]:[^:]*:Catastrophe:2372:/
+137.1 "100 Gs" sync / 1[56]:[^:]*:Catastrophe:2355:/
+140.9 "Main Quake" sync / 1[56]:[^:]*:Catastrophe:2359:/
+145.2 "Gravitational Wave" sync / 1[56]:[^:]*:Catastrophe:2372:/
 
-150.5 "Paranormal Wave 1" sync / 1[56]:Catastrophe:2370:/
-160.7 "Gravitational Manipulation" sync / 1[56]:Catastrophe:2363:/
-167.9 "Gravitational Explosion" sync / 1[56]:Catastrophe:2367:/
-175.8 "Paranormal Wave 2" sync / 1[56]:Catastrophe:2370:/
-185.8 "Evilsphere" sync / 1[56]:Catastrophe:2371:/
-192.8 "Paranormal Wave 3" sync / 1[56]:Catastrophe:2370:/
+150.5 "Paranormal Wave 1" sync / 1[56]:[^:]*:Catastrophe:2370:/
+160.7 "Gravitational Manipulation" sync / 1[56]:[^:]*:Catastrophe:2363:/
+167.9 "Gravitational Explosion" sync / 1[56]:[^:]*:Catastrophe:2367:/
+175.8 "Paranormal Wave 2" sync / 1[56]:[^:]*:Catastrophe:2370:/
+185.8 "Evilsphere" sync / 1[56]:[^:]*:Catastrophe:2371:/
+192.8 "Paranormal Wave 3" sync / 1[56]:[^:]*:Catastrophe:2370:/
 
-207.8 "-100 Gs" sync / 1[56]:Catastrophe:235E:/
-217.8 "Death's Gaze" sync / 1[56]:Catastrophe:236F:/
-227.8 "100 Gs" sync / 1[56]:Catastrophe:2355:/
+207.8 "-100 Gs" sync / 1[56]:[^:]*:Catastrophe:235E:/
+217.8 "Death's Gaze" sync / 1[56]:[^:]*:Catastrophe:236F:/
+227.8 "100 Gs" sync / 1[56]:[^:]*:Catastrophe:2355:/
 
-235.8 "Antilight (center)" sync / 1[56]:Catastrophe:2361:/
-238.3 "Unstable Gravity (T/H)" sync / 1[56]:Catastrophe:236C:/
-243.3 "Gravitational Wave" sync / 1[56]:Catastrophe:2372:/
-254.3 "Long Drop" sync / 1[56]:Catastrophe:236B:/
-265.2 "100 Gs" sync / 1[56]:Catastrophe:2355:/
+235.8 "Antilight (center)" sync / 1[56]:[^:]*:Catastrophe:2361:/
+238.3 "Unstable Gravity (T/H)" sync / 1[56]:[^:]*:Catastrophe:236C:/
+243.3 "Gravitational Wave" sync / 1[56]:[^:]*:Catastrophe:2372:/
+254.3 "Long Drop" sync / 1[56]:[^:]*:Catastrophe:236B:/
+265.2 "100 Gs" sync / 1[56]:[^:]*:Catastrophe:2355:/
 
-273.2 "Antilight (ground)" sync / 1[56]:Catastrophe:2361:/
-277.2 "Tremblor" sync / 1[56]:Catastrophe:2373:/
-280.7 "Tremblor" sync / 1[56]:Catastrophe:2373:/
-289.2 "Earthquake" sync / 1[56]:Catastrophe:2374:/
-299.2 "100 Gs" sync / 1[56]:Catastrophe:2355:/
+273.2 "Antilight (ground)" sync / 1[56]:[^:]*:Catastrophe:2361:/
+277.2 "Tremblor" sync / 1[56]:[^:]*:Catastrophe:2373:/
+280.7 "Tremblor" sync / 1[56]:[^:]*:Catastrophe:2373:/
+289.2 "Earthquake" sync / 1[56]:[^:]*:Catastrophe:2374:/
+299.2 "100 Gs" sync / 1[56]:[^:]*:Catastrophe:2355:/
 
-314.2 "Maniacal Probe (DPS)" sync / 1[56]:Catastrophe:235A:/
-324.2 "Erosion" sync / 1[56]:Fleshy Member:235B:/
-325.2 "Death's Gaze" sync / 1[56]:Catastrophe:236F:/
-330.2 "Epicenter" sync / 1[56]:Catastrophe:2357:/
-339.2 "Gravitational Manipulation" sync / 1[56]:Catastrophe:2363:/
-346.2 "Gravitational Explosion" sync / 1[56]:Catastrophe:2367:/
-348.2 "Main Quake" sync / 1[56]:Catastrophe:2359:/
+314.2 "Maniacal Probe (DPS)" sync / 1[56]:[^:]*:Catastrophe:235A:/
+324.2 "Erosion" sync / 1[56]:[^:]*:Fleshy Member:235B:/
+325.2 "Death's Gaze" sync / 1[56]:[^:]*:Catastrophe:236F:/
+330.2 "Epicenter" sync / 1[56]:[^:]*:Catastrophe:2357:/
+339.2 "Gravitational Manipulation" sync / 1[56]:[^:]*:Catastrophe:2363:/
+346.2 "Gravitational Explosion" sync / 1[56]:[^:]*:Catastrophe:2367:/
+348.2 "Main Quake" sync / 1[56]:[^:]*:Catastrophe:2359:/
 
-349.2 "Antilight (center)" sync / 1[56]:Catastrophe:2361:/
-351.7 "Unstable Gravity (DPS)" sync / 1[56]:Catastrophe:236C:/
-356.7 "100 Gs" sync / 1[56]:Catastrophe:2355:/
-367.7 "Long Drop" sync / 1[56]:Catastrophe:236B:/
-377.6 "Paranormal Wave 1" sync / 1[56]:Catastrophe:2370:/
-382.6 "Paranormal Wave 2" sync / 1[56]:Catastrophe:2370:/
-392.6 "Evilsphere" sync / 1[56]:Catastrophe:2371:/
-399.6 "Paranormal Wave 3" sync / 1[56]:Catastrophe:2370:/
+349.2 "Antilight (center)" sync / 1[56]:[^:]*:Catastrophe:2361:/
+351.7 "Unstable Gravity (DPS)" sync / 1[56]:[^:]*:Catastrophe:236C:/
+356.7 "100 Gs" sync / 1[56]:[^:]*:Catastrophe:2355:/
+367.7 "Long Drop" sync / 1[56]:[^:]*:Catastrophe:236B:/
+377.6 "Paranormal Wave 1" sync / 1[56]:[^:]*:Catastrophe:2370:/
+382.6 "Paranormal Wave 2" sync / 1[56]:[^:]*:Catastrophe:2370:/
+392.6 "Evilsphere" sync / 1[56]:[^:]*:Catastrophe:2371:/
+399.6 "Paranormal Wave 3" sync / 1[56]:[^:]*:Catastrophe:2370:/
 
-409.6 "Antilight (ground)" sync / 1[56]:Catastrophe:2361:/
-416.6 "100 Gs" sync / 1[56]:Catastrophe:2355:/
-427.6 "Maniacal Probe (T/H)" sync / 1[56]:Catastrophe:235A:/
-437.6 "Erosion" sync / 1[56]:Fleshy Member:235B:/
-438.6 "Death's Gaze" sync / 1[56]:Catastrophe:236F:/
-443.6 "Epicenter" sync / 1[56]:Catastrophe:2357:/
-452.6 "Gravitational Manipulation" sync / 1[56]:Catastrophe:2363:/
-459.6 "Gravitational Explosion" sync / 1[56]:Catastrophe:2367:/
-461.6 "Main Quake" sync / 1[56]:Catastrophe:2359:/
+409.6 "Antilight (ground)" sync / 1[56]:[^:]*:Catastrophe:2361:/
+416.6 "100 Gs" sync / 1[56]:[^:]*:Catastrophe:2355:/
+427.6 "Maniacal Probe (T/H)" sync / 1[56]:[^:]*:Catastrophe:235A:/
+437.6 "Erosion" sync / 1[56]:[^:]*:Fleshy Member:235B:/
+438.6 "Death's Gaze" sync / 1[56]:[^:]*:Catastrophe:236F:/
+443.6 "Epicenter" sync / 1[56]:[^:]*:Catastrophe:2357:/
+452.6 "Gravitational Manipulation" sync / 1[56]:[^:]*:Catastrophe:2363:/
+459.6 "Gravitational Explosion" sync / 1[56]:[^:]*:Catastrophe:2367:/
+461.6 "Main Quake" sync / 1[56]:[^:]*:Catastrophe:2359:/
 
-462.6 "Antilight (center)" sync / 1[56]:Catastrophe:2361:/
-465.1 "Unstable Gravity (T/H)" sync / 1[56]:Catastrophe:236C:/
-470.1 "100 Gs" sync / 1[56]:Catastrophe:2355:/
-481.1 "Long Drop" sync / 1[56]:Catastrophe:236B:/
-482.0 "Gravitational Distortion" sync / 1[56]:Catastrophe:2369:/
-489.0 "Death's Gaze" sync / 1[56]:Catastrophe:236F:/
-497.0 "Gravitational Wave" sync / 1[56]:Catastrophe:2372:/
+462.6 "Antilight (center)" sync / 1[56]:[^:]*:Catastrophe:2361:/
+465.1 "Unstable Gravity (T/H)" sync / 1[56]:[^:]*:Catastrophe:236C:/
+470.1 "100 Gs" sync / 1[56]:[^:]*:Catastrophe:2355:/
+481.1 "Long Drop" sync / 1[56]:[^:]*:Catastrophe:236B:/
+482.0 "Gravitational Distortion" sync / 1[56]:[^:]*:Catastrophe:2369:/
+489.0 "Death's Gaze" sync / 1[56]:[^:]*:Catastrophe:236F:/
+497.0 "Gravitational Wave" sync / 1[56]:[^:]*:Catastrophe:2372:/
 
-499.0 "Paranormal Wave 1" sync / 1[56]:Catastrophe:2370:/
-507.0 "Antilight (ground)" sync / 1[56]:Catastrophe:2361:/
-514.0 "100 Gs" sync / 1[56]:Catastrophe:2355:/
-519.0 "Paranormal Wave 2" sync / 1[56]:Catastrophe:2370:/
-531.0 "Evilsphere" sync / 1[56]:Catastrophe:2371:/
-538.0 "Paranormal Wave 3" sync / 1[56]:Catastrophe:2370:/
-548.0 "Gravitational Manipulation" sync / 1[56]:Catastrophe:2363:/
-550.0 "Gravitational Distortion" sync / 1[56]:Catastrophe:2369:/
-555.0 "Gravitational Explosion" sync / 1[56]:Catastrophe:2367:/
+499.0 "Paranormal Wave 1" sync / 1[56]:[^:]*:Catastrophe:2370:/
+507.0 "Antilight (ground)" sync / 1[56]:[^:]*:Catastrophe:2361:/
+514.0 "100 Gs" sync / 1[56]:[^:]*:Catastrophe:2355:/
+519.0 "Paranormal Wave 2" sync / 1[56]:[^:]*:Catastrophe:2370:/
+531.0 "Evilsphere" sync / 1[56]:[^:]*:Catastrophe:2371:/
+538.0 "Paranormal Wave 3" sync / 1[56]:[^:]*:Catastrophe:2370:/
+548.0 "Gravitational Manipulation" sync / 1[56]:[^:]*:Catastrophe:2363:/
+550.0 "Gravitational Distortion" sync / 1[56]:[^:]*:Catastrophe:2369:/
+555.0 "Gravitational Explosion" sync / 1[56]:[^:]*:Catastrophe:2367:/
 
-562.0 "Antilight (ground)" sync / 1[56]:Catastrophe:2361:/
-568.0 "Tremblor" #sync / 1[56]:Catastrophe:2373:/
-568.5 "100 Gs" sync / 1[56]:Catastrophe:2355:/
-570.5 "Tremblor" #sync / 1[56]:Catastrophe:2373:/
-579.0 "Earthquake" sync / 1[56]:Catastrophe:2374:/
-587.0 "Gravitational Wave" sync / 1[56]:Catastrophe:2372:/
-600.0 "Gravitational Collapse" sync / 1[56]:Catastrophe:235D:/
-600.0 "-100 Gs" sync / 1[56]:Catastrophe:235E:/
-610.0 "Death's Gaze" sync / 1[56]:Catastrophe:236F:/
+562.0 "Antilight (ground)" sync / 1[56]:[^:]*:Catastrophe:2361:/
+568.0 "Tremblor" #sync / 1[56]:[^:]*:Catastrophe:2373:/
+568.5 "100 Gs" sync / 1[56]:[^:]*:Catastrophe:2355:/
+570.5 "Tremblor" #sync / 1[56]:[^:]*:Catastrophe:2373:/
+579.0 "Earthquake" sync / 1[56]:[^:]*:Catastrophe:2374:/
+587.0 "Gravitational Wave" sync / 1[56]:[^:]*:Catastrophe:2372:/
+600.0 "Gravitational Collapse" sync / 1[56]:[^:]*:Catastrophe:235D:/
+600.0 "-100 Gs" sync / 1[56]:[^:]*:Catastrophe:235E:/
+610.0 "Death's Gaze" sync / 1[56]:[^:]*:Catastrophe:236F:/
 
-615.0 "Antilight (ground)" sync / 1[56]:Catastrophe:2361:/
-621.0 "Tremblor" #sync / 1[56]:Catastrophe:2373:/
-621.5 "100 Gs" sync / 1[56]:Catastrophe:2355:/
-623.5 "Tremblor" #sync / 1[56]:Catastrophe:2373:/
-632.0 "Earthquake" sync / 1[56]:Catastrophe:2374:/
+615.0 "Antilight (ground)" sync / 1[56]:[^:]*:Catastrophe:2361:/
+621.0 "Tremblor" #sync / 1[56]:[^:]*:Catastrophe:2373:/
+621.5 "100 Gs" sync / 1[56]:[^:]*:Catastrophe:2355:/
+623.5 "Tremblor" #sync / 1[56]:[^:]*:Catastrophe:2373:/
+632.0 "Earthquake" sync / 1[56]:[^:]*:Catastrophe:2374:/
 
-562.0 "Antilight (ground)" sync / 1[56]:Catastrophe:2361:/
-568.0 "Tremblor" #sync / 1[56]:Catastrophe:2373:/
-568.5 "100 Gs" sync / 1[56]:Catastrophe:2355:/
-570.5 "Tremblor" #sync / 1[56]:Catastrophe:2373:/
-579.0 "Earthquake" sync / 1[56]:Catastrophe:2374:/
-587.0 "Gravitational Wave" sync / 1[56]:Catastrophe:2372:/
-600.0 "Gravitational Collapse" sync / 1[56]:Catastrophe:235D:/
-600.0 "-100 Gs" sync / 1[56]:Catastrophe:235E:/
-610.0 "Death's Gaze" sync / 1[56]:Catastrophe:236F:/
+562.0 "Antilight (ground)" sync / 1[56]:[^:]*:Catastrophe:2361:/
+568.0 "Tremblor" #sync / 1[56]:[^:]*:Catastrophe:2373:/
+568.5 "100 Gs" sync / 1[56]:[^:]*:Catastrophe:2355:/
+570.5 "Tremblor" #sync / 1[56]:[^:]*:Catastrophe:2373:/
+579.0 "Earthquake" sync / 1[56]:[^:]*:Catastrophe:2374:/
+587.0 "Gravitational Wave" sync / 1[56]:[^:]*:Catastrophe:2372:/
+600.0 "Gravitational Collapse" sync / 1[56]:[^:]*:Catastrophe:235D:/
+600.0 "-100 Gs" sync / 1[56]:[^:]*:Catastrophe:235E:/
+610.0 "Death's Gaze" sync / 1[56]:[^:]*:Catastrophe:236F:/
 
-615.0 "Antilight (ground)" sync / 1[56]:Catastrophe:2361:/
-621.0 "Tremblor" #sync / 1[56]:Catastrophe:2373:/
-621.5 "100 Gs" sync / 1[56]:Catastrophe:2355:/
-623.5 "Tremblor" #sync / 1[56]:Catastrophe:2373:/
-632.0 "Earthquake" sync / 1[56]:Catastrophe:2374:/
+615.0 "Antilight (ground)" sync / 1[56]:[^:]*:Catastrophe:2361:/
+621.0 "Tremblor" #sync / 1[56]:[^:]*:Catastrophe:2373:/
+621.5 "100 Gs" sync / 1[56]:[^:]*:Catastrophe:2355:/
+623.5 "Tremblor" #sync / 1[56]:[^:]*:Catastrophe:2373:/
+632.0 "Earthquake" sync / 1[56]:[^:]*:Catastrophe:2374:/
 
-633.3 "--sync--" sync / 14:Catastrophe:25A2:/
-643.3 "Gravitational Wave Enrage" sync / 1[56]:Catastrophe:25A2:/
+633.3 "--sync--" sync / 14:[^:]*:Catastrophe:25A2:/
+643.3 "Gravitational Wave Enrage" sync / 1[56]:[^:]*:Catastrophe:25A2:/

--- a/ui/raidboss/data/04-sb/raid/o3n.txt
+++ b/ui/raidboss/data/04-sb/raid/o3n.txt
@@ -7,131 +7,131 @@
 0.0 "--Reset--" sync / 21:........:40000010:/ window 100000 jump 0
 
 0.0 "--sync--" sync /:Engage!/ window 0,1
-3.2 "--sync--" sync / 1[56]:Halicarnassus:367:/ window 3.2,1
-9.7 "Ribbit (avoid)" sync / 1[56]:Halicarnassus:2466:/ window 9.7,10
-17.3 "Spellblade Thunder III" sync / 1[56]:Halicarnassus:2462:/
-22.4 "Spellblade Holy" sync / 1[56]:Halicarnassus:22EF:/
-31.4 "Holy Blur" sync / 1[56]:Halicarnassus:2464:/ window 30,30
-36.5 "Spellblade Blizzard III" sync / 1[56]:Halicarnassus:2461:/
-41.6 "Spellblade Fire III" sync / 1[56]:Halicarnassus:2460:/
-49.8 "Place Dark Token" sync / 1[56]:Halicarnassus:22FC:/
-61.9 "The Queen's Waltz (Sword Dance)" sync / 1[56]:Halicarnassus:246F:/ window 30,30
-62.2 "Cross Reaper" sync / 1[56]:Soul Reaper:246B:/
-70.0 "The Playing Field" sync / 1[56]:Halicarnassus:2300:/
-80.2 "The Game (symbols)" sync / 1[56]:Halicarnassus:246D:/
+3.2 "--sync--" sync / 1[56]:[^:]*:Halicarnassus:367:/ window 3.2,1
+9.7 "Ribbit (avoid)" sync / 1[56]:[^:]*:Halicarnassus:2466:/ window 9.7,10
+17.3 "Spellblade Thunder III" sync / 1[56]:[^:]*:Halicarnassus:2462:/
+22.4 "Spellblade Holy" sync / 1[56]:[^:]*:Halicarnassus:22EF:/
+31.4 "Holy Blur" sync / 1[56]:[^:]*:Halicarnassus:2464:/ window 30,30
+36.5 "Spellblade Blizzard III" sync / 1[56]:[^:]*:Halicarnassus:2461:/
+41.6 "Spellblade Fire III" sync / 1[56]:[^:]*:Halicarnassus:2460:/
+49.8 "Place Dark Token" sync / 1[56]:[^:]*:Halicarnassus:22FC:/
+61.9 "The Queen's Waltz (Sword Dance)" sync / 1[56]:[^:]*:Halicarnassus:246F:/ window 30,30
+62.2 "Cross Reaper" sync / 1[56]:[^:]*:Soul Reaper:246B:/
+70.0 "The Playing Field" sync / 1[56]:[^:]*:Halicarnassus:2300:/
+80.2 "The Game (symbols)" sync / 1[56]:[^:]*:Halicarnassus:246D:/
 
 # Cave phase
-89.4 "Panel Swap" sync / 1[56]:Halicarnassus:2304:/
-100.5 "The Queen's Waltz" sync / 1[56]:Halicarnassus:2471:/
-110.7 "Place Token" sync / 1[56]:Halicarnassus:22FB:/ window 30,30
-126.7 "Frost Breath?" # sync / 1[56]:Great Dragon:2476:/
-128.8 "The Queen's Waltz (Uplift)" sync / 1[56]:Halicarnassus:2471:/
-133.9 "Spellblade Blizzard III" sync / 1[56]:Halicarnassus:2461:/
-134.7 "Frost Breath?" # sync / 1[56]:Great Dragon:2476:/
-139.0 "Spellblade Fire III" sync / 1[56]:Halicarnassus:2460:/
-142.8 "Frost Breath?" # sync / 1[56]:Great Dragon:2476:/
-143.7 "Spellblade Thunder III" sync / 1[56]:Halicarnassus:2462:/
-150.9 "Frost Breath?" # sync / 1[56]:Great Dragon:2476:/
-151.8 "Mindjack" sync / 1[56]:Halicarnassus:246[789A]:/ window 30,30
-158.9 "The Queen's Waltz (Uplift)" sync / 1[56]:Halicarnassus:2471:/
-165.1 "Ribbit (avoid)" sync / 1[56]:Halicarnassus:2466:/
-172.2 "Place Dark Token" sync / 1[56]:Halicarnassus:22FC:/
-177.3 "Spellblade Holy" sync / 1[56]:Halicarnassus:22EF:/
-184.6 "Cross Reaper" sync / 1[56]:Soul Reaper:246B:/
-186.3 "Holy Edge" sync / 1[56]:Halicarnassus:2463:/
-190.4 "The Queen's Waltz (Uplift)" sync / 1[56]:Halicarnassus:2471:/
-202.4 "Aetherial Tear" sync / 1[56]:Halicarnassus:2474:/ window 202.4,5
+89.4 "Panel Swap" sync / 1[56]:[^:]*:Halicarnassus:2304:/
+100.5 "The Queen's Waltz" sync / 1[56]:[^:]*:Halicarnassus:2471:/
+110.7 "Place Token" sync / 1[56]:[^:]*:Halicarnassus:22FB:/ window 30,30
+126.7 "Frost Breath?" # sync / 1[56]:[^:]*:Great Dragon:2476:/
+128.8 "The Queen's Waltz (Uplift)" sync / 1[56]:[^:]*:Halicarnassus:2471:/
+133.9 "Spellblade Blizzard III" sync / 1[56]:[^:]*:Halicarnassus:2461:/
+134.7 "Frost Breath?" # sync / 1[56]:[^:]*:Great Dragon:2476:/
+139.0 "Spellblade Fire III" sync / 1[56]:[^:]*:Halicarnassus:2460:/
+142.8 "Frost Breath?" # sync / 1[56]:[^:]*:Great Dragon:2476:/
+143.7 "Spellblade Thunder III" sync / 1[56]:[^:]*:Halicarnassus:2462:/
+150.9 "Frost Breath?" # sync / 1[56]:[^:]*:Great Dragon:2476:/
+151.8 "Mindjack" sync / 1[56]:[^:]*:Halicarnassus:246[789A]:/ window 30,30
+158.9 "The Queen's Waltz (Uplift)" sync / 1[56]:[^:]*:Halicarnassus:2471:/
+165.1 "Ribbit (avoid)" sync / 1[56]:[^:]*:Halicarnassus:2466:/
+172.2 "Place Dark Token" sync / 1[56]:[^:]*:Halicarnassus:22FC:/
+177.3 "Spellblade Holy" sync / 1[56]:[^:]*:Halicarnassus:22EF:/
+184.6 "Cross Reaper" sync / 1[56]:[^:]*:Soul Reaper:246B:/
+186.3 "Holy Edge" sync / 1[56]:[^:]*:Halicarnassus:2463:/
+190.4 "The Queen's Waltz (Uplift)" sync / 1[56]:[^:]*:Halicarnassus:2471:/
+202.4 "Aetherial Tear" sync / 1[56]:[^:]*:Halicarnassus:2474:/ window 202.4,5
 206.5 "--untargetable--"
 
 # Intermission. Nothing of import happens here.
-216.6 "Aetherial Pull" sync / 1[56]:Aetherial Tear:2475:/
-272.9 "Ultimum (Starry End)" # sync / 1[56]:Halicarnassus:2477:/
+216.6 "Aetherial Pull" sync / 1[56]:[^:]*:Aetherial Tear:2475:/
+272.9 "Ultimum (Starry End)" # sync / 1[56]:[^:]*:Halicarnassus:2477:/
 # There is unfortunately no way to continue to display
 # Ultimum if another player escapes before the user
 # We also haven't got a good way to display exactly when
 # Halicarnassus is targetable again.
 
 # Post-intermission.
-300.0 "Panel Swap" sync / 1[56]:Halicarnassus:2304:/ window 150.10
-305.1 "The Playing Field" sync / 1[56]:Halicarnassus:2300:/
-313.3 "Ribbit (avoid)" sync / 1[56]:Halicarnassus:2466:/
-320.5 "The Game (symbols)" sync / 1[56]:Halicarnassus:246D:/
-329.6 "Spellblade Holy" sync / 1[56]:Halicarnassus:22EF:/
-334.7 "Mindjack" sync / 1[56]:Halicarnassus:246[789A]:/ window 30,30
-338.6 "Holy Blur" sync / 1[56]:Halicarnassus:2464:/
-340.4 "Spellblade Thunder III" sync / 1[56]:Halicarnassus:2462:/
-347.6 "Place Dark Token" sync / 1[56]:Halicarnassus:22FC:/
-360.0 "Gusting Gouge" sync / 1[56]:Soul Reaper:246C:/
-361.7 "Spellblade Blizzard III" sync / 1[56]:Halicarnassus:2461:/
-368.9 "The Playing Field" sync / 1[56]:Halicarnassus:2300:/
-377.1 "Ribbit (take)" sync / 1[56]:Halicarnassus:2466:/ window 30,30
-384.2 "The Game (toad)" sync / 1[56]:Halicarnassus:246D:/
-394.3 "Dimensional Wave" sync / 1[56]:Halicarnassus:2465:/
-403.5 "Spellblade Holy" sync / 1[56]:Halicarnassus:22EF:/
-407.6 "Spellblade Fire III" sync / 1[56]:Halicarnassus:2460:/
-412.5 "Holy Blur" sync / 1[56]:Halicarnassus:2464:/
-412.7 "The Queen's Waltz (Sword Dance)" sync / 1[56]:Halicarnassus:246F:/ window 30,30
-421.8 "Dimensional Wave" sync / 1[56]:Halicarnassus:2465:/
+300.0 "Panel Swap" sync / 1[56]:[^:]*:Halicarnassus:2304:/ window 150.10
+305.1 "The Playing Field" sync / 1[56]:[^:]*:Halicarnassus:2300:/
+313.3 "Ribbit (avoid)" sync / 1[56]:[^:]*:Halicarnassus:2466:/
+320.5 "The Game (symbols)" sync / 1[56]:[^:]*:Halicarnassus:246D:/
+329.6 "Spellblade Holy" sync / 1[56]:[^:]*:Halicarnassus:22EF:/
+334.7 "Mindjack" sync / 1[56]:[^:]*:Halicarnassus:246[789A]:/ window 30,30
+338.6 "Holy Blur" sync / 1[56]:[^:]*:Halicarnassus:2464:/
+340.4 "Spellblade Thunder III" sync / 1[56]:[^:]*:Halicarnassus:2462:/
+347.6 "Place Dark Token" sync / 1[56]:[^:]*:Halicarnassus:22FC:/
+360.0 "Gusting Gouge" sync / 1[56]:[^:]*:Soul Reaper:246C:/
+361.7 "Spellblade Blizzard III" sync / 1[56]:[^:]*:Halicarnassus:2461:/
+368.9 "The Playing Field" sync / 1[56]:[^:]*:Halicarnassus:2300:/
+377.1 "Ribbit (take)" sync / 1[56]:[^:]*:Halicarnassus:2466:/ window 30,30
+384.2 "The Game (toad)" sync / 1[56]:[^:]*:Halicarnassus:246D:/
+394.3 "Dimensional Wave" sync / 1[56]:[^:]*:Halicarnassus:2465:/
+403.5 "Spellblade Holy" sync / 1[56]:[^:]*:Halicarnassus:22EF:/
+407.6 "Spellblade Fire III" sync / 1[56]:[^:]*:Halicarnassus:2460:/
+412.5 "Holy Blur" sync / 1[56]:[^:]*:Halicarnassus:2464:/
+412.7 "The Queen's Waltz (Sword Dance)" sync / 1[56]:[^:]*:Halicarnassus:246F:/ window 30,30
+421.8 "Dimensional Wave" sync / 1[56]:[^:]*:Halicarnassus:2465:/
 
 # The blocks don't change, but if we don't track them we can't note the enrage.
-430.0 "The Playing Field" sync / 1[56]:Halicarnassus:2300:/
-438.2 "Ribbit (avoid)" sync / 1[56]:Halicarnassus:2466:/
-445.3 "The Game (symbols)" sync / 1[56]:Halicarnassus:246D:/
-454.4 "Spellblade Holy" sync / 1[56]:Halicarnassus:22EF:/
-459.6 "Mindjack" sync / 1[56]:Halicarnassus:246[789A]:/ window 30,30
-463.5 "Holy Blur" sync / 1[56]:Halicarnassus:2464:/
-465.3 "Spellblade Thunder III" sync / 1[56]:Halicarnassus:2462:/
-472.4 "Place Dark Token" sync / 1[56]:Halicarnassus:22FC:/
-484.8 "Gusting Gouge" sync / 1[56]:Soul Reaper:246C:/
-486.5 "Spellblade Blizzard III" sync / 1[56]:Halicarnassus:2461:/
-493.7 "The Playing Field" sync / 1[56]:Halicarnassus:2300:/
-501.9 "Ribbit (take)" sync / 1[56]:Halicarnassus:2466:/ window 30,30
-509.1 "The Game (toad)" sync / 1[56]:Halicarnassus:246D:/
-519.3 "Dimensional Wave" sync / 1[56]:Halicarnassus:2465:/
-528.5 "Spellblade Holy" sync / 1[56]:Halicarnassus:22EF:/
-532.6 "Spellblade Fire III" sync / 1[56]:Halicarnassus:2460:/
-537.5 "Holy Blur" sync / 1[56]:Halicarnassus:2464:/
-537.7 "The Queen's Waltz (Sword Dance)" sync / 1[56]:Halicarnassus:246F:/ window 30,30
-546.8 "Dimensional Wave" sync / 1[56]:Halicarnassus:2465:/
+430.0 "The Playing Field" sync / 1[56]:[^:]*:Halicarnassus:2300:/
+438.2 "Ribbit (avoid)" sync / 1[56]:[^:]*:Halicarnassus:2466:/
+445.3 "The Game (symbols)" sync / 1[56]:[^:]*:Halicarnassus:246D:/
+454.4 "Spellblade Holy" sync / 1[56]:[^:]*:Halicarnassus:22EF:/
+459.6 "Mindjack" sync / 1[56]:[^:]*:Halicarnassus:246[789A]:/ window 30,30
+463.5 "Holy Blur" sync / 1[56]:[^:]*:Halicarnassus:2464:/
+465.3 "Spellblade Thunder III" sync / 1[56]:[^:]*:Halicarnassus:2462:/
+472.4 "Place Dark Token" sync / 1[56]:[^:]*:Halicarnassus:22FC:/
+484.8 "Gusting Gouge" sync / 1[56]:[^:]*:Soul Reaper:246C:/
+486.5 "Spellblade Blizzard III" sync / 1[56]:[^:]*:Halicarnassus:2461:/
+493.7 "The Playing Field" sync / 1[56]:[^:]*:Halicarnassus:2300:/
+501.9 "Ribbit (take)" sync / 1[56]:[^:]*:Halicarnassus:2466:/ window 30,30
+509.1 "The Game (toad)" sync / 1[56]:[^:]*:Halicarnassus:246D:/
+519.3 "Dimensional Wave" sync / 1[56]:[^:]*:Halicarnassus:2465:/
+528.5 "Spellblade Holy" sync / 1[56]:[^:]*:Halicarnassus:22EF:/
+532.6 "Spellblade Fire III" sync / 1[56]:[^:]*:Halicarnassus:2460:/
+537.5 "Holy Blur" sync / 1[56]:[^:]*:Halicarnassus:2464:/
+537.7 "The Queen's Waltz (Sword Dance)" sync / 1[56]:[^:]*:Halicarnassus:246F:/ window 30,30
+546.8 "Dimensional Wave" sync / 1[56]:[^:]*:Halicarnassus:2465:/
 
-555.0 "The Playing Field" sync / 1[56]:Halicarnassus:2300:/
-563.2 "Ribbit (avoid)" sync / 1[56]:Halicarnassus:2466:/
-570.3 "The Game (symbols)" sync / 1[56]:Halicarnassus:246D:/
-579.5 "Spellblade Holy" sync / 1[56]:Halicarnassus:22EF:/
-584.6 "Mindjack" sync / 1[56]:Halicarnassus:246[789A]:/ window 30,30
-588.5 "Holy Blur" sync / 1[56]:Halicarnassus:2464:/
-590.3 "Spellblade Thunder III" sync / 1[56]:Halicarnassus:2462:/
-597.4 "Place Dark Token" sync / 1[56]:Halicarnassus:22FC:/
-609.9 "Gusting Gouge" sync / 1[56]:Soul Reaper:246C:/
-611.6 "Spellblade Blizzard III" sync / 1[56]:Halicarnassus:2461:/
-618.8 "The Playing Field" sync / 1[56]:Halicarnassus:2300:/
-626.9 "Ribbit (take)" sync / 1[56]:Halicarnassus:2466:/ window 30,30
-634.0 "The Game (toad)" sync / 1[56]:Halicarnassus:246D:/
-644.1 "Dimensional Wave" sync / 1[56]:Halicarnassus:2465:/
-653.3 "Spellblade Holy" sync / 1[56]:Halicarnassus:22EF:/
-657.4 "Spellblade Fire III" sync / 1[56]:Halicarnassus:2460:/
-662.3 "Holy Blur" sync / 1[56]:Halicarnassus:2464:/
-662.5 "The Queen's Waltz (Sword Dance)" sync / 1[56]:Halicarnassus:246F:/ window 30,30
-671.7 "Dimensional Wave" sync / 1[56]:Halicarnassus:2465:/
+555.0 "The Playing Field" sync / 1[56]:[^:]*:Halicarnassus:2300:/
+563.2 "Ribbit (avoid)" sync / 1[56]:[^:]*:Halicarnassus:2466:/
+570.3 "The Game (symbols)" sync / 1[56]:[^:]*:Halicarnassus:246D:/
+579.5 "Spellblade Holy" sync / 1[56]:[^:]*:Halicarnassus:22EF:/
+584.6 "Mindjack" sync / 1[56]:[^:]*:Halicarnassus:246[789A]:/ window 30,30
+588.5 "Holy Blur" sync / 1[56]:[^:]*:Halicarnassus:2464:/
+590.3 "Spellblade Thunder III" sync / 1[56]:[^:]*:Halicarnassus:2462:/
+597.4 "Place Dark Token" sync / 1[56]:[^:]*:Halicarnassus:22FC:/
+609.9 "Gusting Gouge" sync / 1[56]:[^:]*:Soul Reaper:246C:/
+611.6 "Spellblade Blizzard III" sync / 1[56]:[^:]*:Halicarnassus:2461:/
+618.8 "The Playing Field" sync / 1[56]:[^:]*:Halicarnassus:2300:/
+626.9 "Ribbit (take)" sync / 1[56]:[^:]*:Halicarnassus:2466:/ window 30,30
+634.0 "The Game (toad)" sync / 1[56]:[^:]*:Halicarnassus:246D:/
+644.1 "Dimensional Wave" sync / 1[56]:[^:]*:Halicarnassus:2465:/
+653.3 "Spellblade Holy" sync / 1[56]:[^:]*:Halicarnassus:22EF:/
+657.4 "Spellblade Fire III" sync / 1[56]:[^:]*:Halicarnassus:2460:/
+662.3 "Holy Blur" sync / 1[56]:[^:]*:Halicarnassus:2464:/
+662.5 "The Queen's Waltz (Sword Dance)" sync / 1[56]:[^:]*:Halicarnassus:246F:/ window 30,30
+671.7 "Dimensional Wave" sync / 1[56]:[^:]*:Halicarnassus:2465:/
 
-679.9 "The Playing Field" sync / 1[56]:Halicarnassus:2300:/
-688.0 "Ribbit (avoid)" sync / 1[56]:Halicarnassus:2466:/
-695.1 "The Game (symbols)" sync / 1[56]:Halicarnassus:246D:/
-704.3 "Spellblade Holy" sync / 1[56]:Halicarnassus:22EF:/
-709.4 "Mindjack" sync / 1[56]:Halicarnassus:246[789A]:/ window 30,30
-713.3 "Holy Blur" sync / 1[56]:Halicarnassus:2464:/
-715.0 "Spellblade Thunder III" sync / 1[56]:Halicarnassus:2462:/
-722.1 "Place Dark Token" sync / 1[56]:Halicarnassus:22FC:/
-734.6 "Gusting Gouge" sync / 1[56]:Soul Reaper:246C:/
-736.3 "Spellblade Blizzard III" sync / 1[56]:Halicarnassus:2461:/
-743.5 "The Playing Field" sync / 1[56]:Halicarnassus:2300:/
-751.6 "Ribbit (take)" sync / 1[56]:Halicarnassus:2466:/ window 30,30
-758.7 "The Game (toad)" sync / 1[56]:Halicarnassus:246D:/
-768.8 "Dimensional Wave" sync / 1[56]:Halicarnassus:2465:/
-777.9 "Spellblade Holy" sync / 1[56]:Halicarnassus:22EF:/
-782.1 "Spellblade Fire III" sync / 1[56]:Halicarnassus:2460:/
-787.0 "Holy Blur" sync / 1[56]:Halicarnassus:2464:/
-787.2 "The Queen's Waltz (Sword Dance)" sync / 1[56]:Halicarnassus:246F:/ window 30,30
-796.3 "Dimensional Wave" sync / 1[56]:Halicarnassus:2465:/
-804.5 "The Playing Field" sync / 1[56]:Halicarnassus:2300:/
-811.6 "The Game (enrage)" sync / 1[56]:Halicarnassus:246D:/
+679.9 "The Playing Field" sync / 1[56]:[^:]*:Halicarnassus:2300:/
+688.0 "Ribbit (avoid)" sync / 1[56]:[^:]*:Halicarnassus:2466:/
+695.1 "The Game (symbols)" sync / 1[56]:[^:]*:Halicarnassus:246D:/
+704.3 "Spellblade Holy" sync / 1[56]:[^:]*:Halicarnassus:22EF:/
+709.4 "Mindjack" sync / 1[56]:[^:]*:Halicarnassus:246[789A]:/ window 30,30
+713.3 "Holy Blur" sync / 1[56]:[^:]*:Halicarnassus:2464:/
+715.0 "Spellblade Thunder III" sync / 1[56]:[^:]*:Halicarnassus:2462:/
+722.1 "Place Dark Token" sync / 1[56]:[^:]*:Halicarnassus:22FC:/
+734.6 "Gusting Gouge" sync / 1[56]:[^:]*:Soul Reaper:246C:/
+736.3 "Spellblade Blizzard III" sync / 1[56]:[^:]*:Halicarnassus:2461:/
+743.5 "The Playing Field" sync / 1[56]:[^:]*:Halicarnassus:2300:/
+751.6 "Ribbit (take)" sync / 1[56]:[^:]*:Halicarnassus:2466:/ window 30,30
+758.7 "The Game (toad)" sync / 1[56]:[^:]*:Halicarnassus:246D:/
+768.8 "Dimensional Wave" sync / 1[56]:[^:]*:Halicarnassus:2465:/
+777.9 "Spellblade Holy" sync / 1[56]:[^:]*:Halicarnassus:22EF:/
+782.1 "Spellblade Fire III" sync / 1[56]:[^:]*:Halicarnassus:2460:/
+787.0 "Holy Blur" sync / 1[56]:[^:]*:Halicarnassus:2464:/
+787.2 "The Queen's Waltz (Sword Dance)" sync / 1[56]:[^:]*:Halicarnassus:246F:/ window 30,30
+796.3 "Dimensional Wave" sync / 1[56]:[^:]*:Halicarnassus:2465:/
+804.5 "The Playing Field" sync / 1[56]:[^:]*:Halicarnassus:2300:/
+811.6 "The Game (enrage)" sync / 1[56]:[^:]*:Halicarnassus:246D:/

--- a/ui/raidboss/data/04-sb/raid/o3s.txt
+++ b/ui/raidboss/data/04-sb/raid/o3s.txt
@@ -9,128 +9,128 @@ hideall "--sync--"
 # -ii 22EA 22FE 2309 230C 230F 2315
 
 0.0 "--sync--" sync /:Engage!/ window 0,1
-1.7 "--sync--" sync / 1[56]:Halicarnassus:22EA:/ window 1.7,2
-10.7 "Critical Hit" sync / 1[56]:Halicarnassus:22EB:/ window 10.7,5
-19.7 "Spellblade Holy" sync / 1[56]:Halicarnassus:22EF:/
-25.4 "Pole Shift" # sync / 1[56]:Halicarnassus:22F[23]:/
-28.4 "Holy Blur/Holy Edge" sync / 1[56]:Halicarnassus:22F[01]:/
-37.4 "The Queen's Waltz (Clock)" sync / 1[56]:Halicarnassus:2306:/ window 37.4,5
-37.9 "Sword Dance" sync / 1[56]:Halicarnassus:2307:/
-41.4 "Haste" sync / 1[56]:Halicarnassus:22F4:/
-44.8 "Spellblade Thunder III" sync / 1[56]:Halicarnassus:22EE:/
-50.3 "Dimensional Wave" sync / 1[56]:Halicarnassus:22F6:/
-59.3 "The Playing Field" sync / 1[56]:Halicarnassus:2300:/
-65.3 "Oink" sync / 1[56]:Halicarnassus:22F9:/
-72.3 "The Game" sync / 1[56]:Halicarnassus:2301:/ window 72.3,10
+1.7 "--sync--" sync / 1[56]:[^:]*:Halicarnassus:22EA:/ window 1.7,2
+10.7 "Critical Hit" sync / 1[56]:[^:]*:Halicarnassus:22EB:/ window 10.7,5
+19.7 "Spellblade Holy" sync / 1[56]:[^:]*:Halicarnassus:22EF:/
+25.4 "Pole Shift" # sync / 1[56]:[^:]*:Halicarnassus:22F[23]:/
+28.4 "Holy Blur/Holy Edge" sync / 1[56]:[^:]*:Halicarnassus:22F[01]:/
+37.4 "The Queen's Waltz (Clock)" sync / 1[56]:[^:]*:Halicarnassus:2306:/ window 37.4,5
+37.9 "Sword Dance" sync / 1[56]:[^:]*:Halicarnassus:2307:/
+41.4 "Haste" sync / 1[56]:[^:]*:Halicarnassus:22F4:/
+44.8 "Spellblade Thunder III" sync / 1[56]:[^:]*:Halicarnassus:22EE:/
+50.3 "Dimensional Wave" sync / 1[56]:[^:]*:Halicarnassus:22F6:/
+59.3 "The Playing Field" sync / 1[56]:[^:]*:Halicarnassus:2300:/
+65.3 "Oink" sync / 1[56]:[^:]*:Halicarnassus:22F9:/
+72.3 "The Game" sync / 1[56]:[^:]*:Halicarnassus:2301:/ window 72.3,10
 
-81.2 "Panel Swap (Thorns)" sync / 1[56]:Halicarnassus:2304:/
-83.2 "--center--" sync / 1[56]:Halicarnassus:2305:/
-89.5 "The Queen's Waltz (Tethers)" sync / 1[56]:Halicarnassus:2308:/
-94.2 "Spellblade Fire III" sync / 1[56]:Halicarnassus:22EC:/
-98.2 "Haste" sync / 1[56]:Halicarnassus:22F4:/
-101.5 "Spellblade Thunder III" sync / 1[56]:Halicarnassus:22EE:/
-107.0 "Critical Hit" sync / 1[56]:Halicarnassus:22EB:/
-113.0 "Dimensional Wave" sync / 1[56]:Halicarnassus:22F6:/ window 30,30
-119.0 "Place Token (White Flame)" sync / 1[56]:Halicarnassus:22FB:/
-124.9 "Ray of White" # sync / 1[56]:White Flame:2310:/
-129.9 "White Wind" # sync / 1[56]:White Flame:2311:/
-130.0 "Haste" sync / 1[56]:Halicarnassus:22F4:/
-131.9 "Ray of White" # sync / 1[56]:White Flame:2310:/
-133.5 "Spellblade Blizzard III" sync / 1[56]:Halicarnassus:22ED:/
-135.9 "Ray of White" # sync / 1[56]:White Flame:2310:/
-140.5 "Mindjack" sync / 1[56]:Halicarnassus:22FA:/ window 140,10
-146.0 "--center--" sync / 1[56]:Halicarnassus:2305:/
-152.6 "The Queen's Waltz (Tethers)" sync / 1[56]:Halicarnassus:2308:/
-157.6 "Spellblade Fire III" sync / 1[56]:Halicarnassus:22EC:/
-163.6 "Dimensional Wave" sync / 1[56]:Halicarnassus:22F6:/
+81.2 "Panel Swap (Thorns)" sync / 1[56]:[^:]*:Halicarnassus:2304:/
+83.2 "--center--" sync / 1[56]:[^:]*:Halicarnassus:2305:/
+89.5 "The Queen's Waltz (Tethers)" sync / 1[56]:[^:]*:Halicarnassus:2308:/
+94.2 "Spellblade Fire III" sync / 1[56]:[^:]*:Halicarnassus:22EC:/
+98.2 "Haste" sync / 1[56]:[^:]*:Halicarnassus:22F4:/
+101.5 "Spellblade Thunder III" sync / 1[56]:[^:]*:Halicarnassus:22EE:/
+107.0 "Critical Hit" sync / 1[56]:[^:]*:Halicarnassus:22EB:/
+113.0 "Dimensional Wave" sync / 1[56]:[^:]*:Halicarnassus:22F6:/ window 30,30
+119.0 "Place Token (White Flame)" sync / 1[56]:[^:]*:Halicarnassus:22FB:/
+124.9 "Ray of White" # sync / 1[56]:[^:]*:White Flame:2310:/
+129.9 "White Wind" # sync / 1[56]:[^:]*:White Flame:2311:/
+130.0 "Haste" sync / 1[56]:[^:]*:Halicarnassus:22F4:/
+131.9 "Ray of White" # sync / 1[56]:[^:]*:White Flame:2310:/
+133.5 "Spellblade Blizzard III" sync / 1[56]:[^:]*:Halicarnassus:22ED:/
+135.9 "Ray of White" # sync / 1[56]:[^:]*:White Flame:2310:/
+140.5 "Mindjack" sync / 1[56]:[^:]*:Halicarnassus:22FA:/ window 140,10
+146.0 "--center--" sync / 1[56]:[^:]*:Halicarnassus:2305:/
+152.6 "The Queen's Waltz (Tethers)" sync / 1[56]:[^:]*:Halicarnassus:2308:/
+157.6 "Spellblade Fire III" sync / 1[56]:[^:]*:Halicarnassus:22EC:/
+163.6 "Dimensional Wave" sync / 1[56]:[^:]*:Halicarnassus:22F6:/
 
-171.1 "Panel Swap (Cave)" sync / 1[56]:Halicarnassus:2304:/ window 85,10
-176.1 "Place Token (Great Dragon)" sync / 1[56]:Halicarnassus:22FB:/
-187.1 "The Queen's Waltz (Crystals)" sync / 1[56]:Halicarnassus:230A:/
-187.9 "Frost Breath" # sync / 1[56]:Great Dragon:2312:/
-188.0 "--sync--" sync / 1[56]:Halicarnassus:230B:/
-188.4 "Uplift" sync / 1[56]:Halicarnassus:230D:/
-193.3 "Ribbit" sync / 1[56]:Halicarnassus:22F7:/ window 193.3,10
-197.9 "Frost Breath" # sync / 1[56]:Great Dragon:2312:/
-199.3 "Dimensional Wave" sync / 1[56]:Halicarnassus:22F6:/
-212.3 "Critical Hit" sync / 1[56]:Halicarnassus:22EB:/
-223.3 "Place Dark Token (Soul Reapers)" sync / 1[56]:Halicarnassus:22FC:/
-235.3 "The Queen's Waltz (Crystals)" sync / 1[56]:Halicarnassus:230A:/
-236.2 "--sync--" sync / 1[56]:Halicarnassus:230B:/
-236.6 "Uplift" sync / 1[56]:Halicarnassus:230D:/
-236.6 "Cross Reaper/Gusting Gouge" sync / 1[56]:Soul Reaper:22F[DF]:/
-239.3 "Haste" sync / 1[56]:Halicarnassus:22F4:/
-242.9 "Spellblade Blizzard/Fire/Thunder" sync / 1[56]:Halicarnassus:22E[CDE]:/
-248.3 "Dimensional Wave" sync / 1[56]:Halicarnassus:22F6:/ window 30,30
+171.1 "Panel Swap (Cave)" sync / 1[56]:[^:]*:Halicarnassus:2304:/ window 85,10
+176.1 "Place Token (Great Dragon)" sync / 1[56]:[^:]*:Halicarnassus:22FB:/
+187.1 "The Queen's Waltz (Crystals)" sync / 1[56]:[^:]*:Halicarnassus:230A:/
+187.9 "Frost Breath" # sync / 1[56]:[^:]*:Great Dragon:2312:/
+188.0 "--sync--" sync / 1[56]:[^:]*:Halicarnassus:230B:/
+188.4 "Uplift" sync / 1[56]:[^:]*:Halicarnassus:230D:/
+193.3 "Ribbit" sync / 1[56]:[^:]*:Halicarnassus:22F7:/ window 193.3,10
+197.9 "Frost Breath" # sync / 1[56]:[^:]*:Great Dragon:2312:/
+199.3 "Dimensional Wave" sync / 1[56]:[^:]*:Halicarnassus:22F6:/
+212.3 "Critical Hit" sync / 1[56]:[^:]*:Halicarnassus:22EB:/
+223.3 "Place Dark Token (Soul Reapers)" sync / 1[56]:[^:]*:Halicarnassus:22FC:/
+235.3 "The Queen's Waltz (Crystals)" sync / 1[56]:[^:]*:Halicarnassus:230A:/
+236.2 "--sync--" sync / 1[56]:[^:]*:Halicarnassus:230B:/
+236.6 "Uplift" sync / 1[56]:[^:]*:Halicarnassus:230D:/
+236.6 "Cross Reaper/Gusting Gouge" sync / 1[56]:[^:]*:Soul Reaper:22F[DF]:/
+239.3 "Haste" sync / 1[56]:[^:]*:Halicarnassus:22F4:/
+242.9 "Spellblade Blizzard/Fire/Thunder" sync / 1[56]:[^:]*:Halicarnassus:22E[CDE]:/
+248.3 "Dimensional Wave" sync / 1[56]:[^:]*:Halicarnassus:22F6:/ window 30,30
 
-254.3 "Panel Swap (library)" sync / 1[56]:Halicarnassus:2304:/
-261.3 "The Queen's Waltz (Books)" sync / 1[56]:Halicarnassus:230E:/ window 261.3,10
-268.3 "Oink" sync / 1[56]:Halicarnassus:22F9:/
-273.3 "Place Token (Apanda)" sync / 1[56]:Halicarnassus:22FB:/
-281.2 "Pummel" # sync / 1[56]:Apanda:2313:/
-286.4 "The Queen's Waltz (Books)" sync / 1[56]:Halicarnassus:230E:/
-288.7 "Magic Hammer" sync / 1[56]:Apanda:2314:/
-292.4 "Squelch" sync / 1[56]:Halicarnassus:22F8:/ window 292.4,10
-294.8 "Pummel" # sync / 1[56]:Apanda:2313:/
-298.5 "Dimensional Wave" sync / 1[56]:Halicarnassus:22F6:/
-302.9 "Pummel" # sync / 1[56]:Apanda:2313:/
-304.6 "Critical Hit" sync / 1[56]:Halicarnassus:22EB:/
-316.6 "Dimensional Wave" sync / 1[56]:Halicarnassus:22F6:/
-321.6 "Spellblade Holy" sync / 1[56]:Halicarnassus:22EF:/
-329.6 "The Queen's Waltz (Spellblade Books)" sync / 1[56]:Halicarnassus:230E:/ window 30,30
-330.5 "Holy Blur/Holy Edge" sync / 1[56]:Halicarnassus:22F[01]:/
-339.5 "Dimensional Wave" sync / 1[56]:Halicarnassus:22F6:/
+254.3 "Panel Swap (library)" sync / 1[56]:[^:]*:Halicarnassus:2304:/
+261.3 "The Queen's Waltz (Books)" sync / 1[56]:[^:]*:Halicarnassus:230E:/ window 261.3,10
+268.3 "Oink" sync / 1[56]:[^:]*:Halicarnassus:22F9:/
+273.3 "Place Token (Apanda)" sync / 1[56]:[^:]*:Halicarnassus:22FB:/
+281.2 "Pummel" # sync / 1[56]:[^:]*:Apanda:2313:/
+286.4 "The Queen's Waltz (Books)" sync / 1[56]:[^:]*:Halicarnassus:230E:/
+288.7 "Magic Hammer" sync / 1[56]:[^:]*:Apanda:2314:/
+292.4 "Squelch" sync / 1[56]:[^:]*:Halicarnassus:22F8:/ window 292.4,10
+294.8 "Pummel" # sync / 1[56]:[^:]*:Apanda:2313:/
+298.5 "Dimensional Wave" sync / 1[56]:[^:]*:Halicarnassus:22F6:/
+302.9 "Pummel" # sync / 1[56]:[^:]*:Apanda:2313:/
+304.6 "Critical Hit" sync / 1[56]:[^:]*:Halicarnassus:22EB:/
+316.6 "Dimensional Wave" sync / 1[56]:[^:]*:Halicarnassus:22F6:/
+321.6 "Spellblade Holy" sync / 1[56]:[^:]*:Halicarnassus:22EF:/
+329.6 "The Queen's Waltz (Spellblade Books)" sync / 1[56]:[^:]*:Halicarnassus:230E:/ window 30,30
+330.5 "Holy Blur/Holy Edge" sync / 1[56]:[^:]*:Halicarnassus:22F[01]:/
+339.5 "Dimensional Wave" sync / 1[56]:[^:]*:Halicarnassus:22F6:/
 
-347.5 "Panel Swap (thorns)" sync / 1[56]:Halicarnassus:2304:/
-352.5 "The Playing Field" sync / 1[56]:Halicarnassus:2300:/ window 250,20
-362.5 "Oink/Ribbit/Squelch 1" sync / 1[56]:Halicarnassus:22F[789]:/
-368.7 "Oink/Ribbit/Squelch 2" sync / 1[56]:Halicarnassus:22F[789]:/
-374.7 "Oink/Ribbit/Squelch 3" sync / 1[56]:Halicarnassus:22F[789]:/
-381.7 "The Game" sync / 1[56]:Halicarnassus:2301:/
-388.0 "--teleport--" sync / 1[56]:Halicarnassus:2305:/
-394.5 "The Queen's Waltz (Random)" sync / 1[56]:Halicarnassus:230[68AE]:/
-403.8 "Spellblade Holy" sync / 1[56]:Halicarnassus:22EF:/
-409.9 "Pole Shift" # sync / 1[56]:Halicarnassus:22F[23]:/
-412.9 "Holy Blur/Holy Edge" sync / 1[56]:Halicarnassus:22F[01]:/
-420.1 "Critical Hit" sync / 1[56]:Halicarnassus:22EB:/
-429.3 "Mindjack" sync / 1[56]:Halicarnassus:22FA:/
-434.5 "Place Dark Token (Soul Reapers)" sync / 1[56]:Halicarnassus:22FC:/
-448.1 "Cross Reaper/Gusting Gouge" sync / 1[56]:Soul Reaper:22F[DF]:/
-449.7 "--teleport--" sync / 1[56]:Halicarnassus:2305:/
-456.0 "The Queen's Waltz (Random)" sync / 1[56]:Halicarnassus:230[68AE]:/
-469.0 "Dimensional Wave" sync / 1[56]:Halicarnassus:22F6:/
-477.1 "Haste" sync / 1[56]:Halicarnassus:22F4:/ window 30,30
-480.8 "Spellblade Blizzard/Fire/Thunder 1" sync / 1[56]:Halicarnassus:22E[CDE]:/
-485.4 "Spellblade Blizzard/Fire/Thunder 2" sync / 1[56]:Halicarnassus:22E[CDE]:/
-491.5 "Dimensional Wave" sync / 1[56]:Halicarnassus:22F6:/
-501.7 "Place Token (Ninjas/Giant)" sync / 1[56]:Halicarnassus:22FB:/
-512.0 "Haste III" sync / 1[56]:Halicarnassus:22F5:/
-512.7 "Grand Sword" # sync / 1[56]:Iron Giant:2316:/
-516.5 "Dimensional Wave 1" sync / 1[56]:Halicarnassus:22F6:/
-518.7 "Grand Sword" # sync / 1[56]:Iron Giant:2316:/
-522.1 "Dimensional Wave 2" sync / 1[56]:Halicarnassus:22F6:/
-527.7 "Dimensional Wave 3" sync / 1[56]:Halicarnassus:22F6:/
-533.3 "Dimensional Wave 4" sync / 1[56]:Halicarnassus:22F6:/
-535.5 "--teleport--" sync / 1[56]:Halicarnassus:2305:/
-540.9 "The Queen's Waltz (Random)" sync / 1[56]:Halicarnassus:230[68AE]:/
-545.5 "Spellblade Blizzard/Fire/Thunder" sync / 1[56]:Halicarnassus:22E[CDE]:/
-555.6 "Dimensional Wave" sync / 1[56]:Halicarnassus:22F6:/
-561.7 "Critical Hit" sync / 1[56]:Halicarnassus:22EB:/ window 30,15
-567.0 "--teleport--" sync / 1[56]:Halicarnassus:2305:/
-573.3 "The Queen's Waltz (Random)" sync / 1[56]:Halicarnassus:230[68AE]:/
-582.6 "Spellblade Holy" sync / 1[56]:Halicarnassus:22EF:/
-588.6 "Pole Shift" # sync / 1[56]:Halicarnassus:22F[23]:/
-591.6 "Holy Blur/Holy Edge" sync / 1[56]:Halicarnassus:22F[01]:/
-598.8 "Critical Hit" sync / 1[56]:Halicarnassus:22EB:/
-608.0 "Mindjack" sync / 1[56]:Halicarnassus:22FA:/
-613.2 "Place Dark Token (Soul Reapers)" sync / 1[56]:Halicarnassus:22FC:/
-626.7 "Cross Reaper/Gusting Gouge" sync / 1[56]:Soul Reaper:22F[DF]:/
-628.5 "--teleport--" sync / 1[56]:Halicarnassus:2305:/
-635.2 "The Queen's Waltz (Random)" sync / 1[56]:Halicarnassus:230[68AE]:/
-648.4 "Dimensional Wave" sync / 1[56]:Halicarnassus:22F6:/ window 30,15
-656.5 "Haste" sync / 1[56]:Halicarnassus:22F4:/
-660.1 "Spellblade Blizzard/Fire/Thunder 1" sync / 1[56]:Halicarnassus:22E[CDE]:/
-665.0 "Spellblade Blizzard/Fire/Thunder 2" sync / 1[56]:Halicarnassus:22E[CDE]:/
-671.1 "Dimensional Wave" sync / 1[56]:Halicarnassus:22F6:/
-681.2 "The Playing Field" sync / 1[56]:Halicarnassus:2300:/
-688.3 "The Game (Enrage)" sync / 1[56]:Halicarnassus:2301:/
+347.5 "Panel Swap (thorns)" sync / 1[56]:[^:]*:Halicarnassus:2304:/
+352.5 "The Playing Field" sync / 1[56]:[^:]*:Halicarnassus:2300:/ window 250,20
+362.5 "Oink/Ribbit/Squelch 1" sync / 1[56]:[^:]*:Halicarnassus:22F[789]:/
+368.7 "Oink/Ribbit/Squelch 2" sync / 1[56]:[^:]*:Halicarnassus:22F[789]:/
+374.7 "Oink/Ribbit/Squelch 3" sync / 1[56]:[^:]*:Halicarnassus:22F[789]:/
+381.7 "The Game" sync / 1[56]:[^:]*:Halicarnassus:2301:/
+388.0 "--teleport--" sync / 1[56]:[^:]*:Halicarnassus:2305:/
+394.5 "The Queen's Waltz (Random)" sync / 1[56]:[^:]*:Halicarnassus:230[68AE]:/
+403.8 "Spellblade Holy" sync / 1[56]:[^:]*:Halicarnassus:22EF:/
+409.9 "Pole Shift" # sync / 1[56]:[^:]*:Halicarnassus:22F[23]:/
+412.9 "Holy Blur/Holy Edge" sync / 1[56]:[^:]*:Halicarnassus:22F[01]:/
+420.1 "Critical Hit" sync / 1[56]:[^:]*:Halicarnassus:22EB:/
+429.3 "Mindjack" sync / 1[56]:[^:]*:Halicarnassus:22FA:/
+434.5 "Place Dark Token (Soul Reapers)" sync / 1[56]:[^:]*:Halicarnassus:22FC:/
+448.1 "Cross Reaper/Gusting Gouge" sync / 1[56]:[^:]*:Soul Reaper:22F[DF]:/
+449.7 "--teleport--" sync / 1[56]:[^:]*:Halicarnassus:2305:/
+456.0 "The Queen's Waltz (Random)" sync / 1[56]:[^:]*:Halicarnassus:230[68AE]:/
+469.0 "Dimensional Wave" sync / 1[56]:[^:]*:Halicarnassus:22F6:/
+477.1 "Haste" sync / 1[56]:[^:]*:Halicarnassus:22F4:/ window 30,30
+480.8 "Spellblade Blizzard/Fire/Thunder 1" sync / 1[56]:[^:]*:Halicarnassus:22E[CDE]:/
+485.4 "Spellblade Blizzard/Fire/Thunder 2" sync / 1[56]:[^:]*:Halicarnassus:22E[CDE]:/
+491.5 "Dimensional Wave" sync / 1[56]:[^:]*:Halicarnassus:22F6:/
+501.7 "Place Token (Ninjas/Giant)" sync / 1[56]:[^:]*:Halicarnassus:22FB:/
+512.0 "Haste III" sync / 1[56]:[^:]*:Halicarnassus:22F5:/
+512.7 "Grand Sword" # sync / 1[56]:[^:]*:Iron Giant:2316:/
+516.5 "Dimensional Wave 1" sync / 1[56]:[^:]*:Halicarnassus:22F6:/
+518.7 "Grand Sword" # sync / 1[56]:[^:]*:Iron Giant:2316:/
+522.1 "Dimensional Wave 2" sync / 1[56]:[^:]*:Halicarnassus:22F6:/
+527.7 "Dimensional Wave 3" sync / 1[56]:[^:]*:Halicarnassus:22F6:/
+533.3 "Dimensional Wave 4" sync / 1[56]:[^:]*:Halicarnassus:22F6:/
+535.5 "--teleport--" sync / 1[56]:[^:]*:Halicarnassus:2305:/
+540.9 "The Queen's Waltz (Random)" sync / 1[56]:[^:]*:Halicarnassus:230[68AE]:/
+545.5 "Spellblade Blizzard/Fire/Thunder" sync / 1[56]:[^:]*:Halicarnassus:22E[CDE]:/
+555.6 "Dimensional Wave" sync / 1[56]:[^:]*:Halicarnassus:22F6:/
+561.7 "Critical Hit" sync / 1[56]:[^:]*:Halicarnassus:22EB:/ window 30,15
+567.0 "--teleport--" sync / 1[56]:[^:]*:Halicarnassus:2305:/
+573.3 "The Queen's Waltz (Random)" sync / 1[56]:[^:]*:Halicarnassus:230[68AE]:/
+582.6 "Spellblade Holy" sync / 1[56]:[^:]*:Halicarnassus:22EF:/
+588.6 "Pole Shift" # sync / 1[56]:[^:]*:Halicarnassus:22F[23]:/
+591.6 "Holy Blur/Holy Edge" sync / 1[56]:[^:]*:Halicarnassus:22F[01]:/
+598.8 "Critical Hit" sync / 1[56]:[^:]*:Halicarnassus:22EB:/
+608.0 "Mindjack" sync / 1[56]:[^:]*:Halicarnassus:22FA:/
+613.2 "Place Dark Token (Soul Reapers)" sync / 1[56]:[^:]*:Halicarnassus:22FC:/
+626.7 "Cross Reaper/Gusting Gouge" sync / 1[56]:[^:]*:Soul Reaper:22F[DF]:/
+628.5 "--teleport--" sync / 1[56]:[^:]*:Halicarnassus:2305:/
+635.2 "The Queen's Waltz (Random)" sync / 1[56]:[^:]*:Halicarnassus:230[68AE]:/
+648.4 "Dimensional Wave" sync / 1[56]:[^:]*:Halicarnassus:22F6:/ window 30,15
+656.5 "Haste" sync / 1[56]:[^:]*:Halicarnassus:22F4:/
+660.1 "Spellblade Blizzard/Fire/Thunder 1" sync / 1[56]:[^:]*:Halicarnassus:22E[CDE]:/
+665.0 "Spellblade Blizzard/Fire/Thunder 2" sync / 1[56]:[^:]*:Halicarnassus:22E[CDE]:/
+671.1 "Dimensional Wave" sync / 1[56]:[^:]*:Halicarnassus:22F6:/
+681.2 "The Playing Field" sync / 1[56]:[^:]*:Halicarnassus:2300:/
+688.3 "The Game (Enrage)" sync / 1[56]:[^:]*:Halicarnassus:2301:/

--- a/ui/raidboss/data/04-sb/raid/o4n.txt
+++ b/ui/raidboss/data/04-sb/raid/o4n.txt
@@ -11,29 +11,29 @@ hideall "--sync--"
 0.0 "--Reset--" sync / 21:........:40000010:/ window 100000 jump 0
 
 0.0 "--sync--" sync /:Engage!/ window 0,1
-2.5 "--sync--" sync / 1[56]:Exdeath:366:/ window 2.5,1
-9.5 "Doom" sync / 1[56]:Exdeath:24B7:/ window 9.5,5
-19.1 "Blizzard/Fire III" sync / 1[56]:Exdeath:24B[9B]:/
-28.8 "Thunder III (Buster)" sync / 1[56]:Exdeath:24BD:/
-37.4 "Blizzard/Fire III" sync / 1[56]:Exdeath:24B[9B]:/
-50.3 "Mega Blizzard/Fire/Thunder" sync / 1[56]:Exdeath:24(BF|C[01]):/
-63.6 "Mega Blizzard/Fire/Thunder" sync / 1[56]:Exdeath:24(BF|C[01]):/
-74.8 "Mega Blizzard/Fire/Thunder" sync / 1[56]:Exdeath:24(BF|C[01]):/
-87.0 "Mega Blizzard/Fire/Thunder" sync / 1[56]:Exdeath:24(BF|C[01]):/
-92.6 "Blizzard/Fire III" sync / 1[56]:Exdeath:24B[9B]:/
-103.2 "Thunder III (Buster)" sync / 1[56]:Exdeath:24BD:/
+2.5 "--sync--" sync / 1[56]:[^:]*:Exdeath:366:/ window 2.5,1
+9.5 "Doom" sync / 1[56]:[^:]*:Exdeath:24B7:/ window 9.5,5
+19.1 "Blizzard/Fire III" sync / 1[56]:[^:]*:Exdeath:24B[9B]:/
+28.8 "Thunder III (Buster)" sync / 1[56]:[^:]*:Exdeath:24BD:/
+37.4 "Blizzard/Fire III" sync / 1[56]:[^:]*:Exdeath:24B[9B]:/
+50.3 "Mega Blizzard/Fire/Thunder" sync / 1[56]:[^:]*:Exdeath:24(BF|C[01]):/
+63.6 "Mega Blizzard/Fire/Thunder" sync / 1[56]:[^:]*:Exdeath:24(BF|C[01]):/
+74.8 "Mega Blizzard/Fire/Thunder" sync / 1[56]:[^:]*:Exdeath:24(BF|C[01]):/
+87.0 "Mega Blizzard/Fire/Thunder" sync / 1[56]:[^:]*:Exdeath:24(BF|C[01]):/
+92.6 "Blizzard/Fire III" sync / 1[56]:[^:]*:Exdeath:24B[9B]:/
+103.2 "Thunder III (Buster)" sync / 1[56]:[^:]*:Exdeath:24BD:/
 
-113.3 "Vacuum Wave" sync / 1[56]:Exdeath:24B8:/ window 40,30
-121.5 "Holy" sync / 1[56]:Exdeath:24C4:/
-132.8 "Mega Blizzard/Fire/Thunder" sync / 1[56]:Exdeath:24(BF|C[01]):/
-138.4 "Blizzard/Fire III" sync / 1[56]:Exdeath:24B[9B]:/
-149.1 "Thunder III (Buster)" sync / 1[56]:Exdeath:24BD:/
+113.3 "Vacuum Wave" sync / 1[56]:[^:]*:Exdeath:24B8:/ window 40,30
+121.5 "Holy" sync / 1[56]:[^:]*:Exdeath:24C4:/
+132.8 "Mega Blizzard/Fire/Thunder" sync / 1[56]:[^:]*:Exdeath:24(BF|C[01]):/
+138.4 "Blizzard/Fire III" sync / 1[56]:[^:]*:Exdeath:24B[9B]:/
+149.1 "Thunder III (Buster)" sync / 1[56]:[^:]*:Exdeath:24BD:/
 
-159.2 "Vacuum Wave" sync / 1[56]:Exdeath:24B8:/ window 20,20
-167.4 "Holy" sync / 1[56]:Exdeath:24C4:/
-178.7 "Mega Blizzard/Fire/Thunder" sync / 1[56]:Exdeath:24(BF|C[01]):/
-184.3 "Blizzard/Fire III" sync / 1[56]:Exdeath:24B[9B]:/
-195.0 "Thunder III (Buster)" sync / 1[56]:Exdeath:24BD:/ jump 149.1
+159.2 "Vacuum Wave" sync / 1[56]:[^:]*:Exdeath:24B8:/ window 20,20
+167.4 "Holy" sync / 1[56]:[^:]*:Exdeath:24C4:/
+178.7 "Mega Blizzard/Fire/Thunder" sync / 1[56]:[^:]*:Exdeath:24(BF|C[01]):/
+184.3 "Blizzard/Fire III" sync / 1[56]:[^:]*:Exdeath:24B[9B]:/
+195.0 "Thunder III (Buster)" sync / 1[56]:[^:]*:Exdeath:24BD:/ jump 149.1
 
 205.1 "Vacuum Wave"
 213.3 "Holy"
@@ -42,58 +42,58 @@ hideall "--sync--"
 
 # Phase change appears to be 65% HP.
 # This first section is not quite the same as the main rotation.
-300.0 "The Decisive Battle" sync / 1[56]:Exdeath:2408:/ window 300,5
+300.0 "The Decisive Battle" sync / 1[56]:[^:]*:Exdeath:2408:/ window 300,5
 301.4 "--untargetable--"
-305.9 "--sync--" sync / 1[56]:Exdeath:240A:/
-307.0 "Collision" sync / 1[56]:Exdeath:24CA:/
-312.0 "Zombie Breath" sync / 1[56]:Exdeath:24CB:/
+305.9 "--sync--" sync / 1[56]:[^:]*:Exdeath:240A:/
+307.0 "Collision" sync / 1[56]:[^:]*:Exdeath:24CA:/
+312.0 "Zombie Breath" sync / 1[56]:[^:]*:Exdeath:24CB:/
 317.0 "--targetable--"
-322.4 "Holy" sync / 1[56]:Exdeath:24C4:/ window 20,20
-329.5 "Flare" sync / 1[56]:Exdeath:24C2:/
-338.6 "Meteor" sync / 1[56]:Exdeath:24C6:/
-353.8 "Black Hole" sync / 1[56]:Exdeath:24C8:/ window 30,30
-365.1 "Mega Blizzard/Fire/Thunder" sync / 1[56]:Exdeath:24(BF|C[01]):/
+322.4 "Holy" sync / 1[56]:[^:]*:Exdeath:24C4:/ window 20,20
+329.5 "Flare" sync / 1[56]:[^:]*:Exdeath:24C2:/
+338.6 "Meteor" sync / 1[56]:[^:]*:Exdeath:24C6:/
+353.8 "Black Hole" sync / 1[56]:[^:]*:Exdeath:24C8:/ window 30,30
+365.1 "Mega Blizzard/Fire/Thunder" sync / 1[56]:[^:]*:Exdeath:24(BF|C[01]):/
 
 # This section has choices.
-370.7 "Blizzard/Fire III?" sync / 1[56]:Exdeath:24B[9B]:/
-372.2 "Holy?" sync / 1[56]:Exdeath:24C4:/
-386.3 "Meteor" sync / 1[56]:Exdeath:24C6:/
-396.4 "Thunder III (Buster)" sync / 1[56]:Exdeath:24BD:/ window 30,30
-410.7 "Black Hole" sync / 1[56]:Exdeath:24C8:/
-421.0 "Mega Blizzard/Fire/Thunder" sync / 1[56]:Exdeath:24(BF|C[01]):/
-427.1 "Flare?" sync / 1[56]:Exdeath:24C2:/
-427.1 "Vacuum Wave?" sync / 1[56]:Exdeath:24B8:/
-442.3 "Meteor" sync / 1[56]:Exdeath:24C6:/ window 30,30
-452.4 "Thunder III (Buster)" sync / 1[56]:Exdeath:24BD:/
+370.7 "Blizzard/Fire III?" sync / 1[56]:[^:]*:Exdeath:24B[9B]:/
+372.2 "Holy?" sync / 1[56]:[^:]*:Exdeath:24C4:/
+386.3 "Meteor" sync / 1[56]:[^:]*:Exdeath:24C6:/
+396.4 "Thunder III (Buster)" sync / 1[56]:[^:]*:Exdeath:24BD:/ window 30,30
+410.7 "Black Hole" sync / 1[56]:[^:]*:Exdeath:24C8:/
+421.0 "Mega Blizzard/Fire/Thunder" sync / 1[56]:[^:]*:Exdeath:24(BF|C[01]):/
+427.1 "Flare?" sync / 1[56]:[^:]*:Exdeath:24C2:/
+427.1 "Vacuum Wave?" sync / 1[56]:[^:]*:Exdeath:24B8:/
+442.3 "Meteor" sync / 1[56]:[^:]*:Exdeath:24C6:/ window 30,30
+452.4 "Thunder III (Buster)" sync / 1[56]:[^:]*:Exdeath:24BD:/
 
 # Actual rotation block begins. Consistent first half...
-466.8 "The Decisive Battle" sync / 1[56]:Exdeath:2408:/ window 30,30
+466.8 "The Decisive Battle" sync / 1[56]:[^:]*:Exdeath:2408:/ window 30,30
 468.2 "--untargetable--"
-472.6 "--sync--" sync / 1[56]:Exdeath:240A:/
-473.7 "Collision" sync / 1[56]:Exdeath:24CA:/
-475.1 "Clearout" sync / 1[56]:Deathly Vine:24CC:/
-478.8 "Zombie Breath" sync / 1[56]:Exdeath:24CB:/
+472.6 "--sync--" sync / 1[56]:[^:]*:Exdeath:240A:/
+473.7 "Collision" sync / 1[56]:[^:]*:Exdeath:24CA:/
+475.1 "Clearout" sync / 1[56]:[^:]*:Deathly Vine:24CC:/
+478.8 "Zombie Breath" sync / 1[56]:[^:]*:Exdeath:24CB:/
 483.8 "--targetable--"
-488.3 "Vacuum Wave" sync / 1[56]:Exdeath:24B8:/
-496.5 "Holy" sync / 1[56]:Exdeath:24C4:/ window 30,30
-503.6 "Flare" sync / 1[56]:Exdeath:24C2:/
-512.7 "Meteor" sync / 1[56]:Exdeath:24C6:/
-528.0 "Black Hole" sync / 1[56]:Exdeath:24C8:/
-538.2 "Mega Blizzard/Fire/Thunder" sync / 1[56]:Exdeath:24(BF|C[01]):/
+488.3 "Vacuum Wave" sync / 1[56]:[^:]*:Exdeath:24B8:/
+496.5 "Holy" sync / 1[56]:[^:]*:Exdeath:24C4:/ window 30,30
+503.6 "Flare" sync / 1[56]:[^:]*:Exdeath:24C2:/
+512.7 "Meteor" sync / 1[56]:[^:]*:Exdeath:24C6:/
+528.0 "Black Hole" sync / 1[56]:[^:]*:Exdeath:24C8:/
+538.2 "Mega Blizzard/Fire/Thunder" sync / 1[56]:[^:]*:Exdeath:24(BF|C[01]):/
 
 # Leading into choices in the second half.
-543.8 "Blizzard/Fire III?" sync / 1[56]:Exdeath:24B[9B]:/
-545.3 "Holy?" sync / 1[56]:Exdeath:24C4:/
-557.5 "Meteor" sync / 1[56]:Exdeath:24C6:/
-567.7 "Thunder III (Buster)" sync / 1[56]:Exdeath:24BD:/ window 30,30
-582.0 "Black Hole" sync / 1[56]:Exdeath:24C8:/
-592.3 "Mega Blizzard/Fire/Thunder" sync / 1[56]:Exdeath:24(BF|C[01]):/
-599.4 "Flare?" sync / 1[56]:Exdeath:24C2:/
-599.4 "Vacuum Wave?" sync / 1[56]:Exdeath:24B8:/
-613.5 "Meteor" sync / 1[56]:Exdeath:24C6:/ window 30,30
-623.7 "Thunder III (Buster)" sync / 1[56]:Exdeath:24BD:/
+543.8 "Blizzard/Fire III?" sync / 1[56]:[^:]*:Exdeath:24B[9B]:/
+545.3 "Holy?" sync / 1[56]:[^:]*:Exdeath:24C4:/
+557.5 "Meteor" sync / 1[56]:[^:]*:Exdeath:24C6:/
+567.7 "Thunder III (Buster)" sync / 1[56]:[^:]*:Exdeath:24BD:/ window 30,30
+582.0 "Black Hole" sync / 1[56]:[^:]*:Exdeath:24C8:/
+592.3 "Mega Blizzard/Fire/Thunder" sync / 1[56]:[^:]*:Exdeath:24(BF|C[01]):/
+599.4 "Flare?" sync / 1[56]:[^:]*:Exdeath:24C2:/
+599.4 "Vacuum Wave?" sync / 1[56]:[^:]*:Exdeath:24B8:/
+613.5 "Meteor" sync / 1[56]:[^:]*:Exdeath:24C6:/ window 30,30
+623.7 "Thunder III (Buster)" sync / 1[56]:[^:]*:Exdeath:24BD:/
 
-637.9 "The Decisive Battle" sync / 1[56]:Exdeath:2408:/ jump 466.8
+637.9 "The Decisive Battle" sync / 1[56]:[^:]*:Exdeath:2408:/ jump 466.8
 639.3 "--untargetable--"
 644.8 "Collision"
 646.2 "Clearout"
@@ -105,5 +105,5 @@ hideall "--sync--"
 
 # Enrage. Exdeath is untargetable at this point.
 # "Nothingness is my weapon, and nothingness alone can strike me down!"
-1000.0 "--sync--" sync / 14:Exdeath:24C7:/ window 1000,0
-1005.0 "Meteor Enrage" sync / 1[56]:Exdeath:24C7:/
+1000.0 "--sync--" sync / 14:[^:]*:Exdeath:24C7:/ window 1000,0
+1005.0 "Meteor Enrage" sync / 1[56]:[^:]*:Exdeath:24C7:/

--- a/ui/raidboss/data/04-sb/raid/o4s.txt
+++ b/ui/raidboss/data/04-sb/raid/o4s.txt
@@ -8,70 +8,70 @@ hideall "--sync--"
 # -ii 23F2 23F8 2400 240C
 
 # Exfaust
-3.8 "--sync--" sync / 1[56]:Exdeath:23F2:/ window 3.8,0
-12.2 "Dualcast" sync / 1[56]:Exdeath:23F4:/ window 12.2,5
-16.8 "--sync--" sync / 1[56]:Exdeath:23F7:/
-17.3 "Blizzard III" # sync / 1[56]:Exdeath:23F8:/
-19.9 "Blizzard III" # sync / 1[56]:Exdeath:23F8:/
-24.8 "Dualcast" sync / 1[56]:Exdeath:23F4:/
-30.8 "--sync--" sync / 1[56]:Exdeath:23F9:/
-31.5 "Thunder III" # sync / 1[56]:Exdeath:23FA:/
-32.6 "Thunder III" # sync / 1[56]:Exdeath:23FA:/
-37.9 "Dualcast" sync / 1[56]:Exdeath:23F4:/
-42.5 "--sync--" sync / 1[56]:Exdeath:23F5:/
-43.1 "Fire III" # sync / 1[56]:Exdeath:23F6:/
-47.1 "Fire III" # sync / 1[56]:Exdeath:23F6:/
-53.6 "White Hole" sync / 1[56]:Exdeath:23FF:/
-64.7 "The Decisive Battle" sync / 1[56]:Exdeath:2408:/
+3.8 "--sync--" sync / 1[56]:[^:]*:Exdeath:23F2:/ window 3.8,0
+12.2 "Dualcast" sync / 1[56]:[^:]*:Exdeath:23F4:/ window 12.2,5
+16.8 "--sync--" sync / 1[56]:[^:]*:Exdeath:23F7:/
+17.3 "Blizzard III" # sync / 1[56]:[^:]*:Exdeath:23F8:/
+19.9 "Blizzard III" # sync / 1[56]:[^:]*:Exdeath:23F8:/
+24.8 "Dualcast" sync / 1[56]:[^:]*:Exdeath:23F4:/
+30.8 "--sync--" sync / 1[56]:[^:]*:Exdeath:23F9:/
+31.5 "Thunder III" # sync / 1[56]:[^:]*:Exdeath:23FA:/
+32.6 "Thunder III" # sync / 1[56]:[^:]*:Exdeath:23FA:/
+37.9 "Dualcast" sync / 1[56]:[^:]*:Exdeath:23F4:/
+42.5 "--sync--" sync / 1[56]:[^:]*:Exdeath:23F5:/
+43.1 "Fire III" # sync / 1[56]:[^:]*:Exdeath:23F6:/
+47.1 "Fire III" # sync / 1[56]:[^:]*:Exdeath:23F6:/
+53.6 "White Hole" sync / 1[56]:[^:]*:Exdeath:23FF:/
+64.7 "The Decisive Battle" sync / 1[56]:[^:]*:Exdeath:2408:/
 66.5 "--untargetable--"
 
-70.6 "--sync--" sync / 1[56]:Exdeath:240A:/
-71.8 "Collision" sync / 1[56]:Exdeath:2409:/
-73.8 "Holy" sync / 1[56]:Exdeath:2403:/
-77.7 "Zombie Breath" sync / 1[56]:Exdeath:240B:/
-82.4 "Flare" sync / 1[56]:Exdeath:2401:/
+70.6 "--sync--" sync / 1[56]:[^:]*:Exdeath:240A:/
+71.8 "Collision" sync / 1[56]:[^:]*:Exdeath:2409:/
+73.8 "Holy" sync / 1[56]:[^:]*:Exdeath:2403:/
+77.7 "Zombie Breath" sync / 1[56]:[^:]*:Exdeath:240B:/
+82.4 "Flare" sync / 1[56]:[^:]*:Exdeath:2401:/
 
 85.2 "--targetable--"
-89.2 "Blizzard III/Fire III/Thunder III" sync / 1[56]:Exdeath:23F[BCD]:/ window 10,10
-95.4 "Vacuum Wave" sync / 1[56]:Exdeath:23FE:/
-105.6 "White Hole" sync / 1[56]:Exdeath:23FF:/
-118.0 "Black Hole" sync / 1[56]:Exdeath:2406:/
-123.1 "Dualcast" sync / 1[56]:Exdeath:23F4:/
-127.7 "--sync--" sync / 1[56]:Exdeath:23F5:/
-128.3 "Fire III" # sync / 1[56]:Exdeath:23F6:/
-132.2 "Fire III" # sync / 1[56]:Exdeath:23F6:/
-134.8 "Holy" sync / 1[56]:Exdeath:240[23]:/
-144.0 "White Hole" sync / 1[56]:Exdeath:23FF:/
-153.1 "Dualcast" sync / 1[56]:Exdeath:23F4:/
-159.1 "--sync--" sync / 1[56]:Exdeath:23F9:/
-159.8 "Thunder III" # sync / 1[56]:Exdeath:23FA:/
-160.9 "Thunder III" # sync / 1[56]:Exdeath:23FA:/
-166.1 "Meteor" sync / 1[56]:Exdeath:2404:/
-179.4 "The Decisive Battle" sync / 1[56]:Exdeath:2408:/
+89.2 "Blizzard III/Fire III/Thunder III" sync / 1[56]:[^:]*:Exdeath:23F[BCD]:/ window 10,10
+95.4 "Vacuum Wave" sync / 1[56]:[^:]*:Exdeath:23FE:/
+105.6 "White Hole" sync / 1[56]:[^:]*:Exdeath:23FF:/
+118.0 "Black Hole" sync / 1[56]:[^:]*:Exdeath:2406:/
+123.1 "Dualcast" sync / 1[56]:[^:]*:Exdeath:23F4:/
+127.7 "--sync--" sync / 1[56]:[^:]*:Exdeath:23F5:/
+128.3 "Fire III" # sync / 1[56]:[^:]*:Exdeath:23F6:/
+132.2 "Fire III" # sync / 1[56]:[^:]*:Exdeath:23F6:/
+134.8 "Holy" sync / 1[56]:[^:]*:Exdeath:240[23]:/
+144.0 "White Hole" sync / 1[56]:[^:]*:Exdeath:23FF:/
+153.1 "Dualcast" sync / 1[56]:[^:]*:Exdeath:23F4:/
+159.1 "--sync--" sync / 1[56]:[^:]*:Exdeath:23F9:/
+159.8 "Thunder III" # sync / 1[56]:[^:]*:Exdeath:23FA:/
+160.9 "Thunder III" # sync / 1[56]:[^:]*:Exdeath:23FA:/
+166.1 "Meteor" sync / 1[56]:[^:]*:Exdeath:2404:/
+179.4 "The Decisive Battle" sync / 1[56]:[^:]*:Exdeath:2408:/
 181.5 "--untargetable--"
 
-185.3 "--sync--" sync / 1[56]:Exdeath:240A:/
-186.4 "Collision" sync / 1[56]:Exdeath:2409:/
-188.7 "Holy" sync / 1[56]:Exdeath:2403:/
-192.4 "Zombie Breath" sync / 1[56]:Exdeath:240B:/
-197.1 "Flare" sync / 1[56]:Exdeath:2401:/
+185.3 "--sync--" sync / 1[56]:[^:]*:Exdeath:240A:/
+186.4 "Collision" sync / 1[56]:[^:]*:Exdeath:2409:/
+188.7 "Holy" sync / 1[56]:[^:]*:Exdeath:2403:/
+192.4 "Zombie Breath" sync / 1[56]:[^:]*:Exdeath:240B:/
+197.1 "Flare" sync / 1[56]:[^:]*:Exdeath:2401:/
 
 200.0 "--targetable--"
-203.9 "Blizzard III/Fire III/Thunder III" sync / 1[56]:Exdeath:23F[BCD]:/
-210.3 "Vacuum Wave" sync / 1[56]:Exdeath:23FE:/
-220.5 "White Hole" sync / 1[56]:Exdeath:23FF:/
-232.8 "Black Hole" sync / 1[56]:Exdeath:2406:/
-237.9 "Dualcast" sync / 1[56]:Exdeath:23F4:/
-242.5 "--sync--" sync / 1[56]:Exdeath:23F7:/
-243.0 "Blizzard III" # sync / 1[56]:Exdeath:23F8:/
-245.6 "Blizzard III" # sync / 1[56]:Exdeath:23F8:/
-249.6 "Flare" sync / 1[56]:Exdeath:2401:/
-258.8 "White Hole" sync / 1[56]:Exdeath:23FF:/
-267.9 "Dualcast" sync / 1[56]:Exdeath:23F4:/
-274.0 "--sync--" sync / 1[56]:Exdeath:23F9:/
-274.7 "Thunder III" # sync / 1[56]:Exdeath:23FA:/
-275.8 "Thunder III" # sync / 1[56]:Exdeath:23FA:/
-281.0 "Meteor" sync / 1[56]:Exdeath:2404:/
+203.9 "Blizzard III/Fire III/Thunder III" sync / 1[56]:[^:]*:Exdeath:23F[BCD]:/
+210.3 "Vacuum Wave" sync / 1[56]:[^:]*:Exdeath:23FE:/
+220.5 "White Hole" sync / 1[56]:[^:]*:Exdeath:23FF:/
+232.8 "Black Hole" sync / 1[56]:[^:]*:Exdeath:2406:/
+237.9 "Dualcast" sync / 1[56]:[^:]*:Exdeath:23F4:/
+242.5 "--sync--" sync / 1[56]:[^:]*:Exdeath:23F7:/
+243.0 "Blizzard III" # sync / 1[56]:[^:]*:Exdeath:23F8:/
+245.6 "Blizzard III" # sync / 1[56]:[^:]*:Exdeath:23F8:/
+249.6 "Flare" sync / 1[56]:[^:]*:Exdeath:2401:/
+258.8 "White Hole" sync / 1[56]:[^:]*:Exdeath:23FF:/
+267.9 "Dualcast" sync / 1[56]:[^:]*:Exdeath:23F4:/
+274.0 "--sync--" sync / 1[56]:[^:]*:Exdeath:23F9:/
+274.7 "Thunder III" # sync / 1[56]:[^:]*:Exdeath:23FA:/
+275.8 "Thunder III" # sync / 1[56]:[^:]*:Exdeath:23FA:/
+281.0 "Meteor" sync / 1[56]:[^:]*:Exdeath:2404:/
 282.0 "--untargetable--"
 
 
@@ -79,139 +79,139 @@ hideall "--sync--"
 # -p 242C:1116 242D:1339.5 2426:1652.1
 
 # Neo Exdeath
-1002.0 "--sync--" sync / 14:Neo Exdeath:2417:/ window 1002,5
-1007.7 "Almagest" sync / 1[56]:Neo Exdeath:2417:/ window 1008,5
-1016.7 "Aero III" sync / 1[56]:Neo Exdeath:2419:/
-1026.7 "Delta Attack" sync / 1[56]:Neo Exdeath:241E:/
-1027.2 "Blizzard III" # sync / 1[56]:Neo Exdeath:23F8:/
-1027.4 "Thunder III" # sync / 1[56]:Neo Exdeath:23FA:/
-1027.7 "Fire III" # sync / 1[56]:Neo Exdeath:23F6:/
-1028.4 "Thunder III" # sync / 1[56]:Neo Exdeath:23FA:/
-1030.2 "Blizzard III" # sync / 1[56]:Neo Exdeath:23F8:/
-1030.7 "Fire III" # sync / 1[56]:Neo Exdeath:23F6:/
+1002.0 "--sync--" sync / 14:[^:]*:Neo Exdeath:2417:/ window 1002,5
+1007.7 "Almagest" sync / 1[56]:[^:]*:Neo Exdeath:2417:/ window 1008,5
+1016.7 "Aero III" sync / 1[56]:[^:]*:Neo Exdeath:2419:/
+1026.7 "Delta Attack" sync / 1[56]:[^:]*:Neo Exdeath:241E:/
+1027.2 "Blizzard III" # sync / 1[56]:[^:]*:Neo Exdeath:23F8:/
+1027.4 "Thunder III" # sync / 1[56]:[^:]*:Neo Exdeath:23FA:/
+1027.7 "Fire III" # sync / 1[56]:[^:]*:Neo Exdeath:23F6:/
+1028.4 "Thunder III" # sync / 1[56]:[^:]*:Neo Exdeath:23FA:/
+1030.2 "Blizzard III" # sync / 1[56]:[^:]*:Neo Exdeath:23F8:/
+1030.7 "Fire III" # sync / 1[56]:[^:]*:Neo Exdeath:23F6:/
 
-1042.7 "Grand Cross Alpha" sync / 1[56]:Neo Exdeath:242B:/
+1042.7 "Grand Cross Alpha" sync / 1[56]:[^:]*:Neo Exdeath:242B:/
 1045.8 "--untargetable--"
 1048.9 "--targetable--"
-1053.7 "Flood Of Naught (charge)" sync / 1[56]:Neo Exdeath:2416:/
-1061.7 "Flood Of Naught (colors)" sync / 1[56]:Neo Exdeath:(2411|2412):/
-1073.2 "Double Attack" sync / 1[56]:Neo Exdeath:241C:/
-1083.8 "Emptiness x8" sync / 1[56]:Neo Exdeath:2420:/ duration 10
-1091.8 "Flood Of Naught (lasers)" sync / 1[56]:Neo Exdeath:(240E|240F):/
-1101.9 "Aero III" sync / 1[56]:Neo Exdeath:2419:/
+1053.7 "Flood Of Naught (charge)" sync / 1[56]:[^:]*:Neo Exdeath:2416:/
+1061.7 "Flood Of Naught (colors)" sync / 1[56]:[^:]*:Neo Exdeath:(2411|2412):/
+1073.2 "Double Attack" sync / 1[56]:[^:]*:Neo Exdeath:241C:/
+1083.8 "Emptiness x8" sync / 1[56]:[^:]*:Neo Exdeath:2420:/ duration 10
+1091.8 "Flood Of Naught (lasers)" sync / 1[56]:[^:]*:Neo Exdeath:(240E|240F):/
+1101.9 "Aero III" sync / 1[56]:[^:]*:Neo Exdeath:2419:/
 
-1116.0 "Grand Cross Delta" sync / 1[56]:Neo Exdeath:242C:/ window 116,10
-1129.0 "Flood Of Naught (colors/lasers)" sync / 1[56]:Neo Exdeath:(2411|2412|240E|240F):/
-1138.0 "Almagest" sync / 1[56]:Neo Exdeath:2417:/
-1149.1 "Aero III" sync / 1[56]:Neo Exdeath:2419:/
-1158.9 "Earth Shaker" sync / 1[56]:Neo Exdeath:241A:/
-1164.4 "Vacuum Wave" sync / 1[56]:Neo Exdeath:241D:/
-1178.4 "Emptiness x8" sync / 1[56]:Neo Exdeath:2420:/ duration 10
-1186.4 "Light And Darkness" sync / 1[56]:Neo Exdeath:241F:/
+1116.0 "Grand Cross Delta" sync / 1[56]:[^:]*:Neo Exdeath:242C:/ window 116,10
+1129.0 "Flood Of Naught (colors/lasers)" sync / 1[56]:[^:]*:Neo Exdeath:(2411|2412|240E|240F):/
+1138.0 "Almagest" sync / 1[56]:[^:]*:Neo Exdeath:2417:/
+1149.1 "Aero III" sync / 1[56]:[^:]*:Neo Exdeath:2419:/
+1158.9 "Earth Shaker" sync / 1[56]:[^:]*:Neo Exdeath:241A:/
+1164.4 "Vacuum Wave" sync / 1[56]:[^:]*:Neo Exdeath:241D:/
+1178.4 "Emptiness x8" sync / 1[56]:[^:]*:Neo Exdeath:2420:/ duration 10
+1186.4 "Light And Darkness" sync / 1[56]:[^:]*:Neo Exdeath:241F:/
 1189.5 "--untargetable--"
-1192.4 "Flare" sync / 1[56]:Neo Exdeath:2401:/
-1192.4 "Holy" sync / 1[56]:Neo Exdeath:2403:/
+1192.4 "Flare" sync / 1[56]:[^:]*:Neo Exdeath:2401:/
+1192.4 "Holy" sync / 1[56]:[^:]*:Neo Exdeath:2403:/
 1192.8 "--targetable--"
-1197.6 "Flood Of Naught (lasers)" sync / 1[56]:Neo Exdeath:(240E|240F):/
-1211.6 "Meteor" sync / 1[56]:Neo Exdeath:2424:/
+1197.6 "Flood Of Naught (lasers)" sync / 1[56]:[^:]*:Neo Exdeath:(240E|240F):/
+1211.6 "Meteor" sync / 1[56]:[^:]*:Neo Exdeath:2424:/
 1212.3 "--adds targetable--"
-1224.7 "Flood Of Naught (colors)" sync / 1[56]:Neo Exdeath:(2411|2412):/
-1237.4 "Charybdis" sync / 1[56]:Neo Exdeath:2423:/
-1244.9 "Double Attack" sync / 1[56]:Neo Exdeath:241C:/
-1260.4 "Almagest" sync / 1[56]:Neo Exdeath:2417:/
-1266.4 "Vacuum Wave" sync / 1[56]:Neo Exdeath:241D:/
-1272.4 "Aero III" sync / 1[56]:Neo Exdeath:2419:/
-1277.5 "Emptiness x8" sync / 1[56]:Neo Exdeath:2420:/ duration 10
+1224.7 "Flood Of Naught (colors)" sync / 1[56]:[^:]*:Neo Exdeath:(2411|2412):/
+1237.4 "Charybdis" sync / 1[56]:[^:]*:Neo Exdeath:2423:/
+1244.9 "Double Attack" sync / 1[56]:[^:]*:Neo Exdeath:241C:/
+1260.4 "Almagest" sync / 1[56]:[^:]*:Neo Exdeath:2417:/
+1266.4 "Vacuum Wave" sync / 1[56]:[^:]*:Neo Exdeath:241D:/
+1272.4 "Aero III" sync / 1[56]:[^:]*:Neo Exdeath:2419:/
+1277.5 "Emptiness x8" sync / 1[56]:[^:]*:Neo Exdeath:2420:/ duration 10
 
-1286.5 "Grand Cross Alpha" sync / 1[56]:Neo Exdeath:242B:/ window 170,10
+1286.5 "Grand Cross Alpha" sync / 1[56]:[^:]*:Neo Exdeath:242B:/ window 170,10
 1289.6 "--untargetable--"
 1292.7 "--targetable--"
-1297.5 "Flood Of Naught (charge)" sync / 1[56]:Neo Exdeath:2416:/
-1305.5 "Flood Of Naught (colors)" sync / 1[56]:Neo Exdeath:(2411|2412):/
-1322.5 "Delta Attack" sync / 1[56]:Neo Exdeath:241E:/
-1323.0 "Blizzard III" # sync / 1[56]:Neo Exdeath:23F8:/
-1323.2 "Thunder III" # sync / 1[56]:Neo Exdeath:23FA:/
-1323.5 "Fire III" # sync / 1[56]:Neo Exdeath:23F6:/
-1324.2 "Thunder III" # sync / 1[56]:Neo Exdeath:23FA:/
-1326.0 "Blizzard III" # sync / 1[56]:Neo Exdeath:23F8:/
-1326.5 "Fire III" # sync / 1[56]:Neo Exdeath:23F6:/
-1330.5 "Flood Of Naught (lasers)" sync / 1[56]:Neo Exdeath:(240E|240F):/
+1297.5 "Flood Of Naught (charge)" sync / 1[56]:[^:]*:Neo Exdeath:2416:/
+1305.5 "Flood Of Naught (colors)" sync / 1[56]:[^:]*:Neo Exdeath:(2411|2412):/
+1322.5 "Delta Attack" sync / 1[56]:[^:]*:Neo Exdeath:241E:/
+1323.0 "Blizzard III" # sync / 1[56]:[^:]*:Neo Exdeath:23F8:/
+1323.2 "Thunder III" # sync / 1[56]:[^:]*:Neo Exdeath:23FA:/
+1323.5 "Fire III" # sync / 1[56]:[^:]*:Neo Exdeath:23F6:/
+1324.2 "Thunder III" # sync / 1[56]:[^:]*:Neo Exdeath:23FA:/
+1326.0 "Blizzard III" # sync / 1[56]:[^:]*:Neo Exdeath:23F8:/
+1326.5 "Fire III" # sync / 1[56]:[^:]*:Neo Exdeath:23F6:/
+1330.5 "Flood Of Naught (lasers)" sync / 1[56]:[^:]*:Neo Exdeath:(240E|240F):/
 
-1339.5 "Grand Cross Omega" sync / 1[56]:Neo Exdeath:242D:/ window 340,10
+1339.5 "Grand Cross Omega" sync / 1[56]:[^:]*:Neo Exdeath:242D:/ window 340,10
 1345.5 "--untargetable--"
-1346.5 "The Final Battle" sync / 1[56]:Neo Exdeath:242A:/
-1354.6 "Flood Of Naught (colors/lasers)" sync / 1[56]:Neo Exdeath:(2411|2412|240E|240F):/
-1359.6 "Flood Of Naught (colors/lasers)" sync / 1[56]:Neo Exdeath:(2411|2412|240E|240F):/
-1365.6 "Flood Of Naught (lasers)" sync / 1[56]:Neo Exdeath:(240E|240F):/
+1346.5 "The Final Battle" sync / 1[56]:[^:]*:Neo Exdeath:242A:/
+1354.6 "Flood Of Naught (colors/lasers)" sync / 1[56]:[^:]*:Neo Exdeath:(2411|2412|240E|240F):/
+1359.6 "Flood Of Naught (colors/lasers)" sync / 1[56]:[^:]*:Neo Exdeath:(2411|2412|240E|240F):/
+1365.6 "Flood Of Naught (lasers)" sync / 1[56]:[^:]*:Neo Exdeath:(240E|240F):/
 1371.7 "--targetable--"
-1378.1 "Flood Of Naught (charge)" sync / 1[56]:Neo Exdeath:2416:/
-1389.1 "Almagest" sync / 1[56]:Neo Exdeath:2417:/
+1378.1 "Flood Of Naught (charge)" sync / 1[56]:[^:]*:Neo Exdeath:2416:/
+1389.1 "Almagest" sync / 1[56]:[^:]*:Neo Exdeath:2417:/
 
-1396.3 "Emptiness x8" sync / 1[56]:Neo Exdeath:2420:/ duration 10
-1404.4 "Flood Of Naught" sync / 1[56]:Neo Exdeath:(2411|2412|240E|240F):/
-1414.6 "Aero III" sync / 1[56]:Neo Exdeath:2419:/
+1396.3 "Emptiness x8" sync / 1[56]:[^:]*:Neo Exdeath:2420:/ duration 10
+1404.4 "Flood Of Naught" sync / 1[56]:[^:]*:Neo Exdeath:(2411|2412|240E|240F):/
+1414.6 "Aero III" sync / 1[56]:[^:]*:Neo Exdeath:2419:/
 
-1428.6 "Grand Cross Delta" sync / 1[56]:Neo Exdeath:242C:/ window 90,10
-1441.6 "Flood Of Naught (colors/lasers)" sync / 1[56]:Neo Exdeath:(2411|2412|240E|240F):/
-1450.6 "Almagest" sync / 1[56]:Neo Exdeath:2417:/
-1461.6 "Aero III" sync / 1[56]:Neo Exdeath:2419:/
-1471.3 "Earth Shaker" sync / 1[56]:Neo Exdeath:241A:/
-1476.8 "Vacuum Wave" sync / 1[56]:Neo Exdeath:241D:/
-1490.8 "Emptiness x8" sync / 1[56]:Neo Exdeath:2420:/ duration 10
-1498.8 "Light And Darkness" sync / 1[56]:Neo Exdeath:241F:/
+1428.6 "Grand Cross Delta" sync / 1[56]:[^:]*:Neo Exdeath:242C:/ window 90,10
+1441.6 "Flood Of Naught (colors/lasers)" sync / 1[56]:[^:]*:Neo Exdeath:(2411|2412|240E|240F):/
+1450.6 "Almagest" sync / 1[56]:[^:]*:Neo Exdeath:2417:/
+1461.6 "Aero III" sync / 1[56]:[^:]*:Neo Exdeath:2419:/
+1471.3 "Earth Shaker" sync / 1[56]:[^:]*:Neo Exdeath:241A:/
+1476.8 "Vacuum Wave" sync / 1[56]:[^:]*:Neo Exdeath:241D:/
+1490.8 "Emptiness x8" sync / 1[56]:[^:]*:Neo Exdeath:2420:/ duration 10
+1498.8 "Light And Darkness" sync / 1[56]:[^:]*:Neo Exdeath:241F:/
 1501.9 "--untargetable--"
-1504.8 "Flare" sync / 1[56]:Neo Exdeath:2401:/
-1504.8 "Holy" sync / 1[56]:Neo Exdeath:2403:/
+1504.8 "Flare" sync / 1[56]:[^:]*:Neo Exdeath:2401:/
+1504.8 "Holy" sync / 1[56]:[^:]*:Neo Exdeath:2403:/
 1505.2 "--targetable--"
-1509.8 "Flood Of Naught (lasers)" sync / 1[56]:Neo Exdeath:(240E|240F):/
-1523.8 "Meteor" sync / 1[56]:Neo Exdeath:2424:/
+1509.8 "Flood Of Naught (lasers)" sync / 1[56]:[^:]*:Neo Exdeath:(240E|240F):/
+1523.8 "Meteor" sync / 1[56]:[^:]*:Neo Exdeath:2424:/
 1524.5 "--adds targetable--"
-1536.8 "Flood Of Naught (colors)" sync / 1[56]:Neo Exdeath:(2411|2412):/
-1549.8 "Charybdis" sync / 1[56]:Neo Exdeath:2423:/
-1557.3 "Double Attack" sync / 1[56]:Neo Exdeath:241C:/
-1572.8 "Almagest" sync / 1[56]:Neo Exdeath:2417:/
-1578.8 "Vacuum Wave" sync / 1[56]:Neo Exdeath:241D:/
-1584.8 "Aero III" sync / 1[56]:Neo Exdeath:2419:/
-1589.9 "Emptiness x8" sync / 1[56]:Neo Exdeath:2420:/ duration 10
+1536.8 "Flood Of Naught (colors)" sync / 1[56]:[^:]*:Neo Exdeath:(2411|2412):/
+1549.8 "Charybdis" sync / 1[56]:[^:]*:Neo Exdeath:2423:/
+1557.3 "Double Attack" sync / 1[56]:[^:]*:Neo Exdeath:241C:/
+1572.8 "Almagest" sync / 1[56]:[^:]*:Neo Exdeath:2417:/
+1578.8 "Vacuum Wave" sync / 1[56]:[^:]*:Neo Exdeath:241D:/
+1584.8 "Aero III" sync / 1[56]:[^:]*:Neo Exdeath:2419:/
+1589.9 "Emptiness x8" sync / 1[56]:[^:]*:Neo Exdeath:2420:/ duration 10
 
-1598.9 "Grand Cross Alpha" sync / 1[56]:Neo Exdeath:242B:/ window 170,10
+1598.9 "Grand Cross Alpha" sync / 1[56]:[^:]*:Neo Exdeath:242B:/ window 170,10
 1602.0 "--untargetable--"
 1605.3 "--targetable--"
-1609.9 "Flood Of Naught (charge)" sync / 1[56]:Neo Exdeath:2416:/
-1617.9 "Flood Of Naught (colors)" sync / 1[56]:Neo Exdeath:(2411|2412):/
-1634.9 "Delta Attack" sync / 1[56]:Neo Exdeath:241E:/
-1635.4 "Blizzard III" # sync / 1[56]:Neo Exdeath:23F8:/
-1635.6 "Thunder III" # sync / 1[56]:Neo Exdeath:23FA:/
-1635.9 "Fire III" # sync / 1[56]:Neo Exdeath:23F6:/
-1636.6 "Thunder III" # sync / 1[56]:Neo Exdeath:23FA:/
-1638.4 "Blizzard III" # sync / 1[56]:Neo Exdeath:23F8:/
-1638.9 "Fire III" # sync / 1[56]:Neo Exdeath:23F6:/
-1642.9 "Flood Of Naught (lasers)" sync / 1[56]:Neo Exdeath:(240E|240F):/
+1609.9 "Flood Of Naught (charge)" sync / 1[56]:[^:]*:Neo Exdeath:2416:/
+1617.9 "Flood Of Naught (colors)" sync / 1[56]:[^:]*:Neo Exdeath:(2411|2412):/
+1634.9 "Delta Attack" sync / 1[56]:[^:]*:Neo Exdeath:241E:/
+1635.4 "Blizzard III" # sync / 1[56]:[^:]*:Neo Exdeath:23F8:/
+1635.6 "Thunder III" # sync / 1[56]:[^:]*:Neo Exdeath:23FA:/
+1635.9 "Fire III" # sync / 1[56]:[^:]*:Neo Exdeath:23F6:/
+1636.6 "Thunder III" # sync / 1[56]:[^:]*:Neo Exdeath:23FA:/
+1638.4 "Blizzard III" # sync / 1[56]:[^:]*:Neo Exdeath:23F8:/
+1638.9 "Fire III" # sync / 1[56]:[^:]*:Neo Exdeath:23F6:/
+1642.9 "Flood Of Naught (lasers)" sync / 1[56]:[^:]*:Neo Exdeath:(240E|240F):/
 
-1652.1 "Neverwhere" sync / 1[56]:Neo Exdeath:2426:/ window 652.1,10
-1660.2 "Charybdis" sync / 1[56]:Neo Exdeath:2423:/
-1663.4 "Flying Frenzy" sync / 1[56]:Neo Exdeath:2427:/
-1664.4 "Frenzied Fist x9" # sync / 1[56]:Neo Exdeath:2428:/
-1671.2 "Frenzied Sphere 1" sync / 1[56]:Neo Exdeath:2429:/
-1673.2 "Flying Frenzy" sync / 1[56]:Neo Exdeath:2427:/
-1674.1 "Frenzied Fist x9" # sync / 1[56]:Neo Exdeath:2428:/
-1681.0 "Frenzied Sphere 2" sync / 1[56]:Neo Exdeath:2429:/
-1683.2 "Flying Frenzy" sync / 1[56]:Neo Exdeath:2427:/
-1684.1 "Frenzied Fist x9" # sync / 1[56]:Neo Exdeath:2428:/
-1691.0 "Frenzied Sphere 3" sync / 1[56]:Neo Exdeath:2429:/
-1693.2 "Flying Frenzy" sync / 1[56]:Neo Exdeath:2427:/
-1694.1 "Frenzied Fist x9" # sync / 1[56]:Neo Exdeath:2428:/
-1701.0 "Frenzied Sphere 4" sync / 1[56]:Neo Exdeath:2429:/
-1703.2 "Flying Frenzy" sync / 1[56]:Neo Exdeath:2427:/
-1704.1 "Frenzied Fist x9" # sync / 1[56]:Neo Exdeath:2428:/
-1711.0 "Frenzied Sphere 5" sync / 1[56]:Neo Exdeath:2429:/
-1713.2 "Flying Frenzy" sync / 1[56]:Neo Exdeath:2427:/
-1714.1 "Frenzied Fist x9" # sync / 1[56]:Neo Exdeath:2428:/
-1721.0 "Frenzied Sphere 6" sync / 1[56]:Neo Exdeath:2429:/
-1723.2 "Flying Frenzy" sync / 1[56]:Neo Exdeath:2427:/
-1724.1 "Frenzied Fist x9" # sync / 1[56]:Neo Exdeath:2428:/
-1731.0 "Frenzied Sphere 7" sync / 1[56]:Neo Exdeath:2429:/
-1733.2 "Flying Frenzy" sync / 1[56]:Neo Exdeath:2427:/
-1734.1 "Frenzied Fist x9" # sync / 1[56]:Neo Exdeath:2428:/
-1741.0 "Frenzied Sphere 8" sync / 1[56]:Neo Exdeath:2429:/
-1753.2 "Almagest (enrage)" sync / 1[56]:Neo Exdeath:2418:/
+1652.1 "Neverwhere" sync / 1[56]:[^:]*:Neo Exdeath:2426:/ window 652.1,10
+1660.2 "Charybdis" sync / 1[56]:[^:]*:Neo Exdeath:2423:/
+1663.4 "Flying Frenzy" sync / 1[56]:[^:]*:Neo Exdeath:2427:/
+1664.4 "Frenzied Fist x9" # sync / 1[56]:[^:]*:Neo Exdeath:2428:/
+1671.2 "Frenzied Sphere 1" sync / 1[56]:[^:]*:Neo Exdeath:2429:/
+1673.2 "Flying Frenzy" sync / 1[56]:[^:]*:Neo Exdeath:2427:/
+1674.1 "Frenzied Fist x9" # sync / 1[56]:[^:]*:Neo Exdeath:2428:/
+1681.0 "Frenzied Sphere 2" sync / 1[56]:[^:]*:Neo Exdeath:2429:/
+1683.2 "Flying Frenzy" sync / 1[56]:[^:]*:Neo Exdeath:2427:/
+1684.1 "Frenzied Fist x9" # sync / 1[56]:[^:]*:Neo Exdeath:2428:/
+1691.0 "Frenzied Sphere 3" sync / 1[56]:[^:]*:Neo Exdeath:2429:/
+1693.2 "Flying Frenzy" sync / 1[56]:[^:]*:Neo Exdeath:2427:/
+1694.1 "Frenzied Fist x9" # sync / 1[56]:[^:]*:Neo Exdeath:2428:/
+1701.0 "Frenzied Sphere 4" sync / 1[56]:[^:]*:Neo Exdeath:2429:/
+1703.2 "Flying Frenzy" sync / 1[56]:[^:]*:Neo Exdeath:2427:/
+1704.1 "Frenzied Fist x9" # sync / 1[56]:[^:]*:Neo Exdeath:2428:/
+1711.0 "Frenzied Sphere 5" sync / 1[56]:[^:]*:Neo Exdeath:2429:/
+1713.2 "Flying Frenzy" sync / 1[56]:[^:]*:Neo Exdeath:2427:/
+1714.1 "Frenzied Fist x9" # sync / 1[56]:[^:]*:Neo Exdeath:2428:/
+1721.0 "Frenzied Sphere 6" sync / 1[56]:[^:]*:Neo Exdeath:2429:/
+1723.2 "Flying Frenzy" sync / 1[56]:[^:]*:Neo Exdeath:2427:/
+1724.1 "Frenzied Fist x9" # sync / 1[56]:[^:]*:Neo Exdeath:2428:/
+1731.0 "Frenzied Sphere 7" sync / 1[56]:[^:]*:Neo Exdeath:2429:/
+1733.2 "Flying Frenzy" sync / 1[56]:[^:]*:Neo Exdeath:2427:/
+1734.1 "Frenzied Fist x9" # sync / 1[56]:[^:]*:Neo Exdeath:2428:/
+1741.0 "Frenzied Sphere 8" sync / 1[56]:[^:]*:Neo Exdeath:2429:/
+1753.2 "Almagest (enrage)" sync / 1[56]:[^:]*:Neo Exdeath:2418:/

--- a/ui/raidboss/data/04-sb/raid/o5n.txt
+++ b/ui/raidboss/data/04-sb/raid/o5n.txt
@@ -10,61 +10,61 @@ hideall "--sync--"
 0.0 "--Reset--" sync / 21:........:40000010:/ window 100000 jump 0
 
 0.0 "--sync--" sync /:Engage!/ window 0,1
-8 "--sync--" sync / 14:Wroth Ghost:28AE:/ window 8,3
-13 "Encumber" sync / 1[56]:Wroth Ghost:28AE:/ 
-27 "Head On" sync / 1[56]:Phantom Train:28AF:/
-38 "Ghost Beams" sync / 1[56]:Phantom Train:28AA:/
+8 "--sync--" sync / 14:[^:]*:Wroth Ghost:28AE:/ window 8,3
+13 "Encumber" sync / 1[56]:[^:]*:Wroth Ghost:28AE:/ 
+27 "Head On" sync / 1[56]:[^:]*:Phantom Train:28AF:/
+38 "Ghost Beams" sync / 1[56]:[^:]*:Phantom Train:28AA:/
 47 "Saintly Beam" duration 12
-63 "Diabolic Headlamp" sync / 1[56]:Phantom Train:28B0:/ window 5,5
-73 "Tether Whistle" sync / 1[56]:Phantom Train:28A5:/
+63 "Diabolic Headlamp" sync / 1[56]:[^:]*:Phantom Train:28B0:/ window 5,5
+73 "Tether Whistle" sync / 1[56]:[^:]*:Phantom Train:28A5:/
 80 "Saintly Beam" duration 12
-102 "Doom Strike" sync / 1[56]:Phantom Train:28A3:/
-116 "Diabolic Wind" sync / 1[56]:Phantom Train:28B9:/
-119 "Crossing Whistle" sync / 1[56]:Phantom Train:28A5:/
+102 "Doom Strike" sync / 1[56]:[^:]*:Phantom Train:28A3:/
+116 "Diabolic Wind" sync / 1[56]:[^:]*:Phantom Train:28B9:/
+119 "Crossing Whistle" sync / 1[56]:[^:]*:Phantom Train:28A5:/
 139 "Diabolic Light" duration 13
-162 "Acid Rain" sync / 1[56]:Phantom Train:28AB:/
+162 "Acid Rain" sync / 1[56]:[^:]*:Phantom Train:28AB:/
 
 # add phase start
-163 "--untargetable--" sync / 1[56]:Phantom Train:28A7:/
+163 "--untargetable--" sync / 1[56]:[^:]*:Phantom Train:28A7:/
 178 "Add Wave"
-193 "Diabolic Wind" sync / 1[56]:Phantom Train:28B9:/
-250 "Diabolic Chimney" sync / 1[56]:Phantom Train:28A9:/ window 100,100
+193 "Diabolic Wind" sync / 1[56]:[^:]*:Phantom Train:28B9:/
+250 "Diabolic Chimney" sync / 1[56]:[^:]*:Phantom Train:28A9:/ window 100,100
 260 "Ghosts"
 
 # add phase end
-320 "--sync--" sync / 1[56]:Phantom Train:28A8:/ window 320,320 # boss reappears
+320 "--sync--" sync / 1[56]:[^:]*:Phantom Train:28A8:/ window 320,320 # boss reappears
 324 "--targetable--"
-338 "Tether Whistle" sync / 1[56]:Phantom Train:28A5:/
+338 "Tether Whistle" sync / 1[56]:[^:]*:Phantom Train:28A5:/
 342 "Saintly Beam" duration 12
-346 "Acid Rain" sync / 1[56]:Phantom Train:28AB:/
-366 "Doom Strike" sync / 1[56]:Phantom Train:28A3:/
-376 "Crossing Whistle" sync / 1[56]:Phantom Train:28A5:/
-386 "Head On" sync / 1[56]:Phantom Train:28AF:/
-391 "Acid Rain" sync / 1[56]:Phantom Train:28AB:/
+346 "Acid Rain" sync / 1[56]:[^:]*:Phantom Train:28AB:/
+366 "Doom Strike" sync / 1[56]:[^:]*:Phantom Train:28A3:/
+376 "Crossing Whistle" sync / 1[56]:[^:]*:Phantom Train:28A5:/
+386 "Head On" sync / 1[56]:[^:]*:Phantom Train:28AF:/
+391 "Acid Rain" sync / 1[56]:[^:]*:Phantom Train:28AB:/
 398 "Diabolic Light" duration 13
-403 "Diabolic Headlamp" sync / 1[56]:Phantom Train:28B0:/
-425 "Doom Strike" sync / 1[56]:Phantom Train:28A3:/
+403 "Diabolic Headlamp" sync / 1[56]:[^:]*:Phantom Train:28B0:/
+425 "Doom Strike" sync / 1[56]:[^:]*:Phantom Train:28A3:/
 
 # Loop starts here
-433 "Tether Whistle" sync / 1[56]:Phantom Train:28A5:/
+433 "Tether Whistle" sync / 1[56]:[^:]*:Phantom Train:28A5:/
 437 "Saintly Beam" duration 12
-441 "Acid Rain" sync / 1[56]:Phantom Train:28AB:/
-463 "Head On" sync / 1[56]:Phantom Train:28AF:/
-465 "Diabolic Wind" sync / 1[56]:Phantom Train:28B9:/
-470 "Acid Rain" sync / 1[56]:Phantom Train:28AB:/
-477 "Crossing Whistle" sync / 1[56]:Phantom Train:28A5:/
-483 "Encumber" sync / 1[56]:Wroth Ghost:28AE:/
-491 "Diabolic Wind" sync / 1[56]:Phantom Train:28B9:/
-498 "Diabolic Headlamp" sync / 1[56]:Phantom Train:28B0:/
-504 "Acid Rain" sync / 1[56]:Phantom Train:28AB:/
+441 "Acid Rain" sync / 1[56]:[^:]*:Phantom Train:28AB:/
+463 "Head On" sync / 1[56]:[^:]*:Phantom Train:28AF:/
+465 "Diabolic Wind" sync / 1[56]:[^:]*:Phantom Train:28B9:/
+470 "Acid Rain" sync / 1[56]:[^:]*:Phantom Train:28AB:/
+477 "Crossing Whistle" sync / 1[56]:[^:]*:Phantom Train:28A5:/
+483 "Encumber" sync / 1[56]:[^:]*:Wroth Ghost:28AE:/
+491 "Diabolic Wind" sync / 1[56]:[^:]*:Phantom Train:28B9:/
+498 "Diabolic Headlamp" sync / 1[56]:[^:]*:Phantom Train:28B0:/
+504 "Acid Rain" sync / 1[56]:[^:]*:Phantom Train:28AB:/
 509 "Diabolic Light" duration 13
-513 "Doom Strike" sync / 1[56]:Phantom Train:28A3:/
+513 "Doom Strike" sync / 1[56]:[^:]*:Phantom Train:28A3:/
 527 "Saintly Beam" duration 12
-528 "Acid Rain" sync / 1[56]:Phantom Train:28AB:/
-544 "Diabolic Wind" sync / 1[56]:Phantom Train:28B9:/
-559 "Doom Strike" sync / 1[56]:Phantom Train:28A3:/
+528 "Acid Rain" sync / 1[56]:[^:]*:Phantom Train:28AB:/
+544 "Diabolic Wind" sync / 1[56]:[^:]*:Phantom Train:28B9:/
+559 "Doom Strike" sync / 1[56]:[^:]*:Phantom Train:28A3:/
 
-567 "Tether Whistle" sync / 1[56]:Phantom Train:28A5:/ jump 433 # repeats after this?
+567 "Tether Whistle" sync / 1[56]:[^:]*:Phantom Train:28A5:/ jump 433 # repeats after this?
 
 # Visual continuity
 571 "Saintly Beam" duration 12

--- a/ui/raidboss/data/04-sb/raid/o5s.txt
+++ b/ui/raidboss/data/04-sb/raid/o5s.txt
@@ -10,88 +10,88 @@ hideall "--sync--"
 0.0 "--Reset--" sync / 21:........:40000010:/ window 100000 jump 0
 
 0.0 "--sync--" sync /:Engage!/ window 0,1
-11 "Encumber" sync / 1[56]:Wroth Ghost:28B6:/
+11 "Encumber" sync / 1[56]:[^:]*:Wroth Ghost:28B6:/
 18 "Saintly Beam" duration 10
-31 "Knockback Whistle" sync / 1[56]:Phantom Train:28A5:/
-41 "All In The Mind" sync / 1[56]:Remorse:28AD:/
-50 "Doom Strike" sync / 1[56]:Phantom Train:28B1:/
-64 "Head On" sync / 1[56]:Phantom Train:28B7:/
-65 "Diabolic Wind" sync / 1[56]:Phantom Train:28BD:/
-71 "Acid Rain" sync / 1[56]:Phantom Train:28B5:/
-80 "Crossing Whistle" sync / 1[56]:Phantom Train:28A5:/
+31 "Knockback Whistle" sync / 1[56]:[^:]*:Phantom Train:28A5:/
+41 "All In The Mind" sync / 1[56]:[^:]*:Remorse:28AD:/
+50 "Doom Strike" sync / 1[56]:[^:]*:Phantom Train:28B1:/
+64 "Head On" sync / 1[56]:[^:]*:Phantom Train:28B7:/
+65 "Diabolic Wind" sync / 1[56]:[^:]*:Phantom Train:28BD:/
+71 "Acid Rain" sync / 1[56]:[^:]*:Phantom Train:28B5:/
+80 "Crossing Whistle" sync / 1[56]:[^:]*:Phantom Train:28A5:/
 90 "Saintly Beam" duration 10
-104 "Diabolic Headlamp" sync / 1[56]:Phantom Train:28B8:/
-116 "Tether Whistle" sync / 1[56]:Phantom Train:28A5:/
+104 "Diabolic Headlamp" sync / 1[56]:[^:]*:Phantom Train:28B8:/
+116 "Tether Whistle" sync / 1[56]:[^:]*:Phantom Train:28A5:/
 125 "Saintly Beam" duration 10
 141 "Diabolic Light" duration 13
-152 "Doom Strike" sync / 1[56]:Phantom Train:28B1:/
-159 "Acid Rain" sync / 1[56]:Phantom Train:28B5:/
+152 "Doom Strike" sync / 1[56]:[^:]*:Phantom Train:28B1:/
+159 "Acid Rain" sync / 1[56]:[^:]*:Phantom Train:28B5:/
 
 
 # add phase
 
-168 "--untargetable--" sync / 1[56]:Phantom Train:28A7:/ window 500,500
+168 "--untargetable--" sync / 1[56]:[^:]*:Phantom Train:28A7:/ window 500,500
 180 "Add Wave"
-196 "(DPS) Diabolic Wind" sync / 1[56]:Phantom Train:28BD:/
-203 "(T/H) Diabolic Wind" sync / 1[56]:Phantom Train:28BD:/
+196 "(DPS) Diabolic Wind" sync / 1[56]:[^:]*:Phantom Train:28BD:/
+203 "(T/H) Diabolic Wind" sync / 1[56]:[^:]*:Phantom Train:28BD:/
 
 # chimney + train cars
-300 "--sync--" sync / 1[56]:Phantom Train:28B3:/ window 500,500
+300 "--sync--" sync / 1[56]:[^:]*:Phantom Train:28B3:/ window 500,500
 305 "(T/H) Ghosts" sync / 03:........:Agony:/
 309 "(DPS) Ghosts" sync / 03:........:Malice:/
 
 
-491 "--sync--" sync / 1[56]:Phantom Train:28A8:/ window 500,500
+491 "--sync--" sync / 1[56]:[^:]*:Phantom Train:28A8:/ window 500,500
 500 "--targetable--"
-517 "Encumber" sync / 1[56]:Wroth Ghost:28B6:/ window 80,80
+517 "Encumber" sync / 1[56]:[^:]*:Wroth Ghost:28B6:/ window 80,80
 525 "Diabolic Light" duration 13
-530 "Diabolic Headlamp" sync / 1[56]:Phantom Train:28B8:/
+530 "Diabolic Headlamp" sync / 1[56]:[^:]*:Phantom Train:28B8:/
 534 "Saintly Beam" duration 10
-547 "Doom Strike" sync / 1[56]:Phantom Train:28B1:/
+547 "Doom Strike" sync / 1[56]:[^:]*:Phantom Train:28B1:/
 
-556 "Tether Whistle" sync / 1[56]:Phantom Train:28A5:/
+556 "Tether Whistle" sync / 1[56]:[^:]*:Phantom Train:28A5:/
 563 "Saintly Beam" duration 10
-580 "Knockback Whistle" sync / 1[56]:Phantom Train:28A5:/
-589 "All In The Mind" sync / 1[56]:Remorse:28AD:/
-593 "Diabolic Headlamp" sync / 1[56]:Phantom Train:28B8:/
-611 "Head On" sync / 1[56]:Phantom Train:28B7:/
+580 "Knockback Whistle" sync / 1[56]:[^:]*:Phantom Train:28A5:/
+589 "All In The Mind" sync / 1[56]:[^:]*:Remorse:28AD:/
+593 "Diabolic Headlamp" sync / 1[56]:[^:]*:Phantom Train:28B8:/
+611 "Head On" sync / 1[56]:[^:]*:Phantom Train:28B7:/
 612 "Saintly Beam" duration 10
 616 "Ghosts spawn"
 
-629 "Crossing Whistle" sync / 1[56]:Phantom Train:28A5:/
-637 "Diabolic Headlamp" sync / 1[56]:Phantom Train:28B8:/
-645 "Diabolic Wind" sync / 1[56]:Phantom Train:28BD:/
-646 "Tether Whistle" sync / 1[56]:Phantom Train:28A5:/
+629 "Crossing Whistle" sync / 1[56]:[^:]*:Phantom Train:28A5:/
+637 "Diabolic Headlamp" sync / 1[56]:[^:]*:Phantom Train:28B8:/
+645 "Diabolic Wind" sync / 1[56]:[^:]*:Phantom Train:28BD:/
+646 "Tether Whistle" sync / 1[56]:[^:]*:Phantom Train:28A5:/
 653 "Saintly Beam" duration 10
-659 "Diabolic Wind" sync / 1[56]:Phantom Train:28BD:/
+659 "Diabolic Wind" sync / 1[56]:[^:]*:Phantom Train:28BD:/
 
 665 "Diabolic Light" duration 13
-676 "Doom Strike" sync / 1[56]:Phantom Train:28B1:/
-683 "Acid Rain" sync / 1[56]:Phantom Train:28B5:/
-697 "Diabolic Headlamp" sync / 1[56]:Phantom Train:28B8:/
+676 "Doom Strike" sync / 1[56]:[^:]*:Phantom Train:28B1:/
+683 "Acid Rain" sync / 1[56]:[^:]*:Phantom Train:28B5:/
+697 "Diabolic Headlamp" sync / 1[56]:[^:]*:Phantom Train:28B8:/
 699 "Saintly Beam" duration 10
-704 "Acid Rain" sync / 1[56]:Phantom Train:28B5:/
+704 "Acid Rain" sync / 1[56]:[^:]*:Phantom Train:28B5:/
 
-718 "Tether Whistle" sync / 1[56]:Phantom Train:28A5:/
+718 "Tether Whistle" sync / 1[56]:[^:]*:Phantom Train:28A5:/
 728 "Saintly Beam" duration 10
-731 "Encumber" sync / 1[56]:Wroth Ghost:28B6:/
-732 "Diabolic Wind" sync / 1[56]:Phantom Train:28BD:/
+731 "Encumber" sync / 1[56]:[^:]*:Wroth Ghost:28B6:/
+732 "Diabolic Wind" sync / 1[56]:[^:]*:Phantom Train:28BD:/
 
 737 "Diabolic Light" duration 13
-748 "Doom Strike" sync / 1[56]:Phantom Train:28B1:/
-760 "Knockback Whistle" sync / 1[56]:Phantom Train:28A5:/
-769 "All In The Mind" sync / 1[56]:Remorse:28AD:/
-774 "Diabolic Headlamp" sync / 1[56]:Phantom Train:28B8:/
+748 "Doom Strike" sync / 1[56]:[^:]*:Phantom Train:28B1:/
+760 "Knockback Whistle" sync / 1[56]:[^:]*:Phantom Train:28A5:/
+769 "All In The Mind" sync / 1[56]:[^:]*:Remorse:28AD:/
+774 "Diabolic Headlamp" sync / 1[56]:[^:]*:Phantom Train:28B8:/
 
-789 "Head On" sync / 1[56]:Phantom Train:28B7:/
-791 "Diabolic Wind" sync / 1[56]:Phantom Train:28BD:/
-797 "Acid Rain" sync / 1[56]:Phantom Train:28B5:/
-808 "Encumber" sync / 1[56]:Wroth Ghost:28B6:/
-811 "Crossing Whistle" sync / 1[56]:Phantom Train:28A5:/
-819 "Diabolic Headlamp" sync / 1[56]:Phantom Train:28B8:/
-827 "Diabolic Wind" sync / 1[56]:Phantom Train:28BD:/
-828 "Tether Whistle" sync / 1[56]:Phantom Train:28A5:/
+789 "Head On" sync / 1[56]:[^:]*:Phantom Train:28B7:/
+791 "Diabolic Wind" sync / 1[56]:[^:]*:Phantom Train:28BD:/
+797 "Acid Rain" sync / 1[56]:[^:]*:Phantom Train:28B5:/
+808 "Encumber" sync / 1[56]:[^:]*:Wroth Ghost:28B6:/
+811 "Crossing Whistle" sync / 1[56]:[^:]*:Phantom Train:28A5:/
+819 "Diabolic Headlamp" sync / 1[56]:[^:]*:Phantom Train:28B8:/
+827 "Diabolic Wind" sync / 1[56]:[^:]*:Phantom Train:28BD:/
+828 "Tether Whistle" sync / 1[56]:[^:]*:Phantom Train:28A5:/
 
 # 10:00 enrage, final phase length depends on add phase time
-821 "--sync--" sync / 14:Phantom Train:2A87:/ window 821,500
-831 "Saintly Beam" sync / 1[56]:Phantom Train:2A87:/
+821 "--sync--" sync / 14:[^:]*:Phantom Train:2A87:/ window 821,500
+831 "Saintly Beam" sync / 1[56]:[^:]*:Phantom Train:2A87:/

--- a/ui/raidboss/data/04-sb/raid/o6n.txt
+++ b/ui/raidboss/data/04-sb/raid/o6n.txt
@@ -7,60 +7,60 @@ hideall "--sync--"
 
 0 "Start" sync / 00:0044:[^:]*:I have claimed the girl in the picture! She's mine! You can't have her!/ window 0,1
 18 "--targetable--"
-21 "Demonic Howl" sync / 1[56]:Demon Chadarnook:282C:/ window 21,2.5
-30 "Demonic Shear" sync / 1[56]:Demon Chadarnook:282A:/
+21 "Demonic Howl" sync / 1[56]:[^:]*:Demon Chadarnook:282C:/ window 21,2.5
+30 "Demonic Shear" sync / 1[56]:[^:]*:Demon Chadarnook:282A:/
 
-54 "Possession" sync / 1[56]:Demon Chadarnook:2803:/
-59 "Flash Fire" sync / 1[56]:Portrayal of Fire:280B:/
-66 "Demonic Howl" sync / 1[56]:Demon Chadarnook:282C:/
-76 "Demonic Shear" sync / 1[56]:Demon Chadarnook:282A:/
-86 "Release" sync / 1[56]:Demon Chadarnook:2804:/
+54 "Possession" sync / 1[56]:[^:]*:Demon Chadarnook:2803:/
+59 "Flash Fire" sync / 1[56]:[^:]*:Portrayal of Fire:280B:/
+66 "Demonic Howl" sync / 1[56]:[^:]*:Demon Chadarnook:282C:/
+76 "Demonic Shear" sync / 1[56]:[^:]*:Demon Chadarnook:282A:/
+86 "Release" sync / 1[56]:[^:]*:Demon Chadarnook:2804:/
 
-99 "Possession" sync / 1[56]:Demon Chadarnook:2803:/
-104 "Earthquake" sync / 1[56]:Portrayal of Earth:2811:/
-118 "Demonic Stone" sync / 1[56]:Demon Chadarnook:2847:/
-125 "Demonic Howl" sync / 1[56]:Demon Chadarnook:282C:/
-138 "Demonic Shear" sync / 1[56]:Demon Chadarnook:282A:/
-146 "Release" sync / 1[56]:Demon Chadarnook:2804:/
+99 "Possession" sync / 1[56]:[^:]*:Demon Chadarnook:2803:/
+104 "Earthquake" sync / 1[56]:[^:]*:Portrayal of Earth:2811:/
+118 "Demonic Stone" sync / 1[56]:[^:]*:Demon Chadarnook:2847:/
+125 "Demonic Howl" sync / 1[56]:[^:]*:Demon Chadarnook:282C:/
+138 "Demonic Shear" sync / 1[56]:[^:]*:Demon Chadarnook:282A:/
+146 "Release" sync / 1[56]:[^:]*:Demon Chadarnook:2804:/
 
-159 "Possession" sync / 1[56]:Demon Chadarnook:2803:/
-170 "Demonic Wave" sync / 1[56]:Portrayal of Water:2831:/
-179 "Demonic Howl" sync / 1[56]:Demon Chadarnook:282C:/
-187 "Demonic Shear" sync / 1[56]:Demon Chadarnook:282A:/
-195 "Demonic Spout" sync / 1[56]:Demon Chadarnook:2835:/
-200 "Demonic Spout" sync / 1[56]:Demon Chadarnook:2837:/
-209 "Release" sync / 1[56]:Demon Chadarnook:2804:/
+159 "Possession" sync / 1[56]:[^:]*:Demon Chadarnook:2803:/
+170 "Demonic Wave" sync / 1[56]:[^:]*:Portrayal of Water:2831:/
+179 "Demonic Howl" sync / 1[56]:[^:]*:Demon Chadarnook:282C:/
+187 "Demonic Shear" sync / 1[56]:[^:]*:Demon Chadarnook:282A:/
+195 "Demonic Spout" sync / 1[56]:[^:]*:Demon Chadarnook:2835:/
+200 "Demonic Spout" sync / 1[56]:[^:]*:Demon Chadarnook:2837:/
+209 "Release" sync / 1[56]:[^:]*:Demon Chadarnook:2804:/
 
-222 "Possession" sync / 1[56]:Demon Chadarnook:2803:/
-227 "Demonic Typhoon" sync / 1[56]:Demon Chadarnook:283D:/
-244 "Demonic Howl" sync / 1[56]:Demon Chadarnook:282C:/
-245 "Featherlance" sync / 1[56]:Easterly:2AE8:/
-253 "Demonic Pain" sync / 1[56]:Demon Chadarnook:2AEB:/
-264 "Flash Gale" sync / 1[56]:Demon Chadarnook:2842:/
-275 "Release" sync / 1[56]:Demon Chadarnook:2804:/
+222 "Possession" sync / 1[56]:[^:]*:Demon Chadarnook:2803:/
+227 "Demonic Typhoon" sync / 1[56]:[^:]*:Demon Chadarnook:283D:/
+244 "Demonic Howl" sync / 1[56]:[^:]*:Demon Chadarnook:282C:/
+245 "Featherlance" sync / 1[56]:[^:]*:Easterly:2AE8:/
+253 "Demonic Pain" sync / 1[56]:[^:]*:Demon Chadarnook:2AEB:/
+264 "Flash Gale" sync / 1[56]:[^:]*:Demon Chadarnook:2842:/
+275 "Release" sync / 1[56]:[^:]*:Demon Chadarnook:2804:/
 
 # loop starts here
-288 "Possession" sync / 1[56]:Demon Chadarnook:2803:/
-293 "Flash Fire" sync / 1[56]:Portrayal of Fire:280B:/
-299 "Demonic Wave" sync / 1[56]:Portrayal of Water:2831:/
-308 "Demonic Howl" sync / 1[56]:Demon Chadarnook:282C:/
-318 "Demonic Spout" sync / 1[56]:Demon Chadarnook:2835:/
-323 "Demonic Spout" sync / 1[56]:Demon Chadarnook:2837:/
-330 "Demonic Shear" sync / 1[56]:Demon Chadarnook:282A:/
-341 "Release" sync / 1[56]:Haunt:2809:/
+288 "Possession" sync / 1[56]:[^:]*:Demon Chadarnook:2803:/
+293 "Flash Fire" sync / 1[56]:[^:]*:Portrayal of Fire:280B:/
+299 "Demonic Wave" sync / 1[56]:[^:]*:Portrayal of Water:2831:/
+308 "Demonic Howl" sync / 1[56]:[^:]*:Demon Chadarnook:282C:/
+318 "Demonic Spout" sync / 1[56]:[^:]*:Demon Chadarnook:2835:/
+323 "Demonic Spout" sync / 1[56]:[^:]*:Demon Chadarnook:2837:/
+330 "Demonic Shear" sync / 1[56]:[^:]*:Demon Chadarnook:282A:/
+341 "Release" sync / 1[56]:[^:]*:Haunt:2809:/
 
-354 "Possession" sync / 1[56]:Demon Chadarnook:2803:/
-359 "Earthquake" sync / 1[56]:Portrayal of Earth:2811:/
-359 "Flash Fire" sync / 1[56]:Portrayal of Fire:280B:/
-368 "Materialize" sync / 1[56]:Demon Chadarnook:282D:/
-381 "Demonic Stone" sync / 1[56]:Demon Chadarnook:2847:/
-384 "Demonic Howl" sync / 1[56]:Demon Chadarnook:282C:/
-394 "Demonic Shear" sync / 1[56]:Demon Chadarnook:282A:/
-404 "Demonic Howl" sync / 1[56]:Demon Chadarnook:282C:/
-415 "Release" sync / 1[56]:Demon Chadarnook:2804:/
+354 "Possession" sync / 1[56]:[^:]*:Demon Chadarnook:2803:/
+359 "Earthquake" sync / 1[56]:[^:]*:Portrayal of Earth:2811:/
+359 "Flash Fire" sync / 1[56]:[^:]*:Portrayal of Fire:280B:/
+368 "Materialize" sync / 1[56]:[^:]*:Demon Chadarnook:282D:/
+381 "Demonic Stone" sync / 1[56]:[^:]*:Demon Chadarnook:2847:/
+384 "Demonic Howl" sync / 1[56]:[^:]*:Demon Chadarnook:282C:/
+394 "Demonic Shear" sync / 1[56]:[^:]*:Demon Chadarnook:282A:/
+404 "Demonic Howl" sync / 1[56]:[^:]*:Demon Chadarnook:282C:/
+415 "Release" sync / 1[56]:[^:]*:Demon Chadarnook:2804:/
 # loop ends here
 
-428 "Possession" sync / 1[56]:Demon Chadarnook:2803:/ jump 288
+428 "Possession" sync / 1[56]:[^:]*:Demon Chadarnook:2803:/ jump 288
 433 "Flash Fire"
 439 "Demonic Wave"
 448 "Demonic Howl"

--- a/ui/raidboss/data/04-sb/raid/o6s.txt
+++ b/ui/raidboss/data/04-sb/raid/o6s.txt
@@ -7,96 +7,96 @@ hideall "--sync--"
 
 0 "Start" sync / 00:0044:[^:]*I have claimed the girl in the picture!/ window 0,1
 18 "--targetable--"
-21 "Demonic Howl" sync / 1[56]:Demon Chadarnook:282B:/ window 21,0
-31 "Demonic Shear" sync / 1[56]:Demon Chadarnook:2829:/
+21 "Demonic Howl" sync / 1[56]:[^:]*:Demon Chadarnook:282B:/ window 21,0
+31 "Demonic Shear" sync / 1[56]:[^:]*:Demon Chadarnook:2829:/
 
-57 "Possession" sync / 1[56]:Demon Chadarnook:2803:/ window 20,20
-62 "Flash Fire" sync / 1[56]:Portrayal of Fire:280A:/
-71 "Flash Gale" sync / 1[56]:Portrayal of Wind:2ABA:/
-73 "Demonic Howl" sync / 1[56]:Demon Chadarnook:282B:/
-87 "Poltergeist" sync / 1[56]:Goddess Chadarnook:2824:/
-92 "Demonic Shear" sync / 1[56]:Demon Chadarnook:2829:/
-98 "Divine Lure" sync / 1[56]:Goddess Chadarnook:2822:/
-100 "Demonic Howl" sync / 1[56]:Demon Chadarnook:282B:/
-109 "Demonic Pain" sync / 1[56]:Demon Chadarnook:2AEC:/
-121 "Demonic Howl" sync / 1[56]:Demon Chadarnook:282B:/
-130 "Release" sync / 1[56]:Demon Chadarnook:2804:/
+57 "Possession" sync / 1[56]:[^:]*:Demon Chadarnook:2803:/ window 20,20
+62 "Flash Fire" sync / 1[56]:[^:]*:Portrayal of Fire:280A:/
+71 "Flash Gale" sync / 1[56]:[^:]*:Portrayal of Wind:2ABA:/
+73 "Demonic Howl" sync / 1[56]:[^:]*:Demon Chadarnook:282B:/
+87 "Poltergeist" sync / 1[56]:[^:]*:Goddess Chadarnook:2824:/
+92 "Demonic Shear" sync / 1[56]:[^:]*:Demon Chadarnook:2829:/
+98 "Divine Lure" sync / 1[56]:[^:]*:Goddess Chadarnook:2822:/
+100 "Demonic Howl" sync / 1[56]:[^:]*:Demon Chadarnook:282B:/
+109 "Demonic Pain" sync / 1[56]:[^:]*:Demon Chadarnook:2AEC:/
+121 "Demonic Howl" sync / 1[56]:[^:]*:Demon Chadarnook:282B:/
+130 "Release" sync / 1[56]:[^:]*:Demon Chadarnook:2804:/
 
-143 "Possession" sync / 1[56]:Demon Chadarnook:2803:/ window 20
+143 "Possession" sync / 1[56]:[^:]*:Demon Chadarnook:2803:/ window 20
 150 "Easterlies" sync / 03:........:Easterly:/ 
-153 "Rock Hard" sync / 1[56]:Portrayal of Earth:2812:/
-155 "Demonic Shear" sync / 1[56]:Demon Chadarnook:2829:/
-164 "Demonic Howl" sync / 1[56]:Demon Chadarnook:282B:/
-166 "Featherlance" sync / 1[56]:Easterly:283E:/
-171 "Demonic Howl" sync / 1[56]:Demon Chadarnook:282B:/
-184 "Last Kiss" sync / 1[56]:Demon Chadarnook:2826:/
-195 "The Price" sync / 1[56]:Demon Chadarnook:2827:/
-198 "Demonic Howl" sync / 1[56]:Demon Chadarnook:282B:/
-200 "Poltergeist" sync / 1[56]:Goddess Chadarnook:2824:/
-208 "Demonic Shear" sync / 1[56]:Demon Chadarnook:2829:/
-211 "Divine Lure" sync / 1[56]:Goddess Chadarnook:2822:/
-216 "Demonic Storm" sync / 1[56]:Demon Chadarnook:2840:/
-225 "Demonic Howl" sync / 1[56]:Demon Chadarnook:282B:/
-238 "Release" sync / 1[56]:Demon Chadarnook:2804:/
+153 "Rock Hard" sync / 1[56]:[^:]*:Portrayal of Earth:2812:/
+155 "Demonic Shear" sync / 1[56]:[^:]*:Demon Chadarnook:2829:/
+164 "Demonic Howl" sync / 1[56]:[^:]*:Demon Chadarnook:282B:/
+166 "Featherlance" sync / 1[56]:[^:]*:Easterly:283E:/
+171 "Demonic Howl" sync / 1[56]:[^:]*:Demon Chadarnook:282B:/
+184 "Last Kiss" sync / 1[56]:[^:]*:Demon Chadarnook:2826:/
+195 "The Price" sync / 1[56]:[^:]*:Demon Chadarnook:2827:/
+198 "Demonic Howl" sync / 1[56]:[^:]*:Demon Chadarnook:282B:/
+200 "Poltergeist" sync / 1[56]:[^:]*:Goddess Chadarnook:2824:/
+208 "Demonic Shear" sync / 1[56]:[^:]*:Demon Chadarnook:2829:/
+211 "Divine Lure" sync / 1[56]:[^:]*:Goddess Chadarnook:2822:/
+216 "Demonic Storm" sync / 1[56]:[^:]*:Demon Chadarnook:2840:/
+225 "Demonic Howl" sync / 1[56]:[^:]*:Demon Chadarnook:282B:/
+238 "Release" sync / 1[56]:[^:]*:Demon Chadarnook:2804:/
 
-251 "Possession" sync / 1[56]:Demon Chadarnook:2803:/ window 20
-256 "Earthquake" sync / 1[56]:Portrayal of Earth:2810:/
-256 "Flash Fire" sync / 1[56]:Portrayal of Fire:280A:/
-261 "Flash Torrent" sync / 1[56]:Portrayal of Water:2AB9:/
-270 "Materialize" sync / 1[56]:Demon Chadarnook:282D:/
-281 "Demonic Pain" sync / 1[56]:Haunt:2AEC:/
-286 "Lullaby" sync / 1[56]:Goddess Chadarnook:2828:/
-294 "Demonic Howl" sync / 1[56]:Demon Chadarnook:282B:/
-300 "Demonic Howl" sync / 1[56]:Demon Chadarnook:282B:/
-306 "Demonic Shear" sync / 1[56]:Demon Chadarnook:2829:/
+251 "Possession" sync / 1[56]:[^:]*:Demon Chadarnook:2803:/ window 20
+256 "Earthquake" sync / 1[56]:[^:]*:Portrayal of Earth:2810:/
+256 "Flash Fire" sync / 1[56]:[^:]*:Portrayal of Fire:280A:/
+261 "Flash Torrent" sync / 1[56]:[^:]*:Portrayal of Water:2AB9:/
+270 "Materialize" sync / 1[56]:[^:]*:Demon Chadarnook:282D:/
+281 "Demonic Pain" sync / 1[56]:[^:]*:Haunt:2AEC:/
+286 "Lullaby" sync / 1[56]:[^:]*:Goddess Chadarnook:2828:/
+294 "Demonic Howl" sync / 1[56]:[^:]*:Demon Chadarnook:282B:/
+300 "Demonic Howl" sync / 1[56]:[^:]*:Demon Chadarnook:282B:/
+306 "Demonic Shear" sync / 1[56]:[^:]*:Demon Chadarnook:2829:/
 319 "Demonic Stone" duration 5
-329 "Last Kiss" sync / 1[56]:Demon Chadarnook:2826:/
-333 "Demonic Howl" sync / 1[56]:Demon Chadarnook:282B:/
-340 "The Price" sync / 1[56]:Demon Chadarnook:2827:/
-352 "Release" sync / 1[56]:Demon Chadarnook:2804:/
+329 "Last Kiss" sync / 1[56]:[^:]*:Demon Chadarnook:2826:/
+333 "Demonic Howl" sync / 1[56]:[^:]*:Demon Chadarnook:282B:/
+340 "The Price" sync / 1[56]:[^:]*:Demon Chadarnook:2827:/
+352 "Release" sync / 1[56]:[^:]*:Demon Chadarnook:2804:/
 
-365 "Possession" sync / 1[56]:Demon Chadarnook:2803:/ window 20
+365 "Possession" sync / 1[56]:[^:]*:Demon Chadarnook:2803:/ window 20
 373 "Easterlies" sync / 03:........:Easterly:/ 
-375 "Rock Hard" sync / 1[56]:Portrayal of Earth:2812:/
-376 "Demonic Wave" sync / 1[56]:Portrayal of Water:2830:/
-384 "Demonic Howl" sync / 1[56]:Demon Chadarnook:282B:/
-388 "Featherlance" sync / 1[56]:Easterly:283E:/
-396 "Materialize" sync / 1[56]:Demon Chadarnook:282D:/
-403 "Demonic Spout" sync / 1[56]:Demon Chadarnook:2834:/
-408 "Demonic Storm" sync / 1[56]:Demon Chadarnook:2840:/
-408 "Demonic Spout" sync / 1[56]:Demon Chadarnook:2836:/
-425 "Demonic Howl" sync / 1[56]:Demon Chadarnook:282B:/
-438 "Demonic Pain" sync / 1[56]:Demon Chadarnook:2AEC:/
-443 "Last Kiss" sync / 1[56]:Demon Chadarnook:2826:/
-447 "Flash Torrent" sync / 1[56]:Demon Chadarnook:280C:/
-449 "Flash Flood" sync / 1[56]:Haunt:2AEA:/
-454 "The Price" sync / 1[56]:Demon Chadarnook:2827:/
-454 "Demonic Howl" sync / 1[56]:Demon Chadarnook:282B:/
-469 "Demonic Shear" sync / 1[56]:Demon Chadarnook:2829:/
-482 "Release" sync / 1[56]:Demon Chadarnook:2804:/
+375 "Rock Hard" sync / 1[56]:[^:]*:Portrayal of Earth:2812:/
+376 "Demonic Wave" sync / 1[56]:[^:]*:Portrayal of Water:2830:/
+384 "Demonic Howl" sync / 1[56]:[^:]*:Demon Chadarnook:282B:/
+388 "Featherlance" sync / 1[56]:[^:]*:Easterly:283E:/
+396 "Materialize" sync / 1[56]:[^:]*:Demon Chadarnook:282D:/
+403 "Demonic Spout" sync / 1[56]:[^:]*:Demon Chadarnook:2834:/
+408 "Demonic Storm" sync / 1[56]:[^:]*:Demon Chadarnook:2840:/
+408 "Demonic Spout" sync / 1[56]:[^:]*:Demon Chadarnook:2836:/
+425 "Demonic Howl" sync / 1[56]:[^:]*:Demon Chadarnook:282B:/
+438 "Demonic Pain" sync / 1[56]:[^:]*:Demon Chadarnook:2AEC:/
+443 "Last Kiss" sync / 1[56]:[^:]*:Demon Chadarnook:2826:/
+447 "Flash Torrent" sync / 1[56]:[^:]*:Demon Chadarnook:280C:/
+449 "Flash Flood" sync / 1[56]:[^:]*:Haunt:2AEA:/
+454 "The Price" sync / 1[56]:[^:]*:Demon Chadarnook:2827:/
+454 "Demonic Howl" sync / 1[56]:[^:]*:Demon Chadarnook:282B:/
+469 "Demonic Shear" sync / 1[56]:[^:]*:Demon Chadarnook:2829:/
+482 "Release" sync / 1[56]:[^:]*:Demon Chadarnook:2804:/
 
-495 "Possession" sync / 1[56]:Demon Chadarnook:2803:/ window 20
-500 "Earthquake" sync / 1[56]:Portrayal of Earth:2810:/
-500 "Flash Fire" sync / 1[56]:Portrayal of Fire:280A:/
-509 "Flash Gale" sync / 1[56]:Portrayal of Wind:2ABA:/
-511 "Demonic Howl" sync / 1[56]:Demon Chadarnook:282B:/
-519 "Demonic Shear" sync / 1[56]:Demon Chadarnook:2829:/
-531 "Materialize" sync / 1[56]:Demon Chadarnook:282D:/
-538 "Poltergeist" sync / 1[56]:Goddess Chadarnook:2824:/
+495 "Possession" sync / 1[56]:[^:]*:Demon Chadarnook:2803:/ window 20
+500 "Earthquake" sync / 1[56]:[^:]*:Portrayal of Earth:2810:/
+500 "Flash Fire" sync / 1[56]:[^:]*:Portrayal of Fire:280A:/
+509 "Flash Gale" sync / 1[56]:[^:]*:Portrayal of Wind:2ABA:/
+511 "Demonic Howl" sync / 1[56]:[^:]*:Demon Chadarnook:282B:/
+519 "Demonic Shear" sync / 1[56]:[^:]*:Demon Chadarnook:2829:/
+531 "Materialize" sync / 1[56]:[^:]*:Demon Chadarnook:282D:/
+538 "Poltergeist" sync / 1[56]:[^:]*:Goddess Chadarnook:2824:/
 546 "Demonic Stone" duration 5
-552 "Demonic Howl" sync / 1[56]:Demon Chadarnook:282B:/
-554 "Divine Lure" sync / 1[56]:Goddess Chadarnook:2822:/
-560 "Demonic Shear" sync / 1[56]:Demon Chadarnook:2829:/
-573 "Demonic Pain" sync / 1[56]:Demon Chadarnook:2AEC:/
-581 "Demonic Howl" sync / 1[56]:Demon Chadarnook:282B:/
-590 "Release" sync / 1[56]:Demon Chadarnook:2804:/
+552 "Demonic Howl" sync / 1[56]:[^:]*:Demon Chadarnook:282B:/
+554 "Divine Lure" sync / 1[56]:[^:]*:Goddess Chadarnook:2822:/
+560 "Demonic Shear" sync / 1[56]:[^:]*:Demon Chadarnook:2829:/
+573 "Demonic Pain" sync / 1[56]:[^:]*:Demon Chadarnook:2AEC:/
+581 "Demonic Howl" sync / 1[56]:[^:]*:Demon Chadarnook:282B:/
+590 "Release" sync / 1[56]:[^:]*:Demon Chadarnook:2804:/
 
-603 "Possession" sync / 1[56]:Demon Chadarnook:2803:/ window 20
+603 "Possession" sync / 1[56]:[^:]*:Demon Chadarnook:2803:/ window 20
 611 "Easterlies" sync / 03:........:Easterly:/ 
-613 "Rock Hard" sync / 1[56]:Portrayal of Earth:2812:/
-614 "Demonic Wave" sync / 1[56]:Portrayal of Water:2830:/
-622 "Demonic Howl" sync / 1[56]:Demon Chadarnook:282B:/
-626 "Featherlance" sync / 1[56]:Easterly:283E:/
+613 "Rock Hard" sync / 1[56]:[^:]*:Portrayal of Earth:2812:/
+614 "Demonic Wave" sync / 1[56]:[^:]*:Portrayal of Water:2830:/
+622 "Demonic Howl" sync / 1[56]:[^:]*:Demon Chadarnook:282B:/
+626 "Featherlance" sync / 1[56]:[^:]*:Easterly:283E:/
 
-626 "--sync--" sync / 1[56]:284D:Demon Chadarnook:/
+626 "--sync--" sync / 1[56]:[^:]*:284D:Demon Chadarnook:/
 641 "Enrage"

--- a/ui/raidboss/data/04-sb/raid/o7n.txt
+++ b/ui/raidboss/data/04-sb/raid/o7n.txt
@@ -6,83 +6,83 @@ hideall "--sync--"
 0.0 "--Reset--" sync / 21:........:40000010:/ window 100000 jump 0
 
 0 "Start" sync / 00:0044:[^:]*:WEAPON SYSTEMS ONLINE/
-11 "Magitek Ray" sync / 1[56]:Guardian:276B:/ window 11,10
-21 "Arm And Hammer" sync / 1[56]:Guardian:276C:/
-31 "Prey" sync / 1[56]:Guardian:276D:/
-39 "Load" sync / 1[56]:Guardian:275C:/
+11 "Magitek Ray" sync / 1[56]:[^:]*:Guardian:276B:/ window 11,10
+21 "Arm And Hammer" sync / 1[56]:[^:]*:Guardian:276C:/
+31 "Prey" sync / 1[56]:[^:]*:Guardian:276D:/
+39 "Load" sync / 1[56]:[^:]*:Guardian:275C:/
 
 # Ultros
 200 "--sync--" sync / 1A:5D1:Ultros  Simulation:[^:]*:[^:]*:[^:]*:[^:]*:Guardian:/ window 2000,2000
-203 "Ink" sync / 1[56]:Guardian:275D:/
-209 "Diffractive Plasma" sync / 1[56]:Guardian:276E:/
-219 "Tentacle Simulation" sync / 1[56]:Guardian:275E:/
-223 "Tentacle" sync / 1[56]:Tentacle:275F:/
-229 "Wallop" sync / 1[56]:Tentacle:2760:/
-231 "Run Program" sync / 1[56]:Guardian:276F:/
-237 "--untargetable--" sync / 1[56]:Guardian:2937:/
+203 "Ink" sync / 1[56]:[^:]*:Guardian:275D:/
+209 "Diffractive Plasma" sync / 1[56]:[^:]*:Guardian:276E:/
+219 "Tentacle Simulation" sync / 1[56]:[^:]*:Guardian:275E:/
+223 "Tentacle" sync / 1[56]:[^:]*:Tentacle:275F:/
+229 "Wallop" sync / 1[56]:[^:]*:Tentacle:2760:/
+231 "Run Program" sync / 1[56]:[^:]*:Guardian:276F:/
+237 "--untargetable--" sync / 1[56]:[^:]*:Guardian:2937:/
 244 "Chain Cannon" duration 2
-250 "Main Cannon" sync / 1[56]:Guardian:2771:/
-253 "--targetable--" sync / 1[56]:Guardian:2938:/
-260 "Diffractive Plasma" sync / 1[56]:Guardian:276E:/
-266 "Magitek Ray" sync / 1[56]:Guardian:276B:/ # drift 0.35
-275 "Arm And Hammer" sync / 1[56]:Guardian:276C:/
-284 "Load" sync / 1[56]:Guardian:275C:/
+250 "Main Cannon" sync / 1[56]:[^:]*:Guardian:2771:/
+253 "--targetable--" sync / 1[56]:[^:]*:Guardian:2938:/
+260 "Diffractive Plasma" sync / 1[56]:[^:]*:Guardian:276E:/
+266 "Magitek Ray" sync / 1[56]:[^:]*:Guardian:276B:/ # drift 0.35
+275 "Arm And Hammer" sync / 1[56]:[^:]*:Guardian:276C:/
+284 "Load" sync / 1[56]:[^:]*:Guardian:275C:/
 
 # Dadaluma
 400 "--sync--" sync / 1A:5D3:Dadaluma Simulation:[^:]*:[^:]*:[^:]*:[^:]*:Guardian:/ window 2000,2000
-404 "Shockwave" sync / 1[56]:Guardian:2766:/
-415 "--sync--" sync / 1[56]:Guardian:276B:/ jump 1215 # rare version
-424 "Chakra Burst" sync / 1[56]:Guardian:276A:/
-427 "Run Program" sync / 1[56]:Guardian:276F:/
+404 "Shockwave" sync / 1[56]:[^:]*:Guardian:2766:/
+415 "--sync--" sync / 1[56]:[^:]*:Guardian:276B:/ jump 1215 # rare version
+424 "Chakra Burst" sync / 1[56]:[^:]*:Guardian:276A:/
+427 "Run Program" sync / 1[56]:[^:]*:Guardian:276F:/
 436 "Aura Cannon"
-441 "Prey" sync / 1[56]:Guardian:276D:/
-449 "Magitek Ray" sync / 1[56]:Guardian:276B:/
-460 "Load" sync / 1[56]:Guardian:275C:/
+441 "Prey" sync / 1[56]:[^:]*:Guardian:276D:/
+449 "Magitek Ray" sync / 1[56]:[^:]*:Guardian:276B:/
+460 "Load" sync / 1[56]:[^:]*:Guardian:275C:/
 
 # Air Force
 600 "--sync--" sync / 1A:5D2:Air Force Simulation:[^:]*:[^:]*:[^:]*:[^:]*:Guardian:/ window 2000,2000
-604 "Diffractive Laser" sync / 1[56]:Guardian:2761:/
-613 "Missile Simulation" sync / 1[56]:Guardian:2764:/
-614 "--sync--" sync / 1[56]:Guardian:276F:/ jump 1014 # rare version
-623 "Diffractive Plasma" sync / 1[56]:Guardian:276E:/
-637 "Bomb Deployment" sync / 1[56]:Guardian:2762:/
-648 "Arm And Hammer" sync / 1[56]:Guardian:276C:/
-659 "Run Program" sync / 1[56]:Guardian:276F:/
-672 "Prey" sync / 1[56]:Guardian:276D:/
+604 "Diffractive Laser" sync / 1[56]:[^:]*:Guardian:2761:/
+613 "Missile Simulation" sync / 1[56]:[^:]*:Guardian:2764:/
+614 "--sync--" sync / 1[56]:[^:]*:Guardian:276F:/ jump 1014 # rare version
+623 "Diffractive Plasma" sync / 1[56]:[^:]*:Guardian:276E:/
+637 "Bomb Deployment" sync / 1[56]:[^:]*:Guardian:2762:/
+648 "Arm And Hammer" sync / 1[56]:[^:]*:Guardian:276C:/
+659 "Run Program" sync / 1[56]:[^:]*:Guardian:276F:/
+672 "Prey" sync / 1[56]:[^:]*:Guardian:276D:/
 678 "Plane Laser"
-682 "Diffractive Plasma" sync / 1[56]:Guardian:276E:/
-688 "Load" sync / 1[56]:Guardian:275C:/
+682 "Diffractive Plasma" sync / 1[56]:[^:]*:Guardian:276E:/
+688 "Load" sync / 1[56]:[^:]*:Guardian:275C:/
 
 # Bibliotaph
 800 "--sync--" sync / 1A:5D4:Bibliotaph Simulation:[^:]*:[^:]*:[^:]*:[^:]*:Guardian:/ window 2000,2000
-817 "Demon Simulation" sync / 1[56]:Guardian:2752:/
-824 "Run Program" sync / 1[56]:Guardian:276F:/
-838 "Burst/Darkness" sync / 1[56]:Bibliotaph:29(BF|C0):/
-840 "Magitek Ray" sync / 1[56]:Guardian:276B:/
-851 "Arm And Hammer" sync / 1[56]:Guardian:276C:/
-860 "Diffractive Plasma" sync / 1[56]:Guardian:276E:/
-870 "Load" sync / 1[56]:Guardian:275C:/
+817 "Demon Simulation" sync / 1[56]:[^:]*:Guardian:2752:/
+824 "Run Program" sync / 1[56]:[^:]*:Guardian:276F:/
+838 "Burst/Darkness" sync / 1[56]:[^:]*:Bibliotaph:29(BF|C0):/
+840 "Magitek Ray" sync / 1[56]:[^:]*:Guardian:276B:/
+851 "Arm And Hammer" sync / 1[56]:[^:]*:Guardian:276C:/
+860 "Diffractive Plasma" sync / 1[56]:[^:]*:Guardian:276E:/
+870 "Load" sync / 1[56]:[^:]*:Guardian:275C:/
 
 # Air Force later
 1000 "--sync--"
-1004 "Diffractive Laser" sync / 1[56]:Guardian:2761:/
-1014 "Run Program" sync / 1[56]:Guardian:276F:/
-1033 "Missile Simulation" sync / 1[56]:Guardian:2764:/
+1004 "Diffractive Laser" sync / 1[56]:[^:]*:Guardian:2761:/
+1014 "Run Program" sync / 1[56]:[^:]*:Guardian:276F:/
+1033 "Missile Simulation" sync / 1[56]:[^:]*:Guardian:2764:/
 1034 "Plane Laser"
-1036 "--untargetable--" sync / 1[56]:Guardian:2937:/
+1036 "--untargetable--" sync / 1[56]:[^:]*:Guardian:2937:/
 1043 "Chain Cannon" duration 2
-1049 "Main Cannon" sync / 1[56]:Guardian:2771:/
-1052 "--targetable--" sync / 1[56]:Guardian:2938:/
-1062 "Bomb Deployment" sync / 1[56]:Guardian:2762:/
-1085 "Load" sync / 1[56]:Guardian:275C:/
+1049 "Main Cannon" sync / 1[56]:[^:]*:Guardian:2771:/
+1052 "--targetable--" sync / 1[56]:[^:]*:Guardian:2938:/
+1062 "Bomb Deployment" sync / 1[56]:[^:]*:Guardian:2762:/
+1085 "Load" sync / 1[56]:[^:]*:Guardian:275C:/
 
 # Dadaluma later
 1200 "--sync--"
-1204 "Shockwave" sync / 1[56]:Guardian:2766:/
-1215 "Magitek Ray" sync / 1[56]:Guardian:276B:/
-1224 "Chakra Burst" sync / 1[56]:Guardian:276A:/
-1227 "Magitek Ray" sync / 1[56]:Guardian:276B:/
-1238 "Diffractive Plasma" sync / 1[56]:Guardian:276E:/
-1246 "Prey" sync / 1[56]:Guardian:276D:/
-1254 "Arm And Hammer" sync / 1[56]:Guardian:276C:/
-1266 "Load" sync / 1[56]:Guardian:275C:/
+1204 "Shockwave" sync / 1[56]:[^:]*:Guardian:2766:/
+1215 "Magitek Ray" sync / 1[56]:[^:]*:Guardian:276B:/
+1224 "Chakra Burst" sync / 1[56]:[^:]*:Guardian:276A:/
+1227 "Magitek Ray" sync / 1[56]:[^:]*:Guardian:276B:/
+1238 "Diffractive Plasma" sync / 1[56]:[^:]*:Guardian:276E:/
+1246 "Prey" sync / 1[56]:[^:]*:Guardian:276D:/
+1254 "Arm And Hammer" sync / 1[56]:[^:]*:Guardian:276C:/
+1266 "Load" sync / 1[56]:[^:]*:Guardian:275C:/

--- a/ui/raidboss/data/04-sb/raid/o7s.txt
+++ b/ui/raidboss/data/04-sb/raid/o7s.txt
@@ -5,95 +5,95 @@ hideall "--sync--"
 0.0 "--Reset--" sync / 21:........:40000010:/ window 100000 jump 0
 
 0 "Start" sync / 00:0044:[^:]*:WEAPON SYSTEMS ONLINE/ window 0,1
-11 "Magitek Ray" sync / 1[56]:Guardian:2788:/ window 11,10
-21 "Arm And Hammer" sync / 1[56]:Guardian:2789:/
-31 "Atomic Ray" sync / 1[56]:Guardian:278D:/
-40 "Prey" sync / 1[56]:Guardian:278A:/
-49 "Load ??" sync / 1[56]:Guardian:275C:/
+11 "Magitek Ray" sync / 1[56]:[^:]*:Guardian:2788:/ window 11,10
+21 "Arm And Hammer" sync / 1[56]:[^:]*:Guardian:2789:/
+31 "Atomic Ray" sync / 1[56]:[^:]*:Guardian:278D:/
+40 "Prey" sync / 1[56]:[^:]*:Guardian:278A:/
+49 "Load ??" sync / 1[56]:[^:]*:Guardian:275C:/
 50 "--sync--" sync / 1A:5D3:Dadaluma Simulation:[^:]+:[^:]*:[^:]*:[^:]*:Guardian:/ jump 1050
 52 "Shockwave?"
 
 # This is Version A of the encounter, with Bibliotaph first
 
-59 "Demon Simulation" sync / 1[56]:Guardian:2B36:/
+59 "Demon Simulation" sync / 1[56]:[^:]*:Guardian:2B36:/
 
 # Dadaluma
-67 "Load Dada / Skip Ultros" sync / 1[56]:Guardian:2773:/
-70 "Shockwave" sync / 1[56]:Guardian:2783:/
-77 "Missile Simulation" sync / 1[56]:Guardian:2764:/
-92 "Chakra Burst" sync / 1[56]:Guardian:2787:/
-95 "Run Dada (NW)" sync / 1[56]:Guardian:276F:/
-108 "Magitek Ray" sync / 1[56]:Guardian:2788:/
+67 "Load Dada / Skip Ultros" sync / 1[56]:[^:]*:Guardian:2773:/
+70 "Shockwave" sync / 1[56]:[^:]*:Guardian:2783:/
+77 "Missile Simulation" sync / 1[56]:[^:]*:Guardian:2764:/
+92 "Chakra Burst" sync / 1[56]:[^:]*:Guardian:2787:/
+95 "Run Dada (NW)" sync / 1[56]:[^:]*:Guardian:276F:/
+108 "Magitek Ray" sync / 1[56]:[^:]*:Guardian:2788:/
 113 "(H) Aura Cannon"
 123 "(DPS) Aura Cannon"
-124 "Arm And Hammer" sync / 1[56]:Guardian:2789:/
-136 "Prey" sync / 1[56]:Guardian:278A:/
-144 "Magitek Ray" sync / 1[56]:Guardian:2788:/
+124 "Arm And Hammer" sync / 1[56]:[^:]*:Guardian:2789:/
+136 "Prey" sync / 1[56]:[^:]*:Guardian:278A:/
+144 "Magitek Ray" sync / 1[56]:[^:]*:Guardian:2788:/
 
 # Ultros
-153 "Retrieve Ultros" sync / 1[56]:Guardian:2774:/
-154 "Ink" sync / 1[56]:Guardian:277D:/
-163 "Copy Ultros" sync / 1[56]:Guardian:2775:/
-170 "Diffractive Plasma" sync / 1[56]:Guardian:278B:/
-179 "Tentacle Simulation" sync / 1[56]:Guardian:275E:/
+153 "Retrieve Ultros" sync / 1[56]:[^:]*:Guardian:2774:/
+154 "Ink" sync / 1[56]:[^:]*:Guardian:277D:/
+163 "Copy Ultros" sync / 1[56]:[^:]*:Guardian:2775:/
+170 "Diffractive Plasma" sync / 1[56]:[^:]*:Guardian:278B:/
+179 "Tentacle Simulation" sync / 1[56]:[^:]*:Guardian:275E:/
 183 "Tentacle"
 189 "Wallop"
-191 "Run Ultros (NE)" sync / 1[56]:Guardian:276F:/
+191 "Run Ultros (NE)" sync / 1[56]:[^:]*:Guardian:276F:/
 198 "Interrupt Stoneskin" duration 4
-200 "--untargetable--" sync / 1[56]:Guardian:2937:/
+200 "--untargetable--" sync / 1[56]:[^:]*:Guardian:2937:/
 207 "Chain Cannon" duration 2
-213 "Main Cannon" sync / 1[56]:Guardian:2790:/ window 10,10
-216 "--targetable--" sync / 1[56]:Guardian:2938:/
-228 "Diffractive Plasma" sync / 1[56]:Guardian:278B:/
+213 "Main Cannon" sync / 1[56]:[^:]*:Guardian:2790:/ window 10,10
+216 "--targetable--" sync / 1[56]:[^:]*:Guardian:2938:/
+228 "Diffractive Plasma" sync / 1[56]:[^:]*:Guardian:278B:/
 
 # Air Force
-236 "Load Air Force" sync / 1[56]:Guardian:275C:/
-239 "Diffractive Laser" sync / 1[56]:Guardian:2780:/
-254 "Missile Simulation" sync / 1[56]:Guardian:2764:/
-264 "Run Air Force" sync / 1[56]:Guardian:276F:/
-278 "Bomb Deployment" sync / 1[56]:Guardian:2762:/
+236 "Load Air Force" sync / 1[56]:[^:]*:Guardian:275C:/
+239 "Diffractive Laser" sync / 1[56]:[^:]*:Guardian:2780:/
+254 "Missile Simulation" sync / 1[56]:[^:]*:Guardian:2764:/
+264 "Run Air Force" sync / 1[56]:[^:]*:Guardian:276F:/
+278 "Bomb Deployment" sync / 1[56]:[^:]*:Guardian:2762:/
 279 "Plane Laser" duration 2
 287 "Plane Laser" duration 2
-290 "Arm And Hammer" sync / 1[56]:Guardian:2789:/
-298 "Magitek Ray" sync / 1[56]:Guardian:2788:/
+290 "Arm And Hammer" sync / 1[56]:[^:]*:Guardian:2789:/
+298 "Magitek Ray" sync / 1[56]:[^:]*:Guardian:2788:/
 
 # Virus
-306 "Virus" sync / 1[56]:Guardian:2773:/
+306 "Virus" sync / 1[56]:[^:]*:Guardian:2773:/
 309 "Aether Rot"
-319 "Magnetism/Repel" sync / 1[56]:Fire Control System:2779:/
-332 "Diffractive Plasma" sync / 1[56]:Guardian:278B:/
-344 "Diffractive Plasma" sync / 1[56]:Guardian:278B:/
-356 "Prey" sync / 1[56]:Guardian:278A:/
-366 "Viral Weapon" sync / 1[56]:Guardian:277C:/
+319 "Magnetism/Repel" sync / 1[56]:[^:]*:Fire Control System:2779:/
+332 "Diffractive Plasma" sync / 1[56]:[^:]*:Guardian:278B:/
+344 "Diffractive Plasma" sync / 1[56]:[^:]*:Guardian:278B:/
+356 "Prey" sync / 1[56]:[^:]*:Guardian:278A:/
+366 "Viral Weapon" sync / 1[56]:[^:]*:Guardian:277C:/
 367 "Temporary Misdirection" duration 15
-372 "Magitek Ray" sync / 1[56]:Guardian:2788:/
-375 "--untargetable--" sync / 1[56]:Guardian:2937:/
+372 "Magitek Ray" sync / 1[56]:[^:]*:Guardian:2788:/
+375 "--untargetable--" sync / 1[56]:[^:]*:Guardian:2937:/
 382 "Chain Cannon" duration 2
-388 "Main Cannon" sync / 1[56]:Guardian:2790:/
+388 "Main Cannon" sync / 1[56]:[^:]*:Guardian:2790:/
 389 "Radar" duration 2
-391 "--targetable--" sync / 1[56]:Guardian:2938:/
-400 "Arm And Hammer" sync / 1[56]:Guardian:2789:/
-408 "Diffractive Plasma" sync / 1[56]:Guardian:278B:/
+391 "--targetable--" sync / 1[56]:[^:]*:Guardian:2938:/
+400 "Arm And Hammer" sync / 1[56]:[^:]*:Guardian:2789:/
+408 "Diffractive Plasma" sync / 1[56]:[^:]*:Guardian:278B:/
 
 # Ultros
-416 "Paste Ultros" sync / 1[56]:Guardian:2776:/
-417 "Ink" sync / 1[56]:Guardian:277D:/
-424 "Tentacle Simulation" sync / 1[56]:Guardian:275E:/
-430 "Bomb Deployment" sync / 1[56]:Guardian:2762:/
-439 "Atomic Ray" sync / 1[56]:Guardian:278D:/
-444 "Magitek Ray" sync / 1[56]:Guardian:2788:/
-453 "Diffractive Plasma" sync / 1[56]:Guardian:278B:/
-463 "Run Ultros (SW)" sync / 1[56]:Guardian:276F:/
-469 "Missile Simulation" sync / 1[56]:Guardian:2764:/
+416 "Paste Ultros" sync / 1[56]:[^:]*:Guardian:2776:/
+417 "Ink" sync / 1[56]:[^:]*:Guardian:277D:/
+424 "Tentacle Simulation" sync / 1[56]:[^:]*:Guardian:275E:/
+430 "Bomb Deployment" sync / 1[56]:[^:]*:Guardian:2762:/
+439 "Atomic Ray" sync / 1[56]:[^:]*:Guardian:278D:/
+444 "Magitek Ray" sync / 1[56]:[^:]*:Guardian:2788:/
+453 "Diffractive Plasma" sync / 1[56]:[^:]*:Guardian:278B:/
+463 "Run Ultros (SW)" sync / 1[56]:[^:]*:Guardian:276F:/
+469 "Missile Simulation" sync / 1[56]:[^:]*:Guardian:2764:/
 472 "Interrupt Stoneskin" duration 4
-474 "--untargetable--" sync / 1[56]:Guardian:2937:/
+474 "--untargetable--" sync / 1[56]:[^:]*:Guardian:2937:/
 481 "Chain Cannon" duration 2
-487 "Main Cannon" sync / 1[56]:Guardian:2790:/
-490 "--targetable--" sync / 1[56]:Guardian:2937:/
-499 "Diffractive Plasma" sync / 1[56]:Guardian:278B:/
+487 "Main Cannon" sync / 1[56]:[^:]*:Guardian:2790:/
+490 "--targetable--" sync / 1[56]:[^:]*:Guardian:2937:/
+499 "Diffractive Plasma" sync / 1[56]:[^:]*:Guardian:278B:/
 
 # Divergence point
-509 "Load/Skip ???" sync / 1[56]:Guardian:(275C|2773):/
+509 "Load/Skip ???" sync / 1[56]:[^:]*:Guardian:(275C|2773):/
 510 "--sync--" sync / 1A:5D4:Bibliotaph Simulation:[^:]+:[^:]*:[^:]*:[^:]*:Guardian:/ jump 2510       # Bibliotaph buff, jump to A1
 510 "--sync--" sync / 1A:5D3:Dadaluma Simulation:[^:]+:[^:]*:[^:]*:[^:]*:Guardian:/ jump 3510         # Dadaluma buff, jump to A2
 512 "Shockwave?"
@@ -104,28 +104,28 @@ hideall "--sync--"
 ########################################################
 
 # Bibliotaph
-2509 "Load Biblio" sync / 1[56]:Guardian:(275C|2773):/
+2509 "Load Biblio" sync / 1[56]:[^:]*:Guardian:(275C|2773):/
 2518 "Radar" duration 2
-2519 "Demon Simulation" sync / 1[56]:Guardian:2B36:/
-2532 "Run Biblio" sync / 1[56]:Guardian:276F:/
-2539 "Diffractive Plasma" sync / 1[56]:Guardian:278B:/
-2546 "Diffractive Plasma" sync / 1[56]:Guardian:278B:/
-2553 "Diffractive Plasma" sync / 1[56]:Guardian:278B:/
-2561 "Prey" sync / 1[56]:Guardian:278A:/
-2570 "Magitek Ray" sync / 1[56]:Guardian:2788:/
-2579 "Diffractive Plasma" sync / 1[56]:Guardian:278B:/
+2519 "Demon Simulation" sync / 1[56]:[^:]*:Guardian:2B36:/
+2532 "Run Biblio" sync / 1[56]:[^:]*:Guardian:276F:/
+2539 "Diffractive Plasma" sync / 1[56]:[^:]*:Guardian:278B:/
+2546 "Diffractive Plasma" sync / 1[56]:[^:]*:Guardian:278B:/
+2553 "Diffractive Plasma" sync / 1[56]:[^:]*:Guardian:278B:/
+2561 "Prey" sync / 1[56]:[^:]*:Guardian:278A:/
+2570 "Magitek Ray" sync / 1[56]:[^:]*:Guardian:2788:/
+2579 "Diffractive Plasma" sync / 1[56]:[^:]*:Guardian:278B:/
 
 # Dadaluma
-2590 "Load Dada" sync / 1[56]:Guardian:(275C|2774):/
-2593 "Shockwave" sync / 1[56]:Guardian:2783:/
+2590 "Load Dada" sync / 1[56]:[^:]*:Guardian:(275C|2774):/
+2593 "Shockwave" sync / 1[56]:[^:]*:Guardian:2783:/
 2597 "Radar" duration 2
-2603 "Missile Simulation" sync / 1[56]:Guardian:2764:/
-2612 "Atomic Ray" sync / 1[56]:Guardian:278D:/
-2617 "Chakra Burst" sync / 1[56]:Guardian:2787:/
-2629 "Prey" sync / 1[56]:Guardian:278A:/
-2635 "Magitek Ray" sync / 1[56]:Guardian:2788:/
-2643 "Diffractive Plasma" sync / 1[56]:Guardian:278B:/
-2648 "--sync--" sync / 14:Guardian:(275C|2773):/ jump 648          # Load/Skip starts casting, return to A
+2603 "Missile Simulation" sync / 1[56]:[^:]*:Guardian:2764:/
+2612 "Atomic Ray" sync / 1[56]:[^:]*:Guardian:278D:/
+2617 "Chakra Burst" sync / 1[56]:[^:]*:Guardian:2787:/
+2629 "Prey" sync / 1[56]:[^:]*:Guardian:278A:/
+2635 "Magitek Ray" sync / 1[56]:[^:]*:Guardian:2788:/
+2643 "Diffractive Plasma" sync / 1[56]:[^:]*:Guardian:278B:/
+2648 "--sync--" sync / 14:[^:]*:Guardian:(275C|2773):/ jump 648          # Load/Skip starts casting, return to A
 
 # Should be unreachable, only here for visual continuity before/after jump
 2653 "Load Air Force"
@@ -137,28 +137,28 @@ hideall "--sync--"
 #### Divergent path, Version A2: Dadaluma->Biblio
 
 # Dadaluma
-3509 "Load Dada" sync / 1[56]:Guardian:(275C|2773):/
-3512 "Shockwave" sync / 1[56]:Guardian:2783:/
+3509 "Load Dada" sync / 1[56]:[^:]*:Guardian:(275C|2773):/
+3512 "Shockwave" sync / 1[56]:[^:]*:Guardian:2783:/
 3516 "Radar" duration 2
-3522 "Missile Simulation" sync / 1[56]:Guardian:2764:/
-3531 "Atomic Ray" sync / 1[56]:Guardian:278D:/
-3536 "Chakra Burst" sync / 1[56]:Guardian:2787:/
-3548 "Prey" sync / 1[56]:Guardian:278A:/
-3554 "Magitek Ray" sync / 1[56]:Guardian:2788:/
-3562 "Diffractive Plasma" sync / 1[56]:Guardian:278B:/
+3522 "Missile Simulation" sync / 1[56]:[^:]*:Guardian:2764:/
+3531 "Atomic Ray" sync / 1[56]:[^:]*:Guardian:278D:/
+3536 "Chakra Burst" sync / 1[56]:[^:]*:Guardian:2787:/
+3548 "Prey" sync / 1[56]:[^:]*:Guardian:278A:/
+3554 "Magitek Ray" sync / 1[56]:[^:]*:Guardian:2788:/
+3562 "Diffractive Plasma" sync / 1[56]:[^:]*:Guardian:278B:/
 
 # Bibliotaph
-3572 "Load Biblio" sync / 1[56]:Guardian:(275C|2774):/
+3572 "Load Biblio" sync / 1[56]:[^:]*:Guardian:(275C|2774):/
 3581 "Radar" duration 2
-3582 "Demon Simulation" sync / 1[56]:Guardian:2B36:/
-3595 "Run Biblio" sync / 1[56]:Guardian:276F:/
-3602 "Diffractive Plasma" sync / 1[56]:Guardian:278B:/
-3609 "Diffractive Plasma" sync / 1[56]:Guardian:278B:/
-3616 "Diffractive Plasma" sync / 1[56]:Guardian:278B:/
-3624 "Prey" sync / 1[56]:Guardian:278A:/
-3633 "Magitek Ray" sync / 1[56]:Guardian:2788:/
-3642 "Diffractive Plasma" sync / 1[56]:Guardian:278B:/
-3648 "--sync--" sync / 14:Guardian:(275C|2773):/ jump 648 # Load/Skip starts casting, return to A
+3582 "Demon Simulation" sync / 1[56]:[^:]*:Guardian:2B36:/
+3595 "Run Biblio" sync / 1[56]:[^:]*:Guardian:276F:/
+3602 "Diffractive Plasma" sync / 1[56]:[^:]*:Guardian:278B:/
+3609 "Diffractive Plasma" sync / 1[56]:[^:]*:Guardian:278B:/
+3616 "Diffractive Plasma" sync / 1[56]:[^:]*:Guardian:278B:/
+3624 "Prey" sync / 1[56]:[^:]*:Guardian:278A:/
+3633 "Magitek Ray" sync / 1[56]:[^:]*:Guardian:2788:/
+3642 "Diffractive Plasma" sync / 1[56]:[^:]*:Guardian:278B:/
+3648 "--sync--" sync / 14:[^:]*:Guardian:(275C|2773):/ jump 648 # Load/Skip starts casting, return to A
 
 # Should be unreachable, only here for visual continuity before/after jump
 3653 "Load Air Force"
@@ -173,19 +173,19 @@ hideall "--sync--"
 ##########################################################
 
 # Air Force
-653 "Load Air Force" sync / 1[56]:Guardian:(275C|2773):/
-656 "Diffractive Laser" sync / 1[56]:Guardian:2780:/
+653 "Load Air Force" sync / 1[56]:[^:]*:Guardian:(275C|2773):/
+656 "Diffractive Laser" sync / 1[56]:[^:]*:Guardian:2780:/
 659 "Radar" duration 2
-666 "Diffractive Plasma" sync / 1[56]:Guardian:278B:/
-678 "Run Air Force" sync / 1[56]:Guardian:276F:/
-684 "Bomb Deployment" sync / 1[56]:Guardian:2762:/
+666 "Diffractive Plasma" sync / 1[56]:[^:]*:Guardian:278B:/
+678 "Run Air Force" sync / 1[56]:[^:]*:Guardian:276F:/
+684 "Bomb Deployment" sync / 1[56]:[^:]*:Guardian:2762:/
 685 "Plane Laser" duration 2
-691 "Arm And Hammer" sync / 1[56]:Guardian:2789:/
+691 "Arm And Hammer" sync / 1[56]:[^:]*:Guardian:2789:/
 693 "Plane Laser" duration 2
-699 "Diffractive Plasma" sync / 1[56]:Guardian:278B:/
+699 "Diffractive Plasma" sync / 1[56]:[^:]*:Guardian:278B:/
 
-700 "--sync--" sync / 14:Guardian:2791:/ window 100,100
-715 "Enrage" sync / 1[56]:Guardian:2791:/ jump 0
+700 "--sync--" sync / 14:[^:]*:Guardian:2791:/ window 100,100
+715 "Enrage" sync / 1[56]:[^:]*:Guardian:2791:/ jump 0
 
 ######################################
 ########## END of Version A ##########
@@ -202,80 +202,80 @@ hideall "--sync--"
 
 # This is Version B of the encounter, with Dadaluma first
 
-1052 "Shockwave" sync / 1[56]:Guardian:2783:/
-1059 "Missile Simulation" sync / 1[56]:Guardian:2764:/
-1074 "Chakra Burst" sync / 1[56]:Guardian:2787:/
-1077 "Run Dada (NW)" sync / 1[56]:Guardian:276F:/
-1090 "Magitek Ray" sync / 1[56]:Guardian:2788:/
+1052 "Shockwave" sync / 1[56]:[^:]*:Guardian:2783:/
+1059 "Missile Simulation" sync / 1[56]:[^:]*:Guardian:2764:/
+1074 "Chakra Burst" sync / 1[56]:[^:]*:Guardian:2787:/
+1077 "Run Dada (NW)" sync / 1[56]:[^:]*:Guardian:276F:/
+1090 "Magitek Ray" sync / 1[56]:[^:]*:Guardian:2788:/
 1095 "(H) Aura Cannon"
 1105 "(DPS) Aura Cannon"
-1106 "Arm And Hammer" sync / 1[56]:Guardian:2789:/
-1118 "Prey" sync / 1[56]:Guardian:278A:/
-1126 "Magitek Ray" sync / 1[56]:Guardian:2788:/
+1106 "Arm And Hammer" sync / 1[56]:[^:]*:Guardian:2789:/
+1118 "Prey" sync / 1[56]:[^:]*:Guardian:278A:/
+1126 "Magitek Ray" sync / 1[56]:[^:]*:Guardian:2788:/
 
 # Bibliotaph
-1135 "Load Biblio / Skip Air Force" sync / 1[56]:Guardian:2773:/
-1145 "Demon Simulation" sync / 1[56]:Guardian:2B36:/
-1153 "Retrieve Air Force" sync / 1[56]:Guardian:2774:/
-1156 "Diffractive Laser" sync / 1[56]:Guardian:2780:/
-1164 "Copy Air Force" sync / 1[56]:Guardian:2775:/
-1171 "Missile Simulation" sync / 1[56]:Guardian:2764:/
+1135 "Load Biblio / Skip Air Force" sync / 1[56]:[^:]*:Guardian:2773:/
+1145 "Demon Simulation" sync / 1[56]:[^:]*:Guardian:2B36:/
+1153 "Retrieve Air Force" sync / 1[56]:[^:]*:Guardian:2774:/
+1156 "Diffractive Laser" sync / 1[56]:[^:]*:Guardian:2780:/
+1164 "Copy Air Force" sync / 1[56]:[^:]*:Guardian:2775:/
+1171 "Missile Simulation" sync / 1[56]:[^:]*:Guardian:2764:/
 
 # Air Force
-1181 "Run Air Force" sync / 1[56]:Guardian:276F:/
-1195 "Bomb Deployment" sync / 1[56]:Guardian:2762:/
+1181 "Run Air Force" sync / 1[56]:[^:]*:Guardian:276F:/
+1195 "Bomb Deployment" sync / 1[56]:[^:]*:Guardian:2762:/
 1196 "Plane Laser" duration 2
 1204 "Plane Laser" duration 2
-1206 "Arm And Hammer" sync / 1[56]:Guardian:2789:/
-1214 "Magitek Ray" sync / 1[56]:Guardian:2788:/
+1206 "Arm And Hammer" sync / 1[56]:[^:]*:Guardian:2789:/
+1214 "Magitek Ray" sync / 1[56]:[^:]*:Guardian:2788:/
 
 # Ultros
-1222 "Load Ultros" sync / 1[56]:Guardian:275C:/
-1223 "Ink" sync / 1[56]:Guardian:277D:/
-1239 "Diffractive Plasma" sync / 1[56]:Guardian:278B:/
-1248 "Tentacle Simulation" sync / 1[56]:Guardian:275E:/
+1222 "Load Ultros" sync / 1[56]:[^:]*:Guardian:275C:/
+1223 "Ink" sync / 1[56]:[^:]*:Guardian:277D:/
+1239 "Diffractive Plasma" sync / 1[56]:[^:]*:Guardian:278B:/
+1248 "Tentacle Simulation" sync / 1[56]:[^:]*:Guardian:275E:/
 1252 "Tentacle"
 1258 "Wallop"
-1260 "Run Ultros (SE)" sync / 1[56]:Guardian:276F:/
+1260 "Run Ultros (SE)" sync / 1[56]:[^:]*:Guardian:276F:/
 1267 "Interrupt Stoneskin" duration 4
-1269 "--targetable--" sync / 1[56]:Guardian:2937:/
+1269 "--targetable--" sync / 1[56]:[^:]*:Guardian:2937:/
 1276 "Chain Cannon" duration 2
-1282 "Main Cannon" sync / 1[56]:Guardian:2790:/
-1285 "--untargetable--" sync / 1[56]:Guardian:2938:/
-1297 "Diffractive Plasma" sync / 1[56]:Guardian:278B:/
+1282 "Main Cannon" sync / 1[56]:[^:]*:Guardian:2790:/
+1285 "--untargetable--" sync / 1[56]:[^:]*:Guardian:2938:/
+1297 "Diffractive Plasma" sync / 1[56]:[^:]*:Guardian:278B:/
 
 # Virus
-1305 "Virus" sync / 1[56]:Guardian:2773:/
+1305 "Virus" sync / 1[56]:[^:]*:Guardian:2773:/
 1308 "Aether Rot"
-1318 "Magnetism/Repel" sync / 1[56]:Fire Control System:2779:/ # optional?
-1331 "Diffractive Plasma" sync / 1[56]:Guardian:278B:/
-1343 "Diffractive Plasma" sync / 1[56]:Guardian:278B:/
-1355 "Prey" sync / 1[56]:Guardian:278A:/
-1365 "Viral Weapon" sync / 1[56]:Guardian:277C:/
+1318 "Magnetism/Repel" sync / 1[56]:[^:]*:Fire Control System:2779:/ # optional?
+1331 "Diffractive Plasma" sync / 1[56]:[^:]*:Guardian:278B:/
+1343 "Diffractive Plasma" sync / 1[56]:[^:]*:Guardian:278B:/
+1355 "Prey" sync / 1[56]:[^:]*:Guardian:278A:/
+1365 "Viral Weapon" sync / 1[56]:[^:]*:Guardian:277C:/
 1366 "Temporary Misdirection" duration 15
-1371 "Magitek Ray" sync / 1[56]:Guardian:2788:/
-1375 "--untargetable--" sync / 1[56]:Guardian:2937:/
+1371 "Magitek Ray" sync / 1[56]:[^:]*:Guardian:2788:/
+1375 "--untargetable--" sync / 1[56]:[^:]*:Guardian:2937:/
 1382 "Chain Cannon" duration 2
-1388 "Main Cannon" sync / 1[56]:Guardian:2790:/
+1388 "Main Cannon" sync / 1[56]:[^:]*:Guardian:2790:/
 1389 "Radar" duration 2
-1391 "--targetable--" sync / 1[56]:Guardian:2938:/
-1400 "Arm And Hammer" sync / 1[56]:Guardian:2789:/
-1408 "Diffractive Plasma" sync / 1[56]:Guardian:278B:/
+1391 "--targetable--" sync / 1[56]:[^:]*:Guardian:2938:/
+1400 "Arm And Hammer" sync / 1[56]:[^:]*:Guardian:2789:/
+1408 "Diffractive Plasma" sync / 1[56]:[^:]*:Guardian:278B:/
 
 # Air Force
-1416 "Paste Air Force" sync / 1[56]:Guardian:2776:/ window 10,10
-1419 "Diffractive Laser" sync / 1[56]:Guardian:2780:/
+1416 "Paste Air Force" sync / 1[56]:[^:]*:Guardian:2776:/ window 10,10
+1419 "Diffractive Laser" sync / 1[56]:[^:]*:Guardian:2780:/
 1422 "Radar" duration 2
-1431 "Diffractive Plasma" sync / 1[56]:Guardian:278B:/
-1441 "Run Air Force" sync / 1[56]:Guardian:276F:/
-1447 "Bomb Deployment" sync / 1[56]:Guardian:2762:/
+1431 "Diffractive Plasma" sync / 1[56]:[^:]*:Guardian:278B:/
+1441 "Run Air Force" sync / 1[56]:[^:]*:Guardian:276F:/
+1447 "Bomb Deployment" sync / 1[56]:[^:]*:Guardian:2762:/
 1454 "Plane Laser" duration 2
 1462 "Plane Laser" duration 2
-1462 "Arm And Hammer" sync / 1[56]:Guardian:2789:/
-1470 "Diffractive Plasma" sync / 1[56]:Guardian:278B:/
+1462 "Arm And Hammer" sync / 1[56]:[^:]*:Guardian:2789:/
+1470 "Diffractive Plasma" sync / 1[56]:[^:]*:Guardian:278B:/
 
 # Divergence point
-1481 "Load/Skip ??" sync / 1[56]:Guardian:(275C|2773):/
+1481 "Load/Skip ??" sync / 1[56]:[^:]*:Guardian:(275C|2773):/
 1482 "--sync--" sync / 1A:5D4:Bibliotaph Simulation:[^:]*:[^:]*:[^:]*:[^:]*:Guardian:/ jump 4482       # Bibliotaph buff, jump to B1
 1482 "--sync--" sync / 1A:5D3:Dadaluma Simulation:[^:]*:[^:]*:[^:]*:[^:]*:Guardian:/ jump 5482         # Dadaluma buff, jump to B2
 1484 "Shockwave?"
@@ -286,28 +286,28 @@ hideall "--sync--"
 ##########################################################
 
 # Bibliotaph
-4481 "Load Biblio" sync / 1[56]:Guardian:(275C|2773):/
+4481 "Load Biblio" sync / 1[56]:[^:]*:Guardian:(275C|2773):/
 4490 "Radar" duration 2
-4491 "Demon Simulation" sync / 1[56]:Guardian:2B36:/
-4504 "Run Biblio" sync / 1[56]:Guardian:276F:/
-4511 "Diffractive Plasma" sync / 1[56]:Guardian:278B:/
-4518 "Diffractive Plasma" sync / 1[56]:Guardian:278B:/
-4525 "Diffractive Plasma" sync / 1[56]:Guardian:278B:/
-4533 "Prey" sync / 1[56]:Guardian:278A:/
-4542 "Magitek Ray" sync / 1[56]:Guardian:2788:/
-4551 "Diffractive Plasma" sync / 1[56]:Guardian:278B:/
+4491 "Demon Simulation" sync / 1[56]:[^:]*:Guardian:2B36:/
+4504 "Run Biblio" sync / 1[56]:[^:]*:Guardian:276F:/
+4511 "Diffractive Plasma" sync / 1[56]:[^:]*:Guardian:278B:/
+4518 "Diffractive Plasma" sync / 1[56]:[^:]*:Guardian:278B:/
+4525 "Diffractive Plasma" sync / 1[56]:[^:]*:Guardian:278B:/
+4533 "Prey" sync / 1[56]:[^:]*:Guardian:278A:/
+4542 "Magitek Ray" sync / 1[56]:[^:]*:Guardian:2788:/
+4551 "Diffractive Plasma" sync / 1[56]:[^:]*:Guardian:278B:/
 
 # Dadaluma
-4562 "Load Dada" sync / 1[56]:Guardian:(275C|2774):/
-4565 "Shockwave" sync / 1[56]:Guardian:2783:/
+4562 "Load Dada" sync / 1[56]:[^:]*:Guardian:(275C|2774):/
+4565 "Shockwave" sync / 1[56]:[^:]*:Guardian:2783:/
 4569 "Radar" duration 2
-4575 "Missile Simulation" sync / 1[56]:Guardian:2764:/
-4584 "Atomic Ray" sync / 1[56]:Guardian:278D:/
-4589 "Chakra Burst" sync / 1[56]:Guardian:2787:/
-4601 "Prey" sync / 1[56]:Guardian:278A:/
-4607 "Magitek Ray" sync / 1[56]:Guardian:2788:/
-4615 "Diffractive Plasma" sync / 1[56]:Guardian:278B:/
-4620 "--sync--" sync / 14:Guardian:(275C|2773):/ jump 1620         # Load/Skip casting, return to B
+4575 "Missile Simulation" sync / 1[56]:[^:]*:Guardian:2764:/
+4584 "Atomic Ray" sync / 1[56]:[^:]*:Guardian:278D:/
+4589 "Chakra Burst" sync / 1[56]:[^:]*:Guardian:2787:/
+4601 "Prey" sync / 1[56]:[^:]*:Guardian:278A:/
+4607 "Magitek Ray" sync / 1[56]:[^:]*:Guardian:2788:/
+4615 "Diffractive Plasma" sync / 1[56]:[^:]*:Guardian:278B:/
+4620 "--sync--" sync / 14:[^:]*:Guardian:(275C|2773):/ jump 1620         # Load/Skip casting, return to B
 
 # Should be unreachable, only here for visual continuity before/after jump
 4625 "Load Ultros"
@@ -321,28 +321,28 @@ hideall "--sync--"
 #### Divergent path, Version B2: Dadaluma -> Bibliotaph
 
 # Dadaluma
-5481 "Load Dada" sync / 1[56]:Guardian:(275C|2773):/
-5484 "Shockwave" sync / 1[56]:Guardian:2783:/
+5481 "Load Dada" sync / 1[56]:[^:]*:Guardian:(275C|2773):/
+5484 "Shockwave" sync / 1[56]:[^:]*:Guardian:2783:/
 5488 "Radar" duration 2
-5494 "Missile Simulation" sync / 1[56]:Guardian:2764:/
-5503 "Atomic Ray" sync / 1[56]:Guardian:278D:/
-5508 "Chakra Burst" sync / 1[56]:Guardian:2787:/
-5520 "Prey" sync / 1[56]:Guardian:278A:/
-5526 "Magitek Ray" sync / 1[56]:Guardian:2788:/
-5534 "Diffractive Plasma" sync / 1[56]:Guardian:278B:/
+5494 "Missile Simulation" sync / 1[56]:[^:]*:Guardian:2764:/
+5503 "Atomic Ray" sync / 1[56]:[^:]*:Guardian:278D:/
+5508 "Chakra Burst" sync / 1[56]:[^:]*:Guardian:2787:/
+5520 "Prey" sync / 1[56]:[^:]*:Guardian:278A:/
+5526 "Magitek Ray" sync / 1[56]:[^:]*:Guardian:2788:/
+5534 "Diffractive Plasma" sync / 1[56]:[^:]*:Guardian:278B:/
 
 # Bibliotaph
-5544 "Load Biblio" sync / 1[56]:Guardian:(275C|2774):/
+5544 "Load Biblio" sync / 1[56]:[^:]*:Guardian:(275C|2774):/
 5553 "Radar" duration 2
-5554 "Demon Simulation" sync / 1[56]:Guardian:2B36:/
-5567 "Run Biblio" sync / 1[56]:Guardian:276F:/
-5574 "Diffractive Plasma" sync / 1[56]:Guardian:278B:/
-5581 "Diffractive Plasma" sync / 1[56]:Guardian:278B:/
-5588 "Diffractive Plasma" sync / 1[56]:Guardian:278B:/
-5596 "Prey" sync / 1[56]:Guardian:278A:/
-5605 "Magitek Ray" sync / 1[56]:Guardian:2788:/
-5614 "Diffractive Plasma" sync / 1[56]:Guardian:278B:/
-5620 "--sync--" sync / 14:Guardian:(275C|2773):/ jump 1620         # Load/Skip casting, return to B
+5554 "Demon Simulation" sync / 1[56]:[^:]*:Guardian:2B36:/
+5567 "Run Biblio" sync / 1[56]:[^:]*:Guardian:276F:/
+5574 "Diffractive Plasma" sync / 1[56]:[^:]*:Guardian:278B:/
+5581 "Diffractive Plasma" sync / 1[56]:[^:]*:Guardian:278B:/
+5588 "Diffractive Plasma" sync / 1[56]:[^:]*:Guardian:278B:/
+5596 "Prey" sync / 1[56]:[^:]*:Guardian:278A:/
+5605 "Magitek Ray" sync / 1[56]:[^:]*:Guardian:2788:/
+5614 "Diffractive Plasma" sync / 1[56]:[^:]*:Guardian:278B:/
+5620 "--sync--" sync / 14:[^:]*:Guardian:(275C|2773):/ jump 1620         # Load/Skip casting, return to B
 
 # Should be unreachable, only here for visual continuity before/after jump
 5625 "Load Ultros"
@@ -358,24 +358,24 @@ hideall "--sync--"
 ##########################################################
 
 # Ultros
-1625 "Load Ultros" sync / 1[56]:Guardian:(275C|2773):/
-1626 "Ink" sync / 1[56]:Guardian:277D:/
-1633 "Tentacle Simulation" sync / 1[56]:Guardian:275E:/
+1625 "Load Ultros" sync / 1[56]:[^:]*:Guardian:(275C|2773):/
+1626 "Ink" sync / 1[56]:[^:]*:Guardian:277D:/
+1633 "Tentacle Simulation" sync / 1[56]:[^:]*:Guardian:275E:/
 1637 "Tentacle"
-1639 "Bomb Deployment" sync / 1[56]:Guardian:2762:/
+1639 "Bomb Deployment" sync / 1[56]:[^:]*:Guardian:2762:/
 1643 "Wallop"
-1648 "Atomic Ray" sync / 1[56]:Guardian:278D:/
-1653 "Magitek Ray" sync / 1[56]:Guardian:2788:/
-1662 "Diffractive Plasma" sync / 1[56]:Guardian:278B:/
-1672 "Run Ultros (NE)" sync / 1[56]:Guardian:276F:/
-1678 "Missile Simulation" sync / 1[56]:Guardian:2764:/
+1648 "Atomic Ray" sync / 1[56]:[^:]*:Guardian:278D:/
+1653 "Magitek Ray" sync / 1[56]:[^:]*:Guardian:2788:/
+1662 "Diffractive Plasma" sync / 1[56]:[^:]*:Guardian:278B:/
+1672 "Run Ultros (NE)" sync / 1[56]:[^:]*:Guardian:276F:/
+1678 "Missile Simulation" sync / 1[56]:[^:]*:Guardian:2764:/
 1681 "Interrupt Stoneskin" duration 4
-1681 "--untargetable--" sync / 1[56]:Guardian:2937:/
+1681 "--untargetable--" sync / 1[56]:[^:]*:Guardian:2937:/
 1688 "Chain Cannon" duration 2
-1694 "Main Cannon" sync / 1[56]:Guardian:2790:/
-1697 "--targetable--" sync / 1[56]:Guardian:2938:/
-1706 "Diffractive Plasma" sync / 1[56]:Guardian:278B:/
+1694 "Main Cannon" sync / 1[56]:[^:]*:Guardian:2790:/
+1697 "--targetable--" sync / 1[56]:[^:]*:Guardian:2938:/
+1706 "Diffractive Plasma" sync / 1[56]:[^:]*:Guardian:278B:/
 
 # Enrage
-1711 "--sync--" sync / 14:Guardian:2791:/ window 100,100
-1726 "Enrage" sync / 1[56]:Guardian:2791:/ jump 0
+1711 "--sync--" sync / 14:[^:]*:Guardian:2791:/ window 100,100
+1726 "Enrage" sync / 1[56]:[^:]*:Guardian:2791:/ jump 0

--- a/ui/raidboss/data/04-sb/raid/o7s.txt
+++ b/ui/raidboss/data/04-sb/raid/o7s.txt
@@ -158,7 +158,7 @@ hideall "--sync--"
 3624 "Prey" sync / 1[56]:Guardian:278A:/
 3633 "Magitek Ray" sync / 1[56]:Guardian:2788:/
 3642 "Diffractive Plasma" sync / 1[56]:Guardian:278B:/
-3648 "--sync--" sync / 14:Guardian(275C|2773):/ jump 648          # Load/Skip starts casting, return to A
+3648 "--sync--" sync / 14:Guardian:(275C|2773):/ jump 648 # Load/Skip starts casting, return to A
 
 # Should be unreachable, only here for visual continuity before/after jump
 3653 "Load Air Force"

--- a/ui/raidboss/data/04-sb/raid/o8n.txt
+++ b/ui/raidboss/data/04-sb/raid/o8n.txt
@@ -6,76 +6,76 @@ hideall "--sync--"
 0.0 "--Reset--" sync / 21:........:40000010:/ window 100000 jump 0
 
 0 "Start" sync / 00:0044:[^:]*:Destroy! Destroy! Destroy! I will destroy it all!/
-15 "Hyperdrive" sync / 1[56]:Kefka:292E:/ window 16,3
-23 "Blizzard Blitz" sync / 1[56]:Kefka:291(4|6|8|9):/
-36 "Flagrant Fire" sync / 1[56]:Kefka:291F:/
-38 "Thrumming Thunder" sync / 1[56]:Kefka:291(B|D):/
-54 "Blizzard Blitz" sync / 1[56]:Kefka:291(4|6|8|9):/
-62 "Thrumming Thunder" sync / 1[56]:Kefka:291(B|D):/
+15 "Hyperdrive" sync / 1[56]:[^:]*:Kefka:292E:/ window 16,3
+23 "Blizzard Blitz" sync / 1[56]:[^:]*:Kefka:291(4|6|8|9):/
+36 "Flagrant Fire" sync / 1[56]:[^:]*:Kefka:291F:/
+38 "Thrumming Thunder" sync / 1[56]:[^:]*:Kefka:291(B|D):/
+54 "Blizzard Blitz" sync / 1[56]:[^:]*:Kefka:291(4|6|8|9):/
+62 "Thrumming Thunder" sync / 1[56]:[^:]*:Kefka:291(B|D):/
 
-82 "Graven Image" sync / 1[56]:Kefka:2925:/
-94 "Wave Cannon" sync / 1[56]:Graven Image:2928:/
-95 "Shockwave" sync / 1[56]:Graven Image:2927:/
-107 "Ultima Upsurge" sync / 1[56]:Kefka:292D:/
-115 "Hyperdrive" sync / 1[56]:Kefka:292E:/
-129 "Flagrant Fire" sync / 1[56]:Kefka:2920:/
-131 "Blizzard Blitz" sync / 1[56]:Kefka:291(4|6|8|9):/
-137 "Timely Teleport" sync / 1[56]:Kefka:2922:/
+82 "Graven Image" sync / 1[56]:[^:]*:Kefka:2925:/
+94 "Wave Cannon" sync / 1[56]:[^:]*:Graven Image:2928:/
+95 "Shockwave" sync / 1[56]:[^:]*:Graven Image:2927:/
+107 "Ultima Upsurge" sync / 1[56]:[^:]*:Kefka:292D:/
+115 "Hyperdrive" sync / 1[56]:[^:]*:Kefka:292E:/
+129 "Flagrant Fire" sync / 1[56]:[^:]*:Kefka:2920:/
+131 "Blizzard Blitz" sync / 1[56]:[^:]*:Kefka:291(4|6|8|9):/
+137 "Timely Teleport" sync / 1[56]:[^:]*:Kefka:2922:/
 137 "--untargetable--"
 140 "--targetable--"
 140 "Aero/Ruin" duration 3
-148 "Aero Assault" sync / 1[56]:Kefka:2924:/
+148 "Aero Assault" sync / 1[56]:[^:]*:Kefka:2924:/
 
-160 "Graven Image" sync / 1[56]:Kefka:2925:/
-170 "Thrumming Thunder" sync / 1[56]:Kefka:291(B|D):/
-172 "Wave Cannon" sync / 1[56]:Graven Image:2928:/
-173 "Shockwave" sync / 1[56]:Graven Image:2927:/
-183 "Ultima Upsurge" sync / 1[56]:Kefka:292D:/
-190 "Hyperdrive" sync / 1[56]:Kefka:292E:/
+160 "Graven Image" sync / 1[56]:[^:]*:Kefka:2925:/
+170 "Thrumming Thunder" sync / 1[56]:[^:]*:Kefka:291(B|D):/
+172 "Wave Cannon" sync / 1[56]:[^:]*:Graven Image:2928:/
+173 "Shockwave" sync / 1[56]:[^:]*:Graven Image:2927:/
+183 "Ultima Upsurge" sync / 1[56]:[^:]*:Kefka:292D:/
+190 "Hyperdrive" sync / 1[56]:[^:]*:Kefka:292E:/
 
-204 "Graven Image" sync / 1[56]:Kefka:2925:/
-210 "Half Arena" sync / 1[56]:Graven Image:(292A|2929):/
-218 "Ultima Upsurge" sync / 1[56]:Kefka:292D:/
+204 "Graven Image" sync / 1[56]:[^:]*:Kefka:2925:/
+210 "Half Arena" sync / 1[56]:[^:]*:Graven Image:(292A|2929):/
+218 "Ultima Upsurge" sync / 1[56]:[^:]*:Kefka:292D:/
 
-228 "Graven Image" sync / 1[56]:Kefka:2925:/
-234 "Half Arena" sync / 1[56]:Graven Image:(292A|2929):/
-240 "Flagrant Fire" sync / 1[56]:Kefka:291F:/
-242 "Thrumming Thunder" sync / 1[56]:Kefka:291(B|D):/
-248 "Timely Teleport" sync / 1[56]:Kefka:2922:/
+228 "Graven Image" sync / 1[56]:[^:]*:Kefka:2925:/
+234 "Half Arena" sync / 1[56]:[^:]*:Graven Image:(292A|2929):/
+240 "Flagrant Fire" sync / 1[56]:[^:]*:Kefka:291F:/
+242 "Thrumming Thunder" sync / 1[56]:[^:]*:Kefka:291(B|D):/
+248 "Timely Teleport" sync / 1[56]:[^:]*:Kefka:2922:/
 248 "--untargetable--"
 251 "--targetable--"
 251 "Aero/Ruin" duration 3
 
-268 "Graven Image" sync / 1[56]:Kefka:2925:/
-274 "Half Arena" sync / 1[56]:Graven Image:292(9|A):/
-275 "Thrumming Thunder" sync / 1[56]:Kefka:291(B|D):/
-282 "Ultima Upsurge" sync / 1[56]:Kefka:292D:/
-289 "Hyperdrive" sync / 1[56]:Kefka:292E:/
+268 "Graven Image" sync / 1[56]:[^:]*:Kefka:2925:/
+274 "Half Arena" sync / 1[56]:[^:]*:Graven Image:292(9|A):/
+275 "Thrumming Thunder" sync / 1[56]:[^:]*:Kefka:291(B|D):/
+282 "Ultima Upsurge" sync / 1[56]:[^:]*:Kefka:292D:/
+289 "Hyperdrive" sync / 1[56]:[^:]*:Kefka:292E:/
 
-302 "Graven Image" sync / 1[56]:Kefka:2925:/
-308 "Statue Gaze" sync / 1[56]:Graven Image:292C:/
-318 "Ultima Upsurge" sync / 1[56]:Kefka:292D:/
-325 "Ultima Upsurge" sync / 1[56]:Kefka:292D:/
+302 "Graven Image" sync / 1[56]:[^:]*:Kefka:2925:/
+308 "Statue Gaze" sync / 1[56]:[^:]*:Graven Image:292C:/
+318 "Ultima Upsurge" sync / 1[56]:[^:]*:Kefka:292D:/
+325 "Ultima Upsurge" sync / 1[56]:[^:]*:Kefka:292D:/
 
 # loop here
-335 "Graven Image" sync / 1[56]:Kefka:2925:/
-341 "Statue Gaze" sync / 1[56]:Graven Image:292(B|C):/
-342 "Thrumming Thunder" sync / 1[56]:Kefka:291(B|D):/
-348 "Timely Teleport" sync / 1[56]:Kefka:2922:/
+335 "Graven Image" sync / 1[56]:[^:]*:Kefka:2925:/
+341 "Statue Gaze" sync / 1[56]:[^:]*:Graven Image:292(B|C):/
+342 "Thrumming Thunder" sync / 1[56]:[^:]*:Kefka:291(B|D):/
+348 "Timely Teleport" sync / 1[56]:[^:]*:Kefka:2922:/
 348 "--untargetable--"
 351 "--targetable--"
 351 "Aero/Ruin" duration 3
-366 "Hyperdrive" sync / 1[56]:Kefka:292E:/
+366 "Hyperdrive" sync / 1[56]:[^:]*:Kefka:292E:/
 
-374 "Graven Image" sync / 1[56]:Kefka:2925:/
-380 "Statue Gaze" sync / 1[56]:Graven Image:292(B|C):/
-386 "Flagrant Fire" sync / 1[56]:Kefka:291F:/
-388 "Blizzard Blitz" sync / 1[56]:Kefka:291(4|6|8|9):/
-401 "Ultima Upsurge" sync / 1[56]:Kefka:292D:/
-408 "Ultima Upsurge" sync / 1[56]:Kefka:292D:/
+374 "Graven Image" sync / 1[56]:[^:]*:Kefka:2925:/
+380 "Statue Gaze" sync / 1[56]:[^:]*:Graven Image:292(B|C):/
+386 "Flagrant Fire" sync / 1[56]:[^:]*:Kefka:291F:/
+388 "Blizzard Blitz" sync / 1[56]:[^:]*:Kefka:291(4|6|8|9):/
+401 "Ultima Upsurge" sync / 1[56]:[^:]*:Kefka:292D:/
+408 "Ultima Upsurge" sync / 1[56]:[^:]*:Kefka:292D:/
 # end loop
 
-418 "Graven Image" sync / 1[56]:Kefka:2925:/ jump 333
+418 "Graven Image" sync / 1[56]:[^:]*:Kefka:2925:/ jump 333
 424 "Statue Gaze"
 425 "Thrumming Thunder"
 431 "Timely Teleport"

--- a/ui/raidboss/data/04-sb/raid/o8s.txt
+++ b/ui/raidboss/data/04-sb/raid/o8s.txt
@@ -6,200 +6,200 @@ hideall "--sync--"
 0.0 "--Reset--" sync / 00:0839::The limit gauge resets!/ window 10000 jump 0
 0.0 "--Reset--" sync / 21:........:40000010:/ window 100000 jump 0
 
-4 "--sync--" sync / 1[56]:Kefka:28C2:/ window 5,0
-13 "Mana Charge" sync / 1[56]:Kefka:28D1:/ window 20,20 # drift 0.476
-19 "Flagrant Fire" #sync / 1[56]:Kefka:28CE:/ # drift 0.215
-28 "Hyperdrive" sync / 1[56]:Kefka:28E8:/
-36 "Mana Release" sync / 1[56]:Kefka:28D2:/
-41 "Flagrant Fire" #sync / 1[56]:Kefka:2B32:/
-44 "Thrumming Thunder" #sync / 1[56]:Kefka:28CA:/
-50 "Ultima Upsurge" sync / 1[56]:Kefka:28E7:/
+4 "--sync--" sync / 1[56]:[^:]*:Kefka:28C2:/ window 5,0
+13 "Mana Charge" sync / 1[56]:[^:]*:Kefka:28D1:/ window 20,20 # drift 0.476
+19 "Flagrant Fire" #sync / 1[56]:[^:]*:Kefka:28CE:/ # drift 0.215
+28 "Hyperdrive" sync / 1[56]:[^:]*:Kefka:28E8:/
+36 "Mana Release" sync / 1[56]:[^:]*:Kefka:28D2:/
+41 "Flagrant Fire" #sync / 1[56]:[^:]*:Kefka:2B32:/
+44 "Thrumming Thunder" #sync / 1[56]:[^:]*:Kefka:28CA:/
+50 "Ultima Upsurge" sync / 1[56]:[^:]*:Kefka:28E7:/
 
 # First Graven
-71 "Graven Image" sync / 1[56]:Kefka:28D7:/
-73 "--untargetable--" sync / 14:Kefka:2B34:/
-75 "Inexorable Will" sync / 1[56]:Graven Image:28DA:/
-76 "Wave Cannon" sync / 1[56]:Graven Image:28DC:/
-79 "Inexorable Will" sync / 1[56]:Graven Image:28DA:/
-81 "Wave Cannon" sync / 1[56]:Graven Image:28DC:/
-83 "Pulse Wave" sync / 1[56]:Graven Image:28DD:/
-83 "Inexorable Will" sync / 1[56]:Graven Image:28DA:/
-86 "Indomitable Will" sync / 1[56]:Graven Image:28D9:/
-87 "Timely Teleport" sync / 1[56]:Kefka:28D3:/
-90 "Revolting Ruin" sync / 1[56]:Kefka:28D5:/
-98 "Light Of Judgment" sync / 1[56]:Kefka:28D8:/
+71 "Graven Image" sync / 1[56]:[^:]*:Kefka:28D7:/
+73 "--untargetable--" sync / 14:[^:]*:Kefka:2B34:/
+75 "Inexorable Will" sync / 1[56]:[^:]*:Graven Image:28DA:/
+76 "Wave Cannon" sync / 1[56]:[^:]*:Graven Image:28DC:/
+79 "Inexorable Will" sync / 1[56]:[^:]*:Graven Image:28DA:/
+81 "Wave Cannon" sync / 1[56]:[^:]*:Graven Image:28DC:/
+83 "Pulse Wave" sync / 1[56]:[^:]*:Graven Image:28DD:/
+83 "Inexorable Will" sync / 1[56]:[^:]*:Graven Image:28DA:/
+86 "Indomitable Will" sync / 1[56]:[^:]*:Graven Image:28D9:/
+87 "Timely Teleport" sync / 1[56]:[^:]*:Kefka:28D3:/
+90 "Revolting Ruin" sync / 1[56]:[^:]*:Kefka:28D5:/
+98 "Light Of Judgment" sync / 1[56]:[^:]*:Kefka:28D8:/
 
 # Second Graven
-108 "Mana Charge" sync / 1[56]:Kefka:28D1:/
-115 "Thrumming Thunder" #sync / 1[56]:Kefka:28CA:/
-122 "Blizzard Blitz" #sync / 1[56]:Kefka:28C7:/
-130 "Graven Image" sync / 1[56]:Kefka:28D7:/
-139 "Mana Release" sync / 1[56]:Kefka:28D2:/
-140 "Shockwave" sync / 1[56]:Graven Image:28DB:/
-146 "Blizzard+Thunder" #sync / 1[56]:Kefka:2B2(E|F):/
-156 "Ultima Upsurge" sync / 1[56]:Kefka:28E7:/
-163 "Hyperdrive" sync / 1[56]:Kefka:28E8:/
+108 "Mana Charge" sync / 1[56]:[^:]*:Kefka:28D1:/
+115 "Thrumming Thunder" #sync / 1[56]:[^:]*:Kefka:28CA:/
+122 "Blizzard Blitz" #sync / 1[56]:[^:]*:Kefka:28C7:/
+130 "Graven Image" sync / 1[56]:[^:]*:Kefka:28D7:/
+139 "Mana Release" sync / 1[56]:[^:]*:Kefka:28D2:/
+140 "Shockwave" sync / 1[56]:[^:]*:Graven Image:28DB:/
+146 "Blizzard+Thunder" #sync / 1[56]:[^:]*:Kefka:2B2(E|F):/
+156 "Ultima Upsurge" sync / 1[56]:[^:]*:Kefka:28E7:/
+163 "Hyperdrive" sync / 1[56]:[^:]*:Kefka:28E8:/
 
 # Third Graven
-178 "Graven Image" sync / 1[56]:Kefka:28D7:/
-181 "--untargetable--" sync / 14:Kefka:2B34:/
-183 "Gravitas" sync / 1[56]:Graven Image:28E0:/
-186 "Vitrophyre" sync / 1[56]:Graven Image:28E2:/
-190 "Half Arena" sync / 1[56]:Graven Image:28D(E|F):/
-193 "Gravitas" sync / 1[56]:Graven Image:28E0:/
+178 "Graven Image" sync / 1[56]:[^:]*:Kefka:28D7:/
+181 "--untargetable--" sync / 14:[^:]*:Kefka:2B34:/
+183 "Gravitas" sync / 1[56]:[^:]*:Graven Image:28E0:/
+186 "Vitrophyre" sync / 1[56]:[^:]*:Graven Image:28E2:/
+190 "Half Arena" sync / 1[56]:[^:]*:Graven Image:28D(E|F):/
+193 "Gravitas" sync / 1[56]:[^:]*:Graven Image:28E0:/
 195 "--targetable--"
-196 "Vitrophyre" sync / 1[56]:Graven Image:28E2:/
-200 "Aero Assault" sync / 1[56]:Kefka:28D6:/
-208 "Light Of Judgment" sync / 1[56]:Kefka:28D8:/
+196 "Vitrophyre" sync / 1[56]:[^:]*:Graven Image:28E2:/
+200 "Aero Assault" sync / 1[56]:[^:]*:Kefka:28D6:/
+208 "Light Of Judgment" sync / 1[56]:[^:]*:Kefka:28D8:/
 
 # Fourth Graven
-218 "Mana Charge" sync / 1[56]:Kefka:28D1:/ # drift 0.296
-224 "Flagrant Fire" #sync / 1[56]:Kefka:28CE:/ # drift 0.304
-232 "Ultima Upsurge" sync / 1[56]:Kefka:28E7:/
-240 "Graven Image" sync / 1[56]:Kefka:28D7:/ # drift 0.203
-245 "Half Arena" sync / 1[56]:Graven Image:28D(E|F):/
-246 "Mana Release" sync / 1[56]:Kefka:28D2:/ # drift 0.302
-251 "Flagrant Fire" #sync / 1[56]:Kefka:2B32:/
-254 "Thrumming Thunder" #sync / 1[56]:Kefka:28CA:/
-261 "Ultima Upsurge" sync / 1[56]:Kefka:28E7:/
-268 "Hyperdrive" sync / 1[56]:Kefka:28E8:/
+218 "Mana Charge" sync / 1[56]:[^:]*:Kefka:28D1:/ # drift 0.296
+224 "Flagrant Fire" #sync / 1[56]:[^:]*:Kefka:28CE:/ # drift 0.304
+232 "Ultima Upsurge" sync / 1[56]:[^:]*:Kefka:28E7:/
+240 "Graven Image" sync / 1[56]:[^:]*:Kefka:28D7:/ # drift 0.203
+245 "Half Arena" sync / 1[56]:[^:]*:Graven Image:28D(E|F):/
+246 "Mana Release" sync / 1[56]:[^:]*:Kefka:28D2:/ # drift 0.302
+251 "Flagrant Fire" #sync / 1[56]:[^:]*:Kefka:2B32:/
+254 "Thrumming Thunder" #sync / 1[56]:[^:]*:Kefka:28CA:/
+261 "Ultima Upsurge" sync / 1[56]:[^:]*:Kefka:28E7:/
+268 "Hyperdrive" sync / 1[56]:[^:]*:Kefka:28E8:/
 
 # Fifth Graven
-288 "Graven Image" sync / 1[56]:Kefka:28D7:/ # drift 0.259
-290 "--untargetable--" sync / 14:Kefka:2B34:/
-293 "Inexorable Will" sync / 1[56]:Graven Image:28DA:/
-293 "Statue Gaze" #sync / 1[56]:Graven Image:28E(3|4):/
-308 "Statue Gaze" sync / 1[56]:Graven Image:28E(3|4):/ # drift -0.387
-310 "Timely Teleport" sync / 1[56]:Kefka:28D3:/
-313 "Revolting Ruin" sync / 1[56]:Kefka:28D5:/ # drift 0.227
-322 "Light Of Judgment" sync / 1[56]:Kefka:28D8:/
-329 "Ultima Upsurge" sync / 1[56]:Kefka:28E7:/ # drift 0.31
+288 "Graven Image" sync / 1[56]:[^:]*:Kefka:28D7:/ # drift 0.259
+290 "--untargetable--" sync / 14:[^:]*:Kefka:2B34:/
+293 "Inexorable Will" sync / 1[56]:[^:]*:Graven Image:28DA:/
+293 "Statue Gaze" #sync / 1[56]:[^:]*:Graven Image:28E(3|4):/
+308 "Statue Gaze" sync / 1[56]:[^:]*:Graven Image:28E(3|4):/ # drift -0.387
+310 "Timely Teleport" sync / 1[56]:[^:]*:Kefka:28D3:/
+313 "Revolting Ruin" sync / 1[56]:[^:]*:Kefka:28D5:/ # drift 0.227
+322 "Light Of Judgment" sync / 1[56]:[^:]*:Kefka:28D8:/
+329 "Ultima Upsurge" sync / 1[56]:[^:]*:Kefka:28E7:/ # drift 0.31
 
 # Sixth Graven
-336 "Mana Charge" sync / 1[56]:Kefka:28D1:/ # drift 0.256
-343 "Thrumming Thunder" #sync / 1[56]:Kefka:28CA:/
-350 "Blizzard Blitz" #sync / 1[56]:Kefka:28C7:/
-358 "Graven Image" sync / 1[56]:Kefka:28D7:/
-363 "Statue Gaze" sync / 1[56]:Graven Image:28E(3|4):/
-364 "Mana Release" sync / 1[56]:Kefka:28D2:/
-371 "Blizzard+Thunder" #sync / 1[56]:Kefka:2B2(E|F):/
-377 "Hyperdrive" sync / 1[56]:Kefka:28E8:/
+336 "Mana Charge" sync / 1[56]:[^:]*:Kefka:28D1:/ # drift 0.256
+343 "Thrumming Thunder" #sync / 1[56]:[^:]*:Kefka:28CA:/
+350 "Blizzard Blitz" #sync / 1[56]:[^:]*:Kefka:28C7:/
+358 "Graven Image" sync / 1[56]:[^:]*:Kefka:28D7:/
+363 "Statue Gaze" sync / 1[56]:[^:]*:Graven Image:28E(3|4):/
+364 "Mana Release" sync / 1[56]:[^:]*:Kefka:28D2:/
+371 "Blizzard+Thunder" #sync / 1[56]:[^:]*:Kefka:2B2(E|F):/
+377 "Hyperdrive" sync / 1[56]:[^:]*:Kefka:28E8:/
 
 # Enrage
-384 "Ultima Upsurge" sync / 1[56]:Kefka:28E7:/ # drift 0.285
-392 "Ultima Upsurge" sync / 1[56]:Kefka:28E7:/
-400 "Ultima Upsurge" sync / 1[56]:Kefka:28E7:/
+384 "Ultima Upsurge" sync / 1[56]:[^:]*:Kefka:28E7:/ # drift 0.285
+392 "Ultima Upsurge" sync / 1[56]:[^:]*:Kefka:28E7:/
+400 "Ultima Upsurge" sync / 1[56]:[^:]*:Kefka:28E7:/
 404 "--untargetable--"
-408 "Light Of Judgment" sync / 1[56]:Kefka:2A51:/
+408 "Light Of Judgment" sync / 1[56]:[^:]*:Kefka:2A51:/
 
 #############
 # GOD KEFKA #
 #############
 
 1000 "Start"
-1001 "--sync--" sync / 1[56]:Kefka:28EC:/ window 1001,0
-1006 "--sync--" sync / 14:Kefka:28FA:/ window 10,0
-1010 "Heartless Angel" sync / 1[56]:Kefka:28FA:/
-1016 "Ultima" sync / 1[56]:Kefka:2911:/
-1023 "Hyperdrive" sync / 1[56]:Kefka:2912:/
-1032 "Celestriad" sync / 1[56]:Kefka:2907:/
-1034 "Thunder III" sync / 1[56]:Kefka:290A:/
-1035 "(DPS) Fire III" sync / 1[56]:Kefka:290B:/
-1041 "Ultima" sync / 1[56]:Kefka:2911:/
+1001 "--sync--" sync / 1[56]:[^:]*:Kefka:28EC:/ window 1001,0
+1006 "--sync--" sync / 14:[^:]*:Kefka:28FA:/ window 10,0
+1010 "Heartless Angel" sync / 1[56]:[^:]*:Kefka:28FA:/
+1016 "Ultima" sync / 1[56]:[^:]*:Kefka:2911:/
+1023 "Hyperdrive" sync / 1[56]:[^:]*:Kefka:2912:/
+1032 "Celestriad" sync / 1[56]:[^:]*:Kefka:2907:/
+1034 "Thunder III" sync / 1[56]:[^:]*:Kefka:290A:/
+1035 "(DPS) Fire III" sync / 1[56]:[^:]*:Kefka:290B:/
+1041 "Ultima" sync / 1[56]:[^:]*:Kefka:2911:/
 
 # Forsaken 1
-1048 "--sync--" sync / 14:Kefka:28E9:/ window 120,60
-1053 "Forsaken #1" sync / 1[56]:Kefka:28E9:/
-1064 "Heartless Archangel" sync / 1[56]:Kefka:28FB:/
-1067 "Soak" sync / 1[56]:Light Of Consecration:28EA:/
-1077 "2x Wings Of Destruction" sync / 1[56]:Kefka:2900:/
-1083 "Ultima" sync / 1[56]:Kefka:2911:/
-1093 "Heartless Archangel" sync / 1[56]:Kefka:28FB:/
-1096 "Soak" sync / 1[56]:Light Of Consecration:28EA:/
+1048 "--sync--" sync / 14:[^:]*:Kefka:28E9:/ window 120,60
+1053 "Forsaken #1" sync / 1[56]:[^:]*:Kefka:28E9:/
+1064 "Heartless Archangel" sync / 1[56]:[^:]*:Kefka:28FB:/
+1067 "Soak" sync / 1[56]:[^:]*:Light Of Consecration:28EA:/
+1077 "2x Wings Of Destruction" sync / 1[56]:[^:]*:Kefka:2900:/
+1083 "Ultima" sync / 1[56]:[^:]*:Kefka:2911:/
+1093 "Heartless Archangel" sync / 1[56]:[^:]*:Kefka:28FB:/
+1096 "Soak" sync / 1[56]:[^:]*:Light Of Consecration:28EA:/
 
 # Light 1
-1108 "Light Of Judgment" sync / 1[56]:Kefka:28ED:/
-1122 "Trine (small)" sync / 1[56]:Kefka:290D:/
-1129 "1x Wings Of Destruction" sync / 1[56]:Kefka:28FE:/
-1140 "2x Wings Of Destruction" sync / 1[56]:Kefka:2900:/
-1157 "Ultima" sync / 1[56]:Kefka:2911:/
-1165 "Past/Future" sync / 1[56]:Kefka:28(EF|F1):/
-1175 "Ultimate Embrace" sync / 1[56]:Kefka:2910:/
-1182 "Hyperdrive" sync / 1[56]:Kefka:2912:/
-1189 "Ultima" sync / 1[56]:Kefka:2911:/
+1108 "Light Of Judgment" sync / 1[56]:[^:]*:Kefka:28ED:/
+1122 "Trine (small)" sync / 1[56]:[^:]*:Kefka:290D:/
+1129 "1x Wings Of Destruction" sync / 1[56]:[^:]*:Kefka:28FE:/
+1140 "2x Wings Of Destruction" sync / 1[56]:[^:]*:Kefka:2900:/
+1157 "Ultima" sync / 1[56]:[^:]*:Kefka:2911:/
+1165 "Past/Future" sync / 1[56]:[^:]*:Kefka:28(EF|F1):/
+1175 "Ultimate Embrace" sync / 1[56]:[^:]*:Kefka:2910:/
+1182 "Hyperdrive" sync / 1[56]:[^:]*:Kefka:2912:/
+1189 "Ultima" sync / 1[56]:[^:]*:Kefka:2911:/
 
 # Forsaken 2
-1201 "--sync--" sync / 14:Kefka:28E9:/ window 120,60
-1206 "Forsaken #2" sync / 1[56]:Kefka:28E9:/
-1214 "Starstrafe" sync / 1[56]:Kefka:2902:/
-1221 "Past/Future End" sync / 1[56]:Kefka:28F(5|8):/
-1228 "All Things Ending" sync / 1[56]:Kefka:28F6:/
-1233 "Meteor" sync / 1[56]:Kefka:2905:/
+1201 "--sync--" sync / 14:[^:]*:Kefka:28E9:/ window 120,60
+1206 "Forsaken #2" sync / 1[56]:[^:]*:Kefka:28E9:/
+1214 "Starstrafe" sync / 1[56]:[^:]*:Kefka:2902:/
+1221 "Past/Future End" sync / 1[56]:[^:]*:Kefka:28F(5|8):/
+1228 "All Things Ending" sync / 1[56]:[^:]*:Kefka:28F6:/
+1233 "Meteor" sync / 1[56]:[^:]*:Kefka:2905:/
 
 # Light 2
-1240 "Light Of Judgment" sync / 1[56]:Kefka:28ED:/
-1256 "Celestriad" sync / 1[56]:Kefka:2907:/
-1258 "Thunder III" sync / 1[56]:Kefka:290A:/
-1259 "(DPS) Fire III" sync / 1[56]:Kefka:290B:/
-1264 "1x Wings Of Destruction" sync / 1[56]:Kefka:28FF:/
-1271 "Ultima" sync / 1[56]:Kefka:2911:/
-1287 "Trine (big)" sync / 1[56]:Kefka:290D:/
-1297 "Past/Future" sync / 1[56]:Kefka:28(EF|F1):/
-1307 "2x Wings Of Destruction" sync / 1[56]:Kefka:2900:/
-1313 "Ultimate Embrace" sync / 1[56]:Kefka:2910:/
-1320 "Hyperdrive" sync / 1[56]:Kefka:2912:/
-1328 "Ultima" sync / 1[56]:Kefka:2911:/
+1240 "Light Of Judgment" sync / 1[56]:[^:]*:Kefka:28ED:/
+1256 "Celestriad" sync / 1[56]:[^:]*:Kefka:2907:/
+1258 "Thunder III" sync / 1[56]:[^:]*:Kefka:290A:/
+1259 "(DPS) Fire III" sync / 1[56]:[^:]*:Kefka:290B:/
+1264 "1x Wings Of Destruction" sync / 1[56]:[^:]*:Kefka:28FF:/
+1271 "Ultima" sync / 1[56]:[^:]*:Kefka:2911:/
+1287 "Trine (big)" sync / 1[56]:[^:]*:Kefka:290D:/
+1297 "Past/Future" sync / 1[56]:[^:]*:Kefka:28(EF|F1):/
+1307 "2x Wings Of Destruction" sync / 1[56]:[^:]*:Kefka:2900:/
+1313 "Ultimate Embrace" sync / 1[56]:[^:]*:Kefka:2910:/
+1320 "Hyperdrive" sync / 1[56]:[^:]*:Kefka:2912:/
+1328 "Ultima" sync / 1[56]:[^:]*:Kefka:2911:/
 
 # Forsaken 3
-1340 "--sync--" sync / 14:Kefka:28E9:/ window 120,60
-1345 "Forsaken #3" sync / 1[56]:Kefka:28E9:/
-1358 "Ultima" sync / 1[56]:Kefka:2911:/
-1359 "Knockback Tethers" sync / 1[56]:Graven Image:28DD:/
-1362 "Soak" sync / 1[56]:Light Of Consecration:28EA:/
-1364 "Ultimate Embrace" sync / 1[56]:Kefka:2910:/
-1371 "Sleep/Confuse Tethers" sync / 1[56]:Graven Image:28E(5|6):/
-1377 "Ultima" sync / 1[56]:Kefka:2911:/
-1386 "Heartless Archangel" sync / 1[56]:Kefka:28FB:/
-1389 "Soak" sync / 1[56]:Light Of Consecration:28EA:/
-1399 "2x Wings Of Destruction" sync / 1[56]:Kefka:2900:/
+1340 "--sync--" sync / 14:[^:]*:Kefka:28E9:/ window 120,60
+1345 "Forsaken #3" sync / 1[56]:[^:]*:Kefka:28E9:/
+1358 "Ultima" sync / 1[56]:[^:]*:Kefka:2911:/
+1359 "Knockback Tethers" sync / 1[56]:[^:]*:Graven Image:28DD:/
+1362 "Soak" sync / 1[56]:[^:]*:Light Of Consecration:28EA:/
+1364 "Ultimate Embrace" sync / 1[56]:[^:]*:Kefka:2910:/
+1371 "Sleep/Confuse Tethers" sync / 1[56]:[^:]*:Graven Image:28E(5|6):/
+1377 "Ultima" sync / 1[56]:[^:]*:Kefka:2911:/
+1386 "Heartless Archangel" sync / 1[56]:[^:]*:Kefka:28FB:/
+1389 "Soak" sync / 1[56]:[^:]*:Light Of Consecration:28EA:/
+1399 "2x Wings Of Destruction" sync / 1[56]:[^:]*:Kefka:2900:/
 1400 "Soak"
-1405 "Ultima" sync / 1[56]:Kefka:2911:/
-1412 "Statue Half Cleave" sync / 1[56]:Graven Image:28D(E|F):/
-1413 "1x Wings Of Destruction" sync / 1[56]:Kefka:28FF:/
+1405 "Ultima" sync / 1[56]:[^:]*:Kefka:2911:/
+1412 "Statue Half Cleave" sync / 1[56]:[^:]*:Graven Image:28D(E|F):/
+1413 "1x Wings Of Destruction" sync / 1[56]:[^:]*:Kefka:28FF:/
 
 # Light 3
-1421 "Light Of Judgment" sync / 1[56]:Kefka:28ED:/
-1435 "Trine (small)" sync / 1[56]:Kefka:290D:/
-1442 "1x Wings Of Destruction" sync / 1[56]:Kefka:28FF:/
-1453 "2x Wings Of Destruction" sync / 1[56]:Kefka:2900:/
-1459 "Ultimate Embrace" sync / 1[56]:Kefka:2910:/
-1475 "Trine (big)" sync / 1[56]:Kefka:290D:/
-1485 "Past/Future" sync / 1[56]:Kefka:28(EF|F1):/
-1496 "Hyperdrive" sync / 1[56]:Kefka:2912:/
-1504 "Ultima" sync / 1[56]:Kefka:2911:/
-1512 "Ultima" sync / 1[56]:Kefka:2911:/
+1421 "Light Of Judgment" sync / 1[56]:[^:]*:Kefka:28ED:/
+1435 "Trine (small)" sync / 1[56]:[^:]*:Kefka:290D:/
+1442 "1x Wings Of Destruction" sync / 1[56]:[^:]*:Kefka:28FF:/
+1453 "2x Wings Of Destruction" sync / 1[56]:[^:]*:Kefka:2900:/
+1459 "Ultimate Embrace" sync / 1[56]:[^:]*:Kefka:2910:/
+1475 "Trine (big)" sync / 1[56]:[^:]*:Kefka:290D:/
+1485 "Past/Future" sync / 1[56]:[^:]*:Kefka:28(EF|F1):/
+1496 "Hyperdrive" sync / 1[56]:[^:]*:Kefka:2912:/
+1504 "Ultima" sync / 1[56]:[^:]*:Kefka:2911:/
+1512 "Ultima" sync / 1[56]:[^:]*:Kefka:2911:/
 
 # Forsaken 4 (repeats #3)
-1525 "--sync--" sync / 14:Kefka:28E9:/ window 120,60
-1530 "Forsaken #4" sync / 1[56]:Kefka:28E9:/
-1543 "Ultima" sync / 1[56]:Kefka:2911:/
-1544 "Knockback Tethers" sync / 1[56]:Graven Image:28DD:/
-1547 "Soak" sync / 1[56]:Light Of Consecration:28EA:/
-1549 "Ultimate Embrace" sync / 1[56]:Kefka:2910:/
-1556 "Sleep/Confuse Tethers" sync / 1[56]:Graven Image:28E(5|6):/
-1562 "Ultima" sync / 1[56]:Kefka:2911:/
-1571 "Heartless Archangel" sync / 1[56]:Kefka:28FB:/
+1525 "--sync--" sync / 14:[^:]*:Kefka:28E9:/ window 120,60
+1530 "Forsaken #4" sync / 1[56]:[^:]*:Kefka:28E9:/
+1543 "Ultima" sync / 1[56]:[^:]*:Kefka:2911:/
+1544 "Knockback Tethers" sync / 1[56]:[^:]*:Graven Image:28DD:/
+1547 "Soak" sync / 1[56]:[^:]*:Light Of Consecration:28EA:/
+1549 "Ultimate Embrace" sync / 1[56]:[^:]*:Kefka:2910:/
+1556 "Sleep/Confuse Tethers" sync / 1[56]:[^:]*:Graven Image:28E(5|6):/
+1562 "Ultima" sync / 1[56]:[^:]*:Kefka:2911:/
+1571 "Heartless Archangel" sync / 1[56]:[^:]*:Kefka:28FB:/
 1574 "Soak"
-1584 "2x Wings Of Destruction" sync / 1[56]:Kefka:2900:/
+1584 "2x Wings Of Destruction" sync / 1[56]:[^:]*:Kefka:2900:/
 1586 "Soak"
-1590 "Ultima" sync / 1[56]:Kefka:2911:/
+1590 "Ultima" sync / 1[56]:[^:]*:Kefka:2911:/
 1595 "Statue Half Cleave"
-1596 "1x Wings Of Destruction" sync / 1[56]:Kefka:28FF:/
+1596 "1x Wings Of Destruction" sync / 1[56]:[^:]*:Kefka:28FF:/
 
 # Enrage
-1602 "Ultima" sync / 1[56]:Kefka:283D:/
-1610 "Ultima" sync / 1[56]:Kefka:283D:/
-1618 "Ultima" sync / 1[56]:Kefka:283D:/
-1626 "Ultima" sync / 1[56]:Kefka:283D:/
-1630 "--sync--" sync / 14:Kefka:2A52:/
-1640 "Enrage" sync / 1[56]:Kefka:2A52:/ jump 0
+1602 "Ultima" sync / 1[56]:[^:]*:Kefka:283D:/
+1610 "Ultima" sync / 1[56]:[^:]*:Kefka:283D:/
+1618 "Ultima" sync / 1[56]:[^:]*:Kefka:283D:/
+1626 "Ultima" sync / 1[56]:[^:]*:Kefka:283D:/
+1630 "--sync--" sync / 14:[^:]*:Kefka:2A52:/
+1640 "Enrage" sync / 1[56]:[^:]*:Kefka:2A52:/ jump 0

--- a/ui/raidboss/data/04-sb/raid/o9n.txt
+++ b/ui/raidboss/data/04-sb/raid/o9n.txt
@@ -9,79 +9,79 @@ hideall "--sync--"
 # Start branch
 0.0 "Start"
 0.0 "--sync--" sync /:Engage!/ window 0,1
-1.5 "--sync--" sync / 1[56]:Chaos:314E:/ window 2,0
+1.5 "--sync--" sync / 1[56]:[^:]*:Chaos:314E:/ window 2,0
 # This buster at slightly different times depending on the window.
-15.0 "Chaotic Dispersion" sync / 1[56]:Chaos:314F:/
-25.7 "Long/Lat Implosion?" sync / 1[56]:Chaos:315[12]:/ window 30,10 jump 1025.7
-28.0 "Damning Edict?" sync / 1[56]:Chaos:3150:/ window 30,10 jump 2028.0
+15.0 "Chaotic Dispersion" sync / 1[56]:[^:]*:Chaos:314F:/
+25.7 "Long/Lat Implosion?" sync / 1[56]:[^:]*:Chaos:315[12]:/ window 30,10 jump 1025.7
+28.0 "Damning Edict?" sync / 1[56]:[^:]*:Chaos:3150:/ window 30,10 jump 2028.0
 
 
 ## Fire -> Air start
-1014.4 "Chaotic Dispersion" sync / 1[56]:Chaos:314F:/
-1025.7 "Long/Lat Implosion" sync / 1[56]:Chaos:315[12]:/
-1040.0 "Blaze" sync / 1[56]:Chaos:3165:/
-1040.0 "--sync--" sync / 1[56]:Chaos:319A:/
-1050.0 "(T/H) Stray Flames" sync / 1[56]:Chaos:316B:/
-1056.2 "Chaosphere" sync / 1[56]:Chaos:3155:/
-1056.2 "(DPS) Stray Flames" sync / 1[56]:Chaos:316B:/
+1014.4 "Chaotic Dispersion" sync / 1[56]:[^:]*:Chaos:314F:/
+1025.7 "Long/Lat Implosion" sync / 1[56]:[^:]*:Chaos:315[12]:/
+1040.0 "Blaze" sync / 1[56]:[^:]*:Chaos:3165:/
+1040.0 "--sync--" sync / 1[56]:[^:]*:Chaos:319A:/
+1050.0 "(T/H) Stray Flames" sync / 1[56]:[^:]*:Chaos:316B:/
+1056.2 "Chaosphere" sync / 1[56]:[^:]*:Chaos:3155:/
+1056.2 "(DPS) Stray Flames" sync / 1[56]:[^:]*:Chaos:316B:/
 1064.3 "Knock"
 1070.9 "Knock"
-1080.0 "Big Bang" sync / 1[56]:Chaos:3159:/
-1089.5 "Fiendish Orbs" sync / 1[56]:Chaos:315B:/
-1111.7 "Cyclone" sync / 1[56]:Chaos:3167:/
-1111.7 "--sync--" sync / 1[56]:Chaos:319C:/
-1127.1 "Damning Edict" sync / 1[56]:Chaos:3150:/
-1140.3 "Chaotic Dispersion" sync / 1[56]:Chaos:314F:/
-1152.4 "Chaosphere" sync / 1[56]:Chaos:3156:/
-1152.5 "Cyclone" sync / 1[56]:Chaos:316D:/
-1160.5 "Knock" sync / 1[56]:Chaos:315E:/
-1166.6 "Big Bang" sync / 1[56]:Chaos:315A:/
-1178.8 "Fiendish Orbs" sync / 1[56]:Chaos:315C:/
+1080.0 "Big Bang" sync / 1[56]:[^:]*:Chaos:3159:/
+1089.5 "Fiendish Orbs" sync / 1[56]:[^:]*:Chaos:315B:/
+1111.7 "Cyclone" sync / 1[56]:[^:]*:Chaos:3167:/
+1111.7 "--sync--" sync / 1[56]:[^:]*:Chaos:319C:/
+1127.1 "Damning Edict" sync / 1[56]:[^:]*:Chaos:3150:/
+1140.3 "Chaotic Dispersion" sync / 1[56]:[^:]*:Chaos:314F:/
+1152.4 "Chaosphere" sync / 1[56]:[^:]*:Chaos:3156:/
+1152.5 "Cyclone" sync / 1[56]:[^:]*:Chaos:316D:/
+1160.5 "Knock" sync / 1[56]:[^:]*:Chaos:315E:/
+1166.6 "Big Bang" sync / 1[56]:[^:]*:Chaos:315A:/
+1178.8 "Fiendish Orbs" sync / 1[56]:[^:]*:Chaos:315C:/
 
 ## Fire->Water Midphase
-1204.1 "Bowels of Agony" sync / 1[56]:Chaos:3169:/
+1204.1 "Bowels of Agony" sync / 1[56]:[^:]*:Chaos:3169:/
 1208.1 "--untargetable--"
-1211.6 "--sync--" sync / 1[56]:Chaos:3215:/
-1218.3 "Stray Flames" sync / 1[56]:Chaos:316B:/
-1224.2 "Stray Spray" sync / 1[56]:Chaos:316C:/
+1211.6 "--sync--" sync / 1[56]:[^:]*:Chaos:3215:/
+1218.3 "Stray Flames" sync / 1[56]:[^:]*:Chaos:316B:/
+1224.2 "Stray Spray" sync / 1[56]:[^:]*:Chaos:316C:/
 1500.0 "--sync--" sync / 00:0044:Chaos:The crystal\.\.\.destroyed\!\?/ window 500,10
-1503.0 "Soul of Chaos" sync / 1[56]:Chaos:316A:/ window 500,10
+1503.0 "Soul of Chaos" sync / 1[56]:[^:]*:Chaos:316A:/ window 500,10
 1513.1 "--targetable--"
 # fake window into Water->Earth loop
-1530.0 "Chaotic Dispersion" sync / 1[56]:Chaos:314F:/ window 50,50 jump 3015.7
+1530.0 "Chaotic Dispersion" sync / 1[56]:[^:]*:Chaos:314F:/ window 50,50 jump 3015.7
 
 
 ## Water -> Earth start
-2015.7 "Chaotic Dispersion" sync / 1[56]:Chaos:314F:/
-2028.0 "Damning Edict" sync / 1[56]:Chaos:3150:/
-2041.1 "Tsunami" sync / 1[56]:Chaos:3166:/
-2041.1 "--sync--" sync / 1[56]:Chaos:319B:/
-2050.0 "(T/H) Stray Spray" sync / 1[56]:Chaos:316C:/
-2056.2 "(DPS) Stray Spray" sync / 1[56]:Chaos:316C:/
-2057.3 "Chaosphere" sync / 1[56]:Chaos:3156:/
-2065.4 "Knock" sync / 1[56]:Chaos:315E:/
-2076.6 "Big Bang" sync / 1[56]:Chaos:315A:/
-2088.8 "Fiendish Orbs" sync / 1[56]:Chaos:315C:/
+2015.7 "Chaotic Dispersion" sync / 1[56]:[^:]*:Chaos:314F:/
+2028.0 "Damning Edict" sync / 1[56]:[^:]*:Chaos:3150:/
+2041.1 "Tsunami" sync / 1[56]:[^:]*:Chaos:3166:/
+2041.1 "--sync--" sync / 1[56]:[^:]*:Chaos:319B:/
+2050.0 "(T/H) Stray Spray" sync / 1[56]:[^:]*:Chaos:316C:/
+2056.2 "(DPS) Stray Spray" sync / 1[56]:[^:]*:Chaos:316C:/
+2057.3 "Chaosphere" sync / 1[56]:[^:]*:Chaos:3156:/
+2065.4 "Knock" sync / 1[56]:[^:]*:Chaos:315E:/
+2076.6 "Big Bang" sync / 1[56]:[^:]*:Chaos:315A:/
+2088.8 "Fiendish Orbs" sync / 1[56]:[^:]*:Chaos:315C:/
 
-2111.1 "Earthquake" sync / 1[56]:Chaos:3168:/
-2111.1 "--sync--" sync / 1[56]:Chaos:319D:/
-2125.4 "Long/Lat Implosion" sync / 1[56]:Chaos:315[12]:/
-2139.6 "Chaotic Dispersion" sync / 1[56]:Chaos:314F:/
-2151.8 "Earthquake" sync / 1[56]:Chaos:3418:/
-2151.8 "Chaosphere" sync / 1[56]:Chaos:3155:/
-2159.9 "Knock" sync / 1[56]:Chaos:315D:/
-2166.6 "Knock" sync / 1[56]:Chaos:315D:/
-2170.8 "Big Bang" sync / 1[56]:Chaos:3159:/
-2180.3 "Fiendish Orbs" sync / 1[56]:Chaos:315B:/
+2111.1 "Earthquake" sync / 1[56]:[^:]*:Chaos:3168:/
+2111.1 "--sync--" sync / 1[56]:[^:]*:Chaos:319D:/
+2125.4 "Long/Lat Implosion" sync / 1[56]:[^:]*:Chaos:315[12]:/
+2139.6 "Chaotic Dispersion" sync / 1[56]:[^:]*:Chaos:314F:/
+2151.8 "Earthquake" sync / 1[56]:[^:]*:Chaos:3418:/
+2151.8 "Chaosphere" sync / 1[56]:[^:]*:Chaos:3155:/
+2159.9 "Knock" sync / 1[56]:[^:]*:Chaos:315D:/
+2166.6 "Knock" sync / 1[56]:[^:]*:Chaos:315D:/
+2170.8 "Big Bang" sync / 1[56]:[^:]*:Chaos:3159:/
+2180.3 "Fiendish Orbs" sync / 1[56]:[^:]*:Chaos:315B:/
 
-2205.3 "Bowels of Agony" sync / 1[56]:Chaos:3169:/
-2212.8 "--sync--" sync / 1[56]:Chaos:3215:/
-2219.5 "Stray Flames" sync / 1[56]:Chaos:316B:/
-2225.4 "Stray Spray" sync / 1[56]:Chaos:316C:/
+2205.3 "Bowels of Agony" sync / 1[56]:[^:]*:Chaos:3169:/
+2212.8 "--sync--" sync / 1[56]:[^:]*:Chaos:3215:/
+2219.5 "Stray Flames" sync / 1[56]:[^:]*:Chaos:316B:/
+2225.4 "Stray Spray" sync / 1[56]:[^:]*:Chaos:316C:/
 2500.0 "--sync--" sync / 00:0044:Chaos:The crystal\.\.\.destroyed\!\?/ window 500,10
-2503.0 "Soul of Chaos" sync / 1[56]:Chaos:316A:/ window 500,10
+2503.0 "Soul of Chaos" sync / 1[56]:[^:]*:Chaos:316A:/ window 500,10
 # fake window into Fire->Air loop
-2529.5 "Chaotic Dispersion" sync / 1[56]:Chaos:314F:/ window 50,50 jump 3212.6
+2529.5 "Chaotic Dispersion" sync / 1[56]:[^:]*:Chaos:314F:/ window 50,50 jump 3212.6
 
 
 #### Water -> Earth -> Fire -> Air loop
@@ -90,52 +90,52 @@ hideall "--sync--"
 2983.7 "Fiendish Orbs"
 
 ## Water
-3015.7 "Chaotic Dispersion" sync / 1[56]:Chaos:314F:/
-3028.0 "Damning Edict" sync / 1[56]:Chaos:3150:/
-3041.1 "Tsunami" sync / 1[56]:Chaos:3166:/
-3041.1 "--sync--" sync / 1[56]:Chaos:319B:/
-3050.0 "(T/H) Stray Spray" sync / 1[56]:Chaos:316C:/
-3056.2 "(DPS) Stray Spray" sync / 1[56]:Chaos:316C:/
-3057.3 "Chaosphere" sync / 1[56]:Chaos:3156:/
-3065.4 "Knock" sync / 1[56]:Chaos:315E:/
-3076.6 "Big Bang" sync / 1[56]:Chaos:315A:/
-3088.8 "Fiendish Orbs" sync / 1[56]:Chaos:315C:/
+3015.7 "Chaotic Dispersion" sync / 1[56]:[^:]*:Chaos:314F:/
+3028.0 "Damning Edict" sync / 1[56]:[^:]*:Chaos:3150:/
+3041.1 "Tsunami" sync / 1[56]:[^:]*:Chaos:3166:/
+3041.1 "--sync--" sync / 1[56]:[^:]*:Chaos:319B:/
+3050.0 "(T/H) Stray Spray" sync / 1[56]:[^:]*:Chaos:316C:/
+3056.2 "(DPS) Stray Spray" sync / 1[56]:[^:]*:Chaos:316C:/
+3057.3 "Chaosphere" sync / 1[56]:[^:]*:Chaos:3156:/
+3065.4 "Knock" sync / 1[56]:[^:]*:Chaos:315E:/
+3076.6 "Big Bang" sync / 1[56]:[^:]*:Chaos:315A:/
+3088.8 "Fiendish Orbs" sync / 1[56]:[^:]*:Chaos:315C:/
 
 ## Earth
-3111.1 "Earthquake" sync / 1[56]:Chaos:3168:/
-3111.1 "--sync--" sync / 1[56]:Chaos:319D:/
-3125.4 "Long/Lat Implosion" sync / 1[56]:Chaos:315[12]:/
-3139.6 "Chaotic Dispersion" sync / 1[56]:Chaos:314F:/
-3151.8 "Earthquake" sync / 1[56]:Chaos:3418:/
-3151.8 "Chaosphere" sync / 1[56]:Chaos:3155:/
-3159.9 "Knock" sync / 1[56]:Chaos:315D:/
-3166.6 "Knock" sync / 1[56]:Chaos:315D:/
-3170.8 "Big Bang" sync / 1[56]:Chaos:3159:/
-3180.3 "Fiendish Orbs" sync / 1[56]:Chaos:315B:/
+3111.1 "Earthquake" sync / 1[56]:[^:]*:Chaos:3168:/
+3111.1 "--sync--" sync / 1[56]:[^:]*:Chaos:319D:/
+3125.4 "Long/Lat Implosion" sync / 1[56]:[^:]*:Chaos:315[12]:/
+3139.6 "Chaotic Dispersion" sync / 1[56]:[^:]*:Chaos:314F:/
+3151.8 "Earthquake" sync / 1[56]:[^:]*:Chaos:3418:/
+3151.8 "Chaosphere" sync / 1[56]:[^:]*:Chaos:3155:/
+3159.9 "Knock" sync / 1[56]:[^:]*:Chaos:315D:/
+3166.6 "Knock" sync / 1[56]:[^:]*:Chaos:315D:/
+3170.8 "Big Bang" sync / 1[56]:[^:]*:Chaos:3159:/
+3180.3 "Fiendish Orbs" sync / 1[56]:[^:]*:Chaos:315B:/
 
 ## Fire
-3212.6 "Chaotic Dispersion" sync / 1[56]:Chaos:314F:/
-3223.9 "Long/Lat Implosion" sync / 1[56]:Chaos:315[12]:/
-3238.2 "Blaze" sync / 1[56]:Chaos:3165:/
-3238.2 "--sync--" sync / 1[56]:Chaos:319A:/
-3248.2 "(T/H) Stray Flames" sync / 1[56]:Chaos:316B:/
-3254.4 "Chaosphere" sync / 1[56]:Chaos:3155:/
-3254.4 "(DPS) Stray Flames" sync / 1[56]:Chaos:316B:/
+3212.6 "Chaotic Dispersion" sync / 1[56]:[^:]*:Chaos:314F:/
+3223.9 "Long/Lat Implosion" sync / 1[56]:[^:]*:Chaos:315[12]:/
+3238.2 "Blaze" sync / 1[56]:[^:]*:Chaos:3165:/
+3238.2 "--sync--" sync / 1[56]:[^:]*:Chaos:319A:/
+3248.2 "(T/H) Stray Flames" sync / 1[56]:[^:]*:Chaos:316B:/
+3254.4 "Chaosphere" sync / 1[56]:[^:]*:Chaos:3155:/
+3254.4 "(DPS) Stray Flames" sync / 1[56]:[^:]*:Chaos:316B:/
 3262.5 "Knock"
 3269.1 "Knock"
-3278.2 "Big Bang" sync / 1[56]:Chaos:3159:/
-3287.7 "Fiendish Orbs" sync / 1[56]:Chaos:315B:/
+3278.2 "Big Bang" sync / 1[56]:[^:]*:Chaos:3159:/
+3287.7 "Fiendish Orbs" sync / 1[56]:[^:]*:Chaos:315B:/
 
 ## Air
-3309.9 "Cyclone" sync / 1[56]:Chaos:3167:/
-3309.9 "--sync--" sync / 1[56]:Chaos:319C:/
-3325.3 "Damning Edict" sync / 1[56]:Chaos:3150:/
-3338.5 "Chaotic Dispersion" sync / 1[56]:Chaos:314F:/
-3350.6 "Chaosphere" sync / 1[56]:Chaos:3156:/
-3350.7 "Cyclone" sync / 1[56]:Chaos:316D:/
-3358.7 "Knock" sync / 1[56]:Chaos:315E:/
-3364.8 "Big Bang" sync / 1[56]:Chaos:315A:/
-3377.0 "Fiendish Orbs" sync / 1[56]:Chaos:315C:/ window 50,50 jump 2983.7
+3309.9 "Cyclone" sync / 1[56]:[^:]*:Chaos:3167:/
+3309.9 "--sync--" sync / 1[56]:[^:]*:Chaos:319C:/
+3325.3 "Damning Edict" sync / 1[56]:[^:]*:Chaos:3150:/
+3338.5 "Chaotic Dispersion" sync / 1[56]:[^:]*:Chaos:314F:/
+3350.6 "Chaosphere" sync / 1[56]:[^:]*:Chaos:3156:/
+3350.7 "Cyclone" sync / 1[56]:[^:]*:Chaos:316D:/
+3358.7 "Knock" sync / 1[56]:[^:]*:Chaos:315E:/
+3364.8 "Big Bang" sync / 1[56]:[^:]*:Chaos:315A:/
+3377.0 "Fiendish Orbs" sync / 1[56]:[^:]*:Chaos:315C:/ window 50,50 jump 2983.7
 
 # fake lookahead window into water
 3409.0 "Chaotic Dispersion"

--- a/ui/raidboss/data/04-sb/raid/o9s.txt
+++ b/ui/raidboss/data/04-sb/raid/o9s.txt
@@ -11,7 +11,7 @@ hideall "--sync--"
 2.5 "--sync--" sync / 1[56]:Chaos:316F:/ window 3,0 # First autoattack
 
 ## Branch between Fire/Water paths
-10.7 "--sync--" sync / 14:317(2|3):Chaos/ window 12,12 jump 2010.1 # Long/lat means water path
+10.7 "--sync--" sync / 14:Chaos:317(2|3):/ window 12,12 jump 2010.1 # Long/lat means water path
 10.7 "--sync--" sync / 14:Chaos:3171:/ window 12,12 jump 1010.7 # Edict means fire path
 
 # Fake water path

--- a/ui/raidboss/data/04-sb/raid/o9s.txt
+++ b/ui/raidboss/data/04-sb/raid/o9s.txt
@@ -8,11 +8,11 @@ hideall "--sync--"
 
 0 "Start"
 0.0 "--sync--" sync /:Engage!/ window 0,1
-2.5 "--sync--" sync / 1[56]:Chaos:316F:/ window 3,0 # First autoattack
+2.5 "--sync--" sync / 1[56]:[^:]*:Chaos:316F:/ window 3,0 # First autoattack
 
 ## Branch between Fire/Water paths
-10.7 "--sync--" sync / 14:Chaos:317(2|3):/ window 12,12 jump 2010.1 # Long/lat means water path
-10.7 "--sync--" sync / 14:Chaos:3171:/ window 12,12 jump 1010.7 # Edict means fire path
+10.7 "--sync--" sync / 14:[^:]*:Chaos:317(2|3):/ window 12,12 jump 2010.1 # Long/lat means water path
+10.7 "--sync--" sync / 14:[^:]*:Chaos:3171:/ window 12,12 jump 1010.7 # Edict means fire path
 
 # Fake water path
 15.7 "Long/Lat Implosion?"
@@ -29,69 +29,69 @@ hideall "--sync--"
 #############
 
 # Fire phase
-1016.7 "Damning Edict" sync / 1[56]:Chaos:3171:/
-1029.9 "Blaze" sync / 1[56]:Chaos:3206:/
-1041.7 "(T/H) Stray Flames" sync / 1[56]:Chaos:318C:/
-1047.6 "Long/Lat Implosion" sync / 1[56]:Chaos:317(2|3):/
-1055.8 "(DPS) Stray Flames" sync / 1[56]:Chaos:318C:/
-1066.8 "Chaotic Dispersion" sync / 1[56]:Chaos:3170:/
-1079.1 "Blaze" sync / 1[56]:Chaos:3206:/ # drift 0.028
-1090.9 "(T/H) Stray Flames" sync / 1[56]:Chaos:318C:/
-1098.8 "Knock" sync / 1[56]:Chaos:317E:/
-1104.9 "(DPS) Stray Flames" sync / 1[56]:Chaos:318C:/
-1109.8 "Big Bang" sync / 1[56]:Chaos:3180:/
-1118.6 "Fiendish Orbs" sync / 1[56]:Chaos:317C:/
+1016.7 "Damning Edict" sync / 1[56]:[^:]*:Chaos:3171:/
+1029.9 "Blaze" sync / 1[56]:[^:]*:Chaos:3206:/
+1041.7 "(T/H) Stray Flames" sync / 1[56]:[^:]*:Chaos:318C:/
+1047.6 "Long/Lat Implosion" sync / 1[56]:[^:]*:Chaos:317(2|3):/
+1055.8 "(DPS) Stray Flames" sync / 1[56]:[^:]*:Chaos:318C:/
+1066.8 "Chaotic Dispersion" sync / 1[56]:[^:]*:Chaos:3170:/
+1079.1 "Blaze" sync / 1[56]:[^:]*:Chaos:3206:/ # drift 0.028
+1090.9 "(T/H) Stray Flames" sync / 1[56]:[^:]*:Chaos:318C:/
+1098.8 "Knock" sync / 1[56]:[^:]*:Chaos:317E:/
+1104.9 "(DPS) Stray Flames" sync / 1[56]:[^:]*:Chaos:318C:/
+1109.8 "Big Bang" sync / 1[56]:[^:]*:Chaos:3180:/
+1118.6 "Fiendish Orbs" sync / 1[56]:[^:]*:Chaos:317C:/
 
 # Wind phase
-1141.0 "Cyclone" sync / 1[56]:Chaos:3208:/
-1153.2 "Umbra Smash" sync / 1[56]:Chaos:3175:/
-1160.7 "Cyclone" sync / 1[56]:Chaos:318F:/
-1163.4 "Damning Edict" sync / 1[56]:Chaos:3171:/
-1181.6 "Chaotic Dispersion" sync / 1[56]:Chaos:3170:/
-1194.0 "Cyclone" sync / 1[56]:Chaos:3208:/
-1207.2 "Knock" sync / 1[56]:Chaos:317F:/
-1214.2 "Big Bang" sync / 1[56]:Chaos:3181:/
-1225.6 "Fiendish Orbs" sync / 1[56]:Chaos:317D:/
+1141.0 "Cyclone" sync / 1[56]:[^:]*:Chaos:3208:/
+1153.2 "Umbra Smash" sync / 1[56]:[^:]*:Chaos:3175:/
+1160.7 "Cyclone" sync / 1[56]:[^:]*:Chaos:318F:/
+1163.4 "Damning Edict" sync / 1[56]:[^:]*:Chaos:3171:/
+1181.6 "Chaotic Dispersion" sync / 1[56]:[^:]*:Chaos:3170:/
+1194.0 "Cyclone" sync / 1[56]:[^:]*:Chaos:3208:/
+1207.2 "Knock" sync / 1[56]:[^:]*:Chaos:317F:/
+1214.2 "Big Bang" sync / 1[56]:[^:]*:Chaos:3181:/
+1225.6 "Fiendish Orbs" sync / 1[56]:[^:]*:Chaos:317D:/
 
 # Orb phase
-1251.0 "Bowels of Agony" sync / 1[56]:Chaos:318A:/ # drift 0.04
-1265.1 "(DPS) Stray Flames" sync / 1[56]:Chaos:318C:/
-1268.1 "(T/H) Stray Spray" sync / 1[56]:Chaos:318D:/
-1293.1 "Soul of Chaos" sync / 1[56]:Chaos:318B:/ window 500,500
+1251.0 "Bowels of Agony" sync / 1[56]:[^:]*:Chaos:318A:/ # drift 0.04
+1265.1 "(DPS) Stray Flames" sync / 1[56]:[^:]*:Chaos:318C:/
+1268.1 "(T/H) Stray Spray" sync / 1[56]:[^:]*:Chaos:318D:/
+1293.1 "Soul of Chaos" sync / 1[56]:[^:]*:Chaos:318B:/ window 500,500
 
 # Water phase
-1320.1 "Long/Lat Implosion" sync / 1[56]:Chaos:317(2|3):/
-1334.5 "Tsunami" sync / 1[56]:Chaos:3207:/
-1343.6 "Umbra Smash" sync / 1[56]:Chaos:3175:/
-1345.1 "(T/H) Stray Spray" sync / 1[56]:Chaos:318D:/
-1352.1 "(DPS) Stray Spray" sync / 1[56]:Chaos:318D:/
-1353.8 "Damning Edict" sync / 1[56]:Chaos:3171:/
-1371.9 "Chaotic Dispersion" sync / 1[56]:Chaos:3170:/
-1384.3 "Tsunami" sync / 1[56]:Chaos:3207:/
-1395.0 "(T/H) Stray Spray" sync / 1[56]:Chaos:318D:/
-1395.4 "Knock" sync / 1[56]:Chaos:317F:/
-1402.0 "(DPS) Stray Spray" sync / 1[56]:Chaos:318D:/
-1402.3 "Big Bang" sync / 1[56]:Chaos:3181:/
-1413.7 "Fiendish Orbs" sync / 1[56]:Chaos:317D:/
+1320.1 "Long/Lat Implosion" sync / 1[56]:[^:]*:Chaos:317(2|3):/
+1334.5 "Tsunami" sync / 1[56]:[^:]*:Chaos:3207:/
+1343.6 "Umbra Smash" sync / 1[56]:[^:]*:Chaos:3175:/
+1345.1 "(T/H) Stray Spray" sync / 1[56]:[^:]*:Chaos:318D:/
+1352.1 "(DPS) Stray Spray" sync / 1[56]:[^:]*:Chaos:318D:/
+1353.8 "Damning Edict" sync / 1[56]:[^:]*:Chaos:3171:/
+1371.9 "Chaotic Dispersion" sync / 1[56]:[^:]*:Chaos:3170:/
+1384.3 "Tsunami" sync / 1[56]:[^:]*:Chaos:3207:/
+1395.0 "(T/H) Stray Spray" sync / 1[56]:[^:]*:Chaos:318D:/
+1395.4 "Knock" sync / 1[56]:[^:]*:Chaos:317F:/
+1402.0 "(DPS) Stray Spray" sync / 1[56]:[^:]*:Chaos:318D:/
+1402.3 "Big Bang" sync / 1[56]:[^:]*:Chaos:3181:/
+1413.7 "Fiendish Orbs" sync / 1[56]:[^:]*:Chaos:317D:/
 
 # Earth phase
-1436.0 "Earthquake" sync / 1[56]:Chaos:3209:/
-1446.0 "Earthquake" sync / 1[56]:Chaos:3190:/
-1449.6 "Long/Lat Implosion" sync / 1[56]:Chaos:317(2|3):/
-1468.8 "Chaotic Dispersion" sync / 1[56]:Chaos:3170:/
-1491.1 "Earthquake" sync / 1[56]:Chaos:3190:/
-1494.2 "Knock" sync / 1[56]:Chaos:317E:/
-1499.1 "Big Bang" sync / 1[56]:Chaos:3180:/
-1507.9 "Fiendish Orbs" sync / 1[56]:Chaos:317C:/
+1436.0 "Earthquake" sync / 1[56]:[^:]*:Chaos:3209:/
+1446.0 "Earthquake" sync / 1[56]:[^:]*:Chaos:3190:/
+1449.6 "Long/Lat Implosion" sync / 1[56]:[^:]*:Chaos:317(2|3):/
+1468.8 "Chaotic Dispersion" sync / 1[56]:[^:]*:Chaos:3170:/
+1491.1 "Earthquake" sync / 1[56]:[^:]*:Chaos:3190:/
+1494.2 "Knock" sync / 1[56]:[^:]*:Chaos:317E:/
+1499.1 "Big Bang" sync / 1[56]:[^:]*:Chaos:3180:/
+1507.9 "Fiendish Orbs" sync / 1[56]:[^:]*:Chaos:317C:/
 
 # Enrage phase
-1538.4 "Blaze" sync / 1[56]:Chaos:3206:/
-1546.1 "(ALL) Stray Flames" sync / 1[56]:Chaos:318C:/
-1551.4 "Tsunami" sync / 1[56]:Chaos:3207:/
-1558.0 "(ALL) Stray Spray" sync / 1[56]:Chaos:318D:/
-1564.6 "Cyclone" sync / 1[56]:Chaos:3208:/
+1538.4 "Blaze" sync / 1[56]:[^:]*:Chaos:3206:/
+1546.1 "(ALL) Stray Flames" sync / 1[56]:[^:]*:Chaos:318C:/
+1551.4 "Tsunami" sync / 1[56]:[^:]*:Chaos:3207:/
+1558.0 "(ALL) Stray Spray" sync / 1[56]:[^:]*:Chaos:318D:/
+1564.6 "Cyclone" sync / 1[56]:[^:]*:Chaos:3208:/
 1571.3 "Stray Gusts"
-1577.6 "Earthquake" sync / 1[56]:Chaos:3209:/
+1577.6 "Earthquake" sync / 1[56]:[^:]*:Chaos:3209:/
 1585.9 "Stray Earth"
 
 ##############
@@ -99,68 +99,68 @@ hideall "--sync--"
 ##############
 
 # Water phase
-2015.7 "Long/Lat Implosion" sync / 1[56]:Chaos:317(2|3):/
-2029.7 "Tsunami" sync / 1[56]:Chaos:3207:/
-2038.7 "Umbra Smash" sync / 1[56]:Chaos:3175:/
-2040.2 "(T/H) Stray Spray" sync / 1[56]:Chaos:318D:/
-2048.8 "Damning Edict" sync / 1[56]:Chaos:3171:/
-2066.8 "Chaotic Dispersion" sync / 1[56]:Chaos:3170:/
-2078.8 "Tsunami" sync / 1[56]:Chaos:3207:/
-2096.3 "(T/H) Stray Spray" sync / 1[56]:Chaos:318D:/
-2089.6 "Knock" sync / 1[56]:Chaos:317F:/
-2096.3 "(DPS) Stray Spray" sync / 1[56]:Chaos:318D:/
-2096.5 "Big Bang" sync / 1[56]:Chaos:3181:/
-2107.8 "Fiendish Orbs" sync / 1[56]:Chaos:317D:/
+2015.7 "Long/Lat Implosion" sync / 1[56]:[^:]*:Chaos:317(2|3):/
+2029.7 "Tsunami" sync / 1[56]:[^:]*:Chaos:3207:/
+2038.7 "Umbra Smash" sync / 1[56]:[^:]*:Chaos:3175:/
+2040.2 "(T/H) Stray Spray" sync / 1[56]:[^:]*:Chaos:318D:/
+2048.8 "Damning Edict" sync / 1[56]:[^:]*:Chaos:3171:/
+2066.8 "Chaotic Dispersion" sync / 1[56]:[^:]*:Chaos:3170:/
+2078.8 "Tsunami" sync / 1[56]:[^:]*:Chaos:3207:/
+2096.3 "(T/H) Stray Spray" sync / 1[56]:[^:]*:Chaos:318D:/
+2089.6 "Knock" sync / 1[56]:[^:]*:Chaos:317F:/
+2096.3 "(DPS) Stray Spray" sync / 1[56]:[^:]*:Chaos:318D:/
+2096.5 "Big Bang" sync / 1[56]:[^:]*:Chaos:3181:/
+2107.8 "Fiendish Orbs" sync / 1[56]:[^:]*:Chaos:317D:/
 
 # Earth phase
-2129.8 "Earthquake" sync / 1[56]:Chaos:3209:/
-2139.8 "Earthquake" sync / 1[56]:Chaos:3190:/
-2143.3 "Long/Lat Implosion" sync / 1[56]:Chaos:317(2|3):/
-2162.3 "Chaotic Dispersion" sync / 1[56]:Chaos:3170:/
-2174.3 "Earthquake" sync / 1[56]:Chaos:3209:/
-2184.3 "Earthquake" sync / 1[56]:Chaos:3190:/
-2187.2 "Knock" sync / 1[56]:Chaos:317E:/
-2192.0 "Big Bang" sync / 1[56]:Chaos:3180:/
-2200.6 "Fiendish Orbs" sync / 1[56]:Chaos:317C:/
+2129.8 "Earthquake" sync / 1[56]:[^:]*:Chaos:3209:/
+2139.8 "Earthquake" sync / 1[56]:[^:]*:Chaos:3190:/
+2143.3 "Long/Lat Implosion" sync / 1[56]:[^:]*:Chaos:317(2|3):/
+2162.3 "Chaotic Dispersion" sync / 1[56]:[^:]*:Chaos:3170:/
+2174.3 "Earthquake" sync / 1[56]:[^:]*:Chaos:3209:/
+2184.3 "Earthquake" sync / 1[56]:[^:]*:Chaos:3190:/
+2187.2 "Knock" sync / 1[56]:[^:]*:Chaos:317E:/
+2192.0 "Big Bang" sync / 1[56]:[^:]*:Chaos:3180:/
+2200.6 "Fiendish Orbs" sync / 1[56]:[^:]*:Chaos:317C:/
 
 # Orb phase
-2225.6 "Bowels of Agony" sync / 1[56]:Chaos:318A:/ # drift 0.038
-2239.6 "(DPS) Stray Flames" sync / 1[56]:Chaos:318C:/
-2242.6 "(T/H) Stray Spray" sync / 1[56]:Chaos:318D:/
-2267.6 "Soul of Chaos" sync / 1[56]:Chaos:318B:/ window 500,500
+2225.6 "Bowels of Agony" sync / 1[56]:[^:]*:Chaos:318A:/ # drift 0.038
+2239.6 "(DPS) Stray Flames" sync / 1[56]:[^:]*:Chaos:318C:/
+2242.6 "(T/H) Stray Spray" sync / 1[56]:[^:]*:Chaos:318D:/
+2267.6 "Soul of Chaos" sync / 1[56]:[^:]*:Chaos:318B:/ window 500,500
 
 # Fire phase
-2295.3 "Damning Edict" sync / 1[56]:Chaos:3171:/
-2308.3 "Blaze" sync / 1[56]:Chaos:3206:/
-2320.0 "(T/H) Stray Flames" sync / 1[56]:Chaos:318C:/
-2325.8 "Long/Lat Implosion" sync / 1[56]:Chaos:317(2|3):/
-2334.0 "(DPS) Stray Flames" sync / 1[56]:Chaos:318C:/
-2344.8 "Chaotic Dispersion" sync / 1[56]:Chaos:3170:/
-2356.8 "Blaze" sync / 1[56]:Chaos:3206:/
-2368.5 "(T/H) Stray Flames" sync / 1[56]:Chaos:318C:/
-2376.2 "Knock" sync / 1[56]:Chaos:317E:/
-2382.5 "(DPS) Stray Flames" sync / 1[56]:Chaos:318C:/
-2387.0 "Big Bang" sync / 1[56]:Chaos:3180:/
-2395.6 "Fiendish Orbs" sync / 1[56]:Chaos:317C:/
+2295.3 "Damning Edict" sync / 1[56]:[^:]*:Chaos:3171:/
+2308.3 "Blaze" sync / 1[56]:[^:]*:Chaos:3206:/
+2320.0 "(T/H) Stray Flames" sync / 1[56]:[^:]*:Chaos:318C:/
+2325.8 "Long/Lat Implosion" sync / 1[56]:[^:]*:Chaos:317(2|3):/
+2334.0 "(DPS) Stray Flames" sync / 1[56]:[^:]*:Chaos:318C:/
+2344.8 "Chaotic Dispersion" sync / 1[56]:[^:]*:Chaos:3170:/
+2356.8 "Blaze" sync / 1[56]:[^:]*:Chaos:3206:/
+2368.5 "(T/H) Stray Flames" sync / 1[56]:[^:]*:Chaos:318C:/
+2376.2 "Knock" sync / 1[56]:[^:]*:Chaos:317E:/
+2382.5 "(DPS) Stray Flames" sync / 1[56]:[^:]*:Chaos:318C:/
+2387.0 "Big Bang" sync / 1[56]:[^:]*:Chaos:3180:/
+2395.6 "Fiendish Orbs" sync / 1[56]:[^:]*:Chaos:317C:/
 
 # Wind phase
-2417.6 "Cyclone" sync / 1[56]:Chaos:3208:/
-2429.6 "Umbra Smash" sync / 1[56]:Chaos:3175:/
-2437.1 "Cyclone" sync / 1[56]:Chaos:318F:/
-2439.7 "Damning Edict" sync / 1[56]:Chaos:3171:/
-2457.7 "Chaotic Dispersion" sync / 1[56]:Chaos:3170:/
-2469.7 "Cyclone" sync / 1[56]:Chaos:3208:/
-2482.6 "Knock" sync / 1[56]:Chaos:317F:/
-2482.7 "Cyclone" sync / 1[56]:Chaos:318F:/
-2489.4 "Big Bang" sync / 1[56]:Chaos:3181:/
-2500.7 "Fiendish Orbs" sync / 1[56]:Chaos:317D:/
+2417.6 "Cyclone" sync / 1[56]:[^:]*:Chaos:3208:/
+2429.6 "Umbra Smash" sync / 1[56]:[^:]*:Chaos:3175:/
+2437.1 "Cyclone" sync / 1[56]:[^:]*:Chaos:318F:/
+2439.7 "Damning Edict" sync / 1[56]:[^:]*:Chaos:3171:/
+2457.7 "Chaotic Dispersion" sync / 1[56]:[^:]*:Chaos:3170:/
+2469.7 "Cyclone" sync / 1[56]:[^:]*:Chaos:3208:/
+2482.6 "Knock" sync / 1[56]:[^:]*:Chaos:317F:/
+2482.7 "Cyclone" sync / 1[56]:[^:]*:Chaos:318F:/
+2489.4 "Big Bang" sync / 1[56]:[^:]*:Chaos:3181:/
+2500.7 "Fiendish Orbs" sync / 1[56]:[^:]*:Chaos:317D:/
 
 # Enrage phase
-2530.8 "Blaze" sync / 1[56]:Chaos:3206:/
-2538.5 "(ALL) Stray Flames" sync / 1[56]:Chaos:318C:/
-2543.8 "Tsunami" sync / 1[56]:Chaos:3207:/
-2550.4 "(ALL) Stray Spray" sync / 1[56]:Chaos:318D:/
-2556.9 "Cyclone" sync / 1[56]:Chaos:3208:/
+2530.8 "Blaze" sync / 1[56]:[^:]*:Chaos:3206:/
+2538.5 "(ALL) Stray Flames" sync / 1[56]:[^:]*:Chaos:318C:/
+2543.8 "Tsunami" sync / 1[56]:[^:]*:Chaos:3207:/
+2550.4 "(ALL) Stray Spray" sync / 1[56]:[^:]*:Chaos:318D:/
+2556.9 "Cyclone" sync / 1[56]:[^:]*:Chaos:3208:/
 2563.5 "Stray Gusts"
-2569.7 "Earthquake" sync / 1[56]:Chaos:3209:/
+2569.7 "Earthquake" sync / 1[56]:[^:]*:Chaos:3209:/
 2578.0 "Stray Earth"

--- a/ui/raidboss/data/04-sb/trial/byakko-ex.txt
+++ b/ui/raidboss/data/04-sb/trial/byakko-ex.txt
@@ -12,137 +12,137 @@ hideall "Answer On High"
 
 ### Phase 1
 0.0 "--sync--" sync /:Engage!/ window 0,1
-6.9 "--sync--" sync / 14:Byakko:27DC:/ window 20,20
-10.9 "Storm Pulse" sync / 1[56]:Byakko:27DC:/
-17.1 "Heavenly Strike" sync / 1[56]:Byakko:27DA:/
-27.3 "State of Shock 1" sync / 1[56]:Byakko:27E0:/
-28.5 "Clutch" sync / 1[56]:Byakko:27E1:/
-34.7 "Highest Stakes" sync / 1[56]:Byakko:27E2:/
-37.5 "State of Shock 2" sync / 1[56]:Byakko:2756:/
-38.5 "Clutch" sync / 1[56]:Byakko:27E1:/
-44.7 "Highest Stakes" sync / 1[56]:Byakko:27E2:/
+6.9 "--sync--" sync / 14:[^:]*:Byakko:27DC:/ window 20,20
+10.9 "Storm Pulse" sync / 1[56]:[^:]*:Byakko:27DC:/
+17.1 "Heavenly Strike" sync / 1[56]:[^:]*:Byakko:27DA:/
+27.3 "State of Shock 1" sync / 1[56]:[^:]*:Byakko:27E0:/
+28.5 "Clutch" sync / 1[56]:[^:]*:Byakko:27E1:/
+34.7 "Highest Stakes" sync / 1[56]:[^:]*:Byakko:27E2:/
+37.5 "State of Shock 2" sync / 1[56]:[^:]*:Byakko:2756:/
+38.5 "Clutch" sync / 1[56]:[^:]*:Byakko:27E1:/
+44.7 "Highest Stakes" sync / 1[56]:[^:]*:Byakko:27E2:/
 
-55.5 "--middle--" sync / 1[56]:Byakko:2757:/
-59.6 "Unrelenting Anguish" sync / 1[56]:Byakko:27ED:/
-65.8 "Storm Pulse" sync / 1[56]:Byakko:27DC:/
-68.0 "Ominous Wind" sync / 1[56]:Byakko:27EB:/
-77.4 "Fire and Lightning" sync / 1[56]:Byakko:27D9:/
-85.7 "--leap north--" sync / 1[56]:Byakko:2757:/
-87.3 "Dance Of The Incomplete" sync / 1[56]:Byakko:25D1:/
+55.5 "--middle--" sync / 1[56]:[^:]*:Byakko:2757:/
+59.6 "Unrelenting Anguish" sync / 1[56]:[^:]*:Byakko:27ED:/
+65.8 "Storm Pulse" sync / 1[56]:[^:]*:Byakko:27DC:/
+68.0 "Ominous Wind" sync / 1[56]:[^:]*:Byakko:27EB:/
+77.4 "Fire and Lightning" sync / 1[56]:[^:]*:Byakko:27D9:/
+85.7 "--leap north--" sync / 1[56]:[^:]*:Byakko:2757:/
+87.3 "Dance Of The Incomplete" sync / 1[56]:[^:]*:Byakko:25D1:/
 92.2 "--Hakutei Add--"
-103.4 "Storm Pulse" sync / 1[56]:Byakko:27DC:/
-103.4 "Steel Claw" sync / 1[56]:Hakutei:27DF:/
-109.6 "Steel Claw" sync / 1[56]:Hakutei:27DF:/
-113.7 "Heavenly Strike" sync / 1[56]:Byakko:27DA:/
+103.4 "Storm Pulse" sync / 1[56]:[^:]*:Byakko:27DC:/
+103.4 "Steel Claw" sync / 1[56]:[^:]*:Hakutei:27DF:/
+109.6 "Steel Claw" sync / 1[56]:[^:]*:Hakutei:27DF:/
+113.7 "Heavenly Strike" sync / 1[56]:[^:]*:Byakko:27DA:/
 116.6 "--tiger untargetable--"
-122.4 "White Herald" sync / 1[56]:Hakutei:27FA:/
+122.4 "White Herald" sync / 1[56]:[^:]*:Hakutei:27FA:/
 124.4 "--tiger targetable--"
-124.8 "Distant Clap" sync / 1[56]:Byakko:27DD:/
-128.6 "Fire and Lightning" sync / 1[56]:Hakutei:27DE:/
-133.0 "Storm Pulse" sync / 1[56]:Byakko:27DC:/
+124.8 "Distant Clap" sync / 1[56]:[^:]*:Byakko:27DD:/
+128.6 "Fire and Lightning" sync / 1[56]:[^:]*:Hakutei:27DE:/
+133.0 "Storm Pulse" sync / 1[56]:[^:]*:Byakko:27DC:/
 135.1 "--untargetable--"
-135.2 "--sync--" sync / 1[56]:Hakutei:265E:/
-136.6 "The Voice Of Thunder" sync / 1[56]:Hakutei:27F7:/
-159.8 "The Roar Of Thunder" sync / 1[56]:Hakutei:27F9:/
+135.2 "--sync--" sync / 1[56]:[^:]*:Hakutei:265E:/
+136.6 "The Voice Of Thunder" sync / 1[56]:[^:]*:Hakutei:27F7:/
+159.8 "The Roar Of Thunder" sync / 1[56]:[^:]*:Hakutei:27F9:/
 162.9 "--untargetable--"
 
 
 ### Phase 2: zzz x infinity
-191.1 "--sync--" sync / 1[56]:Byakko:27EE:/ window 200,5
-197.2 "Sweep the Leg" sync / 1[56]:Byakko:27F3:/
-208.1 "Imperial Guard" sync / 1[56]:Hakutei:27F1:/
-208.4 "--sync--" sync / 1[56]:Byakko:27EE:/
-220.2 "Imperial Guard" sync / 1[56]:Hakutei:27F1:/
-222.6 "--sync--" sync / 1[56]:Byakko:27EE:/
-228.7 "Sweep the Leg" sync / 1[56]:Byakko:27F3:/
-237.3 "Imperial Guard" sync / 1[56]:Hakutei:27F1:/
+191.1 "--sync--" sync / 1[56]:[^:]*:Byakko:27EE:/ window 200,5
+197.2 "Sweep the Leg" sync / 1[56]:[^:]*:Byakko:27F3:/
+208.1 "Imperial Guard" sync / 1[56]:[^:]*:Hakutei:27F1:/
+208.4 "--sync--" sync / 1[56]:[^:]*:Byakko:27EE:/
+220.2 "Imperial Guard" sync / 1[56]:[^:]*:Hakutei:27F1:/
+222.6 "--sync--" sync / 1[56]:[^:]*:Byakko:27EE:/
+228.7 "Sweep the Leg" sync / 1[56]:[^:]*:Byakko:27F3:/
+237.3 "Imperial Guard" sync / 1[56]:[^:]*:Hakutei:27F1:/
 
 
 ### Phase 3: More Bubbles
-250.1 "--sync--" sync / 1[56]:Byakko:2A2A:/
-265.1 "Fell Swoop" sync / 1[56]:Byakko:27FB:/ window 300,10
-284.4 "Heavenly Strike" sync / 1[56]:Byakko:27DA:/
-290.5 "Answer On High" sync / 1[56]:Byakko:27E4:/
-295.6 "Hundredfold Havoc" sync / 1[56]:Byakko:27E5:/ duration 3.2
-296.6 "State of Shock 1" sync / 1[56]:Byakko:27E0:/
-297.7 "Clutch" sync / 1[56]:Byakko:27E1:/
-298.6 "Hundredfold Havoc" sync / 1[56]:Byakko:27E5:/ duration 3.2
-304.0 "Highest Stakes" sync / 1[56]:Byakko:27E2:/
-306.9 "State of Shock 2" sync / 1[56]:Byakko:2756:/
-307.9 "Clutch" sync / 1[56]:Byakko:27E1:/
-314.1 "Highest Stakes" sync / 1[56]:Byakko:27E2:/
-320.8 "Sweep the Leg" sync / 1[56]:Byakko:27DB:/
+250.1 "--sync--" sync / 1[56]:[^:]*:Byakko:2A2A:/
+265.1 "Fell Swoop" sync / 1[56]:[^:]*:Byakko:27FB:/ window 300,10
+284.4 "Heavenly Strike" sync / 1[56]:[^:]*:Byakko:27DA:/
+290.5 "Answer On High" sync / 1[56]:[^:]*:Byakko:27E4:/
+295.6 "Hundredfold Havoc" sync / 1[56]:[^:]*:Byakko:27E5:/ duration 3.2
+296.6 "State of Shock 1" sync / 1[56]:[^:]*:Byakko:27E0:/
+297.7 "Clutch" sync / 1[56]:[^:]*:Byakko:27E1:/
+298.6 "Hundredfold Havoc" sync / 1[56]:[^:]*:Byakko:27E5:/ duration 3.2
+304.0 "Highest Stakes" sync / 1[56]:[^:]*:Byakko:27E2:/
+306.9 "State of Shock 2" sync / 1[56]:[^:]*:Byakko:2756:/
+307.9 "Clutch" sync / 1[56]:[^:]*:Byakko:27E1:/
+314.1 "Highest Stakes" sync / 1[56]:[^:]*:Byakko:27E2:/
+320.8 "Sweep the Leg" sync / 1[56]:[^:]*:Byakko:27DB:/
 
-330.9 "--sync--" sync / 1[56]:Byakko:2757:/ window 10,10
-335.2 "Unrelenting Anguish" sync / 1[56]:Byakko:27ED:/
-341.4 "Storm Pulse x2" sync / 1[56]:Byakko:27DC:/
-345.6 "Bombogenesis" sync / 1[56]:Byakko:27E7:/
-351.6 "Ominous Wind" sync / 1[56]:Byakko:27EB:/
-353.6 "Gale Force" sync / 1[56]:Byakko:27E8:/
-361.0 "Fire and Lightning" sync / 1[56]:Byakko:27D9:/
-364.1 "--north--" sync / 1[56]:Byakko:2757:/
-369.9 "Fire and Lightning" sync / 1[56]:Byakko:27D9:/
+330.9 "--sync--" sync / 1[56]:[^:]*:Byakko:2757:/ window 10,10
+335.2 "Unrelenting Anguish" sync / 1[56]:[^:]*:Byakko:27ED:/
+341.4 "Storm Pulse x2" sync / 1[56]:[^:]*:Byakko:27DC:/
+345.6 "Bombogenesis" sync / 1[56]:[^:]*:Byakko:27E7:/
+351.6 "Ominous Wind" sync / 1[56]:[^:]*:Byakko:27EB:/
+353.6 "Gale Force" sync / 1[56]:[^:]*:Byakko:27E8:/
+361.0 "Fire and Lightning" sync / 1[56]:[^:]*:Byakko:27D9:/
+364.1 "--north--" sync / 1[56]:[^:]*:Byakko:2757:/
+369.9 "Fire and Lightning" sync / 1[56]:[^:]*:Byakko:27D9:/
 
-373.1 "--sync--" sync / 1[56]:Byakko:2757:/
-374.5 "Dance Of The Incomplete" sync / 1[56]:Byakko:25D1:/
+373.1 "--sync--" sync / 1[56]:[^:]*:Byakko:2757:/
+374.5 "Dance Of The Incomplete" sync / 1[56]:[^:]*:Byakko:25D1:/
 379.5 "--tiger targetable--"
 388.8 "--tiger untargetable--"
-394.5 "White Herald" sync / 1[56]:Hakutei:27FA:/
+394.5 "White Herald" sync / 1[56]:[^:]*:Hakutei:27FA:/
 396.5 "--tiger targetable--"
-396.8 "Distant Clap" sync / 1[56]:Byakko:27DD:/
-400.7 "Fire and Lightning" sync / 1[56]:Hakutei:27DE:/
-405.0 "Distant Clap" sync / 1[56]:Byakko:27DD:/
-408.9 "Fire and Lightning" sync / 1[56]:Hakutei:27DE:/
-416.1 "Steel Claw" sync / 1[56]:Hakutei:27DF:/
-416.4 "Heavenly Strike" sync / 1[56]:Byakko:27DA:/
-422.4 "--sync--" sync / 1[56]:Hakutei:265E:/
-423.9 "The Voice Of Thunder" sync / 1[56]:Hakutei:27F7:/
-436.5 "Storm Pulse x2" sync / 1[56]:Byakko:27DC:/
-447.1 "The Roar Of Thunder" sync / 1[56]:Hakutei:27F9:/
-450.6 "--sync--" sync / 1[56]:Hakutei:29E5:/
+396.8 "Distant Clap" sync / 1[56]:[^:]*:Byakko:27DD:/
+400.7 "Fire and Lightning" sync / 1[56]:[^:]*:Hakutei:27DE:/
+405.0 "Distant Clap" sync / 1[56]:[^:]*:Byakko:27DD:/
+408.9 "Fire and Lightning" sync / 1[56]:[^:]*:Hakutei:27DE:/
+416.1 "Steel Claw" sync / 1[56]:[^:]*:Hakutei:27DF:/
+416.4 "Heavenly Strike" sync / 1[56]:[^:]*:Byakko:27DA:/
+422.4 "--sync--" sync / 1[56]:[^:]*:Hakutei:265E:/
+423.9 "The Voice Of Thunder" sync / 1[56]:[^:]*:Hakutei:27F7:/
+436.5 "Storm Pulse x2" sync / 1[56]:[^:]*:Byakko:27DC:/
+447.1 "The Roar Of Thunder" sync / 1[56]:[^:]*:Hakutei:27F9:/
+450.6 "--sync--" sync / 1[56]:[^:]*:Hakutei:29E5:/
 
-451.5 "--sync--" sync / 1[56]:Byakko:29E4:/
-453.5 "--sync--" sync / 1[56]:Byakko:2757:/
-459.3 "Fire and Lightning" sync / 1[56]:Byakko:27D9:/
-474.5 "Storm Pulse x2" sync / 1[56]:Byakko:27DC:/
-484.8 "Bombogenesis" sync / 1[56]:Byakko:27E7:/
-487.0 "Answer On High" sync / 1[56]:Byakko:27E4:/
-492.0 "Hundredfold Havoc" sync / 1[56]:Byakko:27E5:/ duration 3.2
-492.9 "Gale Force" sync / 1[56]:Byakko:27E8:/
-495.1 "Hundredfold Havoc" sync / 1[56]:Byakko:27E5:/ duration 3.2
-495.8 "State of Shock 1" sync / 1[56]:Byakko:27E0:/
-496.9 "Clutch" sync / 1[56]:Byakko:27E1:/
-503.2 "Highest Stakes" sync / 1[56]:Byakko:27E2:/
-505.8 "State of Shock 2" sync / 1[56]:Byakko:2756:/
-506.9 "Clutch" sync / 1[56]:Byakko:27E1:/
-513.2 "Highest Stakes" sync / 1[56]:Byakko:27E2:/
-519.7 "Sweep the Leg" sync / 1[56]:Byakko:27DB:/
-534.2 "Heavenly Strike" sync / 1[56]:Byakko:27DA:/
-544.5 "Storm Pulse x2" sync / 1[56]:Byakko:27DC:/
-557.9 "Distant Clap" sync / 1[56]:Byakko:27DD:/
-564.1 "Heavenly Strike" sync / 1[56]:Byakko:27DA:/
+451.5 "--sync--" sync / 1[56]:[^:]*:Byakko:29E4:/
+453.5 "--sync--" sync / 1[56]:[^:]*:Byakko:2757:/
+459.3 "Fire and Lightning" sync / 1[56]:[^:]*:Byakko:27D9:/
+474.5 "Storm Pulse x2" sync / 1[56]:[^:]*:Byakko:27DC:/
+484.8 "Bombogenesis" sync / 1[56]:[^:]*:Byakko:27E7:/
+487.0 "Answer On High" sync / 1[56]:[^:]*:Byakko:27E4:/
+492.0 "Hundredfold Havoc" sync / 1[56]:[^:]*:Byakko:27E5:/ duration 3.2
+492.9 "Gale Force" sync / 1[56]:[^:]*:Byakko:27E8:/
+495.1 "Hundredfold Havoc" sync / 1[56]:[^:]*:Byakko:27E5:/ duration 3.2
+495.8 "State of Shock 1" sync / 1[56]:[^:]*:Byakko:27E0:/
+496.9 "Clutch" sync / 1[56]:[^:]*:Byakko:27E1:/
+503.2 "Highest Stakes" sync / 1[56]:[^:]*:Byakko:27E2:/
+505.8 "State of Shock 2" sync / 1[56]:[^:]*:Byakko:2756:/
+506.9 "Clutch" sync / 1[56]:[^:]*:Byakko:27E1:/
+513.2 "Highest Stakes" sync / 1[56]:[^:]*:Byakko:27E2:/
+519.7 "Sweep the Leg" sync / 1[56]:[^:]*:Byakko:27DB:/
+534.2 "Heavenly Strike" sync / 1[56]:[^:]*:Byakko:27DA:/
+544.5 "Storm Pulse x2" sync / 1[56]:[^:]*:Byakko:27DC:/
+557.9 "Distant Clap" sync / 1[56]:[^:]*:Byakko:27DD:/
+564.1 "Heavenly Strike" sync / 1[56]:[^:]*:Byakko:27DA:/
 
-572.2 "--middle--" sync / 1[56]:Byakko:2757:/
-576.3 "Unrelenting Anguish" sync / 1[56]:Byakko:27ED:/
-582.4 "Storm Pulse x2" sync / 1[56]:Byakko:27DC:/
-586.7 "Bombogenesis" sync / 1[56]:Byakko:27E7:/
-592.8 "Ominous Wind" sync / 1[56]:Byakko:27EB:/
-594.7 "Gale Force" sync / 1[56]:Byakko:27E8:/
-602.1 "Fire and Lightning" sync / 1[56]:Byakko:27D9:/
-605.3 "--north--" sync / 1[56]:Byakko:2757:/
-611.0 "Fire and Lightning" sync / 1[56]:Byakko:27D9:/
-626.2 "Storm Pulse x2" sync / 1[56]:Byakko:27DC:/
-634.4 "Answer On High" sync / 1[56]:Byakko:27E4:/
-639.4 "Hundredfold Havoc" sync / 1[56]:Byakko:27E5:/
-640.5 "State of Shock 1" sync / 1[56]:Byakko:27E0:/
-641.6 "Clutch" sync / 1[56]:Byakko:27E1:/
-642.5 "Hundredfold Havoc" sync / 1[56]:Byakko:27E5:/
-647.9 "Highest Stakes" sync / 1[56]:Byakko:27E2:/
-650.8 "State of Shock 2" sync / 1[56]:Byakko:2756:/
-651.8 "Clutch" sync / 1[56]:Byakko:27E1:/
-658.1 "Highest Stakes" sync / 1[56]:Byakko:27E2:/
-664.8 "Sweep the Leg" sync / 1[56]:Byakko:27DB:/
+572.2 "--middle--" sync / 1[56]:[^:]*:Byakko:2757:/
+576.3 "Unrelenting Anguish" sync / 1[56]:[^:]*:Byakko:27ED:/
+582.4 "Storm Pulse x2" sync / 1[56]:[^:]*:Byakko:27DC:/
+586.7 "Bombogenesis" sync / 1[56]:[^:]*:Byakko:27E7:/
+592.8 "Ominous Wind" sync / 1[56]:[^:]*:Byakko:27EB:/
+594.7 "Gale Force" sync / 1[56]:[^:]*:Byakko:27E8:/
+602.1 "Fire and Lightning" sync / 1[56]:[^:]*:Byakko:27D9:/
+605.3 "--north--" sync / 1[56]:[^:]*:Byakko:2757:/
+611.0 "Fire and Lightning" sync / 1[56]:[^:]*:Byakko:27D9:/
+626.2 "Storm Pulse x2" sync / 1[56]:[^:]*:Byakko:27DC:/
+634.4 "Answer On High" sync / 1[56]:[^:]*:Byakko:27E4:/
+639.4 "Hundredfold Havoc" sync / 1[56]:[^:]*:Byakko:27E5:/
+640.5 "State of Shock 1" sync / 1[56]:[^:]*:Byakko:27E0:/
+641.6 "Clutch" sync / 1[56]:[^:]*:Byakko:27E1:/
+642.5 "Hundredfold Havoc" sync / 1[56]:[^:]*:Byakko:27E5:/
+647.9 "Highest Stakes" sync / 1[56]:[^:]*:Byakko:27E2:/
+650.8 "State of Shock 2" sync / 1[56]:[^:]*:Byakko:2756:/
+651.8 "Clutch" sync / 1[56]:[^:]*:Byakko:27E1:/
+658.1 "Highest Stakes" sync / 1[56]:[^:]*:Byakko:27E2:/
+664.8 "Sweep the Leg" sync / 1[56]:[^:]*:Byakko:27DB:/
 
-674.9 "--middle--" sync / 1[56]:Byakko:2757:/
-680.2 "Storm Pulse x4" sync / 1[56]:Byakko:27DC:/
-696.3 "Storm Pulse Enrage" sync / 1[56]:Byakko:2A09:/
+674.9 "--middle--" sync / 1[56]:[^:]*:Byakko:2757:/
+680.2 "Storm Pulse x4" sync / 1[56]:[^:]*:Byakko:27DC:/
+696.3 "Storm Pulse Enrage" sync / 1[56]:[^:]*:Byakko:2A09:/

--- a/ui/raidboss/data/04-sb/trial/byakko.txt
+++ b/ui/raidboss/data/04-sb/trial/byakko.txt
@@ -14,103 +14,103 @@ hideall "Clutch"
 
 ### Phase 1
 0.0 "--sync--" sync /:Engage!/ window 0,1
-7.4 "--sync--" sync / 14:Byakko:2A2F:/ window 10,10
-11.4 "Storm Pulse" sync / 1[56]:Byakko:2A2F:/
-17.6 "Heavenly Strike" sync / 1[56]:Byakko:2A2D:/
-28.7 "State Of Shock" sync / 1[56]:Byakko:27E0:/
-29.8 "Clutch" sync / 1[56]:Byakko:27E1:/
-36.1 "Highest Stakes" sync / 1[56]:Byakko:27E2:/
-42.7 "Sweep The Leg" sync / 1[56]:Byakko:2A2E:/
-54.9 "Heavenly Strike" sync / 1[56]:Byakko:2A2D:/
-62.0 "--middle--" sync / 1[56]:Byakko:2757:/
-66.1 "Unrelenting Anguish" sync / 1[56]:Byakko:27ED:/
-71.4 "Aratama" sync / 1[56]:Aratama Force:2A48:/
-72.3 "Storm Pulse" sync / 1[56]:Byakko:2A2F:/
-78.5 "Fire And Lightning" sync / 1[56]:Byakko:2A2C:/
-85.8 "Fire And Lightning" sync / 1[56]:Byakko:2A2C:/
-89.0 "--jump--" sync / 1[56]:Byakko:2757:/
-94.7 "Fire And Lightning" sync / 1[56]:Byakko:2A2C:/
-105.9 "--sync--" sync / 1[56]:Byakko:2757:/
-107.7 "Dance Of The Incomplete" sync / 1[56]:Byakko:25D1:/
-107.8 "--sync--" sync / 1[56]:Hakutei:25CF:/
+7.4 "--sync--" sync / 14:[^:]*:Byakko:2A2F:/ window 10,10
+11.4 "Storm Pulse" sync / 1[56]:[^:]*:Byakko:2A2F:/
+17.6 "Heavenly Strike" sync / 1[56]:[^:]*:Byakko:2A2D:/
+28.7 "State Of Shock" sync / 1[56]:[^:]*:Byakko:27E0:/
+29.8 "Clutch" sync / 1[56]:[^:]*:Byakko:27E1:/
+36.1 "Highest Stakes" sync / 1[56]:[^:]*:Byakko:27E2:/
+42.7 "Sweep The Leg" sync / 1[56]:[^:]*:Byakko:2A2E:/
+54.9 "Heavenly Strike" sync / 1[56]:[^:]*:Byakko:2A2D:/
+62.0 "--middle--" sync / 1[56]:[^:]*:Byakko:2757:/
+66.1 "Unrelenting Anguish" sync / 1[56]:[^:]*:Byakko:27ED:/
+71.4 "Aratama" sync / 1[56]:[^:]*:Aratama Force:2A48:/
+72.3 "Storm Pulse" sync / 1[56]:[^:]*:Byakko:2A2F:/
+78.5 "Fire And Lightning" sync / 1[56]:[^:]*:Byakko:2A2C:/
+85.8 "Fire And Lightning" sync / 1[56]:[^:]*:Byakko:2A2C:/
+89.0 "--jump--" sync / 1[56]:[^:]*:Byakko:2757:/
+94.7 "Fire And Lightning" sync / 1[56]:[^:]*:Byakko:2A2C:/
+105.9 "--sync--" sync / 1[56]:[^:]*:Byakko:2757:/
+107.7 "Dance Of The Incomplete" sync / 1[56]:[^:]*:Byakko:25D1:/
+107.8 "--sync--" sync / 1[56]:[^:]*:Hakutei:25CF:/
 111.7 "--untargetable--"
 
 ### Hakutei add
 112.7 "--targetable--"
-119.3 "Aratama" sync / 1[56]:Hakutei:2A29:/
-121.9 "Steel Claw 1" sync / 1[56]:Hakutei:2A32:/
-128.0 "Steel Claw 2" sync / 1[56]:Hakutei:2A32:/
+119.3 "Aratama" sync / 1[56]:[^:]*:Hakutei:2A29:/
+121.9 "Steel Claw 1" sync / 1[56]:[^:]*:Hakutei:2A32:/
+128.0 "Steel Claw 2" sync / 1[56]:[^:]*:Hakutei:2A32:/
 134.0 "--untargetable--"
-139.8 "White Herald" sync / 1[56]:Hakutei:2A4C:/
+139.8 "White Herald" sync / 1[56]:[^:]*:Hakutei:2A4C:/
 141.8 "--targetable--"
-145.9 "Fire And Lightning" sync / 1[56]:Hakutei:2A31:/
-149.1 "--sync--" sync / 1[56]:Hakutei:265E:/
-150.3 "The Voice Of Thunder" sync / 1[56]:Hakutei:2A49:/
-173.4 "The Roar Of Thunder" sync / 1[56]:Hakutei:2A4B:/
+145.9 "Fire And Lightning" sync / 1[56]:[^:]*:Hakutei:2A31:/
+149.1 "--sync--" sync / 1[56]:[^:]*:Hakutei:265E:/
+150.3 "The Voice Of Thunder" sync / 1[56]:[^:]*:Hakutei:2A49:/
+173.4 "The Roar Of Thunder" sync / 1[56]:[^:]*:Hakutei:2A4B:/
 176.5 "--untargetable--"
 
 ### Midphase
-204.3 "--sync--" sync / 1[56]:Byakko:27EE:/ window 210,10
-218.6 "Sweep The Leg" sync / 1[56]:Byakko:2A46:/
-222.6 "--sync--" sync / 1[56]:Byakko:27EE:/
-224.3 "Imperial Guard" sync / 1[56]:Hakutei:2A43:/
-238.3 "Imperial Guard" sync / 1[56]:Hakutei:2A43:/
-242.8 "Sweep The Leg" sync / 1[56]:Byakko:2A46:/
-248.3 "Imperial Guard" sync / 1[56]:Hakutei:2A43:/
+204.3 "--sync--" sync / 1[56]:[^:]*:Byakko:27EE:/ window 210,10
+218.6 "Sweep The Leg" sync / 1[56]:[^:]*:Byakko:2A46:/
+222.6 "--sync--" sync / 1[56]:[^:]*:Byakko:27EE:/
+224.3 "Imperial Guard" sync / 1[56]:[^:]*:Hakutei:2A43:/
+238.3 "Imperial Guard" sync / 1[56]:[^:]*:Hakutei:2A43:/
+242.8 "Sweep The Leg" sync / 1[56]:[^:]*:Byakko:2A46:/
+248.3 "Imperial Guard" sync / 1[56]:[^:]*:Hakutei:2A43:/
 
 ### Final phase loop
-259.3 "--sync--" sync / 1[56]:Byakko:2A2A:/ window 260,100
-274.3 "Fell Swoop" sync / 1[56]:Byakko:2A4D:/
+259.3 "--sync--" sync / 1[56]:[^:]*:Byakko:2A2A:/ window 260,100
+274.3 "Fell Swoop" sync / 1[56]:[^:]*:Byakko:2A4D:/
 
-294.5 "Heavenly Strike" sync / 1[56]:Byakko:2A2D:/
-300.6 "Answer On High" sync / 1[56]:Byakko:27E4:/
-305.6 "Hundredfold Havoc 1" sync / 1[56]:Byakko:2A38:/
-308.6 "Hundredfold Havoc 2" sync / 1[56]:Byakko:2A38:/
-316.7 "Bombogenesis" sync / 1[56]:Byakko:2A3B:/
-320.8 "Distant Clap" sync / 1[56]:Byakko:2A30:/
+294.5 "Heavenly Strike" sync / 1[56]:[^:]*:Byakko:2A2D:/
+300.6 "Answer On High" sync / 1[56]:[^:]*:Byakko:27E4:/
+305.6 "Hundredfold Havoc 1" sync / 1[56]:[^:]*:Byakko:2A38:/
+308.6 "Hundredfold Havoc 2" sync / 1[56]:[^:]*:Byakko:2A38:/
+316.7 "Bombogenesis" sync / 1[56]:[^:]*:Byakko:2A3B:/
+320.8 "Distant Clap" sync / 1[56]:[^:]*:Byakko:2A30:/
 
-326.9 "Answer On High" sync / 1[56]:Byakko:27E4:/
-331.9 "Hundredfold Havoc 1" sync / 1[56]:Byakko:2A38:/
-333.0 "State Of Shock 1" sync / 1[56]:Byakko:27E0:/
-334.1 "Clutch" sync / 1[56]:Byakko:27E1:/
-334.9 "Hundredfold Havoc 2" sync / 1[56]:Byakko:2A38:/
-340.3 "Highest Stakes 1" sync / 1[56]:Byakko:27E2:/
-342.9 "State Of Shock 2" sync / 1[56]:Byakko:2756:/
-344.0 "Clutch" sync / 1[56]:Byakko:27E1:/
-350.3 "Highest Stakes 2" sync / 1[56]:Byakko:27E2:/
-356.9 "Sweep The Leg" sync / 1[56]:Byakko:2A2E:/
-362.2 "--sync--" sync / 1[56]:Byakko:2757:/
-367.0 "Bombogenesis" sync / 1[56]:Byakko:2A3B:/
-367.8 "Fire And Lightning" sync / 1[56]:Byakko:2A2C:/
-383.1 "Heavenly Strike" sync / 1[56]:Byakko:2A2D:/
-393.2 "Sweep The Leg" sync / 1[56]:Byakko:2A2E:/
+326.9 "Answer On High" sync / 1[56]:[^:]*:Byakko:27E4:/
+331.9 "Hundredfold Havoc 1" sync / 1[56]:[^:]*:Byakko:2A38:/
+333.0 "State Of Shock 1" sync / 1[56]:[^:]*:Byakko:27E0:/
+334.1 "Clutch" sync / 1[56]:[^:]*:Byakko:27E1:/
+334.9 "Hundredfold Havoc 2" sync / 1[56]:[^:]*:Byakko:2A38:/
+340.3 "Highest Stakes 1" sync / 1[56]:[^:]*:Byakko:27E2:/
+342.9 "State Of Shock 2" sync / 1[56]:[^:]*:Byakko:2756:/
+344.0 "Clutch" sync / 1[56]:[^:]*:Byakko:27E1:/
+350.3 "Highest Stakes 2" sync / 1[56]:[^:]*:Byakko:27E2:/
+356.9 "Sweep The Leg" sync / 1[56]:[^:]*:Byakko:2A2E:/
+362.2 "--sync--" sync / 1[56]:[^:]*:Byakko:2757:/
+367.0 "Bombogenesis" sync / 1[56]:[^:]*:Byakko:2A3B:/
+367.8 "Fire And Lightning" sync / 1[56]:[^:]*:Byakko:2A2C:/
+383.1 "Heavenly Strike" sync / 1[56]:[^:]*:Byakko:2A2D:/
+393.2 "Sweep The Leg" sync / 1[56]:[^:]*:Byakko:2A2E:/
 
-399.4 "--middle--" sync / 1[56]:Byakko:2757:/
-403.7 "Unrelenting Anguish" sync / 1[56]:Byakko:27ED:/
-409.8 "Storm Pulse x2" sync / 1[56]:Byakko:2A2F:/
-418.2 "Fire And Lightning" sync / 1[56]:Byakko:2A2C:/
-424.5 "--sync--" sync / 1[56]:Byakko:2757:/
-429.4 "Bombogenesis" sync / 1[56]:Byakko:2A3B:/
-430.3 "Fire And Lightning" sync / 1[56]:Byakko:2A2C:/
-445.6 "Heavenly Strike" sync / 1[56]:Byakko:2A2D:/
-455.7 "Storm Pulse x2" sync / 1[56]:Byakko:2A2F:/
-463.9 "Sweep The Leg" sync / 1[56]:Byakko:2A2E:/
-474.0 "Storm Pulse x2" sync / 1[56]:Byakko:2A2F:/
+399.4 "--middle--" sync / 1[56]:[^:]*:Byakko:2757:/
+403.7 "Unrelenting Anguish" sync / 1[56]:[^:]*:Byakko:27ED:/
+409.8 "Storm Pulse x2" sync / 1[56]:[^:]*:Byakko:2A2F:/
+418.2 "Fire And Lightning" sync / 1[56]:[^:]*:Byakko:2A2C:/
+424.5 "--sync--" sync / 1[56]:[^:]*:Byakko:2757:/
+429.4 "Bombogenesis" sync / 1[56]:[^:]*:Byakko:2A3B:/
+430.3 "Fire And Lightning" sync / 1[56]:[^:]*:Byakko:2A2C:/
+445.6 "Heavenly Strike" sync / 1[56]:[^:]*:Byakko:2A2D:/
+455.7 "Storm Pulse x2" sync / 1[56]:[^:]*:Byakko:2A2F:/
+463.9 "Sweep The Leg" sync / 1[56]:[^:]*:Byakko:2A2E:/
+474.0 "Storm Pulse x2" sync / 1[56]:[^:]*:Byakko:2A2F:/
 
-483.3 "Answer On High" sync / 1[56]:Byakko:27E4:/
-488.3 "Hundredfold Havoc 1" sync / 1[56]:Byakko:2A38:/
-491.3 "Hundredfold Havoc 2" sync / 1[56]:Byakko:2A38:/
-499.4 "Bombogenesis" sync / 1[56]:Byakko:2A3B:/
-503.5 "Distant Clap" sync / 1[56]:Byakko:2A30:/
-509.6 "Storm Pulse x2" sync / 1[56]:Byakko:2A2F:/
+483.3 "Answer On High" sync / 1[56]:[^:]*:Byakko:27E4:/
+488.3 "Hundredfold Havoc 1" sync / 1[56]:[^:]*:Byakko:2A38:/
+491.3 "Hundredfold Havoc 2" sync / 1[56]:[^:]*:Byakko:2A38:/
+499.4 "Bombogenesis" sync / 1[56]:[^:]*:Byakko:2A3B:/
+503.5 "Distant Clap" sync / 1[56]:[^:]*:Byakko:2A30:/
+509.6 "Storm Pulse x2" sync / 1[56]:[^:]*:Byakko:2A2F:/
 
 # loop
-517.8 "Answer On High" sync / 1[56]:Byakko:27E4:/ window 20,20 jump 326.9
-522.8 "Hundredfold Havoc 1" #sync / 1[56]:Byakko:2A38:/
-523.9 "State Of Shock 1" #sync / 1[56]:Byakko:27E0:/
-525.0 "Clutch" #sync / 1[56]:Byakko:27E1:/
-525.8 "Hundredfold Havoc 2" #sync / 1[56]:Byakko:2A38:/
-531.2 "Highest Stakes 1" #sync / 1[56]:Byakko:27E2:/
-533.8 "State Of Shock 2" #sync / 1[56]:Byakko:2756:/
-534.9 "Clutch" #sync / 1[56]:Byakko:27E1:/
-541.2 "Highest Stakes 2" #sync / 1[56]:Byakko:27E2:/
+517.8 "Answer On High" sync / 1[56]:[^:]*:Byakko:27E4:/ window 20,20 jump 326.9
+522.8 "Hundredfold Havoc 1" #sync / 1[56]:[^:]*:Byakko:2A38:/
+523.9 "State Of Shock 1" #sync / 1[56]:[^:]*:Byakko:27E0:/
+525.0 "Clutch" #sync / 1[56]:[^:]*:Byakko:27E1:/
+525.8 "Hundredfold Havoc 2" #sync / 1[56]:[^:]*:Byakko:2A38:/
+531.2 "Highest Stakes 1" #sync / 1[56]:[^:]*:Byakko:27E2:/
+533.8 "State Of Shock 2" #sync / 1[56]:[^:]*:Byakko:2756:/
+534.9 "Clutch" #sync / 1[56]:[^:]*:Byakko:27E1:/
+541.2 "Highest Stakes 2" #sync / 1[56]:[^:]*:Byakko:27E2:/

--- a/ui/raidboss/data/04-sb/trial/lakshmi-ex.txt
+++ b/ui/raidboss/data/04-sb/trial/lakshmi-ex.txt
@@ -11,45 +11,45 @@ hideall "Alluring Arm"
 
 ### Adds
 0.0 "--sync--" sync /:Engage!/ window 0,1
-4.0 "Vril" sync / 1[56]:Dreaming Kshatriya:2146:/ window 10,10
-12.1 "Tail Slap" sync / 1[56]:Dreaming Kshatriya:258C:/
-16.0 "Stotram" sync / 1[56]:Lakshmi:2147:/
-16.9 "Inner Demons" sync / 1[56]:Dreaming Kshatriya:258D:/
-28.1 "Inner Demons" sync / 1[56]:Dreaming Kshatriya:258D:/
-29.0 "Tail Slap" sync / 1[56]:Dreaming Kshatriya:258C:/
+4.0 "Vril" sync / 1[56]:[^:]*:Dreaming Kshatriya:2146:/ window 10,10
+12.1 "Tail Slap" sync / 1[56]:[^:]*:Dreaming Kshatriya:258C:/
+16.0 "Stotram" sync / 1[56]:[^:]*:Lakshmi:2147:/
+16.9 "Inner Demons" sync / 1[56]:[^:]*:Dreaming Kshatriya:258D:/
+28.1 "Inner Demons" sync / 1[56]:[^:]*:Dreaming Kshatriya:258D:/
+29.0 "Tail Slap" sync / 1[56]:[^:]*:Dreaming Kshatriya:258C:/
 
 # infinite loop
 60.0 "--sync--" sync /.*/ window 0,30 jump 30
 
 ### Warmup
 # first auto comes out before rp text.
-107.2 "Hand Of Grace" sync / 1[56]:Lakshmi:214C:/ window 110,0
-114.4 "The Pull Of Light" sync / 1[56]:Lakshmi:215E:/
-121.4 "Blissful Arrow" sync / 1[56]:Lakshmi:214F:/
-122.0 "Blissful Spear" sync / 1[56]:Lakshmi:2151:/
-124.6 "Stotram" sync / 1[56]:Lakshmi:2147:/
-135.8 "The Pull Of Light" sync / 1[56]:Lakshmi:215E:/
-143.1 "The Path Of Light" sync / 1[56]:Lakshmi:215A:/
-153.2 "Alluring Arm" sync / 1[56]:Lakshmi:214E:/
-160.4 "The Pull Of Light" sync / 1[56]:Lakshmi:215E:/
-167.5 "Blissful Hammer" sync / 1[56]:Lakshmi:21DC:/
-170.6 "Stotram" sync / 1[56]:Lakshmi:2147:/
-177.8 "The Pall Of Light" sync / 1[56]:Lakshmi:215C:/
-187.0 "The Pull Of Light" sync / 1[56]:Lakshmi:215E:/
+107.2 "Hand Of Grace" sync / 1[56]:[^:]*:Lakshmi:214C:/ window 110,0
+114.4 "The Pull Of Light" sync / 1[56]:[^:]*:Lakshmi:215E:/
+121.4 "Blissful Arrow" sync / 1[56]:[^:]*:Lakshmi:214F:/
+122.0 "Blissful Spear" sync / 1[56]:[^:]*:Lakshmi:2151:/
+124.6 "Stotram" sync / 1[56]:[^:]*:Lakshmi:2147:/
+135.8 "The Pull Of Light" sync / 1[56]:[^:]*:Lakshmi:215E:/
+143.1 "The Path Of Light" sync / 1[56]:[^:]*:Lakshmi:215A:/
+153.2 "Alluring Arm" sync / 1[56]:[^:]*:Lakshmi:214E:/
+160.4 "The Pull Of Light" sync / 1[56]:[^:]*:Lakshmi:215E:/
+167.5 "Blissful Hammer" sync / 1[56]:[^:]*:Lakshmi:21DC:/
+170.6 "Stotram" sync / 1[56]:[^:]*:Lakshmi:2147:/
+177.8 "The Pall Of Light" sync / 1[56]:[^:]*:Lakshmi:215C:/
+187.0 "The Pull Of Light" sync / 1[56]:[^:]*:Lakshmi:215E:/
 
 ### Chanchala #1
-195.2 "Chanchala #1" sync / 1[56]:Lakshmi:2148:/
-209.0 "Divine Denial" sync / 1[56]:Lakshmi:2149:/
-217.2 "Hand Of Beauty" sync / 1[56]:Lakshmi:214D:/
-224.4 "The Pull Of Light" sync / 1[56]:Lakshmi:215F:/
-231.4 "Blissful Hammer" sync / 1[56]:Lakshmi:21DD:/
-231.7 "The Path Of Light" sync / 1[56]:Lakshmi:215B:/
-245.0 "Divine Desire" sync / 1[56]:Lakshmi:214B:/
+195.2 "Chanchala #1" sync / 1[56]:[^:]*:Lakshmi:2148:/
+209.0 "Divine Denial" sync / 1[56]:[^:]*:Lakshmi:2149:/
+217.2 "Hand Of Beauty" sync / 1[56]:[^:]*:Lakshmi:214D:/
+224.4 "The Pull Of Light" sync / 1[56]:[^:]*:Lakshmi:215F:/
+231.4 "Blissful Hammer" sync / 1[56]:[^:]*:Lakshmi:21DD:/
+231.7 "The Path Of Light" sync / 1[56]:[^:]*:Lakshmi:215B:/
+245.0 "Divine Desire" sync / 1[56]:[^:]*:Lakshmi:214B:/
 247.1 "--chanchala end--"
 
-257.3 "The Pull Of Light" sync / 1[56]:Lakshmi:215E:/
-269.7 "The Path Of Light" sync / 1[56]:Lakshmi:215A:/
-277.8 "Stotram" sync / 1[56]:Lakshmi:2147:/
+257.3 "The Pull Of Light" sync / 1[56]:[^:]*:Lakshmi:215E:/
+269.7 "The Path Of Light" sync / 1[56]:[^:]*:Lakshmi:215A:/
+277.8 "Stotram" sync / 1[56]:[^:]*:Lakshmi:2147:/
 281.5 "--untargetable--"
 
 ### More Adds
@@ -58,52 +58,52 @@ hideall "Alluring Arm"
 335.0 "--sync--" sync /.*/ window 0,50 jump 300
 
 ### Hugging
-400.0 "Jagadishwari" sync / 1[56]:Lakshmi:2342:/ window 400,0
+400.0 "Jagadishwari" sync / 1[56]:[^:]*:Lakshmi:2342:/ window 400,0
 421.4 "/dance"
-421.4 "--sync--" sync / 1[56]:Lakshmi:2159:/
-437.1 "Alluring Embrace" sync / 1[56]:Lakshmi:2343:/
+421.4 "--sync--" sync / 1[56]:[^:]*:Lakshmi:2159:/
+437.1 "Alluring Embrace" sync / 1[56]:[^:]*:Lakshmi:2343:/
 441.5 "--targetable--"
 
 ### Chanchala #2
-441.7 "--sync--" sync / 14:Lakshmi:2148:/ window 50,10
-444.7 "Chanchala #2" sync / 1[56]:Lakshmi:2148:/
-458.5 "Divine Doubt" sync / 1[56]:Lakshmi:214A:/
-473.9 "The Path Of Light" sync / 1[56]:Lakshmi:215B:/
-484.0 "The Pull Of Light" sync / 1[56]:Lakshmi:215F:/
+441.7 "--sync--" sync / 14:[^:]*:Lakshmi:2148:/ window 50,10
+444.7 "Chanchala #2" sync / 1[56]:[^:]*:Lakshmi:2148:/
+458.5 "Divine Doubt" sync / 1[56]:[^:]*:Lakshmi:214A:/
+473.9 "The Path Of Light" sync / 1[56]:[^:]*:Lakshmi:215B:/
+484.0 "The Pull Of Light" sync / 1[56]:[^:]*:Lakshmi:215F:/
 486.0 "--chanchala end--"
-509.5 "The Pull Of Light" sync / 1[56]:Lakshmi:215E:/
-511.5 "Blissful Spear (Z)" sync / 1[56]:Lakshmi:2166:/
+509.5 "The Pull Of Light" sync / 1[56]:[^:]*:Lakshmi:215E:/
+511.5 "Blissful Spear (Z)" sync / 1[56]:[^:]*:Lakshmi:2166:/
 
-525.9 "The Path Of Light" sync / 1[56]:Lakshmi:215A:/
-528.8 "Blissful Spear (mid)" sync / 1[56]:Lakshmi:2156:/
-533.1 "The Pall Of Light" sync / 1[56]:Lakshmi:215C:/
-544.3 "Alluring Arm" sync / 1[56]:Lakshmi:214E:/
-551.5 "The Pull Of Light" sync / 1[56]:Lakshmi:215E:/
-558.6 "Blissful Hammer" sync / 1[56]:Lakshmi:21DC:/
-558.9 "The Path Of Light" sync / 1[56]:Lakshmi:215A:/
-569.0 "Stotram" sync / 1[56]:Lakshmi:2147:/
+525.9 "The Path Of Light" sync / 1[56]:[^:]*:Lakshmi:215A:/
+528.8 "Blissful Spear (mid)" sync / 1[56]:[^:]*:Lakshmi:2156:/
+533.1 "The Pall Of Light" sync / 1[56]:[^:]*:Lakshmi:215C:/
+544.3 "Alluring Arm" sync / 1[56]:[^:]*:Lakshmi:214E:/
+551.5 "The Pull Of Light" sync / 1[56]:[^:]*:Lakshmi:215E:/
+558.6 "Blissful Hammer" sync / 1[56]:[^:]*:Lakshmi:21DC:/
+558.9 "The Path Of Light" sync / 1[56]:[^:]*:Lakshmi:215A:/
+569.0 "Stotram" sync / 1[56]:[^:]*:Lakshmi:2147:/
 
 ### Chanchala #3
-580.3 "Chanchala #3" sync / 1[56]:Lakshmi:2148:/
-595.6 "Divine Doubt" sync / 1[56]:Lakshmi:214A:/
-610.8 "The Pall Of Light" sync / 1[56]:Lakshmi:215D:/
-636.5 "Divine Desire" sync / 1[56]:Lakshmi:214B:/
-638.2 "Blissful Spear (out)" sync / 1[56]:Lakshmi:2154:/
-650.8 "The Pall Of Light" sync / 1[56]:Lakshmi:215D:/
-651.8 "Blissful Spear (Z)" sync / 1[56]:Lakshmi:2166:/
-664.0 "Stotram" sync / 1[56]:Lakshmi:249D:/
+580.3 "Chanchala #3" sync / 1[56]:[^:]*:Lakshmi:2148:/
+595.6 "Divine Doubt" sync / 1[56]:[^:]*:Lakshmi:214A:/
+610.8 "The Pall Of Light" sync / 1[56]:[^:]*:Lakshmi:215D:/
+636.5 "Divine Desire" sync / 1[56]:[^:]*:Lakshmi:214B:/
+638.2 "Blissful Spear (out)" sync / 1[56]:[^:]*:Lakshmi:2154:/
+650.8 "The Pall Of Light" sync / 1[56]:[^:]*:Lakshmi:215D:/
+651.8 "Blissful Spear (Z)" sync / 1[56]:[^:]*:Lakshmi:2166:/
+664.0 "Stotram" sync / 1[56]:[^:]*:Lakshmi:249D:/
 666.1 "--chanchala end--"
-675.3 "Alluring Arm" sync / 1[56]:Lakshmi:214E:/
-682.5 "The Pall Of Light" sync / 1[56]:Lakshmi:215C:/
-689.5 "Blissful Hammer" sync / 1[56]:Lakshmi:21DC:/
-689.8 "The Path Of Light" sync / 1[56]:Lakshmi:215A:/
-697.9 "Stotram" sync / 1[56]:Lakshmi:2147:/
+675.3 "Alluring Arm" sync / 1[56]:[^:]*:Lakshmi:214E:/
+682.5 "The Pall Of Light" sync / 1[56]:[^:]*:Lakshmi:215C:/
+689.5 "Blissful Hammer" sync / 1[56]:[^:]*:Lakshmi:21DC:/
+689.8 "The Path Of Light" sync / 1[56]:[^:]*:Lakshmi:215A:/
+697.9 "Stotram" sync / 1[56]:[^:]*:Lakshmi:2147:/
 
-708.1 "The Pull Of Light" sync / 1[56]:Lakshmi:215E:/
-718.3 "Alluring Arm" sync / 1[56]:Lakshmi:214E:/
-732.6 "Blissful Hammer" sync / 1[56]:Lakshmi:21DD:/
+708.1 "The Pull Of Light" sync / 1[56]:[^:]*:Lakshmi:215E:/
+718.3 "Alluring Arm" sync / 1[56]:[^:]*:Lakshmi:214E:/
+732.6 "Blissful Hammer" sync / 1[56]:[^:]*:Lakshmi:21DD:/
 
 ### Chanchala #4
-732.8 "Chanchala #4" sync / 1[56]:Lakshmi:2148:/
-735.0 "--sync--" sync / 14:Lakshmi:2560:/ window 1000,1000
-750.0 "Divine Denial Enrage" sync / 1[56]:Lakshmi:2560:/
+732.8 "Chanchala #4" sync / 1[56]:[^:]*:Lakshmi:2148:/
+735.0 "--sync--" sync / 14:[^:]*:Lakshmi:2560:/ window 1000,1000
+750.0 "Divine Denial Enrage" sync / 1[56]:[^:]*:Lakshmi:2560:/

--- a/ui/raidboss/data/04-sb/trial/lakshmi.txt
+++ b/ui/raidboss/data/04-sb/trial/lakshmi.txt
@@ -10,87 +10,87 @@ hideall "Alluring Arm"
 0.0 "--Reset--" sync / 21:........:40000010:/ window 100000 jump 0
 
 0.0 "--sync--" sync /:Engage!/ window 0,1
-3.9 "Vril" sync / 1[56]:Dreaming Kshatriya:2482:/ window 3.9,5
-13.0 "Stotram" sync / 1[56]:Lakshmi:2483:/ window 13,5
-16.1 "Inner Demons" # sync / 1[56]:Dreaming Kshatriya:258D:/
-19.0 "Aether Drain" sync / 1[56]:Vril:248D:/
-29.3 "Tail Slap" # sync / 1[56]:Dreaming Kshatriya:258C:/
+3.9 "Vril" sync / 1[56]:[^:]*:Dreaming Kshatriya:2482:/ window 3.9,5
+13.0 "Stotram" sync / 1[56]:[^:]*:Lakshmi:2483:/ window 13,5
+16.1 "Inner Demons" # sync / 1[56]:[^:]*:Dreaming Kshatriya:258D:/
+19.0 "Aether Drain" sync / 1[56]:[^:]*:Vril:248D:/
+29.3 "Tail Slap" # sync / 1[56]:[^:]*:Dreaming Kshatriya:258C:/
 
 # We can't sync to abilities here to make the loop visible,
 # since two adds are present, and the timeline would jerk around.
 # A group that actually manages to bridge this gap is doing so deliberately,
 # and it's probably not necessary to account for that edge case.
 
-1000.0 "--sync--" sync / 1[56]:Lakshmi:2157:/ window 1000,5
-1007.1 "Hand Of Grace" sync / 1[56]:Lakshmi:2486:/
-1021.3 "Blissful Arrow" sync / 1[56]:Lakshmi:2489:/
-1021.9 "Blissful Spear" sync / 1[56]:Lakshmi:248B:/
-1032.3 "The Pull Of Light" sync / 1[56]:Lakshmi:2492:/
-1044.5 "Hand Of Beauty" sync / 1[56]:Lakshmi:2487:/
-1058.8 "Blissful Spear" sync / 1[56]:Lakshmi:2494:/
-1065.7 "Stotram" sync / 1[56]:Lakshmi:2483:/
+1000.0 "--sync--" sync / 1[56]:[^:]*:Lakshmi:2157:/ window 1000,5
+1007.1 "Hand Of Grace" sync / 1[56]:[^:]*:Lakshmi:2486:/
+1021.3 "Blissful Arrow" sync / 1[56]:[^:]*:Lakshmi:2489:/
+1021.9 "Blissful Spear" sync / 1[56]:[^:]*:Lakshmi:248B:/
+1032.3 "The Pull Of Light" sync / 1[56]:[^:]*:Lakshmi:2492:/
+1044.5 "Hand Of Beauty" sync / 1[56]:[^:]*:Lakshmi:2487:/
+1058.8 "Blissful Spear" sync / 1[56]:[^:]*:Lakshmi:2494:/
+1065.7 "Stotram" sync / 1[56]:[^:]*:Lakshmi:2483:/
 1067.9 "--vril spawn--"
 1069.0 "--untargetable--"
 
-1069.9 "Jagadishwari" sync / 1[56]:Lakshmi:2342:/ window 169.9,30
-1086.1 "--sync--" sync / 1[56]:Lakshmi:2459:/
+1069.9 "Jagadishwari" sync / 1[56]:[^:]*:Lakshmi:2342:/ window 169.9,30
+1086.1 "--sync--" sync / 1[56]:[^:]*:Lakshmi:2459:/
 1089.6 "--stun--"
-1090.4 "--sync--" sync / 1[56]:Lakshmi:245A:/
-1091.2 "--sync--" sync / 1[56]:Lakshmi:248E:/
-1106.9 "Alluring Embrace" sync / 1[56]:Lakshmi:2496:/
+1090.4 "--sync--" sync / 1[56]:[^:]*:Lakshmi:245A:/
+1091.2 "--sync--" sync / 1[56]:[^:]*:Lakshmi:248E:/
+1106.9 "Alluring Embrace" sync / 1[56]:[^:]*:Lakshmi:2496:/
 1111.3 "--targetable--"
 
-1114.5 "Chanchala" sync / 1[56]:Lakshmi:2484:/ window 214.5,15
+1114.5 "Chanchala" sync / 1[56]:[^:]*:Lakshmi:2484:/ window 214.5,15
 1116.7 "--chanchala start--"
-1122.6 "Stotram" sync / 1[56]:Lakshmi:249E:/
+1122.6 "Stotram" sync / 1[56]:[^:]*:Lakshmi:249E:/
 1124.5 "--vril spawn--"
-1134.9 "Divine Denial" sync / 1[56]:Lakshmi:2485:/ window 234.9,30
+1134.9 "Divine Denial" sync / 1[56]:[^:]*:Lakshmi:2485:/ window 234.9,30
 1134.9 "--vril despawn--"
-1147.1 "Hand Of Beauty" sync / 1[56]:Lakshmi:2487:/
-1154.3 "The Pull Of Light" sync / 1[56]:Lakshmi:2493:/
-1161.4 "Blissful Spear" sync / 1[56]:Lakshmi:2495:/
-1170.7 "The Path Of Light" sync / 1[56]:Lakshmi:24A1:/ window 270.7,30
-1184.9 "Hand Of Grace" sync / 1[56]:Lakshmi:2486:/
-1192.1 "The Pall Of Light" sync / 1[56]:Lakshmi:2491:/
-1199.1 "Blissful Arrow" sync / 1[56]:Lakshmi:248A:/
-1199.7 "Blissful Spear" sync / 1[56]:Lakshmi:248C:/
-1205.3 "Stotram" sync / 1[56]:Lakshmi:249E:/
+1147.1 "Hand Of Beauty" sync / 1[56]:[^:]*:Lakshmi:2487:/
+1154.3 "The Pull Of Light" sync / 1[56]:[^:]*:Lakshmi:2493:/
+1161.4 "Blissful Spear" sync / 1[56]:[^:]*:Lakshmi:2495:/
+1170.7 "The Path Of Light" sync / 1[56]:[^:]*:Lakshmi:24A1:/ window 270.7,30
+1184.9 "Hand Of Grace" sync / 1[56]:[^:]*:Lakshmi:2486:/
+1192.1 "The Pall Of Light" sync / 1[56]:[^:]*:Lakshmi:2491:/
+1199.1 "Blissful Arrow" sync / 1[56]:[^:]*:Lakshmi:248A:/
+1199.7 "Blissful Spear" sync / 1[56]:[^:]*:Lakshmi:248C:/
+1205.3 "Stotram" sync / 1[56]:[^:]*:Lakshmi:249E:/
 1207.6 "--vril spawn--"
-1220.2 "Divine Denial" sync / 1[56]:Lakshmi:2485:/ window 30,30
+1220.2 "Divine Denial" sync / 1[56]:[^:]*:Lakshmi:2485:/ window 30,30
 1220.2 "--vril despawn--"
 1221.6 "--chanchala end--"
-1234.5 "Alluring Arm" sync / 1[56]:Lakshmi:2488:/
-1248.8 "Blissful Arrow/Spear" sync / 1[56]:Lakshmi:(2489|2494):/
-1256.8 "The Pull Of Light" sync / 1[56]:Lakshmi:2492:/
+1234.5 "Alluring Arm" sync / 1[56]:[^:]*:Lakshmi:2488:/
+1248.8 "Blissful Arrow/Spear" sync / 1[56]:[^:]*:Lakshmi:(2489|2494):/
+1256.8 "The Pull Of Light" sync / 1[56]:[^:]*:Lakshmi:2492:/
 
-1265.0 "Chanchala" sync / 1[56]:Lakshmi:2484:/ window 30,30
+1265.0 "Chanchala" sync / 1[56]:[^:]*:Lakshmi:2484:/ window 30,30
 1265.9 "--chanchala start--"
-1279.2 "Hand Of Grace" sync / 1[56]:Lakshmi:2486:/
-1292.4 "The Pall Of Light" sync / 1[56]:Lakshmi:2491:/
-1293.4 "Blissful Arrow" sync / 1[56]:Lakshmi:248A:/
-1294.0 "Blissful Spear" sync / 1[56]:Lakshmi:248C:/
-1302.6 "Stotram" sync / 1[56]:Lakshmi:249E:/
+1279.2 "Hand Of Grace" sync / 1[56]:[^:]*:Lakshmi:2486:/
+1292.4 "The Pall Of Light" sync / 1[56]:[^:]*:Lakshmi:2491:/
+1293.4 "Blissful Arrow" sync / 1[56]:[^:]*:Lakshmi:248A:/
+1294.0 "Blissful Spear" sync / 1[56]:[^:]*:Lakshmi:248C:/
+1302.6 "Stotram" sync / 1[56]:[^:]*:Lakshmi:249E:/
 1304.4 "--vril spawn--"
-1317.9 "Divine Denial" sync / 1[56]:Lakshmi:2485:/ window 30,30
+1317.9 "Divine Denial" sync / 1[56]:[^:]*:Lakshmi:2485:/ window 30,30
 1317.9 "--vril despawn--"
-1332.1 "Alluring Arm" sync / 1[56]:Lakshmi:2488:/
-1346.4 "Blissful Arrow/Spear" sync / 1[56]:Lakshmi:(248A|2495):/
-1348.4 "The Pall Of Light" sync / 1[56]:Lakshmi:2491:/ window 30,30
-1360.5 "The Pull Of Light" sync / 1[56]:Lakshmi:2493:/
+1332.1 "Alluring Arm" sync / 1[56]:[^:]*:Lakshmi:2488:/
+1346.4 "Blissful Arrow/Spear" sync / 1[56]:[^:]*:Lakshmi:(248A|2495):/
+1348.4 "The Pall Of Light" sync / 1[56]:[^:]*:Lakshmi:2491:/ window 30,30
+1360.5 "The Pull Of Light" sync / 1[56]:[^:]*:Lakshmi:2493:/
 1360.9 "--chanchala end--"
-1378.9 "Alluring Arm" sync / 1[56]:Lakshmi:2488:/
-1392.1 "Stotram" sync / 1[56]:Lakshmi:2483:/ window 30,30
+1378.9 "Alluring Arm" sync / 1[56]:[^:]*:Lakshmi:2488:/
+1392.1 "Stotram" sync / 1[56]:[^:]*:Lakshmi:2483:/ window 30,30
 1393.9 "--vril spawn--"
-1393.2 "Blissful Spear" sync / 1[56]:Lakshmi:2494:/
-1402.3 "The Pull Of Light" sync / 1[56]:Lakshmi:2492:/
+1393.2 "Blissful Spear" sync / 1[56]:[^:]*:Lakshmi:2494:/
+1402.3 "The Pull Of Light" sync / 1[56]:[^:]*:Lakshmi:2492:/
 1407.4 "--vril despawn--"
-1421.5 "Alluring Arm" sync / 1[56]:Lakshmi:2488:/
-1430.9 "The Path Of Light" sync / 1[56]:Lakshmi:248F:/ window 30,30
-1435.7 "Blissful Spear" sync / 1[56]:Lakshmi:2494:/
-1440.0 "The Pall Of Light" sync / 1[56]:Lakshmi:2490:/
-1452.2 "The Pull Of Light" sync / 1[56]:Lakshmi:2492:/
+1421.5 "Alluring Arm" sync / 1[56]:[^:]*:Lakshmi:2488:/
+1430.9 "The Path Of Light" sync / 1[56]:[^:]*:Lakshmi:248F:/ window 30,30
+1435.7 "Blissful Spear" sync / 1[56]:[^:]*:Lakshmi:2494:/
+1440.0 "The Pall Of Light" sync / 1[56]:[^:]*:Lakshmi:2490:/
+1452.2 "The Pull Of Light" sync / 1[56]:[^:]*:Lakshmi:2492:/
 
-1465.5 "Chanchala" sync / 1[56]:Lakshmi:2484:/ window 30,30 jump 1365.0
+1465.5 "Chanchala" sync / 1[56]:[^:]*:Lakshmi:2484:/ window 30,30 jump 1365.0
 1466.4 "--chanchala start--"
 1479.7 "Hand Of Grace"
 1492.9 "The Pall Of Light"

--- a/ui/raidboss/data/04-sb/trial/seiryu-ex.txt
+++ b/ui/raidboss/data/04-sb/trial/seiryu-ex.txt
@@ -8,115 +8,115 @@ hideall "--sync--"
 
 # Phase 1
 0.0 "--sync--" sync /:Engage!/ window 0,1
-2.5 "--sync--" sync / 1[56]:Seiryu:366:/ window 3,0
-12.5 "Fifth Element" sync / 1[56]:Seiryu:37C3:/
-#18.5 "Serpent Ascending" sync / 1[56]:Seiryu:37DC:/ # towers later, but nothing here
-20.5 "--rotate--" sync / 1[56]:Seiryu:37C4:/
-27.0 "Kuji-kiri" sync / 1[56]:Seiryu:37E1:/
-30.0 "--jump--" sync / 1[56]:Seiryu:37D5:/
-#33.5 "Onmyo Sigil" sync / 1[56]:Seiryu:37D6:/
-36.5 "Onmyo Sigil" sync / 1[56]:Seiryu:3A01:/
-46.5 "Cursekeeper" sync / 1[56]:Seiryu:37D2:/
-62.8 "Summon Shiki" sync / 1[56]:Seiryu:37CE:/
-#64.8 "--rotate--" sync / 1[56]:Seiryu:37C4:/
-69.8 "--sync--" sync / 1[56]:Seiryu:37EF:/
-75.8 "Red Rush" sync / 1[56]:Aka-no-shiki:37F1:/
-75.8 "Blue Bolt" sync / 1[56]:Ao-no-shiki:37F0:/
-80.5 "100-tonze Swing" sync / 1[56]:Iwa-no-shiki:37ED:/
-89.5 "Kanabo" sync / 1[56]:Iwa-no-shiki:37EE:/
+2.5 "--sync--" sync / 1[56]:[^:]*:Seiryu:366:/ window 3,0
+12.5 "Fifth Element" sync / 1[56]:[^:]*:Seiryu:37C3:/
+#18.5 "Serpent Ascending" sync / 1[56]:[^:]*:Seiryu:37DC:/ # towers later, but nothing here
+20.5 "--rotate--" sync / 1[56]:[^:]*:Seiryu:37C4:/
+27.0 "Kuji-kiri" sync / 1[56]:[^:]*:Seiryu:37E1:/
+30.0 "--jump--" sync / 1[56]:[^:]*:Seiryu:37D5:/
+#33.5 "Onmyo Sigil" sync / 1[56]:[^:]*:Seiryu:37D6:/
+36.5 "Onmyo Sigil" sync / 1[56]:[^:]*:Seiryu:3A01:/
+46.5 "Cursekeeper" sync / 1[56]:[^:]*:Seiryu:37D2:/
+62.8 "Summon Shiki" sync / 1[56]:[^:]*:Seiryu:37CE:/
+#64.8 "--rotate--" sync / 1[56]:[^:]*:Seiryu:37C4:/
+69.8 "--sync--" sync / 1[56]:[^:]*:Seiryu:37EF:/
+75.8 "Red Rush" sync / 1[56]:[^:]*:Aka-no-shiki:37F1:/
+75.8 "Blue Bolt" sync / 1[56]:[^:]*:Ao-no-shiki:37F0:/
+80.5 "100-tonze Swing" sync / 1[56]:[^:]*:Iwa-no-shiki:37ED:/
+89.5 "Kanabo" sync / 1[56]:[^:]*:Iwa-no-shiki:37EE:/
 
 # Phase 2
 160.0 "Enrage"
 
 # Phase 3
-400.0 "Strength of Spirit" sync / 1[56]:Seiryu:37C9:/ window 400,0
-427.0 "Dragon's Wake" sync / 1[56]:Seiryu:37CB:/
-#429.5 "--rotate--" sync / 1[56]:Seiryu:37C4:/
-437.5 "Summon Shiki" sync / 1[56]:Seiryu:37D0:/
-448.0 "Coursing River" sync / 1[56]:Seiryu:37F6:/
-462.0 "Handprint" sync / 1[56]:Seiryu:37E8:/
-466.5 "Fifth Element" sync / 1[56]:Seiryu:37C3:/
-470.0 "Handprint" sync / 1[56]:Seiryu:37E8:/
-478.0 "Summon Shiki" sync / 1[56]:Seiryu:37D0:/
-478.0 "Handprint" sync / 1[56]:Seiryu:37E8:/
-486.5 "Force of Nature" sync / 1[56]:Seiryu:37EB:/
-488.5 "Coursing River" sync / 1[56]:Seiryu:37F6:/
-494.3 "Forbidden Arts" sync / 1[56]:Seiryu:37C7:/
-496.3 "Forbidden Arts" sync / 1[56]:Seiryu:37C8:/
-504.3 "--rotate--" sync / 1[56]:Seiryu:37C4:/
-511.9 "Blazing Aramitama" sync / 1[56]:Seiryu:37E4:/
-515.9 "--jump--" sync / 1[56]:Seiryu:37D5:/
-#519.4 "In/Out" sync / 1[56]:Seiryu:(37DA|37D8):/
-522.4 "In/Out" sync / 1[56]:Seiryu:(3A05|3A03):/
-#524.9 "Out/In" sync / 1[56]:Seiryu:(37DB|37D9):/
-525.4 "Out/In" sync / 1[56]:Seiryu:(3A06|3A04):/
-531.9 "--rotate--" sync / 1[56]:Seiryu:37C4:/
-538.6 "Kuji-kiri" sync / 1[56]:Seiryu:37E1:/
-541.6 "--jump--" sync / 1[56]:Seiryu:37D5:/
-#545.1 "In/Out" sync / 1[56]:Seiryu:(37DA|37D8):/
-548.1 "In/Out" sync / 1[56]:Seiryu:(3A05|3A03):/
-#550.6 "Out/In" sync / 1[56]:Seiryu:(37DB|37D9):/
-551.1 "Out/In" sync / 1[56]:Seiryu:(3A06|3A04):/
-558.6 "Fifth Element" sync / 1[56]:Seiryu:37C3:/
-572.6 "Serpent Ascending" sync / 1[56]:Seiryu:3C25:/
-578.6 "Serpent Descending" sync / 1[56]:Seiryu:37DE:/
-582.6 "Serpent's Fang" sync / 1[56]:Seiryu:37DF:/
-589.8 "Forbidden Arts 1" sync / 1[56]:Seiryu:3C22:/
-592.0 "Forbidden Arts 2" sync / 1[56]:Seiryu:3C23:/
-599.0 "Fifth Element" sync / 1[56]:Seiryu:37C3:/
-611.0 "Cursekeeper" sync / 1[56]:Seiryu:37D2:/
-624.1 "Cursekeeper" sync / 1[56]:Seiryu:37D2:/
-633.3 "Fifth Element" sync / 1[56]:Seiryu:37C3:/
-646.3 "Summon Shiki" sync / 1[56]:Seiryu:37CD:/
-652.3 "--jump--" sync / 1[56]:Seiryu:37D5:/
-#655.8 "In/Out" sync / 1[56]:Seiryu:(37DA|37D8):/
-658.4 "100-tonze Swing" sync / 1[56]:Iwa-no-shiki:37ED:/
-658.8 "In/Out" sync / 1[56]:Seiryu:(3A05|3A03):/
-#661.3 "Out/In" sync / 1[56]:Seiryu:(37DB|37D9):/
-661.8 "Out/In" sync / 1[56]:Seiryu:(3A06|3A04):/
-667.5 "Kanabo" sync / 1[56]:Iwa-no-shiki:37EE:/
-671.3 "--sync--" sync / 1[56]:Seiryu:37EF:/
-676.3 "Serpent Ascending" sync / 1[56]:Seiryu:37DC:/
-677.3 "Red Rush" sync / 1[56]:Aka-no-shiki:37F1:/
-677.3 "Blue Bolt" sync / 1[56]:Ao-no-shiki:37F0:/
-678.3 "--rotate--" sync / 1[56]:Seiryu:37C4:/
-685.0 "Kuji-kiri" sync / 1[56]:Seiryu:37E1:/
-691.9 "Handprint" sync / 1[56]:Seiryu:37E8:/
-697.1 "Fifth Element" sync / 1[56]:Seiryu:37C3:/
-700.0 "Handprint" sync / 1[56]:Seiryu:37E8:/
-708.0 "Handprint" sync / 1[56]:Seiryu:37E8:/
-708.6 "Summon Shiki" sync / 1[56]:Seiryu:37D0:/
-716.5 "Force of Nature" sync / 1[56]:Seiryu:37EB:/
-719.1 "Coursing River" sync / 1[56]:Seiryu:37F6:/
-721.6 "--jump--" sync / 1[56]:Seiryu:37D5:/
-#725.1 "In/Out" sync / 1[56]:Seiryu:(37DA|37D8):/
-728.1 "In/Out" sync / 1[56]:Seiryu:(3A05|3A03):/
-#730.6 "Out/In" sync / 1[56]:Seiryu:(37DB|37D9):/
-731.1 "Out/In" sync / 1[56]:Seiryu:(3A06|3A04):/
-733.9 "Handprint" sync / 1[56]:Seiryu:37E8:/
-741.9 "Handprint" sync / 1[56]:Seiryu:37E8:/
-749.9 "Handprint" sync / 1[56]:Seiryu:37E8:/
-751.0 "Summon Shiki" sync / 1[56]:Seiryu:37D0:/
-758.4 "Force of Nature" sync / 1[56]:Seiryu:37EB:/
-761.5 "Coursing River" sync / 1[56]:Seiryu:37F6:/
-768.6 "Forbidden Arts 1" sync / 1[56]:Seiryu:3C22:/
-770.6 "Forbidden Arts 2" sync / 1[56]:Seiryu:3C23:/
-777.6 "Fifth Element" sync / 1[56]:Seiryu:37C3:/
-794.6 "Cursekeeper" sync / 1[56]:Seiryu:37D2:/
-807.8 "Cursekeeper" sync / 1[56]:Seiryu:37D2:/
-817.0 "Fifth Element" sync / 1[56]:Seiryu:37C3:/
-823.0 "--jump--" sync / 1[56]:Seiryu:37D5:/
-#826.5 "In/Out" sync / 1[56]:Seiryu:(37DA|37D8):/
-829.5 "In/Out" sync / 1[56]:Seiryu:(3A05|3A03):/
-#832.0 "Out/In" sync / 1[56]:Seiryu:(37DB|37D9):/
-832.5 "Out/In" sync / 1[56]:Seiryu:(3A06|3A04):/
-839.0 "Serpent Ascending" sync / 1[56]:Seiryu:3C25:/
-842.5 "--rotate--" sync / 1[56]:Seiryu:37C4:/
-845.0 "Serpent Descending" sync / 1[56]:Seiryu:37DE:/
-849.0 "Serpent's Fang" sync / 1[56]:Seiryu:37DF:/
-849.0 "Kuji-kiri" sync / 1[56]:Seiryu:37E1:/
-857.6 "Fifth Element" sync / 1[56]:Seiryu:37C3:/
-869.6 "--rotate--" sync / 1[56]:Seiryu:37C4:/
-876.9 "Fifth Element" sync / 1[56]:Seiryu:37C3:/
-883.9 "Fifth Element" sync / 1[56]:Seiryu:37C3:/
-906.0 "Enrage" sync / 1[56]:Seiryu:3CA9:/
+400.0 "Strength of Spirit" sync / 1[56]:[^:]*:Seiryu:37C9:/ window 400,0
+427.0 "Dragon's Wake" sync / 1[56]:[^:]*:Seiryu:37CB:/
+#429.5 "--rotate--" sync / 1[56]:[^:]*:Seiryu:37C4:/
+437.5 "Summon Shiki" sync / 1[56]:[^:]*:Seiryu:37D0:/
+448.0 "Coursing River" sync / 1[56]:[^:]*:Seiryu:37F6:/
+462.0 "Handprint" sync / 1[56]:[^:]*:Seiryu:37E8:/
+466.5 "Fifth Element" sync / 1[56]:[^:]*:Seiryu:37C3:/
+470.0 "Handprint" sync / 1[56]:[^:]*:Seiryu:37E8:/
+478.0 "Summon Shiki" sync / 1[56]:[^:]*:Seiryu:37D0:/
+478.0 "Handprint" sync / 1[56]:[^:]*:Seiryu:37E8:/
+486.5 "Force of Nature" sync / 1[56]:[^:]*:Seiryu:37EB:/
+488.5 "Coursing River" sync / 1[56]:[^:]*:Seiryu:37F6:/
+494.3 "Forbidden Arts" sync / 1[56]:[^:]*:Seiryu:37C7:/
+496.3 "Forbidden Arts" sync / 1[56]:[^:]*:Seiryu:37C8:/
+504.3 "--rotate--" sync / 1[56]:[^:]*:Seiryu:37C4:/
+511.9 "Blazing Aramitama" sync / 1[56]:[^:]*:Seiryu:37E4:/
+515.9 "--jump--" sync / 1[56]:[^:]*:Seiryu:37D5:/
+#519.4 "In/Out" sync / 1[56]:[^:]*:Seiryu:(37DA|37D8):/
+522.4 "In/Out" sync / 1[56]:[^:]*:Seiryu:(3A05|3A03):/
+#524.9 "Out/In" sync / 1[56]:[^:]*:Seiryu:(37DB|37D9):/
+525.4 "Out/In" sync / 1[56]:[^:]*:Seiryu:(3A06|3A04):/
+531.9 "--rotate--" sync / 1[56]:[^:]*:Seiryu:37C4:/
+538.6 "Kuji-kiri" sync / 1[56]:[^:]*:Seiryu:37E1:/
+541.6 "--jump--" sync / 1[56]:[^:]*:Seiryu:37D5:/
+#545.1 "In/Out" sync / 1[56]:[^:]*:Seiryu:(37DA|37D8):/
+548.1 "In/Out" sync / 1[56]:[^:]*:Seiryu:(3A05|3A03):/
+#550.6 "Out/In" sync / 1[56]:[^:]*:Seiryu:(37DB|37D9):/
+551.1 "Out/In" sync / 1[56]:[^:]*:Seiryu:(3A06|3A04):/
+558.6 "Fifth Element" sync / 1[56]:[^:]*:Seiryu:37C3:/
+572.6 "Serpent Ascending" sync / 1[56]:[^:]*:Seiryu:3C25:/
+578.6 "Serpent Descending" sync / 1[56]:[^:]*:Seiryu:37DE:/
+582.6 "Serpent's Fang" sync / 1[56]:[^:]*:Seiryu:37DF:/
+589.8 "Forbidden Arts 1" sync / 1[56]:[^:]*:Seiryu:3C22:/
+592.0 "Forbidden Arts 2" sync / 1[56]:[^:]*:Seiryu:3C23:/
+599.0 "Fifth Element" sync / 1[56]:[^:]*:Seiryu:37C3:/
+611.0 "Cursekeeper" sync / 1[56]:[^:]*:Seiryu:37D2:/
+624.1 "Cursekeeper" sync / 1[56]:[^:]*:Seiryu:37D2:/
+633.3 "Fifth Element" sync / 1[56]:[^:]*:Seiryu:37C3:/
+646.3 "Summon Shiki" sync / 1[56]:[^:]*:Seiryu:37CD:/
+652.3 "--jump--" sync / 1[56]:[^:]*:Seiryu:37D5:/
+#655.8 "In/Out" sync / 1[56]:[^:]*:Seiryu:(37DA|37D8):/
+658.4 "100-tonze Swing" sync / 1[56]:[^:]*:Iwa-no-shiki:37ED:/
+658.8 "In/Out" sync / 1[56]:[^:]*:Seiryu:(3A05|3A03):/
+#661.3 "Out/In" sync / 1[56]:[^:]*:Seiryu:(37DB|37D9):/
+661.8 "Out/In" sync / 1[56]:[^:]*:Seiryu:(3A06|3A04):/
+667.5 "Kanabo" sync / 1[56]:[^:]*:Iwa-no-shiki:37EE:/
+671.3 "--sync--" sync / 1[56]:[^:]*:Seiryu:37EF:/
+676.3 "Serpent Ascending" sync / 1[56]:[^:]*:Seiryu:37DC:/
+677.3 "Red Rush" sync / 1[56]:[^:]*:Aka-no-shiki:37F1:/
+677.3 "Blue Bolt" sync / 1[56]:[^:]*:Ao-no-shiki:37F0:/
+678.3 "--rotate--" sync / 1[56]:[^:]*:Seiryu:37C4:/
+685.0 "Kuji-kiri" sync / 1[56]:[^:]*:Seiryu:37E1:/
+691.9 "Handprint" sync / 1[56]:[^:]*:Seiryu:37E8:/
+697.1 "Fifth Element" sync / 1[56]:[^:]*:Seiryu:37C3:/
+700.0 "Handprint" sync / 1[56]:[^:]*:Seiryu:37E8:/
+708.0 "Handprint" sync / 1[56]:[^:]*:Seiryu:37E8:/
+708.6 "Summon Shiki" sync / 1[56]:[^:]*:Seiryu:37D0:/
+716.5 "Force of Nature" sync / 1[56]:[^:]*:Seiryu:37EB:/
+719.1 "Coursing River" sync / 1[56]:[^:]*:Seiryu:37F6:/
+721.6 "--jump--" sync / 1[56]:[^:]*:Seiryu:37D5:/
+#725.1 "In/Out" sync / 1[56]:[^:]*:Seiryu:(37DA|37D8):/
+728.1 "In/Out" sync / 1[56]:[^:]*:Seiryu:(3A05|3A03):/
+#730.6 "Out/In" sync / 1[56]:[^:]*:Seiryu:(37DB|37D9):/
+731.1 "Out/In" sync / 1[56]:[^:]*:Seiryu:(3A06|3A04):/
+733.9 "Handprint" sync / 1[56]:[^:]*:Seiryu:37E8:/
+741.9 "Handprint" sync / 1[56]:[^:]*:Seiryu:37E8:/
+749.9 "Handprint" sync / 1[56]:[^:]*:Seiryu:37E8:/
+751.0 "Summon Shiki" sync / 1[56]:[^:]*:Seiryu:37D0:/
+758.4 "Force of Nature" sync / 1[56]:[^:]*:Seiryu:37EB:/
+761.5 "Coursing River" sync / 1[56]:[^:]*:Seiryu:37F6:/
+768.6 "Forbidden Arts 1" sync / 1[56]:[^:]*:Seiryu:3C22:/
+770.6 "Forbidden Arts 2" sync / 1[56]:[^:]*:Seiryu:3C23:/
+777.6 "Fifth Element" sync / 1[56]:[^:]*:Seiryu:37C3:/
+794.6 "Cursekeeper" sync / 1[56]:[^:]*:Seiryu:37D2:/
+807.8 "Cursekeeper" sync / 1[56]:[^:]*:Seiryu:37D2:/
+817.0 "Fifth Element" sync / 1[56]:[^:]*:Seiryu:37C3:/
+823.0 "--jump--" sync / 1[56]:[^:]*:Seiryu:37D5:/
+#826.5 "In/Out" sync / 1[56]:[^:]*:Seiryu:(37DA|37D8):/
+829.5 "In/Out" sync / 1[56]:[^:]*:Seiryu:(3A05|3A03):/
+#832.0 "Out/In" sync / 1[56]:[^:]*:Seiryu:(37DB|37D9):/
+832.5 "Out/In" sync / 1[56]:[^:]*:Seiryu:(3A06|3A04):/
+839.0 "Serpent Ascending" sync / 1[56]:[^:]*:Seiryu:3C25:/
+842.5 "--rotate--" sync / 1[56]:[^:]*:Seiryu:37C4:/
+845.0 "Serpent Descending" sync / 1[56]:[^:]*:Seiryu:37DE:/
+849.0 "Serpent's Fang" sync / 1[56]:[^:]*:Seiryu:37DF:/
+849.0 "Kuji-kiri" sync / 1[56]:[^:]*:Seiryu:37E1:/
+857.6 "Fifth Element" sync / 1[56]:[^:]*:Seiryu:37C3:/
+869.6 "--rotate--" sync / 1[56]:[^:]*:Seiryu:37C4:/
+876.9 "Fifth Element" sync / 1[56]:[^:]*:Seiryu:37C3:/
+883.9 "Fifth Element" sync / 1[56]:[^:]*:Seiryu:37C3:/
+906.0 "Enrage" sync / 1[56]:[^:]*:Seiryu:3CA9:/

--- a/ui/raidboss/data/04-sb/trial/seiryu.txt
+++ b/ui/raidboss/data/04-sb/trial/seiryu.txt
@@ -10,116 +10,116 @@ hideall "--sync--"
 
 ### Phase 1
 0.0 "--sync--" sync /:Engage!/ window 0,1
-8.7 "--sync--" sync / 14:Seiryu:37FE:/ window 10,10
-12.7 "Fifth Element" sync / 1[56]:Seiryu:37FE:/
-24.8 "Infirm Soul" sync / 1[56]:Seiryu:37FD:/
-33.1 "--sync--" sync / 1[56]:Seiryu:37D5:/
-39.8 "Onmyo Sigil / Serpent-Eye Sigil" sync / 1[56]:Seiryu:3A0[78]:/
-52.9 "Serpent Descending" sync / 1[56]:Seiryu:3804:/
-54.1 "--sync--" sync / 1[56]:Seiryu:37D5:/
-60.8 "Serpent-Eye Sigil / Onmyo Sigil" sync / 1[56]:Seiryu:3A0[78]:/
-62.9 "--sync--" sync / 1[56]:Seiryu:37C4:/
-69.3 "Kuji-Kiri" sync / 1[56]:Seiryu:37E1:/
-71.8 "Fortune-Blade Sigil" sync / 1[56]:Seiryu:3806:/
-88.6 "Summon Shiki" sync / 1[56]:Seiryu:37CE:/
+8.7 "--sync--" sync / 14:[^:]*:Seiryu:37FE:/ window 10,10
+12.7 "Fifth Element" sync / 1[56]:[^:]*:Seiryu:37FE:/
+24.8 "Infirm Soul" sync / 1[56]:[^:]*:Seiryu:37FD:/
+33.1 "--sync--" sync / 1[56]:[^:]*:Seiryu:37D5:/
+39.8 "Onmyo Sigil / Serpent-Eye Sigil" sync / 1[56]:[^:]*:Seiryu:3A0[78]:/
+52.9 "Serpent Descending" sync / 1[56]:[^:]*:Seiryu:3804:/
+54.1 "--sync--" sync / 1[56]:[^:]*:Seiryu:37D5:/
+60.8 "Serpent-Eye Sigil / Onmyo Sigil" sync / 1[56]:[^:]*:Seiryu:3A0[78]:/
+62.9 "--sync--" sync / 1[56]:[^:]*:Seiryu:37C4:/
+69.3 "Kuji-Kiri" sync / 1[56]:[^:]*:Seiryu:37E1:/
+71.8 "Fortune-Blade Sigil" sync / 1[56]:[^:]*:Seiryu:3806:/
+88.6 "Summon Shiki" sync / 1[56]:[^:]*:Seiryu:37CE:/
 90.7 "--untargetable--"
 
 ### Add Phase
-90.7 "--sync--" sync / 1[56]:Seiryu:37C4:/ window 20,50
-95.7 "--sync--" sync / 1[56]:Ao-No-Shiki:37EF:/
-100.7 "--sync--" sync / 1[56]:Iwa-No-Shiki:37EC:/
-101.7 "Red Rush" sync / 1[56]:Aka-No-Shiki:3C1D:/
-101.7 "Blue Bolt" sync / 1[56]:Ao-No-Shiki:3C1C:/
-106.5 "100-Tonze Swing" sync / 1[56]:Iwa-No-Shiki:3C1E:/
+90.7 "--sync--" sync / 1[56]:[^:]*:Seiryu:37C4:/ window 20,50
+95.7 "--sync--" sync / 1[56]:[^:]*:Ao-No-Shiki:37EF:/
+100.7 "--sync--" sync / 1[56]:[^:]*:Iwa-No-Shiki:37EC:/
+101.7 "Red Rush" sync / 1[56]:[^:]*:Aka-No-Shiki:3C1D:/
+101.7 "Blue Bolt" sync / 1[56]:[^:]*:Ao-No-Shiki:3C1C:/
+106.5 "100-Tonze Swing" sync / 1[56]:[^:]*:Iwa-No-Shiki:3C1E:/
 107.4 "3x Doro-No-Shiki"
 107.4 "1x Numa-No-Shiki"
-112.7 "Yama-Kagura" sync / 1[56]:Ten-No-Shiki:3813:/
-118.8 "Kanabo" sync / 1[56]:Iwa-No-Shiki:3C1F:/
+112.7 "Yama-Kagura" sync / 1[56]:[^:]*:Ten-No-Shiki:3813:/
+118.8 "Kanabo" sync / 1[56]:[^:]*:Iwa-No-Shiki:3C1F:/
 123.8 "3x Doro-No-Shiki"
 123.8 "1x Numa-No-Shiki"
 
 ### Final Phase
-200.0 "--sync--" sync / 14:Seiryu:37C9:/ window 200,0
-205.0 "Strength Of Spirit" sync / 1[56]:Seiryu:37C9:/
-208.1 "--sync--" sync / 1[56]:Seiryu:37CA:/
-232.1 "Dragon's Wake" sync / 1[56]:Seiryu:3800:/
+200.0 "--sync--" sync / 14:[^:]*:Seiryu:37C9:/ window 200,0
+205.0 "Strength Of Spirit" sync / 1[56]:[^:]*:Seiryu:37C9:/
+208.1 "--sync--" sync / 1[56]:[^:]*:Seiryu:37CA:/
+232.1 "Dragon's Wake" sync / 1[56]:[^:]*:Seiryu:3800:/
 234.6 "--targetable--"
-234.7 "--sync--" sync / 1[56]:Seiryu:37C4:/
-243.9 "Summon Shiki" sync / 1[56]:Seiryu:37D0:/
-251.9 "Coursing River" sync / 1[56]:Blue Orochi:37F5:/
-262.0 "Summon Shiki" sync / 1[56]:Seiryu:37D0:/
-270.0 "Coursing River" sync / 1[56]:Blue Orochi:37F5:/
-271.2 "Forbidden Arts 1" sync / 1[56]:Seiryu:37C5:/
-278.6 "Forbidden Arts 2" sync / 1[56]:Seiryu:3C72:/
+234.7 "--sync--" sync / 1[56]:[^:]*:Seiryu:37C4:/
+243.9 "Summon Shiki" sync / 1[56]:[^:]*:Seiryu:37D0:/
+251.9 "Coursing River" sync / 1[56]:[^:]*:Blue Orochi:37F5:/
+262.0 "Summon Shiki" sync / 1[56]:[^:]*:Seiryu:37D0:/
+270.0 "Coursing River" sync / 1[56]:[^:]*:Blue Orochi:37F5:/
+271.2 "Forbidden Arts 1" sync / 1[56]:[^:]*:Seiryu:37C5:/
+278.6 "Forbidden Arts 2" sync / 1[56]:[^:]*:Seiryu:3C72:/
 
-283.7 "Summon Shiki" sync / 1[56]:Seiryu:37CF:/
-293.8 "Handprint" sync / 1[56]:Yama-No-Shiki:37E[56]:/
-302.0 "Handprint" sync / 1[56]:Yama-No-Shiki:37E[56]:/
-309.8 "Fifth Element" sync / 1[56]:Seiryu:37FE:/
-310.1 "Handprint" sync / 1[56]:Yama-No-Shiki:37E[56]:/
-318.2 "Force Of Nature" sync / 1[56]:Yama-No-Shiki:37E9:/
-334.1 "--sync--" sync / 1[56]:Seiryu:37D5:/
-340.7 "Onmyo Sigil / Serpent-Eye Sigil" sync / 1[56]:Seiryu:3A0[78]:/
-342.9 "--sync--" sync / 1[56]:Seiryu:37C4:/
-349.0 "Serpent Descending" sync / 1[56]:Seiryu:3804:/
-349.7 "Kuji-Kiri" sync / 1[56]:Seiryu:37E1:/
-352.2 "Fortune-Blade Sigil" sync / 1[56]:Seiryu:3806:/
-356.8 "Fifth Element" sync / 1[56]:Seiryu:37FE:/
-370.0 "Infirm Soul" sync / 1[56]:Seiryu:37FD:/
-376.1 "Fifth Element" sync / 1[56]:Seiryu:37FE:/
+283.7 "Summon Shiki" sync / 1[56]:[^:]*:Seiryu:37CF:/
+293.8 "Handprint" sync / 1[56]:[^:]*:Yama-No-Shiki:37E[56]:/
+302.0 "Handprint" sync / 1[56]:[^:]*:Yama-No-Shiki:37E[56]:/
+309.8 "Fifth Element" sync / 1[56]:[^:]*:Seiryu:37FE:/
+310.1 "Handprint" sync / 1[56]:[^:]*:Yama-No-Shiki:37E[56]:/
+318.2 "Force Of Nature" sync / 1[56]:[^:]*:Yama-No-Shiki:37E9:/
+334.1 "--sync--" sync / 1[56]:[^:]*:Seiryu:37D5:/
+340.7 "Onmyo Sigil / Serpent-Eye Sigil" sync / 1[56]:[^:]*:Seiryu:3A0[78]:/
+342.9 "--sync--" sync / 1[56]:[^:]*:Seiryu:37C4:/
+349.0 "Serpent Descending" sync / 1[56]:[^:]*:Seiryu:3804:/
+349.7 "Kuji-Kiri" sync / 1[56]:[^:]*:Seiryu:37E1:/
+352.2 "Fortune-Blade Sigil" sync / 1[56]:[^:]*:Seiryu:3806:/
+356.8 "Fifth Element" sync / 1[56]:[^:]*:Seiryu:37FE:/
+370.0 "Infirm Soul" sync / 1[56]:[^:]*:Seiryu:37FD:/
+376.1 "Fifth Element" sync / 1[56]:[^:]*:Seiryu:37FE:/
 
 # More adds
-387.3 "Summon Shiki" sync / 1[56]:Seiryu:37CD:/
-393.4 "--sync--" sync / 1[56]:Iwa-No-Shiki:37EC:/
-394.6 "--sync--" sync / 1[56]:Seiryu:37D5:/
-399.2 "100-Tonze Swing" sync / 1[56]:Iwa-No-Shiki:3C1E:/
-401.2 "Onmyo Sigil / Serpent-Eye Sigil" sync / 1[56]:Seiryu:3A0[78]:/
-411.5 "Kanabo" sync / 1[56]:Iwa-No-Shiki:3C1F:/
-415.3 "--sync--" sync / 1[56]:Ao-No-Shiki:37EF:/
-421.3 "Red Rush" sync / 1[56]:Aka-No-Shiki:3C1D:/
-421.3 "Blue Bolt" sync / 1[56]:Ao-No-Shiki:3C1C:/
-424.4 "--sync--" sync / 1[56]:Seiryu:37C4:/
-429.3 "Serpent Descending" sync / 1[56]:Seiryu:3804:/
-430.3 "Yama-Kagura" sync / 1[56]:Ten-No-Shiki:3813:/
-431.0 "Kuji-Kiri" sync / 1[56]:Seiryu:37E1:/
-433.5 "Fortune-Blade Sigil" sync / 1[56]:Seiryu:3806:/
-443.2 "Handprint" sync / 1[56]:Yama-No-Shiki:37E[56]:/
+387.3 "Summon Shiki" sync / 1[56]:[^:]*:Seiryu:37CD:/
+393.4 "--sync--" sync / 1[56]:[^:]*:Iwa-No-Shiki:37EC:/
+394.6 "--sync--" sync / 1[56]:[^:]*:Seiryu:37D5:/
+399.2 "100-Tonze Swing" sync / 1[56]:[^:]*:Iwa-No-Shiki:3C1E:/
+401.2 "Onmyo Sigil / Serpent-Eye Sigil" sync / 1[56]:[^:]*:Seiryu:3A0[78]:/
+411.5 "Kanabo" sync / 1[56]:[^:]*:Iwa-No-Shiki:3C1F:/
+415.3 "--sync--" sync / 1[56]:[^:]*:Ao-No-Shiki:37EF:/
+421.3 "Red Rush" sync / 1[56]:[^:]*:Aka-No-Shiki:3C1D:/
+421.3 "Blue Bolt" sync / 1[56]:[^:]*:Ao-No-Shiki:3C1C:/
+424.4 "--sync--" sync / 1[56]:[^:]*:Seiryu:37C4:/
+429.3 "Serpent Descending" sync / 1[56]:[^:]*:Seiryu:3804:/
+430.3 "Yama-Kagura" sync / 1[56]:[^:]*:Ten-No-Shiki:3813:/
+431.0 "Kuji-Kiri" sync / 1[56]:[^:]*:Seiryu:37E1:/
+433.5 "Fortune-Blade Sigil" sync / 1[56]:[^:]*:Seiryu:3806:/
+443.2 "Handprint" sync / 1[56]:[^:]*:Yama-No-Shiki:37E[56]:/
 
-448.1 "Summon Shiki" sync / 1[56]:Seiryu:37D0:/
-451.4 "Handprint" sync / 1[56]:Yama-No-Shiki:37E[56]:/
-456.2 "Coursing River" sync / 1[56]:Blue Orochi:37F5:/
-459.5 "Handprint" sync / 1[56]:Yama-No-Shiki:37E[56]:/
-467.7 "Force Of Nature" sync / 1[56]:Yama-No-Shiki:37E9:/
+448.1 "Summon Shiki" sync / 1[56]:[^:]*:Seiryu:37D0:/
+451.4 "Handprint" sync / 1[56]:[^:]*:Yama-No-Shiki:37E[56]:/
+456.2 "Coursing River" sync / 1[56]:[^:]*:Blue Orochi:37F5:/
+459.5 "Handprint" sync / 1[56]:[^:]*:Yama-No-Shiki:37E[56]:/
+467.7 "Force Of Nature" sync / 1[56]:[^:]*:Yama-No-Shiki:37E9:/
 
 # towers
-470.2 "Serpent Ascending" sync / 1[56]:Seiryu:3C25:/
-480.4 "Serpent's Fang" sync / 1[56]:Seiryu:3A8C:/
-484.4 "Fifth Element" sync / 1[56]:Seiryu:37FE:/
-498.7 "--sync--" sync / 1[56]:Seiryu:37C4:/
-505.2 "Kuji-Kiri" sync / 1[56]:Seiryu:37E1:/
-505.6 "Serpent Descending" sync / 1[56]:Seiryu:3804:/
-507.7 "Fortune-Blade Sigil" sync / 1[56]:Seiryu:3806:/
-508.4 "--sync--" sync / 1[56]:Seiryu:37D5:/
-515.0 "Onmyo Sigil / Serpent-Eye Sigil" sync / 1[56]:Seiryu:3A0[78]:/
-524.1 "Infirm Soul" sync / 1[56]:Seiryu:37FD:/
-530.2 "Fifth Element" sync / 1[56]:Seiryu:37FE:/
-540.4 "--sync--" sync / 1[56]:Seiryu:37C4:/
+470.2 "Serpent Ascending" sync / 1[56]:[^:]*:Seiryu:3C25:/
+480.4 "Serpent's Fang" sync / 1[56]:[^:]*:Seiryu:3A8C:/
+484.4 "Fifth Element" sync / 1[56]:[^:]*:Seiryu:37FE:/
+498.7 "--sync--" sync / 1[56]:[^:]*:Seiryu:37C4:/
+505.2 "Kuji-Kiri" sync / 1[56]:[^:]*:Seiryu:37E1:/
+505.6 "Serpent Descending" sync / 1[56]:[^:]*:Seiryu:3804:/
+507.7 "Fortune-Blade Sigil" sync / 1[56]:[^:]*:Seiryu:3806:/
+508.4 "--sync--" sync / 1[56]:[^:]*:Seiryu:37D5:/
+515.0 "Onmyo Sigil / Serpent-Eye Sigil" sync / 1[56]:[^:]*:Seiryu:3A0[78]:/
+524.1 "Infirm Soul" sync / 1[56]:[^:]*:Seiryu:37FD:/
+530.2 "Fifth Element" sync / 1[56]:[^:]*:Seiryu:37FE:/
+540.4 "--sync--" sync / 1[56]:[^:]*:Seiryu:37C4:/
 
-547.6 "Summon Shiki" sync / 1[56]:Seiryu:37D0:/
-555.7 "Coursing River" sync / 1[56]:Blue Orochi:37F5:/
-558.8 "Fifth Element" sync / 1[56]:Seiryu:37FE:/
-565.9 "Summon Shiki" sync / 1[56]:Seiryu:37D0:/
-573.9 "Coursing River" sync / 1[56]:Blue Orochi:37F5:/
-575.1 "Forbidden Arts" sync / 1[56]:Seiryu:37C5:/
-582.4 "Forbidden Arts" sync / 1[56]:Seiryu:3C72:/
-588.5 "Fifth Element" sync / 1[56]:Seiryu:37FE:/
-595.6 "Fifth Element" sync / 1[56]:Seiryu:37FE:/
+547.6 "Summon Shiki" sync / 1[56]:[^:]*:Seiryu:37D0:/
+555.7 "Coursing River" sync / 1[56]:[^:]*:Blue Orochi:37F5:/
+558.8 "Fifth Element" sync / 1[56]:[^:]*:Seiryu:37FE:/
+565.9 "Summon Shiki" sync / 1[56]:[^:]*:Seiryu:37D0:/
+573.9 "Coursing River" sync / 1[56]:[^:]*:Blue Orochi:37F5:/
+575.1 "Forbidden Arts" sync / 1[56]:[^:]*:Seiryu:37C5:/
+582.4 "Forbidden Arts" sync / 1[56]:[^:]*:Seiryu:3C72:/
+588.5 "Fifth Element" sync / 1[56]:[^:]*:Seiryu:37FE:/
+595.6 "Fifth Element" sync / 1[56]:[^:]*:Seiryu:37FE:/
 
 # adds loop
-610.8 "Summon Shiki" sync / 1[56]:Seiryu:37CD:/ window 100,100 jump 387.3
-616.9 "--sync--" #sync / 1[56]:Iwa-No-Shiki:37EC:/
-618.1 "--sync--" #sync / 1[56]:Seiryu:37D5:/
-622.7 "100-Tonze Swing" #sync / 1[56]:Iwa-No-Shiki:3C1E:/
+610.8 "Summon Shiki" sync / 1[56]:[^:]*:Seiryu:37CD:/ window 100,100 jump 387.3
+616.9 "--sync--" #sync / 1[56]:[^:]*:Iwa-No-Shiki:37EC:/
+618.1 "--sync--" #sync / 1[56]:[^:]*:Seiryu:37D5:/
+622.7 "100-Tonze Swing" #sync / 1[56]:[^:]*:Iwa-No-Shiki:3C1E:/
 624.7 "Onmyo Sigil / Serpent-Eye Sigil" #ync /:Seiryu:3A0[78]:/
-635.0 "Kanabo" #sync / 1[56]:Iwa-No-Shiki:3C1F:/
-638.8 "--sync--" #sync / 1[56]:Ao-No-Shiki:37EF:/
+635.0 "Kanabo" #sync / 1[56]:[^:]*:Iwa-No-Shiki:3C1F:/
+638.8 "--sync--" #sync / 1[56]:[^:]*:Ao-No-Shiki:37EF:/

--- a/ui/raidboss/data/04-sb/trial/shinryu-ex.txt
+++ b/ui/raidboss/data/04-sb/trial/shinryu-ex.txt
@@ -15,112 +15,112 @@ hideall "--sync--"
 ### PHASE 1: Elemental carousel
 ###
 0.0 "--sync--" sync /:Engage!/ window 0,1
-11.3 "--sync--" sync / 14:Shinryu:25FD:/ window 20,20
-21.3 "Earthen Fury" sync / 1[56]:Shinryu:25DE:/
+11.3 "--sync--" sync / 14:[^:]*:Shinryu:25FD:/ window 20,20
+21.3 "Earthen Fury" sync / 1[56]:[^:]*:Shinryu:25DE:/
 36.4 "--Tethers--" # Burning Chains (301) effect
-44.5 "Tidal Wave" sync / 1[56]:Shinryu:25F9:/
+44.5 "Tidal Wave" sync / 1[56]:[^:]*:Shinryu:25F9:/
 49.7 "--Tail Marker (healer)--" # 007E headmarker
-61.7 "Summon Icicle" sync / 1[56]:Left Wing:25EE:/
-62.4 "Icicle Impact" sync / 1[56]:Icicle:25EF:/
-67.0 "Spikesicle" sync / 1[56]:Icicle:25F0:/
-67.9 "Tail Slap" sync / 1[56]:Tail:25E2:/
-79.8 "Hypernova / Levinbolt" sync / 1[56]:Right Wing:(25E8|25EA):/
-90.9 "Dragonfist" sync / 1[56]:Shinryu:2610:/
-97.8 "Ice Storm" sync / 1[56]:Left Wing:25F1:/ # sometimes 3 seconds earlier?
-108.0 "Akh Morn 1" sync / 1[56]:Shinryu:25F3:/ duration 3.2
-110.1 "Akh Rhai" sync / 1[56]:Shinryu:25F5:/ duration 5.3
-116.3 "Summon Icicle" sync / 1[56]:Left Wing:25EE:/
-116.9 "Icicle Impact" sync / 1[56]:Icicle:25EF:/
-121.4 "Spikesicle" sync / 1[56]:Icicle:25F0:/
-123.3 "Judgment Bolt / Hellfire" sync / 1[56]:Shinryu:(25FA|25DC):/
+61.7 "Summon Icicle" sync / 1[56]:[^:]*:Left Wing:25EE:/
+62.4 "Icicle Impact" sync / 1[56]:[^:]*:Icicle:25EF:/
+67.0 "Spikesicle" sync / 1[56]:[^:]*:Icicle:25F0:/
+67.9 "Tail Slap" sync / 1[56]:[^:]*:Tail:25E2:/
+79.8 "Hypernova / Levinbolt" sync / 1[56]:[^:]*:Right Wing:(25E8|25EA):/
+90.9 "Dragonfist" sync / 1[56]:[^:]*:Shinryu:2610:/
+97.8 "Ice Storm" sync / 1[56]:[^:]*:Left Wing:25F1:/ # sometimes 3 seconds earlier?
+108.0 "Akh Morn 1" sync / 1[56]:[^:]*:Shinryu:25F3:/ duration 3.2
+110.1 "Akh Rhai" sync / 1[56]:[^:]*:Shinryu:25F5:/ duration 5.3
+116.3 "Summon Icicle" sync / 1[56]:[^:]*:Left Wing:25EE:/
+116.9 "Icicle Impact" sync / 1[56]:[^:]*:Icicle:25EF:/
+121.4 "Spikesicle" sync / 1[56]:[^:]*:Icicle:25F0:/
+123.3 "Judgment Bolt / Hellfire" sync / 1[56]:[^:]*:Shinryu:(25FA|25DC):/
 
 138.4 "--Tail Marker (dps)--"
-149.5 "Levinbolt" sync / 1[56]:Right Wing:25EA:/
-156.6 "Tail Slap" sync / 1[56]:Tail:25E2:/
-164.5 "Ice Storm" sync / 1[56]:Left Wing:25F1:/
+149.5 "Levinbolt" sync / 1[56]:[^:]*:Right Wing:25EA:/
+156.6 "Tail Slap" sync / 1[56]:[^:]*:Tail:25E2:/
+164.5 "Ice Storm" sync / 1[56]:[^:]*:Left Wing:25F1:/
 171.8 "--Tethers (T/H)--"
-180.6 "Earth Breath" sync / 1[56]:Shinryu:25EC:/
-188.0 "Akh Morn 2" sync / 1[56]:Shinryu:25F3:/ duration 3.2
-190.1 "Akh Rhai" sync / 1[56]:Shinryu:25F5:/ duration 5.3
-194.0 "Ice Storm" sync / 1[56]:Left Wing:25F1:/
+180.6 "Earth Breath" sync / 1[56]:[^:]*:Shinryu:25EC:/
+188.0 "Akh Morn 2" sync / 1[56]:[^:]*:Shinryu:25F3:/ duration 3.2
+190.1 "Akh Rhai" sync / 1[56]:[^:]*:Shinryu:25F5:/ duration 5.3
+194.0 "Ice Storm" sync / 1[56]:[^:]*:Left Wing:25F1:/
 206.6 "--Tethers (healers)--"
-208.2 "Diamond Dust" sync / 1[56]:Shinryu:25FC:/
+208.2 "Diamond Dust" sync / 1[56]:[^:]*:Shinryu:25FC:/
 224.9 "--Reiryu Adds--"
 
 233.3 "--Tail Marker (tank)--"
-251.5 "Tail Slap" sync / 1[56]:Tail:260D:/
-268.5 "Summon Icicle" sync / 1[56]:Left Wing:25EE:/
-269.1 "Icicle Impact" sync / 1[56]:Icicle:25EF:/
-272.4 "Akh Morn 3" sync / 1[56]:Shinryu:25F3:/ duration 3.2
-273.6 "Spikesicle" sync / 1[56]:Icicle:25F0:/
-274.5 "Akh Rhai" sync / 1[56]:Shinryu:25F5:/ duration 5.3
-285.3 "Super Cyclone 1" #sync / 1[56]:Shinryu:260C:/
-287.4 "Super Cyclone 2" #sync / 1[56]:Shinryu:260C:/
-289.5 "Super Cyclone 3" #sync / 1[56]:Shinryu:260C:/
-291.7 "Aerial Blast" sync / 1[56]:Shinryu:25FE:/
+251.5 "Tail Slap" sync / 1[56]:[^:]*:Tail:260D:/
+268.5 "Summon Icicle" sync / 1[56]:[^:]*:Left Wing:25EE:/
+269.1 "Icicle Impact" sync / 1[56]:[^:]*:Icicle:25EF:/
+272.4 "Akh Morn 3" sync / 1[56]:[^:]*:Shinryu:25F3:/ duration 3.2
+273.6 "Spikesicle" sync / 1[56]:[^:]*:Icicle:25F0:/
+274.5 "Akh Rhai" sync / 1[56]:[^:]*:Shinryu:25F5:/ duration 5.3
+285.3 "Super Cyclone 1" #sync / 1[56]:[^:]*:Shinryu:260C:/
+287.4 "Super Cyclone 2" #sync / 1[56]:[^:]*:Shinryu:260C:/
+289.5 "Super Cyclone 3" #sync / 1[56]:[^:]*:Shinryu:260C:/
+291.7 "Aerial Blast" sync / 1[56]:[^:]*:Shinryu:25FE:/
 292.7 "--Tethers (dps)--"
-318.9 "Earth Breath" sync / 1[56]:Shinryu:25EC:/
-321.9 "Ice Storm" sync / 1[56]:Left Wing:25F1:/
+318.9 "Earth Breath" sync / 1[56]:[^:]*:Shinryu:25EC:/
+321.9 "Ice Storm" sync / 1[56]:[^:]*:Left Wing:25F1:/
 
 325.3 "--untargetable--"
-334.7 "--sync--" sync / 1[56]:Shinryu:25F7:/
-335.9 "Gyre Charge" sync / 1[56]:Shinryu:2603:/
+334.7 "--sync--" sync / 1[56]:[^:]*:Shinryu:25F7:/
+335.9 "Gyre Charge" sync / 1[56]:[^:]*:Shinryu:2603:/
 341.8 "--targetable--"
 
-350.9 "Hypernova" sync / 1[56]:Right Wing:25E8:/
-363.0 "Akh Morn 4" sync / 1[56]:Shinryu:25F3:/ duration 4.3
-365.1 "Akh Rhai" sync / 1[56]:Shinryu:25F5:/ duration 5.3
-378.3 "Hypernova / Levinbolt" sync / 1[56]:Right Wing:(25E8|25EA):/
-384.3 "Tidal Wave" sync / 1[56]:Shinryu:25F9:/
+350.9 "Hypernova" sync / 1[56]:[^:]*:Right Wing:25E8:/
+363.0 "Akh Morn 4" sync / 1[56]:[^:]*:Shinryu:25F3:/ duration 4.3
+365.1 "Akh Rhai" sync / 1[56]:[^:]*:Shinryu:25F5:/ duration 5.3
+378.3 "Hypernova / Levinbolt" sync / 1[56]:[^:]*:Right Wing:(25E8|25EA):/
+384.3 "Tidal Wave" sync / 1[56]:[^:]*:Shinryu:25F9:/
 387.4 "--untargetable--"
-394.8 "Dark Matter" #sync / 1[56]:Shinryu:25E7:/
+394.8 "Dark Matter" #sync / 1[56]:[^:]*:Shinryu:25E7:/
 
 
 ### PHASE 2: Adds, explosions, dramatic tail climbing
 ###
-500.0 "--Phase 2--" sync / 14:Shinryu:25E7:/ window 500,500
-503.0 "Dark Matter" sync / 1[56]:Shinryu:25E7:/
+500.0 "--Phase 2--" sync / 14:[^:]*:Shinryu:25E7:/ window 500,500
+503.0 "Dark Matter" sync / 1[56]:[^:]*:Shinryu:25E7:/
 513.0 "TAP BUTTON OR ELSE" duration 5
-540.7 "Touchdown" sync / 1[56]:Shinryu:2613:/
-545.2 "--sync--" sync / 1[56]:Shinryu:25D9:/
-552.3 "Meteor Impact 1" sync / 1[56]:Cocoon:25E5:/
-553.9 "--sync--" sync / 1[56]:Cocoon:2605:/
-571.1 "Meteor Impact 2" sync / 1[56]:Cocoon:25E5:/
-572.7 "--sync--" sync / 1[56]:Cocoon:2605:/
+540.7 "Touchdown" sync / 1[56]:[^:]*:Shinryu:2613:/
+545.2 "--sync--" sync / 1[56]:[^:]*:Shinryu:25D9:/
+552.3 "Meteor Impact 1" sync / 1[56]:[^:]*:Cocoon:25E5:/
+553.9 "--sync--" sync / 1[56]:[^:]*:Cocoon:2605:/
+571.1 "Meteor Impact 2" sync / 1[56]:[^:]*:Cocoon:25E5:/
+572.7 "--sync--" sync / 1[56]:[^:]*:Cocoon:2605:/
 588.0 "--Cocoon Markers--"
-601.0 "Meteor Impact 3" sync / 1[56]:Cocoon:25E5:/
-602.6 "--sync--" sync / 1[56]:Cocoon:2605:/
+601.0 "Meteor Impact 3" sync / 1[56]:[^:]*:Cocoon:25E5:/
+602.6 "--sync--" sync / 1[56]:[^:]*:Cocoon:2605:/
 
 ### PHASE 3: Anticlimax
 ###
-800.0 "--Phase 3--" sync / 14:Shinryu:25E4:/ window 500,500
-806.0 "Protostar" sync / 1[56]:Shinryu:25E4:/
-813.1 "Tail Spit" sync / 1[56]:Shinryu:2615:/
-837.4 "Shatter" sync / 1[56]:Shinryu:2617:/ window 50,50
+800.0 "--Phase 3--" sync / 14:[^:]*:Shinryu:25E4:/ window 500,500
+806.0 "Protostar" sync / 1[56]:[^:]*:Shinryu:25E4:/
+813.1 "Tail Spit" sync / 1[56]:[^:]*:Shinryu:2615:/
+837.4 "Shatter" sync / 1[56]:[^:]*:Shinryu:2617:/ window 50,50
 843.4 "--targetable--"
 
 # Loop 1
-855.5 "--sync--" sync / 14:Shinryu:264B:/ window 20,20
-859.5 "Tera Slash" sync / 1[56]:Shinryu:264B:/
-868.2 "Atomic Ray" sync / 1[56]:Shinryu:264C:/
-885.9 "Ice Storm" sync / 1[56]:Left Wing:2722:/
-889.9 "Levinbolt / Hypernova" sync / 1[56]:Right Wing:(2720|271F):/
-897.9 "Wormwail / Benighting Breath" sync / 1[56]:Shinryu:(2648|2649):/
-907.1 "Tera Slash" sync / 1[56]:Shinryu:264B:/
+855.5 "--sync--" sync / 14:[^:]*:Shinryu:264B:/ window 20,20
+859.5 "Tera Slash" sync / 1[56]:[^:]*:Shinryu:264B:/
+868.2 "Atomic Ray" sync / 1[56]:[^:]*:Shinryu:264C:/
+885.9 "Ice Storm" sync / 1[56]:[^:]*:Left Wing:2722:/
+889.9 "Levinbolt / Hypernova" sync / 1[56]:[^:]*:Right Wing:(2720|271F):/
+897.9 "Wormwail / Benighting Breath" sync / 1[56]:[^:]*:Shinryu:(2648|2649):/
+907.1 "Tera Slash" sync / 1[56]:[^:]*:Shinryu:264B:/
 910.8 "--Reiryu Adds--"
 
 # Loop 2
-957.4 "Tera Slash" sync / 1[56]:Shinryu:264B:/ window 20,20
-966.1 "Atomic Ray" sync / 1[56]:Shinryu:264C:/
-983.8 "Ice Storm" sync / 1[56]:Left Wing:2722:/
-987.8 "Levinbolt / Hypernova" sync / 1[56]:Right Wing:(2720|271F):/
-995.9 "Wormwail / Benighting Breath" sync / 1[56]:Shinryu:(2648|2649):/
-1005.1 "Tera Slash" sync / 1[56]:Shinryu:264B:/
+957.4 "Tera Slash" sync / 1[56]:[^:]*:Shinryu:264B:/ window 20,20
+966.1 "Atomic Ray" sync / 1[56]:[^:]*:Shinryu:264C:/
+983.8 "Ice Storm" sync / 1[56]:[^:]*:Left Wing:2722:/
+987.8 "Levinbolt / Hypernova" sync / 1[56]:[^:]*:Right Wing:(2720|271F):/
+995.9 "Wormwail / Benighting Breath" sync / 1[56]:[^:]*:Shinryu:(2648|2649):/
+1005.1 "Tera Slash" sync / 1[56]:[^:]*:Shinryu:264B:/
 1009.1 "--Reiryu Adds--"
 
 ### PHASE 4: Race to the finish!
 ###
-1046.0 "--sync--" sync / 14:Shinryu:264E:/ window 300,300
+1046.0 "--sync--" sync / 14:[^:]*:Shinryu:264E:/ window 300,300
 1085.0 "First Wing" # 35 second cast, starts 4 seconds later, 2718/2719
 1090.0 "Second Wing" # 35 second cast, starts 9 seconds later, 2719/2718
-1116.0 "Tidal Wave" sync / 1[56]:Shinryu:264E:/ # 70 second cast
+1116.0 "Tidal Wave" sync / 1[56]:[^:]*:Shinryu:264E:/ # 70 second cast

--- a/ui/raidboss/data/04-sb/trial/shinryu.txt
+++ b/ui/raidboss/data/04-sb/trial/shinryu.txt
@@ -9,78 +9,78 @@ hideall "--sync--"
 0.0 "--Reset--" sync / 21:........:40000010:/ window 100000 jump 0
 
 0.0 "--sync--" sync /:Engage!/ window 0,1
-1.0 "--sync--" sync / 1[56]:(Left Wing|Right Wing):1FA9:/ window 1,2
-20.6 "Tidal Wave" sync / 1[56]:Shinryu:1FAA:/ window 20.6,5
-38.8 "Hypernova/Levinbolt" sync / 1[56]:Right Wing:1F9[9B]:/
-49.9 "Akh Morn" sync / 1[56]:Shinryu:1FA4:/
-59.2 "Summon Icicle" sync / 1[56]:Left Wing:1F9F:/
-59.9 "Icicle Impact x2" # sync / 1[56]:Icicle:1FA0:/
-64.4 "Spikesicle x2" # sync / 1[56]:Icicle:1FA1:/
-75.2 "Ice Storm" sync / 1[56]:Left Wing:1FA2:/
-88.3 "Earth Breath" sync / 1[56]:Shinryu:1F9D:/ # May be skipped with high DPS
-115.8 "Hellfire/Judgment Bolt"sync / 1[56]:Shinryu:1FA[BC]:/ window 30,30
+1.0 "--sync--" sync / 1[56]:[^:]*:(Left Wing|Right Wing):1FA9:/ window 1,2
+20.6 "Tidal Wave" sync / 1[56]:[^:]*:Shinryu:1FAA:/ window 20.6,5
+38.8 "Hypernova/Levinbolt" sync / 1[56]:[^:]*:Right Wing:1F9[9B]:/
+49.9 "Akh Morn" sync / 1[56]:[^:]*:Shinryu:1FA4:/
+59.2 "Summon Icicle" sync / 1[56]:[^:]*:Left Wing:1F9F:/
+59.9 "Icicle Impact x2" # sync / 1[56]:[^:]*:Icicle:1FA0:/
+64.4 "Spikesicle x2" # sync / 1[56]:[^:]*:Icicle:1FA1:/
+75.2 "Ice Storm" sync / 1[56]:[^:]*:Left Wing:1FA2:/
+88.3 "Earth Breath" sync / 1[56]:[^:]*:Shinryu:1F9D:/ # May be skipped with high DPS
+115.8 "Hellfire/Judgment Bolt"sync / 1[56]:[^:]*:Shinryu:1FA[BC]:/ window 30,30
 118.1 "--untargetable--"
 
 # Intermission.
 # The given times for Meteor Impact are the latest they can occur.
-119.0 "--sync--" sync / 1[56]:Shinryu:1F8A:/ window 120,5
-125.4 "--sync--" sync / 14:Cocoon:1F96:/ window 10,5
-129.1 "Meteor Impact" sync / 1[56]:Cocoon:1F96:/
-130.6 "--adds spawn--" sync / 1[56]:Cocoon:2142:/
-146.2 "--sync--" sync / 14:Cocoon:1F96:/ window 15,5
-150.9 "Meteor Impact" sync / 1[56]:Cocoon:1F96:/
-152.5 "--adds spawn--" sync / 1[56]:Cocoon:2142:/
-176.1 "--sync--" sync / 14:Cocoon:1F96:/ window 25,5
-180.8 "Meteor Impact" sync / 1[56]:Cocoon:1F96:/
-182.4 "--adds spawn--" sync / 1[56]:Cocoon:2142:/
-219.7 "--sync--" sync / 14:Shinryu:1F95:/ window 220,5
-225.2 "Protostar" sync / 1[56]:Shinryu:1F95:/
-234.3 "Dark Matter" sync / 1[56]:Shinryu:1F98:/
-240.5 "--sync--" sync / 1[56]:Shinryu:2128:/
+119.0 "--sync--" sync / 1[56]:[^:]*:Shinryu:1F8A:/ window 120,5
+125.4 "--sync--" sync / 14:[^:]*:Cocoon:1F96:/ window 10,5
+129.1 "Meteor Impact" sync / 1[56]:[^:]*:Cocoon:1F96:/
+130.6 "--adds spawn--" sync / 1[56]:[^:]*:Cocoon:2142:/
+146.2 "--sync--" sync / 14:[^:]*:Cocoon:1F96:/ window 15,5
+150.9 "Meteor Impact" sync / 1[56]:[^:]*:Cocoon:1F96:/
+152.5 "--adds spawn--" sync / 1[56]:[^:]*:Cocoon:2142:/
+176.1 "--sync--" sync / 14:[^:]*:Cocoon:1F96:/ window 25,5
+180.8 "Meteor Impact" sync / 1[56]:[^:]*:Cocoon:1F96:/
+182.4 "--adds spawn--" sync / 1[56]:[^:]*:Cocoon:2142:/
+219.7 "--sync--" sync / 14:[^:]*:Shinryu:1F95:/ window 220,5
+225.2 "Protostar" sync / 1[56]:[^:]*:Shinryu:1F95:/
+234.3 "Dark Matter" sync / 1[56]:[^:]*:Shinryu:1F98:/
+240.5 "--sync--" sync / 1[56]:[^:]*:Shinryu:2128:/
 244.9 "TAP BUTTON OR ELSE" # Doesn't seem to have an actual log line to sync
 
 # Post-intermission block
-271.9 "Gyre Charge" sync / 1[56]:Shinryu:1FA8:/
+271.9 "Gyre Charge" sync / 1[56]:[^:]*:Shinryu:1FA8:/
 279.1 "--targetable--"
-290.3 "Tail Slap" sync / 1[56]:Tail:1F93:/
-311.3 "Ice Storm" sync / 1[56]:Left Wing:1FA2:/
-317.4 "Tail Slap" sync / 1[56]:Tail:1F93:/
-328.4 "Ice Storm" sync / 1[56]:Left Wing:1FA2:/
-335.5 "Dragonfist" sync / 1[56]:Shinryu:24EF:/ window 30,30
-353.6 "Elemental Attack" sync / 1[56]:Shinryu:1FA[ABCDEF]:/
-360.8 "--sync--" sync / 1[56]:Shinryu:1F9[12]:/ window 30,15
-363.7 "Summon Icicle" sync / 1[56]:Left Wing:1F9F:/
-364.3 "Icicle Impact x2" # sync / 1[56]:Icicle:1FA0:/
-368.8 "Spikesicle x2" # sync / 1[56]:Icicle:1FA1:/
-370.8 "Tail Slap" sync / 1[56]:Tail:1F93:/
-377.8 "Ice Storm" sync / 1[56]:Left Wing:1FA2:/
-387.8 "Hypernova/Levinbolt" sync / 1[56]:Right Wing:1F9[9B]:/
-388.0 "--sync--" sync / 1[56]:Shinryu:1F9[12]:/
-398.1 "Tail Slap" sync / 1[56]:Tail:1F93:/
-425.2 "Elemental Attack" sync / 1[56]:Shinryu:1FA[ABCDEF]:/
-425.2 "--sync--" sync / 1[56]:Shinryu:23BA:/
+290.3 "Tail Slap" sync / 1[56]:[^:]*:Tail:1F93:/
+311.3 "Ice Storm" sync / 1[56]:[^:]*:Left Wing:1FA2:/
+317.4 "Tail Slap" sync / 1[56]:[^:]*:Tail:1F93:/
+328.4 "Ice Storm" sync / 1[56]:[^:]*:Left Wing:1FA2:/
+335.5 "Dragonfist" sync / 1[56]:[^:]*:Shinryu:24EF:/ window 30,30
+353.6 "Elemental Attack" sync / 1[56]:[^:]*:Shinryu:1FA[ABCDEF]:/
+360.8 "--sync--" sync / 1[56]:[^:]*:Shinryu:1F9[12]:/ window 30,15
+363.7 "Summon Icicle" sync / 1[56]:[^:]*:Left Wing:1F9F:/
+364.3 "Icicle Impact x2" # sync / 1[56]:[^:]*:Icicle:1FA0:/
+368.8 "Spikesicle x2" # sync / 1[56]:[^:]*:Icicle:1FA1:/
+370.8 "Tail Slap" sync / 1[56]:[^:]*:Tail:1F93:/
+377.8 "Ice Storm" sync / 1[56]:[^:]*:Left Wing:1FA2:/
+387.8 "Hypernova/Levinbolt" sync / 1[56]:[^:]*:Right Wing:1F9[9B]:/
+388.0 "--sync--" sync / 1[56]:[^:]*:Shinryu:1F9[12]:/
+398.1 "Tail Slap" sync / 1[56]:[^:]*:Tail:1F93:/
+425.2 "Elemental Attack" sync / 1[56]:[^:]*:Shinryu:1FA[ABCDEF]:/
+425.2 "--sync--" sync / 1[56]:[^:]*:Shinryu:23BA:/
 
 # Rotation to 0% HP
-434.4 "Akh Morn x3" sync / 1[56]:Shinryu:1FA4:/ window 30,30
+434.4 "Akh Morn x3" sync / 1[56]:[^:]*:Shinryu:1FA4:/ window 30,30
 440.7 "--untargetable--"
-450.1 "Gyre Charge" sync / 1[56]:Shinryu:1FA8:/
+450.1 "Gyre Charge" sync / 1[56]:[^:]*:Shinryu:1FA8:/
 457.2 "--targetable--"
-466.4 "Ice Storm" sync / 1[56]:Left Wing:1FA2:/
-478.4 "Dragonfist" sync / 1[56]:Shinryu:24EF:/ window 30,30
-484.4 "Hypernova/Levinbolt" sync / 1[56]:Right Wing:1F9[9B]:/
-496.5 "Elemental Attack" sync / 1[56]:Shinryu:1FA[ABCDEF]:/
-507.7 "--sync--" sync / 1[56]:Shinryu:1F9[12]:/ window 30,15
-509.7 "Summon Icicle" sync / 1[56]:Left Wing:1F9F:/
-510.3 "Icicle Impact" # sync / 1[56]:Icicle:1FA0:/
-514.8 "Spikesicle x2" # sync / 1[56]:Icicle:1FA1:/
-517.9 "Tail Slap" sync / 1[56]:Tail:1F93:/
-527.8 "Hypernova/Levinbolt" sync / 1[56]:Right Wing:1F9[9B]:/
-540.8 "Akh Morn x3" # sync / 1[56]:Shinryu:1FA4:/ duration 5
-548.9 "Ice Storm" sync / 1[56]:Left Wing:1FA2:/
-555.2 "Earth Breath" sync / 1[56]:Shinryu:1F9D:/
-569.6 "Elemental Attack" sync / 1[56]:Shinryu:1FA[ABCDEF]:/
+466.4 "Ice Storm" sync / 1[56]:[^:]*:Left Wing:1FA2:/
+478.4 "Dragonfist" sync / 1[56]:[^:]*:Shinryu:24EF:/ window 30,30
+484.4 "Hypernova/Levinbolt" sync / 1[56]:[^:]*:Right Wing:1F9[9B]:/
+496.5 "Elemental Attack" sync / 1[56]:[^:]*:Shinryu:1FA[ABCDEF]:/
+507.7 "--sync--" sync / 1[56]:[^:]*:Shinryu:1F9[12]:/ window 30,15
+509.7 "Summon Icicle" sync / 1[56]:[^:]*:Left Wing:1F9F:/
+510.3 "Icicle Impact" # sync / 1[56]:[^:]*:Icicle:1FA0:/
+514.8 "Spikesicle x2" # sync / 1[56]:[^:]*:Icicle:1FA1:/
+517.9 "Tail Slap" sync / 1[56]:[^:]*:Tail:1F93:/
+527.8 "Hypernova/Levinbolt" sync / 1[56]:[^:]*:Right Wing:1F9[9B]:/
+540.8 "Akh Morn x3" # sync / 1[56]:[^:]*:Shinryu:1FA4:/ duration 5
+548.9 "Ice Storm" sync / 1[56]:[^:]*:Left Wing:1FA2:/
+555.2 "Earth Breath" sync / 1[56]:[^:]*:Shinryu:1F9D:/
+569.6 "Elemental Attack" sync / 1[56]:[^:]*:Shinryu:1FA[ABCDEF]:/
 
-578.8 "Akh Morn x3" sync / 1[56]:Shinryu:1FA4:/ jump 434.4
+578.8 "Akh Morn x3" sync / 1[56]:[^:]*:Shinryu:1FA4:/ jump 434.4
 585.1 "--untargetable--"
 594.5 "Gyre Charge"
 601.6 "--targetable--"

--- a/ui/raidboss/data/04-sb/trial/susano-ex.txt
+++ b/ui/raidboss/data/04-sb/trial/susano-ex.txt
@@ -14,24 +14,24 @@ hideall "--knockback cloud--"
 
 ### Phase 1 ###
 0.0 "--sync--" sync /:Engage!/ window 0,1
-9.1 "Assail" sync / 1[56]:Susano:202C:/ window 10,10
-12.3 "Churn" sync / 1[56]:Susano:203E:/
-36.4 "Yata-No-Kagami" sync / 1[56]:Susano:202F:/
-40.7 "Seasplitter" sync / 1[56]:Susano:25BD:/
-42.5 "Brightstorm" sync / 1[56]:Susano:2030:/
-47.7 "Assail" sync / 1[56]:Susano:202C:/
-50.8 "Churn" sync / 1[56]:Susano:203E:/
-58.8 "Rasen Kaikyo" sync / 1[56]:Susano:202D:/
-70.0 "Yasakani-No-Magatama" sync / 1[56]:Susano:2040:/
-77.1 "Yata-No-Kagami" sync / 1[56]:Susano:202F:/
-81.4 "Seasplitter" sync / 1[56]:Susano:25BD:/
-81.5 "The Parting Clouds" sync / 1[56]:Thunderhead:2041:/
-88.2 "Assail" sync / 1[56]:Susano:202C:/
+9.1 "Assail" sync / 1[56]:[^:]*:Susano:202C:/ window 10,10
+12.3 "Churn" sync / 1[56]:[^:]*:Susano:203E:/
+36.4 "Yata-No-Kagami" sync / 1[56]:[^:]*:Susano:202F:/
+40.7 "Seasplitter" sync / 1[56]:[^:]*:Susano:25BD:/
+42.5 "Brightstorm" sync / 1[56]:[^:]*:Susano:2030:/
+47.7 "Assail" sync / 1[56]:[^:]*:Susano:202C:/
+50.8 "Churn" sync / 1[56]:[^:]*:Susano:203E:/
+58.8 "Rasen Kaikyo" sync / 1[56]:[^:]*:Susano:202D:/
+70.0 "Yasakani-No-Magatama" sync / 1[56]:[^:]*:Susano:2040:/
+77.1 "Yata-No-Kagami" sync / 1[56]:[^:]*:Susano:202F:/
+81.4 "Seasplitter" sync / 1[56]:[^:]*:Susano:25BD:/
+81.5 "The Parting Clouds" sync / 1[56]:[^:]*:Thunderhead:2041:/
+88.2 "Assail" sync / 1[56]:[^:]*:Susano:202C:/
 93.8 "--untargetable--"
 
 ### Phase 2 (hp push at ???% / time push)
 # sync to touching the Blade's Shadow, this happens twice
-300.0 "--sync--" sync / 1[56]:Susano:21C6:/ window 300,100
+300.0 "--sync--" sync / 1[56]:[^:]*:Susano:21C6:/ window 300,100
 305.6 "--targetable--"
 305.6 "--Dark Levin 1--"
 308.4 "--Dark Levin 2--"
@@ -39,94 +39,94 @@ hideall "--knockback cloud--"
 314.4 "--Dark Levin 4--"
 
 ### Phase 3 ###
-400.0 "Ame-No-Murakumo" sync / 1[56]:Susano:2032:/ window 400,100
-404.1 "Ame-No-Murakumo" sync / 1[56]:Susano:218C:/
+400.0 "Ame-No-Murakumo" sync / 1[56]:[^:]*:Susano:2032:/ window 400,100
+404.1 "Ame-No-Murakumo" sync / 1[56]:[^:]*:Susano:218C:/
 413.6 "--targetable--"
 
-425.9 "Stormsplitter" sync / 1[56]:Susano:2033:/
-432.6 "Levinbolt 1" sync / 1[56]:Susano:203C:/
-438.1 "Levinbolt 2" sync / 1[56]:Susano:203C:/
-443.5 "Levinbolt 3" sync / 1[56]:Susano:203C:/
-449.0 "Levinbolt 4" sync / 1[56]:Susano:203C:/
-458.9 "Ukehi x2" sync / 1[56]:Susano:2036:/
-467.2 "Yasakani-No-Magatama" sync / 1[56]:Susano:2040:/
+425.9 "Stormsplitter" sync / 1[56]:[^:]*:Susano:2033:/
+432.6 "Levinbolt 1" sync / 1[56]:[^:]*:Susano:203C:/
+438.1 "Levinbolt 2" sync / 1[56]:[^:]*:Susano:203C:/
+443.5 "Levinbolt 3" sync / 1[56]:[^:]*:Susano:203C:/
+449.0 "Levinbolt 4" sync / 1[56]:[^:]*:Susano:203C:/
+458.9 "Ukehi x2" sync / 1[56]:[^:]*:Susano:2036:/
+467.2 "Yasakani-No-Magatama" sync / 1[56]:[^:]*:Susano:2040:/
 474.5 "--knockback cloud--"
-474.5 "Yata-No-Kagami" sync / 1[56]:Susano:202F:/
-478.8 "Seasplitter" sync / 1[56]:Susano:25BD:/
-478.9 "The Parting Clouds" sync / 1[56]:Thunderhead:2041:/
-480.6 "Brightstorm" sync / 1[56]:Susano:2030:/
+474.5 "Yata-No-Kagami" sync / 1[56]:[^:]*:Susano:202F:/
+478.8 "Seasplitter" sync / 1[56]:[^:]*:Susano:25BD:/
+478.9 "The Parting Clouds" sync / 1[56]:[^:]*:Thunderhead:2041:/
+480.6 "Brightstorm" sync / 1[56]:[^:]*:Susano:2030:/
 
-490.8 "Stormsplitter" sync / 1[56]:Susano:2033:/
-495.9 "Yasakani-No-Magatama" sync / 1[56]:Susano:2040:/
-497.5 "Levinbolt 1" sync / 1[56]:Susano:203C:/
-503.0 "Levinbolt 2" sync / 1[56]:Susano:203C:/
-506.7 "The Parting Clouds" sync / 1[56]:Thunderhead:2041:/
-508.5 "Levinbolt 3" sync / 1[56]:Susano:203C:/
-514.0 "Levinbolt 4" sync / 1[56]:Susano:203C:/
-521.1 "Ukehi x3" sync / 1[56]:Susano:2036:/
+490.8 "Stormsplitter" sync / 1[56]:[^:]*:Susano:2033:/
+495.9 "Yasakani-No-Magatama" sync / 1[56]:[^:]*:Susano:2040:/
+497.5 "Levinbolt 1" sync / 1[56]:[^:]*:Susano:203C:/
+503.0 "Levinbolt 2" sync / 1[56]:[^:]*:Susano:203C:/
+506.7 "The Parting Clouds" sync / 1[56]:[^:]*:Thunderhead:2041:/
+508.5 "Levinbolt 3" sync / 1[56]:[^:]*:Susano:203C:/
+514.0 "Levinbolt 4" sync / 1[56]:[^:]*:Susano:203C:/
+521.1 "Ukehi x3" sync / 1[56]:[^:]*:Susano:2036:/
 
-531.5 "The Hidden Gate" sync / 1[56]:Susano:2034:/
-547.2 "Rasen Kaikyo" sync / 1[56]:Susano:202D:/
-554.5 "Stormsplitter" sync / 1[56]:Susano:2033:/
-557.1 "The Sealed Gate" sync / 1[56]:Ama-No-Iwato:2035:/
-566.7 "Levinbolt Stun 1" sync / 1[56]:Susano:203C:/
-573.2 "Levinbolt Stun 2" sync / 1[56]:Susano:203C:/
-579.7 "Levinbolt Stun 3" sync / 1[56]:Susano:203C:/
-586.2 "Levinbolt Stun 4" sync / 1[56]:Susano:203C:/
-592.6 "Ukehi x3" sync / 1[56]:Susano:2036:/
-604.0 "Churn" sync / 1[56]:Susano:203E:/
-611.2 "Yata-No-Kagami" sync / 1[56]:Susano:202F:/
-615.5 "Seasplitter" sync / 1[56]:Susano:25BD:/
-617.3 "Brightstorm" sync / 1[56]:Susano:2030:/
-622.4 "Rasen Kaikyo" sync / 1[56]:Susano:202D:/
+531.5 "The Hidden Gate" sync / 1[56]:[^:]*:Susano:2034:/
+547.2 "Rasen Kaikyo" sync / 1[56]:[^:]*:Susano:202D:/
+554.5 "Stormsplitter" sync / 1[56]:[^:]*:Susano:2033:/
+557.1 "The Sealed Gate" sync / 1[56]:[^:]*:Ama-No-Iwato:2035:/
+566.7 "Levinbolt Stun 1" sync / 1[56]:[^:]*:Susano:203C:/
+573.2 "Levinbolt Stun 2" sync / 1[56]:[^:]*:Susano:203C:/
+579.7 "Levinbolt Stun 3" sync / 1[56]:[^:]*:Susano:203C:/
+586.2 "Levinbolt Stun 4" sync / 1[56]:[^:]*:Susano:203C:/
+592.6 "Ukehi x3" sync / 1[56]:[^:]*:Susano:2036:/
+604.0 "Churn" sync / 1[56]:[^:]*:Susano:203E:/
+611.2 "Yata-No-Kagami" sync / 1[56]:[^:]*:Susano:202F:/
+615.5 "Seasplitter" sync / 1[56]:[^:]*:Susano:25BD:/
+617.3 "Brightstorm" sync / 1[56]:[^:]*:Susano:2030:/
+622.4 "Rasen Kaikyo" sync / 1[56]:[^:]*:Susano:202D:/
 
-632.7 "Stormsplitter" sync / 1[56]:Susano:2033:/
-642.9 "Levinbolt Stun 1" sync / 1[56]:Susano:203C:/
-649.3 "Levinbolt Stun 2" sync / 1[56]:Susano:203C:/
-655.9 "Levinbolt Stun 3" sync / 1[56]:Susano:203C:/
-662.4 "Levinbolt Stun 4" sync / 1[56]:Susano:203C:/
-669.8 "Ukehi x3" sync / 1[56]:Susano:2036:/
-676.1 "Churn" sync / 1[56]:Susano:203E:/
-684.1 "Rasen Kaikyo 1" sync / 1[56]:Susano:202D:/
-689.3 "Rasen Kaikyo 2" sync / 1[56]:Susano:202D:/
+632.7 "Stormsplitter" sync / 1[56]:[^:]*:Susano:2033:/
+642.9 "Levinbolt Stun 1" sync / 1[56]:[^:]*:Susano:203C:/
+649.3 "Levinbolt Stun 2" sync / 1[56]:[^:]*:Susano:203C:/
+655.9 "Levinbolt Stun 3" sync / 1[56]:[^:]*:Susano:203C:/
+662.4 "Levinbolt Stun 4" sync / 1[56]:[^:]*:Susano:203C:/
+669.8 "Ukehi x3" sync / 1[56]:[^:]*:Susano:2036:/
+676.1 "Churn" sync / 1[56]:[^:]*:Susano:203E:/
+684.1 "Rasen Kaikyo 1" sync / 1[56]:[^:]*:Susano:202D:/
+689.3 "Rasen Kaikyo 2" sync / 1[56]:[^:]*:Susano:202D:/
 
-701.6 "Stormsplitter" sync / 1[56]:Susano:2033:/
-706.7 "Yasakani-No-Magatama" sync / 1[56]:Susano:2040:/
-708.3 "Levinbolt 1" sync / 1[56]:Susano:203C:/
-713.8 "Levinbolt 2" sync / 1[56]:Susano:203C:/
-713.8 "Rasen Kaikyo" sync / 1[56]:Susano:202D:/
-717.4 "The Parting Clouds" sync / 1[56]:Thunderhead:2041:/
-719.2 "Levinbolt 3" sync / 1[56]:Susano:203C:/
-723.9 "Rasen Kaikyo" sync / 1[56]:Susano:202D:/
-724.7 "Levinbolt 4" sync / 1[56]:Susano:203C:/
-728.1 "Yasakani-No-Magatama" sync / 1[56]:Susano:2040:/
+701.6 "Stormsplitter" sync / 1[56]:[^:]*:Susano:2033:/
+706.7 "Yasakani-No-Magatama" sync / 1[56]:[^:]*:Susano:2040:/
+708.3 "Levinbolt 1" sync / 1[56]:[^:]*:Susano:203C:/
+713.8 "Levinbolt 2" sync / 1[56]:[^:]*:Susano:203C:/
+713.8 "Rasen Kaikyo" sync / 1[56]:[^:]*:Susano:202D:/
+717.4 "The Parting Clouds" sync / 1[56]:[^:]*:Thunderhead:2041:/
+719.2 "Levinbolt 3" sync / 1[56]:[^:]*:Susano:203C:/
+723.9 "Rasen Kaikyo" sync / 1[56]:[^:]*:Susano:202D:/
+724.7 "Levinbolt 4" sync / 1[56]:[^:]*:Susano:203C:/
+728.1 "Yasakani-No-Magatama" sync / 1[56]:[^:]*:Susano:2040:/
 735.3 "--knockback cloud--"
-735.3 "Yata-No-Kagami" sync / 1[56]:Susano:202F:/
-739.6 "Seasplitter" sync / 1[56]:Susano:25BD:/
-739.7 "The Parting Clouds" sync / 1[56]:Thunderhead:2041:/
-741.4 "Brightstorm" sync / 1[56]:Susano:2030:/
-748.5 "Ukehi x3" sync / 1[56]:Susano:2036:/
+735.3 "Yata-No-Kagami" sync / 1[56]:[^:]*:Susano:202F:/
+739.6 "Seasplitter" sync / 1[56]:[^:]*:Susano:25BD:/
+739.7 "The Parting Clouds" sync / 1[56]:[^:]*:Thunderhead:2041:/
+741.4 "Brightstorm" sync / 1[56]:[^:]*:Susano:2030:/
+748.5 "Ukehi x3" sync / 1[56]:[^:]*:Susano:2036:/
 
-760.0 "The Hidden Gate" sync / 1[56]:Susano:2034:/
-776.0 "Stormsplitter" sync / 1[56]:Susano:2033:/
-781.1 "Yasakani-No-Magatama" sync / 1[56]:Susano:2040:/
-782.7 "Levinbolt 1" sync / 1[56]:Susano:203C:/
-785.6 "The Sealed Gate" sync / 1[56]:Ama-No-Iwato:2035:/
-788.2 "Levinbolt 2" sync / 1[56]:Susano:203C:/
-791.9 "The Parting Clouds" sync / 1[56]:Thunderhead:2041:/
-793.7 "Levinbolt 3" sync / 1[56]:Susano:203C:/
-797.3 "Seasplitter" sync / 1[56]:Susano:25BD:/
-799.2 "Levinbolt 4" sync / 1[56]:Susano:203C:/
-807.3 "Yasakani-No-Magatama" sync / 1[56]:Susano:2040:/
-812.4 "Rasen Kaikyo" sync / 1[56]:Susano:202D:/
-814.8 "Yata-No-Kagami" sync / 1[56]:Susano:202F:/
-819.1 "Seasplitter" sync / 1[56]:Susano:25BD:/
-819.2 "The Parting Clouds" sync / 1[56]:Thunderhead:2041:/
-820.9 "Brightstorm" sync / 1[56]:Susano:2030:/
-826.0 "Rasen Kaikyo" sync / 1[56]:Susano:202D:/
-832.1 "Ukehi x3" sync / 1[56]:Susano:2036:/
+760.0 "The Hidden Gate" sync / 1[56]:[^:]*:Susano:2034:/
+776.0 "Stormsplitter" sync / 1[56]:[^:]*:Susano:2033:/
+781.1 "Yasakani-No-Magatama" sync / 1[56]:[^:]*:Susano:2040:/
+782.7 "Levinbolt 1" sync / 1[56]:[^:]*:Susano:203C:/
+785.6 "The Sealed Gate" sync / 1[56]:[^:]*:Ama-No-Iwato:2035:/
+788.2 "Levinbolt 2" sync / 1[56]:[^:]*:Susano:203C:/
+791.9 "The Parting Clouds" sync / 1[56]:[^:]*:Thunderhead:2041:/
+793.7 "Levinbolt 3" sync / 1[56]:[^:]*:Susano:203C:/
+797.3 "Seasplitter" sync / 1[56]:[^:]*:Susano:25BD:/
+799.2 "Levinbolt 4" sync / 1[56]:[^:]*:Susano:203C:/
+807.3 "Yasakani-No-Magatama" sync / 1[56]:[^:]*:Susano:2040:/
+812.4 "Rasen Kaikyo" sync / 1[56]:[^:]*:Susano:202D:/
+814.8 "Yata-No-Kagami" sync / 1[56]:[^:]*:Susano:202F:/
+819.1 "Seasplitter" sync / 1[56]:[^:]*:Susano:25BD:/
+819.2 "The Parting Clouds" sync / 1[56]:[^:]*:Thunderhead:2041:/
+820.9 "Brightstorm" sync / 1[56]:[^:]*:Susano:2030:/
+826.0 "Rasen Kaikyo" sync / 1[56]:[^:]*:Susano:202D:/
+832.1 "Ukehi x3" sync / 1[56]:[^:]*:Susano:2036:/
 
-843.6 "The Hidden Gate" sync / 1[56]:Susano:2034:/ window 40,40 jump 531.5
-859.3 "Rasen Kaikyo" #sync / 1[56]:Susano:202D:/
-866.6 "Stormsplitter" #sync / 1[56]:Susano:2033:/
-869.2 "The Sealed Gate" #sync / 1[56]:Ama-No-Iwato:2035:/
+843.6 "The Hidden Gate" sync / 1[56]:[^:]*:Susano:2034:/ window 40,40 jump 531.5
+859.3 "Rasen Kaikyo" #sync / 1[56]:[^:]*:Susano:202D:/
+866.6 "Stormsplitter" #sync / 1[56]:[^:]*:Susano:2033:/
+869.2 "The Sealed Gate" #sync / 1[56]:[^:]*:Ama-No-Iwato:2035:/

--- a/ui/raidboss/data/04-sb/trial/susano.txt
+++ b/ui/raidboss/data/04-sb/trial/susano.txt
@@ -12,82 +12,82 @@ hideall "Yasakani-No-Magatama"
 
 ### Phase 1
 0.0 "--sync--" sync /:Engage!/ window 0,1
-8.5 "Assail" sync / 1[56]:Susano:201C:/ window 10,0
-19.6 "Rasen Kaikyo" sync / 1[56]:Susano:201D:/
-32.8 "Yata-No-Kagami" sync / 1[56]:Susano:201F:/
-38.9 "Brightstorm" sync / 1[56]:Susano:2020:/
-47.1 "Assail" sync / 1[56]:Susano:201C:/
-54.3 "Yasakani-No-Magatama" sync / 1[56]:Susano:25A1:/
-63.0 "The Parting Clouds" sync / 1[56]:Dark Cloud:259F:/
-73.5 "Yata-No-Kagami" sync / 1[56]:Susano:201F:/
-77.8 "Seasplitter" sync / 1[56]:Susano:25BD:/
-82.6 "Rasen Kaikyo" sync / 1[56]:Susano:201D:/
-89.8 "Brightstorm" sync / 1[56]:Susano:2020:/
-98.9 "Assail" sync / 1[56]:Susano:201C:/
-112.1 "Yata-No-Kagami" sync / 1[56]:Susano:201F:/
-116.4 "Seasplitter" sync / 1[56]:Susano:25BD:/
-118.2 "Brightstorm" sync / 1[56]:Susano:2020:/
-125.4 "Yasakani-No-Magatama" sync / 1[56]:Susano:25A1:/
-134.1 "The Parting Clouds" sync / 1[56]:Dark Cloud:259F:/
-138.5 "The Parting Clouds" sync / 1[56]:Dark Cloud:259F:/
-142.9 "The Parting Clouds" sync / 1[56]:Dark Cloud:259F:/
-147.5 "Assail" sync / 1[56]:Susano:201C:/
-160.7 "Yata-No-Kagami" sync / 1[56]:Susano:201F:/
-165.0 "Seasplitter" sync / 1[56]:Susano:25BD:/
-166.8 "Brightstorm" sync / 1[56]:Susano:2020:/
+8.5 "Assail" sync / 1[56]:[^:]*:Susano:201C:/ window 10,0
+19.6 "Rasen Kaikyo" sync / 1[56]:[^:]*:Susano:201D:/
+32.8 "Yata-No-Kagami" sync / 1[56]:[^:]*:Susano:201F:/
+38.9 "Brightstorm" sync / 1[56]:[^:]*:Susano:2020:/
+47.1 "Assail" sync / 1[56]:[^:]*:Susano:201C:/
+54.3 "Yasakani-No-Magatama" sync / 1[56]:[^:]*:Susano:25A1:/
+63.0 "The Parting Clouds" sync / 1[56]:[^:]*:Dark Cloud:259F:/
+73.5 "Yata-No-Kagami" sync / 1[56]:[^:]*:Susano:201F:/
+77.8 "Seasplitter" sync / 1[56]:[^:]*:Susano:25BD:/
+82.6 "Rasen Kaikyo" sync / 1[56]:[^:]*:Susano:201D:/
+89.8 "Brightstorm" sync / 1[56]:[^:]*:Susano:2020:/
+98.9 "Assail" sync / 1[56]:[^:]*:Susano:201C:/
+112.1 "Yata-No-Kagami" sync / 1[56]:[^:]*:Susano:201F:/
+116.4 "Seasplitter" sync / 1[56]:[^:]*:Susano:25BD:/
+118.2 "Brightstorm" sync / 1[56]:[^:]*:Susano:2020:/
+125.4 "Yasakani-No-Magatama" sync / 1[56]:[^:]*:Susano:25A1:/
+134.1 "The Parting Clouds" sync / 1[56]:[^:]*:Dark Cloud:259F:/
+138.5 "The Parting Clouds" sync / 1[56]:[^:]*:Dark Cloud:259F:/
+142.9 "The Parting Clouds" sync / 1[56]:[^:]*:Dark Cloud:259F:/
+147.5 "Assail" sync / 1[56]:[^:]*:Susano:201C:/
+160.7 "Yata-No-Kagami" sync / 1[56]:[^:]*:Susano:201F:/
+165.0 "Seasplitter" sync / 1[56]:[^:]*:Susano:25BD:/
+166.8 "Brightstorm" sync / 1[56]:[^:]*:Susano:2020:/
 174.6 "--untargetable--"
 
 ### Phase 2 (hp push at ???% / time push)
 # sync to touching the Blade's Shadow, this happens twice
-300.0 "--sync--" sync / 1[56]:Susano:21C6:/ window 300,100
+300.0 "--sync--" sync / 1[56]:[^:]*:Susano:21C6:/ window 300,100
 305.2 "--targetable--"
 305.2 "--Dark Levin--"
 308.2 "--Dark Levin--"
 312.2 "--Dark Levin--"
 
 ### Phase 3
-400.0 "Ame-No-Murakumo" sync / 1[56]:Susano:2022:/ window 400,0
-404.0 "Ame-No-Murakumo" sync / 1[56]:Susano:218C:/
+400.0 "Ame-No-Murakumo" sync / 1[56]:[^:]*:Susano:2022:/ window 400,0
+404.0 "Ame-No-Murakumo" sync / 1[56]:[^:]*:Susano:218C:/
 413.6 "--targetable--"
 
-425.9 "Stormsplitter" sync / 1[56]:Susano:2023:/
-431.1 "The Hidden Gate" sync / 1[56]:Susano:2024:/
-456.6 "The Sealed Gate" sync / 1[56]:Ama-No-Iwato:2025:/
-458.7 "Rasen Kaikyo" sync / 1[56]:Susano:201D:/
-466.8 "Ukehi" sync / 1[56]:Susano:2026:/
+425.9 "Stormsplitter" sync / 1[56]:[^:]*:Susano:2023:/
+431.1 "The Hidden Gate" sync / 1[56]:[^:]*:Susano:2024:/
+456.6 "The Sealed Gate" sync / 1[56]:[^:]*:Ama-No-Iwato:2025:/
+458.7 "Rasen Kaikyo" sync / 1[56]:[^:]*:Susano:201D:/
+466.8 "Ukehi" sync / 1[56]:[^:]*:Susano:2026:/
 
-478.1 "Stormsplitter" sync / 1[56]:Susano:2023:/
-488.3 "Yata-No-Kagami" sync / 1[56]:Susano:201F:/
-492.6 "Seasplitter" sync / 1[56]:Susano:25BD:/
-494.4 "Brightstorm" sync / 1[56]:Susano:2020:/
-499.5 "Rasen Kaikyo" sync / 1[56]:Susano:201D:/
-507.6 "Ukehi" sync / 1[56]:Susano:2026:/
-514.9 "Yasakani-No-Magatama" sync / 1[56]:Susano:25A1:/
-523.6 "The Parting Clouds" sync / 1[56]:Dark Cloud:259F:/
-528.0 "The Parting Clouds" sync / 1[56]:Dark Cloud:259F:/
-532.4 "The Parting Clouds" sync / 1[56]:Dark Cloud:259F:/
-540.1 "Stormsplitter" sync / 1[56]:Susano:2023:/
-548.3 "Rasen Kaikyo" sync / 1[56]:Susano:201D:/
-552.4 "Brightstorm" sync / 1[56]:Susano:2020:/
-554.5 "The Hidden Gate" sync / 1[56]:Susano:2024:/
-573.1 "Ukehi" sync / 1[56]:Susano:2026:/
-580.0 "The Sealed Gate" sync / 1[56]:Ama-No-Iwato:2025:/
-588.4 "Stormsplitter" sync / 1[56]:Susano:2023:/
-593.5 "Rasen Kaikyo" sync / 1[56]:Susano:201D:/
-595.8 "Yata-No-Kagami" sync / 1[56]:Susano:201F:/
-600.1 "Seasplitter" sync / 1[56]:Susano:25BD:/
-601.9 "Brightstorm" sync / 1[56]:Susano:2020:/
-605.1 "Yasakani-No-Magatama" sync / 1[56]:Susano:25A1:/
-613.8 "The Parting Clouds" sync / 1[56]:Dark Cloud:259F:/
-618.2 "The Parting Clouds" sync / 1[56]:Dark Cloud:259F:/
-622.6 "The Parting Clouds" sync / 1[56]:Dark Cloud:259F:/
-624.2 "Rasen Kaikyo" sync / 1[56]:Susano:201D:/
-633.3 "Ukehi" sync / 1[56]:Susano:2026:/
+478.1 "Stormsplitter" sync / 1[56]:[^:]*:Susano:2023:/
+488.3 "Yata-No-Kagami" sync / 1[56]:[^:]*:Susano:201F:/
+492.6 "Seasplitter" sync / 1[56]:[^:]*:Susano:25BD:/
+494.4 "Brightstorm" sync / 1[56]:[^:]*:Susano:2020:/
+499.5 "Rasen Kaikyo" sync / 1[56]:[^:]*:Susano:201D:/
+507.6 "Ukehi" sync / 1[56]:[^:]*:Susano:2026:/
+514.9 "Yasakani-No-Magatama" sync / 1[56]:[^:]*:Susano:25A1:/
+523.6 "The Parting Clouds" sync / 1[56]:[^:]*:Dark Cloud:259F:/
+528.0 "The Parting Clouds" sync / 1[56]:[^:]*:Dark Cloud:259F:/
+532.4 "The Parting Clouds" sync / 1[56]:[^:]*:Dark Cloud:259F:/
+540.1 "Stormsplitter" sync / 1[56]:[^:]*:Susano:2023:/
+548.3 "Rasen Kaikyo" sync / 1[56]:[^:]*:Susano:201D:/
+552.4 "Brightstorm" sync / 1[56]:[^:]*:Susano:2020:/
+554.5 "The Hidden Gate" sync / 1[56]:[^:]*:Susano:2024:/
+573.1 "Ukehi" sync / 1[56]:[^:]*:Susano:2026:/
+580.0 "The Sealed Gate" sync / 1[56]:[^:]*:Ama-No-Iwato:2025:/
+588.4 "Stormsplitter" sync / 1[56]:[^:]*:Susano:2023:/
+593.5 "Rasen Kaikyo" sync / 1[56]:[^:]*:Susano:201D:/
+595.8 "Yata-No-Kagami" sync / 1[56]:[^:]*:Susano:201F:/
+600.1 "Seasplitter" sync / 1[56]:[^:]*:Susano:25BD:/
+601.9 "Brightstorm" sync / 1[56]:[^:]*:Susano:2020:/
+605.1 "Yasakani-No-Magatama" sync / 1[56]:[^:]*:Susano:25A1:/
+613.8 "The Parting Clouds" sync / 1[56]:[^:]*:Dark Cloud:259F:/
+618.2 "The Parting Clouds" sync / 1[56]:[^:]*:Dark Cloud:259F:/
+622.6 "The Parting Clouds" sync / 1[56]:[^:]*:Dark Cloud:259F:/
+624.2 "Rasen Kaikyo" sync / 1[56]:[^:]*:Susano:201D:/
+633.3 "Ukehi" sync / 1[56]:[^:]*:Susano:2026:/
 
-646.6 "Stormsplitter" sync / 1[56]:Susano:2023:/ window 40,100 jump 478.1
-656.8 "Yata-No-Kagami" #sync / 1[56]:Susano:201F:/
-661.1 "Seasplitter" #sync / 1[56]:Susano:25BD:/
-662.9 "Brightstorm" #sync / 1[56]:Susano:2020:/
-668.0 "Rasen Kaikyo" #sync / 1[56]:Susano:201D:/
-676.1 "Ukehi" #sync / 1[56]:Susano:2026:/
-683.4 "Yasakani-No-Magatama" #sync / 1[56]:Susano:25A1:/
+646.6 "Stormsplitter" sync / 1[56]:[^:]*:Susano:2023:/ window 40,100 jump 478.1
+656.8 "Yata-No-Kagami" #sync / 1[56]:[^:]*:Susano:201F:/
+661.1 "Seasplitter" #sync / 1[56]:[^:]*:Susano:25BD:/
+662.9 "Brightstorm" #sync / 1[56]:[^:]*:Susano:2020:/
+668.0 "Rasen Kaikyo" #sync / 1[56]:[^:]*:Susano:201D:/
+676.1 "Ukehi" #sync / 1[56]:[^:]*:Susano:2026:/
+683.4 "Yasakani-No-Magatama" #sync / 1[56]:[^:]*:Susano:25A1:/

--- a/ui/raidboss/data/04-sb/trial/suzaku-ex.txt
+++ b/ui/raidboss/data/04-sb/trial/suzaku-ex.txt
@@ -7,29 +7,29 @@ hideall "--sync--"
 0.0 "--Reset--" sync / 21:........:40000010:/ window 100000 jump 0
 
 0.0 "Start" sync / 00:0044:[^:]*:Tenzen/
-2.5 "--sync--" sync / 1[56]:Suzaku:367:/ window 5,0
-11.5 "Screams Of The Damned" sync / 1[56]:Suzaku:32D2:/ window 12,20
+2.5 "--sync--" sync / 1[56]:[^:]*:Suzaku:367:/ window 5,0
+11.5 "Screams Of The Damned" sync / 1[56]:[^:]*:Suzaku:32D2:/ window 12,20
 18.9 "--untargetable--"
-24.5 "Rout" sync / 1[56]:Suzaku:32F0:/
-26.2 "Rekindle" sync / 1[56]:Suzaku:32E0:/
+24.5 "Rout" sync / 1[56]:[^:]*:Suzaku:32F0:/
+26.2 "Rekindle" sync / 1[56]:[^:]*:Suzaku:32E0:/
 29.0 "--targetable--"
-35.3 "Fleeting Summer" sync / 1[56]:Suzaku:32D3:/
-42.8 "Cremate" sync / 1[56]:Suzaku:32D1:/
-54.3 "Phoenix Down" sync / 1[56]:Suzaku:3224:/
-67.4 "Rekindle" sync / 1[56]:Suzaku:32E0:/
-78.5 "Cremate" sync / 1[56]:Suzaku:32D1:/
-79.6 "Wing And A Prayer" sync / 1[56]:Scarlet Tail Feather:32D4:/
-92.2 "Screams Of The Damned" sync / 1[56]:Suzaku:32D2:/
-109.2 "Eternal Flame" sync / 1[56]:Suzaku:3222:/ # drift 0.023
+35.3 "Fleeting Summer" sync / 1[56]:[^:]*:Suzaku:32D3:/
+42.8 "Cremate" sync / 1[56]:[^:]*:Suzaku:32D1:/
+54.3 "Phoenix Down" sync / 1[56]:[^:]*:Suzaku:3224:/
+67.4 "Rekindle" sync / 1[56]:[^:]*:Suzaku:32E0:/
+78.5 "Cremate" sync / 1[56]:[^:]*:Suzaku:32D1:/
+79.6 "Wing And A Prayer" sync / 1[56]:[^:]*:Scarlet Tail Feather:32D4:/
+92.2 "Screams Of The Damned" sync / 1[56]:[^:]*:Suzaku:32D2:/
+109.2 "Eternal Flame" sync / 1[56]:[^:]*:Suzaku:3222:/ # drift 0.023
 111.3 "--untargetable--"
 
 # DDR phase
-126.5 "--sync--" sync / 1[56]:Suzaku:3226:/
-132.7 "--sync--" sync / 1[56]:Suzaku:3485:/
+126.5 "--sync--" sync / 1[56]:[^:]*:Suzaku:3226:/
+132.7 "--sync--" sync / 1[56]:[^:]*:Suzaku:3485:/
 137.8 "Scarlet Hymn"
 138.9 "Scarlet Hymn"
 140.0 "Scarlet Hymn"
-144.6 "--sync--" sync / 1[56]:Suzaku:3486:/
+144.6 "--sync--" sync / 1[56]:[^:]*:Suzaku:3486:/
 147.7 "Scarlet Hymn"
 149.8 "Scarlet Hymn"
 150.9 "Scarlet Hymn"
@@ -37,96 +37,96 @@ hideall "--sync--"
 154.2 "Scarlet Hymn"
 156.3 "Scarlet Hymn"
 157.5 "Scarlet Hymn"
-174.7 "Scarlet Fever" sync / 1[56]:Suzaku:32D9:/ window 165,20
+174.7 "Scarlet Fever" sync / 1[56]:[^:]*:Suzaku:32D9:/ window 165,20
 
 # Main phase
 179.9 "--targetable--"
-189.4 "Southron Star" sync / 1[56]:Suzaku:32DF:/ window 20,20
-195.0 "--sync--" sync / 1[56]:Suzaku:322E:/
-200.1 "Mesmerizing Melody" sync / 1[56]:Suzaku:32DA:/
-208.1 "Well Of Flame" sync / 1[56]:Suzaku:32E1:/
-208.8 "Rekindle" sync / 1[56]:Suzaku:32E0:/
-215.2 "Scathing Net" sync / 1[56]:Suzaku:3243:/
-220.2 "Phantom Flurry" sync / 1[56]:Suzaku:32DD:/ # drift 0.035
-226.3 "Phantom Half" sync / 1[56]:Suzaku:32DE:/
+189.4 "Southron Star" sync / 1[56]:[^:]*:Suzaku:32DF:/ window 20,20
+195.0 "--sync--" sync / 1[56]:[^:]*:Suzaku:322E:/
+200.1 "Mesmerizing Melody" sync / 1[56]:[^:]*:Suzaku:32DA:/
+208.1 "Well Of Flame" sync / 1[56]:[^:]*:Suzaku:32E1:/
+208.8 "Rekindle" sync / 1[56]:[^:]*:Suzaku:32E0:/
+215.2 "Scathing Net" sync / 1[56]:[^:]*:Suzaku:3243:/
+220.2 "Phantom Flurry" sync / 1[56]:[^:]*:Suzaku:32DD:/ # drift 0.035
+226.3 "Phantom Half" sync / 1[56]:[^:]*:Suzaku:32DE:/
 
 # Simon says 1 (8+8)
-231.0 "Scarlet Hymn" sync / 1[56]:Suzaku:3237:/
+231.0 "Scarlet Hymn" sync / 1[56]:[^:]*:Suzaku:3237:/
 252.1 "Hotspot x8" duration 7.7
 269.9 "Hotspot x8" duration 7.7
 
 # Back to center
-286.7 "--sync--" sync / 1[56]:Suzaku:323A:/ window 20,20
-288.8 "--sync--" sync / 1[56]:Suzaku:322E:/
-294.2 "Ruthless/Mesmerizing" sync / 1[56]:Suzaku:32D(A|B):/
-305.3 "Close-Quarter Crescendo" sync / 1[56]:Suzaku:32E4:/
+286.7 "--sync--" sync / 1[56]:[^:]*:Suzaku:323A:/ window 20,20
+288.8 "--sync--" sync / 1[56]:[^:]*:Suzaku:322E:/
+294.2 "Ruthless/Mesmerizing" sync / 1[56]:[^:]*:Suzaku:32D(A|B):/
+305.3 "Close-Quarter Crescendo" sync / 1[56]:[^:]*:Suzaku:32E4:/
 317.4 "Pay The Piper"
-321.1 "--sync--" sync / 1[56]:Suzaku:322E:/
-327.0 "Well Of Flame" sync / 1[56]:Suzaku:32E1:/
-327.6 "Rekindle" sync / 1[56]:Suzaku:32E0:/
-334.1 "Scathing Net" sync / 1[56]:Suzaku:3243:/
-338.2 "Phantom Flurry" sync / 1[56]:Suzaku:32DD:/
-344.4 "Phantom Half" sync / 1[56]:Suzaku:32DE:/
+321.1 "--sync--" sync / 1[56]:[^:]*:Suzaku:322E:/
+327.0 "Well Of Flame" sync / 1[56]:[^:]*:Suzaku:32E1:/
+327.6 "Rekindle" sync / 1[56]:[^:]*:Suzaku:32E0:/
+334.1 "Scathing Net" sync / 1[56]:[^:]*:Suzaku:3243:/
+338.2 "Phantom Flurry" sync / 1[56]:[^:]*:Suzaku:32DD:/
+344.4 "Phantom Half" sync / 1[56]:[^:]*:Suzaku:32DE:/
 
 # Simon Says 2 (8+8 with aoe)
-350.7 "Scarlet Hymn" sync / 1[56]:Suzaku:3237:/
-360.2 "--sync--" sync / 1[56]:Suzaku:322E:/
-365.3 "Ruthless/Mesmerizing" sync / 1[56]:Suzaku:32D(A|B):/
+350.7 "Scarlet Hymn" sync / 1[56]:[^:]*:Suzaku:3237:/
+360.2 "--sync--" sync / 1[56]:[^:]*:Suzaku:322E:/
+365.3 "Ruthless/Mesmerizing" sync / 1[56]:[^:]*:Suzaku:32D(A|B):/
 370.4 "Hotspot x8" duration 7.7
-385.9 "Southron Star" sync / 1[56]:Suzaku:32DF:/
+385.9 "Southron Star" sync / 1[56]:[^:]*:Suzaku:32DF:/
 391.0 "Hotspot x8" duration 7.7
 
 # Back to center
-407.5 "--sync--" sync / 1[56]:Suzaku:323A:/
-413.6 "Phantom Flurry" sync / 1[56]:Suzaku:32DD:/
-419.7 "Phantom Half" sync / 1[56]:Suzaku:32DE:/
-430.4 "Southron Star" sync / 1[56]:Suzaku:32DF:/
-442.0 "Incandescent Interlude" sync / 1[56]:Suzaku:323C:/
-446.1 "--sync--" sync / 1[56]:Suzaku:322E:/
-452.1 "Ruthless Refrain" sync / 1[56]:Suzaku:32DB:/
-454.6 "Rekindle" sync / 1[56]:Suzaku:32E0:/
-459.5 "Well Of Flame" sync / 1[56]:Suzaku:32E1:/
+407.5 "--sync--" sync / 1[56]:[^:]*:Suzaku:323A:/
+413.6 "Phantom Flurry" sync / 1[56]:[^:]*:Suzaku:32DD:/
+419.7 "Phantom Half" sync / 1[56]:[^:]*:Suzaku:32DE:/
+430.4 "Southron Star" sync / 1[56]:[^:]*:Suzaku:32DF:/
+442.0 "Incandescent Interlude" sync / 1[56]:[^:]*:Suzaku:323C:/
+446.1 "--sync--" sync / 1[56]:[^:]*:Suzaku:322E:/
+452.1 "Ruthless Refrain" sync / 1[56]:[^:]*:Suzaku:32DB:/
+454.6 "Rekindle" sync / 1[56]:[^:]*:Suzaku:32E0:/
+459.5 "Well Of Flame" sync / 1[56]:[^:]*:Suzaku:32E1:/
 
 # Simon Says 2 (4+4+4+4 with forced march, knock/draw, phantom half)
-466.7 "Scarlet Hymn" sync / 1[56]:Suzaku:3237:/
-483.6 "Well Of Flame" sync / 1[56]:Suzaku:32E1:/
-484.3 "Rekindle" sync / 1[56]:Suzaku:32E0:/
+466.7 "Scarlet Hymn" sync / 1[56]:[^:]*:Suzaku:3237:/
+483.6 "Well Of Flame" sync / 1[56]:[^:]*:Suzaku:32E1:/
+484.3 "Rekindle" sync / 1[56]:[^:]*:Suzaku:32E0:/
 489.4 "Hotspot x4" duration 3.3
-496.6 "Close-Quarter Crescendo" sync / 1[56]:Suzaku:32E4:/
+496.6 "Close-Quarter Crescendo" sync / 1[56]:[^:]*:Suzaku:32E4:/
 508.7 "Pay the Piper"
 508.8 "Hotspot x4" duration 3.3
-517.9 "--sync--" sync / 1[56]:Suzaku:322E:/
-523.4 "Ruthless/Mesmerizing" sync / 1[56]:Suzaku:32D(A|B):/
+517.9 "--sync--" sync / 1[56]:[^:]*:Suzaku:322E:/
+523.4 "Ruthless/Mesmerizing" sync / 1[56]:[^:]*:Suzaku:32D(A|B):/
 528.5 "Hotspot x4" duration 3.3
-539.6 "Phantom Flurry" sync / 1[56]:Suzaku:32DD:/
-545.8 "Phantom Half" sync / 1[56]:Suzaku:32DE:/
+539.6 "Phantom Flurry" sync / 1[56]:[^:]*:Suzaku:32DD:/
+545.8 "Phantom Half" sync / 1[56]:[^:]*:Suzaku:32DE:/
 547.9 "Hotspot x4" duration 3.3
 
 # Back to center
-562.4 "--sync--" sync / 1[56]:Suzaku:323A:/
-572.5 "Southron Star" sync / 1[56]:Suzaku:32DF:/
-580.0 "--sync--" sync / 1[56]:Suzaku:322E:/
-585.5 "Ruthless/Mesmerizing" sync / 1[56]:Suzaku:32D(A|B):/
-597.9 "Well Of Flame" sync / 1[56]:Suzaku:32E1:/
-598.5 "Rekindle" sync / 1[56]:Suzaku:32E0:/
-605.1 "Scathing Net" sync / 1[56]:Suzaku:3243:/
-610.2 "Phantom Flurry" sync / 1[56]:Suzaku:32DD:/
-616.4 "Phantom Half" sync / 1[56]:Suzaku:32DE:/
-626.5 "Southron Star" sync / 1[56]:Suzaku:32DF:/
-633.6 "--sync--" sync / 1[56]:Suzaku:322E:/
-639.0 "Ruthless/Mesmerizing" sync / 1[56]:Suzaku:32D(A|B):/
-652.0 "Southron Star" sync / 1[56]:Suzaku:32DF:/
-658.4 "Phantom Flurry" sync / 1[56]:Suzaku:32DD:/
-664.5 "Phantom Half" sync / 1[56]:Suzaku:32DE:/
-674.1 "Scarlet Hymn" sync / 1[56]:Suzaku:3237:/
-683.6 "--sync--" sync / 1[56]:Suzaku:322E:/
-689.0 "Ruthless/Mesmerizing" sync / 1[56]:Suzaku:32D(A|B):/
+562.4 "--sync--" sync / 1[56]:[^:]*:Suzaku:323A:/
+572.5 "Southron Star" sync / 1[56]:[^:]*:Suzaku:32DF:/
+580.0 "--sync--" sync / 1[56]:[^:]*:Suzaku:322E:/
+585.5 "Ruthless/Mesmerizing" sync / 1[56]:[^:]*:Suzaku:32D(A|B):/
+597.9 "Well Of Flame" sync / 1[56]:[^:]*:Suzaku:32E1:/
+598.5 "Rekindle" sync / 1[56]:[^:]*:Suzaku:32E0:/
+605.1 "Scathing Net" sync / 1[56]:[^:]*:Suzaku:3243:/
+610.2 "Phantom Flurry" sync / 1[56]:[^:]*:Suzaku:32DD:/
+616.4 "Phantom Half" sync / 1[56]:[^:]*:Suzaku:32DE:/
+626.5 "Southron Star" sync / 1[56]:[^:]*:Suzaku:32DF:/
+633.6 "--sync--" sync / 1[56]:[^:]*:Suzaku:322E:/
+639.0 "Ruthless/Mesmerizing" sync / 1[56]:[^:]*:Suzaku:32D(A|B):/
+652.0 "Southron Star" sync / 1[56]:[^:]*:Suzaku:32DF:/
+658.4 "Phantom Flurry" sync / 1[56]:[^:]*:Suzaku:32DD:/
+664.5 "Phantom Half" sync / 1[56]:[^:]*:Suzaku:32DE:/
+674.1 "Scarlet Hymn" sync / 1[56]:[^:]*:Suzaku:3237:/
+683.6 "--sync--" sync / 1[56]:[^:]*:Suzaku:322E:/
+689.0 "Ruthless/Mesmerizing" sync / 1[56]:[^:]*:Suzaku:32D(A|B):/
 695.0 "Hotspot x8" duration 7.7
-708.8 "Southron Star" sync / 1[56]:Suzaku:32DF:/ # drift -0.047
+708.8 "Southron Star" sync / 1[56]:[^:]*:Suzaku:32DF:/ # drift -0.047
 714.2 "Hotspot x8" duration 7.7
-730.1 "--sync--" sync / 1[56]:Suzaku:323A:/
-736.1 "Phantom Flurry" sync / 1[56]:Suzaku:32DD:/
-742.2 "Phantom Half" sync / 1[56]:Suzaku:32DE:/
-743.8 "Scarlet Hymn" sync / 1[56]:Suzaku:3237:/
-755.3 "--sync--" sync / 1[56]:Suzaku:322E:/
+730.1 "--sync--" sync / 1[56]:[^:]*:Suzaku:323A:/
+736.1 "Phantom Flurry" sync / 1[56]:[^:]*:Suzaku:32DD:/
+742.2 "Phantom Half" sync / 1[56]:[^:]*:Suzaku:32DE:/
+743.8 "Scarlet Hymn" sync / 1[56]:[^:]*:Suzaku:3237:/
+755.3 "--sync--" sync / 1[56]:[^:]*:Suzaku:322E:/
 766.7 "Hotspot Enrage"

--- a/ui/raidboss/data/04-sb/trial/suzaku.txt
+++ b/ui/raidboss/data/04-sb/trial/suzaku.txt
@@ -7,100 +7,100 @@ hideall "--sync--"
 0.0 "--Reset--" sync / 21:........:40000010:/ window 100000 jump 0
 
 0.0 "--sync--" sync /:Engage!/ window 0,1
-2.5 "--sync--" sync / 1[56]:Suzaku:367:/ window 2.5,1
-9.1 "Cremate" sync / 1[56]:Suzaku:3220:/ window 9.1,5
-18.7 "Eternal Flame" sync / 1[56]:Suzaku:3222:/
-29.9 "Fleeting Summer" sync / 1[56]:Suzaku:3223:/
-40.0 "Ashes To Ashes?" # sync / 1[56]:Scarlet Lady:321F:/
-42.5 "Screams Of The Damned" sync / 1[56]:Suzaku:3221:/
-50.6 "Phoenix Down" sync / 1[56]:Suzaku:3224:/
-62.1 "Cremate" sync / 1[56]:Suzaku:3220:/
-71.2 "Wing And A Prayer" sync / 1[56]:Scarlet Plume:3225:/
-71.6 "Screams Of The Damned" sync / 1[56]:Suzaku:3221:/
-85.1 "Fleeting Summer" sync / 1[56]:Suzaku:3223:/
-93.7 "Ashes To Ashes?" # sync / 1[56]:Scarlet Lady:321F:/
-100.0 "Eternal Flame" sync / 1[56]:Suzaku:3222:/
+2.5 "--sync--" sync / 1[56]:[^:]*:Suzaku:367:/ window 2.5,1
+9.1 "Cremate" sync / 1[56]:[^:]*:Suzaku:3220:/ window 9.1,5
+18.7 "Eternal Flame" sync / 1[56]:[^:]*:Suzaku:3222:/
+29.9 "Fleeting Summer" sync / 1[56]:[^:]*:Suzaku:3223:/
+40.0 "Ashes To Ashes?" # sync / 1[56]:[^:]*:Scarlet Lady:321F:/
+42.5 "Screams Of The Damned" sync / 1[56]:[^:]*:Suzaku:3221:/
+50.6 "Phoenix Down" sync / 1[56]:[^:]*:Suzaku:3224:/
+62.1 "Cremate" sync / 1[56]:[^:]*:Suzaku:3220:/
+71.2 "Wing And A Prayer" sync / 1[56]:[^:]*:Scarlet Plume:3225:/
+71.6 "Screams Of The Damned" sync / 1[56]:[^:]*:Suzaku:3221:/
+85.1 "Fleeting Summer" sync / 1[56]:[^:]*:Suzaku:3223:/
+93.7 "Ashes To Ashes?" # sync / 1[56]:[^:]*:Scarlet Lady:321F:/
+100.0 "Eternal Flame" sync / 1[56]:[^:]*:Suzaku:3222:/
 102.0 "--untargetable--"
 
-117.3 "--sync--" sync / 1[56]:Suzaku:3226:/ window 117.3
-132.4 "--sync--" sync / 1[56]:Suzaku:3485:/
-133.9 "Scarlet Hymn 1" sync / 1[56]:Rapturous Echo:3228:/
-144.0 "Scarlet Hymn 2" sync / 1[56]:Rapturous Echo:3228:/
-153.2 "--sync--" sync / 1[56]:Suzaku:3486:/
-153.5 "Scarlet Hymn 3" sync / 1[56]:Rapturous Echo:3228:/
-156.5 "Scarlet Hymn 4" sync / 1[56]:Rapturous Echo:3228:/
-165.6 "Scarlet Hymn 5" sync / 1[56]:Rapturous Echo:3228:/
-167.6 "Scarlet Hymn 6" sync / 1[56]:Rapturous Echo:3228:/
-169.6 "Scarlet Hymn 7" sync / 1[56]:Rapturous Echo:3228:/
-182.8 "Scarlet Fever" sync / 1[56]:Suzaku:322C:/ window 182.8
+117.3 "--sync--" sync / 1[56]:[^:]*:Suzaku:3226:/ window 117.3
+132.4 "--sync--" sync / 1[56]:[^:]*:Suzaku:3485:/
+133.9 "Scarlet Hymn 1" sync / 1[56]:[^:]*:Rapturous Echo:3228:/
+144.0 "Scarlet Hymn 2" sync / 1[56]:[^:]*:Rapturous Echo:3228:/
+153.2 "--sync--" sync / 1[56]:[^:]*:Suzaku:3486:/
+153.5 "Scarlet Hymn 3" sync / 1[56]:[^:]*:Rapturous Echo:3228:/
+156.5 "Scarlet Hymn 4" sync / 1[56]:[^:]*:Rapturous Echo:3228:/
+165.6 "Scarlet Hymn 5" sync / 1[56]:[^:]*:Rapturous Echo:3228:/
+167.6 "Scarlet Hymn 6" sync / 1[56]:[^:]*:Rapturous Echo:3228:/
+169.6 "Scarlet Hymn 7" sync / 1[56]:[^:]*:Rapturous Echo:3228:/
+182.8 "Scarlet Fever" sync / 1[56]:[^:]*:Suzaku:322C:/ window 182.8
 187.4 "--targetable--"
 
-197.6 "Southron Star" sync / 1[56]:Suzaku:3234:/
-205.2 "--sync--" sync / 1[56]:Suzaku:322E:/
-210.7 "Ruthless Refrain" sync / 1[56]:Suzaku:3230:/
-222.9 "Phantom Flurry" sync / 1[56]:Suzaku:3231:/
-229.0 "Phantom Half" sync / 1[56]:Suzaku:3233:/
-239.7 "Well Of Flame" sync / 1[56]:Suzaku:3236:/
-246.9 "Scarlet Hymn" sync / 1[56]:Suzaku:3237:/ window 246.9
-270.8 "Hotspot 1" sync / 1[56]:Suzaku:3238:/
-286.0 "Hotspot 2" sync / 1[56]:Suzaku:3238:/
-291.6 "Well Of Flame" sync / 1[56]:Suzaku:3236:/
-302.3 "Hotspot 3" sync / 1[56]:Suzaku:3238:/
-304.8 "--sync--" sync / 1[56]:Suzaku:322E:/
-310.3 "Ruthless Refrain" sync / 1[56]:Suzaku:3230:/
-318.6 "Hotspot 4" sync / 1[56]:Suzaku:3238:/
-329.5 "--sync--" sync / 1[56]:Suzaku:323A:/
-335.6 "Southron Star" sync / 1[56]:Suzaku:3234:/
+197.6 "Southron Star" sync / 1[56]:[^:]*:Suzaku:3234:/
+205.2 "--sync--" sync / 1[56]:[^:]*:Suzaku:322E:/
+210.7 "Ruthless Refrain" sync / 1[56]:[^:]*:Suzaku:3230:/
+222.9 "Phantom Flurry" sync / 1[56]:[^:]*:Suzaku:3231:/
+229.0 "Phantom Half" sync / 1[56]:[^:]*:Suzaku:3233:/
+239.7 "Well Of Flame" sync / 1[56]:[^:]*:Suzaku:3236:/
+246.9 "Scarlet Hymn" sync / 1[56]:[^:]*:Suzaku:3237:/ window 246.9
+270.8 "Hotspot 1" sync / 1[56]:[^:]*:Suzaku:3238:/
+286.0 "Hotspot 2" sync / 1[56]:[^:]*:Suzaku:3238:/
+291.6 "Well Of Flame" sync / 1[56]:[^:]*:Suzaku:3236:/
+302.3 "Hotspot 3" sync / 1[56]:[^:]*:Suzaku:3238:/
+304.8 "--sync--" sync / 1[56]:[^:]*:Suzaku:322E:/
+310.3 "Ruthless Refrain" sync / 1[56]:[^:]*:Suzaku:3230:/
+318.6 "Hotspot 4" sync / 1[56]:[^:]*:Suzaku:3238:/
+329.5 "--sync--" sync / 1[56]:[^:]*:Suzaku:323A:/
+335.6 "Southron Star" sync / 1[56]:[^:]*:Suzaku:3234:/
 
-346.2 "Incandescent Interlude" sync / 1[56]:Suzaku:323C:/ window 346.2
-355.6 "Rekindle" sync / 1[56]:Suzaku:3235:/
-358.6 "Immolate" sync / 1[56]:Suzaku:323E:/
-366.6 "Phantom Flurry" sync / 1[56]:Suzaku:3231:/
-372.9 "Phantom Half" sync / 1[56]:Suzaku:3233:/
-378.5 "--sync--" sync / 1[56]:Suzaku:3239:/
-380.7 "--sync--" sync / 1[56]:Suzaku:322E:/
-386.5 "Well Of Flame" sync / 1[56]:Suzaku:3236:/
-387.0 "Swoop" sync / 1[56]:Suzaku:323B:/ window 30,30
-389.7 "--sync--" sync / 1[56]:Suzaku:323A:/
-395.8 "Southron Star" sync / 1[56]:Suzaku:3234:/
-402.4 "Scarlet Hymn" sync / 1[56]:Suzaku:3237:/
-420.0 "Southron Star" sync / 1[56]:Suzaku:3234:/
-430.8 "Hotspot 1" # sync / 1[56]:Suzaku:3238:/
-432.9 "Hotspot 2" # sync / 1[56]:Suzaku:3238:/
-435.0 "Hotspot 3" # sync / 1[56]:Suzaku:3238:/
-437.0 "Hotspot 4" # sync / 1[56]:Suzaku:3238:/
-443.6 "Phantom Flurry" sync / 1[56]:Suzaku:3231:/ window 30,30
-449.9 "Phantom Half" sync / 1[56]:Suzaku:3233:/
-462.7 "Hotspot 1" # sync / 1[56]:Suzaku:3238:/
-464.8 "Hotspot 2" # sync / 1[56]:Suzaku:3238:/
-466.8 "Hotspot 3" # sync / 1[56]:Suzaku:3238:/
-468.9 "Hotspot 4" # sync / 1[56]:Suzaku:3238:/
-474.6 "--sync--" sync / 1[56]:Suzaku:322E:/
-480.2 "Well Of Flame" sync / 1[56]:Suzaku:3236:/ window 30,30
-481.1 "Rekindle" sync / 1[56]:Suzaku:3235:/
-493.7 "Hotspot 1" # sync / 1[56]:Suzaku:3238:/
-494.4 "Phantom Flurry" sync / 1[56]:Suzaku:3231:/
-495.7 "Hotspot 2" # sync / 1[56]:Suzaku:3238:/
-497.8 "Hotspot 3" # sync / 1[56]:Suzaku:3238:/
-499.8 "Hotspot 4" # sync / 1[56]:Suzaku:3238:/
-500.5 "Phantom Half" sync / 1[56]:Suzaku:3233:/
-512.1 "Southron Star" sync / 1[56]:Suzaku:3234:/
-519.7 "--sync--" sync / 1[56]:Suzaku:322E:/
-525.3 "Well Of Flame" sync / 1[56]:Suzaku:3236:/ window 30,30
-525.3 "Hotspot 1" # sync / 1[56]:Suzaku:3238:/
-527.4 "Hotspot 2" # sync / 1[56]:Suzaku:3238:/
-529.5 "Hotspot 3" # sync / 1[56]:Suzaku:3238:/
-531.6 "Hotspot 4" # sync / 1[56]:Suzaku:3238:/
-542.5 "Southron Star" sync / 1[56]:Suzaku:3234:/
-548.1 "--sync--" sync / 1[56]:Suzaku:323A:/
-554.2 "Southron Star" sync / 1[56]:Suzaku:3234:/
-566.9 "Phantom Flurry" sync / 1[56]:Suzaku:3231:/
-573.1 "Phantom Half" sync / 1[56]:Suzaku:3233:/
-584.8 "Well Of Flame" sync / 1[56]:Suzaku:3236:/
-585.7 "Rekindle" sync / 1[56]:Suzaku:3235:/
-596.9 "Southron Star" sync / 1[56]:Suzaku:3234:/
+346.2 "Incandescent Interlude" sync / 1[56]:[^:]*:Suzaku:323C:/ window 346.2
+355.6 "Rekindle" sync / 1[56]:[^:]*:Suzaku:3235:/
+358.6 "Immolate" sync / 1[56]:[^:]*:Suzaku:323E:/
+366.6 "Phantom Flurry" sync / 1[56]:[^:]*:Suzaku:3231:/
+372.9 "Phantom Half" sync / 1[56]:[^:]*:Suzaku:3233:/
+378.5 "--sync--" sync / 1[56]:[^:]*:Suzaku:3239:/
+380.7 "--sync--" sync / 1[56]:[^:]*:Suzaku:322E:/
+386.5 "Well Of Flame" sync / 1[56]:[^:]*:Suzaku:3236:/
+387.0 "Swoop" sync / 1[56]:[^:]*:Suzaku:323B:/ window 30,30
+389.7 "--sync--" sync / 1[56]:[^:]*:Suzaku:323A:/
+395.8 "Southron Star" sync / 1[56]:[^:]*:Suzaku:3234:/
+402.4 "Scarlet Hymn" sync / 1[56]:[^:]*:Suzaku:3237:/
+420.0 "Southron Star" sync / 1[56]:[^:]*:Suzaku:3234:/
+430.8 "Hotspot 1" # sync / 1[56]:[^:]*:Suzaku:3238:/
+432.9 "Hotspot 2" # sync / 1[56]:[^:]*:Suzaku:3238:/
+435.0 "Hotspot 3" # sync / 1[56]:[^:]*:Suzaku:3238:/
+437.0 "Hotspot 4" # sync / 1[56]:[^:]*:Suzaku:3238:/
+443.6 "Phantom Flurry" sync / 1[56]:[^:]*:Suzaku:3231:/ window 30,30
+449.9 "Phantom Half" sync / 1[56]:[^:]*:Suzaku:3233:/
+462.7 "Hotspot 1" # sync / 1[56]:[^:]*:Suzaku:3238:/
+464.8 "Hotspot 2" # sync / 1[56]:[^:]*:Suzaku:3238:/
+466.8 "Hotspot 3" # sync / 1[56]:[^:]*:Suzaku:3238:/
+468.9 "Hotspot 4" # sync / 1[56]:[^:]*:Suzaku:3238:/
+474.6 "--sync--" sync / 1[56]:[^:]*:Suzaku:322E:/
+480.2 "Well Of Flame" sync / 1[56]:[^:]*:Suzaku:3236:/ window 30,30
+481.1 "Rekindle" sync / 1[56]:[^:]*:Suzaku:3235:/
+493.7 "Hotspot 1" # sync / 1[56]:[^:]*:Suzaku:3238:/
+494.4 "Phantom Flurry" sync / 1[56]:[^:]*:Suzaku:3231:/
+495.7 "Hotspot 2" # sync / 1[56]:[^:]*:Suzaku:3238:/
+497.8 "Hotspot 3" # sync / 1[56]:[^:]*:Suzaku:3238:/
+499.8 "Hotspot 4" # sync / 1[56]:[^:]*:Suzaku:3238:/
+500.5 "Phantom Half" sync / 1[56]:[^:]*:Suzaku:3233:/
+512.1 "Southron Star" sync / 1[56]:[^:]*:Suzaku:3234:/
+519.7 "--sync--" sync / 1[56]:[^:]*:Suzaku:322E:/
+525.3 "Well Of Flame" sync / 1[56]:[^:]*:Suzaku:3236:/ window 30,30
+525.3 "Hotspot 1" # sync / 1[56]:[^:]*:Suzaku:3238:/
+527.4 "Hotspot 2" # sync / 1[56]:[^:]*:Suzaku:3238:/
+529.5 "Hotspot 3" # sync / 1[56]:[^:]*:Suzaku:3238:/
+531.6 "Hotspot 4" # sync / 1[56]:[^:]*:Suzaku:3238:/
+542.5 "Southron Star" sync / 1[56]:[^:]*:Suzaku:3234:/
+548.1 "--sync--" sync / 1[56]:[^:]*:Suzaku:323A:/
+554.2 "Southron Star" sync / 1[56]:[^:]*:Suzaku:3234:/
+566.9 "Phantom Flurry" sync / 1[56]:[^:]*:Suzaku:3231:/
+573.1 "Phantom Half" sync / 1[56]:[^:]*:Suzaku:3233:/
+584.8 "Well Of Flame" sync / 1[56]:[^:]*:Suzaku:3236:/
+585.7 "Rekindle" sync / 1[56]:[^:]*:Suzaku:3235:/
+596.9 "Southron Star" sync / 1[56]:[^:]*:Suzaku:3234:/
 
-609.4 "Incandescent Interlude" sync / 1[56]:Suzaku:323C:/ window 30,30 jump 346.2
+609.4 "Incandescent Interlude" sync / 1[56]:[^:]*:Suzaku:323C:/ window 30,30 jump 346.2
 618.8 "Rekindle"
 621.8 "Immolate"
 629.9 "Phantom Flurry"

--- a/ui/raidboss/data/04-sb/trial/tsukuyomi-ex.txt
+++ b/ui/raidboss/data/04-sb/trial/tsukuyomi-ex.txt
@@ -12,145 +12,145 @@ hideall "--Reset--"
 
 # Timings get slightly off if there's lead or steel first, so do a split.
 0.0 "--sync--" sync /:Engage!/ window 0,1
-10.8 "--sync--" sync / 14:Tsukuyomi:2BBA:/ window 30,30
-14.8 "Reprimand" sync / 1[56]:Tsukuyomi:2BBA:/
-25.0 "Nightfall (gun/spear)" sync / 1[56]:Tsukuyomi:2BB[CD]:/
-25.0 "--sync--" sync / 1[56]:Tsukuyomi:2BBC:/ window 30,30 jump 225
-25.0 "--sync--" sync / 1[56]:Tsukuyomi:2BBD:/ window 30,30 jump 525
-31.1 "Lead Of The Underworld?" sync / 1[56]:Tsukuyomi:2BBE:/
-31.8 "Steel Of The Underworld 1?" sync / 1[56]:Tsukuyomi:2BBF:/
-33.6 "Steel Of The Underworld 2?" sync / 1[56]:Tsukuyomi:2BBF:/
-35.4 "Steel Of The Underworld 3?" sync / 1[56]:Tsukuyomi:2BBF:/
+10.8 "--sync--" sync / 14:[^:]*:Tsukuyomi:2BBA:/ window 30,30
+14.8 "Reprimand" sync / 1[56]:[^:]*:Tsukuyomi:2BBA:/
+25.0 "Nightfall (gun/spear)" sync / 1[56]:[^:]*:Tsukuyomi:2BB[CD]:/
+25.0 "--sync--" sync / 1[56]:[^:]*:Tsukuyomi:2BBC:/ window 30,30 jump 225
+25.0 "--sync--" sync / 1[56]:[^:]*:Tsukuyomi:2BBD:/ window 30,30 jump 525
+31.1 "Lead Of The Underworld?" sync / 1[56]:[^:]*:Tsukuyomi:2BBE:/
+31.8 "Steel Of The Underworld 1?" sync / 1[56]:[^:]*:Tsukuyomi:2BBF:/
+33.6 "Steel Of The Underworld 2?" sync / 1[56]:[^:]*:Tsukuyomi:2BBF:/
+35.4 "Steel Of The Underworld 3?" sync / 1[56]:[^:]*:Tsukuyomi:2BBF:/
 
 # Lead first
-214.8 "Reprimand" sync / 1[56]:Tsukuyomi:2BBA:/
-225.0 "Nightfall (gun)" sync / 1[56]:Tsukuyomi:2BBC:/
-231.1 "Lead Of The Underworld" sync / 1[56]:Tsukuyomi:2BBE:/
-236.2 "--sync--" sync / 1[56]:Tsukuyomi:2CCF:/
-242.3 "Nightfall (spear)" sync / 1[56]:Tsukuyomi:2BBD:/
-249.1 "Steel Of The Underworld 1" #sync / 1[56]:Tsukuyomi:2BBF:/
-250.9 "Steel Of The Underworld 2" #sync / 1[56]:Tsukuyomi:2BBF:/
-252.7 "Steel Of The Underworld 3" #sync / 1[56]:Tsukuyomi:2BBF:/
-255.9 "--sync--" sync / 1[56]:Tsukuyomi:2BC0:/
-267.0 "Reprimand" sync / 1[56]:Tsukuyomi:2BBA:/
-281.0 "Nightbloom" #sync / 1[56]:Tsukuyomi:2BC7:/
+214.8 "Reprimand" sync / 1[56]:[^:]*:Tsukuyomi:2BBA:/
+225.0 "Nightfall (gun)" sync / 1[56]:[^:]*:Tsukuyomi:2BBC:/
+231.1 "Lead Of The Underworld" sync / 1[56]:[^:]*:Tsukuyomi:2BBE:/
+236.2 "--sync--" sync / 1[56]:[^:]*:Tsukuyomi:2CCF:/
+242.3 "Nightfall (spear)" sync / 1[56]:[^:]*:Tsukuyomi:2BBD:/
+249.1 "Steel Of The Underworld 1" #sync / 1[56]:[^:]*:Tsukuyomi:2BBF:/
+250.9 "Steel Of The Underworld 2" #sync / 1[56]:[^:]*:Tsukuyomi:2BBF:/
+252.7 "Steel Of The Underworld 3" #sync / 1[56]:[^:]*:Tsukuyomi:2BBF:/
+255.9 "--sync--" sync / 1[56]:[^:]*:Tsukuyomi:2BC0:/
+267.0 "Reprimand" sync / 1[56]:[^:]*:Tsukuyomi:2BBA:/
+281.0 "Nightbloom" #sync / 1[56]:[^:]*:Tsukuyomi:2BC7:/
 281.8 "--untargetable--"
 
 # Steel first
-514.8 "Reprimand" sync / 1[56]:Tsukuyomi:2BBA:/
-525.0 "Nightfall (spear)" sync / 1[56]:Tsukuyomi:2BBD:/
-531.8 "Steel Of The Underworld 1" #sync / 1[56]:Tsukuyomi:2BBF:/
-533.6 "Steel Of The Underworld 2" #sync / 1[56]:Tsukuyomi:2BBF:/
-535.4 "Steel Of The Underworld 3" #sync / 1[56]:Tsukuyomi:2BBF:/
-538.5 "--sync--" sync / 1[56]:Tsukuyomi:2BC0:/
-545.6 "Nightfall (gun)" sync / 1[56]:Tsukuyomi:2BBC:/
-551.8 "Lead Of The Underworld" sync / 1[56]:Tsukuyomi:2BBE:/
-556.9 "--sync--" sync / 1[56]:Tsukuyomi:2CCF:/
-567.0 "Reprimand" sync / 1[56]:Tsukuyomi:2BBA:/
-581.0 "Nightbloom" #sync / 1[56]:Tsukuyomi:2BC7:/
+514.8 "Reprimand" sync / 1[56]:[^:]*:Tsukuyomi:2BBA:/
+525.0 "Nightfall (spear)" sync / 1[56]:[^:]*:Tsukuyomi:2BBD:/
+531.8 "Steel Of The Underworld 1" #sync / 1[56]:[^:]*:Tsukuyomi:2BBF:/
+533.6 "Steel Of The Underworld 2" #sync / 1[56]:[^:]*:Tsukuyomi:2BBF:/
+535.4 "Steel Of The Underworld 3" #sync / 1[56]:[^:]*:Tsukuyomi:2BBF:/
+538.5 "--sync--" sync / 1[56]:[^:]*:Tsukuyomi:2BC0:/
+545.6 "Nightfall (gun)" sync / 1[56]:[^:]*:Tsukuyomi:2BBC:/
+551.8 "Lead Of The Underworld" sync / 1[56]:[^:]*:Tsukuyomi:2BBE:/
+556.9 "--sync--" sync / 1[56]:[^:]*:Tsukuyomi:2CCF:/
+567.0 "Reprimand" sync / 1[56]:[^:]*:Tsukuyomi:2BBA:/
+581.0 "Nightbloom" #sync / 1[56]:[^:]*:Tsukuyomi:2BC7:/
 581.8 "--untargetable--"
 
 # Add phase
-781.0 "Nightbloom" sync / 1[56]:Tsukuyomi:2BC7:/ window 800,0
+781.0 "Nightbloom" sync / 1[56]:[^:]*:Tsukuyomi:2BC7:/ window 800,0
 781.8 "--untargetable--"
 792.3 "Homeland adds (E->W)" sync / 03:........:Specter Of The Patriarch:/  window 40,20
 852.3 "Empire adds (SW->NW)" sync / 03:........:Specter Of Asahi:/  window 160,20
 886.3 "Enrage"
 
-1000.0 "Concentrativity" sync / 1[56]:Specter of Zenos:2BC8:/ window 1000,0
-1006.7 "Unmoving Troika" sync / 1[56]:Specter Of Zenos:2CA8:/
-1013.7 "--sync--" sync / 1[56]:Specter Of Zenos:2BCA:/
-1013.7 "--sync--" sync / 1[56]:Specter Of Gosetsu:2BCB:/
-1023.7 "Dispersivity" sync / 1[56]:Specter:2BCC:/
-1029.8 "Dispersivity" sync / 1[56]:Specter:2BCC:/
-1035.9 "Dispersivity" sync / 1[56]:Specter:2BCC:/
-1042.0 "Dispersivity" sync / 1[56]:Specter:2BCC:/
-1048.1 "Dispersivity" sync / 1[56]:Specter:2BCC:/
+1000.0 "Concentrativity" sync / 1[56]:[^:]*:Specter of Zenos:2BC8:/ window 1000,0
+1006.7 "Unmoving Troika" sync / 1[56]:[^:]*:Specter Of Zenos:2CA8:/
+1013.7 "--sync--" sync / 1[56]:[^:]*:Specter Of Zenos:2BCA:/
+1013.7 "--sync--" sync / 1[56]:[^:]*:Specter Of Gosetsu:2BCB:/
+1023.7 "Dispersivity" sync / 1[56]:[^:]*:Specter:2BCC:/
+1029.8 "Dispersivity" sync / 1[56]:[^:]*:Specter:2BCC:/
+1035.9 "Dispersivity" sync / 1[56]:[^:]*:Specter:2BCC:/
+1042.0 "Dispersivity" sync / 1[56]:[^:]*:Specter:2BCC:/
+1048.1 "Dispersivity" sync / 1[56]:[^:]*:Specter:2BCC:/
 
 # Adds complete, crescent phase
-1100.0 "--sync--" sync / 1[56]:Specter Of Gosetsu:2CD6:/ window 1200,0
-1114.3 "Nightbloom" sync / 1[56]:Tsukuyomi:2CAF:/ window 1200,0
+1100.0 "--sync--" sync / 1[56]:[^:]*:Specter Of Gosetsu:2CD6:/ window 1200,0
+1114.3 "Nightbloom" sync / 1[56]:[^:]*:Tsukuyomi:2CAF:/ window 1200,0
 1120.1 "--targetable--"
-1134.5 "Supreme Selenomancy" sync / 1[56]:Tsukuyomi:2EB0:/
-1143.5 "Lunar Halo" sync / 1[56]:Moonlight:2BD6:/
-1153.8 "Tsuki-No-Kakera" sync / 1[56]:Tsukuyomi:2BD0:/
-1159.9 "Nightfall (gun)" sync / 1[56]:Tsukuyomi:2BBC:/
-1166.4 "Lead Of The Underworld" sync / 1[56]:Tsukuyomi:2BBE:/
-1179.0 "Moonfall" sync / 1[56]:Moondust:2BD1:/
-1180.8 "Midnight Rain" sync / 1[56]:Tsukuyomi:2BCE:/
-1189.7 "Lunar Halo" sync / 1[56]:Moonlight:2BD6:/
-1195.2 "Lunar Rays" sync / 1[56]:Tsukuyomi:2BD3:/
-1196.8 "Lunar Halo" sync / 1[56]:Moonlight:2BD6:/
-1197.2 "Crater" sync / 1[56]:Moondust:2CD7:/
-1197.2 "Moonbeam" sync / 1[56]:Moondust:2BD4:/
-1208.3 "Antitwilight/Perilune" sync / 1[56]:Tsukuyomi:(2BD7|2BD8):/
+1134.5 "Supreme Selenomancy" sync / 1[56]:[^:]*:Tsukuyomi:2EB0:/
+1143.5 "Lunar Halo" sync / 1[56]:[^:]*:Moonlight:2BD6:/
+1153.8 "Tsuki-No-Kakera" sync / 1[56]:[^:]*:Tsukuyomi:2BD0:/
+1159.9 "Nightfall (gun)" sync / 1[56]:[^:]*:Tsukuyomi:2BBC:/
+1166.4 "Lead Of The Underworld" sync / 1[56]:[^:]*:Tsukuyomi:2BBE:/
+1179.0 "Moonfall" sync / 1[56]:[^:]*:Moondust:2BD1:/
+1180.8 "Midnight Rain" sync / 1[56]:[^:]*:Tsukuyomi:2BCE:/
+1189.7 "Lunar Halo" sync / 1[56]:[^:]*:Moonlight:2BD6:/
+1195.2 "Lunar Rays" sync / 1[56]:[^:]*:Tsukuyomi:2BD3:/
+1196.8 "Lunar Halo" sync / 1[56]:[^:]*:Moonlight:2BD6:/
+1197.2 "Crater" sync / 1[56]:[^:]*:Moondust:2CD7:/
+1197.2 "Moonbeam" sync / 1[56]:[^:]*:Moondust:2BD4:/
+1208.3 "Antitwilight/Perilune" sync / 1[56]:[^:]*:Tsukuyomi:(2BD7|2BD8):/
 
-1223.4 "Reprimand" sync / 1[56]:Tsukuyomi:2BBA:/
-1230.6 "Zashiki-Asobi" sync / 1[56]:Tsukuyomi:2BC5:/
-1239.8 "Nightfall (gun/spear)" sync / 1[56]:Tsukuyomi:2BB[CD]:/
-1241.7 "Tsuki-No-Maiogi" sync / 1[56]:Dancing Fan:2BC6:/
-1244.7 "Tsuki-No-Maiogi" sync / 1[56]:Dancing Fan:2BC6:/
+1223.4 "Reprimand" sync / 1[56]:[^:]*:Tsukuyomi:2BBA:/
+1230.6 "Zashiki-Asobi" sync / 1[56]:[^:]*:Tsukuyomi:2BC5:/
+1239.8 "Nightfall (gun/spear)" sync / 1[56]:[^:]*:Tsukuyomi:2BB[CD]:/
+1241.7 "Tsuki-No-Maiogi" sync / 1[56]:[^:]*:Dancing Fan:2BC6:/
+1244.7 "Tsuki-No-Maiogi" sync / 1[56]:[^:]*:Dancing Fan:2BC6:/
 # don't match 2BBF here because there's three of them, close in time.
-1246.3 "Lead Of The Underworld/Steel Of The Underworld" sync / 1[56]:Tsukuyomi:2BBE:/
+1246.3 "Lead Of The Underworld/Steel Of The Underworld" sync / 1[56]:[^:]*:Tsukuyomi:2BBE:/
 
 # Torment Unto Death can be delayed by ~2s if it's Steel
-1257.5 "--sync--" sync / 14:Tsukuyomi:2BBB:/ window 10,10
-1262.5 "Torment Unto Death" sync / 1[56]:Tsukuyomi:2BBB:/
-1273.8 "Supreme Selenomancy" sync / 1[56]:Tsukuyomi:2EB0:/
-1282.8 "Lunar Halo" sync / 1[56]:Moonlight:2BD6:/
-1292.8 "Tsuki-No-Kakera" sync / 1[56]:Tsukuyomi:2BD0:/
-1298.8 "Nightfall (spear)" sync / 1[56]:Tsukuyomi:2BBD:/
-1305.4 "Steel Of The Underworld 1" #sync / 1[56]:Tsukuyomi:2BBF:/
-1307.2 "Steel Of The Underworld 2" #sync / 1[56]:Tsukuyomi:2BBF:/
-1308.8 "Steel Of The Underworld 3" #sync / 1[56]:Tsukuyomi:2BBF:/
-1317.8 "Moonfall" sync / 1[56]:Moondust:2BD1:/
-1318.9 "Midnight Rain" sync / 1[56]:Tsukuyomi:2BCE:/
-1328.9 "Lunar Halo" sync / 1[56]:Moonlight:2BD6:/
-1332.9 "Lunar Rays" sync / 1[56]:Tsukuyomi:2BD3:/
-1334.9 "Moonbeam" sync / 1[56]:Moondust:2BD4:/
-1334.9 "Crater" sync / 1[56]:Moondust:2CD7:/
-1335.9 "Lunar Halo" sync / 1[56]:Moonlight:2BD6:/
-1346.0 "Antitwilight/Perilune" sync / 1[56]:Tsukuyomi:(2BD7|2BD8):/
+1257.5 "--sync--" sync / 14:[^:]*:Tsukuyomi:2BBB:/ window 10,10
+1262.5 "Torment Unto Death" sync / 1[56]:[^:]*:Tsukuyomi:2BBB:/
+1273.8 "Supreme Selenomancy" sync / 1[56]:[^:]*:Tsukuyomi:2EB0:/
+1282.8 "Lunar Halo" sync / 1[56]:[^:]*:Moonlight:2BD6:/
+1292.8 "Tsuki-No-Kakera" sync / 1[56]:[^:]*:Tsukuyomi:2BD0:/
+1298.8 "Nightfall (spear)" sync / 1[56]:[^:]*:Tsukuyomi:2BBD:/
+1305.4 "Steel Of The Underworld 1" #sync / 1[56]:[^:]*:Tsukuyomi:2BBF:/
+1307.2 "Steel Of The Underworld 2" #sync / 1[56]:[^:]*:Tsukuyomi:2BBF:/
+1308.8 "Steel Of The Underworld 3" #sync / 1[56]:[^:]*:Tsukuyomi:2BBF:/
+1317.8 "Moonfall" sync / 1[56]:[^:]*:Moondust:2BD1:/
+1318.9 "Midnight Rain" sync / 1[56]:[^:]*:Tsukuyomi:2BCE:/
+1328.9 "Lunar Halo" sync / 1[56]:[^:]*:Moonlight:2BD6:/
+1332.9 "Lunar Rays" sync / 1[56]:[^:]*:Tsukuyomi:2BD3:/
+1334.9 "Moonbeam" sync / 1[56]:[^:]*:Moondust:2BD4:/
+1334.9 "Crater" sync / 1[56]:[^:]*:Moondust:2CD7:/
+1335.9 "Lunar Halo" sync / 1[56]:[^:]*:Moonlight:2BD6:/
+1346.0 "Antitwilight/Perilune" sync / 1[56]:[^:]*:Tsukuyomi:(2BD7|2BD8):/
 
 # 35% push
-1361.3 "Dance Of The Dead" sync / 1[56]:Tsukuyomi:2CD0:/ window 1400,20
-1378.6 "Bright Blade/Dark Blade" sync / 1[56]:Tsukuyomi:2BD(A|B):/
-1379.5 "Waning Grudge/Waxing Grudge" sync / 1[56]:Tsukuyomi:2BD(E|F):/
-1392.0 "Bright Blade/Dark Blade" sync / 1[56]:Tsukuyomi:2BD(A|B):/
-1393.0 "Waning Grudge/Waxing Grudge" sync / 1[56]:Tsukuyomi:2BD(E|F):/
+1361.3 "Dance Of The Dead" sync / 1[56]:[^:]*:Tsukuyomi:2CD0:/ window 1400,20
+1378.6 "Bright Blade/Dark Blade" sync / 1[56]:[^:]*:Tsukuyomi:2BD(A|B):/
+1379.5 "Waning Grudge/Waxing Grudge" sync / 1[56]:[^:]*:Tsukuyomi:2BD(E|F):/
+1392.0 "Bright Blade/Dark Blade" sync / 1[56]:[^:]*:Tsukuyomi:2BD(A|B):/
+1393.0 "Waning Grudge/Waxing Grudge" sync / 1[56]:[^:]*:Tsukuyomi:2BD(E|F):/
 
 # loop begins
-1403.1 "Reprimand" sync / 1[56]:Tsukuyomi:2BBA:/
-1415.3 "Lunacy" sync / 1[56]:Tsukuyomi:2BDC:/
-1416.1 "Tsuki-No-Maiogi" duration 4 #sync / 1[56]:Dancing Fan:2BC6:/
-1417.4 "Lunacy x3" #sync / 1[56]:Tsukuyomi:2BDD:/
-#1418.4 "Lunacy" sync / 1[56]:Tsukuyomi:2BDD:/
-#1419.4 "Lunacy" sync / 1[56]:Tsukuyomi:2BDD:/
+1403.1 "Reprimand" sync / 1[56]:[^:]*:Tsukuyomi:2BBA:/
+1415.3 "Lunacy" sync / 1[56]:[^:]*:Tsukuyomi:2BDC:/
+1416.1 "Tsuki-No-Maiogi" duration 4 #sync / 1[56]:[^:]*:Dancing Fan:2BC6:/
+1417.4 "Lunacy x3" #sync / 1[56]:[^:]*:Tsukuyomi:2BDD:/
+#1418.4 "Lunacy" sync / 1[56]:[^:]*:Tsukuyomi:2BDD:/
+#1419.4 "Lunacy" sync / 1[56]:[^:]*:Tsukuyomi:2BDD:/
 
-1427.4 "Bright Blade/Dark Blade" sync / 1[56]:Tsukuyomi:2BD(A|B):/
-1428.4 "Waning Grudge/Waxing Grudge" sync / 1[56]:Tsukuyomi:2BD(E|F):/
-1437.5 "Torment Unto Death" sync / 1[56]:Tsukuyomi:2EB2:/
+1427.4 "Bright Blade/Dark Blade" sync / 1[56]:[^:]*:Tsukuyomi:2BD(A|B):/
+1428.4 "Waning Grudge/Waxing Grudge" sync / 1[56]:[^:]*:Tsukuyomi:2BD(E|F):/
+1437.5 "Torment Unto Death" sync / 1[56]:[^:]*:Tsukuyomi:2EB2:/
 
-1450.7 "Hagetsu" sync / 1[56]:Tsukuyomi:2D1C:/
-1452.5 "Tsuki-No-Maiogi" sync / 1[56]:Dancing Fan:2BC6:/
-1455.5 "Tsuki-No-Maiogi" sync / 1[56]:Dancing Fan:2BC6:/
+1450.7 "Hagetsu" sync / 1[56]:[^:]*:Tsukuyomi:2D1C:/
+1452.5 "Tsuki-No-Maiogi" sync / 1[56]:[^:]*:Dancing Fan:2BC6:/
+1455.5 "Tsuki-No-Maiogi" sync / 1[56]:[^:]*:Dancing Fan:2BC6:/
 
-1460.9 "Bright Blade/Dark Blade" sync / 1[56]:Tsukuyomi:2BD(A|B):/
-1461.9 "Waning Grudge/Waxing Grudge" sync / 1[56]:Tsukuyomi:2BD(E|F):/
-1469.9 "Reprimand" sync / 1[56]:Tsukuyomi:2BBA:/
+1460.9 "Bright Blade/Dark Blade" sync / 1[56]:[^:]*:Tsukuyomi:2BD(A|B):/
+1461.9 "Waning Grudge/Waxing Grudge" sync / 1[56]:[^:]*:Tsukuyomi:2BD(E|F):/
+1469.9 "Reprimand" sync / 1[56]:[^:]*:Tsukuyomi:2BBA:/
 
 # loop
-1476.9 "Reprimand" sync / 1[56]:Tsukuyomi:2BBA:/
-1489.2 "Lunacy" sync / 1[56]:Tsukuyomi:2BDC:/ window 50,50 jump 1415.3
-1490.0 "Tsuki-No-Maiogi" #duration 4 #sync / 1[56]:Dancing Fan:2BC6:/
-1491.3 "Lunacy x3" #sync / 1[56]:Tsukuyomi:2BDD:/
-#1492.3 "Lunacy" sync / 1[56]:Tsukuyomi:2BDD:/
-#1493.3 "Lunacy" sync / 1[56]:Tsukuyomi:2BDD:/
+1476.9 "Reprimand" sync / 1[56]:[^:]*:Tsukuyomi:2BBA:/
+1489.2 "Lunacy" sync / 1[56]:[^:]*:Tsukuyomi:2BDC:/ window 50,50 jump 1415.3
+1490.0 "Tsuki-No-Maiogi" #duration 4 #sync / 1[56]:[^:]*:Dancing Fan:2BC6:/
+1491.3 "Lunacy x3" #sync / 1[56]:[^:]*:Tsukuyomi:2BDD:/
+#1492.3 "Lunacy" sync / 1[56]:[^:]*:Tsukuyomi:2BDD:/
+#1493.3 "Lunacy" sync / 1[56]:[^:]*:Tsukuyomi:2BDD:/
 
-1501.3 "Bright Blade/Dark Blade" #sync / 1[56]:Tsukuyomi:2BD(A|B):/
-1502.3 "Waning Grudge/Waxing Grudge" #sync / 1[56]:Tsukuyomi:2BD(E|F):/
-1511.4 "Torment Unto Death" #sync / 1[56]:Tsukuyomi:2EB2:/
+1501.3 "Bright Blade/Dark Blade" #sync / 1[56]:[^:]*:Tsukuyomi:2BD(A|B):/
+1502.3 "Waning Grudge/Waxing Grudge" #sync / 1[56]:[^:]*:Tsukuyomi:2BD(E|F):/
+1511.4 "Torment Unto Death" #sync / 1[56]:[^:]*:Tsukuyomi:2EB2:/
 
-1524.6 "Hagetsu" #sync / 1[56]:Tsukuyomi:2D1C:/
-1526.4 "Tsuki-No-Maiogi" #sync / 1[56]:Dancing Fan:2BC6:/
-1529.4 "Tsuki-No-Maiogi" #sync / 1[56]:Dancing Fan:2BC6:/
+1524.6 "Hagetsu" #sync / 1[56]:[^:]*:Tsukuyomi:2D1C:/
+1526.4 "Tsuki-No-Maiogi" #sync / 1[56]:[^:]*:Dancing Fan:2BC6:/
+1529.4 "Tsuki-No-Maiogi" #sync / 1[56]:[^:]*:Dancing Fan:2BC6:/

--- a/ui/raidboss/data/04-sb/trial/tsukuyomi.txt
+++ b/ui/raidboss/data/04-sb/trial/tsukuyomi.txt
@@ -10,21 +10,21 @@ hideall "--Reset--"
 
 ### Phase 1
 0.0 "--sync--" sync /:Engage!/ window 0,1
-10.2 "--sync--" sync / 14:Tsukuyomi:2BE3:/ window 20,20
-14.2 "Torment Unto Death" sync / 1[56]:Tsukuyomi:2BE3:/
-24.3 "Zashiki-Asobi" sync / 1[56]:Tsukuyomi:2BEC:/
-30.4 "Nightfall" sync / 1[56]:Tsukuyomi:2BE5:/
-35.3 "Tsuki-No-Maiogi" duration 4 #sync / 1[56]:Dancing Fan:2BED:/
-36.6 "Steel Of The Underworld" sync / 1[56]:Tsukuyomi:2BE7:/
-39.8 "--sync--" sync / 1[56]:Tsukuyomi:2BC0:/
-49.9 "Reprimand" sync / 1[56]:Tsukuyomi:2BE2:/
-65.2 "Midnight Haze 1" sync / 1[56]:Tsukuyomi:2BE8:/
-69.6 "Midnight Haze 2" sync / 1[56]:Tsukuyomi:2BE9:/
-77.7 "Nightfall" sync / 1[56]:Tsukuyomi:2BE4:/
-79.9 "--sync--" sync / 1[56]:Tsukuyomi:2CB1:/
-85.0 "Lead Of The Underworld" sync / 1[56]:Tsukuyomi:2BE6:/
-88.1 "--sync--" sync / 1[56]:Tsukuyomi:2CCF:/
-107.0 "Nightbloom" sync / 1[56]:Tsukuyomi:2BEE:/ window 110,10
+10.2 "--sync--" sync / 14:[^:]*:Tsukuyomi:2BE3:/ window 20,20
+14.2 "Torment Unto Death" sync / 1[56]:[^:]*:Tsukuyomi:2BE3:/
+24.3 "Zashiki-Asobi" sync / 1[56]:[^:]*:Tsukuyomi:2BEC:/
+30.4 "Nightfall" sync / 1[56]:[^:]*:Tsukuyomi:2BE5:/
+35.3 "Tsuki-No-Maiogi" duration 4 #sync / 1[56]:[^:]*:Dancing Fan:2BED:/
+36.6 "Steel Of The Underworld" sync / 1[56]:[^:]*:Tsukuyomi:2BE7:/
+39.8 "--sync--" sync / 1[56]:[^:]*:Tsukuyomi:2BC0:/
+49.9 "Reprimand" sync / 1[56]:[^:]*:Tsukuyomi:2BE2:/
+65.2 "Midnight Haze 1" sync / 1[56]:[^:]*:Tsukuyomi:2BE8:/
+69.6 "Midnight Haze 2" sync / 1[56]:[^:]*:Tsukuyomi:2BE9:/
+77.7 "Nightfall" sync / 1[56]:[^:]*:Tsukuyomi:2BE4:/
+79.9 "--sync--" sync / 1[56]:[^:]*:Tsukuyomi:2CB1:/
+85.0 "Lead Of The Underworld" sync / 1[56]:[^:]*:Tsukuyomi:2BE6:/
+88.1 "--sync--" sync / 1[56]:[^:]*:Tsukuyomi:2CCF:/
+107.0 "Nightbloom" sync / 1[56]:[^:]*:Tsukuyomi:2BEE:/ window 110,10
 108.0 "--untargetable--"
 
 
@@ -33,86 +33,86 @@ hideall "--Reset--"
 174.5 "--Empire/Homeland Adds--" sync / 03:........:Specter Of The Empire:/  window 80,10
 # TODO: Specter of Asahi shows up alone after all other adds are dead, so can't have a timeline entry.
 
-400.0 "Concentrativity" sync / 1[56]:Specter of Zenos:2BEF:/ window 400,0
-406.7 "Unmoving Troika" sync / 1[56]:Specter of Zenos:2CAB:/
-413.6 "--sync--" sync / 1[56]:Specter of Zenos:2BCA:/
+400.0 "Concentrativity" sync / 1[56]:[^:]*:Specter of Zenos:2BEF:/ window 400,0
+406.7 "Unmoving Troika" sync / 1[56]:[^:]*:Specter of Zenos:2CAB:/
+413.6 "--sync--" sync / 1[56]:[^:]*:Specter of Zenos:2BCA:/
 416.6 "--targetable--"
-423.7 "Dispersivity" sync / 1[56]:Specter:2BF0:/ window 40,40
-429.7 "Dispersivity" #sync / 1[56]:Specter:2BF0:/
-435.7 "Dispersivity" #sync / 1[56]:Specter:2BF0:/
-441.7 "Dispersivity" #sync / 1[56]:Specter:2BF0:/
-447.7 "Dispersivity" #sync / 1[56]:Specter:2BF0:/
-453.7 "Dispersivity" #sync / 1[56]:Specter:2BF0:/
+423.7 "Dispersivity" sync / 1[56]:[^:]*:Specter:2BF0:/ window 40,40
+429.7 "Dispersivity" #sync / 1[56]:[^:]*:Specter:2BF0:/
+435.7 "Dispersivity" #sync / 1[56]:[^:]*:Specter:2BF0:/
+441.7 "Dispersivity" #sync / 1[56]:[^:]*:Specter:2BF0:/
+447.7 "Dispersivity" #sync / 1[56]:[^:]*:Specter:2BF0:/
+453.7 "Dispersivity" #sync / 1[56]:[^:]*:Specter:2BF0:/
 
 
 ### Phase 3: Selenomancy
-500.0 "--sync--" sync / 14:Tsukuyomi:2CB0:/ window 500,0
-504.0 "Nightbloom" sync / 1[56]:Tsukuyomi:2CB0:/
+500.0 "--sync--" sync / 14:[^:]*:Tsukuyomi:2CB0:/ window 500,0
+504.0 "Nightbloom" sync / 1[56]:[^:]*:Tsukuyomi:2CB0:/
 509.9 "--targetable--"
-524.4 "Selenomancy" sync / 1[56]:Tsukuyomi:2BF1:/
-541.6 "Nightfall" sync / 1[56]:Tsukuyomi:2BE4:/
-543.6 "Lunar Halo" sync / 1[56]:Moonlight:2C73:/
-543.8 "--sync--" sync / 1[56]:Tsukuyomi:2CB1:/
-549.0 "Lead Of The Underworld" sync / 1[56]:Tsukuyomi:2BE6:/
-552.1 "--sync--" sync / 1[56]:Tsukuyomi:2CCF:/
-565.3 "Antitwilight" sync / 1[56]:Tsukuyomi:2BF8:/
-575.5 "Torment Unto Death" sync / 1[56]:Tsukuyomi:2BE3:/
-582.7 "Zashiki-Asobi" sync / 1[56]:Tsukuyomi:2BEC:/
-588.8 "Nightfall" sync / 1[56]:Tsukuyomi:2BE4:/
-591.0 "--sync--" sync / 1[56]:Tsukuyomi:2CB1:/
-593.7 "Tsuki-No-Maiogi" sync / 1[56]:Dancing Fan:2BED:/ duration 4
-596.2 "Lead Of The Underworld" sync / 1[56]:Tsukuyomi:2BE6:/
-599.3 "--sync--" sync / 1[56]:Tsukuyomi:2CCF:/
-611.5 "Torment Unto Death" sync / 1[56]:Tsukuyomi:2BE3:/
-623.2 "Selenomancy" sync / 1[56]:Tsukuyomi:2BF1:/
-630.5 "Midnight Haze" sync / 1[56]:Tsukuyomi:2BE8:/
-635.0 "Midnight Haze" sync / 1[56]:Tsukuyomi:2BE9:/
-643.1 "Nightfall" sync / 1[56]:Tsukuyomi:2BE5:/
-649.3 "Steel Of The Underworld" sync / 1[56]:Tsukuyomi:2BE7:/
-652.2 "Lunar Halo" sync / 1[56]:Moonlight:2C73:/
-652.5 "--sync--" sync / 1[56]:Tsukuyomi:2BC0:/
-667.7 "Perilune" sync / 1[56]:Tsukuyomi:2BF7:/
+524.4 "Selenomancy" sync / 1[56]:[^:]*:Tsukuyomi:2BF1:/
+541.6 "Nightfall" sync / 1[56]:[^:]*:Tsukuyomi:2BE4:/
+543.6 "Lunar Halo" sync / 1[56]:[^:]*:Moonlight:2C73:/
+543.8 "--sync--" sync / 1[56]:[^:]*:Tsukuyomi:2CB1:/
+549.0 "Lead Of The Underworld" sync / 1[56]:[^:]*:Tsukuyomi:2BE6:/
+552.1 "--sync--" sync / 1[56]:[^:]*:Tsukuyomi:2CCF:/
+565.3 "Antitwilight" sync / 1[56]:[^:]*:Tsukuyomi:2BF8:/
+575.5 "Torment Unto Death" sync / 1[56]:[^:]*:Tsukuyomi:2BE3:/
+582.7 "Zashiki-Asobi" sync / 1[56]:[^:]*:Tsukuyomi:2BEC:/
+588.8 "Nightfall" sync / 1[56]:[^:]*:Tsukuyomi:2BE4:/
+591.0 "--sync--" sync / 1[56]:[^:]*:Tsukuyomi:2CB1:/
+593.7 "Tsuki-No-Maiogi" sync / 1[56]:[^:]*:Dancing Fan:2BED:/ duration 4
+596.2 "Lead Of The Underworld" sync / 1[56]:[^:]*:Tsukuyomi:2BE6:/
+599.3 "--sync--" sync / 1[56]:[^:]*:Tsukuyomi:2CCF:/
+611.5 "Torment Unto Death" sync / 1[56]:[^:]*:Tsukuyomi:2BE3:/
+623.2 "Selenomancy" sync / 1[56]:[^:]*:Tsukuyomi:2BF1:/
+630.5 "Midnight Haze" sync / 1[56]:[^:]*:Tsukuyomi:2BE8:/
+635.0 "Midnight Haze" sync / 1[56]:[^:]*:Tsukuyomi:2BE9:/
+643.1 "Nightfall" sync / 1[56]:[^:]*:Tsukuyomi:2BE5:/
+649.3 "Steel Of The Underworld" sync / 1[56]:[^:]*:Tsukuyomi:2BE7:/
+652.2 "Lunar Halo" sync / 1[56]:[^:]*:Moonlight:2C73:/
+652.5 "--sync--" sync / 1[56]:[^:]*:Tsukuyomi:2BC0:/
+667.7 "Perilune" sync / 1[56]:[^:]*:Tsukuyomi:2BF7:/
 
 
 ### Phase 4: Dance Of The Dead -> Bright/Dark Blade (hp push and timed)
-677.3 "--sync--" sync / 1[56]:Tsukuyomi:2BFD:/ window 700,50
-678.3 "--sync--" sync / 1[56]:Tsukuyomi:2D1F:/
-683.2 "Dance Of The Dead" sync / 1[56]:Tsukuyomi:2E79:/
-693.5 "Lunacy x3" sync / 1[56]:Tsukuyomi:2BFB:/
-701.8 "Bright Blade/Dark Blade" sync / 1[56]:Tsukuyomi:(2BF9|2BFA):/
-709.0 "Reprimand" sync / 1[56]:Tsukuyomi:2BE2:/
-719.2 "Bright Blade/Dark Blade" sync / 1[56]:Tsukuyomi:(2BF9|2BFA):/
-725.2 "Tsuki-No-Maiogi" sync / 1[56]:Dancing Fan:2BED:/ duration 4
-726.5 "Lunacy x4" sync / 1[56]:Tsukuyomi:2BFB:/
-738.8 "Reprimand" sync / 1[56]:Tsukuyomi:2BE2:/
-749.1 "Torment Unto Death" sync / 1[56]:Tsukuyomi:2EB3:/
-758.2 "Reprimand" sync / 1[56]:Tsukuyomi:2BE2:/
-759.0 "Tsuki-No-Maiogi" sync / 1[56]:Dancing Fan:2BED:/ duration 4
-763.4 "Bright Blade/Dark Blade" sync / 1[56]:Tsukuyomi:(2BF9|2BFA):/
-770.6 "Reprimand" sync / 1[56]:Tsukuyomi:2BE2:/
-780.7 "Bright Blade/Dark Blade" sync / 1[56]:Tsukuyomi:(2BF9|2BFA):/
-786.7 "Tsuki-No-Maiogi" sync / 1[56]:Dancing Fan:2BED:/ duration 4
-788.1 "Lunacy x5" sync / 1[56]:Tsukuyomi:2BFB:/
-801.5 "Reprimand" sync / 1[56]:Tsukuyomi:2BE2:/
+677.3 "--sync--" sync / 1[56]:[^:]*:Tsukuyomi:2BFD:/ window 700,50
+678.3 "--sync--" sync / 1[56]:[^:]*:Tsukuyomi:2D1F:/
+683.2 "Dance Of The Dead" sync / 1[56]:[^:]*:Tsukuyomi:2E79:/
+693.5 "Lunacy x3" sync / 1[56]:[^:]*:Tsukuyomi:2BFB:/
+701.8 "Bright Blade/Dark Blade" sync / 1[56]:[^:]*:Tsukuyomi:(2BF9|2BFA):/
+709.0 "Reprimand" sync / 1[56]:[^:]*:Tsukuyomi:2BE2:/
+719.2 "Bright Blade/Dark Blade" sync / 1[56]:[^:]*:Tsukuyomi:(2BF9|2BFA):/
+725.2 "Tsuki-No-Maiogi" sync / 1[56]:[^:]*:Dancing Fan:2BED:/ duration 4
+726.5 "Lunacy x4" sync / 1[56]:[^:]*:Tsukuyomi:2BFB:/
+738.8 "Reprimand" sync / 1[56]:[^:]*:Tsukuyomi:2BE2:/
+749.1 "Torment Unto Death" sync / 1[56]:[^:]*:Tsukuyomi:2EB3:/
+758.2 "Reprimand" sync / 1[56]:[^:]*:Tsukuyomi:2BE2:/
+759.0 "Tsuki-No-Maiogi" sync / 1[56]:[^:]*:Dancing Fan:2BED:/ duration 4
+763.4 "Bright Blade/Dark Blade" sync / 1[56]:[^:]*:Tsukuyomi:(2BF9|2BFA):/
+770.6 "Reprimand" sync / 1[56]:[^:]*:Tsukuyomi:2BE2:/
+780.7 "Bright Blade/Dark Blade" sync / 1[56]:[^:]*:Tsukuyomi:(2BF9|2BFA):/
+786.7 "Tsuki-No-Maiogi" sync / 1[56]:[^:]*:Dancing Fan:2BED:/ duration 4
+788.1 "Lunacy x5" sync / 1[56]:[^:]*:Tsukuyomi:2BFB:/
+801.5 "Reprimand" sync / 1[56]:[^:]*:Tsukuyomi:2BE2:/
 
 # begin loop
-811.7 "Torment Unto Death" sync / 1[56]:Tsukuyomi:2EB3:/
-820.8 "Reprimand" sync / 1[56]:Tsukuyomi:2BE2:/
-821.7 "Tsuki-No-Maiogi" sync / 1[56]:Dancing Fan:2BED:/ duration 4
-826.1 "Bright Blade/Dark Blade" sync / 1[56]:Tsukuyomi:(2BF9|2BFA):/
-833.2 "Reprimand" sync / 1[56]:Tsukuyomi:2BE2:/
-843.4 "Bright Blade/Dark Blade" sync / 1[56]:Tsukuyomi:(2BF9|2BFA):/
-849.4 "Tsuki-No-Maiogi" sync / 1[56]:Dancing Fan:2BED:/ duration 4
-850.7 "Lunacy x5" sync / 1[56]:Tsukuyomi:2BFB:/
-864.1 "Reprimand" sync / 1[56]:Tsukuyomi:2BE2:/
+811.7 "Torment Unto Death" sync / 1[56]:[^:]*:Tsukuyomi:2EB3:/
+820.8 "Reprimand" sync / 1[56]:[^:]*:Tsukuyomi:2BE2:/
+821.7 "Tsuki-No-Maiogi" sync / 1[56]:[^:]*:Dancing Fan:2BED:/ duration 4
+826.1 "Bright Blade/Dark Blade" sync / 1[56]:[^:]*:Tsukuyomi:(2BF9|2BFA):/
+833.2 "Reprimand" sync / 1[56]:[^:]*:Tsukuyomi:2BE2:/
+843.4 "Bright Blade/Dark Blade" sync / 1[56]:[^:]*:Tsukuyomi:(2BF9|2BFA):/
+849.4 "Tsuki-No-Maiogi" sync / 1[56]:[^:]*:Dancing Fan:2BED:/ duration 4
+850.7 "Lunacy x5" sync / 1[56]:[^:]*:Tsukuyomi:2BFB:/
+864.1 "Reprimand" sync / 1[56]:[^:]*:Tsukuyomi:2BE2:/
 
 # loop
-874.3 "Torment Unto Death" sync / 1[56]:Tsukuyomi:2EB3:/ window 50,50 jump 811.7
-883.4 "Reprimand" #sync / 1[56]:Tsukuyomi:2BE2:/
-884.3 "Tsuki-No-Maiogi" #sync / 1[56]:Dancing Fan:2BED:/ duration 4
-888.7 "Bright Blade/Dark Blade" #sync / 1[56]:Tsukuyomi:(2BF9|2BFA):/
-895.8 "Reprimand" #sync / 1[56]:Tsukuyomi:2BE2:/
-906.0 "Bright Blade/Dark Blade" #sync / 1[56]:Tsukuyomi:(2BF9|2BFA):/
-912.0 "Tsuki-No-Maiogi" #sync / 1[56]:Dancing Fan:2BED:/ duration 4
-913.3 "Lunacy x5" #sync / 1[56]:Tsukuyomi:2BFB:/
-926.7 "Reprimand" #sync / 1[56]:Tsukuyomi:2BE2:/
+874.3 "Torment Unto Death" sync / 1[56]:[^:]*:Tsukuyomi:2EB3:/ window 50,50 jump 811.7
+883.4 "Reprimand" #sync / 1[56]:[^:]*:Tsukuyomi:2BE2:/
+884.3 "Tsuki-No-Maiogi" #sync / 1[56]:[^:]*:Dancing Fan:2BED:/ duration 4
+888.7 "Bright Blade/Dark Blade" #sync / 1[56]:[^:]*:Tsukuyomi:(2BF9|2BFA):/
+895.8 "Reprimand" #sync / 1[56]:[^:]*:Tsukuyomi:2BE2:/
+906.0 "Bright Blade/Dark Blade" #sync / 1[56]:[^:]*:Tsukuyomi:(2BF9|2BFA):/
+912.0 "Tsuki-No-Maiogi" #sync / 1[56]:[^:]*:Dancing Fan:2BED:/ duration 4
+913.3 "Lunacy x5" #sync / 1[56]:[^:]*:Tsukuyomi:2BFB:/
+926.7 "Reprimand" #sync / 1[56]:[^:]*:Tsukuyomi:2BE2:/

--- a/ui/raidboss/data/04-sb/trial/yojimbo.txt
+++ b/ui/raidboss/data/04-sb/trial/yojimbo.txt
@@ -28,99 +28,99 @@ hideall "--sync--"
 
 0.0 "Start"
 0.0 "--sync--" sync /:Engage!/ window 0,1
-6.4 "Wakizashi" sync / 1[56]:Yojimbo:3827:/ window 7,7
-14.5 "Inoshikacho" sync / 1[56]:Yojimbo:3829:/ duration 9.2
-23.7 "--sync--" sync / 1[56]:Inoshikacho:382A:/
-28.8 "Metta-giri" sync / 1[56]:Yojimbo:3828:/
-32.0 "--untargetable--" sync / 1[56]:Yojimbo:382B:/
-37.2 "--sync--" sync / 1[56]:Yojimbo:382C:/
-44.0 "Unveiling" sync / 1[56]:Yojimbo:382D:/
-55.6 "--sync--" sync / 1[56]:Yojimbo:382F:/
-58.5 "Yukikaze" #sync / 1[56]:Yojimbo:3832:/
-59.6 "--sync--" sync / 1[56]:Yojimbo:3830:/
-62.1 "Yukikaze" #sync / 1[56]:Yojimbo:3832:/
-63.7 "Gekko" sync / 1[56]:Yojimbo:3833:/
-67.7 "Kasha" sync / 1[56]:Gilgamesh:3834:/
-73.7 "Bitter End" sync / 1[56]:Yojimbo:31DE:/
-84.2 "Tiny Song" sync / 1[56]:Yojimbo:3835:/
-88.8 "Dragon's Lair" sync / 1[56]:Yojimbo:3836:/
-97.4 "Bitter End" sync / 1[56]:Yojimbo:382E:/
-103.8 "Bitter End" sync / 1[56]:Yojimbo:382E:/
-106.8 "Dragon Night" sync / 1[56]:Yojimbo:3838:/
-123.2 "Tiny Song" sync / 1[56]:Yojimbo:3835:/
-128.8 "--sync--" sync / 1[56]:Yojimbo:382F:/
-131.8 "Yukikaze" #sync / 1[56]:Yojimbo:3832:/
-132.9 "--sync--" sync / 1[56]:Yojimbo:3830:/
-135.4 "Yukikaze" #sync / 1[56]:Yojimbo:3832:/
-136.9 "Gekko" sync / 1[56]:Yojimbo:3833:/
-141.0 "Kasha" sync / 1[56]:Gilgamesh:3834:/
+6.4 "Wakizashi" sync / 1[56]:[^:]*:Yojimbo:3827:/ window 7,7
+14.5 "Inoshikacho" sync / 1[56]:[^:]*:Yojimbo:3829:/ duration 9.2
+23.7 "--sync--" sync / 1[56]:[^:]*:Inoshikacho:382A:/
+28.8 "Metta-giri" sync / 1[56]:[^:]*:Yojimbo:3828:/
+32.0 "--untargetable--" sync / 1[56]:[^:]*:Yojimbo:382B:/
+37.2 "--sync--" sync / 1[56]:[^:]*:Yojimbo:382C:/
+44.0 "Unveiling" sync / 1[56]:[^:]*:Yojimbo:382D:/
+55.6 "--sync--" sync / 1[56]:[^:]*:Yojimbo:382F:/
+58.5 "Yukikaze" #sync / 1[56]:[^:]*:Yojimbo:3832:/
+59.6 "--sync--" sync / 1[56]:[^:]*:Yojimbo:3830:/
+62.1 "Yukikaze" #sync / 1[56]:[^:]*:Yojimbo:3832:/
+63.7 "Gekko" sync / 1[56]:[^:]*:Yojimbo:3833:/
+67.7 "Kasha" sync / 1[56]:[^:]*:Gilgamesh:3834:/
+73.7 "Bitter End" sync / 1[56]:[^:]*:Yojimbo:31DE:/
+84.2 "Tiny Song" sync / 1[56]:[^:]*:Yojimbo:3835:/
+88.8 "Dragon's Lair" sync / 1[56]:[^:]*:Yojimbo:3836:/
+97.4 "Bitter End" sync / 1[56]:[^:]*:Yojimbo:382E:/
+103.8 "Bitter End" sync / 1[56]:[^:]*:Yojimbo:382E:/
+106.8 "Dragon Night" sync / 1[56]:[^:]*:Yojimbo:3838:/
+123.2 "Tiny Song" sync / 1[56]:[^:]*:Yojimbo:3835:/
+128.8 "--sync--" sync / 1[56]:[^:]*:Yojimbo:382F:/
+131.8 "Yukikaze" #sync / 1[56]:[^:]*:Yojimbo:3832:/
+132.9 "--sync--" sync / 1[56]:[^:]*:Yojimbo:3830:/
+135.4 "Yukikaze" #sync / 1[56]:[^:]*:Yojimbo:3832:/
+136.9 "Gekko" sync / 1[56]:[^:]*:Yojimbo:3833:/
+141.0 "Kasha" sync / 1[56]:[^:]*:Gilgamesh:3834:/
 
-147.1 "Bitter End" sync / 1[56]:Yojimbo:382E:/
-151.5 "Bitter End" sync / 1[56]:Yojimbo:382E:/
+147.1 "Bitter End" sync / 1[56]:[^:]*:Yojimbo:382E:/
+151.5 "Bitter End" sync / 1[56]:[^:]*:Yojimbo:382E:/
 
 # """Adds""" phase
 157.3 "--untargetable--"
 # starts 100 seconds of gauge
-157.7 "--sync--" sync / 1[56]:Yojimbo:383A:/ window 200,200
-161.2 "Giga Jump" sync / 1[56]:Embodiment:383B:/
+157.7 "--sync--" sync / 1[56]:[^:]*:Yojimbo:383A:/ window 200,200
+161.2 "Giga Jump" sync / 1[56]:[^:]*:Embodiment:383B:/
 164.0 "--targetable--"
 
-169.6 "Bitter End" #sync / 1[56]:Embodiment:382E:/
-175.1 "Bitter End" #sync / 1[56]:Embodiment:382E:/
-175.3 "A Giant Me" sync / 1[56]:Embodiment:3830:/
-179.3 "Gekko" sync / 1[56]:Yojimbo:3833:/
-182.4 "Bitter End" #sync / 1[56]:Embodiment:382E:/
-183.4 "Kasha" sync / 1[56]:Gilgamesh:3834:/
-187.5 "Bitter End" #sync / 1[56]:Embodiment:382E:/
-198.9 "Kasha" sync / 1[56]:Yojimbo:3834:/
-203.2 "Gekko" sync / 1[56]:Yojimbo:3833:/
-206.0 "Bitter End" #sync / 1[56]:Embodiment:382E:/
-210.3 "Bitter End" #sync / 1[56]:Embodiment:382E:/
-223.7 "Bitter End" #sync / 1[56]:Embodiment:382E:/
-229.1 "Bitter End" #sync / 1[56]:Embodiment:382E:/
+169.6 "Bitter End" #sync / 1[56]:[^:]*:Embodiment:382E:/
+175.1 "Bitter End" #sync / 1[56]:[^:]*:Embodiment:382E:/
+175.3 "A Giant Me" sync / 1[56]:[^:]*:Embodiment:3830:/
+179.3 "Gekko" sync / 1[56]:[^:]*:Yojimbo:3833:/
+182.4 "Bitter End" #sync / 1[56]:[^:]*:Embodiment:382E:/
+183.4 "Kasha" sync / 1[56]:[^:]*:Gilgamesh:3834:/
+187.5 "Bitter End" #sync / 1[56]:[^:]*:Embodiment:382E:/
+198.9 "Kasha" sync / 1[56]:[^:]*:Yojimbo:3834:/
+203.2 "Gekko" sync / 1[56]:[^:]*:Yojimbo:3833:/
+206.0 "Bitter End" #sync / 1[56]:[^:]*:Embodiment:382E:/
+210.3 "Bitter End" #sync / 1[56]:[^:]*:Embodiment:382E:/
+223.7 "Bitter End" #sync / 1[56]:[^:]*:Embodiment:382E:/
+229.1 "Bitter End" #sync / 1[56]:[^:]*:Embodiment:382E:/
 # ???
 
-296.0 "--sync--" sync / 14:Gilgamesh:383D:/ window 100,0
-300.0 "Ame-no-Murakumo" sync / 1[56]:Gilgamesh:383D:/ window 300,300
-316.4 "Giga Jump" sync / 1[56]:Yojimbo:383E:/ # drift -0.048
+296.0 "--sync--" sync / 14:[^:]*:Gilgamesh:383D:/ window 100,0
+300.0 "Ame-no-Murakumo" sync / 1[56]:[^:]*:Gilgamesh:383D:/ window 300,300
+316.4 "Giga Jump" sync / 1[56]:[^:]*:Yojimbo:383E:/ # drift -0.048
 316.4 "--targetable--"
-319.0 "Electrogenetic Force" sync / 1[56]:Yojimbo:383F:/ duration 9.6
-328.6 "--sync--" sync / 1[56]:Electrogenetic Force:3840:/
-338.6 "Enchain" sync / 1[56]:Yojimbo:3841:/
-361.1 "Hell's Gate" sync / 1[56]:Yojimbo:3842:/
+319.0 "Electrogenetic Force" sync / 1[56]:[^:]*:Yojimbo:383F:/ duration 9.6
+328.6 "--sync--" sync / 1[56]:[^:]*:Electrogenetic Force:3840:/
+338.6 "Enchain" sync / 1[56]:[^:]*:Yojimbo:3841:/
+361.1 "Hell's Gate" sync / 1[56]:[^:]*:Yojimbo:3842:/
 
 # final loop
-374.5 "Masamune" sync / 1[56]:Yojimbo:3843:/
-380.4 "Zanma Zanmai" sync / 1[56]:Yojimbo:3844:/
-388.0 "Epic Stormsplitter" sync / 1[56]:Yojimbo:3845:/
-396.5 "Dragon's Lair" sync / 1[56]:Yojimbo:3836:/
-399.0 "Electrogenetic Force" sync / 1[56]:Yojimbo:383F:/ duration 9.6
-408.7 "--sync--" sync / 1[56]:Electrogenetic Force:3840:/
-414.5 "Dragon Night" sync / 1[56]:Yojimbo:3838:/
-416.6 "Bitter End" sync / 1[56]:Yojimbo:382E:/
-422.0 "Bitter End" sync / 1[56]:Yojimbo:382E:/
+374.5 "Masamune" sync / 1[56]:[^:]*:Yojimbo:3843:/
+380.4 "Zanma Zanmai" sync / 1[56]:[^:]*:Yojimbo:3844:/
+388.0 "Epic Stormsplitter" sync / 1[56]:[^:]*:Yojimbo:3845:/
+396.5 "Dragon's Lair" sync / 1[56]:[^:]*:Yojimbo:3836:/
+399.0 "Electrogenetic Force" sync / 1[56]:[^:]*:Yojimbo:383F:/ duration 9.6
+408.7 "--sync--" sync / 1[56]:[^:]*:Electrogenetic Force:3840:/
+414.5 "Dragon Night" sync / 1[56]:[^:]*:Yojimbo:3838:/
+416.6 "Bitter End" sync / 1[56]:[^:]*:Yojimbo:382E:/
+422.0 "Bitter End" sync / 1[56]:[^:]*:Yojimbo:382E:/
 
-433.5 "--sync--" sync / 1[56]:Yojimbo:382F:/
-436.5 "Yukikaze" #sync / 1[56]:Yojimbo:3832:/
-437.6 "--sync--" sync / 1[56]:Yojimbo:3830:/
-430.0 "Yukikaze" #sync / 1[56]:Yojimbo:3832:/
-441.6 "Gekko" sync / 1[56]:Yojimbo:3833:/
-445.7 "Kasha" sync / 1[56]:Gilgamesh:3834:/
-445.8 "Dragon's Lair" sync / 1[56]:Yojimbo:3836:/
-456.5 "Tiny Song" sync / 1[56]:Yojimbo:3835:/
-463.8 "Dragon Night" sync / 1[56]:Yojimbo:3838:/
-469.1 "Bitter End" sync / 1[56]:Yojimbo:382E:/
+433.5 "--sync--" sync / 1[56]:[^:]*:Yojimbo:382F:/
+436.5 "Yukikaze" #sync / 1[56]:[^:]*:Yojimbo:3832:/
+437.6 "--sync--" sync / 1[56]:[^:]*:Yojimbo:3830:/
+430.0 "Yukikaze" #sync / 1[56]:[^:]*:Yojimbo:3832:/
+441.6 "Gekko" sync / 1[56]:[^:]*:Yojimbo:3833:/
+445.7 "Kasha" sync / 1[56]:[^:]*:Gilgamesh:3834:/
+445.8 "Dragon's Lair" sync / 1[56]:[^:]*:Yojimbo:3836:/
+456.5 "Tiny Song" sync / 1[56]:[^:]*:Yojimbo:3835:/
+463.8 "Dragon Night" sync / 1[56]:[^:]*:Yojimbo:3838:/
+469.1 "Bitter End" sync / 1[56]:[^:]*:Yojimbo:382E:/
 
-474.4 "--sync--" sync / 1[56]:Yojimbo:382F:/
-477.4 "Yukikaze" sync / 1[56]:Yojimbo:3832:/
-478.5 "--sync--" sync / 1[56]:Yojimbo:3830:/
-480.9 "Yukikaze" sync / 1[56]:Yojimbo:3832:/
-482.5 "Gekko" sync / 1[56]:Yojimbo:3833:/
-486.6 "Kasha" sync / 1[56]:Gilgamesh:3834:/
-489.8 "Bitter End" sync / 1[56]:Yojimbo:382E:/
+474.4 "--sync--" sync / 1[56]:[^:]*:Yojimbo:382F:/
+477.4 "Yukikaze" sync / 1[56]:[^:]*:Yojimbo:3832:/
+478.5 "--sync--" sync / 1[56]:[^:]*:Yojimbo:3830:/
+480.9 "Yukikaze" sync / 1[56]:[^:]*:Yojimbo:3832:/
+482.5 "Gekko" sync / 1[56]:[^:]*:Yojimbo:3833:/
+486.6 "Kasha" sync / 1[56]:[^:]*:Gilgamesh:3834:/
+489.8 "Bitter End" sync / 1[56]:[^:]*:Yojimbo:382E:/
 
 # fake loop lookahead
-505.0 "Masamune" sync / 1[56]:Yojimbo:3843:/ window 40,40 jump 374.5
+505.0 "Masamune" sync / 1[56]:[^:]*:Yojimbo:3843:/ window 40,40 jump 374.5
 510.9 "Zanma Zanmai"
 518.5 "Epic Stormsplitter"
 527.0 "Dragon's Lair"

--- a/ui/raidboss/data/04-sb/ultimate/ultima_weapon_ultimate.txt
+++ b/ui/raidboss/data/04-sb/ultimate/ultima_weapon_ultimate.txt
@@ -9,69 +9,69 @@ hideall "--Reset--"
 ### Phase 1: Garuda ###
 0.0 "--sync--" sync /:Engage!/ window 0,1
 0 "--sync--" sync / 00:0044:[^:]*:Heehee HAHA hahaha HEEHEE haha HEEEEEE/ window 0,20
-9 "Slipstream" sync / 1[56]:Garuda:2B53:/ window 10,5 # drift 0.293
-12 "Mistral Song" sync / 1[56]:Garuda:2B42:/ # drift -0.456
-18 "Grand Whirlwind" sync / 1[56]:Garuda:2B41:/
-24 "Slipstream" sync / 1[56]:Garuda:2B53:/ # drift 0.494
-27 "Downburst" sync / 1[56]:Garuda:2B50:/ # drift 0.422
-29 "Grand Whirlwind" sync / 1[56]:Garuda:2B41:/ # drift 0.247
+9 "Slipstream" sync / 1[56]:[^:]*:Garuda:2B53:/ window 10,5 # drift 0.293
+12 "Mistral Song" sync / 1[56]:[^:]*:Garuda:2B42:/ # drift -0.456
+18 "Grand Whirlwind" sync / 1[56]:[^:]*:Garuda:2B41:/
+24 "Slipstream" sync / 1[56]:[^:]*:Garuda:2B53:/ # drift 0.494
+27 "Downburst" sync / 1[56]:[^:]*:Garuda:2B50:/ # drift 0.422
+29 "Grand Whirlwind" sync / 1[56]:[^:]*:Garuda:2B41:/ # drift 0.247
 34 "--untargetable--"
-37 "Feather Rain" sync / 1[56]:Garuda:2B4D:/
+37 "Feather Rain" sync / 1[56]:[^:]*:Garuda:2B4D:/
 39 "--targetable--"
-42 "Mistral Shriek" sync / 1[56]:Garuda:2B54:/
-51 "Friction" sync / 1[56]:Garuda:2B48:/ # drift 0.492
-57 "Friction" sync / 1[56]:Garuda:2B48:/
+42 "Mistral Shriek" sync / 1[56]:[^:]*:Garuda:2B54:/
+51 "Friction" sync / 1[56]:[^:]*:Garuda:2B48:/ # drift 0.492
+57 "Friction" sync / 1[56]:[^:]*:Garuda:2B48:/
 69 "--untargetable--"
-72 "Feather Rain" sync / 1[56]:Garuda:2B4D:/ # drift -0.32
+72 "Feather Rain" sync / 1[56]:[^:]*:Garuda:2B4D:/ # drift -0.32
 73.5 "--targetable--"
-77 "Aerial Blast" sync / 1[56]:Garuda:2B55:/
-93 "Feather Rain" sync / 1[56]:Garuda:2B4D:/ # drift 0.228
-100 "Mistral Song" sync / 1[56]:Chirada:2B4B:/
-100 "Eye Of The Storm" sync / 1[56]:Garuda:2B52:/ # drift 0.358
-100 "Wicked Wheel" sync / 1[56]:Garuda:2B4E:/
-104 "Feather Rain" sync / 1[56]:Garuda:2B4D:/ # drift 0.248
-105 "Grand Whirlwind" sync / 1[56]:Suparna:2B41:/ # drift 0.48
-121 "Slipstream" sync / 1[56]:Garuda:2B53:/
-122 "Eye Of The Storm" sync / 1[56]:Garuda:2B52:/
-124 "Mesohigh" sync / 1[56]:Chirada:2B49:/
-124 "Downburst" sync / 1[56]:Garuda:2B50:/
-129 "Feather Rain" sync / 1[56]:Garuda:2B4D:/ # drift -0.449
-142 "Slipstream" sync / 1[56]:Garuda:2B53:/ # drift -0.479
-151 "Wicked Wheel" sync / 1[56]:Garuda:2B4E:/ # drift -0.486
-153 "Wicked Tornado" sync / 1[56]:Garuda:2B4F:/
-156 "Downburst" sync / 1[56]:Garuda:2B50:/ # drift -0.218
-164 "Slipstream" sync / 1[56]:Garuda:2B53:/
-176 "--untargetable--" sync / 1[56]:Garuda:2B4D:/
-181 "Aerial Blast" sync / 1[56]:Garuda:2B55:/ # drift -0.29
+77 "Aerial Blast" sync / 1[56]:[^:]*:Garuda:2B55:/
+93 "Feather Rain" sync / 1[56]:[^:]*:Garuda:2B4D:/ # drift 0.228
+100 "Mistral Song" sync / 1[56]:[^:]*:Chirada:2B4B:/
+100 "Eye Of The Storm" sync / 1[56]:[^:]*:Garuda:2B52:/ # drift 0.358
+100 "Wicked Wheel" sync / 1[56]:[^:]*:Garuda:2B4E:/
+104 "Feather Rain" sync / 1[56]:[^:]*:Garuda:2B4D:/ # drift 0.248
+105 "Grand Whirlwind" sync / 1[56]:[^:]*:Suparna:2B41:/ # drift 0.48
+121 "Slipstream" sync / 1[56]:[^:]*:Garuda:2B53:/
+122 "Eye Of The Storm" sync / 1[56]:[^:]*:Garuda:2B52:/
+124 "Mesohigh" sync / 1[56]:[^:]*:Chirada:2B49:/
+124 "Downburst" sync / 1[56]:[^:]*:Garuda:2B50:/
+129 "Feather Rain" sync / 1[56]:[^:]*:Garuda:2B4D:/ # drift -0.449
+142 "Slipstream" sync / 1[56]:[^:]*:Garuda:2B53:/ # drift -0.479
+151 "Wicked Wheel" sync / 1[56]:[^:]*:Garuda:2B4E:/ # drift -0.486
+153 "Wicked Tornado" sync / 1[56]:[^:]*:Garuda:2B4F:/
+156 "Downburst" sync / 1[56]:[^:]*:Garuda:2B50:/ # drift -0.218
+164 "Slipstream" sync / 1[56]:[^:]*:Garuda:2B53:/
+176 "--untargetable--" sync / 1[56]:[^:]*:Garuda:2B4D:/
+181 "Aerial Blast" sync / 1[56]:[^:]*:Garuda:2B55:/ # drift -0.29
 
 
 ### Phase 2: Ifrit ###
-300 "Crimson Cyclone" sync / 1[56]:Ifrit:2B5F:/ window 300,70
-301 "Radiant Plume" sync / 1[56]:Ifrit:2B61:/
-307 "Hellfire" sync / 1[56]:Ifrit:2B5E:/ # drift 0.246
-315 "Vulcan Burst" sync / 1[56]:Ifrit:2B57:/
+300 "Crimson Cyclone" sync / 1[56]:[^:]*:Ifrit:2B5F:/ window 300,70
+301 "Radiant Plume" sync / 1[56]:[^:]*:Ifrit:2B61:/
+307 "Hellfire" sync / 1[56]:[^:]*:Ifrit:2B5E:/ # drift 0.246
+315 "Vulcan Burst" sync / 1[56]:[^:]*:Ifrit:2B57:/
 318 "Incinerate"
 321 "Incinerate"
 325 "Incinerate"
-328 "Nail Adds" sync / 1[56]:Ifrit:1CD:/
-337 "Infernal Fetters" sync / 1[56]:Ifrit:2C19:/ # drift 0.214
-339 "Inferno Howl" sync / 1[56]:Ifrit:2B5B:/
+328 "Nail Adds" sync / 1[56]:[^:]*:Ifrit:1CD:/
+337 "Infernal Fetters" sync / 1[56]:[^:]*:Ifrit:2C19:/ # drift 0.214
+339 "Inferno Howl" sync / 1[56]:[^:]*:Ifrit:2B5B:/
 345 "Searing Wind"
 345 "Eruption" duration 6
 351 "Searing Wind"
 357 "Searing Wind"
 361.5 "--untargetable--"
 365.5 "--targetable--"
-369 "Hellfire" sync / 1[56]:Ifrit:2B5E:/ window 40,40 # drift 0.411
-377 "Inferno Howl" sync / 1[56]:Ifrit:2B5B:/ # drift 0.374
+369 "Hellfire" sync / 1[56]:[^:]*:Ifrit:2B5E:/ window 40,40 # drift 0.411
+377 "Inferno Howl" sync / 1[56]:[^:]*:Ifrit:2B5B:/ # drift 0.374
 383 "Searing Wind"
 383 "Eruption" duration 6
 389 "Searing Wind"
-390 "Crimson Cyclone" sync / 1[56]:Ifrit:2B5F:/
-395 "Inferno Howl" sync / 1[56]:Ifrit:2B5B:/
+390 "Crimson Cyclone" sync / 1[56]:[^:]*:Ifrit:2B5F:/
+395 "Inferno Howl" sync / 1[56]:[^:]*:Ifrit:2B5B:/
 395 "Searing Wind"
 401 "Searing Wind"
-405 "Flaming Crush" sync / 1[56]:Ifrit:2B5D:/
+405 "Flaming Crush" sync / 1[56]:[^:]*:Ifrit:2B5D:/
 407 "Searing Wind"
 409 "--untargetable--"
 413 "Searing Wind"
@@ -79,197 +79,197 @@ hideall "--Reset--"
 417 "Crimson Cyclone"
 419 "Crimson Cyclone"
 420 "Crimson Cyclone"
-428 "Incinerate" sync / 1[56]:Ifrit:2B56:/ window 5,1
+428 "Incinerate" sync / 1[56]:[^:]*:Ifrit:2B56:/ window 5,1
 431 "Incinerate"
 435 "Incinerate"
 444 "Eruption" duration 6
-453 "Flaming Crush" sync / 1[56]:Ifrit:2B5D:/
+453 "Flaming Crush" sync / 1[56]:[^:]*:Ifrit:2B5D:/
 
 
 ### Phase 3: Titan ###
-600 "Geocrush" sync / 1[56]:Titan:2CFD:/ window 600,0
-605 "Earthen Fury" sync / 1[56]:Titan:2B90:/ # drift 0.312999
-613 "Rock Buster" sync / 1[56]:Titan:2B62:/
-616 "Mountain Buster" sync / 1[56]:Titan:2B63:/ # drift 0.235001
-621 "Weight Of The Land" #sync / 1[56]:Titan:2B65:/
+600 "Geocrush" sync / 1[56]:[^:]*:Titan:2CFD:/ window 600,0
+605 "Earthen Fury" sync / 1[56]:[^:]*:Titan:2B90:/ # drift 0.312999
+613 "Rock Buster" sync / 1[56]:[^:]*:Titan:2B62:/
+616 "Mountain Buster" sync / 1[56]:[^:]*:Titan:2B63:/ # drift 0.235001
+621 "Weight Of The Land" #sync / 1[56]:[^:]*:Titan:2B65:/
 623.5 "--untargetable--"
-624 "Weight Of The Land" #sync / 1[56]:Titan:2B65:/
-629 "--sync--" sync / 1[56]:Titan:2B66:/
-631 "Geocrush" sync / 1[56]:Titan:2B68:/ # drift 0.474
-634 "Bury" sync / 1[56]:Bomb Boulder:2B69:/
-637 "Upheaval" sync / 1[56]:Titan:2B67:/
-639 "Rock Throw" sync / 1[56]:Titan:2B6B:/
-642 "Bury" sync / 1[56]:Bomb Boulder:2B69:/
-644 "Landslide" sync / 1[56]:Titan:2B6F:/ window 5,3
+624 "Weight Of The Land" #sync / 1[56]:[^:]*:Titan:2B65:/
+629 "--sync--" sync / 1[56]:[^:]*:Titan:2B66:/
+631 "Geocrush" sync / 1[56]:[^:]*:Titan:2B68:/ # drift 0.474
+634 "Bury" sync / 1[56]:[^:]*:Bomb Boulder:2B69:/
+637 "Upheaval" sync / 1[56]:[^:]*:Titan:2B67:/
+639 "Rock Throw" sync / 1[56]:[^:]*:Titan:2B6B:/
+642 "Bury" sync / 1[56]:[^:]*:Bomb Boulder:2B69:/
+644 "Landslide" sync / 1[56]:[^:]*:Titan:2B6F:/ window 5,3
 649 "Landslide"
 651 "Tumult x8" duration 7
-666 "Weight Of The Land" sync / 1[56]:Titan:2B65:/ window 5,1
+666 "Weight Of The Land" sync / 1[56]:[^:]*:Titan:2B65:/ window 5,1
 669 "Weight Of The Land"
 671 "Landslide"
 673 "Landslide"
 676.5 "--untargetable--"
-684 "Rock Throw" sync / 1[56]:Titan:2B6B:/ # drift 0.420001
+684 "Rock Throw" sync / 1[56]:[^:]*:Titan:2B6B:/ # drift 0.420001
 699 "Landslide"
 701 "Landslide"
-704 "Tumult x6" sync / 1[56]:Titan:2C18:/ duration 5 window 5,0 # drift 0.254
-711 "Rock Buster" sync / 1[56]:Titan:2B62:/ # drift 0.280001
-715 "Mountain Buster" sync / 1[56]:Titan:2B63:/ # drift 0.205999
+704 "Tumult x6" sync / 1[56]:[^:]*:Titan:2C18:/ duration 5 window 5,0 # drift 0.254
+711 "Rock Buster" sync / 1[56]:[^:]*:Titan:2B62:/ # drift 0.280001
+715 "Mountain Buster" sync / 1[56]:[^:]*:Titan:2B63:/ # drift 0.205999
 720 "Bury" duration 6
-722 "Weight Of The Land" sync / 1[56]:Titan:2B65:/ window 5,1
+722 "Weight Of The Land" sync / 1[56]:[^:]*:Titan:2B65:/ window 5,1
 725 "Weight Of The Land"
 727 "Landslide"
 728 "Weight Of The Land"
 729 "Landslide"
-735 "Rock Buster" sync / 1[56]:Titan:2B62:/ # drift 0.26
-739 "Mountain Buster" sync / 1[56]:Titan:2B63:/
-744 "Weight Of The Land" sync / 1[56]:Titan:2B65:/
-747 "Weight Of The Land" sync / 1[56]:Titan:2B65:/
+735 "Rock Buster" sync / 1[56]:[^:]*:Titan:2B62:/ # drift 0.26
+739 "Mountain Buster" sync / 1[56]:[^:]*:Titan:2B63:/
+744 "Weight Of The Land" sync / 1[56]:[^:]*:Titan:2B65:/
+747 "Weight Of The Land" sync / 1[56]:[^:]*:Titan:2B65:/
 750 "Weight Of The Land"
-752 "Tumult x8" sync / 1[56]:Titan:2C18:/ duration 7 window 5,0 # drift -0.293
+752 "Tumult x8" sync / 1[56]:[^:]*:Titan:2C18:/ duration 7 window 5,0 # drift -0.293
 768 "--untargetable--"
 
 
 ### Phase 4: Snacks ###
-800 "Freefire" sync / 1[56]:(Titan|The Ultima Weapon):2CF5:/ window 800,0
-815 "Blight" sync / 1[56]:Lahabrea:2B73:/
+800 "Freefire" sync / 1[56]:[^:]*:(Titan|The Ultima Weapon):2CF5:/ window 800,0
+815 "Blight" sync / 1[56]:[^:]*:Lahabrea:2B73:/
 840 "Dark IV"
-848 "Ultima" sync / 1[56]:The Ultima Weapon:2B8B:/ window 50,10 jump 961
+848 "Ultima" sync / 1[56]:[^:]*:The Ultima Weapon:2B8B:/ window 50,10 jump 961
 
 
 ### Phase 5: Ultima ###
-1000 "--targetable--" sync / 14:The Ultima Weapon:2B87:/ window 1000,100
-1004 "Tank Purge" sync / 1[56]:The Ultima Weapon:2B87:/ # drift -0.314001
-1006 "Apply Viscous" sync / 1[56]:The Ultima Weapon:2B79:/ # drift 0.430001
-1012 "Homing Lasers" sync / 1[56]:The Ultima Weapon:2B7B:/ # drift 0.220999
-1017 "Viscous Aetheroplasm" sync / 1[56]:The Ultima Weapon:2B7A:/
+1000 "--targetable--" sync / 14:[^:]*:The Ultima Weapon:2B87:/ window 1000,100
+1004 "Tank Purge" sync / 1[56]:[^:]*:The Ultima Weapon:2B87:/ # drift -0.314001
+1006 "Apply Viscous" sync / 1[56]:[^:]*:The Ultima Weapon:2B79:/ # drift 0.430001
+1012 "Homing Lasers" sync / 1[56]:[^:]*:The Ultima Weapon:2B7B:/ # drift 0.220999
+1017 "Viscous Aetheroplasm" sync / 1[56]:[^:]*:The Ultima Weapon:2B7A:/
 
 ## Ultimate Predation
-1023 "Ultimate Predation" sync / 1[56]:The Ultima Weapon:2B76:/ # drift 0.349
+1023 "Ultimate Predation" sync / 1[56]:[^:]*:The Ultima Weapon:2B76:/ # drift 0.349
 1026 "--untargetable--"
-1038 "Crimson Cyclone" sync / 1[56]:Ifrit:2B5F:/
-1038 "Wicked Wheel" sync / 1[56]:Garuda:2B4E:/
-1038 "Landslide" sync / 1[56]:Titan:2B71:/
+1038 "Crimson Cyclone" sync / 1[56]:[^:]*:Ifrit:2B5F:/
+1038 "Wicked Wheel" sync / 1[56]:[^:]*:Garuda:2B4E:/
+1038 "Landslide" sync / 1[56]:[^:]*:Titan:2B71:/
 1040 "Wicked Tornado"
-1040 "Ceruleum Vent" sync / 1[56]:The Ultima Weapon:2B7C:/
+1040 "Ceruleum Vent" sync / 1[56]:[^:]*:The Ultima Weapon:2B7C:/
 1040 "Crimson Cyclone"
 1040 "Landslide"
-1045 "Feather Rain" sync / 1[56]:Garuda:2B4D:/
+1045 "Feather Rain" sync / 1[56]:[^:]*:Garuda:2B4D:/
 
 ## Interlude Dance
 1048 "--targetable--"
-1059 "Eruption" sync / 1[56]:Ifrit:2B5A:/ duration 6 window 5,0 # drift 0.223
+1059 "Eruption" sync / 1[56]:[^:]*:Ifrit:2B5A:/ duration 6 window 5,0 # drift 0.223
 1064 "Infernal Fetters"
-1069 "Radiant Plume" sync / 1[56]:The Ultima Weapon:2B7D:/
-1070 "Bury" sync / 1[56]:Bomb Boulder:2B69:/ duration 10 window 5,0
-1073 "Landslide" sync / 1[56]:Titan:2B71:/ window 5,1
-1074 "Landslide" sync / 1[56]:The Ultima Weapon:2B7E:/
-1079 "Tumult x7" sync / 1[56]:Titan:2C18:/ duration 6 window 5,0 # drift -0.248001
-1082 "Apply Viscous" sync / 1[56]:The Ultima Weapon:2B79:/
-1086 "Wicked Wheel" sync / 1[56]:Chirada:2B4C:/ # drift 0.339
-1088 "Mistral Shriek" sync / 1[56]:Garuda:2B54:/
-1091 "Feather Rain" sync / 1[56]:Garuda:2B4D:/ # drift 0.402001
-1092 "Viscous Aetheroplasm" sync / 1[56]:The Ultima Weapon:2B7A:/ # drift -0.261001
-1093 "Homing Lasers" sync / 1[56]:The Ultima Weapon:2B7B:/
+1069 "Radiant Plume" sync / 1[56]:[^:]*:The Ultima Weapon:2B7D:/
+1070 "Bury" sync / 1[56]:[^:]*:Bomb Boulder:2B69:/ duration 10 window 5,0
+1073 "Landslide" sync / 1[56]:[^:]*:Titan:2B71:/ window 5,1
+1074 "Landslide" sync / 1[56]:[^:]*:The Ultima Weapon:2B7E:/
+1079 "Tumult x7" sync / 1[56]:[^:]*:Titan:2C18:/ duration 6 window 5,0 # drift -0.248001
+1082 "Apply Viscous" sync / 1[56]:[^:]*:The Ultima Weapon:2B79:/
+1086 "Wicked Wheel" sync / 1[56]:[^:]*:Chirada:2B4C:/ # drift 0.339
+1088 "Mistral Shriek" sync / 1[56]:[^:]*:Garuda:2B54:/
+1091 "Feather Rain" sync / 1[56]:[^:]*:Garuda:2B4D:/ # drift 0.402001
+1092 "Viscous Aetheroplasm" sync / 1[56]:[^:]*:The Ultima Weapon:2B7A:/ # drift -0.261001
+1093 "Homing Lasers" sync / 1[56]:[^:]*:The Ultima Weapon:2B7B:/
 1095 "Feather Rain"
 
 ## Ultimate Annihilation
-1100 "Ultimate Annihilation" sync / 1[56]:The Ultima Weapon:2D4C:/ # drift 0.261
+1100 "Ultimate Annihilation" sync / 1[56]:[^:]*:The Ultima Weapon:2D4C:/ # drift 0.261
 1105 "--untargetable--"
 1109 "--targetable--"
-1112 "Weight Of The Land" sync / 1[56]:Titan:2B65:/ window 5,1
-1114 "Flaming Crush" sync / 1[56]:Ifrit:2B5D:/
+1112 "Weight Of The Land" sync / 1[56]:[^:]*:Titan:2B65:/ window 5,1
+1114 "Flaming Crush" sync / 1[56]:[^:]*:Ifrit:2B5D:/
 1115 "Weight Of The Land"
-1115 "Eye Of The Storm" sync / 1[56]:Garuda:2B52:/
+1115 "Eye Of The Storm" sync / 1[56]:[^:]*:Garuda:2B52:/
 1116 "Aetheroplasm"
-1117 "Mesohigh" sync / 1[56]:Garuda:2B49:/
+1117 "Mesohigh" sync / 1[56]:[^:]*:Garuda:2B49:/
 1118 "Weight Of The Land"
-1118 "Inferno Howl" sync / 1[56]:Ifrit:2B5B:/
-1122 "Feather Rain" sync / 1[56]:Garuda:2B4D:/ # drift -0.466001
+1118 "Inferno Howl" sync / 1[56]:[^:]*:Ifrit:2B5B:/
+1122 "Feather Rain" sync / 1[56]:[^:]*:Garuda:2B4D:/ # drift -0.466001
 1123 "Aetheroplasm"
-1124 "Searing Wind" sync / 1[56]:Ifrit:2B5C:/ # drift -0.237
-1126 "Crimson Cyclone" sync / 1[56]:Ifrit:2B5F:/
-1127 "Landslide" sync / 1[56]:Titan:2B71:/
-1128 "Crimson Cyclone" sync / 1[56]:Ifrit:2B60:/
-1129 "Landslide" sync / 1[56]:Titan:2C22:/
-1130 "Searing Wind" sync / 1[56]:Titan:2B5C:/ # drift -0.432999
+1124 "Searing Wind" sync / 1[56]:[^:]*:Ifrit:2B5C:/ # drift -0.237
+1126 "Crimson Cyclone" sync / 1[56]:[^:]*:Ifrit:2B5F:/
+1127 "Landslide" sync / 1[56]:[^:]*:Titan:2B71:/
+1128 "Crimson Cyclone" sync / 1[56]:[^:]*:Ifrit:2B60:/
+1129 "Landslide" sync / 1[56]:[^:]*:Titan:2C22:/
+1130 "Searing Wind" sync / 1[56]:[^:]*:Titan:2B5C:/ # drift -0.432999
 1131 "Aetheroplasm"
-1133 "Eye Of The Storm" sync / 1[56]:Garuda:2B52:/ # drift -0.436001
-1136 "Mesohigh" sync / 1[56]:Garuda:2B49:/ # drift -0.478999
+1133 "Eye Of The Storm" sync / 1[56]:[^:]*:Garuda:2B52:/ # drift -0.436001
+1136 "Mesohigh" sync / 1[56]:[^:]*:Garuda:2B49:/ # drift -0.478999
 1136 "Aetheroplasm"
-1137 "Searing Wind" sync / 1[56]:Ifrit:2B5C:/ # drift 0.374
-1139 "Tank Purge" sync / 1[56]:The Ultima Weapon:2B87:/ # drift -0.434
-1141 "Feather Rain" sync / 1[56]:Garuda:2B4D:/ # drift -0.328
+1137 "Searing Wind" sync / 1[56]:[^:]*:Ifrit:2B5C:/ # drift 0.374
+1139 "Tank Purge" sync / 1[56]:[^:]*:The Ultima Weapon:2B87:/ # drift -0.434
+1141 "Feather Rain" sync / 1[56]:[^:]*:Garuda:2B4D:/ # drift -0.328
 1142 "--untargetable--"
-1144 "Searing Wind" sync / 1[56]:Garuda:2B5C:/
+1144 "Searing Wind" sync / 1[56]:[^:]*:Garuda:2B5C:/
 1147 "--targetable--"
-1150 "Searing Wind" sync / 1[56]:Garuda:2B5C:/
-1151 "Eye Of The Storm" sync / 1[56]:Garuda:2B52:/
-1155 "Homing Lasers" sync / 1[56]:The Ultima Weapon:2B7B:/
-1163 "Eye Of The Storm" sync / 1[56]:Garuda:2B52:/
-1165 "Radiant Plume" sync / 1[56]:The Ultima Weapon:2B7D:/ # drift 0.324001
-1169 "Diffractive Laser" sync / 1[56]:The Ultima Weapon:2B78:/ # drift -0.486999
-1173 "Vulcan Burst" sync / 1[56]:The Ultima Weapon:2CF4:/
-1175 "Eye Of The Storm" sync / 1[56]:Garuda:2B52:/
-1181 "Homing Lasers" sync / 1[56]:The Ultima Weapon:2B7B:/
-1186 "Vulcan Burst" sync / 1[56]:The Ultima Weapon:2CF4:/
+1150 "Searing Wind" sync / 1[56]:[^:]*:Garuda:2B5C:/
+1151 "Eye Of The Storm" sync / 1[56]:[^:]*:Garuda:2B52:/
+1155 "Homing Lasers" sync / 1[56]:[^:]*:The Ultima Weapon:2B7B:/
+1163 "Eye Of The Storm" sync / 1[56]:[^:]*:Garuda:2B52:/
+1165 "Radiant Plume" sync / 1[56]:[^:]*:The Ultima Weapon:2B7D:/ # drift 0.324001
+1169 "Diffractive Laser" sync / 1[56]:[^:]*:The Ultima Weapon:2B78:/ # drift -0.486999
+1173 "Vulcan Burst" sync / 1[56]:[^:]*:The Ultima Weapon:2CF4:/
+1175 "Eye Of The Storm" sync / 1[56]:[^:]*:Garuda:2B52:/
+1181 "Homing Lasers" sync / 1[56]:[^:]*:The Ultima Weapon:2B7B:/
+1186 "Vulcan Burst" sync / 1[56]:[^:]*:The Ultima Weapon:2CF4:/
 1190 "Diffractive Laser"
 
 ## Ultimate Suppression (50%)
-1195 "Ultimate Suppression" sync / 1[56]:The Ultima Weapon:2D4D:/ window 1200,500
+1195 "Ultimate Suppression" sync / 1[56]:[^:]*:The Ultima Weapon:2D4D:/ window 1200,500
 1200 "--untargetable--"
-1206 "Rock Throw" sync / 1[56]:Titan:2B6B:/
-1207 "Eruption" sync / 1[56]:Ifrit:2B5A:/ duration 6 window 5,0
+1206 "Rock Throw" sync / 1[56]:[^:]*:Titan:2B6B:/
+1207 "Eruption" sync / 1[56]:[^:]*:Ifrit:2B5A:/ duration 6 window 5,0
 1210 "Mistral Song"
 1212 "Mistral Song"
-1215 "Feather Rain" sync / 1[56]:Garuda:2B4D:/ # drift -0.221
-1216 "Grand Whirlwind" sync / 1[56]:Garuda:2B41:/
-1216 "Feather Rain" sync / 1[56]:Ifrit:2B4D:/ # drift 0.468
-1216 "Aetherochemical Laser" sync / 1[56]:The Ultima Weapon:2B85:/ window 5,2
+1215 "Feather Rain" sync / 1[56]:[^:]*:Garuda:2B4D:/ # drift -0.221
+1216 "Grand Whirlwind" sync / 1[56]:[^:]*:Garuda:2B41:/
+1216 "Feather Rain" sync / 1[56]:[^:]*:Ifrit:2B4D:/ # drift 0.468
+1216 "Aetherochemical Laser" sync / 1[56]:[^:]*:The Ultima Weapon:2B85:/ window 5,2
 1220 "Aetherochemical Laser"
-1223 "Landslide" sync / 1[56]:Titan:2B71:/
+1223 "Landslide" sync / 1[56]:[^:]*:Titan:2B71:/
 1224 "Aetherochemical Laser"
-1225 "Landslide" sync / 1[56]:Ifrit:2C22:/ # drift 0.288999
-1226 "Mesohigh" sync / 1[56]:Garuda:2B49:/
-1227 "Flaming Crush" sync / 1[56]:Ifrit:2B5D:/ # drift -0.252
-1232 "Feather Rain" sync / 1[56]:Garuda:2B4D:/ # drift -0.393999
-1232 "Tank Purge" sync / 1[56]:The Ultima Weapon:2B87:/ # drift 0.369999
-1243 "Ultima" sync / 1[56]:The Ultima Weapon:2B8B:/ # drift 0.468
-1253 "Aetheric Boom" sync / 1[56]:The Ultima Weapon:2B88:/ # drift 0.227
-1274 "Apply Viscous" sync / 1[56]:The Ultima Weapon:2B8F:/ # drift 0.256
+1225 "Landslide" sync / 1[56]:[^:]*:Ifrit:2C22:/ # drift 0.288999
+1226 "Mesohigh" sync / 1[56]:[^:]*:Garuda:2B49:/
+1227 "Flaming Crush" sync / 1[56]:[^:]*:Ifrit:2B5D:/ # drift -0.252
+1232 "Feather Rain" sync / 1[56]:[^:]*:Garuda:2B4D:/ # drift -0.393999
+1232 "Tank Purge" sync / 1[56]:[^:]*:The Ultima Weapon:2B87:/ # drift 0.369999
+1243 "Ultima" sync / 1[56]:[^:]*:The Ultima Weapon:2B8B:/ # drift 0.468
+1253 "Aetheric Boom" sync / 1[56]:[^:]*:The Ultima Weapon:2B88:/ # drift 0.227
+1274 "Apply Viscous" sync / 1[56]:[^:]*:The Ultima Weapon:2B8F:/ # drift 0.256
 1278 "Summon Random Primal"
 
 ## Random Primal Finale (summon all three in random order)
 
 ## Summon Garuda (random order)
-1300 "--sync--" sync / 1[56]:The Ultima Weapon:2CD3:/ window 50,300
-1307 "Wicked Wheel" sync / 1[56]:Garuda:2B4E:/ # drift 0.351
-1308 "Viscous Aetheroplasm" sync / 1[56]:The Ultima Weapon:2B7A:/ # drift 0.326
-1309 "Wicked Tornado" sync / 1[56]:Garuda:2B4F:/ # drift -0.239
-1314 "Aerial Blast" sync / 1[56]:Garuda:2B55:/
+1300 "--sync--" sync / 1[56]:[^:]*:The Ultima Weapon:2CD3:/ window 50,300
+1307 "Wicked Wheel" sync / 1[56]:[^:]*:Garuda:2B4E:/ # drift 0.351
+1308 "Viscous Aetheroplasm" sync / 1[56]:[^:]*:The Ultima Weapon:2B7A:/ # drift 0.326
+1309 "Wicked Tornado" sync / 1[56]:[^:]*:Garuda:2B4F:/ # drift -0.239
+1314 "Aerial Blast" sync / 1[56]:[^:]*:Garuda:2B55:/
 1320 "Summon Random Primal"
-1322 "Feather Rain" sync / 1[56]:Garuda:2B4D:/ # drift -0.208
+1322 "Feather Rain" sync / 1[56]:[^:]*:Garuda:2B4D:/ # drift -0.208
 
 ## Summon Ifrit (random order)
-1400 "--sync--" sync / 1[56]:The Ultima Weapon:2CD4:/ window 150,300
-1408 "Eruption" sync / 1[56]:Ifrit:2B5A:/ # drift -0.445001
-1408 "Crimson Cyclone" sync / 1[56]:Ifrit:2B5F:/
-1409 "Viscous Aetheroplasm" sync / 1[56]:The Ultima Weapon:2B7A:/
-1416 "Hellfire" sync / 1[56]:Ifrit:2B5E:/ # drift -0.208999
+1400 "--sync--" sync / 1[56]:[^:]*:The Ultima Weapon:2CD4:/ window 150,300
+1408 "Eruption" sync / 1[56]:[^:]*:Ifrit:2B5A:/ # drift -0.445001
+1408 "Crimson Cyclone" sync / 1[56]:[^:]*:Ifrit:2B5F:/
+1409 "Viscous Aetheroplasm" sync / 1[56]:[^:]*:The Ultima Weapon:2B7A:/
+1416 "Hellfire" sync / 1[56]:[^:]*:Ifrit:2B5E:/ # drift -0.208999
 1421 "Summon Random Primal"
 
 ## Summon Titan (random order)
-1500 "--sync--" sync / 1[56]:The Ultima Weapon:2CD5:/ window 250,300
-1505 "Weight Of The Land" #sync / 1[56]:Titan:2B65:/
-1508 "Weight Of The Land" #sync / 1[56]:Titan:2B65:/
-1508 "Viscous Aetheroplasm" sync / 1[56]:The Ultima Weapon:2B7A:/ # drift 0.201999
+1500 "--sync--" sync / 1[56]:[^:]*:The Ultima Weapon:2CD5:/ window 250,300
+1505 "Weight Of The Land" #sync / 1[56]:[^:]*:Titan:2B65:/
+1508 "Weight Of The Land" #sync / 1[56]:[^:]*:Titan:2B65:/
+1508 "Viscous Aetheroplasm" sync / 1[56]:[^:]*:The Ultima Weapon:2B7A:/ # drift 0.201999
 1511 "Weight Of The Land"
-1514 "Earthen Fury" sync / 1[56]:Titan:2B90:/ # drift 0.241001
+1514 "Earthen Fury" sync / 1[56]:[^:]*:Titan:2B90:/ # drift 0.241001
 1516 "Summon Random Primal"
 
 ## Enrage
-1600.0 "Enrage" sync / 1[56]:The Ultima Weapon:2B8C:/ window 400,0
+1600.0 "Enrage" sync / 1[56]:[^:]*:The Ultima Weapon:2B8C:/ window 400,0
 # FIXME: this waits until 100% aether, so likely needs to be shifted later for natural push.
 # +3 seconds for each further one.  Maybe not worth including.
-#1625.0 "Citadel Siege" sync / 1[56]:Garuda:2B92:/ window 100,50
+#1625.0 "Citadel Siege" sync / 1[56]:[^:]*:Garuda:2B92:/ window 100,50
 
 #$ python util/make_timeline.py --ignore-id 2B51 2B59 2B58 2Bb5 2B46 2B44 2B64 2B6E 2B77 2B6A 2B98 2B89 2B83 2B91 2DB8 2B75 2C20 2C21 2C1F 2CD4 2CD5 2B80 --phase 2B5F:300 2CFD:600 2CF5:800 2B87:1004

--- a/ui/raidboss/data/04-sb/ultimate/unending_coil_ultimate.txt
+++ b/ui/raidboss/data/04-sb/ultimate/unending_coil_ultimate.txt
@@ -11,289 +11,289 @@ hideall "--sync--"
 ##### TWINTANIA #####
 ### Twintania P1: 100% -> 75%
 0.0 "--sync--" sync /:Engage!/ window 0,1
-1.5 "--sync--" sync / 1[56]:Twintania:26A7:/ window 2,0
-7.0 "Plummet" sync / 1[56]:Twintania:26A8:/ window 12,12
-13.1 "Twister" sync / 1[56]:Twintania:26AA:/
-16.3 "Fireball" sync / 1[56]:Twintania:26AC:/
-24.5 "Death Sentence" sync / 1[56]:Twintania:26A9:/
-27.6 "Plummet" sync / 1[56]:Twintania:26A8:/
-32.8 "Twister" sync / 1[56]:Twintania:26AA:/
-36.0 "Fireball" sync / 1[56]:Twintania:26AC:/
+1.5 "--sync--" sync / 1[56]:[^:]*:Twintania:26A7:/ window 2,0
+7.0 "Plummet" sync / 1[56]:[^:]*:Twintania:26A8:/ window 12,12
+13.1 "Twister" sync / 1[56]:[^:]*:Twintania:26AA:/
+16.3 "Fireball" sync / 1[56]:[^:]*:Twintania:26AC:/
+24.5 "Death Sentence" sync / 1[56]:[^:]*:Twintania:26A9:/
+27.6 "Plummet" sync / 1[56]:[^:]*:Twintania:26A8:/
+32.8 "Twister" sync / 1[56]:[^:]*:Twintania:26AA:/
+36.0 "Fireball" sync / 1[56]:[^:]*:Twintania:26AC:/
 40.0 "--push--"
-#44.2 "Death Sentence" sync / 1[56]:Twintania:26A9:/
+#44.2 "Death Sentence" sync / 1[56]:[^:]*:Twintania:26A9:/
 # TODO: presumably 44.2 is a loop back to 24.5.
 
 ### Twintania P2: 75% -> 45%
-47.5 "Liquid Hell x5" duration 4.5 sync / 1[56]:Twintania:26AD:/ window 50,0
-53.0 "--sync--" sync / 14:Twintania:26AE:/ window 53,10
-56.0 "Generate" sync / 1[56]:Twintania:26AE:/
-59.1 "Liquid Hell x5" duration 4.5 #sync / 1[56]:Twintania:26AD:/
-70.6 "Death Sentence" sync / 1[56]:Twintania:26A9:/
-77.6 "Generate" sync / 1[56]:Twintania:26AE:/
-80.6 "Twister" sync / 1[56]:Twintania:26AA:/
-86.6 "Plummet" sync / 1[56]:Twintania:26A8:/
-91.7 "Liquid Hell x5" duration 4.5 #sync / 1[56]:Twintania:26AD:/
+47.5 "Liquid Hell x5" duration 4.5 sync / 1[56]:[^:]*:Twintania:26AD:/ window 50,0
+53.0 "--sync--" sync / 14:[^:]*:Twintania:26AE:/ window 53,10
+56.0 "Generate" sync / 1[56]:[^:]*:Twintania:26AE:/
+59.1 "Liquid Hell x5" duration 4.5 #sync / 1[56]:[^:]*:Twintania:26AD:/
+70.6 "Death Sentence" sync / 1[56]:[^:]*:Twintania:26A9:/
+77.6 "Generate" sync / 1[56]:[^:]*:Twintania:26AE:/
+80.6 "Twister" sync / 1[56]:[^:]*:Twintania:26AA:/
+86.6 "Plummet" sync / 1[56]:[^:]*:Twintania:26A8:/
+91.7 "Liquid Hell x5" duration 4.5 #sync / 1[56]:[^:]*:Twintania:26AD:/
 99.0 "--push--"
 # TODO: presumably 91.7 is a loop back to 47.5.
 
 ### Twintania P3: 45% -> 0%
-106.4 "Liquid Hell x5" duration 4.5 #sync / 1[56]:Twintania:26AD:/
-111.9 "--sync--" sync / 14:Twintania:26AE:/ window 30,10
-114.9 "Generate x2" sync / 1[56]:Twintania:26AE:/
-118.0 "Targeted Fire x5" duration 4.5 #sync / 1[56]:Twintania:26AD:/
-124.6 "Fireball" sync / 1[56]:Twintania:26AC:/ window 70,10
-133.6 "Death Sentence" sync / 1[56]:Twintania:26A9:/
-136.6 "Plummet" sync / 1[56]:Twintania:26A8:/
-143.6 "Generate x2" sync / 1[56]:Twintania:26AE:/
-146.6 "Twister" sync / 1[56]:Twintania:26AA:/
-151.6 "Plummet" sync / 1[56]:Twintania:26A8:/
+106.4 "Liquid Hell x5" duration 4.5 #sync / 1[56]:[^:]*:Twintania:26AD:/
+111.9 "--sync--" sync / 14:[^:]*:Twintania:26AE:/ window 30,10
+114.9 "Generate x2" sync / 1[56]:[^:]*:Twintania:26AE:/
+118.0 "Targeted Fire x5" duration 4.5 #sync / 1[56]:[^:]*:Twintania:26AD:/
+124.6 "Fireball" sync / 1[56]:[^:]*:Twintania:26AC:/ window 70,10
+133.6 "Death Sentence" sync / 1[56]:[^:]*:Twintania:26A9:/
+136.6 "Plummet" sync / 1[56]:[^:]*:Twintania:26A8:/
+143.6 "Generate x2" sync / 1[56]:[^:]*:Twintania:26AE:/
+146.6 "Twister" sync / 1[56]:[^:]*:Twintania:26AA:/
+151.6 "Plummet" sync / 1[56]:[^:]*:Twintania:26A8:/
 
-153.8 "Liquid Hell x5" duration 4.5 #sync / 1[56]:Twintania:26AD:/
-162.3 "Generate x2" sync / 1[56]:Twintania:26AE:/
-165.4 "Targeted Fire x5" duration 4.5 #sync / 1[56]:Twintania:26AD:/
-172.0 "Fireball" sync / 1[56]:Twintania:26AC:/ window 20,20 jump 124.6
-181.0 "Death Sentence" #sync / 1[56]:Twintania:26A9:/
-184.0 "Plummet" #sync / 1[56]:Twintania:26A8:/
-191.0 "Generate x2" #sync / 1[56]:Twintania:26AE:/
-194.0 "Twister" #sync / 1[56]:Twintania:26AA:/
-199.0 "Plummet" #sync / 1[56]:Twintania:26A8:/
+153.8 "Liquid Hell x5" duration 4.5 #sync / 1[56]:[^:]*:Twintania:26AD:/
+162.3 "Generate x2" sync / 1[56]:[^:]*:Twintania:26AE:/
+165.4 "Targeted Fire x5" duration 4.5 #sync / 1[56]:[^:]*:Twintania:26AD:/
+172.0 "Fireball" sync / 1[56]:[^:]*:Twintania:26AC:/ window 20,20 jump 124.6
+181.0 "Death Sentence" #sync / 1[56]:[^:]*:Twintania:26A9:/
+184.0 "Plummet" #sync / 1[56]:[^:]*:Twintania:26A8:/
+191.0 "Generate x2" #sync / 1[56]:[^:]*:Twintania:26AE:/
+194.0 "Twister" #sync / 1[56]:[^:]*:Twintania:26AA:/
+199.0 "Plummet" #sync / 1[56]:[^:]*:Twintania:26A8:/
 
 
 ##### NAEL #####
-200.0 "Heavensfall" sync / 1[56]:Ragnarok:26B8:/ window 200,0
-205.5 "Meteor Stream x4" sync / 1[56]:Nael Geminus:26C0:/
-207.0 "Thermionic Burst" sync / 1[56]:Ragnarok:26B9:/
-208.5 "Meteor Stream x4" sync / 1[56]:Nael Geminus:26C0:/
-211.0 "Thermionic Burst" sync / 1[56]:Ragnarok:26B9:/
-211.5 "Dalamud Dive" sync / 1[56]:Nael deus Darnus:26C1:/
+200.0 "Heavensfall" sync / 1[56]:[^:]*:Ragnarok:26B8:/ window 200,0
+205.5 "Meteor Stream x4" sync / 1[56]:[^:]*:Nael Geminus:26C0:/
+207.0 "Thermionic Burst" sync / 1[56]:[^:]*:Ragnarok:26B9:/
+208.5 "Meteor Stream x4" sync / 1[56]:[^:]*:Nael Geminus:26C0:/
+211.0 "Thermionic Burst" sync / 1[56]:[^:]*:Ragnarok:26B9:/
+211.5 "Dalamud Dive" sync / 1[56]:[^:]*:Nael deus Darnus:26C1:/
 
 213.5 "--targetable--"
-213.6 "Bahamut's Claw x5" duration 2.8 #sync / 1[56]:Nael deus Darnus:26B5:/
-222.1 "Bahamut's Favor" sync / 1[56]:Nael deus Darnus:26C2:/
+213.6 "Bahamut's Claw x5" duration 2.8 #sync / 1[56]:[^:]*:Nael deus Darnus:26B5:/
+222.1 "Bahamut's Favor" sync / 1[56]:[^:]*:Nael deus Darnus:26C2:/
 
 230.6 "Dynamo + Beam/Chariot" duration 8
-235.1 "Chain Lightning x2" sync / 1[56]:Thunderwing:26C8:/
-#235.1 "Lunar Dynamo" sync / 1[56]:Nael deus Darnus:26BC:/
-#238.3 "Thermionic Beam" sync / 1[56]:Nael deus Darnus:26BD:/
-239.1 "Doom x2" sync / 1[56]:Tail of Darkness:26C9:/
-241.1 "Fireball (1)" sync / 1[56]:Firehorn:26C5:/
-242.1 "Wings Of Salvation x2" duration 4 sync / 1[56]:Fang of Light:26CA:/
-249.3 "Bahamut's Claw x5" duration 2.8 #sync / 1[56]:Nael deus Darnus:26B5:/
-256.0 "Fireball (2)" sync / 1[56]:Firehorn:26C5:/
+235.1 "Chain Lightning x2" sync / 1[56]:[^:]*:Thunderwing:26C8:/
+#235.1 "Lunar Dynamo" sync / 1[56]:[^:]*:Nael deus Darnus:26BC:/
+#238.3 "Thermionic Beam" sync / 1[56]:[^:]*:Nael deus Darnus:26BD:/
+239.1 "Doom x2" sync / 1[56]:[^:]*:Tail of Darkness:26C9:/
+241.1 "Fireball (1)" sync / 1[56]:[^:]*:Firehorn:26C5:/
+242.1 "Wings Of Salvation x2" duration 4 sync / 1[56]:[^:]*:Fang of Light:26CA:/
+249.3 "Bahamut's Claw x5" duration 2.8 #sync / 1[56]:[^:]*:Nael deus Darnus:26B5:/
+256.0 "Fireball (2)" sync / 1[56]:[^:]*:Firehorn:26C5:/
 
 258.0 "Thermionic + Dynamo/Chariot" duration 8
-260.0 "Chain Lightning" sync / 1[56]:Thunderwing:26C8:/
-#262.8 "Thermionic Beam" sync / 1[56]:Nael deus Darnus:26BD:/
-#265.8 "Lunar Dynamo" sync / 1[56]:Nael deus Darnus:26BC:/
-268.0 "Doom x3" sync / 1[56]:Tail of Darkness:26C9:/
-270.0 "Wings Of Salvation x3" duration 8 sync / 1[56]:Fang of Light:26CA:/
-278.9 "Chain Lightning x2" sync / 1[56]:Thunderwing:26C8:/
-281.9 "Fireball (3)" sync / 1[56]:Firehorn:26C5:/
+260.0 "Chain Lightning" sync / 1[56]:[^:]*:Thunderwing:26C8:/
+#262.8 "Thermionic Beam" sync / 1[56]:[^:]*:Nael deus Darnus:26BD:/
+#265.8 "Lunar Dynamo" sync / 1[56]:[^:]*:Nael deus Darnus:26BC:/
+268.0 "Doom x3" sync / 1[56]:[^:]*:Tail of Darkness:26C9:/
+270.0 "Wings Of Salvation x3" duration 8 sync / 1[56]:[^:]*:Fang of Light:26CA:/
+278.9 "Chain Lightning x2" sync / 1[56]:[^:]*:Thunderwing:26C8:/
+281.9 "Fireball (3)" sync / 1[56]:[^:]*:Firehorn:26C5:/
 
 290.4 "Dive + Dynamo/Chariot" duration 8
-284.7 "Bahamut's Claw x5" duration 2.8 sync / 1[56]:Nael deus Darnus:26B5:/
-#295.3 "Raven Dive" sync / 1[56]:Nael deus Darnus:26BE:/
-#298.3 "Lunar Dynamo" sync / 1[56]:Nael deus Darnus:26BC:/
-302.9 "Fireball (4)" sync / 1[56]:Firehorn:26C5:/
-303.9 "Doom x3" sync / 1[56]:Tail of Darkness:26C9:/
-305.9 "Chain Lightning x2" sync / 1[56]:Thunderwing:26C8:/
-306.0 "Wings Of Salvation x3" duration 8 sync / 1[56]:Fang of Light:26CA:/
-323.3 "Ravensbeak" sync / 1[56]:Nael deus Darnus:26B6:/
-333.5 "Hypernova x4" duration 6 #sync / 1[56]:Nael deus Darnus:26BF:/
+284.7 "Bahamut's Claw x5" duration 2.8 sync / 1[56]:[^:]*:Nael deus Darnus:26B5:/
+#295.3 "Raven Dive" sync / 1[56]:[^:]*:Nael deus Darnus:26BE:/
+#298.3 "Lunar Dynamo" sync / 1[56]:[^:]*:Nael deus Darnus:26BC:/
+302.9 "Fireball (4)" sync / 1[56]:[^:]*:Firehorn:26C5:/
+303.9 "Doom x3" sync / 1[56]:[^:]*:Tail of Darkness:26C9:/
+305.9 "Chain Lightning x2" sync / 1[56]:[^:]*:Thunderwing:26C8:/
+306.0 "Wings Of Salvation x3" duration 8 sync / 1[56]:[^:]*:Fang of Light:26CA:/
+323.3 "Ravensbeak" sync / 1[56]:[^:]*:Nael deus Darnus:26B6:/
+333.5 "Hypernova x4" duration 6 #sync / 1[56]:[^:]*:Nael deus Darnus:26BF:/
 
 328.5 "Marker 1"
 332.5 "Marker 2"
 336.5 "Marker 3"
-339.5 "Cauterize" #sync / 1[56]:Thunderwing:26CD:/
-#339.5 "Cauterize" #sync / 1[56]:Tail of Darkness:26CE:/
+339.5 "Cauterize" #sync / 1[56]:[^:]*:Thunderwing:26CD:/
+#339.5 "Cauterize" #sync / 1[56]:[^:]*:Tail of Darkness:26CE:/
 341.0 "--untargetable--"
 341.0 "Meteor/Dive or Dive/Beam" duration 3 # first mechanic -> second
-#342.7 "Meteor Stream" sync / 1[56]:Nael Geminus:26C0:/
-343.5 "Cauterize" #sync / 1[56]:Firehorn:26CB:/
-#345.7 "Dalamud Dive" sync / 1[56]:Nael deus Darnus:26C1:/
-347.4 "Cauterize" #sync / 1[56]:Iceclaw:26CC:/
-#347.5 "Cauterize" #sync / 1[56]:Fang of Light:26CF:/
+#342.7 "Meteor Stream" sync / 1[56]:[^:]*:Nael Geminus:26C0:/
+343.5 "Cauterize" #sync / 1[56]:[^:]*:Firehorn:26CB:/
+#345.7 "Dalamud Dive" sync / 1[56]:[^:]*:Nael deus Darnus:26C1:/
+347.4 "Cauterize" #sync / 1[56]:[^:]*:Iceclaw:26CC:/
+#347.5 "Cauterize" #sync / 1[56]:[^:]*:Fang of Light:26CF:/
 
-349.7 "Bahamut's Claw x5" duration 2.8 #sync / 1[56]:Nael deus Darnus:26B5:/
+349.7 "Bahamut's Claw x5" duration 2.8 #sync / 1[56]:[^:]*:Nael deus Darnus:26B5:/
 
 361.2 "Random Combo Attack" duration 8
-#366.2 "Thermionic Beam" sync / 1[56]:Nael deus Darnus:26BD:/
-#369.2 "Lunar Dynamo" sync / 1[56]:Nael deus Darnus:26BC:/
+#366.2 "Thermionic Beam" sync / 1[56]:[^:]*:Nael deus Darnus:26BD:/
+#369.2 "Lunar Dynamo" sync / 1[56]:[^:]*:Nael deus Darnus:26BC:/
 
 372.7 "Random Combo Attack" duration 8
-#377.3 "Raven Dive" sync / 1[56]:Nael deus Darnus:26BE:/
-#380.3 "Lunar Dynamo" sync / 1[56]:Nael deus Darnus:26BC:/
+#377.3 "Raven Dive" sync / 1[56]:[^:]*:Nael deus Darnus:26BE:/
+#380.3 "Lunar Dynamo" sync / 1[56]:[^:]*:Nael deus Darnus:26BC:/
 
-388.7 "Ravensbeak" sync / 1[56]:Nael deus Darnus:26B6:/
-395.7 "Bahamut's Claw x5" duration 2.8 #sync / 1[56]:Nael deus Darnus:26B5:/
+388.7 "Ravensbeak" sync / 1[56]:[^:]*:Nael deus Darnus:26B6:/
+395.7 "Bahamut's Claw x5" duration 2.8 #sync / 1[56]:[^:]*:Nael deus Darnus:26B5:/
 403.2 "--untargetable--"
-408.2 "Megaflare Enrage" sync / 1[56]:Nael deus Darnus:26BA:/
+408.2 "Megaflare Enrage" sync / 1[56]:[^:]*:Nael deus Darnus:26BA:/
 
 
 ##### BAHAMUT #####
-500.0 "Seventh Umbral Era" sync / 1[56]:Bahamut Prime:26D1:/ window 500,0
-503.0 "Calamitous Flame x3" sync / 1[56]:Bahamut Prime:26D2:/ duration 2
-508.0 "Calamitous Blaze" sync / 1[56]:Bahamut Prime:26D3:/
+500.0 "Seventh Umbral Era" sync / 1[56]:[^:]*:Bahamut Prime:26D1:/ window 500,0
+503.0 "Calamitous Flame x3" sync / 1[56]:[^:]*:Bahamut Prime:26D2:/ duration 2
+508.0 "Calamitous Blaze" sync / 1[56]:[^:]*:Bahamut Prime:26D3:/
 511.0 "--targetable--"
-517.0 "Flare Breath" sync / 1[56]:Bahamut Prime:26D4:/
-525.0 "Flatten" sync / 1[56]:Bahamut Prime:26D5:/
+517.0 "Flare Breath" sync / 1[56]:[^:]*:Bahamut Prime:26D4:/
+525.0 "Flatten" sync / 1[56]:[^:]*:Bahamut Prime:26D5:/
 
 ### QUICKMARCH
-532.0 "Quickmarch Trio" sync / 1[56]:Bahamut Prime:26E2:/ window 30,10
+532.0 "Quickmarch Trio" sync / 1[56]:[^:]*:Bahamut Prime:26E2:/ window 30,10
 534.0 "--untargetable--"
-#540.0 "Megaflare Dive" sync / 1[56]:Bahamut Prime:26E1:/
-#540.0 "Lunar Dive" sync / 1[56]:Nael deus Darnus:26C3:/
-540.0 "Twisting Dive" sync / 1[56]:Twintania:26B2:/
-544.0 "Spread" sync / 1[56]:Bahamut Prime:26DC:/
+#540.0 "Megaflare Dive" sync / 1[56]:[^:]*:Bahamut Prime:26E1:/
+#540.0 "Lunar Dive" sync / 1[56]:[^:]*:Nael deus Darnus:26C3:/
+540.0 "Twisting Dive" sync / 1[56]:[^:]*:Twintania:26B2:/
+544.0 "Spread" sync / 1[56]:[^:]*:Bahamut Prime:26DC:/
 545.0 "--targetable--"
-546.0 "Pepperoni" sync / 1[56]:Bahamut Prime:26DD:/
-548.0 "Stack" sync / 1[56]:Bahamut Prime:26DE:/
-550.0 "Earth Shaker x3" sync / 1[56]:Bahamut Prime:26D9:/
-552.0 "Tempest Wing" sync / 1[56]:Bahamut Prime:26D7:/
+546.0 "Pepperoni" sync / 1[56]:[^:]*:Bahamut Prime:26DD:/
+548.0 "Stack" sync / 1[56]:[^:]*:Bahamut Prime:26DE:/
+550.0 "Earth Shaker x3" sync / 1[56]:[^:]*:Bahamut Prime:26D9:/
+552.0 "Tempest Wing" sync / 1[56]:[^:]*:Bahamut Prime:26D7:/
 
-555.9 "Flare Breath" sync / 1[56]:Bahamut Prime:26D4:/
-563.9 "Flatten" sync / 1[56]:Bahamut Prime:26D5:/
+555.9 "Flare Breath" sync / 1[56]:[^:]*:Bahamut Prime:26D4:/
+563.9 "Flatten" sync / 1[56]:[^:]*:Bahamut Prime:26D5:/
 
 ### BLACKFIRE
-572.0 "Blackfire Trio" sync / 1[56]:Bahamut Prime:26E3:/ window 70,10
+572.0 "Blackfire Trio" sync / 1[56]:[^:]*:Bahamut Prime:26E3:/ window 70,10
 574.0 "--untargetable--"
-576.0 "Liquid Hell x5" duration 4.5 #sync / 1[56]:Twintania:26AD:/ 
-579.0 "Thermionic Beam" sync / 1[56]:Nael deus Darnus:26BD:/
-580.0 "Megaflare Dive" sync / 1[56]:Bahamut Prime:26E1:/
-586.1 "Hypernova x4" duration 4.5 #sync / 1[56]:Nael deus Darnus:26BF:/
-588.0 "Stack" sync / 1[56]:Bahamut Prime:26DE:/
-590.0 "Towers" sync / 1[56]:Bahamut Prime:26DF:/
+576.0 "Liquid Hell x5" duration 4.5 #sync / 1[56]:[^:]*:Twintania:26AD:/ 
+579.0 "Thermionic Beam" sync / 1[56]:[^:]*:Nael deus Darnus:26BD:/
+580.0 "Megaflare Dive" sync / 1[56]:[^:]*:Bahamut Prime:26E1:/
+586.1 "Hypernova x4" duration 4.5 #sync / 1[56]:[^:]*:Nael deus Darnus:26BF:/
+588.0 "Stack" sync / 1[56]:[^:]*:Bahamut Prime:26DE:/
+590.0 "Towers" sync / 1[56]:[^:]*:Bahamut Prime:26DF:/
 
 590.0 "--targetable--"
-596.0 "Gigaflare" sync / 1[56]:Bahamut Prime:26D6:/
-605.0 "Flare Breath 1" #sync / 1[56]:Bahamut Prime:26D4:/
-607.0 "Flare Breath 2" #sync / 1[56]:Bahamut Prime:26D4:/
-609.0 "Flare Breath 3" #sync / 1[56]:Bahamut Prime:26D4:/
+596.0 "Gigaflare" sync / 1[56]:[^:]*:Bahamut Prime:26D6:/
+605.0 "Flare Breath 1" #sync / 1[56]:[^:]*:Bahamut Prime:26D4:/
+607.0 "Flare Breath 2" #sync / 1[56]:[^:]*:Bahamut Prime:26D4:/
+609.0 "Flare Breath 3" #sync / 1[56]:[^:]*:Bahamut Prime:26D4:/
 
 ### FELLRUIN
-622.0 "Fellruin Trio" sync / 1[56]:Bahamut Prime:26E4:/ window 130,10
+622.0 "Fellruin Trio" sync / 1[56]:[^:]*:Bahamut Prime:26E4:/ window 130,10
 624.0 "--untargetable--"
 626.6 "Dive Dynamo Combo" duration 8
-#631.1 "Lunar Dynamo" sync / 1[56]:Nael deus Darnus:26BC:/
-#634.1 "Raven Dive" sync / 1[56]:Nael deus Darnus:26BE:/
-637.1 "Tempest Wing" sync / 1[56]:Bahamut Prime:26D7:/
-638.1 "Aetheric Profusion" sync / 1[56]:Twintania:26B1:/
+#631.1 "Lunar Dynamo" sync / 1[56]:[^:]*:Nael deus Darnus:26BC:/
+#634.1 "Raven Dive" sync / 1[56]:[^:]*:Nael deus Darnus:26BE:/
+637.1 "Tempest Wing" sync / 1[56]:[^:]*:Bahamut Prime:26D7:/
+638.1 "Aetheric Profusion" sync / 1[56]:[^:]*:Twintania:26B1:/
 
 640.1 "--targetable--"
-641.1 "Meteor Stream" sync / 1[56]:Nael Geminus:26C0:/
-646.1 "Gigaflare" sync / 1[56]:Bahamut Prime:26D6:/
-651.4 "Flare Breath" sync / 1[56]:Bahamut Prime:26D4:/
-660.4 "Flatten" sync / 1[56]:Bahamut Prime:26D5:/
-665.4 "Flare Breath" sync / 1[56]:Bahamut Prime:26D4:/
+641.1 "Meteor Stream" sync / 1[56]:[^:]*:Nael Geminus:26C0:/
+646.1 "Gigaflare" sync / 1[56]:[^:]*:Bahamut Prime:26D6:/
+651.4 "Flare Breath" sync / 1[56]:[^:]*:Bahamut Prime:26D4:/
+660.4 "Flatten" sync / 1[56]:[^:]*:Bahamut Prime:26D5:/
+665.4 "Flare Breath" sync / 1[56]:[^:]*:Bahamut Prime:26D4:/
 
 #### HEAVENSFALL
-673.4 "Heavensfall Trio" sync / 1[56]:Bahamut Prime:26E5:/ window 170,10
+673.4 "Heavensfall Trio" sync / 1[56]:[^:]*:Bahamut Prime:26E5:/ window 170,10
 675.4 "--untargetable--"
-#681.4 "Megaflare Dive" sync / 1[56]:Bahamut Prime:26E1:/
-681.4 "Twisting Dive" sync / 1[56]:Twintania:26B2:/
-686.9 "Heavensfall" sync / 1[56]:Nael deus Darnus:26B7:/
-687.4 "Pepperoni" sync / 1[56]:Bahamut Prime:26DD:/
-688.9 "Heavensfall" sync / 1[56]:Ragnarok:26B8:/
-691.4 "Towers" sync / 1[56]:Bahamut Prime:26DF:/
-694.5 "Hypernova x3" duration 3.2 #sync / 1[56]:Nael deus Darnus:26BF:/
-696.0 "Thermionic Burst x8" duration 5 #sync / 1[56]:Ragnarok:26B9:/
+#681.4 "Megaflare Dive" sync / 1[56]:[^:]*:Bahamut Prime:26E1:/
+681.4 "Twisting Dive" sync / 1[56]:[^:]*:Twintania:26B2:/
+686.9 "Heavensfall" sync / 1[56]:[^:]*:Nael deus Darnus:26B7:/
+687.4 "Pepperoni" sync / 1[56]:[^:]*:Bahamut Prime:26DD:/
+688.9 "Heavensfall" sync / 1[56]:[^:]*:Ragnarok:26B8:/
+691.4 "Towers" sync / 1[56]:[^:]*:Bahamut Prime:26DF:/
+694.5 "Hypernova x3" duration 3.2 #sync / 1[56]:[^:]*:Nael deus Darnus:26BF:/
+696.0 "Thermionic Burst x8" duration 5 #sync / 1[56]:[^:]*:Ragnarok:26B9:/
 
 702.5 "--targetable--"
-703.5 "Fireball" sync / 1[56]:Twintania:26AC:/
-708.5 "Gigaflare" sync / 1[56]:Bahamut Prime:26D6:/
-717.5 "Flare Breath 1" #sync / 1[56]:Bahamut Prime:26D4:/
-719.5 "Flare Breath 2" #sync / 1[56]:Bahamut Prime:26D4:/
-721.5 "Flare Breath 3" #sync / 1[56]:Bahamut Prime:26D4:/
+703.5 "Fireball" sync / 1[56]:[^:]*:Twintania:26AC:/
+708.5 "Gigaflare" sync / 1[56]:[^:]*:Bahamut Prime:26D6:/
+717.5 "Flare Breath 1" #sync / 1[56]:[^:]*:Bahamut Prime:26D4:/
+719.5 "Flare Breath 2" #sync / 1[56]:[^:]*:Bahamut Prime:26D4:/
+721.5 "Flare Breath 3" #sync / 1[56]:[^:]*:Bahamut Prime:26D4:/
 
 ### TENSTRIKE
-733.5 "Tenstrike Trio" sync / 1[56]:Bahamut Prime:26E6:/ window 200,10
+733.5 "Tenstrike Trio" sync / 1[56]:[^:]*:Bahamut Prime:26E6:/ window 200,10
 735.5 "--untargetable--"
-740.5 "Generate x3" sync / 1[56]:Twintania:26AE:/
-741.5 "Meteor Stream (dps)" duration 3 #sync / 1[56]:Nael Geminus:26C0:/
-744.5 "Generate x3" sync / 1[56]:Twintania:26AE:/
-745.5 "Meteor Stream (T/H)" duration 3 #sync / 1[56]:Nael Geminus:26C0:/
+740.5 "Generate x3" sync / 1[56]:[^:]*:Twintania:26AE:/
+741.5 "Meteor Stream (dps)" duration 3 #sync / 1[56]:[^:]*:Nael Geminus:26C0:/
+744.5 "Generate x3" sync / 1[56]:[^:]*:Twintania:26AE:/
+745.5 "Meteor Stream (T/H)" duration 3 #sync / 1[56]:[^:]*:Nael Geminus:26C0:/
 754.4 "--targetable--"
-754.4 "Earth Shaker x4" sync / 1[56]:Bahamut Prime:26D9:/
-759.4 "Earth Shaker x4" sync / 1[56]:Bahamut Prime:26D9:/
+754.4 "Earth Shaker x4" sync / 1[56]:[^:]*:Bahamut Prime:26D9:/
+759.4 "Earth Shaker x4" sync / 1[56]:[^:]*:Bahamut Prime:26D9:/
 
-767.4 "Gigaflare" sync / 1[56]:Bahamut Prime:26D6:/
-778.4 "Flatten" sync / 1[56]:Bahamut Prime:26D5:/
-781.4 "Flare Breath" sync / 1[56]:Bahamut Prime:26D4:/
+767.4 "Gigaflare" sync / 1[56]:[^:]*:Bahamut Prime:26D6:/
+778.4 "Flatten" sync / 1[56]:[^:]*:Bahamut Prime:26D5:/
+781.4 "Flare Breath" sync / 1[56]:[^:]*:Bahamut Prime:26D4:/
 
 ### GRAND OCTET
-789.4 "Grand Octet" sync / 1[56]:Bahamut Prime:26E7:/ window 200,10
+789.4 "Grand Octet" sync / 1[56]:[^:]*:Bahamut Prime:26E7:/ window 200,10
 791.4 "--untargetable--"
 797.4 "Nael Marker"
-801.4 "Lunar Dive" sync / 1[56]:Nael deus Darnus:26C3:/
-808.4 "Cauterize" #sync / 1[56]:Firehorn:26CB:/
-810.6 "Cauterize" #sync / 1[56]:Iceclaw:26CC:/
-812.6 "Cauterize" #sync / 1[56]:Fang of Light:26CF:/
+801.4 "Lunar Dive" sync / 1[56]:[^:]*:Nael deus Darnus:26C3:/
+808.4 "Cauterize" #sync / 1[56]:[^:]*:Firehorn:26CB:/
+810.6 "Cauterize" #sync / 1[56]:[^:]*:Iceclaw:26CC:/
+812.6 "Cauterize" #sync / 1[56]:[^:]*:Fang of Light:26CF:/
 814.4 "Bahamut Marker"
-814.6 "Cauterize" #sync / 1[56]:Thunderwing:26CD:/
-816.6 "Cauterize" #sync / 1[56]:Tail of Darkness:26CE:/
-818.6 "Megaflare Dive" sync / 1[56]:Bahamut Prime:26E1:/
+814.6 "Cauterize" #sync / 1[56]:[^:]*:Thunderwing:26CD:/
+816.6 "Cauterize" #sync / 1[56]:[^:]*:Tail of Darkness:26CE:/
+818.6 "Megaflare Dive" sync / 1[56]:[^:]*:Bahamut Prime:26E1:/
 823.4 "Twin Marker"
-826.4 "Stack" sync / 1[56]:Bahamut Prime:26DE:/
-827.6 "Twisting Dive" sync / 1[56]:Twintania:26B2:/
-828.4 "Towers" sync / 1[56]:Bahamut Prime:26DF:/
+826.4 "Stack" sync / 1[56]:[^:]*:Bahamut Prime:26DE:/
+827.6 "Twisting Dive" sync / 1[56]:[^:]*:Twintania:26B2:/
+828.4 "Towers" sync / 1[56]:[^:]*:Bahamut Prime:26DF:/
 
 
 ##### ADDS PHASE: NAEL + TWIN #####
-843.4 "Bahamut's Favor" sync / 1[56]:Bahamut Prime:26E8:/ window 1000,100
+843.4 "Bahamut's Favor" sync / 1[56]:[^:]*:Bahamut Prime:26E8:/ window 1000,100
 844.9 "--targetable--"
-852.9 "Bahamut's Claw x5" duration 2.8 #sync / 1[56]:Nael deus Darnus:26B5:/
-852.9 "Plummet" sync / 1[56]:Twintania:26A8:/
+852.9 "Bahamut's Claw x5" duration 2.8 #sync / 1[56]:[^:]*:Nael deus Darnus:26B5:/
+852.9 "Plummet" sync / 1[56]:[^:]*:Twintania:26A8:/
 
-856.0 "Liquid Hell x5" duration 4.5 #sync / 1[56]:Twintania:26AD:/
-864.5 "Generate x3" sync / 1[56]:Twintania:26AE:/
-868.6 "Twister" sync / 1[56]:Twintania:26AA:/
+856.0 "Liquid Hell x5" duration 4.5 #sync / 1[56]:[^:]*:Twintania:26AD:/
+864.5 "Generate x3" sync / 1[56]:[^:]*:Twintania:26AE:/
+868.6 "Twister" sync / 1[56]:[^:]*:Twintania:26AA:/
 871.6 "Triple Nael Quote"
-#876.3 "Iron Chariot" sync / 1[56]:Nael deus Darnus:26BB:/
-#879.3 "Thermionic Beam" sync / 1[56]:Nael deus Darnus:26BD:/
-#882.4 "Raven Dive" sync / 1[56]:Nael deus Darnus:26BE:/
-885.5 "Twister" sync / 1[56]:Twintania:26AA:/
+#876.3 "Iron Chariot" sync / 1[56]:[^:]*:Nael deus Darnus:26BB:/
+#879.3 "Thermionic Beam" sync / 1[56]:[^:]*:Nael deus Darnus:26BD:/
+#882.4 "Raven Dive" sync / 1[56]:[^:]*:Nael deus Darnus:26BE:/
+885.5 "Twister" sync / 1[56]:[^:]*:Twintania:26AA:/
 
-896.5 "Megaflare" sync / 1[56]:Nael deus Darnus:26BA:/
-904.6 "Death Sentence" sync / 1[56]:Twintania:26A9:/
-904.6 "Ravensbeak" sync / 1[56]:Nael deus Darnus:26B6:/
-908.6 "Plummet" sync / 1[56]:Twintania:26A8:/
-908.6 "Bahamut's Claw x5" duration 2.8 #sync / 1[56]:Nael deus Darnus:26B5:/
+896.5 "Megaflare" sync / 1[56]:[^:]*:Nael deus Darnus:26BA:/
+904.6 "Death Sentence" sync / 1[56]:[^:]*:Twintania:26A9:/
+904.6 "Ravensbeak" sync / 1[56]:[^:]*:Nael deus Darnus:26B6:/
+908.6 "Plummet" sync / 1[56]:[^:]*:Twintania:26A8:/
+908.6 "Bahamut's Claw x5" duration 2.8 #sync / 1[56]:[^:]*:Nael deus Darnus:26B5:/
 
-917.7 "Liquid Hell x5" duration 4.5 #sync / 1[56]:Twintania:26AD:/
-926.5 "Generate x3" sync / 1[56]:Twintania:26AE:/
-930.7 "Twister" sync / 1[56]:Twintania:26AA:/
+917.7 "Liquid Hell x5" duration 4.5 #sync / 1[56]:[^:]*:Twintania:26AD:/
+926.5 "Generate x3" sync / 1[56]:[^:]*:Twintania:26AE:/
+930.7 "Twister" sync / 1[56]:[^:]*:Twintania:26AA:/
 934.7 "Triple Nael Quote"
-#938.3 "Lunar Dynamo" sync / 1[56]:Nael deus Darnus:26BC:/
-#941.4 "Iron Chariot" sync / 1[56]:Nael deus Darnus:26BB:/
-#944.6 "Raven Dive" sync / 1[56]:Nael deus Darnus:26BE:/
-947.9 "Twister" sync / 1[56]:Twintania:26AA:/
+#938.3 "Lunar Dynamo" sync / 1[56]:[^:]*:Nael deus Darnus:26BC:/
+#941.4 "Iron Chariot" sync / 1[56]:[^:]*:Nael deus Darnus:26BB:/
+#944.6 "Raven Dive" sync / 1[56]:[^:]*:Nael deus Darnus:26BE:/
+947.9 "Twister" sync / 1[56]:[^:]*:Twintania:26AA:/
 
-960.1 "Death Sentence" sync / 1[56]:Twintania:26A9:/
-960.7 "Ravensbeak" sync / 1[56]:Nael deus Darnus:26B6:/
-973.0 "Megaflare" sync / 1[56]:Nael deus Darnus:26BA:/
+960.1 "Death Sentence" sync / 1[56]:[^:]*:Twintania:26A9:/
+960.7 "Ravensbeak" sync / 1[56]:[^:]*:Nael deus Darnus:26B6:/
+973.0 "Megaflare" sync / 1[56]:[^:]*:Nael deus Darnus:26BA:/
 984.0 "Enrage" # ???
 
 
 ##### GOLDEN BAHAMUT #####
-1200.0 "Teraflare" sync / 1[56]:Bahamut Prime:26E9:/ window 1200,0
-1225.1 "Flames Of Rebirth" #sync / 1[56]:Phoenix:26F2:/
-1230.9 "--sync--" sync / 1[56]:Bahamut Prime:2707:/ window 30,30 # Glowing ball
+1200.0 "Teraflare" sync / 1[56]:[^:]*:Bahamut Prime:26E9:/ window 1200,0
+1225.1 "Flames Of Rebirth" #sync / 1[56]:[^:]*:Phoenix:26F2:/
+1230.9 "--sync--" sync / 1[56]:[^:]*:Bahamut Prime:2707:/ window 30,30 # Glowing ball
 1245.0 "--targetable--"
-1251.1 "Morn Afah #1" sync / 1[56]:Bahamut Prime:26EC:/
-1257.5 "Akh Morn #1" sync / 1[56]:Bahamut Prime:26EA:/ duration 3.3
-1270.0 "Exaflare #1" sync / 1[56]:Bahamut Prime:26EF:/ window 10,10
-1289.3 "Akh Morn #2" sync / 1[56]:Bahamut Prime:26EA:/ duration 4.4
-1306.9 "Morn Afah #2" sync / 1[56]:Bahamut Prime:26EC:/
-1319.2 "Exaflare #2" sync / 1[56]:Bahamut Prime:26EF:/ window 10,10
-1340.5 "Morn Afah #3" sync / 1[56]:Bahamut Prime:26EC:/
-1352.7 "Akh Morn #3" sync / 1[56]:Bahamut Prime:26EA:/ duration 5.5
-1369.4 "Exaflare #3" sync / 1[56]:Bahamut Prime:26EF:/ window 10,10
-1390.6 "Morn Afah #4" sync / 1[56]:Bahamut Prime:26EC:/
-1402.7 "Akh Morn #4" sync / 1[56]:Bahamut Prime:26EA:/ duration 6.6
-1420.5 "Exaflare #4" sync / 1[56]:Bahamut Prime:26EF:/ window 10,10
-1441.6 "Morn Afah #5" sync / 1[56]:Bahamut Prime:26EC:/
-1453.7 "Morn Afah Enrage" sync / 1[56]:Bahamut Prime:26ED:/
-#1455.9 "Morn Afah" sync / 1[56]:Bahamut Prime:26EE:/
-#1457.2 "Morn Afah" sync / 1[56]:Bahamut Prime:26EE:/
+1251.1 "Morn Afah #1" sync / 1[56]:[^:]*:Bahamut Prime:26EC:/
+1257.5 "Akh Morn #1" sync / 1[56]:[^:]*:Bahamut Prime:26EA:/ duration 3.3
+1270.0 "Exaflare #1" sync / 1[56]:[^:]*:Bahamut Prime:26EF:/ window 10,10
+1289.3 "Akh Morn #2" sync / 1[56]:[^:]*:Bahamut Prime:26EA:/ duration 4.4
+1306.9 "Morn Afah #2" sync / 1[56]:[^:]*:Bahamut Prime:26EC:/
+1319.2 "Exaflare #2" sync / 1[56]:[^:]*:Bahamut Prime:26EF:/ window 10,10
+1340.5 "Morn Afah #3" sync / 1[56]:[^:]*:Bahamut Prime:26EC:/
+1352.7 "Akh Morn #3" sync / 1[56]:[^:]*:Bahamut Prime:26EA:/ duration 5.5
+1369.4 "Exaflare #3" sync / 1[56]:[^:]*:Bahamut Prime:26EF:/ window 10,10
+1390.6 "Morn Afah #4" sync / 1[56]:[^:]*:Bahamut Prime:26EC:/
+1402.7 "Akh Morn #4" sync / 1[56]:[^:]*:Bahamut Prime:26EA:/ duration 6.6
+1420.5 "Exaflare #4" sync / 1[56]:[^:]*:Bahamut Prime:26EF:/ window 10,10
+1441.6 "Morn Afah #5" sync / 1[56]:[^:]*:Bahamut Prime:26EC:/
+1453.7 "Morn Afah Enrage" sync / 1[56]:[^:]*:Bahamut Prime:26ED:/
+#1455.9 "Morn Afah" sync / 1[56]:[^:]*:Bahamut Prime:26EE:/
+#1457.2 "Morn Afah" sync / 1[56]:[^:]*:Bahamut Prime:26EE:/
 
 # victory ezpz

--- a/ui/raidboss/data/05-shb/alliance/the_copied_factory.txt
+++ b/ui/raidboss/data/05-shb/alliance/the_copied_factory.txt
@@ -9,44 +9,44 @@ hideall "--sync--"
 # -ic 2P -p 48B2:108.5 -ii 4B31 48B3 48B4 48B7 48B6 48CB 48CC 48BA 4B32 48FA 48BC 48BD 48BE 48BF 48C0 48C1 48C2 48C9
 
 100.0 "--sync--" sync / 00:0839::Warehouse A will be sealed off/ window 100,0
-108.5 "Systematic Siege" sync / 1[56]:Serial-jointed Command Model:48B2:/
-122.6 "Clanging Blow" sync / 1[56]:Serial-jointed Command Model:48CE:/
-134.1 "Energy Bombardment" sync / 1[56]:Serial-jointed Command Model:48B8:/
-143.3 "Forceful Impact" sync / 1[56]:Serial-jointed Command Model:48CF:/
-156.1 "Energy Assault" sync / 1[56]:Serial-jointed Command Model:48B5:/ duration 6.5
-163.2 "--sync--" sync / 1[56]:Serial-jointed Command Model:4A10:/
-176.0 "Systematic Targeting" sync / 1[56]:Serial-jointed Command Model:48C4:/
-188.5 "High-Powered Laser" #sync / 1[56]:Serial-jointed Service Model:48C5:/
-193.8 "Forceful Impact" sync / 1[56]:Serial-jointed Command Model:48CF:/
-206.7 "Spin" sync / 1[56]:Serial-jointed Command Model:48C[A8]:/
-220.3 "Systematic Airstrike" sync / 1[56]:Serial-jointed Command Model:48B9:/ duration 24.8
-234.2 "Clanging Blow" sync / 1[56]:Serial-jointed Command Model:48CE:/
-259.1 "Systematic Suppression" sync / 1[56]:Serial-jointed Command Model:48C6:/
-272.0 "High-Caliber Laser" #sync / 1[56]:Serial-jointed Service Model:48C7:/
-276.0 "High-Caliber Laser" #sync / 1[56]:Serial-jointed Service Model:48C7:/
-281.9 "Forceful Impact" sync / 1[56]:Serial-jointed Command Model:48CF:/
+108.5 "Systematic Siege" sync / 1[56]:[^:]*:Serial-jointed Command Model:48B2:/
+122.6 "Clanging Blow" sync / 1[56]:[^:]*:Serial-jointed Command Model:48CE:/
+134.1 "Energy Bombardment" sync / 1[56]:[^:]*:Serial-jointed Command Model:48B8:/
+143.3 "Forceful Impact" sync / 1[56]:[^:]*:Serial-jointed Command Model:48CF:/
+156.1 "Energy Assault" sync / 1[56]:[^:]*:Serial-jointed Command Model:48B5:/ duration 6.5
+163.2 "--sync--" sync / 1[56]:[^:]*:Serial-jointed Command Model:4A10:/
+176.0 "Systematic Targeting" sync / 1[56]:[^:]*:Serial-jointed Command Model:48C4:/
+188.5 "High-Powered Laser" #sync / 1[56]:[^:]*:Serial-jointed Service Model:48C5:/
+193.8 "Forceful Impact" sync / 1[56]:[^:]*:Serial-jointed Command Model:48CF:/
+206.7 "Spin" sync / 1[56]:[^:]*:Serial-jointed Command Model:48C[A8]:/
+220.3 "Systematic Airstrike" sync / 1[56]:[^:]*:Serial-jointed Command Model:48B9:/ duration 24.8
+234.2 "Clanging Blow" sync / 1[56]:[^:]*:Serial-jointed Command Model:48CE:/
+259.1 "Systematic Suppression" sync / 1[56]:[^:]*:Serial-jointed Command Model:48C6:/
+272.0 "High-Caliber Laser" #sync / 1[56]:[^:]*:Serial-jointed Service Model:48C7:/
+276.0 "High-Caliber Laser" #sync / 1[56]:[^:]*:Serial-jointed Service Model:48C7:/
+281.9 "Forceful Impact" sync / 1[56]:[^:]*:Serial-jointed Command Model:48CF:/
 
 # Maybe an HP push?
-292.3 "Systematic Siege" sync / 1[56]:Serial-jointed Command Model:48B2:/ window 150,5
-303.2 "Energy Bombardment" sync / 1[56]:Serial-jointed Command Model:48B8:/
-306.8 "Systematic Targeting" sync / 1[56]:Serial-jointed Command Model:48C4:/
-317.8 "Clanging Blow" sync / 1[56]:Serial-jointed Command Model:48CE:/
-319.3 "High-Powered Laser" #sync / 1[56]:Serial-jointed Service Model:48C5:/
-332.1 "Spin" sync / 1[56]:Serial-jointed Command Model:48C[A8]:/
-343.2 "Forceful Impact" sync / 1[56]:Serial-jointed Command Model:48CF:/
-352.6 "Systematic Airstrike" sync / 1[56]:Serial-jointed Command Model:48B9:/ duration 24.8
-371.5 "Shockwave" sync / 1[56]:Serial-jointed Command Model:48C3:/
-387.9 "Energy Ring" sync / 1[56]:Serial-jointed Command Model:48BB:/ duration 7.2
-404.9 "Energy Assault" sync / 1[56]:Serial-jointed Command Model:48B5:/ duration 6.5
-412.1 "--sync--" sync / 1[56]:Serial-jointed Command Model:4A10:/
-420.7 "Systematic Suppression" sync / 1[56]:Serial-jointed Command Model:48C6:/
-433.5 "High-Caliber Laser" #sync / 1[56]:Serial-jointed Service Model:48C7:/
-437.6 "High-Caliber Laser" #sync / 1[56]:Serial-jointed Service Model:48C7:/
-442.6 "Forceful Impact" sync / 1[56]:Serial-jointed Command Model:48CF:/
-457.4 "Spin" sync / 1[56]:Serial-jointed Command Model:48C[A8]:/
-468.5 "Clanging Blow" sync / 1[56]:Serial-jointed Command Model:48CE:/
+292.3 "Systematic Siege" sync / 1[56]:[^:]*:Serial-jointed Command Model:48B2:/ window 150,5
+303.2 "Energy Bombardment" sync / 1[56]:[^:]*:Serial-jointed Command Model:48B8:/
+306.8 "Systematic Targeting" sync / 1[56]:[^:]*:Serial-jointed Command Model:48C4:/
+317.8 "Clanging Blow" sync / 1[56]:[^:]*:Serial-jointed Command Model:48CE:/
+319.3 "High-Powered Laser" #sync / 1[56]:[^:]*:Serial-jointed Service Model:48C5:/
+332.1 "Spin" sync / 1[56]:[^:]*:Serial-jointed Command Model:48C[A8]:/
+343.2 "Forceful Impact" sync / 1[56]:[^:]*:Serial-jointed Command Model:48CF:/
+352.6 "Systematic Airstrike" sync / 1[56]:[^:]*:Serial-jointed Command Model:48B9:/ duration 24.8
+371.5 "Shockwave" sync / 1[56]:[^:]*:Serial-jointed Command Model:48C3:/
+387.9 "Energy Ring" sync / 1[56]:[^:]*:Serial-jointed Command Model:48BB:/ duration 7.2
+404.9 "Energy Assault" sync / 1[56]:[^:]*:Serial-jointed Command Model:48B5:/ duration 6.5
+412.1 "--sync--" sync / 1[56]:[^:]*:Serial-jointed Command Model:4A10:/
+420.7 "Systematic Suppression" sync / 1[56]:[^:]*:Serial-jointed Command Model:48C6:/
+433.5 "High-Caliber Laser" #sync / 1[56]:[^:]*:Serial-jointed Service Model:48C7:/
+437.6 "High-Caliber Laser" #sync / 1[56]:[^:]*:Serial-jointed Service Model:48C7:/
+442.6 "Forceful Impact" sync / 1[56]:[^:]*:Serial-jointed Command Model:48CF:/
+457.4 "Spin" sync / 1[56]:[^:]*:Serial-jointed Command Model:48C[A8]:/
+468.5 "Clanging Blow" sync / 1[56]:[^:]*:Serial-jointed Command Model:48CE:/
 
-478.4 "Systematic Siege" sync / 1[56]:Serial-jointed Command Model:48B2:/ window 100,100 jump 292.3
+478.4 "Systematic Siege" sync / 1[56]:[^:]*:Serial-jointed Command Model:48B2:/ window 100,100 jump 292.3
 489.3 "Energy Bombardment"
 492.9 "Systematic Targeting"
 503.9 "Clanging Blow"
@@ -59,18 +59,18 @@ hideall "--sync--"
 # -ic 2P -ii 491D 491C -p 491B:715.5
 600.0 "--sync--" sync / 00:0839::Warehouse B will be sealed off/ window 600,0
 700.0 "--sync--" sync / 22:........:Small Flyer:........:Small Flyer:01/ window 100,0
-715.5 "Frontal Somersault" sync / 1[56]:Small Biped:491B:/ window 116,2.5
-721.4 "Frontal Somersault" sync / 1[56]:Small Biped:491B:/
-725.7 "High-Frequency Laser" sync / 1[56]:Multi-leg Medium Model:491E:/
-732.1 "High-Frequency Laser" sync / 1[56]:Multi-leg Medium Model:491E:/
-738.5 "High-Frequency Laser" sync / 1[56]:Multi-leg Medium Model:491E:/
-740.8 "Frontal Somersault" sync / 1[56]:Small Biped:491B:/
-746.9 "Frontal Somersault" sync / 1[56]:Small Biped:491B:/
-751.2 "High-Frequency Laser" sync / 1[56]:Multi-leg Medium Model:491E:/
-757.5 "High-Frequency Laser" sync / 1[56]:Multi-leg Medium Model:491E:/
-763.9 "High-Frequency Laser" sync / 1[56]:Multi-leg Medium Model:491E:/
-770.1 "High-Frequency Laser" sync / 1[56]:Multi-leg Medium Model:491E:/
-776.3 "High-Frequency Laser" sync / 1[56]:Multi-leg Medium Model:491E:/
+715.5 "Frontal Somersault" sync / 1[56]:[^:]*:Small Biped:491B:/ window 116,2.5
+721.4 "Frontal Somersault" sync / 1[56]:[^:]*:Small Biped:491B:/
+725.7 "High-Frequency Laser" sync / 1[56]:[^:]*:Multi-leg Medium Model:491E:/
+732.1 "High-Frequency Laser" sync / 1[56]:[^:]*:Multi-leg Medium Model:491E:/
+738.5 "High-Frequency Laser" sync / 1[56]:[^:]*:Multi-leg Medium Model:491E:/
+740.8 "Frontal Somersault" sync / 1[56]:[^:]*:Small Biped:491B:/
+746.9 "Frontal Somersault" sync / 1[56]:[^:]*:Small Biped:491B:/
+751.2 "High-Frequency Laser" sync / 1[56]:[^:]*:Multi-leg Medium Model:491E:/
+757.5 "High-Frequency Laser" sync / 1[56]:[^:]*:Multi-leg Medium Model:491E:/
+763.9 "High-Frequency Laser" sync / 1[56]:[^:]*:Multi-leg Medium Model:491E:/
+770.1 "High-Frequency Laser" sync / 1[56]:[^:]*:Multi-leg Medium Model:491E:/
+776.3 "High-Frequency Laser" sync / 1[56]:[^:]*:Multi-leg Medium Model:491E:/
 
 
 ### Hobbes
@@ -111,79 +111,79 @@ hideall "--sync--"
 # branch out to six timelines again for the second half, but it'd be, well, a lot.
 
 900.0 "--sync--" sync / 00:0839::Quality assurance will be sealed off/ window 900,0
-913.0 "Laser-Resistance Test x3" sync / 1[56]:Hobbes:4805:/ duration 2.3
+913.0 "Laser-Resistance Test x3" sync / 1[56]:[^:]*:Hobbes:4805:/ duration 2.3
 
-924.5 "--sync--" sync / 1[56]:Hobbes:480A:/
-926.0 "--sync--" sync / 1[56]:Hobbes:4913:/
+924.5 "--sync--" sync / 1[56]:[^:]*:Hobbes:480A:/
+926.0 "--sync--" sync / 1[56]:[^:]*:Hobbes:4913:/
 934.0 "Wall Mechanic 1"
 
-969.6 "--sync--" sync / 1[56]:Hobbes:480A:/
-971.1 "--sync--" sync / 1[56]:Hobbes:4913:/
+969.6 "--sync--" sync / 1[56]:[^:]*:Hobbes:480A:/
+971.1 "--sync--" sync / 1[56]:[^:]*:Hobbes:4913:/
 
 979.1 "Wall Mechanic 2"
 
-996.8 "Ring Laser" sync / 1[56]:Hobbes:47FF:/ duration 8.1
+996.8 "Ring Laser" sync / 1[56]:[^:]*:Hobbes:47FF:/ duration 8.1
 
-1030.5 "--sync--" sync / 1[56]:Hobbes:480A:/
-1032.1 "--sync--" sync / 1[56]:Hobbes:4913:/
+1030.5 "--sync--" sync / 1[56]:[^:]*:Hobbes:480A:/
+1032.1 "--sync--" sync / 1[56]:[^:]*:Hobbes:4913:/
 
 1040.1 "Wall Mechanic 3"
 
-1061.3 "Laser Sight" sync / 1[56]:Hobbes:4807:/
+1061.3 "Laser Sight" sync / 1[56]:[^:]*:Hobbes:4807:/
 
-1090.7 "Floor 1" sync / 1[56]:Hobbes:481B:/
-1097.3 "Floor 2" sync / 1[56]:Hobbes:481B:/
+1090.7 "Floor 1" sync / 1[56]:[^:]*:Hobbes:481B:/
+1097.3 "Floor 2" sync / 1[56]:[^:]*:Hobbes:481B:/
 
-1114.1 "Laser-Resistance Test x4" sync / 1[56]:Hobbes:4805:/ duration 3.3
+1114.1 "Laser-Resistance Test x4" sync / 1[56]:[^:]*:Hobbes:4805:/ duration 3.3
 
-1128.6 "Floor 1" sync / 1[56]:Hobbes:481B:/
-1130.5 "Short-Range Missile" sync / 1[56]:Hobbes:4815:/
-1135.2 "Floor 2" sync / 1[56]:Hobbes:481B:/
+1128.6 "Floor 1" sync / 1[56]:[^:]*:Hobbes:481B:/
+1130.5 "Short-Range Missile" sync / 1[56]:[^:]*:Hobbes:4815:/
+1135.2 "Floor 2" sync / 1[56]:[^:]*:Hobbes:481B:/
 
-1143.7 "--sync--" sync / 1[56]:Hobbes:480A:/
-1149.2 "--sync--" sync / 1[56]:Hobbes:4913:/
-1149.6 "Laser Sight" sync / 1[56]:Hobbes:4807:/
+1143.7 "--sync--" sync / 1[56]:[^:]*:Hobbes:480A:/
+1149.2 "--sync--" sync / 1[56]:[^:]*:Hobbes:4913:/
+1149.6 "Laser Sight" sync / 1[56]:[^:]*:Hobbes:4807:/
 
 1157.2 "Wall Mechanic A"
 
-1187.9 "Laser-Resistance Test x5" sync / 1[56]:Hobbes:4805:/ duration 4.3
+1187.9 "Laser-Resistance Test x5" sync / 1[56]:[^:]*:Hobbes:4805:/ duration 4.3
 
-1200.8 "Ring Laser" sync / 1[56]:Hobbes:47FF:/ duration 8.1
-1203.4 "Floor 1" sync / 1[56]:Hobbes:481B:/
-1209.9 "Floor 2" sync / 1[56]:Hobbes:481B:/
+1200.8 "Ring Laser" sync / 1[56]:[^:]*:Hobbes:47FF:/ duration 8.1
+1203.4 "Floor 1" sync / 1[56]:[^:]*:Hobbes:481B:/
+1209.9 "Floor 2" sync / 1[56]:[^:]*:Hobbes:481B:/
 
-1218.2 "--sync--" sync / 1[56]:Hobbes:480A:/
-1223.8 "--sync--" sync / 1[56]:Hobbes:4913:/
-1224.2 "Short-Range Missile" sync / 1[56]:Hobbes:4815:/
+1218.2 "--sync--" sync / 1[56]:[^:]*:Hobbes:480A:/
+1223.8 "--sync--" sync / 1[56]:[^:]*:Hobbes:4913:/
+1224.2 "Short-Range Missile" sync / 1[56]:[^:]*:Hobbes:4815:/
 
 1231.8 "Wall Mechanic B"
 
-1262.6 "Laser-Resistance Test x6" sync / 1[56]:Hobbes:4805:/ duration 5.3
+1262.6 "Laser-Resistance Test x6" sync / 1[56]:[^:]*:Hobbes:4805:/ duration 5.3
 
-1279.2 "Floor 1" sync / 1[56]:Hobbes:481B:/
-1281.2 "Laser Sight" sync / 1[56]:Hobbes:4807:/
-1285.8 "Floor 2" sync / 1[56]:Hobbes:481B:/
+1279.2 "Floor 1" sync / 1[56]:[^:]*:Hobbes:481B:/
+1281.2 "Laser Sight" sync / 1[56]:[^:]*:Hobbes:4807:/
+1285.8 "Floor 2" sync / 1[56]:[^:]*:Hobbes:481B:/
 
-1294.5 "--sync--" sync / 1[56]:Hobbes:480A:/
-1300.0 "--sync--" sync / 1[56]:Hobbes:4913:/
-1301.9 "Ring Laser" sync / 1[56]:Hobbes:47FF:/ duration 8.1
+1294.5 "--sync--" sync / 1[56]:[^:]*:Hobbes:480A:/
+1300.0 "--sync--" sync / 1[56]:[^:]*:Hobbes:4913:/
+1301.9 "Ring Laser" sync / 1[56]:[^:]*:Hobbes:47FF:/ duration 8.1
 
 1308.0 "Wall Mechanic C"
 
-1339.0 "Laser-Resistance Test x6" sync / 1[56]:Hobbes:4805:/ duration 5.3
+1339.0 "Laser-Resistance Test x6" sync / 1[56]:[^:]*:Hobbes:4805:/ duration 5.3
 
-1355.7 "Floor 1" sync / 1[56]:Hobbes:481B:/
-1357.7 "Short-Range Missile" sync / 1[56]:Hobbes:4815:/
-1362.3 "Floor 2" sync / 1[56]:Hobbes:481B:/
+1355.7 "Floor 1" sync / 1[56]:[^:]*:Hobbes:481B:/
+1357.7 "Short-Range Missile" sync / 1[56]:[^:]*:Hobbes:4815:/
+1362.3 "Floor 2" sync / 1[56]:[^:]*:Hobbes:481B:/
 
-1370.9 "--sync--" sync / 1[56]:Hobbes:480A:/
-1376.4 "--sync--" sync / 1[56]:Hobbes:4913:/
-1376.8 "Laser Sight" sync / 1[56]:Hobbes:4807:/
+1370.9 "--sync--" sync / 1[56]:[^:]*:Hobbes:480A:/
+1376.4 "--sync--" sync / 1[56]:[^:]*:Hobbes:4913:/
+1376.8 "Laser Sight" sync / 1[56]:[^:]*:Hobbes:4807:/
 1384.4 "Wall Mechanic A"
 
-1414.9 "Laser-Resistance Test x6" sync / 1[56]:Hobbes:4805:/ duration 5.3
+1414.9 "Laser-Resistance Test x6" sync / 1[56]:[^:]*:Hobbes:4805:/ duration 5.3
 
-1429.0 "Ring Laser" sync / 1[56]:Hobbes:47FF:/ duration 8.1 window 100,100 jump 1200.8
+1429.0 "Ring Laser" sync / 1[56]:[^:]*:Hobbes:47FF:/ duration 8.1 window 100,100 jump 1200.8
 
 1431.6 "Floor 1"
 1438.1 "Floor 2"
@@ -198,31 +198,31 @@ hideall "--sync--"
 ### Goliath Tank
 # -ic 2P -p 4932:1509 493D:1800 -ii 4937 4934 4938 4935 4939 4936 493A 4933 470D 4943 493E
 1500.0 "--sync--" sync / 00:0839::Warehouse C will be sealed off/ window 1500,0
-1509.0 "Energy Ring" sync / 1[56]:Goliath Tank:4932:/ duration 15.1
+1509.0 "Energy Ring" sync / 1[56]:[^:]*:Goliath Tank:4932:/ duration 15.1
 1516.9 "Exploding Tethers"
-1526.0 "Convenient Self-Destruction" sync / 1[56]:Medium Exploder:493C:/
-1533.9 "Laser Turret" sync / 1[56]:Goliath Tank:493B:/
-1547.2 "Energy Ring" sync / 1[56]:Goliath Tank:4932:/ duration 30
+1526.0 "Convenient Self-Destruction" sync / 1[56]:[^:]*:Medium Exploder:493C:/
+1533.9 "Laser Turret" sync / 1[56]:[^:]*:Goliath Tank:493B:/
+1547.2 "Energy Ring" sync / 1[56]:[^:]*:Goliath Tank:4932:/ duration 30
 1561.1 "Exploding Tethers"
-1570.2 "Convenient Self-Destruction" sync / 1[56]:Medium Exploder:493C:/
-1584.2 "Laser Turret" sync / 1[56]:Goliath Tank:493B:/
-1593.6 "Laser Turret" sync / 1[56]:Goliath Tank:493B:/
-1603.0 "Laser Turret" sync / 1[56]:Goliath Tank:493B:/
+1570.2 "Convenient Self-Destruction" sync / 1[56]:[^:]*:Medium Exploder:493C:/
+1584.2 "Laser Turret" sync / 1[56]:[^:]*:Goliath Tank:493B:/
+1593.6 "Laser Turret" sync / 1[56]:[^:]*:Goliath Tank:493B:/
+1603.0 "Laser Turret" sync / 1[56]:[^:]*:Goliath Tank:493B:/
 
-1800.0 "--sync--" sync / 1[56]:Flight Unit:493D:/ window 300,0
+1800.0 "--sync--" sync / 1[56]:[^:]*:Flight Unit:493D:/ window 300,0
 1810.0 "--targetable--"
-1817.2 "--sync--" sync / 1[56]:Flight Unit:493F:/
-1821.7 "Area Bombing Maneuver" sync / 1[56]:Flight Unit:4942:/ duration 9.1
-1835.9 "360-Degree Bombing Maneuver" sync / 1[56]:Flight Unit:4941:/
-1851.3 "Lightfast Blade" sync / 1[56]:Flight Unit:4940:/
-1857.5 "--sync--" sync / 1[56]:Flight Unit:493F:/
-1861.8 "Area Bombing Maneuver" sync / 1[56]:Flight Unit:4942:/ duration 9.1
-1871.1 "Lightfast Blade" sync / 1[56]:Flight Unit:4940:/
-1873.2 "--jump--" sync / 1[56]:Flight Unit:493F:/
-1879.7 "Lightfast Blade" sync / 1[56]:Flight Unit:4940:/
-1888.8 "360-Degree Bombing Maneuver" sync / 1[56]:Flight Unit:4941:/
-1899.1 "360-Degree Bombing Maneuver" sync / 1[56]:Flight Unit:4941:/
-1918.5 "Lightfast Blade" sync / 1[56]:Flight Unit:4940:/
+1817.2 "--sync--" sync / 1[56]:[^:]*:Flight Unit:493F:/
+1821.7 "Area Bombing Maneuver" sync / 1[56]:[^:]*:Flight Unit:4942:/ duration 9.1
+1835.9 "360-Degree Bombing Maneuver" sync / 1[56]:[^:]*:Flight Unit:4941:/
+1851.3 "Lightfast Blade" sync / 1[56]:[^:]*:Flight Unit:4940:/
+1857.5 "--sync--" sync / 1[56]:[^:]*:Flight Unit:493F:/
+1861.8 "Area Bombing Maneuver" sync / 1[56]:[^:]*:Flight Unit:4942:/ duration 9.1
+1871.1 "Lightfast Blade" sync / 1[56]:[^:]*:Flight Unit:4940:/
+1873.2 "--jump--" sync / 1[56]:[^:]*:Flight Unit:493F:/
+1879.7 "Lightfast Blade" sync / 1[56]:[^:]*:Flight Unit:4940:/
+1888.8 "360-Degree Bombing Maneuver" sync / 1[56]:[^:]*:Flight Unit:4941:/
+1899.1 "360-Degree Bombing Maneuver" sync / 1[56]:[^:]*:Flight Unit:4941:/
+1918.5 "Lightfast Blade" sync / 1[56]:[^:]*:Flight Unit:4940:/
 
 
 ### Engels
@@ -232,87 +232,87 @@ hideall "--sync--"
 # One log has 472[6,7,7,A] as the four.  Left as all random for now.
 
 2000.0 "--sync--" sync / 00:0839::The forward deck will be sealed off/ window 2000,0
-2015.7 "Marx Smash L/R" sync / 1[56]:Engels:472[67]:/
-2029.6 "Marx Smash R/L" sync / 1[56]:Engels:472[67]:/
-2044.4 "Precision Guided Missile" sync / 1[56]:Engels:4754:/
-2055.8 "Incendiary Bombing" sync / 1[56]:Engels:4739:/
-2070.5 "Guided Missile" sync / 1[56]:Engels:4736:/ duration 3.4
-2078.8 "Diffuse Laser" sync / 1[56]:Engels:4755:/
-2097.3 "Marx Smash Back" sync / 1[56]:Engels:472[AE]:/
-2115.9 "Marx Smash Front" sync / 1[56]:Engels:472[AE]:/
-2135.6 "Energy Barrage" sync / 1[56]:Engels:473C:/
-2143.4 "Laser Sight" sync / 1[56]:Engels:473A:/
-2154.1 "Energy Blast" sync / 1[56]:Engels:473E:/
-2156.7 "Surface Missile" sync / 1[56]:Engels:4733:/
-2171.6 "Precision Guided Missile" sync / 1[56]:Engels:4754:/
-2178.0 "Diffuse Laser" sync / 1[56]:Engels:4755:/
+2015.7 "Marx Smash L/R" sync / 1[56]:[^:]*:Engels:472[67]:/
+2029.6 "Marx Smash R/L" sync / 1[56]:[^:]*:Engels:472[67]:/
+2044.4 "Precision Guided Missile" sync / 1[56]:[^:]*:Engels:4754:/
+2055.8 "Incendiary Bombing" sync / 1[56]:[^:]*:Engels:4739:/
+2070.5 "Guided Missile" sync / 1[56]:[^:]*:Engels:4736:/ duration 3.4
+2078.8 "Diffuse Laser" sync / 1[56]:[^:]*:Engels:4755:/
+2097.3 "Marx Smash Back" sync / 1[56]:[^:]*:Engels:472[AE]:/
+2115.9 "Marx Smash Front" sync / 1[56]:[^:]*:Engels:472[AE]:/
+2135.6 "Energy Barrage" sync / 1[56]:[^:]*:Engels:473C:/
+2143.4 "Laser Sight" sync / 1[56]:[^:]*:Engels:473A:/
+2154.1 "Energy Blast" sync / 1[56]:[^:]*:Engels:473E:/
+2156.7 "Surface Missile" sync / 1[56]:[^:]*:Engels:4733:/
+2171.6 "Precision Guided Missile" sync / 1[56]:[^:]*:Engels:4754:/
+2178.0 "Diffuse Laser" sync / 1[56]:[^:]*:Engels:4755:/
 
 # TODO: Maybe time-based or hp-based?
 2193.1 "--untargetable--"
-2193.2 "--sync--" sync / 1[56]:Engels:473F:/ window 200,50
+2193.2 "--sync--" sync / 1[56]:[^:]*:Engels:473F:/ window 200,50
 2197.0 "Adds"
 2198.3 "--targetable--"
 # These arm lasers can get desynced.
-2214.5 "Arm Laser" #sync / 1[56]:Reverse-jointed Goliath:4757:/
-2229.7 "Arm Laser" #sync / 1[56]:Reverse-jointed Goliath:4757:/
-2244.9 "Arm Laser" #sync / 1[56]:Reverse-jointed Goliath:4757:/
+2214.5 "Arm Laser" #sync / 1[56]:[^:]*:Reverse-jointed Goliath:4757:/
+2229.7 "Arm Laser" #sync / 1[56]:[^:]*:Reverse-jointed Goliath:4757:/
+2244.9 "Arm Laser" #sync / 1[56]:[^:]*:Reverse-jointed Goliath:4757:/
 2258.3 "Enrage" # 60 seconds ???
 
-2400.0 "Wide-Angle Diffuse Laser" sync / 1[56]:Engels:4740:/ window 200,0
-2402.1 "Diffuse Laser" sync / 1[56]:Engels:4741:/
-2412.2 "--sync--" sync / 1[56]:Engels:4743:/
-2433.0 "Demolish Structure" sync / 1[56]:Engels:4744:/
+2400.0 "Wide-Angle Diffuse Laser" sync / 1[56]:[^:]*:Engels:4740:/ window 200,0
+2402.1 "Diffuse Laser" sync / 1[56]:[^:]*:Engels:4741:/
+2412.2 "--sync--" sync / 1[56]:[^:]*:Engels:4743:/
+2433.0 "Demolish Structure" sync / 1[56]:[^:]*:Engels:4744:/
 
 2442.2 "--targetable--"
-2448.2 "Marx Activation" sync / 1[56]:Engels:48A8:/
-2466.3 "Marx Thrust" sync / 1[56]:Marx:4756:/
-2476.3 "Marx Thrust" sync / 1[56]:Marx:4756:/
-2478.5 "Area Bombardment" sync / 1[56]:Engels:4750:/
-2486.3 "Marx Thrust" sync / 1[56]:Marx:4756:/
-2491.1 "Incendiary Bombing" sync / 1[56]:Engels:4739:/
-2505.1 "Guided Missile" sync / 1[56]:Engels:4736:/
-2511.4 "Diffuse Laser" sync / 1[56]:Engels:4755:/
-2529.2 "Incendiary Bombing" sync / 1[56]:Engels:4739:/
-2533.7 "Marx Smash" sync / 1[56]:Engels:472E:/
-2553.9 "Incendiary Bombing" sync / 1[56]:Engels:4739:/
-2558.5 "Marx Smash" sync / 1[56]:Engels:472A:/
-2572.5 "Incendiary Saturation Bombing" sync / 1[56]:Engels:474E:/
+2448.2 "Marx Activation" sync / 1[56]:[^:]*:Engels:48A8:/
+2466.3 "Marx Thrust" sync / 1[56]:[^:]*:Marx:4756:/
+2476.3 "Marx Thrust" sync / 1[56]:[^:]*:Marx:4756:/
+2478.5 "Area Bombardment" sync / 1[56]:[^:]*:Engels:4750:/
+2486.3 "Marx Thrust" sync / 1[56]:[^:]*:Marx:4756:/
+2491.1 "Incendiary Bombing" sync / 1[56]:[^:]*:Engels:4739:/
+2505.1 "Guided Missile" sync / 1[56]:[^:]*:Engels:4736:/
+2511.4 "Diffuse Laser" sync / 1[56]:[^:]*:Engels:4755:/
+2529.2 "Incendiary Bombing" sync / 1[56]:[^:]*:Engels:4739:/
+2533.7 "Marx Smash" sync / 1[56]:[^:]*:Engels:472E:/
+2553.9 "Incendiary Bombing" sync / 1[56]:[^:]*:Engels:4739:/
+2558.5 "Marx Smash" sync / 1[56]:[^:]*:Engels:472A:/
+2572.5 "Incendiary Saturation Bombing" sync / 1[56]:[^:]*:Engels:474E:/
 
 2581.2 "Crusher Adds"
-2584.7 "Marx Crush" sync / 1[56]:Engels:4746:/
-2586.8 "Radiate Heat" sync / 1[56]:Engels:474C:/
-2586.8 "Radiate Heat" sync / 1[56]:Engels:474C:/
-2593.9 "Radiate Heat" sync / 1[56]:Engels:474C:/
-2600.0 "Crushing Wheel" sync / 1[56]:Marx [LR]:474B:/
-2600.7 "Radiate Heat" sync / 1[56]:Engels:474C:/
-2607.8 "Radiate Heat" sync / 1[56]:Engels:474C:/
-2614.1 "Crushing Wheel" sync / 1[56]:Marx [LR]:474B:/
+2584.7 "Marx Crush" sync / 1[56]:[^:]*:Engels:4746:/
+2586.8 "Radiate Heat" sync / 1[56]:[^:]*:Engels:474C:/
+2586.8 "Radiate Heat" sync / 1[56]:[^:]*:Engels:474C:/
+2593.9 "Radiate Heat" sync / 1[56]:[^:]*:Engels:474C:/
+2600.0 "Crushing Wheel" sync / 1[56]:[^:]*:Marx [LR]:474B:/
+2600.7 "Radiate Heat" sync / 1[56]:[^:]*:Engels:474C:/
+2607.8 "Radiate Heat" sync / 1[56]:[^:]*:Engels:474C:/
+2614.1 "Crushing Wheel" sync / 1[56]:[^:]*:Marx [LR]:474B:/
 # guessing here for enrage ???
-2621.8 "Radiate Heat" sync / 1[56]:Engels:474C:/
-2625.2 "Crushing Wheel Enrage?"  sync / 1[56]:Marx [LR]:474B:/
+2621.8 "Radiate Heat" sync / 1[56]:[^:]*:Engels:474C:/
+2625.2 "Crushing Wheel Enrage?"  sync / 1[56]:[^:]*:Marx [LR]:474B:/
 
 2700.0 "--targetable--" sync / 22:........:Engels:........:Engels:01/ window 150,0
-2706.2 "--sync--" sync / 14:Engels:4733:/ window 150,5
-2709.7 "Surface Missile" sync / 1[56]:Engels:4733:/
-2718.9 "Marx Smash" sync / 1[56]:Engels:472[67AE]:/
-2728.6 "Surface Missile" sync / 1[56]:Engels:4733:/
-2737.9 "Marx Smash" sync / 1[56]:Engels:472[67AE]:/
-2747.0 "Energy Barrage" sync / 1[56]:Engels:473C:/
-2754.8 "Laser Sight" sync / 1[56]:Engels:473A:/
-2765.5 "Energy Blast" sync / 1[56]:Engels:473E:/
-2768.1 "Surface Missile" sync / 1[56]:Engels:4733:/
-2776.8 "Diffuse Laser" sync / 1[56]:Engels:4755:/
-2790.6 "Precision Guided Missile" sync / 1[56]:Engels:4754:/
-2795.0 "Diffuse Laser" sync / 1[56]:Engels:4755:/
-2816.3 "Surface Missile" sync / 1[56]:Engels:4733:/
-2825.5 "Marx Smash" sync / 1[56]:Engels:472[67AE]:/
-2840.7 "Incendiary Bombing" sync / 1[56]:Engels:4739:/
-2845.5 "Marx Smash" sync / 1[56]:Engels:472[67AE]:/
+2706.2 "--sync--" sync / 14:[^:]*:Engels:4733:/ window 150,5
+2709.7 "Surface Missile" sync / 1[56]:[^:]*:Engels:4733:/
+2718.9 "Marx Smash" sync / 1[56]:[^:]*:Engels:472[67AE]:/
+2728.6 "Surface Missile" sync / 1[56]:[^:]*:Engels:4733:/
+2737.9 "Marx Smash" sync / 1[56]:[^:]*:Engels:472[67AE]:/
+2747.0 "Energy Barrage" sync / 1[56]:[^:]*:Engels:473C:/
+2754.8 "Laser Sight" sync / 1[56]:[^:]*:Engels:473A:/
+2765.5 "Energy Blast" sync / 1[56]:[^:]*:Engels:473E:/
+2768.1 "Surface Missile" sync / 1[56]:[^:]*:Engels:4733:/
+2776.8 "Diffuse Laser" sync / 1[56]:[^:]*:Engels:4755:/
+2790.6 "Precision Guided Missile" sync / 1[56]:[^:]*:Engels:4754:/
+2795.0 "Diffuse Laser" sync / 1[56]:[^:]*:Engels:4755:/
+2816.3 "Surface Missile" sync / 1[56]:[^:]*:Engels:4733:/
+2825.5 "Marx Smash" sync / 1[56]:[^:]*:Engels:472[67AE]:/
+2840.7 "Incendiary Bombing" sync / 1[56]:[^:]*:Engels:4739:/
+2845.5 "Marx Smash" sync / 1[56]:[^:]*:Engels:472[67AE]:/
 
 # TODO: it is unclear if this is the actual loop.
 # The log needs to be about ~14 min to verify if the
 # crusher phase happens again or if that's a one time thing.
-2859.3 "Marx Activation" sync / 1[56]:Engels:48A8:/ window 200,200 jump 2448.2
+2859.3 "Marx Activation" sync / 1[56]:[^:]*:Engels:48A8:/ window 200,200 jump 2448.2
 2877.4 "Marx Thrust"
 2887.4 "Marx Thrust"
 2889.6 "Area Bombardment"
@@ -324,47 +324,47 @@ hideall "--sync--"
 ### 9S
 # -ic 2P -p 48F5:3013.3 48E7:3310 48EB:3510 -ii 49C4 48F9 48F7 48DC 485E 48E3 48E6 48E0 48EC 48A5 48A7 48D6 4ABE
 3000.0 "--sync--" sync / 00:0839::The rear deck will be sealed off/ window 3000,0
-3013.3 "Neutralization" sync / 1[56]:9S-Operated Walking Fortress:48F5:/
-3021.5 "Laser Saturation" sync / 1[56]:9S-Operated Walking Fortress:48F6:/
-3030.2 "Laser Turret" sync / 1[56]:9S-Operated Walking Fortress:4A74:/
-3039.7 "Ground-To-Ground Missile" sync / 1[56]:9S-Operated Walking Fortress:4974:/
-3049.3 "Cannons" sync / 1[56]:9S-Operated Walking Fortress:48D[EF]:/
-3056.5 "Cannons" sync / 1[56]:9S-Operated Walking Fortress:48D[EF]:/
-3065.7 "Engage Marx Support" sync / 1[56]:9S-Operated Walking Fortress:48D3:/
-3081.9 "Marx Impact" sync / 1[56]:Marx:48D4:/
-3087.5 "Ground-To-Ground Missile" sync / 1[56]:9S-Operated Walking Fortress:4974:/
-3088.8 "Laser Turret" sync / 1[56]:9S-Operated Walking Fortress:4A74:/
-3094.7 "Laser Saturation" sync / 1[56]:9S-Operated Walking Fortress:48F6:/
+3013.3 "Neutralization" sync / 1[56]:[^:]*:9S-Operated Walking Fortress:48F5:/
+3021.5 "Laser Saturation" sync / 1[56]:[^:]*:9S-Operated Walking Fortress:48F6:/
+3030.2 "Laser Turret" sync / 1[56]:[^:]*:9S-Operated Walking Fortress:4A74:/
+3039.7 "Ground-To-Ground Missile" sync / 1[56]:[^:]*:9S-Operated Walking Fortress:4974:/
+3049.3 "Cannons" sync / 1[56]:[^:]*:9S-Operated Walking Fortress:48D[EF]:/
+3056.5 "Cannons" sync / 1[56]:[^:]*:9S-Operated Walking Fortress:48D[EF]:/
+3065.7 "Engage Marx Support" sync / 1[56]:[^:]*:9S-Operated Walking Fortress:48D3:/
+3081.9 "Marx Impact" sync / 1[56]:[^:]*:Marx:48D4:/
+3087.5 "Ground-To-Ground Missile" sync / 1[56]:[^:]*:9S-Operated Walking Fortress:4974:/
+3088.8 "Laser Turret" sync / 1[56]:[^:]*:9S-Operated Walking Fortress:4A74:/
+3094.7 "Laser Saturation" sync / 1[56]:[^:]*:9S-Operated Walking Fortress:48F6:/
 
 # Dodging Phase
 3108.2 "--untargetable--"
-3108.2 "Undock" sync / 1[56]:9S-Operated Walking Fortress:4B37:/
-3108.5 "--sync--" sync / 1[56]:9S-Operated Flight Unit:4A5D:/
-3123.6 "--sync--" sync / 1[56]:9S-Operated Flight Unit:48D8:/
-3125.7 "--sync--" sync / 1[56]:9S-Operated Walking Fortress:48D9:/
-3128.2 "--sync--" sync / 1[56]:9S-Operated Walking Fortress:48DA:/
-3130.7 "--sync--" sync / 1[56]:9S-Operated Walking Fortress:48DB:/
-3136.7 "--sync--" sync / 1[56]:9S-Operated Flight Unit:4B17:/
-3138.9 "--sync--" sync / 1[56]:9S-Operated Walking Fortress:48D9:/
-3141.4 "--sync--" sync / 1[56]:9S-Operated Walking Fortress:48DA:/
-3143.9 "--sync--" sync / 1[56]:9S-Operated Walking Fortress:48DB:/
-3146.8 "--sync--" sync / 1[56]:9S-Operated Walking Fortress:48DD:/
+3108.2 "Undock" sync / 1[56]:[^:]*:9S-Operated Walking Fortress:4B37:/
+3108.5 "--sync--" sync / 1[56]:[^:]*:9S-Operated Flight Unit:4A5D:/
+3123.6 "--sync--" sync / 1[56]:[^:]*:9S-Operated Flight Unit:48D8:/
+3125.7 "--sync--" sync / 1[56]:[^:]*:9S-Operated Walking Fortress:48D9:/
+3128.2 "--sync--" sync / 1[56]:[^:]*:9S-Operated Walking Fortress:48DA:/
+3130.7 "--sync--" sync / 1[56]:[^:]*:9S-Operated Walking Fortress:48DB:/
+3136.7 "--sync--" sync / 1[56]:[^:]*:9S-Operated Flight Unit:4B17:/
+3138.9 "--sync--" sync / 1[56]:[^:]*:9S-Operated Walking Fortress:48D9:/
+3141.4 "--sync--" sync / 1[56]:[^:]*:9S-Operated Walking Fortress:48DA:/
+3143.9 "--sync--" sync / 1[56]:[^:]*:9S-Operated Walking Fortress:48DB:/
+3146.8 "--sync--" sync / 1[56]:[^:]*:9S-Operated Walking Fortress:48DD:/
 
 3151.7 "--targetable--"
-3152.0 "--sync--" sync / 14:9S-Operated Walking Fortress:48F5:/
-3156.0 "Neutralization" sync / 1[56]:9S-Operated Walking Fortress:48F5:/
-3170.7 "Anti-Personnel Missile" #sync / 1[56]:9S-Operated Walking Fortress:48E4:/
-3172.7 "Anti-Personnel Missile" #sync / 1[56]:9S-Operated Walking Fortress:48E4:/
-3178.3 "Laser Turret" sync / 1[56]:9S-Operated Walking Fortress:4A74:/
+3152.0 "--sync--" sync / 14:[^:]*:9S-Operated Walking Fortress:48F5:/
+3156.0 "Neutralization" sync / 1[56]:[^:]*:9S-Operated Walking Fortress:48F5:/
+3170.7 "Anti-Personnel Missile" #sync / 1[56]:[^:]*:9S-Operated Walking Fortress:48E4:/
+3172.7 "Anti-Personnel Missile" #sync / 1[56]:[^:]*:9S-Operated Walking Fortress:48E4:/
+3178.3 "Laser Turret" sync / 1[56]:[^:]*:9S-Operated Walking Fortress:4A74:/
 
 # Tank Adds
-3187.6 "Engage Goliath Tank Support" sync / 1[56]:9S-Operated Walking Fortress:48E5:/
+3187.6 "Engage Goliath Tank Support" sync / 1[56]:[^:]*:9S-Operated Walking Fortress:48E5:/
 3190.8 "Tank Adds"
-3196.9 "--sync--" sync / 1[56]:9S-Operated Walking Fortress:48F8:/
-3202.5 "Ground-To-Ground Missile" sync / 1[56]:9S-Operated Walking Fortress:4974:/
-3209.2 "Laser Saturation" sync / 1[56]:9S-Operated Walking Fortress:48F6:/
+3196.9 "--sync--" sync / 1[56]:[^:]*:9S-Operated Walking Fortress:48F8:/
+3202.5 "Ground-To-Ground Missile" sync / 1[56]:[^:]*:9S-Operated Walking Fortress:4974:/
+3209.2 "Laser Saturation" sync / 1[56]:[^:]*:9S-Operated Walking Fortress:48F6:/
 
-3217.4 "--sync--" sync / 1[56]:9S-Operated Walking Fortress:48F8:/ window 10,10 jump 3196.9
+3217.4 "--sync--" sync / 1[56]:[^:]*:9S-Operated Walking Fortress:48F8:/ window 10,10 jump 3196.9
 3223.0 "Ground-To-Ground Missile"
 3229.7 "Laser Saturation"
 
@@ -375,81 +375,81 @@ hideall "--sync--"
 3270.7 "Laser Saturation"
 
 # Tank Explosions
-3300.0 "--sync--" sync / 14:9S-Operated Walking Fortress:48E7:/ window 200,0
-3310.0 "Hack Goliath Tank" sync / 1[56]:9S-Operated Walking Fortress:48E7:/
-3310.0 "Convenient Self-Destruction" sync / 1[56]:Goliath Tank:48E8:/
-3313.2 "Ground-To-Ground Missile" sync / 1[56]:9S-Operated Walking Fortress:48F8:/
-3318.9 "Convenient Self-Destruction" sync / 1[56]:Goliath Tank:48E9:/
-3325.4 "Cannons" sync / 1[56]:9S-Operated Walking Fortress:48D[EF]:/
-3336.5 "Laser Saturation" sync / 1[56]:9S-Operated Walking Fortress:48F6:/
-3342.6 "Neutralization" sync / 1[56]:9S-Operated Walking Fortress:48F5:/
+3300.0 "--sync--" sync / 14:[^:]*:9S-Operated Walking Fortress:48E7:/ window 200,0
+3310.0 "Hack Goliath Tank" sync / 1[56]:[^:]*:9S-Operated Walking Fortress:48E7:/
+3310.0 "Convenient Self-Destruction" sync / 1[56]:[^:]*:Goliath Tank:48E8:/
+3313.2 "Ground-To-Ground Missile" sync / 1[56]:[^:]*:9S-Operated Walking Fortress:48F8:/
+3318.9 "Convenient Self-Destruction" sync / 1[56]:[^:]*:Goliath Tank:48E9:/
+3325.4 "Cannons" sync / 1[56]:[^:]*:9S-Operated Walking Fortress:48D[EF]:/
+3336.5 "Laser Saturation" sync / 1[56]:[^:]*:9S-Operated Walking Fortress:48F6:/
+3342.6 "Neutralization" sync / 1[56]:[^:]*:9S-Operated Walking Fortress:48F5:/
 
 # Three Adds
 # Adds independently can do Sidestriking or Centrifugal spin.
 3353.5 "--untargetable--"
-3353.6 "--sync--" sync / 1[56]:9S-Operated Walking Fortress:48EA:/
+3353.6 "--sync--" sync / 1[56]:[^:]*:9S-Operated Walking Fortress:48EA:/
 3360.0 "Serial-Jointed Adds"
 3362.7 "--targetable--"
-3379.8 "Clanging Blow" sync / 1[56]:Serial-jointed Service Model:48F0:/
-3392.0 "Shrapnel Impact" sync / 1[56]:9S-Operated Walking Fortress:48F3:/
-3398.0 "Spin" sync / 1[56]:Serial-jointed Service Model:4A8[46]:/
-3407.1 "Clanging Blow" sync / 1[56]:Serial-jointed Service Model:48F0:/
-3421.4 "Shrapnel Impact" sync / 1[56]:9S-Operated Walking Fortress:48F3:/
-3422.3 "Spin" sync / 1[56]:Serial-jointed Service Model:4A8[46]:/
+3379.8 "Clanging Blow" sync / 1[56]:[^:]*:Serial-jointed Service Model:48F0:/
+3392.0 "Shrapnel Impact" sync / 1[56]:[^:]*:9S-Operated Walking Fortress:48F3:/
+3398.0 "Spin" sync / 1[56]:[^:]*:Serial-jointed Service Model:4A8[46]:/
+3407.1 "Clanging Blow" sync / 1[56]:[^:]*:Serial-jointed Service Model:48F0:/
+3421.4 "Shrapnel Impact" sync / 1[56]:[^:]*:9S-Operated Walking Fortress:48F3:/
+3422.3 "Spin" sync / 1[56]:[^:]*:Serial-jointed Service Model:4A8[46]:/
 3432.7 "Enrage?" # 70s ???
 
-3500.0 "--sync--" sync / 14:9S-Operated Walking Fortress:48EB:/ window 300,0
-3510.0 "Total Annihilation Maneuver" sync / 1[56]:9S-Operated Walking Fortress:48EB:/
+3500.0 "--sync--" sync / 14:[^:]*:9S-Operated Walking Fortress:48EB:/ window 300,0
+3510.0 "Total Annihilation Maneuver" sync / 1[56]:[^:]*:9S-Operated Walking Fortress:48EB:/
 3520.0 "--targetable--"
-3530.1 "Neutralization" sync / 1[56]:9S-Operated Walking Fortress:48F5:/
-3541.9 "Ground-To-Ground Missile" sync / 1[56]:9S-Operated Walking Fortress:4974:/
-3543.2 "Laser Turret" sync / 1[56]:9S-Operated Walking Fortress:4A74:/
-3562.0 "Anti-Personnel Missile" # sync / 1[56]:9S-Operated Walking Fortress:48E4:/
-3564.0 "Anti-Personnel Missile" # sync / 1[56]:9S-Operated Walking Fortress:48E4:/
-3566.0 "Anti-Personnel Missile" # sync / 1[56]:9S-Operated Walking Fortress:48E4:/
-3573.0 "Cannons" sync / 1[56]:9S-Operated Walking Fortress:48D[EF]:/
-3581.1 "Laser Saturation" sync / 1[56]:9S-Operated Walking Fortress:48F6:/
+3530.1 "Neutralization" sync / 1[56]:[^:]*:9S-Operated Walking Fortress:48F5:/
+3541.9 "Ground-To-Ground Missile" sync / 1[56]:[^:]*:9S-Operated Walking Fortress:4974:/
+3543.2 "Laser Turret" sync / 1[56]:[^:]*:9S-Operated Walking Fortress:4A74:/
+3562.0 "Anti-Personnel Missile" # sync / 1[56]:[^:]*:9S-Operated Walking Fortress:48E4:/
+3564.0 "Anti-Personnel Missile" # sync / 1[56]:[^:]*:9S-Operated Walking Fortress:48E4:/
+3566.0 "Anti-Personnel Missile" # sync / 1[56]:[^:]*:9S-Operated Walking Fortress:48E4:/
+3573.0 "Cannons" sync / 1[56]:[^:]*:9S-Operated Walking Fortress:48D[EF]:/
+3581.1 "Laser Saturation" sync / 1[56]:[^:]*:9S-Operated Walking Fortress:48F6:/
 
 3591.1 "--untargetable--"
-3591.1 "Undock" sync / 1[56]:9S-Operated Walking Fortress:48D5:/
-3600.3 "--sync--" sync / 1[56]:9S-Operated Flight Unit:48D8:/
-3602.4 "--sync--" sync / 1[56]:9S-Operated Walking Fortress:48D9:/
-3604.9 "--sync--" sync / 1[56]:9S-Operated Walking Fortress:48DA:/
-3607.4 "--sync--" sync / 1[56]:9S-Operated Walking Fortress:48DB:/
-3611.4 "Anti-Personnel Missile" sync / 1[56]:9S-Operated Walking Fortress:4B11:/
-3614.6 "--sync--" sync / 1[56]:9S-Operated Flight Unit:48D8:/
-3616.7 "--sync--" sync / 1[56]:9S-Operated Walking Fortress:48D9:/
-3619.2 "--sync--" sync / 1[56]:9S-Operated Walking Fortress:48DA:/
-3621.7 "--sync--" sync / 1[56]:9S-Operated Walking Fortress:48DB:/
-3627.6 "Anti-Personnel Missile" sync / 1[56]:9S-Operated Walking Fortress:4B11:/
-3628.7 "--sync--" sync / 1[56]:9S-Operated Flight Unit:4B17:/
-3630.8 "--sync--" sync / 1[56]:9S-Operated Walking Fortress:48D9:/
-3633.3 "--sync--" sync / 1[56]:9S-Operated Walking Fortress:48DA:/
-3635.8 "--sync--" sync / 1[56]:9S-Operated Walking Fortress:48DB:/
-3638.8 "--sync--" sync / 1[56]:9S-Operated Walking Fortress:48DD:/
+3591.1 "Undock" sync / 1[56]:[^:]*:9S-Operated Walking Fortress:48D5:/
+3600.3 "--sync--" sync / 1[56]:[^:]*:9S-Operated Flight Unit:48D8:/
+3602.4 "--sync--" sync / 1[56]:[^:]*:9S-Operated Walking Fortress:48D9:/
+3604.9 "--sync--" sync / 1[56]:[^:]*:9S-Operated Walking Fortress:48DA:/
+3607.4 "--sync--" sync / 1[56]:[^:]*:9S-Operated Walking Fortress:48DB:/
+3611.4 "Anti-Personnel Missile" sync / 1[56]:[^:]*:9S-Operated Walking Fortress:4B11:/
+3614.6 "--sync--" sync / 1[56]:[^:]*:9S-Operated Flight Unit:48D8:/
+3616.7 "--sync--" sync / 1[56]:[^:]*:9S-Operated Walking Fortress:48D9:/
+3619.2 "--sync--" sync / 1[56]:[^:]*:9S-Operated Walking Fortress:48DA:/
+3621.7 "--sync--" sync / 1[56]:[^:]*:9S-Operated Walking Fortress:48DB:/
+3627.6 "Anti-Personnel Missile" sync / 1[56]:[^:]*:9S-Operated Walking Fortress:4B11:/
+3628.7 "--sync--" sync / 1[56]:[^:]*:9S-Operated Flight Unit:4B17:/
+3630.8 "--sync--" sync / 1[56]:[^:]*:9S-Operated Walking Fortress:48D9:/
+3633.3 "--sync--" sync / 1[56]:[^:]*:9S-Operated Walking Fortress:48DA:/
+3635.8 "--sync--" sync / 1[56]:[^:]*:9S-Operated Walking Fortress:48DB:/
+3638.8 "--sync--" sync / 1[56]:[^:]*:9S-Operated Walking Fortress:48DD:/
 
 3643.8 "--targetable--"
-3643.9 "--sync--" sync / 14:9S-Operated Walking Fortress:48F6:/ window 10,10
-3647.9 "Laser Saturation" sync / 1[56]:9S-Operated Walking Fortress:48F6:/
-3659.3 "Engage Marx Support" sync / 1[56]:9S-Operated Walking Fortress:48D3:/
-3674.5 "Ground-To-Ground Missile" sync / 1[56]:9S-Operated Walking Fortress:48F8:/
-3675.6 "Marx Impact" sync / 1[56]:Marx:48D4:/
-3681.6 "Cannons" sync / 1[56]:9S-Operated Walking Fortress:48D[EF]:/
-3693.9 "Neutralization" sync / 1[56]:9S-Operated Walking Fortress:48F5:/
-3705.7 "Ground-To-Ground Missile" sync / 1[56]:9S-Operated Walking Fortress:4974:/
-3706.9 "Laser Turret" sync / 1[56]:9S-Operated Walking Fortress:4A74:/
-3724.3 "Anti-Personnel Missile" #sync / 1[56]:9S-Operated Walking Fortress:48E4:/
-3726.3 "Anti-Personnel Missile" #sync / 1[56]:9S-Operated Walking Fortress:48E4:/
-3728.3 "Anti-Personnel Missile" #sync / 1[56]:9S-Operated Walking Fortress:48E4:/
-3735.4 "Cannons" sync / 1[56]:9S-Operated Walking Fortress:48D[EF]:/
-3743.5 "Laser Saturation" sync / 1[56]:9S-Operated Walking Fortress:48F6:/
-3755.3 "Ground-To-Ground Missile" sync / 1[56]:9S-Operated Walking Fortress:4974:/
-3756.5 "Laser Turret" sync / 1[56]:9S-Operated Walking Fortress:4A74:/
-3763.4 "Cannons" sync / 1[56]:9S-Operated Walking Fortress:48D[EF]:/
-3773.5 "Neutralization" sync / 1[56]:9S-Operated Walking Fortress:48F5:/
-3783.6 "Laser Saturation" sync / 1[56]:9S-Operated Walking Fortress:48F6:/
+3643.9 "--sync--" sync / 14:[^:]*:9S-Operated Walking Fortress:48F6:/ window 10,10
+3647.9 "Laser Saturation" sync / 1[56]:[^:]*:9S-Operated Walking Fortress:48F6:/
+3659.3 "Engage Marx Support" sync / 1[56]:[^:]*:9S-Operated Walking Fortress:48D3:/
+3674.5 "Ground-To-Ground Missile" sync / 1[56]:[^:]*:9S-Operated Walking Fortress:48F8:/
+3675.6 "Marx Impact" sync / 1[56]:[^:]*:Marx:48D4:/
+3681.6 "Cannons" sync / 1[56]:[^:]*:9S-Operated Walking Fortress:48D[EF]:/
+3693.9 "Neutralization" sync / 1[56]:[^:]*:9S-Operated Walking Fortress:48F5:/
+3705.7 "Ground-To-Ground Missile" sync / 1[56]:[^:]*:9S-Operated Walking Fortress:4974:/
+3706.9 "Laser Turret" sync / 1[56]:[^:]*:9S-Operated Walking Fortress:4A74:/
+3724.3 "Anti-Personnel Missile" #sync / 1[56]:[^:]*:9S-Operated Walking Fortress:48E4:/
+3726.3 "Anti-Personnel Missile" #sync / 1[56]:[^:]*:9S-Operated Walking Fortress:48E4:/
+3728.3 "Anti-Personnel Missile" #sync / 1[56]:[^:]*:9S-Operated Walking Fortress:48E4:/
+3735.4 "Cannons" sync / 1[56]:[^:]*:9S-Operated Walking Fortress:48D[EF]:/
+3743.5 "Laser Saturation" sync / 1[56]:[^:]*:9S-Operated Walking Fortress:48F6:/
+3755.3 "Ground-To-Ground Missile" sync / 1[56]:[^:]*:9S-Operated Walking Fortress:4974:/
+3756.5 "Laser Turret" sync / 1[56]:[^:]*:9S-Operated Walking Fortress:4A74:/
+3763.4 "Cannons" sync / 1[56]:[^:]*:9S-Operated Walking Fortress:48D[EF]:/
+3773.5 "Neutralization" sync / 1[56]:[^:]*:9S-Operated Walking Fortress:48F5:/
+3783.6 "Laser Saturation" sync / 1[56]:[^:]*:9S-Operated Walking Fortress:48F6:/
 
-3794.8 "Engage Marx Support" sync / 1[56]:9S-Operated Walking Fortress:48D3:/ window 100,100 jump 3659.3
+3794.8 "Engage Marx Support" sync / 1[56]:[^:]*:9S-Operated Walking Fortress:48D3:/ window 100,100 jump 3659.3
 3810.0 "Ground-To-Ground Missile"
 3811.1 "Marx Impact"
 3817.1 "Cannons"

--- a/ui/raidboss/data/05-shb/alliance/the_puppets_bunker.txt
+++ b/ui/raidboss/data/05-shb/alliance/the_puppets_bunker.txt
@@ -9,123 +9,123 @@ hideall "--sync--"
 # -p 508D:112.8 -ii 5074 5075 5076 5091 5092 5081 5099 507E 5090 51BC
 
 100.0 "--sync--" sync / 00:0839::The elevated detritus will be sealed off/ window 100,0
-112.8 "Firing Order: Anti-Personnel Laser" sync / 1[56]:813P-Operated Aegis Unit:508D:/ window 20,20
-125.1 "--sync--" sync / 1[56]:813P-Operated Aegis Unit:507[789A]:/
-140.1 "Maneuver: Beam Cannons" sync / 1[56]:813P-Operated Aegis Unit:5073:/
-158.4 "Maneuver: Collider Cannons" sync / 1[56]:813P-Operated Aegis Unit:507[BCD]:/
-170.6 "Firing Order: Surface Laser" sync / 1[56]:813P-Operated Aegis Unit:508E:/
-177.7 "Aerial Support: Swoop" sync / 1[56]:813P-Operated Aegis Unit:50D2:/
-187.8 "Flight Path" sync / 1[56]:Flight Unit:508C:/
-197.9 "Maneuver: Refraction Cannons" sync / 1[56]:813P-Operated Aegis Unit:(507F|5080):/
-206.2 "--sync--" sync / 1[56]:813P-Operated Aegis Unit:507[789A]:/
-220.2 "Maneuver: Beam Cannons" sync / 1[56]:813P-Operated Aegis Unit:5073:/
-239.6 "Aerial Support: Bombardment" sync / 1[56]:813P-Operated Aegis Unit:50D3:/
+112.8 "Firing Order: Anti-Personnel Laser" sync / 1[56]:[^:]*:813P-Operated Aegis Unit:508D:/ window 20,20
+125.1 "--sync--" sync / 1[56]:[^:]*:813P-Operated Aegis Unit:507[789A]:/
+140.1 "Maneuver: Beam Cannons" sync / 1[56]:[^:]*:813P-Operated Aegis Unit:5073:/
+158.4 "Maneuver: Collider Cannons" sync / 1[56]:[^:]*:813P-Operated Aegis Unit:507[BCD]:/
+170.6 "Firing Order: Surface Laser" sync / 1[56]:[^:]*:813P-Operated Aegis Unit:508E:/
+177.7 "Aerial Support: Swoop" sync / 1[56]:[^:]*:813P-Operated Aegis Unit:50D2:/
+187.8 "Flight Path" sync / 1[56]:[^:]*:Flight Unit:508C:/
+197.9 "Maneuver: Refraction Cannons" sync / 1[56]:[^:]*:813P-Operated Aegis Unit:(507F|5080):/
+206.2 "--sync--" sync / 1[56]:[^:]*:813P-Operated Aegis Unit:507[789A]:/
+220.2 "Maneuver: Beam Cannons" sync / 1[56]:[^:]*:813P-Operated Aegis Unit:5073:/
+239.6 "Aerial Support: Bombardment" sync / 1[56]:[^:]*:813P-Operated Aegis Unit:50D3:/
 244.4 "--adds targetable--"
-249.8 "Firing Order: Surface Laser" sync / 1[56]:813P-Operated Aegis Unit:508E:/
-256.0 "Firing Order: High-Powered Laser" sync / 1[56]:813P-Operated Aegis Unit:508F:/
-263.3 "High-Powered Laser" sync / 1[56]:813P-Operated Aegis Unit:5093:/
-269.5 "Maneuver: Saturation Bombing?" sync / 1[56]:Flight Unit:5097:/
+249.8 "Firing Order: Surface Laser" sync / 1[56]:[^:]*:813P-Operated Aegis Unit:508E:/
+256.0 "Firing Order: High-Powered Laser" sync / 1[56]:[^:]*:813P-Operated Aegis Unit:508F:/
+263.3 "High-Powered Laser" sync / 1[56]:[^:]*:813P-Operated Aegis Unit:5093:/
+269.5 "Maneuver: Saturation Bombing?" sync / 1[56]:[^:]*:Flight Unit:5097:/
 
 # Singing Rotation 1
-280.3 "--sync--" sync / 1[56]:813P-Operated Aegis Unit:53B2:/
-287.8 "Life's Last Song" sync / 1[56]:813P-Operated Aegis Unit:53B3:/
-288.3 "--sync--" sync / 1[56]:813P-Operated Aegis Unit:53B2:/
-295.8 "Life's Last Song" sync / 1[56]:813P-Operated Aegis Unit:53B3:/
-296.3 "--sync--" sync / 1[56]:813P-Operated Aegis Unit:53B2:/
-303.8 "Life's Last Song" sync / 1[56]:813P-Operated Aegis Unit:53B3:/
-309.3 "Aerial Support: Swoop" sync / 1[56]:813P-Operated Aegis Unit:50D2:/
-317.4 "Maneuver: Refraction Cannons" sync / 1[56]:813P-Operated Aegis Unit:(507F|5080):/
-319.4 "Flight Path" sync / 1[56]:Flight Unit:508C:/
-328.5 "Firing Order: Surface Laser" sync / 1[56]:813P-Operated Aegis Unit:508E:/
-330.7 "--sync--" sync / 1[56]:813P-Operated Aegis Unit:507[789A]:/
-345.7 "Maneuver: Beam Cannons" sync / 1[56]:813P-Operated Aegis Unit:5073:/
-349.8 "--sync--" sync / 1[56]:813P-Operated Aegis Unit:53B2:/
+280.3 "--sync--" sync / 1[56]:[^:]*:813P-Operated Aegis Unit:53B2:/
+287.8 "Life's Last Song" sync / 1[56]:[^:]*:813P-Operated Aegis Unit:53B3:/
+288.3 "--sync--" sync / 1[56]:[^:]*:813P-Operated Aegis Unit:53B2:/
+295.8 "Life's Last Song" sync / 1[56]:[^:]*:813P-Operated Aegis Unit:53B3:/
+296.3 "--sync--" sync / 1[56]:[^:]*:813P-Operated Aegis Unit:53B2:/
+303.8 "Life's Last Song" sync / 1[56]:[^:]*:813P-Operated Aegis Unit:53B3:/
+309.3 "Aerial Support: Swoop" sync / 1[56]:[^:]*:813P-Operated Aegis Unit:50D2:/
+317.4 "Maneuver: Refraction Cannons" sync / 1[56]:[^:]*:813P-Operated Aegis Unit:(507F|5080):/
+319.4 "Flight Path" sync / 1[56]:[^:]*:Flight Unit:508C:/
+328.5 "Firing Order: Surface Laser" sync / 1[56]:[^:]*:813P-Operated Aegis Unit:508E:/
+330.7 "--sync--" sync / 1[56]:[^:]*:813P-Operated Aegis Unit:507[789A]:/
+345.7 "Maneuver: Beam Cannons" sync / 1[56]:[^:]*:813P-Operated Aegis Unit:5073:/
+349.8 "--sync--" sync / 1[56]:[^:]*:813P-Operated Aegis Unit:53B2:/
 
 # Singing Rotation 2
-354.8 "--sync--" sync / 1[56]:813P-Operated Aegis Unit:53B2:/
-357.3 "Life's Last Song" sync / 1[56]:813P-Operated Aegis Unit:53B3:/
-359.8 "--sync--" sync / 1[56]:813P-Operated Aegis Unit:53B2:/
-362.3 "Life's Last Song" sync / 1[56]:813P-Operated Aegis Unit:53B3:/
-364.8 "--sync--" sync / 1[56]:813P-Operated Aegis Unit:53B2:/
-367.3 "Life's Last Song" sync / 1[56]:813P-Operated Aegis Unit:53B3:/
-369.8 "--sync--" sync / 1[56]:813P-Operated Aegis Unit:53B2:/
-372.3 "Life's Last Song" sync / 1[56]:813P-Operated Aegis Unit:53B3:/
-377.3 "Life's Last Song" sync / 1[56]:813P-Operated Aegis Unit:53B3:/
-382.8 "Aerial Support: Swoop" sync / 1[56]:813P-Operated Aegis Unit:50D2:/
-392.9 "Flight Path" sync / 1[56]:Flight Unit:508C:/
-394.4 "Maneuver: Collider Cannons" sync / 1[56]:813P-Operated Aegis Unit:507[BCD]:/
-411.7 "Firing Order: Anti-Personnel Laser" sync / 1[56]:813P-Operated Aegis Unit:508D:/
-422.3 "Maneuver: Collider Cannons" sync / 1[56]:813P-Operated Aegis Unit:507[BCD]:/
-441.6 "Firing Order: Surface Laser" sync / 1[56]:813P-Operated Aegis Unit:508E:/
-443.8 "--sync--" sync / 1[56]:813P-Operated Aegis Unit:507[789A]:/
-458.8 "Maneuver: Beam Cannons" sync / 1[56]:813P-Operated Aegis Unit:5073:/
-462.9 "--sync--" sync / 1[56]:813P-Operated Aegis Unit:53B2:/
+354.8 "--sync--" sync / 1[56]:[^:]*:813P-Operated Aegis Unit:53B2:/
+357.3 "Life's Last Song" sync / 1[56]:[^:]*:813P-Operated Aegis Unit:53B3:/
+359.8 "--sync--" sync / 1[56]:[^:]*:813P-Operated Aegis Unit:53B2:/
+362.3 "Life's Last Song" sync / 1[56]:[^:]*:813P-Operated Aegis Unit:53B3:/
+364.8 "--sync--" sync / 1[56]:[^:]*:813P-Operated Aegis Unit:53B2:/
+367.3 "Life's Last Song" sync / 1[56]:[^:]*:813P-Operated Aegis Unit:53B3:/
+369.8 "--sync--" sync / 1[56]:[^:]*:813P-Operated Aegis Unit:53B2:/
+372.3 "Life's Last Song" sync / 1[56]:[^:]*:813P-Operated Aegis Unit:53B3:/
+377.3 "Life's Last Song" sync / 1[56]:[^:]*:813P-Operated Aegis Unit:53B3:/
+382.8 "Aerial Support: Swoop" sync / 1[56]:[^:]*:813P-Operated Aegis Unit:50D2:/
+392.9 "Flight Path" sync / 1[56]:[^:]*:Flight Unit:508C:/
+394.4 "Maneuver: Collider Cannons" sync / 1[56]:[^:]*:813P-Operated Aegis Unit:507[BCD]:/
+411.7 "Firing Order: Anti-Personnel Laser" sync / 1[56]:[^:]*:813P-Operated Aegis Unit:508D:/
+422.3 "Maneuver: Collider Cannons" sync / 1[56]:[^:]*:813P-Operated Aegis Unit:507[BCD]:/
+441.6 "Firing Order: Surface Laser" sync / 1[56]:[^:]*:813P-Operated Aegis Unit:508E:/
+443.8 "--sync--" sync / 1[56]:[^:]*:813P-Operated Aegis Unit:507[789A]:/
+458.8 "Maneuver: Beam Cannons" sync / 1[56]:[^:]*:813P-Operated Aegis Unit:5073:/
+462.9 "--sync--" sync / 1[56]:[^:]*:813P-Operated Aegis Unit:53B2:/
 
 # Singing Rotation Loop
-467.9 "--sync--" sync / 1[56]:813P-Operated Aegis Unit:53B2:/
-470.3 "Life's Last Song" sync / 1[56]:813P-Operated Aegis Unit:53B3:/
-472.8 "--sync--" sync / 1[56]:813P-Operated Aegis Unit:53B2:/
-475.3 "Life's Last Song" sync / 1[56]:813P-Operated Aegis Unit:53B3:/
-477.8 "--sync--" sync / 1[56]:813P-Operated Aegis Unit:53B2:/
-480.3 "Life's Last Song" sync / 1[56]:813P-Operated Aegis Unit:53B3:/
-482.8 "--sync--" sync / 1[56]:813P-Operated Aegis Unit:53B2:/
-485.2 "Life's Last Song" sync / 1[56]:813P-Operated Aegis Unit:53B3:/
-490.2 "Life's Last Song" sync / 1[56]:813P-Operated Aegis Unit:53B3:/
-495.7 "Aerial Support: Swoop" sync / 1[56]:813P-Operated Aegis Unit:50D2:/
-503.8 "Maneuver: Refraction Cannons" sync / 1[56]:813P-Operated Aegis Unit:(507F|5080):/
-505.8 "Flight Path" sync / 1[56]:Flight Unit:508C:/
-521.1 "Firing Order: Anti-Personnel Laser" sync / 1[56]:813P-Operated Aegis Unit:508D:/
-531.1 "Maneuver: Collider Cannons" sync / 1[56]:813P-Operated Aegis Unit:507[BCD]:/
-550.5 "Firing Order: Surface Laser" sync / 1[56]:813P-Operated Aegis Unit:508E:/
-552.7 "--sync--" sync / 1[56]:813P-Operated Aegis Unit:507[789A]:/
-566.7 "Maneuver: Beam Cannons" sync / 1[56]:813P-Operated Aegis Unit:5073:/
-570.8 "--sync--" sync / 1[56]:813P-Operated Aegis Unit:53B2:/
+467.9 "--sync--" sync / 1[56]:[^:]*:813P-Operated Aegis Unit:53B2:/
+470.3 "Life's Last Song" sync / 1[56]:[^:]*:813P-Operated Aegis Unit:53B3:/
+472.8 "--sync--" sync / 1[56]:[^:]*:813P-Operated Aegis Unit:53B2:/
+475.3 "Life's Last Song" sync / 1[56]:[^:]*:813P-Operated Aegis Unit:53B3:/
+477.8 "--sync--" sync / 1[56]:[^:]*:813P-Operated Aegis Unit:53B2:/
+480.3 "Life's Last Song" sync / 1[56]:[^:]*:813P-Operated Aegis Unit:53B3:/
+482.8 "--sync--" sync / 1[56]:[^:]*:813P-Operated Aegis Unit:53B2:/
+485.2 "Life's Last Song" sync / 1[56]:[^:]*:813P-Operated Aegis Unit:53B3:/
+490.2 "Life's Last Song" sync / 1[56]:[^:]*:813P-Operated Aegis Unit:53B3:/
+495.7 "Aerial Support: Swoop" sync / 1[56]:[^:]*:813P-Operated Aegis Unit:50D2:/
+503.8 "Maneuver: Refraction Cannons" sync / 1[56]:[^:]*:813P-Operated Aegis Unit:(507F|5080):/
+505.8 "Flight Path" sync / 1[56]:[^:]*:Flight Unit:508C:/
+521.1 "Firing Order: Anti-Personnel Laser" sync / 1[56]:[^:]*:813P-Operated Aegis Unit:508D:/
+531.1 "Maneuver: Collider Cannons" sync / 1[56]:[^:]*:813P-Operated Aegis Unit:507[BCD]:/
+550.5 "Firing Order: Surface Laser" sync / 1[56]:[^:]*:813P-Operated Aegis Unit:508E:/
+552.7 "--sync--" sync / 1[56]:[^:]*:813P-Operated Aegis Unit:507[789A]:/
+566.7 "Maneuver: Beam Cannons" sync / 1[56]:[^:]*:813P-Operated Aegis Unit:5073:/
+570.8 "--sync--" sync / 1[56]:[^:]*:813P-Operated Aegis Unit:53B2:/
 
 # lookahead loop
-575.8 "--sync--" sync / 1[56]:813P-Operated Aegis Unit:53B2:/
-578.2 "Life's Last Song" sync / 1[56]:813P-Operated Aegis Unit:53B3:/
-580.7 "--sync--" sync / 1[56]:813P-Operated Aegis Unit:53B2:/
-583.2 "Life's Last Song" sync / 1[56]:813P-Operated Aegis Unit:53B3:/
-585.7 "--sync--" sync / 1[56]:813P-Operated Aegis Unit:53B2:/
-588.2 "Life's Last Song" sync / 1[56]:813P-Operated Aegis Unit:53B3:/
-590.7 "--sync--" sync / 1[56]:813P-Operated Aegis Unit:53B2:/
-593.1 "Life's Last Song" sync / 1[56]:813P-Operated Aegis Unit:53B3:/
-598.1 "Life's Last Song" sync / 1[56]:813P-Operated Aegis Unit:53B3:/
-603.6 "Aerial Support: Swoop" sync / 1[56]:813P-Operated Aegis Unit:50D2:/ window 100,100 jump 495.7
-611.7 "Maneuver: Refraction Cannons" #sync / 1[56]:813P-Operated Aegis Unit:(507F|5080):/
-613.7 "Flight Path" #sync / 1[56]:Flight Unit:508C:/
-629.0 "Firing Order: Anti-Personnel Laser" #sync / 1[56]:813P-Operated Aegis Unit:508D:/
-639.0 "Maneuver: Collider Cannons" #sync / 1[56]:813P-Operated Aegis Unit:507[BCD]:/
-658.4 "Firing Order: Surface Laser" #sync / 1[56]:813P-Operated Aegis Unit:508E:/
-660.6 "--sync--" #sync / 1[56]:813P-Operated Aegis Unit:507[789A]:/
-674.6 "Maneuver: Beam Cannons" #sync / 1[56]:813P-Operated Aegis Unit:5073:/
-678.7 "--sync--" #sync / 1[56]:813P-Operated Aegis Unit:53B2:/
+575.8 "--sync--" sync / 1[56]:[^:]*:813P-Operated Aegis Unit:53B2:/
+578.2 "Life's Last Song" sync / 1[56]:[^:]*:813P-Operated Aegis Unit:53B3:/
+580.7 "--sync--" sync / 1[56]:[^:]*:813P-Operated Aegis Unit:53B2:/
+583.2 "Life's Last Song" sync / 1[56]:[^:]*:813P-Operated Aegis Unit:53B3:/
+585.7 "--sync--" sync / 1[56]:[^:]*:813P-Operated Aegis Unit:53B2:/
+588.2 "Life's Last Song" sync / 1[56]:[^:]*:813P-Operated Aegis Unit:53B3:/
+590.7 "--sync--" sync / 1[56]:[^:]*:813P-Operated Aegis Unit:53B2:/
+593.1 "Life's Last Song" sync / 1[56]:[^:]*:813P-Operated Aegis Unit:53B3:/
+598.1 "Life's Last Song" sync / 1[56]:[^:]*:813P-Operated Aegis Unit:53B3:/
+603.6 "Aerial Support: Swoop" sync / 1[56]:[^:]*:813P-Operated Aegis Unit:50D2:/ window 100,100 jump 495.7
+611.7 "Maneuver: Refraction Cannons" #sync / 1[56]:[^:]*:813P-Operated Aegis Unit:(507F|5080):/
+613.7 "Flight Path" #sync / 1[56]:[^:]*:Flight Unit:508C:/
+629.0 "Firing Order: Anti-Personnel Laser" #sync / 1[56]:[^:]*:813P-Operated Aegis Unit:508D:/
+639.0 "Maneuver: Collider Cannons" #sync / 1[56]:[^:]*:813P-Operated Aegis Unit:507[BCD]:/
+658.4 "Firing Order: Surface Laser" #sync / 1[56]:[^:]*:813P-Operated Aegis Unit:508E:/
+660.6 "--sync--" #sync / 1[56]:[^:]*:813P-Operated Aegis Unit:507[789A]:/
+674.6 "Maneuver: Beam Cannons" #sync / 1[56]:[^:]*:813P-Operated Aegis Unit:5073:/
+678.7 "--sync--" #sync / 1[56]:[^:]*:813P-Operated Aegis Unit:53B2:/
 
 
 ### Light Artillery Unit x3 and friends
 # -ic "Yorha Close-Combat Unit: Spear" "Yorha Close-Combat Unit: Blade" "Yorha Close-Combat Unit: Martial"
 # -p 5212:1013.9 -ii 5214
 1000.0 "--sync--" sync / 00:0839::The sunken detritus will be sealed off/ window 1000,0
-1013.9 "Maneuver: Long-Barreled Laser" sync / 1[56]:Light Artillery Unit:5212:/ window 20,20
-1025.7 "Maneuver: Volt Array" sync / 1[56]:Light Artillery Unit:5211:/
-1036.0 "Authorization: No Restrictions" sync / 1[56]:Light Artillery Unit:520E:/
-1041.7 "Surface Missile Impact" sync / 1[56]:Light Artillery Unit:520F:/
-1043.7 "Homing Missile Impact" sync / 1[56]:Light Artillery Unit:5210:/
+1013.9 "Maneuver: Long-Barreled Laser" sync / 1[56]:[^:]*:Light Artillery Unit:5212:/ window 20,20
+1025.7 "Maneuver: Volt Array" sync / 1[56]:[^:]*:Light Artillery Unit:5211:/
+1036.0 "Authorization: No Restrictions" sync / 1[56]:[^:]*:Light Artillery Unit:520E:/
+1041.7 "Surface Missile Impact" sync / 1[56]:[^:]*:Light Artillery Unit:520F:/
+1043.7 "Homing Missile Impact" sync / 1[56]:[^:]*:Light Artillery Unit:5210:/
 
-1052.7 "Maneuver: Long-Barreled Laser" sync / 1[56]:Light Artillery Unit:5212:/
-1059.5 "Maneuver: Long-Barreled Laser" sync / 1[56]:Light Artillery Unit:5212:/
-1070.2 "Maneuver: Volt Array" sync / 1[56]:Light Artillery Unit:5211:/
-1086.7 "Maneuver: Martial Arm" sync / 1[56]:Light Artillery Unit:5213:/
-1097.1 "Maneuver: Martial Arm" sync / 1[56]:Light Artillery Unit:5213:/
-1103.5 "Maneuver: Long-Barreled Laser" sync / 1[56]:Light Artillery Unit:5212:/
+1052.7 "Maneuver: Long-Barreled Laser" sync / 1[56]:[^:]*:Light Artillery Unit:5212:/
+1059.5 "Maneuver: Long-Barreled Laser" sync / 1[56]:[^:]*:Light Artillery Unit:5212:/
+1070.2 "Maneuver: Volt Array" sync / 1[56]:[^:]*:Light Artillery Unit:5211:/
+1086.7 "Maneuver: Martial Arm" sync / 1[56]:[^:]*:Light Artillery Unit:5213:/
+1097.1 "Maneuver: Martial Arm" sync / 1[56]:[^:]*:Light Artillery Unit:5213:/
+1103.5 "Maneuver: Long-Barreled Laser" sync / 1[56]:[^:]*:Light Artillery Unit:5212:/
 
-1103.7 "Maneuver: Long-Barreled Laser" sync / 1[56]:Light Artillery Unit:5212:/
-1119.6 "Maneuver: Volt Array" sync / 1[56]:Light Artillery Unit:5211:/
-1129.9 "Authorization: No Restrictions" sync / 1[56]:Light Artillery Unit:520E:/ window 50,50 jump 1036.0
-1135.6 "Surface Missile Impact" #sync / 1[56]:Light Artillery Unit:520F:/
-1137.6 "Homing Missile Impact" #sync / 1[56]:Light Artillery Unit:5210:/
-1153.7 "Initiate Self-Destruct" #sync / 1[56]:Light Artillery Unit:5215:/
-1153.7 "Initiate Self-Destruct" #sync / 1[56]:Light Artillery Unit:5215:/
+1103.7 "Maneuver: Long-Barreled Laser" sync / 1[56]:[^:]*:Light Artillery Unit:5212:/
+1119.6 "Maneuver: Volt Array" sync / 1[56]:[^:]*:Light Artillery Unit:5211:/
+1129.9 "Authorization: No Restrictions" sync / 1[56]:[^:]*:Light Artillery Unit:520E:/ window 50,50 jump 1036.0
+1135.6 "Surface Missile Impact" #sync / 1[56]:[^:]*:Light Artillery Unit:520F:/
+1137.6 "Homing Missile Impact" #sync / 1[56]:[^:]*:Light Artillery Unit:5210:/
+1153.7 "Initiate Self-Destruct" #sync / 1[56]:[^:]*:Light Artillery Unit:5215:/
+1153.7 "Initiate Self-Destruct" #sync / 1[56]:[^:]*:Light Artillery Unit:5215:/
 
 
 ### Superior Flight Unit Swordy Boi Trio
@@ -139,83 +139,83 @@ hideall "--sync--"
 # * however, syncing against multiple planes simultaneously might cause timeline jitter
 
 2000.0 "--sync--" sync / 00:0839::The launch deck will be sealed off/ window 2000,0
-2005.1 "Apply Shield Protocol" sync / 1[56]:724P-Operated Superior Flight Unit \(A-Lpha\):4FA6:/ window 20,20
-2018.3 "Maneuver: Missile Command" sync / 1[56]:724P-Operated Superior Flight Unit \(A-Lpha\):4FBD:/
-2031.5 "Maneuver: Incendiary Bombing" sync / 1[56]:724P-Operated Superior Flight Unit \(A-Lpha\):4FC3:/
-2040.7 "Maneuver: High-Powered Laser" sync / 1[56]:724P-Operated Superior Flight Unit \(A-Lpha\):4FB4:/
+2005.1 "Apply Shield Protocol" sync / 1[56]:[^:]*:724P-Operated Superior Flight Unit \(A-Lpha\):4FA6:/ window 20,20
+2018.3 "Maneuver: Missile Command" sync / 1[56]:[^:]*:724P-Operated Superior Flight Unit \(A-Lpha\):4FBD:/
+2031.5 "Maneuver: Incendiary Bombing" sync / 1[56]:[^:]*:724P-Operated Superior Flight Unit \(A-Lpha\):4FC3:/
+2040.7 "Maneuver: High-Powered Laser" sync / 1[56]:[^:]*:724P-Operated Superior Flight Unit \(A-Lpha\):4FB4:/
 
-2060.4 "Formation: Sharp Turn" sync / 1[56]:724P-Operated Superior Flight Unit \(A-Lpha\):4FAB:/
-2073.6 "Sharp Turn" sync / 1[56]:724P-Operated Superior Flight Unit \(A-Lpha\):4FA[9A]:/
+2060.4 "Formation: Sharp Turn" sync / 1[56]:[^:]*:724P-Operated Superior Flight Unit \(A-Lpha\):4FAB:/
+2073.6 "Sharp Turn" sync / 1[56]:[^:]*:724P-Operated Superior Flight Unit \(A-Lpha\):4FA[9A]:/
 
-2090.4 "Maneuver: Precision Guided Missile" sync / 1[56]:724P-Operated Superior Flight Unit \(A-Lpha\):4FC4:/
-2104.7 "Formation: Air Raid" sync / 1[56]:724P-Operated Superior Flight Unit \(A-Lpha\):4FB0:/
+2090.4 "Maneuver: Precision Guided Missile" sync / 1[56]:[^:]*:724P-Operated Superior Flight Unit \(A-Lpha\):4FC4:/
+2104.7 "Formation: Air Raid" sync / 1[56]:[^:]*:724P-Operated Superior Flight Unit \(A-Lpha\):4FB0:/
 # Technically 2 missiles (4FB1/4FB2) come out during the 2.2s before this cast??
-2114.0 "Lethal Revolution" sync / 1[56]:724P-Operated Superior Flight Unit \(A-Lpha\):4FB3:/ duration 5.8
+2114.0 "Lethal Revolution" sync / 1[56]:[^:]*:724P-Operated Superior Flight Unit \(A-Lpha\):4FB3:/ duration 5.8
 
-2142.4 "Formation: Sliding Swipe" sync / 1[56]:724P-Operated Superior Flight Unit \(A-Lpha\):4FAE:/
+2142.4 "Formation: Sliding Swipe" sync / 1[56]:[^:]*:724P-Operated Superior Flight Unit \(A-Lpha\):4FAE:/
 2144.4 "--untargetable--"
-2153.5 "Incendiary Barrage" sync / 1[56]:724P-Operated Superior Flight Unit \(A-Lpha\):4FAF:/
-2155.0 "Sliding Swipe 1" sync / 1[56]:724P-Operated Superior Flight Unit \(A-Lpha\):4FA[CD]:/
-2157.0 "Sliding Swipe 2" sync / 1[56]:767P-Operated Superior Flight Unit \(B-Eta\):550[DE]:/
-2159.0 "Sliding Swipe 3" sync / 1[56]:772P-Operated Superior Flight Unit \(C-Hi\):(550F|5510):/
+2153.5 "Incendiary Barrage" sync / 1[56]:[^:]*:724P-Operated Superior Flight Unit \(A-Lpha\):4FAF:/
+2155.0 "Sliding Swipe 1" sync / 1[56]:[^:]*:724P-Operated Superior Flight Unit \(A-Lpha\):4FA[CD]:/
+2157.0 "Sliding Swipe 2" sync / 1[56]:[^:]*:767P-Operated Superior Flight Unit \(B-Eta\):550[DE]:/
+2159.0 "Sliding Swipe 3" sync / 1[56]:[^:]*:772P-Operated Superior Flight Unit \(C-Hi\):(550F|5510):/
 2161.3 "--targetable--"
 
-2172.7 "--sync--" sync / 14:724P-Operated Superior Flight Unit \(A-Lpha\):4FC4:/ window 70,20
-2172.7 "--sync--" sync / 14:767P-Operated Superior Flight Unit \(B-Eta\):4FC4:/ window 70,20
-2172.7 "--sync--" sync / 14:772P-Operated Superior Flight Unit \(C-Hi\):4FC4:/ window 70,20
-2176.7 "Maneuver: Precision Guided Missile" sync / 1[56]:724P-Operated Superior Flight Unit \(A-Lpha\):4FC4:/ window 10,10
-2191.0 "Maneuver: Area Bombardment" sync / 1[56]:724P-Operated Superior Flight Unit \(A-Lpha\):4FB7:/ duration 15
-2206.2 "Maneuver: High-Powered Laser" sync / 1[56]:724P-Operated Superior Flight Unit \(A-Lpha\):4FB4:/
-2224.8 "Maneuver: Missile Command" sync / 1[56]:724P-Operated Superior Flight Unit \(A-Lpha\):4FBD:/
+2172.7 "--sync--" sync / 14:[^:]*:724P-Operated Superior Flight Unit \(A-Lpha\):4FC4:/ window 70,20
+2172.7 "--sync--" sync / 14:[^:]*:767P-Operated Superior Flight Unit \(B-Eta\):4FC4:/ window 70,20
+2172.7 "--sync--" sync / 14:[^:]*:772P-Operated Superior Flight Unit \(C-Hi\):4FC4:/ window 70,20
+2176.7 "Maneuver: Precision Guided Missile" sync / 1[56]:[^:]*:724P-Operated Superior Flight Unit \(A-Lpha\):4FC4:/ window 10,10
+2191.0 "Maneuver: Area Bombardment" sync / 1[56]:[^:]*:724P-Operated Superior Flight Unit \(A-Lpha\):4FB7:/ duration 15
+2206.2 "Maneuver: High-Powered Laser" sync / 1[56]:[^:]*:724P-Operated Superior Flight Unit \(A-Lpha\):4FB4:/
+2224.8 "Maneuver: Missile Command" sync / 1[56]:[^:]*:724P-Operated Superior Flight Unit \(A-Lpha\):4FBD:/
 
-2243.1 "Formation: Air Raid" sync / 1[56]:724P-Operated Superior Flight Unit \(A-Lpha\):4FB0:/
-2252.5 "Lethal Revolution" sync / 1[56]:724P-Operated Superior Flight Unit \(A-Lpha\):4FB3:/ duration 5.8
+2243.1 "Formation: Air Raid" sync / 1[56]:[^:]*:724P-Operated Superior Flight Unit \(A-Lpha\):4FB0:/
+2252.5 "Lethal Revolution" sync / 1[56]:[^:]*:724P-Operated Superior Flight Unit \(A-Lpha\):4FB3:/ duration 5.8
 
-2273.8 "Maneuver: Area Bombardment" sync / 1[56]:724P-Operated Superior Flight Unit \(A-Lpha\):4FB7:/ duration 15
+2273.8 "Maneuver: Area Bombardment" sync / 1[56]:[^:]*:724P-Operated Superior Flight Unit \(A-Lpha\):4FB7:/ duration 15
 
-2304.1 "Maneuver: Precision Guided Missile" sync / 1[56]:724P-Operated Superior Flight Unit \(A-Lpha\):4FC4:/
-2315.3 "Maneuver: Incendiary Bombing" sync / 1[56]:724P-Operated Superior Flight Unit \(A-Lpha\):4FC3:/
+2304.1 "Maneuver: Precision Guided Missile" sync / 1[56]:[^:]*:724P-Operated Superior Flight Unit \(A-Lpha\):4FC4:/
+2315.3 "Maneuver: Incendiary Bombing" sync / 1[56]:[^:]*:724P-Operated Superior Flight Unit \(A-Lpha\):4FC3:/
 
 # Loop begins roughly here:
-2321.5 "Maneuver: High-Order Explosive Blast" sync / 1[56]:724P-Operated Superior Flight Unit \(A-Lpha\):4FBF:/
-2339.8 "Maneuver: Missile Command" sync / 1[56]:724P-Operated Superior Flight Unit \(A-Lpha\):4FBD:/
+2321.5 "Maneuver: High-Order Explosive Blast" sync / 1[56]:[^:]*:724P-Operated Superior Flight Unit \(A-Lpha\):4FBF:/
+2339.8 "Maneuver: Missile Command" sync / 1[56]:[^:]*:724P-Operated Superior Flight Unit \(A-Lpha\):4FBD:/
 
-2356.1 "Formation: Sharp Turn" sync / 1[56]:724P-Operated Superior Flight Unit \(A-Lpha\):4FAB:/
-2369.2 "Sharp Turn" sync / 1[56]:724P-Operated Superior Flight Unit \(A-Lpha\):4FA[9A]:/
+2356.1 "Formation: Sharp Turn" sync / 1[56]:[^:]*:724P-Operated Superior Flight Unit \(A-Lpha\):4FAB:/
+2369.2 "Sharp Turn" sync / 1[56]:[^:]*:724P-Operated Superior Flight Unit \(A-Lpha\):4FA[9A]:/
 
-2392.0 "Formation: Sliding Swipe" sync / 1[56]:724P-Operated Superior Flight Unit \(A-Lpha\):4FAE:/
+2392.0 "Formation: Sliding Swipe" sync / 1[56]:[^:]*:724P-Operated Superior Flight Unit \(A-Lpha\):4FAE:/
 2394.0 "--untargetable--"
-2400.0 "Anti-Personnel Missile" sync / 1[56]:724P-Operated Superior Flight Unit \(A-Lpha\):4FBB:/
-2403.1 "Incendiary Barrage" sync / 1[56]:724P-Operated Superior Flight Unit \(A-Lpha\):4FAF:/
-2404.6 "Sliding Swipe 1" sync / 1[56]:724P-Operated Superior Flight Unit \(A-Lpha\):4FA[CD]:/
-2406.6 "Sliding Swipe 2" sync / 1[56]:767P-Operated Superior Flight Unit \(B-Eta\):550[DE]:/
-2408.6 "Sliding Swipe 3" sync / 1[56]:772P-Operated Superior Flight Unit \(C-Hi\):(550F|5510):/
+2400.0 "Anti-Personnel Missile" sync / 1[56]:[^:]*:724P-Operated Superior Flight Unit \(A-Lpha\):4FBB:/
+2403.1 "Incendiary Barrage" sync / 1[56]:[^:]*:724P-Operated Superior Flight Unit \(A-Lpha\):4FAF:/
+2404.6 "Sliding Swipe 1" sync / 1[56]:[^:]*:724P-Operated Superior Flight Unit \(A-Lpha\):4FA[CD]:/
+2406.6 "Sliding Swipe 2" sync / 1[56]:[^:]*:767P-Operated Superior Flight Unit \(B-Eta\):550[DE]:/
+2408.6 "Sliding Swipe 3" sync / 1[56]:[^:]*:772P-Operated Superior Flight Unit \(C-Hi\):(550F|5510):/
 2410.9 "--targetable--"
 
-2427.2 "--sync--" sync / 14:724P-Operated Superior Flight Unit \(A-Lpha\):4FBD:/ window 70,20
-2427.2 "--sync--" sync / 14:767P-Operated Superior Flight Unit \(B-Eta\):4FBD:/ window 70,20
-2427.2 "--sync--" sync / 14:772P-Operated Superior Flight Unit \(C-Hi\):4FBD:/ window 70,20
-2431.2 "Maneuver: Missile Command" sync / 1[56]:724P-Operated Superior Flight Unit \(A-Lpha\):4FBD:/ window 10,10
-2447.4 "Maneuver: Precision Guided Missile" sync / 1[56]:724P-Operated Superior Flight Unit \(A-Lpha\):4FC4:/
-2467.7 "Maneuver: Area Bombardment" sync / 1[56]:724P-Operated Superior Flight Unit \(A-Lpha\):4FB7:/ duration 15
-2482.9 "Maneuver: High-Powered Laser" sync / 1[56]:724P-Operated Superior Flight Unit \(A-Lpha\):4FB4:/
-2501.5 "Maneuver: Missile Command" sync / 1[56]:724P-Operated Superior Flight Unit \(A-Lpha\):4FBD:/
-2519.8 "Formation: Air Raid" sync / 1[56]:724P-Operated Superior Flight Unit \(A-Lpha\):4FB0:/
-2529.0 "Lethal Revolution" sync / 1[56]:724P-Operated Superior Flight Unit \(A-Lpha\):4FB3:/ duration 5.8
-2550.5 "Maneuver: Area Bombardment" sync / 1[56]:724P-Operated Superior Flight Unit \(A-Lpha\):4FB7:/ duration 15
-2565.6 "Anti-Personnel Missile" sync / 1[56]:724P-Operated Superior Flight Unit \(A-Lpha\):4FBB:/
-2580.8 "Maneuver: Precision Guided Missile" sync / 1[56]:724P-Operated Superior Flight Unit \(A-Lpha\):4FC4:/
-2592.0 "Maneuver: Incendiary Bombing" sync / 1[56]:724P-Operated Superior Flight Unit \(A-Lpha\):4FC3:/
+2427.2 "--sync--" sync / 14:[^:]*:724P-Operated Superior Flight Unit \(A-Lpha\):4FBD:/ window 70,20
+2427.2 "--sync--" sync / 14:[^:]*:767P-Operated Superior Flight Unit \(B-Eta\):4FBD:/ window 70,20
+2427.2 "--sync--" sync / 14:[^:]*:772P-Operated Superior Flight Unit \(C-Hi\):4FBD:/ window 70,20
+2431.2 "Maneuver: Missile Command" sync / 1[56]:[^:]*:724P-Operated Superior Flight Unit \(A-Lpha\):4FBD:/ window 10,10
+2447.4 "Maneuver: Precision Guided Missile" sync / 1[56]:[^:]*:724P-Operated Superior Flight Unit \(A-Lpha\):4FC4:/
+2467.7 "Maneuver: Area Bombardment" sync / 1[56]:[^:]*:724P-Operated Superior Flight Unit \(A-Lpha\):4FB7:/ duration 15
+2482.9 "Maneuver: High-Powered Laser" sync / 1[56]:[^:]*:724P-Operated Superior Flight Unit \(A-Lpha\):4FB4:/
+2501.5 "Maneuver: Missile Command" sync / 1[56]:[^:]*:724P-Operated Superior Flight Unit \(A-Lpha\):4FBD:/
+2519.8 "Formation: Air Raid" sync / 1[56]:[^:]*:724P-Operated Superior Flight Unit \(A-Lpha\):4FB0:/
+2529.0 "Lethal Revolution" sync / 1[56]:[^:]*:724P-Operated Superior Flight Unit \(A-Lpha\):4FB3:/ duration 5.8
+2550.5 "Maneuver: Area Bombardment" sync / 1[56]:[^:]*:724P-Operated Superior Flight Unit \(A-Lpha\):4FB7:/ duration 15
+2565.6 "Anti-Personnel Missile" sync / 1[56]:[^:]*:724P-Operated Superior Flight Unit \(A-Lpha\):4FBB:/
+2580.8 "Maneuver: Precision Guided Missile" sync / 1[56]:[^:]*:724P-Operated Superior Flight Unit \(A-Lpha\):4FC4:/
+2592.0 "Maneuver: Incendiary Bombing" sync / 1[56]:[^:]*:724P-Operated Superior Flight Unit \(A-Lpha\):4FC3:/
 
-2598.2 "--sync--" sync / 1[56]:724P-Operated Superior Flight Unit \(A-Lpha\):4FBF:/ window 90,90 jump 2321.5
-2598.2 "--sync--" sync / 1[56]:767P-Operated Superior Flight Unit \(B-Eta\):4FBF:/ window 90,90 jump 2321.5
-2598.2 "--sync--" sync / 1[56]:772P-Operated Superior Flight Unit \(C-Hi\):4FBF:/ window 90,90 jump 2321.5
+2598.2 "--sync--" sync / 1[56]:[^:]*:724P-Operated Superior Flight Unit \(A-Lpha\):4FBF:/ window 90,90 jump 2321.5
+2598.2 "--sync--" sync / 1[56]:[^:]*:767P-Operated Superior Flight Unit \(B-Eta\):4FBF:/ window 90,90 jump 2321.5
+2598.2 "--sync--" sync / 1[56]:[^:]*:772P-Operated Superior Flight Unit \(C-Hi\):4FBF:/ window 90,90 jump 2321.5
 
-2598.2 "Maneuver: High-Order Explosive Blast" #sync / 1[56]:724P-Operated Superior Flight Unit \(A-Lpha\):4FBF:/ jump 2321.5
-2616.5 "Maneuver: Missile Command" #sync / 1[56]:724P-Operated Superior Flight Unit \(A-Lpha\):4FBD:/
-2632.8 "Formation: Sharp Turn" #sync / 1[56]:724P-Operated Superior Flight Unit \(A-Lpha\):4FAB:/
-2645.9 "Sharp Turn" #sync / 1[56]:724P-Operated Superior Flight Unit \(A-Lpha\):4FA[9A]:/
-2668.7 "Formation: Sliding Swipe" #sync / 1[56]:724P-Operated Superior Flight Unit \(A-Lpha\):4FAE:/
+2598.2 "Maneuver: High-Order Explosive Blast" #sync / 1[56]:[^:]*:724P-Operated Superior Flight Unit \(A-Lpha\):4FBF:/ jump 2321.5
+2616.5 "Maneuver: Missile Command" #sync / 1[56]:[^:]*:724P-Operated Superior Flight Unit \(A-Lpha\):4FBD:/
+2632.8 "Formation: Sharp Turn" #sync / 1[56]:[^:]*:724P-Operated Superior Flight Unit \(A-Lpha\):4FAB:/
+2645.9 "Sharp Turn" #sync / 1[56]:[^:]*:724P-Operated Superior Flight Unit \(A-Lpha\):4FA[9A]:/
+2668.7 "Formation: Sliding Swipe" #sync / 1[56]:[^:]*:724P-Operated Superior Flight Unit \(A-Lpha\):4FAE:/
 
 
 
@@ -223,77 +223,77 @@ hideall "--sync--"
 # -p 5006:3012.1 -ii 4FF6 4FF7 4FF8 4FF9 4FFC 5004 4FFA 4FFF 4FFE 5002
 
 3000.0 "--sync--" sync / 00:0839::Core Command will be sealed off/ window 3000,0
-3012.1 "Maneuver: Volt Array" sync / 1[56]:905P-Operated Heavy Artillery Unit:5006:/ window 20,20
-3024.5 "Operation: Activate Laser Turret" sync / 1[56]:905P-Operated Heavy Artillery Unit:4FED:/
-3028.2 "Lower Laser" sync / 1[56]:905P-Operated Heavy Artillery Unit:5086:/ duration 3.5
-3028.2 "Upper Laser" sync / 1[56]:905P-Operated Heavy Artillery Unit:5087:/ duration 2.5
-3031.2 "Upper Laser" sync / 1[56]:905P-Operated Heavy Artillery Unit:5088:/ duration 2.5
-3034.2 "Upper Laser" sync / 1[56]:905P-Operated Heavy Artillery Unit:5089:/ duration 2.5
-3038.5 "Maneuver: High-Powered Laser x2" sync / 1[56]:905P-Operated Heavy Artillery Unit:5001:/ duration 2.3
-3048.3 "--sync--" sync / 1[56]:905P-Operated Heavy Artillery Unit:5005:/
-3054.3 "Maneuver: Unconventional Voltage" sync / 1[56]:905P-Operated Heavy Artillery Unit:5003:/
-3061.4 "Energy Bombardment" sync / 1[56]:905P-Operated Heavy Artillery Unit:4FFB:/ duration 9.2
-3072.5 "Maneuver: Impact Crusher x3" sync / 1[56]:905P-Operated Heavy Artillery Unit:4FFD:/ duration 3.3
+3012.1 "Maneuver: Volt Array" sync / 1[56]:[^:]*:905P-Operated Heavy Artillery Unit:5006:/ window 20,20
+3024.5 "Operation: Activate Laser Turret" sync / 1[56]:[^:]*:905P-Operated Heavy Artillery Unit:4FED:/
+3028.2 "Lower Laser" sync / 1[56]:[^:]*:905P-Operated Heavy Artillery Unit:5086:/ duration 3.5
+3028.2 "Upper Laser" sync / 1[56]:[^:]*:905P-Operated Heavy Artillery Unit:5087:/ duration 2.5
+3031.2 "Upper Laser" sync / 1[56]:[^:]*:905P-Operated Heavy Artillery Unit:5088:/ duration 2.5
+3034.2 "Upper Laser" sync / 1[56]:[^:]*:905P-Operated Heavy Artillery Unit:5089:/ duration 2.5
+3038.5 "Maneuver: High-Powered Laser x2" sync / 1[56]:[^:]*:905P-Operated Heavy Artillery Unit:5001:/ duration 2.3
+3048.3 "--sync--" sync / 1[56]:[^:]*:905P-Operated Heavy Artillery Unit:5005:/
+3054.3 "Maneuver: Unconventional Voltage" sync / 1[56]:[^:]*:905P-Operated Heavy Artillery Unit:5003:/
+3061.4 "Energy Bombardment" sync / 1[56]:[^:]*:905P-Operated Heavy Artillery Unit:4FFB:/ duration 9.2
+3072.5 "Maneuver: Impact Crusher x3" sync / 1[56]:[^:]*:905P-Operated Heavy Artillery Unit:4FFD:/ duration 3.3
 
-3078.8 "Maneuver: Revolving Laser" sync / 1[56]:905P-Operated Heavy Artillery Unit:5000:/
-3087.9 "Maneuver: Volt Array" sync / 1[56]:905P-Operated Heavy Artillery Unit:5006:/
-3109.9 "Operation: Access Self-Consciousness Data" sync / 1[56]:905P-Operated Heavy Artillery Unit:4FEF:/
-3126.2 "Operation: Activate Suppressive Unit" sync / 1[56]:905P-Operated Heavy Artillery Unit:4FEE:/ duration 30
+3078.8 "Maneuver: Revolving Laser" sync / 1[56]:[^:]*:905P-Operated Heavy Artillery Unit:5000:/
+3087.9 "Maneuver: Volt Array" sync / 1[56]:[^:]*:905P-Operated Heavy Artillery Unit:5006:/
+3109.9 "Operation: Access Self-Consciousness Data" sync / 1[56]:[^:]*:905P-Operated Heavy Artillery Unit:4FEF:/
+3126.2 "Operation: Activate Suppressive Unit" sync / 1[56]:[^:]*:905P-Operated Heavy Artillery Unit:4FEE:/ duration 30
 
-3156.2 "Maneuver: Volt Array" sync / 1[56]:905P-Operated Heavy Artillery Unit:5006:/
-3172.4 "Support: Pod" sync / 1[56]:905P-Operated Heavy Artillery Unit:4FE9:/
-3182.7 "Operation: Pod Program" sync / 1[56]:905P-Operated Heavy Artillery Unit:4FEA:/
-3194.6 "R010: Laser / R030: Hammer" sync / 1[56]:Pod:4FF[01]:/
-3199.6 "Support: Pod" sync / 1[56]:905P-Operated Heavy Artillery Unit:4FE9:/
-3210.8 "Operation: Pod Program" sync / 1[56]:905P-Operated Heavy Artillery Unit:4FEA:/
-3222.7 "R030: Hammer / R010: Laser" sync / 1[56]:Pod:4FF[01]:/
-3232.8 "Operation: Synthesize Compound" sync / 1[56]:905P-Operated Heavy Artillery Unit:4FEC:/
-3249.8 "Chemical Burn" sync / 1[56]:905P-Operated Heavy Artillery Unit:4FF4:/
-3254.8 "Maneuver: Volt Array" sync / 1[56]:905P-Operated Heavy Artillery Unit:5006:/
+3156.2 "Maneuver: Volt Array" sync / 1[56]:[^:]*:905P-Operated Heavy Artillery Unit:5006:/
+3172.4 "Support: Pod" sync / 1[56]:[^:]*:905P-Operated Heavy Artillery Unit:4FE9:/
+3182.7 "Operation: Pod Program" sync / 1[56]:[^:]*:905P-Operated Heavy Artillery Unit:4FEA:/
+3194.6 "R010: Laser / R030: Hammer" sync / 1[56]:[^:]*:Pod:4FF[01]:/
+3199.6 "Support: Pod" sync / 1[56]:[^:]*:905P-Operated Heavy Artillery Unit:4FE9:/
+3210.8 "Operation: Pod Program" sync / 1[56]:[^:]*:905P-Operated Heavy Artillery Unit:4FEA:/
+3222.7 "R030: Hammer / R010: Laser" sync / 1[56]:[^:]*:Pod:4FF[01]:/
+3232.8 "Operation: Synthesize Compound" sync / 1[56]:[^:]*:905P-Operated Heavy Artillery Unit:4FEC:/
+3249.8 "Chemical Burn" sync / 1[56]:[^:]*:905P-Operated Heavy Artillery Unit:4FF4:/
+3254.8 "Maneuver: Volt Array" sync / 1[56]:[^:]*:905P-Operated Heavy Artillery Unit:5006:/
 
-3266.1 "--sync--" sync / 1[56]:905P-Operated Heavy Artillery Unit:5005:/
-3272.1 "Maneuver: Unconventional Voltage" sync / 1[56]:905P-Operated Heavy Artillery Unit:5003:/
-3276.2 "Energy Bombardment" sync / 1[56]:905P-Operated Heavy Artillery Unit:4FFB:/ duration 9.2
-3297.1 "Maneuver: Volt Array" sync / 1[56]:905P-Operated Heavy Artillery Unit:5006:/
-3309.3 "Maneuver: Volt Array" sync / 1[56]:905P-Operated Heavy Artillery Unit:5006:/
-3313.4 "Support: Pod" sync / 1[56]:905P-Operated Heavy Artillery Unit:4FE9:/
-3323.7 "Operation: Pod Program" sync / 1[56]:905P-Operated Heavy Artillery Unit:4FEA:/
-3335.6 "R010: Laser" sync / 1[56]:Pod:4FF0:/
-3335.6 "R030: Hammer" sync / 1[56]:Pod:4FF1:/
-3340.6 "Support: Pod" sync / 1[56]:905P-Operated Heavy Artillery Unit:4FE9:/
-3351.9 "Operation: Pod Program" sync / 1[56]:905P-Operated Heavy Artillery Unit:4FEA:/
-3363.9 "R010: Laser" sync / 1[56]:Pod:4FF0:/
-3363.9 "R030: Hammer" sync / 1[56]:Pod:4FF1:/
-3370.4 "Operation: Activate Laser Turret" sync / 1[56]:905P-Operated Heavy Artillery Unit:4FED:/
-3374.1 "Lower Laser" sync / 1[56]:905P-Operated Heavy Artillery Unit:5086:/ duration 3.5
-3374.1 "Upper Laser" sync / 1[56]:905P-Operated Heavy Artillery Unit:5087:/ duration 2.5
-3377.1 "Upper Laser" sync / 1[56]:905P-Operated Heavy Artillery Unit:5088:/ duration 2.5
-3380.1 "Upper Laser" sync / 1[56]:905P-Operated Heavy Artillery Unit:5089:/ duration 2.5
+3266.1 "--sync--" sync / 1[56]:[^:]*:905P-Operated Heavy Artillery Unit:5005:/
+3272.1 "Maneuver: Unconventional Voltage" sync / 1[56]:[^:]*:905P-Operated Heavy Artillery Unit:5003:/
+3276.2 "Energy Bombardment" sync / 1[56]:[^:]*:905P-Operated Heavy Artillery Unit:4FFB:/ duration 9.2
+3297.1 "Maneuver: Volt Array" sync / 1[56]:[^:]*:905P-Operated Heavy Artillery Unit:5006:/
+3309.3 "Maneuver: Volt Array" sync / 1[56]:[^:]*:905P-Operated Heavy Artillery Unit:5006:/
+3313.4 "Support: Pod" sync / 1[56]:[^:]*:905P-Operated Heavy Artillery Unit:4FE9:/
+3323.7 "Operation: Pod Program" sync / 1[56]:[^:]*:905P-Operated Heavy Artillery Unit:4FEA:/
+3335.6 "R010: Laser" sync / 1[56]:[^:]*:Pod:4FF0:/
+3335.6 "R030: Hammer" sync / 1[56]:[^:]*:Pod:4FF1:/
+3340.6 "Support: Pod" sync / 1[56]:[^:]*:905P-Operated Heavy Artillery Unit:4FE9:/
+3351.9 "Operation: Pod Program" sync / 1[56]:[^:]*:905P-Operated Heavy Artillery Unit:4FEA:/
+3363.9 "R010: Laser" sync / 1[56]:[^:]*:Pod:4FF0:/
+3363.9 "R030: Hammer" sync / 1[56]:[^:]*:Pod:4FF1:/
+3370.4 "Operation: Activate Laser Turret" sync / 1[56]:[^:]*:905P-Operated Heavy Artillery Unit:4FED:/
+3374.1 "Lower Laser" sync / 1[56]:[^:]*:905P-Operated Heavy Artillery Unit:5086:/ duration 3.5
+3374.1 "Upper Laser" sync / 1[56]:[^:]*:905P-Operated Heavy Artillery Unit:5087:/ duration 2.5
+3377.1 "Upper Laser" sync / 1[56]:[^:]*:905P-Operated Heavy Artillery Unit:5088:/ duration 2.5
+3380.1 "Upper Laser" sync / 1[56]:[^:]*:905P-Operated Heavy Artillery Unit:5089:/ duration 2.5
 
-3381.3 "Maneuver: Volt Array" sync / 1[56]:905P-Operated Heavy Artillery Unit:5006:/
-3395.5 "Maneuver: Volt Array" sync / 1[56]:905P-Operated Heavy Artillery Unit:5006:/
-3404.7 "Operation: Synthesize Compound" sync / 1[56]:905P-Operated Heavy Artillery Unit:4FEC:/
-3421.7 "Chemical Conflagration" sync / 1[56]:905P-Operated Heavy Artillery Unit:4FF5:/
+3381.3 "Maneuver: Volt Array" sync / 1[56]:[^:]*:905P-Operated Heavy Artillery Unit:5006:/
+3395.5 "Maneuver: Volt Array" sync / 1[56]:[^:]*:905P-Operated Heavy Artillery Unit:5006:/
+3404.7 "Operation: Synthesize Compound" sync / 1[56]:[^:]*:905P-Operated Heavy Artillery Unit:4FEC:/
+3421.7 "Chemical Conflagration" sync / 1[56]:[^:]*:905P-Operated Heavy Artillery Unit:4FF5:/
 
-3424.7 "Maneuver: Impact Crusher x3" sync / 1[56]:905P-Operated Heavy Artillery Unit:4FFD:/ duration 3.3
-3431.0 "Maneuver: Revolving Laser" sync / 1[56]:905P-Operated Heavy Artillery Unit:5000:/
-3439.1 "Maneuver: Volt Array" sync / 1[56]:905P-Operated Heavy Artillery Unit:5006:/
-3456.4 "Operation: Activate Suppressive Unit" sync / 1[56]:905P-Operated Heavy Artillery Unit:4FEE:/ duration 30
+3424.7 "Maneuver: Impact Crusher x3" sync / 1[56]:[^:]*:905P-Operated Heavy Artillery Unit:4FFD:/ duration 3.3
+3431.0 "Maneuver: Revolving Laser" sync / 1[56]:[^:]*:905P-Operated Heavy Artillery Unit:5000:/
+3439.1 "Maneuver: Volt Array" sync / 1[56]:[^:]*:905P-Operated Heavy Artillery Unit:5006:/
+3456.4 "Operation: Activate Suppressive Unit" sync / 1[56]:[^:]*:905P-Operated Heavy Artillery Unit:4FEE:/ duration 30
 
-3480.4 "--sync--" sync / 1[56]:905P-Operated Heavy Artillery Unit:5005:/
-3486.4 "Maneuver: Unconventional Voltage" sync / 1[56]:905P-Operated Heavy Artillery Unit:5003:/
-3495.5 "Maneuver: Volt Array" sync / 1[56]:905P-Operated Heavy Artillery Unit:5006:/
-3503.6 "Maneuver: Volt Array" sync / 1[56]:905P-Operated Heavy Artillery Unit:5006:/
+3480.4 "--sync--" sync / 1[56]:[^:]*:905P-Operated Heavy Artillery Unit:5005:/
+3486.4 "Maneuver: Unconventional Voltage" sync / 1[56]:[^:]*:905P-Operated Heavy Artillery Unit:5003:/
+3495.5 "Maneuver: Volt Array" sync / 1[56]:[^:]*:905P-Operated Heavy Artillery Unit:5006:/
+3503.6 "Maneuver: Volt Array" sync / 1[56]:[^:]*:905P-Operated Heavy Artillery Unit:5006:/
 
 # loop back to the first hammer+laser combo deal pod program
-3515.8 "--sync--" sync / 1[56]:905P-Operated Heavy Artillery Unit:5005:/
-3521.8 "Maneuver: Unconventional Voltage" sync / 1[56]:905P-Operated Heavy Artillery Unit:5003:/
-3525.9 "Energy Bombardment" sync / 1[56]:905P-Operated Heavy Artillery Unit:4FFB:/ window 100,100 jump 3276.2
-3538.1 "Maneuver: High-Powered Laser" #sync / 1[56]:905P-Operated Heavy Artillery Unit:5001:/
-3546.9 "Maneuver: Volt Array" #sync / 1[56]:905P-Operated Heavy Artillery Unit:5006:/
-3559.1 "Maneuver: Volt Array" #sync / 1[56]:905P-Operated Heavy Artillery Unit:5006:/
-3563.2 "Support: Pod" #sync / 1[56]:905P-Operated Heavy Artillery Unit:4FE9:/
-3573.5 "Operation: Pod Program" #sync / 1[56]:905P-Operated Heavy Artillery Unit:4FEA:/
+3515.8 "--sync--" sync / 1[56]:[^:]*:905P-Operated Heavy Artillery Unit:5005:/
+3521.8 "Maneuver: Unconventional Voltage" sync / 1[56]:[^:]*:905P-Operated Heavy Artillery Unit:5003:/
+3525.9 "Energy Bombardment" sync / 1[56]:[^:]*:905P-Operated Heavy Artillery Unit:4FFB:/ window 100,100 jump 3276.2
+3538.1 "Maneuver: High-Powered Laser" #sync / 1[56]:[^:]*:905P-Operated Heavy Artillery Unit:5001:/
+3546.9 "Maneuver: Volt Array" #sync / 1[56]:[^:]*:905P-Operated Heavy Artillery Unit:5006:/
+3559.1 "Maneuver: Volt Array" #sync / 1[56]:[^:]*:905P-Operated Heavy Artillery Unit:5006:/
+3563.2 "Support: Pod" #sync / 1[56]:[^:]*:905P-Operated Heavy Artillery Unit:4FE9:/
+3573.5 "Operation: Pod Program" #sync / 1[56]:[^:]*:905P-Operated Heavy Artillery Unit:4FEA:/
 
 
 ### Heavy Artillery Unit: caster-friendly hallway section
@@ -307,34 +307,34 @@ hideall "--sync--"
 # * Can't use "The Bridge" area sync due to checkpoint with Compound 2P.
 
 #5000.0 "--sync--" sync / 00:0839::The bridge will be sealed off/ window 5000,0
-5002.0 "--sync--" sync / 1[56]:The Compound:53CA:/ window 6000,0
-5013.2 "Mechanical Laceration" sync / 1[56]:The Compound:51B8:/ window 6000,20
-5024.4 "Mechanical Decapitation/Dissection" sync / 1[56]:The Compound:51B[34]:/
-5034.9 "Mechanical Dissection/Decapitation" sync / 1[56]:The Compound:51B[34]:/
-5043.9 "Mechanical Contusion" sync / 1[56]:The Compound:51B5:/
+5002.0 "--sync--" sync / 1[56]:[^:]*:The Compound:53CA:/ window 6000,0
+5013.2 "Mechanical Laceration" sync / 1[56]:[^:]*:The Compound:51B8:/ window 6000,20
+5024.4 "Mechanical Decapitation/Dissection" sync / 1[56]:[^:]*:The Compound:51B[34]:/
+5034.9 "Mechanical Dissection/Decapitation" sync / 1[56]:[^:]*:The Compound:51B[34]:/
+5043.9 "Mechanical Contusion" sync / 1[56]:[^:]*:The Compound:51B5:/
 
 5058.0 "--untargetable--"
-5068.7 "Incongruous Spin x2" #sync / 1[56]:The Compound:51B2:/
+5068.7 "Incongruous Spin x2" #sync / 1[56]:[^:]*:The Compound:51B2:/
 5073.9 "--targetable--"
 
-5088.0 "Mechanical Laceration" sync / 1[56]:The Compound:51B8:/
-5099.1 "Mechanical Decapitation" sync / 1[56]:The Compound:51B4:/
-5105.1 "Mechanical Contusion" sync / 1[56]:The Compound:51B5:/
-5115.3 "Mechanical Dissection" sync / 1[56]:The Compound:51B3:/
-5125.6 "Mechanical Laceration" sync / 1[56]:The Compound:51B8:/
-5141.7 "Mechanical Decapitation" sync / 1[56]:The Compound:51B4:/
-5147.7 "Mechanical Contusion" sync / 1[56]:The Compound:51B5:/
-5157.9 "Mechanical Dissection" sync / 1[56]:The Compound:51B3:/
+5088.0 "Mechanical Laceration" sync / 1[56]:[^:]*:The Compound:51B8:/
+5099.1 "Mechanical Decapitation" sync / 1[56]:[^:]*:The Compound:51B4:/
+5105.1 "Mechanical Contusion" sync / 1[56]:[^:]*:The Compound:51B5:/
+5115.3 "Mechanical Dissection" sync / 1[56]:[^:]*:The Compound:51B3:/
+5125.6 "Mechanical Laceration" sync / 1[56]:[^:]*:The Compound:51B8:/
+5141.7 "Mechanical Decapitation" sync / 1[56]:[^:]*:The Compound:51B4:/
+5147.7 "Mechanical Contusion" sync / 1[56]:[^:]*:The Compound:51B5:/
+5157.9 "Mechanical Dissection" sync / 1[56]:[^:]*:The Compound:51B3:/
 
-5168.2 "Mechanical Laceration" sync / 1[56]:The Compound:51B8:/
-5184.5 "Mechanical Dissection" sync / 1[56]:The Compound:51B3:/
-5190.8 "Mechanical Contusion" sync / 1[56]:The Compound:51B5:/
-5200.9 "Mechanical Decapitation" sync / 1[56]:The Compound:51B4:/
+5168.2 "Mechanical Laceration" sync / 1[56]:[^:]*:The Compound:51B8:/
+5184.5 "Mechanical Dissection" sync / 1[56]:[^:]*:The Compound:51B3:/
+5190.8 "Mechanical Contusion" sync / 1[56]:[^:]*:The Compound:51B5:/
+5200.9 "Mechanical Decapitation" sync / 1[56]:[^:]*:The Compound:51B4:/
 
-5210.9 "Mechanical Laceration" sync / 1[56]:The Compound:51B8:/ window 30,30 jump 5168.2
-5227.2 "Mechanical Dissection" #sync / 1[56]:The Compound:51B3:/
-5233.5 "Mechanical Contusion" #sync / 1[56]:The Compound:51B5:/
-5243.6 "Mechanical Decapitation" #sync / 1[56]:The Compound:51B4:/
+5210.9 "Mechanical Laceration" sync / 1[56]:[^:]*:The Compound:51B8:/ window 30,30 jump 5168.2
+5227.2 "Mechanical Dissection" #sync / 1[56]:[^:]*:The Compound:51B3:/
+5233.5 "Mechanical Contusion" #sync / 1[56]:[^:]*:The Compound:51B5:/
+5243.6 "Mechanical Decapitation" #sync / 1[56]:[^:]*:The Compound:51B4:/
 
 
 ### Compound 2P
@@ -345,84 +345,84 @@ hideall "--sync--"
 # * 53D0 / 53D1 are included here as stand-ins for "Forced Transfer" when there is no ability.
 # * However, 53D0 / 53D1 are noisy so they're not included everywhere.
 
-6000.0 "Mechanical Laceration" sync / 1[56]:The Compound:53D5:/ window 6000,0
+6000.0 "Mechanical Laceration" sync / 1[56]:[^:]*:The Compound:53D5:/ window 6000,0
 6051.1 "--targetable--"
-6068.3 "Centrifugal Slice" sync / 1[56]:Compound 2P:51B0:/ window 7000,0
-6080.1 "Relentless Spiral x3" sync / 1[56]:Compound 2P:51A9:/ duration 4.1
-6099.9 "Prime Blade (Out)" sync / 1[56]:Compound 2P:541F:/
-6110.5 "Prime Blade (Behind)" sync / 1[56]:Compound 2P:5420:/
-6121.0 "Prime Blade (In)" sync / 1[56]:Compound 2P:5421:/
+6068.3 "Centrifugal Slice" sync / 1[56]:[^:]*:Compound 2P:51B0:/ window 7000,0
+6080.1 "Relentless Spiral x3" sync / 1[56]:[^:]*:Compound 2P:51A9:/ duration 4.1
+6099.9 "Prime Blade (Out)" sync / 1[56]:[^:]*:Compound 2P:541F:/
+6110.5 "Prime Blade (Behind)" sync / 1[56]:[^:]*:Compound 2P:5420:/
+6121.0 "Prime Blade (In)" sync / 1[56]:[^:]*:Compound 2P:5421:/
 
-6131.5 "--sync--" sync / 1[56]:Compound 2P:51A3:/
-6140.1 "Forced Transfer" sync / 1[56]:Compound 2P:53D0:/
-6143.6 "Prime Blade (In)" sync / 1[56]:Compound 2P:519A:/
-6153.1 "Centrifugal Slice" sync / 1[56]:Compound 2P:51B0:/
+6131.5 "--sync--" sync / 1[56]:[^:]*:Compound 2P:51A3:/
+6140.1 "Forced Transfer" sync / 1[56]:[^:]*:Compound 2P:53D0:/
+6143.6 "Prime Blade (In)" sync / 1[56]:[^:]*:Compound 2P:519A:/
+6153.1 "Centrifugal Slice" sync / 1[56]:[^:]*:Compound 2P:51B0:/
 
-6166.6 "Three Parts Disdain" sync / 1[56]:Compound 2P:519B:/ duration 3.6
+6166.6 "Three Parts Disdain" sync / 1[56]:[^:]*:Compound 2P:519B:/ duration 3.6
 
-6179.5 "Compound Pod: R012" sync / 1[56]:Compound 2P:51AB:/
-6183.3 "R012: Laser" sync / 1[56]:Compound Pod:51AC:/
+6179.5 "Compound Pod: R012" sync / 1[56]:[^:]*:Compound 2P:51AB:/
+6183.3 "R012: Laser" sync / 1[56]:[^:]*:Compound Pod:51AC:/
 
-6204.6 "Four Parts Resolve" sync / 1[56]:Compound 2P:519E:/ duration 9.4
+6204.6 "Four Parts Resolve" sync / 1[56]:[^:]*:Compound 2P:519E:/ duration 9.4
 
-6224.4 "--sync--" sync / 1[56]:Compound 2P:51A3:/
-6230.6 "Reproduce" sync / 1[56]:Compound 2P:51A1:/
-6240.3 "Prime Blade (In)" sync / 1[56]:Compound 2P:5421:/
-6250.7 "Prime Blade (In)" sync / 1[56]:Puppet 2P:5421:/
+6224.4 "--sync--" sync / 1[56]:[^:]*:Compound 2P:51A3:/
+6230.6 "Reproduce" sync / 1[56]:[^:]*:Compound 2P:51A1:/
+6240.3 "Prime Blade (In)" sync / 1[56]:[^:]*:Compound 2P:5421:/
+6250.7 "Prime Blade (In)" sync / 1[56]:[^:]*:Puppet 2P:5421:/
 
-6255.8 "--sync--" sync / 1[56]:Compound 2P:51A3:/
-6261.9 "Energy Compression" sync / 1[56]:Compound 2P:51A6:/
-6272.9 "Explosion" sync / 1[56]:Compound 2P:51A7:/
-6287.4 "Forced Transfer" sync / 1[56]:Compound 2P:51A2:/
-6291.2 "Explosion" sync / 1[56]:Compound 2P:51A7:/
+6255.8 "--sync--" sync / 1[56]:[^:]*:Compound 2P:51A3:/
+6261.9 "Energy Compression" sync / 1[56]:[^:]*:Compound 2P:51A6:/
+6272.9 "Explosion" sync / 1[56]:[^:]*:Compound 2P:51A7:/
+6287.4 "Forced Transfer" sync / 1[56]:[^:]*:Compound 2P:51A2:/
+6291.2 "Explosion" sync / 1[56]:[^:]*:Compound 2P:51A7:/
 
-6299.2 "Compound Pod: R011" sync / 1[56]:Compound 2P:51A4:/
-6315.6 "Forced Transfer" sync / 1[56]:Compound 2P:543A:/
-6318.5 "R011: Laser" sync / 1[56]:Compound Pod:51A5:/
-6329.9 "Relentless Spiral x3" sync / 1[56]:Compound 2P:51A9:/ duration 4.1
+6299.2 "Compound Pod: R011" sync / 1[56]:[^:]*:Compound 2P:51A4:/
+6315.6 "Forced Transfer" sync / 1[56]:[^:]*:Compound 2P:543A:/
+6318.5 "R011: Laser" sync / 1[56]:[^:]*:Compound Pod:51A5:/
+6329.9 "Relentless Spiral x3" sync / 1[56]:[^:]*:Compound 2P:51A9:/ duration 4.1
 
-6332.7 "--sync--" sync / 1[56]:Compound 2P:51A3:/
-6341.3 "Forced Transfer" sync / 1[56]:Compound 2P:53D1:/
-6344.7 "Prime Blade (Out/Behind)" sync / 1[56]:Compound 2P:519[89]:/
+6332.7 "--sync--" sync / 1[56]:[^:]*:Compound 2P:51A3:/
+6341.3 "Forced Transfer" sync / 1[56]:[^:]*:Compound 2P:53D1:/
+6344.7 "Prime Blade (Out/Behind)" sync / 1[56]:[^:]*:Compound 2P:519[89]:/
 
 # beginning of loop
-6350.2 "--sync--" sync / 1[56]:Compound 2P:51A3:/
-6356.3 "Reproduce" sync / 1[56]:Compound 2P:51A1:/
-6366.0 "Prime Blade (In/Out)" sync / 1[56]:Compound 2P:(541F|5421):/
-6375.9 "Forced Transfer" sync / 1[56]:Compound 2P:51A2:/
-6379.4 "Prime Blade (In/Out)" sync / 1[56]:Puppet 2P:(5198|519A):/
+6350.2 "--sync--" sync / 1[56]:[^:]*:Compound 2P:51A3:/
+6356.3 "Reproduce" sync / 1[56]:[^:]*:Compound 2P:51A1:/
+6366.0 "Prime Blade (In/Out)" sync / 1[56]:[^:]*:Compound 2P:(541F|5421):/
+6375.9 "Forced Transfer" sync / 1[56]:[^:]*:Compound 2P:51A2:/
+6379.4 "Prime Blade (In/Out)" sync / 1[56]:[^:]*:Puppet 2P:(5198|519A):/
 
 
 # Random Three Parts/ Four Parts
-6391.8 "--sync--" sync / 14:Compound 2P:519E:/ window 50,50
-6399.8 "Four Parts Resolve?" sync / 1[56]:Compound 2P:519E:/
+6391.8 "--sync--" sync / 14:[^:]*:Compound 2P:519E:/ window 50,50
+6399.8 "Four Parts Resolve?" sync / 1[56]:[^:]*:Compound 2P:519E:/
 
 # This is adjusted 9 seconds ahead so that Compound Pod: R012 lines up.  @_@;;
-6400.7 "--sync--" sync / 14:Compound 2P:519B:/ window 50,50
-6406.7 "Three Parts Disdain?" sync / 1[56]:Compound 2P:519B:/
+6400.7 "--sync--" sync / 14:[^:]*:Compound 2P:519B:/ window 50,50
+6406.7 "Three Parts Disdain?" sync / 1[56]:[^:]*:Compound 2P:519B:/
 
 
-6420.5 "Compound Pod: R012" sync / 1[56]:Compound 2P:51AB:/
-6423.4 "--sync--" sync / 1[56]:Compound 2P:51A3:/
-6424.3 "R012: Laser" sync / 1[56]:Compound Pod:51AC:/
-6429.6 "Energy Compression" sync / 1[56]:Compound 2P:51A6:/
-6440.6 "Explosion" sync / 1[56]:Compound 2P:51A7:/
+6420.5 "Compound Pod: R012" sync / 1[56]:[^:]*:Compound 2P:51AB:/
+6423.4 "--sync--" sync / 1[56]:[^:]*:Compound 2P:51A3:/
+6424.3 "R012: Laser" sync / 1[56]:[^:]*:Compound Pod:51AC:/
+6429.6 "Energy Compression" sync / 1[56]:[^:]*:Compound 2P:51A6:/
+6440.6 "Explosion" sync / 1[56]:[^:]*:Compound 2P:51A7:/
 
-6455.1 "Forced Transfer" sync / 1[56]:Compound 2P:51A2:/
-6458.9 "Explosion" sync / 1[56]:Compound 2P:51A7:/
+6455.1 "Forced Transfer" sync / 1[56]:[^:]*:Compound 2P:51A2:/
+6458.9 "Explosion" sync / 1[56]:[^:]*:Compound 2P:51A7:/
 
-6471.9 "Centrifugal Slice" sync / 1[56]:Compound 2P:51B0:/
-6490.2 "Compound Pod: R011" sync / 1[56]:Compound 2P:51A4:/
-6506.6 "Forced Transfer" sync / 1[56]:Compound 2P:543A:/
-6509.5 "R011: Laser" sync / 1[56]:Compound Pod:51A5:/
-6520.9 "Relentless Spiral x3" sync / 1[56]:Compound 2P:51A9:/ duration 4.1
+6471.9 "Centrifugal Slice" sync / 1[56]:[^:]*:Compound 2P:51B0:/
+6490.2 "Compound Pod: R011" sync / 1[56]:[^:]*:Compound 2P:51A4:/
+6506.6 "Forced Transfer" sync / 1[56]:[^:]*:Compound 2P:543A:/
+6509.5 "R011: Laser" sync / 1[56]:[^:]*:Compound Pod:51A5:/
+6520.9 "Relentless Spiral x3" sync / 1[56]:[^:]*:Compound 2P:51A9:/ duration 4.1
 
-6523.7 "--sync--" sync / 1[56]:Compound 2P:51A3:/
-6532.5 "Forced Transfer" sync / 1[56]:Compound 2P:53D[01]:/
-6535.8 "Prime Blade (In/Out)" sync / 1[56]:Compound 2P:(5198|519A):/
+6523.7 "--sync--" sync / 1[56]:[^:]*:Compound 2P:51A3:/
+6532.5 "Forced Transfer" sync / 1[56]:[^:]*:Compound 2P:53D[01]:/
+6535.8 "Prime Blade (In/Out)" sync / 1[56]:[^:]*:Compound 2P:(5198|519A):/
 
-6541.3 "--sync--" sync / 1[56]:Compound 2P:51A3:/
-6547.4 "Reproduce" sync / 1[56]:Compound 2P:51A1:/ window 100,100 jump 6356.3
-6557.2 "Prime Blade (In/Out)" sync / 1[56]:Compound 2P:(541F|5421):/
-6567.1 "Forced Transfer" sync / 1[56]:Compound 2P:51A2:/
-6570.6 "Prime Blade (In/Out)" sync / 1[56]:Puppet 2P:(5198|519A):/
+6541.3 "--sync--" sync / 1[56]:[^:]*:Compound 2P:51A3:/
+6547.4 "Reproduce" sync / 1[56]:[^:]*:Compound 2P:51A1:/ window 100,100 jump 6356.3
+6557.2 "Prime Blade (In/Out)" sync / 1[56]:[^:]*:Compound 2P:(541F|5421):/
+6567.1 "Forced Transfer" sync / 1[56]:[^:]*:Compound 2P:51A2:/
+6570.6 "Prime Blade (In/Out)" sync / 1[56]:[^:]*:Puppet 2P:(5198|519A):/

--- a/ui/raidboss/data/05-shb/alliance/the_tower_at_paradigms_breach.txt
+++ b/ui/raidboss/data/05-shb/alliance/the_tower_at_paradigms_breach.txt
@@ -18,76 +18,76 @@ hideall "--sync--"
 # So, give up, and add extra syncs on abilities after.
 
 1000.0 "--sync--" sync / 00:0839::Closed Area A will be sealed off/ window 10000,0
-1012.0 "Roar" sync / 1[56]:Knave Of Hearts:5EB5:/ window 10,10
-1022.1 "Colossal Impact" sync / 1[56]:Knave Of Hearts:5EA7:/
-1033.2 "Colossal Impact" sync / 1[56]:Knave Of Hearts:5EA4:/
-1040.3 "--sync--" sync / 1[56]:Knave Of Hearts:5EB2:/ # Magic Artillery Beta cast
-1047.4 "Magic Artillery Beta" sync / 1[56]:Knave Of Hearts:5EB3:/ # damage
+1012.0 "Roar" sync / 1[56]:[^:]*:Knave Of Hearts:5EB5:/ window 10,10
+1022.1 "Colossal Impact" sync / 1[56]:[^:]*:Knave Of Hearts:5EA7:/
+1033.2 "Colossal Impact" sync / 1[56]:[^:]*:Knave Of Hearts:5EA4:/
+1040.3 "--sync--" sync / 1[56]:[^:]*:Knave Of Hearts:5EB2:/ # Magic Artillery Beta cast
+1047.4 "Magic Artillery Beta" sync / 1[56]:[^:]*:Knave Of Hearts:5EB3:/ # damage
 
-1050.5 "Replicate" sync / 1[56]:Knave Of Hearts:5EA9:/
-1061.8 "Stacking The Deck" sync / 1[56]:Copied Knave:60F0:/
-1072.0 "Colossal Impact 1" sync / 1[56]:Knave Of Hearts:5EA[47]:/ window 4,4
-1077.0 "Colossal Impact 2" sync / 1[56]:Copied Knave:5EA[47]:/ window 4,4
-1085.2 "--sync--" sync / 14:Knave Of Hearts:5EA8:/ window 10,10
-1089.2 "Spheroids" sync / 1[56]:Knave Of Hearts:5EA8:/
-1093.4 "Knavish Bullets" sync / 1[56]:Spheroid:5EAD:/
-1094.2 "--sync--" sync / 1[56]:Knave Of Hearts:5EAA:/ # Magic Artillery Alpha cast
-1102.3 "Magic Artillery Alpha" sync / 1[56]:Knave Of Hearts:5EAB:/ # damage
-1116.4 "Light Leap" sync / 1[56]:Knave Of Hearts:5EAE:/
+1050.5 "Replicate" sync / 1[56]:[^:]*:Knave Of Hearts:5EA9:/
+1061.8 "Stacking The Deck" sync / 1[56]:[^:]*:Copied Knave:60F0:/
+1072.0 "Colossal Impact 1" sync / 1[56]:[^:]*:Knave Of Hearts:5EA[47]:/ window 4,4
+1077.0 "Colossal Impact 2" sync / 1[56]:[^:]*:Copied Knave:5EA[47]:/ window 4,4
+1085.2 "--sync--" sync / 14:[^:]*:Knave Of Hearts:5EA8:/ window 10,10
+1089.2 "Spheroids" sync / 1[56]:[^:]*:Knave Of Hearts:5EA8:/
+1093.4 "Knavish Bullets" sync / 1[56]:[^:]*:Spheroid:5EAD:/
+1094.2 "--sync--" sync / 1[56]:[^:]*:Knave Of Hearts:5EAA:/ # Magic Artillery Alpha cast
+1102.3 "Magic Artillery Alpha" sync / 1[56]:[^:]*:Knave Of Hearts:5EAB:/ # damage
+1116.4 "Light Leap" sync / 1[56]:[^:]*:Knave Of Hearts:5EAE:/
 1116.4 "--untargetable--"
-1118.5 "--sync--" sync / 1[56]:Knave Of Hearts:5EB0:/
+1118.5 "--sync--" sync / 1[56]:[^:]*:Knave Of Hearts:5EB0:/
 1120.5 "--targetable--"
 
-1123.6 "Replicate" sync / 1[56]:Knave Of Hearts:5EA9:/
-1134.9 "Stacking The Deck" sync / 1[56]:Copied Knave:60F0:/
-1145.1 "Lunge 1" sync / 1[56]:Knave Of Hearts:5EB1:/
-1146.2 "--sync--" sync / 1[56]:Knave Of Hearts:5EB0:/
-1155.1 "Lunge 2" sync / 1[56]:Copied Knave:5EB1:/
-1167.3 "Roar" sync / 1[56]:Knave Of Hearts:5EB5:/
+1123.6 "Replicate" sync / 1[56]:[^:]*:Knave Of Hearts:5EA9:/
+1134.9 "Stacking The Deck" sync / 1[56]:[^:]*:Copied Knave:60F0:/
+1145.1 "Lunge 1" sync / 1[56]:[^:]*:Knave Of Hearts:5EB1:/
+1146.2 "--sync--" sync / 1[56]:[^:]*:Knave Of Hearts:5EB0:/
+1155.1 "Lunge 2" sync / 1[56]:[^:]*:Copied Knave:5EB1:/
+1167.3 "Roar" sync / 1[56]:[^:]*:Knave Of Hearts:5EB5:/
 
-1178.5 "Replicate" sync / 1[56]:Knave Of Hearts:5EA9:/
-1189.8 "Stacking The Deck" sync / 1[56]:Copied Knave:60F0:/
-1200.0 "Colossal Impact 1" sync / 1[56]:Knave Of Hearts:5EA[47]:/ window 4,4
-1206.0 "Colossal Impact 2" sync / 1[56]:Copied Knave:5EA[47]:/ window 4,4
-1208.1 "Spheroids" sync / 1[56]:Knave Of Hearts:5EA8:/ window 10,10
-1211.0 "Colossal Impact 3" #sync / 1[56]:Copied Knave:5EA[47]:/
-1213.2 "--sync--" sync / 1[56]:Knave Of Hearts:5EAA:/ # Magic Artillery Alpha cast
-1221.2 "Magic Barrage 1" #sync / 1[56]:Spheroid:5EAC:/
-1221.3 "Magic Artillery Alpha" sync / 1[56]:Knave Of Hearts:5EAB:/ # damage
-1224.2 "Magic Barrage 2" #sync / 1[56]:Spheroid:5EAC:/
-1239.4 "Light Leap" sync / 1[56]:Knave Of Hearts:5EAE:/
+1178.5 "Replicate" sync / 1[56]:[^:]*:Knave Of Hearts:5EA9:/
+1189.8 "Stacking The Deck" sync / 1[56]:[^:]*:Copied Knave:60F0:/
+1200.0 "Colossal Impact 1" sync / 1[56]:[^:]*:Knave Of Hearts:5EA[47]:/ window 4,4
+1206.0 "Colossal Impact 2" sync / 1[56]:[^:]*:Copied Knave:5EA[47]:/ window 4,4
+1208.1 "Spheroids" sync / 1[56]:[^:]*:Knave Of Hearts:5EA8:/ window 10,10
+1211.0 "Colossal Impact 3" #sync / 1[56]:[^:]*:Copied Knave:5EA[47]:/
+1213.2 "--sync--" sync / 1[56]:[^:]*:Knave Of Hearts:5EAA:/ # Magic Artillery Alpha cast
+1221.2 "Magic Barrage 1" #sync / 1[56]:[^:]*:Spheroid:5EAC:/
+1221.3 "Magic Artillery Alpha" sync / 1[56]:[^:]*:Knave Of Hearts:5EAB:/ # damage
+1224.2 "Magic Barrage 2" #sync / 1[56]:[^:]*:Spheroid:5EAC:/
+1239.4 "Light Leap" sync / 1[56]:[^:]*:Knave Of Hearts:5EAE:/
 1239.4 "--untargetable--"
-1241.5 "--sync--" sync / 1[56]:Knave Of Hearts:5EB0:/
+1241.5 "--sync--" sync / 1[56]:[^:]*:Knave Of Hearts:5EB0:/
 1243.5 "--targetable--"
 
-1246.6 "Replicate" sync / 1[56]:Knave Of Hearts:5EA9:/
-1257.9 "Stacking The Deck" sync / 1[56]:Copied Knave:60F0:/
-1268.1 "Lunge 1" sync / 1[56]:Knave Of Hearts:5EB1:/
-1269.2 "--sync--" sync / 1[56]:Knave Of Hearts:5EB0:/
-1278.1 "Lunge 2" sync / 1[56]:Copied Knave:5EB1:/
-1280.1 "Colossal Impact" sync / 1[56]:Knave Of Hearts:(60C8|5CFD):/
-1287.2 "--sync--" sync / 1[56]:Knave Of Hearts:5EB2:/ # Magic Artillery Beta cast
-1294.3 "Magic Artillery Beta" sync / 1[56]:Knave Of Hearts:5EB3:/ # damage
+1246.6 "Replicate" sync / 1[56]:[^:]*:Knave Of Hearts:5EA9:/
+1257.9 "Stacking The Deck" sync / 1[56]:[^:]*:Copied Knave:60F0:/
+1268.1 "Lunge 1" sync / 1[56]:[^:]*:Knave Of Hearts:5EB1:/
+1269.2 "--sync--" sync / 1[56]:[^:]*:Knave Of Hearts:5EB0:/
+1278.1 "Lunge 2" sync / 1[56]:[^:]*:Copied Knave:5EB1:/
+1280.1 "Colossal Impact" sync / 1[56]:[^:]*:Knave Of Hearts:(60C8|5CFD):/
+1287.2 "--sync--" sync / 1[56]:[^:]*:Knave Of Hearts:5EB2:/ # Magic Artillery Beta cast
+1294.3 "Magic Artillery Beta" sync / 1[56]:[^:]*:Knave Of Hearts:5EB3:/ # damage
 
-1305.4 "Spheroids" sync / 1[56]:Knave Of Hearts:5EA8:/
-1309.6 "Knavish Bullets" sync / 1[56]:Spheroid:5EAD:/
-1318.3 "Colossal Impact" sync / 1[56]:Knave Of Hearts:5EA[47]:/
-1332.5 "Roar" sync / 1[56]:Knave Of Hearts:5EB5:/
+1305.4 "Spheroids" sync / 1[56]:[^:]*:Knave Of Hearts:5EA8:/
+1309.6 "Knavish Bullets" sync / 1[56]:[^:]*:Spheroid:5EAD:/
+1318.3 "Colossal Impact" sync / 1[56]:[^:]*:Knave Of Hearts:5EA[47]:/
+1332.5 "Roar" sync / 1[56]:[^:]*:Knave Of Hearts:5EB5:/
 
 # loop
-1342.7 "Replicate" sync / 1[56]:Knave Of Hearts:5EA9:/ window 50,50 jump 1178.5
-1354.0 "Stacking The Deck" #sync / 1[56]:Copied Knave:60F0:/
-1364.2 "Colossal Impact 1" #sync / 1[56]:Knave Of Hearts:5EA7:/ window 4,4
-1370.2 "Colossal Impact 2" #sync / 1[56]:Copied Knave:5EA7:/ window 4,4
-1372.3 "Spheroids" #sync / 1[56]:Knave Of Hearts:5EA8:/ window 10,10
-1375.2 "Colossal Impact 3" #sync / 1[56]:Copied Knave:5EA4:/
-1377.4 "--sync--" #sync / 1[56]:Knave Of Hearts:5EAA:/ # Magic Artillery Alpha cast
-1385.4 "Magic Barrage 1" #sync / 1[56]:Spheroid:5EAC:/
-1385.5 "Magic Artillery Alpha" sync / 1[56]:Knave Of Hearts:5EAB:/ # damage
-1388.4 "Magic Barrage 2" #sync / 1[56]:Spheroid:5EAC:/
-1403.6 "Light Leap" #sync / 1[56]:Knave Of Hearts:5EAE:/
+1342.7 "Replicate" sync / 1[56]:[^:]*:Knave Of Hearts:5EA9:/ window 50,50 jump 1178.5
+1354.0 "Stacking The Deck" #sync / 1[56]:[^:]*:Copied Knave:60F0:/
+1364.2 "Colossal Impact 1" #sync / 1[56]:[^:]*:Knave Of Hearts:5EA7:/ window 4,4
+1370.2 "Colossal Impact 2" #sync / 1[56]:[^:]*:Copied Knave:5EA7:/ window 4,4
+1372.3 "Spheroids" #sync / 1[56]:[^:]*:Knave Of Hearts:5EA8:/ window 10,10
+1375.2 "Colossal Impact 3" #sync / 1[56]:[^:]*:Copied Knave:5EA4:/
+1377.4 "--sync--" #sync / 1[56]:[^:]*:Knave Of Hearts:5EAA:/ # Magic Artillery Alpha cast
+1385.4 "Magic Barrage 1" #sync / 1[56]:[^:]*:Spheroid:5EAC:/
+1385.5 "Magic Artillery Alpha" sync / 1[56]:[^:]*:Knave Of Hearts:5EAB:/ # damage
+1388.4 "Magic Barrage 2" #sync / 1[56]:[^:]*:Spheroid:5EAC:/
+1403.6 "Light Leap" #sync / 1[56]:[^:]*:Knave Of Hearts:5EAE:/
 1403.6 "--untargetable--"
-1405.7 "--sync--" #sync / 1[56]:Knave Of Hearts:5EB0:/
+1405.7 "--sync--" #sync / 1[56]:[^:]*:Knave Of Hearts:5EB0:/
 1407.7 "--targetable--"
 
 
@@ -99,128 +99,128 @@ hideall "--sync--"
 # -it "Hansel"
 
 2000.0 "--sync--" sync / 00:0839::Staging Node B will be sealed off/ window 10000,0
-2012.0 "Upgraded Shield" sync / 1[56]:Gretel:5C6[89]:/
-2012.0 "Upgraded Lance" sync / 1[56]:Hansel:5C6[AB]:/
-2025.2 "Wail" sync / 1[56]:Hansel:5C77:/
-2025.3 "Crippling Blow (G)" sync / 1[56]:Gretel:5C78:/
-2035.5 "Wail" sync / 1[56]:Gretel:5C76:/
-2035.6 "Crippling Blow (H)" sync / 1[56]:Hansel:5C79:/
+2012.0 "Upgraded Shield" sync / 1[56]:[^:]*:Gretel:5C6[89]:/
+2012.0 "Upgraded Lance" sync / 1[56]:[^:]*:Hansel:5C6[AB]:/
+2025.2 "Wail" sync / 1[56]:[^:]*:Hansel:5C77:/
+2025.3 "Crippling Blow (G)" sync / 1[56]:[^:]*:Gretel:5C78:/
+2035.5 "Wail" sync / 1[56]:[^:]*:Gretel:5C76:/
+2035.6 "Crippling Blow (H)" sync / 1[56]:[^:]*:Hansel:5C79:/
 
-2043.8 "Tandem Assault: Bloody Sweep" sync / 1[56]:Gretel:61B8:/
-2046.0 "--sync--" sync / 1[56]:Gretel:5C7E:/
-2056.2 "Bloody Sweep" sync / 1[56]:Gretel:5C54:/
+2043.8 "Tandem Assault: Bloody Sweep" sync / 1[56]:[^:]*:Gretel:61B8:/
+2046.0 "--sync--" sync / 1[56]:[^:]*:Gretel:5C7E:/
+2056.2 "Bloody Sweep" sync / 1[56]:[^:]*:Gretel:5C54:/
 
-2070.4 "Upgraded Shield" sync / 1[56]:Gretel:5C6[89]:/
-2070.4 "Upgraded Lance" sync / 1[56]:Hansel:5C6[AB]:/
-2083.6 "--sync--" sync / 1[56]:Gretel:5C7A:/ # Seed Of Magic Alpha cast
-2083.6 "--sync--" sync / 1[56]:Hansel:5C7B:/ # Riot Of Magic cast
-2089.4 "Seed Of Magic Alpha" sync / 1[56]:Gretel:5C61:/ # damage
-2089.4 "Riot Of Magic" sync / 1[56]:Hansel:5C63:/ # damage
+2070.4 "Upgraded Shield" sync / 1[56]:[^:]*:Gretel:5C6[89]:/
+2070.4 "Upgraded Lance" sync / 1[56]:[^:]*:Hansel:5C6[AB]:/
+2083.6 "--sync--" sync / 1[56]:[^:]*:Gretel:5C7A:/ # Seed Of Magic Alpha cast
+2083.6 "--sync--" sync / 1[56]:[^:]*:Hansel:5C7B:/ # Riot Of Magic cast
+2089.4 "Seed Of Magic Alpha" sync / 1[56]:[^:]*:Gretel:5C61:/ # damage
+2089.4 "Riot Of Magic" sync / 1[56]:[^:]*:Hansel:5C63:/ # damage
 
-2098.9 "Tandem Assault: Passing Lance" sync / 1[56]:Gretel:61BC:/
+2098.9 "Tandem Assault: Passing Lance" sync / 1[56]:[^:]*:Gretel:61BC:/
 2101.0 "--untargetable--"
-2101.1 "--sync--" sync / 1[56]:Gretel:5C7E:/
-2111.3 "Passing Lance" sync / 1[56]:Gretel:5C64:/
+2101.1 "--sync--" sync / 1[56]:[^:]*:Gretel:5C7E:/
+2111.3 "Passing Lance" sync / 1[56]:[^:]*:Gretel:5C64:/
 2116.1 "--targetable--"
 
-2126.2 "Upgraded Shield" sync / 1[56]:Gretel:5C6[89]:/
-2126.2 "Upgraded Lance" sync / 1[56]:Hansel:5C6[AB]:/
-2139.5 "Wail" sync / 1[56]:Hansel:5C77:/
-2139.6 "Crippling Blow (G)" sync / 1[56]:Gretel:5C78:/
-2149.8 "Wail" sync / 1[56]:Gretel:5C76:/
-2149.9 "Crippling Blow (H)" sync / 1[56]:Hansel:5C79:/
+2126.2 "Upgraded Shield" sync / 1[56]:[^:]*:Gretel:5C6[89]:/
+2126.2 "Upgraded Lance" sync / 1[56]:[^:]*:Hansel:5C6[AB]:/
+2139.5 "Wail" sync / 1[56]:[^:]*:Hansel:5C77:/
+2139.6 "Crippling Blow (G)" sync / 1[56]:[^:]*:Gretel:5C78:/
+2149.8 "Wail" sync / 1[56]:[^:]*:Gretel:5C76:/
+2149.9 "Crippling Blow (H)" sync / 1[56]:[^:]*:Hansel:5C79:/
 
-2162.2 "Tandem Assault: Bloody Sweep" sync / 1[56]:Gretel:61B8:/
-2164.4 "--sync--" sync / 1[56]:Gretel:5C7E:/
-2166.5 "Tandem" sync / 1[56]:Gretel:5C58:/
-2176.7 "Transference" sync / 1[56]:Gretel:5CF1:/
-2181.6 "Bloody Sweep" sync / 1[56]:Gretel:5C56:/
+2162.2 "Tandem Assault: Bloody Sweep" sync / 1[56]:[^:]*:Gretel:61B8:/
+2164.4 "--sync--" sync / 1[56]:[^:]*:Gretel:5C7E:/
+2166.5 "Tandem" sync / 1[56]:[^:]*:Gretel:5C58:/
+2176.7 "Transference" sync / 1[56]:[^:]*:Gretel:5CF1:/
+2181.6 "Bloody Sweep" sync / 1[56]:[^:]*:Gretel:5C56:/
 
-2184.9 "--sync--" sync / 1[56]:Gretel:5C7E:/
-2192.1 "Wandering Trail" sync / 1[56]:Gretel:5C5A:/
-2199.3 "Tandem Assault: Breakthrough" sync / 1[56]:Gretel:61BA:/
+2184.9 "--sync--" sync / 1[56]:[^:]*:Gretel:5C7E:/
+2192.1 "Wandering Trail" sync / 1[56]:[^:]*:Gretel:5C5A:/
+2199.3 "Tandem Assault: Breakthrough" sync / 1[56]:[^:]*:Gretel:61BA:/
 2201.4 "--untargetable--"
-2201.5 "--sync--" sync / 1[56]:Gretel:5C7E:/
-2212.8 "Breakthrough" sync / 1[56]:Hansel:5C5E:/
-2213.1 "Uneven Footing" sync / 1[56]:Hansel & Gretel:5C5F:/
+2201.5 "--sync--" sync / 1[56]:[^:]*:Gretel:5C7E:/
+2212.8 "Breakthrough" sync / 1[56]:[^:]*:Hansel:5C5E:/
+2213.1 "Uneven Footing" sync / 1[56]:[^:]*:Hansel & Gretel:5C5F:/
 2214.9 "--targetable--"
 
-2227.0 "Upgraded Shield" sync / 1[56]:Gretel:5C6[89]:/
-2227.0 "Upgraded Lance" sync / 1[56]:Hansel:5C6[AB]:/
-2240.2 "Wail" sync / 1[56]:Hansel:5C77:/
-2240.3 "Crippling Blow (G)" sync / 1[56]:Gretel:5C78:/
-2250.5 "Wail" sync / 1[56]:Gretel:5C76:/
-2250.6 "Crippling Blow (H)" sync / 1[56]:Hansel:5C79:/
+2227.0 "Upgraded Shield" sync / 1[56]:[^:]*:Gretel:5C6[89]:/
+2227.0 "Upgraded Lance" sync / 1[56]:[^:]*:Hansel:5C6[AB]:/
+2240.2 "Wail" sync / 1[56]:[^:]*:Hansel:5C77:/
+2240.3 "Crippling Blow (G)" sync / 1[56]:[^:]*:Gretel:5C78:/
+2250.5 "Wail" sync / 1[56]:[^:]*:Gretel:5C76:/
+2250.6 "Crippling Blow (H)" sync / 1[56]:[^:]*:Hansel:5C79:/
 
-2262.9 "Tandem Assault: Passing Lance" sync / 1[56]:Gretel:61BC:/
+2262.9 "Tandem Assault: Passing Lance" sync / 1[56]:[^:]*:Gretel:61BC:/
 2266.1 "--untargetable--"
-2266.2 "--sync--" sync / 1[56]:Gretel:5C7E:/
-2267.9 "Seed Of Magic Alpha" sync / 1[56]:Gretel:5C61:/
-2267.9 "Riot Of Magic" sync / 1[56]:Hansel:5C63:/
-2276.4 "Passing Lance" sync / 1[56]:Gretel:5C64:/
+2266.2 "--sync--" sync / 1[56]:[^:]*:Gretel:5C7E:/
+2267.9 "Seed Of Magic Alpha" sync / 1[56]:[^:]*:Gretel:5C61:/
+2267.9 "Riot Of Magic" sync / 1[56]:[^:]*:Hansel:5C63:/
+2276.4 "Passing Lance" sync / 1[56]:[^:]*:Gretel:5C64:/
 2281.2 "--targetable--"
 
-2291.3 "Upgraded Shield" sync / 1[56]:Gretel:5C6[89]:/
-2291.3 "Upgraded Lance" sync / 1[56]:Hansel:5C6A:/
-2307.6 "Wandering Trail" sync / 1[56]:Gretel:5C5A:/
-2315.8 "--sync--" sync / 1[56]:Gretel:5C7E:/
-2322.5 "Hungry Lance" sync / 1[56]:Gretel:5C71:/
+2291.3 "Upgraded Shield" sync / 1[56]:[^:]*:Gretel:5C6[89]:/
+2291.3 "Upgraded Lance" sync / 1[56]:[^:]*:Hansel:5C6A:/
+2307.6 "Wandering Trail" sync / 1[56]:[^:]*:Gretel:5C5A:/
+2315.8 "--sync--" sync / 1[56]:[^:]*:Gretel:5C7E:/
+2322.5 "Hungry Lance" sync / 1[56]:[^:]*:Gretel:5C71:/
 
-2334.7 "Upgraded Shield" sync / 1[56]:Gretel:5C6[89]:/
-2334.7 "Upgraded Lance" sync / 1[56]:Hansel:5C6[AB]:/
-2351.0 "--sync--" sync / 1[56]:Gretel:5C7C:/ # Seed Of Magic Beta cast
-2353.2 "--sync--" sync / 1[56]:Gretel:5C7E:/
-2359.9 "Wandering Trail" sync / 1[56]:Gretel:5C5A:/
-2361.8 "Seed Of Magic Beta" sync / 1[56]:Gretel:5C75:/ # damage
+2334.7 "Upgraded Shield" sync / 1[56]:[^:]*:Gretel:5C6[89]:/
+2334.7 "Upgraded Lance" sync / 1[56]:[^:]*:Hansel:5C6[AB]:/
+2351.0 "--sync--" sync / 1[56]:[^:]*:Gretel:5C7C:/ # Seed Of Magic Beta cast
+2353.2 "--sync--" sync / 1[56]:[^:]*:Gretel:5C7E:/
+2359.9 "Wandering Trail" sync / 1[56]:[^:]*:Gretel:5C5A:/
+2361.8 "Seed Of Magic Beta" sync / 1[56]:[^:]*:Gretel:5C75:/ # damage
 
-2367.1 "Tandem Assault: Breakthrough" sync / 1[56]:Gretel:61BA:/
+2367.1 "Tandem Assault: Breakthrough" sync / 1[56]:[^:]*:Gretel:61BA:/
 2369.2 "--untargetable--"
-2369.3 "--sync--" sync / 1[56]:Gretel:5C7E:/
-2380.6 "Breakthrough" sync / 1[56]:Hansel:5C5E:/
-2380.9 "Uneven Footing" sync / 1[56]:Hansel & Gretel:5C5F:/
+2369.3 "--sync--" sync / 1[56]:[^:]*:Gretel:5C7E:/
+2380.6 "Breakthrough" sync / 1[56]:[^:]*:Hansel:5C5E:/
+2380.9 "Uneven Footing" sync / 1[56]:[^:]*:Hansel & Gretel:5C5F:/
 2382.7 "--targetable--"
 
-2394.8 "Upgraded Shield" sync / 1[56]:Gretel:5C6[89]:/
-2394.8 "Upgraded Lance" sync / 1[56]:Hansel:5C6[AB]:/
-2408.1 "Wail" sync / 1[56]:Hansel:5C77:/
-2408.2 "Crippling Blow (G)" sync / 1[56]:Gretel:5C78:/
-2418.4 "Wail" sync / 1[56]:Gretel:5C76:/
-2418.5 "Crippling Blow (H)" sync / 1[56]:Hansel:5C79:/
+2394.8 "Upgraded Shield" sync / 1[56]:[^:]*:Gretel:5C6[89]:/
+2394.8 "Upgraded Lance" sync / 1[56]:[^:]*:Hansel:5C6[AB]:/
+2408.1 "Wail" sync / 1[56]:[^:]*:Hansel:5C77:/
+2408.2 "Crippling Blow (G)" sync / 1[56]:[^:]*:Gretel:5C78:/
+2418.4 "Wail" sync / 1[56]:[^:]*:Gretel:5C76:/
+2418.5 "Crippling Blow (H)" sync / 1[56]:[^:]*:Hansel:5C79:/
 
-2430.8 "Tandem Assault: Bloody Sweep" sync / 1[56]:Gretel:61B8:/
-2433.0 "--sync--" sync / 1[56]:Gretel:5C7E:/
-2435.3 "Tandem" sync / 1[56]:Gretel:5C58:/
-2445.5 "Transference" sync / 1[56]:Gretel:5CF1:/
-2450.4 "Bloody Sweep" sync / 1[56]:Gretel:5C56:/
-2464.6 "Upgraded Shield" sync / 1[56]:Gretel:5C6[89]:/
-2464.6 "Upgraded Lance" sync / 1[56]:Hansel:5C6[AB]:/
+2430.8 "Tandem Assault: Bloody Sweep" sync / 1[56]:[^:]*:Gretel:61B8:/
+2433.0 "--sync--" sync / 1[56]:[^:]*:Gretel:5C7E:/
+2435.3 "Tandem" sync / 1[56]:[^:]*:Gretel:5C58:/
+2445.5 "Transference" sync / 1[56]:[^:]*:Gretel:5CF1:/
+2450.4 "Bloody Sweep" sync / 1[56]:[^:]*:Gretel:5C56:/
+2464.6 "Upgraded Shield" sync / 1[56]:[^:]*:Gretel:5C6[89]:/
+2464.6 "Upgraded Lance" sync / 1[56]:[^:]*:Hansel:5C6[AB]:/
 
 # loop
-2476.9 "Tandem Assault: Passing Lance" sync / 1[56]:Gretel:61BC:/ window 100,100 jump 2262.9
+2476.9 "Tandem Assault: Passing Lance" sync / 1[56]:[^:]*:Gretel:61BC:/ window 100,100 jump 2262.9
 2480.1 "--untargetable--"
-2480.2 "--sync--" #sync / 1[56]:Gretel:5C7E:/
-2481.9 "Seed Of Magic Alpha" #sync / 1[56]:Gretel:5C61:/
-2481.9 "Riot Of Magic" #sync / 1[56]:Hansel:5C63:/
-2490.4 "Passing Lance" #sync / 1[56]:Gretel:5C64:/
+2480.2 "--sync--" #sync / 1[56]:[^:]*:Gretel:5C7E:/
+2481.9 "Seed Of Magic Alpha" #sync / 1[56]:[^:]*:Gretel:5C61:/
+2481.9 "Riot Of Magic" #sync / 1[56]:[^:]*:Hansel:5C63:/
+2490.4 "Passing Lance" #sync / 1[56]:[^:]*:Gretel:5C64:/
 2495.2 "--targetable--"
 
-2505.3 "Upgraded Shield" #sync / 1[56]:Gretel:5C6[89]:/
-2505.3 "Upgraded Lance" #sync / 1[56]:Hansel:5C6A:/
-2521.6 "Wandering Trail" #sync / 1[56]:Gretel:5C5A:/
-2529.8 "--sync--" #sync / 1[56]:Gretel:5C7E:/
-2536.5 "Hungry Lance" #sync / 1[56]:Gretel:5C71:/
+2505.3 "Upgraded Shield" #sync / 1[56]:[^:]*:Gretel:5C6[89]:/
+2505.3 "Upgraded Lance" #sync / 1[56]:[^:]*:Hansel:5C6A:/
+2521.6 "Wandering Trail" #sync / 1[56]:[^:]*:Gretel:5C5A:/
+2529.8 "--sync--" #sync / 1[56]:[^:]*:Gretel:5C7E:/
+2536.5 "Hungry Lance" #sync / 1[56]:[^:]*:Gretel:5C71:/
 
 
 # Enrage (when one dies)
-2700.0 "--sync--" sync / 14:Gretel:5C73:/ window 700,0
-2700.0 "--sync--" sync / 14:Hansel:5C74:/ window 700,0
-2708.0 "Lamentation" sync / 1[56]:(Gretel:5C73|Hansel:5C74):/ window 100,100
-2713.8 "Seed Of Magic Beta" sync / 1[56]:(Gretel|Hansel):5C75:/
-2718.1 "Lamentation" #sync / 1[56]:(Gretel:5C73|Hansel:5C74):/
-2723.9 "Seed Of Magic Beta" #sync / 1[56]:(Gretel|Hansel):5C75:/
-2728.2 "Lamentation" #sync / 1[56]:(Gretel:5C73|Hansel:5C74):/
-2734.0 "Seed Of Magic Beta" #sync / 1[56]:(Gretel|Hansel):5C75:/
-2738.3 "Lamentation" #sync / 1[56]:(Gretel:5C73|Hansel:5C74):/
+2700.0 "--sync--" sync / 14:[^:]*:Gretel:5C73:/ window 700,0
+2700.0 "--sync--" sync / 14:[^:]*:Hansel:5C74:/ window 700,0
+2708.0 "Lamentation" sync / 1[56]:[^:]*:(Gretel:5C73|Hansel:5C74):/ window 100,100
+2713.8 "Seed Of Magic Beta" sync / 1[56]:[^:]*:(Gretel|Hansel):5C75:/
+2718.1 "Lamentation" #sync / 1[56]:[^:]*:(Gretel:5C73|Hansel:5C74):/
+2723.9 "Seed Of Magic Beta" #sync / 1[56]:[^:]*:(Gretel|Hansel):5C75:/
+2728.2 "Lamentation" #sync / 1[56]:[^:]*:(Gretel:5C73|Hansel:5C74):/
+2734.0 "Seed Of Magic Beta" #sync / 1[56]:[^:]*:(Gretel|Hansel):5C75:/
+2738.3 "Lamentation" #sync / 1[56]:[^:]*:(Gretel:5C73|Hansel:5C74):/
 
 
 ### Assorted Trash
@@ -237,17 +237,17 @@ hideall "--sync--"
 3031.6 "Lightfast Blade 1?"
 
 3500.0 "--targetable--"
-3501.1 "--sync--" sync / 14:2P-Operated Flight Unit:5BFE:/ window 3510,0
+3501.1 "--sync--" sync / 14:[^:]*:2P-Operated Flight Unit:5BFE:/ window 3510,0
 3505.0 "--targetable--"
 3510.0 "--targetable--"
-3513.1 "Lightfast Blade 1" sync / 1[56]:2P-Operated Flight Unit:5BFE:/
+3513.1 "Lightfast Blade 1" sync / 1[56]:[^:]*:2P-Operated Flight Unit:5BFE:/
 3515.0 "--targetable--"
-3518.1 "Lightfast Blade 2" sync / 1[56]:2P-Operated Flight Unit:5BFE:/
-3523.1 "Lightfast Blade 3" sync / 1[56]:2P-Operated Flight Unit:5BFE:/
-3528.1 "Lightfast Blade 4" sync / 1[56]:2P-Operated Flight Unit:5BFE:/
-3539.2 "Maneuver: Standard Laser" sync / 1[56]:2P-Operated Flight Unit:5BFF:/
-3549.4 "Maneuver: Standard Laser" sync / 1[56]:2P-Operated Flight Unit:5BFF:/
-3568.6 "Maneuver: Standard Laser" sync / 1[56]:2P-Operated Flight Unit:5BFF:/
+3518.1 "Lightfast Blade 2" sync / 1[56]:[^:]*:2P-Operated Flight Unit:5BFE:/
+3523.1 "Lightfast Blade 3" sync / 1[56]:[^:]*:2P-Operated Flight Unit:5BFE:/
+3528.1 "Lightfast Blade 4" sync / 1[56]:[^:]*:2P-Operated Flight Unit:5BFE:/
+3539.2 "Maneuver: Standard Laser" sync / 1[56]:[^:]*:2P-Operated Flight Unit:5BFF:/
+3549.4 "Maneuver: Standard Laser" sync / 1[56]:[^:]*:2P-Operated Flight Unit:5BFF:/
+3568.6 "Maneuver: Standard Laser" sync / 1[56]:[^:]*:2P-Operated Flight Unit:5BFF:/
 ### ??? more lasers?
 
 # After flight units die, then a bunch more 2P doing 5BFA Balanced Edge/5BFB Whirling Assault
@@ -262,96 +262,96 @@ hideall "--sync--"
 
 # Phase 1
 4000.0 "--sync--" sync / 00:0839::Staging Node D will be sealed off/ window 10000,0
-4009.0 "--sync--" sync / 14:Red Girl:6012:/ window 10,10
-4014.0 "Cruelty" sync / 1[56]:Red Girl:6012:/
-4019.9 "Shockwave" sync / 1[56]:Red Girl:600E:/
-4026.0 "Generate: Barrier" sync / 1[56]:Red Girl:6004:/
-4031.0 "Shock: White" sync / 1[56]:Red Girl:600F:/
-4037.1 "Generate: Barrier" sync / 1[56]:Red Girl:6004:/
-4041.1 "Point: White" sync / 1[56]:White Lance:601F:/
-4043.2 "Shockwave" sync / 1[56]:Red Girl:600E:/
-4054.3 "Shock: Black" sync / 1[56]:Red Girl:6011:/
-4060.4 "Generate: Barrier" sync / 1[56]:Red Girl:6004:/
-4064.5 "Point: Black" sync / 1[56]:Black Lance:6020:/
-4074.7 "Cruelty" sync / 1[56]:Red Girl:6012:/
+4009.0 "--sync--" sync / 14:[^:]*:Red Girl:6012:/ window 10,10
+4014.0 "Cruelty" sync / 1[56]:[^:]*:Red Girl:6012:/
+4019.9 "Shockwave" sync / 1[56]:[^:]*:Red Girl:600E:/
+4026.0 "Generate: Barrier" sync / 1[56]:[^:]*:Red Girl:6004:/
+4031.0 "Shock: White" sync / 1[56]:[^:]*:Red Girl:600F:/
+4037.1 "Generate: Barrier" sync / 1[56]:[^:]*:Red Girl:6004:/
+4041.1 "Point: White" sync / 1[56]:[^:]*:White Lance:601F:/
+4043.2 "Shockwave" sync / 1[56]:[^:]*:Red Girl:600E:/
+4054.3 "Shock: Black" sync / 1[56]:[^:]*:Red Girl:6011:/
+4060.4 "Generate: Barrier" sync / 1[56]:[^:]*:Red Girl:6004:/
+4064.5 "Point: Black" sync / 1[56]:[^:]*:Black Lance:6020:/
+4074.7 "Cruelty" sync / 1[56]:[^:]*:Red Girl:6012:/
 
-4086.7 "Vortex" sync / 1[56]:Red Girl:6017:/
-4088.7 "Generate: Barrier" sync / 1[56]:Red Girl:6004:/
-4092.8 "Recreate Meteor" sync / 1[56]:Red Girl:6147:/
-4099.9 "Shockwave" sync / 1[56]:Red Girl:600E:/
-4106.0 "Shock: White" sync / 1[56]:Red Girl:600F:/
-4111.8 "Wipe: White" sync / 1[56]:Red Girl:600C:/
-4118.1 "Manipulate Energy" sync / 1[56]:Red Girl:6018:/
-4129.3 "Cruelty" sync / 1[56]:Red Girl:6012:/
-4142.5 "Replicate" sync / 1[56]:Red Girl:600A:/
-4153.6 "Diffuse Energy" sync / 1[56]:Red Girl:6023:/ duration 13.7
-4173.9 "Manipulate Energy" sync / 1[56]:Red Girl:6018:/
+4086.7 "Vortex" sync / 1[56]:[^:]*:Red Girl:6017:/
+4088.7 "Generate: Barrier" sync / 1[56]:[^:]*:Red Girl:6004:/
+4092.8 "Recreate Meteor" sync / 1[56]:[^:]*:Red Girl:6147:/
+4099.9 "Shockwave" sync / 1[56]:[^:]*:Red Girl:600E:/
+4106.0 "Shock: White" sync / 1[56]:[^:]*:Red Girl:600F:/
+4111.8 "Wipe: White" sync / 1[56]:[^:]*:Red Girl:600C:/
+4118.1 "Manipulate Energy" sync / 1[56]:[^:]*:Red Girl:6018:/
+4129.3 "Cruelty" sync / 1[56]:[^:]*:Red Girl:6012:/
+4142.5 "Replicate" sync / 1[56]:[^:]*:Red Girl:600A:/
+4153.6 "Diffuse Energy" sync / 1[56]:[^:]*:Red Girl:6023:/ duration 13.7
+4173.9 "Manipulate Energy" sync / 1[56]:[^:]*:Red Girl:6018:/
 
 # Phase 2: hacking
-4189.1 "Sublime Transcendence" sync / 1[56]:Red Girl:620A:/
+4189.1 "Sublime Transcendence" sync / 1[56]:[^:]*:Red Girl:620A:/
 4193.2 "--untargetable--"
-4204.5 "--sync--" sync / 1[56]:Red Girl:601D:/ window 300,10
-4219.5 "Wave: White / Wave: Black" sync / 1[56]:Red Sphere:618[DE]:/
-4229.7 "Wave: White / Wave: Black" sync / 1[56]:Red Sphere:618[DE]:/
-4239.8 "Wave: Black / Wave: Black" sync / 1[56]:Red Sphere:618[DE]:/
-4249.9 "Wave: White / Wave: Black" sync / 1[56]:Red Sphere:618[DE]:/ window 10,100
-4260.0 "Wave: Black / Wave: Black" #sync / 1[56]:Red Sphere:618[DE]:/
-4270.1 "Wave: Black / Wave: Black" #sync / 1[56]:Red Sphere:618[DE]:/
-4280.2 "Wave: Black / Wave: Black" #sync / 1[56]:Red Sphere:618[DE]:/
+4204.5 "--sync--" sync / 1[56]:[^:]*:Red Girl:601D:/ window 300,10
+4219.5 "Wave: White / Wave: Black" sync / 1[56]:[^:]*:Red Sphere:618[DE]:/
+4229.7 "Wave: White / Wave: Black" sync / 1[56]:[^:]*:Red Sphere:618[DE]:/
+4239.8 "Wave: Black / Wave: Black" sync / 1[56]:[^:]*:Red Sphere:618[DE]:/
+4249.9 "Wave: White / Wave: Black" sync / 1[56]:[^:]*:Red Sphere:618[DE]:/ window 10,100
+4260.0 "Wave: Black / Wave: Black" #sync / 1[56]:[^:]*:Red Sphere:618[DE]:/
+4270.1 "Wave: Black / Wave: Black" #sync / 1[56]:[^:]*:Red Sphere:618[DE]:/
+4280.2 "Wave: Black / Wave: Black" #sync / 1[56]:[^:]*:Red Sphere:618[DE]:/
 
 
 # Phase 3
-4500.0 "--sync--" sync / 14:Red Girl:6013:/ window 300,10
-4505.0 "Cruelty" sync / 1[56]:Red Girl:6013:/
-4521.2 "Child's Play" sync / 1[56]:Red Girl:6024:/
-4527.1 "Explosion" sync / 1[56]:Black Pylon:6026:/
-4533.3 "Shockwave" sync / 1[56]:Red Girl:600E:/
-4545.4 "Shock: Black" sync / 1[56]:Red Girl:6011:/
-4545.5 "Child's Play" sync / 1[56]:Red Girl:6025:/
-4551.4 "Explosion" sync / 1[56]:Black Pylon:6026:/
-4559.7 "Cruelty" sync / 1[56]:Red Girl:6013:/
-4572.9 "Cruelty" sync / 1[56]:Red Girl:6013:/
+4500.0 "--sync--" sync / 14:[^:]*:Red Girl:6013:/ window 300,10
+4505.0 "Cruelty" sync / 1[56]:[^:]*:Red Girl:6013:/
+4521.2 "Child's Play" sync / 1[56]:[^:]*:Red Girl:6024:/
+4527.1 "Explosion" sync / 1[56]:[^:]*:Black Pylon:6026:/
+4533.3 "Shockwave" sync / 1[56]:[^:]*:Red Girl:600E:/
+4545.4 "Shock: Black" sync / 1[56]:[^:]*:Red Girl:6011:/
+4545.5 "Child's Play" sync / 1[56]:[^:]*:Red Girl:6025:/
+4551.4 "Explosion" sync / 1[56]:[^:]*:Black Pylon:6026:/
+4559.7 "Cruelty" sync / 1[56]:[^:]*:Red Girl:6013:/
+4572.9 "Cruelty" sync / 1[56]:[^:]*:Red Girl:6013:/
 
-4581.0 "Generate: Barrier" sync / 1[56]:Red Girl:6005:/
-4591.1 "Point: Black" sync / 1[56]:Black Lance:6020:/
-4591.1 "Point: White" sync / 1[56]:White Lance:601F:/
-4597.2 "Generate: Barrier" sync / 1[56]:Red Girl:6005:/
-4601.3 "Point: Black" sync / 1[56]:Black Lance:6020:/
-4601.3 "Point: White" sync / 1[56]:White Lance:601F:/
-4601.3 "Recreate Meteor" sync / 1[56]:Red Girl:6147:/
-4611.4 "Point: Black" sync / 1[56]:Black Lance:6020:/
-4620.4 "Wipe: Black" sync / 1[56]:Red Girl:600D:/
-4620.4 "Wipe: White" sync / 1[56]:Red Girl:600C:/
-4628.6 "Cruelty" sync / 1[56]:Red Girl:6013:/
+4581.0 "Generate: Barrier" sync / 1[56]:[^:]*:Red Girl:6005:/
+4591.1 "Point: Black" sync / 1[56]:[^:]*:Black Lance:6020:/
+4591.1 "Point: White" sync / 1[56]:[^:]*:White Lance:601F:/
+4597.2 "Generate: Barrier" sync / 1[56]:[^:]*:Red Girl:6005:/
+4601.3 "Point: Black" sync / 1[56]:[^:]*:Black Lance:6020:/
+4601.3 "Point: White" sync / 1[56]:[^:]*:White Lance:601F:/
+4601.3 "Recreate Meteor" sync / 1[56]:[^:]*:Red Girl:6147:/
+4611.4 "Point: Black" sync / 1[56]:[^:]*:Black Lance:6020:/
+4620.4 "Wipe: Black" sync / 1[56]:[^:]*:Red Girl:600D:/
+4620.4 "Wipe: White" sync / 1[56]:[^:]*:Red Girl:600C:/
+4628.6 "Cruelty" sync / 1[56]:[^:]*:Red Girl:6013:/
 
-4647.9 "Replicate" sync / 1[56]:Red Girl:600B:/
-4658.9 "Diffuse Energy" sync / 1[56]:Red Girl:6023:/ duration 13.7
-4663.1 "Child's Play" sync / 1[56]:Red Girl:6024:/
-4676.2 "Manipulate Energy" sync / 1[56]:Red Girl:6019:/
-4691.4 "Cruelty" sync / 1[56]:Red Girl:6013:/
-4707.6 "Child's Play" sync / 1[56]:Red Girl:6025:/
-4713.5 "Explosion" sync / 1[56]:Black Pylon:6026:/
-4719.7 "Shockwave" sync / 1[56]:Red Girl:600E:/
-4731.8 "Shock: Black" sync / 1[56]:Red Girl:6011:/
-4731.9 "Child's Play" sync / 1[56]:Red Girl:6025:/
-4737.8 "Explosion" sync / 1[56]:Black Pylon:6026:/
-4746.1 "Cruelty" sync / 1[56]:Red Girl:6013:/
-4756.3 "Cruelty" sync / 1[56]:Red Girl:6013:/
-4763.4 "Manipulate Energy" sync / 1[56]:Red Girl:6018:/
-4780.7 "Cruelty" sync / 1[56]:Red Girl:6013:/
+4647.9 "Replicate" sync / 1[56]:[^:]*:Red Girl:600B:/
+4658.9 "Diffuse Energy" sync / 1[56]:[^:]*:Red Girl:6023:/ duration 13.7
+4663.1 "Child's Play" sync / 1[56]:[^:]*:Red Girl:6024:/
+4676.2 "Manipulate Energy" sync / 1[56]:[^:]*:Red Girl:6019:/
+4691.4 "Cruelty" sync / 1[56]:[^:]*:Red Girl:6013:/
+4707.6 "Child's Play" sync / 1[56]:[^:]*:Red Girl:6025:/
+4713.5 "Explosion" sync / 1[56]:[^:]*:Black Pylon:6026:/
+4719.7 "Shockwave" sync / 1[56]:[^:]*:Red Girl:600E:/
+4731.8 "Shock: Black" sync / 1[56]:[^:]*:Red Girl:6011:/
+4731.9 "Child's Play" sync / 1[56]:[^:]*:Red Girl:6025:/
+4737.8 "Explosion" sync / 1[56]:[^:]*:Black Pylon:6026:/
+4746.1 "Cruelty" sync / 1[56]:[^:]*:Red Girl:6013:/
+4756.3 "Cruelty" sync / 1[56]:[^:]*:Red Girl:6013:/
+4763.4 "Manipulate Energy" sync / 1[56]:[^:]*:Red Girl:6018:/
+4780.7 "Cruelty" sync / 1[56]:[^:]*:Red Girl:6013:/
 
 # loop
-4788.8 "Generate: Barrier" sync / 1[56]:Red Girl:6005:/ window 100,100 jump 4581.0
-4798.9 "Point: Black" #sync / 1[56]:Black Lance:6020:/
-4798.9 "Point: White" #sync / 1[56]:White Lance:601F:/
-4805.0 "Generate: Barrier" #sync / 1[56]:Red Girl:6005:/
-4809.1 "Point: Black" #sync / 1[56]:Black Lance:6020:/
-4809.1 "Point: White" #sync / 1[56]:White Lance:601F:/
-4809.1 "Recreate Meteor" #sync / 1[56]:Red Girl:6147:/
-4819.2 "Point: Black" #sync / 1[56]:Black Lance:6020:/
-4828.2 "Wipe: Black" #sync / 1[56]:Red Girl:600D:/
-4828.2 "Wipe: White" #sync / 1[56]:Red Girl:600C:/
-4836.4 "Cruelty" #sync / 1[56]:Red Girl:6013:/
+4788.8 "Generate: Barrier" sync / 1[56]:[^:]*:Red Girl:6005:/ window 100,100 jump 4581.0
+4798.9 "Point: Black" #sync / 1[56]:[^:]*:Black Lance:6020:/
+4798.9 "Point: White" #sync / 1[56]:[^:]*:White Lance:601F:/
+4805.0 "Generate: Barrier" #sync / 1[56]:[^:]*:Red Girl:6005:/
+4809.1 "Point: Black" #sync / 1[56]:[^:]*:Black Lance:6020:/
+4809.1 "Point: White" #sync / 1[56]:[^:]*:White Lance:601F:/
+4809.1 "Recreate Meteor" #sync / 1[56]:[^:]*:Red Girl:6147:/
+4819.2 "Point: Black" #sync / 1[56]:[^:]*:Black Lance:6020:/
+4828.2 "Wipe: Black" #sync / 1[56]:[^:]*:Red Girl:600D:/
+4828.2 "Wipe: White" #sync / 1[56]:[^:]*:Red Girl:600C:/
+4836.4 "Cruelty" #sync / 1[56]:[^:]*:Red Girl:6013:/
 
 
 ### Trash-talking Philosophers
@@ -360,36 +360,36 @@ hideall "--sync--"
 # -p 5C00:5013.3
 # -ii 5CEC 5CED 5CEE 5C02 5C05 5C07 5C08
 5000.0 "--sync--" sync / 00:0839::The Ascension Platform will be sealed off/ window 10000,0
-5013.3 "Deploy Armaments" sync / 1[56]:Xun-Zi:5C0[03]:/
-5023.4 "Deploy Armaments" sync / 1[56]:Xun-Zi:5C0[03]:/
-5036.4 "Universal Assault" sync / 1[56]:Xun-Zi:5C06:/
+5013.3 "Deploy Armaments" sync / 1[56]:[^:]*:Xun-Zi:5C0[03]:/
+5023.4 "Deploy Armaments" sync / 1[56]:[^:]*:Xun-Zi:5C0[03]:/
+5036.4 "Universal Assault" sync / 1[56]:[^:]*:Xun-Zi:5C06:/
 # ???
 
 # ~70% HP push?
 5200.0 "--untargetable--" sync / 22:........:Xun-Zi:........:Xun-Zi:00/ window 200,0
 5210.9 "--targetable--"
-5221.0 "Deploy Armaments" sync / 1[56]:Xun-Zi:5C0[03]:/
-5224.0 "Deploy Armaments" sync / 1[56]:Meng-Zi:5C0[03]:/
+5221.0 "Deploy Armaments" sync / 1[56]:[^:]*:Xun-Zi:5C0[03]:/
+5224.0 "Deploy Armaments" sync / 1[56]:[^:]*:Meng-Zi:5C0[03]:/
 
-5235.9 "Deploy Armaments" sync / 1[56]:Meng-Zi:5C0[03]:/
-5238.9 "Deploy Armaments" sync / 1[56]:Xun-Zi:5C0[03]:/
+5235.9 "Deploy Armaments" sync / 1[56]:[^:]*:Meng-Zi:5C0[03]:/
+5238.9 "Deploy Armaments" sync / 1[56]:[^:]*:Xun-Zi:5C0[03]:/
 
-5250.1 "Deploy Armaments" sync / 1[56]:Xun-Zi:5C0[14]:/
-5250.1 "Deploy Armaments" sync / 1[56]:Meng-Zi:5C0[14]:/
+5250.1 "Deploy Armaments" sync / 1[56]:[^:]*:Xun-Zi:5C0[14]:/
+5250.1 "Deploy Armaments" sync / 1[56]:[^:]*:Meng-Zi:5C0[14]:/
 
-5256.8 "High-Powered Laser" sync / 1[56]:Serial-Jointed Model:5C09:/
+5256.8 "High-Powered Laser" sync / 1[56]:[^:]*:Serial-Jointed Model:5C09:/
 
-5267.1 "Universal Assault" sync / 1[56]:Xun-Zi:5C06:/
-5270.1 "Universal Assault" sync / 1[56]:Meng-Zi:5C06:/
-5290.3 "Universal Assault" sync / 1[56]:Meng-Zi:5C06:/
-5293.3 "Universal Assault" sync / 1[56]:Xun-Zi:5C06:/
+5267.1 "Universal Assault" sync / 1[56]:[^:]*:Xun-Zi:5C06:/
+5270.1 "Universal Assault" sync / 1[56]:[^:]*:Meng-Zi:5C06:/
+5290.3 "Universal Assault" sync / 1[56]:[^:]*:Meng-Zi:5C06:/
+5293.3 "Universal Assault" sync / 1[56]:[^:]*:Xun-Zi:5C06:/
 
 # loop?
 # not sure what happens if Xun-Zi is still alive here?
-5312.7 "Deploy Armaments" sync / 1[56]:Meng-Zi:5C0[03]:/
-5322.8 "Deploy Armaments" sync / 1[56]:Meng-Zi:5C0[03]:/
-5333.9 "Deploy Armaments" sync / 1[56]:Meng-Zi:5C01:/
-5340.6 "High-Powered Laser" sync / 1[56]:Serial-Jointed Model:5C09:/
+5312.7 "Deploy Armaments" sync / 1[56]:[^:]*:Meng-Zi:5C0[03]:/
+5322.8 "Deploy Armaments" sync / 1[56]:[^:]*:Meng-Zi:5C0[03]:/
+5333.9 "Deploy Armaments" sync / 1[56]:[^:]*:Meng-Zi:5C01:/
+5340.6 "High-Powered Laser" sync / 1[56]:[^:]*:Serial-Jointed Model:5C09:/
 
 
 
@@ -399,48 +399,48 @@ hideall "--sync--"
 # -p 5BDD:6012.3
 # -ii 5CEC 5CED 5CEE 5CEF 5FFC 5FFF 5BDA 5BDC
 6000.0 "--sync--" sync / 00:0839::Beyond will be sealed off/ window 10000,0
-6007.3 "--sync--" sync / 14:False Idol:5BDD:/ window 10000,10
-6012.3 "Screaming Score" sync / 1[56]:False Idol:5BDD:/
-6025.5 "Made Magic" sync / 1[56]:False Idol:5BD[67]:/
-6035.7 "Made Magic" sync / 1[56]:False Idol:5BD[67]:/
-6044.9 "--sync--" sync / 1[56]:False Idol:5BD8:/ # Lighter Note castbar
-6053.9 "Lighter Note" sync / 1[56]:False Idol:5BD9:/ duration 6.2
-6063.1 "Rhythm Rings" sync / 1[56]:False Idol:5BD4:/
-6074.1 "Magical Interference" #sync / 1[56]:False Idol:5BD5:/
-6076.1 "Magical Interference" #sync / 1[56]:False Idol:5BD5:/
-6078.1 "Magical Interference" #sync / 1[56]:False Idol:5BD5:/
-6080.1 "Magical Interference" #sync / 1[56]:False Idol:5BD5:/
-6082.1 "Magical Interference" #sync / 1[56]:False Idol:5BD5:/
-6092.3 "Seed Of Magic" sync / 1[56]:False Idol:5BDE:/
-6093.4 "Magical Interference" #sync / 1[56]:False Idol:5BD5:/
-6095.4 "Scattered Magic" sync / 1[56]:False Idol:5BDF:/
-6097.0 "Magical Interference" #sync / 1[56]:False Idol:5BD5:/
-6107.6 "Made Magic" sync / 1[56]:False Idol:5BD[67]:/
-6115.8 "Screaming Score" sync / 1[56]:False Idol:5BDD:/
+6007.3 "--sync--" sync / 14:[^:]*:False Idol:5BDD:/ window 10000,10
+6012.3 "Screaming Score" sync / 1[56]:[^:]*:False Idol:5BDD:/
+6025.5 "Made Magic" sync / 1[56]:[^:]*:False Idol:5BD[67]:/
+6035.7 "Made Magic" sync / 1[56]:[^:]*:False Idol:5BD[67]:/
+6044.9 "--sync--" sync / 1[56]:[^:]*:False Idol:5BD8:/ # Lighter Note castbar
+6053.9 "Lighter Note" sync / 1[56]:[^:]*:False Idol:5BD9:/ duration 6.2
+6063.1 "Rhythm Rings" sync / 1[56]:[^:]*:False Idol:5BD4:/
+6074.1 "Magical Interference" #sync / 1[56]:[^:]*:False Idol:5BD5:/
+6076.1 "Magical Interference" #sync / 1[56]:[^:]*:False Idol:5BD5:/
+6078.1 "Magical Interference" #sync / 1[56]:[^:]*:False Idol:5BD5:/
+6080.1 "Magical Interference" #sync / 1[56]:[^:]*:False Idol:5BD5:/
+6082.1 "Magical Interference" #sync / 1[56]:[^:]*:False Idol:5BD5:/
+6092.3 "Seed Of Magic" sync / 1[56]:[^:]*:False Idol:5BDE:/
+6093.4 "Magical Interference" #sync / 1[56]:[^:]*:False Idol:5BD5:/
+6095.4 "Scattered Magic" sync / 1[56]:[^:]*:False Idol:5BDF:/
+6097.0 "Magical Interference" #sync / 1[56]:[^:]*:False Idol:5BD5:/
+6107.6 "Made Magic" sync / 1[56]:[^:]*:False Idol:5BD[67]:/
+6115.8 "Screaming Score" sync / 1[56]:[^:]*:False Idol:5BDD:/
 
-6128.0 "Darker Note" sync / 1[56]:False Idol:5BDB:/
-6137.2  "--sync--" sync / 1[56]:False Idol:5BD8:/ # Lighter Note castbar
-6146.2 "Lighter Note" sync / 1[56]:False Idol:5BD9:/ duration 6.2
-6159.4 "Made Magic" sync / 1[56]:False Idol:5BD[67]:/
-6167.6 "Rhythm Rings" sync / 1[56]:False Idol:5BD4:/
-6173.8 "Seed Of Magic" sync / 1[56]:False Idol:5BDE:/
-6176.8 "Scattered Magic" sync / 1[56]:False Idol:5BDF:/
-6178.6 "Magical Interference" #sync / 1[56]:False Idol:5BD5:/
-6180.6 "Magical Interference" #sync / 1[56]:False Idol:5BD5:/
-6182.6 "Magical Interference" #sync / 1[56]:False Idol:5BD5:/
-6184.6 "Magical Interference" #sync / 1[56]:False Idol:5BD5:/
-6190.9 "Seed Of Magic" sync / 1[56]:False Idol:5BDE:/
-6193.9 "Scattered Magic" sync / 1[56]:False Idol:5BDF:/
-6197.0 "Magical Interference" #sync / 1[56]:False Idol:5BD5:/
-6200.5 "Magical Interference" #sync / 1[56]:False Idol:5BD5:/
-6209.0 "Made Magic" sync / 1[56]:False Idol:5BD[67]:/
-6217.2 "Screaming Score" sync / 1[56]:False Idol:5BDD:/
-6225.4 "Screaming Score" sync / 1[56]:False Idol:5BDD:/
+6128.0 "Darker Note" sync / 1[56]:[^:]*:False Idol:5BDB:/
+6137.2  "--sync--" sync / 1[56]:[^:]*:False Idol:5BD8:/ # Lighter Note castbar
+6146.2 "Lighter Note" sync / 1[56]:[^:]*:False Idol:5BD9:/ duration 6.2
+6159.4 "Made Magic" sync / 1[56]:[^:]*:False Idol:5BD[67]:/
+6167.6 "Rhythm Rings" sync / 1[56]:[^:]*:False Idol:5BD4:/
+6173.8 "Seed Of Magic" sync / 1[56]:[^:]*:False Idol:5BDE:/
+6176.8 "Scattered Magic" sync / 1[56]:[^:]*:False Idol:5BDF:/
+6178.6 "Magical Interference" #sync / 1[56]:[^:]*:False Idol:5BD5:/
+6180.6 "Magical Interference" #sync / 1[56]:[^:]*:False Idol:5BD5:/
+6182.6 "Magical Interference" #sync / 1[56]:[^:]*:False Idol:5BD5:/
+6184.6 "Magical Interference" #sync / 1[56]:[^:]*:False Idol:5BD5:/
+6190.9 "Seed Of Magic" sync / 1[56]:[^:]*:False Idol:5BDE:/
+6193.9 "Scattered Magic" sync / 1[56]:[^:]*:False Idol:5BDF:/
+6197.0 "Magical Interference" #sync / 1[56]:[^:]*:False Idol:5BD5:/
+6200.5 "Magical Interference" #sync / 1[56]:[^:]*:False Idol:5BD5:/
+6209.0 "Made Magic" sync / 1[56]:[^:]*:False Idol:5BD[67]:/
+6217.2 "Screaming Score" sync / 1[56]:[^:]*:False Idol:5BDD:/
+6225.4 "Screaming Score" sync / 1[56]:[^:]*:False Idol:5BDD:/
 
 # loop ??? (plz confirm)
-6239.6 "Darker Note" sync / 1[56]:False Idol:5BDB:/
-6248.8  "--sync--" sync / 1[56]:False Idol:5BD8:/ # Lighter Note castbar
-6257.8 "Lighter Note" sync / 1[56]:False Idol:5BD9:/ duration 6.2
+6239.6 "Darker Note" sync / 1[56]:[^:]*:False Idol:5BDB:/
+6248.8  "--sync--" sync / 1[56]:[^:]*:False Idol:5BD8:/ # Lighter Note castbar
+6257.8 "Lighter Note" sync / 1[56]:[^:]*:False Idol:5BD9:/ duration 6.2
 
 
 ### Her Inflorescence
@@ -450,88 +450,88 @@ hideall "--sync--"
 # -ii 5CEC 5CED 5CEE 5CEF 5FFF 5BDA 5BDC 5BEF 5BF2 5BE6 5BE8 5BE7
 # Whether there is a checkpoint is unclear, but sync as if there is.
 
-6963.3 "--sync--" sync / 14:False Idol:5DD5:/ window 1000,0
-6968.3 "Eminence" sync / 1[56]:False Idol:5DD5:/
+6963.3 "--sync--" sync / 14:[^:]*:False Idol:5DD5:/ window 1000,0
+6968.3 "Eminence" sync / 1[56]:[^:]*:False Idol:5DD5:/
 6968.3 "--untargetable--"
 
 7000.0 "--targetable--"
-7010.2 "--sync--" sync / 14:Her Inflorescence:5BE0:/ window 10000,0
-7013.2 "Pervasion" sync / 1[56]:Her Inflorescence:5BE0:/
-7019.3 "Recreate Structure" sync / 1[56]:Her Inflorescence:5BE1:/
-7030.4 "Uneven Footing" sync / 1[56]:Her Inflorescence:5BE2:/
-7033.9 "Recreate Structure" sync / 1[56]:Her Inflorescence:5BE1:/
-7045.0 "Uneven Footing" sync / 1[56]:Her Inflorescence:5BE2:/
+7010.2 "--sync--" sync / 14:[^:]*:Her Inflorescence:5BE0:/ window 10000,0
+7013.2 "Pervasion" sync / 1[56]:[^:]*:Her Inflorescence:5BE0:/
+7019.3 "Recreate Structure" sync / 1[56]:[^:]*:Her Inflorescence:5BE1:/
+7030.4 "Uneven Footing" sync / 1[56]:[^:]*:Her Inflorescence:5BE2:/
+7033.9 "Recreate Structure" sync / 1[56]:[^:]*:Her Inflorescence:5BE1:/
+7045.0 "Uneven Footing" sync / 1[56]:[^:]*:Her Inflorescence:5BE2:/
 
-7050.6 "Recreate Signal" sync / 1[56]:Her Inflorescence:5BE3:/
-7056.7 "Mixed Signals" sync / 1[56]:Her Inflorescence:5BE4:/
-7066.6 "Crash" sync / 1[56]:Her Inflorescence:5BE5:/
-7074.8 "Mixed Signals" sync / 1[56]:Her Inflorescence:5BE4:/
-7082.7 "Crash" sync / 1[56]:Her Inflorescence:5BE5:/
-7086.9 "--sync--" sync / 1[56]:Her Inflorescence:5C0C:/ # Lighter Note castbar
-7095.9 "Lighter Note" sync / 1[56]:Her Inflorescence:5BD9:/ # duration 6.2
-7105.0 "Screaming Score" sync / 1[56]:Her Inflorescence:5BF5:/
-7113.2 "Darker Note" sync / 1[56]:Her Inflorescence:5C0A:/
-7128.4 "Heavy Arms" sync / 1[56]:Her Inflorescence:5BE[DE]:/
-7138.6 "Heavy Arms" sync / 1[56]:Her Inflorescence:5BE[DE]:/
+7050.6 "Recreate Signal" sync / 1[56]:[^:]*:Her Inflorescence:5BE3:/
+7056.7 "Mixed Signals" sync / 1[56]:[^:]*:Her Inflorescence:5BE4:/
+7066.6 "Crash" sync / 1[56]:[^:]*:Her Inflorescence:5BE5:/
+7074.8 "Mixed Signals" sync / 1[56]:[^:]*:Her Inflorescence:5BE4:/
+7082.7 "Crash" sync / 1[56]:[^:]*:Her Inflorescence:5BE5:/
+7086.9 "--sync--" sync / 1[56]:[^:]*:Her Inflorescence:5C0C:/ # Lighter Note castbar
+7095.9 "Lighter Note" sync / 1[56]:[^:]*:Her Inflorescence:5BD9:/ # duration 6.2
+7105.0 "Screaming Score" sync / 1[56]:[^:]*:Her Inflorescence:5BF5:/
+7113.2 "Darker Note" sync / 1[56]:[^:]*:Her Inflorescence:5C0A:/
+7128.4 "Heavy Arms" sync / 1[56]:[^:]*:Her Inflorescence:5BE[DE]:/
+7138.6 "Heavy Arms" sync / 1[56]:[^:]*:Her Inflorescence:5BE[DE]:/
 
-7151.4 "Distortion" sync / 1[56]:Her Inflorescence:5BE9:/
-7157.6 "Place Of Power" sync / 1[56]:Her Inflorescence:5C0D:/
-7157.6 "The Final Song" sync / 1[56]:Her Inflorescence:5BEA:/
-7167.7 "White Dissonance / Black Dissonance" sync / 1[56]:Her Inflorescence:5BE[BC]:/
-7173.7 "White Dissonance / Black Dissonance" sync / 1[56]:Her Inflorescence:5BE[BC]:/
-7179.7 "White Dissonance / Black Dissonance" sync / 1[56]:Her Inflorescence:5BE[BC]:/
+7151.4 "Distortion" sync / 1[56]:[^:]*:Her Inflorescence:5BE9:/
+7157.6 "Place Of Power" sync / 1[56]:[^:]*:Her Inflorescence:5C0D:/
+7157.6 "The Final Song" sync / 1[56]:[^:]*:Her Inflorescence:5BEA:/
+7167.7 "White Dissonance / Black Dissonance" sync / 1[56]:[^:]*:Her Inflorescence:5BE[BC]:/
+7173.7 "White Dissonance / Black Dissonance" sync / 1[56]:[^:]*:Her Inflorescence:5BE[BC]:/
+7179.7 "White Dissonance / Black Dissonance" sync / 1[56]:[^:]*:Her Inflorescence:5BE[BC]:/
 
-7200.5 "Pillar Impact" sync / 1[56]:Her Inflorescence:5BF0:/
-7202.0 "Shockwave" sync / 1[56]:Her Inflorescence:5BF1:/
-7204.6 "Pillar Impact" sync / 1[56]:Her Inflorescence:5C0E:/
-7206.0 "Shockwave" sync / 1[56]:Her Inflorescence:5BF1:/
-7211.6 "Towerfall" sync / 1[56]:Her Inflorescence:5BF3:/
-7220.8 "Towerfall" sync / 1[56]:Her Inflorescence:5BF4:/
+7200.5 "Pillar Impact" sync / 1[56]:[^:]*:Her Inflorescence:5BF0:/
+7202.0 "Shockwave" sync / 1[56]:[^:]*:Her Inflorescence:5BF1:/
+7204.6 "Pillar Impact" sync / 1[56]:[^:]*:Her Inflorescence:5C0E:/
+7206.0 "Shockwave" sync / 1[56]:[^:]*:Her Inflorescence:5BF1:/
+7211.6 "Towerfall" sync / 1[56]:[^:]*:Her Inflorescence:5BF3:/
+7220.8 "Towerfall" sync / 1[56]:[^:]*:Her Inflorescence:5BF4:/
 
-7231.2 "Recreate Signal" sync / 1[56]:Her Inflorescence:5BE3:/
-7237.3 "Mixed Signals" sync / 1[56]:Her Inflorescence:5BE4:/
-7255.4 "Distortion" sync / 1[56]:Her Inflorescence:6058:/
-7261.6 "The Final Song" sync / 1[56]:Her Inflorescence:5BEA:/
-7270.7 "White Dissonance / Black Dissonance" #sync / 1[56]:Her Inflorescence:5BE[BC]:/
-7272.7 "White Dissonance / Black Dissonance" #sync / 1[56]:Her Inflorescence:5BE[BC]:/
-7274.7 "White Dissonance / Black Dissonance" #sync / 1[56]:Her Inflorescence:5BE[BC]:/
-7283.7 "Heavy Arms" sync / 1[56]:Her Inflorescence:5BE[DE]:/
-7289.8 "--sync--" sync / 1[56]:Her Inflorescence:5C0C:/ # Lighter Note castbar
-7298.8 "Lighter Note" sync / 1[56]:Her Inflorescence:5BD9:/ duration 6.2
-7309.9 "Heavy Arms" sync / 1[56]:Her Inflorescence:5BE[DE]:/
+7231.2 "Recreate Signal" sync / 1[56]:[^:]*:Her Inflorescence:5BE3:/
+7237.3 "Mixed Signals" sync / 1[56]:[^:]*:Her Inflorescence:5BE4:/
+7255.4 "Distortion" sync / 1[56]:[^:]*:Her Inflorescence:6058:/
+7261.6 "The Final Song" sync / 1[56]:[^:]*:Her Inflorescence:5BEA:/
+7270.7 "White Dissonance / Black Dissonance" #sync / 1[56]:[^:]*:Her Inflorescence:5BE[BC]:/
+7272.7 "White Dissonance / Black Dissonance" #sync / 1[56]:[^:]*:Her Inflorescence:5BE[BC]:/
+7274.7 "White Dissonance / Black Dissonance" #sync / 1[56]:[^:]*:Her Inflorescence:5BE[BC]:/
+7283.7 "Heavy Arms" sync / 1[56]:[^:]*:Her Inflorescence:5BE[DE]:/
+7289.8 "--sync--" sync / 1[56]:[^:]*:Her Inflorescence:5C0C:/ # Lighter Note castbar
+7298.8 "Lighter Note" sync / 1[56]:[^:]*:Her Inflorescence:5BD9:/ duration 6.2
+7309.9 "Heavy Arms" sync / 1[56]:[^:]*:Her Inflorescence:5BE[DE]:/
 
-7316.0 "Recreate Signal" sync / 1[56]:Her Inflorescence:5BE3:/
-7322.1 "Mixed Signals" sync / 1[56]:Her Inflorescence:5BE4:/
-7328.2 "Rhythm Rings" sync / 1[56]:Her Inflorescence:5C0B:/
-7330.0 "Crash" sync / 1[56]:Her Inflorescence:5BE5:/
-7338.2 "Magical Interference" sync / 1[56]:Her Inflorescence:5BD5:/
-7344.3 "Screaming Score" sync / 1[56]:Her Inflorescence:5BF5:/
-7352.5 "Darker Note" sync / 1[56]:Her Inflorescence:5C0A:/
-7364.7 "Pervasion" sync / 1[56]:Her Inflorescence:5BE0:/
+7316.0 "Recreate Signal" sync / 1[56]:[^:]*:Her Inflorescence:5BE3:/
+7322.1 "Mixed Signals" sync / 1[56]:[^:]*:Her Inflorescence:5BE4:/
+7328.2 "Rhythm Rings" sync / 1[56]:[^:]*:Her Inflorescence:5C0B:/
+7330.0 "Crash" sync / 1[56]:[^:]*:Her Inflorescence:5BE5:/
+7338.2 "Magical Interference" sync / 1[56]:[^:]*:Her Inflorescence:5BD5:/
+7344.3 "Screaming Score" sync / 1[56]:[^:]*:Her Inflorescence:5BF5:/
+7352.5 "Darker Note" sync / 1[56]:[^:]*:Her Inflorescence:5C0A:/
+7364.7 "Pervasion" sync / 1[56]:[^:]*:Her Inflorescence:5BE0:/
 
-7370.8 "Recreate Structure" sync / 1[56]:Her Inflorescence:5BE1:/
-7381.0 "Rhythm Rings" sync / 1[56]:Her Inflorescence:5C0B:/
-7383.0 "Uneven Footing" sync / 1[56]:Her Inflorescence:5BE2:/
-7391.0 "Magical Interference" sync / 1[56]:Her Inflorescence:5BD5:/
-7398.2 "Heavy Arms" sync / 1[56]:Her Inflorescence:5BE[DE]:/
-7406.4 "Screaming Score" sync / 1[56]:Her Inflorescence:5BF5:/
+7370.8 "Recreate Structure" sync / 1[56]:[^:]*:Her Inflorescence:5BE1:/
+7381.0 "Rhythm Rings" sync / 1[56]:[^:]*:Her Inflorescence:5C0B:/
+7383.0 "Uneven Footing" sync / 1[56]:[^:]*:Her Inflorescence:5BE2:/
+7391.0 "Magical Interference" sync / 1[56]:[^:]*:Her Inflorescence:5BD5:/
+7398.2 "Heavy Arms" sync / 1[56]:[^:]*:Her Inflorescence:5BE[DE]:/
+7406.4 "Screaming Score" sync / 1[56]:[^:]*:Her Inflorescence:5BF5:/
 
-7425.3 "Pillar Impact" sync / 1[56]:Her Inflorescence:5BF0:/
-7426.8 "Shockwave" sync / 1[56]:Her Inflorescence:5BF1:/
-7429.4 "Pillar Impact" sync / 1[56]:Her Inflorescence:5C0E:/
-7430.8 "Shockwave" sync / 1[56]:Her Inflorescence:5BF1:/
-7436.4 "Towerfall" sync / 1[56]:Her Inflorescence:5BF3:/
-7445.6 "Towerfall" sync / 1[56]:Her Inflorescence:5BF4:/
+7425.3 "Pillar Impact" sync / 1[56]:[^:]*:Her Inflorescence:5BF0:/
+7426.8 "Shockwave" sync / 1[56]:[^:]*:Her Inflorescence:5BF1:/
+7429.4 "Pillar Impact" sync / 1[56]:[^:]*:Her Inflorescence:5C0E:/
+7430.8 "Shockwave" sync / 1[56]:[^:]*:Her Inflorescence:5BF1:/
+7436.4 "Towerfall" sync / 1[56]:[^:]*:Her Inflorescence:5BF3:/
+7445.6 "Towerfall" sync / 1[56]:[^:]*:Her Inflorescence:5BF4:/
 
 # loop
-7455.8 "Recreate Signal" sync / 1[56]:Her Inflorescence:5BE3:/ window 100,100 jump 7231.2
-7461.9 "Mixed Signals" #sync / 1[56]:Her Inflorescence:5BE4:/
-7480.0 "Distortion" #sync / 1[56]:Her Inflorescence:6058:/
-7486.2 "The Final Song" #sync / 1[56]:Her Inflorescence:5BEA:/
-7495.3 "White Dissonance / Black Dissonance" #sync / 1[56]:Her Inflorescence:5BE[BC]:/
-7497.3 "White Dissonance / Black Dissonance" #sync / 1[56]:Her Inflorescence:5BE[BC]:/
-7499.3 "White Dissonance / Black Dissonance" #sync / 1[56]:Her Inflorescence:5BE[BC]:/
-7508.3 "Heavy Arms" #sync / 1[56]:Her Inflorescence:5BE[DE]:/
-7514.4 "--sync--" #sync / 1[56]:Her Inflorescence:5C0C:/ # Lighter Note castbar
-7523.4 "Lighter Note" #sync / 1[56]:Her Inflorescence:5BD9:/ duration 6.2
-7534.5 "Heavy Arms" #sync / 1[56]:Her Inflorescence:5BE[DE]:/
+7455.8 "Recreate Signal" sync / 1[56]:[^:]*:Her Inflorescence:5BE3:/ window 100,100 jump 7231.2
+7461.9 "Mixed Signals" #sync / 1[56]:[^:]*:Her Inflorescence:5BE4:/
+7480.0 "Distortion" #sync / 1[56]:[^:]*:Her Inflorescence:6058:/
+7486.2 "The Final Song" #sync / 1[56]:[^:]*:Her Inflorescence:5BEA:/
+7495.3 "White Dissonance / Black Dissonance" #sync / 1[56]:[^:]*:Her Inflorescence:5BE[BC]:/
+7497.3 "White Dissonance / Black Dissonance" #sync / 1[56]:[^:]*:Her Inflorescence:5BE[BC]:/
+7499.3 "White Dissonance / Black Dissonance" #sync / 1[56]:[^:]*:Her Inflorescence:5BE[BC]:/
+7508.3 "Heavy Arms" #sync / 1[56]:[^:]*:Her Inflorescence:5BE[DE]:/
+7514.4 "--sync--" #sync / 1[56]:[^:]*:Her Inflorescence:5C0C:/ # Lighter Note castbar
+7523.4 "Lighter Note" #sync / 1[56]:[^:]*:Her Inflorescence:5BD9:/ duration 6.2
+7534.5 "Heavy Arms" #sync / 1[56]:[^:]*:Her Inflorescence:5BE[DE]:/

--- a/ui/raidboss/data/05-shb/dungeon/akadaemia_anyder.txt
+++ b/ui/raidboss/data/05-shb/dungeon/akadaemia_anyder.txt
@@ -14,30 +14,30 @@ hideall "--sync--"
 # This is maybe like +/- 1-2 seconds?
 
 100.0 "--sync--" sync / 00:0839::Ichthyology will be sealed off/ window 100,0
-103.0 "--sync--" sync / 1[56]:Cladoselache:368:/ window 103,0
-110.5 "Protolithic Puncture" sync / 1[56]:Cladoselache:3E04:/
-119.5 "Tidal Guillotine" sync / 1[56]:Cladoselache:3E08:/
+103.0 "--sync--" sync / 1[56]:[^:]*:Cladoselache:368:/ window 103,0
+110.5 "Protolithic Puncture" sync / 1[56]:[^:]*:Cladoselache:3E04:/
+119.5 "Tidal Guillotine" sync / 1[56]:[^:]*:Cladoselache:3E08:/
 128.7 "--2x targetable--" sync / 22:........:Doliodus:........:Doliodus:01/
 129.7 "--1x targetable--" sync / 22:........:Cladoselache:........:Cladoselache:00/
 
-138.5 "Pelagic Cleaver" sync / 1[56]:Doliodus:3E09:/
-150.5 "Tidal Guillotine" sync / 1[56]:Cladoselache:3E0A:/ window 10,10
+138.5 "Pelagic Cleaver" sync / 1[56]:[^:]*:Doliodus:3E09:/
+150.5 "Tidal Guillotine" sync / 1[56]:[^:]*:Cladoselache:3E0A:/ window 10,10
 152.7 "--2x targetable--" sync / 22:........:Cladoselache:........:Cladoselache:01/
 154.7 "--1x targetable--" sync / 22:........:Doliodus:........:Doliodus:00/
 
-162.4 "Aquatic Lance" sync / 1[56]:Cladoselache:3E05:/
-173.5 "Protolithic Puncture" sync / 1[56]:Cladoselache:3E04:/
-179.9 "Pelagic Cleaver" sync / 1[56]:Doliodus:3E0B:/ window 10,10
+162.4 "Aquatic Lance" sync / 1[56]:[^:]*:Cladoselache:3E05:/
+173.5 "Protolithic Puncture" sync / 1[56]:[^:]*:Cladoselache:3E04:/
+179.9 "Pelagic Cleaver" sync / 1[56]:[^:]*:Doliodus:3E0B:/ window 10,10
 181.5 "--untargetable--" sync / 22:........:Cladoselache:........:Cladoselache:00/
 183.3 "--targetable--" sync / 22:........:Doliodus:........:Doliodus:01/
 
-189.4 "Marine Mayhem" sync / 1[56]:Doliodus:3E06:/
-199.8 "Protolithic Puncture" sync / 1[56]:Doliodus:3E04:/
-201.4 "Tidal Guillotine" sync / 1[56]:Cladoselache:3E0A:/ window 10,10
+189.4 "Marine Mayhem" sync / 1[56]:[^:]*:Doliodus:3E06:/
+199.8 "Protolithic Puncture" sync / 1[56]:[^:]*:Doliodus:3E04:/
+201.4 "Tidal Guillotine" sync / 1[56]:[^:]*:Cladoselache:3E0A:/ window 10,10
 203.8 "--2x targetable--" sync / 22:........:Cladoselache:........:Cladoselache:01/
 205.1 "--1x targetable--" sync / 22:........:Doliodus:........:Doliodus:00/
 
-213.2 "Aquatic Lance" sync / 1[56]:Cladoselache:3E05:/ window 30,30 jump 162.4
+213.2 "Aquatic Lance" sync / 1[56]:[^:]*:Cladoselache:3E05:/ window 30,30 jump 162.4
 224.3 "Protolithic Puncture"
 230.7 "Pelagic Cleaver"
 232.3 "--untargetable--"
@@ -51,51 +51,51 @@ hideall "--sync--"
 
 # When one dies, the other powers up and starts casting stuff after it jumps back in.
 # However, I've never seen this cast get off, so just guessing on Marine Mayhem cast length.
-300.0 "--sync--" sync / 14:(Doliodus|Cladoselache):3E07:/ window 300,0
-302.0 "Carcharian Verve" sync / 1[56]:(Doliodus|Cladoselache):3E07:/ window 300,0
-305.5 "Marine Mayhem" sync / 1[56]:(Doliodus|Cladoselache):3E06:/
+300.0 "--sync--" sync / 14:[^:]*:(Doliodus|Cladoselache):3E07:/ window 300,0
+302.0 "Carcharian Verve" sync / 1[56]:[^:]*:(Doliodus|Cladoselache):3E07:/ window 300,0
+305.5 "Marine Mayhem" sync / 1[56]:[^:]*:(Doliodus|Cladoselache):3E06:/
 
 
 
 ### Marquis Morbol
 # -p 3E16:508.5 -ii 3E11 3E14
 500.0 "--sync--" sync / 00:0839::Phytobiology will be sealed off/ window 500,0
-505.0 "--sync--" sync / 1[56]:Marquis Morbol:3E14:/ window 505,5
-508.5 "Lash" sync / 1[56]:Marquis Morbol:3E16:/
-516.1 "Sap Shower" sync / 1[56]:Marquis Morbol:3E15:/
-524.7 "Arbor Storm" sync / 1[56]:Marquis Morbol:3E17:/
+505.0 "--sync--" sync / 1[56]:[^:]*:Marquis Morbol:3E14:/ window 505,5
+508.5 "Lash" sync / 1[56]:[^:]*:Marquis Morbol:3E16:/
+516.1 "Sap Shower" sync / 1[56]:[^:]*:Marquis Morbol:3E15:/
+524.7 "Arbor Storm" sync / 1[56]:[^:]*:Marquis Morbol:3E17:/
 
 # extensible tendrils appears to have some variation on start time
-532.3 "--sync--" sync / 14:Marquis Morbol:3E10:/ window 30,10
-537.3 "Extensible Tendrils" sync / 1[56]:Marquis Morbol:3E10:/ duration 25
-564.7 "Putrid Breath" sync / 1[56]:Marquis Morbol:3E12:/
-569.0 "Lash" #sync / 1[56]:Marquis Morbol:3E16:/
-575.0 "Lash" #sync / 1[56]:Marquis Morbol:3E16:/
-581.1 "Blossom" sync / 1[56]:Marquis Morbol:3E13:/
-589.7 "Arbor Storm" sync / 1[56]:Marquis Morbol:3E17:/
+532.3 "--sync--" sync / 14:[^:]*:Marquis Morbol:3E10:/ window 30,10
+537.3 "Extensible Tendrils" sync / 1[56]:[^:]*:Marquis Morbol:3E10:/ duration 25
+564.7 "Putrid Breath" sync / 1[56]:[^:]*:Marquis Morbol:3E12:/
+569.0 "Lash" #sync / 1[56]:[^:]*:Marquis Morbol:3E16:/
+575.0 "Lash" #sync / 1[56]:[^:]*:Marquis Morbol:3E16:/
+581.1 "Blossom" sync / 1[56]:[^:]*:Marquis Morbol:3E13:/
+589.7 "Arbor Storm" sync / 1[56]:[^:]*:Marquis Morbol:3E17:/
 
-598.3 "--sync--" sync / 14:Marquis Morbol:3E10:/ window 10,10
-603.3 "Extensible Tendrils" sync / 1[56]:Marquis Morbol:3E10:/ duration 25
-611.4 "Sap Shower" sync / 1[56]:Marquis Morbol:3E15:/
-630.8 "Putrid Breath" sync / 1[56]:Marquis Morbol:3E12:/
-634.2 "Lash" sync / 1[56]:Marquis Morbol:3E16:/
-646.6 "Blossom" sync / 1[56]:Marquis Morbol:3E13:/
-653.3 "Sap Shower" sync / 1[56]:Marquis Morbol:3E15:/
-657.1 "Lash" sync / 1[56]:Marquis Morbol:3E16:/
+598.3 "--sync--" sync / 14:[^:]*:Marquis Morbol:3E10:/ window 10,10
+603.3 "Extensible Tendrils" sync / 1[56]:[^:]*:Marquis Morbol:3E10:/ duration 25
+611.4 "Sap Shower" sync / 1[56]:[^:]*:Marquis Morbol:3E15:/
+630.8 "Putrid Breath" sync / 1[56]:[^:]*:Marquis Morbol:3E12:/
+634.2 "Lash" sync / 1[56]:[^:]*:Marquis Morbol:3E16:/
+646.6 "Blossom" sync / 1[56]:[^:]*:Marquis Morbol:3E13:/
+653.3 "Sap Shower" sync / 1[56]:[^:]*:Marquis Morbol:3E15:/
+657.1 "Lash" sync / 1[56]:[^:]*:Marquis Morbol:3E16:/
 
-660.3 "--sync--" sync / 14:Marquis Morbol:3E10:/ window 10,10
-665.3 "Extensible Tendrils" sync / 1[56]:Marquis Morbol:3E10:/
-692.6 "Putrid Breath" sync / 1[56]:Marquis Morbol:3E12:/
-699.0 "Arbor Storm" sync / 1[56]:Marquis Morbol:3E17:/
-707.6 "Blossom" sync / 1[56]:Marquis Morbol:3E13:/
-716.1 "Arbor Storm" sync / 1[56]:Marquis Morbol:3E17:/
+660.3 "--sync--" sync / 14:[^:]*:Marquis Morbol:3E10:/ window 10,10
+665.3 "Extensible Tendrils" sync / 1[56]:[^:]*:Marquis Morbol:3E10:/
+692.6 "Putrid Breath" sync / 1[56]:[^:]*:Marquis Morbol:3E12:/
+699.0 "Arbor Storm" sync / 1[56]:[^:]*:Marquis Morbol:3E17:/
+707.6 "Blossom" sync / 1[56]:[^:]*:Marquis Morbol:3E13:/
+716.1 "Arbor Storm" sync / 1[56]:[^:]*:Marquis Morbol:3E17:/
 
-724.8 "--sync--" sync / 14:Marquis Morbol:3E10:/ window 10,10
-729.8 "Extensible Tendrils" sync / 1[56]:Marquis Morbol:3E10:/ duration 25
-737.9 "Sap Shower" sync / 1[56]:Marquis Morbol:3E15:/
-757.3 "Putrid Breath" sync / 1[56]:Marquis Morbol:3E12:/
-760.7 "Lash" sync / 1[56]:Marquis Morbol:3E16:/
-773.1 "Blossom" sync / 1[56]:Marquis Morbol:3E13:/ window 50,50 jump 646.6
+724.8 "--sync--" sync / 14:[^:]*:Marquis Morbol:3E10:/ window 10,10
+729.8 "Extensible Tendrils" sync / 1[56]:[^:]*:Marquis Morbol:3E10:/ duration 25
+737.9 "Sap Shower" sync / 1[56]:[^:]*:Marquis Morbol:3E15:/
+757.3 "Putrid Breath" sync / 1[56]:[^:]*:Marquis Morbol:3E12:/
+760.7 "Lash" sync / 1[56]:[^:]*:Marquis Morbol:3E16:/
+773.1 "Blossom" sync / 1[56]:[^:]*:Marquis Morbol:3E13:/ window 50,50 jump 646.6
 779.8 "Sap Shower"
 783.6 "Lash"
 
@@ -110,24 +110,24 @@ hideall "--sync--"
 ### Quetzalcoatl
 # -ii 3E1A 3E1B 3E22 3E20 -p 3E23:1008.2
 1000.0 "--sync--" sync / 00:0839::Phantomology will be sealed off/ window 1000,0
-1008.2 "Shockbolt" sync / 1[56]:Quetzalcoatl:3E23:/ window 1010,5
-1017.9 "Thunderbolt" sync / 1[56]:Quetzalcoatl:3E24:/
-1031.4 "Thunderstorm" sync / 1[56]:Quetzalcoatl:3E1C:/
-1045.2 "Shocking Plumage" sync / 1[56]:Quetzalcoatl:3E21:/
-1057.5 "Thunderstorm" sync / 1[56]:Quetzalcoatl:3E1C:/
+1008.2 "Shockbolt" sync / 1[56]:[^:]*:Quetzalcoatl:3E23:/ window 1010,5
+1017.9 "Thunderbolt" sync / 1[56]:[^:]*:Quetzalcoatl:3E24:/
+1031.4 "Thunderstorm" sync / 1[56]:[^:]*:Quetzalcoatl:3E1C:/
+1045.2 "Shocking Plumage" sync / 1[56]:[^:]*:Quetzalcoatl:3E21:/
+1057.5 "Thunderstorm" sync / 1[56]:[^:]*:Quetzalcoatl:3E1C:/
 
-1067.6 "Reverse Current" sync / 1[56]:Quetzalcoatl:3E1E:/
-1085.0 "Winding Current" sync / 1[56]:Quetzalcoatl:3E1F:/
-1099.2 "Thunderstorm" sync / 1[56]:Quetzalcoatl:3E1C:/
-1107.0 "Shocking Plumage" sync / 1[56]:Quetzalcoatl:3E21:/
-1113.5 "Shockbolt" sync / 1[56]:Quetzalcoatl:3E23:/
-1122.1 "Thunderbolt" sync / 1[56]:Quetzalcoatl:3E24:/
-1131.5 "Thunderstorm" sync / 1[56]:Quetzalcoatl:3E1C:/
-1140.3 "Shocking Plumage" sync / 1[56]:Quetzalcoatl:3E21:/
-1148.8 "Shocking Plumage" sync / 1[56]:Quetzalcoatl:3E21:/
-1155.2 "Thunderbolt" sync / 1[56]:Quetzalcoatl:3E24:/
+1067.6 "Reverse Current" sync / 1[56]:[^:]*:Quetzalcoatl:3E1E:/
+1085.0 "Winding Current" sync / 1[56]:[^:]*:Quetzalcoatl:3E1F:/
+1099.2 "Thunderstorm" sync / 1[56]:[^:]*:Quetzalcoatl:3E1C:/
+1107.0 "Shocking Plumage" sync / 1[56]:[^:]*:Quetzalcoatl:3E21:/
+1113.5 "Shockbolt" sync / 1[56]:[^:]*:Quetzalcoatl:3E23:/
+1122.1 "Thunderbolt" sync / 1[56]:[^:]*:Quetzalcoatl:3E24:/
+1131.5 "Thunderstorm" sync / 1[56]:[^:]*:Quetzalcoatl:3E1C:/
+1140.3 "Shocking Plumage" sync / 1[56]:[^:]*:Quetzalcoatl:3E21:/
+1148.8 "Shocking Plumage" sync / 1[56]:[^:]*:Quetzalcoatl:3E21:/
+1155.2 "Thunderbolt" sync / 1[56]:[^:]*:Quetzalcoatl:3E24:/
 
-1163.6 "Reverse Current" sync / 1[56]:Quetzalcoatl:3E1E:/ window 50,50 jump 1067.6
+1163.6 "Reverse Current" sync / 1[56]:[^:]*:Quetzalcoatl:3E1E:/ window 50,50 jump 1067.6
 1181.0 "Winding Current"
 1195.2 "Thunderstorm"
 1203.0 "Shocking Plumage"

--- a/ui/raidboss/data/05-shb/dungeon/amaurot.txt
+++ b/ui/raidboss/data/05-shb/dungeon/amaurot.txt
@@ -10,24 +10,24 @@ hideall "--sync--"
 # -p 3CCE:113.5 -ii 3CC6 3CCA 3CC8
 
 100.0 "--sync--" sync / 00:0839::The First Doom will be sealed off/ window 100,0
-101.5 "--sync--" sync / 1[56]:The First Beast:368:/ window 102,0
-113.5 "Venomous Breath" sync / 1[56]:The First Beast:3CCE:/
-122.7 "Meteor Rain" sync / 1[56]:The First Beast:3CC4:/
-132.9 "The Falling Sky" sync / 1[56]:The First Beast:3CC9:/
-136.3 "Cosmic Kiss" sync / 1[56]:Fallen Star:42D4:/
-151.6 "The Final Sky" sync / 1[56]:The First Beast:3CCB:/
+101.5 "--sync--" sync / 1[56]:[^:]*:The First Beast:368:/ window 102,0
+113.5 "Venomous Breath" sync / 1[56]:[^:]*:The First Beast:3CCE:/
+122.7 "Meteor Rain" sync / 1[56]:[^:]*:The First Beast:3CC4:/
+132.9 "The Falling Sky" sync / 1[56]:[^:]*:The First Beast:3CC9:/
+136.3 "Cosmic Kiss" sync / 1[56]:[^:]*:Fallen Star:42D4:/
+151.6 "The Final Sky" sync / 1[56]:[^:]*:The First Beast:3CCB:/
 
-153.0 "Cosmic Shrapnel" sync / 1[56]:Fallen Star:42D6:/
-171.0 "Venomous Breath" sync / 1[56]:The First Beast:3CCE:/
-181.2 "Earthquake" sync / 1[56]:The First Beast:3CCD:/
-190.4 "Venomous Breath" sync / 1[56]:The First Beast:3CCE:/
-200.8 "Meteor Rain" sync / 1[56]:The First Beast:3CC4:/
-211.1 "The Falling Sky" sync / 1[56]:The First Beast:3CC9:/
-214.5 "Cosmic Kiss" sync / 1[56]:Fallen Star:42D4:/
-220.5 "The Burning Sky" sync / 1[56]:The First Beast:3CC7:/
-239.0 "The Final Sky" sync / 1[56]:The First Beast:3CCB:/
+153.0 "Cosmic Shrapnel" sync / 1[56]:[^:]*:Fallen Star:42D6:/
+171.0 "Venomous Breath" sync / 1[56]:[^:]*:The First Beast:3CCE:/
+181.2 "Earthquake" sync / 1[56]:[^:]*:The First Beast:3CCD:/
+190.4 "Venomous Breath" sync / 1[56]:[^:]*:The First Beast:3CCE:/
+200.8 "Meteor Rain" sync / 1[56]:[^:]*:The First Beast:3CC4:/
+211.1 "The Falling Sky" sync / 1[56]:[^:]*:The First Beast:3CC9:/
+214.5 "Cosmic Kiss" sync / 1[56]:[^:]*:Fallen Star:42D4:/
+220.5 "The Burning Sky" sync / 1[56]:[^:]*:The First Beast:3CC7:/
+239.0 "The Final Sky" sync / 1[56]:[^:]*:The First Beast:3CCB:/
 
-240.4 "Cosmic Shrapnel" sync / 1[56]:Fallen Star:42D6:/ window 30,30 jump 153
+240.4 "Cosmic Shrapnel" sync / 1[56]:[^:]*:Fallen Star:42D6:/ window 30,30 jump 153
 258.4 "Venomous Breath"
 268.6 "Earthquake"
 277.8 "Venomous Breath"
@@ -41,49 +41,49 @@ hideall "--sync--"
 ### Terminus Bellwether
 # -p 3CCF:523 -ii 465D 3CE4 3CD3 3CD2 3CD5 417D
 500.0 "--sync--" sync / 00:0839::The Second Doom will be sealed off/ window 500,0
-501.5 "--sync--" sync / 1[56]:Terminus Bellwether:368:/ window 502,0
-523.0 "Shrill Shriek" sync / 1[56]:Terminus Bellwether:3CCF:/
+501.5 "--sync--" sync / 1[56]:[^:]*:Terminus Bellwether:368:/ window 502,0
+523.0 "Shrill Shriek" sync / 1[56]:[^:]*:Terminus Bellwether:3CCF:/
 525.0 "--untargetable--"
 525.0 "Adds (N)"
 561.3 "Adds (SW)" sync / 03:........:Terminus Roiler:/  window 60,60
 610.9 "Adds (S)" sync / 03:........:Terminus Pursuer:/  window 100,100
-800.0 "--sync--" sync / 14:Terminus Bellwether:3CD0:/ window 300,00
-840.0 "Burst" sync / 1[56]:Terminus Bellwether:3CD0:/ window 40,40
+800.0 "--sync--" sync / 14:[^:]*:Terminus Bellwether:3CD0:/ window 300,00
+840.0 "Burst" sync / 1[56]:[^:]*:Terminus Bellwether:3CD0:/ window 40,40
 
 
 ### Therion
 # -ii 3CD6 3CDD 3CD9 3CDE 3CE1 3CDB 4191 4192 -p 3CE3:1013
 1000.0 "--sync--" sync / 00:0839::The Third Doom will be sealed off/ window 1000,0
-1001.0 "--sync--" sync / 1[56]:Therion:3CD6:/ window 1001,0
-1013.0 "Shadow Wreck" sync / 1[56]:Therion:3CE3:/
-1026.2 "Apokalypsis" sync / 1[56]:Therion:3CD7:/ duration 5.9
-1042.8 "Therion Charge" sync / 1[56]:Therion:3CDA:/
-1051.1 "Shadow Wreck" sync / 1[56]:Therion:3CE3:/
-1060.0 "Deathly Ray" sync / 1[56]:The Face of the Beast:3CDC:/ duration 4.4
-1068.9 "Deathly Ray" sync / 1[56]:The Face of the Beast:3CDC:/ duration 4.4
-1081.6 "Shadow Wreck" sync / 1[56]:Therion:3CE3:/
-1091.5 "Deathly Ray" sync / 1[56]:Therion:3CDF:/ duration 4.3
-1096.5 "--sync--" sync / 1[56]:Therion:42D3:/
-1099.2 "Misfortune" sync / 1[56]:Therion:3CE2:/
-1100.2 "Deathly Ray" sync / 1[56]:Therion:3CDF:/ duration 4.3
-1105.3 "--sync--" sync / 1[56]:Therion:42D3:/
-1115.1 "Apokalypsis" sync / 1[56]:Therion:3CD7:/ duration 5.9
-1131.7 "Therion Charge" sync / 1[56]:Therion:3CDA:/
-1140.0 "Shadow Wreck" sync / 1[56]:Therion:3CE3:/
+1001.0 "--sync--" sync / 1[56]:[^:]*:Therion:3CD6:/ window 1001,0
+1013.0 "Shadow Wreck" sync / 1[56]:[^:]*:Therion:3CE3:/
+1026.2 "Apokalypsis" sync / 1[56]:[^:]*:Therion:3CD7:/ duration 5.9
+1042.8 "Therion Charge" sync / 1[56]:[^:]*:Therion:3CDA:/
+1051.1 "Shadow Wreck" sync / 1[56]:[^:]*:Therion:3CE3:/
+1060.0 "Deathly Ray" sync / 1[56]:[^:]*:The Face of the Beast:3CDC:/ duration 4.4
+1068.9 "Deathly Ray" sync / 1[56]:[^:]*:The Face of the Beast:3CDC:/ duration 4.4
+1081.6 "Shadow Wreck" sync / 1[56]:[^:]*:Therion:3CE3:/
+1091.5 "Deathly Ray" sync / 1[56]:[^:]*:Therion:3CDF:/ duration 4.3
+1096.5 "--sync--" sync / 1[56]:[^:]*:Therion:42D3:/
+1099.2 "Misfortune" sync / 1[56]:[^:]*:Therion:3CE2:/
+1100.2 "Deathly Ray" sync / 1[56]:[^:]*:Therion:3CDF:/ duration 4.3
+1105.3 "--sync--" sync / 1[56]:[^:]*:Therion:42D3:/
+1115.1 "Apokalypsis" sync / 1[56]:[^:]*:Therion:3CD7:/ duration 5.9
+1131.7 "Therion Charge" sync / 1[56]:[^:]*:Therion:3CDA:/
+1140.0 "Shadow Wreck" sync / 1[56]:[^:]*:Therion:3CE3:/
 
-1148.8 "Deathly Ray" sync / 1[56]:The Face of the Beast:3CDC:/ duration 4.4
-1156.6 "Misfortune" sync / 1[56]:Therion:3CE2:/
-1157.6 "Deathly Ray" sync / 1[56]:The Face of the Beast:3CDC:/ duration 4.4
-1170.3 "Shadow Wreck" sync / 1[56]:Therion:3CE3:/
-1180.2 "Deathly Ray" sync / 1[56]:Therion:3CDF:/ duration 4.3
-1185.2 "--sync--" sync / 1[56]:Therion:42D3:/
-1188.0 "Misfortune" sync / 1[56]:Therion:3CE2:/
-1188.8 "Deathly Ray" sync / 1[56]:Therion:3CDF:/ duration 4.3
-1193.9 "--sync--" sync / 1[56]:Therion:42D3:/
-1202.5 "Shadow Wreck" sync / 1[56]:Therion:3CE3:/
-1213.7 "Apokalypsis" sync / 1[56]:Therion:3CD7:/ duration 5.9
+1148.8 "Deathly Ray" sync / 1[56]:[^:]*:The Face of the Beast:3CDC:/ duration 4.4
+1156.6 "Misfortune" sync / 1[56]:[^:]*:Therion:3CE2:/
+1157.6 "Deathly Ray" sync / 1[56]:[^:]*:The Face of the Beast:3CDC:/ duration 4.4
+1170.3 "Shadow Wreck" sync / 1[56]:[^:]*:Therion:3CE3:/
+1180.2 "Deathly Ray" sync / 1[56]:[^:]*:Therion:3CDF:/ duration 4.3
+1185.2 "--sync--" sync / 1[56]:[^:]*:Therion:42D3:/
+1188.0 "Misfortune" sync / 1[56]:[^:]*:Therion:3CE2:/
+1188.8 "Deathly Ray" sync / 1[56]:[^:]*:Therion:3CDF:/ duration 4.3
+1193.9 "--sync--" sync / 1[56]:[^:]*:Therion:42D3:/
+1202.5 "Shadow Wreck" sync / 1[56]:[^:]*:Therion:3CE3:/
+1213.7 "Apokalypsis" sync / 1[56]:[^:]*:Therion:3CD7:/ duration 5.9
 
-1230.7 "Deathly Ray" sync / 1[56]:The Face of the Beast:3CDC:/ duration 4.4 window 50,50 jump 1148.8
+1230.7 "Deathly Ray" sync / 1[56]:[^:]*:The Face of the Beast:3CDC:/ duration 4.4 window 50,50 jump 1148.8
 1238.5 "Misfortune"
 1239.5 "Deathly Ray"
 1252.2 "Shadow Wreck"

--- a/ui/raidboss/data/05-shb/dungeon/anamnesis_anyder.txt
+++ b/ui/raidboss/data/05-shb/dungeon/anamnesis_anyder.txt
@@ -9,56 +9,56 @@ hideall "--sync--"
 # -p 4B69:1013.5 4E4B:1313
 # -ii 4B78 4B6D 4B6F
 1000.0 "--sync--" sync / 00:0839::Katharsis will be sealed off/ window 1000,0
-1013.5 "Fetid Fang" sync / 1[56]:Unknown:4B69:/
-1032.3 "Scrutiny" sync / 1[56]:Unknown:4E25:/
-1034.3 "Explosion" sync / 1[56]:Sinister Bubble:4B6E:/
-1042.2 "Luminous Ray" sync / 1[56]:Unknown:4E26:/
+1013.5 "Fetid Fang" sync / 1[56]:[^:]*:Unknown:4B69:/
+1032.3 "Scrutiny" sync / 1[56]:[^:]*:Unknown:4E25:/
+1034.3 "Explosion" sync / 1[56]:[^:]*:Sinister Bubble:4B6E:/
+1042.2 "Luminous Ray" sync / 1[56]:[^:]*:Unknown:4E26:/
 # ???
 
 # Two Adds (hp push???)
 # hopefully there's not an inscrutability cast before the one preceding the add?
-1047.4 "--sync--" sync / 14:Unknown:4B6A:/ window 50,0
-1051.4 "Inscrutability" sync / 1[56]:Unknown:4B6A:/
-1059.8 "Unknown Add" sync / 1[56]:Unknown:4B77:/ window 60,60
-1064.8 "Ectoplasmic Ray" sync / 1[56]:Unknown:4B7A:/
-1072.1 "Scrutiny" sync / 1[56]:Unknown:4E25:/
-1074.1 "Explosion" sync / 1[56]:Sinister Bubble:4B6E:/
-1082.3 "Luminous Ray" sync / 1[56]:Unknown:4E27:/
-1090.9 "Inscrutability" sync / 1[56]:Unknown:4B6A:/
-1100.2 "Fetid Fang" sync / 1[56]:Unknown:4B69:/
-1108.9 "Clearout" sync / 1[56]:Unknown:4B74:/
-1114.9 "Clearout" sync / 1[56]:Unknown:4B6B:/
-1120.1 "Setback" sync / 1[56]:Unknown:4B6C:/
-1126.3 "--sync--" sync / 1[56]:Unknown:4B70:/
-1131.3 "Ectoplasmic Ray" sync / 1[56]:Unknown:4B79:/
-1131.7 "Ectoplasmic Ray" sync / 1[56]:Unknown:4B71:/
-1138.2 "Luminous Ray" sync / 1[56]:Unknown:4E27:/
-1147.8 "Inscrutability" sync / 1[56]:Unknown:4B6A:/
+1047.4 "--sync--" sync / 14:[^:]*:Unknown:4B6A:/ window 50,0
+1051.4 "Inscrutability" sync / 1[56]:[^:]*:Unknown:4B6A:/
+1059.8 "Unknown Add" sync / 1[56]:[^:]*:Unknown:4B77:/ window 60,60
+1064.8 "Ectoplasmic Ray" sync / 1[56]:[^:]*:Unknown:4B7A:/
+1072.1 "Scrutiny" sync / 1[56]:[^:]*:Unknown:4E25:/
+1074.1 "Explosion" sync / 1[56]:[^:]*:Sinister Bubble:4B6E:/
+1082.3 "Luminous Ray" sync / 1[56]:[^:]*:Unknown:4E27:/
+1090.9 "Inscrutability" sync / 1[56]:[^:]*:Unknown:4B6A:/
+1100.2 "Fetid Fang" sync / 1[56]:[^:]*:Unknown:4B69:/
+1108.9 "Clearout" sync / 1[56]:[^:]*:Unknown:4B74:/
+1114.9 "Clearout" sync / 1[56]:[^:]*:Unknown:4B6B:/
+1120.1 "Setback" sync / 1[56]:[^:]*:Unknown:4B6C:/
+1126.3 "--sync--" sync / 1[56]:[^:]*:Unknown:4B70:/
+1131.3 "Ectoplasmic Ray" sync / 1[56]:[^:]*:Unknown:4B79:/
+1131.7 "Ectoplasmic Ray" sync / 1[56]:[^:]*:Unknown:4B71:/
+1138.2 "Luminous Ray" sync / 1[56]:[^:]*:Unknown:4E27:/
+1147.8 "Inscrutability" sync / 1[56]:[^:]*:Unknown:4B6A:/
 
-1156.9 "--sync--" sync / 1[56]:Unknown:4B77:/ window 50,50 jump 1059.8
-1161.9 "Ectoplasmic Ray" sync / 1[56]:Unknown:4B7A:/
-1169.5 "Scrutiny" sync / 1[56]:Unknown:4E25:/
-1171.5 "Explosion" sync / 1[56]:Sinister Bubble:4B6E:/
-1179.3 "Luminous Ray" sync / 1[56]:Unknown:4E27:/
-1187.4 "Inscrutability" sync / 1[56]:Unknown:4B6A:/
-1196.7 "Fetid Fang" sync / 1[56]:Unknown:4B69:/
-1206.0 "Clearout" sync / 1[56]:Unknown:4B74:/
-1212.0 "Clearout" sync / 1[56]:Unknown:4B6B:/
-1217.2 "Setback" sync / 1[56]:Unknown:4B6C:/
+1156.9 "--sync--" sync / 1[56]:[^:]*:Unknown:4B77:/ window 50,50 jump 1059.8
+1161.9 "Ectoplasmic Ray" sync / 1[56]:[^:]*:Unknown:4B7A:/
+1169.5 "Scrutiny" sync / 1[56]:[^:]*:Unknown:4E25:/
+1171.5 "Explosion" sync / 1[56]:[^:]*:Sinister Bubble:4B6E:/
+1179.3 "Luminous Ray" sync / 1[56]:[^:]*:Unknown:4E27:/
+1187.4 "Inscrutability" sync / 1[56]:[^:]*:Unknown:4B6A:/
+1196.7 "Fetid Fang" sync / 1[56]:[^:]*:Unknown:4B69:/
+1206.0 "Clearout" sync / 1[56]:[^:]*:Unknown:4B74:/
+1212.0 "Clearout" sync / 1[56]:[^:]*:Unknown:4B6B:/
+1217.2 "Setback" sync / 1[56]:[^:]*:Unknown:4B6C:/
 
 # One add (???)
 # starts 3 second cast 10 seconds after other add dies?
-1310.0 "--sync--"  sync / 14:Unknown:4E4B:/ window 310,0
-1313.0 "Plain Weirdness" sync / 1[56]:Unknown:4E4B:/
-1319.2 "Inscrutability" sync / 1[56]:Unknown:4B73:/
-1329.4 "--sync--" sync / 1[56]:Unknown:4B77:/
-1334.4 "Ectoplasmic Ray" sync / 1[56]:Unknown:4B7A:/
-1342.0 "Luminous Ray" sync / 1[56]:Unknown:4E27:/
-1354.3 "Fetid Fang" sync / 1[56]:Unknown:4B72:/
-1362.5 "Inscrutability" sync / 1[56]:Unknown:4B73:/
-1383.6 "Scrutiny" sync / 1[56]:Unknown:4E25:/
-1385.6 "Explosion" sync / 1[56]:Sinister Bubble:4B6E:/
-1401.5 "Inscrutability" sync / 1[56]:Unknown:4B73:/
+1310.0 "--sync--"  sync / 14:[^:]*:Unknown:4E4B:/ window 310,0
+1313.0 "Plain Weirdness" sync / 1[56]:[^:]*:Unknown:4E4B:/
+1319.2 "Inscrutability" sync / 1[56]:[^:]*:Unknown:4B73:/
+1329.4 "--sync--" sync / 1[56]:[^:]*:Unknown:4B77:/
+1334.4 "Ectoplasmic Ray" sync / 1[56]:[^:]*:Unknown:4B7A:/
+1342.0 "Luminous Ray" sync / 1[56]:[^:]*:Unknown:4E27:/
+1354.3 "Fetid Fang" sync / 1[56]:[^:]*:Unknown:4B72:/
+1362.5 "Inscrutability" sync / 1[56]:[^:]*:Unknown:4B73:/
+1383.6 "Scrutiny" sync / 1[56]:[^:]*:Unknown:4E25:/
+1385.6 "Explosion" sync / 1[56]:[^:]*:Sinister Bubble:4B6E:/
+1401.5 "Inscrutability" sync / 1[56]:[^:]*:Unknown:4B73:/
 
 
 
@@ -66,25 +66,25 @@ hideall "--sync--"
 # -p 4B58:2011
 # -ii 4B53 4B5C 4B5B
 2000.0 "--sync--" sync / 00:0839::Doxa will be sealed off/ window 2000,0
-2011.0 "The Final Verse" sync / 1[56]:Kyklops:4B58:/ window 2012,5
-2020.6 "Swing/Swipe/Cyclone" sync / 1[56]:Kyklops:4B5[457]:/
-2030.9 "Hammer/Blade Mark" sync / 1[56]:Kyklops:4B5[9A]:/
-2035.5 "Blade/Hammer Mark" sync / 1[56]:Kyklops:4B5[9A]:/
-2044.2 "Swing/Swipe/Cyclone" sync / 1[56]:Kyklops:4B5[457]:/
-2047.9 "Terrible Hammer/Blade" #sync / 1[56]:Kyklops:4B5[DE]:/
-2050.0 "Terrible Blade/Hammer" #sync / 1[56]:Kyklops:4B5[DE]:/
-2054.9 "Raging Glower" sync / 1[56]:Kyklops:4B56:/
-2064.5 "Swing/Swipe/Cyclone" sync / 1[56]:Kyklops:4B5[457]:/
+2011.0 "The Final Verse" sync / 1[56]:[^:]*:Kyklops:4B58:/ window 2012,5
+2020.6 "Swing/Swipe/Cyclone" sync / 1[56]:[^:]*:Kyklops:4B5[457]:/
+2030.9 "Hammer/Blade Mark" sync / 1[56]:[^:]*:Kyklops:4B5[9A]:/
+2035.5 "Blade/Hammer Mark" sync / 1[56]:[^:]*:Kyklops:4B5[9A]:/
+2044.2 "Swing/Swipe/Cyclone" sync / 1[56]:[^:]*:Kyklops:4B5[457]:/
+2047.9 "Terrible Hammer/Blade" #sync / 1[56]:[^:]*:Kyklops:4B5[DE]:/
+2050.0 "Terrible Blade/Hammer" #sync / 1[56]:[^:]*:Kyklops:4B5[DE]:/
+2054.9 "Raging Glower" sync / 1[56]:[^:]*:Kyklops:4B56:/
+2064.5 "Swing/Swipe/Cyclone" sync / 1[56]:[^:]*:Kyklops:4B5[457]:/
 
-2073.2 "The Final Verse" sync / 1[56]:Kyklops:4B58:/
-2083.1 "Hammer/Blade Mark" sync / 1[56]:Kyklops:4B5[9A]:/
-2087.7 "Blade/Hammer Mark" sync / 1[56]:Kyklops:4B5[9A]:/
-2095.4 "Pyre/Hearth" sync / 1[56]:Kyklops:(4B5F|4B60):/
-2100.1 "Terrible Hammer/Blade" #sync / 1[56]:Kyklops:4B5[DE]:/
-2102.2 "Terrible Blade/Hammer" #sync / 1[56]:Kyklops:4B5[DE]:/
-2107.0 "Swing/Swipe/Cyclone" sync / 1[56]:Kyklops:4B5[457]:/
+2073.2 "The Final Verse" sync / 1[56]:[^:]*:Kyklops:4B58:/
+2083.1 "Hammer/Blade Mark" sync / 1[56]:[^:]*:Kyklops:4B5[9A]:/
+2087.7 "Blade/Hammer Mark" sync / 1[56]:[^:]*:Kyklops:4B5[9A]:/
+2095.4 "Pyre/Hearth" sync / 1[56]:[^:]*:Kyklops:(4B5F|4B60):/
+2100.1 "Terrible Hammer/Blade" #sync / 1[56]:[^:]*:Kyklops:4B5[DE]:/
+2102.2 "Terrible Blade/Hammer" #sync / 1[56]:[^:]*:Kyklops:4B5[DE]:/
+2107.0 "Swing/Swipe/Cyclone" sync / 1[56]:[^:]*:Kyklops:4B5[457]:/
 
-2117.5 "The Final Verse" sync / 1[56]:Kyklops:4B58:/ window 20,20 jump 2073.2
+2117.5 "The Final Verse" sync / 1[56]:[^:]*:Kyklops:4B58:/ window 20,20 jump 2073.2
 2127.4 "Hammer/Blade Mark"
 2132.0 "Blade/Hammer Mark"
 2139.7 "Pyre/Hearth"
@@ -97,42 +97,42 @@ hideall "--sync--"
 # -p 4B8C:3013
 # -ii 4B7C 4B7E 4B8A 4B86 4B85 4B80 4B82 4B87
 3000.0 "--sync--" sync / 00:0839::Noesis will be sealed off/ window 3000,0
-3013.0 "Bonebreaker" sync / 1[56]:Rukshs Dheem:4B8C:/
-3019.2 "Swift Shift" sync / 1[56]:Rukshs Dheem:4B83:/
-3026.5 "Seabed Ceremony" sync / 1[56]:Rukshs Dheem:4B7B:/
-3032.6 "Depth Grip" sync / 1[56]:Rukshs Dheem:4B84:/
-3040.7 "Falling Water" sync / 1[56]:Rukshs Dheem:4B7D:/
-3042.4 "Wavebreaker x4" duration 3 #sync / 1[56]:Depth Grip:33D4:/
-3045.9 "Rising Tide" sync / 1[56]:Rukshs Dheem:4B8B:/
-3056.2 "Swift Shift" sync / 1[56]:Rukshs Dheem:4B83:/
-3063.6 "Seabed Ceremony" sync / 1[56]:Rukshs Dheem:4B7B:/ window 30,10
-3074.8 "Falling Water" sync / 1[56]:Rukshs Dheem:4B7D:/
-3087.0 "Bonebreaker" sync / 1[56]:Rukshs Dheem:4B8C:/
-3099.1 "Seabed Ceremony" sync / 1[56]:Rukshs Dheem:4B7B:/ window 30,10
-3105.2 "Depth Grip" sync / 1[56]:Rukshs Dheem:4B84:/
-3115.5 "Wavebreaker x8" duration 7 #sync / 1[56]:Depth Grip:33D4:/
-3131.8 "Bonebreaker" sync / 1[56]:Rukshs Dheem:4B8C:/
-3141.0 "Swift Shift" sync / 1[56]:Rukshs Dheem:4B83:/
-3148.4 "Depth Grip" sync / 1[56]:Rukshs Dheem:4B84:/
-3158.5 "Seabed Ceremony" sync / 1[56]:Rukshs Dheem:4B7B:/
-3160.5 "Wavebreaker" #sync / 1[56]:Depth Grip:33D5:/
-3171.6 "Flying Fount" sync / 1[56]:Rukshs Dheem:4B7F:/
-3178.8 "Swift Shift" sync / 1[56]:Rukshs Dheem:4B83:/
-3186.9 "Command Current" sync / 1[56]:Rukshs Dheem:4B81:/
+3013.0 "Bonebreaker" sync / 1[56]:[^:]*:Rukshs Dheem:4B8C:/
+3019.2 "Swift Shift" sync / 1[56]:[^:]*:Rukshs Dheem:4B83:/
+3026.5 "Seabed Ceremony" sync / 1[56]:[^:]*:Rukshs Dheem:4B7B:/
+3032.6 "Depth Grip" sync / 1[56]:[^:]*:Rukshs Dheem:4B84:/
+3040.7 "Falling Water" sync / 1[56]:[^:]*:Rukshs Dheem:4B7D:/
+3042.4 "Wavebreaker x4" duration 3 #sync / 1[56]:[^:]*:Depth Grip:33D4:/
+3045.9 "Rising Tide" sync / 1[56]:[^:]*:Rukshs Dheem:4B8B:/
+3056.2 "Swift Shift" sync / 1[56]:[^:]*:Rukshs Dheem:4B83:/
+3063.6 "Seabed Ceremony" sync / 1[56]:[^:]*:Rukshs Dheem:4B7B:/ window 30,10
+3074.8 "Falling Water" sync / 1[56]:[^:]*:Rukshs Dheem:4B7D:/
+3087.0 "Bonebreaker" sync / 1[56]:[^:]*:Rukshs Dheem:4B8C:/
+3099.1 "Seabed Ceremony" sync / 1[56]:[^:]*:Rukshs Dheem:4B7B:/ window 30,10
+3105.2 "Depth Grip" sync / 1[56]:[^:]*:Rukshs Dheem:4B84:/
+3115.5 "Wavebreaker x8" duration 7 #sync / 1[56]:[^:]*:Depth Grip:33D4:/
+3131.8 "Bonebreaker" sync / 1[56]:[^:]*:Rukshs Dheem:4B8C:/
+3141.0 "Swift Shift" sync / 1[56]:[^:]*:Rukshs Dheem:4B83:/
+3148.4 "Depth Grip" sync / 1[56]:[^:]*:Rukshs Dheem:4B84:/
+3158.5 "Seabed Ceremony" sync / 1[56]:[^:]*:Rukshs Dheem:4B7B:/
+3160.5 "Wavebreaker" #sync / 1[56]:[^:]*:Depth Grip:33D5:/
+3171.6 "Flying Fount" sync / 1[56]:[^:]*:Rukshs Dheem:4B7F:/
+3178.8 "Swift Shift" sync / 1[56]:[^:]*:Rukshs Dheem:4B83:/
+3186.9 "Command Current" sync / 1[56]:[^:]*:Rukshs Dheem:4B81:/
 
-3193.6 "Swift Shift" sync / 1[56]:Rukshs Dheem:4B83:/
-3200.9 "Seabed Ceremony" sync / 1[56]:Rukshs Dheem:4B7B:/
-3207.0 "Depth Grip" sync / 1[56]:Rukshs Dheem:4B84:/
-3215.1 "Falling Water" sync / 1[56]:Rukshs Dheem:4B7D:/
-3216.8 "Wavebreaker x4" duration 3 #sync / 1[56]:Depth Grip:33D4:/
-3220.2 "Rising Tide" sync / 1[56]:Rukshs Dheem:4B8B:/
-3229.4 "Bonebreaker" sync / 1[56]:Rukshs Dheem:4B8C:/
-3241.7 "Seabed Ceremony" sync / 1[56]:Rukshs Dheem:4B7B:/
-3247.6 "Depth Grip" sync / 1[56]:Rukshs Dheem:4B84:/
-3257.8 "Wavebreaker x8" duration 7 #sync / 1[56]:Depth Grip:33D4:/
-3275.1 "Bonebreaker" sync / 1[56]:Rukshs Dheem:4B8C:/
+3193.6 "Swift Shift" sync / 1[56]:[^:]*:Rukshs Dheem:4B83:/
+3200.9 "Seabed Ceremony" sync / 1[56]:[^:]*:Rukshs Dheem:4B7B:/
+3207.0 "Depth Grip" sync / 1[56]:[^:]*:Rukshs Dheem:4B84:/
+3215.1 "Falling Water" sync / 1[56]:[^:]*:Rukshs Dheem:4B7D:/
+3216.8 "Wavebreaker x4" duration 3 #sync / 1[56]:[^:]*:Depth Grip:33D4:/
+3220.2 "Rising Tide" sync / 1[56]:[^:]*:Rukshs Dheem:4B8B:/
+3229.4 "Bonebreaker" sync / 1[56]:[^:]*:Rukshs Dheem:4B8C:/
+3241.7 "Seabed Ceremony" sync / 1[56]:[^:]*:Rukshs Dheem:4B7B:/
+3247.6 "Depth Grip" sync / 1[56]:[^:]*:Rukshs Dheem:4B84:/
+3257.8 "Wavebreaker x8" duration 7 #sync / 1[56]:[^:]*:Depth Grip:33D4:/
+3275.1 "Bonebreaker" sync / 1[56]:[^:]*:Rukshs Dheem:4B8C:/
 
-3282.3 "Swift Shift" sync / 1[56]:Rukshs Dheem:4B83:/ window 50,50 jump 3193.6
+3282.3 "Swift Shift" sync / 1[56]:[^:]*:Rukshs Dheem:4B83:/ window 50,50 jump 3193.6
 3289.6 "Seabed Ceremony"
 3295.7 "Depth Grip"
 3303.8 "Falling Water"

--- a/ui/raidboss/data/05-shb/dungeon/dohn_mheg.txt
+++ b/ui/raidboss/data/05-shb/dungeon/dohn_mheg.txt
@@ -10,22 +10,22 @@ hideall "--sync--"
 # -ii 1EDB 22BD -p 2299:112.2
 100.0 "--sync--" sync / 00:0839::Teag Gye will be sealed off/ window 100,0
 
-112.2 "Candy Cane" sync / 1[56]:Aenc Thon, Lord of the Lingering Gaze:2299:/ window 113,5
-120.4 "Hydrofall" sync / 1[56]:Aenc Thon, Lord of the Lingering Gaze:22A7:/
-128.7 "Laughing Leap" sync / 1[56]:Aenc Thon, Lord of the Lingering Gaze:2294:/
-133.8 "Landsblood" sync / 1[56]:Aenc Thon, Lord of the Lingering Gaze:1E8E:/
+112.2 "Candy Cane" sync / 1[56]:[^:]*:Aenc Thon, Lord of the Lingering Gaze:2299:/ window 113,5
+120.4 "Hydrofall" sync / 1[56]:[^:]*:Aenc Thon, Lord of the Lingering Gaze:22A7:/
+128.7 "Laughing Leap" sync / 1[56]:[^:]*:Aenc Thon, Lord of the Lingering Gaze:2294:/
+133.8 "Landsblood" sync / 1[56]:[^:]*:Aenc Thon, Lord of the Lingering Gaze:1E8E:/
 139.6 "Geyser x6" duration 12.5
-161.1 "Candy Cane" sync / 1[56]:Aenc Thon, Lord of the Lingering Gaze:2299:/
+161.1 "Candy Cane" sync / 1[56]:[^:]*:Aenc Thon, Lord of the Lingering Gaze:2299:/
 
-170.4 "Hydrofall" sync / 1[56]:Aenc Thon, Lord of the Lingering Gaze:22A7:/
-179.7 "Laughing Leap Stack" sync / 1[56]:Aenc Thon, Lord of the Lingering Gaze:2288:/
-189.9 "Candy Cane" sync / 1[56]:Aenc Thon, Lord of the Lingering Gaze:2299:/
-201.1 "Laughing Leap" sync / 1[56]:Aenc Thon, Lord of the Lingering Gaze:2294:/
-206.2 "Landsblood" sync / 1[56]:Aenc Thon, Lord of the Lingering Gaze:1E8E:/
+170.4 "Hydrofall" sync / 1[56]:[^:]*:Aenc Thon, Lord of the Lingering Gaze:22A7:/
+179.7 "Laughing Leap Stack" sync / 1[56]:[^:]*:Aenc Thon, Lord of the Lingering Gaze:2288:/
+189.9 "Candy Cane" sync / 1[56]:[^:]*:Aenc Thon, Lord of the Lingering Gaze:2299:/
+201.1 "Laughing Leap" sync / 1[56]:[^:]*:Aenc Thon, Lord of the Lingering Gaze:2294:/
+206.2 "Landsblood" sync / 1[56]:[^:]*:Aenc Thon, Lord of the Lingering Gaze:1E8E:/
 212.0 "Geyser x6" duration 12.5
-233.4 "Candy Cane" sync / 1[56]:Aenc Thon, Lord of the Lingering Gaze:2299:/
+233.4 "Candy Cane" sync / 1[56]:[^:]*:Aenc Thon, Lord of the Lingering Gaze:2299:/
 
-242.6 "Hydrofall" sync / 1[56]:Aenc Thon, Lord of the Lingering Gaze:22A7:/ window 50,50 jump 170.4
+242.6 "Hydrofall" sync / 1[56]:[^:]*:Aenc Thon, Lord of the Lingering Gaze:22A7:/ window 50,50 jump 170.4
 251.9 "Laughing Leap Stack"
 262.1 "Candy Cane"
 273.3 "Laughing Leap"
@@ -38,30 +38,30 @@ hideall "--sync--"
 # -p 2873:507.5
 500.0 "--sync--" sync / 00:0839::The Atelier will be sealed off/ window 500,0
 
-507.5 "Rake" sync / 1[56]:Griaule:2873:/ window 508,5
-518.0 "Swinge" sync / 1[56]:Griaule:22CA:/
-525.4 "Fodder" sync / 1[56]:Griaule:22C1:/
-533.5 "Tiiimbeeer" sync / 1[56]:Griaule:22D3:/
-538.6 "Feeding Time" sync / 1[56]:Painted Sapling:22C3:/
-541.7 "Tiiimbeeer" sync / 1[56]:Griaule:22D3:/
-554.0 "Swinge" sync / 1[56]:Griaule:22CA:/
-568.3 "Tiiimbeeer" sync / 1[56]:Griaule:22D3:/
-573.5 "Coiling Ivy" sync / 1[56]:Griaule:22C5:/
-580.7 "Rake" sync / 1[56]:Griaule:2873:/
+507.5 "Rake" sync / 1[56]:[^:]*:Griaule:2873:/ window 508,5
+518.0 "Swinge" sync / 1[56]:[^:]*:Griaule:22CA:/
+525.4 "Fodder" sync / 1[56]:[^:]*:Griaule:22C1:/
+533.5 "Tiiimbeeer" sync / 1[56]:[^:]*:Griaule:22D3:/
+538.6 "Feeding Time" sync / 1[56]:[^:]*:Painted Sapling:22C3:/
+541.7 "Tiiimbeeer" sync / 1[56]:[^:]*:Griaule:22D3:/
+554.0 "Swinge" sync / 1[56]:[^:]*:Griaule:22CA:/
+568.3 "Tiiimbeeer" sync / 1[56]:[^:]*:Griaule:22D3:/
+573.5 "Coiling Ivy" sync / 1[56]:[^:]*:Griaule:22C5:/
+580.7 "Rake" sync / 1[56]:[^:]*:Griaule:2873:/
 
-591.1 "Swinge" sync / 1[56]:Griaule:22CA:/
-605.4 "Tiiimbeeer" sync / 1[56]:Griaule:22D3:/
-614.5 "Rake" sync / 1[56]:Griaule:2873:/
-623.9 "Coiling Ivy" sync / 1[56]:Griaule:22C5:/
-631.1 "Fodder" sync / 1[56]:Griaule:22C1:/
-639.4 "Tiiimbeeer" sync / 1[56]:Griaule:22D3:/
-644.6 "Feeding Time" sync / 1[56]:Painted Sapling:22C3:/
-647.6 "Tiiimbeeer" sync / 1[56]:Griaule:22D3:/
-658.1 "Swinge" sync / 1[56]:Griaule:22CA:/
-665.4 "Coiling Ivy" sync / 1[56]:Griaule:22C5:/
-672.6 "Rake" sync / 1[56]:Griaule:2873:/
+591.1 "Swinge" sync / 1[56]:[^:]*:Griaule:22CA:/
+605.4 "Tiiimbeeer" sync / 1[56]:[^:]*:Griaule:22D3:/
+614.5 "Rake" sync / 1[56]:[^:]*:Griaule:2873:/
+623.9 "Coiling Ivy" sync / 1[56]:[^:]*:Griaule:22C5:/
+631.1 "Fodder" sync / 1[56]:[^:]*:Griaule:22C1:/
+639.4 "Tiiimbeeer" sync / 1[56]:[^:]*:Griaule:22D3:/
+644.6 "Feeding Time" sync / 1[56]:[^:]*:Painted Sapling:22C3:/
+647.6 "Tiiimbeeer" sync / 1[56]:[^:]*:Griaule:22D3:/
+658.1 "Swinge" sync / 1[56]:[^:]*:Griaule:22CA:/
+665.4 "Coiling Ivy" sync / 1[56]:[^:]*:Griaule:22C5:/
+672.6 "Rake" sync / 1[56]:[^:]*:Griaule:2873:/
 
-682.8 "Swinge" sync / 1[56]:Griaule:22CA:/ window 10,10 jump 591.1
+682.8 "Swinge" sync / 1[56]:[^:]*:Griaule:22CA:/ window 10,10 jump 591.1
 697.1 "Tiiimbeeer"
 706.2 "Rake"
 715.6 "Coiling Ivy"
@@ -78,35 +78,35 @@ hideall "--sync--"
 # -p 35A4:1011 34D2:1300 -ii 34EC 3681 3396
 1000.0 "--sync--" sync / 00:0839::The throne room will be sealed off/ window 1000,0
 
-1011.0 "Crippling Blow" sync / 1[56]:Aenc Thon, Lord of the Lengthsome Gait:35A4:/ window 1011,5
-1018.2 "Virtuosic Capriccio" sync / 1[56]:Aenc Thon, Lord of the Lengthsome Gait:358C:/
-1027.5 "Imp Choir" sync / 1[56]:Aenc Thon, Lord of the Lengthsome Gait:34F0:/
-1033.9 "Toad Choir" sync / 1[56]:Aenc Thon, Lord of the Lengthsome Gait:34EF:/
-1044.1 "Crippling Blow" sync / 1[56]:Aenc Thon, Lord of the Lengthsome Gait:35A4:/
+1011.0 "Crippling Blow" sync / 1[56]:[^:]*:Aenc Thon, Lord of the Lengthsome Gait:35A4:/ window 1011,5
+1018.2 "Virtuosic Capriccio" sync / 1[56]:[^:]*:Aenc Thon, Lord of the Lengthsome Gait:358C:/
+1027.5 "Imp Choir" sync / 1[56]:[^:]*:Aenc Thon, Lord of the Lengthsome Gait:34F0:/
+1033.9 "Toad Choir" sync / 1[56]:[^:]*:Aenc Thon, Lord of the Lengthsome Gait:34EF:/
+1044.1 "Crippling Blow" sync / 1[56]:[^:]*:Aenc Thon, Lord of the Lengthsome Gait:35A4:/
 
-1052.7 "Funambulist's Fantasia" sync / 1[56]:Aenc Thon, Lord of the Lengthsome Gait:34BA:/
-1052.7 "--stun--" sync / 1[56]:Aenc Thon, Lord of the Lengthsome Gait:34CF:/
+1052.7 "Funambulist's Fantasia" sync / 1[56]:[^:]*:Aenc Thon, Lord of the Lengthsome Gait:34BA:/
+1052.7 "--stun--" sync / 1[56]:[^:]*:Aenc Thon, Lord of the Lengthsome Gait:34CF:/
 1112.7 "Enrage"
 
-1300.0 "--sync--" sync / 1[56]:Aenc Thon, Lord of the Lengthsome Gait:34D2:/ window 300,0
+1300.0 "--sync--" sync / 1[56]:[^:]*:Aenc Thon, Lord of the Lengthsome Gait:34D2:/ window 300,0
 
-1302.1 "Changeling's Fantasia" sync / 1[56]:Aenc Thon, Lord of the Lengthsome Gait:34D1:/
-1312.4 "Malaise" sync / 1[56]:Aenc Thon, Lord of the Lengthsome Gait:34ED:/
-1318.5 "Bile Bombardment" sync / 1[56]:Shade of Fear:34EE:/
-1326.7 "Corrosive Bile" sync / 1[56]:Aenc Thon, Lord of the Lengthsome Gait:34EB:/
-1338.0 "Malaise" sync / 1[56]:Aenc Thon, Lord of the Lengthsome Gait:34ED:/
-1344.1 "Bile Bombardment" sync / 1[56]:Shade of Fear:34EE:/
-1345.1 "Flailing Tentacles" sync / 1[56]:Aenc Thon, Lord of the Lengthsome Gait:3680:/
-1354.4 "Corrosive Bile" sync / 1[56]:Aenc Thon, Lord of the Lengthsome Gait:34EB:/
+1302.1 "Changeling's Fantasia" sync / 1[56]:[^:]*:Aenc Thon, Lord of the Lengthsome Gait:34D1:/
+1312.4 "Malaise" sync / 1[56]:[^:]*:Aenc Thon, Lord of the Lengthsome Gait:34ED:/
+1318.5 "Bile Bombardment" sync / 1[56]:[^:]*:Shade of Fear:34EE:/
+1326.7 "Corrosive Bile" sync / 1[56]:[^:]*:Aenc Thon, Lord of the Lengthsome Gait:34EB:/
+1338.0 "Malaise" sync / 1[56]:[^:]*:Aenc Thon, Lord of the Lengthsome Gait:34ED:/
+1344.1 "Bile Bombardment" sync / 1[56]:[^:]*:Shade of Fear:34EE:/
+1345.1 "Flailing Tentacles" sync / 1[56]:[^:]*:Aenc Thon, Lord of the Lengthsome Gait:3680:/
+1354.4 "Corrosive Bile" sync / 1[56]:[^:]*:Aenc Thon, Lord of the Lengthsome Gait:34EB:/
 
-1375.7 "Crippling Blow" sync / 1[56]:Aenc Thon, Lord of the Lengthsome Gait:35A4:/
-1389.0 "Virtuosic Capriccio" sync / 1[56]:Aenc Thon, Lord of the Lengthsome Gait:358C:/ window 3,3
-1396.1 "Virtuosic Capriccio" sync / 1[56]:Aenc Thon, Lord of the Lengthsome Gait:358C:/ window 3,3
-1403.2 "Virtuosic Capriccio" sync / 1[56]:Aenc Thon, Lord of the Lengthsome Gait:358C:/ window 3,3
-1414.5 "Imp Choir" sync / 1[56]:Aenc Thon, Lord of the Lengthsome Gait:34F0:/
-1420.9 "Toad Choir" sync / 1[56]:Aenc Thon, Lord of the Lengthsome Gait:34EF:/
+1375.7 "Crippling Blow" sync / 1[56]:[^:]*:Aenc Thon, Lord of the Lengthsome Gait:35A4:/
+1389.0 "Virtuosic Capriccio" sync / 1[56]:[^:]*:Aenc Thon, Lord of the Lengthsome Gait:358C:/ window 3,3
+1396.1 "Virtuosic Capriccio" sync / 1[56]:[^:]*:Aenc Thon, Lord of the Lengthsome Gait:358C:/ window 3,3
+1403.2 "Virtuosic Capriccio" sync / 1[56]:[^:]*:Aenc Thon, Lord of the Lengthsome Gait:358C:/ window 3,3
+1414.5 "Imp Choir" sync / 1[56]:[^:]*:Aenc Thon, Lord of the Lengthsome Gait:34F0:/
+1420.9 "Toad Choir" sync / 1[56]:[^:]*:Aenc Thon, Lord of the Lengthsome Gait:34EF:/
 
-1438.3 "Crippling Blow" sync / 1[56]:Aenc Thon, Lord of the Lengthsome Gait:35A4:/ window 20,20 jump 1375.7
+1438.3 "Crippling Blow" sync / 1[56]:[^:]*:Aenc Thon, Lord of the Lengthsome Gait:35A4:/ window 20,20 jump 1375.7
 1451.6 "Virtuosic Capriccio"
 1458.7 "Virtuosic Capriccio"
 1465.8 "Virtuosic Capriccio"
@@ -114,5 +114,5 @@ hideall "--sync--"
 1483.5 "Toad Choir"
 
 
-1800.0 "--sync--" sync / 1[56]:Aenc Thon, Lord of the Lengthsome Gait:34D2:/ window 590,0
-1802.0 "Changeling's Fantasia" sync / 1[56]:Aenc Thon, Lord of the Lengthsome Gait:34D1:/
+1800.0 "--sync--" sync / 1[56]:[^:]*:Aenc Thon, Lord of the Lengthsome Gait:34D2:/ window 590,0
+1802.0 "Changeling's Fantasia" sync / 1[56]:[^:]*:Aenc Thon, Lord of the Lengthsome Gait:34D1:/

--- a/ui/raidboss/data/05-shb/dungeon/heroes_gauntlet.txt
+++ b/ui/raidboss/data/05-shb/dungeon/heroes_gauntlet.txt
@@ -12,33 +12,33 @@ hideall "--sync--"
 # -ii 4FCD 4FCE 4FCF 4FD0 4FD5 5015
 
 0 "Start" sync / 00:0839::The Mount Argai Mines will be sealed off/ window 0,1
-9.8 "Spectral Dream" sync / 1[56]:Spectral Thief:4FCB:/ window 9.8,5
-16.9 "Dash" sync / 1[56]:Spectral Thief:4FD3:/
-26.7 "Vacuum Blade" sync / 1[56]:Spectral Thief:506[12]:/
-37.8 "Spectral Whirlwind" sync / 1[56]:Spectral Thief:4FCC:/
-44.0 "--sync--" sync / 1[56]:Spectral Thief:53CE:/
-51.1 "Spectral Gust" sync / 1[56]:Spectral Thief:53CF:/
-52.1 "Chicken Knife" sync / 1[56]:Spectral Thief:4FD6:/
-59.2 "Shadowdash" sync / 1[56]:Spectral Thief:4FD4:/
-63.4 "Coward's Cunning" sync / 1[56]:Chicken Knife:4FD7:/
+9.8 "Spectral Dream" sync / 1[56]:[^:]*:Spectral Thief:4FCB:/ window 9.8,5
+16.9 "Dash" sync / 1[56]:[^:]*:Spectral Thief:4FD3:/
+26.7 "Vacuum Blade" sync / 1[56]:[^:]*:Spectral Thief:506[12]:/
+37.8 "Spectral Whirlwind" sync / 1[56]:[^:]*:Spectral Thief:4FCC:/
+44.0 "--sync--" sync / 1[56]:[^:]*:Spectral Thief:53CE:/
+51.1 "Spectral Gust" sync / 1[56]:[^:]*:Spectral Thief:53CF:/
+52.1 "Chicken Knife" sync / 1[56]:[^:]*:Spectral Thief:4FD6:/
+59.2 "Shadowdash" sync / 1[56]:[^:]*:Spectral Thief:4FD4:/
+63.4 "Coward's Cunning" sync / 1[56]:[^:]*:Chicken Knife:4FD7:/
 
-69.0 "Papercutter" sync / 1[56]:Spectral Thief:4FD[12]:/
-83.2 "Spectral Dream" sync / 1[56]:Spectral Thief:4FCB:/
-88.4 "Chicken Knife" sync / 1[56]:Spectral Thief:4FD6:/ window 20,30
-95.5 "Shadowdash" sync / 1[56]:Spectral Thief:4FD4:/
-97.2 "Spectral Gust" sync / 1[56]:Spectral Thief:53CE:/
-99.7 "Coward's Cunning" sync / 1[56]:Chicken Knife:4FD7:/
-104.2 "Spectral Gust" sync / 1[56]:Spectral Thief:53CF:/
+69.0 "Papercutter" sync / 1[56]:[^:]*:Spectral Thief:4FD[12]:/
+83.2 "Spectral Dream" sync / 1[56]:[^:]*:Spectral Thief:4FCB:/
+88.4 "Chicken Knife" sync / 1[56]:[^:]*:Spectral Thief:4FD6:/ window 20,30
+95.5 "Shadowdash" sync / 1[56]:[^:]*:Spectral Thief:4FD4:/
+97.2 "Spectral Gust" sync / 1[56]:[^:]*:Spectral Thief:53CE:/
+99.7 "Coward's Cunning" sync / 1[56]:[^:]*:Chicken Knife:4FD7:/
+104.2 "Spectral Gust" sync / 1[56]:[^:]*:Spectral Thief:53CF:/
 
-107.4 "Vacuum Blade" sync / 1[56]:Spectral Thief:506[12]:/
-121.5 "Spectral Whirlwind" sync / 1[56]:Spectral Thief:4FCC:/
-129.6 "Chicken Knife" sync / 1[56]:Spectral Thief:4FD6:/ window 30,30
-136.8 "Shadowdash" sync / 1[56]:Spectral Thief:4FD4:/
-138.5 "Spectral Gust" sync / 1[56]:Spectral Thief:53CE:/
-141.0 "Coward's Cunning" sync / 1[56]:Chicken Knife:4FD7:/
-145.6 "Spectral Gust" sync / 1[56]:Spectral Thief:53CF:/
+107.4 "Vacuum Blade" sync / 1[56]:[^:]*:Spectral Thief:506[12]:/
+121.5 "Spectral Whirlwind" sync / 1[56]:[^:]*:Spectral Thief:4FCC:/
+129.6 "Chicken Knife" sync / 1[56]:[^:]*:Spectral Thief:4FD6:/ window 30,30
+136.8 "Shadowdash" sync / 1[56]:[^:]*:Spectral Thief:4FD4:/
+138.5 "Spectral Gust" sync / 1[56]:[^:]*:Spectral Thief:53CE:/
+141.0 "Coward's Cunning" sync / 1[56]:[^:]*:Chicken Knife:4FD7:/
+145.6 "Spectral Gust" sync / 1[56]:[^:]*:Spectral Thief:53CF:/
 
-148.8 "Papercutter" sync / 1[56]:Spectral Thief:4FD[12]:/ jump 69.0
+148.8 "Papercutter" sync / 1[56]:[^:]*:Spectral Thief:4FD[12]:/ jump 69.0
 163.0 "Spectral Dream"
 168.2 "Chicken Knife"
 175.3 "Shadowdash"
@@ -54,36 +54,36 @@ hideall "--sync--"
 # -ii 4F51 4F62 4F64 53B5 53B6 53B7 53B8 53B9 53BA
 
 1000.0 "Start" sync / 00:0839::The Summer Ballroom will be sealed off/ window 1000,5
-1012.8 "Absolute Dark II" sync / 1[56]:Spectral Necromancer:4F61:/ window 12.8,5
-1020.0 "Necromancy" sync / 1[56]:Spectral Necromancer:4F57:/
-1030.2 "Twisted Touch" sync / 1[56]:Spectral Necromancer:4F5E:/ window 30,30
-1046.7 "Necroburst" sync / 1[56]:Spectral Necromancer:4F5[9A]:/
-1051.4 "--sync--" sync / 1[56]:Spectral Necromancer:4FA3:/
-1059.0 "Pain Mire" sync / 1[56]:Spectral Necromancer:4FA4:/
-1066.7 "Necromancy" sync / 1[56]:Spectral Necromancer:4F58:/
-1074.2 "Death Throes" # sync / 1[56]:Necrobomb:4F63:/
-1085.7 "Necroburst" sync / 1[56]:Spectral Necromancer:4F5[9A]:/
+1012.8 "Absolute Dark II" sync / 1[56]:[^:]*:Spectral Necromancer:4F61:/ window 12.8,5
+1020.0 "Necromancy" sync / 1[56]:[^:]*:Spectral Necromancer:4F57:/
+1030.2 "Twisted Touch" sync / 1[56]:[^:]*:Spectral Necromancer:4F5E:/ window 30,30
+1046.7 "Necroburst" sync / 1[56]:[^:]*:Spectral Necromancer:4F5[9A]:/
+1051.4 "--sync--" sync / 1[56]:[^:]*:Spectral Necromancer:4FA3:/
+1059.0 "Pain Mire" sync / 1[56]:[^:]*:Spectral Necromancer:4FA4:/
+1066.7 "Necromancy" sync / 1[56]:[^:]*:Spectral Necromancer:4F58:/
+1074.2 "Death Throes" # sync / 1[56]:[^:]*:Necrobomb:4F63:/
+1085.7 "Necroburst" sync / 1[56]:[^:]*:Spectral Necromancer:4F5[9A]:/
 
-1096.8 "Chaos Storm" sync / 1[56]:Spectral Necromancer:4F60:/ window 100,30
-1105.4 "Necromancy" sync / 1[56]:Spectral Necromancer:4F57:/
-1111.6 "Necromancy" sync / 1[56]:Spectral Necromancer:4F58:/
-1121.7 "--sync--" sync / 1[56]:Spectral Necromancer:4F5C:/
-1122.7 "Dark Deluge" sync / 1[56]:Spectral Necromancer:4F5D:/ window 30,30
-1124.0 "Death Throes" # sync / 1[56]:Necrobomb:4F63:/
-1130.1 "Necroburst" sync / 1[56]:Spectral Necromancer:4F5[9A]:/
-1142.6 "Absolute Dark II" sync / 1[56]:Spectral Necromancer:4F61:/
-1149.8 "--sync--" sync / 1[56]:Spectral Necromancer:4FA3:/
-1157.4 "Pain Mire" sync / 1[56]:Spectral Necromancer:4FA4:/
-1164.9 "Chaos Storm" sync / 1[56]:Spectral Necromancer:4F60:/ window 30,30
-1176.0 "Twisted Touch" sync / 1[56]:Spectral Necromancer:4F5E:/
-1182.4 "--sync--" sync / 1[56]:Spectral Necromancer:4FA3:/
-1189.9 "Pain Mire" sync / 1[56]:Spectral Necromancer:4FA4:/
-1196.4 "Necromancy" sync / 1[56]:Spectral Necromancer:4F57:/
-1208.5 "--sync--" sync / 1[56]:Spectral Necromancer:4F5C:/
-1209.5 "Dark Deluge" sync / 1[56]:Spectral Necromancer:4F5D:/
-1218.9 "Necroburst" sync / 1[56]:Spectral Necromancer:4F59:/
+1096.8 "Chaos Storm" sync / 1[56]:[^:]*:Spectral Necromancer:4F60:/ window 100,30
+1105.4 "Necromancy" sync / 1[56]:[^:]*:Spectral Necromancer:4F57:/
+1111.6 "Necromancy" sync / 1[56]:[^:]*:Spectral Necromancer:4F58:/
+1121.7 "--sync--" sync / 1[56]:[^:]*:Spectral Necromancer:4F5C:/
+1122.7 "Dark Deluge" sync / 1[56]:[^:]*:Spectral Necromancer:4F5D:/ window 30,30
+1124.0 "Death Throes" # sync / 1[56]:[^:]*:Necrobomb:4F63:/
+1130.1 "Necroburst" sync / 1[56]:[^:]*:Spectral Necromancer:4F5[9A]:/
+1142.6 "Absolute Dark II" sync / 1[56]:[^:]*:Spectral Necromancer:4F61:/
+1149.8 "--sync--" sync / 1[56]:[^:]*:Spectral Necromancer:4FA3:/
+1157.4 "Pain Mire" sync / 1[56]:[^:]*:Spectral Necromancer:4FA4:/
+1164.9 "Chaos Storm" sync / 1[56]:[^:]*:Spectral Necromancer:4F60:/ window 30,30
+1176.0 "Twisted Touch" sync / 1[56]:[^:]*:Spectral Necromancer:4F5E:/
+1182.4 "--sync--" sync / 1[56]:[^:]*:Spectral Necromancer:4FA3:/
+1189.9 "Pain Mire" sync / 1[56]:[^:]*:Spectral Necromancer:4FA4:/
+1196.4 "Necromancy" sync / 1[56]:[^:]*:Spectral Necromancer:4F57:/
+1208.5 "--sync--" sync / 1[56]:[^:]*:Spectral Necromancer:4F5C:/
+1209.5 "Dark Deluge" sync / 1[56]:[^:]*:Spectral Necromancer:4F5D:/
+1218.9 "Necroburst" sync / 1[56]:[^:]*:Spectral Necromancer:4F59:/
 
-1230.1 "Chaos Storm" sync / 1[56]:Spectral Necromancer:4F60:/ window 30,30 jump 1096.8
+1230.1 "Chaos Storm" sync / 1[56]:[^:]*:Spectral Necromancer:4F60:/ window 30,30 jump 1096.8
 1238.7 "Necromancy"
 1244.9 "Necromancy"
 1256.0 "Dark Deluge"
@@ -98,33 +98,33 @@ hideall "--sync--"
 # -ic "Steelarm Cerigg" "Giott The Aleforged" "Lue-Reeq Of The Gilded Bow" "Granson Of The Mournful Blade"
 
 2000.0 "Start" sync / 00:0839::The Illuminated Plaza will be sealed off/ window 2000,5
-2012.0 "Beastly Fury" sync / 1[56]:Spectral Berserker:520C:/ window 12,5
-2024.4 "Wild Anguish" sync / 1[56]:Spectral Berserker:5208:/
-2036.3 "Raging Slice" sync / 1[56]:Spectral Berserker:520A:/
-2041.0 "Raging Slice" sync / 1[56]:Spectral Berserker:520B:/
-2051.8 "Beastly Fury" sync / 1[56]:Spectral Berserker:520C:/
-2066.0 "Wild Rage" sync / 1[56]:Spectral Berserker:5202:/ window 66,30
-2076.1 "Falling Rock" sync / 1[56]:Rubble:5205:/
-2082.3 "Wild Anguish x4" sync / 1[56]:Spectral Berserker:5208:/
-2105.7 "--sync--" sync / 1[56]:Spectral Berserker:5206:/
-2106.2 "Wild Rampage" sync / 1[56]:Spectral Berserker:5207:/ window 106.2,5
-2117.7 "Raging Slice" sync / 1[56]:Spectral Berserker:520A:/
-2122.6 "Raging Slice" sync / 1[56]:Spectral Berserker:520B:/
-2127.7 "Raging Slice" sync / 1[56]:Spectral Berserker:520B:/
-2137.6 "Wild Rage" sync / 1[56]:Spectral Berserker:5202:/ window 30,30
-2149.4 "--sync--" sync / 1[56]:Spectral Berserker:5206:/
-2149.9 "Wild Rampage" sync / 1[56]:Spectral Berserker:5207:/
-2157.4 "Falling Rock" sync / 1[56]:Rubble:5205:/
-2162.6 "Wild Anguish x4" sync / 1[56]:Spectral Berserker:5208:/
+2012.0 "Beastly Fury" sync / 1[56]:[^:]*:Spectral Berserker:520C:/ window 12,5
+2024.4 "Wild Anguish" sync / 1[56]:[^:]*:Spectral Berserker:5208:/
+2036.3 "Raging Slice" sync / 1[56]:[^:]*:Spectral Berserker:520A:/
+2041.0 "Raging Slice" sync / 1[56]:[^:]*:Spectral Berserker:520B:/
+2051.8 "Beastly Fury" sync / 1[56]:[^:]*:Spectral Berserker:520C:/
+2066.0 "Wild Rage" sync / 1[56]:[^:]*:Spectral Berserker:5202:/ window 66,30
+2076.1 "Falling Rock" sync / 1[56]:[^:]*:Rubble:5205:/
+2082.3 "Wild Anguish x4" sync / 1[56]:[^:]*:Spectral Berserker:5208:/
+2105.7 "--sync--" sync / 1[56]:[^:]*:Spectral Berserker:5206:/
+2106.2 "Wild Rampage" sync / 1[56]:[^:]*:Spectral Berserker:5207:/ window 106.2,5
+2117.7 "Raging Slice" sync / 1[56]:[^:]*:Spectral Berserker:520A:/
+2122.6 "Raging Slice" sync / 1[56]:[^:]*:Spectral Berserker:520B:/
+2127.7 "Raging Slice" sync / 1[56]:[^:]*:Spectral Berserker:520B:/
+2137.6 "Wild Rage" sync / 1[56]:[^:]*:Spectral Berserker:5202:/ window 30,30
+2149.4 "--sync--" sync / 1[56]:[^:]*:Spectral Berserker:5206:/
+2149.9 "Wild Rampage" sync / 1[56]:[^:]*:Spectral Berserker:5207:/
+2157.4 "Falling Rock" sync / 1[56]:[^:]*:Rubble:5205:/
+2162.6 "Wild Anguish x4" sync / 1[56]:[^:]*:Spectral Berserker:5208:/
 
-2182.5 "Beastly Fury" sync / 1[56]:Spectral Berserker:520C:/ window 30,5
-2198.7 "Beastly Fury" sync / 1[56]:Spectral Berserker:520C:/
-2207.8 "Raging Slice" sync / 1[56]:Spectral Berserker:520A:/
-2212.3 "Raging Slice" sync / 1[56]:Spectral Berserker:520B:/
-2217.2 "Raging Slice" sync / 1[56]:Spectral Berserker:520B:/
-2226.1 "Wild Anguish" sync / 1[56]:Spectral Berserker:5208:/
+2182.5 "Beastly Fury" sync / 1[56]:[^:]*:Spectral Berserker:520C:/ window 30,5
+2198.7 "Beastly Fury" sync / 1[56]:[^:]*:Spectral Berserker:520C:/
+2207.8 "Raging Slice" sync / 1[56]:[^:]*:Spectral Berserker:520A:/
+2212.3 "Raging Slice" sync / 1[56]:[^:]*:Spectral Berserker:520B:/
+2217.2 "Raging Slice" sync / 1[56]:[^:]*:Spectral Berserker:520B:/
+2226.1 "Wild Anguish" sync / 1[56]:[^:]*:Spectral Berserker:5208:/
 
-2240.2 "Beastly Fury" sync / 1[56]:Spectral Berserker:520C:/ window 30,5 jump 2182.5
+2240.2 "Beastly Fury" sync / 1[56]:[^:]*:Spectral Berserker:520C:/ window 30,5 jump 2182.5
 2256.4 "Beastly Fury"
 2265.5 "Raging Slice"
 2270.0 "Raging Slice"

--- a/ui/raidboss/data/05-shb/dungeon/holminster_switch.txt
+++ b/ui/raidboss/data/05-shb/dungeon/holminster_switch.txt
@@ -9,35 +9,35 @@ hideall "--sync--"
 ### Forgiven Dissonance
 # -p 3DC5:112
 100.0 "--sync--" sync / 00:0839::The Wound will be sealed off/ window 100,0
-112.0 "The Path Of Light" sync / 1[56]:Forgiven Dissonance:3DC5:/ window 112,0
-120.4 "Brazen Bull" sync / 1[56]:Forgiven Dissonance:3DC9:/
-126.5 "Gibbet Cage" sync / 1[56]:Forgiven Dissonance:3DC8:/
-134.4 "Thumbscrew" sync / 1[56]:Forgiven Dissonance:3DC6:/
-134.6 "Heretic's Fork" sync / 1[56]:Forgiven Dissonance:3DCE:/
-139.7 "Light Shot" sync / 1[56]:Forgiven Dissonance:3DCB:/
-142.0 "Wooden Horse" sync / 1[56]:Forgiven Dissonance:3DC7:/
+112.0 "The Path Of Light" sync / 1[56]:[^:]*:Forgiven Dissonance:3DC5:/ window 112,0
+120.4 "Brazen Bull" sync / 1[56]:[^:]*:Forgiven Dissonance:3DC9:/
+126.5 "Gibbet Cage" sync / 1[56]:[^:]*:Forgiven Dissonance:3DC8:/
+134.4 "Thumbscrew" sync / 1[56]:[^:]*:Forgiven Dissonance:3DC6:/
+134.6 "Heretic's Fork" sync / 1[56]:[^:]*:Forgiven Dissonance:3DCE:/
+139.7 "Light Shot" sync / 1[56]:[^:]*:Forgiven Dissonance:3DCB:/
+142.0 "Wooden Horse" sync / 1[56]:[^:]*:Forgiven Dissonance:3DC7:/
 
-154.2 "The Path Of Light" sync / 1[56]:Forgiven Dissonance:3DC5:/
-162.5 "Pillory" sync / 1[56]:Forgiven Dissonance:3DC4:/
-173.0 "Brazen Bull" sync / 1[56]:Forgiven Dissonance:3DC9:/
-182.3 "Gibbet Cage" sync / 1[56]:Forgiven Dissonance:3DC8:/
-187.2 "Heretic's Fork" sync / 1[56]:Forgiven Dissonance:3DCE:/
-190.3 "Thumbscrew" sync / 1[56]:Forgiven Dissonance:3DC6:/
-192.3 "Light Shot" sync / 1[56]:Forgiven Dissonance:3DCB:/
+154.2 "The Path Of Light" sync / 1[56]:[^:]*:Forgiven Dissonance:3DC5:/
+162.5 "Pillory" sync / 1[56]:[^:]*:Forgiven Dissonance:3DC4:/
+173.0 "Brazen Bull" sync / 1[56]:[^:]*:Forgiven Dissonance:3DC9:/
+182.3 "Gibbet Cage" sync / 1[56]:[^:]*:Forgiven Dissonance:3DC8:/
+187.2 "Heretic's Fork" sync / 1[56]:[^:]*:Forgiven Dissonance:3DCE:/
+190.3 "Thumbscrew" sync / 1[56]:[^:]*:Forgiven Dissonance:3DC6:/
+192.3 "Light Shot" sync / 1[56]:[^:]*:Forgiven Dissonance:3DCB:/
 
-202.8 "The Path Of Light" sync / 1[56]:Forgiven Dissonance:3DC5:/
-211.1 "Pillory" sync / 1[56]:Forgiven Dissonance:3DC4:/
-218.9 "Brazen Bull" sync / 1[56]:Forgiven Dissonance:3DC9:/
-226.8 "Thumbscrew" sync / 1[56]:Forgiven Dissonance:3DC6:/
-233.0 "Heretic's Fork" sync / 1[56]:Forgiven Dissonance:3DCE:/
-234.5 "Wooden Horse" sync / 1[56]:Forgiven Dissonance:3DC7:/
-238.2 "Light Shot" sync / 1[56]:Forgiven Dissonance:3DCB:/
-241.4 "Thumbscrew" sync / 1[56]:Forgiven Dissonance:3DC6:/
-243.2 "Heretic's Fork" sync / 1[56]:Forgiven Dissonance:3DCE:/
-248.4 "Light Shot" sync / 1[56]:Forgiven Dissonance:3DCB:/
-249.0 "Wooden Horse" sync / 1[56]:Forgiven Dissonance:3DC7:/
+202.8 "The Path Of Light" sync / 1[56]:[^:]*:Forgiven Dissonance:3DC5:/
+211.1 "Pillory" sync / 1[56]:[^:]*:Forgiven Dissonance:3DC4:/
+218.9 "Brazen Bull" sync / 1[56]:[^:]*:Forgiven Dissonance:3DC9:/
+226.8 "Thumbscrew" sync / 1[56]:[^:]*:Forgiven Dissonance:3DC6:/
+233.0 "Heretic's Fork" sync / 1[56]:[^:]*:Forgiven Dissonance:3DCE:/
+234.5 "Wooden Horse" sync / 1[56]:[^:]*:Forgiven Dissonance:3DC7:/
+238.2 "Light Shot" sync / 1[56]:[^:]*:Forgiven Dissonance:3DCB:/
+241.4 "Thumbscrew" sync / 1[56]:[^:]*:Forgiven Dissonance:3DC6:/
+243.2 "Heretic's Fork" sync / 1[56]:[^:]*:Forgiven Dissonance:3DCE:/
+248.4 "Light Shot" sync / 1[56]:[^:]*:Forgiven Dissonance:3DCB:/
+249.0 "Wooden Horse" sync / 1[56]:[^:]*:Forgiven Dissonance:3DC7:/
 
-261.3 "The Path Of Light" sync / 1[56]:Forgiven Dissonance:3DC5:/ window 30,30 jump 154.2
+261.3 "The Path Of Light" sync / 1[56]:[^:]*:Forgiven Dissonance:3DC5:/ window 30,30 jump 154.2
 269.6 "Pillory"
 280.1 "Brazen Bull"
 289.4 "Gibbet Cage"
@@ -50,24 +50,24 @@ hideall "--sync--"
 ### Tesleen, the Forgiven
 # -ii 3DD6 3DD3 -p 3DCF:513.5
 500.0 "--sync--" sync / 00:0839::The Auction will be sealed off/ window 500,0
-513.5 "The Tickler" sync / 1[56]:Tesleen, the Forgiven:3DCF:/ window 514,5
-523.6 "Scold's Bridle" sync / 1[56]:Tesleen, the Forgiven:3DD0:/
-533.8 "Fevered Flagellation" sync / 1[56]:Tesleen, the Forgiven:3DD5:/
-548.3 "Scold's Bridle" sync / 1[56]:Tesleen, the Forgiven:3DD0:/
-558.6 "Exorcise" sync / 1[56]:Tesleen, the Forgiven:3DD2:/
-560.4 "Holy Water" sync / 1[56]:Tesleen, the Forgiven:3DD4:/
-573.8 "Fevered Flagellation" sync / 1[56]:Tesleen, the Forgiven:3DD5:/
+513.5 "The Tickler" sync / 1[56]:[^:]*:Tesleen, the Forgiven:3DCF:/ window 514,5
+523.6 "Scold's Bridle" sync / 1[56]:[^:]*:Tesleen, the Forgiven:3DD0:/
+533.8 "Fevered Flagellation" sync / 1[56]:[^:]*:Tesleen, the Forgiven:3DD5:/
+548.3 "Scold's Bridle" sync / 1[56]:[^:]*:Tesleen, the Forgiven:3DD0:/
+558.6 "Exorcise" sync / 1[56]:[^:]*:Tesleen, the Forgiven:3DD2:/
+560.4 "Holy Water" sync / 1[56]:[^:]*:Tesleen, the Forgiven:3DD4:/
+573.8 "Fevered Flagellation" sync / 1[56]:[^:]*:Tesleen, the Forgiven:3DD5:/
 
-578.7 "--sync--" sync / 1[56]:Tesleen, the Forgiven:3DD1:/
-594.8 "Scold's Bridle" sync / 1[56]:Tesleen, the Forgiven:3DD0:/ window 3,3
-602.0 "Scold's Bridle" sync / 1[56]:Tesleen, the Forgiven:3DD0:/ window 3,3
-612.1 "The Tickler" sync / 1[56]:Tesleen, the Forgiven:3DCF:/
-619.2 "Scold's Bridle" sync / 1[56]:Tesleen, the Forgiven:3DD0:/
-636.4 "Exorcise" sync / 1[56]:Tesleen, the Forgiven:3DD2:/
-638.3 "Holy Water" sync / 1[56]:Tesleen, the Forgiven:3DD4:/
-651.6 "Fevered Flagellation" sync / 1[56]:Tesleen, the Forgiven:3DD5:/
+578.7 "--sync--" sync / 1[56]:[^:]*:Tesleen, the Forgiven:3DD1:/
+594.8 "Scold's Bridle" sync / 1[56]:[^:]*:Tesleen, the Forgiven:3DD0:/ window 3,3
+602.0 "Scold's Bridle" sync / 1[56]:[^:]*:Tesleen, the Forgiven:3DD0:/ window 3,3
+612.1 "The Tickler" sync / 1[56]:[^:]*:Tesleen, the Forgiven:3DCF:/
+619.2 "Scold's Bridle" sync / 1[56]:[^:]*:Tesleen, the Forgiven:3DD0:/
+636.4 "Exorcise" sync / 1[56]:[^:]*:Tesleen, the Forgiven:3DD2:/
+638.3 "Holy Water" sync / 1[56]:[^:]*:Tesleen, the Forgiven:3DD4:/
+651.6 "Fevered Flagellation" sync / 1[56]:[^:]*:Tesleen, the Forgiven:3DD5:/
 
-656.7 "--sync--" sync / 1[56]:Tesleen, the Forgiven:3DD1:/ window 30,30 jump 578.7
+656.7 "--sync--" sync / 1[56]:[^:]*:Tesleen, the Forgiven:3DD1:/ window 30,30 jump 578.7
 672.8 "Scold's Bridle"
 680.0 "Scold's Bridle"
 690.1 "The Tickler"
@@ -80,39 +80,39 @@ hideall "--sync--"
 ### Philia
 # -ii 3DDD 3DDF 3DDE 3DDC 3DDB 3DE1 3DE0 3DE9 4196 3DE5 4181 -p 3DD8:1012.5
 1000.0 "--sync--" sync / 00:0839::The manor house courtyard will be sealed off/ window 1000,0
-1012.5 "Scavenger's Daughter" sync / 1[56]:Philia:3DD8:/
-1022.8 "Head Crusher" sync / 1[56]:Philia:3DD7:/
-1032.9 "Pendulum Tank" sync / 1[56]:Philia:4189:/
-1035.0 "Pendulum Center" sync / 1[56]:Philia:3DD9:/
+1012.5 "Scavenger's Daughter" sync / 1[56]:[^:]*:Philia:3DD8:/
+1022.8 "Head Crusher" sync / 1[56]:[^:]*:Philia:3DD7:/
+1032.9 "Pendulum Tank" sync / 1[56]:[^:]*:Philia:4189:/
+1035.0 "Pendulum Center" sync / 1[56]:[^:]*:Philia:3DD9:/
 
-1035.5 "--sync--" sync / 1[56]:Philia:418A:/
-1042.1 "Chain Down" sync / 1[56]:Philia:429C:/
-1059.5 "Aethersup" sync / 1[56]:Philia:3DE8:/ duration 3.5
+1035.5 "--sync--" sync / 1[56]:[^:]*:Philia:418A:/
+1042.1 "Chain Down" sync / 1[56]:[^:]*:Philia:429C:/
+1059.5 "Aethersup" sync / 1[56]:[^:]*:Philia:3DE8:/ duration 3.5
 
-1070.1 "Left/Right Knout" sync / 1[56]:Philia:3DE[67]:/
-1077.1 "Right/Left Knout" sync / 1[56]:Philia:3DE[67]:/
-1088.4 "Head Crusher" sync / 1[56]:Philia:3DD7:/
-1095.0 "Taphephobia" sync / 1[56]:Philia:3DE2:/
+1070.1 "Left/Right Knout" sync / 1[56]:[^:]*:Philia:3DE[67]:/
+1077.1 "Right/Left Knout" sync / 1[56]:[^:]*:Philia:3DE[67]:/
+1088.4 "Head Crusher" sync / 1[56]:[^:]*:Philia:3DD7:/
+1095.0 "Taphephobia" sync / 1[56]:[^:]*:Philia:3DE2:/
 
-1097.2 "--sync--" sync / 1[56]:Philia:3DE4:/
-1102.1 "Into The Light" sync / 1[56]:Philia:4350:/
-1122.8 "Pendulum Tank" sync / 1[56]:Philia:4189:/
-1125.0 "Pendulum Center" sync / 1[56]:Philia:3DD9:/
+1097.2 "--sync--" sync / 1[56]:[^:]*:Philia:3DE4:/
+1102.1 "Into The Light" sync / 1[56]:[^:]*:Philia:4350:/
+1122.8 "Pendulum Tank" sync / 1[56]:[^:]*:Philia:4189:/
+1125.0 "Pendulum Center" sync / 1[56]:[^:]*:Philia:3DD9:/
 
-1125.4 "--sync--" sync / 1[56]:Philia:418A:/
-1132.3 "Fierce Beating" sync / 1[56]:Philia:3DDA:/ duration 42
+1125.4 "--sync--" sync / 1[56]:[^:]*:Philia:418A:/
+1132.3 "Fierce Beating" sync / 1[56]:[^:]*:Philia:3DDA:/ duration 42
 
-1165.8 "--sync--" sync / 1[56]:Philia:3DE4:/
-1170.8 "Into The Light" sync / 1[56]:Philia:4350:/
-1178.5 "Left/Right Knout" sync / 1[56]:Philia:3DE[67]:/
-1185.7 "Right/Left Knout" sync / 1[56]:Philia:3DE[67]:/
-1192.9 "Chain Down" sync / 1[56]:Philia:429C:/
-1210.3 "Aethersup" sync / 1[56]:Philia:3DE8:/ duration 3.5
-1225.6 "Scavenger's Daughter" sync / 1[56]:Philia:3DD8:/
-1244.9 "Head Crusher" sync / 1[56]:Philia:3DD7:/
-1251.6 "Taphephobia" sync / 1[56]:Philia:3DE2:/
+1165.8 "--sync--" sync / 1[56]:[^:]*:Philia:3DE4:/
+1170.8 "Into The Light" sync / 1[56]:[^:]*:Philia:4350:/
+1178.5 "Left/Right Knout" sync / 1[56]:[^:]*:Philia:3DE[67]:/
+1185.7 "Right/Left Knout" sync / 1[56]:[^:]*:Philia:3DE[67]:/
+1192.9 "Chain Down" sync / 1[56]:[^:]*:Philia:429C:/
+1210.3 "Aethersup" sync / 1[56]:[^:]*:Philia:3DE8:/ duration 3.5
+1225.6 "Scavenger's Daughter" sync / 1[56]:[^:]*:Philia:3DD8:/
+1244.9 "Head Crusher" sync / 1[56]:[^:]*:Philia:3DD7:/
+1251.6 "Taphephobia" sync / 1[56]:[^:]*:Philia:3DE2:/
 
-1253.8 "--sync--" sync / 1[56]:Philia:3DE4:/ window 30,30 jump 1097.2
+1253.8 "--sync--" sync / 1[56]:[^:]*:Philia:3DE4:/ window 30,30 jump 1097.2
 1258.7 "Into The Light"
 1279.4 "Pendulum Tank"
 1281.6 "Pendulum Center"

--- a/ui/raidboss/data/05-shb/dungeon/malikahs_well.txt
+++ b/ui/raidboss/data/05-shb/dungeon/malikahs_well.txt
@@ -10,31 +10,31 @@ hideall "--sync--"
 # -ii 3CEA 3CE8 -p 3CE5:115
 100.0 "--sync--" sync / 00:0839::Terminus will be sealed off/ window 100,0
 
-115.0 "Stone Flail" sync / 1[56]:Greater Armadillo:3CE5:/ window 115,5
-133.6 "Head Toss" sync / 1[56]:Greater Armadillo:3CE6:/
-138.6 "Right Round" sync / 1[56]:Greater Armadillo:3CE7:/
-144.2 "Flail Smash" sync / 1[56]:Greater Armadillo:3CE9:/
-148.9 "Earthshake" sync / 1[56]:Greater Armadillo:3E39:/
+115.0 "Stone Flail" sync / 1[56]:[^:]*:Greater Armadillo:3CE5:/ window 115,5
+133.6 "Head Toss" sync / 1[56]:[^:]*:Greater Armadillo:3CE6:/
+138.6 "Right Round" sync / 1[56]:[^:]*:Greater Armadillo:3CE7:/
+144.2 "Flail Smash" sync / 1[56]:[^:]*:Greater Armadillo:3CE9:/
+148.9 "Earthshake" sync / 1[56]:[^:]*:Greater Armadillo:3E39:/
 
 160.7 "2x Pack Armadillo"
 
-175.3 "Stone Flail" sync / 1[56]:Greater Armadillo:3CE5:/
-198.0 "Head Toss" sync / 1[56]:Greater Armadillo:3CE6:/
-203.0 "Right Round" sync / 1[56]:Greater Armadillo:3CE7:/
-208.6 "Flail Smash" sync / 1[56]:Greater Armadillo:3CE9:/
-213.3 "Earthshake" sync / 1[56]:Greater Armadillo:3E39:/
+175.3 "Stone Flail" sync / 1[56]:[^:]*:Greater Armadillo:3CE5:/
+198.0 "Head Toss" sync / 1[56]:[^:]*:Greater Armadillo:3CE6:/
+203.0 "Right Round" sync / 1[56]:[^:]*:Greater Armadillo:3CE7:/
+208.6 "Flail Smash" sync / 1[56]:[^:]*:Greater Armadillo:3CE9:/
+213.3 "Earthshake" sync / 1[56]:[^:]*:Greater Armadillo:3E39:/
 
 225.1 "2x Pack Armadillo"
 
-239.6 "Stone Flail" sync / 1[56]:Greater Armadillo:3CE5:/
-262.0 "Head Toss" sync / 1[56]:Greater Armadillo:3CE6:/
-266.9 "Right Round" sync / 1[56]:Greater Armadillo:3CE7:/
-272.5 "Flail Smash" sync / 1[56]:Greater Armadillo:3CE9:/
-277.2 "Earthshake" sync / 1[56]:Greater Armadillo:3E39:/
+239.6 "Stone Flail" sync / 1[56]:[^:]*:Greater Armadillo:3CE5:/
+262.0 "Head Toss" sync / 1[56]:[^:]*:Greater Armadillo:3CE6:/
+266.9 "Right Round" sync / 1[56]:[^:]*:Greater Armadillo:3CE7:/
+272.5 "Flail Smash" sync / 1[56]:[^:]*:Greater Armadillo:3CE9:/
+277.2 "Earthshake" sync / 1[56]:[^:]*:Greater Armadillo:3E39:/
 
 289.0 "2x Pack Armadillo"
 
-303.5 "Stone Flail" sync / 1[56]:Greater Armadillo:3CE5:/ window 20,20 jump 175.3
+303.5 "Stone Flail" sync / 1[56]:[^:]*:Greater Armadillo:3CE5:/ window 20,20 jump 175.3
 326.2 "Head Toss"
 331.2 "Right Round"
 336.8 "Flail Smash"
@@ -46,22 +46,22 @@ hideall "--sync--"
 ### Amphibious Talos
 # -ii 3CF0 -p 3CEB:515.5
 500.0 "--sync--" sync / 00:0839::Malikah's Gift will be sealed off/ window 500,0
-515.5 "Efface" sync / 1[56]:Amphibious Talos:3CEB:/
-527.1 "Wellbore" sync / 1[56]:Amphibious Talos:3CED:/
-531.3 "Geyser Eruption" sync / 1[56]:Amphibious Talos:3CEE:/
-534.1 "High Pressure" sync / 1[56]:Amphibious Talos:3CEC:/
-544.5 "Swift Spill x6" sync / 1[56]:Amphibious Talos:3CEF:/ duration 6.4
-562.4 "Efface" sync / 1[56]:Amphibious Talos:3CEB:/
-575.1 "Efface" sync / 1[56]:Amphibious Talos:3CEB:/
+515.5 "Efface" sync / 1[56]:[^:]*:Amphibious Talos:3CEB:/
+527.1 "Wellbore" sync / 1[56]:[^:]*:Amphibious Talos:3CED:/
+531.3 "Geyser Eruption" sync / 1[56]:[^:]*:Amphibious Talos:3CEE:/
+534.1 "High Pressure" sync / 1[56]:[^:]*:Amphibious Talos:3CEC:/
+544.5 "Swift Spill x6" sync / 1[56]:[^:]*:Amphibious Talos:3CEF:/ duration 6.4
+562.4 "Efface" sync / 1[56]:[^:]*:Amphibious Talos:3CEB:/
+575.1 "Efface" sync / 1[56]:[^:]*:Amphibious Talos:3CEB:/
 
-590.4 "Wellbore" sync / 1[56]:Amphibious Talos:3CED:/
-594.6 "Geyser Eruption" sync / 1[56]:Amphibious Talos:3CEE:/
-597.4 "High Pressure" sync / 1[56]:Amphibious Talos:3CEC:/
-608.0 "Swift Spill x6" sync / 1[56]:Amphibious Talos:3CEF:/ duration 6.4
-625.9 "Efface" sync / 1[56]:Amphibious Talos:3CEB:/
-638.6 "Efface" sync / 1[56]:Amphibious Talos:3CEB:/
+590.4 "Wellbore" sync / 1[56]:[^:]*:Amphibious Talos:3CED:/
+594.6 "Geyser Eruption" sync / 1[56]:[^:]*:Amphibious Talos:3CEE:/
+597.4 "High Pressure" sync / 1[56]:[^:]*:Amphibious Talos:3CEC:/
+608.0 "Swift Spill x6" sync / 1[56]:[^:]*:Amphibious Talos:3CEF:/ duration 6.4
+625.9 "Efface" sync / 1[56]:[^:]*:Amphibious Talos:3CEB:/
+638.6 "Efface" sync / 1[56]:[^:]*:Amphibious Talos:3CEB:/
 
-653.9 "Wellbore" sync / 1[56]:Amphibious Talos:3CED:/ window 20,20 jump 590.4
+653.9 "Wellbore" sync / 1[56]:[^:]*:Amphibious Talos:3CED:/ window 20,20 jump 590.4
 658.1 "Geyser Eruption"
 660.9 "High Pressure"
 671.5 "Swift Spill x6" duration 6.4
@@ -72,39 +72,39 @@ hideall "--sync--"
 ### Storge
 # -ii 3CF7 3CA8 41A8 -p 3CF1:1015
 1000.0 "--sync--" sync / 00:0839::Unquestioned Acceptance will be sealed off/ window 1000,0
-1015.0 "Intestinal Crank" sync / 1[56]:Storge:3CF1:/ window 1015,5
-1028.2 "Heretic's Fork" sync / 1[56]:Storge:3CF2:/
-1043.0 "Breaking Wheel" sync / 1[56]:Storge:3CF5:/
+1015.0 "Intestinal Crank" sync / 1[56]:[^:]*:Storge:3CF1:/ window 1015,5
+1028.2 "Heretic's Fork" sync / 1[56]:[^:]*:Storge:3CF2:/
+1043.0 "Breaking Wheel" sync / 1[56]:[^:]*:Storge:3CF5:/
 
-1056.1 "Crystal Nail" sync / 1[56]:Storge:3CF6:/
-1063.2 "Heretic's Fork?" sync / 1[56]:Storge:3CF2:/ window 10,10 jump 2063.2
-1065.7 "Breaking Wheel?" sync / 1[56]:Storge:3CF5:/ window 10,10 jump 2156.2
+1056.1 "Crystal Nail" sync / 1[56]:[^:]*:Storge:3CF6:/
+1063.2 "Heretic's Fork?" sync / 1[56]:[^:]*:Storge:3CF2:/ window 10,10 jump 2063.2
+1065.7 "Breaking Wheel?" sync / 1[56]:[^:]*:Storge:3CF5:/ window 10,10 jump 2156.2
 
-2056.1 "Crystal Nail" sync / 1[56]:Storge:3CF6:/
-2063.2 "Heretic's Fork" sync / 1[56]:Storge:3CF2:/
-2068.3 "Censure" sync / 1[56]:Storge:3CF8:/
-2078.5 "Heretic's Fork" #sync / 1[56]:Rhapsodic Nail:3CF9:/
-2082.5 "Heretic's Fork" #sync / 1[56]:Rhapsodic Nail:3CF9:/
-2086.5 "Heretic's Fork" #sync / 1[56]:Rhapsodic Nail:3CF9:/
-2090.5 "Heretic's Fork" #sync / 1[56]:Rhapsodic Nail:3CF9:/
-2093.4 "Heretic's Fork" sync / 1[56]:Storge:3E0E:/
-2105.6 "Intestinal Crank" sync / 1[56]:Storge:3CF1:/
-2119.7 "Intestinal Crank" sync / 1[56]:Storge:3CF1:/
-2133.8 "Intestinal Crank" sync / 1[56]:Storge:3CF1:/
+2056.1 "Crystal Nail" sync / 1[56]:[^:]*:Storge:3CF6:/
+2063.2 "Heretic's Fork" sync / 1[56]:[^:]*:Storge:3CF2:/
+2068.3 "Censure" sync / 1[56]:[^:]*:Storge:3CF8:/
+2078.5 "Heretic's Fork" #sync / 1[56]:[^:]*:Rhapsodic Nail:3CF9:/
+2082.5 "Heretic's Fork" #sync / 1[56]:[^:]*:Rhapsodic Nail:3CF9:/
+2086.5 "Heretic's Fork" #sync / 1[56]:[^:]*:Rhapsodic Nail:3CF9:/
+2090.5 "Heretic's Fork" #sync / 1[56]:[^:]*:Rhapsodic Nail:3CF9:/
+2093.4 "Heretic's Fork" sync / 1[56]:[^:]*:Storge:3E0E:/
+2105.6 "Intestinal Crank" sync / 1[56]:[^:]*:Storge:3CF1:/
+2119.7 "Intestinal Crank" sync / 1[56]:[^:]*:Storge:3CF1:/
+2133.8 "Intestinal Crank" sync / 1[56]:[^:]*:Storge:3CF1:/
 
-2146.6 "Crystal Nail" sync / 1[56]:Storge:3CF6:/
-2156.2 "Breaking Wheel" sync / 1[56]:Storge:3CF5:/
-2161.4 "Censure" sync / 1[56]:Storge:3E37:/
-2172.5 "Breaking Wheel" #sync / 1[56]:Rhapsodic Nail:3CFA:/
-2177.7 "Breaking Wheel" #sync / 1[56]:Rhapsodic Nail:3CFA:/
-2182.7 "Breaking Wheel" #sync / 1[56]:Rhapsodic Nail:3CFA:/
-2187.7 "Breaking Wheel" #sync / 1[56]:Rhapsodic Nail:3CFA:/
-2192.6 "Breaking Wheel" sync / 1[56]:Storge:3E0F:/
-2212.4 "Intestinal Crank" sync / 1[56]:Storge:3CF1:/
-2226.5 "Intestinal Crank" sync / 1[56]:Storge:3CF1:/
-2240.6 "Intestinal Crank" sync / 1[56]:Storge:3CF1:/
+2146.6 "Crystal Nail" sync / 1[56]:[^:]*:Storge:3CF6:/
+2156.2 "Breaking Wheel" sync / 1[56]:[^:]*:Storge:3CF5:/
+2161.4 "Censure" sync / 1[56]:[^:]*:Storge:3E37:/
+2172.5 "Breaking Wheel" #sync / 1[56]:[^:]*:Rhapsodic Nail:3CFA:/
+2177.7 "Breaking Wheel" #sync / 1[56]:[^:]*:Rhapsodic Nail:3CFA:/
+2182.7 "Breaking Wheel" #sync / 1[56]:[^:]*:Rhapsodic Nail:3CFA:/
+2187.7 "Breaking Wheel" #sync / 1[56]:[^:]*:Rhapsodic Nail:3CFA:/
+2192.6 "Breaking Wheel" sync / 1[56]:[^:]*:Storge:3E0F:/
+2212.4 "Intestinal Crank" sync / 1[56]:[^:]*:Storge:3CF1:/
+2226.5 "Intestinal Crank" sync / 1[56]:[^:]*:Storge:3CF1:/
+2240.6 "Intestinal Crank" sync / 1[56]:[^:]*:Storge:3CF1:/
 
-2253.4 "Crystal Nail" sync / 1[56]:Storge:3CF6:/ window 50,50 jump 2056.1
+2253.4 "Crystal Nail" sync / 1[56]:[^:]*:Storge:3CF6:/ window 50,50 jump 2056.1
 2260.5 "Heretic's Fork"
 2265.5 "Censure"
 2275.7 "Heretic's Fork"

--- a/ui/raidboss/data/05-shb/dungeon/matoyas_relict.txt
+++ b/ui/raidboss/data/05-shb/dungeon/matoyas_relict.txt
@@ -10,38 +10,38 @@ hideall "--sync--"
 # -ii 368 5481 5487 548E 548F 5490 5492
 1000.0 "--sync--" sync / 00:0839::The Clayclot Cauldron will be sealed off/ window 1000,0
 # Loop 3 times
-1011.0 "Hard Rock" sync / 1[56]:Mudman:547F:/ window 10,10
-1020.2 "Petrified Peat" sync / 1[56]:Mudman:5480:/
-1032.3 "Peat Pelt" sync / 1[56]:Mudman:5482:/
-1041.4 "Rocky Roll" sync / 1[56]:Mud Bubble:548(3|4):/
-1050.7 "Brittle Breccia" sync / 1[56]:Mudman:548D:/
-1051.1 "Rocky Roll" sync / 1[56]:Mud Bubble:548(3|5):/
-1066.7 "Stone Age" sync / 1[56]:Mudman:5491:/
+1011.0 "Hard Rock" sync / 1[56]:[^:]*:Mudman:547F:/ window 10,10
+1020.2 "Petrified Peat" sync / 1[56]:[^:]*:Mudman:5480:/
+1032.3 "Peat Pelt" sync / 1[56]:[^:]*:Mudman:5482:/
+1041.4 "Rocky Roll" sync / 1[56]:[^:]*:Mud Bubble:548(3|4):/
+1050.7 "Brittle Breccia" sync / 1[56]:[^:]*:Mudman:548D:/
+1051.1 "Rocky Roll" sync / 1[56]:[^:]*:Mud Bubble:548(3|5):/
+1066.7 "Stone Age" sync / 1[56]:[^:]*:Mudman:5491:/
 
-1077.8 "Hard Rock" sync / 1[56]:Mudman:547F:/ window 10,10
-1087.0 "Petrified Peat" sync / 1[56]:Mudman:5480:/
-1099.1 "Peat Pelt" sync / 1[56]:Mudman:5482:/
-1108.2 "Rocky Roll" sync / 1[56]:Mud Bubble:548(3|4):/
-1117.5 "Brittle Breccia" sync / 1[56]:Mudman:548D:/
-1117.9 "Rocky Roll" sync / 1[56]:Mud Bubble:548(3|5):/
-1133.5 "Stone Age" sync / 1[56]:Mudman:5491:/
+1077.8 "Hard Rock" sync / 1[56]:[^:]*:Mudman:547F:/ window 10,10
+1087.0 "Petrified Peat" sync / 1[56]:[^:]*:Mudman:5480:/
+1099.1 "Peat Pelt" sync / 1[56]:[^:]*:Mudman:5482:/
+1108.2 "Rocky Roll" sync / 1[56]:[^:]*:Mud Bubble:548(3|4):/
+1117.5 "Brittle Breccia" sync / 1[56]:[^:]*:Mudman:548D:/
+1117.9 "Rocky Roll" sync / 1[56]:[^:]*:Mud Bubble:548(3|5):/
+1133.5 "Stone Age" sync / 1[56]:[^:]*:Mudman:5491:/
 
 # After this loop, each loop with "Falling Rock"
-1144.6 "Hard Rock" sync / 1[56]:Mudman:547F:/ window 10,10
-1153.8 "Petrified Peat" sync / 1[56]:Mudman:5480:/
-1165.9 "Peat Pelt" sync / 1[56]:Mudman:5482:/
-1175.0 "Rocky Roll" sync / 1[56]:Mud Bubble:548(3|4):/
-1184.3 "Brittle Breccia" sync / 1[56]:Mudman:548D:/
-1184.7 "Rocky Roll" sync / 1[56]:Mud Bubble:548(3|5):/
-1200.3 "Stone Age" sync / 1[56]:Mudman:5491:/
+1144.6 "Hard Rock" sync / 1[56]:[^:]*:Mudman:547F:/ window 10,10
+1153.8 "Petrified Peat" sync / 1[56]:[^:]*:Mudman:5480:/
+1165.9 "Peat Pelt" sync / 1[56]:[^:]*:Mudman:5482:/
+1175.0 "Rocky Roll" sync / 1[56]:[^:]*:Mud Bubble:548(3|4):/
+1184.3 "Brittle Breccia" sync / 1[56]:[^:]*:Mudman:548D:/
+1184.7 "Rocky Roll" sync / 1[56]:[^:]*:Mud Bubble:548(3|5):/
+1200.3 "Stone Age" sync / 1[56]:[^:]*:Mudman:5491:/
 
-1212.3 "Falling Rock" sync / 1[56]:Mudman:549(3|4):/
+1212.3 "Falling Rock" sync / 1[56]:[^:]*:Mudman:549(3|4):/
 
-1223.5 "Hard Rock" sync / 1[56]:Mudman:547F:/ window 10,10 jump 1144.6
-1232.7 "Petrified Peat" # sync / 1[56]:Mudman:5480:/
-1244.8 "Peat Pelt" # sync / 1[56]:Mudman:5482:/
-1253.9 "Rocky Roll" # sync / 1[56]:Mud Bubble:548(3|4):/
-1263.2 "Brittle Breccia" # sync / 1[56]:Mudman:548D:/
+1223.5 "Hard Rock" sync / 1[56]:[^:]*:Mudman:547F:/ window 10,10 jump 1144.6
+1232.7 "Petrified Peat" # sync / 1[56]:[^:]*:Mudman:5480:/
+1244.8 "Peat Pelt" # sync / 1[56]:[^:]*:Mudman:5482:/
+1253.9 "Rocky Roll" # sync / 1[56]:[^:]*:Mud Bubble:548(3|4):/
+1263.2 "Brittle Breccia" # sync / 1[56]:[^:]*:Mudman:548D:/
 
 
 ### Nixie
@@ -49,22 +49,22 @@ hideall "--sync--"
 # -ii 598E 5990 5992 5993 5994 5995 5996 5BB9
 2000.0 "--sync--" sync / 00:0839::The Clearnote Cauldron will be sealed off/ window 2000,0
 
-2009.2 "Crash-Smash" sync / 1[56]:Nixie:598F:/ window 10,10
-2023.4 "Shower Power" sync / 1[56]:Nixie:5991:/
+2009.2 "Crash-Smash" sync / 1[56]:[^:]*:Nixie:598F:/ window 10,10
+2023.4 "Shower Power" sync / 1[56]:[^:]*:Nixie:5991:/
 2038.1 "--untargetable--"
-2044.1 "Pitter-Patter" sync / 1[56]:Nixie:5988:/
-2072.2 "Sea Shanty" sync / 1[56]:Nixie:598[AC]:/
-2092.4 "Shower Power" sync / 1[56]:Nixie:5991:/
+2044.1 "Pitter-Patter" sync / 1[56]:[^:]*:Nixie:5988:/
+2072.2 "Sea Shanty" sync / 1[56]:[^:]*:Nixie:598[AC]:/
+2092.4 "Shower Power" sync / 1[56]:[^:]*:Nixie:5991:/
 
-2110.5 "Crash-Smash" sync / 1[56]:Nixie:598F:/ window 10,10
-2130.7 "Shower Power" sync / 1[56]:Nixie:5991:/
-2134.9 "Splish-Splash" sync / 1[56]:Nixie:598D:/
-2160.0 "Shower Power" sync / 1[56]:Nixie:5991:/
+2110.5 "Crash-Smash" sync / 1[56]:[^:]*:Nixie:598F:/ window 10,10
+2130.7 "Shower Power" sync / 1[56]:[^:]*:Nixie:5991:/
+2134.9 "Splish-Splash" sync / 1[56]:[^:]*:Nixie:598D:/
+2160.0 "Shower Power" sync / 1[56]:[^:]*:Nixie:5991:/
 
-2178.2 "Crash-Smash" sync / 1[56]:Nixie:598F:/ window 10,10 jump 2110.5
-2198.4 "Shower Power" # sync / 1[56]:Nixie:5991:/
-2202.6 "Splish-Splash" # sync / 1[56]:Nixie:598D:/
-2227.7 "Shower Power" # sync / 1[56]:Nixie:5991:/
+2178.2 "Crash-Smash" sync / 1[56]:[^:]*:Nixie:598F:/ window 10,10 jump 2110.5
+2198.4 "Shower Power" # sync / 1[56]:[^:]*:Nixie:5991:/
+2202.6 "Splish-Splash" # sync / 1[56]:[^:]*:Nixie:598D:/
+2227.7 "Shower Power" # sync / 1[56]:[^:]*:Nixie:5991:/
 
 
 ### Mother Porxie
@@ -72,38 +72,38 @@ hideall "--sync--"
 # -ii 4A8F 5912 5914 5917 5918 591E 591F 5923 5925
 3000.0 "--sync--" sync / 00:0839::The Woebegone Workshop will be sealed off/ window 3000,0
 
-3011.3 "Tender Loin" sync / 1[56]:Mother Porxie:5913:/
-3029.5 "Huff And Puff" sync / 1[56]:Mother Porxie:5919:/
-3031.6 "Medium Rear" sync / 1[56]:Mother Porxie:591D:/
-3045.7 "Meat Mallet" sync / 1[56]:Mother Porxie:5916:/
+3011.3 "Tender Loin" sync / 1[56]:[^:]*:Mother Porxie:5913:/
+3029.5 "Huff And Puff" sync / 1[56]:[^:]*:Mother Porxie:5919:/
+3031.6 "Medium Rear" sync / 1[56]:[^:]*:Mother Porxie:591D:/
+3045.7 "Meat Mallet" sync / 1[56]:[^:]*:Mother Porxie:5916:/
 3045.7 "--untargetable--"
-3050.4 "Barbeque" sync / 1[56]:Mother Porxie:5B23:/
-3072.4 "To A Crisp" sync / 1[56]:Mother Porxie:5924:/
+3050.4 "Barbeque" sync / 1[56]:[^:]*:Mother Porxie:5B23:/
+3072.4 "To A Crisp" sync / 1[56]:[^:]*:Mother Porxie:5924:/
 3074.4 "--targetable--"
-3086.5 "Minced Meat" sync / 1[56]:Mother Porxie:5911:/ window 50,10
+3086.5 "Minced Meat" sync / 1[56]:[^:]*:Mother Porxie:5911:/ window 50,10
 3093.6 "--untargetable--"
 
-3096.6 "Huff And Puff" sync / 14:Mother Porxie:591A:/ window 96.6,5 duration 33.7
-3101.6 "Buffet" sync / 1[56]:Aeolian Cave Sprite:5926:/
-3107.3 "Buffet" sync / 1[56]:Aeolian Cave Sprite:5926:/
-3112.8 "Buffet" sync / 1[56]:Aeolian Cave Sprite:5926:/
-3118.4 "Buffet" sync / 1[56]:Aeolian Cave Sprite:5926:/
-3124.0 "Buffet" sync / 1[56]:Aeolian Cave Sprite:5926:/
-3129.6 "Buffet" sync / 1[56]:Aeolian Cave Sprite:5926:/
-3130.3 "Huff And Puff Enrage?" sync / 1[56]:Mother Porxie:591B:/ window 50,5
+3096.6 "Huff And Puff" sync / 14:[^:]*:Mother Porxie:591A:/ window 96.6,5 duration 33.7
+3101.6 "Buffet" sync / 1[56]:[^:]*:Aeolian Cave Sprite:5926:/
+3107.3 "Buffet" sync / 1[56]:[^:]*:Aeolian Cave Sprite:5926:/
+3112.8 "Buffet" sync / 1[56]:[^:]*:Aeolian Cave Sprite:5926:/
+3118.4 "Buffet" sync / 1[56]:[^:]*:Aeolian Cave Sprite:5926:/
+3124.0 "Buffet" sync / 1[56]:[^:]*:Aeolian Cave Sprite:5926:/
+3129.6 "Buffet" sync / 1[56]:[^:]*:Aeolian Cave Sprite:5926:/
+3130.3 "Huff And Puff Enrage?" sync / 1[56]:[^:]*:Mother Porxie:591B:/ window 50,5
 
 3132.3 "--targetable--"
 # Loop
-3132.4 "Medium Rear" sync / 1[56]:Mother Porxie:591D:/
-3148.5 "Open Flame" sync / 1[56]:Mother Porxie:5922:/
-3160.6 "Minced Meat" sync / 1[56]:Mother Porxie:5911:/
-3172.7 "Tender Loin" sync / 1[56]:Mother Porxie:5913:/
-3186.8 "Tender Loin" sync / 1[56]:Mother Porxie:5913:/
-3207.1 "Huff And Puff" sync / 1[56]:Mother Porxie:5919:/
+3132.4 "Medium Rear" sync / 1[56]:[^:]*:Mother Porxie:591D:/
+3148.5 "Open Flame" sync / 1[56]:[^:]*:Mother Porxie:5922:/
+3160.6 "Minced Meat" sync / 1[56]:[^:]*:Mother Porxie:5911:/
+3172.7 "Tender Loin" sync / 1[56]:[^:]*:Mother Porxie:5913:/
+3186.8 "Tender Loin" sync / 1[56]:[^:]*:Mother Porxie:5913:/
+3207.1 "Huff And Puff" sync / 1[56]:[^:]*:Mother Porxie:5919:/
 
-3209.2 "Medium Rear" sync / 1[56]:Mother Porxie:591D:/
-3225.3 "Open Flame" sync / 1[56]:Mother Porxie:5922:/
-3237.5 "Minced Meat" sync / 1[56]:Mother Porxie:5911:/ jump 3160.6
-3249.6 "Tender Loin" # sync / 1[56]:Mother Porxie:5913:/
-3263.7 "Tender Loin" # sync / 1[56]:Mother Porxie:5913:/
-3281.9 "Huff And Puff" # sync / 1[56]:Mother Porxie:5919:/
+3209.2 "Medium Rear" sync / 1[56]:[^:]*:Mother Porxie:591D:/
+3225.3 "Open Flame" sync / 1[56]:[^:]*:Mother Porxie:5922:/
+3237.5 "Minced Meat" sync / 1[56]:[^:]*:Mother Porxie:5911:/ jump 3160.6
+3249.6 "Tender Loin" # sync / 1[56]:[^:]*:Mother Porxie:5913:/
+3263.7 "Tender Loin" # sync / 1[56]:[^:]*:Mother Porxie:5913:/
+3281.9 "Huff And Puff" # sync / 1[56]:[^:]*:Mother Porxie:5919:/

--- a/ui/raidboss/data/05-shb/dungeon/mt_gulg.txt
+++ b/ui/raidboss/data/05-shb/dungeon/mt_gulg.txt
@@ -12,28 +12,28 @@ hideall "Rite Of The Sacrament"
 ### Forgiven Cruelty
 # -p 3CFB:113 -ii 3CFE 3CFD 4301 3CFF
 100.0 "--sync--" sync / 00:0839::The Perished Path will be sealed off/ window 100,0
-113.0 "Rake" sync / 1[56]:Forgiven Cruelty:3CFB:/ window 115,5
-121.2 "Lumen Infinitum" sync / 1[56]:Forgiven Cruelty:41B2:/
-138.3 "Typhoon Wing" sync / 1[56]:Forgiven Cruelty:3D00:/
-147.2 "Cyclone Wing" sync / 1[56]:Forgiven Cruelty:3CFC:/
-160.8 "Typhoon Wing" sync / 1[56]:Forgiven Cruelty:3D00:/
-171.6 "Lumen Infinitum" sync / 1[56]:Forgiven Cruelty:41B2:/
-188.2 "Typhoon Wing" sync / 1[56]:Forgiven Cruelty:3D01:/
-188.2 "Hurricane Wing" sync / 1[56]:Forgiven Cruelty:3D03:/
-197.0 "Cyclone Wing" sync / 1[56]:Forgiven Cruelty:3CFC:/
+113.0 "Rake" sync / 1[56]:[^:]*:Forgiven Cruelty:3CFB:/ window 115,5
+121.2 "Lumen Infinitum" sync / 1[56]:[^:]*:Forgiven Cruelty:41B2:/
+138.3 "Typhoon Wing" sync / 1[56]:[^:]*:Forgiven Cruelty:3D00:/
+147.2 "Cyclone Wing" sync / 1[56]:[^:]*:Forgiven Cruelty:3CFC:/
+160.8 "Typhoon Wing" sync / 1[56]:[^:]*:Forgiven Cruelty:3D00:/
+171.6 "Lumen Infinitum" sync / 1[56]:[^:]*:Forgiven Cruelty:41B2:/
+188.2 "Typhoon Wing" sync / 1[56]:[^:]*:Forgiven Cruelty:3D01:/
+188.2 "Hurricane Wing" sync / 1[56]:[^:]*:Forgiven Cruelty:3D03:/
+197.0 "Cyclone Wing" sync / 1[56]:[^:]*:Forgiven Cruelty:3CFC:/
 
-205.3 "Rake" sync / 1[56]:Forgiven Cruelty:3CFB:/
-214.4 "Lumen Infinitum" sync / 1[56]:Forgiven Cruelty:41B2:/
-231.0 "Typhoon Wing" sync / 1[56]:Forgiven Cruelty:3D0[12]:/
-231.0 "Hurricane Wing" sync / 1[56]:Forgiven Cruelty:3D03:/
-239.8 "Cyclone Wing" sync / 1[56]:Forgiven Cruelty:3CFC:/
-248.2 "Rake" sync / 1[56]:Forgiven Cruelty:3CFB:/
-257.5 "Lumen Infinitum" sync / 1[56]:Forgiven Cruelty:41B2:/
-274.2 "Typhoon Wing" sync / 1[56]:Forgiven Cruelty:3D0[12]:/
-274.2 "Hurricane Wing" sync / 1[56]:Forgiven Cruelty:3D03:/
-283.0 "Cyclone Wing" sync / 1[56]:Forgiven Cruelty:3CFC:/
+205.3 "Rake" sync / 1[56]:[^:]*:Forgiven Cruelty:3CFB:/
+214.4 "Lumen Infinitum" sync / 1[56]:[^:]*:Forgiven Cruelty:41B2:/
+231.0 "Typhoon Wing" sync / 1[56]:[^:]*:Forgiven Cruelty:3D0[12]:/
+231.0 "Hurricane Wing" sync / 1[56]:[^:]*:Forgiven Cruelty:3D03:/
+239.8 "Cyclone Wing" sync / 1[56]:[^:]*:Forgiven Cruelty:3CFC:/
+248.2 "Rake" sync / 1[56]:[^:]*:Forgiven Cruelty:3CFB:/
+257.5 "Lumen Infinitum" sync / 1[56]:[^:]*:Forgiven Cruelty:41B2:/
+274.2 "Typhoon Wing" sync / 1[56]:[^:]*:Forgiven Cruelty:3D0[12]:/
+274.2 "Hurricane Wing" sync / 1[56]:[^:]*:Forgiven Cruelty:3D03:/
+283.0 "Cyclone Wing" sync / 1[56]:[^:]*:Forgiven Cruelty:3CFC:/
 
-291.3 "Rake" sync / 1[56]:Forgiven Cruelty:3CFB:/ window 20,20 jump 205.3
+291.3 "Rake" sync / 1[56]:[^:]*:Forgiven Cruelty:3CFB:/ window 20,20 jump 205.3
 300.4 "Lumen Infinitum"
 317.0 "Typhoon Wing"
 317.0 "Hurricane Wing"
@@ -48,29 +48,29 @@ hideall "Rite Of The Sacrament"
 ### Forgiven Whimsy
 # -p 3D0B:514.5 -ii 3D0C 3D07 3D0A
 500.0 "--sync--" sync / 00:0839::The White Gate will be sealed off/ window 500,0
-514.5 "Sacrament Of Penance" sync / 1[56]:Forgiven Whimsy:3D0B:/ window 515,5
-518.3 "Reformation" sync / 1[56]:Forgiven Whimsy:3D04:/
-530.4 "Exegesis" sync / 1[56]:Forgiven Whimsy:425C:/
-534.1 "Reformation" sync / 1[56]:Forgiven Whimsy:3D04:/
-546.2 "Exegesis" sync / 1[56]:Forgiven Whimsy:425D:/
-557.0 "Catechism" sync / 1[56]:Forgiven Whimsy:3D09:/
-563.7 "Judgment Day" sync / 1[56]:Forgiven Whimsy:3D0F:/
-575.3 "Judged" sync / 1[56]:Forgiven Whimsy:3D11:/
-580.3 "Catechism" sync / 1[56]:Forgiven Whimsy:3D09:/
-580.3 "Judged" sync / 1[56]:Forgiven Whimsy:3D11:/
-584.0 "Reformation" sync / 1[56]:Forgiven Whimsy:3D04:/
+514.5 "Sacrament Of Penance" sync / 1[56]:[^:]*:Forgiven Whimsy:3D0B:/ window 515,5
+518.3 "Reformation" sync / 1[56]:[^:]*:Forgiven Whimsy:3D04:/
+530.4 "Exegesis" sync / 1[56]:[^:]*:Forgiven Whimsy:425C:/
+534.1 "Reformation" sync / 1[56]:[^:]*:Forgiven Whimsy:3D04:/
+546.2 "Exegesis" sync / 1[56]:[^:]*:Forgiven Whimsy:425D:/
+557.0 "Catechism" sync / 1[56]:[^:]*:Forgiven Whimsy:3D09:/
+563.7 "Judgment Day" sync / 1[56]:[^:]*:Forgiven Whimsy:3D0F:/
+575.3 "Judged" sync / 1[56]:[^:]*:Forgiven Whimsy:3D11:/
+580.3 "Catechism" sync / 1[56]:[^:]*:Forgiven Whimsy:3D09:/
+580.3 "Judged" sync / 1[56]:[^:]*:Forgiven Whimsy:3D11:/
+584.0 "Reformation" sync / 1[56]:[^:]*:Forgiven Whimsy:3D04:/
 
-591.3 "Rite Of The Sacrament" sync / 1[56]:Forgiven Whimsy:3D0D:/
-603.6 "Exegesis" sync / 1[56]:Forgiven Whimsy:425B:/
-604.1 "Perfect Contrition" sync / 1[56]:Brightsphere:3D0E:/
-607.2 "Reformation" sync / 1[56]:Forgiven Whimsy:3D04:/
-614.4 "Rite Of The Sacrament" sync / 1[56]:Forgiven Whimsy:3D0D:/
-626.8 "Exegesis" sync / 1[56]:Forgiven Whimsy:3D06:/
-627.2 "Perfect Contrition" sync / 1[56]:Brightsphere:3D0E:/
-636.9 "Sacrament Of Penance" sync / 1[56]:Forgiven Whimsy:3D0B:/
-640.6 "Reformation" sync / 1[56]:Forgiven Whimsy:3D04:/
+591.3 "Rite Of The Sacrament" sync / 1[56]:[^:]*:Forgiven Whimsy:3D0D:/
+603.6 "Exegesis" sync / 1[56]:[^:]*:Forgiven Whimsy:425B:/
+604.1 "Perfect Contrition" sync / 1[56]:[^:]*:Brightsphere:3D0E:/
+607.2 "Reformation" sync / 1[56]:[^:]*:Forgiven Whimsy:3D04:/
+614.4 "Rite Of The Sacrament" sync / 1[56]:[^:]*:Forgiven Whimsy:3D0D:/
+626.8 "Exegesis" sync / 1[56]:[^:]*:Forgiven Whimsy:3D06:/
+627.2 "Perfect Contrition" sync / 1[56]:[^:]*:Brightsphere:3D0E:/
+636.9 "Sacrament Of Penance" sync / 1[56]:[^:]*:Forgiven Whimsy:3D0B:/
+640.6 "Reformation" sync / 1[56]:[^:]*:Forgiven Whimsy:3D04:/
 
-647.7 "Rite Of The Sacrament" sync / 1[56]:Forgiven Whimsy:3D0D:/ window 20,20 jump 591.3
+647.7 "Rite Of The Sacrament" sync / 1[56]:[^:]*:Forgiven Whimsy:3D0D:/ window 20,20 jump 591.3
 660.0 "Exegesis"
 660.5 "Perfect Contrition"
 663.6 "Reformation"
@@ -84,30 +84,30 @@ hideall "Rite Of The Sacrament"
 ### Forgiven Obscenity
 # -ii 3D15 4669 3D19 3D19 3D21 3D13 41CE 3D1B 3D20 -p 3D14:1014
 1000.0 "--sync--" sync / 00:0839::The Winding Flare will be sealed off/ window 1000,0
-1014.0 "Orison Fortissimo" sync / 1[56]:Forgiven Obscenity:3D14:/ window 1014,5
-1023.2 "Divine Diminuendo" sync / 1[56]:Forgiven Obscenity:3D16:/
-1032.4 "--sync--" sync / 1[56]:Forgiven Obscenity:3D17:/
-1040.6 "Divine Diminuendo" sync / 1[56]:Forgiven Obscenity:3D18:/
-1051.0 "Conviction Marcato" sync / 1[56]:Forgiven Obscenity:3D1A:/
-1062.2 "Penance Pianissimo" sync / 1[56]:Forgiven Obscenity:3D1C:/
-1070.4 "Feather Marionette" sync / 1[56]:Forgiven Obscenity:3D1D:/
-1083.3 "Divine Diminuendo" sync / 1[56]:Forgiven Obscenity:3D18:/
-1093.5 "Conviction Marcato" sync / 1[56]:Forgiven Obscenity:3D1A:/
-1107.7 "Orison Fortissimo" sync / 1[56]:Forgiven Obscenity:3D14:/
+1014.0 "Orison Fortissimo" sync / 1[56]:[^:]*:Forgiven Obscenity:3D14:/ window 1014,5
+1023.2 "Divine Diminuendo" sync / 1[56]:[^:]*:Forgiven Obscenity:3D16:/
+1032.4 "--sync--" sync / 1[56]:[^:]*:Forgiven Obscenity:3D17:/
+1040.6 "Divine Diminuendo" sync / 1[56]:[^:]*:Forgiven Obscenity:3D18:/
+1051.0 "Conviction Marcato" sync / 1[56]:[^:]*:Forgiven Obscenity:3D1A:/
+1062.2 "Penance Pianissimo" sync / 1[56]:[^:]*:Forgiven Obscenity:3D1C:/
+1070.4 "Feather Marionette" sync / 1[56]:[^:]*:Forgiven Obscenity:3D1D:/
+1083.3 "Divine Diminuendo" sync / 1[56]:[^:]*:Forgiven Obscenity:3D18:/
+1093.5 "Conviction Marcato" sync / 1[56]:[^:]*:Forgiven Obscenity:3D1A:/
+1107.7 "Orison Fortissimo" sync / 1[56]:[^:]*:Forgiven Obscenity:3D14:/
 
-1124.5 "Solitaire Ring" sync / 1[56]:Forgiven Obscenity:42AA:/
-1129.5 "Ringsmith" sync / 1[56]:Forgiven Obscenity:3D24:/
-1135.5 "Gold Chaser" sync / 1[56]:Forgiven Obscenity:3D25:/
-1147.5 "Sacrament Sforzando" sync / 1[56]:Forgiven Obscenity:3D12:/
-1158.6 "Orison Fortissimo" sync / 1[56]:Forgiven Obscenity:3D14:/
-1169.8 "Divine Diminuendo" sync / 1[56]:Forgiven Obscenity:3D18:/
-1189.2 "Penance Pianissimo" sync / 1[56]:Forgiven Obscenity:3D1C:/
-1197.4 "Feather Marionette" sync / 1[56]:Forgiven Obscenity:3D1D:/
-1210.5 "Divine Diminuendo" sync / 1[56]:Forgiven Obscenity:3D18:/
-1220.6 "Conviction Marcato" sync / 1[56]:Forgiven Obscenity:3D1A:/
-1234.9 "Sacrament Sforzando" sync / 1[56]:Forgiven Obscenity:3D12:/
+1124.5 "Solitaire Ring" sync / 1[56]:[^:]*:Forgiven Obscenity:42AA:/
+1129.5 "Ringsmith" sync / 1[56]:[^:]*:Forgiven Obscenity:3D24:/
+1135.5 "Gold Chaser" sync / 1[56]:[^:]*:Forgiven Obscenity:3D25:/
+1147.5 "Sacrament Sforzando" sync / 1[56]:[^:]*:Forgiven Obscenity:3D12:/
+1158.6 "Orison Fortissimo" sync / 1[56]:[^:]*:Forgiven Obscenity:3D14:/
+1169.8 "Divine Diminuendo" sync / 1[56]:[^:]*:Forgiven Obscenity:3D18:/
+1189.2 "Penance Pianissimo" sync / 1[56]:[^:]*:Forgiven Obscenity:3D1C:/
+1197.4 "Feather Marionette" sync / 1[56]:[^:]*:Forgiven Obscenity:3D1D:/
+1210.5 "Divine Diminuendo" sync / 1[56]:[^:]*:Forgiven Obscenity:3D18:/
+1220.6 "Conviction Marcato" sync / 1[56]:[^:]*:Forgiven Obscenity:3D1A:/
+1234.9 "Sacrament Sforzando" sync / 1[56]:[^:]*:Forgiven Obscenity:3D12:/
 
-1251.6 "Solitaire Ring" sync / 1[56]:Forgiven Obscenity:42AA:/ window 100,100 jump 1124.5
+1251.6 "Solitaire Ring" sync / 1[56]:[^:]*:Forgiven Obscenity:42AA:/ window 100,100 jump 1124.5
 1256.6 "Ringsmith"
 1262.6 "Gold Chaser"
 1274.6 "Sacrament Sforzando"

--- a/ui/raidboss/data/05-shb/dungeon/paglthan.txt
+++ b/ui/raidboss/data/05-shb/dungeon/paglthan.txt
@@ -12,31 +12,31 @@ hideall "--sync--"
 # -ii 5C52 5C53
 
 0 "Start" sync / 00:0839::The Gathering Ring will be sealed off/ window 0,1
-12.6 "Critical Rip" sync / 1[56]:Amhuluk:5C4E:/ window 12.6,10
-18.8 "--sync--" sync / 1[56]:Amhuluk:5C51:/
-30.2 "Lightning Bolt" sync / 1[56]:Amhuluk:5C4B:/
-31.0 "--sync--" sync / 1[56]:Amhuluk:5C4C:/
-36.8 "Electric Burst" sync / 1[56]:Amhuluk:5C4D:/
-48.0 "Thundercall" sync / 1[56]:Amhuluk:5C50:/ window 48,10
+12.6 "Critical Rip" sync / 1[56]:[^:]*:Amhuluk:5C4E:/ window 12.6,10
+18.8 "--sync--" sync / 1[56]:[^:]*:Amhuluk:5C51:/
+30.2 "Lightning Bolt" sync / 1[56]:[^:]*:Amhuluk:5C4B:/
+31.0 "--sync--" sync / 1[56]:[^:]*:Amhuluk:5C4C:/
+36.8 "Electric Burst" sync / 1[56]:[^:]*:Amhuluk:5C4D:/
+48.0 "Thundercall" sync / 1[56]:[^:]*:Amhuluk:5C50:/ window 48,10
 48.5 "--Levin orbs--"
-61.3 "Wide Blaster" sync / 1[56]:Amhuluk:60C5:/ window 61.3,10
-63.9 "Spike Flail" sync / 1[56]:Amhuluk:5C4F:/
-66.1 "--sync--" sync / 1[56]:Amhuluk:5C51:/
-77.6 "Lightning Bolt" sync / 1[56]:Amhuluk:5C4B:/
-78.4 "--sync--" sync / 1[56]:Amhuluk:5C4C:/
-84.2 "Electric Burst" sync / 1[56]:Amhuluk:5C4D:/
+61.3 "Wide Blaster" sync / 1[56]:[^:]*:Amhuluk:60C5:/ window 61.3,10
+63.9 "Spike Flail" sync / 1[56]:[^:]*:Amhuluk:5C4F:/
+66.1 "--sync--" sync / 1[56]:[^:]*:Amhuluk:5C51:/
+77.6 "Lightning Bolt" sync / 1[56]:[^:]*:Amhuluk:5C4B:/
+78.4 "--sync--" sync / 1[56]:[^:]*:Amhuluk:5C4C:/
+84.2 "Electric Burst" sync / 1[56]:[^:]*:Amhuluk:5C4D:/
 
-95.4 "Critical Rip" sync / 1[56]:Amhuluk:5C4E:/ window 45,30
-107.5 "Thundercall" sync / 1[56]:Amhuluk:5C50:/
+95.4 "Critical Rip" sync / 1[56]:[^:]*:Amhuluk:5C4E:/ window 45,30
+107.5 "Thundercall" sync / 1[56]:[^:]*:Amhuluk:5C50:/
 108.0 "--Levin orbs--"
-109.6 "--sync--" sync / 1[56]:Amhuluk:5C51:/
-121.0 "Lightning Bolt" sync / 1[56]:Amhuluk:5C4B:/
-121.8 "--sync--" sync / 1[56]:Amhuluk:5C4C:/
-127.6 "Electric Burst" sync / 1[56]:Amhuluk:5C4D:/
-137.7 "Wide Blaster" sync / 1[56]:Amhuluk:60C5:/ window 30,30
-140.3 "Spike Flail" sync / 1[56]:Amhuluk:5C4F:/
+109.6 "--sync--" sync / 1[56]:[^:]*:Amhuluk:5C51:/
+121.0 "Lightning Bolt" sync / 1[56]:[^:]*:Amhuluk:5C4B:/
+121.8 "--sync--" sync / 1[56]:[^:]*:Amhuluk:5C4C:/
+127.6 "Electric Burst" sync / 1[56]:[^:]*:Amhuluk:5C4D:/
+137.7 "Wide Blaster" sync / 1[56]:[^:]*:Amhuluk:60C5:/ window 30,30
+140.3 "Spike Flail" sync / 1[56]:[^:]*:Amhuluk:5C4F:/
 
-160.4 "Critical Rip" sync / 1[56]:Amhuluk:5C4E:/ jump 95.4
+160.4 "Critical Rip" sync / 1[56]:[^:]*:Amhuluk:5C4E:/ jump 95.4
 172.5 "Thundercall"
 173.0 "--Levin orbs--"
 186.0 "Lightning Bolt"
@@ -52,35 +52,35 @@ hideall "--sync--"
 # -ii 5B56 5B50
 
 2000.0 "Start" sync / 00:0839::Sunseat will be sealed off/ window 2000,5
-2010.0 "Twisted Scream" sync / 1[56]:Lunar Bahamut:5B47:/
-2015.0 "Upburst x4" # sync / 1[56]:Lunar Nail:605B:/
-2021.6 "Big Burst x4" # sync / 1[56]:Lunar Nail:5B48:/
-2029.2 "Perigean Breath" sync / 1[56]:Lunar Bahamut:5B59:/ window 30,10
-2042.4 "Akh Morn x4" sync / 1[56]:Lunar Bahamut:5B55:/ duration 5
-2062.8 "Megaflare x3" sync / 1[56]:Lunar Bahamut:5B4C:/
-2064.8 "--sync--" sync / 1[56]:Lunar Bahamut:5B4D:/
-2068.9 "--sync--" sync / 1[56]:Lunar Bahamut:5B4E:/
-2071.0 "Twisted Scream" sync / 1[56]:Lunar Bahamut:5B47:/
-2076.0 "Upburst x4" # sync / 1[56]:Lunar Nail:605B:/
-2082.6 "Big Burst x4" # sync / 1[56]:Lunar Nail:5B48:/
-2083.9 "Megaflare Dive" sync / 1[56]:Lunar Bahamut:5B52:/ window 30,30
-2095.7 "Kan Rhai" sync / 1[56]:Lunar Bahamut:5B4F:/
-2097.3 "--sync--" sync / 1[56]:Lunar Bahamut:5B51:/
-2107.4 "Lunar Flare (circles)" sync / 1[56]:Lunar Bahamut:5B49:/
-2119.5 "Lunar Flare (explosions)" sync / 1[56]:Lunar Bahamut:5B4A:/
+2010.0 "Twisted Scream" sync / 1[56]:[^:]*:Lunar Bahamut:5B47:/
+2015.0 "Upburst x4" # sync / 1[56]:[^:]*:Lunar Nail:605B:/
+2021.6 "Big Burst x4" # sync / 1[56]:[^:]*:Lunar Nail:5B48:/
+2029.2 "Perigean Breath" sync / 1[56]:[^:]*:Lunar Bahamut:5B59:/ window 30,10
+2042.4 "Akh Morn x4" sync / 1[56]:[^:]*:Lunar Bahamut:5B55:/ duration 5
+2062.8 "Megaflare x3" sync / 1[56]:[^:]*:Lunar Bahamut:5B4C:/
+2064.8 "--sync--" sync / 1[56]:[^:]*:Lunar Bahamut:5B4D:/
+2068.9 "--sync--" sync / 1[56]:[^:]*:Lunar Bahamut:5B4E:/
+2071.0 "Twisted Scream" sync / 1[56]:[^:]*:Lunar Bahamut:5B47:/
+2076.0 "Upburst x4" # sync / 1[56]:[^:]*:Lunar Nail:605B:/
+2082.6 "Big Burst x4" # sync / 1[56]:[^:]*:Lunar Nail:5B48:/
+2083.9 "Megaflare Dive" sync / 1[56]:[^:]*:Lunar Bahamut:5B52:/ window 30,30
+2095.7 "Kan Rhai" sync / 1[56]:[^:]*:Lunar Bahamut:5B4F:/
+2097.3 "--sync--" sync / 1[56]:[^:]*:Lunar Bahamut:5B51:/
+2107.4 "Lunar Flare (circles)" sync / 1[56]:[^:]*:Lunar Bahamut:5B49:/
+2119.5 "Lunar Flare (explosions)" sync / 1[56]:[^:]*:Lunar Bahamut:5B4A:/
 
-2131.6 "Gigaflare" sync / 1[56]:Lunar Bahamut:5B57:/ window 131.6,10
-2150.7 "Akh Morn x4" sync / 1[56]:Lunar Bahamut:5B55:/ duration 5
-2168.1 "Twisted Scream" sync / 1[56]:Lunar Bahamut:5B47:/
-2173.1 "Upburst x4" # sync / 1[56]:Lunar Nail:605B:/
-2179.7 "Big Burst x4" # sync / 1[56]:Lunar Nail:5B48:/
-2191.3 "Lunar Flare (circles)" sync / 1[56]:Lunar Bahamut:5B49:/ window 30,30
-2203.4 "Lunar Flare (explosions)" sync / 1[56]:Lunar Bahamut:(5B4A|5B4B):/
-2215.5 "Kan Rhai" sync / 1[56]:Lunar Bahamut:5B4F:/
-2217.1 "--sync--" sync / 1[56]:Lunar Bahamut:5B51:/
-2223.5 "Flatten" sync / 1[56]:Lunar Bahamut:5B58:/
+2131.6 "Gigaflare" sync / 1[56]:[^:]*:Lunar Bahamut:5B57:/ window 131.6,10
+2150.7 "Akh Morn x4" sync / 1[56]:[^:]*:Lunar Bahamut:5B55:/ duration 5
+2168.1 "Twisted Scream" sync / 1[56]:[^:]*:Lunar Bahamut:5B47:/
+2173.1 "Upburst x4" # sync / 1[56]:[^:]*:Lunar Nail:605B:/
+2179.7 "Big Burst x4" # sync / 1[56]:[^:]*:Lunar Nail:5B48:/
+2191.3 "Lunar Flare (circles)" sync / 1[56]:[^:]*:Lunar Bahamut:5B49:/ window 30,30
+2203.4 "Lunar Flare (explosions)" sync / 1[56]:[^:]*:Lunar Bahamut:(5B4A|5B4B):/
+2215.5 "Kan Rhai" sync / 1[56]:[^:]*:Lunar Bahamut:5B4F:/
+2217.1 "--sync--" sync / 1[56]:[^:]*:Lunar Bahamut:5B51:/
+2223.5 "Flatten" sync / 1[56]:[^:]*:Lunar Bahamut:5B58:/
 
-2241.6 "Gigaflare" sync / 1[56]:Lunar Bahamut:5B57:/ jump 2131.6
+2241.6 "Gigaflare" sync / 1[56]:[^:]*:Lunar Bahamut:5B57:/ jump 2131.6
 2260.7 "Akh Morn x4"
 2278.1 "Twisted Scream"
 2283.1 "Upburst x4"

--- a/ui/raidboss/data/05-shb/dungeon/qitana_ravel.txt
+++ b/ui/raidboss/data/05-shb/dungeon/qitana_ravel.txt
@@ -10,31 +10,31 @@ hideall "--sync--"
 # -p 3C89:113.7
 100.0 "--sync--" sync / 00:0839::The Divine Threshold will be sealed off/ window 100,0
 
-113.7 "Stonefist" sync / 1[56]:Lozatl:3C89:/ window 114,5
-121.0 "Sun Toss" sync / 1[56]:Lozatl:3C8A:/
-127.2 "Lozatl's Scorn" sync / 1[56]:Lozatl:3C8B:/
-137.5 "Sun Toss" sync / 1[56]:Lozatl:3C8A:/
-137.5 "Ronkan Light" sync / 1[56]:Lozatl:(3D6D|3C8C):/
-145.1 "Heat Up" sync / 1[56]:Lozatl:3C8[DE]:/
-151.5 "Lozatl's Fury" sync / 1[56]:Lozatl:(3C8F|3C90):/
+113.7 "Stonefist" sync / 1[56]:[^:]*:Lozatl:3C89:/ window 114,5
+121.0 "Sun Toss" sync / 1[56]:[^:]*:Lozatl:3C8A:/
+127.2 "Lozatl's Scorn" sync / 1[56]:[^:]*:Lozatl:3C8B:/
+137.5 "Sun Toss" sync / 1[56]:[^:]*:Lozatl:3C8A:/
+137.5 "Ronkan Light" sync / 1[56]:[^:]*:Lozatl:(3D6D|3C8C):/
+145.1 "Heat Up" sync / 1[56]:[^:]*:Lozatl:3C8[DE]:/
+151.5 "Lozatl's Fury" sync / 1[56]:[^:]*:Lozatl:(3C8F|3C90):/
 
-161.2 "Stonefist" sync / 1[56]:Lozatl:3C89:/
-168.1 "Heat Up" sync / 1[56]:Lozatl:3C8[DE]:/
-173.2 "Lozatl's Scorn" sync / 1[56]:Lozatl:3C8B:/
-182.7 "Lozatl's Fury" sync / 1[56]:Lozatl:(3C8F|3C90):/
-183.4 "Ronkan Light" sync / 1[56]:Lozatl:(3D6D|3C8C):/
-191.4 "Sun Toss" #sync / 1[56]:Lozatl:3C8A:/
-196.7 "Sun Toss" #sync / 1[56]:Lozatl:3C8A:/
+161.2 "Stonefist" sync / 1[56]:[^:]*:Lozatl:3C89:/
+168.1 "Heat Up" sync / 1[56]:[^:]*:Lozatl:3C8[DE]:/
+173.2 "Lozatl's Scorn" sync / 1[56]:[^:]*:Lozatl:3C8B:/
+182.7 "Lozatl's Fury" sync / 1[56]:[^:]*:Lozatl:(3C8F|3C90):/
+183.4 "Ronkan Light" sync / 1[56]:[^:]*:Lozatl:(3D6D|3C8C):/
+191.4 "Sun Toss" #sync / 1[56]:[^:]*:Lozatl:3C8A:/
+196.7 "Sun Toss" #sync / 1[56]:[^:]*:Lozatl:3C8A:/
 
-207.9 "Stonefist" sync / 1[56]:Lozatl:3C89:/
-222.9 "Heat Up" sync / 1[56]:Lozatl:3C8[DE]:/
-228.1 "Lozatl's Scorn" sync / 1[56]:Lozatl:3C8B:/
-237.4 "Lozatl's Fury" sync / 1[56]:Lozatl:(3C8F|3C90):/
-238.5 "Ronkan Light" sync / 1[56]:Lozatl:(3D6D|3C8C):/
-246.2 "Sun Toss" #sync / 1[56]:Lozatl:3C8A:/
-251.5 "Sun Toss" #sync / 1[56]:Lozatl:3C8A:/
+207.9 "Stonefist" sync / 1[56]:[^:]*:Lozatl:3C89:/
+222.9 "Heat Up" sync / 1[56]:[^:]*:Lozatl:3C8[DE]:/
+228.1 "Lozatl's Scorn" sync / 1[56]:[^:]*:Lozatl:3C8B:/
+237.4 "Lozatl's Fury" sync / 1[56]:[^:]*:Lozatl:(3C8F|3C90):/
+238.5 "Ronkan Light" sync / 1[56]:[^:]*:Lozatl:(3D6D|3C8C):/
+246.2 "Sun Toss" #sync / 1[56]:[^:]*:Lozatl:3C8A:/
+251.5 "Sun Toss" #sync / 1[56]:[^:]*:Lozatl:3C8A:/
 
-262.9 "Stonefist" sync / 1[56]:Lozatl:3C89:/ window 50,50 jump 207.9
+262.9 "Stonefist" sync / 1[56]:[^:]*:Lozatl:3C89:/ window 50,50 jump 207.9
 277.9 "Heat Up"
 283.1 "Lozatl's Scorn"
 292.4 "Lozatl's Fury"
@@ -47,23 +47,23 @@ hideall "--sync--"
 # -ii 3C94 3C96 3C97 3C95 -p 3C91:514.5
 500.0 "--sync--" sync / 00:0839::Shadowed Hollow will be sealed off/ window 500,0
 
-514.5 "Ripper Fang" sync / 1[56]:Batsquatch:3C91:/ window 515,5
-525.7 "Soundwave" sync / 1[56]:Batsquatch:3C92:/
-542.2 "Subsonics" sync / 1[56]:Batsquatch:3C93:/ duration 6.1
-559.8 "Soundwave" sync / 1[56]:Batsquatch:3C92:/
-563.6 "Towerfall" sync / 1[56]:Batsquatch:3C98:/
+514.5 "Ripper Fang" sync / 1[56]:[^:]*:Batsquatch:3C91:/ window 515,5
+525.7 "Soundwave" sync / 1[56]:[^:]*:Batsquatch:3C92:/
+542.2 "Subsonics" sync / 1[56]:[^:]*:Batsquatch:3C93:/ duration 6.1
+559.8 "Soundwave" sync / 1[56]:[^:]*:Batsquatch:3C92:/
+563.6 "Towerfall" sync / 1[56]:[^:]*:Batsquatch:3C98:/
 
-571.4 "Ripper Fang" sync / 1[56]:Batsquatch:3C91:/
-588.0 "Subsonics" sync / 1[56]:Batsquatch:3C93:/ duration 6.1
-605.6 "Soundwave" sync / 1[56]:Batsquatch:3C92:/
-609.4 "Towerfall" sync / 1[56]:Batsquatch:3C98:/
+571.4 "Ripper Fang" sync / 1[56]:[^:]*:Batsquatch:3C91:/
+588.0 "Subsonics" sync / 1[56]:[^:]*:Batsquatch:3C93:/ duration 6.1
+605.6 "Soundwave" sync / 1[56]:[^:]*:Batsquatch:3C92:/
+609.4 "Towerfall" sync / 1[56]:[^:]*:Batsquatch:3C98:/
 
-616.5 "Ripper Fang" sync / 1[56]:Batsquatch:3C91:/
-636.9 "Subsonics" sync / 1[56]:Batsquatch:3C93:/ duration 6.1
-654.5 "Soundwave" sync / 1[56]:Batsquatch:3C92:/
-658.3 "Towerfall" sync / 1[56]:Batsquatch:3C98:/
+616.5 "Ripper Fang" sync / 1[56]:[^:]*:Batsquatch:3C91:/
+636.9 "Subsonics" sync / 1[56]:[^:]*:Batsquatch:3C93:/ duration 6.1
+654.5 "Soundwave" sync / 1[56]:[^:]*:Batsquatch:3C92:/
+658.3 "Towerfall" sync / 1[56]:[^:]*:Batsquatch:3C98:/
 
-666.1 "Ripper Fang" sync / 1[56]:Batsquatch:3C91:/ window 20,20 jump 571.4
+666.1 "Ripper Fang" sync / 1[56]:[^:]*:Batsquatch:3C91:/ window 20,20 jump 571.4
 682.7 "Subsonics"
 700.3 "Soundwave"
 704.1 "Towerfall"
@@ -78,32 +78,32 @@ hideall "--sync--"
 #
 1000.0 "--sync--" sync / 00:0839::The Song of Ox'Gatorl will be sealed off/ window 1000,0
 
-1015.0 "Rend" sync / 1[56]:Eros:3C99:/ window 1015,5
-1026.2 "Hound Out Of Heaven" sync / 1[56]:Eros:3C9A:/
-1036.1 "Glossolalia" sync / 1[56]:Eros:3C9B:/
-1048.3 "Viper Poison" sync / 1[56]:Eros:3C9C:/
-1050.9 "Jump" sync / 1[56]:Eros:3C9F:/
-1057.6 "Inhale" sync / 1[56]:Eros:4310:/
-1063.2 "Heaving Breath" sync / 1[56]:Eros:3CA0:/
-1075.9 "Rend" sync / 1[56]:Eros:3C99:/
-1083.3 "Jump" sync / 1[56]:Eros:3C9F:/
-1092.0 "Confession Of Faith" sync / 1[56]:Eros:3CA[14]:/
-1107.8 "Hound Out Of Heaven" sync / 1[56]:Eros:3C9A:/
+1015.0 "Rend" sync / 1[56]:[^:]*:Eros:3C99:/ window 1015,5
+1026.2 "Hound Out Of Heaven" sync / 1[56]:[^:]*:Eros:3C9A:/
+1036.1 "Glossolalia" sync / 1[56]:[^:]*:Eros:3C9B:/
+1048.3 "Viper Poison" sync / 1[56]:[^:]*:Eros:3C9C:/
+1050.9 "Jump" sync / 1[56]:[^:]*:Eros:3C9F:/
+1057.6 "Inhale" sync / 1[56]:[^:]*:Eros:4310:/
+1063.2 "Heaving Breath" sync / 1[56]:[^:]*:Eros:3CA0:/
+1075.9 "Rend" sync / 1[56]:[^:]*:Eros:3C99:/
+1083.3 "Jump" sync / 1[56]:[^:]*:Eros:3C9F:/
+1092.0 "Confession Of Faith" sync / 1[56]:[^:]*:Eros:3CA[14]:/
+1107.8 "Hound Out Of Heaven" sync / 1[56]:[^:]*:Eros:3C9A:/
 
-1122.6 "Viper Poison" sync / 1[56]:Eros:3C9C:/
-1125.5 "Jump" sync / 1[56]:Eros:3C9F:/
-1132.1 "Inhale" sync / 1[56]:Eros:4310:/
-1137.7 "Heaving Breath" sync / 1[56]:Eros:3CA0:/
-1150.5 "Rend" sync / 1[56]:Eros:3C99:/
-1162.8 "Hound Out Of Heaven" sync / 1[56]:Eros:3C9A:/
-1170.7 "Jump" sync / 1[56]:Eros:3C9F:/
-1179.3 "Confession Of Faith" sync / 1[56]:Eros:3CA[14]:/
-1193.1 "Glossolalia" sync / 1[56]:Eros:3C9B:/
-1202.3 "Glossolalia" sync / 1[56]:Eros:3C9B:/
-1213.5 "Hound Out Of Heaven" sync / 1[56]:Eros:3C9A:/
-1224.4 "Rend" sync / 1[56]:Eros:3C99:/
+1122.6 "Viper Poison" sync / 1[56]:[^:]*:Eros:3C9C:/
+1125.5 "Jump" sync / 1[56]:[^:]*:Eros:3C9F:/
+1132.1 "Inhale" sync / 1[56]:[^:]*:Eros:4310:/
+1137.7 "Heaving Breath" sync / 1[56]:[^:]*:Eros:3CA0:/
+1150.5 "Rend" sync / 1[56]:[^:]*:Eros:3C99:/
+1162.8 "Hound Out Of Heaven" sync / 1[56]:[^:]*:Eros:3C9A:/
+1170.7 "Jump" sync / 1[56]:[^:]*:Eros:3C9F:/
+1179.3 "Confession Of Faith" sync / 1[56]:[^:]*:Eros:3CA[14]:/
+1193.1 "Glossolalia" sync / 1[56]:[^:]*:Eros:3C9B:/
+1202.3 "Glossolalia" sync / 1[56]:[^:]*:Eros:3C9B:/
+1213.5 "Hound Out Of Heaven" sync / 1[56]:[^:]*:Eros:3C9A:/
+1224.4 "Rend" sync / 1[56]:[^:]*:Eros:3C99:/
 
-1237.6 "Viper Poison" sync / 1[56]:Eros:3C9C:/ window 100,100 jump 1122.6
+1237.6 "Viper Poison" sync / 1[56]:[^:]*:Eros:3C9C:/ window 100,100 jump 1122.6
 1240.5 "Jump"
 1247.1 "Inhale"
 1252.7 "Heaving Breath"

--- a/ui/raidboss/data/05-shb/dungeon/the_grand_cosmos.txt
+++ b/ui/raidboss/data/05-shb/dungeon/the_grand_cosmos.txt
@@ -8,26 +8,26 @@ hideall "--sync--"
 ### Seeker of Solitude
 # -ii 4768 49A4 476C 476F 4771 4770 -p 4769:111.7
 100.0 "--sync--" sync / 00:0839::The Martial Court will be sealed off/ window 100,0
-111.7 "Shadowbolt" sync / 1[56]:Seeker of Solitude:4769:/ window 112,5
-119.4 "Immortal Anathema" sync / 1[56]:Seeker of Solitude:49A3:/
+111.7 "Shadowbolt" sync / 1[56]:[^:]*:Seeker of Solitude:4769:/ window 112,5
+119.4 "Immortal Anathema" sync / 1[56]:[^:]*:Seeker of Solitude:49A3:/
 
-126.8 "Tribulation" sync / 1[56]:Seeker of Solitude:476B:/
-135.5 "Dark Shock" sync / 1[56]:Seeker of Solitude:476E:/
-155.4 "Dark Pulse" sync / 1[56]:Seeker of Solitude:476A:/
-162.1 "Dark Well" sync / 1[56]:Seeker of Solitude:476D:/
-172.9 "Shadowbolt" sync / 1[56]:Seeker of Solitude:4769:/
-183.6 "Immortal Anathema" sync / 1[56]:Seeker of Solitude:49A3:/
+126.8 "Tribulation" sync / 1[56]:[^:]*:Seeker of Solitude:476B:/
+135.5 "Dark Shock" sync / 1[56]:[^:]*:Seeker of Solitude:476E:/
+155.4 "Dark Pulse" sync / 1[56]:[^:]*:Seeker of Solitude:476A:/
+162.1 "Dark Well" sync / 1[56]:[^:]*:Seeker of Solitude:476D:/
+172.9 "Shadowbolt" sync / 1[56]:[^:]*:Seeker of Solitude:4769:/
+183.6 "Immortal Anathema" sync / 1[56]:[^:]*:Seeker of Solitude:49A3:/
 
-190.5 "Tribulation" sync / 1[56]:Seeker of Solitude:476B:/
-199.2 "Dark Well" sync / 1[56]:Seeker of Solitude:476D:/
-214.0 "Dark Shock" sync / 1[56]:Seeker of Solitude:476E:/
-224.6 "Shadowbolt" sync / 1[56]:Seeker of Solitude:4769:/
-236.4 "Dark Pulse" sync / 1[56]:Seeker of Solitude:476A:/
-243.1 "Dark Well" sync / 1[56]:Seeker of Solitude:476D:/
-252.9 "Immortal Anathema" sync / 1[56]:Seeker of Solitude:49A3:/
+190.5 "Tribulation" sync / 1[56]:[^:]*:Seeker of Solitude:476B:/
+199.2 "Dark Well" sync / 1[56]:[^:]*:Seeker of Solitude:476D:/
+214.0 "Dark Shock" sync / 1[56]:[^:]*:Seeker of Solitude:476E:/
+224.6 "Shadowbolt" sync / 1[56]:[^:]*:Seeker of Solitude:4769:/
+236.4 "Dark Pulse" sync / 1[56]:[^:]*:Seeker of Solitude:476A:/
+243.1 "Dark Well" sync / 1[56]:[^:]*:Seeker of Solitude:476D:/
+252.9 "Immortal Anathema" sync / 1[56]:[^:]*:Seeker of Solitude:49A3:/
 
 # TODO: not 100% sure this is the loop
-262.7 "Tribulation" sync / 1[56]:Seeker of Solitude:476B:/ window 50,50 jump 190.5
+262.7 "Tribulation" sync / 1[56]:[^:]*:Seeker of Solitude:476B:/ window 50,50 jump 190.5
 271.4 "Dark Well"
 286.2 "Dark Shock"
 296.8 "Shadowbolt"
@@ -39,32 +39,32 @@ hideall "--sync--"
 ### Leannan Sith
 # -ii 4724 471F -p 471B:512
 500.0 "--sync--" sync / 00:0839::The Font of Quintessence will be sealed off/ window 500,0 
-512.0 "Storm Of Color" sync / 1[56]:Leannan Sith:471B:/
-522.3 "Ode To Lost Love" sync / 1[56]:Leannan Sith:471C:/
+512.0 "Storm Of Color" sync / 1[56]:[^:]*:Leannan Sith:471B:/
+522.3 "Ode To Lost Love" sync / 1[56]:[^:]*:Leannan Sith:471C:/
 
-529.9 "Direct Seeding" sync / 1[56]:Leannan Sith:471D:/
-546.4 "Gardener's Hymn" sync / 1[56]:Leannan Sith:471E:/
-552.9 "Storm Of Color" sync / 1[56]:Leannan Sith:471B:/
-562.1 "Ode To Lost Love" sync / 1[56]:Leannan Sith:471C:/
-572.3 "Ode To Far Winds" sync / 1[56]:Leannan Sith:4722:/
-577.4 "Far Wind" sync / 1[56]:Leannan Sith:4723:/
-583.4 "Ode To Fallen Petals" sync / 1[56]:Leannan Sith:4950:/
-594.5 "Ode To Lost Love" sync / 1[56]:Leannan Sith:471C:/
+529.9 "Direct Seeding" sync / 1[56]:[^:]*:Leannan Sith:471D:/
+546.4 "Gardener's Hymn" sync / 1[56]:[^:]*:Leannan Sith:471E:/
+552.9 "Storm Of Color" sync / 1[56]:[^:]*:Leannan Sith:471B:/
+562.1 "Ode To Lost Love" sync / 1[56]:[^:]*:Leannan Sith:471C:/
+572.3 "Ode To Far Winds" sync / 1[56]:[^:]*:Leannan Sith:4722:/
+577.4 "Far Wind" sync / 1[56]:[^:]*:Leannan Sith:4723:/
+583.4 "Ode To Fallen Petals" sync / 1[56]:[^:]*:Leannan Sith:4950:/
+594.5 "Ode To Lost Love" sync / 1[56]:[^:]*:Leannan Sith:471C:/
 
-601.2 "Direct Seeding" sync / 1[56]:Leannan Sith:471D:/
-616.7 "Ireful Wind" sync / 1[56]:Enslaved Love:4721:/
-617.6 "Gardener's Hymn" sync / 1[56]:Leannan Sith:471E:/
-623.1 "Ode To Far Winds" sync / 1[56]:Leannan Sith:4722:/
-628.2 "Far Wind" sync / 1[56]:Leannan Sith:4723:/
-634.1 "Ode To Fallen Petals" sync / 1[56]:Leannan Sith:4950:/
-646.5 "Storm Of Color" sync / 1[56]:Leannan Sith:471B:/
-653.7 "Ode To Lost Love" sync / 1[56]:Leannan Sith:471C:/
-668.8 "Ode To Far Winds" sync / 1[56]:Leannan Sith:4722:/
-673.9 "Far Wind" sync / 1[56]:Leannan Sith:4723:/
-679.9 "Ode To Fallen Petals" sync / 1[56]:Leannan Sith:4950:/
-691.1 "Ode To Lost Love" sync / 1[56]:Leannan Sith:471C:/
+601.2 "Direct Seeding" sync / 1[56]:[^:]*:Leannan Sith:471D:/
+616.7 "Ireful Wind" sync / 1[56]:[^:]*:Enslaved Love:4721:/
+617.6 "Gardener's Hymn" sync / 1[56]:[^:]*:Leannan Sith:471E:/
+623.1 "Ode To Far Winds" sync / 1[56]:[^:]*:Leannan Sith:4722:/
+628.2 "Far Wind" sync / 1[56]:[^:]*:Leannan Sith:4723:/
+634.1 "Ode To Fallen Petals" sync / 1[56]:[^:]*:Leannan Sith:4950:/
+646.5 "Storm Of Color" sync / 1[56]:[^:]*:Leannan Sith:471B:/
+653.7 "Ode To Lost Love" sync / 1[56]:[^:]*:Leannan Sith:471C:/
+668.8 "Ode To Far Winds" sync / 1[56]:[^:]*:Leannan Sith:4722:/
+673.9 "Far Wind" sync / 1[56]:[^:]*:Leannan Sith:4723:/
+679.9 "Ode To Fallen Petals" sync / 1[56]:[^:]*:Leannan Sith:4950:/
+691.1 "Ode To Lost Love" sync / 1[56]:[^:]*:Leannan Sith:471C:/
 
-697.7 "Direct Seeding" sync / 1[56]:Leannan Sith:471D:/ window 50,50 jump 601.2
+697.7 "Direct Seeding" sync / 1[56]:[^:]*:Leannan Sith:471D:/ window 50,50 jump 601.2
 713.2 "Ireful Wind"
 714.1 "Gardener's Hymn"
 719.6 "Ode To Far Winds"
@@ -81,51 +81,51 @@ hideall "--sync--"
 ### Lugus
 # -ii 475B 4766 475A 475E -p 475D:1026.8
 1000.0 "--sync--" sync / 00:0839::The Chamber of Celestial Song will be sealed off/ window 1000,0
-1015.3 "Scorching Left/Right" sync / 1[56]:Lugus:476[23]:/
-1026.8 "Black Flame" sync / 1[56]:Lugus:475D:/
-1030.3 "Otherworldly Heat" sync / 1[56]:Lugus:475C:/
-1037.8 "Captive Bolt" sync / 1[56]:Lugus:4764:/
-1048.2 "Mortal Flame" sync / 1[56]:Lugus:4759:/ window 30,0
-1077.1 "Fire's Domain" sync / 1[56]:Lugus:47(5F|60):/
-1080.2 "Fire's Ire" sync / 1[56]:Lugus:4761:/
-1081.7 "Fire's Domain" sync / 1[56]:Lugus:47(5F|60):/
-1084.7 "Fire's Ire" sync / 1[56]:Lugus:4761:/
-1086.2 "Fire's Domain" sync / 1[56]:Lugus:47(5F|60):/
-1089.2 "Fire's Ire" sync / 1[56]:Lugus:4761:/
-1090.7 "Fire's Domain" sync / 1[56]:Lugus:47(5F|60):/
-1093.7 "Fire's Ire" sync / 1[56]:Lugus:4761:/
-1106.4 "Scorching Left/Right" sync / 1[56]:Lugus:476[23]:/
+1015.3 "Scorching Left/Right" sync / 1[56]:[^:]*:Lugus:476[23]:/
+1026.8 "Black Flame" sync / 1[56]:[^:]*:Lugus:475D:/
+1030.3 "Otherworldly Heat" sync / 1[56]:[^:]*:Lugus:475C:/
+1037.8 "Captive Bolt" sync / 1[56]:[^:]*:Lugus:4764:/
+1048.2 "Mortal Flame" sync / 1[56]:[^:]*:Lugus:4759:/ window 30,0
+1077.1 "Fire's Domain" sync / 1[56]:[^:]*:Lugus:47(5F|60):/
+1080.2 "Fire's Ire" sync / 1[56]:[^:]*:Lugus:4761:/
+1081.7 "Fire's Domain" sync / 1[56]:[^:]*:Lugus:47(5F|60):/
+1084.7 "Fire's Ire" sync / 1[56]:[^:]*:Lugus:4761:/
+1086.2 "Fire's Domain" sync / 1[56]:[^:]*:Lugus:47(5F|60):/
+1089.2 "Fire's Ire" sync / 1[56]:[^:]*:Lugus:4761:/
+1090.7 "Fire's Domain" sync / 1[56]:[^:]*:Lugus:47(5F|60):/
+1093.7 "Fire's Ire" sync / 1[56]:[^:]*:Lugus:4761:/
+1106.4 "Scorching Left/Right" sync / 1[56]:[^:]*:Lugus:476[23]:/
 
-1122.9 "Culling Blade" sync / 1[56]:Lugus:4765:/ window 25,20
-1126.2 "Plummet" sync / 1[56]:Lugus:4767:/
-1133.3 "Black Flame" sync / 1[56]:Lugus:475D:/
-1136.7 "Otherworldly Heat" sync / 1[56]:Lugus:475C:/
-1142.4 "Mortal Flame" sync / 1[56]:Lugus:4759:/
-1169.1 "Scorching Left/Right" sync / 1[56]:Lugus:476[23]:/
-1181.8 "Fire's Domain" sync / 1[56]:Lugus:47(5F|60):/
-1184.9 "Fire's Ire" sync / 1[56]:Lugus:4761:/
-1186.4 "Fire's Domain" sync / 1[56]:Lugus:47(5F|60):/
-1189.4 "Fire's Ire" sync / 1[56]:Lugus:4761:/
-1190.9 "Fire's Domain" sync / 1[56]:Lugus:47(5F|60):/
-1193.9 "Fire's Ire" sync / 1[56]:Lugus:4761:/
-1195.4 "Fire's Domain" sync / 1[56]:Lugus:47(5F|60):/
-1198.4 "Fire's Ire" sync / 1[56]:Lugus:4761:/
+1122.9 "Culling Blade" sync / 1[56]:[^:]*:Lugus:4765:/ window 25,20
+1126.2 "Plummet" sync / 1[56]:[^:]*:Lugus:4767:/
+1133.3 "Black Flame" sync / 1[56]:[^:]*:Lugus:475D:/
+1136.7 "Otherworldly Heat" sync / 1[56]:[^:]*:Lugus:475C:/
+1142.4 "Mortal Flame" sync / 1[56]:[^:]*:Lugus:4759:/
+1169.1 "Scorching Left/Right" sync / 1[56]:[^:]*:Lugus:476[23]:/
+1181.8 "Fire's Domain" sync / 1[56]:[^:]*:Lugus:47(5F|60):/
+1184.9 "Fire's Ire" sync / 1[56]:[^:]*:Lugus:4761:/
+1186.4 "Fire's Domain" sync / 1[56]:[^:]*:Lugus:47(5F|60):/
+1189.4 "Fire's Ire" sync / 1[56]:[^:]*:Lugus:4761:/
+1190.9 "Fire's Domain" sync / 1[56]:[^:]*:Lugus:47(5F|60):/
+1193.9 "Fire's Ire" sync / 1[56]:[^:]*:Lugus:4761:/
+1195.4 "Fire's Domain" sync / 1[56]:[^:]*:Lugus:47(5F|60):/
+1198.4 "Fire's Ire" sync / 1[56]:[^:]*:Lugus:4761:/
 
-1205.9 "Captive Bolt" sync / 1[56]:Lugus:4764:/ window 20,20
-1215.0 "Black Flame" sync / 1[56]:Lugus:475D:/
-1218.5 "Otherworldly Heat" sync / 1[56]:Lugus:475C:/
-1226.1 "Culling Blade" sync / 1[56]:Lugus:4765:/
-1238.9 "Scorching Left/Right" sync / 1[56]:Lugus:476[23]:/
-1251.6 "Fire's Domain" sync / 1[56]:Lugus:47(5F|60):/
-1254.7 "Fire's Ire" sync / 1[56]:Lugus:4761:/
-1256.2 "Fire's Domain" sync / 1[56]:Lugus:47(5F|60):/
-1259.2 "Fire's Ire" sync / 1[56]:Lugus:4761:/
-1260.7 "Fire's Domain" sync / 1[56]:Lugus:47(5F|60):/
-1263.7 "Fire's Ire" sync / 1[56]:Lugus:4761:/
-1265.0 "Fire's Domain" sync / 1[56]:Lugus:47(5F|60):/
-1268.2 "Fire's Ire" sync / 1[56]:Lugus:4761:/
+1205.9 "Captive Bolt" sync / 1[56]:[^:]*:Lugus:4764:/ window 20,20
+1215.0 "Black Flame" sync / 1[56]:[^:]*:Lugus:475D:/
+1218.5 "Otherworldly Heat" sync / 1[56]:[^:]*:Lugus:475C:/
+1226.1 "Culling Blade" sync / 1[56]:[^:]*:Lugus:4765:/
+1238.9 "Scorching Left/Right" sync / 1[56]:[^:]*:Lugus:476[23]:/
+1251.6 "Fire's Domain" sync / 1[56]:[^:]*:Lugus:47(5F|60):/
+1254.7 "Fire's Ire" sync / 1[56]:[^:]*:Lugus:4761:/
+1256.2 "Fire's Domain" sync / 1[56]:[^:]*:Lugus:47(5F|60):/
+1259.2 "Fire's Ire" sync / 1[56]:[^:]*:Lugus:4761:/
+1260.7 "Fire's Domain" sync / 1[56]:[^:]*:Lugus:47(5F|60):/
+1263.7 "Fire's Ire" sync / 1[56]:[^:]*:Lugus:4761:/
+1265.0 "Fire's Domain" sync / 1[56]:[^:]*:Lugus:47(5F|60):/
+1268.2 "Fire's Ire" sync / 1[56]:[^:]*:Lugus:4761:/
 
-1275.7 "Captive Bolt" sync / 1[56]:Lugus:4764:/ window 50,50 jump 1205.9
+1275.7 "Captive Bolt" sync / 1[56]:[^:]*:Lugus:4764:/ window 50,50 jump 1205.9
 1284.8 "Black Flame"
 1288.3 "Otherworldly Heat"
 1295.9 "Culling Blade"

--- a/ui/raidboss/data/05-shb/dungeon/twinning.txt
+++ b/ui/raidboss/data/05-shb/dungeon/twinning.txt
@@ -9,22 +9,22 @@ hideall "--sync--"
 ### Alpha Zaghnal
 # -p 3D65:108.5 -ii 3D66 3D67 3D68 3D69 3D6A 41CA 3D6C
 100.0 "--sync--" sync / 00:0839::Repurposing will be sealed off/ window 100,0
-102.5 "--sync--" sync / 1[56]:Cladoselache:366:/ window 103,0
-108.5 "Augurium" sync / 1[56]:Alpha Zaghnal:3D65:/
-117.6 "Beastly Roar" sync / 1[56]:Alpha Zaghnal:3D64:/
-122.9 "Beast Rampant" sync / 1[56]:Alpha Zaghnal:3D60:/
+102.5 "--sync--" sync / 1[56]:[^:]*:Cladoselache:366:/ window 103,0
+108.5 "Augurium" sync / 1[56]:[^:]*:Alpha Zaghnal:3D65:/
+117.6 "Beastly Roar" sync / 1[56]:[^:]*:Alpha Zaghnal:3D64:/
+122.9 "Beast Rampant" sync / 1[56]:[^:]*:Alpha Zaghnal:3D60:/
 
-136.4 "Forlorn Impact x4" sync / 1[56]:Alpha Zaghnal:3D61:/ duration 4
-141.3 "Beast Passant" sync / 1[56]:Alpha Zaghnal:3D62:/
-149.3 "Beastly Roar" sync / 1[56]:Alpha Zaghnal:3D64:/
-158.3 "Pounce Errant x4" sync / 1[56]:Alpha Zaghnal:3D5F:/ duration 5.2
+136.4 "Forlorn Impact x4" sync / 1[56]:[^:]*:Alpha Zaghnal:3D61:/ duration 4
+141.3 "Beast Passant" sync / 1[56]:[^:]*:Alpha Zaghnal:3D62:/
+149.3 "Beastly Roar" sync / 1[56]:[^:]*:Alpha Zaghnal:3D64:/
+158.3 "Pounce Errant x4" sync / 1[56]:[^:]*:Alpha Zaghnal:3D5F:/ duration 5.2
 # I've seen this Augurium skipped??
-170.5 "Augurium" sync / 1[56]:Alpha Zaghnal:3D65:/
-178.8 "Charge Eradicated" sync / 1[56]:Alpha Zaghnal:3D63:/ window 50,5
-185.9 "Charge Eradicated" sync / 1[56]:Alpha Zaghnal:3D63:/
-195.2 "Beast Rampant" sync / 1[56]:Alpha Zaghnal:3D60:/
+170.5 "Augurium" sync / 1[56]:[^:]*:Alpha Zaghnal:3D65:/
+178.8 "Charge Eradicated" sync / 1[56]:[^:]*:Alpha Zaghnal:3D63:/ window 50,5
+185.9 "Charge Eradicated" sync / 1[56]:[^:]*:Alpha Zaghnal:3D63:/
+195.2 "Beast Rampant" sync / 1[56]:[^:]*:Alpha Zaghnal:3D60:/
 
-208.6 "Forlorn Impact x4" sync / 1[56]:Alpha Zaghnal:3D61:/ duration 4 jump 136.4
+208.6 "Forlorn Impact x4" sync / 1[56]:[^:]*:Alpha Zaghnal:3D61:/ duration 4 jump 136.4
 213.5 "Beast Passant"
 221.5 "Beastly Roar"
 230.5 "Pounce Errant x4"
@@ -37,21 +37,21 @@ hideall "--sync--"
 ### Mithridates
 # -p 3DED:512 -ii 3DEC 3DEF
 500.0 "--sync--" sync / 00:0839::Aetherial Observation will be sealed off/ window 500,0
-501.0 "--sync--" sync / 1[56]:Mithridates:366:/ window 501,0
+501.0 "--sync--" sync / 1[56]:[^:]*:Mithridates:366:/ window 501,0
 
-512.0 "Thunder Beam" sync / 1[56]:Mithridates:3DED:/
-522.2 "Electric Discharge" sync / 1[56]:Mithridates:3DF0:/
-531.1 "Shock" sync / 1[56]:Levinball:3DF1:/
-543.8 "Laserblade" sync / 1[56]:Mithridates:3DEB:/
-555.9 "Thunder Beam" sync / 1[56]:Mithridates:3DED:/
-569.5 "Allagan Thunder" sync / 1[56]:Mithridates:3DEE:/
+512.0 "Thunder Beam" sync / 1[56]:[^:]*:Mithridates:3DED:/
+522.2 "Electric Discharge" sync / 1[56]:[^:]*:Mithridates:3DF0:/
+531.1 "Shock" sync / 1[56]:[^:]*:Levinball:3DF1:/
+543.8 "Laserblade" sync / 1[56]:[^:]*:Mithridates:3DEB:/
+555.9 "Thunder Beam" sync / 1[56]:[^:]*:Mithridates:3DED:/
+569.5 "Allagan Thunder" sync / 1[56]:[^:]*:Mithridates:3DEE:/
 
-582.1 "Electric Discharge" sync / 1[56]:Mithridates:3DF0:/
-590.2 "Laserblade" sync / 1[56]:Mithridates:3DEB:/
-591.0 "Shock" sync / 1[56]:Levinball:3DF1:/
-602.4 "Thunder Beam" sync / 1[56]:Mithridates:3DED:/
+582.1 "Electric Discharge" sync / 1[56]:[^:]*:Mithridates:3DF0:/
+590.2 "Laserblade" sync / 1[56]:[^:]*:Mithridates:3DEB:/
+591.0 "Shock" sync / 1[56]:[^:]*:Levinball:3DF1:/
+602.4 "Thunder Beam" sync / 1[56]:[^:]*:Mithridates:3DED:/
 
-617.5 "Electric Discharge" sync / 1[56]:Mithridates:3DF0:/ window 20,20 jump 582.1
+617.5 "Electric Discharge" sync / 1[56]:[^:]*:Mithridates:3DF0:/ window 20,20 jump 582.1
 625.6 "Laserblade"
 626.4 "Shock"
 637.8 "Thunder Beam"
@@ -69,36 +69,36 @@ hideall "Temporal Paradox"
 hideall "Temporal Flow"
 
 1000.0 "--sync--" sync / 00:0839::The Cornice will be sealed off/ window 1000,0
-1001.0 "--sync--" sync / 1[56]:The Tycoon:3DFD:/ window 1001,0
+1001.0 "--sync--" sync / 1[56]:[^:]*:The Tycoon:3DFD:/ window 1001,0
 
 
-1013.8 "Magitek Crossray" sync / 1[56]:The Tycoon:3DF8:/
-1016.2 "Temporal Paradox" sync / 1[56]:The Tycoon:3DF7:/
-1023.1 "Temporal Flow" sync / 1[56]:The Tycoon:3DF5:/
-1024.4 "Magitek Ray" sync / 1[56]:The Tycoon:3DF3:/
+1013.8 "Magitek Crossray" sync / 1[56]:[^:]*:The Tycoon:3DF8:/
+1016.2 "Temporal Paradox" sync / 1[56]:[^:]*:The Tycoon:3DF7:/
+1023.1 "Temporal Flow" sync / 1[56]:[^:]*:The Tycoon:3DF5:/
+1024.4 "Magitek Ray" sync / 1[56]:[^:]*:The Tycoon:3DF3:/
 
-1034.2 "Defensive Array" sync / 1[56]:The Tycoon:3DF2:/
-1042.3 "Temporal Flow" sync / 1[56]:The Tycoon:3DF5:/
-1043.4 "Magitek Ray" sync / 1[56]:The Tycoon:3DF3:/
-1049.6 "Artificial Gravity" sync / 1[56]:The Tycoon:3DF9:/
-1056.3 "High Gravity" sync / 1[56]:The Tycoon:3DFA:/
-1065.9 "Rail Cannon" sync / 1[56]:The Tycoon:3DFB:/
+1034.2 "Defensive Array" sync / 1[56]:[^:]*:The Tycoon:3DF2:/
+1042.3 "Temporal Flow" sync / 1[56]:[^:]*:The Tycoon:3DF5:/
+1043.4 "Magitek Ray" sync / 1[56]:[^:]*:The Tycoon:3DF3:/
+1049.6 "Artificial Gravity" sync / 1[56]:[^:]*:The Tycoon:3DF9:/
+1056.3 "High Gravity" sync / 1[56]:[^:]*:The Tycoon:3DFA:/
+1065.9 "Rail Cannon" sync / 1[56]:[^:]*:The Tycoon:3DFB:/
 
-1079.1 "Defensive Array" sync / 1[56]:The Tycoon:3DF2:/
-1086.3 "Magicrystal" sync / 1[56]:The Tycoon:3E0C:/
-1093.0 "Shattered Crystal" sync / 1[56]:The Tycoon:439A:/
-1093.6 "Temporal Flow" sync / 1[56]:The Tycoon:3DF5:/
-1094.9 "Magitek Ray" sync / 1[56]:The Tycoon:3DF3:/
+1079.1 "Defensive Array" sync / 1[56]:[^:]*:The Tycoon:3DF2:/
+1086.3 "Magicrystal" sync / 1[56]:[^:]*:The Tycoon:3E0C:/
+1093.0 "Shattered Crystal" sync / 1[56]:[^:]*:The Tycoon:439A:/
+1093.6 "Temporal Flow" sync / 1[56]:[^:]*:The Tycoon:3DF5:/
+1094.9 "Magitek Ray" sync / 1[56]:[^:]*:The Tycoon:3DF3:/
 
-1105.9 "High-Tension Discharger" sync / 1[56]:The Tycoon:3DFC:/
-1119.2 "Magitek Crossray" sync / 1[56]:The Tycoon:3DF8:/
-1129.3 "Artificial Gravity" sync / 1[56]:The Tycoon:3DF9:/
-1135.5 "Temporal Flow" sync / 1[56]:The Tycoon:3DF5:/
-1136.0 "High Gravity" sync / 1[56]:The Tycoon:3DFA:/
-1136.6 "Magitek Ray" sync / 1[56]:The Tycoon:3DF3:/
-1147.7 "Rail Cannon" sync / 1[56]:The Tycoon:3DFB:/
+1105.9 "High-Tension Discharger" sync / 1[56]:[^:]*:The Tycoon:3DFC:/
+1119.2 "Magitek Crossray" sync / 1[56]:[^:]*:The Tycoon:3DF8:/
+1129.3 "Artificial Gravity" sync / 1[56]:[^:]*:The Tycoon:3DF9:/
+1135.5 "Temporal Flow" sync / 1[56]:[^:]*:The Tycoon:3DF5:/
+1136.0 "High Gravity" sync / 1[56]:[^:]*:The Tycoon:3DFA:/
+1136.6 "Magitek Ray" sync / 1[56]:[^:]*:The Tycoon:3DF3:/
+1147.7 "Rail Cannon" sync / 1[56]:[^:]*:The Tycoon:3DFB:/
 
-1161.2 "Defensive Array" sync / 1[56]:The Tycoon:3DF2:/
+1161.2 "Defensive Array" sync / 1[56]:[^:]*:The Tycoon:3DF2:/
 1167.3 "Gravity/Crossray??"
 # ???
 
@@ -109,19 +109,19 @@ hideall "Temporal Flow"
 # and then possibly another discharger??
 
 # Path A?
-#1161.2 "Defensive Array" sync / 1[56]:The Tycoon:3DF2:/
-#1167.3 "Artificial Gravity" sync / 1[56]:The Tycoon:3DF9:/
-#1170.5 "Magicrystal" sync / 1[56]:The Tycoon:3E0C:/
-#1174.0 "High Gravity" sync / 1[56]:The Tycoon:3DFA:/
-#1176.7 "Temporal Flow" sync / 1[56]:The Tycoon:3DF5:/
-#1177.2 "Shattered Crystal" sync / 1[56]:The Tycoon:439A:/
-#1178.0 "Magitek Ray" sync / 1[56]:The Tycoon:3DF3:/
+#1161.2 "Defensive Array" sync / 1[56]:[^:]*:The Tycoon:3DF2:/
+#1167.3 "Artificial Gravity" sync / 1[56]:[^:]*:The Tycoon:3DF9:/
+#1170.5 "Magicrystal" sync / 1[56]:[^:]*:The Tycoon:3E0C:/
+#1174.0 "High Gravity" sync / 1[56]:[^:]*:The Tycoon:3DFA:/
+#1176.7 "Temporal Flow" sync / 1[56]:[^:]*:The Tycoon:3DF5:/
+#1177.2 "Shattered Crystal" sync / 1[56]:[^:]*:The Tycoon:439A:/
+#1178.0 "Magitek Ray" sync / 1[56]:[^:]*:The Tycoon:3DF3:/
 
 # Path B?
-#1161.0 "Defensive Array" sync / 1[56]:The Tycoon:3DF2:/
-#1172.2 "Magitek Crossray" sync / 1[56]:The Tycoon:3DF8:/
-#1179.5 "Magicrystal" sync / 1[56]:The Tycoon:3E0C:/
-#1186.2 "Shattered Crystal" sync / 1[56]:The Tycoon:439A:/
-#1186.7 "Temporal Flow" sync / 1[56]:The Tycoon:3DF5:/
-#1188.0 "Magitek Ray" sync / 1[56]:The Tycoon:3DF3:/
-#1199.0 "Rail Cannon" sync / 1[56]:The Tycoon:3DFB:/
+#1161.0 "Defensive Array" sync / 1[56]:[^:]*:The Tycoon:3DF2:/
+#1172.2 "Magitek Crossray" sync / 1[56]:[^:]*:The Tycoon:3DF8:/
+#1179.5 "Magicrystal" sync / 1[56]:[^:]*:The Tycoon:3E0C:/
+#1186.2 "Shattered Crystal" sync / 1[56]:[^:]*:The Tycoon:439A:/
+#1186.7 "Temporal Flow" sync / 1[56]:[^:]*:The Tycoon:3DF5:/
+#1188.0 "Magitek Ray" sync / 1[56]:[^:]*:The Tycoon:3DF3:/
+#1199.0 "Rail Cannon" sync / 1[56]:[^:]*:The Tycoon:3DFB:/

--- a/ui/raidboss/data/05-shb/eureka/bozjan_southern_front.txt
+++ b/ui/raidboss/data/05-shb/eureka/bozjan_southern_front.txt
@@ -74,55 +74,55 @@ hideall "--sync--"
 #
 # 53C5 Lightning Shower is the first obvious "you are on the top" damage
 # Anti-Warchmachina Weaponry summons an add; once dead, the timeline resumes.
-20014.7 "Electric Anvil" sync / 1[56]:Brionac:51DC:/
-20026.8 "False Thunder" sync / 1[56]:Brionac:51C[EF]:/
-20035.0 "Anti-Warmachina Weaponry" sync / 1[56]:Brionac:51CD:/
-20135.0 "--sync--" sync / 14:Brionac:53C4:/ window 100,50
-20139.0 "Lightning Shower" sync / 1[56]:Brionac:53C4:/
+20014.7 "Electric Anvil" sync / 1[56]:[^:]*:Brionac:51DC:/
+20026.8 "False Thunder" sync / 1[56]:[^:]*:Brionac:51C[EF]:/
+20035.0 "Anti-Warmachina Weaponry" sync / 1[56]:[^:]*:Brionac:51CD:/
+20135.0 "--sync--" sync / 14:[^:]*:Brionac:53C4:/ window 100,50
+20139.0 "Lightning Shower" sync / 1[56]:[^:]*:Brionac:53C4:/
 
-20146.1 "Energy Generation" sync / 1[56]:Brionac:51D0:/
-20158.2 "Lightburst" sync / 1[56]:Lightsphere:51D1:/
+20146.1 "Energy Generation" sync / 1[56]:[^:]*:Brionac:51D0:/
+20158.2 "Lightburst" sync / 1[56]:[^:]*:Lightsphere:51D1:/
 
-20171.2 "False Thunder" sync / 1[56]:Brionac:51C[EF]:/
+20171.2 "False Thunder" sync / 1[56]:[^:]*:Brionac:51C[EF]:/
 
-20177.3 "Energy Generation" sync / 1[56]:Brionac:51D0:/
-20189.5 "Shadow Burst" sync / 1[56]:Shadowsphere:51D2:/
+20177.3 "Energy Generation" sync / 1[56]:[^:]*:Brionac:51D0:/
+20189.5 "Shadow Burst" sync / 1[56]:[^:]*:Shadowsphere:51D2:/
 
-20203.5 "Electric Anvil" sync / 1[56]:Brionac:51DC:/
-20218.8 "Voltstream" sync / 1[56]:Brionac:51DB:/
-20222.8 "Voltstream" sync / 1[56]:Brionac:51DB:/
-20226.9 "Voltstream" sync / 1[56]:Brionac:51DB:/
-20230.9 "Voltstream" sync / 1[56]:Brionac:51DB:/
+20203.5 "Electric Anvil" sync / 1[56]:[^:]*:Brionac:51DC:/
+20218.8 "Voltstream" sync / 1[56]:[^:]*:Brionac:51DB:/
+20222.8 "Voltstream" sync / 1[56]:[^:]*:Brionac:51DB:/
+20226.9 "Voltstream" sync / 1[56]:[^:]*:Brionac:51DB:/
+20230.9 "Voltstream" sync / 1[56]:[^:]*:Brionac:51DB:/
 
-20238.8 "Energy Generation" sync / 1[56]:Brionac:51D0:/
-20250.9 "Pole Shift" sync / 1[56]:Brionac:51D3:/
-20254.9 "Shadow Burst" sync / 1[56]:Shadowsphere:51D2:/
-20254.9 "Lightburst" sync / 1[56]:Lightsphere:51D1:/
+20238.8 "Energy Generation" sync / 1[56]:[^:]*:Brionac:51D0:/
+20250.9 "Pole Shift" sync / 1[56]:[^:]*:Brionac:51D3:/
+20254.9 "Shadow Burst" sync / 1[56]:[^:]*:Shadowsphere:51D2:/
+20254.9 "Lightburst" sync / 1[56]:[^:]*:Lightsphere:51D1:/
 
-20263.2 "Anti-Warmachina Weaponry" sync / 1[56]:Brionac:51CD:/
-20363.2 "--sync--" sync / 14:Brionac:53C4:/ window 100,50
-20367.2 "Lightning Shower" sync / 1[56]:Brionac:53C4:/
-20374.3 "Energy Generation" sync / 1[56]:Brionac:51D0:/
-20384.4 "Magitek Magnetism" sync / 1[56]:Brionac:51D5:/
-20388.6 "Magnetic Jolt" sync / 1[56]:Brionac:51D7:/
-20389.4 "Lightburst" sync / 1[56]:Lightsphere:51D1:/
-20389.4 "Shadow Burst" sync / 1[56]:Shadowsphere:51D2:/
-20399.6 "Voltstream" sync / 1[56]:Brionac:51DB:/
-20403.6 "Voltstream" sync / 1[56]:Brionac:51DB:/
-20407.7 "Voltstream" sync / 1[56]:Brionac:51DB:/
-20411.7 "Voltstream" sync / 1[56]:Brionac:51DB:/
-20418.6 "False Thunder" sync / 1[56]:Brionac:51CF:/
-20427.9 "Anti-Warmachina Weaponry" sync / 1[56]:Brionac:51CD:/
-20527.9 "--sync--" sync / 14:Brionac:51DC:/ window 100,50
-20531.9 "Electric Anvil" sync / 1[56]:Brionac:51DC:/
+20263.2 "Anti-Warmachina Weaponry" sync / 1[56]:[^:]*:Brionac:51CD:/
+20363.2 "--sync--" sync / 14:[^:]*:Brionac:53C4:/ window 100,50
+20367.2 "Lightning Shower" sync / 1[56]:[^:]*:Brionac:53C4:/
+20374.3 "Energy Generation" sync / 1[56]:[^:]*:Brionac:51D0:/
+20384.4 "Magitek Magnetism" sync / 1[56]:[^:]*:Brionac:51D5:/
+20388.6 "Magnetic Jolt" sync / 1[56]:[^:]*:Brionac:51D7:/
+20389.4 "Lightburst" sync / 1[56]:[^:]*:Lightsphere:51D1:/
+20389.4 "Shadow Burst" sync / 1[56]:[^:]*:Shadowsphere:51D2:/
+20399.6 "Voltstream" sync / 1[56]:[^:]*:Brionac:51DB:/
+20403.6 "Voltstream" sync / 1[56]:[^:]*:Brionac:51DB:/
+20407.7 "Voltstream" sync / 1[56]:[^:]*:Brionac:51DB:/
+20411.7 "Voltstream" sync / 1[56]:[^:]*:Brionac:51DB:/
+20418.6 "False Thunder" sync / 1[56]:[^:]*:Brionac:51CF:/
+20427.9 "Anti-Warmachina Weaponry" sync / 1[56]:[^:]*:Brionac:51CD:/
+20527.9 "--sync--" sync / 14:[^:]*:Brionac:51DC:/ window 100,50
+20531.9 "Electric Anvil" sync / 1[56]:[^:]*:Brionac:51DC:/
 
-20539.0 "Energy Generation" sync / 1[56]:Brionac:51D0:/
-20549.1 "Polar Magnetism" sync / 1[56]:Brionac:51D9:/
-20554.2 "Shadow Burst" sync / 1[56]:Shadowsphere:51D2:/
-20554.2 "Lightburst" sync / 1[56]:Lightsphere:51D1:/
+20539.0 "Energy Generation" sync / 1[56]:[^:]*:Brionac:51D0:/
+20549.1 "Polar Magnetism" sync / 1[56]:[^:]*:Brionac:51D9:/
+20554.2 "Shadow Burst" sync / 1[56]:[^:]*:Shadowsphere:51D2:/
+20554.2 "Lightburst" sync / 1[56]:[^:]*:Lightsphere:51D1:/
 
-20565.4 "Energy Generation" sync / 1[56]:Brionac:51D0:/
-20565.4 "Voltstream" sync / 1[56]:Brionac:51DB:/
+20565.4 "Energy Generation" sync / 1[56]:[^:]*:Brionac:51D0:/
+20565.4 "Voltstream" sync / 1[56]:[^:]*:Brionac:51DB:/
 
 # ???
 
@@ -140,52 +140,52 @@ hideall "--sync--"
 
 # Fake intro, where you don't know if you're on the top or the bottom.
 # Don't sync because sometimes these bosses are +/- 3 seconds @_@
-20022.2 "Chain Cannon" duration 6.5 #sync / 1[56]:4Th Legion Helldiver:51F9:/
-20036.9 "Mrv Missile" #sync / 1[56]:4Th Legion Helldiver:51FD:/
+20022.2 "Chain Cannon" duration 6.5 #sync / 1[56]:[^:]*:4Th Legion Helldiver:51F9:/
+20036.9 "Mrv Missile" #sync / 1[56]:[^:]*:4Th Legion Helldiver:51FD:/
 
-30022.2 "Chain Cannon" duration 6.5 #sync / 1[56]:4Th Legion Helldiver:51F9:/
-30036.9 "Mrv Missile" sync / 1[56]:4Th Legion Helldiver:51FD:/ window 50,50
-30049.1 "Command: Lateral Dive" sync / 1[56]:4Th Legion Helldiver:51EA:/
-30057.1 "Lateral Dive" sync / 1[56]:4Th Legion Helldiver:51EB:/
-30065.3 "Command: Suppressive Formation" sync / 1[56]:4Th Legion Helldiver:51F5:/
-30073.3 "Command: Suppressive Formation" sync / 1[56]:4Th Legion Helldiver:51F6:/
-30082.6 "Magitek Missiles" sync / 1[56]:4Th Legion Helldiver:51FE:/
-30097.8 "Command: Infrared Blast" sync / 1[56]:4Th Legion Helldiver:51EC:/
-30102.4 "Infrared Blast" sync / 1[56]:4Th Legion Helldiver:51EE:/
-30106.4 "Infrared Blast" sync / 1[56]:4Th Legion Helldiver:51EE:/
-30110.4 "Infrared Blast" sync / 1[56]:4Th Legion Helldiver:51EE:/
-30114.4 "Infrared Blast" sync / 1[56]:4Th Legion Helldiver:51EE:/
-30134.1 "Command: Chain Cannon" sync / 1[56]:4Th Legion Helldiver:51FB:/
-30138.9 "Chain Cannon" duration 6.5 #sync / 1[56]:4Th Legion Helldiver:51F9:/
-30140.8 "Chain Cannon" duration 6.5 #sync / 1[56]:4Th Legion Helldiver:51F9:/
-30142.9 "Chain Cannon" duration 6.5 #sync / 1[56]:4Th Legion Helldiver:51F9:/
-30144.9 "Chain Cannon" duration 6.5 #sync / 1[56]:4Th Legion Helldiver:51F9:/
-30153.4 "Magitek Missiles" sync / 1[56]:4Th Legion Helldiver:51FE:/ window 15,15
-30167.6 "Command: Dive Formation" sync / 1[56]:4Th Legion Helldiver:51EF:/
-30179.6 "Dive Formation" sync / 1[56]:4Th Legion Helldiver:51F0:/
-30183.6 "Dive Formation" sync / 1[56]:4Th Legion Helldiver:51F0:/
-30187.6 "Dive Formation" sync / 1[56]:4Th Legion Helldiver:51F0:/
-30197.8 "Command: Lateral Dive" sync / 1[56]:4Th Legion Helldiver:51EA:/
-30203.9 "Command: Suppressive Formation" sync / 1[56]:4Th Legion Helldiver:51F5:/
-30205.8 "Lateral Dive" sync / 1[56]:4Th Legion Helldiver:51EB:/
-30209.8 "Chain Cannon" duration 6.5 #sync / 1[56]:4Th Legion Helldiver:51F9:/
-30211.9 "Command: Suppressive Formation" sync / 1[56]:4Th Legion Helldiver:51F6:/
-30232.6 "Magitek Missiles" sync / 1[56]:4Th Legion Helldiver:51FE:/
-30246.8 "Command: Joint Attack" sync / 1[56]:4Th Legion Helldiver:51F2:/
-30255.0 "Command: Infrared Blast" sync / 1[56]:4Th Legion Helldiver:51EC:/
-30259.6 "Infrared Blast" sync / 1[56]:4Th Legion Helldiver:51EE:/
-30263.6 "Infrared Blast" sync / 1[56]:4Th Legion Helldiver:51EE:/
-30265.3 "Surface Missile" sync / 1[56]:4Th Legion Helldiver:51F8:/
-30267.7 "Infrared Blast" sync / 1[56]:4Th Legion Helldiver:51EE:/
-30270.4 "Surface Missile" sync / 1[56]:4Th Legion Helldiver:51F8:/
-30271.6 "Infrared Blast" sync / 1[56]:4Th Legion Helldiver:51EE:/
-30278.2 "Command: Chain Cannon" sync / 1[56]:4Th Legion Helldiver:51FB:/
-30282.8 "Chain Cannon" duration 6.5 #sync / 1[56]:4Th Legion Helldiver:51F9:/
-30284.3 "Command: Suppressive Formation" sync / 1[56]:4Th Legion Helldiver:51F5:/
-30284.9 "Chain Cannon" duration 6.5 #sync / 1[56]:4Th Legion Helldiver:51F9:/
-30286.8 "Chain Cannon" duration 6.5 #sync / 1[56]:4Th Legion Helldiver:51F9:/
-30288.9 "Chain Cannon" duration 6.5 #sync / 1[56]:4Th Legion Helldiver:51F9:/
-30292.3 "Command: Suppressive Formation" sync / 1[56]:4Th Legion Helldiver:51F6:/
+30022.2 "Chain Cannon" duration 6.5 #sync / 1[56]:[^:]*:4Th Legion Helldiver:51F9:/
+30036.9 "Mrv Missile" sync / 1[56]:[^:]*:4Th Legion Helldiver:51FD:/ window 50,50
+30049.1 "Command: Lateral Dive" sync / 1[56]:[^:]*:4Th Legion Helldiver:51EA:/
+30057.1 "Lateral Dive" sync / 1[56]:[^:]*:4Th Legion Helldiver:51EB:/
+30065.3 "Command: Suppressive Formation" sync / 1[56]:[^:]*:4Th Legion Helldiver:51F5:/
+30073.3 "Command: Suppressive Formation" sync / 1[56]:[^:]*:4Th Legion Helldiver:51F6:/
+30082.6 "Magitek Missiles" sync / 1[56]:[^:]*:4Th Legion Helldiver:51FE:/
+30097.8 "Command: Infrared Blast" sync / 1[56]:[^:]*:4Th Legion Helldiver:51EC:/
+30102.4 "Infrared Blast" sync / 1[56]:[^:]*:4Th Legion Helldiver:51EE:/
+30106.4 "Infrared Blast" sync / 1[56]:[^:]*:4Th Legion Helldiver:51EE:/
+30110.4 "Infrared Blast" sync / 1[56]:[^:]*:4Th Legion Helldiver:51EE:/
+30114.4 "Infrared Blast" sync / 1[56]:[^:]*:4Th Legion Helldiver:51EE:/
+30134.1 "Command: Chain Cannon" sync / 1[56]:[^:]*:4Th Legion Helldiver:51FB:/
+30138.9 "Chain Cannon" duration 6.5 #sync / 1[56]:[^:]*:4Th Legion Helldiver:51F9:/
+30140.8 "Chain Cannon" duration 6.5 #sync / 1[56]:[^:]*:4Th Legion Helldiver:51F9:/
+30142.9 "Chain Cannon" duration 6.5 #sync / 1[56]:[^:]*:4Th Legion Helldiver:51F9:/
+30144.9 "Chain Cannon" duration 6.5 #sync / 1[56]:[^:]*:4Th Legion Helldiver:51F9:/
+30153.4 "Magitek Missiles" sync / 1[56]:[^:]*:4Th Legion Helldiver:51FE:/ window 15,15
+30167.6 "Command: Dive Formation" sync / 1[56]:[^:]*:4Th Legion Helldiver:51EF:/
+30179.6 "Dive Formation" sync / 1[56]:[^:]*:4Th Legion Helldiver:51F0:/
+30183.6 "Dive Formation" sync / 1[56]:[^:]*:4Th Legion Helldiver:51F0:/
+30187.6 "Dive Formation" sync / 1[56]:[^:]*:4Th Legion Helldiver:51F0:/
+30197.8 "Command: Lateral Dive" sync / 1[56]:[^:]*:4Th Legion Helldiver:51EA:/
+30203.9 "Command: Suppressive Formation" sync / 1[56]:[^:]*:4Th Legion Helldiver:51F5:/
+30205.8 "Lateral Dive" sync / 1[56]:[^:]*:4Th Legion Helldiver:51EB:/
+30209.8 "Chain Cannon" duration 6.5 #sync / 1[56]:[^:]*:4Th Legion Helldiver:51F9:/
+30211.9 "Command: Suppressive Formation" sync / 1[56]:[^:]*:4Th Legion Helldiver:51F6:/
+30232.6 "Magitek Missiles" sync / 1[56]:[^:]*:4Th Legion Helldiver:51FE:/
+30246.8 "Command: Joint Attack" sync / 1[56]:[^:]*:4Th Legion Helldiver:51F2:/
+30255.0 "Command: Infrared Blast" sync / 1[56]:[^:]*:4Th Legion Helldiver:51EC:/
+30259.6 "Infrared Blast" sync / 1[56]:[^:]*:4Th Legion Helldiver:51EE:/
+30263.6 "Infrared Blast" sync / 1[56]:[^:]*:4Th Legion Helldiver:51EE:/
+30265.3 "Surface Missile" sync / 1[56]:[^:]*:4Th Legion Helldiver:51F8:/
+30267.7 "Infrared Blast" sync / 1[56]:[^:]*:4Th Legion Helldiver:51EE:/
+30270.4 "Surface Missile" sync / 1[56]:[^:]*:4Th Legion Helldiver:51F8:/
+30271.6 "Infrared Blast" sync / 1[56]:[^:]*:4Th Legion Helldiver:51EE:/
+30278.2 "Command: Chain Cannon" sync / 1[56]:[^:]*:4Th Legion Helldiver:51FB:/
+30282.8 "Chain Cannon" duration 6.5 #sync / 1[56]:[^:]*:4Th Legion Helldiver:51F9:/
+30284.3 "Command: Suppressive Formation" sync / 1[56]:[^:]*:4Th Legion Helldiver:51F5:/
+30284.9 "Chain Cannon" duration 6.5 #sync / 1[56]:[^:]*:4Th Legion Helldiver:51F9:/
+30286.8 "Chain Cannon" duration 6.5 #sync / 1[56]:[^:]*:4Th Legion Helldiver:51F9:/
+30288.9 "Chain Cannon" duration 6.5 #sync / 1[56]:[^:]*:4Th Legion Helldiver:51F9:/
+30292.3 "Command: Suppressive Formation" sync / 1[56]:[^:]*:4Th Legion Helldiver:51F6:/
 # ???
 
 
@@ -199,66 +199,66 @@ hideall "--sync--"
 # note: accursed becoming IV casts have different ability ids the first time through.
 
 50000.0 "--sync--" sync / 00:0839::The airship landing will be sealed off/ window 100000,0
-50014.3 "Holy IV" sync / 1[56]:Adrammelech:4F96:/
+50014.3 "Holy IV" sync / 1[56]:[^:]*:Adrammelech:4F96:/
 
-50021.8 "Curse Of The Fiend" sync / 1[56]:Adrammelech:4F7A:/
-50028.9 "Accursed Becoming" sync / 1[56]:Adrammelech:4F7B:/
-50036.1 "Water IV" sync / 1[56]:Adrammelech:53D8:/
+50021.8 "Curse Of The Fiend" sync / 1[56]:[^:]*:Adrammelech:4F7A:/
+50028.9 "Accursed Becoming" sync / 1[56]:[^:]*:Adrammelech:4F7B:/
+50036.1 "Water IV" sync / 1[56]:[^:]*:Adrammelech:53D8:/
 
-50044.4 "Curse Of The Fiend" sync / 1[56]:Adrammelech:4F7A:/
-50051.5 "Accursed Becoming" sync / 1[56]:Adrammelech:4F7B:/
-50058.7 "Fire IV/Blizzard IV" sync / 1[56]:Adrammelech:545[AD]:/
+50044.4 "Curse Of The Fiend" sync / 1[56]:[^:]*:Adrammelech:4F7A:/
+50051.5 "Accursed Becoming" sync / 1[56]:[^:]*:Adrammelech:4F7B:/
+50058.7 "Fire IV/Blizzard IV" sync / 1[56]:[^:]*:Adrammelech:545[AD]:/
 
-50067.0 "Curse Of The Fiend" sync / 1[56]:Adrammelech:4F7A:/
-50074.1 "Accursed Becoming" sync / 1[56]:Adrammelech:4F7B:/
-50081.3 "Stone IV/Aero IV/Thunder IV" sync / 1[56]:Adrammelech:4F(7F|80|81):/
+50067.0 "Curse Of The Fiend" sync / 1[56]:[^:]*:Adrammelech:4F7A:/
+50074.1 "Accursed Becoming" sync / 1[56]:[^:]*:Adrammelech:4F7B:/
+50081.3 "Stone IV/Aero IV/Thunder IV" sync / 1[56]:[^:]*:Adrammelech:4F(7F|80|81):/
 
-50091.4 "Burst II" sync / 1[56]:Adrammelech:4F8A:/
-50102.5 "Warped Light" sync / 1[56]:Adrammelech:4F8C:/
-50105.5 "Shock" sync / 1[56]:Adrammelech:4F8E:/
+50091.4 "Burst II" sync / 1[56]:[^:]*:Adrammelech:4F8A:/
+50102.5 "Warped Light" sync / 1[56]:[^:]*:Adrammelech:4F8C:/
+50105.5 "Shock" sync / 1[56]:[^:]*:Adrammelech:4F8E:/
 
-50116.0 "Curse Of The Fiend" sync / 1[56]:Adrammelech:4F7A:/
-50123.1 "Accursed Becoming" sync / 1[56]:Adrammelech:4F7B:/
-50130.3 "Orb 1" #sync / 1[56]:Adrammelech:(504D|504A|4F7D|4F8[5-7]):/
-50132.1 "Orb 2" #sync / 1[56]:Adrammelech:(504D|504A|4F7D|4F8[5-7]):/
+50116.0 "Curse Of The Fiend" sync / 1[56]:[^:]*:Adrammelech:4F7A:/
+50123.1 "Accursed Becoming" sync / 1[56]:[^:]*:Adrammelech:4F7B:/
+50130.3 "Orb 1" #sync / 1[56]:[^:]*:Adrammelech:(504D|504A|4F7D|4F8[5-7]):/
+50132.1 "Orb 2" #sync / 1[56]:[^:]*:Adrammelech:(504D|504A|4F7D|4F8[5-7]):/
 
-50144.3 "Tornado" sync / 1[56]:Adrammelech:4F8F:/
-50151.4 "Flare" sync / 1[56]:Adrammelech:4F95:/
-50160.5 "Holy IV" sync / 1[56]:Adrammelech:4F96:/
-50168.7 "Meteor" sync / 1[56]:Adrammelech:4F92:/ duration 20.7
+50144.3 "Tornado" sync / 1[56]:[^:]*:Adrammelech:4F8F:/
+50151.4 "Flare" sync / 1[56]:[^:]*:Adrammelech:4F95:/
+50160.5 "Holy IV" sync / 1[56]:[^:]*:Adrammelech:4F96:/
+50168.7 "Meteor" sync / 1[56]:[^:]*:Adrammelech:4F92:/ duration 20.7
 
 # HP push? I have seen Meteor and Tornado->Meteor all skipped.
-50194.3 "--sync--" sync / 14:Adrammelech:4F7A:/ window 70,20
-50197.3 "Curse Of The Fiend" sync / 1[56]:Adrammelech:4F7A:/
-50204.4 "Accursed Becoming" sync / 1[56]:Adrammelech:4F7B:/
-50211.6 "Orb 1" #sync / 1[56]:Adrammelech:(504D|504A|4F7D|4F8[5-7]):/
-50213.4 "Orb 2" #sync / 1[56]:Adrammelech:(504D|504A|4F7D|4F8[5-7]):/
-50213.5 "Accursed Becoming" sync / 1[56]:Adrammelech:4F7B:/
-50220.7 "Orb 3" #sync / 1[56]:Adrammelech:(504D|504A|4F7D|4F8[5-7]):/
-50222.5 "Orb 4" #sync / 1[56]:Adrammelech:(504D|504A|4F7D|4F8[5-7]):/
+50194.3 "--sync--" sync / 14:[^:]*:Adrammelech:4F7A:/ window 70,20
+50197.3 "Curse Of The Fiend" sync / 1[56]:[^:]*:Adrammelech:4F7A:/
+50204.4 "Accursed Becoming" sync / 1[56]:[^:]*:Adrammelech:4F7B:/
+50211.6 "Orb 1" #sync / 1[56]:[^:]*:Adrammelech:(504D|504A|4F7D|4F8[5-7]):/
+50213.4 "Orb 2" #sync / 1[56]:[^:]*:Adrammelech:(504D|504A|4F7D|4F8[5-7]):/
+50213.5 "Accursed Becoming" sync / 1[56]:[^:]*:Adrammelech:4F7B:/
+50220.7 "Orb 3" #sync / 1[56]:[^:]*:Adrammelech:(504D|504A|4F7D|4F8[5-7]):/
+50222.5 "Orb 4" #sync / 1[56]:[^:]*:Adrammelech:(504D|504A|4F7D|4F8[5-7]):/
 
-50230.7 "Flare" sync / 1[56]:Adrammelech:4F95:/
-50237.8 "Tornado" sync / 1[56]:Adrammelech:4F8F:/
-50244.9 "Meteor" sync / 1[56]:Adrammelech:4F92:/ duration 20.7
-50262.6 "Burst II" sync / 1[56]:Adrammelech:4F8A:/
-50273.8 "Warped Light" sync / 1[56]:Adrammelech:4F8C:/
-50276.8 "Shock" sync / 1[56]:Adrammelech:4F8E:/
-50288.0 "Holy IV" sync / 1[56]:Adrammelech:4F96:/
-50295.1 "Holy IV" sync / 1[56]:Adrammelech:4F96:/
-50304.2 "Flare" sync / 1[56]:Adrammelech:4F95:/
+50230.7 "Flare" sync / 1[56]:[^:]*:Adrammelech:4F95:/
+50237.8 "Tornado" sync / 1[56]:[^:]*:Adrammelech:4F8F:/
+50244.9 "Meteor" sync / 1[56]:[^:]*:Adrammelech:4F92:/ duration 20.7
+50262.6 "Burst II" sync / 1[56]:[^:]*:Adrammelech:4F8A:/
+50273.8 "Warped Light" sync / 1[56]:[^:]*:Adrammelech:4F8C:/
+50276.8 "Shock" sync / 1[56]:[^:]*:Adrammelech:4F8E:/
+50288.0 "Holy IV" sync / 1[56]:[^:]*:Adrammelech:4F96:/
+50295.1 "Holy IV" sync / 1[56]:[^:]*:Adrammelech:4F96:/
+50304.2 "Flare" sync / 1[56]:[^:]*:Adrammelech:4F95:/
 
-50316.7 "Curse Of The Fiend" sync / 1[56]:Adrammelech:4F7A:/
-50323.8 "Accursed Becoming" sync / 1[56]:Adrammelech:4F7B:/
-50331.0 "Orb 1" #sync / 1[56]:Adrammelech:(504D|504A|4F7D|4F8[5-7]):/
-50332.8 "Orb 2" #sync / 1[56]:Adrammelech:(504D|504A|4F7D|4F8[5-7]):/
-50332.9 "Accursed Becoming" sync / 1[56]:Adrammelech:4F7B:/
-50340.1 "Orb 3" #sync / 1[56]:Adrammelech:(504D|504A|4F7D|4F8[5-7]):/
-50341.9 "Orb 4" #sync / 1[56]:Adrammelech:(504D|504A|4F7D|4F8[5-7]):/
+50316.7 "Curse Of The Fiend" sync / 1[56]:[^:]*:Adrammelech:4F7A:/
+50323.8 "Accursed Becoming" sync / 1[56]:[^:]*:Adrammelech:4F7B:/
+50331.0 "Orb 1" #sync / 1[56]:[^:]*:Adrammelech:(504D|504A|4F7D|4F8[5-7]):/
+50332.8 "Orb 2" #sync / 1[56]:[^:]*:Adrammelech:(504D|504A|4F7D|4F8[5-7]):/
+50332.9 "Accursed Becoming" sync / 1[56]:[^:]*:Adrammelech:4F7B:/
+50340.1 "Orb 3" #sync / 1[56]:[^:]*:Adrammelech:(504D|504A|4F7D|4F8[5-7]):/
+50341.9 "Orb 4" #sync / 1[56]:[^:]*:Adrammelech:(504D|504A|4F7D|4F8[5-7]):/
 
 # Loop
 # TODO: if anybody ever finds the enrage, we can unroll this.
-50350.1 "Flare" sync / 1[56]:Adrammelech:4F95:/
-50357.2 "Tornado" sync / 1[56]:Adrammelech:4F8F:/ window 100,100 jump 50237.8
+50350.1 "Flare" sync / 1[56]:[^:]*:Adrammelech:4F95:/
+50357.2 "Tornado" sync / 1[56]:[^:]*:Adrammelech:4F8F:/ window 100,100 jump 50237.8
 50364.3 "Meteor"
 50382.0 "Burst II"
 50385.0 "Meteor"
@@ -276,28 +276,28 @@ hideall "--sync--"
 
 # Phase 1
 60000.0 "--sync--" sync / 00:0839::Majesty's Auspice will be sealed off/ window 100000,0
-60014.3 "Molting Plumage" sync / 1[56]:Dawon:517A:/
-60025.9 "Explosion" sync / 1[56]:Verdant Plume:5182:/
-60033.5 "Scratch" sync / 1[56]:Dawon:517B:/
-60042.1 "Fervid Pulse" sync / 1[56]:Dawon:5179:/
-60050.6 "Swooping Frenzy" sync / 1[56]:Dawon:5175:/
-60058.4 "Frigid Pulse" sync / 1[56]:Dawon:5178:/
-60067.9 "Ready x3" duration 4.1 #sync / 1[56]:Lyon The Beast King:5191:/
-60074.9 "Obey" sync / 1[56]:Dawon:517C:/
-60077.0 "Swooping Frenzy" sync / 1[56]:Dawon:517E:/
-60079.8 "Frigid Pulse/Fervid Pulse" sync / 1[56]:Dawon:51(7F|80):/
-60082.2 "Swooping Frenzy" sync / 1[56]:Dawon:517E:/
-60085.0 "Frigid Pulse/Fervid Pulse" sync / 1[56]:Dawon:51(7F|80):/
-60087.4 "Swooping Frenzy" sync / 1[56]:Dawon:517E:/
-60090.2 "Frigid Pulse/Fervid Pulse" sync / 1[56]:Dawon:51(7F|80):/
-60101.6 "Call Beast" sync / 1[56]:Lyon The Beast King:5192:/
-60107.6 "Molting Plumage" sync / 1[56]:Dawon:517A:/
-60119.2 "Explosion" sync / 1[56]:Verdant Plume:5182:/
-60128.9 "Pentagust" sync / 1[56]:Dawon:5176:/
-60139.6 "Scratch" sync / 1[56]:Dawon:517B:/
+60014.3 "Molting Plumage" sync / 1[56]:[^:]*:Dawon:517A:/
+60025.9 "Explosion" sync / 1[56]:[^:]*:Verdant Plume:5182:/
+60033.5 "Scratch" sync / 1[56]:[^:]*:Dawon:517B:/
+60042.1 "Fervid Pulse" sync / 1[56]:[^:]*:Dawon:5179:/
+60050.6 "Swooping Frenzy" sync / 1[56]:[^:]*:Dawon:5175:/
+60058.4 "Frigid Pulse" sync / 1[56]:[^:]*:Dawon:5178:/
+60067.9 "Ready x3" duration 4.1 #sync / 1[56]:[^:]*:Lyon The Beast King:5191:/
+60074.9 "Obey" sync / 1[56]:[^:]*:Dawon:517C:/
+60077.0 "Swooping Frenzy" sync / 1[56]:[^:]*:Dawon:517E:/
+60079.8 "Frigid Pulse/Fervid Pulse" sync / 1[56]:[^:]*:Dawon:51(7F|80):/
+60082.2 "Swooping Frenzy" sync / 1[56]:[^:]*:Dawon:517E:/
+60085.0 "Frigid Pulse/Fervid Pulse" sync / 1[56]:[^:]*:Dawon:51(7F|80):/
+60087.4 "Swooping Frenzy" sync / 1[56]:[^:]*:Dawon:517E:/
+60090.2 "Frigid Pulse/Fervid Pulse" sync / 1[56]:[^:]*:Dawon:51(7F|80):/
+60101.6 "Call Beast" sync / 1[56]:[^:]*:Lyon The Beast King:5192:/
+60107.6 "Molting Plumage" sync / 1[56]:[^:]*:Dawon:517A:/
+60119.2 "Explosion" sync / 1[56]:[^:]*:Verdant Plume:5182:/
+60128.9 "Pentagust" sync / 1[56]:[^:]*:Dawon:5176:/
+60139.6 "Scratch" sync / 1[56]:[^:]*:Dawon:517B:/
 
 # This only sometimes happens?? Is there a loop here?
-# 60158.4 "Call Beast" sync / 1[56]:Lyon The Beast King:5192:/
+# 60158.4 "Call Beast" sync / 1[56]:[^:]*:Lyon The Beast King:5192:/
 
 # Phase 2
 # Raging Winds starts and ends the phase, even if you win.
@@ -306,47 +306,47 @@ hideall "--sync--"
 # Regardless, everything seems to sync ok after that.
 # TODO: is there some way to isolate the top??
 60153.6 "--Lyon Passage--" # ??? double check this timing
-60166.5 "Raging Winds" sync / 1[56]:Lyon The Beast King:5164:/ window 100,20
-60172.6 "Winds' Peak" sync / 1[56]:Lyon The Beast King:516F:/
-60183.8 "Heart Of Nature" sync / 1[56]:Lyon The Beast King:515E:/
-60188.8 "Nature's Pulse" sync / 1[56]:Lyon The Beast King:5161:/
-60190.3 "Nature's Pulse" sync / 1[56]:Lyon The Beast King:5162:/
-60191.8 "Nature's Pulse" sync / 1[56]:Lyon The Beast King:5163:/
-60198.0 "Taste Of Blood" sync / 1[56]:Lyon The Beast King:5173:/
-60210.2 "Heart Of Nature" sync / 1[56]:Lyon The Beast King:515E:/ duration 6.6
-60218.2 "Nature's Blood" sync / 1[56]:Lyon The Beast King:515F:/
-60218.3 "Winds' Peak" sync / 1[56]:Lyon The Beast King:516F:/
-60228.4 "Twin Agonies" sync / 1[56]:Lyon The Beast King:5174:/
-60241.6 "Heart Of Nature" sync / 1[56]:Lyon The Beast King:515E:/ duration 6.6
-60248.7 "The King's Notice" sync / 1[56]:Lyon The Beast King:516E:/
-60249.6 "Nature's Blood" sync / 1[56]:Lyon The Beast King:515F:/
-60256.6 "Taste Of Blood" sync / 1[56]:Lyon The Beast King:5173:/
-60275.7 "Raging Winds Enrage" #sync / 1[56]:Lyon The Beast King:5164:/
+60166.5 "Raging Winds" sync / 1[56]:[^:]*:Lyon The Beast King:5164:/ window 100,20
+60172.6 "Winds' Peak" sync / 1[56]:[^:]*:Lyon The Beast King:516F:/
+60183.8 "Heart Of Nature" sync / 1[56]:[^:]*:Lyon The Beast King:515E:/
+60188.8 "Nature's Pulse" sync / 1[56]:[^:]*:Lyon The Beast King:5161:/
+60190.3 "Nature's Pulse" sync / 1[56]:[^:]*:Lyon The Beast King:5162:/
+60191.8 "Nature's Pulse" sync / 1[56]:[^:]*:Lyon The Beast King:5163:/
+60198.0 "Taste Of Blood" sync / 1[56]:[^:]*:Lyon The Beast King:5173:/
+60210.2 "Heart Of Nature" sync / 1[56]:[^:]*:Lyon The Beast King:515E:/ duration 6.6
+60218.2 "Nature's Blood" sync / 1[56]:[^:]*:Lyon The Beast King:515F:/
+60218.3 "Winds' Peak" sync / 1[56]:[^:]*:Lyon The Beast King:516F:/
+60228.4 "Twin Agonies" sync / 1[56]:[^:]*:Lyon The Beast King:5174:/
+60241.6 "Heart Of Nature" sync / 1[56]:[^:]*:Lyon The Beast King:515E:/ duration 6.6
+60248.7 "The King's Notice" sync / 1[56]:[^:]*:Lyon The Beast King:516E:/
+60249.6 "Nature's Blood" sync / 1[56]:[^:]*:Lyon The Beast King:515F:/
+60256.6 "Taste Of Blood" sync / 1[56]:[^:]*:Lyon The Beast King:5173:/
+60275.7 "Raging Winds Enrage" #sync / 1[56]:[^:]*:Lyon The Beast King:5164:/
 
 # Phase 3
-61000.0 "--sync--" sync / 14:Dawon:517D:/ window 1000,0
-61002.0 "Ready x4" duration 6.1 #sync / 1[56]:Lyon The Beast King:5191:/
-61012.0 "Obey" sync / 1[56]:Dawon:517D:/
-61014.1 "Swooping Frenzy" sync / 1[56]:Dawon:517E:/
-61016.9 "Frigid/Fervid Pulse" sync / 1[56]:Dawon:51(7F|80):/
-61019.3 "Swooping Frenzy" sync / 1[56]:Dawon:517E:/
-61022.1 "Frigid/Fervid Pulse" sync / 1[56]:Dawon:51(7F|80):/
-61024.5 "Swooping Frenzy" sync / 1[56]:Dawon:517E:/
-61027.3 "Frigid/Fervid Pulse" sync / 1[56]:Dawon:51(7F|80):/
-61029.7 "Swooping Frenzy" sync / 1[56]:Dawon:517E:/
-61032.5 "Frigid/Fervid Pulse" sync / 1[56]:Dawon:51(7F|80):/
+61000.0 "--sync--" sync / 14:[^:]*:Dawon:517D:/ window 1000,0
+61002.0 "Ready x4" duration 6.1 #sync / 1[56]:[^:]*:Lyon The Beast King:5191:/
+61012.0 "Obey" sync / 1[56]:[^:]*:Dawon:517D:/
+61014.1 "Swooping Frenzy" sync / 1[56]:[^:]*:Dawon:517E:/
+61016.9 "Frigid/Fervid Pulse" sync / 1[56]:[^:]*:Dawon:51(7F|80):/
+61019.3 "Swooping Frenzy" sync / 1[56]:[^:]*:Dawon:517E:/
+61022.1 "Frigid/Fervid Pulse" sync / 1[56]:[^:]*:Dawon:51(7F|80):/
+61024.5 "Swooping Frenzy" sync / 1[56]:[^:]*:Dawon:517E:/
+61027.3 "Frigid/Fervid Pulse" sync / 1[56]:[^:]*:Dawon:51(7F|80):/
+61029.7 "Swooping Frenzy" sync / 1[56]:[^:]*:Dawon:517E:/
+61032.5 "Frigid/Fervid Pulse" sync / 1[56]:[^:]*:Dawon:51(7F|80):/
 
-61042.9 "Call Beast" sync / 1[56]:Lyon The Beast King:5192:/
-61048.9 "Molting Plumage" sync / 1[56]:Dawon:517A:/
-61060.5 "Explosion" sync / 1[56]:Verdant Plume:5182:/
+61042.9 "Call Beast" sync / 1[56]:[^:]*:Lyon The Beast King:5192:/
+61048.9 "Molting Plumage" sync / 1[56]:[^:]*:Dawon:517A:/
+61060.5 "Explosion" sync / 1[56]:[^:]*:Verdant Plume:5182:/
 
-61070.0 "Swooping Frenzy" sync / 1[56]:Dawon:5175:/
-61075.8 "Pentagust" sync / 1[56]:Dawon:5176:/
-61087.5 "Scratch" sync / 1[56]:Dawon:517B:/
+61070.0 "Swooping Frenzy" sync / 1[56]:[^:]*:Dawon:5175:/
+61075.8 "Pentagust" sync / 1[56]:[^:]*:Dawon:5176:/
+61087.5 "Scratch" sync / 1[56]:[^:]*:Dawon:517B:/
 
 # Loop!
-61100.7 "Ready x4" duration 6.1 #sync / 1[56]:Lyon The Beast King:5191:/
-61110.7 "Obey" sync / 1[56]:Dawon:517D:/ window 90,90 jump 61012.0
+61100.7 "Ready x4" duration 6.1 #sync / 1[56]:[^:]*:Lyon The Beast King:5191:/
+61110.7 "Obey" sync / 1[56]:[^:]*:Dawon:517D:/ window 90,90 jump 61012.0
 61112.8 "Swooping Frenzy"
 61115.6 "Frigid/Fervid Pulse"
 61118.0 "Swooping Frenzy"

--- a/ui/raidboss/data/05-shb/eureka/delubrum_reginae.txt
+++ b/ui/raidboss/data/05-shb/eureka/delubrum_reginae.txt
@@ -21,190 +21,190 @@ hideall "--sync--"
 
 # Initial Merciful Air
 1000.0 "--sync--" sync / 00:0839::The Theater of One will be sealed off/ window 10000,0
-1012.2 "Verdant Tempest" sync / 1[56]:Trinity Seeker:5AB6:/
-1019.4 "First Mercy" sync / 1[56]:Trinity Seeker:5B5D:/
-1022.6 "Second Mercy" sync / 1[56]:Trinity Seeker:5B5E:/
-1025.8 "Third Mercy" sync / 1[56]:Trinity Seeker:5B5F:/
-1029.0 "Fourth Mercy" sync / 1[56]:Trinity Seeker:5B60:/
-1031.4 "Mercy Fourfold" #sync / 1[56]:Trinity Seeker:5B34:/
-1033.3 "Mercy Fourfold" #sync / 1[56]:Trinity Seeker:5B34:/
-1035.2 "Mercy Fourfold" #sync / 1[56]:Trinity Seeker:5B34:/
-1037.1 "Mercy Fourfold" #sync / 1[56]:Trinity Seeker:5B34:/
-1047.4 "Merciful Arc" sync / 1[56]:Trinity Seeker:5AB7:/
+1012.2 "Verdant Tempest" sync / 1[56]:[^:]*:Trinity Seeker:5AB6:/
+1019.4 "First Mercy" sync / 1[56]:[^:]*:Trinity Seeker:5B5D:/
+1022.6 "Second Mercy" sync / 1[56]:[^:]*:Trinity Seeker:5B5E:/
+1025.8 "Third Mercy" sync / 1[56]:[^:]*:Trinity Seeker:5B5F:/
+1029.0 "Fourth Mercy" sync / 1[56]:[^:]*:Trinity Seeker:5B60:/
+1031.4 "Mercy Fourfold" #sync / 1[56]:[^:]*:Trinity Seeker:5B34:/
+1033.3 "Mercy Fourfold" #sync / 1[56]:[^:]*:Trinity Seeker:5B34:/
+1035.2 "Mercy Fourfold" #sync / 1[56]:[^:]*:Trinity Seeker:5B34:/
+1037.1 "Mercy Fourfold" #sync / 1[56]:[^:]*:Trinity Seeker:5B34:/
+1047.4 "Merciful Arc" sync / 1[56]:[^:]*:Trinity Seeker:5AB7:/
 
 # Initial Baleful Air
-1056.5 "Verdant Path" sync / 1[56]:Trinity Seeker:5A98:/ window 80,80
-1064.1 "Baleful Swathe" sync / 1[56]:Trinity Seeker:5AB3:/
-1069.3 "--middle--" sync / 1[56]:Trinity Seeker:5A9A:/
-1078.4 "Baleful Blade" sync / 1[56]:Trinity Seeker:5AA1:/
-1086.6 "Phantom Edge" sync / 1[56]:Trinity Seeker:5AA0:/
-1096.7 "Baleful Blade" sync / 1[56]:Trinity Seeker:5AA2:/
-1107.8 "Verdant Tempest" sync / 1[56]:Trinity Seeker:5AB6:/
+1056.5 "Verdant Path" sync / 1[56]:[^:]*:Trinity Seeker:5A98:/ window 80,80
+1064.1 "Baleful Swathe" sync / 1[56]:[^:]*:Trinity Seeker:5AB3:/
+1069.3 "--middle--" sync / 1[56]:[^:]*:Trinity Seeker:5A9A:/
+1078.4 "Baleful Blade" sync / 1[56]:[^:]*:Trinity Seeker:5AA1:/
+1086.6 "Phantom Edge" sync / 1[56]:[^:]*:Trinity Seeker:5AA0:/
+1096.7 "Baleful Blade" sync / 1[56]:[^:]*:Trinity Seeker:5AA2:/
+1107.8 "Verdant Tempest" sync / 1[56]:[^:]*:Trinity Seeker:5AB6:/
 
 # Initial Iron Air
-1117.0 "Verdant Path" sync / 1[56]:Trinity Seeker:5A99:/ window 80,80
-1126.6 "Iron Impact" sync / 1[56]:Trinity Seeker:5ADB:/
-1131.6 "--jump--" sync / 1[56]:Trinity Seeker:5A9A:/
-1138.5 "Iron Splitter" sync / 1[56]:Trinity Seeker:5AA3:/
-1141.7 "--jump--" sync / 1[56]:Trinity Seeker:5A9A:/
-1148.6 "Iron Splitter" sync / 1[56]:Trinity Seeker:5AA3:/
-1159.7 "Verdant Tempest" sync / 1[56]:Trinity Seeker:5AB6:/
+1117.0 "Verdant Path" sync / 1[56]:[^:]*:Trinity Seeker:5A99:/ window 80,80
+1126.6 "Iron Impact" sync / 1[56]:[^:]*:Trinity Seeker:5ADB:/
+1131.6 "--jump--" sync / 1[56]:[^:]*:Trinity Seeker:5A9A:/
+1138.5 "Iron Splitter" sync / 1[56]:[^:]*:Trinity Seeker:5AA3:/
+1141.7 "--jump--" sync / 1[56]:[^:]*:Trinity Seeker:5A9A:/
+1148.6 "Iron Splitter" sync / 1[56]:[^:]*:Trinity Seeker:5AA3:/
+1159.7 "Verdant Tempest" sync / 1[56]:[^:]*:Trinity Seeker:5AB6:/
 1168.9 "Verdant Path" # -> baleful / merciful jump
 
 # (Baleful jump?)
-1168.9 "--sync--" sync / 1[56]:Trinity Seeker:5A98:/ jump 1300 window 80,80
-1176.5 "Baleful Swathe?" #sync / 1[56]:Trinity Seeker:5AB3:/
-1186.7 "Phantom Edge?" #sync / 1[56]:Trinity Seeker:5AA0:/
-1188.9 "--sync--" #sync / 1[56]:Trinity Seeker:5A9A:/
-1198.0 "Baleful Blade?" #sync / 1[56]:Trinity Seeker:5AA[12]:/
+1168.9 "--sync--" sync / 1[56]:[^:]*:Trinity Seeker:5A98:/ jump 1300 window 80,80
+1176.5 "Baleful Swathe?" #sync / 1[56]:[^:]*:Trinity Seeker:5AB3:/
+1186.7 "Phantom Edge?" #sync / 1[56]:[^:]*:Trinity Seeker:5AA0:/
+1188.9 "--sync--" #sync / 1[56]:[^:]*:Trinity Seeker:5A9A:/
+1198.0 "Baleful Blade?" #sync / 1[56]:[^:]*:Trinity Seeker:5AA[12]:/
 
 # (Merciful jump?)
-1168.9 "--sync--" sync / 1[56]:Trinity Seeker:5A97:/ jump 1500 window 80,80
-1176.5 "Act Of Mercy?" #sync / 1[56]:Trinity Seeker:5AB2:/
-1183.7 "First Mercy?" #sync / 1[56]:Trinity Seeker:5B5D:/
-1186.9 "Second Mercy?" #sync / 1[56]:Trinity Seeker:5B5E:/
-1190.1 "Third Mercy?" #sync / 1[56]:Trinity Seeker:5B5F:/
-1193.3 "Fourth Mercy?" #sync / 1[56]:Trinity Seeker:5B60:/
+1168.9 "--sync--" sync / 1[56]:[^:]*:Trinity Seeker:5A97:/ jump 1500 window 80,80
+1176.5 "Act Of Mercy?" #sync / 1[56]:[^:]*:Trinity Seeker:5AB2:/
+1183.7 "First Mercy?" #sync / 1[56]:[^:]*:Trinity Seeker:5B5D:/
+1186.9 "Second Mercy?" #sync / 1[56]:[^:]*:Trinity Seeker:5B5E:/
+1190.1 "Third Mercy?" #sync / 1[56]:[^:]*:Trinity Seeker:5B5F:/
+1193.3 "Fourth Mercy?" #sync / 1[56]:[^:]*:Trinity Seeker:5B60:/
 
 
 # Baleful Air v2 (randomized, with chains)
-1300.0 "Verdant Path" sync / 1[56]:Trinity Seeker:5A98:/
-1307.6 "Baleful Swathe" sync / 1[56]:Trinity Seeker:5AB3:/
-1317.8 "Phantom Edge?" sync / 1[56]:Trinity Seeker:5AA0:/
-1320.0 "--sync--" sync / 1[56]:Trinity Seeker:5A9A:/
-1329.1 "Baleful Blade" sync / 1[56]:Trinity Seeker:5AA[12]:/
-1339.3 "Phantom Edge?" sync / 1[56]:Trinity Seeker:5AA0:/
-1341.5 "--sync--" sync / 1[56]:Trinity Seeker:5A9A:/
-1350.6 "Baleful Blade" sync / 1[56]:Trinity Seeker:5AA[12]:/
-1361.7 "Verdant Tempest" sync / 1[56]:Trinity Seeker:5AB6:/
+1300.0 "Verdant Path" sync / 1[56]:[^:]*:Trinity Seeker:5A98:/
+1307.6 "Baleful Swathe" sync / 1[56]:[^:]*:Trinity Seeker:5AB3:/
+1317.8 "Phantom Edge?" sync / 1[56]:[^:]*:Trinity Seeker:5AA0:/
+1320.0 "--sync--" sync / 1[56]:[^:]*:Trinity Seeker:5A9A:/
+1329.1 "Baleful Blade" sync / 1[56]:[^:]*:Trinity Seeker:5AA[12]:/
+1339.3 "Phantom Edge?" sync / 1[56]:[^:]*:Trinity Seeker:5AA0:/
+1341.5 "--sync--" sync / 1[56]:[^:]*:Trinity Seeker:5A9A:/
+1350.6 "Baleful Blade" sync / 1[56]:[^:]*:Trinity Seeker:5AA[12]:/
+1361.7 "Verdant Tempest" sync / 1[56]:[^:]*:Trinity Seeker:5AB6:/
 1370.9 "Verdant Path" # -> iron / merciful jump
 
 # (Iron jump?)
-1370.9 "--sync--" sync / 1[56]:Trinity Seeker:5A99:/ jump 1700 window 80,80
-1380.5 "Iron Impact?" #sync / 1[56]:Trinity Seeker:5ADB:/
-1390.5 "Dead Iron?" #sync / 1[56]:Trinity Seeker:5AAF:/
-1397.7 "Dead Iron?" #sync / 1[56]:Trinity Seeker:5B44:/
+1370.9 "--sync--" sync / 1[56]:[^:]*:Trinity Seeker:5A99:/ jump 1700 window 80,80
+1380.5 "Iron Impact?" #sync / 1[56]:[^:]*:Trinity Seeker:5ADB:/
+1390.5 "Dead Iron?" #sync / 1[56]:[^:]*:Trinity Seeker:5AAF:/
+1397.7 "Dead Iron?" #sync / 1[56]:[^:]*:Trinity Seeker:5B44:/
 
 # (Merciful jump?)
-1370.9 "--sync--" sync / 1[56]:Trinity Seeker:5A97:/ jump 1500 window 80,80
-1378.5 "Act Of Mercy?" #sync / 1[56]:Trinity Seeker:5AB2:/
-1385.7 "First Mercy?" #sync / 1[56]:Trinity Seeker:5B5D:/
-1388.9 "Second Mercy?" #sync / 1[56]:Trinity Seeker:5B5E:/
-1392.1 "Third Mercy?" #sync / 1[56]:Trinity Seeker:5B5F:/
-1395.3 "Fourth Mercy?" #sync / 1[56]:Trinity Seeker:5B60:/
+1370.9 "--sync--" sync / 1[56]:[^:]*:Trinity Seeker:5A97:/ jump 1500 window 80,80
+1378.5 "Act Of Mercy?" #sync / 1[56]:[^:]*:Trinity Seeker:5AB2:/
+1385.7 "First Mercy?" #sync / 1[56]:[^:]*:Trinity Seeker:5B5D:/
+1388.9 "Second Mercy?" #sync / 1[56]:[^:]*:Trinity Seeker:5B5E:/
+1392.1 "Third Mercy?" #sync / 1[56]:[^:]*:Trinity Seeker:5B5F:/
+1395.3 "Fourth Mercy?" #sync / 1[56]:[^:]*:Trinity Seeker:5B60:/
 
 
 # Merciful Air v2 (with seasons of mercy))
-1500.0 "Verdant Path" sync / 1[56]:Trinity Seeker:5A97:/
-1507.6 "Act Of Mercy" sync / 1[56]:Trinity Seeker:5AB2:/
-1514.8 "First Mercy" sync / 1[56]:Trinity Seeker:5B5D:/
-1518.0 "Second Mercy" sync / 1[56]:Trinity Seeker:5B5E:/
-1521.2 "Third Mercy" sync / 1[56]:Trinity Seeker:5B5F:/
-1524.4 "Fourth Mercy" sync / 1[56]:Trinity Seeker:5B60:/
-1526.8 "Mercy Fourfold" #sync / 1[56]:Trinity Seeker:5B34:/
-1528.7 "Mercy Fourfold" #sync / 1[56]:Trinity Seeker:5B34:/
-1530.6 "Mercy Fourfold" #sync / 1[56]:Trinity Seeker:5B34:/
-1532.5 "Mercy Fourfold" #sync / 1[56]:Trinity Seeker:5B34:/
-1540.7 "Seasons Of Mercy" sync / 1[56]:Trinity Seeker:5AAA:/
-1545.2 "Merciful Breeze" sync / 1[56]:Trinity Seeker:5AAB:/
-1545.2 "Merciful Breeze" sync / 1[56]:Trinity Seeker:5AAB:/
-1547.7 "Merciful Moon" sync / 1[56]:Aetherial Orb:5AAC:/
-1549.3 "Merciful Breeze" sync / 1[56]:Trinity Seeker:5AAB:/
-1549.3 "Merciful Breeze" sync / 1[56]:Trinity Seeker:5AAB:/
-1552.7 "Merciful Blooms" sync / 1[56]:Trinity Seeker:5AAD:/
-1559.9 "Verdant Tempest" sync / 1[56]:Trinity Seeker:5AB6:/
-1569.1 "Merciful Arc" sync / 1[56]:Trinity Seeker:5AB7:/
+1500.0 "Verdant Path" sync / 1[56]:[^:]*:Trinity Seeker:5A97:/
+1507.6 "Act Of Mercy" sync / 1[56]:[^:]*:Trinity Seeker:5AB2:/
+1514.8 "First Mercy" sync / 1[56]:[^:]*:Trinity Seeker:5B5D:/
+1518.0 "Second Mercy" sync / 1[56]:[^:]*:Trinity Seeker:5B5E:/
+1521.2 "Third Mercy" sync / 1[56]:[^:]*:Trinity Seeker:5B5F:/
+1524.4 "Fourth Mercy" sync / 1[56]:[^:]*:Trinity Seeker:5B60:/
+1526.8 "Mercy Fourfold" #sync / 1[56]:[^:]*:Trinity Seeker:5B34:/
+1528.7 "Mercy Fourfold" #sync / 1[56]:[^:]*:Trinity Seeker:5B34:/
+1530.6 "Mercy Fourfold" #sync / 1[56]:[^:]*:Trinity Seeker:5B34:/
+1532.5 "Mercy Fourfold" #sync / 1[56]:[^:]*:Trinity Seeker:5B34:/
+1540.7 "Seasons Of Mercy" sync / 1[56]:[^:]*:Trinity Seeker:5AAA:/
+1545.2 "Merciful Breeze" sync / 1[56]:[^:]*:Trinity Seeker:5AAB:/
+1545.2 "Merciful Breeze" sync / 1[56]:[^:]*:Trinity Seeker:5AAB:/
+1547.7 "Merciful Moon" sync / 1[56]:[^:]*:Aetherial Orb:5AAC:/
+1549.3 "Merciful Breeze" sync / 1[56]:[^:]*:Trinity Seeker:5AAB:/
+1549.3 "Merciful Breeze" sync / 1[56]:[^:]*:Trinity Seeker:5AAB:/
+1552.7 "Merciful Blooms" sync / 1[56]:[^:]*:Trinity Seeker:5AAD:/
+1559.9 "Verdant Tempest" sync / 1[56]:[^:]*:Trinity Seeker:5AB6:/
+1569.1 "Merciful Arc" sync / 1[56]:[^:]*:Trinity Seeker:5AB7:/
 1576.2 "Verdant Path" # -> baleful / iron jump
 
 # (Baleful jump?)
-1576.2 "--sync--" sync / 1[56]:Trinity Seeker:5A98:/ jump 1300 window 80,80
-1583.8 "Baleful Swathe?" #sync / 1[56]:Trinity Seeker:5AB3:/
-1594.0 "Phantom Edge?" #sync / 1[56]:Trinity Seeker:5AA0:/
-1596.2 "--sync--" #sync / 1[56]:Trinity Seeker:5A9A:/
-1605.3 "Baleful Blade?" #sync / 1[56]:Trinity Seeker:5AA[12]:/
+1576.2 "--sync--" sync / 1[56]:[^:]*:Trinity Seeker:5A98:/ jump 1300 window 80,80
+1583.8 "Baleful Swathe?" #sync / 1[56]:[^:]*:Trinity Seeker:5AB3:/
+1594.0 "Phantom Edge?" #sync / 1[56]:[^:]*:Trinity Seeker:5AA0:/
+1596.2 "--sync--" #sync / 1[56]:[^:]*:Trinity Seeker:5A9A:/
+1605.3 "Baleful Blade?" #sync / 1[56]:[^:]*:Trinity Seeker:5AA[12]:/
 
 # (Iron jump?)
-1576.2 "--sync--" sync / 1[56]:Trinity Seeker:5A99:/ jump 1700 window 80,80
-1585.8 "Iron Impact?" #sync / 1[56]:Trinity Seeker:5ADB:/
-1595.8 "Dead Iron?" #sync / 1[56]:Trinity Seeker:5AAF:/
-1603.0 "Dead Iron?" #sync / 1[56]:Trinity Seeker:5B44:/
+1576.2 "--sync--" sync / 1[56]:[^:]*:Trinity Seeker:5A99:/ jump 1700 window 80,80
+1585.8 "Iron Impact?" #sync / 1[56]:[^:]*:Trinity Seeker:5ADB:/
+1595.8 "Dead Iron?" #sync / 1[56]:[^:]*:Trinity Seeker:5AAF:/
+1603.0 "Dead Iron?" #sync / 1[56]:[^:]*:Trinity Seeker:5B44:/
 
 
 # Iron Air v2 (with iron impact / dead iron)
-1700.0 "Verdant Path" sync / 1[56]:Trinity Seeker:5A99:/
-1709.6 "Iron Impact" sync / 1[56]:Trinity Seeker:5ADB:/
-1719.6 "Dead Iron" sync / 1[56]:Trinity Seeker:5AAF:/
-1726.8 "Dead Iron" sync / 1[56]:Trinity Seeker:5B44:/
-1732.0 "--sync--" sync / 1[56]:Trinity Seeker:5A9A:/
-1738.7 "Iron Splitter" sync / 1[56]:Trinity Seeker:5AA3:/
-1740.9 "--sync--" sync / 1[56]:Trinity Seeker:5A9A:/
-1747.0 "Iron Splitter" sync / 1[56]:Trinity Seeker:5AA3:/
-1758.1 "Verdant Tempest" sync / 1[56]:Trinity Seeker:5AB6:/
+1700.0 "Verdant Path" sync / 1[56]:[^:]*:Trinity Seeker:5A99:/
+1709.6 "Iron Impact" sync / 1[56]:[^:]*:Trinity Seeker:5ADB:/
+1719.6 "Dead Iron" sync / 1[56]:[^:]*:Trinity Seeker:5AAF:/
+1726.8 "Dead Iron" sync / 1[56]:[^:]*:Trinity Seeker:5B44:/
+1732.0 "--sync--" sync / 1[56]:[^:]*:Trinity Seeker:5A9A:/
+1738.7 "Iron Splitter" sync / 1[56]:[^:]*:Trinity Seeker:5AA3:/
+1740.9 "--sync--" sync / 1[56]:[^:]*:Trinity Seeker:5A9A:/
+1747.0 "Iron Splitter" sync / 1[56]:[^:]*:Trinity Seeker:5AA3:/
+1758.1 "Verdant Tempest" sync / 1[56]:[^:]*:Trinity Seeker:5AB6:/
 1767.3 "Verdant Path" # -> baleful / merciful jump
 
 # (Baleful jump?)
-1767.3 "--sync--" sync / 1[56]:Trinity Seeker:5A98:/ jump 1300 window 80,80
-1774.9 "Baleful Swathe?" #sync / 1[56]:Trinity Seeker:5AB3:/
-1785.1 "Phantom Edge?" #sync / 1[56]:Trinity Seeker:5AA0:/
-1787.3 "--sync--" #sync / 1[56]:Trinity Seeker:5A9A:/
-1796.4 "Baleful Blade?" #sync / 1[56]:Trinity Seeker:5AA[12]:/
+1767.3 "--sync--" sync / 1[56]:[^:]*:Trinity Seeker:5A98:/ jump 1300 window 80,80
+1774.9 "Baleful Swathe?" #sync / 1[56]:[^:]*:Trinity Seeker:5AB3:/
+1785.1 "Phantom Edge?" #sync / 1[56]:[^:]*:Trinity Seeker:5AA0:/
+1787.3 "--sync--" #sync / 1[56]:[^:]*:Trinity Seeker:5A9A:/
+1796.4 "Baleful Blade?" #sync / 1[56]:[^:]*:Trinity Seeker:5AA[12]:/
 
 # (Merciful jump?)
-1767.3 "--sync--" sync / 1[56]:Trinity Seeker:5A97:/ jump 1500 window 80,80
-1774.9 "Act Of Mercy?" #sync / 1[56]:Trinity Seeker:5AB2:/
-1782.1 "First Mercy?" #sync / 1[56]:Trinity Seeker:5B5D:/
-1785.3 "Second Mercy?" #sync / 1[56]:Trinity Seeker:5B5E:/
-1788.5 "Third Mercy?" #sync / 1[56]:Trinity Seeker:5B5F:/
-1791.7 "Fourth Mercy?" #sync / 1[56]:Trinity Seeker:5B60:/
+1767.3 "--sync--" sync / 1[56]:[^:]*:Trinity Seeker:5A97:/ jump 1500 window 80,80
+1774.9 "Act Of Mercy?" #sync / 1[56]:[^:]*:Trinity Seeker:5AB2:/
+1782.1 "First Mercy?" #sync / 1[56]:[^:]*:Trinity Seeker:5B5D:/
+1785.3 "Second Mercy?" #sync / 1[56]:[^:]*:Trinity Seeker:5B5E:/
+1788.5 "Third Mercy?" #sync / 1[56]:[^:]*:Trinity Seeker:5B5F:/
+1791.7 "Fourth Mercy?" #sync / 1[56]:[^:]*:Trinity Seeker:5B60:/
 
 
 ### Dahu
 # -p 5755:2023
 # -ii 575A 575C
 2000.0 "--sync--" sync / 00:0839::The Hall of Supplication will be sealed off/ window 10000,0
-2007.0 "--sync--" sync / 14:Dahu:576[12]:/ window 10,2
-2010.0 "Right-Sided Shockwave/Left-Sided Shockwave" #sync / 1[56]:Dahu:576[12]:/
-2012.6 "Left-Sided Shockwave/Right-Sided Shockwave" #sync / 1[56]:Dahu:576[12]:/
-2023.0 "Feral Howl" sync / 1[56]:Dahu:5755:/ window 30,10
-2033.4 "Firebreathe" sync / 1[56]:Dahu:5765:/
-2045.7 "--sync--" sync / 1[56]:Marchosias:5758:/
-2051.9 "Head Down" sync / 1[56]:Marchosias:5756:/
-2058.8 "Head Down" sync / 1[56]:Marchosias:5756:/
-2065.3 "Feral Howl" sync / 1[56]:Dahu:5755:/
-2068.8 "Hunter's Claw" sync / 1[56]:Marchosias:5757:/
-2075.5 "Firebreathe x5" sync / 1[56]:Dahu:5759:/ duration 8.7
-2091.5 "Reverberating Roar" sync / 1[56]:Dahu:575B:/
-2105.0 "Hot Charge" sync / 1[56]:Dahu:5764:/
-2109.8 "Hot Charge" sync / 1[56]:Dahu:5764:/
+2007.0 "--sync--" sync / 14:[^:]*:Dahu:576[12]:/ window 10,2
+2010.0 "Right-Sided Shockwave/Left-Sided Shockwave" #sync / 1[56]:[^:]*:Dahu:576[12]:/
+2012.6 "Left-Sided Shockwave/Right-Sided Shockwave" #sync / 1[56]:[^:]*:Dahu:576[12]:/
+2023.0 "Feral Howl" sync / 1[56]:[^:]*:Dahu:5755:/ window 30,10
+2033.4 "Firebreathe" sync / 1[56]:[^:]*:Dahu:5765:/
+2045.7 "--sync--" sync / 1[56]:[^:]*:Marchosias:5758:/
+2051.9 "Head Down" sync / 1[56]:[^:]*:Marchosias:5756:/
+2058.8 "Head Down" sync / 1[56]:[^:]*:Marchosias:5756:/
+2065.3 "Feral Howl" sync / 1[56]:[^:]*:Dahu:5755:/
+2068.8 "Hunter's Claw" sync / 1[56]:[^:]*:Marchosias:5757:/
+2075.5 "Firebreathe x5" sync / 1[56]:[^:]*:Dahu:5759:/ duration 8.7
+2091.5 "Reverberating Roar" sync / 1[56]:[^:]*:Dahu:575B:/
+2105.0 "Hot Charge" sync / 1[56]:[^:]*:Dahu:5764:/
+2109.8 "Hot Charge" sync / 1[56]:[^:]*:Dahu:5764:/
 
-2116.6 "Firebreathe" sync / 1[56]:Dahu:5765:/
-2129.8 "--sync--" sync / 1[56]:Marchosias:5758:/
-2130.8 "Reverberating Roar" sync / 1[56]:Dahu:575B:/
-2136.1 "Head Down" sync / 1[56]:Marchosias:5756:/
-2142.8 "Head Down" sync / 1[56]:Marchosias:5756:/
-2149.0 "Right-Sided Shockwave/Left-Sided Shockwave" #sync / 1[56]:Dahu:576[12]:/
-2149.5 "Head Down" sync / 1[56]:Marchosias:5756:/
-2151.5 "Left-Sided Shockwave/Right-Sided Shockwave" #sync / 1[56]:Dahu:576[12]:/
-2156.2 "Head Down" sync / 1[56]:Marchosias:5756:/
-2162.7 "Feral Howl" sync / 1[56]:Dahu:5755:/
-2166.2 "Hunter's Claw" sync / 1[56]:Marchosias:5757:/
-2172.9 "Firebreathe x5" sync / 1[56]:Dahu:5759:/
-2195.1 "Heat Breath" sync / 1[56]:Dahu:5766:/
-2205.7 "Tail Swing" sync / 1[56]:Dahu:575F:/
-2217.9 "Reverberating Roar" sync / 1[56]:Dahu:575B:/
-2231.8 "Hot Charge" sync / 1[56]:Dahu:5764:/
-2236.7 "Hot Charge" sync / 1[56]:Dahu:5764:/
+2116.6 "Firebreathe" sync / 1[56]:[^:]*:Dahu:5765:/
+2129.8 "--sync--" sync / 1[56]:[^:]*:Marchosias:5758:/
+2130.8 "Reverberating Roar" sync / 1[56]:[^:]*:Dahu:575B:/
+2136.1 "Head Down" sync / 1[56]:[^:]*:Marchosias:5756:/
+2142.8 "Head Down" sync / 1[56]:[^:]*:Marchosias:5756:/
+2149.0 "Right-Sided Shockwave/Left-Sided Shockwave" #sync / 1[56]:[^:]*:Dahu:576[12]:/
+2149.5 "Head Down" sync / 1[56]:[^:]*:Marchosias:5756:/
+2151.5 "Left-Sided Shockwave/Right-Sided Shockwave" #sync / 1[56]:[^:]*:Dahu:576[12]:/
+2156.2 "Head Down" sync / 1[56]:[^:]*:Marchosias:5756:/
+2162.7 "Feral Howl" sync / 1[56]:[^:]*:Dahu:5755:/
+2166.2 "Hunter's Claw" sync / 1[56]:[^:]*:Marchosias:5757:/
+2172.9 "Firebreathe x5" sync / 1[56]:[^:]*:Dahu:5759:/
+2195.1 "Heat Breath" sync / 1[56]:[^:]*:Dahu:5766:/
+2205.7 "Tail Swing" sync / 1[56]:[^:]*:Dahu:575F:/
+2217.9 "Reverberating Roar" sync / 1[56]:[^:]*:Dahu:575B:/
+2231.8 "Hot Charge" sync / 1[56]:[^:]*:Dahu:5764:/
+2236.7 "Hot Charge" sync / 1[56]:[^:]*:Dahu:5764:/
 
-2243.6 "Firebreathe" sync / 1[56]:Dahu:5765:/ window 50,50 jump 2116.6
-2256.8 "--sync--" #sync / 1[56]:Marchosias:5758:/
-2257.8 "Reverberating Roar" #sync / 1[56]:Dahu:575B:/
-2263.1 "Head Down" #sync / 1[56]:Marchosias:5756:/
-2269.8 "Head Down" #sync / 1[56]:Marchosias:5756:/
-2276.0 "Right-Sided Shockwave/Left-Sided Shockwave" #sync / 1[56]:Dahu:576[12]:/
-2276.5 "Head Down" #sync / 1[56]:#Marchosias:5756:/
-2278.5 "Left-Sided Shockwave/Right-Sided Shockwave" #sync / 1[56]:Dahu:576[12]:/
-2283.2 "Head Down" #sync / 1[56]:Marchosias:5756:/
-2289.7 "Feral Howl" #sync / 1[56]:Dahu:5755:/
+2243.6 "Firebreathe" sync / 1[56]:[^:]*:Dahu:5765:/ window 50,50 jump 2116.6
+2256.8 "--sync--" #sync / 1[56]:[^:]*:Marchosias:5758:/
+2257.8 "Reverberating Roar" #sync / 1[56]:[^:]*:Dahu:575B:/
+2263.1 "Head Down" #sync / 1[56]:[^:]*:Marchosias:5756:/
+2269.8 "Head Down" #sync / 1[56]:[^:]*:Marchosias:5756:/
+2276.0 "Right-Sided Shockwave/Left-Sided Shockwave" #sync / 1[56]:[^:]*:Dahu:576[12]:/
+2276.5 "Head Down" #sync / 1[56]:[^:]*:#Marchosias:5756:/
+2278.5 "Left-Sided Shockwave/Right-Sided Shockwave" #sync / 1[56]:[^:]*:Dahu:576[12]:/
+2283.2 "Head Down" #sync / 1[56]:[^:]*:Marchosias:5756:/
+2289.7 "Feral Howl" #sync / 1[56]:[^:]*:Dahu:5755:/
 
 
 ### Queen's Guard
@@ -215,7 +215,7 @@ hideall "--sync--"
 
 3000.0 "--sync--" sync / 00:0839::The Hall of Hieromancy will be sealed off/ window 10000,0
 # ranged auto should be reasonably timed
-3002.5 "--sync--" sync / 1[56]:Queen's Gunner:5857:/ window 3,1
+3002.5 "--sync--" sync / 1[56]:[^:]*:Queen's Gunner:5857:/ window 3,1
 # can't sync this untargetable as the mobs will hop away sooner if they are damaged enough.
 3025.7 "--untargetable--"
 3028.7 "--targetable--"
@@ -226,143 +226,143 @@ hideall "--sync--"
 # We can't have huge syncs on these because many of these are used
 # multiple times.  So, 22 lines get huge syncs and ability lines
 # get more local windows here and in each block.
-3036.8 "--sync--" sync / 14:Queen's Soldier:5805:/ window 50,50 jump 3108.1
-3039.8 "Double Gambit?" #sync / 1[56]:Queen's Soldier:5805:/
+3036.8 "--sync--" sync / 14:[^:]*:Queen's Soldier:5805:/ window 50,50 jump 3108.1
+3039.8 "Double Gambit?" #sync / 1[56]:[^:]*:Queen's Soldier:5805:/
 
-3036.8 "--sync--" sync / 14:Queen's Gunner:580B:/ window 50,50 jump 3308.1
-3039.8 "Automatic Turret?" #sync / 1[56]:Queen's Gunner:580B:/
+3036.8 "--sync--" sync / 14:[^:]*:Queen's Gunner:580B:/ window 50,50 jump 3308.1
+3039.8 "Automatic Turret?" #sync / 1[56]:[^:]*:Queen's Gunner:580B:/
 
-3036.8 "--sync--" sync / 14:Queen's Warrior:5AFD:/ window 50,50 jump 3508.1
-3039.8 "Bombslinger?" #sync / 1[56]:Queen's Warrior:5AFD:/
+3036.8 "--sync--" sync / 14:[^:]*:Queen's Warrior:5AFD:/ window 50,50 jump 3508.1
+3039.8 "Bombslinger?" #sync / 1[56]:[^:]*:Queen's Warrior:5AFD:/
 
-3036.8 "--sync--" sync / 14:Queen's Knight:57F[01]:/ window 50,50 jump 3708.1
-3039.8 "Shield Omen/Sword Omen?" #sync / 1[56]:Queen's Knight:57F[01]:/
+3036.8 "--sync--" sync / 14:[^:]*:Queen's Knight:57F[01]:/ window 50,50 jump 3708.1
+3039.8 "Shield Omen/Sword Omen?" #sync / 1[56]:[^:]*:Queen's Knight:57F[01]:/
 
 # Queen's Soldier
 # (local jumps to other blocks)
-3100.0 "--sync--" sync / 14:Queen's Gunner:580B:/ window 0,200 jump 3308.1
-3100.0 "--sync--" sync / 14:Queen's Warrior:5AFD:/ window 0,200 jump 3508.1
-3100.0 "--sync--" sync / 14:Queen's Knight:57F[01]:/ window 0,200 jump 3708.1
+3100.0 "--sync--" sync / 14:[^:]*:Queen's Gunner:580B:/ window 0,200 jump 3308.1
+3100.0 "--sync--" sync / 14:[^:]*:Queen's Warrior:5AFD:/ window 0,200 jump 3508.1
+3100.0 "--sync--" sync / 14:[^:]*:Queen's Knight:57F[01]:/ window 0,200 jump 3708.1
 
 3100.0 "--targetable--" sync / 22:........:Queen's Soldier:........:Queen's Soldier:01/ window 500,500
-3108.1 "--sync--" sync / 14:Queen's Soldier:5805:/ window 10,10
-3111.1 "Double Gambit" sync / 1[56]:Queen's Soldier:5805:/
-3119.3 "Secrets Revealed" sync / 1[56]:Queen's Soldier:5B6E:/
-3130.6 "Pawn Off" sync / 1[56]:Soldier Avatar:5807:/
-3142.4 "Rapid Sever" sync / 1[56]:Queen's Soldier:5809:/
+3108.1 "--sync--" sync / 14:[^:]*:Queen's Soldier:5805:/ window 10,10
+3111.1 "Double Gambit" sync / 1[56]:[^:]*:Queen's Soldier:5805:/
+3119.3 "Secrets Revealed" sync / 1[56]:[^:]*:Queen's Soldier:5B6E:/
+3130.6 "Pawn Off" sync / 1[56]:[^:]*:Soldier Avatar:5807:/
+3142.4 "Rapid Sever" sync / 1[56]:[^:]*:Queen's Soldier:5809:/
 
-3149.6 "Double Gambit" sync / 1[56]:Queen's Soldier:5805:/
-3157.8 "Secrets Revealed" sync / 1[56]:Queen's Soldier:5B6E:/
-3175.2 "Pawn Off" sync / 1[56]:Soldier Avatar:5807:/
-3187.0 "Blood And Bone" sync / 1[56]:Queen's Soldier:5808:/
-3197.2 "Rapid Sever" sync / 1[56]:Queen's Soldier:5809:/
+3149.6 "Double Gambit" sync / 1[56]:[^:]*:Queen's Soldier:5805:/
+3157.8 "Secrets Revealed" sync / 1[56]:[^:]*:Queen's Soldier:5B6E:/
+3175.2 "Pawn Off" sync / 1[56]:[^:]*:Soldier Avatar:5807:/
+3187.0 "Blood And Bone" sync / 1[56]:[^:]*:Queen's Soldier:5808:/
+3197.2 "Rapid Sever" sync / 1[56]:[^:]*:Queen's Soldier:5809:/
 
 # (probably a loop, as this has more jumping)
-3204.5 "Double Gambit" sync / 1[56]:Queen's Soldier:5805:/ window 30,30 jump 3149.6
-3212.7 "Secrets Revealed" #sync / 1[56]:Queen's Soldier:5B6E:/
-3230.1 "Pawn Off" #sync / 1[56]:Soldier Avatar:5807:/
-3241.9 "Blood And Bone" #sync / 1[56]:Queen's Soldier:5808:/
-3252.1 "Rapid Sever" #sync / 1[56]:Queen's Soldier:5809:/
+3204.5 "Double Gambit" sync / 1[56]:[^:]*:Queen's Soldier:5805:/ window 30,30 jump 3149.6
+3212.7 "Secrets Revealed" #sync / 1[56]:[^:]*:Queen's Soldier:5B6E:/
+3230.1 "Pawn Off" #sync / 1[56]:[^:]*:Soldier Avatar:5807:/
+3241.9 "Blood And Bone" #sync / 1[56]:[^:]*:Queen's Soldier:5808:/
+3252.1 "Rapid Sever" #sync / 1[56]:[^:]*:Queen's Soldier:5809:/
 
 # Queen's Gunner
 # (local jumps to other blocks)
-3300.0 "--sync--" sync / 14:Queen's Soldier:5805:/ window 0,200 jump 3108.1
-3300.0 "--sync--" sync / 14:Queen's Warrior:5AFD:/ window 0,200 jump 3508.1
-3300.0 "--sync--" sync / 14:Queen's Knight:57F[01]:/ window 0,200 jump 3708.1
+3300.0 "--sync--" sync / 14:[^:]*:Queen's Soldier:5805:/ window 0,200 jump 3108.1
+3300.0 "--sync--" sync / 14:[^:]*:Queen's Warrior:5AFD:/ window 0,200 jump 3508.1
+3300.0 "--sync--" sync / 14:[^:]*:Queen's Knight:57F[01]:/ window 0,200 jump 3708.1
 
 3300.0 "--targetable--" sync / 22:........:Queen's Gunner:........:Queen's Gunner:01/ window 500,500
-3308.1 "--sync--" sync / 14:Queen's Gunner:580B:/ window 10,10
-3311.1 "Automatic Turret" sync / 1[56]:Queen's Gunner:580B:/
-3319.2 "Turret's Tour" sync / 1[56]:Queen's Gunner:580C:/
-3319.8 "Turret's Tour" sync / 1[56]:Automatic Turret:580E:/
-3320.3 "Turret's Tour" sync / 1[56]:Automatic Turret:580F:/
+3308.1 "--sync--" sync / 14:[^:]*:Queen's Gunner:580B:/ window 10,10
+3311.1 "Automatic Turret" sync / 1[56]:[^:]*:Queen's Gunner:580B:/
+3319.2 "Turret's Tour" sync / 1[56]:[^:]*:Queen's Gunner:580C:/
+3319.8 "Turret's Tour" sync / 1[56]:[^:]*:Automatic Turret:580E:/
+3320.3 "Turret's Tour" sync / 1[56]:[^:]*:Automatic Turret:580F:/
 
-3329.3 "Queen's Shot" sync / 1[56]:Queen's Gunner:5810:/
-3337.4 "Automatic Turret" sync / 1[56]:Queen's Gunner:580B:/
-3345.6 "Turret's Tour" sync / 1[56]:Queen's Gunner:580C:/
-3346.2 "Turret's Tour" sync / 1[56]:Automatic Turret:580E:/
-3355.7 "Shot In The Dark" sync / 1[56]:Queen's Gunner:5811:/
+3329.3 "Queen's Shot" sync / 1[56]:[^:]*:Queen's Gunner:5810:/
+3337.4 "Automatic Turret" sync / 1[56]:[^:]*:Queen's Gunner:580B:/
+3345.6 "Turret's Tour" sync / 1[56]:[^:]*:Queen's Gunner:580C:/
+3346.2 "Turret's Tour" sync / 1[56]:[^:]*:Automatic Turret:580E:/
+3355.7 "Shot In The Dark" sync / 1[56]:[^:]*:Queen's Gunner:5811:/
 
 # (probably a loop?)
-3364.9 "Queen's Shot" sync / 1[56]:Queen's Gunner:5810:/ window 20,20 jump 3329.3
-3373.0 "Automatic Turret" #sync / 1[56]:Queen's Gunner:580B:/
-3381.2 "Turret's Tour" #sync / 1[56]:Queen's Gunner:580C:/
-3381.8 "Turret's Tour" #sync / 1[56]:Automatic Turret:580E:/
-3391.3 "Shot In The Dark" #sync / 1[56]:Queen's Gunner:5811:/
+3364.9 "Queen's Shot" sync / 1[56]:[^:]*:Queen's Gunner:5810:/ window 20,20 jump 3329.3
+3373.0 "Automatic Turret" #sync / 1[56]:[^:]*:Queen's Gunner:580B:/
+3381.2 "Turret's Tour" #sync / 1[56]:[^:]*:Queen's Gunner:580C:/
+3381.8 "Turret's Tour" #sync / 1[56]:[^:]*:Automatic Turret:580E:/
+3391.3 "Shot In The Dark" #sync / 1[56]:[^:]*:Queen's Gunner:5811:/
 
 # Queen's Warrior
 # (local jumps to other blocks)
-3500.0 "--sync--" sync / 14:Queen's Soldier:5805:/ window 0,200 jump 3108.1
-3500.0 "--sync--" sync / 14:Queen's Gunner:580B:/ window 0,200 jump 3308.1
-3500.0 "--sync--" sync / 14:Queen's Knight:57F[01]:/ window 0,200 jump 3708.1
+3500.0 "--sync--" sync / 14:[^:]*:Queen's Soldier:5805:/ window 0,200 jump 3108.1
+3500.0 "--sync--" sync / 14:[^:]*:Queen's Gunner:580B:/ window 0,200 jump 3308.1
+3500.0 "--sync--" sync / 14:[^:]*:Queen's Knight:57F[01]:/ window 0,200 jump 3708.1
 
 3500.0 "--targetable--" sync / 22:........:Queen's Warrior:........:Queen's Warrior:01/ window 500,500
-3508.1 "--sync--" sync / 14:Queen's Warrior:5AFD:/ window 10,10
-3511.1 "Bombslinger" sync / 1[56]:Queen's Warrior:5AFD:/
-3520.2 "Above Board" sync / 1[56]:Queen's Warrior:57FC:/
+3508.1 "--sync--" sync / 14:[^:]*:Queen's Warrior:5AFD:/ window 10,10
+3511.1 "Bombslinger" sync / 1[56]:[^:]*:Queen's Warrior:5AFD:/
+3520.2 "Above Board" sync / 1[56]:[^:]*:Queen's Warrior:57FC:/
 3521.2 "--stunned--"
-3523.2 "Lots Cast" sync / 1[56]:Aetherial Burst:5B6B:/
-3526.2 "Lots Cast" sync / 1[56]:Aetherial Bolt:5B6A:/
+3523.2 "Lots Cast" sync / 1[56]:[^:]*:Aetherial Burst:5B6B:/
+3526.2 "Lots Cast" sync / 1[56]:[^:]*:Aetherial Bolt:5B6A:/
 3527.9 "--unstunned--"
 
-3536.5 "Bombslinger" sync / 1[56]:Queen's Warrior:5AFD:/ window 10,10
-3543.6 "Reversal Of Forces" sync / 1[56]:Queen's Warrior:57FF:/
-3552.7 "Above Board" sync / 1[56]:Queen's Warrior:57FC:/
+3536.5 "Bombslinger" sync / 1[56]:[^:]*:Queen's Warrior:5AFD:/ window 10,10
+3543.6 "Reversal Of Forces" sync / 1[56]:[^:]*:Queen's Warrior:57FF:/
+3552.7 "Above Board" sync / 1[56]:[^:]*:Queen's Warrior:57FC:/
 3553.7 "--stunned--"
-3555.7 "Lots Cast" sync / 1[56]:Aetherial Bolt:57FE:/
-3558.7 "Lots Cast" sync / 1[56]:Aetherial Burst:57FD:/
+3555.7 "Lots Cast" sync / 1[56]:[^:]*:Aetherial Bolt:57FE:/
+3558.7 "Lots Cast" sync / 1[56]:[^:]*:Aetherial Burst:57FD:/
 3559.4 "--unstunned--"
-3567.8 "Blood And Bone" sync / 1[56]:Queen's Warrior:5800:/
-3578.0 "Blood And Bone" sync / 1[56]:Queen's Warrior:5800:/
+3567.8 "Blood And Bone" sync / 1[56]:[^:]*:Queen's Warrior:5800:/
+3578.0 "Blood And Bone" sync / 1[56]:[^:]*:Queen's Warrior:5800:/
 
 # FIXME: is this a loop back to the beginning?
 # The Bombslinger/Above Board timings don't seem like there can fit
 # an optional Reversal Of Forces here, but not clear if this is random.
-3586.2 "Bombslinger" sync / 1[56]:Queen's Warrior:5AFD:/ window 30,30 jump 3511.1
-3595.3 "Above Board" #sync / 1[56]:Queen's Warrior:57FC:/
+3586.2 "Bombslinger" sync / 1[56]:[^:]*:Queen's Warrior:5AFD:/ window 30,30 jump 3511.1
+3595.3 "Above Board" #sync / 1[56]:[^:]*:Queen's Warrior:57FC:/
 3596.3 "--stunned--"
-3598.3 "Lots Cast" #sync / 1[56]:Aetherial Burst:5B6B:/
-3601.3 "Lots Cast" #sync / 1[56]:Aetherial Bolt:5B6A:/
+3598.3 "Lots Cast" #sync / 1[56]:[^:]*:Aetherial Burst:5B6B:/
+3601.3 "Lots Cast" #sync / 1[56]:[^:]*:Aetherial Bolt:5B6A:/
 3603.0 "--unstunned--"
-3614.6 "Bombslinger" #sync / 1[56]:Queen's Warrior:5AFD:/
-3621.7 "Reversal Of Forces" #sync / 1[56]:Queen's Warrior:57FF:/
+3614.6 "Bombslinger" #sync / 1[56]:[^:]*:Queen's Warrior:5AFD:/
+3621.7 "Reversal Of Forces" #sync / 1[56]:[^:]*:Queen's Warrior:57FF:/
 
 # Queen's Knight
 # (local jumps to other blocks)
-3700.0 "--sync--" sync / 14:Queen's Soldier:5805:/ window 0,200 jump 3108.1
-3700.0 "--sync--" sync / 14:Queen's Gunner:580B:/ window 0,200 jump 3308.1
-3700.0 "--sync--" sync / 14:Queen's Warrior:5AFD:/ window 0,200 jump 3508.1
+3700.0 "--sync--" sync / 14:[^:]*:Queen's Soldier:5805:/ window 0,200 jump 3108.1
+3700.0 "--sync--" sync / 14:[^:]*:Queen's Gunner:580B:/ window 0,200 jump 3308.1
+3700.0 "--sync--" sync / 14:[^:]*:Queen's Warrior:5AFD:/ window 0,200 jump 3508.1
 
 3700.0 "--targetable--" sync / 22:........:Queen's Knight:........:Queen's Knight:01/ window 500,500
-3708.1 "--sync--" sync / 14:Queen's Knight:57F[01]:/ window 10,10
-3711.1 "Shield Omen/Sword Omen" sync / 1[56]:Queen's Knight:57F[01]:/
-3719.3 "Optimal Play" sync / 1[56]:Queen's Knight:57F4:/
-3727.5 "Sword Omen/Shield Omen" sync / 1[56]:Queen's Knight:57F[01]:/
-3735.7 "Optimal Play" sync / 1[56]:Queen's Knight:57F4:/
+3708.1 "--sync--" sync / 14:[^:]*:Queen's Knight:57F[01]:/ window 10,10
+3711.1 "Shield Omen/Sword Omen" sync / 1[56]:[^:]*:Queen's Knight:57F[01]:/
+3719.3 "Optimal Play" sync / 1[56]:[^:]*:Queen's Knight:57F4:/
+3727.5 "Sword Omen/Shield Omen" sync / 1[56]:[^:]*:Queen's Knight:57F[01]:/
+3735.7 "Optimal Play" sync / 1[56]:[^:]*:Queen's Knight:57F4:/
 
-3746.9 "Rapid Sever" sync / 1[56]:Queen's Knight:57FB:/
-3756.1 "Blood And Bone" sync / 1[56]:Queen's Knight:57FA:/
-3764.3 "Shield Omen/Sword Omen" sync / 1[56]:Queen's Knight:57F[01]:/
-3772.5 "Optimal Play" sync / 1[56]:Queen's Knight:57F4:/
-3780.7 "Sword Omen/Shield Omen" sync / 1[56]:Queen's Knight:57F[01]:/
-3788.9 "Optimal Play" sync / 1[56]:Queen's Knight:57F4:/
+3746.9 "Rapid Sever" sync / 1[56]:[^:]*:Queen's Knight:57FB:/
+3756.1 "Blood And Bone" sync / 1[56]:[^:]*:Queen's Knight:57FA:/
+3764.3 "Shield Omen/Sword Omen" sync / 1[56]:[^:]*:Queen's Knight:57F[01]:/
+3772.5 "Optimal Play" sync / 1[56]:[^:]*:Queen's Knight:57F4:/
+3780.7 "Sword Omen/Shield Omen" sync / 1[56]:[^:]*:Queen's Knight:57F[01]:/
+3788.9 "Optimal Play" sync / 1[56]:[^:]*:Queen's Knight:57F4:/
 
 # (maybe a loop?)
-3800.1 "Rapid Sever" sync / 1[56]:Queen's Knight:57FB:/ window 30,30 jump 3746.9
-3809.3 "Blood And Bone" #sync / 1[56]:Queen's Knight:57FA:/
-3817.5 "Shield Omen/Sword Omen" #sync / 1[56]:Queen's Knight:57F[01]:/
-3825.7 "Optimal Play" #sync / 1[56]:Queen's Knight:57F4:/
-3833.9 "Sword Omen/Shield Omen" #sync / 1[56]:Queen's Knight:57F[01]:/
-3842.1 "Optimal Play" #sync / 1[56]:Queen's Knight:57F4:/
+3800.1 "Rapid Sever" sync / 1[56]:[^:]*:Queen's Knight:57FB:/ window 30,30 jump 3746.9
+3809.3 "Blood And Bone" #sync / 1[56]:[^:]*:Queen's Knight:57FA:/
+3817.5 "Shield Omen/Sword Omen" #sync / 1[56]:[^:]*:Queen's Knight:57F[01]:/
+3825.7 "Optimal Play" #sync / 1[56]:[^:]*:Queen's Knight:57F4:/
+3833.9 "Sword Omen/Shield Omen" #sync / 1[56]:[^:]*:Queen's Knight:57F[01]:/
+3842.1 "Optimal Play" #sync / 1[56]:[^:]*:Queen's Knight:57F4:/
 
 # Aetherial Warded Knights
-4000.0 "--sync--" sync / 14:Queen's Knight:57F5:/ window 1000,0
-4005.0 "Strongpoint Defense" sync / 1[56]:Queen's Knight:57F5:/
+4000.0 "--sync--" sync / 14:[^:]*:Queen's Knight:57F5:/ window 1000,0
+4005.0 "Strongpoint Defense" sync / 1[56]:[^:]*:Queen's Knight:57F5:/
 # 60s enrage cast of 5812, 580A, 5802, 57F9
-4008.0 "Enrage Cast" sync / 14:Queen's Gunner:5812:/ duration 60
-4018.8 "Coat Of Arms" sync / 1[56]:Aetherial Ward:57F6:/
-4036.0 "Coat Of Arms" sync / 1[56]:Aetherial Ward:57F6:/
-4053.1 "Coat Of Arms" sync / 1[56]:Aetherial Ward:57F6:/
+4008.0 "Enrage Cast" sync / 14:[^:]*:Queen's Gunner:5812:/ duration 60
+4018.8 "Coat Of Arms" sync / 1[56]:[^:]*:Aetherial Ward:57F6:/
+4036.0 "Coat Of Arms" sync / 1[56]:[^:]*:Aetherial Ward:57F6:/
+4053.1 "Coat Of Arms" sync / 1[56]:[^:]*:Aetherial Ward:57F6:/
 4068.0 "Enrage"
 
 
@@ -372,159 +372,159 @@ hideall "--sync--"
 5000.0 "--sync--" sync / 00:0839::Pride of the Lion will be sealed off/ window 10000,0
 
 # one circle, one square
-5008.3 "--sync--" sync / 14:Bozjan Phantom:57A3:/ window 10,10
-5011.3 "Weave Miasma" sync / 1[56]:Bozjan Phantom:57A3:/
-5025.5 "Manipulate Miasma" sync / 1[56]:Bozjan Phantom:57A4:/
-5026.5 "Swirling Miasma 1" sync / 1[56]:Bozjan Phantom:57A9:/
-5028.1 "Swirling Miasma 2" #sync / 1[56]:Bozjan Phantom:57AA:/
-5029.7 "Swirling Miasma 3" #sync / 1[56]:Bozjan Phantom:57AA:/
-5030.5 "Creeping Miasma" sync / 1[56]:Bozjan Phantom:57A5:/
-5031.3 "Swirling Miasma 4" #sync / 1[56]:Bozjan Phantom:57AA:/
-5032.9 "Swirling Miasma 5" #sync / 1[56]:Bozjan Phantom:57AA:/
-5034.5 "Swirling Miasma 6" #sync / 1[56]:Bozjan Phantom:57AA:/
-5036.1 "Swirling Miasma 7" #sync / 1[56]:Bozjan Phantom:57AA:/
-5037.7 "Swirling Miasma 8" #sync / 1[56]:Bozjan Phantom:57AA:/
+5008.3 "--sync--" sync / 14:[^:]*:Bozjan Phantom:57A3:/ window 10,10
+5011.3 "Weave Miasma" sync / 1[56]:[^:]*:Bozjan Phantom:57A3:/
+5025.5 "Manipulate Miasma" sync / 1[56]:[^:]*:Bozjan Phantom:57A4:/
+5026.5 "Swirling Miasma 1" sync / 1[56]:[^:]*:Bozjan Phantom:57A9:/
+5028.1 "Swirling Miasma 2" #sync / 1[56]:[^:]*:Bozjan Phantom:57AA:/
+5029.7 "Swirling Miasma 3" #sync / 1[56]:[^:]*:Bozjan Phantom:57AA:/
+5030.5 "Creeping Miasma" sync / 1[56]:[^:]*:Bozjan Phantom:57A5:/
+5031.3 "Swirling Miasma 4" #sync / 1[56]:[^:]*:Bozjan Phantom:57AA:/
+5032.9 "Swirling Miasma 5" #sync / 1[56]:[^:]*:Bozjan Phantom:57AA:/
+5034.5 "Swirling Miasma 6" #sync / 1[56]:[^:]*:Bozjan Phantom:57AA:/
+5036.1 "Swirling Miasma 7" #sync / 1[56]:[^:]*:Bozjan Phantom:57AA:/
+5037.7 "Swirling Miasma 8" #sync / 1[56]:[^:]*:Bozjan Phantom:57AA:/
 
 # two circles, two squares
-5038.6 "Malediction Of Agony" sync / 1[56]:Bozjan Phantom:57AF:/
-5049.8 "Weave Miasma" sync / 1[56]:Bozjan Phantom:57A3:/
-5064.0 "Manipulate Miasma" sync / 1[56]:Bozjan Phantom:57A4:/
-5065.0 "Swirling Miasma 1" sync / 1[56]:Bozjan Phantom:57A9:/
-5066.6 "Swirling Miasma 2" #sync / 1[56]:Bozjan Phantom:57AA:/
-5068.2 "Swirling Miasma 3" #sync / 1[56]:Bozjan Phantom:57AA:/
-5069.0 "Creeping Miasma" sync / 1[56]:Bozjan Phantom:57A5:/
-5069.8 "Swirling Miasma 4" #sync / 1[56]:Bozjan Phantom:57AA:/
-5071.4 "Swirling Miasma 5" #sync / 1[56]:Bozjan Phantom:57AA:/
-5073.0 "Swirling Miasma 6" #sync / 1[56]:Bozjan Phantom:57AA:/
-5074.6 "Swirling Miasma 7" #sync / 1[56]:Bozjan Phantom:57AA:/
-5076.2 "Swirling Miasma 8" #sync / 1[56]:Bozjan Phantom:57AA:/
+5038.6 "Malediction Of Agony" sync / 1[56]:[^:]*:Bozjan Phantom:57AF:/
+5049.8 "Weave Miasma" sync / 1[56]:[^:]*:Bozjan Phantom:57A3:/
+5064.0 "Manipulate Miasma" sync / 1[56]:[^:]*:Bozjan Phantom:57A4:/
+5065.0 "Swirling Miasma 1" sync / 1[56]:[^:]*:Bozjan Phantom:57A9:/
+5066.6 "Swirling Miasma 2" #sync / 1[56]:[^:]*:Bozjan Phantom:57AA:/
+5068.2 "Swirling Miasma 3" #sync / 1[56]:[^:]*:Bozjan Phantom:57AA:/
+5069.0 "Creeping Miasma" sync / 1[56]:[^:]*:Bozjan Phantom:57A5:/
+5069.8 "Swirling Miasma 4" #sync / 1[56]:[^:]*:Bozjan Phantom:57AA:/
+5071.4 "Swirling Miasma 5" #sync / 1[56]:[^:]*:Bozjan Phantom:57AA:/
+5073.0 "Swirling Miasma 6" #sync / 1[56]:[^:]*:Bozjan Phantom:57AA:/
+5074.6 "Swirling Miasma 7" #sync / 1[56]:[^:]*:Bozjan Phantom:57AA:/
+5076.2 "Swirling Miasma 8" #sync / 1[56]:[^:]*:Bozjan Phantom:57AA:/
 
 # learn about knockbacks
-5083.1 "Summon" sync / 1[56]:Bozjan Phantom:57AB:/
-5095.2 "Undying Hatred" sync / 1[56]:Stuffy Wraith:57AC:/
-5096.3 "Transference" sync / 1[56]:Bozjan Phantom:57AD:/
-5103.5 "Vile Wave" sync / 1[56]:Bozjan Phantom:57B1:/
+5083.1 "Summon" sync / 1[56]:[^:]*:Bozjan Phantom:57AB:/
+5095.2 "Undying Hatred" sync / 1[56]:[^:]*:Stuffy Wraith:57AC:/
+5096.3 "Transference" sync / 1[56]:[^:]*:Bozjan Phantom:57AD:/
+5103.5 "Vile Wave" sync / 1[56]:[^:]*:Bozjan Phantom:57B1:/
 
 # knockback into weave miasma
-5114.7 "Weave Miasma" sync / 1[56]:Bozjan Phantom:57A3:/
-5120.8 "Summon" sync / 1[56]:Bozjan Phantom:57AB:/
-5132.9 "Undying Hatred" sync / 1[56]:Stuffy Wraith:57AC:/
-5137.0 "Manipulate Miasma" sync / 1[56]:Bozjan Phantom:57A4:/
-5138.0 "Swirling Miasma 1" sync / 1[56]:Bozjan Phantom:57A9:/
-5139.6 "Swirling Miasma 2" #sync / 1[56]:Bozjan Phantom:57AA:/
-5141.2 "Swirling Miasma 3" #sync / 1[56]:Bozjan Phantom:57AA:/
-5142.0 "Creeping Miasma" sync / 1[56]:Bozjan Phantom:57A5:/
-5142.8 "Swirling Miasma 4" #sync / 1[56]:Bozjan Phantom:57AA:/
-5144.4 "Swirling Miasma 5" #sync / 1[56]:Bozjan Phantom:57AA:/
-5146.0 "Swirling Miasma 6" #sync / 1[56]:Bozjan Phantom:57AA:/
-5147.1 "Transference" sync / 1[56]:Bozjan Phantom:57AD:/
-5147.6 "Swirling Miasma 7" #sync / 1[56]:Bozjan Phantom:57AA:/
-5149.2 "Swirling Miasma 8" #sync / 1[56]:Bozjan Phantom:57AA:/
-5154.4 "Vile Wave" sync / 1[56]:Bozjan Phantom:57B1:/
+5114.7 "Weave Miasma" sync / 1[56]:[^:]*:Bozjan Phantom:57A3:/
+5120.8 "Summon" sync / 1[56]:[^:]*:Bozjan Phantom:57AB:/
+5132.9 "Undying Hatred" sync / 1[56]:[^:]*:Stuffy Wraith:57AC:/
+5137.0 "Manipulate Miasma" sync / 1[56]:[^:]*:Bozjan Phantom:57A4:/
+5138.0 "Swirling Miasma 1" sync / 1[56]:[^:]*:Bozjan Phantom:57A9:/
+5139.6 "Swirling Miasma 2" #sync / 1[56]:[^:]*:Bozjan Phantom:57AA:/
+5141.2 "Swirling Miasma 3" #sync / 1[56]:[^:]*:Bozjan Phantom:57AA:/
+5142.0 "Creeping Miasma" sync / 1[56]:[^:]*:Bozjan Phantom:57A5:/
+5142.8 "Swirling Miasma 4" #sync / 1[56]:[^:]*:Bozjan Phantom:57AA:/
+5144.4 "Swirling Miasma 5" #sync / 1[56]:[^:]*:Bozjan Phantom:57AA:/
+5146.0 "Swirling Miasma 6" #sync / 1[56]:[^:]*:Bozjan Phantom:57AA:/
+5147.1 "Transference" sync / 1[56]:[^:]*:Bozjan Phantom:57AD:/
+5147.6 "Swirling Miasma 7" #sync / 1[56]:[^:]*:Bozjan Phantom:57AA:/
+5149.2 "Swirling Miasma 8" #sync / 1[56]:[^:]*:Bozjan Phantom:57AA:/
+5154.4 "Vile Wave" sync / 1[56]:[^:]*:Bozjan Phantom:57B1:/
 
-5162.5 "Malediction Of Agony" sync / 1[56]:Bozjan Phantom:57AF:/
-5175.7 "Excruciation" sync / 1[56]:Bozjan Phantom:57B0:/
-5184.8 "Malediction Of Agony" sync / 1[56]:Bozjan Phantom:57AF:/
-5191.9 "Malediction Of Agony" sync / 1[56]:Bozjan Phantom:57AF:/
+5162.5 "Malediction Of Agony" sync / 1[56]:[^:]*:Bozjan Phantom:57AF:/
+5175.7 "Excruciation" sync / 1[56]:[^:]*:Bozjan Phantom:57B0:/
+5184.8 "Malediction Of Agony" sync / 1[56]:[^:]*:Bozjan Phantom:57AF:/
+5191.9 "Malediction Of Agony" sync / 1[56]:[^:]*:Bozjan Phantom:57AF:/
 
 # loop
-5205.1 "Weave Miasma" sync / 1[56]:Bozjan Phantom:57A3:/ window 50,50 jump 5114.7
-5211.2 "Summon" #sync / 1[56]:Bozjan Phantom:57AB:/
-5223.3 "Undying Hatred" #sync / 1[56]:Stuffy Wraith:57AC:/
-5227.4 "Manipulate Miasma" #sync / 1[56]:Bozjan Phantom:57A4:/
-5228.4 "Swirling Miasma 1" #sync / 1[56]:Bozjan Phantom:57A9:/
-5230.0 "Swirling Miasma 2" #sync / 1[56]:Bozjan Phantom:57AA:/
-5231.6 "Swirling Miasma 3" #sync / 1[56]:Bozjan Phantom:57AA:/
-5232.4 "Creeping Miasma" #sync / 1[56]:Bozjan Phantom:57A5:/
-5233.2 "Swirling Miasma 4" #sync / 1[56]:Bozjan Phantom:57AA:/
-5234.8 "Swirling Miasma 5" #sync / 1[56]:Bozjan Phantom:57AA:/
-5236.4 "Swirling Miasma 6" #sync / 1[56]:Bozjan Phantom:57AA:/
+5205.1 "Weave Miasma" sync / 1[56]:[^:]*:Bozjan Phantom:57A3:/ window 50,50 jump 5114.7
+5211.2 "Summon" #sync / 1[56]:[^:]*:Bozjan Phantom:57AB:/
+5223.3 "Undying Hatred" #sync / 1[56]:[^:]*:Stuffy Wraith:57AC:/
+5227.4 "Manipulate Miasma" #sync / 1[56]:[^:]*:Bozjan Phantom:57A4:/
+5228.4 "Swirling Miasma 1" #sync / 1[56]:[^:]*:Bozjan Phantom:57A9:/
+5230.0 "Swirling Miasma 2" #sync / 1[56]:[^:]*:Bozjan Phantom:57AA:/
+5231.6 "Swirling Miasma 3" #sync / 1[56]:[^:]*:Bozjan Phantom:57AA:/
+5232.4 "Creeping Miasma" #sync / 1[56]:[^:]*:Bozjan Phantom:57A5:/
+5233.2 "Swirling Miasma 4" #sync / 1[56]:[^:]*:Bozjan Phantom:57AA:/
+5234.8 "Swirling Miasma 5" #sync / 1[56]:[^:]*:Bozjan Phantom:57AA:/
+5236.4 "Swirling Miasma 6" #sync / 1[56]:[^:]*:Bozjan Phantom:57AA:/
 
 
 ### Trinity Avowed
 # -p 5975:7013
 # -ii 5962 4F55 4F99 5B24 5968 4F56 4F9A 5964 5969 5965 5967 596A 596C
 7000.0 "--sync--" sync / 00:0839::The Vault of Singing Crystal will be sealed off/ window 10000,0
-7008.0 "--sync--" sync / 14:Trinity Avowed:5975:/ window 10,10
-7013.0 "Wrath Of Bozja" sync / 1[56]:Trinity Avowed:5975:/
-7021.1 "Glory Of Bozja" sync / 1[56]:Trinity Avowed:5976:/
-7029.3 "Allegiant Arsenal" sync / 1[56]:Trinity Avowed:5987:/
-7037.5 "Fury Of Bozja" sync / 1[56]:Trinity Avowed:5973:/
+7008.0 "--sync--" sync / 14:[^:]*:Trinity Avowed:5975:/ window 10,10
+7013.0 "Wrath Of Bozja" sync / 1[56]:[^:]*:Trinity Avowed:5975:/
+7021.1 "Glory Of Bozja" sync / 1[56]:[^:]*:Trinity Avowed:5976:/
+7029.3 "Allegiant Arsenal" sync / 1[56]:[^:]*:Trinity Avowed:5987:/
+7037.5 "Fury Of Bozja" sync / 1[56]:[^:]*:Trinity Avowed:5973:/
 
 # meteors, 1 level of temperature
-7046.8 "Hot And Cold" sync / 1[56]:Trinity Avowed:597B:/
-7053.9 "Freedom Of Bozja" sync / 1[56]:Trinity Avowed:597C:/
-7061.1 "Elemental Impact" sync / 1[56]:Swirling Orb:5960:/
-7070.1 "Elemental Blast" sync / 1[56]:Blazing Orb:5966:/
-7077.0 "--sync--" sync / 1[56]:Trinity Avowed:5984:/
+7046.8 "Hot And Cold" sync / 1[56]:[^:]*:Trinity Avowed:597B:/
+7053.9 "Freedom Of Bozja" sync / 1[56]:[^:]*:Trinity Avowed:597C:/
+7061.1 "Elemental Impact" sync / 1[56]:[^:]*:Swirling Orb:5960:/
+7070.1 "Elemental Blast" sync / 1[56]:[^:]*:Blazing Orb:5966:/
+7077.0 "--sync--" sync / 1[56]:[^:]*:Trinity Avowed:5984:/
 
-7087.5 "Allegiant Arsenal" sync / 1[56]:Trinity Avowed:5986:/
-7095.7 "Flashvane" sync / 1[56]:Trinity Avowed:5972:/
+7087.5 "Allegiant Arsenal" sync / 1[56]:[^:]*:Trinity Avowed:5986:/
+7095.7 "Flashvane" sync / 1[56]:[^:]*:Trinity Avowed:5972:/
 
 # swords, 1 level of temperature
-7103.9 "Flames Of Bozja" sync / 1[56]:Trinity Avowed:597E:/ duration 8
-7112.0 "--sync--" sync / 1[56]:Trinity Avowed:5B39:/
-7117.1 "Hot And Cold" sync / 1[56]:Trinity Avowed:5BB0:/
-7124.9 "Shimmering Shot" sync / 1[56]:Trinity Avowed:597F:/
-7139.2 "Elemental Arrow" sync / 1[56]:Frost Arrow:596B:/
-7147.8 "--sync--" sync / 1[56]:Trinity Avowed:5983:/
+7103.9 "Flames Of Bozja" sync / 1[56]:[^:]*:Trinity Avowed:597E:/ duration 8
+7112.0 "--sync--" sync / 1[56]:[^:]*:Trinity Avowed:5B39:/
+7117.1 "Hot And Cold" sync / 1[56]:[^:]*:Trinity Avowed:5BB0:/
+7124.9 "Shimmering Shot" sync / 1[56]:[^:]*:Trinity Avowed:597F:/
+7139.2 "Elemental Arrow" sync / 1[56]:[^:]*:Frost Arrow:596B:/
+7147.8 "--sync--" sync / 1[56]:[^:]*:Trinity Avowed:5983:/
 
-7154.9 "Glory Of Bozja" sync / 1[56]:Trinity Avowed:5976:/
-7168.1 "Allegiant Arsenal" sync / 1[56]:Trinity Avowed:5985:/
-7176.3 "Infernal Slash" sync / 1[56]:Trinity Avowed:5971:/
+7154.9 "Glory Of Bozja" sync / 1[56]:[^:]*:Trinity Avowed:5976:/
+7168.1 "Allegiant Arsenal" sync / 1[56]:[^:]*:Trinity Avowed:5985:/
+7176.3 "Infernal Slash" sync / 1[56]:[^:]*:Trinity Avowed:5971:/
 
 # cleaves, 2 levels of temperature
-7182.5 "Hot And Cold" sync / 1[56]:Trinity Avowed:5BAF:/
-7193.7 "Blade Of Entropy" sync / 1[56]:Trinity Avowed:(5B6[5-8]|596[D-F]|5970):/
-7201.9 "Blade Of Entropy" sync / 1[56]:Trinity Avowed:(5B6[5-8]|596[D-F]|5970):/
-7210.0 "Blade Of Entropy" sync / 1[56]:Trinity Avowed:(5B6[5-8]|596[D-F]|5970):/
-7218.2 "Blade Of Entropy" sync / 1[56]:Trinity Avowed:(5B6[5-8]|596[D-F]|5970):/
+7182.5 "Hot And Cold" sync / 1[56]:[^:]*:Trinity Avowed:5BAF:/
+7193.7 "Blade Of Entropy" sync / 1[56]:[^:]*:Trinity Avowed:(5B6[5-8]|596[D-F]|5970):/
+7201.9 "Blade Of Entropy" sync / 1[56]:[^:]*:Trinity Avowed:(5B6[5-8]|596[D-F]|5970):/
+7210.0 "Blade Of Entropy" sync / 1[56]:[^:]*:Trinity Avowed:(5B6[5-8]|596[D-F]|5970):/
+7218.2 "Blade Of Entropy" sync / 1[56]:[^:]*:Trinity Avowed:(5B6[5-8]|596[D-F]|5970):/
 
-7221.3 "--sync--" sync / 1[56]:Trinity Avowed:5982:/
-7227.4 "Unseen Eye" sync / 1[56]:Trinity Avowed:5980:/
-7238.7 "Gleaming Arrow" sync / 1[56]:Avowed Avatar:5974:/
+7221.3 "--sync--" sync / 1[56]:[^:]*:Trinity Avowed:5982:/
+7227.4 "Unseen Eye" sync / 1[56]:[^:]*:Trinity Avowed:5980:/
+7238.7 "Gleaming Arrow" sync / 1[56]:[^:]*:Avowed Avatar:5974:/
 
-7246.3 "Wrath Of Bozja" sync / 1[56]:Trinity Avowed:5975:/
-7254.4 "Glory Of Bozja" sync / 1[56]:Trinity Avowed:5976:/
-7264.8 "Allegiant Arsenal" sync / 1[56]:Trinity Avowed:5987:/
-7273.0 "Fury Of Bozja" sync / 1[56]:Trinity Avowed:5973:/
+7246.3 "Wrath Of Bozja" sync / 1[56]:[^:]*:Trinity Avowed:5975:/
+7254.4 "Glory Of Bozja" sync / 1[56]:[^:]*:Trinity Avowed:5976:/
+7264.8 "Allegiant Arsenal" sync / 1[56]:[^:]*:Trinity Avowed:5987:/
+7273.0 "Fury Of Bozja" sync / 1[56]:[^:]*:Trinity Avowed:5973:/
 
 # meteors, 2 levels of temperature
-7279.2 "Hot And Cold" sync / 1[56]:Trinity Avowed:597B:/
-7286.3 "Freedom Of Bozja" sync / 1[56]:Trinity Avowed:597C:/
-7293.5 "Elemental Impact" sync / 1[56]:Tempestuous Orb:5960:/
-7302.5 "Heated Blast" sync / 1[56]:Blazing Orb:5966:/
+7279.2 "Hot And Cold" sync / 1[56]:[^:]*:Trinity Avowed:597B:/
+7286.3 "Freedom Of Bozja" sync / 1[56]:[^:]*:Trinity Avowed:597C:/
+7293.5 "Elemental Impact" sync / 1[56]:[^:]*:Tempestuous Orb:5960:/
+7302.5 "Heated Blast" sync / 1[56]:[^:]*:Blazing Orb:5966:/
 
-7304.9 "Unseen Eye" sync / 1[56]:Trinity Avowed:5980:/
-7316.2 "Gleaming Arrow" sync / 1[56]:Avowed Avatar:5974:/
-7318.7 "--sync--" sync / 1[56]:Trinity Avowed:5984:/
-7325.8 "Glory Of Bozja" sync / 1[56]:Trinity Avowed:5976:/
-7334.2 "Wrath Of Bozja" sync / 1[56]:Trinity Avowed:5975:/
-7345.1 "Allegiant Arsenal" sync / 1[56]:Trinity Avowed:5986:/
-7353.3 "Flashvane" sync / 1[56]:Trinity Avowed:5972:/
-7359.5 "Unseen Eye" sync / 1[56]:Trinity Avowed:5BB4:/
-7370.8 "Gleaming Arrow" sync / 1[56]:Avowed Avatar:5974:/
-7370.8 "Flames Of Bozja" sync / 1[56]:Trinity Avowed:597E:/ duration 8
-7379.0 "--sync--" sync / 1[56]:Trinity Avowed:5B39:/
+7304.9 "Unseen Eye" sync / 1[56]:[^:]*:Trinity Avowed:5980:/
+7316.2 "Gleaming Arrow" sync / 1[56]:[^:]*:Avowed Avatar:5974:/
+7318.7 "--sync--" sync / 1[56]:[^:]*:Trinity Avowed:5984:/
+7325.8 "Glory Of Bozja" sync / 1[56]:[^:]*:Trinity Avowed:5976:/
+7334.2 "Wrath Of Bozja" sync / 1[56]:[^:]*:Trinity Avowed:5975:/
+7345.1 "Allegiant Arsenal" sync / 1[56]:[^:]*:Trinity Avowed:5986:/
+7353.3 "Flashvane" sync / 1[56]:[^:]*:Trinity Avowed:5972:/
+7359.5 "Unseen Eye" sync / 1[56]:[^:]*:Trinity Avowed:5BB4:/
+7370.8 "Gleaming Arrow" sync / 1[56]:[^:]*:Avowed Avatar:5974:/
+7370.8 "Flames Of Bozja" sync / 1[56]:[^:]*:Trinity Avowed:597E:/ duration 8
+7379.0 "--sync--" sync / 1[56]:[^:]*:Trinity Avowed:5B39:/
 
 # swords, 2 levels of temperature
-7383.8 "Hot And Cold" sync / 1[56]:Trinity Avowed:5BB0:/
-7391.4 "Shimmering Shot" sync / 1[56]:Trinity Avowed:597F:/
-7405.7 "Elemental Arrow" sync / 1[56]:Frost Arrow:596B:/
-7411.0 "--sync--" sync / 1[56]:Trinity Avowed:5983:/
+7383.8 "Hot And Cold" sync / 1[56]:[^:]*:Trinity Avowed:5BB0:/
+7391.4 "Shimmering Shot" sync / 1[56]:[^:]*:Trinity Avowed:597F:/
+7405.7 "Elemental Arrow" sync / 1[56]:[^:]*:Frost Arrow:596B:/
+7411.0 "--sync--" sync / 1[56]:[^:]*:Trinity Avowed:5983:/
 
-7418.1 "Glory Of Bozja" sync / 1[56]:Trinity Avowed:5976:/
-7426.4 "Wrath Of Bozja" sync / 1[56]:Trinity Avowed:5975:/
-7434.5 "Glory Of Bozja" sync / 1[56]:Trinity Avowed:5976:/
-7449.7 "Allegiant Arsenal" sync / 1[56]:Trinity Avowed:5985:/
-7457.8 "Infernal Slash" sync / 1[56]:Trinity Avowed:5971:/
+7418.1 "Glory Of Bozja" sync / 1[56]:[^:]*:Trinity Avowed:5976:/
+7426.4 "Wrath Of Bozja" sync / 1[56]:[^:]*:Trinity Avowed:5975:/
+7434.5 "Glory Of Bozja" sync / 1[56]:[^:]*:Trinity Avowed:5976:/
+7449.7 "Allegiant Arsenal" sync / 1[56]:[^:]*:Trinity Avowed:5985:/
+7457.8 "Infernal Slash" sync / 1[56]:[^:]*:Trinity Avowed:5971:/
 
 # (probably a loop, back to cleaves, 2 levels of temperature)
-7463.9 "Hot And Cold" sync / 1[56]:Trinity Avowed:5BAF:/ window 100,100 jump 7182.5
-7475.1 "Blade Of Entropy" #sync / 1[56]:Trinity Avowed:(5B6[5-8]|596[D-F]|5970):/
-7483.3 "Blade Of Entropy" #sync / 1[56]:Trinity Avowed:(5B6[5-8]|596[D-F]|5970):/
-7491.4 "Blade Of Entropy" #sync / 1[56]:Trinity Avowed:(5B6[5-8]|596[D-F]|5970):/
-7499.6 "Blade Of Entropy" #sync / 1[56]:Trinity Avowed:(5B6[5-8]|596[D-F]|5970):/
+7463.9 "Hot And Cold" sync / 1[56]:[^:]*:Trinity Avowed:5BAF:/ window 100,100 jump 7182.5
+7475.1 "Blade Of Entropy" #sync / 1[56]:[^:]*:Trinity Avowed:(5B6[5-8]|596[D-F]|5970):/
+7483.3 "Blade Of Entropy" #sync / 1[56]:[^:]*:Trinity Avowed:(5B6[5-8]|596[D-F]|5970):/
+7491.4 "Blade Of Entropy" #sync / 1[56]:[^:]*:Trinity Avowed:(5B6[5-8]|596[D-F]|5970):/
+7499.6 "Blade Of Entropy" #sync / 1[56]:[^:]*:Trinity Avowed:(5B6[5-8]|596[D-F]|5970):/
 
 
 ### The Queen
@@ -532,101 +532,101 @@ hideall "--sync--"
 # -p 59C8:9015.5
 # -ii 5B83 5B82 59E0 59E2 59DA 59CC 5B40 59CD 5B8D
 9000.0 "--sync--" sync / 00:0839::Queensheart will be sealed off/ window 10000,0
-9010.5 "--sync--" sync / 14:The Queen:59C8:/ window 15,15
-9015.5 "Empyrean Iniquity" sync / 1[56]:The Queen:59C8:/
-9025.7 "Cleansing Slash" sync / 1[56]:The Queen:59C5:/
-9036.0 "--middle--" sync / 1[56]:The Queen:5BCB:/
+9010.5 "--sync--" sync / 14:[^:]*:The Queen:59C8:/ window 15,15
+9015.5 "Empyrean Iniquity" sync / 1[56]:[^:]*:The Queen:59C8:/
+9025.7 "Cleansing Slash" sync / 1[56]:[^:]*:The Queen:59C5:/
+9036.0 "--middle--" sync / 1[56]:[^:]*:The Queen:5BCB:/
 
-9044.2 "Queen's Will" sync / 1[56]:The Queen:59B9:/
-9052.4 "Beck And Call To Arms" sync / 1[56]:The Queen:5B99:/
-9056.7 "The Means" sync / 1[56]:(Queen's Gunner|Queen's Warrior):59B[BD]:/
-9056.7 "The Ends" sync / 1[56]:(Queen's Soldier|Queen's Knight):59B[AC]:/
+9044.2 "Queen's Will" sync / 1[56]:[^:]*:The Queen:59B9:/
+9052.4 "Beck And Call To Arms" sync / 1[56]:[^:]*:The Queen:5B99:/
+9056.7 "The Means" sync / 1[56]:[^:]*:(Queen's Gunner|Queen's Warrior):59B[BD]:/
+9056.7 "The Ends" sync / 1[56]:[^:]*:(Queen's Soldier|Queen's Knight):59B[AC]:/
 
-9066.6 "Empyrean Iniquity" sync / 1[56]:The Queen:59C8:/
-9074.8 "--middle--" sync / 1[56]:The Queen:5BCB:/
-9081.2 "Northswain's Glow" sync / 1[56]:The Queen:59C3:/
-9092.0 "--explosion--" sync / 1[56]:The Queen:59C4:/
-9094.4 "Heaven's Wrath" sync / 1[56]:The Queen:59C6:/
-9102.2 "--knockback--" sync / 1[56]:The Queen:59C7:/
-9112.6 "Cleansing Slash" sync / 1[56]:The Queen:59C5:/
-9123.9 "--middle--" sync / 1[56]:The Queen:5BCB:/
+9066.6 "Empyrean Iniquity" sync / 1[56]:[^:]*:The Queen:59C8:/
+9074.8 "--middle--" sync / 1[56]:[^:]*:The Queen:5BCB:/
+9081.2 "Northswain's Glow" sync / 1[56]:[^:]*:The Queen:59C3:/
+9092.0 "--explosion--" sync / 1[56]:[^:]*:The Queen:59C4:/
+9094.4 "Heaven's Wrath" sync / 1[56]:[^:]*:The Queen:59C6:/
+9102.2 "--knockback--" sync / 1[56]:[^:]*:The Queen:59C7:/
+9112.6 "Cleansing Slash" sync / 1[56]:[^:]*:The Queen:59C5:/
+9123.9 "--middle--" sync / 1[56]:[^:]*:The Queen:5BCB:/
 
-9132.1 "Queen's Will" sync / 1[56]:The Queen:59B9:/
-9140.2 "Beck And Call To Arms" sync / 1[56]:The Queen:5B99:/
+9132.1 "Queen's Will" sync / 1[56]:[^:]*:The Queen:59B9:/
+9140.2 "Beck And Call To Arms" sync / 1[56]:[^:]*:The Queen:5B99:/
 9143.3 "--untargetable--"
-9144.5 "The Means" sync / 1[56]:(Queen's Gunner|Queen's Warrior):59B[BD]:/
-9144.5 "The Ends" sync / 1[56]:(Queen's Soldier|Queen's Knight):59B[AC]:/
-9151.5 "Judgment Blade" sync / 1[56]:The Queen:59C[12]:/
+9144.5 "The Means" sync / 1[56]:[^:]*:(Queen's Gunner|Queen's Warrior):59B[BD]:/
+9144.5 "The Ends" sync / 1[56]:[^:]*:(Queen's Soldier|Queen's Knight):59B[AC]:/
+9151.5 "Judgment Blade" sync / 1[56]:[^:]*:The Queen:59C[12]:/
 9156.2 "--targetable--"
 
 # HP% push here.
-9160.5 "--middle--" sync / 1[56]:The Queen:5BCB:/
-9163.9 "--sync--" sync / 1[56]:The Queen:55A8:/ window 200,10
-9171.0 "Gods Save The Queen" sync / 1[56]:The Queen:59C9:/
-9192.3 "--middle--" sync / 1[56]:The Queen:5BCB:/
-9200.7 "Queen's Edict" sync / 1[56]:The Queen:59BE:/
+9160.5 "--middle--" sync / 1[56]:[^:]*:The Queen:5BCB:/
+9163.9 "--sync--" sync / 1[56]:[^:]*:The Queen:55A8:/ window 200,10
+9171.0 "Gods Save The Queen" sync / 1[56]:[^:]*:The Queen:59C9:/
+9192.3 "--middle--" sync / 1[56]:[^:]*:The Queen:5BCB:/
+9200.7 "Queen's Edict" sync / 1[56]:[^:]*:The Queen:59BE:/
 9223.4 "--stunned--"
-9225.5 "Queen's Justice" sync / 1[56]:The Queen:59BF:/ # only on failure
+9225.5 "Queen's Justice" sync / 1[56]:[^:]*:The Queen:59BF:/ # only on failure
 9229.3 "--unstunned--"
-9239.9 "Cleansing Slash" sync / 1[56]:The Queen:59C5:/
+9239.9 "Cleansing Slash" sync / 1[56]:[^:]*:The Queen:59C5:/
 
-9253.1 "Relentless Play" sync / 1[56]:The Queen:59FC:/
-9259.3 "Automatic Turret" sync / 1[56]:Queen's Gunner:59DE:/
-9267.3 "Bombslinger" sync / 1[56]:Queen's Warrior:5B3E:/
-9267.4 "Turret's Tour" sync / 1[56]:Queen's Gunner:59DF:/
-9268.0 "Turret's Tour" sync / 1[56]:Automatic Turret:59E1:/
-9271.2 "Heaven's Wrath" sync / 1[56]:The Queen:59C6:/
-9274.3 "Reversal Of Forces?" sync / 1[56]:Queen's Warrior:59D4:/
-9279.0 "--knockback--" sync / 1[56]:The Queen:59C7:/
-9283.5 "Above Board" sync / 1[56]:Queen's Warrior:59D1:/
+9253.1 "Relentless Play" sync / 1[56]:[^:]*:The Queen:59FC:/
+9259.3 "Automatic Turret" sync / 1[56]:[^:]*:Queen's Gunner:59DE:/
+9267.3 "Bombslinger" sync / 1[56]:[^:]*:Queen's Warrior:5B3E:/
+9267.4 "Turret's Tour" sync / 1[56]:[^:]*:Queen's Gunner:59DF:/
+9268.0 "Turret's Tour" sync / 1[56]:[^:]*:Automatic Turret:59E1:/
+9271.2 "Heaven's Wrath" sync / 1[56]:[^:]*:The Queen:59C6:/
+9274.3 "Reversal Of Forces?" sync / 1[56]:[^:]*:Queen's Warrior:59D4:/
+9279.0 "--knockback--" sync / 1[56]:[^:]*:The Queen:59C7:/
+9283.5 "Above Board" sync / 1[56]:[^:]*:Queen's Warrior:59D1:/
 9284.5 "--stunned--"
 # Note: these can be in either order, so can't sync.
-9286.5 "Lots Cast" #sync / 1[56]:Aetherial Bolt:(59D3|5B86):/
-9289.5 "Lots Cast" #sync / 1[56]:Aetherial Burst:(59D2|5B87):/
+9286.5 "Lots Cast" #sync / 1[56]:[^:]*:Aetherial Bolt:(59D3|5B86):/
+9289.5 "Lots Cast" #sync / 1[56]:[^:]*:Aetherial Burst:(59D2|5B87):/
 9291.2 "--unstunned--"
 
-9300.4 "Empyrean Iniquity" sync / 1[56]:The Queen:59C8:/
-9308.6 "--middle--" sync / 1[56]:The Queen:5BCB:/
-9316.8 "Queen's Edict" sync / 1[56]:The Queen:59BE:/
-9338.0 "Beck And Call To Arms" sync / 1[56]:The Queen:5B99:/
+9300.4 "Empyrean Iniquity" sync / 1[56]:[^:]*:The Queen:59C8:/
+9308.6 "--middle--" sync / 1[56]:[^:]*:The Queen:5BCB:/
+9316.8 "Queen's Edict" sync / 1[56]:[^:]*:The Queen:59BE:/
+9338.0 "Beck And Call To Arms" sync / 1[56]:[^:]*:The Queen:5B99:/
 9339.5 "--stunned--"
-9341.7 "Queen's Justice" sync / 1[56]:Queen's Warrior:59BF:/ # only on failure
-9342.4 "The Means" sync / 1[56]:(Queen's Gunner|Queen's Warrior):59B[BD]:/
-9342.4 "The Ends" sync / 1[56]:(Queen's Soldier|Queen's Knight):59B[AC]:/
+9341.7 "Queen's Justice" sync / 1[56]:[^:]*:Queen's Warrior:59BF:/ # only on failure
+9342.4 "The Means" sync / 1[56]:[^:]*:(Queen's Gunner|Queen's Warrior):59B[BD]:/
+9342.4 "The Ends" sync / 1[56]:[^:]*:(Queen's Soldier|Queen's Knight):59B[AC]:/
 9345.4 "--unstunned--"
-9354.5 "Cleansing Slash" sync / 1[56]:The Queen:59C5:/
+9354.5 "Cleansing Slash" sync / 1[56]:[^:]*:The Queen:59C5:/
 
-9367.7 "Relentless Play" sync / 1[56]:The Queen:59FC:/
-9373.8 "Double Gambit" sync / 1[56]:Queen's Soldier:59D9:/
-9382.0 "Secrets Revealed" sync / 1[56]:Queen's Soldier:5B8A:/
-9382.1 "--sync--" sync / 1[56]:Soldier Avatar:5B8C:/
+9367.7 "Relentless Play" sync / 1[56]:[^:]*:The Queen:59FC:/
+9373.8 "Double Gambit" sync / 1[56]:[^:]*:Queen's Soldier:59D9:/
+9382.0 "Secrets Revealed" sync / 1[56]:[^:]*:Queen's Soldier:5B8A:/
+9382.1 "--sync--" sync / 1[56]:[^:]*:Soldier Avatar:5B8C:/
 9388.9 "--untargetable--"
-9391.9 "Pawn Off" sync / 1[56]:Soldier Avatar:59DB:/
-9397.1 "Judgment Blade" sync / 1[56]:The Queen:59C[12]:/
-9397.9 "Sword Omen/Shield Omen" sync / 1[56]:Queen's Knight:59C[AB]:/
+9391.9 "Pawn Off" sync / 1[56]:[^:]*:Soldier Avatar:59DB:/
+9397.1 "Judgment Blade" sync / 1[56]:[^:]*:The Queen:59C[12]:/
+9397.9 "Sword Omen/Shield Omen" sync / 1[56]:[^:]*:Queen's Knight:59C[AB]:/
 9401.9 "--targetable--"
-9406.1 "Optimal Play" sync / 1[56]:Queen's Knight:59CE:/
+9406.1 "Optimal Play" sync / 1[56]:[^:]*:Queen's Knight:59CE:/
 
-9415.0 "Empyrean Iniquity" sync / 1[56]:The Queen:59C8:/
-9423.2 "--sync--" sync / 1[56]:The Queen:5BCB:/
-9429.4 "Northswain's Glow" sync / 1[56]:The Queen:59C3:/
-9437.6 "Queen's Will" sync / 1[56]:The Queen:59B9:/
-9440.2 "--explosion--" sync / 1[56]:The Queen:59C4:/
-9445.7 "Beck And Call To Arms" sync / 1[56]:The Queen:5B99:/
-9450.0 "The Means" sync / 1[56]:(Queen's Gunner|Queen's Warrior):59B[BD]:/
-9450.0 "The Ends" sync / 1[56]:(Queen's Soldier|Queen's Knight):59B[AC]:/
-9459.9 "Cleansing Slash" sync / 1[56]:The Queen:59C5:/
+9415.0 "Empyrean Iniquity" sync / 1[56]:[^:]*:The Queen:59C8:/
+9423.2 "--sync--" sync / 1[56]:[^:]*:The Queen:5BCB:/
+9429.4 "Northswain's Glow" sync / 1[56]:[^:]*:The Queen:59C3:/
+9437.6 "Queen's Will" sync / 1[56]:[^:]*:The Queen:59B9:/
+9440.2 "--explosion--" sync / 1[56]:[^:]*:The Queen:59C4:/
+9445.7 "Beck And Call To Arms" sync / 1[56]:[^:]*:The Queen:5B99:/
+9450.0 "The Means" sync / 1[56]:[^:]*:(Queen's Gunner|Queen's Warrior):59B[BD]:/
+9450.0 "The Ends" sync / 1[56]:[^:]*:(Queen's Soldier|Queen's Knight):59B[AC]:/
+9459.9 "Cleansing Slash" sync / 1[56]:[^:]*:The Queen:59C5:/
 
-9473.1 "Relentless Play" sync / 1[56]:The Queen:59FC:/ window 50,50 jump 9253.1
-9479.3 "Automatic Turret" #sync / 1[56]:Queen's Gunner:59DE:/
-9487.3 "Bombslinger" #sync / 1[56]:Queen's Warrior:5B3E:/
-9487.4 "Turret's Tour" #sync / 1[56]:Queen's Gunner:59DF:/
-9488.0 "Turret's Tour" #sync / 1[56]:Automatic Turret:59E1:/
-9491.2 "Heaven's Wrath" #sync / 1[56]:The Queen:59C6:/
-9494.3 "Reversal Of Forces?" #sync / 1[56]:Queen's Warrior:59D4:/
-9499.0 "--knockback--" #sync / 1[56]:The Queen:59C7:/
-9503.5 "Above Board" #sync / 1[56]:Queen's Warrior:59D1:/
+9473.1 "Relentless Play" sync / 1[56]:[^:]*:The Queen:59FC:/ window 50,50 jump 9253.1
+9479.3 "Automatic Turret" #sync / 1[56]:[^:]*:Queen's Gunner:59DE:/
+9487.3 "Bombslinger" #sync / 1[56]:[^:]*:Queen's Warrior:5B3E:/
+9487.4 "Turret's Tour" #sync / 1[56]:[^:]*:Queen's Gunner:59DF:/
+9488.0 "Turret's Tour" #sync / 1[56]:[^:]*:Automatic Turret:59E1:/
+9491.2 "Heaven's Wrath" #sync / 1[56]:[^:]*:The Queen:59C6:/
+9494.3 "Reversal Of Forces?" #sync / 1[56]:[^:]*:Queen's Warrior:59D4:/
+9499.0 "--knockback--" #sync / 1[56]:[^:]*:The Queen:59C7:/
+9503.5 "Above Board" #sync / 1[56]:[^:]*:Queen's Warrior:59D1:/
 9504.5 "--stunned--"
-9506.5 "Lots Cast" #sync / 1[56]:Aetherial Bolt:(59D3|5B86):/
-9509.5 "Lots Cast" #sync / 1[56]:Aetherial Burst:(59D2|5B87):/
+9506.5 "Lots Cast" #sync / 1[56]:[^:]*:Aetherial Bolt:(59D3|5B86):/
+9509.5 "Lots Cast" #sync / 1[56]:[^:]*:Aetherial Burst:(59D2|5B87):/
 9511.2 "--unstunned--"

--- a/ui/raidboss/data/05-shb/eureka/delubrum_reginae_savage.txt
+++ b/ui/raidboss/data/05-shb/eureka/delubrum_reginae_savage.txt
@@ -51,41 +51,41 @@ hideall "--sync--"
 1233.1 "Sanguine Clot x4" sync / 03:........:Sanguine Clot:/
 1277.3 "Bozjan Soldier x2" sync / 03:........:Bozjan Soldier:/
 1297.3 "Grim Reaper Enrage" sync / 03:........:Grim Reaper:/  window 300,10
-1302.3 "Death Scythe" #sync / 1[56]:Grim Reaper:5747:/
-1305.3 "Death Scythe" #sync / 1[56]:Grim Reaper:5747:/
-1308.3 "Death Scythe" #sync / 1[56]:Grim Reaper:5747:/
-1311.3 "Death Scythe" #sync / 1[56]:Grim Reaper:5747:/
-1314.4 "Death Scythe" #sync / 1[56]:Grim Reaper:5747:/
-1317.4 "Death Scythe" #sync / 1[56]:Grim Reaper:5747:/
-1320.4 "Death Scythe" #sync / 1[56]:Grim Reaper:5747:/
-1323.5 "Death Scythe" #sync / 1[56]:Grim Reaper:5747:/
-1326.5 "Death Scythe" #sync / 1[56]:Grim Reaper:5747:/
+1302.3 "Death Scythe" #sync / 1[56]:[^:]*:Grim Reaper:5747:/
+1305.3 "Death Scythe" #sync / 1[56]:[^:]*:Grim Reaper:5747:/
+1308.3 "Death Scythe" #sync / 1[56]:[^:]*:Grim Reaper:5747:/
+1311.3 "Death Scythe" #sync / 1[56]:[^:]*:Grim Reaper:5747:/
+1314.4 "Death Scythe" #sync / 1[56]:[^:]*:Grim Reaper:5747:/
+1317.4 "Death Scythe" #sync / 1[56]:[^:]*:Grim Reaper:5747:/
+1320.4 "Death Scythe" #sync / 1[56]:[^:]*:Grim Reaper:5747:/
+1323.5 "Death Scythe" #sync / 1[56]:[^:]*:Grim Reaper:5747:/
+1326.5 "Death Scythe" #sync / 1[56]:[^:]*:Grim Reaper:5747:/
 1327.3 "Bozjan Soldier x2" sync / 03:........:Bozjan Soldier:/
-1329.5 "Death Scythe" #sync / 1[56]:Grim Reaper:5747:/
-1332.6 "Death Scythe" #sync / 1[56]:Grim Reaper:5747:/
-1335.6 "Death Scythe" sync / 1[56]:Grim Reaper:5747:/ window 5,10
-1338.6 "Death Scythe" #sync / 1[56]:Grim Reaper:5747:/
-1341.7 "Death Scythe" #sync / 1[56]:Grim Reaper:5747:/ window 10,10
-1341.7 "Death Scythe" #sync / 1[56]:Grim Reaper:5747:/
-1344.7 "Death Scythe" #sync / 1[56]:Grim Reaper:5747:/
-1347.7 "Death Scythe" #sync / 1[56]:Grim Reaper:5747:/
-1350.8 "Death Scythe" #sync / 1[56]:Grim Reaper:5747:/
-1353.8 "Death Scythe" #sync / 1[56]:Grim Reaper:5747:/
-1356.8 "Death Scythe" #sync / 1[56]:Grim Reaper:5747:/
-1359.8 "Death Scythe" #sync / 1[56]:Grim Reaper:5747:/
+1329.5 "Death Scythe" #sync / 1[56]:[^:]*:Grim Reaper:5747:/
+1332.6 "Death Scythe" #sync / 1[56]:[^:]*:Grim Reaper:5747:/
+1335.6 "Death Scythe" sync / 1[56]:[^:]*:Grim Reaper:5747:/ window 5,10
+1338.6 "Death Scythe" #sync / 1[56]:[^:]*:Grim Reaper:5747:/
+1341.7 "Death Scythe" #sync / 1[56]:[^:]*:Grim Reaper:5747:/ window 10,10
+1341.7 "Death Scythe" #sync / 1[56]:[^:]*:Grim Reaper:5747:/
+1344.7 "Death Scythe" #sync / 1[56]:[^:]*:Grim Reaper:5747:/
+1347.7 "Death Scythe" #sync / 1[56]:[^:]*:Grim Reaper:5747:/
+1350.8 "Death Scythe" #sync / 1[56]:[^:]*:Grim Reaper:5747:/
+1353.8 "Death Scythe" #sync / 1[56]:[^:]*:Grim Reaper:5747:/
+1356.8 "Death Scythe" #sync / 1[56]:[^:]*:Grim Reaper:5747:/
+1359.8 "Death Scythe" #sync / 1[56]:[^:]*:Grim Reaper:5747:/
 
 
 ### Golems (The Granary, right side)
 2000.0 "--sync--" sync / 22:........:Bicolor Golem:........:Bicolor Golem:01/ window 2000,0
 2000.0 "--Reset--" sync / 03:........:Trinity Seeker:/  window 0,1000 jump 0
-2025.2 "Core Combustion" sync / 1[56]:Bicolor Golem:5745:/ window 2030,10
+2025.2 "Core Combustion" sync / 1[56]:[^:]*:Bicolor Golem:5745:/ window 2030,10
 2026.1 "--bleed--" # from blue golem
 2029.9 "Ruins Golem x2" sync / 03:........:Ruins Golem:/
-2032.1 "--sync--" sync / 14:Bicolor Golem:5558:/ window 20,10
-2037.1 "Metamorphose" sync / 1[56]:Bicolor Golem:5558:/
+2032.1 "--sync--" sync / 14:[^:]*:Bicolor Golem:5558:/ window 20,10
+2037.1 "Metamorphose" sync / 1[56]:[^:]*:Bicolor Golem:5558:/
 2069.9 "Ruins Golem x2" sync / 03:........:Ruins Golem:/
-2071.3 "--sync--" sync / 14:Bicolor Golem:5558:/ window 20,10
-2076.3 "Metamorphose" sync / 1[56]:Bicolor Golem:5558:/
+2071.3 "--sync--" sync / 14:[^:]*:Bicolor Golem:5558:/ window 20,10
+2076.3 "Metamorphose" sync / 1[56]:[^:]*:Bicolor Golem:5558:/
 2109.7 "Ruins Golem x2" sync / 03:........:Ruins Golem:/
 2140.1 "Ruins Golem x2" sync / 03:........:Ruins Golem:/
 2160.2 "Ruins Golem x2" sync / 03:........:Ruins Golem:/
@@ -104,19 +104,19 @@ hideall "--sync--"
 2290.1 "Ruins Golem x2" sync / 03:........:Ruins Golem:/
 2299.7 "Grim Reaper Enrage" sync / 03:........:Grim Reaper:/
 2300.2 "Ruins Golem x2" sync / 03:........:Ruins Golem:/
-2305.0 "Death Scythe" #sync / 1[56]:Grim Reaper:5747:/
-2308.0 "Death Scythe" #sync / 1[56]:Grim Reaper:5747:/
+2305.0 "Death Scythe" #sync / 1[56]:[^:]*:Grim Reaper:5747:/
+2308.0 "Death Scythe" #sync / 1[56]:[^:]*:Grim Reaper:5747:/
 2310.1 "Ruins Golem x2" sync / 03:........:Ruins Golem:/
-2311.1 "Death Scythe" #sync / 1[56]:Grim Reaper:5747:/
-2314.1 "Death Scythe" #sync / 1[56]:Grim Reaper:5747:/
-2317.1 "Death Scythe" sync / 1[56]:Grim Reaper:5747:/ window 5,10
-2320.1 "Death Scythe" #sync / 1[56]:Grim Reaper:5747:/
-2323.1 "Death Scythe" #sync / 1[56]:Grim Reaper:5747:/
-2326.1 "Death Scythe" #sync / 1[56]:Grim Reaper:5747:/
-2329.1 "Death Scythe" #sync / 1[56]:Grim Reaper:5747:/
-2332.1 "Death Scythe" #sync / 1[56]:Grim Reaper:5747:/
-2335.1 "Death Scythe" #sync / 1[56]:Grim Reaper:5747:/
-2338.1 "Death Scythe" #sync / 1[56]:Grim Reaper:5747:/
+2311.1 "Death Scythe" #sync / 1[56]:[^:]*:Grim Reaper:5747:/
+2314.1 "Death Scythe" #sync / 1[56]:[^:]*:Grim Reaper:5747:/
+2317.1 "Death Scythe" sync / 1[56]:[^:]*:Grim Reaper:5747:/ window 5,10
+2320.1 "Death Scythe" #sync / 1[56]:[^:]*:Grim Reaper:5747:/
+2323.1 "Death Scythe" #sync / 1[56]:[^:]*:Grim Reaper:5747:/
+2326.1 "Death Scythe" #sync / 1[56]:[^:]*:Grim Reaper:5747:/
+2329.1 "Death Scythe" #sync / 1[56]:[^:]*:Grim Reaper:5747:/
+2332.1 "Death Scythe" #sync / 1[56]:[^:]*:Grim Reaper:5747:/
+2335.1 "Death Scythe" #sync / 1[56]:[^:]*:Grim Reaper:5747:/
+2338.1 "Death Scythe" #sync / 1[56]:[^:]*:Grim Reaper:5747:/
 
 
 ### Trinity Seeker
@@ -131,173 +131,173 @@ hideall "--sync--"
 # but with lots of extra syncs to future proof possible hp pushes.
 
 # Initial Merciful Air
-4006.4 "--sync--" sync / 14:Trinity Seeker:5AD3:/ window 20,20
-4011.4 "Verdant Tempest" sync / 1[56]:Trinity Seeker:5AD3:/
-4015.6 "--middle--" sync / 1[56]:Trinity Seeker:5A9A:/
-4020.0 "Manifest Avatar" sync / 1[56]:Trinity Seeker:5ADA:/
-4028.2 "First Mercy" sync / 1[56]:Trinity Seeker:5B61:/
-4031.4 "Second Mercy" sync / 1[56]:Trinity Seeker:5B62:/
-4034.6 "Third Mercy" sync / 1[56]:Trinity Seeker:5B63:/
-4037.8 "Fourth Mercy" sync / 1[56]:Trinity Seeker:5B64:/
-4040.2 "Mercy Fourfold 1" #sync / 1[56]:Trinity Seeker:5B94:/
-4042.1 "Mercy Fourfold 2" #sync / 1[56]:Trinity Seeker:5B94:/
-4042.8 "Seasons Of Mercy" sync / 1[56]:Seeker Avatar:5AC7:/
-4044.0 "Mercy Fourfold 3" #sync / 1[56]:Trinity Seeker:5B94:/
-4045.9 "Mercy Fourfold 4" #sync / 1[56]:Trinity Seeker:5B94:/
-4047.3 "Merciful Breeze" sync / 1[56]:Trinity Seeker:5AC8:/
-4048.8 "Merciful Moon" sync / 1[56]:Aetherial Orb:5AC9:/
-4051.3 "Merciful Breeze" sync / 1[56]:Trinity Seeker:5AC8:/
-4054.7 "Merciful Blooms" sync / 1[56]:Trinity Seeker:5ACA:/
-4062.0 "Verdant Tempest" sync / 1[56]:Trinity Seeker:5AD3:/
-4074.2 "Merciful Arc" sync / 1[56]:Trinity Seeker:5AD4:/
+4006.4 "--sync--" sync / 14:[^:]*:Trinity Seeker:5AD3:/ window 20,20
+4011.4 "Verdant Tempest" sync / 1[56]:[^:]*:Trinity Seeker:5AD3:/
+4015.6 "--middle--" sync / 1[56]:[^:]*:Trinity Seeker:5A9A:/
+4020.0 "Manifest Avatar" sync / 1[56]:[^:]*:Trinity Seeker:5ADA:/
+4028.2 "First Mercy" sync / 1[56]:[^:]*:Trinity Seeker:5B61:/
+4031.4 "Second Mercy" sync / 1[56]:[^:]*:Trinity Seeker:5B62:/
+4034.6 "Third Mercy" sync / 1[56]:[^:]*:Trinity Seeker:5B63:/
+4037.8 "Fourth Mercy" sync / 1[56]:[^:]*:Trinity Seeker:5B64:/
+4040.2 "Mercy Fourfold 1" #sync / 1[56]:[^:]*:Trinity Seeker:5B94:/
+4042.1 "Mercy Fourfold 2" #sync / 1[56]:[^:]*:Trinity Seeker:5B94:/
+4042.8 "Seasons Of Mercy" sync / 1[56]:[^:]*:Seeker Avatar:5AC7:/
+4044.0 "Mercy Fourfold 3" #sync / 1[56]:[^:]*:Trinity Seeker:5B94:/
+4045.9 "Mercy Fourfold 4" #sync / 1[56]:[^:]*:Trinity Seeker:5B94:/
+4047.3 "Merciful Breeze" sync / 1[56]:[^:]*:Trinity Seeker:5AC8:/
+4048.8 "Merciful Moon" sync / 1[56]:[^:]*:Aetherial Orb:5AC9:/
+4051.3 "Merciful Breeze" sync / 1[56]:[^:]*:Trinity Seeker:5AC8:/
+4054.7 "Merciful Blooms" sync / 1[56]:[^:]*:Trinity Seeker:5ACA:/
+4062.0 "Verdant Tempest" sync / 1[56]:[^:]*:Trinity Seeker:5AD3:/
+4074.2 "Merciful Arc" sync / 1[56]:[^:]*:Trinity Seeker:5AD4:/
 
 # Initial Baleful Air (80% or time push)
-4076.5 "--sync--" sync / 14:Trinity Seeker:5A98:/ window 80,20
-4079.5 "Verdant Path" sync / 1[56]:Trinity Seeker:5A98:/
-4084.1 "Baleful Swathe" sync / 1[56]:Trinity Seeker:5AD0:/
-4092.2 "Baleful Onslaught" sync / 1[56]:Trinity Seeker:5AD5:/
-4099.3 "Phantom Edge" sync / 1[56]:Trinity Seeker:5ABD:/
-4105.5 "Baleful Onslaught" sync / 1[56]:Trinity Seeker:5AD6:/
-4115.6 "Phantom Edge?" sync / 1[56]:Trinity Seeker:5ABD:/
-4117.8 "--middle--" sync / 1[56]:Trinity Seeker:5A9A:/
+4076.5 "--sync--" sync / 14:[^:]*:Trinity Seeker:5A98:/ window 80,20
+4079.5 "Verdant Path" sync / 1[56]:[^:]*:Trinity Seeker:5A98:/
+4084.1 "Baleful Swathe" sync / 1[56]:[^:]*:Trinity Seeker:5AD0:/
+4092.2 "Baleful Onslaught" sync / 1[56]:[^:]*:Trinity Seeker:5AD5:/
+4099.3 "Phantom Edge" sync / 1[56]:[^:]*:Trinity Seeker:5ABD:/
+4105.5 "Baleful Onslaught" sync / 1[56]:[^:]*:Trinity Seeker:5AD6:/
+4115.6 "Phantom Edge?" sync / 1[56]:[^:]*:Trinity Seeker:5ABD:/
+4117.8 "--middle--" sync / 1[56]:[^:]*:Trinity Seeker:5A9A:/
 4118.4 "--chains--" duration 3.1 # sync / 00:0000:0080:/
-4126.9 "Baleful Blade" sync / 1[56]:Trinity Seeker:5AB[EF]:/
-4132.1 "Manifest Avatar" sync / 1[56]:Trinity Seeker:5ADA:/
-4138.8 "Baleful Comet 1" #sync / 1[56]:Seeker Avatar:5AD7:/
-4139.8 "Baleful Comet 2" #sync / 1[56]:Seeker Avatar:5AD7:/
-4140.8 "Baleful Comet 3" #sync / 1[56]:Seeker Avatar:5AD7:/
-4141.8 "Baleful Comet 4" #sync / 1[56]:Seeker Avatar:5AD7:/
-4142.2 "Phantom Edge?" sync / 1[56]:Trinity Seeker:5ABD:/
-4144.4 "--middle--" sync / 1[56]:Trinity Seeker:5A9A:/
-4146.4 "Baleful Firestorm 1" #sync / 1[56]:Seeker Avatar:5AD8:/
-4148.4 "Baleful Firestorm 2" #sync / 1[56]:Seeker Avatar:5AD8:/
-4150.4 "Baleful Firestorm 3" #sync / 1[56]:Seeker Avatar:5AD8:/
-4152.4 "Baleful Firestorm 4" #sync / 1[56]:Seeker Avatar:5AD8:/
-4153.5 "Baleful Blade" sync / 1[56]:Trinity Seeker:5AB[EF]:/
-4162.6 "Verdant Tempest" sync / 1[56]:Trinity Seeker:5AD3:/
+4126.9 "Baleful Blade" sync / 1[56]:[^:]*:Trinity Seeker:5AB[EF]:/
+4132.1 "Manifest Avatar" sync / 1[56]:[^:]*:Trinity Seeker:5ADA:/
+4138.8 "Baleful Comet 1" #sync / 1[56]:[^:]*:Seeker Avatar:5AD7:/
+4139.8 "Baleful Comet 2" #sync / 1[56]:[^:]*:Seeker Avatar:5AD7:/
+4140.8 "Baleful Comet 3" #sync / 1[56]:[^:]*:Seeker Avatar:5AD7:/
+4141.8 "Baleful Comet 4" #sync / 1[56]:[^:]*:Seeker Avatar:5AD7:/
+4142.2 "Phantom Edge?" sync / 1[56]:[^:]*:Trinity Seeker:5ABD:/
+4144.4 "--middle--" sync / 1[56]:[^:]*:Trinity Seeker:5A9A:/
+4146.4 "Baleful Firestorm 1" #sync / 1[56]:[^:]*:Seeker Avatar:5AD8:/
+4148.4 "Baleful Firestorm 2" #sync / 1[56]:[^:]*:Seeker Avatar:5AD8:/
+4150.4 "Baleful Firestorm 3" #sync / 1[56]:[^:]*:Seeker Avatar:5AD8:/
+4152.4 "Baleful Firestorm 4" #sync / 1[56]:[^:]*:Seeker Avatar:5AD8:/
+4153.5 "Baleful Blade" sync / 1[56]:[^:]*:Trinity Seeker:5AB[EF]:/
+4162.6 "Verdant Tempest" sync / 1[56]:[^:]*:Trinity Seeker:5AD3:/
 
 # Initial Iron Air
-4168.7 "--sync--" sync / 14:Trinity Seeker:5A99:/ window 200,20
-4171.7 "Verdant Path" sync / 1[56]:Trinity Seeker:5A99:/
-4176.6 "Iron Impact" sync / 1[56]:Trinity Seeker:5AD2:/
-4180.7 "--middle--" sync / 1[56]:Trinity Seeker:5A9A:/
-4184.9 "Manifest Avatar" sync / 1[56]:Trinity Seeker:5ADA:/
-4196.6 "--jump--" sync / 1[56]:Trinity Seeker:5A9A:/
-4197.7 "Iron Rose" sync / 1[56]:Seeker Avatar:5AD9:/
-4203.5 "Iron Splitter" sync / 1[56]:Trinity Seeker:5AC0:/
-4207.7 "--middle--" sync / 1[56]:Trinity Seeker:5A9A:/
-4211.9 "Manifest Avatar" sync / 1[56]:Trinity Seeker:5ADA:/
-4216.1 "--jump--" sync / 1[56]:Trinity Seeker:5A9A:/
-4223.0 "Iron Splitter" sync / 1[56]:Trinity Seeker:5AC0:/
-4225.2 "Dead Iron" sync / 1[56]:Seeker Avatar:5ACC:/
-4228.3 "--jump--" sync / 1[56]:Trinity Seeker:5A9A:/
-4232.5 "Dead Iron" sync / 1[56]:Seeker Avatar:5B44:/
-4235.1 "Iron Splitter" sync / 1[56]:Trinity Seeker:5AC0:/
-4239.9 "Iron Rose" sync / 1[56]:Seeker Avatar:5AD9:/
-4251.3 "Verdant Tempest" sync / 1[56]:Trinity Seeker:5AD3:/
+4168.7 "--sync--" sync / 14:[^:]*:Trinity Seeker:5A99:/ window 200,20
+4171.7 "Verdant Path" sync / 1[56]:[^:]*:Trinity Seeker:5A99:/
+4176.6 "Iron Impact" sync / 1[56]:[^:]*:Trinity Seeker:5AD2:/
+4180.7 "--middle--" sync / 1[56]:[^:]*:Trinity Seeker:5A9A:/
+4184.9 "Manifest Avatar" sync / 1[56]:[^:]*:Trinity Seeker:5ADA:/
+4196.6 "--jump--" sync / 1[56]:[^:]*:Trinity Seeker:5A9A:/
+4197.7 "Iron Rose" sync / 1[56]:[^:]*:Seeker Avatar:5AD9:/
+4203.5 "Iron Splitter" sync / 1[56]:[^:]*:Trinity Seeker:5AC0:/
+4207.7 "--middle--" sync / 1[56]:[^:]*:Trinity Seeker:5A9A:/
+4211.9 "Manifest Avatar" sync / 1[56]:[^:]*:Trinity Seeker:5ADA:/
+4216.1 "--jump--" sync / 1[56]:[^:]*:Trinity Seeker:5A9A:/
+4223.0 "Iron Splitter" sync / 1[56]:[^:]*:Trinity Seeker:5AC0:/
+4225.2 "Dead Iron" sync / 1[56]:[^:]*:Seeker Avatar:5ACC:/
+4228.3 "--jump--" sync / 1[56]:[^:]*:Trinity Seeker:5A9A:/
+4232.5 "Dead Iron" sync / 1[56]:[^:]*:Seeker Avatar:5B44:/
+4235.1 "Iron Splitter" sync / 1[56]:[^:]*:Trinity Seeker:5AC0:/
+4239.9 "Iron Rose" sync / 1[56]:[^:]*:Seeker Avatar:5AD9:/
+4251.3 "Verdant Tempest" sync / 1[56]:[^:]*:Trinity Seeker:5AD3:/
 
 # Merciful Air v2
-4262.8 "--sync--" sync / 14:Trinity Seeker:5A97:/ window 300,10
-4265.8 "Verdant Path" sync / 1[56]:Trinity Seeker:5A97:/
-4270.4 "Act Of Mercy" sync / 1[56]:Trinity Seeker:5ACF:/
-4276.5 "--middle--" sync / 1[56]:Trinity Seeker:5A9A:/
-4280.8 "Manifest Avatar" sync / 1[56]:Trinity Seeker:5ADA:/
-4286.9 "Baleful Comet 1" #sync / 1[56]:Seeker Avatar:5AD7:/
-4287.9 "Baleful Comet 2" #sync / 1[56]:Seeker Avatar:5AD7:/
-4288.9 "Baleful Comet 3" #sync / 1[56]: Seeker Avatar:5AD7:/
-4289.9 "Baleful Comet 4" #sync / 1[56]:Seeker Avatar:5AD7:/
-4290.9 "--middle--" sync / 1[56]:Trinity Seeker:5A9A:/
-4294.5 "Baleful Firestorm" #sync / 1[56]:Seeker Avatar:5AD8:/
-4295.1 "First Mercy" sync / 1[56]:Trinity Seeker:5B61:/
-4296.5 "Baleful Firestorm" #sync / 1[56]:Seeker Avatar:5AD8:/
-4298.3 "Second Mercy" sync / 1[56]:Trinity Seeker:5B62:/
-4298.5 "Baleful Firestorm" #sync / 1[56]:Seeker Avatar:5AD8:/
-4300.5 "Baleful Firestorm" #sync / 1[56]:Seeker Avatar:5AD8:/
-4301.5 "Third Mercy" sync / 1[56]:Trinity Seeker:5B63:/
-4304.7 "Fourth Mercy" sync / 1[56]:Trinity Seeker:5B64:/
-4307.1 "Mercy Fourfold 1" #sync / 1[56]:Trinity Seeker:5B94:/
-4309.0 "Mercy Fourfold 2" #sync / 1[56]:Trinity Seeker:5B94:/
-4309.7 "Seasons Of Mercy" sync / 1[56]:Seeker Avatar:5AC7:/
-4311.0 "Mercy Fourfold 3" #sync / 1[56]:Trinity Seeker:5B94:/
-4312.9 "Mercy Fourfold 4" #sync / 1[56]:Trinity Seeker:5B94:/
-4314.3 "Merciful Breeze" sync / 1[56]:Trinity Seeker:5AC8:/
-4315.8 "Merciful Moon" sync / 1[56]:Aetherial Orb:5AC9:/
-4318.4 "Merciful Breeze" sync / 1[56]:Trinity Seeker:5AC8:/
-4321.8 "Merciful Blooms" sync / 1[56]:Trinity Seeker:5ACA:/
+4262.8 "--sync--" sync / 14:[^:]*:Trinity Seeker:5A97:/ window 300,10
+4265.8 "Verdant Path" sync / 1[56]:[^:]*:Trinity Seeker:5A97:/
+4270.4 "Act Of Mercy" sync / 1[56]:[^:]*:Trinity Seeker:5ACF:/
+4276.5 "--middle--" sync / 1[56]:[^:]*:Trinity Seeker:5A9A:/
+4280.8 "Manifest Avatar" sync / 1[56]:[^:]*:Trinity Seeker:5ADA:/
+4286.9 "Baleful Comet 1" #sync / 1[56]:[^:]*:Seeker Avatar:5AD7:/
+4287.9 "Baleful Comet 2" #sync / 1[56]:[^:]*:Seeker Avatar:5AD7:/
+4288.9 "Baleful Comet 3" #sync / 1[56]:[^:]*: Seeker Avatar:5AD7:/
+4289.9 "Baleful Comet 4" #sync / 1[56]:[^:]*:Seeker Avatar:5AD7:/
+4290.9 "--middle--" sync / 1[56]:[^:]*:Trinity Seeker:5A9A:/
+4294.5 "Baleful Firestorm" #sync / 1[56]:[^:]*:Seeker Avatar:5AD8:/
+4295.1 "First Mercy" sync / 1[56]:[^:]*:Trinity Seeker:5B61:/
+4296.5 "Baleful Firestorm" #sync / 1[56]:[^:]*:Seeker Avatar:5AD8:/
+4298.3 "Second Mercy" sync / 1[56]:[^:]*:Trinity Seeker:5B62:/
+4298.5 "Baleful Firestorm" #sync / 1[56]:[^:]*:Seeker Avatar:5AD8:/
+4300.5 "Baleful Firestorm" #sync / 1[56]:[^:]*:Seeker Avatar:5AD8:/
+4301.5 "Third Mercy" sync / 1[56]:[^:]*:Trinity Seeker:5B63:/
+4304.7 "Fourth Mercy" sync / 1[56]:[^:]*:Trinity Seeker:5B64:/
+4307.1 "Mercy Fourfold 1" #sync / 1[56]:[^:]*:Trinity Seeker:5B94:/
+4309.0 "Mercy Fourfold 2" #sync / 1[56]:[^:]*:Trinity Seeker:5B94:/
+4309.7 "Seasons Of Mercy" sync / 1[56]:[^:]*:Seeker Avatar:5AC7:/
+4311.0 "Mercy Fourfold 3" #sync / 1[56]:[^:]*:Trinity Seeker:5B94:/
+4312.9 "Mercy Fourfold 4" #sync / 1[56]:[^:]*:Trinity Seeker:5B94:/
+4314.3 "Merciful Breeze" sync / 1[56]:[^:]*:Trinity Seeker:5AC8:/
+4315.8 "Merciful Moon" sync / 1[56]:[^:]*:Aetherial Orb:5AC9:/
+4318.4 "Merciful Breeze" sync / 1[56]:[^:]*:Trinity Seeker:5AC8:/
+4321.8 "Merciful Blooms" sync / 1[56]:[^:]*:Trinity Seeker:5ACA:/
 4325.1 "--chains--" duration 3.1 # sync / 23:0000:0000:0080:/
-4335.2 "Verdant Tempest" sync / 1[56]:Trinity Seeker:5AD3:/
-4346.5 "Merciful Arc" sync / 1[56]:Trinity Seeker:5AD4:/
-4349.7 "--middle--" sync / 1[56]:Trinity Seeker:5A9A:/
-4354.0 "Manifest Avatar" sync / 1[56]:Trinity Seeker:5ADA:/
-4361.2 "First Mercy" sync / 1[56]:Trinity Seeker:5B61:/
-4364.4 "Second Mercy" sync / 1[56]:Trinity Seeker:5B62:/
-4365.4 "--jump--" sync / 1[56]:Seeker Avatar:5A9A:/
-4367.6 "Third Mercy" sync / 1[56]:Trinity Seeker:5B63:/
-4370.8 "Fourth Mercy" sync / 1[56]:Trinity Seeker:5B64:/
-4371.6 "Iron Splitter" sync / 1[56]:Seeker Avatar:5AC0:/
-4373.2 "Mercy Fourfold 1" #sync / 1[56]:Trinity Seeker:5B94:/
-4375.1 "Mercy Fourfold 2" #sync / 1[56]:Trinity Seeker:5B94:/
-4377.0 "Mercy Fourfold 3" #sync / 1[56]:Trinity Seeker:5B94:/
-4378.9 "Mercy Fourfold 4" #sync / 1[56]:Trinity Seeker:5B94:/
-4380.6 "Iron Splitter" sync / 1[56]:Seeker Avatar:5AC0:/
-4382.8 "--jump--" sync / 1[56]:Seeker Avatar:5A9A:/
-4389.5 "Iron Splitter" sync / 1[56]:Seeker Avatar:5AC0:/
-4390.3 "Seasons Of Mercy" sync / 1[56]:Trinity Seeker:5AC7:/
-4394.8 "Merciful Breeze" sync / 1[56]:Trinity Seeker:5AC8:/
-4396.3 "Merciful Moon" sync / 1[56]:Aetherial Orb:5AC9:/
-4398.9 "Merciful Breeze" sync / 1[56]:Trinity Seeker:5AC8:/
-4400.9 "Iron Rose" sync / 1[56]:Seeker Avatar:5AD9:/
-4402.2 "Merciful Blooms" sync / 1[56]:Trinity Seeker:5ACA:/
-4412.3 "Verdant Tempest" sync / 1[56]:Trinity Seeker:5AD3:/
+4335.2 "Verdant Tempest" sync / 1[56]:[^:]*:Trinity Seeker:5AD3:/
+4346.5 "Merciful Arc" sync / 1[56]:[^:]*:Trinity Seeker:5AD4:/
+4349.7 "--middle--" sync / 1[56]:[^:]*:Trinity Seeker:5A9A:/
+4354.0 "Manifest Avatar" sync / 1[56]:[^:]*:Trinity Seeker:5ADA:/
+4361.2 "First Mercy" sync / 1[56]:[^:]*:Trinity Seeker:5B61:/
+4364.4 "Second Mercy" sync / 1[56]:[^:]*:Trinity Seeker:5B62:/
+4365.4 "--jump--" sync / 1[56]:[^:]*:Seeker Avatar:5A9A:/
+4367.6 "Third Mercy" sync / 1[56]:[^:]*:Trinity Seeker:5B63:/
+4370.8 "Fourth Mercy" sync / 1[56]:[^:]*:Trinity Seeker:5B64:/
+4371.6 "Iron Splitter" sync / 1[56]:[^:]*:Seeker Avatar:5AC0:/
+4373.2 "Mercy Fourfold 1" #sync / 1[56]:[^:]*:Trinity Seeker:5B94:/
+4375.1 "Mercy Fourfold 2" #sync / 1[56]:[^:]*:Trinity Seeker:5B94:/
+4377.0 "Mercy Fourfold 3" #sync / 1[56]:[^:]*:Trinity Seeker:5B94:/
+4378.9 "Mercy Fourfold 4" #sync / 1[56]:[^:]*:Trinity Seeker:5B94:/
+4380.6 "Iron Splitter" sync / 1[56]:[^:]*:Seeker Avatar:5AC0:/
+4382.8 "--jump--" sync / 1[56]:[^:]*:Seeker Avatar:5A9A:/
+4389.5 "Iron Splitter" sync / 1[56]:[^:]*:Seeker Avatar:5AC0:/
+4390.3 "Seasons Of Mercy" sync / 1[56]:[^:]*:Trinity Seeker:5AC7:/
+4394.8 "Merciful Breeze" sync / 1[56]:[^:]*:Trinity Seeker:5AC8:/
+4396.3 "Merciful Moon" sync / 1[56]:[^:]*:Aetherial Orb:5AC9:/
+4398.9 "Merciful Breeze" sync / 1[56]:[^:]*:Trinity Seeker:5AC8:/
+4400.9 "Iron Rose" sync / 1[56]:[^:]*:Seeker Avatar:5AD9:/
+4402.2 "Merciful Blooms" sync / 1[56]:[^:]*:Trinity Seeker:5ACA:/
+4412.3 "Verdant Tempest" sync / 1[56]:[^:]*:Trinity Seeker:5AD3:/
 
 # Baleful Air v2
-4422.5 "--sync--" sync / 14:Trinity Seeker:5A98:/ window 300,10
-4425.5 "Verdant Path" sync / 1[56]:Trinity Seeker:5A98:/
-4430.2 "Baleful Swathe" sync / 1[56]:Trinity Seeker:5AD0:/
-4433.4 "--middle--" sync / 1[56]:Trinity Seeker:5A9A:/
-4437.8 "Manifest Avatar" sync / 1[56]:Trinity Seeker:5ADA:/
-4448.0 "Phantom Edge" sync / 1[56]:Trinity Seeker:5ABD:/
-4450.2 "--middle--" sync / 1[56]:Trinity Seeker:5A9A:/
-4451.1 "First Mercy" sync / 1[56]:Seeker Avatar:5B61:/
-4454.3 "Second Mercy" sync / 1[56]:Seeker Avatar:5B62:/
-4457.5 "Third Mercy" sync / 1[56]:Seeker Avatar:5B63:/
-4459.2 "Baleful Blade" sync / 1[56]:Trinity Seeker:5ABF:/
-4460.7 "Fourth Mercy" sync / 1[56]:Seeker Avatar:5B64:/
-4463.1 "Mercy Fourfold 1" #sync / 1[56]:Trinity Seeker:5B94:/
-4465.0 "Mercy Fourfold 2" #sync / 1[56]:Trinity Seeker:5B94:/
-4466.9 "Mercy Fourfold 3" #sync / 1[56]:Trinity Seeker:5B94:/
-4468.8 "Mercy Fourfold 4" #sync / 1[56]:Trinity Seeker:5B94:/
+4422.5 "--sync--" sync / 14:[^:]*:Trinity Seeker:5A98:/ window 300,10
+4425.5 "Verdant Path" sync / 1[56]:[^:]*:Trinity Seeker:5A98:/
+4430.2 "Baleful Swathe" sync / 1[56]:[^:]*:Trinity Seeker:5AD0:/
+4433.4 "--middle--" sync / 1[56]:[^:]*:Trinity Seeker:5A9A:/
+4437.8 "Manifest Avatar" sync / 1[56]:[^:]*:Trinity Seeker:5ADA:/
+4448.0 "Phantom Edge" sync / 1[56]:[^:]*:Trinity Seeker:5ABD:/
+4450.2 "--middle--" sync / 1[56]:[^:]*:Trinity Seeker:5A9A:/
+4451.1 "First Mercy" sync / 1[56]:[^:]*:Seeker Avatar:5B61:/
+4454.3 "Second Mercy" sync / 1[56]:[^:]*:Seeker Avatar:5B62:/
+4457.5 "Third Mercy" sync / 1[56]:[^:]*:Seeker Avatar:5B63:/
+4459.2 "Baleful Blade" sync / 1[56]:[^:]*:Trinity Seeker:5ABF:/
+4460.7 "Fourth Mercy" sync / 1[56]:[^:]*:Seeker Avatar:5B64:/
+4463.1 "Mercy Fourfold 1" #sync / 1[56]:[^:]*:Trinity Seeker:5B94:/
+4465.0 "Mercy Fourfold 2" #sync / 1[56]:[^:]*:Trinity Seeker:5B94:/
+4466.9 "Mercy Fourfold 3" #sync / 1[56]:[^:]*:Trinity Seeker:5B94:/
+4468.8 "Mercy Fourfold 4" #sync / 1[56]:[^:]*:Trinity Seeker:5B94:/
 4472.2 "--chains--" duration 3.1 # sync / 00:0000:0080:/
-4482.4 "Verdant Tempest" sync / 1[56]:Trinity Seeker:5AD3:/
-4484.6 "--middle--" sync / 1[56]:Trinity Seeker:5A9A:/
-4488.8 "Manifest Avatar" sync / 1[56]:Trinity Seeker:5ADA:/
-4498.4 "Phantom Edge?" sync / 1[56]:Trinity Seeker:5ABD:/
-4500.1 "--jump--" sync / 1[56]:Trinity Seeker:5A9A:/
-4504.9 "Iron Splitter" sync / 1[56]:Seeker Avatar:5AC0:/
-4509.2 "Baleful Blade" sync / 1[56]:Trinity Seeker:5AB[EF]:/
-4514.5 "--middle--" sync / 1[56]:Trinity Seeker:5A9A:/
-4518.7 "Manifest Avatar" sync / 1[56]:Trinity Seeker:5ADA:/
-4530.9 "First Mercy" sync / 1[56]:Seeker Avatar:5B61:/
-4534.1 "Second Mercy" sync / 1[56]:Seeker Avatar:5B62:/
+4482.4 "Verdant Tempest" sync / 1[56]:[^:]*:Trinity Seeker:5AD3:/
+4484.6 "--middle--" sync / 1[56]:[^:]*:Trinity Seeker:5A9A:/
+4488.8 "Manifest Avatar" sync / 1[56]:[^:]*:Trinity Seeker:5ADA:/
+4498.4 "Phantom Edge?" sync / 1[56]:[^:]*:Trinity Seeker:5ABD:/
+4500.1 "--jump--" sync / 1[56]:[^:]*:Trinity Seeker:5A9A:/
+4504.9 "Iron Splitter" sync / 1[56]:[^:]*:Seeker Avatar:5AC0:/
+4509.2 "Baleful Blade" sync / 1[56]:[^:]*:Trinity Seeker:5AB[EF]:/
+4514.5 "--middle--" sync / 1[56]:[^:]*:Trinity Seeker:5A9A:/
+4518.7 "Manifest Avatar" sync / 1[56]:[^:]*:Trinity Seeker:5ADA:/
+4530.9 "First Mercy" sync / 1[56]:[^:]*:Seeker Avatar:5B61:/
+4534.1 "Second Mercy" sync / 1[56]:[^:]*:Seeker Avatar:5B62:/
 4534.7 "--chains--" duration 3.1 # sync / 00:0000:0080:/
-4537.3 "Third Mercy" sync / 1[56]:Seeker Avatar:5B63:/
-4540.5 "Fourth Mercy" sync / 1[56]:Seeker Avatar:5B64:/
-4541.8 "Phantom Edge?" sync / 1[56]:Trinity Seeker:5ABD:/
-4543.0 "Mercy Fourfold 1" #sync / 1[56]:Trinity Seeker:5B94:/
-4544.0 "--middle--" sync / 1[56]:Trinity Seeker:5A9A:/
-4544.9 "Mercy Fourfold 2" #sync / 1[56]:Trinity Seeker:5B94:/
-4546.8 "Mercy Fourfold 3" #sync / 1[56]:Trinity Seeker:5B94:/
-4548.7 "Mercy Fourfold 4" #sync / 1[56]:Trinity Seeker:5B94:/
-4553.1 "Baleful Blade" sync / 1[56]:Trinity Seeker:5AB[EF]:/
-4562.3 "Phantom Edge?" sync / 1[56]:Trinity Seeker:5ABD:/
-4568.4 "Baleful Onslaught" sync / 1[56]:Trinity Seeker:5AD[56]:/
+4537.3 "Third Mercy" sync / 1[56]:[^:]*:Seeker Avatar:5B63:/
+4540.5 "Fourth Mercy" sync / 1[56]:[^:]*:Seeker Avatar:5B64:/
+4541.8 "Phantom Edge?" sync / 1[56]:[^:]*:Trinity Seeker:5ABD:/
+4543.0 "Mercy Fourfold 1" #sync / 1[56]:[^:]*:Trinity Seeker:5B94:/
+4544.0 "--middle--" sync / 1[56]:[^:]*:Trinity Seeker:5A9A:/
+4544.9 "Mercy Fourfold 2" #sync / 1[56]:[^:]*:Trinity Seeker:5B94:/
+4546.8 "Mercy Fourfold 3" #sync / 1[56]:[^:]*:Trinity Seeker:5B94:/
+4548.7 "Mercy Fourfold 4" #sync / 1[56]:[^:]*:Trinity Seeker:5B94:/
+4553.1 "Baleful Blade" sync / 1[56]:[^:]*:Trinity Seeker:5AB[EF]:/
+4562.3 "Phantom Edge?" sync / 1[56]:[^:]*:Trinity Seeker:5ABD:/
+4568.4 "Baleful Onslaught" sync / 1[56]:[^:]*:Trinity Seeker:5AD[56]:/
 
 # Enrage
-4580.9 "--sync--" sync / 14:Trinity Seeker:5BBA:/ window 1000,10
-4590.9 "Verdant Tempest Enrage" sync / 1[56]:Trinity Seeker:5BBA:/
-4593.0 "Verdant Tempest" sync / 1[56]:Trinity Seeker:5BBB:/ window 10,10 # x infinity
-4595.0 "Verdant Tempest" sync / 1[56]:Trinity Seeker:5BBB:/
-4597.0 "Verdant Tempest" sync / 1[56]:Trinity Seeker:5BBB:/
+4580.9 "--sync--" sync / 14:[^:]*:Trinity Seeker:5BBA:/ window 1000,10
+4590.9 "Verdant Tempest Enrage" sync / 1[56]:[^:]*:Trinity Seeker:5BBA:/
+4593.0 "Verdant Tempest" sync / 1[56]:[^:]*:Trinity Seeker:5BBB:/ window 10,10 # x infinity
+4595.0 "Verdant Tempest" sync / 1[56]:[^:]*:Trinity Seeker:5BBB:/
+4597.0 "Verdant Tempest" sync / 1[56]:[^:]*:Trinity Seeker:5BBB:/
 
 
 ### Dahu
@@ -310,95 +310,95 @@ hideall "--sync--"
 # are in the Dahu fight.
 6000.0 "--sync--" sync / 00:0839::The Hall of Supplication will be sealed off/ window 6000,0
 6000.0 "--Reset--" sync / 19:Dahu was defeated by/ window 0,2000 jump 0
-6008.4 "Reverberating Roar" sync / 1[56]:Dahu:576D:/ window 10,2.5
-6014.5 "Reverberating Roar" sync / 1[56]:Dahu:576D:/
-6022.7 "Hot Charge 1" sync / 1[56]:Dahu:5773:/
-6027.5 "Hot Charge 2" sync / 1[56]:Dahu:5773:/
-6034.3 "Firebreathe" sync / 1[56]:Dahu:5774:/
-6046.5 "--sync--" sync / 1[56]:Marchosias:576A:/
-6051.8 "Head Down" sync / 1[56]:Marchosias:5768:/
-6057.5 "Head Down" sync / 1[56]:Marchosias:5768:/
+6008.4 "Reverberating Roar" sync / 1[56]:[^:]*:Dahu:576D:/ window 10,2.5
+6014.5 "Reverberating Roar" sync / 1[56]:[^:]*:Dahu:576D:/
+6022.7 "Hot Charge 1" sync / 1[56]:[^:]*:Dahu:5773:/
+6027.5 "Hot Charge 2" sync / 1[56]:[^:]*:Dahu:5773:/
+6034.3 "Firebreathe" sync / 1[56]:[^:]*:Dahu:5774:/
+6046.5 "--sync--" sync / 1[56]:[^:]*:Marchosias:576A:/
+6051.8 "Head Down" sync / 1[56]:[^:]*:Marchosias:5768:/
+6057.5 "Head Down" sync / 1[56]:[^:]*:Marchosias:5768:/
 
-6061.4 "Spit Flame" sync / 1[56]:Dahu:5776:/
-6061.6 "Spit Flame 1" #sync / 1[56]:Dahu:5777:/
-6062.7 "Spit Flame 2" #sync / 1[56]:Dahu:5777:/
-6063.8 "Spit Flame 3" #sync / 1[56]:Dahu:5777:/
-6065.0 "Spit Flame 4" #sync / 1[56]:Dahu:5777:/
-6069.1 "Head Down" sync / 1[56]:Marchosias:5768:/
-6071.1 "Right-Sided Shockwave/Left-Sided Shockwave" #sync / 1[56]:Dahu:57(70|6F):/
-6073.7 "Left-Sided Shockwave/Right-Sided Shockwave" #sync / 1[56]:Dahu:577[12]:/
-6074.8 "Head Down" sync / 1[56]:Marchosias:5768:/
-6081.4 "Feral Howl" sync / 1[56]:Dahu:5767:/
-6083.5 "--knockback--" sync / 1[56]:Dahu:5B35:/
-6084.9 "Hunter's Claw" sync / 1[56]:Marchosias:5769:/
-6091.5 "Firebreathe x5" sync / 1[56]:Dahu:576B:/ duration 8.7
-6112.5 "--sync--" sync / 1[56]:Crowned Marchosias:576A:/
-6117.5 "--sync--" sync / 1[56]:Crowned Marchosias:576A:/
-6122.5 "--sync--" sync / 1[56]:Crowned Marchosias:576A:/
-6142.5 "--sync--" sync / 1[56]:Marchosias:576A:/
-6142.5 "Reverberating Roar" sync / 1[56]:Dahu:576D:/
-6147.6 "Falling Rock x6" duration 10 #sync / 1[56]:Dahu:576E:/
-6147.7 "Head Down" sync / 1[56]:Marchosias:5768:/
-6151.6 "Right-Sided Shockwave/Left-Sided Shockwave" #sync / 1[56]:Dahu:57(70|6F):/
-6153.4 "Head Down" sync / 1[56]:Marchosias:5768:/
-6154.1 "Left-Sided Shockwave/Right-Sided Shockwave" #sync / 1[56]:Dahu:577[12]:/
-6159.1 "Head Down" sync / 1[56]:Marchosias:5768:/
+6061.4 "Spit Flame" sync / 1[56]:[^:]*:Dahu:5776:/
+6061.6 "Spit Flame 1" #sync / 1[56]:[^:]*:Dahu:5777:/
+6062.7 "Spit Flame 2" #sync / 1[56]:[^:]*:Dahu:5777:/
+6063.8 "Spit Flame 3" #sync / 1[56]:[^:]*:Dahu:5777:/
+6065.0 "Spit Flame 4" #sync / 1[56]:[^:]*:Dahu:5777:/
+6069.1 "Head Down" sync / 1[56]:[^:]*:Marchosias:5768:/
+6071.1 "Right-Sided Shockwave/Left-Sided Shockwave" #sync / 1[56]:[^:]*:Dahu:57(70|6F):/
+6073.7 "Left-Sided Shockwave/Right-Sided Shockwave" #sync / 1[56]:[^:]*:Dahu:577[12]:/
+6074.8 "Head Down" sync / 1[56]:[^:]*:Marchosias:5768:/
+6081.4 "Feral Howl" sync / 1[56]:[^:]*:Dahu:5767:/
+6083.5 "--knockback--" sync / 1[56]:[^:]*:Dahu:5B35:/
+6084.9 "Hunter's Claw" sync / 1[56]:[^:]*:Marchosias:5769:/
+6091.5 "Firebreathe x5" sync / 1[56]:[^:]*:Dahu:576B:/ duration 8.7
+6112.5 "--sync--" sync / 1[56]:[^:]*:Crowned Marchosias:576A:/
+6117.5 "--sync--" sync / 1[56]:[^:]*:Crowned Marchosias:576A:/
+6122.5 "--sync--" sync / 1[56]:[^:]*:Crowned Marchosias:576A:/
+6142.5 "--sync--" sync / 1[56]:[^:]*:Marchosias:576A:/
+6142.5 "Reverberating Roar" sync / 1[56]:[^:]*:Dahu:576D:/
+6147.6 "Falling Rock x6" duration 10 #sync / 1[56]:[^:]*:Dahu:576E:/
+6147.7 "Head Down" sync / 1[56]:[^:]*:Marchosias:5768:/
+6151.6 "Right-Sided Shockwave/Left-Sided Shockwave" #sync / 1[56]:[^:]*:Dahu:57(70|6F):/
+6153.4 "Head Down" sync / 1[56]:[^:]*:Marchosias:5768:/
+6154.1 "Left-Sided Shockwave/Right-Sided Shockwave" #sync / 1[56]:[^:]*:Dahu:577[12]:/
+6159.1 "Head Down" sync / 1[56]:[^:]*:Marchosias:5768:/
 
-6164.7 "Spit Flame" sync / 1[56]:Dahu:5776:/
-6165.0 "Spit Flame 1" #sync / 1[56]:Dahu:5777:/
-6166.1 "Spit Flame 2" #sync / 1[56]:Dahu:5777:/
-6167.3 "Spit Flame 3" #sync / 1[56]:Dahu:5777:/
-6168.4 "Spit Flame 4" #sync / 1[56]:Dahu:5777:/
-6174.6 "Hysteric Assault" sync / 1[56]:Dahu:5778:/
-6175.5 "--knockback--" sync / 1[56]:Dahu:5B43:/
-6177.7 "Burn x2" sync / 1[56]:Dahu:5463:/
-6178.1 "Hunter's Claw" sync / 1[56]:Marchosias:5769:/
-6187.6 "Head Down" sync / 1[56]:Marchosias:5768:/
-6188.9 "Firebreathe x5" sync / 1[56]:Dahu:576B:/ duration 8.7
-6209.9 "Right-Sided Shockwave/Left-Sided Shockwave" #sync / 1[56]:Dahu:57(70|6F):/
-6212.5 "Left-Sided Shockwave/Right-Sided Shockwave" #sync / 1[56]:Dahu:577[12]:/
+6164.7 "Spit Flame" sync / 1[56]:[^:]*:Dahu:5776:/
+6165.0 "Spit Flame 1" #sync / 1[56]:[^:]*:Dahu:5777:/
+6166.1 "Spit Flame 2" #sync / 1[56]:[^:]*:Dahu:5777:/
+6167.3 "Spit Flame 3" #sync / 1[56]:[^:]*:Dahu:5777:/
+6168.4 "Spit Flame 4" #sync / 1[56]:[^:]*:Dahu:5777:/
+6174.6 "Hysteric Assault" sync / 1[56]:[^:]*:Dahu:5778:/
+6175.5 "--knockback--" sync / 1[56]:[^:]*:Dahu:5B43:/
+6177.7 "Burn x2" sync / 1[56]:[^:]*:Dahu:5463:/
+6178.1 "Hunter's Claw" sync / 1[56]:[^:]*:Marchosias:5769:/
+6187.6 "Head Down" sync / 1[56]:[^:]*:Marchosias:5768:/
+6188.9 "Firebreathe x5" sync / 1[56]:[^:]*:Dahu:576B:/ duration 8.7
+6209.9 "Right-Sided Shockwave/Left-Sided Shockwave" #sync / 1[56]:[^:]*:Dahu:57(70|6F):/
+6212.5 "Left-Sided Shockwave/Right-Sided Shockwave" #sync / 1[56]:[^:]*:Dahu:577[12]:/
 
 # This is a single or a double hot charge.
-6221.4 "Hot Charge 1" sync / 1[56]:Dahu:5773:/
-6226.2 "Hot Charge 2?" sync / 1[56]:Dahu:5773:/
-6228.0 "--sync--" sync / 14:Dahu:5774:/ window 20,20
-6233.0 "Firebreathe" sync / 1[56]:Dahu:5774:/
-6246.3 "--sync--" sync / 1[56]:Crowned Marchosias:576A:/
-6251.3 "--sync--" sync / 1[56]:Crowned Marchosias:576A:/
-6252.2 "Reverberating Roar" sync / 1[56]:Dahu:576D:/
-6256.3 "--sync--" sync / 1[56]:Crowned Marchosias:576A:/
-6261.3 "Reverberating Roar" sync / 1[56]:Dahu:576D:/
-6289.5 "Reverberating Roar" sync / 1[56]:Dahu:576D:/
-6289.5 "--sync--" sync / 1[56]:Marchosias:576A:/
-6289.5 "--sync--" sync / 1[56]:Marchosias:576A:/
-6294.7 "Head Down" sync / 1[56]:Marchosias:5768:/
-6298.6 "Right-Sided Shockwave/Left-Sided Shockwave" #sync / 1[56]:Dahu:57(70|6F):/
-6300.4 "Head Down" sync / 1[56]:Marchosias:5768:/
-6301.1 "Left-Sided Shockwave/Right-Sided Shockwave" #sync / 1[56]:Dahu:577[12]:/
-6306.0 "Head Down" sync / 1[56]:Marchosias:5768:/
-6306.0 "Head Down" sync / 1[56]:Marchosias:5768:/
+6221.4 "Hot Charge 1" sync / 1[56]:[^:]*:Dahu:5773:/
+6226.2 "Hot Charge 2?" sync / 1[56]:[^:]*:Dahu:5773:/
+6228.0 "--sync--" sync / 14:[^:]*:Dahu:5774:/ window 20,20
+6233.0 "Firebreathe" sync / 1[56]:[^:]*:Dahu:5774:/
+6246.3 "--sync--" sync / 1[56]:[^:]*:Crowned Marchosias:576A:/
+6251.3 "--sync--" sync / 1[56]:[^:]*:Crowned Marchosias:576A:/
+6252.2 "Reverberating Roar" sync / 1[56]:[^:]*:Dahu:576D:/
+6256.3 "--sync--" sync / 1[56]:[^:]*:Crowned Marchosias:576A:/
+6261.3 "Reverberating Roar" sync / 1[56]:[^:]*:Dahu:576D:/
+6289.5 "Reverberating Roar" sync / 1[56]:[^:]*:Dahu:576D:/
+6289.5 "--sync--" sync / 1[56]:[^:]*:Marchosias:576A:/
+6289.5 "--sync--" sync / 1[56]:[^:]*:Marchosias:576A:/
+6294.7 "Head Down" sync / 1[56]:[^:]*:Marchosias:5768:/
+6298.6 "Right-Sided Shockwave/Left-Sided Shockwave" #sync / 1[56]:[^:]*:Dahu:57(70|6F):/
+6300.4 "Head Down" sync / 1[56]:[^:]*:Marchosias:5768:/
+6301.1 "Left-Sided Shockwave/Right-Sided Shockwave" #sync / 1[56]:[^:]*:Dahu:577[12]:/
+6306.0 "Head Down" sync / 1[56]:[^:]*:Marchosias:5768:/
+6306.0 "Head Down" sync / 1[56]:[^:]*:Marchosias:5768:/
 
-6311.7 "Spit Flame 1" sync / 1[56]:Dahu:5776:/
-6312.1 "Spit Flame 2" sync / 1[56]:Dahu:5777:/
-6313.3 "Spit Flame 3" sync / 1[56]:Dahu:5777:/
-6314.4 "Spit Flame 4" sync / 1[56]:Dahu:5777:/
-6320.6 "Hysteric Assault" sync / 1[56]:Dahu:5778:/
-6321.5 "--knockback--" sync / 1[56]:Dahu:5B43:/
-6323.7 "Burn x2" sync / 1[56]:Dahu:5463:/
-6324.1 "Hunter's Claw" sync / 1[56]:Marchosias:5769:/
-6334.4 "Head Down" sync / 1[56]:Marchosias:5768:/
-6335.2 "Firebreathe" sync / 1[56]:Dahu:576B:/
-6356.2 "Right-Sided Shockwave/Left-Sided Shockwave" #sync / 1[56]:Dahu:57(70|6F):/
-6358.8 "Left-Sided Shockwave/Right-Sided Shockwave" #sync / 1[56]:Dahu:577[12]:/
+6311.7 "Spit Flame 1" sync / 1[56]:[^:]*:Dahu:5776:/
+6312.1 "Spit Flame 2" sync / 1[56]:[^:]*:Dahu:5777:/
+6313.3 "Spit Flame 3" sync / 1[56]:[^:]*:Dahu:5777:/
+6314.4 "Spit Flame 4" sync / 1[56]:[^:]*:Dahu:5777:/
+6320.6 "Hysteric Assault" sync / 1[56]:[^:]*:Dahu:5778:/
+6321.5 "--knockback--" sync / 1[56]:[^:]*:Dahu:5B43:/
+6323.7 "Burn x2" sync / 1[56]:[^:]*:Dahu:5463:/
+6324.1 "Hunter's Claw" sync / 1[56]:[^:]*:Marchosias:5769:/
+6334.4 "Head Down" sync / 1[56]:[^:]*:Marchosias:5768:/
+6335.2 "Firebreathe" sync / 1[56]:[^:]*:Dahu:576B:/
+6356.2 "Right-Sided Shockwave/Left-Sided Shockwave" #sync / 1[56]:[^:]*:Dahu:57(70|6F):/
+6358.8 "Left-Sided Shockwave/Right-Sided Shockwave" #sync / 1[56]:[^:]*:Dahu:577[12]:/
 
 # Probably a loop, but you shouldn't see this charge, let alone the previous one.
-6367.8 "Hot Charge 1" sync / 1[56]:Dahu:5773:/
-6372.6 "Hot Charge 2?" sync / 1[56]:Dahu:5773:/
-6374.4 "--sync--" sync / 14:Dahu:5774:/ window 100,100 jump 6228.0
-6379.4 "Firebreathe" sync / 1[56]:Dahu:5774:/
-6398.6 "Reverberating Roar" #sync / 1[56]:Dahu:576D:/
-6407.7 "Reverberating Roar" #sync / 1[56]:Dahu:576D:/
-6435.9 "Reverberating Roar" #sync / 1[56]:Dahu:576D:/
+6367.8 "Hot Charge 1" sync / 1[56]:[^:]*:Dahu:5773:/
+6372.6 "Hot Charge 2?" sync / 1[56]:[^:]*:Dahu:5773:/
+6374.4 "--sync--" sync / 14:[^:]*:Dahu:5774:/ window 100,100 jump 6228.0
+6379.4 "Firebreathe" sync / 1[56]:[^:]*:Dahu:5774:/
+6398.6 "Reverberating Roar" #sync / 1[56]:[^:]*:Dahu:576D:/
+6407.7 "Reverberating Roar" #sync / 1[56]:[^:]*:Dahu:576D:/
+6435.9 "Reverberating Roar" #sync / 1[56]:[^:]*:Dahu:576D:/
 
 
 ### Stygimoloch Warrior
@@ -412,77 +412,77 @@ hideall "--sync--"
 # TODO: is there a reset dialog line for losing?
 # Alternatively, we could always insert " 19:${data.me} was defeated by" from script.
 
-8002.1 "--sync--" sync / 1[56]:Stygimoloch Warrior:1961:/ window 20000,0
-8009.1 "--sync--" sync / 14:Stygimoloch Warrior:5796:/ window 20,20
-8012.1 "Surge of Vigor" sync / 1[56]:Stygimoloch Warrior:5796:/
-8024.3 "Unrelenting Charge x3" sync / 1[56]:Stygimoloch Warrior:5799:/
-8035.4 "--north--" sync / 1[56]:Stygimoloch Warrior:577C:/
-8039.7 "Entrapment" sync / 1[56]:Stygimoloch Warrior:577D:/
-8040.5 "--knockback--" sync / 1[56]:Stygimoloch Warrior:577E:/
-8061.8 "Lethal Blow" sync / 1[56]:Stygimoloch Warrior:577F:/
-8067.9 "Vicious Swipe" sync / 1[56]:Stygimoloch Warrior:5797:/
+8002.1 "--sync--" sync / 1[56]:[^:]*:Stygimoloch Warrior:1961:/ window 20000,0
+8009.1 "--sync--" sync / 14:[^:]*:Stygimoloch Warrior:5796:/ window 20,20
+8012.1 "Surge of Vigor" sync / 1[56]:[^:]*:Stygimoloch Warrior:5796:/
+8024.3 "Unrelenting Charge x3" sync / 1[56]:[^:]*:Stygimoloch Warrior:5799:/
+8035.4 "--north--" sync / 1[56]:[^:]*:Stygimoloch Warrior:577C:/
+8039.7 "Entrapment" sync / 1[56]:[^:]*:Stygimoloch Warrior:577D:/
+8040.5 "--knockback--" sync / 1[56]:[^:]*:Stygimoloch Warrior:577E:/
+8061.8 "Lethal Blow" sync / 1[56]:[^:]*:Stygimoloch Warrior:577F:/
+8067.9 "Vicious Swipe" sync / 1[56]:[^:]*:Stygimoloch Warrior:5797:/
 8069.9 "--knockback--"
-8069.9 "Crazed Rampage" sync / 1[56]:Stygimoloch Warrior:5798:/
-8081.0 "Focused Tremor" sync / 1[56]:Stygimoloch Warrior:578E:/
-8083.2 "--corner--" sync / 1[56]:Stygimoloch Warrior:577C:/
-8089.8 "Focused Tremor 1" #sync / 1[56]:Stygimoloch Warrior:578F:/
-8091.8 "Focused Tremor 2" #sync / 1[56]:Stygimoloch Warrior:578F:/
-8093.8 "Focused Tremor 3" #sync / 1[56]:Stygimoloch Warrior:578F:/
-8095.8 "Focused Tremor 4" #sync / 1[56]:Stygimoloch Warrior:578F:/
-8099.4 "Forceful Strike" sync / 1[56]:Stygimoloch Warrior:5792:/
-8109.5 "--middle--" sync / 1[56]:Stygimoloch Warrior:577C:/
-8113.7 "Inescapable Entrapment" sync / 1[56]:Stygimoloch Warrior:5780:/
+8069.9 "Crazed Rampage" sync / 1[56]:[^:]*:Stygimoloch Warrior:5798:/
+8081.0 "Focused Tremor" sync / 1[56]:[^:]*:Stygimoloch Warrior:578E:/
+8083.2 "--corner--" sync / 1[56]:[^:]*:Stygimoloch Warrior:577C:/
+8089.8 "Focused Tremor 1" #sync / 1[56]:[^:]*:Stygimoloch Warrior:578F:/
+8091.8 "Focused Tremor 2" #sync / 1[56]:[^:]*:Stygimoloch Warrior:578F:/
+8093.8 "Focused Tremor 3" #sync / 1[56]:[^:]*:Stygimoloch Warrior:578F:/
+8095.8 "Focused Tremor 4" #sync / 1[56]:[^:]*:Stygimoloch Warrior:578F:/
+8099.4 "Forceful Strike" sync / 1[56]:[^:]*:Stygimoloch Warrior:5792:/
+8109.5 "--middle--" sync / 1[56]:[^:]*:Stygimoloch Warrior:577C:/
+8113.7 "Inescapable Entrapment" sync / 1[56]:[^:]*:Stygimoloch Warrior:5780:/
 
 # Single Trap
-8120.8 "--sync--" sync / 14:Stygimoloch Warrior:578[15]:/ window 20,20
-8133.8 "Surging Flames/Withering Curse?" sync / 1[56]:Stygimoloch Warrior:578[15]:/
-8133.8 "--sync--" sync / 1[56]:Stygimoloch Warrior:5781:/ jump 8137.3 # if Surging Flames, skip +3.5s ahead
-8136.4 "Devour?" sync / 1[56]:Stygimoloch Warrior:5789:/ # only if Withering Curse
+8120.8 "--sync--" sync / 14:[^:]*:Stygimoloch Warrior:578[15]:/ window 20,20
+8133.8 "Surging Flames/Withering Curse?" sync / 1[56]:[^:]*:Stygimoloch Warrior:578[15]:/
+8133.8 "--sync--" sync / 1[56]:[^:]*:Stygimoloch Warrior:5781:/ jump 8137.3 # if Surging Flames, skip +3.5s ahead
+8136.4 "Devour?" sync / 1[56]:[^:]*:Stygimoloch Warrior:5789:/ # only if Withering Curse
 
 # Round 2
-8146.6 "--sync--" sync / 14:Stygimoloch Warrior:5796:/ window 20,20
-8149.6 "Surge of Vigor" sync / 1[56]:Stygimoloch Warrior:5796:/
-8163.7 "Focused Tremor x16" sync / 1[56]:Stygimoloch Warrior:578E:/ duration 30.7
-8167.8 "--middle--" sync / 1[56]:Stygimoloch Warrior:577C:/
-8178.2 "Flailing Strike x7" sync / 1[56]:Stygimoloch Warrior:578C:/ duration 8.7
-8191.7 "Vicious Swipe" sync / 1[56]:Stygimoloch Warrior:5797:/
+8146.6 "--sync--" sync / 14:[^:]*:Stygimoloch Warrior:5796:/ window 20,20
+8149.6 "Surge of Vigor" sync / 1[56]:[^:]*:Stygimoloch Warrior:5796:/
+8163.7 "Focused Tremor x16" sync / 1[56]:[^:]*:Stygimoloch Warrior:578E:/ duration 30.7
+8167.8 "--middle--" sync / 1[56]:[^:]*:Stygimoloch Warrior:577C:/
+8178.2 "Flailing Strike x7" sync / 1[56]:[^:]*:Stygimoloch Warrior:578C:/ duration 8.7
+8191.7 "Vicious Swipe" sync / 1[56]:[^:]*:Stygimoloch Warrior:5797:/
 8193.7 "--knockback--"
-8193.7 "Crazed Rampage" sync / 1[56]:Stygimoloch Warrior:5798:/
-8202.9 "--middle--" sync / 1[56]:Stygimoloch Warrior:577C:/
-8207.2 "Inescapable Entrapment" sync / 1[56]:Stygimoloch Warrior:5780:/
+8193.7 "Crazed Rampage" sync / 1[56]:[^:]*:Stygimoloch Warrior:5798:/
+8202.9 "--middle--" sync / 1[56]:[^:]*:Stygimoloch Warrior:577C:/
+8207.2 "Inescapable Entrapment" sync / 1[56]:[^:]*:Stygimoloch Warrior:5780:/
 
 # Triple Trap
-8210.4 "--sync--" sync / 14:Stygimoloch Warrior:578[15]:/ window 20,20
-8223.4 "Surging Flames/Withering Curse?" sync / 1[56]:Stygimoloch Warrior:578[15]:/
-8223.4 "--sync--" sync / 1[56]:Stygimoloch Warrior:5781:/ jump 8223.9 # if Surging Flames, skip +3.5s ahead
-8225.8 "Devour?" sync / 1[56]:Stygimoloch Warrior:5789:/ # only if Withering Curse
-8229.9 "--sync--" sync / 14:Stygimoloch Warrior:5783:/ window 20,20
-8239.9 "Surging Flood" sync / 1[56]:Stygimoloch Warrior:5783:/
-8248.1 "Leaping Spark x3" sync / 1[56]:Stygimoloch Warrior:578A:/
+8210.4 "--sync--" sync / 14:[^:]*:Stygimoloch Warrior:578[15]:/ window 20,20
+8223.4 "Surging Flames/Withering Curse?" sync / 1[56]:[^:]*:Stygimoloch Warrior:578[15]:/
+8223.4 "--sync--" sync / 1[56]:[^:]*:Stygimoloch Warrior:5781:/ jump 8223.9 # if Surging Flames, skip +3.5s ahead
+8225.8 "Devour?" sync / 1[56]:[^:]*:Stygimoloch Warrior:5789:/ # only if Withering Curse
+8229.9 "--sync--" sync / 14:[^:]*:Stygimoloch Warrior:5783:/ window 20,20
+8239.9 "Surging Flood" sync / 1[56]:[^:]*:Stygimoloch Warrior:5783:/
+8248.1 "Leaping Spark x3" sync / 1[56]:[^:]*:Stygimoloch Warrior:578A:/
 
 # From here on is without log
 # Unsure which ID Coerce is: 5795, 5794, 5793
-8263.1 "Coerce" sync / 1[56]:Stygimoloch Warrior:579[345]:/ window 20,20
+8263.1 "Coerce" sync / 1[56]:[^:]*:Stygimoloch Warrior:579[345]:/ window 20,20
 
 # Round 3
-8269.1 "Surge of Vigor" sync / 1[56]:Stygimoloch Warrior:5796:/ window 20,20
-8284.0 "Focused Tremor" sync / 1[56]:Stygimoloch Warrior:578E:/
-8286.3 "--corner--" sync / 1[56]:Stygimoloch Warrior:577C:/
-8292.8 "Focused Tremor 1" sync / 1[56]:Stygimoloch Warrior:578F:/
-8294.8 "Focused Tremor 2" #sync / 1[56]:Stygimoloch Warrior:578F:/
-8296.8 "Focused Tremor 3" #sync / 1[56]:Stygimoloch Warrior:578F:/
-8298.8 "Focused Tremor 4" #sync / 1[56]:Stygimoloch Warrior:578F:/
-8302.4 "Forceful Strike" sync / 1[56]:Stygimoloch Warrior:5792:/
+8269.1 "Surge of Vigor" sync / 1[56]:[^:]*:Stygimoloch Warrior:5796:/ window 20,20
+8284.0 "Focused Tremor" sync / 1[56]:[^:]*:Stygimoloch Warrior:578E:/
+8286.3 "--corner--" sync / 1[56]:[^:]*:Stygimoloch Warrior:577C:/
+8292.8 "Focused Tremor 1" sync / 1[56]:[^:]*:Stygimoloch Warrior:578F:/
+8294.8 "Focused Tremor 2" #sync / 1[56]:[^:]*:Stygimoloch Warrior:578F:/
+8296.8 "Focused Tremor 3" #sync / 1[56]:[^:]*:Stygimoloch Warrior:578F:/
+8298.8 "Focused Tremor 4" #sync / 1[56]:[^:]*:Stygimoloch Warrior:578F:/
+8302.4 "Forceful Strike" sync / 1[56]:[^:]*:Stygimoloch Warrior:5792:/
 
 # Round 4
-8315.1 "Surge of Vigor" sync / 1[56]:Stygimoloch Warrior:5796:/ window 20,20
-8327.3 "Unrelenting Charge x3" sync / 1[56]:Stygimoloch Warrior:5799:/
-8336.3 "Vicious Swipe" sync / 1[56]:Stygimoloch Warrior:5797:/
+8315.1 "Surge of Vigor" sync / 1[56]:[^:]*:Stygimoloch Warrior:5796:/ window 20,20
+8327.3 "Unrelenting Charge x3" sync / 1[56]:[^:]*:Stygimoloch Warrior:5799:/
+8336.3 "Vicious Swipe" sync / 1[56]:[^:]*:Stygimoloch Warrior:5797:/
 8338.3 "--knockback--"
-8338.3 "Crazed Rampage" sync / 1[56]:Stygimoloch Warrior:5798:/
-8348.3 "--middle--" sync / 1[56]:Stygimoloch Warrior:577C:/
+8338.3 "Crazed Rampage" sync / 1[56]:[^:]*:Stygimoloch Warrior:5798:/
+8348.3 "--middle--" sync / 1[56]:[^:]*:Stygimoloch Warrior:577C:/
 
-8359.1 "Sun's Ire (Enrage)" sync / 1[56]:Stygimoloch Warrior:577A:/ window 20,20
+8359.1 "Sun's Ire (Enrage)" sync / 1[56]:[^:]*:Stygimoloch Warrior:577A:/ window 20,20
 
 
 ### Queen's Guard
@@ -503,164 +503,164 @@ hideall "--sync--"
 10000.0 "--sync--" sync / 00:0839::The Hall of Hieromancy will be sealed off/ window 20000,0
 10000.0 "--Reset--" sync / 00:0839::.*is no longer sealed/ window 0,2000 jump 0
 # ranged auto should be reasonably timed
-10002.5 "--sync--" sync / 1[56]:Queen's Gunner:5858:/ window 3,1
+10002.5 "--sync--" sync / 1[56]:[^:]*:Queen's Gunner:5858:/ window 3,1
 
 # Phase 1: aoes (to 80%)
-10011.5 "--sync--" sync / 14:Queen's Warrior:5831:/ window 20,20
-10016.6 "Blood And Bone" sync / 1[56]:Queen's Warrior:5831:/
-10025.6 "Blood And Bone" sync / 1[56]:Queen's Soldier:5841:/
+10011.5 "--sync--" sync / 14:[^:]*:Queen's Warrior:5831:/ window 20,20
+10016.6 "Blood And Bone" sync / 1[56]:[^:]*:Queen's Warrior:5831:/
+10025.6 "Blood And Bone" sync / 1[56]:[^:]*:Queen's Soldier:5841:/
 10030.6 "--untargetable--"
 
 
 # Phase 2: Warrior + Knight section
 10033.9 "--targetable--" sync / 22:........:Queen's Knight:........:Queen's Knight:01/ window 25,0
-10051.1 "--sync--" sync / 14:Queen's Warrior:5825:/ window 60,20
-10056.1 "Relentless Battery" sync / 1[56]:Queen's Warrior:5825:/
-10062.2 "Shield Omen/Sword Omen" sync / 1[56]:Queen's Knight:581[45]:/
+10051.1 "--sync--" sync / 14:[^:]*:Queen's Warrior:5825:/ window 60,20
+10056.1 "Relentless Battery" sync / 1[56]:[^:]*:Queen's Warrior:5825:/
+10062.2 "Shield Omen/Sword Omen" sync / 1[56]:[^:]*:Queen's Knight:581[45]:/
 
-10063.2 "Bombslinger" sync / 1[56]:Queen's Warrior:5AFE:/
+10063.2 "Bombslinger" sync / 1[56]:[^:]*:Queen's Warrior:5AFE:/
 10066.3 "--tethers--"
 10069.3 "--untargetable--" # knight
-10070.3 "Reversal Of Forces" sync / 1[56]:Queen's Warrior:5829:/
-10070.3 "--sync--" sync / 1[56]:Queen's Warrior:5A94:/
-10079.5 "Optimal Offensive" sync / 1[56]:Queen's Knight:581[9A]:/
-10081.1 "Unlucky Lot" #sync / 1[56]:Aetherial Sphere:581D:/
-10081.4 "Above Board" sync / 1[56]:Queen's Warrior:5826:/
+10070.3 "Reversal Of Forces" sync / 1[56]:[^:]*:Queen's Warrior:5829:/
+10070.3 "--sync--" sync / 1[56]:[^:]*:Queen's Warrior:5A94:/
+10079.5 "Optimal Offensive" sync / 1[56]:[^:]*:Queen's Knight:581[9A]:/
+10081.1 "Unlucky Lot" #sync / 1[56]:[^:]*:Aetherial Sphere:581D:/
+10081.4 "Above Board" sync / 1[56]:[^:]*:Queen's Warrior:5826:/
 10082.4 "--stunned--" # 3 or 7 second stun
-10084.5 "Lots Cast" #sync / 1[56]:Aetherial Bolt:5828:/
+10084.5 "Lots Cast" #sync / 1[56]:[^:]*:Aetherial Bolt:5828:/
 #10085.8 "--targetable--" # knight, everybody stunned, so not listed
-10087.5 "Lots Cast" #sync / 1[56]:Aetherial Burst:5827:/
-10088.7 "Lots Cast" #sync / 1[56]:Aetherial Burst:5BB7:/
+10087.5 "Lots Cast" #sync / 1[56]:[^:]*:Aetherial Burst:5827:/
+10088.7 "Lots Cast" #sync / 1[56]:[^:]*:Aetherial Burst:5BB7:/
 10089.4 "--unstunned--"
 
-10097.6 "Boost" sync / 1[56]:Queen's Warrior:582D:/
-10105.8 "Blood And Bone" sync / 1[56]:Queen's Warrior:5831:/
-10121.0 "Relentless Battery" sync / 1[56]:Queen's Warrior:5825:/
+10097.6 "Boost" sync / 1[56]:[^:]*:Queen's Warrior:582D:/
+10105.8 "Blood And Bone" sync / 1[56]:[^:]*:Queen's Warrior:5831:/
+10121.0 "Relentless Battery" sync / 1[56]:[^:]*:Queen's Warrior:5825:/
 10124.1 "--tethers--"
-10128.1 "Reversal Of Forces" sync / 1[56]:Queen's Warrior:5829:/
-10136.2 "Shield Omen/Sword Omen" sync / 1[56]:Queen's Knight:581[45]:/
-10137.3 "Winds Of Weight" sync / 1[56]:Queen's Warrior:582A:/
-10137.3 "Winds Of Fate" sync / 1[56]:Queen's Warrior:582C:/
-10137.3 "Weight Of Fortune" sync / 1[56]:Queen's Warrior:582B:/
-10144.4 "Optimal Play" sync / 1[56]:Queen's Knight:581[67]:/
-10146.4 "Boost" sync / 1[56]:Queen's Warrior:582D:/
-10154.6 "Blood And Bone" sync / 1[56]:Queen's Warrior:5831:/
-10163.7 "Rapid Sever" sync / 1[56]:Queen's Warrior:5832:/
+10128.1 "Reversal Of Forces" sync / 1[56]:[^:]*:Queen's Warrior:5829:/
+10136.2 "Shield Omen/Sword Omen" sync / 1[56]:[^:]*:Queen's Knight:581[45]:/
+10137.3 "Winds Of Weight" sync / 1[56]:[^:]*:Queen's Warrior:582A:/
+10137.3 "Winds Of Fate" sync / 1[56]:[^:]*:Queen's Warrior:582C:/
+10137.3 "Weight Of Fortune" sync / 1[56]:[^:]*:Queen's Warrior:582B:/
+10144.4 "Optimal Play" sync / 1[56]:[^:]*:Queen's Knight:581[67]:/
+10146.4 "Boost" sync / 1[56]:[^:]*:Queen's Warrior:582D:/
+10154.6 "Blood And Bone" sync / 1[56]:[^:]*:Queen's Warrior:5831:/
+10163.7 "Rapid Sever" sync / 1[56]:[^:]*:Queen's Warrior:5832:/
 
 # loop, unrolled so there can be an explicit enrage
-10185.9 "Relentless Battery" sync / 1[56]:Queen's Warrior:5825:/
-10192.1 "Shield Omen/Sword Omen" sync / 1[56]:Queen's Knight:581[45]:/
+10185.9 "Relentless Battery" sync / 1[56]:[^:]*:Queen's Warrior:5825:/
+10192.1 "Shield Omen/Sword Omen" sync / 1[56]:[^:]*:Queen's Knight:581[45]:/
 
-10193.0 "Bombslinger" sync / 1[56]:Queen's Warrior:5AFE:/
+10193.0 "Bombslinger" sync / 1[56]:[^:]*:Queen's Warrior:5AFE:/
 10196.1 "--tethers--"
 10199.1 "--untargetable--" # knight
-10200.1 "Reversal Of Forces" sync / 1[56]:Queen's Warrior:5829:/
-10209.4 "Optimal Offensive" sync / 1[56]:Queen's Knight:581[9A]:/
-10211.0 "Unlucky Lot" #sync / 1[56]:Aetherial Sphere:581D:/
-10211.2 "Above Board" sync / 1[56]:Queen's Warrior:5826:/
+10200.1 "Reversal Of Forces" sync / 1[56]:[^:]*:Queen's Warrior:5829:/
+10209.4 "Optimal Offensive" sync / 1[56]:[^:]*:Queen's Knight:581[9A]:/
+10211.0 "Unlucky Lot" #sync / 1[56]:[^:]*:Aetherial Sphere:581D:/
+10211.2 "Above Board" sync / 1[56]:[^:]*:Queen's Warrior:5826:/
 10212.2 "--stunned--" # 3 or 7 second stun
-10211.2 "--sync--" sync / 1[56]:Queen's Warrior:5B72:/
-10214.2 "Lots Cast" #sync / 1[56]:Aetherial Burst:5B6D:/
+10211.2 "--sync--" sync / 1[56]:[^:]*:Queen's Warrior:5B72:/
+10214.2 "Lots Cast" #sync / 1[56]:[^:]*:Aetherial Burst:5B6D:/
 #10215.5 "--targetable--" # knight, everybody stunned, so not listed
-10217.2 "Lots Cast" #sync / 1[56]:Aetherial Bolt:5B6C:/
-10218.4 "Lots Cast" #sync / 1[56]:Aetherial Bolt:5BB7:/
+10217.2 "Lots Cast" #sync / 1[56]:[^:]*:Aetherial Bolt:5B6C:/
+10218.4 "Lots Cast" #sync / 1[56]:[^:]*:Aetherial Bolt:5BB7:/
 10219.2 "--unstunned--"
 
-10227.3 "Boost" sync / 1[56]:Queen's Warrior:582D:/
-10235.5 "Blood And Bone" sync / 1[56]:Queen's Warrior:5831:/
-10250.7 "Relentless Battery" sync / 1[56]:Queen's Warrior:5825:/
+10227.3 "Boost" sync / 1[56]:[^:]*:Queen's Warrior:582D:/
+10235.5 "Blood And Bone" sync / 1[56]:[^:]*:Queen's Warrior:5831:/
+10250.7 "Relentless Battery" sync / 1[56]:[^:]*:Queen's Warrior:5825:/
 10253.8 "--tethers--"
-10257.8 "Reversal Of Forces" sync / 1[56]:Queen's Warrior:5829:/
-10265.9 "Shield Omen/Sword Omen" sync / 1[56]:Queen's Knight:581[45]:/
-10267.0 "Winds Of Weight" sync / 1[56]:Queen's Warrior:582A:/
-10267.0 "Winds Of Fate" sync / 1[56]:Queen's Warrior:582C:/
-10267.0 "Winds Of Fate" sync / 1[56]:Queen's Warrior:582C:/
-10267.0 "Weight Of Fortune" sync / 1[56]:Queen's Warrior:582B:/
-10274.1 "Optimal Play" sync / 1[56]:Queen's Knight:581[67]:/
-10276.1 "Boost" sync / 1[56]:Queen's Warrior:582D:/
-10284.3 "Blood And Bone" sync / 1[56]:Queen's Warrior:5831:/
-10293.4 "Rapid Sever" sync / 1[56]:Queen's Warrior:5832:/
+10257.8 "Reversal Of Forces" sync / 1[56]:[^:]*:Queen's Warrior:5829:/
+10265.9 "Shield Omen/Sword Omen" sync / 1[56]:[^:]*:Queen's Knight:581[45]:/
+10267.0 "Winds Of Weight" sync / 1[56]:[^:]*:Queen's Warrior:582A:/
+10267.0 "Winds Of Fate" sync / 1[56]:[^:]*:Queen's Warrior:582C:/
+10267.0 "Winds Of Fate" sync / 1[56]:[^:]*:Queen's Warrior:582C:/
+10267.0 "Weight Of Fortune" sync / 1[56]:[^:]*:Queen's Warrior:582B:/
+10274.1 "Optimal Play" sync / 1[56]:[^:]*:Queen's Knight:581[67]:/
+10276.1 "Boost" sync / 1[56]:[^:]*:Queen's Warrior:582D:/
+10284.3 "Blood And Bone" sync / 1[56]:[^:]*:Queen's Warrior:5831:/
+10293.4 "Rapid Sever" sync / 1[56]:[^:]*:Queen's Warrior:5832:/
 
 # If either die, they will start casting enrage.
-10302.9 "--sync--" sync / 14:Queen's Knight:5823:/ window 300,10
-10302.9 "--sync--" sync / 14:Queen's Warrior:5833:/ window 300,10
-10312.9 "Blood and Bone Enrage" sync / 1[56]:Queen's Warrior:5833:/
-10316.0 "Blood and Bone Enrage" sync / 1[56]:Queen's Knight:5B9D:/ window 10,10 # x infinity
-10319.1 "Blood and Bone Enrage" sync / 1[56]:Queen's Knight:5B9D:/
-10322.2 "Blood and Bone Enrage" sync / 1[56]:Queen's Knight:5B9D:/
+10302.9 "--sync--" sync / 14:[^:]*:Queen's Knight:5823:/ window 300,10
+10302.9 "--sync--" sync / 14:[^:]*:Queen's Warrior:5833:/ window 300,10
+10312.9 "Blood and Bone Enrage" sync / 1[56]:[^:]*:Queen's Warrior:5833:/
+10316.0 "Blood and Bone Enrage" sync / 1[56]:[^:]*:Queen's Knight:5B9D:/ window 10,10 # x infinity
+10319.1 "Blood and Bone Enrage" sync / 1[56]:[^:]*:Queen's Knight:5B9D:/
+10322.2 "Blood and Bone Enrage" sync / 1[56]:[^:]*:Queen's Knight:5B9D:/
 
 # Phase 3: Soldier + Gunner section
 10600.0 "--sync--" sync / 22:........:Queen's Gunner::........::Queen's Gunner:01/ window 600,0
-10612.0 "--sync--" sync / 14:Queen's Gunner:5844:/ window 600,0
-10617.0 "Relentless Battery" sync / 1[56]:Queen's Gunner:5844:/
-10623.2 "Great Ball Of Fire" sync / 1[56]:Queen's Soldier:583B:/
-10632.3 "Fool's Gambit" sync / 1[56]:Queen's Soldier:583C:/
-10635.2 "Automatic Turret" sync / 1[56]:Queen's Gunner:584A:/
-10641.3 "Reading" sync / 1[56]:Queen's Gunner:584B:/
-10647.9 "Burn" sync / 1[56]:Immolating Flame:583E:/
-10651.5 "Queen's Shot" sync / 1[56]:Queen's Gunner:584C:/
-10655.0 "Turret's Tour" sync / 1[56]:Automatic Turret:584E:/
-10665.6 "Rapid Sever" sync / 1[56]:Queen's Soldier:5842:/
-10665.6 "Shot In The Dark" sync / 1[56]:Queen's Gunner:5855:/
-10674.7 "Blood And Bone" sync / 1[56]:Queen's Soldier:5841:/
-10689.9 "Relentless Battery" sync / 1[56]:Queen's Gunner:5844:/
-10696.0 "Gun Turret" sync / 1[56]:Queen's Gunner:584F:/
+10612.0 "--sync--" sync / 14:[^:]*:Queen's Gunner:5844:/ window 600,0
+10617.0 "Relentless Battery" sync / 1[56]:[^:]*:Queen's Gunner:5844:/
+10623.2 "Great Ball Of Fire" sync / 1[56]:[^:]*:Queen's Soldier:583B:/
+10632.3 "Fool's Gambit" sync / 1[56]:[^:]*:Queen's Soldier:583C:/
+10635.2 "Automatic Turret" sync / 1[56]:[^:]*:Queen's Gunner:584A:/
+10641.3 "Reading" sync / 1[56]:[^:]*:Queen's Gunner:584B:/
+10647.9 "Burn" sync / 1[56]:[^:]*:Immolating Flame:583E:/
+10651.5 "Queen's Shot" sync / 1[56]:[^:]*:Queen's Gunner:584C:/
+10655.0 "Turret's Tour" sync / 1[56]:[^:]*:Automatic Turret:584E:/
+10665.6 "Rapid Sever" sync / 1[56]:[^:]*:Queen's Soldier:5842:/
+10665.6 "Shot In The Dark" sync / 1[56]:[^:]*:Queen's Gunner:5855:/
+10674.7 "Blood And Bone" sync / 1[56]:[^:]*:Queen's Soldier:5841:/
+10689.9 "Relentless Battery" sync / 1[56]:[^:]*:Queen's Gunner:5844:/
+10696.0 "Gun Turret" sync / 1[56]:[^:]*:Queen's Gunner:584F:/
 10696.8 "--targetable--" # gun turret
-10703.1 "Higher Power" sync / 1[56]:Queen's Gunner:5853:/
-10710.1 "Sniper Shot" sync / 1[56]:Gun Turret:5850:/
-10715.0 "Blood And Bone" sync / 1[56]:Queen's Soldier:5841:/
+10703.1 "Higher Power" sync / 1[56]:[^:]*:Queen's Gunner:5853:/
+10710.1 "Sniper Shot" sync / 1[56]:[^:]*:Gun Turret:5850:/
+10715.0 "Blood And Bone" sync / 1[56]:[^:]*:Queen's Soldier:5841:/
 10728.4 "--gun turret enrage--"
-10732.2 "Icy Portent/Fiery Portent" sync / 1[56]:Queen's Soldier:(583F|5840):/
-10747.4 "Relentless Battery" sync / 1[56]:Queen's Gunner:5844:/
-10753.5 "Double Gambit" sync / 1[56]:Queen's Soldier:5837:/
-10761.5 "Automatic Turret" sync / 1[56]:Queen's Gunner:584A:/
-10761.7 "Secrets Revealed" sync / 1[56]:Queen's Soldier:5B6F:/
-10767.7 "Reading" sync / 1[56]:Queen's Gunner:584B:/
-10777.9 "Queen's Shot" sync / 1[56]:Queen's Gunner:584C:/
-10778.3 "Pawn Off" sync / 1[56]:Soldier Avatar:5839:/
-10781.4 "Turret's Tour" sync / 1[56]:Automatic Turret:584E:/
-10792.1 "Blood And Bone" sync / 1[56]:Queen's Soldier:5841:/
-10801.3 "Shot In The Dark" sync / 1[56]:Queen's Gunner:5855:/
-10801.3 "Rapid Sever" sync / 1[56]:Queen's Soldier:5842:/
-10816.5 "Relentless Battery" sync / 1[56]:Queen's Gunner:5844:/
-10822.6 "Automatic Turret" sync / 1[56]:Queen's Gunner:5845:/
-10830.8 "Turret's Tour 1" sync / 1[56]:Queen's Gunner:5846:/
-10831.4 "Turret's Tour 2" sync / 1[56]:Automatic Turret:5848:/
-10837.6 "Fiery Portent/Icy Portent" sync / 1[56]:Queen's Soldier:(583F|5840):/
-10847.8 "Blood And Bone" sync / 1[56]:Queen's Soldier:5841:/
-10856.9 "Rapid Sever" sync / 1[56]:Queen's Soldier:5842:/
-10856.9 "Shot In The Dark" sync / 1[56]:Queen's Gunner:5855:/
+10732.2 "Icy Portent/Fiery Portent" sync / 1[56]:[^:]*:Queen's Soldier:(583F|5840):/
+10747.4 "Relentless Battery" sync / 1[56]:[^:]*:Queen's Gunner:5844:/
+10753.5 "Double Gambit" sync / 1[56]:[^:]*:Queen's Soldier:5837:/
+10761.5 "Automatic Turret" sync / 1[56]:[^:]*:Queen's Gunner:584A:/
+10761.7 "Secrets Revealed" sync / 1[56]:[^:]*:Queen's Soldier:5B6F:/
+10767.7 "Reading" sync / 1[56]:[^:]*:Queen's Gunner:584B:/
+10777.9 "Queen's Shot" sync / 1[56]:[^:]*:Queen's Gunner:584C:/
+10778.3 "Pawn Off" sync / 1[56]:[^:]*:Soldier Avatar:5839:/
+10781.4 "Turret's Tour" sync / 1[56]:[^:]*:Automatic Turret:584E:/
+10792.1 "Blood And Bone" sync / 1[56]:[^:]*:Queen's Soldier:5841:/
+10801.3 "Shot In The Dark" sync / 1[56]:[^:]*:Queen's Gunner:5855:/
+10801.3 "Rapid Sever" sync / 1[56]:[^:]*:Queen's Soldier:5842:/
+10816.5 "Relentless Battery" sync / 1[56]:[^:]*:Queen's Gunner:5844:/
+10822.6 "Automatic Turret" sync / 1[56]:[^:]*:Queen's Gunner:5845:/
+10830.8 "Turret's Tour 1" sync / 1[56]:[^:]*:Queen's Gunner:5846:/
+10831.4 "Turret's Tour 2" sync / 1[56]:[^:]*:Automatic Turret:5848:/
+10837.6 "Fiery Portent/Icy Portent" sync / 1[56]:[^:]*:Queen's Soldier:(583F|5840):/
+10847.8 "Blood And Bone" sync / 1[56]:[^:]*:Queen's Soldier:5841:/
+10856.9 "Rapid Sever" sync / 1[56]:[^:]*:Queen's Soldier:5842:/
+10856.9 "Shot In The Dark" sync / 1[56]:[^:]*:Queen's Gunner:5855:/
 
 # If either die, they will start casting enrage.
-10865.7 "--sync--" sync / 14:Queen's Soldier:5843:/ window 300,10
-10865.7 "--sync--" sync / 14:Queen's Gunner:5856:/ window 300,10
-10875.7 "Blood And Bone Enrage" sync / 1[56]:Queen's Soldier:5843:/
-10878.8 "Blood And Bone Enrage" sync / 1[56]:Queen's Soldier:5B9F:/ window 10,10 # x infinity
-10881.9 "Blood And Bone Enrage" sync / 1[56]:Queen's Soldier:5B9F:/
-10885.0 "Blood And Bone Enrage" sync / 1[56]:Queen's Soldier:5B9F:/
-10888.1 "Blood And Bone Enrage" sync / 1[56]:Queen's Soldier:5B9F:/
+10865.7 "--sync--" sync / 14:[^:]*:Queen's Soldier:5843:/ window 300,10
+10865.7 "--sync--" sync / 14:[^:]*:Queen's Gunner:5856:/ window 300,10
+10875.7 "Blood And Bone Enrage" sync / 1[56]:[^:]*:Queen's Soldier:5843:/
+10878.8 "Blood And Bone Enrage" sync / 1[56]:[^:]*:Queen's Soldier:5B9F:/ window 10,10 # x infinity
+10881.9 "Blood And Bone Enrage" sync / 1[56]:[^:]*:Queen's Soldier:5B9F:/
+10885.0 "Blood And Bone Enrage" sync / 1[56]:[^:]*:Queen's Soldier:5B9F:/
+10888.1 "Blood And Bone Enrage" sync / 1[56]:[^:]*:Queen's Soldier:5B9F:/
 
 
 # Phase 4: Aetherial Wards
-11000.0 "--sync--" sync / 14:Queen's Knight:581E:/ window 1000,0
-11005.0 "Strongpoint Defense" sync / 1[56]:Queen's Knight:581E:/
-11005.0 "Spiteful Spirit" sync / 1[56]:Queen's Warrior:582E:/
+11000.0 "--sync--" sync / 14:[^:]*:Queen's Knight:581E:/ window 1000,0
+11005.0 "Strongpoint Defense" sync / 1[56]:[^:]*:Queen's Knight:581E:/
+11005.0 "Spiteful Spirit" sync / 1[56]:[^:]*:Queen's Warrior:582E:/
 11006.0 "--2x Aura Sphere--"
 11007.9 "--12x Spiritual Sphere--"
-11014.8 "Coat Of Arms" sync / 1[56]:Aetherial Ward:5820:/
-11016.0 "Fracture 1" sync / 1[56]:Spiritual Sphere:5B95:/
-11020.0 "Fracture 2" sync / 1[56]:Spiritual Sphere:5B95:/
+11014.8 "Coat Of Arms" sync / 1[56]:[^:]*:Aetherial Ward:5820:/
+11016.0 "Fracture 1" sync / 1[56]:[^:]*:Spiritual Sphere:5B95:/
+11020.0 "Fracture 2" sync / 1[56]:[^:]*:Spiritual Sphere:5B95:/
 11020.0 "--Spite Check--"
-11032.0 "Coat Of Arms" sync / 1[56]:Aetherial Ward:5820:/
+11032.0 "Coat Of Arms" sync / 1[56]:[^:]*:Aetherial Ward:5820:/
 11037.9 "--12x Spiritual Sphere--"
 11039.9 "--2x Aura Sphere--"
-11046.0 "Fracture 1" sync / 1[56]:Spiritual Sphere:5B95:/
-11049.0 "Coat Of Arms" sync / 1[56]:Aetherial Ward:5820:/
-11050.0 "Fracture 2" sync / 1[56]:Spiritual Sphere:5B95:/
+11046.0 "Fracture 1" sync / 1[56]:[^:]*:Spiritual Sphere:5B95:/
+11049.0 "Coat Of Arms" sync / 1[56]:[^:]*:Aetherial Ward:5820:/
+11050.0 "Fracture 2" sync / 1[56]:[^:]*:Spiritual Sphere:5B95:/
 11054.1 "--Spite Check--"
-11066.1 "Coat Of Arms" sync / 1[56]:Aetherial Ward:5820:/
+11066.1 "Coat Of Arms" sync / 1[56]:[^:]*:Aetherial Ward:5820:/
 # 70s enrage cast, started 3 seconds after Strongpoint Defense.
-11078.0 "Blood And Bone Enrage" sync / 1[56]:Queen's Knight:5909:/
+11078.0 "Blood And Bone Enrage" sync / 1[56]:[^:]*:Queen's Knight:5909:/
 
 
 ### Bozjan Phantom
@@ -677,55 +677,55 @@ hideall "--sync--"
 
 12000.0 "--sync--" sync / 00:0839::Pride of the Lion will be sealed off/ window 20000,0
 12000.0 "--Reset--" sync / 00:0839::.*is no longer sealed/ window 0,2000 jump 0
-12007.1 "--sync--" sync / 14:Bozjan Phantom:57BD:/ window 20000,0
-12011.1 "Malediction of Agony" sync / 1[56]:Bozjan Phantom:57BD:/
-12019.2 "Weave Miasma" sync / 1[56]:Bozjan Phantom:57B2:/
+12007.1 "--sync--" sync / 14:[^:]*:Bozjan Phantom:57BD:/ window 20000,0
+12011.1 "Malediction of Agony" sync / 1[56]:[^:]*:Bozjan Phantom:57BD:/
+12019.2 "Weave Miasma" sync / 1[56]:[^:]*:Bozjan Phantom:57B2:/
 
 # Manipulate Miasma Phase (go Swirling -> Creeping lanes)
-12035.4 "Manipulate Miasma" sync / 1[56]:Bozjan Phantom:57B3:/
-12036.4 "Swirling Miasma 1" sync / 1[56]:Bozjan Phantom:57B8:/
-12038.0 "Swirling Miasma 2" #sync / 1[56]:Bozjan Phantom:57B9:/
-12039.6 "Swirling Miasma 3" #sync / 1[56]:Bozjan Phantom:57B9:/
-12041.2 "Swirling Miasma 4" #sync / 1[56]:Bozjan Phantom:57B9:/
-12042.8 "Swirling Miasma 5" #sync / 1[56]:Bozjan Phantom:57B9:/
-12044.4 "Swirling Miasma 6" #sync / 1[56]:Bozjan Phantom:57B9:/
-12046.0 "Swirling Miasma 7" #sync / 1[56]:Bozjan Phantom:57B9:/
-12046.4 "Creeping Miasma 1" sync / 1[56]:Bozjan Phantom:57B4:/
-12047.6 "Swirling Miasma 8" #sync / 1[56]:Bozjan Phantom:57B9:/
-12047.9 "Creeping Miasma 2" #sync / 1[56]:Bozjan Phantom:57B5:/
-12049.5 "Creeping Miasma 3" #sync / 1[56]:Bozjan Phantom:57B5:/
-12051.1 "Lingering Miasma" #sync / 1[56]:Bozjan Phantom:57B7:/
-12052.7 "Lingering Miasma" #sync / 1[56]:Bozjan Phantom:57B7:/
-12054.3 "Lingering Miasma" #sync / 1[56]:Bozjan Phantom:57B7:/
-12055.9 "Lingering Miasma" #sync / 1[56]:Bozjan Phantom:57B7:/
-12057.5 "Lingering Miasma" #sync / 1[56]:Bozjan Phantom:57B7:/
-12063.5 "Weave Miasma" sync / 1[56]:Bozjan Phantom:57B2:/
+12035.4 "Manipulate Miasma" sync / 1[56]:[^:]*:Bozjan Phantom:57B3:/
+12036.4 "Swirling Miasma 1" sync / 1[56]:[^:]*:Bozjan Phantom:57B8:/
+12038.0 "Swirling Miasma 2" #sync / 1[56]:[^:]*:Bozjan Phantom:57B9:/
+12039.6 "Swirling Miasma 3" #sync / 1[56]:[^:]*:Bozjan Phantom:57B9:/
+12041.2 "Swirling Miasma 4" #sync / 1[56]:[^:]*:Bozjan Phantom:57B9:/
+12042.8 "Swirling Miasma 5" #sync / 1[56]:[^:]*:Bozjan Phantom:57B9:/
+12044.4 "Swirling Miasma 6" #sync / 1[56]:[^:]*:Bozjan Phantom:57B9:/
+12046.0 "Swirling Miasma 7" #sync / 1[56]:[^:]*:Bozjan Phantom:57B9:/
+12046.4 "Creeping Miasma 1" sync / 1[56]:[^:]*:Bozjan Phantom:57B4:/
+12047.6 "Swirling Miasma 8" #sync / 1[56]:[^:]*:Bozjan Phantom:57B9:/
+12047.9 "Creeping Miasma 2" #sync / 1[56]:[^:]*:Bozjan Phantom:57B5:/
+12049.5 "Creeping Miasma 3" #sync / 1[56]:[^:]*:Bozjan Phantom:57B5:/
+12051.1 "Lingering Miasma" #sync / 1[56]:[^:]*:Bozjan Phantom:57B7:/
+12052.7 "Lingering Miasma" #sync / 1[56]:[^:]*:Bozjan Phantom:57B7:/
+12054.3 "Lingering Miasma" #sync / 1[56]:[^:]*:Bozjan Phantom:57B7:/
+12055.9 "Lingering Miasma" #sync / 1[56]:[^:]*:Bozjan Phantom:57B7:/
+12057.5 "Lingering Miasma" #sync / 1[56]:[^:]*:Bozjan Phantom:57B7:/
+12063.5 "Weave Miasma" sync / 1[56]:[^:]*:Bozjan Phantom:57B2:/
 
 # Invert Miasma Phase (go Lingering -> Creeping -> Creeping lanes)
-12079.6 "Invert Miasma" sync / 1[56]:Bozjan Phantom:59EE:/
-12080.6 "Creeping Miasma 1" sync / 1[56]:Bozjan Phantom:57B4:/
-12082.2 "Creeping Miasma 2" #sync / 1[56]:Bozjan Phantom:57B5:/
-12083.8 "Creeping Miasma 3" #sync / 1[56]:Bozjan Phantom:57B5:/
-12085.4 "Lingering Miasma" #sync / 1[56]:Bozjan Phantom:57B7:/
-12087.0 "Lingering Miasma" #sync / 1[56]:Bozjan Phantom:57B7:/
-12088.6 "Lingering Miasma" #sync / 1[56]:Bozjan Phantom:57B7:/
-12090.2 "Lingering Miasma" #sync / 1[56]:Bozjan Phantom:57B7:/
-12090.6 "Creeping Miasma 1" sync / 1[56]:Bozjan Phantom:57B4:/
-12091.8 "Lingering Miasma" #sync / 1[56]:Bozjan Phantom:57B7:/
-12092.0 "Creeping Miasma 2" #sync / 1[56]:Bozjan Phantom:57B5:/
-12093.6 "Creeping Miasma 3" #sync / 1[56]:Bozjan Phantom:57B5:/
-12095.2 "Lingering Miasma" #sync / 1[56]:Bozjan Phantom:57B7:/
-12096.8 "Lingering Miasma" #sync / 1[56]:Bozjan Phantom:57B7:/
-12098.4 "Lingering Miasma" #sync / 1[56]:Bozjan Phantom:57B7:/
-12100.0 "Lingering Miasma" #sync / 1[56]:Bozjan Phantom:57B7:/
-12100.7 "--middle--" sync / 1[56]:Bozjan Phantom:57AD:/
-12101.6 "Lingering Miasma" #sync / 1[56]:Bozjan Phantom:57B7:/
+12079.6 "Invert Miasma" sync / 1[56]:[^:]*:Bozjan Phantom:59EE:/
+12080.6 "Creeping Miasma 1" sync / 1[56]:[^:]*:Bozjan Phantom:57B4:/
+12082.2 "Creeping Miasma 2" #sync / 1[56]:[^:]*:Bozjan Phantom:57B5:/
+12083.8 "Creeping Miasma 3" #sync / 1[56]:[^:]*:Bozjan Phantom:57B5:/
+12085.4 "Lingering Miasma" #sync / 1[56]:[^:]*:Bozjan Phantom:57B7:/
+12087.0 "Lingering Miasma" #sync / 1[56]:[^:]*:Bozjan Phantom:57B7:/
+12088.6 "Lingering Miasma" #sync / 1[56]:[^:]*:Bozjan Phantom:57B7:/
+12090.2 "Lingering Miasma" #sync / 1[56]:[^:]*:Bozjan Phantom:57B7:/
+12090.6 "Creeping Miasma 1" sync / 1[56]:[^:]*:Bozjan Phantom:57B4:/
+12091.8 "Lingering Miasma" #sync / 1[56]:[^:]*:Bozjan Phantom:57B7:/
+12092.0 "Creeping Miasma 2" #sync / 1[56]:[^:]*:Bozjan Phantom:57B5:/
+12093.6 "Creeping Miasma 3" #sync / 1[56]:[^:]*:Bozjan Phantom:57B5:/
+12095.2 "Lingering Miasma" #sync / 1[56]:[^:]*:Bozjan Phantom:57B7:/
+12096.8 "Lingering Miasma" #sync / 1[56]:[^:]*:Bozjan Phantom:57B7:/
+12098.4 "Lingering Miasma" #sync / 1[56]:[^:]*:Bozjan Phantom:57B7:/
+12100.0 "Lingering Miasma" #sync / 1[56]:[^:]*:Bozjan Phantom:57B7:/
+12100.7 "--middle--" sync / 1[56]:[^:]*:Bozjan Phantom:57AD:/
+12101.6 "Lingering Miasma" #sync / 1[56]:[^:]*:Bozjan Phantom:57B7:/
 
 # Add phase
 # TODO: unclear if these adds are on a timer (~3 logs were +/- 1 second) or if
 # they just pop when previous set is done.  Include here for clarity, but
 # don't bother syncing so that the enrage is correct, regardless.
-12105.1 "Summon Adds" sync / 1[56]:Bozjan Phantom:57C0:/
+12105.1 "Summon Adds" sync / 1[56]:[^:]*:Bozjan Phantom:57C0:/
 12105.8 "1x Misty Wraith"
 12105.8 "2x Bloody Wraith"
 12106.1 "--untargetable--"
@@ -733,79 +733,79 @@ hideall "--sync--"
 12115.8 "2x Bloody Wraith"
 12128.0 "3x Misty Wraith"
 12128.0 "3x Bloody Wraith"
-12155.2 "Malediction of Ruin Enrage" sync / 1[56]:Bozjan Phantom:57C1:/
+12155.2 "Malediction of Ruin Enrage" sync / 1[56]:[^:]*:Bozjan Phantom:57C1:/
 12157.2 "--targetable--"
 
 # Start of loop block
-12162.3 "--sync--" sync / 14:Bozjan Phantom:57B2:/ window 100,50
-12165.3 "Weave Miasma" sync / 1[56]:Bozjan Phantom:57B2:/
-12171.5 "Summon" sync / 1[56]:Bozjan Phantom:57BA:/
-12187.6 "Undying Hatred" sync / 1[56]:Stuffy Wraith:57C2:/
+12162.3 "--sync--" sync / 14:[^:]*:Bozjan Phantom:57B2:/ window 100,50
+12165.3 "Weave Miasma" sync / 1[56]:[^:]*:Bozjan Phantom:57B2:/
+12171.5 "Summon" sync / 1[56]:[^:]*:Bozjan Phantom:57BA:/
+12187.6 "Undying Hatred" sync / 1[56]:[^:]*:Stuffy Wraith:57C2:/
 
-12191.5 "Manipulate Miasma?" sync / 1[56]:Bozjan Phantom:57B3:/ jump 12300
-12191.5 "Invert Miasma?" sync / 1[56]:Bozjan Phantom:59EE:/ jump 12500
+12191.5 "Manipulate Miasma?" sync / 1[56]:[^:]*:Bozjan Phantom:57B3:/ jump 12300
+12191.5 "Invert Miasma?" sync / 1[56]:[^:]*:Bozjan Phantom:59EE:/ jump 12500
 
 # Manipulate Miasma Phase (go Swirling -> Creeping lanes)
-12300.0 "Manipulate Miasma" sync / 1[56]:Bozjan Phantom:57B3:/
-12301.0 "Swirling Miasma 1" #sync / 1[56]:Bozjan Phantom:57B8:/
-12302.7 "Swirling Miasma 2" #sync / 1[56]:Bozjan Phantom:57B9:/
-12304.3 "Swirling Miasma 3" #sync / 1[56]:Bozjan Phantom:57B9:/
-12305.9 "Swirling Miasma 4" #sync / 1[56]:Bozjan Phantom:57B9:/
-12307.5 "Swirling Miasma 5" #sync / 1[56]:Bozjan Phantom:57B9:/
-12309.1 "Swirling Miasma 6" #sync / 1[56]:Bozjan Phantom:57B9:/
-12310.7 "Swirling Miasma 7" #sync / 1[56]:Bozjan Phantom:57B9:/
-12311.0 "Creeping Miasma 1" sync / 1[56]:Bozjan Phantom:57B4:/
-12312.2 "Swirling Miasma 8" #sync / 1[56]:Bozjan Phantom:57B9:/
-12312.4 "Creeping Miasma 2" #sync / 1[56]:Bozjan Phantom:57B5:/
-12314.0 "Creeping Miasma 3" #sync / 1[56]:Bozjan Phantom:57B5:/
-12314.0 "Lingering Miasma" #sync / 1[56]:Bozjan Phantom:57B7:/
-12315.6 "Lingering Miasma" #sync / 1[56]:Bozjan Phantom:57B7:/
-12317.0 "--middle--" sync / 1[56]:Bozjan Phantom:57AD:/ # "Transference"
-12317.2 "Lingering Miasma" #sync / 1[56]:Bozjan Phantom:57B7:/
-12318.8 "Lingering Miasma" #sync / 1[56]:Bozjan Phantom:57B7:/
-12320.4 "Lingering Miasma" #sync / 1[56]:Bozjan Phantom:57B7:/
-12322.0 "Lingering Miasma" #sync / 1[56]:Bozjan Phantom:57B7:/
+12300.0 "Manipulate Miasma" sync / 1[56]:[^:]*:Bozjan Phantom:57B3:/
+12301.0 "Swirling Miasma 1" #sync / 1[56]:[^:]*:Bozjan Phantom:57B8:/
+12302.7 "Swirling Miasma 2" #sync / 1[56]:[^:]*:Bozjan Phantom:57B9:/
+12304.3 "Swirling Miasma 3" #sync / 1[56]:[^:]*:Bozjan Phantom:57B9:/
+12305.9 "Swirling Miasma 4" #sync / 1[56]:[^:]*:Bozjan Phantom:57B9:/
+12307.5 "Swirling Miasma 5" #sync / 1[56]:[^:]*:Bozjan Phantom:57B9:/
+12309.1 "Swirling Miasma 6" #sync / 1[56]:[^:]*:Bozjan Phantom:57B9:/
+12310.7 "Swirling Miasma 7" #sync / 1[56]:[^:]*:Bozjan Phantom:57B9:/
+12311.0 "Creeping Miasma 1" sync / 1[56]:[^:]*:Bozjan Phantom:57B4:/
+12312.2 "Swirling Miasma 8" #sync / 1[56]:[^:]*:Bozjan Phantom:57B9:/
+12312.4 "Creeping Miasma 2" #sync / 1[56]:[^:]*:Bozjan Phantom:57B5:/
+12314.0 "Creeping Miasma 3" #sync / 1[56]:[^:]*:Bozjan Phantom:57B5:/
+12314.0 "Lingering Miasma" #sync / 1[56]:[^:]*:Bozjan Phantom:57B7:/
+12315.6 "Lingering Miasma" #sync / 1[56]:[^:]*:Bozjan Phantom:57B7:/
+12317.0 "--middle--" sync / 1[56]:[^:]*:Bozjan Phantom:57AD:/ # "Transference"
+12317.2 "Lingering Miasma" #sync / 1[56]:[^:]*:Bozjan Phantom:57B7:/
+12318.8 "Lingering Miasma" #sync / 1[56]:[^:]*:Bozjan Phantom:57B7:/
+12320.4 "Lingering Miasma" #sync / 1[56]:[^:]*:Bozjan Phantom:57B7:/
+12322.0 "Lingering Miasma" #sync / 1[56]:[^:]*:Bozjan Phantom:57B7:/
 
 # Tank buster and AoE Intermediary Loop
-12324.3 "Vile Wave" sync / 1[56]:Bozjan Phantom:57BF:/
-12340.4 "Ice Spikes" sync / 1[56]:Bozjan Phantom:57BC:/
-12351.5 "Excruciation" sync / 1[56]:Bozjan Phantom:57BE:/
-12357.6 "Malediction of Agony" sync / 1[56]:Bozjan Phantom:57BD:/
-12368.9 "Weave Miasma" sync / 1[56]:Bozjan Phantom:57B2:/ window 100,100 jump 12165.3
-12375.0 "Summon" #sync / 1[56]:Bozjan Phantom:57BA:/
-12391.1 "Undying Hatred" #sync / 1[56]:Stuffy Wraith:57C2:/
-12395.0 "Manipulate Miasma?" #sync / 1[56]:Bozjan Phantom:57B3:/
-12395.0 "Invert Miasma?" #sync / 1[56]:Bozjan Phantom:59EE:/
+12324.3 "Vile Wave" sync / 1[56]:[^:]*:Bozjan Phantom:57BF:/
+12340.4 "Ice Spikes" sync / 1[56]:[^:]*:Bozjan Phantom:57BC:/
+12351.5 "Excruciation" sync / 1[56]:[^:]*:Bozjan Phantom:57BE:/
+12357.6 "Malediction of Agony" sync / 1[56]:[^:]*:Bozjan Phantom:57BD:/
+12368.9 "Weave Miasma" sync / 1[56]:[^:]*:Bozjan Phantom:57B2:/ window 100,100 jump 12165.3
+12375.0 "Summon" #sync / 1[56]:[^:]*:Bozjan Phantom:57BA:/
+12391.1 "Undying Hatred" #sync / 1[56]:[^:]*:Stuffy Wraith:57C2:/
+12395.0 "Manipulate Miasma?" #sync / 1[56]:[^:]*:Bozjan Phantom:57B3:/
+12395.0 "Invert Miasma?" #sync / 1[56]:[^:]*:Bozjan Phantom:59EE:/
 
 # Invert Miasma Phase (go Lingering -> Creeping -> Creeping lanes)
-12500.0 "Invert Miasma" sync / 1[56]:Bozjan Phantom:59EE:/
-12501.0 "Creeping Miasma 1" sync / 1[56]:Bozjan Phantom:57B4:/
-12502.6 "Creeping Miasma 2" #sync / 1[56]:Bozjan Phantom:57B5:/
-12504.2 "Creeping Miasma 3" #sync / 1[56]:Bozjan Phantom:57B5:/
-12505.8 "Lingering Miasma" #sync / 1[56]:Bozjan Phantom:57B7:/
-12507.4 "Lingering Miasma" #sync / 1[56]:Bozjan Phantom:57B7:/
-12509.0 "Lingering Miasma" #sync / 1[56]:Bozjan Phantom:57B7:/
-12510.6 "Lingering Miasma" #sync / 1[56]:Bozjan Phantom:57B7:/
-12511.0 "Creeping Miasma 1" sync / 1[56]:Bozjan Phantom:57B4:/
-12512.5 "Creeping Miasma 2" #sync / 1[56]:Bozjan Phantom:57B5:/
-12514.1 "Creeping Miasma 3" #sync / 1[56]:Bozjan Phantom:57B5:/
-12515.7 "Lingering Miasma" #sync / 1[56]:Bozjan Phantom:57B7:/
-12517.1 "--middle--" sync / 1[56]:Bozjan Phantom:57AD:/ # "Transference"
-12517.3 "Lingering Miasma" #sync / 1[56]:Bozjan Phantom:57B7:/
-12518.9 "Lingering Miasma" #sync / 1[56]:Bozjan Phantom:57B7:/
-12520.5 "Lingering Miasma" #sync / 1[56]:Bozjan Phantom:57B7:/
-12522.1 "Lingering Miasma" #sync / 1[56]:Bozjan Phantom:57B7:/
+12500.0 "Invert Miasma" sync / 1[56]:[^:]*:Bozjan Phantom:59EE:/
+12501.0 "Creeping Miasma 1" sync / 1[56]:[^:]*:Bozjan Phantom:57B4:/
+12502.6 "Creeping Miasma 2" #sync / 1[56]:[^:]*:Bozjan Phantom:57B5:/
+12504.2 "Creeping Miasma 3" #sync / 1[56]:[^:]*:Bozjan Phantom:57B5:/
+12505.8 "Lingering Miasma" #sync / 1[56]:[^:]*:Bozjan Phantom:57B7:/
+12507.4 "Lingering Miasma" #sync / 1[56]:[^:]*:Bozjan Phantom:57B7:/
+12509.0 "Lingering Miasma" #sync / 1[56]:[^:]*:Bozjan Phantom:57B7:/
+12510.6 "Lingering Miasma" #sync / 1[56]:[^:]*:Bozjan Phantom:57B7:/
+12511.0 "Creeping Miasma 1" sync / 1[56]:[^:]*:Bozjan Phantom:57B4:/
+12512.5 "Creeping Miasma 2" #sync / 1[56]:[^:]*:Bozjan Phantom:57B5:/
+12514.1 "Creeping Miasma 3" #sync / 1[56]:[^:]*:Bozjan Phantom:57B5:/
+12515.7 "Lingering Miasma" #sync / 1[56]:[^:]*:Bozjan Phantom:57B7:/
+12517.1 "--middle--" sync / 1[56]:[^:]*:Bozjan Phantom:57AD:/ # "Transference"
+12517.3 "Lingering Miasma" #sync / 1[56]:[^:]*:Bozjan Phantom:57B7:/
+12518.9 "Lingering Miasma" #sync / 1[56]:[^:]*:Bozjan Phantom:57B7:/
+12520.5 "Lingering Miasma" #sync / 1[56]:[^:]*:Bozjan Phantom:57B7:/
+12522.1 "Lingering Miasma" #sync / 1[56]:[^:]*:Bozjan Phantom:57B7:/
 
 # Invert Miasma Loop
-12524.4 "Vile Wave" sync / 1[56]:Bozjan Phantom:57BF:/
-12540.5 "Ice Spikes" sync / 1[56]:Bozjan Phantom:57BC:/
-12551.6 "Excruciation" sync / 1[56]:Bozjan Phantom:57BE:/
-12557.7 "Malediction of Agony" sync / 1[56]:Bozjan Phantom:57BD:/
-12568.9 "Weave Miasma" sync / 1[56]:Bozjan Phantom:57B2:/ window 100,100 jump 12165.3
-12575.1 "Summon" #sync / 1[56]:Bozjan Phantom:57BA:/
-12591.2 "Undying Hatred" #sync / 1[56]:Stuffy Wraith:57C2:/
-12395.1 "Manipulate Miasma?" #sync / 1[56]:Bozjan Phantom:57B3:/
-12395.1 "Invert Miasma?" #sync / 1[56]:Bozjan Phantom:59EE:/
+12524.4 "Vile Wave" sync / 1[56]:[^:]*:Bozjan Phantom:57BF:/
+12540.5 "Ice Spikes" sync / 1[56]:[^:]*:Bozjan Phantom:57BC:/
+12551.6 "Excruciation" sync / 1[56]:[^:]*:Bozjan Phantom:57BE:/
+12557.7 "Malediction of Agony" sync / 1[56]:[^:]*:Bozjan Phantom:57BD:/
+12568.9 "Weave Miasma" sync / 1[56]:[^:]*:Bozjan Phantom:57B2:/ window 100,100 jump 12165.3
+12575.1 "Summon" #sync / 1[56]:[^:]*:Bozjan Phantom:57BA:/
+12591.2 "Undying Hatred" #sync / 1[56]:[^:]*:Stuffy Wraith:57C2:/
+12395.1 "Manipulate Miasma?" #sync / 1[56]:[^:]*:Bozjan Phantom:57B3:/
+12395.1 "Invert Miasma?" #sync / 1[56]:[^:]*:Bozjan Phantom:59EE:/
 
 
 ### Trinity Avowed
@@ -839,405 +839,405 @@ hideall "--sync--"
 # Note: various "Blast" are renamed "Elemental Blast" and various "Arrow" are renamed
 # to be "Elemental Arrow" to avoid having too many skills on the timeline.
 
-# Note: Blade of Entropy is `sync / 1[56]:(Trinity Avowed|Avowed Avatar):594[23456789]|595[6789ABCD]:/``
+# Note: Blade of Entropy is `sync / 1[56]:[^:]*:(Trinity Avowed|Avowed Avatar):594[23456789]|595[6789ABCD]:/``
 
 14000.0 "--sync--" sync / 00:0839::The Vault of Singing Crystal will be sealed off/ window 20000,0
 14000.0 "--Reset--" sync / 00:0839::.*is no longer sealed/ window 0,2000 jump 0
-14006.7 "--sync--" sync / 14:Trinity Avowed:594E:/ window 10,10
-14011.8 "Wrath Of Bozja" sync / 1[56]:Trinity Avowed:594E:/
-14019.9 "Glory Of Bozja" sync / 1[56]:Trinity Avowed:594F:/
+14006.7 "--sync--" sync / 14:[^:]*:Trinity Avowed:594E:/ window 10,10
+14011.8 "Wrath Of Bozja" sync / 1[56]:[^:]*:Trinity Avowed:594E:/
+14019.9 "Glory Of Bozja" sync / 1[56]:[^:]*:Trinity Avowed:594F:/
 
 # Initial Phase
-14029.2 "Allegiant Arsenal" sync / 1[56]:Trinity Avowed:598[567]:/
-14034.4 "Flashvane/Fury Of Bozja/Infernal Slash" sync / 1[56]:Trinity Avowed:(594B|594C|594A):/
-14037.5 "--sync--" sync / 1[56]:Trinity Avowed:5983:/
-14042.6 "Allegiant Arsenal" sync / 1[56]:Trinity Avowed:598[567]:/
-14047.8 "Flashvane/Fury Of Bozja/Infernal Slash" sync / 1[56]:Trinity Avowed:(594B|594C|594A):/
-14050.9 "--sync--" sync / 1[56]:Trinity Avowed:5984:/
+14029.2 "Allegiant Arsenal" sync / 1[56]:[^:]*:Trinity Avowed:598[567]:/
+14034.4 "Flashvane/Fury Of Bozja/Infernal Slash" sync / 1[56]:[^:]*:Trinity Avowed:(594B|594C|594A):/
+14037.5 "--sync--" sync / 1[56]:[^:]*:Trinity Avowed:5983:/
+14042.6 "Allegiant Arsenal" sync / 1[56]:[^:]*:Trinity Avowed:598[567]:/
+14047.8 "Flashvane/Fury Of Bozja/Infernal Slash" sync / 1[56]:[^:]*:Trinity Avowed:(594B|594C|594A):/
+14050.9 "--sync--" sync / 1[56]:[^:]*:Trinity Avowed:5984:/
 14056.0 "Allegiant Arsenal" # -> random jump to initial weapon phase
 
 # -> Sword v1 (initial)?
-14053.0 "--sync--" sync / 14:Trinity Avowed:5985:/ window 10,10 jump 14100
-14061.2 "Infernal Slash?" #sync / 1[56]:Trinity Avowed:594A:/
+14053.0 "--sync--" sync / 14:[^:]*:Trinity Avowed:5985:/ window 10,10 jump 14100
+14061.2 "Infernal Slash?" #sync / 1[56]:[^:]*:Trinity Avowed:594A:/
 # -> Bow v1 (initial)?
-14053.0 "--sync--" sync / 14:Trinity Avowed:5986:/ window 10,10 jump 14700
-14061.2 "Flashvane?" #sync / 1[56]:Trinity Avowed:594B:/
+14053.0 "--sync--" sync / 14:[^:]*:Trinity Avowed:5986:/ window 10,10 jump 14700
+14061.2 "Flashvane?" #sync / 1[56]:[^:]*:Trinity Avowed:594B:/
 # -> Staff v1 (initial)?
-14053.0 "--sync--" sync / 14:Trinity Avowed:5987:/ window 10,10 jump 15300
-14061.2 "Fury Of Bozja?" #sync / 1[56]:Trinity Avowed:594C:/
+14053.0 "--sync--" sync / 14:[^:]*:Trinity Avowed:5987:/ window 10,10 jump 15300
+14061.2 "Fury Of Bozja?" #sync / 1[56]:[^:]*:Trinity Avowed:594C:/
 
 
 # Sword v1 (initial)
-14100.0 "--sync--" sync / 14:Trinity Avowed:5985:/
-14103.0 "Allegiant Arsenal" sync / 1[56]:Trinity Avowed:5985:/
-14108.2 "Infernal Slash" sync / 1[56]:Trinity Avowed:594A:/
-14115.6 "Hot And Cold" sync / 1[56]:Trinity Avowed:5BAF:/
-14122.7 "Unwavering Apparition" sync / 1[56]:Trinity Avowed:5B3A:/
+14100.0 "--sync--" sync / 14:[^:]*:Trinity Avowed:5985:/
+14103.0 "Allegiant Arsenal" sync / 1[56]:[^:]*:Trinity Avowed:5985:/
+14108.2 "Infernal Slash" sync / 1[56]:[^:]*:Trinity Avowed:594A:/
+14115.6 "Hot And Cold" sync / 1[56]:[^:]*:Trinity Avowed:5BAF:/
+14122.7 "Unwavering Apparition" sync / 1[56]:[^:]*:Trinity Avowed:5B3A:/
 14128.7 "--untargetable--"
-14138.8 "Blade Of Entropy 1" #sync / 1[56]:Trinity Avowed:5959:/
-14152.5 "Blade Of Entropy 2" #sync / 1[56]:Trinity Avowed:5959:/
+14138.8 "Blade Of Entropy 1" #sync / 1[56]:[^:]*:Trinity Avowed:5959:/
+14152.5 "Blade Of Entropy 2" #sync / 1[56]:[^:]*:Trinity Avowed:5959:/
 14155.6 "--targetable--"
-14160.3 "--sync--" sync / 1[56]:Trinity Avowed:5982:/
-14167.4 "Glory Of Bozja" sync / 1[56]:Trinity Avowed:594F:/
+14160.3 "--sync--" sync / 1[56]:[^:]*:Trinity Avowed:5982:/
+14167.4 "Glory Of Bozja" sync / 1[56]:[^:]*:Trinity Avowed:594F:/
 
 # -> Bow v1 (seen sword)?
-14175.3 "--sync--" sync / 14:Trinity Avowed:5986:/ window 70,10 jump 14900
-14183.5 "Flashvane?" #sync / 1[56]:Trinity Avowed:594B:/
+14175.3 "--sync--" sync / 14:[^:]*:Trinity Avowed:5986:/ window 70,10 jump 14900
+14183.5 "Flashvane?" #sync / 1[56]:[^:]*:Trinity Avowed:594B:/
 # -> Staff v1 (seen sword)?
-14175.3 "--sync--" sync / 14:Trinity Avowed:5987:/ window 70,10 jump 15500
-14183.5 "Fury Of Bozja?" #sync / 1[56]:Trinity Avowed:594C:/
+14175.3 "--sync--" sync / 14:[^:]*:Trinity Avowed:5987:/ window 70,10 jump 15500
+14183.5 "Fury Of Bozja?" #sync / 1[56]:[^:]*:Trinity Avowed:594C:/
 
 
 # Sword v1 (seen bow)
-14300.0 "--sync--" sync / 14:Trinity Avowed:5985:/
-14303.0 "Allegiant Arsenal" sync / 1[56]:Trinity Avowed:5985:/
-14308.2 "Infernal Slash" sync / 1[56]:Trinity Avowed:594A:/
-14315.6 "Hot And Cold" sync / 1[56]:Trinity Avowed:5BAF:/
-14322.7 "Unwavering Apparition" sync / 1[56]:Trinity Avowed:5B3A:/
+14300.0 "--sync--" sync / 14:[^:]*:Trinity Avowed:5985:/
+14303.0 "Allegiant Arsenal" sync / 1[56]:[^:]*:Trinity Avowed:5985:/
+14308.2 "Infernal Slash" sync / 1[56]:[^:]*:Trinity Avowed:594A:/
+14315.6 "Hot And Cold" sync / 1[56]:[^:]*:Trinity Avowed:5BAF:/
+14322.7 "Unwavering Apparition" sync / 1[56]:[^:]*:Trinity Avowed:5B3A:/
 14328.7 "--untargetable--"
-14338.8 "Blade Of Entropy 1" #sync / 1[56]:Trinity Avowed:5959:/
-14352.5 "Blade Of Entropy 2" #sync / 1[56]:Trinity Avowed:5959:/
+14338.8 "Blade Of Entropy 1" #sync / 1[56]:[^:]*:Trinity Avowed:5959:/
+14352.5 "Blade Of Entropy 2" #sync / 1[56]:[^:]*:Trinity Avowed:5959:/
 14355.6 "--targetable--"
-14360.3 "--sync--" sync / 1[56]:Trinity Avowed:5982:/
-14367.4 "Glory Of Bozja" sync / 1[56]:Trinity Avowed:594F:/
+14360.3 "--sync--" sync / 1[56]:[^:]*:Trinity Avowed:5982:/
+14367.4 "Glory Of Bozja" sync / 1[56]:[^:]*:Trinity Avowed:594F:/
 # -> roll into Staff v1 (final)
-14375.3 "--sync--" sync / 14:Trinity Avowed:5987:/ window 70,10
-14378.3 "Allegiant Arsenal" sync / 1[56]:Trinity Avowed:5987:/
-14383.5 "Fury Of Bozja" sync / 1[56]:Trinity Avowed:594C:/
-14389.6 "Hot And Cold" sync / 1[56]:Trinity Avowed:597B:/
-14396.7 "Quick March" sync / 1[56]:Trinity Avowed:5981:/
-14402.9 "Freedom Of Bozja" sync / 1[56]:Trinity Avowed:597C:/
-14410.3 "Elemental Impact" sync / 1[56]:Tempestuous Orb:4F52:/
-14420.1 "Elemental Blast" sync / 1[56]:Tempestuous Orb:592E:/
-14425.9 "--sync--" sync / 1[56]:Trinity Avowed:5984:/
-14433.0 "Glory Of Bozja" sync / 1[56]:Trinity Avowed:594F:/
+14375.3 "--sync--" sync / 14:[^:]*:Trinity Avowed:5987:/ window 70,10
+14378.3 "Allegiant Arsenal" sync / 1[56]:[^:]*:Trinity Avowed:5987:/
+14383.5 "Fury Of Bozja" sync / 1[56]:[^:]*:Trinity Avowed:594C:/
+14389.6 "Hot And Cold" sync / 1[56]:[^:]*:Trinity Avowed:597B:/
+14396.7 "Quick March" sync / 1[56]:[^:]*:Trinity Avowed:5981:/
+14402.9 "Freedom Of Bozja" sync / 1[56]:[^:]*:Trinity Avowed:597C:/
+14410.3 "Elemental Impact" sync / 1[56]:[^:]*:Tempestuous Orb:4F52:/
+14420.1 "Elemental Blast" sync / 1[56]:[^:]*:Tempestuous Orb:592E:/
+14425.9 "--sync--" sync / 1[56]:[^:]*:Trinity Avowed:5984:/
+14433.0 "Glory Of Bozja" sync / 1[56]:[^:]*:Trinity Avowed:594F:/
 14444.5 "Allegiant Arsenal"
 
 # -> Sword v2?
-14441.5 "--sync--" sync / 14:Trinity Avowed:5985:/ window 40,10 jump 15900
-14449.7 "Infernal Slash?" #sync / 1[56]:Trinity Avowed:594A:/
+14441.5 "--sync--" sync / 14:[^:]*:Trinity Avowed:5985:/ window 40,10 jump 15900
+14449.7 "Infernal Slash?" #sync / 1[56]:[^:]*:Trinity Avowed:594A:/
 # -> Bow v2?
-14441.5 "--sync--" sync / 14:Trinity Avowed:5986:/ window 40,10 jump 16100
-14449.7 "Flashvane?" #sync / 1[56]:Trinity Avowed:594B:/
+14441.5 "--sync--" sync / 14:[^:]*:Trinity Avowed:5986:/ window 40,10 jump 16100
+14449.7 "Flashvane?" #sync / 1[56]:[^:]*:Trinity Avowed:594B:/
 # -> Staff v2?
-14441.5 "--sync--" sync / 14:Trinity Avowed:5987:/ window 40,10 jump 16300
-14449.7 "Fury Of Bozja?" #sync / 1[56]:Trinity Avowed:594C:/
+14441.5 "--sync--" sync / 14:[^:]*:Trinity Avowed:5987:/ window 40,10 jump 16300
+14449.7 "Fury Of Bozja?" #sync / 1[56]:[^:]*:Trinity Avowed:594C:/
 
 
 # Sword v1 (seen staff)
-14500.0 "--sync--" sync / 14:Trinity Avowed:5985:/
-14503.0 "Allegiant Arsenal" sync / 1[56]:Trinity Avowed:5985:/
-14508.2 "Infernal Slash" sync / 1[56]:Trinity Avowed:594A:/
-14515.6 "Hot And Cold" sync / 1[56]:Trinity Avowed:5BAF:/
-14522.7 "Unwavering Apparition" sync / 1[56]:Trinity Avowed:5B3A:/
+14500.0 "--sync--" sync / 14:[^:]*:Trinity Avowed:5985:/
+14503.0 "Allegiant Arsenal" sync / 1[56]:[^:]*:Trinity Avowed:5985:/
+14508.2 "Infernal Slash" sync / 1[56]:[^:]*:Trinity Avowed:594A:/
+14515.6 "Hot And Cold" sync / 1[56]:[^:]*:Trinity Avowed:5BAF:/
+14522.7 "Unwavering Apparition" sync / 1[56]:[^:]*:Trinity Avowed:5B3A:/
 14528.7 "--untargetable--"
-14538.8 "Blade Of Entropy 1" #sync / 1[56]:Trinity Avowed:5959:/
-14552.5 "Blade Of Entropy 2" #sync / 1[56]:Trinity Avowed:5959:/
+14538.8 "Blade Of Entropy 1" #sync / 1[56]:[^:]*:Trinity Avowed:5959:/
+14552.5 "Blade Of Entropy 2" #sync / 1[56]:[^:]*:Trinity Avowed:5959:/
 14555.6 "--targetable--"
-14560.3 "--sync--" sync / 1[56]:Trinity Avowed:5982:/
-14567.4 "Glory Of Bozja" sync / 1[56]:Trinity Avowed:594F:/
+14560.3 "--sync--" sync / 1[56]:[^:]*:Trinity Avowed:5982:/
+14567.4 "Glory Of Bozja" sync / 1[56]:[^:]*:Trinity Avowed:594F:/
 # -> roll into Bow v1 (final)
-14575.3 "--sync--" sync / 14:Trinity Avowed:5986:/ window 70,10
-14578.3 "Allegiant Arsenal" sync / 1[56]:Trinity Avowed:5986:/
-14583.5 "Flashvane" sync / 1[56]:Trinity Avowed:594B:/
-14589.6 "Quick March" sync / 1[56]:Trinity Avowed:5BB3:/
-14597.9 "Wrath Of Bozja" sync / 1[56]:Trinity Avowed:5BB5:/
-14604.0 "Flames Of Bozja" sync / 1[56]:Trinity Avowed:597E:/
-14614.1 "--sync--" sync / 1[56]:Trinity Avowed:5B3D:/
-14614.1 "Flames Of Bozja" sync / 1[56]:Trinity Avowed:5939:/
-14617.3 "Hot And Cold" sync / 1[56]:Trinity Avowed:5BB0:/
-14625.1 "Shimmering Shot" sync / 1[56]:Trinity Avowed:597F:/
-14641.4 "Elemental Arrow" sync / 1[56]:Spark Arrow:593A:/
-14646.7 "--sync--" sync / 1[56]:Trinity Avowed:5983:/ window 10,10 # some variance here
-14653.8 "Glory Of Bozja" sync / 1[56]:Trinity Avowed:594F:/
+14575.3 "--sync--" sync / 14:[^:]*:Trinity Avowed:5986:/ window 70,10
+14578.3 "Allegiant Arsenal" sync / 1[56]:[^:]*:Trinity Avowed:5986:/
+14583.5 "Flashvane" sync / 1[56]:[^:]*:Trinity Avowed:594B:/
+14589.6 "Quick March" sync / 1[56]:[^:]*:Trinity Avowed:5BB3:/
+14597.9 "Wrath Of Bozja" sync / 1[56]:[^:]*:Trinity Avowed:5BB5:/
+14604.0 "Flames Of Bozja" sync / 1[56]:[^:]*:Trinity Avowed:597E:/
+14614.1 "--sync--" sync / 1[56]:[^:]*:Trinity Avowed:5B3D:/
+14614.1 "Flames Of Bozja" sync / 1[56]:[^:]*:Trinity Avowed:5939:/
+14617.3 "Hot And Cold" sync / 1[56]:[^:]*:Trinity Avowed:5BB0:/
+14625.1 "Shimmering Shot" sync / 1[56]:[^:]*:Trinity Avowed:597F:/
+14641.4 "Elemental Arrow" sync / 1[56]:[^:]*:Spark Arrow:593A:/
+14646.7 "--sync--" sync / 1[56]:[^:]*:Trinity Avowed:5983:/ window 10,10 # some variance here
+14653.8 "Glory Of Bozja" sync / 1[56]:[^:]*:Trinity Avowed:594F:/
 14664.2 "Allegiant Arsenal"
 
 # -> Sword v2?
-14661.2 "--sync--" sync / 14:Trinity Avowed:5985:/ window 40,10 jump 15900
-14669.4 "Infernal Slash?" #sync / 1[56]:Trinity Avowed:594A:/
+14661.2 "--sync--" sync / 14:[^:]*:Trinity Avowed:5985:/ window 40,10 jump 15900
+14669.4 "Infernal Slash?" #sync / 1[56]:[^:]*:Trinity Avowed:594A:/
 # -> Bow v2?
-14661.2 "--sync--" sync / 14:Trinity Avowed:5986:/ window 40,10 jump 16100
-14669.4 "Flashvane?" #sync / 1[56]:Trinity Avowed:594B:/
+14661.2 "--sync--" sync / 14:[^:]*:Trinity Avowed:5986:/ window 40,10 jump 16100
+14669.4 "Flashvane?" #sync / 1[56]:[^:]*:Trinity Avowed:594B:/
 # -> Staff v2?
-14661.2 "--sync--" sync / 14:Trinity Avowed:5987:/ window 40,10 jump 16300
-14669.4 "Fury Of Bozja?" #sync / 1[56]:Trinity Avowed:594C:/
+14661.2 "--sync--" sync / 14:[^:]*:Trinity Avowed:5987:/ window 40,10 jump 16300
+14669.4 "Fury Of Bozja?" #sync / 1[56]:[^:]*:Trinity Avowed:594C:/
 
 
 # Bow v1 (initial)
-14700.0 "--sync--" sync / 14:Trinity Avowed:5986:/
-14703.0 "Allegiant Arsenal" sync / 1[56]:Trinity Avowed:5986:/
-14708.2 "Flashvane" sync / 1[56]:Trinity Avowed:594B:/
-14714.3 "Quick March" sync / 1[56]:Trinity Avowed:5BB3:/
-14722.6 "Wrath Of Bozja" sync / 1[56]:Trinity Avowed:5BB5:/
-14728.7 "Flames Of Bozja" sync / 1[56]:Trinity Avowed:597E:/
-14738.8 "--sync--" sync / 1[56]:Trinity Avowed:5B3D:/
-14738.8 "Flames Of Bozja" sync / 1[56]:Trinity Avowed:5939:/
-14742.0 "Hot And Cold" sync / 1[56]:Trinity Avowed:5BB0:/
-14749.8 "Shimmering Shot" sync / 1[56]:Trinity Avowed:597F:/
-14766.1 "Elemental Arrow" sync / 1[56]:Spark Arrow:593A:/
-14771.4 "--sync--" sync / 1[56]:Trinity Avowed:5983:/ window 10,10 # some variance here
-14778.5 "Glory Of Bozja" sync / 1[56]:Trinity Avowed:594F:/
+14700.0 "--sync--" sync / 14:[^:]*:Trinity Avowed:5986:/
+14703.0 "Allegiant Arsenal" sync / 1[56]:[^:]*:Trinity Avowed:5986:/
+14708.2 "Flashvane" sync / 1[56]:[^:]*:Trinity Avowed:594B:/
+14714.3 "Quick March" sync / 1[56]:[^:]*:Trinity Avowed:5BB3:/
+14722.6 "Wrath Of Bozja" sync / 1[56]:[^:]*:Trinity Avowed:5BB5:/
+14728.7 "Flames Of Bozja" sync / 1[56]:[^:]*:Trinity Avowed:597E:/
+14738.8 "--sync--" sync / 1[56]:[^:]*:Trinity Avowed:5B3D:/
+14738.8 "Flames Of Bozja" sync / 1[56]:[^:]*:Trinity Avowed:5939:/
+14742.0 "Hot And Cold" sync / 1[56]:[^:]*:Trinity Avowed:5BB0:/
+14749.8 "Shimmering Shot" sync / 1[56]:[^:]*:Trinity Avowed:597F:/
+14766.1 "Elemental Arrow" sync / 1[56]:[^:]*:Spark Arrow:593A:/
+14771.4 "--sync--" sync / 1[56]:[^:]*:Trinity Avowed:5983:/ window 10,10 # some variance here
+14778.5 "Glory Of Bozja" sync / 1[56]:[^:]*:Trinity Avowed:594F:/
 14788.9 "Allegiant Arsenal"
 
 # -> Sword v1 (seen bow)?
-14785.9 "--sync--" sync / 14:Trinity Avowed:5985:/ window 70,10 jump 14300
-14794.1 "Infernal Slash?" #sync / 1[56]:Trinity Avowed:594A:/
+14785.9 "--sync--" sync / 14:[^:]*:Trinity Avowed:5985:/ window 70,10 jump 14300
+14794.1 "Infernal Slash?" #sync / 1[56]:[^:]*:Trinity Avowed:594A:/
 # -> Staff v1 (seen bow)?
-14785.9 "--sync--" sync / 14:Trinity Avowed:5987:/ window 70,10 jump 15700
-14794.1 "Fury Of Bozja?" #sync / 1[56]:Trinity Avowed:594C:/
+14785.9 "--sync--" sync / 14:[^:]*:Trinity Avowed:5987:/ window 70,10 jump 15700
+14794.1 "Fury Of Bozja?" #sync / 1[56]:[^:]*:Trinity Avowed:594C:/
 
 
 # Bow v1 (seen sword)
-14900.0 "--sync--" sync / 14:Trinity Avowed:5986:/
-14903.0 "Allegiant Arsenal" sync / 1[56]:Trinity Avowed:5986:/
-14908.2 "Flashvane" sync / 1[56]:Trinity Avowed:594B:/
-14914.3 "Quick March" sync / 1[56]:Trinity Avowed:5BB3:/
-14922.6 "Wrath Of Bozja" sync / 1[56]:Trinity Avowed:5BB5:/
-14928.7 "Flames Of Bozja" sync / 1[56]:Trinity Avowed:597E:/
-14938.8 "--sync--" sync / 1[56]:Trinity Avowed:5B3D:/
-14938.8 "Flames Of Bozja" sync / 1[56]:Trinity Avowed:5939:/
-14942.0 "Hot And Cold" sync / 1[56]:Trinity Avowed:5BB0:/
-14949.8 "Shimmering Shot" sync / 1[56]:Trinity Avowed:597F:/
-14966.1 "Elemental Arrow" sync / 1[56]:Spark Arrow:593A:/
-14971.4 "--sync--" sync / 1[56]:Trinity Avowed:5983:/ window 10,10 # some variance here
-14978.5 "Glory Of Bozja" sync / 1[56]:Trinity Avowed:594F:/
+14900.0 "--sync--" sync / 14:[^:]*:Trinity Avowed:5986:/
+14903.0 "Allegiant Arsenal" sync / 1[56]:[^:]*:Trinity Avowed:5986:/
+14908.2 "Flashvane" sync / 1[56]:[^:]*:Trinity Avowed:594B:/
+14914.3 "Quick March" sync / 1[56]:[^:]*:Trinity Avowed:5BB3:/
+14922.6 "Wrath Of Bozja" sync / 1[56]:[^:]*:Trinity Avowed:5BB5:/
+14928.7 "Flames Of Bozja" sync / 1[56]:[^:]*:Trinity Avowed:597E:/
+14938.8 "--sync--" sync / 1[56]:[^:]*:Trinity Avowed:5B3D:/
+14938.8 "Flames Of Bozja" sync / 1[56]:[^:]*:Trinity Avowed:5939:/
+14942.0 "Hot And Cold" sync / 1[56]:[^:]*:Trinity Avowed:5BB0:/
+14949.8 "Shimmering Shot" sync / 1[56]:[^:]*:Trinity Avowed:597F:/
+14966.1 "Elemental Arrow" sync / 1[56]:[^:]*:Spark Arrow:593A:/
+14971.4 "--sync--" sync / 1[56]:[^:]*:Trinity Avowed:5983:/ window 10,10 # some variance here
+14978.5 "Glory Of Bozja" sync / 1[56]:[^:]*:Trinity Avowed:594F:/
 # -> roll into Staff v1 (final)
-14985.9 "--sync--" sync / 14:Trinity Avowed:5987:/ window 70,10
-14988.9 "Allegiant Arsenal" sync / 1[56]:Trinity Avowed:5987:/
-14994.1 "Fury Of Bozja" sync / 1[56]:Trinity Avowed:594C:/
-15000.2 "Hot And Cold" sync / 1[56]:Trinity Avowed:597B:/
-15007.3 "Quick March" sync / 1[56]:Trinity Avowed:5981:/
-15013.5 "Freedom Of Bozja" sync / 1[56]:Trinity Avowed:597C:/
-15020.9 "Elemental Impact" sync / 1[56]:Tempestuous Orb:4F52:/
-15030.7 "Elemental Blast" sync / 1[56]:Tempestuous Orb:592E:/
-15036.5 "--sync--" sync / 1[56]:Trinity Avowed:5984:/
-15043.6 "Glory Of Bozja" sync / 1[56]:Trinity Avowed:594F:/
+14985.9 "--sync--" sync / 14:[^:]*:Trinity Avowed:5987:/ window 70,10
+14988.9 "Allegiant Arsenal" sync / 1[56]:[^:]*:Trinity Avowed:5987:/
+14994.1 "Fury Of Bozja" sync / 1[56]:[^:]*:Trinity Avowed:594C:/
+15000.2 "Hot And Cold" sync / 1[56]:[^:]*:Trinity Avowed:597B:/
+15007.3 "Quick March" sync / 1[56]:[^:]*:Trinity Avowed:5981:/
+15013.5 "Freedom Of Bozja" sync / 1[56]:[^:]*:Trinity Avowed:597C:/
+15020.9 "Elemental Impact" sync / 1[56]:[^:]*:Tempestuous Orb:4F52:/
+15030.7 "Elemental Blast" sync / 1[56]:[^:]*:Tempestuous Orb:592E:/
+15036.5 "--sync--" sync / 1[56]:[^:]*:Trinity Avowed:5984:/
+15043.6 "Glory Of Bozja" sync / 1[56]:[^:]*:Trinity Avowed:594F:/
 15055.1 "Allegiant Arsenal"
 
 # -> Sword v2?
-15052.1 "--sync--" sync / 14:Trinity Avowed:5985:/ window 40,10 jump 15900
-15060.3 "Infernal Slash?" #sync / 1[56]:Trinity Avowed:594A:/
+15052.1 "--sync--" sync / 14:[^:]*:Trinity Avowed:5985:/ window 40,10 jump 15900
+15060.3 "Infernal Slash?" #sync / 1[56]:[^:]*:Trinity Avowed:594A:/
 # -> Bow v2?
-15052.1 "--sync--" sync / 14:Trinity Avowed:5986:/ window 40,10 jump 16100
-15060.3 "Flashvane?" #sync / 1[56]:Trinity Avowed:594B:/
+15052.1 "--sync--" sync / 14:[^:]*:Trinity Avowed:5986:/ window 40,10 jump 16100
+15060.3 "Flashvane?" #sync / 1[56]:[^:]*:Trinity Avowed:594B:/
 # -> Staff v2?
-15052.1 "--sync--" sync / 14:Trinity Avowed:5987:/ window 40,10 jump 16300
-15060.3 "Fury Of Bozja?" #sync / 1[56]:Trinity Avowed:594C:/
+15052.1 "--sync--" sync / 14:[^:]*:Trinity Avowed:5987:/ window 40,10 jump 16300
+15060.3 "Fury Of Bozja?" #sync / 1[56]:[^:]*:Trinity Avowed:594C:/
 
 
 # Bow v1 (seen staff)
-15100.0 "--sync--" sync / 14:Trinity Avowed:5986:/
-15103.0 "Allegiant Arsenal" sync / 1[56]:Trinity Avowed:5986:/
-15108.2 "Flashvane" sync / 1[56]:Trinity Avowed:594B:/
-15114.3 "Quick March" sync / 1[56]:Trinity Avowed:5BB3:/
-15122.6 "Wrath Of Bozja" sync / 1[56]:Trinity Avowed:5BB5:/
-15128.7 "Flames Of Bozja" sync / 1[56]:Trinity Avowed:597E:/
-15138.8 "--sync--" sync / 1[56]:Trinity Avowed:5B3D:/
-15138.8 "Flames Of Bozja" sync / 1[56]:Trinity Avowed:5939:/
-15142.0 "Hot And Cold" sync / 1[56]:Trinity Avowed:5BB0:/
-15149.8 "Shimmering Shot" sync / 1[56]:Trinity Avowed:597F:/
-15166.1 "Elemental Arrow" sync / 1[56]:Spark Arrow:593A:/
-15171.4 "--sync--" sync / 1[56]:Trinity Avowed:5983:/ window 10,10 # some variance here
-15178.5 "Glory Of Bozja" sync / 1[56]:Trinity Avowed:594F:/
+15100.0 "--sync--" sync / 14:[^:]*:Trinity Avowed:5986:/
+15103.0 "Allegiant Arsenal" sync / 1[56]:[^:]*:Trinity Avowed:5986:/
+15108.2 "Flashvane" sync / 1[56]:[^:]*:Trinity Avowed:594B:/
+15114.3 "Quick March" sync / 1[56]:[^:]*:Trinity Avowed:5BB3:/
+15122.6 "Wrath Of Bozja" sync / 1[56]:[^:]*:Trinity Avowed:5BB5:/
+15128.7 "Flames Of Bozja" sync / 1[56]:[^:]*:Trinity Avowed:597E:/
+15138.8 "--sync--" sync / 1[56]:[^:]*:Trinity Avowed:5B3D:/
+15138.8 "Flames Of Bozja" sync / 1[56]:[^:]*:Trinity Avowed:5939:/
+15142.0 "Hot And Cold" sync / 1[56]:[^:]*:Trinity Avowed:5BB0:/
+15149.8 "Shimmering Shot" sync / 1[56]:[^:]*:Trinity Avowed:597F:/
+15166.1 "Elemental Arrow" sync / 1[56]:[^:]*:Spark Arrow:593A:/
+15171.4 "--sync--" sync / 1[56]:[^:]*:Trinity Avowed:5983:/ window 10,10 # some variance here
+15178.5 "Glory Of Bozja" sync / 1[56]:[^:]*:Trinity Avowed:594F:/
 # -> roll into Sword v1 (final)
-15185.9 "--sync--" sync / 14:Trinity Avowed:5985:/ window 70,10
-15188.9 "Allegiant Arsenal" sync / 1[56]:Trinity Avowed:5985:/
-15194.1 "Infernal Slash" sync / 1[56]:Trinity Avowed:594A:/
-15201.5 "Hot And Cold" sync / 1[56]:Trinity Avowed:5BAF:/
-15208.6 "Unwavering Apparition" sync / 1[56]:Trinity Avowed:5B3A:/
+15185.9 "--sync--" sync / 14:[^:]*:Trinity Avowed:5985:/ window 70,10
+15188.9 "Allegiant Arsenal" sync / 1[56]:[^:]*:Trinity Avowed:5985:/
+15194.1 "Infernal Slash" sync / 1[56]:[^:]*:Trinity Avowed:594A:/
+15201.5 "Hot And Cold" sync / 1[56]:[^:]*:Trinity Avowed:5BAF:/
+15208.6 "Unwavering Apparition" sync / 1[56]:[^:]*:Trinity Avowed:5B3A:/
 15214.6 "--untargetable--"
-15224.7 "Blade Of Entropy 1" #sync / 1[56]:Trinity Avowed:5959:/
-15238.4 "Blade Of Entropy 2" #sync / 1[56]:Trinity Avowed:5959:/
+15224.7 "Blade Of Entropy 1" #sync / 1[56]:[^:]*:Trinity Avowed:5959:/
+15238.4 "Blade Of Entropy 2" #sync / 1[56]:[^:]*:Trinity Avowed:5959:/
 15241.5 "--targetable--"
-15246.2 "--sync--" sync / 1[56]:Trinity Avowed:5982:/
-15253.3 "Glory Of Bozja" sync / 1[56]:Trinity Avowed:594F:/
+15246.2 "--sync--" sync / 1[56]:[^:]*:Trinity Avowed:5982:/
+15253.3 "Glory Of Bozja" sync / 1[56]:[^:]*:Trinity Avowed:594F:/
 
 # -> Sword v2?
-15261.2 "--sync--" sync / 14:Trinity Avowed:5985:/ window 40,10 jump 15900
-15269.4 "Infernal Slash?" #sync / 1[56]:Trinity Avowed:594A:/
+15261.2 "--sync--" sync / 14:[^:]*:Trinity Avowed:5985:/ window 40,10 jump 15900
+15269.4 "Infernal Slash?" #sync / 1[56]:[^:]*:Trinity Avowed:594A:/
 # -> Bow v2?
-15261.2 "--sync--" sync / 14:Trinity Avowed:5986:/ window 40,10 jump 16100
-15269.4 "Flashvane?" #sync / 1[56]:Trinity Avowed:594B:/
+15261.2 "--sync--" sync / 14:[^:]*:Trinity Avowed:5986:/ window 40,10 jump 16100
+15269.4 "Flashvane?" #sync / 1[56]:[^:]*:Trinity Avowed:594B:/
 # -> Staff v2?
-15261.2 "--sync--" sync / 14:Trinity Avowed:5987:/ window 40,10 jump 16300
-15269.4 "Fury Of Bozja?" #sync / 1[56]:Trinity Avowed:594C:/
+15261.2 "--sync--" sync / 14:[^:]*:Trinity Avowed:5987:/ window 40,10 jump 16300
+15269.4 "Fury Of Bozja?" #sync / 1[56]:[^:]*:Trinity Avowed:594C:/
 
 
 # Staff v1 (initial)
-15300.0 "--sync--" sync / 14:Trinity Avowed:5987:/
-15303.0 "Allegiant Arsenal" sync / 1[56]:Trinity Avowed:5987:/
-15308.2 "Fury Of Bozja" sync / 1[56]:Trinity Avowed:594C:/
-15314.3 "Hot And Cold" sync / 1[56]:Trinity Avowed:597B:/
-15321.4 "Quick March" sync / 1[56]:Trinity Avowed:5981:/
-15327.6 "Freedom Of Bozja" sync / 1[56]:Trinity Avowed:597C:/
-15335.0 "Elemental Impact" sync / 1[56]:Tempestuous Orb:4F52:/
-15344.8 "Elemental Blast" sync / 1[56]:Tempestuous Orb:592E:/
-15350.6 "--sync--" sync / 1[56]:Trinity Avowed:5984:/
-15357.7 "Glory Of Bozja" sync / 1[56]:Trinity Avowed:594F:/
+15300.0 "--sync--" sync / 14:[^:]*:Trinity Avowed:5987:/
+15303.0 "Allegiant Arsenal" sync / 1[56]:[^:]*:Trinity Avowed:5987:/
+15308.2 "Fury Of Bozja" sync / 1[56]:[^:]*:Trinity Avowed:594C:/
+15314.3 "Hot And Cold" sync / 1[56]:[^:]*:Trinity Avowed:597B:/
+15321.4 "Quick March" sync / 1[56]:[^:]*:Trinity Avowed:5981:/
+15327.6 "Freedom Of Bozja" sync / 1[56]:[^:]*:Trinity Avowed:597C:/
+15335.0 "Elemental Impact" sync / 1[56]:[^:]*:Tempestuous Orb:4F52:/
+15344.8 "Elemental Blast" sync / 1[56]:[^:]*:Tempestuous Orb:592E:/
+15350.6 "--sync--" sync / 1[56]:[^:]*:Trinity Avowed:5984:/
+15357.7 "Glory Of Bozja" sync / 1[56]:[^:]*:Trinity Avowed:594F:/
 15369.2 "Allegiant Arsenal"
 
 # -> Sword v1 (seen staff)
-15366.2 "--sync--" sync / 14:Trinity Avowed:5985:/ window 70,10 jump 14500
-15374.4 "Infernal Slash?" #sync / 1[56]:Trinity Avowed:594A:/
+15366.2 "--sync--" sync / 14:[^:]*:Trinity Avowed:5985:/ window 70,10 jump 14500
+15374.4 "Infernal Slash?" #sync / 1[56]:[^:]*:Trinity Avowed:594A:/
 # -> Bow v1 (seen staff)
-15366.2 "--sync--" sync / 14:Trinity Avowed:5986:/ window 70,10 jump 15100
-15374.4 "Flashvane?" #sync / 1[56]:Trinity Avowed:594B:/
+15366.2 "--sync--" sync / 14:[^:]*:Trinity Avowed:5986:/ window 70,10 jump 15100
+15374.4 "Flashvane?" #sync / 1[56]:[^:]*:Trinity Avowed:594B:/
 
 
 # Staff v1 (seen sword)
-15500.0 "--sync--" sync / 14:Trinity Avowed:5987:/
-15503.0 "Allegiant Arsenal" sync / 1[56]:Trinity Avowed:5987:/
-15508.2 "Fury Of Bozja" sync / 1[56]:Trinity Avowed:594C:/
-15514.3 "Hot And Cold" sync / 1[56]:Trinity Avowed:597B:/
-15521.4 "Quick March" sync / 1[56]:Trinity Avowed:5981:/
-15527.6 "Freedom Of Bozja" sync / 1[56]:Trinity Avowed:597C:/
-15535.0 "Elemental Impact" sync / 1[56]:Tempestuous Orb:4F52:/
-15544.8 "Elemental Blast" sync / 1[56]:Tempestuous Orb:592E:/
-15550.6 "--sync--" sync / 1[56]:Trinity Avowed:5984:/
-15557.7 "Glory Of Bozja" sync / 1[56]:Trinity Avowed:594F:/
+15500.0 "--sync--" sync / 14:[^:]*:Trinity Avowed:5987:/
+15503.0 "Allegiant Arsenal" sync / 1[56]:[^:]*:Trinity Avowed:5987:/
+15508.2 "Fury Of Bozja" sync / 1[56]:[^:]*:Trinity Avowed:594C:/
+15514.3 "Hot And Cold" sync / 1[56]:[^:]*:Trinity Avowed:597B:/
+15521.4 "Quick March" sync / 1[56]:[^:]*:Trinity Avowed:5981:/
+15527.6 "Freedom Of Bozja" sync / 1[56]:[^:]*:Trinity Avowed:597C:/
+15535.0 "Elemental Impact" sync / 1[56]:[^:]*:Tempestuous Orb:4F52:/
+15544.8 "Elemental Blast" sync / 1[56]:[^:]*:Tempestuous Orb:592E:/
+15550.6 "--sync--" sync / 1[56]:[^:]*:Trinity Avowed:5984:/
+15557.7 "Glory Of Bozja" sync / 1[56]:[^:]*:Trinity Avowed:594F:/
 # -> roll into Bow v1 (final)
-15566.2 "--sync--" sync / 14:Trinity Avowed:5986:/ window 70,10
-15569.2 "Allegiant Arsenal" sync / 1[56]:Trinity Avowed:5986:/
-15574.4 "Flashvane" sync / 1[56]:Trinity Avowed:594B:/
-15580.5 "Quick March" sync / 1[56]:Trinity Avowed:5BB3:/
-15588.8 "Wrath Of Bozja" sync / 1[56]:Trinity Avowed:5BB5:/
-15594.9 "Flames Of Bozja" sync / 1[56]:Trinity Avowed:597E:/
-15605.0 "--sync--" sync / 1[56]:Trinity Avowed:5B3D:/
-15605.0 "Flames Of Bozja" sync / 1[56]:Trinity Avowed:5939:/
-15608.2 "Hot And Cold" sync / 1[56]:Trinity Avowed:5BB0:/
-15616.0 "Shimmering Shot" sync / 1[56]:Trinity Avowed:597F:/
-15632.3 "Elemental Arrow" sync / 1[56]:Spark Arrow:593A:/
-15637.6 "--sync--" sync / 1[56]:Trinity Avowed:5983:/ window 10,10 # some variance here
-15644.7 "Glory Of Bozja" sync / 1[56]:Trinity Avowed:594F:/
+15566.2 "--sync--" sync / 14:[^:]*:Trinity Avowed:5986:/ window 70,10
+15569.2 "Allegiant Arsenal" sync / 1[56]:[^:]*:Trinity Avowed:5986:/
+15574.4 "Flashvane" sync / 1[56]:[^:]*:Trinity Avowed:594B:/
+15580.5 "Quick March" sync / 1[56]:[^:]*:Trinity Avowed:5BB3:/
+15588.8 "Wrath Of Bozja" sync / 1[56]:[^:]*:Trinity Avowed:5BB5:/
+15594.9 "Flames Of Bozja" sync / 1[56]:[^:]*:Trinity Avowed:597E:/
+15605.0 "--sync--" sync / 1[56]:[^:]*:Trinity Avowed:5B3D:/
+15605.0 "Flames Of Bozja" sync / 1[56]:[^:]*:Trinity Avowed:5939:/
+15608.2 "Hot And Cold" sync / 1[56]:[^:]*:Trinity Avowed:5BB0:/
+15616.0 "Shimmering Shot" sync / 1[56]:[^:]*:Trinity Avowed:597F:/
+15632.3 "Elemental Arrow" sync / 1[56]:[^:]*:Spark Arrow:593A:/
+15637.6 "--sync--" sync / 1[56]:[^:]*:Trinity Avowed:5983:/ window 10,10 # some variance here
+15644.7 "Glory Of Bozja" sync / 1[56]:[^:]*:Trinity Avowed:594F:/
 15655.1 "Allegiant Arsenal"
 
 # -> Sword v2?
-15652.1 "--sync--" sync / 14:Trinity Avowed:5985:/ window 40,10 jump 15900
-15660.3 "Infernal Slash?" #sync / 1[56]:Trinity Avowed:594A:/
+15652.1 "--sync--" sync / 14:[^:]*:Trinity Avowed:5985:/ window 40,10 jump 15900
+15660.3 "Infernal Slash?" #sync / 1[56]:[^:]*:Trinity Avowed:594A:/
 # -> Bow v2?
-15652.1 "--sync--" sync / 14:Trinity Avowed:5986:/ window 40,10 jump 16100
-15660.3 "Flashvane?" #sync / 1[56]:Trinity Avowed:594B:/
+15652.1 "--sync--" sync / 14:[^:]*:Trinity Avowed:5986:/ window 40,10 jump 16100
+15660.3 "Flashvane?" #sync / 1[56]:[^:]*:Trinity Avowed:594B:/
 # -> Staff v2?
-15652.1 "--sync--" sync / 14:Trinity Avowed:5987:/ window 40,10 jump 16300
-15660.3 "Fury Of Bozja?" #sync / 1[56]:Trinity Avowed:594C:/
+15652.1 "--sync--" sync / 14:[^:]*:Trinity Avowed:5987:/ window 40,10 jump 16300
+15660.3 "Fury Of Bozja?" #sync / 1[56]:[^:]*:Trinity Avowed:594C:/
 
 
 # Staff v1 (seen bow)
-15700.0 "--sync--" sync / 14:Trinity Avowed:5987:/
-15703.0 "Allegiant Arsenal" sync / 1[56]:Trinity Avowed:5987:/
-15708.2 "Fury Of Bozja" sync / 1[56]:Trinity Avowed:594C:/
-15714.3 "Hot And Cold" sync / 1[56]:Trinity Avowed:597B:/
-15721.4 "Quick March" sync / 1[56]:Trinity Avowed:5981:/
-15727.6 "Freedom Of Bozja" sync / 1[56]:Trinity Avowed:597C:/
-15735.0 "Elemental Impact" sync / 1[56]:Tempestuous Orb:4F52:/
-15744.8 "Elemental Blast" sync / 1[56]:Tempestuous Orb:592E:/
-15750.6 "--sync--" sync / 1[56]:Trinity Avowed:5984:/
-15757.7 "Glory Of Bozja" sync / 1[56]:Trinity Avowed:594F:/
+15700.0 "--sync--" sync / 14:[^:]*:Trinity Avowed:5987:/
+15703.0 "Allegiant Arsenal" sync / 1[56]:[^:]*:Trinity Avowed:5987:/
+15708.2 "Fury Of Bozja" sync / 1[56]:[^:]*:Trinity Avowed:594C:/
+15714.3 "Hot And Cold" sync / 1[56]:[^:]*:Trinity Avowed:597B:/
+15721.4 "Quick March" sync / 1[56]:[^:]*:Trinity Avowed:5981:/
+15727.6 "Freedom Of Bozja" sync / 1[56]:[^:]*:Trinity Avowed:597C:/
+15735.0 "Elemental Impact" sync / 1[56]:[^:]*:Tempestuous Orb:4F52:/
+15744.8 "Elemental Blast" sync / 1[56]:[^:]*:Tempestuous Orb:592E:/
+15750.6 "--sync--" sync / 1[56]:[^:]*:Trinity Avowed:5984:/
+15757.7 "Glory Of Bozja" sync / 1[56]:[^:]*:Trinity Avowed:594F:/
 # -> roll into Sword v1 (final)
-15766.2 "--sync--" sync / 14:Trinity Avowed:5985:/ window 70,10
-15769.2 "Allegiant Arsenal" sync / 1[56]:Trinity Avowed:5985:/
-15774.4 "Infernal Slash" sync / 1[56]:Trinity Avowed:594A:/
-15781.8 "Hot And Cold" sync / 1[56]:Trinity Avowed:5BAF:/
-15788.9 "Unwavering Apparition" sync / 1[56]:Trinity Avowed:5B3A:/
+15766.2 "--sync--" sync / 14:[^:]*:Trinity Avowed:5985:/ window 70,10
+15769.2 "Allegiant Arsenal" sync / 1[56]:[^:]*:Trinity Avowed:5985:/
+15774.4 "Infernal Slash" sync / 1[56]:[^:]*:Trinity Avowed:594A:/
+15781.8 "Hot And Cold" sync / 1[56]:[^:]*:Trinity Avowed:5BAF:/
+15788.9 "Unwavering Apparition" sync / 1[56]:[^:]*:Trinity Avowed:5B3A:/
 15794.9 "--untargetable--"
-15805.0 "Blade Of Entropy 1" #sync / 1[56]:Trinity Avowed:5959:/
-15818.7 "Blade Of Entropy 2" #sync / 1[56]:Trinity Avowed:5959:/
+15805.0 "Blade Of Entropy 1" #sync / 1[56]:[^:]*:Trinity Avowed:5959:/
+15818.7 "Blade Of Entropy 2" #sync / 1[56]:[^:]*:Trinity Avowed:5959:/
 15821.8 "--targetable--"
-15826.5 "--sync--" sync / 1[56]:Trinity Avowed:5982:/
-15833.6 "Glory Of Bozja" sync / 1[56]:Trinity Avowed:594F:/
+15826.5 "--sync--" sync / 1[56]:[^:]*:Trinity Avowed:5982:/
+15833.6 "Glory Of Bozja" sync / 1[56]:[^:]*:Trinity Avowed:594F:/
 15844.5 "Allegiant Arsenal"
 
 # -> Sword v2?
-15841.5 "--sync--" sync / 14:Trinity Avowed:5985:/ window 40,10 jump 15900
-15849.7 "Infernal Slash?" #sync / 1[56]:Trinity Avowed:594A:/
+15841.5 "--sync--" sync / 14:[^:]*:Trinity Avowed:5985:/ window 40,10 jump 15900
+15849.7 "Infernal Slash?" #sync / 1[56]:[^:]*:Trinity Avowed:594A:/
 # -> Bow v2?
-15841.5 "--sync--" sync / 14:Trinity Avowed:5986:/ window 40,10 jump 16100
-15849.7 "Flashvane?" #sync / 1[56]:Trinity Avowed:594B:/
+15841.5 "--sync--" sync / 14:[^:]*:Trinity Avowed:5986:/ window 40,10 jump 16100
+15849.7 "Flashvane?" #sync / 1[56]:[^:]*:Trinity Avowed:594B:/
 # -> Staff v2?
-15841.5 "--sync--" sync / 14:Trinity Avowed:5987:/ window 40,10 jump 16300
-15849.7 "Fury Of Bozja?" #sync / 1[56]:Trinity Avowed:594C:/
+15841.5 "--sync--" sync / 14:[^:]*:Trinity Avowed:5987:/ window 40,10 jump 16300
+15849.7 "Fury Of Bozja?" #sync / 1[56]:[^:]*:Trinity Avowed:594C:/
 
 
 # Sword v2
-15900.0 "--sync--" sync / 14:Trinity Avowed:5985:/
-15903.0 "Allegiant Arsenal" sync / 1[56]:Trinity Avowed:5985:/
-15908.2 "Infernal Slash" sync / 1[56]:Trinity Avowed:594A:/
-15915.4 "Hot And Cold" sync / 1[56]:Trinity Avowed:5BAF:/
-15922.5 "Elemental Brand" sync / 1[56]:Trinity Avowed:5BB1:/
-15928.6 "Unwavering Apparition" sync / 1[56]:Trinity Avowed:5B3A:/
+15900.0 "--sync--" sync / 14:[^:]*:Trinity Avowed:5985:/
+15903.0 "Allegiant Arsenal" sync / 1[56]:[^:]*:Trinity Avowed:5985:/
+15908.2 "Infernal Slash" sync / 1[56]:[^:]*:Trinity Avowed:594A:/
+15915.4 "Hot And Cold" sync / 1[56]:[^:]*:Trinity Avowed:5BAF:/
+15922.5 "Elemental Brand" sync / 1[56]:[^:]*:Trinity Avowed:5BB1:/
+15928.6 "Unwavering Apparition" sync / 1[56]:[^:]*:Trinity Avowed:5B3A:/
 15934.6 "--untargetable--"
-15944.7 "Blade Of Entropy 1" #sync / 1[56]:Trinity Avowed:5959:/
-15958.7 "Blade Of Entropy 2" #sync / 1[56]:Trinity Avowed:5959:/
+15944.7 "Blade Of Entropy 1" #sync / 1[56]:[^:]*:Trinity Avowed:5959:/
+15958.7 "Blade Of Entropy 2" #sync / 1[56]:[^:]*:Trinity Avowed:5959:/
 15961.8 "--targetable--"
-15966.2 "--sync--" sync / 1[56]:Trinity Avowed:5982:/
-15973.3 "Glory Of Bozja" sync / 1[56]:Trinity Avowed:594F:/
+15966.2 "--sync--" sync / 1[56]:[^:]*:Trinity Avowed:5982:/
+15973.3 "Glory Of Bozja" sync / 1[56]:[^:]*:Trinity Avowed:594F:/
 15984.6 "Allegiant Arsenal"
 
 # -> Bow v2?
-15981.6 "--sync--" sync / 14:Trinity Avowed:5986:/ window 70,10 jump 16100
-15989.8 "Flashvane?" #sync / 1[56]:Trinity Avowed:594B:/
+15981.6 "--sync--" sync / 14:[^:]*:Trinity Avowed:5986:/ window 70,10 jump 16100
+15989.8 "Flashvane?" #sync / 1[56]:[^:]*:Trinity Avowed:594B:/
 # -> Staff v2?
-15981.6 "--sync--" sync / 14:Trinity Avowed:5987:/ window 70,10 jump 16300
-15989.8 "Fury Of Bozja?" #sync / 1[56]:Trinity Avowed:594C:/
+15981.6 "--sync--" sync / 14:[^:]*:Trinity Avowed:5987:/ window 70,10 jump 16300
+15989.8 "Fury Of Bozja?" #sync / 1[56]:[^:]*:Trinity Avowed:594C:/
 
 
 # Bow v2
-16100.0 "--sync--" sync / 14:Trinity Avowed:5986:/
-16103.0 "Allegiant Arsenal" sync / 1[56]:Trinity Avowed:5986:/
-16108.2 "Flashvane" sync / 1[56]:Trinity Avowed:594B:/
-16114.3 "Unseen Eye" sync / 1[56]:Trinity Avowed:5BB4:/
-16120.5 "Flames Of Bozja" sync / 1[56]:Trinity Avowed:597E:/
-16125.6 "Gleaming Arrow" sync / 1[56]:Avowed Avatar:594D:/
-16130.6 "--sync--" sync / 1[56]:Trinity Avowed:5B3D:/
-16130.6 "Flames Of Bozja" sync / 1[56]:Trinity Avowed:5939:/
-16133.9 "Hot And Cold" sync / 1[56]:Trinity Avowed:5BB0:/
-16141.0 "Elemental Brand" sync / 1[56]:Trinity Avowed:5BB2:/
-16147.2 "Quick March" sync / 1[56]:Trinity Avowed:5BB3:/
-16154.0 "Shimmering Shot" sync / 1[56]:Trinity Avowed:597F:/
-16171.3 "Elemental Arrow" sync / 1[56]:Spark Arrow:593A:/
-16176.7 "--sync--" sync / 1[56]:Trinity Avowed:5983:/ window 10,10 # some variance here
-16183.8 "Glory Of Bozja" sync / 1[56]:Trinity Avowed:594F:/
-16192.3 "Wrath Of Bozja" sync / 1[56]:Trinity Avowed:594E:/
-16203.0 "Allegiant Arsenal" sync / 1[56]:Trinity Avowed:5987:/
+16100.0 "--sync--" sync / 14:[^:]*:Trinity Avowed:5986:/
+16103.0 "Allegiant Arsenal" sync / 1[56]:[^:]*:Trinity Avowed:5986:/
+16108.2 "Flashvane" sync / 1[56]:[^:]*:Trinity Avowed:594B:/
+16114.3 "Unseen Eye" sync / 1[56]:[^:]*:Trinity Avowed:5BB4:/
+16120.5 "Flames Of Bozja" sync / 1[56]:[^:]*:Trinity Avowed:597E:/
+16125.6 "Gleaming Arrow" sync / 1[56]:[^:]*:Avowed Avatar:594D:/
+16130.6 "--sync--" sync / 1[56]:[^:]*:Trinity Avowed:5B3D:/
+16130.6 "Flames Of Bozja" sync / 1[56]:[^:]*:Trinity Avowed:5939:/
+16133.9 "Hot And Cold" sync / 1[56]:[^:]*:Trinity Avowed:5BB0:/
+16141.0 "Elemental Brand" sync / 1[56]:[^:]*:Trinity Avowed:5BB2:/
+16147.2 "Quick March" sync / 1[56]:[^:]*:Trinity Avowed:5BB3:/
+16154.0 "Shimmering Shot" sync / 1[56]:[^:]*:Trinity Avowed:597F:/
+16171.3 "Elemental Arrow" sync / 1[56]:[^:]*:Spark Arrow:593A:/
+16176.7 "--sync--" sync / 1[56]:[^:]*:Trinity Avowed:5983:/ window 10,10 # some variance here
+16183.8 "Glory Of Bozja" sync / 1[56]:[^:]*:Trinity Avowed:594F:/
+16192.3 "Wrath Of Bozja" sync / 1[56]:[^:]*:Trinity Avowed:594E:/
+16203.0 "Allegiant Arsenal" sync / 1[56]:[^:]*:Trinity Avowed:5987:/
 
 # -> Sword v2?
-16200.0 "--sync--" sync / 14:Trinity Avowed:5985:/ window 70,10 jump 15900
-16208.2 "Infernal Slash?" #sync / 1[56]:Trinity Avowed:594A:/
+16200.0 "--sync--" sync / 14:[^:]*:Trinity Avowed:5985:/ window 70,10 jump 15900
+16208.2 "Infernal Slash?" #sync / 1[56]:[^:]*:Trinity Avowed:594A:/
 # -> Staff v2?
-16200.0 "--sync--" sync / 14:Trinity Avowed:5987:/ window 70,10 jump 16300
-16208.2 "Fury Of Bozja?" #sync / 1[56]:Trinity Avowed:594C:/
+16200.0 "--sync--" sync / 14:[^:]*:Trinity Avowed:5987:/ window 70,10 jump 16300
+16208.2 "Fury Of Bozja?" #sync / 1[56]:[^:]*:Trinity Avowed:594C:/
 
 
 
 # Staff v2
-16300.0 "--sync--" sync / 14:Trinity Avowed:5987:/
-16303.0 "Allegiant Arsenal" sync / 1[56]:Trinity Avowed:5987:/
-16308.2 "Fury Of Bozja" sync / 1[56]:Trinity Avowed:594C:/
-16314.3 "Hot And Cold" sync / 1[56]:Trinity Avowed:597B:/
-16321.4 "Elemental Brand" sync / 1[56]:Trinity Avowed:597D:/
-16327.6 "Freedom Of Bozja" sync / 1[56]:Trinity Avowed:597C:/
-16333.7 "Unseen Eye" sync / 1[56]:Trinity Avowed:5980:/
-16335.0 "Elemental Impact" sync / 1[56]:Tempestuous Orb:4F52:/
-16344.8 "Elemental Blast" sync / 1[56]:Tempestuous Orb:592E:/
-16345.0 "Gleaming Arrow" sync / 1[56]:Avowed Avatar:594D:/
-16350.5 "--sync--" sync / 1[56]:Trinity Avowed:5984:/
-16357.6 "Glory Of Bozja" sync / 1[56]:Trinity Avowed:594F:/
+16300.0 "--sync--" sync / 14:[^:]*:Trinity Avowed:5987:/
+16303.0 "Allegiant Arsenal" sync / 1[56]:[^:]*:Trinity Avowed:5987:/
+16308.2 "Fury Of Bozja" sync / 1[56]:[^:]*:Trinity Avowed:594C:/
+16314.3 "Hot And Cold" sync / 1[56]:[^:]*:Trinity Avowed:597B:/
+16321.4 "Elemental Brand" sync / 1[56]:[^:]*:Trinity Avowed:597D:/
+16327.6 "Freedom Of Bozja" sync / 1[56]:[^:]*:Trinity Avowed:597C:/
+16333.7 "Unseen Eye" sync / 1[56]:[^:]*:Trinity Avowed:5980:/
+16335.0 "Elemental Impact" sync / 1[56]:[^:]*:Tempestuous Orb:4F52:/
+16344.8 "Elemental Blast" sync / 1[56]:[^:]*:Tempestuous Orb:592E:/
+16345.0 "Gleaming Arrow" sync / 1[56]:[^:]*:Avowed Avatar:594D:/
+16350.5 "--sync--" sync / 1[56]:[^:]*:Trinity Avowed:5984:/
+16357.6 "Glory Of Bozja" sync / 1[56]:[^:]*:Trinity Avowed:594F:/
 16369.4 "Allegiant Arsenal"
 
 # -> Sword v2?
-16366.4 "--sync--" sync / 14:Trinity Avowed:5985:/ window 70,10 jump 15900
-16374.6 "Infernal Slash?" #sync / 1[56]:Trinity Avowed:594A:/
+16366.4 "--sync--" sync / 14:[^:]*:Trinity Avowed:5985:/ window 70,10 jump 15900
+16374.6 "Infernal Slash?" #sync / 1[56]:[^:]*:Trinity Avowed:594A:/
 # -> Bow v2?
-16366.4 "--sync--" sync / 14:Trinity Avowed:5986:/ window 70,10 jump 16100
-16374.6 "Flashvane?" #sync / 1[56]:Trinity Avowed:594B:/
+16366.4 "--sync--" sync / 14:[^:]*:Trinity Avowed:5986:/ window 70,10 jump 16100
+16374.6 "Flashvane?" #sync / 1[56]:[^:]*:Trinity Avowed:594B:/
 
 
 # Enrage
 # This happens ~10 seconds after when the allegiant arsenal would have cast.
 # We could...technically...break up phase 2 into the same blocks like phase 1, but no.
 # TODO: Alternatively we could add this in as "Enrage?" to each block?
-16500.0 "--sync--" sync / 14:Trinity Avowed:5954:/ window 2500,0
-16512.0 "Glory Of Bozja Enrage" sync / 1[56]:Trinity Avowed:5954:/
+16500.0 "--sync--" sync / 14:[^:]*:Trinity Avowed:5954:/ window 2500,0
+16512.0 "Glory Of Bozja Enrage" sync / 1[56]:[^:]*:Trinity Avowed:5954:/
 16512.0 "--untargetable--"
 
 
@@ -1254,17 +1254,17 @@ hideall "--sync--"
 
 # Phase 1
 18008.3 "--sync--" sync /:57D7:Stygimoloch Lord:/ window 15,15
-18015.3 "Foe Splitter" sync / 1[56]:Stygimoloch Lord:57D7:/
-18023.4 "Vicious Swipe" sync / 1[56]:Stygimoloch Lord:5552:/
-18028.5 "--sync--" sync / 1[56]:Stygimoloch Lord:57CF:/
-18028.5 "Whack 1" #sync / 1[56]:Stygimoloch Lord:57D1:/
-18030.5 "Whack 2" #sync / 1[56]:Stygimoloch Lord:57D1:/
-18032.5 "Whack 3" #sync / 1[56]:Stygimoloch Lord:57D1:/
-18042.8 "1111-Tonze Swing" sync / 1[56]:Stygimoloch Lord:57D8:/
-18056.0 "Rapid Bolts" sync / 1[56]:Stygimoloch Lord:57CD:/ duration 12.8
-18063.1 "Rapid Bolts" sync / 1[56]:Stygimoloch Lord:57CD:/ duration 12.8
-18070.4 "Rush" sync / 1[56]:Stygimoloch Lord:57D9:/
-18074.7 "Rush" sync / 1[56]:Stygimoloch Lord:57D9:/
+18015.3 "Foe Splitter" sync / 1[56]:[^:]*:Stygimoloch Lord:57D7:/
+18023.4 "Vicious Swipe" sync / 1[56]:[^:]*:Stygimoloch Lord:5552:/
+18028.5 "--sync--" sync / 1[56]:[^:]*:Stygimoloch Lord:57CF:/
+18028.5 "Whack 1" #sync / 1[56]:[^:]*:Stygimoloch Lord:57D1:/
+18030.5 "Whack 2" #sync / 1[56]:[^:]*:Stygimoloch Lord:57D1:/
+18032.5 "Whack 3" #sync / 1[56]:[^:]*:Stygimoloch Lord:57D1:/
+18042.8 "1111-Tonze Swing" sync / 1[56]:[^:]*:Stygimoloch Lord:57D8:/
+18056.0 "Rapid Bolts" sync / 1[56]:[^:]*:Stygimoloch Lord:57CD:/ duration 12.8
+18063.1 "Rapid Bolts" sync / 1[56]:[^:]*:Stygimoloch Lord:57CD:/ duration 12.8
+18070.4 "Rush" sync / 1[56]:[^:]*:Stygimoloch Lord:57D9:/
+18074.7 "Rush" sync / 1[56]:[^:]*:Stygimoloch Lord:57D9:/
 # ??? does this loop? is there a natural push here?
 
 # Phase 2: Adds (70%)
@@ -1272,98 +1272,98 @@ hideall "--sync--"
 # in a loop, but the adds are on an 18s timer which doesn't line up with the
 # loop.  Therefore, we'll just unroll this loop a few times and drop the
 # Mana Flame after a while.  Most logs don't even see the 2nd Fateful Words.
-18200.0 "--untargetable--" sync / 1[56]:Stygimoloch Lord:57DA:/
-18201.5 "--sync--" sync / 14:Stygimoloch Lord:57C3:/ window 210,0
-18204.5 "Memory of the Labyrinth" sync / 1[56]:Stygimoloch Lord:57C3:/
+18200.0 "--untargetable--" sync / 1[56]:[^:]*:Stygimoloch Lord:57DA:/
+18201.5 "--sync--" sync / 14:[^:]*:Stygimoloch Lord:57C3:/ window 210,0
+18204.5 "Memory of the Labyrinth" sync / 1[56]:[^:]*:Stygimoloch Lord:57C3:/
 18205.1 "--adds--"
-18215.4 "Mana Flame" sync / 1[56]:Ball Of Fire:57DE:/
-18223.2 "Entrapment" sync / 1[56]:Stygimoloch Monk:57DB:/
-18232.8 "Labyrinthine Fate" sync / 1[56]:Stygimoloch Lord:57C7:/
-18233.4 "Mana Flame" sync / 1[56]:Ball Of Fire:57DE:/
+18215.4 "Mana Flame" sync / 1[56]:[^:]*:Ball Of Fire:57DE:/
+18223.2 "Entrapment" sync / 1[56]:[^:]*:Stygimoloch Monk:57DB:/
+18232.8 "Labyrinthine Fate" sync / 1[56]:[^:]*:Stygimoloch Lord:57C7:/
+18233.4 "Mana Flame" sync / 1[56]:[^:]*:Ball Of Fire:57DE:/
 
-18241.1 "Fateful Words" sync / 1[56]:Stygimoloch Lord:57C9:/
-18247.2 "--sync--" sync / 1[56]:Stygimoloch Lord:57C4:/
-18251.3 "Mana Flame" sync / 1[56]:Ball Of Fire:57DE:/
-18251.7 "Devastating Bolt" sync / 1[56]:Stygimoloch Lord:57C5:/
-18257.5 "Rending Bolt" sync / 1[56]:Stygimoloch Lord:57CB:/
-18269.3 "Mana Flame" sync / 1[56]:Ball Of Fire:57DE:/
-18271.7 "Labyrinthine Fate" sync / 1[56]:Stygimoloch Lord:57C7:/
-18277.9 "--sync--" sync / 1[56]:Stygimoloch Lord:57C4:/
-18282.4 "Devastating Bolt" sync / 1[56]:Stygimoloch Lord:57C5:/
-18287.2 "Mana Flame" sync / 1[56]:Ball Of Fire:57DE:/
-18288.3 "Rending Bolt" sync / 1[56]:Stygimoloch Lord:57CB:/
-18296.4 "Mana Flame" sync / 1[56]:Ball Of Fire:57DE:/
+18241.1 "Fateful Words" sync / 1[56]:[^:]*:Stygimoloch Lord:57C9:/
+18247.2 "--sync--" sync / 1[56]:[^:]*:Stygimoloch Lord:57C4:/
+18251.3 "Mana Flame" sync / 1[56]:[^:]*:Ball Of Fire:57DE:/
+18251.7 "Devastating Bolt" sync / 1[56]:[^:]*:Stygimoloch Lord:57C5:/
+18257.5 "Rending Bolt" sync / 1[56]:[^:]*:Stygimoloch Lord:57CB:/
+18269.3 "Mana Flame" sync / 1[56]:[^:]*:Ball Of Fire:57DE:/
+18271.7 "Labyrinthine Fate" sync / 1[56]:[^:]*:Stygimoloch Lord:57C7:/
+18277.9 "--sync--" sync / 1[56]:[^:]*:Stygimoloch Lord:57C4:/
+18282.4 "Devastating Bolt" sync / 1[56]:[^:]*:Stygimoloch Lord:57C5:/
+18287.2 "Mana Flame" sync / 1[56]:[^:]*:Ball Of Fire:57DE:/
+18288.3 "Rending Bolt" sync / 1[56]:[^:]*:Stygimoloch Lord:57CB:/
+18296.4 "Mana Flame" sync / 1[56]:[^:]*:Ball Of Fire:57DE:/
 
-18296.6 "Fateful Words" sync / 1[56]:Stygimoloch Lord:57C9:/
-18304.7 "Rending Bolt" sync / 1[56]:Stygimoloch Lord:57CB:/
-18305.2 "Mana Flame" sync / 1[56]:Ball Of Fire:57DE:/
-18309.1 "--sync--" sync / 1[56]:Stygimoloch Lord:57C4:/
-18313.6 "Devastating Bolt" sync / 1[56]:Stygimoloch Lord:57C5:/
-18323.3 "Mana Flame" sync / 1[56]:Ball Of Fire:57DE:/
-18327.4 "Labyrinthine Fate" sync / 1[56]:Stygimoloch Lord:57C7:/
-18333.7 "--sync--" sync / 1[56]:Stygimoloch Lord:57C4:/
-18338.2 "Devastating Bolt" sync / 1[56]:Stygimoloch Lord:57C5:/
-18341.3 "Mana Flame" sync / 1[56]:Ball Of Fire:57DE:/
-18344.0 "Rending Bolt" sync / 1[56]:Stygimoloch Lord:57CB:/
+18296.6 "Fateful Words" sync / 1[56]:[^:]*:Stygimoloch Lord:57C9:/
+18304.7 "Rending Bolt" sync / 1[56]:[^:]*:Stygimoloch Lord:57CB:/
+18305.2 "Mana Flame" sync / 1[56]:[^:]*:Ball Of Fire:57DE:/
+18309.1 "--sync--" sync / 1[56]:[^:]*:Stygimoloch Lord:57C4:/
+18313.6 "Devastating Bolt" sync / 1[56]:[^:]*:Stygimoloch Lord:57C5:/
+18323.3 "Mana Flame" sync / 1[56]:[^:]*:Ball Of Fire:57DE:/
+18327.4 "Labyrinthine Fate" sync / 1[56]:[^:]*:Stygimoloch Lord:57C7:/
+18333.7 "--sync--" sync / 1[56]:[^:]*:Stygimoloch Lord:57C4:/
+18338.2 "Devastating Bolt" sync / 1[56]:[^:]*:Stygimoloch Lord:57C5:/
+18341.3 "Mana Flame" sync / 1[56]:[^:]*:Ball Of Fire:57DE:/
+18344.0 "Rending Bolt" sync / 1[56]:[^:]*:Stygimoloch Lord:57CB:/
 
-18352.3 "Fateful Words" sync / 1[56]:Stygimoloch Lord:57C9:/
-18359.3 "Mana Flame" sync / 1[56]:Ball Of Fire:57DE:/
-18360.5 "Rending Bolt" sync / 1[56]:Stygimoloch Lord:57CB:/
-18364.8 "--sync--" sync / 1[56]:Stygimoloch Lord:57C4:/
-18369.3 "Devastating Bolt" sync / 1[56]:Stygimoloch Lord:57C5:/
-18377.4 "Mana Flame" sync / 1[56]:Ball Of Fire:57DE:/
-18383.1 "Labyrinthine Fate" sync / 1[56]:Stygimoloch Lord:57C7:/
-18389.4 "--sync--" sync / 1[56]:Stygimoloch Lord:57C4:/
-18393.9 "Devastating Bolt" sync / 1[56]:Stygimoloch Lord:57C5:/
-18395.4 "Mana Flame" sync / 1[56]:Ball Of Fire:57DE:/
-18399.7 "Rending Bolt" sync / 1[56]:Stygimoloch Lord:57CB:/
+18352.3 "Fateful Words" sync / 1[56]:[^:]*:Stygimoloch Lord:57C9:/
+18359.3 "Mana Flame" sync / 1[56]:[^:]*:Ball Of Fire:57DE:/
+18360.5 "Rending Bolt" sync / 1[56]:[^:]*:Stygimoloch Lord:57CB:/
+18364.8 "--sync--" sync / 1[56]:[^:]*:Stygimoloch Lord:57C4:/
+18369.3 "Devastating Bolt" sync / 1[56]:[^:]*:Stygimoloch Lord:57C5:/
+18377.4 "Mana Flame" sync / 1[56]:[^:]*:Ball Of Fire:57DE:/
+18383.1 "Labyrinthine Fate" sync / 1[56]:[^:]*:Stygimoloch Lord:57C7:/
+18389.4 "--sync--" sync / 1[56]:[^:]*:Stygimoloch Lord:57C4:/
+18393.9 "Devastating Bolt" sync / 1[56]:[^:]*:Stygimoloch Lord:57C5:/
+18395.4 "Mana Flame" sync / 1[56]:[^:]*:Ball Of Fire:57DE:/
+18399.7 "Rending Bolt" sync / 1[56]:[^:]*:Stygimoloch Lord:57CB:/
 
 # Drop Mana Flame callouts in order to make a loop.
-18408.0 "Fateful Words" sync / 1[56]:Stygimoloch Lord:57C9:/
-18416.2 "Rending Bolt" sync / 1[56]:Stygimoloch Lord:57CB:/
-18420.5 "--sync--" sync / 1[56]:Stygimoloch Lord:57C4:/
-18425.0 "Devastating Bolt" sync / 1[56]:Stygimoloch Lord:57C5:/
-18438.8 "Labyrinthine Fate" sync / 1[56]:Stygimoloch Lord:57C7:/
-18445.1 "--sync--" sync / 1[56]:Stygimoloch Lord:57C4:/
-18449.6 "Devastating Bolt" sync / 1[56]:Stygimoloch Lord:57C5:/
-18455.4 "Rending Bolt" sync / 1[56]:Stygimoloch Lord:57CB:/
+18408.0 "Fateful Words" sync / 1[56]:[^:]*:Stygimoloch Lord:57C9:/
+18416.2 "Rending Bolt" sync / 1[56]:[^:]*:Stygimoloch Lord:57CB:/
+18420.5 "--sync--" sync / 1[56]:[^:]*:Stygimoloch Lord:57C4:/
+18425.0 "Devastating Bolt" sync / 1[56]:[^:]*:Stygimoloch Lord:57C5:/
+18438.8 "Labyrinthine Fate" sync / 1[56]:[^:]*:Stygimoloch Lord:57C7:/
+18445.1 "--sync--" sync / 1[56]:[^:]*:Stygimoloch Lord:57C4:/
+18449.6 "Devastating Bolt" sync / 1[56]:[^:]*:Stygimoloch Lord:57C5:/
+18455.4 "Rending Bolt" sync / 1[56]:[^:]*:Stygimoloch Lord:57CB:/
 
-18463.7 "Fateful Words" sync / 1[56]:Stygimoloch Lord:57C9:/ window 50,50 jump 18408
-18471.9 "Rending Bolt" #sync / 1[56]:Stygimoloch Lord:57CB:/
-18476.2 "--sync--" #sync / 1[56]:Stygimoloch Lord:57C4:/
-18480.7 "Devastating Bolt" #sync / 1[56]:Stygimoloch Lord:57C5:/
-18494.5 "Labyrinthine Fate" #sync / 1[56]:Stygimoloch Lord:57C7:/
-18500.8 "--sync--" #sync / 1[56]:Stygimoloch Lord:57C4:/
-18505.3 "Devastating Bolt" #sync / 1[56]:Stygimoloch Lord:57C5:/
-18511.1 "Rending Bolt" #sync / 1[56]:Stygimoloch Lord:57CB:/
+18463.7 "Fateful Words" sync / 1[56]:[^:]*:Stygimoloch Lord:57C9:/ window 50,50 jump 18408
+18471.9 "Rending Bolt" #sync / 1[56]:[^:]*:Stygimoloch Lord:57CB:/
+18476.2 "--sync--" #sync / 1[56]:[^:]*:Stygimoloch Lord:57C4:/
+18480.7 "Devastating Bolt" #sync / 1[56]:[^:]*:Stygimoloch Lord:57C5:/
+18494.5 "Labyrinthine Fate" #sync / 1[56]:[^:]*:Stygimoloch Lord:57C7:/
+18500.8 "--sync--" #sync / 1[56]:[^:]*:Stygimoloch Lord:57C4:/
+18505.3 "Devastating Bolt" #sync / 1[56]:[^:]*:Stygimoloch Lord:57C5:/
+18511.1 "Rending Bolt" #sync / 1[56]:[^:]*:Stygimoloch Lord:57CB:/
 
 
 # Phase 3: Victory Lap (once adds are dead)
 19000.0 "--targetable--" sync / 22:........:Stygimoloch Lord:........:Stygimoloch Lord/ window 800,0
-19008.2 "--sync--" sync / 14:Stygimoloch Lord:57D2:/ window 1010,0
-19013.2 "Thunderous Discharge" sync / 1[56]:Stygimoloch Lord:57D2:/
-19028.4 "Rapid Bolts 1" sync / 1[56]:Stygimoloch Lord:57CD:/ duration 12.8
-19040.5 "1111-Tonze Swing" sync / 1[56]:Stygimoloch Lord:57D8:/
-19051.6 "Rapid Bolts 2" sync / 1[56]:Stygimoloch Lord:57CD:/ duration 12.8
-19058.7 "Rapid Bolts 3" sync / 1[56]:Stygimoloch Lord:57CD:/ duration 12.8
-19065.8 "Crushing Hoof" sync / 1[56]:Stygimoloch Lord:57D5:/
-19072.0 "--sync--" sync / 1[56]:Stygimoloch Lord:57CF:/
-19072.0 "Whack 1" #sync / 1[56]:Stygimoloch Lord:57D1:/
-19074.0 "Whack 2" #sync / 1[56]:Stygimoloch Lord:57D1:/
-19076.0 "Whack 3" #sync / 1[56]:Stygimoloch Lord:57D1:/
-19092.5 "Foe Splitter" sync / 1[56]:Stygimoloch Lord:57D7:/
-19097.7 "Vicious Swipe" sync / 1[56]:Stygimoloch Lord:5552:/
-19102.8 "--sync--" sync / 1[56]:Stygimoloch Lord:57CF:/
-19102.8 "Whack 1" #sync / 1[56]:Stygimoloch Lord:57D1:/
-19104.8 "Whack 2" #sync / 1[56]:Stygimoloch Lord:57D1:/
-19106.8 "Whack 3" #sync / 1[56]:Stygimoloch Lord:57D1:/
+19008.2 "--sync--" sync / 14:[^:]*:Stygimoloch Lord:57D2:/ window 1010,0
+19013.2 "Thunderous Discharge" sync / 1[56]:[^:]*:Stygimoloch Lord:57D2:/
+19028.4 "Rapid Bolts 1" sync / 1[56]:[^:]*:Stygimoloch Lord:57CD:/ duration 12.8
+19040.5 "1111-Tonze Swing" sync / 1[56]:[^:]*:Stygimoloch Lord:57D8:/
+19051.6 "Rapid Bolts 2" sync / 1[56]:[^:]*:Stygimoloch Lord:57CD:/ duration 12.8
+19058.7 "Rapid Bolts 3" sync / 1[56]:[^:]*:Stygimoloch Lord:57CD:/ duration 12.8
+19065.8 "Crushing Hoof" sync / 1[56]:[^:]*:Stygimoloch Lord:57D5:/
+19072.0 "--sync--" sync / 1[56]:[^:]*:Stygimoloch Lord:57CF:/
+19072.0 "Whack 1" #sync / 1[56]:[^:]*:Stygimoloch Lord:57D1:/
+19074.0 "Whack 2" #sync / 1[56]:[^:]*:Stygimoloch Lord:57D1:/
+19076.0 "Whack 3" #sync / 1[56]:[^:]*:Stygimoloch Lord:57D1:/
+19092.5 "Foe Splitter" sync / 1[56]:[^:]*:Stygimoloch Lord:57D7:/
+19097.7 "Vicious Swipe" sync / 1[56]:[^:]*:Stygimoloch Lord:5552:/
+19102.8 "--sync--" sync / 1[56]:[^:]*:Stygimoloch Lord:57CF:/
+19102.8 "Whack 1" #sync / 1[56]:[^:]*:Stygimoloch Lord:57D1:/
+19104.8 "Whack 2" #sync / 1[56]:[^:]*:Stygimoloch Lord:57D1:/
+19106.8 "Whack 3" #sync / 1[56]:[^:]*:Stygimoloch Lord:57D1:/
 
 # loop block
-19121.3 "Thunderous Discharge" sync / 1[56]:Stygimoloch Lord:57D2:/ window 80,80 jump 19013.2
-19136.5 "Rapid Bolts 1" #sync / 1[56]:Stygimoloch Lord:57CD:/ duration 12.8
-19148.6 "1111-Tonze Swing" #sync / 1[56]:Stygimoloch Lord:57D8:/
-19159.7 "Rapid Bolts 2" #sync / 1[56]:Stygimoloch Lord:57CD:/ duration 12.8
-19166.8 "Rapid Bolts 3" #sync / 1[56]:Stygimoloch Lord:57CD:/ duration 12.8
+19121.3 "Thunderous Discharge" sync / 1[56]:[^:]*:Stygimoloch Lord:57D2:/ window 80,80 jump 19013.2
+19136.5 "Rapid Bolts 1" #sync / 1[56]:[^:]*:Stygimoloch Lord:57CD:/ duration 12.8
+19148.6 "1111-Tonze Swing" #sync / 1[56]:[^:]*:Stygimoloch Lord:57D8:/
+19159.7 "Rapid Bolts 2" #sync / 1[56]:[^:]*:Stygimoloch Lord:57CD:/ duration 12.8
+19166.8 "Rapid Bolts 3" #sync / 1[56]:[^:]*:Stygimoloch Lord:57CD:/ duration 12.8
 
 
 ### The Queen
@@ -1374,133 +1374,133 @@ hideall "--sync--"
 # TODO: what is 55A8?
 20000.0 "--sync--" sync / 00:0839::Queensheart will be sealed off/ window 20000,0
 20000.0 "--Reset--" sync / 00:0839::.*is no longer sealed/ window 0,2000 jump 0
-20010.3 "--sync--" sync / 14:The Queen:59F9:/ window 20,20
-20015.3 "Empyrean Iniquity" sync / 1[56]:The Queen:59F9:/
-20025.5 "--sync--" sync / 1[56]:The Queen:5BCB:/
-20033.9 "Queen's Will" sync / 1[56]:The Queen:59E6:/
-20040.0 "Northswain's Glow" sync / 1[56]:The Queen:59F3:/
-20048.2 "Beck And Call To Arms" sync / 1[56]:The Queen:5B99:/
-20050.8 "Northswain's Glow" sync / 1[56]:The Queen:59F4:/
-20052.5 "The Means" sync / 1[56]:Queen's Warrior:59E8:/
-20052.5 "The Ends" sync / 1[56]:Queen's Knight:59E7:/
-20056.3 "Beck And Call To Arms" sync / 1[56]:The Queen:5B9A:/
-20060.6 "The Means" sync / 1[56]:Queen's Gunner:59EA:/
-20060.6 "The Ends" sync / 1[56]:Queen's Soldier:59E9:/
-20076.5 "Cleansing Slash 1" sync / 1[56]:The Queen:59F5:/
-20079.7 "Cleansing Slash 2" sync / 1[56]:The Queen:5BB8:/
-20088.8 "Empyrean Iniquity" sync / 1[56]:The Queen:59F9:/
-20097.0 "--sync--" sync / 1[56]:The Queen:5BCB:/
-20105.2 "Queen's Edict" sync / 1[56]:The Queen:59EC:/
+20010.3 "--sync--" sync / 14:[^:]*:The Queen:59F9:/ window 20,20
+20015.3 "Empyrean Iniquity" sync / 1[56]:[^:]*:The Queen:59F9:/
+20025.5 "--sync--" sync / 1[56]:[^:]*:The Queen:5BCB:/
+20033.9 "Queen's Will" sync / 1[56]:[^:]*:The Queen:59E6:/
+20040.0 "Northswain's Glow" sync / 1[56]:[^:]*:The Queen:59F3:/
+20048.2 "Beck And Call To Arms" sync / 1[56]:[^:]*:The Queen:5B99:/
+20050.8 "Northswain's Glow" sync / 1[56]:[^:]*:The Queen:59F4:/
+20052.5 "The Means" sync / 1[56]:[^:]*:Queen's Warrior:59E8:/
+20052.5 "The Ends" sync / 1[56]:[^:]*:Queen's Knight:59E7:/
+20056.3 "Beck And Call To Arms" sync / 1[56]:[^:]*:The Queen:5B9A:/
+20060.6 "The Means" sync / 1[56]:[^:]*:Queen's Gunner:59EA:/
+20060.6 "The Ends" sync / 1[56]:[^:]*:Queen's Soldier:59E9:/
+20076.5 "Cleansing Slash 1" sync / 1[56]:[^:]*:The Queen:59F5:/
+20079.7 "Cleansing Slash 2" sync / 1[56]:[^:]*:The Queen:5BB8:/
+20088.8 "Empyrean Iniquity" sync / 1[56]:[^:]*:The Queen:59F9:/
+20097.0 "--sync--" sync / 1[56]:[^:]*:The Queen:5BCB:/
+20105.2 "Queen's Edict" sync / 1[56]:[^:]*:The Queen:59EC:/
 20108.3 "--untargetable--"
-20124.7 "Beck And Call To Arms" sync / 1[56]:The Queen:5B9B:/
-20129.0 "The Means" sync / 1[56]:Queen's Warrior:59E8:/
-20129.0 "The Ends" sync / 1[56]:Queen's Knight:59E7:/
-20136.5 "Beck And Call To Arms" sync / 1[56]:The Queen:5B9C:/
-20140.8 "The Means" sync / 1[56]:Queen's Gunner:59EA:/
-20140.8 "The Ends" sync / 1[56]:Queen's Soldier:59E9:/
+20124.7 "Beck And Call To Arms" sync / 1[56]:[^:]*:The Queen:5B9B:/
+20129.0 "The Means" sync / 1[56]:[^:]*:Queen's Warrior:59E8:/
+20129.0 "The Ends" sync / 1[56]:[^:]*:Queen's Knight:59E7:/
+20136.5 "Beck And Call To Arms" sync / 1[56]:[^:]*:The Queen:5B9C:/
+20140.8 "The Means" sync / 1[56]:[^:]*:Queen's Gunner:59EA:/
+20140.8 "The Ends" sync / 1[56]:[^:]*:Queen's Soldier:59E9:/
 
-20141.0 "Queen's Justice" sync / 1[56]:The Queen:59EB:/
-20156.0 "Queen's Justice" sync / 1[56]:The Queen:59EB:/
-20157.6 "Gunnhildr's Blades" sync / 1[56]:The Queen:5B21:/
+20141.0 "Queen's Justice" sync / 1[56]:[^:]*:The Queen:59EB:/
+20156.0 "Queen's Justice" sync / 1[56]:[^:]*:The Queen:59EB:/
+20157.6 "Gunnhildr's Blades" sync / 1[56]:[^:]*:The Queen:5B21:/
 20160.7 "--targetable--"
-20167.9 "--sync--" sync / 1[56]:The Queen:5BCB:/
-20171.3 "--sync--" sync / 1[56]:The Queen:55A8:/
-20178.4 "Gods Save The Queen" sync / 1[56]:The Queen:59FA:/
-20194.7 "--sync--" sync / 1[56]:The Queen:5BCB:/
-20198.1 "--sync--" sync / 1[56]:The Queen:55A8:/
-20203.1 "Unlucky Lot x5" duration 8 #sync / 1[56]:Ball Lightning:55B6:/
-20198.1 "--sync--" sync / 1[56]:The Queen:55A8:/
-20210.0 "Maelstrom's Bolt" sync / 1[56]:The Queen:59EF:/
+20167.9 "--sync--" sync / 1[56]:[^:]*:The Queen:5BCB:/
+20171.3 "--sync--" sync / 1[56]:[^:]*:The Queen:55A8:/
+20178.4 "Gods Save The Queen" sync / 1[56]:[^:]*:The Queen:59FA:/
+20194.7 "--sync--" sync / 1[56]:[^:]*:The Queen:5BCB:/
+20198.1 "--sync--" sync / 1[56]:[^:]*:The Queen:55A8:/
+20203.1 "Unlucky Lot x5" duration 8 #sync / 1[56]:[^:]*:Ball Lightning:55B6:/
+20198.1 "--sync--" sync / 1[56]:[^:]*:The Queen:55A8:/
+20210.0 "Maelstrom's Bolt" sync / 1[56]:[^:]*:The Queen:59EF:/
 
-20224.2 "Relentless Play 1" sync / 1[56]:The Queen:59FC:/ window 20,20
+20224.2 "Relentless Play 1" sync / 1[56]:[^:]*:The Queen:59FC:/ window 20,20
 20227.3 "--tethers--"
-20231.3 "Reversal Of Forces" sync / 1[56]:Queen's Warrior:5A0E:/
-20231.3 "Automatic Turret" sync / 1[56]:Queen's Gunner:5A2B:/
-20235.3 "Northswain's Glow" sync / 1[56]:The Queen:59F3:/
-20237.4 "Reading" sync / 1[56]:Queen's Gunner:5A2C:/
-20246.0 "Northswain's Glow" sync / 1[56]:The Queen:59F4:/
-20246.3 "Winds Of Weight" sync / 1[56]:Queen's Warrior:5A0F:/
-20246.3 "Winds Of Fate" sync / 1[56]:Queen's Warrior:5A11:/
-20246.3 "Weight Of Fortune" sync / 1[56]:Queen's Warrior:5A10:/
-20247.5 "Queen's Shot" sync / 1[56]:Queen's Gunner:5A2D:/
-20251.0 "Turret's Tour" sync / 1[56]:Automatic Turret:5A2F:/
-20260.4 "Cleansing Slash 1" sync / 1[56]:The Queen:59F5:/
-20263.6 "Cleansing Slash 2" sync / 1[56]:The Queen:5BB8:/
+20231.3 "Reversal Of Forces" sync / 1[56]:[^:]*:Queen's Warrior:5A0E:/
+20231.3 "Automatic Turret" sync / 1[56]:[^:]*:Queen's Gunner:5A2B:/
+20235.3 "Northswain's Glow" sync / 1[56]:[^:]*:The Queen:59F3:/
+20237.4 "Reading" sync / 1[56]:[^:]*:Queen's Gunner:5A2C:/
+20246.0 "Northswain's Glow" sync / 1[56]:[^:]*:The Queen:59F4:/
+20246.3 "Winds Of Weight" sync / 1[56]:[^:]*:Queen's Warrior:5A0F:/
+20246.3 "Winds Of Fate" sync / 1[56]:[^:]*:Queen's Warrior:5A11:/
+20246.3 "Weight Of Fortune" sync / 1[56]:[^:]*:Queen's Warrior:5A10:/
+20247.5 "Queen's Shot" sync / 1[56]:[^:]*:Queen's Gunner:5A2D:/
+20251.0 "Turret's Tour" sync / 1[56]:[^:]*:Automatic Turret:5A2F:/
+20260.4 "Cleansing Slash 1" sync / 1[56]:[^:]*:The Queen:59F5:/
+20263.6 "Cleansing Slash 2" sync / 1[56]:[^:]*:The Queen:5BB8:/
 
-20276.8 "Relentless Play 2" sync / 1[56]:The Queen:59FC:/ window 20,20
-20282.9 "Sword Omen/Shield Omen" sync / 1[56]:Queen's Knight:59F[DE]:/
+20276.8 "Relentless Play 2" sync / 1[56]:[^:]*:The Queen:59FC:/ window 20,20
+20282.9 "Sword Omen/Shield Omen" sync / 1[56]:[^:]*:Queen's Knight:59F[DE]:/
 20287.9 "--untargetable--"
-20292.5 "Double Gambit" sync / 1[56]:Queen's Soldier:5A1B:/
-20296.3 "Optimal Offensive" sync / 1[56]:Queen's Knight:5A0[23]:/
-20298.2 "Judgment Blade" sync / 1[56]:The Queen:59F[12]:/
-20298.9 "Unlucky Lot" sync / 1[56]:Aetherial Sphere:5A06:/
-20300.7 "Secrets Revealed" sync / 1[56]:Queen's Soldier:5B8B:/
-20300.8 "--sync--" sync / 1[56]:Soldier Avatar:5B8C:/
-20309.9 "Judgment Blade" sync / 1[56]:The Queen:59F[12]:/
-20312.6 "Pawn Off" sync / 1[56]:Soldier Avatar:5A1D:/
+20292.5 "Double Gambit" sync / 1[56]:[^:]*:Queen's Soldier:5A1B:/
+20296.3 "Optimal Offensive" sync / 1[56]:[^:]*:Queen's Knight:5A0[23]:/
+20298.2 "Judgment Blade" sync / 1[56]:[^:]*:The Queen:59F[12]:/
+20298.9 "Unlucky Lot" sync / 1[56]:[^:]*:Aetherial Sphere:5A06:/
+20300.7 "Secrets Revealed" sync / 1[56]:[^:]*:Queen's Soldier:5B8B:/
+20300.8 "--sync--" sync / 1[56]:[^:]*:Soldier Avatar:5B8C:/
+20309.9 "Judgment Blade" sync / 1[56]:[^:]*:The Queen:59F[12]:/
+20312.6 "Pawn Off" sync / 1[56]:[^:]*:Soldier Avatar:5A1D:/
 
 20314.6 "--targetable--"
-20324.7 "Empyrean Iniquity" sync / 1[56]:The Queen:59F9:/
-20332.9 "--sync--" sync / 1[56]:The Queen:5BCB:/
-20341.3 "Queen's Edict" sync / 1[56]:The Queen:59EC:/
+20324.7 "Empyrean Iniquity" sync / 1[56]:[^:]*:The Queen:59F9:/
+20332.9 "--sync--" sync / 1[56]:[^:]*:The Queen:5BCB:/
+20341.3 "Queen's Edict" sync / 1[56]:[^:]*:The Queen:59EC:/
 20344.4 "--untargetable--"
-20360.8 "Beck And Call To Arms" sync / 1[56]:The Queen:5B9B:/
-20365.1 "The Means" sync / 1[56]:Queen's Warrior:59E8:/
-20365.1 "The Ends" sync / 1[56]:Queen's Knight:59E7:/
-20372.6 "Beck And Call To Arms" sync / 1[56]:The Queen:5B9C:/
-20376.9 "The Means" sync / 1[56]:Queen's Gunner:59EA:/
-20376.9 "The Ends" sync / 1[56]:Queen's Soldier:59E9:/
-20377.1 "Queen's Justice" sync / 1[56]:The Queen:59EB:/
-20392.1 "Queen's Justice" sync / 1[56]:The Queen:59EB:/
-20393.8 "Gunnhildr's Blades" sync / 1[56]:The Queen:5B21:/
+20360.8 "Beck And Call To Arms" sync / 1[56]:[^:]*:The Queen:5B9B:/
+20365.1 "The Means" sync / 1[56]:[^:]*:Queen's Warrior:59E8:/
+20365.1 "The Ends" sync / 1[56]:[^:]*:Queen's Knight:59E7:/
+20372.6 "Beck And Call To Arms" sync / 1[56]:[^:]*:The Queen:5B9C:/
+20376.9 "The Means" sync / 1[56]:[^:]*:Queen's Gunner:59EA:/
+20376.9 "The Ends" sync / 1[56]:[^:]*:Queen's Soldier:59E9:/
+20377.1 "Queen's Justice" sync / 1[56]:[^:]*:The Queen:59EB:/
+20392.1 "Queen's Justice" sync / 1[56]:[^:]*:The Queen:59EB:/
+20393.8 "Gunnhildr's Blades" sync / 1[56]:[^:]*:The Queen:5B21:/
 20396.9 "--targetable--"
-20404.1 "Cleansing Slash 1" sync / 1[56]:The Queen:59F5:/
-20407.3 "Cleansing Slash 2" sync / 1[56]:The Queen:5BB8:/
+20404.1 "Cleansing Slash 1" sync / 1[56]:[^:]*:The Queen:59F5:/
+20407.3 "Cleansing Slash 2" sync / 1[56]:[^:]*:The Queen:5BB8:/
 
-20422.5 "Relentless Play 3" sync / 1[56]:The Queen:59FC:/ window 20,20
-20428.6 "Sword Omen/Shield Omen" sync / 1[56]:Queen's Knight:59F[DE]:/
-20437.9 "Automatic Turret" sync / 1[56]:Queen's Gunner:5A26:/
-20440.0 "Optimal Play" sync / 1[56]:Queen's Knight:(5A00|59FF):/
-20446.0 "Turret's Tour" sync / 1[56]:Queen's Gunner:5A27:/
-20446.6 "--sync--" sync / 1[56]:The Queen:5BCB:/
-20446.6 "Turret's Tour" #sync / 1[56]:Automatic Turret:5A29:/
-20447.6 "Turret's Tour" #sync / 1[56]:Automatic Turret:5A29:/
-20449.9 "--sync--" sync / 1[56]:The Queen:55A8:/
-20454.9 "Unlucky Lot x5" duration 8 #sync / 1[56]:Ball Lightning:55B6:/
-20461.8 "Maelstrom's Bolt" sync / 1[56]:The Queen:59EF:/
-20474.9 "Empyrean Iniquity" sync / 1[56]:The Queen:59F9:/
+20422.5 "Relentless Play 3" sync / 1[56]:[^:]*:The Queen:59FC:/ window 20,20
+20428.6 "Sword Omen/Shield Omen" sync / 1[56]:[^:]*:Queen's Knight:59F[DE]:/
+20437.9 "Automatic Turret" sync / 1[56]:[^:]*:Queen's Gunner:5A26:/
+20440.0 "Optimal Play" sync / 1[56]:[^:]*:Queen's Knight:(5A00|59FF):/
+20446.0 "Turret's Tour" sync / 1[56]:[^:]*:Queen's Gunner:5A27:/
+20446.6 "--sync--" sync / 1[56]:[^:]*:The Queen:5BCB:/
+20446.6 "Turret's Tour" #sync / 1[56]:[^:]*:Automatic Turret:5A29:/
+20447.6 "Turret's Tour" #sync / 1[56]:[^:]*:Automatic Turret:5A29:/
+20449.9 "--sync--" sync / 1[56]:[^:]*:The Queen:55A8:/
+20454.9 "Unlucky Lot x5" duration 8 #sync / 1[56]:[^:]*:Ball Lightning:55B6:/
+20461.8 "Maelstrom's Bolt" sync / 1[56]:[^:]*:The Queen:59EF:/
+20474.9 "Empyrean Iniquity" sync / 1[56]:[^:]*:The Queen:59F9:/
 
-20488.1 "Relentless Play 4" sync / 1[56]:The Queen:59FC:/ window 20,20
-20494.2 "Bombslinger" sync / 1[56]:Queen's Warrior:5B3F:/
+20488.1 "Relentless Play 4" sync / 1[56]:[^:]*:The Queen:59FC:/ window 20,20
+20494.2 "Bombslinger" sync / 1[56]:[^:]*:Queen's Warrior:5B3F:/
 20497.3 "--tethers--"
-20501.3 "Reversal Of Forces" sync / 1[56]:Queen's Warrior:5A0E:/
-20503.2 "Heaven's Wrath" sync / 1[56]:The Queen:59F6:/
-20509.0 "--knockback--" sync / 1[56]:The Queen:59F8:/
+20501.3 "Reversal Of Forces" sync / 1[56]:[^:]*:Queen's Warrior:5A0E:/
+20503.2 "Heaven's Wrath" sync / 1[56]:[^:]*:The Queen:59F6:/
+20509.0 "--knockback--" sync / 1[56]:[^:]*:The Queen:59F8:/
 20511.3 "--untargetable--"
-20512.2 "Icy Portent/Fiery Portent" sync / 1[56]:Queen's Soldier:5A2[12]:/
-20515.5 "Above Board" sync / 1[56]:Queen's Warrior:5A0B:/
-20515.5 "--sync--" sync / 1[56]:Queen's Warrior:5B8E:/
+20512.2 "Icy Portent/Fiery Portent" sync / 1[56]:[^:]*:Queen's Soldier:5A2[12]:/
+20515.5 "Above Board" sync / 1[56]:[^:]*:Queen's Warrior:5A0B:/
+20515.5 "--sync--" sync / 1[56]:[^:]*:Queen's Warrior:5B8E:/
 20516.5 "--stunned--" # 3 or 7 second stun
 20518.5 "Lots Cast" sync /(:Aetherial Burst:5B89:|:Aetherial Bolt:5A0D:)/
-20521.5 "Lots Cast" #sync / 1[56]:Aetherial Bolt:5B88:/
-20522.7 "Lots Cast" #sync / 1[56]:Aetherial Bolt:5BB6:/
+20521.5 "Lots Cast" #sync / 1[56]:[^:]*:Aetherial Bolt:5B88:/
+20522.7 "Lots Cast" #sync / 1[56]:[^:]*:Aetherial Bolt:5BB6:/
 20523.5 "--unstunned--"
 20525.6 "--targetable--"
 
-20530.7 "Relentless Play 5" sync / 1[56]:The Queen:59FC:/
-20538.8 "Blood And Bone" sync / 1[56]:Queen's Knight:5A08:/
-20538.8 "Blood And Bone" sync / 1[56]:Queen's Warrior:5A16:/
-20541.8 "Queen's Shot" sync / 1[56]:Queen's Gunner:5A35:/
-20541.8 "Blood And Bone" sync / 1[56]:Queen's Soldier:5A23:/
-20546.9 "Blood And Bone" sync / 1[56]:Queen's Knight:5A08:/
-20546.9 "Blood And Bone" sync / 1[56]:Queen's Warrior:5A16:/
-20549.9 "Queen's Shot" sync / 1[56]:Queen's Gunner:5A35:/
-20549.9 "Blood And Bone" sync / 1[56]:Queen's Soldier:5A23:/
-20552.7 "Empyrean Iniquity" sync / 1[56]:The Queen:59F9:/
-20558.9 "Blood And Bone" sync / 1[56]:Queen's Knight:5A08:/
-20561.9 "Blood And Bone" sync / 1[56]:Queen's Warrior:5A16:/
-20565.0 "Blood And Bone" sync / 1[56]:Queen's Soldier:5A23:/
-20567.9 "Queen's Shot" sync / 1[56]:Queen's Gunner:5A35:/
-20574.6 "--sync--" sync / 1[56]:The Queen:55A8:/
-20586.7 "Gods Save The Queen Enrage" sync / 1[56]:The Queen:5B5A:/
+20530.7 "Relentless Play 5" sync / 1[56]:[^:]*:The Queen:59FC:/
+20538.8 "Blood And Bone" sync / 1[56]:[^:]*:Queen's Knight:5A08:/
+20538.8 "Blood And Bone" sync / 1[56]:[^:]*:Queen's Warrior:5A16:/
+20541.8 "Queen's Shot" sync / 1[56]:[^:]*:Queen's Gunner:5A35:/
+20541.8 "Blood And Bone" sync / 1[56]:[^:]*:Queen's Soldier:5A23:/
+20546.9 "Blood And Bone" sync / 1[56]:[^:]*:Queen's Knight:5A08:/
+20546.9 "Blood And Bone" sync / 1[56]:[^:]*:Queen's Warrior:5A16:/
+20549.9 "Queen's Shot" sync / 1[56]:[^:]*:Queen's Gunner:5A35:/
+20549.9 "Blood And Bone" sync / 1[56]:[^:]*:Queen's Soldier:5A23:/
+20552.7 "Empyrean Iniquity" sync / 1[56]:[^:]*:The Queen:59F9:/
+20558.9 "Blood And Bone" sync / 1[56]:[^:]*:Queen's Knight:5A08:/
+20561.9 "Blood And Bone" sync / 1[56]:[^:]*:Queen's Warrior:5A16:/
+20565.0 "Blood And Bone" sync / 1[56]:[^:]*:Queen's Soldier:5A23:/
+20567.9 "Queen's Shot" sync / 1[56]:[^:]*:Queen's Gunner:5A35:/
+20574.6 "--sync--" sync / 1[56]:[^:]*:The Queen:55A8:/
+20586.7 "Gods Save The Queen Enrage" sync / 1[56]:[^:]*:The Queen:5B5A:/
 20586.7 "--untargetable--"

--- a/ui/raidboss/data/05-shb/eureka/zadnor.txt
+++ b/ui/raidboss/data/05-shb/eureka/zadnor.txt
@@ -70,47 +70,47 @@ hideall "--sync--"
 # -p 5E7C:21016 5E7E:21300
 # -ii 61BE 5E7D 5E75 5E88 5E8A 5E79 5E7B
 #21000.0 "--sync--" sync / 00:0839::The loading dock will be sealed off/ window 100000,0
-21016.0 "Pyrokinesis" sync / 1[56]:Sartauvoir The Inferno:5E7C:/ window 100000,0
-21028.2 "--sync--" sync / 1[56]:Sartauvoir The Inferno:5E6C:/
-21034.3 "Time Eruption 1" sync / 1[56]:Sartauvoir The Inferno:5E6E:/
-21036.3 "Time Eruption 2" sync / 1[56]:Sartauvoir The Inferno:5E6F:/
-21045.4 "Phenex" sync / 1[56]:Sartauvoir The Inferno:5E72:/
-21053.6 "Thermal Gust" sync / 1[56]:Sartauvoir The Inferno:5E74:/
-21057.6 "Flamedive" sync / 1[56]:Huma:5E73:/
+21016.0 "Pyrokinesis" sync / 1[56]:[^:]*:Sartauvoir The Inferno:5E7C:/ window 100000,0
+21028.2 "--sync--" sync / 1[56]:[^:]*:Sartauvoir The Inferno:5E6C:/
+21034.3 "Time Eruption 1" sync / 1[56]:[^:]*:Sartauvoir The Inferno:5E6E:/
+21036.3 "Time Eruption 2" sync / 1[56]:[^:]*:Sartauvoir The Inferno:5E6F:/
+21045.4 "Phenex" sync / 1[56]:[^:]*:Sartauvoir The Inferno:5E72:/
+21053.6 "Thermal Gust" sync / 1[56]:[^:]*:Sartauvoir The Inferno:5E74:/
+21057.6 "Flamedive" sync / 1[56]:[^:]*:Huma:5E73:/
 # This can push.
-21059.8 "--sync--" sync / 14:Sartauvoir The Inferno:5E6D:/ window 70,10
-21066.8 "--sync--" sync / 1[56]:Sartauvoir The Inferno:5E6D:/
-21072.9 "Reverse Time Eruption 1" sync / 1[56]:Sartauvoir The Inferno:5E71:/
-21074.9 "Reverse Time Eruption 2" sync / 1[56]:Sartauvoir The Inferno:5E70:/
+21059.8 "--sync--" sync / 14:[^:]*:Sartauvoir The Inferno:5E6D:/ window 70,10
+21066.8 "--sync--" sync / 1[56]:[^:]*:Sartauvoir The Inferno:5E6D:/
+21072.9 "Reverse Time Eruption 1" sync / 1[56]:[^:]*:Sartauvoir The Inferno:5E71:/
+21074.9 "Reverse Time Eruption 2" sync / 1[56]:[^:]*:Sartauvoir The Inferno:5E70:/
 # This too?
-21078.0 "--sync--" sync / 14:Sartauvoir The Inferno:5E7C:/ window 80,10
-21083.0 "Pyrokinesis" sync / 1[56]:Sartauvoir The Inferno:5E7C:/
-21091.2 "Hyperpyroplexy" sync / 1[56]:Sartauvoir The Inferno:5E76:/
-21101.4 "Pyroplexy" sync / 1[56]:Sartauvoir The Inferno:5E77:/
-21106.7 "Grand Crossflame" sync / 1[56]:Sartauvoir The Inferno:5E7A:/
+21078.0 "--sync--" sync / 14:[^:]*:Sartauvoir The Inferno:5E7C:/ window 80,10
+21083.0 "Pyrokinesis" sync / 1[56]:[^:]*:Sartauvoir The Inferno:5E7C:/
+21091.2 "Hyperpyroplexy" sync / 1[56]:[^:]*:Sartauvoir The Inferno:5E76:/
+21101.4 "Pyroplexy" sync / 1[56]:[^:]*:Sartauvoir The Inferno:5E77:/
+21106.7 "Grand Crossflame" sync / 1[56]:[^:]*:Sartauvoir The Inferno:5E7A:/
 # ???
 
 # transformation (hp% push)
-21300.0 "--sync--" sync / 1[56]:Sartauvoir The Inferno:5E7E:/ window 300,0
-21306.1 "Burn" sync / 1[56]:Sartauvoir The Inferno:5E7F:/
-21311.1 "Burn" sync / 1[56]:Sartauvoir The Inferno:5E7F:/
-21316.1 "Immolate" sync / 1[56]:Sartauvoir The Inferno:5E80:/
-21319.1 "--sync--" sync / 1[56]:Sartauvoir The Inferno:5E81:/
-21334.6 "Burning Blade" sync / 1[56]:Sartauvoir The Inferno:5E90:/
-21343.9 "Mannatheihwon Flame" sync / 1[56]:Sartauvoir The Inferno:5E87:/
-21356.8 "Ignis Est" sync / 1[56]:Ignis Est:5E89:/
-21366.2 "Left Brand/Right Brand" sync / 1[56]:Sartauvoir The Inferno:5E8[BC]:/
-21374.5 "Double Cast" sync / 1[56]:Sartauvoir The Inferno:5E8D:/
-21382.6 "Pyrodoxy" sync / 1[56]:Sartauvoir The Inferno:5E8E:/
-21382.6 "Pyrocrisis" sync / 1[56]:Sartauvoir The Inferno:5E8F:/
-21389.9 "Left Brand/Right Brand" sync / 1[56]:Sartauvoir The Inferno:5E8[BC]:/
-21398.3 "Phenex" sync / 1[56]:Sartauvoir The Inferno:5E85:/
-21408.6 "Time Eruption/Reverse Time Eruption" sync / 1[56]:Sartauvoir The Inferno:5E8[34]:/
-21411.6 "Flamedive" sync / 1[56]:Huma:5E73:/
-21415.9 "Time Eruption 1" sync / 1[56]:Sartauvoir The Inferno:(5E6E|5E71):/
-21417.9 "Time Eruption 2" sync / 1[56]:Sartauvoir The Inferno:(5E6F|5E70):/
-21425.9 "Pyrokinesis" sync / 1[56]:Sartauvoir The Inferno:5E82:/
-21437.3 "Hyperpyroplexy" sync / 1[56]:Sartauvoir The Inferno:5E86:/
+21300.0 "--sync--" sync / 1[56]:[^:]*:Sartauvoir The Inferno:5E7E:/ window 300,0
+21306.1 "Burn" sync / 1[56]:[^:]*:Sartauvoir The Inferno:5E7F:/
+21311.1 "Burn" sync / 1[56]:[^:]*:Sartauvoir The Inferno:5E7F:/
+21316.1 "Immolate" sync / 1[56]:[^:]*:Sartauvoir The Inferno:5E80:/
+21319.1 "--sync--" sync / 1[56]:[^:]*:Sartauvoir The Inferno:5E81:/
+21334.6 "Burning Blade" sync / 1[56]:[^:]*:Sartauvoir The Inferno:5E90:/
+21343.9 "Mannatheihwon Flame" sync / 1[56]:[^:]*:Sartauvoir The Inferno:5E87:/
+21356.8 "Ignis Est" sync / 1[56]:[^:]*:Ignis Est:5E89:/
+21366.2 "Left Brand/Right Brand" sync / 1[56]:[^:]*:Sartauvoir The Inferno:5E8[BC]:/
+21374.5 "Double Cast" sync / 1[56]:[^:]*:Sartauvoir The Inferno:5E8D:/
+21382.6 "Pyrodoxy" sync / 1[56]:[^:]*:Sartauvoir The Inferno:5E8E:/
+21382.6 "Pyrocrisis" sync / 1[56]:[^:]*:Sartauvoir The Inferno:5E8F:/
+21389.9 "Left Brand/Right Brand" sync / 1[56]:[^:]*:Sartauvoir The Inferno:5E8[BC]:/
+21398.3 "Phenex" sync / 1[56]:[^:]*:Sartauvoir The Inferno:5E85:/
+21408.6 "Time Eruption/Reverse Time Eruption" sync / 1[56]:[^:]*:Sartauvoir The Inferno:5E8[34]:/
+21411.6 "Flamedive" sync / 1[56]:[^:]*:Huma:5E73:/
+21415.9 "Time Eruption 1" sync / 1[56]:[^:]*:Sartauvoir The Inferno:(5E6E|5E71):/
+21417.9 "Time Eruption 2" sync / 1[56]:[^:]*:Sartauvoir The Inferno:(5E6F|5E70):/
+21425.9 "Pyrokinesis" sync / 1[56]:[^:]*:Sartauvoir The Inferno:5E82:/
+21437.3 "Hyperpyroplexy" sync / 1[56]:[^:]*:Sartauvoir The Inferno:5E86:/
 # ???
 
 
@@ -122,59 +122,59 @@ hideall "--sync--"
 #22000.0 "--sync--" sync / 00:0839::The flagship landing will be sealed off/ window 100000,0
 
 # Blackburn
-22011.0 "--sync--" sync / 14:4Th Legion Blackburn:5F12:/ window 100000,0
-22016.0 "Suppressive Magitek Rays" sync / 1[56]:4Th Legion Blackburn:5F12:/
-22031.7 "Anti-Personnel Missile" sync / 1[56]:4Th Legion Blackburn:5F0D:/
-22033.8 "Ballistic Impact 1" #sync / 1[56]:4Th Legion Blackburn:5F0E:/
-22036.8 "Ballistic Impact 2" #sync / 1[56]:4Th Legion Blackburn:5F0E:/
-22039.8 "Ballistic Impact 3" #sync / 1[56]:4Th Legion Blackburn:5F0E:/
-22047.9 "Read Orders: Field Support" sync / 1[56]:4Th Legion Blackburn:5F0C:/
-22054.6 "Terminus Est" #sync / 1[56]:4Th Legion Infantry:5F03:/
-22057.6 "Analysis" sync / 1[56]:4Th Legion Blackburn:5F0F:/ window 10,10
-22064.7 "Terminus Est" #sync / 1[56]:Terminus Est:5F07:/
-22073.2 "Suppressive Magitek Rays" sync / 1[56]:4Th Legion Blackburn:5F12:/
-22083.4 "Surface Missile" sync / 1[56]:4Th Legion Blackburn:5F10:/
-22089.5 "Surface Missile" sync / 1[56]:4Th Legion Blackburn:5F11:/
+22011.0 "--sync--" sync / 14:[^:]*:4Th Legion Blackburn:5F12:/ window 100000,0
+22016.0 "Suppressive Magitek Rays" sync / 1[56]:[^:]*:4Th Legion Blackburn:5F12:/
+22031.7 "Anti-Personnel Missile" sync / 1[56]:[^:]*:4Th Legion Blackburn:5F0D:/
+22033.8 "Ballistic Impact 1" #sync / 1[56]:[^:]*:4Th Legion Blackburn:5F0E:/
+22036.8 "Ballistic Impact 2" #sync / 1[56]:[^:]*:4Th Legion Blackburn:5F0E:/
+22039.8 "Ballistic Impact 3" #sync / 1[56]:[^:]*:4Th Legion Blackburn:5F0E:/
+22047.9 "Read Orders: Field Support" sync / 1[56]:[^:]*:4Th Legion Blackburn:5F0C:/
+22054.6 "Terminus Est" #sync / 1[56]:[^:]*:4Th Legion Infantry:5F03:/
+22057.6 "Analysis" sync / 1[56]:[^:]*:4Th Legion Blackburn:5F0F:/ window 10,10
+22064.7 "Terminus Est" #sync / 1[56]:[^:]*:Terminus Est:5F07:/
+22073.2 "Suppressive Magitek Rays" sync / 1[56]:[^:]*:4Th Legion Blackburn:5F12:/
+22083.4 "Surface Missile" sync / 1[56]:[^:]*:4Th Legion Blackburn:5F10:/
+22089.5 "Surface Missile" sync / 1[56]:[^:]*:4Th Legion Blackburn:5F11:/
 # ???
 
 # Augur
 # this cast starts almost immediately after the Augur apperas
-22300.0 "--sync--" sync / 14:4Th Legion Augur:5F1F:/ window 300,0
-22305.0 "Sanctified Quake III" sync / 1[56]:4Th Legion Augur:5F1F:/
-22313.2 "Void Call" sync / 1[56]:4Th Legion Augur:5F1E:/
-22325.5 "Turbine" sync / 1[56]:Flameborne Zirnitra:5F14:/
-22328.0 "Flaming Cyclone" sync / 1[56]:Stormborne Zirnitra:5F19:/
-22328.6 "74 Degrees" sync / 1[56]:Waveborne Zirnitra:5F17:/
-22332.5 "Pyroplexy" sync / 1[56]:4Th Legion Augur:5F1B:/
-22358.7 "Sanctified Quake III" sync / 1[56]:4Th Legion Augur:5F1F:/
+22300.0 "--sync--" sync / 14:[^:]*:4Th Legion Augur:5F1F:/ window 300,0
+22305.0 "Sanctified Quake III" sync / 1[56]:[^:]*:4Th Legion Augur:5F1F:/
+22313.2 "Void Call" sync / 1[56]:[^:]*:4Th Legion Augur:5F1E:/
+22325.5 "Turbine" sync / 1[56]:[^:]*:Flameborne Zirnitra:5F14:/
+22328.0 "Flaming Cyclone" sync / 1[56]:[^:]*:Stormborne Zirnitra:5F19:/
+22328.6 "74 Degrees" sync / 1[56]:[^:]*:Waveborne Zirnitra:5F17:/
+22332.5 "Pyroplexy" sync / 1[56]:[^:]*:4Th Legion Augur:5F1B:/
+22358.7 "Sanctified Quake III" sync / 1[56]:[^:]*:4Th Legion Augur:5F1F:/
 # ???
 
 # Tamed Alkonost / Tamed Carrion Crow
 22500.0 "--sync--" sync / 03:........:Tamed Carrion Crow:/  window 600,0
-22507.0 "--sync--" sync / 14:Tamed Alkonost:5F26:/ window 600,10
-22512.0 "Stormcall" sync / 1[56]:Tamed Alkonost:5F26:/
-22526.9 "Orb 1" sync / 1[56]:Vortical Orb:5F27:/
-22526.9 "North Wind/South Wind" sync / 1[56]:Tamed Carrion Crow:5F2[12]:/
-22527.0 "--sync--" sync / 1[56]:Tamed Carrion Crow:5F23:/
-22527.6 "--knockback--" sync / 1[56]:Tamed Carrion Crow:60E[EF]:/
-22534.0 "Orb 2" sync / 1[56]:Vortical Orb:5F27:/
-22548.7 "Painful Gust/Pain Storm" sync / 1[56]:Tamed Alkonost:5F2[BC]:/
-22557.8 "Frigid Pulse" sync / 1[56]:Tamed Alkonost:5F2A:/
-22568.2 "North Wind/South Wind" sync / 1[56]:Tamed Carrion Crow:5F2[12]:/
-22568.3 "--sync--" sync / 1[56]:Tamed Carrion Crow:5F23:/
-22568.9 "--knockback--" sync / 1[56]:Tamed Carrion Crow:60E[EF]:/
-22572.9 "Foreshadowing" sync / 1[56]:Tamed Alkonost:5F30:/
-22572.9 "Painful Gust/Pain Storm" sync / 1[56]:Tamed Alkonost's Shadow:5F2[EF]:/
-22572.9 "Frigid Pulse" sync / 1[56]:Tamed Alkonost's Shadow:5F2D:/
+22507.0 "--sync--" sync / 14:[^:]*:Tamed Alkonost:5F26:/ window 600,10
+22512.0 "Stormcall" sync / 1[56]:[^:]*:Tamed Alkonost:5F26:/
+22526.9 "Orb 1" sync / 1[56]:[^:]*:Vortical Orb:5F27:/
+22526.9 "North Wind/South Wind" sync / 1[56]:[^:]*:Tamed Carrion Crow:5F2[12]:/
+22527.0 "--sync--" sync / 1[56]:[^:]*:Tamed Carrion Crow:5F23:/
+22527.6 "--knockback--" sync / 1[56]:[^:]*:Tamed Carrion Crow:60E[EF]:/
+22534.0 "Orb 2" sync / 1[56]:[^:]*:Vortical Orb:5F27:/
+22548.7 "Painful Gust/Pain Storm" sync / 1[56]:[^:]*:Tamed Alkonost:5F2[BC]:/
+22557.8 "Frigid Pulse" sync / 1[56]:[^:]*:Tamed Alkonost:5F2A:/
+22568.2 "North Wind/South Wind" sync / 1[56]:[^:]*:Tamed Carrion Crow:5F2[12]:/
+22568.3 "--sync--" sync / 1[56]:[^:]*:Tamed Carrion Crow:5F23:/
+22568.9 "--knockback--" sync / 1[56]:[^:]*:Tamed Carrion Crow:60E[EF]:/
+22572.9 "Foreshadowing" sync / 1[56]:[^:]*:Tamed Alkonost:5F30:/
+22572.9 "Painful Gust/Pain Storm" sync / 1[56]:[^:]*:Tamed Alkonost's Shadow:5F2[EF]:/
+22572.9 "Frigid Pulse" sync / 1[56]:[^:]*:Tamed Alkonost's Shadow:5F2D:/
 
-22586.1 "Nihility's Song" sync / 1[56]:Tamed Alkonost:5F28:/
-22597.8 "Broadside Barrage" sync / 1[56]:Tamed Carrion Crow:5F25:/
-22605.7 "Painful Gust" sync / 1[56]:Tamed Alkonost:5F2C:/
-22612.8 "Nihility's Song" sync / 1[56]:Tamed Alkonost:5F28:/
-22613.1 "Broadside Barrage" sync / 1[56]:Tamed Carrion Crow:5F25:/
-22613.4 "Nihility's Song" sync / 1[56]:Tamed Alkonost:5F29:/
-22629.0 "Frigid Pulse" sync / 1[56]:Tamed Alkonost:5F2A:/
-22635.5 "Broadside Barrage" sync / 1[56]:Tamed Carrion Crow:5F25:/
+22586.1 "Nihility's Song" sync / 1[56]:[^:]*:Tamed Alkonost:5F28:/
+22597.8 "Broadside Barrage" sync / 1[56]:[^:]*:Tamed Carrion Crow:5F25:/
+22605.7 "Painful Gust" sync / 1[56]:[^:]*:Tamed Alkonost:5F2C:/
+22612.8 "Nihility's Song" sync / 1[56]:[^:]*:Tamed Alkonost:5F28:/
+22613.1 "Broadside Barrage" sync / 1[56]:[^:]*:Tamed Carrion Crow:5F25:/
+22613.4 "Nihility's Song" sync / 1[56]:[^:]*:Tamed Alkonost:5F29:/
+22629.0 "Frigid Pulse" sync / 1[56]:[^:]*:Tamed Alkonost:5F2A:/
+22635.5 "Broadside Barrage" sync / 1[56]:[^:]*:Tamed Carrion Crow:5F25:/
 # ???
 
 
@@ -182,45 +182,45 @@ hideall "--sync--"
 # -p 5C8F:23013.3
 # -ii 5C89 5C90 5C83 5C84 5C85 6179 614E 5C8C 5C87
 23000.0 "--sync--" sync / 00:0839::Magitek Development will be sealed off/ window 100000,0
-23013.3 "Putrified Soul" sync / 1[56]:4Th-Make Cuchulainn:5C8F:/
-23022.4 "Burgeoning Dread" sync / 1[56]:4Th-Make Cuchulainn:5C88:/
-23043.7 "Putrified Soul" sync / 1[56]:4Th-Make Cuchulainn:5C8F:/
-23055.9 "Fleshy Necromass" sync / 1[56]:4Th-Make Cuchulainn:5C82:/ duration 8.7
-23082.7 "Necrotic Billow" sync / 1[56]:4Th-Make Cuchulainn:5C86:/ duration 8.7
-23099.9 "--sync--" sync / 1[56]:4Th-Make Cuchulainn:5C8D:/
-23108.7 "Ambient Pulsation 1" #sync / 1[56]:4Th-Make Cuchulainn:5C8E:/
-23110.2 "Ambient Pulsation 2" #sync / 1[56]:4Th-Make Cuchulainn:5C8E:/
-23111.7 "Ambient Pulsation 3" #sync / 1[56]:4Th-Make Cuchulainn:5C8E:/
+23013.3 "Putrified Soul" sync / 1[56]:[^:]*:4Th-Make Cuchulainn:5C8F:/
+23022.4 "Burgeoning Dread" sync / 1[56]:[^:]*:4Th-Make Cuchulainn:5C88:/
+23043.7 "Putrified Soul" sync / 1[56]:[^:]*:4Th-Make Cuchulainn:5C8F:/
+23055.9 "Fleshy Necromass" sync / 1[56]:[^:]*:4Th-Make Cuchulainn:5C82:/ duration 8.7
+23082.7 "Necrotic Billow" sync / 1[56]:[^:]*:4Th-Make Cuchulainn:5C86:/ duration 8.7
+23099.9 "--sync--" sync / 1[56]:[^:]*:4Th-Make Cuchulainn:5C8D:/
+23108.7 "Ambient Pulsation 1" #sync / 1[56]:[^:]*:4Th-Make Cuchulainn:5C8E:/
+23110.2 "Ambient Pulsation 2" #sync / 1[56]:[^:]*:4Th-Make Cuchulainn:5C8E:/
+23111.7 "Ambient Pulsation 3" #sync / 1[56]:[^:]*:4Th-Make Cuchulainn:5C8E:/
 
-23126.1 "Might Of Malice" sync / 1[56]:4Th-Make Cuchulainn:5C92:/
-23140.2 "Necrotic Billow?" sync / 1[56]:4Th-Make Cuchulainn:5C86:/
-23143.3 "Fleshy Necromass?" sync / 1[56]:4Th-Make Cuchulainn:5C82:/
+23126.1 "Might Of Malice" sync / 1[56]:[^:]*:4Th-Make Cuchulainn:5C92:/
+23140.2 "Necrotic Billow?" sync / 1[56]:[^:]*:4Th-Make Cuchulainn:5C86:/
+23143.3 "Fleshy Necromass?" sync / 1[56]:[^:]*:4Th-Make Cuchulainn:5C82:/
 # this timing can be 8 seconds earlier if it's Billow instead of Necromass.
-23163.2 "--sync--" sync / 14:4Th-Make Cuchulainn:5C88:/ window 20,20
-23168.2 "Burgeoning Dread" sync / 1[56]:4Th-Make Cuchulainn:5C88:/
+23163.2 "--sync--" sync / 14:[^:]*:4Th-Make Cuchulainn:5C88:/ window 20,20
+23168.2 "Burgeoning Dread" sync / 1[56]:[^:]*:4Th-Make Cuchulainn:5C88:/
 
-23179.3 "--sync--" sync / 1[56]:4Th-Make Cuchulainn:5C8D:/
-23188.1 "Ambient Pulsation 1" #sync / 1[56]:4Th-Make Cuchulainn:5C8E:/
-23189.6 "Ambient Pulsation 2" #sync / 1[56]:4Th-Make Cuchulainn:5C8E:/
-23191.1 "Ambient Pulsation 3" #sync / 1[56]:4Th-Make Cuchulainn:5C8E:/
-23195.5 "Might Of Malice" sync / 1[56]:4Th-Make Cuchulainn:5C92:/
-23210.6 "Putrified Soul" sync / 1[56]:4Th-Make Cuchulainn:5C8F:/
+23179.3 "--sync--" sync / 1[56]:[^:]*:4Th-Make Cuchulainn:5C8D:/
+23188.1 "Ambient Pulsation 1" #sync / 1[56]:[^:]*:4Th-Make Cuchulainn:5C8E:/
+23189.6 "Ambient Pulsation 2" #sync / 1[56]:[^:]*:4Th-Make Cuchulainn:5C8E:/
+23191.1 "Ambient Pulsation 3" #sync / 1[56]:[^:]*:4Th-Make Cuchulainn:5C8E:/
+23195.5 "Might Of Malice" sync / 1[56]:[^:]*:4Th-Make Cuchulainn:5C92:/
+23210.6 "Putrified Soul" sync / 1[56]:[^:]*:4Th-Make Cuchulainn:5C8F:/
 
-23217.7 "Ghastly Aura" sync / 1[56]:4Th-Make Cuchulainn:614D:/
-23226.8 "Necrotic Billow?" sync / 1[56]:4Th-Make Cuchulainn:5C86:/
-23230.9 "Fleshy Necromass?" sync / 1[56]:4Th-Make Cuchulainn:5C82:/
+23217.7 "Ghastly Aura" sync / 1[56]:[^:]*:4Th-Make Cuchulainn:614D:/
+23226.8 "Necrotic Billow?" sync / 1[56]:[^:]*:4Th-Make Cuchulainn:5C86:/
+23230.9 "Fleshy Necromass?" sync / 1[56]:[^:]*:4Th-Make Cuchulainn:5C82:/
 # this timing can be 8 seconds earlier if it's Billow instead of Necromass.
-23249.1 "--sync--" sync / 14:4Th-Make Cuchulainn:5C8B:/ window 20,5
-23254.1 "Fell Flow 1" sync / 1[56]:4Th-Make Cuchulainn:5C8B:/
-23261.4 "Fell Flow 2" sync / 1[56]:4Th-Make Cuchulainn:5C8B:/
-23275.6 "Burgeoning Dread" sync / 1[56]:4Th-Make Cuchulainn:5C88:/
+23249.1 "--sync--" sync / 14:[^:]*:4Th-Make Cuchulainn:5C8B:/ window 20,5
+23254.1 "Fell Flow 1" sync / 1[56]:[^:]*:4Th-Make Cuchulainn:5C8B:/
+23261.4 "Fell Flow 2" sync / 1[56]:[^:]*:4Th-Make Cuchulainn:5C8B:/
+23275.6 "Burgeoning Dread" sync / 1[56]:[^:]*:4Th-Make Cuchulainn:5C88:/
 
 # TODO: is this a loop??? guessing it goes back to the previous burgeoning+ambient
-23286.7 "--sync--" sync / 1[56]:4Th-Make Cuchulainn:5C8D:/ window 30,30 jump 23179.3
-23295.5 "Ambient Pulsation 1" #sync / 1[56]:4Th-Make Cuchulainn:5C8E:/
-23297.0 "Ambient Pulsation 2" #sync / 1[56]:4Th-Make Cuchulainn:5C8E:/
-23298.5 "Ambient Pulsation 3" #sync / 1[56]:4Th-Make Cuchulainn:5C8E:/
-23303.0 "Might Of Malice" sync / 1[56]:4Th-Make Cuchulainn:5C92:/
+23286.7 "--sync--" sync / 1[56]:[^:]*:4Th-Make Cuchulainn:5C8D:/ window 30,30 jump 23179.3
+23295.5 "Ambient Pulsation 1" #sync / 1[56]:[^:]*:4Th-Make Cuchulainn:5C8E:/
+23297.0 "Ambient Pulsation 2" #sync / 1[56]:[^:]*:4Th-Make Cuchulainn:5C8E:/
+23298.5 "Ambient Pulsation 3" #sync / 1[56]:[^:]*:4Th-Make Cuchulainn:5C8E:/
+23303.0 "Might Of Malice" sync / 1[56]:[^:]*:4Th-Make Cuchulainn:5C92:/
 
 
 ### Saunion & Dawon
@@ -228,89 +228,89 @@ hideall "--sync--"
 # -it "Saunion"
 # -ii 5DB6 5DB8 6150 5DC7 60C4 5DCF 5DB3 5DD2 61E4 61E5
 24000.0 "--sync--" sync / 00:0839::The greater hold will be sealed off/ window 100000,0
-24011.7 "Magitek Halo/Magitek Crossray" sync / 1[56]:Saunion:5DB[57]:/
-24022.9 "High-Powered Magitek Ray" sync / 1[56]:Saunion:5DC5:/
-24034.1 "Magitek Crossray/Magitek Halo" sync / 1[56]:Saunion:5DB[57]:/
-24040.3 "--sync--" sync / 1[56]:Saunion:5DD7:/
-24050.5 "Mobile Halo/Mobile Crossray" sync / 1[56]:Saunion:(5DB[9ABCDEF]|5DC0):/
-24063.7 "Missile Command" sync / 1[56]:Saunion:5DC1:/
-24069.9 "Surface Missile" sync / 1[56]:Saunion:5DC4:/
-24069.9 "Anti-Personnel Missile" sync / 1[56]:Saunion:5DC2:/
-24074.9 "Missile Salvo" sync / 1[56]:Saunion:5DC3:/
-24078.9 "--sync--" sync / 1[56]:Saunion:5DD7:/
-24089.0 "Mobile Crossray/Mobile Halo" sync / 1[56]:Saunion:(5DB[9ABCDEF]|5DC0):/
-24099.8 "--sync--" sync / 1[56]:Saunion:5DD7:/
+24011.7 "Magitek Halo/Magitek Crossray" sync / 1[56]:[^:]*:Saunion:5DB[57]:/
+24022.9 "High-Powered Magitek Ray" sync / 1[56]:[^:]*:Saunion:5DC5:/
+24034.1 "Magitek Crossray/Magitek Halo" sync / 1[56]:[^:]*:Saunion:5DB[57]:/
+24040.3 "--sync--" sync / 1[56]:[^:]*:Saunion:5DD7:/
+24050.5 "Mobile Halo/Mobile Crossray" sync / 1[56]:[^:]*:Saunion:(5DB[9ABCDEF]|5DC0):/
+24063.7 "Missile Command" sync / 1[56]:[^:]*:Saunion:5DC1:/
+24069.9 "Surface Missile" sync / 1[56]:[^:]*:Saunion:5DC4:/
+24069.9 "Anti-Personnel Missile" sync / 1[56]:[^:]*:Saunion:5DC2:/
+24074.9 "Missile Salvo" sync / 1[56]:[^:]*:Saunion:5DC3:/
+24078.9 "--sync--" sync / 1[56]:[^:]*:Saunion:5DD7:/
+24089.0 "Mobile Crossray/Mobile Halo" sync / 1[56]:[^:]*:Saunion:(5DB[9ABCDEF]|5DC0):/
+24099.8 "--sync--" sync / 1[56]:[^:]*:Saunion:5DD7:/
 # ?
 
-24300.0 "--sync--" sync / 14:Dawon The Younger:5DC6:/ window 300,0
-24306.0 "Touchdown" sync / 1[56]:Dawon The Younger:5DC6:/
+24300.0 "--sync--" sync / 14:[^:]*:Dawon The Younger:5DC6:/ window 300,0
+24306.0 "Touchdown" sync / 1[56]:[^:]*:Dawon The Younger:5DC6:/
 24323.3 "--targetable--"
-24342.5 "--sync--" sync / 1[56]:Saunion:5DD7:/
-24348.5 "Wildfire Winds" sync / 1[56]:Dawon The Younger:5DCD:/
-24352.5 "Mobile Halo/Mobile Crossray" sync / 1[56]:Saunion:(5DB[9ABCDEF]|5DC0):/
-24361.2 "Raw Heat" sync / 1[56]:Vermilion Flame:5DCE:/
-24362.7 "Missile Command" sync / 1[56]:Saunion:5DC1:/
-24368.9 "Surface Missile" sync / 1[56]:Saunion:5DC4:/
-24368.9 "Anti-Personnel Missile" sync / 1[56]:Saunion:5DC2:/
-24372.1 "Swooping Frenzy" sync / 1[56]:Dawon The Younger:5DD0:/
-24373.9 "Missile Salvo" sync / 1[56]:Saunion:5DC3:/
-24380.2 "Frigid Pulse" sync / 1[56]:Dawon The Younger:607D:/
-24402.5 "--sync--" sync / 1[56]:Saunion:5DD7:/
+24342.5 "--sync--" sync / 1[56]:[^:]*:Saunion:5DD7:/
+24348.5 "Wildfire Winds" sync / 1[56]:[^:]*:Dawon The Younger:5DCD:/
+24352.5 "Mobile Halo/Mobile Crossray" sync / 1[56]:[^:]*:Saunion:(5DB[9ABCDEF]|5DC0):/
+24361.2 "Raw Heat" sync / 1[56]:[^:]*:Vermilion Flame:5DCE:/
+24362.7 "Missile Command" sync / 1[56]:[^:]*:Saunion:5DC1:/
+24368.9 "Surface Missile" sync / 1[56]:[^:]*:Saunion:5DC4:/
+24368.9 "Anti-Personnel Missile" sync / 1[56]:[^:]*:Saunion:5DC2:/
+24372.1 "Swooping Frenzy" sync / 1[56]:[^:]*:Dawon The Younger:5DD0:/
+24373.9 "Missile Salvo" sync / 1[56]:[^:]*:Saunion:5DC3:/
+24380.2 "Frigid Pulse" sync / 1[56]:[^:]*:Dawon The Younger:607D:/
+24402.5 "--sync--" sync / 1[56]:[^:]*:Saunion:5DD7:/
 
 # spiral scourge + obey
-24412.1 "Spiral Scourge" sync / 1[56]:Saunion:5DB2:/ duration 20.5
+24412.1 "Spiral Scourge" sync / 1[56]:[^:]*:Saunion:5DB2:/ duration 20.5
 24412.1 "--untargetable--"
-24413.4 "Obey" sync / 1[56]:Dawon The Younger:5DC9:/
-24415.5 "Swooping Frenzy 1" sync / 1[56]:Dawon The Younger:5DCA:/
-24418.6 "Frigid Pulse/Fire Brand" sync / 1[56]:Dawon The Younger:5DC[BC]:/
-24421.9 "Swooping Frenzy 2" sync / 1[56]:Dawon The Younger:5DCA:/
-24425.0 "Frigid Pulse/Fire Brand" sync / 1[56]:Dawon The Younger:5DC[BC]:/
-24428.4 "Swooping Frenzy 3" sync / 1[56]:Dawon The Younger:5DCA:/
-24431.5 "Frigid Pulse/Fire Brand" sync / 1[56]:Dawon The Younger:5DC[BC]:/
-24432.2 "--sync--" sync / 1[56]:Saunion:5DB4:/
+24413.4 "Obey" sync / 1[56]:[^:]*:Dawon The Younger:5DC9:/
+24415.5 "Swooping Frenzy 1" sync / 1[56]:[^:]*:Dawon The Younger:5DCA:/
+24418.6 "Frigid Pulse/Fire Brand" sync / 1[56]:[^:]*:Dawon The Younger:5DC[BC]:/
+24421.9 "Swooping Frenzy 2" sync / 1[56]:[^:]*:Dawon The Younger:5DCA:/
+24425.0 "Frigid Pulse/Fire Brand" sync / 1[56]:[^:]*:Dawon The Younger:5DC[BC]:/
+24428.4 "Swooping Frenzy 3" sync / 1[56]:[^:]*:Dawon The Younger:5DCA:/
+24431.5 "Frigid Pulse/Fire Brand" sync / 1[56]:[^:]*:Dawon The Younger:5DC[BC]:/
+24432.2 "--sync--" sync / 1[56]:[^:]*:Saunion:5DB4:/
 24432.2 "--targetable--"
-24450.0 "Swooping Frenzy" sync / 1[56]:Dawon The Younger:5DD0:/
-24452.2 "Missile Command" sync / 1[56]:Saunion:5DC1:/
-24458.1 "Pentagust" sync / 1[56]:Dawon The Younger:5DD1:/
-24458.4 "Surface Missile" sync / 1[56]:Saunion:5DC4:/
-24458.4 "Anti-Personnel Missile" sync / 1[56]:Saunion:5DC2:/
-24463.4 "Missile Salvo" sync / 1[56]:Saunion:5DC3:/
-24479.9 "Tooth And Talon" sync / 1[56]:Dawon The Younger:5DD4:/
-24479.9 "High-Powered Magitek Ray" sync / 1[56]:Saunion:5DC5:/
-24500.4 "--sync--" sync / 1[56]:Saunion:5DD7:/
-24501.3 "Wildfire Winds 1" sync / 1[56]:Dawon The Younger:5DCD:/
+24450.0 "Swooping Frenzy" sync / 1[56]:[^:]*:Dawon The Younger:5DD0:/
+24452.2 "Missile Command" sync / 1[56]:[^:]*:Saunion:5DC1:/
+24458.1 "Pentagust" sync / 1[56]:[^:]*:Dawon The Younger:5DD1:/
+24458.4 "Surface Missile" sync / 1[56]:[^:]*:Saunion:5DC4:/
+24458.4 "Anti-Personnel Missile" sync / 1[56]:[^:]*:Saunion:5DC2:/
+24463.4 "Missile Salvo" sync / 1[56]:[^:]*:Saunion:5DC3:/
+24479.9 "Tooth And Talon" sync / 1[56]:[^:]*:Dawon The Younger:5DD4:/
+24479.9 "High-Powered Magitek Ray" sync / 1[56]:[^:]*:Saunion:5DC5:/
+24500.4 "--sync--" sync / 1[56]:[^:]*:Saunion:5DD7:/
+24501.3 "Wildfire Winds 1" sync / 1[56]:[^:]*:Dawon The Younger:5DCD:/
 
 # spiral scourge + wildfire winds
-24510.1 "Spiral Scourge" sync / 1[56]:Saunion:5DB2:/ duration 20.5
+24510.1 "Spiral Scourge" sync / 1[56]:[^:]*:Saunion:5DB2:/ duration 20.5
 24510.1 "--untargetable--"
-24514.1 "Raw Heat 1" sync / 1[56]:Vermilion Flame:5DCE:/
-24516.5 "Wildfire Winds 2" sync / 1[56]:Dawon The Younger:5DCD:/
-24529.3 "Raw Heat 2" sync / 1[56]:Vermilion Flame:5DCE:/
-24530.1 "--sync--" sync / 1[56]:Saunion:5DB4:/
+24514.1 "Raw Heat 1" sync / 1[56]:[^:]*:Vermilion Flame:5DCE:/
+24516.5 "Wildfire Winds 2" sync / 1[56]:[^:]*:Dawon The Younger:5DCD:/
+24529.3 "Raw Heat 2" sync / 1[56]:[^:]*:Vermilion Flame:5DCE:/
+24530.1 "--sync--" sync / 1[56]:[^:]*:Saunion:5DB4:/
 24530.1 "--targetable--"
-24549.9 "--sync--" sync / 1[56]:Saunion:5DD7:/
-24555.8 "Wildfire Winds" sync / 1[56]:Dawon The Younger:5DCD:/
-24559.9 "Mobile Crossray/Mobile Halo" sync / 1[56]:Saunion:(5DB[9ABCDEF]|5DC0):/
-24568.6 "Raw Heat" sync / 1[56]:Vermilion Flame:5DCE:/
-24570.1 "Missile Command" sync / 1[56]:Saunion:5DC1:/
-24576.3 "Surface Missile" sync / 1[56]:Saunion:5DC4:/
-24576.3 "Anti-Personnel Missile" sync / 1[56]:Saunion:5DC2:/
-24579.5 "Swooping Frenzy" sync / 1[56]:Dawon The Younger:5DD0:/
-24581.3 "Missile Salvo" sync / 1[56]:Saunion:5DC3:/
-24587.6 "Frigid Pulse" sync / 1[56]:Dawon The Younger:607D:/
-24609.7 "--sync--" sync / 1[56]:Saunion:5DD7:/
+24549.9 "--sync--" sync / 1[56]:[^:]*:Saunion:5DD7:/
+24555.8 "Wildfire Winds" sync / 1[56]:[^:]*:Dawon The Younger:5DCD:/
+24559.9 "Mobile Crossray/Mobile Halo" sync / 1[56]:[^:]*:Saunion:(5DB[9ABCDEF]|5DC0):/
+24568.6 "Raw Heat" sync / 1[56]:[^:]*:Vermilion Flame:5DCE:/
+24570.1 "Missile Command" sync / 1[56]:[^:]*:Saunion:5DC1:/
+24576.3 "Surface Missile" sync / 1[56]:[^:]*:Saunion:5DC4:/
+24576.3 "Anti-Personnel Missile" sync / 1[56]:[^:]*:Saunion:5DC2:/
+24579.5 "Swooping Frenzy" sync / 1[56]:[^:]*:Dawon The Younger:5DD0:/
+24581.3 "Missile Salvo" sync / 1[56]:[^:]*:Saunion:5DC3:/
+24587.6 "Frigid Pulse" sync / 1[56]:[^:]*:Dawon The Younger:607D:/
+24609.7 "--sync--" sync / 1[56]:[^:]*:Saunion:5DD7:/
 
 # loop
-24619.2 "Spiral Scourge" sync / 1[56]:Saunion:5DB2:/ window 50,50 jump 24412.1
+24619.2 "Spiral Scourge" sync / 1[56]:[^:]*:Saunion:5DB2:/ window 50,50 jump 24412.1
 24619.2 "--untargetable--"
-24620.5 "Obey" #sync / 1[56]:Dawon The Younger:5DC9:/
-24622.6 "Swooping Frenzy 1" #sync / 1[56]:Dawon The Younger:5DCA:/
-24625.7 "Frigid Pulse/Fire Brand" #sync / 1[56]:Dawon The Younger:5DC{BC]}:/
-24629.0 "Swooping Frenzy 2" #sync / 1[56]:Dawon The Younger:5DCA:/
-24632.1 "Frigid Pulse/Fire Brand" #sync / 1[56]:Dawon The Younger:5DC[BC]:/
-24635.5 "Swooping Frenzy 3" #sync / 1[56]:Dawon The Younger:5DCA:/
-24638.6 "Frigid Pulse/Fire Brand" #sync / 1[56]:Dawon The Younger:5DC[BC]:/
-24639.3 "--sync--" #sync / 1[56]:Saunion:5DB4:/
+24620.5 "Obey" #sync / 1[56]:[^:]*:Dawon The Younger:5DC9:/
+24622.6 "Swooping Frenzy 1" #sync / 1[56]:[^:]*:Dawon The Younger:5DCA:/
+24625.7 "Frigid Pulse/Fire Brand" #sync / 1[56]:[^:]*:Dawon The Younger:5DC{BC]}:/
+24629.0 "Swooping Frenzy 2" #sync / 1[56]:[^:]*:Dawon The Younger:5DCA:/
+24632.1 "Frigid Pulse/Fire Brand" #sync / 1[56]:[^:]*:Dawon The Younger:5DC[BC]:/
+24635.5 "Swooping Frenzy 3" #sync / 1[56]:[^:]*:Dawon The Younger:5DCA:/
+24638.6 "Frigid Pulse/Fire Brand" #sync / 1[56]:[^:]*:Dawon The Younger:5DC[BC]:/
+24639.3 "--sync--" #sync / 1[56]:[^:]*:Saunion:5DB4:/
 24639.3 "--targetable--"
 
 # TODO: not enough data for what happens when one of them dies?
@@ -321,105 +321,105 @@ hideall "--sync--"
 # -p 5CC6:25013 5CB7:25805
 # -ii 6143 61A2 5CC7 61C4 5CB2 5CB8 5CC5 6092 6091 6093 5CC3 5CB4 5CB5 5CC1 5CAD 5CA1 5CA2
 25000.0 "--sync--" sync / 00:0839::The fallen ring will be sealed off/ window 100000,0
-25013.0 "Aetheric Explosion" sync / 1[56]:The Diablo Armament:5CC6:/
-25023.4 "Aetherochemical Laser 1" sync / 1[56]:The Diablo Armament:5CA[45]:/
-25027.5 "Aetherochemical Laser 2" sync / 1[56]:The Diablo Armament:5CA[45]:/
-25034.5 "Explosion 1" sync / 1[56]:The Diablo Armament:5CA[67]:/
-25036.6 "Explosion 2" sync / 1[56]:The Diablo Armament:5CA[89]:/
-25046.0 "Advanced Death Ray" sync / 1[56]:The Diablo Armament:5CC4:/
-25057.3 "Aetheric Explosion" sync / 1[56]:The Diablo Armament:5CC6:/
+25013.0 "Aetheric Explosion" sync / 1[56]:[^:]*:The Diablo Armament:5CC6:/
+25023.4 "Aetherochemical Laser 1" sync / 1[56]:[^:]*:The Diablo Armament:5CA[45]:/
+25027.5 "Aetherochemical Laser 2" sync / 1[56]:[^:]*:The Diablo Armament:5CA[45]:/
+25034.5 "Explosion 1" sync / 1[56]:[^:]*:The Diablo Armament:5CA[67]:/
+25036.6 "Explosion 2" sync / 1[56]:[^:]*:The Diablo Armament:5CA[89]:/
+25046.0 "Advanced Death Ray" sync / 1[56]:[^:]*:The Diablo Armament:5CC4:/
+25057.3 "Aetheric Explosion" sync / 1[56]:[^:]*:The Diablo Armament:5CC6:/
 
 # If you are in a cutscene and don't make it down in time, you miss the zone seal.
 # Add one extra "really big" sync a little bit in.
-25068.6 "Diabolic Gate" sync / 1[56]:The Diablo Armament:5C9F:/ window 100000,100
-25091.1 "--sync--" sync / 1[56]:The Diablo Armament:5CA0:/
-25092.7 "Ruinous Pseudomen 1" sync / 1[56]:The Diablo Armament:61A3:/
-25096.7 "Ruinous Pseudomen 2" #sync / 1[56]:The Diablo Armament:614C:/
-25099.7 "Ruinous Pseudomen 3" #sync / 1[56]:The Diablo Armament:614C:/
-25104.0 "Ruinous Pseudomen 4" sync / 1[56]:The Diablo Armament:614F:/
-25111.0 "Ultimate Pseudoterror" sync / 1[56]:The Diablo Armament:5CA3:/
+25068.6 "Diabolic Gate" sync / 1[56]:[^:]*:The Diablo Armament:5C9F:/ window 100000,100
+25091.1 "--sync--" sync / 1[56]:[^:]*:The Diablo Armament:5CA0:/
+25092.7 "Ruinous Pseudomen 1" sync / 1[56]:[^:]*:The Diablo Armament:61A3:/
+25096.7 "Ruinous Pseudomen 2" #sync / 1[56]:[^:]*:The Diablo Armament:614C:/
+25099.7 "Ruinous Pseudomen 3" #sync / 1[56]:[^:]*:The Diablo Armament:614C:/
+25104.0 "Ruinous Pseudomen 4" sync / 1[56]:[^:]*:The Diablo Armament:614F:/
+25111.0 "Ultimate Pseudoterror" sync / 1[56]:[^:]*:The Diablo Armament:5CA3:/
 
-25125.4 "Aetheric Explosion" sync / 1[56]:The Diablo Armament:5CC6:/
-25139.8 "Advanced Death Ray" sync / 1[56]:The Diablo Armament:5CC4:/
-25147.0 "Magitek Bit" sync / 1[56]:The Diablo Armament:5CAC:/
-25161.5 "Assault Cannon" sync / 1[56]:Diabolic Bit:5CAE:/
-25163.4 "Aetheric Explosion" sync / 1[56]:The Diablo Armament:5CC6:/
-25175.7 "--sync--" sync / 1[56]:The Diablo Armament:5CAF:/
-25183.8 "Advanced Death IV" sync / 1[56]:The Diablo Armament:5CB0:/
-25190.8 "Advanced Death IV" sync / 1[56]:The Diablo Armament:5CB0:/
-25196.5 "Light Pseudopillar" sync / 1[56]:The Diablo Armament:5CB1:/ duration 2.5
-25203.6 "Advanced Death Ray" sync / 1[56]:The Diablo Armament:5CC4:/
-25209.9 "Aetherochemical Laser 1" sync / 1[56]:The Diablo Armament:5CA[45]:/
-25214.0 "Aetherochemical Laser 2" sync / 1[56]:The Diablo Armament:5CA[45]:/
-25219.5 "Aetherochemical Laser 3" sync / 1[56]:The Diablo Armament:5CA[45]:/
-25221.0 "Explosion 1" sync / 1[56]:The Diablo Armament:5CA[67]:/
-25223.1 "Explosion 2" sync / 1[56]:The Diablo Armament:5CA[89]:/
-25226.6 "Explosion 3" sync / 1[56]:The Diablo Armament:5CA[AB]:/
-25242.2 "Aetheric Boom" sync / 1[56]:The Diablo Armament:5CB3:/
+25125.4 "Aetheric Explosion" sync / 1[56]:[^:]*:The Diablo Armament:5CC6:/
+25139.8 "Advanced Death Ray" sync / 1[56]:[^:]*:The Diablo Armament:5CC4:/
+25147.0 "Magitek Bit" sync / 1[56]:[^:]*:The Diablo Armament:5CAC:/
+25161.5 "Assault Cannon" sync / 1[56]:[^:]*:Diabolic Bit:5CAE:/
+25163.4 "Aetheric Explosion" sync / 1[56]:[^:]*:The Diablo Armament:5CC6:/
+25175.7 "--sync--" sync / 1[56]:[^:]*:The Diablo Armament:5CAF:/
+25183.8 "Advanced Death IV" sync / 1[56]:[^:]*:The Diablo Armament:5CB0:/
+25190.8 "Advanced Death IV" sync / 1[56]:[^:]*:The Diablo Armament:5CB0:/
+25196.5 "Light Pseudopillar" sync / 1[56]:[^:]*:The Diablo Armament:5CB1:/ duration 2.5
+25203.6 "Advanced Death Ray" sync / 1[56]:[^:]*:The Diablo Armament:5CC4:/
+25209.9 "Aetherochemical Laser 1" sync / 1[56]:[^:]*:The Diablo Armament:5CA[45]:/
+25214.0 "Aetherochemical Laser 2" sync / 1[56]:[^:]*:The Diablo Armament:5CA[45]:/
+25219.5 "Aetherochemical Laser 3" sync / 1[56]:[^:]*:The Diablo Armament:5CA[45]:/
+25221.0 "Explosion 1" sync / 1[56]:[^:]*:The Diablo Armament:5CA[67]:/
+25223.1 "Explosion 2" sync / 1[56]:[^:]*:The Diablo Armament:5CA[89]:/
+25226.6 "Explosion 3" sync / 1[56]:[^:]*:The Diablo Armament:5CA[AB]:/
+25242.2 "Aetheric Boom" sync / 1[56]:[^:]*:The Diablo Armament:5CB3:/
 
-25265.0 "Diabolic Gate" sync / 1[56]:The Diablo Armament:5C9F:/ window 100,100
-25287.5 "--sync--" sync / 1[56]:The Diablo Armament:5CA0:/
-25289.1 "Ruinous Pseudomen 1" sync / 1[56]:The Diablo Armament:61A3:/
-25293.1 "Ruinous Pseudomen 2" #sync / 1[56]:The Diablo Armament:614C:/
-25296.1 "Ruinous Pseudomen 3" #sync / 1[56]:The Diablo Armament:614C:/
-25300.3 "Ruinous Pseudomen 4" sync / 1[56]:The Diablo Armament:614F:/
-25307.4 "Ultimate Pseudoterror" sync / 1[56]:The Diablo Armament:5CA3:/
+25265.0 "Diabolic Gate" sync / 1[56]:[^:]*:The Diablo Armament:5C9F:/ window 100,100
+25287.5 "--sync--" sync / 1[56]:[^:]*:The Diablo Armament:5CA0:/
+25289.1 "Ruinous Pseudomen 1" sync / 1[56]:[^:]*:The Diablo Armament:61A3:/
+25293.1 "Ruinous Pseudomen 2" #sync / 1[56]:[^:]*:The Diablo Armament:614C:/
+25296.1 "Ruinous Pseudomen 3" #sync / 1[56]:[^:]*:The Diablo Armament:614C:/
+25300.3 "Ruinous Pseudomen 4" sync / 1[56]:[^:]*:The Diablo Armament:614F:/
+25307.4 "Ultimate Pseudoterror" sync / 1[56]:[^:]*:The Diablo Armament:5CA3:/
 
-25321.8 "Aetheric Explosion" sync / 1[56]:The Diablo Armament:5CC6:/
-25327.9 "--sync--" sync / 1[56]:The Diablo Armament:5CAF:/
-25336.0 "Advanced Death IV" sync / 1[56]:The Diablo Armament:5CB0:/
-25344.0 "Advanced Death IV" sync / 1[56]:The Diablo Armament:5CB0:/
-25346.6 "Magitek Bit" sync / 1[56]:The Diablo Armament:5CAC:/
-25353.8 "Aetherochemical Laser 1" sync / 1[56]:The Diablo Armament:5CA[45]:/
-25357.9 "Aetherochemical Laser 2" sync / 1[56]:The Diablo Armament:5CA[45]:/
-25361.3 "Assault Cannon" sync / 1[56]:Diabolic Bit:5CAE:/
-25364.8 "Explosion 1" sync / 1[56]:The Diablo Armament:5CA[67]:/
-25366.9 "Explosion 2" sync / 1[56]:The Diablo Armament:5CA[89]:/
-25373.1 "Assault Cannon" sync / 1[56]:Diabolic Bit:5CAE:/
-25380.4 "Deadly Dealing" sync / 1[56]:The Diablo Armament:5CC2:/
-25384.6 "Assault Cannon" sync / 1[56]:Diabolic Bit:5CAE:/
-25397.9 "Aetheric Explosion" sync / 1[56]:The Diablo Armament:5CC6:/
-25404.1 "Light Pseudopillar" sync / 1[56]:The Diablo Armament:5CB1:/ duration 2.5
+25321.8 "Aetheric Explosion" sync / 1[56]:[^:]*:The Diablo Armament:5CC6:/
+25327.9 "--sync--" sync / 1[56]:[^:]*:The Diablo Armament:5CAF:/
+25336.0 "Advanced Death IV" sync / 1[56]:[^:]*:The Diablo Armament:5CB0:/
+25344.0 "Advanced Death IV" sync / 1[56]:[^:]*:The Diablo Armament:5CB0:/
+25346.6 "Magitek Bit" sync / 1[56]:[^:]*:The Diablo Armament:5CAC:/
+25353.8 "Aetherochemical Laser 1" sync / 1[56]:[^:]*:The Diablo Armament:5CA[45]:/
+25357.9 "Aetherochemical Laser 2" sync / 1[56]:[^:]*:The Diablo Armament:5CA[45]:/
+25361.3 "Assault Cannon" sync / 1[56]:[^:]*:Diabolic Bit:5CAE:/
+25364.8 "Explosion 1" sync / 1[56]:[^:]*:The Diablo Armament:5CA[67]:/
+25366.9 "Explosion 2" sync / 1[56]:[^:]*:The Diablo Armament:5CA[89]:/
+25373.1 "Assault Cannon" sync / 1[56]:[^:]*:Diabolic Bit:5CAE:/
+25380.4 "Deadly Dealing" sync / 1[56]:[^:]*:The Diablo Armament:5CC2:/
+25384.6 "Assault Cannon" sync / 1[56]:[^:]*:Diabolic Bit:5CAE:/
+25397.9 "Aetheric Explosion" sync / 1[56]:[^:]*:The Diablo Armament:5CC6:/
+25404.1 "Light Pseudopillar" sync / 1[56]:[^:]*:The Diablo Armament:5CB1:/ duration 2.5
 
-25407.3 "Aetherochemical Laser 1" sync / 1[56]:The Diablo Armament:5CA[45]:/
-25411.4 "Aetherochemical Laser 2" sync / 1[56]:The Diablo Armament:5CA[45]:/
-25416.9 "Aetherochemical Laser 3" sync / 1[56]:The Diablo Armament:5CA[45]:/
-25418.4 "Explosion 1" sync / 1[56]:The Diablo Armament:5CA[67]:/
-25420.5 "Explosion 2" sync / 1[56]:The Diablo Armament:5CA[89]:/
-25424.0 "Explosion 3" sync / 1[56]:The Diablo Armament:5CA[AB]:/
-25426.0 "Advanced Death Ray" sync / 1[56]:The Diablo Armament:5CC4:/
-25438.3 "--sync--" sync / 1[56]:The Diablo Armament:5CBF:/
-25447.4 "Deadly Dealing" sync / 1[56]:The Diablo Armament:5CC2:/
-25449.0 "Advanced Nox" sync / 1[56]:The Diablo Armament:5CC0:/ duration 4.5
-25461.7 "Aetheric Boom" sync / 1[56]:The Diablo Armament:5CB3:/
-25463.8 "Aetherochemical Laser 1" sync / 1[56]:The Diablo Armament:5CA5:/
-25467.9 "Aetherochemical Laser 2" sync / 1[56]:The Diablo Armament:5CA4:/
-25474.9 "Explosion 1" sync / 1[56]:The Diablo Armament:5CA[67]:/
-25477.0 "Explosion 2" sync / 1[56]:The Diablo Armament:5CA[89]:/
+25407.3 "Aetherochemical Laser 1" sync / 1[56]:[^:]*:The Diablo Armament:5CA[45]:/
+25411.4 "Aetherochemical Laser 2" sync / 1[56]:[^:]*:The Diablo Armament:5CA[45]:/
+25416.9 "Aetherochemical Laser 3" sync / 1[56]:[^:]*:The Diablo Armament:5CA[45]:/
+25418.4 "Explosion 1" sync / 1[56]:[^:]*:The Diablo Armament:5CA[67]:/
+25420.5 "Explosion 2" sync / 1[56]:[^:]*:The Diablo Armament:5CA[89]:/
+25424.0 "Explosion 3" sync / 1[56]:[^:]*:The Diablo Armament:5CA[AB]:/
+25426.0 "Advanced Death Ray" sync / 1[56]:[^:]*:The Diablo Armament:5CC4:/
+25438.3 "--sync--" sync / 1[56]:[^:]*:The Diablo Armament:5CBF:/
+25447.4 "Deadly Dealing" sync / 1[56]:[^:]*:The Diablo Armament:5CC2:/
+25449.0 "Advanced Nox" sync / 1[56]:[^:]*:The Diablo Armament:5CC0:/ duration 4.5
+25461.7 "Aetheric Boom" sync / 1[56]:[^:]*:The Diablo Armament:5CB3:/
+25463.8 "Aetherochemical Laser 1" sync / 1[56]:[^:]*:The Diablo Armament:5CA5:/
+25467.9 "Aetherochemical Laser 2" sync / 1[56]:[^:]*:The Diablo Armament:5CA4:/
+25474.9 "Explosion 1" sync / 1[56]:[^:]*:The Diablo Armament:5CA[67]:/
+25477.0 "Explosion 2" sync / 1[56]:[^:]*:The Diablo Armament:5CA[89]:/
 
 # TODO: this is probably a loop?? guessing it goes back to first gate???
-25489.6 "Diabolic Gate" sync / 1[56]:The Diablo Armament:5C9F:/ window 100,100 jump 25068.6
-25512.1 "--sync--" sync / 1[56]:The Diablo Armament:5CA0:/
-25513.7 "Ruinous Pseudomen 1" sync / 1[56]:The Diablo Armament:61A3:/
-25517.7 "Ruinous Pseudomen 2" #sync / 1[56]:The Diablo Armament:614C:/
-25520.7 "Ruinous Pseudomen 3" #sync / 1[56]:The Diablo Armament:614C:/
-25525.0 "Ruinous Pseudomen 4" sync / 1[56]:The Diablo Armament:614F:/
-25532.0 "Ultimate Pseudoterror" sync / 1[56]:The Diablo Armament:5CA3:/
+25489.6 "Diabolic Gate" sync / 1[56]:[^:]*:The Diablo Armament:5C9F:/ window 100,100 jump 25068.6
+25512.1 "--sync--" sync / 1[56]:[^:]*:The Diablo Armament:5CA0:/
+25513.7 "Ruinous Pseudomen 1" sync / 1[56]:[^:]*:The Diablo Armament:61A3:/
+25517.7 "Ruinous Pseudomen 2" #sync / 1[56]:[^:]*:The Diablo Armament:614C:/
+25520.7 "Ruinous Pseudomen 3" #sync / 1[56]:[^:]*:The Diablo Armament:614C:/
+25525.0 "Ruinous Pseudomen 4" sync / 1[56]:[^:]*:The Diablo Armament:614F:/
+25532.0 "Ultimate Pseudoterror" sync / 1[56]:[^:]*:The Diablo Armament:5CA3:/
 
 # final phase (hp%?)
-25800.0 "--sync--" sync / 14:The Diablo Armament:5CB7:/ window 1000,0
-25805.0 "Void Systems Overload" sync / 1[56]:The Diablo Armament:5CB7:/
-25815.1 "Pillar Of Shamash" sync / 1[56]:The Diablo Armament:5CB9:/
-25816.6 "Pillar Of Shamash" sync / 1[56]:The Diablo Armament:5CBA:/
-25818.1 "Pillar Of Shamash" sync / 1[56]:The Diablo Armament:5CBB:/
-25822.2 "Pillar Of Shamash" sync / 1[56]:The Diablo Armament:5CBD:/
-25824.2 "--lasers--" sync / 1[56]:The Diablo Armament:5CBC:/
-25828.2 "--line stack--" sync / 1[56]:The Diablo Armament:5CBE:/
+25800.0 "--sync--" sync / 14:[^:]*:The Diablo Armament:5CB7:/ window 1000,0
+25805.0 "Void Systems Overload" sync / 1[56]:[^:]*:The Diablo Armament:5CB7:/
+25815.1 "Pillar Of Shamash" sync / 1[56]:[^:]*:The Diablo Armament:5CB9:/
+25816.6 "Pillar Of Shamash" sync / 1[56]:[^:]*:The Diablo Armament:5CBA:/
+25818.1 "Pillar Of Shamash" sync / 1[56]:[^:]*:The Diablo Armament:5CBB:/
+25822.2 "Pillar Of Shamash" sync / 1[56]:[^:]*:The Diablo Armament:5CBD:/
+25824.2 "--lasers--" sync / 1[56]:[^:]*:The Diablo Armament:5CBC:/
+25828.2 "--line stack--" sync / 1[56]:[^:]*:The Diablo Armament:5CBE:/
 
-25842.2 "Void Systems Overload" sync / 1[56]:The Diablo Armament:6314:/ window 100,100 jump 25805.0
-25852.3 "Pillar Of Shamash" sync / 1[56]:The Diablo Armament:5CB9:/
-25853.8 "Pillar Of Shamash" sync / 1[56]:The Diablo Armament:5CBA:/
-25855.3 "Pillar Of Shamash" sync / 1[56]:The Diablo Armament:5CBB:/
-25859.4 "Pillar Of Shamash" sync / 1[56]:The Diablo Armament:5CBD:/
-25861.4 "--lasers--" sync / 1[56]:The Diablo Armament:5CBC:/
-25865.4 "--line stack--" sync / 1[56]:The Diablo Armament:5CBE:/
+25842.2 "Void Systems Overload" sync / 1[56]:[^:]*:The Diablo Armament:6314:/ window 100,100 jump 25805.0
+25852.3 "Pillar Of Shamash" sync / 1[56]:[^:]*:The Diablo Armament:5CB9:/
+25853.8 "Pillar Of Shamash" sync / 1[56]:[^:]*:The Diablo Armament:5CBA:/
+25855.3 "Pillar Of Shamash" sync / 1[56]:[^:]*:The Diablo Armament:5CBB:/
+25859.4 "Pillar Of Shamash" sync / 1[56]:[^:]*:The Diablo Armament:5CBD:/
+25861.4 "--lasers--" sync / 1[56]:[^:]*:The Diablo Armament:5CBC:/
+25865.4 "--line stack--" sync / 1[56]:[^:]*:The Diablo Armament:5CBE:/

--- a/ui/raidboss/data/05-shb/raid/e10n.txt
+++ b/ui/raidboss/data/05-shb/raid/e10n.txt
@@ -9,59 +9,59 @@ hideall "--sync--"
 0.0 "--Reset--" sync / 21:........:40000010:/ window 100000 jump 0
 
 0.0 "--sync--" sync /:Engage!/ window 0,1
-2.6 "--sync--" sync / 1[56]:Shadowkeeper:5B09:/ window 2.6,1
-17.0 "Forward Implosion" sync / 1[56]:Shadowkeeper:56B4:/ window 17,5
-30.5 "Forward Shadow Implosion" sync / 1[56]:Shadowkeeper:56B5:/
-41.8 "Deepshadow Nova" sync / 1[56]:Shadowkeeper:56E5:/
-55.0 "Backward Implosion" sync / 1[56]:Shadowkeeper:56B7:/
-68.5 "Backward Shadow Implosion" sync / 1[56]:Shadowkeeper:56B8:/
-74.9 "--center--" sync / 1[56]:Shadowkeeper:5B08:/ window 74.9,10
-80.3 "Spawn Shadow" sync / 1[56]:Shadowkeeper:56D6:/
-82.0 "--sync--" sync / 1[56]:Shadowkeeper:56D7:/
-86.4 "Shadow Warrior" sync / 1[56]:Shadowkeeper:56E2:/
-99.6 "Barbs Of Agony" sync / 1[56]:Shadowkeeper:5743:/
-112.7 "Deepshadow Nova" sync / 1[56]:Shadowkeeper:56E5:/ window 30,30
-118.9 "--center--" sync / 1[56]:Shadowkeeper:5B08:/
-124.3 "Fade To Shadow" sync / 1[56]:Shadowkeeper:56DA:/
-135.4 "--sync--" sync / 1[56]:Shadowkeeper:56DB:/
-137.9 "Cloak Of Shadows" sync / 1[56]:Shadowkeeper:5B11:/ window 50,50
-149.1 "Throne Of Shadow" sync / 1[56]:Shadowkeeper:56C7:/
-157.7 "Umbra Smash x4" duration 5 # sync / 1[56]:Shadowkeeper:5BAB:/
-169.2 "Shadow's Edge" sync / 1[56]:Shadowkeeper:5B0B:/
-180.6 "Left/Right Giga Slash" sync / 1[56]:Shadowkeeper:56(AE|B1):/
-194.1 "Left/Right Shadow Slash" sync / 1[56]:Shadowkeeper:56(AF|B2):/
-205.5 "Voidgate" sync / 1[56]:Shadowkeeper:56DD:/ window 50,50
-219.6 "Void Pulse" sync / 1[56]:Shadowkeeper:56DE:/
-230.8 "Left/Right Shadow Slash" sync / 1[56]:Shadowkeeper:56(AF|B2):/
-233.9 "Left/Right Shadow Slash" sync / 1[56]:Shadowkeeper:56(AF|B2):/
-246.6 "Distant Scream" sync / 1[56]:Shadowkeeper:56C6:/ window 246.6,10
+2.6 "--sync--" sync / 1[56]:[^:]*:Shadowkeeper:5B09:/ window 2.6,1
+17.0 "Forward Implosion" sync / 1[56]:[^:]*:Shadowkeeper:56B4:/ window 17,5
+30.5 "Forward Shadow Implosion" sync / 1[56]:[^:]*:Shadowkeeper:56B5:/
+41.8 "Deepshadow Nova" sync / 1[56]:[^:]*:Shadowkeeper:56E5:/
+55.0 "Backward Implosion" sync / 1[56]:[^:]*:Shadowkeeper:56B7:/
+68.5 "Backward Shadow Implosion" sync / 1[56]:[^:]*:Shadowkeeper:56B8:/
+74.9 "--center--" sync / 1[56]:[^:]*:Shadowkeeper:5B08:/ window 74.9,10
+80.3 "Spawn Shadow" sync / 1[56]:[^:]*:Shadowkeeper:56D6:/
+82.0 "--sync--" sync / 1[56]:[^:]*:Shadowkeeper:56D7:/
+86.4 "Shadow Warrior" sync / 1[56]:[^:]*:Shadowkeeper:56E2:/
+99.6 "Barbs Of Agony" sync / 1[56]:[^:]*:Shadowkeeper:5743:/
+112.7 "Deepshadow Nova" sync / 1[56]:[^:]*:Shadowkeeper:56E5:/ window 30,30
+118.9 "--center--" sync / 1[56]:[^:]*:Shadowkeeper:5B08:/
+124.3 "Fade To Shadow" sync / 1[56]:[^:]*:Shadowkeeper:56DA:/
+135.4 "--sync--" sync / 1[56]:[^:]*:Shadowkeeper:56DB:/
+137.9 "Cloak Of Shadows" sync / 1[56]:[^:]*:Shadowkeeper:5B11:/ window 50,50
+149.1 "Throne Of Shadow" sync / 1[56]:[^:]*:Shadowkeeper:56C7:/
+157.7 "Umbra Smash x4" duration 5 # sync / 1[56]:[^:]*:Shadowkeeper:5BAB:/
+169.2 "Shadow's Edge" sync / 1[56]:[^:]*:Shadowkeeper:5B0B:/
+180.6 "Left/Right Giga Slash" sync / 1[56]:[^:]*:Shadowkeeper:56(AE|B1):/
+194.1 "Left/Right Shadow Slash" sync / 1[56]:[^:]*:Shadowkeeper:56(AF|B2):/
+205.5 "Voidgate" sync / 1[56]:[^:]*:Shadowkeeper:56DD:/ window 50,50
+219.6 "Void Pulse" sync / 1[56]:[^:]*:Shadowkeeper:56DE:/
+230.8 "Left/Right Shadow Slash" sync / 1[56]:[^:]*:Shadowkeeper:56(AF|B2):/
+233.9 "Left/Right Shadow Slash" sync / 1[56]:[^:]*:Shadowkeeper:56(AF|B2):/
+246.6 "Distant Scream" sync / 1[56]:[^:]*:Shadowkeeper:56C6:/ window 246.6,10
 
-253.2 "--center--" sync / 1[56]:Shadowkeeper:5B08:/
-258.6 "Spawn Shadow" sync / 1[56]:Shadowkeeper:56D6:/
-260.3 "--sync--" sync / 1[56]:Shadowkeeper:56D7:/
-264.7 "Shadow Warrior" sync / 1[56]:Shadowkeeper:56E2:/
-276.9 "Shadowy Eruption" sync / 1[56]:Shadowkeeper:56(DF|E4):/
-278.0 "Barbs Of Agony" sync / 1[56]:Shadowkeeper:5743:/
-295.1 "Deepshadow Nova" sync / 1[56]:Shadowkeeper:56E5:/
-309.4 "Front/Back Shadow Implosion" sync / 1[56]:Shadowkeeper:56B[58]:/
-312.5 "Front/Back Shadow Implosion" sync / 1[56]:Shadowkeeper:56B[58]:/
-320.7 "Deepshadow Nova" sync / 1[56]:Shadowkeeper:56E5:/
-328.9 "--center--" sync / 1[56]:Shadowkeeper:5B08:/
-334.3 "Fade To Shadow" sync / 1[56]:Shadowkeeper:56DA:/
-345.4 "--sync--" sync / 1[56]:Shadowkeeper:56DB:/
-347.1 "Forward/Backward Implosion" sync / 1[56]:Shadowkeeper:56B[47]:/
-347.9 "Cloak Of Shadows" sync / 1[56]:Shadowkeeper:5B11:/
-359.0 "Throne Of Shadow" sync / 1[56]:Shadowkeeper:56C7:/
-367.6 "Voidgate" sync / 1[56]:Shadowkeeper:56DD:/
-381.7 "Void Pulse" sync / 1[56]:Shadowkeeper:56DE:/
-384.8 "Left/Right Giga Slash" sync / 1[56]:Shadowkeeper:56(AE|B1):/
-395.2 "Shadowy Eruption" sync / 1[56]:Shadowkeeper:56(DF|E4):/
-404.4 "Left/Right Shadow Slash" sync / 1[56]:Shadowkeeper:56(AF|B2):/
-407.5 "Left/Right Shadow Slash" sync / 1[56]:Shadowkeeper:56(AF|B2):/
-418.6 "Umbra Smash x4" duration 5 # sync / 1[56]:Shadowkeeper:5BAB:/
-430.0 "Shadow's Edge" sync / 1[56]:Shadowkeeper:5B0B:/
-439.3 "Shadowy Eruption x3" # sync / 1[56]:Shadowkeeper:56E0:/
-449.0 "Distant Scream" sync / 1[56]:Shadowkeeper:56C6:/ jump 246.6
+253.2 "--center--" sync / 1[56]:[^:]*:Shadowkeeper:5B08:/
+258.6 "Spawn Shadow" sync / 1[56]:[^:]*:Shadowkeeper:56D6:/
+260.3 "--sync--" sync / 1[56]:[^:]*:Shadowkeeper:56D7:/
+264.7 "Shadow Warrior" sync / 1[56]:[^:]*:Shadowkeeper:56E2:/
+276.9 "Shadowy Eruption" sync / 1[56]:[^:]*:Shadowkeeper:56(DF|E4):/
+278.0 "Barbs Of Agony" sync / 1[56]:[^:]*:Shadowkeeper:5743:/
+295.1 "Deepshadow Nova" sync / 1[56]:[^:]*:Shadowkeeper:56E5:/
+309.4 "Front/Back Shadow Implosion" sync / 1[56]:[^:]*:Shadowkeeper:56B[58]:/
+312.5 "Front/Back Shadow Implosion" sync / 1[56]:[^:]*:Shadowkeeper:56B[58]:/
+320.7 "Deepshadow Nova" sync / 1[56]:[^:]*:Shadowkeeper:56E5:/
+328.9 "--center--" sync / 1[56]:[^:]*:Shadowkeeper:5B08:/
+334.3 "Fade To Shadow" sync / 1[56]:[^:]*:Shadowkeeper:56DA:/
+345.4 "--sync--" sync / 1[56]:[^:]*:Shadowkeeper:56DB:/
+347.1 "Forward/Backward Implosion" sync / 1[56]:[^:]*:Shadowkeeper:56B[47]:/
+347.9 "Cloak Of Shadows" sync / 1[56]:[^:]*:Shadowkeeper:5B11:/
+359.0 "Throne Of Shadow" sync / 1[56]:[^:]*:Shadowkeeper:56C7:/
+367.6 "Voidgate" sync / 1[56]:[^:]*:Shadowkeeper:56DD:/
+381.7 "Void Pulse" sync / 1[56]:[^:]*:Shadowkeeper:56DE:/
+384.8 "Left/Right Giga Slash" sync / 1[56]:[^:]*:Shadowkeeper:56(AE|B1):/
+395.2 "Shadowy Eruption" sync / 1[56]:[^:]*:Shadowkeeper:56(DF|E4):/
+404.4 "Left/Right Shadow Slash" sync / 1[56]:[^:]*:Shadowkeeper:56(AF|B2):/
+407.5 "Left/Right Shadow Slash" sync / 1[56]:[^:]*:Shadowkeeper:56(AF|B2):/
+418.6 "Umbra Smash x4" duration 5 # sync / 1[56]:[^:]*:Shadowkeeper:5BAB:/
+430.0 "Shadow's Edge" sync / 1[56]:[^:]*:Shadowkeeper:5B0B:/
+439.3 "Shadowy Eruption x3" # sync / 1[56]:[^:]*:Shadowkeeper:56E0:/
+449.0 "Distant Scream" sync / 1[56]:[^:]*:Shadowkeeper:56C6:/ jump 246.6
 
 461.0 "Spawn Shadow"
 467.1 "Shadow Warrior"

--- a/ui/raidboss/data/05-shb/raid/e10s.txt
+++ b/ui/raidboss/data/05-shb/raid/e10s.txt
@@ -16,104 +16,104 @@ hideall "--sync--"
 
 0 "Start"
 0.0 "--sync--" sync /:Engage!/ window 0,1
-1.6 "--sync--" sync / 1[56]:Shadowkeeper:5B0A:/ window 2,0
-11.3 "Deepshadow Nova" sync / 1[56]:Shadowkeeper:573E:/ window 12,10
-24.5 "Implosion" sync / 1[56]:Shadowkeeper:56F[03]:/
-33.3 "Throne Of Shadow" sync / 1[56]:Shadowkeeper:5717:/
-40.9 "Giga Slash" sync / 1[56]:Shadowkeeper:56E[AD]:/
-53.2 "Umbra Smash" sync / 1[56]:Shadowkeeper:5BAA:/
-54.8 "Umbra Smash" #sync / 1[56]:Shadowkeeper:5724:/
-56.4 "Umbra Smash" #sync / 1[56]:Shadowkeeper:5724:/
-58.0 "Umbra Smash" #sync / 1[56]:Shadowkeeper:5724:/
-66.1 "Darkness Unleashed / Shadow's Edge" sync / 1[56]:Shadowkeeper:5B0[CE]:/
-80.9 "Shadow Cleave" sync / 1[56]:Shadowkeeper:5718:/
-94.0 "Dualspell" sync / 1[56]:Shadowkeeper:573A:/
-94.0 "Blighting Blitz" sync / 1[56]:Shadowkeeper:573B:/
-97.0 "Blighting Blitz" sync / 1[56]:Shadowkeeper:573B:/
-100.0 "Blighting Blitz" sync / 1[56]:Shadowkeeper:573B:/
-107.4 "Shadowkeeper" sync / 1[56]:Shadowkeeper:5720:/
-110.5 "Swath Of Silence" sync / 1[56]:Shadow Of A Hero:5BBF:/
-119.8 "Umbra Smash" sync / 1[56]:Shadowkeeper:5BAA:/
-121.4 "Umbra Smash" #sync / 1[56]:Shadowkeeper:5724:/
-123.0 "Umbra Smash" #sync / 1[56]:Shadowkeeper:5724:/
-124.6 "Umbra Smash" #sync / 1[56]:Shadowkeeper:5724:/
-132.7 "Darkness Unleashed / Shadow's Edge" sync / 1[56]:Shadowkeeper:5B0[CE]:/
-144.3 "Shadow Servant" sync / 1[56]:Shadowkeeper:5704:/
-159.4 "Giga Slash" sync / 1[56]:Shadowkeeper:5B2[CD]:/
-177.5 "Giga Slash" sync / 1[56]:Shadowkeeper:5B2[CD]:/
-191.2 "Distant Scream" sync / 1[56]:Shadowkeeper:5716:/
-199.7 "Umbral Orbs" sync / 1[56]:Shadowkeeper:5730:/
-209.5 "Flameshadow" sync / 1[56]:Shadefire:5733:/
-211.9 "--sync--" sync / 1[56]:Shadowkeeper:5B08:/
-217.3 "Spawn Shadow" sync / 1[56]:Shadowkeeper:5727:/
-223.4 "Shadow Warrior" sync / 1[56]:Shadowkeeper:5739:/
-229.5 "Umbral Orbs" sync / 1[56]:Shadowkeeper:5730:/
-239.3 "Flameshadow" sync / 1[56]:Shadefire:5733:/
-253.7 "Deepshadow Nova" sync / 1[56]:Shadowkeeper:573E:/
-261.9 "--sync--" sync / 1[56]:Shadowkeeper:5B08:/
-267.1 "Fade To Shadow" sync / 1[56]:Shadowkeeper:572B:/
-279.4 "Implosion" sync / 1[56]:Shadowkeeper:56F[03]:/
-280.7 "Cloak Of Shadows" sync / 1[56]:Shadowkeeper:5B13:/
-285.7 "Cloak Of Shadows" sync / 1[56]:Shadowkeeper:5B14:/
-290.7 "Deepshadow Nova" sync / 1[56]:Shadowkeeper:573E:/
-306.0 "Implosion" sync / 1[56]:Shadowkeeper:(5700|56FC):/
-309.1 "Implosion" sync / 1[56]:Shadowkeeper:(5701|56FD):/
-312.2 "Implosion" sync / 1[56]:Shadowkeeper:(5701|56FD):/
-315.3 "Implosion" sync / 1[56]:Shadowkeeper:(5702|56FE):/
-323.4 "Deepshadow Nova" sync / 1[56]:Shadowkeeper:573E:/
-335.1 "Throne Of Shadow" sync / 1[56]:Shadowkeeper:5717:/
-341.6 "Umbra Smash" sync / 1[56]:Shadowkeeper:5BAA:/
-343.2 "Umbra Smash" #sync / 1[56]:Shadowkeeper:5724:/
-344.8 "Umbra Smash" #sync / 1[56]:Shadowkeeper:5724:/
-346.4 "Umbra Smash" #sync / 1[56]:Shadowkeeper:5724:/
-354.5 "Darkness Unleashed / Shadow's Edge" sync / 1[56]:Shadowkeeper:5B0[CE]:/
-367.1 "Voidgate" sync / 1[56]:Shadowkeeper:5734:/
-373.3 "Shadow Servant" sync / 1[56]:Shadowkeeper:5704:/
-384.2 "Void Pulse" sync / 1[56]:Shadowkeeper:5735:/
-388.4 "Giga Slash" sync / 1[56]:Shadowkeeper:5B2[CD]:/
-401.9 "Void Pulse" sync / 1[56]:Shadowkeeper:5735:/
-409.5 "Giga Slash" sync / 1[56]:Shadowkeeper:5B2[CD]:/
-425.7 "Pitch Bog" sync / 1[56]:Shadowkeeper:5721:/
-431.0 "Umbral Orbs" sync / 1[56]:Shadowkeeper:5731:/
-438.9 "Distant Scream" sync / 1[56]:Shadowkeeper:5716:/
-440.9 "Flameshadow" sync / 1[56]:Shadefire:5733:/
-449.6 "Implosion" sync / 1[56]:Shadowkeeper:(5700|56FC):/
-452.7 "Implosion" sync / 1[56]:Shadowkeeper:(5702|5701|56FE):/
-464.8 "Deepshadow Nova" sync / 1[56]:Shadowkeeper:573E:/
-476.0 "Shackled Apart" sync / 1[56]:Shadowkeeper:5BAC:/
-478.5 "--sync--" sync / 1[56]:Shadowkeeper:5B08:/
-483.7 "Fade To Shadow" sync / 1[56]:Shadowkeeper:572B:/
-491.9 "Umbral Orbs" sync / 1[56]:Shadowkeeper:5730:/
-497.3 "Cloak Of Shadows" sync / 1[56]:Shadowkeeper:5B13:/
-502.3 "Cloak Of Shadows" sync / 1[56]:Shadowkeeper:5B14:/
-503.7 "Flameshadow" sync / 1[56]:Shadefire:5733:/
-516.0 "Deepshadow Nova" sync / 1[56]:Shadowkeeper:573E:/
-531.6 "Throne Of Shadow" sync / 1[56]:Shadowkeeper:5717:/
-538.2 "Pitch Bog" sync / 1[56]:Shadowkeeper:5721:/
-546.6 "Giga Slash" sync / 1[56]:Shadowkeeper:(56F8|56F4):/
-549.7 "Giga Slash" sync / 1[56]:Shadowkeeper:(56F9|56F5):/
-552.8 "Giga Slash" sync / 1[56]:Shadowkeeper:(56F9|56F5):/
-555.9 "Giga Slash" sync / 1[56]:Shadowkeeper:(56FA|56F6):/
-563.0 "Voidgate Amplifier" sync / 1[56]:Shadowkeeper:5BCF:/
-570.1 "Shadowkeeper" sync / 1[56]:Shadowkeeper:5720:/
-573.2 "Swath Of Silence" sync / 1[56]:Shadow Of A Hero:5BBF:/
-577.6 "Void Pulse" sync / 1[56]:Shadowkeeper:5735:/
-581.6 "Shadowy Eruption" sync / 1[56]:Shadowkeeper:5737:/
-585.4 "Shadowy Eruption" sync / 1[56]:Shadowkeeper:5738:/
-587.0 "Shackled Together" sync / 1[56]:Shadowkeeper:572E:/
-592.8 "Void Pulse" sync / 1[56]:Shadowkeeper:5735:/
-601.4 "Umbra Smash" #sync / 1[56]:Shadowkeeper:5BAA:/
-603.0 "Umbra Smash" #sync / 1[56]:Shadowkeeper:5724:/
-604.6 "Umbra Smash" #sync / 1[56]:Shadowkeeper:5724:/
-606.2 "Umbra Smash" #sync / 1[56]:Shadowkeeper:5724:/
-614.3 "Darkness Unleashed / Shadow's Edge" sync / 1[56]:Shadowkeeper:5B0[CE]:/
-621.9 "Umbral Orbs" sync / 1[56]:Shadowkeeper:5731:/
-629.8 "Distant Scream" sync / 1[56]:Shadowkeeper:5716:/
-631.7 "Flameshadow" sync / 1[56]:Shadefire:5733:/
-642.3 "Deepshadow Nova" sync / 1[56]:Shadowkeeper:573E:/
-654.5 "Deepshadow Nova" sync / 1[56]:Shadowkeeper:573E:/
-662.7 "Deepshadow Nova" sync / 1[56]:Shadowkeeper:573E:/
+1.6 "--sync--" sync / 1[56]:[^:]*:Shadowkeeper:5B0A:/ window 2,0
+11.3 "Deepshadow Nova" sync / 1[56]:[^:]*:Shadowkeeper:573E:/ window 12,10
+24.5 "Implosion" sync / 1[56]:[^:]*:Shadowkeeper:56F[03]:/
+33.3 "Throne Of Shadow" sync / 1[56]:[^:]*:Shadowkeeper:5717:/
+40.9 "Giga Slash" sync / 1[56]:[^:]*:Shadowkeeper:56E[AD]:/
+53.2 "Umbra Smash" sync / 1[56]:[^:]*:Shadowkeeper:5BAA:/
+54.8 "Umbra Smash" #sync / 1[56]:[^:]*:Shadowkeeper:5724:/
+56.4 "Umbra Smash" #sync / 1[56]:[^:]*:Shadowkeeper:5724:/
+58.0 "Umbra Smash" #sync / 1[56]:[^:]*:Shadowkeeper:5724:/
+66.1 "Darkness Unleashed / Shadow's Edge" sync / 1[56]:[^:]*:Shadowkeeper:5B0[CE]:/
+80.9 "Shadow Cleave" sync / 1[56]:[^:]*:Shadowkeeper:5718:/
+94.0 "Dualspell" sync / 1[56]:[^:]*:Shadowkeeper:573A:/
+94.0 "Blighting Blitz" sync / 1[56]:[^:]*:Shadowkeeper:573B:/
+97.0 "Blighting Blitz" sync / 1[56]:[^:]*:Shadowkeeper:573B:/
+100.0 "Blighting Blitz" sync / 1[56]:[^:]*:Shadowkeeper:573B:/
+107.4 "Shadowkeeper" sync / 1[56]:[^:]*:Shadowkeeper:5720:/
+110.5 "Swath Of Silence" sync / 1[56]:[^:]*:Shadow Of A Hero:5BBF:/
+119.8 "Umbra Smash" sync / 1[56]:[^:]*:Shadowkeeper:5BAA:/
+121.4 "Umbra Smash" #sync / 1[56]:[^:]*:Shadowkeeper:5724:/
+123.0 "Umbra Smash" #sync / 1[56]:[^:]*:Shadowkeeper:5724:/
+124.6 "Umbra Smash" #sync / 1[56]:[^:]*:Shadowkeeper:5724:/
+132.7 "Darkness Unleashed / Shadow's Edge" sync / 1[56]:[^:]*:Shadowkeeper:5B0[CE]:/
+144.3 "Shadow Servant" sync / 1[56]:[^:]*:Shadowkeeper:5704:/
+159.4 "Giga Slash" sync / 1[56]:[^:]*:Shadowkeeper:5B2[CD]:/
+177.5 "Giga Slash" sync / 1[56]:[^:]*:Shadowkeeper:5B2[CD]:/
+191.2 "Distant Scream" sync / 1[56]:[^:]*:Shadowkeeper:5716:/
+199.7 "Umbral Orbs" sync / 1[56]:[^:]*:Shadowkeeper:5730:/
+209.5 "Flameshadow" sync / 1[56]:[^:]*:Shadefire:5733:/
+211.9 "--sync--" sync / 1[56]:[^:]*:Shadowkeeper:5B08:/
+217.3 "Spawn Shadow" sync / 1[56]:[^:]*:Shadowkeeper:5727:/
+223.4 "Shadow Warrior" sync / 1[56]:[^:]*:Shadowkeeper:5739:/
+229.5 "Umbral Orbs" sync / 1[56]:[^:]*:Shadowkeeper:5730:/
+239.3 "Flameshadow" sync / 1[56]:[^:]*:Shadefire:5733:/
+253.7 "Deepshadow Nova" sync / 1[56]:[^:]*:Shadowkeeper:573E:/
+261.9 "--sync--" sync / 1[56]:[^:]*:Shadowkeeper:5B08:/
+267.1 "Fade To Shadow" sync / 1[56]:[^:]*:Shadowkeeper:572B:/
+279.4 "Implosion" sync / 1[56]:[^:]*:Shadowkeeper:56F[03]:/
+280.7 "Cloak Of Shadows" sync / 1[56]:[^:]*:Shadowkeeper:5B13:/
+285.7 "Cloak Of Shadows" sync / 1[56]:[^:]*:Shadowkeeper:5B14:/
+290.7 "Deepshadow Nova" sync / 1[56]:[^:]*:Shadowkeeper:573E:/
+306.0 "Implosion" sync / 1[56]:[^:]*:Shadowkeeper:(5700|56FC):/
+309.1 "Implosion" sync / 1[56]:[^:]*:Shadowkeeper:(5701|56FD):/
+312.2 "Implosion" sync / 1[56]:[^:]*:Shadowkeeper:(5701|56FD):/
+315.3 "Implosion" sync / 1[56]:[^:]*:Shadowkeeper:(5702|56FE):/
+323.4 "Deepshadow Nova" sync / 1[56]:[^:]*:Shadowkeeper:573E:/
+335.1 "Throne Of Shadow" sync / 1[56]:[^:]*:Shadowkeeper:5717:/
+341.6 "Umbra Smash" sync / 1[56]:[^:]*:Shadowkeeper:5BAA:/
+343.2 "Umbra Smash" #sync / 1[56]:[^:]*:Shadowkeeper:5724:/
+344.8 "Umbra Smash" #sync / 1[56]:[^:]*:Shadowkeeper:5724:/
+346.4 "Umbra Smash" #sync / 1[56]:[^:]*:Shadowkeeper:5724:/
+354.5 "Darkness Unleashed / Shadow's Edge" sync / 1[56]:[^:]*:Shadowkeeper:5B0[CE]:/
+367.1 "Voidgate" sync / 1[56]:[^:]*:Shadowkeeper:5734:/
+373.3 "Shadow Servant" sync / 1[56]:[^:]*:Shadowkeeper:5704:/
+384.2 "Void Pulse" sync / 1[56]:[^:]*:Shadowkeeper:5735:/
+388.4 "Giga Slash" sync / 1[56]:[^:]*:Shadowkeeper:5B2[CD]:/
+401.9 "Void Pulse" sync / 1[56]:[^:]*:Shadowkeeper:5735:/
+409.5 "Giga Slash" sync / 1[56]:[^:]*:Shadowkeeper:5B2[CD]:/
+425.7 "Pitch Bog" sync / 1[56]:[^:]*:Shadowkeeper:5721:/
+431.0 "Umbral Orbs" sync / 1[56]:[^:]*:Shadowkeeper:5731:/
+438.9 "Distant Scream" sync / 1[56]:[^:]*:Shadowkeeper:5716:/
+440.9 "Flameshadow" sync / 1[56]:[^:]*:Shadefire:5733:/
+449.6 "Implosion" sync / 1[56]:[^:]*:Shadowkeeper:(5700|56FC):/
+452.7 "Implosion" sync / 1[56]:[^:]*:Shadowkeeper:(5702|5701|56FE):/
+464.8 "Deepshadow Nova" sync / 1[56]:[^:]*:Shadowkeeper:573E:/
+476.0 "Shackled Apart" sync / 1[56]:[^:]*:Shadowkeeper:5BAC:/
+478.5 "--sync--" sync / 1[56]:[^:]*:Shadowkeeper:5B08:/
+483.7 "Fade To Shadow" sync / 1[56]:[^:]*:Shadowkeeper:572B:/
+491.9 "Umbral Orbs" sync / 1[56]:[^:]*:Shadowkeeper:5730:/
+497.3 "Cloak Of Shadows" sync / 1[56]:[^:]*:Shadowkeeper:5B13:/
+502.3 "Cloak Of Shadows" sync / 1[56]:[^:]*:Shadowkeeper:5B14:/
+503.7 "Flameshadow" sync / 1[56]:[^:]*:Shadefire:5733:/
+516.0 "Deepshadow Nova" sync / 1[56]:[^:]*:Shadowkeeper:573E:/
+531.6 "Throne Of Shadow" sync / 1[56]:[^:]*:Shadowkeeper:5717:/
+538.2 "Pitch Bog" sync / 1[56]:[^:]*:Shadowkeeper:5721:/
+546.6 "Giga Slash" sync / 1[56]:[^:]*:Shadowkeeper:(56F8|56F4):/
+549.7 "Giga Slash" sync / 1[56]:[^:]*:Shadowkeeper:(56F9|56F5):/
+552.8 "Giga Slash" sync / 1[56]:[^:]*:Shadowkeeper:(56F9|56F5):/
+555.9 "Giga Slash" sync / 1[56]:[^:]*:Shadowkeeper:(56FA|56F6):/
+563.0 "Voidgate Amplifier" sync / 1[56]:[^:]*:Shadowkeeper:5BCF:/
+570.1 "Shadowkeeper" sync / 1[56]:[^:]*:Shadowkeeper:5720:/
+573.2 "Swath Of Silence" sync / 1[56]:[^:]*:Shadow Of A Hero:5BBF:/
+577.6 "Void Pulse" sync / 1[56]:[^:]*:Shadowkeeper:5735:/
+581.6 "Shadowy Eruption" sync / 1[56]:[^:]*:Shadowkeeper:5737:/
+585.4 "Shadowy Eruption" sync / 1[56]:[^:]*:Shadowkeeper:5738:/
+587.0 "Shackled Together" sync / 1[56]:[^:]*:Shadowkeeper:572E:/
+592.8 "Void Pulse" sync / 1[56]:[^:]*:Shadowkeeper:5735:/
+601.4 "Umbra Smash" #sync / 1[56]:[^:]*:Shadowkeeper:5BAA:/
+603.0 "Umbra Smash" #sync / 1[56]:[^:]*:Shadowkeeper:5724:/
+604.6 "Umbra Smash" #sync / 1[56]:[^:]*:Shadowkeeper:5724:/
+606.2 "Umbra Smash" #sync / 1[56]:[^:]*:Shadowkeeper:5724:/
+614.3 "Darkness Unleashed / Shadow's Edge" sync / 1[56]:[^:]*:Shadowkeeper:5B0[CE]:/
+621.9 "Umbral Orbs" sync / 1[56]:[^:]*:Shadowkeeper:5731:/
+629.8 "Distant Scream" sync / 1[56]:[^:]*:Shadowkeeper:5716:/
+631.7 "Flameshadow" sync / 1[56]:[^:]*:Shadefire:5733:/
+642.3 "Deepshadow Nova" sync / 1[56]:[^:]*:Shadowkeeper:573E:/
+654.5 "Deepshadow Nova" sync / 1[56]:[^:]*:Shadowkeeper:573E:/
+662.7 "Deepshadow Nova" sync / 1[56]:[^:]*:Shadowkeeper:573E:/
 
 ### TODO: is this enrage??
-675.8 "Doom Arc" sync / 1[56]:Shadowkeeper:5741:/
-677.5 "Doom Arc" sync / 1[56]:Shadowkeeper:5742:/
+675.8 "Doom Arc" sync / 1[56]:[^:]*:Shadowkeeper:5741:/
+677.5 "Doom Arc" sync / 1[56]:[^:]*:Shadowkeeper:5742:/

--- a/ui/raidboss/data/05-shb/raid/e11n.txt
+++ b/ui/raidboss/data/05-shb/raid/e11n.txt
@@ -10,88 +10,88 @@ hideall "--sync--"
 
 # Opening Block. Introduces Fire/Lightning in a random order.
 0.0 "--sync--" sync /:Engage!/ window 0,1
-1.2 "--sync--" sync / 1[56]:Fatebreaker:366:/ window 1.2,1
-11.0 "--center--" sync / 1[56]:Fatebreaker:5908:/ window 11,5
-21.8 "Burnt Strike" sync / 1[56]:Fatebreaker:562[CE]:/
-23.5 "Blastburn/Burnout" # sync / 1[56]:Fatebreaker:562[DF]:/
-39.3 "Floating Fetters" sync / 1[56]:Fatebreaker:58F4:/
-41.4 "Solemn Charge" sync / 1[56]:Fatebreaker:563[24]:/
-42.7 "Sinsmite/Sinsmoke" sync / 1[56]:Fatebreaker:563[35]:/
-54.5 "Burnished Glory" sync / 1[56]:Fatebreaker:5650:/ window 54.5,5
-65.0 "Powder Mark" sync / 1[56]:Fatebreaker:564E:/
-67.5 "--center--" sync / 1[56]:Fatebreaker:5908:/ window 30,30
-78.7 "Burnt Strike" sync / 1[56]:Fatebreaker:562[CE]:/
-78.9 "Burn Mark" sync / 1[56]:Fatebreaker:564F:/
-80.4 "Blastburn/Burnout" # sync / 1[56]:Fatebreaker:562[DF]:/
-88.8 "Burnished Glory" sync / 1[56]:Fatebreaker:5650:/
-103.6 "Floating Fetters" sync / 1[56]:Fatebreaker:58F4:/
-105.6 "Solemn Charge" sync / 1[56]:Fatebreaker:563[24]:/
-106.9 "Sinsmite/Sinsmoke" sync / 1[56]:Fatebreaker:563[35]:/
+1.2 "--sync--" sync / 1[56]:[^:]*:Fatebreaker:366:/ window 1.2,1
+11.0 "--center--" sync / 1[56]:[^:]*:Fatebreaker:5908:/ window 11,5
+21.8 "Burnt Strike" sync / 1[56]:[^:]*:Fatebreaker:562[CE]:/
+23.5 "Blastburn/Burnout" # sync / 1[56]:[^:]*:Fatebreaker:562[DF]:/
+39.3 "Floating Fetters" sync / 1[56]:[^:]*:Fatebreaker:58F4:/
+41.4 "Solemn Charge" sync / 1[56]:[^:]*:Fatebreaker:563[24]:/
+42.7 "Sinsmite/Sinsmoke" sync / 1[56]:[^:]*:Fatebreaker:563[35]:/
+54.5 "Burnished Glory" sync / 1[56]:[^:]*:Fatebreaker:5650:/ window 54.5,5
+65.0 "Powder Mark" sync / 1[56]:[^:]*:Fatebreaker:564E:/
+67.5 "--center--" sync / 1[56]:[^:]*:Fatebreaker:5908:/ window 30,30
+78.7 "Burnt Strike" sync / 1[56]:[^:]*:Fatebreaker:562[CE]:/
+78.9 "Burn Mark" sync / 1[56]:[^:]*:Fatebreaker:564F:/
+80.4 "Blastburn/Burnout" # sync / 1[56]:[^:]*:Fatebreaker:562[DF]:/
+88.8 "Burnished Glory" sync / 1[56]:[^:]*:Fatebreaker:5650:/
+103.6 "Floating Fetters" sync / 1[56]:[^:]*:Fatebreaker:58F4:/
+105.6 "Solemn Charge" sync / 1[56]:[^:]*:Fatebreaker:563[24]:/
+106.9 "Sinsmite/Sinsmoke" sync / 1[56]:[^:]*:Fatebreaker:563[35]:/
 
 # Turn of the Heavens introduced, random element.
-121.7 "Turn Of The Heavens" sync / 1[56]:Fatebreaker:563[9A]:/ window 121.7,5
-133.5 "Brightfire" # sync / 1[56]:Halo Of Flame:563[BC]:/
-146.2 "Burnished Glory" sync / 1[56]:Fatebreaker:5650:/
-159.7 "Shifting Sky" sync / 1[56]:Fatebreaker:563F:/ window 159.7,5
+121.7 "Turn Of The Heavens" sync / 1[56]:[^:]*:Fatebreaker:563[9A]:/ window 121.7,5
+133.5 "Brightfire" # sync / 1[56]:[^:]*:Halo Of Flame:563[BC]:/
+146.2 "Burnished Glory" sync / 1[56]:[^:]*:Fatebreaker:5650:/
+159.7 "Shifting Sky" sync / 1[56]:[^:]*:Fatebreaker:563F:/ window 159.7,5
 162.1 "--untargetable--"
 
 # Single serpent intermission. Lightning Burnt Strike is always first.
-167.2 "--sync--" sync / 1[56]:Demi-Gukumatz:564B:/
-167.3 "Ageless Serpent" sync / 1[56]:Demi-Gukumatz:564C:/ window 167.3,5
-174.7 "Resounding Crack" sync / 1[56]:Demi-Gukumatz:564D:/
-183.9 "Burnt Strike" sync / 1[56]:Fatebreaker's Image:5645:/
-185.6 "Burnout" sync / 1[56]:Fatebreaker's Image:5646:/
-187.9 "Burnt Strike" sync / 1[56]:Fatebreaker's Image:5643:/
-189.9 "Blastburn" sync / 1[56]:Fatebreaker's Image:5644:/
+167.2 "--sync--" sync / 1[56]:[^:]*:Demi-Gukumatz:564B:/
+167.3 "Ageless Serpent" sync / 1[56]:[^:]*:Demi-Gukumatz:564C:/ window 167.3,5
+174.7 "Resounding Crack" sync / 1[56]:[^:]*:Demi-Gukumatz:564D:/
+183.9 "Burnt Strike" sync / 1[56]:[^:]*:Fatebreaker's Image:5645:/
+185.6 "Burnout" sync / 1[56]:[^:]*:Fatebreaker's Image:5646:/
+187.9 "Burnt Strike" sync / 1[56]:[^:]*:Fatebreaker's Image:5643:/
+189.9 "Blastburn" sync / 1[56]:[^:]*:Fatebreaker's Image:5644:/
 195.7 "--targetable--"
 
 # Holy introduction block.
-201.9 "Burnished Glory" sync / 1[56]:Fatebreaker:5650:/ window 40,5
-213.5 "--center--" sync / 1[56]:Fatebreaker:5908:/
-224.5 "Burnt Strike" sync / 1[56]:Fatebreaker:5630:/
-229.5 "Shining Blade" sync / 1[56]:Fatebreaker:5631:/
-236.6 "Burnished Glory" sync / 1[56]:Fatebreaker:5650:/
-250.4 "Floating Fetters" sync / 1[56]:Fatebreaker:58F4:/ window 50,30
-252.4 "Solemn Charge" sync / 1[56]:Fatebreaker:5636:/
-253.7 "Sinsight" sync / 1[56]:Fatebreaker:5637:/
-259.3 "Mortal Burn Mark" sync / 1[56]:Fatebreaker:5638:/
-260.5 "--center--" sync / 1[56]:Fatebreaker:5908:/
-269.1 "Prismatic Deception" sync / 1[56]:Fatebreaker:563D:/ window 269.1,5
+201.9 "Burnished Glory" sync / 1[56]:[^:]*:Fatebreaker:5650:/ window 40,5
+213.5 "--center--" sync / 1[56]:[^:]*:Fatebreaker:5908:/
+224.5 "Burnt Strike" sync / 1[56]:[^:]*:Fatebreaker:5630:/
+229.5 "Shining Blade" sync / 1[56]:[^:]*:Fatebreaker:5631:/
+236.6 "Burnished Glory" sync / 1[56]:[^:]*:Fatebreaker:5650:/
+250.4 "Floating Fetters" sync / 1[56]:[^:]*:Fatebreaker:58F4:/ window 50,30
+252.4 "Solemn Charge" sync / 1[56]:[^:]*:Fatebreaker:5636:/
+253.7 "Sinsight" sync / 1[56]:[^:]*:Fatebreaker:5637:/
+259.3 "Mortal Burn Mark" sync / 1[56]:[^:]*:Fatebreaker:5638:/
+260.5 "--center--" sync / 1[56]:[^:]*:Fatebreaker:5908:/
+269.1 "Prismatic Deception" sync / 1[56]:[^:]*:Fatebreaker:563D:/ window 269.1,5
 272.2 "--untargetable--"
 
 # Clone intermission.
-294.5 "Blasting Zone" sync / 1[56]:Fatebreaker's Image:563E:/
+294.5 "Blasting Zone" sync / 1[56]:[^:]*:Fatebreaker's Image:563E:/
 300.4 "--targetable--"
 
 # Multi-Strike rotation block
-306.5 "Burnished Glory" sync / 1[56]:Fatebreaker:5650:/
-319.1 "Powder Mark" sync / 1[56]:Fatebreaker:564E:/
-329.6 "Turn Of The Heavens" sync / 1[56]:Fatebreaker:563[9A]:/ window 30,30
-333.0 "Burn Mark" sync / 1[56]:Fatebreaker:564F:/
-341.4 "Brightfire" # sync / 1[56]:Halo Of Flame:563[BC]:/
-346.1 "--center--" sync / 1[56]:Fatebreaker:5908:/
-356.8 "Burnt Strike" sync / 1[56]:Fatebreaker:56(2C|2E|30):/
-358.5 "Blastburn/Burnout" # sync / 1[56]:Fatebreaker:(2D|2F|31):/
-369.2 "Burnt Strike" sync / 1[56]:Fatebreaker:56(2C|2E|30):/
-370.9 "Blastburn/Burnout" # sync / 1[56]:Fatebreaker:(2D|2F|31):/
-381.2 "Burnished Glory" sync / 1[56]:Fatebreaker:5650:/
+306.5 "Burnished Glory" sync / 1[56]:[^:]*:Fatebreaker:5650:/
+319.1 "Powder Mark" sync / 1[56]:[^:]*:Fatebreaker:564E:/
+329.6 "Turn Of The Heavens" sync / 1[56]:[^:]*:Fatebreaker:563[9A]:/ window 30,30
+333.0 "Burn Mark" sync / 1[56]:[^:]*:Fatebreaker:564F:/
+341.4 "Brightfire" # sync / 1[56]:[^:]*:Halo Of Flame:563[BC]:/
+346.1 "--center--" sync / 1[56]:[^:]*:Fatebreaker:5908:/
+356.8 "Burnt Strike" sync / 1[56]:[^:]*:Fatebreaker:56(2C|2E|30):/
+358.5 "Blastburn/Burnout" # sync / 1[56]:[^:]*:Fatebreaker:(2D|2F|31):/
+369.2 "Burnt Strike" sync / 1[56]:[^:]*:Fatebreaker:56(2C|2E|30):/
+370.9 "Blastburn/Burnout" # sync / 1[56]:[^:]*:Fatebreaker:(2D|2F|31):/
+381.2 "Burnished Glory" sync / 1[56]:[^:]*:Fatebreaker:5650:/
 
 # Fetters rotation block
-391.7 "Burnished Glory" sync / 1[56]:Fatebreaker:5650:/
-404.2 "Powder Mark" sync / 1[56]:Fatebreaker:564E:/
-414.7 "Turn Of The Heavens" sync / 1[56]:Fatebreaker:563[9A]:/ window 30,30
-418.1 "Burn Mark" sync / 1[56]:Fatebreaker:564F:/
-426.5 "Brightfire" # sync / 1[56]:Halo Of Flame:563[BC]:/
-431.2 "--center--" sync / 1[56]:Fatebreaker:5908:/
-442.1 "Burnt Strike" sync / 1[56]:Fatebreaker:56(2C|2E|30):/
-446.9 "Shining Blade" # sync / 1[56]:Fatebreaker:5631:/
-454.2 "Burnished Glory" sync / 1[56]:Fatebreaker:5650:/
-466.9 "Floating Fetters" sync / 1[56]:Fatebreaker:58F4:/
-469.0 "Solemn Charge" sync / 1[56]:Fatebreaker:563[246]:/
-470.3 "Sinsmite/Sinsmoke/Sinsight" sync / 1[56]:Fatebreaker:563[357]:/
-475.9 "Mortal Burn Mark?" sync / 1[56]:Fatebreaker:5638:/
+391.7 "Burnished Glory" sync / 1[56]:[^:]*:Fatebreaker:5650:/
+404.2 "Powder Mark" sync / 1[56]:[^:]*:Fatebreaker:564E:/
+414.7 "Turn Of The Heavens" sync / 1[56]:[^:]*:Fatebreaker:563[9A]:/ window 30,30
+418.1 "Burn Mark" sync / 1[56]:[^:]*:Fatebreaker:564F:/
+426.5 "Brightfire" # sync / 1[56]:[^:]*:Halo Of Flame:563[BC]:/
+431.2 "--center--" sync / 1[56]:[^:]*:Fatebreaker:5908:/
+442.1 "Burnt Strike" sync / 1[56]:[^:]*:Fatebreaker:56(2C|2E|30):/
+446.9 "Shining Blade" # sync / 1[56]:[^:]*:Fatebreaker:5631:/
+454.2 "Burnished Glory" sync / 1[56]:[^:]*:Fatebreaker:5650:/
+466.9 "Floating Fetters" sync / 1[56]:[^:]*:Fatebreaker:58F4:/
+469.0 "Solemn Charge" sync / 1[56]:[^:]*:Fatebreaker:563[246]:/
+470.3 "Sinsmite/Sinsmoke/Sinsight" sync / 1[56]:[^:]*:Fatebreaker:563[357]:/
+475.9 "Mortal Burn Mark?" sync / 1[56]:[^:]*:Fatebreaker:5638:/
 
-480.1 "Burnished Glory" sync / 1[56]:Fatebreaker:5650:/ jump 306.5
+480.1 "Burnished Glory" sync / 1[56]:[^:]*:Fatebreaker:5650:/ jump 306.5
 492.7 "Powder Mark"
 503.2 "Turn Of The Heavens"
 506.6 "Burn Mark"

--- a/ui/raidboss/data/05-shb/raid/e11s.txt
+++ b/ui/raidboss/data/05-shb/raid/e11s.txt
@@ -8,24 +8,24 @@ hideall "--Reset--"
 hideall "--sync--"
 
 # example lightning bound of faith
-# 46.7 "Bound Of Faith" sync / 1[56]:Fatebreaker:565[8B]:/
-# 46.8 "Floating Fetters" sync / 1[56]:Fatebreaker:58F4:/
-# 48.8 "Solemn Charge" sync / 1[56]:Fatebreaker:565C:/
-# 50.1 "Sinsmite" sync / 1[56]:Fatebreaker:565D:/
-# 50.5 "Bow Shock" sync / 1[56]:Fatebreaker:565E:/
+# 46.7 "Bound Of Faith" sync / 1[56]:[^:]*:Fatebreaker:565[8B]:/
+# 46.8 "Floating Fetters" sync / 1[56]:[^:]*:Fatebreaker:58F4:/
+# 48.8 "Solemn Charge" sync / 1[56]:[^:]*:Fatebreaker:565C:/
+# 50.1 "Sinsmite" sync / 1[56]:[^:]*:Fatebreaker:565D:/
+# 50.5 "Bow Shock" sync / 1[56]:[^:]*:Fatebreaker:565E:/
 
 # example fire bound of faith
-# 46.6 "Bound Of Faith" sync / 1[56]:Fatebreaker:5658:/
-# 46.9 "Floating Fetters" sync / 1[56]:Fatebreaker:58F4:/
-# 49.0 "Solemn Charge" sync / 1[56]:Fatebreaker:5659:/
-# 50.3 "Sinsmoke" sync / 1[56]:Fatebreaker:565A:/
+# 46.6 "Bound Of Faith" sync / 1[56]:[^:]*:Fatebreaker:5658:/
+# 46.9 "Floating Fetters" sync / 1[56]:[^:]*:Fatebreaker:58F4:/
+# 49.0 "Solemn Charge" sync / 1[56]:[^:]*:Fatebreaker:5659:/
+# 50.3 "Sinsmoke" sync / 1[56]:[^:]*:Fatebreaker:565A:/
 
 # example holy bound of faith
-# 46.7 "Bound Of Faith" sync / 1[56]:Fatebreaker:565F:/
-# 46.9 "Floating Fetters" sync / 1[56]:Fatebreaker:58F4:/
-# 49.0 "Solemn Charge" sync / 1[56]:Fatebreaker:5660:/
-# 50.3 "Sinsight" sync / 1[56]:Fatebreaker:5661:/
-# 55.9 "Mortal Burn Mark" sync / 1[56]:Fatebreaker:5662:/
+# 46.7 "Bound Of Faith" sync / 1[56]:[^:]*:Fatebreaker:565F:/
+# 46.9 "Floating Fetters" sync / 1[56]:[^:]*:Fatebreaker:58F4:/
+# 49.0 "Solemn Charge" sync / 1[56]:[^:]*:Fatebreaker:5660:/
+# 50.3 "Sinsight" sync / 1[56]:[^:]*:Fatebreaker:5661:/
+# 55.9 "Mortal Burn Mark" sync / 1[56]:[^:]*:Fatebreaker:5662:/
 
 # Burnt Strike timings:
 # * Burnout, lightning, 5655, 1.7s delay
@@ -39,117 +39,117 @@ hideall "--sync--"
 # Phase 1
 0 "Start"
 0.0 "--sync--" sync /:Engage!/ window 0,1
-2.8 "--sync--" sync / 1[56]:Fatebreaker:366:/ window 3,0
-17.4 "Elemental Break" sync / 1[56]:Fatebreaker:566[36]:/
-19.9 "Sinsmoke/Sinsmite" sync / 1[56]:Fatebreaker:566[57]:/
-23.9 "--center--" sync / 1[56]:Fatebreaker:5908:/
-33.0 "Burnt Strike" sync / 1[56]:Fatebreaker:565[24]:/
-34.7 "Burnout/Blastburn" #sync / 1[56]:Fatebreaker:565[35]:/
-46.7 "Bound Of Faith" sync / 1[56]:Fatebreaker:565[8B]:/
-50.1 "Sinsmoke/Sinsmite" sync / 1[56]:Fatebreaker:565[AD]:/
+2.8 "--sync--" sync / 1[56]:[^:]*:Fatebreaker:366:/ window 3,0
+17.4 "Elemental Break" sync / 1[56]:[^:]*:Fatebreaker:566[36]:/
+19.9 "Sinsmoke/Sinsmite" sync / 1[56]:[^:]*:Fatebreaker:566[57]:/
+23.9 "--center--" sync / 1[56]:[^:]*:Fatebreaker:5908:/
+33.0 "Burnt Strike" sync / 1[56]:[^:]*:Fatebreaker:565[24]:/
+34.7 "Burnout/Blastburn" #sync / 1[56]:[^:]*:Fatebreaker:565[35]:/
+46.7 "Bound Of Faith" sync / 1[56]:[^:]*:Fatebreaker:565[8B]:/
+50.1 "Sinsmoke/Sinsmite" sync / 1[56]:[^:]*:Fatebreaker:565[AD]:/
 
-59.9 "Burnished Glory" sync / 1[56]:Fatebreaker:56A4:/
-70.4 "Powder Mark" sync / 1[56]:Fatebreaker:56A2:/
-77.9 "Turn Of The Heavens" sync / 1[56]:Fatebreaker:566A:/
-89.3 "Burn Mark" sync / 1[56]:Fatebreaker:56A3:/
-89.7 "Brightfire" # sync / 1[56]:Halo of Flame:566D:/
+59.9 "Burnished Glory" sync / 1[56]:[^:]*:Fatebreaker:56A4:/
+70.4 "Powder Mark" sync / 1[56]:[^:]*:Fatebreaker:56A2:/
+77.9 "Turn Of The Heavens" sync / 1[56]:[^:]*:Fatebreaker:566A:/
+89.3 "Burn Mark" sync / 1[56]:[^:]*:Fatebreaker:56A3:/
+89.7 "Brightfire" # sync / 1[56]:[^:]*:Halo of Flame:566D:/
 
-94.4 "--center--" sync / 1[56]:Fatebreaker:5908:/
-103.9 "Burnt Strike" sync / 1[56]:Fatebreaker:565[24]:/
-105.6 "Burnout/Blastburn" #sync / 1[56]:Fatebreaker:565[35]:/
-117.6 "Bound Of Faith" sync / 1[56]:Fatebreaker:565[8B]:/
-121.3 "Sinsmoke/Sinsmite" sync / 1[56]:Fatebreaker:565[AD]:/
+94.4 "--center--" sync / 1[56]:[^:]*:Fatebreaker:5908:/
+103.9 "Burnt Strike" sync / 1[56]:[^:]*:Fatebreaker:565[24]:/
+105.6 "Burnout/Blastburn" #sync / 1[56]:[^:]*:Fatebreaker:565[35]:/
+117.6 "Bound Of Faith" sync / 1[56]:[^:]*:Fatebreaker:565[8B]:/
+121.3 "Sinsmoke/Sinsmite" sync / 1[56]:[^:]*:Fatebreaker:565[AD]:/
 
 # Dragon trio
-132.6 "Elemental Break" sync / 1[56]:Fatebreaker:566[36]:/
-135.1 "Sinsmite/Sinsmoke" sync / 1[56]:Fatebreaker:56(5A|57|65|67):/ window 10,10
-147.1 "Shifting Sky" sync / 1[56]:Fatebreaker:567[56]:/
+132.6 "Elemental Break" sync / 1[56]:[^:]*:Fatebreaker:566[36]:/
+135.1 "Sinsmite/Sinsmoke" sync / 1[56]:[^:]*:Fatebreaker:56(5A|57|65|67):/ window 10,10
+147.1 "Shifting Sky" sync / 1[56]:[^:]*:Fatebreaker:567[56]:/
 149.5 "--untargetable--"
-154.7 "Ageless Serpent" sync / 1[56]:Demi-Gukumatz:5687:/
-165.8 "Resonant Winds" sync / 1[56]:Demi-Gukumatz:5689:/
-169.4 "Sinsmoke" sync / 1[56]:Fatebreaker's Image:5681:/
-169.4 "Sinsmite" sync / 1[56]:Fatebreaker's Image:5684:/
-169.8 "Bow Shock" sync / 1[56]:Fatebreaker's Image:5685:/
-173.0 "Burnt Strike " sync / 1[56]:Fatebreaker's Image:567B:/
-174.7 "Burnout" sync / 1[56]:Fatebreaker's Image:567C:/
-176.0 "Burnt Strike" sync / 1[56]:Fatebreaker's Image:5679:/
-178.0 "Blastburn" sync / 1[56]:Fatebreaker's Image:567A:/
+154.7 "Ageless Serpent" sync / 1[56]:[^:]*:Demi-Gukumatz:5687:/
+165.8 "Resonant Winds" sync / 1[56]:[^:]*:Demi-Gukumatz:5689:/
+169.4 "Sinsmoke" sync / 1[56]:[^:]*:Fatebreaker's Image:5681:/
+169.4 "Sinsmite" sync / 1[56]:[^:]*:Fatebreaker's Image:5684:/
+169.8 "Bow Shock" sync / 1[56]:[^:]*:Fatebreaker's Image:5685:/
+173.0 "Burnt Strike " sync / 1[56]:[^:]*:Fatebreaker's Image:567B:/
+174.7 "Burnout" sync / 1[56]:[^:]*:Fatebreaker's Image:567C:/
+176.0 "Burnt Strike" sync / 1[56]:[^:]*:Fatebreaker's Image:5679:/
+178.0 "Blastburn" sync / 1[56]:[^:]*:Fatebreaker's Image:567A:/
 180.7 "--targetable--"
 
 # Phase 2: light sparkles
-191.5 "Elemental Break" sync / 1[56]:Fatebreaker:566[368]:/
-194.1 "Sinsmite/Sinsmoke" sync / 1[56]:Fatebreaker:56(5A|57|65|67):/
-204.0 "Burnished Glory" sync / 1[56]:Fatebreaker:56A4:/
+191.5 "Elemental Break" sync / 1[56]:[^:]*:Fatebreaker:566[368]:/
+194.1 "Sinsmite/Sinsmoke" sync / 1[56]:[^:]*:Fatebreaker:56(5A|57|65|67):/
+204.0 "Burnished Glory" sync / 1[56]:[^:]*:Fatebreaker:56A4:/
 
-221.1 "Elemental Break" sync / 1[56]:Fatebreaker:5668:/
-223.6 "Sinsight" sync / 1[56]:Fatebreaker:5669:/
-227.6 "--center--" sync / 1[56]:Fatebreaker:5908:/
-237.0 "Burnt Strike" sync / 1[56]:Fatebreaker:5656:/
-242.0 "Shining Blade" sync / 1[56]:Fatebreaker:5657:/
-250.7 "Bound Of Faith" sync / 1[56]:Fatebreaker:565F:/
-254.3 "Sinsight" sync / 1[56]:Fatebreaker:5661:/
-259.9 "Mortal Burn Mark" sync / 1[56]:Fatebreaker:5662:/
+221.1 "Elemental Break" sync / 1[56]:[^:]*:Fatebreaker:5668:/
+223.6 "Sinsight" sync / 1[56]:[^:]*:Fatebreaker:5669:/
+227.6 "--center--" sync / 1[56]:[^:]*:Fatebreaker:5908:/
+237.0 "Burnt Strike" sync / 1[56]:[^:]*:Fatebreaker:5656:/
+242.0 "Shining Blade" sync / 1[56]:[^:]*:Fatebreaker:5657:/
+250.7 "Bound Of Faith" sync / 1[56]:[^:]*:Fatebreaker:565F:/
+254.3 "Sinsight" sync / 1[56]:[^:]*:Fatebreaker:5661:/
+259.9 "Mortal Burn Mark" sync / 1[56]:[^:]*:Fatebreaker:5662:/
 
-264.1 "Burnished Glory" sync / 1[56]:Fatebreaker:56A4:/
-274.6 "Powder Mark" sync / 1[56]:Fatebreaker:56A2:/
-282.1 "Right Of The Heavens" sync / 1[56]:Fatebreaker:566[EF]:/ window 50,50
-293.5 "Burn Mark" sync / 1[56]:Fatebreaker:56A3:/
+264.1 "Burnished Glory" sync / 1[56]:[^:]*:Fatebreaker:56A4:/
+274.6 "Powder Mark" sync / 1[56]:[^:]*:Fatebreaker:56A2:/
+282.1 "Right Of The Heavens" sync / 1[56]:[^:]*:Fatebreaker:566[EF]:/ window 50,50
+293.5 "Burn Mark" sync / 1[56]:[^:]*:Fatebreaker:56A3:/
 
-298.6 "--center--" sync / 1[56]:Fatebreaker:5908:/
-308.2 "Burnt Strike" sync / 1[56]:Fatebreaker:565[246]:/
-309.9 "Burnout/Blastburn" #sync / 1[56]:Fatebreaker:565[35]:/
-321.9 "Bound Of Faith" sync / 1[56]:Fatebreaker:565[8BF]:/
-325.6 "Sinsmoke/Sinsmite/Sinsight" sync / 1[56]:Fatebreaker:56(5[AD]|6[159]):/
-331.2 "Mortal Burn Mark?" # sync / 1[56]:Fatebreaker:5662:/
-336.9 "Elemental Break" sync / 1[56]:Fatebreaker:566[368]:/
-339.4 "Sinsmoke/Sinsmite/Sinsight" sync / 1[56]:Fatebreaker:56(5[AD]|6[1579]):/
+298.6 "--center--" sync / 1[56]:[^:]*:Fatebreaker:5908:/
+308.2 "Burnt Strike" sync / 1[56]:[^:]*:Fatebreaker:565[246]:/
+309.9 "Burnout/Blastburn" #sync / 1[56]:[^:]*:Fatebreaker:565[35]:/
+321.9 "Bound Of Faith" sync / 1[56]:[^:]*:Fatebreaker:565[8BF]:/
+325.6 "Sinsmoke/Sinsmite/Sinsight" sync / 1[56]:[^:]*:Fatebreaker:56(5[AD]|6[159]):/
+331.2 "Mortal Burn Mark?" # sync / 1[56]:[^:]*:Fatebreaker:5662:/
+336.9 "Elemental Break" sync / 1[56]:[^:]*:Fatebreaker:566[368]:/
+339.4 "Sinsmoke/Sinsmite/Sinsight" sync / 1[56]:[^:]*:Fatebreaker:56(5[AD]|6[1579]):/
 
 # dragon trio 2
-351.4 "Sundered Sky" sync / 1[56]:Fatebreaker:567[78]:/ window 50,50
+351.4 "Sundered Sky" sync / 1[56]:[^:]*:Fatebreaker:567[78]:/ window 50,50
 353.8 "--untargetable--"
-359.0 "Ageless Serpent" sync / 1[56]:Demi-Gukumatz:5687:/
-370.5 "Resounding Crack" sync / 1[56]:Demi-Gukumatz:5688:/
-372.5 "Sinsmoke" sync / 1[56]:Fatebreaker's Image:5681:/
-372.6 "Sinsight" sync / 1[56]:Fatebreaker's Image:5BC7:/
-376.5 "Burnt Strike" sync / 1[56]:Fatebreaker's Image:567D:/
-378.2 "Mortal Burn Mark" sync / 1[56]:Fatebreaker's Image:5BC8:/
-380.1 "Burnt Strike " sync / 1[56]:Fatebreaker's Image:567B:/
-381.6 "Shining Blade" sync / 1[56]:Fatebreaker's Image:567E:/
-381.8 "Burnout" sync / 1[56]:Fatebreaker's Image:567C:/
-383.6 "Burnt Strike" sync / 1[56]:Fatebreaker's Image:5679:/
-385.6 "Blastburn" sync / 1[56]:Fatebreaker's Image:567A:/
+359.0 "Ageless Serpent" sync / 1[56]:[^:]*:Demi-Gukumatz:5687:/
+370.5 "Resounding Crack" sync / 1[56]:[^:]*:Demi-Gukumatz:5688:/
+372.5 "Sinsmoke" sync / 1[56]:[^:]*:Fatebreaker's Image:5681:/
+372.6 "Sinsight" sync / 1[56]:[^:]*:Fatebreaker's Image:5BC7:/
+376.5 "Burnt Strike" sync / 1[56]:[^:]*:Fatebreaker's Image:567D:/
+378.2 "Mortal Burn Mark" sync / 1[56]:[^:]*:Fatebreaker's Image:5BC8:/
+380.1 "Burnt Strike " sync / 1[56]:[^:]*:Fatebreaker's Image:567B:/
+381.6 "Shining Blade" sync / 1[56]:[^:]*:Fatebreaker's Image:567E:/
+381.8 "Burnout" sync / 1[56]:[^:]*:Fatebreaker's Image:567C:/
+383.6 "Burnt Strike" sync / 1[56]:[^:]*:Fatebreaker's Image:5679:/
+385.6 "Blastburn" sync / 1[56]:[^:]*:Fatebreaker's Image:567A:/
 386.4 "--targetable--"
 
-397.1 "Elemental Break" sync / 1[56]:Fatebreaker:566[368]:/
-399.6 "Sinsight/Sinsmite" sync / 1[56]:Fatebreaker:566[579]:/
-409.6 "Burnished Glory" sync / 1[56]:Fatebreaker:56A4:/
+397.1 "Elemental Break" sync / 1[56]:[^:]*:Fatebreaker:566[368]:/
+399.6 "Sinsight/Sinsmite" sync / 1[56]:[^:]*:Fatebreaker:566[579]:/
+409.6 "Burnished Glory" sync / 1[56]:[^:]*:Fatebreaker:56A4:/
 
-427.1 "Turn Of The Heavens" sync / 1[56]:Fatebreaker:566[AB]:/ window 50,50
-429.6 "--center--" sync / 1[56]:Fatebreaker:5908:/
-438.6 "Elemental Break" sync / 1[56]:Fatebreaker:566[368]:/
-441.1 "Sinsmite/Sinsmoke" sync / 1[56]:Fatebreaker:56(5A|57|65|67):/
-450.6 "Powder Mark" sync / 1[56]:Fatebreaker:56A2:/
-458.1 "Right Of The Heavens" sync / 1[56]:Fatebreaker:566[EF]:/
-460.6 "--center--" sync / 1[56]:Fatebreaker:5908:/
-469.5 "Burn Mark" sync / 1[56]:Fatebreaker:56A3:/
-469.5 "Bound Of Faith" sync / 1[56]:Fatebreaker:565[8F]:/
-471.6 "Solemn Charge" # sync / 1[56]:Fatebreaker:56(59|60):/
-472.9 "Sinsight/Sinsmoke" # sync / 1[56]:Fatebreaker:56[56][159A]:/
-478.5 "Mortal Burn Mark?" # sync / 1[56]:Fatebreaker:5662:/
-488.3 "--center--" sync / 1[56]:Fatebreaker:5908:/
+427.1 "Turn Of The Heavens" sync / 1[56]:[^:]*:Fatebreaker:566[AB]:/ window 50,50
+429.6 "--center--" sync / 1[56]:[^:]*:Fatebreaker:5908:/
+438.6 "Elemental Break" sync / 1[56]:[^:]*:Fatebreaker:566[368]:/
+441.1 "Sinsmite/Sinsmoke" sync / 1[56]:[^:]*:Fatebreaker:56(5A|57|65|67):/
+450.6 "Powder Mark" sync / 1[56]:[^:]*:Fatebreaker:56A2:/
+458.1 "Right Of The Heavens" sync / 1[56]:[^:]*:Fatebreaker:566[EF]:/
+460.6 "--center--" sync / 1[56]:[^:]*:Fatebreaker:5908:/
+469.5 "Burn Mark" sync / 1[56]:[^:]*:Fatebreaker:56A3:/
+469.5 "Bound Of Faith" sync / 1[56]:[^:]*:Fatebreaker:565[8F]:/
+471.6 "Solemn Charge" # sync / 1[56]:[^:]*:Fatebreaker:56(59|60):/
+472.9 "Sinsight/Sinsmoke" # sync / 1[56]:[^:]*:Fatebreaker:56[56][159A]:/
+478.5 "Mortal Burn Mark?" # sync / 1[56]:[^:]*:Fatebreaker:5662:/
+488.3 "--center--" sync / 1[56]:[^:]*:Fatebreaker:5908:/
 
-493.7 "Prismatic Deception" sync / 1[56]:Fatebreaker:5672:/ window 493.7,10
+493.7 "Prismatic Deception" sync / 1[56]:[^:]*:Fatebreaker:5672:/ window 493.7,10
 496.8 "--untargetable--"
-513.9 "Blasting Zone" sync / 1[56]:Fatebreaker's Image:56A5:/
-532.0 "Blasting Zone" sync / 1[56]:Fatebreaker's Image:56A5:/
+513.9 "Blasting Zone" sync / 1[56]:[^:]*:Fatebreaker's Image:56A5:/
+532.0 "Blasting Zone" sync / 1[56]:[^:]*:Fatebreaker's Image:56A5:/
 537.9 "--targetable--"
-549.2 "Burnished Glory" sync / 1[56]:Fatebreaker:56A4:/ window 30,30
+549.2 "Burnished Glory" sync / 1[56]:[^:]*:Fatebreaker:56A4:/ window 30,30
 
 
-561.7 "--center--" sync / 1[56]:Fatebreaker:5908:/
-570.7 "Cycle Of Faith" sync / 1[56]:Fatebreaker:5692:/ jump 700
-570.7 "--sync--" sync / 1[56]:Fatebreaker:569A:/ jump 800
-570.7 "--sync--" sync / 1[56]:Fatebreaker:568B:/ jump 900
+561.7 "--center--" sync / 1[56]:[^:]*:Fatebreaker:5908:/
+570.7 "Cycle Of Faith" sync / 1[56]:[^:]*:Fatebreaker:5692:/ jump 700
+570.7 "--sync--" sync / 1[56]:[^:]*:Fatebreaker:569A:/ jump 800
+570.7 "--sync--" sync / 1[56]:[^:]*:Fatebreaker:568B:/ jump 900
 570.8 "Elemental Break"
 573.3 "Sinsight/Sinsmite/Sinsmoke"
 575.2 "Burnt Strike"
@@ -160,20 +160,20 @@ hideall "--sync--"
 
 
 # Lightning Cycle
-691.0 "--center--" sync / 1[56]:Fatebreaker:5908:/
-700.0 "Cycle Of Faith" sync / 1[56]:Fatebreaker:5692:/
-700.1 "Elemental Break" sync / 1[56]:Fatebreaker:5693:/
-702.7 "Sinsmite" sync / 1[56]:Fatebreaker:5694:/
-704.5 "Burnt Strike" sync / 1[56]:Fatebreaker:5695:/
-706.2 "Burnout" sync / 1[56]:Fatebreaker:5696:/
-711.6 "Solemn Charge" sync / 1[56]:Fatebreaker:5697:/
-713.1 "Sinsmite" sync / 1[56]:Fatebreaker:5698:/
-713.2 "--sync--" sync / 1[56]:Fatebreaker:5699:/
-725.7 "Burnished Glory" sync / 1[56]:Fatebreaker:56A4:/
+691.0 "--center--" sync / 1[56]:[^:]*:Fatebreaker:5908:/
+700.0 "Cycle Of Faith" sync / 1[56]:[^:]*:Fatebreaker:5692:/
+700.1 "Elemental Break" sync / 1[56]:[^:]*:Fatebreaker:5693:/
+702.7 "Sinsmite" sync / 1[56]:[^:]*:Fatebreaker:5694:/
+704.5 "Burnt Strike" sync / 1[56]:[^:]*:Fatebreaker:5695:/
+706.2 "Burnout" sync / 1[56]:[^:]*:Fatebreaker:5696:/
+711.6 "Solemn Charge" sync / 1[56]:[^:]*:Fatebreaker:5697:/
+713.1 "Sinsmite" sync / 1[56]:[^:]*:Fatebreaker:5698:/
+713.2 "--sync--" sync / 1[56]:[^:]*:Fatebreaker:5699:/
+725.7 "Burnished Glory" sync / 1[56]:[^:]*:Fatebreaker:56A4:/
 
-728.2 "--center--" sync / 1[56]:Fatebreaker:5908:/ window 30,30
-737.2 "Cycle Of Faith" sync / 1[56]:Fatebreaker:568A:/ jump 900.0
-737.2 "--sync--" sync / 1[56]:Fatebreaker:569A:/ jump 800.0
+728.2 "--center--" sync / 1[56]:[^:]*:Fatebreaker:5908:/ window 30,30
+737.2 "Cycle Of Faith" sync / 1[56]:[^:]*:Fatebreaker:568A:/ jump 900.0
+737.2 "--sync--" sync / 1[56]:[^:]*:Fatebreaker:569A:/ jump 800.0
 737.3 "Elemental Break"
 739.8 "Sinsight/Sinsmite/Sinsmoke"
 741.7 "Burnt Strike"
@@ -182,20 +182,20 @@ hideall "--sync--"
 
 
 # Holy Cycle
-791.0 "--center--" sync / 1[56]:Fatebreaker:5908:/
-800.0 "Cycle Of Faith" sync / 1[56]:Fatebreaker:569A:/
-800.1 "Elemental Break" sync / 1[56]:Fatebreaker:56[89]B:/
-802.7 "Sinsight" sync / 1[56]:Fatebreaker:569C:/
-804.5 "Burnt Strike" sync / 1[56]:Fatebreaker:569D:/
-809.5 "Shining Blade" sync / 1[56]:Fatebreaker:569E:/
-811.6 "Solemn Charge" sync / 1[56]:Fatebreaker:569F:/
-813.1 "Sinsight" sync / 1[56]:Fatebreaker:56A0:/
-818.7 "Mortal Burn Mark" sync / 1[56]:Fatebreaker:56A1:/
-825.7 "Burnished Glory" sync / 1[56]:Fatebreaker:56A4:/
+791.0 "--center--" sync / 1[56]:[^:]*:Fatebreaker:5908:/
+800.0 "Cycle Of Faith" sync / 1[56]:[^:]*:Fatebreaker:569A:/
+800.1 "Elemental Break" sync / 1[56]:[^:]*:Fatebreaker:56[89]B:/
+802.7 "Sinsight" sync / 1[56]:[^:]*:Fatebreaker:569C:/
+804.5 "Burnt Strike" sync / 1[56]:[^:]*:Fatebreaker:569D:/
+809.5 "Shining Blade" sync / 1[56]:[^:]*:Fatebreaker:569E:/
+811.6 "Solemn Charge" sync / 1[56]:[^:]*:Fatebreaker:569F:/
+813.1 "Sinsight" sync / 1[56]:[^:]*:Fatebreaker:56A0:/
+818.7 "Mortal Burn Mark" sync / 1[56]:[^:]*:Fatebreaker:56A1:/
+825.7 "Burnished Glory" sync / 1[56]:[^:]*:Fatebreaker:56A4:/
 
-828.2 "--center--" sync / 1[56]:Fatebreaker:5908:/ window 30,30
-837.2 "Cycle Of Faith" sync / 1[56]:Fatebreaker:5692:/ jump 700.0
-837.2 "--sync--" sync / 1[56]:Fatebreaker:568A:/ jump 900.0
+828.2 "--center--" sync / 1[56]:[^:]*:Fatebreaker:5908:/ window 30,30
+837.2 "Cycle Of Faith" sync / 1[56]:[^:]*:Fatebreaker:5692:/ jump 700.0
+837.2 "--sync--" sync / 1[56]:[^:]*:Fatebreaker:568A:/ jump 900.0
 837.3 "Elemental Break"
 839.8 "Sinsight/Sinsmite/Sinsmoke"
 841.7 "Burnt Strike"
@@ -203,19 +203,19 @@ hideall "--sync--"
 846.7 "Shining Blade?"
 
 # Fire Cycle
-891.0 "--center--" sync / 1[56]:Fatebreaker:5908:/
-900.0 "Cycle Of Faith" sync / 1[56]:Fatebreaker:568A:/
-900.1 "Elemental Break" sync / 1[56]:Fatebreaker:568B:/
-902.7 "Sinsmoke" sync / 1[56]:Fatebreaker:568D:/
-904.5 "Burnt Strike" sync / 1[56]:Fatebreaker:568E:/
-906.5 "Blastburn" sync / 1[56]:Fatebreaker:568F:/
-911.6 "Solemn Charge" sync / 1[56]:Fatebreaker:5690:/
-913.1 "Sinsmoke" sync / 1[56]:Fatebreaker:5691:/
-925.7 "Burnished Glory" sync / 1[56]:Fatebreaker:56A4:/
+891.0 "--center--" sync / 1[56]:[^:]*:Fatebreaker:5908:/
+900.0 "Cycle Of Faith" sync / 1[56]:[^:]*:Fatebreaker:568A:/
+900.1 "Elemental Break" sync / 1[56]:[^:]*:Fatebreaker:568B:/
+902.7 "Sinsmoke" sync / 1[56]:[^:]*:Fatebreaker:568D:/
+904.5 "Burnt Strike" sync / 1[56]:[^:]*:Fatebreaker:568E:/
+906.5 "Blastburn" sync / 1[56]:[^:]*:Fatebreaker:568F:/
+911.6 "Solemn Charge" sync / 1[56]:[^:]*:Fatebreaker:5690:/
+913.1 "Sinsmoke" sync / 1[56]:[^:]*:Fatebreaker:5691:/
+925.7 "Burnished Glory" sync / 1[56]:[^:]*:Fatebreaker:56A4:/
 
-928.2 "--center--" sync / 1[56]:Fatebreaker:5908:/ window 30,30
-937.2 "Cycle Of Faith" sync / 1[56]:Fatebreaker:5692:/ jump 700
-937.2 "--sync--" sync / 1[56]:Fatebreaker:569A:/ jump 800
+928.2 "--center--" sync / 1[56]:[^:]*:Fatebreaker:5908:/ window 30,30
+937.2 "Cycle Of Faith" sync / 1[56]:[^:]*:Fatebreaker:5692:/ jump 700
+937.2 "--sync--" sync / 1[56]:[^:]*:Fatebreaker:569A:/ jump 800
 937.3 "Elemental Break"
 939.8 "Sinsight/Sinsmite/Sinsmoke"
 941.7 "Burnt Strike"
@@ -223,5 +223,5 @@ hideall "--sync--"
 946.7 "Shining Blade?"
 
 
-992.3 "Burnished Glory" sync / 14:Fatebreaker:5529:/ window 1000,0
-1000.0 "Burnished Glory Enrage" sync / 1[56]:Fatebreaker:5529:/
+992.3 "Burnished Glory" sync / 14:[^:]*:Fatebreaker:5529:/ window 1000,0
+1000.0 "Burnished Glory Enrage" sync / 1[56]:[^:]*:Fatebreaker:5529:/

--- a/ui/raidboss/data/05-shb/raid/e12n.txt
+++ b/ui/raidboss/data/05-shb/raid/e12n.txt
@@ -11,55 +11,55 @@ hideall "--sync--"
 
 
 0.0 "--sync--" sync /:Engage!/ window 0,1
-1.0 "--sync--" sync / 1[56]:Eden's Promise:4B1D:/ window 1,1
-14.9 "Maleficium" sync / 1[56]:Eden's Promise:5872:/ window 14.9,5
-22.1 "--sync--" sync / 1[56]:Eden's Promise:5879:/
-25.3 "Initialize Recall" sync / 1[56]:Eden's Promise:5859:/
-34.9 "Judgment Jolt" sync / 1[56]:Eden's Promise:585F:/
-45.6 "Temporary Current" sync / 1[56]:Eden's Promise:585C:/
-56.3 "Judgment Jolt" sync / 1[56]:Eden's Promise:585F:/
-67.0 "Temporary Current" sync / 1[56]:Eden's Promise:585C:/
-80.0 "Formless Judgment" sync / 1[56]:Eden's Promise:5873:/
-87.3 "--sync--" sync / 1[56]:Eden's Promise:5879:/
-96.7 "Conflag Strike" sync / 1[56]:Eden's Promise:585D:/
-107.4 "Ferostorm" sync / 1[56]:Eden's Promise:585E:/
-118.1 "Conflag Strike" sync / 1[56]:Eden's Promise:585D:/
-128.7 "Ferostorm" sync / 1[56]:Eden's Promise:585E:/
-140.1 "Maleficium" sync / 1[56]:Eden's Promise:5872:/
-145.9 "--sync--" sync / 1[56]:Eden's Promise:585A:/ window 145.9
+1.0 "--sync--" sync / 1[56]:[^:]*:Eden's Promise:4B1D:/ window 1,1
+14.9 "Maleficium" sync / 1[56]:[^:]*:Eden's Promise:5872:/ window 14.9,5
+22.1 "--sync--" sync / 1[56]:[^:]*:Eden's Promise:5879:/
+25.3 "Initialize Recall" sync / 1[56]:[^:]*:Eden's Promise:5859:/
+34.9 "Judgment Jolt" sync / 1[56]:[^:]*:Eden's Promise:585F:/
+45.6 "Temporary Current" sync / 1[56]:[^:]*:Eden's Promise:585C:/
+56.3 "Judgment Jolt" sync / 1[56]:[^:]*:Eden's Promise:585F:/
+67.0 "Temporary Current" sync / 1[56]:[^:]*:Eden's Promise:585C:/
+80.0 "Formless Judgment" sync / 1[56]:[^:]*:Eden's Promise:5873:/
+87.3 "--sync--" sync / 1[56]:[^:]*:Eden's Promise:5879:/
+96.7 "Conflag Strike" sync / 1[56]:[^:]*:Eden's Promise:585D:/
+107.4 "Ferostorm" sync / 1[56]:[^:]*:Eden's Promise:585E:/
+118.1 "Conflag Strike" sync / 1[56]:[^:]*:Eden's Promise:585D:/
+128.7 "Ferostorm" sync / 1[56]:[^:]*:Eden's Promise:585E:/
+140.1 "Maleficium" sync / 1[56]:[^:]*:Eden's Promise:5872:/
+145.9 "--sync--" sync / 1[56]:[^:]*:Eden's Promise:585A:/ window 145.9
 148.4 "--untargetable--"
 
 # Intermission. Can be pushed, unknown threshold, maybe 70% HP?
-196.5 "Eternal Oblivion" sync / 1[56]:Eden's Promise:587A:/ window 200,10
-204.3 "--sync--" sync / 1[56]:Eden's Promise:4B20:/
-232.9 "Earth Shaker" sync / 1[56]:Eden's Promise:5885:/
-232.9 "Obliteration" sync / 1[56]:Eden's Promise:4B43:/
-251.2 "Eternal Oblivion" sync / 1[56]:Eden's Promise:587B:/ window 20,20
-259.0 "--sync--" sync / 1[56]:Eden's Promise:4B21:/
-267.3 "Classical Sculpture" sync / 1[56]:Chiseled Sculpture:5886:/
-290.2 "Rapturous Reach" sync / 1[56]:Eden's Promise:5889:/
-290.2 "Palm Of Temperance" sync / 1[56]:Eden's Promise:4B44:/
-308.4 "Eternal Oblivion" sync / 1[56]:Eden's Promise:587C:/ window 20,20
-316.2 "--sync--" sync / 1[56]:Eden's Promise:4B22:/
-337.5 "Laser Eye" sync / 1[56]:Eden's Promise:4B47:/
-356.3 "Eternal Oblivion" sync / 1[56]:Eden's Promise:587D:/ window 20,20
-364.1 "--sync--" sync / 1[56]:Eden's Promise:4B23:/
+196.5 "Eternal Oblivion" sync / 1[56]:[^:]*:Eden's Promise:587A:/ window 200,10
+204.3 "--sync--" sync / 1[56]:[^:]*:Eden's Promise:4B20:/
+232.9 "Earth Shaker" sync / 1[56]:[^:]*:Eden's Promise:5885:/
+232.9 "Obliteration" sync / 1[56]:[^:]*:Eden's Promise:4B43:/
+251.2 "Eternal Oblivion" sync / 1[56]:[^:]*:Eden's Promise:587B:/ window 20,20
+259.0 "--sync--" sync / 1[56]:[^:]*:Eden's Promise:4B21:/
+267.3 "Classical Sculpture" sync / 1[56]:[^:]*:Chiseled Sculpture:5886:/
+290.2 "Rapturous Reach" sync / 1[56]:[^:]*:Eden's Promise:5889:/
+290.2 "Palm Of Temperance" sync / 1[56]:[^:]*:Eden's Promise:4B44:/
+308.4 "Eternal Oblivion" sync / 1[56]:[^:]*:Eden's Promise:587C:/ window 20,20
+316.2 "--sync--" sync / 1[56]:[^:]*:Eden's Promise:4B22:/
+337.5 "Laser Eye" sync / 1[56]:[^:]*:Eden's Promise:4B47:/
+356.3 "Eternal Oblivion" sync / 1[56]:[^:]*:Eden's Promise:587D:/ window 20,20
+364.1 "--sync--" sync / 1[56]:[^:]*:Eden's Promise:4B23:/
 
 
 # Post-intermission initial block.
-500.0 "--sync--" sync / 14:Eden's Promise:4B48:/ window 500,10
-504.9 "Paradise Lost" sync / 1[56]:Eden's Promise:4B48:/
+500.0 "--sync--" sync / 14:[^:]*:Eden's Promise:4B48:/ window 500,10
+504.9 "Paradise Lost" sync / 1[56]:[^:]*:Eden's Promise:4B48:/
 511.9 "--targetable--"
-522.0 "Initialize Recall" sync / 1[56]:Eden's Promise:5859:/ window 30,30
-534.1 "Stock" sync / 1[56]:Eden's Promise:5860:/
-542.8 "Formless Judgment" sync / 1[56]:Eden's Promise:5873:/ window 30,30
-545.6 "--sync--" sync / 1[56]:Eden's Promise:5879:/
-555.7 "Release" sync / 1[56]:Eden's Promise:5861:/
+522.0 "Initialize Recall" sync / 1[56]:[^:]*:Eden's Promise:5859:/ window 30,30
+534.1 "Stock" sync / 1[56]:[^:]*:Eden's Promise:5860:/
+542.8 "Formless Judgment" sync / 1[56]:[^:]*:Eden's Promise:5873:/ window 30,30
+545.6 "--sync--" sync / 1[56]:[^:]*:Eden's Promise:5879:/
+555.7 "Release" sync / 1[56]:[^:]*:Eden's Promise:5861:/
 
 
-568.6 "Stock" sync / 1[56]:Eden's Promise:5860:/ window 15,30
-578.3 "Junction Shiva?" sync / 1[56]:Eden's Promise:5862:/ jump 700.0
-578.3 "Junction Titan?" sync / 1[56]:Eden's Promise:5863:/ jump 800.0
+568.6 "Stock" sync / 1[56]:[^:]*:Eden's Promise:5860:/ window 15,30
+578.3 "Junction Shiva?" sync / 1[56]:[^:]*:Eden's Promise:5862:/ jump 700.0
+578.3 "Junction Titan?" sync / 1[56]:[^:]*:Eden's Promise:5863:/ jump 800.0
 589.0 "Diamond Dust?"
 589.0 "Earthen Fury?"
 594.0 "Impact 1?"
@@ -82,20 +82,20 @@ hideall "--sync--"
 # The time between Release and Stock is consistent at 14 seconds.
 
 # Shiva Block
-690.4 "Stock" sync / 1[56]:Eden's Promise:5860:/
-700.0 "Junction Shiva" sync / 1[56]:Eden's Promise:5862:/
-710.7 "Diamond Dust" sync / 1[56]:Eden's Promise:5864:/ window 30,30
-716.8 "--sync--" sync / 1[56]:Eden's Promise:5866:/
-721.9 "Frigid Stone" sync / 1[56]:Eden's Promise:5867:/
-727.9 "Ice Floe" sync / 1[56]:Eden's Promise:5868:/
-732.9 "Rapturous Reach" sync / 1[56]:Eden's Promise:587[78]:/ window 30,30
-735.4 "Frigid Stone" # sync / 1[56]:Eden's Promise:5869:/
-735.6 "--sync--" sync / 1[56]:Eden's Promise:5871:/
-738.2 "--sync--" sync / 1[56]:Eden's Promise:5879:/
-747.6 "Release" sync / 1[56]:Eden's Promise:5861:/
+690.4 "Stock" sync / 1[56]:[^:]*:Eden's Promise:5860:/
+700.0 "Junction Shiva" sync / 1[56]:[^:]*:Eden's Promise:5862:/
+710.7 "Diamond Dust" sync / 1[56]:[^:]*:Eden's Promise:5864:/ window 30,30
+716.8 "--sync--" sync / 1[56]:[^:]*:Eden's Promise:5866:/
+721.9 "Frigid Stone" sync / 1[56]:[^:]*:Eden's Promise:5867:/
+727.9 "Ice Floe" sync / 1[56]:[^:]*:Eden's Promise:5868:/
+732.9 "Rapturous Reach" sync / 1[56]:[^:]*:Eden's Promise:587[78]:/ window 30,30
+735.4 "Frigid Stone" # sync / 1[56]:[^:]*:Eden's Promise:5869:/
+735.6 "--sync--" sync / 1[56]:[^:]*:Eden's Promise:5871:/
+738.2 "--sync--" sync / 1[56]:[^:]*:Eden's Promise:5879:/
+747.6 "Release" sync / 1[56]:[^:]*:Eden's Promise:5861:/
 
-756.6 "--sync--" sync / 1[56]:Eden's Promise:5879:/ jump 900.0
-761.5 "Stock?" sync / 1[56]:Eden's Promise:5860:/ jump 1000.0
+756.6 "--sync--" sync / 1[56]:[^:]*:Eden's Promise:5879:/ jump 900.0
+761.5 "Stock?" sync / 1[56]:[^:]*:Eden's Promise:5860:/ jump 1000.0
 766.2 "Cast?"
 770.2 "Formless Judgment?"
 776.9 "Cast?"
@@ -104,21 +104,21 @@ hideall "--sync--"
 
 
 # Titan Block
-790.3 "Stock" sync / 1[56]:Eden's Promise:5860:/
-800.0 "Junction Titan" sync / 1[56]:Eden's Promise:5863:/
-810.7 "Earthen Fury" sync / 1[56]:Eden's Promise:586A:/ window 30,30
-815.7 "Impact 1" sync / 1[56]:Titanic Bomb Boulder:586E:/
-818.7 "Impact 2" # sync / 1[56]:Bomb Boulder:586C:/
-822.7 "Explosion 1" sync / 1[56]:Titanic Bomb Boulder:586F:/
-825.7 "Explosion 2" # sync / 1[56]:Bomb Boulder:586D:/
-831.7 "Rapturous Reach" sync / 1[56]:Eden's Promise:587[78]:/ window 30,30
-834.2 "Under The Weight" sync / 1[56]:Eden's Promise:5870:/
-834.3 "--sync--" sync / 1[56]:Eden's Promise:5871:/
-836.9 "--sync--" sync / 1[56]:Eden's Promise:5879:/
-846.3 "Release" sync / 1[56]:Eden's Promise:5861:/
+790.3 "Stock" sync / 1[56]:[^:]*:Eden's Promise:5860:/
+800.0 "Junction Titan" sync / 1[56]:[^:]*:Eden's Promise:5863:/
+810.7 "Earthen Fury" sync / 1[56]:[^:]*:Eden's Promise:586A:/ window 30,30
+815.7 "Impact 1" sync / 1[56]:[^:]*:Titanic Bomb Boulder:586E:/
+818.7 "Impact 2" # sync / 1[56]:[^:]*:Bomb Boulder:586C:/
+822.7 "Explosion 1" sync / 1[56]:[^:]*:Titanic Bomb Boulder:586F:/
+825.7 "Explosion 2" # sync / 1[56]:[^:]*:Bomb Boulder:586D:/
+831.7 "Rapturous Reach" sync / 1[56]:[^:]*:Eden's Promise:587[78]:/ window 30,30
+834.2 "Under The Weight" sync / 1[56]:[^:]*:Eden's Promise:5870:/
+834.3 "--sync--" sync / 1[56]:[^:]*:Eden's Promise:5871:/
+836.9 "--sync--" sync / 1[56]:[^:]*:Eden's Promise:5879:/
+846.3 "Release" sync / 1[56]:[^:]*:Eden's Promise:5861:/
 
-855.3 "--sync--" sync / 1[56]:Eden's Promise:5879:/ jump 900.0
-860.2 "Stock?" sync / 1[56]:Eden's Promise:5860:/ jump 1000.0
+855.3 "--sync--" sync / 1[56]:[^:]*:Eden's Promise:5879:/ jump 900.0
+860.2 "Stock?" sync / 1[56]:[^:]*:Eden's Promise:5860:/ jump 1000.0
 864.9 "Cast?"
 868.9 "Formless Judgment?"
 875.6 "Cast?"
@@ -126,14 +126,14 @@ hideall "--sync--"
 883.3 "Maleficium?"
 
 # Maleficium Block
-900.0 "--sync--" sync / 1[56]:Eden's Promise:5879:/
-909.6 "Cast" sync / 1[56]:Eden's Promise:4E2C:/
-920.3 "Cast" sync / 1[56]:Eden's Promise:4E2C:/
-928.0 "Maleficium" sync / 1[56]:Eden's Promise:5872:/ window 15,15
+900.0 "--sync--" sync / 1[56]:[^:]*:Eden's Promise:5879:/
+909.6 "Cast" sync / 1[56]:[^:]*:Eden's Promise:4E2C:/
+920.3 "Cast" sync / 1[56]:[^:]*:Eden's Promise:4E2C:/
+928.0 "Maleficium" sync / 1[56]:[^:]*:Eden's Promise:5872:/ window 15,15
 
-940.9 "Stock" sync / 1[56]:Eden's Promise:5860:/
-950.5 "Junction Shiva?" sync / 1[56]:Eden's Promise:5862:/ window 15,15 jump 700.0
-950.5 "Junction Titan?" sync / 1[56]:Eden's Promise:5863:/ window 15,15 jump 800.0
+940.9 "Stock" sync / 1[56]:[^:]*:Eden's Promise:5860:/
+950.5 "Junction Shiva?" sync / 1[56]:[^:]*:Eden's Promise:5862:/ window 15,15 jump 700.0
+950.5 "Junction Titan?" sync / 1[56]:[^:]*:Eden's Promise:5863:/ window 15,15 jump 800.0
 961.2 "Diamond Dust?"
 961.2 "Earthen Fury?"
 966.2 "Impact 1?"
@@ -143,14 +143,14 @@ hideall "--sync--"
 
 
 # Formless Judgment Block
-1000.0 "Stock" sync / 1[56]:Eden's Promise:5860:/
-1008.7 "Formless Judgment" sync / 1[56]:Eden's Promise:5873:/ window 15,15
-1011.5 "--sync--" sync / 1[56]:Eden's Promise:5879:/
-1020.9 "Release" sync / 1[56]:Eden's Promise:5861:/
+1000.0 "Stock" sync / 1[56]:[^:]*:Eden's Promise:5860:/
+1008.7 "Formless Judgment" sync / 1[56]:[^:]*:Eden's Promise:5873:/ window 15,15
+1011.5 "--sync--" sync / 1[56]:[^:]*:Eden's Promise:5879:/
+1020.9 "Release" sync / 1[56]:[^:]*:Eden's Promise:5861:/
 
-1034.8 "Stock" sync / 1[56]:Eden's Promise:5860:/
-1044.4 "Junction Shiva?" sync / 1[56]:Eden's Promise:5862:/ jump 700.0
-1044.4 "Junction Titan?" sync / 1[56]:Eden's Promise:5863:/ jump 800.0
+1034.8 "Stock" sync / 1[56]:[^:]*:Eden's Promise:5860:/
+1044.4 "Junction Shiva?" sync / 1[56]:[^:]*:Eden's Promise:5862:/ jump 700.0
+1044.4 "Junction Titan?" sync / 1[56]:[^:]*:Eden's Promise:5863:/ jump 800.0
 1055.1 "Diamond Dust?"
 1055.1 "Earthen Fury?"
 1060.1 "Impact 1?"

--- a/ui/raidboss/data/05-shb/raid/e12s.txt
+++ b/ui/raidboss/data/05-shb/raid/e12s.txt
@@ -11,106 +11,106 @@ hideall "--sync--"
 # -p 58A8:16
 
 0 "Start"
-0.8 "--sync--" sync / 1[56]:Eden's Promise:4B1E:/ window 1,0
-11.0 "--sync--" sync / 14:Eden's Promise:58A8:/ window 11,20
-16.0 "Maleficium" sync / 1[56]:Eden's Promise:58A8:/
-23.2 "--middle--" sync / 1[56]:Eden's Promise:58AF:/
-25.8 "Initialize Recall" sync / 1[56]:Eden's Promise:588C:/
-32.4 "Junction Shiva/Titan" sync / 1[56]:Eden's Promise:589[45]:/
-40.1 "Rapturous Reach" sync / 1[56]:Eden's Promise:58A[DE]:/
-43.6 "Frigid Stone/Under The Weight" sync / 1[56]:Eden's Promise:(589E|58A6):/
-53.3 "Cast" sync / 1[56]:Eden's Promise:4E43:/
-56.8 "Frigid Stone/Under The Weight" sync / 1[56]:Eden's Promise:(589E|58A6):/
-57.5 "--sync--" sync / 1[56]:Eden's Promise:58A7:/
-68.7 "Formless Judgment" sync / 1[56]:Eden's Promise:58A9:/
-#69.0 "Formless Judgment" sync / 1[56]:Eden's Promise:58AC:/
-71.4 "Formless Judgment" #sync / 1[56]:Eden's Promise:58AC:/
-81.9 "Maleficium" sync / 1[56]:Eden's Promise:58A8:/
-90.2 "--middle--" sync / 1[56]:Eden's Promise:58AF:/
+0.8 "--sync--" sync / 1[56]:[^:]*:Eden's Promise:4B1E:/ window 1,0
+11.0 "--sync--" sync / 14:[^:]*:Eden's Promise:58A8:/ window 11,20
+16.0 "Maleficium" sync / 1[56]:[^:]*:Eden's Promise:58A8:/
+23.2 "--middle--" sync / 1[56]:[^:]*:Eden's Promise:58AF:/
+25.8 "Initialize Recall" sync / 1[56]:[^:]*:Eden's Promise:588C:/
+32.4 "Junction Shiva/Titan" sync / 1[56]:[^:]*:Eden's Promise:589[45]:/
+40.1 "Rapturous Reach" sync / 1[56]:[^:]*:Eden's Promise:58A[DE]:/
+43.6 "Frigid Stone/Under The Weight" sync / 1[56]:[^:]*:Eden's Promise:(589E|58A6):/
+53.3 "Cast" sync / 1[56]:[^:]*:Eden's Promise:4E43:/
+56.8 "Frigid Stone/Under The Weight" sync / 1[56]:[^:]*:Eden's Promise:(589E|58A6):/
+57.5 "--sync--" sync / 1[56]:[^:]*:Eden's Promise:58A7:/
+68.7 "Formless Judgment" sync / 1[56]:[^:]*:Eden's Promise:58A9:/
+#69.0 "Formless Judgment" sync / 1[56]:[^:]*:Eden's Promise:58AC:/
+71.4 "Formless Judgment" #sync / 1[56]:[^:]*:Eden's Promise:58AC:/
+81.9 "Maleficium" sync / 1[56]:[^:]*:Eden's Promise:58A8:/
+90.2 "--middle--" sync / 1[56]:[^:]*:Eden's Promise:58AF:/
 
-95.6 "Junction Shiva" sync / 1[56]:Eden's Promise:5894:/
-106.5 "Diamond Dust" sync / 1[56]:Eden's Promise:5896:/
-112.6 "--sync--" sync / 1[56]:Eden's Promise:5898:/
-118.8 "Ice Floe" sync / 1[56]:Eden's Promise:5899:/
-125.8 "Ice Pillar" sync / 1[56]:Ice Pillar:589A:/
-137.8 "Plunging Ice" sync / 1[56]:Eden's Promise:589D:/
-141.8 "Pillar Pierce" sync / 1[56]:Ice Pillar:4B3F:/
-143.9 "--sync--" sync / 1[56]:Eden's Promise:58A7:/
-155.0 "Maleficium" sync / 1[56]:Eden's Promise:58A8:/
+95.6 "Junction Shiva" sync / 1[56]:[^:]*:Eden's Promise:5894:/
+106.5 "Diamond Dust" sync / 1[56]:[^:]*:Eden's Promise:5896:/
+112.6 "--sync--" sync / 1[56]:[^:]*:Eden's Promise:5898:/
+118.8 "Ice Floe" sync / 1[56]:[^:]*:Eden's Promise:5899:/
+125.8 "Ice Pillar" sync / 1[56]:[^:]*:Ice Pillar:589A:/
+137.8 "Plunging Ice" sync / 1[56]:[^:]*:Eden's Promise:589D:/
+141.8 "Pillar Pierce" sync / 1[56]:[^:]*:Ice Pillar:4B3F:/
+143.9 "--sync--" sync / 1[56]:[^:]*:Eden's Promise:58A7:/
+155.0 "Maleficium" sync / 1[56]:[^:]*:Eden's Promise:58A8:/
 
-163.3 "--middle--" sync / 1[56]:Eden's Promise:58AF:/
-168.7 "Junction Titan" sync / 1[56]:Eden's Promise:5895:/
-179.6 "Earthen Fury" sync / 1[56]:Eden's Promise:589F:/
+163.3 "--middle--" sync / 1[56]:[^:]*:Eden's Promise:58AF:/
+168.7 "Junction Titan" sync / 1[56]:[^:]*:Eden's Promise:5895:/
+179.6 "Earthen Fury" sync / 1[56]:[^:]*:Eden's Promise:589F:/
 
-184.6 "Impact" sync / 1[56]:Bomb Boulder:58A1:/
-193.3 "Pulse Of The Land" sync / 1[56]:Eden's Promise:58A3:/
-193.3 "Force Of The Land" sync / 1[56]:Eden's Promise:58A4:/
-193.3 "Weight Of The World" sync / 1[56]:Eden's Promise:58A5:/
+184.6 "Impact" sync / 1[56]:[^:]*:Bomb Boulder:58A1:/
+193.3 "Pulse Of The Land" sync / 1[56]:[^:]*:Eden's Promise:58A3:/
+193.3 "Force Of The Land" sync / 1[56]:[^:]*:Eden's Promise:58A4:/
+193.3 "Weight Of The World" sync / 1[56]:[^:]*:Eden's Promise:58A5:/
 
-197.8 "Impact" sync / 1[56]:Bomb Boulder:58A1:/
-206.4 "Force Of The Land" sync / 1[56]:Eden's Promise:58A4:/
-206.4 "Weight Of The World" sync / 1[56]:Eden's Promise:58A5:/
+197.8 "Impact" sync / 1[56]:[^:]*:Bomb Boulder:58A1:/
+206.4 "Force Of The Land" sync / 1[56]:[^:]*:Eden's Promise:58A4:/
+206.4 "Weight Of The World" sync / 1[56]:[^:]*:Eden's Promise:58A5:/
 
-210.9 "Impact" sync / 1[56]:Bomb Boulder:58A1:/
-219.5 "Pulse Of The Land" sync / 1[56]:Eden's Promise:58A3:/
-219.5 "Force Of The Land" sync / 1[56]:Eden's Promise:58A4:/
-219.5 "Weight Of The World" sync / 1[56]:Eden's Promise:58A5:/
+210.9 "Impact" sync / 1[56]:[^:]*:Bomb Boulder:58A1:/
+219.5 "Pulse Of The Land" sync / 1[56]:[^:]*:Eden's Promise:58A3:/
+219.5 "Force Of The Land" sync / 1[56]:[^:]*:Eden's Promise:58A4:/
+219.5 "Weight Of The World" sync / 1[56]:[^:]*:Eden's Promise:58A5:/
 
-222.0 "--sync--" sync / 1[56]:Eden's Promise:58A7:/
-239.2 "Maleficium" sync / 1[56]:Eden's Promise:58A8:/
-248.4 "--middle--" sync / 1[56]:Eden's Promise:58AF:/
-258.5 "Cast" sync / 1[56]:Eden's Promise:4E43:/
-259.6 "Obliteration Laser" sync / 1[56]:Guardian Of Eden:4E36:/
-269.8 "Maleficium" sync / 1[56]:Eden's Promise:58A8:/
+222.0 "--sync--" sync / 1[56]:[^:]*:Eden's Promise:58A7:/
+239.2 "Maleficium" sync / 1[56]:[^:]*:Eden's Promise:58A8:/
+248.4 "--middle--" sync / 1[56]:[^:]*:Eden's Promise:58AF:/
+258.5 "Cast" sync / 1[56]:[^:]*:Eden's Promise:4E43:/
+259.6 "Obliteration Laser" sync / 1[56]:[^:]*:Guardian Of Eden:4E36:/
+269.8 "Maleficium" sync / 1[56]:[^:]*:Eden's Promise:58A8:/
 
-283.0 "Stock" sync / 1[56]:Eden's Promise:5892:/
-288.1 "Classical Sculpture" sync / 1[56]:Chiseled Sculpture:58B2:/
-298.8 "Blade Of Flame 1" #sync / 1[56]:Chiseled Sculpture:58B3:/
-299.2 "Rapturous Reach" sync / 1[56]:Eden's Promise:58A[DE]:/
-301.9 "Blade Of Flame 2" #sync / 1[56]:Chiseled Sculpture:58B3:/
-305.0 "Blade Of Flame 3" #sync / 1[56]:Chiseled Sculpture:58B3:/
-307.1 "--sync--" sync / 1[56]:Eden's Promise:58AF:/
-308.0 "Blade Of Flame 4" #sync / 1[56]:Chiseled Sculpture:58B3:/
-310.2 "Palm Of Temperance" sync / 1[56]:Eden's Promise:58B6:/
-316.5 "Release" sync / 1[56]:Eden's Promise:5893:/
-327.7 "Maleficium" sync / 1[56]:Eden's Promise:58A8:/
+283.0 "Stock" sync / 1[56]:[^:]*:Eden's Promise:5892:/
+288.1 "Classical Sculpture" sync / 1[56]:[^:]*:Chiseled Sculpture:58B2:/
+298.8 "Blade Of Flame 1" #sync / 1[56]:[^:]*:Chiseled Sculpture:58B3:/
+299.2 "Rapturous Reach" sync / 1[56]:[^:]*:Eden's Promise:58A[DE]:/
+301.9 "Blade Of Flame 2" #sync / 1[56]:[^:]*:Chiseled Sculpture:58B3:/
+305.0 "Blade Of Flame 3" #sync / 1[56]:[^:]*:Chiseled Sculpture:58B3:/
+307.1 "--sync--" sync / 1[56]:[^:]*:Eden's Promise:58AF:/
+308.0 "Blade Of Flame 4" #sync / 1[56]:[^:]*:Chiseled Sculpture:58B3:/
+310.2 "Palm Of Temperance" sync / 1[56]:[^:]*:Eden's Promise:58B6:/
+316.5 "Release" sync / 1[56]:[^:]*:Eden's Promise:5893:/
+327.7 "Maleficium" sync / 1[56]:[^:]*:Eden's Promise:58A8:/
 
-335.4 "Formless Judgment" sync / 1[56]:Eden's Promise:58A9:/
-#335.7 "Formless Judgment" sync / 1[56]:Eden's Promise:58AC:/
-338.1 "Formless Judgment" #sync / 1[56]:Eden's Promise:58AC:/
+335.4 "Formless Judgment" sync / 1[56]:[^:]*:Eden's Promise:58A9:/
+#335.7 "Formless Judgment" sync / 1[56]:[^:]*:Eden's Promise:58AC:/
+338.1 "Formless Judgment" #sync / 1[56]:[^:]*:Eden's Promise:58AC:/
 
-352.1 "Stock" sync / 1[56]:Eden's Promise:5892:/
-362.3 "Rapturous Reach" sync / 1[56]:Eden's Promise:58A[DE]:/
-365.4 "Lionsblaze 1" sync / 1[56]:Beastly Sculpture:58B9:/
-369.5 "--sync--" sync / 1[56]:Eden's Promise:58AF:/
-370.3 "Laser Eye" sync / 1[56]:Guardian Of Eden:58B7:/
-374.5 "Lionsblaze 2" sync / 1[56]:Beastly Sculpture:58B9:/
-379.7 "Release" sync / 1[56]:Eden's Promise:5893:/
-383.8 "Lionsblaze 3" sync / 1[56]:Beastly Sculpture:58B9:/
-388.9 "Rapturous Reach" sync / 1[56]:Eden's Promise:58A[DE]:/
-401.7 "Maleficium" sync / 1[56]:Eden's Promise:58A8:/
+352.1 "Stock" sync / 1[56]:[^:]*:Eden's Promise:5892:/
+362.3 "Rapturous Reach" sync / 1[56]:[^:]*:Eden's Promise:58A[DE]:/
+365.4 "Lionsblaze 1" sync / 1[56]:[^:]*:Beastly Sculpture:58B9:/
+369.5 "--sync--" sync / 1[56]:[^:]*:Eden's Promise:58AF:/
+370.3 "Laser Eye" sync / 1[56]:[^:]*:Guardian Of Eden:58B7:/
+374.5 "Lionsblaze 2" sync / 1[56]:[^:]*:Beastly Sculpture:58B9:/
+379.7 "Release" sync / 1[56]:[^:]*:Eden's Promise:5893:/
+383.8 "Lionsblaze 3" sync / 1[56]:[^:]*:Beastly Sculpture:58B9:/
+388.9 "Rapturous Reach" sync / 1[56]:[^:]*:Eden's Promise:58A[DE]:/
+401.7 "Maleficium" sync / 1[56]:[^:]*:Eden's Promise:58A8:/
 
-414.9 "Stock" sync / 1[56]:Eden's Promise:5892:/
-418.2 "--middle--" sync / 1[56]:Eden's Promise:58AF:/
-424.3 "Junction Shiva/Titan" sync / 1[56]:Eden's Promise:589[45]:/
-434.0 "Cast" sync / 1[56]:Eden's Promise:4E43:/
-437.5 "Frigid Stone/Under The Weight" sync / 1[56]:Eden's Promise:(589E|58A6):/
-438.2 "--sync--" sync / 1[56]:Eden's Promise:58A7:/
-445.8 "Maleficium" sync / 1[56]:Eden's Promise:58A8:/
+414.9 "Stock" sync / 1[56]:[^:]*:Eden's Promise:5892:/
+418.2 "--middle--" sync / 1[56]:[^:]*:Eden's Promise:58AF:/
+424.3 "Junction Shiva/Titan" sync / 1[56]:[^:]*:Eden's Promise:589[45]:/
+434.0 "Cast" sync / 1[56]:[^:]*:Eden's Promise:4E43:/
+437.5 "Frigid Stone/Under The Weight" sync / 1[56]:[^:]*:Eden's Promise:(589E|58A6):/
+438.2 "--sync--" sync / 1[56]:[^:]*:Eden's Promise:58A7:/
+445.8 "Maleficium" sync / 1[56]:[^:]*:Eden's Promise:58A8:/
 
-453.0 "Junction Shiva/Titan" sync / 1[56]:Eden's Promise:589[45]:/
-462.7 "Release" sync / 1[56]:Eden's Promise:5893:/
-466.2 "Frigid Stone/Under The Weight" sync / 1[56]:Eden's Promise:(589E|58A6):/
-466.9 "--sync--" sync / 1[56]:Eden's Promise:58A7:/
+453.0 "Junction Shiva/Titan" sync / 1[56]:[^:]*:Eden's Promise:589[45]:/
+462.7 "Release" sync / 1[56]:[^:]*:Eden's Promise:5893:/
+466.2 "Frigid Stone/Under The Weight" sync / 1[56]:[^:]*:Eden's Promise:(589E|58A6):/
+466.9 "--sync--" sync / 1[56]:[^:]*:Eden's Promise:58A7:/
 
-478.1 "Formless Judgment" sync / 1[56]:Eden's Promise:58A9:/
-#478.4 "Formless Judgment" sync / 1[56]:Eden's Promise:58AC:/
-480.9 "Formless Judgment" #sync / 1[56]:Eden's Promise:58AC:/
+478.1 "Formless Judgment" sync / 1[56]:[^:]*:Eden's Promise:58A9:/
+#478.4 "Formless Judgment" sync / 1[56]:[^:]*:Eden's Promise:58AC:/
+480.9 "Formless Judgment" #sync / 1[56]:[^:]*:Eden's Promise:58AC:/
 
-489.4 "Maleficium" sync / 1[56]:Eden's Promise:58A8:/
-498.6 "Maleficium" sync / 1[56]:Eden's Promise:58A8:/
+489.4 "Maleficium" sync / 1[56]:[^:]*:Eden's Promise:58A8:/
+498.6 "Maleficium" sync / 1[56]:[^:]*:Eden's Promise:58A8:/
 506.9 "--untargetable--"
-512.0 "Paradise Lost" sync / 1[56]:Eden's Promise:58BA:/
+512.0 "Paradise Lost" sync / 1[56]:[^:]*:Eden's Promise:58BA:/
 
 
 ### Oracle of Darkness
@@ -119,107 +119,107 @@ hideall "--sync--"
 # -ii 4B1F 58C5 58C6 58D7 58BF 58C9 58CB 58CC 58CE
 
 1000.0 "Start"
-1011.0 "--sync--" sync / 14:Oracle Of Darkness:58EF:/ window 1011,0
-1015.0 "Hell's Judgment" sync / 1[56]:Oracle Of Darkness:58EF:/
-1023.2 "Shockwave Pulsar" sync / 1[56]:Oracle Of Darkness:58F0:/
+1011.0 "--sync--" sync / 14:[^:]*:Oracle Of Darkness:58EF:/ window 1011,0
+1015.0 "Hell's Judgment" sync / 1[56]:[^:]*:Oracle Of Darkness:58EF:/
+1023.2 "Shockwave Pulsar" sync / 1[56]:[^:]*:Oracle Of Darkness:58F0:/
 
-1032.3 "Spell-In-Waiting" sync / 1[56]:Oracle Of Darkness:58C8:/
-1045.6 "Spell-In-Waiting" sync / 1[56]:Oracle Of Darkness:58C8:/
-1053.3 "Dark Water III / Dark Eruption" sync / 1[56]:Oracle Of Darkness:58C[AD]:/
-1064.9 "Darkest Dance" sync / 1[56]:Oracle Of Darkness:58BE:/
-1067.9 "Darkest Dance" sync / 1[56]:Oracle Of Darkness:58C1:/
-1071.5 "Dark Eruption / Dark Water III" sync / 1[56]:Oracle Of Darkness:58C[AD]:/
-1080.7 "Shockwave Pulsar" sync / 1[56]:Oracle Of Darkness:58F0:/
+1032.3 "Spell-In-Waiting" sync / 1[56]:[^:]*:Oracle Of Darkness:58C8:/
+1045.6 "Spell-In-Waiting" sync / 1[56]:[^:]*:Oracle Of Darkness:58C8:/
+1053.3 "Dark Water III / Dark Eruption" sync / 1[56]:[^:]*:Oracle Of Darkness:58C[AD]:/
+1064.9 "Darkest Dance" sync / 1[56]:[^:]*:Oracle Of Darkness:58BE:/
+1067.9 "Darkest Dance" sync / 1[56]:[^:]*:Oracle Of Darkness:58C1:/
+1071.5 "Dark Eruption / Dark Water III" sync / 1[56]:[^:]*:Oracle Of Darkness:58C[AD]:/
+1080.7 "Shockwave Pulsar" sync / 1[56]:[^:]*:Oracle Of Darkness:58F0:/
 
-1101.9 "Basic Relativity" sync / 1[56]:Oracle Of Darkness:58E0:/ window 200,100
-1110.0 "Speed" sync / 1[56]:Oracle Of Darkness:58DD:/
-1110.0 "Slow" sync / 1[56]:Oracle Of Darkness:58DF:/
-1110.0 "Quicken" sync / 1[56]:Oracle Of Darkness:58DE:/
-1117.0 "Dark Current" sync / 1[56]:Sorrow's Hourglass:58D7:/
-1124.0 "Dark Current" sync / 1[56]:Sorrow's Hourglass:58D7:/
-1124.8 "Return" sync / 1[56]:Oracle Of Darkness:58D6:/
-1124.8 "Shadoweye" sync / 1[56]:Oracle Of Darkness:58D2:/
-1131.0 "Dark Current" sync / 1[56]:Sorrow's Hourglass:58D7:/
-1131.0 "Empty Rage" sync / 1[56]:Sorrow's Hourglass:58DB:/
-1135.1 "Empty Hate" sync / 1[56]:Sorrow's Hourglass:58DC:/
-1138.8 "Dark Water III" sync / 1[56]:Oracle Of Darkness:58CA:/
-1148.1 "Shockwave Pulsar" sync / 1[56]:Oracle Of Darkness:58F0:/
+1101.9 "Basic Relativity" sync / 1[56]:[^:]*:Oracle Of Darkness:58E0:/ window 200,100
+1110.0 "Speed" sync / 1[56]:[^:]*:Oracle Of Darkness:58DD:/
+1110.0 "Slow" sync / 1[56]:[^:]*:Oracle Of Darkness:58DF:/
+1110.0 "Quicken" sync / 1[56]:[^:]*:Oracle Of Darkness:58DE:/
+1117.0 "Dark Current" sync / 1[56]:[^:]*:Sorrow's Hourglass:58D7:/
+1124.0 "Dark Current" sync / 1[56]:[^:]*:Sorrow's Hourglass:58D7:/
+1124.8 "Return" sync / 1[56]:[^:]*:Oracle Of Darkness:58D6:/
+1124.8 "Shadoweye" sync / 1[56]:[^:]*:Oracle Of Darkness:58D2:/
+1131.0 "Dark Current" sync / 1[56]:[^:]*:Sorrow's Hourglass:58D7:/
+1131.0 "Empty Rage" sync / 1[56]:[^:]*:Sorrow's Hourglass:58DB:/
+1135.1 "Empty Hate" sync / 1[56]:[^:]*:Sorrow's Hourglass:58DC:/
+1138.8 "Dark Water III" sync / 1[56]:[^:]*:Oracle Of Darkness:58CA:/
+1148.1 "Shockwave Pulsar" sync / 1[56]:[^:]*:Oracle Of Darkness:58F0:/
 
-1163.3 "Singular Apocalypse" sync / 1[56]:Oracle Of Darkness:58E5:/ window 200,100
-1172.7 "Cataclysm" sync / 1[56]:Oracle Of Darkness:58C2:/
-1181.3 "Black Halo" sync / 1[56]:Oracle Of Darkness:58C7:/
-1185.6 "Apocalypse" #sync / 1[56]:Oracle Of Darkness:58E6:/
-1187.1 "Apocalypse" #sync / 1[56]:Oracle Of Darkness:58E6:/
-1188.6 "Apocalypse" #sync / 1[56]:Oracle Of Darkness:58E6:/
-1189.0 "Shell Crusher" sync / 1[56]:Oracle Of Darkness:58C3:/
-1190.1 "Apocalypse" #sync / 1[56]:Oracle Of Darkness:58E6:/
-1191.6 "Apocalypse" #sync / 1[56]:Oracle Of Darkness:58E6:/
-1193.1 "Apocalypse" #sync / 1[56]:Oracle Of Darkness:58E6:/
-1194.6 "Apocalypse" #sync / 1[56]:Oracle Of Darkness:58E6:/
-1195.0 "Spirit Taker" sync / 1[56]:Oracle Of Darkness:58C4:/
-1196.0 "Apocalypse" #sync / 1[56]:Oracle Of Darkness:58E6:/
-1197.5 "Apocalypse" #sync / 1[56]:Oracle Of Darkness:58E6:/
-1199.0 "Apocalypse" #sync / 1[56]:Oracle Of Darkness:58E6:/
-1206.2 "Shockwave Pulsar" sync / 1[56]:Oracle Of Darkness:58F0:/
+1163.3 "Singular Apocalypse" sync / 1[56]:[^:]*:Oracle Of Darkness:58E5:/ window 200,100
+1172.7 "Cataclysm" sync / 1[56]:[^:]*:Oracle Of Darkness:58C2:/
+1181.3 "Black Halo" sync / 1[56]:[^:]*:Oracle Of Darkness:58C7:/
+1185.6 "Apocalypse" #sync / 1[56]:[^:]*:Oracle Of Darkness:58E6:/
+1187.1 "Apocalypse" #sync / 1[56]:[^:]*:Oracle Of Darkness:58E6:/
+1188.6 "Apocalypse" #sync / 1[56]:[^:]*:Oracle Of Darkness:58E6:/
+1189.0 "Shell Crusher" sync / 1[56]:[^:]*:Oracle Of Darkness:58C3:/
+1190.1 "Apocalypse" #sync / 1[56]:[^:]*:Oracle Of Darkness:58E6:/
+1191.6 "Apocalypse" #sync / 1[56]:[^:]*:Oracle Of Darkness:58E6:/
+1193.1 "Apocalypse" #sync / 1[56]:[^:]*:Oracle Of Darkness:58E6:/
+1194.6 "Apocalypse" #sync / 1[56]:[^:]*:Oracle Of Darkness:58E6:/
+1195.0 "Spirit Taker" sync / 1[56]:[^:]*:Oracle Of Darkness:58C4:/
+1196.0 "Apocalypse" #sync / 1[56]:[^:]*:Oracle Of Darkness:58E6:/
+1197.5 "Apocalypse" #sync / 1[56]:[^:]*:Oracle Of Darkness:58E6:/
+1199.0 "Apocalypse" #sync / 1[56]:[^:]*:Oracle Of Darkness:58E6:/
+1206.2 "Shockwave Pulsar" sync / 1[56]:[^:]*:Oracle Of Darkness:58F0:/
 
-1224.4 "Intermediate Relativity" sync / 1[56]:Oracle Of Darkness:58E1:/ window 300,100
+1224.4 "Intermediate Relativity" sync / 1[56]:[^:]*:Oracle Of Darkness:58E1:/ window 300,100
 # TODO: fill this in better with where the rewinds drop
-1237.3 "Return IV" sync / 1[56]:Oracle Of Darkness:4E59:/
-1265.6 "Shockwave Pulsar" sync / 1[56]:Oracle Of Darkness:58F0:/
+1237.3 "Return IV" sync / 1[56]:[^:]*:Oracle Of Darkness:4E59:/
+1265.6 "Shockwave Pulsar" sync / 1[56]:[^:]*:Oracle Of Darkness:58F0:/
 
-1280.8 "Dual Apocalypse" sync / 1[56]:Oracle Of Darkness:501C:/ window 300,100
-1290.2 "Cataclysm" sync / 1[56]:Oracle Of Darkness:58C2:/
-1295.1 "Apocalypse" #sync / 1[56]:Oracle Of Darkness:58E6:/
-1297.1 "Apocalypse" #sync / 1[56]:Oracle Of Darkness:58E6:/
-1299.1 "Apocalypse" #sync / 1[56]:Oracle Of Darkness:58E6:/
-1301.1 "Apocalypse" #sync / 1[56]:Oracle Of Darkness:58E6:/
-1302.4 "Somber Dance" sync / 1[56]:Oracle Of Darkness:58BD:/
-1303.1 "Apocalypse" #sync / 1[56]:Oracle Of Darkness:58E6:/
-1305.1 "Apocalypse" #sync / 1[56]:Oracle Of Darkness:58E6:/
-1305.9 "Somber Dance" sync / 1[56]:Oracle Of Darkness:58C0:/
-1316.2 "Shell Crusher" sync / 1[56]:Oracle Of Darkness:58C3:/
-1322.1 "Spirit Taker" sync / 1[56]:Oracle Of Darkness:58C4:/
-1330.7 "Shockwave Pulsar" sync / 1[56]:Oracle Of Darkness:58F0:/
+1280.8 "Dual Apocalypse" sync / 1[56]:[^:]*:Oracle Of Darkness:501C:/ window 300,100
+1290.2 "Cataclysm" sync / 1[56]:[^:]*:Oracle Of Darkness:58C2:/
+1295.1 "Apocalypse" #sync / 1[56]:[^:]*:Oracle Of Darkness:58E6:/
+1297.1 "Apocalypse" #sync / 1[56]:[^:]*:Oracle Of Darkness:58E6:/
+1299.1 "Apocalypse" #sync / 1[56]:[^:]*:Oracle Of Darkness:58E6:/
+1301.1 "Apocalypse" #sync / 1[56]:[^:]*:Oracle Of Darkness:58E6:/
+1302.4 "Somber Dance" sync / 1[56]:[^:]*:Oracle Of Darkness:58BD:/
+1303.1 "Apocalypse" #sync / 1[56]:[^:]*:Oracle Of Darkness:58E6:/
+1305.1 "Apocalypse" #sync / 1[56]:[^:]*:Oracle Of Darkness:58E6:/
+1305.9 "Somber Dance" sync / 1[56]:[^:]*:Oracle Of Darkness:58C0:/
+1316.2 "Shell Crusher" sync / 1[56]:[^:]*:Oracle Of Darkness:58C3:/
+1322.1 "Spirit Taker" sync / 1[56]:[^:]*:Oracle Of Darkness:58C4:/
+1330.7 "Shockwave Pulsar" sync / 1[56]:[^:]*:Oracle Of Darkness:58F0:/
 
-1349.9 "Advanced Relativity" sync / 1[56]:Oracle Of Darkness:58E2:/ window 400,100
+1349.9 "Advanced Relativity" sync / 1[56]:[^:]*:Oracle Of Darkness:58E2:/ window 400,100
 1353.9 "--untargetable--"
-1358.0 "Speed" sync / 1[56]:Oracle Of Darkness:58DD:/
-1358.1 "Slow" sync / 1[56]:Oracle Of Darkness:58DF:/
-1358.1 "Quicken" sync / 1[56]:Oracle Of Darkness:58DE:/
-1362.8 "Return IV" sync / 1[56]:Oracle Of Darkness:4E59:/
-1362.8 "Dark Water III" sync / 1[56]:Oracle Of Darkness:58CA:/
-1373.1 "Maelstrom" sync / 1[56]:Sorrow's Hourglass:58DA:/
-1373.9 "Dark Fire III" sync / 1[56]:Oracle Of Darkness:58CF:/
-1373.9 "Dark Aero III" sync / 1[56]:Oracle Of Darkness:58D4:/
-1377.1 "Maelstrom" sync / 1[56]:Sorrow's Hourglass:58DA:/
-1377.9 "Shadoweye" sync / 1[56]:Oracle Of Darkness:58D2:/
-1381.2 "Maelstrom" sync / 1[56]:Sorrow's Hourglass:58DA:/
-1382.0 "Dark Aero III" sync / 1[56]:Oracle Of Darkness:58D4:/
-1386.0 "Dark Water III" sync / 1[56]:Oracle Of Darkness:58CA:/
+1358.0 "Speed" sync / 1[56]:[^:]*:Oracle Of Darkness:58DD:/
+1358.1 "Slow" sync / 1[56]:[^:]*:Oracle Of Darkness:58DF:/
+1358.1 "Quicken" sync / 1[56]:[^:]*:Oracle Of Darkness:58DE:/
+1362.8 "Return IV" sync / 1[56]:[^:]*:Oracle Of Darkness:4E59:/
+1362.8 "Dark Water III" sync / 1[56]:[^:]*:Oracle Of Darkness:58CA:/
+1373.1 "Maelstrom" sync / 1[56]:[^:]*:Sorrow's Hourglass:58DA:/
+1373.9 "Dark Fire III" sync / 1[56]:[^:]*:Oracle Of Darkness:58CF:/
+1373.9 "Dark Aero III" sync / 1[56]:[^:]*:Oracle Of Darkness:58D4:/
+1377.1 "Maelstrom" sync / 1[56]:[^:]*:Sorrow's Hourglass:58DA:/
+1377.9 "Shadoweye" sync / 1[56]:[^:]*:Oracle Of Darkness:58D2:/
+1381.2 "Maelstrom" sync / 1[56]:[^:]*:Sorrow's Hourglass:58DA:/
+1382.0 "Dark Aero III" sync / 1[56]:[^:]*:Oracle Of Darkness:58D4:/
+1386.0 "Dark Water III" sync / 1[56]:[^:]*:Oracle Of Darkness:58CA:/
 1387.2 "--targetable--"
-1395.4 "Shockwave Pulsar" sync / 1[56]:Oracle Of Darkness:58F0:/
+1395.4 "Shockwave Pulsar" sync / 1[56]:[^:]*:Oracle Of Darkness:58F0:/
 
-1412.6 "Triple Apocalypse" sync / 1[56]:Oracle Of Darkness:501D:/ window 500,100
-1421.3 "Apocalypse" #sync / 1[56]:Oracle Of Darkness:58E6:/
-1422.8 "Darkest Dance" sync / 1[56]:Oracle Of Darkness:58BE:/
-1424.3 "Apocalypse" #sync / 1[56]:Oracle Of Darkness:58E6:/
-1425.9 "Darkest Dance" sync / 1[56]:Oracle Of Darkness:58C1:/
-1427.3 "Apocalypse" #sync / 1[56]:Oracle Of Darkness:58E6:/
-1439.3 "Shockwave Pulsar" sync / 1[56]:Oracle Of Darkness:58F0:/
-1447.9 "Black Halo" sync / 1[56]:Oracle Of Darkness:58C7:/
+1412.6 "Triple Apocalypse" sync / 1[56]:[^:]*:Oracle Of Darkness:501D:/ window 500,100
+1421.3 "Apocalypse" #sync / 1[56]:[^:]*:Oracle Of Darkness:58E6:/
+1422.8 "Darkest Dance" sync / 1[56]:[^:]*:Oracle Of Darkness:58BE:/
+1424.3 "Apocalypse" #sync / 1[56]:[^:]*:Oracle Of Darkness:58E6:/
+1425.9 "Darkest Dance" sync / 1[56]:[^:]*:Oracle Of Darkness:58C1:/
+1427.3 "Apocalypse" #sync / 1[56]:[^:]*:Oracle Of Darkness:58E6:/
+1439.3 "Shockwave Pulsar" sync / 1[56]:[^:]*:Oracle Of Darkness:58F0:/
+1447.9 "Black Halo" sync / 1[56]:[^:]*:Oracle Of Darkness:58C7:/
 
-1471.1 "Terminal Relativity" sync / 1[56]:Oracle Of Darkness:58E3:/ window 500,100
-1477.9 "--1--" #sync / 1[56]:Oracle Of Darkness:501E:/
-1481.0 "--2--" #sync / 1[56]:Oracle Of Darkness:501E:/
-1484.0 "--3--" #sync / 1[56]:Oracle Of Darkness:501E:/
-1486.2 "Shockwave Pulsar 1" sync / 1[56]:Oracle Of Darkness:58D5:/
-1491.0 "--1--" #sync / 1[56]:Oracle Of Darkness:501E:/
-1493.9 "--2--" #sync / 1[56]:Oracle Of Darkness:501E:/
-1496.9 "--3--" #sync / 1[56]:Oracle Of Darkness:501E:/
-1499.7 "Shockwave Pulsar 2" sync / 1[56]:Oracle Of Darkness:58D5:/
-1503.9 "--1--" #sync / 1[56]:Oracle Of Darkness:501E:/
-1506.9 "--2--" #sync / 1[56]:Oracle Of Darkness:501E:/
-1509.9 "--3--" #sync / 1[56]:Oracle Of Darkness:501E:/
-1513.2 "Shockwave Pulsar 3" sync / 1[56]:Oracle Of Darkness:58D5:/
+1471.1 "Terminal Relativity" sync / 1[56]:[^:]*:Oracle Of Darkness:58E3:/ window 500,100
+1477.9 "--1--" #sync / 1[56]:[^:]*:Oracle Of Darkness:501E:/
+1481.0 "--2--" #sync / 1[56]:[^:]*:Oracle Of Darkness:501E:/
+1484.0 "--3--" #sync / 1[56]:[^:]*:Oracle Of Darkness:501E:/
+1486.2 "Shockwave Pulsar 1" sync / 1[56]:[^:]*:Oracle Of Darkness:58D5:/
+1491.0 "--1--" #sync / 1[56]:[^:]*:Oracle Of Darkness:501E:/
+1493.9 "--2--" #sync / 1[56]:[^:]*:Oracle Of Darkness:501E:/
+1496.9 "--3--" #sync / 1[56]:[^:]*:Oracle Of Darkness:501E:/
+1499.7 "Shockwave Pulsar 2" sync / 1[56]:[^:]*:Oracle Of Darkness:58D5:/
+1503.9 "--1--" #sync / 1[56]:[^:]*:Oracle Of Darkness:501E:/
+1506.9 "--2--" #sync / 1[56]:[^:]*:Oracle Of Darkness:501E:/
+1509.9 "--3--" #sync / 1[56]:[^:]*:Oracle Of Darkness:501E:/
+1513.2 "Shockwave Pulsar 3" sync / 1[56]:[^:]*:Oracle Of Darkness:58D5:/
 
-1533.7 "Memory's End" sync / 1[56]:Oracle Of Darkness:58E4:/
+1533.7 "Memory's End" sync / 1[56]:[^:]*:Oracle Of Darkness:58E4:/

--- a/ui/raidboss/data/05-shb/raid/e1n.txt
+++ b/ui/raidboss/data/05-shb/raid/e1n.txt
@@ -11,78 +11,78 @@ hideall "Vice And Virtue"
 ### Phase 1
 0 "Start"
 0.0 "--sync--" sync /:Engage!/ window 0,1
-2.0 "--sync--" sync / 1[56]:Eden Prime:367:/ window 2,0
-12.0 "Spear Of Paradise" sync / 1[56]:Eden Prime:3DA1:/ window 12,5
-13.5 "Heavensunder" sync / 1[56]:Eden Prime:3DA2:/
-22.5 "Eden's Gravity" sync / 1[56]:Eden Prime:3D94:/
-34.1 "Vice And Virtue" sync / 1[56]:Eden Prime:44E5:/
-34.1 "Vice Of Apathy" sync / 1[56]:Eden Prime:44E8:/
-40.5 "Eden's Flare" sync / 1[56]:Eden Prime:3D97:/
-56.1 "Vice And Virtue" sync / 1[56]:Eden Prime:44E4:/
-56.9 "Vice Of Vanity" sync / 1[56]:Eden Prime:44E7:/
-66.7 "Spear Of Paradise" sync / 1[56]:Eden Prime:3DA1:/
-68.2 "Heavensunder" sync / 1[56]:Eden Prime:3DA2:/
-73.2 "--corner--" sync / 1[56]:Eden Prime:4683:/
-86.5 "Pure Light" sync / 1[56]:Eden Prime:3DA3:/
-92.4 "--center--" sync / 1[56]:Eden Prime:4683:/
-101.6 "Delta Attack" sync / 1[56]:Eden Prime:44EA:/
-102.2 "Eden's Thunder III" sync / 1[56]:Eden Prime:44ED:/
-102.2 "Eden's Blizzard III" sync / 1[56]:Eden Prime:44EC:/
-102.2 "Eden's Fire III" sync / 1[56]:Eden Prime:44EB:/
-108.3 "--sync--" sync / 1[56]:Eden Prime:4683:/
-114.8 "Dimensional Shift" sync / 1[56]:Eden Prime:3D9C:/
-123.3 "Pure Beam x6" sync / 1[56]:Eden Prime:3D9D:/ duration 17.3
-128.7 "Paradise Lost x3" sync / 1[56]:Eden Prime:3D9F:/ duration 11.2
-131.2 "--corner--" sync / 1[56]:Eden Prime:4683:/
-144.5 "Pure Light" sync / 1[56]:Eden Prime:3DA3:/
-147.3 "--center--" sync / 1[56]:Eden Prime:4683:/
-153.9 "Dimensional Shift" sync / 1[56]:Eden Prime:3D9C:/
+2.0 "--sync--" sync / 1[56]:[^:]*:Eden Prime:367:/ window 2,0
+12.0 "Spear Of Paradise" sync / 1[56]:[^:]*:Eden Prime:3DA1:/ window 12,5
+13.5 "Heavensunder" sync / 1[56]:[^:]*:Eden Prime:3DA2:/
+22.5 "Eden's Gravity" sync / 1[56]:[^:]*:Eden Prime:3D94:/
+34.1 "Vice And Virtue" sync / 1[56]:[^:]*:Eden Prime:44E5:/
+34.1 "Vice Of Apathy" sync / 1[56]:[^:]*:Eden Prime:44E8:/
+40.5 "Eden's Flare" sync / 1[56]:[^:]*:Eden Prime:3D97:/
+56.1 "Vice And Virtue" sync / 1[56]:[^:]*:Eden Prime:44E4:/
+56.9 "Vice Of Vanity" sync / 1[56]:[^:]*:Eden Prime:44E7:/
+66.7 "Spear Of Paradise" sync / 1[56]:[^:]*:Eden Prime:3DA1:/
+68.2 "Heavensunder" sync / 1[56]:[^:]*:Eden Prime:3DA2:/
+73.2 "--corner--" sync / 1[56]:[^:]*:Eden Prime:4683:/
+86.5 "Pure Light" sync / 1[56]:[^:]*:Eden Prime:3DA3:/
+92.4 "--center--" sync / 1[56]:[^:]*:Eden Prime:4683:/
+101.6 "Delta Attack" sync / 1[56]:[^:]*:Eden Prime:44EA:/
+102.2 "Eden's Thunder III" sync / 1[56]:[^:]*:Eden Prime:44ED:/
+102.2 "Eden's Blizzard III" sync / 1[56]:[^:]*:Eden Prime:44EC:/
+102.2 "Eden's Fire III" sync / 1[56]:[^:]*:Eden Prime:44EB:/
+108.3 "--sync--" sync / 1[56]:[^:]*:Eden Prime:4683:/
+114.8 "Dimensional Shift" sync / 1[56]:[^:]*:Eden Prime:3D9C:/
+123.3 "Pure Beam x6" sync / 1[56]:[^:]*:Eden Prime:3D9D:/ duration 17.3
+128.7 "Paradise Lost x3" sync / 1[56]:[^:]*:Eden Prime:3D9F:/ duration 11.2
+131.2 "--corner--" sync / 1[56]:[^:]*:Eden Prime:4683:/
+144.5 "Pure Light" sync / 1[56]:[^:]*:Eden Prime:3DA3:/
+147.3 "--center--" sync / 1[56]:[^:]*:Eden Prime:4683:/
+153.9 "Dimensional Shift" sync / 1[56]:[^:]*:Eden Prime:3D9C:/
 
 
 ### Phase 2: cleavy adds
 166.5 "--untargetable--"
-166.5 "Fragor Maximus" sync / 1[56]:Eden Prime:3DA4:/ window 200,5
+166.5 "Fragor Maximus" sync / 1[56]:[^:]*:Eden Prime:3DA4:/ window 200,5
 182.7 "--targetable--"
-182.7 "Paradisal Dive" sync / 1[56]:Guardian of Paradise:3DA9:/
-193.8 "Mana Slice" sync / 1[56]:Guardian of Paradise:3DA6:/
-203.0 "Mana Burst" sync / 1[56]:Guardian of Paradise:3DA7:/
-209.1 "Mana Slice" sync / 1[56]:Guardian of Paradise:3DA6:/
-218.3 "Mana Burst" sync / 1[56]:Guardian of Paradise:3DA7:/
-223.5 "Mana Slice" sync / 1[56]:Guardian of Paradise:3DA6:/
-228.7 "Mana Slice" sync / 1[56]:Guardian of Paradise:3DA6:/
-242.7 "Unto Dust Enrage" sync / 1[56]:Guardian of Paradise:3DA8:/
+182.7 "Paradisal Dive" sync / 1[56]:[^:]*:Guardian of Paradise:3DA9:/
+193.8 "Mana Slice" sync / 1[56]:[^:]*:Guardian of Paradise:3DA6:/
+203.0 "Mana Burst" sync / 1[56]:[^:]*:Guardian of Paradise:3DA7:/
+209.1 "Mana Slice" sync / 1[56]:[^:]*:Guardian of Paradise:3DA6:/
+218.3 "Mana Burst" sync / 1[56]:[^:]*:Guardian of Paradise:3DA7:/
+223.5 "Mana Slice" sync / 1[56]:[^:]*:Guardian of Paradise:3DA6:/
+228.7 "Mana Slice" sync / 1[56]:[^:]*:Guardian of Paradise:3DA6:/
+242.7 "Unto Dust Enrage" sync / 1[56]:[^:]*:Guardian of Paradise:3DA8:/
 
 
 ### Phase 3: more of the same
-300.0 "Primeval Stasis" sync / 1[56]:Eden:3E3A:/ window 300,0
-343.6 "Eternal Breath" sync / 1[56]:Eden Prime:3DA5:/
+300.0 "Primeval Stasis" sync / 1[56]:[^:]*:Eden:3E3A:/ window 300,0
+343.6 "Eternal Breath" sync / 1[56]:[^:]*:Eden Prime:3DA5:/
 
 354.0 "--targetable--"
-360.0 "Vice And Virtue" sync / 1[56]:Eden Prime:44E4:/
-360.8 "Vice Of Vanity" sync / 1[56]:Eden Prime:44E7:/
-370.6 "Spear Of Paradise" sync / 1[56]:Eden Prime:3DA1:/
-372.1 "Heavensunder" sync / 1[56]:Eden Prime:3DA2:/
-377.0 "--corner--" sync / 1[56]:Eden Prime:4683:/
-390.3 "Pure Light" sync / 1[56]:Eden Prime:3DA3:/
-396.2 "--center--" sync / 1[56]:Eden Prime:4683:/
-405.5 "Delta Attack" sync / 1[56]:Eden Prime:44EA:/
-406.1 "Eden's Thunder III" sync / 1[56]:Eden Prime:44ED:/
-406.1 "Eden's Blizzard III" sync / 1[56]:Eden Prime:44EC:/
-406.1 "Eden's Fire III" sync / 1[56]:Eden Prime:44EB:/
-412.1 "--sync--" sync / 1[56]:Eden Prime:4683:/
-418.7 "Dimensional Shift" sync / 1[56]:Eden Prime:3D9C:/
-427.1 "Pure Beam x6" sync / 1[56]:Eden Prime:3D9D:/ duration 17.3
-432.6 "Paradise Lost x3" sync / 1[56]:Eden Prime:3D9F:/ duration 11.2
-435.1 "--corner--" sync / 1[56]:Eden Prime:4683:/
-448.4 "Pure Light" sync / 1[56]:Eden Prime:3DA3:/
-451.2 "--center--" sync / 1[56]:Eden Prime:4683:/
-457.8 "Dimensional Shift" sync / 1[56]:Eden Prime:3D9C:/
-470.3 "Vice And Virtue" sync / 1[56]:Eden Prime:44E5:/
-470.4 "Vice Of Apathy" sync / 1[56]:Eden Prime:44E8:/
-476.9 "Eden's Flare" sync / 1[56]:Eden Prime:3D97:/
-488.4 "Eden's Gravity" sync / 1[56]:Eden Prime:3D94:/
+360.0 "Vice And Virtue" sync / 1[56]:[^:]*:Eden Prime:44E4:/
+360.8 "Vice Of Vanity" sync / 1[56]:[^:]*:Eden Prime:44E7:/
+370.6 "Spear Of Paradise" sync / 1[56]:[^:]*:Eden Prime:3DA1:/
+372.1 "Heavensunder" sync / 1[56]:[^:]*:Eden Prime:3DA2:/
+377.0 "--corner--" sync / 1[56]:[^:]*:Eden Prime:4683:/
+390.3 "Pure Light" sync / 1[56]:[^:]*:Eden Prime:3DA3:/
+396.2 "--center--" sync / 1[56]:[^:]*:Eden Prime:4683:/
+405.5 "Delta Attack" sync / 1[56]:[^:]*:Eden Prime:44EA:/
+406.1 "Eden's Thunder III" sync / 1[56]:[^:]*:Eden Prime:44ED:/
+406.1 "Eden's Blizzard III" sync / 1[56]:[^:]*:Eden Prime:44EC:/
+406.1 "Eden's Fire III" sync / 1[56]:[^:]*:Eden Prime:44EB:/
+412.1 "--sync--" sync / 1[56]:[^:]*:Eden Prime:4683:/
+418.7 "Dimensional Shift" sync / 1[56]:[^:]*:Eden Prime:3D9C:/
+427.1 "Pure Beam x6" sync / 1[56]:[^:]*:Eden Prime:3D9D:/ duration 17.3
+432.6 "Paradise Lost x3" sync / 1[56]:[^:]*:Eden Prime:3D9F:/ duration 11.2
+435.1 "--corner--" sync / 1[56]:[^:]*:Eden Prime:4683:/
+448.4 "Pure Light" sync / 1[56]:[^:]*:Eden Prime:3DA3:/
+451.2 "--center--" sync / 1[56]:[^:]*:Eden Prime:4683:/
+457.8 "Dimensional Shift" sync / 1[56]:[^:]*:Eden Prime:3D9C:/
+470.3 "Vice And Virtue" sync / 1[56]:[^:]*:Eden Prime:44E5:/
+470.4 "Vice Of Apathy" sync / 1[56]:[^:]*:Eden Prime:44E8:/
+476.9 "Eden's Flare" sync / 1[56]:[^:]*:Eden Prime:3D97:/
+488.4 "Eden's Gravity" sync / 1[56]:[^:]*:Eden Prime:3D94:/
 
-502.0 "Vice And Virtue" sync / 1[56]:Eden Prime:44E4:/ window 100,100 jump 360.0
+502.0 "Vice And Virtue" sync / 1[56]:[^:]*:Eden Prime:44E4:/ window 100,100 jump 360.0
 502.7 "Vice Of Vanity"
 512.5 "Spear Of Paradise"
 514.0 "Heavensunder"

--- a/ui/raidboss/data/05-shb/raid/e1s.txt
+++ b/ui/raidboss/data/05-shb/raid/e1s.txt
@@ -10,76 +10,76 @@ hideall "--sync--"
 ### Phase 1
 0 "Start"
 0.0 "--sync--" sync /:Engage!/ window 0,1
-1.5 "--sync--" sync / 1[56]:Eden Prime:367:/ window 2,0
-12.0 "Eden's Gravity" sync / 1[56]:Eden Prime:3D70:/ window 12,5
-25.6 "Vice And Virtue (D)" sync / 1[56]:Eden Prime:44EF:/
-32.0 "Eden's Flare" sync / 1[56]:Eden Prime:3D73:/
-50.5 "Vice And Virtue (T)" sync / 1[56]:Eden Prime:44EE:/
-58.0 "Spear Of Paradise" sync / 1[56]:Eden Prime:3D88:/
-59.5 "Heavensunder" sync / 1[56]:Eden Prime:3D89:/
-69.4 "Vice And Virtue (H)" sync / 1[56]:Eden Prime:44F0:/
-71.7 "--corner--" sync / 1[56]:Eden Prime:4683:/
-80.4 "Pure Light" sync / 1[56]:Eden Prime:3D8A:/
-83.2 "--center--" sync / 1[56]:Eden Prime:4683:/
-93.3 "Delta Attack (Cross)" sync / 1[56]:Eden Prime:44F4:/
-98.9 "--sync--" sync / 1[56]:Eden Prime:4683:/
-105.5 "Dimensional Shift" sync / 1[56]:Eden Prime:3D7F:/
-112.0 "Paradise Lost" sync / 1[56]:Eden Prime:3D86:/ duration 9
-122.5 "Pure Beam" sync / 1[56]:Eden Prime:3D80:/
-125.0 "--corner--" sync / 1[56]:Eden Prime:4683:/
-133.7 "Pure Light" sync / 1[56]:Eden Prime:3D8A:/
-136.5 "--center--" sync / 1[56]:Eden Prime:4683:/
-143.1 "Dimensional Shift" sync / 1[56]:Eden Prime:3D7F:/
-153.7 "Fragor Maximus" sync / 1[56]:Eden Prime:3D8B:/ window 200,0
+1.5 "--sync--" sync / 1[56]:[^:]*:Eden Prime:367:/ window 2,0
+12.0 "Eden's Gravity" sync / 1[56]:[^:]*:Eden Prime:3D70:/ window 12,5
+25.6 "Vice And Virtue (D)" sync / 1[56]:[^:]*:Eden Prime:44EF:/
+32.0 "Eden's Flare" sync / 1[56]:[^:]*:Eden Prime:3D73:/
+50.5 "Vice And Virtue (T)" sync / 1[56]:[^:]*:Eden Prime:44EE:/
+58.0 "Spear Of Paradise" sync / 1[56]:[^:]*:Eden Prime:3D88:/
+59.5 "Heavensunder" sync / 1[56]:[^:]*:Eden Prime:3D89:/
+69.4 "Vice And Virtue (H)" sync / 1[56]:[^:]*:Eden Prime:44F0:/
+71.7 "--corner--" sync / 1[56]:[^:]*:Eden Prime:4683:/
+80.4 "Pure Light" sync / 1[56]:[^:]*:Eden Prime:3D8A:/
+83.2 "--center--" sync / 1[56]:[^:]*:Eden Prime:4683:/
+93.3 "Delta Attack (Cross)" sync / 1[56]:[^:]*:Eden Prime:44F4:/
+98.9 "--sync--" sync / 1[56]:[^:]*:Eden Prime:4683:/
+105.5 "Dimensional Shift" sync / 1[56]:[^:]*:Eden Prime:3D7F:/
+112.0 "Paradise Lost" sync / 1[56]:[^:]*:Eden Prime:3D86:/ duration 9
+122.5 "Pure Beam" sync / 1[56]:[^:]*:Eden Prime:3D80:/
+125.0 "--corner--" sync / 1[56]:[^:]*:Eden Prime:4683:/
+133.7 "Pure Light" sync / 1[56]:[^:]*:Eden Prime:3D8A:/
+136.5 "--center--" sync / 1[56]:[^:]*:Eden Prime:4683:/
+143.1 "Dimensional Shift" sync / 1[56]:[^:]*:Eden Prime:3D7F:/
+153.7 "Fragor Maximus" sync / 1[56]:[^:]*:Eden Prime:3D8B:/ window 200,0
 154.3 "--untargetable--"
 
 ### Phase 2 - Adds
 169.9 "--targetable--"
-169.9 "Paradisal Dive" sync / 1[56]:Guardian of Paradise:3D91:/
-185.2 "Mana Slice" sync / 1[56]:Guardian of Paradise:3D8E:/
-194.3 "Mana Burst" sync / 1[56]:Guardian of Paradise:3D8F:/
-199.4 "Mana Slice" sync / 1[56]:Guardian of Paradise:3D8E:/
-208.6 "Mana Burst" sync / 1[56]:Guardian of Paradise:3D8F:/
-213.7 "Mana Slice" sync / 1[56]:Guardian of Paradise:3D8E:/
+169.9 "Paradisal Dive" sync / 1[56]:[^:]*:Guardian of Paradise:3D91:/
+185.2 "Mana Slice" sync / 1[56]:[^:]*:Guardian of Paradise:3D8E:/
+194.3 "Mana Burst" sync / 1[56]:[^:]*:Guardian of Paradise:3D8F:/
+199.4 "Mana Slice" sync / 1[56]:[^:]*:Guardian of Paradise:3D8E:/
+208.6 "Mana Burst" sync / 1[56]:[^:]*:Guardian of Paradise:3D8F:/
+213.7 "Mana Slice" sync / 1[56]:[^:]*:Guardian of Paradise:3D8E:/
 
 ### Phase 3
-500.0 "Eternal Breath" sync / 1[56]:Eden Prime:3D8C:/ window 500,0
+500.0 "Eternal Breath" sync / 1[56]:[^:]*:Eden Prime:3D8C:/ window 500,0
 510.0 "--targetable--"
-518.4 "Paradise Regained" sync / 1[56]:Eden Prime:44FC:/
-528.8 "Vice And Virtue! (T)" sync / 1[56]:Eden Prime:3D78:/
-542.5 "Vice And Virtue! (D)" sync / 1[56]:Eden Prime:3D7A:/
-544.9 "--sync--" sync / 1[56]:Eden Prime:4683:/
-555.0 "Delta Attack (Donut)" sync / 1[56]:Eden Prime:44F8:/
-568.8 "Vice And Virtue! (H)" sync / 1[56]:Eden Prime:3D7D:/
-576.1 "Spear Of Paradise" sync / 1[56]:Eden Prime:3D88:/
-577.7 "Heavensunder" sync / 1[56]:Eden Prime:3D89:/
-582.5 "--sync--" sync / 1[56]:Eden Prime:4683:/
-589.1 "Dimensional Shift" sync / 1[56]:Eden Prime:3D7F:/
-599.5 "Pure Beam!" sync / 1[56]:Eden Prime:3D82:/
-611.2 "--corner--" sync / 1[56]:Eden Prime:4683:/
-619.9 "Pure Light" sync / 1[56]:Eden Prime:3D8A:/ duration 11.7
-622.8 "--center--" sync / 1[56]:Eden Prime:4683:/
-629.3 "Dimensional Shift" sync / 1[56]:Eden Prime:3D7F:/
-642.1 "Eden's Gravity" sync / 1[56]:Eden Prime:3D70:/
-653.6 "Eden's Flare" sync / 1[56]:Eden Prime:3D73:/
-669.2 "Vice And Virtue (T)" sync / 1[56]:Eden Prime:44EE:/
-676.8 "Spear Of Paradise" sync / 1[56]:Eden Prime:3D88:/
-678.3 "Heavensunder" sync / 1[56]:Eden Prime:3D89:/
-688.0 "Vice And Virtue (D)" sync / 1[56]:Eden Prime:44EF:/
-690.5 "--sync--" sync / 1[56]:Eden Prime:4683:/
-700.6 "Delta Attack (Cross)" sync / 1[56]:Eden Prime:44F4:/
-714.1 "Vice And Virtue (H)" sync / 1[56]:Eden Prime:44F0:/
-719.8 "--sync--" sync / 1[56]:Eden Prime:4683:/
-726.4 "Dimensional Shift" sync / 1[56]:Eden Prime:3D7F:/
-736.9 "Pure Beam!" sync / 1[56]:Eden Prime:3D82:/ duration 11.7
-748.3 "--corner--" sync / 1[56]:Eden Prime:4683:/
-757.1 "Pure Light" sync / 1[56]:Eden Prime:3D8A:/
-760.0 "--center--" sync / 1[56]:Eden Prime:4683:/
-766.5 "Dimensional Shift" sync / 1[56]:Eden Prime:3D7F:/
-779.2 "Eden's Gravity" sync / 1[56]:Eden Prime:3D70:/
-790.7 "Eden's Flare" sync / 1[56]:Eden Prime:3D73:/
+518.4 "Paradise Regained" sync / 1[56]:[^:]*:Eden Prime:44FC:/
+528.8 "Vice And Virtue! (T)" sync / 1[56]:[^:]*:Eden Prime:3D78:/
+542.5 "Vice And Virtue! (D)" sync / 1[56]:[^:]*:Eden Prime:3D7A:/
+544.9 "--sync--" sync / 1[56]:[^:]*:Eden Prime:4683:/
+555.0 "Delta Attack (Donut)" sync / 1[56]:[^:]*:Eden Prime:44F8:/
+568.8 "Vice And Virtue! (H)" sync / 1[56]:[^:]*:Eden Prime:3D7D:/
+576.1 "Spear Of Paradise" sync / 1[56]:[^:]*:Eden Prime:3D88:/
+577.7 "Heavensunder" sync / 1[56]:[^:]*:Eden Prime:3D89:/
+582.5 "--sync--" sync / 1[56]:[^:]*:Eden Prime:4683:/
+589.1 "Dimensional Shift" sync / 1[56]:[^:]*:Eden Prime:3D7F:/
+599.5 "Pure Beam!" sync / 1[56]:[^:]*:Eden Prime:3D82:/
+611.2 "--corner--" sync / 1[56]:[^:]*:Eden Prime:4683:/
+619.9 "Pure Light" sync / 1[56]:[^:]*:Eden Prime:3D8A:/ duration 11.7
+622.8 "--center--" sync / 1[56]:[^:]*:Eden Prime:4683:/
+629.3 "Dimensional Shift" sync / 1[56]:[^:]*:Eden Prime:3D7F:/
+642.1 "Eden's Gravity" sync / 1[56]:[^:]*:Eden Prime:3D70:/
+653.6 "Eden's Flare" sync / 1[56]:[^:]*:Eden Prime:3D73:/
+669.2 "Vice And Virtue (T)" sync / 1[56]:[^:]*:Eden Prime:44EE:/
+676.8 "Spear Of Paradise" sync / 1[56]:[^:]*:Eden Prime:3D88:/
+678.3 "Heavensunder" sync / 1[56]:[^:]*:Eden Prime:3D89:/
+688.0 "Vice And Virtue (D)" sync / 1[56]:[^:]*:Eden Prime:44EF:/
+690.5 "--sync--" sync / 1[56]:[^:]*:Eden Prime:4683:/
+700.6 "Delta Attack (Cross)" sync / 1[56]:[^:]*:Eden Prime:44F4:/
+714.1 "Vice And Virtue (H)" sync / 1[56]:[^:]*:Eden Prime:44F0:/
+719.8 "--sync--" sync / 1[56]:[^:]*:Eden Prime:4683:/
+726.4 "Dimensional Shift" sync / 1[56]:[^:]*:Eden Prime:3D7F:/
+736.9 "Pure Beam!" sync / 1[56]:[^:]*:Eden Prime:3D82:/ duration 11.7
+748.3 "--corner--" sync / 1[56]:[^:]*:Eden Prime:4683:/
+757.1 "Pure Light" sync / 1[56]:[^:]*:Eden Prime:3D8A:/
+760.0 "--center--" sync / 1[56]:[^:]*:Eden Prime:4683:/
+766.5 "Dimensional Shift" sync / 1[56]:[^:]*:Eden Prime:3D7F:/
+779.2 "Eden's Gravity" sync / 1[56]:[^:]*:Eden Prime:3D70:/
+790.7 "Eden's Flare" sync / 1[56]:[^:]*:Eden Prime:3D73:/
 
-801.2 "Paradise Regained" sync / 1[56]:Eden Prime:44FC:/ window 200,200 jump 518.4
+801.2 "Paradise Regained" sync / 1[56]:[^:]*:Eden Prime:44FC:/ window 200,200 jump 518.4
 811.6 "Vice And Virtue! (T)"
 825.3 "Vice And Virtue! (D)"
 827.7 "--sync--"
@@ -90,4 +90,4 @@ hideall "--sync--"
 
 
 ### Enrage
-900.0 "Fragor Maximus (Enrage)" sync / 14:Eden Prime:45E4:/ window 500,0 duration 10.0
+900.0 "Fragor Maximus (Enrage)" sync / 14:[^:]*:Eden Prime:45E4:/ window 500,0 duration 10.0

--- a/ui/raidboss/data/05-shb/raid/e2n.txt
+++ b/ui/raidboss/data/05-shb/raid/e2n.txt
@@ -10,59 +10,59 @@ hideall "Spell-In-Waiting"
 
 0 "Start"
 0.0 "--sync--" sync /:Engage!/ window 0,1
-1.0 "--sync--" sync / 1[56]:Voidwalker:3E4C:/ window 1,0
-10.7 "Doomvoid Guillotine" sync / 1[56]:Voidwalker:3E3B:/ window 11,5
-27.7 "Doomvoid Slicer" sync / 1[56]:Voidwalker:3E3C:/
-46.7 "Shadowflame" sync / 1[56]:Voidwalker:3E4D:/
-59.4 "Dark Fire III" sync / 1[56]:Voidwalker:3E43:/ window 60,5
-67.4 "Unholy Darkness" sync / 1[56]:Voidwalker:3E40:/
-72.7 "Spell-In-Waiting" sync / 1[56]:Voidwalker:3E3E:/
-91.2 "Dark Fire III" sync / 1[56]:Voidwalker:3E43:/
-92.9 "Spell-In-Waiting" sync / 1[56]:Voidwalker:3E3E:/
-111.4 "Unholy Darkness" sync / 1[56]:Voidwalker:3E40:/
-113.3 "Spell-In-Waiting" sync / 1[56]:Voidwalker:3E3E:/
-127.3 "Spell-In-Waiting" sync / 1[56]:Voidwalker:3E3E:/
-146.4 "Dark Fire III" sync / 1[56]:Voidwalker:3E43:/
-146.4 "Unholy Darkness" sync / 1[56]:Voidwalker:3E40:/
+1.0 "--sync--" sync / 1[56]:[^:]*:Voidwalker:3E4C:/ window 1,0
+10.7 "Doomvoid Guillotine" sync / 1[56]:[^:]*:Voidwalker:3E3B:/ window 11,5
+27.7 "Doomvoid Slicer" sync / 1[56]:[^:]*:Voidwalker:3E3C:/
+46.7 "Shadowflame" sync / 1[56]:[^:]*:Voidwalker:3E4D:/
+59.4 "Dark Fire III" sync / 1[56]:[^:]*:Voidwalker:3E43:/ window 60,5
+67.4 "Unholy Darkness" sync / 1[56]:[^:]*:Voidwalker:3E40:/
+72.7 "Spell-In-Waiting" sync / 1[56]:[^:]*:Voidwalker:3E3E:/
+91.2 "Dark Fire III" sync / 1[56]:[^:]*:Voidwalker:3E43:/
+92.9 "Spell-In-Waiting" sync / 1[56]:[^:]*:Voidwalker:3E3E:/
+111.4 "Unholy Darkness" sync / 1[56]:[^:]*:Voidwalker:3E40:/
+113.3 "Spell-In-Waiting" sync / 1[56]:[^:]*:Voidwalker:3E3E:/
+127.3 "Spell-In-Waiting" sync / 1[56]:[^:]*:Voidwalker:3E3E:/
+146.4 "Dark Fire III" sync / 1[56]:[^:]*:Voidwalker:3E43:/
+146.4 "Unholy Darkness" sync / 1[56]:[^:]*:Voidwalker:3E40:/
 
-156.8 "Entropy" sync / 1[56]:Voidwalker:3E6E:/ window 200,5
-167.3 "Empty Hate" sync / 1[56]:The Hand of Erebos:3E46:/
-174.3 "Doomvoid Guillotine" sync / 1[56]:Voidwalker:3E3B:/
-184.3 "Empty Hate" sync / 1[56]:The Hand of Erebos:3E46:/
-191.3 "Doomvoid Slicer" sync / 1[56]:Voidwalker:3E3C:/
-206.3 "Shadowflame" sync / 1[56]:Voidwalker:3E4D:/
+156.8 "Entropy" sync / 1[56]:[^:]*:Voidwalker:3E6E:/ window 200,5
+167.3 "Empty Hate" sync / 1[56]:[^:]*:The Hand of Erebos:3E46:/
+174.3 "Doomvoid Guillotine" sync / 1[56]:[^:]*:Voidwalker:3E3B:/
+184.3 "Empty Hate" sync / 1[56]:[^:]*:The Hand of Erebos:3E46:/
+191.3 "Doomvoid Slicer" sync / 1[56]:[^:]*:Voidwalker:3E3C:/
+206.3 "Shadowflame" sync / 1[56]:[^:]*:Voidwalker:3E4D:/
 
-216.8 "Entropy" sync / 1[56]:Voidwalker:3E6E:/ window 30,5
-223.3 "Spell-In-Waiting" sync / 1[56]:Voidwalker:3E3E:/
-230.3 "Punishing Ray" sync / 1[56]:Voidwalker:3E47:/
-241.3 "Spell-In-Waiting" sync / 1[56]:Voidwalker:3E3E:/
-252.4 "Unholy Darkness" sync / 1[56]:Voidwalker:3E40:/
-259.4 "Dark Fire III" sync / 1[56]:Voidwalker:3E43:/
-270.3 "Empty Hate" sync / 1[56]:The Hand of Erebos:3E46:/
-277.3 "Punishing Ray" sync / 1[56]:Voidwalker:3E47:/
+216.8 "Entropy" sync / 1[56]:[^:]*:Voidwalker:3E6E:/ window 30,5
+223.3 "Spell-In-Waiting" sync / 1[56]:[^:]*:Voidwalker:3E3E:/
+230.3 "Punishing Ray" sync / 1[56]:[^:]*:Voidwalker:3E47:/
+241.3 "Spell-In-Waiting" sync / 1[56]:[^:]*:Voidwalker:3E3E:/
+252.4 "Unholy Darkness" sync / 1[56]:[^:]*:Voidwalker:3E40:/
+259.4 "Dark Fire III" sync / 1[56]:[^:]*:Voidwalker:3E43:/
+270.3 "Empty Hate" sync / 1[56]:[^:]*:The Hand of Erebos:3E46:/
+277.3 "Punishing Ray" sync / 1[56]:[^:]*:Voidwalker:3E47:/
 
-286.8 "Entropy" sync / 1[56]:Voidwalker:3E6E:/
-296.0 "Shadoweye" sync / 1[56]:Voidwalker:40B7:/
-301.3 "Spell-In-Waiting" sync / 1[56]:Voidwalker:3E3E:/
-316.3 "Doomvoid Guillotine" sync / 1[56]:Voidwalker:3E3B:/
-331.3 "Doomvoid Slicer" sync / 1[56]:Voidwalker:3E3C:/
-331.4 "Shadoweye" sync / 1[56]:Voidwalker:40B7:/
+286.8 "Entropy" sync / 1[56]:[^:]*:Voidwalker:3E6E:/
+296.0 "Shadoweye" sync / 1[56]:[^:]*:Voidwalker:40B7:/
+301.3 "Spell-In-Waiting" sync / 1[56]:[^:]*:Voidwalker:3E3E:/
+316.3 "Doomvoid Guillotine" sync / 1[56]:[^:]*:Voidwalker:3E3B:/
+331.3 "Doomvoid Slicer" sync / 1[56]:[^:]*:Voidwalker:3E3C:/
+331.4 "Shadoweye" sync / 1[56]:[^:]*:Voidwalker:40B7:/
 
-351.8 "Entropy" sync / 1[56]:Voidwalker:3E6E:/
-360.3 "Spell-In-Waiting" sync / 1[56]:Voidwalker:3E3E:/
-366.3 "Empty Hate" sync / 1[56]:The Hand of Erebos:3E46:/
-374.3 "Punishing Ray" sync / 1[56]:Voidwalker:3E47:/
-383.3 "Spell-In-Waiting" sync / 1[56]:Voidwalker:3E3E:/
-394.5 "Unholy Darkness" sync / 1[56]:Voidwalker:3E40:/
-401.5 "Dark Fire III" sync / 1[56]:Voidwalker:3E43:/
-408.4 "Shadowflame" sync / 1[56]:Voidwalker:3E4D:/
-416.4 "Doomvoid Guillotine" sync / 1[56]:Voidwalker:3E3B:/
-426.4 "Empty Hate" sync / 1[56]:The Hand of Erebos:3E46:/
-431.4 "Doomvoid Slicer" sync / 1[56]:Voidwalker:3E3C:/
-441.1 "Shadoweye" sync / 1[56]:Voidwalker:40B7:/
-450.4 "Shadowflame" sync / 1[56]:Voidwalker:3E4D:/
+351.8 "Entropy" sync / 1[56]:[^:]*:Voidwalker:3E6E:/
+360.3 "Spell-In-Waiting" sync / 1[56]:[^:]*:Voidwalker:3E3E:/
+366.3 "Empty Hate" sync / 1[56]:[^:]*:The Hand of Erebos:3E46:/
+374.3 "Punishing Ray" sync / 1[56]:[^:]*:Voidwalker:3E47:/
+383.3 "Spell-In-Waiting" sync / 1[56]:[^:]*:Voidwalker:3E3E:/
+394.5 "Unholy Darkness" sync / 1[56]:[^:]*:Voidwalker:3E40:/
+401.5 "Dark Fire III" sync / 1[56]:[^:]*:Voidwalker:3E43:/
+408.4 "Shadowflame" sync / 1[56]:[^:]*:Voidwalker:3E4D:/
+416.4 "Doomvoid Guillotine" sync / 1[56]:[^:]*:Voidwalker:3E3B:/
+426.4 "Empty Hate" sync / 1[56]:[^:]*:The Hand of Erebos:3E46:/
+431.4 "Doomvoid Slicer" sync / 1[56]:[^:]*:Voidwalker:3E3C:/
+441.1 "Shadoweye" sync / 1[56]:[^:]*:Voidwalker:40B7:/
+450.4 "Shadowflame" sync / 1[56]:[^:]*:Voidwalker:3E4D:/
 
-461.8 "Entropy" sync / 1[56]:Voidwalker:3E6E:/ window 50,50 jump 351.8
+461.8 "Entropy" sync / 1[56]:[^:]*:Voidwalker:3E6E:/ window 50,50 jump 351.8
 470.3 "Spell-In-Waiting"
 476.3 "Empty Hate"
 484.3 "Punishing Ray"

--- a/ui/raidboss/data/05-shb/raid/e2s.txt
+++ b/ui/raidboss/data/05-shb/raid/e2s.txt
@@ -10,7 +10,7 @@ hideall "Spell-In-Waiting"
 
 0 "Start"
 0.0 "--sync--" sync /:Engage!/ window 0,1
-1.5 "--sync--" sync / 1[56]:Voidwalker:3E60/ window 2,0
+1.5 "--sync--" sync / 1[56]:Voidwalker:3E60:/ window 2,0
 10.5 "--sync--" sync / 1[56]:Voidwalker:3E63:/ window 11,5
 11.2 "Doomvoid Cleaver" sync / 1[56]:Voidwalker:3E64:/
 25.4 "Unholy Darkness" sync / 1[56]:Voidwalker:3E54:/

--- a/ui/raidboss/data/05-shb/raid/e2s.txt
+++ b/ui/raidboss/data/05-shb/raid/e2s.txt
@@ -10,80 +10,80 @@ hideall "Spell-In-Waiting"
 
 0 "Start"
 0.0 "--sync--" sync /:Engage!/ window 0,1
-1.5 "--sync--" sync / 1[56]:Voidwalker:3E60:/ window 2,0
-10.5 "--sync--" sync / 1[56]:Voidwalker:3E63:/ window 11,5
-11.2 "Doomvoid Cleaver" sync / 1[56]:Voidwalker:3E64:/
-25.4 "Unholy Darkness" sync / 1[56]:Voidwalker:3E54:/
-31.8 "Slicer/Guillotine" sync / 1[56]:Voidwalker:(3E4F|3E50):/
-43.8 "Dark Fire III" sync / 1[56]:Voidwalker:3E57:/
-59.2 "Spell-In-Waiting" sync / 1[56]:Voidwalker:3E52:/
-69.3 "Punishing Ray" sync / 1[56]:Voidwalker:3E5B:/
-72.7 "Spell-In-Waiting" sync / 1[56]:Voidwalker:3E52:/
-86.1 "Spell-In-Waiting" sync / 1[56]:Voidwalker:3E52:/
-95.3 "Dark Fire III" sync / 1[56]:Voidwalker:3E57:/
-105.3 "Hell Wind" sync / 1[56]:Voidwalker:3E66:/
-106.8 "Shadoweye" sync / 1[56]:Voidwalker:3E69:/
-106.8 "Unholy Darkness" sync / 1[56]:Voidwalker:3E54:/
-121.9 "Shadowflame" sync / 1[56]:Voidwalker:3E61:/
-134.1 "Entropy" sync / 1[56]:Voidwalker:3E70:/
-143.8 "Empty Rage" sync / 1[56]:Voidwalker:3E6C:/
-148.7 "Doomvoid Guillotine" sync / 1[56]:Voidwalker:3E4F:/
-156.9 "Doomvoid Slicer" sync / 1[56]:Voidwalker:3E50:/
-164.9 "Empty Hate" sync / 1[56]:Voidwalker:3E5A:/
-175.8 "Doomvoid Cleaver" sync / 1[56]:Voidwalker:3E64:/
-191.2 "Shadowflame" sync / 1[56]:Voidwalker:3E61:/
-203.4 "Entropy" sync / 1[56]:Voidwalker:3E70:/
-208.0 "Spell-In-Waiting" sync / 1[56]:Voidwalker:3E52:/
-224.9 "Flare" sync / 1[56]:Voidwalker:4685:/
-229.3 "Spell-In-Waiting" sync / 1[56]:Voidwalker:3E52:/
-242.5 "Hell Wind" sync / 1[56]:Voidwalker:3E66:/
-248.5 "Punishing Ray" sync / 1[56]:Voidwalker:3E5B:/
-248.9 "Shadoweye" sync / 1[56]:Voidwalker:3E69:/
-260.7 "Shadowflame" sync / 1[56]:Voidwalker:3E61:/
-272.9 "Entropy" sync / 1[56]:Voidwalker:3E70:/
+1.5 "--sync--" sync / 1[56]:[^:]*:Voidwalker:3E60:/ window 2,0
+10.5 "--sync--" sync / 1[56]:[^:]*:Voidwalker:3E63:/ window 11,5
+11.2 "Doomvoid Cleaver" sync / 1[56]:[^:]*:Voidwalker:3E64:/
+25.4 "Unholy Darkness" sync / 1[56]:[^:]*:Voidwalker:3E54:/
+31.8 "Slicer/Guillotine" sync / 1[56]:[^:]*:Voidwalker:(3E4F|3E50):/
+43.8 "Dark Fire III" sync / 1[56]:[^:]*:Voidwalker:3E57:/
+59.2 "Spell-In-Waiting" sync / 1[56]:[^:]*:Voidwalker:3E52:/
+69.3 "Punishing Ray" sync / 1[56]:[^:]*:Voidwalker:3E5B:/
+72.7 "Spell-In-Waiting" sync / 1[56]:[^:]*:Voidwalker:3E52:/
+86.1 "Spell-In-Waiting" sync / 1[56]:[^:]*:Voidwalker:3E52:/
+95.3 "Dark Fire III" sync / 1[56]:[^:]*:Voidwalker:3E57:/
+105.3 "Hell Wind" sync / 1[56]:[^:]*:Voidwalker:3E66:/
+106.8 "Shadoweye" sync / 1[56]:[^:]*:Voidwalker:3E69:/
+106.8 "Unholy Darkness" sync / 1[56]:[^:]*:Voidwalker:3E54:/
+121.9 "Shadowflame" sync / 1[56]:[^:]*:Voidwalker:3E61:/
+134.1 "Entropy" sync / 1[56]:[^:]*:Voidwalker:3E70:/
+143.8 "Empty Rage" sync / 1[56]:[^:]*:Voidwalker:3E6C:/
+148.7 "Doomvoid Guillotine" sync / 1[56]:[^:]*:Voidwalker:3E4F:/
+156.9 "Doomvoid Slicer" sync / 1[56]:[^:]*:Voidwalker:3E50:/
+164.9 "Empty Hate" sync / 1[56]:[^:]*:Voidwalker:3E5A:/
+175.8 "Doomvoid Cleaver" sync / 1[56]:[^:]*:Voidwalker:3E64:/
+191.2 "Shadowflame" sync / 1[56]:[^:]*:Voidwalker:3E61:/
+203.4 "Entropy" sync / 1[56]:[^:]*:Voidwalker:3E70:/
+208.0 "Spell-In-Waiting" sync / 1[56]:[^:]*:Voidwalker:3E52:/
+224.9 "Flare" sync / 1[56]:[^:]*:Voidwalker:4685:/
+229.3 "Spell-In-Waiting" sync / 1[56]:[^:]*:Voidwalker:3E52:/
+242.5 "Hell Wind" sync / 1[56]:[^:]*:Voidwalker:3E66:/
+248.5 "Punishing Ray" sync / 1[56]:[^:]*:Voidwalker:3E5B:/
+248.9 "Shadoweye" sync / 1[56]:[^:]*:Voidwalker:3E69:/
+260.7 "Shadowflame" sync / 1[56]:[^:]*:Voidwalker:3E61:/
+272.9 "Entropy" sync / 1[56]:[^:]*:Voidwalker:3E70:/
 282.9 "Light/Dark Circles" # ???
-286.4 "Doomvoid Cleaver" sync / 1[56]:Voidwalker:3E64:/
-295.7 "Unholy Darkness" sync / 1[56]:Voidwalker:3E54:/
-304.1 "Slicer/Guillotine" sync / 1[56]:Voidwalker:(3E4F|3E50):/
-330.3 "Shadowflame" sync / 1[56]:Voidwalker:3E61:/
-342.5 "Entropy" sync / 1[56]:Voidwalker:3E70:/
-348.1 "Spell-In-Waiting" sync / 1[56]:Voidwalker:3E52:/
-358.2 "Empty Hate/Rage" sync / 1[56]:Voidwalker:(3E5A|3E6C):/
-361.4 "Spell-In-Waiting" sync / 1[56]:Voidwalker:3E52:/
-374.7 "Spell-In-Waiting" sync / 1[56]:Voidwalker:3E52:/
-381.6 "Flare" sync / 1[56]:Voidwalker:4685:/
-386.9 "Unholy Darkness" sync / 1[56]:Voidwalker:3E54:/
-399.9 "Shadowflame" sync / 1[56]:Voidwalker:3E61:/
-408.5 "Spell-In-Waiting" sync / 1[56]:Voidwalker:3E52:/
-421.8 "Spell-In-Waiting" sync / 1[56]:Voidwalker:3E52:/
-430.0 "Shadoweye" sync / 1[56]:Voidwalker:3E69:/
-430.0 "Flare" sync / 1[56]:Voidwalker:4685:/
-437.4 "Dark Fire III" sync / 1[56]:Voidwalker:3E57:/
+286.4 "Doomvoid Cleaver" sync / 1[56]:[^:]*:Voidwalker:3E64:/
+295.7 "Unholy Darkness" sync / 1[56]:[^:]*:Voidwalker:3E54:/
+304.1 "Slicer/Guillotine" sync / 1[56]:[^:]*:Voidwalker:(3E4F|3E50):/
+330.3 "Shadowflame" sync / 1[56]:[^:]*:Voidwalker:3E61:/
+342.5 "Entropy" sync / 1[56]:[^:]*:Voidwalker:3E70:/
+348.1 "Spell-In-Waiting" sync / 1[56]:[^:]*:Voidwalker:3E52:/
+358.2 "Empty Hate/Rage" sync / 1[56]:[^:]*:Voidwalker:(3E5A|3E6C):/
+361.4 "Spell-In-Waiting" sync / 1[56]:[^:]*:Voidwalker:3E52:/
+374.7 "Spell-In-Waiting" sync / 1[56]:[^:]*:Voidwalker:3E52:/
+381.6 "Flare" sync / 1[56]:[^:]*:Voidwalker:4685:/
+386.9 "Unholy Darkness" sync / 1[56]:[^:]*:Voidwalker:3E54:/
+399.9 "Shadowflame" sync / 1[56]:[^:]*:Voidwalker:3E61:/
+408.5 "Spell-In-Waiting" sync / 1[56]:[^:]*:Voidwalker:3E52:/
+421.8 "Spell-In-Waiting" sync / 1[56]:[^:]*:Voidwalker:3E52:/
+430.0 "Shadoweye" sync / 1[56]:[^:]*:Voidwalker:3E69:/
+430.0 "Flare" sync / 1[56]:[^:]*:Voidwalker:4685:/
+437.4 "Dark Fire III" sync / 1[56]:[^:]*:Voidwalker:3E57:/
 445.4 "Light/Dark Circles" # ???
-450.2 "Punishing Ray" sync / 1[56]:Voidwalker:3E5B:/
-455.0 "Doomvoid Cleaver" sync / 1[56]:Voidwalker:3E64:/
-469.4 "Shadowflame" sync / 1[56]:Voidwalker:3E61:/
+450.2 "Punishing Ray" sync / 1[56]:[^:]*:Voidwalker:3E5B:/
+455.0 "Doomvoid Cleaver" sync / 1[56]:[^:]*:Voidwalker:3E64:/
+469.4 "Shadowflame" sync / 1[56]:[^:]*:Voidwalker:3E61:/
 
 # FIXME: I've seen this push ~6s earlier once
 # but is pretty consistent otherwise?
-499.2 "Quietus" sync / 1[56]:Voidwalker:3E71:/ window 500,20
-507.4 "Cycle Of ?" sync / 1[56]:Voidwalker:(40B9|4659):/
-510.5 "Slicer/Guillotine?" sync / 1[56]:Voidwalker:465A:/
-511.2 "Cleaver/Slicer?" sync / 1[56]:Voidwalker:3E64:/
-513.6 "Guillotine/Cleaver?" sync / 1[56]:Voidwalker:465B:/
+499.2 "Quietus" sync / 1[56]:[^:]*:Voidwalker:3E71:/ window 500,20
+507.4 "Cycle Of ?" sync / 1[56]:[^:]*:Voidwalker:(40B9|4659):/
+510.5 "Slicer/Guillotine?" sync / 1[56]:[^:]*:Voidwalker:465A:/
+511.2 "Cleaver/Slicer?" sync / 1[56]:[^:]*:Voidwalker:3E64:/
+513.6 "Guillotine/Cleaver?" sync / 1[56]:[^:]*:Voidwalker:465B:/
 
-531.8 "Cycle Of ?" sync / 1[56]:Voidwalker:(40B9|4659):/
-534.9 "Slicer/Guillotine?" sync / 1[56]:Voidwalker:40BA:/
-538.0 "Cleaver/Slicer?" sync / 1[56]:Voidwalker:40BB:/
-538.7 "Guillotine/Cleaver?" sync / 1[56]:Voidwalker:3E64:/
+531.8 "Cycle Of ?" sync / 1[56]:[^:]*:Voidwalker:(40B9|4659):/
+534.9 "Slicer/Guillotine?" sync / 1[56]:[^:]*:Voidwalker:40BA:/
+538.0 "Cleaver/Slicer?" sync / 1[56]:[^:]*:Voidwalker:40BB:/
+538.7 "Guillotine/Cleaver?" sync / 1[56]:[^:]*:Voidwalker:3E64:/
 
-558.2 "Quietus" sync / 1[56]:Voidwalker:3E71:/
-568.2 "Cycle Of ?" sync / 1[56]:Voidwalker:(40B9|4659):/
-571.3 "Slicer/Guillotine?" sync / 1[56]:Voidwalker:(40BA|465A):/
-574.4 "Cleaver/Slicer?" #sync / 1[56]:Voidwalker:(40BB|3E64):/
-575.1 "Guillotine/Cleaver?" #sync / 1[56]:Voidwalker:(3E64|465B):/
-593.2 "Quietus" sync / 1[56]:Voidwalker:3E71:/
-602.5 "Quietus" sync / 1[56]:Voidwalker:3E71:/
-611.8 "Quietus" sync / 1[56]:Voidwalker:3E71:/
-624.8 "--sync--" sync / 14:Voidwalker:3E73:/ window 700,5
+558.2 "Quietus" sync / 1[56]:[^:]*:Voidwalker:3E71:/
+568.2 "Cycle Of ?" sync / 1[56]:[^:]*:Voidwalker:(40B9|4659):/
+571.3 "Slicer/Guillotine?" sync / 1[56]:[^:]*:Voidwalker:(40BA|465A):/
+574.4 "Cleaver/Slicer?" #sync / 1[56]:[^:]*:Voidwalker:(40BB|3E64):/
+575.1 "Guillotine/Cleaver?" #sync / 1[56]:[^:]*:Voidwalker:(3E64|465B):/
+593.2 "Quietus" sync / 1[56]:[^:]*:Voidwalker:3E71:/
+602.5 "Quietus" sync / 1[56]:[^:]*:Voidwalker:3E71:/
+611.8 "Quietus" sync / 1[56]:[^:]*:Voidwalker:3E71:/
+624.8 "--sync--" sync / 14:[^:]*:Voidwalker:3E73:/ window 700,5
 629.8 "Quietus Enrage"

--- a/ui/raidboss/data/05-shb/raid/e3n.txt
+++ b/ui/raidboss/data/05-shb/raid/e3n.txt
@@ -8,81 +8,81 @@ hideall "--sync--"
 0.0 "--Reset--" sync / 21:........:40000010:/ window 100000 jump 0
 
 0.0 "--sync--" sync /:Engage!/ window 0,1
-0.5 "--sync--" sync / 1[56]:Leviathan:42D8:/ window 1,0
-12.5 "Tidal Roar" sync / 1[56]:Leviathan:3FC4:/ window 13,5
-23.5 "Rip Current" sync / 1[56]:Leviathan:3FC6:/
-37.7 "Temporary Current" sync / 1[56]:Leviathan:3FC[DE]:/
-47.0 "Drenching Pulse" sync / 1[56]:Leviathan:3FC8:/
-51.1 "Monster Wave" sync / 1[56]:Leviathan:3FCA:/
-55.1 "Freak Wave" sync / 1[56]:Leviathan:3FCB:/
-60.2 "Temporary Current" sync / 1[56]:Leviathan:3FC[DE]:/
-70.4 "Tidal Roar" sync / 1[56]:Leviathan:3FC4:/ window 30,30
-77.4 "Rip Current" sync / 1[56]:Leviathan:3FC6:/
-98.7 "Tidal Wave" sync / 1[56]:Leviathan:3FD3:/
+0.5 "--sync--" sync / 1[56]:[^:]*:Leviathan:42D8:/ window 1,0
+12.5 "Tidal Roar" sync / 1[56]:[^:]*:Leviathan:3FC4:/ window 13,5
+23.5 "Rip Current" sync / 1[56]:[^:]*:Leviathan:3FC6:/
+37.7 "Temporary Current" sync / 1[56]:[^:]*:Leviathan:3FC[DE]:/
+47.0 "Drenching Pulse" sync / 1[56]:[^:]*:Leviathan:3FC8:/
+51.1 "Monster Wave" sync / 1[56]:[^:]*:Leviathan:3FCA:/
+55.1 "Freak Wave" sync / 1[56]:[^:]*:Leviathan:3FCB:/
+60.2 "Temporary Current" sync / 1[56]:[^:]*:Leviathan:3FC[DE]:/
+70.4 "Tidal Roar" sync / 1[56]:[^:]*:Leviathan:3FC4:/ window 30,30
+77.4 "Rip Current" sync / 1[56]:[^:]*:Leviathan:3FC6:/
+98.7 "Tidal Wave" sync / 1[56]:[^:]*:Leviathan:3FD3:/
 
-105.6 "Undersea Quake" sync / 1[56]:Leviathan:3FD0:/ window 105.6,10
-114.8 "Crashing Pulse" sync / 1[56]:Leviathan:3FC9:/
-118.9 "Monster Wave" sync / 1[56]:Leviathan:3FCA:/
-122.9 "Killer Wave" sync / 1[56]:Leviathan:3FCC:/
-128.9 "Tidal Roar" sync / 1[56]:Leviathan:3FC4:/
-140.0 "Temporary Current" sync / 1[56]:Leviathan:3FC[DE]:/ window 30,30
-162.3 "Tsunami" sync / 1[56]:Leviathan:441B:/
-171.9 "Surging Tsunami" sync / 1[56]:Leviathan:4011:/
-178.9 "Smothering Tsunami" sync / 1[56]:Leviathan:3FD7:/
-184.9 "Splashing Tsunami" sync / 1[56]:Leviathan:3FD6:/
-185.8 "Swirling Tsunami" sync / 1[56]:Leviathan:3FD5:/
-192.8 "Surging Tsunami" sync / 1[56]:Leviathan:4011:/
-203.5 "Tidal Roar" sync / 1[56]:Leviathan:3FC4:/ window 20,20
+105.6 "Undersea Quake" sync / 1[56]:[^:]*:Leviathan:3FD0:/ window 105.6,10
+114.8 "Crashing Pulse" sync / 1[56]:[^:]*:Leviathan:3FC9:/
+118.9 "Monster Wave" sync / 1[56]:[^:]*:Leviathan:3FCA:/
+122.9 "Killer Wave" sync / 1[56]:[^:]*:Leviathan:3FCC:/
+128.9 "Tidal Roar" sync / 1[56]:[^:]*:Leviathan:3FC4:/
+140.0 "Temporary Current" sync / 1[56]:[^:]*:Leviathan:3FC[DE]:/ window 30,30
+162.3 "Tsunami" sync / 1[56]:[^:]*:Leviathan:441B:/
+171.9 "Surging Tsunami" sync / 1[56]:[^:]*:Leviathan:4011:/
+178.9 "Smothering Tsunami" sync / 1[56]:[^:]*:Leviathan:3FD7:/
+184.9 "Splashing Tsunami" sync / 1[56]:[^:]*:Leviathan:3FD6:/
+185.8 "Swirling Tsunami" sync / 1[56]:[^:]*:Leviathan:3FD5:/
+192.8 "Surging Tsunami" sync / 1[56]:[^:]*:Leviathan:4011:/
+203.5 "Tidal Roar" sync / 1[56]:[^:]*:Leviathan:3FC4:/ window 20,20
 
-216.7 "Maelstrom" sync / 1[56]:Leviathan:3FD8:/ window 216.7,2.5 duration 30
+216.7 "Maelstrom" sync / 1[56]:[^:]*:Leviathan:3FD8:/ window 216.7,2.5 duration 30
 218.7 "--untargetable--"
-222.0 "--sync--" sync / 1[56]:Leviathan:3F7E:/
-226.9 "Spinning Dive 1" sync / 1[56]:Leviathan:3FDB:/
-229.1 "--sync--" sync / 1[56]:Leviathan:3F7E:/
-234.0 "Spinning Dive 2" sync / 1[56]:Leviathan:3FDB:/
+222.0 "--sync--" sync / 1[56]:[^:]*:Leviathan:3F7E:/
+226.9 "Spinning Dive 1" sync / 1[56]:[^:]*:Leviathan:3FDB:/
+229.1 "--sync--" sync / 1[56]:[^:]*:Leviathan:3F7E:/
+234.0 "Spinning Dive 2" sync / 1[56]:[^:]*:Leviathan:3FDB:/
 240.4 "--targetable--"
-248.4 "Tidal Roar" sync / 1[56]:Leviathan:3FC4:/
-255.4 "Rip Current" sync / 1[56]:Leviathan:3FC6:/ window 30,30
-276.8 "Tidal Wave" sync / 1[56]:Leviathan:3FD3:/
+248.4 "Tidal Roar" sync / 1[56]:[^:]*:Leviathan:3FC4:/
+255.4 "Rip Current" sync / 1[56]:[^:]*:Leviathan:3FC6:/ window 30,30
+276.8 "Tidal Wave" sync / 1[56]:[^:]*:Leviathan:3FD3:/
 
-283.8 "Undersea Quake" sync / 1[56]:Leviathan:3FCF:/ window 300,100
-293.0 "Drenching Pulse" sync / 1[56]:Leviathan:3FC8:/
-297.1 "Monster Wave" sync / 1[56]:Leviathan:3FCA:/
-301.1 "Freak Wave" sync / 1[56]:Leviathan:3FCB:/
-308.2 "Temporary Current 1" sync / 1[56]:Leviathan:3FC[DE]:/
-317.3 "Temporary Current 2" sync / 1[56]:Leviathan:3FC[DE]:/
-332.5 "Tidal Roar" sync / 1[56]:Leviathan:3FC4:/
-338.6 "Tidal Roar" sync / 1[56]:Leviathan:3FC4:/
-348.8 "Rip Current" sync / 1[56]:Leviathan:3FC6:/ window 30,30
-360.0 "Drenching Pulse" sync / 1[56]:Leviathan:3FC8:/
-364.1 "Monster Wave" sync / 1[56]:Leviathan:3FCA:/
-368.1 "Freak Wave" sync / 1[56]:Leviathan:3FCB:/
+283.8 "Undersea Quake" sync / 1[56]:[^:]*:Leviathan:3FCF:/ window 300,100
+293.0 "Drenching Pulse" sync / 1[56]:[^:]*:Leviathan:3FC8:/
+297.1 "Monster Wave" sync / 1[56]:[^:]*:Leviathan:3FCA:/
+301.1 "Freak Wave" sync / 1[56]:[^:]*:Leviathan:3FCB:/
+308.2 "Temporary Current 1" sync / 1[56]:[^:]*:Leviathan:3FC[DE]:/
+317.3 "Temporary Current 2" sync / 1[56]:[^:]*:Leviathan:3FC[DE]:/
+332.5 "Tidal Roar" sync / 1[56]:[^:]*:Leviathan:3FC4:/
+338.6 "Tidal Roar" sync / 1[56]:[^:]*:Leviathan:3FC4:/
+348.8 "Rip Current" sync / 1[56]:[^:]*:Leviathan:3FC6:/ window 30,30
+360.0 "Drenching Pulse" sync / 1[56]:[^:]*:Leviathan:3FC8:/
+364.1 "Monster Wave" sync / 1[56]:[^:]*:Leviathan:3FCA:/
+368.1 "Freak Wave" sync / 1[56]:[^:]*:Leviathan:3FCB:/
 
-372.1 "Undersea Quake" sync / 1[56]:Leviathan:3FD0:/ window 30,30
-386.3 "Tsunami" sync / 1[56]:Leviathan:441B:/
-395.9 "Surging Tsunami" sync / 1[56]:Leviathan:4011:/
-402.9 "Smothering Tsunami" sync / 1[56]:Leviathan:3FD7:/
-408.8 "Splashing Tsunami" sync / 1[56]:Leviathan:3FD6:/
-409.8 "Swirling Tsunami" sync / 1[56]:Leviathan:3FD5:/
-416.8 "Surging Tsunami" sync / 1[56]:Leviathan:4011:/
-429.4 "Temporary Current 1" sync / 1[56]:Leviathan:3FC[DE]:/
-438.4 "Temporary Current 2" sync / 1[56]:Leviathan:3FC[DE]:/
-449.4 "Rip Current" sync / 1[56]:Leviathan:3FC6:/ window 30,30
-455.4 "Tidal Roar" sync / 1[56]:Leviathan:3FC4:/
-461.4 "Tidal Roar" sync / 1[56]:Leviathan:3FC4:/
+372.1 "Undersea Quake" sync / 1[56]:[^:]*:Leviathan:3FD0:/ window 30,30
+386.3 "Tsunami" sync / 1[56]:[^:]*:Leviathan:441B:/
+395.9 "Surging Tsunami" sync / 1[56]:[^:]*:Leviathan:4011:/
+402.9 "Smothering Tsunami" sync / 1[56]:[^:]*:Leviathan:3FD7:/
+408.8 "Splashing Tsunami" sync / 1[56]:[^:]*:Leviathan:3FD6:/
+409.8 "Swirling Tsunami" sync / 1[56]:[^:]*:Leviathan:3FD5:/
+416.8 "Surging Tsunami" sync / 1[56]:[^:]*:Leviathan:4011:/
+429.4 "Temporary Current 1" sync / 1[56]:[^:]*:Leviathan:3FC[DE]:/
+438.4 "Temporary Current 2" sync / 1[56]:[^:]*:Leviathan:3FC[DE]:/
+449.4 "Rip Current" sync / 1[56]:[^:]*:Leviathan:3FC6:/ window 30,30
+455.4 "Tidal Roar" sync / 1[56]:[^:]*:Leviathan:3FC4:/
+461.4 "Tidal Roar" sync / 1[56]:[^:]*:Leviathan:3FC4:/
 
-476.4 "Maelstrom" sync / 1[56]:Leviathan:3FD8:/ duration 30
+476.4 "Maelstrom" sync / 1[56]:[^:]*:Leviathan:3FD8:/ duration 30
 478.4 "--untargetable--"
-481.4 "--sync--" sync / 1[56]:Leviathan:3F7E:/
-486.4 "Spinning Dive 1" sync / 1[56]:Leviathan:3FDB:/
-488.4 "--sync--" sync / 1[56]:Leviathan:3F7E:/
-493.4 "Spinning Dive 2" sync / 1[56]:Leviathan:3FDB:/
+481.4 "--sync--" sync / 1[56]:[^:]*:Leviathan:3F7E:/
+486.4 "Spinning Dive 1" sync / 1[56]:[^:]*:Leviathan:3FDB:/
+488.4 "--sync--" sync / 1[56]:[^:]*:Leviathan:3F7E:/
+493.4 "Spinning Dive 2" sync / 1[56]:[^:]*:Leviathan:3FDB:/
 499.9 "--targetable--"
-507.9 "Tidal Roar" sync / 1[56]:Leviathan:3FC4:/
-515.0 "Rip Current" sync / 1[56]:Leviathan:3FC6:/ window 30,30
-536.4 "Tidal Wave" sync / 1[56]:Leviathan:3FD3:/
+507.9 "Tidal Roar" sync / 1[56]:[^:]*:Leviathan:3FC4:/
+515.0 "Rip Current" sync / 1[56]:[^:]*:Leviathan:3FC6:/ window 30,30
+536.4 "Tidal Wave" sync / 1[56]:[^:]*:Leviathan:3FD3:/
 
-543.4 "Undersea Quake" sync / 1[56]:Leviathan:3FCF:/ window 100,100 jump 283.8
+543.4 "Undersea Quake" sync / 1[56]:[^:]*:Leviathan:3FCF:/ window 100,100 jump 283.8
 552.6 "Drenching Pulse"
 556.7 "Monster Wave"
 560.7 "Freak Wave"

--- a/ui/raidboss/data/05-shb/raid/e3s.txt
+++ b/ui/raidboss/data/05-shb/raid/e3s.txt
@@ -9,92 +9,92 @@ hideall "--sync--"
 
 0 "Start"
 0.0 "--sync--" sync /:Engage!/ window 0,1
-1.0 "--sync--" sync / 1[56]:Leviathan:42D9:/ window 1,0
-12.8 "Tidal Roar" sync / 1[56]:Leviathan:3FDC:/
-23.9 "Rip Current" sync / 1[56]:Leviathan:3FE0:/
-43.3 "Undersea Quake" sync / 1[56]:Leviathan:3FEF:/
-46.1 "Tidal Wave" sync / 1[56]:Leviathan:3FF2:/
-52.4 "Temporary Current" sync / 1[56]:Leviathan:(3FEB|3FEA):/
-61.6 "Drenching Pulse" sync / 1[56]:Leviathan:3FE2:/
-65.7 "Monster Wave" sync / 1[56]:Leviathan:3FE5:/
-69.7 "Freak Wave" sync / 1[56]:Leviathan:3FE6:/
-73.7 "Temporary Current" sync / 1[56]:Leviathan:(3FEB|3FEA):/
-87.9 "Maelstrom" sync / 1[56]:Leviathan:3FFA:/
+1.0 "--sync--" sync / 1[56]:[^:]*:Leviathan:42D9:/ window 1,0
+12.8 "Tidal Roar" sync / 1[56]:[^:]*:Leviathan:3FDC:/
+23.9 "Rip Current" sync / 1[56]:[^:]*:Leviathan:3FE0:/
+43.3 "Undersea Quake" sync / 1[56]:[^:]*:Leviathan:3FEF:/
+46.1 "Tidal Wave" sync / 1[56]:[^:]*:Leviathan:3FF2:/
+52.4 "Temporary Current" sync / 1[56]:[^:]*:Leviathan:(3FEB|3FEA):/
+61.6 "Drenching Pulse" sync / 1[56]:[^:]*:Leviathan:3FE2:/
+65.7 "Monster Wave" sync / 1[56]:[^:]*:Leviathan:3FE5:/
+69.7 "Freak Wave" sync / 1[56]:[^:]*:Leviathan:3FE6:/
+73.7 "Temporary Current" sync / 1[56]:[^:]*:Leviathan:(3FEB|3FEA):/
+87.9 "Maelstrom" sync / 1[56]:[^:]*:Leviathan:3FFA:/
 90.0 "--untargetable--"
-99.3 "Spinning Dive 1" #sync / 1[56]:Leviathan:3FFD:/
-101.3 "Spinning Dive 2" #sync / 1[56]:Leviathan:3FFD:/
+99.3 "Spinning Dive 1" #sync / 1[56]:[^:]*:Leviathan:3FFD:/
+101.3 "Spinning Dive 2" #sync / 1[56]:[^:]*:Leviathan:3FFD:/
 106.0 "--targetable--"
-111.5 "Tidal Roar" sync / 1[56]:Leviathan:3FDC:/
-127.8 "Tsunami" sync / 1[56]:Leviathan:3FF3:/
-132.8 "Tsunami" sync / 1[56]:Leviathan:441C:/
-141.4 "Sundering Tsunami" sync / 1[56]:Leviathan:3FF6:/
-146.1 "Undersea Quake" sync / 1[56]:Leviathan:3FEE:/
-158.4 "Temporary Current" sync / 1[56]:Leviathan:(3FEB|3FEA):/
-158.4 "Smothering Tsunami" sync / 1[56]:Leviathan:3FF7:/
-158.4 "Swirling Tsunami" sync / 1[56]:Leviathan:3FF4:/
-168.7 "Tidal Roar" sync / 1[56]:Leviathan:3FDC:/
-175.9 "Rip Current" sync / 1[56]:Leviathan:3FE0:/
-186.1 "Temporary Current" sync / 1[56]:Leviathan:(3FEB|3FEA):/
-197.3 "Tidal Roar" sync / 1[56]:Leviathan:3FDC:/
-210.4 "Refreshing Shower" sync / 1[56]:Leviathan:400F:/
-223.6 "Tidal Rage" sync / 1[56]:Leviathan:3FDE:/
-235.9 "Undersea Quake" sync / 1[56]:Leviathan:3FEF:/
-238.9 "Tidal Wave" sync / 1[56]:Leviathan:3FF2:/
-246.0 "Temporary Current" sync / 1[56]:Leviathan:(3FEB|3FEA):/
-250.1 "Temporary Current" sync / 1[56]:Leviathan:(3FEC|3FED):/
-256.2 "Drenching Pulse" sync / 1[56]:Leviathan:3FE2:/
-260.3 "Monster Wave" sync / 1[56]:Leviathan:3FE9:/
-264.3 "Freak Wave" sync / 1[56]:Leviathan:3FE6:/
-269.4 "Temporary Current" sync / 1[56]:Leviathan:(3FEB|3FEA):/
-273.5 "Temporary Current" sync / 1[56]:Leviathan:(3FEC|3FED):/
-287.8 "Maelstrom" sync / 1[56]:Leviathan:3FFA:/
+111.5 "Tidal Roar" sync / 1[56]:[^:]*:Leviathan:3FDC:/
+127.8 "Tsunami" sync / 1[56]:[^:]*:Leviathan:3FF3:/
+132.8 "Tsunami" sync / 1[56]:[^:]*:Leviathan:441C:/
+141.4 "Sundering Tsunami" sync / 1[56]:[^:]*:Leviathan:3FF6:/
+146.1 "Undersea Quake" sync / 1[56]:[^:]*:Leviathan:3FEE:/
+158.4 "Temporary Current" sync / 1[56]:[^:]*:Leviathan:(3FEB|3FEA):/
+158.4 "Smothering Tsunami" sync / 1[56]:[^:]*:Leviathan:3FF7:/
+158.4 "Swirling Tsunami" sync / 1[56]:[^:]*:Leviathan:3FF4:/
+168.7 "Tidal Roar" sync / 1[56]:[^:]*:Leviathan:3FDC:/
+175.9 "Rip Current" sync / 1[56]:[^:]*:Leviathan:3FE0:/
+186.1 "Temporary Current" sync / 1[56]:[^:]*:Leviathan:(3FEB|3FEA):/
+197.3 "Tidal Roar" sync / 1[56]:[^:]*:Leviathan:3FDC:/
+210.4 "Refreshing Shower" sync / 1[56]:[^:]*:Leviathan:400F:/
+223.6 "Tidal Rage" sync / 1[56]:[^:]*:Leviathan:3FDE:/
+235.9 "Undersea Quake" sync / 1[56]:[^:]*:Leviathan:3FEF:/
+238.9 "Tidal Wave" sync / 1[56]:[^:]*:Leviathan:3FF2:/
+246.0 "Temporary Current" sync / 1[56]:[^:]*:Leviathan:(3FEB|3FEA):/
+250.1 "Temporary Current" sync / 1[56]:[^:]*:Leviathan:(3FEC|3FED):/
+256.2 "Drenching Pulse" sync / 1[56]:[^:]*:Leviathan:3FE2:/
+260.3 "Monster Wave" sync / 1[56]:[^:]*:Leviathan:3FE9:/
+264.3 "Freak Wave" sync / 1[56]:[^:]*:Leviathan:3FE6:/
+269.4 "Temporary Current" sync / 1[56]:[^:]*:Leviathan:(3FEB|3FEA):/
+273.5 "Temporary Current" sync / 1[56]:[^:]*:Leviathan:(3FEC|3FED):/
+287.8 "Maelstrom" sync / 1[56]:[^:]*:Leviathan:3FFA:/
 290.0 "--untargetable--"
-301.2 "Spinning Dive 1" #sync / 1[56]:Leviathan:3FFD:/
-303.1 "Spinning Dive 2" #sync / 1[56]:Leviathan:3FFD:/
-305.1 "Spinning Dive 3" #sync / 1[56]:Leviathan:3FFD:/
+301.2 "Spinning Dive 1" #sync / 1[56]:[^:]*:Leviathan:3FFD:/
+303.1 "Spinning Dive 2" #sync / 1[56]:[^:]*:Leviathan:3FFD:/
+305.1 "Spinning Dive 3" #sync / 1[56]:[^:]*:Leviathan:3FFD:/
 310.0 "--targetable--"
-316.4 "Tidal Rage" sync / 1[56]:Leviathan:3FDE:/
-323.5 "Rip Current" sync / 1[56]:Leviathan:3FE0:/
-339.7 "Stormy Horizon" sync / 1[56]:Leviathan:3FFE:/
-346.8 "Monster Wave x4" duration 6 #sync / 1[56]:Leviathan:3FE9:/
-352.8 "Backbreaking Wave" sync / 1[56]:Leviathan:4001:/
-353.9 "Temporary Current" sync / 1[56]:Leviathan:(3FEB|3FEA):/
-358.1 "Temporary Current" sync / 1[56]:Leviathan:(3FEC|3FED):/
-363.0 "Plunging Wave x5" duration 4.4 #sync / 1[56]:Leviathan:4003:/
-373.2 "Tidal Rage" sync / 1[56]:Leviathan:3FDE:/
-383.5 "Tidal Rage" sync / 1[56]:Leviathan:3FDE:/
-402.3 "Drenching Pulse" sync / 1[56]:Leviathan:3FE2:/
-406.4 "Monster Wave" sync / 1[56]:Leviathan:3FE9:/
-410.4 "Freak Wave" sync / 1[56]:Leviathan:3FE6:/
-413.4 "Undersea Quake" sync / 1[56]:Leviathan:3FEF:/
-422.6 "Tsunami" sync / 1[56]:Leviathan:3FF3:/
-427.6 "Tsunami" sync / 1[56]:Leviathan:441C:/
-436.1 "Surging Tsunami" sync / 1[56]:Leviathan:3FF8:/
-441.1 "Smothering Tsunami" sync / 1[56]:Leviathan:3FF7:/
-443.1 "Sweeping Tsunami" sync / 1[56]:Leviathan:3FF5:/
-449.2 "Sundering Tsunami" #sync / 1[56]:Leviathan:3FF6:/
-453.2 "Sundering Tsunami" #sync / 1[56]:Leviathan:3FF6:/
-457.1 "Scouring Tsunami" sync / 1[56]:Leviathan:3CE0:/
-466.8 "Temporary Current" sync / 1[56]:Leviathan:(3FEB|3FEA):/
-470.9 "Temporary Current" sync / 1[56]:Leviathan:(3FEC|3FED):/
-483.1 "Tidal Rage" sync / 1[56]:Leviathan:3FDE:/
-493.2 "Tidal Rage" sync / 1[56]:Leviathan:3FDE:/
-500.3 "Rip Current" sync / 1[56]:Leviathan:3FE0:/
-516.5 "Roiling Pulse" sync / 1[56]:Leviathan:3FE4:/
-520.6 "Monster Wave" sync / 1[56]:Leviathan:3FE9:/
-524.6 "Breaking Wave" sync / 1[56]:Leviathan:3FE8:/
-524.6 "Killer Wave" sync / 1[56]:Leviathan:3FE7:/
-525.7 "Undersea Quake" sync / 1[56]:Leviathan:3FEE:/
-534.9 "Black Smokers" sync / 1[56]:Leviathan:4007:/
-536.9 "Spilling Wave x12" duration 15 #sync / 1[56]:Leviathan:4008:/
-540.9 "Hydrothermal Vent x4" duration 9 #sync / 1[56]:Leviathan:4004:/
-544.4 "Hot Water x5" duration 9 #sync / 1[56]:Leviathan:4005:/
-561.9 "Temporary Current" sync / 1[56]:Leviathan:(3FEB|3FEA):/
-565.9 "Temporary Current" sync / 1[56]:Leviathan:(3FEC|3FED):/
-576.9 "Tidal Rage" sync / 1[56]:Leviathan:3FDE:/
-587.9 "Tidal Rage" sync / 1[56]:Leviathan:3FDE:/
-604.9 "The Calm" sync / 1[56]:Leviathan:4009:/
-617.9 "Tidal Rage" sync / 1[56]:Leviathan:400B:/
-625.9 "Tidal Rage" sync / 1[56]:Leviathan:400B:/
-633.9 "Tidal Rage" sync / 1[56]:Leviathan:400B:/
-654.9 "The Storm" sync / 1[56]:Leviathan:400D:/
+316.4 "Tidal Rage" sync / 1[56]:[^:]*:Leviathan:3FDE:/
+323.5 "Rip Current" sync / 1[56]:[^:]*:Leviathan:3FE0:/
+339.7 "Stormy Horizon" sync / 1[56]:[^:]*:Leviathan:3FFE:/
+346.8 "Monster Wave x4" duration 6 #sync / 1[56]:[^:]*:Leviathan:3FE9:/
+352.8 "Backbreaking Wave" sync / 1[56]:[^:]*:Leviathan:4001:/
+353.9 "Temporary Current" sync / 1[56]:[^:]*:Leviathan:(3FEB|3FEA):/
+358.1 "Temporary Current" sync / 1[56]:[^:]*:Leviathan:(3FEC|3FED):/
+363.0 "Plunging Wave x5" duration 4.4 #sync / 1[56]:[^:]*:Leviathan:4003:/
+373.2 "Tidal Rage" sync / 1[56]:[^:]*:Leviathan:3FDE:/
+383.5 "Tidal Rage" sync / 1[56]:[^:]*:Leviathan:3FDE:/
+402.3 "Drenching Pulse" sync / 1[56]:[^:]*:Leviathan:3FE2:/
+406.4 "Monster Wave" sync / 1[56]:[^:]*:Leviathan:3FE9:/
+410.4 "Freak Wave" sync / 1[56]:[^:]*:Leviathan:3FE6:/
+413.4 "Undersea Quake" sync / 1[56]:[^:]*:Leviathan:3FEF:/
+422.6 "Tsunami" sync / 1[56]:[^:]*:Leviathan:3FF3:/
+427.6 "Tsunami" sync / 1[56]:[^:]*:Leviathan:441C:/
+436.1 "Surging Tsunami" sync / 1[56]:[^:]*:Leviathan:3FF8:/
+441.1 "Smothering Tsunami" sync / 1[56]:[^:]*:Leviathan:3FF7:/
+443.1 "Sweeping Tsunami" sync / 1[56]:[^:]*:Leviathan:3FF5:/
+449.2 "Sundering Tsunami" #sync / 1[56]:[^:]*:Leviathan:3FF6:/
+453.2 "Sundering Tsunami" #sync / 1[56]:[^:]*:Leviathan:3FF6:/
+457.1 "Scouring Tsunami" sync / 1[56]:[^:]*:Leviathan:3CE0:/
+466.8 "Temporary Current" sync / 1[56]:[^:]*:Leviathan:(3FEB|3FEA):/
+470.9 "Temporary Current" sync / 1[56]:[^:]*:Leviathan:(3FEC|3FED):/
+483.1 "Tidal Rage" sync / 1[56]:[^:]*:Leviathan:3FDE:/
+493.2 "Tidal Rage" sync / 1[56]:[^:]*:Leviathan:3FDE:/
+500.3 "Rip Current" sync / 1[56]:[^:]*:Leviathan:3FE0:/
+516.5 "Roiling Pulse" sync / 1[56]:[^:]*:Leviathan:3FE4:/
+520.6 "Monster Wave" sync / 1[56]:[^:]*:Leviathan:3FE9:/
+524.6 "Breaking Wave" sync / 1[56]:[^:]*:Leviathan:3FE8:/
+524.6 "Killer Wave" sync / 1[56]:[^:]*:Leviathan:3FE7:/
+525.7 "Undersea Quake" sync / 1[56]:[^:]*:Leviathan:3FEE:/
+534.9 "Black Smokers" sync / 1[56]:[^:]*:Leviathan:4007:/
+536.9 "Spilling Wave x12" duration 15 #sync / 1[56]:[^:]*:Leviathan:4008:/
+540.9 "Hydrothermal Vent x4" duration 9 #sync / 1[56]:[^:]*:Leviathan:4004:/
+544.4 "Hot Water x5" duration 9 #sync / 1[56]:[^:]*:Leviathan:4005:/
+561.9 "Temporary Current" sync / 1[56]:[^:]*:Leviathan:(3FEB|3FEA):/
+565.9 "Temporary Current" sync / 1[56]:[^:]*:Leviathan:(3FEC|3FED):/
+576.9 "Tidal Rage" sync / 1[56]:[^:]*:Leviathan:3FDE:/
+587.9 "Tidal Rage" sync / 1[56]:[^:]*:Leviathan:3FDE:/
+604.9 "The Calm" sync / 1[56]:[^:]*:Leviathan:4009:/
+617.9 "Tidal Rage" sync / 1[56]:[^:]*:Leviathan:400B:/
+625.9 "Tidal Rage" sync / 1[56]:[^:]*:Leviathan:400B:/
+633.9 "Tidal Rage" sync / 1[56]:[^:]*:Leviathan:400B:/
+654.9 "The Storm" sync / 1[56]:[^:]*:Leviathan:400D:/

--- a/ui/raidboss/data/05-shb/raid/e4n.txt
+++ b/ui/raidboss/data/05-shb/raid/e4n.txt
@@ -20,54 +20,54 @@ hideall "Earthen Wheels"
 ### Phase 1
 0 "Start"
 0.0 "--sync--" sync /:Engage!/ window 0,1
-2.0 "--sync--" sync / 1[56]:Titan:413D:/ window 2,0
-13.0 "Voice Of The Land" sync / 1[56]:Titan:40F7:/
-21.3 "Evil Earth" sync / 1[56]:Titan:40EE:/
-30.5 "Weight Of The Land" sync / 1[56]:Titan:40EA:/
-41.6 "Stonecrusher" sync / 1[56]:Titan:40F9:/ window 30,30
-54.0 "Crumbling Down" sync / 1[56]:Massive Boulder:40F2:/
-66.0 "Seismic Wave" sync / 1[56]:Titan:40F3:/
-79.3 "Geocrush" sync / 1[56]:Titan:40F6:/
-83.2 "Earthen Gauntlets" sync / 1[56]:Titan:40E6:/
-91.3 "Massive Landslide" sync / 1[56]:Titan:40FA:/
-97.1 "Earthen Armor" sync / 1[56]:Titan:40E7:/
+2.0 "--sync--" sync / 1[56]:[^:]*:Titan:413D:/ window 2,0
+13.0 "Voice Of The Land" sync / 1[56]:[^:]*:Titan:40F7:/
+21.3 "Evil Earth" sync / 1[56]:[^:]*:Titan:40EE:/
+30.5 "Weight Of The Land" sync / 1[56]:[^:]*:Titan:40EA:/
+41.6 "Stonecrusher" sync / 1[56]:[^:]*:Titan:40F9:/ window 30,30
+54.0 "Crumbling Down" sync / 1[56]:[^:]*:Massive Boulder:40F2:/
+66.0 "Seismic Wave" sync / 1[56]:[^:]*:Titan:40F3:/
+79.3 "Geocrush" sync / 1[56]:[^:]*:Titan:40F6:/
+83.2 "Earthen Gauntlets" sync / 1[56]:[^:]*:Titan:40E6:/
+91.3 "Massive Landslide" sync / 1[56]:[^:]*:Titan:40FA:/
+97.1 "Earthen Armor" sync / 1[56]:[^:]*:Titan:40E7:/
 
 
 ### Phase 2
-109.1 "Stonecrusher" sync / 1[56]:Titan:40F9:/ window 30,30
-115.2 "Bomb Boulders" sync / 1[56]:Titan:40EC:/
-116.2 "Bury" #sync / 1[56]:Bomb Boulder:4141:/
-122.1 "Cobalt Bomb" sync / 1[56]:Titan:40F4:/
-129.3 "Explosion" sync / 1[56]:Bomb Boulder:40F5:/
-137.3 "Voice Of The Land" sync / 1[56]:Titan:40F7:/
-149.7 "Geocrush" sync / 1[56]:Titan:40F6:/
-153.6 "Earthen Wheels" sync / 1[56]:Titan:40E8:/
-161.7 "Fault Zone" sync / 1[56]:Titan:4102:/
-163.9 "Earthen Armor" sync / 1[56]:Titan:40E9:/
+109.1 "Stonecrusher" sync / 1[56]:[^:]*:Titan:40F9:/ window 30,30
+115.2 "Bomb Boulders" sync / 1[56]:[^:]*:Titan:40EC:/
+116.2 "Bury" #sync / 1[56]:[^:]*:Bomb Boulder:4141:/
+122.1 "Cobalt Bomb" sync / 1[56]:[^:]*:Titan:40F4:/
+129.3 "Explosion" sync / 1[56]:[^:]*:Bomb Boulder:40F5:/
+137.3 "Voice Of The Land" sync / 1[56]:[^:]*:Titan:40F7:/
+149.7 "Geocrush" sync / 1[56]:[^:]*:Titan:40F6:/
+153.6 "Earthen Wheels" sync / 1[56]:[^:]*:Titan:40E8:/
+161.7 "Fault Zone" sync / 1[56]:[^:]*:Titan:4102:/
+163.9 "Earthen Armor" sync / 1[56]:[^:]*:Titan:40E9:/
 
 
 ### Phase 3
-182.0 "Earthen Fury" sync / 1[56]:Titan:40F8:/
-197.2 "Stonecrusher" sync / 1[56]:Titan:40F9:/ window 30,30
-203.4 "Bomb Boulders" sync / 1[56]:Titan:40EC:/
-204.5 "Bury" #sync / 1[56]:Bomb Boulder:4141:/
-206.5 "Bury" #sync / 1[56]:Bomb Boulder:4141:/
-208.5 "Bury" #sync / 1[56]:Bomb Boulder:4141:/
-209.9 "Cobalt Bomb" sync / 1[56]:Titan:40F4:/
-217.4 "Explosion" sync / 1[56]:Bomb Boulder:40F5:/
-221.2 "Weight Of The Land" sync / 1[56]:Titan:40EA:/
-231.3 "Voice Of The Land" sync / 1[56]:Titan:40F7:/
-244.6 "Crumbling Down" sync / 1[56]:Massive Boulder:40F2:/
-245.7 "Evil Earth" sync / 1[56]:Titan:40EE:/
-256.8 "Seismic Wave" sync / 1[56]:Titan:40F3:/
+182.0 "Earthen Fury" sync / 1[56]:[^:]*:Titan:40F8:/
+197.2 "Stonecrusher" sync / 1[56]:[^:]*:Titan:40F9:/ window 30,30
+203.4 "Bomb Boulders" sync / 1[56]:[^:]*:Titan:40EC:/
+204.5 "Bury" #sync / 1[56]:[^:]*:Bomb Boulder:4141:/
+206.5 "Bury" #sync / 1[56]:[^:]*:Bomb Boulder:4141:/
+208.5 "Bury" #sync / 1[56]:[^:]*:Bomb Boulder:4141:/
+209.9 "Cobalt Bomb" sync / 1[56]:[^:]*:Titan:40F4:/
+217.4 "Explosion" sync / 1[56]:[^:]*:Bomb Boulder:40F5:/
+221.2 "Weight Of The Land" sync / 1[56]:[^:]*:Titan:40EA:/
+231.3 "Voice Of The Land" sync / 1[56]:[^:]*:Titan:40F7:/
+244.6 "Crumbling Down" sync / 1[56]:[^:]*:Massive Boulder:40F2:/
+245.7 "Evil Earth" sync / 1[56]:[^:]*:Titan:40EE:/
+256.8 "Seismic Wave" sync / 1[56]:[^:]*:Titan:40F3:/
 
 
 ### Phase 4A or Phase 6B?
-267.0 "Stonecrusher" sync / 1[56]:Titan:40F9:/ window 30,30
-274.3 "Geocrush" sync / 1[56]:Titan:40F6:/
+267.0 "Stonecrusher" sync / 1[56]:[^:]*:Titan:40F9:/ window 30,30
+274.3 "Geocrush" sync / 1[56]:[^:]*:Titan:40F6:/
 
-278.1 "Earthen Gauntlets" sync / 1[56]:Titan:40E6:/ window 30,30 jump 1278.1
-278.1 "Earthen Wheels" sync / 1[56]:Titan:40E8:/ window 30,30 jump 2278.1
+278.1 "Earthen Gauntlets" sync / 1[56]:[^:]*:Titan:40E6:/ window 30,30 jump 1278.1
+278.1 "Earthen Wheels" sync / 1[56]:[^:]*:Titan:40E8:/ window 30,30 jump 2278.1
 
 286.2 "Massive Landslide?"
 288.2 "Fault Zone?"
@@ -81,55 +81,55 @@ hideall "Earthen Wheels"
 
 
 ### Phase 4A
-1267.0 "Stonecrusher" sync / 1[56]:Titan:40F9:/ window 30,30
-1274.3 "Geocrush" sync / 1[56]:Titan:40F6:/
-1278.1 "Earthen Gauntlets" sync / 1[56]:Titan:40E6:/
-1286.2 "Massive Landslide" sync / 1[56]:Titan:40FA:/
-1300.8 "Left/Right Landslide" sync / 1[56]:Titan:(40FF|4100):/
-1315.4 "Left/Right Landslide" sync / 1[56]:Titan:(40FF|4100):/
-1324.1 "Earthen Armor" sync / 1[56]:Titan:40E7:/
+1267.0 "Stonecrusher" sync / 1[56]:[^:]*:Titan:40F9:/ window 30,30
+1274.3 "Geocrush" sync / 1[56]:[^:]*:Titan:40F6:/
+1278.1 "Earthen Gauntlets" sync / 1[56]:[^:]*:Titan:40E6:/
+1286.2 "Massive Landslide" sync / 1[56]:[^:]*:Titan:40FA:/
+1300.8 "Left/Right Landslide" sync / 1[56]:[^:]*:Titan:(40FF|4100):/
+1315.4 "Left/Right Landslide" sync / 1[56]:[^:]*:Titan:(40FF|4100):/
+1324.1 "Earthen Armor" sync / 1[56]:[^:]*:Titan:40E7:/
 
 
 ### Phase 5A
-1339.3 "Stonecrusher" sync / 1[56]:Titan:40F9:/ window 30,30
-1345.5 "Bomb Boulders" sync / 1[56]:Titan:40EC:/
-1346.5 "Bury" #sync / 1[56]:Bomb Boulder:4141:/
-1350.6 "Bury" #sync / 1[56]:Bomb Boulder:4141:/
-1361.9 "Evil Earth" sync / 1[56]:Titan:40EE:/
-1373.0 "Voice Of The Land" sync / 1[56]:Titan:40F7:/
-1382.3 "Evil Earth" sync / 1[56]:Titan:40EE:/
-1392.5 "Weight Of The Land" sync / 1[56]:Titan:40EA:/
+1339.3 "Stonecrusher" sync / 1[56]:[^:]*:Titan:40F9:/ window 30,30
+1345.5 "Bomb Boulders" sync / 1[56]:[^:]*:Titan:40EC:/
+1346.5 "Bury" #sync / 1[56]:[^:]*:Bomb Boulder:4141:/
+1350.6 "Bury" #sync / 1[56]:[^:]*:Bomb Boulder:4141:/
+1361.9 "Evil Earth" sync / 1[56]:[^:]*:Titan:40EE:/
+1373.0 "Voice Of The Land" sync / 1[56]:[^:]*:Titan:40F7:/
+1382.3 "Evil Earth" sync / 1[56]:[^:]*:Titan:40EE:/
+1392.5 "Weight Of The Land" sync / 1[56]:[^:]*:Titan:40EA:/
 
 
 ### Phase 6A
-1402.6 "Stonecrusher" sync / 1[56]:Titan:40F9:/ window 30,30
-1411.9 "Geocrush" sync / 1[56]:Titan:40F6:/
-1415.6 "Earthen Wheels" sync / 1[56]:Titan:40E8:/
-1423.8 "Fault Zone" sync / 1[56]:Titan:4102:/
-1431.4 "Fault Zone" sync / 1[56]:Titan:4102:/
-1439.0 "Fault Zone" sync / 1[56]:Titan:4102:/
-1447.0 "Magnitude 5.0" sync / 1[56]:Titan:4104:/
-1450.2 "Earthen Armor" sync / 1[56]:Titan:40E9:/
+1402.6 "Stonecrusher" sync / 1[56]:[^:]*:Titan:40F9:/ window 30,30
+1411.9 "Geocrush" sync / 1[56]:[^:]*:Titan:40F6:/
+1415.6 "Earthen Wheels" sync / 1[56]:[^:]*:Titan:40E8:/
+1423.8 "Fault Zone" sync / 1[56]:[^:]*:Titan:4102:/
+1431.4 "Fault Zone" sync / 1[56]:[^:]*:Titan:4102:/
+1439.0 "Fault Zone" sync / 1[56]:[^:]*:Titan:4102:/
+1447.0 "Magnitude 5.0" sync / 1[56]:[^:]*:Titan:4104:/
+1450.2 "Earthen Armor" sync / 1[56]:[^:]*:Titan:40E9:/
 
 
 ### Phase 3A Redux
-1463.3 "Earthen Fury" sync / 1[56]:Titan:40F8:/
-1478.4 "Stonecrusher" sync / 1[56]:Titan:40F9:/ window 30,30
-1484.6 "Bomb Boulders" sync / 1[56]:Titan:40EC:/
-1485.5 "Bury" #sync / 1[56]:Bomb Boulder:4141:/
-1487.5 "Bury" #sync / 1[56]:Bomb Boulder:4141:/
-1489.5 "Bury" #sync / 1[56]:Bomb Boulder:4141:/
-1491.0 "Cobalt Bomb" sync / 1[56]:Titan:40F4:/
-1498.6 "Explosion" sync / 1[56]:Bomb Boulder:40F5:/
-1502.2 "Weight Of The Land" sync / 1[56]:Titan:40EA:/
-1512.3 "Voice Of The Land" sync / 1[56]:Titan:40F7:/
-1525.6 "Crumbling Down" sync / 1[56]:Massive Boulder:40F2:/
-1526.8 "Evil Earth" sync / 1[56]:Titan:40EE:/
-1537.9 "Seismic Wave" sync / 1[56]:Titan:40F3:/
+1463.3 "Earthen Fury" sync / 1[56]:[^:]*:Titan:40F8:/
+1478.4 "Stonecrusher" sync / 1[56]:[^:]*:Titan:40F9:/ window 30,30
+1484.6 "Bomb Boulders" sync / 1[56]:[^:]*:Titan:40EC:/
+1485.5 "Bury" #sync / 1[56]:[^:]*:Bomb Boulder:4141:/
+1487.5 "Bury" #sync / 1[56]:[^:]*:Bomb Boulder:4141:/
+1489.5 "Bury" #sync / 1[56]:[^:]*:Bomb Boulder:4141:/
+1491.0 "Cobalt Bomb" sync / 1[56]:[^:]*:Titan:40F4:/
+1498.6 "Explosion" sync / 1[56]:[^:]*:Bomb Boulder:40F5:/
+1502.2 "Weight Of The Land" sync / 1[56]:[^:]*:Titan:40EA:/
+1512.3 "Voice Of The Land" sync / 1[56]:[^:]*:Titan:40F7:/
+1525.6 "Crumbling Down" sync / 1[56]:[^:]*:Massive Boulder:40F2:/
+1526.8 "Evil Earth" sync / 1[56]:[^:]*:Titan:40EE:/
+1537.9 "Seismic Wave" sync / 1[56]:[^:]*:Titan:40F3:/
 
 
 ### Phase 4A loop
-1548.0 "Stonecrusher" sync / 1[56]:Titan:40F9:/ window 50,50 jump 1267
+1548.0 "Stonecrusher" sync / 1[56]:[^:]*:Titan:40F9:/ window 50,50 jump 1267
 1555.2 "Geocrush"
 1559.0 "Earthen Gauntlets"
 1567.2 "Massive Landslide"
@@ -141,55 +141,55 @@ hideall "Earthen Wheels"
 
 
 ### Phase 6B
-2267.0 "Stonecrusher" sync / 1[56]:Titan:40F9:/ window 30,30
-2274.3 "Geocrush" sync / 1[56]:Titan:40F6:/
-2278.1 "Earthen Wheels" sync / 1[56]:Titan:40E8:/
-2286.2 "Fault Zone" sync / 1[56]:Titan:4102:/
-2293.8 "Fault Zone" sync / 1[56]:Titan:4102:/
-2301.4 "Fault Zone" sync / 1[56]:Titan:4102:/
-2309.4 "Magnitude 5.0" sync / 1[56]:Titan:4104:/
-2312.6 "Earthen Armor" sync / 1[56]:Titan:40E9:/
+2267.0 "Stonecrusher" sync / 1[56]:[^:]*:Titan:40F9:/ window 30,30
+2274.3 "Geocrush" sync / 1[56]:[^:]*:Titan:40F6:/
+2278.1 "Earthen Wheels" sync / 1[56]:[^:]*:Titan:40E8:/
+2286.2 "Fault Zone" sync / 1[56]:[^:]*:Titan:4102:/
+2293.8 "Fault Zone" sync / 1[56]:[^:]*:Titan:4102:/
+2301.4 "Fault Zone" sync / 1[56]:[^:]*:Titan:4102:/
+2309.4 "Magnitude 5.0" sync / 1[56]:[^:]*:Titan:4104:/
+2312.6 "Earthen Armor" sync / 1[56]:[^:]*:Titan:40E9:/
 
 
 ### Phase 5B
-2329.4 "Stonecrusher" sync / 1[56]:Titan:40F9:/ window 30,30
-2335.4 "Bomb Boulders" sync / 1[56]:Titan:40EC:/
-2336.4 "Bury" #sync / 1[56]:Bomb Boulder:4141:/
-2340.4 "Bury" #sync / 1[56]:Bomb Boulder:4141:/
-2351.5 "Evil Earth" sync / 1[56]:Titan:40EE:/
-2362.4 "Voice Of The Land" sync / 1[56]:Titan:40F7:/
-2371.5 "Evil Earth" sync / 1[56]:Titan:40EE:/
-2381.5 "Weight Of The Land" sync / 1[56]:Titan:40EA:/
+2329.4 "Stonecrusher" sync / 1[56]:[^:]*:Titan:40F9:/ window 30,30
+2335.4 "Bomb Boulders" sync / 1[56]:[^:]*:Titan:40EC:/
+2336.4 "Bury" #sync / 1[56]:[^:]*:Bomb Boulder:4141:/
+2340.4 "Bury" #sync / 1[56]:[^:]*:Bomb Boulder:4141:/
+2351.5 "Evil Earth" sync / 1[56]:[^:]*:Titan:40EE:/
+2362.4 "Voice Of The Land" sync / 1[56]:[^:]*:Titan:40F7:/
+2371.5 "Evil Earth" sync / 1[56]:[^:]*:Titan:40EE:/
+2381.5 "Weight Of The Land" sync / 1[56]:[^:]*:Titan:40EA:/
 
 
 ### Phase 4B
-2391.4 "Stonecrusher" sync / 1[56]:Titan:40F9:/ window 30,30
-2400.4 "Geocrush" sync / 1[56]:Titan:40F6:/
-2404.2 "Earthen Gauntlets" sync / 1[56]:Titan:40E6:/
-2412.3 "Massive Landslide" sync / 1[56]:Titan:40FA:/
-2426.9 "Left/Right Landslide" sync / 1[56]:Titan:(40FF|4100):/
-2441.5 "Left/Right Landslide" sync / 1[56]:Titan:(40FF|4100):/
-2450.1 "Earthen Armor" sync / 1[56]:Titan:40E7:/
+2391.4 "Stonecrusher" sync / 1[56]:[^:]*:Titan:40F9:/ window 30,30
+2400.4 "Geocrush" sync / 1[56]:[^:]*:Titan:40F6:/
+2404.2 "Earthen Gauntlets" sync / 1[56]:[^:]*:Titan:40E6:/
+2412.3 "Massive Landslide" sync / 1[56]:[^:]*:Titan:40FA:/
+2426.9 "Left/Right Landslide" sync / 1[56]:[^:]*:Titan:(40FF|4100):/
+2441.5 "Left/Right Landslide" sync / 1[56]:[^:]*:Titan:(40FF|4100):/
+2450.1 "Earthen Armor" sync / 1[56]:[^:]*:Titan:40E7:/
 
 
 ### Phase 3B Redux
-2461.2 "Earthen Fury" sync / 1[56]:Titan:40F8:/
-2476.2 "Stonecrusher" sync / 1[56]:Titan:40F9:/ window 30,30
-2482.8 "Bomb Boulders" sync / 1[56]:Titan:40EC:/
-2483.8 "Bury" #sync / 1[56]:Bomb Boulder:4141:/
-2485.8 "Bury" #sync / 1[56]:Bomb Boulder:4141:/
-2487.8 "Bury" #sync / 1[56]:Bomb Boulder:4141:/
-2489.4 "Cobalt Bomb" sync / 1[56]:Titan:40F4:/
-2496.8 "Explosion" sync / 1[56]:Bomb Boulder:40F5:/
-2500.6 "Weight Of The Land" sync / 1[56]:Titan:40EA:/
-2510.5 "Voice Of The Land" sync / 1[56]:Titan:40F7:/
-2523.5 "Crumbling Down" sync / 1[56]:Massive Boulder:40F2:/
-2524.6 "Evil Earth" sync / 1[56]:Titan:40EE:/
-2535.5 "Seismic Wave" sync / 1[56]:Titan:40F3:/
+2461.2 "Earthen Fury" sync / 1[56]:[^:]*:Titan:40F8:/
+2476.2 "Stonecrusher" sync / 1[56]:[^:]*:Titan:40F9:/ window 30,30
+2482.8 "Bomb Boulders" sync / 1[56]:[^:]*:Titan:40EC:/
+2483.8 "Bury" #sync / 1[56]:[^:]*:Bomb Boulder:4141:/
+2485.8 "Bury" #sync / 1[56]:[^:]*:Bomb Boulder:4141:/
+2487.8 "Bury" #sync / 1[56]:[^:]*:Bomb Boulder:4141:/
+2489.4 "Cobalt Bomb" sync / 1[56]:[^:]*:Titan:40F4:/
+2496.8 "Explosion" sync / 1[56]:[^:]*:Bomb Boulder:40F5:/
+2500.6 "Weight Of The Land" sync / 1[56]:[^:]*:Titan:40EA:/
+2510.5 "Voice Of The Land" sync / 1[56]:[^:]*:Titan:40F7:/
+2523.5 "Crumbling Down" sync / 1[56]:[^:]*:Massive Boulder:40F2:/
+2524.6 "Evil Earth" sync / 1[56]:[^:]*:Titan:40EE:/
+2535.5 "Seismic Wave" sync / 1[56]:[^:]*:Titan:40F3:/
 
 
 ### Phase 6B Loop
-2545.5 "Stonecrusher" sync / 1[56]:Titan:40F9:/ window 50,50 jump 2267
+2545.5 "Stonecrusher" sync / 1[56]:[^:]*:Titan:40F9:/ window 50,50 jump 2267
 2554.8 "Geocrush"
 2558.5 "Earthen Wheels"
 2566.7 "Fault Zone"

--- a/ui/raidboss/data/05-shb/raid/e4n.txt
+++ b/ui/raidboss/data/05-shb/raid/e4n.txt
@@ -173,7 +173,7 @@ hideall "Earthen Wheels"
 
 
 ### Phase 3B Redux
-2461.2 "Earthen Fury" sync / 1[56]:Titan:40F8/
+2461.2 "Earthen Fury" sync / 1[56]:Titan:40F8:/
 2476.2 "Stonecrusher" sync / 1[56]:Titan:40F9:/ window 30,30
 2482.8 "Bomb Boulders" sync / 1[56]:Titan:40EC:/
 2483.8 "Bury" #sync / 1[56]:Bomb Boulder:4141:/

--- a/ui/raidboss/data/05-shb/raid/e4s.txt
+++ b/ui/raidboss/data/05-shb/raid/e4s.txt
@@ -13,136 +13,136 @@ hideall "Earthen Wheels"
 ### Warmup
 0 "Start"
 0.0 "--sync--" sync /:Engage!/ window 0,1
-2.5 "--sync--" sync / 1[56]:Titan:413D:/ window 3,0
-11.0 "--sync--" sync / 14:Titan:4116:/ window 11,5
-16.0 "Stonecrusher 1" sync / 1[56]:Titan:4116:/
-19.1 "Stonecrusher 2" #sync / 1[56]:Titan:4143:/
-22.1 "Stonecrusher 3" #sync / 1[56]:Titan:4143:/
-34.2 "Weight of the Land" sync / 1[56]:Titan:4108:/
-37.2 "Pulse of the Land" sync / 1[56]:Titan:4106:/
-39.5 "Evil Earth" sync / 1[56]:Titan:410B:/
-48.4 "Force of the Land" sync / 1[56]:Titan:4107:/
-54.6 "Voice of the Land" sync / 1[56]:Titan:4114:/
-66.8 "Geocrush" sync / 1[56]:Titan:4113:/
+2.5 "--sync--" sync / 1[56]:[^:]*:Titan:413D:/ window 3,0
+11.0 "--sync--" sync / 14:[^:]*:Titan:4116:/ window 11,5
+16.0 "Stonecrusher 1" sync / 1[56]:[^:]*:Titan:4116:/
+19.1 "Stonecrusher 2" #sync / 1[56]:[^:]*:Titan:4143:/
+22.1 "Stonecrusher 3" #sync / 1[56]:[^:]*:Titan:4143:/
+34.2 "Weight of the Land" sync / 1[56]:[^:]*:Titan:4108:/
+37.2 "Pulse of the Land" sync / 1[56]:[^:]*:Titan:4106:/
+39.5 "Evil Earth" sync / 1[56]:[^:]*:Titan:410B:/
+48.4 "Force of the Land" sync / 1[56]:[^:]*:Titan:4107:/
+54.6 "Voice of the Land" sync / 1[56]:[^:]*:Titan:4114:/
+66.8 "Geocrush" sync / 1[56]:[^:]*:Titan:4113:/
 
 70.5 "Earthen Wheels/Gauntlets?"
-70.5 "--sync--" sync / 1[56]:Titan:40E8:/ window 100,100 jump 270.5
-70.5 "--sync--" sync / 1[56]:Titan:40E6:/ window 100,100 jump 570.5
+70.5 "--sync--" sync / 1[56]:[^:]*:Titan:40E8:/ window 100,100 jump 270.5
+70.5 "--sync--" sync / 1[56]:[^:]*:Titan:40E6:/ window 100,100 jump 570.5
 
 ### Wheels Path
-270.5 "Earthen Wheels" sync / 1[56]:Titan:40E8:/
-277.7 "Pulse of the Land" sync / 1[56]:Titan:4106:/
-277.7 "Force of the Land" sync / 1[56]:Titan:4107:/
-286.0 "Magnitude 5.0" sync / 1[56]:Titan:4121:/ window 10,10
-289.1 "Earthen Armor" sync / 1[56]:Titan:40E9:/
-291.0 "Pulse of the Land" sync / 1[56]:Titan:4106:/
-307.2 "Crumbling Down" sync / 1[56]:Titan:410E:/
-315.3 "Bomb Boulders" sync / 1[56]:Titan:4109:/
-327.4 "Seismic Wave" sync / 1[56]:Titan:4110:/
-340.7 "Voice of the Land" sync / 1[56]:Titan:4114:/
-350.0 "Stonecrusher 1" sync / 1[56]:Titan:4116:/
-353.1 "Stonecrusher 2" #sync / 1[56]:Titan:4143:/
-356.1 "Stonecrusher 3" #sync / 1[56]:Titan:4143:/
-372.4 "Geocrush" sync / 1[56]:Titan:4113:/
-376.2 "Earthen Gauntlets" sync / 1[56]:Titan:40E6:/
-382.6 "Pulse of the Land" sync / 1[56]:Titan:4106:/
-382.6 "Force of the Land" sync / 1[56]:Titan:4107:/
-396.7 "Voice of the Land" sync / 1[56]:Titan:4114:/
-407.5 "Landslide" sync / 1[56]:Titan:411A:/
-413.5 "Right/Left Landslide" sync / 1[56]:Titan:411[CD]:/
-420.7 "Earthen Armor" sync / 1[56]:Titan:40E7:/
+270.5 "Earthen Wheels" sync / 1[56]:[^:]*:Titan:40E8:/
+277.7 "Pulse of the Land" sync / 1[56]:[^:]*:Titan:4106:/
+277.7 "Force of the Land" sync / 1[56]:[^:]*:Titan:4107:/
+286.0 "Magnitude 5.0" sync / 1[56]:[^:]*:Titan:4121:/ window 10,10
+289.1 "Earthen Armor" sync / 1[56]:[^:]*:Titan:40E9:/
+291.0 "Pulse of the Land" sync / 1[56]:[^:]*:Titan:4106:/
+307.2 "Crumbling Down" sync / 1[56]:[^:]*:Titan:410E:/
+315.3 "Bomb Boulders" sync / 1[56]:[^:]*:Titan:4109:/
+327.4 "Seismic Wave" sync / 1[56]:[^:]*:Titan:4110:/
+340.7 "Voice of the Land" sync / 1[56]:[^:]*:Titan:4114:/
+350.0 "Stonecrusher 1" sync / 1[56]:[^:]*:Titan:4116:/
+353.1 "Stonecrusher 2" #sync / 1[56]:[^:]*:Titan:4143:/
+356.1 "Stonecrusher 3" #sync / 1[56]:[^:]*:Titan:4143:/
+372.4 "Geocrush" sync / 1[56]:[^:]*:Titan:4113:/
+376.2 "Earthen Gauntlets" sync / 1[56]:[^:]*:Titan:40E6:/
+382.6 "Pulse of the Land" sync / 1[56]:[^:]*:Titan:4106:/
+382.6 "Force of the Land" sync / 1[56]:[^:]*:Titan:4107:/
+396.7 "Voice of the Land" sync / 1[56]:[^:]*:Titan:4114:/
+407.5 "Landslide" sync / 1[56]:[^:]*:Titan:411A:/
+413.5 "Right/Left Landslide" sync / 1[56]:[^:]*:Titan:411[CD]:/
+420.7 "Earthen Armor" sync / 1[56]:[^:]*:Titan:40E7:/
 425.7 "--untargetable--"
-431.1 "Orogenesis" #sync / 1[56]:Titan:4371:/
+431.1 "Orogenesis" #sync / 1[56]:[^:]*:Titan:4371:/
 
 
 ### Gauntlets path
-570.5 "Earthen Gauntlets" sync / 1[56]:Titan:40E6:/
-576.8 "Force of the Land" sync / 1[56]:Titan:4107:/
-576.8 "Pulse of the Land" sync / 1[56]:Titan:4106:/
-590.8 "Voice of the Land" sync / 1[56]:Titan:4114:/
-601.5 "Landslide" sync / 1[56]:Titan:411A:/
-607.5 "Right/Left Landslide" sync / 1[56]:Titan:411[CD]:/
-614.7 "Earthen Armor" sync / 1[56]:Titan:40E7:/
-632.9 "Crumbling Down" sync / 1[56]:Titan:410E:/
-641.1 "Bomb Boulders" sync / 1[56]:Titan:4109:/
-653.1 "Seismic Wave" sync / 1[56]:Titan:4110:/
-666.4 "Voice of the Land" sync / 1[56]:Titan:4114:/
-675.6 "Stonecrusher 1" sync / 1[56]:Titan:4116:/
-678.7 "Stonecrusher 2" #sync / 1[56]:Titan:4143:/
-681.8 "Stonecrusher 3" #sync / 1[56]:Titan:4143:/
-698.1 "Geocrush" sync / 1[56]:Titan:4113:/
-702.0 "Earthen Wheels" sync / 1[56]:Titan:40E8:/
-709.0 "Pulse of the Land" sync / 1[56]:Titan:4106:/
-709.0 "Force of the Land" sync / 1[56]:Titan:4107:/
-717.6 "Magnitude 5.0" sync / 1[56]:Titan:4121:/ window 10,10
-720.7 "Earthen Armor" sync / 1[56]:Titan:40E9:/
-722.6 "Pulse of the Land" sync / 1[56]:Titan:4106:/
+570.5 "Earthen Gauntlets" sync / 1[56]:[^:]*:Titan:40E6:/
+576.8 "Force of the Land" sync / 1[56]:[^:]*:Titan:4107:/
+576.8 "Pulse of the Land" sync / 1[56]:[^:]*:Titan:4106:/
+590.8 "Voice of the Land" sync / 1[56]:[^:]*:Titan:4114:/
+601.5 "Landslide" sync / 1[56]:[^:]*:Titan:411A:/
+607.5 "Right/Left Landslide" sync / 1[56]:[^:]*:Titan:411[CD]:/
+614.7 "Earthen Armor" sync / 1[56]:[^:]*:Titan:40E7:/
+632.9 "Crumbling Down" sync / 1[56]:[^:]*:Titan:410E:/
+641.1 "Bomb Boulders" sync / 1[56]:[^:]*:Titan:4109:/
+653.1 "Seismic Wave" sync / 1[56]:[^:]*:Titan:4110:/
+666.4 "Voice of the Land" sync / 1[56]:[^:]*:Titan:4114:/
+675.6 "Stonecrusher 1" sync / 1[56]:[^:]*:Titan:4116:/
+678.7 "Stonecrusher 2" #sync / 1[56]:[^:]*:Titan:4143:/
+681.8 "Stonecrusher 3" #sync / 1[56]:[^:]*:Titan:4143:/
+698.1 "Geocrush" sync / 1[56]:[^:]*:Titan:4113:/
+702.0 "Earthen Wheels" sync / 1[56]:[^:]*:Titan:40E8:/
+709.0 "Pulse of the Land" sync / 1[56]:[^:]*:Titan:4106:/
+709.0 "Force of the Land" sync / 1[56]:[^:]*:Titan:4107:/
+717.6 "Magnitude 5.0" sync / 1[56]:[^:]*:Titan:4121:/ window 10,10
+720.7 "Earthen Armor" sync / 1[56]:[^:]*:Titan:40E9:/
+722.6 "Pulse of the Land" sync / 1[56]:[^:]*:Titan:4106:/
 725.8 "--untargetable--"
-730.5 "Orogenesis" #sync / 1[56]:Titan:4371:/
+730.5 "Orogenesis" #sync / 1[56]:[^:]*:Titan:4371:/
 
 
 ### Transition
-1000.0 "Orogenesis" sync / 1[56]:Titan:4371:/ window 1000,0
+1000.0 "Orogenesis" sync / 1[56]:[^:]*:Titan:4371:/ window 1000,0
 1026.3 "--targetable--"
-1033.1 "Earthen Fury" sync / 1[56]:Titan Maximum:4124:/
-1048.3 "Earthen Fist" sync / 1[56]:Titan Maximum:(4130|4131|4132|412F):/
-1053.2 "Weight of the Land" sync / 1[56]:Titan:4108:/
-1061.9 "Dual Earthen Fists" sync / 1[56]:Titan Maximum:4135:/
-1065.9 "Earthen Anguish" sync / 1[56]:Titan:4137:/
-1071.8 "Megalith?" sync / 1[56]:Titan Maximum:4138:/
-1088.0 "Tectonic Uplift" sync / 1[56]:Titan Maximum:4122:/ window 20,20
-1100.1 "Force of the Land" sync / 1[56]:Titan:4107:/
-1100.1 "Pulse of the Land" sync / 1[56]:Titan:4106:/
-1108.2 "Earthen Fury" sync / 1[56]:Titan Maximum:4124:/
-1122.3 "Rock Throw" sync / 1[56]:Titan Maximum:412D:/
-1135.1 "Plate Fracture" sync / 1[56]:Titan:43EA:/
-1149.2 "Plate Fracture" sync / 1[56]:Titan:43EA:/
-1162.4 "Plate Fracture" sync / 1[56]:Titan:43EA:/
-1171.9 "Earthen Fury" sync / 1[56]:Titan Maximum:4124:/
-1180.7 "Tumult x5" sync / 1[56]:Titan Maximum:412A:/ duration 6
-1197.4 "Dual Earthen Fists" sync / 1[56]:Titan Maximum:4135:/
-1201.4 "Earthen Anguish" sync / 1[56]:Titan:4137:/
-1208.3 "Earthen Fist" sync / 1[56]:Titan Maximum:(4130|4131|4132|412F):/
-1225.7 "Tectonic Uplift" sync / 1[56]:Titan Maximum:4122:/
-1249.0 "Pulse of the Land" sync / 1[56]:Titan:4106:/
-1226.6 "Force of the Land" sync / 1[56]:Titan:4107:/
-1263.2 "Weight of the World" sync / 1[56]:Titan Maximum:442B:/
-1275.1 "Force of the Land" sync / 1[56]:Titan:4107:/
-1283.4 "Earthen Fury" sync / 1[56]:Titan Maximum:4124:/
-1292.2 "Tumult x5" sync / 1[56]:Titan Maximum:412A:/ duration 6
-1314.4 "Plate Fracture" sync / 1[56]:Titan:43EA:/
-1324.0 "Megalith" sync / 1[56]:Titan Maximum:4138:/
-1337.7 "Plate Fracture" sync / 1[56]:Titan:43EA:/
-1340.7 "Pulse of the Land" sync / 1[56]:Titan:4106:/
-1340.7 "Force of the Land" sync / 1[56]:Titan:4107:/
-1349.1 "Earthen Fury" sync / 1[56]:Titan Maximum:4124:/
+1033.1 "Earthen Fury" sync / 1[56]:[^:]*:Titan Maximum:4124:/
+1048.3 "Earthen Fist" sync / 1[56]:[^:]*:Titan Maximum:(4130|4131|4132|412F):/
+1053.2 "Weight of the Land" sync / 1[56]:[^:]*:Titan:4108:/
+1061.9 "Dual Earthen Fists" sync / 1[56]:[^:]*:Titan Maximum:4135:/
+1065.9 "Earthen Anguish" sync / 1[56]:[^:]*:Titan:4137:/
+1071.8 "Megalith?" sync / 1[56]:[^:]*:Titan Maximum:4138:/
+1088.0 "Tectonic Uplift" sync / 1[56]:[^:]*:Titan Maximum:4122:/ window 20,20
+1100.1 "Force of the Land" sync / 1[56]:[^:]*:Titan:4107:/
+1100.1 "Pulse of the Land" sync / 1[56]:[^:]*:Titan:4106:/
+1108.2 "Earthen Fury" sync / 1[56]:[^:]*:Titan Maximum:4124:/
+1122.3 "Rock Throw" sync / 1[56]:[^:]*:Titan Maximum:412D:/
+1135.1 "Plate Fracture" sync / 1[56]:[^:]*:Titan:43EA:/
+1149.2 "Plate Fracture" sync / 1[56]:[^:]*:Titan:43EA:/
+1162.4 "Plate Fracture" sync / 1[56]:[^:]*:Titan:43EA:/
+1171.9 "Earthen Fury" sync / 1[56]:[^:]*:Titan Maximum:4124:/
+1180.7 "Tumult x5" sync / 1[56]:[^:]*:Titan Maximum:412A:/ duration 6
+1197.4 "Dual Earthen Fists" sync / 1[56]:[^:]*:Titan Maximum:4135:/
+1201.4 "Earthen Anguish" sync / 1[56]:[^:]*:Titan:4137:/
+1208.3 "Earthen Fist" sync / 1[56]:[^:]*:Titan Maximum:(4130|4131|4132|412F):/
+1225.7 "Tectonic Uplift" sync / 1[56]:[^:]*:Titan Maximum:4122:/
+1249.0 "Pulse of the Land" sync / 1[56]:[^:]*:Titan:4106:/
+1226.6 "Force of the Land" sync / 1[56]:[^:]*:Titan:4107:/
+1263.2 "Weight of the World" sync / 1[56]:[^:]*:Titan Maximum:442B:/
+1275.1 "Force of the Land" sync / 1[56]:[^:]*:Titan:4107:/
+1283.4 "Earthen Fury" sync / 1[56]:[^:]*:Titan Maximum:4124:/
+1292.2 "Tumult x5" sync / 1[56]:[^:]*:Titan Maximum:412A:/ duration 6
+1314.4 "Plate Fracture" sync / 1[56]:[^:]*:Titan:43EA:/
+1324.0 "Megalith" sync / 1[56]:[^:]*:Titan Maximum:4138:/
+1337.7 "Plate Fracture" sync / 1[56]:[^:]*:Titan:43EA:/
+1340.7 "Pulse of the Land" sync / 1[56]:[^:]*:Titan:4106:/
+1340.7 "Force of the Land" sync / 1[56]:[^:]*:Titan:4107:/
+1349.1 "Earthen Fury" sync / 1[56]:[^:]*:Titan Maximum:4124:/
 1359.3 "--untargetable--"
 
-1359.3 "Orogenesis" sync / 1[56]:Titan Maximum:4372:/ window 1500,1500
+1359.3 "Orogenesis" sync / 1[56]:[^:]*:Titan Maximum:4372:/ window 1500,1500
 1364.3 "--targetable--"
-1373.3 "Earthen Fury" sync / 1[56]:Titan Maximum:413A:/
-1392.6 "Force of the Land" sync / 1[56]:Titan:4107:/
-1392.6 "Pulse of the Land" sync / 1[56]:Titan:4106:/
-1401.9 "Dual Earthen Fists" sync / 1[56]:Titan Maximum:4135:/
-1406.0 "Earthen Anguish" sync / 1[56]:Titan:4137:/
-1414.6 "Voice of the Land" sync / 1[56]:Titan:4114:/
-1417.4 "Tumult x5" sync / 1[56]:Titan Maximum:412A:/ duration 6
-1426.9 "Voice of the Land" sync / 1[56]:Titan:4114:/
-1438.1 "Earthen Fury" sync / 1[56]:Titan Maximum:413A:/
-1457.3 "Pulse of the Land" sync / 1[56]:Titan:4106:/
-1457.3 "Force of the Land" sync / 1[56]:Titan:4107:/
-1468.4 "Earthen Fist" sync / 1[56]:Titan Maximum:(4130|4131|4132|412F):/
-1479.5 "Stonecrusher 1" sync / 1[56]:Titan:4116:/
-1482.6 "Stonecrusher 2" #sync / 1[56]:Titan:4143:/
-1485.7 "Stonecrusher 3" #sync / 1[56]:Titan:4143:/
-1491.8 "Megalith" sync / 1[56]:Titan Maximum:4138:/
-1504.1 "Earthen Fury" sync / 1[56]:Titan Maximum:413A:/
-1523.4 "Pulse of the Land" sync / 1[56]:Titan:4106:/
-1523.4 "Force of the Land" sync / 1[56]:Titan:4107:/
-1534.3 "Earthen Fist" sync / 1[56]:Titan Maximum:(4130|4131|4132|412F):/
-1543.4 "Voice of the Land" sync / 1[56]:Titan:4114:/
-1546.2 "Tumult x5" sync / 1[56]:Titan Maximum:412A:/ duration 6
-1555.6 "Voice of the Land" sync / 1[56]:Titan:4114:/
-1558.4 "Tumult x5" sync / 1[56]:Titan Maximum:412A:/ duration 6
-1567.9 "Voice of the Land" sync / 1[56]:Titan:4114:/
-1581.1 "Earthen Fury Enrage" sync / 1[56]:Titan Maximum:4140:/
+1373.3 "Earthen Fury" sync / 1[56]:[^:]*:Titan Maximum:413A:/
+1392.6 "Force of the Land" sync / 1[56]:[^:]*:Titan:4107:/
+1392.6 "Pulse of the Land" sync / 1[56]:[^:]*:Titan:4106:/
+1401.9 "Dual Earthen Fists" sync / 1[56]:[^:]*:Titan Maximum:4135:/
+1406.0 "Earthen Anguish" sync / 1[56]:[^:]*:Titan:4137:/
+1414.6 "Voice of the Land" sync / 1[56]:[^:]*:Titan:4114:/
+1417.4 "Tumult x5" sync / 1[56]:[^:]*:Titan Maximum:412A:/ duration 6
+1426.9 "Voice of the Land" sync / 1[56]:[^:]*:Titan:4114:/
+1438.1 "Earthen Fury" sync / 1[56]:[^:]*:Titan Maximum:413A:/
+1457.3 "Pulse of the Land" sync / 1[56]:[^:]*:Titan:4106:/
+1457.3 "Force of the Land" sync / 1[56]:[^:]*:Titan:4107:/
+1468.4 "Earthen Fist" sync / 1[56]:[^:]*:Titan Maximum:(4130|4131|4132|412F):/
+1479.5 "Stonecrusher 1" sync / 1[56]:[^:]*:Titan:4116:/
+1482.6 "Stonecrusher 2" #sync / 1[56]:[^:]*:Titan:4143:/
+1485.7 "Stonecrusher 3" #sync / 1[56]:[^:]*:Titan:4143:/
+1491.8 "Megalith" sync / 1[56]:[^:]*:Titan Maximum:4138:/
+1504.1 "Earthen Fury" sync / 1[56]:[^:]*:Titan Maximum:413A:/
+1523.4 "Pulse of the Land" sync / 1[56]:[^:]*:Titan:4106:/
+1523.4 "Force of the Land" sync / 1[56]:[^:]*:Titan:4107:/
+1534.3 "Earthen Fist" sync / 1[56]:[^:]*:Titan Maximum:(4130|4131|4132|412F):/
+1543.4 "Voice of the Land" sync / 1[56]:[^:]*:Titan:4114:/
+1546.2 "Tumult x5" sync / 1[56]:[^:]*:Titan Maximum:412A:/ duration 6
+1555.6 "Voice of the Land" sync / 1[56]:[^:]*:Titan:4114:/
+1558.4 "Tumult x5" sync / 1[56]:[^:]*:Titan Maximum:412A:/ duration 6
+1567.9 "Voice of the Land" sync / 1[56]:[^:]*:Titan:4114:/
+1581.1 "Earthen Fury Enrage" sync / 1[56]:[^:]*:Titan Maximum:4140:/

--- a/ui/raidboss/data/05-shb/raid/e5n.txt
+++ b/ui/raidboss/data/05-shb/raid/e5n.txt
@@ -11,61 +11,61 @@ hideall "--sync--"
 # Opening block
 0 "Start"
 0.0 "--sync--" sync /:Engage!/ window 0,1
-0.5 "--sync--" sync / 1[56]:Ramuh:4BA2:/ window 0,1
-13.6 "Crippling Blow" sync / 1[56]:Ramuh:4BA3:/ window 15,15
-20.9 "--sync--" sync / 1[56]:Ramuh:4BCB:/
-26.8 "Stratospear Summons" sync / 1[56]:Ramuh:4B8D:/ window 30,30
-31.7 "Impact" sync / 1[56]:Ramuh:4E3A:/
-38.7 "Judgment Jolt" sync / 1[56]:Ramuh:4B8E:/
-47.8 "Stormcloud Summons" sync / 1[56]:Ramuh:4B9B:/
-63.3 "Judgment Volts" sync / 1[56]:Ramuh:4B98:/
-75.5 "Crippling Blow" sync / 1[56]:Ramuh:4BA3:/ window 30,30
-84.8 "Fury's Bolt" sync / 1[56]:Ramuh:4B90:/
-93.9 "Divine Judgment Volts" sync / 1[56]:Ramuh:4E62:/
-107.1 "Tribunal Summons" sync / 1[56]:Ramuh:4B91:/
-114.6 "Deadly Discharge" sync / 1[56]:Will Of Ramuh:4B92:/
-123.7 "Tribunal Summons" sync / 1[56]:Ramuh:4B91:/
-131.2 "Gallop" sync / 1[56]:Will Of Ixion:4B96:/
+0.5 "--sync--" sync / 1[56]:[^:]*:Ramuh:4BA2:/ window 0,1
+13.6 "Crippling Blow" sync / 1[56]:[^:]*:Ramuh:4BA3:/ window 15,15
+20.9 "--sync--" sync / 1[56]:[^:]*:Ramuh:4BCB:/
+26.8 "Stratospear Summons" sync / 1[56]:[^:]*:Ramuh:4B8D:/ window 30,30
+31.7 "Impact" sync / 1[56]:[^:]*:Ramuh:4E3A:/
+38.7 "Judgment Jolt" sync / 1[56]:[^:]*:Ramuh:4B8E:/
+47.8 "Stormcloud Summons" sync / 1[56]:[^:]*:Ramuh:4B9B:/
+63.3 "Judgment Volts" sync / 1[56]:[^:]*:Ramuh:4B98:/
+75.5 "Crippling Blow" sync / 1[56]:[^:]*:Ramuh:4BA3:/ window 30,30
+84.8 "Fury's Bolt" sync / 1[56]:[^:]*:Ramuh:4B90:/
+93.9 "Divine Judgment Volts" sync / 1[56]:[^:]*:Ramuh:4E62:/
+107.1 "Tribunal Summons" sync / 1[56]:[^:]*:Ramuh:4B91:/
+114.6 "Deadly Discharge" sync / 1[56]:[^:]*:Will Of Ramuh:4B92:/
+123.7 "Tribunal Summons" sync / 1[56]:[^:]*:Ramuh:4B91:/
+131.2 "Gallop" sync / 1[56]:[^:]*:Will Of Ixion:4B96:/
 
 #Training block
-137.3 "--sync--" sync / 1[56]:Ramuh:4BCB:/
-143.3 "Stratospear Summons" sync / 1[56]:Ramuh:4B8D:/
-148.2 "Impact" sync / 1[56]:Ramuh:4E3A:/
-155.2 "Judgment Jolt" sync / 1[56]:Ramuh:4B8E:/ window 30,30
-164.4 "Fury's Bolt" sync / 1[56]:Ramuh:4B90:/
-173.5 "Divine Judgment Volts" sync / 1[56]:Ramuh:4E62:/
-181.7 "Thunderstorm" sync / 1[56]:Ramuh:4BA0:/ window 30,30
-192.1 "Volt Strike" sync / 1[56]:Ramuh:4CF2:/
-199.1 "Volt Strike" sync / 1[56]:Ramuh:4CF2:/
-211.1 "Stormcloud Summons" sync / 1[56]:Ramuh:4B9B:/ window 30,30
-221.6 "Tribunal Summons" sync / 1[56]:Ramuh:4B91:/
-229.0 "Deadly Discharge" sync / 1[56]:Will Of Ramuh:4B92:/
-244.1 "Thunderstorm" sync / 1[56]:Ramuh:4BA0:/ window 30,30
-251.5 "Tribunal Summons" sync / 1[56]:Ramuh:4B91:/
-254.5 "Volt Strike" sync / 1[56]:Ramuh:4CF2:/
-261.0 "Gallop" sync / 1[56]:Will Of Ixion:4B96:/
-261.6 "Volt Strike" sync / 1[56]:Ramuh:4CF2:/
-272.0 "Crippling Blow" sync / 1[56]:Ramuh:4BA3:/ window 30,30
+137.3 "--sync--" sync / 1[56]:[^:]*:Ramuh:4BCB:/
+143.3 "Stratospear Summons" sync / 1[56]:[^:]*:Ramuh:4B8D:/
+148.2 "Impact" sync / 1[56]:[^:]*:Ramuh:4E3A:/
+155.2 "Judgment Jolt" sync / 1[56]:[^:]*:Ramuh:4B8E:/ window 30,30
+164.4 "Fury's Bolt" sync / 1[56]:[^:]*:Ramuh:4B90:/
+173.5 "Divine Judgment Volts" sync / 1[56]:[^:]*:Ramuh:4E62:/
+181.7 "Thunderstorm" sync / 1[56]:[^:]*:Ramuh:4BA0:/ window 30,30
+192.1 "Volt Strike" sync / 1[56]:[^:]*:Ramuh:4CF2:/
+199.1 "Volt Strike" sync / 1[56]:[^:]*:Ramuh:4CF2:/
+211.1 "Stormcloud Summons" sync / 1[56]:[^:]*:Ramuh:4B9B:/ window 30,30
+221.6 "Tribunal Summons" sync / 1[56]:[^:]*:Ramuh:4B91:/
+229.0 "Deadly Discharge" sync / 1[56]:[^:]*:Will Of Ramuh:4B92:/
+244.1 "Thunderstorm" sync / 1[56]:[^:]*:Ramuh:4BA0:/ window 30,30
+251.5 "Tribunal Summons" sync / 1[56]:[^:]*:Ramuh:4B91:/
+254.5 "Volt Strike" sync / 1[56]:[^:]*:Ramuh:4CF2:/
+261.0 "Gallop" sync / 1[56]:[^:]*:Will Of Ixion:4B96:/
+261.6 "Volt Strike" sync / 1[56]:[^:]*:Ramuh:4CF2:/
+272.0 "Crippling Blow" sync / 1[56]:[^:]*:Ramuh:4BA3:/ window 30,30
 
 #Rotation block
-279.3 "--sync--" sync / 1[56]:Ramuh:4BCB:/ window 30,30
-285.2 "Stratospear Summons" sync / 1[56]:Ramuh:4B8D:/
-290.1 "Impact" sync / 1[56]:Ramuh:4E3A:/
-293.6 "Stormcloud Summons" sync / 1[56]:Ramuh:4B9B:/
-303.1 "Judgment Jolt" sync / 1[56]:Ramuh:4B8E:/
-311.3 "Fury's Bolt" sync / 1[56]:Ramuh:4B90:/
-320.4 "Divine Judgment Volts" sync / 1[56]:Ramuh:4E62:/
-331.6 "Tribunal Summons" sync / 1[56]:Ramuh:4B91:/ window 30,30
-339.1 "Gallop" sync / 1[56]:Will Of Ixion:4B96:/
-339.1 "Deadly Discharge" sync / 1[56]:Will Of Ramuh:4B92:/
-350.1 "Crippling Blow" sync / 1[56]:Ramuh:4BA3:/
-362.4 "Judgment Volts" sync / 1[56]:Ramuh:4B98:/
-371.6 "Thunderstorm" sync / 1[56]:Ramuh:4BA0:/ window 30,30
-379.0 "Tribunal Summons" sync / 1[56]:Ramuh:4B91:/
-382.0 "Volt Strike" sync / 1[56]:Ramuh:4CF2:/
-388.5 "Gallop" sync / 1[56]:Will Of Ixion:4B96:/
-389.1 "Volt Strike" sync / 1[56]:Ramuh:4CF2:/
-399.5 "Crippling Blow" sync / 1[56]:Ramuh:4BA3:/ window 30,30 jump 272.0
+279.3 "--sync--" sync / 1[56]:[^:]*:Ramuh:4BCB:/ window 30,30
+285.2 "Stratospear Summons" sync / 1[56]:[^:]*:Ramuh:4B8D:/
+290.1 "Impact" sync / 1[56]:[^:]*:Ramuh:4E3A:/
+293.6 "Stormcloud Summons" sync / 1[56]:[^:]*:Ramuh:4B9B:/
+303.1 "Judgment Jolt" sync / 1[56]:[^:]*:Ramuh:4B8E:/
+311.3 "Fury's Bolt" sync / 1[56]:[^:]*:Ramuh:4B90:/
+320.4 "Divine Judgment Volts" sync / 1[56]:[^:]*:Ramuh:4E62:/
+331.6 "Tribunal Summons" sync / 1[56]:[^:]*:Ramuh:4B91:/ window 30,30
+339.1 "Gallop" sync / 1[56]:[^:]*:Will Of Ixion:4B96:/
+339.1 "Deadly Discharge" sync / 1[56]:[^:]*:Will Of Ramuh:4B92:/
+350.1 "Crippling Blow" sync / 1[56]:[^:]*:Ramuh:4BA3:/
+362.4 "Judgment Volts" sync / 1[56]:[^:]*:Ramuh:4B98:/
+371.6 "Thunderstorm" sync / 1[56]:[^:]*:Ramuh:4BA0:/ window 30,30
+379.0 "Tribunal Summons" sync / 1[56]:[^:]*:Ramuh:4B91:/
+382.0 "Volt Strike" sync / 1[56]:[^:]*:Ramuh:4CF2:/
+388.5 "Gallop" sync / 1[56]:[^:]*:Will Of Ixion:4B96:/
+389.1 "Volt Strike" sync / 1[56]:[^:]*:Ramuh:4CF2:/
+399.5 "Crippling Blow" sync / 1[56]:[^:]*:Ramuh:4BA3:/ window 30,30 jump 272.0
 
 412.7 "Stratospear Summons"
 417.6 "Impact"

--- a/ui/raidboss/data/05-shb/raid/e5s.txt
+++ b/ui/raidboss/data/05-shb/raid/e5s.txt
@@ -9,108 +9,108 @@ hideall "--sync--"
 
 0 "Start"
 0.0 "--sync--" sync /:Engage!/ window 0,1
-12.0 "Judgment Volts" sync / 1[56]:Ramuh:4BB5:/ window 12,20
-22.2 "Stratospear Summons" sync / 1[56]:Ramuh:4BA5:/
-27.1 "Impact" sync / 1[56]:Ramuh:4E3B:/
-35.6 "Judgment Jolt" sync / 1[56]:Ramuh:4BA6:/
-42.7 "Executor Summons" sync / 1[56]:Ramuh:4BBC:/
-52.2 "Fury's Bolt" sync / 1[56]:Ramuh:4BAA:/
-63.3 "Judgment Volts" sync / 1[56]:Ramuh:4BB5:/
-69.5 "Shock Blast" sync / 1[56]:Raiden:4BBE:/
-73.4 "Crippling Blow" sync / 1[56]:Ramuh:4BCA:/
-79.7 "Stormcloud Summons" sync / 1[56]:Ramuh:4BB8:/
-84.8 "Chaos Strike" sync / 1[56]:Ramuh:4BBB:/
-89.2 "--sync--" sync / 1[56]:Ramuh:4BCB:/
-89.9 "Lightning Bolt" duration 24.5 # sync / 1[56]:Stormcloud:4BB9:/
-96.2 "Levinforce" sync / 1[56]:Ramuh:4BCC:/
+12.0 "Judgment Volts" sync / 1[56]:[^:]*:Ramuh:4BB5:/ window 12,20
+22.2 "Stratospear Summons" sync / 1[56]:[^:]*:Ramuh:4BA5:/
+27.1 "Impact" sync / 1[56]:[^:]*:Ramuh:4E3B:/
+35.6 "Judgment Jolt" sync / 1[56]:[^:]*:Ramuh:4BA6:/
+42.7 "Executor Summons" sync / 1[56]:[^:]*:Ramuh:4BBC:/
+52.2 "Fury's Bolt" sync / 1[56]:[^:]*:Ramuh:4BAA:/
+63.3 "Judgment Volts" sync / 1[56]:[^:]*:Ramuh:4BB5:/
+69.5 "Shock Blast" sync / 1[56]:[^:]*:Raiden:4BBE:/
+73.4 "Crippling Blow" sync / 1[56]:[^:]*:Ramuh:4BCA:/
+79.7 "Stormcloud Summons" sync / 1[56]:[^:]*:Ramuh:4BB8:/
+84.8 "Chaos Strike" sync / 1[56]:[^:]*:Ramuh:4BBB:/
+89.2 "--sync--" sync / 1[56]:[^:]*:Ramuh:4BCB:/
+89.9 "Lightning Bolt" duration 24.5 # sync / 1[56]:[^:]*:Stormcloud:4BB9:/
+96.2 "Levinforce" sync / 1[56]:[^:]*:Ramuh:4BCC:/
 
-110.6 "Fury's Bolt?" sync / 1[56]:Ramuh:4BAA:/
-117.7 "Tribunal Summons" sync / 1[56]:Ramuh:4BAC:/
-128.6 "Gallop" sync / 1[56]:Will Of Ixion:4BB3:/
-138.1 "Crippling Blow" sync / 1[56]:Ramuh:4BCA:/
-148.3 "Judgment Volts" sync / 1[56]:Ramuh:4BB5:/
-155.5 "Fury's Bolt" sync / 1[56]:Ramuh:4BAA:/
-163.6 "Thunderstorm" sync / 1[56]:Ramuh:4BBF:/
-174.5 "Volt Strike" sync / 1[56]:Ramuh:4BC3:/
-182.6 "Volt Strike" sync / 1[56]:Ramuh:4BC3:/
-189.1 "Executor Summons" sync / 1[56]:Ramuh:4BBC:/
-198.5 "Crippling Blow" sync / 1[56]:Ramuh:4BCA:/
-210.1 "Stepped Leader" sync / 1[56]:Ramuh:4BC7:/
-215.9 "Shock Blast" sync / 1[56]:Raiden:4BBE:/
-221.2 "Judgment Volts" sync / 1[56]:Ramuh:4BB5:/
+110.6 "Fury's Bolt?" sync / 1[56]:[^:]*:Ramuh:4BAA:/
+117.7 "Tribunal Summons" sync / 1[56]:[^:]*:Ramuh:4BAC:/
+128.6 "Gallop" sync / 1[56]:[^:]*:Will Of Ixion:4BB3:/
+138.1 "Crippling Blow" sync / 1[56]:[^:]*:Ramuh:4BCA:/
+148.3 "Judgment Volts" sync / 1[56]:[^:]*:Ramuh:4BB5:/
+155.5 "Fury's Bolt" sync / 1[56]:[^:]*:Ramuh:4BAA:/
+163.6 "Thunderstorm" sync / 1[56]:[^:]*:Ramuh:4BBF:/
+174.5 "Volt Strike" sync / 1[56]:[^:]*:Ramuh:4BC3:/
+182.6 "Volt Strike" sync / 1[56]:[^:]*:Ramuh:4BC3:/
+189.1 "Executor Summons" sync / 1[56]:[^:]*:Ramuh:4BBC:/
+198.5 "Crippling Blow" sync / 1[56]:[^:]*:Ramuh:4BCA:/
+210.1 "Stepped Leader" sync / 1[56]:[^:]*:Ramuh:4BC7:/
+215.9 "Shock Blast" sync / 1[56]:[^:]*:Raiden:4BBE:/
+221.2 "Judgment Volts" sync / 1[56]:[^:]*:Ramuh:4BB5:/
 
-230.5 "Fury's Fourteen" sync / 1[56]:Ramuh:4BAB:/
-244.6 "Stratospear Summons" sync / 1[56]:Ramuh:4BA5:/
-249.5 "Impact" sync / 1[56]:Ramuh:4E3B:/
-253.0 "Tribunal Summons" sync / 1[56]:Ramuh:4BAC:/
-255.4 "--sync--" sync / 1[56]:Ramuh:4BCB:/
-262.3 "Centaur's Charge" sync / 1[56]:Ramuh:4BAD:/
-267.3 "Gallop" sync / 1[56]:Will Of Ixion:4BB3:/
+230.5 "Fury's Fourteen" sync / 1[56]:[^:]*:Ramuh:4BAB:/
+244.6 "Stratospear Summons" sync / 1[56]:[^:]*:Ramuh:4BA5:/
+249.5 "Impact" sync / 1[56]:[^:]*:Ramuh:4E3B:/
+253.0 "Tribunal Summons" sync / 1[56]:[^:]*:Ramuh:4BAC:/
+255.4 "--sync--" sync / 1[56]:[^:]*:Ramuh:4BCB:/
+262.3 "Centaur's Charge" sync / 1[56]:[^:]*:Ramuh:4BAD:/
+267.3 "Gallop" sync / 1[56]:[^:]*:Will Of Ixion:4BB3:/
 
-267.5 "Judgment Jolt" sync / 1[56]:Will Of Ramuh:4BA9:/
-279.1 "Fury's Bolt" sync / 1[56]:Ramuh:4BAA:/
-287.9 "Stepped Leader" sync / 1[56]:Ramuh:4BC8:/
-297.8 "Chain Lightning" sync / 1[56]:Ramuh:4BC4:/
-301.6 "Chain Lightning 1" #sync / 1[56]:Ramuh:4BC5:/
-305.2 "Crippling Blow" sync / 1[56]:Ramuh:4BCA:/
-305.3 "Chain Lightning 2" #sync / 1[56]:Ramuh:4BC5:/
-309.0 "Chain Lightning 3" #sync / 1[56]:Ramuh:4BC5:/
-312.7 "Chain Lightning 4" #sync / 1[56]:Ramuh:4BC5:/
-316.4 "Chain Lightning 5" #sync / 1[56]:Ramuh:4BC5:/
-317.4 "Judgment Volts" sync / 1[56]:Ramuh:4BB5:/
-320.1 "Chain Lightning 6" #sync / 1[56]:Ramuh:4BC5:/
-323.8 "Chain Lightning 7" #sync / 1[56]:Ramuh:4BC5:/
-327.5 "Chain Lightning 8" #sync / 1[56]:Ramuh:4BC5:/
+267.5 "Judgment Jolt" sync / 1[56]:[^:]*:Will Of Ramuh:4BA9:/
+279.1 "Fury's Bolt" sync / 1[56]:[^:]*:Ramuh:4BAA:/
+287.9 "Stepped Leader" sync / 1[56]:[^:]*:Ramuh:4BC8:/
+297.8 "Chain Lightning" sync / 1[56]:[^:]*:Ramuh:4BC4:/
+301.6 "Chain Lightning 1" #sync / 1[56]:[^:]*:Ramuh:4BC5:/
+305.2 "Crippling Blow" sync / 1[56]:[^:]*:Ramuh:4BCA:/
+305.3 "Chain Lightning 2" #sync / 1[56]:[^:]*:Ramuh:4BC5:/
+309.0 "Chain Lightning 3" #sync / 1[56]:[^:]*:Ramuh:4BC5:/
+312.7 "Chain Lightning 4" #sync / 1[56]:[^:]*:Ramuh:4BC5:/
+316.4 "Chain Lightning 5" #sync / 1[56]:[^:]*:Ramuh:4BC5:/
+317.4 "Judgment Volts" sync / 1[56]:[^:]*:Ramuh:4BB5:/
+320.1 "Chain Lightning 6" #sync / 1[56]:[^:]*:Ramuh:4BC5:/
+323.8 "Chain Lightning 7" #sync / 1[56]:[^:]*:Ramuh:4BC5:/
+327.5 "Chain Lightning 8" #sync / 1[56]:[^:]*:Ramuh:4BC5:/
 
-329.6 "Executor Summons" sync / 1[56]:Ramuh:4BBC:/
-337.0 "Fury's Bolt" sync / 1[56]:Ramuh:4BAA:/
-346.2 "Thunderstorm" sync / 1[56]:Ramuh:4BBF:/
-356.4 "Shock Blast" sync / 1[56]:Raiden:4BBE:/
-357.1 "Volt Strike" sync / 1[56]:Ramuh:4BC3:/
-365.2 "Volt Strike" sync / 1[56]:Ramuh:4BC3:/
-368.0 "Stepped Leader" sync / 1[56]:Ramuh:4BC7:/
-380.1 "Crippling Blow" sync / 1[56]:Ramuh:4BCA:/
-388.3 "Judgment Volts" sync / 1[56]:Ramuh:4BB5:/
+329.6 "Executor Summons" sync / 1[56]:[^:]*:Ramuh:4BBC:/
+337.0 "Fury's Bolt" sync / 1[56]:[^:]*:Ramuh:4BAA:/
+346.2 "Thunderstorm" sync / 1[56]:[^:]*:Ramuh:4BBF:/
+356.4 "Shock Blast" sync / 1[56]:[^:]*:Raiden:4BBE:/
+357.1 "Volt Strike" sync / 1[56]:[^:]*:Ramuh:4BC3:/
+365.2 "Volt Strike" sync / 1[56]:[^:]*:Ramuh:4BC3:/
+368.0 "Stepped Leader" sync / 1[56]:[^:]*:Ramuh:4BC7:/
+380.1 "Crippling Blow" sync / 1[56]:[^:]*:Ramuh:4BCA:/
+388.3 "Judgment Volts" sync / 1[56]:[^:]*:Ramuh:4BB5:/
 
-395.6 "Fury's Fourteen" sync / 1[56]:Ramuh:4BAB:/
-411.7 "Stratospear Summons" sync / 1[56]:Ramuh:4BA5:/
-416.6 "Impact" sync / 1[56]:Ramuh:4E3B:/
-420.1 "Tribunal Summons" sync / 1[56]:Ramuh:4BAC:/
-422.5 "--sync--" sync / 1[56]:Ramuh:4BCB:/
-429.4 "Centaur's Charge" sync / 1[56]:Ramuh:4BAD:/
-434.4 "Gallop" sync / 1[56]:Will Of Ixion:4BB3:/
+395.6 "Fury's Fourteen" sync / 1[56]:[^:]*:Ramuh:4BAB:/
+411.7 "Stratospear Summons" sync / 1[56]:[^:]*:Ramuh:4BA5:/
+416.6 "Impact" sync / 1[56]:[^:]*:Ramuh:4E3B:/
+420.1 "Tribunal Summons" sync / 1[56]:[^:]*:Ramuh:4BAC:/
+422.5 "--sync--" sync / 1[56]:[^:]*:Ramuh:4BCB:/
+429.4 "Centaur's Charge" sync / 1[56]:[^:]*:Ramuh:4BAD:/
+434.4 "Gallop" sync / 1[56]:[^:]*:Will Of Ixion:4BB3:/
 
-434.6 "Judgment Jolt" sync / 1[56]:Will Of Ramuh:4BA9:/
-440.2 "Fury's Bolt" sync / 1[56]:Ramuh:4BAA:/
-450.4 "Judgment Volts" sync / 1[56]:Ramuh:4BB5:/
-460.5 "Stormcloud Summons" sync / 1[56]:Ramuh:4BB8:/
-465.6 "Chaos Strike" sync / 1[56]:Ramuh:4BBB:/
-470.7 "Lightning Bolt" duration 24.5 # sync / 1[56]:Stormcloud:4BB9:/
-470.0 "--sync--" sync / 1[56]:Ramuh:4BCB:/
-477.0 "Levinforce" sync / 1[56]:Ramuh:4BCC:/
-487.4 "Judgment Volts" sync / 1[56]:Ramuh:4BB5:/
-502.6 "Chain Lightning" sync / 1[56]:Ramuh:4BC4:/
-506.4 "Chain Lightning 1" #sync / 1[56]:Ramuh:4BC5:/
-510.0 "Crippling Blow" sync / 1[56]:Ramuh:4BCA:/
-510.1 "Chain Lightning 2" #sync / 1[56]:Ramuh:4BC5:/
-513.8 "Chain Lightning 3" #sync / 1[56]:Ramuh:4BC5:/
-517.5 "Chain Lightning 4" #sync / 1[56]:Ramuh:4BC5:/
-521.2 "Chain Lightning 5" #sync / 1[56]:Ramuh:4BC5:/
-523.2 "Judgment Volts" sync / 1[56]:Ramuh:4BB5:/
-524.8 "Chain Lightning 6" #sync / 1[56]:Ramuh:4BC5:/
-528.5 "Chain Lightning 7" #sync / 1[56]:Ramuh:4BC5:/
-532.2 "Chain Lightning 8" #sync / 1[56]:Ramuh:4BC5:/
+434.6 "Judgment Jolt" sync / 1[56]:[^:]*:Will Of Ramuh:4BA9:/
+440.2 "Fury's Bolt" sync / 1[56]:[^:]*:Ramuh:4BAA:/
+450.4 "Judgment Volts" sync / 1[56]:[^:]*:Ramuh:4BB5:/
+460.5 "Stormcloud Summons" sync / 1[56]:[^:]*:Ramuh:4BB8:/
+465.6 "Chaos Strike" sync / 1[56]:[^:]*:Ramuh:4BBB:/
+470.7 "Lightning Bolt" duration 24.5 # sync / 1[56]:[^:]*:Stormcloud:4BB9:/
+470.0 "--sync--" sync / 1[56]:[^:]*:Ramuh:4BCB:/
+477.0 "Levinforce" sync / 1[56]:[^:]*:Ramuh:4BCC:/
+487.4 "Judgment Volts" sync / 1[56]:[^:]*:Ramuh:4BB5:/
+502.6 "Chain Lightning" sync / 1[56]:[^:]*:Ramuh:4BC4:/
+506.4 "Chain Lightning 1" #sync / 1[56]:[^:]*:Ramuh:4BC5:/
+510.0 "Crippling Blow" sync / 1[56]:[^:]*:Ramuh:4BCA:/
+510.1 "Chain Lightning 2" #sync / 1[56]:[^:]*:Ramuh:4BC5:/
+513.8 "Chain Lightning 3" #sync / 1[56]:[^:]*:Ramuh:4BC5:/
+517.5 "Chain Lightning 4" #sync / 1[56]:[^:]*:Ramuh:4BC5:/
+521.2 "Chain Lightning 5" #sync / 1[56]:[^:]*:Ramuh:4BC5:/
+523.2 "Judgment Volts" sync / 1[56]:[^:]*:Ramuh:4BB5:/
+524.8 "Chain Lightning 6" #sync / 1[56]:[^:]*:Ramuh:4BC5:/
+528.5 "Chain Lightning 7" #sync / 1[56]:[^:]*:Ramuh:4BC5:/
+532.2 "Chain Lightning 8" #sync / 1[56]:[^:]*:Ramuh:4BC5:/
 
-539.7 "Stepped Leader" sync / 1[56]:Ramuh:4BC7:/
-545.8 "Fury's Bolt" sync / 1[56]:Ramuh:4BAA:/
-554.9 "Judgment Volts" sync / 1[56]:Ramuh:4BB5:/
-566.0 "Judgment Volts" sync / 1[56]:Ramuh:4BB5:/
-574.1 "Fury's Bolt" sync / 1[56]:Ramuh:4BAA:/
-583.2 "Judgment Volts" sync / 1[56]:Ramuh:4BB5:/
-594.3 "Judgment Volts" sync / 1[56]:Ramuh:4BB5:/
-605.4 "Judgment Volts" sync / 1[56]:Ramuh:4BB5:/
+539.7 "Stepped Leader" sync / 1[56]:[^:]*:Ramuh:4BC7:/
+545.8 "Fury's Bolt" sync / 1[56]:[^:]*:Ramuh:4BAA:/
+554.9 "Judgment Volts" sync / 1[56]:[^:]*:Ramuh:4BB5:/
+566.0 "Judgment Volts" sync / 1[56]:[^:]*:Ramuh:4BB5:/
+574.1 "Fury's Bolt" sync / 1[56]:[^:]*:Ramuh:4BAA:/
+583.2 "Judgment Volts" sync / 1[56]:[^:]*:Ramuh:4BB5:/
+594.3 "Judgment Volts" sync / 1[56]:[^:]*:Ramuh:4BB5:/
+605.4 "Judgment Volts" sync / 1[56]:[^:]*:Ramuh:4BB5:/
 
-612.3 "Fury's Fourteen" sync / 1[56]:Ramuh:4BAB:/
-628.4 "Stratospear Summons" sync / 1[56]:Ramuh:4BA5:/
+612.3 "Fury's Fourteen" sync / 1[56]:[^:]*:Ramuh:4BAB:/
+628.4 "Stratospear Summons" sync / 1[56]:[^:]*:Ramuh:4BA5:/
 
 #??? "Judgment Volts Enrage"

--- a/ui/raidboss/data/05-shb/raid/e6n.txt
+++ b/ui/raidboss/data/05-shb/raid/e6n.txt
@@ -12,96 +12,96 @@ hideall "--sync--"
 0.0 "--sync--" sync /:Engage!/ window 0,1
 
 # Garuda solo
-2.0 "--sync--" sync / 1[56]:Garuda:366:/ window 3,1
-13.5 "Ferostorm" # sync / 1[56]:Garuda:4BD[DEF]:/
-20.6 "Superstorm" sync / 1[56]:Garuda:4BD7:/ window 20,30
-31.4 "Air Bump" sync / 1[56]:Garuda:4BD1:/
-36.8 "Thorns" sync / 1[56]:Garuda:4BDA:/
-48.0 "Downburst" sync / 1[56]:Garuda:4BDB:/ window 30,30
-54.6 "Air Bump" sync / 1[56]:Garuda:4BD1:/
-60.0 "Thorns" sync / 1[56]:Garuda:4BDA:/
-72.2 "Storm Of Fury" sync / 1[56]:Garuda:4BE0:/
-75.4 "--sync--" sync / 1[56]:Garuda:4BD0:/
-81.7 "Vacuum Slice" sync / 1[56]:Garuda:4BD5:/
-88.8 "Occluded Front" sync / 1[56]:Garuda:4BD2:/ window 30,30
-98.3 "Irresistible Pull" sync / 1[56]:Garuda:4BD6:/
+2.0 "--sync--" sync / 1[56]:[^:]*:Garuda:366:/ window 3,1
+13.5 "Ferostorm" # sync / 1[56]:[^:]*:Garuda:4BD[DEF]:/
+20.6 "Superstorm" sync / 1[56]:[^:]*:Garuda:4BD7:/ window 20,30
+31.4 "Air Bump" sync / 1[56]:[^:]*:Garuda:4BD1:/
+36.8 "Thorns" sync / 1[56]:[^:]*:Garuda:4BDA:/
+48.0 "Downburst" sync / 1[56]:[^:]*:Garuda:4BDB:/ window 30,30
+54.6 "Air Bump" sync / 1[56]:[^:]*:Garuda:4BD1:/
+60.0 "Thorns" sync / 1[56]:[^:]*:Garuda:4BDA:/
+72.2 "Storm Of Fury" sync / 1[56]:[^:]*:Garuda:4BE0:/
+75.4 "--sync--" sync / 1[56]:[^:]*:Garuda:4BD0:/
+81.7 "Vacuum Slice" sync / 1[56]:[^:]*:Garuda:4BD5:/
+88.8 "Occluded Front" sync / 1[56]:[^:]*:Garuda:4BD2:/ window 30,30
+98.3 "Irresistible Pull" sync / 1[56]:[^:]*:Garuda:4BD6:/
 111.0 "--untargetable--"
 
 # Ifrit solo
-114.1 "Touchdown" sync / 1[56]:Ifrit:4BE8:/ window 30,30
+114.1 "Touchdown" sync / 1[56]:[^:]*:Ifrit:4BE8:/ window 30,30
 115.5 "--targetable--"
-129.2 "Hands Of Flame" sync / 1[56]:Ifrit:4CFE:/
-143.6 "Hands Of Hell" sync / 1[56]:Ifrit:4CFF:/
-152.3 "Instant Incineration" sync / 1[56]:Ifrit:4BED:/ window 30,30
-156.9 "Eruption" sync / 1[56]:Ifrit:4BF3:/
-166.1 "Strike Spark" sync / 1[56]:Ifrit:4BD3:/
-177.5 "Hot Foot" sync / 1[56]:Ifrit:4BEF:/
-188.2 "Inferno Howl" sync / 1[56]:Ifrit:4BF1:/ window 30,30
+129.2 "Hands Of Flame" sync / 1[56]:[^:]*:Ifrit:4CFE:/
+143.6 "Hands Of Hell" sync / 1[56]:[^:]*:Ifrit:4CFF:/
+152.3 "Instant Incineration" sync / 1[56]:[^:]*:Ifrit:4BED:/ window 30,30
+156.9 "Eruption" sync / 1[56]:[^:]*:Ifrit:4BF3:/
+166.1 "Strike Spark" sync / 1[56]:[^:]*:Ifrit:4BD3:/
+177.5 "Hot Foot" sync / 1[56]:[^:]*:Ifrit:4BEF:/
+188.2 "Inferno Howl" sync / 1[56]:[^:]*:Ifrit:4BF1:/ window 30,30
 196.3 "--untargetable--"
 
 
 # Garuda and Ifrit
 200.6 "--targetable--"
-207.2 "Vacuum Slice" sync / 1[56]:Garuda:4BD5:/ window 30,30
-209.9 "Eruption" sync / 1[56]:Ifrit:4BF3:/
-209.9 "Eruption" sync / 1[56]:Ifrit:4BF4:/
-213.1 "--sync--" sync / 1[56]:Ifrit:4F98:/
-214.3 "Occluded Front" sync / 1[56]:Garuda:4BD2:/
-221.2 "Hot Foot" sync / 1[56]:Ifrit:4BEF:/
-223.8 "Irresistible Pull" sync / 1[56]:Garuda:4BD6:/ window 30,30
-228.0 "Air Bump" sync / 1[56]:Garuda:4BD1:/
-233.3 "Thorns" sync / 1[56]:Garuda:4BDA:/
-237.9 "Hands Of Hell" sync / 1[56]:Ifrit:4CFF:/
-245.5 "Ferostorm" # sync / 1[56]:Garuda:4BD[DEF]:/
+207.2 "Vacuum Slice" sync / 1[56]:[^:]*:Garuda:4BD5:/ window 30,30
+209.9 "Eruption" sync / 1[56]:[^:]*:Ifrit:4BF3:/
+209.9 "Eruption" sync / 1[56]:[^:]*:Ifrit:4BF4:/
+213.1 "--sync--" sync / 1[56]:[^:]*:Ifrit:4F98:/
+214.3 "Occluded Front" sync / 1[56]:[^:]*:Garuda:4BD2:/
+221.2 "Hot Foot" sync / 1[56]:[^:]*:Ifrit:4BEF:/
+223.8 "Irresistible Pull" sync / 1[56]:[^:]*:Garuda:4BD6:/ window 30,30
+228.0 "Air Bump" sync / 1[56]:[^:]*:Garuda:4BD1:/
+233.3 "Thorns" sync / 1[56]:[^:]*:Garuda:4BDA:/
+237.9 "Hands Of Hell" sync / 1[56]:[^:]*:Ifrit:4CFF:/
+245.5 "Ferostorm" # sync / 1[56]:[^:]*:Garuda:4BD[DEF]:/
 250.2 "--untargetable--"
 
 
 # Raktapaksa initial block
-267.9 "Firestorm" sync / 1[56]:Raktapaksa:4BD8:/ window 30,30
+267.9 "Firestorm" sync / 1[56]:[^:]*:Raktapaksa:4BD8:/ window 30,30
 272.1 "--targetable--"
-283.2 "Radiant Plume" sync / 1[56]:Raktapaksa:4BF2:/
-286.2 "Ferostorm" # sync / 1[56]:Raktapaksa:4BE[345]:/
-297.3 "Hands Of Flame" sync / 1[56]:Raktapaksa:4CFE:/ window 30,30
-301.1 "Heat Burst" sync / 1[56]:Raktapaksa:4C1E:/
-311.2 "Eruption" sync / 1[56]:Raktapaksa:4BF4:/
-312.6 "Thorns" sync / 1[56]:Raktapaksa:4BDA:/
-313.7 "Hands Of Hell" sync / 1[56]:Raktapaksa:4CFF:/
-317.6 "Heat Burst" sync / 1[56]:Raktapaksa:4C1E:/
+283.2 "Radiant Plume" sync / 1[56]:[^:]*:Raktapaksa:4BF2:/
+286.2 "Ferostorm" # sync / 1[56]:[^:]*:Raktapaksa:4BE[345]:/
+297.3 "Hands Of Flame" sync / 1[56]:[^:]*:Raktapaksa:4CFE:/ window 30,30
+301.1 "Heat Burst" sync / 1[56]:[^:]*:Raktapaksa:4C1E:/
+311.2 "Eruption" sync / 1[56]:[^:]*:Raktapaksa:4BF4:/
+312.6 "Thorns" sync / 1[56]:[^:]*:Raktapaksa:4BDA:/
+313.7 "Hands Of Hell" sync / 1[56]:[^:]*:Raktapaksa:4CFF:/
+317.6 "Heat Burst" sync / 1[56]:[^:]*:Raktapaksa:4C1E:/
 325.2 "--untargetable--"
-325.2 "Downburst" sync / 1[56]:Raktapaksa:4BDC:/ window 30,30
+325.2 "Downburst" sync / 1[56]:[^:]*:Raktapaksa:4BDC:/ window 30,30
 329.5 "--targetable--"
-336.6 "Radiant Plume" sync / 1[56]:Raktapaksa:4BF2:/
-341.6 "Eruption" sync / 1[56]:Raktapaksa:4BF4:/
-348.1 "Radiant Plume" sync / 1[56]:Raktapaksa:4BF2:/
-353.1 "Eruption" sync / 1[56]:Raktapaksa:4BF4:/
-360.4 "Conflag Strike" sync / 1[56]:Raktapaksa:4BEE:/ window 30,30
+336.6 "Radiant Plume" sync / 1[56]:[^:]*:Raktapaksa:4BF2:/
+341.6 "Eruption" sync / 1[56]:[^:]*:Raktapaksa:4BF4:/
+348.1 "Radiant Plume" sync / 1[56]:[^:]*:Raktapaksa:4BF2:/
+353.1 "Eruption" sync / 1[56]:[^:]*:Raktapaksa:4BF4:/
+360.4 "Conflag Strike" sync / 1[56]:[^:]*:Raktapaksa:4BEE:/ window 30,30
 
 # Raktapaksa rotation block
-375.6 "Ferostorm" # sync / 1[56]:Raktapaksa:4BE[345]:/
-377.6 "Air Bump" sync / 1[56]:Raktapaksa:4BD4:/
-382.5 "Thorns" sync / 1[56]:Raktapaksa:4BDA:/ window 30,30
-390.7 "Storm Of Fury" sync / 1[56]:Raktapaksa:4BE6:/
-391.7 "Eruption" sync / 1[56]:Raktapaksa:4BF4:/
-401.4 "Inferno Howl" sync / 1[56]:Raktapaksa:4BF1:/
-415.6 "Eruption" sync / 1[56]:Raktapaksa:4BF4:/
-416.6 "Hands Of Hell" sync / 1[56]:Raktapaksa:4CFF:/ window 30,30
-420.5 "Heat Burst" sync / 1[56]:Raktapaksa:4C1E:/
-427.2 "Instant Incineration" sync / 1[56]:Raktapaksa:4BED:/
-433.4 "Radiant Plume" sync / 1[56]:Raktapaksa:4BF2:/
-439.4 "Inferno Howl" sync / 1[56]:Raktapaksa:4BF1:/ window 30,30
+375.6 "Ferostorm" # sync / 1[56]:[^:]*:Raktapaksa:4BE[345]:/
+377.6 "Air Bump" sync / 1[56]:[^:]*:Raktapaksa:4BD4:/
+382.5 "Thorns" sync / 1[56]:[^:]*:Raktapaksa:4BDA:/ window 30,30
+390.7 "Storm Of Fury" sync / 1[56]:[^:]*:Raktapaksa:4BE6:/
+391.7 "Eruption" sync / 1[56]:[^:]*:Raktapaksa:4BF4:/
+401.4 "Inferno Howl" sync / 1[56]:[^:]*:Raktapaksa:4BF1:/
+415.6 "Eruption" sync / 1[56]:[^:]*:Raktapaksa:4BF4:/
+416.6 "Hands Of Hell" sync / 1[56]:[^:]*:Raktapaksa:4CFF:/ window 30,30
+420.5 "Heat Burst" sync / 1[56]:[^:]*:Raktapaksa:4C1E:/
+427.2 "Instant Incineration" sync / 1[56]:[^:]*:Raktapaksa:4BED:/
+433.4 "Radiant Plume" sync / 1[56]:[^:]*:Raktapaksa:4BF2:/
+439.4 "Inferno Howl" sync / 1[56]:[^:]*:Raktapaksa:4BF1:/ window 30,30
 
-454.6 "Ferostorm" # sync / 1[56]:Raktapaksa:4BE[345]:/
-456.6 "Air Bump" sync / 1[56]:Raktapaksa:4BD4:/
-461.5 "Thorns" sync / 1[56]:Raktapaksa:4BDA:/ window 30,30
-469.7 "Storm Of Fury" sync / 1[56]:Raktapaksa:4BE6:/
-470.7 "Eruption" sync / 1[56]:Raktapaksa:4BF4:/
-480.4 "Inferno Howl" sync / 1[56]:Raktapaksa:4BF1:/
-494.6 "Eruption" sync / 1[56]:Raktapaksa:4BF4:/
-495.6 "Hands Of Hell" sync / 1[56]:Raktapaksa:4CFF:/ window 30,30
-499.5 "Heat Burst" sync / 1[56]:Raktapaksa:4C1E:/
-506.2 "Instant Incineration" sync / 1[56]:Raktapaksa:4BED:/
-512.4 "Radiant Plume" sync / 1[56]:Raktapaksa:4BF2:/
-518.4 "Inferno Howl" sync / 1[56]:Raktapaksa:4BF1:/ window 30,30 jump 439.4
+454.6 "Ferostorm" # sync / 1[56]:[^:]*:Raktapaksa:4BE[345]:/
+456.6 "Air Bump" sync / 1[56]:[^:]*:Raktapaksa:4BD4:/
+461.5 "Thorns" sync / 1[56]:[^:]*:Raktapaksa:4BDA:/ window 30,30
+469.7 "Storm Of Fury" sync / 1[56]:[^:]*:Raktapaksa:4BE6:/
+470.7 "Eruption" sync / 1[56]:[^:]*:Raktapaksa:4BF4:/
+480.4 "Inferno Howl" sync / 1[56]:[^:]*:Raktapaksa:4BF1:/
+494.6 "Eruption" sync / 1[56]:[^:]*:Raktapaksa:4BF4:/
+495.6 "Hands Of Hell" sync / 1[56]:[^:]*:Raktapaksa:4CFF:/ window 30,30
+499.5 "Heat Burst" sync / 1[56]:[^:]*:Raktapaksa:4C1E:/
+506.2 "Instant Incineration" sync / 1[56]:[^:]*:Raktapaksa:4BED:/
+512.4 "Radiant Plume" sync / 1[56]:[^:]*:Raktapaksa:4BF2:/
+518.4 "Inferno Howl" sync / 1[56]:[^:]*:Raktapaksa:4BF1:/ window 30,30 jump 439.4
 
 533.6 "Ferostorm"
 535.6 "Air Bump"

--- a/ui/raidboss/data/05-shb/raid/e6s.txt
+++ b/ui/raidboss/data/05-shb/raid/e6s.txt
@@ -11,132 +11,132 @@ hideall "--sync--"
 ### Phase 1: Garuda
 0 "Start"
 0.0 "--sync--" sync /:Engage!/ window 0,1
-2.3 "--sync--" sync / 1[56]:Garuda:366:/ window 5,0
-18.0 "Superstorm" sync / 1[56]:Garuda:4BF7:/ window 18,20
-27.1 "Occluded Front" sync / 1[56]:Garuda:4BD2:/
-36.2 "Wind Cutter" sync / 1[56]:Tumultuous Nexus:4C02:/
-39.2 "Storm Of Fury" sync / 1[56]:Garuda:4C01:/
-46.8 "Air Bump" sync / 1[56]:Garuda:4BF9:/
-64.0 "Ferostorm" sync / 1[56]:Garuda:4BFD:/
-73.6 "Downburst" sync / 1[56]:Garuda:4BFB:/
-76.1 "Air Bump" sync / 1[56]:Garuda:4BF9:/
-88.0 "Vacuum Slice" sync / 1[56]:Garuda:4BF5:/
-95.2 "Occluded Front" sync / 1[56]:Garuda:4BD2:/
-103.3 "Storm Of Fury" sync / 1[56]:Garuda:4C01:/
-104.7 "Irresistible Pull" sync / 1[56]:Garuda:4BF6:/
-105.5 "Explosions" #sync / 1[56]:Tumultuous Nexus:4C03:/
-110.8 "Ferostorm" sync / 1[56]:Garuda:4BFD:/
+2.3 "--sync--" sync / 1[56]:[^:]*:Garuda:366:/ window 5,0
+18.0 "Superstorm" sync / 1[56]:[^:]*:Garuda:4BF7:/ window 18,20
+27.1 "Occluded Front" sync / 1[56]:[^:]*:Garuda:4BD2:/
+36.2 "Wind Cutter" sync / 1[56]:[^:]*:Tumultuous Nexus:4C02:/
+39.2 "Storm Of Fury" sync / 1[56]:[^:]*:Garuda:4C01:/
+46.8 "Air Bump" sync / 1[56]:[^:]*:Garuda:4BF9:/
+64.0 "Ferostorm" sync / 1[56]:[^:]*:Garuda:4BFD:/
+73.6 "Downburst" sync / 1[56]:[^:]*:Garuda:4BFB:/
+76.1 "Air Bump" sync / 1[56]:[^:]*:Garuda:4BF9:/
+88.0 "Vacuum Slice" sync / 1[56]:[^:]*:Garuda:4BF5:/
+95.2 "Occluded Front" sync / 1[56]:[^:]*:Garuda:4BD2:/
+103.3 "Storm Of Fury" sync / 1[56]:[^:]*:Garuda:4C01:/
+104.7 "Irresistible Pull" sync / 1[56]:[^:]*:Garuda:4BF6:/
+105.5 "Explosions" #sync / 1[56]:[^:]*:Tumultuous Nexus:4C03:/
+110.8 "Ferostorm" sync / 1[56]:[^:]*:Garuda:4BFD:/
 119.0 "--untargetable--"
 
 ### Phase 2: Ifrit
-122.0 "Touchdown" sync / 1[56]:Ifrit:4C09:/
-135.3 "Hands Of Flame" sync / 1[56]:Ifrit:4C0A:/
-139.6 "Eruption" sync / 1[56]:Ifrit:4C17:/
-143.5 "Instant Incineration" sync / 1[56]:Ifrit:4C0E:/
-147.1 "Meteor Strike" sync / 1[56]:Ifrit:4C0F:/
-159.2 "Inferno Howl" sync / 1[56]:Ifrit:4C14:/
-172.3 "Hands Of Hell" sync / 1[56]:Ifrit:4D01:/
-176.9 "Eruption" sync / 1[56]:Ifrit:4C17:/
-184.7 "Strike Spark" sync / 1[56]:Ifrit:4BD3:/
-187.9 "Call Of The Inferno" sync / 1[56]:Ifrit:4C12:/
-197.1 "Hot Foot" sync / 1[56]:Ifrit:4C11:/
-198.5 "Eruption" sync / 1[56]:Ifrit:4C17:/
-215.1 "Hands Of Hell" sync / 1[56]:Ifrit:4D01:/
-219.8 "Eruption" sync / 1[56]:Ifrit:4C17:/
-223.9 "Hands Of Flame" sync / 1[56]:Ifrit:4C0A:/
-228.2 "Eruption" sync / 1[56]:Ifrit:4C17:/
-232.1 "Instant Incineration" sync / 1[56]:Ifrit:4C0E:/
-235.7 "Meteor Strike" sync / 1[56]:Ifrit:4C0F:/
+122.0 "Touchdown" sync / 1[56]:[^:]*:Ifrit:4C09:/
+135.3 "Hands Of Flame" sync / 1[56]:[^:]*:Ifrit:4C0A:/
+139.6 "Eruption" sync / 1[56]:[^:]*:Ifrit:4C17:/
+143.5 "Instant Incineration" sync / 1[56]:[^:]*:Ifrit:4C0E:/
+147.1 "Meteor Strike" sync / 1[56]:[^:]*:Ifrit:4C0F:/
+159.2 "Inferno Howl" sync / 1[56]:[^:]*:Ifrit:4C14:/
+172.3 "Hands Of Hell" sync / 1[56]:[^:]*:Ifrit:4D01:/
+176.9 "Eruption" sync / 1[56]:[^:]*:Ifrit:4C17:/
+184.7 "Strike Spark" sync / 1[56]:[^:]*:Ifrit:4BD3:/
+187.9 "Call Of The Inferno" sync / 1[56]:[^:]*:Ifrit:4C12:/
+197.1 "Hot Foot" sync / 1[56]:[^:]*:Ifrit:4C11:/
+198.5 "Eruption" sync / 1[56]:[^:]*:Ifrit:4C17:/
+215.1 "Hands Of Hell" sync / 1[56]:[^:]*:Ifrit:4D01:/
+219.8 "Eruption" sync / 1[56]:[^:]*:Ifrit:4C17:/
+223.9 "Hands Of Flame" sync / 1[56]:[^:]*:Ifrit:4C0A:/
+228.2 "Eruption" sync / 1[56]:[^:]*:Ifrit:4C17:/
+232.1 "Instant Incineration" sync / 1[56]:[^:]*:Ifrit:4C0E:/
+235.7 "Meteor Strike" sync / 1[56]:[^:]*:Ifrit:4C0F:/
 241.1 "--untargetable--"
 
 ### Phase 3: Garuda and Ifrit
 245.4 "--targetable--"
-248.4 "Hated Of Embers/Vortex" sync / 1[56]:Ifrit:4FA0:/
-253.6 "Occluded Front" sync / 1[56]:Garuda:4BD2:/
-262.7 "Wind Cutter" sync / 1[56]:Tumultuous Nexus:4C02:/
-265.1 "Hands Of Flame" sync / 1[56]:Ifrit:4C0A:/
-269.4 "Eruption" sync / 1[56]:Ifrit:4C17:/
-273.3 "Instant Incineration" sync / 1[56]:Ifrit:4C0E:/
-276.9 "Meteor Strike" sync / 1[56]:Ifrit:4C0F:/
-277.0 "Vacuum Slice" sync / 1[56]:Garuda:4BF5:/
-280.1 "Call Of The Inferno" sync / 1[56]:Ifrit:4C12:/
-284.2 "Occluded Front" sync / 1[56]:Garuda:4BD2:/
-291.8 "Hot Foot" sync / 1[56]:Ifrit:4C11:/
-293.7 "Irresistible Pull" sync / 1[56]:Garuda:4BF6:/
-293.7 "Eruption" sync / 1[56]:Ifrit:4C17:/
-294.5 "Explosion" sync / 1[56]:Tumultuous Nexus:4C03:/
-294.5 "Explosion" sync / 1[56]:Tumultuous Nexus:4C03:/
-294.5 "Explosion" sync / 1[56]:Tumultuous Nexus:4C03:/
-294.5 "Explosion" sync / 1[56]:Tumultuous Nexus:4C03:/
-298.6 "Ferostorm" sync / 1[56]:Garuda:4BFD:/
+248.4 "Hated Of Embers/Vortex" sync / 1[56]:[^:]*:Ifrit:4FA0:/
+253.6 "Occluded Front" sync / 1[56]:[^:]*:Garuda:4BD2:/
+262.7 "Wind Cutter" sync / 1[56]:[^:]*:Tumultuous Nexus:4C02:/
+265.1 "Hands Of Flame" sync / 1[56]:[^:]*:Ifrit:4C0A:/
+269.4 "Eruption" sync / 1[56]:[^:]*:Ifrit:4C17:/
+273.3 "Instant Incineration" sync / 1[56]:[^:]*:Ifrit:4C0E:/
+276.9 "Meteor Strike" sync / 1[56]:[^:]*:Ifrit:4C0F:/
+277.0 "Vacuum Slice" sync / 1[56]:[^:]*:Garuda:4BF5:/
+280.1 "Call Of The Inferno" sync / 1[56]:[^:]*:Ifrit:4C12:/
+284.2 "Occluded Front" sync / 1[56]:[^:]*:Garuda:4BD2:/
+291.8 "Hot Foot" sync / 1[56]:[^:]*:Ifrit:4C11:/
+293.7 "Irresistible Pull" sync / 1[56]:[^:]*:Garuda:4BF6:/
+293.7 "Eruption" sync / 1[56]:[^:]*:Ifrit:4C17:/
+294.5 "Explosion" sync / 1[56]:[^:]*:Tumultuous Nexus:4C03:/
+294.5 "Explosion" sync / 1[56]:[^:]*:Tumultuous Nexus:4C03:/
+294.5 "Explosion" sync / 1[56]:[^:]*:Tumultuous Nexus:4C03:/
+294.5 "Explosion" sync / 1[56]:[^:]*:Tumultuous Nexus:4C03:/
+298.6 "Ferostorm" sync / 1[56]:[^:]*:Garuda:4BFD:/
 303.2 "--untargetable--"
 
 ### Phase 4: Raktapaksa
-309.6 "--sync--" sync / 1[56]:Raktapaksa:4D55:/
-320.4 "Firestorm" sync / 1[56]:Raktapaksa:4BF8:/ window 350,5
+309.6 "--sync--" sync / 1[56]:[^:]*:Raktapaksa:4D55:/
+320.4 "Firestorm" sync / 1[56]:[^:]*:Raktapaksa:4BF8:/ window 350,5
 324.5 "--targetable--"
-343.8 "Hands Of Hell" sync / 1[56]:Raktapaksa:4D01:/
-348.1 "Heat Burst" sync / 1[56]:Raktapaksa:4C0D:/
-348.3 "Eruption" sync / 1[56]:Raktapaksa:4C17:/
-361.1 "Hands Of Hell" sync / 1[56]:Raktapaksa:4D01:/
-365.5 "Heat Burst" sync / 1[56]:Raktapaksa:4C0D:/
-365.7 "Eruption" sync / 1[56]:Raktapaksa:4C17:/
-376.5 "Inferno Howl" sync / 1[56]:Raktapaksa:4C14:/
-384.1 "Air Bump" sync / 1[56]:Raktapaksa:4BF9:/
-387.1 "Ferostorm" sync / 1[56]:Raktapaksa:4C06:/
+343.8 "Hands Of Hell" sync / 1[56]:[^:]*:Raktapaksa:4D01:/
+348.1 "Heat Burst" sync / 1[56]:[^:]*:Raktapaksa:4C0D:/
+348.3 "Eruption" sync / 1[56]:[^:]*:Raktapaksa:4C17:/
+361.1 "Hands Of Hell" sync / 1[56]:[^:]*:Raktapaksa:4D01:/
+365.5 "Heat Burst" sync / 1[56]:[^:]*:Raktapaksa:4C0D:/
+365.7 "Eruption" sync / 1[56]:[^:]*:Raktapaksa:4C17:/
+376.5 "Inferno Howl" sync / 1[56]:[^:]*:Raktapaksa:4C14:/
+384.1 "Air Bump" sync / 1[56]:[^:]*:Raktapaksa:4BF9:/
+387.1 "Ferostorm" sync / 1[56]:[^:]*:Raktapaksa:4C06:/
 
-394.8 "Strike Spark" sync / 1[56]:Raktapaksa:4BD3:/
-398.0 "Call Of The Inferno" sync / 1[56]:Raktapaksa:4C12:/
-407.2 "Hot Foot" sync / 1[56]:Raktapaksa:4C11:/
-408.6 "Eruption" sync / 1[56]:Raktapaksa:4C17:/
-411.0 "Hands Of Flame" sync / 1[56]:Raktapaksa:4C0A:/
-415.0 "Heat Burst" sync / 1[56]:Raktapaksa:4C0D:/
-415.3 "Eruption" sync / 1[56]:Raktapaksa:4C17:/
-419.2 "Instant Incineration" sync / 1[56]:Raktapaksa:4C0E:/
-423.0 "Meteor Strike" sync / 1[56]:Raktapaksa:4C0F:/
-436.7 "Downburst" sync / 1[56]:Raktapaksa:4BFC:/
+394.8 "Strike Spark" sync / 1[56]:[^:]*:Raktapaksa:4BD3:/
+398.0 "Call Of The Inferno" sync / 1[56]:[^:]*:Raktapaksa:4C12:/
+407.2 "Hot Foot" sync / 1[56]:[^:]*:Raktapaksa:4C11:/
+408.6 "Eruption" sync / 1[56]:[^:]*:Raktapaksa:4C17:/
+411.0 "Hands Of Flame" sync / 1[56]:[^:]*:Raktapaksa:4C0A:/
+415.0 "Heat Burst" sync / 1[56]:[^:]*:Raktapaksa:4C0D:/
+415.3 "Eruption" sync / 1[56]:[^:]*:Raktapaksa:4C17:/
+419.2 "Instant Incineration" sync / 1[56]:[^:]*:Raktapaksa:4C0E:/
+423.0 "Meteor Strike" sync / 1[56]:[^:]*:Raktapaksa:4C0F:/
+436.7 "Downburst" sync / 1[56]:[^:]*:Raktapaksa:4BFC:/
 436.7 "--untargetable--"
 
 441.0 "--targetable--"
-445.2 "--sync--" sync / 1[56]:Raktapaksa:4C19:/
-449.2 "Radiant Plume" sync / 1[56]:Raktapaksa:4C15:/
-457.3 "Blaze 1" #sync / 1[56]:Twisting Blaze:4C1B:/
-459.4 "Blaze 2" #sync / 1[56]:Twisting Blaze:4C1B:/
-459.8 "Wind Cutter" #sync / 1[56]:Tumultuous Nexus:4C02:/
-461.5 "Blaze 3" #sync / 1[56]:Twisting Blaze:4C1B:/
-462.8 "Wind Cutter" #sync / 1[56]:Tumultuous Nexus:4C02:/
-463.6 "Blaze 4" #sync / 1[56]:Twisting Blaze:4C1B:/
-465.7 "Blaze 5" #sync / 1[56]:Twisting Blaze:4C1B:/
-465.8 "Wind Cutter" #sync / 1[56]:Tumultuous Nexus:4C02:/
-472.3 "Spread Of Fire" sync / 1[56]:Raktapaksa:4C18:/
-472.8 "Air Bump" sync / 1[56]:Raktapaksa:4BF9:/
-476.0 "Conflag Strike" sync / 1[56]:Raktapaksa:4C10:/
+445.2 "--sync--" sync / 1[56]:[^:]*:Raktapaksa:4C19:/
+449.2 "Radiant Plume" sync / 1[56]:[^:]*:Raktapaksa:4C15:/
+457.3 "Blaze 1" #sync / 1[56]:[^:]*:Twisting Blaze:4C1B:/
+459.4 "Blaze 2" #sync / 1[56]:[^:]*:Twisting Blaze:4C1B:/
+459.8 "Wind Cutter" #sync / 1[56]:[^:]*:Tumultuous Nexus:4C02:/
+461.5 "Blaze 3" #sync / 1[56]:[^:]*:Twisting Blaze:4C1B:/
+462.8 "Wind Cutter" #sync / 1[56]:[^:]*:Tumultuous Nexus:4C02:/
+463.6 "Blaze 4" #sync / 1[56]:[^:]*:Twisting Blaze:4C1B:/
+465.7 "Blaze 5" #sync / 1[56]:[^:]*:Twisting Blaze:4C1B:/
+465.8 "Wind Cutter" #sync / 1[56]:[^:]*:Tumultuous Nexus:4C02:/
+472.3 "Spread Of Fire" sync / 1[56]:[^:]*:Raktapaksa:4C18:/
+472.8 "Air Bump" sync / 1[56]:[^:]*:Raktapaksa:4BF9:/
+476.0 "Conflag Strike" sync / 1[56]:[^:]*:Raktapaksa:4C10:/
 
-490.2 "Occluded Front" sync / 1[56]:Raktapaksa:4E4C:/
-494.7 "Air Bump" sync / 1[56]:Raktapaksa:4BF9:/
-499.2 "Wind Cutter" sync / 1[56]:Tumultuous Nexus:4C02:/
-502.2 "Storm Of Fury" sync / 1[56]:Raktapaksa:4C08:/
-509.4 "Inferno Howl" sync / 1[56]:Raktapaksa:4C14:/
-520.5 "Occluded Front" sync / 1[56]:Raktapaksa:4E4C:/
-529.6 "Wind Cutter" sync / 1[56]:Tumultuous Nexus:4C02:/
+490.2 "Occluded Front" sync / 1[56]:[^:]*:Raktapaksa:4E4C:/
+494.7 "Air Bump" sync / 1[56]:[^:]*:Raktapaksa:4BF9:/
+499.2 "Wind Cutter" sync / 1[56]:[^:]*:Tumultuous Nexus:4C02:/
+502.2 "Storm Of Fury" sync / 1[56]:[^:]*:Raktapaksa:4C08:/
+509.4 "Inferno Howl" sync / 1[56]:[^:]*:Raktapaksa:4C14:/
+520.5 "Occluded Front" sync / 1[56]:[^:]*:Raktapaksa:4E4C:/
+529.6 "Wind Cutter" sync / 1[56]:[^:]*:Tumultuous Nexus:4C02:/
 
-530.6 "Hands Of Hell" sync / 1[56]:Raktapaksa:4D01:/
-535.0 "Heat Burst" sync / 1[56]:Raktapaksa:4C0D:/
-535.2 "Eruption" sync / 1[56]:Raktapaksa:4C17:/
-546.6 "Air Bump" sync / 1[56]:Raktapaksa:4BF9:/
+530.6 "Hands Of Hell" sync / 1[56]:[^:]*:Raktapaksa:4D01:/
+535.0 "Heat Burst" sync / 1[56]:[^:]*:Raktapaksa:4C0D:/
+535.2 "Eruption" sync / 1[56]:[^:]*:Raktapaksa:4C17:/
+546.6 "Air Bump" sync / 1[56]:[^:]*:Raktapaksa:4BF9:/
 
-548.1 "Hands Of Hell" sync / 1[56]:Raktapaksa:4D01:/
-552.4 "Heat Burst" sync / 1[56]:Raktapaksa:4C0D:/
-552.6 "Eruption" sync / 1[56]:Raktapaksa:4C17:/
-556.7 "Hands Of Flame" sync / 1[56]:Raktapaksa:4C0A:/
-560.7 "Heat Burst" sync / 1[56]:Raktapaksa:4C0D:/
-561.0 "Eruption" sync / 1[56]:Raktapaksa:4C17:/
-565.0 "Instant Incineration" sync / 1[56]:Raktapaksa:4C0E:/
-568.7 "Meteor Strike" sync / 1[56]:Raktapaksa:4C0F:/
-586.4 "Ferostorm" sync / 1[56]:Raktapaksa:4C06:/
-594.5 "Ferostorm" sync / 1[56]:Raktapaksa:4C06:/
+548.1 "Hands Of Hell" sync / 1[56]:[^:]*:Raktapaksa:4D01:/
+552.4 "Heat Burst" sync / 1[56]:[^:]*:Raktapaksa:4C0D:/
+552.6 "Eruption" sync / 1[56]:[^:]*:Raktapaksa:4C17:/
+556.7 "Hands Of Flame" sync / 1[56]:[^:]*:Raktapaksa:4C0A:/
+560.7 "Heat Burst" sync / 1[56]:[^:]*:Raktapaksa:4C0D:/
+561.0 "Eruption" sync / 1[56]:[^:]*:Raktapaksa:4C17:/
+565.0 "Instant Incineration" sync / 1[56]:[^:]*:Raktapaksa:4C0E:/
+568.7 "Meteor Strike" sync / 1[56]:[^:]*:Raktapaksa:4C0F:/
+586.4 "Ferostorm" sync / 1[56]:[^:]*:Raktapaksa:4C06:/
+594.5 "Ferostorm" sync / 1[56]:[^:]*:Raktapaksa:4C06:/
 
-603.3 "Downburst" sync / 1[56]:Raktapaksa:4BFC:/
+603.3 "Downburst" sync / 1[56]:[^:]*:Raktapaksa:4BFC:/
 603.3 "--untargetable--"
 607.6 "--targetable--"
-619.6 "Conflag Strike Enrage" sync / 1[56]:Raktapaksa:4C1C:/
+619.6 "Conflag Strike Enrage" sync / 1[56]:[^:]*:Raktapaksa:4C1C:/

--- a/ui/raidboss/data/05-shb/raid/e7n.txt
+++ b/ui/raidboss/data/05-shb/raid/e7n.txt
@@ -11,88 +11,88 @@ hideall "--sync--"
 
 # Opening block
 0.0 "--sync--" sync /:Engage!/ window 0,1
-3.8 "--sync--" sync / 1[56]:The Idol Of Darkness:4C50:/ window 3.8,1
-12.8 "Empty Wave" sync / 1[56]:The Idol Of Darkness:4C52:/ window 12.8,30
-25.0 "Unshadowed Stake" sync / 1[56]:The Idol Of Darkness:4C51:/
-37.8 "Words of Motion" sync / 1[56]:The Idol Of Darkness:4C2B:/ window 30,30
-49.6 "Light's Course" # sync / 1[56]:Unforgiven Idolatry:4C3C:/
-52.6 "Light's Course" # sync / 1[56]:Unforgiven Idolatry:4C3C:/
-55.5 "Betwixt Worlds" sync / 1[56]:The Idol Of Darkness:4CF8:/ window 20,20
-72.7 "Light's Course" # sync / 1[56]:Unforgiven Idolatry:(4E63|4C3C):/
-75.7 "Light's Course" # sync / 1[56]:Unforgiven Idolatry:(4E63|4C3C):/
-78.7 "Light's Course" # sync / 1[56]:Unforgiven Idolatry:4C40:/
-81.7 "Light's Course" # sync / 1[56]:Unforgiven Idolatry:4C40:/
-88.7 "Betwixt Worlds" sync / 1[56]:The Idol Of Darkness:4CF8:/
-104.9 "Light's Course" # sync / 1[56]:Unforgiven Idolatry:(4E63|4C3C):/
-107.9 "Light's Course" # sync / 1[56]:Unforgiven Idolatry:(4E63|4C3C):/
-110.8 "Light's Course" # sync / 1[56]:Unforgiven Idolatry:4C40:/
-113.8 "Light's Course" # sync / 1[56]:Unforgiven Idolatry:4C40:/
-124.6 "Away with Thee" sync / 1[56]:The Idol Of Darkness:4C39:/ window 30,30
-141.8 "False Twilight" sync / 1[56]:The Idol Of Darkness:4C59:/
-145.9 "Stygian Sword" sync / 1[56]:The Idol Of Darkness:4C55:/
-150.9 "Silver Sledge" sync / 1[56]:The Idol Of Darkness:4C54:/
-157.9 "Empty Wave" sync / 1[56]:The Idol Of Darkness:4C52:/
-165.5 "Unshadowed Stake" sync / 1[56]:The Idol Of Darkness:4C51:/
-175.7 "Unjoined Aspect" sync / 1[56]:The Idol Of Darkness:4C3B:/ window 30,30
-184.4 "Words of Night" sync / 1[56]:The Idol Of Darkness:4C2C:/
-196.2 "Dark's Course/Light's Course" # sync / 1[56]:Unforgiven Idolatry:4C3[CD]:/
-203.3 "Dark's Course/Light's Course" # sync / 1[56]:Unforgiven Idolatry:4C2[23]:/
-210.3 "Dark's Course/Light's Course" # sync / 1[56]:Unforgiven Idolatry:4C2[23]:/
+3.8 "--sync--" sync / 1[56]:[^:]*:The Idol Of Darkness:4C50:/ window 3.8,1
+12.8 "Empty Wave" sync / 1[56]:[^:]*:The Idol Of Darkness:4C52:/ window 12.8,30
+25.0 "Unshadowed Stake" sync / 1[56]:[^:]*:The Idol Of Darkness:4C51:/
+37.8 "Words of Motion" sync / 1[56]:[^:]*:The Idol Of Darkness:4C2B:/ window 30,30
+49.6 "Light's Course" # sync / 1[56]:[^:]*:Unforgiven Idolatry:4C3C:/
+52.6 "Light's Course" # sync / 1[56]:[^:]*:Unforgiven Idolatry:4C3C:/
+55.5 "Betwixt Worlds" sync / 1[56]:[^:]*:The Idol Of Darkness:4CF8:/ window 20,20
+72.7 "Light's Course" # sync / 1[56]:[^:]*:Unforgiven Idolatry:(4E63|4C3C):/
+75.7 "Light's Course" # sync / 1[56]:[^:]*:Unforgiven Idolatry:(4E63|4C3C):/
+78.7 "Light's Course" # sync / 1[56]:[^:]*:Unforgiven Idolatry:4C40:/
+81.7 "Light's Course" # sync / 1[56]:[^:]*:Unforgiven Idolatry:4C40:/
+88.7 "Betwixt Worlds" sync / 1[56]:[^:]*:The Idol Of Darkness:4CF8:/
+104.9 "Light's Course" # sync / 1[56]:[^:]*:Unforgiven Idolatry:(4E63|4C3C):/
+107.9 "Light's Course" # sync / 1[56]:[^:]*:Unforgiven Idolatry:(4E63|4C3C):/
+110.8 "Light's Course" # sync / 1[56]:[^:]*:Unforgiven Idolatry:4C40:/
+113.8 "Light's Course" # sync / 1[56]:[^:]*:Unforgiven Idolatry:4C40:/
+124.6 "Away with Thee" sync / 1[56]:[^:]*:The Idol Of Darkness:4C39:/ window 30,30
+141.8 "False Twilight" sync / 1[56]:[^:]*:The Idol Of Darkness:4C59:/
+145.9 "Stygian Sword" sync / 1[56]:[^:]*:The Idol Of Darkness:4C55:/
+150.9 "Silver Sledge" sync / 1[56]:[^:]*:The Idol Of Darkness:4C54:/
+157.9 "Empty Wave" sync / 1[56]:[^:]*:The Idol Of Darkness:4C52:/
+165.5 "Unshadowed Stake" sync / 1[56]:[^:]*:The Idol Of Darkness:4C51:/
+175.7 "Unjoined Aspect" sync / 1[56]:[^:]*:The Idol Of Darkness:4C3B:/ window 30,30
+184.4 "Words of Night" sync / 1[56]:[^:]*:The Idol Of Darkness:4C2C:/
+196.2 "Dark's Course/Light's Course" # sync / 1[56]:[^:]*:Unforgiven Idolatry:4C3[CD]:/
+203.3 "Dark's Course/Light's Course" # sync / 1[56]:[^:]*:Unforgiven Idolatry:4C2[23]:/
+210.3 "Dark's Course/Light's Course" # sync / 1[56]:[^:]*:Unforgiven Idolatry:4C2[23]:/
 219.1 "--untargetable--"
 
 
 # Intermission block
 226.3 "--targetable--"
-236.8 "Away with Thee" sync / 1[56]:The Idol Of Darkness:(4C39|4E7E):/ window 30,30
-251.7 "Strength in Numbers" sync / 1[56]:Idolatry:4C4[CD]:/ window 251.7,5
-262.3 "Silver Shot" sync / 1[56]:The Idol Of Darkness:4E7[CD]:/
-270.3 "Silver Shot" sync / 1[56]:The Idol Of Darkness:4E7[CD]:/
-271.7 "Strength in Numbers" sync / 1[56]:Idolatry:4C4[CD]:/
+236.8 "Away with Thee" sync / 1[56]:[^:]*:The Idol Of Darkness:(4C39|4E7E):/ window 30,30
+251.7 "Strength in Numbers" sync / 1[56]:[^:]*:Idolatry:4C4[CD]:/ window 251.7,5
+262.3 "Silver Shot" sync / 1[56]:[^:]*:The Idol Of Darkness:4E7[CD]:/
+270.3 "Silver Shot" sync / 1[56]:[^:]*:The Idol Of Darkness:4E7[CD]:/
+271.7 "Strength in Numbers" sync / 1[56]:[^:]*:Idolatry:4C4[CD]:/
 281.7 "Explosion enrage?"
 
 
 # Rotation block. 135.6 seconds
-400.0 "Empty Flood" sync / 1[56]:The Idol Of Darkness:(4E5[46]|4C53):/ window 400,20
+400.0 "Empty Flood" sync / 1[56]:[^:]*:The Idol Of Darkness:(4E5[46]|4C53):/ window 400,20
 410.3 "--targetable--"
-414.4 "Unjoined Aspect" sync / 1[56]:The Idol Of Darkness:4C3B:/
-419.6 "Betwixt Worlds" sync / 1[56]:The Idol Of Darkness:4CF8:/
-424.6 "Words of Night" sync / 1[56]:The Idol Of Darkness:4C2C:/ window 30,30
-436.8 "Dark's Course/Light's Course" # sync / 1[56]:Unforgiven Idolatry:4C(3[CDE]|4[013]):/
-439.8 "Dark's Course/Light's Course" # sync / 1[56]:Unforgiven Idolatry:4C(3[CDE]|4[013]):/
-449.9 "Dark's Course/Light's Course" # sync / 1[56]:Unforgiven Idolatry:4C2[23]:/
-460.8 "Away with Thee" sync / 1[56]:The Idol Of Darkness:4C39:/ window 30,30
-475.9 "Black Smoke" sync / 1[56]:The Idol Of Darkness:4C56:/
-485.1 "Empty Wave" sync / 1[56]:The Idol Of Darkness:4C52:/
-492.7 "Unshadowed Stake" sync / 1[56]:The Idol Of Darkness:4C51:/
-501.4 "Words of Motion" sync / 1[56]:The Idol Of Darkness:4C2B:/
-505.6 "Betwixt Worlds" sync / 1[56]:The Idol Of Darkness:4CF8:/ window 30,30
-522.8 "Light's Course" # sync / 1[56]:Unforgiven Idolatry:4C3[CE]:/
-525.8 "Light's Course" # sync / 1[56]:Unforgiven Idolatry:4C3[CE]:/
-528.9 "Light's Course" # sync / 1[56]:Unforgiven Idolatry:4C40:/
-532.0 "False Twilight" sync / 1[56]:The Idol Of Darkness:4C59:/
-532.1 "Light's Course" # sync / 1[56]:Unforgiven Idolatry:4C40:/
-536.0 "Stygian Sword" sync / 1[56]:The Idol Of Darkness:4C55:/ window 30,30
-541.0 "Silver Sledge" sync / 1[56]:The Idol Of Darkness:4C54:/
+414.4 "Unjoined Aspect" sync / 1[56]:[^:]*:The Idol Of Darkness:4C3B:/
+419.6 "Betwixt Worlds" sync / 1[56]:[^:]*:The Idol Of Darkness:4CF8:/
+424.6 "Words of Night" sync / 1[56]:[^:]*:The Idol Of Darkness:4C2C:/ window 30,30
+436.8 "Dark's Course/Light's Course" # sync / 1[56]:[^:]*:Unforgiven Idolatry:4C(3[CDE]|4[013]):/
+439.8 "Dark's Course/Light's Course" # sync / 1[56]:[^:]*:Unforgiven Idolatry:4C(3[CDE]|4[013]):/
+449.9 "Dark's Course/Light's Course" # sync / 1[56]:[^:]*:Unforgiven Idolatry:4C2[23]:/
+460.8 "Away with Thee" sync / 1[56]:[^:]*:The Idol Of Darkness:4C39:/ window 30,30
+475.9 "Black Smoke" sync / 1[56]:[^:]*:The Idol Of Darkness:4C56:/
+485.1 "Empty Wave" sync / 1[56]:[^:]*:The Idol Of Darkness:4C52:/
+492.7 "Unshadowed Stake" sync / 1[56]:[^:]*:The Idol Of Darkness:4C51:/
+501.4 "Words of Motion" sync / 1[56]:[^:]*:The Idol Of Darkness:4C2B:/
+505.6 "Betwixt Worlds" sync / 1[56]:[^:]*:The Idol Of Darkness:4CF8:/ window 30,30
+522.8 "Light's Course" # sync / 1[56]:[^:]*:Unforgiven Idolatry:4C3[CE]:/
+525.8 "Light's Course" # sync / 1[56]:[^:]*:Unforgiven Idolatry:4C3[CE]:/
+528.9 "Light's Course" # sync / 1[56]:[^:]*:Unforgiven Idolatry:4C40:/
+532.0 "False Twilight" sync / 1[56]:[^:]*:The Idol Of Darkness:4C59:/
+532.1 "Light's Course" # sync / 1[56]:[^:]*:Unforgiven Idolatry:4C40:/
+536.0 "Stygian Sword" sync / 1[56]:[^:]*:The Idol Of Darkness:4C55:/ window 30,30
+541.0 "Silver Sledge" sync / 1[56]:[^:]*:The Idol Of Darkness:4C54:/
 
-550.0 "Unjoined Aspect" sync / 1[56]:The Idol Of Darkness:4C3B:/
-555.2 "Betwixt Worlds" sync / 1[56]:The Idol Of Darkness:4CF8:/
-560.2 "Words of Night" sync / 1[56]:The Idol Of Darkness:4C2C:/ window 30,30
-572.4 "Dark's Course/Light's Course" # sync / 1[56]:Unforgiven Idolatry:4C(3[CDE]|4[013]):/
-575.4 "Dark's Course/Light's Course" # sync / 1[56]:Unforgiven Idolatry:4C(3[CDE]|4[013]):/
-585.5 "Dark's Course/Light's Course" # sync / 1[56]:Unforgiven Idolatry:4C2[23]:/
-596.4 "Away with Thee" sync / 1[56]:The Idol Of Darkness:4C39:/ window 30,30
-611.5 "Black Smoke" sync / 1[56]:The Idol Of Darkness:4C56:/
-620.7 "Empty Wave" sync / 1[56]:The Idol Of Darkness:4C52:/
-628.3 "Unshadowed Stake" sync / 1[56]:The Idol Of Darkness:4C51:/
-637.0 "Words of Motion" sync / 1[56]:The Idol Of Darkness:4C2B:/
-641.2 "Betwixt Worlds" sync / 1[56]:The Idol Of Darkness:4CF8:/ window 30,30
-658.4 "Light's Course" # sync / 1[56]:Unforgiven Idolatry:4C3[CE]:/
-661.4 "Light's Course" # sync / 1[56]:Unforgiven Idolatry:4C3[CE]:/
-664.5 "Light's Course" # sync / 1[56]:Unforgiven Idolatry:4C40:/
-667.6 "False Twilight" sync / 1[56]:The Idol Of Darkness:4C59:/
-667.7 "Light's Course" # sync / 1[56]:Unforgiven Idolatry:4C40:/
-671.6 "Stygian Sword" sync / 1[56]:The Idol Of Darkness:4C55:/ window 30,30
-676.6 "Silver Sledge" sync / 1[56]:The Idol Of Darkness:4C54:/ jump 541.0
+550.0 "Unjoined Aspect" sync / 1[56]:[^:]*:The Idol Of Darkness:4C3B:/
+555.2 "Betwixt Worlds" sync / 1[56]:[^:]*:The Idol Of Darkness:4CF8:/
+560.2 "Words of Night" sync / 1[56]:[^:]*:The Idol Of Darkness:4C2C:/ window 30,30
+572.4 "Dark's Course/Light's Course" # sync / 1[56]:[^:]*:Unforgiven Idolatry:4C(3[CDE]|4[013]):/
+575.4 "Dark's Course/Light's Course" # sync / 1[56]:[^:]*:Unforgiven Idolatry:4C(3[CDE]|4[013]):/
+585.5 "Dark's Course/Light's Course" # sync / 1[56]:[^:]*:Unforgiven Idolatry:4C2[23]:/
+596.4 "Away with Thee" sync / 1[56]:[^:]*:The Idol Of Darkness:4C39:/ window 30,30
+611.5 "Black Smoke" sync / 1[56]:[^:]*:The Idol Of Darkness:4C56:/
+620.7 "Empty Wave" sync / 1[56]:[^:]*:The Idol Of Darkness:4C52:/
+628.3 "Unshadowed Stake" sync / 1[56]:[^:]*:The Idol Of Darkness:4C51:/
+637.0 "Words of Motion" sync / 1[56]:[^:]*:The Idol Of Darkness:4C2B:/
+641.2 "Betwixt Worlds" sync / 1[56]:[^:]*:The Idol Of Darkness:4CF8:/ window 30,30
+658.4 "Light's Course" # sync / 1[56]:[^:]*:Unforgiven Idolatry:4C3[CE]:/
+661.4 "Light's Course" # sync / 1[56]:[^:]*:Unforgiven Idolatry:4C3[CE]:/
+664.5 "Light's Course" # sync / 1[56]:[^:]*:Unforgiven Idolatry:4C40:/
+667.6 "False Twilight" sync / 1[56]:[^:]*:The Idol Of Darkness:4C59:/
+667.7 "Light's Course" # sync / 1[56]:[^:]*:Unforgiven Idolatry:4C40:/
+671.6 "Stygian Sword" sync / 1[56]:[^:]*:The Idol Of Darkness:4C55:/ window 30,30
+676.6 "Silver Sledge" sync / 1[56]:[^:]*:The Idol Of Darkness:4C54:/ jump 541.0
 
 685.6 "Unjoined Aspect"
 690.8 "Betwixt Worlds"

--- a/ui/raidboss/data/05-shb/raid/e7s.txt
+++ b/ui/raidboss/data/05-shb/raid/e7s.txt
@@ -13,135 +13,135 @@ hideall "--sync--"
 
 ### Phase 1
 0.0 "--sync--" sync /:Engage!/ window 0,1
-4.0 "--sync--" sync / 1[56]:The Idol Of Darkness:4D59:/ window 5,0
-13.0 "Empty Wave" sync / 1[56]:The Idol Of Darkness:4C8A:/ window 13,20
-25.2 "Unshadowed Stake" sync / 1[56]:The Idol Of Darkness:4C88:/
-27.8 "Silver Stake" sync / 1[56]:The Idol Of Darkness:4C89:/
-40.4 "Words Of Motion" sync / 1[56]:The Idol Of Darkness:4C2B:/
-44.6 "Betwixt Worlds" sync / 1[56]:The Idol Of Darkness:4CF9:/
-51.7 "--sync--" sync / 1[56]:Unforgiven Idolatry:4C37:/
-54.7 "--sync--" sync / 1[56]:Unforgiven Idolatry:4C37:/
-59.7 "Light's Course" #sync / 1[56]:Unforgiven Idolatry:4C62:/
-62.7 "Light's Course" #sync / 1[56]:Unforgiven Idolatry:4C62:/
-71.3 "Light's Course" #sync / 1[56]:Unforgiven Idolatry:4C63:/
-74.3 "Light's Course" #sync / 1[56]:Unforgiven Idolatry:4C63:/
-81.9 "Light's Course" #sync / 1[56]:Unforgiven Idolatry:4C63:/
-84.9 "Light's Course" #sync / 1[56]:Unforgiven Idolatry:4C63:/
-92.5 "Light's Course" #sync / 1[56]:Unforgiven Idolatry:4C63:/
-95.5 "Light's Course" #sync / 1[56]:Unforgiven Idolatry:4C64:/
+4.0 "--sync--" sync / 1[56]:[^:]*:The Idol Of Darkness:4D59:/ window 5,0
+13.0 "Empty Wave" sync / 1[56]:[^:]*:The Idol Of Darkness:4C8A:/ window 13,20
+25.2 "Unshadowed Stake" sync / 1[56]:[^:]*:The Idol Of Darkness:4C88:/
+27.8 "Silver Stake" sync / 1[56]:[^:]*:The Idol Of Darkness:4C89:/
+40.4 "Words Of Motion" sync / 1[56]:[^:]*:The Idol Of Darkness:4C2B:/
+44.6 "Betwixt Worlds" sync / 1[56]:[^:]*:The Idol Of Darkness:4CF9:/
+51.7 "--sync--" sync / 1[56]:[^:]*:Unforgiven Idolatry:4C37:/
+54.7 "--sync--" sync / 1[56]:[^:]*:Unforgiven Idolatry:4C37:/
+59.7 "Light's Course" #sync / 1[56]:[^:]*:Unforgiven Idolatry:4C62:/
+62.7 "Light's Course" #sync / 1[56]:[^:]*:Unforgiven Idolatry:4C62:/
+71.3 "Light's Course" #sync / 1[56]:[^:]*:Unforgiven Idolatry:4C63:/
+74.3 "Light's Course" #sync / 1[56]:[^:]*:Unforgiven Idolatry:4C63:/
+81.9 "Light's Course" #sync / 1[56]:[^:]*:Unforgiven Idolatry:4C63:/
+84.9 "Light's Course" #sync / 1[56]:[^:]*:Unforgiven Idolatry:4C63:/
+92.5 "Light's Course" #sync / 1[56]:[^:]*:Unforgiven Idolatry:4C63:/
+95.5 "Light's Course" #sync / 1[56]:[^:]*:Unforgiven Idolatry:4C64:/
 
-96.5 "--sync--" sync / 1[56]:The Idol Of Darkness:4C30:/
-105.4 "Betwixt Worlds" sync / 1[56]:The Idol Of Darkness:4C6B:/
-108.5 "Shockwave" sync / 1[56]:The Idol Of Darkness:4C6C:/
-111.0 "Words Of Spite" sync / 1[56]:The Idol Of Darkness:4C2F:/
-113.7 "--sync--" sync / 1[56]:Unforgiven Idolatry:4C37:/
-116.7 "Away With Thee" sync / 1[56]:The Idol Of Darkness:4C39:/
-122.9 "Silver Sledge" sync / 1[56]:The Idol Of Darkness:4C26:/
-130.9 "Fate's Course" sync / 1[56]:Unforgiven Idolatry:4C61:/
-131.0 "Silver Sledge" sync / 1[56]:The Idol Of Darkness:4C27:/
+96.5 "--sync--" sync / 1[56]:[^:]*:The Idol Of Darkness:4C30:/
+105.4 "Betwixt Worlds" sync / 1[56]:[^:]*:The Idol Of Darkness:4C6B:/
+108.5 "Shockwave" sync / 1[56]:[^:]*:The Idol Of Darkness:4C6C:/
+111.0 "Words Of Spite" sync / 1[56]:[^:]*:The Idol Of Darkness:4C2F:/
+113.7 "--sync--" sync / 1[56]:[^:]*:Unforgiven Idolatry:4C37:/
+116.7 "Away With Thee" sync / 1[56]:[^:]*:The Idol Of Darkness:4C39:/
+122.9 "Silver Sledge" sync / 1[56]:[^:]*:The Idol Of Darkness:4C26:/
+130.9 "Fate's Course" sync / 1[56]:[^:]*:Unforgiven Idolatry:4C61:/
+131.0 "Silver Sledge" sync / 1[56]:[^:]*:The Idol Of Darkness:4C27:/
 
-132.1 "--sync--" sync / 1[56]:The Idol Of Darkness:4C30:/
-139.9 "Empty Wave" sync / 1[56]:The Idol Of Darkness:4C8A:/
-147.5 "Unshadowed Stake" sync / 1[56]:The Idol Of Darkness:4C88:/
-150.1 "Silver Stake" sync / 1[56]:The Idol Of Darkness:4C89:/
-159.1 "Words Of Motion" sync / 1[56]:The Idol Of Darkness:4C2B:/
-162.3 "--sync--" sync / 1[56]:Unforgiven Idolatry:4C37:/
-163.3 "False Moonlight" sync / 1[56]:The Idol Of Darkness:4C98:/
-166.5 "--sync--" sync / 1[56]:Unforgiven Idolatry:4C37:/
-167.4 "Silver Sword" sync / 1[56]:The Idol Of Darkness:4C8E:/
-170.4 "Dark's Course" sync / 1[56]:Unforgiven Idolatry:4C5A:/
-170.4 "Silver Scourge" sync / 1[56]:The Idol Of Darkness:4C93:/
-174.5 "Dark's Course" sync / 1[56]:Unforgiven Idolatry:4C5A:/
-177.5 "Away With Thee" sync / 1[56]:The Idol Of Darkness:4C39:/
+132.1 "--sync--" sync / 1[56]:[^:]*:The Idol Of Darkness:4C30:/
+139.9 "Empty Wave" sync / 1[56]:[^:]*:The Idol Of Darkness:4C8A:/
+147.5 "Unshadowed Stake" sync / 1[56]:[^:]*:The Idol Of Darkness:4C88:/
+150.1 "Silver Stake" sync / 1[56]:[^:]*:The Idol Of Darkness:4C89:/
+159.1 "Words Of Motion" sync / 1[56]:[^:]*:The Idol Of Darkness:4C2B:/
+162.3 "--sync--" sync / 1[56]:[^:]*:Unforgiven Idolatry:4C37:/
+163.3 "False Moonlight" sync / 1[56]:[^:]*:The Idol Of Darkness:4C98:/
+166.5 "--sync--" sync / 1[56]:[^:]*:Unforgiven Idolatry:4C37:/
+167.4 "Silver Sword" sync / 1[56]:[^:]*:The Idol Of Darkness:4C8E:/
+170.4 "Dark's Course" sync / 1[56]:[^:]*:Unforgiven Idolatry:4C5A:/
+170.4 "Silver Scourge" sync / 1[56]:[^:]*:The Idol Of Darkness:4C93:/
+174.5 "Dark's Course" sync / 1[56]:[^:]*:Unforgiven Idolatry:4C5A:/
+177.5 "Away With Thee" sync / 1[56]:[^:]*:The Idol Of Darkness:4C39:/
 
-179.5 "--sync--" sync / 1[56]:Unforgiven Idolatry:4C37:/
-183.7 "False Midnight" sync / 1[56]:The Idol Of Darkness:4C99:/
-183.7 "--sync--" sync / 1[56]:Unforgiven Idolatry:4C37:/
-187.5 "Dark's Course" sync / 1[56]:Unforgiven Idolatry:4C5A:/
-191.7 "Silver Sledge" sync / 1[56]:The Idol Of Darkness:4C8D:/
-191.7 "Silver Shot" sync / 1[56]:The Idol Of Darkness:4C92:/
-191.7 "Dark's Course" sync / 1[56]:Unforgiven Idolatry:4C5A:/
-191.7 "--sync--" sync / 1[56]:The Idol Of Darkness:4C30:/
+179.5 "--sync--" sync / 1[56]:[^:]*:Unforgiven Idolatry:4C37:/
+183.7 "False Midnight" sync / 1[56]:[^:]*:The Idol Of Darkness:4C99:/
+183.7 "--sync--" sync / 1[56]:[^:]*:Unforgiven Idolatry:4C37:/
+187.5 "Dark's Course" sync / 1[56]:[^:]*:Unforgiven Idolatry:4C5A:/
+191.7 "Silver Sledge" sync / 1[56]:[^:]*:The Idol Of Darkness:4C8D:/
+191.7 "Silver Shot" sync / 1[56]:[^:]*:The Idol Of Darkness:4C92:/
+191.7 "Dark's Course" sync / 1[56]:[^:]*:Unforgiven Idolatry:4C5A:/
+191.7 "--sync--" sync / 1[56]:[^:]*:The Idol Of Darkness:4C30:/
 198.5 "--untargetable--"
-198.6 "--sync--" sync / 1[56]:The Idol Of Darkness:4D0A:/
+198.6 "--sync--" sync / 1[56]:[^:]*:The Idol Of Darkness:4D0A:/
 
-202.7 "--sync--" sync / 1[56]:The Idol Of Darkness:4C32:/ window 210,10
-203.6 "--sync--" sync / 1[56]:Idolatry:4C3A:/
+202.7 "--sync--" sync / 1[56]:[^:]*:The Idol Of Darkness:4C32:/ window 210,10
+203.6 "--sync--" sync / 1[56]:[^:]*:Idolatry:4C3A:/
 205.6 "--targetable--"
-224.9 "Overwhelming Force" sync / 1[56]:Blasphemy:4C73:/
-231.8 "Insatiable Light" sync / 1[56]:Idolatry:4C6D:/
-239.5 "Advent Of Light" sync / 14:Idolatry:4C6E:/ # use start of cast for this interrupt
-243.6 "Overwhelming Force" sync / 1[56]:Blasphemy:4C73:/
-253.7 "Overwhelming Force" sync / 1[56]:Blasphemy:4C73:/
-254.5 "Insatiable Light" sync / 1[56]:Idolatry:4C6D:/
-264.3 "Away With Thee" sync / 1[56]:The Idol Of Darkness:4C39:/
-268.1 "Strength In Numbers" sync / 1[56]:Idolatry:4C70:/
-278.2 "Insatiable Light" sync / 1[56]:Idolatry:4C6D:/
-290.9 "Overwhelming Force" sync / 1[56]:Blasphemy:4C73:/
-291.8 "Strength In Numbers" sync / 1[56]:Idolatry:4C7[01]:/
-302.0 "Insatiable Light" sync / 1[56]:Idolatry:4C6D:/
+224.9 "Overwhelming Force" sync / 1[56]:[^:]*:Blasphemy:4C73:/
+231.8 "Insatiable Light" sync / 1[56]:[^:]*:Idolatry:4C6D:/
+239.5 "Advent Of Light" sync / 14:[^:]*:Idolatry:4C6E:/ # use start of cast for this interrupt
+243.6 "Overwhelming Force" sync / 1[56]:[^:]*:Blasphemy:4C73:/
+253.7 "Overwhelming Force" sync / 1[56]:[^:]*:Blasphemy:4C73:/
+254.5 "Insatiable Light" sync / 1[56]:[^:]*:Idolatry:4C6D:/
+264.3 "Away With Thee" sync / 1[56]:[^:]*:The Idol Of Darkness:4C39:/
+268.1 "Strength In Numbers" sync / 1[56]:[^:]*:Idolatry:4C70:/
+278.2 "Insatiable Light" sync / 1[56]:[^:]*:Idolatry:4C6D:/
+290.9 "Overwhelming Force" sync / 1[56]:[^:]*:Blasphemy:4C73:/
+291.8 "Strength In Numbers" sync / 1[56]:[^:]*:Idolatry:4C7[01]:/
+302.0 "Insatiable Light" sync / 1[56]:[^:]*:Idolatry:4C6D:/
 # TODO: fix this sync up
-323.4 "Unearned Envy" sync / 1[56]:Blasphemy:4C74:/
-325.5 "Unearned Envy" #sync / 1[56]:Blasphemy:4C74:/
-327.6 "Unearned Envy" #sync / 1[56]:Blasphemy:4C74:/
-329.7 "Unearned Envy" #sync / 1[56]:Blasphemy:4C74:/
-331.8 "Unearned Envy" #sync / 1[56]:Blasphemy:4C74:/
-333.9 "Unearned Envy" #sync / 1[56]:Blasphemy:4C74:/
+323.4 "Unearned Envy" sync / 1[56]:[^:]*:Blasphemy:4C74:/
+325.5 "Unearned Envy" #sync / 1[56]:[^:]*:Blasphemy:4C74:/
+327.6 "Unearned Envy" #sync / 1[56]:[^:]*:Blasphemy:4C74:/
+329.7 "Unearned Envy" #sync / 1[56]:[^:]*:Blasphemy:4C74:/
+331.8 "Unearned Envy" #sync / 1[56]:[^:]*:Blasphemy:4C74:/
+333.9 "Unearned Envy" #sync / 1[56]:[^:]*:Blasphemy:4C74:/
 # TODO: explosion?
 
-500.0 "Empty Flood" sync / 1[56]:The Idol Of Darkness:4C8B:/ window 500,10
-503.2 "--sync--" sync / 1[56]:The Idol Of Darkness:4D0B:/
-507.3 "--sync--" sync / 1[56]:The Idol Of Darkness:4C32:/
+500.0 "Empty Flood" sync / 1[56]:[^:]*:The Idol Of Darkness:4C8B:/ window 500,10
+503.2 "--sync--" sync / 1[56]:[^:]*:The Idol Of Darkness:4D0B:/
+507.3 "--sync--" sync / 1[56]:[^:]*:The Idol Of Darkness:4C32:/
 
 510.3 "--targetable--"
-514.4 "Unjoined Aspect" sync / 1[56]:The Idol Of Darkness:4C3B:/
-519.4 "Words Of Unity" sync / 1[56]:The Idol Of Darkness:4C2D:/
-524.0 "--sync--" sync / 1[56]:The Idol Of Darkness:4C5E:/
-529.0 "Light's Course" #sync / 1[56]:Unforgiven Idolatry:4C5B:/
-529.5 "--sync--" sync / 1[56]:The Idol Of Darkness:4C30:/
-534.8 "Words Of Entrapment" sync / 1[56]:The Idol Of Darkness:4C2E:/
-550.5 "Light's Course" #sync / 1[56]:Unforgiven Idolatry:4C5F:/
-550.5 "--sync--" sync / 1[56]:The Idol Of Darkness:4C30:/
-550.5 "White/Black Smoke" sync / 1[56]:The Idol Of Darkness:4C9[46]:/
-555.7 "Words Of Unity" sync / 1[56]:The Idol Of Darkness:4C2D:/
-560.4 "--sync--" sync / 1[56]:The Idol Of Darkness:4C5E:/
-565.4 "Light's Course" #sync / 1[56]:Unforgiven Idolatry:4C5B:/
-565.5 "Boundless Light" sync / 1[56]:Unforgiven Idolatry:4C5C:/
-565.9 "--sync--" sync / 1[56]:The Idol Of Darkness:4C30:/
+514.4 "Unjoined Aspect" sync / 1[56]:[^:]*:The Idol Of Darkness:4C3B:/
+519.4 "Words Of Unity" sync / 1[56]:[^:]*:The Idol Of Darkness:4C2D:/
+524.0 "--sync--" sync / 1[56]:[^:]*:The Idol Of Darkness:4C5E:/
+529.0 "Light's Course" #sync / 1[56]:[^:]*:Unforgiven Idolatry:4C5B:/
+529.5 "--sync--" sync / 1[56]:[^:]*:The Idol Of Darkness:4C30:/
+534.8 "Words Of Entrapment" sync / 1[56]:[^:]*:The Idol Of Darkness:4C2E:/
+550.5 "Light's Course" #sync / 1[56]:[^:]*:Unforgiven Idolatry:4C5F:/
+550.5 "--sync--" sync / 1[56]:[^:]*:The Idol Of Darkness:4C30:/
+550.5 "White/Black Smoke" sync / 1[56]:[^:]*:The Idol Of Darkness:4C9[46]:/
+555.7 "Words Of Unity" sync / 1[56]:[^:]*:The Idol Of Darkness:4C2D:/
+560.4 "--sync--" sync / 1[56]:[^:]*:The Idol Of Darkness:4C5E:/
+565.4 "Light's Course" #sync / 1[56]:[^:]*:Unforgiven Idolatry:4C5B:/
+565.5 "Boundless Light" sync / 1[56]:[^:]*:Unforgiven Idolatry:4C5C:/
+565.9 "--sync--" sync / 1[56]:[^:]*:The Idol Of Darkness:4C30:/
 
-578.8 "Unjoined Aspect" sync / 1[56]:The Idol Of Darkness:4C3B:/
-582.0 "Betwixt Worlds" sync / 1[56]:The Idol Of Darkness:4CF9:/
-587.0 "Words Of Night" sync / 1[56]:The Idol Of Darkness:4C2C:/
-596.6 "Light's Course" #sync / 1[56]:Unforgiven Idolatry:4C62:/
-605.2 "Light's Course" #sync / 1[56]:Unforgiven Idolatry:4C63:/
-610.2 "False Dawn" sync / 1[56]:The Idol Of Darkness:4C9A:/
-614.3 "Stygian Sword" sync / 1[56]:The Idol Of Darkness:4C8F:/
-614.4 "Light's Course" #sync / 1[56]:Unforgiven Idolatry:4C63:/
-617.3 "Stygian Spear" sync / 1[56]:The Idol Of Darkness:4C91:/
-617.3 "Silver Spear" sync / 1[56]:The Idol Of Darkness:4C90:/
-622.4 "Light's Course" #sync / 1[56]:Unforgiven Idolatry:4C63:/
+578.8 "Unjoined Aspect" sync / 1[56]:[^:]*:The Idol Of Darkness:4C3B:/
+582.0 "Betwixt Worlds" sync / 1[56]:[^:]*:The Idol Of Darkness:4CF9:/
+587.0 "Words Of Night" sync / 1[56]:[^:]*:The Idol Of Darkness:4C2C:/
+596.6 "Light's Course" #sync / 1[56]:[^:]*:Unforgiven Idolatry:4C62:/
+605.2 "Light's Course" #sync / 1[56]:[^:]*:Unforgiven Idolatry:4C63:/
+610.2 "False Dawn" sync / 1[56]:[^:]*:The Idol Of Darkness:4C9A:/
+614.3 "Stygian Sword" sync / 1[56]:[^:]*:The Idol Of Darkness:4C8F:/
+614.4 "Light's Course" #sync / 1[56]:[^:]*:Unforgiven Idolatry:4C63:/
+617.3 "Stygian Spear" sync / 1[56]:[^:]*:The Idol Of Darkness:4C91:/
+617.3 "Silver Spear" sync / 1[56]:[^:]*:The Idol Of Darkness:4C90:/
+622.4 "Light's Course" #sync / 1[56]:[^:]*:Unforgiven Idolatry:4C63:/
 
-625.4 "--sync--" sync / 1[56]:The Idol Of Darkness:4C30:/
-636.2 "Empty Wave" sync / 1[56]:The Idol Of Darkness:4C8A:/
-643.8 "Unshadowed Stake" sync / 1[56]:The Idol Of Darkness:4C88:/
-646.4 "Silver Stake" sync / 1[56]:The Idol Of Darkness:4C89:/
+625.4 "--sync--" sync / 1[56]:[^:]*:The Idol Of Darkness:4C30:/
+636.2 "Empty Wave" sync / 1[56]:[^:]*:The Idol Of Darkness:4C8A:/
+643.8 "Unshadowed Stake" sync / 1[56]:[^:]*:The Idol Of Darkness:4C88:/
+646.4 "Silver Stake" sync / 1[56]:[^:]*:The Idol Of Darkness:4C89:/
 658.8 "--untargetable--"
-658.9 "--sync--" sync / 1[56]:The Idol Of Darkness:4C31:/
+658.9 "--sync--" sync / 1[56]:[^:]*:The Idol Of Darkness:4C31:/
 
-668.5 "Crusade" sync / 1[56]:The Idol Of Darkness:4C58:/ window 700,10
+668.5 "Crusade" sync / 1[56]:[^:]*:The Idol Of Darkness:4C58:/ window 700,10
 673.5 "--targetable--"
-677.6 "Unjoined Aspect" sync / 1[56]:The Idol Of Darkness:4C7A:/
-683.7 "Words Of Fervor" sync / 1[56]:The Idol Of Darkness:4C7B:/
-716.9 "Threefold Grace" sync / 1[56]:The Idol Of Darkness:4C7E:/
-722.6 "Threefold Grace" sync / 1[56]:The Idol Of Darkness:4C7E:/
-728.3 "Threefold Grace" sync / 1[56]:The Idol Of Darkness:4C7E:/
-736.6 "Empty Wave" sync / 1[56]:The Idol Of Darkness:4CB0:/
-746.2 "Empty Wave" sync / 1[56]:The Idol Of Darkness:4CB0:/
+677.6 "Unjoined Aspect" sync / 1[56]:[^:]*:The Idol Of Darkness:4C7A:/
+683.7 "Words Of Fervor" sync / 1[56]:[^:]*:The Idol Of Darkness:4C7B:/
+716.9 "Threefold Grace" sync / 1[56]:[^:]*:The Idol Of Darkness:4C7E:/
+722.6 "Threefold Grace" sync / 1[56]:[^:]*:The Idol Of Darkness:4C7E:/
+728.3 "Threefold Grace" sync / 1[56]:[^:]*:The Idol Of Darkness:4C7E:/
+736.6 "Empty Wave" sync / 1[56]:[^:]*:The Idol Of Darkness:4CB0:/
+746.2 "Empty Wave" sync / 1[56]:[^:]*:The Idol Of Darkness:4CB0:/
 
-755.7 "Unjoined Aspect" sync / 1[56]:The Idol Of Darkness:4C7A:/
-761.9 "Words Of Fervor" sync / 1[56]:The Idol Of Darkness:4C7B:/
-795.1 "Threefold Grace" sync / 1[56]:The Idol Of Darkness:4C7E:/
-800.8 "Threefold Grace" sync / 1[56]:The Idol Of Darkness:4C7E:/
-806.5 "Threefold Grace" sync / 1[56]:The Idol Of Darkness:4C7E:/
-814.8 "Empty Wave" sync / 1[56]:The Idol Of Darkness:4CB0:/
-824.3 "Empty Wave" sync / 1[56]:The Idol Of Darkness:4CB0:/
+755.7 "Unjoined Aspect" sync / 1[56]:[^:]*:The Idol Of Darkness:4C7A:/
+761.9 "Words Of Fervor" sync / 1[56]:[^:]*:The Idol Of Darkness:4C7B:/
+795.1 "Threefold Grace" sync / 1[56]:[^:]*:The Idol Of Darkness:4C7E:/
+800.8 "Threefold Grace" sync / 1[56]:[^:]*:The Idol Of Darkness:4C7E:/
+806.5 "Threefold Grace" sync / 1[56]:[^:]*:The Idol Of Darkness:4C7E:/
+814.8 "Empty Wave" sync / 1[56]:[^:]*:The Idol Of Darkness:4CB0:/
+824.3 "Empty Wave" sync / 1[56]:[^:]*:The Idol Of Darkness:4CB0:/

--- a/ui/raidboss/data/05-shb/raid/e8n.txt
+++ b/ui/raidboss/data/05-shb/raid/e8n.txt
@@ -11,7 +11,8 @@ hideall "--sync--"
 # Opening block
 0.0 "--sync--" sync /:Engage!/ window 0,1
 1.4 "--sync--" sync / 1[56]:[^:]*:Shiva:4DD3:/ window 1.4,2
-15.1 "Absolute Zero" sync / 1[56]:[^:]*:Shiva:4DD7:/ window 15,5
+10.1 "--sync--" sync / 1[56]:[^:]*:Shiva:4DD7:/ window 15,5
+15.1 "Absolute Zero" sync / 1[56]:[^:]*:Shiva:4DD7:/
 27.2 "Redress" sync / 1[56]:[^:]*:Shiva:4F4F:/
 32.4 "Shining Armor" sync / 1[56]:[^:]*:Shiva:4DF1:/
 40.4 "Axe Kick/Scythe Kick" sync / 1[56]:[^:]*:Shiva:4DE[23]:/

--- a/ui/raidboss/data/05-shb/raid/e8n.txt
+++ b/ui/raidboss/data/05-shb/raid/e8n.txt
@@ -10,89 +10,89 @@ hideall "--sync--"
 
 # Opening block
 0.0 "--sync--" sync /:Engage!/ window 0,1
-1.4 "--sync--" sync / 1[56]:Shiva:4DD3:/ window 1.4,2
-15.1 "Absolute Zero" sync / 1[56]:Shiva:4DD7:/ window 15,5
-27.2 "Redress" sync / 1[56]:Shiva:4F4F:/
-32.4 "Shining Armor" sync / 1[56]:Shiva:4DF1:/
-40.4 "Axe Kick/Scythe Kick" sync / 1[56]:Shiva:4DE[23]:/
-52.5 "Redress" sync / 1[56]:Shiva:4F4E:/
-57.6 "Frost Armor" sync / 1[56]:Shiva:4DF0:/
-65.6 "Biting Frost/Driving Frost" sync / 1[56]:Shiva:4DD[BC]:/
-78.8 "Double Slap" sync / 1[56]:Shiva:4DDA:/
-92.0 "Diamond Frost" sync / 1[56]:Shiva:4DE1:/
-100.2 "Frigid Water/Frigid Stone" # sync / 1[56]:Shiva:4E(08|66):/
-103.1 "Icicle Impact" sync / 1[56]:Shiva:4E0A:/
-110.2 "Frigid Eruption" # sync / 1[56]:Shiva:4E09:/
-111.2 "Icicle Impact" sync / 1[56]:Shiva:4E0A:/
-112.3 "Frigid Eruption" # sync / 1[56]:Shiva:4E09:/
-114.3 "Frigid Eruption" # sync / 1[56]:Shiva:4E09:/
-120.1 "Heavenly Strike" sync / 1[56]:Shiva:4DD8:/
-131.2 "Mirror, Mirror" sync / 1[56]:Shiva:4DD4:/
-143.4 "Driving Frost/Biting Frost" sync / 1[56]:Shiva:4DD[BC]:/
-148.5 "Reflected Frost" sync / 1[56]:Frozen Mirror:4DF[EF]:/
-160.6 "Redress" sync / 1[56]:Shiva:4F4F:/
-165.7 "Shining Armor" sync / 1[56]:Shiva:4DF1:/
-173.7 "Axe Kick/Scythe Kick" sync / 1[56]:Shiva:4DE[23]:/
+1.4 "--sync--" sync / 1[56]:[^:]*:Shiva:4DD3:/ window 1.4,2
+15.1 "Absolute Zero" sync / 1[56]:[^:]*:Shiva:4DD7:/ window 15,5
+27.2 "Redress" sync / 1[56]:[^:]*:Shiva:4F4F:/
+32.4 "Shining Armor" sync / 1[56]:[^:]*:Shiva:4DF1:/
+40.4 "Axe Kick/Scythe Kick" sync / 1[56]:[^:]*:Shiva:4DE[23]:/
+52.5 "Redress" sync / 1[56]:[^:]*:Shiva:4F4E:/
+57.6 "Frost Armor" sync / 1[56]:[^:]*:Shiva:4DF0:/
+65.6 "Biting Frost/Driving Frost" sync / 1[56]:[^:]*:Shiva:4DD[BC]:/
+78.8 "Double Slap" sync / 1[56]:[^:]*:Shiva:4DDA:/
+92.0 "Diamond Frost" sync / 1[56]:[^:]*:Shiva:4DE1:/
+100.2 "Frigid Water/Frigid Stone" # sync / 1[56]:[^:]*:Shiva:4E(08|66):/
+103.1 "Icicle Impact" sync / 1[56]:[^:]*:Shiva:4E0A:/
+110.2 "Frigid Eruption" # sync / 1[56]:[^:]*:Shiva:4E09:/
+111.2 "Icicle Impact" sync / 1[56]:[^:]*:Shiva:4E0A:/
+112.3 "Frigid Eruption" # sync / 1[56]:[^:]*:Shiva:4E09:/
+114.3 "Frigid Eruption" # sync / 1[56]:[^:]*:Shiva:4E09:/
+120.1 "Heavenly Strike" sync / 1[56]:[^:]*:Shiva:4DD8:/
+131.2 "Mirror, Mirror" sync / 1[56]:[^:]*:Shiva:4DD4:/
+143.4 "Driving Frost/Biting Frost" sync / 1[56]:[^:]*:Shiva:4DD[BC]:/
+148.5 "Reflected Frost" sync / 1[56]:[^:]*:Frozen Mirror:4DF[EF]:/
+160.6 "Redress" sync / 1[56]:[^:]*:Shiva:4F4F:/
+165.7 "Shining Armor" sync / 1[56]:[^:]*:Shiva:4DF1:/
+173.7 "Axe Kick/Scythe Kick" sync / 1[56]:[^:]*:Shiva:4DE[23]:/
 181.9 "--Untargetable--"
-193.2 "Shattered World" sync / 1[56]:Shiva:4DE9:/
+193.2 "Shattered World" sync / 1[56]:[^:]*:Shiva:4DE9:/
 
 # Intermission. Fixed length.
-209.4 "Heart Asunder" sync / 1[56]:Mothercrystal:4E12:/
-218.1 "Stoneskin" # sync / 1[56]:Earthen Aether:4DEF:/
-223.5 "Heart Asunder" sync / 1[56]:Mothercrystal:4E12:/
-228.2 "Shock Spikes" sync / 1[56]:Electric Aether:4DEE:/
-233.2 "Rush" sync / 1[56]:Luminous Aether:4FC8:/
-237.5 "Heart Asunder" sync / 1[56]:Mothercrystal:4E12:/
-251.5 "Heart Asunder" sync / 1[56]:Mothercrystal:4E12:/
-256.2 "Shock Spikes" sync / 1[56]:Electric Aether:4DEE:/
-260.2 "Stoneskin" # sync / 1[56]:Earthen Aether:4DEF:/
-261.2 "Rush" sync / 1[56]:Luminous Aether:4FC8:/
+209.4 "Heart Asunder" sync / 1[56]:[^:]*:Mothercrystal:4E12:/
+218.1 "Stoneskin" # sync / 1[56]:[^:]*:Earthen Aether:4DEF:/
+223.5 "Heart Asunder" sync / 1[56]:[^:]*:Mothercrystal:4E12:/
+228.2 "Shock Spikes" sync / 1[56]:[^:]*:Electric Aether:4DEE:/
+233.2 "Rush" sync / 1[56]:[^:]*:Luminous Aether:4FC8:/
+237.5 "Heart Asunder" sync / 1[56]:[^:]*:Mothercrystal:4E12:/
+251.5 "Heart Asunder" sync / 1[56]:[^:]*:Mothercrystal:4E12:/
+256.2 "Shock Spikes" sync / 1[56]:[^:]*:Electric Aether:4DEE:/
+260.2 "Stoneskin" # sync / 1[56]:[^:]*:Earthen Aether:4DEF:/
+261.2 "Rush" sync / 1[56]:[^:]*:Luminous Aether:4FC8:/
 
 # Post-intermission block
-272.6 "Skyfall" sync / 1[56]:Shiva:4E13:/
+272.6 "Skyfall" sync / 1[56]:[^:]*:Shiva:4E13:/
 287.9 "--targetable--"
-306.9 "Holy" sync / 1[56]:Shiva:4DE[CD]:/
-321.4 "Light Rampant" sync / 1[56]:Shiva:4DE8:/
-329.6 "The Path of Light" sync / 1[56]:Shiva:4DD9:/
-332.6 "Bright Hunger" sync / 1[56]:Shiva:4E0C:/
-337.7 "The Path of Light" sync / 1[56]:Shiva:4DD9:/
-340.6 "Bright Hunger" sync / 1[56]:Shiva:4E0C:/
-345.9 "The Path of Light" sync / 1[56]:Shiva:4DD9:/
-348.6 "Bright Hunger" sync / 1[56]:Shiva:4E0C:/
-356.0 "Mirror, Mirror" sync / 1[56]:Shiva:4DD4:/
-368.1 "Kick/Frost" sync / 1[56]:Shiva:4D(D[BC]|E[23]):/
-373.2 "Reflected Kick/Frost" sync / 1[56]:Frozen Mirror:(4DF[EF]|4E0[01]):/
+306.9 "Holy" sync / 1[56]:[^:]*:Shiva:4DE[CD]:/
+321.4 "Light Rampant" sync / 1[56]:[^:]*:Shiva:4DE8:/
+329.6 "The Path of Light" sync / 1[56]:[^:]*:Shiva:4DD9:/
+332.6 "Bright Hunger" sync / 1[56]:[^:]*:Shiva:4E0C:/
+337.7 "The Path of Light" sync / 1[56]:[^:]*:Shiva:4DD9:/
+340.6 "Bright Hunger" sync / 1[56]:[^:]*:Shiva:4E0C:/
+345.9 "The Path of Light" sync / 1[56]:[^:]*:Shiva:4DD9:/
+348.6 "Bright Hunger" sync / 1[56]:[^:]*:Shiva:4E0C:/
+356.0 "Mirror, Mirror" sync / 1[56]:[^:]*:Shiva:4DD4:/
+368.1 "Kick/Frost" sync / 1[56]:[^:]*:Shiva:4D(D[BC]|E[23]):/
+373.2 "Reflected Kick/Frost" sync / 1[56]:[^:]*:Frozen Mirror:(4DF[EF]|4E0[01]):/
 
 # Rotation block
-385.3 "Redress" sync / 1[56]:Shiva:4F4E:/
-390.4 "Frost Armor" sync / 1[56]:Shiva:4DF0:/
-398.4 "Twin Stillness/Twin Silence" sync / 1[56]:Shiva:4DD[DE]:/
-413.7 "Double Slap" sync / 1[56]:Shiva:4DDA:/
-424.8 "Mirror, Mirror" sync / 1[56]:Shiva:4DD4:/
-437.0 "Kick/Frost" sync / 1[56]:Shiva:4D(D[BC]|E[23]):/
-442.1 "Reflected Kick/Frost" sync / 1[56]:Frozen Mirror:(4DF[EF]|4E0[01]):/
-455.2 "Absolute Zero" sync / 1[56]:Shiva:4DD7:/
-467.4 "Redress" sync / 1[56]:Shiva:4F4F:/
-472.6 "Shining Armor" sync / 1[56]:Shiva:4DF1:/
-480.6 "Embittered Dance/Spiteful Dance" sync / 1[56]:Shiva:4DE[4567]:/
-484.7 "Spiteful Dance/Embittered Dance" sync / 1[56]:Shiva:4DE[4567]:/
-500.8 "Holy" sync / 1[56]:Shiva:4DE[CD]:/
-513.9 "Absolute Zero" sync / 1[56]:Shiva:4DD7:/
+385.3 "Redress" sync / 1[56]:[^:]*:Shiva:4F4E:/
+390.4 "Frost Armor" sync / 1[56]:[^:]*:Shiva:4DF0:/
+398.4 "Twin Stillness/Twin Silence" sync / 1[56]:[^:]*:Shiva:4DD[DE]:/
+413.7 "Double Slap" sync / 1[56]:[^:]*:Shiva:4DDA:/
+424.8 "Mirror, Mirror" sync / 1[56]:[^:]*:Shiva:4DD4:/
+437.0 "Kick/Frost" sync / 1[56]:[^:]*:Shiva:4D(D[BC]|E[23]):/
+442.1 "Reflected Kick/Frost" sync / 1[56]:[^:]*:Frozen Mirror:(4DF[EF]|4E0[01]):/
+455.2 "Absolute Zero" sync / 1[56]:[^:]*:Shiva:4DD7:/
+467.4 "Redress" sync / 1[56]:[^:]*:Shiva:4F4F:/
+472.6 "Shining Armor" sync / 1[56]:[^:]*:Shiva:4DF1:/
+480.6 "Embittered Dance/Spiteful Dance" sync / 1[56]:[^:]*:Shiva:4DE[4567]:/
+484.7 "Spiteful Dance/Embittered Dance" sync / 1[56]:[^:]*:Shiva:4DE[4567]:/
+500.8 "Holy" sync / 1[56]:[^:]*:Shiva:4DE[CD]:/
+513.9 "Absolute Zero" sync / 1[56]:[^:]*:Shiva:4DD7:/
 
-526.1 "Redress" sync / 1[56]:Shiva:4F4E:/
-531.2 "Frost Armor" sync / 1[56]:Shiva:4DF0:/
-539.2 "Twin Stillness/Twin Silence" sync / 1[56]:Shiva:4DD[DE]:/
-554.5 "Double Slap" sync / 1[56]:Shiva:4DDA:/
-565.6 "Mirror, Mirror" sync / 1[56]:Shiva:4DD4:/
-577.8 "Kick/Frost" sync / 1[56]:Shiva:4D(D[BC]|E[23]):/
-582.9 "Reflected Kick/Frost" sync / 1[56]:Frozen Mirror:(4DF[EF]|4E0[01]):/
-596.0 "Absolute Zero" sync / 1[56]:Shiva:4DD7:/
-608.2 "Redress" sync / 1[56]:Shiva:4F4F:/
-613.4 "Shining Armor" sync / 1[56]:Shiva:4DF1:/
-621.4 "Embittered Dance/Spiteful Dance" sync / 1[56]:Shiva:4DE[4567]:/
-625.5 "Spiteful Dance/Embittered Dance" sync / 1[56]:Shiva:4DE[4567]:/
-641.6 "Holy" sync / 1[56]:Shiva:4DE[CD]:/
-654.7 "Absolute Zero" sync / 1[56]:Shiva:4DD7:/ jump 513.9
+526.1 "Redress" sync / 1[56]:[^:]*:Shiva:4F4E:/
+531.2 "Frost Armor" sync / 1[56]:[^:]*:Shiva:4DF0:/
+539.2 "Twin Stillness/Twin Silence" sync / 1[56]:[^:]*:Shiva:4DD[DE]:/
+554.5 "Double Slap" sync / 1[56]:[^:]*:Shiva:4DDA:/
+565.6 "Mirror, Mirror" sync / 1[56]:[^:]*:Shiva:4DD4:/
+577.8 "Kick/Frost" sync / 1[56]:[^:]*:Shiva:4D(D[BC]|E[23]):/
+582.9 "Reflected Kick/Frost" sync / 1[56]:[^:]*:Frozen Mirror:(4DF[EF]|4E0[01]):/
+596.0 "Absolute Zero" sync / 1[56]:[^:]*:Shiva:4DD7:/
+608.2 "Redress" sync / 1[56]:[^:]*:Shiva:4F4F:/
+613.4 "Shining Armor" sync / 1[56]:[^:]*:Shiva:4DF1:/
+621.4 "Embittered Dance/Spiteful Dance" sync / 1[56]:[^:]*:Shiva:4DE[4567]:/
+625.5 "Spiteful Dance/Embittered Dance" sync / 1[56]:[^:]*:Shiva:4DE[4567]:/
+641.6 "Holy" sync / 1[56]:[^:]*:Shiva:4DE[CD]:/
+654.7 "Absolute Zero" sync / 1[56]:[^:]*:Shiva:4DD7:/ jump 513.9
 
 666.9 "Redress"
 672.0 "Frost Armor"
@@ -102,5 +102,5 @@ hideall "--sync--"
 
 # There's an Absolute Zero spam sequence before this, but
 # it's indistinguishable from the standard usage.
-1000.0 "--sync--" sync / 1[56]:Shiva:4E29:/ window 1000,0
+1000.0 "--sync--" sync / 1[56]:[^:]*:Shiva:4E29:/ window 1000,0
 1066.2 "--targetable--"

--- a/ui/raidboss/data/05-shb/raid/e8s.txt
+++ b/ui/raidboss/data/05-shb/raid/e8s.txt
@@ -8,150 +8,150 @@ hideall "--sync--"
 0.0 "--Reset--" sync / 21:........:40000010:/ window 100000 jump 0
 
 0.0 "--sync--" sync /:Engage!/ window 0,1
-1.5 "--sync--" sync / 1[56]:Shiva:4D59:/ window 2,0
-16.0 "Absolute Zero" sync / 1[56]:Shiva:4DCC:/ window 17,20
-27.2 "Mirror, Mirror" sync / 1[56]:Shiva:4D5A:/
-39.3 "Biting/Driving Frost" sync / 1[56]:Shiva:4D6[67]:/
-44.4 "Reflected Frost (G)" sync / 1[56]:Frozen Mirror:4DB[78]:/
-49.4 "Reflected Frost (R)" sync / 1[56]:Frozen Mirror:4DC[34]:/
+1.5 "--sync--" sync / 1[56]:[^:]*:Shiva:4D59:/ window 2,0
+16.0 "Absolute Zero" sync / 1[56]:[^:]*:Shiva:4DCC:/ window 17,20
+27.2 "Mirror, Mirror" sync / 1[56]:[^:]*:Shiva:4D5A:/
+39.3 "Biting/Driving Frost" sync / 1[56]:[^:]*:Shiva:4D6[67]:/
+44.4 "Reflected Frost (G)" sync / 1[56]:[^:]*:Frozen Mirror:4DB[78]:/
+49.4 "Reflected Frost (R)" sync / 1[56]:[^:]*:Frozen Mirror:4DC[34]:/
 
 ### Diamond Frost
-57.5 "--middle--" sync / 1[56]:Shiva:4D58:/
-63.7 "Diamond Frost" sync / 1[56]:Shiva:4D6C:/
-71.9 "Frigid Stone" sync / 1[56]:Shiva:4D9B:/
-74.9 "Icicle Impact" sync / 1[56]:Shiva:4DA0:/
-76.9 "Heavenly Strike" sync / 1[56]:Shiva:4D61:/
-78.9 "Icicle Impact" sync / 1[56]:Shiva:4DA0:/
-80.9 "Frigid Needle" sync / 1[56]:Shiva:4D9D:/
-80.9 "Frigid Water" sync / 1[56]:Shiva:4D9E:/
-82.9 "Icicle Impact" sync / 1[56]:Shiva:4DA0:/
-83.9 "Frigid Eruption 1" #sync / 1[56]:Shiva:4D9F:/
-85.9 "Frigid Eruption 2" #sync / 1[56]:Shiva:4D9F:/
-87.9 "Frigid Eruption 3" #sync / 1[56]:Shiva:4D9F:/
-92.9 "Driving/Biting Frost" sync / 1[56]:Shiva:4D6[67]:/
-101.7 "Double Slap" sync / 1[56]:Shiva:4D65:/
-115.0 "Shining Armor" sync / 1[56]:Shiva:4DD1:/
-123.0 "Axe/Scythe Kick" sync / 1[56]:Shiva:4D6[DE]:/
+57.5 "--middle--" sync / 1[56]:[^:]*:Shiva:4D58:/
+63.7 "Diamond Frost" sync / 1[56]:[^:]*:Shiva:4D6C:/
+71.9 "Frigid Stone" sync / 1[56]:[^:]*:Shiva:4D9B:/
+74.9 "Icicle Impact" sync / 1[56]:[^:]*:Shiva:4DA0:/
+76.9 "Heavenly Strike" sync / 1[56]:[^:]*:Shiva:4D61:/
+78.9 "Icicle Impact" sync / 1[56]:[^:]*:Shiva:4DA0:/
+80.9 "Frigid Needle" sync / 1[56]:[^:]*:Shiva:4D9D:/
+80.9 "Frigid Water" sync / 1[56]:[^:]*:Shiva:4D9E:/
+82.9 "Icicle Impact" sync / 1[56]:[^:]*:Shiva:4DA0:/
+83.9 "Frigid Eruption 1" #sync / 1[56]:[^:]*:Shiva:4D9F:/
+85.9 "Frigid Eruption 2" #sync / 1[56]:[^:]*:Shiva:4D9F:/
+87.9 "Frigid Eruption 3" #sync / 1[56]:[^:]*:Shiva:4D9F:/
+92.9 "Driving/Biting Frost" sync / 1[56]:[^:]*:Shiva:4D6[67]:/
+101.7 "Double Slap" sync / 1[56]:[^:]*:Shiva:4D65:/
+115.0 "Shining Armor" sync / 1[56]:[^:]*:Shiva:4DD1:/
+123.0 "Axe/Scythe Kick" sync / 1[56]:[^:]*:Shiva:4D6[DE]:/
 
 ### Light Rampant
-131.2 "--middle--" sync / 1[56]:Shiva:4D58:/
-137.4 "Light Rampant" sync / 1[56]:Shiva:4D73:/ window 150,10
-148.6 "Bright Hunger" sync / 1[56]:Shiva:4DA2:/
-148.6 "The Path Of Light" sync / 1[56]:Shiva:4D63:/
-156.6 "Bright Hunger" sync / 1[56]:Shiva:4DA2:/
-159.8 "The Path Of Light" sync / 1[56]:Shiva:4D63:/
-164.7 "Bright Hunger" sync / 1[56]:Shiva:4DA2:/
-173.0 "Mirror, Mirror" sync / 1[56]:Shiva:4D5A:/
-185.2 "Scythe/Axe Kick" sync / 1[56]:Shiva:4D6[DE]:/
-190.2 "Reflected Kick (G)" sync / 1[56]:Frozen Mirror:4DB[9A]:/
-193.3 "Banish III" sync / 1[56]:Shiva:4D8[01]:/
+131.2 "--middle--" sync / 1[56]:[^:]*:Shiva:4D58:/
+137.4 "Light Rampant" sync / 1[56]:[^:]*:Shiva:4D73:/ window 150,10
+148.6 "Bright Hunger" sync / 1[56]:[^:]*:Shiva:4DA2:/
+148.6 "The Path Of Light" sync / 1[56]:[^:]*:Shiva:4D63:/
+156.6 "Bright Hunger" sync / 1[56]:[^:]*:Shiva:4DA2:/
+159.8 "The Path Of Light" sync / 1[56]:[^:]*:Shiva:4D63:/
+164.7 "Bright Hunger" sync / 1[56]:[^:]*:Shiva:4DA2:/
+173.0 "Mirror, Mirror" sync / 1[56]:[^:]*:Shiva:4D5A:/
+185.2 "Scythe/Axe Kick" sync / 1[56]:[^:]*:Shiva:4D6[DE]:/
+190.2 "Reflected Kick (G)" sync / 1[56]:[^:]*:Frozen Mirror:4DB[9A]:/
+193.3 "Banish III" sync / 1[56]:[^:]*:Shiva:4D8[01]:/
 
 ### Adds Phase
 201.5 "--untargetable--"
-201.7 "--sync--" sync / 1[56]:Shiva:4D58:/
-213.0 "Shattered World" sync / 1[56]:Shiva:4D74:/ window 220,20
-229.2 "Heart Asunder" sync / 1[56]:Mothercrystal:4DAC:/
-238.9 "Rush 1" sync / 1[56]:Luminous Aether:4D86:/
-243.3 "Heart Asunder" sync / 1[56]:Mothercrystal:4DAC:/
-253.0 "Rush 2" sync / 1[56]:Luminous Aether:4D86:/
-257.4 "Heart Asunder" sync / 1[56]:Mothercrystal:4DAC:/
-267.1 "Rush 3" sync / 1[56]:Luminous Aether:4D86:/
-271.5 "Heart Asunder" sync / 1[56]:Mothercrystal:4DAC:/
-281.2 "Rush 4" sync / 1[56]:Luminous Aether:4D86:/
-292.6 "Skyfall" sync / 1[56]:Shiva:4DAD:/ window 100,100
+201.7 "--sync--" sync / 1[56]:[^:]*:Shiva:4D58:/
+213.0 "Shattered World" sync / 1[56]:[^:]*:Shiva:4D74:/ window 220,20
+229.2 "Heart Asunder" sync / 1[56]:[^:]*:Mothercrystal:4DAC:/
+238.9 "Rush 1" sync / 1[56]:[^:]*:Luminous Aether:4D86:/
+243.3 "Heart Asunder" sync / 1[56]:[^:]*:Mothercrystal:4DAC:/
+253.0 "Rush 2" sync / 1[56]:[^:]*:Luminous Aether:4D86:/
+257.4 "Heart Asunder" sync / 1[56]:[^:]*:Mothercrystal:4DAC:/
+267.1 "Rush 3" sync / 1[56]:[^:]*:Luminous Aether:4D86:/
+271.5 "Heart Asunder" sync / 1[56]:[^:]*:Mothercrystal:4DAC:/
+281.2 "Rush 4" sync / 1[56]:[^:]*:Luminous Aether:4D86:/
+292.6 "Skyfall" sync / 1[56]:[^:]*:Shiva:4DAD:/ window 100,100
 
 ### Dragon Fanfic
 # :eyes:
 
 ### Wing Mirrors
 350.5 "--targetable--"
-364.2 "--sync--" sync / 14:Shiva:4D79:/ window 370,10
-368.6 "Akh Morn x3" sync / 1[56]:Shiva:4D79:/ duration 3.1
-378.0 "Morn Afah" sync / 1[56]:Shiva:4D7B:/
-389.4 "Mirror, Mirror" sync / 1[56]:Shiva:4D5A:/
-396.9 "--sync--" sync / 1[56]:Shiva:4D58:/
-403.2 "Hallowed Wings" sync / 1[56]:Shiva:4D7[56]:/
-403.2 "Reflected Wings (B)" sync / 1[56]:Frozen Mirror:4D9[01]:/
-408.2 "Reflected Wings (G)" sync / 1[56]:Frozen Mirror:4DB[BC]:/
-413.2 "Hallowed Wings" sync / 1[56]:Shiva:4D7[56]:/
-413.2 "Reflected Wings (R)" sync / 1[56]:Frozen Mirror:4DC[78]:/
+364.2 "--sync--" sync / 14:[^:]*:Shiva:4D79:/ window 370,10
+368.6 "Akh Morn x3" sync / 1[56]:[^:]*:Shiva:4D79:/ duration 3.1
+378.0 "Morn Afah" sync / 1[56]:[^:]*:Shiva:4D7B:/
+389.4 "Mirror, Mirror" sync / 1[56]:[^:]*:Shiva:4D5A:/
+396.9 "--sync--" sync / 1[56]:[^:]*:Shiva:4D58:/
+403.2 "Hallowed Wings" sync / 1[56]:[^:]*:Shiva:4D7[56]:/
+403.2 "Reflected Wings (B)" sync / 1[56]:[^:]*:Frozen Mirror:4D9[01]:/
+408.2 "Reflected Wings (G)" sync / 1[56]:[^:]*:Frozen Mirror:4DB[BC]:/
+413.2 "Hallowed Wings" sync / 1[56]:[^:]*:Shiva:4D7[56]:/
+413.2 "Reflected Wings (R)" sync / 1[56]:[^:]*:Frozen Mirror:4DC[78]:/
 
 ### Wyrm's Lament
-421.7 "--middle--" sync / 1[56]:Shiva:4D58:/
-427.9 "Wyrm's Lament" sync / 1[56]:Shiva:4D7C:/
-441.0 "Hallowed Wings" sync / 1[56]:Shiva:4D7[56]:/
-449.1 "Hallowed Wings" sync / 1[56]:Shiva:4D7[56]:/
-457.2 "Hallowed Wings" sync / 1[56]:Shiva:4D7[56]:/
-465.3 "Hallowed Wings" sync / 1[56]:Shiva:4D7[56]:/
-473.5 "Frost Armor" sync / 1[56]:Shiva:4DD0:/
-481.4 "Twin Silence/Stillness" sync / 1[56]:Shiva:4D6[89]:/
-483.5 "Twin Stillness/Silence" sync / 1[56]:Shiva:4D6[AB]:/
-491.6 "Double Slap" sync / 1[56]:Shiva:4D65:/
-504.8 "Drachen Armor" sync / 1[56]:Shiva:4DD2:/
-507.3 "Akh Rhai" sync / 1[56]:Shiva:4D99:/
+421.7 "--middle--" sync / 1[56]:[^:]*:Shiva:4D58:/
+427.9 "Wyrm's Lament" sync / 1[56]:[^:]*:Shiva:4D7C:/
+441.0 "Hallowed Wings" sync / 1[56]:[^:]*:Shiva:4D7[56]:/
+449.1 "Hallowed Wings" sync / 1[56]:[^:]*:Shiva:4D7[56]:/
+457.2 "Hallowed Wings" sync / 1[56]:[^:]*:Shiva:4D7[56]:/
+465.3 "Hallowed Wings" sync / 1[56]:[^:]*:Shiva:4D7[56]:/
+473.5 "Frost Armor" sync / 1[56]:[^:]*:Shiva:4DD0:/
+481.4 "Twin Silence/Stillness" sync / 1[56]:[^:]*:Shiva:4D6[89]:/
+483.5 "Twin Stillness/Silence" sync / 1[56]:[^:]*:Shiva:4D6[AB]:/
+491.6 "Double Slap" sync / 1[56]:[^:]*:Shiva:4D65:/
+504.8 "Drachen Armor" sync / 1[56]:[^:]*:Shiva:4DD2:/
+507.3 "Akh Rhai" sync / 1[56]:[^:]*:Shiva:4D99:/
 
 ### Stack Mirrors
-516.1 "Mirror, Mirror" sync / 1[56]:Shiva:4D5A:/
-523.6 "--teleport--" sync / 1[56]:Shiva:4D58:/
-530.0 "Hallowed Wings" sync / 1[56]:Shiva:4D77:/
-535.1 "Reflected Wings (G)" sync / 1[56]:Frozen Mirror:4DBD:/
-540.1 "Reflected Wings (R)" sync / 1[56]:Frozen Mirror:4DC9:/
+516.1 "Mirror, Mirror" sync / 1[56]:[^:]*:Shiva:4D5A:/
+523.6 "--teleport--" sync / 1[56]:[^:]*:Shiva:4D58:/
+530.0 "Hallowed Wings" sync / 1[56]:[^:]*:Shiva:4D77:/
+535.1 "Reflected Wings (G)" sync / 1[56]:[^:]*:Frozen Mirror:4DBD:/
+540.1 "Reflected Wings (R)" sync / 1[56]:[^:]*:Frozen Mirror:4DC9:/
 
 ### Lookaway Mirrors
-554.1 "Mirror, Mirror" sync / 1[56]:Shiva:4D5A:/
-566.6 "Shining Armor" sync / 1[56]:Shiva:4DD1:/
-566.6 "Reflected Armor (B)" sync / 1[56]:Frozen Mirror:4D8A:/
-571.7 "Reflected Armor (G)" sync / 1[56]:Frozen Mirror:4DB5:/
-576.7 "Reflected Armor (R)" sync / 1[56]:Frozen Mirror:4DC1:/
-577.6 "Holy" sync / 1[56]:Shiva:4D8[23]:/
-585.7 "Embittered/Spiteful Dance" sync / 1[56]:Shiva:4D(6F|70):/
-589.8 "Spiteful/Embittered Dance" sync / 1[56]:Shiva:4D7[12]:/
+554.1 "Mirror, Mirror" sync / 1[56]:[^:]*:Shiva:4D5A:/
+566.6 "Shining Armor" sync / 1[56]:[^:]*:Shiva:4DD1:/
+566.6 "Reflected Armor (B)" sync / 1[56]:[^:]*:Frozen Mirror:4D8A:/
+571.7 "Reflected Armor (G)" sync / 1[56]:[^:]*:Frozen Mirror:4DB5:/
+576.7 "Reflected Armor (R)" sync / 1[56]:[^:]*:Frozen Mirror:4DC1:/
+577.6 "Holy" sync / 1[56]:[^:]*:Shiva:4D8[23]:/
+585.7 "Embittered/Spiteful Dance" sync / 1[56]:[^:]*:Shiva:4D(6F|70):/
+589.8 "Spiteful/Embittered Dance" sync / 1[56]:[^:]*:Shiva:4D7[12]:/
 
 ### Akh Rhai Mirrors
-600.9 "Mirror, Mirror" sync / 1[56]:Shiva:4D5A:/
-608.1 "Drachen Armor" sync / 1[56]:Shiva:4DD2:/
-610.6 "Akh Rhai" sync / 1[56]:Shiva:4D99:/
-618.2 "Reflected Drachen" sync / 1[56]:Frozen Mirror:4DC2:/
-620.4 "Akh Morn x4" sync / 1[56]:Shiva:4D79:/ duration 4.2
-620.7 "Akh Rhai" sync / 1[56]:Shiva:4D99:/
-630.8 "Morn Afah" sync / 1[56]:Shiva:4D7B:/
+600.9 "Mirror, Mirror" sync / 1[56]:[^:]*:Shiva:4D5A:/
+608.1 "Drachen Armor" sync / 1[56]:[^:]*:Shiva:4DD2:/
+610.6 "Akh Rhai" sync / 1[56]:[^:]*:Shiva:4D99:/
+618.2 "Reflected Drachen" sync / 1[56]:[^:]*:Frozen Mirror:4DC2:/
+620.4 "Akh Morn x4" sync / 1[56]:[^:]*:Shiva:4D79:/ duration 4.2
+620.7 "Akh Rhai" sync / 1[56]:[^:]*:Shiva:4D99:/
+630.8 "Morn Afah" sync / 1[56]:[^:]*:Shiva:4D7B:/
 
 ### Icelit Dragonsong
-648.8 "--middle--" sync / 1[56]:Shiva:4D58:/
-655.4 "Icelit Dragonsong" sync / 1[56]:Shiva:4D7D:/
-663.6 "Frigid Stone" sync / 1[56]:Shiva:4D9B:/
-666.6 "Bright Hunger" sync / 1[56]:Shiva:4DA2:/
-668.6 "Draconic Strike" sync / 1[56]:Shiva:4D62:/
+648.8 "--middle--" sync / 1[56]:[^:]*:Shiva:4D58:/
+655.4 "Icelit Dragonsong" sync / 1[56]:[^:]*:Shiva:4D7D:/
+663.6 "Frigid Stone" sync / 1[56]:[^:]*:Shiva:4D9B:/
+666.6 "Bright Hunger" sync / 1[56]:[^:]*:Shiva:4DA2:/
+668.6 "Draconic Strike" sync / 1[56]:[^:]*:Shiva:4D62:/
 669.3 "--knockback--"
-672.7 "Frigid Needle" sync / 1[56]:Shiva:4D9D:/
-674.7 "Bright Hunger" sync / 1[56]:Shiva:4DA2:/
-676.7 "Frigid Eruption 1" #sync / 1[56]:Shiva:4D9F:/
-676.8 "Banish" sync / 1[56]:Shiva:4D7[EF]:/
-678.7 "Frigid Eruption 2" #sync / 1[56]:Shiva:4D9F:/
-680.8 "Frigid Eruption 3" #sync / 1[56]:Shiva:4D9F:/
-682.7 "Inescapable Illumination" sync / 1[56]:Shiva:4DA3:/
-688.0 "The House Of Light" sync / 1[56]:Shiva:4D64:/
-688.9 "The Path Of Light" sync / 1[56]:Shiva:4DA1:/
+672.7 "Frigid Needle" sync / 1[56]:[^:]*:Shiva:4D9D:/
+674.7 "Bright Hunger" sync / 1[56]:[^:]*:Shiva:4DA2:/
+676.7 "Frigid Eruption 1" #sync / 1[56]:[^:]*:Shiva:4D9F:/
+676.8 "Banish" sync / 1[56]:[^:]*:Shiva:4D7[EF]:/
+678.7 "Frigid Eruption 2" #sync / 1[56]:[^:]*:Shiva:4D9F:/
+680.8 "Frigid Eruption 3" #sync / 1[56]:[^:]*:Shiva:4D9F:/
+682.7 "Inescapable Illumination" sync / 1[56]:[^:]*:Shiva:4DA3:/
+688.0 "The House Of Light" sync / 1[56]:[^:]*:Shiva:4D64:/
+688.9 "The Path Of Light" sync / 1[56]:[^:]*:Shiva:4DA1:/
 
 ### Ice Mirror
-699.6 "Mirror, Mirror" sync / 1[56]:Shiva:4D5A:/
-709.9 "Frost Armor" sync / 1[56]:Shiva:4DD0:/
-719.9 "Reflected Frost Armor (R)" sync / 1[56]:Frozen Mirror:4DC0:/
-720.4 "Drachen Armor" sync / 1[56]:Shiva:4DD2:/
-722.9 "Akh Rhai" sync / 1[56]:Shiva:4D99:/
+699.6 "Mirror, Mirror" sync / 1[56]:[^:]*:Shiva:4D5A:/
+709.9 "Frost Armor" sync / 1[56]:[^:]*:Shiva:4DD0:/
+719.9 "Reflected Frost Armor (R)" sync / 1[56]:[^:]*:Frozen Mirror:4DC0:/
+720.4 "Drachen Armor" sync / 1[56]:[^:]*:Shiva:4DD2:/
+722.9 "Akh Rhai" sync / 1[56]:[^:]*:Shiva:4D99:/
 
 ### Wyrm's Lament Take 2
-732.1 "--middle--" sync / 1[56]:Shiva:4D58:/
-738.3 "Wyrm's Lament" sync / 1[56]:Shiva:4D7C:/
-745.5 "Akh Morn x5" sync / 1[56]:Shiva:4D79:/ duration 5.3
-757.1 "Morn Afah" sync / 1[56]:Shiva:4D7B:/
-764.3 "Akh Morn x6" sync / 1[56]:Shiva:4D79:/ duration 6.4
-777.0 "Morn Afah" sync / 1[56]:Shiva:4D7B:/
-784.3 "Akh Morn x7" sync / 1[56]:Shiva:4D79:/ duration 7.5
-798.1 "Morn Afah" sync / 1[56]:Shiva:4D7B:/
+732.1 "--middle--" sync / 1[56]:[^:]*:Shiva:4D58:/
+738.3 "Wyrm's Lament" sync / 1[56]:[^:]*:Shiva:4D7C:/
+745.5 "Akh Morn x5" sync / 1[56]:[^:]*:Shiva:4D79:/ duration 5.3
+757.1 "Morn Afah" sync / 1[56]:[^:]*:Shiva:4D7B:/
+764.3 "Akh Morn x6" sync / 1[56]:[^:]*:Shiva:4D79:/ duration 6.4
+777.0 "Morn Afah" sync / 1[56]:[^:]*:Shiva:4D7B:/
+784.3 "Akh Morn x7" sync / 1[56]:[^:]*:Shiva:4D79:/ duration 7.5
+798.1 "Morn Afah" sync / 1[56]:[^:]*:Shiva:4D7B:/
 
 ### Enrage Mirrors
-817.1 "Mirror, Mirror" sync / 1[56]:Shiva:4D5A:/
-819.2 "--teleport--" sync / 1[56]:Shiva:4D58:/
-830.6 "Hallowed Wings" sync / 1[56]:Shiva:4D78:/
-840.8 "Enrage" sync / 1[56]:Frozen Mirror:4DC[AB]:/
+817.1 "Mirror, Mirror" sync / 1[56]:[^:]*:Shiva:4D5A:/
+819.2 "--teleport--" sync / 1[56]:[^:]*:Shiva:4D58:/
+830.6 "Hallowed Wings" sync / 1[56]:[^:]*:Shiva:4D78:/
+840.8 "Enrage" sync / 1[56]:[^:]*:Frozen Mirror:4DC[AB]:/

--- a/ui/raidboss/data/05-shb/raid/e9n.txt
+++ b/ui/raidboss/data/05-shb/raid/e9n.txt
@@ -11,57 +11,57 @@ hideall "--sync--"
 0.0 "--sync--" sync /:Engage!/ window 0,1
 # Unfortunately we can't sync to a first attack here,
 # as Cloud of Darkness uses an auto at random before starting her 3-second rotation.
-# 0.1 "--sync--" sync / 1[56]:Cloud Of Darkness:5626:/ window 0.1,1
-10.4 "--sync--" sync / 14:Cloud Of Darkness:55ED:/ window 10.4,5
-15.1 "Ground-Razing Particle Beam" sync / 1[56]:Cloud Of Darkness:55ED:/
-25.3 "The Art Of Darkness" sync / 1[56]:Cloud Of Darkness:522[34]:/
-34.8 "Wide-Angle Particle Beam" sync / 1[56]:Cloud Of Darkness:5AFF:/
-45.2 "Zero-Form Particle Beam" sync / 1[56]:Cloud Of Darkness:55EB:/
-56.7 "Empty Plane" sync / 1[56]:Cloud Of Darkness:4FC6:/ window 56.7,10
-70.9 "Flood Of Emptiness" sync / 1[56]:Cloud Of Darkness:5132:/
-71.3 "Mire Of Despair" sync / 1[56]:Cloud Of Darkness:5B07:/
-71.3 "Earth-Shattering Particle Beam" sync / 1[56]:Cloud Of Darkness:5225:/
-88.0 "Ground-Razing Particle Beam" sync / 1[56]:Cloud Of Darkness:55ED:/
-99.2 "The Art Of Darkness" sync / 1[56]:Cloud Of Darkness:522[34]:/
+# 0.1 "--sync--" sync / 1[56]:[^:]*:Cloud Of Darkness:5626:/ window 0.1,1
+10.4 "--sync--" sync / 14:[^:]*:Cloud Of Darkness:55ED:/ window 10.4,5
+15.1 "Ground-Razing Particle Beam" sync / 1[56]:[^:]*:Cloud Of Darkness:55ED:/
+25.3 "The Art Of Darkness" sync / 1[56]:[^:]*:Cloud Of Darkness:522[34]:/
+34.8 "Wide-Angle Particle Beam" sync / 1[56]:[^:]*:Cloud Of Darkness:5AFF:/
+45.2 "Zero-Form Particle Beam" sync / 1[56]:[^:]*:Cloud Of Darkness:55EB:/
+56.7 "Empty Plane" sync / 1[56]:[^:]*:Cloud Of Darkness:4FC6:/ window 56.7,10
+70.9 "Flood Of Emptiness" sync / 1[56]:[^:]*:Cloud Of Darkness:5132:/
+71.3 "Mire Of Despair" sync / 1[56]:[^:]*:Cloud Of Darkness:5B07:/
+71.3 "Earth-Shattering Particle Beam" sync / 1[56]:[^:]*:Cloud Of Darkness:5225:/
+88.0 "Ground-Razing Particle Beam" sync / 1[56]:[^:]*:Cloud Of Darkness:55ED:/
+99.2 "The Art Of Darkness" sync / 1[56]:[^:]*:Cloud Of Darkness:522[34]:/
 
-111.5 "Obscure Woods" sync / 1[56]:Cloud Of Darkness:4FA2:/ window 111.5,10
-124.7 "Flood Of Obscurity" sync / 1[56]:Cloud Of Darkness:58F1:/
-124.9 "Waste Away" sync / 1[56]:Cloud Of Darkness:55DE:/
-127.2 "Evil Seed" sync / 1[56]:Cloud Of Darkness:55E7:/
-145.3 "The Art Of Darkness" sync / 1[56]:Cloud Of Darkness:522[34]:/
-157.3 "Wide-Angle Phaser" sync / 1[56]:Cloud Of Darkness:55E0:/
-171.1 "Rejuvenating Balm" sync / 1[56]:Cloud Of Darkness:55E2:/
-181.3 "Bad Vibrations" sync / 1[56]:Stygian Arbor:55E6:/ window 30,30
-192.3 "Deluge Of Darkness" sync / 1[56]:Cloud Of Darkness:5155:/
-205.7 "Zero-Form Particle Beam" sync / 1[56]:Cloud Of Darkness:55EB:/
-211.9 "Particle Concentration" sync / 1[56]:Cloud Of Darkness:55E8:/
-222.9 "Particle Beam" sync / 1[56]:Cloud Of Darkness:55E9:/
-226.6 "The Art Of Darkness" sync / 1[56]:Cloud Of Darkness:522[34]:/
+111.5 "Obscure Woods" sync / 1[56]:[^:]*:Cloud Of Darkness:4FA2:/ window 111.5,10
+124.7 "Flood Of Obscurity" sync / 1[56]:[^:]*:Cloud Of Darkness:58F1:/
+124.9 "Waste Away" sync / 1[56]:[^:]*:Cloud Of Darkness:55DE:/
+127.2 "Evil Seed" sync / 1[56]:[^:]*:Cloud Of Darkness:55E7:/
+145.3 "The Art Of Darkness" sync / 1[56]:[^:]*:Cloud Of Darkness:522[34]:/
+157.3 "Wide-Angle Phaser" sync / 1[56]:[^:]*:Cloud Of Darkness:55E0:/
+171.1 "Rejuvenating Balm" sync / 1[56]:[^:]*:Cloud Of Darkness:55E2:/
+181.3 "Bad Vibrations" sync / 1[56]:[^:]*:Stygian Arbor:55E6:/ window 30,30
+192.3 "Deluge Of Darkness" sync / 1[56]:[^:]*:Cloud Of Darkness:5155:/
+205.7 "Zero-Form Particle Beam" sync / 1[56]:[^:]*:Cloud Of Darkness:55EB:/
+211.9 "Particle Concentration" sync / 1[56]:[^:]*:Cloud Of Darkness:55E8:/
+222.9 "Particle Beam" sync / 1[56]:[^:]*:Cloud Of Darkness:55E9:/
+226.6 "The Art Of Darkness" sync / 1[56]:[^:]*:Cloud Of Darkness:522[34]:/
 
-239.2 "Empty Plane" sync / 1[56]:Cloud Of Darkness:4FC6:/ window 30,30
-253.4 "Flood Of Emptiness" sync / 1[56]:Cloud Of Darkness:5132:/
-253.8 "Mire Of Despair" sync / 1[56]:Cloud Of Darkness:5B07:/
-253.8 "Earth-Shattering Particle Beam" sync / 1[56]:Cloud Of Darkness:5225:/
-259.5 "Hypercharged Condensation" sync / 1[56]:Cloud Of Darkness:532E:/
-281.7 "Summon" sync / 1[56]:Cloud Of Darkness:5330:/ window 30,30
-289.8 "Anti-Air Particle Beam" sync / 1[56]:Cloud Of Darkness:55DC:/
-301.0 "The Art Of Darkness" sync / 1[56]:Cloud Of Darkness:522[34]:/
-313.2 "Ground-Razing Particle Beam" sync / 1[56]:Cloud Of Darkness:55ED:/
+239.2 "Empty Plane" sync / 1[56]:[^:]*:Cloud Of Darkness:4FC6:/ window 30,30
+253.4 "Flood Of Emptiness" sync / 1[56]:[^:]*:Cloud Of Darkness:5132:/
+253.8 "Mire Of Despair" sync / 1[56]:[^:]*:Cloud Of Darkness:5B07:/
+253.8 "Earth-Shattering Particle Beam" sync / 1[56]:[^:]*:Cloud Of Darkness:5225:/
+259.5 "Hypercharged Condensation" sync / 1[56]:[^:]*:Cloud Of Darkness:532E:/
+281.7 "Summon" sync / 1[56]:[^:]*:Cloud Of Darkness:5330:/ window 30,30
+289.8 "Anti-Air Particle Beam" sync / 1[56]:[^:]*:Cloud Of Darkness:55DC:/
+301.0 "The Art Of Darkness" sync / 1[56]:[^:]*:Cloud Of Darkness:522[34]:/
+313.2 "Ground-Razing Particle Beam" sync / 1[56]:[^:]*:Cloud Of Darkness:55ED:/
 
-327.7 "Obscure Woods" sync / 1[56]:Cloud Of Darkness:4FA2:/ window 30,30
-339.9 "Flood Of Obscurity" sync / 1[56]:Cloud Of Darkness:58F1:/
-340.1 "Waste Away" sync / 1[56]:Cloud Of Darkness:55DE:/
-342.4 "Evil Seed" sync / 1[56]:Cloud Of Darkness:55E7:/
-361.7 "Wide-Angle Phaser" sync / 1[56]:Cloud Of Darkness:55E0:/
-376.8 "Rejuvenating Balm" sync / 1[56]:Cloud Of Darkness:55E2:/
-384.2 "The Art Of Darkness" sync / 1[56]:Cloud Of Darkness:522[34]:/
-386.6 "Bad Vibrations" sync / 1[56]:Stygian Arbor:55E6:/ window 30,30
-399.2 "Deluge Of Darkness" sync / 1[56]:Cloud Of Darkness:5155:/
-414.3 "The Art Of Darkness" sync / 1[56]:Cloud Of Darkness:522[34]:/
-426.5 "Ground-Razing Particle Beam" sync / 1[56]:Cloud Of Darkness:55ED:/
-434.9 "Zero-Form Particle Beam" sync / 1[56]:Cloud Of Darkness:55EB:/
+327.7 "Obscure Woods" sync / 1[56]:[^:]*:Cloud Of Darkness:4FA2:/ window 30,30
+339.9 "Flood Of Obscurity" sync / 1[56]:[^:]*:Cloud Of Darkness:58F1:/
+340.1 "Waste Away" sync / 1[56]:[^:]*:Cloud Of Darkness:55DE:/
+342.4 "Evil Seed" sync / 1[56]:[^:]*:Cloud Of Darkness:55E7:/
+361.7 "Wide-Angle Phaser" sync / 1[56]:[^:]*:Cloud Of Darkness:55E0:/
+376.8 "Rejuvenating Balm" sync / 1[56]:[^:]*:Cloud Of Darkness:55E2:/
+384.2 "The Art Of Darkness" sync / 1[56]:[^:]*:Cloud Of Darkness:522[34]:/
+386.6 "Bad Vibrations" sync / 1[56]:[^:]*:Stygian Arbor:55E6:/ window 30,30
+399.2 "Deluge Of Darkness" sync / 1[56]:[^:]*:Cloud Of Darkness:5155:/
+414.3 "The Art Of Darkness" sync / 1[56]:[^:]*:Cloud Of Darkness:522[34]:/
+426.5 "Ground-Razing Particle Beam" sync / 1[56]:[^:]*:Cloud Of Darkness:55ED:/
+434.9 "Zero-Form Particle Beam" sync / 1[56]:[^:]*:Cloud Of Darkness:55EB:/
 
-449.6 "Empty Plane" sync / 1[56]:Cloud Of Darkness:4FC6:/ window 30,30 jump 239.2
+449.6 "Empty Plane" sync / 1[56]:[^:]*:Cloud Of Darkness:4FC6:/ window 30,30 jump 239.2
 463.8 "Flood Of Emptiness"
 464.2 "Mire Of Despair"
 464.2 "Earth-Shattering Particle Beam"

--- a/ui/raidboss/data/05-shb/raid/e9s.txt
+++ b/ui/raidboss/data/05-shb/raid/e9s.txt
@@ -8,63 +8,63 @@ hideall "--sync--"
 0.0 "--Reset--" sync / 21:........:40000010:/ window 100000 jump 0
 
 0.0 "--sync--" sync /:Engage!/ window 0,1
-0.8 "--sync--" sync / 1[56]:Cloud Of Darkness:5627:/ window 1,0
-16.9 "Ground-Razing Particle Beam" sync / 1[56]:Cloud Of Darkness:5625:/ window 17,10
-27.1 "The Art Of Darkness" sync / 1[56]:Cloud Of Darkness:5B4[56]:/
-36.8 "The Art Of Darkness" sync / 1[56]:Cloud Of Darkness:5B4[56]:/
-47.5 "Devouring Dark" sync / 1[56]:Cloud Of Darkness:5623:/
+0.8 "--sync--" sync / 1[56]:[^:]*:Cloud Of Darkness:5627:/ window 1,0
+16.9 "Ground-Razing Particle Beam" sync / 1[56]:[^:]*:Cloud Of Darkness:5625:/ window 17,10
+27.1 "The Art Of Darkness" sync / 1[56]:[^:]*:Cloud Of Darkness:5B4[56]:/
+36.8 "The Art Of Darkness" sync / 1[56]:[^:]*:Cloud Of Darkness:5B4[56]:/
+47.5 "Devouring Dark" sync / 1[56]:[^:]*:Cloud Of Darkness:5623:/
 
 ## Woods
-63.1 "Obscure Woods" sync / 1[56]:Cloud Of Darkness:55EE:/
-74.3 "Flood Of Obscurity" sync / 1[56]:Cloud Of Darkness:5907:/
-81.8 "Rejuvenating Balm" sync / 1[56]:Cloud Of Darkness:5618:/
-101.6 "Phaser Unlimited 1" sync / 1[56]:Cloud Of Darkness:56(1[23]|0[DE]):/ window 4,4
-103.7 "--1--" sync / 1[56]:Cloud Of Darkness:56(14|0F):/
-105.7 "--2--" sync / 1[56]:Cloud Of Darkness:561[05]:/
-109.0 "--3--" sync / 1[56]:Cloud Of Darkness:5B0[01]:/
-126.2 "Ground-Razing Particle Beam" sync / 1[56]:Cloud Of Darkness:5625:/
-144.4 "The Second Art Of Darkness" sync / 1[56]:Cloud Of Darkness:560[12]:/
-159.5 "Phaser Unlimited 2" sync / 1[56]:Cloud Of Darkness:56(1[23]|0[DE]):/ window 4,4
-161.6 "--1--" sync / 1[56]:Cloud Of Darkness:56(14|0F):/
-163.6 "--2--" sync / 1[56]:Cloud Of Darkness:561[05]:/
-166.9 "--3--" sync / 1[56]:Cloud Of Darkness:5B0[01]:/
-182.1 "Devouring Dark" sync / 1[56]:Cloud Of Darkness:5623:/
+63.1 "Obscure Woods" sync / 1[56]:[^:]*:Cloud Of Darkness:55EE:/
+74.3 "Flood Of Obscurity" sync / 1[56]:[^:]*:Cloud Of Darkness:5907:/
+81.8 "Rejuvenating Balm" sync / 1[56]:[^:]*:Cloud Of Darkness:5618:/
+101.6 "Phaser Unlimited 1" sync / 1[56]:[^:]*:Cloud Of Darkness:56(1[23]|0[DE]):/ window 4,4
+103.7 "--1--" sync / 1[56]:[^:]*:Cloud Of Darkness:56(14|0F):/
+105.7 "--2--" sync / 1[56]:[^:]*:Cloud Of Darkness:561[05]:/
+109.0 "--3--" sync / 1[56]:[^:]*:Cloud Of Darkness:5B0[01]:/
+126.2 "Ground-Razing Particle Beam" sync / 1[56]:[^:]*:Cloud Of Darkness:5625:/
+144.4 "The Second Art Of Darkness" sync / 1[56]:[^:]*:Cloud Of Darkness:560[12]:/
+159.5 "Phaser Unlimited 2" sync / 1[56]:[^:]*:Cloud Of Darkness:56(1[23]|0[DE]):/ window 4,4
+161.6 "--1--" sync / 1[56]:[^:]*:Cloud Of Darkness:56(14|0F):/
+163.6 "--2--" sync / 1[56]:[^:]*:Cloud Of Darkness:561[05]:/
+166.9 "--3--" sync / 1[56]:[^:]*:Cloud Of Darkness:5B0[01]:/
+182.1 "Devouring Dark" sync / 1[56]:[^:]*:Cloud Of Darkness:5623:/
 
 ## Tiles
-197.7 "Empty Plane" sync / 1[56]:Cloud Of Darkness:55EF:/
-208.9 "Flood Of Emptiness" sync / 1[56]:Cloud Of Darkness:55F0:/
-216.0 "Hypercharged Condensation" sync / 1[56]:Cloud Of Darkness:560C:/
-231.2 "Full-Perimeter Particle Beam" sync / 1[56]:Cloud Of Darkness:5629:/
-248.5 "The Art Of Darkness (L/R)" sync / 1[56]:Cloud Of Darkness:5A9[56]:/
-264.3 "The Art Of Darkness" sync / 1[56]:Cloud Of Darkness:55F[BE]:/
-279.0 "Deluge Of Darkness" sync / 1[56]:Cloud Of Darkness:55F1:/
+197.7 "Empty Plane" sync / 1[56]:[^:]*:Cloud Of Darkness:55EF:/
+208.9 "Flood Of Emptiness" sync / 1[56]:[^:]*:Cloud Of Darkness:55F0:/
+216.0 "Hypercharged Condensation" sync / 1[56]:[^:]*:Cloud Of Darkness:560C:/
+231.2 "Full-Perimeter Particle Beam" sync / 1[56]:[^:]*:Cloud Of Darkness:5629:/
+248.5 "The Art Of Darkness (L/R)" sync / 1[56]:[^:]*:Cloud Of Darkness:5A9[56]:/
+264.3 "The Art Of Darkness" sync / 1[56]:[^:]*:Cloud Of Darkness:55F[BE]:/
+279.0 "Deluge Of Darkness" sync / 1[56]:[^:]*:Cloud Of Darkness:55F1:/
 
 ## Default
-285.9 "Summon" sync / 1[56]:Cloud Of Darkness:5019:/
-301.2 "The Art Of Darkness (L/R)" sync / 1[56]:Cloud Of Darkness:5A9[56]:/
-314.8 "Devouring Dark" sync / 1[56]:Cloud Of Darkness:5623:/
-337.4 "The Third Art Of Darkness" sync / 1[56]:Cloud Of Darkness:560[34]:/
+285.9 "Summon" sync / 1[56]:[^:]*:Cloud Of Darkness:5019:/
+301.2 "The Art Of Darkness (L/R)" sync / 1[56]:[^:]*:Cloud Of Darkness:5A9[56]:/
+314.8 "Devouring Dark" sync / 1[56]:[^:]*:Cloud Of Darkness:5623:/
+337.4 "The Third Art Of Darkness" sync / 1[56]:[^:]*:Cloud Of Darkness:560[34]:/
 
 ## Woods
-358.0 "Obscure Woods" sync / 1[56]:Cloud Of Darkness:55EE:/
-369.2 "Flood Of Obscurity" sync / 1[56]:Cloud Of Darkness:5907:/
-377.3 "Particle Concentration" sync / 1[56]:Cloud Of Darkness:5620:/
-397.3 "Phaser Unlimited 3" sync / 1[56]:Cloud Of Darkness:56(1[23]|0[DE]):/ window 4,4
-399.4 "--1--" sync / 1[56]:Cloud Of Darkness:56(14|0F):/
-401.4 "--2--" sync / 1[56]:Cloud Of Darkness:561[05]:/
-404.7 "--3--" sync / 1[56]:Cloud Of Darkness:5B0[01]:/
-418.9 "Ground-Razing Particle Beam" sync / 1[56]:Cloud Of Darkness:5625:/
-433.0 "Rejuvenating Balm" sync / 1[56]:Cloud Of Darkness:5618:/
-444.6 "The Second Art Of Darkness" sync / 1[56]:Cloud Of Darkness:560[12]:/
-461.3 "Devouring Dark" sync / 1[56]:Cloud Of Darkness:5623:/
+358.0 "Obscure Woods" sync / 1[56]:[^:]*:Cloud Of Darkness:55EE:/
+369.2 "Flood Of Obscurity" sync / 1[56]:[^:]*:Cloud Of Darkness:5907:/
+377.3 "Particle Concentration" sync / 1[56]:[^:]*:Cloud Of Darkness:5620:/
+397.3 "Phaser Unlimited 3" sync / 1[56]:[^:]*:Cloud Of Darkness:56(1[23]|0[DE]):/ window 4,4
+399.4 "--1--" sync / 1[56]:[^:]*:Cloud Of Darkness:56(14|0F):/
+401.4 "--2--" sync / 1[56]:[^:]*:Cloud Of Darkness:561[05]:/
+404.7 "--3--" sync / 1[56]:[^:]*:Cloud Of Darkness:5B0[01]:/
+418.9 "Ground-Razing Particle Beam" sync / 1[56]:[^:]*:Cloud Of Darkness:5625:/
+433.0 "Rejuvenating Balm" sync / 1[56]:[^:]*:Cloud Of Darkness:5618:/
+444.6 "The Second Art Of Darkness" sync / 1[56]:[^:]*:Cloud Of Darkness:560[12]:/
+461.3 "Devouring Dark" sync / 1[56]:[^:]*:Cloud Of Darkness:5623:/
 
 ## Tiles
-476.7 "Empty Plane" sync / 1[56]:Cloud Of Darkness:55EF:/
-487.9 "Flood Of Emptiness" sync / 1[56]:Cloud Of Darkness:55F0:/
-495.0 "Hypercharged Condensation" sync / 1[56]:Cloud Of Darkness:560C:/
-510.2 "Full-Perimeter Particle Beam" sync / 1[56]:Cloud Of Darkness:5629:/
-527.5 "The Art Of Darkness (L/R)" sync / 1[56]:Cloud Of Darkness:5A9[56]:/
-543.3 "The Art Of Darkness" sync / 1[56]:Cloud Of Darkness:55F[BE]:/
-564.2 "The Art Of Darkness (L/R)" sync / 1[56]:Cloud Of Darkness:5A9[56]:/
-580.0 "The Art Of Darkness" sync / 1[56]:Cloud Of Darkness:55F[BE]:/
-597.1 "Enrage" sync / 1[56]:Cloud Of Darkness:562A:/
+476.7 "Empty Plane" sync / 1[56]:[^:]*:Cloud Of Darkness:55EF:/
+487.9 "Flood Of Emptiness" sync / 1[56]:[^:]*:Cloud Of Darkness:55F0:/
+495.0 "Hypercharged Condensation" sync / 1[56]:[^:]*:Cloud Of Darkness:560C:/
+510.2 "Full-Perimeter Particle Beam" sync / 1[56]:[^:]*:Cloud Of Darkness:5629:/
+527.5 "The Art Of Darkness (L/R)" sync / 1[56]:[^:]*:Cloud Of Darkness:5A9[56]:/
+543.3 "The Art Of Darkness" sync / 1[56]:[^:]*:Cloud Of Darkness:55F[BE]:/
+564.2 "The Art Of Darkness (L/R)" sync / 1[56]:[^:]*:Cloud Of Darkness:5A9[56]:/
+580.0 "The Art Of Darkness" sync / 1[56]:[^:]*:Cloud Of Darkness:55F[BE]:/
+597.1 "Enrage" sync / 1[56]:[^:]*:Cloud Of Darkness:562A:/

--- a/ui/raidboss/data/05-shb/trial/diamond_weapon-ex.txt
+++ b/ui/raidboss/data/05-shb/trial/diamond_weapon-ex.txt
@@ -9,115 +9,115 @@ hideall "--sync--"
 
 ### Phase 1
 0.0 "--sync--" sync /:Engage!/ window 0,1
-16.3 "--sync--" sync / 14:The Diamond Weapon:5FA7:/ window 17,10
-21.3 "Diamond Rain" sync / 1[56]:The Diamond Weapon:5FA7:/ window 25,10
+16.3 "--sync--" sync / 14:[^:]*:The Diamond Weapon:5FA7:/ window 17,10
+21.3 "Diamond Rain" sync / 1[56]:[^:]*:The Diamond Weapon:5FA7:/ window 25,10
 
 # 5FA2 = Spread (Homing Laser, 5FA0)
 # 5F9B = "nothing" (Diamond Rain, 5FA7)
 # 5FA5 = Stack (Diamond Flash, 5FA1)
-36.5 "Adamant Purge" sync / 1[56]:The Diamond Weapon:5FA[2345]:/ window 20,5
-46.7 "Claw Swipe" sync / 1[56]:The Diamond Weapon:5F9[EF]:/
-49.9 "Homing Laser/Diamond Flash" sync / 1[56]:The Diamond Weapon:5FA[01]:/
-67.1 "Photon Burst" sync / 1[56]:The Diamond Weapon:5FA8:/
-83.4 "Adamant Purge" sync / 1[56]:The Diamond Weapon:5F9[8B]:/
-93.6 "Claw Swipe" sync / 1[56]:The Diamond Weapon:5F9[EF]:/
-104.8 "Diamond Rain" sync / 1[56]:The Diamond Weapon:5FA7:/
-120.0 "Adamant Purge" sync / 1[56]:The Diamond Weapon:5FA[2345]:/
-130.2 "Claw Swipe" sync / 1[56]:The Diamond Weapon:5F9[EF]:/
-133.7 "Homing Laser/Diamond Flash" sync / 1[56]:The Diamond Weapon:5FA[01]:/
-151.4 "Photon Burst" sync / 1[56]:The Diamond Weapon:5FA8:/
+36.5 "Adamant Purge" sync / 1[56]:[^:]*:The Diamond Weapon:5FA[2345]:/ window 20,5
+46.7 "Claw Swipe" sync / 1[56]:[^:]*:The Diamond Weapon:5F9[EF]:/
+49.9 "Homing Laser/Diamond Flash" sync / 1[56]:[^:]*:The Diamond Weapon:5FA[01]:/
+67.1 "Photon Burst" sync / 1[56]:[^:]*:The Diamond Weapon:5FA8:/
+83.4 "Adamant Purge" sync / 1[56]:[^:]*:The Diamond Weapon:5F9[8B]:/
+93.6 "Claw Swipe" sync / 1[56]:[^:]*:The Diamond Weapon:5F9[EF]:/
+104.8 "Diamond Rain" sync / 1[56]:[^:]*:The Diamond Weapon:5FA7:/
+120.0 "Adamant Purge" sync / 1[56]:[^:]*:The Diamond Weapon:5FA[2345]:/
+130.2 "Claw Swipe" sync / 1[56]:[^:]*:The Diamond Weapon:5F9[EF]:/
+133.7 "Homing Laser/Diamond Flash" sync / 1[56]:[^:]*:The Diamond Weapon:5FA[01]:/
+151.4 "Photon Burst" sync / 1[56]:[^:]*:The Diamond Weapon:5FA8:/
 
 # Phase transition
-167.7 "Code Chi-Xi-Stigma" sync / 1[56]:The Diamond Weapon:5FAD:/
+167.7 "Code Chi-Xi-Stigma" sync / 1[56]:[^:]*:The Diamond Weapon:5FAD:/
 168.0 "--untargetable--"
-183.3 "Auri Cyclone" sync / 1[56]:The Diamond Weapon:5FB9:/
-188.0 "Diamond Shot" sync / 1[56]:Articulated Bit:5FC0:/
+183.3 "Auri Cyclone" sync / 1[56]:[^:]*:The Diamond Weapon:5FB9:/
+188.0 "Diamond Shot" sync / 1[56]:[^:]*:Articulated Bit:5FC0:/
 
 ### Phase 2
 197.8 "--targetable--"
-210.0 "Outrage" sync / 1[56]:The Diamond Weapon:5FBC:/
-218.2 "Outrage" sync / 1[56]:The Diamond Weapon:5FBC:/
-229.6 "Auri Arts (Z)" sync / 1[56]:The Diamond Weapon:5FAF:/
+210.0 "Outrage" sync / 1[56]:[^:]*:The Diamond Weapon:5FBC:/
+218.2 "Outrage" sync / 1[56]:[^:]*:The Diamond Weapon:5FBC:/
+229.6 "Auri Arts (Z)" sync / 1[56]:[^:]*:The Diamond Weapon:5FAF:/
 229.6 "--untargetable--"
-236.4 "Auri Arts (Jump)" sync / 1[56]:The Diamond Weapon:5FB2:/
+236.4 "Auri Arts (Jump)" sync / 1[56]:[^:]*:The Diamond Weapon:5FB2:/
 241.0 "--targetable--"
-250.4 "Outrage" sync / 1[56]:The Diamond Weapon:5FBC:/
-257.6 "Auri Doomstead" sync / 1[56]:The Diamond Weapon:5FBD:/
+250.4 "Outrage" sync / 1[56]:[^:]*:The Diamond Weapon:5FBC:/
+257.6 "Auri Doomstead" sync / 1[56]:[^:]*:The Diamond Weapon:5FBD:/
 265.5 "--untargetable--"
-271.8 "Auri Arts (Cleave)?" sync / 1[56]:The Diamond Weapon:5FB5:/
-272.8 "Auri Arts (Jump)" sync / 1[56]:The Diamond Weapon:5FCF:/
+271.8 "Auri Arts (Cleave)?" sync / 1[56]:[^:]*:The Diamond Weapon:5FB5:/
+272.8 "Auri Arts (Jump)" sync / 1[56]:[^:]*:The Diamond Weapon:5FCF:/
 272.8 "--targetable--"
-278.7 "Vertical Cleave" sync / 1[56]:The Diamond Weapon:5FD0:/
-291.1 "Outrage" sync / 1[56]:The Diamond Weapon:5FBC:/
-301.3 "Articulated Bits" sync / 1[56]:The Diamond Weapon:5FC1:/
-312.4 "Aetherial Bullet" sync / 1[56]:Articulated Bit:5FAB:/
-312.9 "Auri Arts (Z)" sync / 1[56]:The Diamond Weapon:5FAF:/
+278.7 "Vertical Cleave" sync / 1[56]:[^:]*:The Diamond Weapon:5FD0:/
+291.1 "Outrage" sync / 1[56]:[^:]*:The Diamond Weapon:5FBC:/
+301.3 "Articulated Bits" sync / 1[56]:[^:]*:The Diamond Weapon:5FC1:/
+312.4 "Aetherial Bullet" sync / 1[56]:[^:]*:Articulated Bit:5FAB:/
+312.9 "Auri Arts (Z)" sync / 1[56]:[^:]*:The Diamond Weapon:5FAF:/
 312.9 "--untargetable--"
-319.7 "Auri Arts (Jump)" sync / 1[56]:The Diamond Weapon:5FB2:/
-320.4 "Aetherial Bullet" sync / 1[56]:Articulated Bit:5FAB:/
+319.7 "Auri Arts (Jump)" sync / 1[56]:[^:]*:The Diamond Weapon:5FB2:/
+320.4 "Aetherial Bullet" sync / 1[56]:[^:]*:Articulated Bit:5FAB:/
 324.2 "--targetable--"
-333.7 "Outrage" sync / 1[56]:The Diamond Weapon:5FBC:/
-340.9 "Auri Doomstead" sync / 1[56]:The Diamond Weapon:5FBD:/
-353.1 "Articulated Bits" sync / 1[56]:The Diamond Weapon:5FC1:/
+333.7 "Outrage" sync / 1[56]:[^:]*:The Diamond Weapon:5FBC:/
+340.9 "Auri Doomstead" sync / 1[56]:[^:]*:The Diamond Weapon:5FBD:/
+353.1 "Articulated Bits" sync / 1[56]:[^:]*:The Diamond Weapon:5FC1:/
 355.7 "--untargetable--"
-360.7 "Aetherial Bullet" sync / 1[56]:Articulated Bit:5FAB:/
-362.2 "Auri Arts (Cleave)?" sync / 1[56]:The Diamond Weapon:5FB5:/
+360.7 "Aetherial Bullet" sync / 1[56]:[^:]*:Articulated Bit:5FAB:/
+362.2 "Auri Arts (Cleave)?" sync / 1[56]:[^:]*:The Diamond Weapon:5FB5:/
 364.0 "--targetable--"
-364.0 "Auri Arts (Jump)" sync / 1[56]:The Diamond Weapon:5FCF:/
-369.9 "Vertical Cleave" sync / 1[56]:The Diamond Weapon:5FD0:/
-370.7 "Aetherial Bullet" sync / 1[56]:Articulated Bit:5FAB:/
-382.4 "Outrage" sync / 1[56]:The Diamond Weapon:5FBC:/
+364.0 "Auri Arts (Jump)" sync / 1[56]:[^:]*:The Diamond Weapon:5FCF:/
+369.9 "Vertical Cleave" sync / 1[56]:[^:]*:The Diamond Weapon:5FD0:/
+370.7 "Aetherial Bullet" sync / 1[56]:[^:]*:Articulated Bit:5FAB:/
+382.4 "Outrage" sync / 1[56]:[^:]*:The Diamond Weapon:5FBC:/
 388.0 "--untargetable--"
 
 ### Phase 3
 397.9 "--targetable--"
-422.1 "--sync--" sync / 1[56]:The Diamond Weapon:5FA6:/
-422.7 "Flood Ray 1" #sync / 1[56]:The Diamond Weapon:5FC7:/
-424.2 "Flood Ray 2" #sync / 1[56]:The Diamond Weapon:5FC7:/
-425.7 "Flood Ray 3" #sync / 1[56]:The Diamond Weapon:5FC7:/
-427.2 "Flood Ray 4" #sync / 1[56]:The Diamond Weapon:5FC7:/
-428.7 "Flood Ray 5" #sync / 1[56]:The Diamond Weapon:5FC7:/
-430.2 "Flood Ray 6" #sync / 1[56]:The Diamond Weapon:5FC7:/
-431.7 "Flood Ray 7" #sync / 1[56]:The Diamond Weapon:5FC7:/
-433.2 "Flood Ray 8" #sync / 1[56]:The Diamond Weapon:5FC7:/
-450.7 "Photon Burst" sync / 1[56]:The Diamond Weapon:5FA8:/
-470.0 "Articulated Bits" sync / 1[56]:The Diamond Weapon:5FA9:/
-477.1 "Adamant Purge" sync / 1[56]:The Diamond Weapon:5FA[2345]:/
-481.6 "Aetherial Bullet" sync / 1[56]:Articulated Bit:5FAB:/
-486.2 "Claw Swipe" sync / 1[56]:The Diamond Weapon:5F9[EF]:/
-489.7 "Homing Laser/Diamond Flash" sync / 1[56]:The Diamond Weapon:5FA[01]:/
-490.6 "Aetherial Bullet" sync / 1[56]:Articulated Bit:5FAB:/
-501.3 "Diamond Rain" sync / 1[56]:The Diamond Weapon:5FA7:/
-516.5 "Articulated Bits" sync / 1[56]:The Diamond Weapon:5FA9:/
-523.6 "Diamond Shrapnel" sync / 1[56]:The Diamond Weapon:5FAC:/
-528.1 "Aetherial Bullet" sync / 1[56]:Articulated Bit:5FAB:/
-537.1 "Aetherial Bullet" sync / 1[56]:Articulated Bit:5FAB:/
-541.5 "Burst" sync / 1[56]:The Diamond Weapon:5FC[56]:/
-546.8 "Photon Burst" sync / 1[56]:The Diamond Weapon:5FA8:/
-566.1 "Articulated Bits" sync / 1[56]:The Diamond Weapon:5FA9:/
+422.1 "--sync--" sync / 1[56]:[^:]*:The Diamond Weapon:5FA6:/
+422.7 "Flood Ray 1" #sync / 1[56]:[^:]*:The Diamond Weapon:5FC7:/
+424.2 "Flood Ray 2" #sync / 1[56]:[^:]*:The Diamond Weapon:5FC7:/
+425.7 "Flood Ray 3" #sync / 1[56]:[^:]*:The Diamond Weapon:5FC7:/
+427.2 "Flood Ray 4" #sync / 1[56]:[^:]*:The Diamond Weapon:5FC7:/
+428.7 "Flood Ray 5" #sync / 1[56]:[^:]*:The Diamond Weapon:5FC7:/
+430.2 "Flood Ray 6" #sync / 1[56]:[^:]*:The Diamond Weapon:5FC7:/
+431.7 "Flood Ray 7" #sync / 1[56]:[^:]*:The Diamond Weapon:5FC7:/
+433.2 "Flood Ray 8" #sync / 1[56]:[^:]*:The Diamond Weapon:5FC7:/
+450.7 "Photon Burst" sync / 1[56]:[^:]*:The Diamond Weapon:5FA8:/
+470.0 "Articulated Bits" sync / 1[56]:[^:]*:The Diamond Weapon:5FA9:/
+477.1 "Adamant Purge" sync / 1[56]:[^:]*:The Diamond Weapon:5FA[2345]:/
+481.6 "Aetherial Bullet" sync / 1[56]:[^:]*:Articulated Bit:5FAB:/
+486.2 "Claw Swipe" sync / 1[56]:[^:]*:The Diamond Weapon:5F9[EF]:/
+489.7 "Homing Laser/Diamond Flash" sync / 1[56]:[^:]*:The Diamond Weapon:5FA[01]:/
+490.6 "Aetherial Bullet" sync / 1[56]:[^:]*:Articulated Bit:5FAB:/
+501.3 "Diamond Rain" sync / 1[56]:[^:]*:The Diamond Weapon:5FA7:/
+516.5 "Articulated Bits" sync / 1[56]:[^:]*:The Diamond Weapon:5FA9:/
+523.6 "Diamond Shrapnel" sync / 1[56]:[^:]*:The Diamond Weapon:5FAC:/
+528.1 "Aetherial Bullet" sync / 1[56]:[^:]*:Articulated Bit:5FAB:/
+537.1 "Aetherial Bullet" sync / 1[56]:[^:]*:Articulated Bit:5FAB:/
+541.5 "Burst" sync / 1[56]:[^:]*:The Diamond Weapon:5FC[56]:/
+546.8 "Photon Burst" sync / 1[56]:[^:]*:The Diamond Weapon:5FA8:/
+566.1 "Articulated Bits" sync / 1[56]:[^:]*:The Diamond Weapon:5FA9:/
 # This Purge seems to be able to be at least 5FA3, 5FA4, 5FA5, so including every possiblility
-573.2 "Adamant Purge" sync / 1[56]:The Diamond Weapon:5F(9[ABCD]|A[2345]):/
-577.7 "Aetherial Bullet" sync / 1[56]:Articulated Bit:5FAB:/
-583.4 "Claw Swipe" sync / 1[56]:The Diamond Weapon:5F9[EF]:/
-586.8 "Aetherial Bullet" sync / 1[56]:Articulated Bit:5FAB:/
-597.8 "Diamond Rain" sync / 1[56]:The Diamond Weapon:5FA7:/
-621.0 "--sync--" sync / 1[56]:The Diamond Weapon:5FA6:/
-621.1 "Flood Ray 1" #sync / 1[56]:The Diamond Weapon:5FC7:/
-622.6 "Flood Ray 2" #sync / 1[56]:The Diamond Weapon:5FC7:/
-624.1 "Flood Ray 3" #sync / 1[56]:The Diamond Weapon:5FC7:/
-625.6 "Flood Ray 4" #sync / 1[56]:The Diamond Weapon:5FC7:/
-627.1 "Flood Ray 5" #sync / 1[56]:The Diamond Weapon:5FC7:/
-628.6 "Flood Ray 6" #sync / 1[56]:The Diamond Weapon:5FC7:/
-630.1 "Flood Ray 7" #sync / 1[56]:The Diamond Weapon:5FC7:/
-631.6 "Flood Ray 8" #sync / 1[56]:The Diamond Weapon:5FC7:/
-649.2 "Photon Burst" sync / 1[56]:The Diamond Weapon:5FA8:/
-668.5 "Articulated Bits" sync / 1[56]:The Diamond Weapon:5FA9:/
-675.6 "Adamant Purge" sync / 1[56]:The Diamond Weapon:5FA[2345]:/
-680.1 "Aetherial Bullet" sync / 1[56]:Articulated Bit:5FAB:/
-685.8 "Claw Swipe" sync / 1[56]:The Diamond Weapon:5F9[EF]:/
-689.0 "Homing Laser/Diamond Flash" sync / 1[56]:The Diamond Weapon:5FA[01]:/
-689.2 "Aetherial Bullet" sync / 1[56]:Articulated Bit:5FAB:/
-700.2 "Diamond Rain" sync / 1[56]:The Diamond Weapon:5FA7:/
+573.2 "Adamant Purge" sync / 1[56]:[^:]*:The Diamond Weapon:5F(9[ABCD]|A[2345]):/
+577.7 "Aetherial Bullet" sync / 1[56]:[^:]*:Articulated Bit:5FAB:/
+583.4 "Claw Swipe" sync / 1[56]:[^:]*:The Diamond Weapon:5F9[EF]:/
+586.8 "Aetherial Bullet" sync / 1[56]:[^:]*:Articulated Bit:5FAB:/
+597.8 "Diamond Rain" sync / 1[56]:[^:]*:The Diamond Weapon:5FA7:/
+621.0 "--sync--" sync / 1[56]:[^:]*:The Diamond Weapon:5FA6:/
+621.1 "Flood Ray 1" #sync / 1[56]:[^:]*:The Diamond Weapon:5FC7:/
+622.6 "Flood Ray 2" #sync / 1[56]:[^:]*:The Diamond Weapon:5FC7:/
+624.1 "Flood Ray 3" #sync / 1[56]:[^:]*:The Diamond Weapon:5FC7:/
+625.6 "Flood Ray 4" #sync / 1[56]:[^:]*:The Diamond Weapon:5FC7:/
+627.1 "Flood Ray 5" #sync / 1[56]:[^:]*:The Diamond Weapon:5FC7:/
+628.6 "Flood Ray 6" #sync / 1[56]:[^:]*:The Diamond Weapon:5FC7:/
+630.1 "Flood Ray 7" #sync / 1[56]:[^:]*:The Diamond Weapon:5FC7:/
+631.6 "Flood Ray 8" #sync / 1[56]:[^:]*:The Diamond Weapon:5FC7:/
+649.2 "Photon Burst" sync / 1[56]:[^:]*:The Diamond Weapon:5FA8:/
+668.5 "Articulated Bits" sync / 1[56]:[^:]*:The Diamond Weapon:5FA9:/
+675.6 "Adamant Purge" sync / 1[56]:[^:]*:The Diamond Weapon:5FA[2345]:/
+680.1 "Aetherial Bullet" sync / 1[56]:[^:]*:Articulated Bit:5FAB:/
+685.8 "Claw Swipe" sync / 1[56]:[^:]*:The Diamond Weapon:5F9[EF]:/
+689.0 "Homing Laser/Diamond Flash" sync / 1[56]:[^:]*:The Diamond Weapon:5FA[01]:/
+689.2 "Aetherial Bullet" sync / 1[56]:[^:]*:Articulated Bit:5FAB:/
+700.2 "Diamond Rain" sync / 1[56]:[^:]*:The Diamond Weapon:5FA7:/
 
 # Enrage
-718.6 "Flood Ray (Enrage)" sync / 1[56]:The Diamond Weapon:5FEE:/
+718.6 "Flood Ray (Enrage)" sync / 1[56]:[^:]*:The Diamond Weapon:5FEE:/

--- a/ui/raidboss/data/05-shb/trial/diamond_weapon.txt
+++ b/ui/raidboss/data/05-shb/trial/diamond_weapon.txt
@@ -10,94 +10,94 @@ hideall "--sync--"
 
 # Phase 1
 0.0 "--sync--" sync /:Engage!/ window 0,1
-6.0 "--sync--" sync / 14:The Diamond Weapon:5FA7:/ window 10,10
-11.0 "Diamond Rain" sync / 1[56]:The Diamond Weapon:5FA7:/
-40.3 "Adamant Purge" sync / 1[56]:The Diamond Weapon:5F9B:/
-50.5 "Claw Swipe" sync / 1[56]:The Diamond Weapon:5F9F:/
-63.7 "Adamant Purge" sync / 1[56]:The Diamond Weapon:5F9A:/
-73.9 "Claw Swipe" sync / 1[56]:The Diamond Weapon:5F9E:/
-91.2 "Diamond Rain" sync / 1[56]:The Diamond Weapon:5FA7:/
-102.4 "Photon Burst" sync / 1[56]:The Diamond Weapon:5FA8:/
-115.6 "Adamant Purge" sync / 1[56]:The Diamond Weapon:5F9D:/
-118.8 "--sync--" sync / 1[56]:The Diamond Weapon:5779:/
-127.2 "Diamond Flash" sync / 1[56]:The Diamond Weapon:5FD4:/
-144.1 "Code Chi-Xi-Stigma" sync / 1[56]:The Diamond Weapon:5FAD:/
+6.0 "--sync--" sync / 14:[^:]*:The Diamond Weapon:5FA7:/ window 10,10
+11.0 "Diamond Rain" sync / 1[56]:[^:]*:The Diamond Weapon:5FA7:/
+40.3 "Adamant Purge" sync / 1[56]:[^:]*:The Diamond Weapon:5F9B:/
+50.5 "Claw Swipe" sync / 1[56]:[^:]*:The Diamond Weapon:5F9F:/
+63.7 "Adamant Purge" sync / 1[56]:[^:]*:The Diamond Weapon:5F9A:/
+73.9 "Claw Swipe" sync / 1[56]:[^:]*:The Diamond Weapon:5F9E:/
+91.2 "Diamond Rain" sync / 1[56]:[^:]*:The Diamond Weapon:5FA7:/
+102.4 "Photon Burst" sync / 1[56]:[^:]*:The Diamond Weapon:5FA8:/
+115.6 "Adamant Purge" sync / 1[56]:[^:]*:The Diamond Weapon:5F9D:/
+118.8 "--sync--" sync / 1[56]:[^:]*:The Diamond Weapon:5779:/
+127.2 "Diamond Flash" sync / 1[56]:[^:]*:The Diamond Weapon:5FD4:/
+144.1 "Code Chi-Xi-Stigma" sync / 1[56]:[^:]*:The Diamond Weapon:5FAD:/
 
 # Intermission
 144.1 "--untargetable--"
-147.1 "--sync--" sync / 1[56]:The Diamond Weapon:5FEB:/
-149.0 "--sync--" sync / 1[56]:The Diamond Weapon:5FBE:/
-159.6 "--sync--" sync / 1[56]:The Diamond Weapon:5FB9:/ # Auri Cyclone castbar
-160.6 "Auri Cyclone 1" sync / 1[56]:The Diamond Weapon:5FE6:/
-162.1 "Auri Cyclone 2" sync / 1[56]:The Diamond Weapon:5FE7:/
-169.1 "Airship's Bane" sync / 1[56]:The Diamond Weapon:5FFE:/
-169.9 "--sync--" sync / 1[56]:The Diamond Weapon:5FBB:/
+147.1 "--sync--" sync / 1[56]:[^:]*:The Diamond Weapon:5FEB:/
+149.0 "--sync--" sync / 1[56]:[^:]*:The Diamond Weapon:5FBE:/
+159.6 "--sync--" sync / 1[56]:[^:]*:The Diamond Weapon:5FB9:/ # Auri Cyclone castbar
+160.6 "Auri Cyclone 1" sync / 1[56]:[^:]*:The Diamond Weapon:5FE6:/
+162.1 "Auri Cyclone 2" sync / 1[56]:[^:]*:The Diamond Weapon:5FE7:/
+169.1 "Airship's Bane" sync / 1[56]:[^:]*:The Diamond Weapon:5FFE:/
+169.9 "--sync--" sync / 1[56]:[^:]*:The Diamond Weapon:5FBB:/
 
 # Phase 2
 174.1 "--targetable--"
-186.3 "Outrage" sync / 1[56]:The Diamond Weapon:5FD7:/
-193.5 "--sync--" sync / 1[56]:The Diamond Weapon:6055:/
-201.5 "--sync--" sync / 1[56]:The Diamond Weapon:61A0:/
+186.3 "Outrage" sync / 1[56]:[^:]*:The Diamond Weapon:5FD7:/
+193.5 "--sync--" sync / 1[56]:[^:]*:The Diamond Weapon:6055:/
+201.5 "--sync--" sync / 1[56]:[^:]*:The Diamond Weapon:61A0:/
 
-201.9 "Auri Arts (Z)" sync / 1[56]:The Diamond Weapon:5FF8:/
+201.9 "Auri Arts (Z)" sync / 1[56]:[^:]*:The Diamond Weapon:5FF8:/
 201.9 "--untargetable--"
-210.2 "Auri Arts (Jump)" sync / 1[56]:The Diamond Weapon:5FE4:/
+210.2 "Auri Arts (Jump)" sync / 1[56]:[^:]*:The Diamond Weapon:5FE4:/
 213.6 "--targetable--"
 
-220.7 "Auri Doomstead" sync / 1[56]:The Diamond Weapon:5FD8:/
+220.7 "Auri Doomstead" sync / 1[56]:[^:]*:The Diamond Weapon:5FD8:/
 
 226.8 "--untargetable--"
-232.9 "Auri Arts (Cleave)" sync / 1[56]:The Diamond Weapon:6151:/
+232.9 "Auri Arts (Cleave)" sync / 1[56]:[^:]*:The Diamond Weapon:6151:/
 234.6 "--targetable--"
-234.9 "Auri Arts (Jump)" sync / 1[56]:The Diamond Weapon:6152:/
+234.9 "Auri Arts (Jump)" sync / 1[56]:[^:]*:The Diamond Weapon:6152:/
 
-245.0 "Outrage" sync / 1[56]:The Diamond Weapon:5FD7:/
-255.2 "--sync--" sync / 1[56]:The Diamond Weapon:5FD6:/ # Vertical Cleave castbar
-256.9 "Vertical Cleave" sync / 1[56]:The Diamond Weapon:5FE5:/
-266.4 "Auri Doomstead" sync / 1[56]:The Diamond Weapon:5FD8:/
+245.0 "Outrage" sync / 1[56]:[^:]*:The Diamond Weapon:5FD7:/
+255.2 "--sync--" sync / 1[56]:[^:]*:The Diamond Weapon:5FD6:/ # Vertical Cleave castbar
+256.9 "Vertical Cleave" sync / 1[56]:[^:]*:The Diamond Weapon:5FE5:/
+266.4 "Auri Doomstead" sync / 1[56]:[^:]*:The Diamond Weapon:5FD8:/
 
-269.6 "--sync--" sync / 1[56]:The Diamond Weapon:6055:/
-277.6 "--sync--" sync / 1[56]:The Diamond Weapon:61A0:/
-278.0 "Auri Arts (Z)" sync / 1[56]:The Diamond Weapon:5FF8:/
+269.6 "--sync--" sync / 1[56]:[^:]*:The Diamond Weapon:6055:/
+277.6 "--sync--" sync / 1[56]:[^:]*:The Diamond Weapon:61A0:/
+278.0 "Auri Arts (Z)" sync / 1[56]:[^:]*:The Diamond Weapon:5FF8:/
 278.0 "--untargetable--"
-281.8 "--sync--" sync / 1[56]:The Diamond Weapon:6130:/
-286.3 "Auri Arts (Jump)" sync / 1[56]:The Diamond Weapon:5FE4:/
+281.8 "--sync--" sync / 1[56]:[^:]*:The Diamond Weapon:6130:/
+286.3 "Auri Arts (Jump)" sync / 1[56]:[^:]*:The Diamond Weapon:5FE4:/
 289.7 "--targetable--"
 
 # Intermission
 299.8 "--untargetable--"
-302.2 "--sync--" sync / 1[56]:The Diamond Weapon:5FBF:/
-303.0 "--sync--" sync / 1[56]:The Diamond Weapon:5FEB:/
-304.6 "--sync--" sync / 1[56]:The Diamond Weapon:5FAE:/
+302.2 "--sync--" sync / 1[56]:[^:]*:The Diamond Weapon:5FBF:/
+303.0 "--sync--" sync / 1[56]:[^:]*:The Diamond Weapon:5FEB:/
+304.6 "--sync--" sync / 1[56]:[^:]*:The Diamond Weapon:5FAE:/
 309.7 "--targetable--"
 
 # Phase 3
-335.0 "Diamond Shrapnel" sync / 1[56]:The Diamond Weapon:5FAC:/ duration 8
-342.1 "Adamant Purge" sync / 1[56]:The Diamond Weapon:5F9B:/
-352.3 "Claw Swipe" sync / 1[56]:The Diamond Weapon:5F9[EF]:/
-368.6 "Articulated Bits" sync / 1[56]:The Diamond Weapon:5FA9:/
-375.7 "Adamant Purge" sync / 1[56]:The Diamond Weapon:5F9A:/
-376.2 "Aetherial Bullet" sync / 1[56]:Articulated Bit:5FD5:/
-385.9 "Claw Swipe" sync / 1[56]:The Diamond Weapon:5F9[EF]:/
-387.8 "Aetherial Bullet" sync / 1[56]:Articulated Bit:5FD5:/
+335.0 "Diamond Shrapnel" sync / 1[56]:[^:]*:The Diamond Weapon:5FAC:/ duration 8
+342.1 "Adamant Purge" sync / 1[56]:[^:]*:The Diamond Weapon:5F9B:/
+352.3 "Claw Swipe" sync / 1[56]:[^:]*:The Diamond Weapon:5F9[EF]:/
+368.6 "Articulated Bits" sync / 1[56]:[^:]*:The Diamond Weapon:5FA9:/
+375.7 "Adamant Purge" sync / 1[56]:[^:]*:The Diamond Weapon:5F9A:/
+376.2 "Aetherial Bullet" sync / 1[56]:[^:]*:Articulated Bit:5FD5:/
+385.9 "Claw Swipe" sync / 1[56]:[^:]*:The Diamond Weapon:5F9[EF]:/
+387.8 "Aetherial Bullet" sync / 1[56]:[^:]*:Articulated Bit:5FD5:/
 
-400.2 "Photon Burst" sync / 1[56]:The Diamond Weapon:5FA8:/
-410.4 "Adamant Sphere" sync / 1[56]:The Diamond Weapon:6144:/
-420.5 "Adamant Purge" sync / 1[56]:The Diamond Weapon:5F9D:/
-421.2 "Burst" sync / 1[56]:The Diamond Weapon:5FDC:/
+400.2 "Photon Burst" sync / 1[56]:[^:]*:The Diamond Weapon:5FA8:/
+410.4 "Adamant Sphere" sync / 1[56]:[^:]*:The Diamond Weapon:6144:/
+420.5 "Adamant Purge" sync / 1[56]:[^:]*:The Diamond Weapon:5F9D:/
+421.2 "Burst" sync / 1[56]:[^:]*:The Diamond Weapon:5FDC:/
 
-432.1 "Diamond Flash" sync / 1[56]:The Diamond Weapon:5FD4:/
-446.8 "Diamond Rain" sync / 1[56]:The Diamond Weapon:5FA7:/
-460.0 "Adamant Purge" sync / 1[56]:The Diamond Weapon:5F9C:/
-470.2 "Homing Laser" sync / 1[56]:The Diamond Weapon:5FA0:/
-484.4 "Photon Burst" sync / 1[56]:The Diamond Weapon:5FA8:/
+432.1 "Diamond Flash" sync / 1[56]:[^:]*:The Diamond Weapon:5FD4:/
+446.8 "Diamond Rain" sync / 1[56]:[^:]*:The Diamond Weapon:5FA7:/
+460.0 "Adamant Purge" sync / 1[56]:[^:]*:The Diamond Weapon:5F9C:/
+470.2 "Homing Laser" sync / 1[56]:[^:]*:The Diamond Weapon:5FA0:/
+484.4 "Photon Burst" sync / 1[56]:[^:]*:The Diamond Weapon:5FA8:/
 
 # loop
-497.6 "Diamond Shrapnel" sync / 1[56]:The Diamond Weapon:5FAC:/ window 100,100 jump 335
-504.7 "Adamant Purge" #sync / 1[56]:The Diamond Weapon:5F9B:/
-514.9 "Claw Swipe" #sync / 1[56]:The Diamond Weapon:5F9[EF]:/
-531.2 "Articulated Bits" #sync / 1[56]:The Diamond Weapon:5FA9:/
-538.3 "Adamant Purge" #sync / 1[56]:The Diamond Weapon:5F9A:/
-538.8 "Aetherial Bullet" #sync / 1[56]:Articulated Bit:5FD5:/
-548.5 "Claw Swipe" #sync / 1[56]:The Diamond Weapon:5F9[EF]:/
-550.4 "Aetherial Bullet" #sync / 1[56]:Articulated Bit:5FD5:/
+497.6 "Diamond Shrapnel" sync / 1[56]:[^:]*:The Diamond Weapon:5FAC:/ window 100,100 jump 335
+504.7 "Adamant Purge" #sync / 1[56]:[^:]*:The Diamond Weapon:5F9B:/
+514.9 "Claw Swipe" #sync / 1[56]:[^:]*:The Diamond Weapon:5F9[EF]:/
+531.2 "Articulated Bits" #sync / 1[56]:[^:]*:The Diamond Weapon:5FA9:/
+538.3 "Adamant Purge" #sync / 1[56]:[^:]*:The Diamond Weapon:5F9A:/
+538.8 "Aetherial Bullet" #sync / 1[56]:[^:]*:Articulated Bit:5FD5:/
+548.5 "Claw Swipe" #sync / 1[56]:[^:]*:The Diamond Weapon:5F9[EF]:/
+550.4 "Aetherial Bullet" #sync / 1[56]:[^:]*:Articulated Bit:5FD5:/

--- a/ui/raidboss/data/05-shb/trial/emerald_weapon-ex.txt
+++ b/ui/raidboss/data/05-shb/trial/emerald_weapon-ex.txt
@@ -10,30 +10,30 @@ hideall "--sync--"
 # -ii 55AF 55AE 557B 58D3 557D 557F 5BA6 5BA7 5596 557A 5579 5BD3 5017 559E 55A0 5597 5018 55A4 5BA3 554B 554C 5593 559A 5B03 5598 5B1A
 
 0.0 "--sync--" sync /:Engage!/ window 0,1
-1.1 "--sync--" sync / 1[56]:The Emerald Weapon:5B1A:/ window 1.1,0
-17.1 "Emerald Shot" sync / 1[56]:The Emerald Weapon:55B0:/ window 18,10
-28.2 "Optimized Ultima" sync / 1[56]:The Emerald Weapon:55B1:/
-39.4 "Aetheroplasm Production" sync / 1[56]:The Emerald Weapon:55AA:/
-65.6 "Emerald Beam" sync / 1[56]:The Emerald Weapon:557[13]:/
-92.8 "Magitek Magnetism" sync / 1[56]:The Emerald Weapon:5594:/
-118.0 "Magitek Magnetism" sync / 1[56]:The Emerald Weapon:5594:/
-138.1 "Emerald Beam" sync / 1[56]:The Emerald Weapon:557[57]:/
-160.3 "Optimized Ultima" sync / 1[56]:The Emerald Weapon:55B1:/
-171.4 "Bit Storm" sync / 1[56]:The Emerald Weapon:55A2:/
-178.5 "Divide Et Impera" sync / 1[56]:The Emerald Weapon:5537:/
-198.6 "Expire" sync / 1[56]:The Emerald Weapon:5591:/
-208.6 "Aire Tam Storm" sync / 1[56]:The Emerald Weapon:558F:/
-231.7 "Photon Ring" sync / 1[56]:The Emerald Weapon:55A9:/
-243.9 "Magitek Magnetism" sync / 1[56]:The Emerald Weapon:5594:/
-278.1 "Optimized Ultima" sync / 1[56]:The Emerald Weapon:55B1:/
-291.1 "Bit Storm" sync / 1[56]:The Emerald Weapon:55A2:/
-298.2 "Divide Et Impera" sync / 1[56]:The Emerald Weapon:5537:/
-312.5 "Optimized Ultima" sync / 1[56]:The Emerald Weapon:55B2:/
-339.6 "Enrage" sync / 1[56]:The Emerald Weapon:5B16:/
+1.1 "--sync--" sync / 1[56]:[^:]*:The Emerald Weapon:5B1A:/ window 1.1,0
+17.1 "Emerald Shot" sync / 1[56]:[^:]*:The Emerald Weapon:55B0:/ window 18,10
+28.2 "Optimized Ultima" sync / 1[56]:[^:]*:The Emerald Weapon:55B1:/
+39.4 "Aetheroplasm Production" sync / 1[56]:[^:]*:The Emerald Weapon:55AA:/
+65.6 "Emerald Beam" sync / 1[56]:[^:]*:The Emerald Weapon:557[13]:/
+92.8 "Magitek Magnetism" sync / 1[56]:[^:]*:The Emerald Weapon:5594:/
+118.0 "Magitek Magnetism" sync / 1[56]:[^:]*:The Emerald Weapon:5594:/
+138.1 "Emerald Beam" sync / 1[56]:[^:]*:The Emerald Weapon:557[57]:/
+160.3 "Optimized Ultima" sync / 1[56]:[^:]*:The Emerald Weapon:55B1:/
+171.4 "Bit Storm" sync / 1[56]:[^:]*:The Emerald Weapon:55A2:/
+178.5 "Divide Et Impera" sync / 1[56]:[^:]*:The Emerald Weapon:5537:/
+198.6 "Expire" sync / 1[56]:[^:]*:The Emerald Weapon:5591:/
+208.6 "Aire Tam Storm" sync / 1[56]:[^:]*:The Emerald Weapon:558F:/
+231.7 "Photon Ring" sync / 1[56]:[^:]*:The Emerald Weapon:55A9:/
+243.9 "Magitek Magnetism" sync / 1[56]:[^:]*:The Emerald Weapon:5594:/
+278.1 "Optimized Ultima" sync / 1[56]:[^:]*:The Emerald Weapon:55B1:/
+291.1 "Bit Storm" sync / 1[56]:[^:]*:The Emerald Weapon:55A2:/
+298.2 "Divide Et Impera" sync / 1[56]:[^:]*:The Emerald Weapon:5537:/
+312.5 "Optimized Ultima" sync / 1[56]:[^:]*:The Emerald Weapon:55B2:/
+339.6 "Enrage" sync / 1[56]:[^:]*:The Emerald Weapon:5B16:/
 
 
 ### Cutscene
-800.0 "--cutscene--" sync / 1[56]:The Emerald Weapon:5B02:/ window 800,0 duration 58.5
+800.0 "--cutscene--" sync / 1[56]:[^:]*:The Emerald Weapon:5B02:/ window 800,0 duration 58.5
 858.5 "--targetable--"
 
 
@@ -44,57 +44,57 @@ hideall "--sync--"
 # -ii 5B1C 55DA 55D9 55C4 55C5 55C6 55C7 55BC 55BD 55CD 55D2 5585 55CA 55C9 55CB
 
 1000.0 "Start"
-1001.0 "--sync--" sync / 1[56]:The Emerald Weapon:5B1C:/ window 1001,0
-1015.0 "Divide Et Impera" sync / 1[56]:The Emerald Weapon:555B:/ window 1015,5
-1021.3 "--sync--" sync / 1[56]:The Emerald Weapon:5B1F:/
-1031.3 "Primus Terminus Est" sync / 1[56]:The Emerald Weapon:55C3:/
-1046.4 "Tertius Terminus Est" sync / 1[56]:The Emerald Weapon:55CC:/
-1056.4 "Tertius Terminus Est 1" #sync / 1[56]:The Emerald Weapon:55CE:/
-1057.6 "Tertius Terminus Est 2" #sync / 1[56]:The Emerald Weapon:55CE:/
-1058.8 "Tertius Terminus Est 3" #sync / 1[56]:The Emerald Weapon:55CE:/
+1001.0 "--sync--" sync / 1[56]:[^:]*:The Emerald Weapon:5B1C:/ window 1001,0
+1015.0 "Divide Et Impera" sync / 1[56]:[^:]*:The Emerald Weapon:555B:/ window 1015,5
+1021.3 "--sync--" sync / 1[56]:[^:]*:The Emerald Weapon:5B1F:/
+1031.3 "Primus Terminus Est" sync / 1[56]:[^:]*:The Emerald Weapon:55C3:/
+1046.4 "Tertius Terminus Est" sync / 1[56]:[^:]*:The Emerald Weapon:55CC:/
+1056.4 "Tertius Terminus Est 1" #sync / 1[56]:[^:]*:The Emerald Weapon:55CE:/
+1057.6 "Tertius Terminus Est 2" #sync / 1[56]:[^:]*:The Emerald Weapon:55CE:/
+1058.8 "Tertius Terminus Est 3" #sync / 1[56]:[^:]*:The Emerald Weapon:55CE:/
 
-1075.6 "Legio Phantasmatis" sync / 1[56]:The Emerald Weapon:55B4:/ window 20,20
+1075.6 "Legio Phantasmatis" sync / 1[56]:[^:]*:The Emerald Weapon:55B4:/ window 20,20
 1077.7 "--untargetable--"
 1080.8 "--targetable--"
-1084.7 "Mechanized Maneuver" sync / 1[56]:Black Wolf's Image:55BA:/
-1096.2 "Heirsbane" sync / 1[56]:Black Wolf's Image:55B9:/
-1099.4 "Bombs Away" sync / 1[56]:Black Wolf's Image:55BB:/
+1084.7 "Mechanized Maneuver" sync / 1[56]:[^:]*:Black Wolf's Image:55BA:/
+1096.2 "Heirsbane" sync / 1[56]:[^:]*:Black Wolf's Image:55B9:/
+1099.4 "Bombs Away" sync / 1[56]:[^:]*:Black Wolf's Image:55BB:/
 1104.6 "--untargetable--"
-1117.6 "Magitek Cannon" sync / 1[56]:Reaper Image:55BE:/ window 20,20
+1117.6 "Magitek Cannon" sync / 1[56]:[^:]*:Reaper Image:55BE:/ window 20,20
 1127.3 "--targetable--"
 
-1135.4 "Optimized Ultima" sync / 1[56]:The Emerald Weapon:5B10:/
-1148.6 "Divide Et Impera" sync / 1[56]:The Emerald Weapon:555B:/
-1155.4 "--sync--" sync / 1[56]:The Emerald Weapon:5B1F:/
-1162.4 "Tertius Terminus Est" sync / 1[56]:The Emerald Weapon:55CC:/
-1168.1 "Split" sync / 1[56]:The Emerald Weapon:55(CF|D3):/
-1174.3 "Expire / Sidescathe" sync / 1[56]:The Emerald Weapon:55D[145]:/
-1183.3 "Aire Tam Storm / Emerald Crusher" sync / 1[56]:The Emerald Weapon:(55D0|5585):/
-1186.7 "Tertius Terminus Est 1" #sync / 1[56]:The Emerald Weapon:55CE:/
-1187.9 "Tertius Terminus Est 2" #sync / 1[56]:The Emerald Weapon:55CE:/
-1189.0 "Tertius Terminus Est 3" #sync / 1[56]:The Emerald Weapon:55CE:/
+1135.4 "Optimized Ultima" sync / 1[56]:[^:]*:The Emerald Weapon:5B10:/
+1148.6 "Divide Et Impera" sync / 1[56]:[^:]*:The Emerald Weapon:555B:/
+1155.4 "--sync--" sync / 1[56]:[^:]*:The Emerald Weapon:5B1F:/
+1162.4 "Tertius Terminus Est" sync / 1[56]:[^:]*:The Emerald Weapon:55CC:/
+1168.1 "Split" sync / 1[56]:[^:]*:The Emerald Weapon:55(CF|D3):/
+1174.3 "Expire / Sidescathe" sync / 1[56]:[^:]*:The Emerald Weapon:55D[145]:/
+1183.3 "Aire Tam Storm / Emerald Crusher" sync / 1[56]:[^:]*:The Emerald Weapon:(55D0|5585):/
+1186.7 "Tertius Terminus Est 1" #sync / 1[56]:[^:]*:The Emerald Weapon:55CE:/
+1187.9 "Tertius Terminus Est 2" #sync / 1[56]:[^:]*:The Emerald Weapon:55CE:/
+1189.0 "Tertius Terminus Est 3" #sync / 1[56]:[^:]*:The Emerald Weapon:55CE:/
 
-1205.5 "Legio Phantasmatis" sync / 1[56]:The Emerald Weapon:55B4:/ window 20,20
+1205.5 "Legio Phantasmatis" sync / 1[56]:[^:]*:The Emerald Weapon:55B4:/ window 20,20
 1207.5 "--untargetable--"
 1210.7 "--targetable--"
-1214.9 "Full Rank" sync / 1[56]:Black Wolf's Image:55C0:/
-1226.2 "Final Formation" sync / 1[56]:Black Wolf's Image:55C1:/
-1232.4 "Fatal Fire" sync / 1[56]:Black Wolf's Image:55C2:/
+1214.9 "Full Rank" sync / 1[56]:[^:]*:Black Wolf's Image:55C0:/
+1226.2 "Final Formation" sync / 1[56]:[^:]*:Black Wolf's Image:55C1:/
+1232.4 "Fatal Fire" sync / 1[56]:[^:]*:Black Wolf's Image:55C2:/
 1234.6 "--untargetable--"
-1238.4 "Shots Fired 1" #sync / 1[56]:Imperial Image:55B7:/
-1240.4 "Shots Fired 2" #sync / 1[56]:Imperial Image:55B7:/
-1242.4 "Shots Fired 3" #sync / 1[56]:Imperial Image:55B7:/
-1247.5 "Magitek Cannon" sync / 1[56]:Reaper Image:55BE:/ window 20,20
+1238.4 "Shots Fired 1" #sync / 1[56]:[^:]*:Imperial Image:55B7:/
+1240.4 "Shots Fired 2" #sync / 1[56]:[^:]*:Imperial Image:55B7:/
+1242.4 "Shots Fired 3" #sync / 1[56]:[^:]*:Imperial Image:55B7:/
+1247.5 "Magitek Cannon" sync / 1[56]:[^:]*:Reaper Image:55BE:/ window 20,20
 1257.2 "--targetable--"
 
-1269.4 "Secundus Terminus Est" sync / 1[56]:The Emerald Weapon:55C8:/
-1286.5 "Tertius Terminus Est" sync / 1[56]:The Emerald Weapon:55CC:/
-1292.7 "Split" sync / 1[56]:The Emerald Weapon:55(CF|D3):/
-1298.5 "Sidescathe / Expire" sync / 1[56]:The Emerald Weapon:55D[145]:/
-1307.5 "Emerald Crusher / Aire Tam Storm" sync / 1[56]:The Emerald Weapon:(55D0|5585):/
-1310.4 "Tertius Terminus Est 1" #sync / 1[56]:The Emerald Weapon:55CE:/
-1311.6 "Tertius Terminus Est 2" #sync / 1[56]:The Emerald Weapon:55CE:/
-1312.8 "Tertius Terminus Est 3" #sync / 1[56]:The Emerald Weapon:55CE:/
-1326.5 "Primus Terminus Est" sync / 1[56]:The Emerald Weapon:55C3:/
-1343.2 "Divide Et Impera" sync / 1[56]:The Emerald Weapon:555B:/
-1374.5 "Enrage" sync / 1[56]:The Emerald Weapon:5B17:/
+1269.4 "Secundus Terminus Est" sync / 1[56]:[^:]*:The Emerald Weapon:55C8:/
+1286.5 "Tertius Terminus Est" sync / 1[56]:[^:]*:The Emerald Weapon:55CC:/
+1292.7 "Split" sync / 1[56]:[^:]*:The Emerald Weapon:55(CF|D3):/
+1298.5 "Sidescathe / Expire" sync / 1[56]:[^:]*:The Emerald Weapon:55D[145]:/
+1307.5 "Emerald Crusher / Aire Tam Storm" sync / 1[56]:[^:]*:The Emerald Weapon:(55D0|5585):/
+1310.4 "Tertius Terminus Est 1" #sync / 1[56]:[^:]*:The Emerald Weapon:55CE:/
+1311.6 "Tertius Terminus Est 2" #sync / 1[56]:[^:]*:The Emerald Weapon:55CE:/
+1312.8 "Tertius Terminus Est 3" #sync / 1[56]:[^:]*:The Emerald Weapon:55CE:/
+1326.5 "Primus Terminus Est" sync / 1[56]:[^:]*:The Emerald Weapon:55C3:/
+1343.2 "Divide Et Impera" sync / 1[56]:[^:]*:The Emerald Weapon:555B:/
+1374.5 "Enrage" sync / 1[56]:[^:]*:The Emerald Weapon:5B17:/

--- a/ui/raidboss/data/05-shb/trial/emerald_weapon.txt
+++ b/ui/raidboss/data/05-shb/trial/emerald_weapon.txt
@@ -10,141 +10,141 @@ hideall "--sync--"
 
 ### Phase 1
 0 "Start"
-0.5 "--sync--" sync / 1[56]:The Emerald Weapon:5B1A:/ window 1,0.5
-8.4 "--sync--" sync / 14:The Emerald Weapon:5554:/ window 10,5
-13.4 "Emerald Shot" sync / 1[56]:The Emerald Weapon:5554:/
+0.5 "--sync--" sync / 1[56]:[^:]*:The Emerald Weapon:5B1A:/ window 1,0.5
+8.4 "--sync--" sync / 14:[^:]*:The Emerald Weapon:5554:/ window 10,5
+13.4 "Emerald Shot" sync / 1[56]:[^:]*:The Emerald Weapon:5554:/
 
-26.6 "Emerald Beam" sync / 1[56]:The Emerald Weapon:552A:/
-26.6 "Heat Ray" sync / 1[56]:The Emerald Weapon:4F9D:/ duration 9.7
-26.6 "Photon Laser" sync / 1[56]:The Emerald Weapon:5534:/
-28.6 "Photon Laser" sync / 1[56]:The Emerald Weapon:5536:/
-30.6 "Photon Laser" sync / 1[56]:The Emerald Weapon:5538:/
-32.4 "Photon Laser" sync / 1[56]:The Emerald Weapon:5534:/
-34.4 "Photon Laser" sync / 1[56]:The Emerald Weapon:5536:/
-36.4 "Photon Laser" sync / 1[56]:The Emerald Weapon:5538:/
-39.4 "--sync--" sync / 1[56]:The Emerald Weapon:5017:/
+26.6 "Emerald Beam" sync / 1[56]:[^:]*:The Emerald Weapon:552A:/
+26.6 "Heat Ray" sync / 1[56]:[^:]*:The Emerald Weapon:4F9D:/ duration 9.7
+26.6 "Photon Laser" sync / 1[56]:[^:]*:The Emerald Weapon:5534:/
+28.6 "Photon Laser" sync / 1[56]:[^:]*:The Emerald Weapon:5536:/
+30.6 "Photon Laser" sync / 1[56]:[^:]*:The Emerald Weapon:5538:/
+32.4 "Photon Laser" sync / 1[56]:[^:]*:The Emerald Weapon:5534:/
+34.4 "Photon Laser" sync / 1[56]:[^:]*:The Emerald Weapon:5536:/
+36.4 "Photon Laser" sync / 1[56]:[^:]*:The Emerald Weapon:5538:/
+39.4 "--sync--" sync / 1[56]:[^:]*:The Emerald Weapon:5017:/
 
-50.7 "Magitek Magnetism" sync / 1[56]:The Emerald Weapon:5B05:/
-64.3 "--sync--" sync / 1[56]:The Emerald Weapon:5545:/
-65.2 "Explosion" sync / 1[56]:Magnetic Mine:5B04:/
+50.7 "Magitek Magnetism" sync / 1[56]:[^:]*:The Emerald Weapon:5B05:/
+64.3 "--sync--" sync / 1[56]:[^:]*:The Emerald Weapon:5545:/
+65.2 "Explosion" sync / 1[56]:[^:]*:Magnetic Mine:5B04:/
 
-73.9 "Optimized Ultima" sync / 1[56]:The Emerald Weapon:5555:/
-79.1 "Split" sync / 1[56]:The Emerald Weapon:553A:/
-85.2 "Sidescathe" sync / 1[56]:The Emerald Weapon:(553F|5541):/
-95.0 "Emerald Crusher" sync / 1[56]:The Emerald Weapon:553E:/
+73.9 "Optimized Ultima" sync / 1[56]:[^:]*:The Emerald Weapon:5555:/
+79.1 "Split" sync / 1[56]:[^:]*:The Emerald Weapon:553A:/
+85.2 "Sidescathe" sync / 1[56]:[^:]*:The Emerald Weapon:(553F|5541):/
+95.0 "Emerald Crusher" sync / 1[56]:[^:]*:The Emerald Weapon:553E:/
 
-99.2 "--sync--" sync / 1[56]:The Emerald Weapon:5543:/
-108.6 "Emerald Beam" sync / 1[56]:The Emerald Weapon:5530:/
+99.2 "--sync--" sync / 1[56]:[^:]*:The Emerald Weapon:5543:/
+108.6 "Emerald Beam" sync / 1[56]:[^:]*:The Emerald Weapon:5530:/
 
-108.6 "Heat Ray" sync / 1[56]:The Emerald Weapon:4F9D:/ duration 9.7
-108.6 "Photon Laser" sync / 1[56]:The Emerald Weapon:5534:/
-110.6 "Photon Laser" sync / 1[56]:The Emerald Weapon:5536:/
-112.6 "Photon Laser" sync / 1[56]:The Emerald Weapon:5538:/
-114.4 "Photon Laser" sync / 1[56]:The Emerald Weapon:5534:/
-116.4 "Photon Laser" sync / 1[56]:The Emerald Weapon:5536:/
-118.4 "Photon Laser" sync / 1[56]:The Emerald Weapon:5538:/
-121.5 "--sync--" sync / 1[56]:The Emerald Weapon:5018:/
+108.6 "Heat Ray" sync / 1[56]:[^:]*:The Emerald Weapon:4F9D:/ duration 9.7
+108.6 "Photon Laser" sync / 1[56]:[^:]*:The Emerald Weapon:5534:/
+110.6 "Photon Laser" sync / 1[56]:[^:]*:The Emerald Weapon:5536:/
+112.6 "Photon Laser" sync / 1[56]:[^:]*:The Emerald Weapon:5538:/
+114.4 "Photon Laser" sync / 1[56]:[^:]*:The Emerald Weapon:5534:/
+116.4 "Photon Laser" sync / 1[56]:[^:]*:The Emerald Weapon:5536:/
+118.4 "Photon Laser" sync / 1[56]:[^:]*:The Emerald Weapon:5538:/
+121.5 "--sync--" sync / 1[56]:[^:]*:The Emerald Weapon:5018:/
 
-134.8 "Bit Storm" sync / 1[56]:The Emerald Weapon:554A:/
-134.8 "--sync--" sync / 1[56]:The Emerald Weapon:4F9C:/
-149.9 "Divide Et Impera" sync / 1[56]:The Emerald Weapon:5535:/
-162.2 "Magitek Magnetism" sync / 1[56]:The Emerald Weapon:5B06:/
-175.8 "--sync--" sync / 1[56]:The Emerald Weapon:5545:/
-176.6 "Explosion" sync / 1[56]:Magnetic Mine:5B04:/
+134.8 "Bit Storm" sync / 1[56]:[^:]*:The Emerald Weapon:554A:/
+134.8 "--sync--" sync / 1[56]:[^:]*:The Emerald Weapon:4F9C:/
+149.9 "Divide Et Impera" sync / 1[56]:[^:]*:The Emerald Weapon:5535:/
+162.2 "Magitek Magnetism" sync / 1[56]:[^:]*:The Emerald Weapon:5B06:/
+175.8 "--sync--" sync / 1[56]:[^:]*:The Emerald Weapon:5545:/
+176.6 "Explosion" sync / 1[56]:[^:]*:Magnetic Mine:5B04:/
 
-180.2 "Pulse Laser" sync / 1[56]:The Emerald Weapon:5547:/
-180.4 "Pulse Laser" sync / 1[56]:The Emerald Weapon:5548:/
-184.5 "Pulse Laser" sync / 1[56]:The Emerald Weapon:5547:/
-184.7 "Pulse Laser" sync / 1[56]:The Emerald Weapon:5548:/
-188.8 "Pulse Laser" sync / 1[56]:The Emerald Weapon:5547:/
-189.0 "Pulse Laser" sync / 1[56]:The Emerald Weapon:5548:/
-195.5 "--sync--" sync / 1[56]:The Emerald Weapon:5B1D:/
+180.2 "Pulse Laser" sync / 1[56]:[^:]*:The Emerald Weapon:5547:/
+180.4 "Pulse Laser" sync / 1[56]:[^:]*:The Emerald Weapon:5548:/
+184.5 "Pulse Laser" sync / 1[56]:[^:]*:The Emerald Weapon:5547:/
+184.7 "Pulse Laser" sync / 1[56]:[^:]*:The Emerald Weapon:5548:/
+188.8 "Pulse Laser" sync / 1[56]:[^:]*:The Emerald Weapon:5547:/
+189.0 "Pulse Laser" sync / 1[56]:[^:]*:The Emerald Weapon:5548:/
+195.5 "--sync--" sync / 1[56]:[^:]*:The Emerald Weapon:5B1D:/
 
-200.6 "Split" sync / 1[56]:The Emerald Weapon:553B:/
-211.7 "Bit Plasma" sync / 1[56]:Claw Bit:554F:/
-211.7 "Sidescathe" sync / 1[56]:The Emerald Weapon:(5540|5542):/
-219.2 "Bit Plasma" sync / 1[56]:Claw Bit:554F:/
-226.7 "Bit Plasma" sync / 1[56]:Claw Bit:554F:/
+200.6 "Split" sync / 1[56]:[^:]*:The Emerald Weapon:553B:/
+211.7 "Bit Plasma" sync / 1[56]:[^:]*:Claw Bit:554F:/
+211.7 "Sidescathe" sync / 1[56]:[^:]*:The Emerald Weapon:(5540|5542):/
+219.2 "Bit Plasma" sync / 1[56]:[^:]*:Claw Bit:554F:/
+226.7 "Bit Plasma" sync / 1[56]:[^:]*:Claw Bit:554F:/
 
-240.5 "Emerald Crusher" sync / 1[56]:The Emerald Weapon:553E:/
-244.8 "--sync--" sync / 1[56]:The Emerald Weapon:5544:/
-247.9 "--sync--" sync / 1[56]:The Emerald Weapon:5B1E:/
-260.1 "Magitek Magnetism" sync / 1[56]:The Emerald Weapon:5B06:/
-273.6 "--sync--" sync / 1[56]:The Emerald Weapon:5545:/
-274.4 "Explosion" sync / 1[56]:Magnetic Mine:5B04:/
-284.2 "Optimized Ultima" sync / 1[56]:The Emerald Weapon:5556:/
-296.4 "Emerald Shot" sync / 1[56]:The Emerald Weapon:5554:/
-308.7 "Optimized Ultima" sync / 1[56]:The Emerald Weapon:5556:/
-315.9 "--sync--" sync / 1[56]:The Emerald Weapon:5B1D:/
+240.5 "Emerald Crusher" sync / 1[56]:[^:]*:The Emerald Weapon:553E:/
+244.8 "--sync--" sync / 1[56]:[^:]*:The Emerald Weapon:5544:/
+247.9 "--sync--" sync / 1[56]:[^:]*:The Emerald Weapon:5B1E:/
+260.1 "Magitek Magnetism" sync / 1[56]:[^:]*:The Emerald Weapon:5B06:/
+273.6 "--sync--" sync / 1[56]:[^:]*:The Emerald Weapon:5545:/
+274.4 "Explosion" sync / 1[56]:[^:]*:Magnetic Mine:5B04:/
+284.2 "Optimized Ultima" sync / 1[56]:[^:]*:The Emerald Weapon:5556:/
+296.4 "Emerald Shot" sync / 1[56]:[^:]*:The Emerald Weapon:5554:/
+308.7 "Optimized Ultima" sync / 1[56]:[^:]*:The Emerald Weapon:5556:/
+315.9 "--sync--" sync / 1[56]:[^:]*:The Emerald Weapon:5B1D:/
 
 # TODO: loop???
 # TODO: there's sometimes a 5544/5B1E ability here?
-321.0 "Split" sync / 1[56]:The Emerald Weapon:553B:/ window 100,100 jump 200.6
-332.1 "Bit Plasma" #sync / 1[56]:Claw Bit:554F:/
-332.1 "Sidescathe" #sync / 1[56]:The Emerald Weapon:(5541|5542):/
-339.6 "Bit Plasma" #sync / 1[56]:Claw Bit:554F:/
-347.1 "Bit Plasma" #sync / 1[56]:Claw Bit:554F:/
+321.0 "Split" sync / 1[56]:[^:]*:The Emerald Weapon:553B:/ window 100,100 jump 200.6
+332.1 "Bit Plasma" #sync / 1[56]:[^:]*:Claw Bit:554F:/
+332.1 "Sidescathe" #sync / 1[56]:[^:]*:The Emerald Weapon:(5541|5542):/
+339.6 "Bit Plasma" #sync / 1[56]:[^:]*:Claw Bit:554F:/
+347.1 "Bit Plasma" #sync / 1[56]:[^:]*:Claw Bit:554F:/
 
 
 ### Intermission
 936.6 "--untargetable--"
-936.7 "--sync--" sync / 14:The Emerald Weapon:5B02:/ window 1000,10
-940.7 "Disruption Field" sync / 1[56]:The Emerald Weapon:5B02:/
+936.7 "--sync--" sync / 14:[^:]*:The Emerald Weapon:5B02:/ window 1000,10
+940.7 "Disruption Field" sync / 1[56]:[^:]*:The Emerald Weapon:5B02:/
 1000.0 "--targetable--"
 
 
 ### Phase 2 (checkpoint)
-1006.2 "--sync--" sync / 14:The Emerald Weapon:5539:/ window 1200,10
-1011.2 "Divide Et Impera" sync / 1[56]:The Emerald Weapon:5539:/
-1016.5 "--sync--" sync / 1[56]:The Emerald Weapon:5B1F:/
-1025.6 "Primus Terminus Est" sync / 1[56]:The Emerald Weapon:5562:/
-1037.7 "Secundus Terminus Est" sync / 1[56]:The Emerald Weapon:5567:/
+1006.2 "--sync--" sync / 14:[^:]*:The Emerald Weapon:5539:/ window 1200,10
+1011.2 "Divide Et Impera" sync / 1[56]:[^:]*:The Emerald Weapon:5539:/
+1016.5 "--sync--" sync / 1[56]:[^:]*:The Emerald Weapon:5B1F:/
+1025.6 "Primus Terminus Est" sync / 1[56]:[^:]*:The Emerald Weapon:5562:/
+1037.7 "Secundus Terminus Est" sync / 1[56]:[^:]*:The Emerald Weapon:5567:/
 
 # Swords
-1053.9 "Tertius Terminus Est" sync / 1[56]:The Emerald Weapon:556B:/
-1055.9 "Tertius Terminus Est 1" #sync / 1[56]:Bitblade:556C:/
-1057.4 "Tertius Terminus Est 2" #sync / 1[56]:Bitblade:556C:/
-1058.9 "Tertius Terminus Est 3" #sync / 1[56]:Bitblade:556C:/
-1063.9 "Tertius Terminus Est 1" #sync / 1[56]:The Emerald Weapon:556D:/
-1065.4 "Tertius Terminus Est 2" #sync / 1[56]:The Emerald Weapon:556D:/
-1066.9 "Tertius Terminus Est 3" #sync / 1[56]:The Emerald Weapon:556D:/
+1053.9 "Tertius Terminus Est" sync / 1[56]:[^:]*:The Emerald Weapon:556B:/
+1055.9 "Tertius Terminus Est 1" #sync / 1[56]:[^:]*:Bitblade:556C:/
+1057.4 "Tertius Terminus Est 2" #sync / 1[56]:[^:]*:Bitblade:556C:/
+1058.9 "Tertius Terminus Est 3" #sync / 1[56]:[^:]*:Bitblade:556C:/
+1063.9 "Tertius Terminus Est 1" #sync / 1[56]:[^:]*:The Emerald Weapon:556D:/
+1065.4 "Tertius Terminus Est 2" #sync / 1[56]:[^:]*:The Emerald Weapon:556D:/
+1066.9 "Tertius Terminus Est 3" #sync / 1[56]:[^:]*:The Emerald Weapon:556D:/
 
 # Soldier phase
-1070.1 "--sync--" sync / 1[56]:The Emerald Weapon:5B20:/
-1082.3 "Legio Phantasmatis" sync / 1[56]:The Emerald Weapon:5559:/
+1070.1 "--sync--" sync / 1[56]:[^:]*:The Emerald Weapon:5B20:/
+1082.3 "Legio Phantasmatis" sync / 1[56]:[^:]*:The Emerald Weapon:5559:/
 1084.3 "--untargetable--"
-1091.6 "Rank And File" sync / 1[56]:Black Wolf's Image:555A:/
+1091.6 "Rank And File" sync / 1[56]:[^:]*:Black Wolf's Image:555A:/
 
-1096.9 "Threefold Formation" sync / 1[56]:Black Wolf's Image:555D:/
-1104.8 "Fire Away" sync / 1[56]:Black Wolf's Image:555E:/
-1107.9 "Shots Fired 1" #sync / 1[56]:Imperial Image:555F:/
-1109.9 "Shots Fired 2" #sync / 1[56]:Imperial Image:555F:/
-1111.9 "Shots Fired 3" #sync / 1[56]:Imperial Image:555F:/
-1114.6 "Heirsbane" sync / 1[56]:Black Wolf's Image:5561:/
+1096.9 "Threefold Formation" sync / 1[56]:[^:]*:Black Wolf's Image:555D:/
+1104.8 "Fire Away" sync / 1[56]:[^:]*:Black Wolf's Image:555E:/
+1107.9 "Shots Fired 1" #sync / 1[56]:[^:]*:Imperial Image:555F:/
+1109.9 "Shots Fired 2" #sync / 1[56]:[^:]*:Imperial Image:555F:/
+1111.9 "Shots Fired 3" #sync / 1[56]:[^:]*:Imperial Image:555F:/
+1114.6 "Heirsbane" sync / 1[56]:[^:]*:Black Wolf's Image:5561:/
 
-1117.8 "Threefold Formation" sync / 1[56]:Black Wolf's Image:555D:/
-1125.4 "Fire Away" sync / 1[56]:Black Wolf's Image:555E:/
-1128.5 "Shots Fired 1" #sync / 1[56]:Imperial Image:555F:/
-1130.5 "Shots Fired 2" #sync / 1[56]:Imperial Image:555F:/
-1132.5 "Shots Fired 3" #sync / 1[56]:Imperial Image:555F:/
-1135.1 "Heirsbane" sync / 1[56]:Black Wolf's Image:5561:/
+1117.8 "Threefold Formation" sync / 1[56]:[^:]*:Black Wolf's Image:555D:/
+1125.4 "Fire Away" sync / 1[56]:[^:]*:Black Wolf's Image:555E:/
+1128.5 "Shots Fired 1" #sync / 1[56]:[^:]*:Imperial Image:555F:/
+1130.5 "Shots Fired 2" #sync / 1[56]:[^:]*:Imperial Image:555F:/
+1132.5 "Shots Fired 3" #sync / 1[56]:[^:]*:Imperial Image:555F:/
+1135.1 "Heirsbane" sync / 1[56]:[^:]*:Black Wolf's Image:5561:/
 1146.8 "--targetable--"
 
-1157.9 "Optimized Ultima" sync / 1[56]:The Emerald Weapon:5B0F:/
-1166.1 "--sync--" sync / 1[56]:The Emerald Weapon:5B1F:/
+1157.9 "Optimized Ultima" sync / 1[56]:[^:]*:The Emerald Weapon:5B0F:/
+1166.1 "--sync--" sync / 1[56]:[^:]*:The Emerald Weapon:5B1F:/
 
 # Swords
-1173.2 "Tertius Terminus Est" sync / 1[56]:The Emerald Weapon:556B:/
-1175.2 "Tertius Terminus Est 1" #sync / 1[56]:Bitblade:556C:/
-1176.7 "Tertius Terminus Est 2" #sync / 1[56]:Bitblade:556C:/
-1178.2 "Tertius Terminus Est 3" #sync / 1[56]:Bitblade:556C:/
-1183.2 "Tertius Terminus Est 1" #sync / 1[56]:The Emerald Weapon:556D:/
-1184.7 "Tertius Terminus Est 2" #sync / 1[56]:The Emerald Weapon:556D:/
-1186.2 "Tertius Terminus Est 3" #sync / 1[56]:The Emerald Weapon:556D:/
-1189.4 "--sync--" sync / 1[56]:The Emerald Weapon:5B20:/
+1173.2 "Tertius Terminus Est" sync / 1[56]:[^:]*:The Emerald Weapon:556B:/
+1175.2 "Tertius Terminus Est 1" #sync / 1[56]:[^:]*:Bitblade:556C:/
+1176.7 "Tertius Terminus Est 2" #sync / 1[56]:[^:]*:Bitblade:556C:/
+1178.2 "Tertius Terminus Est 3" #sync / 1[56]:[^:]*:Bitblade:556C:/
+1183.2 "Tertius Terminus Est 1" #sync / 1[56]:[^:]*:The Emerald Weapon:556D:/
+1184.7 "Tertius Terminus Est 2" #sync / 1[56]:[^:]*:The Emerald Weapon:556D:/
+1186.2 "Tertius Terminus Est 3" #sync / 1[56]:[^:]*:The Emerald Weapon:556D:/
+1189.4 "--sync--" sync / 1[56]:[^:]*:The Emerald Weapon:5B20:/
 
 # loop?
-1196.5 "Divide Et Impera" sync / 1[56]:The Emerald Weapon:5539:/ window 100,100 jump 1011.2
-1201.8 "--sync--" #sync / 1[56]:The Emerald Weapon:5B1F:/
-1210.9 "Primus Terminus Est" #sync / 1[56]:The Emerald Weapon:5562:/
-1223.0 "Secundus Terminus Est" #sync / 1[56]:The Emerald Weapon:5567:/
+1196.5 "Divide Et Impera" sync / 1[56]:[^:]*:The Emerald Weapon:5539:/ window 100,100 jump 1011.2
+1201.8 "--sync--" #sync / 1[56]:[^:]*:The Emerald Weapon:5B1F:/
+1210.9 "Primus Terminus Est" #sync / 1[56]:[^:]*:The Emerald Weapon:5562:/
+1223.0 "Secundus Terminus Est" #sync / 1[56]:[^:]*:The Emerald Weapon:5567:/

--- a/ui/raidboss/data/05-shb/trial/hades-ex.txt
+++ b/ui/raidboss/data/05-shb/trial/hades-ex.txt
@@ -11,7 +11,7 @@ hideall "--sync--"
 ### Phase 1
 0 "Start"
 0.0 "--sync--" sync /:Engage!/ window 0,1
-2.5 "--sync--" sync / 1[56]:Hades:368/ window 3,0
+2.5 "--sync--" sync / 1[56]:Hades:368:/ window 3,0
 10.7 "Ancient Double" sync / 1[56]:Hades:47A5:/ window 11,0
 19.8 "Shadow Spread" sync / 1[56]:Hades:47A9:/
 22.8 "Shadow Spread" sync / 1[56]:Hades:47AA:/

--- a/ui/raidboss/data/05-shb/trial/hades-ex.txt
+++ b/ui/raidboss/data/05-shb/trial/hades-ex.txt
@@ -11,28 +11,28 @@ hideall "--sync--"
 ### Phase 1
 0 "Start"
 0.0 "--sync--" sync /:Engage!/ window 0,1
-2.5 "--sync--" sync / 1[56]:Hades:368:/ window 3,0
-10.7 "Ancient Double" sync / 1[56]:Hades:47A5:/ window 11,0
-19.8 "Shadow Spread" sync / 1[56]:Hades:47A9:/
-22.8 "Shadow Spread" sync / 1[56]:Hades:47AA:/
-30.7 "Bad Faith" sync / 1[56]:Hades:(47AE|47AD):/
-33.8 "Bad Faith" sync / 1[56]:Hades:(47AF|47B0):/
-42.0 "Ravenous Assault" sync / 1[56]:Hades:47A6:/
-45.2 "Ravenous Assault" sync / 1[56]:Hades:47A7:/
-51.3 "Arcane Utterance" sync / 1[56]:Hades:47B3:/
-59.4 "Arcane Control" sync / 1[56]:Hades:47B4:/
-60.3 "Magic Chakram/Spear" #sync / 1[56]:Arcane Globe:47B5:/
-68.5 "Broken Faith" sync / 1[56]:Hades:47B1:/ duration 35.3
-107.8 "Arcane Utterance" sync / 1[56]:Hades:47B3:/
-115.9 "Arcane Control" sync / 1[56]:Hades:47B4:/
-116.8 "Magic Spear/Chakram" #sync / 1[56]:Arcane Font:47B6:/
-130.0 "Shadow Spread" sync / 1[56]:Hades:47A9:/
-133.0 "Shadow Spread" sync / 1[56]:Hades:47AA:/
-140.9 "Bad Faith" sync / 1[56]:Hades:(47AE|47AD):/
-144.0 "Bad Faith" sync / 1[56]:Hades:(47AF|47B0):/
-152.2 "Ravenous Assault" sync / 1[56]:Hades:47A6:/
-155.4 "Ravenous Assault" sync / 1[56]:Hades:47A7:/
-169.7 "Ancient Dark IV" sync / 1[56]:Hades:47B7:/
+2.5 "--sync--" sync / 1[56]:[^:]*:Hades:368:/ window 3,0
+10.7 "Ancient Double" sync / 1[56]:[^:]*:Hades:47A5:/ window 11,0
+19.8 "Shadow Spread" sync / 1[56]:[^:]*:Hades:47A9:/
+22.8 "Shadow Spread" sync / 1[56]:[^:]*:Hades:47AA:/
+30.7 "Bad Faith" sync / 1[56]:[^:]*:Hades:(47AE|47AD):/
+33.8 "Bad Faith" sync / 1[56]:[^:]*:Hades:(47AF|47B0):/
+42.0 "Ravenous Assault" sync / 1[56]:[^:]*:Hades:47A6:/
+45.2 "Ravenous Assault" sync / 1[56]:[^:]*:Hades:47A7:/
+51.3 "Arcane Utterance" sync / 1[56]:[^:]*:Hades:47B3:/
+59.4 "Arcane Control" sync / 1[56]:[^:]*:Hades:47B4:/
+60.3 "Magic Chakram/Spear" #sync / 1[56]:[^:]*:Arcane Globe:47B5:/
+68.5 "Broken Faith" sync / 1[56]:[^:]*:Hades:47B1:/ duration 35.3
+107.8 "Arcane Utterance" sync / 1[56]:[^:]*:Hades:47B3:/
+115.9 "Arcane Control" sync / 1[56]:[^:]*:Hades:47B4:/
+116.8 "Magic Spear/Chakram" #sync / 1[56]:[^:]*:Arcane Font:47B6:/
+130.0 "Shadow Spread" sync / 1[56]:[^:]*:Hades:47A9:/
+133.0 "Shadow Spread" sync / 1[56]:[^:]*:Hades:47AA:/
+140.9 "Bad Faith" sync / 1[56]:[^:]*:Hades:(47AE|47AD):/
+144.0 "Bad Faith" sync / 1[56]:[^:]*:Hades:(47AF|47B0):/
+152.2 "Ravenous Assault" sync / 1[56]:[^:]*:Hades:47A6:/
+155.4 "Ravenous Assault" sync / 1[56]:[^:]*:Hades:47A7:/
+169.7 "Ancient Dark IV" sync / 1[56]:[^:]*:Hades:47B7:/
 
 
 ### Phase 2
@@ -44,98 +44,98 @@ hideall "--sync--"
 # 00:0044:Hades:Come, Nabriales!
 # 00:0044:Hades:Tremble and fall to the ground before me!
 227.9 "--targetable--"
-232.0 "--sync--" sync / 14:Nabriales's Shade:47B8:/ window 232,0
-238.0 "Comet 1" #sync / 1[56]:Nabriales's Shade:4951:/
-241.0 "Comet 2" #sync / 1[56]:Nabriales's Shade:4951:/
-241.2 "Dark II" sync / 1[56]:Shadow of the Ancients:47BA:/
-243.9 "Comet 3" #sync / 1[56]:Nabriales's Shade:4951:/
-246.9 "Comet 4" #sync / 1[56]:Nabriales's Shade:4951:/
-254.2 "Ancient Water III" sync / 1[56]:Shadow of the Ancients:47BC:/
-254.2 "Ancient Darkness" sync / 1[56]:Shadow of the Ancients:47BB:/
-259.7 "Quake III" sync / 1[56]:Nabriales's Shade:47B8:/
+232.0 "--sync--" sync / 14:[^:]*:Nabriales's Shade:47B8:/ window 232,0
+238.0 "Comet 1" #sync / 1[56]:[^:]*:Nabriales's Shade:4951:/
+241.0 "Comet 2" #sync / 1[56]:[^:]*:Nabriales's Shade:4951:/
+241.2 "Dark II" sync / 1[56]:[^:]*:Shadow of the Ancients:47BA:/
+243.9 "Comet 3" #sync / 1[56]:[^:]*:Nabriales's Shade:4951:/
+246.9 "Comet 4" #sync / 1[56]:[^:]*:Nabriales's Shade:4951:/
+254.2 "Ancient Water III" sync / 1[56]:[^:]*:Shadow of the Ancients:47BC:/
+254.2 "Ancient Darkness" sync / 1[56]:[^:]*:Shadow of the Ancients:47BB:/
+259.7 "Quake III" sync / 1[56]:[^:]*:Nabriales's Shade:47B8:/
 # 00:0044:Hades:Emerge, Lahabrea! Rise, Igeyorhm!
 272.3 "--targetable--"
-277.5 "Annihilation" sync / 1[56]:Lahabrea's and Igeyorhm's Shades:47BF:/ window 50,10
-277.5 "Fire Sphere" #sync / 1[56]:Lahabrea's Shade:47BE:/
-277.5 "Blizzard Sphere" #sync / 1[56]:Igeyorhm's Shade:47BD:/
-295.6 "Fire IV" sync / 1[56]:Lahabrea's Shade:47C2:/
-295.6 "Blizzard IV" #sync / 1[56]:Igeyorhm's Shade:47C3:/
-299.5 "Dark Flame" sync / 1[56]:Shadow of the Ancients:47C6:/
-299.5 "Dark Freeze" #sync / 1[56]:Shadow of the Ancients:47C4:/
-307.6 "Annihilation" sync / 1[56]:Lahabrea's and Igeyorhm's Shades:47BF:/
-307.6 "Fire Sphere" #sync / 1[56]:Lahabrea's Shade:47BE:/
-307.6 "Blizzard Sphere" #sync / 1[56]:Igeyorhm's Shade:47BD:/
-320.8 "Fire IV" sync / 1[56]:Lahabrea's Shade:47C2:/
-320.8 "Blizzard IV" sync / 1[56]:Igeyorhm's Shade:47C3:/
-336.6 "Fire IV" sync / 1[56]:Lahabrea's Shade:47C2:/
-336.6 "Blizzard IV" sync / 1[56]:Igeyorhm's Shade:47C3:/
-355.2 "Shadow Flare" #sync / 1[56]:Lahabrea's Shade:47FD:/
+277.5 "Annihilation" sync / 1[56]:[^:]*:Lahabrea's and Igeyorhm's Shades:47BF:/ window 50,10
+277.5 "Fire Sphere" #sync / 1[56]:[^:]*:Lahabrea's Shade:47BE:/
+277.5 "Blizzard Sphere" #sync / 1[56]:[^:]*:Igeyorhm's Shade:47BD:/
+295.6 "Fire IV" sync / 1[56]:[^:]*:Lahabrea's Shade:47C2:/
+295.6 "Blizzard IV" #sync / 1[56]:[^:]*:Igeyorhm's Shade:47C3:/
+299.5 "Dark Flame" sync / 1[56]:[^:]*:Shadow of the Ancients:47C6:/
+299.5 "Dark Freeze" #sync / 1[56]:[^:]*:Shadow of the Ancients:47C4:/
+307.6 "Annihilation" sync / 1[56]:[^:]*:Lahabrea's and Igeyorhm's Shades:47BF:/
+307.6 "Fire Sphere" #sync / 1[56]:[^:]*:Lahabrea's Shade:47BE:/
+307.6 "Blizzard Sphere" #sync / 1[56]:[^:]*:Igeyorhm's Shade:47BD:/
+320.8 "Fire IV" sync / 1[56]:[^:]*:Lahabrea's Shade:47C2:/
+320.8 "Blizzard IV" sync / 1[56]:[^:]*:Igeyorhm's Shade:47C3:/
+336.6 "Fire IV" sync / 1[56]:[^:]*:Lahabrea's Shade:47C2:/
+336.6 "Blizzard IV" sync / 1[56]:[^:]*:Igeyorhm's Shade:47C3:/
+355.2 "Shadow Flare" #sync / 1[56]:[^:]*:Lahabrea's Shade:47FD:/
 
 
 ### Phase 3
 493.0 "--sync--" sync / 00:0044:Hades:Our plea transcends/ window 500,0
 # 00:0044:Hades:At last, you are one!
 499.9 "--targetable--"
-500.0 "--sync--" sync / 14:Ascian Prime's Shade:47C8:/ window 500,0
-510.0 "Universal Manipulation" sync / 1[56]:Ascian Prime's Shade:47C8:/
-520.2 "Ancient Circle" sync / 1[56]:Ascian Prime's Shade:47CA:/
-522.2 "Death Shriek" sync / 1[56]:Ascian Prime's Shade:47CB:/
-524.2 "Forked Lightning" sync / 1[56]:Ascian Prime's Shade:47C9:/
-531.2 "Blight" sync / 1[56]:Ascian Prime's Shade:47CC:/
-542.6 "Height Of Chaos" sync / 1[56]:Ascian Prime's Shade:47D1:/
-552.8 "Megiddo Flame" sync / 1[56]:Ascian Prime's Shade:47CD:/
-561.9 "Shadow Flare" sync / 1[56]:Ascian Prime's Shade:47D0:/
-569.4 "Ancient Eruption" sync / 1[56]:Ascian Prime's Shade:47D2:/
-580.8 "Shadow Flare" sync / 1[56]:Ascian Prime's Shade:47D0:/
-609.3 "Shadow Flare Enrage" sync / 1[56]:Ascian Prime's Shade:47D4:/
+500.0 "--sync--" sync / 14:[^:]*:Ascian Prime's Shade:47C8:/ window 500,0
+510.0 "Universal Manipulation" sync / 1[56]:[^:]*:Ascian Prime's Shade:47C8:/
+520.2 "Ancient Circle" sync / 1[56]:[^:]*:Ascian Prime's Shade:47CA:/
+522.2 "Death Shriek" sync / 1[56]:[^:]*:Ascian Prime's Shade:47CB:/
+524.2 "Forked Lightning" sync / 1[56]:[^:]*:Ascian Prime's Shade:47C9:/
+531.2 "Blight" sync / 1[56]:[^:]*:Ascian Prime's Shade:47CC:/
+542.6 "Height Of Chaos" sync / 1[56]:[^:]*:Ascian Prime's Shade:47D1:/
+552.8 "Megiddo Flame" sync / 1[56]:[^:]*:Ascian Prime's Shade:47CD:/
+561.9 "Shadow Flare" sync / 1[56]:[^:]*:Ascian Prime's Shade:47D0:/
+569.4 "Ancient Eruption" sync / 1[56]:[^:]*:Ascian Prime's Shade:47D2:/
+580.8 "Shadow Flare" sync / 1[56]:[^:]*:Ascian Prime's Shade:47D0:/
+609.3 "Shadow Flare Enrage" sync / 1[56]:[^:]*:Ascian Prime's Shade:47D4:/
 
 
 ### Phase 4
 750.2 "--sync--" sync / 22:........:Ascian Prime's Shade:........:Ascian Prime's Shade:00/ window 800,0
 799.9 "--targetable--"
-800.0 "--sync--" sync / 14:Hades:47D5:/ window 800,0
-804.0 "Again The Majestic" sync / 1[56]:Hades:47D5:/
-810.6 "Comet 1" sync / 1[56]:Hades:4952:/
-812.2 "Captivity" sync / 1[56]:Hades:47D[67]:/
-816.6 "Comet 2" sync / 1[56]:Hades:4952:/
-822.6 "Comet 3" sync / 1[56]:Hades:4952:/
-828.6 "Comet 4" sync / 1[56]:Hades:4952:/
-837.2 "Again The Martyr" sync / 1[56]:Hades:47DE:/
-846.3 "Wail Of The Lost" sync / 1[56]:Hades:47E1:/
-848.4 "Dark Flame" sync / 1[56]:Hades:47E0:/
-848.4 "Dark Freeze" sync / 1[56]:Hades:47DF:/
-856.5 "Again The Abyssal Celebrant" sync / 1[56]:Hades:47E2:/
-864.6 "Shadow Spread x3" #sync / 1[56]:Hades:47E4:/
-865.6 "Megiddo Flame x3" #sync / 1[56]:Hades:47E8:/
-865.6 "Nether Blast x3" #sync / 1[56]:Hades:47E6:/
-876.7 "Dark Seal" sync / 1[56]:Hades:47E9:/
-884.8 "Purgation/Stream" sync / 1[56]:Hades:47E[AB]:/
-892.9 "Stream/Purgation" sync / 1[56]:Hades:47E[AB]:/
-904.1 "Dark Seal" sync / 1[56]:Hades:47E9:/
-912.2 "Purgation/Stream" sync / 1[56]:Hades:47E[AB]:/
-918.3 "Stream/Purgation" sync / 1[56]:Hades:47E[AB]:/
-950.2 "Titanomachy Enrage" sync / 1[56]:Hades:47EF:/
+800.0 "--sync--" sync / 14:[^:]*:Hades:47D5:/ window 800,0
+804.0 "Again The Majestic" sync / 1[56]:[^:]*:Hades:47D5:/
+810.6 "Comet 1" sync / 1[56]:[^:]*:Hades:4952:/
+812.2 "Captivity" sync / 1[56]:[^:]*:Hades:47D[67]:/
+816.6 "Comet 2" sync / 1[56]:[^:]*:Hades:4952:/
+822.6 "Comet 3" sync / 1[56]:[^:]*:Hades:4952:/
+828.6 "Comet 4" sync / 1[56]:[^:]*:Hades:4952:/
+837.2 "Again The Martyr" sync / 1[56]:[^:]*:Hades:47DE:/
+846.3 "Wail Of The Lost" sync / 1[56]:[^:]*:Hades:47E1:/
+848.4 "Dark Flame" sync / 1[56]:[^:]*:Hades:47E0:/
+848.4 "Dark Freeze" sync / 1[56]:[^:]*:Hades:47DF:/
+856.5 "Again The Abyssal Celebrant" sync / 1[56]:[^:]*:Hades:47E2:/
+864.6 "Shadow Spread x3" #sync / 1[56]:[^:]*:Hades:47E4:/
+865.6 "Megiddo Flame x3" #sync / 1[56]:[^:]*:Hades:47E8:/
+865.6 "Nether Blast x3" #sync / 1[56]:[^:]*:Hades:47E6:/
+876.7 "Dark Seal" sync / 1[56]:[^:]*:Hades:47E9:/
+884.8 "Purgation/Stream" sync / 1[56]:[^:]*:Hades:47E[AB]:/
+892.9 "Stream/Purgation" sync / 1[56]:[^:]*:Hades:47E[AB]:/
+904.1 "Dark Seal" sync / 1[56]:[^:]*:Hades:47E9:/
+912.2 "Purgation/Stream" sync / 1[56]:[^:]*:Hades:47E[AB]:/
+918.3 "Stream/Purgation" sync / 1[56]:[^:]*:Hades:47E[AB]:/
+950.2 "Titanomachy Enrage" sync / 1[56]:[^:]*:Hades:47EF:/
 
 
 ### Phase 5
-1200.0 "--sync--" sync / 14:Hades:4948:/ window 1200,0
-1204.0 "Life In Captivity" sync / 1[56]:Hades:4948:/
-1207.2 "--sync--" sync / 1[56]:Hades:47D9:/
-1210.2 "--sync--" sync / 1[56]:Hades:4949:/
-1242.3 "--sync--" sync / 1[56]:Hades:494A:/
+1200.0 "--sync--" sync / 14:[^:]*:Hades:4948:/ window 1200,0
+1204.0 "Life In Captivity" sync / 1[56]:[^:]*:Hades:4948:/
+1207.2 "--sync--" sync / 1[56]:[^:]*:Hades:47D9:/
+1210.2 "--sync--" sync / 1[56]:[^:]*:Hades:4949:/
+1242.3 "--sync--" sync / 1[56]:[^:]*:Hades:494A:/
 1282.4 "--targetable--"
-1286.6 "Dark Current" sync / 1[56]:Hades:47F0:/
-1311.2 "Gigantomachy" sync / 1[56]:Hades:47F3:/
-1318.4 "--sync--" sync / 1[56]:Hades:47F4:/
-1318.8 "Quadrastrike 1" #sync / 1[56]:Hades:47F5:/
-1320.2 "Quadrastrike 2" #sync / 1[56]:Hades:47F5:/
-1323.8 "Quadrastrike Tower" sync / 1[56]:Hades:47F6:/
-1330.6 "Quadrastrike Bleed" sync / 1[56]:Hades:47F8:/
-1344.5 "Dark Current" sync / 1[56]:Hades:47F0:/
-1369.0 "Gigantomachy" sync / 1[56]:Hades:47F3:/
-1376.2 "--sync--" sync / 1[56]:Hades:47F4:/
-1376.6 "Quadrastrike 1" #sync / 1[56]:Hades:47F5:/
-1378.0 "Quadrastrike 2" #sync / 1[56]:Hades:47F5:/
-1381.7 "Quadrastrike Tower" sync / 1[56]:Hades:47F6:/
-1388.5 "Quadrastrike Bleed" sync / 1[56]:Hades:47F8:/
-1426.5 "Gigantomachy Enrage" sync / 1[56]:Hades:47F9:/
+1286.6 "Dark Current" sync / 1[56]:[^:]*:Hades:47F0:/
+1311.2 "Gigantomachy" sync / 1[56]:[^:]*:Hades:47F3:/
+1318.4 "--sync--" sync / 1[56]:[^:]*:Hades:47F4:/
+1318.8 "Quadrastrike 1" #sync / 1[56]:[^:]*:Hades:47F5:/
+1320.2 "Quadrastrike 2" #sync / 1[56]:[^:]*:Hades:47F5:/
+1323.8 "Quadrastrike Tower" sync / 1[56]:[^:]*:Hades:47F6:/
+1330.6 "Quadrastrike Bleed" sync / 1[56]:[^:]*:Hades:47F8:/
+1344.5 "Dark Current" sync / 1[56]:[^:]*:Hades:47F0:/
+1369.0 "Gigantomachy" sync / 1[56]:[^:]*:Hades:47F3:/
+1376.2 "--sync--" sync / 1[56]:[^:]*:Hades:47F4:/
+1376.6 "Quadrastrike 1" #sync / 1[56]:[^:]*:Hades:47F5:/
+1378.0 "Quadrastrike 2" #sync / 1[56]:[^:]*:Hades:47F5:/
+1381.7 "Quadrastrike Tower" sync / 1[56]:[^:]*:Hades:47F6:/
+1388.5 "Quadrastrike Bleed" sync / 1[56]:[^:]*:Hades:47F8:/
+1426.5 "Gigantomachy Enrage" sync / 1[56]:[^:]*:Hades:47F9:/

--- a/ui/raidboss/data/05-shb/trial/hades.txt
+++ b/ui/raidboss/data/05-shb/trial/hades.txt
@@ -9,28 +9,28 @@ hideall "Double"
 
 # Phase 1: Everybody Murdered By Circles
 0.0 "--sync--" sync /:Engage!/ window 0,1
-1.5 "--sync--" sync / 1[56]:Hades:368:/ window 2,0
-15.5 "Ravenous Assault" sync / 1[56]:Hades:4158:/ window 16,5
-25.9 "Bad Faith" sync / 1[56]:Hades:414[9A]:/
-32.9 "Double" sync / 1[56]:Hades:414F:/
-38.9 "Dark Eruption" sync / 1[56]:Hades:4150:/
-47.9 "Broken Faith" sync / 1[56]:Hades:414D:/ duration 22.5
-72.9 "Double" sync / 1[56]:Hades:414F:/
-78.9 "Shadow Spread" sync / 1[56]:Hades:4154:/
-84.9 "Shadow Spread" sync / 1[56]:Hades:4157:/
-90.9 "Ravenous Assault" sync / 1[56]:Hades:4158:/
+1.5 "--sync--" sync / 1[56]:[^:]*:Hades:368:/ window 2,0
+15.5 "Ravenous Assault" sync / 1[56]:[^:]*:Hades:4158:/ window 16,5
+25.9 "Bad Faith" sync / 1[56]:[^:]*:Hades:414[9A]:/
+32.9 "Double" sync / 1[56]:[^:]*:Hades:414F:/
+38.9 "Dark Eruption" sync / 1[56]:[^:]*:Hades:4150:/
+47.9 "Broken Faith" sync / 1[56]:[^:]*:Hades:414D:/ duration 22.5
+72.9 "Double" sync / 1[56]:[^:]*:Hades:414F:/
+78.9 "Shadow Spread" sync / 1[56]:[^:]*:Hades:4154:/
+84.9 "Shadow Spread" sync / 1[56]:[^:]*:Hades:4157:/
+90.9 "Ravenous Assault" sync / 1[56]:[^:]*:Hades:4158:/
 
-104.4 "Bad Faith" sync / 1[56]:Hades:414[9A]:/
-114.4 "Ravenous Assault" sync / 1[56]:Hades:4158:/
-122.4 "Double" sync / 1[56]:Hades:414F:/
-128.4 "Dark Eruption" sync / 1[56]:Hades:4150:/
-139.4 "Broken Faith" sync / 1[56]:Hades:414D:/ duration 22.5
-156.4 "Double" sync / 1[56]:Hades:414F:/
-162.4 "Shadow Spread" sync / 1[56]:Hades:4154:/
-168.4 "Shadow Spread" sync / 1[56]:Hades:4157:/
-175.4 "Ravenous Assault" sync / 1[56]:Hades:4158:/
+104.4 "Bad Faith" sync / 1[56]:[^:]*:Hades:414[9A]:/
+114.4 "Ravenous Assault" sync / 1[56]:[^:]*:Hades:4158:/
+122.4 "Double" sync / 1[56]:[^:]*:Hades:414F:/
+128.4 "Dark Eruption" sync / 1[56]:[^:]*:Hades:4150:/
+139.4 "Broken Faith" sync / 1[56]:[^:]*:Hades:414D:/ duration 22.5
+156.4 "Double" sync / 1[56]:[^:]*:Hades:414F:/
+162.4 "Shadow Spread" sync / 1[56]:[^:]*:Hades:4154:/
+168.4 "Shadow Spread" sync / 1[56]:[^:]*:Hades:4157:/
+175.4 "Ravenous Assault" sync / 1[56]:[^:]*:Hades:4158:/
 
-190.2 "Bad Faith" sync / 1[56]:Hades:414[9A]:/ window 80,80 jump 104.4
+190.2 "Bad Faith" sync / 1[56]:[^:]*:Hades:414[9A]:/ window 80,80 jump 104.4
 200.2 "Ravenous Assault"
 208.2 "Double"
 214.2 "Dark Eruption"
@@ -43,40 +43,40 @@ hideall "Double"
 
 # Phase 2: Push at 10%
 # (untargetable happens 2 seconds before :4599:, so no warning, sorry)
-300.0 "--sync--" sync / 1[56]:Hades:4599:/ window 300,0
+300.0 "--sync--" sync / 1[56]:[^:]*:Hades:4599:/ window 300,0
 # Give voice to your anguish, my brethren!
 304.5 "Adds (E/W)"
 
-400.0 "--sync--" sync / 14:Shadow .f .he Ancients:4593:/ window 500,0
-405.0 "Ancient Darkness" sync / 1[56]:Shadow .f .he Ancients:4593:/
-405.0 "Ancient Water III" sync / 1[56]:Shadow .f .he Ancients:4594:/
+400.0 "--sync--" sync / 14:[^:]*:Shadow .f .he Ancients:4593:/ window 500,0
+405.0 "Ancient Darkness" sync / 1[56]:[^:]*:Shadow .f .he Ancients:4593:/
+405.0 "Ancient Water III" sync / 1[56]:[^:]*:Shadow .f .he Ancients:4594:/
 # Give substance to our hopes, our dreams, our prayers...
 408.0 "Adds (NE/SW)"
 
-500.0 "--sync--" sync / 14:Shadow .f .he Ancients:4595:/ window 600,0
-505.0 "Ancient Aero" sync / 1[56]:Shadow .f .he Ancients:4595:/
-508.0 "Ancient Water III" sync / 1[56]:Shadow .f .he Ancients:4594:/
-508.0 "Ancient Darkness" sync / 1[56]:Shadow .f .he Ancients:4593:/
+500.0 "--sync--" sync / 14:[^:]*:Shadow .f .he Ancients:4595:/ window 600,0
+505.0 "Ancient Aero" sync / 1[56]:[^:]*:Shadow .f .he Ancients:4595:/
+508.0 "Ancient Water III" sync / 1[56]:[^:]*:Shadow .f .he Ancients:4594:/
+508.0 "Ancient Darkness" sync / 1[56]:[^:]*:Shadow .f .he Ancients:4593:/
 # And by their undeniable grace, may our perfect world rise anew!
 510.0 "Adds (N/S)"
 
 # Yawn wide, the ever-hungering void!
-600.0 "--sync--" sync / 14:Hades:4597:/ window 600,0
-605.0 "Ancient Dark IV" sync / 1[56]:Hades:4597:/
+600.0 "--sync--" sync / 14:[^:]*:Hades:4597:/ window 600,0
+605.0 "Ancient Dark IV" sync / 1[56]:[^:]*:Hades:4597:/
 
 
 # Phase 3: neo hades
 666.8 "--targetable--"
-666.8 "--sync--" sync / 1[56]:Hades:417C:/ window 680,0
-680.8 "Titanomachy" sync / 1[56]:Hades:4180:/ window 80,5
-689.8 "Shadow Stream" sync / 1[56]:Hades:415C:/
-696.8 "Dual Strike" sync / 1[56]:Hades:4161:/
-711.8 "Echo Of The Lost" sync / 1[56]:Hades:416[34]:/
-720.8 "Polydegmon's Purgation" sync / 1[56]:Hades:4170:/
-729.8 "Titanomachy" sync / 1[56]:Hades:4180:/
-739.8 "Hellborn Yawp" sync / 1[56]:Hades:416E:/
+666.8 "--sync--" sync / 1[56]:[^:]*:Hades:417C:/ window 680,0
+680.8 "Titanomachy" sync / 1[56]:[^:]*:Hades:4180:/ window 80,5
+689.8 "Shadow Stream" sync / 1[56]:[^:]*:Hades:415C:/
+696.8 "Dual Strike" sync / 1[56]:[^:]*:Hades:4161:/
+711.8 "Echo Of The Lost" sync / 1[56]:[^:]*:Hades:416[34]:/
+720.8 "Polydegmon's Purgation" sync / 1[56]:[^:]*:Hades:4170:/
+729.8 "Titanomachy" sync / 1[56]:[^:]*:Hades:4180:/
+739.8 "Hellborn Yawp" sync / 1[56]:[^:]*:Hades:416E:/
 
-780.1 "Titanomachy" sync / 1[56]:Hades:4180:/ window 40,40 jump 680.8
+780.1 "Titanomachy" sync / 1[56]:[^:]*:Hades:4180:/ window 40,40 jump 680.8
 789.1 "Shadow Stream"
 796.1 "Dual Strike"
 811.1 "Echo Of The Lost"
@@ -88,41 +88,41 @@ hideall "Double"
 # There is technically an echo of the lost before this captivity
 # but impossible to properly sync that given that the previous phase
 # also uses that ability.
-895.0 "--sync--" sync / 14:Hades:4168:/ window 300,0
-900.0 "Captivity" sync / 1[56]:Hades:4168:/
+895.0 "--sync--" sync / 14:[^:]*:Hades:4168:/ window 300,0
+900.0 "Captivity" sync / 1[56]:[^:]*:Hades:4168:/
 900.8 "--fetters--"
-903.0 "--sync--" sync / 1[56]:Hades:417F:/
+903.0 "--sync--" sync / 1[56]:[^:]*:Hades:417F:/
 905.0 "Gaol Add"
-906.5 "--sync--" sync / 14:Hades:416C:/
-936.2 "Chorus Of The Lost" sync / 1[56]:416C:Hades:/
+906.5 "--sync--" sync / 14:[^:]*:Hades:416C:/
+936.2 "Chorus Of The Lost" sync / 1[56]:[^:]*:416C:Hades:/
 # FIXME: I've never seen this go off, so unclear how far 416D is from 416C.
 # Chorus of the lost does seem likely to be 30 seconds.
-939.0 "--sync--" sync / 1[56]:Hades:416D:/ window 100,0
+939.0 "--sync--" sync / 1[56]:[^:]*:Hades:416D:/ window 100,0
 
-952.0 "Dual Strike" sync / 1[56]:Hades:4161:/ window 50,5
-953.0 "Nether Blast x6" duration 5 #sync / 1[56]:Hades:4173:/
+952.0 "Dual Strike" sync / 1[56]:[^:]*:Hades:4161:/ window 50,5
+953.0 "Nether Blast x6" duration 5 #sync / 1[56]:[^:]*:Hades:4173:/
 962.3 "Doom"
 
-985.0 "Wail Of The Lost" sync / 1[56]:Hades:416[56]:/
-993.0 "Stream/Purgation?" sync / 1[56]:Hades:(415C|4170):/
-1002.0 "Titanomachy" sync / 1[56]:Hades:4180:/
-1011.0 "Hellborn Yawp" sync / 1[56]:Hades:416E:/
-1021.0 "Echo Of The Lost" sync / 1[56]:Hades:416[34]:/
-1031.0 "Dual Strike" sync / 1[56]:Hades:4161:/
-1039.0 "Titanomachy" sync / 1[56]:Hades:4180:/
-1046.0 "Shadow Spread" sync / 1[56]:Hades:415D:/
-1051.0 "Nether Blast x6" duration 5 #sync / 1[56]:Hades:4173:/
+985.0 "Wail Of The Lost" sync / 1[56]:[^:]*:Hades:416[56]:/
+993.0 "Stream/Purgation?" sync / 1[56]:[^:]*:Hades:(415C|4170):/
+1002.0 "Titanomachy" sync / 1[56]:[^:]*:Hades:4180:/
+1011.0 "Hellborn Yawp" sync / 1[56]:[^:]*:Hades:416E:/
+1021.0 "Echo Of The Lost" sync / 1[56]:[^:]*:Hades:416[34]:/
+1031.0 "Dual Strike" sync / 1[56]:[^:]*:Hades:4161:/
+1039.0 "Titanomachy" sync / 1[56]:[^:]*:Hades:4180:/
+1046.0 "Shadow Spread" sync / 1[56]:[^:]*:Hades:415D:/
+1051.0 "Nether Blast x6" duration 5 #sync / 1[56]:[^:]*:Hades:4173:/
 
-1062.0 "Captivity" sync / 1[56]:Hades:4168:/ window 150,10
+1062.0 "Captivity" sync / 1[56]:[^:]*:Hades:4168:/ window 150,10
 1062.8 "--fetters--"
-1065.0 "--sync--" sync / 1[56]:Hades:417F:/
+1065.0 "--sync--" sync / 1[56]:[^:]*:Hades:417F:/
 1066.0 "Doom"
 1067.0 "Gaol Add"
-1068.5 "--sync--" sync / 14:Hades:416C:/
-1098.2 "Chorus Of The Lost" sync / 1[56]:Hades:416C:/
-1101.0 "--sync--" sync / 1[56]:Hades:416D:/ window 100,0
+1068.5 "--sync--" sync / 14:[^:]*:Hades:416C:/
+1098.2 "Chorus Of The Lost" sync / 1[56]:[^:]*:Hades:416C:/
+1101.0 "--sync--" sync / 1[56]:[^:]*:Hades:416D:/ window 100,0
 
-1114.0 "Wail Of The Lost" sync / 1[56]:Hades:416[56]:/ window 50,5 jump 985
+1114.0 "Wail Of The Lost" sync / 1[56]:[^:]*:Hades:416[56]:/ window 50,5 jump 985
 1122.0 "Stream/Purgation?"
 1131.0 "Titanomachy"
 1140.0 "Hellborn Yawp"
@@ -133,21 +133,21 @@ hideall "Double"
 
 
 # Cutscene: Push at 30%?
-1300.0 "--sync--" sync / 14:Hades:4175:/ window 1300,0
+1300.0 "--sync--" sync / 14:[^:]*:Hades:4175:/ window 1300,0
 1304.0 "--untargetable--"
-1304.0 "Life In Captivity" sync / 1[56]:Hades:4175:/
-1307.0 "--sync--" sync / 1[56]:Hades:417F:/
-1307.0 "--sync--" sync / 1[56]:Hades:442C:/
-1310.0 "--sync--" sync / 1[56]:Hades:4176:/
-1342.0 "Black Cauldron" sync / 1[56]:Hades:415A:/
+1304.0 "Life In Captivity" sync / 1[56]:[^:]*:Hades:4175:/
+1307.0 "--sync--" sync / 1[56]:[^:]*:Hades:417F:/
+1307.0 "--sync--" sync / 1[56]:[^:]*:Hades:442C:/
+1310.0 "--sync--" sync / 1[56]:[^:]*:Hades:4176:/
+1342.0 "Black Cauldron" sync / 1[56]:[^:]*:Hades:415A:/
 
 # Final dps race
 1354.0 "--targetable--"
-1361.0 "The Dark Devours x5" sync / 1[56]:Hades:4177:/ duration 9
-1376.0 "The Dark Devours x5" sync / 1[56]:Hades:4177:/ duration 9
-1391.0 "The Dark Devours x5" sync / 1[56]:Hades:4177:/ duration 9
-1403.0 "--sync--" sync / 1[56]:Hades:4159:/
+1361.0 "The Dark Devours x5" sync / 1[56]:[^:]*:Hades:4177:/ duration 9
+1376.0 "The Dark Devours x5" sync / 1[56]:[^:]*:Hades:4177:/ duration 9
+1391.0 "The Dark Devours x5" sync / 1[56]:[^:]*:Hades:4177:/ duration 9
+1403.0 "--sync--" sync / 1[56]:[^:]*:Hades:4159:/
 
 # Gratuitous 45 second enrage.
-1412.7 "--sync--" sync / 14:Hades:417B:/ window 100,100
-1457.7 "Enrage" sync / 1[56]:Hades:417B:/
+1412.7 "--sync--" sync / 14:[^:]*:Hades:417B:/ window 100,100
+1457.7 "Enrage" sync / 1[56]:[^:]*:Hades:417B:/

--- a/ui/raidboss/data/05-shb/trial/innocence-ex.txt
+++ b/ui/raidboss/data/05-shb/trial/innocence-ex.txt
@@ -13,126 +13,126 @@ hideall "Soul And Body"
 ### Phase 1
 0 "Start"
 0.0 "--sync--" sync /:Engage!/ window 0,1
-1.0 "--sync--" sync / 1[56]:Innocence:3ECA:/ window 2,0
-17.0 "Shadowreaver" sync / 1[56]:Innocence:3EEA:/ window 20,5
-28.0 "Winged Rep Tethers" sync / 1[56]:Innocence:40BD:/
-37.0 "Duel Descent" sync / 1[56]:Nail of Condemnation:3EA9:/
-47.0 "Righteous Bolt" sync / 1[56]:Innocence:3ECD:/
-58.0 "Winged Rep Tethers" sync / 1[56]:Innocence:40BD:/
-61.0 "--sync--" sync / 1[56]:Innocence:3EA2:/
-65.2 "Rightful Reprobation" sync / 1[56]:Innocence:3EDC:/
-67.0 "Duel Descent" sync / 1[56]:Nail of Condemnation:3EA9:/
-72.1 "Reprobation" sync / 1[56]:Innocence:3ECC:/
-81.2 "Winged Rep Rotate" sync / 1[56]:Innocence:40BD:/
-95.2 "Drop Of Light" sync / 1[56]:Innocence:3EEC:/
-107.8 "Righteous Bolt" sync / 1[56]:Innocence:3ECD:/
-118.8 "Winged Rep Trident" sync / 1[56]:Innocence:40BD:/
-121.8 "--sync--" sync / 1[56]:Innocence:3EA2:/
-124.8 "Holy Trinity" #sync / 1[56]:Innocence:3EDB:/
-125.8 "Rightful Reprobation" sync / 1[56]:Innocence:3EDD:/
-129.3 "Holy Trinity" #sync / 1[56]:Innocence:3EDB:/
-132.6 "Reprobation" sync / 1[56]:Innocence:3ECC:/
-133.7 "Holy Trinity" #sync / 1[56]:Innocence:3EDB:/
-137.0 "Light Pillar" sync / 1[56]:Innocence:3EED:/
-144.0 "Shadowreaver" sync / 1[56]:Innocence:3EEA:/
+1.0 "--sync--" sync / 1[56]:[^:]*:Innocence:3ECA:/ window 2,0
+17.0 "Shadowreaver" sync / 1[56]:[^:]*:Innocence:3EEA:/ window 20,5
+28.0 "Winged Rep Tethers" sync / 1[56]:[^:]*:Innocence:40BD:/
+37.0 "Duel Descent" sync / 1[56]:[^:]*:Nail of Condemnation:3EA9:/
+47.0 "Righteous Bolt" sync / 1[56]:[^:]*:Innocence:3ECD:/
+58.0 "Winged Rep Tethers" sync / 1[56]:[^:]*:Innocence:40BD:/
+61.0 "--sync--" sync / 1[56]:[^:]*:Innocence:3EA2:/
+65.2 "Rightful Reprobation" sync / 1[56]:[^:]*:Innocence:3EDC:/
+67.0 "Duel Descent" sync / 1[56]:[^:]*:Nail of Condemnation:3EA9:/
+72.1 "Reprobation" sync / 1[56]:[^:]*:Innocence:3ECC:/
+81.2 "Winged Rep Rotate" sync / 1[56]:[^:]*:Innocence:40BD:/
+95.2 "Drop Of Light" sync / 1[56]:[^:]*:Innocence:3EEC:/
+107.8 "Righteous Bolt" sync / 1[56]:[^:]*:Innocence:3ECD:/
+118.8 "Winged Rep Trident" sync / 1[56]:[^:]*:Innocence:40BD:/
+121.8 "--sync--" sync / 1[56]:[^:]*:Innocence:3EA2:/
+124.8 "Holy Trinity" #sync / 1[56]:[^:]*:Innocence:3EDB:/
+125.8 "Rightful Reprobation" sync / 1[56]:[^:]*:Innocence:3EDD:/
+129.3 "Holy Trinity" #sync / 1[56]:[^:]*:Innocence:3EDB:/
+132.6 "Reprobation" sync / 1[56]:[^:]*:Innocence:3ECC:/
+133.7 "Holy Trinity" #sync / 1[56]:[^:]*:Innocence:3EDB:/
+137.0 "Light Pillar" sync / 1[56]:[^:]*:Innocence:3EED:/
+144.0 "Shadowreaver" sync / 1[56]:[^:]*:Innocence:3EEA:/
 # technically Tethers + Rotate
-155.0 "Winged Rep Tethers" sync / 1[56]:Innocence:40BD:/
-161.0 "Soul And Body" sync / 1[56]:Innocence:3ED7:/
-161.0 "Duel Descent" sync / 1[56]:Nail of Condemnation:3EA9:/
+155.0 "Winged Rep Tethers" sync / 1[56]:[^:]*:Innocence:40BD:/
+161.0 "Soul And Body" sync / 1[56]:[^:]*:Innocence:3ED7:/
+161.0 "Duel Descent" sync / 1[56]:[^:]*:Nail of Condemnation:3EA9:/
 
 
 ### Phase 2: Adds
-178.0 "--untargetable--" sync / 1[56]:Innocence:3EA2:/
-180.3 "--targetable--" sync / 1[56]:Innocence:42B0:/ window 200,200
-183.3 "--sync--" sync / 1[56]:Sword of Condemnation:42B1:/
-190.3 "Scold's Bridle" sync / 1[56]:Forgiven Shame:3EC8:/
-195.3 "Holy Sword" sync / 1[56]:Forgiven Venery:3EC9:/
-197.3 "Guiding Light" sync / 1[56]:Innocence:3F46:/
-211.3 "Holy Sword" sync / 1[56]:Forgiven Venery:3EC9:/
-213.3 "Guiding Light" sync / 1[56]:Innocence:3F46:/
-227.3 "Holy Sword" sync / 1[56]:Forgiven Venery:3EC9:/
+178.0 "--untargetable--" sync / 1[56]:[^:]*:Innocence:3EA2:/
+180.3 "--targetable--" sync / 1[56]:[^:]*:Innocence:42B0:/ window 200,200
+183.3 "--sync--" sync / 1[56]:[^:]*:Sword of Condemnation:42B1:/
+190.3 "Scold's Bridle" sync / 1[56]:[^:]*:Forgiven Shame:3EC8:/
+195.3 "Holy Sword" sync / 1[56]:[^:]*:Forgiven Venery:3EC9:/
+197.3 "Guiding Light" sync / 1[56]:[^:]*:Innocence:3F46:/
+211.3 "Holy Sword" sync / 1[56]:[^:]*:Forgiven Venery:3EC9:/
+213.3 "Guiding Light" sync / 1[56]:[^:]*:Innocence:3F46:/
+227.3 "Holy Sword" sync / 1[56]:[^:]*:Forgiven Venery:3EC9:/
 230.3 "Enrage"
 
 
 ### Phase 3: Starbirth
-300.0 "--sync--" sync / 1[56]:Sword of Condemnation:3EE9:/ window 300,0
+300.0 "--sync--" sync / 1[56]:[^:]*:Sword of Condemnation:3EE9:/ window 300,0
 314.0 "--targetable--"
-323.0 "Starbirth Corner" sync / 1[56]:Innocence:3EEF:/
-336.0 "Shadowreaver" sync / 1[56]:Innocence:3EEA:/
-337.0 "Explosion" sync / 1[56]:Innocence:3EF0:/
-347.0 "Winged Rep Rotate" sync / 1[56]:Innocence:40BD:/
-353.0 "Soul And Body" sync / 1[56]:Innocence:3ED9:/
-359.0 "--sync--" sync / 1[56]:Innocence:3EA2:/
-363.0 "Rightful Reprobation" sync / 1[56]:Innocence:3EDD:/
-367.0 "--jump--" sync / 1[56]:Innocence:3EA2:/
-369.8 "Reprobation" sync / 1[56]:Innocence:3ECC:/
-373.7 "Beatific Vision" sync / 1[56]:Innocence:3EEE:/
-389.7 "Righteous Bolt" sync / 1[56]:Innocence:3ECD:/
+323.0 "Starbirth Corner" sync / 1[56]:[^:]*:Innocence:3EEF:/
+336.0 "Shadowreaver" sync / 1[56]:[^:]*:Innocence:3EEA:/
+337.0 "Explosion" sync / 1[56]:[^:]*:Innocence:3EF0:/
+347.0 "Winged Rep Rotate" sync / 1[56]:[^:]*:Innocence:40BD:/
+353.0 "Soul And Body" sync / 1[56]:[^:]*:Innocence:3ED9:/
+359.0 "--sync--" sync / 1[56]:[^:]*:Innocence:3EA2:/
+363.0 "Rightful Reprobation" sync / 1[56]:[^:]*:Innocence:3EDD:/
+367.0 "--jump--" sync / 1[56]:[^:]*:Innocence:3EA2:/
+369.8 "Reprobation" sync / 1[56]:[^:]*:Innocence:3ECC:/
+373.7 "Beatific Vision" sync / 1[56]:[^:]*:Innocence:3EEE:/
+389.7 "Righteous Bolt" sync / 1[56]:[^:]*:Innocence:3ECD:/
 
-400.7 "Starbirth Avoid" sync / 1[56]:Innocence:3EEF:/
-407.7 "Drop Of Light 1" #sync / 1[56]:Innocence:3EEC:/
-412.8 "Drop Of Light 2" #sync / 1[56]:Innocence:3EEC:/
-419.7 "Light Pillar" sync / 1[56]:Innocence:3EED:/
-421.7 "--jump--" sync / 1[56]:Innocence:3EA2:/
-428.3 "Beatific Vision" sync / 1[56]:Innocence:3EEE:/
-441.3 "--sync--" sync / 1[56]:Innocence:3EA2:/
-445.4 "Rightful Reprobation" sync / 1[56]:Innocence:3EDC:/
-452.3 "Reprobation" sync / 1[56]:Innocence:3ECC:/
-452.9 "God Ray x3" sync / 1[56]:Innocence:3EE6:/ window 5,1 duration 10
-469.9 "Shadowreaver" sync / 1[56]:Innocence:3EEA:/
-480.9 "Righteous Bolt" sync / 1[56]:Innocence:3ECD:/
+400.7 "Starbirth Avoid" sync / 1[56]:[^:]*:Innocence:3EEF:/
+407.7 "Drop Of Light 1" #sync / 1[56]:[^:]*:Innocence:3EEC:/
+412.8 "Drop Of Light 2" #sync / 1[56]:[^:]*:Innocence:3EEC:/
+419.7 "Light Pillar" sync / 1[56]:[^:]*:Innocence:3EED:/
+421.7 "--jump--" sync / 1[56]:[^:]*:Innocence:3EA2:/
+428.3 "Beatific Vision" sync / 1[56]:[^:]*:Innocence:3EEE:/
+441.3 "--sync--" sync / 1[56]:[^:]*:Innocence:3EA2:/
+445.4 "Rightful Reprobation" sync / 1[56]:[^:]*:Innocence:3EDC:/
+452.3 "Reprobation" sync / 1[56]:[^:]*:Innocence:3ECC:/
+452.9 "God Ray x3" sync / 1[56]:[^:]*:Innocence:3EE6:/ window 5,1 duration 10
+469.9 "Shadowreaver" sync / 1[56]:[^:]*:Innocence:3EEA:/
+480.9 "Righteous Bolt" sync / 1[56]:[^:]*:Innocence:3ECD:/
 
-489.9 "Starbirth Explode" sync / 1[56]:Innocence:3EEF:/
-494.9 "Winged Rep Trident" sync / 1[56]:Innocence:40BD:/
-500.9 "Holy Trinity" #sync / 1[56]:Innocence:3EDB:/
-505.4 "Holy Trinity" #sync / 1[56]:Innocence:3EDB:/
-509.9 "Holy Trinity" #sync / 1[56]:Innocence:3EDB:/
-514.2 "Light Pillar" sync / 1[56]:Innocence:3EED:/
-523.2 "Shadowreaver" sync / 1[56]:Innocence:3EEA:/
-538.3 "Righteous Bolt" sync / 1[56]:Innocence:3ECD:/
+489.9 "Starbirth Explode" sync / 1[56]:[^:]*:Innocence:3EEF:/
+494.9 "Winged Rep Trident" sync / 1[56]:[^:]*:Innocence:40BD:/
+500.9 "Holy Trinity" #sync / 1[56]:[^:]*:Innocence:3EDB:/
+505.4 "Holy Trinity" #sync / 1[56]:[^:]*:Innocence:3EDB:/
+509.9 "Holy Trinity" #sync / 1[56]:[^:]*:Innocence:3EDB:/
+514.2 "Light Pillar" sync / 1[56]:[^:]*:Innocence:3EED:/
+523.2 "Shadowreaver" sync / 1[56]:[^:]*:Innocence:3EEA:/
+538.3 "Righteous Bolt" sync / 1[56]:[^:]*:Innocence:3ECD:/
 # technical tethers + trident
-547.3 "Winged Rep Tethers" sync / 1[56]:Innocence:40BD:/
-553.3 "Holy Trinity" #sync / 1[56]:Innocence:3EDB:/
-553.3 "Duel Descent" sync / 1[56]:Nail of Condemnation:3EA9:/
-557.8 "Holy Trinity" #sync / 1[56]:Innocence:3EDB:/
+547.3 "Winged Rep Tethers" sync / 1[56]:[^:]*:Innocence:40BD:/
+553.3 "Holy Trinity" #sync / 1[56]:[^:]*:Innocence:3EDB:/
+553.3 "Duel Descent" sync / 1[56]:[^:]*:Nail of Condemnation:3EA9:/
+557.8 "Holy Trinity" #sync / 1[56]:[^:]*:Innocence:3EDB:/
 # technically trident + rotate
-561.3 "Winged Rep Trident" sync / 1[56]:Innocence:40BD:/
-562.3 "Holy Trinity" #sync / 1[56]:Innocence:3EDB:/
-562.3 "Holy Trinity" #sync / 1[56]:Innocence:3EDB:/
+561.3 "Winged Rep Trident" sync / 1[56]:[^:]*:Innocence:40BD:/
+562.3 "Holy Trinity" #sync / 1[56]:[^:]*:Innocence:3EDB:/
+562.3 "Holy Trinity" #sync / 1[56]:[^:]*:Innocence:3EDB:/
 
-570.3 "Starbirth Charge" sync / 1[56]:Innocence:3EEF:/
-573.3 "--jump--" sync / 1[56]:Innocence:3EA2:/
-579.9 "Beatific Vision" sync / 1[56]:Innocence:3EEE:/
-592.9 "--sync--" sync / 1[56]:Innocence:3EA2:/
-597.1 "Rightful Reprobation" sync / 1[56]:Innocence:3EDC:/
-598.9 "Drop Of Light 1" #sync / 1[56]:Innocence:3EEC:/
-604.0 "Reprobation" sync / 1[56]:Innocence:3ECC:/
-604.8 "Drop Of Light 2" #sync / 1[56]:Innocence:3EEC:/
-613.4 "Winged Rep Tethers" sync / 1[56]:Innocence:40BD:/
-622.4 "Duel Descent" sync / 1[56]:Nail of Condemnation:3EA9:/
-623.4 "Righteous Bolt" sync / 1[56]:Innocence:3ECD:/
+570.3 "Starbirth Charge" sync / 1[56]:[^:]*:Innocence:3EEF:/
+573.3 "--jump--" sync / 1[56]:[^:]*:Innocence:3EA2:/
+579.9 "Beatific Vision" sync / 1[56]:[^:]*:Innocence:3EEE:/
+592.9 "--sync--" sync / 1[56]:[^:]*:Innocence:3EA2:/
+597.1 "Rightful Reprobation" sync / 1[56]:[^:]*:Innocence:3EDC:/
+598.9 "Drop Of Light 1" #sync / 1[56]:[^:]*:Innocence:3EEC:/
+604.0 "Reprobation" sync / 1[56]:[^:]*:Innocence:3ECC:/
+604.8 "Drop Of Light 2" #sync / 1[56]:[^:]*:Innocence:3EEC:/
+613.4 "Winged Rep Tethers" sync / 1[56]:[^:]*:Innocence:40BD:/
+622.4 "Duel Descent" sync / 1[56]:[^:]*:Nail of Condemnation:3EA9:/
+623.4 "Righteous Bolt" sync / 1[56]:[^:]*:Innocence:3ECD:/
 
-634.4 "Starbirth Avoid" sync / 1[56]:Innocence:3EEF:/
-641.4 "Drop Of Light 1" #sync / 1[56]:Innocence:3EEC:/
-646.5 "Drop Of Light 2" #sync / 1[56]:Innocence:3EEC:/
-653.4 "Light Pillar" sync / 1[56]:Innocence:3EED:/
-655.4 "--jump--" sync / 1[56]:Innocence:3EA2:/
-662.1 "Beatific Vision" sync / 1[56]:Innocence:3EEE:/
-675.2 "--sync--" sync / 1[56]:Innocence:3EA2:/
-679.4 "Rightful Reprobation" sync / 1[56]:Innocence:3EDC:/
-686.3 "Reprobation" sync / 1[56]:Innocence:3ECC:/
-686.9 "God Ray x3" sync / 1[56]:Innocence:3EE6:/ window 5,1 duration 10
-703.9 "Shadowreaver" sync / 1[56]:Innocence:3EEA:/
-714.9 "Righteous Bolt" sync / 1[56]:Innocence:3ECD:/
+634.4 "Starbirth Avoid" sync / 1[56]:[^:]*:Innocence:3EEF:/
+641.4 "Drop Of Light 1" #sync / 1[56]:[^:]*:Innocence:3EEC:/
+646.5 "Drop Of Light 2" #sync / 1[56]:[^:]*:Innocence:3EEC:/
+653.4 "Light Pillar" sync / 1[56]:[^:]*:Innocence:3EED:/
+655.4 "--jump--" sync / 1[56]:[^:]*:Innocence:3EA2:/
+662.1 "Beatific Vision" sync / 1[56]:[^:]*:Innocence:3EEE:/
+675.2 "--sync--" sync / 1[56]:[^:]*:Innocence:3EA2:/
+679.4 "Rightful Reprobation" sync / 1[56]:[^:]*:Innocence:3EDC:/
+686.3 "Reprobation" sync / 1[56]:[^:]*:Innocence:3ECC:/
+686.9 "God Ray x3" sync / 1[56]:[^:]*:Innocence:3EE6:/ window 5,1 duration 10
+703.9 "Shadowreaver" sync / 1[56]:[^:]*:Innocence:3EEA:/
+714.9 "Righteous Bolt" sync / 1[56]:[^:]*:Innocence:3ECD:/
 
-723.9 "Starbirth Final" sync / 1[56]:Innocence:3EEF:/
-728.9 "Winged Rep Trident" sync / 1[56]:Innocence:40BD:/
-734.9 "Holy Trinity" #sync / 1[56]:Innocence:3EDB:/
-739.4 "Holy Trinity" #sync / 1[56]:Innocence:3EDB:/
-740.4 "--sync--" sync / 1[56]:Innocence:3EA2:/
-743.9 "Holy Trinity" #sync / 1[56]:Innocence:3EDB:/
+723.9 "Starbirth Final" sync / 1[56]:[^:]*:Innocence:3EEF:/
+728.9 "Winged Rep Trident" sync / 1[56]:[^:]*:Innocence:40BD:/
+734.9 "Holy Trinity" #sync / 1[56]:[^:]*:Innocence:3EDB:/
+739.4 "Holy Trinity" #sync / 1[56]:[^:]*:Innocence:3EDB:/
+740.4 "--sync--" sync / 1[56]:[^:]*:Innocence:3EA2:/
+743.9 "Holy Trinity" #sync / 1[56]:[^:]*:Innocence:3EDB:/
 
-741.7 "--sync--" sync / 14:Innocence:3EEF:/ window 10,10
-744.7 "Starbirth Final" sync / 1[56]:Innocence:3EEF:/
-764.7 "Beatific Vision" sync / 1[56]:Innocence:3EF1:/
-765.6 "Explosion Enrage" sync / 1[56]:Innocence:3EF0:/
+741.7 "--sync--" sync / 14:[^:]*:Innocence:3EEF:/ window 10,10
+744.7 "Starbirth Final" sync / 1[56]:[^:]*:Innocence:3EEF:/
+764.7 "Beatific Vision" sync / 1[56]:[^:]*:Innocence:3EF1:/
+765.6 "Explosion Enrage" sync / 1[56]:[^:]*:Innocence:3EF0:/

--- a/ui/raidboss/data/05-shb/trial/innocence.txt
+++ b/ui/raidboss/data/05-shb/trial/innocence.txt
@@ -9,84 +9,84 @@ hideall "--sync--"
 ### Phase 1
 0 "Start"
 0.0 "--sync--" sync /:Engage!/ window 0,1
-1.0 "--sync--" sync / 1[56]:Innocence:3E90:/ window 1,0
-15.0 "Realmrazer" sync / 1[56]:Innocence:3E9A:/ window 15,5
-28.2 "Heavenly Host" sync / 1[56]:Innocence:3E95:/
-54.9 "Daybreak" sync / 1[56]:Innocence:3E9D:/
-69.1 "Enthrall" sync / 1[56]:Innocence:3E99:/
-71.1 "Sinsphere" sync / 1[56]:Innocence:3E97:/
-80.3 "Heavenly Host" sync / 1[56]:Innocence:3E95:/
-82.4 "--center--" sync / 1[56]:Innocence:3E91:/
-86.7 "Guiding Light" sync / 1[56]:Innocence:3E96:/
-100.4 "Daybreak" sync / 1[56]:Innocence:3E9D:/
-111.5 "Realmrazer" sync / 1[56]:Innocence:3E9A:/
-123.6 "Enthrall" sync / 1[56]:Innocence:3E99:/
-125.8 "Sinsphere" sync / 1[56]:Innocence:3E97:/
+1.0 "--sync--" sync / 1[56]:[^:]*:Innocence:3E90:/ window 1,0
+15.0 "Realmrazer" sync / 1[56]:[^:]*:Innocence:3E9A:/ window 15,5
+28.2 "Heavenly Host" sync / 1[56]:[^:]*:Innocence:3E95:/
+54.9 "Daybreak" sync / 1[56]:[^:]*:Innocence:3E9D:/
+69.1 "Enthrall" sync / 1[56]:[^:]*:Innocence:3E99:/
+71.1 "Sinsphere" sync / 1[56]:[^:]*:Innocence:3E97:/
+80.3 "Heavenly Host" sync / 1[56]:[^:]*:Innocence:3E95:/
+82.4 "--center--" sync / 1[56]:[^:]*:Innocence:3E91:/
+86.7 "Guiding Light" sync / 1[56]:[^:]*:Innocence:3E96:/
+100.4 "Daybreak" sync / 1[56]:[^:]*:Innocence:3E9D:/
+111.5 "Realmrazer" sync / 1[56]:[^:]*:Innocence:3E9A:/
+123.6 "Enthrall" sync / 1[56]:[^:]*:Innocence:3E99:/
+125.8 "Sinsphere" sync / 1[56]:[^:]*:Innocence:3E97:/
 
 # aoe spam until low
-200.0 "--north--" sync / 1[56]:Innocence:3E91:/ window 100,0
-205.5 "--sync--" sync / 1[56]:Innocence:3E92:/ window 200,0
-209.2 "Exalted Wing" #sync / 1[56]:Innocence:3E93:/
-215.6 "Exalted Wing" sync / 1[56]:Innocence:3E93:/ window 0,30
-220.6 "Exalted Wing" #sync / 1[56]:Innocence:3E93:/
-225.6 "Exalted Wing" #sync / 1[56]:Innocence:3E93:/
-230.6 "Exalted Wing" #sync / 1[56]:Innocence:3E93:/
-235.6 "Exalted Wing" #sync / 1[56]:Innocence:3E93:/
-240.6 "Exalted Wing" #sync / 1[56]:Innocence:3E93:/
-245.6 "Exalted Wing" #sync / 1[56]:Innocence:3E93:/
-250.6 "Exalted Wing" #sync / 1[56]:Innocence:3E93:/
+200.0 "--north--" sync / 1[56]:[^:]*:Innocence:3E91:/ window 100,0
+205.5 "--sync--" sync / 1[56]:[^:]*:Innocence:3E92:/ window 200,0
+209.2 "Exalted Wing" #sync / 1[56]:[^:]*:Innocence:3E93:/
+215.6 "Exalted Wing" sync / 1[56]:[^:]*:Innocence:3E93:/ window 0,30
+220.6 "Exalted Wing" #sync / 1[56]:[^:]*:Innocence:3E93:/
+225.6 "Exalted Wing" #sync / 1[56]:[^:]*:Innocence:3E93:/
+230.6 "Exalted Wing" #sync / 1[56]:[^:]*:Innocence:3E93:/
+235.6 "Exalted Wing" #sync / 1[56]:[^:]*:Innocence:3E93:/
+240.6 "Exalted Wing" #sync / 1[56]:[^:]*:Innocence:3E93:/
+245.6 "Exalted Wing" #sync / 1[56]:[^:]*:Innocence:3E93:/
+250.6 "Exalted Wing" #sync / 1[56]:[^:]*:Innocence:3E93:/
 
 # ye olde cutscene
-300.0 "--sync--" sync / 1[56]:Innocence:4144:/ window 300,0
-302.5 "Exalted Plumes" sync / 1[56]:Innocence:3EF2:/
-306.6 "--sync--" sync / 1[56]:Innocence:3EA1:/
-306.6 "--sync--" sync / 1[56]:Innocence:3E94:/
-363.2 "Righteous Bolt" sync / 1[56]:Innocence:3EA3:/
-372.4 "Winged Reprobation" sync / 1[56]:Innocence:40BC:/
-378.5 "Holy Trinity" #sync / 1[56]:Innocence:3EB3:/
-383.6 "Holy Trinity" #sync / 1[56]:Innocence:3EB3:/
-388.7 "Holy Trinity" #sync / 1[56]:Innocence:3EB3:/
-397.6 "Winged Reprobation" sync / 1[56]:Innocence:40BC:/
-403.8 "Soul And Body" sync / 1[56]:Innocence:3EB1:/
-416.7 "--sync--" sync / 1[56]:Innocence:3EA2:/
-420.9 "Rightful Reprobation" sync / 1[56]:Innocence:3EB5:/
-428.2 "Righteous Bolt" sync / 1[56]:Innocence:3EA3:/
-430.7 "Reprobation" sync / 1[56]:Innocence:3ECB:/
-439.3 "Shadowreaver" sync / 1[56]:Innocence:3EEA:/
+300.0 "--sync--" sync / 1[56]:[^:]*:Innocence:4144:/ window 300,0
+302.5 "Exalted Plumes" sync / 1[56]:[^:]*:Innocence:3EF2:/
+306.6 "--sync--" sync / 1[56]:[^:]*:Innocence:3EA1:/
+306.6 "--sync--" sync / 1[56]:[^:]*:Innocence:3E94:/
+363.2 "Righteous Bolt" sync / 1[56]:[^:]*:Innocence:3EA3:/
+372.4 "Winged Reprobation" sync / 1[56]:[^:]*:Innocence:40BC:/
+378.5 "Holy Trinity" #sync / 1[56]:[^:]*:Innocence:3EB3:/
+383.6 "Holy Trinity" #sync / 1[56]:[^:]*:Innocence:3EB3:/
+388.7 "Holy Trinity" #sync / 1[56]:[^:]*:Innocence:3EB3:/
+397.6 "Winged Reprobation" sync / 1[56]:[^:]*:Innocence:40BC:/
+403.8 "Soul And Body" sync / 1[56]:[^:]*:Innocence:3EB1:/
+416.7 "--sync--" sync / 1[56]:[^:]*:Innocence:3EA2:/
+420.9 "Rightful Reprobation" sync / 1[56]:[^:]*:Innocence:3EB5:/
+428.2 "Righteous Bolt" sync / 1[56]:[^:]*:Innocence:3EA3:/
+430.7 "Reprobation" sync / 1[56]:[^:]*:Innocence:3ECB:/
+439.3 "Shadowreaver" sync / 1[56]:[^:]*:Innocence:3EEA:/
 
 # add phase with manacles
-449.5 "--add Phase--" sync / 1[56]:Innocence:3EA2:/
-451.9 "--untargetable--" sync / 1[56]:Innocence:42B0:/
+449.5 "--add Phase--" sync / 1[56]:[^:]*:Innocence:3EA2:/
+451.9 "--untargetable--" sync / 1[56]:[^:]*:Innocence:42B0:/
 
 # looping final phase
-579.8 "Flaming Sword" sync / 1[56]:Sword of Condemnation:3EC1:/ window 600,0
-588.6 "Flaming Sword" sync / 1[56]:Innocence:4708:/
-600.0 "--targetable--" sync / 1[56]:Innocence:3EA2:/
-605.7 "God Ray" #sync / 1[56]:Innocence:3EBE:/
-610.8 "God Ray" #sync / 1[56]:Innocence:3EBE:/
-615.9 "God Ray" #sync / 1[56]:Innocence:3EBE:/
-618.1 "--sync--" sync / 1[56]:Innocence:38FC:/
-623.1 "Light Pillar" sync / 1[56]:Innocence:3F3E:/
-632.6 "Winged Reprobation" sync / 1[56]:Innocence:40BC:/
-638.6 "Holy Trinity" #sync / 1[56]:Innocence:3EB3:/
-638.6 "Soul And Body" sync / 1[56]:Innocence:3EB1:/
-643.7 "Holy Trinity" #sync / 1[56]:Innocence:3EB3:/
-644.6 "Righteous Bolt" sync / 1[56]:Innocence:3EA3:/
-648.8 "Holy Trinity" #sync / 1[56]:Innocence:3EB3:/
-651.8 "--jump--" sync / 1[56]:Innocence:3EA2:/
-658.5 "Beatific Vision" sync / 1[56]:Innocence:3EC7:/
-676.8 "Shadowreaver" sync / 1[56]:Innocence:3EEA:/
-685.0 "--sync--" sync / 1[56]:Innocence:3EA2:/
-689.2 "Rightful Reprobation" sync / 1[56]:Innocence:3EB5:/
-695.8 "Drop Of Light" sync / 1[56]:Innocence:3EC4:/
-697.9 "--sync--" sync / 1[56]:Innocence:38FC:/
-699.1 "Reprobation" sync / 1[56]:Innocence:3ECB:/
-702.9 "Light Pillar" sync / 1[56]:Innocence:3F3E:/
-707.4 "--jump--" sync / 1[56]:Innocence:3EA2:/
-714.2 "Beatific Vision" sync / 1[56]:Innocence:3EC7:/
-730.4 "Righteous Bolt" sync / 1[56]:Innocence:3EA3:/
+579.8 "Flaming Sword" sync / 1[56]:[^:]*:Sword of Condemnation:3EC1:/ window 600,0
+588.6 "Flaming Sword" sync / 1[56]:[^:]*:Innocence:4708:/
+600.0 "--targetable--" sync / 1[56]:[^:]*:Innocence:3EA2:/
+605.7 "God Ray" #sync / 1[56]:[^:]*:Innocence:3EBE:/
+610.8 "God Ray" #sync / 1[56]:[^:]*:Innocence:3EBE:/
+615.9 "God Ray" #sync / 1[56]:[^:]*:Innocence:3EBE:/
+618.1 "--sync--" sync / 1[56]:[^:]*:Innocence:38FC:/
+623.1 "Light Pillar" sync / 1[56]:[^:]*:Innocence:3F3E:/
+632.6 "Winged Reprobation" sync / 1[56]:[^:]*:Innocence:40BC:/
+638.6 "Holy Trinity" #sync / 1[56]:[^:]*:Innocence:3EB3:/
+638.6 "Soul And Body" sync / 1[56]:[^:]*:Innocence:3EB1:/
+643.7 "Holy Trinity" #sync / 1[56]:[^:]*:Innocence:3EB3:/
+644.6 "Righteous Bolt" sync / 1[56]:[^:]*:Innocence:3EA3:/
+648.8 "Holy Trinity" #sync / 1[56]:[^:]*:Innocence:3EB3:/
+651.8 "--jump--" sync / 1[56]:[^:]*:Innocence:3EA2:/
+658.5 "Beatific Vision" sync / 1[56]:[^:]*:Innocence:3EC7:/
+676.8 "Shadowreaver" sync / 1[56]:[^:]*:Innocence:3EEA:/
+685.0 "--sync--" sync / 1[56]:[^:]*:Innocence:3EA2:/
+689.2 "Rightful Reprobation" sync / 1[56]:[^:]*:Innocence:3EB5:/
+695.8 "Drop Of Light" sync / 1[56]:[^:]*:Innocence:3EC4:/
+697.9 "--sync--" sync / 1[56]:[^:]*:Innocence:38FC:/
+699.1 "Reprobation" sync / 1[56]:[^:]*:Innocence:3ECB:/
+702.9 "Light Pillar" sync / 1[56]:[^:]*:Innocence:3F3E:/
+707.4 "--jump--" sync / 1[56]:[^:]*:Innocence:3EA2:/
+714.2 "Beatific Vision" sync / 1[56]:[^:]*:Innocence:3EC7:/
+730.4 "Righteous Bolt" sync / 1[56]:[^:]*:Innocence:3EA3:/
 
-738.5 "--targetable--" sync / 1[56]:Innocence:3EA2:/ window 10,10 jump 600
+738.5 "--targetable--" sync / 1[56]:[^:]*:Innocence:3EA2:/ window 10,10 jump 600
 744.2 "God Ray"
 749.3 "God Ray"
 754.4 "God Ray"

--- a/ui/raidboss/data/05-shb/trial/levi-un.txt
+++ b/ui/raidboss/data/05-shb/trial/levi-un.txt
@@ -40,151 +40,151 @@ hideall "--sync--"
 ### Phase 1: Literally Just Autos (100% -> 90%)
 0.0 "Start"
 0.0 "--sync--" sync /:Engage!/ window 0,1
-2.7 "--sync--" sync / 1[56]:Leviathan:5CC8:/ window 3,1
+2.7 "--sync--" sync / 1[56]:[^:]*:Leviathan:5CC8:/ window 3,1
 25.8 "--untargetable--" sync / 22:........:Leviathan:........:Leviathan:00/ window 30,10
 
 ### Phase 2: One Set of Orbs (90% -> 50%?)
 33.0 "--targetable--"
-33.1 "Body Slam" sync / 1[56]:Leviathan:5CD2:/ window 40,10
-38.3 "Veil Of The Whorl" sync / 1[56]:Leviathan:5CE5:/ window 40,10
-43.3 "Mantle Of The Whorl" sync / 1[56]:Leviathan's Tail:5CE4:/
+33.1 "Body Slam" sync / 1[56]:[^:]*:Leviathan:5CD2:/ window 40,10
+38.3 "Veil Of The Whorl" sync / 1[56]:[^:]*:Leviathan:5CE5:/ window 40,10
+43.3 "Mantle Of The Whorl" sync / 1[56]:[^:]*:Leviathan's Tail:5CE4:/
 45.6 "--2x Wavespine Sahagin (N)--"
-53.2 "Aqua Breath" sync / 1[56]:Leviathan:5CCD:/
-59.3 "Tail Whip" sync / 1[56]:Leviathan's Tail:5CCE:/
-60.4 "Waterspout" sync / 1[56]:Leviathan:5CD0:/
-73.8 "Dread Tide" sync / 1[56]:Leviathan:5CC9:/
-77.9 "Tidal Roar" sync / 1[56]:Leviathan:5CDA:/
+53.2 "Aqua Breath" sync / 1[56]:[^:]*:Leviathan:5CCD:/
+59.3 "Tail Whip" sync / 1[56]:[^:]*:Leviathan's Tail:5CCE:/
+60.4 "Waterspout" sync / 1[56]:[^:]*:Leviathan:5CD0:/
+73.8 "Dread Tide" sync / 1[56]:[^:]*:Leviathan:5CC9:/
+77.9 "Tidal Roar" sync / 1[56]:[^:]*:Leviathan:5CDA:/
 
 85.2 "--untargetable--"
-88.3 "Grand Fall" sync / 1[56]:Leviathan:5CDF:/
-90.8 "Spinning Dive" sync / 1[56]:Leviathan:5CDB:/
-94.3 "Grand Fall" sync / 1[56]:Leviathan:5CDF:/
-95.8 "Spinning Dive" sync / 1[56]:Leviathan:5CDB:/
+88.3 "Grand Fall" sync / 1[56]:[^:]*:Leviathan:5CDF:/
+90.8 "Spinning Dive" sync / 1[56]:[^:]*:Leviathan:5CDB:/
+94.3 "Grand Fall" sync / 1[56]:[^:]*:Leviathan:5CDF:/
+95.8 "Spinning Dive" sync / 1[56]:[^:]*:Leviathan:5CDB:/
 101.5 "--targetable--"
 
-101.6 "Body Slam" sync / 1[56]:Leviathan:5CD2:/ window 30,30
-106.0 "Briny Veil" sync / 1[56]:Leviathan:5CE1:/
+101.6 "Body Slam" sync / 1[56]:[^:]*:Leviathan:5CD2:/ window 30,30
+106.0 "Briny Veil" sync / 1[56]:[^:]*:Leviathan:5CE1:/
 110.7 "--Wavetooth Sahagin (E)--"
-121.0 "Dread Tide" sync / 1[56]:Leviathan:5CC9:/
-125.1 "Aqua Breath" sync / 1[56]:Leviathan:5CCD:/
-126.0 "Tail Whip" sync / 1[56]:Leviathan's Tail:5CCE:/
-132.3 "Waterspout" sync / 1[56]:Leviathan:5CD0:/
-145.7 "Dread Tide" sync / 1[56]:Leviathan:5CC9:/
-149.8 "Tidal Roar" sync / 1[56]:Leviathan:5CDA:/
+121.0 "Dread Tide" sync / 1[56]:[^:]*:Leviathan:5CC9:/
+125.1 "Aqua Breath" sync / 1[56]:[^:]*:Leviathan:5CCD:/
+126.0 "Tail Whip" sync / 1[56]:[^:]*:Leviathan's Tail:5CCE:/
+132.3 "Waterspout" sync / 1[56]:[^:]*:Leviathan:5CD0:/
+145.7 "Dread Tide" sync / 1[56]:[^:]*:Leviathan:5CC9:/
+149.8 "Tidal Roar" sync / 1[56]:[^:]*:Leviathan:5CDA:/
 
 154.9 "--untargetable--"
-158.0 "Grand Fall x3" #sync / 1[56]:Leviathan:5CDF:/
-160.5 "Spinning Dive" sync / 1[56]:Leviathan:5CDB:/
-165.4 "Spinning Dive" sync / 1[56]:Leviathan:5CDB:/
+158.0 "Grand Fall x3" #sync / 1[56]:[^:]*:Leviathan:5CDF:/
+160.5 "Spinning Dive" sync / 1[56]:[^:]*:Leviathan:5CDB:/
+165.4 "Spinning Dive" sync / 1[56]:[^:]*:Leviathan:5CDB:/
 171.1 "--targetable--"
 
-171.2 "Body Slam" sync / 1[56]:Leviathan:5CD2:/ window 30,30
+171.2 "Body Slam" sync / 1[56]:[^:]*:Leviathan:5CD2:/ window 30,30
 180.8 "--4x Gyre Spume--"
-192.7 "Dread Tide" sync / 1[56]:Leviathan:5CC9:/
-196.3 "Tail Whip" #sync / 1[56]:Leviathan's Tail:5CCE:/
-196.8 "Aqua Breath" sync / 1[56]:Leviathan:5CCD:/
-204.0 "Waterspout" sync / 1[56]:Leviathan:5CD0:/
-217.3 "Dread Tide" sync / 1[56]:Leviathan:5CC9:/
-221.4 "Tidal Roar" sync / 1[56]:Leviathan:5CDA:/
+192.7 "Dread Tide" sync / 1[56]:[^:]*:Leviathan:5CC9:/
+196.3 "Tail Whip" #sync / 1[56]:[^:]*:Leviathan's Tail:5CCE:/
+196.8 "Aqua Breath" sync / 1[56]:[^:]*:Leviathan:5CCD:/
+204.0 "Waterspout" sync / 1[56]:[^:]*:Leviathan:5CD0:/
+217.3 "Dread Tide" sync / 1[56]:[^:]*:Leviathan:5CC9:/
+221.4 "Tidal Roar" sync / 1[56]:[^:]*:Leviathan:5CDA:/
 
 228.9 "--untargetable--"
-232.0 "Grand Fall x3" #sync / 1[56]:Leviathan:5CDF:/
-234.5 "Spinning Dive" sync / 1[56]:Leviathan:5CDB:/
-239.4 "Spinning Dive" sync / 1[56]:Leviathan:5CDB:/
+232.0 "Grand Fall x3" #sync / 1[56]:[^:]*:Leviathan:5CDF:/
+234.5 "Spinning Dive" sync / 1[56]:[^:]*:Leviathan:5CDB:/
+239.4 "Spinning Dive" sync / 1[56]:[^:]*:Leviathan:5CDB:/
 245.1 "--targetable--"
 
-245.2 "Body Slam" sync / 1[56]:Leviathan:5CD2:/ window 30,30
-267.5 "Dread Tide" sync / 1[56]:Leviathan:5CC9:/
+245.2 "Body Slam" sync / 1[56]:[^:]*:Leviathan:5CD2:/ window 30,30
+267.5 "Dread Tide" sync / 1[56]:[^:]*:Leviathan:5CC9:/
 
 275.2 "--untargetable--"
-278.3 "Grand Fall" sync / 1[56]:Leviathan:5CDF:/
-280.8 "Spinning Dive" sync / 1[56]:Leviathan:5CDB:/
+278.3 "Grand Fall" sync / 1[56]:[^:]*:Leviathan:5CDF:/
+280.8 "Spinning Dive" sync / 1[56]:[^:]*:Leviathan:5CDB:/
 280.8 "--untargetable--"
-286.5 "Tidal Wave" sync / 1[56]:Leviathan:5CDE:/ window 300,100
+286.5 "Tidal Wave" sync / 1[56]:[^:]*:Leviathan:5CDE:/ window 300,100
 
 
 ### Phase 3: Two Sets of Orbs (50% -> 20%?)
 299.2 "--targetable--"
-299.3 "Body Slam" sync / 1[56]:Leviathan:5CD2:/ window 30,30
+299.3 "Body Slam" sync / 1[56]:[^:]*:Leviathan:5CD2:/ window 30,30
 301.3 "--2x Wavespine Sahagin (S)--"
-318.6 "Aqua Breath" sync / 1[56]:Leviathan:5CCD:/
-318.6 "Tail Whip" #sync / 1[56]:Leviathan's Tail:5CCE:/
-322.7 "Waterspout" sync / 1[56]:Leviathan:5CD0:/
-329.9 "Dread Tide" sync / 1[56]:Leviathan:5CC9:/
-338.1 "Tidal Roar" sync / 1[56]:Leviathan:5CDA:/
+318.6 "Aqua Breath" sync / 1[56]:[^:]*:Leviathan:5CCD:/
+318.6 "Tail Whip" #sync / 1[56]:[^:]*:Leviathan's Tail:5CCE:/
+322.7 "Waterspout" sync / 1[56]:[^:]*:Leviathan:5CD0:/
+329.9 "Dread Tide" sync / 1[56]:[^:]*:Leviathan:5CC9:/
+338.1 "Tidal Roar" sync / 1[56]:[^:]*:Leviathan:5CDA:/
 
 347.3 "--untargetable--"
-350.4 "Grand Fall" sync / 1[56]:Leviathan:5CDF:/
-352.9 "Spinning Dive" sync / 1[56]:Leviathan:5CDB:/
-357.8 "Spinning Dive" sync / 1[56]:Leviathan:5CDB:/
+350.4 "Grand Fall" sync / 1[56]:[^:]*:Leviathan:5CDF:/
+352.9 "Spinning Dive" sync / 1[56]:[^:]*:Leviathan:5CDB:/
+357.8 "Spinning Dive" sync / 1[56]:[^:]*:Leviathan:5CDB:/
 
 363.5 "--targetable--"
-363.6 "Body Slam" sync / 1[56]:Leviathan:5CD2:/ window 30,30
+363.6 "Body Slam" sync / 1[56]:[^:]*:Leviathan:5CD2:/ window 30,30
 364.9 "--4x Gyre Spume--"
-382.9 "Aqua Breath" sync / 1[56]:Leviathan:5CCD:/
-385.0 "Tail Whip" #sync / 1[56]:Leviathan's Tail:5CCE:/
-387.1 "Waterspout" sync / 1[56]:Leviathan:5CD0:/
-394.3 "Dread Tide" sync / 1[56]:Leviathan:5CC9:/
+382.9 "Aqua Breath" sync / 1[56]:[^:]*:Leviathan:5CCD:/
+385.0 "Tail Whip" #sync / 1[56]:[^:]*:Leviathan's Tail:5CCE:/
+387.1 "Waterspout" sync / 1[56]:[^:]*:Leviathan:5CD0:/
+394.3 "Dread Tide" sync / 1[56]:[^:]*:Leviathan:5CC9:/
 402.4 "--4x Wave Spume--"
-402.5 "Tidal Roar" sync / 1[56]:Leviathan:5CDA:/
+402.5 "Tidal Roar" sync / 1[56]:[^:]*:Leviathan:5CDA:/
 
 413.8 "--untargetable--"
-416.9 "Grand Fall x3" #sync / 1[56]:Leviathan:5CDF:/
-419.4 "Spinning Dive" sync / 1[56]:Leviathan:5CDB:/
+416.9 "Grand Fall x3" #sync / 1[56]:[^:]*:Leviathan:5CDF:/
+419.4 "Spinning Dive" sync / 1[56]:[^:]*:Leviathan:5CDB:/
 
 
 425.1 "--targetable--"
-425.2 "Body Slam" sync / 1[56]:Leviathan:5CD2:/
-435.3 "Dread Tide" sync / 1[56]:Leviathan:5CC9:/
-439.6 "Aqua Burst" sync / 1[56]:Wave Spume:888:/
-442.5 "Aqua Breath" sync / 1[56]:Leviathan:5CCD:/
-446.6 "Waterspout" sync / 1[56]:Leviathan:5CD0:/
-455.8 "Dread Tide" sync / 1[56]:Leviathan:5CC9:/
+425.2 "Body Slam" sync / 1[56]:[^:]*:Leviathan:5CD2:/
+435.3 "Dread Tide" sync / 1[56]:[^:]*:Leviathan:5CC9:/
+439.6 "Aqua Burst" sync / 1[56]:[^:]*:Wave Spume:888:/
+442.5 "Aqua Breath" sync / 1[56]:[^:]*:Leviathan:5CCD:/
+446.6 "Waterspout" sync / 1[56]:[^:]*:Leviathan:5CD0:/
+455.8 "Dread Tide" sync / 1[56]:[^:]*:Leviathan:5CC9:/
 462.5 "--untargetable--"
-465.6 "Grand Fall x3" #sync / 1[56]:Leviathan:5CDF:/
-468.1 "Spinning Dive" sync / 1[56]:Leviathan:5CDB:/
+465.6 "Grand Fall x3" #sync / 1[56]:[^:]*:Leviathan:5CDF:/
+468.1 "Spinning Dive" sync / 1[56]:[^:]*:Leviathan:5CDB:/
 468.1 "--untargetable--"
-473.9 "Tidal Wave" sync / 1[56]:Leviathan:5CDE:/ window 150,100
+473.9 "Tidal Wave" sync / 1[56]:[^:]*:Leviathan:5CDE:/ window 150,100
 
 
 ### Phase 4: more adds, enrage
 486.6 "--targetable--"
-486.7 "Body Slam" sync / 1[56]:Leviathan:5CD2:/ window 30,30
+486.7 "Body Slam" sync / 1[56]:[^:]*:Leviathan:5CD2:/ window 30,30
 488.2 "--Wavetooth Sahagin (NW)--"
-500.3 "Tidal Roar" sync / 1[56]:Leviathan:5CDA:/
-508.5 "Aqua Breath" sync / 1[56]:Leviathan:5CCD:/
-512.6 "Waterspout" sync / 1[56]:Leviathan:5CD0:/
-512.6 "Tail Whip" #sync / 1[56]:Leviathan's Tail:5CCE:/
-519.8 "Dread Tide" sync / 1[56]:Leviathan:5CC9:/
-523.9 "Tidal Roar" sync / 1[56]:Leviathan:5CDA:/
+500.3 "Tidal Roar" sync / 1[56]:[^:]*:Leviathan:5CDA:/
+508.5 "Aqua Breath" sync / 1[56]:[^:]*:Leviathan:5CCD:/
+512.6 "Waterspout" sync / 1[56]:[^:]*:Leviathan:5CD0:/
+512.6 "Tail Whip" #sync / 1[56]:[^:]*:Leviathan's Tail:5CCE:/
+519.8 "Dread Tide" sync / 1[56]:[^:]*:Leviathan:5CC9:/
+523.9 "Tidal Roar" sync / 1[56]:[^:]*:Leviathan:5CDA:/
 
 532.1 "--untargetable--"
-535.2 "Grand Fall x3" #sync / 1[56]:Leviathan:5CDF:/
-537.7 "Spinning Dive" sync / 1[56]:Leviathan:5CDB:/
-542.6 "Spinning Dive" sync / 1[56]:Leviathan:5CDB:/
+535.2 "Grand Fall x3" #sync / 1[56]:[^:]*:Leviathan:5CDF:/
+537.7 "Spinning Dive" sync / 1[56]:[^:]*:Leviathan:5CDB:/
+542.6 "Spinning Dive" sync / 1[56]:[^:]*:Leviathan:5CDB:/
 
 548.3 "--targetable--"
-548.4 "Body Slam" sync / 1[56]:Leviathan:5CD2:/ window 30,30
-563.6 "Dread Tide" sync / 1[56]:Leviathan:5CC9:/
-567.7 "Tidal Roar" sync / 1[56]:Leviathan:5CDA:/
-581.1 "Dread Tide" sync / 1[56]:Leviathan:5CC9:/
-587.3 "Tidal Roar" sync / 1[56]:Leviathan:5CDA:/
+548.4 "Body Slam" sync / 1[56]:[^:]*:Leviathan:5CD2:/ window 30,30
+563.6 "Dread Tide" sync / 1[56]:[^:]*:Leviathan:5CC9:/
+567.7 "Tidal Roar" sync / 1[56]:[^:]*:Leviathan:5CDA:/
+581.1 "Dread Tide" sync / 1[56]:[^:]*:Leviathan:5CC9:/
+587.3 "Tidal Roar" sync / 1[56]:[^:]*:Leviathan:5CDA:/
 600.9 "--2x Wavespine Sahagin--" # ? not sure where
-601.6 "Tidal Roar" sync / 1[56]:Leviathan:5CDA:/
-609.8 "Aqua Breath" sync / 1[56]:Leviathan:5CCD:/
-613.9 "Waterspout" sync / 1[56]:Leviathan:5CD0:/
-614.8 "Tail Whip" #sync / 1[56]:Leviathan's Tail:5CCE:/
-621.1 "Dread Tide" sync / 1[56]:Leviathan:5CC9:/
-625.2 "Tidal Roar" sync / 1[56]:Leviathan:5CDA:/
+601.6 "Tidal Roar" sync / 1[56]:[^:]*:Leviathan:5CDA:/
+609.8 "Aqua Breath" sync / 1[56]:[^:]*:Leviathan:5CCD:/
+613.9 "Waterspout" sync / 1[56]:[^:]*:Leviathan:5CD0:/
+614.8 "Tail Whip" #sync / 1[56]:[^:]*:Leviathan's Tail:5CCE:/
+621.1 "Dread Tide" sync / 1[56]:[^:]*:Leviathan:5CC9:/
+625.2 "Tidal Roar" sync / 1[56]:[^:]*:Leviathan:5CDA:/
 
 634.1 "--untargetable--"
-637.2 "Grand Fall x3" sync / 1[56]:Leviathan:5CDF:/
-639.7 "Spinning Dive" sync / 1[56]:Leviathan:5CDB:/
-644.6 "Spinning Dive" sync / 1[56]:Leviathan:5CDB:/
+637.2 "Grand Fall x3" sync / 1[56]:[^:]*:Leviathan:5CDF:/
+639.7 "Spinning Dive" sync / 1[56]:[^:]*:Leviathan:5CDB:/
+644.6 "Spinning Dive" sync / 1[56]:[^:]*:Leviathan:5CDB:/
 
 650.3 "--targetable--"
-650.4 "Body Slam" sync / 1[56]:Leviathan:5CD2:/ window 30,30
-665.6 "Dread Tide" sync / 1[56]:Leviathan:5CC9:/
+650.4 "Body Slam" sync / 1[56]:[^:]*:Leviathan:5CD2:/ window 30,30
+665.6 "Dread Tide" sync / 1[56]:[^:]*:Leviathan:5CC9:/
 
 669.6 "--untargetable--"
-676.9 "Tidal Wave Enrage" sync / 1[56]:Leviathan:5CDE:/
+676.9 "Tidal Wave Enrage" sync / 1[56]:[^:]*:Leviathan:5CDE:/

--- a/ui/raidboss/data/05-shb/trial/ruby_weapon-ex.txt
+++ b/ui/raidboss/data/05-shb/trial/ruby_weapon-ex.txt
@@ -10,80 +10,80 @@ hideall "--sync--"
 # -ii 4B2F 4D05 4ACD 4ACE 4ADA 4E6C 4AE9 4AE8 4E6B 4AEA 4AE8 4A6E 4ADE 4E6E 4AE2 4A98 4AE6 4E70 4B06 4B07 4B08 4B0D 4D0D 4AD9 4AE0 4AE4 4D04 4D57 4ADC 4E79 4BCF 4E77 4AD7 4AE7 4ADD 4E6D  4E6F 4AE5 4AE1
 
 0 "Start"
-2.0 "--sync--" sync / 1[56]:The Ruby Weapon:368:/ window 3,0
-14.5 "Optimized Ultima" sync / 1[56]:The Ruby Weapon:4ABE:/ window 15,5
-28.7 "Magitek Bit" sync / 1[56]:The Ruby Weapon:4AD1:/
-30.8 "--middle--" sync / 1[56]:The Ruby Weapon:4A9B:/
-36.0 "Flexiclaw" sync / 1[56]:The Ruby Weapon:4A92:/
-38.9 "Magitek Ray" sync / 1[56]:Ruby Bit:4AD2:/
-44.6 "Helicoclaw" sync / 1[56]:The Ruby Weapon:4A99:/
-45.3 "Spike Of Flame" sync / 1[56]:The Ruby Weapon:(4D04|4AD3):/
-46.7 "Magitek Ray" sync / 1[56]:Ruby Bit:4AD2:/
-52.7 "Helicoclaw" sync / 1[56]:The Ruby Weapon:4A99:/
-53.4 "Spike Of Flame" sync / 1[56]:The Ruby Weapon:(4D04|4AD3):/
-54.5 "Magitek Ray" sync / 1[56]:Ruby Bit:4AD2:/
-62.4 "Magitek Ray" sync / 1[56]:Ruby Bit:4AD2:/
-72.6 "Stamp" sync / 1[56]:The Ruby Weapon:4B03:/
-77.8 "--middle--" sync / 1[56]:The Ruby Weapon:4A9B:/
-80.2 "Ruby Sphere" sync / 1[56]:The Ruby Weapon:4AC9:/
-86.3 "Flexiclaw" sync / 1[56]:The Ruby Weapon:4A92:/
-95.9 "Ravensclaw" sync / 1[56]:The Ruby Weapon:4ACC:/
-102.0 "Liquefaction?/Undermine?" sync / 1[56]:The Ruby Weapon:(4ACF|4AD0):/
-105.2 "Ruby Sphere 1" #sync / 1[56]:The Ruby Weapon:4ACA:/
-108.2 "Ruby Sphere 2" #sync / 1[56]:The Ruby Weapon:4ACA:/
-111.2 "Ruby Sphere 3" #sync / 1[56]:The Ruby Weapon:4ACA:/
-127.6 "Ruby Ray" sync / 1[56]:The Ruby Weapon:4B02:/
-134.7 "Optimized Ultima" sync / 1[56]:The Ruby Weapon:4ABE:/
-145.4 "Flexiclaw" sync / 1[56]:The Ruby Weapon:4A92:/
-151.1 "Liquefaction" sync / 1[56]:The Ruby Weapon:4AEC:/
-157.6 "--north--" sync / 1[56]:The Ruby Weapon:4A9B:/
+2.0 "--sync--" sync / 1[56]:[^:]*:The Ruby Weapon:368:/ window 3,0
+14.5 "Optimized Ultima" sync / 1[56]:[^:]*:The Ruby Weapon:4ABE:/ window 15,5
+28.7 "Magitek Bit" sync / 1[56]:[^:]*:The Ruby Weapon:4AD1:/
+30.8 "--middle--" sync / 1[56]:[^:]*:The Ruby Weapon:4A9B:/
+36.0 "Flexiclaw" sync / 1[56]:[^:]*:The Ruby Weapon:4A92:/
+38.9 "Magitek Ray" sync / 1[56]:[^:]*:Ruby Bit:4AD2:/
+44.6 "Helicoclaw" sync / 1[56]:[^:]*:The Ruby Weapon:4A99:/
+45.3 "Spike Of Flame" sync / 1[56]:[^:]*:The Ruby Weapon:(4D04|4AD3):/
+46.7 "Magitek Ray" sync / 1[56]:[^:]*:Ruby Bit:4AD2:/
+52.7 "Helicoclaw" sync / 1[56]:[^:]*:The Ruby Weapon:4A99:/
+53.4 "Spike Of Flame" sync / 1[56]:[^:]*:The Ruby Weapon:(4D04|4AD3):/
+54.5 "Magitek Ray" sync / 1[56]:[^:]*:Ruby Bit:4AD2:/
+62.4 "Magitek Ray" sync / 1[56]:[^:]*:Ruby Bit:4AD2:/
+72.6 "Stamp" sync / 1[56]:[^:]*:The Ruby Weapon:4B03:/
+77.8 "--middle--" sync / 1[56]:[^:]*:The Ruby Weapon:4A9B:/
+80.2 "Ruby Sphere" sync / 1[56]:[^:]*:The Ruby Weapon:4AC9:/
+86.3 "Flexiclaw" sync / 1[56]:[^:]*:The Ruby Weapon:4A92:/
+95.9 "Ravensclaw" sync / 1[56]:[^:]*:The Ruby Weapon:4ACC:/
+102.0 "Liquefaction?/Undermine?" sync / 1[56]:[^:]*:The Ruby Weapon:(4ACF|4AD0):/
+105.2 "Ruby Sphere 1" #sync / 1[56]:[^:]*:The Ruby Weapon:4ACA:/
+108.2 "Ruby Sphere 2" #sync / 1[56]:[^:]*:The Ruby Weapon:4ACA:/
+111.2 "Ruby Sphere 3" #sync / 1[56]:[^:]*:The Ruby Weapon:4ACA:/
+127.6 "Ruby Ray" sync / 1[56]:[^:]*:The Ruby Weapon:4B02:/
+134.7 "Optimized Ultima" sync / 1[56]:[^:]*:The Ruby Weapon:4ABE:/
+145.4 "Flexiclaw" sync / 1[56]:[^:]*:The Ruby Weapon:4A92:/
+151.1 "Liquefaction" sync / 1[56]:[^:]*:The Ruby Weapon:4AEC:/
+157.6 "--north--" sync / 1[56]:[^:]*:The Ruby Weapon:4A9B:/
 168.0 "--untargetable--"
-168.0 "Ravensflight" sync / 1[56]:The Ruby Weapon:4AA1:/
+168.0 "Ravensflight" sync / 1[56]:[^:]*:The Ruby Weapon:4AA1:/
 181.8 "--targetable--"
-196.9 "Optimized Ultima" sync / 1[56]:The Ruby Weapon:4ABE:/
-205.2 "Stamp" sync / 1[56]:The Ruby Weapon:4B03:/
-212.4 "--teleport--" sync / 1[56]:The Ruby Weapon:4A9B:/
-220.3 "Ruby Dynamics" sync / 1[56]:The Ruby Weapon:4B09:/
-221.4 "High-Powered Homing Lasers" sync / 1[56]:The Ruby Weapon:4AD8:/
-229.5 "Cut And Run" sync / 1[56]:The Ruby Weapon:4B05:/ duration 2.5
-231.1 "Homing Lasers" sync / 1[56]:The Ruby Weapon:4AD6:/
-237.1 "Magitek Charge" sync / 1[56]:The Ruby Weapon:4AD4:/
-246.2 "Ruby Ray" sync / 1[56]:The Ruby Weapon:4B02:/
-253.3 "Optimized Ultima" sync / 1[56]:The Ruby Weapon:4ABE:/
-259.5 "--middle--" sync / 1[56]:The Ruby Weapon:4A9B:/
-261.8 "Ruby Sphere" sync / 1[56]:The Ruby Weapon:4AC9:/
-267.9 "Flexiclaw" sync / 1[56]:The Ruby Weapon:4A92:/
-277.5 "Ravensclaw" sync / 1[56]:The Ruby Weapon:4ACC:/
-283.6 "Undermine?/Liquefaction?" sync / 1[56]:The Ruby Weapon:(4ACF|4AD0):/
-286.9 "Ruby Sphere 1" #sync / 1[56]:The Ruby Weapon:4ACA:/
-289.9 "Ruby Sphere 2" #sync / 1[56]:The Ruby Weapon:4ACA:/
-292.9 "Ruby Sphere 3" #sync / 1[56]:The Ruby Weapon:4ACA:/
-307.2 "Ruby Ray" sync / 1[56]:The Ruby Weapon:4B02:/
-314.3 "Optimized Ultima" sync / 1[56]:The Ruby Weapon:4ABE:/
-325.0 "Flexiclaw" sync / 1[56]:The Ruby Weapon:4A92:/
-330.7 "Liquefaction" sync / 1[56]:The Ruby Weapon:4AEC:/
-337.2 "--north--" sync / 1[56]:The Ruby Weapon:4A9B:/
+196.9 "Optimized Ultima" sync / 1[56]:[^:]*:The Ruby Weapon:4ABE:/
+205.2 "Stamp" sync / 1[56]:[^:]*:The Ruby Weapon:4B03:/
+212.4 "--teleport--" sync / 1[56]:[^:]*:The Ruby Weapon:4A9B:/
+220.3 "Ruby Dynamics" sync / 1[56]:[^:]*:The Ruby Weapon:4B09:/
+221.4 "High-Powered Homing Lasers" sync / 1[56]:[^:]*:The Ruby Weapon:4AD8:/
+229.5 "Cut And Run" sync / 1[56]:[^:]*:The Ruby Weapon:4B05:/ duration 2.5
+231.1 "Homing Lasers" sync / 1[56]:[^:]*:The Ruby Weapon:4AD6:/
+237.1 "Magitek Charge" sync / 1[56]:[^:]*:The Ruby Weapon:4AD4:/
+246.2 "Ruby Ray" sync / 1[56]:[^:]*:The Ruby Weapon:4B02:/
+253.3 "Optimized Ultima" sync / 1[56]:[^:]*:The Ruby Weapon:4ABE:/
+259.5 "--middle--" sync / 1[56]:[^:]*:The Ruby Weapon:4A9B:/
+261.8 "Ruby Sphere" sync / 1[56]:[^:]*:The Ruby Weapon:4AC9:/
+267.9 "Flexiclaw" sync / 1[56]:[^:]*:The Ruby Weapon:4A92:/
+277.5 "Ravensclaw" sync / 1[56]:[^:]*:The Ruby Weapon:4ACC:/
+283.6 "Undermine?/Liquefaction?" sync / 1[56]:[^:]*:The Ruby Weapon:(4ACF|4AD0):/
+286.9 "Ruby Sphere 1" #sync / 1[56]:[^:]*:The Ruby Weapon:4ACA:/
+289.9 "Ruby Sphere 2" #sync / 1[56]:[^:]*:The Ruby Weapon:4ACA:/
+292.9 "Ruby Sphere 3" #sync / 1[56]:[^:]*:The Ruby Weapon:4ACA:/
+307.2 "Ruby Ray" sync / 1[56]:[^:]*:The Ruby Weapon:4B02:/
+314.3 "Optimized Ultima" sync / 1[56]:[^:]*:The Ruby Weapon:4ABE:/
+325.0 "Flexiclaw" sync / 1[56]:[^:]*:The Ruby Weapon:4A92:/
+330.7 "Liquefaction" sync / 1[56]:[^:]*:The Ruby Weapon:4AEC:/
+337.2 "--north--" sync / 1[56]:[^:]*:The Ruby Weapon:4A9B:/
 347.6 "--untargetable--"
-347.6 "Ravensflight" sync / 1[56]:The Ruby Weapon:4AA1:/
+347.6 "Ravensflight" sync / 1[56]:[^:]*:The Ruby Weapon:4AA1:/
 360.4 "--targetable--"
-375.5 "Optimized Ultima" sync / 1[56]:The Ruby Weapon:4ABE:/
-383.8 "Stamp" sync / 1[56]:The Ruby Weapon:4B03:/
-391.0 "--teleport--" sync / 1[56]:The Ruby Weapon:4A9B:/
-398.8 "Ruby Dynamics" sync / 1[56]:The Ruby Weapon:4B09:/
-399.9 "High-Powered Homing Lasers" sync / 1[56]:The Ruby Weapon:4AD8:/
-407.9 "Cut And Run" sync / 1[56]:The Ruby Weapon:4B05:/
-409.5 "Homing Lasers" sync / 1[56]:The Ruby Weapon:4AD6:/
-414.9 "--sync--" sync / 1[56]:The Ruby Weapon:4A9B:/
-415.4 "Magitek Charge" sync / 1[56]:The Ruby Weapon:4AD4:/
-424.5 "Ruby Ray" sync / 1[56]:The Ruby Weapon:4B02:/
-431.7 "Optimized Ultima" sync / 1[56]:The Ruby Weapon:4ABE:/
-437.9 "--sync--" sync / 1[56]:The Ruby Weapon:4A9B:/
+375.5 "Optimized Ultima" sync / 1[56]:[^:]*:The Ruby Weapon:4ABE:/
+383.8 "Stamp" sync / 1[56]:[^:]*:The Ruby Weapon:4B03:/
+391.0 "--teleport--" sync / 1[56]:[^:]*:The Ruby Weapon:4A9B:/
+398.8 "Ruby Dynamics" sync / 1[56]:[^:]*:The Ruby Weapon:4B09:/
+399.9 "High-Powered Homing Lasers" sync / 1[56]:[^:]*:The Ruby Weapon:4AD8:/
+407.9 "Cut And Run" sync / 1[56]:[^:]*:The Ruby Weapon:4B05:/
+409.5 "Homing Lasers" sync / 1[56]:[^:]*:The Ruby Weapon:4AD6:/
+414.9 "--sync--" sync / 1[56]:[^:]*:The Ruby Weapon:4A9B:/
+415.4 "Magitek Charge" sync / 1[56]:[^:]*:The Ruby Weapon:4AD4:/
+424.5 "Ruby Ray" sync / 1[56]:[^:]*:The Ruby Weapon:4B02:/
+431.7 "Optimized Ultima" sync / 1[56]:[^:]*:The Ruby Weapon:4ABE:/
+437.9 "--sync--" sync / 1[56]:[^:]*:The Ruby Weapon:4A9B:/
 ### Enrage (both time and hp% pushes)
-440.2 "--sync--" sync / 14:The Ruby Weapon:4B2D:/ window 600,0
-455.2 "Enrage" sync / 1[56]:The Ruby Weapon:4B2D:/
+440.2 "--sync--" sync / 14:[^:]*:The Ruby Weapon:4B2D:/ window 600,0
+455.2 "Enrage" sync / 1[56]:[^:]*:The Ruby Weapon:4B2D:/
 
 ### Cutscene
-800.0 "--cutscene--" sync / 1[56]:The Ruby Weapon:4E1C:/ window 800,0 duration 65.5
+800.0 "--cutscene--" sync / 1[56]:[^:]*:The Ruby Weapon:4E1C:/ window 800,0 duration 65.5
 865.5 "--targetable--"
 
 ### Phase 2
@@ -91,37 +91,37 @@ hideall "--sync--"
 # -ii 4CF7 4E68 4B00 4E20 4AF3 4AF4 4AF1 4AF2 4B30 4E31 4AB1
 
 1000.0 "Start"
-1000.5 "--sync--" sync / 1[56]:The Ruby Weapon:4CF7:/ window 1001,0
-1007.0 "Meteor Project" sync / 1[56]:The Ruby Weapon:4AAA:/ window 1007,5
-1013.2 "Negative Personae" sync / 1[56]:The Ruby Weapon:4ABD:/
-1023.9 "Meteor Stream" sync / 1[56]:The Ruby Weapon:4E72:/
-1029.3 "Greater Memory" sync / 1[56]:Raven's Image:4AFD:/
-1035.4 "Chariot/Dynamo" sync / 1[56]:Raven's Image:4EB[01]:/
-1035.5 "Negative Affect" sync / 1[56]:The Ruby Weapon:4AF8:/
-1043.7 "Meteor Stream" sync / 1[56]:The Ruby Weapon:4E72:/
-1052.0 "Ruby Claw x5" sync / 1[56]:Raven's Image:4AFF:/ duration 2.5
-1061.8 "Change Of Heart" sync / 1[56]:The Ruby Weapon:4AFC:/
-1063.4 "Greater Memory" sync / 1[56]:Raven's Image:4AFD:/
-1071.0 "Meteor Stream" sync / 1[56]:The Ruby Weapon:4E72:/
-1075.6 "Chariot/Dynamo" sync / 1[56]:Raven's Image:4EB[01]:/
-1092.2 "Negative Aura" sync / 1[56]:The Ruby Weapon:4AFE:/
-1106.0 "Dalamud Impact" sync / 1[56]:The Ruby Weapon:4B0B:/
-1120.4 "Meteor Project" sync / 1[56]:The Ruby Weapon:4AAA:/
-1126.6 "Meteor Mine" sync / 1[56]:The Ruby Weapon:4E89:/
-1143.8 "Landing x8" duration 7 #sync / 1[56]:Meteor:4AF1:/
-1156.0 "Screech" sync / 1[56]:The Ruby Weapon:4AEE:/
-1157.0 "Burst x8" duration 7 #sync / 1[56]:Meteor:4AF2:/
-1159.7 "Magitek Meteor" sync / 1[56]:The Ruby Weapon:4AF0:/
-1167.2 "Mark II Magitek Comet" sync / 1[56]:The Ruby Weapon:4AB6:/
+1000.5 "--sync--" sync / 1[56]:[^:]*:The Ruby Weapon:4CF7:/ window 1001,0
+1007.0 "Meteor Project" sync / 1[56]:[^:]*:The Ruby Weapon:4AAA:/ window 1007,5
+1013.2 "Negative Personae" sync / 1[56]:[^:]*:The Ruby Weapon:4ABD:/
+1023.9 "Meteor Stream" sync / 1[56]:[^:]*:The Ruby Weapon:4E72:/
+1029.3 "Greater Memory" sync / 1[56]:[^:]*:Raven's Image:4AFD:/
+1035.4 "Chariot/Dynamo" sync / 1[56]:[^:]*:Raven's Image:4EB[01]:/
+1035.5 "Negative Affect" sync / 1[56]:[^:]*:The Ruby Weapon:4AF8:/
+1043.7 "Meteor Stream" sync / 1[56]:[^:]*:The Ruby Weapon:4E72:/
+1052.0 "Ruby Claw x5" sync / 1[56]:[^:]*:Raven's Image:4AFF:/ duration 2.5
+1061.8 "Change Of Heart" sync / 1[56]:[^:]*:The Ruby Weapon:4AFC:/
+1063.4 "Greater Memory" sync / 1[56]:[^:]*:Raven's Image:4AFD:/
+1071.0 "Meteor Stream" sync / 1[56]:[^:]*:The Ruby Weapon:4E72:/
+1075.6 "Chariot/Dynamo" sync / 1[56]:[^:]*:Raven's Image:4EB[01]:/
+1092.2 "Negative Aura" sync / 1[56]:[^:]*:The Ruby Weapon:4AFE:/
+1106.0 "Dalamud Impact" sync / 1[56]:[^:]*:The Ruby Weapon:4B0B:/
+1120.4 "Meteor Project" sync / 1[56]:[^:]*:The Ruby Weapon:4AAA:/
+1126.6 "Meteor Mine" sync / 1[56]:[^:]*:The Ruby Weapon:4E89:/
+1143.8 "Landing x8" duration 7 #sync / 1[56]:[^:]*:Meteor:4AF1:/
+1156.0 "Screech" sync / 1[56]:[^:]*:The Ruby Weapon:4AEE:/
+1157.0 "Burst x8" duration 7 #sync / 1[56]:[^:]*:Meteor:4AF2:/
+1159.7 "Magitek Meteor" sync / 1[56]:[^:]*:The Ruby Weapon:4AF0:/
+1167.2 "Mark II Magitek Comet" sync / 1[56]:[^:]*:The Ruby Weapon:4AB6:/
 1178.8 "Tank Comets"
-1190.4 "--sync--" sync / 1[56]:The Ruby Weapon:4E38:/
-1190.5 "Bradamante" sync / 1[56]:The Ruby Weapon:4AF7:/
-1199.6 "--sync--" sync / 1[56]:The Ruby Weapon:4E38:/
-1199.7 "Bradamante" sync / 1[56]:The Ruby Weapon:4AF7:/
-1208.6 "Dalamud Impact" sync / 1[56]:The Ruby Weapon:4E52:/
-1221.9 "Meteor Project" sync / 1[56]:The Ruby Weapon:4AAC:/
-1235.1 "Outrage" sync / 1[56]:The Ruby Weapon:4B04:/
-1245.2 "Outrage" sync / 1[56]:The Ruby Weapon:4B04:/
-1254.3 "Meteor Stream" sync / 1[56]:The Ruby Weapon:4E72:/
-1262.1 "Meteor Stream" sync / 1[56]:The Ruby Weapon:4E72:/
+1190.4 "--sync--" sync / 1[56]:[^:]*:The Ruby Weapon:4E38:/
+1190.5 "Bradamante" sync / 1[56]:[^:]*:The Ruby Weapon:4AF7:/
+1199.6 "--sync--" sync / 1[56]:[^:]*:The Ruby Weapon:4E38:/
+1199.7 "Bradamante" sync / 1[56]:[^:]*:The Ruby Weapon:4AF7:/
+1208.6 "Dalamud Impact" sync / 1[56]:[^:]*:The Ruby Weapon:4E52:/
+1221.9 "Meteor Project" sync / 1[56]:[^:]*:The Ruby Weapon:4AAC:/
+1235.1 "Outrage" sync / 1[56]:[^:]*:The Ruby Weapon:4B04:/
+1245.2 "Outrage" sync / 1[56]:[^:]*:The Ruby Weapon:4B04:/
+1254.3 "Meteor Stream" sync / 1[56]:[^:]*:The Ruby Weapon:4E72:/
+1262.1 "Meteor Stream" sync / 1[56]:[^:]*:The Ruby Weapon:4E72:/
 # Enrage ???

--- a/ui/raidboss/data/05-shb/trial/ruby_weapon.txt
+++ b/ui/raidboss/data/05-shb/trial/ruby_weapon.txt
@@ -12,55 +12,55 @@ hideall "--sync--"
 # -ii 4AA7 4E6A 4AA3 4E69 4AA5 4B2E 4D03 4C21 4AA4 4C2A 4AA2 4AA6 4A95 4AC4 4A98
 
 0 "Start"
-2.0 "--sync--" sync / 1[56]:The Ruby Weapon:368:/ window 3,0
-16.0 "Stamp" sync / 1[56]:The Ruby Weapon:4AC7:/ window 17,0
-24.1 "Optimized Ultima" sync / 1[56]:The Ruby Weapon:4AA8:/
-31.3 "--sync--" sync / 1[56]:The Ruby Weapon:4A9B:/
-36.7 "Flexiclaw" sync / 1[56]:The Ruby Weapon:4A92:/
-46.4 "Ravensclaw" sync / 1[56]:The Ruby Weapon:4A93:/
-47.0 "Spike Of Flame" sync / 1[56]:The Ruby Weapon:4A94:/
-53.6 "Liquefaction?/Undermine?" sync / 1[56]:The Ruby Weapon:4A9[67]:/
-70.6 "Ruby Ray" sync / 1[56]:The Ruby Weapon:4AC6:/
-79.7 "Optimized Ultima" sync / 1[56]:The Ruby Weapon:4AA8:/
-84.9 "--sync--" sync / 1[56]:The Ruby Weapon:4A9B:/
-90.1 "Flexiclaw" sync / 1[56]:The Ruby Weapon:4A92:/
-98.7 "Helicoclaw" sync / 1[56]:The Ruby Weapon:4A99:/
-99.4 "Spike Of Flame" sync / 1[56]:The Ruby Weapon:(4A9A|4D02):/
-113.8 "High-Powered Homing Lasers" sync / 1[56]:The Ruby Weapon:4AC5:/
-120.5 "--sync--" sync / 1[56]:The Ruby Weapon:4A9B:/
-130.8 "Ravensflight" sync / 1[56]:The Ruby Weapon:4AA1:/
-138.0 "--sync--" sync / 1[56]:The Ruby Weapon:4BCD:/
-154.3 "Stamp" sync / 1[56]:The Ruby Weapon:4AC7:/
-161.4 "Homing Lasers" sync / 1[56]:The Ruby Weapon:4AC2:/
-164.0 "--sync--" sync / 1[56]:The Ruby Weapon:4A9B:/
-171.7 "Ruby Dynamics" sync / 1[56]:The Ruby Weapon:4AA0:/
-178.4 "Homing Lasers" sync / 1[56]:The Ruby Weapon:4AC3:/
-186.0 "Optimized Ultima" sync / 1[56]:The Ruby Weapon:4AA8:/
-191.2 "--sync--" sync / 1[56]:The Ruby Weapon:4A9B:/
-196.4 "Flexiclaw" sync / 1[56]:The Ruby Weapon:4A92:/
-206.0 "Ravensclaw" sync / 1[56]:The Ruby Weapon:4A93:/
-206.6 "Spike Of Flame" sync / 1[56]:The Ruby Weapon:4A94:/
-213.1 "Undermine?/Liquifaction?" sync / 1[56]:The Ruby Weapon:4A9[67]:/
-224.8 "Ruby Ray" sync / 1[56]:The Ruby Weapon:4AC6:/
-233.9 "Optimized Ultima" sync / 1[56]:The Ruby Weapon:4AA8:/
-239.1 "--sync--" sync / 1[56]:The Ruby Weapon:4A9B:/
-244.4 "Flexiclaw" sync / 1[56]:The Ruby Weapon:4A92:/
-253.0 "Helicoclaw" sync / 1[56]:The Ruby Weapon:4A99:/
-253.7 "Spike Of Flame" sync / 1[56]:The Ruby Weapon:(4A9A|4D02):/
-268.2 "High-Powered Homing Lasers" sync / 1[56]:The Ruby Weapon:4AC5:/
-274.9 "--sync--" sync / 1[56]:The Ruby Weapon:4A9B:/
-285.2 "Ravensflight" sync / 1[56]:The Ruby Weapon:4AA1:/
-292.4 "--sync--" sync / 1[56]:The Ruby Weapon:4BCD:/
-308.7 "Stamp" sync / 1[56]:The Ruby Weapon:4AC7:/
-311.8 "--sync--" sync / 1[56]:The Ruby Weapon:4A9B:/
+2.0 "--sync--" sync / 1[56]:[^:]*:The Ruby Weapon:368:/ window 3,0
+16.0 "Stamp" sync / 1[56]:[^:]*:The Ruby Weapon:4AC7:/ window 17,0
+24.1 "Optimized Ultima" sync / 1[56]:[^:]*:The Ruby Weapon:4AA8:/
+31.3 "--sync--" sync / 1[56]:[^:]*:The Ruby Weapon:4A9B:/
+36.7 "Flexiclaw" sync / 1[56]:[^:]*:The Ruby Weapon:4A92:/
+46.4 "Ravensclaw" sync / 1[56]:[^:]*:The Ruby Weapon:4A93:/
+47.0 "Spike Of Flame" sync / 1[56]:[^:]*:The Ruby Weapon:4A94:/
+53.6 "Liquefaction?/Undermine?" sync / 1[56]:[^:]*:The Ruby Weapon:4A9[67]:/
+70.6 "Ruby Ray" sync / 1[56]:[^:]*:The Ruby Weapon:4AC6:/
+79.7 "Optimized Ultima" sync / 1[56]:[^:]*:The Ruby Weapon:4AA8:/
+84.9 "--sync--" sync / 1[56]:[^:]*:The Ruby Weapon:4A9B:/
+90.1 "Flexiclaw" sync / 1[56]:[^:]*:The Ruby Weapon:4A92:/
+98.7 "Helicoclaw" sync / 1[56]:[^:]*:The Ruby Weapon:4A99:/
+99.4 "Spike Of Flame" sync / 1[56]:[^:]*:The Ruby Weapon:(4A9A|4D02):/
+113.8 "High-Powered Homing Lasers" sync / 1[56]:[^:]*:The Ruby Weapon:4AC5:/
+120.5 "--sync--" sync / 1[56]:[^:]*:The Ruby Weapon:4A9B:/
+130.8 "Ravensflight" sync / 1[56]:[^:]*:The Ruby Weapon:4AA1:/
+138.0 "--sync--" sync / 1[56]:[^:]*:The Ruby Weapon:4BCD:/
+154.3 "Stamp" sync / 1[56]:[^:]*:The Ruby Weapon:4AC7:/
+161.4 "Homing Lasers" sync / 1[56]:[^:]*:The Ruby Weapon:4AC2:/
+164.0 "--sync--" sync / 1[56]:[^:]*:The Ruby Weapon:4A9B:/
+171.7 "Ruby Dynamics" sync / 1[56]:[^:]*:The Ruby Weapon:4AA0:/
+178.4 "Homing Lasers" sync / 1[56]:[^:]*:The Ruby Weapon:4AC3:/
+186.0 "Optimized Ultima" sync / 1[56]:[^:]*:The Ruby Weapon:4AA8:/
+191.2 "--sync--" sync / 1[56]:[^:]*:The Ruby Weapon:4A9B:/
+196.4 "Flexiclaw" sync / 1[56]:[^:]*:The Ruby Weapon:4A92:/
+206.0 "Ravensclaw" sync / 1[56]:[^:]*:The Ruby Weapon:4A93:/
+206.6 "Spike Of Flame" sync / 1[56]:[^:]*:The Ruby Weapon:4A94:/
+213.1 "Undermine?/Liquifaction?" sync / 1[56]:[^:]*:The Ruby Weapon:4A9[67]:/
+224.8 "Ruby Ray" sync / 1[56]:[^:]*:The Ruby Weapon:4AC6:/
+233.9 "Optimized Ultima" sync / 1[56]:[^:]*:The Ruby Weapon:4AA8:/
+239.1 "--sync--" sync / 1[56]:[^:]*:The Ruby Weapon:4A9B:/
+244.4 "Flexiclaw" sync / 1[56]:[^:]*:The Ruby Weapon:4A92:/
+253.0 "Helicoclaw" sync / 1[56]:[^:]*:The Ruby Weapon:4A99:/
+253.7 "Spike Of Flame" sync / 1[56]:[^:]*:The Ruby Weapon:(4A9A|4D02):/
+268.2 "High-Powered Homing Lasers" sync / 1[56]:[^:]*:The Ruby Weapon:4AC5:/
+274.9 "--sync--" sync / 1[56]:[^:]*:The Ruby Weapon:4A9B:/
+285.2 "Ravensflight" sync / 1[56]:[^:]*:The Ruby Weapon:4AA1:/
+292.4 "--sync--" sync / 1[56]:[^:]*:The Ruby Weapon:4BCD:/
+308.7 "Stamp" sync / 1[56]:[^:]*:The Ruby Weapon:4AC7:/
+311.8 "--sync--" sync / 1[56]:[^:]*:The Ruby Weapon:4A9B:/
 
 # FIXME: does this push at a percent like extreme?
-314.0 "--sync--" sync / 14:The Ruby Weapon:4AA9:/ window 500,500
-329.0 "Optimized Ultima Enrage" sync / 1[56]:The Ruby Weapon:4AA9:/
+314.0 "--sync--" sync / 14:[^:]*:The Ruby Weapon:4AA9:/ window 500,500
+329.0 "Optimized Ultima Enrage" sync / 1[56]:[^:]*:The Ruby Weapon:4AA9:/
 
 ### Cutscene
 # FIXME: this duration differs from the extreme version??? is that true??
-500.0 "--cutscene--" sync / 1[56]:The Ruby Weapon:4E1C:/ window 500,0 duration 61.5
+500.0 "--cutscene--" sync / 1[56]:[^:]*:The Ruby Weapon:4E1C:/ window 500,0 duration 61.5
 561.5 "--targetable--"
 
 ### Phase 2
@@ -68,28 +68,28 @@ hideall "--sync--"
 # -ii 4CF6 4AC0 4AB8 4AB7 4E31 4E67 4ABB 4AB1
 
 1000.0 "Start"
-1000.5 "--sync--" sync / 1[56]:The Ruby Weapon:4CF6:/ window 1001,0
-1007.0 "Meteor Project" sync / 1[56]:The Ruby Weapon:4AAA:/ window 1007,5
-1014.2 "Negative Personae" sync / 1[56]:The Ruby Weapon:4ABD:/
-1023.3 "Meteor Stream" sync / 1[56]:The Ruby Weapon:4E71:/
-1031.8 "Ruby Claw" sync / 1[56]:Raven's Image:4ABF:/ duration 2.5
-1039.5 "Meteor Stream" sync / 1[56]:The Ruby Weapon:4E71:/
-1052.0 "Ruby Claw" sync / 1[56]:Raven's Image:4ABF:/ duration 2.5
-1057.7 "Meteor Stream" sync / 1[56]:The Ruby Weapon:4E71:/
-1069.0 "Dalamud Impact" sync / 1[56]:The Ruby Weapon:4AAE:/
-1080.9 "Meteor Project" sync / 1[56]:The Ruby Weapon:4AAA:/
-1094.2 "Magitek Comet" sync / 1[56]:The Ruby Weapon:4AB0:/
-1104.3 "Landing" sync / 1[56]:Comet:4E2B:/
-1114.9 "Magitek Meteor" sync / 1[56]:The Ruby Weapon:4AB2:/
-1115.9 "Burst" sync / 1[56]:Comet:4AB4:/
-1122.4 "Mark II Magitek Comet" sync / 1[56]:The Ruby Weapon:4AB6:/
-1150.5 "Bradamante" sync / 1[56]:The Ruby Weapon:4ABC:/
-1159.7 "Dalamud Impact" sync / 1[56]:The Ruby Weapon:4E51:/
-1171.7 "Meteor Project" sync / 1[56]:The Ruby Weapon:4AAC:/
-1181.9 "Outrage" sync / 1[56]:The Ruby Weapon:4AC8:/
-1192.0 "Outrage" sync / 1[56]:The Ruby Weapon:4AC8:/
-1202.1 "Outrage" sync / 1[56]:The Ruby Weapon:4AC8:/
-1212.2 "Meteor Stream" sync / 1[56]:The Ruby Weapon:4E71:/
-1220.5 "Meteor Stream" sync / 1[56]:The Ruby Weapon:4E71:/
-1230.7 "Outrage" sync / 1[56]:The Ruby Weapon:4AC8:/
+1000.5 "--sync--" sync / 1[56]:[^:]*:The Ruby Weapon:4CF6:/ window 1001,0
+1007.0 "Meteor Project" sync / 1[56]:[^:]*:The Ruby Weapon:4AAA:/ window 1007,5
+1014.2 "Negative Personae" sync / 1[56]:[^:]*:The Ruby Weapon:4ABD:/
+1023.3 "Meteor Stream" sync / 1[56]:[^:]*:The Ruby Weapon:4E71:/
+1031.8 "Ruby Claw" sync / 1[56]:[^:]*:Raven's Image:4ABF:/ duration 2.5
+1039.5 "Meteor Stream" sync / 1[56]:[^:]*:The Ruby Weapon:4E71:/
+1052.0 "Ruby Claw" sync / 1[56]:[^:]*:Raven's Image:4ABF:/ duration 2.5
+1057.7 "Meteor Stream" sync / 1[56]:[^:]*:The Ruby Weapon:4E71:/
+1069.0 "Dalamud Impact" sync / 1[56]:[^:]*:The Ruby Weapon:4AAE:/
+1080.9 "Meteor Project" sync / 1[56]:[^:]*:The Ruby Weapon:4AAA:/
+1094.2 "Magitek Comet" sync / 1[56]:[^:]*:The Ruby Weapon:4AB0:/
+1104.3 "Landing" sync / 1[56]:[^:]*:Comet:4E2B:/
+1114.9 "Magitek Meteor" sync / 1[56]:[^:]*:The Ruby Weapon:4AB2:/
+1115.9 "Burst" sync / 1[56]:[^:]*:Comet:4AB4:/
+1122.4 "Mark II Magitek Comet" sync / 1[56]:[^:]*:The Ruby Weapon:4AB6:/
+1150.5 "Bradamante" sync / 1[56]:[^:]*:The Ruby Weapon:4ABC:/
+1159.7 "Dalamud Impact" sync / 1[56]:[^:]*:The Ruby Weapon:4E51:/
+1171.7 "Meteor Project" sync / 1[56]:[^:]*:The Ruby Weapon:4AAC:/
+1181.9 "Outrage" sync / 1[56]:[^:]*:The Ruby Weapon:4AC8:/
+1192.0 "Outrage" sync / 1[56]:[^:]*:The Ruby Weapon:4AC8:/
+1202.1 "Outrage" sync / 1[56]:[^:]*:The Ruby Weapon:4AC8:/
+1212.2 "Meteor Stream" sync / 1[56]:[^:]*:The Ruby Weapon:4E71:/
+1220.5 "Meteor Stream" sync / 1[56]:[^:]*:The Ruby Weapon:4E71:/
+1230.7 "Outrage" sync / 1[56]:[^:]*:The Ruby Weapon:4AC8:/
 ### ???

--- a/ui/raidboss/data/05-shb/trial/shiva-un.txt
+++ b/ui/raidboss/data/05-shb/trial/shiva-un.txt
@@ -30,204 +30,204 @@ hideall "--Reset--"
 
 # Phase 1: Literally Just Autos (100% -> 95%)
 0.0 "--sync--" sync /:Engage!/ window 0,1
-2.0 "--sync--" sync / 1[56]:Shiva:5365:/ window 10,10
+2.0 "--sync--" sync / 1[56]:[^:]*:Shiva:5365:/ window 10,10
 
 # jump to staff
-10.0 "--sync--" sync / 1[56]:Shiva:5367:/ window 10,100 jump 100
+10.0 "--sync--" sync / 1[56]:[^:]*:Shiva:5367:/ window 10,100 jump 100
 # jump to sword
-10.0 "--sync--" sync / 1[56]:Shiva:5366:/ window 10,100 jump 400
+10.0 "--sync--" sync / 1[56]:[^:]*:Shiva:5366:/ window 10,100 jump 400
 
 # Phase 2a: Staff (95% -> 90%)
-100.0 "Frost Staff" sync / 1[56]:Shiva:5367:/
-108.1 "Hailstorm" sync / 1[56]:Shiva:536E:/
+100.0 "Frost Staff" sync / 1[56]:[^:]*:Shiva:5367:/
+108.1 "Hailstorm" sync / 1[56]:[^:]*:Shiva:536E:/
 
-117.6 "Absolute Zero" sync / 1[56]:Shiva:5370:/
-127.0 "Absolute Zero" sync / 1[56]:Shiva:5370:/
+117.6 "Absolute Zero" sync / 1[56]:[^:]*:Shiva:5370:/
+127.0 "Absolute Zero" sync / 1[56]:[^:]*:Shiva:5370:/
 
-140.5 "Absolute Zero" sync / 1[56]:Shiva:5370:/ window 8,8 jump 117.6
-149.9 "Absolute Zero" #sync / 1[56]:Shiva:5370:/
+140.5 "Absolute Zero" sync / 1[56]:[^:]*:Shiva:5370:/ window 8,8 jump 117.6
+149.9 "Absolute Zero" #sync / 1[56]:[^:]*:Shiva:5370:/
 
-163.4 "Absolute Zero" #sync / 1[56]:Shiva:5370:/
-173.8 "Absolute Zero" #sync / 1[56]:Shiva:5370:/
+163.4 "Absolute Zero" #sync / 1[56]:[^:]*:Shiva:5370:/
+173.8 "Absolute Zero" #sync / 1[56]:[^:]*:Shiva:5370:/
 
 
 # Phase 3a: Sword (90% -> 80%)
-200.0 "Melt" sync / 1[56]:Shiva:53AE:/ window 100,0
+200.0 "Melt" sync / 1[56]:[^:]*:Shiva:53AE:/ window 100,0
 # This rolls out x4 over 1.5 seconds, so don't sync
-207.2 "Icicle Impact" #sync / 1[56]:Shiva:537B:/
-212.3 "Dreams Of Ice" sync / 1[56]:Shiva:536A:/
+207.2 "Icicle Impact" #sync / 1[56]:[^:]*:Shiva:537B:/
+212.3 "Dreams Of Ice" sync / 1[56]:[^:]*:Shiva:536A:/
 
-225.0 "Frost Blade" sync / 1[56]:Shiva:5366:/
-230.1 "Icebrand" sync / 1[56]:Shiva:5373:/
+225.0 "Frost Blade" sync / 1[56]:[^:]*:Shiva:5366:/
+230.1 "Icebrand" sync / 1[56]:[^:]*:Shiva:5373:/
 
-235.4 "Heavenly Strike" sync / 1[56]:Shiva:5374:/
-245.0 "Glacier Bash" sync / 1[56]:Shiva:5375:/
-255.4 "Whiteout" sync / 1[56]:Shiva:5376:/
+235.4 "Heavenly Strike" sync / 1[56]:[^:]*:Shiva:5374:/
+245.0 "Glacier Bash" sync / 1[56]:[^:]*:Shiva:5375:/
+255.4 "Whiteout" sync / 1[56]:[^:]*:Shiva:5376:/
 
-263.9 "Heavenly Strike" sync / 1[56]:Shiva:5374:/
-273.5 "Glacier Bash" sync / 1[56]:Shiva:5375:/
-284.5 "Whiteout" sync / 1[56]:Shiva:5376:/
+263.9 "Heavenly Strike" sync / 1[56]:[^:]*:Shiva:5374:/
+273.5 "Glacier Bash" sync / 1[56]:[^:]*:Shiva:5375:/
+284.5 "Whiteout" sync / 1[56]:[^:]*:Shiva:5376:/
 
-292.8 "Heavenly Strike" sync / 1[56]:Shiva:5374:/ window 20,20 jump 235.4
-302.4 "Glacier Bash" #sync / 1[56]:Shiva:5375:/
-312.8 "Whiteout" #sync / 1[56]:Shiva:5376:/
+292.8 "Heavenly Strike" sync / 1[56]:[^:]*:Shiva:5374:/ window 20,20 jump 235.4
+302.4 "Glacier Bash" #sync / 1[56]:[^:]*:Shiva:5375:/
+312.8 "Whiteout" #sync / 1[56]:[^:]*:Shiva:5376:/
 
-321.3 "Heavenly Strike" #sync / 1[56]:Shiva:5374:/
-330.9 "Glacier Bash" #sync / 1[56]:Shiva:5375:/
-341.9 "Whiteout" #sync / 1[56]:Shiva:5376:/
+321.3 "Heavenly Strike" #sync / 1[56]:[^:]*:Shiva:5374:/
+330.9 "Glacier Bash" #sync / 1[56]:[^:]*:Shiva:5375:/
+341.9 "Whiteout" #sync / 1[56]:[^:]*:Shiva:5376:/
 
 
 # Jump to adds phase from 1a/2a
-350.0 "--sync--" sync / 1[56]:Shiva:5372:/ window 350,0 jump 800
+350.0 "--sync--" sync / 1[56]:[^:]*:Shiva:5372:/ window 350,0 jump 800
 
 
 # Phase 2b: Sword (95% -> 90%)
-400.0 "Frost Blade" sync / 1[56]:Shiva:5366:/
-405.1 "Icebrand" sync / 1[56]:Shiva:5373:/
+400.0 "Frost Blade" sync / 1[56]:[^:]*:Shiva:5366:/
+405.1 "Icebrand" sync / 1[56]:[^:]*:Shiva:5373:/
 
-410.3 "Heavenly Strike" sync / 1[56]:Shiva:5374:/
-419.9 "Glacier Bash" sync / 1[56]:Shiva:5375:/
-430.3 "Whiteout" sync / 1[56]:Shiva:5376:/
+410.3 "Heavenly Strike" sync / 1[56]:[^:]*:Shiva:5374:/
+419.9 "Glacier Bash" sync / 1[56]:[^:]*:Shiva:5375:/
+430.3 "Whiteout" sync / 1[56]:[^:]*:Shiva:5376:/
 
-438.8 "Heavenly Strike" sync / 1[56]:Shiva:5374:/
-448.4 "Glacier Bash" sync / 1[56]:Shiva:5375:/
-458.8 "Whiteout" sync / 1[56]:Shiva:5376:/
+438.8 "Heavenly Strike" sync / 1[56]:[^:]*:Shiva:5374:/
+448.4 "Glacier Bash" sync / 1[56]:[^:]*:Shiva:5375:/
+458.8 "Whiteout" sync / 1[56]:[^:]*:Shiva:5376:/
 
-467.2 "Heavenly Strike" sync / 1[56]:Shiva:5374:/ window 20,20 jump 410.3
-477.3 "Glacier Bash" #sync / 1[56]:Shiva:5375:/
-487.7 "Whiteout" #sync / 1[56]:Shiva:5376:/
+467.2 "Heavenly Strike" sync / 1[56]:[^:]*:Shiva:5374:/ window 20,20 jump 410.3
+477.3 "Glacier Bash" #sync / 1[56]:[^:]*:Shiva:5375:/
+487.7 "Whiteout" #sync / 1[56]:[^:]*:Shiva:5376:/
 
-496.2 "Heavenly Strike" #sync / 1[56]:Shiva:5374:/
-505.8 "Glacier Bash" #sync / 1[56]:Shiva:5375:/
-516.8 "Whiteout" #sync / 1[56]:Shiva:5376:/
+496.2 "Heavenly Strike" #sync / 1[56]:[^:]*:Shiva:5374:/
+505.8 "Glacier Bash" #sync / 1[56]:[^:]*:Shiva:5375:/
+516.8 "Whiteout" #sync / 1[56]:[^:]*:Shiva:5376:/
 
 
 # Phase 3b: Staff (90% -> 80%)
-600.0 "Melt" sync / 1[56]:Shiva:5372:/ window 200,0
+600.0 "Melt" sync / 1[56]:[^:]*:Shiva:5372:/ window 200,0
 # This rolls out x4 over 1.5 seconds, so don't sync
-607.2 "Icicle Impact" #sync / 1[56]:Shiva:537B:/
-612.3 "Dreams Of Ice" sync / 1[56]:Shiva:536A:/
+607.2 "Icicle Impact" #sync / 1[56]:[^:]*:Shiva:537B:/
+612.3 "Dreams Of Ice" sync / 1[56]:[^:]*:Shiva:536A:/
 
-625.0 "Frost Staff" sync / 1[56]:Shiva:5367:/
-633.1 "Hailstorm" sync / 1[56]:Shiva:536E:/
+625.0 "Frost Staff" sync / 1[56]:[^:]*:Shiva:5367:/
+633.1 "Hailstorm" sync / 1[56]:[^:]*:Shiva:536E:/
 
-642.6 "Absolute Zero" sync / 1[56]:Shiva:5370:/
-652.0 "Absolute Zero" sync / 1[56]:Shiva:5370:/
+642.6 "Absolute Zero" sync / 1[56]:[^:]*:Shiva:5370:/
+652.0 "Absolute Zero" sync / 1[56]:[^:]*:Shiva:5370:/
 
-665.5 "Absolute Zero" sync / 1[56]:Shiva:5370:/ window 8,8 jump 642.6
-674.9 "Absolute Zero" #sync / 1[56]:Shiva:5370:/
+665.5 "Absolute Zero" sync / 1[56]:[^:]*:Shiva:5370:/ window 8,8 jump 642.6
+674.9 "Absolute Zero" #sync / 1[56]:[^:]*:Shiva:5370:/
 
-688.4 "Absolute Zero" #sync / 1[56]:Shiva:5370:/
-698.8 "Absolute Zero" #sync / 1[56]:Shiva:5370:/
+688.4 "Absolute Zero" #sync / 1[56]:[^:]*:Shiva:5370:/
+698.8 "Absolute Zero" #sync / 1[56]:[^:]*:Shiva:5370:/
 
 
 # Jump to adds phase from 1b/2b
-750.0 "--sync--" sync / 1[56]:Shiva:53AE:/ window 350,0 jump 801
+750.0 "--sync--" sync / 1[56]:[^:]*:Shiva:53AE:/ window 350,0 jump 801
 
 
 # Phase 4: Adds
-800.0 "--sync--" #sync / 1[56]:Shiva:5372:/
-801.0 "--sync--" #sync / 1[56]:Shiva:53AE:/
+800.0 "--sync--" #sync / 1[56]:[^:]*:Shiva:5372:/
+801.0 "--sync--" #sync / 1[56]:[^:]*:Shiva:53AE:/
 # If you push *really* fast and skip a 3a/3b weapon phase, you'll miss the melt jump.
 # So, fix that up with a combatant sync here.
 806.6 "--adds targetable--" sync / 03:........:Ice Soldier:/  window 807,10
-807.6 "Dreams Of Ice" sync / 1[56]:Shiva:536A:/
-813.2 "Frost Blade" sync / 1[56]:Shiva:5366:/
-818.5 "Icebrand" sync / 1[56]:Shiva:5373:/
-828.0 "Glacier Bash" sync / 1[56]:Shiva:5375:/
-837.5 "Heavenly Strike" sync / 1[56]:Shiva:5374:/
+807.6 "Dreams Of Ice" sync / 1[56]:[^:]*:Shiva:536A:/
+813.2 "Frost Blade" sync / 1[56]:[^:]*:Shiva:5366:/
+818.5 "Icebrand" sync / 1[56]:[^:]*:Shiva:5373:/
+828.0 "Glacier Bash" sync / 1[56]:[^:]*:Shiva:5375:/
+837.5 "Heavenly Strike" sync / 1[56]:[^:]*:Shiva:5374:/
 
 
 # Diamond Dust Cutscene
-854.4 "Melt" sync / 1[56]:Shiva:5372:/ window 60,10
+854.4 "Melt" sync / 1[56]:[^:]*:Shiva:5372:/ window 60,10
 855.5 "--untargetable--"
-866.7 "--frozen--" sync / 1[56]:Shiva:53AC:/ window 900,50
-871.6 "Diamond Dust" sync / 1[56]:Shiva:536C:/
+866.7 "--frozen--" sync / 1[56]:[^:]*:Shiva:53AC:/ window 900,50
+871.6 "Diamond Dust" sync / 1[56]:[^:]*:Shiva:536C:/
 878.7 "--targetable--"
-878.9 "Dreams Of Ice" sync / 1[56]:Shiva:536A:/
+878.9 "Dreams Of Ice" sync / 1[56]:[^:]*:Shiva:536A:/
 
 
 # Phase 5: Post-Cutscene Staff
 # Unlike phase 7a staff, this one can only have a single optional Permafrost.
-885.8 "Frost Staff" sync / 1[56]:Shiva:5367:/
-888.1 "Icicle Impact (cross)" #sync / 1[56]:Shiva:537B:/
-893.9 "Hailstorm" sync / 1[56]:Shiva:536E:/
-896.0 "Icicle Impact (cross)" #sync / 1[56]:Shiva:537B:/
-908.6 "Absolute Zero" sync / 1[56]:Shiva:5370:/
-920.2 "Absolute Zero" sync / 1[56]:Shiva:5370:/
-925.4 "Melt" sync / 1[56]:Shiva:53AE:/
-932.6 "Icicle Impact (circle)" duration 4 #sync / 1[56]:Shiva:537B:/
-935.5 "Permafrost?" sync / 1[56]:Shiva:5369:/
-939.7 "Dreams Of Ice" sync / 1[56]:Shiva:536A:/ window 20,10
+885.8 "Frost Staff" sync / 1[56]:[^:]*:Shiva:5367:/
+888.1 "Icicle Impact (cross)" #sync / 1[56]:[^:]*:Shiva:537B:/
+893.9 "Hailstorm" sync / 1[56]:[^:]*:Shiva:536E:/
+896.0 "Icicle Impact (cross)" #sync / 1[56]:[^:]*:Shiva:537B:/
+908.6 "Absolute Zero" sync / 1[56]:[^:]*:Shiva:5370:/
+920.2 "Absolute Zero" sync / 1[56]:[^:]*:Shiva:5370:/
+925.4 "Melt" sync / 1[56]:[^:]*:Shiva:53AE:/
+932.6 "Icicle Impact (circle)" duration 4 #sync / 1[56]:[^:]*:Shiva:537B:/
+935.5 "Permafrost?" sync / 1[56]:[^:]*:Shiva:5369:/
+939.7 "Dreams Of Ice" sync / 1[56]:[^:]*:Shiva:536A:/ window 20,10
 
 
 # Phase 6: Bow
-942.8 "Frost Bow" sync / 1[56]:Shiva:5368:/
-947.9 "Glass Dance" sync / 1[56]:Shiva:5378:/
-970.5 "Avalanche" sync / 1[56]:Shiva:5379:/
-974.6 "Permafrost?" sync / 1[56]:Shiva:5369:/
-986.1 "Melt" sync / 1[56]:Shiva:53AD:/ window 20,20
-988.3 "Dreams Of Ice" sync / 1[56]:Shiva:536A:/
+942.8 "Frost Bow" sync / 1[56]:[^:]*:Shiva:5368:/
+947.9 "Glass Dance" sync / 1[56]:[^:]*:Shiva:5378:/
+970.5 "Avalanche" sync / 1[56]:[^:]*:Shiva:5379:/
+974.6 "Permafrost?" sync / 1[56]:[^:]*:Shiva:5369:/
+986.1 "Melt" sync / 1[56]:[^:]*:Shiva:53AD:/ window 20,20
+988.3 "Dreams Of Ice" sync / 1[56]:[^:]*:Shiva:536A:/
 
-996.2 "Frost Staff?" sync / 1[56]:Shiva:5367:/ window 100,50 jump 1096.2
-996.2 "Frost Blade?" sync / 1[56]:Shiva:5366:/ window 100,50 jump 1296.2
+996.2 "Frost Staff?" sync / 1[56]:[^:]*:Shiva:5367:/ window 100,50 jump 1096.2
+996.2 "Frost Blade?" sync / 1[56]:[^:]*:Shiva:5366:/ window 100,50 jump 1296.2
 
 
 # Phase 7a: Staff
-1096.2 "Frost Staff" sync / 1[56]:Shiva:5367:/
-1098.1 "Icicle Impact (cross)" #sync / 1[56]:Shiva:537B:/
-1104.3 "Hailstorm" sync / 1[56]:Shiva:536E:/
-1106.1 "Icicle Impact (cross)" #sync / 1[56]:Shiva:537B:/
-1109.0 "Permafrost?" sync / 1[56]:Shiva:5369:/
-1117.8 "Absolute Zero" sync / 1[56]:Shiva:5370:/ window 20,2.5
-1125.6 "Absolute Zero" sync / 1[56]:Shiva:5370:/
-1133.0 "Absolute Zero" sync / 1[56]:Shiva:5370:/
+1096.2 "Frost Staff" sync / 1[56]:[^:]*:Shiva:5367:/
+1098.1 "Icicle Impact (cross)" #sync / 1[56]:[^:]*:Shiva:537B:/
+1104.3 "Hailstorm" sync / 1[56]:[^:]*:Shiva:536E:/
+1106.1 "Icicle Impact (cross)" #sync / 1[56]:[^:]*:Shiva:537B:/
+1109.0 "Permafrost?" sync / 1[56]:[^:]*:Shiva:5369:/
+1117.8 "Absolute Zero" sync / 1[56]:[^:]*:Shiva:5370:/ window 20,2.5
+1125.6 "Absolute Zero" sync / 1[56]:[^:]*:Shiva:5370:/
+1133.0 "Absolute Zero" sync / 1[56]:[^:]*:Shiva:5370:/
 # Note: this last absolute zero can either happen at 1135.8 or 1140.4 depending on
 # where the permafrost shows up.  So, don't sync it.
-1138.0 "Absolute Zero" #sync / 1[56]:Shiva:5370:/
-1140.0 "Permafrost?" sync / 1[56]:Shiva:5369:/
-1149.4 "Melt" sync / 1[56]:Shiva:53AE:/ window 20,20
-1156.6 "Icicle Impact (circle)" duration 4 #sync / 1[56]:Shiva:537B:/
-1159.5 "Permafrost?" sync / 1[56]:Shiva:5369:/
-1163.7 "Dreams Of Ice" sync / 1[56]:Shiva:536A:/ window 20,20
+1138.0 "Absolute Zero" #sync / 1[56]:[^:]*:Shiva:5370:/
+1140.0 "Permafrost?" sync / 1[56]:[^:]*:Shiva:5369:/
+1149.4 "Melt" sync / 1[56]:[^:]*:Shiva:53AE:/ window 20,20
+1156.6 "Icicle Impact (circle)" duration 4 #sync / 1[56]:[^:]*:Shiva:537B:/
+1159.5 "Permafrost?" sync / 1[56]:[^:]*:Shiva:5369:/
+1163.7 "Dreams Of Ice" sync / 1[56]:[^:]*:Shiva:536A:/ window 20,20
 
-1166.9 "Frost Bow" sync / 1[56]:Shiva:5368:/ window 100,20 jump 942.8
-1172.0 "Glass Dance" #sync / 1[56]:Shiva:5378:/
-1194.6 "Avalanche" #sync / 1[56]:Shiva:5379:/
-1198.7 "Permafrost?" #sync / 1[56]:Shiva:5369:/
-1210.2 "Melt" #sync / 1[56]:Shiva:53AD:/ window 20,20
-1212.4 "Dreams Of Ice" #sync / 1[56]:Shiva:536A:/
+1166.9 "Frost Bow" sync / 1[56]:[^:]*:Shiva:5368:/ window 100,20 jump 942.8
+1172.0 "Glass Dance" #sync / 1[56]:[^:]*:Shiva:5378:/
+1194.6 "Avalanche" #sync / 1[56]:[^:]*:Shiva:5379:/
+1198.7 "Permafrost?" #sync / 1[56]:[^:]*:Shiva:5369:/
+1210.2 "Melt" #sync / 1[56]:[^:]*:Shiva:53AD:/ window 20,20
+1212.4 "Dreams Of Ice" #sync / 1[56]:[^:]*:Shiva:536A:/
 
 
 
 
 # Phase 7b: Sword
-1296.2 "Frost Blade" sync / 1[56]:Shiva:5366:/
-1298.5 "Icicle Impact (cross)" #sync / 1[56]:Shiva:537B:/
-1302.3 "Icebrand" sync / 1[56]:Shiva:5373:/
-1306.4 "Icicle Impact (cross)" #sync / 1[56]:Shiva:537B:/
-1306.4 "Permafrost?" sync / 1[56]:Shiva:5369:/
-1316.8 "--sync--" sync / 14:Shiva:5375:/ window 10,10
-1319.0 "Glacier Bash" sync / 1[56]:Shiva:5375:/
-1329.4 "Whiteout" sync / 1[56]:Shiva:5376:/
-1334.7 "Heavenly Strike" sync / 1[56]:Shiva:5374:/
-1338.8 "Permafrost?" sync / 1[56]:Shiva:5369:/
-1350.7 "Melt" sync / 1[56]:Shiva:5372:/ window 20,10
-1357.9 "Icicle Impact (circle)" duration 4 #sync / 1[56]:Shiva:537B:/
-1360.8 "Permafrost?" sync / 1[56]:Shiva:5369:/
-1365.0 "Dreams Of Ice" sync / 1[56]:Shiva:536A:/ window 20,20
+1296.2 "Frost Blade" sync / 1[56]:[^:]*:Shiva:5366:/
+1298.5 "Icicle Impact (cross)" #sync / 1[56]:[^:]*:Shiva:537B:/
+1302.3 "Icebrand" sync / 1[56]:[^:]*:Shiva:5373:/
+1306.4 "Icicle Impact (cross)" #sync / 1[56]:[^:]*:Shiva:537B:/
+1306.4 "Permafrost?" sync / 1[56]:[^:]*:Shiva:5369:/
+1316.8 "--sync--" sync / 14:[^:]*:Shiva:5375:/ window 10,10
+1319.0 "Glacier Bash" sync / 1[56]:[^:]*:Shiva:5375:/
+1329.4 "Whiteout" sync / 1[56]:[^:]*:Shiva:5376:/
+1334.7 "Heavenly Strike" sync / 1[56]:[^:]*:Shiva:5374:/
+1338.8 "Permafrost?" sync / 1[56]:[^:]*:Shiva:5369:/
+1350.7 "Melt" sync / 1[56]:[^:]*:Shiva:5372:/ window 20,10
+1357.9 "Icicle Impact (circle)" duration 4 #sync / 1[56]:[^:]*:Shiva:537B:/
+1360.8 "Permafrost?" sync / 1[56]:[^:]*:Shiva:5369:/
+1365.0 "Dreams Of Ice" sync / 1[56]:[^:]*:Shiva:536A:/ window 20,20
 
-1368.2 "Frost Bow" sync / 1[56]:Shiva:5368:/ window 100,20 jump 942.8
-1373.3 "Glass Dance" #sync / 1[56]:Shiva:5378:/
-1395.9 "Avalanche" #sync / 1[56]:Shiva:5379:/
-1400.0 "Permafrost?" #sync / 1[56]:Shiva:5369:/
-1411.5 "Melt" #sync / 1[56]:Shiva:53AD:/ window 20,20
-1413.7 "Dreams Of Ice" #sync / 1[56]:Shiva:536A:/
+1368.2 "Frost Bow" sync / 1[56]:[^:]*:Shiva:5368:/ window 100,20 jump 942.8
+1373.3 "Glass Dance" #sync / 1[56]:[^:]*:Shiva:5378:/
+1395.9 "Avalanche" #sync / 1[56]:[^:]*:Shiva:5379:/
+1400.0 "Permafrost?" #sync / 1[56]:[^:]*:Shiva:5369:/
+1411.5 "Melt" #sync / 1[56]:[^:]*:Shiva:53AD:/ window 20,20
+1413.7 "Dreams Of Ice" #sync / 1[56]:[^:]*:Shiva:536A:/
 
 
 
 # Enrage
 #1165.6 "--untargetable--"
-#1176.7 "--sync--" sync / 1[56]:Shiva:53AC:/
-#1176.7 "Diamond Dust" sync / 1[56]:Shiva:536B:/
-#1181.6 "Diamond Dust" sync / 1[56]:Shiva:536C:/
+#1176.7 "--sync--" sync / 1[56]:[^:]*:Shiva:53AC:/
+#1176.7 "Diamond Dust" sync / 1[56]:[^:]*:Shiva:536B:/
+#1181.6 "Diamond Dust" sync / 1[56]:[^:]*:Shiva:536C:/

--- a/ui/raidboss/data/05-shb/trial/titan-un.txt
+++ b/ui/raidboss/data/05-shb/trial/titan-un.txt
@@ -14,19 +14,19 @@ hideall "--sync--"
 0.0 "Start"
 0.0 "--sync--" sync /:Engage!/ window 0,1
 
-10.0 "Landslide" sync / 1[56]:Titan:58FA:/ window 10,10
-18.7 "Weight Of The Land" sync / 1[56]:Titan:58FE:/ window 20,5
-22.3 "Mountain Buster" sync / 1[56]:Titan:58F7:/
-27.5 "Tumult x4" duration 3.5 #sync / 1[56]:Titan:58F8:/
-37.3 "Landslide" sync / 1[56]:Titan:58FA:/
-41.4 "Mountain Buster" sync / 1[56]:Titan:58F7:/
-48.0 "Weight Of The Land" sync / 1[56]:Titan:58FE:/
-55.7 "Mountain Buster" sync / 1[56]:Titan:58F7:/
+10.0 "Landslide" sync / 1[56]:[^:]*:Titan:58FA:/ window 10,10
+18.7 "Weight Of The Land" sync / 1[56]:[^:]*:Titan:58FE:/ window 20,5
+22.3 "Mountain Buster" sync / 1[56]:[^:]*:Titan:58F7:/
+27.5 "Tumult x4" duration 3.5 #sync / 1[56]:[^:]*:Titan:58F8:/
+37.3 "Landslide" sync / 1[56]:[^:]*:Titan:58FA:/
+41.4 "Mountain Buster" sync / 1[56]:[^:]*:Titan:58F7:/
+48.0 "Weight Of The Land" sync / 1[56]:[^:]*:Titan:58FE:/
+55.7 "Mountain Buster" sync / 1[56]:[^:]*:Titan:58F7:/
 
-62.0 "Landslide" sync / 1[56]:Titan:58FA:/ window 15,15 jump 10
+62.0 "Landslide" sync / 1[56]:[^:]*:Titan:58FA:/ window 15,15 jump 10
 70.2 "Weight Of The Land"
 74.3 "Mountain Buster"
-79.5 "Tumult x4" duration 3.5 #sync / 1[56]:Titan:58F8:/
+79.5 "Tumult x4" duration 3.5 #sync / 1[56]:[^:]*:Titan:58F8:/
 89.3 "Landslide"
 93.4 "Mountain Buster"
 99.5 "Weight Of The Land"
@@ -34,38 +34,38 @@ hideall "--sync--"
 
 
 # Phase 2: 85%->55%
-200.0 "--sync--" sync / 14:Titan:58FF:/ window 200,0
-203.0 "Geocrush" sync / 1[56]:Titan:58FF:/
+200.0 "--sync--" sync / 14:[^:]*:Titan:58FF:/ window 200,0
+203.0 "Geocrush" sync / 1[56]:[^:]*:Titan:58FF:/
 
-212.6 "Landslide" sync / 1[56]:Titan:58FA:/
-216.7 "Rock Throw" sync / 1[56]:Titan:5ADD:/ duration 21.5
-220.8 "Mountain Buster" sync / 1[56]:Titan:58F7:/
-229.8 "Upheaval" sync / 1[56]:Titan:58F9:/
-234.8 "Landslide" sync / 1[56]:Titan:58FA:/
-242.0 "Tumult x4" duration 3.5 # sync / 1[56]:Titan:58F8:/
-251.0 "Weight Of The Land" sync / 1[56]:Titan:58FE:/ window 15,15
-254.6 "Mountain Buster" sync / 1[56]:Titan:58F7:/
-262.0 "Landslide" sync / 1[56]:Titan:58FA:/
-271.7 "Weight Of The Land" sync / 1[56]:Titan:58FE:/
-276.8 "Bury (one side)" sync / 1[56]:Bomb Boulder:5AFB:/
-278.0 "Mountain Buster" sync / 1[56]:Titan:58F7:/
-287.4 "Burst" sync / 1[56]:Bomb Boulder:5ADF:/
+212.6 "Landslide" sync / 1[56]:[^:]*:Titan:58FA:/
+216.7 "Rock Throw" sync / 1[56]:[^:]*:Titan:5ADD:/ duration 21.5
+220.8 "Mountain Buster" sync / 1[56]:[^:]*:Titan:58F7:/
+229.8 "Upheaval" sync / 1[56]:[^:]*:Titan:58F9:/
+234.8 "Landslide" sync / 1[56]:[^:]*:Titan:58FA:/
+242.0 "Tumult x4" duration 3.5 # sync / 1[56]:[^:]*:Titan:58F8:/
+251.0 "Weight Of The Land" sync / 1[56]:[^:]*:Titan:58FE:/ window 15,15
+254.6 "Mountain Buster" sync / 1[56]:[^:]*:Titan:58F7:/
+262.0 "Landslide" sync / 1[56]:[^:]*:Titan:58FA:/
+271.7 "Weight Of The Land" sync / 1[56]:[^:]*:Titan:58FE:/
+276.8 "Bury (one side)" sync / 1[56]:[^:]*:Bomb Boulder:5AFB:/
+278.0 "Mountain Buster" sync / 1[56]:[^:]*:Titan:58F7:/
+287.4 "Burst" sync / 1[56]:[^:]*:Bomb Boulder:5ADF:/
 
-288.1 "Landslide" sync / 1[56]:Titan:58FA:/
-292.2 "Rock Throw" sync / 1[56]:Titan:5ADD:/ duration 21.5
-296.3 "Mountain Buster" sync / 1[56]:Titan:58F7:/
-305.4 "Upheaval" sync / 1[56]:Titan:58F9:/
-310.4 "Landslide" sync / 1[56]:Titan:58FA:/
-317.5 "Tumult x4" duration 3.5 #sync / 1[56]:Titan:58F8:/
-326.5 "Weight Of The Land" sync / 1[56]:Titan:58FE:/ window 15,15
-330.1 "Mountain Buster" sync / 1[56]:Titan:58F7:/
-337.3 "Landslide" sync / 1[56]:Titan:58FA:/
-347.0 "Weight Of The Land" sync / 1[56]:Titan:58FE:/
-351.7 "Bury (clock)" duration 4.2 #sync / 1[56]:Bomb Boulder:5AFB:/
-353.6 "Mountain Buster" sync / 1[56]:Titan:58F7:/
-360.9 "Burst" duration 4.2 #sync / 1[56]:Bomb Boulder:5ADF:/
+288.1 "Landslide" sync / 1[56]:[^:]*:Titan:58FA:/
+292.2 "Rock Throw" sync / 1[56]:[^:]*:Titan:5ADD:/ duration 21.5
+296.3 "Mountain Buster" sync / 1[56]:[^:]*:Titan:58F7:/
+305.4 "Upheaval" sync / 1[56]:[^:]*:Titan:58F9:/
+310.4 "Landslide" sync / 1[56]:[^:]*:Titan:58FA:/
+317.5 "Tumult x4" duration 3.5 #sync / 1[56]:[^:]*:Titan:58F8:/
+326.5 "Weight Of The Land" sync / 1[56]:[^:]*:Titan:58FE:/ window 15,15
+330.1 "Mountain Buster" sync / 1[56]:[^:]*:Titan:58F7:/
+337.3 "Landslide" sync / 1[56]:[^:]*:Titan:58FA:/
+347.0 "Weight Of The Land" sync / 1[56]:[^:]*:Titan:58FE:/
+351.7 "Bury (clock)" duration 4.2 #sync / 1[56]:[^:]*:Bomb Boulder:5AFB:/
+353.6 "Mountain Buster" sync / 1[56]:[^:]*:Titan:58F7:/
+360.9 "Burst" duration 4.2 #sync / 1[56]:[^:]*:Bomb Boulder:5ADF:/
 
-363.9 "Landslide" sync / 1[56]:Titan:58FA:/ window 20,20 jump 212.6
+363.9 "Landslide" sync / 1[56]:[^:]*:Titan:58FA:/ window 20,20 jump 212.6
 368.0 "Rock Throw"
 372.1 "Mountain Buster"
 381.1 "Upheaval"
@@ -80,71 +80,71 @@ hideall "--sync--"
 
 
 ### Phase 3: Heart Phase (at 55%)
-500.0 "--sync--" sync / 14:Titan:58FF:/ window 299,0
-503.0 "Geocrush" sync / 1[56]:Titan:58FF:/
-515.6 "Weight Of The Land" sync / 1[56]:Titan:58FE:/
-521.2 "Rock Throw" sync / 1[56]:Titan:5ADD:/ duration 21.5
-526.0 "Rock Buster" sync / 1[56]:Titan:58F6:/
-533.0 "Upheaval" sync / 1[56]:Titan:58F9:/
-538.0 "Landslide" sync / 1[56]:Titan:58FA:/
-544.0 "Tumult x4" duration 3.5 #sync / 1[56]:Titan:58F8:/
-553.1 "Weight Of The Land" sync / 1[56]:Titan:58FE:/ window 15,15
-561.8 "Rock Buster" sync / 1[56]:Titan:58F6:/
-563.8 "Bury (clock)" duration 3 # sync / 1[56]:Bomb Boulder:5AFB:/
-570.8 "Landslide" sync / 1[56]:Titan:58FA:/
-572.9 "Burst" duration 3 # sync / 1[56]:Bomb Boulder:5ADF:/
-574.9 "Tumult x4" duration 3.5 #sync / 1[56]:Titan:58F8:/
-583.0 "Weight Of The Land" sync / 1[56]:Titan:58FE:/
+500.0 "--sync--" sync / 14:[^:]*:Titan:58FF:/ window 299,0
+503.0 "Geocrush" sync / 1[56]:[^:]*:Titan:58FF:/
+515.6 "Weight Of The Land" sync / 1[56]:[^:]*:Titan:58FE:/
+521.2 "Rock Throw" sync / 1[56]:[^:]*:Titan:5ADD:/ duration 21.5
+526.0 "Rock Buster" sync / 1[56]:[^:]*:Titan:58F6:/
+533.0 "Upheaval" sync / 1[56]:[^:]*:Titan:58F9:/
+538.0 "Landslide" sync / 1[56]:[^:]*:Titan:58FA:/
+544.0 "Tumult x4" duration 3.5 #sync / 1[56]:[^:]*:Titan:58F8:/
+553.1 "Weight Of The Land" sync / 1[56]:[^:]*:Titan:58FE:/ window 15,15
+561.8 "Rock Buster" sync / 1[56]:[^:]*:Titan:58F6:/
+563.8 "Bury (clock)" duration 3 # sync / 1[56]:[^:]*:Bomb Boulder:5AFB:/
+570.8 "Landslide" sync / 1[56]:[^:]*:Titan:58FA:/
+572.9 "Burst" duration 3 # sync / 1[56]:[^:]*:Bomb Boulder:5ADF:/
+574.9 "Tumult x4" duration 3.5 #sync / 1[56]:[^:]*:Titan:58F8:/
+583.0 "Weight Of The Land" sync / 1[56]:[^:]*:Titan:58FE:/
 593.0 "--untargetable--"
 
 
 ### Phase 4
-700.0 "Earthen Fury" sync / 1[56]:Titan:5900:/ window 700,0
+700.0 "Earthen Fury" sync / 1[56]:[^:]*:Titan:5900:/ window 700,0
 713.1 "Gaoler Adds (E/W)"
-715.8 "Gaoler Tumult" #sync / 1[56]:Granite Gaoler:5903:/
-716.3 "Mountain Buster" sync / 1[56]:Titan:58F7:/
+715.8 "Gaoler Tumult" #sync / 1[56]:[^:]*:Granite Gaoler:5903:/
+716.3 "Mountain Buster" sync / 1[56]:[^:]*:Titan:58F7:/
 
-723.3 "Bury x4" #sync / 1[56]:Bomb Boulder:5AFB:/
-725.8 "Bury x4" #sync / 1[56]:Bomb Boulder:5AFB:/
-730.2 "Landslide" sync / 1[56]:Titan:58FA:/
-732.5 "Burst x4" #sync / 1[56]:Bomb Boulder:5ADF:/
-734.9 "Burst x4" #sync / 1[56]:Bomb Boulder:5ADF:/
-735.4 "Mountain Buster" sync / 1[56]:Titan:58F7:/
-739.8 "Gaoler Landslide?" #sync / 1[56]:Granite Gaoler:5902:/
-744.0 "Weight Of The Land" sync / 1[56]:Titan:58FE:/
+723.3 "Bury x4" #sync / 1[56]:[^:]*:Bomb Boulder:5AFB:/
+725.8 "Bury x4" #sync / 1[56]:[^:]*:Bomb Boulder:5AFB:/
+730.2 "Landslide" sync / 1[56]:[^:]*:Titan:58FA:/
+732.5 "Burst x4" #sync / 1[56]:[^:]*:Bomb Boulder:5ADF:/
+734.9 "Burst x4" #sync / 1[56]:[^:]*:Bomb Boulder:5ADF:/
+735.4 "Mountain Buster" sync / 1[56]:[^:]*:Titan:58F7:/
+739.8 "Gaoler Landslide?" #sync / 1[56]:[^:]*:Granite Gaoler:5902:/
+744.0 "Weight Of The Land" sync / 1[56]:[^:]*:Titan:58FE:/
 
-749.7 "Rock Throw" sync / 1[56]:Titan:5ADD:/ duration 21.5
-753.9 "Mountain Buster" sync / 1[56]:Titan:58F7:/
-762.9 "Upheaval" sync / 1[56]:Titan:58F9:/
-767.9 "Landslide" sync / 1[56]:Titan:58FA:/
-779.0 "Mountain Buster" sync / 1[56]:Titan:58F7:/ window 15,15
-783.2 "Tumult x4" duration 3.5 #sync / 1[56]:Titan:58F8:/
-792.2 "Weight Of The Land 1" #sync / 1[56]:Titan:58FE:/
-794.7 "Weight Of The Land 2" #sync / 1[56]:Titan:58FE:/
-799.9 "Mountain Buster" sync / 1[56]:Titan:58F7:/
+749.7 "Rock Throw" sync / 1[56]:[^:]*:Titan:5ADD:/ duration 21.5
+753.9 "Mountain Buster" sync / 1[56]:[^:]*:Titan:58F7:/
+762.9 "Upheaval" sync / 1[56]:[^:]*:Titan:58F9:/
+767.9 "Landslide" sync / 1[56]:[^:]*:Titan:58FA:/
+779.0 "Mountain Buster" sync / 1[56]:[^:]*:Titan:58F7:/ window 15,15
+783.2 "Tumult x4" duration 3.5 #sync / 1[56]:[^:]*:Titan:58F8:/
+792.2 "Weight Of The Land 1" #sync / 1[56]:[^:]*:Titan:58FE:/
+794.7 "Weight Of The Land 2" #sync / 1[56]:[^:]*:Titan:58FE:/
+799.9 "Mountain Buster" sync / 1[56]:[^:]*:Titan:58F7:/
 
-804.1 "Bury (row 1)" #sync / 1[56]:Bomb Boulder:5AFB:/
-805.0 "Bury (row 2)" #sync / 1[56]:Bomb Boulder:5AFB:/
-806.1 "Bury (row 3)" #sync / 1[56]:Bomb Boulder:5AFB:/
-811.0 "Landslide" sync / 1[56]:Titan:58FA:/
-813.1 "Burst 1" #sync / 1[56]:Bomb Boulder:5ADF:/
-814.6 "Burst 2" #sync / 1[56]:Bomb Boulder:5ADF:/
-816.1 "Burst 3" #sync / 1[56]:Bomb Boulder:5ADF:/
-819.2 "Mountain Buster" sync / 1[56]:Titan:58F7:/
+804.1 "Bury (row 1)" #sync / 1[56]:[^:]*:Bomb Boulder:5AFB:/
+805.0 "Bury (row 2)" #sync / 1[56]:[^:]*:Bomb Boulder:5AFB:/
+806.1 "Bury (row 3)" #sync / 1[56]:[^:]*:Bomb Boulder:5AFB:/
+811.0 "Landslide" sync / 1[56]:[^:]*:Titan:58FA:/
+813.1 "Burst 1" #sync / 1[56]:[^:]*:Bomb Boulder:5ADF:/
+814.6 "Burst 2" #sync / 1[56]:[^:]*:Bomb Boulder:5ADF:/
+816.1 "Burst 3" #sync / 1[56]:[^:]*:Bomb Boulder:5ADF:/
+819.2 "Mountain Buster" sync / 1[56]:[^:]*:Titan:58F7:/
 
-832.7 "Bury (all)" sync / 1[56]:Bomb Boulder:5AFB:/
-837.0 "Tumult x4" duration 3.5 #sync / 1[56]:Titan:58F8:/
-845.9 "Weight Of The Land" sync / 1[56]:Titan:58FE:/
+832.7 "Bury (all)" sync / 1[56]:[^:]*:Bomb Boulder:5AFB:/
+837.0 "Tumult x4" duration 3.5 #sync / 1[56]:[^:]*:Titan:58F8:/
+845.9 "Weight Of The Land" sync / 1[56]:[^:]*:Titan:58FE:/
 852.5 "--untargetable--"
-855.1 "Burst" sync / 1[56]:Bomb Boulder:5ADF:/
-856.7 "Geocrush" sync / 1[56]:Titan:58FF:/
+855.1 "Burst" sync / 1[56]:[^:]*:Bomb Boulder:5ADF:/
+856.7 "Geocrush" sync / 1[56]:[^:]*:Titan:58FF:/
 857.1 "--targetable--"
-862.4 "Landslide" sync / 1[56]:Titan:58FA:/
+862.4 "Landslide" sync / 1[56]:[^:]*:Titan:58FA:/
 
 # loop
 874.0 "Gaoler Adds (E/W)"
-876.7 "Gaoler Tumult" #sync / 1[56]:Granite Gaoler:5903:/
-877.2 "Mountain Buster" sync / 1[56]:Titan:58F7:/ window 40,40 jump 716.3
+876.7 "Gaoler Tumult" #sync / 1[56]:[^:]*:Granite Gaoler:5903:/
+877.2 "Mountain Buster" sync / 1[56]:[^:]*:Titan:58F7:/ window 40,40 jump 716.3
 
 884.2 "Bury x4"
 886.7 "Bury x4"
@@ -157,8 +157,8 @@ hideall "--sync--"
 
 
 ### Enrage
-1000.0 "--sync--" sync / 14:Titan:5901:/ window 1000,1000
-1010.0 "Upheaval Enrage" #sync / 1[56]:Titan:5901:/
-1022.0 "Upheaval Enrage" #sync / 1[56]:Titan:5901:/
-1034.0 "Upheaval Enrage" #sync / 1[56]:Titan:5901:/
-1046.0 "Upheaval Enrage" #sync / 1[56]:Titan:5901:/
+1000.0 "--sync--" sync / 14:[^:]*:Titan:5901:/ window 1000,1000
+1010.0 "Upheaval Enrage" #sync / 1[56]:[^:]*:Titan:5901:/
+1022.0 "Upheaval Enrage" #sync / 1[56]:[^:]*:Titan:5901:/
+1034.0 "Upheaval Enrage" #sync / 1[56]:[^:]*:Titan:5901:/
+1046.0 "Upheaval Enrage" #sync / 1[56]:[^:]*:Titan:5901:/

--- a/ui/raidboss/data/05-shb/trial/titania-ex.txt
+++ b/ui/raidboss/data/05-shb/trial/titania-ex.txt
@@ -11,109 +11,109 @@ hideall "--sync--"
 ### Phase 1: single mechanics
 0 "Start"
 0.0 "--sync--" sync /:Engage!/ window 0,1
-1.5 "--sync--" sync / 1[56]:Titania:366:/ window 2,0
-12.0 "Bright Sabbath" sync / 1[56]:Titania:3D4B:/ window 15,5
-26.0 "Phantom Rune Out" sync / 1[56]:Titania:3D4C:/
-37.0 "Mist Rune" sync / 1[56]:Titania:3D45:/
-55.5 "Flame Rune" sync / 1[56]:Titania:3D47:/
-69.7 "Flame Hammer 1" #sync / 1[56]:Spirit of Flame:3D48:/
-72.0 "Flame Hammer 2" #sync / 1[56]:Spirit of Flame:3D48:/
-78.6 "Divination Rune" sync / 1[56]:Titania:3D4A:/
-87.6 "Chain Of Brambles" sync / 1[56]:Titania:42D7:/
-103.9 "Phantom Rune In" sync / 1[56]:Titania:3D4D:/
+1.5 "--sync--" sync / 1[56]:[^:]*:Titania:366:/ window 2,0
+12.0 "Bright Sabbath" sync / 1[56]:[^:]*:Titania:3D4B:/ window 15,5
+26.0 "Phantom Rune Out" sync / 1[56]:[^:]*:Titania:3D4C:/
+37.0 "Mist Rune" sync / 1[56]:[^:]*:Titania:3D45:/
+55.5 "Flame Rune" sync / 1[56]:[^:]*:Titania:3D47:/
+69.7 "Flame Hammer 1" #sync / 1[56]:[^:]*:Spirit of Flame:3D48:/
+72.0 "Flame Hammer 2" #sync / 1[56]:[^:]*:Spirit of Flame:3D48:/
+78.6 "Divination Rune" sync / 1[56]:[^:]*:Titania:3D4A:/
+87.6 "Chain Of Brambles" sync / 1[56]:[^:]*:Titania:42D7:/
+103.9 "Phantom Rune In" sync / 1[56]:[^:]*:Titania:3D4D:/
 
-114.9 "Midsummer Night's Dream" sync / 1[56]:Titania:3D30:/
-128.2 "--center--" sync / 1[56]:Titania:3D28:/
-133.8 "Thunder Rune 1" sync / 1[56]:Titania:3D29:/ window 5,1
-139.3 "Thunder Rune 2" #sync / 1[56]:Titania:3D29:/
-144.8 "Thunder Rune 3" #sync / 1[56]:Titania:3D29:/
-150.3 "Thunder Rune 4" #sync / 1[56]:Titania:3D29:/
-155.8 "Thunder Rune 5" #sync / 1[56]:Titania:3D29:/
-161.4 "Thunder Rune 6" sync / 1[56]:Titania:3F2A:/ window 15,15
-172.4 "Fae Light" sync / 1[56]:Titania:3D2C:/
-175.4 "Fae Light 1" #sync / 1[56]:Titania:3D2D:/
-177.4 "Fae Light 2" #sync / 1[56]:Titania:3D2D:/
-179.6 "Fae Light 3" #sync / 1[56]:Titania:3D2D:/
-188.6 "Growth Rune" sync / 1[56]:Titania:3D2E:/
-194.6 "Chain Of Brambles" sync / 1[56]:Titania:42D7:/
-213.8 "Divination Rune" sync / 1[56]:Titania:3D4A:/
-222.8 "Frost Rune" sync / 1[56]:Titania:3D2A:/
-230.8 "Frost Rune Middle" #sync / 1[56]:Titania:3D2B:/
-239.8 "Uplift" sync / 1[56]:Titania:421E:/
-246.8 "Phantom Rune In" sync / 1[56]:Titania:3D4D:/
+114.9 "Midsummer Night's Dream" sync / 1[56]:[^:]*:Titania:3D30:/
+128.2 "--center--" sync / 1[56]:[^:]*:Titania:3D28:/
+133.8 "Thunder Rune 1" sync / 1[56]:[^:]*:Titania:3D29:/ window 5,1
+139.3 "Thunder Rune 2" #sync / 1[56]:[^:]*:Titania:3D29:/
+144.8 "Thunder Rune 3" #sync / 1[56]:[^:]*:Titania:3D29:/
+150.3 "Thunder Rune 4" #sync / 1[56]:[^:]*:Titania:3D29:/
+155.8 "Thunder Rune 5" #sync / 1[56]:[^:]*:Titania:3D29:/
+161.4 "Thunder Rune 6" sync / 1[56]:[^:]*:Titania:3F2A:/ window 15,15
+172.4 "Fae Light" sync / 1[56]:[^:]*:Titania:3D2C:/
+175.4 "Fae Light 1" #sync / 1[56]:[^:]*:Titania:3D2D:/
+177.4 "Fae Light 2" #sync / 1[56]:[^:]*:Titania:3D2D:/
+179.6 "Fae Light 3" #sync / 1[56]:[^:]*:Titania:3D2D:/
+188.6 "Growth Rune" sync / 1[56]:[^:]*:Titania:3D2E:/
+194.6 "Chain Of Brambles" sync / 1[56]:[^:]*:Titania:42D7:/
+213.8 "Divination Rune" sync / 1[56]:[^:]*:Titania:3D4A:/
+222.8 "Frost Rune" sync / 1[56]:[^:]*:Titania:3D2A:/
+230.8 "Frost Rune Middle" #sync / 1[56]:[^:]*:Titania:3D2B:/
+239.8 "Uplift" sync / 1[56]:[^:]*:Titania:421E:/
+246.8 "Phantom Rune In" sync / 1[56]:[^:]*:Titania:3D4D:/
 
 
 ### Phase 2a: smol adds
-256.4 "--untargetable--" sync / 1[56]:Titania:3D31:/ window 300,0
+256.4 "--untargetable--" sync / 1[56]:[^:]*:Titania:3D31:/ window 300,0
 258.8 "--targetable--"
-271.0 "Leafstorm" sync / 1[56]:Mustardseed:3D38:/
-271.1 "Gentle Breeze" sync / 1[56]:Puck:3F82:/
-273.4 "Pease" sync / 1[56]:Peaseblossom:3D35:/
-273.4 "Peasebomb" sync / 1[56]:Peaseblossom:3D34:/
-277.1 "Leafstorm" sync / 1[56]:Mustardseed:3D38:/
-281.2 "Pummel" sync / 1[56]:Puck:3D37:/
-284.4 "Hard Swipe" sync / 1[56]:Peaseblossom:3D36:/
-293.2 "Pummel" sync / 1[56]:Puck:3D37:/
-296.9 "Pease" sync / 1[56]:Peaseblossom:3D35:/
-296.9 "Peasebomb" sync / 1[56]:Peaseblossom:3D34:/
-307.9 "Hard Swipe" sync / 1[56]:Peaseblossom:3D36:/
+271.0 "Leafstorm" sync / 1[56]:[^:]*:Mustardseed:3D38:/
+271.1 "Gentle Breeze" sync / 1[56]:[^:]*:Puck:3F82:/
+273.4 "Pease" sync / 1[56]:[^:]*:Peaseblossom:3D35:/
+273.4 "Peasebomb" sync / 1[56]:[^:]*:Peaseblossom:3D34:/
+277.1 "Leafstorm" sync / 1[56]:[^:]*:Mustardseed:3D38:/
+281.2 "Pummel" sync / 1[56]:[^:]*:Puck:3D37:/
+284.4 "Hard Swipe" sync / 1[56]:[^:]*:Peaseblossom:3D36:/
+293.2 "Pummel" sync / 1[56]:[^:]*:Puck:3D37:/
+296.9 "Pease" sync / 1[56]:[^:]*:Peaseblossom:3D35:/
+296.9 "Peasebomb" sync / 1[56]:[^:]*:Peaseblossom:3D34:/
+307.9 "Hard Swipe" sync / 1[56]:[^:]*:Peaseblossom:3D36:/
 ### ???
 
 
 ### Phase 2b: bigger is better
-500.0 "Love-In-Idleness" sync / 1[56]:Titania:3D3D:/ window 500,0
+500.0 "Love-In-Idleness" sync / 1[56]:[^:]*:Titania:3D3D:/ window 500,0
 518.2 "--targetable--"
-528.5 "Leafstorm" sync / 1[56]:Mustardseed:3D3E:/
-529.0 "War And Pease" sync / 1[56]:Peaseblossom:3D40:/
-529.0 "Peasebomb" sync / 1[56]:Peaseblossom:3D3F:/
-536.0 "Puck's Breath" sync / 1[56]:Puck:3D41:/
-545.0 "Whispering Wind" sync / 1[56]:Mustardseed:40E2:/
-555.0 "Puck's Rebuke" sync / 1[56]:Puck:3D44:/
-557.0 "Wallop" sync / 1[56]:Spirit of Wood:3D3B:/
-559.5 "Leafstorm" sync / 1[56]:Mustardseed:3D3E:/
-568.0 "War And Pease" sync / 1[56]:Peaseblossom:3D40:/
-568.0 "Puck's Breath" sync / 1[56]:Puck:3D41:/
-568.0 "Peasebomb" sync / 1[56]:Peaseblossom:3D3F:/
-577.0 "Puck's Caprice" sync / 1[56]:Puck:3D3A:/
+528.5 "Leafstorm" sync / 1[56]:[^:]*:Mustardseed:3D3E:/
+529.0 "War And Pease" sync / 1[56]:[^:]*:Peaseblossom:3D40:/
+529.0 "Peasebomb" sync / 1[56]:[^:]*:Peaseblossom:3D3F:/
+536.0 "Puck's Breath" sync / 1[56]:[^:]*:Puck:3D41:/
+545.0 "Whispering Wind" sync / 1[56]:[^:]*:Mustardseed:40E2:/
+555.0 "Puck's Rebuke" sync / 1[56]:[^:]*:Puck:3D44:/
+557.0 "Wallop" sync / 1[56]:[^:]*:Spirit of Wood:3D3B:/
+559.5 "Leafstorm" sync / 1[56]:[^:]*:Mustardseed:3D3E:/
+568.0 "War And Pease" sync / 1[56]:[^:]*:Peaseblossom:3D40:/
+568.0 "Puck's Breath" sync / 1[56]:[^:]*:Puck:3D41:/
+568.0 "Peasebomb" sync / 1[56]:[^:]*:Peaseblossom:3D3F:/
+577.0 "Puck's Caprice" sync / 1[56]:[^:]*:Puck:3D3A:/
 
 
 ### Phase 3: double mechanics
-800.0 "Being Mortal" sync / 1[56]:Titania:3D32:/ window 800,0
-808.5 "Being Mortal" sync / 1[56]:Titania:3D33:/
+800.0 "Being Mortal" sync / 1[56]:[^:]*:Titania:3D32:/ window 800,0
+808.5 "Being Mortal" sync / 1[56]:[^:]*:Titania:3D33:/
 814.0 "--targetable--"
-825.3 "Mist Rune" sync / 1[56]:Titania:3D45:/
-833.3 "Phantom Rune" sync / 1[56]:Titania:3D4[CD]:/
-846.3 "Flame Rune" sync / 1[56]:Titania:3D47:/
-852.3 "Growth Rune" sync / 1[56]:Titania:3D2E:/
-860.4 "Flame Hammer 1" #sync / 1[56]:Spirit of Flame:3D48:/
-862.6 "Flame Hammer 2" #sync / 1[56]:Spirit of Flame:3D48:/
-880.2 "Phantom Rune" sync / 1[56]:Titania:3D4[CD]:/
-891.2 "Bright Sabbath" sync / 1[56]:Titania:3D4B:/
-903.2 "Fae Light" sync / 1[56]:Titania:3D2C:/
-906.2 "Fae Light 1" #sync / 1[56]:Titania:3D2D:/
-908.2 "Fae Light 2" #sync / 1[56]:Titania:3D2D:/
-910.2 "Fae Light 3" #sync / 1[56]:Titania:3D2D:/
-919.2 "Frost Rune" sync / 1[56]:Titania:3D2A:/
-927.2 "Frost Rune Middle" #sync / 1[56]:Titania:3D2B:/
-934.2 "Uplift" sync / 1[56]:Titania:421E:/
-942.2 "Bright Sabbath" sync / 1[56]:Titania:3D4B:/
-950.6 "--center--" sync / 1[56]:Titania:3D28:/
-956.2 "Thunder Rune 1" sync / 1[56]:Titania:3D29:/ window 5,1
-961.7 "Thunder Rune 2" #sync / 1[56]:Titania:3D29:/
-967.2 "Thunder Rune 3" #sync / 1[56]:Titania:3D29:/
-972.7 "Thunder Rune 4" #sync / 1[56]:Titania:3D29:/
-978.2 "Thunder Rune 5" #sync / 1[56]:Titania:3D29:/
-983.7 "Thunder Rune 6" sync / 1[56]:Titania:3F2A:/ window 15,15
-994.7 "Growth Rune" sync / 1[56]:Titania:3D2E:/
-1000.7 "Chain Of Brambles" sync / 1[56]:Titania:42D7:/
-1023.7 "Phantom Rune" sync / 1[56]:Titania:3D4[CD]:/
-1031.7 "Phantom Rune" sync / 1[56]:Titania:3D4[CD]:/
-1043.7 "Bright Sabbath" sync / 1[56]:Titania:3D4B:/
-1050.7 "Divination Rune" sync / 1[56]:Titania:3D4A:/
-1065.6 "Mist Rune" sync / 1[56]:Titania:3D45:/
+825.3 "Mist Rune" sync / 1[56]:[^:]*:Titania:3D45:/
+833.3 "Phantom Rune" sync / 1[56]:[^:]*:Titania:3D4[CD]:/
+846.3 "Flame Rune" sync / 1[56]:[^:]*:Titania:3D47:/
+852.3 "Growth Rune" sync / 1[56]:[^:]*:Titania:3D2E:/
+860.4 "Flame Hammer 1" #sync / 1[56]:[^:]*:Spirit of Flame:3D48:/
+862.6 "Flame Hammer 2" #sync / 1[56]:[^:]*:Spirit of Flame:3D48:/
+880.2 "Phantom Rune" sync / 1[56]:[^:]*:Titania:3D4[CD]:/
+891.2 "Bright Sabbath" sync / 1[56]:[^:]*:Titania:3D4B:/
+903.2 "Fae Light" sync / 1[56]:[^:]*:Titania:3D2C:/
+906.2 "Fae Light 1" #sync / 1[56]:[^:]*:Titania:3D2D:/
+908.2 "Fae Light 2" #sync / 1[56]:[^:]*:Titania:3D2D:/
+910.2 "Fae Light 3" #sync / 1[56]:[^:]*:Titania:3D2D:/
+919.2 "Frost Rune" sync / 1[56]:[^:]*:Titania:3D2A:/
+927.2 "Frost Rune Middle" #sync / 1[56]:[^:]*:Titania:3D2B:/
+934.2 "Uplift" sync / 1[56]:[^:]*:Titania:421E:/
+942.2 "Bright Sabbath" sync / 1[56]:[^:]*:Titania:3D4B:/
+950.6 "--center--" sync / 1[56]:[^:]*:Titania:3D28:/
+956.2 "Thunder Rune 1" sync / 1[56]:[^:]*:Titania:3D29:/ window 5,1
+961.7 "Thunder Rune 2" #sync / 1[56]:[^:]*:Titania:3D29:/
+967.2 "Thunder Rune 3" #sync / 1[56]:[^:]*:Titania:3D29:/
+972.7 "Thunder Rune 4" #sync / 1[56]:[^:]*:Titania:3D29:/
+978.2 "Thunder Rune 5" #sync / 1[56]:[^:]*:Titania:3D29:/
+983.7 "Thunder Rune 6" sync / 1[56]:[^:]*:Titania:3F2A:/ window 15,15
+994.7 "Growth Rune" sync / 1[56]:[^:]*:Titania:3D2E:/
+1000.7 "Chain Of Brambles" sync / 1[56]:[^:]*:Titania:42D7:/
+1023.7 "Phantom Rune" sync / 1[56]:[^:]*:Titania:3D4[CD]:/
+1031.7 "Phantom Rune" sync / 1[56]:[^:]*:Titania:3D4[CD]:/
+1043.7 "Bright Sabbath" sync / 1[56]:[^:]*:Titania:3D4B:/
+1050.7 "Divination Rune" sync / 1[56]:[^:]*:Titania:3D4A:/
+1065.6 "Mist Rune" sync / 1[56]:[^:]*:Titania:3D45:/
 # ???
 
 
 ### Phase 4: too slow
-1500.0 "--sync--" sync / 14:Titania:3DAE:/ window 1500,0
-1510.0 "Bright Sabbath Enrage" sync / 1[56]:Titania:3DAE:/
+1500.0 "--sync--" sync / 14:[^:]*:Titania:3DAE:/ window 1500,0
+1510.0 "Bright Sabbath Enrage" sync / 1[56]:[^:]*:Titania:3DAE:/

--- a/ui/raidboss/data/05-shb/trial/titania.txt
+++ b/ui/raidboss/data/05-shb/trial/titania.txt
@@ -9,56 +9,56 @@ hideall "--sync--"
 ### Phase 1
 0 "Start"
 0.0 "--sync--" sync /:Engage!/ window 0,1
-2.5 "--sync--" sync / 1[56]:Titania:368:/ window 3,0
-12.5 "Bright Sabbath" sync / 1[56]:Titania:3D5C:/ window 13,5
-26.7 "Phantom Rune" sync / 1[56]:Titania:3D5[DE]:/
-37.9 "Divination Rune" sync / 1[56]:Titania:3D5B:/
-47.1 "Mist Rune" sync / 1[56]:Titania:3D45:/
-67.3 "Flame Rune" sync / 1[56]:Titania:3D47:/
-81.4 "Flame Hammer" sync / 1[56]:Spirit of Flame:4373:/
-91.4 "Phantom Rune" sync / 1[56]:Titania:3D5[DE]:/
+2.5 "--sync--" sync / 1[56]:[^:]*:Titania:368:/ window 3,0
+12.5 "Bright Sabbath" sync / 1[56]:[^:]*:Titania:3D5C:/ window 13,5
+26.7 "Phantom Rune" sync / 1[56]:[^:]*:Titania:3D5[DE]:/
+37.9 "Divination Rune" sync / 1[56]:[^:]*:Titania:3D5B:/
+47.1 "Mist Rune" sync / 1[56]:[^:]*:Titania:3D45:/
+67.3 "Flame Rune" sync / 1[56]:[^:]*:Titania:3D47:/
+81.4 "Flame Hammer" sync / 1[56]:[^:]*:Spirit of Flame:4373:/
+91.4 "Phantom Rune" sync / 1[56]:[^:]*:Titania:3D5[DE]:/
 
-103.7 "Midsummer Night's Dream" sync / 1[56]:Titania:3D30:/ window 150,0
-116.8 "Growth Rune" sync / 1[56]:Titania:3D2E:/
-144.0 "Phantom Rune" sync / 1[56]:Titania:3D5[DE]:/
-151.1 "Bright Sabbath" sync / 1[56]:Titania:3D5C:/
-161.4 "Frost Rune" sync / 1[56]:Titania:3D2A:/
-170.4 "Frost Rune Middle" #sync / 1[56]:Titania:3D4E:/
-176.7 "Uplift" sync / 1[56]:Titania:421F:/
-182.8 "Phantom Rune" sync / 1[56]:Titania:3D5[DE]:/
+103.7 "Midsummer Night's Dream" sync / 1[56]:[^:]*:Titania:3D30:/ window 150,0
+116.8 "Growth Rune" sync / 1[56]:[^:]*:Titania:3D2E:/
+144.0 "Phantom Rune" sync / 1[56]:[^:]*:Titania:3D5[DE]:/
+151.1 "Bright Sabbath" sync / 1[56]:[^:]*:Titania:3D5C:/
+161.4 "Frost Rune" sync / 1[56]:[^:]*:Titania:3D2A:/
+170.4 "Frost Rune Middle" #sync / 1[56]:[^:]*:Titania:3D4E:/
+176.7 "Uplift" sync / 1[56]:[^:]*:Titania:421F:/
+182.8 "Phantom Rune" sync / 1[56]:[^:]*:Titania:3D5[DE]:/
 
 ### Phase 2a
-193.5 "--untargetable--" sync / 1[56]:Titania:3D31:/ window 200,0
+193.5 "--untargetable--" sync / 1[56]:[^:]*:Titania:3D31:/ window 200,0
 196.0 "--targetable--"
-208.5 "Gentle Breeze" sync / 1[56]:Puck:3F83:/
-208.5 "Leafstorm" sync / 1[56]:Mustardseed:3D38:/
-210.8 "Peasebomb" sync / 1[56]:Peaseblossom:3D34:/
-210.8 "Pease" sync / 1[56]:Peaseblossom:3D52:/
-219.7 "Pummel" sync / 1[56]:Puck:3D54:/
-220.9 "Leafstorm" sync / 1[56]:Mustardseed:3D38:/
-222.1 "Hard Swipe" sync / 1[56]:Peaseblossom:3D53:/
-238.5 "Gentle Breeze" sync / 1[56]:Puck:3F83:/
-238.6 "Peasebomb" sync / 1[56]:Peaseblossom:3D34:/
-238.6 "Pease" sync / 1[56]:Peaseblossom:3D52:/
-249.8 "Pummel" sync / 1[56]:Puck:3D54:/
-250.7 "Hard Swipe" sync / 1[56]:Peaseblossom:3D53:/
+208.5 "Gentle Breeze" sync / 1[56]:[^:]*:Puck:3F83:/
+208.5 "Leafstorm" sync / 1[56]:[^:]*:Mustardseed:3D38:/
+210.8 "Peasebomb" sync / 1[56]:[^:]*:Peaseblossom:3D34:/
+210.8 "Pease" sync / 1[56]:[^:]*:Peaseblossom:3D52:/
+219.7 "Pummel" sync / 1[56]:[^:]*:Puck:3D54:/
+220.9 "Leafstorm" sync / 1[56]:[^:]*:Mustardseed:3D38:/
+222.1 "Hard Swipe" sync / 1[56]:[^:]*:Peaseblossom:3D53:/
+238.5 "Gentle Breeze" sync / 1[56]:[^:]*:Puck:3F83:/
+238.6 "Peasebomb" sync / 1[56]:[^:]*:Peaseblossom:3D34:/
+238.6 "Pease" sync / 1[56]:[^:]*:Peaseblossom:3D52:/
+249.8 "Pummel" sync / 1[56]:[^:]*:Puck:3D54:/
+250.7 "Hard Swipe" sync / 1[56]:[^:]*:Peaseblossom:3D53:/
 
 ### Phase 2b: bigger is better
-500.0 "Love-In-Idleness" sync / 1[56]:Titania:3D3D:/
+500.0 "Love-In-Idleness" sync / 1[56]:[^:]*:Titania:3D3D:/
 518.1 "--targetable--"
-528.5 "Leafstorm" sync / 1[56]:Mustardseed:3D3E:/
-529.0 "Peasebomb" sync / 1[56]:Peaseblossom:3D3F:/
-529.0 "War And Pease" sync / 1[56]:Peaseblossom:3DAD:/
-536.0 "Puck's Breath" sync / 1[56]:Puck:3D57:/
-541.0 "--sync--" sync / 1[56]:Puck:3D42:/
-546.0 "Puck's Rebuke" sync / 1[56]:Puck:3D59:/
+528.5 "Leafstorm" sync / 1[56]:[^:]*:Mustardseed:3D3E:/
+529.0 "Peasebomb" sync / 1[56]:[^:]*:Peaseblossom:3D3F:/
+529.0 "War And Pease" sync / 1[56]:[^:]*:Peaseblossom:3DAD:/
+536.0 "Puck's Breath" sync / 1[56]:[^:]*:Puck:3D57:/
+541.0 "--sync--" sync / 1[56]:[^:]*:Puck:3D42:/
+546.0 "Puck's Rebuke" sync / 1[56]:[^:]*:Puck:3D59:/
 
-551.5 "Leafstorm" sync / 1[56]:Mustardseed:3D3E:/
-560.0 "Peasebomb" sync / 1[56]:Peaseblossom:3D3F:/
-560.0 "War And Pease" sync / 1[56]:Peaseblossom:3DAD:/
-567.0 "Puck's Caprice" sync / 1[56]:Puck:3D56:/
+551.5 "Leafstorm" sync / 1[56]:[^:]*:Mustardseed:3D3E:/
+560.0 "Peasebomb" sync / 1[56]:[^:]*:Peaseblossom:3D3F:/
+560.0 "War And Pease" sync / 1[56]:[^:]*:Peaseblossom:3DAD:/
+567.0 "Puck's Caprice" sync / 1[56]:[^:]*:Puck:3D56:/
 
-583.5 "Leafstorm" sync / 1[56]:Mustardseed:3D3E:/ window 15,15 jump 528.5
+583.5 "Leafstorm" sync / 1[56]:[^:]*:Mustardseed:3D3E:/ window 15,15 jump 528.5
 584.0 "Peasebomb"
 584.0 "War And Pease"
 591.0 "Puck's Breath"
@@ -66,30 +66,30 @@ hideall "--sync--"
 601.0 "Puck's Rebuke"
 
 ### Phase 3
-800.0 "Being Mortal" sync / 1[56]:Titania:3D32:/ window 800,0
-808.5 "Being Mortal" sync / 1[56]:Titania:3D51:/
+800.0 "Being Mortal" sync / 1[56]:[^:]*:Titania:3D32:/ window 800,0
+808.5 "Being Mortal" sync / 1[56]:[^:]*:Titania:3D51:/
 814.0 "--targetable--"
-825.0 "Mist Rune" sync / 1[56]:Titania:3D45:/
-833.0 "Uplift" sync / 1[56]:Titania:421F:/
+825.0 "Mist Rune" sync / 1[56]:[^:]*:Titania:3D45:/
+833.0 "Uplift" sync / 1[56]:[^:]*:Titania:421F:/
 
-838.3 "Flame Rune" sync / 1[56]:Titania:3D47:/
-846.3 "Phantom Rune" sync / 1[56]:Titania:3D5E:/
-852.4 "Flame Hammer" sync / 1[56]:Spirit of Flame:4373:/
-856.3 "Growth Rune" sync / 1[56]:Titania:3D2E:/
-864.3 "Phantom Rune" sync / 1[56]:Titania:3D5D:/
-878.3 "Divination Rune" sync / 1[56]:Titania:3D5B:/
-887.3 "Frost Rune" sync / 1[56]:Titania:3D2A:/
-896.3 "Frost Rune Middle" #sync / 1[56]:Titania:3D4E:/
-903.3 "Bright Sabbath" sync / 1[56]:Titania:3D5C:/
-915.3 "Phantom Rune" sync / 1[56]:Titania:3D5E:/
-923.3 "Phantom Rune" sync / 1[56]:Titania:3D5D:/
-937.3 "Divination Rune" sync / 1[56]:Titania:3D5B:/
-949.3 "Bright Sabbath" sync / 1[56]:Titania:3D5C:/
-956.3 "Bright Sabbath" sync / 1[56]:Titania:3D5C:/
-970.3 "Mist Rune" sync / 1[56]:Titania:3D45:/
-978.3 "Uplift" sync / 1[56]:Titania:421F:/
+838.3 "Flame Rune" sync / 1[56]:[^:]*:Titania:3D47:/
+846.3 "Phantom Rune" sync / 1[56]:[^:]*:Titania:3D5E:/
+852.4 "Flame Hammer" sync / 1[56]:[^:]*:Spirit of Flame:4373:/
+856.3 "Growth Rune" sync / 1[56]:[^:]*:Titania:3D2E:/
+864.3 "Phantom Rune" sync / 1[56]:[^:]*:Titania:3D5D:/
+878.3 "Divination Rune" sync / 1[56]:[^:]*:Titania:3D5B:/
+887.3 "Frost Rune" sync / 1[56]:[^:]*:Titania:3D2A:/
+896.3 "Frost Rune Middle" #sync / 1[56]:[^:]*:Titania:3D4E:/
+903.3 "Bright Sabbath" sync / 1[56]:[^:]*:Titania:3D5C:/
+915.3 "Phantom Rune" sync / 1[56]:[^:]*:Titania:3D5E:/
+923.3 "Phantom Rune" sync / 1[56]:[^:]*:Titania:3D5D:/
+937.3 "Divination Rune" sync / 1[56]:[^:]*:Titania:3D5B:/
+949.3 "Bright Sabbath" sync / 1[56]:[^:]*:Titania:3D5C:/
+956.3 "Bright Sabbath" sync / 1[56]:[^:]*:Titania:3D5C:/
+970.3 "Mist Rune" sync / 1[56]:[^:]*:Titania:3D45:/
+978.3 "Uplift" sync / 1[56]:[^:]*:Titania:421F:/
 
-985.3 "Flame Rune" sync / 1[56]:Titania:3D47:/ window 100,100 jump 838.3
+985.3 "Flame Rune" sync / 1[56]:[^:]*:Titania:3D47:/ window 100,100 jump 838.3
 993.3 "Phantom Rune"
 999.4 "Flame Hammer"
 1003.3 "Growth Rune"

--- a/ui/raidboss/data/05-shb/trial/varis-ex.txt
+++ b/ui/raidboss/data/05-shb/trial/varis-ex.txt
@@ -10,264 +10,264 @@ hideall "--sync--"
 ### Phase 1
 0 "Start!"
 0.0 "--sync--" sync /:Engage!/ window 0,1
-0.9 "--sync--" sync / 1[56]:Varis Yae Galvus:4CEF:/ window 1,0
-19.0 "Altius" sync / 1[56]:Varis Yae Galvus:4CCA:/ window 19,5
-28.5 "Alea Iacta Est" sync / 1[56]:Varis Yae Galvus:4CD2:/
-29.7 "--sync--" sync / 1[56]:Varis Yae Galvus:4CD3:/
-30.1 "--sync--" sync / 1[56]:Varis Yae Galvus:4CD4:/
-30.5 "--sync--" sync / 1[56]:Varis Yae Galvus:4CD5:/
-33.2 "--sync--" sync / 1[56]:Varis Yae Galvus:4CD6:/
-34.1 "Terminus Est" sync / 1[56]:Terminus Est:4CB4:/
-45.1 "Citius" sync / 1[56]:Varis Yae Galvus:4CF0:/
-56.0 "--sync--" sync / 1[56]:Varis Yae Galvus:4CB5:/
-64.2 "Ignis Est" sync / 1[56]:Ignis Est:4CB6:/
-64.2 "Festina Lente" sync / 1[56]:Varis Yae Galvus:4CC9:/
-82.4 "Electrified Gunshield" sync / 1[56]:Varis Yae Galvus:4CD7:/
-91.5 "Altius" sync / 1[56]:Varis Yae Galvus:4CCA:/
-100.4 "--sync--" sync / 1[56]:Varis Yae Galvus:4CB5:/
-101.6 "Terminus Est" sync / 1[56]:Terminus Est:4CB4:/
-108.5 "Ignis Est" sync / 1[56]:Ignis Est:4CB6:/
-109.6 "Magitek Shock" sync / 1[56]:Varis Yae Galvus:4CDA:/
-120.7 "Reinforced Gunshield" sync / 1[56]:Varis Yae Galvus:4CD9:/
-128.9 "Citius" sync / 1[56]:Varis Yae Galvus:4CF0:/
-132.0 "Magitek Shielding" sync / 1[56]:Varis Yae Galvus:4CD[BC]:/
-147.2 "Loaded Gunshield" sync / 1[56]:Varis Yae Galvus:4CD8:/
-156.0 "--sync--" sync / 1[56]:Varis Yae Galvus:4CC6:/
-163.6 "--sync--" sync / 1[56]:Varis Yae Galvus:4CDE:/
-164.2 "Ventus Est" sync / 1[56]:Ventus Est:4CC7:/
-166.7 "Magitek Burst" sync / 1[56]:Varis Yae Galvus:4CDF:/
+0.9 "--sync--" sync / 1[56]:[^:]*:Varis Yae Galvus:4CEF:/ window 1,0
+19.0 "Altius" sync / 1[56]:[^:]*:Varis Yae Galvus:4CCA:/ window 19,5
+28.5 "Alea Iacta Est" sync / 1[56]:[^:]*:Varis Yae Galvus:4CD2:/
+29.7 "--sync--" sync / 1[56]:[^:]*:Varis Yae Galvus:4CD3:/
+30.1 "--sync--" sync / 1[56]:[^:]*:Varis Yae Galvus:4CD4:/
+30.5 "--sync--" sync / 1[56]:[^:]*:Varis Yae Galvus:4CD5:/
+33.2 "--sync--" sync / 1[56]:[^:]*:Varis Yae Galvus:4CD6:/
+34.1 "Terminus Est" sync / 1[56]:[^:]*:Terminus Est:4CB4:/
+45.1 "Citius" sync / 1[56]:[^:]*:Varis Yae Galvus:4CF0:/
+56.0 "--sync--" sync / 1[56]:[^:]*:Varis Yae Galvus:4CB5:/
+64.2 "Ignis Est" sync / 1[56]:[^:]*:Ignis Est:4CB6:/
+64.2 "Festina Lente" sync / 1[56]:[^:]*:Varis Yae Galvus:4CC9:/
+82.4 "Electrified Gunshield" sync / 1[56]:[^:]*:Varis Yae Galvus:4CD7:/
+91.5 "Altius" sync / 1[56]:[^:]*:Varis Yae Galvus:4CCA:/
+100.4 "--sync--" sync / 1[56]:[^:]*:Varis Yae Galvus:4CB5:/
+101.6 "Terminus Est" sync / 1[56]:[^:]*:Terminus Est:4CB4:/
+108.5 "Ignis Est" sync / 1[56]:[^:]*:Ignis Est:4CB6:/
+109.6 "Magitek Shock" sync / 1[56]:[^:]*:Varis Yae Galvus:4CDA:/
+120.7 "Reinforced Gunshield" sync / 1[56]:[^:]*:Varis Yae Galvus:4CD9:/
+128.9 "Citius" sync / 1[56]:[^:]*:Varis Yae Galvus:4CF0:/
+132.0 "Magitek Shielding" sync / 1[56]:[^:]*:Varis Yae Galvus:4CD[BC]:/
+147.2 "Loaded Gunshield" sync / 1[56]:[^:]*:Varis Yae Galvus:4CD8:/
+156.0 "--sync--" sync / 1[56]:[^:]*:Varis Yae Galvus:4CC6:/
+163.6 "--sync--" sync / 1[56]:[^:]*:Varis Yae Galvus:4CDE:/
+164.2 "Ventus Est" sync / 1[56]:[^:]*:Ventus Est:4CC7:/
+166.7 "Magitek Burst" sync / 1[56]:[^:]*:Varis Yae Galvus:4CDF:/
 177.1 "--untargetable--"
 
 
 ### Phase 2: Susano Remix
-177.1 "Vivere Militare Est" sync / 1[56]:Varis Yae Galvus:4CCC:/ window 180,50
+177.1 "Vivere Militare Est" sync / 1[56]:[^:]*:Varis Yae Galvus:4CCC:/ window 180,50
 192.3 "Blade's Pulse x2"
 200.1 "--targetable--"
-203.1 "Shockwave" #sync / 1[56]:Bladesblood:4CCE:/
+203.1 "Shockwave" #sync / 1[56]:[^:]*:Bladesblood:4CCE:/
 # shockwaves continue every 2 seconds
-260.1 "Vivere Militare Est" sync / 1[56]:Bladesblood:4CCF:/ window 261,50
+260.1 "Vivere Militare Est" sync / 1[56]:[^:]*:Bladesblood:4CCF:/ window 261,50
 
 
 ### Phase 3: Random Groups
 # Note: all three of these blocks occur, but can occur in any order
 269.1 "--targetable--"
-274.3 "--sync--" sync / 14:Varis Yae Galvus:4CD8:/ window 100,100 jump 500
-274.3 "--sync--" sync / 14:Varis Yae Galvus:4CD9:/ window 100,100 jump 700
-274.3 "--sync--" sync / 14:Varis Yae Galvus:4CD7:/ window 100,100 jump 900
+274.3 "--sync--" sync / 14:[^:]*:Varis Yae Galvus:4CD8:/ window 100,100 jump 500
+274.3 "--sync--" sync / 14:[^:]*:Varis Yae Galvus:4CD9:/ window 100,100 jump 700
+274.3 "--sync--" sync / 14:[^:]*:Varis Yae Galvus:4CD7:/ window 100,100 jump 900
 
 # loaded lookahead window
-279.3 "Loaded Gunshield?" #sync / 1[56]:Varis Yae Galvus:4CD8:/
-288.2 "--sync--" #sync / 1[56]:Varis Yae Galvus:4CB5:/
-292.5 "--sync--" #sync / 1[56]:Varis Yae Galvus:4CDE:/
-294.0 "--clones appear?--" #sync / 1[56]:Phantom Varis:4CB3:/
-295.6 "Magitek Burst?" #sync / 1[56]:Varis Yae Galvus:4CDF:/
-296.3 "Ignis Est?" #sync / 1[56]:Ignis Est:4CB6:/
-303.6 "Terminus Est?" #sync / 1[56]:Terminus Est:4CB4:/
-303.8 "Festina Lente?" #sync / 1[56]:Varis Yae Galvus:4CC9:/
-315.0 "Citius?" #sync / 1[56]:Varis Yae Galvus:4CF0:/
+279.3 "Loaded Gunshield?" #sync / 1[56]:[^:]*:Varis Yae Galvus:4CD8:/
+288.2 "--sync--" #sync / 1[56]:[^:]*:Varis Yae Galvus:4CB5:/
+292.5 "--sync--" #sync / 1[56]:[^:]*:Varis Yae Galvus:4CDE:/
+294.0 "--clones appear?--" #sync / 1[56]:[^:]*:Phantom Varis:4CB3:/
+295.6 "Magitek Burst?" #sync / 1[56]:[^:]*:Varis Yae Galvus:4CDF:/
+296.3 "Ignis Est?" #sync / 1[56]:[^:]*:Ignis Est:4CB6:/
+303.6 "Terminus Est?" #sync / 1[56]:[^:]*:Terminus Est:4CB4:/
+303.8 "Festina Lente?" #sync / 1[56]:[^:]*:Varis Yae Galvus:4CC9:/
+315.0 "Citius?" #sync / 1[56]:[^:]*:Varis Yae Galvus:4CF0:/
 
 # reinforced lookahead window
-279.3 "Reinforced Gunshield?" #sync / 1[56]:Varis Yae Galvus:4CD9:/
-288.4 "Altius?" #sync / 1[56]:Varis Yae Galvus:4CCA:/
-297.3 "--sync--" #sync / 1[56]:Varis Yae Galvus:4CC6:/
-298.5 "Terminus Est" #sync / 1[56]:Terminus Est:4CB4:/
-300.6 "Magitek Shielding" #sync / 1[56]:Varis Yae Galvus:4CDB:/
-305.4 "Ventus Est" #sync / 1[56]:Ventus Est:4CC7:/
-315.8 "Citius" #sync / 1[56]:Varis Yae Galvus:4CF0:/
+279.3 "Reinforced Gunshield?" #sync / 1[56]:[^:]*:Varis Yae Galvus:4CD9:/
+288.4 "Altius?" #sync / 1[56]:[^:]*:Varis Yae Galvus:4CCA:/
+297.3 "--sync--" #sync / 1[56]:[^:]*:Varis Yae Galvus:4CC6:/
+298.5 "Terminus Est" #sync / 1[56]:[^:]*:Terminus Est:4CB4:/
+300.6 "Magitek Shielding" #sync / 1[56]:[^:]*:Varis Yae Galvus:4CDB:/
+305.4 "Ventus Est" #sync / 1[56]:[^:]*:Ventus Est:4CC7:/
+315.8 "Citius" #sync / 1[56]:[^:]*:Varis Yae Galvus:4CF0:/
 
 # electrified lookahead window
-279.3 "Electrified Gunshield?" #sync / 1[56]:Varis Yae Galvus:4CD7:/
-284.4 "Reinforcements?" #sync / 1[56]:Varis Yae Galvus:4CEA:/
-290.3 "--clones appear?--" #sync / 1[56]:Phantom Varis:4CB3:/
-293.5 "Aetherochemical Grenado?" #sync / 1[56]:Magitek Turret II:4CED:/
-303.2 "Terminus Est?" #sync / 1[56]:Terminus Est:4CB4:/
-305.9 "Magitek Shock?" #sync / 1[56]:Varis Yae Galvus:4CDA:/
-316.8 "Alea Iacta Est?" #sync / 1[56]:Varis Yae Galvus:4CD2:/
-318.0 "--sync--" #sync / 1[56]:Varis Yae Galvus:4CD3:/
-318.4 "--sync--" #sync / 1[56]:Varis Yae Galvus:4CD4:/
-318.8 "--sync--" #sync / 1[56]:Varis Yae Galvus:4CD5:/
-321.5 "--sync--" #sync / 1[56]:Varis Yae Galvus:4CD6:/
+279.3 "Electrified Gunshield?" #sync / 1[56]:[^:]*:Varis Yae Galvus:4CD7:/
+284.4 "Reinforcements?" #sync / 1[56]:[^:]*:Varis Yae Galvus:4CEA:/
+290.3 "--clones appear?--" #sync / 1[56]:[^:]*:Phantom Varis:4CB3:/
+293.5 "Aetherochemical Grenado?" #sync / 1[56]:[^:]*:Magitek Turret II:4CED:/
+303.2 "Terminus Est?" #sync / 1[56]:[^:]*:Terminus Est:4CB4:/
+305.9 "Magitek Shock?" #sync / 1[56]:[^:]*:Varis Yae Galvus:4CDA:/
+316.8 "Alea Iacta Est?" #sync / 1[56]:[^:]*:Varis Yae Galvus:4CD2:/
+318.0 "--sync--" #sync / 1[56]:[^:]*:Varis Yae Galvus:4CD3:/
+318.4 "--sync--" #sync / 1[56]:[^:]*:Varis Yae Galvus:4CD4:/
+318.8 "--sync--" #sync / 1[56]:[^:]*:Varis Yae Galvus:4CD5:/
+321.5 "--sync--" #sync / 1[56]:[^:]*:Varis Yae Galvus:4CD6:/
 
 
 ## Phase 3: Loaded Gunshield, Spread
-500.0 "--sync--" sync / 14:Varis Yae Galvus:4CD8:/
-505.0 "Loaded Gunshield" sync / 1[56]:Varis Yae Galvus:4CD8:/
-513.9 "--sync--" sync / 1[56]:Varis Yae Galvus:4CB5:/
-518.2 "--sync--" sync / 1[56]:Varis Yae Galvus:4CDE:/
-519.7 "--clones appear--" sync / 1[56]:Phantom Varis:4CB3:/
-521.3 "Magitek Burst" sync / 1[56]:Varis Yae Galvus:4CDF:/
-522.0 "Ignis Est" sync / 1[56]:Ignis Est:4CB6:/
-529.3 "Terminus Est" sync / 1[56]:Terminus Est:4CB4:/
-529.5 "Festina Lente" sync / 1[56]:Varis Yae Galvus:4CC9:/
-540.7 "Citius" sync / 1[56]:Varis Yae Galvus:4CF0:/
+500.0 "--sync--" sync / 14:[^:]*:Varis Yae Galvus:4CD8:/
+505.0 "Loaded Gunshield" sync / 1[56]:[^:]*:Varis Yae Galvus:4CD8:/
+513.9 "--sync--" sync / 1[56]:[^:]*:Varis Yae Galvus:4CB5:/
+518.2 "--sync--" sync / 1[56]:[^:]*:Varis Yae Galvus:4CDE:/
+519.7 "--clones appear--" sync / 1[56]:[^:]*:Phantom Varis:4CB3:/
+521.3 "Magitek Burst" sync / 1[56]:[^:]*:Varis Yae Galvus:4CDF:/
+522.0 "Ignis Est" sync / 1[56]:[^:]*:Ignis Est:4CB6:/
+529.3 "Terminus Est" sync / 1[56]:[^:]*:Terminus Est:4CB4:/
+529.5 "Festina Lente" sync / 1[56]:[^:]*:Varis Yae Galvus:4CC9:/
+540.7 "Citius" sync / 1[56]:[^:]*:Varis Yae Galvus:4CF0:/
 
-554.3 "--sync--" sync / 14:Varis Yae Galvus:4CD9:/ window 10,10 jump 700
-554.3 "--sync--" sync / 14:Varis Yae Galvus:4CD7:/ window 10,10 jump 900
+554.3 "--sync--" sync / 14:[^:]*:Varis Yae Galvus:4CD9:/ window 10,10 jump 700
+554.3 "--sync--" sync / 14:[^:]*:Varis Yae Galvus:4CD7:/ window 10,10 jump 900
 
 # reinforced lookahead window
-559.3 "Reinforced Gunshield?" #sync / 1[56]:Varis Yae Galvus:4CD9:/
-568.4 "Altius?" #sync / 1[56]:Varis Yae Galvus:4CCA:/
-577.3 "--sync--" #sync / 1[56]:Varis Yae Galvus:4CC6:/
-578.5 "Terminus Est" #sync / 1[56]:Terminus Est:4CB4:/
-580.6 "Magitek Shielding" #sync / 1[56]:Varis Yae Galvus:4CDB:/
-585.4 "Ventus Est" #sync / 1[56]:Ventus Est:4CC7:/
-595.8 "Citius" #sync / 1[56]:Varis Yae Galvus:4CF0:/
+559.3 "Reinforced Gunshield?" #sync / 1[56]:[^:]*:Varis Yae Galvus:4CD9:/
+568.4 "Altius?" #sync / 1[56]:[^:]*:Varis Yae Galvus:4CCA:/
+577.3 "--sync--" #sync / 1[56]:[^:]*:Varis Yae Galvus:4CC6:/
+578.5 "Terminus Est" #sync / 1[56]:[^:]*:Terminus Est:4CB4:/
+580.6 "Magitek Shielding" #sync / 1[56]:[^:]*:Varis Yae Galvus:4CDB:/
+585.4 "Ventus Est" #sync / 1[56]:[^:]*:Ventus Est:4CC7:/
+595.8 "Citius" #sync / 1[56]:[^:]*:Varis Yae Galvus:4CF0:/
 
 # electrified lookahead window
-559.3 "Electrified Gunshield?" #sync / 1[56]:Varis Yae Galvus:4CD7:/
-564.4 "Reinforcements?" #sync / 1[56]:Varis Yae Galvus:4CEA:/
-570.3 "--clones appear?--" #sync / 1[56]:Phantom Varis:4CB3:/
-573.5 "Aetherochemical Grenado?" #sync / 1[56]:Magitek Turret II:4CED:/
-583.2 "Terminus Est?" #sync / 1[56]:Terminus Est:4CB4:/
-585.9 "Magitek Shock?" #sync / 1[56]:Varis Yae Galvus:4CDA:/
-596.8 "Alea Iacta Est?" #sync / 1[56]:Varis Yae Galvus:4CD2:/
-598.0 "--sync--" #sync / 1[56]:Varis Yae Galvus:4CD3:/
-598.4 "--sync--" #sync / 1[56]:Varis Yae Galvus:4CD4:/
-598.8 "--sync--" #sync / 1[56]:Varis Yae Galvus:4CD5:/
-601.5 "--sync--" #sync / 1[56]:Varis Yae Galvus:4CD6:/
+559.3 "Electrified Gunshield?" #sync / 1[56]:[^:]*:Varis Yae Galvus:4CD7:/
+564.4 "Reinforcements?" #sync / 1[56]:[^:]*:Varis Yae Galvus:4CEA:/
+570.3 "--clones appear?--" #sync / 1[56]:[^:]*:Phantom Varis:4CB3:/
+573.5 "Aetherochemical Grenado?" #sync / 1[56]:[^:]*:Magitek Turret II:4CED:/
+583.2 "Terminus Est?" #sync / 1[56]:[^:]*:Terminus Est:4CB4:/
+585.9 "Magitek Shock?" #sync / 1[56]:[^:]*:Varis Yae Galvus:4CDA:/
+596.8 "Alea Iacta Est?" #sync / 1[56]:[^:]*:Varis Yae Galvus:4CD2:/
+598.0 "--sync--" #sync / 1[56]:[^:]*:Varis Yae Galvus:4CD3:/
+598.4 "--sync--" #sync / 1[56]:[^:]*:Varis Yae Galvus:4CD4:/
+598.8 "--sync--" #sync / 1[56]:[^:]*:Varis Yae Galvus:4CD5:/
+601.5 "--sync--" #sync / 1[56]:[^:]*:Varis Yae Galvus:4CD6:/
 
 
 
 ## Phase 3: Reinforced Gunshield, Block
-700.0 "--sync--" sync / 14:Varis Yae Galvus:4CD9:/
-705.0 "Reinforced Gunshield" sync / 1[56]:Varis Yae Galvus:4CD9:/
-714.1 "Altius" sync / 1[56]:Varis Yae Galvus:4CCA:/
-723.0 "--sync--" sync / 1[56]:Varis Yae Galvus:4CC6:/
-724.2 "Terminus Est" sync / 1[56]:Terminus Est:4CB4:/
-726.3 "Magitek Shielding" sync / 1[56]:Varis Yae Galvus:4CD[BC]:/
-731.1 "Ventus Est" sync / 1[56]:Ventus Est:4CC7:/
-741.5 "Citius" sync / 1[56]:Varis Yae Galvus:4CF0:/
+700.0 "--sync--" sync / 14:[^:]*:Varis Yae Galvus:4CD9:/
+705.0 "Reinforced Gunshield" sync / 1[56]:[^:]*:Varis Yae Galvus:4CD9:/
+714.1 "Altius" sync / 1[56]:[^:]*:Varis Yae Galvus:4CCA:/
+723.0 "--sync--" sync / 1[56]:[^:]*:Varis Yae Galvus:4CC6:/
+724.2 "Terminus Est" sync / 1[56]:[^:]*:Terminus Est:4CB4:/
+726.3 "Magitek Shielding" sync / 1[56]:[^:]*:Varis Yae Galvus:4CD[BC]:/
+731.1 "Ventus Est" sync / 1[56]:[^:]*:Ventus Est:4CC7:/
+741.5 "Citius" sync / 1[56]:[^:]*:Varis Yae Galvus:4CF0:/
 
-752.8 "--sync--" sync / 14:Varis Yae Galvus:4CD8:/ window 10,10 jump 500
-752.8 "--sync--" sync / 14:Varis Yae Galvus:4CD7:/ window 10,10 jump 900
+752.8 "--sync--" sync / 14:[^:]*:Varis Yae Galvus:4CD8:/ window 10,10 jump 500
+752.8 "--sync--" sync / 14:[^:]*:Varis Yae Galvus:4CD7:/ window 10,10 jump 900
 
 # loaded lookahead window
-757.8 "Loaded Gunshield?" #sync / 1[56]:Varis Yae Galvus:4CD8:/
-766.7 "--sync--" #sync / 1[56]:Varis Yae Galvus:4CB5:/
-771.0 "--sync--" #sync / 1[56]:Varis Yae Galvus:4CDE:/
-772.5 "--clones appear?--" #sync / 1[56]:Phantom Varis:4CB3:/
-774.1 "Magitek Burst?" #sync / 1[56]:Varis Yae Galvus:4CDF:/
-774.8 "Ignis Est?" #sync / 1[56]:Ignis Est:4CB6:/
-782.1 "Terminus Est?" #sync / 1[56]:Terminus Est:4CB4:/
-782.3 "Festina Lente?" #sync / 1[56]:Varis Yae Galvus:4CC9:/
-793.5 "Citius?" #sync / 1[56]:Varis Yae Galvus:4CF0:/
+757.8 "Loaded Gunshield?" #sync / 1[56]:[^:]*:Varis Yae Galvus:4CD8:/
+766.7 "--sync--" #sync / 1[56]:[^:]*:Varis Yae Galvus:4CB5:/
+771.0 "--sync--" #sync / 1[56]:[^:]*:Varis Yae Galvus:4CDE:/
+772.5 "--clones appear?--" #sync / 1[56]:[^:]*:Phantom Varis:4CB3:/
+774.1 "Magitek Burst?" #sync / 1[56]:[^:]*:Varis Yae Galvus:4CDF:/
+774.8 "Ignis Est?" #sync / 1[56]:[^:]*:Ignis Est:4CB6:/
+782.1 "Terminus Est?" #sync / 1[56]:[^:]*:Terminus Est:4CB4:/
+782.3 "Festina Lente?" #sync / 1[56]:[^:]*:Varis Yae Galvus:4CC9:/
+793.5 "Citius?" #sync / 1[56]:[^:]*:Varis Yae Galvus:4CF0:/
 
 # electrified lookahead window
-757.8 "Electrified Gunshield?" #sync / 1[56]:Varis Yae Galvus:4CD7:/
-762.9 "Reinforcements?" #sync / 1[56]:Varis Yae Galvus:4CEA:/
-768.8 "--clones appear?--" #sync / 1[56]:Phantom Varis:4CB3:/
-772.0 "Aetherochemical Grenado?" #sync / 1[56]:Magitek Turret II:4CED:/
-781.7 "Terminus Est?" #sync / 1[56]:Terminus Est:4CB4:/
-784.4 "Magitek Shock?" #sync / 1[56]:Varis Yae Galvus:4CDA:/
-795.3 "Alea Iacta Est?" #sync / 1[56]:Varis Yae Galvus:4CD2:/
-796.5 "--sync--" #sync / 1[56]:Varis Yae Galvus:4CD3:/
-796.9 "--sync--" #sync / 1[56]:Varis Yae Galvus:4CD4:/
-797.3 "--sync--" #sync / 1[56]:Varis Yae Galvus:4CD5:/
-800.0 "--sync--" #sync / 1[56]:Varis Yae Galvus:4CD6:/
+757.8 "Electrified Gunshield?" #sync / 1[56]:[^:]*:Varis Yae Galvus:4CD7:/
+762.9 "Reinforcements?" #sync / 1[56]:[^:]*:Varis Yae Galvus:4CEA:/
+768.8 "--clones appear?--" #sync / 1[56]:[^:]*:Phantom Varis:4CB3:/
+772.0 "Aetherochemical Grenado?" #sync / 1[56]:[^:]*:Magitek Turret II:4CED:/
+781.7 "Terminus Est?" #sync / 1[56]:[^:]*:Terminus Est:4CB4:/
+784.4 "Magitek Shock?" #sync / 1[56]:[^:]*:Varis Yae Galvus:4CDA:/
+795.3 "Alea Iacta Est?" #sync / 1[56]:[^:]*:Varis Yae Galvus:4CD2:/
+796.5 "--sync--" #sync / 1[56]:[^:]*:Varis Yae Galvus:4CD3:/
+796.9 "--sync--" #sync / 1[56]:[^:]*:Varis Yae Galvus:4CD4:/
+797.3 "--sync--" #sync / 1[56]:[^:]*:Varis Yae Galvus:4CD5:/
+800.0 "--sync--" #sync / 1[56]:[^:]*:Varis Yae Galvus:4CD6:/
 
 
 
 ## Phase 3: Electrified Gunshield, Knockback
-900.0 "--sync--" sync / 14:Varis Yae Galvus:4CD7:/
-905.0 "Electrified Gunshield" sync / 1[56]:Varis Yae Galvus:4CD7:/
-910.1 "Reinforcements" sync / 1[56]:Varis Yae Galvus:4CEA:/
-916.0 "--clones appear--" sync / 1[56]:Phantom Varis:4CB3:/
-919.2 "Aetherochemical Grenado" sync / 1[56]:Magitek Turret II:4CED:/
-928.9 "Terminus Est" sync / 1[56]:Terminus Est:4CB4:/
-931.6 "Magitek Shock" sync / 1[56]:Varis Yae Galvus:4CDA:/
-942.5 "Alea Iacta Est" sync / 1[56]:Varis Yae Galvus:4CD2:/
-943.7 "--sync--" sync / 1[56]:Varis Yae Galvus:4CD3:/
-944.1 "--sync--" sync / 1[56]:Varis Yae Galvus:4CD4:/
-944.5 "--sync--" sync / 1[56]:Varis Yae Galvus:4CD5:/
-947.2 "--sync--" sync / 1[56]:Varis Yae Galvus:4CD6:/
+900.0 "--sync--" sync / 14:[^:]*:Varis Yae Galvus:4CD7:/
+905.0 "Electrified Gunshield" sync / 1[56]:[^:]*:Varis Yae Galvus:4CD7:/
+910.1 "Reinforcements" sync / 1[56]:[^:]*:Varis Yae Galvus:4CEA:/
+916.0 "--clones appear--" sync / 1[56]:[^:]*:Phantom Varis:4CB3:/
+919.2 "Aetherochemical Grenado" sync / 1[56]:[^:]*:Magitek Turret II:4CED:/
+928.9 "Terminus Est" sync / 1[56]:[^:]*:Terminus Est:4CB4:/
+931.6 "Magitek Shock" sync / 1[56]:[^:]*:Varis Yae Galvus:4CDA:/
+942.5 "Alea Iacta Est" sync / 1[56]:[^:]*:Varis Yae Galvus:4CD2:/
+943.7 "--sync--" sync / 1[56]:[^:]*:Varis Yae Galvus:4CD3:/
+944.1 "--sync--" sync / 1[56]:[^:]*:Varis Yae Galvus:4CD4:/
+944.5 "--sync--" sync / 1[56]:[^:]*:Varis Yae Galvus:4CD5:/
+947.2 "--sync--" sync / 1[56]:[^:]*:Varis Yae Galvus:4CD6:/
 
-958.7 "--sync--" sync / 14:Varis Yae Galvus:4CD8:/ window 10,10 jump 500
-958.7 "--sync--" sync / 14:Varis Yae Galvus:4CD9:/ window 10,10 jump 700
+958.7 "--sync--" sync / 14:[^:]*:Varis Yae Galvus:4CD8:/ window 10,10 jump 500
+958.7 "--sync--" sync / 14:[^:]*:Varis Yae Galvus:4CD9:/ window 10,10 jump 700
 
 # loaded lookahead window
-963.7 "Loaded Gunshield?" #sync / 1[56]:Varis Yae Galvus:4CD8:/
-972.6 "--sync--" #sync / 1[56]:Varis Yae Galvus:4CB5:/
-976.9 "--sync--" #sync / 1[56]:Varis Yae Galvus:4CDE:/
-978.4 "--clones appear?--" #sync / 1[56]:Phantom Varis:4CB3:/
-980.0 "Magitek Burst?" #sync / 1[56]:Varis Yae Galvus:4CDF:/
-980.7 "Ignis Est?" #sync / 1[56]:Ignis Est:4CB6:/
-988.0 "Terminus Est?" #sync / 1[56]:Terminus Est:4CB4:/
-988.2 "Festina Lente?" #sync / 1[56]:Varis Yae Galvus:4CC9:/
-999.4 "Citius?" #sync / 1[56]:Varis Yae Galvus:4CF0:/
+963.7 "Loaded Gunshield?" #sync / 1[56]:[^:]*:Varis Yae Galvus:4CD8:/
+972.6 "--sync--" #sync / 1[56]:[^:]*:Varis Yae Galvus:4CB5:/
+976.9 "--sync--" #sync / 1[56]:[^:]*:Varis Yae Galvus:4CDE:/
+978.4 "--clones appear?--" #sync / 1[56]:[^:]*:Phantom Varis:4CB3:/
+980.0 "Magitek Burst?" #sync / 1[56]:[^:]*:Varis Yae Galvus:4CDF:/
+980.7 "Ignis Est?" #sync / 1[56]:[^:]*:Ignis Est:4CB6:/
+988.0 "Terminus Est?" #sync / 1[56]:[^:]*:Terminus Est:4CB4:/
+988.2 "Festina Lente?" #sync / 1[56]:[^:]*:Varis Yae Galvus:4CC9:/
+999.4 "Citius?" #sync / 1[56]:[^:]*:Varis Yae Galvus:4CF0:/
 
 # reinforced lookahead window
-963.7 "Reinforced Gunshield?" #sync / 1[56]:Varis Yae Galvus:4CD9:/
-972.8 "Altius?" #sync / 1[56]:Varis Yae Galvus:4CCA:/
-981.7 "--sync--" #sync / 1[56]:Varis Yae Galvus:4CC6:/
-982.9 "Terminus Est" #sync / 1[56]:Terminus Est:4CB4:/
-985.0 "Magitek Shielding" #sync / 1[56]:Varis Yae Galvus:4CDB:/
-989.8 "Ventus Est" #sync / 1[56]:Ventus Est:4CC7:/
-1000.2 "Citius" #sync / 1[56]:Varis Yae Galvus:4CF0:/
+963.7 "Reinforced Gunshield?" #sync / 1[56]:[^:]*:Varis Yae Galvus:4CD9:/
+972.8 "Altius?" #sync / 1[56]:[^:]*:Varis Yae Galvus:4CCA:/
+981.7 "--sync--" #sync / 1[56]:[^:]*:Varis Yae Galvus:4CC6:/
+982.9 "Terminus Est" #sync / 1[56]:[^:]*:Terminus Est:4CB4:/
+985.0 "Magitek Shielding" #sync / 1[56]:[^:]*:Varis Yae Galvus:4CDB:/
+989.8 "Ventus Est" #sync / 1[56]:[^:]*:Ventus Est:4CC7:/
+1000.2 "Citius" #sync / 1[56]:[^:]*:Varis Yae Galvus:4CF0:/
 
 
 ### Phase 4: Stack Spread Shield
 1200.0 "--untargetable--"
-1200.0 "--sync--" sync / 1[56]:Varis Yae Galvus:4CE0:/ window 1200,0
+1200.0 "--sync--" sync / 1[56]:[^:]*:Varis Yae Galvus:4CE0:/ window 1200,0
 1200.1 "Gunshield"
-1210.4 "Magitek Spark/Torch" sync / 1[56]:Gunshield:(4CE4|4CE3):/ window 10,5
-1219.1 "Magitek Torch/Spark" sync / 1[56]:Gunshield:(4CE4|4CE3):/ window 5,5
+1210.4 "Magitek Spark/Torch" sync / 1[56]:[^:]*:Gunshield:(4CE4|4CE3):/ window 10,5
+1219.1 "Magitek Torch/Spark" sync / 1[56]:[^:]*:Gunshield:(4CE4|4CE3):/ window 5,5
 # 52 second cast
-1254.0 "Altius Enrage" sync / 1[56]:Varis Yae Galvus:4CE1:/
+1254.0 "Altius Enrage" sync / 1[56]:[^:]*:Varis Yae Galvus:4CE1:/
 
 
 ### Phase 5: Fortius
-1300.0 "--sync--" sync / 1[56]:Varis Yae Galvus:4CE2:/ window 1300,0
+1300.0 "--sync--" sync / 1[56]:[^:]*:Varis Yae Galvus:4CE2:/ window 1300,0
 1303.0 "--targetable--"
-1313.3 "Loaded Gunshield" sync / 1[56]:Varis Yae Galvus:4CD8:/
+1313.3 "Loaded Gunshield" sync / 1[56]:[^:]*:Varis Yae Galvus:4CD8:/
 # note: two different abilities for clockwise vs counter-clockwise
-1322.5 "--sync--" sync / 1[56]:Varis Yae Galvus:4CE[56]:/
-1323.3 "Fortius" sync / 1[56]:Varis Yae Galvus:4CE7:/
-1335.0 "--sync--" sync / 1[56]:Varis Yae Galvus:4CDE:/
-1338.0 "Magitek Burst" sync / 1[56]:Varis Yae Galvus:4CDF:/
-1343.3 "Festina Lente" sync / 1[56]:Varis Yae Galvus:4CC9:/
-1354.4 "Citius" sync / 1[56]:Varis Yae Galvus:4CF0:/
+1322.5 "--sync--" sync / 1[56]:[^:]*:Varis Yae Galvus:4CE[56]:/
+1323.3 "Fortius" sync / 1[56]:[^:]*:Varis Yae Galvus:4CE7:/
+1335.0 "--sync--" sync / 1[56]:[^:]*:Varis Yae Galvus:4CDE:/
+1338.0 "Magitek Burst" sync / 1[56]:[^:]*:Varis Yae Galvus:4CDF:/
+1343.3 "Festina Lente" sync / 1[56]:[^:]*:Varis Yae Galvus:4CC9:/
+1354.4 "Citius" sync / 1[56]:[^:]*:Varis Yae Galvus:4CF0:/
 
-1363.3 "--clones appear--" sync / 1[56]:Phantom Varis:4CB3:/
-1368.0 "Electrified Gunshield" sync / 1[56]:Varis Yae Galvus:4CD7:/
-1377.2 "--sync--" sync / 1[56]:Varis Yae Galvus:4CE[56]:/
-1378.0 "Fortius" sync / 1[56]:Varis Yae Galvus:4CE7:/
-1392.2 "Terminus Est" sync / 1[56]:Terminus Est:4CB4:/
-1394.6 "Magitek Shock" sync / 1[56]:Varis Yae Galvus:4CDA:/
-1408.5 "--clones appear--" sync / 1[56]:Phantom Varis:4CB3:/
-1412.9 "Altius" sync / 1[56]:Varis Yae Galvus:4CCA:/
-1421.2 "Festina Lente" sync / 1[56]:Varis Yae Galvus:4CC9:/
-1427.7 "--sync--" sync / 1[56]:Varis Yae Galvus:4CC6:/
-1435.1 "Alea Iacta Est" sync / 1[56]:Varis Yae Galvus:4CD2:/
-1436.3 "--sync--" sync / 1[56]:Varis Yae Galvus:4CD3:/
-1436.7 "--sync--" sync / 1[56]:Varis Yae Galvus:4CD4:/
-1437.1 "--sync--" sync / 1[56]:Varis Yae Galvus:4CD5:/
-1439.8 "--sync--" sync / 1[56]:Varis Yae Galvus:4CD6:/
-1440.9 "Terminus Est" sync / 1[56]:Terminus Est:4CB4:/
-1440.9 "Ventus Est" sync / 1[56]:Ventus Est:4CC7:/
-1451.5 "Citius" sync / 1[56]:Varis Yae Galvus:4CF0:/
+1363.3 "--clones appear--" sync / 1[56]:[^:]*:Phantom Varis:4CB3:/
+1368.0 "Electrified Gunshield" sync / 1[56]:[^:]*:Varis Yae Galvus:4CD7:/
+1377.2 "--sync--" sync / 1[56]:[^:]*:Varis Yae Galvus:4CE[56]:/
+1378.0 "Fortius" sync / 1[56]:[^:]*:Varis Yae Galvus:4CE7:/
+1392.2 "Terminus Est" sync / 1[56]:[^:]*:Terminus Est:4CB4:/
+1394.6 "Magitek Shock" sync / 1[56]:[^:]*:Varis Yae Galvus:4CDA:/
+1408.5 "--clones appear--" sync / 1[56]:[^:]*:Phantom Varis:4CB3:/
+1412.9 "Altius" sync / 1[56]:[^:]*:Varis Yae Galvus:4CCA:/
+1421.2 "Festina Lente" sync / 1[56]:[^:]*:Varis Yae Galvus:4CC9:/
+1427.7 "--sync--" sync / 1[56]:[^:]*:Varis Yae Galvus:4CC6:/
+1435.1 "Alea Iacta Est" sync / 1[56]:[^:]*:Varis Yae Galvus:4CD2:/
+1436.3 "--sync--" sync / 1[56]:[^:]*:Varis Yae Galvus:4CD3:/
+1436.7 "--sync--" sync / 1[56]:[^:]*:Varis Yae Galvus:4CD4:/
+1437.1 "--sync--" sync / 1[56]:[^:]*:Varis Yae Galvus:4CD5:/
+1439.8 "--sync--" sync / 1[56]:[^:]*:Varis Yae Galvus:4CD6:/
+1440.9 "Terminus Est" sync / 1[56]:[^:]*:Terminus Est:4CB4:/
+1440.9 "Ventus Est" sync / 1[56]:[^:]*:Ventus Est:4CC7:/
+1451.5 "Citius" sync / 1[56]:[^:]*:Varis Yae Galvus:4CF0:/
 
-1461.0 "--sync--" sync / 1[56]:Varis Yae Galvus:4CB5:/
-1468.8 "Alea Iacta Est" sync / 1[56]:Varis Yae Galvus:4CD2:/
-1470.0 "--sync--" sync / 1[56]:Varis Yae Galvus:4CD3:/
-1470.4 "--sync--" sync / 1[56]:Varis Yae Galvus:4CD4:/
-1470.8 "--sync--" sync / 1[56]:Varis Yae Galvus:4CD5:/
-1473.5 "--sync--" sync / 1[56]:Varis Yae Galvus:4CD6:/
-1474.2 "Ignis Est" sync / 1[56]:Ignis Est:4CB6:/
+1461.0 "--sync--" sync / 1[56]:[^:]*:Varis Yae Galvus:4CB5:/
+1468.8 "Alea Iacta Est" sync / 1[56]:[^:]*:Varis Yae Galvus:4CD2:/
+1470.0 "--sync--" sync / 1[56]:[^:]*:Varis Yae Galvus:4CD3:/
+1470.4 "--sync--" sync / 1[56]:[^:]*:Varis Yae Galvus:4CD4:/
+1470.8 "--sync--" sync / 1[56]:[^:]*:Varis Yae Galvus:4CD5:/
+1473.5 "--sync--" sync / 1[56]:[^:]*:Varis Yae Galvus:4CD6:/
+1474.2 "Ignis Est" sync / 1[56]:[^:]*:Ignis Est:4CB6:/
 
-1492.4 "Loaded Gunshield" sync / 1[56]:Varis Yae Galvus:4CD8:/
-1501.6 "--sync--" sync / 1[56]:Varis Yae Galvus:4CE[56]:/
-1502.4 "Fortius" sync / 1[56]:Varis Yae Galvus:4CE7:/
-1514.1 "--sync--" sync / 1[56]:Varis Yae Galvus:4CDE:/
-1517.2 "Magitek Burst" sync / 1[56]:Varis Yae Galvus:4CDF:/
+1492.4 "Loaded Gunshield" sync / 1[56]:[^:]*:Varis Yae Galvus:4CD8:/
+1501.6 "--sync--" sync / 1[56]:[^:]*:Varis Yae Galvus:4CE[56]:/
+1502.4 "Fortius" sync / 1[56]:[^:]*:Varis Yae Galvus:4CE7:/
+1514.1 "--sync--" sync / 1[56]:[^:]*:Varis Yae Galvus:4CDE:/
+1517.2 "Magitek Burst" sync / 1[56]:[^:]*:Varis Yae Galvus:4CDF:/
 
-1522.4 "Festina Lente" sync / 1[56]:Varis Yae Galvus:4CC9:/
-1533.7 "Citius" sync / 1[56]:Varis Yae Galvus:4CF0:/
-1542.5 "--clones appear--" sync / 1[56]:Phantom Varis:4CB3:/
-1547.0 "Electrified Gunshield" sync / 1[56]:Varis Yae Galvus:4CD7:/
-1556.3 "--sync--" sync / 1[56]:Varis Yae Galvus:4CE[56]:/
-1557.1 "Fortius" sync / 1[56]:Varis Yae Galvus:4CE7:/
-1571.3 "Terminus Est" sync / 1[56]:Terminus Est:4CB4:/
-1573.6 "Magitek Shock" sync / 1[56]:Varis Yae Galvus:4CDA:/
+1522.4 "Festina Lente" sync / 1[56]:[^:]*:Varis Yae Galvus:4CC9:/
+1533.7 "Citius" sync / 1[56]:[^:]*:Varis Yae Galvus:4CF0:/
+1542.5 "--clones appear--" sync / 1[56]:[^:]*:Phantom Varis:4CB3:/
+1547.0 "Electrified Gunshield" sync / 1[56]:[^:]*:Varis Yae Galvus:4CD7:/
+1556.3 "--sync--" sync / 1[56]:[^:]*:Varis Yae Galvus:4CE[56]:/
+1557.1 "Fortius" sync / 1[56]:[^:]*:Varis Yae Galvus:4CE7:/
+1571.3 "Terminus Est" sync / 1[56]:[^:]*:Terminus Est:4CB4:/
+1573.6 "Magitek Shock" sync / 1[56]:[^:]*:Varis Yae Galvus:4CDA:/
 
-1579.7 "--sync--" sync / 14:Varis Yae Galvus:4CA9:/ window 30,30
-1589.7 "Altius Enrage" sync / 1[56]:Varis Yae Galvus:4CA9:/
+1579.7 "--sync--" sync / 14:[^:]*:Varis Yae Galvus:4CA9:/ window 30,30
+1589.7 "Altius Enrage" sync / 1[56]:[^:]*:Varis Yae Galvus:4CA9:/

--- a/ui/raidboss/data/05-shb/trial/wol-ex.txt
+++ b/ui/raidboss/data/05-shb/trial/wol-ex.txt
@@ -29,424 +29,424 @@ hideall "Limit Break"
 
 ### Phase 1: Warmup
 0.0 "--sync--" sync /:Engage!/ window 0,1
-3.0 "--sync--" sync / 1[56]:Warrior Of Light:5459:/ window 3,0
-9.7 "Terror Unleashed" sync / 1[56]:Warrior Of Light:4F09:/ window 20,20
-15.8 "To The Limit 3" sync / 1[56]:Warrior Of Light:4F36:/
-27.6 "Solemn Confiteor" sync / 1[56]:Warrior Of Light:4F0C:/
-32.1 "Absolute Stone III" sync / 1[56]:Warrior Of Light:4F2C:/
-41.2 "Limit Break" sync / 1[56]:Warrior Of Light:4EFB:/
-41.3 "Radiant Meteor" sync / 1[56]:Warrior Of Light:4EFC:/
-49.4 "--middle--" sync / 1[56]:Warrior Of Light:4F45:/
-54.6 "Imbued Stone" sync / 1[56]:Warrior Of Light:4EF6:/
-63.7 "Imbued Fire/Ice" sync / 1[56]:Warrior Of Light:4EF[34]:/
-76.8 "Imbued Coruscance" sync / 1[56]:Warrior Of Light:4F4[9A]:/
-84.0 "To The Limit 2" sync / 1[56]:Warrior Of Light:4F35:/
-92.1 "Sword Of Light" sync / 1[56]:Warrior Of Light:4F42:/
-109.4 "Absolute Holy" sync / 1[56]:Warrior Of Light:4F2B:/
-110.4 "Shining Wave" sync / 1[56]:Warrior Of Light:4F08:/
-118.6 "Limit Break" sync / 1[56]:Warrior Of Light:53CB:/
-119.0 "Radiant Desperado 1" sync / 1[56]:Warrior Of Light:4EF9:/
-123.3 "Radiant Desperado 2" sync / 1[56]:Warrior Of Light:4EFA:/
-127.4 "--middle--" sync / 1[56]:Warrior Of Light:4F45:/
-132.7 "To The Limit 1" sync / 1[56]:Warrior Of Light:4F34:/
-140.8 "Imbued Holy" sync / 1[56]:Warrior Of Light:4EF5:/
-149.9 "Imbued Ice/Fire" sync / 1[56]:Warrior Of Light:4EF[34]:/
-163.0 "Imbued Coruscance" sync / 1[56]:Warrior Of Light:4F4[9A]:/
-173.1 "Limit Break" sync / 1[56]:Warrior Of Light:515C:/
-173.4 "Radiant Braver" sync / 1[56]:Warrior Of Light:4EF7:/
-186.5 "The Bitter End" sync / 1[56]:Warrior Of Light:4F0A:/
-192.7 "Summon Wyrm" sync / 1[56]:Warrior Of Light:4F41:/
-198.8 "Solemn Confiteor" sync / 1[56]:Warrior Of Light:4F0C:/
-200.8 "Absolute Flash" sync / 1[56]:Warrior Of Light:4F2F:/
-202.9 "Cauterize" sync / 1[56]:Wyrm Of Light:4F07:/
-209.0 "Elddragon Dive" sync / 1[56]:Warrior Of Light:4F0B:/
+3.0 "--sync--" sync / 1[56]:[^:]*:Warrior Of Light:5459:/ window 3,0
+9.7 "Terror Unleashed" sync / 1[56]:[^:]*:Warrior Of Light:4F09:/ window 20,20
+15.8 "To The Limit 3" sync / 1[56]:[^:]*:Warrior Of Light:4F36:/
+27.6 "Solemn Confiteor" sync / 1[56]:[^:]*:Warrior Of Light:4F0C:/
+32.1 "Absolute Stone III" sync / 1[56]:[^:]*:Warrior Of Light:4F2C:/
+41.2 "Limit Break" sync / 1[56]:[^:]*:Warrior Of Light:4EFB:/
+41.3 "Radiant Meteor" sync / 1[56]:[^:]*:Warrior Of Light:4EFC:/
+49.4 "--middle--" sync / 1[56]:[^:]*:Warrior Of Light:4F45:/
+54.6 "Imbued Stone" sync / 1[56]:[^:]*:Warrior Of Light:4EF6:/
+63.7 "Imbued Fire/Ice" sync / 1[56]:[^:]*:Warrior Of Light:4EF[34]:/
+76.8 "Imbued Coruscance" sync / 1[56]:[^:]*:Warrior Of Light:4F4[9A]:/
+84.0 "To The Limit 2" sync / 1[56]:[^:]*:Warrior Of Light:4F35:/
+92.1 "Sword Of Light" sync / 1[56]:[^:]*:Warrior Of Light:4F42:/
+109.4 "Absolute Holy" sync / 1[56]:[^:]*:Warrior Of Light:4F2B:/
+110.4 "Shining Wave" sync / 1[56]:[^:]*:Warrior Of Light:4F08:/
+118.6 "Limit Break" sync / 1[56]:[^:]*:Warrior Of Light:53CB:/
+119.0 "Radiant Desperado 1" sync / 1[56]:[^:]*:Warrior Of Light:4EF9:/
+123.3 "Radiant Desperado 2" sync / 1[56]:[^:]*:Warrior Of Light:4EFA:/
+127.4 "--middle--" sync / 1[56]:[^:]*:Warrior Of Light:4F45:/
+132.7 "To The Limit 1" sync / 1[56]:[^:]*:Warrior Of Light:4F34:/
+140.8 "Imbued Holy" sync / 1[56]:[^:]*:Warrior Of Light:4EF5:/
+149.9 "Imbued Ice/Fire" sync / 1[56]:[^:]*:Warrior Of Light:4EF[34]:/
+163.0 "Imbued Coruscance" sync / 1[56]:[^:]*:Warrior Of Light:4F4[9A]:/
+173.1 "Limit Break" sync / 1[56]:[^:]*:Warrior Of Light:515C:/
+173.4 "Radiant Braver" sync / 1[56]:[^:]*:Warrior Of Light:4EF7:/
+186.5 "The Bitter End" sync / 1[56]:[^:]*:Warrior Of Light:4F0A:/
+192.7 "Summon Wyrm" sync / 1[56]:[^:]*:Warrior Of Light:4F41:/
+198.8 "Solemn Confiteor" sync / 1[56]:[^:]*:Warrior Of Light:4F0C:/
+200.8 "Absolute Flash" sync / 1[56]:[^:]*:Warrior Of Light:4F2F:/
+202.9 "Cauterize" sync / 1[56]:[^:]*:Wyrm Of Light:4F07:/
+209.0 "Elddragon Dive" sync / 1[56]:[^:]*:Warrior Of Light:4F0B:/
 
 ### Phase 2: Adds
-217.4 "--middle--" sync / 1[56]:Warrior Of Light:4F45:/
-222.8 "Specter Of Light" sync / 1[56]:Warrior Of Light:4F37:/ window 300,10
+217.4 "--middle--" sync / 1[56]:[^:]*:Warrior Of Light:4F45:/
+222.8 "Specter Of Light" sync / 1[56]:[^:]*:Warrior Of Light:4F37:/ window 300,10
 225.9 "--untargetable--"
-226.0 "--sync--" sync / 1[56]:Warrior Of Light:5151:/
+226.0 "--sync--" sync / 1[56]:[^:]*:Warrior Of Light:5151:/
 
 231.2 "--adds targetable--"
-239.3 "Deluge Of Death" sync / 1[56]:Spectral Bard:4F3B:/
-241.3 "Twincast" sync / 1[56]:Spectral Black Mage:4F3D:/
-243.3 "--sync--" sync / 1[56]:Spectral Ninja:4F39:/
-244.0 "--sync--" sync / 1[56]:Spectral White Mage:531E:/
-245.4 "Fatal Cleave" sync / 1[56]:Spectral Warrior:5154:/
-245.4 "Blade Of Shadow" sync / 1[56]:Spectral Dark Knight:5157:/
-246.3 "Summon" sync / 1[56]:Spectral Summoner:4F3F:/
-247.4 "Deluge Of Death" sync / 1[56]:Spectral Bard:4F02:/
-251.0 "--sync--" sync / 1[56]:Spectral Bard:531E:/
-251.4 "Katon: San" sync / 1[56]:Spectral Ninja:4EFE:/
-253.4 "Meteor Impact" sync / 1[56]:Spectral Black Mage:5098:/
-255.1 "--sync--" sync / 1[56]:Spectral Ninja:531E:/
-258.4 "Berserk" #sync / 1[56]:Spectral Warrior:5156:/
-258.4 "Deep Darkside" #sync / 1[56]:Spectral Dark Knight:5158:/
-260.4 "Flare Breath" sync / 1[56]:Spectral Summoner:4F40:/
-266.2 "--sync--" sync / 1[56]:Spectral Summoner:531E:/
+239.3 "Deluge Of Death" sync / 1[56]:[^:]*:Spectral Bard:4F3B:/
+241.3 "Twincast" sync / 1[56]:[^:]*:Spectral Black Mage:4F3D:/
+243.3 "--sync--" sync / 1[56]:[^:]*:Spectral Ninja:4F39:/
+244.0 "--sync--" sync / 1[56]:[^:]*:Spectral White Mage:531E:/
+245.4 "Fatal Cleave" sync / 1[56]:[^:]*:Spectral Warrior:5154:/
+245.4 "Blade Of Shadow" sync / 1[56]:[^:]*:Spectral Dark Knight:5157:/
+246.3 "Summon" sync / 1[56]:[^:]*:Spectral Summoner:4F3F:/
+247.4 "Deluge Of Death" sync / 1[56]:[^:]*:Spectral Bard:4F02:/
+251.0 "--sync--" sync / 1[56]:[^:]*:Spectral Bard:531E:/
+251.4 "Katon: San" sync / 1[56]:[^:]*:Spectral Ninja:4EFE:/
+253.4 "Meteor Impact" sync / 1[56]:[^:]*:Spectral Black Mage:5098:/
+255.1 "--sync--" sync / 1[56]:[^:]*:Spectral Ninja:531E:/
+258.4 "Berserk" #sync / 1[56]:[^:]*:Spectral Warrior:5156:/
+258.4 "Deep Darkside" #sync / 1[56]:[^:]*:Spectral Dark Knight:5158:/
+260.4 "Flare Breath" sync / 1[56]:[^:]*:Spectral Summoner:4F40:/
+266.2 "--sync--" sync / 1[56]:[^:]*:Spectral Summoner:531E:/
 
-272.6 "Fatal Cleave" sync / 1[56]:Spectral Warrior:5154:/
-272.6 "Blade Of Shadow" sync / 1[56]:Spectral Dark Knight:5157:/
+272.6 "Fatal Cleave" sync / 1[56]:[^:]*:Spectral Warrior:5154:/
+272.6 "Blade Of Shadow" sync / 1[56]:[^:]*:Spectral Dark Knight:5157:/
 
-288.8 "Fatal Cleave" sync / 1[56]:Spectral Warrior:5154:/
-288.8 "Blade Of Shadow" sync / 1[56]:Spectral Dark Knight:5157:/
+288.8 "Fatal Cleave" sync / 1[56]:[^:]*:Spectral Warrior:5154:/
+288.8 "Blade Of Shadow" sync / 1[56]:[^:]*:Spectral Dark Knight:5157:/
 
-305.4 "Fatal Cleave" sync / 1[56]:Spectral Warrior:5154:/
-305.4 "Blade Of Shadow" sync / 1[56]:Spectral Dark Knight:5157:/
+305.4 "Fatal Cleave" sync / 1[56]:[^:]*:Spectral Warrior:5154:/
+305.4 "Blade Of Shadow" sync / 1[56]:[^:]*:Spectral Dark Knight:5157:/
 # ??? enrage
 
 
 ### Phase 3: Random Summons
-500.0 "--sync--" sync / 1[56]:Warrior Of Light:5152:/ window 500,0
-506.1 "Ultimate Crossover" sync / 1[56]:Warrior Of Light:5153:/
+500.0 "--sync--" sync / 1[56]:[^:]*:Warrior Of Light:5152:/ window 500,0
+506.1 "Ultimate Crossover" sync / 1[56]:[^:]*:Warrior Of Light:5153:/
 513.1 "--targetable--"
-517.3 "--middle--" sync / 1[56]:Warrior Of Light:4F45:/
+517.3 "--middle--" sync / 1[56]:[^:]*:Warrior Of Light:4F45:/
 
 # BLM/WHM
-519.6 "--sync--" sync / 14:Warrior Of Light:4F73:/ window 5,5 jump 1519.5
-522.6 "Specter -> BLM/WHM" #sync / 1[56]:Warrior Of Light:4F73:/
-527.8 "--sync--" sync / 14:Spectral Black Mage:4F3D:/ window 40,40 jump 1527.8
+519.6 "--sync--" sync / 14:[^:]*:Warrior Of Light:4F73:/ window 5,5 jump 1519.5
+522.6 "Specter -> BLM/WHM" #sync / 1[56]:[^:]*:Warrior Of Light:4F73:/
+527.8 "--sync--" sync / 14:[^:]*:Spectral Black Mage:4F3D:/ window 40,40 jump 1527.8
 
 # DRK/BRD
-519.6 "--sync--" sync / 14:Warrior Of Light:4F3[456]:/ window 5,5 jump 2519.6
-522.6 "Limit -> DRK/BRD" #sync / 1[56]:Warrior Of Light:4F3[456]:/
-534.0 "--sync--" sync / 14:Warrior Of Light:4F43:/ window 40,40 jump 2534.0
+519.6 "--sync--" sync / 14:[^:]*:Warrior Of Light:4F3[456]:/ window 5,5 jump 2519.6
+522.6 "Limit -> DRK/BRD" #sync / 1[56]:[^:]*:Warrior Of Light:4F3[456]:/
+534.0 "--sync--" sync / 14:[^:]*:Warrior Of Light:4F43:/ window 40,40 jump 2534.0
 
 # NIN
-519.6 "--sync--" sync / 14:Warrior Of Light:4EF[56]:/ window 40,40 jump 3519.6
-522.6 "Stone/Holy -> NIN" #sync / 1[56]:Warrior Of Light:4EF[56]:/
+519.6 "--sync--" sync / 14:[^:]*:Warrior Of Light:4EF[56]:/ window 40,40 jump 3519.6
+522.6 "Stone/Holy -> NIN" #sync / 1[56]:[^:]*:Warrior Of Light:4EF[56]:/
 
 # SMN/WAR
-519.6 "--sync--" sync / 14:Warrior Of Light:4EF[34]:/ window 40,40 jump 4519.7
-522.6 "Fire/Ice -> SMN/WAR" #sync / 1[56]:Warrior Of Light:4EF[34]:/
+519.6 "--sync--" sync / 14:[^:]*:Warrior Of Light:4EF[34]:/ window 40,40 jump 4519.7
+522.6 "Fire/Ice -> SMN/WAR" #sync / 1[56]:[^:]*:Warrior Of Light:4EF[34]:/
 
 
 ### Phase 3a: BLM/WHM
-1517.3 "--middle--" sync / 1[56]:Warrior Of Light:4F45:/
-1519.5 "--sync--" sync / 14:Warrior Of Light:4F37:/
-1522.5 "Specter Of Light" sync / 1[56]:Warrior Of Light:4F37:/
-1525.6 "--sync--" sync / 14:Warrior Of Light:4F3[56]:/
-1527.8 "--sync--" sync / 14:Spectral Black Mage:4F3D:/
-1528.6 "To The Limit" sync / 1[56]:Warrior Of Light:4F3[456]:/
-1530.8 "Twincast" sync / 1[56]:Spectral Black Mage:4F3D:/
-1533.2 "--sync--" sync / 1[56]:Spectral White Mage:531E:/
-1533.2 "--sync--" sync / 1[56]:Spectral Black Mage:531E:/
-1545.3 "Meteor Impact 1" #sync / 1[56]:Spectral Black Mage:4F03:/
-1547.3 "Meteor Impact 2" #sync / 1[56]:Spectral Black Mage:4F03:/
-1549.4 "Meteor Impact 3" #sync / 1[56]:Spectral Black Mage:4F03:/
-1551.4 "Meteor Impact 4" #sync / 1[56]:Spectral Black Mage:4F03:/
-1553.4 "Meteor Impact 5" #sync / 1[56]:Spectral Black Mage:4F03:/
-1555.4 "Meteor Impact 6" #sync / 1[56]:Spectral Black Mage:4F03:/
-1557.4 "Meteor Impact 7" #sync / 1[56]:Spectral Black Mage:4F03:/
-1557.8 "Summon Wyrm" sync / 1[56]:Warrior Of Light:4F41:/
-1559.4 "Meteor Impact 8" #sync / 1[56]:Spectral Black Mage:4F03:/
-1567.9 "Coruscant Saber" sync / 1[56]:Warrior Of Light:4EF[12]:/
-1568.0 "Cauterize" sync / 1[56]:Wyrm Of Light:4F07:/
-1580.2 "Limit Break" sync / 1[56]:Warrior Of Light:(4EFB|53CB|515C):/
+1517.3 "--middle--" sync / 1[56]:[^:]*:Warrior Of Light:4F45:/
+1519.5 "--sync--" sync / 14:[^:]*:Warrior Of Light:4F37:/
+1522.5 "Specter Of Light" sync / 1[56]:[^:]*:Warrior Of Light:4F37:/
+1525.6 "--sync--" sync / 14:[^:]*:Warrior Of Light:4F3[56]:/
+1527.8 "--sync--" sync / 14:[^:]*:Spectral Black Mage:4F3D:/
+1528.6 "To The Limit" sync / 1[56]:[^:]*:Warrior Of Light:4F3[456]:/
+1530.8 "Twincast" sync / 1[56]:[^:]*:Spectral Black Mage:4F3D:/
+1533.2 "--sync--" sync / 1[56]:[^:]*:Spectral White Mage:531E:/
+1533.2 "--sync--" sync / 1[56]:[^:]*:Spectral Black Mage:531E:/
+1545.3 "Meteor Impact 1" #sync / 1[56]:[^:]*:Spectral Black Mage:4F03:/
+1547.3 "Meteor Impact 2" #sync / 1[56]:[^:]*:Spectral Black Mage:4F03:/
+1549.4 "Meteor Impact 3" #sync / 1[56]:[^:]*:Spectral Black Mage:4F03:/
+1551.4 "Meteor Impact 4" #sync / 1[56]:[^:]*:Spectral Black Mage:4F03:/
+1553.4 "Meteor Impact 5" #sync / 1[56]:[^:]*:Spectral Black Mage:4F03:/
+1555.4 "Meteor Impact 6" #sync / 1[56]:[^:]*:Spectral Black Mage:4F03:/
+1557.4 "Meteor Impact 7" #sync / 1[56]:[^:]*:Spectral Black Mage:4F03:/
+1557.8 "Summon Wyrm" sync / 1[56]:[^:]*:Warrior Of Light:4F41:/
+1559.4 "Meteor Impact 8" #sync / 1[56]:[^:]*:Spectral Black Mage:4F03:/
+1567.9 "Coruscant Saber" sync / 1[56]:[^:]*:Warrior Of Light:4EF[12]:/
+1568.0 "Cauterize" sync / 1[56]:[^:]*:Wyrm Of Light:4F07:/
+1580.2 "Limit Break" sync / 1[56]:[^:]*:Warrior Of Light:(4EFB|53CB|515C):/
 ### TODO: bitter end gets moved up 0.5s if it's meteor???
-1593.1 "--sync--" sync / 14:Warrior Of Light:4F0A:/ window 10,10
-1598.1 "The Bitter End" sync / 1[56]:Warrior Of Light:4F0A:/
+1593.1 "--sync--" sync / 14:[^:]*:Warrior Of Light:4F0A:/ window 10,10
+1598.1 "The Bitter End" sync / 1[56]:[^:]*:Warrior Of Light:4F0A:/
 
-1605.4 "--middle--" sync / 1[56]:Warrior Of Light:4F45:/
-1619.6 "Quintuplecast" sync / 1[56]:Warrior Of Light:4EEF:/
-1622.8 "Cast 1" sync / 1[56]:Warrior Of Light:4EF0:/
-1625.9 "Cast 2" sync / 1[56]:Warrior Of Light:4EF0:/
-1629.0 "Cast 3" sync / 1[56]:Warrior Of Light:4EF0:/
-1632.1 "Cast 4" sync / 1[56]:Warrior Of Light:4EF0:/
-1635.2 "Cast 5" sync / 1[56]:Warrior Of Light:4EF0:/
-1650.2 "Shining Wave" sync / 1[56]:Warrior Of Light:4F08:/
-1651.4 "Elddragon Dive" sync / 1[56]:Warrior Of Light:4F0B:/
-1661.7 "--middle--" sync / 1[56]:Warrior Of Light:4F45:/
+1605.4 "--middle--" sync / 1[56]:[^:]*:Warrior Of Light:4F45:/
+1619.6 "Quintuplecast" sync / 1[56]:[^:]*:Warrior Of Light:4EEF:/
+1622.8 "Cast 1" sync / 1[56]:[^:]*:Warrior Of Light:4EF0:/
+1625.9 "Cast 2" sync / 1[56]:[^:]*:Warrior Of Light:4EF0:/
+1629.0 "Cast 3" sync / 1[56]:[^:]*:Warrior Of Light:4EF0:/
+1632.1 "Cast 4" sync / 1[56]:[^:]*:Warrior Of Light:4EF0:/
+1635.2 "Cast 5" sync / 1[56]:[^:]*:Warrior Of Light:4EF0:/
+1650.2 "Shining Wave" sync / 1[56]:[^:]*:Warrior Of Light:4F08:/
+1651.4 "Elddragon Dive" sync / 1[56]:[^:]*:Warrior Of Light:4F0B:/
+1661.7 "--middle--" sync / 1[56]:[^:]*:Warrior Of Light:4F45:/
 
 # DRK/BRD
-1664.0 "--sync--" sync / 14:Warrior Of Light:4F3[456]:/ window 5,5 jump 7002.2
-1667.0 "Limit -> DRK/BRD" #sync / 1[56]:Warrior Of Light:4F3[456]:/
-1678.3 "--sync--" sync / 14:Warrior Of Light:4F43:/ window 40,40 jump 7016.6
+1664.0 "--sync--" sync / 14:[^:]*:Warrior Of Light:4F3[456]:/ window 5,5 jump 7002.2
+1667.0 "Limit -> DRK/BRD" #sync / 1[56]:[^:]*:Warrior Of Light:4F3[456]:/
+1678.3 "--sync--" sync / 14:[^:]*:Warrior Of Light:4F43:/ window 40,40 jump 7016.6
 
 # NIN
-1664.0 "--sync--" sync / 14:Warrior Of Light:4EF[56]:/ window 40,40 jump 8002.3
-1667.0 "Stone/Holy -> NIN" #sync / 1[56]:Warrior Of Light:4EF[56]:/
+1664.0 "--sync--" sync / 14:[^:]*:Warrior Of Light:4EF[56]:/ window 40,40 jump 8002.3
+1667.0 "Stone/Holy -> NIN" #sync / 1[56]:[^:]*:Warrior Of Light:4EF[56]:/
 
 # SMN/WAR
-1664.0 "--sync--" sync / 14:Warrior Of Light:4EF[34]:/ window 40,40 jump 9002.3
-1667.0 "Fire/Ice -> SMN/WAR" #sync / 1[56]:Warrior Of Light:4EF[34]:/
+1664.0 "--sync--" sync / 14:[^:]*:Warrior Of Light:4EF[34]:/ window 40,40 jump 9002.3
+1667.0 "Fire/Ice -> SMN/WAR" #sync / 1[56]:[^:]*:Warrior Of Light:4EF[34]:/
 
 
 
 ### Phase 3a: DRK/BRD
-2517.3 "--middle--" sync / 1[56]:Warrior Of Light:4F45:/
-2519.6 "--sync--" sync / 14:Warrior Of Light:4F3[46]:/
-2522.6 "To The Limit" sync / 1[56]:Warrior Of Light:4F3[456]:/
-2530.8 "Specter Of Light" sync / 1[56]:Warrior Of Light:4F37:/
-2534.0 "--sync--" sync / 14:Warrior Of Light:4F43:/
-2537.0 "--sync--" sync / 1[56]:Warrior Of Light:4F43:/
-2540.6 "Solemn Confiteor" sync / 1[56]:Warrior Of Light:4F0C:/
-2544.1 "Brimstone Earth" sync / 1[56]:Spectral Dark Knight:4F3A:/
-2547.4 "--sync--" sync / 1[56]:Spectral Dark Knight:531E:/
-2548.4 "Deluge Of Death" sync / 1[56]:Spectral Bard:4F3B:/
-2552.0 "--sync--" sync / 1[56]:Spectral Bard:531E:/
-2556.6 "Absolute Holy" sync / 1[56]:Warrior Of Light:4F2B:/
-2556.6 "Deluge Of Death" sync / 1[56]:Spectral Bard:4F02:/
-2563.6 "--middle--" sync / 1[56]:Warrior Of Light:4F45:/
-2571.8 "Limit Break" sync / 1[56]:Warrior Of Light:(4EFB|53CB|515C):/
-2584.1 "--sync--" sync / 14:Warrior Of Light:4F0A:/ window 10,10
-2589.1 "The Bitter End" sync / 1[56]:Warrior Of Light:4F0A:/
+2517.3 "--middle--" sync / 1[56]:[^:]*:Warrior Of Light:4F45:/
+2519.6 "--sync--" sync / 14:[^:]*:Warrior Of Light:4F3[46]:/
+2522.6 "To The Limit" sync / 1[56]:[^:]*:Warrior Of Light:4F3[456]:/
+2530.8 "Specter Of Light" sync / 1[56]:[^:]*:Warrior Of Light:4F37:/
+2534.0 "--sync--" sync / 14:[^:]*:Warrior Of Light:4F43:/
+2537.0 "--sync--" sync / 1[56]:[^:]*:Warrior Of Light:4F43:/
+2540.6 "Solemn Confiteor" sync / 1[56]:[^:]*:Warrior Of Light:4F0C:/
+2544.1 "Brimstone Earth" sync / 1[56]:[^:]*:Spectral Dark Knight:4F3A:/
+2547.4 "--sync--" sync / 1[56]:[^:]*:Spectral Dark Knight:531E:/
+2548.4 "Deluge Of Death" sync / 1[56]:[^:]*:Spectral Bard:4F3B:/
+2552.0 "--sync--" sync / 1[56]:[^:]*:Spectral Bard:531E:/
+2556.6 "Absolute Holy" sync / 1[56]:[^:]*:Warrior Of Light:4F2B:/
+2556.6 "Deluge Of Death" sync / 1[56]:[^:]*:Spectral Bard:4F02:/
+2563.6 "--middle--" sync / 1[56]:[^:]*:Warrior Of Light:4F45:/
+2571.8 "Limit Break" sync / 1[56]:[^:]*:Warrior Of Light:(4EFB|53CB|515C):/
+2584.1 "--sync--" sync / 14:[^:]*:Warrior Of Light:4F0A:/ window 10,10
+2589.1 "The Bitter End" sync / 1[56]:[^:]*:Warrior Of Light:4F0A:/
 
-2596.4 "--middle--" sync / 1[56]:Warrior Of Light:4F45:/
-2610.6 "Quintuplecast" sync / 1[56]:Warrior Of Light:4EEF:/
-2613.8 "Cast 1" sync / 1[56]:Warrior Of Light:4EF0:/
-2616.9 "Cast 2" sync / 1[56]:Warrior Of Light:4EF0:/
-2620.0 "Cast 3" sync / 1[56]:Warrior Of Light:4EF0:/
-2623.1 "Cast 4" sync / 1[56]:Warrior Of Light:4EF0:/
-2626.2 "Cast 5" sync / 1[56]:Warrior Of Light:4EF0:/
-2641.2 "Shining Wave" sync / 1[56]:Warrior Of Light:4F08:/
-2642.4 "Elddragon Dive" sync / 1[56]:Warrior Of Light:4F0B:/
-2652.7 "--middle--" sync / 1[56]:Warrior Of Light:4F45:/
+2596.4 "--middle--" sync / 1[56]:[^:]*:Warrior Of Light:4F45:/
+2610.6 "Quintuplecast" sync / 1[56]:[^:]*:Warrior Of Light:4EEF:/
+2613.8 "Cast 1" sync / 1[56]:[^:]*:Warrior Of Light:4EF0:/
+2616.9 "Cast 2" sync / 1[56]:[^:]*:Warrior Of Light:4EF0:/
+2620.0 "Cast 3" sync / 1[56]:[^:]*:Warrior Of Light:4EF0:/
+2623.1 "Cast 4" sync / 1[56]:[^:]*:Warrior Of Light:4EF0:/
+2626.2 "Cast 5" sync / 1[56]:[^:]*:Warrior Of Light:4EF0:/
+2641.2 "Shining Wave" sync / 1[56]:[^:]*:Warrior Of Light:4F08:/
+2642.4 "Elddragon Dive" sync / 1[56]:[^:]*:Warrior Of Light:4F0B:/
+2652.7 "--middle--" sync / 1[56]:[^:]*:Warrior Of Light:4F45:/
 
 # BLM/WHM
-2655.0 "--sync--" sync / 14:Warrior Of Light:4F73:/ window 5,5 jump 6002.4
-2658.0 "Specter -> BLM/WHM" #sync / 1[56]:Warrior Of Light:4F73:/
-2663.4 "--sync--" sync / 14:Spectral Black Mage:4F3D:/ window 40,40 jump 6010.7
+2655.0 "--sync--" sync / 14:[^:]*:Warrior Of Light:4F73:/ window 5,5 jump 6002.4
+2658.0 "Specter -> BLM/WHM" #sync / 1[56]:[^:]*:Warrior Of Light:4F73:/
+2663.4 "--sync--" sync / 14:[^:]*:Spectral Black Mage:4F3D:/ window 40,40 jump 6010.7
 
 # NIN
-2655.0 "--sync--" sync / 14:Warrior Of Light:4EF[56]:/ window 40,40 jump 8002.3
-2658.0 "Stone/Holy -> NIN" #sync / 1[56]:Warrior Of Light:4EF[56]:/
+2655.0 "--sync--" sync / 14:[^:]*:Warrior Of Light:4EF[56]:/ window 40,40 jump 8002.3
+2658.0 "Stone/Holy -> NIN" #sync / 1[56]:[^:]*:Warrior Of Light:4EF[56]:/
 
 # SMN/WAR
-2655.0 "--sync--" sync / 14:Warrior Of Light:4EF[34]:/ window 40,40 jump 9002.3
-2658.0 "Fire/Ice -> SMN/WAR" #sync / 1[56]:Warrior Of Light:4EF[34]:/
+2655.0 "--sync--" sync / 14:[^:]*:Warrior Of Light:4EF[34]:/ window 40,40 jump 9002.3
+2658.0 "Fire/Ice -> SMN/WAR" #sync / 1[56]:[^:]*:Warrior Of Light:4EF[34]:/
 
 
 
 ### Phase 3a: NIN
-3517.3 "--middle--" sync / 1[56]:Warrior Of Light:4F45:/
-3519.6 "--sync--" sync / 14:Warrior Of Light:4EF[56]:/
-3522.6 "Imbued Stone/Holy" sync / 1[56]:Warrior Of Light:4EF[56]:/
-3531.7 "Specter Of Light" sync / 1[56]:Warrior Of Light:4F37:/
-3540.0 "--sync--" sync / 1[56]:Spectral Ninja:4F38:/
-3547.1 "--sync--" sync / 1[56]:Spectral Ninja:4F39:/
-3550.5 "Solemn Confiteor" sync / 1[56]:Warrior Of Light:4F0C:/
-3554.1 "Suiton: San" sync / 1[56]:Spectral Ninja:4EFD:/
-3557.2 "--middle--" sync / 1[56]:Warrior Of Light:4F45:/
-3557.2 "Katon: San" sync / 1[56]:Spectral Ninja:4EFE:/
-3558.0 "--sync--" sync / 1[56]:Spectral Ninja:531E:/
-3566.6 "Imbued Coruscance" sync / 1[56]:Warrior Of Light:4F4[9A]:/
-3575.7 "Elddragon Dive" sync / 1[56]:Warrior Of Light:4F0B:/
-3589.0 "The Bitter End" sync / 1[56]:Warrior Of Light:4F0A:/
+3517.3 "--middle--" sync / 1[56]:[^:]*:Warrior Of Light:4F45:/
+3519.6 "--sync--" sync / 14:[^:]*:Warrior Of Light:4EF[56]:/
+3522.6 "Imbued Stone/Holy" sync / 1[56]:[^:]*:Warrior Of Light:4EF[56]:/
+3531.7 "Specter Of Light" sync / 1[56]:[^:]*:Warrior Of Light:4F37:/
+3540.0 "--sync--" sync / 1[56]:[^:]*:Spectral Ninja:4F38:/
+3547.1 "--sync--" sync / 1[56]:[^:]*:Spectral Ninja:4F39:/
+3550.5 "Solemn Confiteor" sync / 1[56]:[^:]*:Warrior Of Light:4F0C:/
+3554.1 "Suiton: San" sync / 1[56]:[^:]*:Spectral Ninja:4EFD:/
+3557.2 "--middle--" sync / 1[56]:[^:]*:Warrior Of Light:4F45:/
+3557.2 "Katon: San" sync / 1[56]:[^:]*:Spectral Ninja:4EFE:/
+3558.0 "--sync--" sync / 1[56]:[^:]*:Spectral Ninja:531E:/
+3566.6 "Imbued Coruscance" sync / 1[56]:[^:]*:Warrior Of Light:4F4[9A]:/
+3575.7 "Elddragon Dive" sync / 1[56]:[^:]*:Warrior Of Light:4F0B:/
+3589.0 "The Bitter End" sync / 1[56]:[^:]*:Warrior Of Light:4F0A:/
 
-3596.3 "--middle--" sync / 1[56]:Warrior Of Light:4F45:/
-3610.5 "Quintuplecast" sync / 1[56]:Warrior Of Light:4EEF:/
-3613.7 "Cast 1" sync / 1[56]:Warrior Of Light:4EF0:/
-3616.8 "Cast 2" sync / 1[56]:Warrior Of Light:4EF0:/
-3619.9 "Cast 3" sync / 1[56]:Warrior Of Light:4EF0:/
-3623.0 "Cast 4" sync / 1[56]:Warrior Of Light:4EF0:/
-3626.1 "Cast 5" sync / 1[56]:Warrior Of Light:4EF0:/
-3641.1 "Shining Wave" sync / 1[56]:Warrior Of Light:4F08:/
-3642.3 "Elddragon Dive" sync / 1[56]:Warrior Of Light:4F0B:/
-3652.6 "--middle--" sync / 1[56]:Warrior Of Light:4F45:/
+3596.3 "--middle--" sync / 1[56]:[^:]*:Warrior Of Light:4F45:/
+3610.5 "Quintuplecast" sync / 1[56]:[^:]*:Warrior Of Light:4EEF:/
+3613.7 "Cast 1" sync / 1[56]:[^:]*:Warrior Of Light:4EF0:/
+3616.8 "Cast 2" sync / 1[56]:[^:]*:Warrior Of Light:4EF0:/
+3619.9 "Cast 3" sync / 1[56]:[^:]*:Warrior Of Light:4EF0:/
+3623.0 "Cast 4" sync / 1[56]:[^:]*:Warrior Of Light:4EF0:/
+3626.1 "Cast 5" sync / 1[56]:[^:]*:Warrior Of Light:4EF0:/
+3641.1 "Shining Wave" sync / 1[56]:[^:]*:Warrior Of Light:4F08:/
+3642.3 "Elddragon Dive" sync / 1[56]:[^:]*:Warrior Of Light:4F0B:/
+3652.6 "--middle--" sync / 1[56]:[^:]*:Warrior Of Light:4F45:/
 
 # BLM/WHM
-3654.9 "--sync--" sync / 14:Warrior Of Light:4F73:/ window 5,5 jump 6002.4
-3657.9 "Specter -> BLM/WHM" #sync / 1[56]:Warrior Of Light:4F73:/
-3663.3 "--sync--" sync / 14:Spectral Black Mage:4F3D:/ window 40,40 jump 6010.7
+3654.9 "--sync--" sync / 14:[^:]*:Warrior Of Light:4F73:/ window 5,5 jump 6002.4
+3657.9 "Specter -> BLM/WHM" #sync / 1[56]:[^:]*:Warrior Of Light:4F73:/
+3663.3 "--sync--" sync / 14:[^:]*:Spectral Black Mage:4F3D:/ window 40,40 jump 6010.7
 
 # DRK/BRD
-3654.9 "--sync--" sync / 14:Warrior Of Light:4F3[456]:/ window 5,5 jump 7002.2
-3657.9 "Limit -> DRK/BRD" #sync / 1[56]:Warrior Of Light:4F3[456]:/
-3669.2 "--sync--" sync / 14:Warrior Of Light:4F43:/ window 40,40 jump 7016.6
+3654.9 "--sync--" sync / 14:[^:]*:Warrior Of Light:4F3[456]:/ window 5,5 jump 7002.2
+3657.9 "Limit -> DRK/BRD" #sync / 1[56]:[^:]*:Warrior Of Light:4F3[456]:/
+3669.2 "--sync--" sync / 14:[^:]*:Warrior Of Light:4F43:/ window 40,40 jump 7016.6
 
 # SMN/WAR
-3654.9 "--sync--" sync / 14:Warrior Of Light:4EF[34]:/ window 40,40 jump 9002.3
-3657.9 "Fire/Ice -> SMN/WAR" #sync / 1[56]:Warrior Of Light:4EF[34]:/
+3654.9 "--sync--" sync / 14:[^:]*:Warrior Of Light:4EF[34]:/ window 40,40 jump 9002.3
+3657.9 "Fire/Ice -> SMN/WAR" #sync / 1[56]:[^:]*:Warrior Of Light:4EF[34]:/
 
 
 ### Phase 3a: SMN/WAR
-4517.4 "--middle--" sync / 1[56]:Warrior Of Light:4F45:/
-4519.7 "--sync--" sync / 14:Warrior Of Light:4EF[34]:/
-4522.7 "Imbued Fire/Ice" sync / 1[56]:Warrior Of Light:4EF[34]:/
-4531.9 "Specter Of Light" sync / 1[56]:Warrior Of Light:4F37:/
-4540.2 "Summon" sync / 1[56]:Spectral Summoner:4F3F:/
-4554.4 "Flare Breath" sync / 1[56]:Spectral Summoner:4F40:/
-4554.7 "Perfect Decimation" sync / 1[56]:(Spectral Warrior|Warrior Of Light):4F05:/
-4554.9 "Solemn Confiteor" sync / 1[56]:Warrior Of Light:4F0C:/
-4566.1 "Solemn Confiteor" sync / 1[56]:Warrior Of Light:4F0C:/
-4566.5 "Flare Breath" sync / 1[56]:Spectral Summoner:4F40:/
-4566.9 "Perfect Decimation" sync / 1[56]:(Spectral Warrior|Warrior Of Light):4F05:/
-4568.2 "--sync--" sync / 1[56]:Spectral Warrior:531E:/
-4572.4 "--sync--" sync / 1[56]:Spectral Summoner:531E:/
-4572.8 "Summon Wyrm" sync / 1[56]:Warrior Of Light:4F41:/
-4576.0 "--middle--" sync / 1[56]:Warrior Of Light:4F45:/
-4583.1 "Cauterize" sync / 1[56]:Wyrm Of Light:4F07:/
-4585.2 "Imbued Coruscance" sync / 1[56]:Warrior Of Light:4F4[9A]:/
-4594.3 "Elddragon Dive" sync / 1[56]:Warrior Of Light:4F0B:/
-4607.6 "The Bitter End" sync / 1[56]:Warrior Of Light:4F0A:/
+4517.4 "--middle--" sync / 1[56]:[^:]*:Warrior Of Light:4F45:/
+4519.7 "--sync--" sync / 14:[^:]*:Warrior Of Light:4EF[34]:/
+4522.7 "Imbued Fire/Ice" sync / 1[56]:[^:]*:Warrior Of Light:4EF[34]:/
+4531.9 "Specter Of Light" sync / 1[56]:[^:]*:Warrior Of Light:4F37:/
+4540.2 "Summon" sync / 1[56]:[^:]*:Spectral Summoner:4F3F:/
+4554.4 "Flare Breath" sync / 1[56]:[^:]*:Spectral Summoner:4F40:/
+4554.7 "Perfect Decimation" sync / 1[56]:[^:]*:(Spectral Warrior|Warrior Of Light):4F05:/
+4554.9 "Solemn Confiteor" sync / 1[56]:[^:]*:Warrior Of Light:4F0C:/
+4566.1 "Solemn Confiteor" sync / 1[56]:[^:]*:Warrior Of Light:4F0C:/
+4566.5 "Flare Breath" sync / 1[56]:[^:]*:Spectral Summoner:4F40:/
+4566.9 "Perfect Decimation" sync / 1[56]:[^:]*:(Spectral Warrior|Warrior Of Light):4F05:/
+4568.2 "--sync--" sync / 1[56]:[^:]*:Spectral Warrior:531E:/
+4572.4 "--sync--" sync / 1[56]:[^:]*:Spectral Summoner:531E:/
+4572.8 "Summon Wyrm" sync / 1[56]:[^:]*:Warrior Of Light:4F41:/
+4576.0 "--middle--" sync / 1[56]:[^:]*:Warrior Of Light:4F45:/
+4583.1 "Cauterize" sync / 1[56]:[^:]*:Wyrm Of Light:4F07:/
+4585.2 "Imbued Coruscance" sync / 1[56]:[^:]*:Warrior Of Light:4F4[9A]:/
+4594.3 "Elddragon Dive" sync / 1[56]:[^:]*:Warrior Of Light:4F0B:/
+4607.6 "The Bitter End" sync / 1[56]:[^:]*:Warrior Of Light:4F0A:/
 
-4614.9 "--middle--" sync / 1[56]:Warrior Of Light:4F45:/
-4629.1 "Quintuplecast" sync / 1[56]:Warrior Of Light:4EEF:/
-4632.3 "Cast 1" sync / 1[56]:Warrior Of Light:4EF0:/
-4635.4 "Cast 2" sync / 1[56]:Warrior Of Light:4EF0:/
-4638.5 "Cast 3" sync / 1[56]:Warrior Of Light:4EF0:/
-4641.6 "Cast 4" sync / 1[56]:Warrior Of Light:4EF0:/
-4644.7 "Cast 5" sync / 1[56]:Warrior Of Light:4EF0:/
-4659.7 "Shining Wave" sync / 1[56]:Warrior Of Light:4F08:/
-4660.9 "Elddragon Dive" sync / 1[56]:Warrior Of Light:4F0B:/
-4671.2 "--middle--" sync / 1[56]:Warrior Of Light:4F45:/
+4614.9 "--middle--" sync / 1[56]:[^:]*:Warrior Of Light:4F45:/
+4629.1 "Quintuplecast" sync / 1[56]:[^:]*:Warrior Of Light:4EEF:/
+4632.3 "Cast 1" sync / 1[56]:[^:]*:Warrior Of Light:4EF0:/
+4635.4 "Cast 2" sync / 1[56]:[^:]*:Warrior Of Light:4EF0:/
+4638.5 "Cast 3" sync / 1[56]:[^:]*:Warrior Of Light:4EF0:/
+4641.6 "Cast 4" sync / 1[56]:[^:]*:Warrior Of Light:4EF0:/
+4644.7 "Cast 5" sync / 1[56]:[^:]*:Warrior Of Light:4EF0:/
+4659.7 "Shining Wave" sync / 1[56]:[^:]*:Warrior Of Light:4F08:/
+4660.9 "Elddragon Dive" sync / 1[56]:[^:]*:Warrior Of Light:4F0B:/
+4671.2 "--middle--" sync / 1[56]:[^:]*:Warrior Of Light:4F45:/
 
 # BLM/WHM
-4673.5 "--sync--" sync / 14:Warrior Of Light:4F73:/ window 5,5 jump 6002.4
-4676.5 "Specter -> BLM/WHM" #sync / 1[56]:Warrior Of Light:4F73:/
-4681.9 "--sync--" sync / 14:Spectral Black Mage:4F3D:/ window 40,40 jump 6010.7
+4673.5 "--sync--" sync / 14:[^:]*:Warrior Of Light:4F73:/ window 5,5 jump 6002.4
+4676.5 "Specter -> BLM/WHM" #sync / 1[56]:[^:]*:Warrior Of Light:4F73:/
+4681.9 "--sync--" sync / 14:[^:]*:Spectral Black Mage:4F3D:/ window 40,40 jump 6010.7
 
 # DRK/BRD
-4673.5 "--sync--" sync / 14:Warrior Of Light:4F3[456]:/ window 5,5 jump 7002.2
-4676.5 "Limit -> DRK/BRD" #sync / 1[56]:Warrior Of Light:4F3[456]:/
-4687.8 "--sync--" sync / 14:Warrior Of Light:4F43:/ window 40,40 jump 7016.6
+4673.5 "--sync--" sync / 14:[^:]*:Warrior Of Light:4F3[456]:/ window 5,5 jump 7002.2
+4676.5 "Limit -> DRK/BRD" #sync / 1[56]:[^:]*:Warrior Of Light:4F3[456]:/
+4687.8 "--sync--" sync / 14:[^:]*:Warrior Of Light:4F43:/ window 40,40 jump 7016.6
 
 # NIN
-4673.5 "--sync--" sync / 14:Warrior Of Light:4EF[56]:/ window 40,40 jump 8002.3
-4676.5 "Stone/Holy -> NIN" #sync / 1[56]:Warrior Of Light:4EF[56]:/
+4673.5 "--sync--" sync / 14:[^:]*:Warrior Of Light:4EF[56]:/ window 40,40 jump 8002.3
+4676.5 "Stone/Holy -> NIN" #sync / 1[56]:[^:]*:Warrior Of Light:4EF[56]:/
 
 
 
 ### Phase 3b: BLM/WHM
-6000.0 "--middle--" sync / 1[56]:Warrior Of Light:4F45:/
-6002.4 "--sync--" sync / 14:Warrior Of Light:4F37:/
-6005.4 "Specter Of Light" sync / 1[56]:Warrior Of Light:4F37:/
-6008.6 "--sync--" sync / 14:Warrior Of Light:4F3[56]:/
-6010.7 "--sync--" sync / 14:Spectral Black Mage:4F3D:/
-6011.6 "To The Limit" sync / 1[56]:Warrior Of Light:4F3[456]:/
-6013.7 "Twincast" sync / 1[56]:Spectral Black Mage:4F3D:/
-6016.2 "--sync--" sync / 1[56]:Spectral White Mage:531E:/
-6028.3 "Meteor Impact 1" #sync / 1[56]:Warrior Of Light:4F03:/
-6030.3 "Meteor Impact 2" #sync / 1[56]:Spectral Black Mage:4F03:/
-6032.3 "Meteor Impact 3" #sync / 1[56]:Spectral Black Mage:4F03:/
-6034.3 "Meteor Impact 4" #sync / 1[56]:Spectral Black Mage:4F03:/
-6036.3 "Meteor Impact 5" #sync / 1[56]:Spectral Black Mage:4F03:/
-6038.3 "Meteor Impact 6" #sync / 1[56]:Spectral Black Mage:4F03:/
-6040.3 "Meteor Impact 7" #sync / 1[56]:Spectral Black Mage:4F03:/
-6040.8 "Summon Wyrm" sync / 1[56]:Warrior Of Light:4F41:/
-6042.3 "Meteor Impact 8" #sync / 1[56]:Spectral Black Mage:4F03:/
-6050.9 "Coruscant Saber" sync / 1[56]:Warrior Of Light:4EF[12]:/
-6051.0 "Cauterize" sync / 1[56]:Wyrm Of Light:4F07:/
+6000.0 "--middle--" sync / 1[56]:[^:]*:Warrior Of Light:4F45:/
+6002.4 "--sync--" sync / 14:[^:]*:Warrior Of Light:4F37:/
+6005.4 "Specter Of Light" sync / 1[56]:[^:]*:Warrior Of Light:4F37:/
+6008.6 "--sync--" sync / 14:[^:]*:Warrior Of Light:4F3[56]:/
+6010.7 "--sync--" sync / 14:[^:]*:Spectral Black Mage:4F3D:/
+6011.6 "To The Limit" sync / 1[56]:[^:]*:Warrior Of Light:4F3[456]:/
+6013.7 "Twincast" sync / 1[56]:[^:]*:Spectral Black Mage:4F3D:/
+6016.2 "--sync--" sync / 1[56]:[^:]*:Spectral White Mage:531E:/
+6028.3 "Meteor Impact 1" #sync / 1[56]:[^:]*:Warrior Of Light:4F03:/
+6030.3 "Meteor Impact 2" #sync / 1[56]:[^:]*:Spectral Black Mage:4F03:/
+6032.3 "Meteor Impact 3" #sync / 1[56]:[^:]*:Spectral Black Mage:4F03:/
+6034.3 "Meteor Impact 4" #sync / 1[56]:[^:]*:Spectral Black Mage:4F03:/
+6036.3 "Meteor Impact 5" #sync / 1[56]:[^:]*:Spectral Black Mage:4F03:/
+6038.3 "Meteor Impact 6" #sync / 1[56]:[^:]*:Spectral Black Mage:4F03:/
+6040.3 "Meteor Impact 7" #sync / 1[56]:[^:]*:Spectral Black Mage:4F03:/
+6040.8 "Summon Wyrm" sync / 1[56]:[^:]*:Warrior Of Light:4F41:/
+6042.3 "Meteor Impact 8" #sync / 1[56]:[^:]*:Spectral Black Mage:4F03:/
+6050.9 "Coruscant Saber" sync / 1[56]:[^:]*:Warrior Of Light:4EF[12]:/
+6051.0 "Cauterize" sync / 1[56]:[^:]*:Wyrm Of Light:4F07:/
 ### TODO: This is random (note: bitter end gets moved up 0.5s if it's meteor)
-6063.1 "Limit Break" sync / 1[56]:Warrior Of Light:(4EFB|53CB|515C):/
-6075.9 "--sync--" sync / 14:Warrior Of Light:4F0A:/ window 10,10
-6080.9 "The Bitter End" sync / 1[56]:Warrior Of Light:4F0A:/
-6084.1 "--middle--" sync / 1[56]:Warrior Of Light:4F45:/
+6063.1 "Limit Break" sync / 1[56]:[^:]*:Warrior Of Light:(4EFB|53CB|515C):/
+6075.9 "--sync--" sync / 14:[^:]*:Warrior Of Light:4F0A:/ window 10,10
+6080.9 "The Bitter End" sync / 1[56]:[^:]*:Warrior Of Light:4F0A:/
+6084.1 "--middle--" sync / 1[56]:[^:]*:Warrior Of Light:4F45:/
 
 # DRK/BRD
-6086.4 "--sync--" sync / 14:Warrior Of Light:4F3[456]:/ window 5,5 jump 7002.2
-6089.4 "Limit -> DRK/BRD" #sync / 1[56]:Warrior Of Light:4F3[456]:/
-6100.7 "--sync--" sync / 14:Warrior Of Light:4F43:/ window 40,40 jump 7016.6
+6086.4 "--sync--" sync / 14:[^:]*:Warrior Of Light:4F3[456]:/ window 5,5 jump 7002.2
+6089.4 "Limit -> DRK/BRD" #sync / 1[56]:[^:]*:Warrior Of Light:4F3[456]:/
+6100.7 "--sync--" sync / 14:[^:]*:Warrior Of Light:4F43:/ window 40,40 jump 7016.6
 
 # NIN
-6086.4 "--sync--" sync / 14:Warrior Of Light:4EF[56]:/ window 40,40 jump 8002.3
-6089.4 "Stone/Holy -> NIN" #sync / 1[56]:Warrior Of Light:4EF[56]:/
+6086.4 "--sync--" sync / 14:[^:]*:Warrior Of Light:4EF[56]:/ window 40,40 jump 8002.3
+6089.4 "Stone/Holy -> NIN" #sync / 1[56]:[^:]*:Warrior Of Light:4EF[56]:/
 
 # SMN/WAR
-6086.4 "--sync--" sync / 14:Warrior Of Light:4EF[34]:/ window 40,40 jump 9002.3
-6089.4 "Fire/Ice -> SMN/WAR" #sync / 1[56]:Warrior Of Light:4EF[34]:/
+6086.4 "--sync--" sync / 14:[^:]*:Warrior Of Light:4EF[34]:/ window 40,40 jump 9002.3
+6089.4 "Fire/Ice -> SMN/WAR" #sync / 1[56]:[^:]*:Warrior Of Light:4EF[34]:/
 
 
 ### Phase 3b: DRK/BRD
-7000.0 "--middle--" sync / 1[56]:Warrior Of Light:4F45:/
-7002.2 "--sync--" sync / 14:Warrior Of Light:4F3[46]:/
-7005.2 "To The Limit" sync / 1[56]:Warrior Of Light:4F3[456]:/
-7013.4 "Specter Of Light" sync / 1[56]:Warrior Of Light:4F37:/
-7016.6 "--sync--" sync / 14:Warrior Of Light:4F43:/
-7019.6 "--sync--" sync / 1[56]:Warrior Of Light:4F43:/
-7023.2 "Solemn Confiteor" sync / 1[56]:Warrior Of Light:4F0C:/
-7026.8 "Brimstone Earth" sync / 1[56]:Spectral Dark Knight:4F3A:/
-7030.1 "--sync--" sync / 1[56]:Spectral Dark Knight:531E:/
-7031.1 "Deluge Of Death" sync / 1[56]:Spectral Bard:4F3B:/
-7034.7 "--sync--" sync / 1[56]:Spectral Bard:531E:/
-7039.3 "Deluge Of Death" sync / 1[56]:Spectral Bard:4F02:/
-7039.3 "Absolute Holy" sync / 1[56]:Warrior Of Light:4F2B:/
-7046.3 "--middle--" sync / 1[56]:Warrior Of Light:4F45:/
-7054.6 "Limit Break" sync / 1[56]:Warrior Of Light:(4EFB|53CB|515C):/
+7000.0 "--middle--" sync / 1[56]:[^:]*:Warrior Of Light:4F45:/
+7002.2 "--sync--" sync / 14:[^:]*:Warrior Of Light:4F3[46]:/
+7005.2 "To The Limit" sync / 1[56]:[^:]*:Warrior Of Light:4F3[456]:/
+7013.4 "Specter Of Light" sync / 1[56]:[^:]*:Warrior Of Light:4F37:/
+7016.6 "--sync--" sync / 14:[^:]*:Warrior Of Light:4F43:/
+7019.6 "--sync--" sync / 1[56]:[^:]*:Warrior Of Light:4F43:/
+7023.2 "Solemn Confiteor" sync / 1[56]:[^:]*:Warrior Of Light:4F0C:/
+7026.8 "Brimstone Earth" sync / 1[56]:[^:]*:Spectral Dark Knight:4F3A:/
+7030.1 "--sync--" sync / 1[56]:[^:]*:Spectral Dark Knight:531E:/
+7031.1 "Deluge Of Death" sync / 1[56]:[^:]*:Spectral Bard:4F3B:/
+7034.7 "--sync--" sync / 1[56]:[^:]*:Spectral Bard:531E:/
+7039.3 "Deluge Of Death" sync / 1[56]:[^:]*:Spectral Bard:4F02:/
+7039.3 "Absolute Holy" sync / 1[56]:[^:]*:Warrior Of Light:4F2B:/
+7046.3 "--middle--" sync / 1[56]:[^:]*:Warrior Of Light:4F45:/
+7054.6 "Limit Break" sync / 1[56]:[^:]*:Warrior Of Light:(4EFB|53CB|515C):/
 # TODO: guessing here
-7066.8 "--sync--" sync / 14:Warrior Of Light:4F0A:/ window 10,10
-7071.8 "The Bitter End" sync / 1[56]:Warrior Of Light:4F0A:/
-7079.1 "--middle--" sync / 1[56]:Warrior Of Light:4F45:/
+7066.8 "--sync--" sync / 14:[^:]*:Warrior Of Light:4F0A:/ window 10,10
+7071.8 "The Bitter End" sync / 1[56]:[^:]*:Warrior Of Light:4F0A:/
+7079.1 "--middle--" sync / 1[56]:[^:]*:Warrior Of Light:4F45:/
 
 # BLM/WHM
-7081.4 "--sync--" sync / 14:Warrior Of Light:4F73:/ window 5,5 jump 6002.4
-7084.4 "Specter -> BLM/WHM" #sync / 1[56]:Warrior Of Light:4F73:/
-7089.8 "--sync--" sync / 14:Spectral Black Mage:4F3D:/ window 40,40 jump 6010.7
+7081.4 "--sync--" sync / 14:[^:]*:Warrior Of Light:4F73:/ window 5,5 jump 6002.4
+7084.4 "Specter -> BLM/WHM" #sync / 1[56]:[^:]*:Warrior Of Light:4F73:/
+7089.8 "--sync--" sync / 14:[^:]*:Spectral Black Mage:4F3D:/ window 40,40 jump 6010.7
 
 # NIN
-7081.4 "--sync--" sync / 14:Warrior Of Light:4EF[56]:/ window 40,40 jump 8002.3
-7084.4 "Stone/Holy -> NIN" #sync / 1[56]:Warrior Of Light:4EF[56]:/
+7081.4 "--sync--" sync / 14:[^:]*:Warrior Of Light:4EF[56]:/ window 40,40 jump 8002.3
+7084.4 "Stone/Holy -> NIN" #sync / 1[56]:[^:]*:Warrior Of Light:4EF[56]:/
 
 # SMN/WAR
-7081.4 "--sync--" sync / 14:Warrior Of Light:4EF[34]:/ window 40,40 jump 9002.3
-7084.4 "Fire/Ice -> SMN/WAR" #sync / 1[56]:Warrior Of Light:4EF[34]:/
+7081.4 "--sync--" sync / 14:[^:]*:Warrior Of Light:4EF[34]:/ window 40,40 jump 9002.3
+7084.4 "Fire/Ice -> SMN/WAR" #sync / 1[56]:[^:]*:Warrior Of Light:4EF[34]:/
 
 
 ### Phase 3b: NIN
-8000.0 "--middle--" sync / 1[56]:Warrior Of Light:4F45:/
-8002.3 "--sync--" sync / 14:Warrior Of Light:4EF[56]:/
-8005.3 "Imbued Stone/Holy" sync / 1[56]:Warrior Of Light:4EF[56]:/
-8014.4 "Specter Of Light" sync / 1[56]:Warrior Of Light:4F37:/
-8022.7 "--sync--" sync / 1[56]:Spectral Ninja:4F38:/
-8029.8 "--sync--" sync / 1[56]:Spectral Ninja:4F39:/
-8033.2 "Solemn Confiteor" sync / 1[56]:Warrior Of Light:4F0C:/
-8036.8 "Suiton: San " sync / 1[56]:Spectral Ninja:4EFD:/
-8039.8 "--middle--" sync / 1[56]:Warrior Of Light:4F45:/
-8039.9 "Katon: San " sync / 1[56]:Spectral Ninja:4EFE:/
-8040.7 "--sync--" sync / 1[56]:Spectral Ninja:531E:/
-8049.1 "Imbued Coruscance" sync / 1[56]:Warrior Of Light:4F4[9A]:/
-8058.2 "Elddragon Dive" sync / 1[56]:Warrior Of Light:4F0B:/
-8071.5 "The Bitter End" sync / 1[56]:Warrior Of Light:4F0A:/
-8074.7 "--middle--" sync / 1[56]:Warrior Of Light:4F45:/
+8000.0 "--middle--" sync / 1[56]:[^:]*:Warrior Of Light:4F45:/
+8002.3 "--sync--" sync / 14:[^:]*:Warrior Of Light:4EF[56]:/
+8005.3 "Imbued Stone/Holy" sync / 1[56]:[^:]*:Warrior Of Light:4EF[56]:/
+8014.4 "Specter Of Light" sync / 1[56]:[^:]*:Warrior Of Light:4F37:/
+8022.7 "--sync--" sync / 1[56]:[^:]*:Spectral Ninja:4F38:/
+8029.8 "--sync--" sync / 1[56]:[^:]*:Spectral Ninja:4F39:/
+8033.2 "Solemn Confiteor" sync / 1[56]:[^:]*:Warrior Of Light:4F0C:/
+8036.8 "Suiton: San " sync / 1[56]:[^:]*:Spectral Ninja:4EFD:/
+8039.8 "--middle--" sync / 1[56]:[^:]*:Warrior Of Light:4F45:/
+8039.9 "Katon: San " sync / 1[56]:[^:]*:Spectral Ninja:4EFE:/
+8040.7 "--sync--" sync / 1[56]:[^:]*:Spectral Ninja:531E:/
+8049.1 "Imbued Coruscance" sync / 1[56]:[^:]*:Warrior Of Light:4F4[9A]:/
+8058.2 "Elddragon Dive" sync / 1[56]:[^:]*:Warrior Of Light:4F0B:/
+8071.5 "The Bitter End" sync / 1[56]:[^:]*:Warrior Of Light:4F0A:/
+8074.7 "--middle--" sync / 1[56]:[^:]*:Warrior Of Light:4F45:/
 
 # BLM/WHM
-8077.0 "--sync--" sync / 14:Warrior Of Light:4F73:/ window 5,5 jump 6002.4
-8080.0 "Specter -> BLM/WHM" #sync / 1[56]:Warrior Of Light:4F73:/
-8085.4 "--sync--" sync / 14:Spectral Black Mage:4F3D:/ window 40,40 jump 6010.7
+8077.0 "--sync--" sync / 14:[^:]*:Warrior Of Light:4F73:/ window 5,5 jump 6002.4
+8080.0 "Specter -> BLM/WHM" #sync / 1[56]:[^:]*:Warrior Of Light:4F73:/
+8085.4 "--sync--" sync / 14:[^:]*:Spectral Black Mage:4F3D:/ window 40,40 jump 6010.7
 
 # DRK/BRD
-8077.0 "--sync--" sync / 14:Warrior Of Light:4F3[456]:/ window 5,5 jump 7002.2
-8080.0 "Limit -> DRK/BRD" #sync / 1[56]:Warrior Of Light:4F3[456]:/
-8091.3 "--sync--" sync / 14:Warrior Of Light:4F43:/ window 40,40 jump 7016.6
+8077.0 "--sync--" sync / 14:[^:]*:Warrior Of Light:4F3[456]:/ window 5,5 jump 7002.2
+8080.0 "Limit -> DRK/BRD" #sync / 1[56]:[^:]*:Warrior Of Light:4F3[456]:/
+8091.3 "--sync--" sync / 14:[^:]*:Warrior Of Light:4F43:/ window 40,40 jump 7016.6
 
 # SMN/WAR
-8077.0 "--sync--" sync / 14:Warrior Of Light:4EF[34]:/ window 40,40 jump 9002.3
-8080.0 "Fire/Ice -> SMN/WAR" #sync / 1[56]:Warrior Of Light:4EF[34]:/
+8077.0 "--sync--" sync / 14:[^:]*:Warrior Of Light:4EF[34]:/ window 40,40 jump 9002.3
+8080.0 "Fire/Ice -> SMN/WAR" #sync / 1[56]:[^:]*:Warrior Of Light:4EF[34]:/
 
 
 ### Phase 3b: SMN/WAR
-9000.0 "--middle--" sync / 1[56]:Warrior Of Light:4F45:/
-9002.3 "--sync--" sync / 14:Warrior Of Light:4EF[34]:/
-9005.3 "Imbued Fire/Ice" sync / 1[56]:Warrior Of Light:4EF[34]:/
-9014.3 "Specter Of Light" sync / 1[56]:Warrior Of Light:4F37:/
-9022.6 "Summon" sync / 1[56]:Spectral Summoner:4F3F:/
-9036.7 "Flare Breath" sync / 1[56]:Spectral Summoner:4F40:/
-9037.0 "Perfect Decimation" sync / 1[56]:(Spectral Warrior|Warrior Of Light):4F05:/
-9037.2 "Solemn Confiteor" sync / 1[56]:Warrior Of Light:4F0C:/
-9048.5 "Solemn Confiteor" sync / 1[56]:Warrior Of Light:4F0C:/
-9048.8 "Flare Breath" sync / 1[56]:Spectral Summoner:4F40:/
-9049.2 "Perfect Decimation" sync / 1[56]:(Spectral Warrior|Warrior Of Light):4F05:/
-9050.8 "--sync--" sync / 1[56]:Spectral Warrior:531E:/
-9054.8 "--sync--" sync / 1[56]:Spectral Summoner:531E:/
-9055.2 "Summon Wyrm" sync / 1[56]:Warrior Of Light:4F41:/
-9058.4 "--middle--" sync / 1[56]:Warrior Of Light:4F45:/
-9065.5 "Cauterize" sync / 1[56]:Wyrm Of Light:4F07:/
-9067.8 "Imbued Coruscance" sync / 1[56]:Warrior Of Light:4F4[9A]:/
-9076.9 "Elddragon Dive" sync / 1[56]:Warrior Of Light:4F0B:/
-9090.2 "The Bitter End" sync / 1[56]:Warrior Of Light:4F0A:/
-9093.4 "--middle--" sync / 1[56]:Warrior Of Light:4F45:/
+9000.0 "--middle--" sync / 1[56]:[^:]*:Warrior Of Light:4F45:/
+9002.3 "--sync--" sync / 14:[^:]*:Warrior Of Light:4EF[34]:/
+9005.3 "Imbued Fire/Ice" sync / 1[56]:[^:]*:Warrior Of Light:4EF[34]:/
+9014.3 "Specter Of Light" sync / 1[56]:[^:]*:Warrior Of Light:4F37:/
+9022.6 "Summon" sync / 1[56]:[^:]*:Spectral Summoner:4F3F:/
+9036.7 "Flare Breath" sync / 1[56]:[^:]*:Spectral Summoner:4F40:/
+9037.0 "Perfect Decimation" sync / 1[56]:[^:]*:(Spectral Warrior|Warrior Of Light):4F05:/
+9037.2 "Solemn Confiteor" sync / 1[56]:[^:]*:Warrior Of Light:4F0C:/
+9048.5 "Solemn Confiteor" sync / 1[56]:[^:]*:Warrior Of Light:4F0C:/
+9048.8 "Flare Breath" sync / 1[56]:[^:]*:Spectral Summoner:4F40:/
+9049.2 "Perfect Decimation" sync / 1[56]:[^:]*:(Spectral Warrior|Warrior Of Light):4F05:/
+9050.8 "--sync--" sync / 1[56]:[^:]*:Spectral Warrior:531E:/
+9054.8 "--sync--" sync / 1[56]:[^:]*:Spectral Summoner:531E:/
+9055.2 "Summon Wyrm" sync / 1[56]:[^:]*:Warrior Of Light:4F41:/
+9058.4 "--middle--" sync / 1[56]:[^:]*:Warrior Of Light:4F45:/
+9065.5 "Cauterize" sync / 1[56]:[^:]*:Wyrm Of Light:4F07:/
+9067.8 "Imbued Coruscance" sync / 1[56]:[^:]*:Warrior Of Light:4F4[9A]:/
+9076.9 "Elddragon Dive" sync / 1[56]:[^:]*:Warrior Of Light:4F0B:/
+9090.2 "The Bitter End" sync / 1[56]:[^:]*:Warrior Of Light:4F0A:/
+9093.4 "--middle--" sync / 1[56]:[^:]*:Warrior Of Light:4F45:/
 
 # BLM/WHM
-9095.7 "--sync--" sync / 14:Warrior Of Light:4F73:/ window 5,5 jump 6002.4
-9098.7 "Specter -> BLM/WHM" #sync / 1[56]:Warrior Of Light:4F73:/
-9104.1 "--sync--" sync / 14:Spectral Black Mage:4F3D:/ window 40,40 jump 6010.7
+9095.7 "--sync--" sync / 14:[^:]*:Warrior Of Light:4F73:/ window 5,5 jump 6002.4
+9098.7 "Specter -> BLM/WHM" #sync / 1[56]:[^:]*:Warrior Of Light:4F73:/
+9104.1 "--sync--" sync / 14:[^:]*:Spectral Black Mage:4F3D:/ window 40,40 jump 6010.7
 
 # DRK/BRD
-9095.7 "--sync--" sync / 14:Warrior Of Light:4F3[456]:/ window 5,5 jump 7002.2
-9098.7 "Limit -> DRK/BRD" #sync / 1[56]:Warrior Of Light:4F3[456]:/
-9110.0 "--sync--" sync / 14:Warrior Of Light:4F43:/ window 40,40 jump 7016.6
+9095.7 "--sync--" sync / 14:[^:]*:Warrior Of Light:4F3[456]:/ window 5,5 jump 7002.2
+9098.7 "Limit -> DRK/BRD" #sync / 1[56]:[^:]*:Warrior Of Light:4F3[456]:/
+9110.0 "--sync--" sync / 14:[^:]*:Warrior Of Light:4F43:/ window 40,40 jump 7016.6
 
 # NIN
-9095.7 "--sync--" sync / 14:Warrior Of Light:4EF[56]:/ window 40,40 jump 8002.3
-9098.7 "Stone/Holy -> NIN" #sync / 1[56]:Warrior Of Light:4EF[56]:/
+9095.7 "--sync--" sync / 14:[^:]*:Warrior Of Light:4EF[56]:/ window 40,40 jump 8002.3
+9098.7 "Stone/Holy -> NIN" #sync / 1[56]:[^:]*:Warrior Of Light:4EF[56]:/

--- a/ui/raidboss/data/05-shb/trial/wol.txt
+++ b/ui/raidboss/data/05-shb/trial/wol.txt
@@ -11,112 +11,112 @@ hideall "--Reset--"
 ### Phase 1: 100%->50%
 # Note: Don't sync on engage or auto here because there's a checkpoint.
 0.0 "Start"
-5.2 "--sync--" sync / 1[56]:Warrior Of Light:4F45:/ window 20,20 jump 475.4
-6.3 "--sync--" sync / 14:Warrior Of Light:4F27:/ window 10,10
-9.3 "Terror Unleashed" sync / 1[56]:Warrior Of Light:4F27:/
-25.1 "Solemn Confiteor" sync / 1[56]:Warrior Of Light:4F2A:/
-31.6 "Coruscant Saber (In)" sync / 1[56]:Warrior Of Light:4F11:/
-42.7 "Coruscant Saber (Out)" sync / 1[56]:Warrior Of Light:4F10:/
-51.9 "Absolute Fire III" sync / 1[56]:Warrior Of Light:4F2E:/
-65.2 "Absolute Blizzard III" sync / 1[56]:Warrior Of Light:4F2D:/
+5.2 "--sync--" sync / 1[56]:[^:]*:Warrior Of Light:4F45:/ window 20,20 jump 475.4
+6.3 "--sync--" sync / 14:[^:]*:Warrior Of Light:4F27:/ window 10,10
+9.3 "Terror Unleashed" sync / 1[56]:[^:]*:Warrior Of Light:4F27:/
+25.1 "Solemn Confiteor" sync / 1[56]:[^:]*:Warrior Of Light:4F2A:/
+31.6 "Coruscant Saber (In)" sync / 1[56]:[^:]*:Warrior Of Light:4F11:/
+42.7 "Coruscant Saber (Out)" sync / 1[56]:[^:]*:Warrior Of Light:4F10:/
+51.9 "Absolute Fire III" sync / 1[56]:[^:]*:Warrior Of Light:4F2E:/
+65.2 "Absolute Blizzard III" sync / 1[56]:[^:]*:Warrior Of Light:4F2D:/
 
-76.5 "Imbued Fire/Blizzard" sync / 1[56]:Warrior Of Light:4F1[23]:/
-89.6 "Imbued Coruscance" sync / 1[56]:Warrior Of Light:4F4[BC]:/
+76.5 "Imbued Fire/Blizzard" sync / 1[56]:[^:]*:Warrior Of Light:4F1[23]:/
+89.6 "Imbued Coruscance" sync / 1[56]:[^:]*:Warrior Of Light:4F4[BC]:/
 
-101.9 "Sword Of Light" sync / 1[56]:Warrior Of Light:4F42:/
-115.2 "Summon Wyrm" sync / 1[56]:Warrior Of Light:4F41:/
-120.1 "Shining Wave" sync / 1[56]:Warrior Of Light:4F26:/
-125.4 "Cauterize" sync / 1[56]:Wyrm Of Light:4F25:/
-131.4 "The Bitter End" sync / 1[56]:Warrior Of Light:4F28:/
-139.5 "Elddragon Dive" sync / 1[56]:Warrior Of Light:4F29:/
-153.1 "Imbued Fire/Blizzard" sync / 1[56]:Warrior Of Light:4F1[23]:/
+101.9 "Sword Of Light" sync / 1[56]:[^:]*:Warrior Of Light:4F42:/
+115.2 "Summon Wyrm" sync / 1[56]:[^:]*:Warrior Of Light:4F41:/
+120.1 "Shining Wave" sync / 1[56]:[^:]*:Warrior Of Light:4F26:/
+125.4 "Cauterize" sync / 1[56]:[^:]*:Wyrm Of Light:4F25:/
+131.4 "The Bitter End" sync / 1[56]:[^:]*:Warrior Of Light:4F28:/
+139.5 "Elddragon Dive" sync / 1[56]:[^:]*:Warrior Of Light:4F29:/
+153.1 "Imbued Fire/Blizzard" sync / 1[56]:[^:]*:Warrior Of Light:4F1[23]:/
 # FIXME: guessing here on timing
-166.2 "Imbued Coruscance" sync / 1[56]:Warrior Of Light:4F4[BC]:/
+166.2 "Imbued Coruscance" sync / 1[56]:[^:]*:Warrior Of Light:4F4[BC]:/
 # FIXME: missing an elddragon dive too??
 # FIXME: need a natural push
 
 ### Cutscene: 50%
-300.0 "--sync--" sync / 1[56]:Warrior Of Light:4F45:/
-302.3 "--sync--" sync / 14:Warrior Of Light:5331:/ window 400,100
-308.3 "Ascendance" sync / 1[56]:Warrior Of Light:5331:/
+300.0 "--sync--" sync / 1[56]:[^:]*:Warrior Of Light:4F45:/
+302.3 "--sync--" sync / 14:[^:]*:Warrior Of Light:5331:/ window 400,100
+308.3 "Ascendance" sync / 1[56]:[^:]*:Warrior Of Light:5331:/
 311.4 "--untargetable--"
-311.5 "--sync--" sync / 1[56]:Warrior Of Light:5071:/
-319.6 "Absolute Teleport" sync / 1[56]:Warrior Of Light:5332:/
-324.3 "--sync--" sync / 1[56]:Warrior Of Light:5083:/
+311.5 "--sync--" sync / 1[56]:[^:]*:Warrior Of Light:5071:/
+319.6 "Absolute Teleport" sync / 1[56]:[^:]*:Warrior Of Light:5332:/
+324.3 "--sync--" sync / 1[56]:[^:]*:Warrior Of Light:5083:/
 346.0 "--active time event--" duration 15
-447.1 "--sync--" sync / 1[56]:Warrior Of Light:5383:/
-457.1 "--sync--" sync / 1[56]:Warrior Of Light:547B:/
-463.2 "Ultimate Crossover" sync / 1[56]:Warrior Of Light:547C:/
+447.1 "--sync--" sync / 1[56]:[^:]*:Warrior Of Light:5383:/
+457.1 "--sync--" sync / 1[56]:[^:]*:Warrior Of Light:547B:/
+463.2 "Ultimate Crossover" sync / 1[56]:[^:]*:Warrior Of Light:547C:/
 
 ### Phase 2: Checkpoint, 50%->0%
 # Can't sync any of these things back to t=0 because they all appear in phase 1.
 # Phase 1 includes a jump to the middle line to sync.
 470.2 "--targetable--"
-475.4 "--middle--" sync / 1[56]:Warrior Of Light:4F45:/
-480.8 "Imbued Fire/Blizzard" sync / 1[56]:Warrior Of Light:4F1[23]:/
+475.4 "--middle--" sync / 1[56]:[^:]*:Warrior Of Light:4F45:/
+480.8 "Imbued Fire/Blizzard" sync / 1[56]:[^:]*:Warrior Of Light:4F1[23]:/
 
-490.0 "Specter Of Light" sync / 1[56]:Warrior Of Light:4F37:/ window 350,10
-500.4 "Twincast" sync / 1[56]:Spectral Black Mage:4F3D:/
-515.0 "Meteor Impact 1" #sync / 1[56]:Spectral Black Mage:4F21:/
-518.0 "Meteor Impact 2" #sync / 1[56]:Spectral Black Mage:4F21:/
-521.0 "Meteor Impact 3" #sync / 1[56]:Spectral Black Mage:4F21:/
-524.0 "Meteor Impact 4" #sync / 1[56]:Spectral Black Mage:4F21:/
-528.2 "Imbued Coruscance" sync / 1[56]:Warrior Of Light:4F4[BC]:/
+490.0 "Specter Of Light" sync / 1[56]:[^:]*:Warrior Of Light:4F37:/ window 350,10
+500.4 "Twincast" sync / 1[56]:[^:]*:Spectral Black Mage:4F3D:/
+515.0 "Meteor Impact 1" #sync / 1[56]:[^:]*:Spectral Black Mage:4F21:/
+518.0 "Meteor Impact 2" #sync / 1[56]:[^:]*:Spectral Black Mage:4F21:/
+521.0 "Meteor Impact 3" #sync / 1[56]:[^:]*:Spectral Black Mage:4F21:/
+524.0 "Meteor Impact 4" #sync / 1[56]:[^:]*:Spectral Black Mage:4F21:/
+528.2 "Imbued Coruscance" sync / 1[56]:[^:]*:Warrior Of Light:4F4[BC]:/
 
-537.3 "Elddragon Dive" sync / 1[56]:Warrior Of Light:4F29:/
-547.6 "Summon Wyrm" sync / 1[56]:Warrior Of Light:4F41:/
-551.7 "Brimstone Earth" sync / 1[56]:Spectral Dark Knight:4F1E:/
-555.9 "Deluge Of Death" sync / 1[56]:Spectral Bard:4F3B:/
-557.8 "Cauterize" sync / 1[56]:Wyrm Of Light:4F25:/
-566.0 "Deluge Of Death" sync / 1[56]:Spectral Bard:4F20:/
-566.0 "Absolute Holy" sync / 1[56]:Warrior Of Light:4F2B:/
-575.9 "The Bitter End" sync / 1[56]:Warrior Of Light:4F28:/
-582.2 "--middle--" sync / 1[56]:Warrior Of Light:4F45:/
+537.3 "Elddragon Dive" sync / 1[56]:[^:]*:Warrior Of Light:4F29:/
+547.6 "Summon Wyrm" sync / 1[56]:[^:]*:Warrior Of Light:4F41:/
+551.7 "Brimstone Earth" sync / 1[56]:[^:]*:Spectral Dark Knight:4F1E:/
+555.9 "Deluge Of Death" sync / 1[56]:[^:]*:Spectral Bard:4F3B:/
+557.8 "Cauterize" sync / 1[56]:[^:]*:Wyrm Of Light:4F25:/
+566.0 "Deluge Of Death" sync / 1[56]:[^:]*:Spectral Bard:4F20:/
+566.0 "Absolute Holy" sync / 1[56]:[^:]*:Warrior Of Light:4F2B:/
+575.9 "The Bitter End" sync / 1[56]:[^:]*:Warrior Of Light:4F28:/
+582.2 "--middle--" sync / 1[56]:[^:]*:Warrior Of Light:4F45:/
 
-587.5 "To The Limit 1" sync / 1[56]:Warrior Of Light:4F34:/
-598.7 "Radiant Braver" sync / 1[56]:Warrior Of Light:5254:/
+587.5 "To The Limit 1" sync / 1[56]:[^:]*:Warrior Of Light:4F34:/
+598.7 "Radiant Braver" sync / 1[56]:[^:]*:Warrior Of Light:5254:/
 
-605.1 "To The Limit 2" sync / 1[56]:Warrior Of Light:4F35:/
-610.4 "--sync--" sync / 1[56]:Warrior Of Light:4F46:/
-616.3 "Radiant Desperado" sync / 1[56]:Warrior Of Light:515D:/
+605.1 "To The Limit 2" sync / 1[56]:[^:]*:Warrior Of Light:4F35:/
+610.4 "--sync--" sync / 1[56]:[^:]*:Warrior Of Light:4F46:/
+616.3 "Radiant Desperado" sync / 1[56]:[^:]*:Warrior Of Light:515D:/
 
-628.0 "To The Limit 3" sync / 1[56]:Warrior Of Light:4F36:/
-639.1 "Radiant Meteor" sync / 1[56]:Warrior Of Light:4F1A:/
+628.0 "To The Limit 3" sync / 1[56]:[^:]*:Warrior Of Light:4F36:/
+639.1 "Radiant Meteor" sync / 1[56]:[^:]*:Warrior Of Light:4F1A:/
 
-650.4 "Sword Of Light" sync / 1[56]:Warrior Of Light:4F42:/
-668.6 "Shining Wave" sync / 1[56]:Warrior Of Light:4F26:/
+650.4 "Sword Of Light" sync / 1[56]:[^:]*:Warrior Of Light:4F42:/
+668.6 "Shining Wave" sync / 1[56]:[^:]*:Warrior Of Light:4F26:/
 
-670.7 "Absolute Fire/Blizzard" sync / 1[56]:Warrior Of Light:4F2[DE]:/
-678.9 "Elddragon Dive" sync / 1[56]:Warrior Of Light:4F29:/
-683.1 "--middle--" sync / 1[56]:Warrior Of Light:4F45:/
-688.3 "Imbued Fire/Blizzard" sync / 1[56]:Warrior Of Light:4F1[23]:/
+670.7 "Absolute Fire/Blizzard" sync / 1[56]:[^:]*:Warrior Of Light:4F2[DE]:/
+678.9 "Elddragon Dive" sync / 1[56]:[^:]*:Warrior Of Light:4F29:/
+683.1 "--middle--" sync / 1[56]:[^:]*:Warrior Of Light:4F45:/
+688.3 "Imbued Fire/Blizzard" sync / 1[56]:[^:]*:Warrior Of Light:4F1[23]:/
 
-697.5 "Specter Of Light" sync / 1[56]:Warrior Of Light:4F37:/
-706.9 "--sync--" sync / 1[56]:Spectral Ninja:4F38:/
-714.0 "--sync--" sync / 1[56]:Spectral Ninja:4F39:/
-717.0 "Suiton: San" sync / 1[56]:Spectral Ninja:4F1C:/
-718.8 "--middle--" sync / 1[56]:Warrior Of Light:4F45:/
-722.1 "Katon: San" sync / 1[56]:Spectral Ninja:4F1D:/
+697.5 "Specter Of Light" sync / 1[56]:[^:]*:Warrior Of Light:4F37:/
+706.9 "--sync--" sync / 1[56]:[^:]*:Spectral Ninja:4F38:/
+714.0 "--sync--" sync / 1[56]:[^:]*:Spectral Ninja:4F39:/
+717.0 "Suiton: San" sync / 1[56]:[^:]*:Spectral Ninja:4F1C:/
+718.8 "--middle--" sync / 1[56]:[^:]*:Warrior Of Light:4F45:/
+722.1 "Katon: San" sync / 1[56]:[^:]*:Spectral Ninja:4F1D:/
 
-727.0 "Summon" sync / 1[56]:Spectral Summoner:4F3F:/
-727.9 "Imbued Coruscance" sync / 1[56]:Warrior Of Light:4F4[BC]:/
+727.0 "Summon" sync / 1[56]:[^:]*:Spectral Summoner:4F3F:/
+727.9 "Imbued Coruscance" sync / 1[56]:[^:]*:Warrior Of Light:4F4[BC]:/
 
-738.6 "Solemn Confiteor" sync / 1[56]:Warrior Of Light:4F2A:/
-743.3 "Flare Breath" sync / 1[56]:Spectral Egi:4F24:/
-752.4 "The Bitter End" sync / 1[56]:Warrior Of Light:4F28:/
-756.1 "Perfect Decimation" sync / 1[56]:Spectral Warrior:4F3E:/
+738.6 "Solemn Confiteor" sync / 1[56]:[^:]*:Warrior Of Light:4F2A:/
+743.3 "Flare Breath" sync / 1[56]:[^:]*:Spectral Egi:4F24:/
+752.4 "The Bitter End" sync / 1[56]:[^:]*:Warrior Of Light:4F28:/
+756.1 "Perfect Decimation" sync / 1[56]:[^:]*:Spectral Warrior:4F3E:/
 
-760.6 "Absolute Fire/Blizzard" sync / 1[56]:Warrior Of Light:4F2[DE]:/
-761.0 "Perfect Decimation" sync / 1[56]:Spectral Warrior:4F23:/
-772.8 "Elddragon Dive" sync / 1[56]:Warrior Of Light:4F29:/
+760.6 "Absolute Fire/Blizzard" sync / 1[56]:[^:]*:Warrior Of Light:4F2[DE]:/
+761.0 "Perfect Decimation" sync / 1[56]:[^:]*:Spectral Warrior:4F23:/
+772.8 "Elddragon Dive" sync / 1[56]:[^:]*:Warrior Of Light:4F29:/
 
-786.2 "--middle--" sync / 1[56]:Warrior Of Light:4F45:/ window 50,50 jump 475.4
-791.6 "Imbued Fire/Blizzard" #sync / 1[56]:Warrior Of Light:4F1[23]:/
+786.2 "--middle--" sync / 1[56]:[^:]*:Warrior Of Light:4F45:/ window 50,50 jump 475.4
+791.6 "Imbued Fire/Blizzard" #sync / 1[56]:[^:]*:Warrior Of Light:4F1[23]:/
 
-800.8 "Specter Of Light" #sync / 1[56]:Warrior Of Light:4F37:/
-811.2 "Twincast" #sync / 1[56]:Spectral Black Mage:4F3D:/
-825.8 "Meteor Impact 1" #sync / 1[56]:Spectral Black Mage:4F21:/
-828.8 "Meteor Impact 2" #sync / 1[56]:Spectral Black Mage:4F21:/
-831.8 "Meteor Impact 3" #sync / 1[56]:Spectral Black Mage:4F21:/
-834.8 "Meteor Impact 4" #sync / 1[56]:Spectral Black Mage:4F21:/
-839.0 "Imbued Coruscance" #sync / 1[56]:Warrior Of Light:4F4[BC]:/
+800.8 "Specter Of Light" #sync / 1[56]:[^:]*:Warrior Of Light:4F37:/
+811.2 "Twincast" #sync / 1[56]:[^:]*:Spectral Black Mage:4F3D:/
+825.8 "Meteor Impact 1" #sync / 1[56]:[^:]*:Spectral Black Mage:4F21:/
+828.8 "Meteor Impact 2" #sync / 1[56]:[^:]*:Spectral Black Mage:4F21:/
+831.8 "Meteor Impact 3" #sync / 1[56]:[^:]*:Spectral Black Mage:4F21:/
+834.8 "Meteor Impact 4" #sync / 1[56]:[^:]*:Spectral Black Mage:4F21:/
+839.0 "Imbued Coruscance" #sync / 1[56]:[^:]*:Warrior Of Light:4F4[BC]:/

--- a/ui/raidboss/data/05-shb/ultimate/the_epic_of_alexander.txt
+++ b/ui/raidboss/data/05-shb/ultimate/the_epic_of_alexander.txt
@@ -10,241 +10,241 @@ hideall "--sync--"
 ### Phase 1: Living Liquid
 0 "Start"
 0.0 "--sync--" sync /:Engage!/ window 0,1
-3.2 "--sync--" sync / 1[56]:Living Liquid:4978:/ window 5,0
-11.4 "Fluid Swing" sync / 1[56]:Living Liquid:49B0:/ window 10,2.5
-19.5 "Cascade" sync / 1[56]:Living Liquid:4826:/
-35.8 "Hand of Prayer/Parting" sync / 1[56]:Liquid Hand:482[BC]:/
-36.7 "Rage Wave 1" sync / 1[56]:Liquid Rage:49B5:/
-37.7 "Fluid Swing" sync / 1[56]:Living Liquid:49B0:/
-37.7 "Fluid Strike" #sync / 1[56]:Liquid Hand:49B7:/
-38.7 "Rage Wave 2" sync / 1[56]:Liquid Rage:49B6:/
-39.7 "Exhaust" sync / 1[56]:Jagd Doll:481E:/
-41.6 "Embolus" sync / 1[56]:Liquid Rage:4829:/
-42.8 "Hand of Pain" sync / 1[56]:Liquid Hand:482D:/
-50.3 "Exhaust" sync / 1[56]:Jagd Doll:481E:/
-56.7 "Fluid Swing" sync / 1[56]:Living Liquid:49B0:/
-56.7 "Fluid Strike" #sync / 1[56]:Liquid Hand:49B7:/
-69.8 "Protean Wave 1" sync / 1[56]:Living Liquid:4822:/
-70.0 "Hand of Pain" sync / 1[56]:Liquid Hand:482D:/
-71.9 "Protean Wave 2" sync / 1[56]:Living Liquid:4823:/
-74.9 "Sluice" sync / 1[56]:Living Liquid:49B1:/
-75.0 "Protean Wave 3" sync / 1[56]:Living Liquid:4823:/
+3.2 "--sync--" sync / 1[56]:[^:]*:Living Liquid:4978:/ window 5,0
+11.4 "Fluid Swing" sync / 1[56]:[^:]*:Living Liquid:49B0:/ window 10,2.5
+19.5 "Cascade" sync / 1[56]:[^:]*:Living Liquid:4826:/
+35.8 "Hand of Prayer/Parting" sync / 1[56]:[^:]*:Liquid Hand:482[BC]:/
+36.7 "Rage Wave 1" sync / 1[56]:[^:]*:Liquid Rage:49B5:/
+37.7 "Fluid Swing" sync / 1[56]:[^:]*:Living Liquid:49B0:/
+37.7 "Fluid Strike" #sync / 1[56]:[^:]*:Liquid Hand:49B7:/
+38.7 "Rage Wave 2" sync / 1[56]:[^:]*:Liquid Rage:49B6:/
+39.7 "Exhaust" sync / 1[56]:[^:]*:Jagd Doll:481E:/
+41.6 "Embolus" sync / 1[56]:[^:]*:Liquid Rage:4829:/
+42.8 "Hand of Pain" sync / 1[56]:[^:]*:Liquid Hand:482D:/
+50.3 "Exhaust" sync / 1[56]:[^:]*:Jagd Doll:481E:/
+56.7 "Fluid Swing" sync / 1[56]:[^:]*:Living Liquid:49B0:/
+56.7 "Fluid Strike" #sync / 1[56]:[^:]*:Liquid Hand:49B7:/
+69.8 "Protean Wave 1" sync / 1[56]:[^:]*:Living Liquid:4822:/
+70.0 "Hand of Pain" sync / 1[56]:[^:]*:Liquid Hand:482D:/
+71.9 "Protean Wave 2" sync / 1[56]:[^:]*:Living Liquid:4823:/
+74.9 "Sluice" sync / 1[56]:[^:]*:Living Liquid:49B1:/
+75.0 "Protean Wave 3" sync / 1[56]:[^:]*:Living Liquid:4823:/
 81.1 "Splash x6" duration 5.6
-86.6 "Drainage" sync / 1[56]:Liquid Rage:4827:/
-89.1 "Hand of Pain" sync / 1[56]:Liquid Hand:482D:/
-91.7 "Cascade" sync / 1[56]:Living Liquid:4826:/
-95.9 "Throttles" sync / 1[56]:Liquid Rage:4828:/
-107.0 "Protean Wave 1" sync / 1[56]:Living Liquid:4822:/
-109.0 "Hand of Pain" sync / 1[56]:Liquid Hand:482D:/
-109.1 "Protean Wave 2" sync / 1[56]:Living Liquid:4823:/
-112.0 "Sluice" sync / 1[56]:Living Liquid:49B1:/
-112.1 "Protean Wave 3" sync / 1[56]:Living Liquid:4823:/
-113.0 "Rage Wave 1" sync / 1[56]:Liquid Rage :49B5:/
-115.1 "Rage Wave 2" sync / 1[56]:Liquid Rage:49B6:/
-119.1 "Embolus" sync / 1[56]:Liquid Rage:4829:/
-124.2 "Hand of Prayer/Parting" sync / 1[56]:Liquid Hand:482[BC]:/
+86.6 "Drainage" sync / 1[56]:[^:]*:Liquid Rage:4827:/
+89.1 "Hand of Pain" sync / 1[56]:[^:]*:Liquid Hand:482D:/
+91.7 "Cascade" sync / 1[56]:[^:]*:Living Liquid:4826:/
+95.9 "Throttles" sync / 1[56]:[^:]*:Liquid Rage:4828:/
+107.0 "Protean Wave 1" sync / 1[56]:[^:]*:Living Liquid:4822:/
+109.0 "Hand of Pain" sync / 1[56]:[^:]*:Liquid Hand:482D:/
+109.1 "Protean Wave 2" sync / 1[56]:[^:]*:Living Liquid:4823:/
+112.0 "Sluice" sync / 1[56]:[^:]*:Living Liquid:49B1:/
+112.1 "Protean Wave 3" sync / 1[56]:[^:]*:Living Liquid:4823:/
+113.0 "Rage Wave 1" sync / 1[56]:[^:]*:Liquid Rage :49B5:/
+115.1 "Rage Wave 2" sync / 1[56]:[^:]*:Liquid Rage:49B6:/
+119.1 "Embolus" sync / 1[56]:[^:]*:Liquid Rage:4829:/
+124.2 "Hand of Prayer/Parting" sync / 1[56]:[^:]*:Liquid Hand:482[BC]:/
 127.4 "Splash x6" duration 5.6
-129.3 "Hand of Pain" sync / 1[56]:Liquid Hand:482D:/
-134.1 "Fluid Swing" sync / 1[56]:Living Liquid:49B0:/
-142.1 "Cascade Enrage" sync / 1[56]:Living Liquid:49B3:/
+129.3 "Hand of Pain" sync / 1[56]:[^:]*:Liquid Hand:482D:/
+134.1 "Fluid Swing" sync / 1[56]:[^:]*:Living Liquid:49B0:/
+142.1 "Cascade Enrage" sync / 1[56]:[^:]*:Living Liquid:49B3:/
 
 ### Transition 1: Cruise Chaser
 196.0 "--sync--" sync / 04:........:Liquid Hand:/ window 50,0
-200.0 "Hawk Blaster 1" sync / 1[56]:Cruise Chaser:4830:/ window 200,0
+200.0 "Hawk Blaster 1" sync / 1[56]:[^:]*:Cruise Chaser:4830:/ window 200,0
 202.2 "Hawk Blaster 2"
 204.4 "Hawk Blaster 3"
 206.6 "Hawk Blaster 4"
-207.4 "#1 Alpha Sword" sync / 1[56]:Cruise Chaser:4834:/
+207.4 "#1 Alpha Sword" sync / 1[56]:[^:]*:Cruise Chaser:4834:/
 208.8 "Middle Blaster"
-208.9 "#2 Super Blassty Charge" sync / 1[56]:Cruise Chaser:4B4F:/
+208.9 "#2 Super Blassty Charge" sync / 1[56]:[^:]*:Cruise Chaser:4B4F:/
 211.0 "Hawk Blaster 1"
-212.1 "#3 Alpha Sword" sync / 1[56]:Cruise Chaser:4834:/
+212.1 "#3 Alpha Sword" sync / 1[56]:[^:]*:Cruise Chaser:4834:/
 213.2 "Hawk Blaster 2"
-213.6 "#4 Super Blassty Charge" sync / 1[56]:Cruise Chaser:4B4F:/
+213.6 "#4 Super Blassty Charge" sync / 1[56]:[^:]*:Cruise Chaser:4B4F:/
 215.5 "Hawk Blaster 3"
-216.8 "#5 Alpha Sword" sync / 1[56]:Cruise Chaser:4834:/
+216.8 "#5 Alpha Sword" sync / 1[56]:[^:]*:Cruise Chaser:4834:/
 217.7 "Hawk Blaster 4"
-218.3 "#6 Super Blassty Charge" sync / 1[56]:Cruise Chaser:4B4F:/
+218.3 "#6 Super Blassty Charge" sync / 1[56]:[^:]*:Cruise Chaser:4B4F:/
 219.9 "Middle Blaster"
-221.4 "#7 Alpha Sword" sync / 1[56]:Cruise Chaser:4834:/
-222.9 "#8 Super Blassty Charge" sync / 1[56]:Cruise Chaser:4B4F:/
+221.4 "#7 Alpha Sword" sync / 1[56]:[^:]*:Cruise Chaser:4834:/
+222.9 "#8 Super Blassty Charge" sync / 1[56]:[^:]*:Cruise Chaser:4B4F:/
 
 ### Phase 2: Cruise Chaser and Brute Justice
-226.1 "J Kick" sync / 1[56]:Brute Justice:4854:/ window 250,5
+226.1 "J Kick" sync / 1[56]:[^:]*:Brute Justice:4854:/ window 250,5
 229.1 "--targetable--"
-238.3 "Whirlwind" sync / 1[56]:Cruise Chaser:49C2:/
-241.3 "Judgment Nisi" sync / 1[56]:Brute Justice:483E:/
-247.4 "Link-Up" sync / 1[56]:Brute Justice:483F:/
-255.4 "Optical Sight" sync / 1[56]:Cruise Chaser:482F:/
-256.2 "Chakrams" sync / 1[56]:Steam Chakram:4855:/
-260.6 "Hawk Blaster" sync / 1[56]:Cruise Chaser:4831:/
-262.5 "Photon" sync / 1[56]:Cruise Chaser:4836:/
-272.7 "Spin Crusher" sync / 1[56]:Cruise Chaser:4A72:/
-277.3 "Water and Thunder" sync / 1[56]:Brute Justice:4841:/
-288.6 "Earth Missile" sync / 1[56]:Brute Justice:484E:/
-290.6 "Hidden Minefield" sync / 1[56]:Brute Justice:4851:/
-292.7 "Enumeration" sync / 1[56]:Brute Justice:4850:/
-306.7 "Water and Thunder" sync / 1[56]:Brute Justice:4841:/
-313.5 "Limit Cut" sync / 1[56]:Cruise Chaser:4833:/
+238.3 "Whirlwind" sync / 1[56]:[^:]*:Cruise Chaser:49C2:/
+241.3 "Judgment Nisi" sync / 1[56]:[^:]*:Brute Justice:483E:/
+247.4 "Link-Up" sync / 1[56]:[^:]*:Brute Justice:483F:/
+255.4 "Optical Sight" sync / 1[56]:[^:]*:Cruise Chaser:482F:/
+256.2 "Chakrams" sync / 1[56]:[^:]*:Steam Chakram:4855:/
+260.6 "Hawk Blaster" sync / 1[56]:[^:]*:Cruise Chaser:4831:/
+262.5 "Photon" sync / 1[56]:[^:]*:Cruise Chaser:4836:/
+272.7 "Spin Crusher" sync / 1[56]:[^:]*:Cruise Chaser:4A72:/
+277.3 "Water and Thunder" sync / 1[56]:[^:]*:Brute Justice:4841:/
+288.6 "Earth Missile" sync / 1[56]:[^:]*:Brute Justice:484E:/
+290.6 "Hidden Minefield" sync / 1[56]:[^:]*:Brute Justice:4851:/
+292.7 "Enumeration" sync / 1[56]:[^:]*:Brute Justice:4850:/
+306.7 "Water and Thunder" sync / 1[56]:[^:]*:Brute Justice:4841:/
+313.5 "Limit Cut" sync / 1[56]:[^:]*:Cruise Chaser:4833:/
 314.1 "--Cruise Chaser Invincible--" duration 6.3
-315.5 "Flarethrower" sync / 1[56]:Brute Justice:4845:/
-327.6 "Whirlwind" sync / 1[56]:Cruise Chaser:49C2:/
-336.2 "Water and Thunder" sync / 1[56]:Brute Justice:4841:/
-354.5 "Propeller Wind" sync / 1[56]:Cruise Chaser:4832:/
-356.5 "Gavel" sync / 1[56]:Brute Justice:483C:/
-366.8 "Photon" sync / 1[56]:Cruise Chaser:4836:/
-374.8 "Double Rocket Punch" sync / 1[56]:Brute Justice:4847:/
-382.1 "Super Jump" sync / 1[56]:Brute Justice:484A:/
+315.5 "Flarethrower" sync / 1[56]:[^:]*:Brute Justice:4845:/
+327.6 "Whirlwind" sync / 1[56]:[^:]*:Cruise Chaser:49C2:/
+336.2 "Water and Thunder" sync / 1[56]:[^:]*:Brute Justice:4841:/
+354.5 "Propeller Wind" sync / 1[56]:[^:]*:Cruise Chaser:4832:/
+356.5 "Gavel" sync / 1[56]:[^:]*:Brute Justice:483C:/
+366.8 "Photon" sync / 1[56]:[^:]*:Cruise Chaser:4836:/
+374.8 "Double Rocket Punch" sync / 1[56]:[^:]*:Brute Justice:4847:/
+382.1 "Super Jump" sync / 1[56]:[^:]*:Brute Justice:484A:/
 384.4 "Apocalyptic Ray x5" duration 4.4
-395.0 "Whirlwind" sync / 1[56]:Cruise Chaser:49C2:/
-403.1 "Whirlwind" sync / 1[56]:Cruise Chaser:49C2:/
-413.7 "Final Sentence" sync / 1[56]:Brute Justice:4856:/
-423.7 "Eternal Darkness Enrage" sync / 1[56]:Cruise Chaser:483A:/
+395.0 "Whirlwind" sync / 1[56]:[^:]*:Cruise Chaser:49C2:/
+403.1 "Whirlwind" sync / 1[56]:[^:]*:Cruise Chaser:49C2:/
+413.7 "Final Sentence" sync / 1[56]:[^:]*:Brute Justice:4856:/
+423.7 "Eternal Darkness Enrage" sync / 1[56]:[^:]*:Cruise Chaser:483A:/
 
 ### Transition 2: Cruise Chaser, Brute Justice and Alexander Prime
-492.0 "--sync--" sync / 14:Alexander Prime:485A:/ window 500,0
-500.0 "Temporal Stasis" sync / 1[56]:Alexander Prime:485A:/
-503.1 "Surety and Severity" sync / 1[56]:Alexander Prime:4861:/
-505.1 "Alpha Sword" #sync / 1[56]:Cruise Chaser:486B:/
-505.2 "Flarethrower 1" #sync / 1[56]:Brute Justice:486C:/
-506.1 "Alpha Sword" #sync / 1[56]:Cruise Chaser:486B:/
-507.4 "Flarethrower 2" #sync / 1[56]:Brute Justice:486C:/
-507.2 "Alpha Sword" #sync / 1[56]:Cruise Chaser:486B:/
+492.0 "--sync--" sync / 14:[^:]*:Alexander Prime:485A:/ window 500,0
+500.0 "Temporal Stasis" sync / 1[56]:[^:]*:Alexander Prime:485A:/
+503.1 "Surety and Severity" sync / 1[56]:[^:]*:Alexander Prime:4861:/
+505.1 "Alpha Sword" #sync / 1[56]:[^:]*:Cruise Chaser:486B:/
+505.2 "Flarethrower 1" #sync / 1[56]:[^:]*:Brute Justice:486C:/
+506.1 "Alpha Sword" #sync / 1[56]:[^:]*:Cruise Chaser:486B:/
+507.4 "Flarethrower 2" #sync / 1[56]:[^:]*:Brute Justice:486C:/
+507.2 "Alpha Sword" #sync / 1[56]:[^:]*:Cruise Chaser:486B:/
 511.4 "--targetable--"
-521.5 "Chastening Heat" sync / 1[56]:Alexander Prime:4A80:/
-524.6 "Divine Spear 1" #sync / 1[56]:Alexander Prime:4A82:/
-526.7 "Divine Spear 2" #sync / 1[56]:Alexander Prime:4A82:/
-528.8 "Divine Spear 3" #sync / 1[56]:Alexander Prime:4A82:/
+521.5 "Chastening Heat" sync / 1[56]:[^:]*:Alexander Prime:4A80:/
+524.6 "Divine Spear 1" #sync / 1[56]:[^:]*:Alexander Prime:4A82:/
+526.7 "Divine Spear 2" #sync / 1[56]:[^:]*:Alexander Prime:4A82:/
+528.8 "Divine Spear 3" #sync / 1[56]:[^:]*:Alexander Prime:4A82:/
 
 ### Phase 3 Part 1 - Inception Formation
-537.9 "Inception Formation" sync / 1[56]:Alexander Prime:486F:/
+537.9 "Inception Formation" sync / 1[56]:[^:]*:Alexander Prime:486F:/
 541.0 "--untargetable--"
-552.4 "Judgment Crystal" sync / 1[56]:Alexander Prime:485B:/
-558.2 "Judgment Crystal + True Heart" sync / 1[56]:Alexander Prime:485C:/
-569.5 "Flarethrower 1" #sync / 1[56]:Brute Justice:486C:/
-571.7 "Flarethrower 2" #sync / 1[56]:Brute Justice:486C:/
-573.8 "Flarethrower 3" #sync / 1[56]:Brute Justice:486C:/
-581.0 "Inception" sync / 1[56]:Alexander Prime:485E:/
-589.1 "Surety, Solidarity and Severity" sync / 1[56]:Alexander Prime:4861:/
-589.4 "Sacrament" sync / 1[56]:Alexander Prime:485F:/
-595.3 "Alpha Sword" #sync / 1[56]:Cruise Chaser:486B:/
-596.4 "Alpha Sword" #sync / 1[56]:Cruise Chaser:486B:/
-597.5 "Alpha Sword" #sync / 1[56]:Cruise Chaser:486B:/
-598.3 "Super Jump" sync / 1[56]:Brute Justice:484A:/
+552.4 "Judgment Crystal" sync / 1[56]:[^:]*:Alexander Prime:485B:/
+558.2 "Judgment Crystal + True Heart" sync / 1[56]:[^:]*:Alexander Prime:485C:/
+569.5 "Flarethrower 1" #sync / 1[56]:[^:]*:Brute Justice:486C:/
+571.7 "Flarethrower 2" #sync / 1[56]:[^:]*:Brute Justice:486C:/
+573.8 "Flarethrower 3" #sync / 1[56]:[^:]*:Brute Justice:486C:/
+581.0 "Inception" sync / 1[56]:[^:]*:Alexander Prime:485E:/
+589.1 "Surety, Solidarity and Severity" sync / 1[56]:[^:]*:Alexander Prime:4861:/
+589.4 "Sacrament" sync / 1[56]:[^:]*:Alexander Prime:485F:/
+595.3 "Alpha Sword" #sync / 1[56]:[^:]*:Cruise Chaser:486B:/
+596.4 "Alpha Sword" #sync / 1[56]:[^:]*:Cruise Chaser:486B:/
+597.5 "Alpha Sword" #sync / 1[56]:[^:]*:Cruise Chaser:486B:/
+598.3 "Super Jump" sync / 1[56]:[^:]*:Brute Justice:484A:/
 600.3 "--targetable--"
-610.9 "Chastening Heat" sync / 1[56]:Alexander Prime:4A80:/
-616.0 "Divine Spear 1" #sync / 1[56]:Alexander Prime:4A82:/
-618.1 "Divine Spear 2" #sync / 1[56]:Alexander Prime:4A82:/
-620.2 "Divine Spear 3" #sync / 1[56]:Alexander Prime:4A82:/
+610.9 "Chastening Heat" sync / 1[56]:[^:]*:Alexander Prime:4A80:/
+616.0 "Divine Spear 1" #sync / 1[56]:[^:]*:Alexander Prime:4A82:/
+618.1 "Divine Spear 2" #sync / 1[56]:[^:]*:Alexander Prime:4A82:/
+620.2 "Divine Spear 3" #sync / 1[56]:[^:]*:Alexander Prime:4A82:/
 
 ### Phase 3 Part 2 - Wormhole Formation
-629.3 "Wormhole Formation" sync / 1[56]:Alexander Prime:486E:/
+629.3 "Wormhole Formation" sync / 1[56]:[^:]*:Alexander Prime:486E:/
 632.3 "--untargetable--"
-637.7 "Limit Cut" sync / 1[56]:Cruise Chaser:4B0F:/
-640.7 "Link-Up" sync / 1[56]:Brute Justice:483F:/
-643.7 "Void Of Repentance" sync / 1[56]:Alexander Prime:4866:/
-649.5 "Chakrams" #sync / 1[56]:Steam Chakram:4855:/
-650.9 "Super Jump" sync / 1[56]:Brute Justice:484A:/
-650.9 "#1 Alpha Sword" #sync / 1[56]:Cruise Chaser:4834:/
-652.4 "#2 Super Blassty Charge" sync / 1[56]:Cruise Chaser:49C3:/
+637.7 "Limit Cut" sync / 1[56]:[^:]*:Cruise Chaser:4B0F:/
+640.7 "Link-Up" sync / 1[56]:[^:]*:Brute Justice:483F:/
+643.7 "Void Of Repentance" sync / 1[56]:[^:]*:Alexander Prime:4866:/
+649.5 "Chakrams" #sync / 1[56]:[^:]*:Steam Chakram:4855:/
+650.9 "Super Jump" sync / 1[56]:[^:]*:Brute Justice:484A:/
+650.9 "#1 Alpha Sword" #sync / 1[56]:[^:]*:Cruise Chaser:4834:/
+652.4 "#2 Super Blassty Charge" sync / 1[56]:[^:]*:Cruise Chaser:49C3:/
 653.3 "Apocalyptic Ray x5" duration 5
-655.2 "#3 Alpha Sword" #sync / 1[56]:Cruise Chaser:4834:/
-655.6 "Repentance 1" sync / 1[56]:Alexander Prime:4869:/
-656.7 "#4 Super Blassty Charge" sync / 1[56]:Cruise Chaser:49C3:/
-657.9 "Sacrament" sync / 1[56]:Alexander Prime:4857:/
-659.5 "#5 Alpha Sword" #sync / 1[56]:Cruise Chaser:4834:/
-659.7 "Repentance 2" sync / 1[56]:Alexander Prime:4868:/
-660.8 "#6 Super Blassty Charge" sync / 1[56]:Cruise Chaser:49C3:/
-663.6 "#7 Alpha Sword" #sync / 1[56]:Cruise Chaser:4834:/
-664.0 "Repentance 3" sync / 1[56]:Alexander Prime:4867:/
-665.1 "#8 Super Blassty Charge" sync / 1[56]:Cruise Chaser:49C3:/
-666.4 "Missile Command" sync / 1[56]:Brute Justice:484D:/
-670.0 "Incinerating Heat" sync / 1[56]:Alexander Prime:4A51:/
+655.2 "#3 Alpha Sword" #sync / 1[56]:[^:]*:Cruise Chaser:4834:/
+655.6 "Repentance 1" sync / 1[56]:[^:]*:Alexander Prime:4869:/
+656.7 "#4 Super Blassty Charge" sync / 1[56]:[^:]*:Cruise Chaser:49C3:/
+657.9 "Sacrament" sync / 1[56]:[^:]*:Alexander Prime:4857:/
+659.5 "#5 Alpha Sword" #sync / 1[56]:[^:]*:Cruise Chaser:4834:/
+659.7 "Repentance 2" sync / 1[56]:[^:]*:Alexander Prime:4868:/
+660.8 "#6 Super Blassty Charge" sync / 1[56]:[^:]*:Cruise Chaser:49C3:/
+663.6 "#7 Alpha Sword" #sync / 1[56]:[^:]*:Cruise Chaser:4834:/
+664.0 "Repentance 3" sync / 1[56]:[^:]*:Alexander Prime:4867:/
+665.1 "#8 Super Blassty Charge" sync / 1[56]:[^:]*:Cruise Chaser:49C3:/
+666.4 "Missile Command" sync / 1[56]:[^:]*:Brute Justice:484D:/
+670.0 "Incinerating Heat" sync / 1[56]:[^:]*:Alexander Prime:4A51:/
 674.2 "--targetable--"
-674.6 "Enumeration" sync / 1[56]:Brute Justice:4850:/
-682.9 "Mega Holy" sync / 1[56]:Alexander Prime:4A83:/
-690.0 "Mega Holy" sync / 1[56]:Alexander Prime:4A83:/
+674.6 "Enumeration" sync / 1[56]:[^:]*:Brute Justice:4850:/
+682.9 "Mega Holy" sync / 1[56]:[^:]*:Alexander Prime:4A83:/
+690.0 "Mega Holy" sync / 1[56]:[^:]*:Alexander Prime:4A83:/
 
 ### Transition 3: DPS Checks
-699.4 "Summon Alexander" sync / 1[56]:Alexander Prime:4A55:/
+699.4 "Summon Alexander" sync / 1[56]:[^:]*:Alexander Prime:4A55:/
 705.6 "--alex untargetable--"
 706.8 "--adds targetable--"
-705.7 "J Storm + Waves x16" sync / 1[56]:Brute Justice:4876:/ duration 50
-731.7 "Eternal Darkness Enrage" sync / 1[56]:Cruise Chaser:4875:/
-771.9 "Divine Judgment Enrage" sync / 1[56]:Alexander Prime:4879:/ window 67,5
-787.3 "Divine Judgment" sync / 1[56]:Alexander:487A:/
+705.7 "J Storm + Waves x16" sync / 1[56]:[^:]*:Brute Justice:4876:/ duration 50
+731.7 "Eternal Darkness Enrage" sync / 1[56]:[^:]*:Cruise Chaser:4875:/
+771.9 "Divine Judgment Enrage" sync / 1[56]:[^:]*:Alexander Prime:4879:/ window 67,5
+787.3 "Divine Judgment" sync / 1[56]:[^:]*:Alexander:487A:/
 787.4 "Down for the Count" duration 57
 
 ### Phase 4: Perfect Alexander Part 1 - Fate Projection α
 845.4 "--targetable--"
-900.0 "--sync--" sync / 1[56]:Perfect Alexander:4A8B:/ window 900,0
-909.1 "The Final Word" sync / 1[56]:Perfect Alexander:487D:/
-916.1 "Ordained Motion/Stillness" sync / 1[56]:Perfect Alexander:487[EF]:/
-926.3 "Ordained Motion/Stillness" sync / 1[56]:Perfect Alexander:487[EF]:/
-936.5 "Optical Sight 1" sync / 1[56]:Perfect Alexander:488[AB]:/
-938.6 "Individual/Collective Reprobation" sync / 1[56]:Perfect Alexander:488[CD]:/
-942.7 "Optical Sight 2" sync / 1[56]:Perfect Alexander:488[AB]:/
-944.7 "Individual/Collective Reprobation" sync / 1[56]:Perfect Alexander:488[CD]:/
-957.6 "Fate Projection α" sync / 1[56]:Perfect Alexander:487B:/
+900.0 "--sync--" sync / 1[56]:[^:]*:Perfect Alexander:4A8B:/ window 900,0
+909.1 "The Final Word" sync / 1[56]:[^:]*:Perfect Alexander:487D:/
+916.1 "Ordained Motion/Stillness" sync / 1[56]:[^:]*:Perfect Alexander:487[EF]:/
+926.3 "Ordained Motion/Stillness" sync / 1[56]:[^:]*:Perfect Alexander:487[EF]:/
+936.5 "Optical Sight 1" sync / 1[56]:[^:]*:Perfect Alexander:488[AB]:/
+938.6 "Individual/Collective Reprobation" sync / 1[56]:[^:]*:Perfect Alexander:488[CD]:/
+942.7 "Optical Sight 2" sync / 1[56]:[^:]*:Perfect Alexander:488[AB]:/
+944.7 "Individual/Collective Reprobation" sync / 1[56]:[^:]*:Perfect Alexander:488[CD]:/
+957.6 "Fate Projection α" sync / 1[56]:[^:]*:Perfect Alexander:487B:/
 ### Enigma Codex Revealed Events
-966.8 "Fate: Ordained Motion/Stillness" sync / 1[56]:Perfect Alexander:4B0[DE]:/
-972.7 "Fate: Obloquy, Solidarity and 3x Severity" sync / 1[56]:Perfect Alexander:48A4:/
-974.9 "Fate: Ordained Motion/Stillness" sync / 1[56]:Perfect Alexander:489[9A]:/
+966.8 "Fate: Ordained Motion/Stillness" sync / 1[56]:[^:]*:Perfect Alexander:4B0[DE]:/
+972.7 "Fate: Obloquy, Solidarity and 3x Severity" sync / 1[56]:[^:]*:Perfect Alexander:48A4:/
+974.9 "Fate: Ordained Motion/Stillness" sync / 1[56]:[^:]*:Perfect Alexander:489[9A]:/
 975.9 "Fate: Sacrament x3" duration 1.5
-982.6 "Fate Calibration α" sync / 1[56]:Perfect Alexander:487C:/
+982.6 "Fate Calibration α" sync / 1[56]:[^:]*:Perfect Alexander:487C:/
 985.6 "--untargetable--"
-989.8 "Ordained Motion/Stillness" sync / 1[56]:Perfect Alexander:49A[BC]:/
+989.8 "Ordained Motion/Stillness" sync / 1[56]:[^:]*:Perfect Alexander:49A[BC]:/
 992.8 "Obloquy, Solidarity and 3x Severity" sync  /:Perfect Alexander:4861:/
-993.8 "Ordained Motion/Stillness" sync / 1[56]:Perfect Alexander:49A[BC]:/
+993.8 "Ordained Motion/Stillness" sync / 1[56]:[^:]*:Perfect Alexander:49A[BC]:/
 993.8 "Sacrament x3" duration 1.5
 998.8 "--targetable--"
 
 ### Phase 4 Part 2 - Fate Projection β
-1008.0 "Ordained Capital Punishment" sync / 1[56]:Perfect Alexander:4892:/
-1011.1 "Ordained Capital Punishment 1" #sync / 1[56]:Perfect Alexander:4893:/
-1012.2 "Ordained Capital Punishment 2" #sync / 1[56]:Perfect Alexander:4893:/
-1013.3 "Ordained Capital Punishment 3" #sync / 1[56]:Perfect Alexander:4893:/
-1017.2 "Ordained Punishment" sync / 1[56]:Perfect Alexander:4891:/
-1032.3 "Fate Projection β" sync / 1[56]:Perfect Alexander:4B13:/
+1008.0 "Ordained Capital Punishment" sync / 1[56]:[^:]*:Perfect Alexander:4892:/
+1011.1 "Ordained Capital Punishment 1" #sync / 1[56]:[^:]*:Perfect Alexander:4893:/
+1012.2 "Ordained Capital Punishment 2" #sync / 1[56]:[^:]*:Perfect Alexander:4893:/
+1013.3 "Ordained Capital Punishment 3" #sync / 1[56]:[^:]*:Perfect Alexander:4893:/
+1017.2 "Ordained Punishment" sync / 1[56]:[^:]*:Perfect Alexander:4891:/
+1032.3 "Fate Projection β" sync / 1[56]:[^:]*:Perfect Alexander:4B13:/
 ### Enigma Codex Revealed Events
-1047.7 "Fate: Surety and Solidarity" #sync / 1[56]:Perfect Alexander:489C:/
-1050.5 "Fate: J Jump" sync / 1[56]:Perfect Alexander:489D:/
-1056.0 "Fate: Optical Sight" sync / 1[56]:Perfect Alexander:48A[01]:/
-1058.1 "Fate: Individual/Collective Reprobation" sync / 1[56]:Perfect Alexander:48A[23]:/
-1061.5 "Fate: Radiant Sacrament" sync / 1[56]:Perfect Alexander:489E:/
-1070.3 "Fate Calibration β" sync / 1[56]:Perfect Alexander:4B14:/
+1047.7 "Fate: Surety and Solidarity" #sync / 1[56]:[^:]*:Perfect Alexander:489C:/
+1050.5 "Fate: J Jump" sync / 1[56]:[^:]*:Perfect Alexander:489D:/
+1056.0 "Fate: Optical Sight" sync / 1[56]:[^:]*:Perfect Alexander:48A[01]:/
+1058.1 "Fate: Individual/Collective Reprobation" sync / 1[56]:[^:]*:Perfect Alexander:48A[23]:/
+1061.5 "Fate: Radiant Sacrament" sync / 1[56]:[^:]*:Perfect Alexander:489E:/
+1070.3 "Fate Calibration β" sync / 1[56]:[^:]*:Perfect Alexander:4B14:/
 1073.3 "--untargetable--"
-1081.5 "Surety and Solidarity" sync / 1[56]:Perfect Alexander:4863:/
-1082.5 "J Jump" sync / 1[56]:Perfect Alexander:4885:/
-1086.5 "Optical Sight 1" sync / 1[56]:Perfect Alexander:49A[ED]:/
-1088.6 "Individual/Collective Reprobation" sync / 1[56]:Perfect Alexander:488[CD]:/
-1093.5 "Radiant Sacrament" sync / 1[56]:Perfect Alexander:4886:/
+1081.5 "Surety and Solidarity" sync / 1[56]:[^:]*:Perfect Alexander:4863:/
+1082.5 "J Jump" sync / 1[56]:[^:]*:Perfect Alexander:4885:/
+1086.5 "Optical Sight 1" sync / 1[56]:[^:]*:Perfect Alexander:49A[ED]:/
+1088.6 "Individual/Collective Reprobation" sync / 1[56]:[^:]*:Perfect Alexander:488[CD]:/
+1093.5 "Radiant Sacrament" sync / 1[56]:[^:]*:Perfect Alexander:4886:/
 1098.5 "--targetable--"
-1106.8 "Ordained Capital Punishment" sync / 1[56]:Perfect Alexander:4892:/
-1109.9 "Ordained Capital Punishment 1" #sync / 1[56]:Perfect Alexander:4893:/
-1111.0 "Ordained Capital Punishment 2" #sync / 1[56]:Perfect Alexander:4893:/
-1112.1 "Ordained Capital Punishment 3" #sync / 1[56]:Perfect Alexander:4893:/
-1116.0 "Ordained Punishment" sync / 1[56]:Perfect Alexander:4891:/
+1106.8 "Ordained Capital Punishment" sync / 1[56]:[^:]*:Perfect Alexander:4892:/
+1109.9 "Ordained Capital Punishment 1" #sync / 1[56]:[^:]*:Perfect Alexander:4893:/
+1111.0 "Ordained Capital Punishment 2" #sync / 1[56]:[^:]*:Perfect Alexander:4893:/
+1112.1 "Ordained Capital Punishment 3" #sync / 1[56]:[^:]*:Perfect Alexander:4893:/
+1116.0 "Ordained Punishment" sync / 1[56]:[^:]*:Perfect Alexander:4891:/
 
 ### Phase 4 Part 3 - Almighty Judgments and Burn
-1126.2 "Almighty Judgment" sync / 1[56]:Perfect Alexander:488E:/
+1126.2 "Almighty Judgment" sync / 1[56]:[^:]*:Perfect Alexander:488E:/
 1130.8 "Almighty Judgment Reveal x3" duration 6
-1137.4 "Almighty Judgment 1" #sync / 1[56]:Perfect Alexander:4890:/
-1139.4 "Almighty Judgment 2" #sync / 1[56]:Perfect Alexander:4890:/
-1141.4 "Almighty Judgment 3" #sync / 1[56]:Perfect Alexander:4890:/
-1142.5 "Irresistible Grace" sync / 1[56]:Perfect Alexander:4894:/
-1152.6 "Ordained Capital Punishment" sync / 1[56]:Perfect Alexander:4892:/
-1155.7 "Ordained Capital Punishment 1" #sync / 1[56]:Perfect Alexander:4893:/
-1156.8 "Ordained Capital Punishment 2" #sync / 1[56]:Perfect Alexander:4893:/
-1157.9 "Ordained Capital Punishment 3" #sync / 1[56]:Perfect Alexander:4893:/
-1161.8 "Ordained Punishment" sync / 1[56]:Perfect Alexander:4891:/
-1171.7 "Almighty Judgment" sync / 1[56]:Perfect Alexander:488E:/
+1137.4 "Almighty Judgment 1" #sync / 1[56]:[^:]*:Perfect Alexander:4890:/
+1139.4 "Almighty Judgment 2" #sync / 1[56]:[^:]*:Perfect Alexander:4890:/
+1141.4 "Almighty Judgment 3" #sync / 1[56]:[^:]*:Perfect Alexander:4890:/
+1142.5 "Irresistible Grace" sync / 1[56]:[^:]*:Perfect Alexander:4894:/
+1152.6 "Ordained Capital Punishment" sync / 1[56]:[^:]*:Perfect Alexander:4892:/
+1155.7 "Ordained Capital Punishment 1" #sync / 1[56]:[^:]*:Perfect Alexander:4893:/
+1156.8 "Ordained Capital Punishment 2" #sync / 1[56]:[^:]*:Perfect Alexander:4893:/
+1157.9 "Ordained Capital Punishment 3" #sync / 1[56]:[^:]*:Perfect Alexander:4893:/
+1161.8 "Ordained Punishment" sync / 1[56]:[^:]*:Perfect Alexander:4891:/
+1171.7 "Almighty Judgment" sync / 1[56]:[^:]*:Perfect Alexander:488E:/
 1176.3 "Almighty Judgment Reveal x3" duration 6
-1182.9 "Almighty Judgment 1" #sync / 1[56]:Perfect Alexander:4890:/
-1184.9 "Almighty Judgment 2" #sync / 1[56]:Perfect Alexander:4890:/
-1186.9 "Almighty Judgment 3" #sync / 1[56]:Perfect Alexander:4890:/
-1187.9 "Irresistible Grace" sync / 1[56]:Perfect Alexander:4894:/
-1202.8 "Temporal Interference" sync / 1[56]:Perfect Alexander:4896:/
+1182.9 "Almighty Judgment 1" #sync / 1[56]:[^:]*:Perfect Alexander:4890:/
+1184.9 "Almighty Judgment 2" #sync / 1[56]:[^:]*:Perfect Alexander:4890:/
+1186.9 "Almighty Judgment 3" #sync / 1[56]:[^:]*:Perfect Alexander:4890:/
+1187.9 "Irresistible Grace" sync / 1[56]:[^:]*:Perfect Alexander:4894:/
+1202.8 "Temporal Interference" sync / 1[56]:[^:]*:Perfect Alexander:4896:/
 1216.4 "7 Players Remaining"
 1221.4 "6 Players Remaining"
 1226.4 "5 Players Remaining"
@@ -252,5 +252,5 @@ hideall "--sync--"
 1236.5 "3 Players Remaining"
 1241.6 "2 Players Remaining"
 1246.6 "1 Players Remaining"
-1247.6 "Temporal Prison Enrage" sync / 1[56]:Perfect Alexander:4897:/ duration 9
+1247.6 "Temporal Prison Enrage" sync / 1[56]:[^:]*:Perfect Alexander:4897:/ duration 9
 1249.8 "0 Players Remaining"


### PR DESCRIPTION
```typescript
import fs from 'fs';
import readline from 'readline';

const filename = process.argv[2];
if (!filename)
  process.exit(0);

const fixupTimelines = async (filename: string): Promise<void> => {
  const lines: string[] = [];

  const fileStream = fs.createReadStream(filename);
  const readInterface = readline.createInterface({ input: fileStream });

  const abilRegex = /sync \/ 1\[56\]:[^:]*:[^:]*:\//;
  const startRegex = /sync \/ 14:[^:]*:[^:]*:\//;
  const oopsRegex = /(?: 14| 15| 16| 1\[56\]):/;

  for await (const line of readInterface) {
    const abil = abilRegex.exec(line);
    if (abil) {
      lines.push(line.replace(/\/ 1\[56\]:/, '\/ 1\[56\]:[^:]*:'));
      continue;
    }
    const start = startRegex.exec(line);
    if (start) {
      lines.push(line.replace(/\/ 14:/, '\/ 14:[^:]*:'));
      continue;
    }
    if (oopsRegex.exec(line)) {
      console.error(`${filename}: ${line}`);
      process.exit(-1);
    }

    lines.push(line);
  }

  fileStream.close();
  fs.writeFileSync(filename, lines.join('\r\n') + '\r\n');
};

if (filename.endsWith('.txt'))
  void fixupTimelines(filename);

```