### PR TITLE
raidboss: Pandaemonium 7 normal package

### DIFF
--- a/ui/oopsyraidsy/data/06-ew/raid/p7n.ts
+++ b/ui/oopsyraidsy/data/06-ew/raid/p7n.ts
@@ -6,6 +6,24 @@ export type Data = OopsyData;
 
 const triggerSet: OopsyTriggerSet<Data> = {
   zoneId: ZoneId.AbyssosTheSeventhCircle,
+  damageWarn: {
+    'P7N Bough Of Attis Out': '77FA',
+    'P7N Bough Of Attis In': '77FF',
+    'P7N Bough Of Attis Sides': '77FD',
+    'P7N Hemitheos Glare III 1': '77F8', // Donut attack alongside Hemitheos's Holy
+    'P7N Hemitheos Glare III 2': '79FA', // Donut attack alongside platform regeneration
+    'P7N Static Moon': '7802', // Behemoths' chariot attack
+    'P7N Stymphalian Strike': '7803', // Birds' line attack
+    'P7N Big Burst': '783E', // Missed tower
+    'P7N Blades Of Attis Stationary': '7805', // Exaflare initial hit
+    'P7N Blades Of Attis Exaflares': '7806',
+  },
+  shareWarn: {
+    'P7N Hemitheos Holy': '7808', // Purple spread circles
+  },
+  shareFail: {
+    'P7N Hemitheos Aero II': '780A', // Tank cleave
+  },
 };
 
 export default triggerSet;

--- a/ui/raidboss/data/06-ew/raid/p7n.ts
+++ b/ui/raidboss/data/06-ew/raid/p7n.ts
@@ -82,7 +82,7 @@ const triggerSet: TriggerSet<Data> = {
       alertText: (_data, _matches, output) => output.text!(),
       outputStrings: {
         text: {
-          en: 'In circle--get to edge',
+          en: 'Get to edge (in circle)',
         },
       },
     },

--- a/ui/raidboss/data/06-ew/raid/p7n.ts
+++ b/ui/raidboss/data/06-ew/raid/p7n.ts
@@ -1,13 +1,172 @@
+import Conditions from '../../../../../resources/conditions';
+import NetRegexes from '../../../../../resources/netregexes';
+import Outputs from '../../../../../resources/outputs';
+import { Responses } from '../../../../../resources/responses';
 import ZoneId from '../../../../../resources/zone_id';
 import { RaidbossData } from '../../../../../types/data';
 import { TriggerSet } from '../../../../../types/trigger';
 
-export type Data = RaidbossData;
+export interface Data extends RaidbossData {
+  busterTargets: string[];
+}
 
 const triggerSet: TriggerSet<Data> = {
   zoneId: ZoneId.AbyssosTheSeventhCircle,
   timelineFile: 'p7n.txt',
-  triggers: [],
+  initData: () => {
+    return {
+      busterTargets: [],
+    };
+  },
+  timelineTriggers: [
+    {
+      id: 'P7N Burst',
+      regex: /Burst/,
+      beforeSeconds: 4,
+      alertText: (_data, _matches, output) => output.text!(),
+      outputStrings: {
+        text: {
+          en: 'Get towers',
+        },
+      },
+    },
+  ],
+  triggers: [
+    {
+      id: 'P7N Bough Of Attis Out',
+      type: 'StartsUsing',
+      netRegex: NetRegexes.startsUsing({ id: '77F9', source: 'Agdistis', capture: false }),
+      response: Responses.getOut(),
+    },
+    {
+      id: 'P7N Bough Of Attis In',
+      type: 'StartsUsing',
+      netRegex: NetRegexes.startsUsing({ id: '77FE', source: 'Agdistis', capture: false }),
+      response: Responses.getIn(),
+    },
+    {
+      id: 'P7N Bough Of Attis Left',
+      type: 'StartsUsing',
+      netRegex: NetRegexes.startsUsing({ id: '77FC', source: 'Agdistis', capture: false }),
+      response: Responses.goLeft(),
+    },
+    {
+      id: 'P7N Bough Of Attis Right',
+      type: 'StartsUsing',
+      netRegex: NetRegexes.startsUsing({ id: '77FB', source: 'Agdistis', capture: false }),
+      response: Responses.goRight(),
+    },
+    {
+      id: 'P7N Hemitheos Holy Spread',
+      type: 'HeadMarker',
+      netRegex: NetRegexes.headMarker({ id: '0137' }),
+      condition: Conditions.targetIsYou(),
+      response: Responses.spread(),
+    },
+    {
+      id: 'P7N Hemitheos Glare',
+      type: 'StartsUsing',
+      netRegex: NetRegexes.startsUsing({ id: '79FA', source: 'Agdistis', capture: false }),
+      suppressSeconds: 5,
+      infoText: (_data, _matches, output) => output.text!(),
+      outputStrings: {
+        text: {
+          en: 'Move center when safe',
+        },
+      },
+    },
+    {
+      id: 'P7N Immortals Obol',
+      type: 'StartsUsing',
+      netRegex: NetRegexes.startsUsing({ id: '77F5', source: 'Agdistis', capture: false }),
+      alertText: (_data, _matches, output) => output.text!(),
+      outputStrings: {
+        text: {
+          en: 'In circle--get to edge',
+        },
+      },
+    },
+    {
+      id: 'P7N Hemitheos Aero II Collect',
+      type: 'HeadMarker',
+      netRegex: NetRegexes.headMarker({ id: '016C' }),
+      run: (data, matches) => data.busterTargets.push(matches.target),
+    },
+    {
+      id: 'P7N Hemitheos Aero II Call',
+      type: 'HeadMarker',
+      netRegex: NetRegexes.headMarker({ id: '016C' }),
+      delaySeconds: 0.3,
+      suppressSeconds: 5,
+      alertText: (data, _matches, output) => {
+        if (data.busterTargets.includes(data.me))
+          return output.markerYou!();
+        return output.avoid!();
+      },
+      outputStrings: {
+        markerYou: Outputs.tankCleave,
+        avoid: Outputs.avoidTankCleave,
+      },
+    },
+    {
+      id: 'P7N Hemitheos Aero II Cleanup',
+      type: 'HeadMarker',
+      netRegex: NetRegexes.headMarker({ id: '016C' }),
+      delaySeconds: 5,
+      run: (data) => data.busterTargets = [],
+    },
+    {
+      id: 'P7N Spark Of Life',
+      type: 'StartsUsing',
+      netRegex: NetRegexes.startsUsing({ id: '780B', source: 'Agdistis', capture: false }),
+      response: Responses.aoe(),
+    },
+    {
+      id: 'P7N Static Moon',
+      type: 'StartsUsing',
+      netRegex: NetRegexes.startsUsing({ id: '7802', source: 'Immature Io', capture: false }),
+      suppressSeconds: 5,
+      alertText: (_data, _matches, output) => output.text!(),
+      outputStrings: {
+        text: {
+          en: 'Avoid Behemoths',
+        },
+      },
+    },
+    {
+      id: 'P7N Stymphalian Strike',
+      type: 'StartsUsing',
+      netRegex: NetRegexes.startsUsing({ id: '7803', source: 'Immature Stymphalide', capture: false }),
+      suppressSeconds: 5,
+      infoText: (_data, _matches, output) => output.text!(),
+      outputStrings: {
+        text: {
+          en: 'Avoid line dashes',
+        },
+      },
+    },
+    {
+      id: 'P7N Blades Of Attis',
+      type: 'StartsUsing',
+      netRegex: NetRegexes.startsUsing({ id: '7805', source: 'Agdistis', capture: false }),
+      suppressSeconds: 5,
+      infoText: (_data, _matches, output) => output.text!(),
+      outputStrings: {
+        text: {
+          en: 'Avoid Exaflares',
+        },
+      },
+    },
+    {
+      id: 'P7N Hemitheos Aero IV',
+      type: 'StartsUsing',
+      netRegex: NetRegexes.startsUsing({ id: '7840', source: 'Agdistis' }),
+      // The cast time is slightly longer than Arm's Length/Surecast's duration.
+      // Don't risk someone being too fast.
+      delaySeconds: (_data, matches) => parseFloat(matches.castTime) - 6,
+      response: Responses.knockback('info'), // avoid collisions with Forbidden Fruit triggers.
+    },
+  ],
 };
 
 export default triggerSet;

