### PR TITLE
raidboss: remaining alpha timeline conversions

### DIFF
--- a/ui/raidboss/data/03-hw/dungeon/gubal_library_hard.txt
+++ b/ui/raidboss/data/03-hw/dungeon/gubal_library_hard.txt
@@ -64,7 +64,7 @@ hideall "--sync--"
 1054.3 "Hand/Tornado?"
 
 # Hand Form
-1100.0 "--sync--" sync /00:....:The liquid flame gains the effect of Chiromorph/ window 100,250
+1100.0 "--sync--" sync / 00:[^:]*:The liquid flame gains the effect of Chiromorph/ window 100,250
 1108.4 "Seal Of Night And Day" sync / 1[56]:[^:]*:Liquid Flame:1949:/ window 10,10
 1112.5 "Searing Wind" sync / 1[56]:[^:]*:Liquid Flame:1948:/
 1116.4 "Searing Wind" sync / 1[56]:[^:]*:Liquid Flame:1948:/
@@ -75,7 +75,7 @@ hideall "--sync--"
 1149.1 "Form Shift"
 
 # Tornado Form
-1200.0 "--sync--" sync /00:....:The liquid flame gains the effect of Anemomorph/ window 200,0
+1200.0 "--sync--" sync / 00:[^:]*:The liquid flame gains the effect of Anemomorph/ window 200,0
 1204.5 "Bibliocide" sync / 1[56]:[^:]*:Liquid Flame:1945:/ window 10,10
 1215.4 "Magnetism/Repel?" sync / 1[56]:[^:]*:Liquid Flame:194[CD]:/
 1226.9 "Bibliocide" sync / 1[56]:[^:]*:Liquid Flame:1945:/
@@ -83,7 +83,7 @@ hideall "--sync--"
 1246.1 "Form Shift"
 
 # Human Form
-1300.0 "--sync--" sync /00:....:The liquid flame gains the effect of Anthropomorph/ window 300,10
+1300.0 "--sync--" sync / 00:[^:]*:The liquid flame gains the effect of Anthropomorph/ window 300,10
 1307.5 "Searing Wind" sync / 1[56]:[^:]*:Liquid Flame:1944:/ window 10,20
 1314.7 "Bibliocide" sync / 1[56]:[^:]*:Liquid Flame:1945:/
 1326.0 "Sea Of Flames x3"

--- a/ui/raidboss/data/03-hw/dungeon/gubal_library_hard.txt
+++ b/ui/raidboss/data/03-hw/dungeon/gubal_library_hard.txt
@@ -64,7 +64,7 @@ hideall "--sync--"
 1054.3 "Hand/Tornado?"
 
 # Hand Form
-1100.0 "--sync--" sync / 00:[^:]*:The liquid flame gains the effect of Chiromorph/ window 100,250
+1100.0 "--sync--" sync / 00:[^:]*::The liquid flame gains the effect of Chiromorph/ window 100,250
 1108.4 "Seal Of Night And Day" sync / 1[56]:[^:]*:Liquid Flame:1949:/ window 10,10
 1112.5 "Searing Wind" sync / 1[56]:[^:]*:Liquid Flame:1948:/
 1116.4 "Searing Wind" sync / 1[56]:[^:]*:Liquid Flame:1948:/
@@ -75,7 +75,7 @@ hideall "--sync--"
 1149.1 "Form Shift"
 
 # Tornado Form
-1200.0 "--sync--" sync / 00:[^:]*:The liquid flame gains the effect of Anemomorph/ window 200,0
+1200.0 "--sync--" sync / 00:[^:]*::The liquid flame gains the effect of Anemomorph/ window 200,0
 1204.5 "Bibliocide" sync / 1[56]:[^:]*:Liquid Flame:1945:/ window 10,10
 1215.4 "Magnetism/Repel?" sync / 1[56]:[^:]*:Liquid Flame:194[CD]:/
 1226.9 "Bibliocide" sync / 1[56]:[^:]*:Liquid Flame:1945:/
@@ -83,7 +83,7 @@ hideall "--sync--"
 1246.1 "Form Shift"
 
 # Human Form
-1300.0 "--sync--" sync / 00:[^:]*:The liquid flame gains the effect of Anthropomorph/ window 300,10
+1300.0 "--sync--" sync / 00:[^:]*::The liquid flame gains the effect of Anthropomorph/ window 300,10
 1307.5 "Searing Wind" sync / 1[56]:[^:]*:Liquid Flame:1944:/ window 10,20
 1314.7 "Bibliocide" sync / 1[56]:[^:]*:Liquid Flame:1945:/
 1326.0 "Sea Of Flames x3"

--- a/ui/raidboss/data/04-sb/eureka/eureka_hydatos.txt
+++ b/ui/raidboss/data/04-sb/eureka/eureka_hydatos.txt
@@ -6,7 +6,7 @@ hideall "--Reset--"
 hideall "--sync--"
 
 0.0 "--Reset--" sync / 00:0839::.*is no longer sealed/ window 100000 jump 0
