### PR TITLE
raidboss: add p1n and p2n timeline

### DIFF
--- a/ui/raidboss/data/06-ew/raid/p1n.ts
+++ b/ui/raidboss/data/06-ew/raid/p1n.ts
@@ -138,7 +138,7 @@ const triggerSet: TriggerSet<Data> = {
       'replaceText': {
         'Gaoler\'s Flail Left/Gaoler\'s Flail Right': 'Gaoler\'s Flail Left/Right',
         'Gaoler\'s Flail Right/Gaoler\'s Flail Left': 'Gaoler\'s Flail Right/Left',
-        'Hot Spell/Cold Spell': 'Hot/Cold',
+        'Hot Spell/Cold Spell': 'Hot/Cold Spell',
         'Powerful Fire/Powerful Light': 'Powerful Fire/Light',
         'Aetherflail Left/Aetherflail Right': 'Aetherflail Left/Right',
         'Aetherflail Right/Aetherflail Left': 'Aetherflail Right/Left',

--- a/ui/raidboss/data/06-ew/raid/p1n.ts
+++ b/ui/raidboss/data/06-ew/raid/p1n.ts
@@ -132,6 +132,19 @@ const triggerSet: TriggerSet<Data> = {
       },
     },
   ],
+  timelineReplace: [
+    {
+      'locale': 'en',
+      'replaceText': {
+        'Gaoler\'s Flail Left/Gaoler\'s Flail Right?': 'Gaoler\'s Flail Left/Right?',
+        'Gaoler\'s Flail Right/Gaoler\'s Flail Left?': 'Gaoler\'s Flail Right/Left?',
+        'Hot Spell/Cold Spell': 'Hot/Cold',
+        'Powerful Fire/Powerful Light': 'Powerful Fire/Light',
+        'Aetherflail Left/Aetherflail Right?': 'Aetherflail Left/Right?',
+        'Aetherflail Right/Aetherflail Left?': 'Aetherflail Right/Left?',
+      },
+    },
+  ],
 };
 
 export default triggerSet;

--- a/ui/raidboss/data/06-ew/raid/p1n.ts
+++ b/ui/raidboss/data/06-ew/raid/p1n.ts
@@ -136,12 +136,12 @@ const triggerSet: TriggerSet<Data> = {
     {
       'locale': 'en',
       'replaceText': {
-        'Gaoler\'s Flail Left/Gaoler\'s Flail Right?': 'Gaoler\'s Flail Left/Right?',
-        'Gaoler\'s Flail Right/Gaoler\'s Flail Left?': 'Gaoler\'s Flail Right/Left?',
+        'Gaoler\'s Flail Left/Gaoler\'s Flail Right': 'Gaoler\'s Flail Left/Right',
+        'Gaoler\'s Flail Right/Gaoler\'s Flail Left': 'Gaoler\'s Flail Right/Left',
         'Hot Spell/Cold Spell': 'Hot/Cold',
         'Powerful Fire/Powerful Light': 'Powerful Fire/Light',
-        'Aetherflail Left/Aetherflail Right?': 'Aetherflail Left/Right?',
-        'Aetherflail Right/Aetherflail Left?': 'Aetherflail Right/Left?',
+        'Aetherflail Left/Aetherflail Right': 'Aetherflail Left/Right',
+        'Aetherflail Right/Aetherflail Left': 'Aetherflail Right/Left',
       },
     },
   ],

--- a/ui/raidboss/data/06-ew/raid/p1n.txt
+++ b/ui/raidboss/data/06-ew/raid/p1n.txt
@@ -6,12 +6,8 @@
 # timeline as that is the cast that is visible. However, damage is from the
 # Gaoler's Flail (6DA3|6DA2) cast end after.
 
-# Note: unknown_6d15 happens same time as marker for the stack
-# to avoid knockback mechanic.
-
 hideall "--Reset--"
 hideall "--sync--"
-hideall "unknown_6d15"
 
 0.0 "--Reset--" sync / 21:........:40000010:/ window 100000 jump 0
 
@@ -23,7 +19,7 @@ hideall "unknown_6d15"
 17.4 "Gaoler's Flail Left/Gaoler's Flail Right?" #sync / 1[56]:[^:]*:Erichthonios:(6DA3|6DA2):/
 28.5 "Gaoler's Flail Right/Gaoler's Flail Left?" #sync / 1[56]:[^:]*:Erichthonios:(6DA2|6DA3):/
 39.0 "Warder's Wrath" #sync / 1[56]:[^:]*:Erichthonios:65F4:/
-46.2 "unknown_6d15" #sync / 1[56]:[^:]*:Erichthonios:6D15:/
+46.2 "--knockback stack--" #sync / 1[56]:[^:]*:Erichthonios:6D15:/
 51.5 "Pitiless Flail" #sync / 1[56]:[^:]*:Erichthonios:65E5:/
 58.6 "True Holy" #sync / 1[56]:[^:]*:Erichthonios:65E7:/
 
@@ -32,7 +28,7 @@ hideall "unknown_6d15"
 117.4 "Gaoler's Flail Left" sync / 1[56]:[^:]*:Erichthonios:6DA3:/
 128.5 "Gaoler's Flail Right" sync / 1[56]:[^:]*:Erichthonios:6DA2:/
 139.0 "Warder's Wrath" sync / 1[56]:[^:]*:Erichthonios:65F4:/ jump 239
-146.2 "unknown_6d15" #sync / 1[56]:[^:]*:Erichthonios:6D15:/
+146.2 "--knockback stack--" #sync / 1[56]:[^:]*:Erichthonios:6D15:/
 151.5 "Pitiless Flail (knockback)" #sync / 1[56]:[^:]*:Erichthonios:65E5:/
 158.6 "True Holy" #sync / 1[56]:[^:]*:Erichthonios:65E7:/
 170.5 "Gaoler's Flail Left/Gaoler's Flail Right?" #sync / 1[56]:[^:]*:Erichthonios:(6DA3|6DA2):/
@@ -43,7 +39,7 @@ hideall "unknown_6d15"
 217.4 "Gaoler's Flail Right" sync / 1[56]:[^:]*:Erichthonios:6DA2:/
 228.5 "Gaoler's Flail Left" sync / 1[56]:[^:]*:Erichthonios:6DA3:/
 239.0 "Warder's Wrath" sync / 1[56]:[^:]*:Erichthonios:65F4:/
-246.2 "unknown_6d15" sync / 1[56]:[^:]*:Erichthonios:6D15:/
+246.2 "--knockback stack--" sync / 1[56]:[^:]*:Erichthonios:6D15:/
 251.5 "Pitiless Flail (knockback)" sync / 1[56]:[^:]*:Erichthonios:65E5:/
 258.6 "True Holy" sync / 1[56]:[^:]*:Erichthonios:65E7:/
 
@@ -97,7 +93,7 @@ hideall "unknown_6d15"
 598.8 "Powerful Fire/Powerful Light" #sync / 1[56]:[^:]*:Erichthonios:(65EC|65ED):/
 609.8 "Aetherflail Right/Aetherflail Left?" #sync / 1[56]:[^:]*:Erichthonios:(6DA2|6DA3):/
 609.9 "Powerful Fire/Powerful Light" #sync / 1[56]:[^:]*:Erichthonios:(65EC|65ED):/
-614.3 "unknown_6d15" #sync / 1[56]:[^:]*:Erichthonios:6D15:/
+614.3 "--knockback stack--" #sync / 1[56]:[^:]*:Erichthonios:6D15:/
 619.6 "Pitiless Flail (knockback)" #sync / 1[56]:[^:]*:Erichthonios:65E5:/
 626.7 "True Holy" #sync / 1[56]:[^:]*:Erichthonios:65E7:/
 632.9 "--middle--" #sync / 1[56]:[^:]*:Erichthonios:65F5:/
@@ -110,7 +106,7 @@ hideall "unknown_6d15"
 698.8 "Powerful Fire/Powerful Light" sync / 1[56]:[^:]*:Erichthonios:(65EC|65ED):/
 709.8 "Aetherflail Right" sync / 1[56]:[^:]*:Erichthonios:6DA2:/
 709.9 "Powerful Fire/Powerful Light" sync / 1[56]:[^:]*:Erichthonios:(65EC|65ED):/ jump 809.9
-714.3 "unknown_6d15" #sync / 1[56]:[^:]*:Erichthonios:6D15:/
+714.3 "--knockback stack--" #sync / 1[56]:[^:]*:Erichthonios:6D15:/
 719.6 "Pitiless Flail (knockback)" #sync / 1[56]:[^:]*:Erichthonios:65E5:/
 726.7 "True Holy" #sync / 1[56]:[^:]*:Erichthonios:65E7:/
 732.9 "--middle--" #sync / 1[56]:[^:]*:Erichthonios:65F5:/
@@ -124,7 +120,7 @@ hideall "unknown_6d15"
 798.8 "Powerful Fire/Powerful Light" sync / 1[56]:[^:]*:Erichthonios:(65EC|65ED):/
 809.8 "Aetherflail Left" sync / 1[56]:[^:]*:Erichthonios:6DA3:/
 809.9 "Powerful Fire/Powerful Light" sync / 1[56]:[^:]*:Erichthonios:(65EC|65ED):/
-814.3 "unknown_6d15" sync / 1[56]:[^:]*:Erichthonios:6D15:/
+814.3 "--knockback stack--" sync / 1[56]:[^:]*:Erichthonios:6D15:/
 819.6 "Pitiless Flail (knockback)" sync / 1[56]:[^:]*:Erichthonios:65E5:/
 826.7 "True Holy" sync / 1[56]:[^:]*:Erichthonios:65E7:/
 832.9 "--middle--" sync / 1[56]:[^:]*:Erichthonios:65F5:/
@@ -185,7 +181,7 @@ hideall "unknown_6d15"
 1370.4 "Powerful Fire/Powerful Light" #sync / 1[56]:[^:]*:Erichthonios:(65EC|65ED):/
 1381.4 "Aetherflail Right/Aetherflail Left?" #sync / 1[56]:[^:]*:Erichthonios:(6DA2|6DA3):/
 1381.5 "Powerful Fire/Powerful Light" #sync / 1[56]:[^:]*:Erichthonios:(65EC|65ED):/
-1385.9 "unknown_6d15" #sync / 1[56]:[^:]*:Erichthonios:6D15:/
+1385.9 "--knockback stack--" #sync / 1[56]:[^:]*:Erichthonios:6D15:/
 1391.2 "Pitiless Flail (knockback)" #sync / 1[56]:[^:]*:Erichthonios:65E5:/
 1398.3 "True Holy" #sync / 1[56]:[^:]*:Erichthonios:65E7:/
 1404.5 "--middle--" #sync / 1[56]:[^:]*:Erichthonios:65F5:/

--- a/ui/raidboss/data/06-ew/raid/p1n.txt
+++ b/ui/raidboss/data/06-ew/raid/p1n.txt
@@ -19,7 +19,7 @@ hideall "unknown_6d15"
 
 ## First Gaoler's Flail
 8.7 "--sync--" sync / 14:[^:]*:Erichthonios:6DA3:/ jump 108.7 window 10,10
-8.8 "--sync--" sync / 14:[^:]*:Erichthonios:6DA2:/ jump 208.7 window 10,10
+8.7 "--sync--" sync / 14:[^:]*:Erichthonios:6DA2:/ jump 208.7 window 10,10
 17.4 "Gaoler's Flail Left/Gaoler's Flail Right?" #sync / 1[56]:[^:]*:Erichthonios:(6DA3|6DA2):/
 28.5 "Gaoler's Flail Right/Gaoler's Flail Left?" #sync / 1[56]:[^:]*:Erichthonios:(6DA2|6DA3):/
 39.0 "Warder's Wrath" #sync / 1[56]:[^:]*:Erichthonios:65F4:/
@@ -49,7 +49,7 @@ hideall "unknown_6d15"
 
 ## Third Gaoler's Flail
 261.8 "--sync--" sync / 14:[^:]*:Erichthonios:6DA3:/ jump 361.8
-261.9 "--sync--" sync / 14:[^:]*:Erichthonios:6DA2:/ jump 461.8
+261.8 "--sync--" sync / 14:[^:]*:Erichthonios:6DA2:/ jump 461.8
 270.5 "Gaoler's Flail Left/Gaoler's Flail Right?" #sync / 1[56]:[^:]*:Erichthonios:(6DA3|6DA2):/
 281.1 "Heavy Hand" #sync / 1[56]:[^:]*:Erichthonios:65F3:/
 293.2 "Intemperance" #sync / 1[56]:[^:]*:Erichthonios:65EE:/
@@ -91,8 +91,8 @@ hideall "unknown_6d15"
 588.3 "--middle--" sync / 1[56]:[^:]*:Erichthonios:65F5:/
 
 ## Fourth Gaoler's Flail
-590.0 "--sync--" sync / 14:[^:]*:Erichthonios:6DA3:/ jump 690.0
-590.1 "--sync--" sync / 14:[^:]*:Erichthonios:6DA2:/ jump 790.0
+590.0 "--sync--" sync / 14:[^:]*:Erichthonios:6DA3:/ jump 690
+590.0 "--sync--" sync / 14:[^:]*:Erichthonios:6DA2:/ jump 790
 598.7 "Aetherflail Left/Aetherflail Right?" sync / 1[56]:[^:]*:Erichthonios:(6DA3|6DA2):/
 598.8 "Powerful Fire/Powerful Light" #sync / 1[56]:[^:]*:Erichthonios:(65EC|65ED):/
 609.8 "Aetherflail Right/Aetherflail Left?" #sync / 1[56]:[^:]*:Erichthonios:(6DA2|6DA3):/
@@ -101,7 +101,6 @@ hideall "unknown_6d15"
 619.6 "Pitiless Flail (knockback)" #sync / 1[56]:[^:]*:Erichthonios:65E5:/
 626.7 "True Holy" #sync / 1[56]:[^:]*:Erichthonios:65E7:/
 632.9 "--middle--" #sync / 1[56]:[^:]*:Erichthonios:65F5:/
-634.6 "--sync--" #sync / 14:[^:]*:Erichthonios:(6DA3|6DA2):/
 643.3 "Aetherflail Left/Aetherflail Right?" #sync / 1[56]:[^:]*:Erichthonios:(6DA3|6DA2):/
 643.4 "Powerful Fire/Powerful Light" #sync / 1[56]:[^:]*:Erichthonios:(65EC|65ED):/
 
@@ -131,8 +130,8 @@ hideall "unknown_6d15"
 832.9 "--middle--" sync / 1[56]:[^:]*:Erichthonios:65F5:/
 
 ## Sixth Gaoler's Flail
-834.6 "--sync--" sync / 14:[^:]*:Erichthonios:6DA3:/ jump 934.6
-834.7 "--sync--" sync / 14:[^:]*:Erichthonios:6DA2:/ jump 1234.6
+834.6 "--sync--" sync / 14:[^:]*:Erichthonios:6DA3:/ jump 934.7
+834.6 "--sync--" sync / 14:[^:]*:Erichthonios:6DA2:/ jump 1234.7
 843.3 "Aetherflail Left/Aetherflail Right?" #sync / 1[56]:[^:]*:Erichthonios:(6DA3|6DA2):/
 843.4 "Powerful Fire/Powerful Light" #sync / 1[56]:[^:]*:Erichthonios:(65EC|65ED):/
 860.8 "Slam Shut" #sync / 1[56]:[^:]*:Erichthonios:65EA:/
@@ -154,7 +153,6 @@ hideall "unknown_6d15"
 981.7 "Intemperate Torment" sync / 1[56]:[^:]*:Erichthonios:65EF:/
 984.3 "Hot Spell/Cold Spell 1" sync / 1[56]:[^:]*:Erichthonios:(65F0|54F1):/
 993.3 "Hot Spell/Cold Spell 2" sync / 1[56]:[^:]*:Erichthonios:(6CC5|6CC6):/
-996.9 "--sync--" sync / 14:[^:]*:Erichthonios:6DA2:/
 1002.3 "Hot Spell/Cold Spell 3" sync / 1[56]:[^:]*:Erichthonios:(6CC5|6CC6):/
 1005.6 "Gaoler's Flail Right" sync / 1[56]:[^:]*:Erichthonios:6DA2:/
 1116.1 "Warder's Wrath" sync / 1[56]:[^:]*:Erichthonios:65F4:/ jump 1316.2

--- a/ui/raidboss/data/06-ew/raid/p1n.txt
+++ b/ui/raidboss/data/06-ew/raid/p1n.txt
@@ -14,173 +14,67 @@ hideall "--sync--"
 0.0 "--sync--" sync /Engage!/ window 0,1
 
 ## First Gaoler's Flail
-8.7 "--sync--" sync / 14:[^:]*:Erichthonios:(6DA2|6DA3):/ window 10,9
+8.7 "--sync--" sync / 14:[^:]*:Erichthonios:(6DA3|6DA2):/ window 10,9
 17.4 "Gaoler's Flail Left/Gaoler's Flail Right" sync / 1[56]:[^:]*:Erichthonios:(6DA3|6DA2):/
 28.5 "Gaoler's Flail Right/Gaoler's Flail Left" sync / 1[56]:[^:]*:Erichthonios:(6DA2|6DA3):/
