### PR TITLE
raidboss: p1s shackles of time call opposite party/player

### DIFF
--- a/ui/raidboss/data/06-ew/raid/p1s.ts
+++ b/ui/raidboss/data/06-ew/raid/p1s.ts
@@ -45,6 +45,12 @@ const fireLightOutputStrings = {
     cn: '站在光',
     ko: '흰색 바닥 위에 서기',
   },
+  oppositePlayer: {
+    en: 'Stand on color opposite of ${player}',
+  },
+  oppositeParty: {
+    en: 'Stand on color opposite of Party',
+  },
 };
 
 const triggerSet: TriggerSet<Data> = {
@@ -343,11 +349,9 @@ const triggerSet: TriggerSet<Data> = {
       type: 'GainsEffect',
       netRegex: NetRegexes.gainsEffect({ effectId: 'AB5' }),
       alertText: (data, matches, output) => {
-        if (!data.safeColor)
-          return;
         if (matches.target === data.me)
-          return output[data.safeColor]!();
-        return output[data.safeColor === 'fire' ? 'light' : 'fire']!();
+          return output.oppositeParty!();
+        return output.oppositePlayer!({ player: matches.target });
       },
       outputStrings: fireLightOutputStrings,
     },

--- a/ui/raidboss/data/06-ew/raid/p1s.ts
+++ b/ui/raidboss/data/06-ew/raid/p1s.ts
@@ -45,12 +45,6 @@ const fireLightOutputStrings = {
     cn: '站在光',
     ko: '흰색 바닥 위에 서기',
   },
-  oppositePlayer: {
-    en: 'Stand on color opposite of ${player}',
-  },
-  oppositeParty: {
-    en: 'Stand on color opposite of Party',
-  },
 };
 
 const triggerSet: TriggerSet<Data> = {
@@ -353,7 +347,14 @@ const triggerSet: TriggerSet<Data> = {
           return output.oppositeParty!();
         return output.oppositePlayer!({ player: data.ShortName(matches.target) });
       },
-      outputStrings: fireLightOutputStrings,
+      outputStrings: {
+        oppositePlayer: {
+          en: 'Opposite color of ${player}',
+        },
+        oppositeParty: {
+          en: 'Opposite color of Party',
+        },
+      },
     },
     {
       id: 'P1S Fourfold Shackles of Companionship 1',

--- a/ui/raidboss/data/06-ew/raid/p1s.ts
+++ b/ui/raidboss/data/06-ew/raid/p1s.ts
@@ -351,7 +351,7 @@ const triggerSet: TriggerSet<Data> = {
       alertText: (data, matches, output) => {
         if (matches.target === data.me)
           return output.oppositeParty!();
-        return output.oppositePlayer!({ player: matches.target });
+        return output.oppositePlayer!({ player: data.ShortName(matches.target) });
       },
       outputStrings: fireLightOutputStrings,
     },


### PR DESCRIPTION
The current Shackles of Time callout is based on a previously used safe spot from a spell that is not relevant. I believe the nature of this debuff is such that wherever the player stands is what is going to do damage to the other players should they stand on it, so the call could be wrong if the party were to choose a color to always have the player be that is not matching whatever spell the boss had used previously.

EDIT: Not sure what to name the PR.