### PR TITLE
jobs: DRK: update Delirium trace

### DIFF
--- a/ui/jobs/components/drk.ts
+++ b/ui/jobs/components/drk.ts
@@ -101,8 +101,20 @@ export class DRKComponent extends BaseComponent {
         break;
       }
       case kAbility.Delirium: {
-        this.delirium.duration = 60;
-        break;
+        if (this.is5x) {
+          this.delirium.duration = 10.5;
+          this.delirium.threshold = 20;
+          this.delirium.fg = computeBackgroundColorFrom(this.delirium, 'drk-color-delirium.active');
+          this.tid2 = window.setTimeout(() => {
+            this.delirium.duration = 79.5;
+            this.delirium.threshold = this.player.gcdSkill * 2;
+            this.delirium.fg = computeBackgroundColorFrom(this.delirium, 'drk-color-delirium');
+          }, 10000);
+          break;
+        } else {
+          this.delirium.duration = 60;
+          break;
+        }
       }
       case kAbility.LivingShadow: {
         this.livingShadow.duration = 24;

--- a/ui/jobs/components/drk.ts
+++ b/ui/jobs/components/drk.ts
@@ -101,14 +101,7 @@ export class DRKComponent extends BaseComponent {
         break;
       }
       case kAbility.Delirium: {
-        this.delirium.duration = 10.5;
-        this.delirium.threshold = 20;
-        this.delirium.fg = computeBackgroundColorFrom(this.delirium, 'drk-color-delirium.active');
-        this.tid2 = window.setTimeout(() => {
-          this.delirium.duration = 79.5;
-          this.delirium.threshold = this.player.gcdSkill * 2;
-          this.delirium.fg = computeBackgroundColorFrom(this.delirium, 'drk-color-delirium');
-        }, 10000);
+        this.delirium.duration = 60;
         break;
       }
       case kAbility.LivingShadow: {


### PR DESCRIPTION
Delirium have been changed from 10s to 3 stacks with 15s, no longer need active time trace.
Cooldown also changed to 60s, same as blood Weapon.
Maybe this can be replaced by Salted Earth later.