### PR TITLE
raidboss: update actor control wipe for timelines

### DIFF
--- a/resources/translations.ts
+++ b/resources/translations.ts
@@ -1,5 +1,6 @@
 import { CactbotBaseRegExp } from '../types/net_trigger';
 import {
+  backCompatParsedSyncReplace,
   commonReplacement,
   partialCommonTimelineReplacementKeys,
   partialCommonTriggerReplacementKeys,
@@ -239,6 +240,15 @@ export const translateWithReplacements = (
     }
 
     text = text.replace(regex, repl);
+  }
+
+  // Backwards compatibility with older versions.
+  // This does not count as `wasTranslated`.
+  if (replaceKey === 'replaceSync') {
+    for (const [key, repl] of Object.entries(backCompatParsedSyncReplace)) {
+      const regex = isGlobal ? Regexes.parseGlobal(key) : Regexes.parse(key);
+      text = text.replace(regex, repl);
+    }
   }
 
   return { text, wasTranslated };

--- a/ui/raidboss/common_replacement.ts
+++ b/ui/raidboss/common_replacement.ts
@@ -465,3 +465,10 @@ export const partialCommonTriggerReplacementKeys = [
   // Because the zone name needs to be translated here, this is partial.
   syncKeys.seal,
 ];
+
+export const backCompatParsedSyncReplace: { [replaceKey: string]: string } = {
+  // TODO: remove this (and all other 40000010 refs) after everybody is on 6.2.
+  // Because 4000000F was only used in triple triad, it should be safe to
+  // do this replacement for everybody.
+  '21:\.\.\.\.\.\.\.\.:4000000F:': '21:\.\.\.\.\.\.\.\.:(4000000F|40000010):',
+};

--- a/ui/raidboss/data/02-arr/raid/t10.txt
+++ b/ui/raidboss/data/02-arr/raid/t10.txt
@@ -4,7 +4,7 @@
 hideall "--Reset--"
 hideall "--sync--"
 
-0.0 "--Reset--" sync / 21:........:40000010:/ window 100000 jump 0
+0.0 "--Reset--" sync / 21:........:4000000F:/ window 100000 jump 0
 
 # Initial Phase: Tankbuster, Charge, Repeat
 0.0 "Start"

--- a/ui/raidboss/data/02-arr/raid/t12.txt
+++ b/ui/raidboss/data/02-arr/raid/t12.txt
@@ -6,7 +6,7 @@ hideall "--sync--"
 hideall "Summon"
 hideall "Scorched Pinion"
 
-0.0 "--Reset--" sync / 21:........:40000010:/ window 100000 jump 0
+0.0 "--Reset--" sync / 21:........:4000000F:/ window 100000 jump 0
 
 ### Phase 1: Blackfire/Whitefire
 0.0 "Start"

--- a/ui/raidboss/data/02-arr/raid/t13.txt
+++ b/ui/raidboss/data/02-arr/raid/t13.txt
@@ -4,7 +4,7 @@
 hideall "--Reset--"
 hideall "--sync--"
 
-0.0 "--Reset--" sync / 21:........:40000010:/ window 100000 jump 0
+0.0 "--Reset--" sync / 21:........:4000000F:/ window 100000 jump 0
 
 ### Phase 1: Megaflare Warmup
 0.0 "Start"

--- a/ui/raidboss/data/02-arr/raid/t9.txt
+++ b/ui/raidboss/data/02-arr/raid/t9.txt
@@ -4,7 +4,7 @@
 hideall "--Reset--"
 hideall "--sync--"
 
-0.0 "--Reset--" sync / 21:........:40000010:/ window 100000 jump 0
+0.0 "--Reset--" sync / 21:........:4000000F:/ window 100000 jump 0
 
 ### Phase 1
 # This phase really doesn't seem to loop anywhere.

--- a/ui/raidboss/data/02-arr/trial/cape_westwind.txt
+++ b/ui/raidboss/data/02-arr/trial/cape_westwind.txt
@@ -4,7 +4,7 @@
 hideall "--Reset--"
 hideall "--sync--"
 
-0.0 "--Reset--" sync / 21:........:40000010:/ window 100000 jump 0
+0.0 "--Reset--" sync / 21:........:4000000F:/ window 100000 jump 0
 
 ### Phase 1: skewers and stuns
 0 "Start"

--- a/ui/raidboss/data/02-arr/trial/ifrit-nm.txt
+++ b/ui/raidboss/data/02-arr/trial/ifrit-nm.txt
@@ -4,7 +4,7 @@
 hideall "--Reset--"
 hideall "--sync--"
 
-0.0 "--Reset--" sync / 21:........:40000010:/ window 100000 jump 0
+0.0 "--Reset--" sync / 21:........:4000000F:/ window 100000 jump 0
 
 # 0%
 0.0 "Start"

--- a/ui/raidboss/data/02-arr/trial/levi-ex.txt
+++ b/ui/raidboss/data/02-arr/trial/levi-ex.txt
@@ -35,7 +35,7 @@
 hideall "--Reset--"
 hideall "--sync--"
 
-0.0 "--Reset--" sync / 21:........:40000010:/ window 100000 jump 0
+0.0 "--Reset--" sync / 21:........:4000000F:/ window 100000 jump 0
 
 ### Phase 1: Literally Just Autos (100% -> 90%)
 0.0 "Start"

--- a/ui/raidboss/data/02-arr/trial/shiva-ex.txt
+++ b/ui/raidboss/data/02-arr/trial/shiva-ex.txt
@@ -34,7 +34,7 @@
 hideall "--sync--"
 hideall "--Reset--"
 
-0.0 "--Reset--" sync / 21:........:40000010:/ window 100000 jump 0
+0.0 "--Reset--" sync / 21:........:4000000F:/ window 100000 jump 0
 
 # Phase 1: Literally Just Autos (100% -> 95%)
 0.0 "--sync--" sync /:Engage!/ window 0,1

--- a/ui/raidboss/data/02-arr/trial/shiva-hm.txt
+++ b/ui/raidboss/data/02-arr/trial/shiva-hm.txt
@@ -29,7 +29,7 @@
 hideall "--sync--"
 hideall "--Reset--"
 
-0.0 "--Reset--" sync / 21:........:40000010:/ window 100000 jump 0
+0.0 "--Reset--" sync / 21:........:4000000F:/ window 100000 jump 0
 
 # Phase 1: Literally Just Autos (100% -> 95%)
 0.0 "--sync--" sync /:Engage!/ window 0,1

--- a/ui/raidboss/data/02-arr/trial/titan-ex.txt
+++ b/ui/raidboss/data/02-arr/trial/titan-ex.txt
@@ -8,7 +8,7 @@
 hideall "--Reset--"
 hideall "--sync--"
 
-0.0 "--Reset--" sync / 21:........:40000010:/ window 100000 jump 0
+0.0 "--Reset--" sync / 21:........:4000000F:/ window 100000 jump 0
 
 ### Phase 1: 100->85%
 0.0 "Start"

--- a/ui/raidboss/data/02-arr/trial/titan-hm.txt
+++ b/ui/raidboss/data/02-arr/trial/titan-hm.txt
@@ -11,7 +11,7 @@
 hideall "--Reset--"
 hideall "--sync--"
 
-0.0 "--Reset--" sync / 21:........:40000010:/ window 100000 jump 0
+0.0 "--Reset--" sync / 21:........:4000000F:/ window 100000 jump 0
 
 ### Phase 1: 100->90%
 0.0 "Start"

--- a/ui/raidboss/data/02-arr/trial/titan-nm.txt
+++ b/ui/raidboss/data/02-arr/trial/titan-nm.txt
@@ -4,7 +4,7 @@
 hideall "--Reset--"
 hideall "--sync--"
 
-0.0 "--Reset--" sync / 21:........:40000010:/ window 100000 jump 0
+0.0 "--Reset--" sync / 21:........:4000000F:/ window 100000 jump 0
 
 ### Phase 1 100 -> 85%
 0.0 "Start"

--- a/ui/raidboss/data/02-arr/trial/ultima-ex.txt
+++ b/ui/raidboss/data/02-arr/trial/ultima-ex.txt
@@ -4,7 +4,7 @@
 hideall "--Reset--"
 hideall "--sync--"
 
-0.0 "--Reset--" sync / 21:........:40000010:/ window 100000 jump 0
+0.0 "--Reset--" sync / 21:........:4000000F:/ window 100000 jump 0
 
 0.0 "--sync--" sync /Engage!/ window 0,1
 

--- a/ui/raidboss/data/03-hw/raid/a11s.txt
+++ b/ui/raidboss/data/03-hw/raid/a11s.txt
@@ -11,7 +11,7 @@ hideall "--Reset--"
 hideall "--sync--"
 
 0.0 "--Reset--" sync / 00:0839::.*is no longer sealed/ window 100000 jump 0
-0.0 "--Reset--" sync / 21:........:40000010:/ window 100000 jump 0
+0.0 "--Reset--" sync / 21:........:4000000F:/ window 100000 jump 0
 
 0.0 "--sync--" sync /:Engage!/ window 0,1
 0.0 "--sync--" sync / 00:0839::The Main Generators will be sealed off in 15 seconds/ window 10,10

--- a/ui/raidboss/data/03-hw/raid/a12n.txt
+++ b/ui/raidboss/data/03-hw/raid/a12n.txt
@@ -6,7 +6,7 @@ hideall "--sync--"
 
 # -ii 1AE2 1AE6 1AF1
 
-0.0 "--Reset--" sync / 21:........:40000010:/ window 100000 jump 0
+0.0 "--Reset--" sync / 21:........:4000000F:/ window 100000 jump 0
 
 0.0 "--sync--" sync /:Engage!/ window 0,1
 0.7 "--sync--" sync / 1[56]:[^:]*:Alexander Prime:1AE2:/ window 0.7,2

--- a/ui/raidboss/data/03-hw/raid/a12s.txt
+++ b/ui/raidboss/data/03-hw/raid/a12s.txt
@@ -7,7 +7,7 @@
 hideall "--Reset--"
 hideall "--sync--"
 
-0.0 "--Reset--" sync / 21:........:40000010:/ window 100000 jump 0
+0.0 "--Reset--" sync / 21:........:4000000F:/ window 100000 jump 0
 0.0 "--Reset--" sync / 00:0839::.*is no longer sealed/ window 100000 jump 0
 
 