-39.0 "Warder's Wrath" #sync / 1[56]:[^:]*:Erichthonios:65F4:/
-46.2 "--knockback stack--" #sync / 1[56]:[^:]*:Erichthonios:6D15:/
-51.5 "Pitiless Flail" #sync / 1[56]:[^:]*:Erichthonios:65E5:/
-58.6 "True Holy" #sync / 1[56]:[^:]*:Erichthonios:65E7:/
-
-# Left First, Right Second
-108.7 "--sync--" sync / 14:[^:]*:Erichthonios:6DA3:/
-117.4 "Gaoler's Flail Left" sync / 1[56]:[^:]*:Erichthonios:6DA3:/
-128.5 "Gaoler's Flail Right" sync / 1[56]:[^:]*:Erichthonios:6DA2:/
-139.0 "Warder's Wrath" sync / 1[56]:[^:]*:Erichthonios:65F4:/ jump 239
-146.2 "--knockback stack--" #sync / 1[56]:[^:]*:Erichthonios:6D15:/
-151.5 "Pitiless Flail (knockback)" #sync / 1[56]:[^:]*:Erichthonios:65E5:/
-158.6 "True Holy" #sync / 1[56]:[^:]*:Erichthonios:65E7:/
-170.5 "Gaoler's Flail Left/Gaoler's Flail Right?" #sync / 1[56]:[^:]*:Erichthonios:(6DA3|6DA2):/
-181.1 "Heavy Hand" #sync / 1[56]:[^:]*:Erichthonios:65F3:/
-
-# Right First, Left Second
-208.7 "--sync--" sync / 14:[^:]*:Erichthonios:6DA2:/
-217.4 "Gaoler's Flail Right" sync / 1[56]:[^:]*:Erichthonios:6DA2:/
-228.5 "Gaoler's Flail Left" sync / 1[56]:[^:]*:Erichthonios:6DA3:/
-239.0 "Warder's Wrath" sync / 1[56]:[^:]*:Erichthonios:65F4:/
-246.2 "--knockback stack--" sync / 1[56]:[^:]*:Erichthonios:6D15:/
-251.5 "Pitiless Flail (knockback)" sync / 1[56]:[^:]*:Erichthonios:65E5:/
-258.6 "True Holy" sync / 1[56]:[^:]*:Erichthonios:65E7:/
+39.0 "Warder's Wrath" sync / 1[56]:[^:]*:Erichthonios:65F4:/
+46.2 "--knockback stack--" sync / 1[56]:[^:]*:Erichthonios:6D15:/
+51.5 "Pitiless Flail" sync / 1[56]:[^:]*:Erichthonios:65E5:/
+58.6 "True Holy" sync / 1[56]:[^:]*:Erichthonios:65E7:/
 
 ## Third Gaoler's Flail
-261.8 "--sync--" sync / 14:[^:]*:Erichthonios:6DA3:/ jump 361.8
-261.8 "--sync--" sync / 14:[^:]*:Erichthonios:6DA2:/ jump 461.8
-270.5 "Gaoler's Flail Left/Gaoler's Flail Right?" #sync / 1[56]:[^:]*:Erichthonios:(6DA3|6DA2):/
-281.1 "Heavy Hand" #sync / 1[56]:[^:]*:Erichthonios:65F3:/
-293.2 "Intemperance" #sync / 1[56]:[^:]*:Erichthonios:65EE:/
-297.3 "--middle--" #sync / 1[56]:[^:]*:Erichthonios:65F5:/
-305.1 "Intemperate Torment" #sync / 1[56]:[^:]*:Erichthonios:65EF:/
-307.7 "Hot Spell/Cold Spell 1" #sync / 1[56]:[^:]*:Erichthonios:(65F0|54F1):/
-316.7 "Hot Spell/Cold Spell 2" #sync / 1[56]:[^:]*:Erichthonios:(6CC5|6CC6):/
-
-# Left Third
-361.8 "--sync--" sync / 14:[^:]*:Erichthonios:6DA3:/
-370.5 "Gaoler's Flail Left" sync / 1[56]:[^:]*:Erichthonios:6DA3:/
-381.1 "Heavy Hand" sync / 1[56]:[^:]*:Erichthonios:65F3:/ jump 481.1
-393.2 "Intemperance" #sync / 1[56]:[^:]*:Erichthonios:65EE:/
-397.3 "--middle--" #sync / 1[56]:[^:]*:Erichthonios:65F5:/
-405.1 "Intemperate Torment" #sync / 1[56]:[^:]*:Erichthonios:65EF:/
-407.7 "Hot Spell/Cold Spell 1" #sync / 1[56]:[^:]*:Erichthonios:(65F0|54F1):/
-416.7 "Hot Spell/Cold Spell 2" #sync / 1[56]:[^:]*:Erichthonios:(6CC5|6CC6):/
-425.7 "Hot Spell/Cold Spell 3" #sync / 1[56]:[^:]*:Erichthonios:(6CC5|6CC6):/
-
-# Right Third
-461.8 "--sync--" sync / 14:[^:]*:Erichthonios:6DA2:/
-470.5 "Gaoler's Flail Right" sync / 1[56]:[^:]*:Erichthonios:6DA2:/
-481.1 "Heavy Hand" sync / 1[56]:[^:]*:Erichthonios:65F3:/
-493.2 "Intemperance" sync / 1[56]:[^:]*:Erichthonios:65EE:/
-497.3 "--middle--" sync / 1[56]:[^:]*:Erichthonios:65F5:/
-505.1 "Intemperate Torment" sync / 1[56]:[^:]*:Erichthonios:65EF:/
-507.7 "Hot Spell/Cold Spell 1" sync / 1[56]:[^:]*:Erichthonios:(65F0|54F1):/
-516.7 "Hot Spell/Cold Spell 2" sync / 1[56]:[^:]*:Erichthonios:(6CC5|6CC6):/
-525.7 "Hot Spell/Cold Spell 3" sync / 1[56]:[^:]*:Erichthonios:(6CC5|6CC6):/
-535.3 "Warder's Wrath" sync / 1[56]:[^:]*:Erichthonios:65F4:/
-547.6 "Heavy Hand" sync / 1[56]:[^:]*:Erichthonios:65F3:/
-562.7 "Shining Cells" sync / 1[56]:[^:]*:Erichthonios:65E9:/
-574.9 "Aetherchain" sync / 1[56]:[^:]*:Erichthonios:65EB:/
-575.8 "Powerful Fire/Powerful Light" sync / 1[56]:[^:]*:Erichthonios:(65EC|65ED):/
-583.1 "Aetherchain" sync / 1[56]:[^:]*:Erichthonios:65EB:/
-584.0 "Powerful Fire/Powerful Light" sync / 1[56]:[^:]*:Erichthonios:(65EC|65ED):/
+70.5 "Gaoler's Flail Left/Gaoler's Flail Right" sync / 1[56]:[^:]*:Erichthonios:(6DA3|6DA2):/
+81.1 "Heavy Hand" sync / 1[56]:[^:]*:Erichthonios:65F3:/
+93.2 "Intemperance" sync / 1[56]:[^:]*:Erichthonios:65EE:/
+97.3 "--middle--" sync / 1[56]:[^:]*:Erichthonios:65F5:/
+105.1 "Intemperate Torment" sync / 1[56]:[^:]*:Erichthonios:65EF:/
+107.7 "Hot Spell/Cold Spell 1" sync / 1[56]:[^:]*:Erichthonios:(65F0|54F1):/
+116.7 "Hot Spell/Cold Spell 2" sync / 1[56]:[^:]*:Erichthonios:(6CC5|6CC6):/
+125.7 "Hot Spell/Cold Spell 3" sync / 1[56]:[^:]*:Erichthonios:(6CC5|6CC6):/
+135.3 "Warder's Wrath" sync / 1[56]:[^:]*:Erichthonios:65F4:/
+147.6 "Heavy Hand" sync / 1[56]:[^:]*:Erichthonios:65F3:/
+162.7 "Shining Cells" sync / 1[56]:[^:]*:Erichthonios:65E9:/
+174.9 "Aetherchain" sync / 1[56]:[^:]*:Erichthonios:65EB:/
+175.8 "Powerful Fire/Powerful Light" sync / 1[56]:[^:]*:Erichthonios:(65EC|65ED):/
+183.1 "Aetherchain" sync / 1[56]:[^:]*:Erichthonios:65EB:/
+184.0 "Powerful Fire/Powerful Light" sync / 1[56]:[^:]*:Erichthonios:(65EC|65ED):/
 
 ## Beginning of Loop
-588.3 "--middle--" sync / 1[56]:[^:]*:Erichthonios:65F5:/
+188.3 "--middle--" sync / 1[56]:[^:]*:Erichthonios:65F5:/
 
-## Fourth Gaoler's Flail
-590.0 "--sync--" sync / 14:[^:]*:Erichthonios:6DA3:/ jump 690
-590.0 "--sync--" sync / 14:[^:]*:Erichthonios:6DA2:/ jump 790
-598.7 "Aetherflail Left/Aetherflail Right?" sync / 1[56]:[^:]*:Erichthonios:(6DA3|6DA2):/
-598.8 "Powerful Fire/Powerful Light" #sync / 1[56]:[^:]*:Erichthonios:(65EC|65ED):/
-609.8 "Aetherflail Right/Aetherflail Left?" #sync / 1[56]:[^:]*:Erichthonios:(6DA2|6DA3):/
-609.9 "Powerful Fire/Powerful Light" #sync / 1[56]:[^:]*:Erichthonios:(65EC|65ED):/
-614.3 "--knockback stack--" #sync / 1[56]:[^:]*:Erichthonios:6D15:/
-619.6 "Pitiless Flail (knockback)" #sync / 1[56]:[^:]*:Erichthonios:65E5:/
-626.7 "True Holy" #sync / 1[56]:[^:]*:Erichthonios:65E7:/
-632.9 "--middle--" #sync / 1[56]:[^:]*:Erichthonios:65F5:/
-643.3 "Aetherflail Left/Aetherflail Right?" #sync / 1[56]:[^:]*:Erichthonios:(6DA3|6DA2):/
-643.4 "Powerful Fire/Powerful Light" #sync / 1[56]:[^:]*:Erichthonios:(65EC|65ED):/
+# Fourth Gaoler's Flail
+198.7 "Aetherflail Left/Aetherflail Right" sync / 1[56]:[^:]*:Erichthonios:(6DA3|6DA2):/
+198.8 "Powerful Fire/Powerful Light" sync / 1[56]:[^:]*:Erichthonios:(65EC|65ED):/
+209.8 "Aetherflail Right/Aetherflail Left" sync / 1[56]:[^:]*:Erichthonios:(6DA2|6DA3):/
+209.9 "Powerful Fire/Powerful Light" sync / 1[56]:[^:]*:Erichthonios:(65EC|65ED):/
+214.3 "--knockback stack--" sync / 1[56]:[^:]*:Erichthonios:6D15:/
+219.6 "Pitiless Flail" sync / 1[56]:[^:]*:Erichthonios:65E5:/
+226.7 "True Holy" sync / 1[56]:[^:]*:Erichthonios:65E7:/
+232.9 "--middle--" sync / 1[56]:[^:]*:Erichthonios:65F5:/
 
-# Left Fourth, Right Fifth
-690.0 "--sync--" sync / 14:[^:]*:Erichthonios:6DA3:/
-698.7 "Aetherflail Left" sync / 1[56]:[^:]*:Erichthonios:6DA3:/
-698.8 "Powerful Fire/Powerful Light" sync / 1[56]:[^:]*:Erichthonios:(65EC|65ED):/
-709.8 "Aetherflail Right" sync / 1[56]:[^:]*:Erichthonios:6DA2:/
-709.9 "Powerful Fire/Powerful Light" sync / 1[56]:[^:]*:Erichthonios:(65EC|65ED):/ jump 809.9
-714.3 "--knockback stack--" #sync / 1[56]:[^:]*:Erichthonios:6D15:/
-719.6 "Pitiless Flail (knockback)" #sync / 1[56]:[^:]*:Erichthonios:65E5:/
-726.7 "True Holy" #sync / 1[56]:[^:]*:Erichthonios:65E7:/
-732.9 "--middle--" #sync / 1[56]:[^:]*:Erichthonios:65F5:/
-734.6 "--sync--" #sync / 14:[^:]*:Erichthonios:(6DA3|6DA2):/
-743.3 "Aetherflail Left/Aetherflail Right?" #sync / 1[56]:[^:]*:Erichthonios:(6DA3|6DA2):/
-743.4 "Powerful Fire/Powerful Light" #sync / 1[56]:[^:]*:Erichthonios:(65EC|65ED):/
-
-# Right Fourth, Left Fifth
-790.0 "--sync--" sync / 14:[^:]*:Erichthonios:6DA2:/
-798.7 "Aetherflail Right" sync / 1[56]:[^:]*:Erichthonios:6DA2:/
-798.8 "Powerful Fire/Powerful Light" sync / 1[56]:[^:]*:Erichthonios:(65EC|65ED):/
-809.8 "Aetherflail Left" sync / 1[56]:[^:]*:Erichthonios:6DA3:/
-809.9 "Powerful Fire/Powerful Light" sync / 1[56]:[^:]*:Erichthonios:(65EC|65ED):/
-814.3 "--knockback stack--" sync / 1[56]:[^:]*:Erichthonios:6D15:/
-819.6 "Pitiless Flail (knockback)" sync / 1[56]:[^:]*:Erichthonios:65E5:/
-826.7 "True Holy" sync / 1[56]:[^:]*:Erichthonios:65E7:/
-832.9 "--middle--" sync / 1[56]:[^:]*:Erichthonios:65F5:/
-
-## Sixth Gaoler's Flail
-834.6 "--sync--" sync / 14:[^:]*:Erichthonios:6DA3:/ jump 934.6
-834.6 "--sync--" sync / 14:[^:]*:Erichthonios:6DA2:/ jump 1234.6
-843.3 "Aetherflail Left/Aetherflail Right?" #sync / 1[56]:[^:]*:Erichthonios:(6DA3|6DA2):/
-843.4 "Powerful Fire/Powerful Light" #sync / 1[56]:[^:]*:Erichthonios:(65EC|65ED):/
-860.8 "Slam Shut" #sync / 1[56]:[^:]*:Erichthonios:65EA:/
-870.0 "Intemperance" #sync / 1[56]:[^:]*:Erichthonios:65EE:/
-874.1 "--middle--" #sync / 1[56]:[^:]*:Erichthonios:65F5:/
-881.7 "Intemperate Torment" #sync / 1[56]:[^:]*:Erichthonios:65EF:/
-884.3 "Hot Spell/Cold Spell 1" #sync / 1[56]:[^:]*:Erichthonios:(65F0|54F1):/
-893.3 "Hot Spell/Cold Spell 2" #sync / 1[56]:[^:]*:Erichthonios:(6CC5|6CC6):/
-902.3 "Hot Spell/Cold Spell 3" #sync / 1[56]:[^:]*:Erichthonios:(6CC5|6CC6):/
-905.6 "Gaoler's Flail Right/Gaoler's Flail Left?" #sync / 1[56]:[^:]*:Erichthonios:(6DA2|6DA3):/
-
-# Left Sixth, Right Seventh
-934.6 "--sync--" sync / 14:[^:]*:Erichthonios:6DA3:/
-943.3 "Aetherflail Left" sync / 1[56]:[^:]*:Erichthonios:6DA3:/
-943.4 "Powerful Fire/Powerful Light" sync / 1[56]:[^:]*:Erichthonios:(65EC|65ED):/
-960.8 "Slam Shut" sync / 1[56]:[^:]*:Erichthonios:65EA:/
-970.0 "Intemperance" sync / 1[56]:[^:]*:Erichthonios:65EE:/
-974.1 "--middle--" sync / 1[56]:[^:]*:Erichthonios:65F5:/
-981.7 "Intemperate Torment" sync / 1[56]:[^:]*:Erichthonios:65EF:/
-984.3 "Hot Spell/Cold Spell 1" sync / 1[56]:[^:]*:Erichthonios:(65F0|54F1):/
-993.3 "Hot Spell/Cold Spell 2" sync / 1[56]:[^:]*:Erichthonios:(6CC5|6CC6):/
-1002.3 "Hot Spell/Cold Spell 3" sync / 1[56]:[^:]*:Erichthonios:(6CC5|6CC6):/
-1005.6 "Gaoler's Flail Right" sync / 1[56]:[^:]*:Erichthonios:6DA2:/
-1116.1 "Warder's Wrath" sync / 1[56]:[^:]*:Erichthonios:65F4:/ jump 1316.2
-1127.3 "Warder's Wrath" #sync / 1[56]:[^:]*:Erichthonios:65F4:/
-1136.6 "Heavy Hand" #sync / 1[56]:[^:]*:Erichthonios:65F3:/
-1155.8 "Shining Cells" #sync / 1[56]:[^:]*:Erichthonios:65E9:/
-1160.0 "--middle--" #sync / 1[56]:[^:]*:Erichthonios:65F5:/
-
-# Right Sixth, Left Seventh
-1234.6 "--sync--" sync / 14:[^:]*:Erichthonios:6DA2:/
-1243.3 "Aetherflail Right" sync / 1[56]:[^:]*:Erichthonios:6DA2:/
-1243.4 "Powerful Fire/Powerful Light" sync / 1[56]:[^:]*:Erichthonios:(65EC|65ED):/
-1260.8 "Slam Shut" sync / 1[56]:[^:]*:Erichthonios:65EA:/
-1270.0 "Intemperance" sync / 1[56]:[^:]*:Erichthonios:65EE:/
-1274.1 "--middle--" sync / 1[56]:[^:]*:Erichthonios:65F5:/
-1281.7 "Intemperate Torment" sync / 1[56]:[^:]*:Erichthonios:65EF:/
-1284.3 "Hot Spell/Cold Spell 1" sync / 1[56]:[^:]*:Erichthonios:(65F0|54F1):/
-1293.3 "Hot Spell/Cold Spell 2" sync / 1[56]:[^:]*:Erichthonios:(6CC5|6CC6):/
-1302.3 "Hot Spell/Cold Spell 3" sync / 1[56]:[^:]*:Erichthonios:(6CC5|6CC6):/
-1305.6 "Gaoler's Flail Left" sync / 1[56]:[^:]*:Erichthonios:6DA3:/
-1316.1 "Warder's Wrath" sync / 1[56]:[^:]*:Erichthonios:65F4:/
-1327.3 "Warder's Wrath" sync / 1[56]:[^:]*:Erichthonios:65F4:/
-1336.6 "Heavy Hand" sync / 1[56]:[^:]*:Erichthonios:65F3:/
-1355.8 "Shining Cells" sync / 1[56]:[^:]*:Erichthonios:65E9:/
+# Sixth Gaoler's Flail
+243.3 "Aetherflail Left/Aetherflail Right" sync / 1[56]:[^:]*:Erichthonios:(6DA3|6DA2):/
+243.4 "Powerful Fire/Powerful Light" sync / 1[56]:[^:]*:Erichthonios:(65EC|65ED):/
+260.8 "Slam Shut" sync / 1[56]:[^:]*:Erichthonios:65EA:/
+270.0 "Intemperance" sync / 1[56]:[^:]*:Erichthonios:65EE:/
+274.1 "--middle--" sync / 1[56]:[^:]*:Erichthonios:65F5:/
+281.7 "Intemperate Torment" sync / 1[56]:[^:]*:Erichthonios:65EF:/
+284.3 "Hot Spell/Cold Spell 1" sync / 1[56]:[^:]*:Erichthonios:(65F0|54F1):/
+293.3 "Hot Spell/Cold Spell 2" sync / 1[56]:[^:]*:Erichthonios:(6CC5|6CC6):/
+302.3 "Hot Spell/Cold Spell 3" sync / 1[56]:[^:]*:Erichthonios:(6CC5|6CC6):/
+305.6 "Gaoler's Flail Right/Gaoler's Flail Left" sync / 1[56]:[^:]*:Erichthonios:(6DA2|6DA3):/
+316.1 "Warder's Wrath" sync / 1[56]:[^:]*:Erichthonios:65F4:/ jump 1316.2
+327.3 "Warder's Wrath" sync / 1[56]:[^:]*:Erichthonios:65F4:/
+336.6 "Heavy Hand" sync / 1[56]:[^:]*:Erichthonios:65F3:/
+355.8 "Shining Cells" sync / 1[56]:[^:]*:Erichthonios:65E9:/
 
 # Repeat
