### PR TITLE
raidboss: p6s Exocleaver Move + Healer Groups

### DIFF
--- a/ui/raidboss/data/06-ew/raid/p6s.ts
+++ b/ui/raidboss/data/06-ew/raid/p6s.ts
@@ -84,9 +84,10 @@ const triggerSet: TriggerSet<Data> = {
     },
     {
       id: 'P6S Exocleaver Move',
-      type: 'StartsUsing',
-      netRegex: NetRegexes.startsUsing({ id: ['7869', '786B'], source: 'Hegemone' }),
-      delaySeconds: (_data, matches) => parseFloat(matches.castTime),
+      type: 'Ability',
+      netRegex: NetRegexes.ability({ id: ['7869', '786B'], source: 'Hegemone', capture: false}),
+      // Supress until after second Exocleaver in the set
+      suppressSeconds: 4,
       response: Responses.moveAway(),
     },
     {

--- a/ui/raidboss/data/06-ew/raid/p6s.ts
+++ b/ui/raidboss/data/06-ew/raid/p6s.ts
@@ -87,10 +87,7 @@ const triggerSet: TriggerSet<Data> = {
       type: 'StartsUsing',
       netRegex: NetRegexes.startsUsing({ id: ['7869', '786B'], source: 'Hegemone' }),
       delaySeconds: (_data, matches) => parseFloat(matches.castTime),
-      infoText: (_data, _matches, output) => output.moveAway!(),
-      outputStrings: {
-        moveAway: Outputs.moveAway,
-      },
+      response: Responses.moveAway(),
     },
     {
       id: 'P6S Choros Ixou Front Back',

--- a/ui/raidboss/data/06-ew/raid/p6s.ts
+++ b/ui/raidboss/data/06-ew/raid/p6s.ts
@@ -71,21 +71,6 @@ const triggerSet: TriggerSet<Data> = {
       },
     },
     {
-      id: 'P6S Unholy Darkness Healer Groups',
-      type: 'HeadMarker',
-      netRegex: NetRegexes.headMarker({}),
-      condition: (data, matches) => {
-        return (/013E/).test(getHeadmarkerId(data, matches));
-      },
-      suppressSeconds: 1,
-      infoText: (_data, matches, output) => {
-        return output.healerGroups!();
-      },
-      outputStrings: {
-        healerGroups: Outputs.healerGroups,
-      },
-    },
-    {
       id: 'P6S Exocleaver',
       // Unholy Darkness stack headmarkers are same time as first Exocleaver
       // Exchange of Agonies headmarkers are 7s before second Exocleavers

--- a/ui/raidboss/data/06-ew/raid/p6s.ts
+++ b/ui/raidboss/data/06-ew/raid/p6s.ts
@@ -73,7 +73,7 @@ const triggerSet: TriggerSet<Data> = {
     {
       id: 'P6S Exocleaver',
       // Unholy Darkness stack headmarkers are same time as first Exocleaver
-      // Exchange of Agonies headmarkers are 7s before second Exocleavers
+      // Exchange of Agonies headmarkers are 3s before second Exocleavers
       type: 'StartsUsing',
       netRegex: NetRegexes.startsUsing({ id: ['7869', '786B'], source: 'Hegemone', capture: false }),
       alertText: (data, _matches, output) => {

--- a/ui/raidboss/data/06-ew/raid/p6s.ts
+++ b/ui/raidboss/data/06-ew/raid/p6s.ts
@@ -10,12 +10,13 @@ export interface Data extends RaidbossData {
   decOffset?: number;
   pathogenicCellsNumber?: number;
   pathogenicCellsDelay?: number;
+  secondExocleavers?: boolean;
 }
 
 // Due to changes introduced in patch 5.2, overhead markers now have a random offset
 // added to their ID. This offset currently appears to be set per instance, so
 // we can determine what it is from the first overhead marker we see.
-// The first 1B marker in the encounter is an Exocleaver (013E).
+// The first 1B marker in the encounter is an Unholy Darkness stack marker (013E).
 const firstHeadmarker = parseInt('013E', 16);
 const getHeadmarkerId = (data: Data, matches: NetMatches['HeadMarker']) => {
   // If we naively just check !data.decOffset and leave it, it breaks if the first marker is 013E.
@@ -90,8 +91,16 @@ const triggerSet: TriggerSet<Data> = {
       // Exchange of Agonies headmarkers are 7s before second Exocleavers
       type: 'StartsUsing',
       netRegex: NetRegexes.startsUsing({ id: ['7869', '786B'], source: 'Hegemone', capture: false }),
-      alertText: (_data, _matches, output) => output.protean!(),
+      alertText: (data, _matches, output) => {
+        if (data.secondExocleavers)
+          return output.protean!();
+        return output.healerGroupsProtean!();
+      },
+      run: (data) => data.secondExocleavers = true,
       outputStrings: {
+        healerGroupsProtean: {
+          en: 'Healer Groups + Protean',
+        },
         protean: {
           en: 'Protean',
           de: 'Himmelsrichtungen',

--- a/ui/raidboss/data/06-ew/raid/p6s.ts
+++ b/ui/raidboss/data/06-ew/raid/p6s.ts
@@ -85,7 +85,7 @@ const triggerSet: TriggerSet<Data> = {
     {
       id: 'P6S Exocleaver Move',
       type: 'Ability',
-      netRegex: NetRegexes.ability({ id: ['7869', '786B'], source: 'Hegemone', capture: false}),
+      netRegex: NetRegexes.ability({ id: ['7869', '786B'], source: 'Hegemone', capture: false }),
       // Supress until after second Exocleaver in the set
       suppressSeconds: 4,
       response: Responses.moveAway(),

--- a/ui/raidboss/data/06-ew/raid/p6s.ts
+++ b/ui/raidboss/data/06-ew/raid/p6s.ts
@@ -70,6 +70,39 @@ const triggerSet: TriggerSet<Data> = {
       },
     },
     {
+      id: 'P6S Unholy Darkness Healer Groups',
+      type: 'HeadMarker',
+      netRegex: NetRegexes.headMarker({}),
+      condition: (data, matches) => {
+        return (/013E/).test(getHeadmarkerId(data, matches));
+      },
+      suppressSeconds: 1,
+      infoText: (_data, matches, output) => {
+        return output.healerGroups!();
+      },
+      outputStrings: {
+        healerGroups: Outputs.healerGroups,
+      },
+    },
+    {
+      id: 'P6S Exocleaver',
+      // Unholy Darkness stack headmarkers are 3.8s before first Exocleavers
+      // Exchange of Agonies headmarkers are 7s before second Exocleavers
+      type: 'StartsUsing',
+      netRegex: NetRegexes.startsUsing({ id: ['7869', '786B'], source: 'Hegemone', capture: false }),
+      alertText: (_data, _matches, output) => output.protean!(),
+      outputStrings: {
+        protean: {
+          en: 'Protean',
+          de: 'Himmelsrichtungen',
+          fr: 'Positions',
+          ja: '8方向散開',
+          cn: '八方位站位',
+          ko: '정해진 위치로 산개',
+        },
+      },
+    },
+    {
       id: 'P6S Choros Ixou Front Back',
       type: 'StartsUsing',
       netRegex: NetRegexes.startsUsing({ id: '7883', source: 'Hegemone', capture: false }),

--- a/ui/raidboss/data/06-ew/raid/p6s.ts
+++ b/ui/raidboss/data/06-ew/raid/p6s.ts
@@ -71,29 +71,25 @@ const triggerSet: TriggerSet<Data> = {
       },
     },
     {
-      id: 'P6S Exocleaver',
+      id: 'P6S Exocleaver Healer Groups',
       // Unholy Darkness stack headmarkers are same time as first Exocleaver
-      // Exchange of Agonies headmarkers are 3s before second Exocleavers
       type: 'StartsUsing',
       netRegex: NetRegexes.startsUsing({ id: ['7869', '786B'], source: 'Hegemone', capture: false }),
-      alertText: (data, _matches, output) => {
-        if (data.secondExocleavers)
-          return output.protean!();
-        return output.healerGroupsProtean!();
-      },
+      condition: (data) => !data.secondExocleavers,
+      alertText: (_data, _matches, output) => output.healerGroups!(),
       run: (data) => data.secondExocleavers = true,
       outputStrings: {
-        healerGroupsProtean: {
-          en: 'Healer Groups + Protean',
-        },
-        protean: {
-          en: 'Protean',
-          de: 'Himmelsrichtungen',
-          fr: 'Positions',
-          ja: '8方向散開',
-          cn: '八方位站位',
-          ko: '정해진 위치로 산개',
-        },
+        healerGroups: Outputs.healerGroups,
+      },
+    },
+    {
+      id: 'P6S Exocleaver Move',
+      type: 'StartsUsing',
+      netRegex: NetRegexes.startsUsing({ id: ['7869', '786B'], source: 'Hegemone' }),
+      delaySeconds: (_data, matches) => parseFloat(matches.castTime),
+      infoText: (_data, _matches, output) => output.moveAway!(),
+      outputStrings: {
+        moveAway: Outputs.moveAway,
       },
     },
     {

--- a/ui/raidboss/data/06-ew/raid/p6s.ts
+++ b/ui/raidboss/data/06-ew/raid/p6s.ts
@@ -86,7 +86,7 @@ const triggerSet: TriggerSet<Data> = {
     },
     {
       id: 'P6S Exocleaver',
-      // Unholy Darkness stack headmarkers are 3.8s before first Exocleavers
+      // Unholy Darkness stack headmarkers are same time as first Exocleaver
       // Exchange of Agonies headmarkers are 7s before second Exocleavers
       type: 'StartsUsing',
       netRegex: NetRegexes.startsUsing({ id: ['7869', '786B'], source: 'Hegemone', capture: false }),


### PR DESCRIPTION
Adds callout for the Exocleaver mechanic and the healer group headmarkers (013E).

Notes:
- ~~Unholy Darkness stack headmarkers are 3.8s before first Exocleavers~~ EDIT: Unholy Darkness stack headmarkers come out same time as first Exocleavers
- Exchange of Agonies headmarkers are ~~7~~3s before second Exocleavers