### PR TITLE
oopsy: Sephirot EX

### DIFF
--- a/ui/oopsyraidsy/data/03-hw/trial/sephirot-ex.ts
+++ b/ui/oopsyraidsy/data/03-hw/trial/sephirot-ex.ts
@@ -1,0 +1,152 @@
+import NetRegexes from '../../../../../resources/netregexes';
+import ZoneId from '../../../../../resources/zone_id';
+import { OopsyData } from '../../../../../types/data';
+import { OopsyTriggerSet } from '../../../../../types/oopsy';
+
+export interface Data extends OopsyData {
+  force?: { [name: string]: string };
+}
+
+const triggerSet: OopsyTriggerSet<Data> = {
+  zoneId: ZoneId.ContainmentBayS1T7Extreme,
+  damageWarn: {
+    'SephirotEX Yesod': '157E', // Snapshot floor spikes
+    'SephirotEX Ain': '1569', // Half-arena baited frontal
+    'SephirotEX Ein Sof': '156F', // Expanding green puddles
+    'SephirotEX Fiendish Wail': '1577', // Raidwide if tower is missed
+  },
+  damageFail: {
+    'SephirotEX Pillar Of Mercy': '1581', // Standing in the blue puddles
+    'SephirotEX Storm Of Words Revelation': '1583', // Missing the enrage on Storm of Words
+  },
+  shareWarn: {
+    'SephirotEX Triple Trial': '1566', // Instant tank cleave
+    'SephirotEX Ratzon Green': '156B', // Small green spread circle
+    'SephirotEX Ratzon Purple': '156C', // Large purple spread circle
+    'SephirotEX Earth Shaker': '157D',
+    'SephirotEX Spread Da\'at': '1573',
+  },
+  soloWarn: {
+    'SephirotEX Fiendish Rage': '156D', // Stack markers, phase 1
+  },
+  triggers: [
+    {
+      // Pillar of Mercy,  Malkuth, and Pillar of Severity
+      id: 'SephirotEX Knockbacks',
+      type: 'Ability',
+      netRegex: NetRegexes.ability({ id: ['1580', '1582', '1586'], source: 'Sephirot' }),
+      deathReason: (_data, matches) => {
+        return {
+          id: matches.targetId,
+          name: matches.target,
+          text: {
+            en: 'Pushed off!',
+            de: 'Runter geschubst!',
+            fr: 'Repoussé(e) !',
+            ja: '落ちた',
+            cn: '击退坠落',
+            ko: '넉백됨',
+          },
+        };
+      },
+    },
+    {
+      // 3ED is Force Against Might orange, 3EE is Force Against Magic, green.
+      id: 'SephirotEX Force Against Gain',
+      type: 'GainsEffect',
+      netRegex: NetRegexes.gainsEffect({ effectId: ['3ED', '3EE'] }),
+      run: (data, matches) => {
+        data.force ??= {};
+        data.force[matches.target] = matches.effectId;
+      },
+    },
+    {
+      id: 'SephirotEX Force Against Lose',
+      type: 'LosesEffect',
+      netRegex: NetRegexes.losesEffect({ effectId: ['3ED', '3EE'] }),
+      run: (data, matches) => {
+        data.force ??= {};
+        delete data.force[matches.target];
+      },
+    },
+    {
+      id: 'SephirotEX Spirit',
+      type: 'Ability',
+      netRegex: NetRegexes.ability({ id: '157B', source: 'Sephirot' }),
+      condition: (data, matches) => data?.force?.[matches.target] === '3ED',
+      mistake: (_data, matches) => {
+        return {
+          type: 'warn',
+          blame: matches.target,
+          text: {
+            en: 'Took green; orange debuff',
+          },
+        };
+      },
+    },
+    {
+      id: 'SephirotEX Life Force',
+      type: 'Ability',
+      netRegex: NetRegexes.ability({ id: '157A', source: 'Sephirot' }),
+      condition: (data, matches) => data?.force?.[matches.target] === '3EE',
+      mistake: (_data, matches) => {
+        return {
+          type: 'warn',
+          blame: matches.target,
+          text: {
+            en: 'Took orange; green debuff',
+          },
+        };
+      },
+    },
+    {
+      id: 'SephirotEX Fiendish Wail Green',
+      type: 'Ability',
+      netRegex: NetRegexes.ability({ id: '1576', source: 'Sephirot' }),
+      condition: (data, matches) => data?.force?.[matches.target] === '3EE',
+      mistake: (_data, matches) => {
+        return {
+          type: 'warn',
+          blame: matches.target,
+          text: {
+            en: 'Tower with green',
+          },
+        };
+      },
+    },
+    {
+      // Only tanks should take towers without a Force debuff.
+      id: 'SephirotEX Fiendish Wail Non-Tank',
+      type: 'Ability',
+      netRegex: NetRegexes.ability({ id: '1576', source: 'Sephirot' }),
+      condition: (data, matches) => !data.party.isTank(matches.target) && data?.force?.[matches.target] === undefined,
+      mistake: (_data, matches) => {
+        return {
+          type: 'fail',
+          blame: matches.target,
+          text: {
+            en: 'Non-tank in tower',
+          },
+        };
+      },
+    },
+    {
+      // Taking a tether while under Force Against Might (orange) kills the target
+      id: 'SephirotEX Tether Da\'at',
+      type: 'Ability',
+      netRegex: NetRegexes.ability({ id: '1574', source: 'Sephirot' }),
+      condition: (data, matches) => data?.force?.[matches.target] === '3ED',
+      mistake: (_data, matches) => {
+        return {
+          type: 'fail',
+          blame: matches.target,
+          text: {
+            en: 'Orange took tether',
+          },
+        };
+      },
+    },
+  ],
+};
+
+export default triggerSet;

