### PR TITLE
raidboss: Add support for optional netlog fields

### DIFF
--- a/resources/netlog_defs.ts
+++ b/resources/netlog_defs.ts
@@ -711,7 +711,7 @@ const latestLogDefinitions = {
     },
     firstUnknownField: 20,
     canAnonymize: true,
-    optionalFields: [15, 16, 17, 18, 19, 20],
+    optionalFields: [18, 19, 20],
   },
   NetworkUpdateHP: {
     type: '39',

--- a/resources/netlog_defs.ts
+++ b/resources/netlog_defs.ts
@@ -28,8 +28,8 @@ export type LogDefinition = {
   playerIds?: { [fieldIdx: number]: number | null };
   // a list of fields that are ok to be blank (or have invalid ids)
   blankFields?: readonly number[];
-  // a list of fields that are ok to be completely missing including separator
-  optionalFields: readonly number[];
+  // this field and any field after will be treated as optional when creating capturing regexes
+  firstOptionalField: (number | undefined);
 };
 export type LogDefinitionMap = { [name: string]: LogDefinition };
 type LogDefinitionVersionMap = { [version: string]: LogDefinitionMap };
@@ -66,7 +66,7 @@ const latestLogDefinitions = {
         },
       },
     },
-    optionalFields: [],
+    firstOptionalField: undefined,
   },
   ChangeZone: {
     type: '01',
@@ -80,7 +80,7 @@ const latestLogDefinitions = {
     },
     lastInclude: true,
     canAnonymize: true,
-    optionalFields: [],
+    firstOptionalField: undefined,
   },
   ChangedPlayer: {
     type: '02',
@@ -97,7 +97,7 @@ const latestLogDefinitions = {
     },
     lastInclude: true,
     canAnonymize: true,
-    optionalFields: [],
+    firstOptionalField: undefined,
   },
   AddedCombatant: {
     type: '03',
@@ -131,7 +131,7 @@ const latestLogDefinitions = {
       6: null,
     },
     canAnonymize: true,
-    optionalFields: [],
+    firstOptionalField: undefined,
   },
   RemovedCombatant: {
     type: '04',
@@ -159,7 +159,7 @@ const latestLogDefinitions = {
       6: null,
     },
     canAnonymize: true,
-    optionalFields: [],
+    firstOptionalField: undefined,
   },
   PartyList: {
     type: '11',
@@ -220,32 +220,7 @@ const latestLogDefinitions = {
       25: null,
       26: null,
     },
-    optionalFields: [
-      3,
-      4,
-      5,
-      6,
-      7,
-      8,
-      9,
-      10,
-      11,
-      12,
-      13,
-      14,
-      15,
-      16,
-      17,
-      18,
-      19,
-      20,
-      21,
-      22,
-      23,
-      24,
-      25,
-      26,
-    ],
+    firstOptionalField: 3,
     canAnonymize: true,
     lastInclude: true,
   },
@@ -276,7 +251,7 @@ const latestLogDefinitions = {
     },
     canAnonymize: true,
     lastInclude: true,
