### PR TITLE
raidboss: Correct Dreamscape dragon direction trigger

### DIFF
--- a/ui/raidboss/data/06-ew/dungeon/stigma_dreamscape.ts
+++ b/ui/raidboss/data/06-ew/dungeon/stigma_dreamscape.ts
@@ -1,6 +1,5 @@
 import Conditions from '../../../../../resources/conditions';
 import NetRegexes from '../../../../../resources/netregexes';
-import Outputs from '../../../../../resources/outputs';
 import { Responses } from '../../../../../resources/responses';
 import ZoneId from '../../../../../resources/zone_id';
 import { RaidbossData } from '../../../../../types/data';
@@ -198,16 +197,11 @@ const triggerSet: TriggerSet<Data> = {
       netRegexFr: NetRegexes.addedCombatant({ name: 'Dragon Hybride' }),
       netRegexJa: NetRegexes.addedCombatant({ name: 'ハイブリッドドラゴン' }),
       condition: (data) => data.lastBoss,
-      infoText: (_data, matches, output) => {
-        // The arena is a 50x50 square, with (0,0) in the exact center.
-        const isEast = parseFloat(matches.x) > 0;
-        if (isEast)
-          return output.east!();
-        return output.west!();
-      },
+      infoText: (_data, matches, output) => output.text!(),
       outputStrings: {
-        east: Outputs.east,
-        west: Outputs.west,
+        text: {
+          en: 'Get behind dragon',
+        },
       },
     },
     {

--- a/ui/raidboss/data/06-ew/dungeon/stigma_dreamscape.ts
+++ b/ui/raidboss/data/06-ew/dungeon/stigma_dreamscape.ts
@@ -1,5 +1,6 @@
 import Conditions from '../../../../../resources/conditions';
 import NetRegexes from '../../../../../resources/netregexes';
+import Outputs from '../../../../../resources/outputs';
 import { Responses } from '../../../../../resources/responses';
 import ZoneId from '../../../../../resources/zone_id';
 import { RaidbossData } from '../../../../../types/data';
@@ -197,11 +198,16 @@ const triggerSet: TriggerSet<Data> = {
       netRegexFr: NetRegexes.addedCombatantFull({ name: 'Dragon Hybride' }),
       netRegexJa: NetRegexes.addedCombatantFull({ name: 'ハイブリッドドラゴン' }),
       condition: (data) => data.lastBoss,
-      infoText: (_data, matches, output) => output.text!(),
+      infoText: (_data, matches, output) => {
+        // The arena is a 50x50 square, with (0,0) in the exact center.
+        const isEast = parseFloat(matches.x) > 0;
+        if (isEast)
+          return output.east!();
+        return output.west!();
+      },
       outputStrings: {
-        text: {
-          en: 'Get behind dragon',
-        },
+        east: Outputs.east,
+        west: Outputs.west,
       },
     },
     {

--- a/ui/raidboss/data/06-ew/dungeon/stigma_dreamscape.ts
+++ b/ui/raidboss/data/06-ew/dungeon/stigma_dreamscape.ts
@@ -192,10 +192,10 @@ const triggerSet: TriggerSet<Data> = {
       // they are likely to be hit.
       id: 'Dreamscape Touchdown',
       type: 'AddedCombatant',
-      netRegex: NetRegexes.addedCombatant({ name: 'Hybrid Dragon' }),
-      netRegexDe: NetRegexes.addedCombatant({ name: 'Hybrid-Drache' }),
-      netRegexFr: NetRegexes.addedCombatant({ name: 'Dragon Hybride' }),
-      netRegexJa: NetRegexes.addedCombatant({ name: 'ハイブリッドドラゴン' }),
+      netRegex: NetRegexes.addedCombatantFull({ name: 'Hybrid Dragon' }),
+      netRegexDe: NetRegexes.addedCombatantFull({ name: 'Hybrid-Drache' }),
+      netRegexFr: NetRegexes.addedCombatantFull({ name: 'Dragon Hybride' }),
+      netRegexJa: NetRegexes.addedCombatantFull({ name: 'ハイブリッドドラゴン' }),
       condition: (data) => data.lastBoss,
       infoText: (_data, matches, output) => output.text!(),
       outputStrings: {

--- a/ui/raidboss/data/06-ew/dungeon/stigma_dreamscape.ts
+++ b/ui/raidboss/data/06-ew/dungeon/stigma_dreamscape.ts
@@ -159,10 +159,10 @@ const triggerSet: TriggerSet<Data> = {
     {
       id: 'Dreamscape Wheel',
       type: 'StartsUsing',
-      netRegex: NetRegexes.startsUsing({ id: '6B9D', source: 'Arch-Lambda' }),
-      netRegexDe: NetRegexes.startsUsing({ id: '6B9D', source: 'Erz-Lambda' }),
-      netRegexFr: NetRegexes.startsUsing({ id: '6B9D', source: 'Arch-Lambda' }),
-      netRegexJa: NetRegexes.startsUsing({ id: '6B9D', source: 'アーチラムダ' }),
+      netRegex: NetRegexes.startsUsing({ id: '63B5', source: 'Arch-Lambda' }),
+      netRegexDe: NetRegexes.startsUsing({ id: '63B5', source: 'Erz-Lambda' }),
+      netRegexFr: NetRegexes.startsUsing({ id: '63B5', source: 'Arch-Lambda' }),
+      netRegexJa: NetRegexes.startsUsing({ id: '63B5', source: 'アーチラムダ' }),
       response: Responses.tankBuster(),
     },
     {


### PR DESCRIPTION
Per a report on the XIV plugin Discord server, this trigger seems to call only West, regardless of the dragon's actual spawn location. I'm not having much luck tracking down the issue, so for now we'll just tell the user to get behind the dragon the moment it spawns.