### PR TITLE
Eureka: Add a BA Portal Timer to Hydatos

### DIFF
--- a/ui/eureka/eureka.css
+++ b/ui/eureka/eureka.css
@@ -76,6 +76,7 @@
 }
 
 #label-time > div,
+#label-portal-timer > div,
 #label-weather-container > div > div {
   display: inline-block;
 }
@@ -251,6 +252,15 @@
   border-bottom: 2px dashed rgba(255, 255, 255, 0.3);
 }
 
+#portal-timer-container {
+  position: absolute;
+  right: 0;
+  font-size: 16px;
+  font-weight: normal;
+  padding: 5px;
+  border: 2px dashed rgba(255, 255, 255, 0.3);
+}
+
 .aspect-ratio-anemos #label-container {
   top: 0%;
 }
@@ -264,6 +274,10 @@
 }
 
 .aspect-ratio-hydatos #label-container {
+  top: 90%;
+}
+
+.aspect-ratio-hydatos #portal-timer-container {
   top: 90%;
 }
 

--- a/ui/eureka/eureka.html
+++ b/ui/eureka/eureka.html
@@ -1,4 +1,4 @@
-﻿<html lang="en-US">
+﻿<html>
 <head>
   <meta charset="utf-8" />
   <title>Cactbot Eureka</title>
@@ -23,6 +23,9 @@
             <div><div id="label-weather-icon4" class="text icon"></div><div id="label-weather-text4" class="text"></div></div>
           </div>
           <div id="label-tracker" class="text"></div>
+        </div>
+        <div id="portal-timer-container" class="hide">
+          <div id="label-portal-timer" class="text"><div id="label-portal-timer-icon" class="text icon"></div><div id="label-portal-timer-text" class="text"></div></div>
         </div>
       </div>
     </div>

