### PR TITLE
oopsy: fix single target damage looking like a share

### DIFF
--- a/ui/oopsyraidsy/damage_tracker.ts
+++ b/ui/oopsyraidsy/damage_tracker.ts
@@ -562,8 +562,12 @@ export class DamageTracker {
       const trigger: OopsyTrigger<OopsyData> = {
         id: key,
         type: 'Ability',
-        netRegex: NetRegexes.abilityFull({ type: '22', id: id, ...playerDamageFields }),
+        netRegex: NetRegexes.ability({ type: '22', id: id, ...playerDamageFields }),
         mistake: (_data, matches) => {
+          // Some single target damage is still marked as AOEActionEffect type 22, so check
+          // the number of targets that it hits.
+          if (parseInt(matches.targetCount) === 1)
+            return;
           return {
             type: type,
             blame: matches.target,

--- a/ui/oopsyraidsy/data/06-ew/raid/p2s.ts
+++ b/ui/oopsyraidsy/data/06-ew/raid/p2s.ts
@@ -39,8 +39,7 @@ const triggerSet: OopsyTriggerSet<Data> = {
   shareFail: {
     'P2S Kampeos Harma Square': '6824', // square dashes #1-4
     'P2S Kampeos Harma Triangle 1': '6825', // triangle circle aoes #1-3
-    // TODO: re-enable this once oopsy can ignore targetCount=1 0x16 lines
-    // 'P2S Kampeos Harma Triangle 2': '6826', // triangle circle aoes #4
+    'P2S Kampeos Harma Triangle 2': '6826', // triangle circle aoes #4
   },
   soloWarn: {
     'P2S Ominous Bubbling': '682B', // healer stacks after shockwave


### PR DESCRIPTION
Sometimes abilities are marked as AOEActionEffect but they only
have one target.  This was fixed in player_state_tracker.ts
but needed to be fixed in damage_tracker.ts as well.

This is most obvious on Ser Adelphel's Execution (62D5) ability.

This is a follow-up to #4161.