### PR TITLE
resources: Convert Simple HTML Text to InnerText

### DIFF
--- a/resources/resourcebar.ts
+++ b/resources/resourcebar.ts
@@ -550,27 +550,27 @@ export default class ResourceBar extends HTMLElement {
     const totalPercent = totalValue / this._maxValue;
     if (this._leftText !== '') {
       if (this._leftText === 'value')
-        this.leftTextElement.innerHTML = totalValue.toString();
+        this.leftTextElement.innerText = totalValue.toString();
       else if (this._leftText === 'maxvalue')
-        this.leftTextElement.innerHTML = `${totalValue} / ${this._maxValue}`;
+        this.leftTextElement.innerText = `${totalValue} / ${this._maxValue}`;
       else if (this._leftText === 'percent')
-        this.leftTextElement.innerHTML = `${(totalPercent * 100).toFixed()} %`;
+        this.leftTextElement.innerText = `${(totalPercent * 100).toFixed()} %`;
     }
     if (this._centerText !== '') {
       if (this._centerText === 'value')
-        this.centerTextElement.innerHTML = totalValue.toString();
+        this.centerTextElement.innerText = totalValue.toString();
       else if (this._centerText === 'maxvalue')
-        this.centerTextElement.innerHTML = `${totalValue} / ${this._maxValue}`;
+        this.centerTextElement.innerText = `${totalValue} / ${this._maxValue}`;
       else if (this._centerText === 'percent')
-        this.centerTextElement.innerHTML = `${(totalPercent * 100).toFixed()} %`;
+        this.centerTextElement.innerText = `${(totalPercent * 100).toFixed()} %`;
     }
     if (this._rightText !== '') {
       if (this._rightText === 'value')
-        this.rightTextElement.innerHTML = totalValue.toString();
+        this.rightTextElement.innerText = totalValue.toString();
       else if (this._rightText === 'maxvalue')
-        this.rightTextElement.innerHTML = `${totalValue} / ${this._maxValue}`;
+        this.rightTextElement.innerText = `${totalValue} / ${this._maxValue}`;
       else if (this._rightText === 'percent')
-        this.rightTextElement.innerHTML = `${(totalPercent * 100).toFixed()} %`;
+        this.rightTextElement.innerText = `${(totalPercent * 100).toFixed()} %`;
     }
   }
 }

--- a/resources/timerbar.ts
+++ b/resources/timerbar.ts
@@ -537,33 +537,33 @@ export default class TimerBar extends HTMLElement {
     this.foregroundElement.style.transform = `scaleX(${percent.toFixed(3)})`;
     if (this._leftText !== '') {
       if (this._leftText === 'remain')
-        this.leftTextElement.innerHTML = displayRemain;
+        this.leftTextElement.innerText = displayRemain;
       else if (this._leftText === 'duration')
-        this.leftTextElement.innerHTML = `${displayRemain} / ${this._duration}`;
+        this.leftTextElement.innerText = `${displayRemain} / ${this._duration}`;
       else if (this._leftText === 'percent')
-        this.leftTextElement.innerHTML = `${(percent * 100).toFixed(1)} %`;
+        this.leftTextElement.innerText = `${(percent * 100).toFixed(1)} %`;
       else if (this._leftText === 'elapsed')
-        this.leftTextElement.innerHTML = displayElapsed;
+        this.leftTextElement.innerText = displayElapsed;
     }
     if (this._centerText !== '') {
       if (this._centerText === 'remain')
-        this.centerTextElement.innerHTML = displayRemain;
+        this.centerTextElement.innerText = displayRemain;
       else if (this._centerText === 'duration')
-        this.centerTextElement.innerHTML = `${displayRemain} / ${this._duration}`;
+        this.centerTextElement.innerText = `${displayRemain} / ${this._duration}`;
       else if (this._centerText === 'percent')
-        this.centerTextElement.innerHTML = `${(percent * 100).toFixed(1)} %`;
+        this.centerTextElement.innerText = `${(percent * 100).toFixed(1)} %`;
       else if (this._centerText === 'elapsed')
-        this.centerTextElement.innerHTML = displayElapsed;
+        this.centerTextElement.innerText = displayElapsed;
     }
     if (this._rightText !== '') {
       if (this._rightText === 'remain')
-        this.rightTextElement.innerHTML = displayRemain;
+        this.rightTextElement.innerText = displayRemain;
       else if (this._rightText === 'duration')
-        this.rightTextElement.innerHTML = `${displayRemain} / ${this._duration}`;
+        this.rightTextElement.innerText = `${displayRemain} / ${this._duration}`;
       else if (this._rightText === 'percent')
-        this.rightTextElement.innerHTML = `${(percent * 100).toFixed(1)} %`;
+        this.rightTextElement.innerText = `${(percent * 100).toFixed(1)} %`;
       else if (this._rightText === 'elapsed')
-        this.rightTextElement.innerHTML = displayElapsed;
+        this.rightTextElement.innerText = displayElapsed;
     }
   }
 


### PR DESCRIPTION
Convert simple text values from using innerHTML to innerText as it has a
significant impact on performance; the values being updated should only
be numbers or percentages and shouldn't need HTML values, even for
potentially custom content.