### PR TITLE
plugin: change tab text to Cactbot Config

### DIFF
--- a/plugin/CactbotEventSource/CactbotEventSource.cs
+++ b/plugin/CactbotEventSource/CactbotEventSource.cs
@@ -102,7 +102,7 @@ namespace Cactbot {
 
     public CactbotEventSource(RainbowMage.OverlayPlugin.ILogger logger)
         : base(logger) {
-      Name = "Cactbot";
+      Name = "Cactbot Config";
 
       RegisterPresets();
 


### PR DESCRIPTION
Apparently this was confusing to some users who thought the
"Cactbot" tab in OverlayPlugin meant that they had cactbot already
and didn't need to add an overlay.

cc @MyTechnoHunter