### PR TITLE
raidboss: DSR DFG minor improvements

### DIFF
--- a/ui/raidboss/data/06-ew/ultimate/dragonsongs_reprise_ultimate.ts
+++ b/ui/raidboss/data/06-ew/ultimate/dragonsongs_reprise_ultimate.ts
@@ -921,27 +921,27 @@ const triggerSet: TriggerSet<Data> = {
         if (matches.id === '6715') {
           data.diveFromGraceLashGnashKey = 'in';
           if (data.eyeOfTheTyrantCounter === 1 && num === 3)
-            return output.inOutThenBait!({ inout: output.in!() });
+            return output.inOutAndBait!({ inout: output.in!() });
           if (data.eyeOfTheTyrantCounter === 2) {
             if (num === 2 || (num === 1 && data.diveFromGracePreviousPosition[data.me] === 'middle'))
-              return output.inOutThenBait!({ inout: output.in!() });
+              return output.inOutAndBait!({ inout: output.in!() });
           }
           return output.in!();
         }
         data.diveFromGraceLashGnashKey = 'out';
         if (data.eyeOfTheTyrantCounter === 1 && num === 3)
-          return output.inOutThenBait!({ inout: output.out!() });
+          return output.inOutAndBait!({ inout: output.out!() });
         if (data.eyeOfTheTyrantCounter === 2) {
           if (num === 2 || (num === 1 && data.diveFromGracePreviousPosition[data.me] === 'middle'))
-            return output.inOutThenBait!({ inout: output.out!() });
+            return output.inOutAndBait!({ inout: output.out!() });
         }
         return output.out!();
       },
       outputStrings: {
         out: Outputs.out,
         in: Outputs.in,
-        inOutThenBait: {
-          en: '${inout} => Bait',
+        inOutAndBait: {
+          en: '${inout} + Bait',
         },
       },
     },