--- a/ui/raidboss/data/03-hw/raid/a1s.txt
+++ b/ui/raidboss/data/03-hw/raid/a1s.txt
@@ -4,7 +4,7 @@
 hideall "--Reset--"
 hideall "--sync--"
 
-0.0 "--Reset--" sync / 21:........:40000010:/ window 100000 jump 0
+0.0 "--Reset--" sync / 21:........:4000000F:/ window 100000 jump 0
 0.0 "--Reset--" sync / 00:0839::.*is no longer sealed/ window 100000 jump 0
 
 ### Faust

--- a/ui/raidboss/data/03-hw/raid/a2s.txt
+++ b/ui/raidboss/data/03-hw/raid/a2s.txt
@@ -11,7 +11,7 @@
 hideall "--Reset--"
 hideall "--sync--"
 
-0.0 "--Reset--" sync / 21:........:40000010:/ window 100000 jump 0
+0.0 "--Reset--" sync / 21:........:4000000F:/ window 100000 jump 0
 0.0 "--Reset--" sync / 00:0839::.*is no longer sealed/ window 100000 jump 0
 
 # Wave 1 (pull)

--- a/ui/raidboss/data/03-hw/raid/a3n.txt
+++ b/ui/raidboss/data/03-hw/raid/a3n.txt
@@ -7,7 +7,7 @@ hideall "--sync--"
 
 # -ii 1305 12FA
 
-0.0 "--Reset--" sync / 21:........:40000010:/ window 10000 jump 0
+0.0 "--Reset--" sync / 21:........:4000000F:/ window 10000 jump 0
 0.0 "--Reset--" sync / 00:0839::.*is no longer sealed/ window 10000 jump 0
 
 0 "Start" sync /Engage!/ window 0,1

--- a/ui/raidboss/data/03-hw/raid/a3s.txt
+++ b/ui/raidboss/data/03-hw/raid/a3s.txt
@@ -10,7 +10,7 @@
 hideall "--Reset--"
 hideall "--sync--"
 
-0.0 "--Reset--" sync / 21:........:40000010:/ window 100000 jump 0
+0.0 "--Reset--" sync / 21:........:4000000F:/ window 100000 jump 0
 0.0 "--Reset--" sync / 00:0839::.*is no longer sealed/ window 100000 jump 0
 
 

--- a/ui/raidboss/data/03-hw/raid/a4s.txt
+++ b/ui/raidboss/data/03-hw/raid/a4s.txt
@@ -8,7 +8,7 @@
 #       From most logs it seemed like ~5.8 seconds before the first ray.
 #       So, I applied that to all perpetual rays.
 
-0.0 "--Reset--" sync / 21:........:40000010:/ window 100000 jump 0
+0.0 "--Reset--" sync / 21:........:4000000F:/ window 100000 jump 0
 
 
 ### Leg 1

--- a/ui/raidboss/data/03-hw/raid/a5s.txt
+++ b/ui/raidboss/data/03-hw/raid/a5s.txt
@@ -7,7 +7,7 @@
 hideall "Guzzle"
 hideall "Relaxant"
 
-0.0 "--Reset--" sync / 21:........:40000010:/ window 100000 jump 0
+0.0 "--Reset--" sync / 21:........:4000000F:/ window 100000 jump 0
 
 ### Hummel and Friends
 1000.0 "--sync--" sync / 00:0839::The Clevering will be sealed off/ window 1000,0

--- a/ui/raidboss/data/03-hw/raid/a6n.txt
+++ b/ui/raidboss/data/03-hw/raid/a6n.txt
@@ -1,7 +1,7 @@
 ### A6N
 # Alexander - The Cuff Of The Son
 
-0.0 "--Reset--" sync / 21:........:40000010:/ window 100000 jump 0
+0.0 "--Reset--" sync / 21:........:4000000F:/ window 100000 jump 0
 
 
 ### Blaster

--- a/ui/raidboss/data/03-hw/raid/a6s.txt
+++ b/ui/raidboss/data/03-hw/raid/a6s.txt
@@ -6,7 +6,7 @@
 
 hideall "Ballistic Missile"
 
-0.0 "--Reset--" sync / 21:........:40000010:/ window 100000 jump 0
+0.0 "--Reset--" sync / 21:........:4000000F:/ window 100000 jump 0
 
 
 ### Blaster

--- a/ui/raidboss/data/03-hw/raid/a8n.txt
+++ b/ui/raidboss/data/03-hw/raid/a8n.txt
@@ -9,7 +9,7 @@ hideall "--sync--"
 hideall "Magicked Mark"
 hideall "Brute Force"
 
-0.0 "--Reset--" sync / 21:........:40000010:/ window 100000 jump 0
+0.0 "--Reset--" sync / 21:........:4000000F:/ window 100000 jump 0
 # Overall enrage is 12 minutes, but it doesn't interrupt any rotations.
 # It just starts a "10 seconds to auto-clean" counter,
 # ending with a Final Judgment sword drop.

--- a/ui/raidboss/data/03-hw/raid/a8s.txt
+++ b/ui/raidboss/data/03-hw/raid/a8s.txt
@@ -9,7 +9,7 @@ hideall "--sync--"
 hideall "Magicked Mark"
 hideall "Brute Force"
 
-0.0 "--Reset--" sync / 21:........:40000010:/ window 100000 jump 0
+0.0 "--Reset--" sync / 21:........:4000000F:/ window 100000 jump 0
 
 ### Phase 1: Onslaughter: Execution and Legislation
 0.0 "--sync--" sync /:Engage!/ window 0,1

--- a/ui/raidboss/data/03-hw/trial/ravana-ex.txt
+++ b/ui/raidboss/data/03-hw/trial/ravana-ex.txt
@@ -4,7 +4,7 @@
 hideall "--Reset--"
 hideall "--sync--"
 
-0.0 "--Reset--" sync / 21:........:40000010:/ window 100000 jump 0
+0.0 "--Reset--" sync / 21:........:4000000F:/ window 100000 jump 0
 
 # During all phases, any attacks will increase Ravana's Bloodlust meter.
 # The relationship between increases and damage done is not fully understood.

--- a/ui/raidboss/data/03-hw/trial/sephirot-ex.txt
+++ b/ui/raidboss/data/03-hw/trial/sephirot-ex.txt
@@ -7,7 +7,7 @@
 hideall "--Reset--"
 hideall "--sync--"
 
-0.0 "--Reset--" sync / 21:........:40000010:/ window 100000 jump 0
+0.0 "--Reset--" sync / 21:........:4000000F:/ window 100000 jump 0
 
 0.0 "--sync--" sync /:Engage!/ window 0,1
 2.5 "--sync--" sync / 1[56]:[^:]*:Sephirot:368:/ window 2.5,1

--- a/ui/raidboss/data/03-hw/trial/sophia-ex.txt
+++ b/ui/raidboss/data/03-hw/trial/sophia-ex.txt
@@ -12,7 +12,7 @@
 hideall "--Reset--"
 hideall "--sync--"
 
-0.0 "--Reset--" sync / 21:........:40000010:/ window 100000 jump 0
+0.0 "--Reset--" sync / 21:........:4000000F:/ window 100000 jump 0
 
 0.0 "--sync--" sync /:Engage!/ window 0,1
 1.8 "--sync--" sync / 1[56]:[^:]*:Sophia:19C3:/ window 1.8,2

--- a/ui/raidboss/data/04-sb/raid/o10n.txt
+++ b/ui/raidboss/data/04-sb/raid/o10n.txt
@@ -1,7 +1,7 @@
 # Omega - Alphascape V2.0 - O10N
 # -r MGmYR8kHQta1vN4D -rf 54 -ii 31F9 362D 31D5 3624 3630 31FB 3638
 
-0.0 "--Reset--" sync / 21:........:40000010:/ window 100000 jump 0
+0.0 "--Reset--" sync / 21:........:4000000F:/ window 100000 jump 0
 
 hideall "--Reset--"
 hideall "--sync--"

--- a/ui/raidboss/data/04-sb/raid/o10s.txt
+++ b/ui/raidboss/data/04-sb/raid/o10s.txt
@@ -4,7 +4,7 @@
 hideall "--Reset--"
 hideall "--sync--"
 
-0.0 "--Reset--" sync / 21:........:40000010:/ window 100000 jump 0
+0.0 "--Reset--" sync / 21:........:4000000F:/ window 100000 jump 0
 
 0.0 "Start" sync / 00:0044:[^:]*:I am Midgardsormr/ window 0,1
 0.0 "--sync--" sync /:Engage!/ window 0,1

--- a/ui/raidboss/data/04-sb/raid/o11n.txt
+++ b/ui/raidboss/data/04-sb/raid/o11n.txt
@@ -1,6 +1,6 @@
 # Omega - Alphascape V3.0 - O11N
 
-0.0 "--Reset--" sync / 21:........:40000010:/ window 100000 jump 0
+0.0 "--Reset--" sync / 21:........:4000000F:/ window 100000 jump 0
 
 hideall "--Reset--"
 hideall "--sync--"

--- a/ui/raidboss/data/04-sb/raid/o11s.txt
+++ b/ui/raidboss/data/04-sb/raid/o11s.txt
@@ -7,7 +7,7 @@
 hideall "--Reset--"
 hideall "--sync--"
 
-0.0 "--Reset--" sync / 21:........:40000010:/ window 100000 jump 0
+0.0 "--Reset--" sync / 21:........:4000000F:/ window 100000 jump 0
 
 # Phase 1
 0.0 "--sync--" sync /:Engage!/ window 0,1

--- a/ui/raidboss/data/04-sb/raid/o12n.txt
+++ b/ui/raidboss/data/04-sb/raid/o12n.txt
@@ -1,7 +1,7 @@
 # Omega - Alphascape V4.0 - O12N
 # -ii 3326 32FA 32FC 32F5 330C 330B 32FE 3302 34CB 32F7 32FB 32F2 32F8 32F9 330E 3318 3306 3307 331C 331D 3395 331F 3324 3321 3310 3393 -p 330F:15.3 3319:700
 
-0.0 "--Reset--" sync / 21:........:40000010:/ window 100000 jump 0
+0.0 "--Reset--" sync / 21:........:4000000F:/ window 100000 jump 0
 
 hideall "--Reset--"
 hideall "--sync--"

