### PR TITLE
config: hide Add More Rows button when collapsing timeline

### DIFF
--- a/ui/config/config.css
+++ b/ui/config/config.css
@@ -56,7 +56,7 @@ html {
   margin-bottom: 20px;
 }
 
-.collapsed > div:not(:first-child) {
+.collapsed > :not(:first-child) {
   display: none;
 }
 


### PR DESCRIPTION
If you expanded and then collapsed Edit Timeline under a
Config > Raidboss section, then the Add More Rows button would
still be visible incorrectly before this patch.