### PR TITLE
raidboss: fix EW hunts wrong ZoneId

### DIFF
--- a/ui/raidboss/data/06-ew/hunts/ultima_thule.ts
+++ b/ui/raidboss/data/06-ew/hunts/ultima_thule.ts
@@ -11,7 +11,7 @@ import { TriggerSet } from '../../../../../types/trigger';
 export type Data = RaidbossData;
 
 const triggerSet: TriggerSet<Data> = {
-  zoneId: ZoneId.Elpis,
+  zoneId: ZoneId.UltimaThule,
   triggers: [
     {
       id: 'Hunt Arch-Eta Energy Wave',


### PR DESCRIPTION
Fixes #3994 incorrect zone id for Ultima Thule hunts.