### PR TITLE
plugin: remove stray variable in fatewatcher

### DIFF
--- a/plugin/CactbotEventSource/FateWatcher.cs
+++ b/plugin/CactbotEventSource/FateWatcher.cs
@@ -143,7 +143,6 @@ namespace Cactbot {
     private static SemaphoreSlim ceSemaphore;
     private Dictionary<string, ACSelfOPCodes> acselfopcodes = null;
     private Dictionary<string, CEDirectorOPCodes> cedirectoropcodes = null;
-    private bool initialized = false;
 
     private Type MessageType = null;
     private Type messageHeader = null;


### PR DESCRIPTION
This got added in fd971b4acc5f2eb6559b7be737f22bc836202247 and I missed it during the merge with 4da4191ce87d2a8c89f3c8b50f26d4beaf4591f5.