--- a/ui/raidboss/data/04-sb/raid/o12s.txt
+++ b/ui/raidboss/data/04-sb/raid/o12s.txt
@@ -6,7 +6,7 @@
 hideall "--Reset--"
 hideall "--sync--"
 
-0.0 "--Reset--" sync / 21:........:40000010:/ window 100000 jump 0
+0.0 "--Reset--" sync / 21:........:4000000F:/ window 100000 jump 0
 
 0.0 "Start" sync / 00:0044:[^:]*:I am the Omega/ window 1,0
 2.4 "--sync--" sync / 1[56]:[^:]*:Omega-M:337D:/ window 2.4,0.5 # first auto
@@ -160,7 +160,7 @@ hideall "--sync--"
 # Final Omega - Alphascape V4.0 (Savage) - O12S+
 # -r ch1gtabdwN7QYDR6 -p 336C:3016 -ii 3380 3369 3366 335F 3377 336B 33B5
 
-0.0 "--Reset--" sync / 21:........:40000010:/ window 100000 jump 0
+0.0 "--Reset--" sync / 21:........:4000000F:/ window 100000 jump 0
 
 3000.0 "Start"
 3002.5 "--sync--" sync / 1[56]:[^:]*:Omega:3380:/ window 3003,0

--- a/ui/raidboss/data/04-sb/raid/o1n.txt
+++ b/ui/raidboss/data/04-sb/raid/o1n.txt
@@ -4,7 +4,7 @@
 
 # Enrage is approximately 13:40. Yes, Normal has an enrage.
 # -ii 1ED9 1EDA 23D7 23D9 2583
-0.0 "--Reset--" sync / 21:........:40000010:/ window 100000 jump 0
+0.0 "--Reset--" sync / 21:........:4000000F:/ window 100000 jump 0
 
 0.0 "--sync--" sync /:Engage!/ window 0,1
 1.8 "--sync--" sync / 1[56]:[^:]*:Alte Roite:368:/ window 2,0

--- a/ui/raidboss/data/04-sb/raid/o1s.txt
+++ b/ui/raidboss/data/04-sb/raid/o1s.txt
@@ -7,7 +7,7 @@ hideall "--sync--"
 hideall "--Reset--"
 hideall "Flame"
 
-0.0 "--Reset--" sync / 21:........:40000010:/ window 100000 jump 0
+0.0 "--Reset--" sync / 21:........:4000000F:/ window 100000 jump 0
 
 ###### 1st Classical Elements
 # spread: knockback => in => spread+lightning

--- a/ui/raidboss/data/04-sb/raid/o2n.txt
+++ b/ui/raidboss/data/04-sb/raid/o2n.txt
@@ -6,7 +6,7 @@ hideall "--sync--"
 
 # Unlike O1N and O3N, Catastrophe has no enrage.
 # -ii 24E8 24FC 2500 2501 2505 2514 2515 2516
-0.0 "--Reset--" sync / 21:........:40000010:/ window 100000 jump 0
+0.0 "--Reset--" sync / 21:........:4000000F:/ window 100000 jump 0
 
 0.0 "--sync--" sync /:Engage!/ window 0,1
 3.0 "--sync--" sync / 1[56]:[^:]*:Catastrophe:24E8:/ window 3,1

--- a/ui/raidboss/data/04-sb/raid/o2s.txt
+++ b/ui/raidboss/data/04-sb/raid/o2s.txt
@@ -8,7 +8,7 @@
 hideall "--sync--"
 hideall "--Reset--"
 
-0.0 "--Reset--" sync / 21:........:40000010:/ window 100000 jump 0
+0.0 "--Reset--" sync / 21:........:4000000F:/ window 100000 jump 0
 
 0.0 "--sync--" sync /:Engage!/ window 0,1
 1.3 "--sync--" sync / 1[56]:[^:]*:Catastrophe:25B6:/ window 0,1.3

--- a/ui/raidboss/data/04-sb/raid/o3n.txt
+++ b/ui/raidboss/data/04-sb/raid/o3n.txt
@@ -4,7 +4,7 @@
 
 # Enrage is approximately 13:10-13:30, depending on intermission length. Yes, Normal has an enrage.
 # -ii 230C 2470 2472 2473
-0.0 "--Reset--" sync / 21:........:40000010:/ window 100000 jump 0
+0.0 "--Reset--" sync / 21:........:4000000F:/ window 100000 jump 0
 
 0.0 "--sync--" sync /:Engage!/ window 0,1
 3.2 "--sync--" sync / 1[56]:[^:]*:Halicarnassus:367:/ window 3.2,1

--- a/ui/raidboss/data/04-sb/raid/o3s.txt
+++ b/ui/raidboss/data/04-sb/raid/o3s.txt
@@ -4,7 +4,7 @@
 hideall "--Reset--"
 hideall "--sync--"
 
-0.0 "--Reset--" sync / 21:........:40000010:/ window 100000 jump 0
+0.0 "--Reset--" sync / 21:........:4000000F:/ window 100000 jump 0
 
 # -ii 22EA 22FE 2309 230C 230F 2315
 

--- a/ui/raidboss/data/04-sb/raid/o4n.txt
+++ b/ui/raidboss/data/04-sb/raid/o4n.txt
@@ -8,7 +8,7 @@ hideall "--Reset--"
 hideall "--sync--"
 
 # -ii 24BA 24BC 24BE 24C3 24C5
-0.0 "--Reset--" sync / 21:........:40000010:/ window 100000 jump 0
+0.0 "--Reset--" sync / 21:........:4000000F:/ window 100000 jump 0
 
 0.0 "--sync--" sync /:Engage!/ window 0,1
 2.5 "--sync--" sync / 1[56]:[^:]*:Exdeath:366:/ window 2.5,1

--- a/ui/raidboss/data/04-sb/raid/o4s.txt
+++ b/ui/raidboss/data/04-sb/raid/o4s.txt
@@ -3,7 +3,7 @@
 hideall "--Reset--"
 hideall "--sync--"
 
-0.0 "--Reset--" sync / 21:........:40000010:/ window 100000 jump 0
+0.0 "--Reset--" sync / 21:........:4000000F:/ window 100000 jump 0
 
 # -ii 23F2 23F8 2400 240C
 

--- a/ui/raidboss/data/04-sb/raid/o5n.txt
+++ b/ui/raidboss/data/04-sb/raid/o5n.txt
@@ -7,7 +7,7 @@ hideall "--sync--"
 # Diabolic Light: 0 target appears, 8 target, 13 hit
 
 ##############################################################
-0.0 "--Reset--" sync / 21:........:40000010:/ window 100000 jump 0
+0.0 "--Reset--" sync / 21:........:4000000F:/ window 100000 jump 0
 
 0.0 "--sync--" sync /:Engage!/ window 0,1
 8 "--sync--" sync / 14:[^:]*:Wroth Ghost:28AE:/ window 8,3

--- a/ui/raidboss/data/04-sb/raid/o5s.txt
+++ b/ui/raidboss/data/04-sb/raid/o5s.txt
@@ -7,7 +7,7 @@ hideall "--sync--"
 # Diabolic Light: 0 target appears, 8 target, 13 hit
 
 ##############################################################
-0.0 "--Reset--" sync / 21:........:40000010:/ window 100000 jump 0
+0.0 "--Reset--" sync / 21:........:4000000F:/ window 100000 jump 0
 
 0.0 "--sync--" sync /:Engage!/ window 0,1
 11 "Encumber" sync / 1[56]:[^:]*:Wroth Ghost:28B6:/

--- a/ui/raidboss/data/04-sb/raid/o6n.txt
+++ b/ui/raidboss/data/04-sb/raid/o6n.txt
@@ -3,7 +3,7 @@
 hideall "--Reset--"
 hideall "--sync--"
 
-0.0 "--Reset--" sync / 21:........:40000010:/ window 100000 jump 0
+0.0 "--Reset--" sync / 21:........:4000000F:/ window 100000 jump 0
 
 0 "Start" sync / 00:0044:[^:]*:I have claimed the girl in the picture! She's mine! You can't have her!/ window 0,1
 18 "--targetable--"

--- a/ui/raidboss/data/04-sb/raid/o6s.txt
+++ b/ui/raidboss/data/04-sb/raid/o6s.txt
@@ -3,7 +3,7 @@
 hideall "--Reset--"
 hideall "--sync--"
 
-0.0 "--Reset--" sync / 21:........:40000010:/ window 100000 jump 0
+0.0 "--Reset--" sync / 21:........:4000000F:/ window 100000 jump 0
 
 0 "Start" sync / 00:0044:[^:]*I have claimed the girl in the picture!/ window 0,1
 18 "--targetable--"

--- a/ui/raidboss/data/04-sb/raid/o7n.txt
+++ b/ui/raidboss/data/04-sb/raid/o7n.txt
@@ -3,7 +3,7 @@
 hideall "--Reset--"
 hideall "--sync--"
 
-0.0 "--Reset--" sync / 21:........:40000010:/ window 100000 jump 0
+0.0 "--Reset--" sync / 21:........:4000000F:/ window 100000 jump 0
 
 0 "Start" sync / 00:0044:[^:]*:WEAPON SYSTEMS ONLINE/
 11 "Magitek Ray" sync / 1[56]:[^:]*:Guardian:276B:/ window 11,10

--- a/ui/raidboss/data/04-sb/raid/o7s.txt
+++ b/ui/raidboss/data/04-sb/raid/o7s.txt
@@ -2,7 +2,7 @@
 
 hideall "--sync--"
 
-0.0 "--Reset--" sync / 21:........:40000010:/ window 100000 jump 0
+0.0 "--Reset--" sync / 21:........:4000000F:/ window 100000 jump 0
 
 0 "Start" sync / 00:0044:[^:]*:WEAPON SYSTEMS ONLINE/ window 0,1
 11 "Magitek Ray" sync / 1[56]:[^:]*:Guardian:2788:/ window 11,10

--- a/ui/raidboss/data/04-sb/raid/o8n.txt
+++ b/ui/raidboss/data/04-sb/raid/o8n.txt
@@ -3,7 +3,7 @@
 hideall "--Reset--"
 hideall "--sync--"
 
-0.0 "--Reset--" sync / 21:........:40000010:/ window 100000 jump 0
+0.0 "--Reset--" sync / 21:........:4000000F:/ window 100000 jump 0
 
 0 "Start" sync / 00:0044:[^:]*:Destroy! Destroy! Destroy! I will destroy it all!/
 15 "Hyperdrive" sync / 1[56]:[^:]*:Kefka:292E:/ window 16,3

