### PR TITLE
raidboss: DSR Thordan location callout.

### DIFF
--- a/ui/raidboss/data/06-ew/ultimate/dragonsongs_reprise_ultimate.ts
+++ b/ui/raidboss/data/06-ew/ultimate/dragonsongs_reprise_ultimate.ts
@@ -258,8 +258,8 @@ const triggerSet: TriggerSet<Data> = {
     },
     {
       id: 'DSR Thordan Finder',
-      type: 'StartsUsing',
-      netRegex: NetRegexes.startsUsing({ id: '63DB', source: 'Ser Grinnaux', capture: false }),
+      type: 'Ability',
+      netRegex: NetRegexes.ability({ id: '63D6', source: 'Ser Guerrique', capture: false }),
       condition: (data) => data.phase === 'thordan',
       durationSeconds: 10,
       promise: async (data, _matches) => {


### PR DESCRIPTION
This is a pretty simple addition. It will call out Thordan's location before he spawns during `Strength of the Ward` by referencing the knight that spawns early in his opposite position. Ideally this trigger allows players to be able to move quicker with the knowledge of where Thordan will re-appear. The trigger its using doesn't actually matter, its just for proper timing on the overlay call.

The hard coded x/y checks are pretty nasty, I'm open to any recommendations on how to make that less ugly. I tested this on 10 of my logs tonight and it had correct predictions for each, but IIRC Overlay Handler calls can be unreliable on the emulator. Real world testing probably required.