--- a/ui/eureka/eureka.ts
+++ b/ui/eureka/eureka.ts
@@ -533,9 +533,10 @@ class EurekaTracker {
   OnFateKill(fate: NMInfo) {
     this.DebugPrint(`OnFateKill: ${this.TransByDispLang(fate.label)}`);
 
-    if (fate.fateID === 1424 || fate.fateID === 1422)
+    if (fate.fateID === 1424 || fate.fateID === 1422) {
       if (fate.progressElement && fate.progressElement.innerText === '100%')
         this.lastBAFateTimeMs = +Date.now();
+    }
 
     if (fate.startTimerOnKill)
       fate.respawnTimeMsLocal = this.RespawnTime(fate);
@@ -681,7 +682,7 @@ class EurekaTracker {
       // blue portals despawn & red portals spawn
       // <4 minutes>
       // red portals despawn
-      if (this.lastBAFateTimeMs) {
+      if (this.options.showBAPortalTimer && this.lastBAFateTimeMs) {
         const lastBAFateTimePlus10Ms = this.lastBAFateTimeMs + (10 * 1000 * 60);
         const lastBAFateTimePlus6Ms = this.lastBAFateTimeMs + (6 * 1000 * 60);
         const lastBAFateTimePlus3Ms = this.lastBAFateTimeMs + (3 * 1000 * 60);

--- a/ui/eureka/eureka.ts
+++ b/ui/eureka/eureka.ts
@@ -53,6 +53,8 @@ type NMInfo = {
   x: number;
   y: number;
   respawnMinutes?: number;
+  respawnMinutesFailed?: number;
+  startTimerOnKill?: boolean;
 
   // Modified
   element?: HTMLElement;
@@ -119,6 +121,8 @@ type EurekaConfigOptions = typeof defaultEurekaConfigOptions;
 export type EurekaTimeStrings = {
   weatherFor: LocaleObject<WeatherForFunc>;
   weatherIn: LocaleObject<WeatherInFunc>;
+  portalFor: LocaleObject<WeatherInFunc>;
+  portalIn: LocaleObject<WeatherInFunc>;
   timeFor: LocaleObject<WeatherTimeForFunc>;
   minute: LocaleText;
 };
@@ -211,6 +215,8 @@ const gWeatherIcons: { [weather: string]: string } = {
 } as const;
 const gNightIcon = '&#x1F319;';
 const gDayIcon = '&#x263C;';
+const gBluePortalIcon = '&#x1F535;';
+const gRedPortalIcon = '&#x1F534;';
 // ✭ for rarity for field notes listing
 const gRarityIcon = '&#x272D;';
 
@@ -220,6 +226,8 @@ class EurekaTracker {
   private updateTimesHandle?: number;
   private fateQueue: EventResponses['onFateEvent'][] = [];
   private CEQueue: EventResponses['onCEEvent'][] = [];
+
+  private lastBAFateTimeMs?: number;
 
   private playerElement?: HTMLElement;
   private fairyRegex?: CactbotBaseRegExp<'AddedCombatant'>;
@@ -461,6 +469,8 @@ class EurekaTracker {
 
   RespawnTime(nm: NMInfo) {
     let respawnTimeMs = 120 * 60 * 1000;
+    if (nm.respawnMinutesFailed && nm.progressElement && nm.progressElement.innerText !== '100%')
+      respawnTimeMs = nm.respawnMinutesFailed * 60 * 1000;
     if (nm.respawnMinutes)
       respawnTimeMs = nm.respawnMinutes * 60 * 1000;
     return respawnTimeMs + (+new Date());
@@ -484,7 +494,8 @@ class EurekaTracker {
     classList.remove('nm-hidden');
     classList.remove('nm-down');
     classList.remove('critical-down');
-    fate.respawnTimeMsLocal = this.RespawnTime(fate);
+    if (!fate.startTimerOnKill)
+      fate.respawnTimeMsLocal = this.RespawnTime(fate);
 
     if (fate.bunny) {
       const shouldPlay = this.options.PopNoiseForBunny;
@@ -521,7 +532,15 @@ class EurekaTracker {
 
   OnFateKill(fate: NMInfo) {
     this.DebugPrint(`OnFateKill: ${this.TransByDispLang(fate.label)}`);
+
+    if (fate.fateID === 1424 || fate.fateID === 1422)
+      if (fate.progressElement && fate.progressElement.innerText === '100%')
+        this.lastBAFateTimeMs = +Date.now();
+
+    if (fate.startTimerOnKill)
+      fate.respawnTimeMsLocal = this.RespawnTime(fate);
     this.UpdateTimes();
+
     if (fate.element?.classList.contains('nm-pop')) {
       if (this.zoneInfo?.onlyShowInactiveWithExplicitRespawns && !fate.respawnMinutes)
         fate.element.classList.add('nm-hidden');
@@ -647,6 +666,53 @@ class EurekaTracker {
     timeIconElem.innerHTML = timeIcon;
     timeTextElem.innerHTML = timeStr;
     labelTrackerElem.innerHTML = this.currentTracker;
+
+    if (zoneId === ZoneId.TheForbiddenLandEurekaHydatos) {
+      const portalContainer = document.getElementById('portal-timer-container');
+      const portalIconElem = document.getElementById('label-portal-timer-icon');
+      const portalTextElem = document.getElementById('label-portal-timer-text');
+      if (!portalContainer || !portalIconElem || !portalTextElem)
+        throw new UnreachableCode();
+
+      // Ovni/Tristitia is killed
+      // <3 minutes>
+      // blue portals spawn
+      // <3 minutes>
+      // blue portals despawn & red portals spawn
+      // <4 minutes>
+      // red portals despawn
+      if (this.lastBAFateTimeMs) {
+        const lastBAFateTimePlus10Ms = this.lastBAFateTimeMs + (10 * 1000 * 60);
+        const lastBAFateTimePlus6Ms = this.lastBAFateTimeMs + (6 * 1000 * 60);
+        const lastBAFateTimePlus3Ms = this.lastBAFateTimeMs + (3 * 1000 * 60);
+        if (nowMs < lastBAFateTimePlus10Ms) {
+          if (nowMs < lastBAFateTimePlus3Ms) {
+            portalIconElem.innerHTML = gBluePortalIcon;
+            portalTextElem.innerHTML = this.TransByDispLang(this.options.timeStrings.portalIn)(
+              nowMs,
+              lastBAFateTimePlus3Ms,
+            );
+          } else if (nowMs < lastBAFateTimePlus6Ms) {
+            portalIconElem.innerHTML = gBluePortalIcon;
+            portalTextElem.innerHTML = this.TransByDispLang(this.options.timeStrings.portalFor)(
+              nowMs,
+              lastBAFateTimePlus6Ms,
+            );
+          } else {
+            portalIconElem.innerHTML = gRedPortalIcon;
+            portalTextElem.innerHTML = this.TransByDispLang(this.options.timeStrings.portalFor)(
+              nowMs,
+              lastBAFateTimePlus10Ms,
+            );
+          }
+
+          portalContainer.classList.remove('hide');
+        } else {
+          if (!portalContainer.classList.contains('hide'))
+            portalContainer.classList.add('hide');
+        }
+      }
+    }
 
     for (const nm of Object.values(this.nms)) {
       let respawnMs = 0;

--- a/ui/eureka/eureka_config.ts
+++ b/ui/eureka/eureka_config.ts
@@ -193,5 +193,13 @@ UserConfig.registerOptions('eureka', {
         options['RefreshRateMs'] = seconds * 1000;
       },
     },
+    {
+      id: 'showBAPortalTimer',
+      name: {
+        en: 'Show Timer for BA red/blue Portals',
+      },
+      type: 'checkbox',
+      default: false,
+    },
   ],
 });

--- a/ui/eureka/eureka_translations.ts
+++ b/ui/eureka/eureka_translations.ts
@@ -11,6 +11,18 @@ export const bunnyLabel: LocaleText = {
   ko: '토끼',
 };
 
+const sec2time = (timeInMs: number) => {
+  const pad = function(num: number, size: number) {
+    return ('000' + num.toString()).slice(size * -1);
+  };
+
+  const time: Date = new Date(timeInMs);
+  const minutes: number = time.getMinutes();
+  const seconds: number = time.getSeconds();
+
+  return minutes.toString() + ':' + pad(seconds, 2);
+};
+
 export const timeStrings: EurekaTimeStrings = {
   weatherFor: {
     en: (nowMs, stopTime) => {
@@ -97,6 +109,71 @@ export const timeStrings: EurekaTimeStrings = {
         const min = (startTime - nowMs) / 1000 / 60;
         return ` ${Math.ceil(min)}분 후`;
       }
+      return ' ??? 후';
+    },
+  },
+  portalFor: {
+    en: (nowMs, stopTime) => {
+      if (stopTime)
+        return ` for ${sec2time(stopTime - nowMs)}`;
+      return ' for ???';
+    },
+    de: (nowMs, stopTime) => {
+      if (stopTime)
+        return ` für ${sec2time(stopTime - nowMs)}`;
+      return ' für ???';
+    },
+    fr: (nowMs, stopTime) => {
+      if (stopTime)
+        return ` pour ${sec2time(stopTime - nowMs)}`;
+      return ' pour ???';
+    },
+    ja: (nowMs, stopTime) => {
+      if (stopTime)
+        return ` 終わるまであと${sec2time(stopTime - nowMs)}`;
+      return ' 終わるまであと ???';
+    },
+    cn: (nowMs, stopTime) => {
+      if (stopTime)
+        return ` ${sec2time(stopTime - nowMs)}后结束`;
+      return ' ???';
+    },
+    ko: (nowMs, stopTime) => {
+      if (stopTime)
+        return ` ${sec2time(stopTime - nowMs)}동안`;
+      return ' ??? 동안';
+    },
+  },
+  portalIn: {
+    en: (nowMs, startTime) => {
+      if (startTime)
+        return ` in ${sec2time(startTime - nowMs)}`;
+
+      return ' in ???';
+    },
+    de: (nowMs, startTime) => {
+      if (startTime)
+        return ` in ${sec2time(startTime - nowMs)}`;
+      return ' in ???';
+    },
+    fr: (nowMs, startTime) => {
+      if (startTime)
+        return ` dans ${sec2time(startTime - nowMs)}`;
+      return ' dans ???';
+    },
+    ja: (nowMs, startTime) => {
+      if (startTime)
+        return ` あと ${sec2time(startTime - nowMs)}`;
+      return ' あと ???';
+    },
+    cn: (nowMs, startTime) => {
+      if (startTime)
+        return ` ${sec2time(startTime - nowMs)}后`;
+      return ' ??? 后';
+    },
+    ko: (nowMs, startTime) => {
+      if (startTime)
+        return ` ${sec2time(startTime - nowMs)} 후`;
       return ' ??? 후';
     },
   },

--- a/ui/eureka/zone_bozja_southern.ts
+++ b/ui/eureka/zone_bozja_southern.ts
@@ -1245,8 +1245,8 @@ export const zoneInfoBozjaSouthern: EurekaZoneInfo = {
       y: 12.6,
       isCritical: true,
       ceKey: 0,
-      // TODO: this needs a 60 minute respawn *after* it finishes.
-      // respawnMinutes: 60,
+      respawnMinutes: 60,
+      startTimerOnKill: true,
     },
     killitwithfire: {
       label: {

--- a/ui/eureka/zone_hydatos.ts
+++ b/ui/eureka/zone_hydatos.ts
@@ -275,7 +275,9 @@ export const zoneInfoHydatos: EurekaZoneInfo = {
       x: 26.8,
       y: 29.0,
       fateID: 1424,
-      respawnMinutes: 20,
+      respawnMinutes: 30,
+      respawnMinutesFailed: 20,
+      startTimerOnKill: true,
     },
     tristitia: {
       label: {

--- a/ui/eureka/zone_zadnor.ts
+++ b/ui/eureka/zone_zadnor.ts
@@ -896,8 +896,8 @@ export const zoneInfoZadnor: EurekaZoneInfo = {
       y: 8.2,
       isCritical: true,
       ceKey: 0,
-      // TODO: this needs a 60 minute respawn *after* it finishes.
-      // respawnMinutes: 60,
+      respawnMinutes: 60,
+      startTimerOnKill: true,
     },
     onserpentswings: {
       label: {


### PR DESCRIPTION
This adds a new timer to the Hydatos map for tracking the blue/red BA portals in the same style as the weather info 

Preview image:
![image](https://user-images.githubusercontent.com/12807478/145150038-cdae37e3-dbb4-47cd-9bf2-cee4e050d82f.png)
![image](https://user-images.githubusercontent.com/12807478/145150737-e6e0626a-f919-4ca4-969c-18863bb2b883.png)

I've also implemented a new check for nm.startTimerOnKill, which allows NMs/CEs such as Ovni, Castrum and the Dalriada to be tracked more accurately as a result.

If you want to test it quickly you can use this url: `https://katttails.github.io/cactbot/ui/eureka/eureka.html`
however do note that I've been doing some other work on top of this PR so there are some other unrelated code changes as well, but they shouldn't affect anything (I hope).