-1360.0 "--middle--" sync / 1[56]:[^:]*:Erichthonios:65F5:/ window 50,50 jump 588.3
-1361.6 "--sync--" #sync / 14:[^:]*:Erichthonios:(6DA3|6DA2):/
-1370.3 "Aetherflail Left/Aetherflail Right?" #sync / 1[56]:[^:]*:Erichthonios:(6DA3|6DA2):/
-1370.4 "Powerful Fire/Powerful Light" #sync / 1[56]:[^:]*:Erichthonios:(65EC|65ED):/
-1381.4 "Aetherflail Right/Aetherflail Left?" #sync / 1[56]:[^:]*:Erichthonios:(6DA2|6DA3):/
-1381.5 "Powerful Fire/Powerful Light" #sync / 1[56]:[^:]*:Erichthonios:(65EC|65ED):/
-1385.9 "--knockback stack--" #sync / 1[56]:[^:]*:Erichthonios:6D15:/
-1391.2 "Pitiless Flail (knockback)" #sync / 1[56]:[^:]*:Erichthonios:65E5:/
-1398.3 "True Holy" #sync / 1[56]:[^:]*:Erichthonios:65E7:/
-1404.5 "--middle--" #sync / 1[56]:[^:]*:Erichthonios:65F5:/
+360.0 "--middle--" sync / 1[56]:[^:]*:Erichthonios:65F5:/ window 50,50 jump 588.3
+370.3 "Aetherflail Left/Aetherflail Right" #sync / 1[56]:[^:]*:Erichthonios:(6DA3|6DA2):/
+370.4 "Powerful Fire/Powerful Light" #sync / 1[56]:[^:]*:Erichthonios:(65EC|65ED):/
+381.4 "Aetherflail Right/Aetherflail Left" #sync / 1[56]:[^:]*:Erichthonios:(6DA2|6DA3):/
+381.5 "Powerful Fire/Powerful Light" #sync / 1[56]:[^:]*:Erichthonios:(65EC|65ED):/
+385.9 "--knockback stack--" #sync / 1[56]:[^:]*:Erichthonios:6D15:/
+391.2 "Pitiless Flail" #sync / 1[56]:[^:]*:Erichthonios:65E5:/
+398.3 "True Holy" #sync / 1[56]:[^:]*:Erichthonios:65E7:/
+404.5 "--middle--" #sync / 1[56]:[^:]*:Erichthonios:65F5:/

--- a/ui/raidboss/data/06-ew/raid/p1n.txt
+++ b/ui/raidboss/data/06-ew/raid/p1n.txt
@@ -105,7 +105,7 @@ hideall "unknown_6d15"
 619.6 "Pitiless Flail (knockback)" #sync / 1[56]:[^:]*:Erichthonios:65E5:/
 626.7 "True Holy" #sync / 1[56]:[^:]*:Erichthonios:65E7:/
 632.9 "--middle--" #sync / 1[56]:[^:]*:Erichthonios:65F5:/
-642.6 "--sync--" #sync / 14:[^:]*:Erichthonios:(65E0|65DF):/
+634.6 "--sync--" #sync / 14:[^:]*:Erichthonios:(65E0|65DF):/
 643.3 "Aetherflail Left/Aetherflail Right?" #sync / 1[56]:[^:]*:Erichthonios:(6DA3|6DA2):/
 643.4 "Powerful Fire/Powerful Light" #sync / 1[56]:[^:]*:Erichthonios:(65EC|65ED):/
 
@@ -120,7 +120,7 @@ hideall "unknown_6d15"
 719.6 "Pitiless Flail (knockback)" #sync / 1[56]:[^:]*:Erichthonios:65E5:/
 726.7 "True Holy" #sync / 1[56]:[^:]*:Erichthonios:65E7:/
 732.9 "--middle--" #sync / 1[56]:[^:]*:Erichthonios:65F5:/
-742.6 "--sync--" #sync / 14:[^:]*:Erichthonios:(65E0|65DF):/
+734.6 "--sync--" #sync / 14:[^:]*:Erichthonios:(65E0|65DF):/
 743.3 "Aetherflail Left/Aetherflail Right?" #sync / 1[56]:[^:]*:Erichthonios:(6DA3|6DA2):/
 743.4 "Powerful Fire/Powerful Light" #sync / 1[56]:[^:]*:Erichthonios:(65EC|65ED):/
 

--- a/ui/raidboss/data/06-ew/raid/p1n.txt
+++ b/ui/raidboss/data/06-ew/raid/p1n.txt
@@ -30,7 +30,7 @@ hideall "unknown_6d15"
 
 # Left First, Right Second
 116.7 "--sync--" sync / 1[56]:[^:]*:Erichthonios:65DA:/
-117.4 "Gaoler's Flail Left" sync / 1[56]:[^:]*:Erichthonios:6DA3:
+117.4 "Gaoler's Flail Left" sync / 1[56]:[^:]*:Erichthonios:6DA3:/
 127.8 "--sync--" sync / 1[56]:[^:]*:Erichthonios:65D9:/
 128.5 "Gaoler's Flail Right" sync / 1[56]:[^:]*:Erichthonios:6DA2:/
 139.0 "Warder's Wrath" sync / 1[56]:[^:]*:Erichthonios:65F4:/ jump 139

--- a/ui/raidboss/data/06-ew/raid/p1n.txt
+++ b/ui/raidboss/data/06-ew/raid/p1n.txt
@@ -22,6 +22,7 @@ hideall "unknown_6d15"
 16.7 "--sync--" sync / 1[56]:[^:]*:Erichthonios:65DA:/ jump 116.7
 16.8 "--sync--" sync / 1[56]:[^:]*:Erichthonios:65D9:/ jump 216.7
 17.4 "Gaoler's Flail Left/Gaoler's Flail Right?" #sync / 1[56]:[^:]*:Erichthonios:(6DA3|6DA2):/
+27.8 "--sync--" #sync / 1[56]:[^:]*:Erichthonios:(65D9|65DA):/
 28.5 "Gaoler's Flail Right/Gaoler's Flail Left?" #sync / 1[56]:[^:]*:Erichthonios:(6DA2|6DA3):/
 39.0 "Warder's Wrath" #sync / 1[56]:[^:]*:Erichthonios:65F4:/
 46.2 "unknown_6d15" #sync / 1[56]:[^:]*:Erichthonios:6D15:/
@@ -94,19 +95,19 @@ hideall "unknown_6d15"
 588.3 "--middle--" sync / 1[56]:[^:]*:Erichthonios:65F5:/
 
 ## Fourth Gaoler's Flail
-598.0 "--sync--" sync / 1[56]:[^:]*:Erichthonios:65DF:/ jump 698.0
-598.1 "--sync--" sync / 1[56]:[^:]*:Erichthonios:65E0:/ jump 798.0
-598.7 "Aetherflail Left/Aetherflail Right?" sync / 1[56]:[^:]*:Erichthonios:(6DA2|6DA3):/
+598.0 "--sync--" sync / 1[56]:[^:]*:Erichthonios:65E0:/ jump 698.0
+598.1 "--sync--" sync / 1[56]:[^:]*:Erichthonios:65DF:/ jump 798.0
+598.7 "Aetherflail Left/Aetherflail Right?" sync / 1[56]:[^:]*:Erichthonios:(6DA3|6DA2):/
 598.8 "Powerful Fire" #sync / 1[56]:[^:]*:Erichthonios:65EC:/
-609.1 "--sync--" #sync / 1[56]:[^:]*:Erichthonios:65E0:/
-609.8 "Aetherflail Right/Aetherflail Left?" #sync / 1[56]:[^:]*:Erichthonios:(6DA3|6DA2):/
+609.1 "--sync--" #sync / 1[56]:[^:]*:Erichthonios:(65DF|65E0):/
+609.8 "Aetherflail Right/Aetherflail Left?" #sync / 1[56]:[^:]*:Erichthonios:(6DA2|6DA3):/
 609.9 "Powerful Fire/Powerful Light" #sync / 1[56]:[^:]*:Erichthonios:(65EC|65ED):/
 614.3 "unknown_6d15" #sync / 1[56]:[^:]*:Erichthonios:6D15:/
 619.6 "Pitiless Flail (knockback)" #sync / 1[56]:[^:]*:Erichthonios:65E5:/
 626.7 "True Holy" #sync / 1[56]:[^:]*:Erichthonios:65E7:/
 632.9 "--middle--" #sync / 1[56]:[^:]*:Erichthonios:65F5:/
-642.6 "--sync--" #sync / 1[56]:[^:]*:Erichthonios:65E0:/
-643.3 "Aetherflail Left/Aetherflail Right?" #sync / 1[56]:[^:]*:Erichthonios:6DA3:/
+642.6 "--sync--" #sync / 1[56]:[^:]*:Erichthonios:(65E0|65DF):/
+643.3 "Aetherflail Left/Aetherflail Right?" #sync / 1[56]:[^:]*:Erichthonios:(6DA3|6DA2):/
 643.4 "Powerful Fire/Powerful Light" #sync / 1[56]:[^:]*:Erichthonios:(65EC|65ED):/
 
 # Left Fourth, Right Fifth
@@ -120,8 +121,8 @@ hideall "unknown_6d15"
 719.6 "Pitiless Flail (knockback)" #sync / 1[56]:[^:]*:Erichthonios:65E5:/
 726.7 "True Holy" #sync / 1[56]:[^:]*:Erichthonios:65E7:/
 732.9 "--middle--" #sync / 1[56]:[^:]*:Erichthonios:65F5:/
-742.6 "--sync--" #sync / 1[56]:[^:]*:Erichthonios:65E0:/
-743.3 "Aetherflail Left/Aetherflail Right?" #sync / 1[56]:[^:]*:Erichthonios:6DA3:/
+742.6 "--sync--" #sync / 1[56]:[^:]*:Erichthonios:(65E0|65DF):/
+743.3 "Aetherflail Left/Aetherflail Right?" #sync / 1[56]:[^:]*:Erichthonios:(6DA3|6DA2):/
 743.4 "Powerful Fire/Powerful Light" #sync / 1[56]:[^:]*:Erichthonios:(65EC|65ED):/
 
 # Right Fourth, Left Fifth
@@ -137,9 +138,9 @@ hideall "unknown_6d15"
 832.9 "--middle--" sync / 1[56]:[^:]*:Erichthonios:65F5:/
 
 ## Sixth Gaoler's Flail
-842.6 "--sync--" sync / 1[56]:[^:]*:Erichthonios:65DF:/ jump 942.6
-842.7 "--sync--" sync / 1[56]:[^:]*:Erichthonios:65E0:/ jump 1242.6
-843.3 "Aetherflail Left/Aetherflail Right?" #sync / 1[56]:[^:]*:Erichthonios:(6DA2|6DA3):/
+842.6 "--sync--" sync / 1[56]:[^:]*:Erichthonios:65E0:/ jump 942.6
+842.7 "--sync--" sync / 1[56]:[^:]*:Erichthonios:65DF:/ jump 1242.6
+843.3 "Aetherflail Left/Aetherflail Right?" #sync / 1[56]:[^:]*:Erichthonios:(6DA3|6DA2):/
 843.4 "Powerful Fire/Powerful Light" #sync / 1[56]:[^:]*:Erichthonios:(65EC|65ED):/
 860.8 "Slam Shut" #sync / 1[56]:[^:]*:Erichthonios:65EA:/
 870.0 "Intemperance" #sync / 1[56]:[^:]*:Erichthonios:65EE:/
@@ -148,7 +149,7 @@ hideall "unknown_6d15"
 884.3 "Hot Spell/Cold Spell 1" #sync / 1[56]:[^:]*:Erichthonios:(65F0|54F1):/
 893.3 "Hot Spell/Cold Spell 2" #sync / 1[56]:[^:]*:Erichthonios:(6CC5|6CC6):/
 902.3 "Hot Spell/Cold Spell 3" #sync / 1[56]:[^:]*:Erichthonios:(6CC5|6CC6):/
-904.9 "--sync--" #sync / 1[56]:[^:]*:Erichthonios:65D9:/
+904.9 "--sync--" #sync / 1[56]:[^:]*:Erichthonios:(65DA|65D9):/
 905.6 "Gaoler's Flail Right/Gaoler's Flail Left?" #sync / 1[56]:[^:]*:Erichthonios:(6DA2|6DA3):/
 
 # Left Sixth, Right Seventh
@@ -190,11 +191,11 @@ hideall "unknown_6d15"
 
 # Repeat
 1360.0 "--middle--" sync / 1[56]:[^:]*:Erichthonios:65F5:/ jump 588.3
-1369.6 "--sync--" #sync / 1[56]:[^:]*:Erichthonios:65E0:/
-1370.3 "Aetherflail Left/Aetherflail Right?" #sync / 1[56]:[^:]*:Erichthonios:(6DA2|6DA3):/
+1369.6 "--sync--" #sync / 1[56]:[^:]*:Erichthonios:(65E0|65DF):/
+1370.3 "Aetherflail Left/Aetherflail Right?" #sync / 1[56]:[^:]*:Erichthonios:(6DA3|6DA2):/
 1370.4 "Powerful Fire/Powerful Light" #sync / 1[56]:[^:]*:Erichthonios:(65EC|65ED):/
