### PR TITLE
util: Argparse separation updates

### DIFF
--- a/util/logtools/arg_parser.ts
+++ b/util/logtools/arg_parser.ts
@@ -1,0 +1,77 @@
+import argparse from 'argparse';
+
+type argsObject = {
+  [index: string]: string | number | boolean | undefined;
+  'file'?: string;
+  'force'?: boolean;
+  'search_fights'?: number;
+  'search_zones'?: number;
+  'fight_regex'?: string;
+  'zone_regex'?: string;
+  'adjust'?: number;
+};
+
+class TimelineParse {
+  parser = new argparse.ArgumentParser({
+    addHelp: true,
+  });
+  args: argsObject;
+  constructor() {
+    this.parser.addArgument(['-f', '--file'], {
+      required: true,
+      help: 'Network log file to analyze',
+    });
+    this.parser.addArgument(['--force'], {
+      nargs: 0,
+      help: 'Overwrite files when exporting',
+    });
+    this.parser.addArgument(['-lf', '--search-fights'], {
+      nargs: '?',
+      constant: -1,
+      type: 'int',
+      help: 'Fight in log to use, e.g. \'1\'. ' +
+        'If no number is specified, returns a list of fights.',
+    });
+    this.parser.addArgument(['-lz', '--search-zones'], {
+      nargs: '?',
+      constant: -1,
+      type: 'int',
+      help: 'Zone in log to use, e.g. \'1\'. ' +
+        'If no number is specified, returns a list of zones.',
+    });
+    this.parser.addArgument(['-fr', '--fight-regex'], {
+      nargs: '?',
+      constant: '*',
+      type: 'string',
+      help: 'Export all fights that match this regex',
+    });
+    this.parser.addArgument(['-zr', '--zone-regex'], {
+      nargs: '?',
+      constant: '*',
+      type: 'string',
+      help: 'Export all zones that match this regex',
+    });
+    this.parser.addArgument(['-a', '--adjust'], {
+      nargs: '?',
+      constant: 0,
+      type: 'float',
+      help: 'Adjust all entries in a timeline file by this amount',
+    });
+    this.args = this.validate(this.parser.parseArgs() as argsObject);
+  }
+
+  validate(args: argsObject): argsObject {
+    let numExclusiveArgs = 0;
+    for (const opt of ['search_fights', 'search_zones', 'fight_regex', 'zone_regex']) {
+      if (args[opt] !== null)
+        numExclusiveArgs++;
+    }
+    if (numExclusiveArgs > 1) {
+      console.error('Error: Must specify exactly zero or one of -lf, -lz, -fr\n');
+      process.exit(-1);
+    }
+    return args;
+  }
+}
+
+export default TimelineParse;

