### PR TITLE
raidboss: fix zodiark ex tankbuster id

### DIFF
--- a/ui/raidboss/data/06-ew/trial/zodiark-ex.ts
+++ b/ui/raidboss/data/06-ew/trial/zodiark-ex.ts
@@ -48,7 +48,7 @@ const triggerSet: TriggerSet<Data> = {
     {
       id: 'ZodiarkEx Ania',
       type: 'StartsUsing',
-      netRegex: NetRegexes.startsUsing({ id: '67EF', source: 'Zodiark' }),
+      netRegex: NetRegexes.startsUsing({ id: '6B63', source: 'Zodiark' }),
       response: Responses.tankBusterSwap(),
     },
     {


### PR DESCRIPTION
The previous id was self-casted, which prevented the response from working properly.