### PR TITLE
raidboss: DSR fix#4664 track p6/p7 by ability trigger

### DIFF
--- a/ui/raidboss/data/06-ew/ultimate/dragonsongs_reprise_ultimate.ts
+++ b/ui/raidboss/data/06-ew/ultimate/dragonsongs_reprise_ultimate.ts
@@ -241,7 +241,7 @@ const triggerSet: TriggerSet<Data> = {
       // 6708 = Final Chorus
       // 62E2 = Spear of the Fury
       // 6B86 = Incarnation
-      netRegex: NetRegexes.startsUsing({ id: ['62D4', '63C8', '6708', '62E2', '6B86' ], capture: true }),
+      netRegex: NetRegexes.startsUsing({ id: ['62D4', '63C8', '6708', '62E2', '6B86'], capture: true }),
       run: (data, matches) => {
         // On the unlikely chance that somebody proceeds directly from the checkpoint into the next phase.
         data.brightwingCounter = 1;
@@ -272,7 +272,7 @@ const triggerSet: TriggerSet<Data> = {
       type: 'Ability',
       // 6667 = unknown_6667
       // 71E4 = Shockwave
-      netRegex: NetRegexes.ability({ id: ['6667', '71E4'], capture: true }),
+      netRegex: NetRegexes.ability({ id: ['6667', '71E4'], source: ['King Thordan', 'Nidhogg'] }),
       suppresSeconds: 1,
       run: (data, matches) => {
         switch (matches.id) {

--- a/ui/raidboss/data/06-ew/ultimate/dragonsongs_reprise_ultimate.ts
+++ b/ui/raidboss/data/06-ew/ultimate/dragonsongs_reprise_ultimate.ts
@@ -241,9 +241,7 @@ const triggerSet: TriggerSet<Data> = {
       // 6708 = Final Chorus
       // 62E2 = Spear of the Fury
       // 6B86 = Incarnation
-      // 6667 = unknown_6667
-      // 71E4 = Shockwave
-      netRegex: NetRegexes.startsUsing({ id: ['62D4', '63C8', '6708', '62E2', '6B86', '6667', '7438'], capture: true }),
+      netRegex: NetRegexes.startsUsing({ id: ['62D4', '63C8', '6708', '62E2', '6B86' ], capture: true }),
       run: (data, matches) => {
         // On the unlikely chance that somebody proceeds directly from the checkpoint into the next phase.
         data.brightwingCounter = 1;
@@ -266,6 +264,17 @@ const triggerSet: TriggerSet<Data> = {
           case '6B86':
             data.phase = 'thordan2';
             break;
+        }
+      },
+    },
+    {
+      id: 'DSR Phase Tracker P6/P7',
+      type: 'Ability',
+      // 6667 = unknown_6667
+      // 71E4 = Shockwave
+      netRegex: NetRegexes.ability({ id: ['6667', '71E4'], capture: true }),
+      run: (data, matches) => {
+        switch (matches.id) {
           case '6667':
             data.phase = 'nidhogg2';
             break;

--- a/ui/raidboss/data/06-ew/ultimate/dragonsongs_reprise_ultimate.ts
+++ b/ui/raidboss/data/06-ew/ultimate/dragonsongs_reprise_ultimate.ts
@@ -268,12 +268,12 @@ const triggerSet: TriggerSet<Data> = {
       },
     },
     {
-      id: 'DSR Phase Tracker P6/P7',
+      id: 'DSR Phase Tracker P6 and P7',
       type: 'Ability',
       // 6667 = unknown_6667
       // 71E4 = Shockwave
-      netRegex: NetRegexes.ability({ id: ['6667', '71E4'], source: ['King Thordan', 'Nidhogg'] }),
-      suppresSeconds: 1,
+      netRegex: NetRegexes.ability({ id: ['6667', '71E4'] }),
+      suppressSeconds: 1,
       run: (data, matches) => {
         switch (matches.id) {
           case '6667':

--- a/ui/raidboss/data/06-ew/ultimate/dragonsongs_reprise_ultimate.ts
+++ b/ui/raidboss/data/06-ew/ultimate/dragonsongs_reprise_ultimate.ts
@@ -273,6 +273,7 @@ const triggerSet: TriggerSet<Data> = {
       // 6667 = unknown_6667
       // 71E4 = Shockwave
       netRegex: NetRegexes.ability({ id: ['6667', '71E4'], capture: true }),
+      suppresSeconds: 1,
       run: (data, matches) => {
         switch (matches.id) {
           case '6667':


### PR DESCRIPTION
fixes #4664

Removes the P6 and P7 regex captures from DSR Phase Tracker as they are not casted abilities.
Adds DSR Phase Tracker P6/P7 to capture network abilities for the p6/p7 ids.
Changes regex to match Shockwave as indicator for p7.