--- a/ui/raidboss/data/06-ew/ultimate/dragonsongs_reprise_ultimate.ts
+++ b/ui/raidboss/data/06-ew/ultimate/dragonsongs_reprise_ultimate.ts
@@ -1254,24 +1254,7 @@ const triggerSet: TriggerSet<Data> = {
       preRun: (data) => data.diveFromGraceTowerCounter = (data.diveFromGraceTowerCounter ?? 0) + 1,
       delaySeconds: 0.2,
       suppressSeconds: 1,
-      response: (data, _matches, output) => {
-        // cactbot-builtin-response
-        output.responseOutputStrings = {
-          unknown: Outputs.unknown,
-          stackNorth: {
-            en: 'Stack North',
-          },
-          unknownTower: {
-            en: 'Tower',
-          },
-          northwestTower2: {
-            en: 'Northwest Tower',
-          },
-          northeastTower2: {
-            en: 'Northeast Tower',
-          },
-        };
-
+      alertText: (data, _matches, output) => {
         const num = data.diveFromGraceNum[data.me];
         if (!num) {
           console.error(`DFG Tower 1 and 2: missing number: ${JSON.stringify(data.diveFromGraceNum)}`);
@@ -1302,24 +1285,29 @@ const triggerSet: TriggerSet<Data> = {
           data.diveFromGracePreviousPosition[nameB] = 'east';
         }
 
-        if (data.diveFromGraceTowerCounter === 1) {
-          if (num === 1 && data.diveFromGracePreviousPosition[data.me] === 'middle')
-            return { infoText: output.stackNorth!() };
-        } else if (data.diveFromGraceTowerCounter === 2) {
-          if (num === 1) {
-            if (data.diveFromGracePreviousPosition[data.me] === 'west')
-              return { alertText: output.northwestTower2!() };
-            if (data.diveFromGracePreviousPosition[data.me] === 'east')
-              return { alertText: output.northeastTower2!() };
-            if (data.diveFromGracePreviousPosition[data.me] === 'middle')
-              return;
-            return { alertText: output.unknownTower!() };
-          } else if (num === 2) {
-            return { infoText: output.stackNorth!() };
-          }
+        if (num === 1 && data.diveFromGraceTowerCounter === 2) {
+          if (data.diveFromGracePreviousPosition[data.me] === 'west')
+            return output.northwestTower2!();
+          if (data.diveFromGracePreviousPosition[data.me] === 'east')
+            return output.northeastTower2!();
+          if (data.diveFromGracePreviousPosition[data.me] === 'middle')
+            return;
+          return output.unknownTower!();
         }
       },
       run: (data) => data.diveFromGracePositions = {},
+      outputStrings: {
+        unknown: Outputs.unknown,
+        unknownTower: {
+          en: 'Tower',
+        },
+        northwestTower2: {
+          en: 'Northwest Tower',
+        },
+        northeastTower2: {
+          en: 'Northeast Tower',
+        },
+      },
     },
     {
       id: 'DSR Darkdragon Dive Single Tower',

--- a/ui/raidboss/data/06-ew/ultimate/dragonsongs_reprise_ultimate.ts
+++ b/ui/raidboss/data/06-ew/ultimate/dragonsongs_reprise_ultimate.ts
@@ -1055,10 +1055,10 @@ const triggerSet: TriggerSet<Data> = {
           en: 'Bait => Stack => ${inout}',
         },
         circlesDive1: {
-          en: 'Dive (circles) => ${inout}',
+          en: 'Dive (all circles) => ${inout}',
         },
         circlesDive3: {
-          en: 'Dive (circles) => ${inout}',
+          en: 'Dive (all circles) => ${inout}',
         },
         southDive1: {
           en: 'South Dive => ${inout}',
@@ -1097,7 +1097,7 @@ const triggerSet: TriggerSet<Data> = {
             en: '${inout} + Bait',
           },
           circlesDive2: {
-            en: '${inout} => Dive (circles)',
+            en: '${inout} => Dive (all circles)',
           },
           upArrowDive2: {
             en: '${inout} => Up Arrow Dive',
@@ -1216,10 +1216,10 @@ const triggerSet: TriggerSet<Data> = {
           en: 'South Tower (${inout})',
         },
         circleTowers1: {
-          en: 'Towers (circles, ${inout})',
+          en: 'Tower (all circles, ${inout})',
         },
         circleTowers3: {
-          en: 'Towers (circles, ${inout})',
+          en: 'Tower (all circles, ${inout})',
         },
         upArrowTower1: {
           en: 'Up Arrow Tower (${inout})',

--- a/ui/raidboss/data/06-ew/ultimate/dragonsongs_reprise_ultimate.ts
+++ b/ui/raidboss/data/06-ew/ultimate/dragonsongs_reprise_ultimate.ts
@@ -915,12 +915,9 @@ const triggerSet: TriggerSet<Data> = {
       // These are ~3s apart.  Only call after the first (and ignore multiple people getting hit).
       suppressSeconds: 6,
       infoText: (data, matches, output) => {
-        let num = data.diveFromGraceNum[data.me];
-        if (!num) {
+        const num = data.diveFromGraceNum[data.me];
+        if (num === undefined)
           console.error(`DSR Lash Gnash Followup: missing number: ${JSON.stringify(data.diveFromGraceNum)}`);
-          // Set to 0 to output default in/out
-          num = 0;
-        }
         if (matches.id === '6715') {
           data.diveFromGraceLashGnashKey = 'in';
           if (data.eyeOfTheTyrantCounter === 1 && num === 3)

--- a/ui/raidboss/data/06-ew/ultimate/dragonsongs_reprise_ultimate.ts
+++ b/ui/raidboss/data/06-ew/ultimate/dragonsongs_reprise_ultimate.ts
@@ -1115,7 +1115,8 @@ const triggerSet: TriggerSet<Data> = {
       outputStrings: diveFromGraceTowerOutputStrings,
     },
     {
-      id: 'DSR Dive From Grace Tower 2 and Stacks',
+      // Callouts after the first and second dives.
+      id: 'DSR Dive From Grace Tower 1 and 2',
       // 670E Dark High Jump
       // 670F Dark Spineshatter Dive
       // 6710 Dark Elusive Jump
@@ -1130,85 +1131,36 @@ const triggerSet: TriggerSet<Data> = {
       infoText: (data, _matches, output) => {
         const num = data.diveFromGraceNum[data.me];
         if (!num) {
-          console.error(`DFG Tower 2 and 3: missing number: ${JSON.stringify(data.diveFromGraceNum)}`);
+          console.error(`DFG Tower 1 and 2: missing number: ${JSON.stringify(data.diveFromGraceNum)}`);
           return;
         }
 
-        // Map position values and player name keys to arrays
-        const [posA, posB, posC] = Object.values(data.diveFromGracePositions);
-        let [nameA, nameB, nameC] = Object.keys(data.diveFromGracePositions);
-
-        // If undefined position, will not be able to predict position
-        const posAX = posA ?? 0;
-        const posBX = posB ?? 0;
-        const posCX = posC ?? 0;
-
-        // If undefined keys, map to non-player names
-        if (nameA === undefined)
-          nameA = output.unknown!();
-        if (nameB === undefined)
-          nameB = output.unknown!();
-        if (nameC === undefined)
-          nameC = output.unknown!();
+        // Sorted from west to east, and filled in with unknown if missing.
+        const [nameA, nameB, nameC] = [
+          ...Object.keys(data.diveFromGracePositions).sort((keyA, keyB) => {
+            const posA = data.diveFromGracePositions[keyA];
+            const posB = data.diveFromGracePositions[keyB];
+            if (posA === undefined || posB === undefined)
+              return 0;
+            return posA - posB;
+          }),
+          output.unknown!(),
+          output.unknown!(),
+          output.unknown!(),
+        ];
 
         // Dive 1 and Dive 3 have 3 players
         if (data.diveFromGraceTowerCounter !== 2) {
-          // Get the posX of each player hitby dive
-          const positionsX = [posAX, posBX, posCX];
-
-          // Sort the the posX values, highest to lowest
-          const sorted = positionsX.sort((a, b) => b - a);
-
-          // Highest value = east
-          switch (sorted[0]) {
-            case posAX:
-              data.diveFromGracePreviousPosition[nameA] = 'east';
-              break;
-            case posBX:
-              data.diveFromGracePreviousPosition[nameB] = 'east';
-              break;
-            case posCX:
-              data.diveFromGracePreviousPosition[nameC] = 'east';
-              break;
-          }
-          // Middle value = middle
-          switch (sorted[1]) {
-            case posAX:
-              data.diveFromGracePreviousPosition[nameA] = 'middle';
-              break;
-            case posBX:
-              data.diveFromGracePreviousPosition[nameB] = 'middle';
-              break;
-            case posCX:
-              data.diveFromGracePreviousPosition[nameC] = 'middle';
-              break;
-          }
-          // Lowest value = west
-          switch (sorted[2]) {
-            case posAX:
-              data.diveFromGracePreviousPosition[nameA] = 'west';
-              break;
-            case posBX:
-              data.diveFromGracePreviousPosition[nameB] = 'west';
-              break;
-            case posCX:
-              data.diveFromGracePreviousPosition[nameC] = 'west';
-              break;
-          }
+          data.diveFromGracePreviousPosition[nameA] = 'west';
+          data.diveFromGracePreviousPosition[nameB] = 'middle';
+          data.diveFromGracePreviousPosition[nameC] = 'east';
         } else {
-          // Only comparing X values for Dive 2
-          if (posAX < posBX) {
-            data.diveFromGracePreviousPosition[nameA] = 'west';
-            data.diveFromGracePreviousPosition[nameB] = 'east';
-          } else {
-            data.diveFromGracePreviousPosition[nameB] = 'west';
-            data.diveFromGracePreviousPosition[nameA] = 'east';
-          }
+          data.diveFromGracePreviousPosition[nameA] = 'west';
+          data.diveFromGracePreviousPosition[nameB] = 'east';
         }
 
         // First Dive, on num1s
         if (data.diveFromGraceTowerCounter === 1) {
-          // Stack or Move
           if (num === 1) {
             // Stack => Predict Tower 3
             if (data.diveFromGracePreviousPosition[data.me] === 'middle')
@@ -1218,9 +1170,8 @@ const triggerSet: TriggerSet<Data> = {
 
         // Second Dive, on num2s
         if (data.diveFromGraceTowerCounter === 2) {
-          // Call stack for 2s
           if (num === 2)
-            return output.stack!();
+            return output.stackNorth!();
 
           // Call Tower 2 Soak (based on previous position)
           if (num === 1) {
@@ -1234,7 +1185,6 @@ const triggerSet: TriggerSet<Data> = {
       run: (data) => data.diveFromGracePositions = {},
       outputStrings: {
         unknown: Outputs.unknown,
-        stack: Outputs.stackMarker,
         stackNorth: {
           en: 'Stack North',
         },


### PR DESCRIPTION
This is a series of opinionated commits to add some minor improvements to #4435.

In particular:
* merges the "dive" callout into the In+Out (or In+Out followup) calls
* uses alert in more places
* more specialized logic for two baiters/placers
* simplifies the position sorting logic

without this PR side 1:
![image](https://user-images.githubusercontent.com/462317/170571913-ac40e6b5-e6b7-4d98-94f5-f09a71d243f5.png)

with this PR side 1:
![image](https://user-images.githubusercontent.com/462317/170570825-1cefa494-28e3-42c9-a80b-380473df4ea7.png)

without this PR 2:
![image](https://user-images.githubusercontent.com/462317/170572113-983cb333-e6fd-445c-8c26-5473bb2b983a.png)

with this PR 2:
![image](https://user-images.githubusercontent.com/462317/170570627-37d75349-95bd-418c-8c75-1b59db5fd0bb.png)

(One other thought is maybe the "1 (all circles)" call should be combined with "Dive (circles) => Out" a second later? Or is it worth having the 1-2 second warning there but a duplicate call? Should there be another out/in reminder after the stack or a dive, e.g. dive => out, out, in vs just dive => out, in (10 seconds later)? Also, the `Dir Group` call is a personal trigger, in case there's confusion.)