-    optionalFields: [],
+    firstOptionalField: undefined,
   },
   StartsUsing: {
     type: '20',
@@ -303,7 +278,7 @@ const latestLogDefinitions = {
       6: 7,
     },
     canAnonymize: true,
-    optionalFields: [],
+    firstOptionalField: undefined,
   },
   Ability: {
     type: '21',
@@ -349,7 +324,7 @@ const latestLogDefinitions = {
     blankFields: [6],
     firstUnknownField: 44,
     canAnonymize: true,
-    optionalFields: [],
+    firstOptionalField: undefined,
   },
   NetworkAOEAbility: {
     type: '22',
@@ -377,7 +352,7 @@ const latestLogDefinitions = {
     blankFields: [6],
     firstUnknownField: 44,
     canAnonymize: true,
-    optionalFields: [],
+    firstOptionalField: undefined,
   },
   NetworkCancelAbility: {
     type: '23',
@@ -396,7 +371,7 @@ const latestLogDefinitions = {
       2: 3,
     },
     canAnonymize: true,
-    optionalFields: [],
+    firstOptionalField: undefined,
   },
   NetworkDoT: {
     type: '24',
@@ -425,7 +400,7 @@ const latestLogDefinitions = {
       2: 3,
     },
     canAnonymize: true,
-    optionalFields: [],
+    firstOptionalField: undefined,
   },
   WasDefeated: {
     type: '25',
@@ -444,7 +419,7 @@ const latestLogDefinitions = {
       4: 5,
     },
     canAnonymize: true,
-    optionalFields: [],
+    firstOptionalField: undefined,
   },
   GainsEffect: {
     type: '26',
@@ -469,7 +444,7 @@ const latestLogDefinitions = {
       7: 8,
     },
     canAnonymize: true,
-    optionalFields: [],
+    firstOptionalField: undefined,
   },
   HeadMarker: {
     type: '27',
@@ -486,7 +461,7 @@ const latestLogDefinitions = {
       2: 3,
     },
     canAnonymize: true,
-    optionalFields: [],
+    firstOptionalField: undefined,
   },
   NetworkRaidMarker: {
     type: '28',
@@ -504,7 +479,7 @@ const latestLogDefinitions = {
       z: 8,
     },
     canAnonymize: true,
-    optionalFields: [],
+    firstOptionalField: undefined,
   },
   NetworkTargetMarker: {
     type: '29',
@@ -524,7 +499,7 @@ const latestLogDefinitions = {
       4: null,
       5: null,
     },
-    optionalFields: [],
+    firstOptionalField: undefined,
   },
   LosesEffect: {
     type: '30',
@@ -546,7 +521,7 @@ const latestLogDefinitions = {
       7: 8,
     },
     canAnonymize: true,
-    optionalFields: [],
+    firstOptionalField: undefined,
   },
   NetworkGauge: {
     type: '31',
@@ -568,7 +543,7 @@ const latestLogDefinitions = {
     // For safety, anonymize all of the gauge data.
     firstUnknownField: 3,
     canAnonymize: true,
-    optionalFields: [],
+    firstOptionalField: undefined,
   },
   NetworkWorld: {
     type: '32',
@@ -579,7 +554,7 @@ const latestLogDefinitions = {
       timestamp: 1,
     },
     isUnknown: true,
-    optionalFields: [],
+    firstOptionalField: undefined,
   },
   ActorControl: {
     type: '33',
@@ -596,7 +571,7 @@ const latestLogDefinitions = {
       data3: 7,
     },
     canAnonymize: true,
-    optionalFields: [],
+    firstOptionalField: undefined,
   },
   NameToggle: {
     type: '34',
@@ -616,7 +591,7 @@ const latestLogDefinitions = {
       4: 5,
     },
     canAnonymize: true,
-    optionalFields: [],
+    firstOptionalField: undefined,
   },
   Tether: {
     type: '35',
@@ -637,7 +612,7 @@ const latestLogDefinitions = {
     },
     canAnonymize: true,
     firstUnknownField: 9,
-    optionalFields: [],
+    firstOptionalField: undefined,
   },
   LimitBreak: {
     type: '36',
@@ -650,7 +625,7 @@ const latestLogDefinitions = {
       bars: 3,
     },
     canAnonymize: true,
-    optionalFields: [],
+    firstOptionalField: undefined,
   },
   NetworkEffectResult: {
     type: '37',
@@ -678,7 +653,7 @@ const latestLogDefinitions = {
     },
     firstUnknownField: 22,
     canAnonymize: true,
-    optionalFields: [],
+    firstOptionalField: undefined,
   },
   StatusEffect: {
     type: '38',
@@ -711,7 +686,7 @@ const latestLogDefinitions = {
     },
     firstUnknownField: 20,
     canAnonymize: true,
-    optionalFields: [18, 19, 20],
+    firstOptionalField: 18,
   },
   NetworkUpdateHP: {
     type: '39',
@@ -737,7 +712,7 @@ const latestLogDefinitions = {
       2: 3,
     },
     canAnonymize: true,
-    optionalFields: [],
+    firstOptionalField: undefined,
   },
   Map: {
     type: '40',
@@ -752,7 +727,7 @@ const latestLogDefinitions = {
       placeNameSub: 5,
     },
     canAnonymize: true,
-    optionalFields: [],
+    firstOptionalField: undefined,
   },
   SystemLogMessage: {
     type: '41',
@@ -768,7 +743,7 @@ const latestLogDefinitions = {
       param2: 6,
     },
     canAnonymize: true,
-    optionalFields: [],
+    firstOptionalField: undefined,
   },
   ParserInfo: {
     type: '249',
@@ -780,7 +755,7 @@ const latestLogDefinitions = {
     },
     globalInclude: true,
     canAnonymize: true,
-    optionalFields: [],
+    firstOptionalField: undefined,
   },
   ProcessInfo: {
     type: '250',
@@ -792,7 +767,7 @@ const latestLogDefinitions = {
     },
     globalInclude: true,
     canAnonymize: true,
-    optionalFields: [],
+    firstOptionalField: undefined,
   },
   Debug: {
     type: '251',
@@ -804,7 +779,7 @@ const latestLogDefinitions = {
     },
     globalInclude: true,
     canAnonymize: false,
-    optionalFields: [],
+    firstOptionalField: undefined,
   },
   PacketDump: {
     type: '252',
@@ -815,7 +790,7 @@ const latestLogDefinitions = {
       timestamp: 1,
     },
     canAnonymize: false,
-    optionalFields: [],
+    firstOptionalField: undefined,
   },
   Version: {
     type: '253',
@@ -827,7 +802,7 @@ const latestLogDefinitions = {
     },
     globalInclude: true,
     canAnonymize: true,
-    optionalFields: [],
+    firstOptionalField: undefined,
   },
   Error: {
     type: '254',
@@ -838,7 +813,7 @@ const latestLogDefinitions = {
       timestamp: 1,
     },
     canAnonymize: false,
-    optionalFields: [],
+    firstOptionalField: undefined,
   },
   None: {
     type: '[0-9]+',
@@ -849,7 +824,7 @@ const latestLogDefinitions = {
       timestamp: 1,
     },
     isUnknown: true,
-    optionalFields: [],
+    firstOptionalField: undefined,
   },
 } as const;
 

--- a/resources/netlog_defs.ts
+++ b/resources/netlog_defs.ts
@@ -26,8 +26,10 @@ export type LogDefinition = {
   };
   // map of indexes from a player id to the index of that player name
   playerIds?: { [fieldIdx: number]: number | null };
-  // a list of fields that are ok to not appear (or have invalid ids)
-  optionalFields?: readonly number[];
+  // a list of fields that are ok to be blank (or have invalid ids)
+  blankFields?: readonly number[];
+  // a list of fields that are ok to be completely missing including separator
+  optionalFields: readonly number[];
 };
 export type LogDefinitionMap = { [name: string]: LogDefinition };
 type LogDefinitionVersionMap = { [version: string]: LogDefinitionMap };
@@ -64,6 +66,7 @@ const latestLogDefinitions = {
         },
       },
     },
