### PR TITLE
raidboss: ex4 switch impact trigger

### DIFF
--- a/ui/raidboss/data/06-ew/trial/barbariccia-ex.ts
+++ b/ui/raidboss/data/06-ew/trial/barbariccia-ex.ts
@@ -23,12 +23,6 @@ const triggerSet: TriggerSet<Data> = {
       beforeSeconds: 5,
       response: Responses.aoe(),
     },
-    {
-      id: 'BarbaricciaEx Impact',
-      regex: /Impact/,
-      beforeSeconds: 5,
-      response: Responses.knockback(),
-    },
   ],
   triggers: [
     {
@@ -140,6 +134,14 @@ const triggerSet: TriggerSet<Data> = {
           ko: '플레어 대상자',
         },
       },
+    },
+    {
+      id: 'BarbaricciaEx Impact',
+      type: 'StartsUsing',
+      netRegex: NetRegexes.startsUsing({ id: '75A0', source: 'Barbariccia' }),
+      // Could also have used 75A1, full cast time is 5.9s
+      delaySeconds: (_data, matches) => parseFloat(matches.castTime) - 5,
+      response: Responses.knockback(),
     },
     {
       id: 'BarbaricciaEx Playstation Hair Chains',


### PR DESCRIPTION
Workaround for a possible timeline trigger issue with tracking Impact. This uses different spell that is also related to the knockback and has a cast time. Using the "standard" 5s timing, although the spell cast is almost the same as the knockback immunity duration.