### PR TITLE
raidboss: A10n raid package

### DIFF
--- a/ui/oopsyraidsy/data/03-hw/raid/a10n.ts
+++ b/ui/oopsyraidsy/data/03-hw/raid/a10n.ts
@@ -1,0 +1,33 @@
+import ZoneId from '../../../../../resources/zone_id';
+import { OopsyData } from '../../../../../types/data';
+import { OopsyTriggerSet } from '../../../../../types/oopsy';
+
+export type Data = OopsyData;
+
+const triggerSet: OopsyTriggerSet<Data> = {
+  zoneId: ZoneId.AlexanderTheBreathOfTheCreator,
+  damageWarn: {
+    'A10N Lamebrix Illuminati Hand Cannon': '1AD2', // Rectangle AoE
+    'A10N Blizzard Arrow Frostbite': '1AC7', // Ice trap AoE on edges
+    'A10N Weight Of The World Impact': '1AC6', // Mace traps in the center
+    'A10N Gobpress Steam Roller': '1AB4', // Intermission Demon Wall AoE
+    'A10N Lamebrix Gobswipe Conklops': '1ACB', // Single Charge dynamo/green
+    'A10N Lamebrix Gobspin Whooshdrop': '1ACC', // Single Charge chariot/red
+    'A10N Buzzsaw Laceration': '1AC8',
+  },
+  damageFail: {
+    'A10N Goblin Of Fortune Gobbieboom': '1AD3', // Add enrage
+  },
+  gainsEffectWarn: {
+    'A10N Electrocution': '120', // Arena danger walls
+  },
+  shareWarn: {
+    'A10N Lamebrix Gobslash Slicetops': '1AD1', // Stretchy tether AoE
+    'A10N Lamebrix Critical Wrath': '1ACD', // Fire spread circles
+  },
+  soloWarn: {
+    'A10N Lamebrix Bomb Toss': '1ACE', // Standard stack marker
+  },
+};
+
+export default triggerSet;

--- a/ui/oopsyraidsy/data/03-hw/raid/a10n.ts
+++ b/ui/oopsyraidsy/data/03-hw/raid/a10n.ts
@@ -20,6 +20,7 @@ const triggerSet: OopsyTriggerSet<Data> = {
   },
   gainsEffectWarn: {
     'A10N Electrocution': '120', // Arena danger walls
+    'A10N Stab Wound': '45D', // Activation of the spike trap. (No info on who did it.)
   },
   shareWarn: {
     'A10N Lamebrix Gobslash Slicetops': '1AD1', // Stretchy tether AoE

--- a/ui/oopsyraidsy/data/oopsy_manifest.txt
+++ b/ui/oopsyraidsy/data/oopsy_manifest.txt
@@ -16,6 +16,7 @@
 03-hw/dungeon/sohm_al_hard.ts
 03-hw/raid/a3n.ts
 03-hw/raid/a12n.ts
+03-hw/raid/a10n.ts
 03-hw/raid/a6n.ts
 04-sb/alliance/orbonne_monastery.ts
 04-sb/alliance/ridorana_lighthouse.ts

--- a/ui/raidboss/data/03-hw/raid/a10n.ts
+++ b/ui/raidboss/data/03-hw/raid/a10n.ts
@@ -122,6 +122,15 @@ const triggerSet: TriggerSet<Data> = {
       },
     },
   ],
+  timelineReplace: [
+    {
+      'locale': 'en',
+      'replaceText': {
+        'Gobspin Whooshdrops/Gobswipe Conklops': 'Single Charge #1',
+        'Gobswipe Conklops/Gobspin Whooshdrops': 'Single Charge #2',
+      },
+    },
+  ],
 };
 
 export default triggerSet;

