### PR TITLE
raidemulator: Adjust loops to be more efficient

### DIFF
--- a/ui/raidboss/emulator/data/Encounter.ts
+++ b/ui/raidboss/emulator/data/Encounter.ts
@@ -58,7 +58,7 @@ export default class Encounter {
   initialize(): void {
     const startStatuses = new Set<string>();
 
-    this.logLines.forEach((line, i) => {
+    for (const line of this.logLines) {
       if (!line)
         throw new UnreachableCode();
 
@@ -68,7 +68,7 @@ export default class Encounter {
         line.networkLine,
       );
       if (res) {
-        this.firstLineIndex = i;
+        this.firstLineIndex = line.index;
         if (res.StartType)
           startStatuses.add(res.StartType);
         const startIn = parseInt(res.StartIn);
@@ -101,7 +101,7 @@ export default class Encounter {
       const matchedLang = res?.language;
       if (isLang(matchedLang))
         this.language = matchedLang;
-    });
+    }
 
     this.combatantTracker = new CombatantTracker(this.logLines, this.language);
     this.startTimestamp = this.combatantTracker.firstTimestamp;

--- a/ui/raidboss/emulator/data/Persistor.ts
+++ b/ui/raidboss/emulator/data/Persistor.ts
@@ -37,9 +37,8 @@ export default class Persistor extends Dexie {
 
                   Object.setPrototypeOf(obj, Encounter.prototype);
 
-                  obj.logLines.forEach((l) => {
-                    Object.setPrototypeOf(l, LineEvent.prototype);
-                  });
+                  for (const line of obj.logLines)
+                    Object.setPrototypeOf(line, LineEvent.prototype);
 
                   // Check for encounter upgrade, re-save encounter if it's upgraded.
                   if (obj.upgrade(obj.version)) {

--- a/ui/raidboss/emulator/data/PopupTextAnalysis.ts
+++ b/ui/raidboss/emulator/data/PopupTextAnalysis.ts
@@ -216,11 +216,12 @@ export default class PopupTextAnalysis extends StubbedPopupText {
   }
 
   async checkResolved(logObj: LineEvent): Promise<void> {
-    await Promise.all(
-      this.triggerResolvers.map(async (resolver) => await resolver.isResolved(logObj)))
-      .then((results) => {
-        this.triggerResolvers = this.triggerResolvers.filter((_, index) => !results[index]);
-      });
+    const unresolved: Resolver[] = [];
+    for (const res of this.triggerResolvers) {
+      if (!(await res.isResolved(logObj)))
+        unresolved.push(res);
+    }
+    this.triggerResolvers = unresolved;
   }
 
   override _onTriggerInternalCondition(triggerHelper: EmulatorTriggerHelper): boolean {


### PR DESCRIPTION
Last PR followup for #3360.

The Regex Caching change improves performance more for analysis per combatant (all performance gain was in `AnalyzedEncounter.analyzeFor`), so that change will see a bigger improvement for 24-man content than 8-man content, whereas these changes benefit more from a lines-per-encounter perspective.

Performance improvement statistics copy/pasted from other PR:

```
p3s: 9m52s encounter duration, 35923 lines
No changes: 15222, 14951, 14959, average 15044
Regex Caching: 14320, 13812, 13873, average 14002, 7% improvement from baseline
Loop Changes: 11543, 10951, 10717, average 11070, 26% improvement from baseline

drs: 27m37s encounter duration, 93598 lines
No changes: 341555, 325064, 326215, average 330945
Regex Caching: 279454, 279426, 276079, average 278320, 16% improvement from baseline
Loop Changes: 232154, 234719, 232621, average 233165, 30% improvement from baseline
```

Since I forgot to mention it in the previous PR for regex caching, these times were gotten via the following adjustment, and refreshing the page to get the same page load timing:

```diff
diff --git a/ui/raidboss/emulator/data/RaidEmulator.ts b/ui/raidboss/emulator/data/RaidEmulator.ts
index 99d14a419..6de375de2 100644
--- a/ui/raidboss/emulator/data/RaidEmulator.ts
+++ b/ui/raidboss/emulator/data/RaidEmulator.ts
@@ -38,9 +38,11 @@ export default class RaidEmulator extends EventBus {
     if (enc.language)
       this.options.ParserLanguage = enc.language;
 
+    const start = Date.now();
     this.currentEncounter = new AnalyzedEncounter(this.options, enc, this, watchCombatantsOverride);
     void this.dispatch('preCurrentEncounterChanged', this.currentEncounter);
     void this.currentEncounter.analyze().then(() => {
+      console.log(`Loaded encounter in ${Date.now() - start} ms`);
       void this.dispatch('currentEncounterChanged', this.currentEncounter);
     });
   }
```

Explanation of changes:

- Combatant.ts: Significantly faster to loop through the array directly to find the correct timestamp, rather than cloning the entire array twice.
- Encounter.ts: Avoid the overhead of calling into the anonymous function for `forEach` since it's usually 30k+ calls per encounter load, that's a lot of context switching
- Persistor.ts: Same as above
- PopupTextAnalysis.ts: For some reason using the `Promise.all` construct was incredibly slow in comparison to just looping, probably something related to the internal promise chaining logic? 🤷‍♂️ 
- CombatantTracker.ts: Cut required looping over lines to just one loop, this made handling the lines a bit more complicated unfortunately.