### PR TITLE
raidboss: fix timeline translation of zone syncs

### DIFF
--- a/ui/raidboss/common_replacement.ts
+++ b/ui/raidboss/common_replacement.ts
@@ -9,7 +9,7 @@ export const syncKeys = {
   // Once we have completely converted things for 6.0,
   // we should come back here and make the doubled colon non-optional.
   seal:
-    '(?<=00:0839:|00\\|[^|]*\\|0839\\|\\|):?(.*) will be sealed off(?: in (?:[0-9]+ seconds)?)?',
+    '(?<=00:0839::?|00\\|[^|]*\\|0839\\|\\|)([^:].*) will be sealed off(?: in (?:[0-9]+ seconds)?)?',
   unseal: 'is no longer sealed',
   engage: 'Engage!',
 };

--- a/ui/raidboss/common_replacement.ts
+++ b/ui/raidboss/common_replacement.ts
@@ -9,7 +9,7 @@ export const syncKeys = {
   // Once we have completely converted things for 6.0,
   // we should come back here and make the doubled colon non-optional.
   seal:
-    '(?<=00:0839::?|00\\|[^|]*\\|0839\\|\\|)(.*) will be sealed off(?: in (?:[0-9]+ seconds)?)?',
+    '(?<=00:0839:|00\\|[^|]*\\|0839\\|\\|):?(.*) will be sealed off(?: in (?:[0-9]+ seconds)?)?',
   unseal: 'is no longer sealed',
   engage: 'Engage!',
 };


### PR DESCRIPTION
This would cause zone seal messages to not sync in other languages,
causing timelines that only start on zone seal to not begin.

The issue is that the positive lookbehind group is always lazy (?!)
and so we need to make sure that the regex doesn't eat the colon
in the capturing group.

This partially addresses #4102, and may address #3949.