### PR TITLE
raidboss: p8s temporarily disable crush/impact direction

### DIFF
--- a/ui/raidboss/data/06-ew/raid/p8s.ts
+++ b/ui/raidboss/data/06-ew/raid/p8s.ts
@@ -913,6 +913,15 @@ const triggerSet: TriggerSet<Data> = {
         if (data.crushImpactSafeZone === undefined)
           return;
 
+        // BEGIN TEMPORARY HACK
+        // This trigger calls out the wrong directions sometimes, so disable until
+        // it can be fixed.
+        if (matches.id === '7A05')
+          return output.crush!();
+        else if (matches.id === '7A04')
+          return output.impact!();
+        // END TEMPORARY HACK
+
         // Check if dir is valid, else output generic
         const dir = dirs[data.crushImpactSafeZone];
         if (dir === undefined) {


### PR DESCRIPTION
Just to avoid incorrect directions, temporarily call out just away/follow.

See: #4835