### PR TITLE
jobs: fix gp alarm from constantly beeping

### DIFF
--- a/ui/jobs/bars.ts
+++ b/ui/jobs/bars.ts
@@ -677,17 +677,10 @@ export class Bars {
     this.o.gpBar.maxvalue = data.maxGp.toString();
   }
 
-  _shouldPlayGpAlarm(data: { gp: number; gpAlarmReady: boolean; gpPotion: boolean }): boolean {
-    // GP Alarm
-    if (data.gp < this.options.GpAlarmPoint) {
-      return true;
-    } else if (data.gpAlarmReady && !data.gpPotion && data.gp >= this.options.GpAlarmPoint) {
-      const audio = new Audio('../../resources/sounds/freesound/power_up.webm');
-      audio.volume = this.options.GpAlarmSoundVolume;
-      void audio.play();
-      return false;
-    }
-    return true;
+  _playGpAlarm(): void {
+    const audio = new Audio('../../resources/sounds/freesound/power_up.webm');
+    audio.volume = this.options.GpAlarmSoundVolume;
+    void audio.play();
   }
 
   _updateOpacity(transparent: boolean): void {


### PR DESCRIPTION
There are several fixes here:
* gp alarm should only beep once after it has gone below the threshold
* if the threshold is zero, don't beep at all
* if we go above the threshold (with a potion), don't beep
  (this may have been an issue before?)

This is a fix for a bug introduced in #3682.