### PR TITLE
raidboss: Remove Unused Transition CSS

### DIFF
--- a/ui/raidboss/raidboss.css
+++ b/ui/raidboss/raidboss.css
@@ -147,10 +147,6 @@
   margin-bottom: 2;
 }
 
-.timeline-grid .timer-bar {
-  transition: all var(--transition-time);
-}
-
 :lang(ko) .timer-bar {
   height: 23px;
 }


### PR DESCRIPTION
Remove a CSS transition property that is not relevant to the timer-bar
animations, and is possibly potentially causing other issues and jank in
the background for other things the timer-bar is normally doing.