### PR TITLE
lint: Update Fixer Node Argument Range

### DIFF
--- a/eslint/cactbot-response-default-severities.js
+++ b/eslint/cactbot-response-default-severities.js
@@ -97,7 +97,7 @@ module.exports = {
 
               fix: (fixer) => {
                 return fixer.replaceTextRange(
-                  [node.arguments[0].start, node.arguments[node.arguments.length - 1].end],
+                  [node.arguments[0].range[0], node.arguments[node.arguments.length - 1].range[1]],
                   '',
                 );
               },


### PR DESCRIPTION
Update fixer node argument range to use the first argument's first range
value and the last argument's last range value instead of using start
and end as they don't seem to be returned as part of the node argument
object anymore. Loc is available, but that doesn't give the text
position in characters and instead returns an object of `{ line, col }`.

Fixes #3754.