### PR TITLE
raidemulator: Implement regex result caching for analysis

### DIFF
--- a/ui/raidboss/emulator/data/AnalyzedEncounter.ts
+++ b/ui/raidboss/emulator/data/AnalyzedEncounter.ts
@@ -15,7 +15,7 @@ import RaidEmulatorWatchCombatantsOverride from '../overrides/RaidEmulatorWatchC
 import Combatant from './Combatant';
 import Encounter from './Encounter';
 import LineEvent from './network_log_converter/LineEvent';
-import PopupTextAnalysis, { Resolver, ResolverStatus } from './PopupTextAnalysis';
+import PopupTextAnalysis, { LineRegExpCache, Resolver, ResolverStatus } from './PopupTextAnalysis';
 import RaidEmulator from './RaidEmulator';
 
 export type PerspectiveTrigger = {
@@ -33,6 +33,7 @@ type Perspectives = { [id: string]: Perspective };
 
 export default class AnalyzedEncounter extends EventBus {
   perspectives: Perspectives = {};
+  regexCache: LineRegExpCache | undefined;
   constructor(
     public options: RaidbossOptions,
     public encounter: Encounter,
@@ -115,6 +116,9 @@ export default class AnalyzedEncounter extends EventBus {
         await this.analyzeFor(id);
     }
 
+    // Free up this memory
+    delete this.regexCache;
+
     return this.dispatch('analyzed');
   }
 
@@ -155,6 +159,9 @@ export default class AnalyzedEncounter extends EventBus {
       new TimelineLoader(timelineController),
       raidbossFileData,
     );
+
+    if (this.regexCache)
+      popupText.regexCache = this.regexCache;
 
     const generator = new PopupTextGenerator(popupText);
     timelineUI.SetPopupTextInterface(generator);
@@ -245,5 +252,6 @@ export default class AnalyzedEncounter extends EventBus {
 
     this.watchCombatantsOverride.clear();
     timelineUI.stop();
+    this.regexCache = popupText.regexCache;
   }
 }

--- a/ui/raidboss/emulator/data/PopupTextAnalysis.ts
+++ b/ui/raidboss/emulator/data/PopupTextAnalysis.ts
@@ -84,9 +84,14 @@ export class Resolver {
   }
 }
 
+export type LineRegExpCache = Map<LineEvent, Map<ProcessedTrigger, RegExpExecArray | false>>;
+
 export default class PopupTextAnalysis extends StubbedPopupText {
   triggerResolvers: Resolver[] = [];
   currentResolver?: Resolver;
+
+  regexCache: LineRegExpCache;
+
   public callback?: (log: LineEvent,
     triggerHelper: EmulatorTriggerHelper | undefined,
     currentTriggerStatus: ResolverStatus,
@@ -97,6 +102,7 @@ export default class PopupTextAnalysis extends StubbedPopupText {
     timelineLoader: TimelineLoader,
     raidbossFileData: RaidbossFileData) {
     super(options, timelineLoader, raidbossFileData);
+    this.regexCache = new Map;
     this.ttsSay = (_text: string) => {
       return;
     };
@@ -121,11 +127,24 @@ export default class PopupTextAnalysis extends StubbedPopupText {
 
   async onEmulatorLog(logs: LineEvent[], getCurrentLogLine: () => LineEvent): Promise<void> {
     for (const logObj of logs) {
-      if (logObj.convertedLine.includes('00:0038:cactbot wipe'))
-        this.SetInCombat(false);
+      if (!this.regexCache.has(logObj))
+        this.regexCache.set(logObj, new Map);
+      const lineCache = this.regexCache.get(logObj);
+      if (!lineCache)
+        continue;
+
+      // Deliberately exclude the check for `cactbot wipe` since that'll never happen here
 
       for (const trigger of this.triggers) {
-        const r = trigger.localRegex?.exec(logObj.convertedLine);
+        const regex = trigger.localRegex;
+        if (!regex)
+          continue;
+
+        let r = lineCache.get(trigger);
+        if (r === undefined) {
+          r = regex.exec(logObj.convertedLine) ?? false;
+          lineCache.set(trigger, r);
+        }
         if (!r)
           continue;
 
@@ -152,7 +171,15 @@ export default class PopupTextAnalysis extends StubbedPopupText {
       }
 
       for (const trigger of this.netTriggers) {
-        const r = trigger.localNetRegex?.exec(logObj.networkLine);
+        const regex = trigger.localRegex;
+        if (!regex)
+          continue;
+
+        let r = lineCache.get(trigger);
+        if (r === undefined) {
+          r = regex.exec(logObj.networkLine) ?? false;
+          lineCache.set(trigger, r);
+        }
         if (r) {
           const resolver = this.currentResolver = new Resolver({
             initialData: EmulatorCommon.cloneData(this.data),

--- a/ui/raidboss/emulator/data/PopupTextAnalysis.ts
+++ b/ui/raidboss/emulator/data/PopupTextAnalysis.ts
@@ -171,7 +171,7 @@ export default class PopupTextAnalysis extends StubbedPopupText {
       }
 
       for (const trigger of this.netTriggers) {
-        const regex = trigger.localRegex;
+        const regex = trigger.localNetRegex;
         if (!regex)
           continue;
 


### PR DESCRIPTION
Penultimate PR for splitting up #3360.

This PR decreases the time to load a Trinity Avowed encounter from 325s to 254s.