--- a/ui/raidboss/data/04-sb/raid/o8s.txt
+++ b/ui/raidboss/data/04-sb/raid/o8s.txt
@@ -4,7 +4,7 @@ hideall "--Reset--"
 hideall "--sync--"
 
 0.0 "--Reset--" sync / 00:0839::The limit gauge resets!/ window 10000 jump 0
-0.0 "--Reset--" sync / 21:........:40000010:/ window 100000 jump 0
+0.0 "--Reset--" sync / 21:........:4000000F:/ window 100000 jump 0
 
 4 "--sync--" sync / 1[56]:[^:]*:Kefka:28C2:/ window 5,0
 13 "Mana Charge" sync / 1[56]:[^:]*:Kefka:28D1:/ window 20,20 # drift 0.476

--- a/ui/raidboss/data/04-sb/raid/o9n.txt
+++ b/ui/raidboss/data/04-sb/raid/o9n.txt
@@ -1,7 +1,7 @@
 # Omega - Alphascape V1.0 - O9N
 # -r v7g6rkfjhNGDzLn8 -rf 2 -ii 314E 3202 3161 3164 3157 316E 315F  3162 3163 3204 3160 3203 3158 3164 3205 3148 3153
 
-0.0 "--Reset--" sync / 21:........:40000010:/ window 100000 jump 0
+0.0 "--Reset--" sync / 21:........:4000000F:/ window 100000 jump 0
 
 hideall "--Reset--"
 hideall "--sync--"

--- a/ui/raidboss/data/04-sb/raid/o9s.txt
+++ b/ui/raidboss/data/04-sb/raid/o9s.txt
@@ -4,7 +4,7 @@
 hideall "--Reset--"
 hideall "--sync--"
 
-0.0 "--Reset--" sync / 21:........:40000010:/ window 100000 jump 0
+0.0 "--Reset--" sync / 21:........:4000000F:/ window 100000 jump 0
 
 0 "Start"
 0.0 "--sync--" sync /:Engage!/ window 0,1

--- a/ui/raidboss/data/04-sb/trial/byakko-ex.txt
+++ b/ui/raidboss/data/04-sb/trial/byakko-ex.txt
@@ -8,7 +8,7 @@ hideall "--Reset--"
 # not useful to see
 hideall "Answer On High"
 
-0.0 "--Reset--" sync / 21:........:40000010:/ window 100000 jump 0
+0.0 "--Reset--" sync / 21:........:4000000F:/ window 100000 jump 0
 
 ### Phase 1
 0.0 "--sync--" sync /:Engage!/ window 0,1

--- a/ui/raidboss/data/04-sb/trial/byakko.txt
+++ b/ui/raidboss/data/04-sb/trial/byakko.txt
@@ -10,7 +10,7 @@ hideall "Answer On High"
 # redundant with Highest Stakes
 hideall "Clutch"
 
-0.0 "--Reset--" sync / 21:........:40000010:/ window 100000 jump 0
+0.0 "--Reset--" sync / 21:........:4000000F:/ window 100000 jump 0
 
 ### Phase 1
 0.0 "--sync--" sync /:Engage!/ window 0,1

--- a/ui/raidboss/data/04-sb/trial/lakshmi-ex.txt
+++ b/ui/raidboss/data/04-sb/trial/lakshmi-ex.txt
@@ -7,7 +7,7 @@ hideall "--Reset--"
 hideall "--sync--"
 hideall "Alluring Arm"
 
-0.0 "--Reset--" sync / 21:........:40000010:/ window 100000 jump 0
+0.0 "--Reset--" sync / 21:........:4000000F:/ window 100000 jump 0
 
 ### Adds
 0.0 "--sync--" sync /:Engage!/ window 0,1

--- a/ui/raidboss/data/04-sb/trial/lakshmi.txt
+++ b/ui/raidboss/data/04-sb/trial/lakshmi.txt
@@ -7,7 +7,7 @@ hideall "Alluring Arm"
 
 # -ii 2157 248B 248D
 
-0.0 "--Reset--" sync / 21:........:40000010:/ window 100000 jump 0
+0.0 "--Reset--" sync / 21:........:4000000F:/ window 100000 jump 0
 
 0.0 "--sync--" sync /:Engage!/ window 0,1
 3.9 "Vril" sync / 1[56]:[^:]*:Dreaming Kshatriya:2482:/ window 3.9,5

--- a/ui/raidboss/data/04-sb/trial/seiryu-ex.txt
+++ b/ui/raidboss/data/04-sb/trial/seiryu-ex.txt
@@ -4,7 +4,7 @@
 hideall "--Reset--"
 hideall "--sync--"
 
-0.0 "--Reset--" sync / 21:........:40000010:/ window 100000 jump 0
+0.0 "--Reset--" sync / 21:........:4000000F:/ window 100000 jump 0
 
 # Phase 1
 0.0 "--sync--" sync /:Engage!/ window 0,1

--- a/ui/raidboss/data/04-sb/trial/seiryu.txt
+++ b/ui/raidboss/data/04-sb/trial/seiryu.txt
@@ -6,7 +6,7 @@
 hideall "--Reset--"
 hideall "--sync--"
 
-0.0 "--Reset--" sync / 21:........:40000010:/ window 100000 jump 0
+0.0 "--Reset--" sync / 21:........:4000000F:/ window 100000 jump 0
 
 ### Phase 1
 0.0 "--sync--" sync /:Engage!/ window 0,1

--- a/ui/raidboss/data/04-sb/trial/shinryu-ex.txt
+++ b/ui/raidboss/data/04-sb/trial/shinryu-ex.txt
@@ -8,7 +8,7 @@
 hideall "--Reset--"
 hideall "--sync--"
 
-0.0 "--Reset--" sync / 21:........:40000010:/ window 100000 jump 0
+0.0 "--Reset--" sync / 21:........:4000000F:/ window 100000 jump 0
 
 # Heart add not listed here. Seems to be on an independent respawn timer.
 

--- a/ui/raidboss/data/04-sb/trial/shinryu.txt
+++ b/ui/raidboss/data/04-sb/trial/shinryu.txt
@@ -6,7 +6,7 @@ hideall "--sync--"
 # Elemental Attack is one of:
 # Aerial Blast, Judgment Bolt, Diamond Dust, Hellfire, Earthen Fury, Tidal Wave
 
-0.0 "--Reset--" sync / 21:........:40000010:/ window 100000 jump 0
+0.0 "--Reset--" sync / 21:........:4000000F:/ window 100000 jump 0
 
 0.0 "--sync--" sync /:Engage!/ window 0,1
 1.0 "--sync--" sync / 1[56]:[^:]*:(Left Wing|Right Wing):1FA9:/ window 1,2

--- a/ui/raidboss/data/04-sb/trial/susano-ex.txt
+++ b/ui/raidboss/data/04-sb/trial/susano-ex.txt
@@ -10,7 +10,7 @@ hideall "Yasakani-No-Magatama"
 # Used for triggers.
 hideall "--knockback cloud--"
 
-0.0 "--Reset--" sync / 21:........:40000010:/ window 100000 jump 0
+0.0 "--Reset--" sync / 21:........:4000000F:/ window 100000 jump 0
 
 ### Phase 1 ###
 0.0 "--sync--" sync /:Engage!/ window 0,1

--- a/ui/raidboss/data/04-sb/trial/susano.txt
+++ b/ui/raidboss/data/04-sb/trial/susano.txt
@@ -8,7 +8,7 @@ hideall "--sync--"
 hideall "Yata-No-Kagami"
 hideall "Yasakani-No-Magatama"
 
-0.0 "--Reset--" sync / 21:........:40000010:/ window 100000 jump 0
+0.0 "--Reset--" sync / 21:........:4000000F:/ window 100000 jump 0
 
 ### Phase 1
 0.0 "--sync--" sync /:Engage!/ window 0,1

--- a/ui/raidboss/data/04-sb/trial/suzaku-ex.txt
+++ b/ui/raidboss/data/04-sb/trial/suzaku-ex.txt
@@ -4,7 +4,7 @@
 hideall "--Reset--"
 hideall "--sync--"
 
-0.0 "--Reset--" sync / 21:........:40000010:/ window 100000 jump 0
+0.0 "--Reset--" sync / 21:........:4000000F:/ window 100000 jump 0
 
 0.0 "Start" sync / 00:0044:[^:]*:Tenzen/
 2.5 "--sync--" sync / 1[56]:[^:]*:Suzaku:367:/ window 5,0

--- a/ui/raidboss/data/04-sb/trial/suzaku.txt
+++ b/ui/raidboss/data/04-sb/trial/suzaku.txt
@@ -4,7 +4,7 @@
 hideall "--Reset--"
 hideall "--sync--"
 
-0.0 "--Reset--" sync / 21:........:40000010:/ window 100000 jump 0
+0.0 "--Reset--" sync / 21:........:4000000F:/ window 100000 jump 0
 
 0.0 "--sync--" sync /:Engage!/ window 0,1
 2.5 "--sync--" sync / 1[56]:[^:]*:Suzaku:367:/ window 2.5,1

--- a/ui/raidboss/data/04-sb/trial/tsukuyomi-ex.txt
+++ b/ui/raidboss/data/04-sb/trial/tsukuyomi-ex.txt
@@ -8,7 +8,7 @@
 hideall "--sync--"
 hideall "--Reset--"
 
-0.0 "--Reset--" sync / 21:........:40000010:/ window 100000 jump 0
+0.0 "--Reset--" sync / 21:........:4000000F:/ window 100000 jump 0
 
 # Timings get slightly off if there's lead or steel first, so do a split.
 0.0 "--sync--" sync /:Engage!/ window 0,1

--- a/ui/raidboss/data/04-sb/trial/tsukuyomi.txt
+++ b/ui/raidboss/data/04-sb/trial/tsukuyomi.txt
@@ -6,7 +6,7 @@
 hideall "--sync--"
 hideall "--Reset--"
 
-0.0 "--Reset--" sync / 21:........:40000010:/ window 100000 jump 0
+0.0 "--Reset--" sync / 21:........:4000000F:/ window 100000 jump 0
 
 ### Phase 1
 0.0 "--sync--" sync /:Engage!/ window 0,1

