### PR TITLE
raidboss: Endsinger Ex star trigger tweaks

### DIFF
--- a/ui/raidboss/data/06-ew/trial/endsinger-ex.ts
+++ b/ui/raidboss/data/06-ew/trial/endsinger-ex.ts
@@ -87,17 +87,13 @@ const getAoEOrbSafeDir = (posX: number, posY: number, output: Output): string | 
 };
 
 const getStarPositionFromHeading = (heading: string) => {
-  switch (parseFloat(heading)) {
-    case 0.79: // SE
-      return [114, 114];
-    case -2.36: // NW
-      return [86, 86];
-    case -0.79: // SW
-      return [86, 114];
-    case 2.36: // NE
-      return [114, 86];
-  }
-  return [];
+  const dir = ((2 - Math.round(parseFloat(heading) * 8 / Math.PI) / 2) + 2) % 8;
+  return {
+    1: [114, 86], //  NE
+    3: [114, 114], // SE
+    5: [86, 114], //  SW
+    7: [86, 86], //  NW
+  }[dir] ?? [];
 };
 
 const getStarText: TriggerField<Data, NetMatches['Ability' | 'StartsUsing'], TriggerOutput<Data, NetMatches['Ability' | 'StartsUsing']>> = (_data, matches, output) => {
@@ -109,7 +105,7 @@ const getStarText: TriggerField<Data, NetMatches['Ability' | 'StartsUsing'], Tri
   // 31 lines that are middle with a heading
   // 91 lines that are correct position, heading = 0
   // All other stars are center with a heading. This holds true for all 294 log lines I have for this event.
-  if (matches.heading !== '0.00') {
+  if (Math.round(parseFloat(matches.heading)) !== 0) {
     [posX, posY] = getStarPositionFromHeading(matches.heading);
   } else {
     posX = parseFloat(matches.x);

--- a/ui/raidboss/data/06-ew/trial/endsinger-ex.ts
+++ b/ui/raidboss/data/06-ew/trial/endsinger-ex.ts
@@ -6,32 +6,12 @@ import { Responses } from '../../../../../resources/responses';
 import ZoneId from '../../../../../resources/zone_id';
 import { RaidbossData } from '../../../../../types/data';
 import { PluginCombatantState } from '../../../../../types/event';
-import { LocaleText, Output, OutputStrings, TriggerSet } from '../../../../../types/trigger';
-
-const redStarLocale: LocaleText = {
-  en: 'Fiery Star',
-  de: 'Roter Himmelskörper',
-  fr: 'Astre Incarnat',
-  ja: '赤色天体',
-};
-
-const redStarNames = Object.values(redStarLocale);
-
-const blueStarLocale: LocaleText = {
-  en: 'Azure Star',
-  de: 'Blauer Himmelskörper',
-  fr: 'Astre Azuré',
-  ja: '青色天体',
-};
-
-const blueStarNames = Object.values(blueStarLocale);
+import { NetMatches } from '../../../../../types/net_matches';
+import { Output, OutputStrings, TriggerField, TriggerOutput, TriggerSet } from '../../../../../types/trigger';
 
 export interface Data extends RaidbossData {
   headPhase?: 5 | 6;
   starMechanicCounter: number;
-  storedStars: {
-    [id: string]: PluginCombatantState;
-  };
   storedHeads: {
     [id: string]: {
       state: PluginCombatantState;
@@ -104,6 +84,51 @@ const getAoEOrbSafeDir = (posX: number, posY: number, output: Output): string | 
     return output.sw!();
 
   return output.nw!();
+};
+
+const getStarPositionFromHeading = (heading: string) => {
+  switch (parseFloat(heading)) {
+    case 0.79: // SE
+      return [114, 114];
+    case -2.36: // NW
+      return [86, 86];
+    case -0.79: // SW
+      return [86, 114];
+    case 2.36: // NE
+      return [114, 86];
+  }
+  return [];
+};
+
+const getStarText: TriggerField<Data, NetMatches['Ability' | 'StartsUsing'], TriggerOutput<Data, NetMatches['Ability' | 'StartsUsing']>> = (_data, matches, output) => {
+  let posX: number | undefined;
+  let posY: number | undefined;
+
+  // Some 6FFA/6FFB (single) stars are at the correct position with no heading, others are center with a heading.
+  // Of the 122 single star lines, I have:
+  // 31 lines that are middle with a heading
+  // 91 lines that are correct position, heading = 0
+  // All other stars are center with a heading. This holds true for all 294 log lines I have for this event.
+  if (matches.heading !== '0.00') {
+    [posX, posY] = getStarPositionFromHeading(matches.heading);
+  } else {
+    posX = parseFloat(matches.x);
+    posY = parseFloat(matches.y);
+  }
+
+  if (posX === undefined || posY === undefined) {
+    console.error(`EndsingerEx getStarText: Could not resolve star position from heading ${parseFloat(matches.heading)}`);
+    return;
+  }
+
+  if (['6FF9', '6FFB', '7000', '7001'].includes(matches.id))
+    return getKBOrbSafeDir(posX, posY, output);
+
+  if (['6FF8', '6FFA', '6FFE', '6FFF'].includes(matches.id))
+    return getAoEOrbSafeDir(posX, posY, output);
+
+  console.error(`EndsingerEx getStarText: Could not match ability ID ${matches.id} to color`);
+  return;
 };
 
 const triggerSet: TriggerSet<Data> = {
@@ -191,61 +216,10 @@ const triggerSet: TriggerSet<Data> = {
       response: Responses.tankCleave(),
     },
     {
-      id: 'EndsingerEx Single KB Star',
+      id: 'EndsingerEx Single Star',
       type: 'StartsUsing',
-      netRegex: NetRegexes.startsUsing({ id: '6FFB', source: blueStarNames, capture: true }),
-      delaySeconds: 0.5,
-      promise: async (data, matches) => {
-        const starData = await callOverlayHandler({
-          call: 'getCombatants',
-          ids: [parseInt(matches.sourceId, 16)],
-        });
-        const starCombatant = starData.combatants[0];
-        if (!starCombatant) {
-          console.error(`Single KB Star: null data`);
-          return;
-        }
-
-        data.storedStars[matches.sourceId] = starCombatant;
-      },
-      alertText: (data, matches, output) => {
-        const starCombatant = data.storedStars[matches.sourceId];
-        if (!starCombatant) {
-          console.error(`AoE Star: null data`);
-          return;
-        }
-
-        return getKBOrbSafeDir(starCombatant.PosX, starCombatant.PosY, output);
-      },
-      outputStrings: orbOutputStrings,
-    },
-    {
-      id: 'EndsingerEx Single AoE Star',
-      type: 'StartsUsing',
-      netRegex: NetRegexes.startsUsing({ id: '6FFA', source: redStarNames, capture: true }),
-      delaySeconds: 0.5,
-      promise: async (data, matches) => {
-        const starData = await callOverlayHandler({
-          call: 'getCombatants',
-          ids: [parseInt(matches.sourceId, 16)],
-        });
-        const starCombatant = starData.combatants[0];
-        if (!starCombatant) {
-          console.error(`Single AoE Star: null data`);
-          return;
-        }
-
-        data.storedStars[matches.sourceId] = starCombatant;
-      },
-      alertText: (data, matches, output) => {
-        const starCombatant = data.storedStars[matches.sourceId];
-        if (!starCombatant) {
-          console.error(`AoE Star: null data`);
-          return;
-        }
-
-        return getAoEOrbSafeDir(starCombatant.PosX, starCombatant.PosY, output);
-      },
+      netRegex: NetRegexes.startsUsing({ id: ['6FFA', '6FFB'], capture: true }),
+      alertText: getStarText,
       outputStrings: orbOutputStrings,
     },
     {
@@ -287,43 +261,7 @@ const triggerSet: TriggerSet<Data> = {
 
         return 0;
       },
-      alertText: (_data, matches, output) => {
-        let posX: number | undefined = undefined;
-        let posY: number | undefined = undefined;
-
-        switch (parseFloat(matches.heading)) {
-          case 0.79: // SE
-            posX = 114;
-            posY = 114;
-            break;
-          case -2.36: // NW
-            posX = 86;
-            posY = 86;
-            break;
-          case -0.79: // SW
-            posX = 86;
-            posY = 114;
-            break;
-          case 2.36: // NE
-            posX = 114;
-            posY = 86;
-            break;
-        }
-
-        if (posX === undefined || posY === undefined) {
-          console.error(`Star Order Resolver: Could not resolve star position from heading ${parseFloat(matches.heading)}`);
-          return;
-        }
-
-        if (blueStarNames.includes(matches.source))
-          return getKBOrbSafeDir(posX, posY, output);
-
-        if (redStarNames.includes(matches.source))
-          return getAoEOrbSafeDir(posX, posY, output);
-
-        console.error(`Star Order Resolver: Could not match combatant name ${matches.source} to color`);
-        return;
-      },
+      alertText: getStarText,
       outputStrings: orbOutputStrings,
     },
     {


### PR DESCRIPTION
I mentioned these changes in a reply to #4270

Basically, remove the star name requirement entirely (change 1) and remove the need for calls to `getCombatants` (change 2).