### PR TITLE
docs: Update DirectorUpdate link to NARI docs

### DIFF
--- a/docs/LogGuide.md
+++ b/docs/LogGuide.md
@@ -1452,7 +1452,7 @@ Unused.
 
 ### Line 33 (0x21): Network6D (Actor Control)
 
-See also: [nari director update documentation](https://xivlogs.github.io/nari/types/event/directorupdate.html)
+See also: [nari director update documentation](https://xivlogs.github.io/nari/types/director.html)
 
 To control aspects of the user interface, the game sends packets called Actor Controls.
 These are broken into 3 types: ActorControl, ActorControlSelf, and ActorControlTarget.


### PR DESCRIPTION
NARI recently merged the `event-rewrite` branch which heavily restructured all our events. This PR updates the URL for Cactbot docs. There's technically also the `instance` data in `nari.types.event.instance` but that's more for specific director commands.

I noticed a few of the event names no longer match ACT/NARI too, prob something to address.