### PR TITLE
raidboss: smileton fix duplicate knockback call

### DIFF
--- a/ui/raidboss/data/06-ew/dungeon/smileton.ts
+++ b/ui/raidboss/data/06-ew/dungeon/smileton.ts
@@ -26,10 +26,10 @@ const triggerSet: TriggerSet<Data> = {
     {
       id: 'Smileton Face Off My Lawn',
       type: 'StartsUsing',
-      netRegex: NetRegexes.startsUsing({ id: ['673E'], source: 'Face', capture: false }),
-      netRegexDe: NetRegexes.startsUsing({ id: ['673E'], source: 'Fratze', capture: false }),
-      netRegexFr: NetRegexes.startsUsing({ id: ['673E'], source: 'Visage Imperturbable', capture: false }),
-      netRegexJa: NetRegexes.startsUsing({ id: ['673E'], source: 'フェイス', capture: false }),
+      netRegex: NetRegexes.startsUsing({ id: '673E', source: 'Face', capture: false }),
+      netRegexDe: NetRegexes.startsUsing({ id: '673E', source: 'Fratze', capture: false }),
+      netRegexFr: NetRegexes.startsUsing({ id: '673E', source: 'Visage Imperturbable', capture: false }),
+      netRegexJa: NetRegexes.startsUsing({ id: '673E', source: 'フェイス', capture: false }),
       infoText: (_data, _matches, output) => output.text!(),
       outputStrings: {
         text: {

--- a/ui/raidboss/data/06-ew/dungeon/smileton.ts
+++ b/ui/raidboss/data/06-ew/dungeon/smileton.ts
@@ -26,11 +26,10 @@ const triggerSet: TriggerSet<Data> = {
     {
       id: 'Smileton Face Off My Lawn',
       type: 'StartsUsing',
-      netRegex: NetRegexes.startsUsing({ id: ['6C5E', '673E'], source: 'Face', capture: false }),
-      netRegexDe: NetRegexes.startsUsing({ id: ['6C5E', '673E'], source: 'Fratze', capture: false }),
-      netRegexFr: NetRegexes.startsUsing({ id: ['6C5E', '673E'], source: 'Visage Imperturbable', capture: false }),
-      netRegexJa: NetRegexes.startsUsing({ id: ['6C5E', '673E'], source: 'フェイス', capture: false }),
-      suppressSeconds: 1,
+      netRegex: NetRegexes.startsUsing({ id: ['673E'], source: 'Face', capture: false }),
+      netRegexDe: NetRegexes.startsUsing({ id: ['673E'], source: 'Fratze', capture: false }),
+      netRegexFr: NetRegexes.startsUsing({ id: ['673E'], source: 'Visage Imperturbable', capture: false }),
+      netRegexJa: NetRegexes.startsUsing({ id: ['673E'], source: 'フェイス', capture: false }),
       infoText: (_data, _matches, output) => output.text!(),
       outputStrings: {
         text: {

--- a/ui/raidboss/data/06-ew/dungeon/smileton.ts
+++ b/ui/raidboss/data/06-ew/dungeon/smileton.ts
@@ -30,6 +30,7 @@ const triggerSet: TriggerSet<Data> = {
       netRegexDe: NetRegexes.startsUsing({ id: ['6C5E', '673E'], source: 'Fratze', capture: false }),
       netRegexFr: NetRegexes.startsUsing({ id: ['6C5E', '673E'], source: 'Visage Imperturbable', capture: false }),
       netRegexJa: NetRegexes.startsUsing({ id: ['6C5E', '673E'], source: 'フェイス', capture: false }),
+      suppressSeconds: 1,
       infoText: (_data, _matches, output) => output.text!(),
       outputStrings: {
         text: {


### PR DESCRIPTION
The knockback call during the first boss is called out more than once simultaneously.

This is caused by the trigger checking for two spellids that go off simultaneously.

673E targets Face
6C5E targets players

suppressSeconds is one fix... an alternative would be to remove one of spellids? Looks like they both are always cast.