### PR TITLE
util: Typescriptify make_timeline

### DIFF
--- a/util/logtools/arg_parser.ts
+++ b/util/logtools/arg_parser.ts
@@ -32,7 +32,7 @@ class LogUtilArgParse {
   // The only validation done here is to ensure that at least one
   // of these arguments is present.
   requiredGroup = this.parser.addMutuallyExclusiveGroup();
-  args: TimelineArgs;
+  args?: TimelineArgs;
 
   constructor() {
     this.fileGroup.addArgument(['-f', '--file'], {
@@ -78,7 +78,6 @@ class LogUtilArgParse {
       type: 'float',
       help: 'Adjust all entries in a timeline file by this amount',
     });
-    this.args = this.parser.parseArgs() as TimelineArgs;
   }
 }
 

--- a/util/logtools/arg_parser.ts
+++ b/util/logtools/arg_parser.ts
@@ -1,14 +1,13 @@
 import argparse from 'argparse';
 
 type TimelineArgs = {
-  [index: string]: string | number | boolean | undefined;
-  'file'?: string;
-  'force'?: boolean;
-  'search_fights'?: number;
-  'search_zones'?: number;
-  'fight_regex'?: string;
-  'zone_regex'?: string;
-  'adjust'?: number;
+  'file': string | null;
+  'force': boolean | null;
+  'search_fights': number | null;
+  'search_zones': number | null;
+  'fight_regex': string | null;
+  'zone_regex': string | null;
+  'adjust': number | null;
 };
 
 class LogUtilArgParse {

--- a/util/logtools/encounter_tools.ts
+++ b/util/logtools/encounter_tools.ts
@@ -201,7 +201,7 @@ export class EncounterFinder {
       zoneName: zoneName,
       startLine: line,
       zoneId: parseInt(matches.id),
-      startTime: this.dateFromMatches(matches),
+      startTime: TLFuncs.dateFromMatches(matches),
     };
   }
   onStartFight(line: string, fightName: string, matches: NetMatches['Ability' | 'GameLog']): void {
@@ -209,7 +209,7 @@ export class EncounterFinder {
       fightName: fightName,
       zoneName: this.currentZone.zoneName, // Sometimes the same as the fight name, but that's fine.
       startLine: line,
-      startTime: this.dateFromMatches(matches),
+      startTime: TLFuncs.dateFromMatches(matches),
     };
   }
 
@@ -231,14 +231,6 @@ export class EncounterFinder {
     this.onEndFight(line, matches, 'Unseal');
     this.currentSeal = undefined;
   }
-
-  dateFromMatches(matches: NetAnyMatches): Date {
-    // No current match definitions are missing a timestamp,
-    // but in the event any are added without in future, we will be ready!
-    if (!matches.timestamp)
-      throw new UnreachableCode();
-    return new Date(Date.parse(matches.timestamp));
-  }
 }
 
 class EncounterCollector extends EncounterFinder {
@@ -251,7 +243,7 @@ class EncounterCollector extends EncounterFinder {
 
   override onEndZone(line: string, _zoneName: string, matches: NetMatches['ChangeZone']): void {
     this.currentZone.endLine = line;
-    this.currentZone.endTime = this.dateFromMatches(matches);
+    this.currentZone.endTime = TLFuncs.dateFromMatches(matches);
     this.zones.push(this.currentZone);
     this.initializeZone();
   }
@@ -261,14 +253,14 @@ class EncounterCollector extends EncounterFinder {
       fightName: fightName,
       zoneName: this.currentZone.zoneName,
       startLine: line,
-      startTime: this.dateFromMatches(matches),
+      startTime: TLFuncs.dateFromMatches(matches),
       zoneId: this.currentZone.zoneId,
     };
   }
 
   override onEndFight(line: string, matches: NetAnyMatches, endType: string): void {
     this.currentFight.endLine = line;
-    this.currentFight.endTime = this.dateFromMatches(matches);
+    this.currentFight.endTime = TLFuncs.dateFromMatches(matches);
     this.currentFight.endType = endType;
     this.fights.push(this.currentFight);
     this.initializeFight();
@@ -288,6 +280,13 @@ class EncounterCollector extends EncounterFinder {
 }
 
 class TLFuncs {
+  static dateFromMatches(matches: NetAnyMatches): Date {
+    // No current match definitions are missing a timestamp,
+    // but in the event any are added without in future, we will be ready!
+    if (!matches.timestamp)
+      throw new UnreachableCode();
+    return new Date(Date.parse(matches.timestamp));
+  }
   static timeFromDate(date?: Date): string {
     if (date)
       return date.toISOString().slice(11, 19);
@@ -469,4 +468,4 @@ class TLFuncs {
   };
 }
 
-export { EncounterCollector, TLFuncs };
+export { EncounterCollector, TLFuncs, ZoneEncInfo, FightEncInfo };

--- a/util/logtools/encounter_tools.ts
+++ b/util/logtools/encounter_tools.ts
@@ -320,7 +320,7 @@ class TLFuncs {
       const cap = str[0]?.toUpperCase();
       const lower = str.slice(1);
       if (cap)
-        return `${cap} ${lower}`;
+        return `${cap}${lower}`;
     }).join(' ');
   }
 

--- a/util/logtools/encounter_tools.ts
+++ b/util/logtools/encounter_tools.ts
@@ -288,8 +288,13 @@ class TLFuncs {
     return new Date(Date.parse(matches.timestamp));
   }
   static timeFromDate(date?: Date): string {
-    if (date)
-      return date.toISOString().slice(11, 23);
+    if (date) {
+      const wholeTime = date.toLocaleTimeString('en-US', { hour12: false });
+      const milliseconds = date.getMilliseconds();
+      // If milliseconds is under 100, the leading zeroes will be truncated.
+      // We don't want that, so we pad it inside the formatter.
+      return `${wholeTime}.${milliseconds.toString().padStart(3, '0')}`;
+    }
     return 'Unknown_Time';
   }
 

--- a/util/logtools/encounter_tools.ts
+++ b/util/logtools/encounter_tools.ts
@@ -289,7 +289,7 @@ class TLFuncs {
   }
   static timeFromDate(date?: Date): string {
     if (date)
-      return date.toISOString().slice(11, 19);
+      return date.toISOString().slice(11, 23);
     return 'Unknown_Time';
   }
 

--- a/util/logtools/make_timeline.ts
+++ b/util/logtools/make_timeline.ts
@@ -7,6 +7,16 @@ import { NetMatches } from '../../types/net_matches';
 import { LogUtilArgParse, TimelineArgs } from './arg_parser';
 import { EncounterCollector, TLFuncs } from './encounter_tools';
 
+// TODO: Add support for auto-commenting repeated abilities
+// that can't be synced but should be visible.
+
+// TODO: Add support for assigning sync windows to specific abilities,
+// with or without phase conditions.
+
+// TODO: Add support for auto-generating loops.
+
+// TODO: Add FFLogs report parsing support.
+
 type TimelineEntry = {
   time: string;
   combatant?: string;

--- a/util/logtools/make_timeline.ts
+++ b/util/logtools/make_timeline.ts
@@ -263,10 +263,10 @@ const ignoreTimelineAbilityEntry = (entry: TimelineEntry, args: ExtendedArgs): b
   const abilityId = entry.abilityId;
   const combatant = entry.combatant;
 
-  const ia = args.ignore_ability as string[];
-  const ii = args.ignore_id as string[];
-  const ic = args.ignore_combatant as string[];
-  const oc = args.only_combatant as string[];
+  const ia = args.ignore_ability as string[] | null;
+  const ii = args.ignore_id as string[] | null;
+  const ic = args.ignore_combatant as string[] | null;
+  const oc = args.only_combatant as string[] | null;
   // Ignore auto-attacks named "attack"
   if (abilityName?.toLowerCase() === 'attack')
     return true;
@@ -276,19 +276,19 @@ const ignoreTimelineAbilityEntry = (entry: TimelineEntry, args: ExtendedArgs): b
     return true;
 
   // Ignore abilities by name.
-  if (abilityName && ia && ia.includes(abilityName))
+  if (abilityName && ia !== null && ia.includes(abilityName))
     return true;
 
   // Ignore abilities by ID
-  if (abilityId && ii && ii.includes(abilityId))
+  if (abilityId && ii !== null && ii.includes(abilityId))
     return true;
 
   // Ignore combatants by name
-  if (combatant && ic && ic.includes(combatant))
+  if (combatant && ic !== null && ic.includes(combatant))
     return true;
 
   // If only-combatants was specified, ignore all combatants not in the list.
-  if (combatant && oc && !oc.includes(combatant))
+  if (combatant && oc !== null && !oc.includes(combatant))
     return true;
   return false;
 };
@@ -353,7 +353,7 @@ const assembleTimelineStrings = (
     }
 
     // Ignore targetable lines if not specified
-    if (entry.lineType === 'targetable' && !args.include_targetable)
+    if (entry.lineType === 'targetable' && args.include_targetable === null)
       continue;
 
     // Find out how long it's been since the last ability.
@@ -461,11 +461,11 @@ const makeTimeline = async () => {
         args.include_targetable as string[],
       );
       const assembled = assembleTimelineStrings(fight, baseEntries, startTime, args);
-      if (args.output_file && typeof args.output_file === 'string') {
+      if (typeof args.output_file === 'string') {
         const force = args.force !== null;
         writeTimelineToFile(assembled, args.output_file, force);
       }
-      if (!args.output_file)
+      if (args.output_file === null)
         printTimelineToConsole(assembled);
       process.exit(0);
     }

--- a/util/logtools/make_timeline.ts
+++ b/util/logtools/make_timeline.ts
@@ -322,10 +322,8 @@ const ignoreTimelineAbilityEntry = (entry: TimelineEntry, args: ExtendedArgs): b
     return true;
 
   // Ignore abilities by ID
-  if (abilityId && ii && ii.length > 0) {
-    if (ii.includes(abilityId))
-      return true;
-  }
+  if (abilityId && ii && ii.includes(abilityId))
+    return true;
 
   // Ignore combatants by name
   if (combatant && ic && ic.includes(combatant))
@@ -429,9 +427,6 @@ const assembleTimelineStrings = (
       delete phases[abilityName];
     }
 
-    // Avoid awkward floating-point nonsense.
-    timelinePosition = Math.round(timelinePosition * 10) / 10;
-
     // We're done manipulating time, so save where we are for the next loop.
     lastAbilityTime = lineTime;
 
@@ -439,12 +434,13 @@ const assembleTimelineStrings = (
       const ability = entry.abilityName ?? 'Unknown';
       const abilityId = entry.abilityId ?? 'Unknown';
       const combatant = entry.combatant ?? 'Unknown';
-      const newEntry =
-        `${timelinePosition} "${ability}" sync / 1[56]:[^:]*:${combatant}:${abilityId}:/`;
+      const newEntry = `${
+        timelinePosition.toFixed(1)
+      } "${ability}" sync / 1[56]:[^:]*:${combatant}:${abilityId}:/`;
       assembled.push(newEntry);
     } else {
       const targetable = entry.targetable ? '--targetable--' : '--untargetable--';
-      const newEntry = `${timelinePosition} "${targetable}"`;
+      const newEntry = `${timelinePosition.toFixed(1)} "${targetable}"`;
       assembled.push(newEntry);
     }
     lastEntry = entry;

--- a/util/logtools/make_timeline.ts
+++ b/util/logtools/make_timeline.ts
@@ -4,7 +4,7 @@ import readline from 'readline';
 import NetRegexes from '../../resources/netregexes';
 import { NetMatches } from '../../types/net_matches';
 
-import { LogUtilArgParse, TimelineArgs as TLArgs } from './arg_parser';
+import { LogUtilArgParse, TimelineArgs } from './arg_parser';
 import { EncounterCollector, TLFuncs } from './encounter_tools';
 
 type TimelineEntry = {
@@ -18,6 +18,19 @@ type TimelineEntry = {
   window?: { beforeWindow: number; afterWindow: number };
   zoneSeal?: { seal: string; code: '0839' };
   lineComment?: string;
+};
+
+type ExtendedArgs = TimelineArgs & {
+  [index: string]: string | string[] | number | boolean | undefined;
+  'output-file'?: string;
+  'start'?: string;
+  'end'?: string;
+  'ignore-id'?: string[];
+  'ignore-ability'?: string[];
+  'ignore-combatant'?: string[];
+  'only-combatant'?: string[];
+  'phase'?: string;
+  'include-targetable'?: string[];
 };
 
 // Some NPCs can be picked up by our entry processor.
@@ -128,7 +141,7 @@ timelineParse.parser.addArgument(['--include-targetable', '-it'], {
   constant: [],
   help: 'Set this flag to include "34" log lines when making the timeline',
 });
-const args = timelineParse.args;
+const args = timelineParse.parser.parseArgs() as ExtendedArgs;
 
 const printHelpAndExit = (errString: string): void => {
   console.error(errString);

--- a/util/logtools/make_timeline.ts
+++ b/util/logtools/make_timeline.ts
@@ -126,31 +126,26 @@ timelineParse.parser.addArgument(['--ignore-id', '-ii'], {
 
 timelineParse.parser.addArgument(['--ignore-ability', '-ia'], {
   nargs: '+',
-  constant: [],
   help: 'Ability names to ignore, e.g. Attack',
 });
 
 timelineParse.parser.addArgument(['--ignore-combatant', '-ic'], {
-  nargs: '*',
-  constant: [],
+  nargs: '+',
   help: 'Combatant names to ignore, e.g. "Aratama Soul"',
 });
 
 timelineParse.parser.addArgument(['--only-combatant', '-oc'], {
-  nargs: '*',
-  constant: [],
+  nargs: '+',
   help: 'Only the listed combatants will generate timeline data, e.g. "Aratama Soul"',
 });
 
 timelineParse.parser.addArgument(['--phase', '-p'], {
-  nargs: '?',
-  type: 'string',
+  nargs: '+',
   help: 'Abilities that indicate a new phase, and the time to jump to, e.g. 28EC:1000',
 });
 
 timelineParse.parser.addArgument(['--include-targetable', '-it'], {
-  nargs: '*',
-  constant: [],
+  nargs: '+',
   help: 'Set this flag to include "34" log lines when making the timeline',
 });
 const args = timelineParse.parser.parseArgs() as ExtendedArgs;

--- a/util/logtools/make_timeline.ts
+++ b/util/logtools/make_timeline.ts
@@ -262,7 +262,7 @@ const extractTLEntries = async (
 
     // Make nameplate toggle lines if and only if the user has specified them.
     if (targetable) {
-      if (targetArray?.length && targetArray.length > 0) {
+      if (targetArray && targetArray.includes(targetable.name)) {
         const targetEntry = parseNameToggleToEntry(targetable);
         entries.push(targetEntry);
       }
@@ -495,7 +495,7 @@ const makeTimeline = async () => {
         args.file,
         startTime,
         endTime,
-        args['include-targetable'],
+        args.include_targetable as string[],
       );
       const assembled = assembleTimelineStrings(fight, baseEntries, startTime, args);
       if (args['output-file'] && typeof args['output-file'] === 'string') {

--- a/util/logtools/make_timeline.ts
+++ b/util/logtools/make_timeline.ts
@@ -2,6 +2,7 @@ import fs from 'fs';
 import readline from 'readline';
 
 import NetRegexes from '../../resources/netregexes';
+import PetData from '../../resources/pet_names';
 import { NetMatches } from '../../types/net_matches';
 
 import { LogUtilArgParse, TimelineArgs } from './arg_parser';
@@ -48,12 +49,7 @@ type ExtendedArgs = TimelineArgs & {
 
 // Some NPCs can be picked up by our entry processor.
 // We list them out explicitly here so we can ignore them at will.
-const ignoredCombatants = [
-  'Eos',
-  'Selene',
-  'Garuda-Egi',
-  'Titan-Egi',
-  'Ifrit-Egi',
+const ignoredCombatants = PetData['en'].concat([
   'Carbuncle',
   'Ruby Ifrit',
   'Emerald Garuda',
@@ -62,15 +58,7 @@ const ignoredCombatants = [
   'Topaz Carbuncle',
   'Ruby Carbuncle',
   'Moonstone Carbuncle',
-  'Rook Autoturret',
-  'Bishop Autoturret',
-  'Demi-Bahamut',
-  'Demi-Phoenix',
   'Earthly Star',
-  'Seraph',
-  'Automaton Queen',
-  'Bunshin',
-  'Esteem',
   'Alphinaud',
   'Alisaie',
   'Y\'shtola',
@@ -91,7 +79,7 @@ const ignoredCombatants = [
   'Crystal Exarch',
   'Mikoto',
   'Liturgic Bell',
-];
+]);
 
 const timeStampValidate = (timeStr?: string) => {
   if (timeStr === undefined)

--- a/util/logtools/make_timeline.ts
+++ b/util/logtools/make_timeline.ts
@@ -1,0 +1,374 @@
+import fs from 'fs';
+import readline from 'readline';
+
+import NetRegexes from '../../resources/netregexes';
+import { NetMatches } from '../../types/net_matches';
+
+import { LogUtilArgParse, TimelineArgs as TLArgs } from './arg_parser';
+import { EncounterCollector, TLFuncs } from './encounter_tools';
+
+type TimelineEntry = {
+  time: string;
+  combatant?: string;
+  abilityId?: string;
+  abilityName?: string;
+  targetable?: boolean;
+  lineType: string;
+  duration?: number;
+  window?: { beforeWindow: number; afterWindow: number };
+  zoneSeal?: { seal: string; code: '0839' };
+  lineComment?: string;
+};
+
+// Some NPCs can be picked up by our entry processor.
+// We list them out explicitly here so we can ignore them at will.
+const ignoredCombatants = [
+  'Eos',
+  'Selene',
+  'Garuda-Egi',
+  'Titan-Egi',
+  'Ifrit-Egi',
+  'Carbuncle',
+  'Ruby Ifrit',
+  'Emerald Garuda',
+  'Topaz Titan',
+  'Emerald Carbuncle',
+  'Topaz Carbuncle',
+  'Ruby Carbuncle',
+  'Moonstone Carbuncle',
+  'Rook Autoturret',
+  'Bishop Autoturret',
+  'Demi-Bahamut',
+  'Demi-Phoenix',
+  'Earthly Star',
+  'Seraph',
+  'Automaton Queen',
+  'Bunshin',
+  'Esteem',
+  'Alphinaud',
+  'Alisaie',
+  'Y\'shtola',
+  'Ryne',
+  'Minfilia',
+  'Thancred',
+  'Urianger',
+  'Estinien',
+  'G\'raha Tia',
+  'Alphinaud\'s Avatar',
+  'Alisaie\'s Avatar',
+  'Thancred\'s Avatar',
+  'Urianger\'s Avatar',
+  'Y\'shtola\'s Avatar',
+  'Estinien\'s Avatar',
+  'G\'raha Tia\'s Avatar',
+  '',
+  'Crystal Exarch',
+  'Mikoto',
+  'Liturgic Bell',
+];
+
+const timeStampValidate = (timeStr?: string) => {
+  if (timeStr === undefined)
+    return false;
+  return /\d{2}:\d{2}:\d{2}\.\d{3}/.test(timeStr);
+};
+
+const timelineParse = new LogUtilArgParse();
+
+timelineParse.parser.addArgument(['--output-file', '-of'], {
+  nargs: '?',
+  type: 'string',
+  help: 'Optional location to write timeline to file.',
+});
+
+timelineParse.parser.addArgument(['--start', '-s'], {
+  nargs: '?',
+  type: 'string',
+  help: 'Timestamp to start assembling an encounter timeline, e.g. 12:34:56.789',
+});
+
+timelineParse.parser.addArgument(['--end', '-e'], {
+  nargs: '?',
+  type: 'string',
+  help: 'Timestamp to end assembling an encounter timeline, e.g. 12:34:56.789',
+});
+
+timelineParse.parser.addArgument(['--ignore-id', '-ii'], {
+  nargs: '?',
+  constant: [],
+  help: 'Ability IDs to ignore, e.g. 27EF',
+});
+
+timelineParse.parser.addArgument(['--ignore-ability', '-ia'], {
+  nargs: '+',
+  constant: [],
+  help: 'Ability names to ignore, e.g. Attack',
+});
+
+timelineParse.parser.addArgument(['--ignore-combatant', '-ic'], {
+  nargs: '*',
+  constant: [],
+  help: 'Combatant names to ignore, e.g. "Aratama Soul"',
+});
+
+timelineParse.parser.addArgument(['--only-combatant', '-oc'], {
+  nargs: '*',
+  constant: [],
+  help: 'Only the listed combatants will generate timeline data, e.g. "Aratama Soul"',
+});
+
+timelineParse.parser.addArgument(['--phase', '-p'], {
+  nargs: '?',
+  type: 'string',
+  help: 'Abilities that indicate a new phase, and the time to jump to, e.g. 28EC:1000',
+});
+
+timelineParse.parser.addArgument(['--include-targetable', '-it'], {
+  nargs: '*',
+  constant: [],
+  help: 'Set this flag to include "34" log lines when making the timeline',
+});
+const args = timelineParse.args;
+
+const printHelpAndExit = (errString: string): void => {
+  console.error(errString);
+  timelineParse.parser.printHelp();
+  process.exit(-1);
+};
+
+// TODO: Revisit this logic when we re-add FFLogs support.
+if (args.file === null)
+  printHelpAndExit('Error: Must specify -f\n');
+if (!args.file?.includes('.log'))
+  printHelpAndExit('Error: Must specify an FFXIV ACT log file, as log.log\n');
+let numExclusiveArgs = 0;
+for (const opt of ['search_fights', 'search_zones', 'fight_regex', 'zone_regex']) {
+  if (args[opt] !== null)
+    numExclusiveArgs++;
+}
+if (numExclusiveArgs !== 1)
+  printHelpAndExit('Error: Must specify exactly one of -lf, -lz, or -fr\n');
+if (args['fight_regex'] === '-1')
+  printHelpAndExit('Error: -fr must specify a regex\n');
+if (args['zone_regex'] === '-1')
+  printHelpAndExit('Error: -zr must specify a regex\n');
+
+if (args.file && !(args.start && args.end)) {
+  printHelpAndExit(
+    'Error: -s and -e must be specified if not using one of -lf, -lz, -fr, or -zr\ ',
+  );
+}
+if (!(typeof args.start === 'string' && timeStampValidate(args.start)))
+  printHelpAndExit('Error: Timestamp must be entered exactly as HH:MM:SS.DDD, as 12:34:56:.789');
+if (!(typeof args.end === 'string' && timeStampValidate(args.end)))
+  printHelpAndExit('Error: Timestamp must be entered exactly as HH:MM:SS.DDD, as 12:34:56:.789');
+
+const makeCollectorFromPrepass = async (fileName: string) => {
+  const collector = new EncounterCollector();
+  const lineReader = readline.createInterface({
+    input: fs.createReadStream(fileName),
+  });
+  for await (const line of lineReader) {
+    // TODO: this could be more efficient if it stopped when it found the requested encounter.
+    collector.process(line);
+  }
+  return collector;
+};
+
+const parseGameLogToEntry = (matches: NetMatches['GameLog']): TimelineEntry => {
+  const entry: TimelineEntry = {
+    time: matches.timestamp,
+    lineType: 'zoneSeal',
+    zoneSeal: { seal: matches.line, code: '0839' },
+  };
+  return entry;
+};
+
+const parseNameToggleToEntry = (matches: NetMatches['NameToggle']): TimelineEntry => {
+  const targetable = matches.toggle === '01';
+  const entry: TimelineEntry = {
+    time: matches.timestamp,
+    combatant: matches.name,
+    lineType: 'nameToggle',
+    targetable: targetable,
+  };
+  return entry;
+};
+
+const parseAbilityToEntry = (matches: NetMatches['Ability']): TimelineEntry => {
+  let abilityName = matches.ability;
+  if (abilityName.toLowerCase().includes('unknown_'))
+    abilityName = '--sync--';
+  const entry: TimelineEntry = {
+    time: matches.timestamp,
+    combatant: matches.source,
+    abilityId: matches.id,
+    abilityName: abilityName,
+    lineType: 'ability',
+  };
+  return entry;
+};
+
+const extractTLEntries = (
+  fileName: string,
+  start: string,
+  end: string,
+  targetArray?: string[],
+): TimelineEntry[] => {
+  const entries: TimelineEntry[] = [];
+  let started = false;
+  const lines: string[] = [];
+  // Read out the relevant encounter lines in a pre-pass
+  const file = readline.createInterface({
+    input: fs.createReadStream(fileName),
+  });
+  file.on('line', (line) => {
+    const lineTimeStamp = line.substring(14, 26);
+    if ([start, end].includes(lineTimeStamp))
+      started = start === lineTimeStamp;
+    if (started)
+      lines.push(line);
+    if (!started && lines.length > 0)
+      file.close();
+  });
+
+  // We have exactly the lines relevant to our encounter now.
+  for (const line of lines) {
+    // Cull non-relevant lines immediately.
+    if (!['00', '21', '22', '34'].includes(line.substring(0, 2)))
+      continue;
+
+    // Check for zone seals.
+    const gameLog = NetRegexes.gameLog().exec(line)?.groups;
+    if (gameLog?.code === '0839' && gameLog.line.includes('will be sealed off')) {
+      const glEntry = parseGameLogToEntry(gameLog);
+      entries.push(glEntry);
+      continue;
+    }
+    // Cull all remaining gameLog lines, as well as all lines not from enemies.
+    // Nameplate change lines are retained.
+    if (!['21', '22', '34'].includes(line.substring(0, 2)) || line.substring(37, 40) === '400')
+      continue;
+
+    // Make nameplate toggle lines if and only if the user has specified them.
+    const targetable = NetRegexes.nameToggle().exec(line)?.groups;
+    if (targetable) {
+      if (targetArray?.length && targetArray.length > 0) {
+        const targetEntry = parseNameToggleToEntry(targetable);
+        entries.push(targetEntry);
+      }
+      continue;
+    }
+
+    // At this point, only enemy combat lines are left.
+    const ability = NetRegexes.ability().exec(line)?.groups;
+    if (ability) {
+      const abilityEntry = parseAbilityToEntry(ability);
+      entries.push(abilityEntry);
+      continue;
+    }
+
+    // There shouldn't be any way that we get here,
+    // but if we do, something is drastically wrong.
+    // Notify the user of the malformed line and continue.
+    const errString = `Warning: Potentially malformed/corrupted log line found:\n${line}\n\n`;
+    console.log(errString);
+    continue;
+  }
+
+  if (entries.length === 0) {
+    console.error('Fight not found');
+    process.exit(-1);
+  }
+  return entries;
+};
+
+const assembleTimelineStrings = (entries: TimelineEntry[], args: TLArgs): string[] => {
+  const assembled: string[] = [];
+  // const phases: {[name: string]: string } = {};
+  // if (args.phase && args.phase is typeof string[]) {
+  //   for (const phase of args.phase)
+  // }
+  const timelinePosition = 0;
+  const lastAbilityTime = entries[0]?.time;
+  const ignoredAbilities = args['ignore-ability'] as string[];
+  if (entries[0]?.zoneSeal) {
+    const zoneMessage = TLFuncs.toProperCase(entries[0].zoneSeal.seal);
+    const tlString = `0.0 "--sync--" sync / 00:0839::${zoneMessage} will be sealed off/ window 0,1`;
+    assembled.push(tlString);
+  } else {
+    assembled.push('0.0 "--sync--" sync /Engage!/ window 0,1');
+  }
+
+  for (const entry of entries) {
+    // Begin by culling ignored items.,
+    if (entry.lineType === 'ability') {
+      const aName = entry.abilityName;
+      const aId = entry.abilityId;
+      const combatant = entry.combatant;
+      // Ignore auto-attacks named "attack"
+      if (aName?.toLowerCase() === 'attack')
+        continue;
+      // Ignore abilities from NPC allies.
+      if (combatant && ignoredCombatants.includes(combatant))
+        continue;
+      const ignoredAbility = aName && ignoredAbilities.includes(aName);
+      const ignoredId = aId
+    }
+  }
+  return assembled;
+};
+
+const printTimelineToConsole = (entryList: string[]): void => {
+  if (entryList.length > 0)
+    console.log(entryList.join('\n'));
+};
+
+const writeTimelineToFile = (entryList: string[], fileName: string, force: boolean): void => {
+  const flags = force ? 'wx' : 'w';
+  const writer = fs.createWriteStream(fileName, { flags: flags });
+  writer.on('error', (err) => {
+    console.error(err);
+    process.exit(-1);
+  });
+  if (entryList.length > 0) {
+    for (const entry of entryList) {
+      writer.write(entry);
+      writer.write('\n');
+    }
+    writer.close();
+  }
+};
+
+(async function() {
+  if (args.file) {
+    const collector = await makeCollectorFromPrepass(args.file);
+    if (args['search_fights'] === -1) {
+      TLFuncs.printCollectedFights(collector);
+      process.exit(0);
+    }
+    if (args['search_zones'] === -1) {
+      TLFuncs.printCollectedZones(collector);
+      process.exit(0);
+    }
+    // All fights are 1-indexed on collectors,
+    // so we subtract 1 from the user's 1-indexed selection.
+    if (args['search_fights']) {
+      const fight = collector.fights[args['search_fights'] - 1];
+      if (!fight) {
+        console.error('No fight found at specified index');
+        process.exit(-1);
+      }
+      const startTime = TLFuncs.timeFromDate(fight.startTime);
+      const endTime = TLFuncs.timeFromDate(fight.endTime);
+      const baseEntries = extractTLEntries(args.file, startTime, endTime);
+      const assembled = assembleTimelineStrings(baseEntries, startTime, endTime, args);
+      if (args['output-file'] && typeof args['output-file'] === 'string') {
+        const force = args.force !== undefined;
+        writeTimelineToFile(assembled, args['output-file'], force);
+      }
+      if (!args['output-file'])
+        printTimelineToConsole(assembled);
+    }
+  }
+});

--- a/util/logtools/make_timeline.ts
+++ b/util/logtools/make_timeline.ts
@@ -89,7 +89,7 @@ const timeStampValidate = (timeStr?: string) => {
 
 const timelineParse = new LogUtilArgParse();
 
-timelineParse.parser.addArgument(['--output-file', '-of'], {
+timelineParse.parser.addArgument(['--output_file', '-of'], {
   nargs: '?',
   type: 'string',
   help: 'Optional location to write timeline to file.',
@@ -107,22 +107,22 @@ timelineParse.parser.addArgument(['--end', '-e'], {
   help: 'Timestamp to end assembling an encounter timeline, e.g. 12:34:56.789',
 });
 
-timelineParse.parser.addArgument(['--ignore-id', '-ii'], {
+timelineParse.parser.addArgument(['--ignore_id', '-ii'], {
   nargs: '+',
   help: 'Ability IDs to ignore, e.g. 27EF',
 });
 
-timelineParse.parser.addArgument(['--ignore-ability', '-ia'], {
+timelineParse.parser.addArgument(['--ignore_ability', '-ia'], {
   nargs: '+',
   help: 'Ability names to ignore, e.g. Attack',
 });
 
-timelineParse.parser.addArgument(['--ignore-combatant', '-ic'], {
+timelineParse.parser.addArgument(['--ignore_combatant', '-ic'], {
   nargs: '+',
   help: 'Combatant names to ignore, e.g. "Aratama Soul"',
 });
 
-timelineParse.parser.addArgument(['--only-combatant', '-oc'], {
+timelineParse.parser.addArgument(['--only_combatant', '-oc'], {
   nargs: '+',
   help: 'Only the listed combatants will generate timeline data, e.g. "Aratama Soul"',
 });
@@ -132,7 +132,7 @@ timelineParse.parser.addArgument(['--phase', '-p'], {
   help: 'Abilities that indicate a new phase, and the time to jump to, e.g. 28EC:1000',
 });
 
-timelineParse.parser.addArgument(['--include-targetable', '-it'], {
+timelineParse.parser.addArgument(['--include_targetable', '-it'], {
   nargs: '+',
   help: 'Set this flag to include "34" log lines when making the timeline',
 });
@@ -156,9 +156,9 @@ for (const opt of ['search_fights', 'search_zones', 'fight_regex', 'zone_regex']
 }
 if (numExclusiveArgs !== 1)
   printHelpAndExit('Error: Must specify exactly one of -lf, -lz, or -fr\n');
-if (args['fight_regex'] === '-1')
+if (args.fight_regex === '-1')
   printHelpAndExit('Error: -fr must specify a regex\n');
-if (args['zone_regex'] === '-1')
+if (args.zone_regex === '-1')
   printHelpAndExit('Error: -zr must specify a regex\n');
 
 if (args.file && numExclusiveArgs !== 1 && !(args.start && args.end)) {
@@ -378,7 +378,7 @@ const assembleTimelineStrings = (
     }
 
     // Ignore targetable lines if not specified
-    if (entry.lineType === 'targetable' && !args['include-targetable'])
+    if (entry.lineType === 'targetable' && !args.include_targetable)
       continue;
 
     // Find out how long it's been since the last ability.
@@ -455,18 +455,18 @@ const writeTimelineToFile = (entryList: string[], fileName: string, force: boole
 const makeTimeline = async () => {
   if (args.file) {
     const collector = await makeCollectorFromPrepass(args.file);
-    if (args['search_fights'] === -1) {
+    if (args.search_fights === -1) {
       TLFuncs.printCollectedFights(collector);
       process.exit(0);
     }
-    if (args['search_zones'] === -1) {
+    if (args.search_zones === -1) {
       TLFuncs.printCollectedZones(collector);
       process.exit(0);
     }
     // All fights are 1-indexed on collectors,
     // so we subtract 1 from the user's 1-indexed selection.
-    if (args['search_fights']) {
-      const fight = collector.fights[args['search_fights'] - 1];
+    if (args.search_fights) {
+      const fight = collector.fights[args.search_fights - 1];
       if (!fight) {
         console.error('No fight found at specified index');
         process.exit(-1);
@@ -486,11 +486,11 @@ const makeTimeline = async () => {
         args.include_targetable as string[],
       );
       const assembled = assembleTimelineStrings(fight, baseEntries, startTime, args);
-      if (args['output-file'] && typeof args['output-file'] === 'string') {
+      if (args.output_file && typeof args.output_file === 'string') {
         const force = args.force !== undefined;
-        writeTimelineToFile(assembled, args['output-file'], force);
+        writeTimelineToFile(assembled, args.output_file, force);
       }
-      if (!args['output-file'])
+      if (!args.output_file)
         printTimelineToConsole(assembled);
       process.exit(0);
     }

--- a/util/logtools/make_timeline.ts
+++ b/util/logtools/make_timeline.ts
@@ -196,9 +196,12 @@ const extractRawLines = async (fileName: string, start: string, end: string): Pr
       started = start === lineTimeStamp;
     if (started)
       lines.push(line);
-    if (lineTimeStamp === end)
+    if (lineTimeStamp === end) {
       file.close();
+      return lines;
+    }
   }
+  file.close();
   return lines;
 };
 
@@ -234,8 +237,8 @@ const extractTLEntries = async (
     // At this point, only ability lines are left.
     if (ability) {
       // Cull non-enemy lines
-      // TODO: Handle this using the raid eumlator's line parsing functionality.
-      if (ability.sourceId.substring(0, 3) !== '400')
+      // TODO: Handle this using the raid emulator's line parsing functionality.
+      if (ability.sourceId[0] !== '4')
         continue;
       const abilityEntry = parseAbilityToEntry(ability);
       entries.push(abilityEntry);

--- a/util/logtools/make_timeline.ts
+++ b/util/logtools/make_timeline.ts
@@ -81,30 +81,12 @@ const ignoredCombatants = PetData['en'].concat([
   'Liturgic Bell',
 ]);
 
-const timeStampValidate = (timeStr?: string) => {
-  if (timeStr === undefined)
-    return false;
-  return /\d{2}:\d{2}:\d{2}\.\d{3}/.test(timeStr);
-};
-
 const timelineParse = new LogUtilArgParse();
 
 timelineParse.parser.addArgument(['--output_file', '-of'], {
   nargs: '?',
   type: 'string',
   help: 'Optional location to write timeline to file.',
-});
-
-timelineParse.parser.addArgument(['--start', '-s'], {
-  nargs: '?',
-  type: 'string',
-  help: 'Timestamp to start assembling an encounter timeline, e.g. 12:34:56.789',
-});
-
-timelineParse.parser.addArgument(['--end', '-e'], {
-  nargs: '?',
-  type: 'string',
-  help: 'Timestamp to end assembling an encounter timeline, e.g. 12:34:56.789',
 });
 
 timelineParse.parser.addArgument(['--ignore_id', '-ii'], {
@@ -150,26 +132,16 @@ if (args.file === null)
 if (!args.file?.includes('.log'))
   printHelpAndExit('Error: Must specify an FFXIV ACT log file, as log.log\n');
 let numExclusiveArgs = 0;
-for (const opt of ['search_fights', 'search_zones', 'fight_regex', 'zone_regex']) {
+for (const opt of ['search_fights', 'search_zones']) {
   if (args[opt] !== null)
     numExclusiveArgs++;
 }
 if (numExclusiveArgs !== 1)
-  printHelpAndExit('Error: Must specify exactly one of -lf, -lz, or -fr\n');
+  printHelpAndExit('Error: Must specify exactly one of -lf or -lz\n');
 if (args.fight_regex === '-1')
-  printHelpAndExit('Error: -fr must specify a regex\n');
+  printHelpAndExit('Error: Timeline generation does not currently support -fr\n');
 if (args.zone_regex === '-1')
-  printHelpAndExit('Error: -zr must specify a regex\n');
-
-if (args.file && numExclusiveArgs !== 1 && !(args.start && args.end)) {
-  printHelpAndExit(
-    'Error: -s and -e must be specified if not using one of -lf, -lz, -fr, or -zr\ ',
-  );
-}
-if (args.start && !(typeof args.start === 'string' && timeStampValidate(args.start)))
-  printHelpAndExit('Error: Timestamp must be entered exactly as HH:MM:SS.DDD, as 12:34:56:.789');
-if (args.end && !(typeof args.end === 'string' && timeStampValidate(args.end)))
-  printHelpAndExit('Error: Timestamp must be entered exactly as HH:MM:SS.DDD, as 12:34:56:.789');
+  printHelpAndExit('Error: Timeline generation does not currently support -zr\n');
 
 const makeCollectorFromPrepass = async (fileName: string) => {
   const collector = new EncounterCollector();

--- a/util/logtools/make_timeline.ts
+++ b/util/logtools/make_timeline.ts
@@ -232,12 +232,12 @@ const parseAbilityToEntry = (matches: NetMatches['Ability']): TimelineEntry => {
   return entry;
 };
 
-const extractTLEntries = (
+const extractTLEntries = async (
   fileName: string,
   start: string,
   end: string,
   targetArray?: string[],
-): TimelineEntry[] => {
+): Promise<TimelineEntry[]> => {
   const entries: TimelineEntry[] = [];
   let started = false;
   const lines: string[] = [];
@@ -245,7 +245,8 @@ const extractTLEntries = (
   const file = readline.createInterface({
     input: fs.createReadStream(fileName),
   });
-  file.on('line', (line) => {
+
+  for await (const line of file) {
     const lineTimeStamp = line.substring(14, 26);
     if (start === lineTimeStamp)
       started = start === lineTimeStamp;
@@ -253,7 +254,7 @@ const extractTLEntries = (
       lines.push(line);
     if (end === lineTimeStamp)
       file.close();
-  });
+  }
 
   // We have exactly the lines relevant to our encounter now.
   for (const line of lines) {
@@ -488,7 +489,7 @@ const makeTimeline = async () => {
       }
       const startTime = TLFuncs.timeFromDate(fight.startTime);
       const endTime = TLFuncs.timeFromDate(fight.endTime);
-      const baseEntries = extractTLEntries(
+      const baseEntries = await extractTLEntries(
         args.file,
         startTime,
         endTime,

--- a/util/logtools/make_timeline.ts
+++ b/util/logtools/make_timeline.ts
@@ -412,7 +412,7 @@ const printTimelineToConsole = (entryList: string[]): void => {
 };
 
 const writeTimelineToFile = (entryList: string[], fileName: string, force: boolean): void => {
-  const flags = force ? 'wx' : 'w';
+  const flags = force ? 'w' : 'wx';
   const writer = fs.createWriteStream(fileName, { flags: flags });
   writer.on('error', (err) => {
     console.error(err);

--- a/util/logtools/split_log.js
+++ b/util/logtools/split_log.js
@@ -9,7 +9,7 @@ import { LogUtilArgParse } from './arg_parser';
 
 // TODO: add options for not splitting / not anonymizing.
 const timelineParse = new LogUtilArgParse();
-const args = timelineParse.args;
+const args = timelineParse.parser.parseArgs();
 
 const printHelpAndExit = (errString) => {
   console.error(errString);


### PR DESCRIPTION
Lots and lots of nonsense, but at a bare minimum, it can produce a basic timeline. We have duplicated (for the most part) the logic of our Python version with some small improvements here and there. Speed is comparable between the two versions. (We should be able to get more speed in future with some improvements to `EncounterCollector`.)

All `ignore` flags should work, as should `-it` and `-oc`.  

A *lot* of the weird-looking declarations are to satisfy the compiler. Most of them are "the heck with it, *now* it's guaranteed defined". This is particularly true in interactions with `args`, since we can't guarantee any specific one is populated from Typescript's point of view. (Also there are very possibly remnants from VSCode's debugger, since it sometimes has subtle behavior differences from a non-integrated shell.)

There's still plenty left to do on this, but this should be a reasonable foundation to build on.