### PR TITLE
i18n: zodiark-ex-cn-fix

### DIFF
--- a/ui/raidboss/data/06-ew/trial/zodiark-ex.ts
+++ b/ui/raidboss/data/06-ew/trial/zodiark-ex.ts
@@ -97,7 +97,7 @@ const triggerSet: TriggerSet<Data> = {
         text: {
           en: 'Stack x6',
           de: 'Sammeln x6',
-          cn: '6次分摊',
+          cn: '多重分摊',
         },
       },
     },
@@ -221,7 +221,7 @@ const triggerSet: TriggerSet<Data> = {
         text: {
           en: Outputs.killAdds.en + '(back first)',
           de: Outputs.killAdds.de + '(hinten zuerst)',
-          cn: Outputs.killAdds.cn + ' (先打后方的) ',
+          cn: Outputs.killAdds.cn + ' (先打后方的)',
         },
       },
     },


### PR DESCRIPTION
In this trigger, the number of stacks is not fixed 6 times, but incremental, should it be modified?
https://github.com/quisquous/cactbot/blob/b6dafe50d41371ba2b49de49eb8aa6fd0f829b4b/ui/raidboss/data/06-ew/trial/zodiark-ex.ts#L88-L100