### PR TITLE
eureka: Bozja map fixes

### DIFF
--- a/ui/eureka/eureka.css
+++ b/ui/eureka/eureka.css
@@ -288,7 +288,9 @@
 }
 
 .aspect-ratio-zadnor #label-container {
-  top: 90%;
+  top: 20%;
+  left: unset !important;
+  right: 0;
 }
 
 .aspect-ratio-hydatos #portal-timer-container {

--- a/ui/eureka/eureka.css
+++ b/ui/eureka/eureka.css
@@ -42,8 +42,10 @@
 .aspect-ratio-bozjasouthern {
   width: 100%;
   height: 0;
-  position: relative;
+  position: absolute;
   padding-bottom: calc(1400% / 16);
+  top: -10%;
+  left: 0;
 }
 
 .aspect-ratio-zadnor {
@@ -278,6 +280,18 @@
 }
 
 .aspect-ratio-hydatos #label-container {
+  top: 90%;
+}
+
+.aspect-ratio-bozjasouthern #label-container {
+  top: 60%;
+}
+
+.aspect-ratio-zadnor #label-container {
+  top: 90%;
+}
+
+.aspect-ratio-hydatos #portal-timer-container {
   top: 90%;
 }
 

--- a/ui/eureka/eureka.css
+++ b/ui/eureka/eureka.css
@@ -39,6 +39,20 @@
   padding-bottom: calc(800% / 15);
 }
 
+.aspect-ratio-bozjasouthern {
+  width: 100%;
+  height: 0;
+  position: relative;
+  padding-bottom: calc(1400% / 16);
+}
+
+.aspect-ratio-zadnor {
+  width: 100%;
+  height: 0;
+  position: relative;
+  padding-bottom: calc(1400% / 16);
+}
+
 .inner-container {
   position: absolute;
   top: 0;

--- a/ui/eureka/eureka.ts
+++ b/ui/eureka/eureka.ts
@@ -208,6 +208,9 @@ const gWeatherIcons: { [weather: string]: string } = {
   'Thunderstorms': '&#x26A1;',
   'Showers': '&#x2614;',
   'Gloom': '&#x2639;',
+  'Rain': '&#x1F4A6;',
+  'Wind': '&#x1F32A;',
+  'Dust Storms': '&#x1F4A8;',
 } as const;
 const gNightIcon = '&#x1F319;';
 const gDayIcon = '&#x263C;';


### PR DESCRIPTION
A friend pointed out to me that the bozja maps didn't lock the aspect ratio, so could be stretched out depending on the overlay window. Fixing that lead me to realise the weather info panel had been hidden all this time.. Oops!

This PR just adds some aspect ratio correction, adjusts the weather info box to fit neatly and adds the missing weathers for Bozja.