--- a/ui/raidboss/data/04-sb/trial/yojimbo.txt
+++ b/ui/raidboss/data/04-sb/trial/yojimbo.txt
@@ -24,7 +24,7 @@
 
 hideall "--Reset--"
 hideall "--sync--"
-0.0 "--Reset--" sync / 21:........:40000010:/ window 100000 jump 0
+0.0 "--Reset--" sync / 21:........:4000000F:/ window 100000 jump 0
 
 0.0 "Start"
 0.0 "--sync--" sync /:Engage!/ window 0,1

--- a/ui/raidboss/data/04-sb/ultimate/ultima_weapon_ultimate.txt
+++ b/ui/raidboss/data/04-sb/ultimate/ultima_weapon_ultimate.txt
@@ -4,7 +4,7 @@
 hideall "--sync--"
 hideall "--Reset--"
 
-0.0 "--Reset--" sync / 21:........:40000010:/ window 100000 jump 0
+0.0 "--Reset--" sync / 21:........:4000000F:/ window 100000 jump 0
 
 ### Phase 1: Garuda ###
 0.0 "--sync--" sync /:Engage!/ window 0,1

--- a/ui/raidboss/data/04-sb/ultimate/unending_coil_ultimate.txt
+++ b/ui/raidboss/data/04-sb/ultimate/unending_coil_ultimate.txt
@@ -6,7 +6,7 @@
 hideall "--Reset--"
 hideall "--sync--"
 
-0.0 "--Reset--" sync / 21:........:40000010:/ window 100000 jump 0
+0.0 "--Reset--" sync / 21:........:4000000F:/ window 100000 jump 0
 
 ##### TWINTANIA #####
 ### Twintania P1: 100% -> 75%

--- a/ui/raidboss/data/05-shb/eureka/delubrum_reginae.txt
+++ b/ui/raidboss/data/05-shb/eureka/delubrum_reginae.txt
@@ -7,7 +7,7 @@ hideall "--sync--"
 # Note: various "Blast" are renamed "Elemental Blast" and various "Arrow" are renamed
 # to be "Elemental Arrow" to avoid having too many skills on the timeline.
 
-0.0 "--Reset--" sync / 21:........:40000010:/ window 100000 jump 0
+0.0 "--Reset--" sync / 21:........:4000000F:/ window 100000 jump 0
 0.0 "--Reset--" sync / 00:0839::.*is no longer sealed/ window 100000 jump 0
 
 ### Trinity Seeker

--- a/ui/raidboss/data/05-shb/eureka/delubrum_reginae_savage.txt
+++ b/ui/raidboss/data/05-shb/eureka/delubrum_reginae_savage.txt
@@ -9,7 +9,7 @@ hideall "--sync--"
 # boss, as the Stygimoloch Warrior and Dahu areas can be seen from one
 # another, and so a generic "is no longer sealed" from one would stop
 # any timeline running for those in the other.
-0.0 "--Reset--" sync / 21:........:40000010:/ window 100000 jump 0
+0.0 "--Reset--" sync / 21:........:4000000F:/ window 100000 jump 0
 
 
 ### Slimes (The Barracks, left side)

--- a/ui/raidboss/data/05-shb/raid/e10n.txt
+++ b/ui/raidboss/data/05-shb/raid/e10n.txt
@@ -6,7 +6,7 @@ hideall "--sync--"
 
 # -ii 56B0 56B6 56B9 56BA 56BB 56BD 56BE 56C0 56C1 56CC 56D4 56D5 56D8 56D9 56E1 56E7 5B09 5B0D 5B26
 
-0.0 "--Reset--" sync / 21:........:40000010:/ window 100000 jump 0
+0.0 "--Reset--" sync / 21:........:4000000F:/ window 100000 jump 0
 
 0.0 "--sync--" sync /:Engage!/ window 0,1
 2.6 "--sync--" sync / 1[56]:[^:]*:Shadowkeeper:5B09:/ window 2.6,1

--- a/ui/raidboss/data/05-shb/raid/e10s.txt
+++ b/ui/raidboss/data/05-shb/raid/e10s.txt
@@ -12,7 +12,7 @@
 hideall "--Reset--"
 hideall "--sync--"
 
-0.0 "--Reset--" sync / 21:........:40000010:/ window 100000 jump 0
+0.0 "--Reset--" sync / 21:........:4000000F:/ window 100000 jump 0
 
 0 "Start"
 0.0 "--sync--" sync /:Engage!/ window 0,1

--- a/ui/raidboss/data/05-shb/raid/e11n.txt
+++ b/ui/raidboss/data/05-shb/raid/e11n.txt
@@ -4,7 +4,7 @@
 hideall "--Reset--"
 hideall "--sync--"
 
-0.0 "--Reset--" sync / 21:........:40000010:/ window 100000 jump 0
+0.0 "--Reset--" sync / 21:........:4000000F:/ window 100000 jump 0
 
 # -ii 366 4B18 4B19 4B1B
 

--- a/ui/raidboss/data/05-shb/raid/e11s.txt
+++ b/ui/raidboss/data/05-shb/raid/e11s.txt
@@ -34,7 +34,7 @@ hideall "--sync--"
 # Time these to burnout where it's random, and comment out the sync.
 # If testing were smarter we could have an optional sync here, otherwise test_timeline.py will be weird.
 
-0.0 "--Reset--" sync / 21:........:40000010:/ window 100000 jump 0
+0.0 "--Reset--" sync / 21:........:4000000F:/ window 100000 jump 0
 
 # Phase 1
 0 "Start"

--- a/ui/raidboss/data/05-shb/raid/e12n.txt
+++ b/ui/raidboss/data/05-shb/raid/e12n.txt
@@ -4,7 +4,7 @@
 hideall "--Reset--"
 hideall "--sync--"
 
-0.0 "--Reset--" sync / 21:........:40000010:/ window 100000 jump 0
+0.0 "--Reset--" sync / 21:........:4000000F:/ window 100000 jump 0
 
 # -ii 4B47 4B1D 5865 585B 586B 5874 5875 5876 587E 587F 5882 5884 5889 588A 588B
 # -ic "Lissom Sculpture" "Beastly Sculpture"

--- a/ui/raidboss/data/05-shb/raid/e12s.txt
+++ b/ui/raidboss/data/05-shb/raid/e12s.txt
@@ -4,7 +4,7 @@
 hideall "--Reset--"
 hideall "--sync--"
 
-0.0 "--Reset--" sync / 21:........:40000010:/ window 100000 jump 0
+0.0 "--Reset--" sync / 21:........:4000000F:/ window 100000 jump 0
 
 ### Eden's Promise
 # -ii 4B1E 58AA 58AB 4E44 4E45 4E46 4E47 589B 4E5A 58A0 58B8 5897 58B0 58B4 4F9E 58BB 58BC

--- a/ui/raidboss/data/05-shb/raid/e1n.txt
+++ b/ui/raidboss/data/05-shb/raid/e1n.txt
@@ -6,7 +6,7 @@ hideall "--Reset--"
 hideall "--sync--"
 hideall "Vice And Virtue"
 
-0.0 "--Reset--" sync / 21:........:40000010:/ window 100000 jump 0
+0.0 "--Reset--" sync / 21:........:4000000F:/ window 100000 jump 0
 
 ### Phase 1
 0 "Start"

--- a/ui/raidboss/data/05-shb/raid/e1s.txt
+++ b/ui/raidboss/data/05-shb/raid/e1s.txt
@@ -5,7 +5,7 @@
 hideall "--Reset--"
 hideall "--sync--"
 
-0.0 "--Reset--" sync / 21:........:40000010:/ window 100000 jump 0
+0.0 "--Reset--" sync / 21:........:4000000F:/ window 100000 jump 0
 
 ### Phase 1
 0 "Start"

--- a/ui/raidboss/data/05-shb/raid/e2n.txt
+++ b/ui/raidboss/data/05-shb/raid/e2n.txt
@@ -6,7 +6,7 @@ hideall "--Reset--"
 hideall "--sync--"
 hideall "Spell-In-Waiting"
 
-0.0 "--Reset--" sync / 21:........:40000010:/ window 100000 jump 0
+0.0 "--Reset--" sync / 21:........:4000000F:/ window 100000 jump 0
 
 0 "Start"
 0.0 "--sync--" sync /:Engage!/ window 0,1

--- a/ui/raidboss/data/05-shb/raid/e2s.txt
+++ b/ui/raidboss/data/05-shb/raid/e2s.txt
@@ -6,7 +6,7 @@ hideall "--Reset--"
 hideall "--sync--"
 hideall "Spell-In-Waiting"
 
-0.0 "--Reset--" sync / 21:........:40000010:/ window 100000 jump 0
+0.0 "--Reset--" sync / 21:........:4000000F:/ window 100000 jump 0
 
 0 "Start"
 0.0 "--sync--" sync /:Engage!/ window 0,1

--- a/ui/raidboss/data/05-shb/raid/e3n.txt
+++ b/ui/raidboss/data/05-shb/raid/e3n.txt
@@ -5,7 +5,7 @@
 hideall "--Reset--"
 hideall "--sync--"
 
-0.0 "--Reset--" sync / 21:........:40000010:/ window 100000 jump 0
+0.0 "--Reset--" sync / 21:........:4000000F:/ window 100000 jump 0
 
 0.0 "--sync--" sync /:Engage!/ window 0,1
 0.5 "--sync--" sync / 1[56]:[^:]*:Leviathan:42D8:/ window 1,0

--- a/ui/raidboss/data/05-shb/raid/e3s.txt
+++ b/ui/raidboss/data/05-shb/raid/e3s.txt
@@ -5,7 +5,7 @@
 hideall "--Reset--"
 hideall "--sync--"
 
-0.0 "--Reset--" sync / 21:........:40000010:/ window 100000 jump 0
+0.0 "--Reset--" sync / 21:........:4000000F:/ window 100000 jump 0
 
 0 "Start"
 0.0 "--sync--" sync /:Engage!/ window 0,1

--- a/ui/raidboss/data/05-shb/raid/e4n.txt
+++ b/ui/raidboss/data/05-shb/raid/e4n.txt
@@ -9,7 +9,7 @@ hideall "Earthen Armor"
 hideall "Earthen Gauntlets"
 hideall "Earthen Wheels"
 
