### PR TITLE
plugin: update bozja intl opcode for 6.15

### DIFF
--- a/plugin/CactbotEventSource/FateWatcher.cs
+++ b/plugin/CactbotEventSource/FateWatcher.cs
@@ -70,6 +70,7 @@ namespace Cactbot {
     // v6.1             0x336
     // v6.11            0x20f
     // v6.11h           0x36a
+    // v6.15            0x96
     //
     // CN
     // v5.35            0x144
@@ -103,7 +104,7 @@ namespace Cactbot {
 
     private static readonly CEDirectorOPCodes cedirector_intl = new CEDirectorOPCodes(
       0x30,
-      0x36a
+      0x96
     );
 
     private struct ActorControlSelf {


### PR DESCRIPTION
Untested due to the other networking changes rendering the FFXIV_ACT_Plugin unusable, but the opcode should be correct.

Might need further work based on the extent of the changes required.