-1380.7 "--sync--" #sync / 1[56]:[^:]*:Erichthonios:65DF:/
-1381.4 "Aetherflail Right/Aetherflail Left?" #sync / 1[56]:[^:]*:Erichthonios:(6DA3|6DA2):/
+1380.7 "--sync--" #sync / 1[56]:[^:]*:Erichthonios:(65DF|65E0):/
+1381.4 "Aetherflail Right/Aetherflail Left?" #sync / 1[56]:[^:]*:Erichthonios:(6DA2|6DA3):/
 1381.5 "Powerful Fire/Powerful Light" #sync / 1[56]:[^:]*:Erichthonios:(65EC|65ED):/
 1385.9 "unknown_6d15" #sync / 1[56]:[^:]*:Erichthonios:6D15:/
 1391.2 "Pitiless Flail (knockback)" #sync / 1[56]:[^:]*:Erichthonios:65E5:/

--- a/ui/raidboss/data/06-ew/raid/p1n.txt
+++ b/ui/raidboss/data/06-ew/raid/p1n.txt
@@ -63,13 +63,13 @@ hideall "--sync--"
 293.3 "Hot Spell/Cold Spell 2" sync / 1[56]:[^:]*:Erichthonios:(6CC5|6CC6):/
 302.3 "Hot Spell/Cold Spell 3" sync / 1[56]:[^:]*:Erichthonios:(6CC5|6CC6):/
 305.6 "Gaoler's Flail Right/Gaoler's Flail Left" sync / 1[56]:[^:]*:Erichthonios:(6DA2|6DA3):/
-316.1 "Warder's Wrath" sync / 1[56]:[^:]*:Erichthonios:65F4:/ jump 1316.2
+316.1 "Warder's Wrath" sync / 1[56]:[^:]*:Erichthonios:65F4:/
 327.3 "Warder's Wrath" sync / 1[56]:[^:]*:Erichthonios:65F4:/
 336.6 "Heavy Hand" sync / 1[56]:[^:]*:Erichthonios:65F3:/
 355.8 "Shining Cells" sync / 1[56]:[^:]*:Erichthonios:65E9:/
 
 # Repeat
-360.0 "--middle--" sync / 1[56]:[^:]*:Erichthonios:65F5:/ window 50,50 jump 588.3
+360.0 "--middle--" sync / 1[56]:[^:]*:Erichthonios:65F5:/ window 50,50 jump 188.3
 370.3 "Aetherflail Left/Aetherflail Right" #sync / 1[56]:[^:]*:Erichthonios:(6DA3|6DA2):/
 370.4 "Powerful Fire/Powerful Light" #sync / 1[56]:[^:]*:Erichthonios:(65EC|65ED):/
 381.4 "Aetherflail Right/Aetherflail Left" #sync / 1[56]:[^:]*:Erichthonios:(6DA2|6DA3):/

--- a/ui/raidboss/data/06-ew/raid/p1n.txt
+++ b/ui/raidboss/data/06-ew/raid/p1n.txt
@@ -16,13 +16,12 @@ hideall "unknown_6d15"
 0.0 "--Reset--" sync / 21:........:40000010:/ window 100000 jump 0
 
 0.0 "--sync--" sync /Engage!/ window 0,1
-8.8 "--sync--" sync / 14:[^:]*:Erichthonios:(65DA|65D9):/ window 10,10
 
 ## First Gaoler's Flail
-16.7 "--sync--" sync / 1[56]:[^:]*:Erichthonios:65DA:/ jump 116.7
-16.8 "--sync--" sync / 1[56]:[^:]*:Erichthonios:65D9:/ jump 216.7
+8.7 "--sync--" sync / 14:[^:]*:Erichthonios:65DA:/ jump 108.7 window 10,10
+8.8 "--sync--" sync / 14:[^:]*:Erichthonios:65D9:/ jump 208.7 window 10,10
 17.4 "Gaoler's Flail Left/Gaoler's Flail Right?" #sync / 1[56]:[^:]*:Erichthonios:(6DA3|6DA2):/
-27.8 "--sync--" #sync / 1[56]:[^:]*:Erichthonios:(65D9|65DA):/
+19.8 "--sync--" #sync / 14:[^:]*:Erichthonios:(65D9|65DA):/
 28.5 "Gaoler's Flail Right/Gaoler's Flail Left?" #sync / 1[56]:[^:]*:Erichthonios:(6DA2|6DA3):/
 39.0 "Warder's Wrath" #sync / 1[56]:[^:]*:Erichthonios:65F4:/
 46.2 "unknown_6d15" #sync / 1[56]:[^:]*:Erichthonios:6D15:/
@@ -30,9 +29,9 @@ hideall "unknown_6d15"
 58.6 "True Holy" #sync / 1[56]:[^:]*:Erichthonios:65E7:/
 
 # Left First, Right Second
-116.7 "--sync--" sync / 1[56]:[^:]*:Erichthonios:65DA:/
+108.7 "--sync--" sync / 14:[^:]*:Erichthonios:65DA:/
 117.4 "Gaoler's Flail Left" sync / 1[56]:[^:]*:Erichthonios:6DA3:/
-127.8 "--sync--" sync / 1[56]:[^:]*:Erichthonios:65D9:/
+119.8 "--sync--" sync / 14:[^:]*:Erichthonios:65D9:/
 128.5 "Gaoler's Flail Right" sync / 1[56]:[^:]*:Erichthonios:6DA2:/
 139.0 "Warder's Wrath" sync / 1[56]:[^:]*:Erichthonios:65F4:/ jump 139
 146.2 "unknown_6d15" #sync / 1[56]:[^:]*:Erichthonios:6D15:/
@@ -42,9 +41,9 @@ hideall "unknown_6d15"
 181.1 "Heavy Hand" #sync / 1[56]:[^:]*:Erichthonios:65F3:/
 
 # Right First, Left Second
-216.7 "--sync--" sync / 1[56]:[^:]*:Erichthonios:65D9:/
+208.7 "--sync--" sync / 14:[^:]*:Erichthonios:65D9:/
 217.4 "Gaoler's Flail Right" sync / 1[56]:[^:]*:Erichthonios:6DA2:/
-227.8 "--sync--" sync / 1[56]:[^:]*:Erichthonios:65DA:/
+219.8 "--sync--" sync / 14:[^:]*:Erichthonios:65DA:/
 228.5 "Gaoler's Flail Left" sync / 1[56]:[^:]*:Erichthonios:6DA3:/
 239.0 "Warder's Wrath" sync / 1[56]:[^:]*:Erichthonios:65F4:/
 246.2 "unknown_6d15" sync / 1[56]:[^:]*:Erichthonios:6D15:/
@@ -52,8 +51,8 @@ hideall "unknown_6d15"
 258.6 "True Holy" sync / 1[56]:[^:]*:Erichthonios:65E7:/
 
 ## Third Gaoler's Flail
-269.8 "--sync--" sync / 1[56]:[^:]*:Erichthonios:65DA:/ jump 369.8
-269.9 "--sync--" sync / 1[56]:[^:]*:Erichthonios:65D9:/ jump 469.8
+261.8 "--sync--" sync / 14:[^:]*:Erichthonios:65DA:/ jump 361.8
+261.9 "--sync--" sync / 14:[^:]*:Erichthonios:65D9:/ jump 461.8
 270.5 "Gaoler's Flail Left/Gaoler's Flail Right?" #sync / 1[56]:[^:]*:Erichthonios:(6DA3|6DA2):/
 281.1 "Heavy Hand" #sync / 1[56]:[^:]*:Erichthonios:65F3:/
 293.2 "Intemperance" #sync / 1[56]:[^:]*:Erichthonios:65EE:/
@@ -63,7 +62,7 @@ hideall "unknown_6d15"
 316.7 "Hot Spell/Cold Spell 2" #sync / 1[56]:[^:]*:Erichthonios:(6CC5|6CC6):/
 
 # Left Third
-369.8 "--sync--" sync / 1[56]:[^:]*:Erichthonios:65DA:/
+361.8 "--sync--" sync / 14:[^:]*:Erichthonios:65DA:/
 370.5 "Gaoler's Flail Left" sync / 1[56]:[^:]*:Erichthonios:6DA3:/
 381.1 "Heavy Hand" sync / 1[56]:[^:]*:Erichthonios:65F3:/ jump 481.1
 393.2 "Intemperance" #sync / 1[56]:[^:]*:Erichthonios:65EE:/
@@ -74,7 +73,7 @@ hideall "unknown_6d15"
 425.7 "Hot Spell/Cold Spell 3" #sync / 1[56]:[^:]*:Erichthonios:(6CC5|6CC6):/
 
 # Right Third
-469.8 "--sync--" sync / 1[56]:[^:]*:Erichthonios:65D9:/
+461.8 "--sync--" sync / 14:[^:]*:Erichthonios:65D9:/
 470.5 "Gaoler's Flail Right" sync / 1[56]:[^:]*:Erichthonios:6DA2:/
 481.1 "Heavy Hand" sync / 1[56]:[^:]*:Erichthonios:65F3:/
 493.2 "Intemperance" sync / 1[56]:[^:]*:Erichthonios:65EE:/
@@ -95,41 +94,41 @@ hideall "unknown_6d15"
 588.3 "--middle--" sync / 1[56]:[^:]*:Erichthonios:65F5:/
 
 ## Fourth Gaoler's Flail
-598.0 "--sync--" sync / 1[56]:[^:]*:Erichthonios:65E0:/ jump 698.0
-598.1 "--sync--" sync / 1[56]:[^:]*:Erichthonios:65DF:/ jump 798.0
+590.0 "--sync--" sync / 14:[^:]*:Erichthonios:65E0:/ jump 690.0
+590.1 "--sync--" sync / 14:[^:]*:Erichthonios:65DF:/ jump 790.0
 598.7 "Aetherflail Left/Aetherflail Right?" sync / 1[56]:[^:]*:Erichthonios:(6DA3|6DA2):/
-598.8 "Powerful Fire" #sync / 1[56]:[^:]*:Erichthonios:65EC:/
-609.1 "--sync--" #sync / 1[56]:[^:]*:Erichthonios:(65DF|65E0):/
+598.8 "Powerful Fire/Powerful Light" #sync / 1[56]:[^:]*:Erichthonios:(65EC|65ED):/
+601.1 "--sync--" #sync / 14:[^:]*:Erichthonios:(65DF|65E0):/
 609.8 "Aetherflail Right/Aetherflail Left?" #sync / 1[56]:[^:]*:Erichthonios:(6DA2|6DA3):/
 609.9 "Powerful Fire/Powerful Light" #sync / 1[56]:[^:]*:Erichthonios:(65EC|65ED):/
 614.3 "unknown_6d15" #sync / 1[56]:[^:]*:Erichthonios:6D15:/
 619.6 "Pitiless Flail (knockback)" #sync / 1[56]:[^:]*:Erichthonios:65E5:/
 626.7 "True Holy" #sync / 1[56]:[^:]*:Erichthonios:65E7:/
 632.9 "--middle--" #sync / 1[56]:[^:]*:Erichthonios:65F5:/
-642.6 "--sync--" #sync / 1[56]:[^:]*:Erichthonios:(65E0|65DF):/
+642.6 "--sync--" #sync / 14:[^:]*:Erichthonios:(65E0|65DF):/
 643.3 "Aetherflail Left/Aetherflail Right?" #sync / 1[56]:[^:]*:Erichthonios:(6DA3|6DA2):/
 643.4 "Powerful Fire/Powerful Light" #sync / 1[56]:[^:]*:Erichthonios:(65EC|65ED):/
 
 # Left Fourth, Right Fifth
-698.0 "--sync--" sync / 1[56]:[^:]*:Erichthonios:65E0:/
+690.0 "--sync--" sync / 14:[^:]*:Erichthonios:65E0:/
 698.7 "Aetherflail Left" sync / 1[56]:[^:]*:Erichthonios:6DA3:/
-698.8 "Powerful Fire" sync / 1[56]:[^:]*:Erichthonios:65EC:/
-709.1 "--sync--" sync / 1[56]:[^:]*:Erichthonios:65DF:/
+698.8 "Powerful Fire/Powerful Light" sync / 1[56]:[^:]*:Erichthonios:(65EC|65ED):/
+701.1 "--sync--" sync / 14:[^:]*:Erichthonios:65DF:/
 709.8 "Aetherflail Right" sync / 1[56]:[^:]*:Erichthonios:6DA2:/
 709.9 "Powerful Fire/Powerful Light" sync / 1[56]:[^:]*:Erichthonios:(65EC|65ED):/ jump 809.9
 714.3 "unknown_6d15" #sync / 1[56]:[^:]*:Erichthonios:6D15:/
 719.6 "Pitiless Flail (knockback)" #sync / 1[56]:[^:]*:Erichthonios:65E5:/
 726.7 "True Holy" #sync / 1[56]:[^:]*:Erichthonios:65E7:/
 732.9 "--middle--" #sync / 1[56]:[^:]*:Erichthonios:65F5:/
-742.6 "--sync--" #sync / 1[56]:[^:]*:Erichthonios:(65E0|65DF):/
+742.6 "--sync--" #sync / 14:[^:]*:Erichthonios:(65E0|65DF):/
 743.3 "Aetherflail Left/Aetherflail Right?" #sync / 1[56]:[^:]*:Erichthonios:(6DA3|6DA2):/
 743.4 "Powerful Fire/Powerful Light" #sync / 1[56]:[^:]*:Erichthonios:(65EC|65ED):/
 
 # Right Fourth, Left Fifth
-798.0 "--sync--" sync / 1[56]:[^:]*:Erichthonios:65DF:/
+790.0 "--sync--" sync / 14:[^:]*:Erichthonios:65DF:/
 798.7 "Aetherflail Right" sync / 1[56]:[^:]*:Erichthonios:6DA2:/
-798.8 "Powerful Fire" sync / 1[56]:[^:]*:Erichthonios:65EC:/
-809.1 "--sync--" sync / 1[56]:[^:]*:Erichthonios:65E0:/
+798.8 "Powerful Fire/Powerful Light" sync / 1[56]:[^:]*:Erichthonios:(65EC|65ED):/
+801.1 "--sync--" sync / 14:[^:]*:Erichthonios:65E0:/
 809.8 "Aetherflail Left" sync / 1[56]:[^:]*:Erichthonios:6DA3:/
 809.9 "Powerful Fire/Powerful Light" sync / 1[56]:[^:]*:Erichthonios:(65EC|65ED):/
 814.3 "unknown_6d15" sync / 1[56]:[^:]*:Erichthonios:6D15:/
@@ -138,8 +137,8 @@ hideall "unknown_6d15"
 832.9 "--middle--" sync / 1[56]:[^:]*:Erichthonios:65F5:/
 
 ## Sixth Gaoler's Flail
-842.6 "--sync--" sync / 1[56]:[^:]*:Erichthonios:65E0:/ jump 942.6
-842.7 "--sync--" sync / 1[56]:[^:]*:Erichthonios:65DF:/ jump 1242.6
+834.6 "--sync--" sync / 14:[^:]*:Erichthonios:65E0:/ jump 934.6
+834.7 "--sync--" sync / 14:[^:]*:Erichthonios:65DF:/ jump 1234.6
 843.3 "Aetherflail Left/Aetherflail Right?" #sync / 1[56]:[^:]*:Erichthonios:(6DA3|6DA2):/
 843.4 "Powerful Fire/Powerful Light" #sync / 1[56]:[^:]*:Erichthonios:(65EC|65ED):/
 860.8 "Slam Shut" #sync / 1[56]:[^:]*:Erichthonios:65EA:/
@@ -148,12 +147,12 @@ hideall "unknown_6d15"
 881.7 "Intemperate Torment" #sync / 1[56]:[^:]*:Erichthonios:65EF:/
 884.3 "Hot Spell/Cold Spell 1" #sync / 1[56]:[^:]*:Erichthonios:(65F0|54F1):/
 893.3 "Hot Spell/Cold Spell 2" #sync / 1[56]:[^:]*:Erichthonios:(6CC5|6CC6):/
+896.9 "--sync--" #sync / 14:[^:]*:Erichthonios:(65DA|65D9):/
 902.3 "Hot Spell/Cold Spell 3" #sync / 1[56]:[^:]*:Erichthonios:(6CC5|6CC6):/
-904.9 "--sync--" #sync / 1[56]:[^:]*:Erichthonios:(65DA|65D9):/
 905.6 "Gaoler's Flail Right/Gaoler's Flail Left?" #sync / 1[56]:[^:]*:Erichthonios:(6DA2|6DA3):/
 
 # Left Sixth, Right Seventh
-942.6 "--sync--" sync / 1[56]:[^:]*:Erichthonios:65E0:/
+934.6 "--sync--" sync / 14:[^:]*:Erichthonios:65E0:/
 943.3 "Aetherflail Left" sync / 1[56]:[^:]*:Erichthonios:6DA3:/
 943.4 "Powerful Fire/Powerful Light" sync / 1[56]:[^:]*:Erichthonios:(65EC|65ED):/
 960.8 "Slam Shut" sync / 1[56]:[^:]*:Erichthonios:65EA:/
