### PR TITLE
util: Move responsibility for arg parsing out of index

### DIFF
--- a/util/find_missing_translations.ts
+++ b/util/find_missing_translations.ts
@@ -3,10 +3,16 @@ import path from 'path';
 import readline from 'readline';
 import { fileURLToPath } from 'url';
 
-import { isLang, Lang } from '../resources/languages';
+import { Namespace, SubParser } from 'argparse';
+import inquirer from 'inquirer';
+
+import { isLang, Lang, languages } from '../resources/languages';
+import { UnreachableCode } from '../resources/not_reached';
 
 import { walkDirSync } from './file_utils';
 import { findMissing } from './find_missing_timeline_translations';
+
+import { ActionChoiceType } from '.';
 
 // Directory names to ignore when looking for JavaScript files.
 const ignoreDirs = [
@@ -146,7 +152,7 @@ const parseJavascriptFile = (file: string, inputLocales: Lang[]) => {
   });
 };
 
-export const run = async (filter: string, locale: Lang): Promise<void> => {
+const findMissingTranslations = async (filter: string, locale: Lang): Promise<void> => {
   const files = findAllJavascriptFiles(filter);
   for (const file of files) {
     await findMissing(
@@ -165,4 +171,74 @@ export const run = async (filter: string, locale: Lang): Promise<void> => {
     );
     parseJavascriptFile(file, [locale]);
   }
+};
+
+type FindMissingTranslationsNamespaceInterface = {
+  'filter': string | null;
+  'locale': string | null;
+};
+
+class FindMissingTranslationsNamespace extends Namespace
+  implements FindMissingTranslationsNamespaceInterface {
+  'filter': string | null;
+  'locale': string | null;
+}
+
+type FindMissingTranslationsInquirerType = {
+  [name in keyof FindMissingTranslationsNamespaceInterface]:
+    FindMissingTranslationsNamespaceInterface[name];
+};
+
+const findMissingTranslationsFunc = (args: Namespace): Promise<void> => {
+  if (!(args instanceof FindMissingTranslationsNamespace))
+    throw new UnreachableCode();
+  const questions = [
+    {
+      type: 'fuzzypath',
+      name: 'filter',
+      message: 'Input a valid trigger JavaScript filename: ',
+      rootPath: 'ui',
+      suggestOnly: true,
+      default: args.filter ?? '',
+      when: () => typeof args.filter !== 'string',
+    },
+    {
+      type: 'list',
+      name: 'locale',
+      message: 'Select a locale: ',
+      choices: languages,
+      default: args.locale,
+      when: () => typeof args.locale !== 'string',
+    },
+  ] as const;
+  return inquirer.prompt<FindMissingTranslationsInquirerType>(questions)
+    .then((answers) => {
+      const filter = answers.filter || args.filter;
+      const locale = answers.locale || args.locale;
+      if (typeof filter === 'string' && typeof locale === 'string' && isLang(locale))
+        return findMissingTranslations(filter, locale);
+    });
+};
+
+export const registerFindMissingTranslations = (
+  actionChoices: ActionChoiceType,
+  subparsers: SubParser,
+): void => {
+  actionChoices.findTranslations = {
+    name: 'Find missing translations',
+    callback: findMissingTranslationsFunc,
+    namespace: FindMissingTranslationsNamespace,
+  };
+  const findParser = subparsers.addParser('findTranslations', {
+    description: actionChoices.findTranslations.name,
+  });
+
+  findParser.addArgument(['-l', '--locale'], {
+    help: 'The locale to find missing translations for, e.g. de',
+  });
+  findParser.addArgument(['-f', '--filter'], {
+    nargs: '?',
+    type: 'string',
+    help: 'Limits the results to only match specific files/path',
+  });
 };

--- a/util/generate_data_files.ts
+++ b/util/generate_data_files.ts
@@ -1,0 +1,67 @@
+import { Namespace, SubParser } from 'argparse';
+import inquirer from 'inquirer';
+
+import { UnreachableCode } from '../resources/not_reached';
+
+import { default as generateEffectIds } from './gen_effect_id';
+import { default as generatePetNames } from './gen_pet_names';
+
+import { ActionChoiceType } from '.';
+
+const genKeys = ['effect_id', 'pet_names'] as const;
+type GenKeysType = typeof genKeys[number];
+
+const dataFilesMap: { [filename in GenKeysType]: () => Promise<void> } = {
+  'effect_id': generateEffectIds,
+  'pet_names': generatePetNames,
+} as const;
+
+type GenerateDataFilesNamespaceInterface = {
+  'choice': GenKeysType | null;
+};
+
+class GenerateDataFilesNamespace extends Namespace implements GenerateDataFilesNamespaceInterface {
+  'choice': GenKeysType | null;
+}
+
+type GenerateDataFilesInquirerType = {
+  [name in keyof GenerateDataFilesNamespaceInterface]: GenerateDataFilesNamespaceInterface[name];
+};
+
+const generateDataFilesFunc = async (args: Namespace): Promise<void> => {
+  if (!(args instanceof GenerateDataFilesNamespace))
+    throw new UnreachableCode();
+  const questions = [
+    {
+      type: 'list',
+      name: 'choice',
+      message: 'Which data file do you want to generate?',
+      choices: Object.keys(dataFilesMap),
+      default: args.choice,
+      when: () => typeof args.choice !== 'string',
+    },
+  ] as const;
+  return inquirer.prompt<GenerateDataFilesInquirerType>(questions)
+    .then((answers) => {
+      if (typeof answers.choice === 'string' && answers.choice in dataFilesMap)
+        return dataFilesMap[answers.choice]?.();
+    });
+};
+
+export const registerGenerateDataFiles = (
+  actionChoices: ActionChoiceType,
+  subparsers: SubParser,
+): void => {
+  actionChoices.generate = {
+    name: 'Generate common data files',
+    callback: generateDataFilesFunc,
+    namespace: GenerateDataFilesNamespace,
+  };
+  const generateParser = subparsers.addParser('generate', {
+    description: actionChoices.generate.name,
+  });
+
+  generateParser.addArgument(['-c', '--choice'], {
+    choices: Object.keys(dataFilesMap),
+  });
+};

--- a/util/index.ts
+++ b/util/index.ts
@@ -1,13 +1,10 @@
-import { ArgumentParser } from 'argparse';
-import inquirer, { Answers } from 'inquirer';
+import { ArgumentParser, Namespace } from 'argparse';
+import inquirer from 'inquirer';
 import inquirerFuzzyPath, { FuzzyPathQuestionOptions } from 'inquirer-fuzzy-path';
 
-import { isLang, languages } from '../resources/languages';
-
-import { run as findMissingTranslations } from './find_missing_translations';
-import { default as generateEffectIds } from './gen_effect_id';
-import { default as generatePetNames } from './gen_pet_names';
-import { default as translateTimeline } from './translate_timeline';
+import { registerFindMissingTranslations } from './find_missing_translations';
+import { registerGenerateDataFiles } from './generate_data_files';
+import { registerTranslateTimeline } from './translate_timeline';
 
 declare module 'inquirer' {
   interface QuestionMap<T> {
@@ -15,36 +12,15 @@ declare module 'inquirer' {
   }
 }
 
-const getArgument = <T>(obj: unknown, propertyName: string): T | undefined => {
-  if (typeof obj !== 'object' || obj === null)
-    return;
-  if (!(propertyName in obj))
-    return;
-
-  const data = obj as { [key: string]: T };
-  // TODO: it'd be nice to check typeof data here too?
-  return data[propertyName];
+export type ActionChoiceType = {
+  [key: string]: {
+    name: string;
+    callback: (args: Namespace) => Promise<void> | void;
+    namespace: typeof Namespace;
+  };
 };
 
-const dataFilesMap: { readonly [filename: string]: () => Promise<void> } = {
-  'effect_id': generateEffectIds,
-  'pet_names': generatePetNames,
-};
-
-const actionChoices = {
-  generate: {
-    name: 'Generate common data files',
-    value: 'generate',
-  },
-  translateTimeline: {
-    name: 'Translate Raidboss timeline',
-    value: 'translateTimeline',
-  },
-  findTranslations: {
-    name: 'Find missing translations',
-    value: 'findTranslations',
-  },
-};
+const actionChoices: ActionChoiceType = {};
 
 const argumentParser = new ArgumentParser({
   description: 'A collection of common util functions for developing cactbot.',
@@ -55,127 +31,58 @@ const subparsers = argumentParser.addSubparsers({
   dest: 'action',
 });
 
-const generateParser = subparsers.addParser(actionChoices.generate.value, {
-  description: actionChoices.generate.name,
-});
-
-generateParser.addArgument(['-c', '--choice'], {
-  choices: Object.keys(dataFilesMap),
-});
-
-const translateParser = subparsers.addParser(actionChoices.translateTimeline.value, {
-  description: actionChoices.translateTimeline.name,
-});
-
-translateParser.addArgument(['-l', '--locale'], {
-  type: 'string',
-  help: 'The locale to translate the timeline for, e.g. de',
-});
-translateParser.addArgument(['-t', '--timeline'], {
-  type: 'string',
-  help: 'The timeline file to match, e.g. "a12s"',
-});
-
-const findParser = subparsers.addParser(actionChoices.findTranslations.value, {
-  description: actionChoices.findTranslations.name,
-});
-
-findParser.addArgument(['-l', '--locale'], {
-  help: 'The locale to find missing translations for, e.g. de',
-});
-findParser.addArgument(['-f', '--filter'], {
-  nargs: '?',
-  type: 'string',
-  help: 'Limits the results to only match specific files/path',
-});
+registerTranslateTimeline(actionChoices, subparsers);
+registerGenerateDataFiles(actionChoices, subparsers);
+registerFindMissingTranslations(actionChoices, subparsers);
 
 inquirer.registerPrompt('fuzzypath', inquirerFuzzyPath);
 
-const run = (args: unknown): Promise<void> => {
-  return inquirer.prompt([{
-    type: 'list',
-    name: 'action',
-    message: 'What do you want to do?',
-    choices: Object.values(actionChoices),
-    default: getArgument<string>(args, 'action'),
-    when: () => typeof getArgument(args, 'action') !== 'string',
-  }]).then((answer: Answers) => {
-    const action = getArgument(answer, 'action') || getArgument<string>(args, 'action');
-    if (action === actionChoices.generate.value)
-      return generateDataFiles(args);
-    if (action === actionChoices.translateTimeline.value)
-      return translateTimelineFunc(args);
-    if (action === actionChoices.findTranslations.value)
-      return findMissingTranslationsFunc(args);
+type UtilNamespaceInterface = {
+  'action': string | null;
+};
+
+class UtilNamespace extends Namespace implements UtilNamespaceInterface {
+  'action': string | null;
+}
+
+type UtilInquirerType = {
+  [name in keyof UtilNamespaceInterface]: UtilNamespaceInterface[name];
+};
+
+const utilArgs = new UtilNamespace({});
+
+const run = (args: UtilNamespace): Promise<unknown> => {
+  const questions = [
+    {
+      type: 'list',
+      name: 'action',
+      message: 'What do you want to do?',
+      choices: Object.entries(actionChoices).map((e) => {
+        const [key, value] = e;
+        return {
+          name: value.name,
+          value: key,
+        };
+      }),
+      default: args.action,
+      when: () => typeof args.action !== 'string',
+    },
+  ] as const;
+  return inquirer.prompt<UtilInquirerType>(questions).then((answer) => {
+    const action = answer.action || args.action;
+    if (action === null)
+      return;
+    const actionMap = actionChoices[action];
+    if (actionMap === undefined)
+      return;
+    const reparsedArgs = new actionMap.namespace({});
+    if (process.argv.length > 2)
+      argumentParser.parseArgs(undefined, reparsedArgs);
+    return actionMap.callback(reparsedArgs);
   }).catch(console.error);
 };
 
-const generateDataFiles = (args: unknown): Promise<void> => {
-  return inquirer.prompt([{
-    type: 'list',
-    name: 'choice',
-    message: 'Which data file do you want to generate?',
-    choices: Object.keys(dataFilesMap),
-    default: getArgument<string>(args, 'choice'),
-    when: () => typeof getArgument(args, 'choice') !== 'string',
-  }]).then(async (answers: Answers) => {
-    if (typeof answers.choice === 'string' && answers.choice in dataFilesMap)
-      return await dataFilesMap[answers.choice]?.();
-  });
-};
+if (process.argv.length > 2)
+  argumentParser.parseArgs(undefined, utilArgs);
 
-const translateTimelineFunc = (args: unknown): Promise<void> => {
-  return inquirer.prompt([
-    {
-      type: 'fuzzypath',
-      excludeFilter: (path: string) => !path.endsWith('.txt'),
-      name: 'timeline',
-      message: 'Input a valid timeline filename: ',
-      rootPath: 'ui/raidboss/data',
-      default: getArgument<string>(args, 'timeline') ?? '',
-      when: () => typeof getArgument(args, 'timeline') !== 'string',
-    },
-    {
-      type: 'list',
-      name: 'locale',
-      message: 'Select a locale: ',
-      choices: languages,
-      default: getArgument<string>(args, 'locale'),
-      when: () => typeof getArgument(args, 'locale') !== 'string',
-    },
-  ]).then((answers: Answers) => {
-    const timeline = getArgument(answers, 'timeline') || getArgument(args, 'timeline');
-    const locale = getArgument(answers, 'locale') || getArgument(args, 'locale');
-    if (typeof timeline === 'string' && typeof locale === 'string' && isLang(locale))
-      return translateTimeline(timeline, locale);
-  });
-};
-
-const findMissingTranslationsFunc = (args: unknown): Promise<void> => {
-  return inquirer.prompt([
-    {
-      type: 'fuzzypath',
-      name: 'filter',
-      message: 'Input a valid trigger JavaScript filename: ',
-      rootPath: 'ui',
-      suggestOnly: true,
-      default: getArgument<string>(args, 'filter') ?? '',
-      when: () => typeof getArgument(args, 'filter') !== 'string',
-    },
-    {
-      type: 'list',
-      name: 'locale',
-      message: 'Select a locale: ',
-      choices: languages,
-      default: getArgument<string>(args, 'locale'),
-      when: () => typeof getArgument(args, 'locale') !== 'string',
-    },
-  ]).then((answers: Answers) => {
-    const filter = (getArgument(answers, 'filter') || getArgument(args, 'filter')) ?? '';
-    const locale = getArgument(answers, 'locale') || getArgument(args, 'locale');
-    if (typeof filter === 'string' && typeof locale === 'string' && isLang(locale))
-      return findMissingTranslations(filter, locale);
-  });
-};
-
-void run(process.argv.length > 2 ? argumentParser.parseArgs() : undefined);
+void run(utilArgs);


### PR DESCRIPTION
Followup to #4466, precursor to #4444.

I tested that `findTranslations` and `translateTimeline` work as expected, and that `findTranslations` output the same as before the change, and that `translateTimeline`'s output made sense/wasn't broken somehow.

`generate` does not work in either `main` or this PR, due to the ESLint update. I'll open an issue for that in general for better tracking.