### PR TITLE
raidboss: Endsinger Ex advanced triggers

### DIFF
--- a/ui/raidboss/data/06-ew/trial/endsinger-ex.ts
+++ b/ui/raidboss/data/06-ew/trial/endsinger-ex.ts
@@ -522,36 +522,39 @@ const triggerSet: TriggerSet<Data> = {
         if (heads.length === 5) {
           const safeDirHead = heads.find((h) => h.mechanic.includes('safe'));
           const donutHeads = heads.filter((h) => h.mechanic === 'donut');
-          const donutHead1 = donutHeads[0];
-          const donutHead2 = donutHeads[1];
 
           // Clean up here for next iteration
           data.storedHeads = {};
           data.rewindHeads = {};
 
-          if (!safeDirHead || !donutHead1 || !donutHead2) {
-            console.error(`5Head Mechanics Collector: null data`);
+          if (!safeDirHead || donutHeads.length < 1) {
+            console.error(`5Head Mechanics Rewind Collector: missing required head`);
             return;
           }
 
+          let safeDonut;
+
           switch (safeDirHead.mechanic) {
             case 'safeN':
-              if (donutHead1.state.PosY < 100)
-                return getKBOrbSafeDir(donutHead1.state.PosX, donutHead1.state.PosY, output);
-              return getKBOrbSafeDir(donutHead2.state.PosX, donutHead2.state.PosY, output);
+              safeDonut = donutHeads.find((head) => head.state.PosY < 100);
+              break;
             case 'safeE':
-              if (donutHead1.state.PosX > 100)
-                return getKBOrbSafeDir(donutHead1.state.PosX, donutHead1.state.PosY, output);
-              return getKBOrbSafeDir(donutHead2.state.PosX, donutHead2.state.PosY, output);
+              safeDonut = donutHeads.find((head) => head.state.PosX > 100);
+              break;
             case 'safeS':
-              if (donutHead1.state.PosY > 100)
-                return getKBOrbSafeDir(donutHead1.state.PosX, donutHead1.state.PosY, output);
-              return getKBOrbSafeDir(donutHead2.state.PosX, donutHead2.state.PosY, output);
+              safeDonut = donutHeads.find((head) => head.state.PosY > 100);
+              break;
             case 'safeW':
-              if (donutHead1.state.PosX < 100)
-                return getKBOrbSafeDir(donutHead1.state.PosX, donutHead1.state.PosY, output);
-              return getKBOrbSafeDir(donutHead2.state.PosX, donutHead2.state.PosY, output);
+              safeDonut = donutHeads.find((head) => head.state.PosX < 100);
+              break;
           }
+
+          if (!safeDonut) {
+            console.error(`5Head Mechanics Rewind Collector: no safe donut found`);
+            return;
+          }
+
+          return getKBOrbSafeDir(safeDonut.state.PosX, safeDonut.state.PosY, output);
         }
       },
       outputStrings: orbOutputStrings,

--- a/ui/raidboss/data/06-ew/trial/endsinger-ex.ts
+++ b/ui/raidboss/data/06-ew/trial/endsinger-ex.ts
@@ -1,3 +1,4 @@
+import conditions from '../../../../../resources/conditions';
 import NetRegexes from '../../../../../resources/netregexes';
 import Outputs from '../../../../../resources/outputs';
 import { callOverlayHandler } from '../../../../../resources/overlay_plugin_api';
@@ -6,10 +7,6 @@ import ZoneId from '../../../../../resources/zone_id';
 import { RaidbossData } from '../../../../../types/data';
 import { PluginCombatantState } from '../../../../../types/event';
 import { LocaleText, Output, OutputStrings, TriggerSet } from '../../../../../types/trigger';
-
-// TODO: 5Head mechanics
-// TODO: 6Head mechanics
-// TODO: Stack/Flare/Donut/Spread mechanics
 
 const redStarLocale: LocaleText = {
   en: 'Fiery Star',
@@ -24,6 +21,7 @@ const blueStarLocale: LocaleText = {
 const blueStarNames = Object.values(blueStarLocale);
 
 export interface Data extends RaidbossData {
+  headPhase?: 5 | 6;
   starMechanicCounter: number;
   storedStars: {
     [id: string]: PluginCombatantState;
@@ -31,7 +29,13 @@ export interface Data extends RaidbossData {
   storedHeads: {
     [id: string]: {
       state: PluginCombatantState;
-      mechanics: ('cleave' | 'donut' | 'aoe')[];
+      mechanics: string[];
+    };
+  };
+  rewindHeads: {
+    [id: string]: {
+      state: PluginCombatantState;
+      mechanic: string;
     };
   };
   storedMechs: {
@@ -47,6 +51,27 @@ const orbOutputStrings: OutputStrings = {
   nw: Outputs.northwest,
   se: Outputs.southeast,
   sw: Outputs.southwest,
+};
+
+const echoesOutputStrings: OutputStrings = {
+  stack: Outputs.stackOnYou,
+  donut: {
+    en: 'Stack Donut',
+    de: 'Sammeln Donut',
+    fr: 'Packez-vous, donut',
+    ja: 'スタック',
+    cn: '集合放月环',
+    ko: '도넛 쉐어',
+  },
+  spread: Outputs.spread,
+  flare: {
+    en: 'Flare',
+    de: 'Flare',
+    fr: 'Brasier',
+    ja: 'フレア',
+    cn: '核爆',
+    ko: '플레어',
+  },
 };
 
 const getKBOrbSafeDir = (posX: number, posY: number, output: Output): string | undefined => {
@@ -83,6 +108,7 @@ const triggerSet: TriggerSet<Data> = {
       starMechanicCounter: 0,
       storedStars: {},
       storedHeads: {},
+      rewindHeads: {},
       storedMechs: {
         counter: 1,
       },
@@ -302,6 +328,381 @@ const triggerSet: TriggerSet<Data> = {
       run: (data) => {
         data.starMechanicCounter = 0;
       },
+    },
+    {
+      id: 'EndsingerEx Head Phase Detector',
+      type: 'Ability',
+      netRegex: NetRegexes.ability({ id: ['7007', '72B1'] }),
+      run: (data, matches) => {
+        switch (matches.id) {
+          case '7007':
+            data.headPhase = 5;
+            break;
+          case '72B1':
+            data.headPhase = 6;
+            break;
+        }
+      },
+    },
+    {
+      id: 'EndsingerEx Head Phase Cleanup',
+      type: 'Ability',
+      netRegex: NetRegexes.ability({ id: ['7007', '72B1'], capture: false }),
+      delaySeconds: 50,
+      run: (data) => {
+        data.headPhase = undefined;
+      },
+    },
+    {
+      id: 'EndsingerEx 5Head Collector',
+      type: 'GainsEffect',
+      netRegex: NetRegexes.gainsEffect({ effectId: '891', capture: true }),
+      condition: (data) => data.headPhase === 5,
+      delaySeconds: 0.5,
+      promise: async (data, matches) => {
+        // Middle head gets buff 891 (cleave head, shows arrow for facing)
+        // Next 4 heads are always the correct heads outside intercardinals
+        const firstId = parseInt(matches.targetId, 16);
+        const ids = [];
+        for (let id = firstId; id < firstId + 5; ++id)
+          ids.push(id);
+
+        const headData = await callOverlayHandler({
+          call: 'getCombatants',
+          ids: ids,
+        });
+        if (headData.combatants.length !== 5) {
+          console.error(`5Head Collector: null data`);
+          return;
+        }
+
+        for (const head of headData.combatants) {
+          const headId = head.ID?.toString(16).toUpperCase();
+          if (!headId) {
+            console.error(`5Head Collector: invalid head ID`);
+            continue;
+          }
+          data.storedHeads[headId] = { state: head, mechanics: [] };
+        }
+      },
+      infoText: (data, matches, output) => {
+        const headCombatant = data.storedHeads[matches.targetId];
+        if (!headCombatant) {
+          console.error(`5Head Collector: null data`);
+          return;
+        }
+
+        // Snap heading to closest card and add 2 for opposite direction
+        // N = 0, E = 1, S = 2, W = 3
+        const cardinal = ((2 - Math.round(headCombatant.state.Heading * 4 / Math.PI) / 2) + 2) % 4;
+
+        const dirs: { [dir: number]: string } = {
+          0: output.north!(),
+          1: output.east!(),
+          2: output.south!(),
+          3: output.west!(),
+        };
+
+        return dirs[cardinal];
+      },
+      outputStrings: {
+        unknown: Outputs.unknown,
+        north: Outputs.north,
+        east: Outputs.east,
+        south: Outputs.south,
+        west: Outputs.west,
+      },
+    },
+    {
+      id: 'EndsingerEx 5Head Mechanics Collector',
+      type: 'StartsUsing',
+      netRegex: NetRegexes.startsUsing({ id: ['6FFC', '7006', '7009', '700A'], source: 'The Endsinger', capture: true }),
+      netRegexDe: NetRegexes.startsUsing({ id: ['6FFC', '7006', '7009', '700A'], source: 'Endsängerin', capture: true }),
+      netRegexFr: NetRegexes.startsUsing({ id: ['6FFC', '7006', '7009', '700A'], source: 'Chantre De L\'Anéantissement', capture: true }),
+      netRegexJa: NetRegexes.startsUsing({ id: ['6FFC', '7006', '7009', '700A'], source: '終焉を謳うもの', capture: true }),
+      netRegexCn: NetRegexes.startsUsing({ id: ['6FFC', '7006', '7009', '700A'], source: '讴歌终结之物', capture: true }),
+      condition: (data) => data.headPhase === 5,
+      infoText: (data, matches, output) => {
+        const head = data.storedHeads[matches.sourceId];
+        if (!head) {
+          console.error(`5Head Mechanics Collector: null data`);
+          return;
+        }
+
+        if (matches.id === '7009') {
+          head.mechanics.push('aoe');
+        } else if (matches.id === '700A') {
+          head.mechanics.push('donut');
+        } else {
+          // Snap heading to closest card and add 2 for opposite direction
+          // N = 0, E = 1, S = 2, W = 3
+          const cardinal = ((2 - Math.round(parseFloat(matches.heading) * 4 / Math.PI) / 2) + 2) % 4;
+          const safeDir = {
+            0: 'safeN',
+            1: 'safeE',
+            2: 'safeS',
+            3: 'safeW',
+          }[cardinal] ?? '';
+          head.mechanics.push(safeDir);
+        }
+
+        // If we have the same count of mechanics stored for all 5 heads, resolve safe spot
+        const heads = Object.values(data.storedHeads);
+        if (heads.length === heads.filter((h) => h.mechanics.length === head.mechanics.length).length) {
+          const lastMechanic = head.mechanics.length - 1;
+
+          const safeDirHead = heads.find((h) => h.mechanics[0]?.includes('safe'));
+          const donutHeads = heads.filter((h) => h.mechanics[lastMechanic] === 'donut');
+          const donutHead1 = donutHeads[0];
+          const donutHead2 = donutHeads[1];
+
+          if (!safeDirHead || !donutHead1 || !donutHead2) {
+            console.error(`5Head Mechanics Collector: null data`);
+            return;
+          }
+
+          switch (safeDirHead.mechanics[lastMechanic]) {
+            case 'safeN':
+              if (donutHead1.state.PosY < 100)
+                return getKBOrbSafeDir(donutHead1.state.PosX, donutHead1.state.PosY, output);
+              return getKBOrbSafeDir(donutHead2.state.PosX, donutHead2.state.PosY, output);
+            case 'safeE':
+              if (donutHead1.state.PosX > 100)
+                return getKBOrbSafeDir(donutHead1.state.PosX, donutHead1.state.PosY, output);
+              return getKBOrbSafeDir(donutHead2.state.PosX, donutHead2.state.PosY, output);
+            case 'safeS':
+              if (donutHead1.state.PosY > 100)
+                return getKBOrbSafeDir(donutHead1.state.PosX, donutHead1.state.PosY, output);
+              return getKBOrbSafeDir(donutHead2.state.PosX, donutHead2.state.PosY, output);
+            case 'safeW':
+              if (donutHead1.state.PosX < 100)
+                return getKBOrbSafeDir(donutHead1.state.PosX, donutHead1.state.PosY, output);
+              return getKBOrbSafeDir(donutHead2.state.PosX, donutHead2.state.PosY, output);
+          }
+        }
+      },
+      outputStrings: orbOutputStrings,
+    },
+    {
+      id: 'EndsingerEx 5Head Mechanics Rewind Collector',
+      type: 'GainsEffect',
+      netRegex: NetRegexes.gainsEffect({ effectId: '808', target: 'The Endsinger', capture: true }),
+      netRegexDe: NetRegexes.gainsEffect({ effectId: '808', target: 'Endsängerin', capture: true }),
+      netRegexFr: NetRegexes.gainsEffect({ effectId: '808', target: 'Chantre De L\'Anéantissement', capture: true }),
+      netRegexJa: NetRegexes.gainsEffect({ effectId: '808', target: '終焉を謳うもの', capture: true }),
+      netRegexCn: NetRegexes.gainsEffect({ effectId: '808', target: '讴歌终结之物', capture: true }),
+      condition: (data) => data.headPhase === 5,
+      infoText: (data, matches, output) => {
+        const head = data.storedHeads[matches.targetId];
+        if (!head) {
+          console.error(`5Head Mechanics Rewind Collector: null data`);
+          return;
+        }
+
+        const mechanicIndex = {
+          '178': 2,
+          '179': 1,
+          '17A': 0,
+        }[matches.count];
+
+        const mechanic = head.mechanics[mechanicIndex ?? 0];
+
+        if (mechanicIndex === undefined || !mechanic) {
+          console.error(`5Head Mechanics Rewind Collector: no mapping for buff count`);
+          return;
+        }
+
+        data.rewindHeads[matches.targetId] = {
+          state: head.state,
+          mechanic: mechanic,
+        };
+
+        // If we have all 5 heads accounted for, resolve safe spot
+        const heads = Object.values(data.rewindHeads);
+        if (heads.length === 5) {
+          const safeDirHead = heads.find((h) => h.mechanic.includes('safe'));
+          const donutHeads = heads.filter((h) => h.mechanic === 'donut');
+          const donutHead1 = donutHeads[0];
+          const donutHead2 = donutHeads[1];
+
+          // Clean up here for next iteration
+          data.storedHeads = {};
+          data.rewindHeads = {};
+
+          if (!safeDirHead || !donutHead1 || !donutHead2) {
+            console.error(`5Head Mechanics Collector: null data`);
+            return;
+          }
+
+          switch (safeDirHead.mechanic) {
+            case 'safeN':
+              if (donutHead1.state.PosY < 100)
+                return getKBOrbSafeDir(donutHead1.state.PosX, donutHead1.state.PosY, output);
+              return getKBOrbSafeDir(donutHead2.state.PosX, donutHead2.state.PosY, output);
+            case 'safeE':
+              if (donutHead1.state.PosX > 100)
+                return getKBOrbSafeDir(donutHead1.state.PosX, donutHead1.state.PosY, output);
+              return getKBOrbSafeDir(donutHead2.state.PosX, donutHead2.state.PosY, output);
+            case 'safeS':
+              if (donutHead1.state.PosY > 100)
+                return getKBOrbSafeDir(donutHead1.state.PosX, donutHead1.state.PosY, output);
+              return getKBOrbSafeDir(donutHead2.state.PosX, donutHead2.state.PosY, output);
+            case 'safeW':
+              if (donutHead1.state.PosX < 100)
+                return getKBOrbSafeDir(donutHead1.state.PosX, donutHead1.state.PosY, output);
+              return getKBOrbSafeDir(donutHead2.state.PosX, donutHead2.state.PosY, output);
+          }
+        }
+      },
+      outputStrings: orbOutputStrings,
+    },
+    {
+      id: 'EndsingerEx 6 Head Collector',
+      type: 'Tether',
+      netRegex: NetRegexes.tether({ id: ['00BD', '00B5'], target: 'The Endsinger', capture: true }),
+      netRegexDe: NetRegexes.tether({ id: ['00BD', '00B5'], target: 'Endsängerin', capture: true }),
+      netRegexFr: NetRegexes.tether({ id: ['00BD', '00B5'], target: 'Chantre De L\'Anéantissement', capture: true }),
+      netRegexJa: NetRegexes.tether({ id: ['00BD', '00B5'], target: '終焉を謳うもの', capture: true }),
+      netRegexCn: NetRegexes.tether({ id: ['00BD', '00B5'], target: '讴歌终结之物', capture: true }),
+      condition: (data) => data.headPhase === 6,
+      delaySeconds: 0.5,
+      promise: async (data, matches) => {
+        const headData = await callOverlayHandler({
+          call: 'getCombatants',
+          ids: [parseInt(matches.sourceId, 16)],
+        });
+        const headCombatant = headData.combatants[0];
+        if (!headCombatant) {
+          console.error(`6 Head Collector: null data`);
+          return;
+        }
+
+        data.storedHeads[matches.sourceId] = { state: headCombatant, mechanics: [] };
+      },
+      infoText: (data, _matches, output) => {
+        const heads = Object.values(data.storedHeads);
+        if (heads.length === 4) {
+          data.storedHeads = {};
+          let headPositions = ['e', 'ne', 'nw', 'w', 'se', 'sw'];
+          for (const head of heads) {
+            let dir = '';
+            if (head.state.PosY < 100)
+              dir = 'n';
+            else if (head.state.PosY > 100)
+              dir = 's';
+            if (head.state.PosX < 100)
+              dir += 'w';
+            else
+              dir += 'e';
+
+            headPositions = headPositions.filter((pos) => pos !== dir);
+          }
+
+          const dir1 = headPositions[0];
+          const dir2 = headPositions[1];
+
+          if (!dir1 || !dir2) {
+            console.error(`6 Head Collector: expected 2 safe heads`);
+            return;
+          }
+
+          return output.text!({
+            dir1: output[dir1]!(),
+            dir2: output[dir2]!(),
+          });
+        }
+      },
+      outputStrings: {
+        e: Outputs.dirE,
+        w: Outputs.dirW,
+        nw: Outputs.dirNW,
+        ne: Outputs.dirNE,
+        sw: Outputs.dirSW,
+        se: Outputs.dirSE,
+        text: {
+          en: '${dir1} / ${dir2}',
+          de: '${dir1} / ${dir2}',
+          fr: '${dir1} / ${dir2}',
+          ja: '${dir1} / ${dir2}',
+          cn: '${dir1} / ${dir2}',
+          ko: '${dir1} / ${dir2}',
+        },
+      },
+    },
+    {
+      id: 'EndsingerEx Echoes of Benevolence',
+      type: 'GainsEffect',
+      netRegex: NetRegexes.gainsEffect({ effectId: 'BB0' }),
+      condition: conditions.targetIsYou(),
+      suppressSeconds: 60,
+      infoText: (data, _matches, output) => {
+        data.storedMechs[data.storedMechs.counter] = 'stack';
+        data.storedMechs.counter++;
+        return output.stack!();
+      },
+      outputStrings: echoesOutputStrings,
+    },
+    {
+      id: 'EndsingerEx Echoes of Nausea',
+      type: 'GainsEffect',
+      netRegex: NetRegexes.gainsEffect({ effectId: 'BAD' }),
+      condition: conditions.targetIsYou(),
+      suppressSeconds: 60,
+      infoText: (data, _matches, output) => {
+        data.storedMechs[data.storedMechs.counter] = 'donut';
+        data.storedMechs.counter++;
+        return output.donut!();
+      },
+      outputStrings: echoesOutputStrings,
+    },
+    {
+      id: 'EndsingerEx Echoes of the Future',
+      type: 'GainsEffect',
+      netRegex: NetRegexes.gainsEffect({ effectId: 'BAF' }),
+      condition: conditions.targetIsYou(),
+      suppressSeconds: 60,
+      infoText: (data, _matches, output) => {
+        data.storedMechs[data.storedMechs.counter] = 'flare';
+        data.storedMechs.counter++;
+        return output.flare!();
+      },
+      outputStrings: echoesOutputStrings,
+    },
+    {
+      id: 'EndsingerEx Echoes of Befoulment',
+      type: 'GainsEffect',
+      netRegex: NetRegexes.gainsEffect({ effectId: 'BAE' }),
+      condition: conditions.targetIsYou(),
+      suppressSeconds: 60,
+      infoText: (data, _matches, output) => {
+        data.storedMechs[data.storedMechs.counter] = 'spread';
+        data.storedMechs.counter++;
+        return output.spread!();
+      },
+      outputStrings: echoesOutputStrings,
+    },
+    {
+      id: 'EndsingerEx Echoes Rewind',
+      type: 'GainsEffect',
+      netRegex: NetRegexes.gainsEffect({ effectId: '95D' }),
+      condition: conditions.targetIsYou(),
+      infoText: (data, matches, output) => {
+        const mechanicIndex: 1 | 2 | 3 | undefined = ({
+          '17C': 3,
+          '17D': 2,
+          '17E': 1,
+        } as const)[matches.count];
+
+        const mechanic = data.storedMechs[mechanicIndex ?? 1];
+
+        if (mechanicIndex === undefined || !mechanic) {
+          console.error(`5Head Mechanics Rewind Collector: no mapping for buff count`);
+          return;
+        }
+
+        return output[mechanic]!();
+      },
+      outputStrings: echoesOutputStrings,
     },
   ],
   timelineReplace: [],

--- a/ui/raidboss/data/06-ew/trial/endsinger-ex.ts
+++ b/ui/raidboss/data/06-ew/trial/endsinger-ex.ts
@@ -1,4 +1,4 @@
-import conditions from '../../../../../resources/conditions';
+import Conditions from '../../../../../resources/conditions';
 import NetRegexes from '../../../../../resources/netregexes';
 import Outputs from '../../../../../resources/outputs';
 import { callOverlayHandler } from '../../../../../resources/overlay_plugin_api';
@@ -425,7 +425,7 @@ const triggerSet: TriggerSet<Data> = {
       infoText: (data, matches, output) => {
         const head = data.storedHeads[matches.sourceId];
         if (!head) {
-          console.error(`5Head Mechanics Collector: null data`);
+          console.error(`5Head Mechanics Collector: null data/missing head`);
           return;
         }
 
@@ -457,7 +457,7 @@ const triggerSet: TriggerSet<Data> = {
           const donutHead2 = donutHeads[1];
 
           if (!safeDirHead || !donutHead1 || !donutHead2) {
-            console.error(`5Head Mechanics Collector: null data`);
+            console.error(`5Head Mechanics Collector: Missing safe/donut head`);
             return;
           }
 
@@ -633,7 +633,7 @@ const triggerSet: TriggerSet<Data> = {
       id: 'EndsingerEx Echoes of Benevolence',
       type: 'GainsEffect',
       netRegex: NetRegexes.gainsEffect({ effectId: 'BB0' }),
-      condition: conditions.targetIsYou(),
+      condition: Conditions.targetIsYou(),
       suppressSeconds: 60,
       infoText: (data, _matches, output) => {
         data.storedMechs[data.storedMechs.counter] = 'stack';
@@ -646,7 +646,7 @@ const triggerSet: TriggerSet<Data> = {
       id: 'EndsingerEx Echoes of Nausea',
       type: 'GainsEffect',
       netRegex: NetRegexes.gainsEffect({ effectId: 'BAD' }),
-      condition: conditions.targetIsYou(),
+      condition: Conditions.targetIsYou(),
       suppressSeconds: 60,
       infoText: (data, _matches, output) => {
         data.storedMechs[data.storedMechs.counter] = 'donut';
@@ -659,7 +659,7 @@ const triggerSet: TriggerSet<Data> = {
       id: 'EndsingerEx Echoes of the Future',
       type: 'GainsEffect',
       netRegex: NetRegexes.gainsEffect({ effectId: 'BAF' }),
-      condition: conditions.targetIsYou(),
+      condition: Conditions.targetIsYou(),
       suppressSeconds: 60,
       infoText: (data, _matches, output) => {
         data.storedMechs[data.storedMechs.counter] = 'flare';
@@ -672,7 +672,7 @@ const triggerSet: TriggerSet<Data> = {
       id: 'EndsingerEx Echoes of Befoulment',
       type: 'GainsEffect',
       netRegex: NetRegexes.gainsEffect({ effectId: 'BAE' }),
-      condition: conditions.targetIsYou(),
+      condition: Conditions.targetIsYou(),
       suppressSeconds: 60,
       infoText: (data, _matches, output) => {
         data.storedMechs[data.storedMechs.counter] = 'spread';
@@ -685,7 +685,7 @@ const triggerSet: TriggerSet<Data> = {
       id: 'EndsingerEx Echoes Rewind',
       type: 'GainsEffect',
       netRegex: NetRegexes.gainsEffect({ effectId: '95D' }),
-      condition: conditions.targetIsYou(),
+      condition: Conditions.targetIsYou(),
       infoText: (data, matches, output) => {
         const mechanicIndex: 1 | 2 | 3 | undefined = ({
           '17C': 3,


### PR DESCRIPTION
Due to a raidemulator bug:
5head triggers won't work in raidemulator for second set in a given pull.
6 head triggers won't work in raidemulator at all.

The super quick and dirty "fix" to test these triggers is:

```diff
diff --git a/ui/raidboss/emulator/data/Combatant.ts b/ui/raidboss/emulator/data/Combatant.ts
index 2b27074e7..c8adb9040 100644
--- a/ui/raidboss/emulator/data/Combatant.ts
+++ b/ui/raidboss/emulator/data/Combatant.ts
@@ -97,7 +97,10 @@ export default class Combatant {
     const oldStateJSON = JSON.stringify(this.states[lastSignificantStateTimestamp]);
     const newStateJSON = JSON.stringify(this.states[timestamp]);
 
-    if (lastSignificantStateTimestamp !== timestamp && newStateJSON !== oldStateJSON)
+    if (
+      (lastSignificantStateTimestamp !== timestamp && newStateJSON !== oldStateJSON) ||
+      this.id[0] === '4'
+    )
       this.significantStates.push(timestamp);
   }

```

This comes back to #3359, which I haven't had time to revisit yet.

---

I haven't had a chance to test these in-zone yet.