### PR TITLE
oopsy: treat combatants with 0000 owners as not pets

### DIFF
--- a/ui/oopsyraidsy/player_state_tracker.ts
+++ b/ui/oopsyraidsy/player_state_tracker.ts
@@ -202,7 +202,9 @@ export class PlayerStateTracker {
   OnAddedCombatant(line: string, splitLine: string[]): void {
     const petId = splitLine[logDefinitions.AddedCombatant.fields.id];
     const ownerId = splitLine[logDefinitions.AddedCombatant.fields.ownerId];
-    if (petId === undefined || ownerId === undefined || ownerId === '0')
+    if (petId === undefined || ownerId === undefined)
+      return;
+    if (ownerId === '0' || ownerId === '0000')
       return;
 
     // Fix any lowercase ids.


### PR DESCRIPTION
It seems like this used to be '0' and now can be '0000'.
This should avoid buff tracking errors and console errors.