### PR TITLE
raidboss: DSR reverse p6 hallowed wings left/right

### DIFF
--- a/ui/raidboss/data/06-ew/ultimate/dragonsongs_reprise_ultimate.ts
+++ b/ui/raidboss/data/06-ew/ultimate/dragonsongs_reprise_ultimate.ts
@@ -1797,10 +1797,10 @@ const triggerSet: TriggerSet<Data> = {
     {
       id: 'DSR Hallowed Wings and Plume',
       // Calls left and right while looking at Hraesvelgr.
-      // 6D23 Head Down, Right Wing
-      // 6D24 Head Up, Right Wing
-      // 6D26 Head Down, Left Wing
-      // 6D27 Head Up, Left Wing
+      // 6D23 Head Down, Left Wing
+      // 6D24 Head Up, Left Wing
+      // 6D26 Head Down, Right Wing
+      // 6D27 Head Up, Right Wing
       // Head Up = Tanks Far
       // Head Down = Tanks Near
       type: 'StartsUsing',

--- a/ui/raidboss/data/06-ew/ultimate/dragonsongs_reprise_ultimate.ts
+++ b/ui/raidboss/data/06-ew/ultimate/dragonsongs_reprise_ultimate.ts
@@ -1796,10 +1796,11 @@ const triggerSet: TriggerSet<Data> = {
     },
     {
       id: 'DSR Hallowed Wings and Plume',
-      // 6D23 Head Down, Left Wing
-      // 6D24 Head Up, Left Wing
-      // 6D26 Head Down, Right Wing
-      // 6D27 Head Up, Right Wing
+      // Calls left and right while looking at Hraesvelgr.
+      // 6D23 Head Down, Right Wing
+      // 6D24 Head Up, Right Wing
+      // 6D26 Head Down, Left Wing
+      // 6D27 Head Up, Left Wing
       // Head Up = Tanks Far
       // Head Down = Tanks Near
       type: 'StartsUsing',
@@ -1809,19 +1810,19 @@ const triggerSet: TriggerSet<Data> = {
         let wings;
         switch (matches.id) {
           case '6D23':
-            wings = output.right!();
+            wings = output.left!();
             head = data.role === 'tank' ? output.near!() : output.far!();
             break;
           case '6D24':
-            wings = output.right!();
+            wings = output.left!();
             head = data.role === 'tank' ? output.far!() : output.near!();
             break;
           case '6D26':
-            wings = output.left!();
+            wings = output.right!();
             head = data.role === 'tank' ? output.near!() : output.far!();
             break;
           case '6D27':
-            wings = output.left!();
+            wings = output.right!();
             head = data.role === 'tank' ? output.far!() : output.near!();
             break;
         }


### PR DESCRIPTION
Looking at fflogs replays and the log from #4564,
it appears that the "left wing" and "right wing" comments
are backwards.

We could consider saying "north" and "south" here to be
absolute, but I think most folks will be looking at Hraesvelgr
to see the wing and head, so left/right is pretty natural.