### PR TITLE
jobs: refactor stacks boxes in flex layout

### DIFF
--- a/ui/jobs/components/blm.ts
+++ b/ui/jobs/components/blm.ts
@@ -46,6 +46,7 @@ export class BLMComponent extends BaseComponent {
     // Maybe some day when cactbot uses new cef.
     const stacksContainer = document.createElement('div');
     stacksContainer.id = 'blm-stacks';
+    stacksContainer.classList.add('stacks');
     this.bars.addJobBarContainer().appendChild(stacksContainer);
 
     const heartStacksContainer = document.createElement('div');

--- a/ui/jobs/components/mch.ts
+++ b/ui/jobs/components/mch.ts
@@ -57,7 +57,7 @@ export class MCHComponent extends BaseComponent {
     // Wild Fire Gauge
     this.stacksContainer = document.createElement('div');
     this.stacksContainer.id = 'mch-stacks';
-    this.stacksContainer.classList.add('hide');
+    this.stacksContainer.classList.add('stacks', 'hide');
     this.bars.addJobBarContainer().appendChild(this.stacksContainer);
     const wildFireContainer = document.createElement('div');
     wildFireContainer.id = 'mch-stacks-wildfire';

--- a/ui/jobs/components/sam.ts
+++ b/ui/jobs/components/sam.ts
@@ -28,9 +28,13 @@ export class SAMComponent extends BaseComponent {
     fgColor: 'combo-color',
   });
 
+  const stacksContainer = document.createElement('div');
+  stacksContainer.id = 'sam-stacks';
+  stacksContainer.classList.add('stacks');
   const senContainer = document.createElement('div');
-  senContainer.id = 'sam-stacks';
-  this.bars.addJobBarContainer().appendChild(senContainer);
+  senContainer.id = 'sam-stacks-sen';
+  stacksContainer.appendChild(senContainer);
+  this.bars.addJobBarContainer().appendChild(stacksContainer);
 
   this.setsu = document.createElement('div');
   this.getsu = document.createElement('div');

--- a/ui/jobs/components/sge.ts
+++ b/ui/jobs/components/sge.ts
@@ -28,6 +28,7 @@ export class SGEComponent extends BaseComponent {
     // addersgall and addersting stacks
     const stacksContainer = document.createElement('div');
     stacksContainer.id = 'sge-stacks';
+    stacksContainer.classList.add('stacks');
     this.bars.addJobBarContainer().appendChild(stacksContainer);
 
     const addersgallStacksConstainer = document.createElement('div');

--- a/ui/jobs/components/whm.ts
+++ b/ui/jobs/components/whm.ts
@@ -40,6 +40,7 @@ export class WHMComponent extends BaseComponent {
     // BloodLily Gauge
     const stacksContainer = document.createElement('div');
     stacksContainer.id = 'whm-stacks';
+    stacksContainer.classList.add('stacks');
     this.bars.addJobBarContainer().appendChild(stacksContainer);
     const bloodlilyContainer = document.createElement('div');
     bloodlilyContainer.id = 'whm-stacks-bloodlily';

--- a/ui/jobs/jobs.css
+++ b/ui/jobs/jobs.css
@@ -299,6 +299,10 @@
   margin-right: 0;
 }
 
+#blm-stacks-xeno > div {
+  background-color: rgba(66, 19, 128, 0.2);
+}
+
 #whm-stacks-bloodlily > div.active {
   background-color: rgb(190, 43, 30);
 }

--- a/ui/jobs/jobs.css
+++ b/ui/jobs/jobs.css
@@ -80,7 +80,7 @@
 
 .bar-container {
   position: relative;
-  width: 201px;
+  width: 202px;
   height: 0;
   background: rgba(30, 30, 30, 0.7);
 }

--- a/ui/jobs/jobs.css
+++ b/ui/jobs/jobs.css
@@ -269,109 +269,34 @@
 }
 
 /* Stacks */