-0 "--Reset--" sync /04:........:Removing combatant Proto Ozma\.  Max HP: \d{8}\./ window 10000 jump 0
+0.0 "--Reset--" sync / 04:........:Proto Ozma:/ window 100000 jump 0
 
 
 #####################
@@ -16,7 +16,7 @@ hideall "--sync--"
 
 # Note: This checks that Art's auto hits a target close enough for you to see.
 # You can see Owain's auto abilities, but the target is listed as empty.
-1002.5 "--sync--" sync / 15:........:Art:3956:[^:]*:........:[^:]/ window 1500,0
+1002.5 "--sync--" sync / 1[56]:[^:]:Art:3956:/ window 1500,0
 1014.5 "Thricecull" sync / 1[56]:[^:]*:Art:3934:/
 1023.1 "Legendcarver" sync / 1[56]:[^:]*:Art:3928:/
 1030.7 "Legendspinner" sync / 1[56]:[^:]*:Art:3929:/
@@ -59,7 +59,7 @@ hideall "--sync--"
 # EAST BRANCH / OWAIN #
 #######################
 # -ic Orlasrach Art -ii 3957 3941 3939 393C 393D 3938 -p 3945:2016.0
-2002.5 "--sync--" sync / 15:........:Owain:3957:[^:]*:........:[^:]/ window 2500,0
+2002.5 "--sync--" sync / 1[56]:[^:]:Owain:3957:/ window 2500,0
 2016.0 "Thricecull" sync / 1[56]:[^:]*:Owain:3945:/
 2028.1 "Acallam Na Senorach" sync / 1[56]:[^:]*:Owain:3946:/ #3:29
 2037.7 "Mythcall" sync / 1[56]:[^:]*:Owain:3936:/ #3:39
@@ -131,7 +131,7 @@ hideall "--sync--"
 3124.4 "Streak Lightning" #sync / 1[56]:[^:]*:Streak Lightning:3877:/
 3134.9 "Ultimate Zantetsuken" sync / 14:[^:]*:Raiden:3878:/ duration 20
 
-3154.9 "--sync--" sync / 17:........:Raiden:3878:/ window 40,0
+3154.9 "--sync--" sync / 17:[^:]:Raiden:3878:/ window 40,0
 3164.9 "Spirits of the Fallen" sync / 1[56]:[^:]*:Raiden:387A:/ window 40,5
 3171.2 "Booming Lament" sync / 1[56]:[^:]*:Raiden:387D:/
 3177.3 "Cloud to Ground" sync / 1[56]:[^:]*:Raiden:3870:/
@@ -153,7 +153,7 @@ hideall "--sync--"
 3316.0 "Lateral Zantetsuken" sync / 1[56]:[^:]*:Raiden:386[BC]:/
 3321.7 "Ultimate Zantetsuken" sync / 14:[^:]*:Raiden:3878:/ duration 20
 
-3341.7 "--sync--" sync / 17:........:Raiden:3878:/ window 40,0
+3341.7 "--sync--" sync / 17:[^:]:Raiden:3878:/ window 40,0
 3347.7 "Spirits of the Fallen" sync / 1[56]:[^:]*:Raiden:387A:/ window 40,5
 3353.8 "Shingan" sync / 1[56]:[^:]*:Raiden:387B:/
 3365.4 "Ame-no-Sakahoko" sync / 1[56]:[^:]*:Raiden:3868:/

--- a/ui/raidboss/data/04-sb/eureka/eureka_hydatos.txt
+++ b/ui/raidboss/data/04-sb/eureka/eureka_hydatos.txt
@@ -16,7 +16,7 @@ hideall "--sync--"
 
 # Note: This checks that Art's auto hits a target close enough for you to see.
 # You can see Owain's auto abilities, but the target is listed as empty.
-1002.5 "--sync--" sync / 1[56]:[^:]*:Art:3956:[^:]*:[^:]*:/ window 1500,0
+1002.5 "--sync--" sync / 1[56]:[^:]*:Art:3956:[^:]*:[^:]*:[^:]+:/ window 1500,0
 1014.5 "Thricecull" sync / 1[56]:[^:]*:Art:3934:/
 1023.1 "Legendcarver" sync / 1[56]:[^:]*:Art:3928:/
 1030.7 "Legendspinner" sync / 1[56]:[^:]*:Art:3929:/
@@ -59,7 +59,7 @@ hideall "--sync--"
 # EAST BRANCH / OWAIN #
 #######################
 # -ic Orlasrach Art -ii 3957 3941 3939 393C 393D 3938 -p 3945:2016.0
-2002.5 "--sync--" sync / 1[56]:[^:]:Owain:3957:/ window 2500,0
+2002.5 "--sync--" sync / 1[56]:[^:]*:Owain:3957:[^:]*:[^:]*:[^:]+:/ window 2500,0
 2016.0 "Thricecull" sync / 1[56]:[^:]*:Owain:3945:/
 2028.1 "Acallam Na Senorach" sync / 1[56]:[^:]*:Owain:3946:/ #3:29
 2037.7 "Mythcall" sync / 1[56]:[^:]*:Owain:3936:/ #3:39

