### PR TITLE
raidboss/raidemulator: Fix issues with initData handling

### DIFF
--- a/ui/raidboss/emulator/overrides/RaidEmulatorPopupText.ts
+++ b/ui/raidboss/emulator/overrides/RaidEmulatorPopupText.ts
@@ -138,9 +138,11 @@ export default class RaidEmulatorPopupText extends StubbedPopupText {
     emulator.on('midSeek', async (line: LineEvent) => {
       await this.doUpdate(line.timestamp);
     });
-    emulator.on('preSeek', () => {
+    emulator.on('preSeek', (seekTimestamp: number) => {
       this.seeking = true;
       this._emulatorReset();
+      if (seekTimestamp < this.emulatedOffset)
+        this.ReloadTimelines();
     });
     emulator.on('postSeek', () => {
       // This is a hacky fix for audio still playing during seek

--- a/ui/raidboss/popup-text.ts
+++ b/ui/raidboss/popup-text.ts
@@ -586,6 +586,7 @@ export class PopupText {
     // Drop the triggers and timelines from the previous zone, so we can add new ones.
     this.triggers = [];
     this.netTriggers = [];
+    this.dataInitializers = [];
     let timelineFiles = [];
     let timelines: string[] = [];
     const replacements: TimelineReplacement[] = [];


### PR DESCRIPTION
Fixes #4425.
While testing the fix I noticed an issue with initData being called multiple times instead. Turns out it wasn't ever being cleared which I'm sure lead to some memory leakage slowly over time, as the initData functions built up and populated the data object with more and more zones' worth of initial state.