### PR TITLE
i18n: fix a mistake in cn

### DIFF
--- a/ui/raidboss/data/05-shb/eureka/bozjan_southern_front.ts
+++ b/ui/raidboss/data/05-shb/eureka/bozjan_southern_front.ts
@@ -628,7 +628,7 @@ const triggerSet: TriggerSet<Data> = {
           de: 'Zu einem weggeschleuderten Lichtorb gehen',
           fr: 'Allez sous un Orbe lumineux soufflé',
           ja: '赤玉へ',
-          cn: '靠近火球',
+          cn: '靠近吹动后的白球',
           ko: '하얀 구슬이 이동할 위치로',
         },
       },


### PR DESCRIPTION
It seems the mistake was inherited from the Japanese version as the messages in other languages are correct. One can easily tell, even without understanding Japanese, that if '白玉へ' means 'go to the white orb', then '赤玉へ' definitely doesn't mean what it's supposed to mean. In fact '赤玉へ' means 'go to the red orb', but my japanese is too poor to fix it, sorry.