### PR TITLE
raidboss: Allow Skins to Override Timerbar Elements

### DIFF
--- a/resources/timerbar.ts
+++ b/resources/timerbar.ts
@@ -348,83 +348,6 @@ export default class TimerBar extends HTMLElement {
           text-align: right;
           padding: 0px 0.4em 0px 0.4em;
         }
-
-        :host-context(.skin-lippe) .timerbar-root {
-          border: none;
-        }
-
-        :host-context(.skin-lippe) .timerbar-bg {
-          height: 5px !important;
-          border-radius: 1px;
-          background-color: #312008 !important;
-          border: 1px solid #AA6E03 !important;
-          box-shadow: 0 0 8px 0 #AA6E03;
-          opacity: 1.0;
-          z-index: 0;
-        }
-
-        :host-context(.skin-lippe) .timerbar-fg {
-          height: 5px !important;
-          top: 0px;
-          left: 0px;
-          background-color: rgba(255, 255, 255, 1) !important;
-          box-shadow: 0 0 2px 0 rgba(255, 255, 255, 1) !important;
-          text-align: center;
-          margin: 1px;
-          z-index: 1;
-          opacity: 1.0;
-        }
-
-        :host-context(.skin-lippe) .text {
-          text-shadow:
-            0 0 3px #AA6E03,
-            0 1px 3px #AA6E03,
-            0 -1px 3px #AA6E03;
-        }
-
-        :host-context(.skin-lippe) .text-container {
-          top: 0px;
-          z-index: 2;
-        }
-
-        :host-context(.skin-jwidea) .timerbar-root {
-          border: none;
-        }
-
-        :host-context(.skin-jwidea) .timerbar-bg {
-          height: 13px !important;
-          border-radius: 0px;
-          background-color: #40444b !important;
-          border: 1px solid #1a1a1c !important;
-          box-shadow: 0 0 8px 0 #1a1a1c;
-          opacity: 1.0;
-          z-index: 0;
-        }
-
-        :host-context(.skin-jwidea) .timerbar-fg {
-          height: 13px !important;
-          top: 0px;
-          left: 0px;
-          background-color: #724ed0 !important;
-          box-shadow: 0 0 2px 0 #8860f0 !important;
-          text-align: center;
-          margin: 1px;
-          z-index: 1;
-          opacity: 1.0;
-        }
-
-        :host-context(.skin-jwidea) .text {
-          text-shadow:
-            0 0 3px #545552,
-            0 1px 3px #545552,
-            0 -1px 3px #545552;
-        }
-
-        :host-context(.skin-jwidea) .text-container {
-          top: 0px;
-          z-index: 2;
-        }
-
         :host-context(.just-a-number) .timerbar-root {
           border: none;
         }
@@ -443,12 +366,18 @@ export default class TimerBar extends HTMLElement {
           top: 0.3ex;
         }
       </style>
