### PR TITLE
build: don't mix webpack static dir and output dir

### DIFF
--- a/webpack/constants.ts
+++ b/webpack/constants.ts
@@ -88,6 +88,24 @@ export const cactbotHtmlChunksMap = {
       cactbotModules.raidboss,
     ],
   },
+  'ui/raidboss/raidboss_alerts_only.html': {
+    chunks: [
+      cactbotChunks.raidbossData,
+      cactbotModules.raidboss,
+    ],
+  },
+  'ui/raidboss/raidboss_silent.html': {
+    chunks: [
+      cactbotChunks.raidbossData,
+      cactbotModules.raidboss,
+    ],
+  },
+  'ui/raidboss/raidboss_timeline_only.html': {
+    chunks: [
+      cactbotChunks.raidbossData,
+      cactbotModules.raidboss,
+    ],
+  },
   'ui/raidboss/raidemulator.html': {
     chunks: [
       cactbotChunks.raidbossData,

--- a/webpack/webpack.config.ts
+++ b/webpack/webpack.config.ts
@@ -105,7 +105,7 @@ export default (
       static: [
         path.join(__dirname, '../dist/resources/ffxiv'),
         path.join(__dirname, '../dist/resources/sounds'),
-        path.join(__dirname, '../ui/raidboss/skins/'),
+        path.join(__dirname, '../dist/ui/raidboss/skins/'),
       ],
       devMiddleware: {
         writeToDisk: true,

--- a/webpack/webpack.config.ts
+++ b/webpack/webpack.config.ts
@@ -58,14 +58,12 @@ export default (
     new MiniCssExtractPlugin(),
     ...htmlPluginRules,
     new CopyPlugin({
+      // All of these patterns should be served individually from the static
+      // directory below.
       patterns: [
         {
           // copy sounds and images
           from: 'resources/@(ffxiv|sounds)/**/*',
-        },
-        {
-          // copy more html in raidboss module
-          from: 'ui/raidboss/raidboss_*.html',
         },
         {
           // copy all the skins folder under modules,
@@ -104,9 +102,11 @@ export default (
       assetModuleFilename: '[file][query]',
     },
     devServer: {
-      static: {
-        directory: path.join(__dirname, '../dist'),
-      },
+      static: [
+        path.join(__dirname, '../dist/resources/ffxiv'),
+        path.join(__dirname, '../dist/resources/sounds'),
+        path.join(__dirname, '../ui/raidboss/skins/'),
+      ],
       devMiddleware: {
         writeToDisk: true,
       },


### PR DESCRIPTION
Fixes #3895.

If the static dir is dist/, then any emitted file into the dist/
directory causes a reload.  This causes the build process to
cause continuous reloads, making a slow process much slower.