### PR TITLE
jobs: refactor procs boxes in flex layout

### DIFF
--- a/ui/jobs/bars.ts
+++ b/ui/jobs/bars.ts
@@ -141,6 +141,10 @@ export class Bars {
       barsContainer.classList.add('pvp');
     opacityContainer.appendChild(barsContainer);
 
+    const procsContainer = document.createElement('div');
+    procsContainer.id = 'procs-container';
+    opacityContainer.appendChild(procsContainer);
+
     if (shouldShow.buffList) {
       if (this.options.JustBuffTracker) {
         // Just alias these two together so the rest of the code doesn't have
@@ -255,8 +259,10 @@ export class Bars {
       container = document.createElement('div');
       container.id = elementId;
       document.getElementById('bars')?.appendChild(container);
-      container.classList.add('proc-box');
+      // container.classList.add('proc-box');
     }
+
+    document.getElementById('procs-container')?.appendChild(container);
 
     const timerBox = TimerBox.create({
       stylefill: 'empty',

--- a/ui/jobs/bars.ts
+++ b/ui/jobs/bars.ts
@@ -259,7 +259,6 @@ export class Bars {
       container = document.createElement('div');
       container.id = elementId;
       document.getElementById('bars')?.appendChild(container);
-      // container.classList.add('proc-box');
     }
 
     document.getElementById('procs-container')?.appendChild(container);

--- a/ui/jobs/jobs.css
+++ b/ui/jobs/jobs.css
@@ -427,82 +427,24 @@
   All jobs should have procs in roughly the same spot, and the
   entire bars + procs should be roughly 250px wide, 210px tall.
 */
-.proc-box {
+
+#procs-container {
   position: absolute;
   top: 146px;
-  left: 0;
+  left: 100px;
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+  align-items: baseline;
+  width: 210px;
+  height: 210px;
 }
 
-/* Box 1 default at left 0, so not needed to define */
+#procs-container > div {
+  display: flex;
 
-/* Box 2/4 */
-#drk-procs-bloodweapon,
-#drg-procs-highjump,
-#nin-procs-trickattack,
-#sam-procs-fugetsu,
-#brd-procs-stormbite,
-#smn-procs-biosmn {
-  position: relative;
-  display: inline-block;
-  left: calc(153px / 3);
-}
-
-/* Box 3/4 */
-#drk-procs-delirium,
-#drg-procs-lancecharge,
-#nin-procs-bunshin,
-#sam-procs-higanbana,
-#brd-procs-song,
-#smn-procs-energydrain {
-  position: relative;
-  display: inline-block;
-  left: calc(153px / 3 * 2);
-}
-
-/* Box 4/4 */
-#drk-procs-livingshadow,
-#drg-procs-dragonsight,
-#nin-procs-ninjutsu,
-#sam-procs-tsubamegaeshi,
-#brd-procs-straightshotready,
-#smn-procs-trance {
-  position: relative;
-  display: inline-block;
-  left: 153px;
-}
-
-/* Box 2/3 */
-#gnb-procs-nomercy,
-#whm-procs-assize,
-#sch-procs-aetherflow,
-#ast-procs-draw,
-#sge-proc-rhizomata,
-#mnk-procs-twinsnakes,
-#mch-procs-airanchor,
-#dnc-procs-technicalstep,
-#blm-dot-thunder,
-#rdm-procs-black,
-#blu-procs-torment {
-  position: relative;
-  display: inline-block;
-  left: calc(153px / 2);
-}
-
-/* Box 3/3 */
-#gnb-procs-bloodfest,
-#whm-procs-lucid,
-#sch-procs-luciddreaming,
-#ast-procs-luciddreaming,
-#sge-proc-lucid,
-#mnk-procs-demolish,
-#mch-procs-wildfire,
-#dnc-procs-flourish,
-#blm-procs-thunder,
-#rdm-procs-lucid,
-#blu-procs-lucid {
-  position: relative;
-  display: inline-block;
-  left: 153px;
+  /* every box is 50px big */
+  width: 50px;
 }
 
 /* Colors */


### PR DESCRIPTION
Per https://github.com/quisquous/cactbot/pull/1856#issuecomment-706589184
So we can abandon to use so many css selectors and calculate the distances.
Add a new div as a container for proc boxes, so now the construction is:
![image](https://user-images.githubusercontent.com/19927330/145716475-7135e107-0769-47b6-bab3-7efcacb5f277.png)
As my test when using caster and healer, it should look the same as before:
BLM:
![image](https://user-images.githubusercontent.com/19927330/145716518-0290c337-54f4-4895-8767-94c39a66c865.png)
