### PR TITLE
eureka: Add an option to only import new NMs from tracker

### DIFF
--- a/ui/eureka/eureka.ts
+++ b/ui/eureka/eureka.ts
@@ -104,6 +104,7 @@ const defaultEurekaConfigOptions = {
   FlagTimeoutMs: 90,
   CompleteNamesSTQ: false,
   EnrichedSTQ: false,
+  TrackerOnlyImportMissing: false,
   PopNoiseForNM: true,
   PopNoiseForBunny: true,
   PopNoiseForSkirmish: false,
@@ -750,10 +751,12 @@ class EurekaTracker {
       if (name === undefined || time === undefined)
         throw new UnreachableCode();
       const nm = trackerToNM[name.toLowerCase()];
-      if (nm)
-        nm.respawnTimeMsTracker = (parseFloat(time) * 60 * 1000) + (+new Date());
-      else
+      if (nm) {
+        if (!this.options.TrackerOnlyImportMissing || !nm.respawnTimeMsLocal)
+          nm.respawnTimeMsTracker = (parseFloat(time) * 60 * 1000) + (+new Date());
+      } else {
         console.error(`Invalid NM Import: ${name}`);
+      }
     }
 
     this.UpdateTimes();

--- a/ui/eureka/eureka_config.ts
+++ b/ui/eureka/eureka_config.ts
@@ -67,6 +67,14 @@ UserConfig.registerOptions('eureka', {
       default: false,
     },
     {
+      id: 'TrackerOnlyImportMissing',
+      name: {
+        en: 'Only import times for missing NMs from external tracker',
+      },
+      type: 'checkbox',
+      default: false,
+    },
+    {
       id: 'PopNoiseForNM',
       name: {
         en: 'Play pop sound for NMs',


### PR DESCRIPTION
Just skips over entries from the tracker if we already have a pop time in the overlay, because it's probably more accurate.

Needs translations.