### PR TITLE
oopsy: clean up debug log messages

### DIFF
--- a/ui/oopsyraidsy/mistake_collector.ts
+++ b/ui/oopsyraidsy/mistake_collector.ts
@@ -29,7 +29,7 @@ export class MistakeCollector implements MistakeObserver {
   }
 
   private RequestSync(): void {
-    console.log(`RequestSync: ${this.creationTime}`);
+    this.DebugPrint(`RequestSync: ${this.creationTime}`);
     void callOverlayHandler({
       call: 'broadcast',
       source: broadcastSource,


### PR DESCRIPTION
The `RequestSync` message should only be printed if the Debug option is
enabled.

Mentioned in #4096.