### PR TITLE
raidboss: Fix P6s Cachexia 1 timeline

### DIFF
--- a/ui/raidboss/data/06-ew/raid/p6s.txt
+++ b/ui/raidboss/data/06-ew/raid/p6s.txt
@@ -68,12 +68,12 @@ hideall "--sync--"
 305.1 "Choros Ixou 2" sync / 1[56]:[^:]*:Hegemone:(7881|7882|7883|7884):/
 311.8 "--sync--" sync / 1[56]:[^:]*:Hegemone:784C:/
 317.6 "Cachexia" sync / 1[56]:[^:]*:Hegemone:7876:/ window 30,30
-326.6 "Aetheronecrosis 1" sync / 1[56]:[^:]*:Hegemone:7877:/
-330.6 "Aetheronecrosis 2" sync / 1[56]:[^:]*:Hegemone:7877:/
-334.6 "Aetheronecrosis 3" sync / 1[56]:[^:]*:Hegemone:7877:/
+326.6 "Aetheronecrosis 1" #sync / 1[56]:[^:]*:Hegemone:7877:/
+330.6 "Aetheronecrosis 2" #sync / 1[56]:[^:]*:Hegemone:7877:/
+334.6 "Aetheronecrosis 3" #sync / 1[56]:[^:]*:Hegemone:7877:/
 334.8 "Dual Predation" sync / 1[56]:[^:]*:Hegemone:7878:/
 335.8 "Predation 1" sync / 1[56]:[^:]*:Hegemone:(787A|787B):/
-338.7 "Aetheronecrosis 4" sync / 1[56]:[^:]*:Hegemone:7877:/
+338.7 "Aetheronecrosis 4" #sync / 1[56]:[^:]*:Hegemone:7877:/
 339.9 "Predation 2" sync / 1[56]:[^:]*:Hegemone:(787A|787B):/
 343.9 "Predation 3" sync / 1[56]:[^:]*:Hegemone:(787A|787B):/
 347.9 "Predation 4" sync / 1[56]:[^:]*:Hegemone:(787A|787B):/


### PR DESCRIPTION
```
334.6 "Aetheronecrosis 3" sync / 1[56]:[^:]*:Hegemone:7877:/
334.8 "Dual Predation" sync / 1[56]:[^:]*:Hegemone:7878:/
335.8 "Predation 1" sync / 1[56]:[^:]*:Hegemone:(787A|787B):/
338.7 "Aetheronecrosis 4" sync / 1[56]:[^:]*:Hegemone:7877:/
```

When I initially wrote this, I assumed that since every ability was more than 2.5s apart, everything was fine. However, Aetheronecrosis 3 looks ahead enough to sync with an early fourth usage immediately after Predation 1. Because of this, it's possible to be behind by about 3-4 seconds during the rest of the Predation usages. It's not always going to happen, but when it does, it looks like this:

```
334.568: Matched entry: 334.6 Aetheronecrosis 3 (+0.032s)
334.865: Matched entry: 334.8 Dual Predation (-0.065s)
335.737: Matched entry: 335.8 Predation 1 (+0.063s)
336.468: Matched entry: 334.6 Aetheronecrosis 3 (-1.868s)
336.468: Matched entry: 338.7 Aetheronecrosis 4 (+2.232s)
342.087: Matched entry: 339.9 Predation 2 (-2.187s)
342.087: Matched entry: 343.9 Predation 3 (+1.813s)
347.907: Matched entry: 347.9 Predation 4 (-0.007s)
388.405: Matched entry: 384.3 Hemitheos's Dark IV (-4.105s)
    Warning: 40.505s since last sync
    Missed sync: Ptera Ixou at 356.9 (last seen at 360.96299999999997)
    Missed sync: Synergy at 372.2 (last seen at 376.289)
394.949: Matched entry: 395.0 Aetheric Polyominoid (+0.051s)
```

It is technically only necessary to remove the syncs from 3/4, but stylistically I felt that it made more sense to remove them all and let the Predations handle any necessary syncs.

(Stuff like this is why we add those giant 30,30 safety syncs all over, specifically to keep this kind of thing from breaking the entire encounter!)