### PR TITLE
raidboss: p7s Bough of Attis (arrows) callout

### DIFF
--- a/ui/raidboss/data/06-ew/raid/p7s.ts
+++ b/ui/raidboss/data/06-ew/raid/p7s.ts
@@ -53,7 +53,7 @@ const triggerSet: TriggerSet<Data> = {
       netRegex: NetRegexes.startsUsing({ id: '7824', source: 'Agdistis', capture: false }),
       alertText: (_data, _matches, output) => output.northwest!(),
       outputStrings: {
-        northwest: Outputs.northwest, 
+        northwest: Outputs.northwest,
       },
     },
     {

--- a/ui/raidboss/data/06-ew/raid/p7s.ts
+++ b/ui/raidboss/data/06-ew/raid/p7s.ts
@@ -51,19 +51,13 @@ const triggerSet: TriggerSet<Data> = {
       id: 'P7S Bough of Attis Left Arrows',
       type: 'StartsUsing',
       netRegex: NetRegexes.startsUsing({ id: '7824', source: 'Agdistis', capture: false }),
-      alertText: (_data, _matches, output) => output.northwest!(),
-      outputStrings: {
-        northwest: Outputs.northwest,
-      },
+      response: Responses.goLeft(),
     },
     {
       id: 'P7S Bough of Attis Right Arrows',
       type: 'StartsUsing',
       netRegex: NetRegexes.startsUsing({ id: '7823', source: 'Agdistis', capture: false }),
-      alertText: (_data, _matches, output) => output.northeast!(),
-      outputStrings: {
-        northeast: Outputs.northeast,
-      },
+      response: Responses.goRight(),
     },
     {
       id: 'P7S Hemitheos\'s Aero IV',

--- a/ui/raidboss/data/06-ew/raid/p7s.ts
+++ b/ui/raidboss/data/06-ew/raid/p7s.ts
@@ -48,6 +48,24 @@ const triggerSet: TriggerSet<Data> = {
       },
     },
     {
+      id: 'P7S Bough of Attis Left Arrows',
+      type: 'StartsUsing',
+      netRegex: NetRegexes.startsUsing({ id: '7824', source: 'Agdistis', capture: false }),
+      alertText: (_data, _matches, output) => output.northwest!(),
+      outputStrings: {
+        northwest: Outputs.northwest, 
+      },
+    },
+    {
+      id: 'P7S Bough of Attis Right Arrows',
+      type: 'StartsUsing',
+      netRegex: NetRegexes.startsUsing({ id: '7823', source: 'Agdistis', capture: false }),
+      alertText: (_data, _matches, output) => output.northeast!(),
+      outputStrings: {
+        northeast: Outputs.northeast,
+      },
+    },
+    {
       id: 'P7S Hemitheos\'s Aero IV',
       type: 'StartsUsing',
       netRegex: NetRegexes.startsUsing({ id: '7A0B', source: 'Agdistis', capture: false }),


### PR DESCRIPTION
Since the Close and Far ones are static, they may be better done with a timeline trigger for pre-positioning.