### PR TITLE
config: show timeline in edit timeline section

### DIFF
--- a/ui/config/config.css
+++ b/ui/config/config.css
@@ -239,6 +239,15 @@ html {
   max-width: 300px;
 }
 
+.timeline-scroller {
+  overflow: auto;
+  resize: both;
+  height: 300px;
+  border: solid black 1px;
+  margin: 12px 0 24px 24px;
+  padding: 8px;
+}
+
 .trigger-file-options {
   display: grid;
   margin: 12px;

--- a/ui/raidboss/raidboss_config.ts
+++ b/ui/raidboss/raidboss_config.ts
@@ -768,8 +768,9 @@ class RaidbossConfigurator {
       container.classList.toggle('collapsed');
       // Build the rest of this UI on demand lazily.
       if (!hasEverBeenExpanded) {
-        const timeline = this.timelineFromSet(set, options);
-        this.buildTimelineUI(zoneId, timeline, container);
+        const text = this.timelineTextFromSet(set);
+        const timeline = new TimelineParser(text, set.timelineReplace ?? [], [], [], options);
+        this.buildTimelineUI(zoneId, timeline, text, container);
       }
       hasEverBeenExpanded = true;
     };
@@ -777,8 +778,7 @@ class RaidbossConfigurator {
     container.appendChild(headerDiv);
   }
 
-  // Returns a parsed timeline from a given trigger set.
-  timelineFromSet(set: ConfigLooseTriggerSet, options: RaidbossOptions): TimelineParser {
+  timelineTextFromSet(set: ConfigLooseTriggerSet): string {
     let text = '';
 
     // Recursively turn the timeline array into a string.
@@ -799,18 +799,33 @@ class RaidbossConfigurator {
           // Functions are pretty uncommon in built-in timelines.
           // If user functions do funky things, those extra lines will be skipped.
         }
-      } else if (obj) {
+      } else if (typeof obj === 'string') {
         text = `${text}\n${obj}`;
       }
     };
     addTimeline(set.timeline);
-    // Using the timelineReplace and the current set of options lets the timeline
-    // entries look like they would in game.
-    return new TimelineParser(text, set.timelineReplace ?? [], [], [], options);
+    return text;
   }
 
   // The internal part of timeline editing ui.
-  buildTimelineUI(zoneId: number, timeline: TimelineParser, parent: HTMLElement): void {
+  buildTimelineUI(
+    zoneId: number,
+    timeline: TimelineParser,
+    timelineText: string,
+    parent: HTMLElement,
+  ): void {
+    // Add timeline text itself
+    const scroller = document.createElement('div');
+    scroller.classList.add('timeline-scroller');
+    parent.appendChild(scroller);
+
+    const timelineContents = document.createElement('pre');
+    scroller.classList.add('timeline-scroller-contents');
+    scroller.appendChild(timelineContents);
+
+    const translated = TimelineParser.Translate(timeline, timelineText);
+    timelineContents.innerText = translated.join('\n');
+
     const uniqEvents: { [key: string]: string } = {};
 
     for (const event of timeline.events) {

--- a/webpack/loaders/timeline-loader.ts
+++ b/webpack/loaders/timeline-loader.ts
@@ -1,17 +1,8 @@
 import webpack from 'webpack';
 
-const commentRegex = /(?<=^(?:[^"/]*(?:|"[^"]*"))[^"/]*(?:|sync\s*\/[^/]*\/[^"/]*))#.*$/i;
-
+// Note: the timeline files are displayed/translated inside of the config,
+// and so we shouldn't simplify them here by stripping comments and blank lines.
 export default function(this: webpack.LoaderContext<never>, content: string): string {
   this.cacheable(true);
-  let ret = '';
-
-  content.split(/\r?\n/).forEach((_line) => {
-    const line = _line.replace(commentRegex, '').trim();
-    if (!line)
-      return;
-    ret += line + '\r\n';
-  });
-
-  return ret;
+  return content;
 }


### PR DESCRIPTION
The follow-up step to this is to add some ui that will allow for adding
custom timeline entries, but to have that make any sense, I think it's
useful for the timeline itself to be visible (and translated), so that
the times for custom timeline entries can have context.

A simpler alternative to this is to make a link to the triggers branch
timeline, but I thought this was nicer, and easy enough to translate
in place like we do for the tools.

This doesn't (and won't) let the user edit the timeline at all.
Perhaps there's some way to make this more obvious?  However,
I didn't want to disallow selection as copy and paste of times
seemed useful.  Not sure how else to indicate that this is a display
and not an editable text field.

Additionally, this doesn't respect the renaming or hiding options (only
the language), as config options don't know about raidboss options
because of the way options are loaded in user_config.ts.  I think this
is fine-ish, but it's likely to be confusing and I'm not sure how to
make it better.