### PR TITLE
raidemulator: Fix bug with last combatant state tracking

### DIFF
--- a/ui/raidboss/emulator/data/CombatantTracker.ts
+++ b/ui/raidboss/emulator/data/CombatantTracker.ts
@@ -178,6 +178,9 @@ export default class CombatantTracker {
     if (line.maxMp !== undefined)
       state.maxMp = line.maxMp;
 
+    if (line.decEvent === 4)
+      state.targetable = false;
+
     return state;
   }
 


### PR DESCRIPTION
If the last event triggered for a given combatant is an 04 line (e.g. a clear) it can cause issues with the pre-flight checks for the getCombatants handler. Found while testing triggers for Endsinger.