### PR TITLE
oopsy: use log lines instead of events for party tracking

### DIFF
--- a/ui/oopsyraidsy/damage_tracker.ts
+++ b/ui/oopsyraidsy/damage_tracker.ts
@@ -1,7 +1,5 @@
 import logDefinitions from '../../resources/netlog_defs';
 import NetRegexes from '../../resources/netregexes';
-import { addOverlayListener } from '../../resources/overlay_plugin_api';
-import PartyTracker from '../../resources/party';
 import { PlayerChangedDetail } from '../../resources/player_override';
 import Regexes from '../../resources/regexes';
 import { LocaleNetRegex } from '../../resources/translations';
@@ -93,7 +91,6 @@ export class DamageTracker {
   private ignoreZone = false;
   private timers: number[] = [];
   private triggers: ProcessedOopsyTrigger[] = [];
-  private partyTracker: PartyTracker;
   private playerStateTracker: PlayerStateTracker;
   private countdownEngageRegex: RegExp;
   private countdownStartRegex: RegExp;
@@ -124,16 +121,10 @@ export class DamageTracker {
     private collector: MistakeCollector,
     private dataFiles: OopsyFileData,
   ) {
-    this.partyTracker = new PartyTracker();
-    addOverlayListener('PartyChanged', (e) => {
-      this.partyTracker.onPartyChanged(e);
-      this.playerStateTracker.OnPartyChanged();
-    });
     const timestampCallback = (timestamp: number, callback: (timestamp: number) => void) =>
       this.OnRequestTimestampCallback(timestamp, callback);
     this.playerStateTracker = new PlayerStateTracker(
       this.options,
-      this.partyTracker,
       this.collector,
       timestampCallback,
     );
@@ -164,7 +155,7 @@ export class DamageTracker {
       me: this.me,
       job: this.job,
       role: this.role,
-      party: this.partyTracker,
+      party: this.playerStateTracker.partyTracker,
       inCombat: this.inCombat,
       ShortName: (name?: string) => ShortNamify(name, this.options.PlayerNicks),
       IsPlayerId: IsPlayerId,
@@ -256,6 +247,9 @@ export class DamageTracker {
           if (name !== undefined && id !== undefined)
             this.SetZone(this.lastTimestamp, name, parseInt(id, 16));
         }
+        break;
+      case logDefinitions.PartyList.type:
+        this.playerStateTracker.OnPartyList(line, splitLine);
         break;
       case logDefinitions.ChangedPlayer.type:
         this.playerStateTracker.OnChangedPlayer(line, splitLine);

--- a/ui/oopsyraidsy/player_state_tracker.ts
+++ b/ui/oopsyraidsy/player_state_tracker.ts
@@ -1,6 +1,7 @@
 import logDefinitions from '../../resources/netlog_defs';
 import { UnreachableCode } from '../../resources/not_reached';
 import PartyTracker from '../../resources/party';
+import { Party } from '../../types/event';
 import {
   DeathReportData,
   OopsyDeathReason,
@@ -84,10 +85,13 @@ export type TrackedEventType = TrackedEvent['type'];
 // * Generates some internal mistakes that need extra tracking (missed buffs, deaths)
 // * Tracks events in `trackedEvents` that can be handed to DeathReports for processing.
 export class PlayerStateTracker {
+  public partyTracker: PartyTracker;
+
   private missedBuffCollector;
   private triggerSets: ProcessedOopsyTriggerSet[] = [];
   private partyIds: Set<string> = new Set();
   private deadIds: Set<string> = new Set();
+  private idToPartyInfo: { [combatantId: string]: Party } = {};
   private petIdToOwnerId: { [petId: string]: string } = {};
   private abilityIdToBuff: { [abilityId: string]: MissableAbility } = {};
   private effectIdToBuff: { [effectId: string]: MissableEffect } = {};
@@ -110,10 +114,10 @@ export class PlayerStateTracker {
 
   constructor(
     private options: OopsyOptions,
-    private partyTracker: PartyTracker,
     private collector: MistakeCollector,
     requestTimestampCallback: RequestTimestampCallback,
   ) {
+    this.partyTracker = new PartyTracker();
     this.missedBuffCollector = new MissedBuffCollector(
       requestTimestampCallback,
       (timestamp, buff) => this.OnBuffCollected(timestamp, buff),
@@ -188,6 +192,7 @@ export class PlayerStateTracker {
   }
 
   private Reset(): void {
+    this.idToPartyInfo = {};
     this.petIdToOwnerId = {};
     this.deadIds.clear();
     this.trackedEvents = [];
@@ -200,6 +205,23 @@ export class PlayerStateTracker {
   }
 
   OnAddedCombatant(_line: string, splitLine: string[]): void {
+    const id = splitLine[logDefinitions.AddedCombatant.fields.id];
+    const name = splitLine[logDefinitions.AddedCombatant.fields.name];
+    const worldIdStr = splitLine[logDefinitions.AddedCombatant.fields.worldId];
+    const jobStr = splitLine[logDefinitions.AddedCombatant.fields.job];
+    if (
+      id !== undefined && name !== undefined &&
+      worldIdStr !== undefined && jobStr !== undefined
+    ) {
+      // Generate the party info we would get from OverlayPlugin via logs.
+      const worldId = parseInt(worldIdStr);
+      const job = parseInt(jobStr);
+      // Consider everybody in the party for now and we'll figure it out later.
+      const inParty = true;
+      this.idToPartyInfo[id] = { id, name, worldId, job, inParty };
+    }
+
+    // Track pet owners as well.
     const petId = splitLine[logDefinitions.AddedCombatant.fields.id];
     const ownerId = splitLine[logDefinitions.AddedCombatant.fields.ownerId];
     if (petId === undefined || ownerId === undefined)
@@ -209,6 +231,30 @@ export class PlayerStateTracker {
 
     // Fix any lowercase ids.
     this.petIdToOwnerId[petId.toUpperCase()] = ownerId.toUpperCase();
+  }
+
+  OnPartyList(_line: string, splitLine: string[]): void {
+    // So that party lists can be used from logs, we will fake `onPartyChanged` events
+    // using log information.  AddedCombatant seems to come before PartyList lines,
+    // so we accumulate those and then generate the party info from here.
+
+    // Start from id0 and drop the hash at the end.
+    const count = parseInt(splitLine[logDefinitions.PartyList.fields.partyCount] ?? '');
+    if (isNaN(count))
+      return;
+
+    const ids = splitLine.slice(logDefinitions.PartyList.fields.id0, -1);
+    const party: Party[] = [];
+    ids.forEach((id, idx) => {
+      const p = this.idToPartyInfo[id];
+      if (!p)
+        return;
+      // count is 1-indexed and idx is 0-indexed.
+      p.inParty = idx < count;
+      party.push(p);
+    });
+    this.partyTracker.onPartyChanged({ party });
+    this.OnPartyChanged();
   }
 
   OnChangedPlayer(_line: string, splitLine: string[]): void {


### PR DESCRIPTION
In order for the log file-based oopsy_viewer to know who is in the
party, the PartyList log lines need to be used instead of the
PartyChanged events.  For simplicity, don't support both and
switch even the live version over to the log-based tracking
so there's only one code path.