### PR TITLE
raidboss: Fix raidboss not obeying `/e end`

### DIFF
--- a/plugin/CactbotEventSource/WipeDetector.cs
+++ b/plugin/CactbotEventSource/WipeDetector.cs
@@ -24,6 +24,9 @@ namespace Cactbot {
         if (log.IndexOf(" 00:0038:cactbot wipe", StringComparison.Ordinal) != -1) {
           WipeIt();
         }
+        if (log.IndexOf(" 00:0038:end", StringComparison.Ordinal) != -1) {
+          WipeIt();
+        }
         if (wipe_regex_.IsMatch(log)) {
           WipeIt();
         }

--- a/ui/raidboss/popup-text.ts
+++ b/ui/raidboss/popup-text.ts
@@ -513,6 +513,9 @@ export class PopupText {
     addOverlayListener('onInCombatChangedEvent', (e) => {
       this.OnInCombatChange(e.detail.inGameCombat);
     });
+    addOverlayListener('onPartyWipe', () => {
+      this.OnInCombatChange(false);
+    });
     addOverlayListener('onLogEvent', (e) => {
       this.OnLog(e);
     });


### PR DESCRIPTION
This is a naive attempt to fix #4189. Basically, add `/e end` detection to WipeDetector and add OnWipe handling to PopupText.

This should also technically allow the removal of every `--Reset--` in every timeline, though I haven't tested this in-game at all yet (I can't actually build the dll file with my current setup).

I'd like to request review and testing by someone that can actually build the plugin dll, especially since I haven't worked with the C# source (and I'm pretty rusty on C# in general, I rarely have need of it).