### PR TITLE
raidboss: DSR Wyrmsbreath 2 Boiling and Freezing

### DIFF
--- a/ui/raidboss/data/06-ew/ultimate/dragonsongs_reprise_ultimate.ts
+++ b/ui/raidboss/data/06-ew/ultimate/dragonsongs_reprise_ultimate.ts
@@ -12,6 +12,7 @@ import { LocaleText, TriggerSet } from '../../../../../types/trigger';
 
 // TODO: Ser Adelphel left/right movement after initial charge
 // TODO: Meteor "run" call?
+// TODO: Wyrmsbreath 2 cardinal positions for Cauterize and adjust delay
 
 type Phase = 'doorboss' | 'thordan' | 'nidhogg' | 'haurchefant' | 'thordan2' | 'nidhogg2' | 'dragon-king';
 
@@ -1026,6 +1027,55 @@ const triggerSet: TriggerSet<Data> = {
           ja: '大竜巻',
           cn: '旋风',
           ko: '회오리',
+        },
+      },
+    },
+    {
+      id: 'DSR Wyrmsbreath 2 Boiling and Freezing',
+      type: 'GainsEffect',
+      // B52 = Boiling
+      // B53 = Freezing
+      // TODO: Get cardinal of the dragon to stand in
+      // TODO: Adjust dealy to when the bosses jump to cardinal
+      netRegex: NetRegexes.gainsEffect({ effectId: ['B52', 'B53'] }),
+      condition: Conditions.targetIsYou(),
+      // Lasts 10.96s, but bosses do not cast Cauterize until 7.5s after debuff
+      delaySeconds: (_data, matches) => parseFloat(matches.duration) - 6, 
+      infoText: (_data, matches, output) => {
+        if (matches.id === 'B52')
+          return output.hraesvelgr!();
+        return output.nidhogg!();
+      },
+      outputStrings: {
+        nidhogg: {
+          en: 'Get hit by Nidhogg',
+        },
+        hraesvelgr: {
+          en: 'Get hit by Hraesvelgr',
+        },
+      },
+    },
+    {
+      id: 'DSR Wyrmsbreath 2 Pyretic',
+      type: 'GainsEffect',
+      // B52 = Boiling
+      // When Boiling expires, Pyretic (3C0) will apply
+      // Pyretic will cause damage on movement
+      netRegex: NetRegexes.gainsEffect({ effectId: ['B52'] }),
+      condition: Conditions.targetIsYou(),
+      // Boiling lasts 10.96s, after which Pyretic is applied Provide warning
+      delaySeconds: (_data, matches) => parseFloat(matches.duration) - 9.5,
+      // Player will have Pyertic for about 3s before hit by Cauterize
+      durationSeconds: 4,
+      infoText: (_data, _matches, output) => output.text!(),
+      outputStrings: {
+        text: {
+          en: 'Stop',
+          de: 'Stopp',
+          fr: 'Stop',
+          ja: '動かない',
+          cn: '停停停',
+          ko: '멈추기',
         },
       },
     },

