### PR TITLE
oopsy: add file viewer

### DIFF
--- a/ui/oopsyraidsy/damage_tracker.ts
+++ b/ui/oopsyraidsy/damage_tracker.ts
@@ -75,7 +75,7 @@ const latePullText = {
 };
 
 // Internal trigger id for early pull
-const earlyPullTriggerId = 'General Early Pull';
+export const earlyPullTriggerId = 'General Early Pull';
 
 const isOopsyMistake = (x: OopsyMistake | OopsyDeathReason): x is OopsyMistake => 'type' in x;
 
@@ -114,7 +114,7 @@ export class DamageTracker {
 
   private job: Job = 'NONE';
   private role: Role = 'none';
-  private me?: string;
+  private me = '';
   private zoneName?: string;
   private zoneId: ZoneIdType = ZoneId.MatchAll;
   private contentType = 0;
@@ -161,7 +161,7 @@ export class DamageTracker {
 
   GetDataObject(): OopsyData {
     return {
-      me: this.me ?? '',
+      me: this.me,
       job: this.job,
       role: this.role,
       party: this.partyTracker,
@@ -481,6 +481,7 @@ export class DamageTracker {
     const zoneInfo = ZoneInfo[this.zoneId];
     this.contentType = zoneInfo?.contentType ?? 0;
 
+    this.combatState.StopCombat(timestamp);
     this.combatState.Reset();
     this.playerStateTracker.ClearTriggerSets();
     this.playerStateTracker.OnChangeZone(timestamp, zoneName, zoneId);
@@ -603,7 +604,7 @@ export class DamageTracker {
     this.ProcessDataFiles();
 
     // Wait for datafiles / jobs / zone events / localization.
-    if (!this.triggerSets || !this.me || !this.zoneName)
+    if (!this.triggerSets || !this.zoneName)
       return;
 
     this.Reset();
@@ -707,8 +708,6 @@ export class DamageTracker {
   ProcessDataFiles(): void {
     // Only run this once.
     if (this.triggerSets)
-      return;
-    if (!this.me)
       return;
 
     this.triggerSets = this.options.Triggers;

--- a/ui/oopsyraidsy/mistake_collector.ts
+++ b/ui/oopsyraidsy/mistake_collector.ts
@@ -18,7 +18,7 @@ export class MistakeCollector implements MistakeObserver {
   private creationTime = Date.now();
   private latestSyncTimestamp?: number;
 
-  constructor(private options: OopsyOptions) {
+  constructor(private options: OopsyOptions, private shouldSync: boolean) {
     this.AddObserver(this);
     this.RequestSync();
   }
@@ -29,6 +29,8 @@ export class MistakeCollector implements MistakeObserver {
   }
 
   private RequestSync(): void {
+    if (!this.shouldSync)
+      return;
     this.DebugPrint(`RequestSync: ${this.creationTime}`);
     void callOverlayHandler({
       call: 'broadcast',
@@ -42,6 +44,8 @@ export class MistakeCollector implements MistakeObserver {
   }
 
   private SendSyncResponse(): void {
+    if (!this.shouldSync)
+      return;
     this.DebugPrint(`SendSyncResponse: ${this.creationTime}`);
     void callOverlayHandler({
       call: 'broadcast',
@@ -77,6 +81,8 @@ export class MistakeCollector implements MistakeObserver {
   }
 
   OnBroadcastMessage(e: EventResponses['BroadcastMessage']): void {
+    if (!this.shouldSync)
+      return;
     if (e.source !== broadcastSource)
       return;
     const msg = e.msg;

--- a/ui/oopsyraidsy/oopsy_viewer.css
+++ b/ui/oopsyraidsy/oopsy_viewer.css
@@ -1,0 +1,9 @@
+#filedrop {
+  width: 400px;
+  height: 100px;
+  background-color: darkgrey;
+  margin: 10px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}

--- a/ui/oopsyraidsy/oopsy_viewer.html
+++ b/ui/oopsyraidsy/oopsy_viewer.html
@@ -1,0 +1,17 @@
+<html lang="en-US">
+<head>
+  <meta charset="utf-8" />
+  <title>Oopsy Viewer</title>
+  <link
+    rel="stylesheet"
+    href="https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free@5.15.4/css/solid.min.css"
+  />
+</head>
+<body>
+<div id="filedrop"></div>
+<div id="container">
+  <div id="mistake-table" class="mistake-table"></div>
+  <div id="summary" class="summary"></div>
+</div>
+</body>
+</html>

--- a/ui/oopsyraidsy/oopsy_viewer.ts
+++ b/ui/oopsyraidsy/oopsy_viewer.ts
@@ -1,0 +1,115 @@
+import { UnreachableCode } from '../../resources/not_reached';
+import { callOverlayHandler } from '../../resources/overlay_plugin_api';
+import UserConfig from '../../resources/user_config';
+import { LocaleText } from '../../types/trigger';
+
+import { DamageTracker, earlyPullTriggerId } from './damage_tracker';
+import oopsyFileData from './data/oopsy_manifest.txt';
+import { MistakeCollector } from './mistake_collector';
+import defaultOptions, { OopsyOptions } from './oopsy_options';
+import { OopsySummaryList, OopsySummaryTable } from './oopsy_summary_list';
+
+import './oopsyraidsy_config';
+
+import '../../resources/defaults.css';
+import './oopsy_common.css';
+import './oopsy_summary.css';
+import './oopsy_viewer.css';
+
+const fileDropText: LocaleText = {
+  en: 'Drop Network log file here',
+};
+
+// TODO: fake the partyTracker somehow (or get it from log lines) for missed buffs
+// TODO: better mouseover text for dropping
+// TODO: support dropping a file anywhere on the page
+// TODO: use browser language if not connected or do what emulator does
+// TODO: load files asynchronously so it doesn't hitch the browser
+// TODO: show some UI for when this is/isn't connected, like emulator
+// TODO: add some display when this is loaded as an overlay as it should only be in a browser
+// TODO: add visible? console output for processed files / errors
+// TODO: add errors for loading wrong kind of log file
+
+const dropHandler = async (e: DragEvent, damageTracker: DamageTracker): Promise<void> => {
+  e.preventDefault();
+  e.stopPropagation();
+
+  for (const file of e.dataTransfer?.files ?? []) {
+    console.log(`Processing ${file.name}`);
+    const text = await file.text();
+
+    for (const line of text.split('\n')) {
+      damageTracker.OnNetLog({
+        type: 'LogLine',
+        line: line.split('|'),
+        rawLine: line,
+      });
+    }
+  }
+};
+
+const initViewer = (options: OopsyOptions, _isConnected: boolean) => {
+  // TODO: fix early pulls from logs (and also make them more accurate <_<)
+  (options.DisabledTriggers ??= {})[earlyPullTriggerId] = true;
+
+  const mistakeCollector = new MistakeCollector(options, false);
+  const summaryElement = document.getElementById('summary');
+
+  if (!summaryElement)
+    throw new UnreachableCode();
+
+  const listView = new OopsySummaryList(options, summaryElement);
+  mistakeCollector.AddObserver(listView);
+
+  const tableElement = document.getElementById('mistake-table');
+  if (!tableElement)
+    throw new UnreachableCode();
+  const table = new OopsySummaryTable(options, tableElement);
+  mistakeCollector.AddObserver(table);
+
+  const damageTracker = new DamageTracker(options, mistakeCollector, oopsyFileData);
+
+  const fileDrop = document.getElementById('filedrop');
+  if (!fileDrop)
+    throw new UnreachableCode();
+  fileDrop.innerText = fileDropText[options.DisplayLanguage] ?? fileDropText['en'];
+  fileDrop.addEventListener('dragover', (e) => {
+    e.preventDefault();
+    e.stopPropagation();
+  });
+  fileDrop.addEventListener('drop', (e) => void dropHandler(e, damageTracker));
+};
+
+const onLoaded = async () => {
+  if (window.location.href.indexOf('OVERLAY_WS') > 0) {
+    // Give the websocket 500ms to connect, then abort.
+    const websocketConnected = await Promise.race<Promise<boolean>>([
+      new Promise<boolean>((res) => {
+        void callOverlayHandler({ call: 'cactbotRequestState' }).then(() => {
+          res(true);
+        });
+      }),
+      new Promise<boolean>((res) => {
+        window.setTimeout(() => {
+          res(false);
+        }, 500);
+      }),
+    ]);
+    if (websocketConnected) {
+      await new Promise<void>((res) => {
+        UserConfig.getUserConfigLocation('oopsyraidsy', defaultOptions, () => {
+          initViewer({ ...defaultOptions }, true);
+          res();
+        });
+      });
+      return;
+    }
+  }
+  initViewer({ ...defaultOptions }, false);
+};
+
+// Wait for DOMContentLoaded if needed.
+if (document.readyState !== 'loading')
+  void onLoaded();
+else
+  document.addEventListener('DOMContentLoaded', () => void onLoaded());

--- a/ui/oopsyraidsy/oopsyraidsy.ts
+++ b/ui/oopsyraidsy/oopsyraidsy.ts
@@ -40,10 +40,12 @@ export const addDebugInfo = (collector: MistakeCollector, numMistakes: number): 
   }
 };
 
+// Note: changes to this setup function should be reflected in
+// oopsy_viewer as well.
 UserConfig.getUserConfigLocation('oopsyraidsy', defaultOptions, () => {
   const options = { ...defaultOptions };
 
-  const mistakeCollector = new MistakeCollector(options);
+  const mistakeCollector = new MistakeCollector(options, true);
   const summaryElement = document.getElementById('summary');
   const liveListElement = document.getElementById('livelist');
 

--- a/webpack/constants.ts
+++ b/webpack/constants.ts
@@ -8,6 +8,7 @@ export const cactbotModules = {
   jobs: 'ui/jobs/jobs',
   oopsyraidsyLive: 'ui/oopsyraidsy/oopsy_live',
   oopsyraidsySummary: 'ui/oopsyraidsy/oopsy_summary',
+  oopsyraidsyViewer: 'ui/oopsyraidsy/oopsy_viewer',
   pullcounter: 'ui/pullcounter/pullcounter',
   radar: 'ui/radar/radar',
   raidboss: 'ui/raidboss/raidboss',
@@ -64,6 +65,12 @@ export const cactbotHtmlChunksMap = {
     chunks: [
       cactbotChunks.oopsyraidsyData,
       cactbotModules.oopsyraidsySummary,
+    ],
+  },
+  'ui/oopsyraidsy/oopsy_viewer.html': {
+    chunks: [
+      cactbotChunks.oopsyraidsyData,
+      cactbotModules.oopsyraidsyViewer,
     ],
   },
   'ui/oopsyraidsy/oopsyraidsy.html': {

--- a/webpack/webpack.config.ts
+++ b/webpack/webpack.config.ts
@@ -36,6 +36,7 @@ export default (
         'jobs',
         'oopsyraidsyLive',
         'oopsyraidsySummary',
+        'oopsyraidsyViewer',
         'pullcounter',
         'radar',
         'raidboss',


### PR DESCRIPTION
This allows you to drag and drop a network log file onto
an html page and get a list of all mistakes.

This is still a bit of a work in progress, especially party buffs
which need to figure out who is in the party and is currently
depending on events that don't exist.

There's also a lot of TODOs here to improve the UI.  The summary
page could probably use a lot of work as well, in terms of being
able to select certain zones/encounters, and also to have a
summary of mistakes by type.

Fixes #3429.