### PR TITLE
raidboss: p7s add Light of Life bigAoe

### DIFF
--- a/ui/raidboss/data/06-ew/raid/p7s.ts
+++ b/ui/raidboss/data/06-ew/raid/p7s.ts
@@ -207,7 +207,7 @@ const triggerSet: TriggerSet<Data> = {
       netRegex: NetRegexes.startsUsing({ id: '78E2', source: 'Agdistis', capture: false }),
       // ~5s castTime, but boss cancels it and ability goes off 26s after start
       delaySeconds: 21,
-      alertText: (data, _matches, output) => output.bigAoEMiddle!(),
+      alertText: (_data, _matches, output) => output.bigAoEMiddle!(),
       outputStrings: {
         bigAoEMiddle: {
           en: 'Big AOE, Get Middle',

--- a/ui/raidboss/data/06-ew/raid/p7s.ts
+++ b/ui/raidboss/data/06-ew/raid/p7s.ts
@@ -201,6 +201,14 @@ const triggerSet: TriggerSet<Data> = {
         stack: Outputs.stackMarker,
       },
     },
+    {
+      id: 'P7S Light of Life',
+      type: 'StartsUsing',
+      netRegex: NetRegexes.startsUsing({ id: '78E2', source: 'Agdistis' }),
+      // ~5s castTime, but boss cancels it and ability goes off 26s after start
+      delaySeconds: 21,
+      response: Responses.bigAoe(),
+    },
   ],
   timelineReplace: [
     {

--- a/ui/raidboss/data/06-ew/raid/p7s.ts
+++ b/ui/raidboss/data/06-ew/raid/p7s.ts
@@ -207,6 +207,7 @@ const triggerSet: TriggerSet<Data> = {
       netRegex: NetRegexes.startsUsing({ id: '78E2', source: 'Agdistis', capture: false }),
       // ~5s castTime, but boss cancels it and ability goes off 26s after start
       delaySeconds: 21,
+      alertText: (data, _matches, output) => output.bigAoEMiddle!(),
       outputStrings: {
         bigAoEMiddle: {
           en: 'Big AOE, Get Middle',

--- a/ui/raidboss/data/06-ew/raid/p7s.ts
+++ b/ui/raidboss/data/06-ew/raid/p7s.ts
@@ -204,10 +204,19 @@ const triggerSet: TriggerSet<Data> = {
     {
       id: 'P7S Light of Life',
       type: 'StartsUsing',
-      netRegex: NetRegexes.startsUsing({ id: '78E2', source: 'Agdistis' }),
+      netRegex: NetRegexes.startsUsing({ id: '78E2', source: 'Agdistis', capture: false }),
       // ~5s castTime, but boss cancels it and ability goes off 26s after start
       delaySeconds: 21,
-      response: Responses.bigAoe(),
+      outputStrings: {
+        bigAoEMiddle: {
+          en: 'Big AOE, Get Middle',
+          de: 'Große AoE, geh in die Mitte',
+          fr: 'Grosse AoE, allez au milieu',
+          ja: '大ダメージ、中へ',
+          cn: '超大伤害，去中间',
+          ko: '아픈 광뎀, 중앙으로',
+        },
+      },
     },
   ],
   timelineReplace: [


### PR DESCRIPTION
The cast on this one is strange, fflogs showing it is canceled, castTime appears to be ~5s, and the ability goes off 26s after start of cast. This adds a ~5s notice for the aoe.

Also to note, strats may vary, but arguably it could be earlier call out such as get middle, big aoe because as far as I am aware, all strats require changing platform between purgations. **EDIT:** Updated to reflect such.