### PR TITLE
raidboss: P6N Initial triggers/oopsy

### DIFF
--- a/ui/oopsyraidsy/data/06-ew/raid/p6n.ts
+++ b/ui/oopsyraidsy/data/06-ew/raid/p6n.ts
@@ -6,6 +6,21 @@ export type Data = OopsyData;
 
 const triggerSet: OopsyTriggerSet<Data> = {
   zoneId: ZoneId.AbyssosTheSixthCircle,
+  damageWarn: {
+    'P6N Polyominous Dark IV': '7855', // Radiating AoEs from totems
+    'P6N Choros Ixou Front Back': '7859',
+    'P6N Choros Ixou Sides': '785A',
+    'P6N Reek Havoc': '79ED', // Parasite conal
+    'P6N Pathogenic Cells': '7A14', // Front portion of Strophe Ixou spinny conal
+    'P6N Chelic Vector': '7A15', // Rear portion of Strophe Ixou spinny conal
+  },
+  shareWarn: {
+    'P6N Dark Ashes': '785F', // Orange spread circles
+  },
+  shareFail: {
+    'P6N Synergy 1': '785C', // Off-tank buster
+    'P6N Synergy 2': '785D', // Main tank buster (Square, why??)
+  },
 };
 
 export default triggerSet;

--- a/ui/raidboss/data/06-ew/raid/p6n.ts
+++ b/ui/raidboss/data/06-ew/raid/p6n.ts
@@ -1,13 +1,150 @@
+import Conditions from '../../../../../resources/conditions';
+import NetRegexes from '../../../../../resources/netregexes';
+import Outputs from '../../../../../resources/outputs';
+import { Responses } from '../../../../../resources/responses';
 import ZoneId from '../../../../../resources/zone_id';
 import { RaidbossData } from '../../../../../types/data';
 import { TriggerSet } from '../../../../../types/trigger';
 
-export type Data = RaidbossData;
+// TODO: Find some data, any data, in the network logs that will let us call Polyominous Dark.
+// and Transmission.
+
+export interface Data extends RaidbossData {
+  busterTargets: string[];
+}
 
 const triggerSet: TriggerSet<Data> = {
   zoneId: ZoneId.AbyssosTheSixthCircle,
   timelineFile: 'p6n.txt',
-  triggers: [],
+  initData: () => {
+    return {
+      busterTargets: [],
+    };
+  },
+  triggers: [
+    {
+      id: 'P6N Hemitheos Dark IV',
+      type: 'StartsUsing',
+      netRegex: NetRegexes.startsUsing({ id: '784E', source: 'Hegemone', capture: false }),
+      response: Responses.aoe(),
+    },
+    {
+      id: 'P6N Choros Ixou Sides',
+      type: 'StartsUsing',
+      netRegex: NetRegexes.startsUsing({ id: '7858', source: 'Hegemone', capture: false }),
+      response: Responses.goFrontBack(),
+    },
+    {
+      id: 'P6N Choros Ixou Front Back',
+      type: 'StartsUsing',
+      netRegex: NetRegexes.startsUsing({ id: '7857', source: 'Hegemone', capture: false }),
+      response: Responses.goSides(),
+    },
+    {
+      id: 'P6N Synergy Collect',
+      type: 'HeadMarker',
+      netRegex: NetRegexes.headMarker({ id: '0157' }),
+      run: (data, matches) => data.busterTargets.push(matches.target),
+    },
+    {
+      id: 'P6N Synergy Call',
+      type: 'HeadMarker',
+      netRegex: NetRegexes.headMarker({ id: '0157', capture: false }),
+      delaySeconds: 0.3,
+      suppressSeconds: 5,
+      alertText: (data, _matches, output) => {
+        if (data.busterTargets.includes(data.me))
+          return output.markerYou!();
+        return output.avoid!();
+      },
+      outputStrings: {
+        markerYou: Outputs.tankCleave,
+        avoid: Outputs.avoidTankCleave,
+      },
+    },
+    {
+      id: 'P6N Synergy Cleanup',
+      type: 'HeadMarker',
+      netRegex: NetRegexes.headMarker({ id: '0157', capture: false }),
+      delaySeconds: 5,
+      run: (data) => data.busterTargets = [],
+    },
+    {
+      id: 'P6N Glossomorph Initial',
+      type: 'GainsEffect',
+      netRegex: NetRegexes.gainsEffect({ effectId: 'CF2' }),
+      condition: Conditions.targetIsYou(),
+      infoText: (_data, matches, output) => {
+        if (parseFloat(matches.duration) > 15)
+          return output.second!();
+        return output.first!();
+      },
+      outputStrings: {
+        first: {
+          en: 'Short parasite on YOU',
+        },
+        second: {
+          en: 'Long parasite on YOU',
+        },
+      },
+    },
+    {
+      id: 'P6N Glossomorph Call',
+      type: 'GainsEffect',
+      netRegex: NetRegexes.gainsEffect({ effectId: 'CF2' }),
+      condition: Conditions.targetIsYou(),
+      delaySeconds: (_data, matches) => parseFloat(matches.duration) - 6,
+      alertText: (_data, _matches, output) => output.text!(),
+      outputStrings: {
+        text: {
+          en: 'Face outside: Parasite',
+        },
+      },
+    },
+    {
+      // 00A7 is the orange clockwise indicator. 00A8 is the blue counterclockwise one.
+      id: 'P6N Strophe Ixou',
+      type: 'HeadMarker',
+      netRegex: NetRegexes.headMarker({ id: ['00A7', '00A8'] }),
+      infoText: (_data, matches, output) => matches.id === '00A7' ? output.left!() : output.right!(),
+      outputStrings: {
+        left: {
+          en: 'Rotate left',
+          de: 'Nach links rotieren',
+          fr: 'Tournez vers la gauche',
+          ja: '左回転',
+          cn: '向左转',
+          ko: '왼쪽으로 회전',
+        },
+        right: {
+          en: 'Rotate right',
+          de: 'Nach rechts rotieren',
+          fr: 'Tournez vers la droite',
+          ja: '右回転',
+          cn: '向右转',
+          ko: '오른쪽으로 회전',
+        },
+      },
+    },
+    {
+      id: 'P6N Dark Ashes',
+      type: 'HeadMarker',
+      netRegex: NetRegexes.headMarker({ id: '0065' }),
+      condition: Conditions.targetIsYou(),
+      response: Responses.spread(),
+    },
+    {
+      id: 'P6N Aetherial Exchange',
+      type: 'Ability',
+      netRegex: NetRegexes.ability({ id: '784D', source: 'Hegemone', capture: false }),
+      alertText: (_data, _matches, output) => output.text!(),
+      outputStrings: {
+        text: {
+          en: 'Be opposite tethered safespot',
+        },
+      },
+    },
+  ],
 };
 
 export default triggerSet;


### PR DESCRIPTION
The timeline for this encounter has ended up being significantly more obstinate than I would like, so quisquous graciously agreed to take over on that.

I couldn't find *anything* in the network log relating to how Polyominous Dark works. (The radiating AoEs from the totems.) All of the totems have identical NPC models, and the cast ID is the same for all of them. There are no status effects on any of them. All of them have a facing of 0.0 from beginning to end of the cast, whether or not they hit a target.