### PR TITLE
raidboss: p8s Blazing Footfalls directions

### DIFF
--- a/ui/raidboss/data/06-ew/raid/p8s.ts
+++ b/ui/raidboss/data/06-ew/raid/p8s.ts
@@ -1077,8 +1077,13 @@ const triggerSet: TriggerSet<Data> = {
             en: '${dir}',
           },
           trailblazeKnockback: {
+            en: '${dir} Knockback',
+          },
+          trailblazeKnockbackTo: {
             en: '${dir1} Knockback to ${dir2}',
           },
+          left: Outputs.left,
+          right: Outputs.right,
           north: Outputs.north,
           east: Outputs.east,
           south: Outputs.south,
@@ -1137,13 +1142,35 @@ const triggerSet: TriggerSet<Data> = {
 
           // Second trailblze should call torch location
           if (data.footfallsOrder[data.trailblazeCount] === 'impact') {
-            // If missing torch data, target to the middle
-            const knockbackTo = (data.trailblazeTorchSafeZone ? output[data.trailblazeTorchSafeZone]!() : dirToCard[(dir + 2) % 4]);
-            return { alertText: output.trailblazeKnockback!({ dir1: dirToCard[dir], dir2: knockbackTo }) };
+            if (
+              (data.trailblazeTorchSafeZone === 'east' && dir === 0) ||
+              (data.trailblazeTorchSafeZone === 'west' && dir === 2)
+            )
+              return { alertText: output.trailblazeKnockbackTo!({ dir1: dirToCard[dir], dir2: output.left!() }) };
+            if (
+              (data.trailblazeTorchSafeZone === 'west' && dir === 0) ||
+              (data.trailblazeTorchSafeZone === 'east' && dir === 2)
+            )
+              return { alertText: output.trailblazeKnockbackTo!({ dir1: dirToCard[dir], dir2: output.right!() }) };
+
+            // Unable to determine direction, output only knockback
+            return { alertText: output.trailblazeKnockback!({ dir1: dirToCard[dir] }) };
           }
+
           // Output torch location during crush
-          if (data.footfallsOrder[data.trailblazeCount] === 'crush' && data.trailblazeTorchSafeZone)
-            return { infoText: output[data.trailblazeTorchSafeZone]!() };
+          if (data.footfallsOrder[data.trailblazeCount] === 'crush' && data.trailblazeTorchSafeZone) {
+            if (
+              (data.trailblazeTorchSafeZone === 'east' && dir === 0) ||
+              (data.trailblazeTorchSafeZone === 'west' && dir === 2)
+            )
+              return { infoText: output.right!() };
+            if (
+              (data.trailblazeTorchSafeZone === 'west' && dir === 0) ||
+              (data.trailblazeTorchSafeZone === 'east' && dir === 2)
+            )
+              return { infoText: output.left!() };
+            // Unable to determine direction, no output
+          }
         }
       },
       run: (data) => data.trailblazeCount++,

--- a/ui/raidboss/data/06-ew/raid/p8s.ts
+++ b/ui/raidboss/data/06-ew/raid/p8s.ts
@@ -919,7 +919,7 @@ const triggerSet: TriggerSet<Data> = {
             en: '${dir}',
           },
           directionsKnockback: {
-            en: '${dir} Knockback',
+            en: 'Knockback ${dir1} to ${dir2}',
           },
           north: Outputs.north,
           east: Outputs.east,
@@ -958,8 +958,10 @@ const triggerSet: TriggerSet<Data> = {
           if (data.trailblazeCount === 0 && data.footfallsOrder[data.trailblazeCount] === 'crush')
             return { infoText: output.directionsPush!({ dir: dirToCard[data.footfallsDirs[1]] }) };
           // Call Knockback direction if Impact
-          if (data.footfallsOrder[data.trailblazeCount] === 'impact')
-            return { alertText: output.directionsKnockback!({ dir: dirToCard[dir] }) };
+          if (data.footfallsOrder[data.trailblazeCount] === 'impact') {
+            const knockbackTo = (dir + 2) % 4;
+            return { alertText: output.directionsKnockback!({ dir1: dirToCard[dir], dir2: dirToCard[knockbackTo] }) };
+          }
         }
       },
       run: (data) => data.trailblazeCount++,

