### PR TITLE
jobs: AST: Minor Arcana support and Sign improve

### DIFF
--- a/plugin/CactbotEventSource/FFXIVProcessIntl.cs
+++ b/plugin/CactbotEventSource/FFXIVProcessIntl.cs
@@ -718,6 +718,7 @@ namespace Cactbot {
         Celestial = 3,
       }
 
+      [NonSerialized]
       [FieldOffset(0x04)]
       private byte _heldCard;
 

--- a/plugin/CactbotEventSource/FFXIVProcessIntl.cs
+++ b/plugin/CactbotEventSource/FFXIVProcessIntl.cs
@@ -707,6 +707,8 @@ namespace Cactbot {
         Spear = 4,
         Ewer = 5,
         Spire = 6,
+        Lord = 0x70,
+        Lady = 0x80,
       }
 
       public enum Arcanum : byte {
@@ -717,7 +719,7 @@ namespace Cactbot {
       }
 
       [FieldOffset(0x04)]
-      private Card _heldCard;
+      private byte _heldCard;
 
       [NonSerialized]
       [FieldOffset(0x05)]
@@ -733,7 +735,13 @@ namespace Cactbot {
 
       public string heldCard {
         get {
-          return _heldCard.ToString();
+          return ((Card)(_heldCard & 0xF)).ToString();
+        }
+      }
+
+      public string crownCard {
+        get {
+          return ((Card)(_heldCard & 0xF0)).ToString();
         }
       }
 

--- a/types/event.d.ts
+++ b/types/event.d.ts
@@ -43,6 +43,7 @@ export interface JobDetail {
   };
   'AST': {
     heldCard: 'Balance' | 'Bole' | 'Arrow' | 'Spear' | 'Ewer' | 'Spire';
+    crownCard: 'Lord' | 'Lady';
     arcanums: ('Solar' | 'Lunar' | 'Celestial')[];
   };
   'SGE': {

--- a/ui/jobs/components/ast.ts
+++ b/ui/jobs/components/ast.ts
@@ -62,9 +62,9 @@ export class AST5xComponent extends BaseComponent {
     if (card in cardsMap)
       cardParent.classList.add(cardsMap[card].bonus);
 
-    // Show whether you already have bars seal
-    // O means it's OK to play bars card
-    // X means don't play bars card directly if time permits
+    // Show whether you already have this seal
+    // O means it's OK to play this card
+    // X means don't play this card directly if time permits
     if (!cardsMap[card])
       this.cardBox.innerText = '';
     else if (seals.includes(cardsMap[card].seal))
@@ -121,9 +121,7 @@ export class ASTComponent extends BaseComponent {
   lucidBox: TimerBox;
   cardBox: ResourceBox;
   minorBox: ResourceBox;
-  sign1: HTMLDivElement;
-  sign2: HTMLDivElement;
-  sign3: HTMLDivElement;
+  signs: HTMLElement[] = [];
 
   constructor(o: ComponentInterface) {
     super(o);
@@ -152,26 +150,27 @@ export class ASTComponent extends BaseComponent {
       classList: ['ast-color-card'],
     });
 
+    // Sign
     const stacksContainer = document.createElement('div');
     stacksContainer.id = 'ast-stacks';
     stacksContainer.classList.add('stacks');
+    this.bars.addJobBarContainer().appendChild(stacksContainer);
     const signContainer = document.createElement('div');
     signContainer.id = 'ast-stacks-sign';
     stacksContainer.appendChild(signContainer);
-    this.bars.addJobBarContainer().appendChild(stacksContainer);
-    this.sign1 = document.createElement('div');
-    this.sign2 = document.createElement('div');
-    this.sign3 = document.createElement('div');
 
-    this.sign1.id = 'ast-stacks-sign1';
-    this.sign2.id = 'ast-stacks-sign2';
-    this.sign3.id = 'ast-stacks-sign3';
-    [this.sign1, this.sign2, this.sign3].forEach((e) => signContainer.appendChild(e));
+    for (let i = 0; i < 3; ++i) {
+      const d = document.createElement('div');
+      signContainer.appendChild(d);
+      this.signs.push(d);
+    }
+    this.signs.reverse();
 
     this.reset();
   }
 
   override onJobDetailUpdate(jobDetail: JobDetail['AST']): void {
+    // Minor Arcana, ↑ = lord, + = lady
     const minor = jobDetail.crownCard;
     this.minorBox.parentNode.classList.toggle('lord', minor === 'Lord');
     this.minorBox.parentNode.classList.toggle('lady', minor === 'Lady');
@@ -191,9 +190,9 @@ export class ASTComponent extends BaseComponent {
     if (card in cardsMap)
       cardParent.classList.add(cardsMap[card].bonus);
 
-    // Show whether you already have bars seal
-    // O means it's OK to play bars card
-    // X means don't play bars card directly if time permits
+    // Show whether you already have this seal
+    // ○ means it's OK to play this card
+    // × means you'd better redraw if possible
     if (!cardsMap[card])
       this.cardBox.innerText = '';
     else if (sign.includes(cardsMap[card].seal))
@@ -201,19 +200,11 @@ export class ASTComponent extends BaseComponent {
     else
       this.cardBox.innerText = '○';
 
-    const signlist = sign.toString().split(',');
-    this.sign1.classList.remove('Solar', 'Lunar', 'Celestial');
-    this.sign2.classList.remove('Solar', 'Lunar', 'Celestial');
-    this.sign3.classList.remove('Solar', 'Lunar', 'Celestial');
-    if (signlist.length === 1) {
-      this.sign3.classList.add(signlist[0] ?? '');
-    } else if (signlist.length === 2) {
-      this.sign2.classList.add(signlist[0] ?? '');
-      this.sign3.classList.add(signlist[1] ?? '');
-    } else if (signlist.length === 3) {
-      this.sign1.classList.add(signlist[0] ?? '');
-      this.sign2.classList.add(signlist[1] ?? '');
-      this.sign3.classList.add(signlist[2] ?? '');
+    const signlist = sign.toString().split(',').reverse();
+    for (let i = 0; i < 3; ++i) {
+      this.signs[i]?.classList.remove('Solar', 'Lunar', 'Celestial');
+      if (signlist.length > i && signlist[0] !== '')
+        this.signs[i]?.classList.add(signlist[i] ?? '');
     }
   }
 

--- a/ui/jobs/components/ast.ts
+++ b/ui/jobs/components/ast.ts
@@ -14,6 +14,11 @@ const cardsMap = {
   'Spire': { 'bonus': 'range', 'seal': 'Celestial' },
 } as const;
 
+const minorMap = {
+  'Lord': '↑',
+  'Lady': '＋',
+} as const;
+
 export class AST5xComponent extends BaseComponent {
   combustBox: TimerBox;
   drawBox: TimerBox;
@@ -76,10 +81,7 @@ export class AST5xComponent extends BaseComponent {
     // Turn green when you have all 3 kinds of seal
     const sealCount = new Set(seals).size;
     this.sealBox.innerText = sealCount.toString();
-    if (sealCount === 3)
-      this.sealBox.parentNode.classList.add('ready');
-    else
-      this.sealBox.parentNode.classList.remove('ready');
+    this.sealBox.parentNode.classList.toggle('ready', sealCount === 3);
   }
 
   override onUseAbility(id: string): void {
@@ -173,12 +175,7 @@ export class ASTComponent extends BaseComponent {
     const minor = jobDetail.crownCard;
     this.minorBox.parentNode.classList.toggle('lord', minor === 'Lord');
     this.minorBox.parentNode.classList.toggle('lady', minor === 'Lady');
-    if (minor === 'Lord')
-      this.minorBox.innerText = '↑';
-    else if (minor === 'Lady')
-      this.minorBox.innerText = '＋';
-    else
-      this.minorBox.innerText = '';
+    this.minorBox.innerText = minorMap[minor] ?? '';
 
     const card = jobDetail.heldCard;
     const sign = jobDetail.arcanums;
@@ -199,12 +196,12 @@ export class ASTComponent extends BaseComponent {
     else
       this.cardBox.innerText = '○';
 
-    for (let i = 0; i < 3; ++i) {
-      this.signs[i]?.classList.remove('Solar', 'Lunar', 'Celestial');
+    this.signs.forEach((elem, i) => {
+      elem.classList.remove('Solar', 'Lunar', 'Celestial');
       const asign = sign[i];
       if (asign)
-        this.signs[i]?.classList.add(asign);
-    }
+        elem.classList.add(asign);
+    });
   }
 
   override onUseAbility(id: string): void {

--- a/ui/jobs/components/ast.ts
+++ b/ui/jobs/components/ast.ts
@@ -164,7 +164,6 @@ export class ASTComponent extends BaseComponent {
       signContainer.appendChild(d);
       this.signs.push(d);
     }
-    this.signs.reverse();
 
     this.reset();
   }
@@ -200,11 +199,11 @@ export class ASTComponent extends BaseComponent {
     else
       this.cardBox.innerText = '○';
 
-    const signlist = sign.toString().split(',').reverse();
     for (let i = 0; i < 3; ++i) {
       this.signs[i]?.classList.remove('Solar', 'Lunar', 'Celestial');
-      if (signlist.length > i && signlist[0] !== '')
-        this.signs[i]?.classList.add(signlist[i] ?? '');
+      const asign = sign[i];
+      if (asign)
+        this.signs[i]?.classList.add(asign);
     }
   }
 

--- a/ui/jobs/components/ast.ts
+++ b/ui/jobs/components/ast.ts
@@ -14,6 +14,121 @@ const cardsMap = {
   'Spire': { 'bonus': 'range', 'seal': 'Celestial' },
 } as const;
 
+export class AST5xComponent extends BaseComponent {
+  combustBox: TimerBox;
+  drawBox: TimerBox;
+  lucidBox: TimerBox;
+  cardBox: ResourceBox;
+  sealBox: ResourceBox;
+
+  constructor(o: ComponentInterface) {
+    super(o);
+
+    this.combustBox = this.bars.addProcBox({
+      id: 'ast-procs-combust',
+      fgColor: 'ast-color-combust',
+      notifyWhenExpired: true,
+    });
+
+    this.drawBox = this.bars.addProcBox({
+      id: 'ast-procs-draw',
+      fgColor: 'ast-color-draw',
+    });
+
+    this.lucidBox = this.bars.addProcBox({
+      id: 'ast-procs-luciddreaming',
+      fgColor: 'ast-color-lucid',
+    });
+
+    this.cardBox = this.bars.addResourceBox({
+      classList: ['ast-color-card'],
+    });
+
+    this.sealBox = this.bars.addResourceBox({
+      classList: ['ast-color-seal'],
+    });
+
+    this.reset();
+  }
+
+  override onJobDetailUpdate(jobDetail: JobDetail['AST']): void {
+    const card = jobDetail.heldCard;
+    const seals = jobDetail.arcanums;
+
+    // Show on which kind of jobs your card plays better by color
+    // Blue on melee, purple on ranged, and grey when no card
+    const cardParent = this.cardBox.parentNode;
+    cardParent.classList.remove('melee', 'range');
+    if (card in cardsMap)
+      cardParent.classList.add(cardsMap[card].bonus);
+
+    // Show whether you already have bars seal
+    // O means it's OK to play bars card
+    // X means don't play bars card directly if time permits
+    if (!cardsMap[card])
+      this.cardBox.innerText = '';
+    else if (seals.includes(cardsMap[card].seal))
+      this.cardBox.innerText = 'X';
+    else
+      this.cardBox.innerText = 'O';
+
+    if (this.is5x) {
+      // Show how many kind of seals you already have
+      // Turn green when you have all 3 kinds of seal
+      const sealCount = new Set(seals).size;
+      this.sealBox.innerText = sealCount.toString();
+      if (sealCount === 3)
+        this.sealBox.parentNode.classList.add('ready');
+      else
+        this.sealBox.parentNode.classList.remove('ready');
+    } else {
+      // Show how many seals you already have
+      // Turn green when you have 3 seals
+      const sealCount = seals.length;
+      this.sealBox.innerText = sealCount.toString();
+      if (sealCount === 3)
+        this.sealBox.parentNode.classList.add('ready');
+      else
+        this.sealBox.parentNode.classList.remove('ready');
+    }
+  }
+
+  override onUseAbility(id: string): void {
+    switch (id) {
+      case kAbility.Combust2:
+      case kAbility.Combust3:
+        this.combustBox.duration = 30;
+        break;
+      case kAbility.Combust:
+        this.combustBox.duration = 18;
+        break;
+      case kAbility.Draw:
+        if (this.is5x)
+          this.drawBox.duration = 30;
+        else
+          this.drawBox.duration = 30 + this.drawBox.value;
+        break;
+      case kAbility.LucidDreaming:
+        this.lucidBox.duration = 60;
+        break;
+    }
+  }
+  override onStatChange({ gcdSpell }: { gcdSpell: number }): void {
+    this.combustBox.valuescale = gcdSpell;
+    this.combustBox.threshold = gcdSpell + 1;
+    this.drawBox.valuescale = gcdSpell;
+    this.drawBox.threshold = gcdSpell + 1;
+    this.lucidBox.valuescale = gcdSpell;
+    this.lucidBox.threshold = gcdSpell + 1;
+  }
+
+  override reset(): void {
+    this.combustBox.duration = 0;
+    this.drawBox.duration = 0;
+    this.lucidBox.duration = 0;
+  }
+}
+
 export class ASTComponent extends BaseComponent {
   combustBox: TimerBox;
   drawBox: TimerBox;

--- a/ui/jobs/components/ast.ts
+++ b/ui/jobs/components/ast.ts
@@ -72,25 +72,14 @@ export class AST5xComponent extends BaseComponent {
     else
       this.cardBox.innerText = 'O';
 
-    if (this.is5x) {
-      // Show how many kind of seals you already have
-      // Turn green when you have all 3 kinds of seal
-      const sealCount = new Set(seals).size;
-      this.sealBox.innerText = sealCount.toString();
-      if (sealCount === 3)
-        this.sealBox.parentNode.classList.add('ready');
-      else
-        this.sealBox.parentNode.classList.remove('ready');
-    } else {
-      // Show how many seals you already have
-      // Turn green when you have 3 seals
-      const sealCount = seals.length;
-      this.sealBox.innerText = sealCount.toString();
-      if (sealCount === 3)
-        this.sealBox.parentNode.classList.add('ready');
-      else
-        this.sealBox.parentNode.classList.remove('ready');
-    }
+    // Show how many kind of seals you already have
+    // Turn green when you have all 3 kinds of seal
+    const sealCount = new Set(seals).size;
+    this.sealBox.innerText = sealCount.toString();
+    if (sealCount === 3)
+      this.sealBox.parentNode.classList.add('ready');
+    else
+      this.sealBox.parentNode.classList.remove('ready');
   }
 
   override onUseAbility(id: string): void {
@@ -103,10 +92,7 @@ export class AST5xComponent extends BaseComponent {
         this.combustBox.duration = 18;
         break;
       case kAbility.Draw:
-        if (this.is5x)
-          this.drawBox.duration = 30;
-        else
-          this.drawBox.duration = 30 + this.drawBox.value;
+        this.drawBox.duration = 30;
         break;
       case kAbility.LucidDreaming:
         this.lucidBox.duration = 60;

--- a/ui/jobs/components/index.ts
+++ b/ui/jobs/components/index.ts
@@ -9,7 +9,7 @@ import { JobsOptions } from '../jobs_options';
 import { Player } from '../player';
 import { doesJobNeedMPBar, isPvPZone, RegexesHolder } from '../utils';
 
-import { ASTComponent } from './ast';
+import { AST5xComponent, ASTComponent } from './ast';
 import { BaseComponent, ComponentInterface, ShouldShow } from './base';
 import { BLMComponent } from './blm';
 import { BLUComponent } from './blu';
@@ -131,6 +131,8 @@ export class ComponentManager {
     if (this.o.is5x) {
       if (job === 'SMN')
         return new SMN5xComponent(this.o);
+      if (job === 'AST')
+        return new AST5xComponent(this.o);
     }
 
     const Component = ComponentMap[job];

--- a/ui/jobs/jobs.css
+++ b/ui/jobs/jobs.css
@@ -320,7 +320,6 @@ div.justbuffs div#procs-container {
   background-color: rgb(125, 250, 250);
 }
 
-
 #sge-stacks-addersgall > div.active {
   background-color: rgb(120, 170, 250);
 }

--- a/ui/jobs/jobs.css
+++ b/ui/jobs/jobs.css
@@ -308,41 +308,18 @@ div.justbuffs div#procs-container {
   background-color: rgb(190, 43, 30);
 }
 
-#ast-stacks-sign1.Solar {
+#ast-stacks-sign > div.Solar {
   background-color: rgb(255, 0, 0);
 }
 
-#ast-stacks-sign1.Lunar {
+#ast-stacks-sign > div.Lunar {
   background-color: rgb(222, 195, 95);
 }
 
-#ast-stacks-sign1.Celestial {
+#ast-stacks-sign > div.Celestial {
   background-color: rgb(125, 250, 250);
 }
 
-#ast-stacks-sign2.Solar {
-  background-color: rgb(255, 0, 0);
-}
-
-#ast-stacks-sign2.Lunar {
-  background-color: rgb(222, 195, 95);
-}
-
-#ast-stacks-sign2.Celestial {
-  background-color: rgb(125, 250, 250);
-}
-
-#ast-stacks-sign3.Solar {
-  background-color: rgb(255, 0, 0);
-}
-
-#ast-stacks-sign3.Lunar {
-  background-color: rgb(222, 195, 95);
-}
-
-#ast-stacks-sign3.Celestial {
-  background-color: rgb(125, 250, 250);
-}
 
 #sge-stacks-addersgall > div.active {
   background-color: rgb(120, 170, 250);

--- a/ui/jobs/jobs.css
+++ b/ui/jobs/jobs.css
@@ -308,6 +308,42 @@ div.justbuffs div#procs-container {
   background-color: rgb(190, 43, 30);
 }
 
+#ast-stacks-sign1.Solar {
+  background-color: rgb(255, 0, 0);
+}
+
+#ast-stacks-sign1.Lunar {
+  background-color: rgb(222, 195, 95);
+}
+
+#ast-stacks-sign1.Celestial {
+  background-color: rgb(125, 250, 250);
+}
+
+#ast-stacks-sign2.Solar {
+  background-color: rgb(255, 0, 0);
+}
+
+#ast-stacks-sign2.Lunar {
+  background-color: rgb(222, 195, 95);
+}
+
+#ast-stacks-sign2.Celestial {
+  background-color: rgb(125, 250, 250);
+}
+
+#ast-stacks-sign3.Solar {
+  background-color: rgb(255, 0, 0);
+}
+
+#ast-stacks-sign3.Lunar {
+  background-color: rgb(222, 195, 95);
+}
+
+#ast-stacks-sign3.Celestial {
+  background-color: rgb(125, 250, 250);
+}
+
 #sge-stacks-addersgall > div.active {
   background-color: rgb(120, 170, 250);
 }