-0.0 "--Reset--" sync / 21:........:40000010:/ window 100000 jump 0
+0.0 "--Reset--" sync / 21:........:4000000F:/ window 100000 jump 0
 
 # Phase chart
 # 1->2->3->

--- a/ui/raidboss/data/05-shb/raid/e4s.txt
+++ b/ui/raidboss/data/05-shb/raid/e4s.txt
@@ -8,7 +8,7 @@ hideall "Earthen Armor"
 hideall "Earthen Gauntlets"
 hideall "Earthen Wheels"
 
-0.0 "--Reset--" sync / 21:........:40000010:/ window 100000 jump 0
+0.0 "--Reset--" sync / 21:........:4000000F:/ window 100000 jump 0
 
 ### Warmup
 0 "Start"

--- a/ui/raidboss/data/05-shb/raid/e5n.txt
+++ b/ui/raidboss/data/05-shb/raid/e5n.txt
@@ -4,7 +4,7 @@
 hideall "--Reset--"
 hideall "--sync--"
 
-0.0 "--Reset--" sync / 21:........:40000010:/ window 100000 jump 0
+0.0 "--Reset--" sync / 21:........:4000000F:/ window 100000 jump 0
 
 # ic "Stormcloud" -ii 4B8F 4B93 4B97 4B99 4B9A 4BA1 4BA2
 

--- a/ui/raidboss/data/05-shb/raid/e5s.txt
+++ b/ui/raidboss/data/05-shb/raid/e5s.txt
@@ -5,7 +5,7 @@
 hideall "--Reset--"
 hideall "--sync--"
 
-0.0 "--Reset--" sync / 21:........:40000010:/ window 100000 jump 0
+0.0 "--Reset--" sync / 21:........:4000000F:/ window 100000 jump 0
 
 0 "Start"
 0.0 "--sync--" sync /:Engage!/ window 0,1

--- a/ui/raidboss/data/05-shb/raid/e6n.txt
+++ b/ui/raidboss/data/05-shb/raid/e6n.txt
@@ -7,7 +7,7 @@ hideall "--sync--"
 # -ii 4BDD 4BE1 4BEB 4BEA 4BE5 4BE9 4BEC 4BD9 4BE7 4E39 4C1D 4C20 4F98
 # -ic "Tumultuous Nexus" "Great Ball Of Fire"
 
-0.0 "--Reset--" sync / 21:........:40000010:/ window 100000 jump 0
+0.0 "--Reset--" sync / 21:........:4000000F:/ window 100000 jump 0
 
 0.0 "--sync--" sync /:Engage!/ window 0,1
 

--- a/ui/raidboss/data/05-shb/raid/e6s.txt
+++ b/ui/raidboss/data/05-shb/raid/e6s.txt
@@ -6,7 +6,7 @@
 hideall "--Reset--"
 hideall "--sync--"
 
-0.0 "--Reset--" sync / 21:........:40000010:/ window 100000 jump 0
+0.0 "--Reset--" sync / 21:........:4000000F:/ window 100000 jump 0
 
 ### Phase 1: Garuda
 0 "Start"

--- a/ui/raidboss/data/05-shb/raid/e7n.txt
+++ b/ui/raidboss/data/05-shb/raid/e7n.txt
@@ -6,7 +6,7 @@ hideall "--sync--"
 
 # -ii 4C30 4C32 4C33 4C36 4C3A 4C49 4D0A 4D0B
 
-0.0 "--Reset--" sync / 21:........:40000010:/ window 100000 jump 0
+0.0 "--Reset--" sync / 21:........:4000000F:/ window 100000 jump 0
 
 
 # Opening block

--- a/ui/raidboss/data/05-shb/raid/e7s.txt
+++ b/ui/raidboss/data/05-shb/raid/e7s.txt
@@ -9,7 +9,7 @@
 hideall "--Reset--"
 hideall "--sync--"
 
-0.0 "--Reset--" sync / 21:........:40000010:/ window 100000 jump 0
+0.0 "--Reset--" sync / 21:........:4000000F:/ window 100000 jump 0
 
 ### Phase 1
 0.0 "--sync--" sync /:Engage!/ window 0,1

--- a/ui/raidboss/data/05-shb/raid/e8n.txt
+++ b/ui/raidboss/data/05-shb/raid/e8n.txt
@@ -6,7 +6,7 @@ hideall "--sync--"
 
 # -ii 4D58 4DD3 4DDF 4DE0 4DF3 4DF5 4E0B 4E0D 4E10 4E11 4E18 4FC9 4FCA
 
-0.0 "--Reset--" sync / 21:........:40000010:/ window 100000 jump 0
+0.0 "--Reset--" sync / 21:........:4000000F:/ window 100000 jump 0
 
 # Opening block
 0.0 "--sync--" sync /:Engage!/ window 0,1

--- a/ui/raidboss/data/05-shb/raid/e8s.txt
+++ b/ui/raidboss/data/05-shb/raid/e8s.txt
@@ -5,7 +5,7 @@
 hideall "--Reset--"
 hideall "--sync--"
 
-0.0 "--Reset--" sync / 21:........:40000010:/ window 100000 jump 0
+0.0 "--Reset--" sync / 21:........:4000000F:/ window 100000 jump 0
 
 0.0 "--sync--" sync /:Engage!/ window 0,1
 1.5 "--sync--" sync / 1[56]:[^:]*:Shiva:4D59:/ window 2,0

--- a/ui/raidboss/data/05-shb/raid/e9n.txt
+++ b/ui/raidboss/data/05-shb/raid/e9n.txt
@@ -6,7 +6,7 @@ hideall "--sync--"
 
 # -ii 5626 5B18 55E1 55E3 5159 532F 55DB 55E5
 
-0.0 "--Reset--" sync / 21:........:40000010:/ window 100000 jump 0
+0.0 "--Reset--" sync / 21:........:4000000F:/ window 100000 jump 0
 
 0.0 "--sync--" sync /:Engage!/ window 0,1
 # Unfortunately we can't sync to a first attack here,

--- a/ui/raidboss/data/05-shb/raid/e9s.txt
+++ b/ui/raidboss/data/05-shb/raid/e9s.txt
@@ -5,7 +5,7 @@
 hideall "--Reset--"
 hideall "--sync--"
 
-0.0 "--Reset--" sync / 21:........:40000010:/ window 100000 jump 0
+0.0 "--Reset--" sync / 21:........:4000000F:/ window 100000 jump 0
 
 0.0 "--sync--" sync /:Engage!/ window 0,1
 0.8 "--sync--" sync / 1[56]:[^:]*:Cloud Of Darkness:5627:/ window 1,0

--- a/ui/raidboss/data/05-shb/trial/diamond_weapon-ex.txt
+++ b/ui/raidboss/data/05-shb/trial/diamond_weapon-ex.txt
@@ -3,7 +3,7 @@
 hideall "--Reset--"
 hideall "--sync--"
 
-0.0 "--Reset--" sync / 21:........:40000010:/ window 100000 jump 0
+0.0 "--Reset--" sync / 21:........:4000000F:/ window 100000 jump 0
 
 # -it "The Diamond Weapon" -ii 5FEB 5FBE 5FAA 5FEC 5FBA 5FFD 5FBB 6055 6159 5FF9 5FCD 5FFA 5FF9 612E 5FB3 5FCE 5FD2 5FFE 5FD3 5FB4 5FB6 5FB1 5FB0 5FBF 5FAE 5FA6 5FC3 5FC9 5FCA 5FC4
 

--- a/ui/raidboss/data/05-shb/trial/diamond_weapon.txt
+++ b/ui/raidboss/data/05-shb/trial/diamond_weapon.txt
@@ -6,7 +6,7 @@
 hideall "--Reset--"
 hideall "--sync--"
 
-0.0 "--Reset--" sync / 21:........:40000010:/ window 100000 jump 0
+0.0 "--Reset--" sync / 21:........:4000000F:/ window 100000 jump 0
 
 # Phase 1
 0.0 "--sync--" sync /:Engage!/ window 0,1

--- a/ui/raidboss/data/05-shb/trial/emerald_weapon-ex.txt
+++ b/ui/raidboss/data/05-shb/trial/emerald_weapon-ex.txt
@@ -3,7 +3,7 @@
 hideall "--Reset--"
 hideall "--sync--"
 
-0.0 "--Reset--" sync / 21:........:40000010:/ window 100000 jump 0
+0.0 "--Reset--" sync / 21:........:4000000F:/ window 100000 jump 0
 
 ### Phase 1
 # -p 55B0:17.1

--- a/ui/raidboss/data/05-shb/trial/emerald_weapon.txt
+++ b/ui/raidboss/data/05-shb/trial/emerald_weapon.txt
@@ -6,7 +6,7 @@
 hideall "--Reset--"
 hideall "--sync--"
 
-0.0 "--Reset--" sync / 21:........:40000010:/ window 100000 jump 0
+0.0 "--Reset--" sync / 21:........:4000000F:/ window 100000 jump 0
 
 ### Phase 1
 0 "Start"

--- a/ui/raidboss/data/05-shb/trial/hades-ex.txt
+++ b/ui/raidboss/data/05-shb/trial/hades-ex.txt
@@ -5,7 +5,7 @@
 hideall "--Reset--"
 hideall "--sync--"
 
-0.0 "--Reset--" sync / 21:........:40000010:/ window 100000 jump 0
+0.0 "--Reset--" sync / 21:........:4000000F:/ window 100000 jump 0
 
 
 ### Phase 1

--- a/ui/raidboss/data/05-shb/trial/hades.txt
+++ b/ui/raidboss/data/05-shb/trial/hades.txt
@@ -5,7 +5,7 @@ hideall "--Reset--"
 hideall "--sync--"
 hideall "Double"
 
-0.0 "--Reset--" sync / 21:........:40000010:/ window 100000 jump 0
+0.0 "--Reset--" sync / 21:........:4000000F:/ window 100000 jump 0
 
 # Phase 1: Everybody Murdered By Circles
 0.0 "--sync--" sync /:Engage!/ window 0,1

--- a/ui/raidboss/data/05-shb/trial/innocence-ex.txt
+++ b/ui/raidboss/data/05-shb/trial/innocence-ex.txt
@@ -7,7 +7,7 @@ hideall "--sync--"
 hideall "Holy Trinity"
 hideall "Soul And Body"
 
