### PR TITLE
util: Fix encounter_tools encounter listing

### DIFF
--- a/util/logtools/encounter_tools.ts
+++ b/util/logtools/encounter_tools.ts
@@ -327,17 +327,17 @@ class TLFuncs {
   static leftExtendStr(str?: string, length?: number): string {
     if (str === undefined)
       return '';
-    if (length === undefined || length <= str.length)
+    if (length === undefined)
       return str;
-    return str.padStart(length - str.length, ' ');
+    return str.padStart(length, ' ');
   }
 
   static rightExtendStr(str?: string, length?: number): string {
     if (str === undefined)
       return '';
-    if (length === undefined || length <= str.length)
+    if (length === undefined)
       return str;
-    return str.padEnd(length - str.length, ' ');
+    return str.padEnd(length, ' ');
   }
 
   static generateFileName(fightOrZone: FightEncInfo | ZoneEncInfo): string {
@@ -367,7 +367,7 @@ class TLFuncs {
         const indexed = row[idx];
         if (indexed !== undefined)
           return Math.max(val, indexed);
-        return 0;
+        return val;
      });
     });
   }
@@ -461,14 +461,17 @@ class TLFuncs {
         lastDate = row[dateIdx];
         console.log(lastDate);
       }
-
       const col0 = TLFuncs.leftExtendStr(row[0], lengths[0]);
       const col1 = row[0] ? ') ' : '  ';
       const col2 = TLFuncs.leftExtendStr(row[2], lengths[2]);
       const col3 = TLFuncs.leftExtendStr(row[3], lengths[3]);
       const col4 = TLFuncs.rightExtendStr(row[4], lengths[4]);
       const col5 = row[5] ? (' ' + '[' + row[5] + ']') : '';
-      console.log(`  ${col0}${col1} ${col2} ${col3} ${col4} ${col5}`);
+      // Differentiate formatting for zone name rows vs encounter rows.
+      if (row[0] === '' && row[4] !== undefined)
+        console.log(`  ${col0}${col1} ${col2} ${col3} ${col4} ${col5}`);
+      else
+        console.log(`  ${col0}${col1} ${col2} | ${col3} | ${col4} ${col5}`);
     }
   };
 }

--- a/util/logtools/encounter_tools.ts
+++ b/util/logtools/encounter_tools.ts
@@ -44,7 +44,7 @@ const fixedTable = (data: { [index: number]: { [index: string]: string } }): voi
     r = r.replace(/^├─*┼/, '├');
     r = r.replace(/│[^│]*/, '');
     r = r.replace(/^└─*┴/, '└');
-    r = r.replace(/('|")/g, ' ');
+    r = r.replace(/(\s['"]|['"]\s)/g, '  ');
     result += `${r}\n`;
   }
   console.log(result);

--- a/util/logtools/encounter_tools.ts
+++ b/util/logtools/encounter_tools.ts
@@ -44,7 +44,12 @@ const fixedTable = (data: { [index: number]: { [index: string]: string } }): voi
     r = r.replace(/^├─*┼/, '├');
     r = r.replace(/│[^│]*/, '');
     r = r.replace(/^└─*┴/, '└');
-    r = r.replace(/(\s['"]|['"]\s)/g, '  ');
+    // console.table emits a pipe character with identifier u2502,
+    // rather than the standard u7C.
+    // If we naively just do /['"](\s+\|/ and aren't explicit about it,
+    // there's too much chance one of the consuming applications will get it wrong.
+    r = r.replace(/['"](\s+\u2502)/g, ' $1');
+    r = r.replace(/(\u2502\s+)['"]/g, '$1 ');
     result += `${r}\n`;
   }
   console.log(result);


### PR DESCRIPTION
```
2022-04-25
2022-04-24
   1)  16:56:11.436 |  2m | Thavnair                             [Zone Change]
   2)  17:25:55.837 |  1m | Eden's Gate: Descent                 [Wipe]
   3)  17:51:32.543 |  6m | Eden's Gate: Descent                 [Win]
   4)  18:25:11.796 |  7m | Alexander - The Soul of the Creator  [Win]
   5)  18:43:18.817 | 83m | Radz-at-Han                          [Zone Change]
2022-04-25
   6)  20:12:08.257 |  6m | Thavnair                             [Zone Change]

                        ~The Temple of the Fist~
2022-04-25
   7)  20:21:50.000 |  1m | Tourmaline Pond                      [Unseal]
   8)  20:27:17.000 |  2m | Harmony                              [Unseal]
   9)  20:32:32.000 |  3m | Guidance                             [Unseal]
  10)  20:42:06.077 | 62m | Radz-at-Han                          [Zone Change]

                        ~Aglaia~
2022-04-25
  11)  21:45:04.000 |  5m | Ingenuity's Foothold                 [Unseal]
  12)  21:51:07.000 |  2m | The Path                             [Unseal]
  13)  21:53:50.000 |  5m | The Monument to Destruction          [Unseal]
  14)  21:59:48.000 |  1m | The Endless City                     [Unseal]
  15)  22:02:01.000 |  6m | The Circle of Inquiry                [Unseal]
  16)  22:09:32.000 |  8m | The Twin Halls                       [Unseal]
  17)  23:05:08.000 |  1m | The command chamber                  [Unseal]
  18)  23:16:28.000 |  2m | The Laboratorium Primum              [Unseal]
  19)  23:25:53.000 |  3m | The Echelon                          [Unseal]
  ```

Primarily this was caused by forgetting that `padStart/padEnd` implicitly contain a `max(currentLength, outputLength)`. While here I also added column separators. This should resolve #4493.