### PR TITLE
raidboss: fix TEA trines / shinryu icicles

### DIFF
--- a/ui/raidboss/data/04-sb/trial/shinryu-ex.ts
+++ b/ui/raidboss/data/04-sb/trial/shinryu-ex.ts
@@ -306,12 +306,15 @@ const triggerSet: TriggerSet<Data> = {
     {
       id: 'ShinryuEx Icicle Left',
       type: 'Ability',
-      netRegex: NetRegexes.abilityFull({ id: '25EF', source: 'Icicle', x: '-29\\.99', y: '-15', capture: false }),
-      netRegexDe: NetRegexes.abilityFull({ id: '25EF', source: 'Eiszapfen', x: '-29\\.99', y: '-15', capture: false }),
-      netRegexFr: NetRegexes.abilityFull({ id: '25EF', source: 'Stalactite', x: '-29\\.99', y: '-15', capture: false }),
-      netRegexJa: NetRegexes.abilityFull({ id: '25EF', source: 'アイシクル', x: '-29\\.99', y: '-15', capture: false }),
-      netRegexCn: NetRegexes.abilityFull({ id: '25EF', source: '冰柱', x: '-29\\.99', y: '-15', capture: false }),
-      netRegexKo: NetRegexes.abilityFull({ id: '25EF', source: '고드름', x: '-29\\.99', y: '-15', capture: false }),
+      netRegex: NetRegexes.ability({ id: '25EF', source: 'Icicle' }),
+      netRegexDe: NetRegexes.ability({ id: '25EF', source: 'Eiszapfen' }),
+      netRegexFr: NetRegexes.ability({ id: '25EF', source: 'Stalactite' }),
+      netRegexJa: NetRegexes.ability({ id: '25EF', source: 'アイシクル' }),
+      netRegexCn: NetRegexes.ability({ id: '25EF', source: '冰柱' }),
+      netRegexKo: NetRegexes.ability({ id: '25EF', source: '고드름' }),
+      condition: (_data, matches) => {
+        return Math.round(parseFloat(matches.x)) === -30 && Math.round(parseFloat(matches.y)) === -15;
+      },
       alarmText: (_data, _matches, output) => output.text!(),
       outputStrings: {
         text: {
@@ -327,12 +330,15 @@ const triggerSet: TriggerSet<Data> = {
     {
       id: 'ShinryuEx Icicle Right',
       type: 'Ability',
-      netRegex: NetRegexes.abilityFull({ id: '25EF', source: 'Icicle', x: '-29\\.99', y: '-25', capture: false }),
-      netRegexDe: NetRegexes.abilityFull({ id: '25EF', source: 'Eiszapfen', x: '-29\\.99', y: '-25', capture: false }),
-      netRegexFr: NetRegexes.abilityFull({ id: '25EF', source: 'Stalactite', x: '-29\\.99', y: '-25', capture: false }),
-      netRegexJa: NetRegexes.abilityFull({ id: '25EF', source: 'アイシクル', x: '-29\\.99', y: '-25', capture: false }),
-      netRegexCn: NetRegexes.abilityFull({ id: '25EF', source: '冰柱', x: '-29\\.99', y: '-25', capture: false }),
-      netRegexKo: NetRegexes.abilityFull({ id: '25EF', source: '고드름', x: '-29\\.99', y: '-25', capture: false }),
+      netRegex: NetRegexes.ability({ id: '25EF', source: 'Icicle' }),
+      netRegexDe: NetRegexes.ability({ id: '25EF', source: 'Eiszapfen' }),
+      netRegexFr: NetRegexes.ability({ id: '25EF', source: 'Stalactite' }),
+      netRegexJa: NetRegexes.ability({ id: '25EF', source: 'アイシクル' }),
+      netRegexCn: NetRegexes.ability({ id: '25EF', source: '冰柱' }),
+      netRegexKo: NetRegexes.ability({ id: '25EF', source: '고드름' }),
+      condition: (_data, matches) => {
+        return Math.round(parseFloat(matches.x)) === -30 && Math.round(parseFloat(matches.y)) === -25;
+      },
       alarmText: (_data, _matches, output) => output.text!(),
       outputStrings: {
         text: {

--- a/ui/raidboss/data/05-shb/ultimate/the_epic_of_alexander.ts
+++ b/ui/raidboss/data/05-shb/ultimate/the_epic_of_alexander.ts
@@ -1,6 +1,5 @@
 import Conditions from '../../../../../resources/conditions';
 import NetRegexes from '../../../../../resources/netregexes';
-import { UnreachableCode } from '../../../../../resources/not_reached';
 import Outputs from '../../../../../resources/outputs';
 import { Responses } from '../../../../../resources/responses';
 import ZoneId from '../../../../../resources/zone_id';
@@ -2763,13 +2762,20 @@ const triggerSet: TriggerSet<Data> = {
     {
       id: 'TEA Trine Initial',
       type: 'Ability',
-      netRegex: NetRegexes.abilityFull({ source: 'Perfect Alexander', id: '488F', x: '100', y: '(?:92|100|108)' }),
-      netRegexDe: NetRegexes.abilityFull({ source: 'Perfekter Alexander', id: '488F', x: '100', y: '(?:92|100|108)' }),
-      netRegexFr: NetRegexes.abilityFull({ source: 'Alexander parfait', id: '488F', x: '100', y: '(?:92|100|108)' }),
-      netRegexJa: NetRegexes.abilityFull({ source: 'パーフェクト・アレキサンダー', id: '488F', x: '100', y: '(?:92|100|108)' }),
-      netRegexCn: NetRegexes.abilityFull({ source: '完美亚历山大', id: '488F', x: '100', y: '(?:92|100|108)' }),
-      netRegexKo: NetRegexes.abilityFull({ source: '완전체 알렉산더', id: '488F', x: '100', y: '(?:92|100|108)' }),
-      preRun: (data, matches) => {
+      netRegex: NetRegexes.ability({ source: 'Perfect Alexander', id: '488F' }),
+      netRegexDe: NetRegexes.ability({ source: 'Perfekter Alexander', id: '488F' }),
+      netRegexFr: NetRegexes.ability({ source: 'Alexander parfait', id: '488F' }),
+      netRegexJa: NetRegexes.ability({ source: 'パーフェクト・アレキサンダー', id: '488F' }),
+      netRegexCn: NetRegexes.ability({ source: '完美亚历山大', id: '488F' }),
+      netRegexKo: NetRegexes.ability({ source: '완전체 알렉산더', id: '488F' }),
+      alertText: (data, matches, output) => {
+        // Looking for (100, 92), (100, 100), or (100, 108).
+        const x = Math.round(parseFloat(matches.x));
+        const y = Math.round(parseFloat(matches.y));
+
+        if (x !== 100)
+          return;
+
         data.trine ??= [];
         // See: https://imgur.com/a/l1n9MhS
         const trineMap: { [posY: number]: string } = {
@@ -2777,12 +2783,11 @@ const triggerSet: TriggerSet<Data> = {
           100: 'g',
           108: 'y',
         };
-        const thisTrine = trineMap[parseFloat(matches.y)];
+        const thisTrine = trineMap[y];
         if (!thisTrine)
-          throw new UnreachableCode();
+          return;
         data.trine.push(thisTrine);
-      },
-      alertText: (data, _matches, output) => {
+
         // Call out after two, because that's when the mechanic is fully known.
         data.trine ??= [];
         if (data.trine.length !== 2)


### PR DESCRIPTION
These were broken due to extra precision from the 6.x ffxiv
act plugin changes.  Changed to look at all numbers and round
them, which should be more robust going forward.

Huge thanks to @valarnin for debugging!

Fixes #4212.