@@ -162,8 +161,8 @@ hideall "unknown_6d15"
 981.7 "Intemperate Torment" sync / 1[56]:[^:]*:Erichthonios:65EF:/
 984.3 "Hot Spell/Cold Spell 1" sync / 1[56]:[^:]*:Erichthonios:(65F0|54F1):/
 993.3 "Hot Spell/Cold Spell 2" sync / 1[56]:[^:]*:Erichthonios:(6CC5|6CC6):/
+996.9 "--sync--" sync / 14:[^:]*:Erichthonios:65D9:/
 1002.3 "Hot Spell/Cold Spell 3" sync / 1[56]:[^:]*:Erichthonios:(6CC5|6CC6):/
-1004.9 "--sync--" sync / 1[56]:[^:]*:Erichthonios:65D9:/
 1005.6 "Gaoler's Flail Right" sync / 1[56]:[^:]*:Erichthonios:6DA2:/
 1116.1 "Warder's Wrath" sync / 1[56]:[^:]*:Erichthonios:65F4:/ jump 1316.2
 1127.3 "Warder's Wrath" #sync / 1[56]:[^:]*:Erichthonios:65F4:/
@@ -172,7 +171,7 @@ hideall "unknown_6d15"
 1160.0 "--middle--" #sync / 1[56]:[^:]*:Erichthonios:65F5:/
 
 # Right Sixth, Left Seventh
-1242.6 "--sync--" sync / 1[56]:[^:]*:Erichthonios:65DF:/
+1234.6 "--sync--" sync / 14:[^:]*:Erichthonios:65DF:/
 1243.3 "Autherflail Right" sync / 1[56]:[^:]*:Erichthonios:6DA2:/
 1243.4 "Powerful Fire/Powerful Light" sync / 1[56]:[^:]*:Erichthonios:(65EC|65ED):/
 1260.8 "Slam Shut" sync / 1[56]:[^:]*:Erichthonios:65EA:/
@@ -181,8 +180,8 @@ hideall "unknown_6d15"
 1281.7 "Intemperate Torment" sync / 1[56]:[^:]*:Erichthonios:65EF:/
 1284.3 "Hot Spell/Cold Spell 1" sync / 1[56]:[^:]*:Erichthonios:(65F0|54F1):/
 1293.3 "Hot Spell/Cold Spell 2" sync / 1[56]:[^:]*:Erichthonios:(6CC5|6CC6):/
+1296.9 "--sync--" sync / 14:[^:]*:Erichthonios:65DA:/
 1302.3 "Hot Spell/Cold Spell 3" sync / 1[56]:[^:]*:Erichthonios:(6CC5|6CC6):/
-1304.9 "--sync--" sync / 1[56]:[^:]*:Erichthonios:65DA:/
 1305.6 "Gaoler's Flail Left" sync / 1[56]:[^:]*:Erichthonios:6DA3:/
 1316.1 "Warder's Wrath" sync / 1[56]:[^:]*:Erichthonios:65F4:/
 1327.3 "Warder's Wrath" sync / 1[56]:[^:]*:Erichthonios:65F4:/
@@ -191,10 +190,10 @@ hideall "unknown_6d15"
 
 # Repeat
 1360.0 "--middle--" sync / 1[56]:[^:]*:Erichthonios:65F5:/ jump 588.3
-1369.6 "--sync--" #sync / 1[56]:[^:]*:Erichthonios:(65E0|65DF):/
+1361.6 "--sync--" #sync / 14:[^:]*:Erichthonios:(65E0|65DF):/
 1370.3 "Aetherflail Left/Aetherflail Right?" #sync / 1[56]:[^:]*:Erichthonios:(6DA3|6DA2):/
 1370.4 "Powerful Fire/Powerful Light" #sync / 1[56]:[^:]*:Erichthonios:(65EC|65ED):/
-1380.7 "--sync--" #sync / 1[56]:[^:]*:Erichthonios:(65DF|65E0):/
+1372.7 "--sync--" #sync / 14:[^:]*:Erichthonios:(65DF|65E0):/
 1381.4 "Aetherflail Right/Aetherflail Left?" #sync / 1[56]:[^:]*:Erichthonios:(6DA2|6DA3):/
 1381.5 "Powerful Fire/Powerful Light" #sync / 1[56]:[^:]*:Erichthonios:(65EC|65ED):/
 1385.9 "unknown_6d15" #sync / 1[56]:[^:]*:Erichthonios:6D15:/

--- a/ui/raidboss/data/06-ew/raid/p1n.txt
+++ b/ui/raidboss/data/06-ew/raid/p1n.txt
@@ -18,8 +18,8 @@ hideall "unknown_6d15"
 0.0 "--sync--" sync /Engage!/ window 0,1
 
 ## First Gaoler's Flail
-8.7 "--sync--" sync / 14:[^:]*:Erichthonios:6DA3:/ jump 108.7 window 10,10
-8.7 "--sync--" sync / 14:[^:]*:Erichthonios:6DA2:/ jump 208.7 window 10,10
+8.7 "--sync--" sync / 14:[^:]*:Erichthonios:6DA3:/ window 10,9 jump 108.7
+8.7 "--sync--" sync / 14:[^:]*:Erichthonios:6DA2:/ window 10,9 jump 208.7
 17.4 "Gaoler's Flail Left/Gaoler's Flail Right?" #sync / 1[56]:[^:]*:Erichthonios:(6DA3|6DA2):/
 28.5 "Gaoler's Flail Right/Gaoler's Flail Left?" #sync / 1[56]:[^:]*:Erichthonios:(6DA2|6DA3):/
 39.0 "Warder's Wrath" #sync / 1[56]:[^:]*:Erichthonios:65F4:/
@@ -179,7 +179,7 @@ hideall "unknown_6d15"
 1355.8 "Shining Cells" sync / 1[56]:[^:]*:Erichthonios:65E9:/
 
 # Repeat
-1360.0 "--middle--" sync / 1[56]:[^:]*:Erichthonios:65F5:/ jump 588.3
+1360.0 "--middle--" sync / 1[56]:[^:]*:Erichthonios:65F5:/ window 50,50 jump 588.3
 1361.6 "--sync--" #sync / 14:[^:]*:Erichthonios:(6DA3|6DA2):/
 1370.3 "Aetherflail Left/Aetherflail Right?" #sync / 1[56]:[^:]*:Erichthonios:(6DA3|6DA2):/
 1370.4 "Powerful Fire/Powerful Light" #sync / 1[56]:[^:]*:Erichthonios:(65EC|65ED):/

--- a/ui/raidboss/data/06-ew/raid/p1n.txt
+++ b/ui/raidboss/data/06-ew/raid/p1n.txt
@@ -1,0 +1,202 @@
+### P1N: Asphodelos: The First Circle
+#
+# -ii 65F2 65E6
+
+# Note: Gaoler's Flail cast is reworded to Aetherflail (65E0|65DF) in the
+# timeline as that is the cast that is visible. However, damage is from the
+# Gaoler's Flail (65DA3|65DA2) cast end after.
+
+# Note: unknown_6d15 happens same time as marker for the stack
+# to avoid knockback mechanic.
+
+hideall "--Reset--"
+hideall "--sync--"
+hideall "unknown_6d15"
+
+0.0 "--Reset--" sync / 21:........:40000010:/ window 100000 jump 0
+
+0.0 "--sync--" sync /Engage!/ window 0,1
+8.8 "--sync--" sync / 14:[^:]*:Erichthonios:(65DA|65D9):/ window 10,10
+
+## First Gaoler's Flail
+16.7 "--sync--" sync / 1[56]:[^:]*:Erichthonios:65DA:/ jump 116.7
+16.8 "--sync--" sync / 1[56]:[^:]*:Erichthonios:65D9:/ jump 216.7
+17.4 "Gaoler's Flail Left/Gaoler's Flail Right?" #sync / 1[56]:[^:]*:Erichthonios:(6DA3|6DA2):/
+28.5 "Gaoler's Flail Right/Gaoler's Flail Left?" #sync / 1[56]:[^:]*:Erichthonios:(6DA2|6DA3):/
+39.0 "Warder's Wrath" #sync / 1[56]:[^:]*:Erichthonios:65F4:/
+46.2 "unknown_6d15" #sync / 1[56]:[^:]*:Erichthonios:6D15:/
+51.5 "Pitiless Flail (knockback)" #sync / 1[56]:[^:]*:Erichthonios:65E5:/
+58.6 "True Holy" #sync / 1[56]:[^:]*:Erichthonios:65E7:/
+
+# Left First, Right Second
+116.7 "--sync--" sync / 1[56]:[^:]*:Erichthonios:65DA:/
+117.4 "Gaoler's Flail Left" sync / 1[56]:[^:]*:Erichthonios:6DA3:
+127.8 "--sync--" sync / 1[56]:[^:]*:Erichthonios:65D9:/
+128.5 "Gaoler's Flail Right" sync / 1[56]:[^:]*:Erichthonios:6DA2:/
+139.0 "Warder's Wrath" sync / 1[56]:[^:]*:Erichthonios:65F4:/ jump 139
+146.2 "unknown_6d15" #sync / 1[56]:[^:]*:Erichthonios:6D15:/
+151.5 "Pitiless Flail (knockback)" #sync / 1[56]:[^:]*:Erichthonios:65E5:/
+158.6 "True Holy" #sync / 1[56]:[^:]*:Erichthonios:65E7:/
+170.5 "Gaoler's Flail Left/Gaoler's Flail Right?" #sync / 1[56]:[^:]*:Erichthonios:(6DA3|6DA2):/
+181.1 "Heavy Hand" #sync / 1[56]:[^:]*:Erichthonios:65F3:/
+
+# Right First, Left Second
+216.7 "--sync--" sync / 1[56]:[^:]*:Erichthonios:65D9:/
+217.4 "Gaoler's Flail Right" sync / 1[56]:[^:]*:Erichthonios:6DA2:/
+227.8 "--sync--" sync / 1[56]:[^:]*:Erichthonios:65DA:/
+228.5 "Gaoler's Flail Left" sync / 1[56]:[^:]*:Erichthonios:6DA3:/
+239.0 "Warder's Wrath" sync / 1[56]:[^:]*:Erichthonios:65F4:/
+246.2 "unknown_6d15" sync / 1[56]:[^:]*:Erichthonios:6D15:/
+251.5 "Pitiless Flail (knockback)" sync / 1[56]:[^:]*:Erichthonios:65E5:/
+258.6 "True Holy" sync / 1[56]:[^:]*:Erichthonios:65E7:/
+
+## Third Gaoler's Flail
+269.8 "--sync--" sync / 1[56]:[^:]*:Erichthonios:65DA:/ jump 369.8
+269.9 "--sync--" sync / 1[56]:[^:]*:Erichthonios:65D9:/ jump 469.8
+270.5 "Gaoler's Flail Left/Gaoler's Flail Right?" #sync / 1[56]:[^:]*:Erichthonios:(6DA3|6DA2):/
+281.1 "Heavy Hand" #sync / 1[56]:[^:]*:Erichthonios:65F3:/
+293.2 "Intemperance" #sync / 1[56]:[^:]*:Erichthonios:65EE:/
+297.3 "--middle--" #sync / 1[56]:[^:]*:Erichthonios:65F5:/
+305.1 "Intemperate Torment" #sync / 1[56]:[^:]*:Erichthonios:65EF:/
+307.7 "Hot Spell/Cold Spell 1" #sync / 1[56]:[^:]*:Erichthonios:(65F0|54F1):/
+316.7 "Hot Spell/Cold Spell 2" #sync / 1[56]:[^:]*:Erichthonios:(6CC5|6CC6):/
+
+# Left Third
+369.8 "--sync--" sync / 1[56]:[^:]*:Erichthonios:65DA:/
+370.5 "Gaoler's Flail Left" sync / 1[56]:[^:]*:Erichthonios:6DA3:/
+381.1 "Heavy Hand" sync / 1[56]:[^:]*:Erichthonios:65F3:/ jump 481.1
+393.2 "Intemperance" #sync / 1[56]:[^:]*:Erichthonios:65EE:/
+397.3 "--middle--" #sync / 1[56]:[^:]*:Erichthonios:65F5:/
+405.1 "Intemperate Torment" #sync / 1[56]:[^:]*:Erichthonios:65EF:/
+407.7 "Hot Spell/Cold Spell 1" #sync / 1[56]:[^:]*:Erichthonios:(65F0|54F1):/
+416.7 "Hot Spell/Cold Spell 2" #sync / 1[56]:[^:]*:Erichthonios:(6CC5|6CC6):/
+525.7 "Hot Spell/Cold Spell 3" #sync / 1[56]:[^:]*:Erichthonios:(6CC5|6CC6):/
+
+# Right Third
+469.8 "--sync--" sync / 1[56]:[^:]*:Erichthonios:65D9:/
+470.5 "Gaoler's Flail Right" sync / 1[56]:[^:]*:Erichthonios:6DA2:/
+481.1 "Heavy Hand" sync / 1[56]:[^:]*:Erichthonios:65F3:/
+493.2 "Intemperance" sync / 1[56]:[^:]*:Erichthonios:65EE:/
+497.3 "--middle--" sync / 1[56]:[^:]*:Erichthonios:65F5:/
+505.1 "Intemperate Torment" sync / 1[56]:[^:]*:Erichthonios:65EF:/
+507.7 "Hot Spell/Cold Spell 1" sync / 1[56]:[^:]*:Erichthonios:(65F0|54F1):/
+516.7 "Hot Spell/Cold Spell 2" sync / 1[56]:[^:]*:Erichthonios:(6CC5|6CC6):/
+525.7 "Hot Spell/Cold Spell 3" sync / 1[56]:[^:]*:Erichthonios:(6CC5|6CC6):/
+535.3 "Warder's Wrath" sync / 1[56]:[^:]*:Erichthonios:65F4:/
+547.6 "Heavy Hand" sync / 1[56]:[^:]*:Erichthonios:65F3:/
+562.7 "Shining Cells" sync / 1[56]:[^:]*:Erichthonios:65E9:/
+574.9 "Aetherchain" sync / 1[56]:[^:]*:Erichthonios:65EB:/
+575.8 "Powerful Fire/Powerful Light" sync / 1[56]:[^:]*:Erichthonios:(65EC|65ED):/
+583.1 "Aetherchain" sync / 1[56]:[^:]*:Erichthonios:65EB:/
+584.0 "Powerful Fire/Powerful Light" sync / 1[56]:[^:]*:Erichthonios:(65EC|65ED):/
+
+## Beginning of Loop
+588.3 "--middle--" sync / 1[56]:[^:]*:Erichthonios:65F5:/
+
+## Fourth Gaoler's Flail
+598.0 "--sync--" sync / 1[56]:[^:]*:Erichthonios:65DF:/ jump 698.0
+598.1 "--sync--" sync / 1[56]:[^:]*:Erichthonios:65E0:/ jump 798.0
+598.7 "Aetherflail Left/Aetherflail Right?" sync / 1[56]:[^:]*:Erichthonios:(6DA2|6DA3):/
+598.8 "Powerful Fire" #sync / 1[56]:[^:]*:Erichthonios:65EC:/
+609.1 "--sync--" #sync / 1[56]:[^:]*:Erichthonios:65E0:/
+609.8 "Aetherflail Right/Aetherflail Left?" #sync / 1[56]:[^:]*:Erichthonios:(6DA3|6DA2):/
+609.9 "Powerful Fire/Powerful Light" #sync / 1[56]:[^:]*:Erichthonios:(65EC|65ED):/
+614.3 "unknown_6d15" #sync / 1[56]:[^:]*:Erichthonios:6D15:/
+619.6 "Pitiless Flail (knockback)" #sync / 1[56]:[^:]*:Erichthonios:65E5:/
+626.7 "True Holy" #sync / 1[56]:[^:]*:Erichthonios:65E7:/
+632.9 "--middle--" #sync / 1[56]:[^:]*:Erichthonios:65F5:/
+642.6 "--sync--" #sync / 1[56]:[^:]*:Erichthonios:65E0:/
+643.3 "Aetherflail Left/Aetherflail Right?" #sync / 1[56]:[^:]*:Erichthonios:6DA3:/
+643.4 "Powerful Fire/Powerful Light" #sync / 1[56]:[^:]*:Erichthonios:(65EC|65ED):/
+
+# Left Fourth, Right Fifth
+698.0 "--sync--" sync / 1[56]:[^:]*:Erichthonios:65E0:/
+698.7 "Aetherflail Left" sync / 1[56]:[^:]*:Erichthonios:6DA3:/
+698.8 "Powerful Fire" sync / 1[56]:[^:]*:Erichthonios:65EC:/
+709.1 "--sync--" sync / 1[56]:[^:]*:Erichthonios:65DF:/
+709.8 "Aetherflail Right" sync / 1[56]:[^:]*:Erichthonios:6DA2:/
+709.9 "Powerful Fire/Powerful Light" sync / 1[56]:[^:]*:Erichthonios:(65EC|65ED):/ jump 809.9
+714.3 "unknown_6d15" #sync / 1[56]:[^:]*:Erichthonios:6D15:/
+719.6 "Pitiless Flail (knockback)" #sync / 1[56]:[^:]*:Erichthonios:65E5:/
+726.7 "True Holy" #sync / 1[56]:[^:]*:Erichthonios:65E7:/
+732.9 "--middle--" #sync / 1[56]:[^:]*:Erichthonios:65F5:/
+742.6 "--sync--" #sync / 1[56]:[^:]*:Erichthonios:65E0:/
+743.3 "Aetherflail Left/Aetherflail Right?" #sync / 1[56]:[^:]*:Erichthonios:6DA3:/
+743.4 "Powerful Fire/Powerful Light" #sync / 1[56]:[^:]*:Erichthonios:(65EC|65ED):/
+
+# Right Fourth, Left Fifth
+798.0 "--sync--" sync / 1[56]:[^:]*:Erichthonios:65DF:/
+798.7 "Aetherflail Right" sync / 1[56]:[^:]*:Erichthonios:6DA2:/
+798.8 "Powerful Fire" sync / 1[56]:[^:]*:Erichthonios:65EC:/
+809.1 "--sync--" sync / 1[56]:[^:]*:Erichthonios:65E0:/
+809.8 "Aetherflail Left" sync / 1[56]:[^:]*:Erichthonios:6DA3:/
+809.9 "Powerful Fire/Powerful Light" sync / 1[56]:[^:]*:Erichthonios:(65EC|65ED):/
+814.3 "unknown_6d15" sync / 1[56]:[^:]*:Erichthonios:6D15:/
+819.6 "Pitiless Flail (knockback)" sync / 1[56]:[^:]*:Erichthonios:65E5:/
+826.7 "True Holy" sync / 1[56]:[^:]*:Erichthonios:65E7:/
+832.9 "--middle--" sync / 1[56]:[^:]*:Erichthonios:65F5:/
+
+## Sixth Gaoler's Flail
+842.6 "--sync--" sync / 1[56]:[^:]*:Erichthonios:65DF:/ jump 942.6
+842.7 "--sync--" sync / 1[56]:[^:]*:Erichthonios:65E0:/ jump 1242.6
+843.3 "Aetherflail Left/Aetherflail Right?" #sync / 1[56]:[^:]*:Erichthonios:(6DA2|6DA3):/
+843.4 "Powerful Fire/Powerful Light" #sync / 1[56]:[^:]*:Erichthonios:(65EC|65ED):/
+860.8 "Slam Shut" #sync / 1[56]:[^:]*:Erichthonios:65EA:/
+870.0 "Intemperance" #sync / 1[56]:[^:]*:Erichthonios:65EE:/
+874.1 "--middle--" #sync / 1[56]:[^:]*:Erichthonios:65F5:/
+881.7 "Intemperate Torment" #sync / 1[56]:[^:]*:Erichthonios:65EF:/
+884.3 "Hot Spell/Cold Spell 1" #sync / 1[56]:[^:]*:Erichthonios:(65F0|54F1):/
+893.3 "Hot Spell/Cold Spell 2" #sync / 1[56]:[^:]*:Erichthonios:(6CC5|6CC6):/
+902.3 "Hot Spell/Cold Spell 3" #sync / 1[56]:[^:]*:Erichthonios:(6CC5|6CC6):/
+904.9 "--sync--" #sync / 1[56]:[^:]*:Erichthonios:65D9:/
+905.6 "Gaoler's Flail Right/Gaoler's Flail Left?" #sync / 1[56]:[^:]*:Erichthonios:(6DA2|6DA3):/
+
+# Left Sixth, Right Seventh
+942.6 "--sync--" sync / 1[56]:[^:]*:Erichthonios:65E0:/
+943.3 "Aetherflail Left" sync / 1[56]:[^:]*:Erichthonios:6DA3:/
+943.4 "Powerful Fire/Powerful Light" sync / 1[56]:[^:]*:Erichthonios:(65EC|65ED):/
+960.8 "Slam Shut" sync / 1[56]:[^:]*:Erichthonios:65EA:/
+970.0 "Intemperance" sync / 1[56]:[^:]*:Erichthonios:65EE:/
+974.1 "--middle--" sync / 1[56]:[^:]*:Erichthonios:65F5:/
+981.7 "Intemperate Torment" sync / 1[56]:[^:]*:Erichthonios:65EF:/
+984.3 "Hot Spell/Cold Spell 1" sync / 1[56]:[^:]*:Erichthonios:(65F0|54F1):/
+993.3 "Hot Spell/Cold Spell 2" sync / 1[56]:[^:]*:Erichthonios:(6CC5|6CC6):/
+1002.3 "Hot Spell/Cold Spell 3" sync / 1[56]:[^:]*:Erichthonios:(6CC5|6CC6):/
+1004.9 "--sync--" sync / 1[56]:[^:]*:Erichthonios:65D9:/
+1005.6 "Gaoler's Flail Right" sync / 1[56]:[^:]*:Erichthonios:6DA2:/
+1116.1 "Warder's Wrath" sync / 1[56]:[^:]*:Erichthonios:65F4:/ jump 1316.2
+1127.3 "Warder's Wrath" #sync / 1[56]:[^:]*:Erichthonios:65F4:/
+1136.6 "Heavy Hand" #sync / 1[56]:[^:]*:Erichthonios:65F3:/
+1155.8 "Shining Cells" #sync / 1[56]:[^:]*:Erichthonios:65E9:/
+1160.0 "--middle--" #sync / 1[56]:[^:]*:Erichthonios:65F5:/
+
+# Right Sixth, Left Seventh
+1242.6 "--sync--" sync / 1[56]:[^:]*:Erichthonios:65DF:/
+1243.3 "Autherflail Right" sync / 1[56]:[^:]*:Erichthonios:6DA2:/
+1243.4 "Powerful Fire/Powerful Light" sync / 1[56]:[^:]*:Erichthonios:(65EC|65ED):/
+1260.8 "Slam Shut" sync / 1[56]:[^:]*:Erichthonios:65EA:/
+1270.0 "Intemperance" sync / 1[56]:[^:]*:Erichthonios:65EE:/
+1274.1 "--middle--" sync / 1[56]:[^:]*:Erichthonios:65F5:/
+1281.7 "Intemperate Torment" sync / 1[56]:[^:]*:Erichthonios:65EF:/
+1284.3 "Hot Spell/Cold Spell 1" sync / 1[56]:[^:]*:Erichthonios:(65F0|54F1):/
+1293.3 "Hot Spell/Cold Spell 2" sync / 1[56]:[^:]*:Erichthonios:(6CC5|6CC6):/
+1302.3 "Hot Spell/Cold Spell 3" sync / 1[56]:[^:]*:Erichthonios:(6CC5|6CC6):/
+1304.9 "--sync--" sync / 1[56]:[^:]*:Erichthonios:65DA:/
+1305.6 "Gaoler's Flail Left" sync / 1[56]:[^:]*:Erichthonios:6DA3:/
+1316.1 "Warder's Wrath" sync / 1[56]:[^:]*:Erichthonios:65F4:/
+1327.3 "Warder's Wrath" sync / 1[56]:[^:]*:Erichthonios:65F4:/
+1336.6 "Heavy Hand" sync / 1[56]:[^:]*:Erichthonios:65F3:/
+1355.8 "Shining Cells" sync / 1[56]:[^:]*:Erichthonios:65E9:/
+
+# Repeat
+1360.0 "--middle--" sync / 1[56]:[^:]*:Erichthonios:65F5:/ jump 588.3
+1369.6 "--sync--" #sync / 1[56]:[^:]*:Erichthonios:65E0:/
+1370.3 "Aetherflail Left/Aetherflail Right?" #sync / 1[56]:[^:]*:Erichthonios:(6DA2|6DA3):/
+1370.4 "Powerful Fire/Powerful Light" #sync / 1[56]:[^:]*:Erichthonios:(65EC|65ED):/
+1380.7 "--sync--" #sync / 1[56]:[^:]*:Erichthonios:65DF:/
+1381.4 "Aetherflail Right/Aetherflail Left?" #sync / 1[56]:[^:]*:Erichthonios:(6DA3|6DA2):/
+1381.5 "Powerful Fire/Powerful Light" #sync / 1[56]:[^:]*:Erichthonios:(65EC|65ED):/
+1385.9 "unknown_6d15" #sync / 1[56]:[^:]*:Erichthonios:6D15:/
+1391.2 "Pitiless Flail (knockback)" #sync / 1[56]:[^:]*:Erichthonios:65E5:/
+1398.3 "True Holy" #sync / 1[56]:[^:]*:Erichthonios:65E7:/
+1404.5 "--middle--" #sync / 1[56]:[^:]*:Erichthonios:65F5:/

