### PR TITLE
raidboss: p6s Pathogenic Cells headmarkers

### DIFF
--- a/ui/raidboss/data/06-ew/raid/p6s.ts
+++ b/ui/raidboss/data/06-ew/raid/p6s.ts
@@ -5,7 +5,6 @@ import { RaidbossData } from '../../../../../types/data';
 import { NetMatches } from '../../../../../types/net_matches';
 import { TriggerSet } from '../../../../../types/trigger';
 
-
 export interface Data extends RaidbossData {
   decOffset?: number;
   pathogenicCellsNumber?: number;

--- a/ui/raidboss/data/06-ew/raid/p6s.ts
+++ b/ui/raidboss/data/06-ew/raid/p6s.ts
@@ -54,6 +54,32 @@ const triggerSet: TriggerSet<Data> = {
       response: Responses.sharedTankBuster(),
     },
     {
+      id: 'P6S Synergy',
+      type: 'StartsUsing',
+      // There are 7889 individual starts using casts on the two tanks as well,
+      // if this trigger wanted to be more complicated.
+      netRegex: NetRegexes.startsUsing({ id: '7887', source: 'Hegemone', capture: false }),
+      alertText: (_data, _matches, output) => output.text!(),
+      outputStrings: {
+        text: {
+          en: 'Split Tankbusters',
+          de: 'Geteilter Tankbuster',
+        },
+      },
+    },
+    {
+      id: 'P6S Choros Ixou Front Back',
+      type: 'StartsUsing',
+      netRegex: NetRegexes.startsUsing({ id: '7883', source: 'Hegemone', capture: false }),
+      response: Responses.goFrontBack(),
+    },
+    {
+      id: 'P6S Choros Ixou Sides',
+      type: 'StartsUsing',
+      netRegex: NetRegexes.startsUsing({ id: '7881', source: 'Hegemone', capture: false }),
+      response: Responses.goSides(),
+    },
+    {
       id: 'P6S Pathogenic Cells Numbers',
       type: 'HeadMarker',
       netRegex: NetRegexes.headMarker({}),
@@ -102,32 +128,6 @@ const triggerSet: TriggerSet<Data> = {
           ko: '${num}번째',
         },
       },
-    },
-    {
-      id: 'P6S Synergy',
-      type: 'StartsUsing',
-      // There are 7889 individual starts using casts on the two tanks as well,
-      // if this trigger wanted to be more complicated.
-      netRegex: NetRegexes.startsUsing({ id: '7887', source: 'Hegemone', capture: false }),
-      alertText: (_data, _matches, output) => output.text!(),
-      outputStrings: {
-        text: {
-          en: 'Split Tankbusters',
-          de: 'Geteilter Tankbuster',
-        },
-      },
-    },
-    {
-      id: 'P6S Choros Ixou Front Back',
-      type: 'StartsUsing',
-      netRegex: NetRegexes.startsUsing({ id: '7883', source: 'Hegemone', capture: false }),
-      response: Responses.goFrontBack(),
-    },
-    {
-      id: 'P6S Choros Ixou Sides',
-      type: 'StartsUsing',
-      netRegex: NetRegexes.startsUsing({ id: '7881', source: 'Hegemone', capture: false }),
-      response: Responses.goSides(),
     },
     {
       id: 'P6S Dark Dome Bait',

--- a/ui/raidboss/data/06-ew/raid/p6s.ts
+++ b/ui/raidboss/data/06-ew/raid/p6s.ts
@@ -3,13 +3,44 @@ import { Responses } from '../../../../../resources/responses';
 import ZoneId from '../../../../../resources/zone_id';
 import { RaidbossData } from '../../../../../types/data';
 import { TriggerSet } from '../../../../../types/trigger';
+import { NetMatches } from '../../../../../types/net_matches';
 
-export type Data = RaidbossData;
+export interface Data extends RaidbossData {
+  decOffset?: number;
+  pathogenicCellsNumber?: number;
+  pathogenicCellsDelay?: number;
+}
+
+// Due to changes introduced in patch 5.2, overhead markers now have a random offset
+// added to their ID. This offset currently appears to be set per instance, so
+// we can determine what it is from the first overhead marker we see.
+// The first 1B marker in the encounter is an Exocleaver (013E).
+const firstHeadmarker = parseInt('013E', 16);
+const getHeadmarkerId = (data: Data, matches: NetMatches['HeadMarker']) => {
+  // If we naively just check !data.decOffset and leave it, it breaks if the first marker is 013E.
+  // (This makes the offset 0, and !0 is true.)
+  if (typeof data.decOffset === 'undefined')
+    data.decOffset = parseInt(matches.id, 16) - firstHeadmarker;
+  // The leading zeroes are stripped when converting back to string, so we re-add them here.
+  // Fortunately, we don't have to worry about whether or not this is robust,
+  // since we know all the IDs that will be present in the encounter.
+  return (parseInt(matches.id, 16) - data.decOffset).toString(16).toUpperCase().padStart(4, '0');
+};
 
 const triggerSet: TriggerSet<Data> = {
   zoneId: ZoneId.AbyssosTheSixthCircleSavage,
   timelineFile: 'p6s.txt',
   triggers: [
+    {
+      id: 'P6S Headmarker Tracker',
+      type: 'HeadMarker',
+      netRegex: NetRegexes.headMarker({}),
+      condition: (data) => data.decOffset === undefined,
+      // Unconditionally set the first headmarker here so that future triggers are conditional.
+      run: (data, matches) => {
+        getHeadmarkerId(data, matches);
+      },
+    },
     {
       id: 'P6S Hemitheos\'s Dark IV',
       type: 'StartsUsing',
@@ -21,6 +52,56 @@ const triggerSet: TriggerSet<Data> = {
       type: 'StartsUsing',
       netRegex: NetRegexes.startsUsing({ id: '788A', source: 'Hegemone' }),
       response: Responses.sharedTankBuster(),
+    },
+    {
+      id: 'P6S Pathogenic Cells Numbers',
+      type: 'HeadMarker',
+      netRegex: NetRegexes.headMarker({}),
+      condition: (data, matches) => {
+        return data.me === matches.target && (/00(?:4F|5[0-6])/).test(getHeadmarkerId(data, matches));
+      },
+      preRun: (data, matches) => {
+        const correctedMatch = getHeadmarkerId(data, matches);
+        const pathogenicCellsNumberMap: { [id: string]: number } = {
+          '004F': 1,
+          '0050': 2,
+          '0051': 3,
+          '0052': 4,
+          '0053': 5,
+          '0054': 6,
+          '0055': 7,
+          '0056': 8,
+        };
+        data.pathogenicCellsNumber = pathogenicCellsNumberMap[correctedMatch];
+
+        const pathogenicCellsDelayMap: { [id: string]: number } = {
+            '004F': 8.6,
+            '0050': 10.6,
+            '0051': 12.5,
+            '0052': 14.4,
+            '0053': 16.4,
+            '0054': 18.3,
+            '0055': 20.2,
+            '0056': 22.2,
+        };
+        data.pathogenicCellsDelay = pathogenicCellsDelayMap[correctedMatch];
+      },
+      durationSeconds: (data) => {
+        // Because people are very forgetful,
+        // show the number until you are done.
+        return data.pathogenicCellsDelay;
+      },
+      alertText: (data, _matches, output) => output.text!({ num: data.pathogenicCellsNumber }),
+      outputStrings: {
+        text: {
+          en: '#${num}',
+          de: '#${num}',
+          fr: '#${num}',
+          ja: '${num}番',
+          cn: '#${num}',
+          ko: '${num}번째',
+        },
+      },
     },
     {
       id: 'P6S Synergy',

--- a/ui/raidboss/data/06-ew/raid/p6s.ts
+++ b/ui/raidboss/data/06-ew/raid/p6s.ts
@@ -2,8 +2,9 @@ import NetRegexes from '../../../../../resources/netregexes';
 import { Responses } from '../../../../../resources/responses';
 import ZoneId from '../../../../../resources/zone_id';
 import { RaidbossData } from '../../../../../types/data';
-import { TriggerSet } from '../../../../../types/trigger';
 import { NetMatches } from '../../../../../types/net_matches';
+import { TriggerSet } from '../../../../../types/trigger';
+
 
 export interface Data extends RaidbossData {
   decOffset?: number;
@@ -75,14 +76,14 @@ const triggerSet: TriggerSet<Data> = {
         data.pathogenicCellsNumber = pathogenicCellsNumberMap[correctedMatch];
 
         const pathogenicCellsDelayMap: { [id: string]: number } = {
-            '004F': 8.6,
-            '0050': 10.6,
-            '0051': 12.5,
-            '0052': 14.4,
-            '0053': 16.4,
-            '0054': 18.3,
-            '0055': 20.2,
-            '0056': 22.2,
+          '004F': 8.6,
+          '0050': 10.6,
+          '0051': 12.5,
+          '0052': 14.4,
+          '0053': 16.4,
+          '0054': 18.3,
+          '0055': 20.2,
+          '0056': 22.2,
         };
         data.pathogenicCellsDelay = pathogenicCellsDelayMap[correctedMatch];
       },

--- a/ui/raidboss/data/06-ew/raid/p6s.ts
+++ b/ui/raidboss/data/06-ew/raid/p6s.ts
@@ -92,7 +92,7 @@ const triggerSet: TriggerSet<Data> = {
         // show the number until you are done.
         return data.pathogenicCellsDelay;
       },
-      alertText: (data, _matches, output) => output.text!({ num: data.pathogenicCellsNumber }),
+      infoText: (data, _matches, output) => output.text!({ num: data.pathogenicCellsNumber }),
       outputStrings: {
         text: {
           en: '#${num}',


### PR DESCRIPTION
First headmarker (the healer stackmarkers) appears to be 013E. This value will have the numbers be treated with their previous 004F starting point.

Would need to do more research to determine the other headmarkers:

First Exchange of Agonies Markers:
These seem to be dependent on tethers too, but not sure if we need to know the tether information as it looks like there are unique headMarker ids for each:
Pattern 1
0163 x1 Targetted by 786D (Unholy Darkness) Stack
0164 x1 Targetted by 7870 (Dark Burst)
016A x3 Targetted by 7872 (Dark Burst)
0168 x3 Donut

Pattern 2
016A x2 Targetted by 7872 (Dark Burst)
0164 x1 Targetted by 7870 (Dark Burst)
0165 x1 Targetted by 7871 (Dark Burst)
0167 x1 Targetted by 786E (Unholy Darkness) Stack
0168 x2 Donut
016E x1 Donut

Other Markers:
0065 Spread Marker for Dark Ashes
0148 Spread Marker for Dark Sphere