### PR TITLE
raidboss: DSR--Phase 1 targetable window addition

### DIFF
--- a/ui/raidboss/data/06-ew/ultimate/dragonsongs_reprise_ultimate.txt
+++ b/ui/raidboss/data/06-ew/ultimate/dragonsongs_reprise_ultimate.txt
@@ -28,8 +28,10 @@ hideall "--sync--"
 44.8 "Hyperdimensional Slash 1" sync / 1[56]:[^:]*:(Ser Grinnaux|Ser Charibert):62D7:/
 50.7 "--sync--" sync / 1[56]:[^:]*:Ser Grinnaux:6315:/
 51.9 "Hyperdimensional Slash 2" sync / 1[56]:[^:]*:(Ser Grinnaux|Ser Charibert):62D7:/
+54.8 "--targetable--"
 59.8 "Faith Unmoving" sync / 1[56]:[^:]*:Ser Grinnaux:62DC:/
 60.9 "Holiest of Holy" sync / 1[56]:[^:]*:Ser Adelphel:62D4:/
+67.5 "--untargetable--"
 69.1 "Execution" sync / 1[56]:[^:]*:Ser Adelphel:62D5:/
 70.8 "--targetable--"
 86.2 "Faith Unmoving" sync / 1[56]:[^:]*:Ser Grinnaux:62DC:/


### PR DESCRIPTION
This is an opinionated addition to #4381. It's not practical for melee jobs, but it's useful for anyone on a ranged job. It's kind of difficult to maintain uptime through the dashes, but it's doable.

(There's a good deal of self-interest here, since with the current opener, Bard has to refresh Iron Jaws very soon after Adelphel returns during the knockback. But again, this is opinionated, so I have no problem just keeping this as a personal addition.)