--- a/ui/raidboss/data/03-hw/raid/a10n.ts
+++ b/ui/raidboss/data/03-hw/raid/a10n.ts
@@ -1,0 +1,127 @@
+import Conditions from '../../../../../resources/conditions';
+import NetRegexes from '../../../../../resources/netregexes';
+import { Responses } from '../../../../../resources/responses';
+import ZoneId from '../../../../../resources/zone_id';
+import { RaidbossData } from '../../../../../types/data';
+import { TriggerSet } from '../../../../../types/trigger';
+
+export type Data = RaidbossData;
+
+const triggerSet: TriggerSet<Data> = {
+  zoneId: ZoneId.AlexanderTheBreathOfTheCreator,
+  timelineFile: 'a10n.txt',
+  timelineTriggers: [
+    {
+      id: 'A10N Goblin Rush',
+      regex: /Goblin Rush/,
+      beforeSeconds: 5,
+      suppressSeconds: 5, // Ensure syncs don't multi-call
+      response: Responses.miniBuster(),
+    },
+    {
+      id: 'A10N Gobsway Rumblerocks',
+      regex: /Gobsway Rumblerocks/,
+      beforeSeconds: 4,
+      suppressSeconds: 4,
+      response: Responses.aoe(),
+    },
+    {
+      id: 'A10N Laceration',
+      regex: /Laceration/,
+      beforeSeconds: 5,
+      suppressSeconds: 10,
+      infoText: (_data, _matches, output) => output.text!(),
+      outputStrings: {
+        text: {
+          en: 'Avoid side saws',
+        },
+      },
+    },
+  ],
+  triggers: [
+    // There doesn't seem to be any indication in the logs if a player activates a trap.
+    {
+      id: 'A10N Frost Laser Trap',
+      type: 'Ability',
+      netRegex: NetRegexes.ability({ source: 'Lamebrix Strikebocks', id: '1AB1', capture: false }),
+      infoText: (_data, _matches, output) => output.text!(),
+      outputStrings: {
+        text: {
+          en: 'Frost Lasers',
+          de: 'Eislaser',
+          fr: 'Lasers de glace',
+          ja: '罠: 氷',
+          cn: '冰晶陷阱',
+          ko: '얼음화살 함정',
+        },
+      },
+    },
+    {
+      id: 'A10N Ceiling Weight Trap',
+      type: 'Ability',
+      netRegex: NetRegexes.ability({ source: 'Lamebrix Strikebocks', id: '1AB0', capture: false }),
+      infoText: (_data, _matches, output) => output.text!(),
+      outputStrings: {
+        text: {
+          en: 'Ceiling Weight',
+          de: 'Gewichte von der Decke',
+          fr: 'Poids du plafond',
+          ja: '罠: 鉄球',
+          cn: '铁球陷阱',
+          ko: '철퇴 함정',
+        },
+      },
+    },
+    {
+      id: 'A10N Single Charge In',
+      type: 'Ability',
+      netRegex: NetRegexes.ability({ id: '1AB8', source: 'Lamebrix Strikebocks', capture: false }),
+      response: Responses.getIn(),
+    },
+    {
+      id: 'A10N Single Charge Out',
+      type: 'Ability',
+      netRegex: NetRegexes.ability({ id: '1AB9', source: 'Lamebrix Strikebocks', capture: false }),
+      response: Responses.getOut(),
+    },
+    {
+      id: 'A10N Gobrush Rushgob',
+      type: 'StartsUsing',
+      netRegex: NetRegexes.startsUsing({ source: 'Lamebrix Strikebocks', id: '1ACF' }),
+      response: Responses.tankBuster(),
+    },
+    {
+      id: 'A10N Critical Wrath',
+      type: 'HeadMarker',
+      netRegex: NetRegexes.headMarker({ id: '0019' }),
+      condition: Conditions.targetIsYou(),
+      response: Responses.spread(),
+    },
+    {
+      id: 'A10N Bomb Toss',
+      type: 'HeadMarker',
+      netRegex: NetRegexes.headMarker({ id: '003E' }),
+      response: Responses.stackMarkerOn(),
+    },
+    {
+      id: 'A10N Gobslash Slicetops',
+      type: 'HeadMarker',
+      netRegex: NetRegexes.headMarker({ id: '0017' }),
+      alertText: (data, matches, output) => {
+        if (data.me === matches.target)
+          return output.target!();
+        return output.avoid!();
+      },
+      outputStrings: {
+        target: {
+          en: 'Get away--Laser on YOU',
+        },
+        avoid: {
+          en: 'Avoid Prey Laser',
+        },
+      },
+    },
+  ],
+};
+
+export default triggerSet;

