### PR TITLE
dps: increase max rdmty bars and allow scrolling

### DIFF
--- a/ui/dps/rdmty/dps.css
+++ b/ui/dps/rdmty/dps.css
@@ -1,7 +1,8 @@
 html {
   box-sizing: border-box;
   height: 100%;
-  overflow: hidden;
+  overflow-x: hidden;
+  overflow-y: auto;
 }
 
 #container {
@@ -351,4 +352,21 @@ li:last-child {
   left: 0;
   padding: 2px 4px;
   z-index: 100;
+}
+
+::-webkit-scrollbar {
+  width: 6px;
+  background-color: #00000;
+}
+
+::-webkit-scrollbar-thumb {
+  border-radius: 4px;
+  -webkit-box-shadow: inset 0 0 6px rgba(0,0,0,1);
+  background-color: #00000;
+}
+
+::-webkit-scrollbar-track {
+  -webkit-box-shadow: inset 0 0 6px rgba(0,0,0,0.5);
+  border-radius: 4px;
+  background-color: #0000;
 }

--- a/ui/dps/rdmty/dps.js
+++ b/ui/dps/rdmty/dps.js
@@ -325,7 +325,7 @@ Object.defineProperty(Combatants.prototype, 'render', {
   configurable: true,
   value: function() {
     const rows = [];
-    const maxRows = 12;
+    const maxRows = 50;
     const isDataArray = _.isArray(this.props.data);
     const dataArray = isDataArray ? this.props.data : Object.keys(this.props.data);
     const limit = Math.max(dataArray.length, maxRows);


### PR DESCRIPTION
Allows up to 49 bars to be shown in Rdmty along with scrolling of overflow. This is helpful to see your rank in large events such as alliance raids, bojan front, etc. It also allows for smaller windows sizes as now bars not fitting can be seen by scrolling the window.

Fixes #3455