### PR TITLE
build: update python formatter and linter

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 # Linting, formatting
-black==19.10b0
-pylint==2.5.3
+black==22.3.0
+pylint==2.13.7
 
 # dependencies for utils/*.py
 PyYAML

--- a/util/coinach.py
+++ b/util/coinach.py
@@ -80,7 +80,10 @@ class CoinachReader:
         # This will throw an exception if stuff is VERY wrong
         # however, return code is still 0 even if all exports fail.
         # Also, it seems to need to be run from the SaintCoinach directory.
-        raw_output = subprocess.check_output(cmd, cwd=self.coinach_path,)
+        raw_output = subprocess.check_output(
+            cmd,
+            cwd=self.coinach_path,
+        )
         output = raw_output.decode("utf8")
 
         # Manually check output for errors.

--- a/util/encounter_tools.py
+++ b/util/encounter_tools.py
@@ -270,7 +270,8 @@ def is_tl_line_buff(poss_match):
 
 def is_tl_line_cast(poss_match):
     return re.search(
-        r"\s1(?:[56]|\[56\]):(?:\[\^:\]\*|[^:]*):(?P<source>[^:]+):(?P<id>[^:]+)", poss_match,
+        r"\s1(?:[56]|\[56\]):(?:\[\^:\]\*|[^:]*):(?P<source>[^:]+):(?P<id>[^:]+)",
+        poss_match,
     )
 
 

--- a/util/gen_fisher_data.py
+++ b/util/gen_fisher_data.py
@@ -200,7 +200,8 @@ def get_fish_data():
 def get_tackle():
     # Also get fishing tackle
     response = xivapi(
-        "ItemUICategory", {"id": tackle_id, "columns": ["GameContentLinks.Item.ItemUICategory"]},
+        "ItemUICategory",
+        {"id": tackle_id, "columns": ["GameContentLinks.Item.ItemUICategory"]},
     )
 
     item_ids = response["GameContentLinks"]["Item"]["ItemUICategory"]

--- a/util/make_timeline.py
+++ b/util/make_timeline.py
@@ -426,7 +426,9 @@ if __name__ == "__main__":
 
     # Report arguments
     parser.add_argument(
-        "-k", "--key", help="The FFLogs API key to use, from https://www.fflogs.com/profile",
+        "-k",
+        "--key",
+        help="The FFLogs API key to use, from https://www.fflogs.com/profile",
     )
     parser.add_argument(
         "-rf",
@@ -507,11 +509,11 @@ if __name__ == "__main__":
 
     # Check dependent args
     if args.search_fights and not args.file:
-        raise parser.error("Automatic encounter listing requires an input file")
+        parser.error("Automatic encounter listing requires an input file")
     if args.file and not ((args.start and args.end) or args.search_fights):
-        raise parser.error("Log file input requires start and end timestamps")
+        parser.error("Log file input requires start and end timestamps")
     if args.report and not args.key:
-        raise parser.error(
+        parser.error(
             "FFlogs parsing requires an API key. Visit https://www.fflogs.com/profile and use the V1 Client Key"
         )
 

--- a/util/test_timeline.py
+++ b/util/test_timeline.py
@@ -262,7 +262,11 @@ def test_match(event, entry):
         elif entry["special_type"] == "battlelog" and event.startswith(entry["special_line"]):
             # Matching this format generically:
             # 00|2019-01-12T18:08:14.0000000-05:00|0839||The Realm of the Machinists will be sealed off in 15 seconds!|
-            log_match = re.search(entry["regex"], event, re.IGNORECASE,)
+            log_match = re.search(
+                entry["regex"],
+                event,
+                re.IGNORECASE,
+            )
             if log_match:
                 return True
             else:
@@ -280,7 +284,10 @@ def test_match(event, entry):
 
         # Head marker case
         elif entry["special_type"] == "headmarker" and event.startswith(entry["special_line"]):
-            marker_match = re.search(entry["regex"], event,)
+            marker_match = re.search(
+                entry["regex"],
+                event,
+            )
             if marker_match:
                 return True
             else:
@@ -600,18 +607,18 @@ if __name__ == "__main__":
 
     # Check dependent args
     if args.search_fights and not args.file:
-        raise parser.error("Automatic encounter listing requires an input file")
+        parser.error("Automatic encounter listing requires an input file")
 
     if args.search_fights and args.search_fights > -1 and not args.timeline:
-        raise parser.error(
+        parser.error(
             "You must specify a timeline file before testing against a specific encounter."
         )
 
     if args.file and not ((args.start and args.end) or args.search_fights):
-        raise parser.error("Log file input requires start and end timestamps")
+        parser.error("Log file input requires start and end timestamps")
 
     if args.report and not args.key:
-        raise parser.error(
+        parser.error(
             "FFlogs parsing requires an API key. Visit https://www.fflogs.com/profile and use the V1 Client Key"
         )
 

--- a/util/translate_fight.py
+++ b/util/translate_fight.py
@@ -231,7 +231,7 @@ if __name__ == "__main__":
         sys.exit(0)
 
     if args.report and not args.key:
-        raise parser.error(
+        parser.error(
             "FFlogs parsing requires an API key. Visit https://www.fflogs.com/profile and use the V1 Client Key"
         )
 


### PR DESCRIPTION
fix #4321

## black

bump black 19.10b0 to 22.3.0

reformatted python files with option `black **/*.py --line-length 100`

## pylint

bump pylint 2.5.3 to 2.13.7

The only new errors that appear are:

```python
>>> pylint **/*.py --errors-only
************* Module make_timeline
util\make_timeline.py:512:8: E0702: Raising NoneType while only classes or instances are allowed (raising-bad-type)
util\make_timeline.py:514:8: E0702: Raising NoneType while only classes or instances are allowed (raising-bad-type)
util\make_timeline.py:516:8: E0702: Raising NoneType while only classes or instances are allowed (raising-bad-type)
************* Module test_timeline
util\test_timeline.py:610:8: E0702: Raising NoneType while only classes or instances are allowed (raising-bad-type)
util\test_timeline.py:613:8: E0702: Raising NoneType while only classes or instances are allowed (raising-bad-type)
util\test_timeline.py:618:8: E0702: Raising NoneType while only classes or instances are allowed (raising-bad-type)
util\test_timeline.py:621:8: E0702: Raising NoneType while only classes or instances are allowed (raising-bad-type)
************* Module translate_fight
util\translate_fight.py:234:8: E0702: Raising NoneType while only classes or instances are allowed (raising-bad-type)
```

```python
# util/make_timeline.py line 511-512
if args.search_fights and not args.file:
    raise parser.error("Automatic encounter listing requires an input file")
```

According to pylint, it is wrong that no error class comes after raise.

But that doesn't make any error. This is because once `parser.error` function is executed, it terminates the program.

```python
# argparse.py
...
    def error(self, message):
        """error(message: string)

        Prints a usage message incorporating the message to stderr and
        exits.

        If you override this in a subclass, it should not return -- it
        should either exit or raise an exception.
        """
        self.print_usage(_sys.stderr)
        args = {'prog': self.prog, 'message': message}
        # ↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓
        self.exit(2, _('%(prog)s: error: %(message)s\n') % args)
```

However, since the latest version of pylint catches that, I fixed it by simply removing `raise`

If you think this part is unnecessary, I'll revert this.