### PR TITLE
raidboss: Add Sephirot Unreal

### DIFF
--- a/ui/oopsyraidsy/data/06-ew/trial/sephirot-un.ts
+++ b/ui/oopsyraidsy/data/06-ew/trial/sephirot-un.ts
@@ -10,29 +10,29 @@ export interface Data extends OopsyData {
 const triggerSet: OopsyTriggerSet<Data> = {
   zoneId: ZoneId.ContainmentBayS1T7Unreal,
   damageWarn: {
-    'SephirotEX Yesod': '76AB', // Snapshot floor spikes
-    'SephirotEX Ain': '7696', // Half-arena baited frontal
-    'SephirotEX Ein Sof': '769C', // Expanding green puddles
-    'SephirotEX Fiendish Wail': '76A4', // Raidwide if tower is missed
+    'SephirotUn Yesod': '76AB', // Snapshot floor spikes
+    'SephirotUn Ain': '7696', // Half-arena baited frontal
+    'SephirotUn Ein Sof': '769C', // Expanding green puddles
+    'SephirotUn Fiendish Wail': '76A4', // Raidwide if tower is missed
   },
   damageFail: {
-    'SephirotEX Pillar Of Mercy': '76AE', // Standing in the blue puddles
-    'SephirotEX Storm Of Words Revelation': '7680', // Missing the enrage on Storm of Words
+    'SephirotUn Pillar Of Mercy': '76AE', // Standing in the blue puddles
+    'SephirotUn Storm Of Words Revelation': '7680', // Missing the enrage on Storm of Words
   },
   shareWarn: {
-    'SephirotEX Triple Trial': '7693', // Instant tank cleave
-    'SephirotEX Ratzon Green': '7698', // Small green spread circle
-    'SephirotEX Ratzon Purple': '7699', // Large purple spread circle
-    'SephirotEX Earth Shaker': '7688',
-    'SephirotEX Spread Da\'at': '76A0',
+    'SephirotUn Triple Trial': '7693', // Instant tank cleave
+    'SephirotUn Ratzon Green': '7698', // Small green spread circle
+    'SephirotUn Ratzon Purple': '7699', // Large purple spread circle
+    'SephirotUn Earth Shaker': '7688',
+    'SephirotUn Spread Da\'at': '76A0',
   },
   soloWarn: {
-    'SephirotEX Fiendish Rage': '769A', // Stack markers, phase 1
+    'SephirotUn Fiendish Rage': '769A', // Stack markers, phase 1
   },
   triggers: [
     {
       // Pillar of Mercy,  Malkuth, and Pillar of Severity
-      id: 'SephirotEX Knockbacks',
+      id: 'SephirotUn Knockbacks',
       type: 'Ability',
       netRegex: NetRegexes.ability({ id: ['76AD', '76AF', '76B2'], source: 'Sephirot' }),
       deathReason: (_data, matches) => {
@@ -52,7 +52,7 @@ const triggerSet: OopsyTriggerSet<Data> = {
     },
     {
       // 3ED is Force Against Might orange, 3EE is Force Against Magic, green.
-      id: 'SephirotEX Force Against Gain',
+      id: 'SephirotUn Force Against Gain',
       type: 'GainsEffect',
       netRegex: NetRegexes.gainsEffect({ effectId: ['3ED', '3EE'] }),
       run: (data, matches) => {
@@ -61,7 +61,7 @@ const triggerSet: OopsyTriggerSet<Data> = {
       },
     },
     {
-      id: 'SephirotEX Force Against Lose',
+      id: 'SephirotUn Force Against Lose',
       type: 'LosesEffect',
       netRegex: NetRegexes.losesEffect({ effectId: ['3ED', '3EE'] }),
       run: (data, matches) => {
@@ -70,7 +70,7 @@ const triggerSet: OopsyTriggerSet<Data> = {
       },
     },
     {
-      id: 'SephirotEX Spirit',
+      id: 'SephirotUn Spirit',
       type: 'Ability',
       netRegex: NetRegexes.ability({ id: '76A8', source: 'Sephirot' }),
       condition: (data, matches) => data?.force?.[matches.target] === '3ED',
@@ -83,7 +83,7 @@ const triggerSet: OopsyTriggerSet<Data> = {
       },
     },
     {
-      id: 'SephirotEX Life Force',
+      id: 'SephirotUn Life Force',
       type: 'Ability',
       netRegex: NetRegexes.ability({ id: '76A7', source: 'Sephirot' }),
       condition: (data, matches) => data?.force?.[matches.target] === '3EE',
@@ -96,7 +96,7 @@ const triggerSet: OopsyTriggerSet<Data> = {
       },
     },
     {
-      id: 'SephirotEX Fiendish Wail Green',
+      id: 'SephirotUn Fiendish Wail Green',
       type: 'Ability',
       netRegex: NetRegexes.ability({ id: '76A3', source: 'Sephirot' }),
       condition: (data, matches) => data?.force?.[matches.target] === '3EE',
@@ -110,7 +110,7 @@ const triggerSet: OopsyTriggerSet<Data> = {
     },
     {
       // Only tanks or Blue Mages should take towers without a Force debuff.
-      id: 'SephirotEX Fiendish Wail Non-Tank',
+      id: 'SephirotUn Fiendish Wail Non-Tank',
       type: 'Ability',
       netRegex: NetRegexes.ability({ id: '76A3', source: 'Sephirot' }),
       condition: (data, matches) => {
@@ -128,7 +128,7 @@ const triggerSet: OopsyTriggerSet<Data> = {
     },
     {
       // Taking a tether while under Force Against Might (orange) kills the target
-      id: 'SephirotEX Tether Da\'at',
+      id: 'SephirotUn Tether Da\'at',
       type: 'Ability',
       netRegex: NetRegexes.ability({ id: '76A1', source: 'Sephirot' }),
       condition: (data, matches) => data?.force?.[matches.target] === '3ED',

--- a/ui/oopsyraidsy/data/06-ew/trial/sephirot-un.ts
+++ b/ui/oopsyraidsy/data/06-ew/trial/sephirot-un.ts
@@ -1,11 +1,146 @@
+import NetRegexes from '../../../../../resources/netregexes';
 import ZoneId from '../../../../../resources/zone_id';
 import { OopsyData } from '../../../../../types/data';
 import { OopsyTriggerSet } from '../../../../../types/oopsy';
 
-export type Data = OopsyData;
+export interface Data extends OopsyData {
+  force?: { [name: string]: string };
+}
 
 const triggerSet: OopsyTriggerSet<Data> = {
   zoneId: ZoneId.ContainmentBayS1T7Unreal,
+  damageWarn: {
+    'SephirotEX Yesod': '76AB', // Snapshot floor spikes
+    'SephirotEX Ain': '7696', // Half-arena baited frontal
+    'SephirotEX Ein Sof': '769C', // Expanding green puddles
+    'SephirotEX Fiendish Wail': '76A4', // Raidwide if tower is missed
+  },
+  damageFail: {
+    'SephirotEX Pillar Of Mercy': '76AE', // Standing in the blue puddles
+    'SephirotEX Storm Of Words Revelation': '7680', // Missing the enrage on Storm of Words
+  },
+  shareWarn: {
+    'SephirotEX Triple Trial': '7693', // Instant tank cleave
+    'SephirotEX Ratzon Green': '7698', // Small green spread circle
+    'SephirotEX Ratzon Purple': '7699', // Large purple spread circle
+    'SephirotEX Earth Shaker': '7688',
+    'SephirotEX Spread Da\'at': '76A0',
+  },
+  soloWarn: {
+    'SephirotEX Fiendish Rage': '769A', // Stack markers, phase 1
+  },
+  triggers: [
+    {
+      // Pillar of Mercy,  Malkuth, and Pillar of Severity
+      id: 'SephirotEX Knockbacks',
+      type: 'Ability',
+      netRegex: NetRegexes.ability({ id: ['76AD', '76AF', '76B2'], source: 'Sephirot' }),
+      deathReason: (_data, matches) => {
+        return {
+          id: matches.targetId,
+          name: matches.target,
+          text: {
+            en: 'Pushed off!',
+            de: 'Runter geschubst!',
+            fr: 'Repoussé(e) !',
+            ja: '落ちた',
+            cn: '击退坠落',
+            ko: '넉백됨',
+          },
+        };
+      },
+    },
+    {
+      // 3ED is Force Against Might orange, 3EE is Force Against Magic, green.
+      id: 'SephirotEX Force Against Gain',
+      type: 'GainsEffect',
+      netRegex: NetRegexes.gainsEffect({ effectId: ['3ED', '3EE'] }),
+      run: (data, matches) => {
+        data.force ??= {};
+        data.force[matches.target] = matches.effectId;
+      },
+    },
+    {
+      id: 'SephirotEX Force Against Lose',
+      type: 'LosesEffect',
+      netRegex: NetRegexes.losesEffect({ effectId: ['3ED', '3EE'] }),
+      run: (data, matches) => {
+        data.force ??= {};
+        delete data.force[matches.target];
+      },
+    },
+    {
+      id: 'SephirotEX Spirit',
+      type: 'Ability',
+      netRegex: NetRegexes.ability({ id: '76A8', source: 'Sephirot' }),
+      condition: (data, matches) => data?.force?.[matches.target] === '3ED',
+      mistake: (_data, matches) => {
+        return {
+          type: 'warn',
+          blame: matches.target,
+          text: matches.ability,
+        };
+      },
+    },
+    {
+      id: 'SephirotEX Life Force',
+      type: 'Ability',
+      netRegex: NetRegexes.ability({ id: '76A7', source: 'Sephirot' }),
+      condition: (data, matches) => data?.force?.[matches.target] === '3EE',
+      mistake: (_data, matches) => {
+        return {
+          type: 'warn',
+          blame: matches.target,
+          text: matches.ability,
+        };
+      },
+    },
+    {
+      id: 'SephirotEX Fiendish Wail Green',
+      type: 'Ability',
+      netRegex: NetRegexes.ability({ id: '76A3', source: 'Sephirot' }),
+      condition: (data, matches) => data?.force?.[matches.target] === '3EE',
+      mistake: (_data, matches) => {
+        return {
+          type: 'fail',
+          blame: matches.target,
+          text: matches.ability,
+        };
+      },
+    },
+    {
+      // Only tanks or Blue Mages should take towers without a Force debuff.
+      id: 'SephirotEX Fiendish Wail Non-Tank',
+      type: 'Ability',
+      netRegex: NetRegexes.ability({ id: '76A3', source: 'Sephirot' }),
+      condition: (data, matches) => {
+        if (data.party.isTank(matches.target) || data.job === 'BLU')
+          return false;
+        return data?.force?.[matches.target] === undefined;
+      },
+      mistake: (_data, matches) => {
+        return {
+          type: 'fail',
+          blame: matches.target,
+          text: matches.ability,
+        };
+      },
+    },
+    {
+      // Taking a tether while under Force Against Might (orange) kills the target
+      id: 'SephirotEX Tether Da\'at',
+      type: 'Ability',
+      netRegex: NetRegexes.ability({ id: '76A1', source: 'Sephirot' }),
+      condition: (data, matches) => data?.force?.[matches.target] === '3ED',
+      mistake: (_data, matches) => {
+        return {
+          type: 'fail',
+          blame: matches.target,
+          text: matches.ability,
+        };
+      },
+    },
+  ],
 };
 
 export default triggerSet;

--- a/ui/raidboss/data/06-ew/trial/sephirot-un.ts
+++ b/ui/raidboss/data/06-ew/trial/sephirot-un.ts
@@ -1,13 +1,510 @@
+import Conditions from '../../../../../resources/conditions';
+import NetRegexes from '../../../../../resources/netregexes';
+import Outputs from '../../../../../resources/outputs';
+import { Responses } from '../../../../../resources/responses';
 import ZoneId from '../../../../../resources/zone_id';
 import { RaidbossData } from '../../../../../types/data';
 import { TriggerSet } from '../../../../../types/trigger';
 
-export type Data = RaidbossData;
+export interface Data extends RaidbossData {
+  mainTank?: string;
+  phase: number;
+  force?: string;
+  shakerTargets?: string[];
+  pillarActive: boolean;
+}
 
 const triggerSet: TriggerSet<Data> = {
   zoneId: ZoneId.ContainmentBayS1T7Unreal,
   timelineFile: 'sephirot-un.txt',
-  triggers: [],
+  initData: () => {
+    return {
+      phase: 1,
+      pillarActive: false,
+    };
+  },
+  timelineTriggers: [
+    {
+      id: 'SephirotUn Tiferet',
+      regex: /Tiferet/,
+      beforeSeconds: 4,
+      suppressSeconds: 2, // Timeline syncs can otherwise make this extra-noisy
+      response: Responses.aoe(),
+    },
+    {
+      id: 'SephirotUn Triple Trial',
+      regex: /Triple Trial/,
+      beforeSeconds: 4,
+      response: Responses.tankCleave(),
+    },
+    {
+      id: 'SephirotUn Ein Sof Rage',
+      regex: /Ein Sof \(4 puddles\)/,
+      infoText: (_data, _matches, output) => output.text!(),
+      outputStrings: {
+        text: {
+          en: 'Move to safe quadrant',
+          de: 'Beweg dich in den sicheren Quadranten',
+          cn: '移动到安全区域',
+          ko: '안전한 지역으로 이동',
+        },
+      },
+    },
+    {
+      id: 'SephirotUn Ein Sof Ratzon',
+      regex: /Ein Sof \(1 puddle\)/,
+      infoText: (_data, _matches, output) => output.text!(),
+      outputStrings: {
+        text: {
+          en: 'Bait toward puddle',
+          de: 'In Richtung Fläche ködern',
+          cn: '靠近圈圈集合诱导AOE',
+          ko: '장판 쪽으로 아인 유도',
+        },
+      },
+    },
+    {
+      id: 'SephirotUn Yesod Bait',
+      regex: /Yesod/,
+      beforeSeconds: 6,
+      alertText: (data, _matches, output) => {
+        if (data.pillarActive)
+          return output.withPillar!();
+        return output.noPillar!();
+      },
+      outputStrings: {
+        noPillar: {
+          en: 'Bait Yesod',
+          de: 'Yesod ködern',
+          cn: '集合诱导基盘碎击',
+          ko: '예소드 붕괴 유도',
+        },
+        withPillar: {
+          en: 'Bait Yesod inside puddle',
+          de: 'Yesod in die Fläche ködern',
+          cn: '圈圈内集合诱导基盘碎击',
+          ko: '장판 안에 예소드 유도하기',
+        },
+      },
+    },
+    {
+      id: 'SephirotUn Pillar Activate',
+      regex: /Pillar of Mercy 1/,
+      beforeSeconds: 10,
+      run: (data) => data.pillarActive = true,
+    },
+    {
+      id: 'SephirotUn Pillar Deactivate',
+      regex: /Pillar of Mercy 3/,
+      run: (data) => data.pillarActive = false,
+    },
+  ],
+  triggers: [
+    {
+      id: 'SephirotUn Main Tank',
+      type: 'Ability',
+      netRegex: NetRegexes.ability({ id: '368', source: 'Sephirot' }),
+      // We make this conditional to avoid constant noise in the raid emulator.
+      condition: (data, matches) => data.mainTank !== matches.target,
+      run: (data, matches) => data.mainTank = matches.target,
+    },
+    {
+      id: 'SephirotUn Chesed Buster',
+      type: 'StartsUsing',
+      netRegex: NetRegexes.startsUsing({ id: '7694', source: 'Sephirot' }),
+      response: Responses.tankBuster(),
+    },
+    {
+      id: 'SephirotUn Ein',
+      type: 'StartsUsing',
+      netRegex: NetRegexes.startsUsing({ id: '7696', source: 'Sephirot', capture: false }),
+
+      response: Responses.getBehind(),
+    },
+    {
+      id: 'SephirotUn Ratzon Spread',
+      type: 'HeadMarker',
+      netRegex: NetRegexes.headMarker({ id: ['0046', '0047'] }),
+      condition: Conditions.targetIsYou(),
+      response: Responses.spread(),
+    },
+    {
+      id: 'SephirotUn Fiendish Rage',
+      type: 'HeadMarker',
+      netRegex: NetRegexes.headMarker({ id: '0048', capture: false }),
+      condition: (data) => data.phase === 1,
+      suppressSeconds: 10,
+      alertText: (data, _matches, output) => {
+        if (data.me === data.mainTank)
+          return output.noStack!();
+        return output.stack!();
+      },
+      outputStrings: {
+        noStack: {
+          en: 'Don\'t Stack!',
+          de: 'Nicht sammeln!',
+          cn: '不要重合！',
+          ko: '겹치면 안됨!',
+        },
+        stack: {
+          en: 'Group Stacks',
+          de: 'In der Gruppe sammeln',
+          cn: '分组集合',
+          ko: '그룹 쉐어',
+        },
+      },
+    },
+    {
+      id: 'SephirotUn Da\'at Spread',
+      type: 'StartsUsing',
+      netRegex: NetRegexes.startsUsing({ id: '769F', source: 'Sephirot', capture: false }),
+      response: Responses.spread(),
+    },
+    {
+      id: 'SephirotUn Malkuth',
+      type: 'StartsUsing',
+      netRegex: NetRegexes.startsUsing({ id: '76AF', source: 'Sephirot', capture: false }),
+      response: Responses.knockback(),
+    },
+    {
+      id: 'SephirotUn Yesod Move',
+      type: 'StartsUsing',
+      netRegex: NetRegexes.startsUsing({ id: '76AB', source: 'Sephirot', capture: false }),
+      suppressSeconds: 2,
+      response: Responses.moveAway('alarm'), // This *will* kill if a non-tank takes 2+.
+    },
+    {
+      // 3ED is Force Against Might orange, 3EE is Force Against Magic, green.
+      id: 'SephirotUn Force Against Gain',
+      type: 'GainsEffect',
+      netRegex: NetRegexes.gainsEffect({ effectId: ['3ED', '3EE'] }),
+      condition: Conditions.targetIsYou(),
+      alertText: (_data, matches, output) => output.text!({ force: matches.effect }),
+      run: (data, matches) => data.force = matches.effectId,
+      outputStrings: {
+        text: {
+          en: '${force} on you',
+          de: '${force} auf dir',
+          cn: '${force}点名',
+          ko: '나에게 ${force}',
+        },
+      },
+    },
+    {
+      // Orange left, Green right. Match color to Force debuff.
+      id: 'SephirotUn Gevurah Chesed',
+      type: 'StartsUsing',
+      netRegex: NetRegexes.startsUsing({ id: '76A5', capture: false }),
+      alertText: (data, _matches, output) => {
+        // Here and for Chesed Gevurah, if the player doesn't have a color debuff,
+        // they just take moderate AoE damage.
+        // Unlike Flood of Naught (colors) in O4s,
+        // standing center is safe if the user has no debuff.
+        if (data.force)
+          return data.force === '3ED' ? output.left!() : output.right!();
+        return output.aoe!();
+      },
+      outputStrings: {
+        left: Outputs.left,
+        right: Outputs.right,
+        aoe: Outputs.aoe,
+      },
+    },
+    {
+      // Green left, Orange right. Match color to Force debuff.
+      id: 'SephirotUn Chesed Gevurah',
+      type: 'StartsUsing',
+      netRegex: NetRegexes.startsUsing({ id: '76A6', capture: false }),
+      alertText: (data, _matches, output) => {
+        if (data.force)
+          return data.force === '3EE' ? output.left!() : output.right!();
+        return output.aoe!();
+      },
+      outputStrings: {
+        left: Outputs.left,
+        right: Outputs.right,
+        aoe: Outputs.aoe,
+      },
+    },
+    {
+      id: 'SephirotUn Fiendish Wail',
+      type: 'Ability',
+      netRegex: NetRegexes.ability({ id: '76A2', source: 'Sephirot', capture: false }),
+      alertText: (data, _matches, output) => {
+        if (data.force === '3ED' || (!data.force && data.role === 'tank'))
+          return output.getTower!();
+        return output.avoidTower!();
+      },
+      outputStrings: {
+        getTower: {
+          en: 'Get a tower',
+          de: 'Nimm einen Turm',
+          cn: '踩塔',
+          ko: '기둥 밟기',
+        },
+        avoidTower: {
+          en: 'Avoid towers',
+          de: 'Turm meiden',
+          cn: '躲塔',
+          ko: '기둥 피하기',
+        },
+      },
+    },
+    {
+      id: 'SephirotUn Da\'at Tethers',
+      type: 'Tether',
+      netRegex: NetRegexes.tether({ id: '0030', capture: false }),
+      suppressSeconds: 30, // The tethers jump around a lot
+      alertText: (data, _matches, output) => {
+        if (data.force === '3EE')
+          return output.magic!();
+        return output.might!();
+      },
+      outputStrings: {
+        might: {
+          en: 'Get Away, Avoid Puddles + Tethers',
+          de: 'Geh weg, weiche Flächen und Verbindungen aus',
+          cn: '远离, 躲避圈圈 + 连线',
+          ko: '멀리 떨어지고, 장판 + 선 피하기',
+        },
+        magic: {
+          en: 'Go Front; Get Tether',
+          de: 'Geh nach Vorne; Nimm eine Verbindung',
+          cn: '去前面; 接线',
+          ko: '앞으로 가서 선 가로채기',
+        },
+      },
+    },
+    {
+      id: 'SephirotUn Force Against Lose',
+      type: 'LosesEffect',
+      netRegex: NetRegexes.losesEffect({ effectId: ['3ED', '3EE'], capture: false }),
+      run: (data) => delete data.force,
+    },
+    {
+      id: 'SephirotUn Earth Shaker Collect',
+      type: 'HeadMarker',
+      netRegex: NetRegexes.headMarker({ id: '0028' }),
+      run: (data, matches) => {
+        data.shakerTargets = data.shakerTargets ??= [];
+        data.shakerTargets.push(matches.target);
+      },
+    },
+    {
+      id: 'SephirotUn Earth Shaker Call',
+      type: 'HeadMarker',
+      netRegex: NetRegexes.headMarker({ id: '0028', capture: false }),
+      delaySeconds: 0.5,
+      alertText: (data, _matches, output) => {
+        if (data.shakerTargets?.includes(data.me))
+          return output.shakerTarget!();
+        return output.shakerAvoid!();
+      },
+      outputStrings: {
+        shakerTarget: {
+          en: 'Earth Shaker (Max Melee)',
+          de: 'Erdstoß (Max Nahkampf)',
+          cn: '大地摇动 (最远近战距离)',
+          ko: '어스징 (칼끝딜 거리)',
+        },
+        shakerAvoid: {
+          en: 'Avoid Earth Shakers',
+          de: 'Weiche Erdstoß aus',
+          cn: '躲避大地摇动',
+          ko: '어스징 피하기',
+        },
+      },
+    },
+    {
+      id: 'SephirotUn Earth Shaker Cleanup',
+      type: 'HeadMarker',
+      netRegex: NetRegexes.headMarker({ id: '0028', capture: false }),
+      delaySeconds: 5,
+      run: (data) => delete data.shakerTargets,
+    },
+    {
+      id: 'SephirotUn Storm of Words Revelation',
+      type: 'StartsUsing',
+      netRegex: NetRegexes.startsUsing({ id: '7680', source: 'Storm of Words', capture: false }),
+      alarmText: (_data, _matches, output) => output.text!(),
+      outputStrings: {
+        text: {
+          en: 'Kill Storm of Words or die',
+          de: 'Wörtersturm besiegen',
+          fr: 'Tuez Tempête de mots ou mourrez',
+          cn: '击杀言语风暴!',
+          ko: '신언의 폭풍 제거',
+        },
+      },
+    },
+    {
+      id: 'SephirotUn Ascension',
+      type: 'HeadMarker',
+      netRegex: NetRegexes.headMarker({ id: '003E', capture: false }),
+      response: Responses.stackMarker(),
+    },
+  ],
+  timelineReplace: [
+    {
+      'locale': 'de',
+      'replaceSync': {
+        'Coronal Wind': 'Koronalwind',
+        'Sephirot': 'Sephirot',
+        'Storm Of Words': 'Wörtersturm',
+      },
+      'replaceText': {
+        'Tethers': 'Verbindungen',
+        'spread': 'verteilen',
+        'Adds Spawn': 'Adds erscheinen',
+        'Ascension': 'Himmelfahrt',
+        'Chesed': 'Chesed',
+        'Da\'at': 'Da\'at',
+        'Earth Shaker': 'Erdstoß',
+        'Ein Sof': 'En Sof',
+        'Fiendish Rage': 'Dämonischer Zorn',
+        'Fiendish Wail': 'Dämonische Klage',
+        'Force Field': 'Kraftfeld',
+        'Impact of Hod': 'Macht von Hod',
+        'Life Force': 'Lebenskraft',
+        'Malkuth': 'Malkuth',
+        'Pillar of Mercy': 'Pfeiler der Gnade',
+        'Pillar of Severity': 'Pfeiler der Strenge',
+        'Ratzon': 'Ratzon',
+        'Spirit': 'Geist',
+        'Tiferet': 'Tiferet',
+        'Triple Trial': 'Tripel-Triade',
+        'Yesod': 'Yesod',
+      },
+    },
+    {
+      'locale': 'fr',
+      'replaceSync': {
+        'Coronal Wind': 'vent coronaire',
+        'Sephirot': 'Sephirot',
+        'Storm Of Words': 'tempête de mots',
+      },
+      'replaceText': {
+        'Adds Spawn': 'Apparition d\'adds',
+        'Ascension': 'Ascension',
+        'Chesed': 'Chesed',
+        'Chesed Gevurah': 'Chesed Gevurah',
+        'Da\'at Tethers': 'Liens Da\'at',
+        'Da\'at spread': 'Dispersion Da\'at',
+        'Earth Shaker': 'Secousse',
+        'Ein Sof': 'Ein Sof',
+        'Fiendish Rage': 'Colère de Sephirot',
+        'Fiendish Wail': 'Plainte de Sephirot',
+        'Force Field': 'Champ de force',
+        'Impact of Hod': 'Impact Hod',
+        'Life Force': 'Force vitale',
+        'Malkuth': 'Malkuth',
+        'Pillar of Mercy': 'Pilier de la miséricorde',
+        'Pillar of Severity': 'Pilier de la rigueur',
+        'Ratzon': 'Ratzon',
+        'Spirit': 'Esprit',
+        'Tiferet': 'Tiferet',
+        'Triple Trial': 'Triple coup',
+        'Yesod': 'Yesod',
+      },
+    },
+    {
+      'locale': 'ja',
+      'missingTranslations': true,
+      'replaceSync': {
+        'Coronal Wind': 'コロナルウィンド',
+        'Sephirot': 'セフィロト',
+        'Storm Of Words': 'ストーム・オブ・ワード',
+      },
+      'replaceText': {
+        'Adds Spawn': '雑魚',
+        'Ascension': 'アセンション',
+        '(?! )Chesed(?! )': 'ケセド',
+        'Chesed Gevurah': 'ケセド・ゲブラー',
+        'Da\'at': 'ダアト',
+        'Earth Shaker': 'アースシェイカー',
+        'Ein Sof(?! )': 'アイン・ソフ',
+        'Ein Sof Ohr': 'アイン・ソフ・オウル',
+        'Fiendish Rage': '魔神の怒り',
+        'Fiendish Wail': '魔神の嘆き',
+        'Force Field': 'フォースフィールド',
+        'Impact of Hod': 'ホドインパクト',
+        'Life Force': 'ライフフォース',
+        'Malkuth': 'マルクト',
+        'Pillar of Mercy': 'ピラー・オブ・メルシー',
+        'Pillar of Severity': 'ピラー・オブ・セベリティ',
+        'Ratzon': 'ラツォン',
+        '(?<= )spread': '散開',
+        'Spirit': 'スピリット',
+        '(?<= )Tethers': '線',
+        'Tiferet': 'ティファレト',
+        'Triple Trial': 'トリプルブロー',
+        'Yesod': 'イェソドクラッシュ',
+      },
+    },
+    {
+      'locale': 'cn',
+      'replaceSync': {
+        'Coronal Wind': '冠状气流',
+        'Sephirot': '萨菲洛特',
+        'Storm Of Words': '言语风暴',
+      },
+      'replaceText': {
+        'puddle(?:s)?': '圈圈',
+        'spread': '散开',
+        'Tethers': '连线',
+        'Adds Spawn': '小怪出现',
+        'Ascension': '上升气流',
+        'Chesed(?! Gevurah)': '仁慈',
+        'Chesed Gevurah': '仁慈之严酷',
+        'Da\'at': '知识',
+        'Earth Shaker': '大地摇动',
+        'Ein Sof': '无限',
+        'Fiendish Rage': '魔神之怒',
+        'Fiendish Wail': '魔神之叹',
+        'Force Field': '力场',
+        'Impact of Hod': '荣光撞击',
+        'Life Force': '生命领域',
+        'Malkuth': '王国',
+        'Pillar of Mercy': '慈悲之柱',
+        'Pillar of Severity': '严厉之柱',
+        'Ratzon': '意志',
+        'Spirit': '圣灵领域',
+        'Tiferet': '美丽',
+        'Triple Trial': '三重强击',
+        'Yesod': '基盘碎击',
+      },
+    },
+    {
+      'locale': 'ko',
+      'replaceSync': {
+        'Coronal Wind': '관상기류',
+        'Sephirot': '세피로트',
+        'Storm Of Words': '신언의 폭풍',
+      },
+      'replaceText': {
+        'puddle(?:s)?': '장판',
+        'Adds Spawn': '쫄 등장',
+        'Ascension': '승천',
+        'Chesed': '헤세드',
+        'Da\'at': '다아트',
+        'Earth Shaker': '요동치는 대지',
+        'Ein Sof': '아인 소프',
+        'Fiendish Rage': '마신의 분노',
+        'Fiendish Wail': '마신의 탄식',
+        'Force Field': '역장',
+        'Impact of Hod': '호드 대충격',
+        'Life Force': '생명의 권능',
+        'Malkuth': '말쿠트',
+        'Pillar of Mercy': '자비의 기둥',
+        'Pillar of Severity': '준엄의 기둥',
+        'Ratzon': '라촌',
+        'Spirit': '성령의 은사',
+        'Tiferet': '티페레트',
+        'Triple Trial': '삼중 강타',
+        'Yesod': '예소드 붕괴',
+      },
+    },
+  ],
 };
 
 export default triggerSet;

--- a/ui/raidboss/data/06-ew/trial/sephirot-un.ts
+++ b/ui/raidboss/data/06-ew/trial/sephirot-un.ts
@@ -126,7 +126,19 @@ const triggerSet: TriggerSet<Data> = {
       type: 'HeadMarker',
       netRegex: NetRegexes.headMarker({ id: ['0046', '0047'] }),
       condition: Conditions.targetIsYou(),
-      response: Responses.spread(),
+      infoText: (_data, matches, output) => {
+        if (matches.id === '0046')
+          return output.green!();
+        return output.purple!();
+      },
+      outputStrings: {
+        purple: {
+          en: 'Purple spread',
+        },
+        green: {
+          en: 'Green spread',
+        },
+      },
     },
     {
       id: 'SephirotUn Fiendish Rage',

--- a/ui/raidboss/data/06-ew/trial/sephirot-un.txt
+++ b/ui/raidboss/data/06-ew/trial/sephirot-un.txt
@@ -1,7 +1,144 @@
 ### Sephirot Unreal
-#
+# -ic Binah Cochma
+# -ii 7698 769C 769D 76A9 76A0 76A1 76A2 76AE
 
 hideall "--Reset--"
 hideall "--sync--"
 
 0.0 "--Reset--" sync / 21:........:4000000F:/ window 100000 jump 0
+
+0.0 "--sync--" sync /:Engage!/ window 0,1
+2.5 "--sync--" sync / 1[56]:[^:]*:Sephirot:368:/ window 2.5,1
+7.1 "Triple Trial" sync / 1[56]:[^:]*:Sephirot:7693:/ window 7.1,5
+11.2 "Tiferet" sync / 1[56]:[^:]*:Sephirot:7695:/
+17.4 "Tiferet" sync / 1[56]:[^:]*:Sephirot:7695:/
+
+# Phase 1 rotation block, 76.3 seconds
+21.6 "Triple Trial" sync / 1[56]:[^:]*:Sephirot:7693:/
+25.6 "Ein Sof (4 puddles)" sync / 1[56]:[^:]*:Sephirot:769B:/
+29.7 "Tiferet" sync / 1[56]:[^:]*:Sephirot:7695:/
+38.3 "Fiendish Rage 1" sync / 1[56]:[^:]*:Sephirot:769A:/
+42.0 "Fiendish Rage 2" sync / 1[56]:[^:]*:Sephirot:769A:/
+49.2 "Tiferet" sync / 1[56]:[^:]*:Sephirot:7695:/
+53.3 "Tiferet" sync / 1[56]:[^:]*:Sephirot:7695:/
+59.4 "Chesed" sync / 1[56]:[^:]*:Sephirot:7694:/ window 20,20
+61.6 "Triple Trial" sync / 1[56]:[^:]*:Sephirot:7693:/
+67.7 "Ein Sof (1 puddle)" sync / 1[56]:[^:]*:Sephirot:769B:/
+70.9 "Tiferet" sync / 1[56]:[^:]*:Sephirot:7695:/
+81.3 "Ratzon" # sync / 1[56]:[^:]*:Sephirot:7697:/
+85.5 "Tiferet" sync / 1[56]:[^:]*:Sephirot:7695:/
+89.6 "Tiferet" sync / 1[56]:[^:]*:Sephirot:7695:/
+95.7 "Chesed" sync / 1[56]:[^:]*:Sephirot:7694:/ window 20,20
+
+97.9 "Triple Trial" sync / 1[56]:[^:]*:Sephirot:7693:/
+101.9 "Ein Sof" sync / 1[56]:[^:]*:Sephirot:769B:/
+106.0 "Tiferet" sync / 1[56]:[^:]*:Sephirot:7695:/
+114.6 "Fiendish Rage 1" sync / 1[56]:[^:]*:Sephirot:769A:/
+118.3 "Fiendish Rage 2" sync / 1[56]:[^:]*:Sephirot:769A:/
+125.5 "Tiferet" sync / 1[56]:[^:]*:Sephirot:7695:/
+129.6 "Tiferet" sync / 1[56]:[^:]*:Sephirot:7695:/
+135.7 "Chesed" sync / 1[56]:[^:]*:Sephirot:7694:/ window 20,20
+137.9 "Triple Trial" sync / 1[56]:[^:]*:Sephirot:7693:/
+144.0 "Ein Sof" sync / 1[56]:[^:]*:Sephirot:769B:/
+147.2 "Tiferet" sync / 1[56]:[^:]*:Sephirot:7695:/
+157.6 "Ratzon" # sync / 1[56]:[^:]*:Sephirot:7697:/
+161.8 "Tiferet" sync / 1[56]:[^:]*:Sephirot:7695:/
+165.9 "Tiferet" sync / 1[56]:[^:]*:Sephirot:7695:/
+172.0 "Chesed" sync / 1[56]:[^:]*:Sephirot:7694:/ window 20,20 jump 95.7
+
+174.2 "Triple Trial"
+178.2 "Ein Sof"
+182.3 "Tiferet"
+190.9 "Fiendish Rage 1"
+194.6 "Fiendish Rage 2"
+201.8 "Tiferet"
+205.9 "Tiferet"
+
+
+# The intermission doesn't have anything worthwhile to sync.
+# Instead we just go straight for the ultimate cast. (It has no cast time.)
+# However, we don't want timeline triggers firing during the intermission.
+
+500.0 "--sync--" sync / 22:........:Sephirot:........:Sephirot:00/ window 500,0
+1000.0 "Ein Sof Ohr" sync / 1[56]:[^:]*:Sephirot:769E:/ window 1000,5
+
+# Phase 2 rotation block, 197.3 seconds
+1013.2 "Yesod" sync / 1[56]:[^:]*:Sephirot:76AB:/ window 30,30
+1016.2 "Force Field" sync / 1[56]:[^:]*:Sephirot:76B4:/
+1028.4 "Chesed Gevurah" sync / 1[56]:[^:]*:Sephirot:(76A5|76A6):/
+1029.0 "Life Force + Spirit" sync / 1[56]:[^:]*:Sephirot:(76A7|76A8):/
+1034.6 "Fiendish Wail" sync / 1[56]:[^:]*:Sephirot:76A3:/
+1042.7 "Da'at Tethers" duration 5 #sync / 1[56]:[^:]*:Sephirot:769F:/
+1053.3 "Fiendish Wail" sync / 1[56]:[^:]*:Sephirot:76A3:/
+1060.3 "Chesed Gevurah" sync / 1[56]:[^:]*:Sephirot:(76A5|76A6):/
+1060.9 "Life Force + Spirit" sync / 1[56]:[^:]*:Sephirot:(76A7|76A8):/
+1068.4 "Earth Shaker" sync / 1[56]:[^:]*:Sephirot:76AA:/
+1070.1 "Yesod" sync / 1[56]:[^:]*:Sephirot:76AB:/ window 20,20
+1077.7 "Da'at spread" duration 3.2 #sync / 1[56]:[^:]*:Sephirot:76AD:/
+1085.1 "Fiendish Wail" sync / 1[56]:[^:]*:Sephirot:76A3:/
+1092.2 "Chesed Gevurah" sync / 1[56]:[^:]*:Sephirot:(76A5|76A6):/
+1092.9 "Life Force + Spirit" sync / 1[56]:[^:]*:Sephirot:(76A7|76A8):/
+1101.0 "Pillar of Mercy 1" sync / 1[56]:[^:]*:Sephirot:76AD:/
+1101.3 "Yesod" sync / 1[56]:[^:]*:Sephirot:76AB:/ window 20,20
+1106.2 "Pillar of Mercy 2" sync / 1[56]:[^:]*:Sephirot:76AD:/
+1110.1 "Pillar of Mercy 3" sync / 1[56]:[^:]*:Sephirot:76AD:/
+1119.3 "Earth Shaker" sync / 1[56]:[^:]*:Sephirot:76AA:/
+1128.8 "Da'at spread" duration 3.2 #sync / 1[56]:[^:]*:Sephirot:76AD:/
+1129.7 "Yesod" sync / 1[56]:[^:]*:Sephirot:76AB:/ window 20,20
+1136.1 "Fiendish Wail" sync / 1[56]:[^:]*:Sephirot:76A3:/
+1143.2 "Chesed Gevurah" sync / 1[56]:[^:]*:Sephirot:(76A5|76A6):/
+1143.8 "Life Force + Spirit" sync / 1[56]:[^:]*:Sephirot:(76A7|76A8):/
+1149.4 "Malkuth" sync / 1[56]:[^:]*:Sephirot:76AF:/ window 30,30
+1150.5 "Adds Spawn" sync / 03:........:Storm Of Words:/
+1158.7 "Chesed Gevurah" sync / 1[56]:[^:]*:Sephirot:(76A5|76A6):/
+1159.3 "Life Force + Spirit" sync / 1[56]:[^:]*:Sephirot:(76A7|76A8):/
+1164.9 "Fiendish Wail" sync / 1[56]:[^:]*:Sephirot:76A3:/
+1166.5 "Yesod" sync / 1[56]:[^:]*:Sephirot:76AB:/
+1172.2 "Chesed Gevurah" sync / 1[56]:[^:]*:Sephirot:(76A5|76A6):/
+1172.8 "Life Force + Spirit" sync / 1[56]:[^:]*:Sephirot:(76A7|76A8):/
+1185.8 "Yesod" sync / 1[56]:[^:]*:Sephirot:76AB:/
+1188.4 "Chesed Gevurah" sync / 1[56]:[^:]*:Sephirot:(76A5|76A6):/
+1189.0 "Life Force + Spirit" sync / 1[56]:[^:]*:Sephirot:(76A7|76A8):/
+1191.6 "Pillar of Severity" sync / 1[56]:[^:]*:Sephirot:76B2:/
+1195.3 "Impact of Hod" sync / 1[56]:[^:]*:Sephirot:76BA:/
+1199.7 "Ascension" sync / 1[56]:[^:]*:Coronal Wind:76B1:/
+
+1210.4 "Yesod" sync / 1[56]:[^:]*:Sephirot:76AB:/ window 30,30
+1213.5 "Force Field" sync / 1[56]:[^:]*:Sephirot:76B4:/
+1225.7 "Chesed Gevurah" sync / 1[56]:[^:]*:Sephirot:(76A5|76A6):/
+1226.3 "Life Force + Spirit" sync / 1[56]:[^:]*:Sephirot:(76A7|76A8):/
+1231.9 "Fiendish Wail" sync / 1[56]:[^:]*:Sephirot:76A3:/
+1240.0 "Da'at Tethers" duration 5 #sync / 1[56]:[^:]*:Sephirot:769F:/
+1250.6 "Fiendish Wail" sync / 1[56]:[^:]*:Sephirot:76A3:/
+1257.6 "Chesed Gevurah" sync / 1[56]:[^:]*:Sephirot:(76A5|76A6):/
+1258.2 "Life Force + Spirit" sync / 1[56]:[^:]*:Sephirot:(76A7|76A8):/
+1265.7 "Earth Shaker" sync / 1[56]:[^:]*:Sephirot:76AA:/
+1267.4 "Yesod" sync / 1[56]:[^:]*:Sephirot:76AB:/ window 20,20
+1275.0 "Da'at spread" duration 3.2 #sync / 1[56]:[^:]*:Sephirot:76AD:/
+1282.4 "Fiendish Wail" sync / 1[56]:[^:]*:Sephirot:76A3:/
+1289.5 "Chesed Gevurah" sync / 1[56]:[^:]*:Sephirot:(76A5|76A6):/
+1290.2 "Life Force + Spirit" sync / 1[56]:[^:]*:Sephirot:(76A7|76A8):/
+1298.3 "Pillar of Mercy 1" sync / 1[56]:[^:]*:Sephirot:76AD:/
+1298.6 "Yesod" sync / 1[56]:[^:]*:Sephirot:76AB:/ window 20,20
+1303.5 "Pillar of Mercy 2" sync / 1[56]:[^:]*:Sephirot:76AD:/
+1307.4 "Pillar of Mercy 3" sync / 1[56]:[^:]*:Sephirot:76AD:/
+1316.6 "Earth Shaker" sync / 1[56]:[^:]*:Sephirot:76AA:/
+1326.1 "Da'at spread" duration 3.2 #sync / 1[56]:[^:]*:Sephirot:76AD:/
+1327.0 "Yesod" sync / 1[56]:[^:]*:Sephirot:76AB:/ window 20,20
+1333.4 "Fiendish Wail" sync / 1[56]:[^:]*:Sephirot:76A3:/
+1340.5 "Chesed Gevurah" sync / 1[56]:[^:]*:Sephirot:(76A5|76A6):/
+1341.1 "Life Force + Spirit" sync / 1[56]:[^:]*:Sephirot:(76A7|76A8):/
+1346.7 "Malkuth" sync / 1[56]:[^:]*:Sephirot:76AF:/
+1347.8 "Adds Spawn" sync / 03:........:Storm Of Words:/
+1356.0 "Chesed Gevurah" sync / 1[56]:[^:]*:Sephirot:(76A5|76A6):/
+1356.6 "Life Force + Spirit" sync / 1[56]:[^:]*:Sephirot:(76A7|76A8):/
+1362.2 "Fiendish Wail" sync / 1[56]:[^:]*:Sephirot:76A3:/
+1363.8 "Yesod" sync / 1[56]:[^:]*:Sephirot:76AB:/
+1369.5 "Chesed Gevurah" sync / 1[56]:[^:]*:Sephirot:(76A5|76A6):/
+1370.1 "Life Force + Spirit" sync / 1[56]:[^:]*:Sephirot:(76A7|76A8):/
+1382.9 "Yesod" sync / 1[56]:[^:]*:Sephirot:76AB:/
+1385.7 "Chesed Gevurah" sync / 1[56]:[^:]*:Sephirot:(76A5|76A6):/
+1386.3 "Life Force + Spirit" sync / 1[56]:[^:]*:Sephirot:(76A7|76A8):/
+1388.9 "Pillar of Severity" sync / 1[56]:[^:]*:Sephirot:76B2:/
+1392.6 "Impact of Hod" sync / 1[56]:[^:]*:Sephirot:76BA:/
+1397.0 "Pillar of Severity Enrage" sync / 1[56]:[^:]*:Sephirot:76B2:/


### PR DESCRIPTION
Largely a matter of find/replace. I finished up the timeline and triggers prior to an attempt at running it, and everything seemed to work okay. The "change to Earth Shakers" that was mentioned in one of the live letters is simply that the targets are now *also* clearly marked with stretchy tethers that turn purple when extended far enough.

Oopsy is untested, but the IDs all match, so I'm comfortable releasing it as it stands.