### PR TITLE
raidboss: DSR add Mortal Vow callout

### DIFF
--- a/ui/raidboss/data/06-ew/ultimate/dragonsongs_reprise_ultimate.ts
+++ b/ui/raidboss/data/06-ew/ultimate/dragonsongs_reprise_ultimate.ts
@@ -214,8 +214,8 @@ const triggerSet: TriggerSet<Data> = {
           return output.vowOn!({ player: data.mortalVowPlayer });
         return output.vowSoon!();
       },
-	    outputStrings: {
-	      vowOnYou: {
+      outputStrings: {
+        vowOnYou: {
           en: 'Vow on you',
         },
         vowOn: {

--- a/ui/raidboss/data/06-ew/ultimate/dragonsongs_reprise_ultimate.ts
+++ b/ui/raidboss/data/06-ew/ultimate/dragonsongs_reprise_ultimate.ts
@@ -59,6 +59,7 @@ export interface Data extends RaidbossData {
   hallowedWingsCount: number;
   spreadingFlame: string[];
   entangledFlame: string[];
+  mortalVowPlayer?: string;
 }
 
 // Due to changes introduced in patch 5.2, overhead markers now have a random offset
@@ -199,6 +200,29 @@ const triggerSet: TriggerSet<Data> = {
           ja: 'AoE + DoT',
           cn: 'AOE + dot',
           ko: '전체공격 + 도트뎀',
+        },
+      },
+    },
+    {
+      id: 'DSR Mortal Vow',
+      regex: /Mortal Vow/,
+      beforeSeconds: 5,
+      infoText: (data, _matches, output) => {
+        if (data.me === data.mortalVowPlayer)
+          return output.vowOnYou!();
+        if (data.mortalVowPlayer)
+          return output.vowOn!({ player: data.mortalVowPlayer });
+        return output.vowSoon!();
+      },
+	    outputStrings: {
+	      vowOnYou: {
+          en: 'Vow on you',
+        },
+        vowOn: {
+          en: 'Vow on ${player}',
+        },
+        vowSoon: {
+          en: 'Vow soon (Spread)',
         },
       },
     },
@@ -2117,6 +2141,13 @@ const triggerSet: TriggerSet<Data> = {
         delete data.hraesvelgrGlowing;
         delete data.nidhoggGlowing;
       },
+    },
+    {
+      id: 'DSR Mortal Vow Collect',
+      type: 'GainsEffect',
+      netRegex: NetRegexes.gainsEffect({ effectId: 'B50' }),
+      suppressSeconds: 1,
+      run: (data, matches) => data.mortalVowPlayer = data.ShortName(matches.target),
     },
     {
       id: 'DSR Akh Afah',

--- a/ui/raidboss/data/06-ew/ultimate/dragonsongs_reprise_ultimate.ts
+++ b/ui/raidboss/data/06-ew/ultimate/dragonsongs_reprise_ultimate.ts
@@ -206,7 +206,9 @@ const triggerSet: TriggerSet<Data> = {
     {
       id: 'DSR Mortal Vow',
       regex: /Mortal Vow/,
-      beforeSeconds: 5,
+      // 3.7s to avoid early movement at Touchdown and last Mortal Vow
+      beforeSeconds: 3.7,
+      durationSeconds: 3.7,
       infoText: (data, _matches, output) => {
         if (data.me === data.mortalVowPlayer)
           return output.vowOnYou!();


### PR DESCRIPTION
Adds a callout ~~5~~ **3.7** seconds before Mortal Vow occurs.
Will call out Soon (Spread), who has it when it is time to pass, and if it is on you when it is time to pass.

I think 5 seconds is enough time, perhaps it could be shorter. I find it helpful to have a callout even if healer as it helps as a reminder to avoid whoever has it when the time is coming since it can be hectic learning this part of the fight so late.

**EDIT:** Changed to 3.7 as last call should happen after touchdown to avoid triggering early movement into bosses.
