### PR TITLE
resources: Convert New Date to Date.now()

### DIFF
--- a/resources/timerbar.ts
+++ b/resources/timerbar.ts
@@ -164,7 +164,7 @@ export default class TimerBar extends HTMLElement {
   get value(): number {
     if (!this._start)
       return this._duration;
-    const elapsedMs = new Date().getTime() - this._start;
+    const elapsedMs = Date.now() - this._start;
     return Math.max(0, this._duration - (elapsedMs / 1000));
   }
 
@@ -175,7 +175,7 @@ export default class TimerBar extends HTMLElement {
   get elapsed(): number {
     if (!this._start)
       return 0;
-    return (new Date().getTime() - this._start) / 1000;
+    return (Date.now() - this._start) / 1000;
   }
 
   // If "right" then animates left-to-right (the default). If "left"
@@ -525,7 +525,7 @@ export default class TimerBar extends HTMLElement {
   }
 
   draw(): void {
-    const elapsedSec = (new Date().getTime() - this._start) / 1000;
+    const elapsedSec = (Date.now() - this._start) / 1000;
     const remainSec = Math.max(0, this._duration - elapsedSec);
     let percent = this._duration <= 0 ? 0 : remainSec / this._duration;
     // Keep it between 0 and 1.
@@ -585,7 +585,7 @@ export default class TimerBar extends HTMLElement {
 
   setvalue(remainSec: number): void {
     const elapsedSec = Math.max(0, this._duration - remainSec);
-    this._start = new Date().getTime() - (elapsedSec * 1000);
+    this._start = Date.now() - (elapsedSec * 1000);
 
     if (!this._connected)
       return;
@@ -598,7 +598,7 @@ export default class TimerBar extends HTMLElement {
   }
 
   advance(): void {
-    const elapsedSec = (new Date().getTime() - this._start) / 1000;
+    const elapsedSec = (Date.now() - this._start) / 1000;
     if (elapsedSec >= this._duration) {
       // Timer completed
       if (this._loop && this._duration > 0) {

--- a/resources/timerbox.ts
+++ b/resources/timerbox.ts
@@ -220,7 +220,7 @@ export default class TimerBox extends HTMLElement {
   get value(): number {
     if (!this._start)
       return this._duration;
-    const elapsedMs = new Date().getTime() - this._start;
+    const elapsedMs = Date.now() - this._start;
     return Math.max(0, this._duration - (elapsedMs / 1000));
   }
 
@@ -228,7 +228,7 @@ export default class TimerBox extends HTMLElement {
   get elapsed(): number {
     if (!this._start)
       return 0;
-    return (new Date().getTime() - this._start) / 1000;
+    return (Date.now() - this._start) / 1000;
   }
 
   // Whether to round up the value to the nearest integer before thresholding.
@@ -451,7 +451,7 @@ export default class TimerBox extends HTMLElement {
     if (!this._connected)
       return;
 
-    const elapsedSec = (new Date().getTime() - this._start) / 1000;
+    const elapsedSec = (Date.now() - this._start) / 1000;
     const remainingSec = Math.max(0, this._duration - elapsedSec);
     let rounded;
     if (this._roundUpThreshold)
@@ -499,7 +499,7 @@ export default class TimerBox extends HTMLElement {
     this.classList.remove('expired');
     this._notifyThresholdCallbacks = true;
 
-    this._start = new Date().getTime();
+    this._start = Date.now();
 
     for (const f of this._onResetCallbacks)
       window.setTimeout(f, 0);
@@ -508,7 +508,7 @@ export default class TimerBox extends HTMLElement {
   }
 
   advance(): void {
-    const elapsedSec = (new Date().getTime() - this._start) / 1000;
+    const elapsedSec = (Date.now() - this._start) / 1000;
     if (elapsedSec >= this._duration) {
       // We need to check for this._duration > 0 here, as for undocumented reason the
       // duration of a timerbox is always set to zero before it is set to the

--- a/resources/timericon.ts
+++ b/resources/timericon.ts
@@ -426,7 +426,7 @@ export default class TimerIcon extends HTMLElement {
     if (!this._connected)
       return;
 
-    this.startTimeMs = +new Date();
+    this.startTimeMs = Date.now();
 
     this.rootElement.style.display = 'block';
     clearTimeout(this._hideTimer ?? 0);
@@ -439,7 +439,7 @@ export default class TimerIcon extends HTMLElement {
   }
 
   advance(): void {
-    this._value = this._duration + (this.startTimeMs - new Date().getTime()) / 1000;
+    this._value = this._duration + (this.startTimeMs - Date.now()) / 1000;
     if (this._value <= 0) {
       this._value = 0;
       if (this._hideAfter >= 0) {


### PR DESCRIPTION
Convert new Date instances that are trying to get current time to
instead use Date.now(). As proposed in #3824.