### PR TITLE
raidboss: p8s Limitless Desolation Callouts

### DIFF
--- a/ui/raidboss/data/06-ew/raid/p8s.ts
+++ b/ui/raidboss/data/06-ew/raid/p8s.ts
@@ -45,6 +45,9 @@ export interface Data extends RaidbossData {
   concept: { [name: string]: InitialConcept };
   splicer: { [name: string]: Splicer };
   alignmentTargets: string[];
+  burstCounter: number;
+  myTower?: number;
+  flareCounter: number;
   inverseMagics: { [name: string]: boolean };
   deformationTargets: string[];
 }
@@ -87,6 +90,8 @@ const triggerSet: TriggerSet<Data> = {
       concept: {},
       splicer: {},
       alignmentTargets: [],
+      burstCounter: 0,
+      flareCounter: 0,
       inverseMagics: {},
       deformationTargets: [],
     };
@@ -1295,6 +1300,56 @@ const triggerSet: TriggerSet<Data> = {
       run: (data) => {
         data.concept = {};
         data.splicer = {};
+      },
+    },
+    {
+      id: 'P8S Tyrant\'s Fire III Counter',
+      type: 'Ability',
+      netRegex: NetRegexes.ability({ id: '75F0', source: 'Hephaistos', capture: false }),
+      preRun: (data) => data.burstCounter++,
+      suppressSeconds: 1,
+      sound: '',
+      infoText: (data, _matches, output) => output.text!({ num: data.burstCounter }),
+      tts: null,
+      outputStrings: {
+        text: {
+          en: '${num}',
+          de: '${num}',
+          fr: '${num}',
+          ja: '${num}',
+          cn: '${num}',
+          ko: '${num}',
+        },
+      },
+    },
+    {
+      id: 'P8S Tyrant\'s Fire III Bait then Tower',
+      type: 'Ability',
+      netRegex: NetRegexes.ability({ id: '75F0', source: 'Hephaistos' }),
+      condition: Conditions.targetIsYou(),
+      durationSeconds: 7.9,
+      infoText: (data, _matches, output) => output.text!({ num: data.burstCounter }),
+      run: (data) => data.myTower = data.burstCounter,
+      outputStrings: {
+        text: {
+          en: '${num}: Bait near Tower ${num}',
+        },
+      },
+    },
+    {
+      id: 'P8S Tyrant\'s Flare II Soak Tower',
+      type: 'StartsUsing',
+      netRegex: NetRegexes.startsUsing({ id: '7A88', source: 'Hephaistos', capture: false }),
+      preRun: (data) => data.flareCounter++,
+      suppressSeconds: 1,
+      alertText: (data, _matches, output) => {
+        if (data.flareCounter === data.myTower)
+          return output.text!({ num: data.myTower });
+      },
+      outputStrings: {
+        text: {
+          en: 'Soak Tower ${num}',
+        },
       },
     },
     {

--- a/ui/raidboss/data/06-ew/raid/p8s.ts
+++ b/ui/raidboss/data/06-ew/raid/p8s.ts
@@ -1303,56 +1303,6 @@ const triggerSet: TriggerSet<Data> = {
       },
     },
     {
-      id: 'P8S Tyrant\'s Fire III Counter',
-      type: 'Ability',
-      netRegex: NetRegexes.ability({ id: '75F0', source: 'Hephaistos', capture: false }),
-      preRun: (data) => data.burstCounter++,
-      suppressSeconds: 1,
-      sound: '',
-      infoText: (data, _matches, output) => output.text!({ num: data.burstCounter }),
-      tts: null,
-      outputStrings: {
-        text: {
-          en: '${num}',
-          de: '${num}',
-          fr: '${num}',
-          ja: '${num}',
-          cn: '${num}',
-          ko: '${num}',
-        },
-      },
-    },
-    {
-      id: 'P8S Tyrant\'s Fire III Bait then Tower',
-      type: 'Ability',
-      netRegex: NetRegexes.ability({ id: '75F0', source: 'Hephaistos' }),
-      condition: Conditions.targetIsYou(),
-      durationSeconds: 7.9,
-      infoText: (data, _matches, output) => output.text!({ num: data.burstCounter }),
-      run: (data) => data.myTower = data.burstCounter,
-      outputStrings: {
-        text: {
-          en: '${num}: Bait near Tower ${num}',
-        },
-      },
-    },
-    {
-      id: 'P8S Tyrant\'s Flare II Soak Tower',
-      type: 'StartsUsing',
-      netRegex: NetRegexes.startsUsing({ id: '7A88', source: 'Hephaistos', capture: false }),
-      preRun: (data) => data.flareCounter++,
-      suppressSeconds: 1,
-      alertText: (data, _matches, output) => {
-        if (data.flareCounter === data.myTower)
-          return output.text!({ num: data.myTower });
-      },
-      outputStrings: {
-        text: {
-          en: 'Soak Tower ${num}',
-        },
-      },
-    },
-    {
       id: 'P8S Inverse Magics',
       type: 'GainsEffect',
       // This gets recast a lot on the same people, but shouldn't cause an issue.
@@ -1786,6 +1736,57 @@ const triggerSet: TriggerSet<Data> = {
       type: 'StartsUsing',
       netRegex: NetRegexes.startsUsing({ id: '75ED', source: 'Hephaistos', capture: false }),
       response: Responses.spread('alert'),
+    },
+    {
+      id: 'P8S Tyrant\'s Fire III Counter',
+      type: 'Ability',
+      netRegex: NetRegexes.ability({ id: '75F0', source: 'Hephaistos', capture: false }),
+      preRun: (data) => data.burstCounter++,
+      durationSeconds: 3,
+      suppressSeconds: 1,
+      sound: '',
+      infoText: (data, _matches, output) => output.text!({ num: data.burstCounter }),
+      tts: null,
+      outputStrings: {
+        text: {
+          en: '${num}',
+          de: '${num}',
+          fr: '${num}',
+          ja: '${num}',
+          cn: '${num}',
+          ko: '${num}',
+        },
+      },
+    },
+    {
+      id: 'P8S Tyrant\'s Fire III Bait then Tower',
+      type: 'Ability',
+      netRegex: NetRegexes.ability({ id: '75F0', source: 'Hephaistos' }),
+      condition: Conditions.targetIsYou(),
+      durationSeconds: 7.9,
+      infoText: (data, _matches, output) => output.text!({ num: data.burstCounter }),
+      run: (data) => data.myTower = data.burstCounter,
+      outputStrings: {
+        text: {
+          en: '${num}: Bait near Tower ${num}',
+        },
+      },
+    },
+    {
+      id: 'P8S Tyrant\'s Flare II Soak Tower',
+      type: 'StartsUsing',
+      netRegex: NetRegexes.startsUsing({ id: '7A88', source: 'Hephaistos', capture: false }),
+      preRun: (data) => data.flareCounter++,
+      suppressSeconds: 1,
+      alertText: (data, _matches, output) => {
+        if (data.flareCounter === data.myTower)
+          return output.text!({ num: data.myTower });
+      },
+      outputStrings: {
+        text: {
+          en: 'Soak Tower ${num}',
+        },
+      },
     },
     {
       id: 'P8S Dominion',

--- a/ui/raidboss/data/06-ew/raid/p8s.ts
+++ b/ui/raidboss/data/06-ew/raid/p8s.ts
@@ -1764,11 +1764,11 @@ const triggerSet: TriggerSet<Data> = {
       netRegex: NetRegexes.ability({ id: '75F0', source: 'Hephaistos' }),
       condition: Conditions.targetIsYou(),
       durationSeconds: 7.9,
-      infoText: (data, _matches, output) => output.text!({ num: data.burstCounter }),
+      alertText: (data, _matches, output) => output.text!({ num: data.burstCounter }),
       run: (data) => data.myTower = data.burstCounter,
       outputStrings: {
         text: {
-          en: '${num}: Bait near Tower ${num}',
+          en: '${num}',
         },
       },
     },

--- a/ui/raidboss/data/06-ew/raid/p8s.ts
+++ b/ui/raidboss/data/06-ew/raid/p8s.ts
@@ -1742,7 +1742,7 @@ const triggerSet: TriggerSet<Data> = {
       type: 'Ability',
       netRegex: NetRegexes.ability({ id: '75F0', source: 'Hephaistos', capture: false }),
       preRun: (data) => data.burstCounter++,
-      durationSeconds: 3,
+      durationSeconds: 2,
       suppressSeconds: 1,
       sound: '',
       infoText: (data, _matches, output) => output.text!({ num: data.burstCounter }),


### PR DESCRIPTION
Adds three callouts:
- A silent counter
- An audible Bait and Tower number
- Soak Tower when safe to move

The Counter is based on Tyrant's Fire III (75F0). The Soak Tower is based on Tyrant's Flare II (7A88) puddles, it could have been just a delayed trigger from the Tyrant's Fire III, but possibly this is a cleaner solution for timings?