### PR TITLE
lint: Enable basic strict-boolean-expressions lint rule

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -254,6 +254,13 @@ const tsOverrides = {
     '@typescript-eslint/no-unsafe-argument': 'error',
     '@typescript-eslint/no-unused-vars': ['warn', { 'args': 'all', 'argsIgnorePattern': '^_\\w?' }],
     '@typescript-eslint/object-curly-spacing': ['warn', 'always'],
+    '@typescript-eslint/strict-boolean-expressions': ['error', {
+      // @TODO: Enable these keys over time
+      'allowAny': true,
+      'allowNullableBoolean': true,
+      'allowNullableNumber': true,
+      'allowNullableString': true,
+    }],
     'func-style': ['error', 'expression', { 'allowArrowFunctions': true }],
     'import/order': [
       'error',


### PR DESCRIPTION
This is the beginning of a series of follow up PRs for #4447. This PR adds the lint rule `@typescript-eslint/strict-boolean-expressions` with its most permissive settings.

This PR can't be merged until the downstream PRs are merged to clean up errors:
- #4449
- #4450
- #4451
- #4452
- #4454