### PR TITLE
raidboss: changed DCoS final boss custom text to preset

### DIFF
--- a/ui/raidboss/data/04-sb/dungeon/drowned_city_of_skalla.ts
+++ b/ui/raidboss/data/04-sb/dungeon/drowned_city_of_skalla.ts
@@ -140,17 +140,7 @@ const triggerSet: TriggerSet<Data> = {
       id: 'Skalla Words Of Woe',
       type: 'StartsUsing',
       netRegex: NetRegexes.startsUsing({ id: '2662', source: 'Hrodric Poisontongue', capture: false }),
-      infoText: (_data, _matches, output) => output.text!(),
-      outputStrings: {
-        text: {
-          en: 'avoid eye lasers',
-          de: 'Augenlaser ausweichen',
-          fr: 'Évitez les lasers',
-          ja: '前方レーザーを避ける',
-          cn: '避开眼部激光',
-          ko: '레이저 피하기',
-        },
-      },
+      response: Responses.awayFromFront(),
     },
   ],
   timelineReplace: [


### PR DESCRIPTION
As far as I can see this is pretty much a clean cut, boss turns to player and does frontal type mechanic. When I first saw the message I was trying to figure out what an eye laser was and where I should be looking.

Only concern I have is that the boss does it multiple times so the previous custom message had 'avoid eye laser**s**' whereas it would now just say 'Away From Front' 🤷‍♂️.