### PR TITLE
raidemulator: Change emulator display to hide pre-pull time

### DIFF
--- a/ui/raidboss/emulator/data/AnalyzedEncounter.ts
+++ b/ui/raidboss/emulator/data/AnalyzedEncounter.ts
@@ -213,14 +213,11 @@ export default class AnalyzedEncounter extends EventBus {
       if (!perspective || !triggerHelper)
         throw new UnreachableCode();
 
-      const delay = currentTriggerStatus.delay ?? 0;
-
       perspective.triggers.push({
         triggerHelper: triggerHelper,
         status: currentTriggerStatus,
         logLine: log,
-        resolvedOffset: (log.timestamp - this.encounter.startTimestamp) +
-          (delay * 1000),
+        resolvedOffset: (log.timestamp - this.encounter.startTimestamp),
       });
     };
     popupText.triggerResolvers = [];

--- a/ui/raidboss/emulator/translations.ts
+++ b/ui/raidboss/emulator/translations.ts
@@ -432,13 +432,6 @@ const emulatorEncounterInfo: Translation = {
     ja: '持続時間: <span class="label"></span>',
     cn: '持续时间: <span class="label"></span>',
   },
-  '.encounterOffset': {
-    en: 'Pull At: <span class="label"></span>',
-    de: 'Start um: <span class="label"></span>',
-    fr: 'Pull à : <span class="label"></span>',
-    ja: '戦闘開始: <span class="label"></span>',
-    cn: '开始于: <span class="label"></span>',
-  },
   '.encounterName': {
     en: 'Name: <span class="label"></span>',
     de: 'Name: <span class="label"></span>',

--- a/ui/raidboss/emulator/ui/EmulatedPartyInfo.ts
+++ b/ui/raidboss/emulator/ui/EmulatedPartyInfo.ts
@@ -220,13 +220,19 @@ export default class EmulatedPartyInfo extends EventBus {
         );
       }
 
+      const trimmedDuration = encounter.encounter.duration - encounter.encounter.initialOffset;
+
       for (const trigger of perspective.triggers) {
-        if (!trigger.status.executed || trigger.resolvedOffset > encounter.encounter.duration)
+        if (
+          !trigger.status.executed ||
+          trigger.resolvedOffset > encounter.encounter.duration ||
+          trigger.resolvedOffset < encounter.encounter.initialOffset
+        )
           continue;
 
         const $e = cloneSafe(this.$triggerItemTemplate);
-        $e.style.left = ((trigger.resolvedOffset / encounter.encounter.duration) * 100).toString() +
-          '%';
+        const adjustedOffset = trigger.resolvedOffset - encounter.encounter.initialOffset;
+        $e.style.left = ((adjustedOffset / trimmedDuration) * 100).toString() + '%';
         const triggerId = trigger.triggerHelper.trigger.id ?? 'Unknown Trigger';
         this.tooltips.push(new Tooltip($e, 'bottom', triggerId));
         bar.append($e);

--- a/ui/raidboss/emulator/ui/EncounterTab.ts
+++ b/ui/raidboss/emulator/ui/EncounterTab.ts
@@ -55,8 +55,8 @@ export default class EncounterTab extends EventBus {
         const zone = enc.zoneName;
         // ?? operator here to account for old encounters that don't have the property
         const encDate = DTFuncs.timeStringToDateString(enc.start, enc.tzOffsetMillis ?? 0);
-        const encTime = DTFuncs.timeToTimeString(enc.start, enc.tzOffsetMillis ?? 0);
-        const encDuration = DTFuncs.msToDuration(enc.duration);
+        const encTime = DTFuncs.timeToTimeString(enc.start + enc.offset, enc.tzOffsetMillis ?? 0);
+        const encDuration = DTFuncs.msToDuration(enc.duration - enc.offset);
         const zoneObj = this.encounters[zone] = this.encounters[zone] || {};
         const dateObj = zoneObj[encDate] = zoneObj[encDate] || [];
         dateObj.push({
@@ -230,10 +230,6 @@ export default class EncounterTab extends EventBus {
 
     const enc = encMap.encounter;
 
-    let pullAt = 'N/A';
-    if (!isNaN(enc.offset))
-      pullAt = DTFuncs.timeToString(enc.offset, false);
-
     const $info = this.$encounterInfoTemplate.cloneNode(true);
     if (!($info instanceof HTMLElement))
       throw new UnreachableCode();
@@ -253,12 +249,11 @@ export default class EncounterTab extends EventBus {
     querySelectorSafe($info, '.encounterZone .label').textContent = enc.zoneName;
     // ?? operator here to account for old encounters that don't have the property
     querySelectorSafe($info, '.encounterStart .label').textContent = DTFuncs
-      .dateTimeToString(enc.start, enc.tzOffsetMillis ?? 0);
+      .dateTimeToString(enc.start + enc.offset, enc.tzOffsetMillis ?? 0);
     querySelectorSafe($info, '.encounterDuration .label').textContent = DTFuncs.timeToString(
-      enc.duration,
+      enc.duration - enc.offset,
       false,
     );
-    querySelectorSafe($info, '.encounterOffset .label').textContent = pullAt;
     querySelectorSafe($info, '.encounterName .label').textContent = enc.name;
     querySelectorSafe($info, '.encounterStartStatus .label').textContent = enc.startStatus;
     querySelectorSafe($info, '.encounterEndStatus .label').textContent = enc.endStatus;

--- a/ui/raidboss/raidemulator.html
+++ b/ui/raidboss/raidemulator.html
@@ -284,7 +284,6 @@
           <div class="translate encounterZone"></div>
           <div class="translate encounterStart"></div>
           <div class="translate encounterDuration"></div>
-          <div class="translate encounterOffset"></div>
           <div class="translate encounterName"></div>
           <div class="translate encounterStartStatus"></div>
           <div class="translate encounterEndStatus"></div>


### PR DESCRIPTION
Assuming I understood the issue correctly, this should fix #4548

Could use some additional testing by another pair of eyes, as stated elsewhere this is a bit of a complicated mess to adjust.

Also this PR fixes a bug I noticed where triggers with a delaySeconds parameter were getting additional time added to their resolvedOffset due to leftover code from a previous way of calculating the resolvedOffset value.