### PR TITLE
util: Move + centralize core date/string handling 

### DIFF
--- a/resources/datetime.ts
+++ b/resources/datetime.ts
@@ -1,0 +1,82 @@
+import StringFuncs from './stringhandlers';
+
+// For performance reasons to prevent re-calculating this every single line,
+// store already calculated values
+const tzOffsetMap: { [key: string]: number } = {};
+
+export default class DateTimeFuncs {
+  static getTimezoneOffsetMillis(timeString: string): number {
+    const timezoneOffsetString = timeString.substr(-6);
+    const mappedValue = tzOffsetMap[timezoneOffsetString];
+    if (mappedValue)
+      return mappedValue;
+    const defaultOffset = new Date().getTimezoneOffset() * 1000;
+    if (timezoneOffsetString === undefined)
+      return defaultOffset;
+    const operator = timezoneOffsetString.substr(0, 1);
+    if (operator !== '+' && operator !== '-')
+      return defaultOffset;
+    const timezoneOffsetParts = timezoneOffsetString.substr(1).split(':');
+    const hoursString = timezoneOffsetParts[0];
+    const minutesString = timezoneOffsetParts[1];
+    if (hoursString === undefined || minutesString === undefined)
+      return defaultOffset;
+    const hours = parseInt(hoursString);
+    const minutes = parseInt(minutesString);
+    const tzOffset = (((hours * 60) + minutes) * 60 * 1000) * (operator === '-' ? -1 : 1);
+    tzOffsetMap[timezoneOffsetString] = tzOffset;
+    return tzOffset;
+  }
+
+  static timeToString(time: number, includeMillis = true): string {
+    const negative = time < 0 ? '-' : '';
+    time = Math.abs(time);
+    const millisNum = time % 1000;
+    const secsNum = ((time % (60 * 1000)) - millisNum) / 1000;
+    // Milliseconds
+    const millis = `00${millisNum}`.substr(-3);
+    const secs = `0${secsNum}`.substr(-2);
+    const mins = `0${((((time % (60 * 60 * 1000)) - millisNum) / 1000) - secsNum) / 60}`.substr(-2);
+    return negative + mins + ':' + secs + (includeMillis ? '.' + millis : '');
+  }
+
+  static timeToTimeString(time: number, tzOffsetMillis: number, includeMillis = false): string {
+    return this.dateObjectToTimeString(new Date(time), tzOffsetMillis, includeMillis);
+  }
+
+  static timeStringToDateString(time: number, tzOffsetMillis: number): string {
+    return this.dateObjectToDateString(new Date(time), tzOffsetMillis);
+  }
+
+  static dateObjectToDateString(date: Date, tzOffsetMillis: number): string {
+    const convDate = new Date(date.getTime() + tzOffsetMillis);
+    const year = convDate.getUTCFullYear();
+    const month = StringFuncs.leftExtendStr((convDate.getUTCMonth() + 1).toString(), 2, '0');
+    const day = StringFuncs.leftExtendStr(convDate.getUTCDate().toString(), 2, '0');
+    return `${year}-${month}-${day}`;
+  }
+
+  static dateObjectToTimeString(date: Date, tzOffsetMillis: number, includeMillis = true): string {
+    const convDate = new Date(date.getTime() + tzOffsetMillis);
+    const hour = StringFuncs.leftExtendStr(convDate.getUTCHours().toString(), 2, '0');
+    const minute = StringFuncs.leftExtendStr(convDate.getUTCMinutes().toString(), 2, '0');
+    const second = StringFuncs.leftExtendStr(convDate.getUTCSeconds().toString(), 2, '0');
+    let ret = `${hour}:${minute}:${second}`;
+    if (includeMillis)
+      ret = ret + `.${StringFuncs.leftExtendStr(convDate.getUTCMilliseconds().toString(), 3, '0')}`;
+
+    return ret;
+  }
+
+  static msToDuration(ms: number): string {
+    const tmp = DateTimeFuncs.timeToString(ms, false);
+    return tmp.replace(':', 'm') + 's';
+  }
+
+  static dateTimeToString(time: number, tzOffsetMillis: number, includeMillis = false): string {
+    const date = new Date(time);
+    const dateString = this.dateObjectToDateString(date, tzOffsetMillis);
+    const timeString = this.dateObjectToTimeString(date, tzOffsetMillis, includeMillis);
+    return dateString + ' ' + timeString;
+  }
+}

