### PR TITLE
raidboss: p3s add callout for add phase tethers

### DIFF
--- a/ui/raidboss/data/06-ew/raid/p3s.ts
+++ b/ui/raidboss/data/06-ew/raid/p3s.ts
@@ -373,7 +373,7 @@ const triggerSet: TriggerSet<Data> = {
       },
       alertText: (data, matches, output) => {
         ++data.sunbirdTetherCounter;
-        if (data.sunbirdTetherCounter < 8) {
+        if (data.sunbirdTetherCounter <= 8) {
           // Save tether
           if (matches.source === 'Sunbird') {
             for (const s of data.sunbirds) {
@@ -392,7 +392,8 @@ const triggerSet: TriggerSet<Data> = {
             // If it's not from a sunbird it's p2p
             data.p2pTethers.push({ source: matches.source, target: matches.target });
           }
-          return;
+          if (data.sunbirdTetherCounter < 8)
+            return;
         }
         // All 8 tethers collected, make the call
         // Start with own name
@@ -400,7 +401,7 @@ const triggerSet: TriggerSet<Data> = {
         // If we're tethered to a player look for this player's sunbird tether instead
         for (const t of data.p2pTethers) {
           if (t.target === lookupName) {
-            lookupName = t.target;
+            lookupName = t.source;
             break;
           }
         }

--- a/ui/raidboss/data/06-ew/raid/p3s.ts
+++ b/ui/raidboss/data/06-ew/raid/p3s.ts
@@ -351,24 +351,6 @@ const triggerSet: TriggerSet<Data> = {
           console.error('SunbirdTether: There is not exactly four Sunbirds?!?: ${JSON.stringify(sunbirds)}');
           return;
         }
-        /*
-        console.log('------------');
-        for (const s of sunbirds) {
-          if (!s.ID) {
-            console.error('SunbirdTether: Sunbird without ID? ', s);
-            return;
-          }
-          if (s.PosY < 93)
-            console.log('sunbird ', '(', s.ID.toString(16).toUpperCase(), ')', s, 'is north');
-          else if (s.PosY > 107)
-            console.log('sunbird ', '(', s.ID.toString(16).toUpperCase(), ')', s, 'is south');
-          else if (s.PosX < 93)
-            console.log('sunbird ', '(', s.ID.toString(16).toUpperCase(), ')', s, 'is west');
-          else if (s.PosX > 107)
-            console.log('sunbird ', '(', s.ID.toString(16).toUpperCase(), ')', s, 'is east');
-        }
-        console.log('------------');
-        */
         data.sunbirds = sunbirds;
       },
       alertText: (data, matches, output) => {
@@ -409,22 +391,22 @@ const triggerSet: TriggerSet<Data> = {
           if (s.name === lookupName) {
             switch (s.pos) {
               case 0:
-                return 'Tethered North Sunbird';
+                return output.n!();
               case 1:
-                return 'Tethered East Sunbird';
+                return output.e!();
               case 2:
-                return 'Tethered South Sunbird';
+                return output.s!();
               case 3:
-                return 'Tethered West Sunbird';
+                return output.w!();
             }
           }
         }
-        return output.text!();
       },
       outputStrings: {
-        text: {
-          en: 'Tether!',
-        },
+        n: Outputs.north,
+        e: Outputs.east,
+        s: Outputs.south,
+        w: Outputs.west,
       },
     },
     {

--- a/ui/raidboss/data/06-ew/raid/p3s.ts
+++ b/ui/raidboss/data/06-ew/raid/p3s.ts
@@ -360,14 +360,8 @@ const triggerSet: TriggerSet<Data> = {
           if (matches.source === 'Sunbird') {
             for (const s of data.sunbirds) {
               if (s.ID && s.ID.toString(16).toUpperCase() === matches.sourceId) {
-                if (s.PosY < 93)
-                  data.sunbirdTethers.push({ name: matches.target, pos: 0 });
-                else if (s.PosY > 107)
-                  data.sunbirdTethers.push({ name: matches.target, pos: 2 });
-                else if (s.PosX < 93)
-                  data.sunbirdTethers.push({ name: matches.target, pos: 3 });
-                else if (s.PosX > 107)
-                  data.sunbirdTethers.push({ name: matches.target, pos: 1 });
+                const pos = Math.round(2 - 2 * Math.atan2(s.PosX - 100, s.PosY - 100) / Math.PI) % 4;
+                data.sunbirdTethers.push({ name: matches.target, pos: pos });
               }
             }
           } else {
@@ -389,6 +383,20 @@ const triggerSet: TriggerSet<Data> = {
         }
         for (const s of data.sunbirdTethers) {
           if (s.name === lookupName) {
+            // If we were tethered to the sunbird go opposite
+            if (lookupName === data.me) {
+              switch (s.pos) {
+                case 0:
+                  return output.s!();
+                case 1:
+                  return output.w!();
+                case 2:
+                  return output.n!();
+                case 3:
+                  return output.e!();
+              }
+            }
+            // If we were not tethered directly go to sunbird
             switch (s.pos) {
               case 0:
                 return output.n!();


### PR DESCRIPTION
This adds callouts for the tethers that go out in p3s' second part of the add phase.

It expects that the adds are being put on cardinal positions (that is how they spawn afterall), it could be extended to cover intercardinals as well but that'd be a lot more complicated and I've never seen anyone do this(?)