### PR TITLE
raidemulator: Update LineEvent indexing

### DIFF
--- a/ui/raidboss/emulator/data/NetworkLogConverter.ts
+++ b/ui/raidboss/emulator/data/NetworkLogConverter.ts
@@ -19,12 +19,7 @@ export default class NetworkLogConverter extends EventBus {
   }
 
   convertLines(lines: string[], repo: LogRepository): LineEvent[] {
-    const lineEvents = lines.map((l) => ParseLine.parse(repo, l)).filter(isLineEvent);
-    // Call `convert` to convert the network line to non-network format and update indexing values
-    return lineEvents.map((l, i) => {
-      l.index = i;
-      return l;
-    });
+    return lines.map((l) => ParseLine.parse(repo, l)).filter(isLineEvent);
   }
 
   static lineSplitRegex = /\r?\n/gm;

--- a/ui/raidboss/emulator/data/NetworkLogConverter.worker.ts
+++ b/ui/raidboss/emulator/data/NetworkLogConverter.worker.ts
@@ -33,10 +33,6 @@ ctx.addEventListener('message', (msg) => {
         line.index = i;
       }
 
-      lines = lines.map((l, i) => {
-        l.index = i;
-        return l;
-      });
       const enc = new Encounter(day, zoneId, zoneName, lines);
       enc.initialize();
       if (enc.shouldPersistFight()) {

--- a/ui/raidboss/emulator/data/NetworkLogConverter.worker.ts
+++ b/ui/raidboss/emulator/data/NetworkLogConverter.worker.ts
@@ -25,6 +25,18 @@ ctx.addEventListener('message', (msg) => {
   localLogHandler.on(
     'fight',
     (day: string, zoneId: string, zoneName: string, lines: LineEvent[]) => {
+      // Index the lines for this encounter
+      for (let i = 0; i < lines.length; ++i) {
+        const line = lines[i];
+        if (!line)
+          throw new UnreachableCode();
+        line.index = i;
+      }
+
+      lines = lines.map((l, i) => {
+        l.index = i;
+        return l;
+      });
       const enc = new Encounter(day, zoneId, zoneName, lines);
       enc.initialize();
       if (enc.shouldPersistFight()) {


### PR DESCRIPTION
This is part two of breaking #3360 up into smaller PRs. Update the indexing logic to be encounter-relative instead of file-relative.

I specifically avoided using `lines.forEach` or any other direct iteration method like that as even a 9-minute fight is 42k lines long which adds a noticeable overhead when having to recreate arrays. Calling `Object.entries` as used elsewhere is even slower.