### PR TITLE
raidboss: add Sharp Gust knockback callout

### DIFF
--- a/ui/raidboss/data/03-hw/trial/bismarck-ex.ts
+++ b/ui/raidboss/data/03-hw/trial/bismarck-ex.ts
@@ -1,0 +1,21 @@
+import NetRegexes from '../../../../../resources/netregexes';
+import { Responses } from '../../../../../resources/responses';
+import ZoneId from '../../../../../resources/zone_id';
+import { RaidbossData } from '../../../../../types/data';
+import { TriggerSet } from '../../../../../types/trigger';
+
+export type Data = RaidbossData;
+
+const triggerSet: TriggerSet<Data> = {
+  zoneId: ZoneId.TheLimitlessBlueExtreme,
+  triggers: [
+    {
+      id: 'Bismarck Sharp Gust',
+      type: 'StartsUsing',
+      netRegex: NetRegexes.startsUsing({ id: 'FAF', source: 'Bismarck', capture: false }),
+      response: Responses.knockback(),
+    },
+  ],
+};
+
+export default triggerSet;

--- a/ui/raidboss/data/raidboss_manifest.txt
+++ b/ui/raidboss/data/raidboss_manifest.txt
@@ -114,6 +114,7 @@
 03-hw/raid/a8s.txt
 03-hw/raid/a9s.ts
 03-hw/raid/a9s.txt
+03-hw/trial/bismarck-ex.ts
 03-hw/trial/ravana-ex.ts
 03-hw/trial/ravana-ex.txt
 03-hw/trial/sephirot.ts


### PR DESCRIPTION
During the 3rd phase of Limitless Blue Extreme, Bismarck will sometimes
use an untelegraphed knockback called "Sharp Gust". The cast only
happens when the weather is windy, but it has no obvious ground
telegraph or cast bar.

Signed-off-by: Jacob Keller <jacob.keller@gmail.com>
