### PR TITLE
raidboss: Refactor ability vs abilityFull

### DIFF
--- a/resources/netregexes.ts
+++ b/resources/netregexes.ts
@@ -153,16 +153,7 @@ export default class NetRegexes {
    */
   static ability(params?: NetParams['Ability']): CactbotBaseRegExp<'Ability'> {
     return parseHelper(params, 'ability', {
-      ...defaultParams('Ability', [
-        'type',
-        'timestamp',
-        'sourceId',
-        'source',
-        'id',
-        'ability',
-        'targetId',
-        'target',
-      ]),
+      ...defaultParams('Ability'),
       // Override type
       0: { field: 'type', value: '2[12]' },
     });
@@ -171,13 +162,11 @@ export default class NetRegexes {
   /**
    * matches: https://github.com/quisquous/cactbot/blob/main/docs/LogGuide.md#15-networkability
    * matches: https://github.com/quisquous/cactbot/blob/main/docs/LogGuide.md#16-networkaoeability
+   *
+   * @deprecated Use `ability` instead
    */
   static abilityFull(params?: NetParams['Ability']): CactbotBaseRegExp<'Ability'> {
-    return parseHelper(params, 'abilityFull', {
-      ...defaultParams('Ability'),
-      // Override type
-      0: { field: 'type', value: '2[12]' },
-    });
+    return this.ability(params);
   }
 
   /**

--- a/resources/regexes.ts
+++ b/resources/regexes.ts
@@ -145,26 +145,17 @@ export default class Regexes {
    * matches: https://github.com/quisquous/cactbot/blob/main/docs/LogGuide.md#16-networkaoeability
    */
   static ability(params?: NetParams['Ability']): CactbotBaseRegExp<'Ability'> {
-    return parseHelper(params, 'Ability', {
-      ...defaultParams('Ability', [
-        'type',
-        'timestamp',
-        'sourceId',
-        'source',
-        'id',
-        'ability',
-        'targetId',
-        'target',
-      ]),
-    });
+    return parseHelper(params, 'Ability', defaultParams('Ability'));
   }
 
   /**
    * matches: https://github.com/quisquous/cactbot/blob/main/docs/LogGuide.md#15-networkability
    * matches: https://github.com/quisquous/cactbot/blob/main/docs/LogGuide.md#16-networkaoeability
+   *
+   * @deprecated Use `ability` instead
    */
   static abilityFull(params?: NetParams['Ability']): CactbotBaseRegExp<'Ability'> {
-    return parseHelper(params, 'Ability', defaultParams('Ability'));
+    return this.ability(params);
   }
 
   /**


### PR DESCRIPTION
Per discussion on #4142, this matches "option B".

Should probably be a follow up PR to make linting check for `@deprecated` and error out, along with related cleanup?