### PR TITLE
jobs: add compact view option

### DIFF
--- a/ui/jobs/bars.ts
+++ b/ui/jobs/bars.ts
@@ -143,6 +143,7 @@ export class Bars {
 
     const procsContainer = document.createElement('div');
     procsContainer.id = 'procs-container';
+    procsContainer.classList.toggle('compact', this.options.CompactView);
     opacityContainer.appendChild(procsContainer);
 
     if (shouldShow.buffList) {

--- a/ui/jobs/jobs.css
+++ b/ui/jobs/jobs.css
@@ -440,6 +440,10 @@
   height: 210px;
 }
 
+#procs-container.compact {
+  top: 80px;
+}
+
 #procs-container > div {
   display: flex;
 

--- a/ui/jobs/jobs_config.ts
+++ b/ui/jobs/jobs_config.ts
@@ -16,6 +16,16 @@ UserConfig.registerOptions('jobs', {
       default: false,
     },
     {
+      id: 'CompactView',
+      name: {
+        en: 'Enable compact view',
+        ja: 'コンパクトUIを有効にする',
+        cn: '启用紧凑视图',
+      },
+      type: 'checkbox',
+      default: false,
+    },
+    {
       id: 'LowerOpacityOutOfCombat',
       name: {
         en: 'Lower ui opacity when out of combat',

--- a/ui/jobs/jobs_options.ts
+++ b/ui/jobs/jobs_options.ts
@@ -23,6 +23,7 @@ export interface JobsNonConfigOptions {
   GpAlarmSoundVolume: number;
   NotifyExpiredProcsInCombat: number;
   NotifyExpiredProcsInCombatSound: 'disabled' | 'expired' | 'threshold';
+  CompactView: boolean;
 }
 
 export interface JobsConfigOptions {
@@ -66,6 +67,7 @@ const defaultJobsNonConfigOptions: JobsNonConfigOptions = {
   GpAlarmSoundVolume: 0.8,
   NotifyExpiredProcsInCombat: 5,
   NotifyExpiredProcsInCombatSound: 'threshold',
+  CompactView: false,
 };
 
 // See user/jobs-example.js for documentation.


### PR DESCRIPTION
This is for someone that they dont like to "wrap" the target bar
in the jobs module UI, but just want to monitor their buffs or something.

i18n: add cn/ja translations for new option

------

BLM Preview:
![image](https://user-images.githubusercontent.com/19927330/145783398-24bf3ff3-b563-448f-9773-6e7175079e92.png)
