### PR TITLE
util: Auto-comment some repeated abilities in make_timeline

### DIFF
--- a/util/logtools/make_timeline.ts
+++ b/util/logtools/make_timeline.ts
@@ -500,9 +500,12 @@ const assembleTimelineStrings = (
     if (entry.lineType !== 'nameToggle') {
       const ability = entry.abilityName ?? 'Unknown';
       const combatant = entry.combatant ?? 'Unknown';
+      let commentSync = '';
+      if (timeInfo.diffSeconds < 2.5 && lastEntry.abilityId === entry.abilityId)
+        commentSync = '#';
       const newEntry = `${
         timelinePosition.toFixed(1)
-      } "${ability}" sync / 1[56]:[^:]*:${combatant}:${abilityId}:/`;
+      } "${ability}" ${commentSync}sync / 1[56]:[^:]*:${combatant}:${abilityId}:/`;
       assembled.push(newEntry);
     } else {
       const targetable = entry.targetable ? '--targetable--' : '--untargetable--';

--- a/util/logtools/make_timeline.ts
+++ b/util/logtools/make_timeline.ts
@@ -13,8 +13,9 @@ import { printCollectedFights, printCollectedZones } from './encounter_printer';
 import { EncounterCollector, FightEncInfo, TLFuncs } from './encounter_tools';
 import FFLogs, { ffLogsEventEntry } from './fflogs';
 
-// TODO: Add support for auto-commenting repeated abilities
-// that can't be synced but should be visible.
+// TODO: Repeated abilities that need to be auto-commented may not get the comment marker
+// if there's an intervening entry between the repeated entries.
+// Figure out a more robust way to auto-comment lines that should be visible but unsynced.
 
 // TODO: Add support for assigning sync windows to specific abilities,
 // with or without phase conditions.


### PR DESCRIPTION
Very basic and very naive. It doesn't work if there are interleaved abilities, but it catches most of them.

```
120.0 "Weight of the Land" sync / 1[56]:[^:]*:The Ultima Weapon:6F01:/
121.0 "Ceruleum Vent" sync / 1[56]:[^:]*:The Ultima Weapon:6EEF:/
134.1 "Eruption" sync / 1[56]:[^:]*:The Ultima Weapon:6F03:/
134.2 "Eruption" #sync / 1[56]:[^:]*:The Ultima Weapon:6F03:/
136.0 "Eruption" #sync / 1[56]:[^:]*:The Ultima Weapon:6F03:/
136.1 "Eruption" #sync / 1[56]:[^:]*:The Ultima Weapon:6F03:/
138.1 "Eruption" #sync / 1[56]:[^:]*:The Ultima Weapon:6F03:/
138.1 "Eruption" #sync / 1[56]:[^:]*:The Ultima Weapon:6F03:/
140.0 "Eruption" #sync / 1[56]:[^:]*:The Ultima Weapon:6F03:/
140.0 "Eruption" #sync / 1[56]:[^:]*:The Ultima Weapon:6F03:/
141.8 "Eruption" #sync / 1[56]:[^:]*:The Ultima Weapon:6F03:/
141.9 "Viscous Aetheroplasm" sync / 1[56]:[^:]*:The Ultima Weapon:6EEE:/
141.9 "Eruption" sync / 1[56]:[^:]*:The Ultima Weapon:6F03:/
150.7 "Tank Purge" sync / 1[56]:[^:]*:The Ultima Weapon:6EF9:/
```

(Eruption particularly bad about this because the "same time" casts are offset by a few milliseconds, and thus aren't caught by the "is this an AoE" multi-hit suppression.)