--- a/ui/raidboss/data/06-ew/raid/p1n.txt
+++ b/ui/raidboss/data/06-ew/raid/p1n.txt
@@ -70,7 +70,7 @@ hideall "unknown_6d15"
 405.1 "Intemperate Torment" #sync / 1[56]:[^:]*:Erichthonios:65EF:/
 407.7 "Hot Spell/Cold Spell 1" #sync / 1[56]:[^:]*:Erichthonios:(65F0|54F1):/
 416.7 "Hot Spell/Cold Spell 2" #sync / 1[56]:[^:]*:Erichthonios:(6CC5|6CC6):/
-525.7 "Hot Spell/Cold Spell 3" #sync / 1[56]:[^:]*:Erichthonios:(6CC5|6CC6):/
+425.7 "Hot Spell/Cold Spell 3" #sync / 1[56]:[^:]*:Erichthonios:(6CC5|6CC6):/
 
 # Right Third
 469.8 "--sync--" sync / 1[56]:[^:]*:Erichthonios:65D9:/

--- a/ui/raidboss/data/06-ew/raid/p1n.txt
+++ b/ui/raidboss/data/06-ew/raid/p1n.txt
@@ -24,7 +24,7 @@ hideall "unknown_6d15"
 28.5 "Gaoler's Flail Right/Gaoler's Flail Left?" #sync / 1[56]:[^:]*:Erichthonios:(6DA2|6DA3):/
 39.0 "Warder's Wrath" #sync / 1[56]:[^:]*:Erichthonios:65F4:/
 46.2 "unknown_6d15" #sync / 1[56]:[^:]*:Erichthonios:6D15:/
-51.5 "Pitiless Flail (knockback)" #sync / 1[56]:[^:]*:Erichthonios:65E5:/
+51.5 "Pitiless Flail" #sync / 1[56]:[^:]*:Erichthonios:65E5:/
 58.6 "True Holy" #sync / 1[56]:[^:]*:Erichthonios:65E7:/
 
 # Left First, Right Second

--- a/ui/raidboss/data/06-ew/raid/p1n.txt
+++ b/ui/raidboss/data/06-ew/raid/p1n.txt
@@ -130,8 +130,8 @@ hideall "unknown_6d15"
 832.9 "--middle--" sync / 1[56]:[^:]*:Erichthonios:65F5:/
 
 ## Sixth Gaoler's Flail
-834.6 "--sync--" sync / 14:[^:]*:Erichthonios:6DA3:/ jump 934.7
-834.6 "--sync--" sync / 14:[^:]*:Erichthonios:6DA2:/ jump 1234.7
+834.6 "--sync--" sync / 14:[^:]*:Erichthonios:6DA3:/ jump 934.6
+834.6 "--sync--" sync / 14:[^:]*:Erichthonios:6DA2:/ jump 1234.6
 843.3 "Aetherflail Left/Aetherflail Right?" #sync / 1[56]:[^:]*:Erichthonios:(6DA3|6DA2):/
 843.4 "Powerful Fire/Powerful Light" #sync / 1[56]:[^:]*:Erichthonios:(65EC|65ED):/
 860.8 "Slam Shut" #sync / 1[56]:[^:]*:Erichthonios:65EA:/

--- a/ui/raidboss/data/06-ew/raid/p1n.txt
+++ b/ui/raidboss/data/06-ew/raid/p1n.txt
@@ -163,7 +163,7 @@ hideall "unknown_6d15"
 
 # Right Sixth, Left Seventh
 1234.6 "--sync--" sync / 14:[^:]*:Erichthonios:6DA2:/
-1243.3 "Autherflail Right" sync / 1[56]:[^:]*:Erichthonios:6DA2:/
+1243.3 "Aetherflail Right" sync / 1[56]:[^:]*:Erichthonios:6DA2:/
 1243.4 "Powerful Fire/Powerful Light" sync / 1[56]:[^:]*:Erichthonios:(65EC|65ED):/
 1260.8 "Slam Shut" sync / 1[56]:[^:]*:Erichthonios:65EA:/
 1270.0 "Intemperance" sync / 1[56]:[^:]*:Erichthonios:65EE:/

--- a/ui/raidboss/data/06-ew/raid/p1n.txt
+++ b/ui/raidboss/data/06-ew/raid/p1n.txt
@@ -1,10 +1,10 @@
 ### P1N: Asphodelos: The First Circle
 #
-# -ii 65F2 65E6
+# -ii 65F2 65E6 65DA 65D9 65E0 65DF
 
 # Note: Gaoler's Flail cast is reworded to Aetherflail (65E0|65DF) in the
 # timeline as that is the cast that is visible. However, damage is from the
-# Gaoler's Flail (65DA3|65DA2) cast end after.
+# Gaoler's Flail (6DA3|6DA2) cast end after.
 
 # Note: unknown_6d15 happens same time as marker for the stack
 # to avoid knockback mechanic.
@@ -18,10 +18,9 @@ hideall "unknown_6d15"
 0.0 "--sync--" sync /Engage!/ window 0,1
 
 ## First Gaoler's Flail
-8.7 "--sync--" sync / 14:[^:]*:Erichthonios:65DA:/ jump 108.7 window 10,10
-8.8 "--sync--" sync / 14:[^:]*:Erichthonios:65D9:/ jump 208.7 window 10,10
+8.7 "--sync--" sync / 14:[^:]*:Erichthonios:6DA3:/ jump 108.7 window 10,10
+8.8 "--sync--" sync / 14:[^:]*:Erichthonios:6DA2:/ jump 208.7 window 10,10
 17.4 "Gaoler's Flail Left/Gaoler's Flail Right?" #sync / 1[56]:[^:]*:Erichthonios:(6DA3|6DA2):/
-19.8 "--sync--" #sync / 14:[^:]*:Erichthonios:(65D9|65DA):/
 28.5 "Gaoler's Flail Right/Gaoler's Flail Left?" #sync / 1[56]:[^:]*:Erichthonios:(6DA2|6DA3):/
 39.0 "Warder's Wrath" #sync / 1[56]:[^:]*:Erichthonios:65F4:/
 46.2 "unknown_6d15" #sync / 1[56]:[^:]*:Erichthonios:6D15:/
@@ -29,11 +28,10 @@ hideall "unknown_6d15"
 58.6 "True Holy" #sync / 1[56]:[^:]*:Erichthonios:65E7:/
 
 # Left First, Right Second
-108.7 "--sync--" sync / 14:[^:]*:Erichthonios:65DA:/
+108.7 "--sync--" sync / 14:[^:]*:Erichthonios:6DA3:/
 117.4 "Gaoler's Flail Left" sync / 1[56]:[^:]*:Erichthonios:6DA3:/
-119.8 "--sync--" sync / 14:[^:]*:Erichthonios:65D9:/
 128.5 "Gaoler's Flail Right" sync / 1[56]:[^:]*:Erichthonios:6DA2:/
-139.0 "Warder's Wrath" sync / 1[56]:[^:]*:Erichthonios:65F4:/ jump 139
+139.0 "Warder's Wrath" sync / 1[56]:[^:]*:Erichthonios:65F4:/ jump 239
 146.2 "unknown_6d15" #sync / 1[56]:[^:]*:Erichthonios:6D15:/
 151.5 "Pitiless Flail (knockback)" #sync / 1[56]:[^:]*:Erichthonios:65E5:/
 158.6 "True Holy" #sync / 1[56]:[^:]*:Erichthonios:65E7:/
@@ -41,9 +39,8 @@ hideall "unknown_6d15"
 181.1 "Heavy Hand" #sync / 1[56]:[^:]*:Erichthonios:65F3:/
 
 # Right First, Left Second
-208.7 "--sync--" sync / 14:[^:]*:Erichthonios:65D9:/
+208.7 "--sync--" sync / 14:[^:]*:Erichthonios:6DA2:/
 217.4 "Gaoler's Flail Right" sync / 1[56]:[^:]*:Erichthonios:6DA2:/
