### PR TITLE
jobs: RDM: EW changes

### DIFF
--- a/ui/jobs/components/index.ts
+++ b/ui/jobs/components/index.ts
@@ -22,7 +22,7 @@ import { MCHComponent } from './mch';
 import { MNKComponent } from './mnk';
 import { NINComponent } from './nin';
 import { PLDComponent } from './pld';
-import { RDMComponent } from './rdm';
+import { RDM5xComponent, RDMComponent } from './rdm';
 import { RPRComponent } from './rpr';
 import { SAMComponent } from './sam';
 import { SCHComponent } from './sch';
@@ -133,6 +133,8 @@ export class ComponentManager {
         return new SMN5xComponent(this.o);
       if (job === 'AST')
         return new AST5xComponent(this.o);
+      if (job === 'RDM')
+        return new RDM5xComponent(this.o);
     }
 
     const Component = ComponentMap[job];

--- a/ui/jobs/components/rdm.ts
+++ b/ui/jobs/components/rdm.ts
@@ -141,11 +141,11 @@ export class RDMComponent extends BaseComponent {
     super(o);
     const container = this.bars.addJobBarContainer();
 
-    const incs = 20;
+    const incs = 25;
     for (let i = 0; i < 100; i += incs) {
       const marker = document.createElement('div');
       marker.classList.add('marker');
-      marker.classList.add((i % 40 === 0) ? 'odd' : 'even');
+      marker.classList.add((i % 50 === 0) ? 'odd' : 'even');
       container.appendChild(marker);
       marker.style.left = `${i}%`;
       marker.style.width = `${incs}%`;

--- a/ui/jobs/components/rdm.ts
+++ b/ui/jobs/components/rdm.ts
@@ -135,7 +135,8 @@ export class RDMComponent extends BaseComponent {
   blackManaBox: ResourceBox;
   whiteProc: TimerBox;
   blackProc: TimerBox;
-  lucidBox: TimerBox;
+  flecheBox: TimerBox;
+  contreSixteBox: TimerBox;
 
   constructor(o: ComponentInterface) {
     super(o);
@@ -184,21 +185,30 @@ export class RDMComponent extends BaseComponent {
     });
     this.blackProc.bigatzero = false;
 
-    this.lucidBox = this.bars.addProcBox({
-      id: 'rdm-procs-lucid',
-      fgColor: 'rdm-color-lucid',
+    this.flecheBox = this.bars.addProcBox({
+      id: 'rdm-procs-fleche',
+      fgColor: 'rdm-color-fleche',
+    });
+
+    this.contreSixteBox = this.bars.addProcBox({
+      id: 'rdm-procs-contresixte',
+      fgColor: 'rdm-color-contresixte',
     });
 
     this.reset();
   }
 
   override onUseAbility(id: string): void {
-    if (id === kAbility.LucidDreaming)
-      this.lucidBox.duration = 60;
+    if (id === kAbility.Fleche)
+      this.flecheBox.duration = 25;
+    if (id === kAbility.ContreSixte)
+      this.contreSixteBox.duration = this.player.level < 74 ? 45 : 35;
   }
   override onStatChange({ gcdSpell }: { gcdSpell: number }): void {
-    this.lucidBox.valuescale = gcdSpell;
-    this.lucidBox.threshold = gcdSpell + 1;
+    this.flecheBox.valuescale = gcdSpell;
+    this.flecheBox.threshold = gcdSpell + 1;
+    this.contreSixteBox.valuescale = gcdSpell;
+    this.contreSixteBox.threshold = gcdSpell + 1;
   }
 
   override onJobDetailUpdate(jobDetail: JobDetail['RDM']): void {
@@ -242,7 +252,8 @@ export class RDMComponent extends BaseComponent {
   }
 
   override reset(): void {
-    this.lucidBox.duration = 0;
+    this.flecheBox.duration = 0;
+    this.contreSixteBox.duration = 0;
     this.whiteProc.duration = 0;
     this.blackProc.duration = 0;
   }

--- a/ui/jobs/components/rdm.ts
+++ b/ui/jobs/components/rdm.ts
@@ -233,11 +233,9 @@ export class RDMComponent extends BaseComponent {
 
   override onYouGainEffect(id: string, matches: PartialFieldMatches<'GainsEffect'>): void {
     if (id === EffectId.VerstoneReady)
-      this.whiteProc.duration = parseFloat(matches.duration ?? '0') - this.player.gcdSpell;
-    if (id === EffectId.VerfireReady) {
-      this.blackProc.duration = 0;
-      this.blackProc.duration = parseFloat(matches.duration ?? '0') - this.player.gcdSpell;
-    }
+      this.whiteProc.duration = parseFloat(matches.duration ?? '0') - (this.player.gcdSpell * 0.8 - 0.5);
+    if (id === EffectId.VerfireReady)
+      this.blackProc.duration = parseFloat(matches.duration ?? '0') - (this.player.gcdSpell * 0.8 - 0.5);
   }
   override onYouLoseEffect(id: string) :void {
     if (id === EffectId.VerstoneReady)

--- a/ui/jobs/components/rdm.ts
+++ b/ui/jobs/components/rdm.ts
@@ -8,7 +8,7 @@ import { PartialFieldMatches } from '../event_emitter';
 
 import { BaseComponent, ComponentInterface } from './base';
 
-export class RDMComponent extends BaseComponent {
+export class RDM5xComponent extends BaseComponent {
   whiteManaBar: ResourceBar;
   blackManaBar: ResourceBar;
   whiteManaBox: ResourceBox;
@@ -128,3 +128,122 @@ export class RDMComponent extends BaseComponent {
   }
 }
 
+export class RDMComponent extends BaseComponent {
+  whiteManaBar: ResourceBar;
+  blackManaBar: ResourceBar;
+  whiteManaBox: ResourceBox;
+  blackManaBox: ResourceBox;
+  whiteProc: TimerBox;
+  blackProc: TimerBox;
+  lucidBox: TimerBox;
+
+  constructor(o: ComponentInterface) {
+    super(o);
+    const container = this.bars.addJobBarContainer();
+
+    const incs = 20;
+    for (let i = 0; i < 100; i += incs) {
+      const marker = document.createElement('div');
+      marker.classList.add('marker');
+      marker.classList.add((i % 40 === 0) ? 'odd' : 'even');
+      container.appendChild(marker);
+      marker.style.left = `${i}%`;
+      marker.style.width = `${incs}%`;
+    }
+
+    this.whiteManaBar = this.bars.addResourceBar({
+      id: 'rdm-white-bar',
+      fgColor: 'rdm-color-white-mana',
+      maxvalue: 100,
+    });
+
+    this.blackManaBar = this.bars.addResourceBar({
+      id: 'rdm-black-bar',
+      fgColor: 'rdm-color-black-mana',
+      maxvalue: 100,
+    });
+
+    this.whiteManaBox = this.bars.addResourceBox({
+      classList: ['rdm-color-white-mana'],
+    });
+
+    this.blackManaBox = this.bars.addResourceBox({
+      classList: ['rdm-color-black-mana'],
+    });
+
+    this.whiteProc = this.bars.addProcBox({
+      id: 'rdm-procs-white',
+      fgColor: 'rdm-color-white-mana',
+      threshold: 1000,
+    });
+    this.whiteProc.bigatzero = false;
+    this.blackProc = this.bars.addProcBox({
+      id: 'rdm-procs-black',
+      fgColor: 'rdm-color-black-mana',
+      threshold: 1000,
+    });
+    this.blackProc.bigatzero = false;
+
+    this.lucidBox = this.bars.addProcBox({
+      id: 'rdm-procs-lucid',
+      fgColor: 'rdm-color-lucid',
+    });
+
+    this.reset();
+  }
+
+  override onUseAbility(id: string): void {
+    if (id === kAbility.LucidDreaming)
+      this.lucidBox.duration = 60;
+  }
+  override onStatChange({ gcdSpell }: { gcdSpell: number }): void {
+    this.lucidBox.valuescale = gcdSpell;
+    this.lucidBox.threshold = gcdSpell + 1;
+  }
+
+  override onJobDetailUpdate(jobDetail: JobDetail['RDM']): void {
+    const white = jobDetail.whiteMana.toString();
+    const black = jobDetail.blackMana.toString();
+
+    this.whiteManaBar.value = white;
+    this.blackManaBar.value = black;
+
+    if (this.whiteManaBox.innerText !== white) {
+      this.whiteManaBox.innerText = white;
+      const p = this.whiteManaBox.parentNode;
+      if (jobDetail.whiteMana < 80)
+        p.classList.add('dim');
+      else
+        p.classList.remove('dim');
+    }
+    if (this.blackManaBox.innerText !== black) {
+      this.blackManaBox.innerText = black;
+      const p = this.blackManaBox.parentNode;
+      if (jobDetail.blackMana < 80)
+        p.classList.add('dim');
+      else
+        p.classList.remove('dim');
+    }
+  }
+
+  override onYouGainEffect(id: string, matches: PartialFieldMatches<'GainsEffect'>): void {
+    if (id === EffectId.VerstoneReady)
+      this.whiteProc.duration = parseFloat(matches.duration ?? '0') - this.player.gcdSpell;
+    if (id === EffectId.VerfireReady) {
+      this.blackProc.duration = 0;
+      this.blackProc.duration = parseFloat(matches.duration ?? '0') - this.player.gcdSpell;
+    }
+  }
+  override onYouLoseEffect(id: string) :void {
+    if (id === EffectId.VerstoneReady)
+      this.whiteProc.duration = 0;
+    if (id === EffectId.VerfireReady)
+      this.blackProc.duration = 0;
+  }
+
+  override reset(): void {
+    this.lucidBox.duration = 0;
+    this.whiteProc.duration = 0;
+    this.blackProc.duration = 0;
+  }
+}

--- a/ui/jobs/components/rdm.ts
+++ b/ui/jobs/components/rdm.ts
@@ -5,6 +5,7 @@ import { JobDetail } from '../../../types/event';
 import { ResourceBox } from '../bars';
 import { kAbility } from '../constants';
 import { PartialFieldMatches } from '../event_emitter';
+import { computeBackgroundColorFrom } from '../utils';
 
 import { BaseComponent, ComponentInterface } from './base';
 
@@ -220,19 +221,13 @@ export class RDMComponent extends BaseComponent {
 
     if (this.whiteManaBox.innerText !== white) {
       this.whiteManaBox.innerText = white;
-      const p = this.whiteManaBox.parentNode;
-      if (jobDetail.whiteMana < 80)
-        p.classList.add('dim');
-      else
-        p.classList.remove('dim');
+      this.whiteManaBox.parentNode.classList.toggle('dim', jobDetail.whiteMana < 50);
+      this.whiteManaBar.fg = computeBackgroundColorFrom(this.whiteManaBar, jobDetail.whiteMana < 50 ? 'rdm-color-white-mana.dim' : 'rdm-color-white-mana');
     }
     if (this.blackManaBox.innerText !== black) {
       this.blackManaBox.innerText = black;
-      const p = this.blackManaBox.parentNode;
-      if (jobDetail.blackMana < 80)
-        p.classList.add('dim');
-      else
-        p.classList.remove('dim');
+      this.blackManaBox.parentNode.classList.toggle('dim', jobDetail.blackMana < 50);
+      this.blackManaBar.fg = computeBackgroundColorFrom(this.blackManaBar, jobDetail.blackMana < 50 ? 'rdm-color-black-mana.dim' : 'rdm-color-black-mana');
     }
   }
 

--- a/ui/jobs/components/rdm.ts
+++ b/ui/jobs/components/rdm.ts
@@ -138,6 +138,8 @@ export class RDMComponent extends BaseComponent {
   blackProc: TimerBox;
   flecheBox: TimerBox;
   contreSixteBox: TimerBox;
+  stacksContainer: HTMLDivElement;
+  manaStacks: HTMLElement[] = [];
 
   constructor(o: ComponentInterface) {
     super(o);
@@ -196,6 +198,20 @@ export class RDMComponent extends BaseComponent {
       fgColor: 'rdm-color-contresixte',
     });
 
+    this.stacksContainer = document.createElement('div');
+    this.stacksContainer.id = 'rdm-stacks';
+    this.stacksContainer.classList.add('stacks', 'hide');
+    this.bars.addJobBarContainer().appendChild(this.stacksContainer);
+    const manaStackContainer = document.createElement('div');
+    manaStackContainer.id = 'rdm-stacks-manastack';
+    this.stacksContainer.appendChild(manaStackContainer);
+
+    for (let i = 0; i < 3; ++i) {
+      const d = document.createElement('div');
+      manaStackContainer.appendChild(d);
+      this.manaStacks.push(d);
+    }
+
     this.reset();
   }
 
@@ -229,6 +245,14 @@ export class RDMComponent extends BaseComponent {
       this.blackManaBox.parentNode.classList.toggle('dim', jobDetail.blackMana < 50);
       this.blackManaBar.fg = computeBackgroundColorFrom(this.blackManaBar, jobDetail.blackMana < 50 ? 'rdm-color-black-mana.dim' : 'rdm-color-black-mana');
     }
+
+    this.stacksContainer.classList.toggle('hide', jobDetail.manaStacks === 0);
+    for (let i = 0; i < 3; ++i) {
+      if (jobDetail.manaStacks > i)
+        this.manaStacks[i]?.classList.add('active');
+      else
+        this.manaStacks[i]?.classList.remove('active');
+      }
   }
 
   override onYouGainEffect(id: string, matches: PartialFieldMatches<'GainsEffect'>): void {

--- a/ui/jobs/components/rdm.ts
+++ b/ui/jobs/components/rdm.ts
@@ -173,13 +173,13 @@ export class RDMComponent extends BaseComponent {
 
     this.whiteProc = this.bars.addProcBox({
       id: 'rdm-procs-white',
-      fgColor: 'rdm-color-white-mana',
+      fgColor: 'rdm-color-stone',
       threshold: 1000,
     });
     this.whiteProc.bigatzero = false;
     this.blackProc = this.bars.addProcBox({
       id: 'rdm-procs-black',
-      fgColor: 'rdm-color-black-mana',
+      fgColor: 'rdm-color-fire',
       threshold: 1000,
     });
     this.blackProc.bigatzero = false;

--- a/ui/jobs/constants.ts
+++ b/ui/jobs/constants.ts
@@ -277,6 +277,8 @@ export const kAbility = {
   EnchantedReprise: '4090',
   Embolden: '1D60',
   Manafication: '1D61',
+  Fleche: '1D5D',
+  ContreSixte: '1D5F',
   // BLU
   SongOfTorment: '2C7A',
   OffGuard: '2C93',

--- a/ui/jobs/jobs.css
+++ b/ui/jobs/jobs.css
@@ -1075,6 +1075,14 @@ div.justbuffs div#procs-container {
   background-color: rgb(227, 148, 210);
 }
 
+.rdm-color-stone {
+  background-color: rgb(250, 176, 73);
+}
+
+.rdm-color-fire {
+  background-color: rgb(240, 76, 0);
+}
+
 /* BLU */
 .blu-color-offguard {
   background-color: rgb(210, 255, 196);

--- a/ui/jobs/jobs.css
+++ b/ui/jobs/jobs.css
@@ -1083,6 +1083,14 @@ div.justbuffs div#procs-container {
   background-color: rgb(240, 76, 0);
 }
 
+.rdm-color-fleche {
+  background-color: rgb(25, 190, 255);
+}
+
+.rdm-color-contresixte {
+  background-color: rgb(30, 80, 170);
+}
+
 /* BLU */
 .blu-color-offguard {
   background-color: rgb(210, 255, 196);

--- a/ui/jobs/jobs.css
+++ b/ui/jobs/jobs.css
@@ -372,6 +372,10 @@ div.justbuffs div#procs-container {
   background-color: rgb(238, 234, 14);
 }
 
+#rdm-stacks-manastack > div.active {
+  background-color: rgb(255, 100, 100);
+}
+
 /* Procs */
 
 /*


### PR DESCRIPTION
- Adjust black and white mana related code
mana bar adjust to 25 per incs, and bright threshold change to 50
- Add fleche and contre sixte timer, also remove lucid dream.
white and black proc color are adjusted, for the black one cannot be distinguish from contre sixte.
- Adjust proc timer
it set to 30 - 1 gcd before, but cast time is 0.8 gcd, and proc will be comsumed 0.5s earlier before cast complete.
- Add mana stack guage
only shown when you have any.