### PR TITLE
raidboss: Fix EW Ex2 north/south trigger

### DIFF
--- a/ui/raidboss/data/06-ew/trial/hydaelyn-ex.ts
+++ b/ui/raidboss/data/06-ew/trial/hydaelyn-ex.ts
@@ -317,11 +317,11 @@ const triggerSet: TriggerSet<Data> = {
     {
       id: 'HydaelynEx Crystal of Light',
       type: 'Ability',
-      netRegex: NetRegexes.ability({ id: '65BE', source: 'Crystal of Light', capture: true }),
+      netRegex: NetRegexes.abilityFull({ id: '65BE', source: 'Crystal of Light', capture: true }),
       // Each of the three adds fires every 1.1s or so until about Exodus or their death
       suppressSeconds: 60,
       infoText: (data, matches, output) => {
-        // North Crystals: (87.87, 93.00),  (112.12, 86.00), (112.12, 93)
+        // North Crystals: (87.87, 93.00),  (100.00, 86.00), (112.12, 93)
         // South Crystals: (87.87, 107.00), (100.00, 114.00), (112.12, 107.00)
         const isSouthFirst = parseFloat(matches.y) > 100;
         if (data.role === 'tank')


### PR DESCRIPTION
Per discord discussion.

Probably the underlying typescript mechanisms for this should be examined to prevent this issue in the future? Either:
a. `NetRegexes.ability` should return a partial type conforming to its valid matching fields
b. `NetRegexes.ability` should match every field, losing that performance gain