### PR TITLE
raidboss: Ultima EX timeline and minimal triggers

### DIFF
--- a/ui/raidboss/data/02-arr/trial/ultima-ex.ts
+++ b/ui/raidboss/data/02-arr/trial/ultima-ex.ts
@@ -32,7 +32,7 @@ const triggerSet: TriggerSet<Data> = {
     {
       // At 5 stacks of Aetheroplasm, the target begins taking massive damage.
       id: 'Ultima EX Viscous Aetheroplasm',
-      netRegex: NetRegexes.gainsEffect({ effectId: '171', count: '4' }),
+      netRegex: NetRegexes.gainsEffect({ effectId: '171', count: '04' }),
       response: Responses.tankBusterSwap(),
     },
   ],

--- a/ui/raidboss/data/02-arr/trial/ultima-ex.ts
+++ b/ui/raidboss/data/02-arr/trial/ultima-ex.ts
@@ -4,17 +4,26 @@ import ZoneId from '../../../../../resources/zone_id';
 import { RaidbossData } from '../../../../../types/data';
 import { TriggerSet } from '../../../../../types/trigger';
 
-export type Data = RaidbossData;
+export interface Data extends RaidbossData {
+  plasmTargets?: Array<string>;
+  boomCounter: number;
+}
 
 const triggerSet: TriggerSet<Data> = {
   zoneId: ZoneId.TheMinstrelsBalladUltimasBane,
   timelineFile: 'ultima-ex.txt',
+  initData: () => {
+    return {
+      plasmTargets: [],
+      boomCounter: 0,
+    };
+  },
   timelineTriggers: [
     {
       // Early Callout for Tank Cleave
       id: 'Ultima EX Homing Lasers',
       regex: /Homing Lasers/,
-      beforeSeconds: 5,
+      beforeSeconds: 4,
       alertText: (_data, _matches, output) => output.text!(),
       outputStrings: {
         text: {
@@ -22,18 +31,94 @@ const triggerSet: TriggerSet<Data> = {
         },
       },
     },
+    {
+      id: 'Ultima EX Vulcan Burst',
+      regex: /Vulcan Burst/,
+      beforeSeconds: 4,
+      infoText: (_data, _matches, output) => output.text!(),
+      outputStrings: {
+        text: {
+          en: 'Melee knockback',
+        },
+      },
+    },
   ],
   triggers: [
     {
       id: 'Ultima EX Tank Purge',
+      type: 'StartsUsing',
       netRegex: NetRegexes.startsUsing({ id: '5EA', source: 'The Ultima Weapon', capture: false }),
       response: Responses.bigAoe(),
     },
     {
-      // At 5 stacks of Aetheroplasm, the target begins taking massive damage.
+      // At 5 stacks of Viscous Aetheroplasm, the target begins taking massive damage.
       id: 'Ultima EX Viscous Aetheroplasm',
-      netRegex: NetRegexes.gainsEffect({ effectId: '171', count: '04' }),
-      response: Responses.tankBusterSwap(),
+      type: 'GainsEffect',
+      netRegex: NetRegexes.gainsEffect({ effectId: '171', count: '04', capture: false }),
+      condition: (data) => data.role === 'tank',
+      alertText: (_data, _matches, output) => output.text!(),
+      outputStrings: {
+        text: {
+          en: 'Tank Swap Now--4 Stacks',
+        },
+      },
+    },
+    {
+      id: 'Ultima EX Homing Aetheroplasm Collect',
+      type: 'Ability',
+      netRegex: NetRegexes.ability({ id: '672' }),
+      run: (data, matches) => {
+        data.plasmTargets = data.plasmTargets ??= [];
+        data.plasmTargets.push(matches.target);
+      },
+    },
+    {
+      // This ability is ARR 2.0's version of headmarkers. No associated 27 lines are present.
+      // These lines are sent by entities with no name and no 03/04 lines.
+      id: 'Ultima EX Homing Aetheroplasm Call',
+      type: 'Ability',
+      netRegex: NetRegexes.ability({ id: '672', capture: false }),
+      delaySeconds: 0.5,
+      suppressSeconds: 5,
+      infoText: (data, _matches, output) => {
+        if (data.plasmTargets?.includes(data.me))
+          return output.target!();
+        return output.avoid!();
+      },
+      outputStrings: {
+        target: {
+          en: 'Homing Aetheroplasm on YOU',
+        },
+        avoid: {
+          en: 'Avoid Homing Aetheroplasm',
+        },
+      },
+    },
+    {
+      id: 'Ultima EX Homing Aetheroplasm Cleanup',
+      type: 'Ability',
+      netRegex: NetRegexes.ability({ id: '672', capture: false }),
+      suppressSeconds: 5,
+      run: (data) => delete data.plasmTargets,
+    },
+    {
+      // We use a StartsUsing line here because we can't use timeline triggers for this,
+      // and we want to warn players as early as possible.
+      id: 'Ultima EX Aetheric Boom',
+      type: 'StartsUsing',
+      netRegex: NetRegexes.startsUsing({ id: '5E7', source: 'The Ultima Weapon', capture: false }),
+      alarmText: (data, _matches, output) => output[data.boomCounter]!(),
+      outputStrings: {
+        0: {
+          en: 'Boom Orbs: 1x at cardinals',
+        },
+        1: {
+          en: 'Boom Orbs: 1x N/S, 2x E/W',
+        },
+        2: {
+          en: 'Boom Orbs: 2x at intercardinals',
+        },
+      },
     },
   ],
 };

--- a/ui/raidboss/data/02-arr/trial/ultima-ex.ts
+++ b/ui/raidboss/data/02-arr/trial/ultima-ex.ts
@@ -1,0 +1,41 @@
+import NetRegexes from '../../../../../resources/netregexes';
+import { Responses } from '../../../../../resources/responses';
+import ZoneId from '../../../../../resources/zone_id';
+import { RaidbossData } from '../../../../../types/data';
+import { TriggerSet } from '../../../../../types/trigger';
+
+export type Data = RaidbossData;
+
+const triggerSet: TriggerSet<Data> = {
+  zoneId: ZoneId.TheMinstrelsBalladUltimasBane,
+  timelineFile: 'ultima-ex.txt',
+  timelineTriggers: [
+    {
+      // Early Callout for Tank Cleave
+      id: 'Ultima EX Homing Lasers',
+      regex: /Homing Lasers/,
+      beforeSeconds: 5,
+      alertText: (_data, _matches, output) => output.text!(),
+      outputStrings: {
+        text: {
+          en: 'Off-tank cleave',
+        },
+      },
+    },
+  ],
+  triggers: [
+    {
+      id: 'Ultima EX Tank Purge',
+      netRegex: NetRegexes.startsUsing({ id: '5EA', source: 'The Ultima Weapon', capture: false }),
+      response: Responses.bigAoe(),
+    },
+    {
+      // At 5 stacks of Aetheroplasm, the target begins taking massive damage.
+      id: 'Ultima EX Viscous Aetheroplasm',
+      netRegex: NetRegexes.gainsEffect({ effectId: '171', count: '4' }),
+      response: Responses.tankBusterSwap(),
+    },
+  ],
+};
+
+export default triggerSet;

--- a/ui/raidboss/data/02-arr/trial/ultima-ex.ts
+++ b/ui/raidboss/data/02-arr/trial/ultima-ex.ts
@@ -1,5 +1,5 @@
 import NetRegexes from '../../../../../resources/netregexes';
-import outputs from '../../../../../resources/outputs';
+import Outputs from '../../../../../resources/outputs';
 import { Responses } from '../../../../../resources/responses';
 import ZoneId from '../../../../../resources/zone_id';
 import { RaidbossData } from '../../../../../types/data';
@@ -59,7 +59,7 @@ const triggerSet: TriggerSet<Data> = {
       condition: (data) => data.role === 'tank',
       alertText: (_data, _matches, output) => output.text!(),
       outputStrings: {
-        text: outputs.tankSwap,
+        text: Outputs.tankSwap,
       },
     },
     {

--- a/ui/raidboss/data/02-arr/trial/ultima-ex.ts
+++ b/ui/raidboss/data/02-arr/trial/ultima-ex.ts
@@ -35,7 +35,7 @@ const triggerSet: TriggerSet<Data> = {
     {
       id: 'Ultima EX Vulcan Burst',
       regex: /Vulcan Burst/,
-      beforeSeconds: 4,
+      beforeSeconds: 5,
       infoText: (_data, _matches, output) => output.text!(),
       outputStrings: {
         text: {

--- a/ui/raidboss/data/02-arr/trial/ultima-ex.ts
+++ b/ui/raidboss/data/02-arr/trial/ultima-ex.ts
@@ -1,4 +1,5 @@
 import NetRegexes from '../../../../../resources/netregexes';
+import outputs from '../../../../../resources/outputs';
 import { Responses } from '../../../../../resources/responses';
 import ZoneId from '../../../../../resources/zone_id';
 import { RaidbossData } from '../../../../../types/data';
@@ -15,7 +16,7 @@ const triggerSet: TriggerSet<Data> = {
   initData: () => {
     return {
       plasmTargets: [],
-      boomCounter: 0,
+      boomCounter: 1,
     };
   },
   timelineTriggers: [
@@ -58,9 +59,7 @@ const triggerSet: TriggerSet<Data> = {
       condition: (data) => data.role === 'tank',
       alertText: (_data, _matches, output) => output.text!(),
       outputStrings: {
-        text: {
-          en: 'Tank Swap Now--4 Stacks',
-        },
+        text: outputs.tankSwap,
       },
     },
     {
@@ -107,16 +106,17 @@ const triggerSet: TriggerSet<Data> = {
       id: 'Ultima EX Aetheric Boom',
       type: 'StartsUsing',
       netRegex: NetRegexes.startsUsing({ id: '5E7', source: 'The Ultima Weapon', capture: false }),
-      alarmText: (data, _matches, output) => output[data.boomCounter]!(),
+      alarmText: (data, _matches, output) => output[`boom${data.boomCounter}`]!(),
+      run: (data) => data.boomCounter += 1,
       outputStrings: {
-        0: {
-          en: 'Boom Orbs: 1x at cardinals',
+        boom1: {
+          en: 'Orbs: Cardinals',
         },
-        1: {
-          en: 'Boom Orbs: 1x N/S, 2x E/W',
+        boom2: {
+          en: 'Orbs: Cardinals (N/S first)',
         },
-        2: {
-          en: 'Boom Orbs: 2x at intercardinals',
+        boom3: {
+          en: 'Orbs: Intercardinals',
         },
       },
     },

--- a/ui/raidboss/data/02-arr/trial/ultima-ex.txt
+++ b/ui/raidboss/data/02-arr/trial/ultima-ex.txt
@@ -59,7 +59,7 @@ hideall "--sync--"
 201.6 "Weight of the Land" sync / 1[56]:[^:]*:The Ultima Weapon:5F2:/
 203.7 "Viscous Aetheroplasm" sync / 1[56]:[^:]*:The Ultima Weapon:5DF:/
 
-212.5 "Tank Purge" sync / 1[56]:[^:]*:The Ultima Weapon:5EA:/ window 30,30 jump 168.2
+212.5 "Tank Purge" sync / 1[56]:[^:]*:The Ultima Weapon:5EA:/ window 30,30 jump 164.8
 215.9 "Homing Lasers"
 223.2 "Radiant Plume"
 227.2 "Weight of the Land"
@@ -71,89 +71,161 @@ hideall "--sync--"
 # As in phase 2, Titan's death animation comes first with no indicator.
 # The phase opens with what seems to be a *long* set of fixed blocks.
 
-271.3 "--sync--" sync / 14:[^:]*:The Ultima Weapon:5F4:/ window 271.3,0
-274.0 "Eruption x5" duration 8 #sync / 1[56]:[^:]*:The Ultima Weapon:5F4:/
-280.6 "Viscous Aetheroplasm" sync / 1[56]:[^:]*:The Ultima Weapon:5DF:/
-289.3 "Tank Purge" sync / 1[56]:[^:]*:The Ultima Weapon:5EA:/
-292.6 "Homing Lasers" sync / 1[56]:[^:]*:The Ultima Weapon:5E1:/
-297.9 "Ceruleum Vent" sync / 1[56]:[^:]*:The Ultima Weapon:5E0:/
-304.0 "Radiant Plume" sync / 1[56]:[^:]*:The Ultima Weapon:5F1:/
-306.8 "Crimson Cyclone" sync / 1[56]:[^:]*:Ultima Ifrit:5F5:/
-308.1 "Radiant Plume" sync / 1[56]:[^:]*:The Ultima Weapon:5F1:/
-312.1 "Radiant Plume" sync / 1[56]:[^:]*:The Ultima Weapon:5F1:/
-314.3 "Viscous Aetheroplasm" sync / 1[56]:[^:]*:The Ultima Weapon:5DF:/
-314.8 "Crimson Cyclone" sync / 1[56]:[^:]*:Ultima Ifrit:5F5:/
-316.0 "Radiant Plume" sync / 1[56]:[^:]*:The Ultima Weapon:5F1:/
-321.6 "Homing Lasers" sync / 1[56]:[^:]*:The Ultima Weapon:5E1:/
+297.3 "--sync--" sync / 14:[^:]*:The Ultima Weapon:5F4:/ window 297.3,0
+300.0 "Eruption x5" duration 8 #sync / 1[56]:[^:]*:The Ultima Weapon:5F4:/
+306.6 "Viscous Aetheroplasm" sync / 1[56]:[^:]*:The Ultima Weapon:5DF:/
+315.3 "Tank Purge" sync / 1[56]:[^:]*:The Ultima Weapon:5EA:/ window 15,15
+318.6 "Homing Lasers" sync / 1[56]:[^:]*:The Ultima Weapon:5E1:/
+323.9 "Ceruleum Vent" sync / 1[56]:[^:]*:The Ultima Weapon:5E0:/
+330.0 "Radiant Plume" sync / 1[56]:[^:]*:The Ultima Weapon:5F1:/
+332.8 "Crimson Cyclone" sync / 1[56]:[^:]*:Ultima Ifrit:5F5:/
+334.1 "Radiant Plume" sync / 1[56]:[^:]*:The Ultima Weapon:5F1:/
+338.1 "Radiant Plume" sync / 1[56]:[^:]*:The Ultima Weapon:5F1:/
+340.3 "Viscous Aetheroplasm" sync / 1[56]:[^:]*:The Ultima Weapon:5DF:/ window 15,15
+340.8 "Crimson Cyclone" sync / 1[56]:[^:]*:Ultima Ifrit:5F5:/
+342.0 "Radiant Plume" sync / 1[56]:[^:]*:The Ultima Weapon:5F1:/
+347.6 "Homing Lasers" sync / 1[56]:[^:]*:The Ultima Weapon:5E1:/
 
-329.5 "Eruption x5" duration 8 #sync / 1[56]:[^:]*:The Ultima Weapon:5F4:/
-334.0 "Ceruleum Vent" sync / 1[56]:[^:]*:The Ultima Weapon:5E0:/
-337.4 "Viscous Aetheroplasm" sync / 1[56]:[^:]*:The Ultima Weapon:5DF:/
-346.1 "Tank Purge" sync / 1[56]:[^:]*:The Ultima Weapon:5EA:/
-349.5 "Homing Lasers" sync / 1[56]:[^:]*:The Ultima Weapon:5E1:/
+355.5 "Eruption x5" duration 8 #sync / 1[56]:[^:]*:The Ultima Weapon:5F4:/
+360.0 "Ceruleum Vent" sync / 1[56]:[^:]*:The Ultima Weapon:5E0:/
+363.4 "Viscous Aetheroplasm" sync / 1[56]:[^:]*:The Ultima Weapon:5DF:/
+372.1 "Tank Purge" sync / 1[56]:[^:]*:The Ultima Weapon:5EA:/ window 15,15
+375.5 "Homing Lasers" sync / 1[56]:[^:]*:The Ultima Weapon:5E1:/
 
 # A possible extra block is here, but it doesn't seem to change the rotation.
 # Ceruleum Vent jumps to a small sidetrack before continuing.
-354.1 "--sync--" sync / 14:[^:]*:The Ultima Weapon:5F1:/ # Radiant Plume cast
-354.8 "Ceruleum Vent?" sync / 1[56]:[^:]*:The Ultima Weapon:5E0:/
-356.8 "Radiant Plume?" sync / 1[56]:[^:]*:The Ultima Weapon:5F1:/
-358.1 "Viscous Aetheroplasm?" sync / 1[56]:[^:]*:The Ultima Weapon:5DF:/
-359.6 "Crimson Cyclone" sync / 1[56]:[^:]*:Ultima Ifrit:5F5:/
-360.9 "Radiant Plume" sync / 1[56]:[^:]*:The Ultima Weapon:5F1:/
-364.9 "Radiant Plume" sync / 1[56]:[^:]*:The Ultima Weapon:5F1:/
-365.4 "Homing Lasers" sync / 1[56]:[^:]*:The Ultima Weapon:5E1:/
-370.8 "Ceruleum Vent" sync / 1[56]:[^:]*:The Ultima Weapon:5E0:/
+380.1 "--sync--" sync / 14:[^:]*:The Ultima Weapon:5F1:/ jump 547.3 # Radiant Plume
+380.8 "Ceruleum Vent?" sync / 1[56]:[^:]*:The Ultima Weapon:5E0:/ jump 450
+382.8 "Radiant Plume?"
+384.1 "Viscous Aetheroplasm?"
+385.6 "Crimson Cyclone?"
+386.9 "Radiant Plume?"
+390.9 "Radiant Plume?"
+391.4 "Homing Lasers?"
 
 # Vent sidetrack into normal early Eruption block
-355.7 "Ceruleum Vent" sync / 1[56]:[^:]*:The Ultima Weapon:5E0:/
-359.0 "Viscous Aetheroplasm" sync / 1[56]:[^:]*:The Ultima Weapon:5DF:/
-366.3 "Homing Lasers" sync / 1[56]:[^:]*:The Ultima Weapon:5E1:/
-371.7 "Ceruleum Vent" sync / 1[56]:[^:]*:The Ultima Weapon:5E0:/
-
+450.0 "Ceruleum Vent" sync / 1[56]:[^:]*:The Ultima Weapon:5E0:/
+453.3 "Viscous Aetheroplasm" sync / 1[56]:[^:]*:The Ultima Weapon:5DF:/
+460.6 "Homing Lasers" sync / 1[56]:[^:]*:The Ultima Weapon:5E1:/
+466.0 "Ceruleum Vent" sync / 1[56]:[^:]*:The Ultima Weapon:5E0:/
 
 # Normal early Eruption block
-374.9 "Eruption x5" duration 8 #sync / 1[56]:[^:]*:The Ultima Weapon:5F4:/
-380.7 "Viscous Aetheroplasm" sync / 1[56]:[^:]*:The Ultima Weapon:5DF:/
-389.5 "Tank Purge" sync / 1[56]:[^:]*:The Ultima Weapon:5EA:/
-392.8 "Homing Lasers" sync / 1[56]:[^:]*:The Ultima Weapon:5E1:/
-398.2 "Ceruleum Vent" sync / 1[56]:[^:]*:The Ultima Weapon:5E0:/
+466.5 "--sync--" sync / 14:[^:]*:The Ultima Weapon:5F4:/
+469.2 "Eruption x5" duration 8 #sync / 1[56]:[^:]*:The Ultima Weapon:5F4:/
+475.0 "Viscous Aetheroplasm" sync / 1[56]:[^:]*:The Ultima Weapon:5DF:/
+483.8 "Tank Purge" sync / 1[56]:[^:]*:The Ultima Weapon:5EA:/
+487.1 "Homing Lasers" sync / 1[56]:[^:]*:The Ultima Weapon:5E1:/
+492.5 "Ceruleum Vent" sync / 1[56]:[^:]*:The Ultima Weapon:5E0:/
 
 # Eruption and Cyclone blocks will alternate from here.
 # *However*, at any time, a Viscous Aetheroplasm bridge may follow.
 # Subesquent blocks are different, ending with an Aetheroplasm rather than a Vent.
 
-398.4 "--sync--" sync / 14:[^:]*:The Ultima Weapon:5F1:/
-401.1 "Radiant Plume?" sync / 1[56]:[^:]*:The Ultima Weapon:5F1:/
-401.5 "Viscous Aetheroplasm?" sync / 1[56]:[^:]*:The Ultima Weapon:5DF:/
-403.9 "Crimson Cyclone?"
-405.2 "Radiant Plume"
-408.8 "Homing Lasers?"
-409.2 "Radiant Plume?"
-412.0 "Crimson Cyclone?"
+492.7 "--sync--" sync / 14:[^:]*:The Ultima Weapon:5F1:/ window 20,20 jump 547.3 # Radiant Plume
+495.4 "Radiant Plume?"
+495.8 "Viscous Aetheroplasm?" sync / 1[56]:[^:]*:The Ultima Weapon:5DF:/ window 15,15 jump 650
+498.2 "Crimson Cyclone?"
+499.5 "Radiant Plume"
+503.1 "Homing Lasers?"
+503.5 "Radiant Plume?"
+506.3 "Crimson Cyclone?"
 
 # Normal early Cyclone block
 # Ceruleum Vent doesn't always happen during these Cyclone blocks.
 # However, timings don't seem dependent on its use,
 # so we can safely just not sync it and leave the block alone.
-401.1 "Radiant Plume" sync / 1[56]:[^:]*:The Ultima Weapon:5F1:/
-403.9 "Crimson Cyclone" sync / 1[56]:[^:]*:Ultima Ifrit:5F5:/
-405.2 "Radiant Plume" sync / 1[56]:[^:]*:The Ultima Weapon:5F1:/
-409.2 "Radiant Plume" sync / 1[56]:[^:]*:The Ultima Weapon:5F1:/
-412.0 "Crimson Cyclone" sync / 1[56]:[^:]*:Ultima Ifrit:5F5:/
-412.2 "Ceruleum Vent?" #sync / 1[56]:[^:]*:The Ultima Weapon:5E0:/
-413.2 "Radiant Plume" sync / 1[56]:[^:]*:The Ultima Weapon:5F1:/
-415.5 "Viscous Aetheroplasm" sync / 1[56]:[^:]*:The Ultima Weapon:5DF:/
-422.8 "Homing Lasers" sync / 1[56]:[^:]*:The Ultima Weapon:5E1:/
-428.2 "Ceruleum Vent" sync / 1[56]:[^:]*:The Ultima Weapon:5E0:/
+547.3 "--sync--" sync / 14:[^:]*:The Ultima Weapon:5F1:/
+550.0 "Radiant Plume" sync / 1[56]:[^:]*:The Ultima Weapon:5F1:/
+552.8 "Crimson Cyclone" sync / 1[56]:[^:]*:Ultima Ifrit:5F5:/
+554.1 "Radiant Plume" sync / 1[56]:[^:]*:The Ultima Weapon:5F1:/
+558.1 "Radiant Plume" sync / 1[56]:[^:]*:The Ultima Weapon:5F1:/
+560.9 "Crimson Cyclone" sync / 1[56]:[^:]*:Ultima Ifrit:5F5:/
+561.1 "Ceruleum Vent?" #sync / 1[56]:[^:]*:The Ultima Weapon:5E0:/
+562.1 "Radiant Plume" sync / 1[56]:[^:]*:The Ultima Weapon:5F1:/
+564.4 "Viscous Aetheroplasm" sync / 1[56]:[^:]*:The Ultima Weapon:5DF:/
+571.7 "Homing Lasers" sync / 1[56]:[^:]*:The Ultima Weapon:5E1:/
+577.1 "Ceruleum Vent" sync / 1[56]:[^:]*:The Ultima Weapon:5E0:/
 
 # Jump to the Aetheroplasm bridge or the early Eruption block
-428.5 "--sync--" sync / 14:[^:]*:The Ultima Weapon:5F4:/
-431.2 "Eruption x5"
-431.5 "Viscous Aetheroplasm?" sync / 1[56]:[^:]*:The Ultima Weapon:5DF:/
-437.0 "Viscous Aetheroplasm?"
-438.8 "Homing Lasers?"
-444.1 "Ceruleum Vent?"
-445.8 "Tank Purge"
+577.4 "--sync--" sync / 14:[^:]*:The Ultima Weapon:5F4:/ window 20,20 jump 466.5
+580.1 "Eruption x5?"
+580.4 "Viscous Aetheroplasm?" sync / 1[56]:[^:]*:The Ultima Weapon:5DF:/ window 10,10 jump 650
+585.9 "Viscous Aetheroplasm?"
+587.7 "Homing Lasers?"
+593.0 "Ceruleum Vent?"
+594.7 "Tank Purge"
+
+# An Aetheroplasm immediately following a Vent seems to indicate the start of the late rotation.
+# If this block follows an Eruption block, Tank Purge is skipped.
+# If this block follows a Cyclone block, Aetheroplasm is skipped
+650.0 "Viscous Aetheroplasm" sync / 1[56]:[^:]*:The Ultima Weapon:5DF:/
+658.7 "Tank Purge?" #sync / 1[56]:[^:]*:The Ultima Weapon:5EA:/
+662.0 "Homing Lasers" sync / 1[56]:[^:]*:The Ultima Weapon:5E1:/ window 12,5
+667.3 "Ceruleum Vent" sync / 1[56]:[^:]*:The Ultima Weapon:5E0:/
+670.7 "Viscous Aetheroplasm?" #sync / 1[56]:[^:]*:The Ultima Weapon:5DF:/
+
+# From here, the late Cyclone/Eruption blocks are added.
+669.9 "--sync--" sync / 14:[^:]*:The Ultima Weapon:5F1:/ jump 697.3 # Radiant Plume
+671.0 "--sync--" sync / 14:[^:]*:The Ultima Weapon:5F4:/ jump 797.3 # Eruption
+672.6 "Radiant Plume?"
+673.7 "Eruption x5?"
+675.4 "Crimson Cyclone?"
+676.7 "Radiant Plume?"
+680.7 "Radiant Plume?"
+684.3 "Tank Purge?"
+
+# Late Cyclone block
+697.3 "--sync--" sync / 14:[^:]*:The Ultima Weapon:5F1:/
+700.0 "Radiant Plume" sync / 1[56]:[^:]*:The Ultima Weapon:5F1:/
+702.8 "Crimson Cyclone" sync / 1[56]:[^:]*:Ultima Ifrit:5F5:/
+704.1 "Radiant Plume" sync / 1[56]:[^:]*:The Ultima Weapon:5F1:/
+708.1 "Radiant Plume" sync / 1[56]:[^:]*:The Ultima Weapon:5F1:/
+710.9 "Crimson Cyclone" sync / 1[56]:[^:]*:Ultima Ifrit:5F5:/
+712.1 "Radiant Plume" sync / 1[56]:[^:]*:The Ultima Weapon:5F1:/
+716.1 "Homing Lasers" sync / 1[56]:[^:]*:The Ultima Weapon:5E1:/
+721.4 "Ceruleum Vent" sync / 1[56]:[^:]*:The Ultima Weapon:5E0:/
+724.7 "Viscous Aetheroplasm" sync / 1[56]:[^:]*:The Ultima Weapon:5DF:/
+
+727.3 "--sync--" sync / 14:[^:]*:The Ultima Weapon:5F4:/ jump 797.3 # Eruption
+730.0 "Eruption x5?"
+732.0 "Homing Lasers?" sync / 1[56]:[^:]*:The Ultima Weapon:5E1:/ jump 900
+737.3 "Ceruleum Vent?"
+740.6 "Viscous Aetheroplasm?"
+740.6 "Tank Purge?"
+743.9 "Homing Lasers?"
+
+# Late Eruption block
+797.3 "--sync--" sync / 14:[^:]*:The Ultima Weapon:5F4:/ window 2.5,0
+800.0 "Eruption x5" duration 8 #sync / 1[56]:[^:]*:The Ultima Weapon:5F4:/
+810.6 "Tank Purge" sync / 1[56]:[^:]*:The Ultima Weapon:5EA:/
+813.9 "Homing Lasers" sync / 1[56]:[^:]*:The Ultima Weapon:5E1:/
+819.2 "Ceruleum Vent" sync / 1[56]:[^:]*:The Ultima Weapon:5E0:/
+822.5 "Viscous Aetheroplasm" sync / 1[56]:[^:]*:The Ultima Weapon:5DF:/
+
+825.1 "--sync--" sync / 14:[^:]*:The Ultima Weapon:5F1:/ jump 697.3 # Radiant  Plume
+827.8 "Radiant Plume?"
+829.8 "Homing Lasers?" sync / 1[56]:[^:]*:The Ultima Weapon:5E1:/ jump 900
+830.6 "Crimson Cyclone?"
+831.9 "Radiant Plume?"
+835.1 "Ceruleum Vent?"
+835.9 "Radiant Plume?"
+838.4 "Viscous Aetheroplasm?"
+
+# Late Homing Lasers sidetrack
+900.0 "Homing Lasers" sync / 1[56]:[^:]*:The Ultima Weapon:5E1:/
+905.3 "Ceruleum Vent" sync / 1[56]:[^:]*:The Ultima Weapon:5E0:/
+908.6 "Viscous Aetheroplasm" sync / 1[56]:[^:]*:The Ultima Weapon:5DF:/
+
+912.3 "--sync--" sync / 14:[^:]*:The Ultima Weapon:5F4:/ jump 797.3 # Eruption
+913.2 "--sync--" sync / 14:[^:]*:The Ultima Weapon:5F1:/ jump 697.3 # Radiant Plume
+915.0 "Eruption x5?"
+915.9 "Radiant Plume?"
+918.7 "Crimson Cyclone?"
+920.0 "Radiant Plume?"
+924.0 "Radiant Plume?"
+924.1 "Tank Purge?"
+927.4 "Homing Lasers?"
+
 
 
 9989.3 "--sync--" sync / 14:[^:]*:The Ultima Weapon:5EC:/ window 10000

--- a/ui/raidboss/data/02-arr/trial/ultima-ex.txt
+++ b/ui/raidboss/data/02-arr/trial/ultima-ex.txt
@@ -69,7 +69,129 @@ hideall "--sync--"
 
 # Phase 3: 64.9% -50%
 # As in phase 2, Titan's death animation comes first with no indicator.
+# The phase opens with what seems to be a *long* set of fixed blocks.
 
+271.3 "--sync--" sync / 14:[^:]*:The Ultima Weapon:5F4:/ window 271.3,0
+274.0 "Eruption x5" duration 8 #sync / 1[56]:[^:]*:The Ultima Weapon:5F4:/
+280.6 "Viscous Aetheroplasm" sync / 1[56]:[^:]*:The Ultima Weapon:5DF:/
+289.3 "Tank Purge" sync / 1[56]:[^:]*:The Ultima Weapon:5EA:/
+292.6 "Homing Lasers" sync / 1[56]:[^:]*:The Ultima Weapon:5E1:/
+297.9 "Ceruleum Vent" sync / 1[56]:[^:]*:The Ultima Weapon:5E0:/
+304.0 "Radiant Plume" sync / 1[56]:[^:]*:The Ultima Weapon:5F1:/
+306.8 "Crimson Cyclone" sync / 1[56]:[^:]*:Ultima Ifrit:5F5:/
+308.1 "Radiant Plume" sync / 1[56]:[^:]*:The Ultima Weapon:5F1:/
+312.1 "Radiant Plume" sync / 1[56]:[^:]*:The Ultima Weapon:5F1:/
+314.3 "Viscous Aetheroplasm" sync / 1[56]:[^:]*:The Ultima Weapon:5DF:/
+314.8 "Crimson Cyclone" sync / 1[56]:[^:]*:Ultima Ifrit:5F5:/
+316.0 "Radiant Plume" sync / 1[56]:[^:]*:The Ultima Weapon:5F1:/
+321.6 "Homing Lasers" sync / 1[56]:[^:]*:The Ultima Weapon:5E1:/
+
+329.5 "Eruption x5" duration 8 #sync / 1[56]:[^:]*:The Ultima Weapon:5F4:/
+334.0 "Ceruleum Vent" sync / 1[56]:[^:]*:The Ultima Weapon:5E0:/
+337.4 "Viscous Aetheroplasm" sync / 1[56]:[^:]*:The Ultima Weapon:5DF:/
+346.1 "Tank Purge" sync / 1[56]:[^:]*:The Ultima Weapon:5EA:/
+349.5 "Homing Lasers" sync / 1[56]:[^:]*:The Ultima Weapon:5E1:/
+
+356.8 "Radiant Plume" sync / 1[56]:[^:]*:The Ultima Weapon:5F1:/
+359.6 "Crimson Cyclone" sync / 1[56]:[^:]*:Ultima Ifrit:5F5:/
+360.9 "Radiant Plume" sync / 1[56]:[^:]*:The Ultima Weapon:5F1:/
+364.9 "Radiant Plume" sync / 1[56]:[^:]*:The Ultima Weapon:5F1:/
+367.7 "Crimson Cyclone" sync / 1[56]:[^:]*:Ultima Ifrit:5F5:/
+367.9 "Ceruleum Vent" sync / 1[56]:[^:]*:The Ultima Weapon:5E0:/
+368.9 "Radiant Plume" sync / 1[56]:[^:]*:The Ultima Weapon:5F1:/
+371.2 "Viscous Aetheroplasm" sync / 1[56]:[^:]*:The Ultima Weapon:5DF:/
+378.5 "Homing Lasers" sync / 1[56]:[^:]*:The Ultima Weapon:5E1:/
+383.9 "Ceruleum Vent" sync / 1[56]:[^:]*:The Ultima Weapon:5E0:/
+
+387.1 "Eruption x5" duration 8 #sync / 1[56]:[^:]*:The Ultima Weapon:5F4:/
+392.9 "Viscous Aetheroplasm" sync / 1[56]:[^:]*:The Ultima Weapon:5DF:/
+401.7 "Tank Purge" sync / 1[56]:[^:]*:The Ultima Weapon:5EA:/
+405.0 "Homing Lasers" sync / 1[56]:[^:]*:The Ultima Weapon:5E1:/
+410.4 "Ceruleum Vent" sync / 1[56]:[^:]*:The Ultima Weapon:5E0:/
+
+413.3 "Radiant Plume" sync / 1[56]:[^:]*:The Ultima Weapon:5F1:/
+416.1 "Crimson Cyclone" sync / 1[56]:[^:]*:Ultima Ifrit:5F5:/
+417.4 "Radiant Plume" sync / 1[56]:[^:]*:The Ultima Weapon:5F1:/
+421.4 "Radiant Plume" sync / 1[56]:[^:]*:The Ultima Weapon:5F1:/
+424.2 "Crimson Cyclone" sync / 1[56]:[^:]*:Ultima Ifrit:5F5:/
+425.4 "Viscous Aetheroplasm" sync / 1[56]:[^:]*:The Ultima Weapon:5DF:/
+425.4 "Radiant Plume" sync / 1[56]:[^:]*:The Ultima Weapon:5F1:/
+432.7 "Homing Lasers" sync / 1[56]:[^:]*:The Ultima Weapon:5E1:/
+438.0 "Ceruleum Vent" sync / 1[56]:[^:]*:The Ultima Weapon:5E0:/
+
+443.3 "Eruption x5" duration 8 #sync / 1[56]:[^:]*:The Ultima Weapon:5F4:/
+448.4 "Viscous Aetheroplasm" sync / 1[56]:[^:]*:The Ultima Weapon:5DF:/
+457.2 "Tank Purge" sync / 1[56]:[^:]*:The Ultima Weapon:5EA:/
+460.5 "Homing Lasers" sync / 1[56]:[^:]*:The Ultima Weapon:5E1:/
+465.8 "Ceruleum Vent" sync / 1[56]:[^:]*:The Ultima Weapon:5E0:/
+
+471.1 "Radiant Plume" sync / 1[56]:[^:]*:The Ultima Weapon:5F1:/
+473.9 "Crimson Cyclone" sync / 1[56]:[^:]*:Ultima Ifrit:5F5:/
+475.2 "Radiant Plume" sync / 1[56]:[^:]*:The Ultima Weapon:5F1:/
+479.2 "Radiant Plume" sync / 1[56]:[^:]*:The Ultima Weapon:5F1:/
+482.0 "Crimson Cyclone" sync / 1[56]:[^:]*:Ultima Ifrit:5F5:/
+482.2 "Viscous Aetheroplasm" sync / 1[56]:[^:]*:The Ultima Weapon:5DF:/
+483.2 "Radiant Plume" sync / 1[56]:[^:]*:The Ultima Weapon:5F1:/
+489.5 "Homing Lasers" sync / 1[56]:[^:]*:The Ultima Weapon:5E1:/
+494.8 "Ceruleum Vent" sync / 1[56]:[^:]*:The Ultima Weapon:5E0:/
+
+# An Aetheroplasm immediately following a Vent seems to indicate the start of rotations.
+498.1 "Viscous Aetheroplasm" sync / 1[56]:[^:]*:The Ultima Weapon:5DF:/
+506.8 "Tank Purge" sync / 1[56]:[^:]*:The Ultima Weapon:5EA:/
+510.1 "Homing Lasers" sync / 1[56]:[^:]*:The Ultima Weapon:5E1:/
+515.4 "Ceruleum Vent" sync / 1[56]:[^:]*:The Ultima Weapon:5E0:/
+518.8 "Viscous Aetheroplasm" sync / 1[56]:[^:]*:The Ultima Weapon:5DF:/
+
+521.7 "Radiant Plume" sync / 1[56]:[^:]*:The Ultima Weapon:5F1:/
+524.5 "Crimson Cyclone" sync / 1[56]:[^:]*:Ultima Ifrit:5F5:/
+525.8 "Radiant Plume" sync / 1[56]:[^:]*:The Ultima Weapon:5F1:/
+529.8 "Radiant Plume" sync / 1[56]:[^:]*:The Ultima Weapon:5F1:/
+532.6 "Crimson Cyclone" sync / 1[56]:[^:]*:Ultima Ifrit:5F5:/
+533.8 "Radiant Plume" sync / 1[56]:[^:]*:The Ultima Weapon:5F1:/
+537.8 "Homing Lasers" sync / 1[56]:[^:]*:The Ultima Weapon:5E1:/
+543.1 "Ceruleum Vent" sync / 1[56]:[^:]*:The Ultima Weapon:5E0:/
+546.4 "Viscous Aetheroplasm" sync / 1[56]:[^:]*:The Ultima Weapon:5DF:/
+
+551.7 "Eruption x5" duration 8 #sync / 1[56]:[^:]*:The Ultima Weapon:5F4:/
+562.3 "Tank Purge" sync / 1[56]:[^:]*:The Ultima Weapon:5EA:/
+565.6 "Homing Lasers" sync / 1[56]:[^:]*:The Ultima Weapon:5E1:/
+570.9 "Ceruleum Vent" sync / 1[56]:[^:]*:The Ultima Weapon:5E0:/
+574.2 "Viscous Aetheroplasm" sync / 1[56]:[^:]*:The Ultima Weapon:5DF:/
+
+579.5 "Radiant Plume" sync / 1[56]:[^:]*:The Ultima Weapon:5F1:/
+582.3 "Crimson Cyclone" sync / 1[56]:[^:]*:Ultima Ifrit:5F5:/
+583.6 "Radiant Plume" sync / 1[56]:[^:]*:The Ultima Weapon:5F1:/
+587.6 "Radiant Plume" sync / 1[56]:[^:]*:The Ultima Weapon:5F1:/
+590.4 "Crimson Cyclone" sync / 1[56]:[^:]*:Ultima Ifrit:5F5:/
+591.6 "Radiant Plume" sync / 1[56]:[^:]*:The Ultima Weapon:5F1:/
+594.6 "Homing Lasers" sync / 1[56]:[^:]*:The Ultima Weapon:5E1:/
+599.9 "Ceruleum Vent" sync / 1[56]:[^:]*:The Ultima Weapon:5E0:/
+603.2 "Viscous Aetheroplasm" sync / 1[56]:[^:]*:The Ultima Weapon:5DF:/
+
+610.1 "Eruption x5" duration 8 #sync / 1[56]:[^:]*:The Ultima Weapon:5F4:/
+619.2 "Tank Purge" sync / 1[56]:[^:]*:The Ultima Weapon:5EA:/
+622.5 "Homing Lasers" sync / 1[56]:[^:]*:The Ultima Weapon:5E1:/
+627.8 "Ceruleum Vent" sync / 1[56]:[^:]*:The Ultima Weapon:5E0:/
+631.1 "Viscous Aetheroplasm" sync / 1[56]:[^:]*:The Ultima Weapon:5DF:/
+
+638.4 "Homing Lasers" sync / 1[56]:[^:]*:The Ultima Weapon:5E1:/
+643.7 "Ceruleum Vent" sync / 1[56]:[^:]*:The Ultima Weapon:5E0:/
+647.0 "Viscous Aetheroplasm" sync / 1[56]:[^:]*:The Ultima Weapon:5DF:/
+
+654.3 "Eruption x5" duration 8 #sync / 1[56]:[^:]*:The Ultima Weapon:5F4:/
+662.9 "Tank Purge" sync / 1[56]:[^:]*:The Ultima Weapon:5EA:/
+666.2 "Homing Lasers" sync / 1[56]:[^:]*:The Ultima Weapon:5E1:/
+671.5 "Ceruleum Vent" sync / 1[56]:[^:]*:The Ultima Weapon:5E0:/
+674.8 "Viscous Aetheroplasm" sync / 1[56]:[^:]*:The Ultima Weapon:5DF:/
+
+682.1 "Radiant Plume" sync / 1[56]:[^:]*:The Ultima Weapon:5F1:/
+684.9 "Crimson Cyclone" sync / 1[56]:[^:]*:Ultima Ifrit:5F5:/
+686.2 "Radiant Plume" sync / 1[56]:[^:]*:The Ultima Weapon:5F1:/
+690.2 "Radiant Plume" sync / 1[56]:[^:]*:The Ultima Weapon:5F1:/
+693.0 "Crimson Cyclone" sync / 1[56]:[^:]*:Ultima Ifrit:5F5:/
+694.2 "Radiant Plume" sync / 1[56]:[^:]*:The Ultima Weapon:5F1:/
+695.2 "Homing Lasers" sync / 1[56]:[^:]*:The Ultima Weapon:5E1:/
+700.5 "Ceruleum Vent" sync / 1[56]:[^:]*:The Ultima Weapon:5E0:/
 
 
 9989.3 "--sync--" sync / 14:[^:]*:The Ultima Weapon:5EC:/ window 10000

--- a/ui/raidboss/data/02-arr/trial/ultima-ex.txt
+++ b/ui/raidboss/data/02-arr/trial/ultima-ex.txt
@@ -206,7 +206,7 @@ hideall "--sync--"
 
 825.1 "--sync--" sync / 14:[^:]*:The Ultima Weapon:5F1:/ window 15,15 jump 697.3 # Radiant  Plume
 827.8 "Radiant Plume?"
-829.8 "Homing Lasers?" sync / 1[56]:[^:]*:The Ultima Weapon:5E1:/window 10,10 jump 900
+829.8 "Homing Lasers?" sync / 1[56]:[^:]*:The Ultima Weapon:5E1:/ window 10,10 jump 900
 830.6 "Crimson Cyclone?"
 831.9 "Radiant Plume?"
 835.1 "Ceruleum Vent?"

--- a/ui/raidboss/data/02-arr/trial/ultima-ex.txt
+++ b/ui/raidboss/data/02-arr/trial/ultima-ex.txt
@@ -95,8 +95,8 @@ hideall "--sync--"
 
 # A possible extra block is here, but it doesn't seem to change the rotation.
 # Ceruleum Vent jumps to a small sidetrack before continuing.
-380.1 "--sync--" sync / 14:[^:]*:The Ultima Weapon:5F1:/ jump 547.3 # Radiant Plume
-380.8 "Ceruleum Vent?" sync / 1[56]:[^:]*:The Ultima Weapon:5E0:/ jump 450
+380.1 "--sync--" sync / 14:[^:]*:The Ultima Weapon:5F1:/ window 15,15 jump 547.3 # Radiant Plume
+380.8 "Ceruleum Vent?" sync / 1[56]:[^:]*:The Ultima Weapon:5E0:/ window 15,15 jump 450
 382.8 "Radiant Plume?"
 384.1 "Viscous Aetheroplasm?"
 385.6 "Crimson Cyclone?"
@@ -111,10 +111,10 @@ hideall "--sync--"
 466.0 "Ceruleum Vent" sync / 1[56]:[^:]*:The Ultima Weapon:5E0:/
 
 # Normal early Eruption block
-466.5 "--sync--" sync / 14:[^:]*:The Ultima Weapon:5F4:/
+466.5 "--sync--" sync / 14:[^:]*:The Ultima Weapon:5F4:/ window 30,1
 469.2 "Eruption x5" duration 8 #sync / 1[56]:[^:]*:The Ultima Weapon:5F4:/
 475.0 "Viscous Aetheroplasm" sync / 1[56]:[^:]*:The Ultima Weapon:5DF:/
-483.8 "Tank Purge" sync / 1[56]:[^:]*:The Ultima Weapon:5EA:/
+483.8 "Tank Purge" sync / 1[56]:[^:]*:The Ultima Weapon:5EA:/ window 15,15
 487.1 "Homing Lasers" sync / 1[56]:[^:]*:The Ultima Weapon:5E1:/
 492.5 "Ceruleum Vent" sync / 1[56]:[^:]*:The Ultima Weapon:5E0:/
 
@@ -150,7 +150,7 @@ hideall "--sync--"
 # Jump to the Aetheroplasm bridge or the early Eruption block
 577.4 "--sync--" sync / 14:[^:]*:The Ultima Weapon:5F4:/ window 20,20 jump 466.5
 580.1 "Eruption x5?"
-580.4 "Viscous Aetheroplasm?" sync / 1[56]:[^:]*:The Ultima Weapon:5DF:/ window 10,10 jump 650
+580.4 "Viscous Aetheroplasm?" sync / 1[56]:[^:]*:The Ultima Weapon:5DF:/ window 5,5 jump 650
 585.9 "Viscous Aetheroplasm?"
 587.7 "Homing Lasers?"
 593.0 "Ceruleum Vent?"
@@ -165,13 +165,14 @@ hideall "--sync--"
 667.3 "Ceruleum Vent" sync / 1[56]:[^:]*:The Ultima Weapon:5E0:/
 670.7 "Viscous Aetheroplasm?" #sync / 1[56]:[^:]*:The Ultima Weapon:5DF:/
 
-# From here, the late Cyclone/Eruption blocks are added.
-669.9 "--sync--" sync / 14:[^:]*:The Ultima Weapon:5F1:/ jump 697.3 # Radiant Plume
-671.0 "--sync--" sync / 14:[^:]*:The Ultima Weapon:5F4:/ jump 797.3 # Eruption
+# From here, the late Cyclone/EruptionHoming Lasers blocks are added.
+669.9 "--sync--" sync / 14:[^:]*:The Ultima Weapon:5F1:/ window 15,15 jump 697.3 # Radiant Plume
+671.0 "--sync--" sync / 14:[^:]*:The Ultima Weapon:5F4:/ window 15,15 jump 797.3 # Eruption
 672.6 "Radiant Plume?"
 673.7 "Eruption x5?"
 675.4 "Crimson Cyclone?"
 676.7 "Radiant Plume?"
+678.0 "Homing Lasers?" sync / 1[56]:[^:]*:The Ultima Weapon:5E1:/ window 10,10 jump 900
 680.7 "Radiant Plume?"
 684.3 "Tank Purge?"
 
@@ -183,13 +184,13 @@ hideall "--sync--"
 708.1 "Radiant Plume" sync / 1[56]:[^:]*:The Ultima Weapon:5F1:/
 710.9 "Crimson Cyclone" sync / 1[56]:[^:]*:Ultima Ifrit:5F5:/
 712.1 "Radiant Plume" sync / 1[56]:[^:]*:The Ultima Weapon:5F1:/
-716.1 "Homing Lasers" sync / 1[56]:[^:]*:The Ultima Weapon:5E1:/
+716.1 "Homing Lasers" sync / 1[56]:[^:]*:The Ultima Weapon:5E1:/ window 12,5
 721.4 "Ceruleum Vent" sync / 1[56]:[^:]*:The Ultima Weapon:5E0:/
 724.7 "Viscous Aetheroplasm" sync / 1[56]:[^:]*:The Ultima Weapon:5DF:/
 
-727.3 "--sync--" sync / 14:[^:]*:The Ultima Weapon:5F4:/ jump 797.3 # Eruption
+727.3 "--sync--" sync / 14:[^:]*:The Ultima Weapon:5F4:/ window 15,15 jump 797.3 # Eruption
 730.0 "Eruption x5?"
-732.0 "Homing Lasers?" sync / 1[56]:[^:]*:The Ultima Weapon:5E1:/ jump 900
+732.0 "Homing Lasers?" sync / 1[56]:[^:]*:The Ultima Weapon:5E1:/ window 10,10 jump 900
 737.3 "Ceruleum Vent?"
 740.6 "Viscous Aetheroplasm?"
 740.6 "Tank Purge?"
@@ -198,14 +199,14 @@ hideall "--sync--"
 # Late Eruption block
 797.3 "--sync--" sync / 14:[^:]*:The Ultima Weapon:5F4:/ window 2.5,0
 800.0 "Eruption x5" duration 8 #sync / 1[56]:[^:]*:The Ultima Weapon:5F4:/
-810.6 "Tank Purge" sync / 1[56]:[^:]*:The Ultima Weapon:5EA:/
+810.6 "Tank Purge" sync / 1[56]:[^:]*:The Ultima Weapon:5EA:/ window 15,15
 813.9 "Homing Lasers" sync / 1[56]:[^:]*:The Ultima Weapon:5E1:/
 819.2 "Ceruleum Vent" sync / 1[56]:[^:]*:The Ultima Weapon:5E0:/
 822.5 "Viscous Aetheroplasm" sync / 1[56]:[^:]*:The Ultima Weapon:5DF:/
 
-825.1 "--sync--" sync / 14:[^:]*:The Ultima Weapon:5F1:/ jump 697.3 # Radiant  Plume
+825.1 "--sync--" sync / 14:[^:]*:The Ultima Weapon:5F1:/ window 15,15 jump 697.3 # Radiant  Plume
 827.8 "Radiant Plume?"
-829.8 "Homing Lasers?" sync / 1[56]:[^:]*:The Ultima Weapon:5E1:/ jump 900
+829.8 "Homing Lasers?" sync / 1[56]:[^:]*:The Ultima Weapon:5E1:/window 10,10 jump 900
 830.6 "Crimson Cyclone?"
 831.9 "Radiant Plume?"
 835.1 "Ceruleum Vent?"
@@ -217,8 +218,8 @@ hideall "--sync--"
 905.3 "Ceruleum Vent" sync / 1[56]:[^:]*:The Ultima Weapon:5E0:/
 908.6 "Viscous Aetheroplasm" sync / 1[56]:[^:]*:The Ultima Weapon:5DF:/
 
-912.3 "--sync--" sync / 14:[^:]*:The Ultima Weapon:5F4:/ jump 797.3 # Eruption
-913.2 "--sync--" sync / 14:[^:]*:The Ultima Weapon:5F1:/ jump 697.3 # Radiant Plume
+912.3 "--sync--" sync / 14:[^:]*:The Ultima Weapon:5F4:/ window 15,15 jump 797.3 # Eruption
+913.2 "--sync--" sync / 14:[^:]*:The Ultima Weapon:5F1:/ window 15,15 jump 697.3 # Radiant Plume
 915.0 "Eruption x5?"
 915.9 "Radiant Plume?"
 918.7 "Crimson Cyclone?"

--- a/ui/raidboss/data/02-arr/trial/ultima-ex.txt
+++ b/ui/raidboss/data/02-arr/trial/ultima-ex.txt
@@ -1,4 +1,5 @@
 ### The Minstrel's Ballad: Ultima's Bane
+# -ii 5E8 5E9 5F6 60A
 
 hideall "--Reset--"
 hideall "--sync--"
@@ -227,7 +228,58 @@ hideall "--sync--"
 927.4 "Homing Lasers?"
 
 
+# Phase 4 -- 49.9% - 0%
+# Phase 4 seems to have a single rotation block.
+# Aetheric Boom and Freefire events happen at HP thresholds,
+# but they do not appear to change ability usage,
+# they just delay whatever ability was queued up next.
+# Because of this, we add many more sync windows than we normally would.
 
+# The opening block is short.
+1000.0 "Aetheric Boom" sync / 1[56]:[^:]*:The Ultima Weapon:5E7:/ window 1000,5
+1011.3 "Viscous Aetheroplasm" sync / 1[56]:[^:]*:The Ultima Weapon:5DF:/
+1015.6 "Homing Lasers" sync / 1[56]:[^:]*:The Ultima Weapon:5E1:/
+1019.9 "Ceruleum Vent" sync / 1[56]:[^:]*:The Ultima Weapon:5E0:/
+1023.1 "Viscous Aetheroplasm" sync / 1[56]:[^:]*:The Ultima Weapon:5DF:/
+1034.1 "Magitek Ray 1" sync / 1[56]:[^:]*:The Ultima Weapon:(5E3|5E4|5E5):/
+1037.1 "Magitek Ray 2" sync / 1[56]:[^:]*:The Ultima Weapon:(5E3|5E4|5E5):/
+1040.1 "Magitek Ray 3" sync / 1[56]:[^:]*:The Ultima Weapon:(5E3|5E4|5E5):/
+
+1042.7 "--sync--" sync / 14:[^:]*:The Ultima Weapon:5EA:/ window 45,45
+1045.9 "Tank Purge" sync / 1[56]:[^:]*:The Ultima Weapon:5EA:/
+1049.2 "Viscous Aetheroplasm" sync / 1[56]:[^:]*:The Ultima Weapon:5DF:/
+1052.5 "Diffractive Laser" sync / 1[56]:[^:]*:The Ultima Weapon:5E2:/ window 20,20
+1054.8 "Homing Lasers" sync / 1[56]:[^:]*:The Ultima Weapon:5E1:/ window 20,20
+1059.1 "Ceruleum Vent" sync / 1[56]:[^:]*:The Ultima Weapon:5E0:/
+1062.4 "Viscous Aetheroplasm" sync / 1[56]:[^:]*:The Ultima Weapon:5DF:/
+1070.5 "Magitek Ray 1" sync / 1[56]:[^:]*:The Ultima Weapon:(5E3|5E4|5E5):/ window 15,1
+1073.5 "Magitek Ray 2" sync / 1[56]:[^:]*:The Ultima Weapon:(5E3|5E4|5E5):/
+1076.5 "Magitek Ray 3" sync / 1[56]:[^:]*:The Ultima Weapon:(5E3|5E4|5E5):/
+1080.8 "Viscous Aetheroplasm" sync / 1[56]:[^:]*:The Ultima Weapon:5DF:/
+1084.1 "Diffractive Laser" sync / 1[56]:[^:]*:The Ultima Weapon:5E2:/ window 10,20
+1086.4 "Homing Lasers" sync / 1[56]:[^:]*:The Ultima Weapon:5E1:/ window 10,20
+1090.7 "Ceruleum Vent" sync / 1[56]:[^:]*:The Ultima Weapon:5E0:/
+1094.0 "Viscous Aetheroplasm" sync / 1[56]:[^:]*:The Ultima Weapon:5DF:/
+1105.1 "Magitek Ray 1" sync / 1[56]:[^:]*:The Ultima Weapon:(5E3|5E4|5E5):/ window 15,1
+1108.1 "Magitek Ray 2" sync / 1[56]:[^:]*:The Ultima Weapon:(5E3|5E4|5E5):/
+1111.0 "Magitek Ray 3" sync / 1[56]:[^:]*:The Ultima Weapon:(5E3|5E4|5E5):/
+
+1113.6 "--sync--" sync / 14:[^:]*:The Ultima Weapon:5EA:/ window 45,45 jump 1042.7
+1116.8 "Tank Purge" sync / 1[56]:[^:]*:The Ultima Weapon:5EA:/
+1120.2 "Viscous Aetheroplasm" sync / 1[56]:[^:]*:The Ultima Weapon:5DF:/
+1123.5 "Diffractive Laser" sync / 1[56]:[^:]*:The Ultima Weapon:5E2:/
+1125.8 "Homing Lasers" sync / 1[56]:[^:]*:The Ultima Weapon:5E1:/
+1130.1 "Ceruleum Vent" sync / 1[56]:[^:]*:The Ultima Weapon:5E0:/
+1133.4 "Viscous Aetheroplasm" sync / 1[56]:[^:]*:The Ultima Weapon:5DF:/
+1141.5 "Magitek Ray 1" sync / 1[56]:[^:]*:The Ultima Weapon:(5E3|5E4|5E5):/
+1144.5 "Magitek Ray 2" sync / 1[56]:[^:]*:The Ultima Weapon:(5E3|5E4|5E5):/
+1147.5 "Magitek Ray 3" sync / 1[56]:[^:]*:The Ultima Weapon:(5E3|5E4|5E5):/
+1151.8 "Viscous Aetheroplasm" sync / 1[56]:[^:]*:The Ultima Weapon:5DF:/
+
+
+
+# Enrage appears to be at 10:30.
+# Ultima Weapon teleports to the center and casts Ultima.
 9989.3 "--sync--" sync / 14:[^:]*:The Ultima Weapon:5EC:/ window 10000
 10000.0 "Ultima Enrage" sync / 1[56]:[^:]*:The Ultima Weapon:5EC:/
 

--- a/ui/raidboss/data/02-arr/trial/ultima-ex.txt
+++ b/ui/raidboss/data/02-arr/trial/ultima-ex.txt
@@ -1,0 +1,78 @@
+### The Minstrel's Ballad: Ultima's Bane
+
+hideall "--Reset--"
+hideall "--sync--"
+
+0.0 "--Reset--" sync / 21:........:40000010:/ window 100000 jump 0
+
+0.0 "--sync--" sync /Engage!/ window 0,1
+
+# Phase 1: 100% - 85%
+3.2 "Viscous Aetheroplasm" sync / 1[56]:[^:]*:The Ultima Weapon:5DF:/ window 3.2,10
+15.1 "Vulcan Burst" sync / 1[56]:[^:]*:The Ultima Weapon:5EE:/
+16.6 "Mistral Song" sync / 1[56]:[^:]*:Ultima Garuda:5ED:/
+26.4 "Homing Lasers" sync / 1[56]:[^:]*:The Ultima Weapon:5E1:/
+29.7 "Ceruleum Vent" sync / 1[56]:[^:]*:The Ultima Weapon:5E0:/
+33.0 "Viscous Aetheroplasm" sync / 1[56]:[^:]*:The Ultima Weapon:5DF:/ window 10,10
+41.3 "Eye of the Storm" sync / 1[56]:[^:]*:The Ultima Weapon:5EF:/
+43.9 "Geocrush" sync / 1[56]:[^:]*:Ultima Titan:5F0:/
+48.4 "Homing Lasers" sync / 1[56]:[^:]*:The Ultima Weapon:5E1:/
+51.7 "Ceruleum Vent" sync / 1[56]:[^:]*:The Ultima Weapon:5E0:/
+
+55.0 "Viscous Aetheroplasm" sync / 1[56]:[^:]*:The Ultima Weapon:5DF:/ window 10,10 jump 3.2
+66.9 "Vulcan Burst"
+68.4 "Mistral Song"
+78.2 "Homing Lasers"
+81.5 "Ceruleum Vent"
+84.8 "Viscous Aetheroplasm"
+
+
+# Phase 2: 84.9% - 65%
+# The animation for Garuda dying precedes this,
+# but there are no log lines that show for her death.
+98.3 "--sync--" sync / 14:[^:]*:The Ultima Weapon:5F1:/ window 98.3,5
+100.0 "Radiant Plume" sync / 1[56]:[^:]*:The Ultima Weapon:5F1:/
+103.0 "Weight of the Land" sync / 1[56]:[^:]*:The Ultima Weapon:5F2:/
+107.1 "Viscous Aetheroplasm" sync / 1[56]:[^:]*:The Ultima Weapon:5DF:/
+
+115.9 "Tank Purge" sync / 1[56]:[^:]*:The Ultima Weapon:5EA:/ window 30,30
+119.3 "Homing Lasers" sync / 1[56]:[^:]*:The Ultima Weapon:5E1:/
+125.6 "Radiant Plume" sync / 1[56]:[^:]*:The Ultima Weapon:5F1:/
+129.6 "Weight of the Land" sync / 1[56]:[^:]*:The Ultima Weapon:5F2:/
+130.7 "Ceruleum Vent" sync / 1[56]:[^:]*:The Ultima Weapon:5E0:/
+134.0 "Viscous Aetheroplasm" sync / 1[56]:[^:]*:The Ultima Weapon:5DF:/
+141.3 "Homing Lasers" sync / 1[56]:[^:]*:The Ultima Weapon:5E1:/
+148.6 "Radiant Plume" sync / 1[56]:[^:]*:The Ultima Weapon:5F1:/
+151.6 "Weight of the Land" sync / 1[56]:[^:]*:The Ultima Weapon:5F2:/
+152.7 "Ceruleum Vent" sync / 1[56]:[^:]*:The Ultima Weapon:5E0:/
+156.0 "Viscous Aetheroplasm" sync / 1[56]:[^:]*:The Ultima Weapon:5DF:/
+
+164.8 "Tank Purge" sync / 1[56]:[^:]*:The Ultima Weapon:5EA:/ window 30,30
+168.2 "Homing Lasers" sync / 1[56]:[^:]*:The Ultima Weapon:5E1:/
+175.5 "Radiant Plume" sync / 1[56]:[^:]*:The Ultima Weapon:5F1:/
+179.5 "Weight of the Land" sync / 1[56]:[^:]*:The Ultima Weapon:5F2:/
+179.6 "Ceruleum Vent" sync / 1[56]:[^:]*:The Ultima Weapon:5E0:/
+182.9 "Viscous Aetheroplasm" sync / 1[56]:[^:]*:The Ultima Weapon:5DF:/
+190.3 "Homing Lasers" sync / 1[56]:[^:]*:The Ultima Weapon:5E1:/
+195.7 "Ceruleum Vent" sync / 1[56]:[^:]*:The Ultima Weapon:5E0:/
+198.6 "Radiant Plume" sync / 1[56]:[^:]*:The Ultima Weapon:5F1:/
+201.6 "Weight of the Land" sync / 1[56]:[^:]*:The Ultima Weapon:5F2:/
+203.7 "Viscous Aetheroplasm" sync / 1[56]:[^:]*:The Ultima Weapon:5DF:/
+
+212.5 "Tank Purge" sync / 1[56]:[^:]*:The Ultima Weapon:5EA:/ window 30,30 jump 168.2
+215.9 "Homing Lasers"
+223.2 "Radiant Plume"
+227.2 "Weight of the Land"
+227.3 "Ceruleum Vent"
+230.6 "Viscous Aetheroplasm"
+
+
+# Phase 3: 64.9% -50%
+# As in phase 2, Titan's death animation comes first with no indicator.
+
+
+
+9989.3 "--sync--" sync / 14:[^:]*:The Ultima Weapon:5EC:/ window 10000
+10000.0 "Ultima Enrage" sync / 1[56]:[^:]*:The Ultima Weapon:5EC:/
+
+

--- a/ui/raidboss/data/02-arr/trial/ultima-ex.txt
+++ b/ui/raidboss/data/02-arr/trial/ultima-ex.txt
@@ -92,106 +92,68 @@ hideall "--sync--"
 346.1 "Tank Purge" sync / 1[56]:[^:]*:The Ultima Weapon:5EA:/
 349.5 "Homing Lasers" sync / 1[56]:[^:]*:The Ultima Weapon:5E1:/
 
-356.8 "Radiant Plume" sync / 1[56]:[^:]*:The Ultima Weapon:5F1:/
+# A possible extra block is here, but it doesn't seem to change the rotation.
+# Ceruleum Vent jumps to a small sidetrack before continuing.
+354.1 "--sync--" sync / 14:[^:]*:The Ultima Weapon:5F1:/ # Radiant Plume cast
+354.8 "Ceruleum Vent?" sync / 1[56]:[^:]*:The Ultima Weapon:5E0:/
+356.8 "Radiant Plume?" sync / 1[56]:[^:]*:The Ultima Weapon:5F1:/
+358.1 "Viscous Aetheroplasm?" sync / 1[56]:[^:]*:The Ultima Weapon:5DF:/
 359.6 "Crimson Cyclone" sync / 1[56]:[^:]*:Ultima Ifrit:5F5:/
 360.9 "Radiant Plume" sync / 1[56]:[^:]*:The Ultima Weapon:5F1:/
 364.9 "Radiant Plume" sync / 1[56]:[^:]*:The Ultima Weapon:5F1:/
-367.7 "Crimson Cyclone" sync / 1[56]:[^:]*:Ultima Ifrit:5F5:/
-367.9 "Ceruleum Vent" sync / 1[56]:[^:]*:The Ultima Weapon:5E0:/
-368.9 "Radiant Plume" sync / 1[56]:[^:]*:The Ultima Weapon:5F1:/
-371.2 "Viscous Aetheroplasm" sync / 1[56]:[^:]*:The Ultima Weapon:5DF:/
-378.5 "Homing Lasers" sync / 1[56]:[^:]*:The Ultima Weapon:5E1:/
-383.9 "Ceruleum Vent" sync / 1[56]:[^:]*:The Ultima Weapon:5E0:/
+365.4 "Homing Lasers" sync / 1[56]:[^:]*:The Ultima Weapon:5E1:/
+370.8 "Ceruleum Vent" sync / 1[56]:[^:]*:The Ultima Weapon:5E0:/
 
-387.1 "Eruption x5" duration 8 #sync / 1[56]:[^:]*:The Ultima Weapon:5F4:/
-392.9 "Viscous Aetheroplasm" sync / 1[56]:[^:]*:The Ultima Weapon:5DF:/
-401.7 "Tank Purge" sync / 1[56]:[^:]*:The Ultima Weapon:5EA:/
-405.0 "Homing Lasers" sync / 1[56]:[^:]*:The Ultima Weapon:5E1:/
-410.4 "Ceruleum Vent" sync / 1[56]:[^:]*:The Ultima Weapon:5E0:/
+# Vent sidetrack into normal early Eruption block
+355.7 "Ceruleum Vent" sync / 1[56]:[^:]*:The Ultima Weapon:5E0:/
+359.0 "Viscous Aetheroplasm" sync / 1[56]:[^:]*:The Ultima Weapon:5DF:/
+366.3 "Homing Lasers" sync / 1[56]:[^:]*:The Ultima Weapon:5E1:/
+371.7 "Ceruleum Vent" sync / 1[56]:[^:]*:The Ultima Weapon:5E0:/
 
-413.3 "Radiant Plume" sync / 1[56]:[^:]*:The Ultima Weapon:5F1:/
-416.1 "Crimson Cyclone" sync / 1[56]:[^:]*:Ultima Ifrit:5F5:/
-417.4 "Radiant Plume" sync / 1[56]:[^:]*:The Ultima Weapon:5F1:/
-421.4 "Radiant Plume" sync / 1[56]:[^:]*:The Ultima Weapon:5F1:/
-424.2 "Crimson Cyclone" sync / 1[56]:[^:]*:Ultima Ifrit:5F5:/
-425.4 "Viscous Aetheroplasm" sync / 1[56]:[^:]*:The Ultima Weapon:5DF:/
-425.4 "Radiant Plume" sync / 1[56]:[^:]*:The Ultima Weapon:5F1:/
-432.7 "Homing Lasers" sync / 1[56]:[^:]*:The Ultima Weapon:5E1:/
-438.0 "Ceruleum Vent" sync / 1[56]:[^:]*:The Ultima Weapon:5E0:/
 
-443.3 "Eruption x5" duration 8 #sync / 1[56]:[^:]*:The Ultima Weapon:5F4:/
-448.4 "Viscous Aetheroplasm" sync / 1[56]:[^:]*:The Ultima Weapon:5DF:/
-457.2 "Tank Purge" sync / 1[56]:[^:]*:The Ultima Weapon:5EA:/
-460.5 "Homing Lasers" sync / 1[56]:[^:]*:The Ultima Weapon:5E1:/
-465.8 "Ceruleum Vent" sync / 1[56]:[^:]*:The Ultima Weapon:5E0:/
+# Normal early Eruption block
+374.9 "Eruption x5" duration 8 #sync / 1[56]:[^:]*:The Ultima Weapon:5F4:/
+380.7 "Viscous Aetheroplasm" sync / 1[56]:[^:]*:The Ultima Weapon:5DF:/
+389.5 "Tank Purge" sync / 1[56]:[^:]*:The Ultima Weapon:5EA:/
+392.8 "Homing Lasers" sync / 1[56]:[^:]*:The Ultima Weapon:5E1:/
+398.2 "Ceruleum Vent" sync / 1[56]:[^:]*:The Ultima Weapon:5E0:/
 
-471.1 "Radiant Plume" sync / 1[56]:[^:]*:The Ultima Weapon:5F1:/
-473.9 "Crimson Cyclone" sync / 1[56]:[^:]*:Ultima Ifrit:5F5:/
-475.2 "Radiant Plume" sync / 1[56]:[^:]*:The Ultima Weapon:5F1:/
-479.2 "Radiant Plume" sync / 1[56]:[^:]*:The Ultima Weapon:5F1:/
-482.0 "Crimson Cyclone" sync / 1[56]:[^:]*:Ultima Ifrit:5F5:/
-482.2 "Viscous Aetheroplasm" sync / 1[56]:[^:]*:The Ultima Weapon:5DF:/
-483.2 "Radiant Plume" sync / 1[56]:[^:]*:The Ultima Weapon:5F1:/
-489.5 "Homing Lasers" sync / 1[56]:[^:]*:The Ultima Weapon:5E1:/
-494.8 "Ceruleum Vent" sync / 1[56]:[^:]*:The Ultima Weapon:5E0:/
+# Eruption and Cyclone blocks will alternate from here.
+# *However*, at any time, a Viscous Aetheroplasm bridge may follow.
+# Subesquent blocks are different, ending with an Aetheroplasm rather than a Vent.
 
-# An Aetheroplasm immediately following a Vent seems to indicate the start of rotations.
-498.1 "Viscous Aetheroplasm" sync / 1[56]:[^:]*:The Ultima Weapon:5DF:/
-506.8 "Tank Purge" sync / 1[56]:[^:]*:The Ultima Weapon:5EA:/
-510.1 "Homing Lasers" sync / 1[56]:[^:]*:The Ultima Weapon:5E1:/
-515.4 "Ceruleum Vent" sync / 1[56]:[^:]*:The Ultima Weapon:5E0:/
-518.8 "Viscous Aetheroplasm" sync / 1[56]:[^:]*:The Ultima Weapon:5DF:/
+398.4 "--sync--" sync / 14:[^:]*:The Ultima Weapon:5F1:/
+401.1 "Radiant Plume?" sync / 1[56]:[^:]*:The Ultima Weapon:5F1:/
+401.5 "Viscous Aetheroplasm?" sync / 1[56]:[^:]*:The Ultima Weapon:5DF:/
+403.9 "Crimson Cyclone?"
+405.2 "Radiant Plume"
+408.8 "Homing Lasers?"
+409.2 "Radiant Plume?"
+412.0 "Crimson Cyclone?"
 
-521.7 "Radiant Plume" sync / 1[56]:[^:]*:The Ultima Weapon:5F1:/
-524.5 "Crimson Cyclone" sync / 1[56]:[^:]*:Ultima Ifrit:5F5:/
-525.8 "Radiant Plume" sync / 1[56]:[^:]*:The Ultima Weapon:5F1:/
-529.8 "Radiant Plume" sync / 1[56]:[^:]*:The Ultima Weapon:5F1:/
-532.6 "Crimson Cyclone" sync / 1[56]:[^:]*:Ultima Ifrit:5F5:/
-533.8 "Radiant Plume" sync / 1[56]:[^:]*:The Ultima Weapon:5F1:/
-537.8 "Homing Lasers" sync / 1[56]:[^:]*:The Ultima Weapon:5E1:/
-543.1 "Ceruleum Vent" sync / 1[56]:[^:]*:The Ultima Weapon:5E0:/
-546.4 "Viscous Aetheroplasm" sync / 1[56]:[^:]*:The Ultima Weapon:5DF:/
+# Normal early Cyclone block
+# Ceruleum Vent doesn't always happen during these Cyclone blocks.
+# However, timings don't seem dependent on its use,
+# so we can safely just not sync it and leave the block alone.
+401.1 "Radiant Plume" sync / 1[56]:[^:]*:The Ultima Weapon:5F1:/
+403.9 "Crimson Cyclone" sync / 1[56]:[^:]*:Ultima Ifrit:5F5:/
+405.2 "Radiant Plume" sync / 1[56]:[^:]*:The Ultima Weapon:5F1:/
+409.2 "Radiant Plume" sync / 1[56]:[^:]*:The Ultima Weapon:5F1:/
+412.0 "Crimson Cyclone" sync / 1[56]:[^:]*:Ultima Ifrit:5F5:/
+412.2 "Ceruleum Vent?" #sync / 1[56]:[^:]*:The Ultima Weapon:5E0:/
+413.2 "Radiant Plume" sync / 1[56]:[^:]*:The Ultima Weapon:5F1:/
+415.5 "Viscous Aetheroplasm" sync / 1[56]:[^:]*:The Ultima Weapon:5DF:/
+422.8 "Homing Lasers" sync / 1[56]:[^:]*:The Ultima Weapon:5E1:/
+428.2 "Ceruleum Vent" sync / 1[56]:[^:]*:The Ultima Weapon:5E0:/
 
-551.7 "Eruption x5" duration 8 #sync / 1[56]:[^:]*:The Ultima Weapon:5F4:/
-562.3 "Tank Purge" sync / 1[56]:[^:]*:The Ultima Weapon:5EA:/
-565.6 "Homing Lasers" sync / 1[56]:[^:]*:The Ultima Weapon:5E1:/
-570.9 "Ceruleum Vent" sync / 1[56]:[^:]*:The Ultima Weapon:5E0:/
-574.2 "Viscous Aetheroplasm" sync / 1[56]:[^:]*:The Ultima Weapon:5DF:/
-
-579.5 "Radiant Plume" sync / 1[56]:[^:]*:The Ultima Weapon:5F1:/
-582.3 "Crimson Cyclone" sync / 1[56]:[^:]*:Ultima Ifrit:5F5:/
-583.6 "Radiant Plume" sync / 1[56]:[^:]*:The Ultima Weapon:5F1:/
-587.6 "Radiant Plume" sync / 1[56]:[^:]*:The Ultima Weapon:5F1:/
-590.4 "Crimson Cyclone" sync / 1[56]:[^:]*:Ultima Ifrit:5F5:/
-591.6 "Radiant Plume" sync / 1[56]:[^:]*:The Ultima Weapon:5F1:/
-594.6 "Homing Lasers" sync / 1[56]:[^:]*:The Ultima Weapon:5E1:/
-599.9 "Ceruleum Vent" sync / 1[56]:[^:]*:The Ultima Weapon:5E0:/
-603.2 "Viscous Aetheroplasm" sync / 1[56]:[^:]*:The Ultima Weapon:5DF:/
-
-610.1 "Eruption x5" duration 8 #sync / 1[56]:[^:]*:The Ultima Weapon:5F4:/
-619.2 "Tank Purge" sync / 1[56]:[^:]*:The Ultima Weapon:5EA:/
-622.5 "Homing Lasers" sync / 1[56]:[^:]*:The Ultima Weapon:5E1:/
-627.8 "Ceruleum Vent" sync / 1[56]:[^:]*:The Ultima Weapon:5E0:/
-631.1 "Viscous Aetheroplasm" sync / 1[56]:[^:]*:The Ultima Weapon:5DF:/
-
-638.4 "Homing Lasers" sync / 1[56]:[^:]*:The Ultima Weapon:5E1:/
-643.7 "Ceruleum Vent" sync / 1[56]:[^:]*:The Ultima Weapon:5E0:/
-647.0 "Viscous Aetheroplasm" sync / 1[56]:[^:]*:The Ultima Weapon:5DF:/
-
-654.3 "Eruption x5" duration 8 #sync / 1[56]:[^:]*:The Ultima Weapon:5F4:/
-662.9 "Tank Purge" sync / 1[56]:[^:]*:The Ultima Weapon:5EA:/
-666.2 "Homing Lasers" sync / 1[56]:[^:]*:The Ultima Weapon:5E1:/
-671.5 "Ceruleum Vent" sync / 1[56]:[^:]*:The Ultima Weapon:5E0:/
-674.8 "Viscous Aetheroplasm" sync / 1[56]:[^:]*:The Ultima Weapon:5DF:/
-
-682.1 "Radiant Plume" sync / 1[56]:[^:]*:The Ultima Weapon:5F1:/
-684.9 "Crimson Cyclone" sync / 1[56]:[^:]*:Ultima Ifrit:5F5:/
-686.2 "Radiant Plume" sync / 1[56]:[^:]*:The Ultima Weapon:5F1:/
-690.2 "Radiant Plume" sync / 1[56]:[^:]*:The Ultima Weapon:5F1:/
-693.0 "Crimson Cyclone" sync / 1[56]:[^:]*:Ultima Ifrit:5F5:/
-694.2 "Radiant Plume" sync / 1[56]:[^:]*:The Ultima Weapon:5F1:/
-695.2 "Homing Lasers" sync / 1[56]:[^:]*:The Ultima Weapon:5E1:/
-700.5 "Ceruleum Vent" sync / 1[56]:[^:]*:The Ultima Weapon:5E0:/
+# Jump to the Aetheroplasm bridge or the early Eruption block
+428.5 "--sync--" sync / 14:[^:]*:The Ultima Weapon:5F4:/
+431.2 "Eruption x5"
+431.5 "Viscous Aetheroplasm?" sync / 1[56]:[^:]*:The Ultima Weapon:5DF:/
+437.0 "Viscous Aetheroplasm?"
+438.8 "Homing Lasers?"
+444.1 "Ceruleum Vent?"
+445.8 "Tank Purge"
 
 
 9989.3 "--sync--" sync / 14:[^:]*:The Ultima Weapon:5EC:/ window 10000

--- a/ui/raidboss/data/raidboss_manifest.txt
+++ b/ui/raidboss/data/raidboss_manifest.txt
@@ -43,6 +43,8 @@
 02-arr/trial/titan-hm.txt
 02-arr/trial/titan-nm.ts
 02-arr/trial/titan-nm.txt
+02-arr/trial/ultima-ex.ts
+02-arr/trial/ultima-ex.txt
 03-hw/alliance/dun_scaith.ts
 03-hw/alliance/dun_scaith.txt
 03-hw/alliance/weeping_city.ts


### PR DESCRIPTION
Ultima is a mostly-typical ARR-style encounter. It consists of four phases each with its own rotation, with each activating in turn at HP thresholds. Phases 1/2/4 are reasonably well-behaved and presented basically no problems working out. Phase 3 appears to be incredibly convoluted almost beyond belief.

 Triggers first though. As is normal for ARR-era encounters, the vast majority of Ultima's abilities have no cast times. This means most of our triggers will have to be timeline-driven. This is mostly not an issue, but we will discuss the exceptions later. For now, the major important triggers are in place. (Raidwide, tank swap, and off-tank cleave.)

The major issue experienced with generating this timeline was in phase 3. At 64.9% HP, Ultima enters its Ifrit phase, where it (mostly) alternates ability blocks centered on Eruption or Crimson Cyclone. Most of the ridiculousness is noted in-line in the comments, but it is *astonishing* how much variability Square seems to have put into what is likely the shortest of the phases! I haven't yet been able to fully test whether this variability is fully random or whether it might be some HP-based thresholds within the phase. (Unfortunately it can take 2-3 minutes of waiting around within phase 3 t o see whether Ultima does something or not, so it's not easy to test.)

Phase 4 also deserves a mention. It looks like this encounter uses 21 log lines instead of 27 for the Aetheroplasm headmarkers in phase 4. (I'll be adding those into the PR, both timeline and triggers, once maintenance is over and I can test them.) This would fit in with the lack of 27 log lines in other ARR-era content.

The transition to phase 4 is indicated by the first cast of Aetheric Boom, and the rotation starts fresh from there. None of the Aetheric Boom casts appear to delay the timeline by more than a few seconds. The appearance of the Ultima Bits similarly causes no delay. The gunship crashes, inflicting proximity damage with Freefire, seem to interrupt the rotation and postpone whatever they interrupted by about 12 seconds. All this is to say, we need to sync phase 4 much more aggressively than we normally would. Fortunately Tank Purge occurs only once per rotation, so we do have an if-all-else-fails stopgap.

Finally, Homing Lasers needs special mention. There's a point in the phase 3 rotation at 732 where a shorter "bridge" block between two standard ability blocks is indicated by a Homing Lasers usage. Unfortunately, we will have no way to definitively warn the player if and only if Homing Lasers is used here. I think we'll just have to accept the possibility of a phantom tank cleave callout here and hope for the best. 

Realistically, most groups should clear phase 3 long before any of this becomes a problem, but we do need to do our best because of how timeline-dependent the trigger set is.