### PR TITLE
raidboss: add basic triggers for Sephirot Normal mode

### DIFF
--- a/docs/LogGuide.md
+++ b/docs/LogGuide.md
@@ -1199,6 +1199,7 @@ ID | Name | Sample Locations | Consistent meaning?
 0039 | Purple Spread Circle (large) | Ravana N/EX, Shinryu EX | Yes
 003E | Stack Marker (bordered) | o8n/s, Dun Scaith | Yes
 0046 | Green Pinwheel | Dun Scaith boss 1, o5n/s | Yes
+0048 | Stack Marker | Sephirot | Yes
 004B | Acceleration Bomb | Weeping City boss 3, Susano N/EX, o4s | Yes
 004C | Purple Fire Circle (large) | e2n/s | Yes
 0054 | Thunder Tether (orange) | Titania EX | N/A

--- a/ui/raidboss/data/03-hw/trial/sephirot.ts
+++ b/ui/raidboss/data/03-hw/trial/sephirot.ts
@@ -37,38 +37,12 @@ const triggerSet: TriggerSet<Data> = {
       response: Responses.earthshaker(),
     },
     {
+      // The coordinates for skill are inconsistent and can't be used to
+      // reliably determine the position of the knockback.
       id: 'Sephirot Pillar of Mercy',
       type: 'StartsUsing',
-      netRegex: NetRegexes.startsUsing({ id: '16EA', source: 'Sephirot' }),
-      alertText: (_data, matches, output) => {
-        // The pillars spawn in slightly randomized positions, typically
-        // either in the west side, center, or east side. The X position
-        // range for the arena is -20 to 20.
-        //
-        // TODO: Sometimes the coordinates for the Pillar of Mercy seem to be
-        // wrong (an xPos of -10 for a central knockback or +12.5 for a west
-        // knockback). It's unclear if this is a bug in the parser or
-        // cactbot.
-        const xPos = parseFloat(matches.x);
-
-        if (xPos < -6)
-          return output.west!();
-        if (xPos > 6)
-          return output.east!();
-
-        return output.center!();
-      },
-      outputStrings: {
-        west: {
-          en: 'Knockback from West',
-        },
-        east: {
-          en: 'Knockback from East',
-        },
-        center: {
-          en: 'Knockback from Center',
-        },
-      },
+      netRegex: NetRegexes.startsUsing({ id: '16EA', source: 'Sephirot', capture: false }),
+      response: Responses.knockback(),
     },
     {
       id: 'Sephirot Storm of Words Revelation',

--- a/ui/raidboss/data/03-hw/trial/sephirot.ts
+++ b/ui/raidboss/data/03-hw/trial/sephirot.ts
@@ -1,0 +1,93 @@
+import Conditions from '../../../../../resources/conditions';
+import NetRegexes from '../../../../../resources/netregexes';
+import { Responses } from '../../../../../resources/responses';
+import ZoneId from '../../../../../resources/zone_id';
+import { RaidbossData } from '../../../../../types/data';
+import { TriggerSet } from '../../../../../types/trigger';
+
+export type Data = RaidbossData;
+
+const triggerSet: TriggerSet<Data> = {
+  zoneId: ZoneId.ContainmentBayS1T7,
+  triggers: [
+    {
+      id: 'Sephirot Fiendish Rage',
+      type: 'HeadMarker',
+      netRegex: NetRegexes.headMarker({ id: '0048' }),
+      response: Responses.stackMarkerOn(),
+    },
+    {
+      id: 'Sephirot Ratzon',
+      type: 'HeadMarker',
+      netRegex: NetRegexes.headMarker({ id: '0046' }),
+      condition: Conditions.targetIsYou(),
+      response: Responses.spread(),
+    },
+    {
+      id: 'Sephirot Ain',
+      type: 'StartsUsing',
+      netRegex: NetRegexes.startsUsing({ id: '16DD', source: 'Sephirot', capture: false }),
+      response: Responses.getBehind(),
+    },
+    {
+      id: 'Sephirot Earth Shaker',
+      type: 'HeadMarker',
+      netRegex: NetRegexes.headMarker({ id: '0028' }),
+      condition: Conditions.targetIsYou(),
+      response: Responses.earthshaker(),
+    },
+    {
+      id: 'Sephirot Pillar of Mercy',
+      type: 'StartsUsing',
+      netRegex: NetRegexes.startsUsing({ id: '16EA', source: 'Sephirot' }),
+      alertText: (_data, matches, output) => {
+        // The pillars spawn in slightly randomized positions, typically
+        // either in the west side, center, or east side. The X position
+        // range for the arena is -20 to 20.
+        //
+        // TODO: Sometimes the coordinates for the Pillar of Mercy seem to be
+        // wrong (an xPos of -10 for a central knockback or +12.5 for a west
+        // knockback). It's unclear if this is a bug in the parser or
+        // cactbot.
+        const xPos = parseFloat(matches.x);
+
+        if (xPos < -6)
+          return output.west!();
+        if (xPos > 6)
+          return output.east!();
+
+        return output.center!();
+      },
+      outputStrings: {
+        west: {
+          en: 'Knockback from West',
+        },
+        east: {
+          en: 'Knockback from East',
+        },
+        center: {
+          en: 'Knockback from Center',
+        },
+      },
+    },
+    {
+      id: 'Sephirot Storm of Words Revelation',
+      type: 'StartsUsing',
+      netRegex: NetRegexes.startsUsing({ id: '16EC', source: 'Storm of Words', capture: false }),
+      alarmText: (_data, _matches, output) => output.text!(),
+      outputStrings: {
+        text: {
+          en: 'Kill Storm of Words or die',
+        },
+      },
+    },
+    {
+      id: 'Sephirot Malkuth',
+      type: 'StartsUsing',
+      netRegex: NetRegexes.startsUsing({ id: '16EB', source: 'Sephirot', capture: false }),
+      response: Responses.knockback(),
+    },
+  ],
+};
+
+export default triggerSet;

--- a/ui/raidboss/data/raidboss_manifest.txt
+++ b/ui/raidboss/data/raidboss_manifest.txt
@@ -96,6 +96,7 @@
 03-hw/raid/a9s.txt
 03-hw/trial/ravana-ex.ts
 03-hw/trial/ravana-ex.txt
+03-hw/trial/sephirot.ts
 03-hw/trial/sephirot-ex.ts
 03-hw/trial/sephirot-ex.txt
 03-hw/trial/sophia-ex.ts


### PR DESCRIPTION
The sephirot normal mode boss does not have any triggers or data. This
boss has many mechanics without cast bars, and low visual tells.

Add some basic triggers to alert the player of the major mechanics like
the stack marker, earth shaker, spreading, etc. Also add a trigger to
warn about where knockbacks will land during Pillar of Mercy and to kill
the add that pops up before the three-arm wave (as failing to kill it in
time will be a wipe).

Signed-off-by: Jacob Keller <jacob.keller@gmail.com>
