### PR TITLE
raidboss: p8s fix initial impact/crush

### DIFF
--- a/ui/raidboss/data/06-ew/raid/p8s.ts
+++ b/ui/raidboss/data/06-ew/raid/p8s.ts
@@ -904,31 +904,17 @@ const triggerSet: TriggerSet<Data> = {
         data.crushImpactSafeZone = cardinal;
       },
       infoText: (data, matches, output) => {
-        const dirs: { [dir: number]: string } = {
-          0: 'north',
-          1: 'east',
-          2: 'south',
-          3: 'west',
-        };
-        if (data.crushImpactSafeZone === undefined)
-          return;
-
-        // BEGIN TEMPORARY HACK
-        // This trigger calls out the wrong directions sometimes, so disable until
-        // it can be fixed.
-        if (matches.id === '7A05')
-          return output.crush!();
-        else if (matches.id === '7A04')
-          return output.impact!();
-        // END TEMPORARY HACK
-
-        // Check if dir is valid, else output generic
-        const dir = dirs[data.crushImpactSafeZone];
-        if (dir === undefined) {
-          if (matches.id === '7A05')
+        if (data.crushImpactSafeZone === undefined) {
+          // Failed to get data, return generic result
+           if (matches.id === '7A05')
             return output.crush!();
           return output.impact!();
         }
+
+        // Boss casts 7108 which teleports him middle with heading North
+        // Boss then does not turn until or after Crush/Impact cast, thus
+        // if heading is not 0, then he is turning south
+        const dir = (data.crushImpactSafeZone === 0 ? 'north' : 'south');
 
         if (matches.id === '7A05')
           return output.crushDir!({ dir: output[dir]!() });
@@ -955,11 +941,8 @@ const triggerSet: TriggerSet<Data> = {
           ja: '近づく',
           ko: '보스 따라가기',
         },
-        unknown: Outputs.unknown,
         north: Outputs.north,
-        east: Outputs.east,
         south: Outputs.south,
-        west: Outputs.west,
       },
     },
     {

--- a/ui/raidboss/data/06-ew/raid/p8s.ts
+++ b/ui/raidboss/data/06-ew/raid/p8s.ts
@@ -903,7 +903,8 @@ const triggerSet: TriggerSet<Data> = {
         const epsilon = 0.1;
         if (Math.abs(hephaistos.Heading - 3.14) < epsilon)
           data.crushImpactSafeZone = (matches.id === '7A05' ? 'south' : 'north');
-        else // Boss will be facing South
+        // Boss will be facing South
+        else
           data.crushImpactSafeZone = (matches.id === '7A05' ? 'north' : 'south');
       },
       infoText: (data, matches, output) => {

--- a/ui/raidboss/data/06-ew/raid/p8s.ts
+++ b/ui/raidboss/data/06-ew/raid/p8s.ts
@@ -906,9 +906,9 @@ const triggerSet: TriggerSet<Data> = {
       infoText: (data, matches, output) => {
         if (data.crushImpactSafeZone === undefined) {
           // Failed to get data, return generic result
-           if (matches.id === '7A05')
+          if (matches.id === '7A05')
             return output.crush!();
-           return output.impact!();
+          return output.impact!();
         }
 
         // Boss casts 7108 which teleports him middle with heading North

--- a/ui/raidboss/data/06-ew/raid/p8s.ts
+++ b/ui/raidboss/data/06-ew/raid/p8s.ts
@@ -908,7 +908,7 @@ const triggerSet: TriggerSet<Data> = {
           // Failed to get data, return generic result
            if (matches.id === '7A05')
             return output.crush!();
-          return output.impact!();
+           return output.impact!();
         }
 
         // Boss casts 7108 which teleports him middle with heading North

--- a/ui/raidboss/data/06-ew/raid/p8s.ts
+++ b/ui/raidboss/data/06-ew/raid/p8s.ts
@@ -900,7 +900,8 @@ const triggerSet: TriggerSet<Data> = {
 
         // Boss faces 3.14159274 when North
         // Flip callout if crush (7A05)
-        if (hephaistos.Heading >= 3.14)
+        const epsilon = 0.1;
+        if (Math.abs(hephaistos.Heading - 3.14) < epsilon)
           data.crushImpactSafeZone = (matches.id === '7A05' ? 'south' : 'north');
         else // Boss will be facing South
           data.crushImpactSafeZone = (matches.id === '7A05' ? 'north' : 'south');


### PR DESCRIPTION
Originally needed delay to get correct data even after OverlayPlugin update, however it turns out this mechanic only has results of 0 or 1 and since the boss starts at 0, we can safely assume non-0 is south.

Fixes #4835