-#whm-stacks {
-  display: flex;
-  margin-top: 1px;
-  width: 206px;
-  height: 12px;
-}
-
-#sam-stacks {
-  display: flex;
-  margin-top: 1px;
-  width: 206px;
-  height: 12px;
-}
-
-#mch-stacks {
-  display: flex;
-  margin-top: 1px;
-  width: 206px;
-  height: 12px;
-}
-
-#mch-stacks.hide {
-  display: none;
-}
-
-#sge-stacks,
-#blm-stacks {
+.stacks {
   display: flex;
   margin-top: 1px;
   width: 202px;
   height: 12px;
+  align-items: stretch;
 }
 
-#smn-stacks {
+.stacks > * {
   display: flex;
-  margin-top: 1px;
-  width: 204px;
-  height: 12px;
-}
-
-#whm-stacks-bloodlily,
-#mch-stacks-wildfire,
-#smn-stacks-ruin4 {
+  margin-right: 2px;
+  flex: 1;
   width: 100%;
   height: 100%;
+  align-items: stretch;
 }
 
-#sge-stacks-addersgall,
-#sge-stacks-addersting,
-#blm-stacks-heart,
-#blm-stacks-xeno {
-  width: 50%;
-  height: 100%;
-}
-
-#sam-stacks-setsu,
-#sam-stacks-getsu,
-#sam-stacks-ka {
+.stacks > * > * {
   background-color: rgba(174, 227, 235, 0.2);
   margin-right: 2px;
   display: inline-block;
   border: 1px solid black;
-  width: calc(33% - 4px);
   height: 100%;
+  flex: 1;
 }
 
-#whm-stacks-bloodlily > div,
-#sge-stacks-addersgall > div,
-#sge-stacks-addersting > div,
-#blm-stacks-heart > div {
-  background-color: rgba(174, 227, 235, 0.2);
-  margin-right: 2px;
-  display: inline-block;
-  border: 1px solid black;
-  width: calc(33% - 4px);
-  height: 100%;
-}
-
-#mch-stacks-wildfire > div {
-  background-color: rgba(174, 227, 235, 0.2);
-  margin-right: 2px;
-  display: inline-block;
-  border: 1px solid black;
-  width: calc(16% - 3px);
-  height: 100%;
-}
-
-#blm-stacks-xeno > div {
-  background-color: rgba(66, 19, 128, 0.2);
-  margin-left: 2px;
-  display: inline-block;
-  border: 1px solid black;
-  width: calc(50% - 4px);
-  height: 100%;
-}
-
-#smn-stacks-ruin4 > div {
-  background-color: rgba(174, 227, 235, 0.2);
-  margin-right: 2px;
-  display: inline-block;
-  border: 1px solid black;
-  width: calc(25% - 4px);
-  height: 100%;
+.stacks :last-child {
+  margin-right: 0;
 }
 
 #whm-stacks-bloodlily > div.active {


### PR DESCRIPTION
Consist the structure of stacks to something like `div#blm-stacks.stacks > div#blm-stacks-hearts > div` even there is only one type of stacks like MCH or SAM does:
![image](https://user-images.githubusercontent.com/19927330/145767732-b5a47fe8-84ef-42ce-a17d-3154bbd36fec.png)

------

Also, I found that many combo timer bar is slightly shorter than others, so change its width to 202px, too.
(Samurai as the example)
Before:
![image](https://user-images.githubusercontent.com/19927330/145771269-c38c4e3c-6089-4240-b5bc-6de4c51c8dfa.png)
After:
![image](https://user-images.githubusercontent.com/19927330/145771338-e0f2cfa1-cc4f-4e8d-8326-bc40f8a63105.png)

------

What @Echoring said in #1856 is caused by the `margin-right: 2px;` CSS property, so I add a `:last-child` pseudo-selector to clear the margin, then all elements can use the same CSS.
So Echoring can you test other jobs to make sure that behaves properly? You can download this ZIP package and replace your files in `cactbot/ui/jobs/`.
[cactbot-jobs.zip](https://github.com/quisquous/cactbot/files/7701853/cactbot-jobs.zip)
