### PR TITLE
raidboss: add triggers Angra Mainyu Flare and Death

### DIFF
--- a/ui/raidboss/data/02-arr/alliance/the_world_of_darkness.ts
+++ b/ui/raidboss/data/02-arr/alliance/the_world_of_darkness.ts
@@ -115,6 +115,20 @@ const triggerSet: TriggerSet<Data> = {
         },
       },
     },
+    {
+      id: 'Angra Mainyu Level 100 Flare Marker',
+      type: 'HeadMarker',
+      netRegex: NetRegexes.headMarker({ id: '002C' }),
+      condition: Conditions.targetIsNotYou(),
+      response: Responses.awayFrom(),
+    },
+    {
+      id: 'Angra Mainyu Level 150 Death Marker',
+      type: 'HeadMarker',
+      netRegex: NetRegexes.headMarker({ id: '002D' }),
+      condition: Conditions.targetIsNotYou(),
+      response: Responses.awayFrom(),
+    },
   ],
 };
 


### PR DESCRIPTION
During the Angra Mainyu encounter of the World of Darkness, the boss
will cast Level 100 Flare and Level 150 Death. These attacks put a head
marker on a target, and tether a few nearby players. After a few
seconds, the flare or death will trigger. For flare, if the number of
tethered players is still in the circle, everyone in the circle takes
massive damage. For death, if the number of players is a multiple of
3 then all players in the circle die.

The simplest way to avoid this is to have every player except the bound
target leave the circle.

Add an alarm that warns players to move away from the target. For
simplicity, just alert all players even if they aren't tethered. We
could possibly determine the tethers and alert only those players, but
its much simpler to just alert all players to move away.

Signed-off-by: Jacob Keller <jacob.keller@gmail.com>
