### PR TITLE
raidboss: add trigger for Bloody Sweep (#3605)

### DIFF
--- a/ui/raidboss/data/05-shb/alliance/the_tower_at_paradigms_breach.ts
+++ b/ui/raidboss/data/05-shb/alliance/the_tower_at_paradigms_breach.ts
@@ -24,7 +24,6 @@ export interface Data extends RaidbossData {
 
 // TODO:
 //   Update Knave knockback directions to instead use cardinals
-//   Hansel and Gretel Bloody Sweep
 //   Hansel and Gretel Stronger Together Tethered
 //   Hansel & Gretel Passing Lance
 //   Hansel & Gretel Breakthrough
@@ -401,6 +400,53 @@ const triggerSet: TriggerSet<Data> = {
       netRegexCn: NetRegexes.startsUsing({ id: '5C7[34]', source: ['韩塞尔', '格雷特'], capture: false }),
       netRegexKo: NetRegexes.startsUsing({ id: '5C7[34]', source: ['헨젤', '그레텔'], capture: false }),
       response: Responses.aoe(),
+    },
+    {
+      id: 'Paradigm Hansel/Gretel Bloody Sweep',
+      type: 'StartsUsing',
+      netRegex: NetRegexes.startsUsing({ id: '5C5[4567]', source: ['Hansel', 'Gretel'] }),
+      durationSeconds: 5,
+      suppressSeconds: 1,
+      alertText: (_data, matches, output) => {
+        // Hansel and Gretel each have unique abilities which indicate which
+        // side of the Bloody Sweep they're starting in. Hanssel is left
+        // handed, and Gretel is right handed. 5C54 and 5C55 indicate that
+        // Hansel is on the right and Gretel is on the left, relative to the
+        // two bosses. Using this, we can identify if the safe area is
+        // between the two, or on the opposite side of the arena.
+        //
+        // A further complication is that the pair might use Transference
+        // first, which causes them to swap places. We can detect this based
+        // on the cast time of the Bloody Sweep ability, since the cast time
+        // will be extended to account for the Transference. If the swap
+        // will take place, then the cast time will go from 7.7 seconds up
+        // to 12.7 seconds. We use an average of 10 seconds to detect the
+        // swap.
+        if (matches.id === '5C54' || matches.id === '5C55') {
+          // Hansel is on the right and Gretel is on the left.
+          if (parseFloat(matches.castTime) > 10) {
+            // Hansel and Gretel will switch places
+            return output.between!();
+          }
+          // Hansel and Gretel stay in same position
+          return output.opposite!();
+        }
+        // Gretel is on the right and Hansel is on the left.
+        if (parseFloat(matches.castTime) > 10) {
+          // Hansel and Gretel will switch places
+          return output.opposite!();
+        }
+        // Hansel and Gretel stay in same position
+        return output.between!();
+      },
+      outputStrings: {
+        between: {
+          en: 'Move between',
+        },
+        opposite: {
+          en: 'Move opposite',
+        },
+      },
     },
     {
       id: 'Paradigm Red Girl Cruelty',


### PR DESCRIPTION
Hansel and Gretel use "Tandem Assault: Bloody Sweep" as a combo move in
which the two bosses stand on the edge of the arena and each swipe
a large angled chunk of the platform simultaneously.

Hansel and Gretel will teleport to the side of the platform and will
sweep with their spears. Hansel is left handed and will hit the left
half while Gretel will hit the right half. Depending on which side of
the arena each is on, the safe spot to avoid getting hit will either be
between the two bosses or on the opposite side of the platform.

This can be detected using the relevant IDs, as determining whether the
spears are on the outside or inside of the arena is based on which of
the two IDs that Hansel and Gretel open the attack with.

To further complicate this, sometimes Hansel and Gretel will use
Transference after starting the Bloody Sweep but before it finishes
casting. This causes them to swap places, reversing the safe spot. This
is shown to players using a red/blue twisting tether. However, we can
also detect it via the cast time. A shorter cast time of 7.7 seconds
indicates no swap, while a longer 12.7 second cast time indicates
a Transference swap.

Using this logic we can alert the player whether the safe spot is
inbetween the two bosses, or on the opposite side.

Note that a previous implementation assumed that Hansel and Gretel
always teleported to the north side of the arena. This is incorrect, and
they appear to have multiple different teleport spots. However, using
the simpler "Move between" and "Move opposite" tells is clear as the
player can always orient relative to their starting sweep positions.

Signed-off-by: Jacob Keller <jacob.keller@gmail.com>
