### PR TITLE
raidboss: make empty string sound mean no sound

### DIFF
--- a/ui/raidboss/popup-text.ts
+++ b/ui/raidboss/popup-text.ts
@@ -1444,7 +1444,7 @@ export class PopupText {
         duration = 0;
 
       this._createTextFor(triggerHelper, text, textType, lowerTextKey, duration);
-      if (!triggerHelper.soundUrl) {
+      if (triggerHelper.soundUrl === undefined) {
         triggerHelper.soundUrl = this.options[upperSound];
         triggerHelper.soundVol = this.options[upperSoundVolume];
       }


### PR DESCRIPTION
There's currently no way to disable sound for a trigger.
This makes `sound: ''` to mean don't play any sound.

It's possible but unlikely this will fix #4588 due to the
`DSR Wrath Thunderstruck Targets` trigger having `sound: ''` and
`tts: 'null'`, but I was unable to repro this situation.

This also intersects with the https://github.com/quisquous/cactbot/pull/4523 changes.