### PR TITLE
raidboss: extend duration for diamond ex platform switch

### DIFF
--- a/ui/raidboss/data/05-shb/trial/diamond_weapon-ex.ts
+++ b/ui/raidboss/data/05-shb/trial/diamond_weapon-ex.ts
@@ -64,6 +64,7 @@ const triggerSet: TriggerSet<Data> = {
       netRegexJa: NetRegexes.startsUsing({ source: 'ダイヤウェポン', id: '5F9B', capture: false }),
       netRegexCn: NetRegexes.startsUsing({ source: '钻石神兵', id: '5F9B', capture: false }),
       netRegexKo: NetRegexes.startsUsing({ source: '다이아몬드 웨폰', id: '5F9B', capture: false }),
+      durationSeconds: 15,
       infoText: (_data, _matches, output) => output.text!(),
       outputStrings: {
         text: {
@@ -85,6 +86,7 @@ const triggerSet: TriggerSet<Data> = {
       netRegexJa: NetRegexes.startsUsing({ source: 'ダイヤウェポン', id: '5F9A', capture: false }),
       netRegexCn: NetRegexes.startsUsing({ source: '钻石神兵', id: '5F9A', capture: false }),
       netRegexKo: NetRegexes.startsUsing({ source: '다이아몬드 웨폰', id: '5F9A', capture: false }),
+      durationSeconds: 15,
       infoText: (_data, _matches, output) => output.text!(),
       outputStrings: {
         text: {
@@ -106,6 +108,7 @@ const triggerSet: TriggerSet<Data> = {
       netRegexJa: NetRegexes.startsUsing({ source: 'ダイヤウェポン', id: '5FA5', capture: false }),
       netRegexCn: NetRegexes.startsUsing({ source: '钻石神兵', id: '5FA5', capture: false }),
       netRegexKo: NetRegexes.startsUsing({ source: '다이아몬드 웨폰', id: '5FA5', capture: false }),
+      durationSeconds: 15,
       infoText: (_data, _matches, output) => output.text!(),
       outputStrings: {
         text: {
@@ -127,6 +130,7 @@ const triggerSet: TriggerSet<Data> = {
       netRegexJa: NetRegexes.startsUsing({ source: 'ダイヤウェポン', id: '5FA4', capture: false }),
       netRegexCn: NetRegexes.startsUsing({ source: '钻石神兵', id: '5FA4', capture: false }),
       netRegexKo: NetRegexes.startsUsing({ source: '다이아몬드 웨폰', id: '5FA4', capture: false }),
+      durationSeconds: 15,
       infoText: (_data, _matches, output) => output.text!(),
       outputStrings: {
         text: {
@@ -148,6 +152,7 @@ const triggerSet: TriggerSet<Data> = {
       netRegexJa: NetRegexes.startsUsing({ source: 'ダイヤウェポン', id: '5FA3', capture: false }),
       netRegexCn: NetRegexes.startsUsing({ source: '钻石神兵', id: '5FA3', capture: false }),
       netRegexKo: NetRegexes.startsUsing({ source: '다이아몬드 웨폰', id: '5FA3', capture: false }),
+      durationSeconds: 15,
       infoText: (_data, _matches, output) => output.text!(),
       outputStrings: {
         text: {
@@ -169,6 +174,7 @@ const triggerSet: TriggerSet<Data> = {
       netRegexJa: NetRegexes.startsUsing({ source: 'ダイヤウェポン', id: '5FA2', capture: false }),
       netRegexCn: NetRegexes.startsUsing({ source: '钻石神兵', id: '5FA2', capture: false }),
       netRegexKo: NetRegexes.startsUsing({ source: '다이아몬드 웨폰', id: '5FA2', capture: false }),
+      durationSeconds: 15,
       infoText: (_data, _matches, output) => output.text!(),
       outputStrings: {
         text: {


### PR DESCRIPTION
When the Diamond Weapon is going to swipe a platform, an info message is
presented to inform the user of which side to move to and what attack
will follow this.

The default 5 second duration causes the info message to be gone well
before the attacks happen. Extend this duration to 15 seconds, lining up
better with the overall mechanic. This is ok because no other alerts
happen during this time.

The longer duration allows users to see what is happening more easily,
giving time to notice it and response without needing to memorize it for
10 seconds while focusing on other aspects of the fight.

Signed-off-by: Jacob Keller <jacob.keller@gmail.com>