+    optionalFields: [],
   },
   ChangeZone: {
     type: '01',
@@ -77,6 +80,7 @@ const latestLogDefinitions = {
     },
     lastInclude: true,
     canAnonymize: true,
+    optionalFields: [],
   },
   ChangedPlayer: {
     type: '02',
@@ -93,6 +97,7 @@ const latestLogDefinitions = {
     },
     lastInclude: true,
     canAnonymize: true,
+    optionalFields: [],
   },
   AddedCombatant: {
     type: '03',
@@ -126,6 +131,7 @@ const latestLogDefinitions = {
       6: null,
     },
     canAnonymize: true,
+    optionalFields: [],
   },
   RemovedCombatant: {
     type: '04',
@@ -153,6 +159,7 @@ const latestLogDefinitions = {
       6: null,
     },
     canAnonymize: true,
+    optionalFields: [],
   },
   PartyList: {
     type: '11',
@@ -269,6 +276,7 @@ const latestLogDefinitions = {
     },
     canAnonymize: true,
     lastInclude: true,
+    optionalFields: [],
   },
   StartsUsing: {
     type: '20',
@@ -289,12 +297,13 @@ const latestLogDefinitions = {
       z: 11,
       heading: 12,
     },
-    optionalFields: [6],
+    blankFields: [6],
     playerIds: {
       2: 3,
       6: 7,
     },
     canAnonymize: true,
+    optionalFields: [],
   },
   Ability: {
     type: '21',
@@ -337,9 +346,10 @@ const latestLogDefinitions = {
       2: 3,
       6: 7,
     },
-    optionalFields: [6],
+    blankFields: [6],
     firstUnknownField: 44,
     canAnonymize: true,
+    optionalFields: [],
   },
   NetworkAOEAbility: {
     type: '22',
@@ -364,9 +374,10 @@ const latestLogDefinitions = {
       2: 3,
       6: 7,
     },
-    optionalFields: [6],
+    blankFields: [6],
     firstUnknownField: 44,
     canAnonymize: true,
+    optionalFields: [],
   },
   NetworkCancelAbility: {
     type: '23',
@@ -385,6 +396,7 @@ const latestLogDefinitions = {
       2: 3,
     },
     canAnonymize: true,
+    optionalFields: [],
   },
   NetworkDoT: {
     type: '24',
@@ -413,6 +425,7 @@ const latestLogDefinitions = {
       2: 3,
     },
     canAnonymize: true,
+    optionalFields: [],
   },
   WasDefeated: {
     type: '25',
@@ -431,6 +444,7 @@ const latestLogDefinitions = {
       4: 5,
     },
     canAnonymize: true,
+    optionalFields: [],
   },
   GainsEffect: {
     type: '26',
@@ -455,6 +469,7 @@ const latestLogDefinitions = {
       7: 8,
     },
     canAnonymize: true,
+    optionalFields: [],
   },
   HeadMarker: {
     type: '27',
@@ -471,6 +486,7 @@ const latestLogDefinitions = {
       2: 3,
     },
     canAnonymize: true,
+    optionalFields: [],
   },
   NetworkRaidMarker: {
     type: '28',
@@ -488,6 +504,7 @@ const latestLogDefinitions = {
       z: 8,
     },
     canAnonymize: true,
+    optionalFields: [],
   },
   NetworkTargetMarker: {
     type: '29',
@@ -507,6 +524,7 @@ const latestLogDefinitions = {
       4: null,
       5: null,
     },
+    optionalFields: [],
   },
   LosesEffect: {
     type: '30',
@@ -528,6 +546,7 @@ const latestLogDefinitions = {
       7: 8,
     },
     canAnonymize: true,
+    optionalFields: [],
   },
   NetworkGauge: {
     type: '31',
@@ -549,6 +568,7 @@ const latestLogDefinitions = {
     // For safety, anonymize all of the gauge data.
     firstUnknownField: 3,
     canAnonymize: true,
+    optionalFields: [],
   },
   NetworkWorld: {
     type: '32',
@@ -559,6 +579,7 @@ const latestLogDefinitions = {
       timestamp: 1,
     },
     isUnknown: true,
+    optionalFields: [],
   },
   ActorControl: {
     type: '33',
@@ -575,6 +596,7 @@ const latestLogDefinitions = {
       data3: 7,
     },
     canAnonymize: true,
+    optionalFields: [],
   },
   NameToggle: {
     type: '34',
@@ -594,6 +616,7 @@ const latestLogDefinitions = {
       4: 5,
     },
     canAnonymize: true,
+    optionalFields: [],
   },
   Tether: {
     type: '35',
@@ -614,6 +637,7 @@ const latestLogDefinitions = {
     },
     canAnonymize: true,
     firstUnknownField: 9,
+    optionalFields: [],
   },
   LimitBreak: {
     type: '36',
@@ -626,6 +650,7 @@ const latestLogDefinitions = {
       bars: 3,
     },
     canAnonymize: true,
+    optionalFields: [],
   },
   NetworkEffectResult: {
     type: '37',
@@ -653,6 +678,7 @@ const latestLogDefinitions = {
     },
     firstUnknownField: 22,
     canAnonymize: true,
+    optionalFields: [],
   },
   StatusEffect: {
     type: '38',
@@ -675,6 +701,9 @@ const latestLogDefinitions = {
       data0: 15,
       data1: 16,
       data2: 17,
+      data3: 18,
+      data4: 19,
+      data5: 20,
       // Variable number of triplets here, but at least one.
     },
     playerIds: {
@@ -682,6 +711,7 @@ const latestLogDefinitions = {
     },
     firstUnknownField: 20,
     canAnonymize: true,
+    optionalFields: [15, 16, 17, 18, 19, 20],
   },
   NetworkUpdateHP: {
     type: '39',
@@ -707,6 +737,7 @@ const latestLogDefinitions = {
       2: 3,
     },
     canAnonymize: true,
+    optionalFields: [],
   },
   Map: {
     type: '40',
@@ -721,6 +752,7 @@ const latestLogDefinitions = {
       placeNameSub: 5,
     },
     canAnonymize: true,
+    optionalFields: [],
   },
   SystemLogMessage: {
     type: '41',
@@ -736,6 +768,7 @@ const latestLogDefinitions = {
       param2: 6,
     },
     canAnonymize: true,
+    optionalFields: [],
   },
   ParserInfo: {
     type: '249',
@@ -747,6 +780,7 @@ const latestLogDefinitions = {
     },
     globalInclude: true,
     canAnonymize: true,
+    optionalFields: [],
   },
   ProcessInfo: {
     type: '250',
@@ -758,6 +792,7 @@ const latestLogDefinitions = {
     },
     globalInclude: true,
     canAnonymize: true,
+    optionalFields: [],
   },
   Debug: {
     type: '251',
@@ -769,6 +804,7 @@ const latestLogDefinitions = {
     },
     globalInclude: true,
     canAnonymize: false,
+    optionalFields: [],
   },
   PacketDump: {
     type: '252',
@@ -779,6 +815,7 @@ const latestLogDefinitions = {
       timestamp: 1,
     },
     canAnonymize: false,
+    optionalFields: [],
   },
   Version: {
     type: '253',
@@ -790,6 +827,7 @@ const latestLogDefinitions = {
     },
     globalInclude: true,
     canAnonymize: true,
+    optionalFields: [],
   },
   Error: {
     type: '254',
@@ -800,6 +838,7 @@ const latestLogDefinitions = {
       timestamp: 1,
     },
     canAnonymize: false,
+    optionalFields: [],
   },
   None: {
     type: '[0-9]+',
@@ -810,6 +849,7 @@ const latestLogDefinitions = {
       timestamp: 1,
     },
     isUnknown: true,
+    optionalFields: [],
   },
 } as const;
 
@@ -832,6 +872,7 @@ export type ParseHelperField<
 > = {
   field: Fields[Field] extends string ? Fields[Field] : never;
   value?: string;
+  optional?: boolean;
 };
 
 export type ParseHelperFields<T extends LogDefinitionTypes> = {

--- a/resources/netregexes.ts
+++ b/resources/netregexes.ts
@@ -34,14 +34,14 @@ const defaultParams = <
 >(type: T, version: V, include?: string[]): Partial<ParseHelperFields<T>> => {
   include ??= Object.keys(logDefinitionsVersions[version][type].fields);
   const params: { [index: number]: { field: string; value?: string; optional: boolean } } = {};
-  const optionalFields: number[] = [...logDefinitionsVersions[version][type].optionalFields];
+  const firstOptionalField = logDefinitionsVersions[version][type].firstOptionalField;
 
   for (const [prop, index] of Object.entries(logDefinitionsVersions[version][type].fields)) {
     if (!include.includes(prop))
       continue;
     const param: { field: string; value?: string; optional: boolean } = {
       field: prop,
-      optional: optionalFields.includes(index),
+      optional: firstOptionalField !== undefined && index >= firstOptionalField,
     };
     if (prop === 'type')
       param.value = logDefinitionsVersions[version][type].type;

--- a/resources/netregexes.ts
+++ b/resources/netregexes.ts
@@ -1,3 +1,4 @@
+import { NetFieldsReverse } from '../types/net_fields';
 import { NetParams } from '../types/net_props';
 import { CactbotBaseRegExp } from '../types/net_trigger';
 
@@ -32,13 +33,15 @@ const defaultParams = <
   V extends LogDefinitionVersions,
 >(type: T, version: V, include?: string[]): Partial<ParseHelperFields<T>> => {
   include ??= Object.keys(logDefinitionsVersions[version][type].fields);
-  const params: { [index: number]: { field: string; value?: string } } = {};
+  const params: { [index: number]: { field: string; value?: string; optional: boolean } } = {};
+  const optionalFields: number[] = [...logDefinitionsVersions[version][type].optionalFields];
 
   for (const [prop, index] of Object.entries(logDefinitionsVersions[version][type].fields)) {
     if (!include.includes(prop))
       continue;
-    const param: { field: string; value?: string } = {
+    const param: { field: string; value?: string; optional: boolean } = {
       field: prop,
+      optional: optionalFields.includes(index),
     };
     if (prop === 'type')
       param.value = logDefinitionsVersions[version][type].type;
@@ -49,8 +52,14 @@ const defaultParams = <
   return params as unknown as Partial<ParseHelperFields<T>>;
 };
 
+type ParseHelperType<T extends LogDefinitionTypes> =
+  & {
+    [field in Extract<keyof NetFieldsReverse[T], string>]?: string;
+  }
+  & { capture?: boolean };
+
 const parseHelper = <T extends LogDefinitionTypes>(
-  params: { timestamp?: string; capture?: boolean } | undefined,
+  params: ParseHelperType<T> | undefined,
   funcName: string,
   fields: Partial<ParseHelperFields<T>>,
 ): CactbotBaseRegExp<T> => {
@@ -70,7 +79,20 @@ const parseHelper = <T extends LogDefinitionTypes>(
   const fieldKeys = Object.keys(fields).sort((a, b) => parseInt(a) - parseInt(b));
   let maxKeyStr: string;
   if (capture) {
-    maxKeyStr = fieldKeys[fieldKeys.length - 1] ?? '0';
+    const keys: Extract<keyof NetFieldsReverse[T], string>[] = [];
+    for (const key in fields)
+      keys.push(key);
+    let tmpKey = keys.pop();
+    if (!tmpKey) {
+      maxKeyStr = fieldKeys[fieldKeys.length - 1] ?? '0';
+    } else {
+      while (
+        fields[tmpKey]?.optional &&
+        !((fields[tmpKey]?.field ?? '') in params)
+      )
+        tmpKey = keys.pop();
+      maxKeyStr = tmpKey ?? '0';
+    }
   } else {
     maxKeyStr = '0';
     for (const key in fields) {
@@ -119,7 +141,7 @@ const parseHelper = <T extends LogDefinitionTypes>(
         // maybe this function needs a refactoring
         capture,
         fieldName,
-        (params as { [s: string]: string })[fieldName],
+        params[fieldName],
         fieldValue,
       ) +
         separator;
@@ -163,7 +185,7 @@ export default class NetRegexes {
     return parseHelper(params, 'ability', {
       ...defaultParams('Ability', NetRegexes.logVersion),
       // Override type
-      0: { field: 'type', value: '2[12]' },
+      0: { field: 'type', value: '2[12]', optional: false },
     });
   }
 

--- a/resources/regexes.ts
+++ b/resources/regexes.ts
@@ -137,25 +137,17 @@ const parseHelper = <T extends LogDefinitionTypes>(
       : matchDefault;
     const fieldValue = fields[keyStr]?.value?.toString() ?? fieldDefault;
 
-    const fieldOptional = value?.optional;
-
     if (fieldName) {
-      const regexField = Regexes.maybeCapture(
+      str += Regexes.maybeCapture(
         // more accurate type instead of `as` cast
         // maybe this function needs a refactoring
         capture,
         fieldName,
         params[fieldName],
         fieldValue,
-      ) +
-        separator;
-
-      if (fieldOptional)
-        str += Regexes.optional(regexField);
-      else
-        str += regexField;
+      );
     } else {
-      str += fieldValue + separator;
+      str += fieldValue;
     }
 
     // Stop if we're not capturing and don't care about future fields.

--- a/resources/regexes.ts
+++ b/resources/regexes.ts
@@ -20,14 +20,14 @@ const defaultParams = <
 >(type: T, version: V, include?: string[]): Partial<ParseHelperFields<T>> => {
   include ??= Object.keys(logDefinitionsVersions[version][type].fields);
   const params: { [index: number]: { field: string; value?: string; optional: boolean } } = {};
-  const optionalFields: number[] = [...logDefinitionsVersions[version][type].optionalFields];
+  const firstOptionalField = logDefinitionsVersions[version][type].firstOptionalField;
 
   for (const [prop, index] of Object.entries(logDefinitionsVersions[version][type].fields)) {
     if (!include.includes(prop))
       continue;
     const param: { field: string; value?: string; optional: boolean } = {
       field: prop,
-      optional: optionalFields.includes(index),
+      optional: firstOptionalField !== undefined && index >= firstOptionalField,
     };
     if (prop === 'type')
       param.value = logDefinitionsVersions[version][type].type;


### PR DESCRIPTION
Fixes #3713.

Also managed to clean up an `x as y` cast in both files as part of this.

Examples with this change:

```js
// NetRegexes.statusEffectExplicit({ data4: '00', capture: true });
/^(?<type>(?:38))\|(?<timestamp>(?:[^|]*))\|(?<targetId>(?:[^|]*))\|(?<target>(?:[^|]*))\|(?<jobLevelData>(?:[^|]*))\|(?<hp>(?:[^|]*))\|(?<maxHp>(?:[^|]*))\|(?<mp>(?:[^|]*))\|(?<maxMp>(?:[^|]*))\|(?:[^|]*\|){2}(?<x>(?:[^|]*))\|(?<y>(?:[^|]*))\|(?<z>(?:[^|]*))\|(?<heading>(?:[^|]*))\|(?<data0>(?:[^|]*))\|(?<data1>(?:[^|]*))\|(?<data2>(?:[^|]*))\|(?<data3>(?:[^|]*))\|(?<data4>(?:00))\|/i;
// NetRegexes.statusEffectExplicit({ data1: '00', capture: true });
/^(?<type>(?:38))\|(?<timestamp>(?:[^|]*))\|(?<targetId>(?:[^|]*))\|(?<target>(?:[^|]*))\|(?<jobLevelData>(?:[^|]*))\|(?<hp>(?:[^|]*))\|(?<maxHp>(?:[^|]*))\|(?<mp>(?:[^|]*))\|(?<maxMp>(?:[^|]*))\|(?:[^|]*\|){2}(?<x>(?:[^|]*))\|(?<y>(?:[^|]*))\|(?<z>(?:[^|]*))\|(?<heading>(?:[^|]*))\|(?<data0>(?:[^|]*))\|(?<data1>(?:00))\|/i;
// NetRegexes.statusEffectExplicit({ maxHp: '00', capture: true });
/^(?<type>(?:38))\|(?<timestamp>(?:[^|]*))\|(?<targetId>(?:[^|]*))\|(?<target>(?:[^|]*))\|(?<jobLevelData>(?:[^|]*))\|(?<hp>(?:[^|]*))\|(?<maxHp>(?:00))\|(?<mp>(?:[^|]*))\|(?<maxMp>(?:[^|]*))\|(?:[^|]*\|){2}(?<x>(?:[^|]*))\|(?<y>(?:[^|]*))\|(?<z>(?:[^|]*))\|(?<heading>(?:[^|]*))\|/i;
// NetRegexes.statusEffectExplicit({ data4: '00' });
/^(?<type>(?:38))\|(?<timestamp>(?:[^|]*))\|(?<targetId>(?:[^|]*))\|(?<target>(?:[^|]*))\|(?<jobLevelData>(?:[^|]*))\|(?<hp>(?:[^|]*))\|(?<maxHp>(?:[^|]*))\|(?<mp>(?:[^|]*))\|(?<maxMp>(?:[^|]*))\|(?:[^|]*\|){2}(?<x>(?:[^|]*))\|(?<y>(?:[^|]*))\|(?<z>(?:[^|]*))\|(?<heading>(?:[^|]*))\|(?<data0>(?:[^|]*))\|(?<data1>(?:[^|]*))\|(?<data2>(?:[^|]*))\|(?<data3>(?:[^|]*))\|(?<data4>(?:00))\|/i;
// NetRegexes.statusEffectExplicit({ data4: '00', capture: false });
/^(?:38)\|(?:[^|]*)\|(?:[^|]*)\|(?:[^|]*)\|(?:[^|]*)\|(?:[^|]*)\|(?:[^|]*)\|(?:[^|]*)\|(?:[^|]*)\|(?:[^|]*\|){2}(?:[^|]*)\|(?:[^|]*)\|(?:[^|]*)\|(?:[^|]*)\|(?:[^|]*)\|(?:[^|]*)\|(?:[^|]*)\|(?:[^|]*)\|(?:00)\|/i;
// NetRegexes.statusEffectExplicit({ maxHp: '00', capture: false });
/^(?:38)\|(?:[^|]*)\|(?:[^|]*)\|(?:[^|]*)\|(?:[^|]*)\|(?:[^|]*)\|(?:00)\|/i;

// NetRegexes.statusEffectExplicit({ data4: '........', capture: true }).exec('38|2022-04-26T08:49:42.3420000-07:00|40003B54||005A5A00|51357|53616|10000|10000|0||||||8E02|F9|0|29310030|4472C95C|10001234|06867907b260d524')
Array(19) [ "38|2022-04-26T08:49:42.3420000-07:00|40003B54||005A5A00|51357|53616|10000|10000|0||||||8E02|F9|0|29310030|4472C95C|", "38", "2022-04-26T08:49:42.3420000-07:00", "40003B54", "", "005A5A00", "51357", "53616", "10000", "10000", ... ];
// NetRegexes.statusEffectExplicit({ data4: '........', capture: true }).exec('38|2022-04-26T08:49:42.3420000-07:00|40003B54||005A5A00|51357|53616|10000|10000|0||||||8E02|F9|0|06867907b260d524')
null
```