### PR TITLE
resources: build NetRegexes from helper in most cases

### DIFF
--- a/resources/netregexes.ts
+++ b/resources/netregexes.ts
@@ -156,6 +156,13 @@ const parseHelper = <T extends LogDefinitionTypes>(
   return Regexes.parse(str) as CactbotBaseRegExp<T>;
 };
 
+export const buildRegex = <T extends keyof NetParams>(
+  type: T,
+  params?: ParseHelperType<T>,
+): CactbotBaseRegExp<T> => {
+  return parseHelper(params, type, defaultParams(type, NetRegexes.logVersion));
+};
+
 export default class NetRegexes {
   static logVersion: LogDefinitionVersions = 'latest';
 
@@ -174,7 +181,7 @@ export default class NetRegexes {
    * matches: https://github.com/quisquous/cactbot/blob/main/docs/LogGuide.md#line-20-0x14-networkstartscasting
    */
   static startsUsing(params?: NetParams['StartsUsing']): CactbotBaseRegExp<'StartsUsing'> {
-    return parseHelper(params, 'startsUsing', defaultParams('StartsUsing', NetRegexes.logVersion));
+    return buildRegex('StartsUsing', params);
   }
 
   /**
@@ -182,7 +189,7 @@ export default class NetRegexes {
    * matches: https://github.com/quisquous/cactbot/blob/main/docs/LogGuide.md#line-22-0x16-networkaoeability
    */
   static ability(params?: NetParams['Ability']): CactbotBaseRegExp<'Ability'> {
-    return parseHelper(params, 'ability', {
+    return parseHelper(params, 'Ability', {
       ...defaultParams('Ability', NetRegexes.logVersion),
       // Override type
       0: { field: 'type', value: '2[12]', optional: false },
@@ -203,7 +210,7 @@ export default class NetRegexes {
    * matches: https://github.com/quisquous/cactbot/blob/main/docs/LogGuide.md#line-27-0x1b-networktargeticon-head-marker
    */
   static headMarker(params?: NetParams['HeadMarker']): CactbotBaseRegExp<'HeadMarker'> {
-    return parseHelper(params, 'headMarker', defaultParams('HeadMarker', NetRegexes.logVersion));
+    return buildRegex('HeadMarker', params);
   }
 
   /**
@@ -212,7 +219,7 @@ export default class NetRegexes {
   static addedCombatant(params?: NetParams['AddedCombatant']): CactbotBaseRegExp<'AddedCombatant'> {
     return parseHelper(
       params,
-      'addedCombatant',
+      'AddedCombatant',
       defaultParams('AddedCombatant', NetRegexes.logVersion, [
         'type',
         'timestamp',
@@ -230,7 +237,7 @@ export default class NetRegexes {
   ): CactbotBaseRegExp<'AddedCombatant'> {
     return parseHelper(
       params,
-      'addedCombatantFull',
+      'AddedCombatantFull',
       defaultParams('AddedCombatant', NetRegexes.logVersion),
     );
   }
@@ -241,18 +248,14 @@ export default class NetRegexes {
   static removingCombatant(
     params?: NetParams['RemovedCombatant'],
   ): CactbotBaseRegExp<'RemovedCombatant'> {
-    return parseHelper(
-      params,
-      'removingCombatant',
-      defaultParams('RemovedCombatant', NetRegexes.logVersion),
-    );
+    return buildRegex('RemovedCombatant', params);
   }
 
   /**
    * matches: https://github.com/quisquous/cactbot/blob/main/docs/LogGuide.md#line-26-0x1a-networkbuff
    */
   static gainsEffect(params?: NetParams['GainsEffect']): CactbotBaseRegExp<'GainsEffect'> {
-    return parseHelper(params, 'gainsEffect', defaultParams('GainsEffect', NetRegexes.logVersion));
+    return buildRegex('GainsEffect', params);
   }
 
   /**
@@ -262,25 +265,21 @@ export default class NetRegexes {
   static statusEffectExplicit(
     params?: NetParams['StatusEffect'],
   ): CactbotBaseRegExp<'StatusEffect'> {
-    return parseHelper(
-      params,
-      'statusEffectExplicit',
-      defaultParams('StatusEffect', NetRegexes.logVersion),
-    );
+    return buildRegex('StatusEffect', params);
   }
 
   /**
    * matches: https://github.com/quisquous/cactbot/blob/main/docs/LogGuide.md#line-30-0x1e-networkbuffremove
    */
   static losesEffect(params?: NetParams['LosesEffect']): CactbotBaseRegExp<'LosesEffect'> {
-    return parseHelper(params, 'losesEffect', defaultParams('LosesEffect', NetRegexes.logVersion));
+    return buildRegex('LosesEffect', params);
   }
 
   /**
    * matches: https://github.com/quisquous/cactbot/blob/main/docs/LogGuide.md#line-35-0x23-networktether
    */
   static tether(params?: NetParams['Tether']): CactbotBaseRegExp<'Tether'> {
-    return parseHelper(params, 'tether', defaultParams('Tether', NetRegexes.logVersion));
+    return buildRegex('Tether', params);
   }
 
   /**
@@ -288,14 +287,14 @@ export default class NetRegexes {
    * matches: https://github.com/quisquous/cactbot/blob/main/docs/LogGuide.md#line-25-0x19-networkdeath
    */
   static wasDefeated(params?: NetParams['WasDefeated']): CactbotBaseRegExp<'WasDefeated'> {
-    return parseHelper(params, 'wasDefeated', defaultParams('WasDefeated', NetRegexes.logVersion));
+    return buildRegex('WasDefeated', params);
   }
 
   /**
    * matches: https://github.com/quisquous/cactbot/blob/main/docs/LogGuide.md#line-24-0x18-networkdot
    */
   static networkDoT(params?: NetParams['NetworkDoT']): CactbotBaseRegExp<'NetworkDoT'> {
-    return parseHelper(params, 'networkDoT', defaultParams('NetworkDoT', NetRegexes.logVersion));
+    return buildRegex('NetworkDoT', params);
   }
 
   /**
@@ -306,7 +305,7 @@ export default class NetRegexes {
       params = {};
     Regexes.validateParams(
       params,
-      'echo',
+      'Echo',
       ['type', 'timestamp', 'code', 'name', 'line', 'capture'],
     );
     params.code = '0038';
@@ -321,7 +320,7 @@ export default class NetRegexes {
       params = {};
     Regexes.validateParams(
       params,
-      'dialog',
+      'Dialog',
       ['type', 'timestamp', 'code', 'name', 'line', 'capture'],
     );
     params.code = '0044';
@@ -336,7 +335,7 @@ export default class NetRegexes {
       params = {};
     Regexes.validateParams(
       params,
-      'message',
+      'Message',
       ['type', 'timestamp', 'code', 'name', 'line', 'capture'],
     );
     params.code = '0839';
@@ -348,7 +347,7 @@ export default class NetRegexes {
    * matches: https://github.com/quisquous/cactbot/blob/main/docs/LogGuide.md#line-00-0x00-logline
    */
   static gameLog(params?: NetParams['GameLog']): CactbotBaseRegExp<'GameLog'> {
-    return parseHelper(params, 'gameLog', defaultParams('GameLog', NetRegexes.logVersion));
+    return buildRegex('GameLog', params);
   }
 
   /**
@@ -363,35 +362,35 @@ export default class NetRegexes {
    * matches: https://github.com/quisquous/cactbot/blob/main/docs/LogGuide.md#line-12-0x0c-playerstats
    */
   static statChange(params?: NetParams['PlayerStats']): CactbotBaseRegExp<'PlayerStats'> {
-    return parseHelper(params, 'statChange', defaultParams('PlayerStats', NetRegexes.logVersion));
+    return buildRegex('PlayerStats', params);
   }
 
   /**
    * matches: https://github.com/quisquous/cactbot/blob/main/docs/LogGuide.md#line-01-0x01-changezone
    */
   static changeZone(params?: NetParams['ChangeZone']): CactbotBaseRegExp<'ChangeZone'> {
-    return parseHelper(params, 'changeZone', defaultParams('ChangeZone', NetRegexes.logVersion));
+    return buildRegex('ChangeZone', params);
   }
 
   /**
    * matches: https://github.com/quisquous/cactbot/blob/main/docs/LogGuide.md#line-33-0x21-network6d-actor-control
    */
   static network6d(params?: NetParams['ActorControl']): CactbotBaseRegExp<'ActorControl'> {
-    return parseHelper(params, 'network6d', defaultParams('ActorControl', NetRegexes.logVersion));
+    return buildRegex('ActorControl', params);
   }
 
   /**
    * matches: https://github.com/quisquous/cactbot/blob/main/docs/LogGuide.md#line-34-0x22-networknametoggle
    */
   static nameToggle(params?: NetParams['NameToggle']): CactbotBaseRegExp<'NameToggle'> {
-    return parseHelper(params, 'nameToggle', defaultParams('NameToggle', NetRegexes.logVersion));
+    return buildRegex('NameToggle', params);
   }
 
   /**
    * matches: https://github.com/quisquous/cactbot/blob/main/docs/LogGuide.md#line-40-0x28-map
    */
   static map(params?: NetParams['Map']): CactbotBaseRegExp<'Map'> {
-    return parseHelper(params, 'map', defaultParams('Map', NetRegexes.logVersion));
+    return buildRegex('Map', params);
   }
 
   /**
@@ -400,10 +399,6 @@ export default class NetRegexes {
   static systemLogMessage(
     params?: NetParams['SystemLogMessage'],
   ): CactbotBaseRegExp<'SystemLogMessage'> {
-    return parseHelper(
-      params,
-      'systemLogMessage',
-      defaultParams('SystemLogMessage', NetRegexes.logVersion),
-    );
+    return buildRegex('SystemLogMessage', params);
   }
 }


### PR DESCRIPTION
This will make it possible to have the log guide have regexes for things that don't have built-in cactbot regexes automatically by using this helper.

This also changes the default "error name" for NetRegexes to match the NetMatches type in most cases, and at least be capitalized in others.  This is cosmetic and only shows up in errors.