### PR TITLE
build: Update typescript to latest version (4.6.4)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -86,7 +86,7 @@
         "ts-node": "^10.7.0",
         "tsconfig-paths": "^3.9.0",
         "ttypescript": "^1.5.12",
-        "typescript": "^4.5.0",
+        "typescript": "^4.6.4",
         "webpack": "^5.64.3",
         "webpack-cli": "^4.9.1",
         "webpack-dev-server": "^4.5.0",
@@ -15016,9 +15016,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.5.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.5.tgz",
-      "integrity": "sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==",
+      "version": "4.6.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.4.tgz",
+      "integrity": "sha512-9ia/jWHIEbo49HfjrLGfKbZSuWo9iTMwXO+Ca3pRsSpbsMbc7/IU8NKdCZVRRBafVPGnoJeFL76ZOAA84I9fEg==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
@@ -27453,9 +27453,9 @@
       }
     },
     "typescript": {
-      "version": "4.5.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.5.tgz",
-      "integrity": "sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==",
+      "version": "4.6.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.4.tgz",
+      "integrity": "sha512-9ia/jWHIEbo49HfjrLGfKbZSuWo9iTMwXO+Ca3pRsSpbsMbc7/IU8NKdCZVRRBafVPGnoJeFL76ZOAA84I9fEg==",
       "dev": true
     },
     "typescript-service": {

--- a/package.json
+++ b/package.json
@@ -97,7 +97,7 @@
     "ts-node": "^10.7.0",
     "tsconfig-paths": "^3.9.0",
     "ttypescript": "^1.5.12",
-    "typescript": "^4.5.0",
+    "typescript": "^4.6.4",
     "webpack": "^5.64.3",
     "webpack-cli": "^4.9.1",
     "webpack-dev-server": "^4.5.0",

--- a/test/helper/test_trigger.ts
+++ b/test/helper/test_trigger.ts
@@ -24,6 +24,7 @@ import {
   LooseTriggerSet,
   Output,
   OutputStrings,
+  ResponseFunc,
   TriggerFunc,
 } from '../../types/trigger';
 
@@ -48,6 +49,10 @@ const netRegexLanguages: (keyof LooseTrigger)[] = [
 ];
 
 const isKeyInTriggerFunctions = (arr: string[], key: string): boolean => arr.includes(key);
+
+const isResponseFunc = (func: unknown): func is ResponseFunc<RaidbossData, Matches> => {
+  return typeof func === 'function';
+};
 
 const createTriggerRegexString = (str: string): RegExp => {
   return new RegExp(`(?:regex|triggerRegex)(?:|\\w{2}): \/${str}\/`, 'g');
@@ -527,14 +532,18 @@ const testTriggerFile = (file: string) => {
             );
             continue;
           }
-          const output = new TestOutputProxy(trigger, outputStrings) as Output;
-          // Call the function to get the outputStrings.
-          const data = (triggerSet.initData?.() ?? {}) as RaidbossData;
-          response = trigger.response(data, {}, output) ?? {};
 
-          if (typeof outputStrings !== 'object') {
-            assert.fail(`'${trigger.id}' built-in response did not set outputStrings.`);
-            continue;
+          const output = new TestOutputProxy(trigger, outputStrings) as Output;
+          const responseFunc = trigger.response;
+          if (isResponseFunc(responseFunc)) {
+            // Call the function to get the outputStrings.
+            const data = (triggerSet.initData?.() ?? {}) as RaidbossData;
+            response = responseFunc(data, {}, output) ?? {};
+
+            if (typeof outputStrings !== 'object') {
+              assert.fail(`'${trigger.id}' built-in response did not set outputStrings.`);
+              continue;
+            }
           }
         } else {
           if (trigger.outputStrings && typeof outputStrings !== 'object') {


### PR DESCRIPTION
Closes #4230 as well.

Sorry for stealing your change, @MaikoTan.

I elected to go with a typeguard rather than an `as` cast as I outlined in the mentioned issue. Still not sure what caused this breakage in the typescript update to begin with 🤷‍♂️ 