### PR TITLE
raidboss: add s-rank hunts

### DIFF
--- a/resources/outputs.ts
+++ b/resources/outputs.ts
@@ -378,6 +378,12 @@ export default {
     cn: '去中间',
     ko: '중앙으로',
   },
+  front: {
+    en: 'Front',
+  },
+  back: {
+    en: 'Back',
+  },
   right: {
     en: 'Right',
     de: 'Rechts',

--- a/resources/responses.ts
+++ b/resources/responses.ts
@@ -116,6 +116,10 @@ const getTarget = (matches: TargetedMatches) => {
   // Consider this as "not having a target".
   if (matches.target === matches.source)
     return;
+  // In hunts, sometimes there are too many people for the target
+  // to have a name.  Treat this as "no target".
+  if (matches.target === '')
+    return;
   return matches.target;
 };
 
@@ -427,6 +431,7 @@ export const Responses = {
   getOutThenIn: (sev?: Severity) => staticResponse(defaultInfoText(sev), Outputs.outThenIn),
   getBackThenFront: (sev?: Severity) => staticResponse(defaultInfoText(sev), Outputs.backThenFront),
   getFrontThenBack: (sev?: Severity) => staticResponse(defaultInfoText(sev), Outputs.frontThenBack),
+  goFront: (sev?: Severity) => staticResponse(defaultAlertText(sev), Outputs.goFront),
   goMiddle: (sev?: Severity) => staticResponse(defaultAlertText(sev), Outputs.goIntoMiddle),
   goRight: (sev?: Severity) => staticResponse(defaultAlertText(sev), Outputs.right),
   goLeft: (sev?: Severity) => staticResponse(defaultAlertText(sev), Outputs.left),

--- a/ui/raidboss/data/06-ew/hunts/elpis.ts
+++ b/ui/raidboss/data/06-ew/hunts/elpis.ts
@@ -104,10 +104,72 @@ const triggerSet: TriggerSet<Data> = {
         return { alertText: output.waterMarker!() };
       },
     },
+    {
+      id: 'Hunt Ophioneus Scratch',
+      type: 'StartsUsing',
+      netRegex: NetRegexes.startsUsing({ id: '6AD4', source: 'Ophioneus' }),
+      condition: (data) => data.inCombat,
+      response: Responses.tankBuster('info'),
+    },
+    {
+      id: 'Hunt Ophioneus Right Maw',
+      type: 'StartsUsing',
+      netRegex: NetRegexes.startsUsing({ id: '6AD6', source: 'Ophioneus', capture: false }),
+      condition: (data) => data.inCombat,
+      response: Responses.goLeft(),
+    },
+    {
+      id: 'Hunt Ophioneus Left Maw',
+      type: 'StartsUsing',
+      netRegex: NetRegexes.startsUsing({ id: '6AD7', source: 'Ophioneus', capture: false }),
+      condition: (data) => data.inCombat,
+      response: Responses.goRight(),
+    },
+    {
+      id: 'Hunt Ophioneus Pyric Circle',
+      type: 'StartsUsing',
+      netRegex: NetRegexes.startsUsing({ id: '6AD8', source: 'Ophioneus', capture: false }),
+      condition: (data) => data.inCombat,
+      response: Responses.getUnder(),
+    },
+    {
+      id: 'Hunt Ophioneus Pyric Burst',
+      type: 'StartsUsing',
+      netRegex: NetRegexes.startsUsing({ id: '6AD9', source: 'Ophioneus', capture: false }),
+      condition: (data) => data.inCombat,
+      response: Responses.getOut(),
+    },
+    {
+      id: 'Hunt Ophioneus Leaping Pyric Circle',
+      type: 'StartsUsing',
+      // Followed by a 6AD2 fast cast.
+      netRegex: NetRegexes.startsUsing({ id: '6ACD', source: 'Ophioneus', capture: false }),
+      condition: (data) => data.inCombat,
+      alertText: (_data, _matches, output) => output.text!(),
+      outputStrings: {
+        text: {
+          en: 'Follow Jump => Under',
+        },
+      },
+    },
+    {
+      id: 'Hunt Ophioneus Leaping Pyric Burst',
+      type: 'StartsUsing',
+      // Followed by a 6AD3 fast cast.
+      netRegex: NetRegexes.startsUsing({ id: '6ACE', source: 'Ophioneus', capture: false }),
+      condition: (data) => data.inCombat,
+      alertText: (_data, _matches, output) => output.text!(),
+      outputStrings: {
+        text: {
+          en: 'Away From Jump',
+        },
+      },
+    },
   ],
   timelineReplace: [
     {
       'locale': 'de',
+      'missingTranslations': true,
       'replaceSync': {
         'Gurangatch': 'Gurangatch',
         'Petalodus': 'Petalodus',
@@ -115,6 +177,7 @@ const triggerSet: TriggerSet<Data> = {
     },
     {
       'locale': 'fr',
+      'missingTranslations': true,
       'replaceSync': {
         'Gurangatch': 'Gurangatch',
         'Petalodus': 'petalodus',
@@ -122,6 +185,7 @@ const triggerSet: TriggerSet<Data> = {
     },
     {
       'locale': 'ja',
+      'missingTranslations': true,
       'replaceSync': {
         'Gurangatch': 'グランガチ',
         'Petalodus': 'ペタロドゥス',
@@ -129,6 +193,7 @@ const triggerSet: TriggerSet<Data> = {
     },
     {
       'locale': 'cn',
+      'missingTranslations': true,
       'replaceSync': {
         'Gurangatch': '固兰盖奇',
         'Petalodus': '瓣齿鲨',
@@ -136,6 +201,7 @@ const triggerSet: TriggerSet<Data> = {
     },
     {
       'locale': 'ko',
+      'missingTranslations': true,
       'replaceSync': {
         'Gurangatch': '구랑가치',
         'Petalodus': '페탈로두스',

--- a/ui/raidboss/data/06-ew/hunts/mare_lamentorum.ts
+++ b/ui/raidboss/data/06-ew/hunts/mare_lamentorum.ts
@@ -1,13 +1,24 @@
 import NetRegexes from '../../../../../resources/netregexes';
+import Outputs from '../../../../../resources/outputs';
 import { Responses } from '../../../../../resources/responses';
 import ZoneId from '../../../../../resources/zone_id';
 import { RaidbossData } from '../../../../../types/data';
 import { TriggerSet } from '../../../../../types/trigger';
 
-export type Data = RaidbossData;
+type ChitinousTrace = 'out' | 'in';
+
+export interface Data extends RaidbossData {
+  chitinous: ChitinousTrace[];
+}
 
 const triggerSet: TriggerSet<Data> = {
   zoneId: ZoneId.MareLamentorum,
+  resetWhenOutOfCombat: false,
+  initData: () => {
+    return {
+      chitinous: [],
+    };
+  },
   triggers: [
     {
       id: 'Hunt Lunatender Queen Away With You',
@@ -145,10 +156,129 @@ const triggerSet: TriggerSet<Data> = {
       condition: (data) => data.inCombat,
       response: Responses.outOfMelee(),
     },
+    {
+      // Note: "out" here means "get out", and "in" means "get in"
+      // There's a Trace cast, followed by a number of indicators,
+      // then an Advance/Reversal cast (which is the first set of damage)
+      // followed by several instant damage casts, e.g.
+      //
+      //   68FA/68FC/68FD/68FC/68FC => 6923/6637/6638/6637
+      //   ... means the following:
+      //   68FA (trace, first out), 68FC (out), 68FD (in), 68FC (out), 68FC (in)
+      //   6923 (reversal cast/in) -> 6637 (out) -> 6638 (in) -> 6637 (out)
+      //
+      // Casts:
+      // 68FA = chitinous trace, first indicator is out (68FC)
+      // 68FB = chitinous trace, first indicator is in (68FD)
+      // 68FC = "get out" indicator
+      // 68FD = "get in" indicator
+      //
+      // Casts that do damage:
+      // 68FE = chitinous advance out first
+      // 68FF = chitinous advance in first
+      // 6923 = chitinous reversal out first
+      // 6924 = chitinous reversal in first
+      //
+      // Instant Abilities:
+      // 6637 = out (reversal)
+      // 6638 = in (reversal)
+      // 6900 = out (advance)
+      // 6901 = in (advance)
+      id: 'Hunt Ruminator Chitinous Trace',
+      type: 'StartsUsing',
+      netRegex: NetRegexes.startsUsing({ id: ['68FA', '68FB'], source: 'Ruminator', capture: false }),
+      run: (data) => data.chitinous = [],
+    },
+    {
+      id: 'Hunt Ruminator Chitinous Trace Out',
+      type: 'StartsUsing',
+      netRegex: NetRegexes.startsUsing({ id: '68FC', source: 'Ruminator', capture: false }),
+      run: (data) => data.chitinous.push('out'),
+    },
+    {
+      id: 'Hunt Ruminator Chitinous Trace In',
+      type: 'StartsUsing',
+      netRegex: NetRegexes.startsUsing({ id: '68FD', source: 'Ruminator', capture: false }),
+      run: (data) => data.chitinous.push('in'),
+    },
+    {
+      id: 'Hunt Ruminator Chitinous Reversal',
+      type: 'StartsUsing',
+      netRegex: NetRegexes.startsUsing({ id: ['6923', '6924'], source: 'Ruminator', capture: false }),
+      run: (data) => data.chitinous.reverse(),
+    },
+    {
+      id: 'Hunt Ruminator Chitinous All Dirs',
+      type: 'StartsUsing',
+      netRegex: NetRegexes.startsUsing({ id: ['68FE', '68FF', '6923', '6924'], source: 'Ruminator', capture: false }),
+      // TODO: maybe figure out the duration from the length?
+      durationSeconds: 5,
+      sound: '',
+      infoText: (data, _matches, output) => {
+        if (data.chitinous.length === 0)
+          return;
+        if (!data.inCombat)
+          return;
+        return data.chitinous.map((x) => output[x]!()).join(output.joiner!());
+      },
+      tts: null,
+      outputStrings: {
+        out: Outputs.out,
+        in: Outputs.in,
+        joiner: {
+          en: ' => ',
+        },
+        unknown: Outputs.unknown,
+      },
+    },
+    {
+      id: 'Hunt Ruminator Chitinous Initial',
+      type: 'StartsUsing',
+      netRegex: NetRegexes.startsUsing({ id: ['68FE', '68FF', '6923', '6924'], source: 'Ruminator', capture: false }),
+      alertText: (data, _matches, output) => {
+        // TODO: should we verify that 68FE/6923 are out and 68FF/6924 are in?
+        const key = data.chitinous.shift() ?? 'unknown';
+        if (!data.inCombat)
+          return;
+        return output[key]!();
+      },
+      outputStrings: {
+        out: Outputs.out,
+        in: Outputs.in,
+        unknown: Outputs.unknown,
+      },
+    },
+    {
+      id: 'Hunt Ruminator Chitinous Step',
+      type: 'Ability',
+      netRegex: NetRegexes.ability({ id: ['68FE', '68FF', '6923', '6924', '6637', '6638', '6900', '6901'], source: 'Ruminator', capture: false }),
+      suppressSeconds: 1,
+      infoText: (data, _matches, output) => {
+        // Skip the last one.
+        const key = data.chitinous.shift();
+        if (!key)
+          return;
+        if (!data.inCombat)
+          return;
+        return output[key]!();
+      },
+      outputStrings: {
+        out: Outputs.out,
+        in: Outputs.in,
+      },
+    },
+    {
+      id: 'Hunt Ruminator Stygian Vapor',
+      type: 'StartsUsing',
+      netRegex: NetRegexes.startsUsing({ id: '6902', source: 'Ruminator', capture: false }),
+      condition: (data) => data.inCombat,
+      response: Responses.aoe(),
+    },
   ],
   timelineReplace: [
     {
       'locale': 'de',
+      'missingTranslations': true,
       'replaceSync': {
         'Lunatender Queen': 'Lunatender-Königin',
         'Mousse Princess': 'Mousse-Prinzessin',
@@ -156,6 +286,7 @@ const triggerSet: TriggerSet<Data> = {
     },
     {
       'locale': 'fr',
+      'missingTranslations': true,
       'replaceSync': {
         'Lunatender Queen': 'pampa sélénienne reine',
         'Mousse Princess': 'princesse mousse',
@@ -163,6 +294,7 @@ const triggerSet: TriggerSet<Data> = {
     },
     {
       'locale': 'ja',
+      'missingTranslations': true,
       'replaceSync': {
         'Lunatender Queen': 'ルナテンダー・クイーン',
         'Mousse Princess': 'ムースプリンセス',
@@ -170,6 +302,7 @@ const triggerSet: TriggerSet<Data> = {
     },
     {
       'locale': 'cn',
+      'missingTranslations': true,
       'replaceSync': {
         'Lunatender Queen': '月面仙人刺女王',
         'Mousse Princess': '慕斯公主',
@@ -177,6 +310,7 @@ const triggerSet: TriggerSet<Data> = {
     },
     {
       'locale': 'ko',
+      'missingTranslations': true,
       'replaceSync': {
         'Lunatender Queen': '루나텐더 여왕',
         'Mousse Princess': '무스 공주',

--- a/ui/raidboss/data/06-ew/hunts/ss_rank.ts
+++ b/ui/raidboss/data/06-ew/hunts/ss_rank.ts
@@ -1,0 +1,83 @@
+import NetRegexes from '../../../../../resources/netregexes';
+import { Responses } from '../../../../../resources/responses';
+import ZoneId from '../../../../../resources/zone_id';
+import { RaidbossData } from '../../../../../types/data';
+import { TriggerSet } from '../../../../../types/trigger';
+
+export type Data = RaidbossData;
+
+// TODO:
+// Ancient Flare is probably 6FB6?, Pyretic debuff effect is ?
+// Whispered Incantation + Whispers Manifest
+// Handle Mirrored Incantation + Interments
+
+const triggerSet: TriggerSet<Data> = {
+  zoneId: [
+    ZoneId.Labyrinthos,
+    ZoneId.Thavnair,
+    ZoneId.Garlemald,
+    ZoneId.MareLamentorum,
+    ZoneId.Elpis,
+    ZoneId.UltimaThule,
+  ],
+  triggers: [
+    {
+      id: 'Hunt Ker Heliovoid',
+      type: 'StartsUsing',
+      netRegex: NetRegexes.startsUsing({ id: '6BF4', source: 'Ker', capture: false }),
+      condition: (data) => data.inCombat,
+      response: Responses.outOfMelee(),
+    },
+    {
+      id: 'Hunt Ker Ancient Blizzard III',
+      type: 'StartsUsing',
+      netRegex: NetRegexes.startsUsing({ id: '6BF5', source: 'Ker', capture: false }),
+      condition: (data) => data.inCombat,
+      response: Responses.getUnder(),
+    },
+    {
+      id: 'Hunt Ker Eternal Damnation',
+      type: 'StartsUsing',
+      netRegex: NetRegexes.startsUsing({ id: '6BFF', source: 'Ker', capture: false }),
+      condition: (data) => data.inCombat,
+      response: Responses.lookAway(),
+    },
+    {
+      id: 'Hunt Ker Ancient Holy',
+      type: 'StartsUsing',
+      netRegex: NetRegexes.startsUsing({ id: '6BFE', source: 'Ker', capture: false }),
+      condition: (data) => data.inCombat,
+      response: Responses.getOut(),
+    },
+    {
+      id: 'Hunt Ker Fore Interment',
+      type: 'StartsUsing',
+      netRegex: NetRegexes.startsUsing({ id: '6BF9', source: 'Ker', capture: false }),
+      condition: (data) => data.inCombat,
+      response: Responses.getBehind(),
+    },
+    {
+      id: 'Hunt Ker Rear Interment',
+      type: 'StartsUsing',
+      netRegex: NetRegexes.startsUsing({ id: '6BFA', source: 'Ker', capture: false }),
+      condition: (data) => data.inCombat,
+      response: Responses.goFront(),
+    },
+    {
+      id: 'Hunt Ker Right Interment',
+      type: 'StartsUsing',
+      netRegex: NetRegexes.startsUsing({ id: '6BFB', source: 'Ker', capture: false }),
+      condition: (data) => data.inCombat,
+      response: Responses.goRight(),
+    },
+    {
+      id: 'Hunt Ker Left Interment',
+      type: 'StartsUsing',
+      netRegex: NetRegexes.startsUsing({ id: '6BFC', source: 'Ker', capture: false }),
+      condition: (data) => data.inCombat,
+      response: Responses.goRight(),
+    },
+  ],
+};
+
+export default triggerSet;

--- a/ui/raidboss/data/06-ew/hunts/thavnair.ts
+++ b/ui/raidboss/data/06-ew/hunts/thavnair.ts
@@ -207,7 +207,6 @@ const triggerSet: TriggerSet<Data> = {
           'B16': ['left', 'right'],
         };
         const dirs = map[matches.effectId];
-        console.log(`BEARING: ${dirs?.toString() ?? 'undefined'}`);
         if (dirs === undefined)
           return;
 
@@ -215,18 +214,11 @@ const triggerSet: TriggerSet<Data> = {
       },
     },
     {
-      id: 'Hunt Sphatika Lickwhip Debug',
-      type: 'StartsUsing',
-      netRegex: NetRegexes.startsUsing({ id: '6BE8', source: 'Sphatika', capture: false }),
-      run: (data) => console.log(`FINAL BEARING: ${JSON.stringify(data.sphatikaBearing)}`),
-    },
-    {
       id: 'Hunt Sphatika Whiplick Reverse',
       type: 'StartsUsing',
       netRegex: NetRegexes.startsUsing({ id: '6BE9', source: 'Sphatika', capture: false }),
       run: (data) => {
         // Whiplick does the directions in reverse, so reverse here so we can have a single logic path.
-        console.log(`PREVIOUS BEARING: ${JSON.stringify(data.sphatikaBearing)}`);
         data.sphatikaBearing = data.sphatikaBearing.map((x) => {
           if (x === 'front')
             return 'back';
@@ -236,7 +228,6 @@ const triggerSet: TriggerSet<Data> = {
             return 'right';
           return 'left';
         });
-        console.log(`FINAL BEARING: ${JSON.stringify(data.sphatikaBearing)}`);
       },
     },
     {
@@ -251,9 +242,8 @@ const triggerSet: TriggerSet<Data> = {
         const [dir1, dir2, dir3, dir4] = data.sphatikaBearing;
         if (dir1 === undefined || dir2 === undefined || dir3 === undefined || dir4 === undefined)
           return;
-        console.log(data.inCombat);
-        // if (!data.inCombat)
-        //  return;
+        if (!data.inCombat)
+          return;
         return output.text!({ dir1: dir1, dir2: dir2, dir3: dir3, dir4: dir4 });
       },
       tts: null,
@@ -277,9 +267,8 @@ const triggerSet: TriggerSet<Data> = {
         const key = data.sphatikaBearing.shift();
         if (key === undefined)
           return;
-        console.log(data.inCombat);
-        // if (!data.inCombat)
-        //  return;
+        if (!data.inCombat)
+          return;
         return output[key]!();
       },
       outputStrings: {
@@ -299,9 +288,8 @@ const triggerSet: TriggerSet<Data> = {
         const key = data.sphatikaBearing.shift();
         if (key === undefined)
           return;
-        console.log(data.inCombat);
-        // if (!data.inCombat)
-        //  return;
+        if (!data.inCombat)
+          return;
         return output[key]!();
       },
       outputStrings: {

--- a/ui/raidboss/data/06-ew/hunts/ultima_thule.ts
+++ b/ui/raidboss/data/06-ew/hunts/ultima_thule.ts
@@ -4,9 +4,16 @@ import ZoneId from '../../../../../resources/zone_id';
 import { RaidbossData } from '../../../../../types/data';
 import { TriggerSet } from '../../../../../types/trigger';
 
-// TODO: Fan Ail Death Sentence tankbuster
-
 export type Data = RaidbossData;
+
+// TODO: Narrow-rift Continual Meddling
+// Continual Meddling = 6AC0, applies two of these, one 7 one 10 second, about ~1s before Empty Refrain cast:
+//   7A6 = Forward March
+//   7A7 = About Face
+//   7A8 = Left Face
+//   7A9 = Right Face
+// Empty Refrain = 6AC3 / 6AC9, 12 second cast followed by 1 second cast of the other
+//   damage is the same ability id
 
 const triggerSet: TriggerSet<Data> = {
   zoneId: ZoneId.UltimaThule,
@@ -88,10 +95,37 @@ const triggerSet: TriggerSet<Data> = {
       condition: (data) => data.inCombat,
       response: Responses.awayFromFront(),
     },
+    {
+      id: 'Hunt Fan Ail Death Sentence',
+      type: 'StartsUsing',
+      netRegex: NetRegexes.startsUsing({ id: '6AF3', source: 'Fan Ail' }),
+      condition: (data) => data.inCombat,
+      response: Responses.tankBuster('info'),
+    },
+    {
+      id: 'Hunt Narrow-rift Empty Promise Donut',
+      type: 'StartsUsing',
+      netRegex: NetRegexes.startsUsing({ id: '6B60', source: 'Narrow-rift', capture: false }),
+      response: Responses.getIn(),
+    },
+    {
+      id: 'Hunt Narrow-rift Empty Promise Circle',
+      type: 'StartsUsing',
+      netRegex: NetRegexes.startsUsing({ id: '6B5F', source: 'Narrow-rift', capture: false }),
+      response: Responses.getOut(),
+    },
+    {
+      id: 'Hunt Narrow-rift Vanishing Ray',
+      type: 'Ability',
+      // An unknown single-target ability that preceeds Vanishing Ray with no cast bar.
+      netRegex: NetRegexes.ability({ id: '6AC5', source: 'Narrow-rift', capture: false }),
+      response: Responses.getBehind(),
+    },
   ],
   timelineReplace: [
     {
       'locale': 'de',
+      'missingTranslations': true,
       'replaceSync': {
         'Arch-Eta': 'Erz-Eta',
         'Fan Ail': 'Fan Ail',
@@ -99,6 +133,7 @@ const triggerSet: TriggerSet<Data> = {
     },
     {
       'locale': 'fr',
+      'missingTranslations': true,
       'replaceSync': {
         'Arch-Eta': 'Arch-Êta',
         'Fan Ail': 'Fan Ail',
@@ -106,6 +141,7 @@ const triggerSet: TriggerSet<Data> = {
     },
     {
       'locale': 'ja',
+      'missingTranslations': true,
       'replaceSync': {
         'Arch-Eta': 'アーチイータ',
         'Fan Ail': 'ファン・アイル',
@@ -113,6 +149,7 @@ const triggerSet: TriggerSet<Data> = {
     },
     {
       'locale': 'cn',
+      'missingTranslations': true,
       'replaceSync': {
         'Arch-Eta': '伊塔总领',
         'Fan Ail': '凡·艾尔',
@@ -120,6 +157,7 @@ const triggerSet: TriggerSet<Data> = {
     },
     {
       'locale': 'ko',
+      'missingTranslations': true,
       'replaceSync': {
         'Arch-Eta': '아치 에타',
         'Fan Ail': '판 아일',

--- a/ui/raidboss/data/raidboss_manifest.txt
+++ b/ui/raidboss/data/raidboss_manifest.txt
@@ -404,6 +404,7 @@
 06-ew/hunts/garlemald.ts
 06-ew/hunts/labyrinthos.ts
 06-ew/hunts/mare_lamentorum.ts
+06-ew/hunts/ss_rank.ts
 06-ew/hunts/thavnair.ts
 06-ew/hunts/ultima_thule.ts
 06-ew/trial/barbariccia.ts

--- a/ui/raidboss/popup-text.ts
+++ b/ui/raidboss/popup-text.ts
@@ -530,7 +530,7 @@ export class PopupText {
       this.OnChangeZone(e);
     });
     addOverlayListener('onInCombatChangedEvent', (e) => {
-      this.OnInCombatChange(e.detail.inGameCombat);
+      this.SetInCombat(e.detail.inGameCombat);
     });
     addOverlayListener('onLogEvent', (e) => {
       this.OnLog(e);
@@ -827,23 +827,19 @@ export class PopupText {
     this.ReloadTimelines();
   }
 
-  OnInCombatChange(inCombat: boolean): void {
+  SetInCombat(inCombat: boolean): void {
     if (this.inCombat === inCombat)
       return;
 
-    if (this.resetWhenOutOfCombat)
-      this.SetInCombat(inCombat);
-  }
+    this.inCombat = inCombat;
 
-  SetInCombat(inCombat: boolean): void {
-    if (this.inCombat === inCombat)
+    if (!this.resetWhenOutOfCombat)
       return;
 
     // Stop timers when stopping combat to stop any active timers that
     // are delayed.  However, also reset when starting combat.
     // This prevents late attacks from affecting |data| which
     // throws off the next run, potentially.
-    this.inCombat = inCombat;
     if (!this.inCombat) {
       this.StopTimers();
       this.timelineLoader.StopCombat();


### PR DESCRIPTION
This also includes a few fixes to make these triggers work better:
* target-less tankbusters (b/c there's too many people around) are now handled
* `resetWhenOutOfCombat: false` now properly sets `inCombat` rather than just ignoring changes to combat
* to avoid clearing any stored `data` fields when engaging a mob, set `resetWhenOutOfCombat: false` in a few places