### PR TITLE
plugin: Fix NonSerialized for drg job data

### DIFF
--- a/plugin/CactbotEventSource/FFXIVProcessIntl.cs
+++ b/plugin/CactbotEventSource/FFXIVProcessIntl.cs
@@ -504,7 +504,6 @@ namespace Cactbot {
         }
       }
 
-      [NonSerialized]
       [FieldOffset(0x04)]
       public byte firstmindsFocus;
     };


### PR DESCRIPTION
This is a following up fixing for #4090 
Opps, untestment makes bug.
If someone have lv90 DRG can you have a check?