--- a/ui/oopsyraidsy/data/03-hw/trial/sephirot-ex.ts
+++ b/ui/oopsyraidsy/data/03-hw/trial/sephirot-ex.ts
@@ -78,9 +78,7 @@ const triggerSet: OopsyTriggerSet<Data> = {
         return {
           type: 'warn',
           blame: matches.target,
-          text: {
-            en: 'Took green; orange debuff',
-          },
+          text: matches.ability,
         };
       },
     },
@@ -93,9 +91,7 @@ const triggerSet: OopsyTriggerSet<Data> = {
         return {
           type: 'warn',
           blame: matches.target,
-          text: {
-            en: 'Took orange; green debuff',
-          },
+          text: matches.ability,
         };
       },
     },
@@ -108,25 +104,25 @@ const triggerSet: OopsyTriggerSet<Data> = {
         return {
           type: 'warn',
           blame: matches.target,
-          text: {
-            en: 'Tower with green',
-          },
+          text: matches.ability,
         };
       },
     },
     {
-      // Only tanks should take towers without a Force debuff.
+      // Only tanks or Blue Mages should take towers without a Force debuff.
       id: 'SephirotEX Fiendish Wail Non-Tank',
       type: 'Ability',
       netRegex: NetRegexes.ability({ id: '1576', source: 'Sephirot' }),
-      condition: (data, matches) => !data.party.isTank(matches.target) && data?.force?.[matches.target] === undefined,
+      condition: (data, matches) => {
+        if (data.party.isTank(matches.target) || data.job === 'BLU')
+          return false;
+        return data?.force?.[matches.target] === undefined;
+      },
       mistake: (_data, matches) => {
         return {
           type: 'fail',
           blame: matches.target,
-          text: {
-            en: 'Non-tank in tower',
-          },
+          text: matches.ability,
         };
       },
     },
@@ -140,9 +136,7 @@ const triggerSet: OopsyTriggerSet<Data> = {
         return {
           type: 'fail',
           blame: matches.target,
-          text: {
-            en: 'Orange took tether',
-          },
+          text: matches.ability,
         };
       },
     },

--- a/ui/oopsyraidsy/data/oopsy_manifest.txt
+++ b/ui/oopsyraidsy/data/oopsy_manifest.txt
@@ -17,6 +17,7 @@
 03-hw/raid/a3n.ts
 03-hw/raid/a12n.ts
 03-hw/raid/a6n.ts
+03-hw/trial/sephirot-ex.ts
 04-sb/alliance/orbonne_monastery.ts
 04-sb/alliance/ridorana_lighthouse.ts
 04-sb/alliance/royal_city_of_rabanastre.ts


### PR DESCRIPTION
Largely self-explanatory. I could use criticism on the Force Against mistake text, since even after I cut it down to what it is now, it's still really long.

I'm not sure what we want to do with the non-tank + no-debuff tower trigger, since #4530 is still floating around. I would be okay removing it, but it's going to be moderately important once this is released for Unreal.