### PR TITLE
test: Tweaks for missing timelineFile

### DIFF
--- a/test/helper/test_trigger.ts
+++ b/test/helper/test_trigger.ts
@@ -671,6 +671,13 @@ const testTriggerFile = (file: string) => {
       }
     }
   });
+
+  it('has valid timeline file', () => {
+    if (triggerSet.timelineFile) {
+      const timelineFile = path.join(path.dirname(file), triggerSet.timelineFile);
+      assert.isTrue(fs.existsSync(timelineFile), `${triggerSet.timelineFile} does not exist`);
+    }
+  });
 };
 
 const testTriggerFiles = (triggerFiles: string[]): void => {

--- a/util/gen_coverage_report.ts
+++ b/util/gen_coverage_report.ts
@@ -92,7 +92,6 @@ const processRaidbossCoverage = async (manifest: string, coverage: Coverage) => 
           continue;
       } catch (e) {
         console.error(e);
-        continue;
       }
     }
 


### PR DESCRIPTION
Fixes #3922

- Fix coverage report skipping file if the timelineFile is missing
- Add test for missing timelineFile

I don't really work with mocha very often but this seems correct and worked for the test setup I did.