--- a/util/logtools/arg_parser.ts
+++ b/util/logtools/arg_parser.ts
@@ -15,12 +15,22 @@ class LogUtilArgParse {
   parser = new argparse.ArgumentParser({
     addHelp: true,
   });
-  // At least one non-file argument must be selected from this group.
+  // At least one argument must be selected from this group.
   fileGroup = this.parser.addArgumentGroup({
     title: 'File Args',
     description: 'A file and/or a timeline must be selected before performing operations',
   });
   // Exactly one argument should be selected from this group.
+  // All arguments within this group are defined with nargs: '?',
+  // so the user can call them from the command line with or without values.
+  // This way, in any consuming script, a value of null means that argument
+  // is not present at the command line.
+
+  // While exactly one argument should be called from this group,
+  // which ones are valid will vary on a per-script basis,
+  // so we leave that level of validation to the consuming scripts.
+  // The only validation done here is to ensure that at least one
+  // of these arguments is present.
   requiredGroup = this.parser.addMutuallyExclusiveGroup();
   args: TimelineArgs;
 

--- a/util/logtools/arg_parser.ts
+++ b/util/logtools/arg_parser.ts
@@ -1,6 +1,6 @@
 import argparse from 'argparse';
 
-type argsObject = {
+type TimelineArgs = {
   [index: string]: string | number | boolean | undefined;
   'file'?: string;
   'force'?: boolean;
@@ -22,7 +22,8 @@ class TimelineParse {
   });
   // Exactly one argument should be selected from this group.
   requiredGroup = this.parser.addMutuallyExclusiveGroup({ required: true });
-  args: argsObject;
+  args: TimelineArgs;
+
   constructor() {
     this.fileGroup.addArgument(['-f', '--file'], {
       help: 'Network log file to analyze',
@@ -50,13 +51,11 @@ class TimelineParse {
     });
     this.requiredGroup.addArgument(['-fr', '--fight-regex'], {
       nargs: '?',
-      constant: '*',
       type: 'string',
       help: 'Export all fights that match this regex',
     });
     this.requiredGroup.addArgument(['-zr', '--zone-regex'], {
       nargs: '?',
-      constant: '*',
       type: 'string',
       help: 'Export all zones that match this regex',
     });
@@ -66,10 +65,10 @@ class TimelineParse {
       type: 'float',
       help: 'Adjust all entries in a timeline file by this amount',
     });
-    this.args = this.validate(this.parser.parseArgs() as argsObject);
+    this.args = this.validate(this.parser.parseArgs() as TimelineArgs);
   }
 
-  validate(args: argsObject): argsObject {
+  validate(args: TimelineArgs): TimelineArgs {
     // We can't enforce 1+ arguments in a non-exclusive group,
     // so we have to do it manually here.
     let numFileArgs = 0;
@@ -85,4 +84,4 @@ class TimelineParse {
   }
 }
 
-export default TimelineParse;
+export { TimelineArgs, TimelineParse };

--- a/util/logtools/arg_parser.ts
+++ b/util/logtools/arg_parser.ts
@@ -21,7 +21,7 @@ class LogUtilArgParse {
     description: 'A file and/or a timeline must be selected before performing operations',
   });
   // Exactly one argument should be selected from this group.
-  requiredGroup = this.parser.addMutuallyExclusiveGroup({ required: true });
+  requiredGroup = this.parser.addMutuallyExclusiveGroup();
   args: TimelineArgs;
 
   constructor() {
@@ -32,7 +32,8 @@ class LogUtilArgParse {
       help: 'The filename of the timeline to test against, e.g. ultima_weapon_ultimate',
     });
     this.parser.addArgument(['--force'], {
-      nargs: 0,
+      nargs: '?',
+      constant: true,
       help: 'Overwrite files when exporting',
     });
     this.requiredGroup.addArgument(['-lf', '--search-fights'], {
@@ -50,12 +51,14 @@ class LogUtilArgParse {
         'If no number is specified, returns a list of zones.',
     });
     this.requiredGroup.addArgument(['-fr', '--fight-regex'], {
-      nargs: '1',
+      nargs: '?',
+      constant: -1,
       type: 'string',
       help: 'Export all fights that match this regex',
     });
     this.requiredGroup.addArgument(['-zr', '--zone-regex'], {
-      nargs: '1',
+      nargs: '?',
+      constant: -1,
       type: 'string',
       help: 'Export all zones that match this regex',
     });
@@ -65,22 +68,7 @@ class LogUtilArgParse {
       type: 'float',
       help: 'Adjust all entries in a timeline file by this amount',
     });
-    this.args = this.validate(this.parser.parseArgs() as TimelineArgs);
-  }
-
-  validate(args: TimelineArgs): TimelineArgs {
-    // We can't enforce 1+ arguments in a non-exclusive group,
-    // so we have to do it manually here.
-    let numFileArgs = 0;
-    for (const opt of ['file', 'timeline']) {
-      if (args[opt] !== null)
-        numFileArgs++;
-    }
-    if (numFileArgs === 0) {
-      console.error('Error: Must specify at least one of -f or -t');
-      process.exit(-1);
-    }
-    return args;
+    this.args = this.parser.parseArgs() as TimelineArgs;
   }
 }
 

