### PR TITLE
raidboss: add x2 indiactor to double Mercy Swords

### DIFF
--- a/ui/raidboss/data/05-shb/eureka/delubrum_reginae.ts
+++ b/ui/raidboss/data/05-shb/eureka/delubrum_reginae.ts
@@ -192,7 +192,7 @@ const triggerSet: TriggerSet<Data> = {
           ko: '왼쪽',
         },
         double: {
-          en: '${dir1} > ${dir2}',
+          en: '${dir1} x2 > ${dir2} x2',
           de: '${dir1} > ${dir2}',
           fr: '${dir1} > ${dir2}',
           ja: '${dir1} > ${dir2}',


### PR DESCRIPTION
When Trinity Seeker does the 4 Mercy Swords mechanic, sometimes the
callout is something like "Right > Left". This callout doesn't clearly
indicate that the player should wait two swords before moving. Improve
this by adding a x2 indicator.

We don't need a x4 indicator for the rare cases where the safe spot is
always the same, since the player doesn't need to move once in position.

Signed-off-by: Jacob Keller <jacob.keller@gmail.com>
