### PR TITLE
jobs: 6.2 changes

### DIFF
--- a/ui/jobs/components/drk.ts
+++ b/ui/jobs/components/drk.ts
@@ -16,7 +16,6 @@ export class DRKComponent extends BaseComponent {
   delirium: TimerBox;
   livingShadow: TimerBox;
   tid1 = 0;
-  tid2 = 0;
 
   constructor(o: ComponentInterface) {
     super(o);
@@ -50,6 +49,15 @@ export class DRKComponent extends BaseComponent {
     });
 
     this.reset();
+  }
+
+  override onStatChange({ gcdSkill }: { gcdSkill: number }): void {
+    this.bloodWeapon.valuescale = gcdSkill;
+    this.bloodWeapon.threshold = gcdSkill + 1;
+    this.delirium.valuescale = gcdSkill;
+    this.delirium.threshold = gcdSkill + 1;
+    this.livingShadow.valuescale = gcdSkill;
+    this.livingShadow.threshold = gcdSkill * 4 + 1;
   }
 
   override onJobDetailUpdate(jobDetail: JobDetail['DRK']): void {
@@ -105,27 +113,12 @@ export class DRKComponent extends BaseComponent {
         }
         break;
       }
-      case kAbility.Delirium: {
-          this.delirium.duration = 60;
-          break;
-      }
-      case kAbility.LivingShadow: {
-        this.livingShadow.duration = 24;
-        this.livingShadow.threshold = 24;
-        this.livingShadow.fg = computeBackgroundColorFrom(
-          this.livingShadow,
-          'drk-color-livingshadow.active',
-        );
-        this.tid2 = window.setTimeout(() => {
-          this.livingShadow.duration = 96;
-          this.livingShadow.threshold = this.player.gcdSkill * 4;
-          this.livingShadow.fg = computeBackgroundColorFrom(
-            this.livingShadow,
-            'drk-color-livingshadow',
-          );
-        }, 24000);
+      case kAbility.Delirium:
+        this.delirium.duration = 60;
         break;
-      }
+      case kAbility.LivingShadow:
+        this.livingShadow.duration = 120;
+        break;
     }
   }
 
@@ -136,10 +129,7 @@ export class DRKComponent extends BaseComponent {
     this.bloodWeapon.fg = computeBackgroundColorFrom(this.bloodWeapon, 'drk-color-bloodweapon');
     this.delirium.duration = 0;
     this.livingShadow.duration = 0;
-    this.livingShadow.threshold = this.player.gcdSkill * 4;
-    this.livingShadow.fg = computeBackgroundColorFrom(this.livingShadow, 'drk-color-livingshadow');
     this.darksideBox.duration = 0;
     window.clearTimeout(this.tid1);
-    window.clearTimeout(this.tid2);
   }
 }

--- a/ui/jobs/components/gnb.ts
+++ b/ui/jobs/components/gnb.ts
@@ -70,7 +70,10 @@ export class GNBComponent extends BaseComponent {
         break;
       }
       case kAbility.Bloodfest:
-        this.bloodfestBox.duration = 90;
+        if (this.ffxivRegion === 'intl')
+          this.bloodfestBox.duration = 120;
+        else
+          this.bloodfestBox.duration = 90;
         break;
       case kAbility.GnashingFang:
         this.gnashingFangBox.duration = this.bars.player.getActionCooldown(30000, 'skill');


### PR DESCRIPTION
- GNB: Bloodfest cooldown changes to 120s.
- DRK: Living Shadow duration is reduced. 
And I think it's not necessary to trace its duration, for there is no action to make the Shadow attack quicker.
The duration-cooldown structure is lengthy, I'm thinking about use a util func to instead them like
```
export const showDuration = (o: {
  tid: number;
  timerbox: TimerBox;
  duration: number;
  cooldown: number;
  threshold: number;
  activecolor: string;
  deactivecolor: string;
}): number => {
  o.timerbox.duration = o.duration;
  o.timerbox.threshold = o.duration;
  o.timerbox.fg = computeBackgroundColorFrom(o.timerbox, o.activecolor);
  o.tid = window.setTimeout(() => {
    o.timerbox.duration = o.cooldown - o.duration;
    o.timerbox.threshold = o.threshold;
    o.timerbox.fg = computeBackgroundColorFrom(o.timerbox, o.deactivecolor);
  });
  return o.tid;
```
maybe later for more test and adjust.