--- a/ui/raidboss/data/03-hw/raid/a10n.txt
+++ b/ui/raidboss/data/03-hw/raid/a10n.txt
@@ -1,0 +1,114 @@
+### A10N
+# Alexander - The Breath of the Creator
+
+# -ii 1DCD 1AC9 1AB4
+
+hideall "--Reset--"
+hideall "--sync--"
+
+0.0 "--Reset--" sync / 00:0839::.*is no longer sealed/ window 100000 jump 0
+
+0.0 "--sync--" sync / 00:0839::The Excruciationator will be sealed off/ window 0,1
+7.0 "Goblin Rush" sync / 1[56]:[^:]*:Lamebrix Strikebocks:1A17:/
+10.1 "Gobsway Rumblerocks" sync / 1[56]:[^:]*:Lamebrix Strikebocks:1AD0:/
+15.2 "Gobsway Rumblerocks" sync / 1[56]:[^:]*:Lamebrix Strikebocks:1AD0:/
+22.2 "Illuminati Hand Cannon" sync / 1[56]:[^:]*:Lamebrix Strikebocks:1AD2:/
+34.4 "Gobslash Slicetops" sync / 1[56]:[^:]*:Lamebrix Strikebocks:1AD1:/
+37.5 "Goblin Rush" sync / 1[56]:[^:]*:Lamebrix Strikebocks:1A17:/
+45.6 "Gobrush Rushgob" sync / 1[56]:[^:]*:Lamebrix Strikebocks:1ACF:/
+49.7 "Gobsway Rumblerocks" sync / 1[56]:[^:]*:Lamebrix Strikebocks:1AD0:/
+56.7 "Trap" sync / 1[56]:[^:]*:Lamebrix Strikebocks:(1AB0|1AB1):/ window 56.7,5
+58.0 "--sync--" sync / 1[56]:[^:]*:Lamebrix Strikebocks:1AA2:/
+61.1 "Goblin Rush" sync / 1[56]:[^:]*:Lamebrix Strikebocks:1A17:/
+61.7 "Frostbite/Impact" sync / 1[56]:[^:]*:(Blizzard Arrow|Weight of the World):(1AC7|1AC6):/
+69.0 "Trap" sync / 1[56]:[^:]*:Lamebrix Strikebocks:(1AB0|1AB1):/
+70.3 "--sync--" sync / 1[56]:[^:]*:Lamebrix Strikebocks:1AA2:/
+74.0 "Impact/Frostbite" sync / 1[56]:[^:]*:(Blizzard Arrow|Weight of the World):(1AC7|1AC6):/
+74.9 "Illuminati Hand Cannon" sync / 1[56]:[^:]*:Lamebrix Strikebocks:1AD2:/
+78.0 "Goblin Rush" sync / 1[56]:[^:]*:Lamebrix Strikebocks:1A17:/
+87.1 "Gobslash Slicetops" sync / 1[56]:[^:]*:Lamebrix Strikebocks:1AD1:/
+90.2 "Goblin Rush" sync / 1[56]:[^:]*:Lamebrix Strikebocks:1A17:/
+98.3 "Gobrush Rushgob" sync / 1[56]:[^:]*:Lamebrix Strikebocks:1ACF:/
+102.4 "Gobsway Rumblerocks" sync / 1[56]:[^:]*:Lamebrix Strikebocks:1AD0:/
+
+105.4 "--untargetable--"
+105.4 "--sync--" sync / 1[56]:[^:]*:Lamebrix Strikebocks:1AA2:/ window 20,20
+110.7 "--targetable--"
+
+111.1 "--sync--"  sync / 14:[^:]*:Gobpress R-VI:1AC9:/ window 112,10
+112.8 "--sync--" sync / 1[56]:[^:]*:Lamebrix Strikebocks:1A9C:/
+117.8 "Critical Wrath" sync / 1[56]:[^:]*:Lamebrix Strikebocks:1ACD:/
+122.9 "Illuminati Hand Cannon" sync / 1[56]:[^:]*:Lamebrix Strikebocks:1AD2:/
+126.2 "Steam Roller" sync / 1[56]:[^:]*:Gobpress R-VI:1ACA:/
+132.2 "Gobsway Rumblerocks" sync / 1[56]:[^:]*:Lamebrix Strikebocks:1AD0:/
+136.2 "Gobsway Rumblerocks" sync / 1[56]:[^:]*:Lamebrix Strikebocks:1AD0:/
+142.3 "Illuminati Hand Cannon" sync / 1[56]:[^:]*:Lamebrix Strikebocks:1AD2:/
+145.5 "Steam Roller" sync / 1[56]:[^:]*:Gobpress R-VI:1ACA:/
+156.2 "Bomb Toss" sync / 1[56]:[^:]*:Lamebrix Strikebocks:1ACE:/
+161.4 "Illuminati Hand Cannon" sync / 1[56]:[^:]*:Lamebrix Strikebocks:1AD2:/
+165.0 "Steam Roller" sync / 1[56]:[^:]*:Gobpress R-VI:1ACA:/
+170.2 "Gobsway Rumblerocks" sync / 1[56]:[^:]*:Lamebrix Strikebocks:1AD0:/
+174.3 "Gobsway Rumblerocks" sync / 1[56]:[^:]*:Lamebrix Strikebocks:1AD0:/
+180.4 "Illuminati Hand Cannon" sync / 1[56]:[^:]*:Lamebrix Strikebocks:1AD2:/
+184.3 "Steam Roller" sync / 1[56]:[^:]*:Gobpress R-VI:1ACA:/
+
+# The Gobpress gains a damage up buff here. The intermission continues and loops if unsynced.
+189.7 "Gobsway Rumblerocks" sync / 1[56]:[^:]*:Lamebrix Strikebocks:1AD0:/
+194.8 "Gobsway Rumblerocks" sync / 1[56]:[^:]*:Lamebrix Strikebocks:1AD0:/
+199.9 "Gobsway Rumblerocks" sync / 1[56]:[^:]*:Lamebrix Strikebocks:1AD0:/
+203.6 "Steam Roller Enrage?" sync / 1[56]:[^:]*:Gobpress R-VI:1ACA:/
+
+# This targetable entry is the earliest we can re-sync the timeline.
+300.0 "--targetable--" sync /22:[^:]*:Lamebrix Strikebocks:[^:]*:Lamebrix Strikebocks:01/ window 190,10
+309.2 "Goblin Rush" sync / 1[56]:[^:]*:Lamebrix Strikebocks:1A17:/ window 200,10
+317.3 "Gobrush Rushgob" sync / 1[56]:[^:]*:Lamebrix Strikebocks:1ACF:/
+
+321.4 "--sync--" sync / 1[56]:[^:]*:Lamebrix Strikebocks:(1AB8|1AB9):/
+324.6 "Single Charge #1" sync / 1[56]:[^:]*:Lamebrix Strikebocks:1A97:/
+325.5 "Gobspin Whooshdrops/Gobswipe Conklops" sync / 1[56]:[^:]*:Lamebrix Strikebocks:(1ACB|1ACC):/ window 25,10
+331.6 "Gobsway Rumblerocks" sync / 1[56]:[^:]*:Lamebrix Strikebocks:1AD0:/
+335.6 "Goblin Rush" sync / 1[56]:[^:]*:Lamebrix Strikebocks:1A17:/
+339.7 "Gobsway Rumblerocks" sync / 1[56]:[^:]*:Lamebrix Strikebocks:1AD0:/
+344.7 "--sync--" sync / 1[56]:[^:]*:Lamebrix Strikebocks:(1AB8|1AB9):/
+347.9 "Single Charge #2" sync / 1[56]:[^:]*:Lamebrix Strikebocks:1A97:/
+348.8 "Gobswipe Conklops/Gobspin Whooshdrops" sync / 1[56]:[^:]*:Lamebrix Strikebocks:(1ACB|1ACC):/ window 10,10
+355.9 "Gobsway Rumblerocks" sync / 1[56]:[^:]*:Lamebrix Strikebocks:1AD0:/
+360.0 "Goblin Rush" sync / 1[56]:[^:]*:Lamebrix Strikebocks:1A17:/
+368.1 "Gobrush Rushgob" sync / 1[56]:[^:]*:Lamebrix Strikebocks:1ACF:/
+372.3 "Goblin Rush" sync / 1[56]:[^:]*:Lamebrix Strikebocks:1A17:/
+377.3 "Laceration #1" sync / 1[56]:[^:]*:Buzzsaw:1AC8:/ window 30,2.5
+380.3 "Laceration #2" sync / 1[56]:[^:]*:Buzzsaw:1AC8:/
+383.3 "Laceration #3" sync / 1[56]:[^:]*:Buzzsaw:1AC8:/
+385.3 "Gobsway Rumblerocks" sync / 1[56]:[^:]*:Lamebrix Strikebocks:1AD0:/
+389.3 "Gobsway Rumblerocks" sync / 1[56]:[^:]*:Lamebrix Strikebocks:1AD0:/
+393.3 "Goblin Rush" sync / 1[56]:[^:]*:Lamebrix Strikebocks:1A17:/
+398.2 "Trap #1" sync / 1[56]:[^:]*:Lamebrix Strikebocks:(1AB0|1AB1):/ window 100,2.5
+402.3 "Trap #2" sync / 1[56]:[^:]*:Lamebrix Strikebocks:(1AB0|1AB1):/
+403.2 "Frostbite/Impact" sync / 1[56]:[^:]*:(Blizzard Arrow|Weight of the World):(1AC7|1AC6):/
+403.6 "--sync--" sync / 1[56]:[^:]*:Lamebrix Strikebocks:1AA2:/
+407.3 "Impact/Frostbite" sync / 1[56]:[^:]*:(Blizzard Arrow|Weight of the World):(1AC7|1AC6):/
+408.9 "Illuminati Hand Cannon" sync / 1[56]:[^:]*:Lamebrix Strikebocks:1AD2:/
+418.1 "Gobslash Slicetops" sync / 1[56]:[^:]*:Lamebrix Strikebocks:1AD1:/
+422.1 "Goblin Rush" sync / 1[56]:[^:]*:Lamebrix Strikebocks:1A17:/
+430.2 "Gobrush Rushgob" sync / 1[56]:[^:]*:Lamebrix Strikebocks:1ACF:/
+434.3 "Gobsway Rumblerocks" sync / 1[56]:[^:]*:Lamebrix Strikebocks:1AD0:/
+440.4 "--sync--" sync / 1[56]:[^:]*:Lamebrix Strikebocks:1A9C:/ window 30,30
+444.4 "Laceration #1" sync / 1[56]:[^:]*:Buzzsaw:1AC8:/
+445.4 "Critical Wrath" sync / 1[56]:[^:]*:Lamebrix Strikebocks:1ACD:/
+447.4 "Laceration #2" sync / 1[56]:[^:]*:Buzzsaw:1AC8:/
+450.4 "Laceration #3" sync / 1[56]:[^:]*:Buzzsaw:1AC8:/
+453.1 "Bomb Toss" sync / 1[56]:[^:]*:Lamebrix Strikebocks:1ACE:/
+465.1 "Gobbieboom?" sync / 1[56]:[^:]*:Goblin of Fortune:1AD3:/
+467.2 "Gobrush Rushgob" sync / 1[56]:[^:]*:Lamebrix Strikebocks:1ACF:/
+470.3 "Gobsway Rumblerocks" sync / 1[56]:[^:]*:Lamebrix Strikebocks:1AD0:/
+
+474.4 "--sync--" sync / 1[56]:[^:]*:Lamebrix Strikebocks:(1AB8|1AB9):/ window 30,10 jump 321.4
+477.6 "Single Charge"
+478.5 "Gobspin Whooshdrops/Gobswipe Conklops"
+484.6 "Gobsway Rumblerocks"
+488.6 "Goblin Rush"
+492.7 "Gobsway Rumblerocks"
+500.9 "Single Charge"
+501.8 "Gobswipe Conklops/Gobspin Whooshdrops"
+508.9 "Gobsway Rumblerocks"
+513.0 "Goblin Rush"

