### PR TITLE
oopsy: fix p1 hot cold spell bugs

### DIFF
--- a/ui/oopsyraidsy/data/06-ew/raid/p1n.ts
+++ b/ui/oopsyraidsy/data/06-ew/raid/p1n.ts
@@ -23,19 +23,19 @@ const triggerSet: OopsyTriggerSet<Data> = {
   },
   triggers: [
     {
-      id: 'P1N Cold Spell Track',
+      id: 'P1N Hot Cold Spell Gain',
       type: 'GainsEffect',
-      // No need to track this falling off or deleting it.
-      // When the next round comes along, it will reassign and give it to somebody.
-      // TODO: not sure if somebody dies if this falls off and so maybe we should track losing it?
-      netRegex: NetRegexes.gainsEffect({ effectId: 'AB3' }),
-      run: (data, matches) => (data.spell ??= {})[matches.target] = 'cold',
+      netRegex: NetRegexes.gainsEffect({ effectId: 'AB[34]' }),
+      run: (data, matches) => {
+        const temp = matches.effectId === 'AB3' ? 'cold' : 'hot';
+        (data.spell ??= {})[matches.target] = temp;
+      },
     },
     {
-      id: 'P1N Hot Spell Track',
-      type: 'GainsEffect',
-      netRegex: NetRegexes.gainsEffect({ effectId: 'AB4' }),
-      run: (data, matches) => (data.spell ??= {})[matches.target] = 'hot',
+      id: 'P1N Hot Cold Spell Lose',
+      type: 'LosesEffect',
+      netRegex: NetRegexes.losesEffect({ effectId: 'AB[34]' }),
+      run: (data, matches) => delete (data.spell ??= {})[matches.target],
     },
     {
       id: 'P1N Cold Spell',

--- a/ui/oopsyraidsy/data/06-ew/raid/p1s.ts
+++ b/ui/oopsyraidsy/data/06-ew/raid/p1s.ts
@@ -44,19 +44,19 @@ const triggerSet: OopsyTriggerSet<Data> = {
   },
   triggers: [
     {
-      id: 'P1S Cold Spell Track',
+      id: 'P1S Hot Cold Spell Gain',
       type: 'GainsEffect',
-      // No need to track this falling off or deleting it.
-      // When the next round comes along, it will reassign and give it to somebody.
-      // TODO: not sure if somebody dies if this falls off and so maybe we should track losing it?
-      netRegex: NetRegexes.gainsEffect({ effectId: 'AB3' }),
-      run: (data, matches) => (data.spell ??= {})[matches.target] = 'cold',
+      netRegex: NetRegexes.gainsEffect({ effectId: 'AB[34]' }),
+      run: (data, matches) => {
+        const temp = matches.effectId === 'AB3' ? 'cold' : 'hot';
+        (data.spell ??= {})[matches.target] = temp;
+      },
     },
     {
-      id: 'P1S Hot Spell Track',
-      type: 'GainsEffect',
-      netRegex: NetRegexes.gainsEffect({ effectId: 'AB4' }),
-      run: (data, matches) => (data.spell ??= {})[matches.target] = 'hot',
+      id: 'P1S Hot Cold Spell Lose',
+      type: 'LosesEffect',
+      netRegex: NetRegexes.losesEffect({ effectId: 'AB[34]' }),
+      run: (data, matches) => delete (data.spell ??= {})[matches.target],
     },
     {
       id: 'P1S Cold Spell',


### PR DESCRIPTION
The hot/cold spell value carried over from the first set of
intemperate and could throw a mistake on the first hot/cold
of the second set of intemperate.  Stop being clever and
just track lose/gain.  Lose always happens prior to gaining
the new one, so this will not clobber the value.