### PR TITLE
jobs: WAR: fix Surging Tempest timer

### DIFF
--- a/ui/jobs/components/war.ts
+++ b/ui/jobs/components/war.ts
@@ -71,7 +71,7 @@ export class WARComponent extends BaseComponent {
     if (skill === kAbility.MythrilTempest &&
       (this.eyeBox.duration === null || this.eyeBox.duration === 0)) {
       if (!this.is5x)
-        this.eyeBox.duration = 30 + 0.5;
+        this.eyeBox.duration = 30;
         this.initial = true;
         setTimeout(() => {
           this.initial = false;

--- a/ui/jobs/components/war.ts
+++ b/ui/jobs/components/war.ts
@@ -69,8 +69,8 @@ export class WARComponent extends BaseComponent {
     // See: https://github.com/quisquous/cactbot/issues/3778
     //
     // Here's a hack to at least get the initial application to be better.
-    const bonus = this.eyeBox.duration === 0 ? 1.1 : 0;
-    this.eyeBox.duration = duration + bonus;
+    const bonus = this.eyeBox.duration === 0 ? 1.6 : 0;
+    this.eyeBox.duration = duration + bonus - 0.5;
   }
   override onYouLoseEffect(id: string): void {
     // TODO: delete StormsEye after every region launch 6.0

--- a/ui/jobs/components/war.ts
+++ b/ui/jobs/components/war.ts
@@ -83,8 +83,12 @@ export class WARComponent extends BaseComponent {
       this.comboTimer.duration = this.comboDuration;
   }
   override onUseAbility(id: string): void {
-    if (id === kAbility.InnerRelease && this.just === true)
-      this.eyeBox.duration = 45 + 0.5;
+    if (id === kAbility.InnerRelease && this.just === true) {
+      if (this.is5x)
+        this.eyeBox.duration = 45 + 0.5;
+      else
+        this.eyeBox.duration = 40 + 0.5;
+    }
   }
   override onYouGainEffect(id: string, matches: PartialFieldMatches<'GainsEffect'>): void {
     // TODO: delete StormsEye after every region launch 6.0

--- a/ui/jobs/components/war.ts
+++ b/ui/jobs/components/war.ts
@@ -84,7 +84,7 @@ export class WARComponent extends BaseComponent {
   override onUseAbility(id: string): void {
     // If you use Inner Release following StormsEye initial at once
     // duration will still not go down until designed time
-    if (id === kAbility.InnerRelease && this.just === true) {
+    if ((id === kAbility.InnerRelease || id === kAbility.Berserk) && this.just === true) {
       if (this.is5x)
         this.eyeBox.duration = 30 + 15 + 0.5;
       else

--- a/ui/jobs/components/war.ts
+++ b/ui/jobs/components/war.ts
@@ -60,15 +60,10 @@ export class WARComponent extends BaseComponent {
     if (id !== EffectId.SurgingTempest && id !== EffectId.StormsEye)
       return;
     const duration = parseFloat(matches.duration ?? '0');
-    // TODO: the buff duration for Storm's Eye appears to be somewhat of a lie.
-    // The initial application seems to have some variability 1.1-1.3ish?
-    // And Storm's Eye and Mythril Tempest when extending also do this.
-    // This needs more investigation and some fixing unfortunately,
-    // as this will drift a lot over the course of a fight.
-    // We may also need to track which skill caused this effect.
-    // See: https://github.com/quisquous/cactbot/issues/3778
-    //
-    // Here's a hack to at least get the initial application to be better.
+    if (this.eyeBox.duration === null)
+      this.eyeBox.duration = 0;
+    // FIXME: may incorrect if initial with Mythril Tempest, but will correct after refresh
+    // also will incorrect if initial with Storm's Eye and Inner Release at once
     const bonus = this.eyeBox.duration === 0 ? 1.6 : 0;
     this.eyeBox.duration = duration + bonus - 0.5;
   }

--- a/ui/jobs/components/war.ts
+++ b/ui/jobs/components/war.ts
@@ -54,6 +54,7 @@ export class WARComponent extends BaseComponent {
 
   override onCombo(skill: string, combo: ComboTracker): void {
     this.comboTimer.duration = 0;
+    // Storm's Eye initiation will freeze Surging Tempest buff for about 1.6s before countdown start
     if (skill === kAbility.StormsEye &&
       (this.eyeBox.duration === null || this.eyeBox.duration === 0))
       this.bonus = 1.6;

--- a/ui/jobs/components/war.ts
+++ b/ui/jobs/components/war.ts
@@ -55,8 +55,7 @@ export class WARComponent extends BaseComponent {
   override onCombo(skill: string, combo: ComboTracker): void {
     this.comboTimer.duration = 0;
     // Storm's Eye initiation will freeze Surging Tempest buff for about 1.6s before countdown start
-    if (skill === kAbility.StormsEye &&
-      (this.eyeBox.duration === null || this.eyeBox.duration === 0))
+    if (skill === kAbility.StormsEye && !this.eyeBox.duration)
       this.bonus = 1.6;
     if (combo.isFinalSkill)
       return;

--- a/ui/jobs/components/war.ts
+++ b/ui/jobs/components/war.ts
@@ -13,8 +13,7 @@ export class WARComponent extends BaseComponent {
   textBox: ResourceBox;
   eyeBox: TimerBox;
   comboTimer: TimerBar;
-  initial: boolean;
-  just: boolean;
+  bonus: number;
 
   constructor(o: ComponentInterface) {
     super(o);
@@ -31,8 +30,8 @@ export class WARComponent extends BaseComponent {
       id: 'war-timers-combo',
       fgColor: 'combo-color',
     });
-    this.initial = false;
-    this.just = false;
+
+    this.bonus = 0;
   }
 
   override onJobDetailUpdate(jobDetail: JobDetail['WAR']): void {
@@ -56,48 +55,20 @@ export class WARComponent extends BaseComponent {
   override onCombo(skill: string, combo: ComboTracker): void {
     this.comboTimer.duration = 0;
     if (skill === kAbility.StormsEye &&
-      (this.eyeBox.duration === null || this.eyeBox.duration === 0)) {
-      this.eyeBox.duration = 30 + 1.1;
-      this.initial = true;
-      this.just = true; // for continue with Inner Release at once case
-      setTimeout(() => {
-        this.initial = false;
-      }, 550);
-      setTimeout(() => {
-        this.just = false;
-      }, 1100);
-    }
-    if (skill === kAbility.MythrilTempest &&
-      (this.eyeBox.duration === null || this.eyeBox.duration === 0)) {
-      if (!this.is5x)
-        this.eyeBox.duration = 30;
-        this.initial = true;
-        setTimeout(() => {
-          this.initial = false;
-        }, 550);
-    }
+      (this.eyeBox.duration === null || this.eyeBox.duration === 0))
+      this.bonus = 1.6;
     if (combo.isFinalSkill)
       return;
     if (skill)
       this.comboTimer.duration = this.comboDuration;
-  }
-  override onUseAbility(id: string): void {
-    // If you use Inner Release following StormsEye initial at once
-    // duration will still not go down until designed time
-    if ((id === kAbility.InnerRelease || id === kAbility.Berserk) && this.just === true) {
-      if (this.is5x)
-        this.eyeBox.duration = 30 + 15 + 0.5;
-      else
-        this.eyeBox.duration = 30 + 10 + 0.5;
-    }
   }
   override onYouGainEffect(id: string, matches: PartialFieldMatches<'GainsEffect'>): void {
     // TODO: delete StormsEye after every region launch 6.0
     if (id !== EffectId.SurgingTempest && id !== EffectId.StormsEye)
       return;
     const duration = parseFloat(matches.duration ?? '0');
-    if (!this.initial && !this.just)
-      this.eyeBox.duration = duration - 0.5; // buff logline delay
+    this.eyeBox.duration = duration + this.bonus - 0.5; // buff logline delay
+    this.bonus = 0;
   }
   override onYouLoseEffect(id: string): void {
     // TODO: delete StormsEye after every region launch 6.0

--- a/ui/jobs/components/war.ts
+++ b/ui/jobs/components/war.ts
@@ -83,11 +83,13 @@ export class WARComponent extends BaseComponent {
       this.comboTimer.duration = this.comboDuration;
   }
   override onUseAbility(id: string): void {
+    // If you use Inner Release following StormsEye initial at once
+    // duration will still not go down until designed time
     if (id === kAbility.InnerRelease && this.just === true) {
       if (this.is5x)
-        this.eyeBox.duration = 45 + 0.5;
+        this.eyeBox.duration = 30 + 15 + 0.5;
       else
-        this.eyeBox.duration = 40 + 0.5;
+        this.eyeBox.duration = 30 + 10 + 0.5;
     }
   }
   override onYouGainEffect(id: string, matches: PartialFieldMatches<'GainsEffect'>): void {

--- a/ui/jobs/components/war.ts
+++ b/ui/jobs/components/war.ts
@@ -67,7 +67,6 @@ export class WARComponent extends BaseComponent {
         this.just = false;
       }, 1100);
     }
-    // FIXME: MythrilTempest delay untested
     if (skill === kAbility.MythrilTempest &&
       (this.eyeBox.duration === null || this.eyeBox.duration === 0)) {
       if (!this.is5x)

--- a/ui/jobs/constants.ts
+++ b/ui/jobs/constants.ts
@@ -88,6 +88,7 @@ export const kAbility = {
   Overpower: '29',
   MythrilTempest: '404E',
   Tomahawk: '2E',
+  Berserk: '26',
   InnerRelease: '1CDD',
   // DRK
   HardSlash: 'E21',

--- a/ui/jobs/constants.ts
+++ b/ui/jobs/constants.ts
@@ -88,7 +88,6 @@ export const kAbility = {
   Overpower: '29',
   MythrilTempest: '404E',
   Tomahawk: '2E',
-  Berserk: '26',
   InnerRelease: '1CDD',
   // DRK
   HardSlash: 'E21',


### PR DESCRIPTION
Fixes #3778 
Some hypothesis to the question in #3778:
> Initial application of Storm's Eye is not exactly 30s (instead is ~31.1):

Storm's Eye will apply Surging Tempest at once with a log says you gain Surging Tempest for 30s,
but this buff duration will not go down until Storm's Eyes' damage is dealed.
(if you use other ability to cancel its animation, duration will still be locked to designed time, this make things very complex when use Inner Release in this case)
When refreshing, this duration lock will not apply.
Mythril Tempest do not have buff lock time. 

> I found that the timer and box were consistent, but if I refreshed then they got offset by like ~0.5s?

There is a log line delay of 0.5s for most buff.