### PR TITLE
jobs: fix effect/gain/you dont trigger self gains buffs

### DIFF
--- a/ui/jobs/player.ts
+++ b/ui/jobs/player.ts
@@ -58,6 +58,7 @@ export interface EventMap {
   // triggered when effect gains or loses
   'effect/gain': (effectId: string, info: PartialFieldMatches<'GainsEffect'>) => void;
   'effect/lose': (effectId: string, info: PartialFieldMatches<'LosesEffect'>) => void;
+  // triggered when you gain or lose a effect
   'effect/gain/you': (effectId: string, info: PartialFieldMatches<'GainsEffect'>) => void;
   'effect/lose/you': (effectId: string, info: PartialFieldMatches<'LosesEffect'>) => void;
 }
@@ -424,7 +425,7 @@ export class Player extends PlayerBase {
         if (!effectId)
           break;
 
-        if (matches.sourceId?.toUpperCase() === this.idHex)
+        if (matches.targetId?.toUpperCase() === this.idHex)
           this.emit('effect/gain/you', effectId, matches);
         this.emit('effect/gain', effectId, matches);
         break;
@@ -435,7 +436,7 @@ export class Player extends PlayerBase {
         if (!effectId)
           break;
 
-        if (matches.sourceId?.toUpperCase() === this.idHex)
+        if (matches.targetId?.toUpperCase() === this.idHex)
           this.emit('effect/lose/you', effectId, matches);
         this.emit('effect/lose', effectId, matches);
         break;


### PR DESCRIPTION
This bug would break something like BuffTracker that
relies on the event, so buffs would not correctly trigger on the event
when the player gains some effect but when the others gains effect
from the player.

This patch fixed this. But I am a bit worrying whether the name is
clear enough for what is it used for.