--- a/ui/raidboss/data/03-hw/raid/a10n.txt
+++ b/ui/raidboss/data/03-hw/raid/a10n.txt
@@ -64,13 +64,13 @@ hideall "--sync--"
 317.3 "Gobrush Rushgob" sync / 1[56]:[^:]*:Lamebrix Strikebocks:1ACF:/
 
 321.4 "--sync--" sync / 1[56]:[^:]*:Lamebrix Strikebocks:(1AB8|1AB9):/
-324.6 "Single Charge #1" sync / 1[56]:[^:]*:Lamebrix Strikebocks:1A97:/
+324.6 "--sync--" sync / 1[56]:[^:]*:Lamebrix Strikebocks:1A97:/
 325.5 "Gobspin Whooshdrops/Gobswipe Conklops" sync / 1[56]:[^:]*:Lamebrix Strikebocks:(1ACB|1ACC):/ window 25,10
 331.6 "Gobsway Rumblerocks" sync / 1[56]:[^:]*:Lamebrix Strikebocks:1AD0:/
 335.6 "Goblin Rush" sync / 1[56]:[^:]*:Lamebrix Strikebocks:1A17:/
 339.7 "Gobsway Rumblerocks" sync / 1[56]:[^:]*:Lamebrix Strikebocks:1AD0:/
 344.7 "--sync--" sync / 1[56]:[^:]*:Lamebrix Strikebocks:(1AB8|1AB9):/
