### PR TITLE
build: add more vscode editorconfig settings

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -10,8 +10,9 @@ root = true
 insert_final_newline = true
 indent_style = space
 
-[*.{js,json,cjs,mjs,ts}]
+[*.{js,json,cjs,mjs,ts,yml,yaml}]
 indent_size = 2
+quote_type = single
 
 [*.py]
 indent_size = 4


### PR DESCRIPTION
This takes the editorconfig from Trim21's #3677, with a slight
modification to also apply quote_type=single to js/ts/json files.