### PR TITLE
raidboss: fix edited-but-empty strings from being skipped

### DIFF
--- a/ui/raidboss/popup-text.ts
+++ b/ui/raidboss/popup-text.ts
@@ -336,8 +336,13 @@ class TriggerOutputProxy {
     template: { [lang: string]: unknown } | string | undefined,
     params: TriggerParams,
     name: string,
-    id: string): string | undefined {
-    if (template === undefined)
+    id: string,
+  ): string | undefined {
+    // If an output strings entry is edited in the config UI and then blanked,
+    // the entry will still exist in the config file as an empty string.
+    // These should be ignored as not being an override.
+    // TODO: maybe blanked/default entries should be deleted from the config?
+    if (template === undefined || template === '')
       return;
 
     let value: unknown;


### PR DESCRIPTION
This was broken in #4449 because I didn't realize that the empty
string check was important behavior, whoops.

If a user edits something in the config ui and then clears it,
then it will leave an empty string in the config json and
output strings overrides.  This needs to be skipped (and could
be cleaned up elsewhere, but this is a small bugfix for now).