@@ -647,6 +683,14 @@ div.justbuffs div#procs-container {
 
 .ast-color-lucid {
   background-color: rgb(227, 148, 210);
+}
+
+.ast-color-card.lady {
+  background-color: rgb(200, 160, 200);
+}
+
+.ast-color-card.lord {
+  background-color: rgb(200, 70, 70);
 }
 
 /* SGE */

--- a/ui/jobs/jobs.css
+++ b/ui/jobs/jobs.css
@@ -309,7 +309,7 @@ div.justbuffs div#procs-container {
 }
 
 #ast-stacks-sign > div.Solar {
-  background-color: rgb(255, 0, 0);
+  background-color: rgb(190, 43, 30);
 }
 
 #ast-stacks-sign > div.Lunar {

--- a/ui/test/test.ts
+++ b/ui/test/test.ts
@@ -99,7 +99,9 @@ addOverlayListener('onPlayerChangedEvent', (e) => {
     } else if (detail.job === 'ACN' && detail.jobDetail) {
       jobInfo.innerText = detail.jobDetail.aetherflowStacks.toString();
     } else if (detail.job === 'AST' && detail.jobDetail) {
-      jobInfo.innerText = `${detail.jobDetail.heldCard} [${detail.jobDetail.arcanums.join(', ')}]`;
+      jobInfo.innerText = `${detail.jobDetail.heldCard} | ${detail.jobDetail.crownCard} | [${
+        detail.jobDetail.arcanums.join(', ')
+      }]`;
     } else if (detail.job === 'MNK' && detail.jobDetail) {
       jobInfo.innerText = `${detail.jobDetail.chakraStacks}`;
     } else if (detail.job === 'MCH' && detail.jobDetail) {


### PR DESCRIPTION
- Fix a mixture of Arcana and Minor Arcana in `Plugin`. This will fix `cardBox` error when you held a minor arcana. 
- Support Minor Arcana analysis in memory.
- Split EW AST from 5.x component.
- Change charactor to symbol `○` `×`, for `O` is too similar to `0`. (I'm not sure how it looks like in other language's PC?)
- Change Sign count box to show Minor Arcana. `↑` refers to Lord, and `＋` refers to Lady. (Is there any better symbols like sword and wings?)
- Add a stack-like gauge to show Sign. (When filling from left to right, users are more likely to feel full, but in-game gauge is from right to left)
![ast](https://user-images.githubusercontent.com/68432572/147722696-835affae-1fff-4949-9e84-871478740956.png)

