### PR TITLE
raidboss: Extend duration of Sanctity direction callout

### DIFF
--- a/ui/raidboss/data/06-ew/ultimate/dragonsongs_reprise_ultimate.ts
+++ b/ui/raidboss/data/06-ew/ultimate/dragonsongs_reprise_ultimate.ts
@@ -692,6 +692,8 @@ const triggerSet: TriggerSet<Data> = {
       netRegex: NetRegexes.ability({ id: '63E1', source: 'King Thordan', capture: false }),
       condition: (data) => data.phase === 'thordan',
       delaySeconds: 4.7,
+      // Keep message up until knights are done dashing
+      durationSeconds: 13,
       promise: async (data, _matches, output) => {
         // The two gladiators spawn in one of two positions: West (95, 100) or East (105, 100).
         // This triggers uses east/west location of the white knight, Ser Janlennoux (3635) to


### PR DESCRIPTION
Self-explanatory; extend duration of Sanctity of the Ward CW/CCW direction callout to 13secs so it stays up for the duration of the mechanic. 