### PR TITLE
util: Convert `find_missing_*_translations` to typescript

### DIFF
--- a/util/find_missing_timeline_translations.ts
+++ b/util/find_missing_timeline_translations.ts
@@ -1,39 +1,53 @@
 import fs from 'fs';
 import path from 'path';
-import Regexes from '../resources/regexes';
+
+import { Lang } from '../resources/languages';
 import NetRegexes from '../resources/netregexes';
-import { TimelineParser } from '../ui/raidboss/timeline_parser';
+import Regexes from '../resources/regexes';
+import { LooseTriggerSet } from '../types/trigger';
 import {
   commonReplacement,
   partialCommonTimelineReplacementKeys,
 } from '../ui/raidboss/common_replacement';
+import { TimelineParser, TimelineReplacement } from '../ui/raidboss/timeline_parser';
 
 // Set a global flag to mark regexes for NetRegexes.doesNetRegexNeedTranslation.
 // See details in that function for more information.
 NetRegexes.setFlagTranslationsNeeded(true);
 
-export async function findMissing(triggersFile, locale, errorFunc) {
+type ErrorFuncType = (
+  file: string,
+  line: number | undefined,
+  label: string | undefined,
+  message: string,
+) => void;
+
+export const findMissing = async (
+  triggersFile: string,
+  locale: Lang,
+  errorFunc: ErrorFuncType,
+): Promise<void> => {
   // Hackily assume that any file with a txt file of the same name is a trigger/timeline.
   const timelineFile = triggersFile.replace(/\.[jt]s$/, '.txt');
   if (!fs.existsSync(timelineFile))
     return;
 
-  const timelineText = String(fs.readFileSync(timelineFile));
-  const timeline = new TimelineParser(timelineText);
+  const timelineText = fs.readFileSync(timelineFile).toString();
+  const timeline = new TimelineParser(timelineText, [], [], []);
 
   const importPath = '../' + path.relative(process.cwd(), triggersFile).replace(/\\/g, '/');
 
-  const triggerText = String(fs.readFileSync(triggersFile));
-  const triggerLines = triggerText.split('\n');
-
-  const triggerSet = (await import(importPath)).default;
+  // Dynamic imports don't have a type, so add type assertion.
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+  const triggerSet = (await import(importPath)).default as LooseTriggerSet;
   const translations = triggerSet.timelineReplace;
   if (!translations)
     return;
 
-  let trans = {
+  let trans: TimelineReplacement = {
     replaceSync: {},
     replaceText: {},
+    locale: locale,
   };
 
   for (const transBlock of translations) {
@@ -43,46 +57,17 @@ export async function findMissing(triggersFile, locale, errorFunc) {
     break;
   }
 
-  const findMissingArgs = {
-    timelineFile,
-    triggersFile,
-    triggerSet,
-    triggerLines,
-    timeline,
-    trans,
-    locale,
-    errorFunc,
-  };
+  findMissingTimeline(timelineFile, triggersFile, triggerSet, timeline, trans, errorFunc);
+};
 
-  findMissingTimeline(findMissingArgs);
-}
-
-// An extremely hacky helper to turn a trigger id back into a line number.
-function findLineNumberByTriggerId(text, id) {
-  // Apostrophes need to be double escaped here, once for the Regexes.parse
-  // and the second time for the the backslash itself, to turn /'/ into /\\'/
-  let escapedId = id.replace(/'/g, '\\\\\'');
-  // Other regex characters just need to be escaped once to get out of
-  // Regexes.parse unscathed.
-  escapedId = escapedId.replace(/([+^$*])/g, '\\$1');
-  const regex = Regexes.parse('^\\s*id: \'' + escapedId + '\',');
-
-  let lineNumber = 0;
-  for (const line of text) {
-    lineNumber++;
-
-    if (regex.test(line))
-      return lineNumber;
-  }
-
-  // This should never happen.
-  console.log('Failure to find id in file for: ' + id);
-  return '?';
-}
-
-function findMissingTimeline(findMissingArgs) {
-  const { timelineFile, triggerSet, timeline, trans, triggersFile, errorFunc } = findMissingArgs;
-
+const findMissingTimeline = (
+  timelineFile: string,
+  triggersFile: string,
+  triggerSet: LooseTriggerSet,
+  timeline: TimelineParser,
+  trans: TimelineReplacement,
+  errorFunc: ErrorFuncType,
+) => {
   // Don't bother translating timelines that are old.
   if (triggerSet.timelineNeedsFixing)
     return;
@@ -103,17 +88,18 @@ function findMissingTimeline(findMissingArgs) {
       replace: trans.replaceText || {},
       label: 'text',
     },
-  ];
+  ] as const;
 
   const skipPartialCommon = true;
 
   // Add all common replacements, so they can be checked for collisions as well.
   for (const testCase of testCases) {
     const common = commonReplacement[testCase.type];
-    for (const key in common) {
+    for (const [key, value] of Object.entries(common)) {
       if (skipPartialCommon && partialCommonTimelineReplacementKeys.includes(key))
         continue;
-      if (!common[key][trans.locale]) {
+      const transValue = value[trans.locale];
+      if (!transValue) {
         // To avoid throwing a "missing translation" error for
         // every single common translation, automatically add noops.
         testCase.replace[key] = key;
@@ -121,16 +107,16 @@ function findMissingTimeline(findMissingArgs) {
       }
 
       if (key in testCase.replace) {
-        errorFunc(triggersFile, null, null, `duplicated common translation of '${key}`);
+        errorFunc(triggersFile, undefined, undefined, `duplicated common translation of '${key}`);
         continue;
       }
 
-      testCase.replace[key] = common[key][trans.locale];
+      testCase.replace[key] = transValue;
     }
   }
 
   const ignore = timeline.GetMissingTranslationsToIgnore();
-  const isIgnored = (x) => {
+  const isIgnored = (x: string) => {
     for (const ig of ignore) {
       if (x.match(ig))
         return true;
@@ -138,7 +124,7 @@ function findMissingTimeline(findMissingArgs) {
     return false;
   };
 
-  const output = {};
+  const output: { [key: string]: [string, number | undefined, 'sync' | 'text', string] } = {};
 
   for (const testCase of testCases) {
     for (const item of testCase.items) {
@@ -155,16 +141,18 @@ function findMissingTimeline(findMissingArgs) {
         // Because we handle syncs separately from texts, in order to
         // sort them all properly together, create a key to be used with sort().
         const sortKey = String(item.line).padStart(8, '0') + testCase.label;
-        const value = [timelineFile, item.line, testCase.label, `"${item.text}"`];
-        output[sortKey] = value;
+        output[sortKey] = [timelineFile, item.line, testCase.label, `"${item.text}"`];
       }
     }
   }
 
   const keys = Object.keys(output).sort();
-  for (const key of keys)
-    errorFunc(...output[key]);
+  for (const key of keys) {
+    const value = output[key];
+    if (value)
+      errorFunc(...value);
+  }
 
   if (keys.length === 0 && trans.missingTranslations)
-    errorFunc(triggersFile, null, null, `missingTranslations set true when not needed`);
-}
+    errorFunc(triggersFile, undefined, undefined, `missingTranslations set true when not needed`);
+};

--- a/util/translate_timeline.ts
+++ b/util/translate_timeline.ts
@@ -39,7 +39,7 @@ export default async (timelinePath: string, locale: Lang): Promise<void> => {
   // Use findMissing to figure out which lines have errors on them.
   const syncErrors: { [lineNumber: number]: boolean } = {};
   const textErrors: { [lineNumber: number]: boolean } = {};
-  await findMissing(triggersFile, locale, (filename: string, lineNumber: number, label: string) => {
+  await findMissing(triggersFile, locale, (filename, lineNumber, label, _message) => {
     if (!filename.endsWith('.txt') || !lineNumber)
       return;
     if (label === 'text')


### PR DESCRIPTION
Working on the new test_timeline.ts file, I wanted to move the building of argparse and handling of args for each util out of `index.ts` and to their own file so that the `index.ts` file doesn't bloat as more tools are added.

While trying to move said code responsibility out of `index.ts`, I ran into issues because these files weren't typescript, so I converted them.

Also there were some bugs that I fixed along the way.