### PR TITLE
raidboss: fix some ew hunts triggers

### DIFF
--- a/ui/raidboss/data/06-ew/hunts/thavnair.ts
+++ b/ui/raidboss/data/06-ew/hunts/thavnair.ts
@@ -145,6 +145,13 @@ const triggerSet: TriggerSet<Data> = {
       condition: (data) => data.inCombat,
       response: Responses.getBehind(),
     },
+    {
+      id: 'Hunt Yilan Mini Light',
+      type: 'StartsUsing',
+      netRegex: NetRegexes.startsUsing({ id: '6A5F', source: 'Yilan', capture: false }),
+      condition: (data) => data.inCombat,
+      response: Responses.getOut(),
+    },
   ],
   timelineReplace: [
     {

--- a/ui/raidboss/data/06-ew/hunts/ultima_thule.ts
+++ b/ui/raidboss/data/06-ew/hunts/ultima_thule.ts
@@ -82,29 +82,9 @@ const triggerSet: TriggerSet<Data> = {
     {
       id: 'Hunt Fan Ail Divebomb',
       type: 'StartsUsing',
-      netRegex: NetRegexes.startsUsing({ id: '6AED', source: 'Fan Ail' }),
+      netRegex: NetRegexes.startsUsing({ id: '6AED', source: 'Fan Ail', capture: false }),
       condition: (data) => data.inCombat,
-      alertText: (data, matches, output) => {
-        if (data.me === matches.target)
-          return output.divebombOnYou!();
-        return output.divebombMarker!();
-      },
-      outputStrings: {
-        divebombOnYou: {
-          en: 'Divebomb on YOU',
-          de: 'Sturzflug auf DIR',
-          fr: 'Bombe plongeante sur VOUS',
-          cn: '俯冲点名',
-          ko: '나에게 초록징',
-        },
-        divebombMarker: {
-          en: 'Away from Divebomb Marker',
-          de: 'Weg von dem Sturzflug-Marker',
-          fr: 'Éloignez-vous de la bombe plongeante',
-          cn: '躲开俯冲点名',
-          ko: '초록징 피하기',
-        },
-      },
+      response: Responses.awayFromFront(),
     },
   ],
   timelineReplace: [


### PR DESCRIPTION
## Yilan Mini Light
[yilan 2022-07-30 11-24-21.webm](https://user-images.githubusercontent.com/37621276/181867570-f30920a8-fb59-453c-aa1f-718fcb0d1054.webm)

Not all players gain directional march effect. so I think it would be better if there was an alarm to go outside

## Fan Ail Divebomb
[Fan Ail 2022-07-30 11-17-32.webm](https://user-images.githubusercontent.com/37621276/181867682-0a712161-68f8-4e4a-b4af-9a63c93951a9.webm)

In fact, the direction of Fan Ail is fixed when the divebomb marker appears, so you only need to avoid front of that.