-347.9 "Single Charge #2" sync / 1[56]:[^:]*:Lamebrix Strikebocks:1A97:/
+347.9 "--sync--" sync / 1[56]:[^:]*:Lamebrix Strikebocks:1A97:/
 348.8 "Gobswipe Conklops/Gobspin Whooshdrops" sync / 1[56]:[^:]*:Lamebrix Strikebocks:(1ACB|1ACC):/ window 10,10
 355.9 "Gobsway Rumblerocks" sync / 1[56]:[^:]*:Lamebrix Strikebocks:1AD0:/
 360.0 "Goblin Rush" sync / 1[56]:[^:]*:Lamebrix Strikebocks:1A17:/

--- a/ui/raidboss/data/raidboss_manifest.txt
+++ b/ui/raidboss/data/raidboss_manifest.txt
@@ -82,6 +82,8 @@
 03-hw/dungeon/xelphatol.ts
 03-hw/dungeon/xelphatol.txt
 03-hw/pvp/shatter.ts
+03-hw/raid/a10n.ts
+03-hw/raid/a10n.txt
 03-hw/raid/a10s.ts
 03-hw/raid/a10s.txt
 03-hw/raid/a11s.ts


### PR DESCRIPTION
I needed a break from high-level content, so I sat down and picked at this one over the weekend. It's mostly self-explanatory. I don't know whether there's a HP% push before the intermission, but the sync windows should handle that.

I did some naming nonsense on the Single Charge abilities since the damage actually resolves on the Conklops/Whooshdrops ability, and nobody is going to remember what that ability *is* from the name anyway.

I haven't tested whether the Gobbieboom add explosion is a genuine enrage or just a healer mechanic, but given that I've literally never seen it even when it was current content, I don't think it matters.

The log doesn't seem to have information on players activating the traps.