### PR TITLE
lint: format triggers branch

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -280,7 +280,7 @@ const overrides = [
     },
   },
   {
-    'files': ['**/oopsyraidsy/data/**/*', '**/raidboss/data/**/*'],
+    'files': ['**/oopsyraidsy/data/**/*.ts', '**/raidboss/data/**/*.ts'],
     'rules': {
       ...dprintRule(300),
       // Raidboss data files always export a trigger set, and explicit types are noisy.
@@ -300,9 +300,26 @@ const overrides = [
     },
   },
   {
-    'files': ['**/oopsyraidsy/data/**/*.js', '**/raidboss/data/**/*.js'],
+    // These are for the triggers branch only.
+    'files': [
+      '**/oopsyraidsy/data/**/*.js',
+      '**/raidboss/data/**/*.js',
+    ],
     'rules': {
-      'no-unused-vars': ['warn', { 'args': 'all', 'argsIgnorePattern': '^_\\w+' }],
+      // This is a bit awkward, but see process_trigger_folders.ts.
+      // It runs once without dprint using the indent rule, and then once with dprint.
+      // dprint is VERY slow on unformatted files, but quick when there is nothing to do.
+      // In general however, we don't want to specify both dprint and indent together,
+      // as these rules fight against each other.
+      ...dprintRule(300),
+      'indent': [
+        'warn',
+        2,
+        {
+          'ignoreComments': false,
+          'SwitchCase': 1,
+        },
+      ],
     },
   },
   {


### PR DESCRIPTION
This broke in f099175.  Fixed by properly setting the filename when
running eslint.  However, dprint was incredibly slow (about 1 minute
per file, at least?).  To fix this, I applied the same approach as
we did in #3378 which does a non-dprint format first.

Fixes #4202.