### PR TITLE
raidboss/config: add ui for timeline text enable/renaming

### DIFF
--- a/ui/config/config.css
+++ b/ui/config/config.css
@@ -187,6 +187,42 @@ html {
   margin-right: 20px;
 }
 
+.timeline-edit-container {
+  margin: 12px 0 12px 12px;
+  grid-column-end: span 2;
+}
+
+.timeline-edit-header {
+  background-color: #ebebeb;
+  padding: 5px;
+  border: 1px solid black;
+  cursor: pointer;
+
+  /* use grid to vertically center */
+  display: grid;
+  grid-template-columns: repeat(1, auto 1fr);
+  justify-items: left;
+  align-items: center;
+}
+
+.timeline-edit-header::before {
+  content: '';
+  box-sizing: border-box;
+  margin-right: 5px;
+  width: 6px;
+  height: 6px;
+  border-left: 3px solid transparent;
+  border-right: 3px solid transparent;
+  border-top: 6px solid black;
+}
+
+.collapsed .timeline-edit-header::before {
+  border-top: 3px solid transparent;
+  border-bottom: 3px solid transparent;
+  border-left: 6px solid black;
+  border-right: none;
+}
+
 .trigger-file-options {
   display: grid;
   margin: 12px;

--- a/ui/config/config.css
+++ b/ui/config/config.css
@@ -223,6 +223,22 @@ html {
   border-right: none;
 }
 
+.timeline-text-container {
+  display: grid;
+  grid-template-columns: auto auto 1fr;
+  grid-gap: 5px;
+  margin: 12px 0 24px 24px;
+  align-items: center;
+}
+
+.timeline-text-enable {
+  justify-self: center;
+}
+
+.timeline-text-edit {
+  max-width: 300px;
+}
+
 .trigger-file-options {
   display: grid;
   margin: 12px;

--- a/ui/config/config.ts
+++ b/ui/config/config.ts
@@ -694,6 +694,8 @@ export class CactbotConfigurator {
       if (!filename.endsWith('.js') && !filename.endsWith('.ts'))
         continue;
 
+      triggerSet.filename = filename;
+
       let prefixKey = '00-misc';
       let prefix: LocaleText = kPrefixToCategory['00-misc'];
       for (const [key, value] of Object.entries(kPrefixToCategory)) {

--- a/ui/raidboss/data/00-misc/test.txt
+++ b/ui/raidboss/data/00-misc/test.txt
@@ -13,10 +13,13 @@
 #
 # /goodbye to the striking dummy to stop the timeline.
 
+hideall "--Reset--"
+hideall "--sync--"
+
 0 "--Reset--" sync /You bid farewell to the striking dummy/ window 10000 jump 0
 
-0 "Engage" sync /:Engage!/ window 100000,100000
-0 "Start" sync /:You bow courteously to the striking dummy/ window 0,1
+0 "--sync--" sync /:Engage!/ window 100000,100000
+0 "--sync--" sync /:You bow courteously to the striking dummy/ window 0,1
 3 "Almagest"
 6 "Angry Dummy"
 10 "Long Castbar" duration 10

--- a/ui/raidboss/emulator/overrides/RaidEmulatorTimeline.ts
+++ b/ui/raidboss/emulator/overrides/RaidEmulatorTimeline.ts
@@ -7,9 +7,15 @@ import RaidEmulator from '../data/RaidEmulator';
 export default class RaidEmulatorTimeline extends Timeline {
   emulatedStatus = 'pause';
   emulator?: RaidEmulator;
-  constructor(text: string, replacements: TimelineReplacement[], triggers: LooseTimelineTrigger[],
-    styles: TimelineStyle[], options: RaidbossOptions) {
-    super(text, replacements, triggers, styles, options);
+  constructor(
+    zoneId: number,
+    text: string,
+    replacements: TimelineReplacement[],
+    triggers: LooseTimelineTrigger[],
+    styles: TimelineStyle[],
+    options: RaidbossOptions
+  ) {
+    super(zoneId, text, replacements, triggers, styles, options);
   }
 
   bindTo(emulator: RaidEmulator): void {

--- a/ui/raidboss/emulator/overrides/RaidEmulatorTimeline.ts
+++ b/ui/raidboss/emulator/overrides/RaidEmulatorTimeline.ts
@@ -8,14 +8,14 @@ export default class RaidEmulatorTimeline extends Timeline {
   emulatedStatus = 'pause';
   emulator?: RaidEmulator;
   constructor(
-    zoneId: number,
     text: string,
     replacements: TimelineReplacement[],
     triggers: LooseTimelineTrigger[],
     styles: TimelineStyle[],
-    options: RaidbossOptions
+    options: RaidbossOptions,
+    zoneId: number,
   ) {
-    super(zoneId, text, replacements, triggers, styles, options);
+    super(text, replacements, triggers, styles, options, zoneId);
   }
 
   bindTo(emulator: RaidEmulator): void {

--- a/ui/raidboss/emulator/overrides/RaidEmulatorTimelineController.ts
+++ b/ui/raidboss/emulator/overrides/RaidEmulatorTimelineController.ts
@@ -19,9 +19,9 @@ export default class RaidEmulatorTimelineController extends TimelineController {
   }
 
   // Override
-  public override SetActiveTimeline(zoneId: number, timelineFiles: string[], timelines: string[],
+  public override SetActiveTimeline(timelineFiles: string[], timelines: string[],
     replacements: TimelineReplacement[], triggers: LooseTimelineTrigger[],
-    styles: TimelineStyle[]): void {
+    styles: TimelineStyle[], zoneId: number): void {
     this.activeTimeline = null;
 
     let text = '';
@@ -40,7 +40,7 @@ export default class RaidEmulatorTimelineController extends TimelineController {
 
     if (text) {
       this.activeTimeline =
-        new RaidEmulatorTimeline(zoneId, text, replacements, triggers, styles, this.options);
+        new RaidEmulatorTimeline(text, replacements, triggers, styles, this.options, zoneId);
       if (this.emulator)
         this.activeTimeline.bindTo(this.emulator);
     }

--- a/ui/raidboss/emulator/overrides/RaidEmulatorTimelineController.ts
+++ b/ui/raidboss/emulator/overrides/RaidEmulatorTimelineController.ts
@@ -19,7 +19,7 @@ export default class RaidEmulatorTimelineController extends TimelineController {
   }
 
   // Override
-  public override SetActiveTimeline(timelineFiles: string[], timelines: string[],
+  public override SetActiveTimeline(zoneId: number, timelineFiles: string[], timelines: string[],
     replacements: TimelineReplacement[], triggers: LooseTimelineTrigger[],
     styles: TimelineStyle[]): void {
     this.activeTimeline = null;
@@ -40,7 +40,7 @@ export default class RaidEmulatorTimelineController extends TimelineController {
 
     if (text) {
       this.activeTimeline =
-        new RaidEmulatorTimeline(text, replacements, triggers, styles, this.options);
+        new RaidEmulatorTimeline(zoneId, text, replacements, triggers, styles, this.options);
       if (this.emulator)
         this.activeTimeline.bindTo(this.emulator);
     }

--- a/ui/raidboss/popup-text.ts
+++ b/ui/raidboss/popup-text.ts
@@ -742,6 +742,7 @@ export class PopupText {
     this.Reset();
 
     this.timelineLoader.SetTimelines(
+      this.zoneId,
       timelineFiles,
       timelines,
       replacements,

--- a/ui/raidboss/popup-text.ts
+++ b/ui/raidboss/popup-text.ts
@@ -742,12 +742,12 @@ export class PopupText {
     this.Reset();
 
     this.timelineLoader.SetTimelines(
-      this.zoneId,
       timelineFiles,
       timelines,
       replacements,
       timelineTriggers,
       timelineStyles,
+      this.zoneId,
     );
   }
 

--- a/ui/raidboss/raidboss_config.ts
+++ b/ui/raidboss/raidboss_config.ts
@@ -806,6 +806,8 @@ class RaidbossConfigurator {
         continue;
       if (event.name in timeline.ignores)
         continue;
+      // name = original timeline text
+      // text = replaced text in current language
       uniqEvents[event.name] = event.text;
     }
 
@@ -830,6 +832,8 @@ class RaidbossConfigurator {
       checkInput.type = 'checkbox';
       container.appendChild(checkInput);
 
+      // Enable/disable here behaves identically to `hideall "key"`, where this text will
+      // not be shown, but timeline triggers related to it will still fire.
       const enableId = ['timeline', zoneId.toString(), 'enable', key];
       const defaultValue = true;
       checkInput.checked = this.base.getBooleanOption('raidboss', enableId, defaultValue);
@@ -844,6 +848,8 @@ class RaidbossConfigurator {
       textInput.classList.add('timeline-text-edit');
       textInput.placeholder = event;
 
+      // Any changes are tied to the original timeline text (key), but the config ui will
+      // display the current language's text with replacements (event) as the placeholder above.
       const textId = ['timeline', zoneId.toString(), 'globalReplace', key];
       textInput.value = this.base.getStringOption('raidboss', textId, '');
       const setFunc = () => this.base.setOption('raidboss', textId, textInput.value);

--- a/ui/raidboss/raidboss_options.ts
+++ b/ui/raidboss/raidboss_options.ts
@@ -27,9 +27,15 @@ export type PerTriggerOption = Partial<{
   TTSText: TriggerOutput<RaidbossData, Matches>;
 }>;
 
+export type TimelineConfig = Partial<{
+  Ignore: string[];
+  Rename: { [text: string]: string };
+}>;
+
 export type PerTriggerAutoConfig = { [triggerId: string]: TriggerAutoConfig };
 export type PerTriggerOptions = { [triggerId: string]: PerTriggerOption };
 export type DisabledTriggers = { [triggerId: string]: boolean };
+export type PerZoneTimelineConfig = { [zoneId: number]: TimelineConfig };
 
 type RaidbossNonConfigOptions = {
   PlayerNicks: { [gameName: string]: string };
@@ -42,6 +48,7 @@ type RaidbossNonConfigOptions = {
   DisabledTriggers: DisabledTriggers;
   PerTriggerAutoConfig: PerTriggerAutoConfig;
   PerTriggerOptions: PerTriggerOptions;
+  PerZoneTimelineConfig: PerZoneTimelineConfig;
   Triggers: LooseTriggerSet[];
   PlayerNameOverride?: string;
   IsRemoteRaidboss: boolean;
@@ -65,6 +72,7 @@ const defaultRaidbossNonConfigOptions: RaidbossNonConfigOptions = {
 
   PerTriggerAutoConfig: {},
   PerTriggerOptions: {},
+  PerZoneTimelineConfig: {},
 
   Triggers: [],
 

--- a/ui/raidboss/timeline.ts
+++ b/ui/raidboss/timeline.ts
@@ -118,12 +118,12 @@ export class Timeline {
   public ui?: TimelineUI;
 
   constructor(
-    private zoneId: number,
     text: string,
     replacements: TimelineReplacement[],
     triggers: LooseTimelineTrigger[],
     styles: TimelineStyle[],
     options: RaidbossOptions,
+    private zoneId: number,
   ) {
     this.options = options || {};
     this.replacements = replacements;
@@ -778,12 +778,12 @@ export class TimelineController {
   }
 
   public SetActiveTimeline(
-    zoneId: number,
     timelineFiles: string[],
     timelines: string[],
     replacements: TimelineReplacement[],
     triggers: LooseTimelineTrigger[],
     styles: TimelineStyle[],
+    zoneId: number,
   ): void {
     this.activeTimeline = null;
 
@@ -803,12 +803,12 @@ export class TimelineController {
 
     if (text) {
       this.activeTimeline = new Timeline(
-        zoneId,
         text,
         replacements,
         triggers,
         styles,
         this.options,
+        zoneId,
       );
     }
     this.ui.SetTimeline(this.activeTimeline);
@@ -825,20 +825,20 @@ export class TimelineLoader {
   }
 
   public SetTimelines(
-    zoneId: number,
     timelineFiles: string[],
     timelines: string[],
     replacements: TimelineReplacement[],
     triggers: LooseTimelineTrigger[],
     styles: TimelineStyle[],
+    zoneId: number,
   ): void {
     this.timelineController.SetActiveTimeline(
-      zoneId,
       timelineFiles,
       timelines,
       replacements,
       triggers,
       styles,
+      zoneId,
     );
   }
 

--- a/ui/raidboss/timeline.ts
+++ b/ui/raidboss/timeline.ts
@@ -118,6 +118,7 @@ export class Timeline {
   public ui?: TimelineUI;
 
   constructor(
+    private zoneId: number,
     text: string,
     replacements: TimelineReplacement[],
     triggers: LooseTimelineTrigger[],
@@ -150,7 +151,14 @@ export class Timeline {
   }
 
   private LoadFile(text: string, triggers: LooseTimelineTrigger[], styles: TimelineStyle[]): void {
-    const parsed = new TimelineParser(text, this.replacements, triggers, styles, this.options);
+    const parsed = new TimelineParser(
+      text,
+      this.replacements,
+      triggers,
+      styles,
+      this.options,
+      this.zoneId,
+    );
     this.ignores = parsed.ignores;
     this.events = parsed.events;
     this.texts = parsed.texts;
@@ -770,6 +778,7 @@ export class TimelineController {
   }
 
   public SetActiveTimeline(
+    zoneId: number,
     timelineFiles: string[],
     timelines: string[],
     replacements: TimelineReplacement[],
@@ -792,8 +801,16 @@ export class TimelineController {
     for (const timeline of timelines)
       text = `${text}\n${timeline}`;
 
-    if (text)
-      this.activeTimeline = new Timeline(text, replacements, triggers, styles, this.options);
+    if (text) {
+      this.activeTimeline = new Timeline(
+        zoneId,
+        text,
+        replacements,
+        triggers,
+        styles,
+        this.options,
+      );
+    }
     this.ui.SetTimeline(this.activeTimeline);
   }
 
@@ -808,6 +825,7 @@ export class TimelineLoader {
   }
 
   public SetTimelines(
+    zoneId: number,
     timelineFiles: string[],
     timelines: string[],
     replacements: TimelineReplacement[],
@@ -815,6 +833,7 @@ export class TimelineLoader {
     styles: TimelineStyle[],
   ): void {
     this.timelineController.SetActiveTimeline(
+      zoneId,
       timelineFiles,
       timelines,
       replacements,

--- a/ui/raidboss/timeline_parser.ts
+++ b/ui/raidboss/timeline_parser.ts
@@ -416,6 +416,8 @@ export class TimelineParser {
   }
 
   private GetReplacedText(text: string): string {
+    // Anything in the timeline config takes precedence over timelineReplace sections in
+    // the trigger file.  It is also a full replacement, vs the regex-style GetReplacedHelper.
     const rename = this.timelineConfig?.Rename?.[text];
     if (rename !== undefined)
       return rename;


### PR DESCRIPTION
This adds a new "Edit Timeline" section to the config ui for any trigger set that has a timeline.  On a per text-basis, it allows for hiding all instances of a particular text or renaming it.  The primary use cases are to for folks who think the timeline is too messy or who want to rename things on the timeline (e.g. `Elegant Evisceration` to `Tank Buster`) or some such.

![image](https://user-images.githubusercontent.com/462317/159372480-cdd74aff-9bec-4c4f-aff2-6bb970d0a977.png)
