### PR TITLE
raidboss: fix overriding trigger index 0 from user file

### DIFF
--- a/ui/raidboss/popup-text.ts
+++ b/ui/raidboss/popup-text.ts
@@ -196,8 +196,8 @@ class OrderedTriggerList {
   idToIndex: { [id: string]: number } = {};
 
   push(trigger: ProcessedTrigger) {
-    const idx = trigger.id ? this.idToIndex[trigger.id] : undefined;
-    if (idx && trigger.id) {
+    const idx = trigger.id !== undefined ? this.idToIndex[trigger.id] : undefined;
+    if (idx !== undefined && trigger.id !== undefined) {
       const oldTrigger = this.triggers[idx];
 
       if (oldTrigger === undefined)
@@ -215,7 +215,7 @@ class OrderedTriggerList {
     }
 
     // Normal case of a new trigger, with no overriding.
-    if (trigger.id)
+    if (trigger.id !== undefined)
       this.idToIndex[trigger.id] = this.triggers.length;
     this.triggers.push(trigger);
   }


### PR DESCRIPTION
The first trigger registered by the system (usually "General Provoke") gets index `0`. When attempting to override this trigger from a user file, the index would be looked up and checked for existence via an implicit conversion to `boolean`. However `0` converts to `false`, so a new trigger would always be created, making it impossible to override this trigger.

This fix explicitly checks both the trigger id and index against `undefined`, instead of using an implicit conversion.