### PR TITLE
raidboss: add 1st ex trial targetable lines to timeline

### DIFF
--- a/ui/raidboss/data/06-ew/trial/zodiark-ex.txt
+++ b/ui/raidboss/data/06-ew/trial/zodiark-ex.txt
@@ -62,7 +62,8 @@ hideall "Infernal Torrent"
 325.9 "Apomnemoneumata" sync / 1[56]:[^:]*:Zodiark:6D7B:/
 336.9 "--targetable--"
 347.6 "Astral Eclipse" sync / 1[56]:[^:]*:Zodiark:67C3:/
-360.3 "--targetable--"
+347.6 "--untargetable--"
+359.7 "--targetable--"
 364.7 "Explosion 1" sync / 1[56]:[^:]*:Zodiark:67E7:/
 368.7 "Explosion 2" sync / 1[56]:[^:]*:Zodiark:67E7:/
 372.7 "Explosion 3" sync / 1[56]:[^:]*:Zodiark:67E7:/
@@ -102,7 +103,8 @@ hideall "Infernal Torrent"
 
 # Star tethers 2
 535.7 "Astral Eclipse" sync / 1[56]:[^:]*:Zodiark:67C3:/
-549.4 "--targetable--"
+535.7 "--untargetable--"
+547.8 "--targetable--"
 552.8 "Explosion 1" sync / 1[56]:[^:]*:Zodiark:67E7:/
 556.8 "Explosion 2" sync / 1[56]:[^:]*:Zodiark:67E7:/
 560.8 "Explosion 3" sync / 1[56]:[^:]*:Zodiark:67E7:/

--- a/ui/raidboss/data/06-ew/trial/zodiark-ex.txt
+++ b/ui/raidboss/data/06-ew/trial/zodiark-ex.txt
@@ -40,6 +40,7 @@ hideall "Infernal Torrent"
 167.4 "Opheos Eidolon" sync / 1[56]:[^:]*:python:67E3:/
 
 # Adds
+177.4 "--adds targetable--"
 182.3 "--sync--" sync / 1[56]:[^:]*:Roiling Darkness:6631:/
 187.4 "--sync--" sync / 1[56]:[^:]*:Roiling Darkness:6631:/
 190.6 "Esoteric Pattern 1" sync / 1[56]:[^:]*:Arcane Sigil:67E[456]:/
@@ -59,7 +60,9 @@ hideall "Infernal Torrent"
 # Star tethers
 314.4 "--sync--" sync / 1[56]:[^:]*:Zodiark:67E9:/ window 300,10
 325.9 "Apomnemoneumata" sync / 1[56]:[^:]*:Zodiark:6D7B:/
+336.9 "--targetable--"
 347.6 "Astral Eclipse" sync / 1[56]:[^:]*:Zodiark:67C3:/
+360.3 "--targetable--"
 364.7 "Explosion 1" sync / 1[56]:[^:]*:Zodiark:67E7:/
 368.7 "Explosion 2" sync / 1[56]:[^:]*:Zodiark:67E7:/
 372.7 "Explosion 3" sync / 1[56]:[^:]*:Zodiark:67E7:/
@@ -99,6 +102,7 @@ hideall "Infernal Torrent"
 
 # Star tethers 2
 535.7 "Astral Eclipse" sync / 1[56]:[^:]*:Zodiark:67C3:/
+549.4 "--targetable--"
 552.8 "Explosion 1" sync / 1[56]:[^:]*:Zodiark:67E7:/
 556.8 "Explosion 2" sync / 1[56]:[^:]*:Zodiark:67E7:/
 560.8 "Explosion 3" sync / 1[56]:[^:]*:Zodiark:67E7:/


### PR DESCRIPTION
Not sure if astral eclipse timings vary or not, but I was seeing ~12.7 and ~13.7 in fflogs.