### PR TITLE
config: fix removing timeline entry

### DIFF
--- a/ui/raidboss/raidboss_config.ts
+++ b/ui/raidboss/raidboss_config.ts
@@ -967,6 +967,7 @@ class RaidbossConfigurator {
       remove.addEventListener('click', () => {
         container.removeChild(timeInput);
         container.removeChild(textInput);
+        container.removeChild(durationInput);
         container.removeChild(remove);
 
         // Update rows in place, as it has been captured by a closure above.


### PR DESCRIPTION
Duration got added later and wasn't added to the remove button
logic, and so clicking "remove" causes layout issues.

Fixes #4332.