### PR TITLE
raidemulator: Refactor state tracking for better performance

### DIFF
--- a/ui/raidboss/emulator/data/Combatant.ts
+++ b/ui/raidboss/emulator/data/Combatant.ts
@@ -99,7 +99,11 @@ export default class Combatant {
     if (!oldState || !newState)
       throw new UnreachableCode();
 
-    if (lastSignificantStateTimestamp !== timestamp && oldState.json !== newState.json) {
+    if (
+      lastSignificantStateTimestamp !== timestamp &&
+      oldState.json &&
+      oldState.json !== newState.json
+    ) {
       delete oldState.json;
       this.significantStates.push(timestamp);
     }

--- a/ui/raidboss/emulator/data/Combatant.ts
+++ b/ui/raidboss/emulator/data/Combatant.ts
@@ -94,11 +94,15 @@ export default class Combatant {
     const lastSignificantStateTimestamp = this.significantStates[this.significantStates.length - 1];
     if (!lastSignificantStateTimestamp)
       throw new UnreachableCode();
-    const oldStateJSON = JSON.stringify(this.states[lastSignificantStateTimestamp]);
-    const newStateJSON = JSON.stringify(this.states[timestamp]);
+    const oldState = this.states[lastSignificantStateTimestamp];
+    const newState = this.states[timestamp];
+    if (!oldState || !newState)
+      throw new UnreachableCode();
 
-    if (lastSignificantStateTimestamp !== timestamp && newStateJSON !== oldStateJSON)
+    if (lastSignificantStateTimestamp !== timestamp && oldState.json !== newState.json) {
+      delete oldState.json;
       this.significantStates.push(timestamp);
+    }
   }
 
   getState(timestamp: number): CombatantState {
@@ -122,6 +126,14 @@ export default class Combatant {
     }
 
     return this.getStateByIndex(i - 1);
+  }
+
+  finalize(): void {
+    for (const state of Object.values(this.states))
+      delete state.json;
+
+    if (!this.significantStates.includes(this.latestTimestamp))
+      this.significantStates.push(this.latestTimestamp);
   }
 
   // Should only be called when `index` is valid.

--- a/ui/raidboss/emulator/data/CombatantState.ts
+++ b/ui/raidboss/emulator/data/CombatantState.ts
@@ -11,6 +11,8 @@ export default class CombatantState {
   mp: number;
   maxMp: number;
 
+  // This is a temporary variable used during CombatantTracker initialization and is `delete`d
+  // after the combatant states have been determined to keep memory usage low.
   json?: string;
 
   constructor(

--- a/ui/raidboss/emulator/data/CombatantState.ts
+++ b/ui/raidboss/emulator/data/CombatantState.ts
@@ -11,6 +11,8 @@ export default class CombatantState {
   mp: number;
   maxMp: number;
 
+  json?: string;
+
   constructor(
     posX: number,
     posY: number,
@@ -31,6 +33,7 @@ export default class CombatantState {
     this.maxHp = maxHp;
     this.mp = mp;
     this.maxMp = maxMp;
+    this.json = JSON.stringify(this);
   }
 
   partialClone(props: Partial<CombatantState>): CombatantState {

--- a/ui/raidboss/emulator/data/CombatantTracker.ts
+++ b/ui/raidboss/emulator/data/CombatantTracker.ts
@@ -1,5 +1,4 @@
 import { Lang } from '../../../../resources/languages';
-import { UnreachableCode } from '../../../../resources/not_reached';
 import PetNamesByLang from '../../../../resources/pet_names';
 
 import Combatant from './Combatant';
@@ -114,14 +113,8 @@ export default class CombatantTracker {
     })[0];
 
     // Finalize combatants, cleaning up state information
-    for (const id in this.combatants) {
-      const combatant = this.combatants[id];
-
-      if (!combatant)
-        throw new UnreachableCode();
-
+    for (const combatant of Object.values(this.combatants))
       combatant.finalize();
-    }
   }
 
   addCombatantFromLine(line: LineEventSource): void {

--- a/ui/raidboss/emulator/data/CombatantTracker.ts
+++ b/ui/raidboss/emulator/data/CombatantTracker.ts
@@ -113,20 +113,14 @@ export default class CombatantTracker {
       return (eventTracker[r] ?? 0) - (eventTracker[l] ?? 0);
     })[0];
 
-    // Always treat the last line involving a combatant as a significant state
+    // Finalize combatants, cleaning up state information
     for (const id in this.combatants) {
       const combatant = this.combatants[id];
 
       if (!combatant)
         throw new UnreachableCode();
 
-      // Get the last state timestamp
-      const state = combatant.latestTimestamp;
-
-      if (state === -1 || combatant.significantStates.includes(state))
-        continue;
-
-      combatant.significantStates.push(state);
+      combatant.finalize();
     }
   }
 


### PR DESCRIPTION
I mentioned changing the way state comparisons work in #3360. This is that change.

This is part one of breaking that old PR up into separate PRs instead.

The logic here is to only have to stringify the state once on creation, and then use that cached value until the combatant tracker state has been fully created.

Also shifted the logic added in #3359 to sit in the Combatant class since it makes more sense to live there alongside the new logic.