### PR TITLE
raidboss: translate Korean logs into pre-6.x forms

### DIFF
--- a/ui/raidboss/common_replacement.ts
+++ b/ui/raidboss/common_replacement.ts
@@ -8,8 +8,7 @@ export const syncKeys = {
   // FIXME: This seal regex includes an optional second colon, as "0839::?"".
   // Once we have completely converted things for 6.0,
   // we should come back here and make the doubled colon non-optional.
-  seal:
-    '(?<=00:0839::?|00\\|[^|]*\\|0839\\|\\|)(.*) will be sealed off(?: in (?:[0-9]+ seconds)?)?',
+  seal: '(?<=00:0839::|00\\|[^|]*\\|0839\\|\\|)(.*) will be sealed off(?: in (?:[0-9]+ seconds)?)?',
   unseal: 'is no longer sealed',
   engage: 'Engage!',
 };
@@ -453,3 +452,13 @@ export const partialCommonReplacementKeys = [
   textKeys.Healer,
   textKeys.DPS,
 ];
+
+// Replacement when using Korean language in the parser, as the Korean version
+// does not have the 6.x changes from Ravahn yet.
+// These are applied after other translations and don't count for collisions.
+// TODO: this misses a few things like 1A lines in a7s/o7n/o7s.
+export const backCompatParsedSyncReplace: { [replaceKey: string]: string } = {
+  ' 00:\\[\\^:\\]\\*:': ' 00:',
+  ' 00:0839::': ' 00:0839:',
+  ' 14:\\[\\^:\\]\\*:([^:]*):([^:]*):': ':$2:$1',
+};

--- a/ui/raidboss/timeline_parser.ts
+++ b/ui/raidboss/timeline_parser.ts
@@ -3,7 +3,7 @@ import { UnreachableCode } from '../../resources/not_reached';
 import Regexes from '../../resources/regexes';
 import { LooseTimelineTrigger, TriggerAutoConfig } from '../../types/trigger';
 
-import { commonReplacement } from './common_replacement';
+import { backCompatParsedSyncReplace, commonReplacement } from './common_replacement';
 import defaultOptions, { RaidbossOptions } from './raidboss_options';
 
 export type TimelineReplacement = {
@@ -388,15 +388,22 @@ export class TimelineParser {
     }
     // Common Replacements
     const replacement = commonReplacement[replaceKey];
-    if (!replacement)
-      return text;
-    for (const [key, value] of Object.entries(replacement)) {
+    for (const [key, value] of Object.entries(replacement ?? {})) {
       const repl = value[replaceLang];
       if (!repl)
         continue;
       const regex = isGlobal ? Regexes.parseGlobal(key) : Regexes.parse(key);
       text = text.replace(regex, repl);
     }
+
+    // Backwards compat replacements for Korean parsed log lines before 6.x changes.
+    if (replaceLang === 'ko' && replaceKey === 'replaceSync') {
+      for (const [key, repl] of Object.entries(backCompatParsedSyncReplace)) {
+        const regex = isGlobal ? Regexes.parseGlobal(key) : Regexes.parse(key);
+        text = text.replace(regex, repl);
+      }
+    }
+
     return text;
   }
 


### PR DESCRIPTION
The international version of the ffxiv act plugin has changes to
log lines in the 2.6.x.x branch.  However, these changes have not
been merged back into the Korean plugin yet.  As timelines are
the only place that cactbot still uses parsed log lines, add
this additional edge case translation for Korean regexes.
This changes them back to the pre-6.x forms.  It doesn't cover
everything, but should cover enough that it's worth merging.

Tested by running `npm run util`, and looking at a few timelines
translated into Korean.

Maybe addresses #3949.

Fixes #4109 (in a better way).

Partially addresses #4102.