-219.8 "--sync--" sync / 14:[^:]*:Erichthonios:65DA:/
 228.5 "Gaoler's Flail Left" sync / 1[56]:[^:]*:Erichthonios:6DA3:/
 239.0 "Warder's Wrath" sync / 1[56]:[^:]*:Erichthonios:65F4:/
 246.2 "unknown_6d15" sync / 1[56]:[^:]*:Erichthonios:6D15:/
@@ -51,8 +48,8 @@ hideall "unknown_6d15"
 258.6 "True Holy" sync / 1[56]:[^:]*:Erichthonios:65E7:/
 
 ## Third Gaoler's Flail
-261.8 "--sync--" sync / 14:[^:]*:Erichthonios:65DA:/ jump 361.8
-261.9 "--sync--" sync / 14:[^:]*:Erichthonios:65D9:/ jump 461.8
+261.8 "--sync--" sync / 14:[^:]*:Erichthonios:6DA3:/ jump 361.8
+261.9 "--sync--" sync / 14:[^:]*:Erichthonios:6DA2:/ jump 461.8
 270.5 "Gaoler's Flail Left/Gaoler's Flail Right?" #sync / 1[56]:[^:]*:Erichthonios:(6DA3|6DA2):/
 281.1 "Heavy Hand" #sync / 1[56]:[^:]*:Erichthonios:65F3:/
 293.2 "Intemperance" #sync / 1[56]:[^:]*:Erichthonios:65EE:/
@@ -62,7 +59,7 @@ hideall "unknown_6d15"
 316.7 "Hot Spell/Cold Spell 2" #sync / 1[56]:[^:]*:Erichthonios:(6CC5|6CC6):/
 
 # Left Third
-361.8 "--sync--" sync / 14:[^:]*:Erichthonios:65DA:/
+361.8 "--sync--" sync / 14:[^:]*:Erichthonios:6DA3:/
 370.5 "Gaoler's Flail Left" sync / 1[56]:[^:]*:Erichthonios:6DA3:/
 381.1 "Heavy Hand" sync / 1[56]:[^:]*:Erichthonios:65F3:/ jump 481.1
 393.2 "Intemperance" #sync / 1[56]:[^:]*:Erichthonios:65EE:/
@@ -73,7 +70,7 @@ hideall "unknown_6d15"
 425.7 "Hot Spell/Cold Spell 3" #sync / 1[56]:[^:]*:Erichthonios:(6CC5|6CC6):/
 
 # Right Third
-461.8 "--sync--" sync / 14:[^:]*:Erichthonios:65D9:/
+461.8 "--sync--" sync / 14:[^:]*:Erichthonios:6DA2:/
 470.5 "Gaoler's Flail Right" sync / 1[56]:[^:]*:Erichthonios:6DA2:/
 481.1 "Heavy Hand" sync / 1[56]:[^:]*:Erichthonios:65F3:/
 493.2 "Intemperance" sync / 1[56]:[^:]*:Erichthonios:65EE:/
@@ -94,41 +91,38 @@ hideall "unknown_6d15"
 588.3 "--middle--" sync / 1[56]:[^:]*:Erichthonios:65F5:/
 
 ## Fourth Gaoler's Flail
-590.0 "--sync--" sync / 14:[^:]*:Erichthonios:65E0:/ jump 690.0
-590.1 "--sync--" sync / 14:[^:]*:Erichthonios:65DF:/ jump 790.0
+590.0 "--sync--" sync / 14:[^:]*:Erichthonios:6DA3:/ jump 690.0
+590.1 "--sync--" sync / 14:[^:]*:Erichthonios:6DA2:/ jump 790.0
 598.7 "Aetherflail Left/Aetherflail Right?" sync / 1[56]:[^:]*:Erichthonios:(6DA3|6DA2):/
 598.8 "Powerful Fire/Powerful Light" #sync / 1[56]:[^:]*:Erichthonios:(65EC|65ED):/
-601.1 "--sync--" #sync / 14:[^:]*:Erichthonios:(65DF|65E0):/
 609.8 "Aetherflail Right/Aetherflail Left?" #sync / 1[56]:[^:]*:Erichthonios:(6DA2|6DA3):/
 609.9 "Powerful Fire/Powerful Light" #sync / 1[56]:[^:]*:Erichthonios:(65EC|65ED):/
 614.3 "unknown_6d15" #sync / 1[56]:[^:]*:Erichthonios:6D15:/
 619.6 "Pitiless Flail (knockback)" #sync / 1[56]:[^:]*:Erichthonios:65E5:/
 626.7 "True Holy" #sync / 1[56]:[^:]*:Erichthonios:65E7:/
 632.9 "--middle--" #sync / 1[56]:[^:]*:Erichthonios:65F5:/
-634.6 "--sync--" #sync / 14:[^:]*:Erichthonios:(65E0|65DF):/
+634.6 "--sync--" #sync / 14:[^:]*:Erichthonios:(6DA3|6DA2):/
 643.3 "Aetherflail Left/Aetherflail Right?" #sync / 1[56]:[^:]*:Erichthonios:(6DA3|6DA2):/
 643.4 "Powerful Fire/Powerful Light" #sync / 1[56]:[^:]*:Erichthonios:(65EC|65ED):/
 
 # Left Fourth, Right Fifth
-690.0 "--sync--" sync / 14:[^:]*:Erichthonios:65E0:/
+690.0 "--sync--" sync / 14:[^:]*:Erichthonios:6DA3:/
 698.7 "Aetherflail Left" sync / 1[56]:[^:]*:Erichthonios:6DA3:/
 698.8 "Powerful Fire/Powerful Light" sync / 1[56]:[^:]*:Erichthonios:(65EC|65ED):/
-701.1 "--sync--" sync / 14:[^:]*:Erichthonios:65DF:/
 709.8 "Aetherflail Right" sync / 1[56]:[^:]*:Erichthonios:6DA2:/
 709.9 "Powerful Fire/Powerful Light" sync / 1[56]:[^:]*:Erichthonios:(65EC|65ED):/ jump 809.9
 714.3 "unknown_6d15" #sync / 1[56]:[^:]*:Erichthonios:6D15:/
 719.6 "Pitiless Flail (knockback)" #sync / 1[56]:[^:]*:Erichthonios:65E5:/
 726.7 "True Holy" #sync / 1[56]:[^:]*:Erichthonios:65E7:/
 732.9 "--middle--" #sync / 1[56]:[^:]*:Erichthonios:65F5:/
-734.6 "--sync--" #sync / 14:[^:]*:Erichthonios:(65E0|65DF):/
+734.6 "--sync--" #sync / 14:[^:]*:Erichthonios:(6DA3|6DA2):/
 743.3 "Aetherflail Left/Aetherflail Right?" #sync / 1[56]:[^:]*:Erichthonios:(6DA3|6DA2):/
 743.4 "Powerful Fire/Powerful Light" #sync / 1[56]:[^:]*:Erichthonios:(65EC|65ED):/
 
 # Right Fourth, Left Fifth
-790.0 "--sync--" sync / 14:[^:]*:Erichthonios:65DF:/
+790.0 "--sync--" sync / 14:[^:]*:Erichthonios:6DA2:/
 798.7 "Aetherflail Right" sync / 1[56]:[^:]*:Erichthonios:6DA2:/
 798.8 "Powerful Fire/Powerful Light" sync / 1[56]:[^:]*:Erichthonios:(65EC|65ED):/
-801.1 "--sync--" sync / 14:[^:]*:Erichthonios:65E0:/
 809.8 "Aetherflail Left" sync / 1[56]:[^:]*:Erichthonios:6DA3:/
 809.9 "Powerful Fire/Powerful Light" sync / 1[56]:[^:]*:Erichthonios:(65EC|65ED):/
 814.3 "unknown_6d15" sync / 1[56]:[^:]*:Erichthonios:6D15:/
@@ -137,8 +131,8 @@ hideall "unknown_6d15"
 832.9 "--middle--" sync / 1[56]:[^:]*:Erichthonios:65F5:/
 
 ## Sixth Gaoler's Flail
-834.6 "--sync--" sync / 14:[^:]*:Erichthonios:65E0:/ jump 934.6
-834.7 "--sync--" sync / 14:[^:]*:Erichthonios:65DF:/ jump 1234.6
+834.6 "--sync--" sync / 14:[^:]*:Erichthonios:6DA3:/ jump 934.6
+834.7 "--sync--" sync / 14:[^:]*:Erichthonios:6DA2:/ jump 1234.6
 843.3 "Aetherflail Left/Aetherflail Right?" #sync / 1[56]:[^:]*:Erichthonios:(6DA3|6DA2):/
 843.4 "Powerful Fire/Powerful Light" #sync / 1[56]:[^:]*:Erichthonios:(65EC|65ED):/
 860.8 "Slam Shut" #sync / 1[56]:[^:]*:Erichthonios:65EA:/
@@ -147,12 +141,11 @@ hideall "unknown_6d15"
 881.7 "Intemperate Torment" #sync / 1[56]:[^:]*:Erichthonios:65EF:/
 884.3 "Hot Spell/Cold Spell 1" #sync / 1[56]:[^:]*:Erichthonios:(65F0|54F1):/
 893.3 "Hot Spell/Cold Spell 2" #sync / 1[56]:[^:]*:Erichthonios:(6CC5|6CC6):/
-896.9 "--sync--" #sync / 14:[^:]*:Erichthonios:(65DA|65D9):/
 902.3 "Hot Spell/Cold Spell 3" #sync / 1[56]:[^:]*:Erichthonios:(6CC5|6CC6):/
 905.6 "Gaoler's Flail Right/Gaoler's Flail Left?" #sync / 1[56]:[^:]*:Erichthonios:(6DA2|6DA3):/
 
 # Left Sixth, Right Seventh
-934.6 "--sync--" sync / 14:[^:]*:Erichthonios:65E0:/
+934.6 "--sync--" sync / 14:[^:]*:Erichthonios:6DA3:/
 943.3 "Aetherflail Left" sync / 1[56]:[^:]*:Erichthonios:6DA3:/
 943.4 "Powerful Fire/Powerful Light" sync / 1[56]:[^:]*:Erichthonios:(65EC|65ED):/
 960.8 "Slam Shut" sync / 1[56]:[^:]*:Erichthonios:65EA:/
@@ -161,7 +154,7 @@ hideall "unknown_6d15"
 981.7 "Intemperate Torment" sync / 1[56]:[^:]*:Erichthonios:65EF:/
 984.3 "Hot Spell/Cold Spell 1" sync / 1[56]:[^:]*:Erichthonios:(65F0|54F1):/
 993.3 "Hot Spell/Cold Spell 2" sync / 1[56]:[^:]*:Erichthonios:(6CC5|6CC6):/
-996.9 "--sync--" sync / 14:[^:]*:Erichthonios:65D9:/
+996.9 "--sync--" sync / 14:[^:]*:Erichthonios:6DA2:/
 1002.3 "Hot Spell/Cold Spell 3" sync / 1[56]:[^:]*:Erichthonios:(6CC5|6CC6):/
 1005.6 "Gaoler's Flail Right" sync / 1[56]:[^:]*:Erichthonios:6DA2:/
 1116.1 "Warder's Wrath" sync / 1[56]:[^:]*:Erichthonios:65F4:/ jump 1316.2
@@ -171,7 +164,7 @@ hideall "unknown_6d15"
 1160.0 "--middle--" #sync / 1[56]:[^:]*:Erichthonios:65F5:/
 
 # Right Sixth, Left Seventh
-1234.6 "--sync--" sync / 14:[^:]*:Erichthonios:65DF:/
+1234.6 "--sync--" sync / 14:[^:]*:Erichthonios:6DA2:/
 1243.3 "Autherflail Right" sync / 1[56]:[^:]*:Erichthonios:6DA2:/
 1243.4 "Powerful Fire/Powerful Light" sync / 1[56]:[^:]*:Erichthonios:(65EC|65ED):/
 1260.8 "Slam Shut" sync / 1[56]:[^:]*:Erichthonios:65EA:/
@@ -180,7 +173,6 @@ hideall "unknown_6d15"
 1281.7 "Intemperate Torment" sync / 1[56]:[^:]*:Erichthonios:65EF:/
 1284.3 "Hot Spell/Cold Spell 1" sync / 1[56]:[^:]*:Erichthonios:(65F0|54F1):/
 1293.3 "Hot Spell/Cold Spell 2" sync / 1[56]:[^:]*:Erichthonios:(6CC5|6CC6):/
-1296.9 "--sync--" sync / 14:[^:]*:Erichthonios:65DA:/
 1302.3 "Hot Spell/Cold Spell 3" sync / 1[56]:[^:]*:Erichthonios:(6CC5|6CC6):/
 1305.6 "Gaoler's Flail Left" sync / 1[56]:[^:]*:Erichthonios:6DA3:/
 1316.1 "Warder's Wrath" sync / 1[56]:[^:]*:Erichthonios:65F4:/
@@ -190,10 +182,9 @@ hideall "unknown_6d15"
 
 # Repeat
 1360.0 "--middle--" sync / 1[56]:[^:]*:Erichthonios:65F5:/ jump 588.3
-1361.6 "--sync--" #sync / 14:[^:]*:Erichthonios:(65E0|65DF):/
+1361.6 "--sync--" #sync / 14:[^:]*:Erichthonios:(6DA3|6DA2):/
 1370.3 "Aetherflail Left/Aetherflail Right?" #sync / 1[56]:[^:]*:Erichthonios:(6DA3|6DA2):/
 1370.4 "Powerful Fire/Powerful Light" #sync / 1[56]:[^:]*:Erichthonios:(65EC|65ED):/
-1372.7 "--sync--" #sync / 14:[^:]*:Erichthonios:(65DF|65E0):/
 1381.4 "Aetherflail Right/Aetherflail Left?" #sync / 1[56]:[^:]*:Erichthonios:(6DA2|6DA3):/
 1381.5 "Powerful Fire/Powerful Light" #sync / 1[56]:[^:]*:Erichthonios:(65EC|65ED):/
 1385.9 "unknown_6d15" #sync / 1[56]:[^:]*:Erichthonios:6D15:/

--- a/ui/raidboss/data/06-ew/raid/p1n.txt
+++ b/ui/raidboss/data/06-ew/raid/p1n.txt
@@ -14,10 +14,9 @@ hideall "--sync--"
 0.0 "--sync--" sync /Engage!/ window 0,1
 
 ## First Gaoler's Flail
-8.7 "--sync--" sync / 14:[^:]*:Erichthonios:6DA3:/ window 10,9 jump 108.7
-8.7 "--sync--" sync / 14:[^:]*:Erichthonios:6DA2:/ window 10,9 jump 208.7
-17.4 "Gaoler's Flail Left/Gaoler's Flail Right?" #sync / 1[56]:[^:]*:Erichthonios:(6DA3|6DA2):/
-28.5 "Gaoler's Flail Right/Gaoler's Flail Left?" #sync / 1[56]:[^:]*:Erichthonios:(6DA2|6DA3):/
+8.7 "--sync--" sync / 14:[^:]*:Erichthonios:(6DA2|6DA3):/ window 10,9
+17.4 "Gaoler's Flail Left/Gaoler's Flail Right" sync / 1[56]:[^:]*:Erichthonios:(6DA3|6DA2):/
+28.5 "Gaoler's Flail Right/Gaoler's Flail Left" sync / 1[56]:[^:]*:Erichthonios:(6DA2|6DA3):/
 39.0 "Warder's Wrath" #sync / 1[56]:[^:]*:Erichthonios:65F4:/
 46.2 "--knockback stack--" #sync / 1[56]:[^:]*:Erichthonios:6D15:/
 51.5 "Pitiless Flail" #sync / 1[56]:[^:]*:Erichthonios:65E5:/

