### PR TITLE
jobs: Temporarily fake kLevelMod data to avoid error

### DIFF
--- a/ui/jobs/constants.ts
+++ b/ui/jobs/constants.ts
@@ -469,4 +469,17 @@ export const kLevelMod = [
   [376, 3034],
   [378, 3164],
   [380, 3300],
+  // FIXME: The following are the assumed values added to avoid errors.
+  // 9999 will make unknown gcd about 2.5
+  // Fix this when parameter is determined.
+  [382, 9999],
+  [384, 9999],
+  [386, 9999],
+  [388, 9999],
+  [390, 9999],
+  [392, 9999],
+  [394, 9999],
+  [396, 9999],
+  [398, 9999],
+  [400, 9999],
 ] as const;


### PR DESCRIPTION
Fixes #3788
https://github.com/quisquous/cactbot/blob/54303910154b6ae5847780f1dbac616ce629a381/ui/jobs/utils.ts#L142
[0,0] will cause a 0 division error, so make it 9999 to make unknown gcd about 2.5
382 at lv81 and 400 at lv90 are confirmed, others are assumed.