### PR TITLE
raidboss: p5s draft timeline

### DIFF
--- a/ui/raidboss/data/06-ew/raid/p5s.txt
+++ b/ui/raidboss/data/06-ew/raid/p5s.txt
@@ -1,7 +1,287 @@
 ### P5N: Abyssos: The Fifth Circle (Savage)
 #
+# -ii 76F3 76FE 771D 784A 7700 7701 76F8 76F9 76FB 76FC 7710 7714 7715 79E2 770A
 
 hideall "--Reset--"
 hideall "--sync--"
 
 0.0 "--Reset--" sync / 21:........:4000000F:/ window 100000 jump 0
+
+0.0 "--sync--" sync /Engage!/ window 0,1
+
+9.7 "--sync--" sync / 14:[^:]*:Proto-Carbuncle:7720:/ window 11,10
+15.4 "Sonic Howl" sync / 1[56]:[^:]*:Proto-Carbuncle:7720:/
+22.6 "Ruby Glow" sync / 1[56]:[^:]*:Proto-Carbuncle:76F4:/
+29.8 "Topaz Stones" sync / 1[56]:[^:]*:Proto-Carbuncle:76FD:/
+43.3 "Topaz Ray" sync / 1[56]:[^:]*:Proto-Carbuncle:79FE:/
+43.8 "Ruby Reflection" #sync / 1[56]:[^:]*:Proto-Carbuncle:7701:/
+44.1 "Ruby Reflection" #sync / 1[56]:[^:]*:Proto-Carbuncle:7701:/
+44.4 "Ruby Reflection" #sync / 1[56]:[^:]*:Proto-Carbuncle:7701:/
+57.7 "Venomous Mass" sync / 1[56]:[^:]*:Proto-Carbuncle:771E:/
+64.3 "Toxic Crunch" sync / 1[56]:[^:]*:Proto-Carbuncle:771F:/
+95.3 "Venomous Mass" sync / 1[56]:[^:]*:Proto-Carbuncle:771E:/
+101.9 "Toxic Crunch" sync / 1[56]:[^:]*:Proto-Carbuncle:771F:/
+116.0 "Ruby Glow" sync / 1[56]:[^:]*:Proto-Carbuncle:76F4:/
+123.2 "Topaz Stones" sync / 1[56]:[^:]*:Proto-Carbuncle:76FD:/
+126.4 "--sync--" sync / 1[56]:[^:]*:Proto-Carbuncle:76F5:/
+133.7 "Double Rush 1" sync / 1[56]:[^:]*:Proto-Carbuncle:771B:/
+135.8 "Double Rush 2" sync / 1[56]:[^:]*:Proto-Carbuncle:771C:/
+136.7 "Topaz Ray" sync / 1[56]:[^:]*:Proto-Carbuncle:79FE:/
+137.2 "Ruby Reflection" #sync / 1[56]:[^:]*:Proto-Carbuncle:76F9:/
+137.5 "Ruby Reflection" #sync / 1[56]:[^:]*:Proto-Carbuncle:76F9:/
+137.8 "Ruby Reflection" #sync / 1[56]:[^:]*:Proto-Carbuncle:76F9:/
+137.9 "--sync--" sync / 1[56]:[^:]*:Proto-Carbuncle:76F5:/
+147.0 "Sonic Howl" sync / 1[56]:[^:]*:Proto-Carbuncle:7720:/
+160.2 "Ruby Glow" sync / 1[56]:[^:]*:Proto-Carbuncle:76F4:/
+166.4 "Topaz Cluster" sync / 1[56]:[^:]*:Proto-Carbuncle:7702:/
+166.4 "--sync--" sync / 1[56]:[^:]*:Proto-Carbuncle:7703:/
+168.9 "--sync--" sync / 1[56]:[^:]*:Proto-Carbuncle:7704:/
+171.4 "--sync--" sync / 1[56]:[^:]*:Proto-Carbuncle:7705:/
+173.9 "--sync--" sync / 1[56]:[^:]*:Proto-Carbuncle:7706:/
+176.9 "Topaz Ray" sync / 1[56]:[^:]*:Proto-Carbuncle:79FF:/
+177.4 "Ruby Reflection" #sync / 1[56]:[^:]*:Proto-Carbuncle:7701:/
+177.7 "Ruby Reflection" #sync / 1[56]:[^:]*:Proto-Carbuncle:7701:/
+178.0 "Ruby Reflection" #sync / 1[56]:[^:]*:Proto-Carbuncle:7701:/
+179.3 "Topaz Ray" sync / 1[56]:[^:]*:Proto-Carbuncle:79FF:/
+179.8 "Ruby Reflection" #sync / 1[56]:[^:]*:Proto-Carbuncle:7701:/
+180.1 "Ruby Reflection" #sync / 1[56]:[^:]*:Proto-Carbuncle:7701:/
+180.4 "Ruby Reflection" #sync / 1[56]:[^:]*:Proto-Carbuncle:7701:/
+181.7 "Topaz Ray" sync / 1[56]:[^:]*:Proto-Carbuncle:79FF:/
+182.2 "Ruby Reflection" #sync / 1[56]:[^:]*:Proto-Carbuncle:7701:/
+182.5 "Ruby Reflection" #sync / 1[56]:[^:]*:Proto-Carbuncle:7701:/
+182.8 "Ruby Reflection" #sync / 1[56]:[^:]*:Proto-Carbuncle:7701:/
+184.2 "Topaz Ray" sync / 1[56]:[^:]*:Proto-Carbuncle:79FF:/
+184.7 "Ruby Reflection" #sync / 1[56]:[^:]*:Proto-Carbuncle:7701:/
+185.0 "Ruby Reflection" #sync / 1[56]:[^:]*:Proto-Carbuncle:7701:/
+185.3 "Ruby Reflection" #sync / 1[56]:[^:]*:Proto-Carbuncle:7701:/
+194.1 "Venomous Mass" sync / 1[56]:[^:]*:Proto-Carbuncle:771E:/
+200.7 "Toxic Crunch" sync / 1[56]:[^:]*:Proto-Carbuncle:771F:/
+
+# Venom Squall/Venom Surge Path 1
+207.1 "--sync--" sync / 14:[^:]*:Proto-Carbuncle:7716:/ jump 307.1
+207.1 "--sync--" sync / 14:[^:]*:Proto-Carbuncle:7717:/ jump 407.1
+211.8 "Venom Squall/Venom Surge?"
+215.6 "Venom Rain/Pool?"
+221.6 "Venom Drops" #sync / 1[56]:[^:]*:Proto-Carbuncle:7719:/
+224.6 "Venom Pool/Rain?"
+232.9 "Claw to Tail/Tail to Claw?"
+
+# Squall: Spread => Bait => Healer Groups
+307.1 "--sync--" #sync / 14:[^:]*:Proto-Carbuncle:7716:/
+311.8 "Venom Squall" sync / 1[56]:[^:]*:Proto-Carbuncle:7716:/
+315.6 "Venom Rain" sync / 1[56]:[^:]*:Proto-Carbuncle:7718:/
+321.6 "Venom Drops" sync / 1[56]:[^:]*:Proto-Carbuncle:7719:/
+324.6 "Venom Pool" sync / 1[56]:[^:]*:Proto-Carbuncle:771A:/
+327.7 "--sync--" sync / 14:[^:]*:Proto-Carbuncle:770E:/ jump 527.7
+327.7 "--sync--" sync / 14:[^:]*:Proto-Carbuncle:7712:/ jump 627.7
+332.9 "Claw to Tail/Tail to Claw?"
+
+# Surge: Healer Groups => Bait => Spread
+407.1 "--sync--" #sync / 14:[^:]*:Proto-Carbuncle:7717:/
+411.8 "Venom Surge" sync / 1[56]:[^:]*:Proto-Carbuncle:7717:/
+415.6 "Venom Pool" sync / 1[56]:[^:]*:Proto-Carbuncle:771A:/
+421.6 "Venom Drops" sync / 1[56]:[^:]*:Proto-Carbuncle:7719:/
+424.6 "Venom Rain" sync / 1[56]:[^:]*:Proto-Carbuncle:7718:/
+427.7 "--sync--" sync / 14:[^:]*:Proto-Carbuncle:770E:/ jump 527.7
+427.7 "--sync--" sync / 14:[^:]*:Proto-Carbuncle:7712:/ jump 627.7
+432.9 "Claw to Tail/Tail to Claw?"
+
+# Claw to Tail/Tail to Claw 1
+# Claw to Tail
+527.7 "--sync--" #sync / 14:[^:]*:Proto-Carbuncle:770E:/
+532.9 "Claw to Tail" sync / 1[56]:[^:]*:Proto-Carbuncle:770E:/
+532.9 "Raging Claw" sync / 1[56]:[^:]*:Proto-Carbuncle:770F:/ duration 2.6
+537.2 "Raging Tail" sync / 1[56]:[^:]*:Proto-Carbuncle:7711:/ jump 637.2
+557.8 "--untargetable--"
+557.8 "Starving Stampede 1" #sync / 1[56]:[^:]*:Proto-Carbuncle:7A03:/
+559.1 "Starving Stampede 2" #sync / 1[56]:[^:]*:Proto-Carbuncle:7A03:/
+560.3 "Starving Stampede 3" #sync / 1[56]:[^:]*:Proto-Carbuncle:7A03:/
+561.5 "Starving Stampede 4" #sync / 1[56]:[^:]*:Proto-Carbuncle:7A03:/
+562.3 "--reverse--"
+562.7 "Starving Stampede 1" #sync / 1[56]:[^:]*:Proto-Carbuncle:7A03:/
+564.0 "Starving Stampede 2" #sync / 1[56]:[^:]*:Proto-Carbuncle:7A03:/
+565.3 "Starving Stampede 3" #sync / 1[56]:[^:]*:Proto-Carbuncle:7A03:/
+566.6 "Starving Stampede 4" #sync / 1[56]:[^:]*:Proto-Carbuncle:7A03:/
+566.6 "--targetable--"
+
+# Tail to Claw
+627.7 "--sync--" #sync / 14:[^:]*:Proto-Carbuncle:7712:/
+632.9 "Tail to Claw" sync / 1[56]:[^:]*:Proto-Carbuncle:7712:/
+633.4 "Raging Tail" sync / 1[56]:[^:]*:Proto-Carbuncle:7A0C:/
+635.3 "Raging Claw" sync / 1[56]:[^:]*:Proto-Carbuncle:7713:/ duration 2.6
+
+639.6 "--sync--" sync / 1[56]:[^:]*:Proto-Carbuncle:76F5:/
+645.8 "--sync--" sync / 1[56]:[^:]*:Proto-Carbuncle:7708:/
+657.8 "--untargetable--"
+657.8 "Starving Stampede 1" sync / 1[56]:[^:]*:Proto-Carbuncle:7A03:/
+659.1 "Starving Stampede 2" sync / 1[56]:[^:]*:Proto-Carbuncle:7A03:/
+660.3 "Starving Stampede 3" sync / 1[56]:[^:]*:Proto-Carbuncle:7A03:/
+661.5 "Starving Stampede 4" sync / 1[56]:[^:]*:Proto-Carbuncle:7A03:/
+662.3 "--reverse--"
+662.7 "Starving Stampede 1" sync / 1[56]:[^:]*:Proto-Carbuncle:7A03:/
+664.0 "Starving Stampede 2" sync / 1[56]:[^:]*:Proto-Carbuncle:7A03:/
+665.3 "Starving Stampede 3" sync / 1[56]:[^:]*:Proto-Carbuncle:7A03:/
+666.6 "Starving Stampede 4" sync / 1[56]:[^:]*:Proto-Carbuncle:7A03:/
+666.6 "--targetable--"
+667.9 "Devour" sync / 1[56]:[^:]*:Proto-Carbuncle:7725:/
+671.1 "Venom" sync / 1[56]:[^:]*:Proto-Carbuncle:770C:/
+675.2 "Spit" sync / 1[56]:[^:]*:Proto-Carbuncle:7727:/
+677.7 "Impact" sync / 1[56]:[^:]*:Proto-Carbuncle:7A1F:/
+677.8 "Devour" sync / 1[56]:[^:]*:Proto-Carbuncle:7728:/
+679.4 "Devour" sync / 1[56]:[^:]*:Proto-Carbuncle:7849:/
+682.5 "--sync--" sync / 1[56]:[^:]*:Proto-Carbuncle:76F5:/
+692.7 "Sonic Howl" sync / 1[56]:[^:]*:Proto-Carbuncle:7720:/
+699.8 "Ruby Glow" sync / 1[56]:[^:]*:Proto-Carbuncle:76F4:/
+705.9 "Topaz Stones" sync / 1[56]:[^:]*:Proto-Carbuncle:76FD:/
+716.9 "Venom Pool (Topaz)" sync / 1[56]:[^:]*:Proto-Carbuncle:79E3:/
+718.2 "--sync--" sync / 1[56]:[^:]*:Proto-Carbuncle:76F5:/
+719.4 "Topaz Ray" sync / 1[56]:[^:]*:Proto-Carbuncle:79FE:/
+719.9 "Ruby Reflection" #sync / 1[56]:[^:]*:Proto-Carbuncle:76F9:/
+720.2 "Ruby Reflection" #sync / 1[56]:[^:]*:Proto-Carbuncle:76F9:/
+720.5 "Ruby Reflection" #sync / 1[56]:[^:]*:Proto-Carbuncle:76F9:/
+725.0 "Raging Claw" sync / 1[56]:[^:]*:Proto-Carbuncle:76FA:/ duration 2.6
+740.2 "Venomous Mass" sync / 1[56]:[^:]*:Proto-Carbuncle:771E:/
+746.7 "Toxic Crunch" sync / 1[56]:[^:]*:Proto-Carbuncle:771F:/
+759.9 "Ruby Glow" sync / 1[56]:[^:]*:Proto-Carbuncle:76F4:/
+767.0 "Topaz Stones" sync / 1[56]:[^:]*:Proto-Carbuncle:76FD:/
+
+# Venom Squall/Venom Surge Path 2
+776.4 "--sync--" sync / 14:[^:]*:Proto-Carbuncle:7716:/ jump 876.4
+776.4 "--sync--" sync / 14:[^:]*:Proto-Carbuncle:7717:/ jump 967.4
+780.6 "Topaz Ray" #sync / 1[56]:[^:]*:Proto-Carbuncle:79FE:/
+781.1 "Ruby Reflection" #sync / 1[56]:[^:]*:Proto-Carbuncle:7701:/
+781.1 "Venom Squall/Venom Surge?"
+781.4 "Ruby Reflection" #sync / 1[56]:[^:]*:Proto-Carbuncle:7701:/
+781.7 "Ruby Reflection" #sync / 1[56]:[^:]*:Proto-Carbuncle:7701:/
+785.0 "Venom Rain/Venom Pool?"
+791.0 "Venom Drops" #sync / 1[56]:[^:]*:Proto-Carbuncle:7719:/
+794.0 "Venom Pool/Venom Rain?"
+
+# Squall: Spread => Bait => Healer Groups
+876.4 "--sync--" #sync / 14:[^:]*:Proto-Carbuncle:7716:/
+880.6 "Topaz Ray" sync / 1[56]:[^:]*:Proto-Carbuncle:79FE:/
+881.1 "Ruby Reflection" #sync / 1[56]:[^:]*:Proto-Carbuncle:7701:/
+881.1 "Venom Squall" sync / 1[56]:[^:]*:Proto-Carbuncle:7716:/
+881.4 "Ruby Reflection" #sync / 1[56]:[^:]*:Proto-Carbuncle:7701:/
+881.7 "Ruby Reflection" #sync / 1[56]:[^:]*:Proto-Carbuncle:7701:/
+885.0 "Venom Rain" sync / 1[56]:[^:]*:Proto-Carbuncle:7718:/
+891.0 "Venom Drops" sync / 1[56]:[^:]*:Proto-Carbuncle:7719:/
+894.0 "Venom Pool" sync / 1[56]:[^:]*:Proto-Carbuncle:771A:/
+906.8 "--sync--" sync / 14:[^:]*:Proto-Carbuncle:770E:/ jump 1106.8
+906.8 "--sync--" sync / 14:[^:]*:Proto-Carbuncle:7712:/ jump 1206.8
+912.0 "Claw to Tail/Tail to Claw?"
+925.6 "Venomous Mass" #sync / 1[56]:[^:]*:Proto-Carbuncle:771E:/
+932.1 "Toxic Crunch" #sync / 1[56]:[^:]*:Proto-Carbuncle:771F:/
+943.2 "Sonic Howl" #sync / 1[56]:[^:]*:Proto-Carbuncle:7720:/
+
+# Surge: Healer Groups => Bait => Spread
+967.4 "--sync--" #sync / 14:[^:]*:Proto-Carbuncle:7717:/
+980.6 "Topaz Ray" sync / 1[56]:[^:]*:Proto-Carbuncle:79FE:/
+981.1 "Ruby Reflection" #sync / 1[56]:[^:]*:Proto-Carbuncle:7701:/
+981.1 "Venom Surge" sync / 1[56]:[^:]*:Proto-Carbuncle:7717:/
+985.0 "Venom Pool" sync / 1[56]:[^:]*:Proto-Carbuncle:771A:/
+991.0 "Venom Drops" sync / 1[56]:[^:]*:Proto-Carbuncle:7719:/
+994.0 "Venom Rain" sync / 1[56]:[^:]*:Proto-Carbuncle:7718:/
+1006.8 "--sync--" sync / 14:[^:]*:Proto-Carbuncle:770E:/ jump 1106.8
+1006.8 "--sync--" sync / 14:[^:]*:Proto-Carbuncle:7712:/ jump 1206.6
+1012.0 "Claw to Tail/Tail to Claw?"
+1025.6 "Venomous Mass" #sync / 1[56]:[^:]*:Proto-Carbuncle:771E:/
+1032.1 "Toxic Crunch" #sync / 1[56]:[^:]*:Proto-Carbuncle:771F:/
+1043.2 "Sonic Howl" #sync / 1[56]:[^:]*:Proto-Carbuncle:7720:/
+
+# Claw to Tail/Tail to Claw 2
+# Claw to Tail
+1106.8 "--sync--" #sync / 14:[^:]*:Proto-Carbuncle:770E:/ jump 1106.8
+1112.0 "Claw to Tail" sync / 1[56]:[^:]*:Proto-Carbuncle:770E:/
+1112.0 "Raging Claw" sync / 1[56]:[^:]*:Proto-Carbuncle:770F:/ duration 2.6
+1116.3 "Raging Tail" sync / 1[56]:[^:]*:Proto-Carbuncle:7711:/ jump 1216.3
+1125.6 "Venomous Mass" #sync / 1[56]:[^:]*:Proto-Carbuncle:771E:/
+1132.1 "Toxic Crunch" #sync / 1[56]:[^:]*:Proto-Carbuncle:771F:/
+1143.2 "Sonic Howl" #sync / 1[56]:[^:]*:Proto-Carbuncle:7720:/
+
+# Tail to Claw
+1206.8 "--sync--" #sync / 14:[^:]*:Proto-Carbuncle:7712:/ jump 1206.6
+1212.0 "Tail to Claw" sync / 1[56]:[^:]*:Proto-Carbuncle:7712:/
+1212.5 "Raging Tail" sync / 1[56]:[^:]*:Proto-Carbuncle:7A0C:/
+1214.4 "Raging Claw" sync / 1[56]:[^:]*:Proto-Carbuncle:7713:/ duration 2.6
+
+1225.6 "Venomous Mass" sync / 1[56]:[^:]*:Proto-Carbuncle:771E:/
+1232.1 "Toxic Crunch" sync / 1[56]:[^:]*:Proto-Carbuncle:771F:/
+1243.2 "Sonic Howl" sync / 1[56]:[^:]*:Proto-Carbuncle:7720:/
+1250.4 "Ruby Glow" sync / 1[56]:[^:]*:Proto-Carbuncle:76F4:/
+1256.5 "Topaz Stones" sync / 1[56]:[^:]*:Proto-Carbuncle:76FD:/
+1267.4 "Venom Pool (Topaz)" sync / 1[56]:[^:]*:Proto-Carbuncle:79E3:/
+1270.0 "Topaz Ray" sync / 1[56]:[^:]*:Proto-Carbuncle:79FE:/
+1270.5 "Ruby Reflection" #sync / 1[56]:[^:]*:Proto-Carbuncle:7701:/
+1270.8 "Ruby Reflection" #sync / 1[56]:[^:]*:Proto-Carbuncle:7701:/
+1271.1 "Ruby Reflection" #sync / 1[56]:[^:]*:Proto-Carbuncle:7701:/
+1273.2 "--sync--" sync / 1[56]:[^:]*:Proto-Carbuncle:76F5:/
+1280.4 "Double Rush 1" sync / 1[56]:[^:]*:Proto-Carbuncle:771B:/
+1282.5 "Double Rush 2" sync / 1[56]:[^:]*:Proto-Carbuncle:771C:/
+1284.6 "--sync--" sync / 1[56]:[^:]*:Proto-Carbuncle:76F5:/
+1291.5 "Venomous Mass" sync / 1[56]:[^:]*:Proto-Carbuncle:771E:/
+1298.1 "Toxic Crunch" sync / 1[56]:[^:]*:Proto-Carbuncle:771F:/
+1311.2 "Sonic Howl" sync / 1[56]:[^:]*:Proto-Carbuncle:7720:/
+
+# Venom Squall/Venom Surge Path 3
+1314.7 "--sync--" sync / 14:[^:]*:Proto-Carbuncle:7716:/ jump 1414.7
+1314.7 "--sync--" sync / 14:[^:]*:Proto-Carbuncle:7717:/ jump 1514.7
+1319.4 "Venom Squall/Venom Surge?"
+1323.2 "Venom Rain/Pool?"
+1329.2 "Venom Drops" #sync / 1[56]:[^:]*:Proto-Carbuncle:7719:/
+1332.2 "Venom Pool/Rain?"
+1338.6 "Claw to Tail/Tail to Claw?"
+1353.1 "Venomous Mass" #sync / 1[56]:[^:]*:Proto-Carbuncle:771E:/
+1359.7 "Toxic Crunch" #sync / 1[56]:[^:]*:Proto-Carbuncle:771F:/
+
+# Squall: Spread => Bait => Healer Groups
+1414.7 "--sync--" #sync / 14:[^:]*:Proto-Carbuncle:7716:/
+1419.4 "Venom Squall" sync / 1[56]:[^:]*:Proto-Carbuncle:7716:/
+1423.2 "Venom Rain" sync / 1[56]:[^:]*:Proto-Carbuncle:7718:/
+1429.2 "Venom Drops" sync / 1[56]:[^:]*:Proto-Carbuncle:7719:/
+1432.2 "Venom Pool" sync / 1[56]:[^:]*:Proto-Carbuncle:771A:/
+1438.6 "Claw to Tail/Tail to Claw?"
+1453.1 "Venomous Mass" #sync / 1[56]:[^:]*:Proto-Carbuncle:771E:/
+1459.7 "Toxic Crunch" #sync / 1[56]:[^:]*:Proto-Carbuncle:771F:/
+1473.8 "Sonic Shatter" #sync / 1[56]:[^:]*:Proto-Carbuncle:7721:/
+
+# Surge: Healer Groups => Bait => Spread
+1514.7 "--sync--" #sync / 14:[^:]*:Proto-Carbuncle:7717:/
+1519.4 "Venom Surge" sync / 1[56]:[^:]*:Proto-Carbuncle:7717:/
+1523.2 "Venom Pool" sync / 1[56]:[^:]*:Proto-Carbuncle:771A:/
+1529.2 "Venom Drops" sync / 1[56]:[^:]*:Proto-Carbuncle:7719:/
+1532.2 "Venom Rain" sync / 1[56]:[^:]*:Proto-Carbuncle:7718:/
+1533.4 "--sync--" sync / 14:[^:]*:Proto-Carbuncle:770E:/ jump 1633.4
+1533.4 "--sync--" sync / 14:[^:]*:Proto-Carbuncle:7712:/ jump 1733.4
+1538.6 "Claw to Tail/Tail to Claw?"
+1553.1 "Venomous Mass" #sync / 1[56]:[^:]*:Proto-Carbuncle:771E:/
+1559.7 "Toxic Crunch" #sync / 1[56]:[^:]*:Proto-Carbuncle:771F:/
+1573.8 "Sonic Shatter" #sync / 1[56]:[^:]*:Proto-Carbuncle:7721:/
+
+# Claw to Tail/Tail to Claw 3
+# Claw to Tail
+1633.4 "--sync--" #sync / 14:[^:]*:Proto-Carbuncle:770E:/
+1638.6 "Claw to Tail" sync / 1[56]:[^:]*:Proto-Carbuncle:770E:/
+1638.6 "Raging Claw" sync / 1[56]:[^:]*:Proto-Carbuncle:770F:/ duration 2.6
+1642.9 "Raging Tail" sync / 1[56]:[^:]*:Proto-Carbuncle:7711:/ jump 1742.9
+1653.1 "Venomous Mass" #sync / 1[56]:[^:]*:Proto-Carbuncle:771E:/
+1659.7 "Toxic Crunch" #sync / 1[56]:[^:]*:Proto-Carbuncle:771F:/
+1673.8 "Sonic Shatter" #sync / 1[56]:[^:]*:Proto-Carbuncle:7721:/
+
+# Tail to Claw
+1733.4 "--sync--" #sync / 14:[^:]*:Proto-Carbuncle:7712:/
+1738.6 "Tail to Claw" sync / 1[56]:[^:]*:Proto-Carbuncle:7712:/
+1739.1 "Raging Tail" sync / 1[56]:[^:]*:Proto-Carbuncle:7A0C:/
+1741.0 "Raging Claw" sync / 1[56]:[^:]*:Proto-Carbuncle:7713:/ duration 2.6
+
+1753.1 "Venomous Mass" sync / 1[56]:[^:]*:Proto-Carbuncle:771E:/
+1759.7 "Toxic Crunch" sync / 1[56]:[^:]*:Proto-Carbuncle:771F:/
+1773.8 "Sonic Shatter" sync / 1[56]:[^:]*:Proto-Carbuncle:7721:/
+1777.0 "Sonic Shatter" sync / 1[56]:[^:]*:Proto-Carbuncle:7722:/
+1780.1 "Sonic Shatter" sync / 1[56]:[^:]*:Proto-Carbuncle:7722:/
+1783.2 "Sonic Shatter" sync / 1[56]:[^:]*:Proto-Carbuncle:7722:/
+1786.3 "Sonic Shatter" sync / 1[56]:[^:]*:Proto-Carbuncle:7722:/
+1791.4 "--sync--" sync / 1[56]:[^:]*:Proto-Carbuncle:7708:/
+
+1801.8 "--sync--" sync / 14:[^:]*:Proto-Carbuncle:7723:/ window 650,10
+1806.5 "Acidic Slaver (enrage)" sync / 1[56]:[^:]*:Proto-Carbuncle:7723:/


### PR DESCRIPTION
I don't have a network log for this to be able to test it. Based on fflogs reports.

Targetable/untargetable lines need to be adjusted. Enumerations I don't think are accounted for in the timeline.