### PR TITLE
raidboss: DSR earlier Strength Thordan call

### DIFF
--- a/ui/raidboss/data/06-ew/ultimate/dragonsongs_reprise_ultimate.ts
+++ b/ui/raidboss/data/06-ew/ultimate/dragonsongs_reprise_ultimate.ts
@@ -29,8 +29,6 @@ export interface Data extends RaidbossData {
   adelphelDir?: number;
   brightwingCounter: number;
   spiralThrustSafeZones?: number[];
-  thordanJumpCounter?: number;
-  thordanDir?: number;
   sanctityWardDir?: string;
   thordanMeteorMarkers: string[];
   // mapping of player name to 1, 2, 3 dot.


### PR DESCRIPTION
Use Ser Adelphel and Ser Janlenoux to find Thordan rather than
waiting for Thordan to appear.  Because this is very close
in time to the "move" trigger it is deliberately silent.

Fixes #4400.