### PR TITLE
test: Update test_trigger.ts

### DIFF
--- a/test/helper/test_trigger.ts
+++ b/test/helper/test_trigger.ts
@@ -1,7 +1,6 @@
 // This test loads an individual trigger file and makes validates
 // the format and regex calls made.
 
-// TODO: Remove ` ?` before each hex value once global prefix `^.{14} ` is added.
 // JavaScript doesn't allow for possessive operators in regular expressions.
 
 import fs from 'fs';
@@ -54,10 +53,6 @@ const isResponseFunc = (func: unknown): func is ResponseFunc<RaidbossData, Match
   return typeof func === 'function';
 };
 
-const createTriggerRegexString = (str: string): RegExp => {
-  return new RegExp(`(?:regex|triggerRegex)(?:|\\w{2}): \/${str}\/`, 'g');
-};
-
 const testTriggerFile = (file: string) => {
   let contents: string;
   let triggerSet: LooseTriggerSet;
@@ -75,93 +70,34 @@ const testTriggerFile = (file: string) => {
   // Dummy test so that failures in before show up with better text.
   it('should load properly', () => {/* noop */});
 
-  it('has valid trigger regex language', () => {
-    const unsupportedRegexLanguage = /(?:regex|triggerRegex)(?!:|Cn|De|Fr|Ko|Ja)\w*\s*:/g;
-    const results = unsupportedRegexLanguage.exec(contents);
+  it('should not use Regexes', () => {
+    const regexes = /(?:(?:regex)(?:|Cn|De|Fr|Ko|Ja)\w*\s*:\w*\s*Regexes\.)/g;
+    const results = regexes.exec(contents);
     if (results && results.length > 0) {
       for (const result of results)
-        assert.fail(`invalid regex language '${result}'`);
+        assert.fail(`using Regexes: '${result}'`);
     }
   });
 
-  it('has well-formed new combatant trigger regex', () => {
-    // Escape the escapes so they can escape the escape in the parsed regex.
-    const newCombatantRegex = createTriggerRegexString(
-      '(?! ?03:\\\\y{ObjectId}:)(.*:)?Added new combatant.*',
-    );
-    const results = newCombatantRegex.exec(contents);
-    if (results) {
-      for (const result of results) {
-        assert.fail(
-          `'Added new combatant' regex should begin with '03:\\y{ObjectId}:', found '${result}'`,
-        );
-      }
+  it('should not use non-network triggers', () => {
+    const regexesProps = ['regex', 'regexCn', 'regexDe', 'regexFr', 'regexKo', 'regexJa'];
+    for (const trigger of triggerSet.triggers ?? []) {
+      for (const prop of regexesProps)
+        assert.isFalse(prop in trigger, `trigger ${trigger.id} has prop ${prop}`);
     }
   });
 
-  it('has well-formed starts using trigger', () => {
-    const startsUsingRegex = createTriggerRegexString('(?! ?14:)(.* )?starts using.*');
-    const results = startsUsingRegex.exec(contents);
-    if (results) {
+  it('should always use NetRegexes', () => {
+    const regexes = /(?:(?:netRegex)(?:|Cn|De|Fr|Ko|Ja)\w*\s*:\w*\s*\/)[^,]+/g;
+    const results = regexes.exec(contents);
+    if (results && results.length > 0) {
       for (const result of results)
-        assert.fail(`'starts using' regex should begin with '14:', found '${result}'`);
-    }
-  });
-
-  it('has well-formed gains effect trigger', () => {
-    // There are some weird Eureka "gains effect" messages with 00:332e.
-    // But everything else is 1A.
-    const gainsEffectRegex = createTriggerRegexString(
-      '(?! (?:1A:\\\\y{ObjectId}|00:332e):)(.* )?gains the effect of.*',
-    );
-    const results = gainsEffectRegex.exec(contents);
-    if (results) {
-      for (const result of results) {
-        assert.fail(
-          `'gains the effect of' regex should begin with '1A:\\y{ObjectId}:', found '${result}'`,
-        );
-      }
-    }
-  });
-
-  it('has well-formed loses effect trigger', () => {
-    const losesEffectRegex = createTriggerRegexString(
-      '(?! ?1E:\\\\y{ObjectId}:)(.* )?loses the effect of.*',
-    );
-    const results = losesEffectRegex.exec(contents);
-    if (results) {
-      for (const result of results) {
-        assert.fail(
-          `'loses the effect of' regex should begin with '1E:\\y{ObjectId}:', found '${result}'`,
-        );
-      }
-    }
-  });
-
-  it('has no bad catch-all regex', () => {
-    // Matches 3, 5, 6, 7, or 9 (or more) consecutive '.' operators
-    const badCatchAllRegex = createTriggerRegexString('.*:(\\.{3}(\\.{2,4})?|\\.{9,}):.*');
-    const results = badCatchAllRegex.exec(contents);
-    if (results) {
-      for (const result of results)
-        assert.fail(`Invalid number of '.' operators, found '${result}'`);
-    }
-  });
-
-  it('should use ObjectId instead of literal periods', () => {
-    const objectIdRegex = createTriggerRegexString('.*:\\.{8}:.*');
-    const results = objectIdRegex.exec(contents);
-    if (results) {
-      for (const result of results) {
-        assert.fail(
-          `${file}: ObjectId should be used in favor of literal '........', found '${result}'`,
-        );
-      }
+        assert.fail(`using raw regex: '${result}'`);
     }
   });
 
   it('should not use an unnecessary group regex', () => {
-    const unnecessaryGroupRegex = createTriggerRegexString('.*\\(\\?:.\\|.\\).*');
+    const unnecessaryGroupRegex = /\(\?:.(?:\|.)+\)/g;
     const results = unnecessaryGroupRegex.exec(contents);
     if (results) {
       for (const result of results) {
@@ -205,13 +141,14 @@ const testTriggerFile = (file: string) => {
           const funcStr = currentTriggerFunction.toString();
 
           const containsOutput = /\boutput\.(\w*)\(/.test(funcStr);
-          const containsOutputParam = getParamNames(funcStr).includes('output');
+          const paramNames = getParamNames(funcStr);
+          const containsOutputParam = paramNames.includes('output');
           // TODO: should we error when there is an unused output param? that seems a bit much.
           if (containsOutput && !containsOutputParam)
             assert.fail(`Missing 'output' param for '${currentTrigger.id}'.`);
 
           containsMatches = containsMatches || /(?<!_)matches/.test(funcStr);
-          for (const paramName of getParamNames(funcStr))
+          for (const paramName of paramNames)
             containsMatchesParam = containsMatchesParam || /(?<!_)matches/.test(paramName);
 
           const builtInResponse = 'cactbot-builtin-response';
@@ -297,20 +234,6 @@ const testTriggerFile = (file: string) => {
             `Found 'matches' as a function parameter without regex capturing group for trigger id '${currentTrigger.id}'.`,
           );
         }
-      }
-    }
-  });
-
-  it('has valid trigger fields', () => {
-    for (const currentTrigger of triggerSet.triggers ?? []) {
-      for (const key in currentTrigger) {
-        if (isKeyInTriggerFunctions(triggerFunctions, key))
-          continue;
-        if (isKeyInTriggerFunctions(regexLanguages, key))
-          continue;
-        if (isKeyInTriggerFunctions(netRegexLanguages, key))
-          continue;
-        assert.fail(`${file}: Found unknown key '${key}' in trigger id '${currentTrigger.id}'.`);
       }
     }
   });

--- a/ui/raidboss/data/04-sb/eureka/eureka_hydatos.ts
+++ b/ui/raidboss/data/04-sb/eureka/eureka_hydatos.ts
@@ -106,7 +106,7 @@ const triggerSet: TriggerSet<Data> = {
       netRegexFr: NetRegexes.message({ line: 'Fermeture d(?:e|u|es) (?:l\'|la |les? )?.* dans.*?', capture: false }),
       netRegexJa: NetRegexes.message({ line: '.*の封鎖まであと.*?', capture: false }),
       netRegexCn: NetRegexes.message({ line: '距.*被封锁还有.*?', capture: false }),
-      netRegexKo: NetRegexes.message({ line: '15초 후에 .*(?:이|가) 봉쇄됩니다.*?', capture: false }),
+      netRegexKo: NetRegexes.message({ line: '15초 후에 .*[이가] 봉쇄됩니다.*?', capture: false }),
       run: (data) => data.sealed = true,
     },
     {

--- a/ui/raidboss/data/05-shb/etc/the_diadem.ts
+++ b/ui/raidboss/data/05-shb/etc/the_diadem.ts
@@ -29,7 +29,7 @@ const triggerSet: TriggerSet<Data> = {
       netRegexFr: NetRegexes.gameLog({ line: 'Vous détectez une? (?:filon de minerai|carrière de pierre|arbre mature|carré de végétation) évanescente?.*?', capture: false }),
       netRegexJa: NetRegexes.gameLog({ line: '(?:東|南|西|北|北東|南東|北西|南西)にレベル80の幻の(?:採掘場|岩場|良木|草刈場)を感知した！.*?', capture: false }),
       netRegexCn: NetRegexes.gameLog({ line: '在(?:东|南|西|北|东北|东南|西北|西南)+感知到了80级的梦幻的(?:矿脉|石场|良材|草场)！.*?', capture: false }),
-      netRegexKo: NetRegexes.gameLog({ line: '(?:동|서|남|북)+쪽에 레벨 80 환상의 (?:광맥|바위터|성목|약초밭)(?:이|가) 있습니다!.*?', capture: false }),
+      netRegexKo: NetRegexes.gameLog({ line: '[동서남북]+쪽에 레벨 80 환상의 (?:광맥|바위터|성목|약초밭)[이가] 있습니다!.*?', capture: false }),
       alertText: (_data, _matches, output) => output.text!(),
       outputStrings: {
         text: {


### PR DESCRIPTION
test_trigger.ts had a bunch of older tests that were no longer valid (testing game log lines instead of network log lines).

Instead, this PR removes those tests and adds new tests as follows:
1. Make sure that built-in triggers don't use the `regex: Regexes` format
2. Make sure that built-in triggers don't use `regex` or a lang-keyed version

It also:
1. Fixes a performance issue with calling `getParamNames` twice
2. Fixes a broken trigger for unnecessary group regex (and fixes the two triggers that had this issue)