### PR TITLE
util: Make encounter info property categories explicit

### DIFF
--- a/util/logtools/split_log.js
+++ b/util/logtools/split_log.js
@@ -77,8 +77,8 @@ const generateFileName = (fightOrZone) => {
     seal = '';
 
   let zoneName;
-  if (fightOrZone.zoneName || fightOrZone.name) {
-    zoneName = fightOrZone.zoneName ?? fightOrZone.name;
+  if (fightOrZone.zoneName || fightOrZone.fightName) {
+    zoneName = fightOrZone.zoneName ?? fightOrZone.fightName;
   } else {
     const idToZoneName = {};
     for (const zoneName in ZoneId)
@@ -122,7 +122,7 @@ const printCollectedZones = (collector) => {
       dayFromDate(zone.startTime),
       timeFromDate(zone.startTime),
       durationFromDates(zone.startTime, zone.endTime),
-      zone.name,
+      zone.zoneName,
     ]);
     idx++;
   }
@@ -170,7 +170,7 @@ const printCollectedFights = (collector) => {
       dayFromDate(fight.startTime),
       timeFromDate(fight.startTime),
       durationFromDates(fight.startTime, fight.endTime),
-      fight.sealName ? fight.sealName : fight.name,
+      fight.sealName ? fight.sealName : fight.fightName,
       fight.endType,
     ]);
     idx++;


### PR DESCRIPTION
When working with `EncounterCollectors` during imports, it's a real pain to deal with properties that may or may not be present on a `FightEncInfo` object vs a `ZoneEncInfo` object. Going forward, there should be no more ambiguity.

(This is a stepping-stone change that came up while I was doing some other work with `encounter_tools`, and I figured it would be best to consider it entirely separately.)