--- a/util/logtools/arg_parser.ts
+++ b/util/logtools/arg_parser.ts
@@ -25,7 +25,6 @@ class TimelineParse {
   args: argsObject;
   constructor() {
     this.fileGroup.addArgument(['-f', '--file'], {
-      required: true,
       help: 'Network log file to analyze',
     });
     this.fileGroup.addArgument(['-t', '--timeline'], {

--- a/util/logtools/arg_parser.ts
+++ b/util/logtools/arg_parser.ts
@@ -11,7 +11,7 @@ type TimelineArgs = {
   'adjust'?: number;
 };
 
-class TimelineParse {
+class LogUtilArgParse {
   parser = new argparse.ArgumentParser({
     addHelp: true,
   });
@@ -84,4 +84,4 @@ class TimelineParse {
   }
 }
 
-export { TimelineArgs, TimelineParse };
+export { LogUtilArgParse, TimelineArgs };

--- a/util/logtools/arg_parser.ts
+++ b/util/logtools/arg_parser.ts
@@ -50,12 +50,12 @@ class TimelineParse {
         'If no number is specified, returns a list of zones.',
     });
     this.requiredGroup.addArgument(['-fr', '--fight-regex'], {
-      nargs: '?',
+      nargs: '1',
       type: 'string',
       help: 'Export all fights that match this regex',
     });
     this.requiredGroup.addArgument(['-zr', '--zone-regex'], {
-      nargs: '?',
+      nargs: '1',
       type: 'string',
       help: 'Export all zones that match this regex',
     });

--- a/util/logtools/split_log.js
+++ b/util/logtools/split_log.js
@@ -26,7 +26,7 @@ for (const opt of ['search_fights', 'search_zones', 'fight_regex', 'zone_regex']
     numExclusiveArgs++;
 }
 if (numExclusiveArgs !== 1)
-  printHelpAndExit('Error: Must specify exactly one of -lf, -lz, -fr\n');
+  printHelpAndExit('Error: Must specify exactly one of -lf, -lz, or -fr\n');
 if (args['fight_regex'] === -1)
   printHelpAndExit('Error: -fr must specify a regex\n');
 if (args['zone_regex'] === -1)

--- a/util/logtools/split_log.js
+++ b/util/logtools/split_log.js
@@ -5,7 +5,7 @@ import Splitter from './splitter';
 import { EncounterCollector } from './encounter_tools';
 import ZoneId from '../../resources/zone_id';
 import argparse from 'argparse';
-import TimelineParse from './arg_parser';
+import { TimelineParse } from './arg_parser';
 
 // TODO: add options for not splitting / not anonymizing.
 const timelineParse = new TimelineParse();
@@ -58,7 +58,7 @@ const generateFileName = (fightOrZone) => {
 
   let zoneName;
   if (fightOrZone.zoneName || fightOrZone.name) {
-    zoneName = fightOrZone.zoneName || fightOrZone.name;
+    zoneName = fightOrZone.zoneName ?? fightOrZone.name;
   } else {
     const idToZoneName = {};
     for (const zoneName in ZoneId)
@@ -272,11 +272,11 @@ const writeFile = (outputFile, startLine, endLine) => {
   }
 
   // This utility prints 1-indexed fights and zones, so adjust - 1.
-  if (!(args['search_fights'] === -1 || args['search_fights'] === null)) {
+  if (args['search_fights']) {
     const fight = collector.fights[args['search_fights'] - 1];
     await writeFile(generateFileName(fight), fight.startLine, fight.endLine);
     process.exit(exitCode);
-  } else if (!(args['search_zones'] === -1 || args['search_zones'] === null)) {
+  } else if (args['search_zones']) {
     const zone = collector.zones[args['search_zones'] - 1];
     await writeFile(generateFileName(zone), zone.startLine, zone.endLine);
     process.exit(exitCode);

--- a/util/logtools/split_log.js
+++ b/util/logtools/split_log.js
@@ -5,69 +5,12 @@ import Splitter from './splitter';
 import { EncounterCollector } from './encounter_tools';
 import ZoneId from '../../resources/zone_id';
 import argparse from 'argparse';
+import TimelineParse from './arg_parser';
 
 // TODO: add options for not splitting / not anonymizing.
-const parser = new argparse.ArgumentParser({
-  addHelp: true,
-});
-parser.addArgument(['-f', '--file'], {
-  required: true,
-  help: 'File to analyze',
-});
-parser.addArgument(['--force'], {
-  nargs: 0,
-  help: 'Overwrite files when exporting',
-});
-parser.addArgument(['-lf', '--search-fights'], {
-  nargs: '?',
-  defaultValue: -1,
-  type: 'int',
-  help: 'Fight in log to use, e.g. \'1\'. ' +
-    'If no number is specified, returns a list of fights.',
-});
-parser.addArgument(['-lz', '--search-zones'], {
-  nargs: '?',
-  defaultValue: -1,
-  type: 'int',
-  help: 'Zone in log to use, e.g. \'1\'. ' +
-    'If no number is specified, returns a list of zones.',
-});
-parser.addArgument(['-fr', '--fight-regex'], {
-  nargs: '?',
-  defaultValue: -1,
-  type: 'string',
-  help: 'Export all fights that match this regex',
-});
-parser.addArgument(['-zr', '--zone-regex'], {
-  nargs: '?',
-  defaultValue: -1,
-  type: 'string',
-  help: 'Export all zones that match this regex',
-});
+const timelineParse = new TimelineParse();
 
-const args = parser.parseArgs();
-
-let numExclusiveArgs = 0;
-for (const opt of ['search_fights', 'search_zones', 'fight_regex', 'zone_regex']) {
-  if (args[opt] !== -1)
-    numExclusiveArgs++;
-}
-if (numExclusiveArgs !== 1) {
-  console.error('Error: Must specify exactly one of -lf, -lz, -fr\n');
-  parser.printHelp();
-  process.exit(-1);
-}
-
-if (args['fight_regex'] === null) {
-  console.error('Error: -fr must specify a regex\n');
-  parser.printHelp();
-  process.exit(-1);
-}
-if (args['zone_regex'] === null) {
-  console.error('Error: -zr must specify a regex\n');
-  parser.printHelp();
-  process.exit(-1);
-}
+const args = timelineParse.args;
 
 const logFileName = args.file;
 let exitCode = 0;
@@ -113,10 +56,15 @@ const generateFileName = (fightOrZone) => {
   else
     seal = '';
 
-  const idToZoneName = {};
-  for (const zoneName in ZoneId)
-    idToZoneName[ZoneId[zoneName]] = zoneName;
-  const zoneName = idToZoneName[zoneId];
+  let zoneName;
+  if (fightOrZone.zoneName || fightOrZone.name) {
+    zoneName = fightOrZone.zoneName || fightOrZone.name;
+  } else {
+    const idToZoneName = {};
+    for (const zoneName in ZoneId)
+      idToZoneName[ZoneId[zoneName]] = zoneName;
+    zoneName = idToZoneName[zoneId];
+  }
 
   const wipeStr = fightOrZone.endType === 'Wipe' ? '_wipe' : '';
   return `${zoneName}${seal}_${dateStr}_${timeStr}_${duration}${wipeStr}.log`;
@@ -314,25 +262,25 @@ const writeFile = (outputFile, startLine, endLine) => {
 
   const collector = await makeCollectorFromPrepass(logFileName);
 
-  if (args['search_fights'] === null) {
+  if (args['search_fights'] === -1) {
     printCollectedFights(collector);
     process.exit(0);
   }
-  if (args['search_zones'] === null) {
+  if (args['search_zones'] === -1) {
     printCollectedZones(collector);
     process.exit(0);
   }
 
   // This utility prints 1-indexed fights and zones, so adjust - 1.
-  if (args['search_fights'] !== -1) {
+  if (!(args['search_fights'] === -1 || args['search_fights'] === null)) {
     const fight = collector.fights[args['search_fights'] - 1];
     await writeFile(generateFileName(fight), fight.startLine, fight.endLine);
     process.exit(exitCode);
-  } else if (args['search_zones'] !== -1) {
+  } else if (!(args['search_zones'] === -1 || args['search_zones'] === null)) {
     const zone = collector.zones[args['search_zones'] - 1];
     await writeFile(generateFileName(zone), zone.startLine, zone.endLine);
     process.exit(exitCode);
-  } else if (args['fight_regex'] !== -1) {
+  } else if (args['fight_regex']) {
     const regex = new RegExp(args['fight_regex'], 'i');
     for (const fight of collector.fights) {
       if (fight.sealName) {
@@ -344,7 +292,7 @@ const writeFile = (outputFile, startLine, endLine) => {
       await writeFile(generateFileName(fight), fight.startLine, fight.endLine);
     }
     process.exit(exitCode);
-  } else if (args['zone_regex'] !== -1) {
+  } else if (args['zone_regex']) {
     const regex = new RegExp(args['zone_regex'], 'i');
     for (const zone of collector.zones) {
       if (!zone.name.match(regex))

--- a/util/logtools/split_log.js
+++ b/util/logtools/split_log.js
@@ -12,6 +12,26 @@ const timelineParse = new LogUtilArgParse();
 
 const args = timelineParse.args;
 
+const printHelpAndExit = (errString) => {
+  console.error(errString);
+  timelineParse.parser.printHelp();
+  process.exit(-1);
+};
+
+if (args.file === null && args.timeline === null)
+  printHelpAndExit('Error: Must specify at least one of -f, -t\n');
+let numExclusiveArgs = 0;
+for (const opt of ['search_fights', 'search_zones', 'fight_regex', 'zone_regex']) {
+  if (args[opt] !== null)
+    numExclusiveArgs++;
+}
+if (numExclusiveArgs !== 1)
+  printHelpAndExit('Error: Must specify exactly one of -lf, -lz, -fr\n');
+if (args['fight_regex'] === -1)
+  printHelpAndExit('Error: -fr must specify a regex\n');
+if (args['zone_regex'] === -1)
+  printHelpAndExit('Error: -zr must specify a regex\n');
+
 const logFileName = args.file;
 let exitCode = 0;
 const errorFunc = (str) => {

--- a/util/logtools/split_log.js
+++ b/util/logtools/split_log.js
@@ -5,10 +5,10 @@ import Splitter from './splitter';
 import { EncounterCollector } from './encounter_tools';
 import ZoneId from '../../resources/zone_id';
 import argparse from 'argparse';
-import { TimelineParse } from './arg_parser';
+import { LogUtilArgParse } from './arg_parser';
 
 // TODO: add options for not splitting / not anonymizing.
-const timelineParse = new TimelineParse();
+const timelineParse = new LogUtilArgParse();
 
 const args = timelineParse.args;
 


### PR DESCRIPTION
This is a cleaned-up (I hope) version of the mess in #3658.

~~It appears that when we create an instance of `LogUtilArgParse` after exporting + importing it, the various values for any unused args are set to `null` rather than their default values. This means we have to shift how we validate the various flags. (That is, if we `invoke split_log -f logfile.log -lf`, all arguments apart from `-f` and `-lf` will be `null` rather than their defined constant values.`-lf` will be -1.) It's very possible I'm missing a better way to handle all this, but as it stands this all seems to *work*.~~

~~`--force` is special-cased to be true if present, since if we don't define it as constant, it will instead have a value of `force[]` rather than `true`.~~

Disregard this because I'm bad at Argparse  and forgot that I changed over to using `constant` over `default`.

To expand on the reason for preferring `constant` over `defaultValue`, the Argparse documentation has it that [`constant` values are passed into the `args` object only if that flag is present on the command line](https://docs.python.org/3/library/argparse.html#const), while `default` is always passed through. Specifically:

> For positional arguments with [nargs](https://docs.python.org/3/library/argparse.html#nargs) equal to ? or *, the default value is used when no command-line argument was present:


Because we need to use `nargs = '?'`, I think in our context it makes more sense for flags not present to present `null` values, and to have their default values only if the flag is actually there. This way we don't have to handle magic numbers in the same step as checking for which flags are present.