### PR TITLE
raidemulator: Fix error in PopupTextAnalysis

### DIFF
--- a/ui/raidboss/emulator/data/PopupTextAnalysis.ts
+++ b/ui/raidboss/emulator/data/PopupTextAnalysis.ts
@@ -130,7 +130,6 @@ export default class PopupTextAnalysis extends StubbedPopupText {
           suppressed: false,
           executed: false,
         });
-        this.triggerResolvers.push(resolver);
 
         this.OnTrigger(trigger, r, logObj.timestamp);
 
@@ -140,9 +139,12 @@ export default class PopupTextAnalysis extends StubbedPopupText {
           if (this.callback)
             this.callback(logObj, resolver.triggerHelper, resolver.status, this.data);
         });
-      }
 
-      await this.checkResolved(logObj);
+        const isResolved = await resolver.isResolved(logObj);
+
+        if (!isResolved)
+          this.triggerResolvers.push(resolver);
+      }
 
       for (const trigger of this.netTriggers) {
         const r = trigger.localNetRegex?.exec(logObj.networkLine);
@@ -152,7 +154,6 @@ export default class PopupTextAnalysis extends StubbedPopupText {
             suppressed: false,
             executed: false,
           });
-          this.triggerResolvers.push(resolver);
 
           const matches = r.groups ?? {};
 
@@ -165,6 +166,11 @@ export default class PopupTextAnalysis extends StubbedPopupText {
             if (this.callback)
               this.callback(logObj, resolver.triggerHelper, resolver.status, this.data);
           });
+
+          const isResolved = await resolver.isResolved(logObj);
+
+          if (!isResolved)
+            this.triggerResolvers.push(resolver);
         }
       }
 


### PR DESCRIPTION
Fixes #4214.

Logic error occurred only when multiple triggers were matched the same line and those triggers depended on each other's output.

Since resolved status is being checked per-line, the call to `this.checkResolved` between the two loops was no longer needed, instead it only needs to run at the end of the outer `for` loop to resolve older triggers.