### PR TITLE
build: update OverlayPlugin dependency to 0.18.2

### DIFF
--- a/util/DEPS.json5
+++ b/util/DEPS.json5
@@ -15,9 +15,9 @@
         "hash": ["sha256", "55eed8660848273b285e2f128a65e6822f086c885942be69691baf5c530a7cd6"],
     },
     "OverlayPlugin": {
-        "url": "https://github.com/ngld/OverlayPlugin/releases/download/v0.17.0/OverlayPlugin-0.17.0.zip",
+        "url": "https://github.com/ngld/OverlayPlugin/releases/download/v0.18.2/OverlayPlugin-0.18.2.zip",
         "dest": "plugin/ThirdParty/OverlayPlugin",
         "strip": 1,
-        "hash": ["sha256", "a4a733139c5239b3a863faa87032008a49e222ff9fd473a2aa83cf37194f66ad"],
+        "hash": ["sha256", "aa07446ecd85d36834de7b28e79eccea53b5577759c2da0e8b8358a2c2bed0a5"],
     },
 }


### PR DESCRIPTION
Update to build against 0.18.2 which uses Newtonsoft.Json 13.x.
Since cactbot builds against OverlayPlugin's version directly,
use this DLL to make sure it depends on 13.x and not 12.x.

See:
https://github.com/ngld/OverlayPlugin/commit/061c11cdb24bcbddf653c8d54ad2070a76cdef77