### PR TITLE
config: Fix display for user triggers with ZoneId.MatchAll

### DIFF
--- a/ui/config/config.ts
+++ b/ui/config/config.ts
@@ -787,6 +787,8 @@ export class CactbotConfigurator {
         const zoneInfo = ZoneInfo[zoneId];
         if (zoneInfo)
           title = this.translate(zoneInfo.name);
+      } else if (triggerSet.zoneId === null) {
+        title = this.translate(kPrefixToCategory['00-misc']);
       } else if (triggerSet.zoneRegex) {
         // zoneRegex can be a localized object.
         let zoneRegex = triggerSet.zoneRegex instanceof RegExp


### PR DESCRIPTION
Partially fixes #4043.

![image](https://user-images.githubusercontent.com/6119598/167261956-5190014e-458f-4b8d-8056-f34c5fceb78a.png)
