### PR TITLE
raidboss: DSR Individual Sacred Sever hits in timeline

### DIFF
--- a/ui/raidboss/data/06-ew/ultimate/dragonsongs_reprise_ultimate.txt
+++ b/ui/raidboss/data/06-ew/ultimate/dragonsongs_reprise_ultimate.txt
@@ -110,10 +110,12 @@ hideall "--sync--"
 631.6 "Knights of the Round" sync / 1[56]:[^:]*:King Thordan:63ED:/
 638.7 "Sanctity of the Ward" sync / 1[56]:[^:]*:King Thordan:63E1:/
 641.8 "--untargetable--"
-652.2 "Sacred Sever 1 x2" duration 3.6 #sync / 1[56]:[^:]*:Ser Zephirin:63E3:/
+652.2 "Sacred Sever 1" #sync / 1[56]:[^:]*:Ser Zephirin:63E3:/
 652.4 "The Dragon's Glory" sync / 1[56]:[^:]*:King Thordan:63D2:/
 652.4 "The Dragon's Gaze" sync / 1[56]:[^:]*:King Thordan:63D1:/
-654.0 "Sacred Sever 2 x2" duration 3.6 #sync / 1[56]:[^:]*:Ser Zephirin:63E3:/
+654.0 "Sacred Sever 2" #sync / 1[56]:[^:]*:Ser Zephirin:63E3:/
+655.8 "Sacred Sever 3" #sync / 1[56]:[^:]*:Ser Zephirin:63E3:/
+657.6 "Sacred Sever 4" #sync / 1[56]:[^:]*:Ser Zephirin:63E3:/
 658.5 "--sync--" sync / 1[56]:[^:]*:King Thordan:63C4:/
 669.8 "Heavens' Stake" sync / 1[56]:[^:]*:Ser Charibert:6FAE:/
 669.8 "Hiemal Storm" sync / 1[56]:[^:]*:Ser Haumeric:63E6:/

--- a/ui/raidboss/data/06-ew/ultimate/dragonsongs_reprise_ultimate.txt
+++ b/ui/raidboss/data/06-ew/ultimate/dragonsongs_reprise_ultimate.txt
@@ -110,11 +110,10 @@ hideall "--sync--"
 631.6 "Knights of the Round" sync / 1[56]:[^:]*:King Thordan:63ED:/
 638.7 "Sanctity of the Ward" sync / 1[56]:[^:]*:King Thordan:63E1:/
 641.8 "--untargetable--"
-652.2 "Sacred Sever x4" duration 5.3 #sync / 1[56]:[^:]*:Ser Zephirin:63E3:/
-652.3 "Shining Blade 1"
+652.2 "Sacred Sever 1 x2" duration 3.6 #sync / 1[56]:[^:]*:Ser Zephirin:63E3:/
 652.4 "The Dragon's Glory" sync / 1[56]:[^:]*:King Thordan:63D2:/
 652.4 "The Dragon's Gaze" sync / 1[56]:[^:]*:King Thordan:63D1:/
-653.9 "Shining Blade 2"
+654.0 "Sacred Sever 2 x2" duration 3.6 #sync / 1[56]:[^:]*:Ser Zephirin:63E3:/
 658.5 "--sync--" sync / 1[56]:[^:]*:King Thordan:63C4:/
 669.8 "Heavens' Stake" sync / 1[56]:[^:]*:Ser Charibert:6FAE:/
 669.8 "Hiemal Storm" sync / 1[56]:[^:]*:Ser Haumeric:63E6:/

--- a/ui/raidboss/data/06-ew/ultimate/dragonsongs_reprise_ultimate.txt
+++ b/ui/raidboss/data/06-ew/ultimate/dragonsongs_reprise_ultimate.txt
@@ -111,8 +111,10 @@ hideall "--sync--"
 638.7 "Sanctity of the Ward" sync / 1[56]:[^:]*:King Thordan:63E1:/
 641.8 "--untargetable--"
 652.2 "Sacred Sever x4" duration 5.3 #sync / 1[56]:[^:]*:Ser Zephirin:63E3:/
+652.3 "Shining Blade 1"
 652.4 "The Dragon's Glory" sync / 1[56]:[^:]*:King Thordan:63D2:/
 652.4 "The Dragon's Gaze" sync / 1[56]:[^:]*:King Thordan:63D1:/
+653.9 "Shining Blade 2"
 658.5 "--sync--" sync / 1[56]:[^:]*:King Thordan:63C4:/
 669.8 "Heavens' Stake" sync / 1[56]:[^:]*:Ser Charibert:6FAE:/
 669.8 "Hiemal Storm" sync / 1[56]:[^:]*:Ser Haumeric:63E6:/


### PR DESCRIPTION
This adds the initial hit to the timeline for the one and two sword marker groups during sanctity. This helps with landing a heal between the swords before movement is required to dodge orbs in daylight strategy.