### PR TITLE
raidboss: p5s add Ruby Glow aoe callout

### DIFF
--- a/ui/raidboss/data/06-ew/raid/p5s.ts
+++ b/ui/raidboss/data/06-ew/raid/p5s.ts
@@ -41,6 +41,13 @@ const triggerSet: TriggerSet<Data> = {
       response: Responses.aoe(),
     },
     {
+      id: 'P5S Ruby Glow',
+      type: 'StartsUsing',
+      netRegex: NetRegexes.startsUsing({ id: '76F[34]', source: 'Proto-Carbuncle', capture: false }),
+      suppressSeconds: 1,
+      response: Responses.aoe(),
+    },
+    {
       id: 'P5S Venomous Mass',
       type: 'StartsUsing',
       netRegex: NetRegexes.startsUsing({ id: '771D', source: 'Proto-Carbuncle', capture: false }),

--- a/ui/raidboss/data/06-ew/raid/p5s.ts
+++ b/ui/raidboss/data/06-ew/raid/p5s.ts
@@ -43,8 +43,7 @@ const triggerSet: TriggerSet<Data> = {
     {
       id: 'P5S Ruby Glow',
       type: 'StartsUsing',
-      netRegex: NetRegexes.startsUsing({ id: '76F[34]', source: 'Proto-Carbuncle', capture: false }),
-      suppressSeconds: 1,
+      netRegex: NetRegexes.startsUsing({ id: '76F3', source: 'Proto-Carbuncle', capture: false }),
       response: Responses.aoe(),
     },
     {


### PR DESCRIPTION
Captures both spellids similar to the normal mode trigger.