--- a/ui/raidboss/data/06-ew/raid/p2n.ts
+++ b/ui/raidboss/data/06-ew/raid/p2n.ts
@@ -13,6 +13,7 @@ export interface Data extends RaidbossData {
 
 const triggerSet: TriggerSet<Data> = {
   zoneId: ZoneId.AsphodelosTheSecondCircle,
+  timelineFile: 'p2n.txt',
   triggers: [
     {
       id: 'P2N Murky Depths',

--- a/ui/raidboss/data/06-ew/raid/p2n.txt
+++ b/ui/raidboss/data/06-ew/raid/p2n.txt
@@ -7,6 +7,7 @@ hideall "--sync--"
 
 0.0 "--Reset--" sync / 21:........:40000010:/ window 100000 jump 0
 
+0.0 "--sync--" sync /Engage!/ window 0,1
 9.3 "--sync--" sync / 14:[^:]*:Hippokampos:680F:/ window 20,20
 14.3 "Murky Depths" sync / 1[56]:[^:]*:Hippokampos:680F:/
 26.6 "Doubled Impact" sync / 1[56]:[^:]*:Hippokampos:680E:/

--- a/ui/raidboss/data/06-ew/raid/p2n.txt
+++ b/ui/raidboss/data/06-ew/raid/p2n.txt
@@ -18,7 +18,7 @@ hideall "--sync--"
 84.6 "Sewage Deluge" sync / 1[56]:[^:]*:Hippokampos:67F6:/
 111.0 "Tainted Flood" sync / 1[56]:[^:]*:Hippokampos:6809:/
 126.9 "Predatory Sight" sync / 1[56]:[^:]*:Hippokampos:680B:/
-137.3 "Shockwave  (knockback)" sync / 1[56]:[^:]*:Hippokampos:6807:/
+137.3 "Shockwave (knockback)" sync / 1[56]:[^:]*:Hippokampos:6807:/
 148.6 "Dissociation" sync / 1[56]:[^:]*:Hippokampos:6804:/
 153.7 "--sync--" sync / 1[56]:[^:]*:Hippokampos:6805:/
 165.8 "Dissociation Dive" sync / 1[56]:[^:]*:Hippokampos:6806:/
@@ -41,7 +41,7 @@ hideall "--sync--"
 287.0 "Murky Depths" sync / 1[56]:[^:]*:Hippokampos:680F:/
 296.2 "Dissociation" sync / 1[56]:[^:]*:Hippokampos:6804:/
 301.3 "--sync--" sync / 1[56]:[^:]*:Hippokampos:6805:/
-310.7 "Shockwave  (knockback)" sync / 1[56]:[^:]*:Hippokampos:6807:/
+310.7 "Shockwave (knockback)" sync / 1[56]:[^:]*:Hippokampos:6807:/
 313.4 "Dissociation Dive" sync / 1[56]:[^:]*:Hippokampos:6806:/
 318.9 "--middle--" sync / 1[56]:[^:]*:Hippokampos:6835:/
 325.3 "Dissociation" sync / 1[56]:[^:]*:Hippokampos:6804:/

--- a/ui/raidboss/data/06-ew/raid/p2n.txt
+++ b/ui/raidboss/data/06-ew/raid/p2n.txt
@@ -33,9 +33,9 @@ hideall "--sync--"
 208.6 "Sewage Deluge" sync / 1[56]:[^:]*:Hippokampos:67F6:/
 227.1 "Tainted Flood" sync / 1[56]:[^:]*:Hippokampos:6809:/
 235.0 "Spoken Cataract" sync / 1[56]:[^:]*:Hippokampos:(67F7|67F8|67F9|67FD):/
-250.7 "Sewage Eruption 1" sync / 1[56]:[^:]*:Hippokampos:680D:/
-252.2 "Sewage Eruption 2" sync / 1[56]:[^:]*:Hippokampos:680D:/
-253.7 "Sewage Eruption 3" sync / 1[56]:[^:]*:Hippokampos:680D:/
+250.7 "Sewage Eruption 1" #sync / 1[56]:[^:]*:Hippokampos:680D:/
+252.2 "Sewage Eruption 2" #sync / 1[56]:[^:]*:Hippokampos:680D:/
+253.7 "Sewage Eruption 3" #sync / 1[56]:[^:]*:Hippokampos:680D:/
 259.5 "Spoken Cataract" sync / 1[56]:[^:]*:Hippokampos:(67F7|67F8|67F9|67FD):/
 273.4 "Tainted Flood" sync / 1[56]:[^:]*:Hippokampos:6809:/
 279.8 "Predatory Sight" sync / 1[56]:[^:]*:Hippokampos:680B:/
@@ -49,9 +49,9 @@ hideall "--sync--"
 330.4 "--sync--" sync / 1[56]:[^:]*:Hippokampos:6805:/
 342.3 "--sync--" sync / 1[56]:[^:]*:Hippokampos:6D14:/
 342.5 "Dissociation Dive" sync / 1[56]:[^:]*:Hippokampos:6806:/
-342.5 "Sewage Eruption 1" sync / 1[56]:[^:]*:Hippokampos:680D:/
-344.0 "Sewage Eruption 2" sync / 1[56]:[^:]*:Hippokampos:680D:/
-345.5 "Sewage Eruption 3" sync / 1[56]:[^:]*:Hippokampos:680D:/
+342.5 "Sewage Eruption 1" #sync / 1[56]:[^:]*:Hippokampos:680D:/
+344.0 "Sewage Eruption 2" #sync / 1[56]:[^:]*:Hippokampos:680D:/
+345.5 "Sewage Eruption 3" #sync / 1[56]:[^:]*:Hippokampos:680D:/
 347.9 "Coherence Flare" sync / 1[56]:[^:]*:Hippokampos:6800:/
 350.4 "Coherence Line" sync / 1[56]:[^:]*:Hippokampos:6802:/
 352.4 "--sync--" sync / 1[56]:[^:]*:Hippokampos:6803:/

--- a/ui/raidboss/data/06-ew/raid/p2n.txt
+++ b/ui/raidboss/data/06-ew/raid/p2n.txt
@@ -1,0 +1,65 @@
+### P2N: Asphodelos: The Second Circle
+#
+# -ii 6808 680A 6801 680C
+
+hideall "--Reset--"
+hideall "--sync--"
+
+0.0 "--Reset--" sync / 21:........:40000010:/ window 100000 jump 0
+
+9.3 "--sync--" sync / 14:[^:]*:Hippokampos:680F:/ window 20,20
+14.3 "Murky Depths" sync / 1[56]:[^:]*:Hippokampos:680F:/
+26.6 "Doubled Impact" sync / 1[56]:[^:]*:Hippokampos:680E:/
+32.8 "--middle--" sync / 1[56]:[^:]*:Hippokampos:6835:/
+43.6 "Spoken Cataract" sync / 1[56]:[^:]*:Hippokampos:(67F7|67F8|67F9|67FD):/
+58.3 "Spoken Cataract" sync / 1[56]:[^:]*:Hippokampos:(67F7|67F8|67F9|67FD):/
+72.0 "Murky Depths" sync / 1[56]:[^:]*:Hippokampos:680F:/
+77.2 "--middle--" sync / 1[56]:[^:]*:Hippokampos:6835:/
+84.6 "Sewage Deluge" sync / 1[56]:[^:]*:Hippokampos:67F6:/
+111.0 "Tainted Flood" sync / 1[56]:[^:]*:Hippokampos:6809:/
+126.9 "Predatory Sight" sync / 1[56]:[^:]*:Hippokampos:680B:/
+137.3 "Shockwave" sync / 1[56]:[^:]*:Hippokampos:6807:/
+148.6 "Dissociation" sync / 1[56]:[^:]*:Hippokampos:6804:/
+153.7 "--sync--" sync / 1[56]:[^:]*:Hippokampos:6805:/
+165.8 "Dissociation Dive" sync / 1[56]:[^:]*:Hippokampos:6806:/
+172.5 "--sync--" sync / 1[56]:[^:]*:Hippokampos:6D14:/
+178.2 "Coherence Flare" sync / 1[56]:[^:]*:Hippokampos:6800:/
+180.7 "Coherence Line" sync / 1[56]:[^:]*:Hippokampos:6802:/
+182.7 "--sync--" sync / 1[56]:[^:]*:Hippokampos:6803:/
+194.8 "Murky Depths" sync / 1[56]:[^:]*:Hippokampos:680F:/
+
+201.0 "--middle--" sync / 1[56]:[^:]*:Hippokampos:6835:/
+208.6 "Sewage Deluge" sync / 1[56]:[^:]*:Hippokampos:67F6:/
+227.1 "Tainted Flood" sync / 1[56]:[^:]*:Hippokampos:6809:/
+235.0 "Spoken Cataract" sync / 1[56]:[^:]*:Hippokampos:(67F7|67F8|67F9|67FD):/
+250.7 "Sewage Eruption 1" sync / 1[56]:[^:]*:Hippokampos:680D:/
+252.2 "Sewage Eruption 2" sync / 1[56]:[^:]*:Hippokampos:680D:/
+253.7 "Sewage Eruption 3" sync / 1[56]:[^:]*:Hippokampos:680D:/
+259.5 "Spoken Cataract" sync / 1[56]:[^:]*:Hippokampos:(67F7|67F8|67F9|67FD):/
+273.4 "Tainted Flood" sync / 1[56]:[^:]*:Hippokampos:6809:/
+279.8 "Predatory Sight" sync / 1[56]:[^:]*:Hippokampos:680B:/
+287.0 "Murky Depths" sync / 1[56]:[^:]*:Hippokampos:680F:/
+296.2 "Dissociation" sync / 1[56]:[^:]*:Hippokampos:6804:/
+301.3 "--sync--" sync / 1[56]:[^:]*:Hippokampos:6805:/
+310.7 "Shockwave" sync / 1[56]:[^:]*:Hippokampos:6807:/
+313.4 "Dissociation Dive" sync / 1[56]:[^:]*:Hippokampos:6806:/
+318.9 "--middle--" sync / 1[56]:[^:]*:Hippokampos:6835:/
+325.3 "Dissociation" sync / 1[56]:[^:]*:Hippokampos:6804:/
+330.4 "--sync--" sync / 1[56]:[^:]*:Hippokampos:6805:/
+342.3 "--sync--" sync / 1[56]:[^:]*:Hippokampos:6D14:/
+342.5 "Dissociation Dive" sync / 1[56]:[^:]*:Hippokampos:6806:/
+342.5 "Sewage Eruption 1" sync / 1[56]:[^:]*:Hippokampos:680D:/
+344.0 "Sewage Eruption 2" sync / 1[56]:[^:]*:Hippokampos:680D:/
+345.5 "Sewage Eruption 3" sync / 1[56]:[^:]*:Hippokampos:680D:/
+347.9 "Coherence Flare" sync / 1[56]:[^:]*:Hippokampos:6800:/
+350.4 "Coherence Line" sync / 1[56]:[^:]*:Hippokampos:6802:/
+352.4 "--sync--" sync / 1[56]:[^:]*:Hippokampos:6803:/
+360.6 "Murky Depths" sync / 1[56]:[^:]*:Hippokampos:680F:/
+371.8 "Murky Depths" sync / 1[56]:[^:]*:Hippokampos:680F:/
+383.1 "Doubled Impact" sync / 1[56]:[^:]*:Hippokampos:680E:/
+
+392.3 "--middle--" sync / 1[56]:[^:]*:Hippokampos:6835:/ jump 201.0
+399.7 "Sewage Deluge" #sync / 1[56]:[^:]*:Hippokampos:67F6:/
+418.2 "Tainted Flood" #sync / 1[56]:[^:]*:Hippokampos:6809:/
+426.1 "Spoken Cataract" #sync / 1[56]:[^:]*:Hippokampos:(67F7|67F8|67F9|67FD):/
+441.8 "Sewage Eruption 1" #sync / 1[56]:[^:]*:Hippokampos:680D:/

--- a/ui/raidboss/data/06-ew/raid/p2n.txt
+++ b/ui/raidboss/data/06-ew/raid/p2n.txt
@@ -18,7 +18,7 @@ hideall "--sync--"
 84.6 "Sewage Deluge" sync / 1[56]:[^:]*:Hippokampos:67F6:/
 111.0 "Tainted Flood" sync / 1[56]:[^:]*:Hippokampos:6809:/
 126.9 "Predatory Sight" sync / 1[56]:[^:]*:Hippokampos:680B:/
-137.3 "Shockwave" sync / 1[56]:[^:]*:Hippokampos:6807:/
+137.3 "Shockwave  (knockback)" sync / 1[56]:[^:]*:Hippokampos:6807:/
 148.6 "Dissociation" sync / 1[56]:[^:]*:Hippokampos:6804:/
 153.7 "--sync--" sync / 1[56]:[^:]*:Hippokampos:6805:/
 165.8 "Dissociation Dive" sync / 1[56]:[^:]*:Hippokampos:6806:/
@@ -41,7 +41,7 @@ hideall "--sync--"
 287.0 "Murky Depths" sync / 1[56]:[^:]*:Hippokampos:680F:/
 296.2 "Dissociation" sync / 1[56]:[^:]*:Hippokampos:6804:/
 301.3 "--sync--" sync / 1[56]:[^:]*:Hippokampos:6805:/
-310.7 "Shockwave" sync / 1[56]:[^:]*:Hippokampos:6807:/
+310.7 "Shockwave  (knockback)" sync / 1[56]:[^:]*:Hippokampos:6807:/
 313.4 "Dissociation Dive" sync / 1[56]:[^:]*:Hippokampos:6806:/
 318.9 "--middle--" sync / 1[56]:[^:]*:Hippokampos:6835:/
 325.3 "Dissociation" sync / 1[56]:[^:]*:Hippokampos:6804:/

--- a/ui/raidboss/data/06-ew/raid/p2n.txt
+++ b/ui/raidboss/data/06-ew/raid/p2n.txt
@@ -59,7 +59,7 @@ hideall "--sync--"
 371.8 "Murky Depths" sync / 1[56]:[^:]*:Hippokampos:680F:/
 383.1 "Doubled Impact" sync / 1[56]:[^:]*:Hippokampos:680E:/
 
-392.3 "--middle--" sync / 1[56]:[^:]*:Hippokampos:6835:/ window 50,50 jump 588.3
+392.3 "--middle--" sync / 1[56]:[^:]*:Hippokampos:6835:/ window 50,50 jump 201.0
 399.7 "Sewage Deluge" #sync / 1[56]:[^:]*:Hippokampos:67F6:/
 418.2 "Tainted Flood" #sync / 1[56]:[^:]*:Hippokampos:6809:/
 426.1 "Spoken Cataract" #sync / 1[56]:[^:]*:Hippokampos:(67F7|67F8|67F9|67FD):/

--- a/ui/raidboss/data/06-ew/raid/p2n.txt
+++ b/ui/raidboss/data/06-ew/raid/p2n.txt
@@ -19,7 +19,7 @@ hideall "--sync--"
 84.6 "Sewage Deluge" sync / 1[56]:[^:]*:Hippokampos:67F6:/
 111.0 "Tainted Flood" sync / 1[56]:[^:]*:Hippokampos:6809:/
 126.9 "Predatory Sight" sync / 1[56]:[^:]*:Hippokampos:680B:/
-137.3 "Shockwave (knockback)" sync / 1[56]:[^:]*:Hippokampos:6807:/
+137.3 "Shockwave" sync / 1[56]:[^:]*:Hippokampos:6807:/
 148.6 "Dissociation" sync / 1[56]:[^:]*:Hippokampos:6804:/
 153.7 "--sync--" sync / 1[56]:[^:]*:Hippokampos:6805:/
 165.8 "Dissociation Dive" sync / 1[56]:[^:]*:Hippokampos:6806:/

--- a/ui/raidboss/data/06-ew/raid/p2n.txt
+++ b/ui/raidboss/data/06-ew/raid/p2n.txt
@@ -59,7 +59,7 @@ hideall "--sync--"
 371.8 "Murky Depths" sync / 1[56]:[^:]*:Hippokampos:680F:/
 383.1 "Doubled Impact" sync / 1[56]:[^:]*:Hippokampos:680E:/
 
-392.3 "--middle--" sync / 1[56]:[^:]*:Hippokampos:6835:/ jump 201.0
+392.3 "--middle--" sync / 1[56]:[^:]*:Hippokampos:6835:/ window 50,50 jump 588.3
 399.7 "Sewage Deluge" #sync / 1[56]:[^:]*:Hippokampos:67F6:/
 418.2 "Tainted Flood" #sync / 1[56]:[^:]*:Hippokampos:6809:/
 426.1 "Spoken Cataract" #sync / 1[56]:[^:]*:Hippokampos:(67F7|67F8|67F9|67FD):/

--- a/ui/raidboss/data/raidboss_manifest.txt
+++ b/ui/raidboss/data/raidboss_manifest.txt
@@ -380,5 +380,6 @@
 06-ew/trial/endsinger.txt
 06-ew/raid/p1n.ts
 06-ew/raid/p2n.ts
+06-ew/raid/p2n.txt
 06-ew/raid/p3n.ts
 06-ew/raid/p4n.ts

--- a/ui/raidboss/data/raidboss_manifest.txt
+++ b/ui/raidboss/data/raidboss_manifest.txt
@@ -379,6 +379,7 @@
 06-ew/trial/endsinger.ts
 06-ew/trial/endsinger.txt
 06-ew/raid/p1n.ts
+06-ew/raid/p1n.txt
 06-ew/raid/p2n.ts
 06-ew/raid/p2n.txt
 06-ew/raid/p3n.ts


### PR DESCRIPTION
I didn't realize renaming the branch would remove the pr.
Originally just had p2n, but decided to work out p1n as it wasn't up yet.

Some comments for P1N:
- ~~Hot Spell/Cold Spell shortened to Hot/Cold as it is similar to DRS Hot/Cold.~~ **EDIT:** Updated
- ~~Not to sure if we want to do something with 'unknown_6d15', a lot of parties don't know they can stack to prevent the knockback, but in normal arms length/surecast is up every cast...~~ **EDIT:** Updated
- I favored the visible cast name over the Gaoler's Flail cast for the later Aetherflail cast.
- I think the third gaoler's flail does not have a pair and that the last atherflail is paired with a gaoler's flail. The other pairs are their own sets?