### PR TITLE
config: Don't Load Raidboss CSS Within Config UI

### DIFF
--- a/resources/user_config.ts
+++ b/resources/user_config.ts
@@ -231,7 +231,7 @@ class UserConfig {
     this.loadUserFiles(overlayName, options, callback);
   }
 
-  loadUserFiles(overlayName: string, options: BaseOptions, callback: () => void) {
+  loadUserFiles(overlayName: string, options: BaseOptions, callback: () => void, loadCss = true) {
     const readOptions = callOverlayHandler({
       call: 'cactbotLoadData',
       overlay: 'options',
@@ -331,7 +331,7 @@ class UserConfig {
         // localFiles may be null if there is no valid user directory.
         const sortedFiles = this.sortUserFiles(Object.keys(localFiles));
         const jsFiles = this.filterUserFiles(sortedFiles, overlayName, '.js');
-        const cssFiles = this.filterUserFiles(sortedFiles, overlayName, '.css');
+        const cssFiles = loadCss ? this.filterUserFiles(sortedFiles, overlayName, '.css') : [];
 
         for (const jsFile of jsFiles) {
           try {

--- a/ui/raidboss/raidboss_config.ts
+++ b/ui/raidboss/raidboss_config.ts
@@ -1572,7 +1572,7 @@ const templateOptions: OptionsTemplate = {
     const userOptions = { ...raidbossOptions };
     UserConfig.loadUserFiles('raidboss', userOptions, () => {
       builder.buildUI(container, raidbossFileData, userOptions);
-    });
+    }, false);
   },
   processExtraOptions: (baseOptions, savedConfig) => {
     // TODO: Rewrite user_config to be templated on option type so that this function knows


### PR DESCRIPTION
The config interface is loading everything from the raidboss overlay,
including raidboss.css if defined in the user's user directory. This can
cause some interesting interactions that overwrite style options.

Fixes #4554 