--- a/ui/raidboss/data/06-ew/raid/p7n.ts
+++ b/ui/raidboss/data/06-ew/raid/p7n.ts
@@ -111,7 +111,7 @@ const triggerSet: TriggerSet<Data> = {
     {
       id: 'P7N Hemitheos Aero II Cleanup',
       type: 'HeadMarker',
-      netRegex: NetRegexes.headMarker({ id: '016C' }),
+      netRegex: NetRegexes.headMarker({ id: '016C', capture: false }),
       delaySeconds: 5,
       run: (data) => data.busterTargets = [],
     },

--- a/ui/raidboss/data/06-ew/raid/p7n.ts
+++ b/ui/raidboss/data/06-ew/raid/p7n.ts
@@ -95,7 +95,7 @@ const triggerSet: TriggerSet<Data> = {
     {
       id: 'P7N Hemitheos Aero II Call',
       type: 'HeadMarker',
-      netRegex: NetRegexes.headMarker({ id: '016C' }),
+      netRegex: NetRegexes.headMarker({ id: '016C', capture: false }),
       delaySeconds: 0.3,
       suppressSeconds: 5,
       alertText: (data, _matches, output) => {

--- a/ui/raidboss/data/06-ew/raid/p7n.txt
+++ b/ui/raidboss/data/06-ew/raid/p7n.txt
@@ -6,84 +6,119 @@ hideall "--sync--"
 
 0.0 "--Reset--" sync / 21:........:4000000F:/ window 100000 jump 0
 
-# -ii 77FA 77FD 77FF 77F6 780A 783E 7800 7804 7806 7807 77F7 7841
+# -ii 77F6 77F7 77FA 77FD 77FF 7800 7804 7806 7807 780A 783E 7841
 
 0.0 "--sync--" sync /Engage!/ window 0,1
-15.8 "Bough of Attis (out)" sync / 1[56]:[^:]*:Agdistis:77F9:/ window 16,5
-23.4 "Bough of Attis (left/right)" sync / 1[56]:[^:]*:Agdistis:77FB:/
+3.0 "--sync--" sync / 1[56]:[^:]*:Agdistis:78E3:/
+15.8 "Bough of Attis (OUT)" sync / 1[56]:[^:]*:Agdistis:77F9:/ window 16,5
+23.4 "Bough of Attis (left/right)" sync / 1[56]:[^:]*:Agdistis:(77FB|77FC):/
 37.6 "Hemitheos's Holy" sync / 1[56]:[^:]*:Agdistis:7808:/
 44.0 "Hemitheos's Glare III" sync / 1[56]:[^:]*:Agdistis:77F8:/
-54.1 "Bough of Attis (in)"  sync / 1[56]:[^:]*:Agdistis:77FE:/
-64.5 "Bough of Attis (out)" sync / 1[56]:[^:]*:Agdistis:77F9:/
-72.1 "Bough of Attis (left/right)" sync / 1[56]:[^:]*:Agdistis:77FC:/
+54.1 "Bough of Attis (IN)"  sync / 1[56]:[^:]*:Agdistis:77FE:/
+64.5 "Bough of Attis (OUT)" sync / 1[56]:[^:]*:Agdistis:77F9:/
+72.1 "Bough of Attis (left/right)" sync / 1[56]:[^:]*:Agdistis:(77FB|77FC):/
 81.9 "Immortal's Obol" sync / 1[56]:[^:]*:Agdistis:77F5:/
-102.0 "Bough of Attis (out)" sync / 1[56]:[^:]*:Agdistis:77F9:/
-109.6 "Bough of Attis (left/right)" sync / 1[56]:[^:]*:Agdistis:77FC:/
+102.0 "Bough of Attis (OUT)" sync / 1[56]:[^:]*:Agdistis:77F9:/
+109.6 "Bough of Attis (left/right)" sync / 1[56]:[^:]*:Agdistis:(77FB|77FC):/
 119.7 "Hemitheos's Aero II" sync / 1[56]:[^:]*:Agdistis:7809:/ window 215,10
 128.9 "Spark of Life" sync / 1[56]:[^:]*:Agdistis:780B:/
 143.2 "Forbidden Fruit" sync / 1[56]:[^:]*:Agdistis:7801:/
 154.9 "Static Moon" sync / 1[56]:[^:]*:Immature Io:7802:/ window 155,10
-166.9 "Blades of Attis x8" sync / 1[56]:[^:]*:Agdistis:7805:/
+166.9 "Blades of Attis(lines)" sync / 1[56]:[^:]*:Agdistis:7805:/
 184.1 "Forbidden Fruit" sync / 1[56]:[^:]*:Agdistis:7801:/
 195.8 "Stymphalian Strike" sync / 1[56]:[^:]*:Immature Stymphalide:7803:/ window 50,50
 216.9 "Hemitheos's Glare III" sync / 1[56]:[^:]*:Agdistis:79FA:/
-224.5 "Blades of Attis x8" sync / 1[56]:[^:]*:Agdistis:7805:/
-238.5 "Bough of Attis (out)" sync / 1[56]:[^:]*:Agdistis:77F9:/
+224.5 "Blades of Attis (triangle)" sync / 1[56]:[^:]*:Agdistis:7805:/
+238.5 "Bough of Attis (OUT)" sync / 1[56]:[^:]*:Agdistis:77F9:/
 246.1 "Bough of Attis (left/right)" sync / 1[56]:[^:]*:Agdistis:77FB:/
 
-258.2 "Forbidden Fruit" sync / 1[56]:[^:]*:Agdistis:7801:/
-270.3 "Static Moon" sync / 1[56]:[^:]*:Immature Io:7802:/ window 50,50
-270.3 "Hemitheos's Holy" sync / 1[56]:[^:]*:Agdistis:7808:/
-280.1 "Immortal's Obol" sync / 1[56]:[^:]*:Agdistis:77F5:/
-300.3 "Forbidden Fruit" sync / 1[56]:[^:]*:Agdistis:7801:/
-313.7 "Bough of Attis (in)" sync / 1[56]:[^:]*:Agdistis:77FE:/
-315.1 "Static Moon" sync / 1[56]:[^:]*:Immature Io:7802:/
-325.3 "Hemitheos's Aero II" sync / 1[56]:[^:]*:Agdistis:7809:/
-338.5 "Forbidden Fruit" sync / 1[56]:[^:]*:Agdistis:7801:/
-341.6 "Shadow of Attis" sync / 1[56]:[^:]*:Agdistis:783C:/
-350.0 "Static Moon" sync / 1[56]:[^:]*:Immature Io:7802:/
-354.6 "Burst" sync / 1[56]:[^:]*:Agdistis:783D:/
-362.8 "Bough of Attis (out)" sync / 1[56]:[^:]*:Agdistis:77F9:/
-370.4 "Bough of Attis (left/right)" sync / 1[56]:[^:]*:Agdistis:77FC:/
-379.6 "Spark of Life" sync / 1[56]:[^:]*:Agdistis:780B:/
-388.7 "Spark of Life" sync / 1[56]:[^:]*:Agdistis:780B:/
-397.8 "Spark of Life" sync / 1[56]:[^:]*:Agdistis:780B:/
-412.9 "Forbidden Fruit" sync / 1[56]:[^:]*:Agdistis:7801:/
-426.0 "Hemitheos's Aero IV" sync / 1[56]:[^:]*:Agdistis:7840:/
-429.4 "Stymphalian Strike" sync / 1[56]:[^:]*:Immature Stymphalide:7803:/
-429.4 "Static Moon" sync / 1[56]:[^:]*:Immature Io:7802:/
-437.1 "Blades of Attis (lines)" sync / 1[56]:[^:]*:Agdistis:7805:/
-448.2 "Hemitheos's Holy" sync / 1[56]:[^:]*:Agdistis:7808:/
-456.5 "Spark of Life" sync / 1[56]:[^:]*:Agdistis:780B:/
-465.6 "Hemitheos's Aero II" sync / 1[56]:[^:]*:Agdistis:7809:/
-484.8 "Hemitheos's Glare III" sync / 1[56]:[^:]*:Agdistis:79FA:/
-492.4 "Blades of Attis (triangle)" sync / 1[56]:[^:]*:Agdistis:7805:/
-506.5 "Bough of Attis (out)" sync / 1[56]:[^:]*:Agdistis:77F9:/
-514.1 "Bough of Attis (left/right)" sync / 1[56]:[^:]*:Agdistis:77FB:/
+# Forbidden Fruit pre-cast
+249.5 "--sync--" sync / 14:[^:]*:Agdistis:7800:/ window 30,30 jump 400
+# Hemitheos' Holy pre-cast
+250.6 "--sync--" sync / 14:[^:]*:Agdistis:7807:/ window 30,30 jump 1000
+258.2 "Forbidden Fruit?"
+260.4 "Hemitheos's Holy?"
+266.8 "Hemitheos's Glare III?"
+270.3 "Static Moon?"
+270.3 "Hemitheos's Holy?"
+276.9 "Bough of Attis?"
+280.1 "Immortal's Obol?"
+287.3 "Bough of Attis?"
 
-526.2 "Forbidden Fruit" sync / 1[56]:[^:]*:Agdistis:7801:/
-538.3 "Static Moon" sync / 1[56]:[^:]*:Immature Io:7802:/ window 25,25
-538.3 "Hemitheos's Holy" sync / 1[56]:[^:]*:Agdistis:7808:/
-548.1 "Immortal's Obol" sync / 1[56]:[^:]*:Agdistis:77F5:/
-568.3 "Forbidden Fruit" sync / 1[56]:[^:]*:Agdistis:7801:/
-581.7 "Bough of Attis (in)" sync / 1[56]:[^:]*:Agdistis:77FE:/
-583.1 "Stymphalian Strike" sync / 1[56]:[^:]*:Immature Stymphalide:7803:/
-593.3 "Hemitheos's Aero II" sync / 1[56]:[^:]*:Agdistis:7809:/
-606.5 "Forbidden Fruit" sync / 1[56]:[^:]*:Agdistis:7801:/
-609.6 "Shadow of Attis" sync / 1[56]:[^:]*:Agdistis:783C:/
-618.0 "Static Moon" sync / 1[56]:[^:]*:Immature Io:7802:/
-622.6 "Burst" sync / 1[56]:[^:]*:Agdistis:783D:/
-630.8 "Bough of Attis (out)" sync / 1[56]:[^:]*:Agdistis:77F9:/
-638.4 "Bough of Attis (left/right)" sync / 1[56]:[^:]*:Agdistis:77FB:/
-647.6 "Spark of Life" sync / 1[56]:[^:]*:Agdistis:780B:/
-656.7 "Spark of Life" sync / 1[56]:[^:]*:Agdistis:780B:/
-665.8 "Spark of Life" sync / 1[56]:[^:]*:Agdistis:780B:/
-681.0 "Forbidden Fruit" sync / 1[56]:[^:]*:Agdistis:7801:/
-694.1 "Hemitheos's Aero IV" sync / 1[56]:[^:]*:Agdistis:7840:/
-697.7 "Stymphalian Strike" sync / 1[56]:[^:]*:Immature Stymphalide:7803:/
-697.7 "Static Moon" sync / 1[56]:[^:]*:Immature Io:7802:/
-705.4 "Blades of Attis" sync / 1[56]:[^:]*:Agdistis:7805:/
-716.7 "Hemitheos's Holy" sync / 1[56]:[^:]*:Agdistis:7808:/
-725.0 "Spark of Life" sync / 1[56]:[^:]*:Agdistis:780B:/
-734.1 "Hemitheos's Aero II" sync / 1[56]:[^:]*:Agdistis:7809:/
-753.3 "Hemitheos's Glare III" sync / 1[56]:[^:]*:Agdistis:79FA:/
+
+# Forbidden Fruit block
+400.0 "--sync--" sync / 14:[^:]*:Agdistis:7800:/
+408.7 "Forbidden Fruit" sync / 1[56]:[^:]*:Agdistis:7801:/
+420.8 "Static Moon" sync / 1[56]:[^:]*:Immature Io:7802:/
+420.8 "Hemitheos's Holy" sync / 1[56]:[^:]*:Agdistis:7808:/
+430.6 "Immortal's Obol" sync / 1[56]:[^:]*:Agdistis:77F5:/
+450.9 "Forbidden Fruit" sync / 1[56]:[^:]*:Agdistis:7801:/
+464.3 "Bough of Attis (IN)"  sync / 1[56]:[^:]*:Agdistis:77FE:/
+465.7 "Static Moon" sync / 1[56]:[^:]*:Immature Io:7802:/
+475.9 "Hemitheos's Aero II" sync / 1[56]:[^:]*:Agdistis:7809:/ window 30,30
+489.2 "Forbidden Fruit" sync / 1[56]:[^:]*:Agdistis:7801:/
+492.3 "Shadow of Attis" sync / 1[56]:[^:]*:Agdistis:783C:/
+500.7 "Static Moon/Stymphalian Strike" sync / 1[56]:[^:]*:(Immature Io|Immature Stymphalide):(7802|7803):/
+505.4 "Burst" sync / 1[56]:[^:]*:Agdistis:783D:/
+513.6 "Bough of Attis (OUT)" sync / 1[56]:[^:]*:Agdistis:77F9:/
+521.2 "Bough of Attis (left/right)" sync / 1[56]:[^:]*:Agdistis:(77FB|77FC):/
+530.4 "Spark of Life" sync / 1[56]:[^:]*:Agdistis:780B:/
+539.5 "Spark of Life" sync / 1[56]:[^:]*:Agdistis:780B:/
+548.6 "Spark of Life" sync / 1[56]:[^:]*:Agdistis:780B:/
+563.8 "Forbidden Fruit" sync / 1[56]:[^:]*:Agdistis:7801:/
+576.9 "Hemitheos's Aero IV" sync / 1[56]:[^:]*:Agdistis:7840:/ window 30,30
+580.5 "Stymphalian Strike" sync / 1[56]:[^:]*:Immature Stymphalide:7803:/
+580.5 "Static Moon" sync / 1[56]:[^:]*:Immature Io:7802:/
+588.2 "Blades of Attis (lines)" sync / 1[56]:[^:]*:Agdistis:7805:/
+599.5 "Hemitheos's Holy" sync / 1[56]:[^:]*:Agdistis:7808:/
+607.8 "Spark of Life" sync / 1[56]:[^:]*:Agdistis:780B:/
+616.9 "Hemitheos's Aero II" sync / 1[56]:[^:]*:Agdistis:7809:/
+636.1 "Hemitheos's Glare III" sync / 1[56]:[^:]*:Agdistis:79FA:/ window 30,30
+643.7 "Blades of Attis (triangle)" sync / 1[56]:[^:]*:Agdistis:7805:/
+658.0 "Bough of Attis (OUT)" sync / 1[56]:[^:]*:Agdistis:77F9:/
+665.6 "Bough of Attis (left/right)" sync / 1[56]:[^:]*:Agdistis:(77FB|77FC):/
+
+669.1 "--sync--" sync / 14:[^:]*:Agdistis:7800:/ window 30,30 jump 400
+670.2 "--sync--" sync / 14:[^:]*:Agdistis:7807:/ window 30,30 jump 1000
+677.8 "Forbidden Fruit?"
+680.0 "Hemitheos's Holy?"
+686.4 "Hemitheos's Glare III?"
+689.9 "Static Moon?"
+689.9 "Hemitheos's Holy?"
+696.5 "Bough of Attis?"
+699.7 "Immortal's Obol?"
+706.9 "Bough of Attis?"
+
+
+# Hemitheos' Holy block
+1000.0 "--sync--" sync / 14:[^:]*:Agdistis:7807:/
+1009.8 "Hemitheos's Holy" sync / 1[56]:[^:]*:Agdistis:7808:/
+1016.2 "Hemitheos's Glare III" sync / 1[56]:[^:]*:Agdistis:77F8:/ window 30,30
+1026.3 "Bough of Attis (IN)"  sync / 1[56]:[^:]*:Agdistis:77FE:/
+1036.7 "Bough of Attis (OUT)" sync / 1[56]:[^:]*:Agdistis:77F9:/
+1044.3 "Bough of Attis (left/right)" sync / 1[56]:[^:]*:Agdistis:(77FB|77FC):/
+1054.1 "Immortal's Obol" sync / 1[56]:[^:]*:Agdistis:77F5:/ window 30,30
+1074.2 "Bough of Attis (OUT)" sync / 1[56]:[^:]*:Agdistis:77F9:/
+1081.8 "Bough of Attis (left/right)" sync / 1[56]:[^:]*:Agdistis:(77FB|77FC):/
+1091.9 "Hemitheos's Aero II" sync / 1[56]:[^:]*:Agdistis:7809:/ window 30,30
+1101.1 "Spark of Life" sync / 1[56]:[^:]*:Agdistis:780B:/
+1115.5 "Forbidden Fruit" sync / 1[56]:[^:]*:Agdistis:7801:/
+1127.2 "Static Moon" sync / 1[56]:[^:]*:Immature Io:7802:/
+1139.2 "Blades of Attis" sync / 1[56]:[^:]*:Agdistis:7805:/
+1156.9 "Forbidden Fruit" sync / 1[56]:[^:]*:Agdistis:7801:/
+1168.6 "Stymphalian Strike" sync / 1[56]:[^:]*:Immature Stymphalide:7803:/
+1189.8 "Hemitheos's Glare III" sync / 1[56]:[^:]*:Agdistis:79FA:/ window 30,30
+1197.4 "Blades of Attis" sync / 1[56]:[^:]*:Agdistis:7805:/
+1211.7 "Bough of Attis (OUT)" sync / 1[56]:[^:]*:Agdistis:77F9:/
+1219.3 "Bough of Attis (left/right)" sync / 1[56]:[^:]*:Agdistis:(77FB|77FC):/
+
+1222.5 "--sync--" sync / 14:[^:]*:Agdistis:7800:/ window 30,30 jump 400
+1223.6 "--sync--" sync / 14:[^:]*:Agdistis:7807:/ window 30,30 jump 1000
+1231.2 "Forbidden Fruit?"
+1233.4 "Hemitheos's Holy?"
+1239.8 "Hemitheos's Glare III?"
+1243.3 "Static Moon?"
+1243.3 "Hemitheos's Holy?"
+1249.9 "Bough of Attis?"
+1253.1 "Immortal's Obol?"
+1260.3 "Bough of Attis?"

--- a/ui/raidboss/data/06-ew/raid/p7n.txt
+++ b/ui/raidboss/data/06-ew/raid/p7n.txt
@@ -5,3 +5,85 @@ hideall "--Reset--"
 hideall "--sync--"
 
 0.0 "--Reset--" sync / 21:........:4000000F:/ window 100000 jump 0
+
+# -ii 77FA 77FD 77FF 77F6 780A 783E 7800 7804 7806 7807 77F7 7841
+
+0.0 "--sync--" sync /Engage!/ window 0,1
+15.8 "Bough of Attis (out)" sync / 1[56]:[^:]*:Agdistis:77F9:/ window 16,5
+23.4 "Bough of Attis (left/right)" sync / 1[56]:[^:]*:Agdistis:77FB:/
+37.6 "Hemitheos's Holy" sync / 1[56]:[^:]*:Agdistis:7808:/
+44.0 "Hemitheos's Glare III" sync / 1[56]:[^:]*:Agdistis:77F8:/
+54.1 "Bough of Attis (in)"  sync / 1[56]:[^:]*:Agdistis:77FE:/
+64.5 "Bough of Attis (out)" sync / 1[56]:[^:]*:Agdistis:77F9:/
+72.1 "Bough of Attis (left/right)" sync / 1[56]:[^:]*:Agdistis:77FC:/
+81.9 "Immortal's Obol" sync / 1[56]:[^:]*:Agdistis:77F5:/
+102.0 "Bough of Attis (out)" sync / 1[56]:[^:]*:Agdistis:77F9:/
+109.6 "Bough of Attis (left/right)" sync / 1[56]:[^:]*:Agdistis:77FC:/
+119.7 "Hemitheos's Aero II" sync / 1[56]:[^:]*:Agdistis:7809:/ window 215,10
+128.9 "Spark of Life" sync / 1[56]:[^:]*:Agdistis:780B:/
+143.2 "Forbidden Fruit" sync / 1[56]:[^:]*:Agdistis:7801:/
+154.9 "Static Moon" sync / 1[56]:[^:]*:Immature Io:7802:/ window 155,10
+166.9 "Blades of Attis x8" sync / 1[56]:[^:]*:Agdistis:7805:/
+184.1 "Forbidden Fruit" sync / 1[56]:[^:]*:Agdistis:7801:/
+195.8 "Stymphalian Strike" sync / 1[56]:[^:]*:Immature Stymphalide:7803:/ window 50,50
+216.9 "Hemitheos's Glare III" sync / 1[56]:[^:]*:Agdistis:79FA:/
+224.5 "Blades of Attis x8" sync / 1[56]:[^:]*:Agdistis:7805:/
+238.5 "Bough of Attis (out)" sync / 1[56]:[^:]*:Agdistis:77F9:/
+246.1 "Bough of Attis (left/right)" sync / 1[56]:[^:]*:Agdistis:77FB:/
+
+258.2 "Forbidden Fruit" sync / 1[56]:[^:]*:Agdistis:7801:/
+270.3 "Static Moon" sync / 1[56]:[^:]*:Immature Io:7802:/ window 50,50
+270.3 "Hemitheos's Holy" sync / 1[56]:[^:]*:Agdistis:7808:/
+280.1 "Immortal's Obol" sync / 1[56]:[^:]*:Agdistis:77F5:/
+300.3 "Forbidden Fruit" sync / 1[56]:[^:]*:Agdistis:7801:/
+313.7 "Bough of Attis (in)" sync / 1[56]:[^:]*:Agdistis:77FE:/
+315.1 "Static Moon" sync / 1[56]:[^:]*:Immature Io:7802:/
+325.3 "Hemitheos's Aero II" sync / 1[56]:[^:]*:Agdistis:7809:/
+338.5 "Forbidden Fruit" sync / 1[56]:[^:]*:Agdistis:7801:/
+341.6 "Shadow of Attis" sync / 1[56]:[^:]*:Agdistis:783C:/
+350.0 "Static Moon" sync / 1[56]:[^:]*:Immature Io:7802:/
+354.6 "Burst" sync / 1[56]:[^:]*:Agdistis:783D:/
+362.8 "Bough of Attis (out)" sync / 1[56]:[^:]*:Agdistis:77F9:/
+370.4 "Bough of Attis (left/right)" sync / 1[56]:[^:]*:Agdistis:77FC:/
+379.6 "Spark of Life" sync / 1[56]:[^:]*:Agdistis:780B:/
+388.7 "Spark of Life" sync / 1[56]:[^:]*:Agdistis:780B:/
+397.8 "Spark of Life" sync / 1[56]:[^:]*:Agdistis:780B:/
+412.9 "Forbidden Fruit" sync / 1[56]:[^:]*:Agdistis:7801:/
+426.0 "Hemitheos's Aero IV" sync / 1[56]:[^:]*:Agdistis:7840:/
+429.4 "Stymphalian Strike" sync / 1[56]:[^:]*:Immature Stymphalide:7803:/
+429.4 "Static Moon" sync / 1[56]:[^:]*:Immature Io:7802:/
+437.1 "Blades of Attis (lines)" sync / 1[56]:[^:]*:Agdistis:7805:/
+448.2 "Hemitheos's Holy" sync / 1[56]:[^:]*:Agdistis:7808:/
+456.5 "Spark of Life" sync / 1[56]:[^:]*:Agdistis:780B:/
+465.6 "Hemitheos's Aero II" sync / 1[56]:[^:]*:Agdistis:7809:/
+484.8 "Hemitheos's Glare III" sync / 1[56]:[^:]*:Agdistis:79FA:/
+492.4 "Blades of Attis (triangle)" sync / 1[56]:[^:]*:Agdistis:7805:/
+506.5 "Bough of Attis (out)" sync / 1[56]:[^:]*:Agdistis:77F9:/
+514.1 "Bough of Attis (left/right)" sync / 1[56]:[^:]*:Agdistis:77FB:/
+
+526.2 "Forbidden Fruit" sync / 1[56]:[^:]*:Agdistis:7801:/
+538.3 "Static Moon" sync / 1[56]:[^:]*:Immature Io:7802:/ window 25,25
+538.3 "Hemitheos's Holy" sync / 1[56]:[^:]*:Agdistis:7808:/
+548.1 "Immortal's Obol" sync / 1[56]:[^:]*:Agdistis:77F5:/
+568.3 "Forbidden Fruit" sync / 1[56]:[^:]*:Agdistis:7801:/
+581.7 "Bough of Attis (in)" sync / 1[56]:[^:]*:Agdistis:77FE:/
+583.1 "Stymphalian Strike" sync / 1[56]:[^:]*:Immature Stymphalide:7803:/
+593.3 "Hemitheos's Aero II" sync / 1[56]:[^:]*:Agdistis:7809:/
+606.5 "Forbidden Fruit" sync / 1[56]:[^:]*:Agdistis:7801:/
+609.6 "Shadow of Attis" sync / 1[56]:[^:]*:Agdistis:783C:/
+618.0 "Static Moon" sync / 1[56]:[^:]*:Immature Io:7802:/
+622.6 "Burst" sync / 1[56]:[^:]*:Agdistis:783D:/
+630.8 "Bough of Attis (out)" sync / 1[56]:[^:]*:Agdistis:77F9:/
+638.4 "Bough of Attis (left/right)" sync / 1[56]:[^:]*:Agdistis:77FB:/
+647.6 "Spark of Life" sync / 1[56]:[^:]*:Agdistis:780B:/
+656.7 "Spark of Life" sync / 1[56]:[^:]*:Agdistis:780B:/
+665.8 "Spark of Life" sync / 1[56]:[^:]*:Agdistis:780B:/
+681.0 "Forbidden Fruit" sync / 1[56]:[^:]*:Agdistis:7801:/
+694.1 "Hemitheos's Aero IV" sync / 1[56]:[^:]*:Agdistis:7840:/
+697.7 "Stymphalian Strike" sync / 1[56]:[^:]*:Immature Stymphalide:7803:/
+697.7 "Static Moon" sync / 1[56]:[^:]*:Immature Io:7802:/
+705.4 "Blades of Attis" sync / 1[56]:[^:]*:Agdistis:7805:/
+716.7 "Hemitheos's Holy" sync / 1[56]:[^:]*:Agdistis:7808:/
+725.0 "Spark of Life" sync / 1[56]:[^:]*:Agdistis:780B:/
+734.1 "Hemitheos's Aero II" sync / 1[56]:[^:]*:Agdistis:7809:/
+753.3 "Hemitheos's Glare III" sync / 1[56]:[^:]*:Agdistis:79FA:/

--- a/ui/raidboss/data/06-ew/raid/p7n.txt
+++ b/ui/raidboss/data/06-ew/raid/p7n.txt
@@ -24,7 +24,7 @@ hideall "--sync--"
 128.9 "Spark of Life" sync / 1[56]:[^:]*:Agdistis:780B:/
 143.2 "Forbidden Fruit" sync / 1[56]:[^:]*:Agdistis:7801:/
 154.9 "Static Moon" sync / 1[56]:[^:]*:Immature Io:7802:/ window 155,10
-166.9 "Blades of Attis(lines)" sync / 1[56]:[^:]*:Agdistis:7805:/
+166.9 "Blades of Attis (lines)" sync / 1[56]:[^:]*:Agdistis:7805:/
 184.1 "Forbidden Fruit" sync / 1[56]:[^:]*:Agdistis:7801:/
 195.8 "Stymphalian Strike" sync / 1[56]:[^:]*:Immature Stymphalide:7803:/ window 50,50
 216.9 "Hemitheos's Glare III" sync / 1[56]:[^:]*:Agdistis:79FA:/

--- a/ui/raidboss/data/06-ew/raid/p7n.txt
+++ b/ui/raidboss/data/06-ew/raid/p7n.txt
@@ -10,15 +10,15 @@ hideall "--sync--"
 
 0.0 "--sync--" sync /Engage!/ window 0,1
 3.0 "--sync--" sync / 1[56]:[^:]*:Agdistis:78E3:/
-15.8 "Bough of Attis (OUT)" sync / 1[56]:[^:]*:Agdistis:77F9:/ window 16,5
+15.8 "Bough of Attis (out)" sync / 1[56]:[^:]*:Agdistis:77F9:/ window 16,5
 23.4 "Bough of Attis (left/right)" sync / 1[56]:[^:]*:Agdistis:(77FB|77FC):/
 37.6 "Hemitheos's Holy" sync / 1[56]:[^:]*:Agdistis:7808:/
 44.0 "Hemitheos's Glare III" sync / 1[56]:[^:]*:Agdistis:77F8:/
-54.1 "Bough of Attis (IN)"  sync / 1[56]:[^:]*:Agdistis:77FE:/
-64.5 "Bough of Attis (OUT)" sync / 1[56]:[^:]*:Agdistis:77F9:/
+54.1 "Bough of Attis (in)"  sync / 1[56]:[^:]*:Agdistis:77FE:/
+64.5 "Bough of Attis (out)" sync / 1[56]:[^:]*:Agdistis:77F9:/
 72.1 "Bough of Attis (left/right)" sync / 1[56]:[^:]*:Agdistis:(77FB|77FC):/
 81.9 "Immortal's Obol" sync / 1[56]:[^:]*:Agdistis:77F5:/
-102.0 "Bough of Attis (OUT)" sync / 1[56]:[^:]*:Agdistis:77F9:/
+102.0 "Bough of Attis (out)" sync / 1[56]:[^:]*:Agdistis:77F9:/
 109.6 "Bough of Attis (left/right)" sync / 1[56]:[^:]*:Agdistis:(77FB|77FC):/
 119.7 "Hemitheos's Aero II" sync / 1[56]:[^:]*:Agdistis:7809:/ window 215,10
 128.9 "Spark of Life" sync / 1[56]:[^:]*:Agdistis:780B:/
@@ -29,7 +29,7 @@ hideall "--sync--"
 195.8 "Stymphalian Strike" sync / 1[56]:[^:]*:Immature Stymphalide:7803:/ window 50,50
 216.9 "Hemitheos's Glare III" sync / 1[56]:[^:]*:Agdistis:79FA:/
 224.5 "Blades of Attis (triangle)" sync / 1[56]:[^:]*:Agdistis:7805:/
-238.5 "Bough of Attis (OUT)" sync / 1[56]:[^:]*:Agdistis:77F9:/
+238.5 "Bough of Attis (out)" sync / 1[56]:[^:]*:Agdistis:77F9:/
 246.1 "Bough of Attis (left/right)" sync / 1[56]:[^:]*:Agdistis:77FB:/
 
 # Forbidden Fruit pre-cast
@@ -53,14 +53,14 @@ hideall "--sync--"
 420.8 "Hemitheos's Holy" sync / 1[56]:[^:]*:Agdistis:7808:/
 430.6 "Immortal's Obol" sync / 1[56]:[^:]*:Agdistis:77F5:/
 450.9 "Forbidden Fruit" sync / 1[56]:[^:]*:Agdistis:7801:/
-464.3 "Bough of Attis (IN)"  sync / 1[56]:[^:]*:Agdistis:77FE:/
+464.3 "Bough of Attis (in)"  sync / 1[56]:[^:]*:Agdistis:77FE:/
 465.7 "Static Moon" sync / 1[56]:[^:]*:Immature Io:7802:/
 475.9 "Hemitheos's Aero II" sync / 1[56]:[^:]*:Agdistis:7809:/ window 30,30
 489.2 "Forbidden Fruit" sync / 1[56]:[^:]*:Agdistis:7801:/
 492.3 "Shadow of Attis" sync / 1[56]:[^:]*:Agdistis:783C:/
 500.7 "Static Moon/Stymphalian Strike" sync / 1[56]:[^:]*:(Immature Io|Immature Stymphalide):(7802|7803):/
 505.4 "Burst" sync / 1[56]:[^:]*:Agdistis:783D:/
-513.6 "Bough of Attis (OUT)" sync / 1[56]:[^:]*:Agdistis:77F9:/
+513.6 "Bough of Attis (out)" sync / 1[56]:[^:]*:Agdistis:77F9:/
 521.2 "Bough of Attis (left/right)" sync / 1[56]:[^:]*:Agdistis:(77FB|77FC):/
 530.4 "Spark of Life" sync / 1[56]:[^:]*:Agdistis:780B:/
 539.5 "Spark of Life" sync / 1[56]:[^:]*:Agdistis:780B:/
@@ -75,7 +75,7 @@ hideall "--sync--"
 616.9 "Hemitheos's Aero II" sync / 1[56]:[^:]*:Agdistis:7809:/
 636.1 "Hemitheos's Glare III" sync / 1[56]:[^:]*:Agdistis:79FA:/ window 30,30
 643.7 "Blades of Attis (triangle)" sync / 1[56]:[^:]*:Agdistis:7805:/
-658.0 "Bough of Attis (OUT)" sync / 1[56]:[^:]*:Agdistis:77F9:/
+658.0 "Bough of Attis (out)" sync / 1[56]:[^:]*:Agdistis:77F9:/
 665.6 "Bough of Attis (left/right)" sync / 1[56]:[^:]*:Agdistis:(77FB|77FC):/
 
 669.1 "--sync--" sync / 14:[^:]*:Agdistis:7800:/ window 30,30 jump 400
@@ -94,11 +94,11 @@ hideall "--sync--"
 1000.0 "--sync--" sync / 14:[^:]*:Agdistis:7807:/
 1009.8 "Hemitheos's Holy" sync / 1[56]:[^:]*:Agdistis:7808:/
 1016.2 "Hemitheos's Glare III" sync / 1[56]:[^:]*:Agdistis:77F8:/ window 30,30
-1026.3 "Bough of Attis (IN)"  sync / 1[56]:[^:]*:Agdistis:77FE:/
-1036.7 "Bough of Attis (OUT)" sync / 1[56]:[^:]*:Agdistis:77F9:/
+1026.3 "Bough of Attis (in)"  sync / 1[56]:[^:]*:Agdistis:77FE:/
+1036.7 "Bough of Attis (out)" sync / 1[56]:[^:]*:Agdistis:77F9:/
 1044.3 "Bough of Attis (left/right)" sync / 1[56]:[^:]*:Agdistis:(77FB|77FC):/
 1054.1 "Immortal's Obol" sync / 1[56]:[^:]*:Agdistis:77F5:/ window 30,30
-1074.2 "Bough of Attis (OUT)" sync / 1[56]:[^:]*:Agdistis:77F9:/
+1074.2 "Bough of Attis (out)" sync / 1[56]:[^:]*:Agdistis:77F9:/
 1081.8 "Bough of Attis (left/right)" sync / 1[56]:[^:]*:Agdistis:(77FB|77FC):/
 1091.9 "Hemitheos's Aero II" sync / 1[56]:[^:]*:Agdistis:7809:/ window 30,30
 1101.1 "Spark of Life" sync / 1[56]:[^:]*:Agdistis:780B:/
@@ -109,7 +109,7 @@ hideall "--sync--"
 1168.6 "Stymphalian Strike" sync / 1[56]:[^:]*:Immature Stymphalide:7803:/
 1189.8 "Hemitheos's Glare III" sync / 1[56]:[^:]*:Agdistis:79FA:/ window 30,30
 1197.4 "Blades of Attis" sync / 1[56]:[^:]*:Agdistis:7805:/
-1211.7 "Bough of Attis (OUT)" sync / 1[56]:[^:]*:Agdistis:77F9:/
+1211.7 "Bough of Attis (out)" sync / 1[56]:[^:]*:Agdistis:77F9:/
 1219.3 "Bough of Attis (left/right)" sync / 1[56]:[^:]*:Agdistis:(77FB|77FC):/
 
 1222.5 "--sync--" sync / 14:[^:]*:Agdistis:7800:/ window 30,30 jump 400


### PR DESCRIPTION
Nothing much to say on this one. Once I figured out which abilities to ignore the loops weren't too hard to identify.

The proximity marker on Immortals' Obol kills people a lot because it's logarithmic falloff damage, but because it always damages players it's tough to make anything from it.