### PR TITLE
eureka: update Hydatos bunny respawn time

### DIFF
--- a/ui/eureka/zone_hydatos.ts
+++ b/ui/eureka/zone_hydatos.ts
@@ -29,7 +29,7 @@ export const zoneInfoHydatos: EurekaZoneInfo = {
       y: 21.5,
       fateID: 1425,
       bunny: true,
-      respawnMinutes: 8,
+      respawnMinutes: 10.5,
     },
     khalamari: {
       label: {


### PR DESCRIPTION
Really minor change, but upon testing the bunny fate respawn time is closer to 10:30 than 8min.

The other zones are *probably* the same, but I haven't tested it enough to be confident.