--- a/ui/raidboss/data/06-ew/ultimate/dragonsongs_reprise_ultimate.ts
+++ b/ui/raidboss/data/06-ew/ultimate/dragonsongs_reprise_ultimate.ts
@@ -1063,9 +1063,9 @@ const triggerSet: TriggerSet<Data> = {
       // Pyretic will cause damage on movement
       netRegex: NetRegexes.gainsEffect({ effectId: ['B52'] }),
       condition: Conditions.targetIsYou(),
-      // Boiling lasts 10.96s, after which Pyretic is applied Provide warning
+      // Boiling lasts 10.96s, after which Pyretic is applied provide warning
       delaySeconds: (_data, matches) => parseFloat(matches.duration) - 9.5,
-      // Player will have Pyertic for about 3s before hit by Cauterize
+      // Player will have Pyretic for about 3s before hit by Cauterize
       durationSeconds: 4,
       infoText: (_data, _matches, output) => output.text!(),
       outputStrings: {

--- a/ui/raidboss/data/06-ew/ultimate/dragonsongs_reprise_ultimate.ts
+++ b/ui/raidboss/data/06-ew/ultimate/dragonsongs_reprise_ultimate.ts
@@ -1040,7 +1040,7 @@ const triggerSet: TriggerSet<Data> = {
       netRegex: NetRegexes.gainsEffect({ effectId: ['B52', 'B53'] }),
       condition: Conditions.targetIsYou(),
       // Lasts 10.96s, but bosses do not cast Cauterize until 7.5s after debuff
-      delaySeconds: (_data, matches) => parseFloat(matches.duration) - 6, 
+      delaySeconds: (_data, matches) => parseFloat(matches.duration) - 6,
       infoText: (_data, matches, output) => {
         if (matches.id === 'B52')
           return output.hraesvelgr!();

--- a/ui/raidboss/data/06-ew/ultimate/dragonsongs_reprise_ultimate.ts
+++ b/ui/raidboss/data/06-ew/ultimate/dragonsongs_reprise_ultimate.ts
@@ -1064,7 +1064,7 @@ const triggerSet: TriggerSet<Data> = {
       netRegex: NetRegexes.gainsEffect({ effectId: ['B52'] }),
       condition: Conditions.targetIsYou(),
       // Boiling lasts 10.96s, after which Pyretic is applied provide warning
-      delaySeconds: (_data, matches) => parseFloat(matches.duration) - 1.5,
+      delaySeconds: (_data, matches) => parseFloat(matches.duration) - 1,
       // Player will have Pyretic for about 3s before hit by Cauterize
       durationSeconds: 4,
       infoText: (_data, _matches, output) => output.text!(),

--- a/ui/raidboss/data/06-ew/ultimate/dragonsongs_reprise_ultimate.ts
+++ b/ui/raidboss/data/06-ew/ultimate/dragonsongs_reprise_ultimate.ts
@@ -1036,7 +1036,7 @@ const triggerSet: TriggerSet<Data> = {
       // B52 = Boiling
       // B53 = Freezing
       // TODO: Get cardinal of the dragon to stand in
-      // TODO: Adjust dealy to when the bosses jump to cardinal
+      // TODO: Adjust delay to when the bosses jump to cardinal
       netRegex: NetRegexes.gainsEffect({ effectId: ['B52', 'B53'] }),
       condition: Conditions.targetIsYou(),
       // Lasts 10.96s, but bosses do not cast Cauterize until 7.5s after debuff

--- a/ui/raidboss/data/06-ew/ultimate/dragonsongs_reprise_ultimate.ts
+++ b/ui/raidboss/data/06-ew/ultimate/dragonsongs_reprise_ultimate.ts
@@ -1064,7 +1064,7 @@ const triggerSet: TriggerSet<Data> = {
       netRegex: NetRegexes.gainsEffect({ effectId: ['B52'] }),
       condition: Conditions.targetIsYou(),
       // Boiling lasts 10.96s, after which Pyretic is applied provide warning
-      delaySeconds: (_data, matches) => parseFloat(matches.duration) - 9.5,
+      delaySeconds: (_data, matches) => parseFloat(matches.duration) - 1.5,
       // Player will have Pyretic for about 3s before hit by Cauterize
       durationSeconds: 4,
       infoText: (_data, _matches, output) => output.text!(),


### PR DESCRIPTION
The second Wyrmsbreath in phase 6 utilizes Boiling and Freezing debuffs. I am not sure if it's possible to get these debuffs by failing the first Wyrmsbreath, but the debuffs do not appear in a kill log at that time that I looked at and so I did not think to add a check for that.

This also brings back Deep Freeze and Pyretic debuffs from old. Deep Freeze looks to be unavoidable, but Pyretic will require an advance notice such that the player is not moving when Boiling expires as there is a brief period of time between Cauterize hit and Boiling expiration where Pyretic is on the player.

I am not certain on the exact timing of when the dragons are in position, but it looks like it's at least random left/right which dragon is where and I am not sure if the cardinal they choose is also random. Position could be done either with Cauterize cast position and collection trigger or modifying this trigger with OverlayHandler in the future which I think the dragons may jump to position prior to starting the cast.