--- a/ui/raidboss/data/06-ew/raid/p8s.ts
+++ b/ui/raidboss/data/06-ew/raid/p8s.ts
@@ -1012,7 +1012,7 @@ const triggerSet: TriggerSet<Data> = {
       },
     },
     {
-      id: 'P8S Blazing Footfalls Second Trailblaze Reminder',
+      id: 'P8S Blazing Footfalls Trailblaze 2',
       type: 'StartsUsing',
       netRegex: NetRegexes.startsUsing({ id: ['7106', '7107'], source: 'Hephaistos', capture: false }),
       condition: (data) => data.trailblazeCount === 1,

--- a/ui/raidboss/data/06-ew/raid/p8s.ts
+++ b/ui/raidboss/data/06-ew/raid/p8s.ts
@@ -893,7 +893,7 @@ const triggerSet: TriggerSet<Data> = {
       },
       outputStrings: {
         directions: {
-          en: 'Get pushed ${dir} => ${action}',
+          en: '${dir} Line => ${action}',
         },
         crush: {
           en: 'Crush',

--- a/ui/raidboss/data/06-ew/raid/p8s.ts
+++ b/ui/raidboss/data/06-ew/raid/p8s.ts
@@ -865,12 +865,10 @@ const triggerSet: TriggerSet<Data> = {
     },
     {
       id: 'P8S Blazing Footfalls Second Trailblaze Reminder',
-      // Reminder after first Trailblaze + Impact/Crush
-      type: 'Ability',
-      netRegex: NetRegexes.ability({ id: ['793C', '793D'], source: 'Hephaistos', capture: false }),
-      delaySeconds: 12.3, // Duration from tell cast to first Impact/Crush cast
-      durationSeconds: 6, // Keep up until Impact/Crush
-      suppressSeconds: 4.4, // Duration between second tell and last tell
+      type: 'StartsUsing',
+      netRegex: NetRegexes.startsUsing({ id: ['7106', '7107'], source: 'Hephaistos', capture: false }),
+      condition: (data) => data.trailblazeCount === 1,
+      durationSeconds: 3.9, // Keep up until Trailblaze
       infoText: (data, _matches, output) => {
         if (data.footfallsDirs[1] !== undefined && data.footfallsOrder[1] !== undefined) {
           // Check if have valid dirs

--- a/ui/raidboss/data/06-ew/raid/p8s.ts
+++ b/ui/raidboss/data/06-ew/raid/p8s.ts
@@ -951,7 +951,7 @@ const triggerSet: TriggerSet<Data> = {
       id: 'P8S Blazing Footfalls',
       // 793B Trailblaze Shown
       // 793D Quadrupedal Crush Shown
-      // 793C Quadrpedal Impact Shown
+      // 793C Quadrupedal Impact Shown
       // These are shown in the span of 8.5s
       // Blazing Footfalls takes 14.5s to complete +4s to resolve Torch Flames
       type: 'Ability',
@@ -995,7 +995,6 @@ const triggerSet: TriggerSet<Data> = {
           return output.firstTrailblaze!({
             dir: dirToCard[data.footfallsDirs[0]],
             concept: data.footfallsConcept,
-            action: output[data.footfallsOrder[0]]!(),
           });
         }
 
@@ -1014,7 +1013,7 @@ const triggerSet: TriggerSet<Data> = {
       },
       outputStrings: {
         firstTrailblaze: {
-          en: '${dir} Black Line => ${concept} => ${action}',
+          en: '${dir} Black Line => ${concept}',
         },
         secondTrailblaze: {
           en: '${dir} Black Line => ${action}',

--- a/ui/raidboss/data/06-ew/raid/p8s.ts
+++ b/ui/raidboss/data/06-ew/raid/p8s.ts
@@ -423,7 +423,7 @@ const triggerSet: TriggerSet<Data> = {
 
         // Blazing Foothills will have 4 safe spots
         // However, it will only be East or West
-        if (data.trailblazeCount == 1) {
+        if (data.trailblazeCount === 1) {
           if (safe2 === 'outsideEast')
             data.trailblazeTorchSafeZone = 'east';
           if (safe2 === 'outsideWest')

--- a/ui/raidboss/data/06-ew/raid/p8s.ts
+++ b/ui/raidboss/data/06-ew/raid/p8s.ts
@@ -1000,26 +1000,10 @@ const triggerSet: TriggerSet<Data> = {
             concept: data.footfallsConcept,
           });
         }
-
-        // Output second push direction
-        if (data.footfallsDirs[1] !== undefined && data.footfallsOrder[1] !== undefined) {
-          if (!validDirs.includes(data.footfallsDirs[1])) {
-            console.error(`Blazing Footfalls: Unexpected dirs, got ${data.footfallsDirs[1]}}`);
-            return;
-          }
-
-          return output.secondTrailblaze!({
-            dir: dirToCard[data.footfallsDirs[1]],
-            action: output[data.footfallsOrder[1]]!(),
-          });
-        }
       },
       outputStrings: {
         firstTrailblaze: {
           en: '${dir} Black Line => ${concept}',
-        },
-        secondTrailblaze: {
-          en: '${dir} Black Line => ${action}',
         },
         crush: {
           en: 'Crush',

--- a/ui/raidboss/data/06-ew/raid/p8s.ts
+++ b/ui/raidboss/data/06-ew/raid/p8s.ts
@@ -1084,6 +1084,9 @@ const triggerSet: TriggerSet<Data> = {
           trailblazeKnockbackTo: {
             en: '${dir1} Knockback to ${dir2}',
           },
+          trailblazeKnockbackSide: {
+            en: 'Knockback ${dir}',
+          },
           trailblazeCrush: {
             en: 'Run ${dir}',
           },
@@ -1140,7 +1143,7 @@ const triggerSet: TriggerSet<Data> = {
             (data.trailblazeTorchSafeZone === 'west' && dir === 2)
           ) {
             if (data.footfallsOrder[data.trailblazeCount] === 'impact')
-              return { alertText: output.trailblazeKnockbackTo!({ dir1: dirToCard[dir], dir2: output.left!() }) };
+              return { alertText: output.trailblazeKnockbackSide!({ dir: output.left!() }) };
             if (data.footfallsOrder[data.trailblazeCount] === 'crush')
               return { infoText: output.trailblazeCrush!({ dir: output.left!() }) };
           }
@@ -1149,7 +1152,7 @@ const triggerSet: TriggerSet<Data> = {
             (data.trailblazeTorchSafeZone === 'east' && dir === 2)
           ) {
             if (data.footfallsOrder[data.trailblazeCount] === 'impact')
-              return { alertText: output.trailblazeKnockbackTo!({ dir1: dirToCard[dir], dir2: output.right!() }) };
+              return { alertText: output.trailblazeKnockbackSide!({ dir: output.right!() }) };
             if (data.footfallsOrder[data.trailblazeCount] === 'crush')
               return { infoText: output.trailblazeCrush!({ dir: output.right!() }) };
           }

--- a/ui/raidboss/data/06-ew/raid/p8s.ts
+++ b/ui/raidboss/data/06-ew/raid/p8s.ts
@@ -1085,7 +1085,7 @@ const triggerSet: TriggerSet<Data> = {
             en: '${dir}',
           },
           trailblazeKnockback: {
-            en: 'Knockback ${dir1} to ${dir2}',
+            en: '${dir1} Knockback to ${dir2}',
           },
           north: Outputs.north,
           east: Outputs.east,

--- a/ui/raidboss/data/06-ew/raid/p8s.ts
+++ b/ui/raidboss/data/06-ew/raid/p8s.ts
@@ -1128,7 +1128,7 @@ const triggerSet: TriggerSet<Data> = {
               return { infoText: output.trailblazeKnockback!({ dir1: dirToCard[dir], dir2: dirToCard[data.footfallsDirs[1]] }) };
           }
 
-          // Second trailblze should call torch location
+          // Second trailblaze should call torch location
           // Dir is flipped for crush, thus matching knockback direction
           if (
             (data.trailblazeTorchSafeZone === 'east' && dir === 0) ||

--- a/ui/raidboss/data/06-ew/raid/p8s.ts
+++ b/ui/raidboss/data/06-ew/raid/p8s.ts
@@ -808,37 +808,48 @@ const triggerSet: TriggerSet<Data> = {
       },
       durationSeconds: 9,
       infoText: (data, _matches, output) => {
+        const dirToCard: { [dir: number]: string } = {
+          0: output.north!(),
+          1: output.east!(),
+          2: output.south!(),
+          3: output.west!(),
+        };
+        const validDirs = [0, 1, 2, 3];
+
+        // Output first push direction
         if (
           data.footfallsDirs[0] !== undefined &&
-          data.footfallsDirs[1] !== undefined &&
           data.footfallsOrder[0] !== undefined &&
-          data.footfallsOrder[1] !== undefined
+          data.footfallsDirs[1] === undefined &&
+          data.footfallsOrder[1] === undefined
         ) {
-          // Check if have valid dirs
-          const validDirs = [0, 1, 2, 3];
-          if (!validDirs.includes(data.footfallsDirs[0]) || !validDirs.includes(data.footfallsDirs[1])) {
-            console.error(`Blazing Footfalls: Unexpected dirs, got ${data.footfallsDirs[0]} and ${data.footfallsDirs[1]}`);
+          if (!validDirs.includes(data.footfallsDirs[0])) {
+            console.error(`Blazing Footfalls: Unexpected dirs, got ${data.footfallsDirs[0]}}`);
             return;
           }
 
-          const dirToCard: { [dir: number]: string } = {
-            0: output.north!(),
-            1: output.east!(),
-            2: output.south!(),
-            3: output.west!(),
-          };
+          return output.directions!({
+            dir: dirToCard[data.footfallsDirs[0]],
+            action: output[data.footfallsOrder[0]]!(),
+          });
+        }
+
+        // Output second push direction
+        if (data.footfallsDirs[1] !== undefined && data.footfallsOrder[1] !== undefined) {
+          if (!validDirs.includes(data.footfallsDirs[1])) {
+            console.error(`Blazing Footfalls: Unexpected dirs, got ${data.footfallsDirs[1]}}`);
+            return;
+          }
 
           return output.directions!({
-            dir1: dirToCard[data.footfallsDirs[0]],
-            action1: output[data.footfallsOrder[0]]!(),
-            dir2: dirToCard[data.footfallsDirs[1]],
-            action2: output[data.footfallsOrder[1]]!(),
+            dir: dirToCard[data.footfallsDirs[1]],
+            action: output[data.footfallsOrder[1]]!(),
           });
         }
       },
       outputStrings: {
         directions: {
-          en: 'Get pushed ${dir1} => ${action1} => Get pushed ${dir2} => ${action2}',
+          en: 'Push to ${dir} => ${action}',
         },
         crush: {
           en: 'Crush',

--- a/ui/raidboss/data/06-ew/raid/p8s.ts
+++ b/ui/raidboss/data/06-ew/raid/p8s.ts
@@ -1128,18 +1128,6 @@ const triggerSet: TriggerSet<Data> = {
               return { infoText: output.trailblazeKnockback!({ dir1: dirToCard[dir], dir2: dirToCard[data.footfallsDirs[1]] }) };
           }
 
-          // First trailblaze may require moving to new cardinal during Crush/Impact
-          if (data.trailblazeCount === 0) {
-            // Call move to next push back side if Crush
-            // Only need to call this out if there is an upcoming pushback
-            if (data.footfallsOrder[data.trailblazeCount] === 'crush')
-              return { infoText: output.trailblaze!({ dir: dirToCard[data.footfallsDirs[1]] }) };
-
-            // Call future push location if knockback
-            if (data.footfallsOrder[data.trailblazeCount] === 'impact')
-              return { infoText: output.trailblazeKnockback!({ dir1: dirToCard[dir], dir2: dirToCard[data.footfallsDirs[1]] }) };
-          }
-
           // Second trailblze should call torch location
           if (data.footfallsOrder[data.trailblazeCount] === 'impact') {
             if (

--- a/ui/raidboss/data/06-ew/raid/p8s.ts
+++ b/ui/raidboss/data/06-ew/raid/p8s.ts
@@ -1106,18 +1106,18 @@ const triggerSet: TriggerSet<Data> = {
             // Call move to next push back side if Crush
             // Only need to call this out if there is an upcoming pushback
             if (data.footfallsOrder[data.trailblazeCount] === 'crush')
-              return { infoText: output.directionsPush!({ dir: dirToCard[data.footfallsDirs[1]] }) };
+              return { infoText: output.trailblaze!({ dir: dirToCard[data.footfallsDirs[1]] }) };
 
             // Call future push location if knockback
             if (data.footfallsOrder[data.trailblazeCount] === 'impact')
-              return { infoText: output.directionsKnockback!({ dir1: dirToCard[dir], dir: dirToCard[data.footfallsDirs[1]] }) };
+              return { infoText: output.trailblazeKnockback!({ dir1: dirToCard[dir], dir: dirToCard[data.footfallsDirs[1]] }) };
           }
 
           // Second trailblze should call torch location
           if (data.footfallsOrder[data.trailblazeCount] === 'impact') {
             // TODO: Fix this to be where torch safe spot is
             const knockbackTo = (dir + 2) % 4;
-            return { alertText: output.directionsKnockback!({ dir1: dirToCard[dir], dir2: dirToCard[knockbackTo] }) };
+            return { alertText: output.trailblazeKnockback!({ dir1: dirToCard[dir], dir2: dirToCard[knockbackTo] }) };
           }
         }
       },

--- a/ui/raidboss/data/06-ew/raid/p8s.ts
+++ b/ui/raidboss/data/06-ew/raid/p8s.ts
@@ -70,8 +70,8 @@ const triggerSet: TriggerSet<Data> = {
       flareTargets: [],
       upliftCounter: 0,
       ventIds: [],
-      footfallsDirs: [];
-      footfallsOrder: [];
+      footfallsDirs: [],
+      footfallsOrder: [],
       firstSnakeOrder: {},
       firstSnakeDebuff: {},
       secondSnakeGazeFirst: {},

--- a/ui/raidboss/data/06-ew/raid/p8s.ts
+++ b/ui/raidboss/data/06-ew/raid/p8s.ts
@@ -199,7 +199,7 @@ const triggerSet: TriggerSet<Data> = {
       // 7915 normally
       // 7916 during Blazing Footfalls
       netRegex: NetRegexes.startsUsing({ id: '7917', source: 'Hephaistos', capture: false }),
-      durationSeconds: 20,
+      durationSeconds: 12,
       infoText: (_data, _matches, output) => output.healerGroups!(),
       run: (data, _matches, output) => data.footfallsConcept = output.healerGroups!(),
       outputStrings: {
@@ -212,7 +212,7 @@ const triggerSet: TriggerSet<Data> = {
       // 7915 normally
       // 7916 during Blazing Footfalls
       netRegex: NetRegexes.startsUsing({ id: '7916', source: 'Hephaistos', capture: false }),
-      durationSeconds: 20,
+      durationSeconds: 12,
       infoText: (_data, _matches, output) => output.text!(),
       run: (data, _matches, output) => data.footfallsConcept = output.text!(),
       outputStrings: {

--- a/ui/raidboss/data/06-ew/raid/p8s.ts
+++ b/ui/raidboss/data/06-ew/raid/p8s.ts
@@ -1084,6 +1084,9 @@ const triggerSet: TriggerSet<Data> = {
           trailblazeKnockbackTo: {
             en: '${dir1} Knockback to ${dir2}',
           },
+          trailblazeCrush: {
+            en: 'Run ${dir}',
+          },
           left: Outputs.left,
           right: Outputs.right,
           north: Outputs.north,
@@ -1139,7 +1142,7 @@ const triggerSet: TriggerSet<Data> = {
             if (data.footfallsOrder[data.trailblazeCount] === 'impact')
               return { alertText: output.trailblazeKnockbackTo!({ dir1: dirToCard[dir], dir2: output.left!() }) };
             if (data.footfallsOrder[data.trailblazeCount] === 'crush')
-              return { infoText: output.left!() };
+              return { infoText: output.trailblazeCrush!({ dir: output.left!() }) };
           }
           if (
             (data.trailblazeTorchSafeZone === 'west' && dir === 0) ||
@@ -1148,7 +1151,7 @@ const triggerSet: TriggerSet<Data> = {
             if (data.footfallsOrder[data.trailblazeCount] === 'impact')
               return { alertText: output.trailblazeKnockbackTo!({ dir1: dirToCard[dir], dir2: output.right!() }) };
             if (data.footfallsOrder[data.trailblazeCount] === 'crush')
-              return { infoText: output.right!() };
+              return { infoText: output.trailblazeCrush!({ dir: output.right!() }) };
           }
           // Unable to determine direction, output only knockback
           if (data.footfallsOrder[data.trailblazeCount] === 'impact')

--- a/ui/raidboss/data/06-ew/raid/p8s.ts
+++ b/ui/raidboss/data/06-ew/raid/p8s.ts
@@ -31,6 +31,7 @@ export interface Data extends RaidbossData {
   gorgons: NetMatches['AddedCombatant'][];
   gorgonCount: number;
   seenSnakeIllusoryCreation?: boolean;
+  footfallsConcept?: string;
   footfallsDirs: number[];
   footfallsOrder: string[];
   trailblazeCount: number;
@@ -198,6 +199,7 @@ const triggerSet: TriggerSet<Data> = {
       netRegex: NetRegexes.startsUsing({ id: '7917', source: 'Hephaistos', capture: false }),
       durationSeconds: 20,
       infoText: (_data, _matches, output) => output.healerGroups!(),
+      run: (data, _matches, output) => data.footfallsConcept = output.text!(),
       outputStrings: {
         healerGroups: Outputs.healerGroups,
       },
@@ -210,6 +212,7 @@ const triggerSet: TriggerSet<Data> = {
       netRegex: NetRegexes.startsUsing({ id: '7916', source: 'Hephaistos', capture: false }),
       durationSeconds: 20,
       infoText: (_data, _matches, output) => output.text!(),
+      run: (data, _matches, output) => data.footfallsConcept = output.text!(),
       outputStrings: {
         text: {
           en: 'Partner Stacks',
@@ -921,8 +924,9 @@ const triggerSet: TriggerSet<Data> = {
             return;
           }
 
-          return output.directions!({
+          return output.firstTrailblaze!({
             dir: dirToCard[data.footfallsDirs[0]],
+            concept: data.footfallsConcept,
             action: output[data.footfallsOrder[0]]!(),
           });
         }
@@ -934,15 +938,18 @@ const triggerSet: TriggerSet<Data> = {
             return;
           }
 
-          return output.directions!({
+          return output.secondTrailblaze!({
             dir: dirToCard[data.footfallsDirs[1]],
             action: output[data.footfallsOrder[1]]!(),
           });
         }
       },
       outputStrings: {
-        directions: {
-          en: 'Push to ${dir} => ${action}',
+        firstTrailblaze: {
+          en: '${dir} Black Line => ${concept} => ${action}',
+        },
+        secondTrailblaze: {
+          en: '${dir} Black Line => ${action}',
         },
         crush: {
           en: 'Crush',
@@ -976,15 +983,15 @@ const triggerSet: TriggerSet<Data> = {
             3: output.west!(),
           };
 
-          return output.directions!({
+          return output.trailblaze!({
             dir: dirToCard[data.footfallsDirs[1]],
             action: output[data.footfallsOrder[1]]!(),
           });
         }
       },
       outputStrings: {
-        directions: {
-          en: '${dir} Line => ${action}',
+        trailblaze: {
+          en: '${dir} Black Line => ${action}',
         },
         crush: {
           en: 'Crush',
@@ -1006,10 +1013,10 @@ const triggerSet: TriggerSet<Data> = {
       response: (data, _matches, output) => {
         // cactbot-builtin-response
         output.responseOutputStrings = {
-          directionsPush: {
+          trailblaze: {
             en: '${dir}',
           },
-          directionsKnockback: {
+          trailblazeKnockback: {
             en: 'Knockback ${dir1} to ${dir2}',
           },
           north: Outputs.north,
@@ -1047,11 +1054,11 @@ const triggerSet: TriggerSet<Data> = {
           // Call move to next push back side if Crush
           // Only need to call this out if there is an upcoming pushback
           if (data.trailblazeCount === 0 && data.footfallsOrder[data.trailblazeCount] === 'crush')
-            return { infoText: output.directionsPush!({ dir: dirToCard[data.footfallsDirs[1]] }) };
+            return { infoText: output.trailblaze!({ dir: dirToCard[data.footfallsDirs[1]] }) };
           // Call Knockback direction if Impact
           if (data.footfallsOrder[data.trailblazeCount] === 'impact') {
             const knockbackTo = (dir + 2) % 4;
-            return { alertText: output.directionsKnockback!({ dir1: dirToCard[dir], dir2: dirToCard[knockbackTo] }) };
+            return { alertText: output.trailblazeKnockback!({ dir1: dirToCard[dir], dir2: dirToCard[knockbackTo] }) };
           }
         }
       },

--- a/ui/raidboss/data/06-ew/raid/p8s.ts
+++ b/ui/raidboss/data/06-ew/raid/p8s.ts
@@ -1081,13 +1081,13 @@ const triggerSet: TriggerSet<Data> = {
           trailblazeKnockback: {
             en: '${dir} Knockback',
           },
-          trailblazeKnockbackTo: {
-            en: '${dir1} Knockback to ${dir2}',
+          trailblazeKnockbackToDir: {
+            en: '${dir1} Knockback ${dir2}',
           },
           trailblazeKnockbackSide: {
             en: 'Knockback ${dir}',
           },
-          trailblazeCrush: {
+          trailblazeCrushSide: {
             en: 'Run ${dir}',
           },
           left: Outputs.left,
@@ -1133,7 +1133,7 @@ const triggerSet: TriggerSet<Data> = {
 
             // Call future push location if knockback
             if (data.footfallsOrder[data.trailblazeCount] === 'impact')
-              return { infoText: output.trailblazeKnockbackTo!({ dir1: dirToCard[dir], dir2: dirToCard[data.footfallsDirs[1]] }) };
+              return { infoText: output.trailblazeKnockbackToDir!({ dir1: dirToCard[dir], dir2: dirToCard[data.footfallsDirs[1]] }) };
           }
 
           // Second trailblaze should call torch location
@@ -1145,7 +1145,7 @@ const triggerSet: TriggerSet<Data> = {
             if (data.footfallsOrder[data.trailblazeCount] === 'impact')
               return { alertText: output.trailblazeKnockbackSide!({ dir: output.left!() }) };
             if (data.footfallsOrder[data.trailblazeCount] === 'crush')
-              return { infoText: output.trailblazeCrush!({ dir: output.left!() }) };
+              return { infoText: output.trailblazeCrushSide!({ dir: output.left!() }) };
           }
           if (
             (data.trailblazeTorchSafeZone === 'west' && dir === 0) ||
@@ -1154,7 +1154,7 @@ const triggerSet: TriggerSet<Data> = {
             if (data.footfallsOrder[data.trailblazeCount] === 'impact')
               return { alertText: output.trailblazeKnockbackSide!({ dir: output.right!() }) };
             if (data.footfallsOrder[data.trailblazeCount] === 'crush')
-              return { infoText: output.trailblazeCrush!({ dir: output.right!() }) };
+              return { infoText: output.trailblazeCrushSide!({ dir: output.right!() }) };
           }
           // Unable to determine direction, output only knockback
           if (data.footfallsOrder[data.trailblazeCount] === 'impact')

--- a/ui/raidboss/data/06-ew/raid/p8s.ts
+++ b/ui/raidboss/data/06-ew/raid/p8s.ts
@@ -1129,36 +1129,28 @@ const triggerSet: TriggerSet<Data> = {
           }
 
           // Second trailblze should call torch location
-          if (data.footfallsOrder[data.trailblazeCount] === 'impact') {
-            if (
-              (data.trailblazeTorchSafeZone === 'east' && dir === 0) ||
-              (data.trailblazeTorchSafeZone === 'west' && dir === 2)
-            )
+          // Dir is flipped for crush, thus matching knockback direction
+          if (
+            (data.trailblazeTorchSafeZone === 'east' && dir === 0) ||
+            (data.trailblazeTorchSafeZone === 'west' && dir === 2)
+          ) {
+           if (data.footfallsOrder[data.trailblazeCount] === 'impact')
               return { alertText: output.trailblazeKnockbackTo!({ dir1: dirToCard[dir], dir2: output.left!() }) };
-            if (
-              (data.trailblazeTorchSafeZone === 'west' && dir === 0) ||
-              (data.trailblazeTorchSafeZone === 'east' && dir === 2)
-            )
-              return { alertText: output.trailblazeKnockbackTo!({ dir1: dirToCard[dir], dir2: output.right!() }) };
-
-            // Unable to determine direction, output only knockback
-            return { alertText: output.trailblazeKnockback!({ dir1: dirToCard[dir] }) };
-          }
-
-          // Output torch location during crush
-          if (data.footfallsOrder[data.trailblazeCount] === 'crush' && data.trailblazeTorchSafeZone) {
-            if (
-              (data.trailblazeTorchSafeZone === 'east' && dir === 0) ||
-              (data.trailblazeTorchSafeZone === 'west' && dir === 2)
-            )
-              return { infoText: output.right!() };
-            if (
-              (data.trailblazeTorchSafeZone === 'west' && dir === 0) ||
-              (data.trailblazeTorchSafeZone === 'east' && dir === 2)
-            )
+            if (data.footfallsOrder[data.trailblazeCount] === 'crush')
               return { infoText: output.left!() };
-            // Unable to determine direction, no output
           }
+          if (
+            (data.trailblazeTorchSafeZone === 'west' && dir === 0) ||
+            (data.trailblazeTorchSafeZone === 'east' && dir === 2)
+          ) {
+            if (data.footfallsOrder[data.trailblazeCount] === 'impact')
+              return { alertText: output.trailblazeKnockbackTo!({ dir1: dirToCard[dir], dir2: output.right!() }) };
+            if (data.footfallsOrder[data.trailblazeCount] === 'crush')
+              return { infoText: output.right!() };
+          }
+          // Unable to determine direction, output only knockback
+          if (data.footfallsOrder[data.trailblazeCount] === 'impact')
+            return { alertText: output.trailblazeKnockback!({ dir1: dirToCard[dir] }) };
         }
       },
       run: (data) => data.trailblazeCount++,

--- a/ui/raidboss/data/06-ew/raid/p8s.ts
+++ b/ui/raidboss/data/06-ew/raid/p8s.ts
@@ -866,8 +866,8 @@ const triggerSet: TriggerSet<Data> = {
       // Reminder after first Trailblaze + Impact/Crush
       type: 'Ability',
       netRegex: NetRegexes.ability({ id: ['793C', '793D'], source: 'Hephaistos', capture: false }),
-      delaySeconds: 12.3, // Duration between second tell and second mechanic
-      durationSeconds: 6, // Duration between second mechanic and fourth mechanic
+      delaySeconds: 12.3, // Duration from tell cast to first Impact/Crush cast
+      durationSeconds: 6, // Keep up until Impact/Crush
       suppressSeconds: 4.4, // Duration between second tell and last tell
       infoText: (data, _matches, output) => {
         if (data.footfallsDirs[1] !== undefined && data.footfallsOrder[1] !== undefined) {

--- a/ui/raidboss/data/06-ew/raid/p8s.ts
+++ b/ui/raidboss/data/06-ew/raid/p8s.ts
@@ -1101,14 +1101,23 @@ const triggerSet: TriggerSet<Data> = {
             3: output.west!(),
           };
 
-          // Call move to next push back side if Crush
-          // Only need to call this out if there is an upcoming pushback
-          if (data.trailblazeCount === 0 && data.footfallsOrder[data.trailblazeCount] === 'crush')
-            return { infoText: output.trailblaze!({ dir: dirToCard[data.footfallsDirs[1]] }) };
-          // Call Knockback direction if Impact
+          // First trailblaze may require moving to new cardinal during Crush/Impact
+          if (data.trailblazeCount === 0) {
+            // Call move to next push back side if Crush
+            // Only need to call this out if there is an upcoming pushback
+            if (data.footfallsOrder[data.trailblazeCount] === 'crush')
+              return { infoText: output.directionsPush!({ dir: dirToCard[data.footfallsDirs[1]] }) };
+
+            // Call future push location if knockback
+            if (data.footfallsOrder[data.trailblazeCount] === 'impact')
+              return { infoText: output.directionsKnockback!({ dir1: dirToCard[dir], dir: dirToCard[data.footfallsDirs[1]] }) };
+          }
+
+          // Second trailblze should call torch location
           if (data.footfallsOrder[data.trailblazeCount] === 'impact') {
+            // TODO: Fix this to be where torch safe spot is
             const knockbackTo = (dir + 2) % 4;
-            return { alertText: output.trailblazeKnockback!({ dir1: dirToCard[dir], dir2: dirToCard[knockbackTo] }) };
+            return { alertText: output.directionsKnockback!({ dir1: dirToCard[dir], dir2: dirToCard[knockbackTo] }) };
           }
         }
       },

--- a/ui/raidboss/data/06-ew/raid/p8s.ts
+++ b/ui/raidboss/data/06-ew/raid/p8s.ts
@@ -1110,7 +1110,7 @@ const triggerSet: TriggerSet<Data> = {
 
             // Call future push location if knockback
             if (data.footfallsOrder[data.trailblazeCount] === 'impact')
-              return { infoText: output.trailblazeKnockback!({ dir1: dirToCard[dir], dir: dirToCard[data.footfallsDirs[1]] }) };
+              return { infoText: output.trailblazeKnockback!({ dir1: dirToCard[dir], dir2: dirToCard[data.footfallsDirs[1]] }) };
           }
 
           // Second trailblze should call torch location

--- a/ui/raidboss/data/06-ew/raid/p8s.ts
+++ b/ui/raidboss/data/06-ew/raid/p8s.ts
@@ -1005,10 +1005,6 @@ const triggerSet: TriggerSet<Data> = {
         firstTrailblaze: {
           en: '${dir} Black Line => ${concept}',
         },
-        crush: {
-          en: 'Crush',
-        },
-        impact: Outputs.knockback,
         north: Outputs.north,
         east: Outputs.east,
         south: Outputs.south,

--- a/ui/raidboss/data/06-ew/raid/p8s.ts
+++ b/ui/raidboss/data/06-ew/raid/p8s.ts
@@ -1076,7 +1076,7 @@ const triggerSet: TriggerSet<Data> = {
         // cactbot-builtin-response
         output.responseOutputStrings = {
           trailblaze: {
-            en: '${dir}',
+            en: 'Wait => ${dir}',
           },
           trailblazeKnockback: {
             en: '${dir} Knockback',

--- a/ui/raidboss/data/06-ew/raid/p8s.ts
+++ b/ui/raidboss/data/06-ew/raid/p8s.ts
@@ -802,8 +802,10 @@ const triggerSet: TriggerSet<Data> = {
           data.footfallsOrder.push('impact');
           data.footfallsDirs.push(dir);
         }
-        data.footfallsOrder.push('crush');
-        data.footfallsDirs.push((dir + 2) % 4);
+        else {
+          data.footfallsOrder.push('crush');
+          data.footfallsDirs.push((dir + 2) % 4);
+        }
       },
       durationSeconds: 9,
       infoText: (data, _matches, output) => {

--- a/ui/raidboss/data/06-ew/raid/p8s.ts
+++ b/ui/raidboss/data/06-ew/raid/p8s.ts
@@ -199,7 +199,7 @@ const triggerSet: TriggerSet<Data> = {
       netRegex: NetRegexes.startsUsing({ id: '7917', source: 'Hephaistos', capture: false }),
       durationSeconds: 20,
       infoText: (_data, _matches, output) => output.healerGroups!(),
-      run: (data, _matches, output) => data.footfallsConcept = output.text!(),
+      run: (data, _matches, output) => data.footfallsConcept = output.healerGroups!(),
       outputStrings: {
         healerGroups: Outputs.healerGroups,
       },

--- a/ui/raidboss/data/06-ew/raid/p8s.ts
+++ b/ui/raidboss/data/06-ew/raid/p8s.ts
@@ -1127,7 +1127,7 @@ const triggerSet: TriggerSet<Data> = {
 
             // Call future push location if knockback
             if (data.footfallsOrder[data.trailblazeCount] === 'impact')
-              return { infoText: output.trailblazeKnockback!({ dir1: dirToCard[dir], dir2: dirToCard[data.footfallsDirs[1]] }) };
+              return { infoText: output.trailblazeKnockbackTo!({ dir1: dirToCard[dir], dir2: dirToCard[data.footfallsDirs[1]] }) };
           }
 
           // Second trailblaze should call torch location

--- a/ui/raidboss/data/06-ew/raid/p8s.ts
+++ b/ui/raidboss/data/06-ew/raid/p8s.ts
@@ -799,8 +799,8 @@ const triggerSet: TriggerSet<Data> = {
         const dir = Math.round(2 - 2 * Math.atan2(x, y) / Math.PI) % 4;
 
         if (matches.id === '793C') {
-            data.footfallsOrder.push('impact');
-            data.footfallsDirs.push(dir);
+          data.footfallsOrder.push('impact');
+          data.footfallsDirs.push(dir);
         }
         data.footfallsOrder.push('crush');
         data.footfallsDirs.push((dir + 2) % 4);
@@ -853,7 +853,7 @@ const triggerSet: TriggerSet<Data> = {
       id: 'P8S Blazing Footfalls Reminder',
       // Reminder after first Trailblaze + Impact/Crush
       type: 'Ability',
-      netRegex: NetRegexes.ability({ id: ['793C', '793D'], source: 'Hephaistos', capture: false}),
+      netRegex: NetRegexes.ability({ id: ['793C', '793D'], source: 'Hephaistos', capture: false }),
       delaySeconds: 12.3, // Duration between second tell and second mechanic
       durationSeconds: 6, // Duration between second mechanic and fourth mechanic
       suppressSeconds: 4.4, // Duration between second tell and last tell

--- a/ui/raidboss/data/06-ew/raid/p8s.ts
+++ b/ui/raidboss/data/06-ew/raid/p8s.ts
@@ -801,8 +801,7 @@ const triggerSet: TriggerSet<Data> = {
         if (matches.id === '793C') {
           data.footfallsOrder.push('impact');
           data.footfallsDirs.push(dir);
-        }
-        else {
+        } else {
           data.footfallsOrder.push('crush');
           data.footfallsDirs.push((dir + 2) % 4);
         }

--- a/ui/raidboss/data/06-ew/raid/p8s.ts
+++ b/ui/raidboss/data/06-ew/raid/p8s.ts
@@ -1134,7 +1134,7 @@ const triggerSet: TriggerSet<Data> = {
             (data.trailblazeTorchSafeZone === 'east' && dir === 0) ||
             (data.trailblazeTorchSafeZone === 'west' && dir === 2)
           ) {
-           if (data.footfallsOrder[data.trailblazeCount] === 'impact')
+            if (data.footfallsOrder[data.trailblazeCount] === 'impact')
               return { alertText: output.trailblazeKnockbackTo!({ dir1: dirToCard[dir], dir2: output.left!() }) };
             if (data.footfallsOrder[data.trailblazeCount] === 'crush')
               return { infoText: output.left!() };

--- a/ui/raidboss/data/06-ew/raid/p8s.ts
+++ b/ui/raidboss/data/06-ew/raid/p8s.ts
@@ -424,9 +424,11 @@ const triggerSet: TriggerSet<Data> = {
         // Blazing Foothills will have 4 safe spots
         // However, it will only be East or West
         if (data.trailblazeCount === 1) {
-          if (safe2 === 'outsideEast')
+          if (safeKeys.length !== 3)
+            return;
+          if (safe0 === 'cornerNE' && safe1 === 'cornerSE' && safe2 === 'outsideEast')
             data.trailblazeTorchSafeZone = 'east';
-          if (safe2 === 'outsideWest')
+          if (safe0 === 'cornerNW' && safe1 === 'cornerSW' && safe2 === 'outsideWest')
             data.trailblazeTorchSafeZone = 'west';
           return;
         }


### PR DESCRIPTION
Adds a callout for all and a reminder.

It looked like the targetX and targetY data of the 793D and 793C spells could be used to resolve this without OverlayPlugin.