### PR TITLE
raidboss: p5s raging claw move use 7710

### DIFF
--- a/ui/raidboss/data/06-ew/raid/p5s.ts
+++ b/ui/raidboss/data/06-ew/raid/p5s.ts
@@ -137,7 +137,7 @@ const triggerSet: TriggerSet<Data> = {
     {
       id: 'P5S Raging Claw Move',
       type: 'Ability',
-      netRegex: NetRegexes.ability({ id: '770F', source: 'Proto-Carbuncle', capture: false }),
+      netRegex: NetRegexes.ability({ id: '7710', source: 'Proto-Carbuncle', capture: false }),
       condition: (data) => {
         data.clawCount = data.clawCount + 1;
         return data.clawCount === 6;


### PR DESCRIPTION
I had used the wrong spellid previously. 7710 is the one to count.