### PR TITLE
jobs: hide raidbuff for crafter&gatherer

### DIFF
--- a/ui/jobs/components/index.ts
+++ b/ui/jobs/components/index.ts
@@ -208,7 +208,8 @@ export class ComponentManager {
       this.gpAlarmReady = false;
 
       this.bars._setupJobContainers(job, {
-        buffList: this.shouldShow.buffList ?? true,
+        buffList: this.shouldShow.buffList ??
+          (!Util.isCraftingJob(job) && !Util.isGatheringJob(job)),
         pullBar: this.shouldShow.pullBar ?? true,
         hpBar: this.shouldShow.hpBar ?? (!Util.isCraftingJob(job) && !Util.isGatheringJob(job)),
         mpBar: this.shouldShow.mpBar ??


### PR DESCRIPTION
Crafter's CP drinks also tracked as potion.
Gatherer may find someone use Chain Stratage or TA nearby.
Hide raidbuff tracker for unnecessary notice.