--- a/ui/raidboss/data/04-sb/eureka/eureka_hydatos.txt
+++ b/ui/raidboss/data/04-sb/eureka/eureka_hydatos.txt
@@ -16,7 +16,7 @@ hideall "--sync--"
 
 # Note: This checks that Art's auto hits a target close enough for you to see.
 # You can see Owain's auto abilities, but the target is listed as empty.
-1002.5 "--sync--" sync / 1[56]:[^:]:Art:3956:/ window 1500,0
+1002.5 "--sync--" sync / 1[56]:[^:]*:Art:3956:[^:]*:[^:]*:/ window 1500,0
 1014.5 "Thricecull" sync / 1[56]:[^:]*:Art:3934:/
 1023.1 "Legendcarver" sync / 1[56]:[^:]*:Art:3928:/
 1030.7 "Legendspinner" sync / 1[56]:[^:]*:Art:3929:/

--- a/ui/raidboss/data/05-shb/eureka/bozjan_southern_front.txt
+++ b/ui/raidboss/data/05-shb/eureka/bozjan_southern_front.txt
@@ -4,7 +4,7 @@
 hideall "--Reset--"
 hideall "--sync--"
 
-0.0 "--Reset--" sync / 21:........:80000014:00:/ window 100000,100000 jump 0
+0.0 "--Reset--" sync / 21:........:80000014:00:/ window 100000 jump 0
 0.0 "--Reset--" sync / 00:0839::.*is no longer sealed/ window 100000 jump 0
 
 # TODO: fill in CEs

--- a/ui/raidboss/data/05-shb/eureka/delubrum_reginae_savage.txt
+++ b/ui/raidboss/data/05-shb/eureka/delubrum_reginae_savage.txt
@@ -309,7 +309,7 @@ hideall "--sync--"
 # override it.  Dahu will only end when Dahu is killed, which can only be seen if you
 # are in the Dahu fight.
 6000.0 "--sync--" sync / 00:0839::The Hall of Supplication will be sealed off/ window 6000,0
-6000.0 "--Reset--" sync / 19:Dahu was defeated by/ window 0,2000 jump 0
+6000.0 "--Reset--" sync / 19:[^:]*:Dahu:/ window 0,2000 jump 0
 6008.4 "Reverberating Roar" sync / 1[56]:[^:]*:Dahu:576D:/ window 10,2.5
 6014.5 "Reverberating Roar" sync / 1[56]:[^:]*:Dahu:576D:/
 6022.7 "Hot Charge 1" sync / 1[56]:[^:]*:Dahu:5773:/
@@ -1253,7 +1253,7 @@ hideall "--sync--"
 # Both of these casts are renamed as --sync-- to clean up the timeline.
 
 # Phase 1
-18008.3 "--sync--" sync /:57D7:Stygimoloch Lord:/ window 15,15
+18008.3 "--sync--" sync / 14:[^:]*:Stygimoloch Lord:57D7:/ window 15,15
 18015.3 "Foe Splitter" sync / 1[56]:[^:]*:Stygimoloch Lord:57D7:/
 18023.4 "Vicious Swipe" sync / 1[56]:[^:]*:Stygimoloch Lord:5552:/
 18028.5 "--sync--" sync / 1[56]:[^:]*:Stygimoloch Lord:57CF:/
@@ -1481,7 +1481,7 @@ hideall "--sync--"
 20515.5 "Above Board" sync / 1[56]:[^:]*:Queen's Warrior:5A0B:/
 20515.5 "--sync--" sync / 1[56]:[^:]*:Queen's Warrior:5B8E:/
 20516.5 "--stunned--" # 3 or 7 second stun
-20518.5 "Lots Cast" sync /(:Aetherial Burst:5B89:|:Aetherial Bolt:5A0D:)/
+20518.5 "Lots Cast" sync / 1[56]:[^:]*:(Aetherial Burst:5B89|Aetherial Bolt:5A0D):/
 20521.5 "Lots Cast" #sync / 1[56]:[^:]*:Aetherial Bolt:5B88:/
 20522.7 "Lots Cast" #sync / 1[56]:[^:]*:Aetherial Bolt:5BB6:/
 20523.5 "--unstunned--"

--- a/ui/raidboss/data/05-shb/eureka/zadnor.txt
+++ b/ui/raidboss/data/05-shb/eureka/zadnor.txt
@@ -3,7 +3,7 @@
 hideall "--Reset--"
 hideall "--sync--"
 
-0.0 "--Reset--" sync / 21:........:80000014:00:/ window 100000,100000 jump 0
+0.0 "--Reset--" sync / 21:........:80000014:00:/ window 100000 jump 0
 0.0 "--Reset--" sync / 00:0839::.*is no longer sealed/ window 100000 jump 0
 
 # TODO: fill in CEs


### PR DESCRIPTION
No issues fixing these up. I didn't touch the `21` lines in the Shadowbringers Eureka files since they looked to be correctly formatted already.

I *think* the line ID for "Enemy Gains Buff" is`2AAE`, but I figured it was safer to just make the Gubal Hard lines universal, since that's basically the only place this happens.