### PR TITLE
config: Adjust typechecks in config.ts

### DIFF
--- a/ui/config/config.ts
+++ b/ui/config/config.ts
@@ -442,7 +442,7 @@ export class CactbotConfigurator {
 
     const allButFinalArg = args.slice(0, -1);
     for (const arg of allButFinalArg) {
-      if (typeof obj !== 'undefined' && typeof obj !== 'object' || Array.isArray(obj)) {
+      if (typeof obj !== 'object' || Array.isArray(obj)) {
         // SavedConfigEntry is arbitrary JSON, but these options should be nothing but objects
         // until leaf node ConfigValue.
         console.error(`Unexpected entry: ${JSON.stringify([group, ...args].join(', '))}`);
@@ -452,7 +452,7 @@ export class CactbotConfigurator {
       obj = obj[arg] ??= {};
     }
 
-    if (typeof obj !== 'undefined' && typeof obj !== 'object' || Array.isArray(obj)) {
+    if (typeof obj !== 'object' || Array.isArray(obj)) {
       // SavedConfigEntry is arbitrary JSON, but these options should be nothing but objects
       // until leaf node ConfigValue.
       console.error(`Unexpected entry: ${JSON.stringify([group, ...args].join(', '))}`);


### PR DESCRIPTION
As a followup to #4449 and #4454, there were two conditionals in config.ts which followed the same general pattern but due to the combined boolean expression (`a && b || c`), didn't turn up with the new eslint rule's most permissive settings.

I figured it's better to submit these as a separate PR.