### PR TITLE
util: Move utility functions to Encounter Tools

### DIFF
--- a/util/logtools/encounter_tools.ts
+++ b/util/logtools/encounter_tools.ts
@@ -288,20 +288,20 @@ class EncounterCollector extends EncounterFinder {
 }
 
 class TLUtilFunctions {
-  timeFromDate(date: Date | undefined): string {
+  timeFromDate(date?: Date): string {
     if (date)
       return date.toISOString().slice(11, 19);
     return 'Unknown_Time';
   }
 
-  dayFromDate(date: Date | undefined): string {
+  dayFromDate(date?: Date): string {
     if (date)
       return date.toISOString().slice(0, 10);
     return 'Unknown_Date';
   }
 
-  durationFromDates(start: Date | undefined, end: Date | undefined): string {
-    if (!(start && end))
+  durationFromDates(start?: Date, end?: Date): string {
+    if (start === undefined || end === undefined)
       return 'Unknown_Duration';
     const ms = end.valueOf() - start.valueOf();
     const totalSeconds = Math.round(ms / 1000);
@@ -320,20 +320,20 @@ class TLUtilFunctions {
     }).join(' ');
   }
 
-  leftExtendStr(str: string | undefined, length: number | undefined): string {
-    if (!str)
+  leftExtendStr(str?: string, length?: number): string {
+    if (str === undefined)
       return '';
-    if (!length)
+    if (length === undefined)
       return str;
     while (str.length < length)
       str = ' ' + str;
     return str;
   }
 
-  rightExtendStr(str: string | undefined, length: number | undefined): string {
-    if (!str)
+  rightExtendStr(str?: string, length?: number): string {
+    if (str === undefined)
       return '';
-    if (!length)
+    if (length === undefined)
       return str;
     while (str.length < length)
       str += ' ';
@@ -341,7 +341,7 @@ class TLUtilFunctions {
   }
 
   generateFileName(fightOrZone: FightEncInfo | ZoneEncInfo): string {
-    const zoneName = fightOrZone.zoneName || 'Unknown_Zone';
+    const zoneName = fightOrZone.zoneName ?? 'Unknown_Zone';
     const dateStr = this.dayFromDate(fightOrZone.startTime).replace(/-/g, '');
     const timeStr = this.timeFromDate(fightOrZone.startTime).replace(/:/g, '');
     const duration = this.durationFromDates(fightOrZone.startTime, fightOrZone.endTime);

--- a/util/logtools/encounter_tools.ts
+++ b/util/logtools/encounter_tools.ts
@@ -287,20 +287,20 @@ class EncounterCollector extends EncounterFinder {
   }
 }
 
-class TLUtilFunctions {
-  timeFromDate(date?: Date): string {
+class TLFuncs {
+  static timeFromDate(date?: Date): string {
     if (date)
       return date.toISOString().slice(11, 19);
     return 'Unknown_Time';
   }
 
-  dayFromDate(date?: Date): string {
+  static dayFromDate(date?: Date): string {
     if (date)
       return date.toISOString().slice(0, 10);
     return 'Unknown_Date';
   }
 
-  durationFromDates(start?: Date, end?: Date): string {
+  static durationFromDates(start?: Date, end?: Date): string {
     if (start === undefined || end === undefined)
       return 'Unknown_Duration';
     const ms = end.valueOf() - start.valueOf();
@@ -311,7 +311,7 @@ class TLUtilFunctions {
     return (totalSeconds % 60).toString() + 's';
   }
 
-  toProperCase(str: string): string {
+  static toProperCase(str: string): string {
     return str.split(' ').map((str) => {
       const cap = str[0]?.toUpperCase();
       const lower = str.slice(1);
@@ -320,7 +320,7 @@ class TLUtilFunctions {
     }).join(' ');
   }
 
-  leftExtendStr(str?: string, length?: number): string {
+  static leftExtendStr(str?: string, length?: number): string {
     if (str === undefined)
       return '';
     if (length === undefined || length <= str.length)
@@ -328,7 +328,7 @@ class TLUtilFunctions {
     return str.padStart(length - str.length, ' ');
   }
 
-  rightExtendStr(str?: string, length?: number): string {
+  static rightExtendStr(str?: string, length?: number): string {
     if (str === undefined)
       return '';
     if (length === undefined || length <= str.length)
@@ -336,16 +336,16 @@ class TLUtilFunctions {
     return str.padEnd(length - str.length, ' ');
   }
 
-  generateFileName(fightOrZone: FightEncInfo | ZoneEncInfo): string {
+  static generateFileName(fightOrZone: FightEncInfo | ZoneEncInfo): string {
     const zoneName = fightOrZone.zoneName ?? 'Unknown_Zone';
-    const dateStr = this.dayFromDate(fightOrZone.startTime).replace(/-/g, '');
-    const timeStr = this.timeFromDate(fightOrZone.startTime).replace(/:/g, '');
-    const duration = this.durationFromDates(fightOrZone.startTime, fightOrZone.endTime);
+    const dateStr = TLFuncs.dayFromDate(fightOrZone.startTime).replace(/-/g, '');
+    const timeStr = TLFuncs.timeFromDate(fightOrZone.startTime).replace(/:/g, '');
+    const duration = TLFuncs.durationFromDates(fightOrZone.startTime, fightOrZone.endTime);
     let seal;
     if ('sealName' in fightOrZone)
       seal = fightOrZone['sealName'];
     if (seal)
-      seal = '_' + this.toProperCase(seal).replace(/[^A-z0-9]/g, '');
+      seal = '_' + TLFuncs.toProperCase(seal).replace(/[^A-z0-9]/g, '');
     else
       seal = '';
     let wipeStr = '';
@@ -356,7 +356,7 @@ class TLUtilFunctions {
 
 // For an array of arrays, return an array where each value is the max length at that index
 // among all of the inner arrays, e.g. find the max length per field of an array of rows.
-  maxLengthPerIndex(outputRows: Array<Array<string>>): Array<number> {
+  static maxLengthPerIndex(outputRows: Array<Array<string>>): Array<number> {
     const outputSizes = outputRows.map((row) => row.map((field) => field.length));
     return outputSizes.reduce((max, row) => {
       return max.map((val, idx) => {
@@ -368,19 +368,19 @@ class TLUtilFunctions {
     });
   }
 
-  printCollectedZones(collector: EncounterCollector): void {
+  static printCollectedZones(collector: EncounterCollector): void {
     let idx = 1;
     const outputRows = [];
     for (const zone of collector.zones) {
       const zoneName = zone.zoneName ?? 'Unknown_Zone';
-      const startDate = zone.startTime ? this.dayFromDate(zone.startTime) : 'Unknown_Date';
-      const startTime = zone.startTime ? this.timeFromDate(zone.startTime) : 'Unknown_Start';
+      const startDate = zone.startTime ? TLFuncs.dayFromDate(zone.startTime) : 'Unknown_Date';
+      const startTime = zone.startTime ? TLFuncs.timeFromDate(zone.startTime) : 'Unknown_Start';
 
       outputRows.push([
         idx.toString(),
         startDate,
         startTime,
-        this.durationFromDates(zone.startTime, zone.endTime),
+        TLFuncs.durationFromDates(zone.startTime, zone.endTime),
         zoneName,
       ]);
       idx++;
@@ -389,7 +389,7 @@ class TLUtilFunctions {
     if (outputRows.length === 0)
       return;
 
-    const lengths = this.maxLengthPerIndex(outputRows);
+    const lengths = TLFuncs.maxLengthPerIndex(outputRows);
 
     const dateIdx = 1;
     let lastDate = null;
@@ -398,16 +398,16 @@ class TLUtilFunctions {
         lastDate = row[dateIdx];
         console.log(lastDate);
       }
-      const row0 = this.leftExtendStr(row[0], lengths[0]);
-      const row2 = this.leftExtendStr(row[2], lengths[2]);
-      const row3 = this.leftExtendStr(row[3], lengths[3]);
-      const row4 = this.rightExtendStr(row[4], lengths[4]);
+      const row0 = TLFuncs.leftExtendStr(row[0], lengths[0]);
+      const row2 = TLFuncs.leftExtendStr(row[2], lengths[2]);
+      const row3 = TLFuncs.leftExtendStr(row[3], lengths[3]);
+      const row4 = TLFuncs.rightExtendStr(row[4], lengths[4]);
 
       console.log(`  ${row0})   ${row2}   ${row3}  ${row4}`);
     }
   }
 
-  printCollectedFights = (collector: EncounterCollector): void => {
+  static printCollectedFights = (collector: EncounterCollector): void => {
     let idx = 1;
     const outputRows = [];
     let seenSeal = false;
@@ -415,9 +415,9 @@ class TLUtilFunctions {
     for (const fight of collector.fights) {
       // Add a zone name row when there's seal messages for clarity.
       const zoneName = fight.zoneName ?? 'Unknown_Zone';
-      const startDate = fight.startTime ? this.dayFromDate(fight.startTime) : 'Unknown_Date';
-      const startTime = fight.startTime ? this.timeFromDate(fight.startTime) : 'Unknown_Start';
-      const fightDuration = this.durationFromDates(fight.startTime, fight.endTime) ?? 'Unknown Duration';
+      const startDate = fight.startTime ? TLFuncs.dayFromDate(fight.startTime) : 'Unknown_Date';
+      const startTime = fight.startTime ? TLFuncs.timeFromDate(fight.startTime) : 'Unknown_Start';
+      const fightDuration = TLFuncs.durationFromDates(fight.startTime, fight.endTime) ?? 'Unknown Duration';
       let fightName = 'Unknown_Encounter';
       if (fight.sealName)
         fightName = fight.sealName;
@@ -431,7 +431,7 @@ class TLUtilFunctions {
         seenSeal = false;
       }
       if (fight.startTime)
-        lastDate = this.dayFromDate(fight.startTime);
+        lastDate = TLFuncs.dayFromDate(fight.startTime);
       const row = [
         idx.toString(),
         startDate,
@@ -447,7 +447,7 @@ class TLUtilFunctions {
     if (outputRows.length === 0)
       return;
 
-    const lengths = this.maxLengthPerIndex(outputRows);
+    const lengths = TLFuncs.maxLengthPerIndex(outputRows);
 
     const dateIdx = 1;
     console.log(lastDate);
@@ -458,15 +458,15 @@ class TLUtilFunctions {
         console.log(lastDate);
       }
 
-      const col0 = this.leftExtendStr(row[0], lengths[0]);
+      const col0 = TLFuncs.leftExtendStr(row[0], lengths[0]);
       const col1 = row[0] ? ') ' : '  ';
-      const col2 = this.leftExtendStr(row[2], lengths[2]);
-      const col3 = this.leftExtendStr(row[3], lengths[3]);
-      const col4 = this.rightExtendStr(row[4], lengths[4]);
+      const col2 = TLFuncs.leftExtendStr(row[2], lengths[2]);
+      const col3 = TLFuncs.leftExtendStr(row[3], lengths[3]);
+      const col4 = TLFuncs.rightExtendStr(row[4], lengths[4]);
       const col5 = row[5] ? (' ' + '[' + row[5] + ']') : '';
       console.log(`  ${col0}${col1} ${col2} ${col3} ${col4} ${col5}`);
     }
   };
 }
 
-export { EncounterCollector, TLUtilFunctions };
+export { EncounterCollector, TLFuncs };

--- a/util/logtools/encounter_tools.ts
+++ b/util/logtools/encounter_tools.ts
@@ -323,21 +323,17 @@ class TLUtilFunctions {
   leftExtendStr(str?: string, length?: number): string {
     if (str === undefined)
       return '';
-    if (length === undefined)
+    if (length === undefined || length <= str.length)
       return str;
-    while (str.length < length)
-      str = ' ' + str;
-    return str;
+    return str.padStart(length - str.length, ' ');
   }
 
   rightExtendStr(str?: string, length?: number): string {
     if (str === undefined)
       return '';
-    if (length === undefined)
+    if (length === undefined || length <= str.length)
       return str;
-    while (str.length < length)
-      str += ' ';
-    return str;
+    return str.padEnd(length - str.length, ' ');
   }
 
   generateFileName(fightOrZone: FightEncInfo | ZoneEncInfo): string {

--- a/util/logtools/split_log.js
+++ b/util/logtools/split_log.js
@@ -2,15 +2,13 @@ import fs from 'fs';
 import readline from 'readline';
 import Anonymizer from './anonymizer';
 import Splitter from './splitter';
-import { EncounterCollector, TLUtilFunctions } from './encounter_tools';
+import { EncounterCollector, TLFuncs } from './encounter_tools';
 import ZoneId from '../../resources/zone_id';
 import argparse from 'argparse';
 import { LogUtilArgParse } from './arg_parser';
 
 // TODO: add options for not splitting / not anonymizing.
 const timelineParse = new LogUtilArgParse();
-const TFuncs = new TLUtilFunctions();
-
 const args = timelineParse.args;
 
 const printHelpAndExit = (errString) => {
@@ -122,22 +120,22 @@ const writeFile = (outputFile, startLine, endLine) => {
   const collector = await makeCollectorFromPrepass(logFileName);
 
   if (args['search_fights'] === -1) {
-    TFuncs.printCollectedFights(collector);
+    TLFuncs.printCollectedFights(collector);
     process.exit(0);
   }
   if (args['search_zones'] === -1) {
-    TFuncs.printCollectedZones(collector);
+    TLFuncs.printCollectedZones(collector);
     process.exit(0);
   }
 
   // This utility prints 1-indexed fights and zones, so adjust - 1.
   if (args['search_fights']) {
     const fight = collector.fights[args['search_fights'] - 1];
-    await writeFile(TFuncs.generateFileName(fight), fight.startLine, fight.endLine);
+    await writeFile(TLFuncs.generateFileName(fight), fight.startLine, fight.endLine);
     process.exit(exitCode);
   } else if (args['search_zones']) {
     const zone = collector.zones[args['search_zones'] - 1];
-    await writeFile(TFuncs.generateFileName(zone), zone.startLine, zone.endLine);
+    await writeFile(TLFuncs.generateFileName(zone), zone.startLine, zone.endLine);
     process.exit(exitCode);
   } else if (args['fight_regex']) {
     const regex = new RegExp(args['fight_regex'], 'i');
@@ -148,7 +146,7 @@ const writeFile = (outputFile, startLine, endLine) => {
       } else if (!fight.name.match(regex)) {
         continue;
       }
-      await writeFile(TFuncs.generateFileName(fight), fight.startLine, fight.endLine);
+      await writeFile(TLFuncs.generateFileName(fight), fight.startLine, fight.endLine);
     }
     process.exit(exitCode);
   } else if (args['zone_regex']) {
@@ -156,7 +154,7 @@ const writeFile = (outputFile, startLine, endLine) => {
     for (const zone of collector.zones) {
       if (!zone.name.match(regex))
         continue;
-      await writeFile(TFuncs.generateFileName(zone), zone.startLine, zone.endLine);
+      await writeFile(TLFuncs.generateFileName(zone), zone.startLine, zone.endLine);
     }
     process.exit(exitCode);
   } else {

--- a/util/logtools/split_log.js
+++ b/util/logtools/split_log.js
@@ -2,13 +2,14 @@ import fs from 'fs';
 import readline from 'readline';
 import Anonymizer from './anonymizer';
 import Splitter from './splitter';
-import { EncounterCollector } from './encounter_tools';
+import { EncounterCollector, TLUtilFunctions } from './encounter_tools';
 import ZoneId from '../../resources/zone_id';
 import argparse from 'argparse';
 import { LogUtilArgParse } from './arg_parser';
 
 // TODO: add options for not splitting / not anonymizing.
 const timelineParse = new LogUtilArgParse();
+const TFuncs = new TLUtilFunctions();
 
 const args = timelineParse.args;
 
@@ -37,168 +38,6 @@ let exitCode = 0;
 const errorFunc = (str) => {
   console.error(str);
   exitCode = 1;
-};
-
-const timeFromDate = (date) => {
-  return date.toISOString().slice(11, 19);
-};
-
-const dayFromDate = (date) => {
-  return date.toISOString().slice(0, 10);
-};
-
-const durationFromDates = (start, end) => {
-  const ms = end - start;
-  const totalSeconds = Math.round(ms / 1000);
-
-  let str = '';
-  const totalMinutes = Math.floor(totalSeconds / 60);
-  if (totalMinutes > 0)
-    str += totalMinutes + 'm';
-  str += (totalSeconds % 60) + 's';
-  return str;
-};
-
-const toProperCase = (str) => {
-  return str.split(' ').map((str) => {
-    return str[0].toUpperCase() + str.slice(1);
-  }).join(' ');
-};
-
-const generateFileName = (fightOrZone) => {
-  const zoneId = parseInt(fightOrZone.zoneId, 16);
-  const dateStr = dayFromDate(fightOrZone.startTime).replace(/-/g, '');
-  const timeStr = timeFromDate(fightOrZone.startTime).replace(/:/g, '');
-  const duration = durationFromDates(fightOrZone.startTime, fightOrZone.endTime);
-  let seal = fightOrZone.sealName;
-  if (seal)
-    seal = '_' + toProperCase(seal).replace(/[^A-z0-9]/g, '');
-  else
-    seal = '';
-
-  let zoneName;
-  if (fightOrZone.zoneName || fightOrZone.fightName) {
-    zoneName = fightOrZone.zoneName ?? fightOrZone.fightName;
-  } else {
-    const idToZoneName = {};
-    for (const zoneName in ZoneId)
-      idToZoneName[ZoneId[zoneName]] = zoneName;
-    zoneName = idToZoneName[zoneId];
-  }
-
-  const wipeStr = fightOrZone.endType === 'Wipe' ? '_wipe' : '';
-  return `${zoneName}${seal}_${dateStr}_${timeStr}_${duration}${wipeStr}.log`;
-};
-
-// For an array of arrays, return an array where each value is the max length at that index
-// among all of the inner arrays, e.g. find the max length per field of an array of rows.
-const maxLengthPerIndex = (outputRows) => {
-  const outputSizes = outputRows.map((row) => row.map((field) => field.length));
-  return outputSizes.reduce((max, row) => {
-    return max.map((val, idx) => Math.max(val, row[idx]));
-  });
-};
-
-const leftExtendStr = (row, lengths, idx) => {
-  let str = row[idx];
-  while (str.length < lengths[idx])
-    str = ' ' + str;
-  return str;
-};
-
-const rightExtendStr = (row, lengths, idx) => {
-  let str = row[idx];
-  while (str.length < lengths[idx])
-    str += ' ';
-  return str;
-};
-
-const printCollectedZones = (collector) => {
-  let idx = 1;
-  const outputRows = [];
-  for (const zone of collector.zones) {
-    outputRows.push([
-      idx.toString(),
-      dayFromDate(zone.startTime),
-      timeFromDate(zone.startTime),
-      durationFromDates(zone.startTime, zone.endTime),
-      zone.zoneName,
-    ]);
-    idx++;
-  }
-
-  if (outputRows.length === 0)
-    return;
-
-  const lengths = maxLengthPerIndex(outputRows);
-
-  const dateIdx = 1;
-  let lastDate = null;
-  for (const row of outputRows) {
-    if (row[dateIdx] !== lastDate) {
-      lastDate = row[dateIdx];
-      console.log(lastDate);
-    }
-
-    console.log(
-      '  ' +
-        leftExtendStr(row, lengths, 0) + ') ' +
-        leftExtendStr(row, lengths, 2) + ' ' +
-        leftExtendStr(row, lengths, 3) + ' ' +
-        rightExtendStr(row, lengths, 4),
-    );
-  }
-};
-
-const printCollectedFights = (collector) => {
-  let idx = 1;
-  const outputRows = [];
-  let seenSeal = false;
-  let lastDate = null;
-  for (const fight of collector.fights) {
-    // Add a zone name row when there's seal messages for clarity.
-    if (!seenSeal && fight.sealName) {
-      outputRows.push(['', '', '', '', '~' + fight.zoneName + '~', '']);
-      seenSeal = true;
-    } else if (seenSeal && !fight.sealName) {
-      seenSeal = false;
-    }
-    if (!lastDate)
-      lastDate = dayFromDate(fight.startTime);
-    outputRows.push([
-      idx.toString(),
-      dayFromDate(fight.startTime),
-      timeFromDate(fight.startTime),
-      durationFromDates(fight.startTime, fight.endTime),
-      fight.sealName ? fight.sealName : fight.fightName,
-      fight.endType,
-    ]);
-    idx++;
-  }
-
-  if (outputRows.length === 0)
-    return;
-
-  const lengths = maxLengthPerIndex(outputRows);
-
-  const dateIdx = 1;
-  console.log(lastDate);
-
-  for (const row of outputRows) {
-    if (row[dateIdx] && row[dateIdx] !== lastDate) {
-      lastDate = row[dateIdx];
-      console.log(lastDate);
-    }
-
-    console.log(
-      '  ' +
-        leftExtendStr(row, lengths, 0) + (row[0] ? ') ' : '  ') +
-        leftExtendStr(row, lengths, 2) + ' ' +
-        leftExtendStr(row, lengths, 3) + ' ' +
-        rightExtendStr(row, lengths, 4) +
-        (row[5] ? (' ' + '[' + row[5] + ']') : ''),
-    );
-  }
 };
 
 class ConsoleNotifier {
@@ -283,22 +122,22 @@ const writeFile = (outputFile, startLine, endLine) => {
   const collector = await makeCollectorFromPrepass(logFileName);
 
   if (args['search_fights'] === -1) {
-    printCollectedFights(collector);
+    TFuncs.printCollectedFights(collector);
     process.exit(0);
   }
   if (args['search_zones'] === -1) {
-    printCollectedZones(collector);
+    TFuncs.printCollectedZones(collector);
     process.exit(0);
   }
 
   // This utility prints 1-indexed fights and zones, so adjust - 1.
   if (args['search_fights']) {
     const fight = collector.fights[args['search_fights'] - 1];
-    await writeFile(generateFileName(fight), fight.startLine, fight.endLine);
+    await writeFile(TFuncs.generateFileName(fight), fight.startLine, fight.endLine);
     process.exit(exitCode);
   } else if (args['search_zones']) {
     const zone = collector.zones[args['search_zones'] - 1];
-    await writeFile(generateFileName(zone), zone.startLine, zone.endLine);
+    await writeFile(TFuncs.generateFileName(zone), zone.startLine, zone.endLine);
     process.exit(exitCode);
   } else if (args['fight_regex']) {
     const regex = new RegExp(args['fight_regex'], 'i');
@@ -309,7 +148,7 @@ const writeFile = (outputFile, startLine, endLine) => {
       } else if (!fight.name.match(regex)) {
         continue;
       }
-      await writeFile(generateFileName(fight), fight.startLine, fight.endLine);
+      await writeFile(TFuncs.generateFileName(fight), fight.startLine, fight.endLine);
     }
     process.exit(exitCode);
   } else if (args['zone_regex']) {
@@ -317,7 +156,7 @@ const writeFile = (outputFile, startLine, endLine) => {
     for (const zone of collector.zones) {
       if (!zone.name.match(regex))
         continue;
-      await writeFile(generateFileName(zone), zone.startLine, zone.endLine);
+      await writeFile(TFuncs.generateFileName(zone), zone.startLine, zone.endLine);
     }
     process.exit(exitCode);
   } else {


### PR DESCRIPTION
This is another stepping-stone for continued changes to our log utilities. I'm not really attached to having these functions live in `encounter_tools`, I mostly placed them here to get them *out* of `split_log`. I'm not really attached to much here in general, really. In large part the changes made here are "satisfy the compiler but otherwise maintain most of the logic".