### PR TITLE
Update p3s Cinderwing correction direction in p3s.js

### DIFF
--- a/06-ew/raid/p3s.js
+++ b/06-ew/raid/p3s.js
@@ -112,13 +112,13 @@ Options.Triggers.push({
       id: 'P3S Right Cinderwing',
       type: 'StartsUsing',
       netRegex: NetRegexes.startsUsing({ id: '6702', source: 'Phoinix', capture: false }),
-      response: Responses.goLeft(),
+      response: Responses.goRight(),
     },
     {
       id: 'P3S Left Cinderwing',
       type: 'StartsUsing',
       netRegex: NetRegexes.startsUsing({ id: '6703', source: 'Phoinix', capture: false }),
-      response: Responses.goRight(),
+      response: Responses.goLeft(),
     },
     {
       id: 'P3S Flare of Condemnation',


### PR DESCRIPTION
in p3s, most time team are in front of boss, so the Cinderwing correct direction should be left for left/right for right