### PR TITLE
raidboss: fix p8s flameviper/tetraflare combo trigger

### DIFF
--- a/ui/raidboss/data/06-ew/raid/p8s.ts
+++ b/ui/raidboss/data/06-ew/raid/p8s.ts
@@ -1038,7 +1038,7 @@ const triggerSet: TriggerSet<Data> = {
     {
       id: 'P8S Illusory Hephaistos Scorched Pinion Second',
       type: 'StartsUsing',
-      netRegex: NetRegexes.startsUsing({ id: '7953', source: 'Illusory Hephaistos', capture: false }),
+      netRegex: NetRegexes.startsUsing({ id: '7953', capture: false }),
       condition: (data) => data.flareTargets.length > 0,
       suppressSeconds: 1,
       run: (data) => data.illusory = 'bird',
@@ -1046,7 +1046,7 @@ const triggerSet: TriggerSet<Data> = {
     {
       id: 'P8S Illusory Hephaistos Scorching Fang Second',
       type: 'StartsUsing',
-      netRegex: NetRegexes.startsUsing({ id: '7952', source: 'Illusory Hephaistos', capture: false }),
+      netRegex: NetRegexes.startsUsing({ id: '7952', capture: false }),
       condition: (data) => data.flareTargets.length > 0,
       suppressSeconds: 1,
       run: (data) => data.illusory = 'snake',


### PR DESCRIPTION
The bird/snake casts should always happen first by a second or two, but sometimes their names are incorrect.

Fixes #4828.