### PR TITLE
raidboss: p7s Hemitheos's Holy III Healer Groups

### DIFF
--- a/ui/raidboss/data/06-ew/raid/p7s.ts
+++ b/ui/raidboss/data/06-ew/raid/p7s.ts
@@ -5,9 +5,11 @@ import Outputs from '../../../../../resources/outputs';
 import { Responses } from '../../../../../resources/responses';
 import ZoneId from '../../../../../resources/zone_id';
 import { RaidbossData } from '../../../../../types/data';
+import { NetMatches } from '../../../../../types/net_matches';
 import { TriggerSet } from '../../../../../types/trigger';
 
 export interface Data extends RaidbossData {
+  decOffset?: number;
   purgationDebuffs: { [role: string]: { [name: string]: number } };
   purgationDebuffCount: number;
 }

--- a/ui/raidboss/data/06-ew/raid/p7s.ts
+++ b/ui/raidboss/data/06-ew/raid/p7s.ts
@@ -12,6 +12,22 @@ export interface Data extends RaidbossData {
   purgationDebuffCount: number;
 }
 
+// Due to changes introduced in patch 5.2, overhead markers now have a random offset
+// added to their ID. This offset currently appears to be set per instance, so
+// we can determine what it is from the first overhead marker we see.
+// The first 1B marker in the encounter is an Hemitheos's Holy III stack marker (013E).
+const firstHeadmarker = parseInt('013E', 16);
+const getHeadmarkerId = (data: Data, matches: NetMatches['HeadMarker']) => {
+  // If we naively just check !data.decOffset and leave it, it breaks if the first marker is 013E.
+  // (This makes the offset 0, and !0 is true.)
+  if (typeof data.decOffset === 'undefined')
+    data.decOffset = parseInt(matches.id, 16) - firstHeadmarker;
+  // The leading zeroes are stripped when converting back to string, so we re-add them here.
+  // Fortunately, we don't have to worry about whether or not this is robust,
+  // since we know all the IDs that will be present in the encounter.
+  return (parseInt(matches.id, 16) - data.decOffset).toString(16).toUpperCase().padStart(4, '0');
+};
+
 // effect ids for inviolate purgation
 const effectIdToOutputStringKey: { [effectId: string]: string } = {
   'CEE': 'spread',
@@ -32,6 +48,30 @@ const triggerSet: TriggerSet<Data> = {
     purgationDebuffCount: 0,
   }),
   triggers: [
+    {
+      id: 'P7S Headmarker Tracker',
+      type: 'HeadMarker',
+      netRegex: NetRegexes.headMarker({}),
+      condition: (data) => data.decOffset === undefined,
+      // Unconditionally set the first headmarker here so that future triggers are conditional.
+      run: (data, matches) => {
+        getHeadmarkerId(data, matches);
+      },
+    },
+    {
+      id: 'P7S Hemitheos\'s Holy III Healer Groups',
+      type: 'HeadMarker',
+      netRegex: NetRegexes.headMarker({}),
+      suppressSeconds: 1,
+      infoText: (data, matches, output) => {
+        const correctedMatch = getHeadmarkerId(data, matches);
+        if (correctedMatch === '013E')
+          return output.healerGroups!();
+      },
+      outputStrings: {
+        healerGroups: Outputs.healerGroups,
+      },
+    },
     {
       id: 'P7S Condensed Aero II',
       type: 'StartsUsing',


### PR DESCRIPTION
Adds code for getting headmarkers in this encounter and a trigger for healer groups. It appears it is using the same 013E marker from p6s.

Spread markers that I have seen in this fight are using 008B.
5s Timer marker appears to be 00A6.