-0.0 "--Reset--" sync / 21:........:40000010:/ window 100000 jump 0
+0.0 "--Reset--" sync / 21:........:4000000F:/ window 100000 jump 0
 
 
 ### Phase 1

--- a/ui/raidboss/data/05-shb/trial/innocence.txt
+++ b/ui/raidboss/data/05-shb/trial/innocence.txt
@@ -4,7 +4,7 @@
 hideall "--Reset--"
 hideall "--sync--"
 
-0.0 "--Reset--" sync / 21:........:40000010:/ window 100000 jump 0
+0.0 "--Reset--" sync / 21:........:4000000F:/ window 100000 jump 0
 
 ### Phase 1
 0 "Start"

--- a/ui/raidboss/data/05-shb/trial/levi-un.txt
+++ b/ui/raidboss/data/05-shb/trial/levi-un.txt
@@ -35,7 +35,7 @@
 hideall "--Reset--"
 hideall "--sync--"
 
-0.0 "--Reset--" sync / 21:........:40000010:/ window 100000 jump 0
+0.0 "--Reset--" sync / 21:........:4000000F:/ window 100000 jump 0
 
 ### Phase 1: Literally Just Autos (100% -> 90%)
 0.0 "Start"

--- a/ui/raidboss/data/05-shb/trial/ruby_weapon-ex.txt
+++ b/ui/raidboss/data/05-shb/trial/ruby_weapon-ex.txt
@@ -3,7 +3,7 @@
 hideall "--Reset--"
 hideall "--sync--"
 
-0.0 "--Reset--" sync / 21:........:40000010:/ window 100000 jump 0
+0.0 "--Reset--" sync / 21:........:4000000F:/ window 100000 jump 0
 
 ### Phase 1
 # -p 4ABE:14.5

--- a/ui/raidboss/data/05-shb/trial/ruby_weapon.txt
+++ b/ui/raidboss/data/05-shb/trial/ruby_weapon.txt
@@ -5,7 +5,7 @@
 hideall "--Reset--"
 hideall "--sync--"
 
-0.0 "--Reset--" sync / 21:........:40000010:/ window 100000 jump 0
+0.0 "--Reset--" sync / 21:........:4000000F:/ window 100000 jump 0
 
 ### Phase 1
 # -p 4AC7:16

--- a/ui/raidboss/data/05-shb/trial/shiva-un.txt
+++ b/ui/raidboss/data/05-shb/trial/shiva-un.txt
@@ -26,7 +26,7 @@
 hideall "--sync--"
 hideall "--Reset--"
 
-0.0 "--Reset--" sync / 21:........:40000010:/ window 100000 jump 0
+0.0 "--Reset--" sync / 21:........:4000000F:/ window 100000 jump 0
 
 # Phase 1: Literally Just Autos (100% -> 95%)
 0.0 "--sync--" sync /:Engage!/ window 0,1

--- a/ui/raidboss/data/05-shb/trial/titan-un.txt
+++ b/ui/raidboss/data/05-shb/trial/titan-un.txt
@@ -8,7 +8,7 @@
 hideall "--Reset--"
 hideall "--sync--"
 
-0.0 "--Reset--" sync / 21:........:40000010:/ window 100000 jump 0
+0.0 "--Reset--" sync / 21:........:4000000F:/ window 100000 jump 0
 
 ### Phase 1: 100->85%
 0.0 "Start"

--- a/ui/raidboss/data/05-shb/trial/titania-ex.txt
+++ b/ui/raidboss/data/05-shb/trial/titania-ex.txt
@@ -5,7 +5,7 @@
 hideall "--Reset--"
 hideall "--sync--"
 
-0.0 "--Reset--" sync / 21:........:40000010:/ window 100000 jump 0
+0.0 "--Reset--" sync / 21:........:4000000F:/ window 100000 jump 0
 
 
 ### Phase 1: single mechanics

--- a/ui/raidboss/data/05-shb/trial/titania.txt
+++ b/ui/raidboss/data/05-shb/trial/titania.txt
@@ -4,7 +4,7 @@
 hideall "--Reset--"
 hideall "--sync--"
 
-0.0 "--Reset--" sync / 21:........:40000010:/ window 100000 jump 0
+0.0 "--Reset--" sync / 21:........:4000000F:/ window 100000 jump 0
 
 ### Phase 1
 0 "Start"

--- a/ui/raidboss/data/05-shb/trial/varis-ex.txt
+++ b/ui/raidboss/data/05-shb/trial/varis-ex.txt
@@ -5,7 +5,7 @@
 hideall "--Reset--"
 hideall "--sync--"
 
-0.0 "--Reset--" sync / 21:........:40000010:/ window 100000 jump 0
+0.0 "--Reset--" sync / 21:........:4000000F:/ window 100000 jump 0
 
 ### Phase 1
 0 "Start!"

--- a/ui/raidboss/data/05-shb/trial/wol-ex.txt
+++ b/ui/raidboss/data/05-shb/trial/wol-ex.txt
@@ -25,7 +25,7 @@ hideall "--sync--"
 hideall "--Reset--"
 hideall "Limit Break"
 
-0.0 "--Reset--" sync / 21:........:40000010:/ window 100000 jump 0
+0.0 "--Reset--" sync / 21:........:4000000F:/ window 100000 jump 0
 
 ### Phase 1: Warmup
 0.0 "--sync--" sync /:Engage!/ window 0,1

--- a/ui/raidboss/data/05-shb/trial/wol.txt
+++ b/ui/raidboss/data/05-shb/trial/wol.txt
@@ -6,7 +6,7 @@
 hideall "--sync--"
 hideall "--Reset--"
 
-0.0 "--Reset--" sync / 21:........:40000010:/ window 100000 jump 0
+0.0 "--Reset--" sync / 21:........:4000000F:/ window 100000 jump 0
 
 ### Phase 1: 100%->50%
 # Note: Don't sync on engage or auto here because there's a checkpoint.

--- a/ui/raidboss/data/05-shb/ultimate/the_epic_of_alexander.txt
+++ b/ui/raidboss/data/05-shb/ultimate/the_epic_of_alexander.txt
@@ -5,7 +5,7 @@
 hideall "--Reset--"
 hideall "--sync--"
 
-0.0 "--Reset--" sync / 21:........:40000010:/ window 100000 jump 0
+0.0 "--Reset--" sync / 21:........:4000000F:/ window 100000 jump 0
 
 ### Phase 1: Living Liquid
 0 "Start"

--- a/ui/raidboss/data/06-ew/raid/p1n.txt
+++ b/ui/raidboss/data/06-ew/raid/p1n.txt
@@ -9,7 +9,7 @@
 hideall "--Reset--"
 hideall "--sync--"
 
-0.0 "--Reset--" sync / 21:........:40000010:/ window 100000 jump 0
+0.0 "--Reset--" sync / 21:........:4000000F:/ window 100000 jump 0
 
 0.0 "--sync--" sync /Engage!/ window 0,1
 

--- a/ui/raidboss/data/06-ew/raid/p1s.txt
+++ b/ui/raidboss/data/06-ew/raid/p1s.txt
@@ -17,7 +17,7 @@
 hideall "--Reset--"
 hideall "--sync--"
 
-0.0 "--Reset--" sync / 21:........:40000010:/ window 100000 jump 0
+0.0 "--Reset--" sync / 21:........:4000000F:/ window 100000 jump 0
 
 # First flail set
 0.0 "--sync--" sync /Engage!/ window 0,1

--- a/ui/raidboss/data/06-ew/raid/p2n.txt
+++ b/ui/raidboss/data/06-ew/raid/p2n.txt
@@ -5,7 +5,7 @@
 hideall "--Reset--"
 hideall "--sync--"
 
-0.0 "--Reset--" sync / 21:........:40000010:/ window 100000 jump 0
+0.0 "--Reset--" sync / 21:........:4000000F:/ window 100000 jump 0
 
 0.0 "--sync--" sync /Engage!/ window 0,1
 9.3 "--sync--" sync / 14:[^:]*:Hippokampos:680F:/ window 20,20

--- a/ui/raidboss/data/06-ew/raid/p2s.txt
+++ b/ui/raidboss/data/06-ew/raid/p2s.txt
@@ -6,7 +6,7 @@
 hideall "--Reset--"
 hideall "--sync--"
 
-0.0 "--Reset--" sync / 21:........:40000010:/ window 100000 jump 0
+0.0 "--Reset--" sync / 21:........:4000000F:/ window 100000 jump 0
 
 0.0 "--sync--" sync /Engage!/ window 0,1
 11.0 "--sync--" sync / 14:[^:]*:Hippokampos:6833:/ window 15,15

--- a/ui/raidboss/data/06-ew/raid/p3n.txt
+++ b/ui/raidboss/data/06-ew/raid/p3n.txt
@@ -3,7 +3,7 @@
 hideall "--Reset--"
 hideall "--sync--"
 
-0.0 "--Reset--" sync / 21:........:40000010:/ window 100000 jump 0
+0.0 "--Reset--" sync / 21:........:4000000F:/ window 100000 jump 0
 
 # -ii 669F 66A7 66A8 66A0 66A1 66AF 66B0 66B3 6D0C 6DDC 6EDD
 # -ic "Liturgic Bell"

--- a/ui/raidboss/data/06-ew/raid/p3s.txt
+++ b/ui/raidboss/data/06-ew/raid/p3s.txt
@@ -8,7 +8,7 @@ hideall "--sync--"
 
 # Note: 66BF "middle" happens 6.2s after experimental fireplume
 
-0.0 "--Reset--" sync / 21:........:40000010:/ window 100000 jump 0
+0.0 "--Reset--" sync / 21:........:4000000F:/ window 100000 jump 0
 
 0.0 "--sync--" sync /Engage!/ window 0,1
 8.7 "--sync--" sync / 14:[^:]*:Phoinix:6706:/ window 10,10

--- a/ui/raidboss/data/06-ew/raid/p4n.txt
+++ b/ui/raidboss/data/06-ew/raid/p4n.txt
@@ -17,7 +17,7 @@
 hideall "--Reset--"
 hideall "--sync--"
 
-0.0 "--Reset--" sync / 21:........:40000010:/ window 100000 jump 0
+0.0 "--Reset--" sync / 21:........:4000000F:/ window 100000 jump 0
 
 0.0 "--sync--" sync /Engage!/ window 0,1
 10.8 "--sync--" sync / 14:[^:]*:Hesperos:6A50:/ window 20,20

