### PR TITLE
raidboss: Fix incorrect response for Violent Discharge

### DIFF
--- a/ui/raidboss/data/06-ew/dungeon/smileton.ts
+++ b/ui/raidboss/data/06-ew/dungeon/smileton.ts
@@ -163,7 +163,7 @@ const triggerSet: TriggerSet<Data> = {
       netRegexDe: NetRegexes.startsUsing({ id: '6752', source: 'Bittelächeln', capture: false }),
       netRegexFr: NetRegexes.startsUsing({ id: '6752', source: 'Béatotron', capture: false }),
       netRegexJa: NetRegexes.startsUsing({ id: '6752', source: 'ビッグチーズ', capture: false }),
-      response: Responses.goRight(),
+      response: Responses.aoe(),
     },
     {
       id: 'Smileton The Big Cheese Right Disassembler',


### PR DESCRIPTION
Violent Discharge, used by The Big Cheese in Smileton, is a room-wide AoE. This was probably a copy/paste error from Right Disassembler.