### PR TITLE
raidboss: p7s Inviolate Bonds/Purgation Reminders

### DIFF
--- a/ui/raidboss/data/06-ew/raid/p7s.ts
+++ b/ui/raidboss/data/06-ew/raid/p7s.ts
@@ -10,7 +10,7 @@ import { TriggerSet } from '../../../../../types/trigger';
 
 export interface Data extends RaidbossData {
   decOffset?: number;
-  previousBondsDebuff?: string;
+  bondsDebuff?: string;
   purgationDebuffs: { [role: string]: { [name: string]: number } };
   purgationDebuffCount: number;
   purgationEffects?: string[];
@@ -146,7 +146,7 @@ const triggerSet: TriggerSet<Data> = {
         };
 
         // Store debuff for reminders
-        data.previousBondsDebuff = matches.effectId;
+        data.bondsDebuff = (matches.effectId === 'CEC' ? 'spread' : 'stackMarker');
 
         const longTimer = parseFloat(matches.duration) > 9;
         if (longTimer)
@@ -163,17 +163,11 @@ const triggerSet: TriggerSet<Data> = {
       suppressSeconds: 1,
       infoText: (data, matches, output) => {
         const correctedMatch = getHeadmarkerId(data, matches);
-        if (correctedMatch === '00A6' && data.purgationDebuffCount === 0) {
-          switch (data.previousBondsDebuff) {
-            case 'CEC':
-              data.previousBondsDebuff = 'D45';
-              return output.spread!();
-            case 'D45':
-              data.previousBondsDebuff = 'CEC';
-              return output.stackMarker!();
-          }
+        if (correctedMatch === '00A6' && data.purgationDebuffCount === 0 && data.bondsDebuff) {
+          return output[data.bondsDebuff]!();
         }
       },
+      run: (data) => data.bondsDebuff = (data.bondsDebuff === 'spread' ? 'stackMarker' : 'spread'),
       outputStrings: {
         spread: Outputs.spread,
         stackMarker: Outputs.stackMarker,

--- a/ui/raidboss/data/06-ew/raid/p7s.ts
+++ b/ui/raidboss/data/06-ew/raid/p7s.ts
@@ -14,7 +14,6 @@ export interface Data extends RaidbossData {
   purgationDebuffCount: number;
   purgationEffects?: string[];
   purgationEffectIndex: number;
-  purgationDebuffCount: number;
 }
 
 // Due to changes introduced in patch 5.2, overhead markers now have a random offset

--- a/ui/raidboss/data/06-ew/raid/p7s.ts
+++ b/ui/raidboss/data/06-ew/raid/p7s.ts
@@ -10,6 +10,7 @@ import { TriggerSet } from '../../../../../types/trigger';
 
 export interface Data extends RaidbossData {
   decOffset?: number;
+  previousInviolateDebuff?: string;
   purgationDebuffs: { [role: string]: { [name: string]: number } };
   purgationDebuffCount: number;
   purgationEffects?: string[];

--- a/ui/raidboss/data/06-ew/raid/p7s.ts
+++ b/ui/raidboss/data/06-ew/raid/p7s.ts
@@ -254,8 +254,9 @@ const triggerSet: TriggerSet<Data> = {
       outputStrings: {
         spread: Outputs.spread,
         stack: Outputs.stackMarker,
-  },
-  {
+      },
+    },
+    {
       id: 'P7S Light of Life',
       type: 'StartsUsing',
       netRegex: NetRegexes.startsUsing({ id: '78E2', source: 'Agdistis', capture: false }),

--- a/ui/raidboss/data/06-ew/raid/p7s.ts
+++ b/ui/raidboss/data/06-ew/raid/p7s.ts
@@ -163,9 +163,8 @@ const triggerSet: TriggerSet<Data> = {
       suppressSeconds: 1,
       infoText: (data, matches, output) => {
         const correctedMatch = getHeadmarkerId(data, matches);
-        if (correctedMatch === '00A6' && data.purgationDebuffCount === 0 && data.bondsDebuff) {
+        if (correctedMatch === '00A6' && data.purgationDebuffCount === 0 && data.bondsDebuff)
           return output[data.bondsDebuff]!();
-        }
       },
       run: (data) => data.bondsDebuff = (data.bondsDebuff === 'spread' ? 'stackMarker' : 'spread'),
       outputStrings: {

--- a/ui/raidboss/data/06-ew/raid/p7s.ts
+++ b/ui/raidboss/data/06-ew/raid/p7s.ts
@@ -10,7 +10,7 @@ import { TriggerSet } from '../../../../../types/trigger';
 
 export interface Data extends RaidbossData {
   decOffset?: number;
-  previousInviolateDebuff?: string;
+  previousBondsDebuff?: string;
   purgationDebuffs: { [role: string]: { [name: string]: number } };
   purgationDebuffCount: number;
   purgationEffects?: string[];
@@ -146,7 +146,7 @@ const triggerSet: TriggerSet<Data> = {
         };
 
         // Strore debuff for reminders
-        data.previousInviolateDebuff = matches.effectId;
+        data.previousBondsDebuff = matches.effectId;
 
         const longTimer = parseFloat(matches.duration) > 9;
         if (longTimer)
@@ -164,12 +164,12 @@ const triggerSet: TriggerSet<Data> = {
       infoText: (data, matches, output) => {
         const correctedMatch = getHeadmarkerId(data, matches);
         if (correctedMatch === '00A6' && data.purgationDebuffCount === 0) {
-          switch (data.previousInviolateDebuff) {
+          switch (data.previousBondsDebuff) {
             case 'CEC':
-              data.previousInviolateDebuff = 'D45';
+              data.previousBondsDebuff = 'D45';
               return output.spread!();
             case 'D45':
-              data.previousInviolateDebuff = 'CEC';
+              data.previousBondsDebuff = 'CEC';
               return output.stackMarker!();
           }
         }

--- a/ui/raidboss/data/06-ew/raid/p7s.ts
+++ b/ui/raidboss/data/06-ew/raid/p7s.ts
@@ -145,7 +145,7 @@ const triggerSet: TriggerSet<Data> = {
           spreadThenStack: Outputs.spreadThenStack,
         };
 
-        // Strore debuff for reminders
+        // Store debuff for reminders
         data.previousBondsDebuff = matches.effectId;
 
         const longTimer = parseFloat(matches.duration) > 9;


### PR DESCRIPTION
Adds a headmarker-based callout for the Inviolate Bonds and Inviolate Purgation mechanics utilizing previous triggers. **EDIT:** This effectively gives a 6s notice, which by then the player should already be headed to or on the platform.

Note: Previous triggers are relying on 4/4 support/dps party and purgation relies on 8-player party, so these may not function properly in non-standard party...