--- a/ui/raidboss/data/06-ew/raid/p4s.txt
+++ b/ui/raidboss/data/06-ew/raid/p4s.txt
@@ -4,7 +4,7 @@
 hideall "--Reset--"
 hideall "--sync--"
 
-0.0 "--Reset--" sync / 21:........:40000010:/ window 100000 jump 0
+0.0 "--Reset--" sync / 21:........:4000000F:/ window 100000 jump 0
 
 ### Hesperos I
 #

--- a/ui/raidboss/data/06-ew/raid/p5n.txt
+++ b/ui/raidboss/data/06-ew/raid/p5n.txt
@@ -4,4 +4,4 @@
 hideall "--Reset--"
 hideall "--sync--"
 
-0.0 "--Reset--" sync / 21:........:40000010:/ window 100000 jump 0
+0.0 "--Reset--" sync / 21:........:4000000F:/ window 100000 jump 0

--- a/ui/raidboss/data/06-ew/raid/p5s.txt
+++ b/ui/raidboss/data/06-ew/raid/p5s.txt
@@ -4,4 +4,4 @@
 hideall "--Reset--"
 hideall "--sync--"
 
-0.0 "--Reset--" sync / 21:........:40000010:/ window 100000 jump 0
+0.0 "--Reset--" sync / 21:........:4000000F:/ window 100000 jump 0

--- a/ui/raidboss/data/06-ew/raid/p6n.txt
+++ b/ui/raidboss/data/06-ew/raid/p6n.txt
@@ -4,4 +4,4 @@
 hideall "--Reset--"
 hideall "--sync--"
 
-0.0 "--Reset--" sync / 21:........:40000010:/ window 100000 jump 0
+0.0 "--Reset--" sync / 21:........:4000000F:/ window 100000 jump 0

--- a/ui/raidboss/data/06-ew/raid/p6s.txt
+++ b/ui/raidboss/data/06-ew/raid/p6s.txt
@@ -4,4 +4,4 @@
 hideall "--Reset--"
 hideall "--sync--"
 
-0.0 "--Reset--" sync / 21:........:40000010:/ window 100000 jump 0
+0.0 "--Reset--" sync / 21:........:4000000F:/ window 100000 jump 0

--- a/ui/raidboss/data/06-ew/raid/p7n.txt
+++ b/ui/raidboss/data/06-ew/raid/p7n.txt
@@ -4,4 +4,4 @@
 hideall "--Reset--"
 hideall "--sync--"
 
-0.0 "--Reset--" sync / 21:........:40000010:/ window 100000 jump 0
+0.0 "--Reset--" sync / 21:........:4000000F:/ window 100000 jump 0

--- a/ui/raidboss/data/06-ew/raid/p7s.txt
+++ b/ui/raidboss/data/06-ew/raid/p7s.txt
@@ -4,4 +4,4 @@
 hideall "--Reset--"
 hideall "--sync--"
 
-0.0 "--Reset--" sync / 21:........:40000010:/ window 100000 jump 0
+0.0 "--Reset--" sync / 21:........:4000000F:/ window 100000 jump 0

--- a/ui/raidboss/data/06-ew/raid/p8n.txt
+++ b/ui/raidboss/data/06-ew/raid/p8n.txt
@@ -4,4 +4,4 @@
 hideall "--Reset--"
 hideall "--sync--"
 
-0.0 "--Reset--" sync / 21:........:40000010:/ window 100000 jump 0
+0.0 "--Reset--" sync / 21:........:4000000F:/ window 100000 jump 0

--- a/ui/raidboss/data/06-ew/raid/p8s.txt
+++ b/ui/raidboss/data/06-ew/raid/p8s.txt
@@ -4,4 +4,4 @@
 hideall "--Reset--"
 hideall "--sync--"
 
-0.0 "--Reset--" sync / 21:........:40000010:/ window 100000 jump 0
+0.0 "--Reset--" sync / 21:........:4000000F:/ window 100000 jump 0

--- a/ui/raidboss/data/06-ew/trial/barbariccia-ex.txt
+++ b/ui/raidboss/data/06-ew/trial/barbariccia-ex.txt
@@ -4,4 +4,4 @@
 hideall "--Reset--"
 hideall "--sync--"
 
-0.0 "--Reset--" sync / 21:........:40000010:/ window 100000 jump 0
+0.0 "--Reset--" sync / 21:........:4000000F:/ window 100000 jump 0

--- a/ui/raidboss/data/06-ew/trial/barbariccia.txt
+++ b/ui/raidboss/data/06-ew/trial/barbariccia.txt
@@ -4,4 +4,4 @@
 hideall "--Reset--"
 hideall "--sync--"
 
-0.0 "--Reset--" sync / 21:........:40000010:/ window 100000 jump 0
+0.0 "--Reset--" sync / 21:........:4000000F:/ window 100000 jump 0

--- a/ui/raidboss/data/06-ew/trial/endsinger-ex.txt
+++ b/ui/raidboss/data/06-ew/trial/endsinger-ex.txt
@@ -6,7 +6,7 @@
 hideall "--Reset--"
 hideall "--sync--"
 
-0.0 "--Reset--" sync / 21:........:40000010:/ window 100000 jump 0
+0.0 "--Reset--" sync / 21:........:4000000F:/ window 100000 jump 0
 
 0.0 "--sync--" sync /Engage!/ window 0,1
 7.0 "--sync--" sync / 14:[^:]*:The Endsinger:6FF6:/ window 10,10

--- a/ui/raidboss/data/06-ew/trial/endsinger.txt
+++ b/ui/raidboss/data/06-ew/trial/endsinger.txt
@@ -10,7 +10,7 @@
 hideall "--Reset--"
 hideall "--sync--"
 
-0.0 "--Reset--" sync / 21:........:40000010:/ window 100000 jump 0
+0.0 "--Reset--" sync / 21:........:4000000F:/ window 100000 jump 0
 
 # P1
 0.0 "--sync--" sync /Engage!/ window 0,1

--- a/ui/raidboss/data/06-ew/trial/hydaelyn-ex.txt
+++ b/ui/raidboss/data/06-ew/trial/hydaelyn-ex.txt
@@ -7,7 +7,7 @@
 hideall "--Reset--"
 hideall "--sync--"
 
-0.0 "--Reset--" sync / 21:........:40000010:/ window 100000 jump 0
+0.0 "--Reset--" sync / 21:........:4000000F:/ window 100000 jump 0
 
 0.0 "--sync--" sync /Engage!/ window 0,1
 11.0 "--sync--" sync / 14:[^:]*:Hydaelyn:65C1:/ window 15,15

--- a/ui/raidboss/data/06-ew/trial/hydaelyn.txt
+++ b/ui/raidboss/data/06-ew/trial/hydaelyn.txt
@@ -7,7 +7,7 @@
 hideall "--Reset--"
 hideall "--sync--"
 
-0.0 "--Reset--" sync / 21:........:40000010:/ window 100000 jump 0
+0.0 "--Reset--" sync / 21:........:4000000F:/ window 100000 jump 0
 
 # Phase 1
 0.0 "--sync--" sync /Engage!/ window 0,1

--- a/ui/raidboss/data/06-ew/trial/sephirot-un.txt
+++ b/ui/raidboss/data/06-ew/trial/sephirot-un.txt
@@ -4,4 +4,4 @@
 hideall "--Reset--"
 hideall "--sync--"
 
-0.0 "--Reset--" sync / 21:........:40000010:/ window 100000 jump 0
+0.0 "--Reset--" sync / 21:........:4000000F:/ window 100000 jump 0

--- a/ui/raidboss/data/06-ew/trial/ultima-un.txt
+++ b/ui/raidboss/data/06-ew/trial/ultima-un.txt
@@ -5,7 +5,7 @@
 hideall "--Reset--"
 hideall "--sync--"
 
-0.0 "--Reset--" sync / 21:........:40000010:/ window 100000 jump 0
+0.0 "--Reset--" sync / 21:........:4000000F:/ window 100000 jump 0
 
 0.0 "--sync--" sync /Engage!/ window 0,1
 

--- a/ui/raidboss/data/06-ew/trial/zodiark-ex.txt
+++ b/ui/raidboss/data/06-ew/trial/zodiark-ex.txt
@@ -9,7 +9,7 @@ hideall "Triple Esoteric Ray"
 hideall "Infernal Stream"
 hideall "Infernal Torrent"
 
-0.0 "--Reset--" sync / 21:........:40000010:/ window 100000 jump 0
+0.0 "--Reset--" sync / 21:........:4000000F:/ window 100000 jump 0
 
 0.0 "--sync--" sync /Engage!/ window 0,1
 1.8 "--sync--" sync / 1[56]:[^:]*:Zodiark:6C73:/ window 2.3,0

--- a/ui/raidboss/data/06-ew/trial/zodiark.txt
+++ b/ui/raidboss/data/06-ew/trial/zodiark.txt
@@ -16,7 +16,7 @@ hideall "Triple Esoteric Ray"
 # Note: Opheos Eidolon sometimes comes from Zodiark/Behemoth and not Python,
 # maybe a race condition in FFXIV ACT Plugin?
 
-0.0 "--Reset--" sync / 21:........:40000010:/ window 100000 jump 0
+0.0 "--Reset--" sync / 21:........:4000000F:/ window 100000 jump 0
 
 0.0 "--sync--" sync /Engage!/ window 0,1
 7.1 "--sync--" sync / 14:[^:]*:Zodiark:6C27:/ window 10,10

--- a/ui/raidboss/data/06-ew/ultimate/dragonsongs_reprise_ultimate.txt
+++ b/ui/raidboss/data/06-ew/ultimate/dragonsongs_reprise_ultimate.txt
@@ -9,7 +9,7 @@
 hideall "--Reset--"
 hideall "--sync--"
 
-0.0 "--Reset--" sync / 21:........:40000010:/ window 100000 jump 0
+0.0 "--Reset--" sync / 21:........:4000000F:/ window 100000 jump 0
 
 ### Phase 1: Adelphel, Grinnaux and Charibert
 


### PR DESCRIPTION
This is the timeline change for #4691.
To avoid having to redo this change in the future,
change the timelines to the desired future 6.2 code,
and use the same "back compat replacement" strategy
that we used before #4431 removed them.