--- a/resources/stringhandlers.ts
+++ b/resources/stringhandlers.ts
@@ -1,0 +1,29 @@
+class StringFuncs {
+  static zeroPad(str: string, len = 2): string {
+    return ('' + str).padStart(len, '0');
+  }
+
+  static toProperCase(str: string): string {
+    return str.replace(/([^\W_]+[^\s-]*) */g, (txt) => {
+      return txt.charAt(0).toUpperCase() + txt.substr(1).toLowerCase();
+    });
+  }
+
+  static leftExtendStr(str?: string, length?: number, padChar = ' '): string {
+    if (str === undefined)
+      return '';
+    if (length === undefined)
+      return str;
+    return str.padStart(length, padChar);
+  }
+
+  static rightExtendStr(str?: string, length?: number, padChar = ' '): string {
+    if (str === undefined)
+      return '';
+    if (length === undefined)
+      return str;
+    return str.padEnd(length, padChar);
+  }
+}
+
+export default StringFuncs;

--- a/ui/raidboss/emulator/EmulatorCommon.ts
+++ b/ui/raidboss/emulator/EmulatorCommon.ts
@@ -58,33 +58,6 @@ export const cloneSafe = (node: HTMLElement): HTMLElement => {
   return cloned;
 };
 
-// For performance reasons to prevent re-calculating this every single line,
-// store already calculated values
-const tzOffsetMap: { [key: string]: number } = {};
-
-export const getTimezoneOffsetMillis = (timeString: string): number => {
-  const timezoneOffsetString = timeString.substr(-6);
-  const mappedValue = tzOffsetMap[timezoneOffsetString];
-  if (mappedValue)
-    return mappedValue;
-  const defaultOffset = new Date().getTimezoneOffset() * 1000;
-  if (timezoneOffsetString === undefined)
-    return defaultOffset;
-  const operator = timezoneOffsetString.substr(0, 1);
-  if (operator !== '+' && operator !== '-')
-    return defaultOffset;
-  const timezoneOffsetParts = timezoneOffsetString.substr(1).split(':');
-  const hoursString = timezoneOffsetParts[0];
-  const minutesString = timezoneOffsetParts[1];
-  if (hoursString === undefined || minutesString === undefined)
-    return defaultOffset;
-  const hours = parseInt(hoursString);
-  const minutes = parseInt(minutesString);
-  const tzOffset = (((hours * 60) + minutes) * 60 * 1000) * (operator === '-' ? -1 : 1);
-  tzOffsetMap[timezoneOffsetString] = tzOffset;
-  return tzOffset;
-};
-
 export default class EmulatorCommon {
   static cloneData(data: DataType, exclude = ['options', 'party']): DataType {
     const ret: DataType = {};
@@ -138,72 +111,6 @@ export default class EmulatorCommon {
       return ret;
     }
     return data;
-  }
-
-  static timeToString(time: number, includeMillis = true): string {
-    const negative = time < 0 ? '-' : '';
-    time = Math.abs(time);
-    const millisNum = time % 1000;
-    const secsNum = ((time % (60 * 1000)) - millisNum) / 1000;
-    // Milliseconds
-    const millis = `00${millisNum}`.substr(-3);
-    const secs = `0${secsNum}`.substr(-2);
-    const mins = `0${((((time % (60 * 60 * 1000)) - millisNum) / 1000) - secsNum) / 60}`.substr(-2);
-    return negative + mins + ':' + secs + (includeMillis ? '.' + millis : '');
-  }
-
-  static timeToDateString(time: number, tzOffsetMillis: number): string {
-    return this.dateObjectToDateString(new Date(time), tzOffsetMillis);
-  }
-
-  static dateObjectToDateString(date: Date, tzOffsetMillis: number): string {
-    const convDate = new Date(date.getTime() + tzOffsetMillis);
-    const year = convDate.getUTCFullYear();
-    const month = EmulatorCommon.zeroPad((convDate.getUTCMonth() + 1).toString());
-    const day = EmulatorCommon.zeroPad(convDate.getUTCDate().toString());
-    return `${year}-${month}-${day}`;
-  }
-
-  static timeToTimeString(time: number, tzOffsetMillis: number, includeMillis = false): string {
-    return this.dateObjectToTimeString(new Date(time), tzOffsetMillis, includeMillis);
-  }
-
-  static dateObjectToTimeString(date: Date, tzOffsetMillis: number, includeMillis = false): string {
-    const convDate = new Date(date.getTime() + tzOffsetMillis);
-    const hour = EmulatorCommon.zeroPad(convDate.getUTCHours().toString());
-    const minute = EmulatorCommon.zeroPad(convDate.getUTCMinutes().toString());
-    const second = EmulatorCommon.zeroPad(convDate.getUTCSeconds().toString());
-    let ret = `${hour}:${minute}:${second}`;
-    if (includeMillis)
-      ret = ret + `.${EmulatorCommon.zeroPad(convDate.getUTCMilliseconds().toString(), 3)}`;
-
-    return ret;
-  }
-
-  static msToDuration(ms: number): string {
-    const tmp = EmulatorCommon.timeToString(ms, false);
-    return tmp.replace(':', 'm') + 's';
-  }
-
-  static dateTimeToString(time: number, tzOffsetMillis: number, includeMillis = false): string {
-    const date = new Date(time);
-    const dateString = this.dateObjectToDateString(date, tzOffsetMillis);
-    const timeString = this.dateObjectToTimeString(date, tzOffsetMillis, includeMillis);
-    return dateString + ' ' + timeString;
-  }
-
-  static zeroPad(str: string, len = 2): string {
-    return ('' + str).padStart(len, '0');
-  }
-
-  static properCase(str: string): string {
-    return str.replace(/([^\W_]+[^\s-]*) */g, (txt) => {
-      return txt.charAt(0).toUpperCase() + txt.substr(1).toLowerCase();
-    });
-  }
-
-  static spacePadLeft(str: string, len: number): string {
-    return str.padStart(len, ' ');
   }
 
   static doesLineMatch<T extends TriggerTypes>(

--- a/ui/raidboss/emulator/data/network_log_converter/LineEvent.ts
+++ b/ui/raidboss/emulator/data/network_log_converter/LineEvent.ts
@@ -1,6 +1,7 @@
+import DTFuncs from '../../../../../resources/datetime';
 import logDefinitions, { LogDefinitionMap } from '../../../../../resources/netlog_defs';
+import SFuncs from '../../../../../resources/stringhandlers';
 import { Job } from '../../../../../types/job';
-import EmulatorCommon, { getTimezoneOffsetMillis } from '../../EmulatorCommon';
 
 import { LineEvent0x03 } from './LineEvent0x03';
 import LogRepository from './LogRepository';
@@ -34,10 +35,10 @@ export default class LineEvent {
 
   constructor(repo: LogRepository, public networkLine: string, parts: string[]) {
     const timestampString = parts[fields.timestamp] ?? '0';
-    this.tzOffsetMillis = getTimezoneOffsetMillis(timestampString);
+    this.tzOffsetMillis = DTFuncs.getTimezoneOffsetMillis(timestampString);
     this.decEventStr = parts[fields.event] ?? '00';
     this.decEvent = parseInt(this.decEventStr);
-    this.hexEvent = EmulatorCommon.zeroPad(this.decEvent.toString(16).toUpperCase());
+    this.hexEvent = SFuncs.zeroPad(this.decEvent.toString(16).toUpperCase());
     this.timestamp = new Date(timestampString).getTime();
     this.checksum = parts.slice(-1)[0] ?? '';
     repo.updateTimestamp(this.timestamp);
@@ -45,7 +46,7 @@ export default class LineEvent {
   }
 
   prefix(): string {
-    const timeString = EmulatorCommon.timeToTimeString(this.timestamp, this.tzOffsetMillis, true);
+    const timeString = DTFuncs.timeToTimeString(this.timestamp, this.tzOffsetMillis, true);
     const logMessageName = logMessagePrefix[this.decEventStr] ?? unknownLogMessagePrefix;
     return `[${timeString}] ${logMessageName} ${this.hexEvent}:`;
   }
@@ -62,7 +63,7 @@ export default class LineEvent {
     if (LineEvent.isDamageHallowed(damage))
       return 0;
 
-    damage = EmulatorCommon.zeroPad(damage, 8);
+    damage = SFuncs.zeroPad(damage, 8);
     const parts = [
       damage.substr(0, 2),
       damage.substr(2, 2),

--- a/ui/raidboss/emulator/data/network_log_converter/LineEvent0x01.ts
+++ b/ui/raidboss/emulator/data/network_log_converter/LineEvent0x01.ts
@@ -1,5 +1,5 @@
 import logDefinitions from '../../../../../resources/netlog_defs';
-import EmulatorCommon from '../../EmulatorCommon';
+import SFuncs from '../../../../../resources/stringhandlers';
 
 import LineEvent from './LineEvent';
 import LogRepository from './LogRepository';
@@ -17,7 +17,7 @@ export class LineEvent0x01 extends LineEvent {
 
     this.zoneId = parts[fields.id] ?? '';
     this.zoneName = parts[fields.name] ?? '';
-    this.zoneNameProperCase = EmulatorCommon.properCase(this.zoneName);
+    this.zoneNameProperCase = SFuncs.toProperCase(this.zoneName);
   }
 }
 

--- a/ui/raidboss/emulator/data/network_log_converter/LineEvent0x1F.ts
+++ b/ui/raidboss/emulator/data/network_log_converter/LineEvent0x1F.ts
@@ -1,5 +1,5 @@
 import logDefinitions from '../../../../../resources/netlog_defs';
-import EmulatorCommon from '../../EmulatorCommon';
+import SFuncs from '../../../../../resources/stringhandlers';
 
 import LineEvent from './LineEvent';
 import LogRepository from './LogRepository';
@@ -28,10 +28,10 @@ export class LineEvent0x1F extends LineEvent {
     super(repo, line, parts);
 
     this.id = parts[fields.id]?.toUpperCase() ?? '';
-    this.dataBytes1 = EmulatorCommon.zeroPad(parts[fields.data0] ?? '');
-    this.dataBytes2 = EmulatorCommon.zeroPad(parts[fields.data1] ?? '');
-    this.dataBytes3 = EmulatorCommon.zeroPad(parts[fields.data2] ?? '');
-    this.dataBytes4 = EmulatorCommon.zeroPad(parts[fields.data3] ?? '');
+    this.dataBytes1 = SFuncs.zeroPad(parts[fields.data0] ?? '');
+    this.dataBytes2 = SFuncs.zeroPad(parts[fields.data1] ?? '');
+    this.dataBytes3 = SFuncs.zeroPad(parts[fields.data2] ?? '');
+    this.dataBytes4 = SFuncs.zeroPad(parts[fields.data3] ?? '');
 
     this.jobGaugeBytes = [
       ...splitFunc(this.dataBytes1),

--- a/ui/raidboss/emulator/data/network_log_converter/LineEvent0x26.ts
+++ b/ui/raidboss/emulator/data/network_log_converter/LineEvent0x26.ts
@@ -1,7 +1,7 @@
 import logDefinitions from '../../../../../resources/netlog_defs';
+import SFuncs from '../../../../../resources/stringhandlers';
 import Util from '../../../../../resources/util';
 import { Job } from '../../../../../types/job';
-import EmulatorCommon from '../../EmulatorCommon';
 
 import LineEvent, { LineEventJobLevel, LineEventSource } from './LineEvent';
 import LogRepository from './LogRepository';
@@ -45,7 +45,7 @@ export class LineEvent0x26 extends LineEvent implements LineEventSource, LineEve
     this.z = parseFloat(parts[fields.z] ?? '');
     this.heading = parseFloat(parts[fields.heading] ?? '');
 
-    const padded = EmulatorCommon.zeroPad(this.jobLevelData, 8);
+    const padded = SFuncs.zeroPad(this.jobLevelData, 8);
 
     this.jobIdHex = padded.substr(6, 2).toUpperCase();
     this.jobId = parseInt(this.jobIdHex, 16);

--- a/ui/raidboss/emulator/ui/EmulatedPartyInfo.ts
+++ b/ui/raidboss/emulator/ui/EmulatedPartyInfo.ts
@@ -1,8 +1,10 @@
+import DTFuncs from '../../../../resources/datetime';
 import { UnreachableCode } from '../../../../resources/not_reached';
+import SFuncs from '../../../../resources/stringhandlers';
 import Util from '../../../../resources/util';
 import AnalyzedEncounter, { PerspectiveTrigger } from '../data/AnalyzedEncounter';
 import RaidEmulator from '../data/RaidEmulator';
-import EmulatorCommon, { cloneSafe, getTemplateChild, querySelectorSafe } from '../EmulatorCommon';
+import { cloneSafe, getTemplateChild, querySelectorSafe } from '../EmulatorCommon';
 import EventBus from '../EventBus';
 
 import Tooltip from './Tooltip';
@@ -285,13 +287,13 @@ export default class EmulatedPartyInfo extends EventBus {
 
     const hpProg = (State.hp / State.maxHp) * 100;
     let hpLabel = `${State.hp}/${State.maxHp}`;
-    hpLabel = EmulatorCommon.spacePadLeft(hpLabel, (State.maxHp.toString().length * 2) + 1);
+    hpLabel = SFuncs.leftExtendStr(hpLabel, (State.maxHp.toString().length * 2) + 1, ' ');
     display.$hpProgElem.style.width = `${hpProg}%`;
     display.$hpLabelElem.textContent = hpLabel;
 
     const mpProg = (State.mp / State.maxMp) * 100;
     let mpLabel = `${State.mp}/${State.maxMp}`;
-    mpLabel = EmulatorCommon.spacePadLeft(mpLabel, (State.maxMp.toString().length * 2) + 1);
+    mpLabel = SFuncs.leftExtendStr(mpLabel, (State.maxMp.toString().length * 2) + 1, ' ');
     display.$mpProgElem.style.width = `${mpProg}%`;
     display.$mpLabelElem.textContent = mpLabel;
   }
@@ -382,7 +384,7 @@ export default class EmulatedPartyInfo extends EventBus {
     $finalDataViewer.textContent = JSON.stringify(per.finalData, null, 2);
 
     $container.append(this._wrapCollapse({
-      time: EmulatorCommon.timeToString(
+      time: DTFuncs.timeToString(
         encounter.encounter.duration - encounter.encounter.initialOffset,
         false,
       ),
@@ -414,14 +416,14 @@ export default class EmulatedPartyInfo extends EventBus {
   }
 
   getTriggerFiredLabelTime(trigger: PerspectiveTrigger): string {
-    return EmulatorCommon.timeToString(
+    return DTFuncs.timeToString(
       trigger.logLine.offset - (this.emulator.currentEncounter?.encounter.initialOffset ?? 0),
       false,
     );
   }
 
   getTriggerResolvedLabelTime(trigger: PerspectiveTrigger): string {
-    return EmulatorCommon.timeToString(
+    return DTFuncs.timeToString(
       trigger.resolvedOffset - (this.emulator.currentEncounter?.encounter.initialOffset ?? 0),
       false,
     );

--- a/ui/raidboss/emulator/ui/EncounterTab.ts
+++ b/ui/raidboss/emulator/ui/EncounterTab.ts
@@ -1,11 +1,8 @@
+import DTFuncs from '../../../../resources/datetime';
 import { UnreachableCode } from '../../../../resources/not_reached';
 import Persistor from '../data/Persistor';
 import PersistorEncounter from '../data/PersistorEncounter';
-import EmulatorCommon, {
-  getTemplateChild,
-  querySelectorAllSafe,
-  querySelectorSafe,
-} from '../EmulatorCommon';
+import { getTemplateChild, querySelectorAllSafe, querySelectorSafe } from '../EmulatorCommon';
 import EventBus from '../EventBus';
 
 type DateMap = {
@@ -57,9 +54,9 @@ export default class EncounterTab extends EventBus {
       for (const enc of encounters) {
         const zone = enc.zoneName;
         // ?? operator here to account for old encounters that don't have the property
-        const encDate = EmulatorCommon.timeToDateString(enc.start, enc.tzOffsetMillis ?? 0);
-        const encTime = EmulatorCommon.timeToTimeString(enc.start, enc.tzOffsetMillis ?? 0);
-        const encDuration = EmulatorCommon.msToDuration(enc.duration);
+        const encDate = DTFuncs.timeStringToDateString(enc.start, enc.tzOffsetMillis ?? 0);
+        const encTime = DTFuncs.timeToTimeString(enc.start, enc.tzOffsetMillis ?? 0);
+        const encDuration = DTFuncs.msToDuration(enc.duration);
         const zoneObj = this.encounters[zone] = this.encounters[zone] || {};
         const dateObj = zoneObj[encDate] = zoneObj[encDate] || [];
         dateObj.push({
@@ -235,7 +232,7 @@ export default class EncounterTab extends EventBus {
 
     let pullAt = 'N/A';
     if (!isNaN(enc.offset))
-      pullAt = EmulatorCommon.timeToString(enc.offset, false);
+      pullAt = DTFuncs.timeToString(enc.offset, false);
 
     const $info = this.$encounterInfoTemplate.cloneNode(true);
     if (!($info instanceof HTMLElement))
@@ -255,9 +252,9 @@ export default class EncounterTab extends EventBus {
     });
     querySelectorSafe($info, '.encounterZone .label').textContent = enc.zoneName;
     // ?? operator here to account for old encounters that don't have the property
-    querySelectorSafe($info, '.encounterStart .label').textContent = EmulatorCommon
+    querySelectorSafe($info, '.encounterStart .label').textContent = DTFuncs
       .dateTimeToString(enc.start, enc.tzOffsetMillis ?? 0);
-    querySelectorSafe($info, '.encounterDuration .label').textContent = EmulatorCommon.timeToString(
+    querySelectorSafe($info, '.encounterDuration .label').textContent = DTFuncs.timeToString(
       enc.duration,
       false,
     );

--- a/ui/raidboss/emulator/ui/ProgressBar.ts
+++ b/ui/raidboss/emulator/ui/ProgressBar.ts
@@ -1,7 +1,8 @@
+import DTFuncs from '../../../../resources/datetime';
 import { UnreachableCode } from '../../../../resources/not_reached';
 import AnalyzedEncounter from '../data/AnalyzedEncounter';
 import RaidEmulator from '../data/RaidEmulator';
-import EmulatorCommon, { querySelectorSafe } from '../EmulatorCommon';
+import { querySelectorSafe } from '../EmulatorCommon';
 
 import Tooltip from './Tooltip';
 
@@ -32,7 +33,7 @@ export default class ProgressBar {
         const time = Math.floor(emulator.currentEncounter.encounter.duration * percent) -
           emulator.currentEncounter.encounter.initialOffset;
         this.$progressBarTooltip.offset.x = e.offsetX - (target.offsetWidth / 2);
-        this.$progressBarTooltip.setText(EmulatorCommon.timeToString(time));
+        this.$progressBarTooltip.setText(DTFuncs.timeToString(time));
         this.$progressBarTooltip.show();
       }
     });
@@ -47,8 +48,8 @@ export default class ProgressBar {
       }
     });
     emulator.on('currentEncounterChanged', (encounter: AnalyzedEncounter) => {
-      this.$progressBarCurrent.textContent = EmulatorCommon.timeToString(0, false);
-      this.$progressBarDuration.textContent = EmulatorCommon.timeToString(
+      this.$progressBarCurrent.textContent = DTFuncs.timeToString(0, false);
+      this.$progressBarDuration.textContent = DTFuncs.timeToString(
         encounter.encounter.duration - encounter.encounter.initialOffset,
         false,
       );
@@ -70,7 +71,7 @@ export default class ProgressBar {
       const currentOffset = currentLogTime - curEnc.encounter.startTimestamp;
       const progPercent = (currentOffset / curEnc.encounter.duration) * 100;
       const progValue = currentLogTime - curEnc.encounter.initialTimestamp;
-      this.$progressBarCurrent.textContent = EmulatorCommon.timeToString(progValue, false);
+      this.$progressBarCurrent.textContent = DTFuncs.timeToString(progValue, false);
       this.$progressBar.style.width = `${progPercent}%`;
     });
     const $play = querySelectorSafe(document, '.progress-bar-row button.play');

--- a/ui/raidboss/raidemulator.ts
+++ b/ui/raidboss/raidemulator.ts
@@ -1,5 +1,5 @@
 import './raidboss_config';
-
+import DTFuncs from '../../resources/datetime';
 import { isLang, Lang, langMap } from '../../resources/languages';
 import { UnreachableCode } from '../../resources/not_reached';
 import { callOverlayHandler } from '../../resources/overlay_plugin_api';
@@ -13,7 +13,7 @@ import Encounter from './emulator/data/Encounter';
 import LineEvent from './emulator/data/network_log_converter/LineEvent';
 import Persistor from './emulator/data/Persistor';
 import RaidEmulator from './emulator/data/RaidEmulator';
-import EmulatorCommon, {
+import {
   getTemplateChild,
   querySelectorAllSafe,
   querySelectorSafe,
@@ -353,14 +353,14 @@ const raidEmulatorOnLoad = async () => {
                 .toString();
               querySelectorSafe(encLabel, '.end').innerText = new Date(enc.endTimestamp).toString();
 
-              const duration = EmulatorCommon.timeToString(
+              const duration = DTFuncs.timeToString(
                 enc.endTimestamp - enc.startTimestamp,
                 false,
               )
                 .split(':');
               const durationMins = duration[0] ?? '0';
               const durationSecs = duration[1] ?? '00';
-              const pullDuration = EmulatorCommon.timeToString(
+              const pullDuration = DTFuncs.timeToString(
                 enc.endTimestamp - enc.initialTimestamp,
                 false,
               )

--- a/util/logtools/make_timeline.ts
+++ b/util/logtools/make_timeline.ts
@@ -5,6 +5,7 @@ import { Namespace } from 'argparse';
 
 import NetRegexes from '../../resources/netregexes';
 import PetData from '../../resources/pet_names';
+import SFuncs from '../../resources/stringhandlers';
 import { NetMatches } from '../../types/net_matches';
 
 import { LogUtilArgParse, TimelineArgs } from './arg_parser';
@@ -358,7 +359,7 @@ const assembleTimelineStrings = (
   let timelinePosition = 0;
   let lastEntry: TimelineEntry = { time: lastAbilityTime.toString(), lineType: 'None' };
   if (fight.sealName) {
-    const zoneMessage = TLFuncs.toProperCase(fight.sealName);
+    const zoneMessage = SFuncs.toProperCase(fight.sealName);
     const tlString = `0.0 "--sync--" sync / 00:0839::${zoneMessage} will be sealed off/ window 0,1`;
     assembled.push(tlString);
   } else {


### PR DESCRIPTION
(*Ping @valarnin, since you probably have the best idea of whether anything I've touched here breaks things.*)

Mostly self-explanatory. I changed a couple of date/time function names to make What They Do slightly easier to follow, but apart from that it's largely simple movement. I'm not strongly attached to the choices I made here, so please offer all the criticisms. In particular, I'm not really sure about all the names I assigned here. (Should I have/have not have aliased the imports? Are some of the function names too long? etc)

(It's noted in-line, but I absolutely do not intend `getTZOffsetFromLogLine` to permanently use naive string parsing to extract a timestamp. Once we get the line parser disentangled from the emulator I'll gladly swap over to using that, but I don't know the emulator well enough to attempt that in this submission.)