-      <div id="root" class="timerbar-root">
-        <div id="bg" class="timerbar-bg"></div>
-        <div id="fg" class="timerbar-fg"></div>
-        <div class="text-container"><div id="lefttext" class="text timerbar-lefttext"></div></div>
-        <div class="text-container"><div id="centertext" class="text timerbar-centertext"></div></div>
-        <div class="text-container"><div id="righttext" class="text timerbar-righttext"></div></div>
+      <div id="root" class="timerbar-root" part="timerbar-root">
+        <div id="bg" class="timerbar-bg" part="timerbar-bg"></div>
+        <div id="fg" class="timerbar-fg" part="timerbar-fg"></div>
+        <div class="text-container" part="text-container">
+          <div id="lefttext" class="text timerbar-lefttext" part="text timerbar-lefttext"></div>
+        </div>
+        <div class="text-container" part="text-container">
+          <div id="centertext" class="text timerbar-centertext" part="text timerbar-centertext"></div>
+        </div>
+        <div class="text-container" part="text-container">
+          <div id="righttext" class="text timerbar-righttext" part="text timerbar-righttext"></div>
+        </div>
       </div>
     `;
   }

--- a/ui/raidboss/skins/jwidea/jwidea.css
+++ b/ui/raidboss/skins/jwidea/jwidea.css
@@ -1,3 +1,41 @@
+timer-bar::part(timerbar-root) {
+  border: none;
+}
+
+timer-bar::part(timerbar-bg) {
+  height: 13px !important;
+  border-radius: 0px;
+  background-color: #40444b !important;
+  border: 1px solid #1a1a1c !important;
+  box-shadow: 0 0 8px 0 #1a1a1c;
+  opacity: 1.0;
+  z-index: 0;
+}
+
+timer-bar::part(timerbar-fg) {
+  height: 13px !important;
+  top: 0px;
+  left: 0px;
+  background-color: #724ed0 !important;
+  box-shadow: 0 0 2px 0 #8860f0 !important;
+  text-align: center;
+  margin: 1px;
+  z-index: 1;
+  opacity: 1.0;
+}
+
+timer-bar::part(text) {
+  text-shadow:
+    0 0 3px #545552,
+    0 1px 3px #545552,
+    0 -1px 3px #545552;
+}
+
+timer-bar::part(text-container) {
+  top: 0px;
+  z-index: 2;
+}
+
 #timeline {
   position: absolute;
   z-index: 0;

--- a/ui/raidboss/skins/jwidea/jwidea.css
+++ b/ui/raidboss/skins/jwidea/jwidea.css
@@ -4,24 +4,24 @@ timer-bar::part(timerbar-root) {
 
 timer-bar::part(timerbar-bg) {
   height: 13px !important;
-  border-radius: 0px;
+  border-radius: 0;
   background-color: #40444b !important;
   border: 1px solid #1a1a1c !important;
   box-shadow: 0 0 8px 0 #1a1a1c;
-  opacity: 1.0;
+  opacity: 1;
   z-index: 0;
 }
 
 timer-bar::part(timerbar-fg) {
   height: 13px !important;
-  top: 0px;
-  left: 0px;
+  top: 0;
+  left: 0;
   background-color: #724ed0 !important;
   box-shadow: 0 0 2px 0 #8860f0 !important;
   text-align: center;
   margin: 1px;
   z-index: 1;
-  opacity: 1.0;
+  opacity: 1;
 }
 
 timer-bar::part(text) {
@@ -32,7 +32,7 @@ timer-bar::part(text) {
 }
 
 timer-bar::part(text-container) {
-  top: 0px;
+  top: 0;
   z-index: 2;
 }
 
@@ -47,37 +47,37 @@ timer-bar::part(text-container) {
 }
 
 .info-text {
-  color: rgba(255, 255, 255, 1);
+  color: rgba(255 255 255 100%);
   text-shadow:
-    -1px 0 rgb(82,190,87),
-    0 -1px rgb(82,190,87),
-    1px 0 rgb(82,190,87),
-    0 1px rgb(82,190,87),
-    0 0 10px rgb(82,190,87);
+    -1px 0 rgb(82 190 87),
+    0 -1px rgb(82 190 87),
+    1px 0 rgb(82 190 87),
+    0 1px rgb(82 190 87),
+    0 0 10 rgb(82 190 87);
   font-size: 100%;
   will-change: transform;
 }
 
 .alert-text {
-  color: rgba(255, 255, 255, 1);
+  color: rgba(255 255 255 100%);
   text-shadow:
-    -1px 0 rgb(250,150,110),
-    0 -1px rgb(250,150,110),
-    1px 0 rgb(250,150,110),
-    0 1px rgb(250,150,110),
-    0 0 10px rgb(250,150,110);
+    -1px 0 rgb(250 150 110),
+    0 -1px rgb(250 150 110),
+    1px 0 rgb(250 150 110),
+    0 1px rgb(250 150 110),
+    0 0 10 rgb(250 150 110);
   font-size: 100%;
   will-change: transform;
 }
 
 .alarm-text {
-  color: rgba(255, 255, 255, 1);
+  color: rgba(255 255 255 100%);
   text-shadow:
-    -1px 0 rgb(210,0,0),
-    0 -1px rgb(210,0,0),
-    1px 0 rgb(210,0,0),
-    0 1px rgb(210,0,0),
-    0 0 10px rgb(210,0,0);
+    -1px 0 rgb(210 0 0),
+    0 -1px rgb(210 0 0),
+    1px 0 rgb(210 0 0),
+    0 1px rgb(210 0 0),
+    0 0 10 rgb(210 0 0);
   font-size: 150%;
   will-change: transform;
 }

--- a/ui/raidboss/skins/lippe/lippe.css
+++ b/ui/raidboss/skins/lippe/lippe.css
@@ -6,33 +6,33 @@ timer-bar::part(timerbar-bg) {
   height: 5px !important;
   border-radius: 1px;
   background-color: #312008 !important;
-  border: 1px solid #AA6E03 !important;
-  box-shadow: 0 0 8px 0 #AA6E03;
-  opacity: 1.0;
+  border: 1px solid #aa6e03 !important;
+  box-shadow: 0 0 8px 0 #aa6e03;
+  opacity: 1;
   z-index: 0;
 }
 
 timer-bar::part(timerbar-fg) {
   height: 5px !important;
-  top: 0px;
-  left: 0px;
-  background-color: rgba(255, 255, 255, 1) !important;
-  box-shadow: 0 0 2px 0 rgba(255, 255, 255, 1) !important;
+  top: 0;
+  left: 0;
+  background-color: rgba(255 255 255 100%) !important;
+  box-shadow: 0 0 2px 0 rgba(255 255 255 100%) !important;
   text-align: center;
   margin: 1px;
   z-index: 1;
-  opacity: 1.0;
+  opacity: 1;
 }
 
 timer-bar::part(text) {
   text-shadow:
-    0 0 3px #AA6E03,
-    0 1px 3px #AA6E03,
-    0 -1px 3px #AA6E03;
+    0 0 3px #aa6e03,
+    0 1px 3px #aa6e03,
+    0 -1px 3px #aa6e03;
 }
 
 timer-bar::part(text-container) {
-  top: 0px;
+  top: 0;
   z-index: 2;
 }
 
@@ -47,38 +47,38 @@ timer-bar::part(text-container) {
 }
 
 .info-text {
-  color: rgba(255, 255, 255, 1);
+  color: rgba(255 255 255 100%);
   text-shadow:
-    -1px 0 rgb(117, 153, 87),
-    0 -1px rgb(117, 153, 87),
-    1px 0 rgb(117, 153, 87),
-    0 1px rgb(117, 153, 87),
-    0 0 10px rgb(117, 153, 87);
+    -1px 0 rgb(117 153 87),
+    0 -1px rgb(117 153 87),
+    1px 0 rgb(117 153 87),
+    0 1px rgb(117 153 87),
+    0 0 10px rgb(117 153 87);
   font-size: 140%;
   will-change: transform;
 }
 
 .alert-text {
-  color: rgba(255, 255, 255, 1);
+  color: rgba(255 255 255 100%);
   text-shadow:
-    -1px 0 rgb(170, 110, 3),
-    0 -1px rgb(170, 110, 3),
-    1px 0 rgb(170, 110, 3),
-    0 1px rgb(170, 110, 3),
-    0 0 10px rgb(170, 110, 3);
+    -1px 0 rgb(170 110 3),
+    0 -1px rgb(170 110 3),
+    1px 0 rgb(170 110 3),
+    0 1px rgb(170 110 3),
+    0 0 10px rgb(170 110 3);
   font-size: 170%;
   will-change: transform;
   text-transform: uppercase;
 }
 
 .alarm-text {
-  color: rgba(255, 255, 255, 1);
+  color: rgba(255 255 255 100%);
   text-shadow:
-    -1px 0 rgb(247, 120, 120),
-    0 -1px rgb(247, 120, 120),
-    1px 0 rgb(247, 120, 120),
-    0 1px rgb(247, 120, 120),
-    0 0 10px rgb(247, 120, 120);
+    -1px 0 rgb(247 120 120),
+    0 -1px rgb(247 120 120),
+    1px 0 rgb(247 120 120),
+    0 1px rgb(247 120 120),
+    0 0 10px rgb(247 120 120);
   font-size: 230%;
   will-change: transform;
   text-transform: uppercase;

--- a/ui/raidboss/skins/lippe/lippe.css
+++ b/ui/raidboss/skins/lippe/lippe.css
@@ -1,3 +1,41 @@
+timer-bar::part(timerbar-root) {
+  border: none;
+}
+
+timer-bar::part(timerbar-bg) {
+  height: 5px !important;
+  border-radius: 1px;
+  background-color: #312008 !important;
+  border: 1px solid #AA6E03 !important;
+  box-shadow: 0 0 8px 0 #AA6E03;
+  opacity: 1.0;
+  z-index: 0;
+}
+
+timer-bar::part(timerbar-fg) {
+  height: 5px !important;
+  top: 0px;
+  left: 0px;
+  background-color: rgba(255, 255, 255, 1) !important;
+  box-shadow: 0 0 2px 0 rgba(255, 255, 255, 1) !important;
+  text-align: center;
+  margin: 1px;
+  z-index: 1;
+  opacity: 1.0;
+}
+
+timer-bar::part(text) {
+  text-shadow:
+    0 0 3px #AA6E03,
+    0 1px 3px #AA6E03,
+    0 -1px 3px #AA6E03;
+}
+
+timer-bar::part(text-container) {
+  top: 0px;
+  z-index: 2;
+}
+
 #timeline {
   position: absolute;
   z-index: 0;


### PR DESCRIPTION
Using [parts](https://developer.mozilla.org/en-US/docs/Web/CSS/::part), you can override parts of custom elements. Hopefully this will alleviate some of the necessary touching of TypeScript components and allow users to completely override via CSS in their user raidboss.css file instead.