### PR TITLE
util: Add basic FFLogs support to make_timeline.ts

### DIFF
--- a/util/logtools/arg_parser.ts
+++ b/util/logtools/arg_parser.ts
@@ -7,6 +7,9 @@ type TimelineArgs = {
   'search_zones': number | null;
   'fight_regex': string | null;
   'zone_regex': string | null;
+  'report_id': string | null;
+  'report_fight': number | null;
+  'key': string | null;
 };
 
 class LogUtilArgParse {
@@ -16,7 +19,7 @@ class LogUtilArgParse {
   // At least one argument must be selected from this group.
   fileGroup = this.parser.addArgumentGroup({
     title: 'File Args',
-    description: 'A file and/or a timeline must be selected before performing operations',
+    description: 'A file, report, and/or timeline must be selected before performing operations',
   });
   // Exactly one argument should be selected from this group.
   // All arguments within this group are defined with nargs: '?',
@@ -30,6 +33,10 @@ class LogUtilArgParse {
   // The only validation done here is to ensure that at least one
   // of these arguments is present.
   requiredGroup = this.parser.addMutuallyExclusiveGroup();
+  reportGroup = this.requiredGroup.addArgumentGroup({
+    title: 'Report Args',
+    description: 'Using an FFLogs report requires use of an API key and report information',
+  });
   args?: TimelineArgs;
 
   constructor() {
@@ -38,6 +45,10 @@ class LogUtilArgParse {
     });
     this.fileGroup.addArgument(['-t', '--timeline'], {
       help: 'The filename of the timeline to test against, e.g. ultima_weapon_ultimate',
+    });
+    this.fileGroup.addArgument(['-r', '--report_id'], {
+      nargs: '?',
+      help: 'The ID of an FFLogs report',
     });
     this.parser.addArgument(['--force'], {
       nargs: '?',
@@ -75,6 +86,13 @@ class LogUtilArgParse {
       constant: 0,
       type: 'float',
       help: 'Adjust all entries in a timeline file by this amount',
+    });
+    this.reportGroup.addArgument(['-k', '--key'], {
+      help: 'The FFLogs API key to use, from https://www.fflogs.com/profile.',
+    });
+    this.reportGroup.addArgument(['-rf', '--report-fight'], {
+      help: 'Fight ID of the report to use.',
+      type: 'int',
     });
   }
 }

--- a/util/logtools/fflogs.ts
+++ b/util/logtools/fflogs.ts
@@ -3,10 +3,17 @@ import fetch from 'node-fetch';
 // The FFLogs API returns more data than just this,
 // but it's only status information for source and target,
 // and currently nothing in the timeline utilities needs this.
-type ffLogsEventEntry = {
+export type ffLogsEventEntry = {
   timestamp: number;
   type: string;
-  sourceID: number;
+  sourceID?: number;
+  source?: {
+    name: string;
+    id: number;
+    guid: number;
+    type: string;
+  };
+  sourceInstance?: number;
   sourceIsFriendly: boolean;
   targetID: number;
   targetIsFriendly: boolean;
@@ -18,48 +25,146 @@ type ffLogsEventEntry = {
   fight: number;
 };
 
-type fflogsEventResponse = {
+export type fflogsFightListEntry = {
+  id: number;
+  boss: number;
+  // eslint-disable-next-line camelcase
+  start_time: number;
+  // eslint-disable-next-line camelcase
+  end_time: number;
+  name: string;
+  zoneID: number;
+  zoneName: string;
+  size: number;
+  difficulty: number;
+  kill: boolean;
+  partial: number;
+  inProgress: boolean;
+  standardComposition: boolean;
+  hasEcho: boolean;
+  bossPercentage: number;
+  fightPercentage: number;
+  lastPhaseAsAbsoluteIndex: number;
+  lastPhaseForPercentageDisplay: number;
+  maps: {
+    mapID: number;
+    mapName: string;
+  };
+};
+
+export type fflogsEventResponse = {
   count: number;
   events: ffLogsEventEntry[];
   nextPageTimestamp?: number;
 };
 
+export type fflogsFightResponse = {
+  lang: 'en' | 'fr' | 'ja' | 'de' | 'cn';
+  start: number;
+  end: number;
+  fights: fflogsFightListEntry[];
+  title: string;
+  zone: number;
+  enemies: fflogsEnemy[];
+  nextPageTimestamp?: number;
+};
+
+export type fflogsEnemy = {
+  guid: number;
+  icon: string;
+  id: number;
+  name: string;
+  type: string;
+};
+
 const makeRequest = async (url: string, options: URLSearchParams) => {
   const requestUrl = `${url}?${options.toString()}`;
   const response = await fetch(requestUrl);
-  const responseText = JSON.parse(await response.text()) as fflogsEventResponse;
+  const responseText = JSON.parse(await response.text()) as
+    | fflogsFightResponse
+    | fflogsEventResponse;
   return responseText;
 };
 
-const callFFLogs = async (
-  fightsOrEvents: 'fights' | 'events',
-  reportId: string,
-  prefix: 'www' | 'fr' | 'ja' | 'de' | 'cn',
-  options: URLSearchParams,
-): Promise<fflogsEventResponse> => {
-  // The Event call requires specifying a View parameter.
-  // There's a long list of these, but choosing "Summary"
-  // permits us to filter more granularly via the option parameters.
-  const urlSegment = fightsOrEvents === 'fights' ? fightsOrEvents : `${fightsOrEvents}/summary`;
-  const url = `https://${prefix}.fflogs.com:443/v1/report/${urlSegment}/${reportId}`;
+class FFLogs {
+  static callFFLogs = async (
+    fightsOrEvents: 'fights' | 'events',
+    reportId: string,
+    prefix: 'www' | 'fr' | 'ja' | 'de' | 'cn',
+    options: URLSearchParams,
+  ): Promise<fflogsEventResponse | fflogsFightResponse> => {
+    // The Event call requires specifying a View parameter.
+    // There's a long list of these, but choosing "Summary"
+    // permits us to filter more granularly via the option parameters.
+    const urlSegment = fightsOrEvents === 'fights' ? fightsOrEvents : `${fightsOrEvents}/summary`;
+    const url = `https://${prefix}.fflogs.com:443/v1/report/${urlSegment}/${reportId}`;
 
-  const data = await makeRequest(url, options);
+    const data = await makeRequest(url, options);
 
-  // For a simple list of encounters, one call should be enough.
-  if (fightsOrEvents === 'fights')
+    // For a simple list of encounters, one call should be enough.
+    if (fightsOrEvents === 'fights')
+      return data;
+
+    // For Event retrieval, check whether the data is paginated.
+    // If it is, recursively retrieve it until it is all obtained.
+    if (data.nextPageTimestamp !== undefined) {
+      const nextOptions = new URLSearchParams();
+      Object.assign(nextOptions, options);
+      nextOptions.set('start', data.nextPageTimestamp.toString());
+      const nextData = await this.callFFLogs('fights', reportId, 'www', nextOptions);
+      const mergedData = Object.assign(data, nextData);
+      return mergedData;
+    }
     return data;
+  };
 
-  // For Event retrieval, check whether the data is paginated.
-  // If it is, recursively retrieve it until it is all obtained.
-  if (data.nextPageTimestamp !== undefined) {
-    const nextOptions = new URLSearchParams();
-    Object.assign(nextOptions, options);
-    nextOptions.set('start', data.nextPageTimestamp.toString());
-    const nextData = await makeRequest(url, nextOptions);
-    const mergedData = Object.assign(data, nextData);
-    return mergedData;
-  }
-  return data;
-};
+  static getFightInfo = async (
+    reportId: string,
+    key: string,
+  ): Promise<fflogsFightResponse> => {
+    const fightOptions = new URLSearchParams();
+    fightOptions.set('api_key', key);
+    const fightListData = await FFLogs.callFFLogs(
+      'fights',
+      reportId,
+      'www',
+      fightOptions,
+    ) as fflogsFightResponse;
+    return fightListData;
+  };
 
-export default callFFLogs;
+  static extractEnemiesFromReport = (
+    fightData: fflogsFightResponse,
+  ): { [index: string]: string } => {
+    const enemies: { [index: string]: string } = {};
+    for (const enemy of fightData.enemies)
+      enemies[enemy.id] = enemy.name;
+    return enemies;
+  };
+
+  static getEventData = async (
+    reportId: string,
+    key: string,
+    startTime: number,
+    endTime: number,
+    filter = 'source.disposition="enemy" and type="cast"',
+    translate = true,
+  ): Promise<ffLogsEventEntry[]> => {
+    const eventOptionParams = new URLSearchParams({
+      'api_key': key,
+      'start': startTime.toString(),
+      'end': endTime.toString(),
+      'filter': filter,
+      'translate': translate.toString(),
+    });
+    const eventData = await this.callFFLogs(
+      'events',
+      reportId,
+      'www',
+      eventOptionParams,
+    ) as fflogsEventResponse;
+    return eventData.events;
+  };
+}
+
+export default FFLogs;

--- a/util/logtools/split_log.ts
+++ b/util/logtools/split_log.ts
@@ -17,6 +17,9 @@ class SplitLogArgs extends Namespace implements TimelineArgs {
   'search_zones': number | null;
   'fight_regex': string | null;
   'zone_regex': string | null;
+  'report_id': string | null;
+  'report_fight': number | null;
+  'key': string | null;
 }
 
 // TODO: add options for not splitting / not anonymizing.


### PR DESCRIPTION
It works for the More Than One reports I tried it on. Usage is (or should be) identical to the original Python implementation. I haven't tested all the combinations of arguments, so it's entirely possible I left in some invalid combinations.

On the error codes, I tried to keep it to "a missing or invalid encounter is -2, actual script errors are -1". If we should make that more granular, I'm happy to make those changes.

Testing On My Machine seems to be not costly at all, with a solid half-hour debugging session not even reaching 100 V1 API points.