### PR TITLE
raidboss: simplify trigger by define api

### DIFF
--- a/resources/api_define_trigger_set.ts
+++ b/resources/api_define_trigger_set.ts
@@ -1,0 +1,23 @@
+import { RaidbossData } from '../types/data';
+import { TriggerSet } from '../types/trigger';
+
+export function defineTriggerSet<InitData>(
+  set:
+    & TriggerSet<RaidbossData & InitData>
+    & (
+      Record<string, never> extends InitData ? Record<never, never>
+        : { initData: () => InitData }
+    ),
+): TriggerSet<RaidbossData>;
+
+export function defineTriggerSet(
+  set: Omit<TriggerSet<RaidbossData>, 'initData'>,
+): TriggerSet<RaidbossData>;
+
+/* eslint-disable func-style */
+export function defineTriggerSet<Data extends RaidbossData>(
+  set: TriggerSet<Data>,
+): TriggerSet<Data> {
+  return set;
+}
+/* eslint-enable func-style */

--- a/resources/api_define_trigger_set.ts
+++ b/resources/api_define_trigger_set.ts
@@ -8,7 +8,7 @@ export function defineTriggerSet<InitData>(
       Record<string, never> extends InitData ? Record<never, never>
         : { initData: () => InitData }
     ),
-): TriggerSet<RaidbossData>;
+): TriggerSet<RaidbossData & InitData>;
 
 export function defineTriggerSet(
   set: Omit<TriggerSet<RaidbossData>, 'initData'>,

--- a/types/trigger.d.ts
+++ b/types/trigger.d.ts
@@ -187,14 +187,11 @@ export type BaseTriggerSet<Data extends RaidbossData> = {
 };
 
 // If Data contains required properties that are not on RaidbossData, require initData
-export type TriggerSet<Data extends RaidbossData> =
+export type TriggerSet<Data extends RaidbossData = RaidbossData> =
   & BaseTriggerSet<Data>
-  & (RequiredFieldsAsUnion<Data> extends RequiredFieldsAsUnion<RaidbossData> ? {
+  & {
     initData?: DataInitializeFunc<Data>;
-  }
-    : {
-      initData: DataInitializeFunc<Data>;
-    });
+  };
 
 // Less strict type for user triggers + built-in triggers, including deprecated fields.
 export type LooseTimelineTrigger = Partial<TimelineTrigger<RaidbossData>>;

--- a/ui/raidboss/data/00-misc/general.ts
+++ b/ui/raidboss/data/00-misc/general.ts
@@ -1,16 +1,14 @@
+import { defineTriggerSet } from '../../../../resources/api_define_trigger_set';
 import NetRegexes from '../../../../resources/netregexes';
 import ZoneId from '../../../../resources/zone_id';
 import { RaidbossData } from '../../../../types/data';
-import { TriggerSet } from '../../../../types/trigger';
-
-export type Data = RaidbossData;
 
 const caresAboutTankStuff = (data: RaidbossData) => {
   return data.role === 'tank' || data.role === 'healer' || data.job === 'BLU';
 };
 
 // Triggers for all occasions and zones.
-const triggerSet: TriggerSet<Data> = {
+export default defineTriggerSet({
   zoneId: ZoneId.MatchAll,
   triggers: [
     {
@@ -261,6 +259,4 @@ const triggerSet: TriggerSet<Data> = {
       },
     },
   ],
-};
-
-export default triggerSet;
+});

--- a/ui/raidboss/data/00-misc/test.ts
+++ b/ui/raidboss/data/00-misc/test.ts
@@ -1,9 +1,9 @@
+import { defineTriggerSet } from '../../../../resources/api_define_trigger_set';
 import NetRegexes from '../../../../resources/netregexes';
 import outputs from '../../../../resources/outputs';
 import Util from '../../../../resources/util';
 import ZoneId from '../../../../resources/zone_id';
-import { RaidbossData } from '../../../../types/data';
-import { LocaleText, TriggerSet } from '../../../../types/trigger';
+import { LocaleText } from '../../../../types/trigger';
 
 const strikingDummyNames: LocaleText = {
   en: 'Striking Dummy',
@@ -14,13 +14,7 @@ const strikingDummyNames: LocaleText = {
   ko: '나무인형',
 };
 
-export interface Data extends RaidbossData {
-  delayedDummyTimestampBefore: number;
-  delayedDummyTimestampAfter: number;
-  pokes: number;
-}
-
-const triggerSet: TriggerSet<Data> = {
+export default defineTriggerSet({
   zoneId: ZoneId.MiddleLaNoscea,
   timelineFile: 'test.txt',
   // timeline here is additions to the timeline.  They can
@@ -426,6 +420,4 @@ const triggerSet: TriggerSet<Data> = {
       },
     },
   ],
-};
-
-export default triggerSet;
+});

--- a/ui/raidboss/data/02-arr/alliance/the_world_of_darkness.ts
+++ b/ui/raidboss/data/02-arr/alliance/the_world_of_darkness.ts
@@ -1,14 +1,8 @@
+import { defineTriggerSet } from '../../../../../resources/api_define_trigger_set';
 import Conditions from '../../../../../resources/conditions';
 import NetRegexes from '../../../../../resources/netregexes';
 import { Responses } from '../../../../../resources/responses';
 import ZoneId from '../../../../../resources/zone_id';
-import { RaidbossData } from '../../../../../types/data';
-import { TriggerSet } from '../../../../../types/trigger';
-
-export interface Data extends RaidbossData {
-  sullenDebuff?: boolean;
-  irefulDebuff?: boolean;
-}
 
 // TODO:
 //  Angra Mainyu
@@ -21,8 +15,14 @@ export interface Data extends RaidbossData {
 //  Cerberus
 //  Cloud of Darkness
 
-const triggerSet: TriggerSet<Data> = {
+export default defineTriggerSet({
   zoneId: ZoneId.TheWorldOfDarkness,
+  initData: () => {
+    return {
+      sullenDebuff: false,
+      irefulDebuff: false,
+    };
+  },
   triggers: [
     {
       id: 'Angra Mainyu Gain Sullen',
@@ -155,6 +155,4 @@ const triggerSet: TriggerSet<Data> = {
       },
     },
   ],
-};
-
-export default triggerSet;
+});

--- a/ui/raidboss/data/02-arr/dungeon/amdapor_keep.ts
+++ b/ui/raidboss/data/02-arr/dungeon/amdapor_keep.ts
@@ -1,12 +1,9 @@
+import { defineTriggerSet } from '../../../../../resources/api_define_trigger_set';
 import NetRegexes from '../../../../../resources/netregexes';
 import { Responses } from '../../../../../resources/responses';
 import ZoneId from '../../../../../resources/zone_id';
-import { RaidbossData } from '../../../../../types/data';
-import { TriggerSet } from '../../../../../types/trigger';
 
-export type Data = RaidbossData;
-
-const triggerSet: TriggerSet<Data> = {
+export default defineTriggerSet({
   zoneId: ZoneId.AmdaporKeep,
   triggers: [
     {
@@ -60,6 +57,4 @@ const triggerSet: TriggerSet<Data> = {
       },
     },
   ],
-};
-
-export default triggerSet;
+});

--- a/ui/raidboss/data/02-arr/dungeon/amdapor_keep_hard.ts
+++ b/ui/raidboss/data/02-arr/dungeon/amdapor_keep_hard.ts
@@ -1,13 +1,10 @@
+import { defineTriggerSet } from '../../../../../resources/api_define_trigger_set';
 import Conditions from '../../../../../resources/conditions';
 import NetRegexes from '../../../../../resources/netregexes';
 import { Responses } from '../../../../../resources/responses';
 import ZoneId from '../../../../../resources/zone_id';
-import { RaidbossData } from '../../../../../types/data';
-import { TriggerSet } from '../../../../../types/trigger';
 
-export type Data = RaidbossData;
-
-const triggerSet: TriggerSet<Data> = {
+export default defineTriggerSet({
   zoneId: ZoneId.AmdaporKeepHard,
   triggers: [
     {
@@ -86,6 +83,4 @@ const triggerSet: TriggerSet<Data> = {
       },
     },
   ],
-};
-
-export default triggerSet;
+});

--- a/ui/raidboss/data/02-arr/dungeon/aurum_vale.ts
+++ b/ui/raidboss/data/02-arr/dungeon/aurum_vale.ts
@@ -1,12 +1,9 @@
+import { defineTriggerSet } from '../../../../../resources/api_define_trigger_set';
 import Conditions from '../../../../../resources/conditions';
 import NetRegexes from '../../../../../resources/netregexes';
 import ZoneId from '../../../../../resources/zone_id';
-import { RaidbossData } from '../../../../../types/data';
-import { TriggerSet } from '../../../../../types/trigger';
 
-export type Data = RaidbossData;
-
-const triggerSet: TriggerSet<Data> = {
+export default defineTriggerSet({
   zoneId: ZoneId.TheAurumVale,
   triggers: [
     {
@@ -27,6 +24,4 @@ const triggerSet: TriggerSet<Data> = {
       },
     },
   ],
-};
-
-export default triggerSet;
+});

--- a/ui/raidboss/data/02-arr/dungeon/brayfloxs_longstop.ts
+++ b/ui/raidboss/data/02-arr/dungeon/brayfloxs_longstop.ts
@@ -1,18 +1,13 @@
+import { defineTriggerSet } from '../../../../../resources/api_define_trigger_set';
 import NetRegexes from '../../../../../resources/netregexes';
 import { Responses } from '../../../../../resources/responses';
 import ZoneId from '../../../../../resources/zone_id';
-import { RaidbossData } from '../../../../../types/data';
-import { TriggerSet } from '../../../../../types/trigger';
 
-export interface Data extends RaidbossData {
-  pelicanPoisons: string[];
-}
-
-const triggerSet: TriggerSet<Data> = {
+export default defineTriggerSet({
   zoneId: ZoneId.BrayfloxsLongstop,
   initData: () => {
     return {
-      pelicanPoisons: [],
+      pelicanPoisons: [] as string[],
     };
   },
   triggers: [
@@ -244,6 +239,4 @@ const triggerSet: TriggerSet<Data> = {
       },
     },
   ],
-};
-
-export default triggerSet;
+});

--- a/ui/raidboss/data/02-arr/dungeon/cutters_cry.ts
+++ b/ui/raidboss/data/02-arr/dungeon/cutters_cry.ts
@@ -1,12 +1,9 @@
+import { defineTriggerSet } from '../../../../../resources/api_define_trigger_set';
 import NetRegexes from '../../../../../resources/netregexes';
 import { Responses } from '../../../../../resources/responses';
 import ZoneId from '../../../../../resources/zone_id';
-import { RaidbossData } from '../../../../../types/data';
-import { TriggerSet } from '../../../../../types/trigger';
 
-export type Data = RaidbossData;
-
-const triggerSet: TriggerSet<Data> = {
+export default defineTriggerSet({
   zoneId: ZoneId.CuttersCry,
   triggers: [
     {
@@ -54,6 +51,4 @@ const triggerSet: TriggerSet<Data> = {
       },
     },
   ],
-};
-
-export default triggerSet;
+});

--- a/ui/raidboss/data/02-arr/dungeon/halatali_hard.ts
+++ b/ui/raidboss/data/02-arr/dungeon/halatali_hard.ts
@@ -1,11 +1,8 @@
+import { defineTriggerSet } from '../../../../../resources/api_define_trigger_set';
 import NetRegexes from '../../../../../resources/netregexes';
 import ZoneId from '../../../../../resources/zone_id';
-import { RaidbossData } from '../../../../../types/data';
-import { TriggerSet } from '../../../../../types/trigger';
 
-export type Data = RaidbossData;
-
-const triggerSet: TriggerSet<Data> = {
+export default defineTriggerSet({
   zoneId: ZoneId.HalataliHard,
   triggers: [
     {
@@ -76,6 +73,4 @@ const triggerSet: TriggerSet<Data> = {
       },
     },
   ],
-};
-
-export default triggerSet;
+});

--- a/ui/raidboss/data/02-arr/dungeon/haukke_manor.ts
+++ b/ui/raidboss/data/02-arr/dungeon/haukke_manor.ts
@@ -1,13 +1,10 @@
+import { defineTriggerSet } from '../../../../../resources/api_define_trigger_set';
 import Conditions from '../../../../../resources/conditions';
 import NetRegexes from '../../../../../resources/netregexes';
 import { Responses } from '../../../../../resources/responses';
 import ZoneId from '../../../../../resources/zone_id';
-import { RaidbossData } from '../../../../../types/data';
-import { TriggerSet } from '../../../../../types/trigger';
 
-export type Data = RaidbossData;
-
-const triggerSet: TriggerSet<Data> = {
+export default defineTriggerSet({
   zoneId: ZoneId.HaukkeManor,
   triggers: [
     {
@@ -145,6 +142,4 @@ const triggerSet: TriggerSet<Data> = {
       },
     },
   ],
-};
-
-export default triggerSet;
+});

--- a/ui/raidboss/data/02-arr/dungeon/haukke_manor_hard.ts
+++ b/ui/raidboss/data/02-arr/dungeon/haukke_manor_hard.ts
@@ -1,12 +1,9 @@
+import { defineTriggerSet } from '../../../../../resources/api_define_trigger_set';
 import NetRegexes from '../../../../../resources/netregexes';
 import { Responses } from '../../../../../resources/responses';
 import ZoneId from '../../../../../resources/zone_id';
-import { RaidbossData } from '../../../../../types/data';
-import { TriggerSet } from '../../../../../types/trigger';
 
-export type Data = RaidbossData;
-
-const triggerSet: TriggerSet<Data> = {
+export default defineTriggerSet({
   zoneId: ZoneId.HaukkeManorHard,
   triggers: [
     {
@@ -24,6 +21,4 @@ const triggerSet: TriggerSet<Data> = {
       response: Responses.stun(),
     },
   ],
-};
-
-export default triggerSet;
+});

--- a/ui/raidboss/data/02-arr/dungeon/hullbreaker_isle.ts
+++ b/ui/raidboss/data/02-arr/dungeon/hullbreaker_isle.ts
@@ -1,12 +1,9 @@
+import { defineTriggerSet } from '../../../../../resources/api_define_trigger_set';
 import NetRegexes from '../../../../../resources/netregexes';
 import { Responses } from '../../../../../resources/responses';
 import ZoneId from '../../../../../resources/zone_id';
-import { RaidbossData } from '../../../../../types/data';
-import { TriggerSet } from '../../../../../types/trigger';
 
-export type Data = RaidbossData;
-
-const triggerSet: TriggerSet<Data> = {
+export default defineTriggerSet({
   zoneId: ZoneId.HullbreakerIsle,
   triggers: [
     {
@@ -63,6 +60,4 @@ const triggerSet: TriggerSet<Data> = {
       },
     },
   ],
-};
-
-export default triggerSet;
+});

--- a/ui/raidboss/data/02-arr/dungeon/pharos_sirius.ts
+++ b/ui/raidboss/data/02-arr/dungeon/pharos_sirius.ts
@@ -1,13 +1,10 @@
+import { defineTriggerSet } from '../../../../../resources/api_define_trigger_set';
 import Conditions from '../../../../../resources/conditions';
 import NetRegexes from '../../../../../resources/netregexes';
 import { Responses } from '../../../../../resources/responses';
 import ZoneId from '../../../../../resources/zone_id';
-import { RaidbossData } from '../../../../../types/data';
-import { TriggerSet } from '../../../../../types/trigger';
 
-export type Data = RaidbossData;
-
-const triggerSet: TriggerSet<Data> = {
+export default defineTriggerSet({
   zoneId: ZoneId.PharosSirius,
   triggers: [
     {
@@ -86,6 +83,4 @@ const triggerSet: TriggerSet<Data> = {
       },
     },
   ],
-};
-
-export default triggerSet;
+});

--- a/ui/raidboss/data/02-arr/dungeon/sastasha_hard.ts
+++ b/ui/raidboss/data/02-arr/dungeon/sastasha_hard.ts
@@ -1,12 +1,9 @@
+import { defineTriggerSet } from '../../../../../resources/api_define_trigger_set';
 import NetRegexes from '../../../../../resources/netregexes';
 import Outputs from '../../../../../resources/outputs';
 import ZoneId from '../../../../../resources/zone_id';
-import { RaidbossData } from '../../../../../types/data';
-import { TriggerSet } from '../../../../../types/trigger';
 
-export type Data = RaidbossData;
-
-const triggerSet: TriggerSet<Data> = {
+export default defineTriggerSet({
   zoneId: ZoneId.SastashaHard,
   triggers: [
     {
@@ -80,6 +77,4 @@ const triggerSet: TriggerSet<Data> = {
       },
     },
   ],
-};
-
-export default triggerSet;
+});

--- a/ui/raidboss/data/02-arr/dungeon/snowcloak.ts
+++ b/ui/raidboss/data/02-arr/dungeon/snowcloak.ts
@@ -1,11 +1,8 @@
+import { defineTriggerSet } from '../../../../../resources/api_define_trigger_set';
 import NetRegexes from '../../../../../resources/netregexes';
 import ZoneId from '../../../../../resources/zone_id';
-import { RaidbossData } from '../../../../../types/data';
-import { TriggerSet } from '../../../../../types/trigger';
 
-export type Data = RaidbossData;
-
-const triggerSet: TriggerSet<Data> = {
+export default defineTriggerSet({
   zoneId: ZoneId.Snowcloak,
   triggers: [
     {
@@ -56,6 +53,4 @@ const triggerSet: TriggerSet<Data> = {
       },
     },
   ],
-};
-
-export default triggerSet;
+});

--- a/ui/raidboss/data/02-arr/dungeon/the_lost_city_of_amdapor.ts
+++ b/ui/raidboss/data/02-arr/dungeon/the_lost_city_of_amdapor.ts
@@ -1,13 +1,10 @@
+import { defineTriggerSet } from '../../../../../resources/api_define_trigger_set';
 import Conditions from '../../../../../resources/conditions';
 import NetRegexes from '../../../../../resources/netregexes';
 import { Responses } from '../../../../../resources/responses';
 import ZoneId from '../../../../../resources/zone_id';
-import { RaidbossData } from '../../../../../types/data';
-import { TriggerSet } from '../../../../../types/trigger';
 
-export type Data = RaidbossData;
-
-const triggerSet: TriggerSet<Data> = {
+export default defineTriggerSet({
   zoneId: ZoneId.TheLostCityOfAmdapor,
   triggers: [
     {
@@ -75,6 +72,4 @@ const triggerSet: TriggerSet<Data> = {
       },
     },
   ],
-};
-
-export default triggerSet;
+});

--- a/ui/raidboss/data/02-arr/dungeon/the_stone_vigil.ts
+++ b/ui/raidboss/data/02-arr/dungeon/the_stone_vigil.ts
@@ -1,12 +1,9 @@
+import { defineTriggerSet } from '../../../../../resources/api_define_trigger_set';
 import NetRegexes from '../../../../../resources/netregexes';
 import { Responses } from '../../../../../resources/responses';
 import ZoneId from '../../../../../resources/zone_id';
-import { RaidbossData } from '../../../../../types/data';
-import { TriggerSet } from '../../../../../types/trigger';
 
-export type Data = RaidbossData;
-
-const triggerSet: TriggerSet<Data> = {
+export default defineTriggerSet({
   zoneId: ZoneId.TheStoneVigil,
   triggers: [
     {
@@ -48,6 +45,4 @@ const triggerSet: TriggerSet<Data> = {
       },
     },
   ],
-};
-
-export default triggerSet;
+});

--- a/ui/raidboss/data/02-arr/dungeon/the_stone_vigil_hard.ts
+++ b/ui/raidboss/data/02-arr/dungeon/the_stone_vigil_hard.ts
@@ -1,12 +1,9 @@
+import { defineTriggerSet } from '../../../../../resources/api_define_trigger_set';
 import NetRegexes from '../../../../../resources/netregexes';
 import { Responses } from '../../../../../resources/responses';
 import ZoneId from '../../../../../resources/zone_id';
-import { RaidbossData } from '../../../../../types/data';
-import { TriggerSet } from '../../../../../types/trigger';
 
-export type Data = RaidbossData;
-
-const triggerSet: TriggerSet<Data> = {
+export default defineTriggerSet({
   zoneId: ZoneId.TheStoneVigilHard,
   triggers: [
     {
@@ -28,6 +25,4 @@ const triggerSet: TriggerSet<Data> = {
       response: Responses.tankBuster(),
     },
   ],
-};
-
-export default triggerSet;
+});

--- a/ui/raidboss/data/02-arr/dungeon/the_sunken_temple_of_quarn.ts
+++ b/ui/raidboss/data/02-arr/dungeon/the_sunken_temple_of_quarn.ts
@@ -1,12 +1,9 @@
+import { defineTriggerSet } from '../../../../../resources/api_define_trigger_set';
 import Conditions from '../../../../../resources/conditions';
 import NetRegexes from '../../../../../resources/netregexes';
 import ZoneId from '../../../../../resources/zone_id';
-import { RaidbossData } from '../../../../../types/data';
-import { TriggerSet } from '../../../../../types/trigger';
 
-export type Data = RaidbossData;
-
-const triggerSet: TriggerSet<Data> = {
+export default defineTriggerSet({
   zoneId: ZoneId.TheSunkenTempleOfQarn,
   triggers: [
     {
@@ -26,6 +23,4 @@ const triggerSet: TriggerSet<Data> = {
       },
     },
   ],
-};
-
-export default triggerSet;
+});

--- a/ui/raidboss/data/02-arr/dungeon/the_sunken_temple_of_quarn_hard.ts
+++ b/ui/raidboss/data/02-arr/dungeon/the_sunken_temple_of_quarn_hard.ts
@@ -1,12 +1,9 @@
+import { defineTriggerSet } from '../../../../../resources/api_define_trigger_set';
 import NetRegexes from '../../../../../resources/netregexes';
 import { Responses } from '../../../../../resources/responses';
 import ZoneId from '../../../../../resources/zone_id';
-import { RaidbossData } from '../../../../../types/data';
-import { TriggerSet } from '../../../../../types/trigger';
 
-export type Data = RaidbossData;
-
-const triggerSet: TriggerSet<Data> = {
+export default defineTriggerSet({
   zoneId: ZoneId.TheSunkenTempleOfQarnHard,
   triggers: [
     {
@@ -16,6 +13,4 @@ const triggerSet: TriggerSet<Data> = {
       response: Responses.awayFromFront(),
     },
   ],
-};
-
-export default triggerSet;
+});

--- a/ui/raidboss/data/02-arr/dungeon/the_tam_tara_depocraft_hard.ts
+++ b/ui/raidboss/data/02-arr/dungeon/the_tam_tara_depocraft_hard.ts
@@ -1,11 +1,8 @@
+import { defineTriggerSet } from '../../../../../resources/api_define_trigger_set';
 import NetRegexes from '../../../../../resources/netregexes';
 import ZoneId from '../../../../../resources/zone_id';
-import { RaidbossData } from '../../../../../types/data';
-import { TriggerSet } from '../../../../../types/trigger';
 
-export type Data = RaidbossData;
-
-const triggerSet: TriggerSet<Data> = {
+export default defineTriggerSet({
   zoneId: ZoneId.TheTamTaraDeepcroftHard,
   triggers: [
     {
@@ -56,6 +53,4 @@ const triggerSet: TriggerSet<Data> = {
       },
     },
   ],
-};
-
-export default triggerSet;
+});

--- a/ui/raidboss/data/02-arr/dungeon/the_wanderers_palace_hard.ts
+++ b/ui/raidboss/data/02-arr/dungeon/the_wanderers_palace_hard.ts
@@ -1,12 +1,9 @@
+import { defineTriggerSet } from '../../../../../resources/api_define_trigger_set';
 import NetRegexes from '../../../../../resources/netregexes';
 import { Responses } from '../../../../../resources/responses';
 import ZoneId from '../../../../../resources/zone_id';
-import { RaidbossData } from '../../../../../types/data';
-import { TriggerSet } from '../../../../../types/trigger';
 
-export type Data = RaidbossData;
-
-const triggerSet: TriggerSet<Data> = {
+export default defineTriggerSet({
   zoneId: ZoneId.TheWanderersPalaceHard,
   triggers: [
     {
@@ -70,6 +67,4 @@ const triggerSet: TriggerSet<Data> = {
       },
     },
   ],
-};
-
-export default triggerSet;
+});

--- a/ui/raidboss/data/02-arr/raid/t1.ts
+++ b/ui/raidboss/data/02-arr/raid/t1.ts
@@ -1,15 +1,10 @@
+import { defineTriggerSet } from '../../../../../resources/api_define_trigger_set';
 import Conditions from '../../../../../resources/conditions';
 import NetRegexes from '../../../../../resources/netregexes';
 import { Responses } from '../../../../../resources/responses';
 import ZoneId from '../../../../../resources/zone_id';
-import { RaidbossData } from '../../../../../types/data';
-import { TriggerSet } from '../../../../../types/trigger';
 
-export interface Data extends RaidbossData {
-  started: boolean;
-}
-
-const triggerSet: TriggerSet<Data> = {
+export default defineTriggerSet({
   zoneId: ZoneId.TheBindingCoilOfBahamutTurn1,
   initData: () => {
     return {
@@ -164,6 +159,4 @@ const triggerSet: TriggerSet<Data> = {
       },
     },
   ],
-};
-
-export default triggerSet;
+});

--- a/ui/raidboss/data/02-arr/raid/t10.ts
+++ b/ui/raidboss/data/02-arr/raid/t10.ts
@@ -1,12 +1,9 @@
+import { defineTriggerSet } from '../../../../../resources/api_define_trigger_set';
 import NetRegexes from '../../../../../resources/netregexes';
 import { Responses } from '../../../../../resources/responses';
 import ZoneId from '../../../../../resources/zone_id';
-import { RaidbossData } from '../../../../../types/data';
-import { TriggerSet } from '../../../../../types/trigger';
 
-export type Data = RaidbossData;
-
-const triggerSet: TriggerSet<Data> = {
+export default defineTriggerSet({
   zoneId: ZoneId.TheFinalCoilOfBahamutTurn1,
   timelineFile: 't10.txt',
   triggers: [
@@ -192,6 +189,4 @@ const triggerSet: TriggerSet<Data> = {
       },
     },
   ],
-};
-
-export default triggerSet;
+});

--- a/ui/raidboss/data/02-arr/raid/t11.ts
+++ b/ui/raidboss/data/02-arr/raid/t11.ts
@@ -1,19 +1,16 @@
+import { defineTriggerSet } from '../../../../../resources/api_define_trigger_set';
 import Conditions from '../../../../../resources/conditions';
 import NetRegexes from '../../../../../resources/netregexes';
 import { Responses } from '../../../../../resources/responses';
 import Util from '../../../../../resources/util';
 import ZoneId from '../../../../../resources/zone_id';
-import { RaidbossData } from '../../../../../types/data';
-import { TriggerSet } from '../../../../../types/trigger';
 
-export interface Data extends RaidbossData {
+export default defineTriggerSet<{
   beganMonitoringHp?: boolean;
   firstSeed?: string;
   tetherA?: string[];
   tetherB?: string[];
-}
-
-const triggerSet: TriggerSet<Data> = {
+}>({
   zoneId: ZoneId.TheFinalCoilOfBahamutTurn2,
   timelineFile: 't11.txt',
   triggers: [
@@ -328,6 +325,4 @@ const triggerSet: TriggerSet<Data> = {
       },
     },
   ],
-};
-
-export default triggerSet;
+});

--- a/ui/raidboss/data/02-arr/raid/t12.ts
+++ b/ui/raidboss/data/02-arr/raid/t12.ts
@@ -1,14 +1,9 @@
+import { defineTriggerSet } from '../../../../../resources/api_define_trigger_set';
 import Conditions from '../../../../../resources/conditions';
 import NetRegexes from '../../../../../resources/netregexes';
 import ZoneId from '../../../../../resources/zone_id';
-import { RaidbossData } from '../../../../../types/data';
-import { TriggerSet } from '../../../../../types/trigger';
 
-export interface Data extends RaidbossData {
-  phase: number;
-}
-
-const triggerSet: TriggerSet<Data> = {
+export default defineTriggerSet({
   zoneId: ZoneId.TheFinalCoilOfBahamutTurn3,
   timelineFile: 't12.txt',
   initData: () => {
@@ -284,6 +279,4 @@ const triggerSet: TriggerSet<Data> = {
       },
     },
   ],
-};
-
-export default triggerSet;
+});

--- a/ui/raidboss/data/02-arr/raid/t13.ts
+++ b/ui/raidboss/data/02-arr/raid/t13.ts
@@ -1,15 +1,10 @@
+import { defineTriggerSet } from '../../../../../resources/api_define_trigger_set';
 import Conditions from '../../../../../resources/conditions';
 import NetRegexes from '../../../../../resources/netregexes';
 import { Responses } from '../../../../../resources/responses';
 import ZoneId from '../../../../../resources/zone_id';
-import { RaidbossData } from '../../../../../types/data';
-import { TriggerSet } from '../../../../../types/trigger';
 
-export interface Data extends RaidbossData {
-  gigaflare: number;
-}
-
-const triggerSet: TriggerSet<Data> = {
+export default defineTriggerSet({
   zoneId: ZoneId.TheFinalCoilOfBahamutTurn4,
   timelineFile: 't13.txt',
   initData: () => {
@@ -335,6 +330,4 @@ const triggerSet: TriggerSet<Data> = {
       },
     },
   ],
-};
-
-export default triggerSet;
+});

--- a/ui/raidboss/data/02-arr/raid/t2.ts
+++ b/ui/raidboss/data/02-arr/raid/t2.ts
@@ -1,16 +1,16 @@
+import { defineTriggerSet } from '../../../../../resources/api_define_trigger_set';
 import Conditions from '../../../../../resources/conditions';
 import NetRegexes from '../../../../../resources/netregexes';
 import { Responses } from '../../../../../resources/responses';
 import ZoneId from '../../../../../resources/zone_id';
-import { RaidbossData } from '../../../../../types/data';
-import { TriggerSet } from '../../../../../types/trigger';
 
-export interface Data extends RaidbossData {
-  rot?: boolean;
-}
-
-const triggerSet: TriggerSet<Data> = {
+export default defineTriggerSet({
   zoneId: ZoneId.TheBindingCoilOfBahamutTurn2,
+  initData: () => {
+    return {
+      rot: undefined as boolean | undefined,
+    };
+  },
   triggers: [
     {
       id: 'T2 High Voltage',
@@ -118,6 +118,4 @@ const triggerSet: TriggerSet<Data> = {
       },
     },
   ],
-};
-
-export default triggerSet;
+});

--- a/ui/raidboss/data/02-arr/raid/t4.ts
+++ b/ui/raidboss/data/02-arr/raid/t4.ts
@@ -1,12 +1,9 @@
+import { defineTriggerSet } from '../../../../../resources/api_define_trigger_set';
 import Conditions from '../../../../../resources/conditions';
 import NetRegexes from '../../../../../resources/netregexes';
 import ZoneId from '../../../../../resources/zone_id';
-import { RaidbossData } from '../../../../../types/data';
-import { TriggerSet } from '../../../../../types/trigger';
 
-export type Data = RaidbossData;
-
-const triggerSet: TriggerSet<Data> = {
+export default defineTriggerSet({
   zoneId: ZoneId.TheBindingCoilOfBahamutTurn4,
   timelineFile: 't4.txt',
   triggers: [
@@ -151,6 +148,4 @@ const triggerSet: TriggerSet<Data> = {
       },
     },
   ],
-};
-
-export default triggerSet;
+});

--- a/ui/raidboss/data/02-arr/raid/t5.ts
+++ b/ui/raidboss/data/02-arr/raid/t5.ts
@@ -1,17 +1,10 @@
+import { defineTriggerSet } from '../../../../../resources/api_define_trigger_set';
 import NetRegexes from '../../../../../resources/netregexes';
 import { Responses } from '../../../../../resources/responses';
 import Util from '../../../../../resources/util';
 import ZoneId from '../../../../../resources/zone_id';
-import { RaidbossData } from '../../../../../types/data';
-import { TriggerSet } from '../../../../../types/trigger';
 
-export interface Data extends RaidbossData {
-  monitoringHP: boolean;
-  hpThresholds: number[];
-  currentPhase: number;
-}
-
-const triggerSet: TriggerSet<Data> = {
+export default defineTriggerSet({
   zoneId: ZoneId.TheBindingCoilOfBahamutTurn5,
   timelineFile: 't5.txt',
   initData: () => {
@@ -370,6 +363,4 @@ const triggerSet: TriggerSet<Data> = {
       },
     },
   ],
-};
-
-export default triggerSet;
+});

--- a/ui/raidboss/data/02-arr/raid/t6.ts
+++ b/ui/raidboss/data/02-arr/raid/t6.ts
@@ -1,19 +1,16 @@
+import { defineTriggerSet } from '../../../../../resources/api_define_trigger_set';
 import Conditions from '../../../../../resources/conditions';
 import NetRegexes from '../../../../../resources/netregexes';
 import { Responses } from '../../../../../resources/responses';
 import Util from '../../../../../resources/util';
 import ZoneId from '../../../../../resources/zone_id';
-import { RaidbossData } from '../../../../../types/data';
-import { TriggerSet } from '../../../../../types/trigger';
 
-export interface Data extends RaidbossData {
+export default defineTriggerSet<{
   beganMonitoringHp?: boolean;
   thornMap?: { [name: string]: string[] };
   honey?: boolean;
   seenLeafstorm?: boolean;
-}
-
-const triggerSet: TriggerSet<Data> = {
+}>({
   zoneId: ZoneId.TheSecondCoilOfBahamutTurn1,
   timelineFile: 't6.txt',
   triggers: [
@@ -352,6 +349,4 @@ const triggerSet: TriggerSet<Data> = {
       },
     },
   ],
-};
-
-export default triggerSet;
+});

--- a/ui/raidboss/data/02-arr/raid/t7.ts
+++ b/ui/raidboss/data/02-arr/raid/t7.ts
@@ -1,18 +1,11 @@
+import { defineTriggerSet } from '../../../../../resources/api_define_trigger_set';
 import Conditions from '../../../../../resources/conditions';
 import NetRegexes from '../../../../../resources/netregexes';
 import { Responses } from '../../../../../resources/responses';
 import Util from '../../../../../resources/util';
 import ZoneId from '../../../../../resources/zone_id';
-import { RaidbossData } from '../../../../../types/data';
-import { TriggerSet } from '../../../../../types/trigger';
 
-export interface Data extends RaidbossData {
-  hpThresholds: number[];
-  monitoringHP: boolean;
-  currentPhase: number;
-}
-
-const triggerSet: TriggerSet<Data> = {
+export default defineTriggerSet({
   zoneId: ZoneId.TheSecondCoilOfBahamutTurn2,
   timelineFile: 't7.txt',
   initData: () => {
@@ -344,6 +337,4 @@ const triggerSet: TriggerSet<Data> = {
       },
     },
   ],
-};
-
-export default triggerSet;
+});

--- a/ui/raidboss/data/02-arr/raid/t8.ts
+++ b/ui/raidboss/data/02-arr/raid/t8.ts
@@ -1,14 +1,11 @@
+import { defineTriggerSet } from '../../../../../resources/api_define_trigger_set';
 import NetRegexes from '../../../../../resources/netregexes';
 import { Responses } from '../../../../../resources/responses';
 import ZoneId from '../../../../../resources/zone_id';
-import { RaidbossData } from '../../../../../types/data';
-import { TriggerSet } from '../../../../../types/trigger';
 
-export interface Data extends RaidbossData {
+export default defineTriggerSet<{
   landmines: { [playerName: string]: boolean };
-}
-
-const triggerSet: TriggerSet<Data> = {
+}>({
   zoneId: ZoneId.TheSecondCoilOfBahamutTurn3,
   timelineFile: 't8.txt',
   initData: () => {
@@ -289,6 +286,4 @@ const triggerSet: TriggerSet<Data> = {
       },
     },
   ],
-};
-
-export default triggerSet;
+});

--- a/ui/raidboss/data/02-arr/raid/t9.ts
+++ b/ui/raidboss/data/02-arr/raid/t9.ts
@@ -1,22 +1,10 @@
+import { defineTriggerSet } from '../../../../../resources/api_define_trigger_set';
 import Conditions from '../../../../../resources/conditions';
 import NetRegexes from '../../../../../resources/netregexes';
 import Outputs from '../../../../../resources/outputs';
 import { Responses } from '../../../../../resources/responses';
 import Util from '../../../../../resources/util';
 import ZoneId from '../../../../../resources/zone_id';
-import { RaidbossData } from '../../../../../types/data';
-import { TriggerSet } from '../../../../../types/trigger';
-
-export interface Data extends RaidbossData {
-  beganMonitoringHp?: boolean;
-  garotte?: boolean;
-  seenFinalPhase: boolean;
-  dragons?: number[];
-  tetherCount: number;
-  naelDiveMarkerCount: number;
-  naelMarks?: string[];
-  safeZone?: string;
-}
 
 const diveDirections = {
   unknown: Outputs.unknown,
@@ -30,7 +18,16 @@ const diveDirections = {
   northwest: Outputs.dirNW,
 };
 
-const triggerSet: TriggerSet<Data> = {
+export default defineTriggerSet<{
+  beganMonitoringHp?: boolean;
+  garotte?: boolean;
+  seenFinalPhase: boolean;
+  dragons?: number[];
+  tetherCount: number;
+  naelDiveMarkerCount: number;
+  naelMarks?: string[];
+  safeZone?: string;
+}>({
   zoneId: ZoneId.TheSecondCoilOfBahamutTurn4,
   timelineFile: 't9.txt',
   initData: () => {
@@ -693,6 +690,4 @@ const triggerSet: TriggerSet<Data> = {
       },
     },
   ],
-};
-
-export default triggerSet;
+});

--- a/ui/raidboss/data/02-arr/trial/cape_westwind.ts
+++ b/ui/raidboss/data/02-arr/trial/cape_westwind.ts
@@ -1,10 +1,7 @@
+import { defineTriggerSet } from '../../../../../resources/api_define_trigger_set';
 import ZoneId from '../../../../../resources/zone_id';
-import { RaidbossData } from '../../../../../types/data';
-import { TriggerSet } from '../../../../../types/trigger';
 
-export type Data = RaidbossData;
-
-const triggerSet: TriggerSet<Data> = {
+export default defineTriggerSet({
   zoneId: ZoneId.CapeWestwind,
   timelineFile: 'cape_westwind.txt',
   triggers: [],
@@ -100,6 +97,4 @@ const triggerSet: TriggerSet<Data> = {
       },
     },
   ],
-};
-
-export default triggerSet;
+});

--- a/ui/raidboss/data/02-arr/trial/ifrit-nm.ts
+++ b/ui/raidboss/data/02-arr/trial/ifrit-nm.ts
@@ -1,11 +1,8 @@
+import { defineTriggerSet } from '../../../../../resources/api_define_trigger_set';
 import { Responses } from '../../../../../resources/responses';
 import ZoneId from '../../../../../resources/zone_id';
-import { RaidbossData } from '../../../../../types/data';
-import { TriggerSet } from '../../../../../types/trigger';
 
-export type Data = RaidbossData;
-
-const triggerSet: TriggerSet<Data> = {
+export default defineTriggerSet({
   zoneId: ZoneId.TheBowlOfEmbers,
   timelineFile: 'ifrit-nm.txt',
   timelineTriggers: [
@@ -121,6 +118,4 @@ const triggerSet: TriggerSet<Data> = {
       },
     },
   ],
-};
-
-export default triggerSet;
+});

--- a/ui/raidboss/data/02-arr/trial/levi-ex.ts
+++ b/ui/raidboss/data/02-arr/trial/levi-ex.ts
@@ -1,17 +1,10 @@
+import { defineTriggerSet } from '../../../../../resources/api_define_trigger_set';
 import NetRegexes from '../../../../../resources/netregexes';
 import Outputs from '../../../../../resources/outputs';
 import { callOverlayHandler } from '../../../../../resources/overlay_plugin_api';
 import Util from '../../../../../resources/util';
 import ZoneId from '../../../../../resources/zone_id';
-import { RaidbossData } from '../../../../../types/data';
 import { PluginCombatantState } from '../../../../../types/event';
-import { TriggerSet } from '../../../../../types/trigger';
-
-export interface Data extends RaidbossData {
-  converter: boolean;
-  diveCounter: number;
-  slamLevis: PluginCombatantState[];
-}
 
 // TODO: we could consider a timeline trigger for the Tidal Roar raidwide,
 // but it barely does 25% health, has no startsUsing, and the timeline for
@@ -24,14 +17,14 @@ export interface Data extends RaidbossData {
 // positions (+/-7, +/-20) and so more work would need to be done to tell
 // them apart.
 
-const triggerSet: TriggerSet<Data> = {
+export default defineTriggerSet({
   zoneId: ZoneId.TheWhorleaterExtreme,
   timelineFile: 'levi-ex.txt',
   initData: () => {
     return {
       converter: false,
       diveCounter: 0,
-      slamLevis: [],
+      slamLevis: [] as PluginCombatantState[],
     };
   },
   triggers: [
@@ -417,6 +410,4 @@ const triggerSet: TriggerSet<Data> = {
       },
     },
   ],
-};
-
-export default triggerSet;
+});

--- a/ui/raidboss/data/02-arr/trial/shiva-ex.ts
+++ b/ui/raidboss/data/02-arr/trial/shiva-ex.ts
@@ -1,22 +1,19 @@
+import { defineTriggerSet } from '../../../../../resources/api_define_trigger_set';
 import Conditions from '../../../../../resources/conditions';
 import NetRegexes from '../../../../../resources/netregexes';
 import { Responses } from '../../../../../resources/responses';
 import ZoneId from '../../../../../resources/zone_id';
-import { RaidbossData } from '../../../../../types/data';
-import { TriggerSet } from '../../../../../types/trigger';
 
-export interface Data extends RaidbossData {
+// TODO: some sort of warning about extra tank damage during bow phase?
+// TODO: should the post-staff "spread" happen unconditionally prior to marker?
+
+export default defineTriggerSet<{
   currentTank?: string;
   blunt: { [playerName: string]: boolean };
   slashing: { [playerName: string]: boolean };
   soonAfterWeaponChange: boolean;
   seenDiamondDust: boolean;
-}
-
-// TODO: some sort of warning about extra tank damage during bow phase?
-// TODO: should the post-staff "spread" happen unconditionally prior to marker?
-
-const triggerSet: TriggerSet<Data> = {
+}>({
   zoneId: ZoneId.TheAkhAfahAmphitheatreExtreme,
   timelineFile: 'shiva-ex.txt',
   initData: () => {
@@ -417,6 +414,4 @@ const triggerSet: TriggerSet<Data> = {
       },
     },
   ],
-};
-
-export default triggerSet;
+});

--- a/ui/raidboss/data/02-arr/trial/shiva-hm.ts
+++ b/ui/raidboss/data/02-arr/trial/shiva-hm.ts
@@ -1,15 +1,12 @@
+import { defineTriggerSet } from '../../../../../resources/api_define_trigger_set';
 import Conditions from '../../../../../resources/conditions';
 import NetRegexes from '../../../../../resources/netregexes';
 import { Responses } from '../../../../../resources/responses';
 import ZoneId from '../../../../../resources/zone_id';
-import { RaidbossData } from '../../../../../types/data';
-import { TriggerSet } from '../../../../../types/trigger';
-
-export type Data = RaidbossData;
 
 // TODO: should the post-staff "spread" happen unconditionally prior to marker?
 
-const triggerSet: TriggerSet<Data> = {
+export default defineTriggerSet({
   zoneId: ZoneId.TheAkhAfahAmphitheatreHard,
   timelineFile: 'shiva-hm.txt',
   timelineTriggers: [
@@ -184,6 +181,4 @@ const triggerSet: TriggerSet<Data> = {
       },
     },
   ],
-};
-
-export default triggerSet;
+});

--- a/ui/raidboss/data/02-arr/trial/titan-ex.ts
+++ b/ui/raidboss/data/02-arr/trial/titan-ex.ts
@@ -1,12 +1,9 @@
+import { defineTriggerSet } from '../../../../../resources/api_define_trigger_set';
 import NetRegexes from '../../../../../resources/netregexes';
 import { Responses } from '../../../../../resources/responses';
 import ZoneId from '../../../../../resources/zone_id';
-import { RaidbossData } from '../../../../../types/data';
-import { TriggerSet } from '../../../../../types/trigger';
 
-export type Data = RaidbossData;
-
-const triggerSet: TriggerSet<Data> = {
+export default defineTriggerSet({
   zoneId: ZoneId.TheNavelExtreme,
   timelineFile: 'titan-ex.txt',
   timelineTriggers: [
@@ -252,6 +249,4 @@ const triggerSet: TriggerSet<Data> = {
       },
     },
   ],
-};
-
-export default triggerSet;
+});

--- a/ui/raidboss/data/02-arr/trial/titan-hm.ts
+++ b/ui/raidboss/data/02-arr/trial/titan-hm.ts
@@ -1,12 +1,9 @@
+import { defineTriggerSet } from '../../../../../resources/api_define_trigger_set';
 import NetRegexes from '../../../../../resources/netregexes';
 import { Responses } from '../../../../../resources/responses';
 import ZoneId from '../../../../../resources/zone_id';
-import { RaidbossData } from '../../../../../types/data';
-import { TriggerSet } from '../../../../../types/trigger';
 
-export type Data = RaidbossData;
-
-const triggerSet: TriggerSet<Data> = {
+export default defineTriggerSet({
   zoneId: ZoneId.TheNavelHard,
   timelineFile: 'titan-hm.txt',
   timelineTriggers: [
@@ -166,6 +163,4 @@ const triggerSet: TriggerSet<Data> = {
       },
     },
   ],
-};
-
-export default triggerSet;
+});

--- a/ui/raidboss/data/02-arr/trial/titan-nm.ts
+++ b/ui/raidboss/data/02-arr/trial/titan-nm.ts
@@ -1,12 +1,9 @@
+import { defineTriggerSet } from '../../../../../resources/api_define_trigger_set';
 import NetRegexes from '../../../../../resources/netregexes';
 import { Responses } from '../../../../../resources/responses';
 import ZoneId from '../../../../../resources/zone_id';
-import { RaidbossData } from '../../../../../types/data';
-import { TriggerSet } from '../../../../../types/trigger';
 
-export type Data = RaidbossData;
-
-const triggerSet: TriggerSet<Data> = {
+export default defineTriggerSet({
   zoneId: ZoneId.TheNavel,
   timelineFile: 'titan-nm.txt',
   timelineTriggers: [
@@ -139,6 +136,4 @@ const triggerSet: TriggerSet<Data> = {
       },
     },
   ],
-};
-
-export default triggerSet;
+});

--- a/ui/raidboss/data/02-arr/trial/ultima-ex.ts
+++ b/ui/raidboss/data/02-arr/trial/ultima-ex.ts
@@ -1,21 +1,15 @@
+import { defineTriggerSet } from '../../../../../resources/api_define_trigger_set';
 import NetRegexes from '../../../../../resources/netregexes';
 import Outputs from '../../../../../resources/outputs';
 import { Responses } from '../../../../../resources/responses';
 import ZoneId from '../../../../../resources/zone_id';
-import { RaidbossData } from '../../../../../types/data';
-import { TriggerSet } from '../../../../../types/trigger';
 
-export interface Data extends RaidbossData {
-  plasmTargets?: Array<string>;
-  boomCounter: number;
-}
-
-const triggerSet: TriggerSet<Data> = {
+export default defineTriggerSet({
   zoneId: ZoneId.TheMinstrelsBalladUltimasBane,
   timelineFile: 'ultima-ex.txt',
   initData: () => {
     return {
-      plasmTargets: [],
+      plasmTargets: [] as Array<string> | undefined,
       boomCounter: 1,
     };
   },
@@ -298,6 +292,4 @@ const triggerSet: TriggerSet<Data> = {
       },
     },
   ],
-};
-
-export default triggerSet;
+});

--- a/ui/raidboss/data/03-hw/alliance/dun_scaith.ts
+++ b/ui/raidboss/data/03-hw/alliance/dun_scaith.ts
@@ -1,18 +1,15 @@
+import { defineTriggerSet } from '../../../../../resources/api_define_trigger_set';
 import Conditions from '../../../../../resources/conditions';
 import NetRegexes from '../../../../../resources/netregexes';
 import { Responses } from '../../../../../resources/responses';
 import ZoneId from '../../../../../resources/zone_id';
-import { RaidbossData } from '../../../../../types/data';
-import { TriggerSet } from '../../../../../types/trigger';
 
-export interface Data extends RaidbossData {
+export default defineTriggerSet<{
   cursing?: string[];
   wailing?: string[];
   sphere?: string[];
   donut?: string[];
-}
-
-const triggerSet: TriggerSet<Data> = {
+}>({
   zoneId: ZoneId.DunScaith,
   timelineFile: 'dun_scaith.txt',
   timelineTriggers: [
@@ -1132,6 +1129,4 @@ const triggerSet: TriggerSet<Data> = {
       },
     },
   ],
-};
-
-export default triggerSet;
+});

--- a/ui/raidboss/data/03-hw/alliance/weeping_city.ts
+++ b/ui/raidboss/data/03-hw/alliance/weeping_city.ts
@@ -1,17 +1,14 @@
+import { defineTriggerSet } from '../../../../../resources/api_define_trigger_set';
 import Conditions from '../../../../../resources/conditions';
 import NetRegexes from '../../../../../resources/netregexes';
 import { Responses } from '../../../../../resources/responses';
 import ZoneId from '../../../../../resources/zone_id';
-import { RaidbossData } from '../../../../../types/data';
-import { TriggerSet } from '../../../../../types/trigger';
 
-export interface Data extends RaidbossData {
+export default defineTriggerSet<{
   arachneStarted?: boolean;
   ozmaStarted?: boolean;
   calStarted?: boolean;
-}
-
-const triggerSet: TriggerSet<Data> = {
+}>({
   zoneId: ZoneId.TheWeepingCityOfMhach,
   timelineFile: 'weeping_city.txt',
   timelineTriggers: [
@@ -808,6 +805,4 @@ const triggerSet: TriggerSet<Data> = {
       },
     },
   ],
-};
-
-export default triggerSet;
+});

--- a/ui/raidboss/data/03-hw/dungeon/aetherochemical_research_facility.ts
+++ b/ui/raidboss/data/03-hw/dungeon/aetherochemical_research_facility.ts
@@ -1,13 +1,10 @@
+import { defineTriggerSet } from '../../../../../resources/api_define_trigger_set';
 import NetRegexes from '../../../../../resources/netregexes';
 import { Responses } from '../../../../../resources/responses';
 import ZoneId from '../../../../../resources/zone_id';
-import { RaidbossData } from '../../../../../types/data';
-import { TriggerSet } from '../../../../../types/trigger';
-
-export type Data = RaidbossData;
 
 // Aetherochemical Research Facility
-const triggerSet: TriggerSet<Data> = {
+export default defineTriggerSet({
   zoneId: ZoneId.TheAetherochemicalResearchFacility,
   timelineFile: 'aetherochemical_research_facility.txt',
   timelineTriggers: [
@@ -373,6 +370,4 @@ const triggerSet: TriggerSet<Data> = {
       },
     },
   ],
-};
-
-export default triggerSet;
+});

--- a/ui/raidboss/data/03-hw/dungeon/baelsars_wall.ts
+++ b/ui/raidboss/data/03-hw/dungeon/baelsars_wall.ts
@@ -1,13 +1,10 @@
+import { defineTriggerSet } from '../../../../../resources/api_define_trigger_set';
 import Conditions from '../../../../../resources/conditions';
 import NetRegexes from '../../../../../resources/netregexes';
 import { Responses } from '../../../../../resources/responses';
 import ZoneId from '../../../../../resources/zone_id';
-import { RaidbossData } from '../../../../../types/data';
-import { TriggerSet } from '../../../../../types/trigger';
 
-export type Data = RaidbossData;
-
-const triggerSet: TriggerSet<Data> = {
+export default defineTriggerSet({
   zoneId: ZoneId.BaelsarsWall,
   timelineFile: 'baelsars_wall.txt',
   timelineTriggers: [
@@ -288,6 +285,4 @@ const triggerSet: TriggerSet<Data> = {
       },
     },
   ],
-};
-
-export default triggerSet;
+});

--- a/ui/raidboss/data/03-hw/dungeon/fractal_continuum.ts
+++ b/ui/raidboss/data/03-hw/dungeon/fractal_continuum.ts
@@ -1,13 +1,10 @@
+import { defineTriggerSet } from '../../../../../resources/api_define_trigger_set';
 import NetRegexes from '../../../../../resources/netregexes';
 import { Responses } from '../../../../../resources/responses';
 import ZoneId from '../../../../../resources/zone_id';
-import { RaidbossData } from '../../../../../types/data';
-import { TriggerSet } from '../../../../../types/trigger';
-
-export type Data = RaidbossData;
 
 // Fractal Continuum
-const triggerSet: TriggerSet<Data> = {
+export default defineTriggerSet({
   zoneId: ZoneId.TheFractalContinuum,
   timelineFile: 'fractal_continuum.txt',
   timelineTriggers: [
@@ -254,6 +251,4 @@ const triggerSet: TriggerSet<Data> = {
       },
     },
   ],
-};
-
-export default triggerSet;
+});

--- a/ui/raidboss/data/03-hw/dungeon/gubal_library_hard.ts
+++ b/ui/raidboss/data/03-hw/dungeon/gubal_library_hard.ts
@@ -1,16 +1,13 @@
+import { defineTriggerSet } from '../../../../../resources/api_define_trigger_set';
 import Conditions from '../../../../../resources/conditions';
 import NetRegexes from '../../../../../resources/netregexes';
 import { Responses } from '../../../../../resources/responses';
 import ZoneId from '../../../../../resources/zone_id';
-import { RaidbossData } from '../../../../../types/data';
-import { TriggerSet } from '../../../../../types/trigger';
-
-export interface Data extends RaidbossData {
-  markers?: string[];
-}
 
 // The Great Gubal Library--Hard
-const triggerSet: TriggerSet<Data> = {
+export default defineTriggerSet<{
+  markers?: string[];
+}>({
   zoneId: ZoneId.TheGreatGubalLibraryHard,
   timelineFile: 'gubal_library_hard.txt',
   timelineTriggers: [
@@ -455,6 +452,4 @@ const triggerSet: TriggerSet<Data> = {
       },
     },
   ],
-};
-
-export default triggerSet;
+});

--- a/ui/raidboss/data/03-hw/dungeon/sohm_al.ts
+++ b/ui/raidboss/data/03-hw/dungeon/sohm_al.ts
@@ -1,14 +1,11 @@
+import { defineTriggerSet } from '../../../../../resources/api_define_trigger_set';
 import Conditions from '../../../../../resources/conditions';
 import NetRegexes from '../../../../../resources/netregexes';
 import { Responses } from '../../../../../resources/responses';
 import ZoneId from '../../../../../resources/zone_id';
-import { RaidbossData } from '../../../../../types/data';
-import { TriggerSet } from '../../../../../types/trigger';
-
-export type Data = RaidbossData;
 
 // Sohm Al (normal)
-const triggerSet: TriggerSet<Data> = {
+export default defineTriggerSet({
   zoneId: ZoneId.SohmAl,
   timelineFile: 'sohm_al.txt',
   timelineTriggers: [
@@ -241,6 +238,4 @@ const triggerSet: TriggerSet<Data> = {
       },
     },
   ],
-};
-
-export default triggerSet;
+});

--- a/ui/raidboss/data/03-hw/dungeon/sohm_al_hard.ts
+++ b/ui/raidboss/data/03-hw/dungeon/sohm_al_hard.ts
@@ -1,13 +1,10 @@
+import { defineTriggerSet } from '../../../../../resources/api_define_trigger_set';
 import Conditions from '../../../../../resources/conditions';
 import NetRegexes from '../../../../../resources/netregexes';
 import { Responses } from '../../../../../resources/responses';
 import ZoneId from '../../../../../resources/zone_id';
-import { RaidbossData } from '../../../../../types/data';
-import { TriggerSet } from '../../../../../types/trigger';
 
-export type Data = RaidbossData;
-
-const triggerSet: TriggerSet<Data> = {
+export default defineTriggerSet({
   zoneId: ZoneId.SohmAlHard,
   timelineFile: 'sohm_al_hard.txt',
   timelineTriggers: [
@@ -297,6 +294,4 @@ const triggerSet: TriggerSet<Data> = {
       },
     },
   ],
-};
-
-export default triggerSet;
+});

--- a/ui/raidboss/data/03-hw/dungeon/the_lost_city_of_amdapor_hard.ts
+++ b/ui/raidboss/data/03-hw/dungeon/the_lost_city_of_amdapor_hard.ts
@@ -1,16 +1,13 @@
+import { defineTriggerSet } from '../../../../../resources/api_define_trigger_set';
 import Conditions from '../../../../../resources/conditions';
 import NetRegexes from '../../../../../resources/netregexes';
 import { Responses } from '../../../../../resources/responses';
 import ZoneId from '../../../../../resources/zone_id';
-import { RaidbossData } from '../../../../../types/data';
-import { TriggerSet } from '../../../../../types/trigger';
 
-export interface Data extends RaidbossData {
+export default defineTriggerSet<{
   earthResistDown: { [name: string]: boolean };
   windResistDown: { [name: string]: boolean };
-}
-
-const triggerSet: TriggerSet<Data> = {
+}>({
   zoneId: ZoneId.TheLostCityOfAmdaporHard,
   timelineFile: 'the_lost_city_of_amdapor_hard.txt',
   // Temporarily out of combat during Kuribu phases.  @_@;;
@@ -434,6 +431,4 @@ const triggerSet: TriggerSet<Data> = {
       },
     },
   ],
-};
-
-export default triggerSet;
+});

--- a/ui/raidboss/data/03-hw/dungeon/the_vault.ts
+++ b/ui/raidboss/data/03-hw/dungeon/the_vault.ts
@@ -1,16 +1,13 @@
+import { defineTriggerSet } from '../../../../../resources/api_define_trigger_set';
 import Conditions from '../../../../../resources/conditions';
 import NetRegexes from '../../../../../resources/netregexes';
 import { Responses } from '../../../../../resources/responses';
 import ZoneId from '../../../../../resources/zone_id';
-import { RaidbossData } from '../../../../../types/data';
-import { TriggerSet } from '../../../../../types/trigger';
-
-export interface Data extends RaidbossData {
-  knightsActive?: boolean;
-}
 
 // The Vault
-const triggerSet: TriggerSet<Data> = {
+export default defineTriggerSet<{
+  knightsActive?: boolean;
+}>({
   zoneId: ZoneId.TheVault,
   timelineFile: 'the_vault.txt',
   timelineTriggers: [
@@ -380,6 +377,4 @@ const triggerSet: TriggerSet<Data> = {
       },
     },
   ],
-};
-
-export default triggerSet;
+});

--- a/ui/raidboss/data/03-hw/dungeon/xelphatol.ts
+++ b/ui/raidboss/data/03-hw/dungeon/xelphatol.ts
@@ -1,14 +1,11 @@
+import { defineTriggerSet } from '../../../../../resources/api_define_trigger_set';
 import Conditions from '../../../../../resources/conditions';
 import NetRegexes from '../../../../../resources/netregexes';
 import { Responses } from '../../../../../resources/responses';
 import ZoneId from '../../../../../resources/zone_id';
-import { RaidbossData } from '../../../../../types/data';
-import { TriggerSet } from '../../../../../types/trigger';
-
-export type Data = RaidbossData;
 
 // Xelphatol
-const triggerSet: TriggerSet<Data> = {
+export default defineTriggerSet({
   zoneId: ZoneId.Xelphatol,
   timelineFile: 'xelphatol.txt',
   timelineTriggers: [
@@ -277,6 +274,4 @@ const triggerSet: TriggerSet<Data> = {
       },
     },
   ],
-};
-
-export default triggerSet;
+});

--- a/ui/raidboss/data/03-hw/pvp/shatter.ts
+++ b/ui/raidboss/data/03-hw/pvp/shatter.ts
@@ -1,12 +1,9 @@
+import { defineTriggerSet } from '../../../../../resources/api_define_trigger_set';
 import NetRegexes from '../../../../../resources/netregexes';
 import ZoneId from '../../../../../resources/zone_id';
-import { RaidbossData } from '../../../../../types/data';
-import { TriggerSet } from '../../../../../types/trigger';
-
-export type Data = RaidbossData;
 
 // Frontlines: Shatter
-const triggerSet: TriggerSet<Data> = {
+export default defineTriggerSet({
   zoneId: ZoneId.TheFieldsOfGloryShatter,
   triggers: [
     {
@@ -121,6 +118,4 @@ const triggerSet: TriggerSet<Data> = {
       },
     },
   ],
-};
-
-export default triggerSet;
+});

--- a/ui/raidboss/data/03-hw/raid/a10n.ts
+++ b/ui/raidboss/data/03-hw/raid/a10n.ts
@@ -1,13 +1,10 @@
+import { defineTriggerSet } from '../../../../../resources/api_define_trigger_set';
 import Conditions from '../../../../../resources/conditions';
 import NetRegexes from '../../../../../resources/netregexes';
 import { Responses } from '../../../../../resources/responses';
 import ZoneId from '../../../../../resources/zone_id';
-import { RaidbossData } from '../../../../../types/data';
-import { TriggerSet } from '../../../../../types/trigger';
 
-export type Data = RaidbossData;
-
-const triggerSet: TriggerSet<Data> = {
+export default defineTriggerSet({
   zoneId: ZoneId.AlexanderTheBreathOfTheCreator,
   timelineFile: 'a10n.txt',
   timelineTriggers: [
@@ -293,6 +290,4 @@ const triggerSet: TriggerSet<Data> = {
       },
     },
   ],
-};
-
-export default triggerSet;
+});

--- a/ui/raidboss/data/03-hw/raid/a10s.ts
+++ b/ui/raidboss/data/03-hw/raid/a10s.ts
@@ -1,15 +1,9 @@
+import { defineTriggerSet } from '../../../../../resources/api_define_trigger_set';
 import Conditions from '../../../../../resources/conditions';
 import NetRegexes from '../../../../../resources/netregexes';
 import Outputs from '../../../../../resources/outputs';
 import { Responses } from '../../../../../resources/responses';
 import ZoneId from '../../../../../resources/zone_id';
-import { RaidbossData } from '../../../../../types/data';
-import { TriggerSet } from '../../../../../types/trigger';
-
-export interface Data extends RaidbossData {
-  charges: string[];
-  seenBrighteyes?: boolean;
-}
 
 // Notes:
 // Ignoring Gobsway Rumblerocks (1AA0) aoe trigger, as it is small and frequent.
@@ -29,7 +23,10 @@ const chargeOutputStrings = {
   unknown: Outputs.unknown,
 };
 
-const triggerSet: TriggerSet<Data> = {
+export default defineTriggerSet<{
+  charges: string[];
+  seenBrighteyes?: boolean;
+}>({
   zoneId: ZoneId.AlexanderTheBreathOfTheCreatorSavage,
   timelineFile: 'a10s.txt',
   initData: () => {
@@ -539,6 +536,4 @@ const triggerSet: TriggerSet<Data> = {
       },
     },
   ],
-};
-
-export default triggerSet;
+});

--- a/ui/raidboss/data/03-hw/raid/a11s.ts
+++ b/ui/raidboss/data/03-hw/raid/a11s.ts
@@ -1,17 +1,14 @@
+import { defineTriggerSet } from '../../../../../resources/api_define_trigger_set';
 import Conditions from '../../../../../resources/conditions';
 import NetRegexes from '../../../../../resources/netregexes';
 import { Responses } from '../../../../../resources/responses';
 import ZoneId from '../../../../../resources/zone_id';
-import { RaidbossData } from '../../../../../types/data';
-import { TriggerSet } from '../../../../../types/trigger';
 
-export interface Data extends RaidbossData {
+export default defineTriggerSet<{
   limitCutMap?: { [limitCutNumber: number]: string };
   limitCutNumber?: number;
   limitCutDelay?: number;
-}
-
-const triggerSet: TriggerSet<Data> = {
+}>({
   zoneId: ZoneId.AlexanderTheHeartOfTheCreatorSavage,
   timelineFile: 'a11s.txt',
   timelineTriggers: [
@@ -640,6 +637,4 @@ const triggerSet: TriggerSet<Data> = {
       },
     },
   ],
-};
-
-export default triggerSet;
+});

--- a/ui/raidboss/data/03-hw/raid/a12n.ts
+++ b/ui/raidboss/data/03-hw/raid/a12n.ts
@@ -1,16 +1,13 @@
+import { defineTriggerSet } from '../../../../../resources/api_define_trigger_set';
 import Conditions from '../../../../../resources/conditions';
 import NetRegexes from '../../../../../resources/netregexes';
 import Outputs from '../../../../../resources/outputs';
 import { Responses } from '../../../../../resources/responses';
 import ZoneId from '../../../../../resources/zone_id';
-import { RaidbossData } from '../../../../../types/data';
-import { TriggerSet } from '../../../../../types/trigger';
 
-export interface Data extends RaidbossData {
+export default defineTriggerSet<{
   assault?: boolean;
-}
-
-const triggerSet: TriggerSet<Data> = {
+}>({
   zoneId: ZoneId.AlexanderTheSoulOfTheCreator,
   timelineFile: 'a12n.txt',
   timelineTriggers: [
@@ -364,6 +361,4 @@ const triggerSet: TriggerSet<Data> = {
       },
     },
   ],
-};
-
-export default triggerSet;
+});

--- a/ui/raidboss/data/03-hw/raid/a12s.ts
+++ b/ui/raidboss/data/03-hw/raid/a12s.ts
@@ -1,20 +1,15 @@
+import { defineTriggerSet } from '../../../../../resources/api_define_trigger_set';
 import Conditions from '../../../../../resources/conditions';
 import NetRegexes from '../../../../../resources/netregexes';
 import { Responses } from '../../../../../resources/responses';
 import ZoneId from '../../../../../resources/zone_id';
-import { RaidbossData } from '../../../../../types/data';
-import { TriggerSet } from '../../../../../types/trigger';
 
-export interface Data extends RaidbossData {
-  scourge: string[];
-}
-
-const triggerSet: TriggerSet<Data> = {
+export default defineTriggerSet({
   zoneId: ZoneId.AlexanderTheSoulOfTheCreatorSavage,
   timelineFile: 'a12s.txt',
   initData: () => {
     return {
-      scourge: [],
+      scourge: [] as string[],
     };
   },
   timelineTriggers: [
@@ -493,6 +488,4 @@ const triggerSet: TriggerSet<Data> = {
       },
     },
   ],
-};
-
-export default triggerSet;
+});

--- a/ui/raidboss/data/03-hw/raid/a1s.ts
+++ b/ui/raidboss/data/03-hw/raid/a1s.ts
@@ -1,23 +1,17 @@
+import { defineTriggerSet } from '../../../../../resources/api_define_trigger_set';
 import Conditions from '../../../../../resources/conditions';
 import NetRegexes from '../../../../../resources/netregexes';
 import Outputs from '../../../../../resources/outputs';
 import { Responses } from '../../../../../resources/responses';
 import ZoneId from '../../../../../resources/zone_id';
-import { RaidbossData } from '../../../../../types/data';
-import { TriggerSet } from '../../../../../types/trigger';
 
-export interface Data extends RaidbossData {
-  hydro: string[];
-  hyper: string[];
-}
-
-const triggerSet: TriggerSet<Data> = {
+export default defineTriggerSet({
   zoneId: ZoneId.AlexanderTheFistOfTheFatherSavage,
   timelineFile: 'a1s.txt',
   initData: () => {
     return {
-      hydro: [],
-      hyper: [],
+      hydro: [] as string[],
+      hyper: [] as string[],
     };
   },
   timelineTriggers: [
@@ -296,6 +290,4 @@ const triggerSet: TriggerSet<Data> = {
       },
     },
   ],
-};
-
-export default triggerSet;
+});

--- a/ui/raidboss/data/03-hw/raid/a2s.ts
+++ b/ui/raidboss/data/03-hw/raid/a2s.ts
@@ -1,12 +1,7 @@
+import { defineTriggerSet } from '../../../../../resources/api_define_trigger_set';
 import Conditions from '../../../../../resources/conditions';
 import NetRegexes from '../../../../../resources/netregexes';
 import ZoneId from '../../../../../resources/zone_id';
-import { RaidbossData } from '../../../../../types/data';
-import { TriggerSet } from '../../../../../types/trigger';
-
-export interface Data extends RaidbossData {
-  bangyzoom?: boolean;
-}
 
 // TODO: could consider keeping track of the gobbie driver?
 // Nothing in the logs for when you get in, other than removing combatanat.
@@ -15,7 +10,9 @@ export interface Data extends RaidbossData {
 // There aren't many triggers, so maybe worth just keeping the global callouts
 // for bombs and stuns.
 
-const triggerSet: TriggerSet<Data> = {
+export default defineTriggerSet<{
+  bangyzoom?: boolean;
+}>({
   zoneId: ZoneId.AlexanderTheCuffOfTheFatherSavage,
   timelineFile: 'a2s.txt',
   timelineTriggers: [
@@ -295,6 +292,4 @@ const triggerSet: TriggerSet<Data> = {
       },
     },
   ],
-};
-
-export default triggerSet;
+});

--- a/ui/raidboss/data/03-hw/raid/a3n.ts
+++ b/ui/raidboss/data/03-hw/raid/a3n.ts
@@ -1,19 +1,16 @@
+import { defineTriggerSet } from '../../../../../resources/api_define_trigger_set';
 import Conditions from '../../../../../resources/conditions';
 import NetRegexes from '../../../../../resources/netregexes';
 import { Responses } from '../../../../../resources/responses';
 import ZoneId from '../../../../../resources/zone_id';
-import { RaidbossData } from '../../../../../types/data';
-import { TriggerSet } from '../../../../../types/trigger';
-
-export interface Data extends RaidbossData {
-  ferroTether?: { [name: string]: string };
-  ferroMarker?: { [name: string]: string };
-}
 
 // ALEXANDER - THE ARM OF THE FATHER NORMAL
 // A3N
 
-const triggerSet: TriggerSet<Data> = {
+export default defineTriggerSet<{
+  ferroTether?: { [name: string]: string };
+  ferroMarker?: { [name: string]: string };
+}>({
   zoneId: ZoneId.AlexanderTheArmOfTheFather,
   timelineFile: 'a3n.txt',
   timelineTriggers: [
@@ -205,6 +202,4 @@ const triggerSet: TriggerSet<Data> = {
       },
     },
   ],
-};
-
-export default triggerSet;
+});

--- a/ui/raidboss/data/03-hw/raid/a3s.ts
+++ b/ui/raidboss/data/03-hw/raid/a3s.ts
@@ -1,16 +1,13 @@
+import { defineTriggerSet } from '../../../../../resources/api_define_trigger_set';
 import Conditions from '../../../../../resources/conditions';
 import NetRegexes from '../../../../../resources/netregexes';
 import { Responses } from '../../../../../resources/responses';
 import ZoneId from '../../../../../resources/zone_id';
-import { RaidbossData } from '../../../../../types/data';
-import { TriggerSet } from '../../../../../types/trigger';
 
-export interface Data extends RaidbossData {
+export default defineTriggerSet<{
   ferroTether?: { [name: string]: string };
   ferroMarker?: { [name: string]: string };
-}
-
-const triggerSet: TriggerSet<Data> = {
+}>({
   zoneId: ZoneId.AlexanderTheArmOfTheFatherSavage,
   timelineFile: 'a3s.txt',
   timelineTriggers: [
@@ -467,6 +464,4 @@ const triggerSet: TriggerSet<Data> = {
       },
     },
   ],
-};
-
-export default triggerSet;
+});

--- a/ui/raidboss/data/03-hw/raid/a4s.ts
+++ b/ui/raidboss/data/03-hw/raid/a4s.ts
@@ -1,13 +1,10 @@
+import { defineTriggerSet } from '../../../../../resources/api_define_trigger_set';
 import Conditions from '../../../../../resources/conditions';
 import NetRegexes from '../../../../../resources/netregexes';
 import { Responses } from '../../../../../resources/responses';
 import ZoneId from '../../../../../resources/zone_id';
-import { RaidbossData } from '../../../../../types/data';
-import { TriggerSet } from '../../../../../types/trigger';
 
-export type Data = RaidbossData;
-
-const triggerSet: TriggerSet<Data> = {
+export default defineTriggerSet({
   zoneId: ZoneId.AlexanderTheBurdenOfTheFatherSavage,
   timelineFile: 'a4s.txt',
   timelineTriggers: [
@@ -236,6 +233,4 @@ const triggerSet: TriggerSet<Data> = {
       },
     },
   ],
-};
-
-export default triggerSet;
+});

--- a/ui/raidboss/data/03-hw/raid/a5s.ts
+++ b/ui/raidboss/data/03-hw/raid/a5s.ts
@@ -1,17 +1,9 @@
+import { defineTriggerSet } from '../../../../../resources/api_define_trigger_set';
 import Conditions from '../../../../../resources/conditions';
 import NetRegexes from '../../../../../resources/netregexes';
 import { Responses } from '../../../../../resources/responses';
 import ZoneId from '../../../../../resources/zone_id';
-import { RaidbossData } from '../../../../../types/data';
 import { NetMatches } from '../../../../../types/net_matches';
-import { TriggerSet } from '../../../../../types/trigger';
-
-// export type Data = RaidbossData;
-export interface Data extends RaidbossData {
-  bombCount: number;
-  boostCount: number;
-  boostBombs?: { x: number; y: number }[];
-}
 
 // TODO: do the gobcut and gobstraight really alternate?
 // if so, then maybe we could call out which was coming.
@@ -34,7 +26,11 @@ const bombLocation = (matches: NetMatches['AddedCombatant']) => {
   };
 };
 
-const triggerSet: TriggerSet<Data> = {
+export default defineTriggerSet<{
+  bombCount: number;
+  boostCount: number;
+  boostBombs?: { x: number; y: number }[];
+}>({
   zoneId: ZoneId.AlexanderTheFistOfTheSonSavage,
   timelineFile: 'a5s.txt',
   initData: () => {
@@ -613,6 +609,4 @@ const triggerSet: TriggerSet<Data> = {
       },
     },
   ],
-};
-
-export default triggerSet;
+});

--- a/ui/raidboss/data/03-hw/raid/a6n.ts
+++ b/ui/raidboss/data/03-hw/raid/a6n.ts
@@ -1,13 +1,10 @@
+import { defineTriggerSet } from '../../../../../resources/api_define_trigger_set';
 import Conditions from '../../../../../resources/conditions';
 import NetRegexes from '../../../../../resources/netregexes';
 import { Responses } from '../../../../../resources/responses';
 import ZoneId from '../../../../../resources/zone_id';
-import { RaidbossData } from '../../../../../types/data';
-import { TriggerSet } from '../../../../../types/trigger';
 
-export type Data = RaidbossData;
-
-const triggerSet: TriggerSet<Data> = {
+export default defineTriggerSet({
   zoneId: ZoneId.AlexanderTheCuffOfTheSon,
   timelineFile: 'a6n.txt',
   timelineTriggers: [
@@ -398,6 +395,4 @@ const triggerSet: TriggerSet<Data> = {
       },
     },
   ],
-};
-
-export default triggerSet;
+});

--- a/ui/raidboss/data/03-hw/raid/a6s.ts
+++ b/ui/raidboss/data/03-hw/raid/a6s.ts
@@ -1,17 +1,14 @@
+import { defineTriggerSet } from '../../../../../resources/api_define_trigger_set';
 import Conditions from '../../../../../resources/conditions';
 import NetRegexes from '../../../../../resources/netregexes';
 import { Responses } from '../../../../../resources/responses';
 import ZoneId from '../../../../../resources/zone_id';
-import { RaidbossData } from '../../../../../types/data';
-import { TriggerSet } from '../../../../../types/trigger';
 
-export interface Data extends RaidbossData {
+export default defineTriggerSet<{
   magicVulnerability?: boolean;
   haveWater?: boolean;
   haveLightning?: boolean;
-}
-
-const triggerSet: TriggerSet<Data> = {
+}>({
   zoneId: ZoneId.AlexanderTheCuffOfTheSonSavage,
   timelineFile: 'a6s.txt',
   triggers: [
@@ -591,6 +588,4 @@ const triggerSet: TriggerSet<Data> = {
       },
     },
   ],
-};
-
-export default triggerSet;
+});

--- a/ui/raidboss/data/03-hw/raid/a7s.ts
+++ b/ui/raidboss/data/03-hw/raid/a7s.ts
@@ -1,15 +1,8 @@
+import { defineTriggerSet } from '../../../../../resources/api_define_trigger_set';
 import Conditions from '../../../../../resources/conditions';
 import NetRegexes from '../../../../../resources/netregexes';
 import { Responses } from '../../../../../resources/responses';
 import ZoneId from '../../../../../resources/zone_id';
-import { RaidbossData } from '../../../../../types/data';
-import { TriggerSet } from '../../../../../types/trigger';
-
-export interface Data extends RaidbossData {
-  phase: number;
-  grabbed: string[];
-  stickyloom?: string;
-}
 
 // TODO: stun call for True Heart sprint ability?
 
@@ -50,7 +43,11 @@ export interface Data extends RaidbossData {
 //     red tether / white prey
 //     green tether / purple prey
 
-const triggerSet: TriggerSet<Data> = {
+export default defineTriggerSet<{
+  phase: number;
+  grabbed: string[];
+  stickyloom?: string;
+}>({
   zoneId: ZoneId.AlexanderTheArmOfTheSonSavage,
   timelineNeedsFixing: true,
   timelineFile: 'a7s.txt',
@@ -399,6 +396,4 @@ const triggerSet: TriggerSet<Data> = {
       },
     },
   ],
-};
-
-export default triggerSet;
+});

--- a/ui/raidboss/data/03-hw/raid/a8n.ts
+++ b/ui/raidboss/data/03-hw/raid/a8n.ts
@@ -1,19 +1,16 @@
+import { defineTriggerSet } from '../../../../../resources/api_define_trigger_set';
 import Conditions from '../../../../../resources/conditions';
 import NetRegexes from '../../../../../resources/netregexes';
 import { Responses } from '../../../../../resources/responses';
 import ZoneId from '../../../../../resources/zone_id';
-import { RaidbossData } from '../../../../../types/data';
-import { TriggerSet } from '../../../../../types/trigger';
-
-export interface Data extends RaidbossData {
-  bruteTank?: string;
-  bruteTankOut?: boolean;
-}
 
 // ALEXANDER - THE BURDEN OF THE SON NORMAL
 // A8N
 
-const triggerSet: TriggerSet<Data> = {
+export default defineTriggerSet<{
+  bruteTank?: string;
+  bruteTankOut?: boolean;
+}>({
   zoneId: ZoneId.AlexanderTheBurdenOfTheSon,
   timelineFile: 'a8n.txt',
   timelineTriggers: [
@@ -567,6 +564,4 @@ const triggerSet: TriggerSet<Data> = {
       },
     },
   ],
-};
-
-export default triggerSet;
+});

--- a/ui/raidboss/data/03-hw/raid/a8s.ts
+++ b/ui/raidboss/data/03-hw/raid/a8s.ts
@@ -1,20 +1,9 @@
+import { defineTriggerSet } from '../../../../../resources/api_define_trigger_set';
 import Conditions from '../../../../../resources/conditions';
 import NetRegexes from '../../../../../resources/netregexes';
 import Outputs from '../../../../../resources/outputs';
 import { Responses } from '../../../../../resources/responses';
 import ZoneId from '../../../../../resources/zone_id';
-import { RaidbossData } from '../../../../../types/data';
-import { TriggerSet } from '../../../../../types/trigger';
-
-export interface Data extends RaidbossData {
-  seenLinkUp?: boolean;
-  lightning?: string;
-  longNeedleStack?: string;
-  longNeedlePrey: string[];
-  verdictMin?: string;
-  verdictMax?: string;
-  water?: string;
-}
 
 // TODO: Final Punishment stack counts are in the network log, but not in ACT log :C
 // e.g. 4 stacks:
@@ -22,7 +11,15 @@ export interface Data extends RaidbossData {
 //   39.95|E0000000||1068E9CB|Potato Chippy|04|19062|||0bd20f2b57d49b17a19caa10e1fb8734
 // TODO: chakram safe spots lol?
 
-const triggerSet: TriggerSet<Data> = {
+export default defineTriggerSet<{
+  seenLinkUp?: boolean;
+  lightning?: string;
+  longNeedleStack?: string;
+  longNeedlePrey: string[];
+  verdictMin?: string;
+  verdictMax?: string;
+  water?: string;
+}>({
   zoneId: ZoneId.AlexanderTheBurdenOfTheSonSavage,
   timelineFile: 'a8s.txt',
   initData: () => {
@@ -1213,6 +1210,4 @@ const triggerSet: TriggerSet<Data> = {
       },
     },
   ],
-};
-
-export default triggerSet;
+});

--- a/ui/raidboss/data/03-hw/raid/a9s.ts
+++ b/ui/raidboss/data/03-hw/raid/a9s.ts
@@ -1,16 +1,13 @@
+import { defineTriggerSet } from '../../../../../resources/api_define_trigger_set';
 import Conditions from '../../../../../resources/conditions';
 import NetRegexes from '../../../../../resources/netregexes';
 import { Responses } from '../../../../../resources/responses';
 import ZoneId from '../../../../../resources/zone_id';
-import { RaidbossData } from '../../../../../types/data';
-import { TriggerSet } from '../../../../../types/trigger';
 
-export interface Data extends RaidbossData {
+export default defineTriggerSet<{
   stockpileCount: number;
   mainTank?: string;
-}
-
-const triggerSet: TriggerSet<Data> = {
+}>({
   zoneId: ZoneId.AlexanderTheEyesOfTheCreatorSavage,
   timelineFile: 'a9s.txt',
   initData: () => {
@@ -475,6 +472,4 @@ const triggerSet: TriggerSet<Data> = {
       },
     },
   ],
-};
-
-export default triggerSet;
+});

--- a/ui/raidboss/data/03-hw/trial/bismarck-ex.ts
+++ b/ui/raidboss/data/03-hw/trial/bismarck-ex.ts
@@ -1,12 +1,9 @@
+import { defineTriggerSet } from '../../../../../resources/api_define_trigger_set';
 import NetRegexes from '../../../../../resources/netregexes';
 import { Responses } from '../../../../../resources/responses';
 import ZoneId from '../../../../../resources/zone_id';
-import { RaidbossData } from '../../../../../types/data';
-import { TriggerSet } from '../../../../../types/trigger';
 
-export type Data = RaidbossData;
-
-const triggerSet: TriggerSet<Data> = {
+export default defineTriggerSet({
   zoneId: ZoneId.TheLimitlessBlueExtreme,
   triggers: [
     {
@@ -16,6 +13,4 @@ const triggerSet: TriggerSet<Data> = {
       response: Responses.knockback(),
     },
   ],
-};
-
-export default triggerSet;
+});

--- a/ui/raidboss/data/03-hw/trial/ravana-ex.ts
+++ b/ui/raidboss/data/03-hw/trial/ravana-ex.ts
@@ -1,10 +1,7 @@
+import { defineTriggerSet } from '../../../../../resources/api_define_trigger_set';
 import ZoneId from '../../../../../resources/zone_id';
-import { RaidbossData } from '../../../../../types/data';
-import { TriggerSet } from '../../../../../types/trigger';
 
-export type Data = RaidbossData;
-
-const triggerSet: TriggerSet<Data> = {
+export default defineTriggerSet({
   zoneId: ZoneId.ThokAstThokExtreme,
   timelineFile: 'ravana-ex.txt',
   triggers: [],
@@ -206,6 +203,4 @@ const triggerSet: TriggerSet<Data> = {
       },
     },
   ],
-};
-
-export default triggerSet;
+});

--- a/ui/raidboss/data/03-hw/trial/sephirot-ex.ts
+++ b/ui/raidboss/data/03-hw/trial/sephirot-ex.ts
@@ -1,20 +1,17 @@
+import { defineTriggerSet } from '../../../../../resources/api_define_trigger_set';
 import Conditions from '../../../../../resources/conditions';
 import NetRegexes from '../../../../../resources/netregexes';
 import Outputs from '../../../../../resources/outputs';
 import { Responses } from '../../../../../resources/responses';
 import ZoneId from '../../../../../resources/zone_id';
-import { RaidbossData } from '../../../../../types/data';
-import { TriggerSet } from '../../../../../types/trigger';
 
-export interface Data extends RaidbossData {
+export default defineTriggerSet<{
   mainTank?: string;
   phase: number;
   force?: string;
   shakerTargets?: string[];
   pillarActive: boolean;
-}
-
-const triggerSet: TriggerSet<Data> = {
+}>({
   zoneId: ZoneId.ContainmentBayS1T7Extreme,
   timelineFile: 'sephirot-ex.txt',
   initData: () => {
@@ -506,6 +503,4 @@ const triggerSet: TriggerSet<Data> = {
       },
     },
   ],
-};
-
-export default triggerSet;
+});

--- a/ui/raidboss/data/03-hw/trial/sephirot.ts
+++ b/ui/raidboss/data/03-hw/trial/sephirot.ts
@@ -1,13 +1,10 @@
+import { defineTriggerSet } from '../../../../../resources/api_define_trigger_set';
 import Conditions from '../../../../../resources/conditions';
 import NetRegexes from '../../../../../resources/netregexes';
 import { Responses } from '../../../../../resources/responses';
 import ZoneId from '../../../../../resources/zone_id';
-import { RaidbossData } from '../../../../../types/data';
-import { TriggerSet } from '../../../../../types/trigger';
 
-export type Data = RaidbossData;
-
-const triggerSet: TriggerSet<Data> = {
+export default defineTriggerSet({
   zoneId: ZoneId.ContainmentBayS1T7,
   triggers: [
     {
@@ -66,6 +63,4 @@ const triggerSet: TriggerSet<Data> = {
       response: Responses.knockback(),
     },
   ],
-};
-
-export default triggerSet;
+});

--- a/ui/raidboss/data/03-hw/trial/sophia-ex.ts
+++ b/ui/raidboss/data/03-hw/trial/sophia-ex.ts
@@ -1,12 +1,12 @@
+import { defineTriggerSet } from '../../../../../resources/api_define_trigger_set';
 import NetRegexes from '../../../../../resources/netregexes';
 import { UnreachableCode } from '../../../../../resources/not_reached';
 import Outputs from '../../../../../resources/outputs';
 import { Responses } from '../../../../../resources/responses';
 import ZoneId from '../../../../../resources/zone_id';
-import { RaidbossData } from '../../../../../types/data';
-import { Output, TriggerSet } from '../../../../../types/trigger';
+import { Output } from '../../../../../types/trigger';
 
-export interface Data extends RaidbossData {
+export interface Data {
   cloneSpots?: { [id: string]: string };
   scaleSophias?: string[];
   quasarTethers?: string[];
@@ -82,7 +82,7 @@ const tiltOutputStrings = {
   },
 };
 
-const triggerSet: TriggerSet<Data> = {
+export default defineTriggerSet<Data>({
   zoneId: ZoneId.ContainmentBayP1T6Extreme,
   timelineFile: 'sophia-ex.txt',
   timelineTriggers: [
@@ -715,6 +715,4 @@ const triggerSet: TriggerSet<Data> = {
       },
     },
   ],
-};
-
-export default triggerSet;
+});

--- a/ui/raidboss/data/04-sb/alliance/orbonne_monastery.ts
+++ b/ui/raidboss/data/04-sb/alliance/orbonne_monastery.ts
@@ -1,20 +1,17 @@
+import { defineTriggerSet } from '../../../../../resources/api_define_trigger_set';
 import Conditions from '../../../../../resources/conditions';
 import NetRegexes from '../../../../../resources/netregexes';
 import { Responses } from '../../../../../resources/responses';
 import ZoneId from '../../../../../resources/zone_id';
-import { RaidbossData } from '../../../../../types/data';
-import { TriggerSet } from '../../../../../types/trigger';
-
-export interface Data extends RaidbossData {
-  agriasGhostCleanse?: boolean;
-  halidom?: string[];
-}
 
 // TODO: grand cross "plummet" attacks have locations,
 // so it should be possible to tell people where to go.
 // This is not true for Mustadio's Maintenance.
 
-const triggerSet: TriggerSet<Data> = {
+export default defineTriggerSet<{
+  agriasGhostCleanse?: boolean;
+  halidom?: string[];
+}>({
   zoneId: ZoneId.TheOrbonneMonastery,
   timelineFile: 'orbonne_monastery.txt',
   timelineTriggers: [
@@ -1166,6 +1163,4 @@ const triggerSet: TriggerSet<Data> = {
       },
     },
   ],
-};
-
-export default triggerSet;
+});

--- a/ui/raidboss/data/04-sb/alliance/ridorana_lighthouse.ts
+++ b/ui/raidboss/data/04-sb/alliance/ridorana_lighthouse.ts
@@ -1,16 +1,10 @@
+import { defineTriggerSet } from '../../../../../resources/api_define_trigger_set';
 import Conditions from '../../../../../resources/conditions';
 import NetRegexes from '../../../../../resources/netregexes';
 import { UnreachableCode } from '../../../../../resources/not_reached';
 import { Responses } from '../../../../../resources/responses';
 import ZoneId from '../../../../../resources/zone_id';
-import { RaidbossData } from '../../../../../types/data';
-import { Output, TriggerSet } from '../../../../../types/trigger';
-
-export interface Data extends RaidbossData {
-  playerMap?: { [name: string]: boolean };
-  accelerateSpreadOnMe?: boolean;
-  mathBaseValue?: number;
-}
+import { Output } from '../../../../../types/trigger';
 
 const mathDirection = (mathBaseValue: number | undefined, correctMath: number[], output: Output) => {
   if (mathBaseValue === undefined)
@@ -76,7 +70,11 @@ const mathOutputStrings = {
   },
 };
 
-const triggerSet: TriggerSet<Data> = {
+export default defineTriggerSet<{
+  playerMap?: { [name: string]: boolean };
+  accelerateSpreadOnMe?: boolean;
+  mathBaseValue?: number;
+}>({
   zoneId: ZoneId.TheRidoranaLighthouse,
   timelineFile: 'ridorana_lighthouse.txt',
   timelineTriggers: [
@@ -805,6 +803,4 @@ const triggerSet: TriggerSet<Data> = {
       },
     },
   ],
-};
-
-export default triggerSet;
+});

--- a/ui/raidboss/data/04-sb/alliance/royal_city_of_rabanastre.ts
+++ b/ui/raidboss/data/04-sb/alliance/royal_city_of_rabanastre.ts
@@ -1,16 +1,13 @@
+import { defineTriggerSet } from '../../../../../resources/api_define_trigger_set';
 import Conditions from '../../../../../resources/conditions';
 import NetRegexes from '../../../../../resources/netregexes';
 import Outputs from '../../../../../resources/outputs';
 import { Responses } from '../../../../../resources/responses';
 import ZoneId from '../../../../../resources/zone_id';
-import { RaidbossData } from '../../../../../types/data';
-import { TriggerSet } from '../../../../../types/trigger';
 
-export interface Data extends RaidbossData {
+export default defineTriggerSet<{
   maskValue?: boolean;
-}
-
-const triggerSet: TriggerSet<Data> = {
+}>({
   zoneId: ZoneId.TheRoyalCityOfRabanastre,
   timelineFile: 'royal_city_of_rabanastre.txt',
   triggers: [
@@ -770,6 +767,4 @@ const triggerSet: TriggerSet<Data> = {
       },
     },
   ],
-};
-
-export default triggerSet;
+});

--- a/ui/raidboss/data/04-sb/dungeon/ala_mhigo.ts
+++ b/ui/raidboss/data/04-sb/dungeon/ala_mhigo.ts
@@ -1,13 +1,10 @@
+import { defineTriggerSet } from '../../../../../resources/api_define_trigger_set';
 import Conditions from '../../../../../resources/conditions';
 import NetRegexes from '../../../../../resources/netregexes';
 import { Responses } from '../../../../../resources/responses';
 import ZoneId from '../../../../../resources/zone_id';
-import { RaidbossData } from '../../../../../types/data';
-import { TriggerSet } from '../../../../../types/trigger';
 
-export type Data = RaidbossData;
-
-const triggerSet: TriggerSet<Data> = {
+export default defineTriggerSet({
   zoneId: ZoneId.AlaMhigo,
   timelineFile: 'ala_mhigo.txt',
   timelineTriggers: [
@@ -296,6 +293,4 @@ const triggerSet: TriggerSet<Data> = {
       },
     },
   ],
-};
-
-export default triggerSet;
+});

--- a/ui/raidboss/data/04-sb/dungeon/bardams_mettle.ts
+++ b/ui/raidboss/data/04-sb/dungeon/bardams_mettle.ts
@@ -1,15 +1,12 @@
+import { defineTriggerSet } from '../../../../../resources/api_define_trigger_set';
 import Conditions from '../../../../../resources/conditions';
 import NetRegexes from '../../../../../resources/netregexes';
 import { Responses } from '../../../../../resources/responses';
 import ZoneId from '../../../../../resources/zone_id';
-import { RaidbossData } from '../../../../../types/data';
-import { TriggerSet } from '../../../../../types/trigger';
 
-export interface Data extends RaidbossData {
+export default defineTriggerSet<{
   deadBardam?: boolean;
-}
-
-const triggerSet: TriggerSet<Data> = {
+}>({
   zoneId: ZoneId.BardamsMettle,
   timelineFile: 'bardams_mettle.txt',
   timelineTriggers: [
@@ -382,6 +379,4 @@ const triggerSet: TriggerSet<Data> = {
       },
     },
   ],
-};
-
-export default triggerSet;
+});

--- a/ui/raidboss/data/04-sb/dungeon/castrum_abania.ts
+++ b/ui/raidboss/data/04-sb/dungeon/castrum_abania.ts
@@ -1,15 +1,13 @@
+import { defineTriggerSet } from '../../../../../resources/api_define_trigger_set';
 import Conditions from '../../../../../resources/conditions';
 import NetRegexes from '../../../../../resources/netregexes';
 import { Responses } from '../../../../../resources/responses';
 import ZoneId from '../../../../../resources/zone_id';
-import { RaidbossData } from '../../../../../types/data';
-import { TriggerSet } from '../../../../../types/trigger';
 
-export interface Data extends RaidbossData {
+export default defineTriggerSet<{
   calledWildSpeed?: boolean;
   calledUseCannon?: boolean;
-}
-const triggerSet: TriggerSet<Data> = {
+}>({
   zoneId: ZoneId.CastrumAbania,
   timelineFile: 'castrum_abania.txt',
   triggers: [
@@ -278,6 +276,4 @@ const triggerSet: TriggerSet<Data> = {
       },
     },
   ],
-};
-
-export default triggerSet;
+});

--- a/ui/raidboss/data/04-sb/dungeon/doma_castle.ts
+++ b/ui/raidboss/data/04-sb/dungeon/doma_castle.ts
@@ -1,15 +1,12 @@
+import { defineTriggerSet } from '../../../../../resources/api_define_trigger_set';
 import Conditions from '../../../../../resources/conditions';
 import NetRegexes from '../../../../../resources/netregexes';
 import { Responses } from '../../../../../resources/responses';
 import ZoneId from '../../../../../resources/zone_id';
-import { RaidbossData } from '../../../../../types/data';
-import { TriggerSet } from '../../../../../types/trigger';
 
-export interface Data extends RaidbossData {
+export default defineTriggerSet<{
   seenTowers?: boolean;
-}
-
-const triggerSet: TriggerSet<Data> = {
+}>({
   zoneId: ZoneId.DomaCastle,
   timelineFile: 'doma_castle.txt',
   triggers: [
@@ -222,6 +219,4 @@ const triggerSet: TriggerSet<Data> = {
       },
     },
   ],
-};
-
-export default triggerSet;
+});

--- a/ui/raidboss/data/04-sb/dungeon/drowned_city_of_skalla.ts
+++ b/ui/raidboss/data/04-sb/dungeon/drowned_city_of_skalla.ts
@@ -1,13 +1,10 @@
+import { defineTriggerSet } from '../../../../../resources/api_define_trigger_set';
 import Conditions from '../../../../../resources/conditions';
 import NetRegexes from '../../../../../resources/netregexes';
 import { Responses } from '../../../../../resources/responses';
 import ZoneId from '../../../../../resources/zone_id';
-import { RaidbossData } from '../../../../../types/data';
-import { TriggerSet } from '../../../../../types/trigger';
 
-export type Data = RaidbossData;
-
-const triggerSet: TriggerSet<Data> = {
+export default defineTriggerSet({
   zoneId: ZoneId.TheDrownedCityOfSkalla,
   timelineFile: 'drowned_city_of_skalla.txt',
   timelineTriggers: [
@@ -329,6 +326,4 @@ const triggerSet: TriggerSet<Data> = {
       },
     },
   ],
-};
-
-export default triggerSet;
+});

--- a/ui/raidboss/data/04-sb/dungeon/fractal_continuum_hard.ts
+++ b/ui/raidboss/data/04-sb/dungeon/fractal_continuum_hard.ts
@@ -1,15 +1,12 @@
+import { defineTriggerSet } from '../../../../../resources/api_define_trigger_set';
 import Conditions from '../../../../../resources/conditions';
 import NetRegexes from '../../../../../resources/netregexes';
 import { Responses } from '../../../../../resources/responses';
 import ZoneId from '../../../../../resources/zone_id';
-import { RaidbossData } from '../../../../../types/data';
-import { TriggerSet } from '../../../../../types/trigger';
 
-export interface Data extends RaidbossData {
+export default defineTriggerSet<{
   dischord?: { [name: string]: string };
-}
-
-const triggerSet: TriggerSet<Data> = {
+}>({
   zoneId: ZoneId.TheFractalContinuumHard,
   timelineFile: 'fractal_continuum_hard.txt',
   timelineTriggers: [
@@ -515,6 +512,4 @@ const triggerSet: TriggerSet<Data> = {
       },
     },
   ],
-};
-
-export default triggerSet;
+});

--- a/ui/raidboss/data/04-sb/dungeon/ghimlyt_dark.ts
+++ b/ui/raidboss/data/04-sb/dungeon/ghimlyt_dark.ts
@@ -1,13 +1,10 @@
+import { defineTriggerSet } from '../../../../../resources/api_define_trigger_set';
 import Conditions from '../../../../../resources/conditions';
 import NetRegexes from '../../../../../resources/netregexes';
 import { Responses } from '../../../../../resources/responses';
 import ZoneId from '../../../../../resources/zone_id';
-import { RaidbossData } from '../../../../../types/data';
-import { TriggerSet } from '../../../../../types/trigger';
 
-export type Data = RaidbossData;
-
-const triggerSet: TriggerSet<Data> = {
+export default defineTriggerSet({
   zoneId: ZoneId.TheGhimlytDark,
   timelineFile: 'ghimlyt_dark.txt',
   timelineTriggers: [
@@ -404,6 +401,4 @@ const triggerSet: TriggerSet<Data> = {
       },
     },
   ],
-};
-
-export default triggerSet;
+});

--- a/ui/raidboss/data/04-sb/dungeon/hells_lid.ts
+++ b/ui/raidboss/data/04-sb/dungeon/hells_lid.ts
@@ -1,13 +1,10 @@
+import { defineTriggerSet } from '../../../../../resources/api_define_trigger_set';
 import Conditions from '../../../../../resources/conditions';
 import NetRegexes from '../../../../../resources/netregexes';
 import { Responses } from '../../../../../resources/responses';
 import ZoneId from '../../../../../resources/zone_id';
-import { RaidbossData } from '../../../../../types/data';
-import { TriggerSet } from '../../../../../types/trigger';
 
-export type Data = RaidbossData;
-
-const triggerSet: TriggerSet<Data> = {
+export default defineTriggerSet({
   zoneId: ZoneId.HellsLid,
   timelineFile: 'hells_lid.txt',
   timelineTriggers: [
@@ -290,6 +287,4 @@ const triggerSet: TriggerSet<Data> = {
       },
     },
   ],
-};
-
-export default triggerSet;
+});

--- a/ui/raidboss/data/04-sb/dungeon/kugane_castle.ts
+++ b/ui/raidboss/data/04-sb/dungeon/kugane_castle.ts
@@ -1,13 +1,10 @@
+import { defineTriggerSet } from '../../../../../resources/api_define_trigger_set';
 import Conditions from '../../../../../resources/conditions';
 import NetRegexes from '../../../../../resources/netregexes';
 import { Responses } from '../../../../../resources/responses';
 import ZoneId from '../../../../../resources/zone_id';
-import { RaidbossData } from '../../../../../types/data';
-import { TriggerSet } from '../../../../../types/trigger';
 
-export type Data = RaidbossData;
-
-const triggerSet: TriggerSet<Data> = {
+export default defineTriggerSet({
   zoneId: ZoneId.KuganeCastle,
   timelineFile: 'kugane_castle.txt',
   timelineTriggers: [
@@ -270,6 +267,4 @@ const triggerSet: TriggerSet<Data> = {
       },
     },
   ],
-};
-
-export default triggerSet;
+});

--- a/ui/raidboss/data/04-sb/dungeon/shisui_of_the_violet_tides.ts
+++ b/ui/raidboss/data/04-sb/dungeon/shisui_of_the_violet_tides.ts
@@ -1,13 +1,10 @@
+import { defineTriggerSet } from '../../../../../resources/api_define_trigger_set';
 import Conditions from '../../../../../resources/conditions';
 import NetRegexes from '../../../../../resources/netregexes';
 import { Responses } from '../../../../../resources/responses';
 import ZoneId from '../../../../../resources/zone_id';
-import { RaidbossData } from '../../../../../types/data';
-import { TriggerSet } from '../../../../../types/trigger';
 
-export type Data = RaidbossData;
-
-const triggerSet: TriggerSet<Data> = {
+export default defineTriggerSet({
   zoneId: ZoneId.ShisuiOfTheVioletTides,
   timelineFile: 'shisui_of_the_violet_tides.txt',
   triggers: [
@@ -228,6 +225,4 @@ const triggerSet: TriggerSet<Data> = {
       },
     },
   ],
-};
-
-export default triggerSet;
+});

--- a/ui/raidboss/data/04-sb/dungeon/sirensong_sea.ts
+++ b/ui/raidboss/data/04-sb/dungeon/sirensong_sea.ts
@@ -1,13 +1,10 @@
+import { defineTriggerSet } from '../../../../../resources/api_define_trigger_set';
 import Conditions from '../../../../../resources/conditions';
 import NetRegexes from '../../../../../resources/netregexes';
 import { Responses } from '../../../../../resources/responses';
 import ZoneId from '../../../../../resources/zone_id';
-import { RaidbossData } from '../../../../../types/data';
-import { TriggerSet } from '../../../../../types/trigger';
 
-export type Data = RaidbossData;
-
-const triggerSet: TriggerSet<Data> = {
+export default defineTriggerSet({
   zoneId: ZoneId.TheSirensongSea,
   timelineFile: 'sirensong_sea.txt',
   timelineTriggers: [
@@ -268,6 +265,4 @@ const triggerSet: TriggerSet<Data> = {
       },
     },
   ],
-};
-
-export default triggerSet;
+});

--- a/ui/raidboss/data/04-sb/dungeon/st_mocianne_hard.ts
+++ b/ui/raidboss/data/04-sb/dungeon/st_mocianne_hard.ts
@@ -1,13 +1,10 @@
+import { defineTriggerSet } from '../../../../../resources/api_define_trigger_set';
 import Conditions from '../../../../../resources/conditions';
 import NetRegexes from '../../../../../resources/netregexes';
 import { Responses } from '../../../../../resources/responses';
 import ZoneId from '../../../../../resources/zone_id';
-import { RaidbossData } from '../../../../../types/data';
-import { TriggerSet } from '../../../../../types/trigger';
 
-export type Data = RaidbossData;
-
-const triggerSet: TriggerSet<Data> = {
+export default defineTriggerSet({
   zoneId: ZoneId.SaintMociannesArboretumHard,
   timelineFile: 'st_mocianne_hard.txt',
   timelineTriggers: [
@@ -371,6 +368,4 @@ const triggerSet: TriggerSet<Data> = {
       },
     },
   ],
-};
-
-export default triggerSet;
+});

--- a/ui/raidboss/data/04-sb/dungeon/swallows_compass.ts
+++ b/ui/raidboss/data/04-sb/dungeon/swallows_compass.ts
@@ -1,17 +1,14 @@
+import { defineTriggerSet } from '../../../../../resources/api_define_trigger_set';
 import Conditions from '../../../../../resources/conditions';
 import NetRegexes from '../../../../../resources/netregexes';
 import { Responses } from '../../../../../resources/responses';
 import ZoneId from '../../../../../resources/zone_id';
-import { RaidbossData } from '../../../../../types/data';
-import { TriggerSet } from '../../../../../types/trigger';
 
-export interface Data extends RaidbossData {
+export default defineTriggerSet<{
   dynamo?: boolean;
   seenIntermission?: boolean;
   tethers?: string[];
-}
-
-const triggerSet: TriggerSet<Data> = {
+}>({
   zoneId: ZoneId.TheSwallowsCompass,
   timelineFile: 'swallows_compass.txt',
   triggers: [
@@ -423,6 +420,4 @@ const triggerSet: TriggerSet<Data> = {
       },
     },
   ],
-};
-
-export default triggerSet;
+});

--- a/ui/raidboss/data/04-sb/dungeon/temple_of_the_fist.ts
+++ b/ui/raidboss/data/04-sb/dungeon/temple_of_the_fist.ts
@@ -1,13 +1,10 @@
+import { defineTriggerSet } from '../../../../../resources/api_define_trigger_set';
 import Conditions from '../../../../../resources/conditions';
 import NetRegexes from '../../../../../resources/netregexes';
 import { Responses } from '../../../../../resources/responses';
 import ZoneId from '../../../../../resources/zone_id';
-import { RaidbossData } from '../../../../../types/data';
-import { TriggerSet } from '../../../../../types/trigger';
 
-export type Data = RaidbossData;
-
-const triggerSet: TriggerSet<Data> = {
+export default defineTriggerSet({
   zoneId: ZoneId.TheTempleOfTheFist,
   timelineFile: 'temple_of_the_fist.txt',
   timelineTriggers: [
@@ -350,6 +347,4 @@ const triggerSet: TriggerSet<Data> = {
       },
     },
   ],
-};
-
-export default triggerSet;
+});

--- a/ui/raidboss/data/04-sb/dungeon/the_burn.ts
+++ b/ui/raidboss/data/04-sb/dungeon/the_burn.ts
@@ -1,15 +1,12 @@
+import { defineTriggerSet } from '../../../../../resources/api_define_trigger_set';
 import Conditions from '../../../../../resources/conditions';
 import NetRegexes from '../../../../../resources/netregexes';
 import { Responses } from '../../../../../resources/responses';
 import ZoneId from '../../../../../resources/zone_id';
-import { RaidbossData } from '../../../../../types/data';
-import { TriggerSet } from '../../../../../types/trigger';
 
-export interface Data extends RaidbossData {
+export default defineTriggerSet<{
   hedetet?: boolean;
-}
-
-const triggerSet: TriggerSet<Data> = {
+}>({
   zoneId: ZoneId.TheBurn,
   timelineFile: 'the_burn.txt',
   triggers: [
@@ -379,6 +376,4 @@ const triggerSet: TriggerSet<Data> = {
       },
     },
   ],
-};
-
-export default triggerSet;
+});

--- a/ui/raidboss/data/04-sb/eureka/eureka_anemos.ts
+++ b/ui/raidboss/data/04-sb/eureka/eureka_anemos.ts
@@ -1,15 +1,12 @@
+import { defineTriggerSet } from '../../../../../resources/api_define_trigger_set';
 import Conditions from '../../../../../resources/conditions';
 import NetRegexes from '../../../../../resources/netregexes';
 import { Responses } from '../../../../../resources/responses';
 import ZoneId from '../../../../../resources/zone_id';
-import { RaidbossData } from '../../../../../types/data';
-import { TriggerSet } from '../../../../../types/trigger';
 
-export interface Data extends RaidbossData {
+export default defineTriggerSet<{
   wraithCount?: number;
-}
-
-const triggerSet: TriggerSet<Data> = {
+}>({
   zoneId: ZoneId.TheForbiddenLandEurekaAnemos,
   resetWhenOutOfCombat: false,
   triggers: [
@@ -186,6 +183,4 @@ const triggerSet: TriggerSet<Data> = {
       response: Responses.wakeUp(),
     },
   ],
-};
-
-export default triggerSet;
+});

--- a/ui/raidboss/data/04-sb/eureka/eureka_hydatos.ts
+++ b/ui/raidboss/data/04-sb/eureka/eureka_hydatos.ts
@@ -1,10 +1,9 @@
+import { defineTriggerSet } from '../../../../../resources/api_define_trigger_set';
 import NetRegexes from '../../../../../resources/netregexes';
 import { Responses } from '../../../../../resources/responses';
 import ZoneId from '../../../../../resources/zone_id';
-import { RaidbossData } from '../../../../../types/data';
-import { TriggerSet } from '../../../../../types/trigger';
 
-export interface Data extends RaidbossData {
+export default defineTriggerSet<{
   sealed?: boolean;
   side?: string;
   mythcall?: boolean;
@@ -12,9 +11,7 @@ export interface Data extends RaidbossData {
   seenHostile?: boolean;
   clones?: string[];
   blackHoleCount?: number;
-}
-
-const triggerSet: TriggerSet<Data> = {
+}>({
   zoneId: ZoneId.TheForbiddenLandEurekaHydatos,
   timelineFile: 'eureka_hydatos.txt',
   resetWhenOutOfCombat: false,
@@ -1298,6 +1295,4 @@ const triggerSet: TriggerSet<Data> = {
       },
     },
   ],
-};
-
-export default triggerSet;
+});

--- a/ui/raidboss/data/04-sb/eureka/eureka_pagos.ts
+++ b/ui/raidboss/data/04-sb/eureka/eureka_pagos.ts
@@ -1,12 +1,9 @@
+import { defineTriggerSet } from '../../../../../resources/api_define_trigger_set';
 import NetRegexes from '../../../../../resources/netregexes';
 import { Responses } from '../../../../../resources/responses';
 import ZoneId from '../../../../../resources/zone_id';
-import { RaidbossData } from '../../../../../types/data';
-import { TriggerSet } from '../../../../../types/trigger';
 
-export type Data = RaidbossData;
-
-const triggerSet: TriggerSet<Data> = {
+export default defineTriggerSet({
   zoneId: ZoneId.TheForbiddenLandEurekaPagos,
   resetWhenOutOfCombat: false,
   triggers: [
@@ -17,6 +14,4 @@ const triggerSet: TriggerSet<Data> = {
       response: Responses.wakeUp(),
     },
   ],
-};
-
-export default triggerSet;
+});

--- a/ui/raidboss/data/04-sb/eureka/eureka_pyros.ts
+++ b/ui/raidboss/data/04-sb/eureka/eureka_pyros.ts
@@ -1,12 +1,9 @@
+import { defineTriggerSet } from '../../../../../resources/api_define_trigger_set';
 import NetRegexes from '../../../../../resources/netregexes';
 import { Responses } from '../../../../../resources/responses';
 import ZoneId from '../../../../../resources/zone_id';
-import { RaidbossData } from '../../../../../types/data';
-import { TriggerSet } from '../../../../../types/trigger';
 
-export type Data = RaidbossData;
-
-const triggerSet: TriggerSet<Data> = {
+export default defineTriggerSet({
   zoneId: ZoneId.TheForbiddenLandEurekaPyros,
   resetWhenOutOfCombat: false,
   triggers: [
@@ -29,6 +26,4 @@ const triggerSet: TriggerSet<Data> = {
       response: Responses.wakeUp(),
     },
   ],
-};
-
-export default triggerSet;
+});

--- a/ui/raidboss/data/04-sb/raid/o10n.ts
+++ b/ui/raidboss/data/04-sb/raid/o10n.ts
@@ -1,16 +1,13 @@
+import { defineTriggerSet } from '../../../../../resources/api_define_trigger_set';
 import Conditions from '../../../../../resources/conditions';
 import NetRegexes from '../../../../../resources/netregexes';
 import { Responses } from '../../../../../resources/responses';
 import ZoneId from '../../../../../resources/zone_id';
-import { RaidbossData } from '../../../../../types/data';
-import { TriggerSet } from '../../../../../types/trigger';
-
-export interface Data extends RaidbossData {
-  lastSpinWasHorizontal?: boolean;
-}
 
 // O10N - Alphascape 2.0
-const triggerSet: TriggerSet<Data> = {
+export default defineTriggerSet<{
+  lastSpinWasHorizontal?: boolean;
+}>({
   zoneId: ZoneId.AlphascapeV20,
   timelineFile: 'o10n.txt',
   triggers: [
@@ -318,6 +315,4 @@ const triggerSet: TriggerSet<Data> = {
       },
     },
   ],
-};
-
-export default triggerSet;
+});

--- a/ui/raidboss/data/04-sb/raid/o10s.ts
+++ b/ui/raidboss/data/04-sb/raid/o10s.ts
@@ -1,13 +1,8 @@
+import { defineTriggerSet } from '../../../../../resources/api_define_trigger_set';
 import Conditions from '../../../../../resources/conditions';
 import NetRegexes from '../../../../../resources/netregexes';
 import { Responses } from '../../../../../resources/responses';
 import ZoneId from '../../../../../resources/zone_id';
-import { RaidbossData } from '../../../../../types/data';
-import { TriggerSet } from '../../../../../types/trigger';
-
-export interface Data extends RaidbossData {
-  lastSpinWasHorizontal?: boolean;
-}
 
 // TODO: fix tail end (seemed to not work??)
 // TODO: add phase tracking (so death from above/below can tell you to swap or not)
@@ -17,7 +12,9 @@ export interface Data extends RaidbossData {
 // TODO: stack head markers
 
 // O10S - Alphascape 2.0 Savage
-const triggerSet: TriggerSet<Data> = {
+export default defineTriggerSet<{
+  lastSpinWasHorizontal?: boolean;
+}>({
   zoneId: ZoneId.AlphascapeV20Savage,
   timelineFile: 'o10s.txt',
   triggers: [
@@ -383,6 +380,4 @@ const triggerSet: TriggerSet<Data> = {
       },
     },
   ],
-};
-
-export default triggerSet;
+});

--- a/ui/raidboss/data/04-sb/raid/o11n.ts
+++ b/ui/raidboss/data/04-sb/raid/o11n.ts
@@ -1,16 +1,13 @@
+import { defineTriggerSet } from '../../../../../resources/api_define_trigger_set';
 import Conditions from '../../../../../resources/conditions';
 import NetRegexes from '../../../../../resources/netregexes';
 import { Responses } from '../../../../../resources/responses';
 import ZoneId from '../../../../../resources/zone_id';
-import { RaidbossData } from '../../../../../types/data';
-import { TriggerSet } from '../../../../../types/trigger';
-
-export interface Data extends RaidbossData {
-  lastWasStarboard?: boolean;
-}
 
 // O11N - Alphascape 3.0
-const triggerSet: TriggerSet<Data> = {
+export default defineTriggerSet<{
+  lastWasStarboard?: boolean;
+}>({
   zoneId: ZoneId.AlphascapeV30,
   timelineFile: 'o11n.txt',
   timelineTriggers: [
@@ -313,6 +310,4 @@ const triggerSet: TriggerSet<Data> = {
       },
     },
   ],
-};
-
-export default triggerSet;
+});

--- a/ui/raidboss/data/04-sb/raid/o11s.ts
+++ b/ui/raidboss/data/04-sb/raid/o11s.ts
@@ -1,15 +1,12 @@
+import { defineTriggerSet } from '../../../../../resources/api_define_trigger_set';
 import NetRegexes from '../../../../../resources/netregexes';
 import { Responses } from '../../../../../resources/responses';
 import ZoneId from '../../../../../resources/zone_id';
-import { RaidbossData } from '../../../../../types/data';
-import { TriggerSet } from '../../../../../types/trigger';
-
-export interface Data extends RaidbossData {
-  lastWasStarboard?: boolean;
-}
 
 // O11S - Alphascape 3.0 Savage
-const triggerSet: TriggerSet<Data> = {
+export default defineTriggerSet<{
+  lastWasStarboard?: boolean;
+}>({
   zoneId: ZoneId.AlphascapeV30Savage,
   timelineFile: 'o11s.txt',
   triggers: [
@@ -394,6 +391,4 @@ const triggerSet: TriggerSet<Data> = {
       },
     },
   ],
-};
-
-export default triggerSet;
+});

--- a/ui/raidboss/data/04-sb/raid/o12n.ts
+++ b/ui/raidboss/data/04-sb/raid/o12n.ts
@@ -1,17 +1,14 @@
+import { defineTriggerSet } from '../../../../../resources/api_define_trigger_set';
 import Conditions from '../../../../../resources/conditions';
 import NetRegexes from '../../../../../resources/netregexes';
 import Outputs from '../../../../../resources/outputs';
 import { Responses } from '../../../../../resources/responses';
 import ZoneId from '../../../../../resources/zone_id';
-import { RaidbossData } from '../../../../../types/data';
-import { TriggerSet } from '../../../../../types/trigger';
-
-export interface Data extends RaidbossData {
-  groundZero?: string;
-}
 
 // O12N - Alphascape 4.0
-const triggerSet: TriggerSet<Data> = {
+export default defineTriggerSet<{
+  groundZero?: string;
+}>({
   zoneId: ZoneId.AlphascapeV40,
   timelineFile: 'o12n.txt',
   timelineTriggers: [
@@ -375,6 +372,4 @@ const triggerSet: TriggerSet<Data> = {
       },
     },
   ],
-};
-
-export default triggerSet;
+});

--- a/ui/raidboss/data/04-sb/raid/o12s.ts
+++ b/ui/raidboss/data/04-sb/raid/o12s.ts
@@ -1,12 +1,15 @@
+import { defineTriggerSet } from '../../../../../resources/api_define_trigger_set';
 import Conditions from '../../../../../resources/conditions';
 import NetRegexes from '../../../../../resources/netregexes';
 import Outputs from '../../../../../resources/outputs';
 import { Responses } from '../../../../../resources/responses';
 import ZoneId from '../../../../../resources/zone_id';
-import { RaidbossData } from '../../../../../types/data';
-import { TriggerSet } from '../../../../../types/trigger';
 
-export interface Data extends RaidbossData {
+// O12S - Alphascape 4.0 Savage
+
+// TODO: targetable lines in timeline
+
+export default defineTriggerSet<{
   seenDischarger?: boolean;
   isFinalOmega?: boolean;
   dpsShortStack?: boolean;
@@ -19,13 +22,7 @@ export interface Data extends RaidbossData {
   weaponPhase?: string;
   solarRayTargets?: string[];
   seenSolarRay?: boolean;
-}
-
-// O12S - Alphascape 4.0 Savage
-
-// TODO: targetable lines in timeline
-
-const triggerSet: TriggerSet<Data> = {
+}>({
   zoneId: ZoneId.AlphascapeV40Savage,
   timelineFile: 'o12s.txt',
   timelineTriggers: [
@@ -1229,6 +1226,4 @@ const triggerSet: TriggerSet<Data> = {
       },
     },
   ],
-};
-
-export default triggerSet;
+});

--- a/ui/raidboss/data/04-sb/raid/o1n.ts
+++ b/ui/raidboss/data/04-sb/raid/o1n.ts
@@ -1,13 +1,10 @@
+import { defineTriggerSet } from '../../../../../resources/api_define_trigger_set';
 import NetRegexes from '../../../../../resources/netregexes';
 import { Responses } from '../../../../../resources/responses';
 import ZoneId from '../../../../../resources/zone_id';
-import { RaidbossData } from '../../../../../types/data';
-import { TriggerSet } from '../../../../../types/trigger';
-
-export type Data = RaidbossData;
 
 // O1S - Deltascape 1.0 Normal
-const triggerSet: TriggerSet<Data> = {
+export default defineTriggerSet({
   zoneId: ZoneId.DeltascapeV10,
   timelineFile: 'o1n.txt',
   timelineTriggers: [
@@ -196,6 +193,4 @@ const triggerSet: TriggerSet<Data> = {
       },
     },
   ],
-};
-
-export default triggerSet;
+});

--- a/ui/raidboss/data/04-sb/raid/o1s.ts
+++ b/ui/raidboss/data/04-sb/raid/o1s.ts
@@ -1,13 +1,10 @@
+import { defineTriggerSet } from '../../../../../resources/api_define_trigger_set';
 import NetRegexes from '../../../../../resources/netregexes';
 import { Responses } from '../../../../../resources/responses';
 import ZoneId from '../../../../../resources/zone_id';
-import { RaidbossData } from '../../../../../types/data';
-import { TriggerSet } from '../../../../../types/trigger';
-
-export type Data = RaidbossData;
 
 // O1S - Deltascape 1.0 Savage
-const triggerSet: TriggerSet<Data> = {
+export default defineTriggerSet({
   zoneId: ZoneId.DeltascapeV10Savage,
   timelineFile: 'o1s.txt',
   triggers: [
@@ -195,6 +192,4 @@ const triggerSet: TriggerSet<Data> = {
       },
     },
   ],
-};
-
-export default triggerSet;
+});

--- a/ui/raidboss/data/04-sb/raid/o2n.ts
+++ b/ui/raidboss/data/04-sb/raid/o2n.ts
@@ -1,18 +1,15 @@
+import { defineTriggerSet } from '../../../../../resources/api_define_trigger_set';
 import Conditions from '../../../../../resources/conditions';
 import NetRegexes from '../../../../../resources/netregexes';
 import Outputs from '../../../../../resources/outputs';
 import { Responses } from '../../../../../resources/responses';
 import ZoneId from '../../../../../resources/zone_id';
-import { RaidbossData } from '../../../../../types/data';
-import { TriggerSet } from '../../../../../types/trigger';
-
-export interface Data extends RaidbossData {
-  levitating?: boolean;
-  antiCounter?: number;
-}
 
 // O2N - Deltascape 2.0 Normal
-const triggerSet: TriggerSet<Data> = {
+export default defineTriggerSet<{
+  levitating?: boolean;
+  antiCounter?: number;
+}>({
   zoneId: ZoneId.DeltascapeV20,
   timelineFile: 'o2n.txt',
   timelineTriggers: [
@@ -396,6 +393,4 @@ const triggerSet: TriggerSet<Data> = {
       },
     },
   ],
-};
-
-export default triggerSet;
+});

--- a/ui/raidboss/data/04-sb/raid/o2s.ts
+++ b/ui/raidboss/data/04-sb/raid/o2s.ts
@@ -1,21 +1,18 @@
+import { defineTriggerSet } from '../../../../../resources/api_define_trigger_set';
 import Conditions from '../../../../../resources/conditions';
 import NetRegexes from '../../../../../resources/netregexes';
 import { Responses } from '../../../../../resources/responses';
 import ZoneId from '../../../../../resources/zone_id';
-import { RaidbossData } from '../../../../../types/data';
-import { TriggerSet } from '../../../../../types/trigger';
 
-export interface Data extends RaidbossData {
+// O2S - Deltascape 2.0 Savage
+export default defineTriggerSet<{
   probeCount?: number;
   levitating?: boolean;
   blueCircle?: string[];
   dpsProbe?: boolean;
   myProbe?: boolean;
   under?: boolean;
-}
-
-// O2S - Deltascape 2.0 Savage
-const triggerSet: TriggerSet<Data> = {
+}>({
   zoneId: ZoneId.DeltascapeV20Savage,
   timelineFile: 'o2s.txt',
   timelineTriggers: [
@@ -542,6 +539,4 @@ const triggerSet: TriggerSet<Data> = {
       },
     },
   ],
-};
-
-export default triggerSet;
+});

--- a/ui/raidboss/data/04-sb/raid/o3n.ts
+++ b/ui/raidboss/data/04-sb/raid/o3n.ts
@@ -1,11 +1,11 @@
+import { defineTriggerSet } from '../../../../../resources/api_define_trigger_set';
 import NetRegexes from '../../../../../resources/netregexes';
 import Outputs from '../../../../../resources/outputs';
 import { Responses } from '../../../../../resources/responses';
 import ZoneId from '../../../../../resources/zone_id';
-import { RaidbossData } from '../../../../../types/data';
-import { TriggerSet } from '../../../../../types/trigger';
 
-export interface Data extends RaidbossData {
+// O3 - Deltascape 3.0 Normal
+export default defineTriggerSet<{
   holyTargets?: string[];
   holyCounter: number;
   gameCount: number;
@@ -15,10 +15,7 @@ export interface Data extends RaidbossData {
   // 2: Cave phase with Uplifts.
   // 3: Post-intermission, with good and bad frogs.
   phaseNumber: number;
-}
-
-// O3 - Deltascape 3.0 Normal
-const triggerSet: TriggerSet<Data> = {
+}>({
   zoneId: ZoneId.DeltascapeV30,
   timelineFile: 'o3n.txt',
   initData: () => {
@@ -484,6 +481,4 @@ const triggerSet: TriggerSet<Data> = {
       },
     },
   ],
-};
-
-export default triggerSet;
+});

--- a/ui/raidboss/data/04-sb/raid/o3s.ts
+++ b/ui/raidboss/data/04-sb/raid/o3s.ts
@@ -1,3 +1,4 @@
+import { defineTriggerSet } from '../../../../../resources/api_define_trigger_set';
 import Conditions from '../../../../../resources/conditions';
 import NetRegexes from '../../../../../resources/netregexes';
 import Outputs from '../../../../../resources/outputs';
@@ -5,10 +6,10 @@ import { Responses } from '../../../../../resources/responses';
 import ZoneId from '../../../../../resources/zone_id';
 import { RaidbossData } from '../../../../../types/data';
 import { NetMatches } from '../../../../../types/net_matches';
-import { ResponseOutput, TriggerSet } from '../../../../../types/trigger';
+import { ResponseOutput } from '../../../../../types/trigger';
 
 // export type Data = RaidbossData;
-export interface Data extends RaidbossData {
+export interface Data {
   phase?: number;
   seenHolyThisPhase?: boolean;
   holyTargets?: string[];
@@ -19,7 +20,7 @@ export interface Data extends RaidbossData {
 }
 
 // O3S - Deltascape 3.0 Savage
-const triggerSet: TriggerSet<Data> = {
+export default defineTriggerSet<Data>({
   zoneId: ZoneId.DeltascapeV30Savage,
   timelineFile: 'o3s.txt',
   timelineTriggers: [
@@ -120,7 +121,7 @@ const triggerSet: TriggerSet<Data> = {
 
         const stackTarget = data.holyTargets[1];
 
-        const ret: ResponseOutput<Data, NetMatches['HeadMarker']> = {};
+        const ret: ResponseOutput<Data & RaidbossData, NetMatches['HeadMarker']> = {};
         if (data.me === stackTarget) {
           ret.alarmText = output.stackOnYou!();
         } else {
@@ -765,6 +766,4 @@ const triggerSet: TriggerSet<Data> = {
       },
     },
   ],
-};
-
-export default triggerSet;
+});

--- a/ui/raidboss/data/04-sb/raid/o4n.ts
+++ b/ui/raidboss/data/04-sb/raid/o4n.ts
@@ -1,16 +1,13 @@
+import { defineTriggerSet } from '../../../../../resources/api_define_trigger_set';
 import Conditions from '../../../../../resources/conditions';
 import NetRegexes from '../../../../../resources/netregexes';
 import { Responses } from '../../../../../resources/responses';
 import ZoneId from '../../../../../resources/zone_id';
-import { RaidbossData } from '../../../../../types/data';
-import { TriggerSet } from '../../../../../types/trigger';
-
-export interface Data extends RaidbossData {
-  battleCount?: number;
-}
 
 // O4N - Deltascape 4.0 Normal
-const triggerSet: TriggerSet<Data> = {
+export default defineTriggerSet<{
+  battleCount?: number;
+}>({
   zoneId: ZoneId.DeltascapeV40,
   timelineFile: 'o4n.txt',
   triggers: [
@@ -278,6 +275,4 @@ const triggerSet: TriggerSet<Data> = {
       },
     },
   ],
-};
-
-export default triggerSet;
+});

--- a/ui/raidboss/data/04-sb/raid/o4s.ts
+++ b/ui/raidboss/data/04-sb/raid/o4s.ts
@@ -1,12 +1,11 @@
+import { defineTriggerSet } from '../../../../../resources/api_define_trigger_set';
 import Conditions from '../../../../../resources/conditions';
 import NetRegexes from '../../../../../resources/netregexes';
 import Outputs from '../../../../../resources/outputs';
 import { Responses } from '../../../../../resources/responses';
 import ZoneId from '../../../../../resources/zone_id';
-import { RaidbossData } from '../../../../../types/data';
-import { TriggerSet } from '../../../../../types/trigger';
 
-export interface Data extends RaidbossData {
+export interface Data {
   thunderCount?: number;
   flareTargets?: string[];
   phase?: string;
@@ -39,7 +38,7 @@ const shouldDieOnLaser = (data: Data) => {
 };
 
 // O4S - Deltascape 4.0 Savage
-const triggerSet: TriggerSet<Data> = {
+export default defineTriggerSet<Data>({
   zoneId: ZoneId.DeltascapeV40Savage,
   timelineFile: 'o4s.txt',
   timelineTriggers: [
@@ -1286,6 +1285,4 @@ const triggerSet: TriggerSet<Data> = {
       },
     },
   ],
-};
-
-export default triggerSet;
+});

--- a/ui/raidboss/data/04-sb/raid/o5n.ts
+++ b/ui/raidboss/data/04-sb/raid/o5n.ts
@@ -1,14 +1,11 @@
+import { defineTriggerSet } from '../../../../../resources/api_define_trigger_set';
 import Conditions from '../../../../../resources/conditions';
 import NetRegexes from '../../../../../resources/netregexes';
 import { Responses } from '../../../../../resources/responses';
 import ZoneId from '../../../../../resources/zone_id';
-import { RaidbossData } from '../../../../../types/data';
-import { TriggerSet } from '../../../../../types/trigger';
-
-export type Data = RaidbossData;
 
 // O5N - Sigmascape 1.0 Normal
-const triggerSet: TriggerSet<Data> = {
+export default defineTriggerSet({
   zoneId: ZoneId.SigmascapeV10,
   timelineFile: 'o5n.txt',
   resetWhenOutOfCombat: false,
@@ -217,6 +214,4 @@ const triggerSet: TriggerSet<Data> = {
       },
     },
   ],
-};
-
-export default triggerSet;
+});

--- a/ui/raidboss/data/04-sb/raid/o5s.ts
+++ b/ui/raidboss/data/04-sb/raid/o5s.ts
@@ -1,14 +1,11 @@
+import { defineTriggerSet } from '../../../../../resources/api_define_trigger_set';
 import Conditions from '../../../../../resources/conditions';
 import NetRegexes from '../../../../../resources/netregexes';
 import { Responses } from '../../../../../resources/responses';
 import ZoneId from '../../../../../resources/zone_id';
-import { RaidbossData } from '../../../../../types/data';
-import { TriggerSet } from '../../../../../types/trigger';
-
-export type Data = RaidbossData;
 
 // O5S - Sigmascape 1.0 Savage
-const triggerSet: TriggerSet<Data> = {
+export default defineTriggerSet({
   zoneId: ZoneId.SigmascapeV10Savage,
   timelineFile: 'o5s.txt',
   resetWhenOutOfCombat: false,
@@ -217,6 +214,4 @@ const triggerSet: TriggerSet<Data> = {
       },
     },
   ],
-};
-
-export default triggerSet;
+});

--- a/ui/raidboss/data/04-sb/raid/o6n.ts
+++ b/ui/raidboss/data/04-sb/raid/o6n.ts
@@ -1,16 +1,13 @@
+import { defineTriggerSet } from '../../../../../resources/api_define_trigger_set';
 import Conditions from '../../../../../resources/conditions';
 import NetRegexes from '../../../../../resources/netregexes';
 import { Responses } from '../../../../../resources/responses';
 import ZoneId from '../../../../../resources/zone_id';
-import { RaidbossData } from '../../../../../types/data';
-import { TriggerSet } from '../../../../../types/trigger';
-
-export type Data = RaidbossData;
 
 // TODO: handle paintings? <_<
 
 // O6N - Sigmascape 2.0 Normal
-const triggerSet: TriggerSet<Data> = {
+export default defineTriggerSet({
   zoneId: ZoneId.SigmascapeV20,
   timelineFile: 'o6n.txt',
   triggers: [
@@ -204,6 +201,4 @@ const triggerSet: TriggerSet<Data> = {
       },
     },
   ],
-};
-
-export default triggerSet;
+});

--- a/ui/raidboss/data/04-sb/raid/o6s.ts
+++ b/ui/raidboss/data/04-sb/raid/o6s.ts
@@ -1,16 +1,13 @@
+import { defineTriggerSet } from '../../../../../resources/api_define_trigger_set';
 import Conditions from '../../../../../resources/conditions';
 import NetRegexes from '../../../../../resources/netregexes';
 import { Responses } from '../../../../../resources/responses';
 import ZoneId from '../../../../../resources/zone_id';
-import { RaidbossData } from '../../../../../types/data';
-import { TriggerSet } from '../../../../../types/trigger';
-
-export interface Data extends RaidbossData {
-  lastKiss?: string;
-}
 
 // O6S - Sigmascape 2.0 Savage
-const triggerSet: TriggerSet<Data> = {
+export default defineTriggerSet<{
+  lastKiss?: string;
+}>({
   zoneId: ZoneId.SigmascapeV20Savage,
   timelineFile: 'o6s.txt',
   triggers: [
@@ -301,6 +298,4 @@ const triggerSet: TriggerSet<Data> = {
       },
     },
   ],
-};
-
-export default triggerSet;
+});

--- a/ui/raidboss/data/04-sb/raid/o7n.ts
+++ b/ui/raidboss/data/04-sb/raid/o7n.ts
@@ -1,15 +1,12 @@
+import { defineTriggerSet } from '../../../../../resources/api_define_trigger_set';
 import NetRegexes from '../../../../../resources/netregexes';
 import { Responses } from '../../../../../resources/responses';
 import ZoneId from '../../../../../resources/zone_id';
-import { RaidbossData } from '../../../../../types/data';
-import { TriggerSet } from '../../../../../types/trigger';
 
 // TODO: kill adds from failed Demon Simulation?
 
-export type Data = RaidbossData;
-
 // O7N - Sigmascape 3.0 Normal
-const triggerSet: TriggerSet<Data> = {
+export default defineTriggerSet({
   zoneId: ZoneId.SigmascapeV30,
   timelineFile: 'o7n.txt',
   timelineTriggers: [
@@ -299,6 +296,4 @@ const triggerSet: TriggerSet<Data> = {
       },
     },
   ],
-};
-
-export default triggerSet;
+});

--- a/ui/raidboss/data/04-sb/raid/o7s.ts
+++ b/ui/raidboss/data/04-sb/raid/o7s.ts
@@ -1,21 +1,18 @@
+import { defineTriggerSet } from '../../../../../resources/api_define_trigger_set';
 import Conditions from '../../../../../resources/conditions';
 import NetRegexes from '../../../../../resources/netregexes';
 import { Responses } from '../../../../../resources/responses';
 import ZoneId from '../../../../../resources/zone_id';
-import { RaidbossData } from '../../../../../types/data';
-import { TriggerSet } from '../../../../../types/trigger';
 
-export interface Data extends RaidbossData {
+// O7S - Sigmascape 3.0 Savage
+export default defineTriggerSet<{
   rot?: boolean;
   seenVirus?: boolean;
   first?: string;
   second?: string;
   loadCount?: number;
   runCount?: number;
-}
-
-// O7S - Sigmascape 3.0 Savage
-const triggerSet: TriggerSet<Data> = {
+}>({
   zoneId: ZoneId.SigmascapeV30Savage,
   timelineFile: 'o7s.txt',
   triggers: [
@@ -593,6 +590,4 @@ const triggerSet: TriggerSet<Data> = {
       },
     },
   ],
-};
-
-export default triggerSet;
+});

--- a/ui/raidboss/data/04-sb/raid/o8n.ts
+++ b/ui/raidboss/data/04-sb/raid/o8n.ts
@@ -1,14 +1,11 @@
+import { defineTriggerSet } from '../../../../../resources/api_define_trigger_set';
 import Conditions from '../../../../../resources/conditions';
 import NetRegexes from '../../../../../resources/netregexes';
 import { Responses } from '../../../../../resources/responses';
 import ZoneId from '../../../../../resources/zone_id';
-import { RaidbossData } from '../../../../../types/data';
-import { TriggerSet } from '../../../../../types/trigger';
-
-export type Data = RaidbossData;
 
 // O8N - Sigmascape 4.0 Normal
-const triggerSet: TriggerSet<Data> = {
+export default defineTriggerSet({
   zoneId: ZoneId.SigmascapeV40,
   timelineFile: 'o8n.txt',
   triggers: [
@@ -339,6 +336,4 @@ const triggerSet: TriggerSet<Data> = {
       },
     },
   ],
-};
-
-export default triggerSet;
+});

--- a/ui/raidboss/data/04-sb/raid/o8s.ts
+++ b/ui/raidboss/data/04-sb/raid/o8s.ts
@@ -1,20 +1,9 @@
+import { defineTriggerSet } from '../../../../../resources/api_define_trigger_set';
 import Conditions from '../../../../../resources/conditions';
 import NetRegexes from '../../../../../resources/netregexes';
 import Outputs from '../../../../../resources/outputs';
 import { Responses } from '../../../../../resources/responses';
 import ZoneId from '../../../../../resources/zone_id';
-import { RaidbossData } from '../../../../../types/data';
-import { TriggerSet } from '../../../../../types/trigger';
-
-export interface Data extends RaidbossData {
-  truths?: boolean;
-  antics?: boolean;
-  lastFire?: string;
-  lastThunder?: string;
-  lastIceDir?: string;
-  manaReleaseText?: string;
-  fireMarker?: string;
-}
 
 const strings = {
   typeAndDir: {
@@ -85,7 +74,15 @@ const strings = {
 };
 
 // O8S - Sigmascape 4.0 Savage
-const triggerSet: TriggerSet<Data> = {
+export default defineTriggerSet<{
+  truths?: boolean;
+  antics?: boolean;
+  lastFire?: string;
+  lastThunder?: string;
+  lastIceDir?: string;
+  manaReleaseText?: string;
+  fireMarker?: string;
+}>({
   zoneId: ZoneId.SigmascapeV40Savage,
   timelineFile: 'o8s.txt',
   triggers: [
@@ -831,6 +828,4 @@ const triggerSet: TriggerSet<Data> = {
       },
     },
   ],
-};
-
-export default triggerSet;
+});

--- a/ui/raidboss/data/04-sb/raid/o9n.ts
+++ b/ui/raidboss/data/04-sb/raid/o9n.ts
@@ -1,17 +1,14 @@
+import { defineTriggerSet } from '../../../../../resources/api_define_trigger_set';
 import Conditions from '../../../../../resources/conditions';
 import NetRegexes from '../../../../../resources/netregexes';
 import Outputs from '../../../../../resources/outputs';
 import { Responses } from '../../../../../resources/responses';
 import ZoneId from '../../../../../resources/zone_id';
-import { RaidbossData } from '../../../../../types/data';
-import { TriggerSet } from '../../../../../types/trigger';
-
-export interface Data extends RaidbossData {
-  stackMarker?: string[];
-}
 
 // O9N - Alphascape 1.0
-const triggerSet: TriggerSet<Data> = {
+export default defineTriggerSet<{
+  stackMarker?: string[];
+}>({
   zoneId: ZoneId.AlphascapeV10,
   timelineFile: 'o9n.txt',
   triggers: [
@@ -283,6 +280,4 @@ const triggerSet: TriggerSet<Data> = {
       },
     },
   ],
-};
-
-export default triggerSet;
+});

--- a/ui/raidboss/data/04-sb/raid/o9s.ts
+++ b/ui/raidboss/data/04-sb/raid/o9s.ts
@@ -1,22 +1,19 @@
+import { defineTriggerSet } from '../../../../../resources/api_define_trigger_set';
 import Conditions from '../../../../../resources/conditions';
 import NetRegexes from '../../../../../resources/netregexes';
 import Outputs from '../../../../../resources/outputs';
 import { Responses } from '../../../../../resources/responses';
 import ZoneId from '../../../../../resources/zone_id';
-import { RaidbossData } from '../../../../../types/data';
-import { TriggerSet } from '../../../../../types/trigger';
 
-export interface Data extends RaidbossData {
+// O9S - Alphascape 1.0 Savage
+export default defineTriggerSet<{
   primordialCrust?: boolean;
   entropyCount?: number;
   phaseType?: string;
   wind?: string;
   head?: string;
   blazeCount?: number;
-}
-
-// O9S - Alphascape 1.0 Savage
-const triggerSet: TriggerSet<Data> = {
+}>({
   zoneId: ZoneId.AlphascapeV10Savage,
   timelineFile: 'o9s.txt',
   triggers: [
@@ -655,6 +652,4 @@ const triggerSet: TriggerSet<Data> = {
       },
     },
   ],
-};
-
-export default triggerSet;
+});

--- a/ui/raidboss/data/04-sb/trial/byakko-ex.ts
+++ b/ui/raidboss/data/04-sb/trial/byakko-ex.ts
@@ -1,17 +1,14 @@
+import { defineTriggerSet } from '../../../../../resources/api_define_trigger_set';
 import Conditions from '../../../../../resources/conditions';
 import NetRegexes from '../../../../../resources/netregexes';
 import { Responses } from '../../../../../resources/responses';
 import ZoneId from '../../../../../resources/zone_id';
-import { RaidbossData } from '../../../../../types/data';
-import { TriggerSet } from '../../../../../types/trigger';
-
-export interface Data extends RaidbossData {
-  roarCount?: number;
-  stakeCount?: number;
-}
 
 // Byakko Extreme
-const triggerSet: TriggerSet<Data> = {
+export default defineTriggerSet<{
+  roarCount?: number;
+  stakeCount?: number;
+}>({
   zoneId: ZoneId.TheJadeStoaExtreme,
   timelineFile: 'byakko-ex.txt',
   triggers: [
@@ -414,6 +411,4 @@ const triggerSet: TriggerSet<Data> = {
       },
     },
   ],
-};
-
-export default triggerSet;
+});

--- a/ui/raidboss/data/04-sb/trial/byakko.ts
+++ b/ui/raidboss/data/04-sb/trial/byakko.ts
@@ -1,14 +1,11 @@
+import { defineTriggerSet } from '../../../../../resources/api_define_trigger_set';
 import Conditions from '../../../../../resources/conditions';
 import NetRegexes from '../../../../../resources/netregexes';
 import { Responses } from '../../../../../resources/responses';
 import ZoneId from '../../../../../resources/zone_id';
-import { RaidbossData } from '../../../../../types/data';
-import { TriggerSet } from '../../../../../types/trigger';
-
-export type Data = RaidbossData;
 
 // Byakko Normal
-const triggerSet: TriggerSet<Data> = {
+export default defineTriggerSet({
   zoneId: ZoneId.TheJadeStoa,
   timelineFile: 'byakko.txt',
   triggers: [
@@ -197,6 +194,4 @@ const triggerSet: TriggerSet<Data> = {
       },
     },
   ],
-};
-
-export default triggerSet;
+});

--- a/ui/raidboss/data/04-sb/trial/lakshmi-ex.ts
+++ b/ui/raidboss/data/04-sb/trial/lakshmi-ex.ts
@@ -1,17 +1,14 @@
+import { defineTriggerSet } from '../../../../../resources/api_define_trigger_set';
 import Conditions from '../../../../../resources/conditions';
 import NetRegexes from '../../../../../resources/netregexes';
 import Outputs from '../../../../../resources/outputs';
 import { Responses } from '../../../../../resources/responses';
 import ZoneId from '../../../../../resources/zone_id';
-import { RaidbossData } from '../../../../../types/data';
-import { TriggerSet } from '../../../../../types/trigger';
-
-export interface Data extends RaidbossData {
-  chanchala?: boolean;
-}
 
 // Lakshmi Extreme
-const triggerSet: TriggerSet<Data> = {
+export default defineTriggerSet<{
+  chanchala?: boolean;
+}>({
   zoneId: ZoneId.EmanationExtreme,
   timelineFile: 'lakshmi-ex.txt',
   timelineTriggers: [
@@ -442,6 +439,4 @@ const triggerSet: TriggerSet<Data> = {
       },
     },
   ],
-};
-
-export default triggerSet;
+});

--- a/ui/raidboss/data/04-sb/trial/lakshmi.ts
+++ b/ui/raidboss/data/04-sb/trial/lakshmi.ts
@@ -1,18 +1,15 @@
+import { defineTriggerSet } from '../../../../../resources/api_define_trigger_set';
 import Conditions from '../../../../../resources/conditions';
 import NetRegexes from '../../../../../resources/netregexes';
 import Outputs from '../../../../../resources/outputs';
 import { Responses } from '../../../../../resources/responses';
 import ZoneId from '../../../../../resources/zone_id';
-import { RaidbossData } from '../../../../../types/data';
-import { TriggerSet } from '../../../../../types/trigger';
-
-export interface Data extends RaidbossData {
-  chanchala?: boolean;
-  avoidStack?: string[];
-}
 
 // Lakshmi Normal
-const triggerSet: TriggerSet<Data> = {
+export default defineTriggerSet<{
+  chanchala?: boolean;
+  avoidStack?: string[];
+}>({
   zoneId: ZoneId.Emanation,
   timelineFile: 'lakshmi.txt',
   triggers: [
@@ -365,6 +362,4 @@ const triggerSet: TriggerSet<Data> = {
       },
     },
   ],
-};
-
-export default triggerSet;
+});

--- a/ui/raidboss/data/04-sb/trial/rathalos-ex.ts
+++ b/ui/raidboss/data/04-sb/trial/rathalos-ex.ts
@@ -1,16 +1,13 @@
+import { defineTriggerSet } from '../../../../../resources/api_define_trigger_set';
 import Conditions from '../../../../../resources/conditions';
 import NetRegexes from '../../../../../resources/netregexes';
 import { Responses } from '../../../../../resources/responses';
 import ZoneId from '../../../../../resources/zone_id';
-import { RaidbossData } from '../../../../../types/data';
-import { TriggerSet } from '../../../../../types/trigger';
-
-export type Data = RaidbossData;
 
 // Note: no warning for Roar (2CC3, 285D).
 
 // Rathalos Extreme
-const triggerSet: TriggerSet<Data> = {
+export default defineTriggerSet({
   zoneId: ZoneId.TheGreatHuntExtreme,
   // Mechanics are random, no timeline is possible.
   hasNoTimeline: true,
@@ -185,6 +182,4 @@ const triggerSet: TriggerSet<Data> = {
       },
     },
   ],
-};
-
-export default triggerSet;
+});

--- a/ui/raidboss/data/04-sb/trial/rathalos.ts
+++ b/ui/raidboss/data/04-sb/trial/rathalos.ts
@@ -1,17 +1,14 @@
+import { defineTriggerSet } from '../../../../../resources/api_define_trigger_set';
 import Conditions from '../../../../../resources/conditions';
 import NetRegexes from '../../../../../resources/netregexes';
 import { Responses } from '../../../../../resources/responses';
 import ZoneId from '../../../../../resources/zone_id';
-import { RaidbossData } from '../../../../../types/data';
-import { TriggerSet } from '../../../../../types/trigger';
 
 // Note: To avoid too many alert-level triggers here, all of the "out of front"
 // ones are info, under the assumption that you should never be in front.
 
-export type Data = RaidbossData;
-
 // Rathalos Extreme
-const triggerSet: TriggerSet<Data> = {
+export default defineTriggerSet({
   zoneId: ZoneId.TheGreatHunt,
   // Mechanics are random, no timeline is possible.
   hasNoTimeline: true,
@@ -168,6 +165,4 @@ const triggerSet: TriggerSet<Data> = {
       },
     },
   ],
-};
-
-export default triggerSet;
+});

--- a/ui/raidboss/data/04-sb/trial/seiryu-ex.ts
+++ b/ui/raidboss/data/04-sb/trial/seiryu-ex.ts
@@ -1,18 +1,15 @@
+import { defineTriggerSet } from '../../../../../resources/api_define_trigger_set';
 import NetRegexes from '../../../../../resources/netregexes';
 import Outputs from '../../../../../resources/outputs';
 import { Responses } from '../../../../../resources/responses';
 import ZoneId from '../../../../../resources/zone_id';
-import { RaidbossData } from '../../../../../types/data';
-import { TriggerSet } from '../../../../../types/trigger';
 
-export interface Data extends RaidbossData {
+// Seiryu Extreme
+export default defineTriggerSet<{
   blazing?: boolean;
   markers?: string[];
   withForce?: boolean;
-}
-
-// Seiryu Extreme
-const triggerSet: TriggerSet<Data> = {
+}>({
   zoneId: ZoneId.TheWreathOfSnakesExtreme,
   timelineFile: 'seiryu-ex.txt',
   timelineTriggers: [
@@ -518,6 +515,4 @@ const triggerSet: TriggerSet<Data> = {
       },
     },
   ],
-};
-
-export default triggerSet;
+});

--- a/ui/raidboss/data/04-sb/trial/seiryu.ts
+++ b/ui/raidboss/data/04-sb/trial/seiryu.ts
@@ -1,17 +1,14 @@
+import { defineTriggerSet } from '../../../../../resources/api_define_trigger_set';
 import Conditions from '../../../../../resources/conditions';
 import NetRegexes from '../../../../../resources/netregexes';
 import Outputs from '../../../../../resources/outputs';
 import { Responses } from '../../../../../resources/responses';
 import ZoneId from '../../../../../resources/zone_id';
-import { RaidbossData } from '../../../../../types/data';
-import { TriggerSet } from '../../../../../types/trigger';
-
-export interface Data extends RaidbossData {
-  redRush?: string[];
-}
 
 // Seiryu Normal
-const triggerSet: TriggerSet<Data> = {
+export default defineTriggerSet<{
+  redRush?: string[];
+}>({
   zoneId: ZoneId.TheWreathOfSnakes,
   timelineFile: 'seiryu.txt',
   timelineTriggers: [
@@ -345,6 +342,4 @@ const triggerSet: TriggerSet<Data> = {
       },
     },
   ],
-};
-
-export default triggerSet;
+});

--- a/ui/raidboss/data/04-sb/trial/shinryu-ex.ts
+++ b/ui/raidboss/data/04-sb/trial/shinryu-ex.ts
@@ -1,18 +1,15 @@
+import { defineTriggerSet } from '../../../../../resources/api_define_trigger_set';
 import Conditions from '../../../../../resources/conditions';
 import NetRegexes from '../../../../../resources/netregexes';
 import { Responses } from '../../../../../resources/responses';
 import ZoneId from '../../../../../resources/zone_id';
-import { RaidbossData } from '../../../../../types/data';
-import { TriggerSet } from '../../../../../types/trigger';
 
-export interface Data extends RaidbossData {
+// Shinryu Extreme
+export default defineTriggerSet<{
   phase?: number;
   finalWing?: boolean;
   shakerTargets?: string[];
-}
-
-// Shinryu Extreme
-const triggerSet: TriggerSet<Data> = {
+}>({
   zoneId: ZoneId.TheMinstrelsBalladShinryusDomain,
   timelineFile: 'shinryu-ex.txt',
   triggers: [
@@ -825,6 +822,4 @@ const triggerSet: TriggerSet<Data> = {
       },
     },
   ],
-};
-
-export default triggerSet;
+});

--- a/ui/raidboss/data/04-sb/trial/shinryu.ts
+++ b/ui/raidboss/data/04-sb/trial/shinryu.ts
@@ -1,16 +1,13 @@
+import { defineTriggerSet } from '../../../../../resources/api_define_trigger_set';
 import Conditions from '../../../../../resources/conditions';
 import NetRegexes from '../../../../../resources/netregexes';
 import { Responses } from '../../../../../resources/responses';
 import ZoneId from '../../../../../resources/zone_id';
-import { RaidbossData } from '../../../../../types/data';
-import { TriggerSet } from '../../../../../types/trigger';
-
-export interface Data extends RaidbossData {
-  finalPhase?: boolean;
-}
 
 // Shinryu Normal
-const triggerSet: TriggerSet<Data> = {
+export default defineTriggerSet<{
+  finalPhase?: boolean;
+}>({
   zoneId: ZoneId.TheRoyalMenagerie,
   timelineFile: 'shinryu.txt',
   triggers: [
@@ -408,6 +405,4 @@ const triggerSet: TriggerSet<Data> = {
       },
     },
   ],
-};
-
-export default triggerSet;
+});

--- a/ui/raidboss/data/04-sb/trial/susano-ex.ts
+++ b/ui/raidboss/data/04-sb/trial/susano-ex.ts
@@ -1,19 +1,16 @@
+import { defineTriggerSet } from '../../../../../resources/api_define_trigger_set';
 import Conditions from '../../../../../resources/conditions';
 import NetRegexes from '../../../../../resources/netregexes';
 import Outputs from '../../../../../resources/outputs';
 import { Responses } from '../../../../../resources/responses';
 import ZoneId from '../../../../../resources/zone_id';
-import { RaidbossData } from '../../../../../types/data';
-import { TriggerSet } from '../../../../../types/trigger';
 
-export interface Data extends RaidbossData {
+// Susano Extreme
+export default defineTriggerSet<{
   cloud?: boolean;
   churning?: boolean;
   levinbolt?: string;
-}
-
-// Susano Extreme
-const triggerSet: TriggerSet<Data> = {
+}>({
   zoneId: ZoneId.ThePoolOfTributeExtreme,
   timelineFile: 'susano-ex.txt',
   timelineTriggers: [
@@ -383,6 +380,4 @@ const triggerSet: TriggerSet<Data> = {
       },
     },
   ],
-};
-
-export default triggerSet;
+});

--- a/ui/raidboss/data/04-sb/trial/susano.ts
+++ b/ui/raidboss/data/04-sb/trial/susano.ts
@@ -1,14 +1,11 @@
+import { defineTriggerSet } from '../../../../../resources/api_define_trigger_set';
 import Conditions from '../../../../../resources/conditions';
 import NetRegexes from '../../../../../resources/netregexes';
 import { Responses } from '../../../../../resources/responses';
 import ZoneId from '../../../../../resources/zone_id';
-import { RaidbossData } from '../../../../../types/data';
-import { TriggerSet } from '../../../../../types/trigger';
-
-export type Data = RaidbossData;
 
 // Susano Normal
-const triggerSet: TriggerSet<Data> = {
+export default defineTriggerSet({
   zoneId: ZoneId.ThePoolOfTribute,
   timelineFile: 'susano.txt',
   timelineTriggers: [
@@ -172,6 +169,4 @@ const triggerSet: TriggerSet<Data> = {
       },
     },
   ],
-};
-
-export default triggerSet;
+});

--- a/ui/raidboss/data/04-sb/trial/suzaku-ex.ts
+++ b/ui/raidboss/data/04-sb/trial/suzaku-ex.ts
@@ -1,14 +1,11 @@
+import { defineTriggerSet } from '../../../../../resources/api_define_trigger_set';
 import NetRegexes from '../../../../../resources/netregexes';
 import Outputs from '../../../../../resources/outputs';
 import { Responses } from '../../../../../resources/responses';
 import ZoneId from '../../../../../resources/zone_id';
-import { RaidbossData } from '../../../../../types/data';
-import { TriggerSet } from '../../../../../types/trigger';
-
-export type Data = RaidbossData;
 
 // Suzaku Extreme
-const triggerSet: TriggerSet<Data> = {
+export default defineTriggerSet({
   zoneId: ZoneId.HellsKierExtreme,
   timelineFile: 'suzaku-ex.txt',
   triggers: [
@@ -222,6 +219,4 @@ const triggerSet: TriggerSet<Data> = {
       },
     },
   ],
-};
-
-export default triggerSet;
+});

--- a/ui/raidboss/data/04-sb/trial/suzaku.ts
+++ b/ui/raidboss/data/04-sb/trial/suzaku.ts
@@ -1,14 +1,11 @@
+import { defineTriggerSet } from '../../../../../resources/api_define_trigger_set';
 import Conditions from '../../../../../resources/conditions';
 import NetRegexes from '../../../../../resources/netregexes';
 import { Responses } from '../../../../../resources/responses';
 import ZoneId from '../../../../../resources/zone_id';
-import { RaidbossData } from '../../../../../types/data';
-import { TriggerSet } from '../../../../../types/trigger';
-
-export type Data = RaidbossData;
 
 // Suzaku Normal
-const triggerSet: TriggerSet<Data> = {
+export default defineTriggerSet({
   zoneId: ZoneId.HellsKier,
   timelineFile: 'suzaku.txt',
   triggers: [
@@ -228,6 +225,4 @@ const triggerSet: TriggerSet<Data> = {
       },
     },
   ],
-};
-
-export default triggerSet;
+});

--- a/ui/raidboss/data/04-sb/trial/tsukuyomi-ex.ts
+++ b/ui/raidboss/data/04-sb/trial/tsukuyomi-ex.ts
@@ -1,19 +1,16 @@
+import { defineTriggerSet } from '../../../../../resources/api_define_trigger_set';
 import Conditions from '../../../../../resources/conditions';
 import NetRegexes from '../../../../../resources/netregexes';
 import Outputs from '../../../../../resources/outputs';
 import { Responses } from '../../../../../resources/responses';
 import ZoneId from '../../../../../resources/zone_id';
-import { RaidbossData } from '../../../../../types/data';
-import { TriggerSet } from '../../../../../types/trigger';
 
-export interface Data extends RaidbossData {
+// Tsukuyomi Extreme
+export default defineTriggerSet<{
   moonIsOut?: boolean;
   moonlitCount?: number;
   moonshadowedCount?: number;
-}
-
-// Tsukuyomi Extreme
-const triggerSet: TriggerSet<Data> = {
+}>({
   zoneId: ZoneId.TheMinstrelsBalladTsukuyomisPain,
   timelineFile: 'tsukuyomi-ex.txt',
   triggers: [
@@ -508,6 +505,4 @@ const triggerSet: TriggerSet<Data> = {
       },
     },
   ],
-};
-
-export default triggerSet;
+});

--- a/ui/raidboss/data/04-sb/trial/tsukuyomi.ts
+++ b/ui/raidboss/data/04-sb/trial/tsukuyomi.ts
@@ -1,13 +1,10 @@
+import { defineTriggerSet } from '../../../../../resources/api_define_trigger_set';
 import NetRegexes from '../../../../../resources/netregexes';
 import { Responses } from '../../../../../resources/responses';
 import ZoneId from '../../../../../resources/zone_id';
-import { RaidbossData } from '../../../../../types/data';
-import { TriggerSet } from '../../../../../types/trigger';
-
-export type Data = RaidbossData;
 
 // Tsukuyomi Normal
-const triggerSet: TriggerSet<Data> = {
+export default defineTriggerSet({
   zoneId: ZoneId.CastrumFluminis,
   timelineFile: 'tsukuyomi.txt',
   triggers: [
@@ -309,6 +306,4 @@ const triggerSet: TriggerSet<Data> = {
       },
     },
   ],
-};
-
-export default triggerSet;
+});

--- a/ui/raidboss/data/04-sb/trial/yojimbo.ts
+++ b/ui/raidboss/data/04-sb/trial/yojimbo.ts
@@ -1,13 +1,10 @@
+import { defineTriggerSet } from '../../../../../resources/api_define_trigger_set';
 import Conditions from '../../../../../resources/conditions';
 import NetRegexes from '../../../../../resources/netregexes';
 import { Responses } from '../../../../../resources/responses';
 import ZoneId from '../../../../../resources/zone_id';
-import { RaidbossData } from '../../../../../types/data';
-import { TriggerSet } from '../../../../../types/trigger';
 
-export type Data = RaidbossData;
-
-const triggerSet: TriggerSet<Data> = {
+export default defineTriggerSet({
   zoneId: ZoneId.KuganeOhashi,
   timelineFile: 'yojimbo.txt',
   triggers: [
@@ -222,6 +219,4 @@ const triggerSet: TriggerSet<Data> = {
       },
     },
   ],
-};
-
-export default triggerSet;
+});

--- a/ui/raidboss/data/04-sb/ultimate/ultima_weapon_ultimate.ts
+++ b/ui/raidboss/data/04-sb/ultimate/ultima_weapon_ultimate.ts
@@ -1,20 +1,17 @@
+import { defineTriggerSet } from '../../../../../resources/api_define_trigger_set';
 import Conditions from '../../../../../resources/conditions';
 import NetRegexes from '../../../../../resources/netregexes';
 import Outputs from '../../../../../resources/outputs';
 import { Responses } from '../../../../../resources/responses';
 import ZoneId from '../../../../../resources/zone_id';
-import { RaidbossData } from '../../../../../types/data';
 import { NetMatches } from '../../../../../types/net_matches';
-import { TriggerSet } from '../../../../../types/trigger';
 
-export interface Data extends RaidbossData {
+// Ultima Weapon Ultimate
+export default defineTriggerSet<{
   phase?: string;
   titanGaols?: string[];
   titanBury?: NetMatches['AddedCombatant'][];
-}
-
-// Ultima Weapon Ultimate
-const triggerSet: TriggerSet<Data> = {
+}>({
   zoneId: ZoneId.TheWeaponsRefrainUltimate,
   timelineFile: 'ultima_weapon_ultimate.txt',
   timelineTriggers: [
@@ -783,6 +780,4 @@ const triggerSet: TriggerSet<Data> = {
       },
     },
   ],
-};
-
-export default triggerSet;
+});

--- a/ui/raidboss/data/04-sb/ultimate/unending_coil_ultimate.ts
+++ b/ui/raidboss/data/04-sb/ultimate/unending_coil_ultimate.ts
@@ -1,13 +1,12 @@
+import { defineTriggerSet } from '../../../../../resources/api_define_trigger_set';
 import Conditions from '../../../../../resources/conditions';
 import NetRegexes from '../../../../../resources/netregexes';
 import Outputs from '../../../../../resources/outputs';
 import { Responses } from '../../../../../resources/responses';
 import Util from '../../../../../resources/util';
 import ZoneId from '../../../../../resources/zone_id';
-import { RaidbossData } from '../../../../../types/data';
-import { TriggerSet } from '../../../../../types/trigger';
 
-export interface Data extends RaidbossData {
+export interface Data {
   // TODO: replace partyList with data.party
   partyList: { [name: string]: boolean };
   hpThresholds: number[];
@@ -172,7 +171,7 @@ export const findDragonMarks = (array: number[]): undefined | { wideThirdDive: b
 // End copy and paste.
 
 // UCU - The Unending Coil Of Bahamut (Ultimate)
-const triggerSet: TriggerSet<Data> = {
+export default defineTriggerSet<Data>({
   zoneId: ZoneId.TheUnendingCoilOfBahamutUltimate,
   timelineFile: 'unending_coil_ultimate.txt',
   initData: () => {
@@ -2033,6 +2032,4 @@ const triggerSet: TriggerSet<Data> = {
       },
     },
   ],
-};
-
-export default triggerSet;
+});

--- a/ui/raidboss/data/05-shb/alliance/the_copied_factory.ts
+++ b/ui/raidboss/data/05-shb/alliance/the_copied_factory.ts
@@ -1,14 +1,8 @@
+import { defineTriggerSet } from '../../../../../resources/api_define_trigger_set';
 import Conditions from '../../../../../resources/conditions';
 import NetRegexes from '../../../../../resources/netregexes';
 import { Responses } from '../../../../../resources/responses';
 import ZoneId from '../../../../../resources/zone_id';
-import { RaidbossData } from '../../../../../types/data';
-import { TriggerSet } from '../../../../../types/trigger';
-
-export interface Data extends RaidbossData {
-  lightfastCount?: number;
-  alliance?: string;
-}
 
 // The Copied Factory
 // TODO: Tell people where to stand for Engels wall saws
@@ -16,7 +10,10 @@ export interface Data extends RaidbossData {
 // TODO: Tell people where to go for 9S divebombs
 // TODO: Tell people where to go for 9S tethered tank
 
-const triggerSet: TriggerSet<Data> = {
+export default defineTriggerSet<{
+  lightfastCount?: number;
+  alliance?: string;
+}>({
   zoneId: ZoneId.TheCopiedFactory,
   timelineFile: 'the_copied_factory.txt',
   timelineTriggers: [
@@ -1119,6 +1116,4 @@ const triggerSet: TriggerSet<Data> = {
       },
     },
   ],
-};
-
-export default triggerSet;
+});

--- a/ui/raidboss/data/05-shb/alliance/the_puppets_bunker.ts
+++ b/ui/raidboss/data/05-shb/alliance/the_puppets_bunker.ts
@@ -1,12 +1,11 @@
+import { defineTriggerSet } from '../../../../../resources/api_define_trigger_set';
 import Conditions from '../../../../../resources/conditions';
 import NetRegexes from '../../../../../resources/netregexes';
 import Outputs from '../../../../../resources/outputs';
 import { Responses } from '../../../../../resources/responses';
 import ZoneId from '../../../../../resources/zone_id';
-import { RaidbossData } from '../../../../../types/data';
-import { TriggerSet } from '../../../../../types/trigger';
 
-export interface Data extends RaidbossData {
+export interface Data {
   phase?: string;
   busterTargets?: string[];
   swipe?: (string | undefined)[];
@@ -35,7 +34,7 @@ const swipeOutputStrings = {
   },
 };
 
-const triggerSet: TriggerSet<Data> = {
+export default defineTriggerSet<Data>({
   zoneId: ZoneId.ThePuppetsBunker,
   timelineFile: 'the_puppets_bunker.txt',
   triggers: [
@@ -1265,6 +1264,4 @@ const triggerSet: TriggerSet<Data> = {
       },
     },
   ],
-};
-
-export default triggerSet;
+});

--- a/ui/raidboss/data/05-shb/alliance/the_tower_at_paradigms_breach.ts
+++ b/ui/raidboss/data/05-shb/alliance/the_tower_at_paradigms_breach.ts
@@ -1,10 +1,9 @@
+import { defineTriggerSet } from '../../../../../resources/api_define_trigger_set';
 import Conditions from '../../../../../resources/conditions';
 import NetRegexes from '../../../../../resources/netregexes';
 import Outputs from '../../../../../resources/outputs';
 import { Responses } from '../../../../../resources/responses';
 import ZoneId from '../../../../../resources/zone_id';
-import { RaidbossData } from '../../../../../types/data';
-import { TriggerSet } from '../../../../../types/trigger';
 
 // Object representing a "Deploy Armaments" attack.
 interface DeployArmaments {
@@ -13,7 +12,7 @@ interface DeployArmaments {
   finishedTime: number;
 }
 
-export interface Data extends RaidbossData {
+export interface Data {
   busterTargets?: string[];
   cloneLunge?: boolean;
   seedTargets?: string[];
@@ -34,7 +33,7 @@ export interface Data extends RaidbossData {
 //   Her Inflorescence Distortion
 //   Her Inflorescence Pillar Impact
 
-const triggerSet: TriggerSet<Data> = {
+export default defineTriggerSet<Data>({
   zoneId: ZoneId.TheTowerAtParadigmsBreach,
   timelineFile: 'the_tower_at_paradigms_breach.txt',
   triggers: [
@@ -1281,6 +1280,4 @@ const triggerSet: TriggerSet<Data> = {
       },
     },
   ],
-};
-
-export default triggerSet;
+});

--- a/ui/raidboss/data/05-shb/dungeon/akadaemia_anyder.ts
+++ b/ui/raidboss/data/05-shb/dungeon/akadaemia_anyder.ts
@@ -1,13 +1,10 @@
+import { defineTriggerSet } from '../../../../../resources/api_define_trigger_set';
 import Conditions from '../../../../../resources/conditions';
 import NetRegexes from '../../../../../resources/netregexes';
 import { Responses } from '../../../../../resources/responses';
 import ZoneId from '../../../../../resources/zone_id';
-import { RaidbossData } from '../../../../../types/data';
-import { TriggerSet } from '../../../../../types/trigger';
 
-export type Data = RaidbossData;
-
-const triggerSet: TriggerSet<Data> = {
+export default defineTriggerSet({
   zoneId: ZoneId.AkadaemiaAnyder,
   timelineFile: 'akadaemia_anyder.txt',
   timelineTriggers: [
@@ -304,6 +301,4 @@ const triggerSet: TriggerSet<Data> = {
       },
     },
   ],
-};
-
-export default triggerSet;
+});

--- a/ui/raidboss/data/05-shb/dungeon/amaurot.ts
+++ b/ui/raidboss/data/05-shb/dungeon/amaurot.ts
@@ -1,15 +1,12 @@
+import { defineTriggerSet } from '../../../../../resources/api_define_trigger_set';
 import Conditions from '../../../../../resources/conditions';
 import NetRegexes from '../../../../../resources/netregexes';
 import { Responses } from '../../../../../resources/responses';
 import ZoneId from '../../../../../resources/zone_id';
-import { RaidbossData } from '../../../../../types/data';
-import { TriggerSet } from '../../../../../types/trigger';
 
-export interface Data extends RaidbossData {
+export default defineTriggerSet<{
   meteor?: number;
-}
-
-const triggerSet: TriggerSet<Data> = {
+}>({
   zoneId: ZoneId.Amaurot,
   timelineFile: 'amaurot.txt',
   triggers: [
@@ -267,6 +264,4 @@ const triggerSet: TriggerSet<Data> = {
       },
     },
   ],
-};
-
-export default triggerSet;
+});

--- a/ui/raidboss/data/05-shb/dungeon/anamnesis_anyder.ts
+++ b/ui/raidboss/data/05-shb/dungeon/anamnesis_anyder.ts
@@ -1,13 +1,10 @@
+import { defineTriggerSet } from '../../../../../resources/api_define_trigger_set';
 import Conditions from '../../../../../resources/conditions';
 import NetRegexes from '../../../../../resources/netregexes';
 import { Responses } from '../../../../../resources/responses';
 import ZoneId from '../../../../../resources/zone_id';
-import { RaidbossData } from '../../../../../types/data';
-import { TriggerSet } from '../../../../../types/trigger';
 
-export type Data = RaidbossData;
-
-const triggerSet: TriggerSet<Data> = {
+export default defineTriggerSet({
   zoneId: ZoneId.AnamnesisAnyder,
   timelineFile: 'anamnesis_anyder.txt',
   triggers: [
@@ -325,6 +322,4 @@ const triggerSet: TriggerSet<Data> = {
       },
     },
   ],
-};
-
-export default triggerSet;
+});

--- a/ui/raidboss/data/05-shb/dungeon/dohn_mheg.ts
+++ b/ui/raidboss/data/05-shb/dungeon/dohn_mheg.ts
@@ -1,12 +1,9 @@
+import { defineTriggerSet } from '../../../../../resources/api_define_trigger_set';
 import NetRegexes from '../../../../../resources/netregexes';
 import { Responses } from '../../../../../resources/responses';
 import ZoneId from '../../../../../resources/zone_id';
-import { RaidbossData } from '../../../../../types/data';
-import { TriggerSet } from '../../../../../types/trigger';
 
-export type Data = RaidbossData;
-
-const triggerSet: TriggerSet<Data> = {
+export default defineTriggerSet({
   zoneId: ZoneId.DohnMheg,
   timelineFile: 'dohn_mheg.txt',
   timelineTriggers: [
@@ -301,6 +298,4 @@ const triggerSet: TriggerSet<Data> = {
       },
     },
   ],
-};
-
-export default triggerSet;
+});

--- a/ui/raidboss/data/05-shb/dungeon/heroes_gauntlet.ts
+++ b/ui/raidboss/data/05-shb/dungeon/heroes_gauntlet.ts
@@ -1,16 +1,13 @@
+import { defineTriggerSet } from '../../../../../resources/api_define_trigger_set';
 import Conditions from '../../../../../resources/conditions';
 import NetRegexes from '../../../../../resources/netregexes';
 import Outputs from '../../../../../resources/outputs';
 import { Responses } from '../../../../../resources/responses';
 import ZoneId from '../../../../../resources/zone_id';
-import { RaidbossData } from '../../../../../types/data';
-import { TriggerSet } from '../../../../../types/trigger';
 
-export interface Data extends RaidbossData {
+export default defineTriggerSet<{
   anguish?: string[];
-}
-
-const triggerSet: TriggerSet<Data> = {
+}>({
   zoneId: ZoneId.TheHeroesGauntlet,
   timelineFile: 'heroes_gauntlet.txt',
   triggers: [
@@ -364,6 +361,4 @@ const triggerSet: TriggerSet<Data> = {
       },
     },
   ],
-};
-
-export default triggerSet;
+});

--- a/ui/raidboss/data/05-shb/dungeon/holminster_switch.ts
+++ b/ui/raidboss/data/05-shb/dungeon/holminster_switch.ts
@@ -1,13 +1,10 @@
+import { defineTriggerSet } from '../../../../../resources/api_define_trigger_set';
 import Conditions from '../../../../../resources/conditions';
 import NetRegexes from '../../../../../resources/netregexes';
 import { Responses } from '../../../../../resources/responses';
 import ZoneId from '../../../../../resources/zone_id';
-import { RaidbossData } from '../../../../../types/data';
-import { TriggerSet } from '../../../../../types/trigger';
 
-export type Data = RaidbossData;
-
-const triggerSet: TriggerSet<Data> = {
+export default defineTriggerSet({
   zoneId: ZoneId.HolminsterSwitch,
   timelineFile: 'holminster_switch.txt',
   triggers: [
@@ -300,6 +297,4 @@ const triggerSet: TriggerSet<Data> = {
       },
     },
   ],
-};
-
-export default triggerSet;
+});

--- a/ui/raidboss/data/05-shb/dungeon/malikahs_well.ts
+++ b/ui/raidboss/data/05-shb/dungeon/malikahs_well.ts
@@ -1,12 +1,9 @@
+import { defineTriggerSet } from '../../../../../resources/api_define_trigger_set';
 import NetRegexes from '../../../../../resources/netregexes';
 import { Responses } from '../../../../../resources/responses';
 import ZoneId from '../../../../../resources/zone_id';
-import { RaidbossData } from '../../../../../types/data';
-import { TriggerSet } from '../../../../../types/trigger';
 
-export type Data = RaidbossData;
-
-const triggerSet: TriggerSet<Data> = {
+export default defineTriggerSet({
   zoneId: ZoneId.MalikahsWell,
   timelineFile: 'malikahs_well.txt',
   triggers: [
@@ -231,6 +228,4 @@ const triggerSet: TriggerSet<Data> = {
       },
     },
   ],
-};
-
-export default triggerSet;
+});

--- a/ui/raidboss/data/05-shb/dungeon/matoyas_relict.ts
+++ b/ui/raidboss/data/05-shb/dungeon/matoyas_relict.ts
@@ -1,14 +1,11 @@
+import { defineTriggerSet } from '../../../../../resources/api_define_trigger_set';
 import Conditions from '../../../../../resources/conditions';
 import NetRegexes from '../../../../../resources/netregexes';
 import Outputs from '../../../../../resources/outputs';
 import { Responses } from '../../../../../resources/responses';
 import ZoneId from '../../../../../resources/zone_id';
-import { RaidbossData } from '../../../../../types/data';
-import { TriggerSet } from '../../../../../types/trigger';
 
-export type Data = RaidbossData;
-
-const triggerSet: TriggerSet<Data> = {
+export default defineTriggerSet({
   zoneId: ZoneId.MatoyasRelict,
   timelineFile: 'matoyas_relict.txt',
   triggers: [
@@ -380,6 +377,4 @@ const triggerSet: TriggerSet<Data> = {
       },
     },
   ],
-};
-
-export default triggerSet;
+});

--- a/ui/raidboss/data/05-shb/dungeon/mt_gulg.ts
+++ b/ui/raidboss/data/05-shb/dungeon/mt_gulg.ts
@@ -1,12 +1,9 @@
+import { defineTriggerSet } from '../../../../../resources/api_define_trigger_set';
 import NetRegexes from '../../../../../resources/netregexes';
 import { Responses } from '../../../../../resources/responses';
 import ZoneId from '../../../../../resources/zone_id';
-import { RaidbossData } from '../../../../../types/data';
-import { TriggerSet } from '../../../../../types/trigger';
 
-export type Data = RaidbossData;
-
-const triggerSet: TriggerSet<Data> = {
+export default defineTriggerSet({
   zoneId: ZoneId.MtGulg,
   timelineFile: 'mt_gulg.txt',
   triggers: [
@@ -359,6 +356,4 @@ const triggerSet: TriggerSet<Data> = {
       },
     },
   ],
-};
-
-export default triggerSet;
+});

--- a/ui/raidboss/data/05-shb/dungeon/paglthan.ts
+++ b/ui/raidboss/data/05-shb/dungeon/paglthan.ts
@@ -1,15 +1,12 @@
+import { defineTriggerSet } from '../../../../../resources/api_define_trigger_set';
 import Conditions from '../../../../../resources/conditions';
 import NetRegexes from '../../../../../resources/netregexes';
 import { Responses } from '../../../../../resources/responses';
 import ZoneId from '../../../../../resources/zone_id';
-import { RaidbossData } from '../../../../../types/data';
-import { TriggerSet } from '../../../../../types/trigger';
 
-export interface Data extends RaidbossData {
+export default defineTriggerSet<{
   lunarFlares?: number;
-}
-
-const triggerSet: TriggerSet<Data> = {
+}>({
   zoneId: ZoneId.Paglthan,
   timelineFile: 'paglthan.txt',
   timelineTriggers: [
@@ -363,6 +360,4 @@ const triggerSet: TriggerSet<Data> = {
       },
     },
   ],
-};
-
-export default triggerSet;
+});

--- a/ui/raidboss/data/05-shb/dungeon/qitana_ravel.ts
+++ b/ui/raidboss/data/05-shb/dungeon/qitana_ravel.ts
@@ -1,13 +1,10 @@
+import { defineTriggerSet } from '../../../../../resources/api_define_trigger_set';
 import Conditions from '../../../../../resources/conditions';
 import NetRegexes from '../../../../../resources/netregexes';
 import { Responses } from '../../../../../resources/responses';
 import ZoneId from '../../../../../resources/zone_id';
-import { RaidbossData } from '../../../../../types/data';
-import { TriggerSet } from '../../../../../types/trigger';
 
-export type Data = RaidbossData;
-
-const triggerSet: TriggerSet<Data> = {
+export default defineTriggerSet({
   zoneId: ZoneId.TheQitanaRavel,
   timelineFile: 'qitana_ravel.txt',
   triggers: [
@@ -320,6 +317,4 @@ const triggerSet: TriggerSet<Data> = {
       },
     },
   ],
-};
-
-export default triggerSet;
+});

--- a/ui/raidboss/data/05-shb/dungeon/the_grand_cosmos.ts
+++ b/ui/raidboss/data/05-shb/dungeon/the_grand_cosmos.ts
@@ -1,15 +1,12 @@
+import { defineTriggerSet } from '../../../../../resources/api_define_trigger_set';
 import Conditions from '../../../../../resources/conditions';
 import NetRegexes from '../../../../../resources/netregexes';
 import { Responses } from '../../../../../resources/responses';
 import ZoneId from '../../../../../resources/zone_id';
-import { RaidbossData } from '../../../../../types/data';
-import { TriggerSet } from '../../../../../types/trigger';
 
-export interface Data extends RaidbossData {
+export default defineTriggerSet<{
   firesDomain?: number;
-}
-
-const triggerSet: TriggerSet<Data> = {
+}>({
   zoneId: ZoneId.TheGrandCosmos,
   timelineFile: 'the_grand_cosmos.txt',
   triggers: [
@@ -404,6 +401,4 @@ const triggerSet: TriggerSet<Data> = {
       },
     },
   ],
-};
-
-export default triggerSet;
+});

--- a/ui/raidboss/data/05-shb/dungeon/twinning.ts
+++ b/ui/raidboss/data/05-shb/dungeon/twinning.ts
@@ -1,13 +1,10 @@
+import { defineTriggerSet } from '../../../../../resources/api_define_trigger_set';
 import Conditions from '../../../../../resources/conditions';
 import NetRegexes from '../../../../../resources/netregexes';
 import { Responses } from '../../../../../resources/responses';
 import ZoneId from '../../../../../resources/zone_id';
-import { RaidbossData } from '../../../../../types/data';
-import { TriggerSet } from '../../../../../types/trigger';
 
-export type Data = RaidbossData;
-
-const triggerSet: TriggerSet<Data> = {
+export default defineTriggerSet({
   zoneId: ZoneId.TheTwinning,
   timelineFile: 'twinning.txt',
   triggers: [
@@ -353,6 +350,4 @@ const triggerSet: TriggerSet<Data> = {
       },
     },
   ],
-};
-
-export default triggerSet;
+});

--- a/ui/raidboss/data/05-shb/etc/the_diadem.ts
+++ b/ui/raidboss/data/05-shb/etc/the_diadem.ts
@@ -1,12 +1,9 @@
+import { defineTriggerSet } from '../../../../../resources/api_define_trigger_set';
 import NetRegexes from '../../../../../resources/netregexes';
 import { Responses } from '../../../../../resources/responses';
 import ZoneId from '../../../../../resources/zone_id';
-import { RaidbossData } from '../../../../../types/data';
-import { TriggerSet } from '../../../../../types/trigger';
 
-export type Data = RaidbossData;
-
-const triggerSet: TriggerSet<Data> = {
+export default defineTriggerSet({
   zoneId: ZoneId.TheDiadem,
   resetWhenOutOfCombat: false,
   triggers: [
@@ -49,6 +46,4 @@ const triggerSet: TriggerSet<Data> = {
       },
     },
   ],
-};
-
-export default triggerSet;
+});

--- a/ui/raidboss/data/05-shb/eureka/bozjan_southern_front.ts
+++ b/ui/raidboss/data/05-shb/eureka/bozjan_southern_front.ts
@@ -1,3 +1,4 @@
+import { defineTriggerSet } from '../../../../../resources/api_define_trigger_set';
 import Conditions from '../../../../../resources/conditions';
 import NetRegexes from '../../../../../resources/netregexes';
 import Outputs from '../../../../../resources/outputs';
@@ -6,9 +7,7 @@ import { Responses } from '../../../../../resources/responses';
 import ZoneId from '../../../../../resources/zone_id';
 import { RaidbossData } from '../../../../../types/data';
 import { NetMatches } from '../../../../../types/net_matches';
-import { TriggerSet } from '../../../../../types/trigger';
-
-export interface Data extends RaidbossData {
+export interface Data {
   ce?: string;
   helldiver?: boolean;
   energyCount?: number;
@@ -131,7 +130,7 @@ const orbOutputStrings = {
 
 // TODO: promote something like this to Conditions?
 const tankBusterOnParty = (ceName?: string) =>
-  (data: Data, matches: NetMatches['StartsUsing']) => {
+  (data: Data & RaidbossData, matches: NetMatches['StartsUsing']) => {
     if (ceName && data.ce !== ceName)
       return false;
     if (matches.target === data.me)
@@ -141,7 +140,7 @@ const tankBusterOnParty = (ceName?: string) =>
     return data.party.inParty(matches.target);
   };
 
-const triggerSet: TriggerSet<Data> = {
+export default defineTriggerSet<Data>({
   zoneId: ZoneId.TheBozjanSouthernFront,
   timelineFile: 'bozjan_southern_front.txt',
   timeline: [
@@ -1130,6 +1129,4 @@ const triggerSet: TriggerSet<Data> = {
       },
     },
   ],
-};
-
-export default triggerSet;
+});

--- a/ui/raidboss/data/05-shb/eureka/delubrum_reginae.ts
+++ b/ui/raidboss/data/05-shb/eureka/delubrum_reginae.ts
@@ -1,3 +1,4 @@
+import { defineTriggerSet } from '../../../../../resources/api_define_trigger_set';
 import Conditions from '../../../../../resources/conditions';
 import NetRegexes from '../../../../../resources/netregexes';
 import { UnreachableCode } from '../../../../../resources/not_reached';
@@ -6,9 +7,8 @@ import { Responses } from '../../../../../resources/responses';
 import ZoneId from '../../../../../resources/zone_id';
 import { RaidbossData } from '../../../../../types/data';
 import { NetMatches } from '../../../../../types/net_matches';
-import { TriggerSet } from '../../../../../types/trigger';
 
-export interface Data extends RaidbossData {
+export interface Data {
   calledSeekerSwords?: boolean;
   seekerSwords?: string[];
   splitterDist?: number;
@@ -32,7 +32,7 @@ const avowedCenterX = -272;
 const avowedCenterY = -82;
 
 // TODO: promote something like this to Conditions?
-const tankBusterOnParty = (data: Data, matches: NetMatches['StartsUsing']) => {
+const tankBusterOnParty = (data: Data & RaidbossData, matches: NetMatches['StartsUsing']) => {
   if (matches.target === data.me)
     return true;
   if (data.role !== 'healer')
@@ -40,7 +40,7 @@ const tankBusterOnParty = (data: Data, matches: NetMatches['StartsUsing']) => {
   return data.party.inParty(matches.target);
 };
 
-const triggerSet: TriggerSet<Data> = {
+export default defineTriggerSet<Data>({
   zoneId: ZoneId.DelubrumReginae,
   timelineFile: 'delubrum_reginae.txt',
   triggers: [
@@ -1915,6 +1915,4 @@ const triggerSet: TriggerSet<Data> = {
       },
     },
   ],
-};
-
-export default triggerSet;
+});

--- a/ui/raidboss/data/05-shb/eureka/delubrum_reginae_savage.ts
+++ b/ui/raidboss/data/05-shb/eureka/delubrum_reginae_savage.ts
@@ -1,3 +1,4 @@
+import { defineTriggerSet } from '../../../../../resources/api_define_trigger_set';
 import Conditions from '../../../../../resources/conditions';
 import NetRegexes from '../../../../../resources/netregexes';
 import { UnreachableCode } from '../../../../../resources/not_reached';
@@ -8,9 +9,9 @@ import ZoneId from '../../../../../resources/zone_id';
 import { RaidbossData } from '../../../../../types/data';
 import { PluginCombatantState } from '../../../../../types/event';
 import { NetMatches } from '../../../../../types/net_matches';
-import { LocaleText, TriggerSet } from '../../../../../types/trigger';
+import { LocaleText } from '../../../../../types/trigger';
 
-export interface Data extends RaidbossData {
+export interface Data {
   decOffset?: number;
   firstUnknownHeadmarker?: string;
   gloryOfBozjaCount?: number;
@@ -68,7 +69,7 @@ const avowedCenterX = -272;
 const avowedCenterY = -82;
 
 // TODO: promote something like this to Conditions?
-const tankBusterOnParty = (data: Data, matches: NetMatches['StartsUsing']) => {
+const tankBusterOnParty = (data: Data & RaidbossData, matches: NetMatches['StartsUsing']) => {
   if (matches.target === data.me)
     return true;
   if (data.role !== 'healer')
@@ -79,7 +80,7 @@ const tankBusterOnParty = (data: Data, matches: NetMatches['StartsUsing']) => {
 // Due to changes introduced in patch 5.2, overhead markers now have a random offset
 // added to their ID. This offset currently appears to be set per instance, so
 // we can determine what it is from the first overhead marker we see.
-const getHeadmarkerId = (data: Data, matches: NetMatches['HeadMarker']) => {
+const getHeadmarkerId = (data: Data & RaidbossData, matches: NetMatches['HeadMarker']) => {
   if (data.decOffset === undefined) {
     // If we don't know, return garbage to avoid accidentally running other triggers.
     if (!data.firstUnknownHeadmarker)
@@ -92,7 +93,7 @@ const getHeadmarkerId = (data: Data, matches: NetMatches['HeadMarker']) => {
   return `000${hexId}`.slice(-4);
 };
 
-const triggerSet: TriggerSet<Data> = {
+export default defineTriggerSet<Data>({
   zoneId: ZoneId.DelubrumReginaeSavage,
   timelineFile: 'delubrum_reginae_savage.txt',
   timelineTriggers: [
@@ -3676,6 +3677,4 @@ const triggerSet: TriggerSet<Data> = {
       },
     },
   ],
-};
-
-export default triggerSet;
+});

--- a/ui/raidboss/data/05-shb/eureka/zadnor.ts
+++ b/ui/raidboss/data/05-shb/eureka/zadnor.ts
@@ -1,3 +1,4 @@
+import { defineTriggerSet } from '../../../../../resources/api_define_trigger_set';
 import Conditions from '../../../../../resources/conditions';
 import NetRegexes from '../../../../../resources/netregexes';
 import Outputs from '../../../../../resources/outputs';
@@ -5,9 +6,8 @@ import { Responses } from '../../../../../resources/responses';
 import ZoneId from '../../../../../resources/zone_id';
 import { RaidbossData } from '../../../../../types/data';
 import { NetMatches } from '../../../../../types/net_matches';
-import { TriggerSet } from '../../../../../types/trigger';
 
-export interface Data extends RaidbossData {
+export interface Data {
   ce?: string;
   serpentsTurbineCount?: number;
   feelingAnalysis?: boolean;
@@ -92,7 +92,7 @@ const limitCutHeadmarkers = ['004F', '0050', '0051', '0052'];
 
 // TODO: promote something like this to Conditions?
 const tankBusterOnParty = (ceName?: string) =>
-  (data: Data, matches: NetMatches['StartsUsing']) => {
+  (data: Data & RaidbossData, matches: NetMatches['StartsUsing']) => {
     if (ceName && data.ce !== ceName)
       return false;
     if (matches.target === data.me)
@@ -102,7 +102,7 @@ const tankBusterOnParty = (ceName?: string) =>
     return data.party.inParty(matches.target);
   };
 
-const triggerSet: TriggerSet<Data> = {
+export default defineTriggerSet<Data>({
   zoneId: ZoneId.Zadnor,
   timelineFile: 'zadnor.txt',
   resetWhenOutOfCombat: false,
@@ -2313,6 +2313,4 @@ const triggerSet: TriggerSet<Data> = {
       },
     },
   ],
-};
-
-export default triggerSet;
+});

--- a/ui/raidboss/data/05-shb/raid/e10n.ts
+++ b/ui/raidboss/data/05-shb/raid/e10n.ts
@@ -1,13 +1,10 @@
+import { defineTriggerSet } from '../../../../../resources/api_define_trigger_set';
 import NetRegexes from '../../../../../resources/netregexes';
 import Outputs from '../../../../../resources/outputs';
 import { Responses } from '../../../../../resources/responses';
 import ZoneId from '../../../../../resources/zone_id';
-import { RaidbossData } from '../../../../../types/data';
-import { TriggerSet } from '../../../../../types/trigger';
 
-export type Data = RaidbossData;
-
-const triggerSet: TriggerSet<Data> = {
+export default defineTriggerSet({
   zoneId: ZoneId.EdensPromiseLitany,
   timelineFile: 'e10n.txt',
   timelineTriggers: [
@@ -328,6 +325,4 @@ const triggerSet: TriggerSet<Data> = {
       },
     },
   ],
-};
-
-export default triggerSet;
+});

--- a/ui/raidboss/data/05-shb/raid/e10s.ts
+++ b/ui/raidboss/data/05-shb/raid/e10s.ts
@@ -1,13 +1,12 @@
+import { defineTriggerSet } from '../../../../../resources/api_define_trigger_set';
 import Conditions from '../../../../../resources/conditions';
 import NetRegexes from '../../../../../resources/netregexes';
 import Outputs from '../../../../../resources/outputs';
 import { Responses } from '../../../../../resources/responses';
 import Util from '../../../../../resources/util';
 import ZoneId from '../../../../../resources/zone_id';
-import { RaidbossData } from '../../../../../types/data';
-import { TriggerSet } from '../../../../../types/trigger';
 
-export interface Data extends RaidbossData {
+export interface Data {
   umbraTarget?: string;
   gigaSlashCleaveDebuffDuration?: number;
   gigaSlashCleaveDebuffId?: string;
@@ -29,7 +28,7 @@ const directions = {
   west: Outputs.west,
 };
 
-const triggerSet: TriggerSet<Data> = {
+export default defineTriggerSet<Data>({
   zoneId: ZoneId.EdensPromiseLitanySavage,
   timelineFile: 'e10s.txt',
   triggers: [
@@ -873,6 +872,4 @@ const triggerSet: TriggerSet<Data> = {
       },
     },
   ],
-};
-
-export default triggerSet;
+});

--- a/ui/raidboss/data/05-shb/raid/e11n.ts
+++ b/ui/raidboss/data/05-shb/raid/e11n.ts
@@ -1,12 +1,13 @@
+import { defineTriggerSet } from '../../../../../resources/api_define_trigger_set';
 import Conditions from '../../../../../resources/conditions';
 import NetRegexes from '../../../../../resources/netregexes';
 import Outputs from '../../../../../resources/outputs';
 import { Responses } from '../../../../../resources/responses';
 import ZoneId from '../../../../../resources/zone_id';
 import { RaidbossData } from '../../../../../types/data';
-import { Output, TriggerSet } from '../../../../../types/trigger';
+import { Output } from '../../../../../types/trigger';
 
-export interface Data extends RaidbossData {
+export interface Data {
   tethers?: { [name: string]: string };
 }
 
@@ -26,7 +27,7 @@ export interface Data extends RaidbossData {
 
 const tetherIds = ['0002', '0005', '0006'];
 
-const boundOfFaithFireTetherResponse = (data: Data, _matches: unknown, output: Output) => {
+const boundOfFaithFireTetherResponse = (data: Data & RaidbossData, _matches: unknown, output: Output) => {
   // cactbot-builtin-response
   output.responseOutputStrings = {
     stackOnYou: Outputs.stackOnYou,
@@ -42,7 +43,7 @@ const boundOfFaithFireTetherResponse = (data: Data, _matches: unknown, output: O
   return { alertText: output.stackOnPlayer!({ player: data.ShortName(targets[0]) }) };
 };
 
-const boundOfFaithLightningTetherResponse = (data: Data, _matches: unknown, output: Output) => {
+const boundOfFaithLightningTetherResponse = (data: Data & RaidbossData, _matches: unknown, output: Output) => {
   // cactbot-builtin-response
   output.responseOutputStrings = {
     onYou: {
@@ -72,7 +73,7 @@ const boundOfFaithLightningTetherResponse = (data: Data, _matches: unknown, outp
   return { infoText: output.tetherInfo!({ player: target }) };
 };
 
-const boundOfFaithHolyTetherResponse = (data: Data, _matches: unknown, output: Output) => {
+const boundOfFaithHolyTetherResponse = (data: Data & RaidbossData, _matches: unknown, output: Output) => {
   // cactbot-builtin-response
   output.responseOutputStrings = {
     awayFromGroup: Outputs.awayFromGroup,
@@ -88,7 +89,7 @@ const boundOfFaithHolyTetherResponse = (data: Data, _matches: unknown, output: O
   return { infoText: output.awayFromPlayer!({ player: data.ShortName(targets[0]) }) };
 };
 
-const triggerSet: TriggerSet<Data> = {
+export default defineTriggerSet({
   zoneId: ZoneId.EdensPromiseAnamorphosis,
   timelineFile: 'e11n.txt',
   triggers: [
@@ -422,6 +423,4 @@ const triggerSet: TriggerSet<Data> = {
       },
     },
   ],
-};
-
-export default triggerSet;
+});

--- a/ui/raidboss/data/05-shb/raid/e11s.ts
+++ b/ui/raidboss/data/05-shb/raid/e11s.ts
@@ -1,12 +1,13 @@
+import { defineTriggerSet } from '../../../../../resources/api_define_trigger_set';
 import Conditions from '../../../../../resources/conditions';
 import NetRegexes from '../../../../../resources/netregexes';
 import Outputs from '../../../../../resources/outputs';
 import { Responses } from '../../../../../resources/responses';
 import ZoneId from '../../../../../resources/zone_id';
 import { RaidbossData } from '../../../../../types/data';
-import { Output, TriggerSet } from '../../../../../types/trigger';
+import { Output } from '../../../../../types/trigger';
 
-export interface Data extends RaidbossData {
+export interface Data {
   tethers?: { [name: string]: string };
 }
 
@@ -24,7 +25,7 @@ export interface Data extends RaidbossData {
 // burnout = burnt strike lightning out
 // shining blade = burnt strike light bait
 
-const boundOfFaithFireTetherResponse = (data: Data, _matches: unknown, output: Output) => {
+const boundOfFaithFireTetherResponse = (data: Data & RaidbossData, _matches: unknown, output: Output) => {
   // cactbot-builtin-response
   output.responseOutputStrings = {
     stackOnYou: Outputs.stackOnYou,
@@ -40,7 +41,7 @@ const boundOfFaithFireTetherResponse = (data: Data, _matches: unknown, output: O
   return { alertText: output.stackOnPlayer!({ player: data.ShortName(targets[0]) }) };
 };
 
-const boundOfFaithLightningTetherResponse = (data: Data, _matches: unknown, output: Output) => {
+const boundOfFaithLightningTetherResponse = (data: Data & RaidbossData, _matches: unknown, output: Output) => {
   // cactbot-builtin-response
   output.responseOutputStrings = {
     onYou: {
@@ -70,7 +71,7 @@ const boundOfFaithLightningTetherResponse = (data: Data, _matches: unknown, outp
   return { infoText: output.tetherInfo!({ player: target }) };
 };
 
-const boundOfFaithHolyTetherResponse = (data: Data, _matches: unknown, output: Output) => {
+const boundOfFaithHolyTetherResponse = (data: Data & RaidbossData, _matches: unknown, output: Output) => {
   // cactbot-builtin-response
   output.responseOutputStrings = {
     awayFromGroup: Outputs.awayFromGroup,
@@ -86,7 +87,7 @@ const boundOfFaithHolyTetherResponse = (data: Data, _matches: unknown, output: O
   return { infoText: output.awayFromPlayer!({ player: data.ShortName(targets[0]) }) };
 };
 
-const triggerSet: TriggerSet<Data> = {
+export default defineTriggerSet({
   zoneId: ZoneId.EdensPromiseAnamorphosisSavage,
   timelineFile: 'e11s.txt',
   triggers: [
@@ -810,6 +811,4 @@ const triggerSet: TriggerSet<Data> = {
       },
     },
   ],
-};
-
-export default triggerSet;
+});

--- a/ui/raidboss/data/05-shb/raid/e12n.ts
+++ b/ui/raidboss/data/05-shb/raid/e12n.ts
@@ -1,12 +1,11 @@
+import { defineTriggerSet } from '../../../../../resources/api_define_trigger_set';
 import Conditions from '../../../../../resources/conditions';
 import NetRegexes from '../../../../../resources/netregexes';
 import Outputs from '../../../../../resources/outputs';
 import { Responses } from '../../../../../resources/responses';
 import ZoneId from '../../../../../resources/zone_id';
-import { RaidbossData } from '../../../../../types/data';
-import { TriggerSet } from '../../../../../types/trigger';
 
-export interface Data extends RaidbossData {
+export interface Data {
   seenIntermission?: boolean;
   bombs?: { north: boolean; east: boolean }[];
   stacks?: string[];
@@ -110,7 +109,7 @@ const primalOutputStrings = {
   },
 };
 
-const triggerSet: TriggerSet<Data> = {
+export default defineTriggerSet<Data>({
   zoneId: ZoneId.EdensPromiseEternity,
   timelineFile: 'e12n.txt',
   triggers: [
@@ -492,6 +491,4 @@ const triggerSet: TriggerSet<Data> = {
       },
     },
   ],
-};
-
-export default triggerSet;
+});

--- a/ui/raidboss/data/05-shb/raid/e12s.ts
+++ b/ui/raidboss/data/05-shb/raid/e12s.ts
@@ -1,3 +1,4 @@
+import { defineTriggerSet } from '../../../../../resources/api_define_trigger_set';
 import Conditions from '../../../../../resources/conditions';
 import NetRegexes from '../../../../../resources/netregexes';
 import { UnreachableCode } from '../../../../../resources/not_reached';
@@ -5,11 +6,10 @@ import Outputs from '../../../../../resources/outputs';
 import { callOverlayHandler } from '../../../../../resources/overlay_plugin_api';
 import { Responses } from '../../../../../resources/responses';
 import ZoneId from '../../../../../resources/zone_id';
-import { RaidbossData } from '../../../../../types/data';
 import { NetMatches } from '../../../../../types/net_matches';
-import { LocaleText, Output, TriggerSet } from '../../../../../types/trigger';
+import { LocaleText, Output } from '../../../../../types/trigger';
 
-export interface Data extends RaidbossData {
+export interface Data {
   isDoorBoss?: boolean;
   decOffset?: number;
   tethers?: string[];
@@ -275,7 +275,7 @@ const dirToOutput = (dir: number, output: Output) => {
   return dirs[dir];
 };
 
-const triggerSet: TriggerSet<Data> = {
+export default defineTriggerSet<Data>({
   zoneId: ZoneId.EdensPromiseEternitySavage,
   timelineFile: 'e12s.txt',
   triggers: [
@@ -2060,6 +2060,4 @@ const triggerSet: TriggerSet<Data> = {
       },
     },
   ],
-};
-
-export default triggerSet;
+});

--- a/ui/raidboss/data/05-shb/raid/e1n.ts
+++ b/ui/raidboss/data/05-shb/raid/e1n.ts
@@ -1,13 +1,10 @@
+import { defineTriggerSet } from '../../../../../resources/api_define_trigger_set';
 import Conditions from '../../../../../resources/conditions';
 import NetRegexes from '../../../../../resources/netregexes';
 import { Responses } from '../../../../../resources/responses';
 import ZoneId from '../../../../../resources/zone_id';
-import { RaidbossData } from '../../../../../types/data';
-import { TriggerSet } from '../../../../../types/trigger';
 
-export type Data = RaidbossData;
-
-const triggerSet: TriggerSet<Data> = {
+export default defineTriggerSet({
   zoneId: ZoneId.EdensGateResurrection,
   timelineFile: 'e1n.txt',
   triggers: [
@@ -246,6 +243,4 @@ const triggerSet: TriggerSet<Data> = {
       },
     },
   ],
-};
-
-export default triggerSet;
+});

--- a/ui/raidboss/data/05-shb/raid/e1s.ts
+++ b/ui/raidboss/data/05-shb/raid/e1s.ts
@@ -1,17 +1,15 @@
+import { defineTriggerSet } from '../../../../../resources/api_define_trigger_set';
 import Conditions from '../../../../../resources/conditions';
 import NetRegexes from '../../../../../resources/netregexes';
 import { Responses } from '../../../../../resources/responses';
 import ZoneId from '../../../../../resources/zone_id';
-import { RaidbossData } from '../../../../../types/data';
-import { LocaleObject, TriggerSet } from '../../../../../types/trigger';
+import { LocaleObject } from '../../../../../types/trigger';
 
-export interface Data extends RaidbossData {
+export default defineTriggerSet<{
   viceCount?: number;
   vice?: string;
   paradise?: boolean;
-}
-
-const triggerSet: TriggerSet<Data> = {
+}>({
   zoneId: ZoneId.EdensGateResurrectionSavage,
   timelineFile: 'e1s.txt',
   timeline: [
@@ -539,6 +537,4 @@ const triggerSet: TriggerSet<Data> = {
       },
     },
   ],
-};
-
-export default triggerSet;
+});

--- a/ui/raidboss/data/05-shb/raid/e2n.ts
+++ b/ui/raidboss/data/05-shb/raid/e2n.ts
@@ -1,17 +1,14 @@
+import { defineTriggerSet } from '../../../../../resources/api_define_trigger_set';
 import Conditions from '../../../../../resources/conditions';
 import NetRegexes from '../../../../../resources/netregexes';
 import Outputs from '../../../../../resources/outputs';
 import { Responses } from '../../../../../resources/responses';
 import ZoneId from '../../../../../resources/zone_id';
-import { RaidbossData } from '../../../../../types/data';
-import { TriggerSet } from '../../../../../types/trigger';
 
-export interface Data extends RaidbossData {
+export default defineTriggerSet<{
   spell?: { [name: string]: string };
   fireCount?: number;
-}
-
-const triggerSet: TriggerSet<Data> = {
+}>({
   zoneId: ZoneId.EdensGateDescent,
   timelineFile: 'e2n.txt',
   timelineTriggers: [
@@ -339,6 +336,4 @@ const triggerSet: TriggerSet<Data> = {
       },
     },
   ],
-};
-
-export default triggerSet;
+});

--- a/ui/raidboss/data/05-shb/raid/e2s.ts
+++ b/ui/raidboss/data/05-shb/raid/e2s.ts
@@ -1,22 +1,19 @@
+import { defineTriggerSet } from '../../../../../resources/api_define_trigger_set';
 import Conditions from '../../../../../resources/conditions';
 import NetRegexes from '../../../../../resources/netregexes';
 import Outputs from '../../../../../resources/outputs';
 import { Responses } from '../../../../../resources/responses';
 import ZoneId from '../../../../../resources/zone_id';
-import { RaidbossData } from '../../../../../types/data';
-import { TriggerSet } from '../../../../../types/trigger';
-
-export interface Data extends RaidbossData {
-  spell?: { [name: string]: string };
-  waiting?: boolean;
-  hellWind?: boolean;
-}
 
 // TODO
 // better callouts for cycle
 // tank provoke messages when cotank has flare
 
-const triggerSet: TriggerSet<Data> = {
+export default defineTriggerSet<{
+  spell?: { [name: string]: string };
+  waiting?: boolean;
+  hellWind?: boolean;
+}>({
   zoneId: ZoneId.EdensGateDescentSavage,
   timelineFile: 'e2s.txt',
   timelineTriggers: [
@@ -682,6 +679,4 @@ const triggerSet: TriggerSet<Data> = {
       },
     },
   ],
-};
-
-export default triggerSet;
+});

--- a/ui/raidboss/data/05-shb/raid/e3n.ts
+++ b/ui/raidboss/data/05-shb/raid/e3n.ts
@@ -1,13 +1,10 @@
+import { defineTriggerSet } from '../../../../../resources/api_define_trigger_set';
 import Conditions from '../../../../../resources/conditions';
 import NetRegexes from '../../../../../resources/netregexes';
 import { Responses } from '../../../../../resources/responses';
 import ZoneId from '../../../../../resources/zone_id';
-import { RaidbossData } from '../../../../../types/data';
-import { TriggerSet } from '../../../../../types/trigger';
 
-export type Data = RaidbossData;
-
-const triggerSet: TriggerSet<Data> = {
+export default defineTriggerSet({
   zoneId: ZoneId.EdensGateInundation,
   timelineFile: 'e3n.txt',
   triggers: [
@@ -266,6 +263,4 @@ const triggerSet: TriggerSet<Data> = {
       },
     },
   ],
-};
-
-export default triggerSet;
+});

--- a/ui/raidboss/data/05-shb/raid/e3s.ts
+++ b/ui/raidboss/data/05-shb/raid/e3s.ts
@@ -1,17 +1,14 @@
+import { defineTriggerSet } from '../../../../../resources/api_define_trigger_set';
 import Conditions from '../../../../../resources/conditions';
 import NetRegexes from '../../../../../resources/netregexes';
 import Outputs from '../../../../../resources/outputs';
 import { Responses } from '../../../../../resources/responses';
 import ZoneId from '../../../../../resources/zone_id';
-import { RaidbossData } from '../../../../../types/data';
-import { TriggerSet } from '../../../../../types/trigger';
 
-export interface Data extends RaidbossData {
+export default defineTriggerSet<{
   vent?: string[];
   refreshed?: boolean;
-}
-
-const triggerSet: TriggerSet<Data> = {
+}>({
   zoneId: ZoneId.EdensGateInundationSavage,
   timelineFile: 'e3s.txt',
   timelineTriggers: [
@@ -725,6 +722,4 @@ const triggerSet: TriggerSet<Data> = {
       },
     },
   ],
-};
-
-export default triggerSet;
+});

--- a/ui/raidboss/data/05-shb/raid/e4n.ts
+++ b/ui/raidboss/data/05-shb/raid/e4n.ts
@@ -1,12 +1,9 @@
+import { defineTriggerSet } from '../../../../../resources/api_define_trigger_set';
 import NetRegexes from '../../../../../resources/netregexes';
 import { Responses } from '../../../../../resources/responses';
 import ZoneId from '../../../../../resources/zone_id';
-import { RaidbossData } from '../../../../../types/data';
-import { TriggerSet } from '../../../../../types/trigger';
 
-export type Data = RaidbossData;
-
-const triggerSet: TriggerSet<Data> = {
+export default defineTriggerSet({
   zoneId: ZoneId.EdensGateSepulture,
   timelineFile: 'e4n.txt',
   triggers: [
@@ -244,6 +241,4 @@ const triggerSet: TriggerSet<Data> = {
       },
     },
   ],
-};
-
-export default triggerSet;
+});

--- a/ui/raidboss/data/05-shb/raid/e4s.ts
+++ b/ui/raidboss/data/05-shb/raid/e4s.ts
@@ -1,17 +1,14 @@
+import { defineTriggerSet } from '../../../../../resources/api_define_trigger_set';
 import Conditions from '../../../../../resources/conditions';
 import NetRegexes from '../../../../../resources/netregexes';
 import Outputs from '../../../../../resources/outputs';
 import { Responses } from '../../../../../resources/responses';
 import ZoneId from '../../../../../resources/zone_id';
-import { RaidbossData } from '../../../../../types/data';
-import { TriggerSet } from '../../../../../types/trigger';
 
-export interface Data extends RaidbossData {
+export default defineTriggerSet<{
   phase?: string;
   printedBury?: boolean;
-}
-
-const triggerSet: TriggerSet<Data> = {
+}>({
   zoneId: ZoneId.EdensGateSepultureSavage,
   timelineFile: 'e4s.txt',
   timelineTriggers: [
@@ -658,6 +655,4 @@ const triggerSet: TriggerSet<Data> = {
       },
     },
   ],
-};
-
-export default triggerSet;
+});

--- a/ui/raidboss/data/05-shb/raid/e5n.ts
+++ b/ui/raidboss/data/05-shb/raid/e5n.ts
@@ -1,15 +1,12 @@
+import { defineTriggerSet } from '../../../../../resources/api_define_trigger_set';
 import Conditions from '../../../../../resources/conditions';
 import NetRegexes from '../../../../../resources/netregexes';
 import { Responses } from '../../../../../resources/responses';
 import ZoneId from '../../../../../resources/zone_id';
-import { RaidbossData } from '../../../../../types/data';
-import { TriggerSet } from '../../../../../types/trigger';
 
-export interface Data extends RaidbossData {
+export default defineTriggerSet<{
   surgeProtection?: boolean;
-}
-
-const triggerSet: TriggerSet<Data> = {
+}>({
   zoneId: ZoneId.EdensVerseFulmination,
   timelineFile: 'e5n.txt',
   triggers: [
@@ -240,6 +237,4 @@ const triggerSet: TriggerSet<Data> = {
       },
     },
   ],
-};
-
-export default triggerSet;
+});

--- a/ui/raidboss/data/05-shb/raid/e5s.ts
+++ b/ui/raidboss/data/05-shb/raid/e5s.ts
@@ -1,20 +1,17 @@
+import { defineTriggerSet } from '../../../../../resources/api_define_trigger_set';
 import Conditions from '../../../../../resources/conditions';
 import NetRegexes from '../../../../../resources/netregexes';
 import { Responses } from '../../../../../resources/responses';
 import ZoneId from '../../../../../resources/zone_id';
-import { RaidbossData } from '../../../../../types/data';
-import { TriggerSet } from '../../../../../types/trigger';
 
-export interface Data extends RaidbossData {
+export default defineTriggerSet<{
   surgeProtection?: boolean;
   steppedLeaderNext?: boolean;
   seenFirstSpear?: boolean;
   furysBoltActive?: boolean;
   seenFirstAdd?: boolean;
   furysFourteenCounter?: number;
-}
-
-const triggerSet: TriggerSet<Data> = {
+}>({
   zoneId: ZoneId.EdensVerseFulminationSavage,
   timelineFile: 'e5s.txt',
   timelineTriggers: [
@@ -465,6 +462,4 @@ const triggerSet: TriggerSet<Data> = {
       },
     },
   ],
-};
-
-export default triggerSet;
+});

--- a/ui/raidboss/data/05-shb/raid/e6n.ts
+++ b/ui/raidboss/data/05-shb/raid/e6n.ts
@@ -1,18 +1,15 @@
+import { defineTriggerSet } from '../../../../../resources/api_define_trigger_set';
 import Conditions from '../../../../../resources/conditions';
 import NetRegexes from '../../../../../resources/netregexes';
 import Outputs from '../../../../../resources/outputs';
 import { Responses } from '../../../../../resources/responses';
 import ZoneId from '../../../../../resources/zone_id';
-import { RaidbossData } from '../../../../../types/data';
-import { TriggerSet } from '../../../../../types/trigger';
 
-export interface Data extends RaidbossData {
+export default defineTriggerSet<{
   handsOfFlame?: boolean;
   seenSpark?: boolean;
   phase?: string;
-}
-
-const triggerSet: TriggerSet<Data> = {
+}>({
   zoneId: ZoneId.EdensVerseFuror,
   timelineFile: 'e6n.txt',
   timelineTriggers: [
@@ -331,6 +328,4 @@ const triggerSet: TriggerSet<Data> = {
       },
     },
   ],
-};
-
-export default triggerSet;
+});

--- a/ui/raidboss/data/05-shb/raid/e6s.ts
+++ b/ui/raidboss/data/05-shb/raid/e6s.ts
@@ -1,3 +1,4 @@
+import { defineTriggerSet } from '../../../../../resources/api_define_trigger_set';
 import Conditions from '../../../../../resources/conditions';
 import NetRegexes from '../../../../../resources/netregexes';
 import { UnreachableCode } from '../../../../../resources/not_reached';
@@ -5,16 +6,12 @@ import Outputs from '../../../../../resources/outputs';
 import { callOverlayHandler } from '../../../../../resources/overlay_plugin_api';
 import { Responses } from '../../../../../resources/responses';
 import ZoneId from '../../../../../resources/zone_id';
-import { RaidbossData } from '../../../../../types/data';
-import { TriggerSet } from '../../../../../types/trigger';
 
-export interface Data extends RaidbossData {
+export default defineTriggerSet<{
   phase?: string;
   safeZone?: string;
   handsOfFlame?: boolean;
-}
-
-const triggerSet: TriggerSet<Data> = {
+}>({
   zoneId: ZoneId.EdensVerseFurorSavage,
   timelineFile: 'e6s.txt',
   triggers: [
@@ -568,6 +565,4 @@ const triggerSet: TriggerSet<Data> = {
       },
     },
   ],
-};
-
-export default triggerSet;
+});

--- a/ui/raidboss/data/05-shb/raid/e7n.ts
+++ b/ui/raidboss/data/05-shb/raid/e7n.ts
@@ -1,15 +1,12 @@
+import { defineTriggerSet } from '../../../../../resources/api_define_trigger_set';
 import Conditions from '../../../../../resources/conditions';
 import NetRegexes from '../../../../../resources/netregexes';
 import { Responses } from '../../../../../resources/responses';
 import ZoneId from '../../../../../resources/zone_id';
-import { RaidbossData } from '../../../../../types/data';
-import { TriggerSet } from '../../../../../types/trigger';
 
-export interface Data extends RaidbossData {
+export default defineTriggerSet<{
   colorCount?: number;
-}
-
-const triggerSet: TriggerSet<Data> = {
+}>({
   zoneId: ZoneId.EdensVerseIconoclasm,
   timelineFile: 'e7n.txt',
   triggers: [
@@ -316,6 +313,4 @@ const triggerSet: TriggerSet<Data> = {
       },
     },
   ],
-};
-
-export default triggerSet;
+});

--- a/ui/raidboss/data/05-shb/raid/e7s.ts
+++ b/ui/raidboss/data/05-shb/raid/e7s.ts
@@ -1,12 +1,11 @@
+import { defineTriggerSet } from '../../../../../resources/api_define_trigger_set';
 import Conditions from '../../../../../resources/conditions';
 import NetRegexes from '../../../../../resources/netregexes';
 import Outputs from '../../../../../resources/outputs';
 import { Responses } from '../../../../../resources/responses';
 import ZoneId from '../../../../../resources/zone_id';
-import { RaidbossData } from '../../../../../types/data';
-import { TriggerSet } from '../../../../../types/trigger';
 
-export interface Data extends RaidbossData {
+export interface Data {
   boundless?: { [name: string]: string };
   phase?: string;
   betwixtWorldsTethers?: string[];
@@ -35,7 +34,7 @@ const colorMap = {
   },
 } as const;
 
-const triggerSet: TriggerSet<Data> = {
+export default defineTriggerSet<Data>({
   zoneId: ZoneId.EdensVerseIconoclasmSavage,
   timelineFile: 'e7s.txt',
   triggers: [
@@ -739,6 +738,4 @@ const triggerSet: TriggerSet<Data> = {
       },
     },
   ],
-};
-
-export default triggerSet;
+});

--- a/ui/raidboss/data/05-shb/raid/e8n.ts
+++ b/ui/raidboss/data/05-shb/raid/e8n.ts
@@ -1,16 +1,13 @@
+import { defineTriggerSet } from '../../../../../resources/api_define_trigger_set';
 import Conditions from '../../../../../resources/conditions';
 import NetRegexes from '../../../../../resources/netregexes';
 import { Responses } from '../../../../../resources/responses';
 import ZoneId from '../../../../../resources/zone_id';
-import { RaidbossData } from '../../../../../types/data';
-import { TriggerSet } from '../../../../../types/trigger';
 
-export interface Data extends RaidbossData {
+export default defineTriggerSet<{
   mirrorsActive?: boolean;
   rampant?: { [name: string]: string };
-}
-
-const triggerSet: TriggerSet<Data> = {
+}>({
   zoneId: ZoneId.EdensVerseRefulgence,
   timelineFile: 'e8n.txt',
   timelineTriggers: [
@@ -502,6 +499,4 @@ const triggerSet: TriggerSet<Data> = {
       },
     },
   ],
-};
-
-export default triggerSet;
+});

--- a/ui/raidboss/data/05-shb/raid/e8s.ts
+++ b/ui/raidboss/data/05-shb/raid/e8s.ts
@@ -1,11 +1,10 @@
+import { defineTriggerSet } from '../../../../../resources/api_define_trigger_set';
 import Conditions from '../../../../../resources/conditions';
 import NetRegexes from '../../../../../resources/netregexes';
 import { Responses } from '../../../../../resources/responses';
 import ZoneId from '../../../../../resources/zone_id';
-import { RaidbossData } from '../../../../../types/data';
-import { TriggerSet } from '../../../../../types/trigger';
 
-export interface Data extends RaidbossData {
+export interface Data {
   firstFrost?: string;
   rushCount?: number;
   akhMornTargets?: string[];
@@ -36,7 +35,7 @@ export interface Data extends RaidbossData {
 // TODO: callouts for the stack group mirrors?
 // TODO: icelit dragonsong callouts?
 
-const triggerSet: TriggerSet<Data> = {
+export default defineTriggerSet<Data>({
   zoneId: ZoneId.EdensVerseRefulgenceSavage,
   timelineFile: 'e8s.txt',
   timelineTriggers: [
@@ -922,6 +921,4 @@ const triggerSet: TriggerSet<Data> = {
       },
     },
   ],
-};
-
-export default triggerSet;
+});

--- a/ui/raidboss/data/05-shb/raid/e9n.ts
+++ b/ui/raidboss/data/05-shb/raid/e9n.ts
@@ -1,13 +1,10 @@
+import { defineTriggerSet } from '../../../../../resources/api_define_trigger_set';
 import Conditions from '../../../../../resources/conditions';
 import NetRegexes from '../../../../../resources/netregexes';
 import { Responses } from '../../../../../resources/responses';
 import ZoneId from '../../../../../resources/zone_id';
-import { RaidbossData } from '../../../../../types/data';
-import { TriggerSet } from '../../../../../types/trigger';
 
-export type Data = RaidbossData;
-
-const triggerSet: TriggerSet<Data> = {
+export default defineTriggerSet({
   zoneId: ZoneId.EdensPromiseUmbra,
   timelineFile: 'e9n.txt',
   triggers: [
@@ -316,6 +313,4 @@ const triggerSet: TriggerSet<Data> = {
       },
     },
   ],
-};
-
-export default triggerSet;
+});

--- a/ui/raidboss/data/05-shb/raid/e9s.ts
+++ b/ui/raidboss/data/05-shb/raid/e9s.ts
@@ -1,3 +1,4 @@
+import { defineTriggerSet } from '../../../../../resources/api_define_trigger_set';
 import Conditions from '../../../../../resources/conditions';
 import NetRegexes from '../../../../../resources/netregexes';
 import { UnreachableCode } from '../../../../../resources/not_reached';
@@ -5,11 +6,9 @@ import Outputs from '../../../../../resources/outputs';
 import { callOverlayHandler } from '../../../../../resources/overlay_plugin_api';
 import { Responses } from '../../../../../resources/responses';
 import ZoneId from '../../../../../resources/zone_id';
-import { RaidbossData } from '../../../../../types/data';
 import { PluginCombatantState } from '../../../../../types/event';
-import { TriggerSet } from '../../../../../types/trigger';
 
-export interface Data extends RaidbossData {
+export interface Data {
   phaserOutputs?: string[];
   phase?: string;
   finalArtOfDarkness?: string;
@@ -197,7 +196,7 @@ const calculateSummonSafeZone = (boss: PluginCombatantState, clone1: PluginComba
   return safeZone;
 };
 
-const triggerSet: TriggerSet<Data> = {
+export default defineTriggerSet<Data>({
   zoneId: ZoneId.EdensPromiseUmbraSavage,
   timelineFile: 'e9s.txt',
   triggers: [
@@ -889,6 +888,4 @@ const triggerSet: TriggerSet<Data> = {
       },
     },
   ],
-};
-
-export default triggerSet;
+});

--- a/ui/raidboss/data/05-shb/trial/diamond_weapon-ex.ts
+++ b/ui/raidboss/data/05-shb/trial/diamond_weapon-ex.ts
@@ -1,12 +1,12 @@
+import { defineTriggerSet } from '../../../../../resources/api_define_trigger_set';
 import NetRegexes from '../../../../../resources/netregexes';
 import Outputs from '../../../../../resources/outputs';
 import { Responses } from '../../../../../resources/responses';
 import ZoneId from '../../../../../resources/zone_id';
 import { RaidbossData } from '../../../../../types/data';
 import { NetMatches } from '../../../../../types/net_matches';
-import { TriggerSet } from '../../../../../types/trigger';
 
-export interface Data extends RaidbossData {
+export interface Data {
   decOffset?: number;
   phase?: number;
 }
@@ -19,7 +19,7 @@ export interface Data extends RaidbossData {
 // P2 buster is 00F3
 // P3 Shrapnal tracking AoE is 00C5
 const firstHeadmarker = parseInt('0057', 16);
-const getHeadmarkerId = (data: Data, matches: NetMatches['HeadMarker']) => {
+const getHeadmarkerId = (data: Data & RaidbossData, matches: NetMatches['HeadMarker']) => {
   // If we naively just check !data.decOffset and leave it, it breaks if the first marker is 0057.
   // (This makes the offset 0, and !0 is true.)
   if (typeof data.decOffset === 'undefined')
@@ -30,7 +30,7 @@ const getHeadmarkerId = (data: Data, matches: NetMatches['HeadMarker']) => {
   return (parseInt(matches.id, 16) - data.decOffset).toString(16).toUpperCase().padStart(4, '0');
 };
 
-const triggerSet: TriggerSet<Data> = {
+export default defineTriggerSet<Data>({
   zoneId: ZoneId.TheCloudDeckExtreme,
   timelineFile: 'diamond_weapon-ex.txt',
   triggers: [
@@ -501,6 +501,4 @@ const triggerSet: TriggerSet<Data> = {
       },
     },
   ],
-};
-
-export default triggerSet;
+});

--- a/ui/raidboss/data/05-shb/trial/diamond_weapon.ts
+++ b/ui/raidboss/data/05-shb/trial/diamond_weapon.ts
@@ -1,12 +1,8 @@
+import { defineTriggerSet } from '../../../../../resources/api_define_trigger_set';
 import Conditions from '../../../../../resources/conditions';
 import NetRegexes from '../../../../../resources/netregexes';
 import { Responses } from '../../../../../resources/responses';
 import ZoneId from '../../../../../resources/zone_id';
-import { RaidbossData } from '../../../../../types/data';
-import { TriggerSet } from '../../../../../types/trigger';
-
-export type Data = RaidbossData;
-
 const sharedOutputStrings = {
   teleportEast: {
     en: 'Teleport to east platform',
@@ -26,7 +22,7 @@ const sharedOutputStrings = {
   },
 };
 
-const triggerSet: TriggerSet<Data> = {
+export default defineTriggerSet({
   zoneId: ZoneId.TheCloudDeck,
   timelineFile: 'diamond_weapon.txt',
   triggers: [
@@ -308,6 +304,4 @@ const triggerSet: TriggerSet<Data> = {
       },
     },
   ],
-};
-
-export default triggerSet;
+});

--- a/ui/raidboss/data/05-shb/trial/emerald_weapon-ex.ts
+++ b/ui/raidboss/data/05-shb/trial/emerald_weapon-ex.ts
@@ -1,12 +1,11 @@
+import { defineTriggerSet } from '../../../../../resources/api_define_trigger_set';
 import Conditions from '../../../../../resources/conditions';
 import NetRegexes from '../../../../../resources/netregexes';
 import { UnreachableCode } from '../../../../../resources/not_reached';
 import Outputs from '../../../../../resources/outputs';
 import { Responses } from '../../../../../resources/responses';
 import ZoneId from '../../../../../resources/zone_id';
-import { RaidbossData } from '../../../../../types/data';
 import { NetMatches } from '../../../../../types/net_matches';
-import { TriggerSet } from '../../../../../types/trigger';
 
 // TODO: is there a way to know if a Tertius Terminus Est sword is X or +?
 // 55CD has no heading.
@@ -16,7 +15,7 @@ import { TriggerSet } from '../../../../../types/trigger';
 // TODO: handle mechanized maneuver with GetCombatnats?
 // TODO: handle divebombs during mechanized maneuver with GetCombatants?
 
-export interface Data extends RaidbossData {
+export interface Data {
   seenMines?: boolean;
   orbs?: NetMatches['AddedCombatant'][];
   primusPlayers?: string[];
@@ -37,7 +36,7 @@ const sharedOutputStrings = {
   },
 };
 
-const triggerSet: TriggerSet<Data> = {
+export default defineTriggerSet<Data>({
   zoneId: ZoneId.CastrumMarinumExtreme,
   timelineFile: 'emerald_weapon-ex.txt',
   timelineTriggers: [
@@ -655,6 +654,4 @@ const triggerSet: TriggerSet<Data> = {
       },
     },
   ],
-};
-
-export default triggerSet;
+});

--- a/ui/raidboss/data/05-shb/trial/emerald_weapon.ts
+++ b/ui/raidboss/data/05-shb/trial/emerald_weapon.ts
@@ -1,15 +1,12 @@
+import { defineTriggerSet } from '../../../../../resources/api_define_trigger_set';
 import Conditions from '../../../../../resources/conditions';
 import NetRegexes from '../../../../../resources/netregexes';
 import { Responses } from '../../../../../resources/responses';
 import ZoneId from '../../../../../resources/zone_id';
-import { RaidbossData } from '../../../../../types/data';
-import { TriggerSet } from '../../../../../types/trigger';
 
-export interface Data extends RaidbossData {
+export default defineTriggerSet<{
   seenMines?: boolean;
-}
-
-const triggerSet: TriggerSet<Data> = {
+}>({
   zoneId: ZoneId.CastrumMarinum,
   timelineFile: 'emerald_weapon.txt',
   triggers: [
@@ -300,6 +297,4 @@ const triggerSet: TriggerSet<Data> = {
       },
     },
   ],
-};
-
-export default triggerSet;
+});

--- a/ui/raidboss/data/05-shb/trial/hades-ex.ts
+++ b/ui/raidboss/data/05-shb/trial/hades-ex.ts
@@ -1,26 +1,23 @@
+import { defineTriggerSet } from '../../../../../resources/api_define_trigger_set';
 import Conditions from '../../../../../resources/conditions';
 import NetRegexes from '../../../../../resources/netregexes';
 import Outputs from '../../../../../resources/outputs';
 import { Responses } from '../../../../../resources/responses';
 import ZoneId from '../../../../../resources/zone_id';
-import { RaidbossData } from '../../../../../types/data';
-import { TriggerSet } from '../../../../../types/trigger';
-
-export interface Data extends RaidbossData {
-  waterDarkMarker?: boolean;
-  freeze?: boolean;
-  flame?: boolean;
-  sphereCount?: number;
-  brand?: string;
-  netherBlast?: boolean;
-}
 
 // Hades Extreme
 
 // TODO: call out direction for safe spot
 // TODO: fire/ice tethers (0060|0061)
 
-const triggerSet: TriggerSet<Data> = {
+export default defineTriggerSet<{
+  waterDarkMarker?: boolean;
+  freeze?: boolean;
+  flame?: boolean;
+  sphereCount?: number;
+  brand?: string;
+  netherBlast?: boolean;
+}>({
   zoneId: ZoneId.TheMinstrelsBalladHadessElegy,
   timelineFile: 'hades-ex.txt',
   timelineTriggers: [
@@ -1036,6 +1033,4 @@ const triggerSet: TriggerSet<Data> = {
       },
     },
   ],
-};
-
-export default triggerSet;
+});

--- a/ui/raidboss/data/05-shb/trial/hades.ts
+++ b/ui/raidboss/data/05-shb/trial/hades.ts
@@ -1,18 +1,15 @@
+import { defineTriggerSet } from '../../../../../resources/api_define_trigger_set';
 import Conditions from '../../../../../resources/conditions';
 import NetRegexes from '../../../../../resources/netregexes';
 import Outputs from '../../../../../resources/outputs';
 import { Responses } from '../../../../../resources/responses';
 import ZoneId from '../../../../../resources/zone_id';
-import { RaidbossData } from '../../../../../types/data';
-import { TriggerSet } from '../../../../../types/trigger';
 
-export interface Data extends RaidbossData {
+export default defineTriggerSet<{
   neoHades?: boolean;
   seenLifeInCaptivity?: boolean;
   ancient?: { [name: string]: string };
-}
-
-const triggerSet: TriggerSet<Data> = {
+}>({
   zoneId: ZoneId.TheDyingGasp,
   timelineFile: 'hades.txt',
   triggers: [
@@ -497,6 +494,4 @@ const triggerSet: TriggerSet<Data> = {
       },
     },
   ],
-};
-
-export default triggerSet;
+});

--- a/ui/raidboss/data/05-shb/trial/innocence-ex.ts
+++ b/ui/raidboss/data/05-shb/trial/innocence-ex.ts
@@ -1,19 +1,16 @@
+import { defineTriggerSet } from '../../../../../resources/api_define_trigger_set';
 import Conditions from '../../../../../resources/conditions';
 import NetRegexes from '../../../../../resources/netregexes';
 import Outputs from '../../../../../resources/outputs';
 import { Responses } from '../../../../../resources/responses';
 import ZoneId from '../../../../../resources/zone_id';
-import { RaidbossData } from '../../../../../types/data';
-import { TriggerSet } from '../../../../../types/trigger';
 
-export interface Data extends RaidbossData {
+// Innocence Extreme
+export default defineTriggerSet<{
   starbirthCount?: number;
   starbirthActive?: boolean;
   lightPillar?: number;
-}
-
-// Innocence Extreme
-const triggerSet: TriggerSet<Data> = {
+}>({
   zoneId: ZoneId.TheCrownOfTheImmaculateExtreme,
   timelineFile: 'innocence-ex.txt',
   triggers: [
@@ -591,6 +588,4 @@ const triggerSet: TriggerSet<Data> = {
       },
     },
   ],
-};
-
-export default triggerSet;
+});

--- a/ui/raidboss/data/05-shb/trial/innocence.ts
+++ b/ui/raidboss/data/05-shb/trial/innocence.ts
@@ -1,14 +1,11 @@
+import { defineTriggerSet } from '../../../../../resources/api_define_trigger_set';
 import Conditions from '../../../../../resources/conditions';
 import NetRegexes from '../../../../../resources/netregexes';
 import { Responses } from '../../../../../resources/responses';
 import ZoneId from '../../../../../resources/zone_id';
-import { RaidbossData } from '../../../../../types/data';
-import { TriggerSet } from '../../../../../types/trigger';
-
-export type Data = RaidbossData;
 
 // Innocence Normal
-const triggerSet: TriggerSet<Data> = {
+export default defineTriggerSet({
   zoneId: ZoneId.TheCrownOfTheImmaculate,
   timelineFile: 'innocence.txt',
   triggers: [
@@ -285,6 +282,4 @@ const triggerSet: TriggerSet<Data> = {
       },
     },
   ],
-};
-
-export default triggerSet;
+});

--- a/ui/raidboss/data/05-shb/trial/levi-un.ts
+++ b/ui/raidboss/data/05-shb/trial/levi-un.ts
@@ -1,17 +1,10 @@
+import { defineTriggerSet } from '../../../../../resources/api_define_trigger_set';
 import NetRegexes from '../../../../../resources/netregexes';
 import Outputs from '../../../../../resources/outputs';
 import { callOverlayHandler } from '../../../../../resources/overlay_plugin_api';
 import Util from '../../../../../resources/util';
 import ZoneId from '../../../../../resources/zone_id';
-import { RaidbossData } from '../../../../../types/data';
 import { PluginCombatantState } from '../../../../../types/event';
-import { TriggerSet } from '../../../../../types/trigger';
-
-export interface Data extends RaidbossData {
-  diveCounter?: number;
-  converter?: boolean;
-  slamLevis?: PluginCombatantState[];
-}
 
 // TODO: we could consider a timeline trigger for the Tidal Roar raidwide,
 // but it barely does 25% health, has no startsUsing, and the timeline for
@@ -24,7 +17,11 @@ export interface Data extends RaidbossData {
 // positions (+/-7, +/-20) and so more work would need to be done to tell
 // them apart.
 
-const triggerSet: TriggerSet<Data> = {
+export default defineTriggerSet<{
+  diveCounter?: number;
+  converter?: boolean;
+  slamLevis?: PluginCombatantState[];
+}>({
   zoneId: ZoneId.TheWhorleaterUnreal,
   timelineFile: 'levi-un.txt',
   triggers: [
@@ -412,6 +409,4 @@ const triggerSet: TriggerSet<Data> = {
       },
     },
   ],
-};
-
-export default triggerSet;
+});

--- a/ui/raidboss/data/05-shb/trial/ruby_weapon-ex.ts
+++ b/ui/raidboss/data/05-shb/trial/ruby_weapon-ex.ts
@@ -1,24 +1,21 @@
+import { defineTriggerSet } from '../../../../../resources/api_define_trigger_set';
 import Conditions from '../../../../../resources/conditions';
 import NetRegexes from '../../../../../resources/netregexes';
 import { UnreachableCode } from '../../../../../resources/not_reached';
 import Outputs from '../../../../../resources/outputs';
 import { Responses } from '../../../../../resources/responses';
 import ZoneId from '../../../../../resources/zone_id';
-import { RaidbossData } from '../../../../../types/data';
-import { TriggerSet } from '../../../../../types/trigger';
 
-export interface Data extends RaidbossData {
+// TODO: ravensflight calls would be nice
+
+export default defineTriggerSet<{
   seenFlight?: boolean;
   ravens?: { [color: string]: string | undefined };
   colors?: { [name: string]: string };
   ravenDead?: boolean;
   colorToImageId?: { [color: string]: string };
   imageIdToAction?: { [id: string]: string };
-}
-
-// TODO: ravensflight calls would be nice
-
-const triggerSet: TriggerSet<Data> = {
+}>({
   zoneId: ZoneId.CinderDriftExtreme,
   timelineFile: 'ruby_weapon-ex.txt',
   timelineTriggers: [
@@ -890,6 +887,4 @@ const triggerSet: TriggerSet<Data> = {
       },
     },
   ],
-};
-
-export default triggerSet;
+});

--- a/ui/raidboss/data/05-shb/trial/ruby_weapon.ts
+++ b/ui/raidboss/data/05-shb/trial/ruby_weapon.ts
@@ -1,15 +1,12 @@
+import { defineTriggerSet } from '../../../../../resources/api_define_trigger_set';
 import Conditions from '../../../../../resources/conditions';
 import NetRegexes from '../../../../../resources/netregexes';
 import { Responses } from '../../../../../resources/responses';
 import ZoneId from '../../../../../resources/zone_id';
-import { RaidbossData } from '../../../../../types/data';
-import { TriggerSet } from '../../../../../types/trigger';
 
-export interface Data extends RaidbossData {
+export default defineTriggerSet<{
   colors?: { [name: string]: string };
-}
-
-const triggerSet: TriggerSet<Data> = {
+}>({
   zoneId: ZoneId.CinderDrift,
   timelineFile: 'ruby_weapon.txt',
   timelineTriggers: [
@@ -369,6 +366,4 @@ const triggerSet: TriggerSet<Data> = {
       },
     },
   ],
-};
-
-export default triggerSet;
+});

--- a/ui/raidboss/data/05-shb/trial/shiva-un.ts
+++ b/ui/raidboss/data/05-shb/trial/shiva-un.ts
@@ -1,22 +1,19 @@
+import { defineTriggerSet } from '../../../../../resources/api_define_trigger_set';
 import Conditions from '../../../../../resources/conditions';
 import NetRegexes from '../../../../../resources/netregexes';
 import { Responses } from '../../../../../resources/responses';
 import ZoneId from '../../../../../resources/zone_id';
-import { RaidbossData } from '../../../../../types/data';
-import { TriggerSet } from '../../../../../types/trigger';
 
-export interface Data extends RaidbossData {
+// TODO: some sort of warning about extra tank damage during bow phase?
+// TODO: should the post-staff "spread" happen unconditionally prior to marker?
+
+export default defineTriggerSet<{
   currentTank?: string;
   blunt?: { [name: string]: boolean };
   slashing?: { [name: string]: boolean };
   soonAfterWeaponChange?: boolean;
   seenDiamondDust?: boolean;
-}
-
-// TODO: some sort of warning about extra tank damage during bow phase?
-// TODO: should the post-staff "spread" happen unconditionally prior to marker?
-
-const triggerSet: TriggerSet<Data> = {
+}>({
   zoneId: ZoneId.TheAkhAfahAmphitheatreUnreal,
   timelineFile: 'shiva-un.txt',
   timelineTriggers: [
@@ -420,6 +417,4 @@ const triggerSet: TriggerSet<Data> = {
       },
     },
   ],
-};
-
-export default triggerSet;
+});

--- a/ui/raidboss/data/05-shb/trial/titan-un.ts
+++ b/ui/raidboss/data/05-shb/trial/titan-un.ts
@@ -1,12 +1,9 @@
+import { defineTriggerSet } from '../../../../../resources/api_define_trigger_set';
 import NetRegexes from '../../../../../resources/netregexes';
 import { Responses } from '../../../../../resources/responses';
 import ZoneId from '../../../../../resources/zone_id';
-import { RaidbossData } from '../../../../../types/data';
-import { TriggerSet } from '../../../../../types/trigger';
 
-export type Data = RaidbossData;
-
-const triggerSet: TriggerSet<Data> = {
+export default defineTriggerSet({
   zoneId: ZoneId.TheNavelUnreal,
   timelineFile: 'titan-un.txt',
   timelineTriggers: [
@@ -254,6 +251,4 @@ const triggerSet: TriggerSet<Data> = {
       },
     },
   ],
-};
-
-export default triggerSet;
+});

--- a/ui/raidboss/data/05-shb/trial/titania-ex.ts
+++ b/ui/raidboss/data/05-shb/trial/titania-ex.ts
@@ -1,21 +1,18 @@
+import { defineTriggerSet } from '../../../../../resources/api_define_trigger_set';
 import Conditions from '../../../../../resources/conditions';
 import NetRegexes from '../../../../../resources/netregexes';
 import Outputs from '../../../../../resources/outputs';
 import { Responses } from '../../../../../resources/responses';
 import ZoneId from '../../../../../resources/zone_id';
-import { RaidbossData } from '../../../../../types/data';
-import { TriggerSet } from '../../../../../types/trigger';
 
-export interface Data extends RaidbossData {
+// Titania Extreme
+export default defineTriggerSet<{
   seenMistRune?: boolean;
   seenFlameRune?: boolean;
   pummelCount?: number;
   bomb?: { [name: string]: boolean };
   thunderCount?: number;
-}
-
-// Titania Extreme
-const triggerSet: TriggerSet<Data> = {
+}>({
   zoneId: ZoneId.TheDancingPlagueExtreme,
   timelineFile: 'titania-ex.txt',
   triggers: [
@@ -541,6 +538,4 @@ const triggerSet: TriggerSet<Data> = {
       },
     },
   ],
-};
-
-export default triggerSet;
+});

--- a/ui/raidboss/data/05-shb/trial/titania.ts
+++ b/ui/raidboss/data/05-shb/trial/titania.ts
@@ -1,14 +1,11 @@
+import { defineTriggerSet } from '../../../../../resources/api_define_trigger_set';
 import Conditions from '../../../../../resources/conditions';
 import NetRegexes from '../../../../../resources/netregexes';
 import { Responses } from '../../../../../resources/responses';
 import ZoneId from '../../../../../resources/zone_id';
-import { RaidbossData } from '../../../../../types/data';
-import { TriggerSet } from '../../../../../types/trigger';
-
-export type Data = RaidbossData;
 
 // Titania Normal Mode
-const triggerSet: TriggerSet<Data> = {
+export default defineTriggerSet({
   zoneId: ZoneId.TheDancingPlague,
   timelineFile: 'titania.txt',
   triggers: [
@@ -369,6 +366,4 @@ const triggerSet: TriggerSet<Data> = {
       },
     },
   ],
-};
-
-export default triggerSet;
+});

--- a/ui/raidboss/data/05-shb/trial/varis-ex.ts
+++ b/ui/raidboss/data/05-shb/trial/varis-ex.ts
@@ -1,17 +1,14 @@
+import { defineTriggerSet } from '../../../../../resources/api_define_trigger_set';
 import NetRegexes from '../../../../../resources/netregexes';
 import Outputs from '../../../../../resources/outputs';
 import { Responses } from '../../../../../resources/responses';
 import ZoneId from '../../../../../resources/zone_id';
-import { RaidbossData } from '../../../../../types/data';
-import { TriggerSet } from '../../../../../types/trigger';
 
-export interface Data extends RaidbossData {
+export default defineTriggerSet<{
   clonesActive?: boolean;
   suppressDodgeCloneCall?: boolean;
   phase?: number;
-}
-
-const triggerSet: TriggerSet<Data> = {
+}>({
   zoneId: ZoneId.MemoriaMiseraExtreme,
   timelineFile: 'varis-ex.txt',
   timelineTriggers: [
@@ -516,6 +513,4 @@ const triggerSet: TriggerSet<Data> = {
       },
     },
   ],
-};
-
-export default triggerSet;
+});

--- a/ui/raidboss/data/05-shb/trial/wol-ex.ts
+++ b/ui/raidboss/data/05-shb/trial/wol-ex.ts
@@ -1,12 +1,11 @@
+import { defineTriggerSet } from '../../../../../resources/api_define_trigger_set';
 import Conditions from '../../../../../resources/conditions';
 import NetRegexes from '../../../../../resources/netregexes';
 import Outputs from '../../../../../resources/outputs';
 import { Responses } from '../../../../../resources/responses';
 import ZoneId from '../../../../../resources/zone_id';
-import { RaidbossData } from '../../../../../types/data';
-import { TriggerSet } from '../../../../../types/trigger';
 
-export interface Data extends RaidbossData {
+export interface Data {
   limitBreak?: number;
   imbued?: string[];
   isAddPhase?: boolean;
@@ -81,7 +80,7 @@ const quintupleOutputStrings = {
   },
 };
 
-const triggerSet: TriggerSet<Data> = {
+export default defineTriggerSet<Data>({
   zoneId: ZoneId.TheSeatOfSacrificeExtreme,
   timelineFile: 'wol-ex.txt',
   timelineTriggers: [
@@ -995,6 +994,4 @@ const triggerSet: TriggerSet<Data> = {
       },
     },
   ],
-};
-
-export default triggerSet;
+});

--- a/ui/raidboss/data/05-shb/trial/wol.ts
+++ b/ui/raidboss/data/05-shb/trial/wol.ts
@@ -1,16 +1,13 @@
+import { defineTriggerSet } from '../../../../../resources/api_define_trigger_set';
 import Conditions from '../../../../../resources/conditions';
 import NetRegexes from '../../../../../resources/netregexes';
 import { Responses } from '../../../../../resources/responses';
 import ZoneId from '../../../../../resources/zone_id';
-import { RaidbossData } from '../../../../../types/data';
-import { TriggerSet } from '../../../../../types/trigger';
 
-export interface Data extends RaidbossData {
+export default defineTriggerSet<{
   imbued?: string;
   deluge?: string;
-}
-
-const triggerSet: TriggerSet<Data> = {
+}>({
   zoneId: ZoneId.TheSeatOfSacrifice,
   timelineFile: 'wol.txt',
   timelineTriggers: [
@@ -581,6 +578,4 @@ const triggerSet: TriggerSet<Data> = {
       },
     },
   ],
-};
-
-export default triggerSet;
+});

--- a/ui/raidboss/data/05-shb/ultimate/the_epic_of_alexander.ts
+++ b/ui/raidboss/data/05-shb/ultimate/the_epic_of_alexander.ts
@@ -1,3 +1,4 @@
+import { defineTriggerSet } from '../../../../../resources/api_define_trigger_set';
 import Conditions from '../../../../../resources/conditions';
 import NetRegexes from '../../../../../resources/netregexes';
 import Outputs from '../../../../../resources/outputs';
@@ -5,9 +6,9 @@ import { Responses } from '../../../../../resources/responses';
 import ZoneId from '../../../../../resources/zone_id';
 import { RaidbossData } from '../../../../../types/data';
 import { NetMatches } from '../../../../../types/net_matches';
-import { Output, TriggerSet } from '../../../../../types/trigger';
+import { Output } from '../../../../../types/trigger';
 
-export interface Data extends RaidbossData {
+export interface Data {
   phase?: string;
   decOffset?: number;
   nisiMap?: { [name: string]: number };
@@ -274,7 +275,7 @@ const nisiPassOutputStrings = {
 };
 
 // Convenience function called for third and fourth nisi passes.
-const namedNisiPass = (data: Data, output: Output) => {
+const namedNisiPass = (data: Data & RaidbossData, output: Output) => {
   const finalNisiMap = data.finalNisiMap;
   const nisiMap = data.nisiMap;
   if (!finalNisiMap || !nisiMap)
@@ -349,7 +350,7 @@ const betaInstructions = (idx: number | undefined, output: Output) => {
   return output.unknown!();
 };
 
-const triggerSet: TriggerSet<Data> = {
+export default defineTriggerSet<Data>({
   zoneId: ZoneId.TheEpicOfAlexanderUltimate,
   timelineFile: 'the_epic_of_alexander.txt',
   timelineTriggers: [
@@ -3188,6 +3189,4 @@ const triggerSet: TriggerSet<Data> = {
       },
     },
   ],
-};
-
-export default triggerSet;
+});

--- a/ui/raidboss/data/06-ew/alliance/aglaia.ts
+++ b/ui/raidboss/data/06-ew/alliance/aglaia.ts
@@ -1,10 +1,9 @@
+import { defineTriggerSet } from '../../../../../resources/api_define_trigger_set';
 import Conditions from '../../../../../resources/conditions';
 import NetRegexes from '../../../../../resources/netregexes';
 import Outputs from '../../../../../resources/outputs';
 import { Responses } from '../../../../../resources/responses';
 import ZoneId from '../../../../../resources/zone_id';
-import { RaidbossData } from '../../../../../types/data';
-import { TriggerSet } from '../../../../../types/trigger';
 
 // TODO: Byregot Levinforge
 // TODO: Byregot Spire
@@ -19,16 +18,14 @@ import { TriggerSet } from '../../../../../types/trigger';
 // TODO: Azeyma Wildfire Ward triangle triggers
 // TODO: Nald'Thal Fired Up I/II/III
 
-export interface Data extends RaidbossData {
+export default defineTriggerSet<{
   rhalgrSeenBeacon?: boolean;
   rhalgrBrokenWorldActive?: boolean;
   tankbusters: string[];
   naldSmeltingSpread: string[];
   naldArrowMarker: string[];
   naldLastColor?: 'orange' | 'blue';
-}
-
-const triggerSet: TriggerSet<Data> = {
+}>({
   zoneId: ZoneId.Aglaia,
   timelineFile: 'aglaia.txt',
   initData: () => {
@@ -1118,6 +1115,4 @@ const triggerSet: TriggerSet<Data> = {
       },
     },
   ],
-};
-
-export default triggerSet;
+});

--- a/ui/raidboss/data/06-ew/dungeon/alzadaals_legacy.ts
+++ b/ui/raidboss/data/06-ew/dungeon/alzadaals_legacy.ts
@@ -1,13 +1,10 @@
+import { defineTriggerSet } from '../../../../../resources/api_define_trigger_set';
 import Conditions from '../../../../../resources/conditions';
 import NetRegexes from '../../../../../resources/netregexes';
 import { Responses } from '../../../../../resources/responses';
 import ZoneId from '../../../../../resources/zone_id';
-import { RaidbossData } from '../../../../../types/data';
-import { TriggerSet } from '../../../../../types/trigger';
 
-export type Data = RaidbossData;
-
-const triggerSet: TriggerSet<Data> = {
+export default defineTriggerSet({
   zoneId: ZoneId.AlzadaalsLegacy,
   timelineFile: 'alzadaals_legacy.txt',
   triggers: [
@@ -294,6 +291,4 @@ const triggerSet: TriggerSet<Data> = {
       },
     },
   ],
-};
-
-export default triggerSet;
+});

--- a/ui/raidboss/data/06-ew/dungeon/ktisis_hyperboreia.ts
+++ b/ui/raidboss/data/06-ew/dungeon/ktisis_hyperboreia.ts
@@ -1,19 +1,16 @@
+import { defineTriggerSet } from '../../../../../resources/api_define_trigger_set';
 import NetRegexes from '../../../../../resources/netregexes';
 import { Responses } from '../../../../../resources/responses';
 import ZoneId from '../../../../../resources/zone_id';
-import { RaidbossData } from '../../../../../types/data';
-import { TriggerSet } from '../../../../../types/trigger';
 
 // TODO: Lyssa Frostbite and Seek
 // TODO: Ladon Lord cleave directions
 // TODO: Hermes correct meteor
 // TODO: Hermes mirror dodge direction
 
-export interface Data extends RaidbossData {
+export default defineTriggerSet<{
   isHermes?: boolean;
-}
-
-const triggerSet: TriggerSet<Data> = {
+}>({
   zoneId: ZoneId.KtisisHyperboreia,
   timelineFile: 'ktisis_hyperboreia.txt',
   triggers: [
@@ -307,6 +304,4 @@ const triggerSet: TriggerSet<Data> = {
       },
     },
   ],
-};
-
-export default triggerSet;
+});

--- a/ui/raidboss/data/06-ew/dungeon/smileton.ts
+++ b/ui/raidboss/data/06-ew/dungeon/smileton.ts
@@ -1,19 +1,16 @@
+import { defineTriggerSet } from '../../../../../resources/api_define_trigger_set';
 import Conditions from '../../../../../resources/conditions';
 import NetRegexes from '../../../../../resources/netregexes';
 import { Responses } from '../../../../../resources/responses';
 import ZoneId from '../../../../../resources/zone_id';
-import { RaidbossData } from '../../../../../types/data';
-import { TriggerSet } from '../../../../../types/trigger';
 
 // TODO: Big Cheese Bomb directions?
 // TODO: Big Cheese Bombs are only spawned once, is it possible the fast one is always the same id?
 
-export interface Data extends RaidbossData {
+export default defineTriggerSet<{
   smileyFace: boolean;
   frownyFace: boolean;
-}
-
-const triggerSet: TriggerSet<Data> = {
+}>({
   zoneId: ZoneId.Smileton,
   timelineFile: 'smileton.txt',
   initData: () => {
@@ -375,6 +372,4 @@ const triggerSet: TriggerSet<Data> = {
       },
     },
   ],
-};
-
-export default triggerSet;
+});

--- a/ui/raidboss/data/06-ew/dungeon/stigma_dreamscape.ts
+++ b/ui/raidboss/data/06-ew/dungeon/stigma_dreamscape.ts
@@ -1,16 +1,11 @@
+import { defineTriggerSet } from '../../../../../resources/api_define_trigger_set';
 import Conditions from '../../../../../resources/conditions';
 import NetRegexes from '../../../../../resources/netregexes';
 import Outputs from '../../../../../resources/outputs';
 import { Responses } from '../../../../../resources/responses';
 import ZoneId from '../../../../../resources/zone_id';
-import { RaidbossData } from '../../../../../types/data';
-import { TriggerSet } from '../../../../../types/trigger';
 
 // TODO: Does Mustard Bomb cleave? Should it be tankCleave() instead?
-
-export interface Data extends RaidbossData {
-  lastBoss: boolean;
-}
 
 const limitCutNumberMap: { [id: string]: number } = {
   '004F': 1,
@@ -19,7 +14,9 @@ const limitCutNumberMap: { [id: string]: number } = {
   '0052': 4,
 };
 
-const triggerSet: TriggerSet<Data> = {
+export default defineTriggerSet<{
+  lastBoss: boolean;
+}>({
   zoneId: ZoneId.TheStigmaDreamscape,
   timelineFile: 'stigma_dreamscape.txt',
   initData: () => {
@@ -528,6 +525,4 @@ const triggerSet: TriggerSet<Data> = {
       },
     },
   ],
-};
-
-export default triggerSet;
+});

--- a/ui/raidboss/data/06-ew/dungeon/the_aitiascope.ts
+++ b/ui/raidboss/data/06-ew/dungeon/the_aitiascope.ts
@@ -1,12 +1,9 @@
+import { defineTriggerSet } from '../../../../../resources/api_define_trigger_set';
 import NetRegexes from '../../../../../resources/netregexes';
 import { Responses } from '../../../../../resources/responses';
 import ZoneId from '../../../../../resources/zone_id';
-import { RaidbossData } from '../../../../../types/data';
-import { TriggerSet } from '../../../../../types/trigger';
 
-export type Data = RaidbossData;
-
-const triggerSet: TriggerSet<Data> = {
+export default defineTriggerSet({
   zoneId: ZoneId.TheAitiascope,
   timelineFile: 'the_aitiascope.txt',
   triggers: [
@@ -379,6 +376,4 @@ const triggerSet: TriggerSet<Data> = {
       },
     },
   ],
-};
-
-export default triggerSet;
+});

--- a/ui/raidboss/data/06-ew/dungeon/the_dead_ends.ts
+++ b/ui/raidboss/data/06-ew/dungeon/the_dead_ends.ts
@@ -1,16 +1,13 @@
+import { defineTriggerSet } from '../../../../../resources/api_define_trigger_set';
 import Conditions from '../../../../../resources/conditions';
 import NetRegexes from '../../../../../resources/netregexes';
 import Outputs from '../../../../../resources/outputs';
 import { Responses } from '../../../../../resources/responses';
 import ZoneId from '../../../../../resources/zone_id';
-import { RaidbossData } from '../../../../../types/data';
-import { TriggerSet } from '../../../../../types/trigger';
 
-export interface Data extends RaidbossData {
+export default defineTriggerSet<{
   seenLovingEmbrace?: boolean;
-}
-
-const triggerSet: TriggerSet<Data> = {
+}>({
   zoneId: ZoneId.TheDeadEnds,
   timelineFile: 'the_dead_ends.txt',
   triggers: [
@@ -436,6 +433,4 @@ const triggerSet: TriggerSet<Data> = {
       },
     },
   ],
-};
-
-export default triggerSet;
+});

--- a/ui/raidboss/data/06-ew/dungeon/the_fell_court_of_troia.ts
+++ b/ui/raidboss/data/06-ew/dungeon/the_fell_court_of_troia.ts
@@ -1,13 +1,10 @@
+import { defineTriggerSet } from '../../../../../resources/api_define_trigger_set';
 import Conditions from '../../../../../resources/conditions';
 import NetRegexes from '../../../../../resources/netregexes';
 import { Responses } from '../../../../../resources/responses';
 import ZoneId from '../../../../../resources/zone_id';
-import { RaidbossData } from '../../../../../types/data';
-import { TriggerSet } from '../../../../../types/trigger';
 
-export type Data = RaidbossData;
-
-const triggerSet: TriggerSet<Data> = {
+export default defineTriggerSet({
   zoneId: ZoneId.TheFellCourtOfTroia,
   timelineFile: 'the_fell_court_of_troia.txt',
   triggers: [
@@ -298,6 +295,4 @@ const triggerSet: TriggerSet<Data> = {
       },
     },
   ],
-};
-
-export default triggerSet;
+});

--- a/ui/raidboss/data/06-ew/dungeon/the_tower_of_babil.ts
+++ b/ui/raidboss/data/06-ew/dungeon/the_tower_of_babil.ts
@@ -1,17 +1,14 @@
+import { defineTriggerSet } from '../../../../../resources/api_define_trigger_set';
 import Conditions from '../../../../../resources/conditions';
 import NetRegexes from '../../../../../resources/netregexes';
 import { Responses } from '../../../../../resources/responses';
 import ZoneId from '../../../../../resources/zone_id';
-import { RaidbossData } from '../../../../../types/data';
-import { TriggerSet } from '../../../../../types/trigger';
-
-export interface Data extends RaidbossData {
-  barnabasNegative?: boolean;
-  playerNegative?: boolean;
-}
 
 // TODO: Figure out a clean way to call the Charnel Claw dashes?
-const triggerSet: TriggerSet<Data> = {
+export default defineTriggerSet<{
+  barnabasNegative?: boolean;
+  playerNegative?: boolean;
+}>({
   zoneId: ZoneId.TheTowerOfBabil,
   timelineFile: 'the_tower_of_babil.txt',
   triggers: [
@@ -495,6 +492,4 @@ const triggerSet: TriggerSet<Data> = {
       },
     },
   ],
-};
-
-export default triggerSet;
+});

--- a/ui/raidboss/data/06-ew/dungeon/the_tower_of_zot.ts
+++ b/ui/raidboss/data/06-ew/dungeon/the_tower_of_zot.ts
@@ -1,16 +1,13 @@
+import { defineTriggerSet } from '../../../../../resources/api_define_trigger_set';
 import NetRegexes from '../../../../../resources/netregexes';
 import Outputs from '../../../../../resources/outputs';
 import { Responses } from '../../../../../resources/responses';
 import ZoneId from '../../../../../resources/zone_id';
-import { RaidbossData } from '../../../../../types/data';
-import { TriggerSet } from '../../../../../types/trigger';
 
-export interface Data extends RaidbossData {
+export default defineTriggerSet<{
   orbCount: number;
   orbs: Map<'Fire' | 'Bio', number>;
-}
-
-const triggerSet: TriggerSet<Data> = {
+}>({
   zoneId: ZoneId.TheTowerOfZot,
   timelineFile: 'the_tower_of_zot.txt',
   initData: () => {
@@ -414,6 +411,4 @@ const triggerSet: TriggerSet<Data> = {
       },
     },
   ],
-};
-
-export default triggerSet;
+});

--- a/ui/raidboss/data/06-ew/dungeon/vanaspati.ts
+++ b/ui/raidboss/data/06-ew/dungeon/vanaspati.ts
@@ -1,15 +1,12 @@
+import { defineTriggerSet } from '../../../../../resources/api_define_trigger_set';
 import Conditions from '../../../../../resources/conditions';
 import NetRegexes from '../../../../../resources/netregexes';
 import { Responses } from '../../../../../resources/responses';
 import ZoneId from '../../../../../resources/zone_id';
-import { RaidbossData } from '../../../../../types/data';
-import { TriggerSet } from '../../../../../types/trigger';
 
 // TODO: is there any way to figure out Svarbhanu color? It doesn't seem to be a headmarker.
 
-export type Data = RaidbossData;
-
-const triggerSet: TriggerSet<Data> = {
+export default defineTriggerSet({
   zoneId: ZoneId.Vanaspati,
   timelineFile: 'vanaspati.txt',
   triggers: [
@@ -334,6 +331,4 @@ const triggerSet: TriggerSet<Data> = {
       },
     },
   ],
-};
-
-export default triggerSet;
+});

--- a/ui/raidboss/data/06-ew/hunts/elpis.ts
+++ b/ui/raidboss/data/06-ew/hunts/elpis.ts
@@ -1,15 +1,12 @@
+import { defineTriggerSet } from '../../../../../resources/api_define_trigger_set';
 import NetRegexes from '../../../../../resources/netregexes';
 import { Responses } from '../../../../../resources/responses';
 import ZoneId from '../../../../../resources/zone_id';
-import { RaidbossData } from '../../../../../types/data';
-import { TriggerSet } from '../../../../../types/trigger';
 
 // TODO: Gurangatch Octuple Slammer rotation directions
 // TODO: Gurangatch Wild Charge (6B77) gap closer, but appears to have no cast?
 
-export type Data = RaidbossData;
-
-const triggerSet: TriggerSet<Data> = {
+export default defineTriggerSet({
   zoneId: ZoneId.Elpis,
   triggers: [
     {
@@ -142,6 +139,4 @@ const triggerSet: TriggerSet<Data> = {
       },
     },
   ],
-};
-
-export default triggerSet;
+});

--- a/ui/raidboss/data/06-ew/hunts/garlemald.ts
+++ b/ui/raidboss/data/06-ew/hunts/garlemald.ts
@@ -1,14 +1,11 @@
+import { defineTriggerSet } from '../../../../../resources/api_define_trigger_set';
 import NetRegexes from '../../../../../resources/netregexes';
 import ZoneId from '../../../../../resources/zone_id';
-import { RaidbossData } from '../../../../../types/data';
-import { TriggerSet } from '../../../../../types/trigger';
 
 // TODO: Minerva Hammer Knuckles tankbuster
 // TODO: Minerva Sonic Amplifier aoe
 
-export type Data = RaidbossData;
-
-const triggerSet: TriggerSet<Data> = {
+export default defineTriggerSet({
   zoneId: ZoneId.Garlemald,
   triggers: [
     {
@@ -147,6 +144,4 @@ const triggerSet: TriggerSet<Data> = {
       },
     },
   ],
-};
-
-export default triggerSet;
+});

--- a/ui/raidboss/data/06-ew/hunts/labyrinthos.ts
+++ b/ui/raidboss/data/06-ew/hunts/labyrinthos.ts
@@ -1,12 +1,9 @@
+import { defineTriggerSet } from '../../../../../resources/api_define_trigger_set';
 import NetRegexes from '../../../../../resources/netregexes';
 import { Responses } from '../../../../../resources/responses';
 import ZoneId from '../../../../../resources/zone_id';
-import { RaidbossData } from '../../../../../types/data';
-import { TriggerSet } from '../../../../../types/trigger';
 
-export type Data = RaidbossData;
-
-const triggerSet: TriggerSet<Data> = {
+export default defineTriggerSet({
   zoneId: ZoneId.Labyrinthos,
   triggers: [
     {
@@ -125,6 +122,4 @@ const triggerSet: TriggerSet<Data> = {
       },
     },
   ],
-};
-
-export default triggerSet;
+});

--- a/ui/raidboss/data/06-ew/hunts/mare_lamentorum.ts
+++ b/ui/raidboss/data/06-ew/hunts/mare_lamentorum.ts
@@ -1,12 +1,9 @@
+import { defineTriggerSet } from '../../../../../resources/api_define_trigger_set';
 import NetRegexes from '../../../../../resources/netregexes';
 import { Responses } from '../../../../../resources/responses';
 import ZoneId from '../../../../../resources/zone_id';
-import { RaidbossData } from '../../../../../types/data';
-import { TriggerSet } from '../../../../../types/trigger';
 
-export type Data = RaidbossData;
-
-const triggerSet: TriggerSet<Data> = {
+export default defineTriggerSet({
   zoneId: ZoneId.MareLamentorum,
   triggers: [
     {
@@ -183,6 +180,4 @@ const triggerSet: TriggerSet<Data> = {
       },
     },
   ],
-};
-
-export default triggerSet;
+});

--- a/ui/raidboss/data/06-ew/hunts/ss_rank.ts
+++ b/ui/raidboss/data/06-ew/hunts/ss_rank.ts
@@ -1,17 +1,14 @@
+import { defineTriggerSet } from '../../../../../resources/api_define_trigger_set';
 import NetRegexes from '../../../../../resources/netregexes';
 import { Responses } from '../../../../../resources/responses';
 import ZoneId from '../../../../../resources/zone_id';
-import { RaidbossData } from '../../../../../types/data';
-import { TriggerSet } from '../../../../../types/trigger';
-
-export type Data = RaidbossData;
 
 // TODO:
 // Ancient Flare is probably 6FB6?, Pyretic debuff effect is ?
 // Whispered Incantation + Whispers Manifest
 // Handle Mirrored Incantation + Interments
 
-const triggerSet: TriggerSet<Data> = {
+export default defineTriggerSet({
   zoneId: [
     ZoneId.Labyrinthos,
     ZoneId.Thavnair,
@@ -78,6 +75,4 @@ const triggerSet: TriggerSet<Data> = {
       response: Responses.goRight(),
     },
   ],
-};
-
-export default triggerSet;
+});

--- a/ui/raidboss/data/06-ew/hunts/thavnair.ts
+++ b/ui/raidboss/data/06-ew/hunts/thavnair.ts
@@ -1,15 +1,12 @@
+import { defineTriggerSet } from '../../../../../resources/api_define_trigger_set';
 import Conditions from '../../../../../resources/conditions';
 import NetRegexes from '../../../../../resources/netregexes';
 import { Responses } from '../../../../../resources/responses';
 import ZoneId from '../../../../../resources/zone_id';
-import { RaidbossData } from '../../../../../types/data';
-import { TriggerSet } from '../../../../../types/trigger';
 
 // TODO: Yilan Bog Bomb (6A61) untelegraphed circle on a random target (can this be called?)
 
-export type Data = RaidbossData;
-
-const triggerSet: TriggerSet<Data> = {
+export default defineTriggerSet({
   zoneId: ZoneId.Thavnair,
   triggers: [
     {
@@ -195,6 +192,4 @@ const triggerSet: TriggerSet<Data> = {
       },
     },
   ],
-};
-
-export default triggerSet;
+});

--- a/ui/raidboss/data/06-ew/hunts/ultima_thule.ts
+++ b/ui/raidboss/data/06-ew/hunts/ultima_thule.ts
@@ -1,14 +1,11 @@
+import { defineTriggerSet } from '../../../../../resources/api_define_trigger_set';
 import NetRegexes from '../../../../../resources/netregexes';
 import { Responses } from '../../../../../resources/responses';
 import ZoneId from '../../../../../resources/zone_id';
-import { RaidbossData } from '../../../../../types/data';
-import { TriggerSet } from '../../../../../types/trigger';
 
 // TODO: Fan Ail Death Sentence tankbuster
 
-export type Data = RaidbossData;
-
-const triggerSet: TriggerSet<Data> = {
+export default defineTriggerSet({
   zoneId: ZoneId.UltimaThule,
   triggers: [
     {
@@ -126,6 +123,4 @@ const triggerSet: TriggerSet<Data> = {
       },
     },
   ],
-};
-
-export default triggerSet;
+});

--- a/ui/raidboss/data/06-ew/raid/p1n.ts
+++ b/ui/raidboss/data/06-ew/raid/p1n.ts
@@ -1,16 +1,13 @@
+import { defineTriggerSet } from '../../../../../resources/api_define_trigger_set';
 import Conditions from '../../../../../resources/conditions';
 import NetRegexes from '../../../../../resources/netregexes';
 import { Responses } from '../../../../../resources/responses';
 import ZoneId from '../../../../../resources/zone_id';
-import { RaidbossData } from '../../../../../types/data';
-import { TriggerSet } from '../../../../../types/trigger';
 
 // TODO: Intemperance calls out a 4th time; should only call out three
 // TODO: Right/Left + Fire/Light happen at the same time later; collect these together
 
-export type Data = RaidbossData;
-
-const triggerSet: TriggerSet<Data> = {
+export default defineTriggerSet({
   zoneId: ZoneId.AsphodelosTheFirstCircle,
   timelineFile: 'p1n.txt',
   triggers: [
@@ -260,6 +257,4 @@ const triggerSet: TriggerSet<Data> = {
       },
     },
   ],
-};
-
-export default triggerSet;
+});

--- a/ui/raidboss/data/06-ew/raid/p1s.ts
+++ b/ui/raidboss/data/06-ew/raid/p1s.ts
@@ -1,19 +1,12 @@
+import { defineTriggerSet } from '../../../../../resources/api_define_trigger_set';
 import Conditions from '../../../../../resources/conditions';
 import NetRegexes from '../../../../../resources/netregexes';
 import Outputs from '../../../../../resources/outputs';
 import { Responses } from '../../../../../resources/responses';
 import ZoneId from '../../../../../resources/zone_id';
-import { RaidbossData } from '../../../../../types/data';
-import { TriggerSet } from '../../../../../types/trigger';
 
 // TODO: Fixup Intemperance callouts
 // TODO: Add Aetherflail callouts to Powerful Light/Fire
-
-export interface Data extends RaidbossData {
-  companionship?: string;
-  loneliness?: string;
-  safeColor?: string;
-}
 
 const flailDirections = {
   l: Outputs.left,
@@ -47,7 +40,11 @@ const fireLightOutputStrings = {
   },
 };
 
-const triggerSet: TriggerSet<Data> = {
+export default defineTriggerSet<{
+  companionship?: string;
+  loneliness?: string;
+  safeColor?: string;
+}>({
   zoneId: ZoneId.AsphodelosTheFirstCircleSavage,
   timelineFile: 'p1s.txt',
   timelineTriggers: [
@@ -668,6 +665,4 @@ const triggerSet: TriggerSet<Data> = {
       },
     },
   ],
-};
-
-export default triggerSet;
+});

--- a/ui/raidboss/data/06-ew/raid/p2n.ts
+++ b/ui/raidboss/data/06-ew/raid/p2n.ts
@@ -1,19 +1,16 @@
+import { defineTriggerSet } from '../../../../../resources/api_define_trigger_set';
 import Conditions from '../../../../../resources/conditions';
 import NetRegexes from '../../../../../resources/netregexes';
 import Outputs from '../../../../../resources/outputs';
 import { callOverlayHandler } from '../../../../../resources/overlay_plugin_api';
 import { Responses } from '../../../../../resources/responses';
 import ZoneId from '../../../../../resources/zone_id';
-import { RaidbossData } from '../../../../../types/data';
 import { PluginCombatantState } from '../../../../../types/event';
-import { TriggerSet } from '../../../../../types/trigger';
 
-export interface Data extends RaidbossData {
+export default defineTriggerSet<{
   bodyActor?: PluginCombatantState;
   flareTarget?: string;
-}
-
-const triggerSet: TriggerSet<Data> = {
+}>({
   zoneId: ZoneId.AsphodelosTheSecondCircle,
   timelineFile: 'p2n.txt',
   triggers: [
@@ -322,6 +319,4 @@ const triggerSet: TriggerSet<Data> = {
       },
     },
   ],
-};
-
-export default triggerSet;
+});

--- a/ui/raidboss/data/06-ew/raid/p2s.ts
+++ b/ui/raidboss/data/06-ew/raid/p2s.ts
@@ -1,18 +1,17 @@
+import { defineTriggerSet } from '../../../../../resources/api_define_trigger_set';
 import Conditions from '../../../../../resources/conditions';
 import NetRegexes from '../../../../../resources/netregexes';
 import Outputs from '../../../../../resources/outputs';
 import { Responses } from '../../../../../resources/responses';
 import ZoneId from '../../../../../resources/zone_id';
-import { RaidbossData } from '../../../../../types/data';
 import { NetMatches } from '../../../../../types/net_matches';
-import { TriggerSet } from '../../../../../types/trigger';
 
 // TODO: Callout cardinal for Spoken Cataract
 // TODO: Debuff collect for Marks and callouts for those without debuff
 // TODO: Add cardinal to Channeling Flow
 // TODO: Fix headmarker ids for Kampeos Harma Callouts
 
-export interface Data extends RaidbossData {
+export interface Data {
   flareTarget?: string;
   decOffset?: number;
   avarice?: NetMatches['GainsEffect'][];
@@ -34,7 +33,7 @@ const getHeadmarkerId = (data: Data, matches: NetMatches['HeadMarker']) => {
   return (parseInt(matches.id, 16) - data.decOffset).toString(16).toUpperCase().padStart(4, '0');
 };
 
-const triggerSet: TriggerSet<Data> = {
+export default defineTriggerSet<Data>({
   zoneId: ZoneId.AsphodelosTheSecondCircleSavage,
   timelineFile: 'p2s.txt',
   triggers: [
@@ -549,6 +548,4 @@ const triggerSet: TriggerSet<Data> = {
       },
     },
   ],
-};
-
-export default triggerSet;
+});

--- a/ui/raidboss/data/06-ew/raid/p3n.ts
+++ b/ui/raidboss/data/06-ew/raid/p3n.ts
@@ -1,16 +1,13 @@
+import { defineTriggerSet } from '../../../../../resources/api_define_trigger_set';
 import Conditions from '../../../../../resources/conditions';
 import NetRegexes from '../../../../../resources/netregexes';
 import Outputs from '../../../../../resources/outputs';
 import { Responses } from '../../../../../resources/responses';
 import ZoneId from '../../../../../resources/zone_id';
-import { RaidbossData } from '../../../../../types/data';
-import { TriggerSet } from '../../../../../types/trigger';
 
-export interface Data extends RaidbossData {
+export default defineTriggerSet<{
   ashenEyeDirections?: number[];
-}
-
-const triggerSet: TriggerSet<Data> = {
+}>({
   zoneId: ZoneId.AsphodelosTheThirdCircle,
   timelineFile: 'p3n.txt',
   triggers: [
@@ -388,6 +385,4 @@ const triggerSet: TriggerSet<Data> = {
       },
     },
   ],
-};
-
-export default triggerSet;
+});

--- a/ui/raidboss/data/06-ew/raid/p3s.ts
+++ b/ui/raidboss/data/06-ew/raid/p3s.ts
@@ -1,14 +1,13 @@
+import { defineTriggerSet } from '../../../../../resources/api_define_trigger_set';
 import Conditions from '../../../../../resources/conditions';
 import NetRegexes from '../../../../../resources/netregexes';
 import { UnreachableCode } from '../../../../../resources/not_reached';
 import Outputs from '../../../../../resources/outputs';
 import { Responses } from '../../../../../resources/responses';
 import ZoneId from '../../../../../resources/zone_id';
-import { RaidbossData } from '../../../../../types/data';
 import { NetMatches } from '../../../../../types/net_matches';
-import { TriggerSet } from '../../../../../types/trigger';
 
-export interface Data extends RaidbossData {
+export interface Data {
   deathsToll?: boolean;
   deathsTollPending?: boolean;
   sunbirdTethers: NetMatches['Tether'][];
@@ -32,7 +31,7 @@ const getHeadmarkerId = (data: Data, matches: NetMatches['HeadMarker']) => {
   return (parseInt(matches.id, 16) - data.decOffset).toString(16).toUpperCase().padStart(4, '0');
 };
 
-const triggerSet: TriggerSet<Data> = {
+export default defineTriggerSet<Data>({
   zoneId: ZoneId.AsphodelosTheThirdCircleSavage,
   timelineFile: 'p3s.txt',
   initData: () => {
@@ -753,6 +752,4 @@ const triggerSet: TriggerSet<Data> = {
       },
     },
   ],
-};
-
-export default triggerSet;
+});

--- a/ui/raidboss/data/06-ew/raid/p4n.ts
+++ b/ui/raidboss/data/06-ew/raid/p4n.ts
@@ -1,12 +1,9 @@
+import { defineTriggerSet } from '../../../../../resources/api_define_trigger_set';
 import NetRegexes from '../../../../../resources/netregexes';
 import { Responses } from '../../../../../resources/responses';
 import ZoneId from '../../../../../resources/zone_id';
-import { RaidbossData } from '../../../../../types/data';
-import { TriggerSet } from '../../../../../types/trigger';
 
-export type Data = RaidbossData;
-
-const triggerSet: TriggerSet<Data> = {
+export default defineTriggerSet({
   zoneId: ZoneId.AsphodelosTheFourthCircle,
   timelineFile: 'p4n.txt',
   triggers: [
@@ -380,6 +377,4 @@ const triggerSet: TriggerSet<Data> = {
       },
     },
   ],
-};
-
-export default triggerSet;
+});

--- a/ui/raidboss/data/06-ew/raid/p4s.ts
+++ b/ui/raidboss/data/06-ew/raid/p4s.ts
@@ -1,13 +1,12 @@
+import { defineTriggerSet } from '../../../../../resources/api_define_trigger_set';
 import Conditions from '../../../../../resources/conditions';
 import NetRegexes from '../../../../../resources/netregexes';
 import Outputs from '../../../../../resources/outputs';
 import { callOverlayHandler } from '../../../../../resources/overlay_plugin_api';
 import { Responses } from '../../../../../resources/responses';
 import ZoneId from '../../../../../resources/zone_id';
-import { RaidbossData } from '../../../../../types/data';
 import { PluginCombatantState } from '../../../../../types/event';
 import { NetMatches } from '../../../../../types/net_matches';
-import { TriggerSet } from '../../../../../types/trigger';
 
 // Part Two
 // TODO: Better Dark Design/tether break callouts
@@ -16,7 +15,7 @@ import { TriggerSet } from '../../../../../types/trigger';
 // TODO: Heart Stake is tankbuster with DoT, does it need to be output differrently?
 // TODO: Curtain Call tank swap
 
-export interface Data extends RaidbossData {
+export interface Data {
   actingRole?: string;
   decOffset?: number;
   tetherRole?: string[];
@@ -120,7 +119,7 @@ const getHeadmarkerId = (data: Data, matches: NetMatches['HeadMarker'], firstDec
   return (parseInt(matches.id, 16) - data.decOffset).toString(16).toUpperCase().padStart(4, '0');
 };
 
-const triggerSet: TriggerSet<Data> = {
+export default defineTriggerSet<Data>({
   zoneId: ZoneId.AsphodelosTheFourthCircleSavage,
   timelineFile: 'p4s.txt',
   initData: () => {
@@ -1561,6 +1560,4 @@ const triggerSet: TriggerSet<Data> = {
       },
     },
   ],
-};
-
-export default triggerSet;
+});

--- a/ui/raidboss/data/06-ew/raid/p5n.ts
+++ b/ui/raidboss/data/06-ew/raid/p5n.ts
@@ -1,22 +1,21 @@
+import { defineTriggerSet } from '../../../../../resources/api_define_trigger_set';
 import Conditions from '../../../../../resources/conditions';
 import NetRegexes from '../../../../../resources/netregexes';
 import Outputs from '../../../../../resources/outputs';
 import { Responses } from '../../../../../resources/responses';
 import ZoneId from '../../../../../resources/zone_id';
-import { RaidbossData } from '../../../../../types/data';
-import { TriggerSet } from '../../../../../types/trigger';
 
 // TODO: Better Topaz Stones guidance
 // TODO: Better Starving Stampede guidance
 
-export interface Data extends RaidbossData {
+export interface Data {
   seenStones?: boolean;
   numStones?: number;
   acid?: boolean;
   topazRayDirections: (string | undefined)[];
 }
 
-const triggerSet: TriggerSet<Data> = {
+export default defineTriggerSet<Data>({
   zoneId: ZoneId.AbyssosTheFifthCircle,
   timelineFile: 'p5n.txt',
   initData: () => {
@@ -279,6 +278,4 @@ const triggerSet: TriggerSet<Data> = {
       },
     },
   ],
-};
-
-export default triggerSet;
+});

--- a/ui/raidboss/data/06-ew/raid/p5s.ts
+++ b/ui/raidboss/data/06-ew/raid/p5s.ts
@@ -1,10 +1,9 @@
+import { defineTriggerSet } from '../../../../../resources/api_define_trigger_set';
 import NetRegexes from '../../../../../resources/netregexes';
 import Outputs from '../../../../../resources/outputs';
 import { callOverlayHandler } from '../../../../../resources/overlay_plugin_api';
 import { Responses } from '../../../../../resources/responses';
 import ZoneId from '../../../../../resources/zone_id';
-import { RaidbossData } from '../../../../../types/data';
-import { TriggerSet } from '../../../../../types/trigger';
 
 // TODO: Callout safe quadrant/half for Venom Pool with Crystals
 
@@ -15,14 +14,14 @@ const directions = {
   'NW': true,
 };
 
-export interface Data extends RaidbossData {
+export interface Data {
   target?: string;
   topazClusterCombatantIdToAbilityId: { [id: number]: string };
   topazRays: { [time: number]: (keyof typeof directions)[] };
   clawCount: number;
 }
 
-const triggerSet: TriggerSet<Data> = {
+export default defineTriggerSet<Data>({
   zoneId: ZoneId.AbyssosTheFifthCircleSavage,
   timelineFile: 'p5s.txt',
   initData: () => {
@@ -417,6 +416,4 @@ const triggerSet: TriggerSet<Data> = {
       },
     },
   ],
-};
-
-export default triggerSet;
+});

--- a/ui/raidboss/data/06-ew/raid/p6n.ts
+++ b/ui/raidboss/data/06-ew/raid/p6n.ts
@@ -1,19 +1,16 @@
+import { defineTriggerSet } from '../../../../../resources/api_define_trigger_set';
 import Conditions from '../../../../../resources/conditions';
 import NetRegexes from '../../../../../resources/netregexes';
 import Outputs from '../../../../../resources/outputs';
 import { Responses } from '../../../../../resources/responses';
 import ZoneId from '../../../../../resources/zone_id';
-import { RaidbossData } from '../../../../../types/data';
-import { TriggerSet } from '../../../../../types/trigger';
 
 // TODO: Find some data, any data, in the network logs that will let us call Polyominous Dark.
 // and Transmission.
 
-export interface Data extends RaidbossData {
+export default defineTriggerSet<{
   busterTargets: string[];
-}
-
-const triggerSet: TriggerSet<Data> = {
+}>({
   zoneId: ZoneId.AbyssosTheSixthCircle,
   timelineFile: 'p6n.txt',
   initData: () => {
@@ -229,6 +226,4 @@ const triggerSet: TriggerSet<Data> = {
       },
     },
   ],
-};
-
-export default triggerSet;
+});

--- a/ui/raidboss/data/06-ew/raid/p6s.ts
+++ b/ui/raidboss/data/06-ew/raid/p6s.ts
@@ -1,13 +1,12 @@
+import { defineTriggerSet } from '../../../../../resources/api_define_trigger_set';
 import Conditions from '../../../../../resources/conditions';
 import NetRegexes from '../../../../../resources/netregexes';
 import Outputs from '../../../../../resources/outputs';
 import { Responses } from '../../../../../resources/responses';
 import ZoneId from '../../../../../resources/zone_id';
-import { RaidbossData } from '../../../../../types/data';
 import { NetMatches } from '../../../../../types/net_matches';
-import { TriggerSet } from '../../../../../types/trigger';
 
-export interface Data extends RaidbossData {
+export interface Data {
   decOffset?: number;
   pathogenicCellsNumber?: number;
   pathogenicCellsDelay?: number;
@@ -34,7 +33,7 @@ const getHeadmarkerId = (data: Data, matches: NetMatches['HeadMarker']) => {
   return (parseInt(matches.id, 16) - data.decOffset).toString(16).toUpperCase().padStart(4, '0');
 };
 
-const triggerSet: TriggerSet<Data> = {
+export default defineTriggerSet<Data>({
   zoneId: ZoneId.AbyssosTheSixthCircleSavage,
   timelineFile: 'p6s.txt',
   initData: () => {
@@ -567,6 +566,4 @@ const triggerSet: TriggerSet<Data> = {
       },
     },
   ],
-};
-
-export default triggerSet;
+});

--- a/ui/raidboss/data/06-ew/raid/p7n.ts
+++ b/ui/raidboss/data/06-ew/raid/p7n.ts
@@ -1,16 +1,13 @@
+import { defineTriggerSet } from '../../../../../resources/api_define_trigger_set';
 import Conditions from '../../../../../resources/conditions';
 import NetRegexes from '../../../../../resources/netregexes';
 import Outputs from '../../../../../resources/outputs';
 import { Responses } from '../../../../../resources/responses';
 import ZoneId from '../../../../../resources/zone_id';
-import { RaidbossData } from '../../../../../types/data';
-import { TriggerSet } from '../../../../../types/trigger';
 
-export interface Data extends RaidbossData {
+export default defineTriggerSet<{
   busterTargets: string[];
-}
-
-const triggerSet: TriggerSet<Data> = {
+}>({
   zoneId: ZoneId.AbyssosTheSeventhCircle,
   timelineFile: 'p7n.txt',
   initData: () => {
@@ -270,6 +267,4 @@ const triggerSet: TriggerSet<Data> = {
       },
     },
   ],
-};
-
-export default triggerSet;
+});

--- a/ui/raidboss/data/06-ew/raid/p7s.ts
+++ b/ui/raidboss/data/06-ew/raid/p7s.ts
@@ -1,19 +1,19 @@
+import { defineTriggerSet } from '../../../../../resources/api_define_trigger_set';
 import Conditions from '../../../../../resources/conditions';
 import NetRegexes from '../../../../../resources/netregexes';
 import Outputs from '../../../../../resources/outputs';
 import { callOverlayHandler } from '../../../../../resources/overlay_plugin_api';
 import { Responses } from '../../../../../resources/responses';
 import ZoneId from '../../../../../resources/zone_id';
-import { RaidbossData } from '../../../../../types/data';
 import { PluginCombatantState } from '../../../../../types/event';
 import { NetMatches } from '../../../../../types/net_matches';
-import { LocaleText, TriggerSet } from '../../../../../types/trigger';
+import { LocaleText } from '../../../../../types/trigger';
 
 // TODO: Tether locations, and/or additional egg locations
 
 export type PurgationDebuff = 'stack' | 'spread';
 
-export interface Data extends RaidbossData {
+export interface Data {
   decOffset?: number;
   fruitCount: number;
   unhatchedEggs?: PluginCombatantState[];
@@ -68,7 +68,7 @@ const effectIdToOutputStringKey: { [effectId: string]: PurgationDebuff } = {
   'D44': 'stack',
 };
 
-const triggerSet: TriggerSet<Data> = {
+export default defineTriggerSet<Data>({
   zoneId: ZoneId.AbyssosTheSeventhCircleSavage,
   timelineFile: 'p7s.txt',
   initData: () => ({
@@ -855,6 +855,4 @@ const triggerSet: TriggerSet<Data> = {
       },
     },
   ],
-};
-
-export default triggerSet;
+});

--- a/ui/raidboss/data/06-ew/raid/p8n.ts
+++ b/ui/raidboss/data/06-ew/raid/p8n.ts
@@ -1,3 +1,4 @@
+import { defineTriggerSet } from '../../../../../resources/api_define_trigger_set';
 import Conditions from '../../../../../resources/conditions';
 import NetRegexes from '../../../../../resources/netregexes';
 import { UnreachableCode } from '../../../../../resources/not_reached';
@@ -5,10 +6,8 @@ import Outputs from '../../../../../resources/outputs';
 import { callOverlayHandler } from '../../../../../resources/overlay_plugin_api';
 import { Responses } from '../../../../../resources/responses';
 import ZoneId from '../../../../../resources/zone_id';
-import { RaidbossData } from '../../../../../types/data';
 import { PluginCombatantState } from '../../../../../types/event';
 import { NetMatches } from '../../../../../types/net_matches';
-import { TriggerSet } from '../../../../../types/trigger';
 
 // TODO: Cthonic Vent is tricky; the initial cast is ~5s, but the next two explosions are ~2s.
 //       There's no map events.  There's two Suneater adds that are added immediately before
@@ -17,12 +16,6 @@ import { TriggerSet } from '../../../../../types/trigger';
 //       It's possible there's some other hidden combatants moving around, or this is
 //       just a case of missing some animation data in network logs that would tell us.
 // TODO: how to detect/what to say for Blazing Footfalls knockbacks?
-
-export interface Data extends RaidbossData {
-  combatantData: PluginCombatantState[];
-  ventIds: string[];
-  torches: NetMatches['StartsUsing'][];
-}
 
 // TODO: how to detect/what to say for Blazing Footfalls knockbacks?
 
@@ -37,7 +30,11 @@ const positionTo8Dir = (combatant: PluginCombatantState) => {
   return Math.round(4 - 4 * Math.atan2(x, y) / Math.PI) % 8;
 };
 
-const triggerSet: TriggerSet<Data> = {
+export default defineTriggerSet<{
+  combatantData: PluginCombatantState[];
+  ventIds: string[];
+  torches: NetMatches['StartsUsing'][];
+}>({
   zoneId: ZoneId.AbyssosTheEighthCircle,
   timelineFile: 'p8n.txt',
   initData: () => {
@@ -125,7 +122,7 @@ const triggerSet: TriggerSet<Data> = {
       type: 'StartsUsing',
       netRegex: NetRegexes.startsUsing({ id: '78F5', source: 'Suneater', capture: false }),
       suppressSeconds: 1,
-      promise: async (data: Data) => {
+      promise: async (data) => {
         data.combatantData = [];
         if (data.ventIds.length !== 2)
           return;
@@ -215,7 +212,7 @@ const triggerSet: TriggerSet<Data> = {
       netRegex: NetRegexes.startsUsing({ id: '78F8', source: 'Hephaistos', capture: false }),
       delaySeconds: 0.5,
       suppressSeconds: 1,
-      promise: async (data: Data) => {
+      promise: async (data) => {
         data.combatantData = [];
 
         const ids = data.torches.map((torch) => parseInt(torch.sourceId, 16));
@@ -459,6 +456,4 @@ const triggerSet: TriggerSet<Data> = {
       },
     },
   ],
-};
-
-export default triggerSet;
+});

--- a/ui/raidboss/data/06-ew/raid/p8s.ts
+++ b/ui/raidboss/data/06-ew/raid/p8s.ts
@@ -1,3 +1,4 @@
+import { defineTriggerSet } from '../../../../../resources/api_define_trigger_set';
 import Conditions from '../../../../../resources/conditions';
 import NetRegexes from '../../../../../resources/netregexes';
 import { UnreachableCode } from '../../../../../resources/not_reached';
@@ -5,10 +6,8 @@ import Outputs from '../../../../../resources/outputs';
 import { callOverlayHandler } from '../../../../../resources/overlay_plugin_api';
 import { Responses } from '../../../../../resources/responses';
 import ZoneId from '../../../../../resources/zone_id';
-import { RaidbossData } from '../../../../../types/data';
 import { PluginCombatantState } from '../../../../../types/event';
 import { NetMatches } from '../../../../../types/net_matches';
-import { TriggerSet } from '../../../../../types/trigger';
 
 // TODO: call out shriek specifically again when debuff soon? (or maybe even gaze/poison/stack too?)
 // TODO: better vent callouts
@@ -18,7 +17,7 @@ import { TriggerSet } from '../../../../../types/trigger';
 export type InitialConcept = 'shortalpha' | 'longalpha' | 'shortbeta' | 'longbeta' | 'shortgamma' | 'longgamma';
 export type Splicer = 'solosplice' | 'multisplice' | 'supersplice';
 
-export interface Data extends RaidbossData {
+export interface Data {
   // Door Boss
   conceptual?: 'octa' | 'tetra' | 'di';
   combatantData: PluginCombatantState[];
@@ -75,7 +74,7 @@ const positionTo8Dir = (combatant: PluginCombatantState) => {
   return Math.round(4 - 4 * Math.atan2(x, y) / Math.PI) % 8;
 };
 
-const triggerSet: TriggerSet<Data> = {
+export default defineTriggerSet<Data>({
   zoneId: ZoneId.AbyssosTheEighthCircleSavage,
   timelineFile: 'p8s.txt',
   initData: () => {
@@ -2431,6 +2430,4 @@ const triggerSet: TriggerSet<Data> = {
       },
     },
   ],
-};
-
-export default triggerSet;
+});

--- a/ui/raidboss/data/06-ew/trial/barbariccia-ex.ts
+++ b/ui/raidboss/data/06-ew/trial/barbariccia-ex.ts
@@ -1,17 +1,14 @@
+import { defineTriggerSet } from '../../../../../resources/api_define_trigger_set';
 import Conditions from '../../../../../resources/conditions';
 import NetRegexes from '../../../../../resources/netregexes';
 import Outputs from '../../../../../resources/outputs';
 import { Responses } from '../../../../../resources/responses';
 import ZoneId from '../../../../../resources/zone_id';
-import { RaidbossData } from '../../../../../types/data';
-import { TriggerSet } from '../../../../../types/trigger';
 
-export interface Data extends RaidbossData {
+export default defineTriggerSet<{
   boldBoulderTargets: string[];
   hairFlayUpbraidTargets: string[];
-}
-
-const triggerSet: TriggerSet<Data> = {
+}>({
   zoneId: ZoneId.StormsCrownExtreme,
   timelineFile: 'barbariccia-ex.txt',
   initData: () => {
@@ -486,6 +483,4 @@ const triggerSet: TriggerSet<Data> = {
       },
     },
   ],
-};
-
-export default triggerSet;
+});

--- a/ui/raidboss/data/06-ew/trial/barbariccia.ts
+++ b/ui/raidboss/data/06-ew/trial/barbariccia.ts
@@ -1,16 +1,13 @@
+import { defineTriggerSet } from '../../../../../resources/api_define_trigger_set';
 import Conditions from '../../../../../resources/conditions';
 import NetRegexes from '../../../../../resources/netregexes';
 import Outputs from '../../../../../resources/outputs';
 import { Responses } from '../../../../../resources/responses';
 import ZoneId from '../../../../../resources/zone_id';
-import { RaidbossData } from '../../../../../types/data';
-import { TriggerSet } from '../../../../../types/trigger';
 
-export interface Data extends RaidbossData {
+export default defineTriggerSet<{
   boldBoulderTarget?: string;
-}
-
-const triggerSet: TriggerSet<Data> = {
+}>({
   zoneId: ZoneId.StormsCrown,
   timelineFile: 'barbariccia.txt',
   timelineTriggers: [
@@ -265,6 +262,4 @@ const triggerSet: TriggerSet<Data> = {
       },
     },
   ],
-};
-
-export default triggerSet;
+});

--- a/ui/raidboss/data/06-ew/trial/endsinger-ex.ts
+++ b/ui/raidboss/data/06-ew/trial/endsinger-ex.ts
@@ -1,3 +1,4 @@
+import { defineTriggerSet } from '../../../../../resources/api_define_trigger_set';
 import Conditions from '../../../../../resources/conditions';
 import NetRegexes from '../../../../../resources/netregexes';
 import Outputs from '../../../../../resources/outputs';
@@ -7,7 +8,7 @@ import ZoneId from '../../../../../resources/zone_id';
 import { RaidbossData } from '../../../../../types/data';
 import { PluginCombatantState } from '../../../../../types/event';
 import { NetMatches } from '../../../../../types/net_matches';
-import { Output, OutputStrings, TriggerField, TriggerOutput, TriggerSet } from '../../../../../types/trigger';
+import { Output, OutputStrings, TriggerField, TriggerOutput } from '../../../../../types/trigger';
 
 export type Mechanic = 'aoe' | 'donut' | 'safeN' | 'safeE' | 'safeS' | 'safeW' | 'unknown';
 
@@ -32,7 +33,7 @@ const echoesOutputStrings = {
   },
 } as const;
 
-export interface Data extends RaidbossData {
+export interface Data {
   headPhase?: 5 | 6;
   starMechanicCounter: number;
   storedHeads: {
@@ -98,7 +99,7 @@ const getStarPositionFromHeading = (heading: string) => {
   }[dir] ?? [];
 };
 
-const getStarText: TriggerField<Data, NetMatches['Ability' | 'StartsUsing'], TriggerOutput<Data, NetMatches['Ability' | 'StartsUsing']>> = (_data, matches, output) => {
+const getStarText: TriggerField<Data & RaidbossData, NetMatches['Ability' | 'StartsUsing'], TriggerOutput<Data & RaidbossData, NetMatches['Ability' | 'StartsUsing']>> = (_data, matches, output) => {
   let posX: number | undefined;
   let posY: number | undefined;
 
@@ -129,7 +130,7 @@ const getStarText: TriggerField<Data, NetMatches['Ability' | 'StartsUsing'], Tri
   return;
 };
 
-const triggerSet: TriggerSet<Data> = {
+export default defineTriggerSet<Data>({
   zoneId: ZoneId.TheMinstrelsBalladEndsingersAria,
   timelineFile: 'endsinger-ex.txt',
   initData: () => {
@@ -770,6 +771,4 @@ const triggerSet: TriggerSet<Data> = {
       },
     },
   ],
-};
-
-export default triggerSet;
+});

--- a/ui/raidboss/data/06-ew/trial/endsinger.ts
+++ b/ui/raidboss/data/06-ew/trial/endsinger.ts
@@ -1,19 +1,19 @@
+import { defineTriggerSet } from '../../../../../resources/api_define_trigger_set';
 import Conditions from '../../../../../resources/conditions';
 import NetRegexes from '../../../../../resources/netregexes';
 import Outputs from '../../../../../resources/outputs';
 import { callOverlayHandler } from '../../../../../resources/overlay_plugin_api';
 import { Responses } from '../../../../../resources/responses';
 import ZoneId from '../../../../../resources/zone_id';
-import { RaidbossData } from '../../../../../types/data';
 import { PluginCombatantState } from '../../../../../types/event';
-import { Output, OutputStrings, TriggerSet } from '../../../../../types/trigger';
+import { Output, OutputStrings } from '../../../../../types/trigger';
 
 // @TODO:
 // Interstellar - Test the timing more. Seems OK but the delaySeconds timing might be too tight depending on latency?
 // Add phase triggers
 // Final phase triggers
 
-export interface Data extends RaidbossData {
+export interface Data {
   storedStars: { [name: string]: PluginCombatantState };
   phase: 1 | 2;
   storedBoss?: PluginCombatantState;
@@ -45,7 +45,7 @@ const getOrbSafeDir = (data: Data, id: string, output: Output): string | undefin
   return output.nw!();
 };
 
-const triggerSet: TriggerSet<Data> = {
+export default defineTriggerSet<Data>({
   zoneId: ZoneId.TheFinalDay,
   timelineFile: 'endsinger.txt',
   initData: () => {
@@ -477,6 +477,4 @@ const triggerSet: TriggerSet<Data> = {
       },
     },
   ],
-};
-
-export default triggerSet;
+});

--- a/ui/raidboss/data/06-ew/trial/hydaelyn-ex.ts
+++ b/ui/raidboss/data/06-ew/trial/hydaelyn-ex.ts
@@ -1,20 +1,13 @@
+import { defineTriggerSet } from '../../../../../resources/api_define_trigger_set';
 import NetRegexes from '../../../../../resources/netregexes';
 import Outputs from '../../../../../resources/outputs';
 import { Responses } from '../../../../../resources/responses';
 import ZoneId from '../../../../../resources/zone_id';
-import { RaidbossData } from '../../../../../types/data';
-import { TriggerSet } from '../../../../../types/trigger';
 
 // TODO: how to call out crystal LOS???
 // TODO: call Chakram stack locations / direction to run
 // TODO: call out intercard to run to in the final phase
 // TODO: Lightwave has different ids, do these mean anything?
-
-export interface Data extends RaidbossData {
-  brightSpectrumStack?: string[];
-  crystallize?: 'spread' | 'groups' | 'stack';
-  parhelion?: boolean;
-}
 
 const storedMechanicsOutputStrings = {
   spread: Outputs.spread,
@@ -60,7 +53,11 @@ const comboOutputStrings = {
   },
 };
 
-const triggerSet: TriggerSet<Data> = {
+export default defineTriggerSet<{
+  brightSpectrumStack?: string[];
+  crystallize?: 'spread' | 'groups' | 'stack';
+  parhelion?: boolean;
+}>({
   zoneId: ZoneId.TheMinstrelsBalladHydaelynsCall,
   timelineFile: 'hydaelyn-ex.txt',
   timelineTriggers: [
@@ -623,6 +620,4 @@ const triggerSet: TriggerSet<Data> = {
       },
     },
   ],
-};
-
-export default triggerSet;
+});

--- a/ui/raidboss/data/06-ew/trial/hydaelyn.ts
+++ b/ui/raidboss/data/06-ew/trial/hydaelyn.ts
@@ -1,17 +1,11 @@
+import { defineTriggerSet } from '../../../../../resources/api_define_trigger_set';
 import Conditions from '../../../../../resources/conditions';
 import NetRegexes from '../../../../../resources/netregexes';
 import Outputs from '../../../../../resources/outputs';
 import { Responses } from '../../../../../resources/responses';
 import ZoneId from '../../../../../resources/zone_id';
-import { RaidbossData } from '../../../../../types/data';
-import { TriggerSet } from '../../../../../types/trigger';
 
 // TODO: Lightwave has different ids, do these mean anything?
-
-export interface Data extends RaidbossData {
-  crystallize?: 'spread' | 'stack';
-  isEquinox?: boolean;
-}
 
 const storedMechanicsOutputStrings = {
   spread: Outputs.spread,
@@ -50,7 +44,10 @@ const comboOutputStrings = {
 };
 
 // Hydaelyn Normal Mode
-const triggerSet: TriggerSet<Data> = {
+export default defineTriggerSet<{
+  crystallize?: 'spread' | 'stack';
+  isEquinox?: boolean;
+}>({
   zoneId: ZoneId.TheMothercrystal,
   timelineFile: 'hydaelyn.txt',
   triggers: [
@@ -416,6 +413,4 @@ const triggerSet: TriggerSet<Data> = {
       },
     },
   ],
-};
-
-export default triggerSet;
+});

--- a/ui/raidboss/data/06-ew/trial/sephirot-un.ts
+++ b/ui/raidboss/data/06-ew/trial/sephirot-un.ts
@@ -1,20 +1,17 @@
+import { defineTriggerSet } from '../../../../../resources/api_define_trigger_set';
 import Conditions from '../../../../../resources/conditions';
 import NetRegexes from '../../../../../resources/netregexes';
 import Outputs from '../../../../../resources/outputs';
 import { Responses } from '../../../../../resources/responses';
 import ZoneId from '../../../../../resources/zone_id';
-import { RaidbossData } from '../../../../../types/data';
-import { TriggerSet } from '../../../../../types/trigger';
 
-export interface Data extends RaidbossData {
+export default defineTriggerSet<{
   mainTank?: string;
   phase: number;
   force?: string;
   shakerTargets?: string[];
   pillarActive: boolean;
-}
-
-const triggerSet: TriggerSet<Data> = {
+}>({
   zoneId: ZoneId.ContainmentBayS1T7Unreal,
   timelineFile: 'sephirot-un.txt',
   initData: () => {
@@ -556,6 +553,4 @@ const triggerSet: TriggerSet<Data> = {
       },
     },
   ],
-};
-
-export default triggerSet;
+});

--- a/ui/raidboss/data/06-ew/trial/ultima-un.ts
+++ b/ui/raidboss/data/06-ew/trial/ultima-un.ts
@@ -1,16 +1,13 @@
+import { defineTriggerSet } from '../../../../../resources/api_define_trigger_set';
 import NetRegexes from '../../../../../resources/netregexes';
 import Outputs from '../../../../../resources/outputs';
 import { Responses } from '../../../../../resources/responses';
 import ZoneId from '../../../../../resources/zone_id';
-import { RaidbossData } from '../../../../../types/data';
-import { TriggerSet } from '../../../../../types/trigger';
 
-export interface Data extends RaidbossData {
+export default defineTriggerSet<{
   plasmTargets?: Array<string>;
   boomCounter: number;
-}
-
-const triggerSet: TriggerSet<Data> = {
+}>({
   zoneId: ZoneId.UltimasBaneUnreal,
   timelineFile: 'ultima-un.txt',
   initData: () => {
@@ -297,6 +294,4 @@ const triggerSet: TriggerSet<Data> = {
       },
     },
   ],
-};
-
-export default triggerSet;
+});

--- a/ui/raidboss/data/06-ew/trial/zodiark-ex.ts
+++ b/ui/raidboss/data/06-ew/trial/zodiark-ex.ts
@@ -1,15 +1,14 @@
+import { defineTriggerSet } from '../../../../../resources/api_define_trigger_set';
 import NetRegexes from '../../../../../resources/netregexes';
 import Outputs from '../../../../../resources/outputs';
 import { callOverlayHandler } from '../../../../../resources/overlay_plugin_api';
 import { Responses } from '../../../../../resources/responses';
 import ZoneId from '../../../../../resources/zone_id';
-import { RaidbossData } from '../../../../../types/data';
-import { TriggerSet } from '../../../../../types/trigger';
 
 // TODO: The second middle/sides laser after Astral Eclipse should be
 // called only after the first goes off.
 
-export interface Data extends RaidbossData {
+export interface Data {
   activeSigils: { x: number; y: number; typeId: string; npcId: string }[];
   activeFrontSigils: { x: number; y: number; typeId: string; npcId: string }[];
   paradeigmaCounter: number;
@@ -34,7 +33,7 @@ const fetchCombatantsById = async (id: string[]) => {
   return callData.combatants;
 };
 
-const triggerSet: TriggerSet<Data> = {
+export default defineTriggerSet<Data>({
   zoneId: ZoneId.TheMinstrelsBalladZodiarksFall,
   timelineFile: 'zodiark-ex.txt',
   initData: () => ({
@@ -565,6 +564,4 @@ const triggerSet: TriggerSet<Data> = {
       },
     },
   ],
-};
-
-export default triggerSet;
+});

--- a/ui/raidboss/data/06-ew/trial/zodiark.ts
+++ b/ui/raidboss/data/06-ew/trial/zodiark.ts
@@ -1,8 +1,7 @@
+import { defineTriggerSet } from '../../../../../resources/api_define_trigger_set';
 import NetRegexes from '../../../../../resources/netregexes';
 import { Responses } from '../../../../../resources/responses';
 import ZoneId from '../../../../../resources/zone_id';
-import { RaidbossData } from '../../../../../types/data';
-import { TriggerSet } from '../../../../../types/trigger';
 
 // TODO: how to call out Astral Flow rotations? Behemoths can be adjacent/catty corner
 // TODO: Esoteric Ray has only one id for starting mid / starting sides (maybe startsUsing pos?)
@@ -11,9 +10,7 @@ import { TriggerSet } from '../../../../../types/trigger';
 // TODO: in the last phase, is the Exoterikos always Sect during Triple Esoteric Ray?
 // TODO: heal to full for Kokytos
 
-export type Data = RaidbossData;
-
-const triggerSet: TriggerSet<Data> = {
+export default defineTriggerSet({
   zoneId: ZoneId.TheDarkInside,
   timelineFile: 'zodiark.txt',
   triggers: [
@@ -218,6 +215,4 @@ const triggerSet: TriggerSet<Data> = {
       },
     },
   ],
-};
-
-export default triggerSet;
+});

--- a/ui/raidboss/data/06-ew/ultimate/dragonsongs_reprise_ultimate.ts
+++ b/ui/raidboss/data/06-ew/ultimate/dragonsongs_reprise_ultimate.ts
@@ -1,3 +1,4 @@
+import { defineTriggerSet } from '../../../../../resources/api_define_trigger_set';
 import Conditions from '../../../../../resources/conditions';
 import NetRegexes from '../../../../../resources/netregexes';
 import { UnreachableCode } from '../../../../../resources/not_reached';
@@ -5,10 +6,9 @@ import Outputs from '../../../../../resources/outputs';
 import { callOverlayHandler } from '../../../../../resources/overlay_plugin_api';
 import { Responses } from '../../../../../resources/responses';
 import ZoneId from '../../../../../resources/zone_id';
-import { RaidbossData } from '../../../../../types/data';
 import { PluginCombatantState } from '../../../../../types/event';
 import { NetMatches } from '../../../../../types/net_matches';
-import { LocaleObject, LocaleText, TriggerSet } from '../../../../../types/trigger';
+import { LocaleObject, LocaleText } from '../../../../../types/trigger';
 
 // TODO: Ser Adelphel left/right movement after initial charge
 // TODO: Meteor "run" call?
@@ -21,7 +21,7 @@ type Phase = 'doorboss' | 'thordan' | 'nidhogg' | 'haurchefant' | 'thordan2' | '
 const playstationMarkers = ['circle', 'cross', 'triangle', 'square'] as const;
 type PlaystationMarker = typeof playstationMarkers[number];
 
-export interface Data extends RaidbossData {
+export interface Data {
   combatantData: PluginCombatantState[];
   phase: Phase;
   decOffset?: number;
@@ -153,7 +153,7 @@ const matchedPositionTo4Dir = (combatant: PluginCombatantState) => {
   return (Math.round(2 - 2 * Math.atan2(x, y) / Math.PI) % 4);
 };
 
-const triggerSet: TriggerSet<Data> = {
+export default defineTriggerSet<Data>({
   zoneId: ZoneId.DragonsongsRepriseUltimate,
   timelineFile: 'dragonsongs_reprise_ultimate.txt',
   initData: () => {
@@ -3271,6 +3271,4 @@ const triggerSet: TriggerSet<Data> = {
       },
     },
   ],
-};
-
-export default triggerSet;
+});

--- a/util/process_triggers_folder.ts
+++ b/util/process_triggers_folder.ts
@@ -45,8 +45,8 @@ const removeExportOnDeclarations = (lines: string[]) => {
 const changeExportToPush = (lines: string[]) => {
   // User files are not modules and so push onto a global Options variable rather than
   // exporting, so modify these files so that they can be used directly as user files.
-  const exportRegex = /^(?:export default {|const triggerSet = {)\s*/;
-  const closingRegex = /^};\s*$/;
+  const exportRegex = /^(?:export default defineTriggerSet\({|const triggerSet = {)\s*/;
+  const closingRegex = /^}\);\s*$/;
 
   let replacedExportCount = 0;
   let replacedClosingCount = 0;


### PR DESCRIPTION
For now, a raidboss trigger was structured like
```ts
import NetRegexes from '../../../../resources/netregexes';
import ZoneId from '../../../../resources/zone_id';
import { RaidbossData } from '../../../../types/data';
import { TriggerSet } from '../../../../types/trigger';

export interface Data extends RaidbossData {
  // ...
}

const triggerSet: TriggerSet<Data> = {
  zoneId: ZoneId.Xxx,
  triggers: [],
};

export default triggerSet;
```

I think it is redundant to declare a `triggerSet` variable then export it as default just because you can not export it with a type in one line.
Recently I am learning VueJS and found that their [`defineComponent`](https://github.com/vuejs/core/blob/fbd697a4b6c238147d661026836314862fd09221/packages/runtime-core/src/apiDefineComponent.ts#L188) API is extremely useful for this use case.
So I changed the trigger type a little bit and add a tiny helper function called `defineTriggerSet` which reflectly return the object eaten by itself.

As in this patch, a trigger set can be structured like
```ts
import { defineTriggerSet } from '../../../../resources/api_define_trigger_set';
import NetRegexes from '../../../../resources/netregexes';
import ZoneId from '../../../../resources/zone_id';

// Or just omit the type parameter, as `export default defineTriggerSet({})`
// if there are no any extra parameters would be feed to `data`.
// The type parameter can also be omitted if there is `initData` function
// with fully typed return value defined
export default defineTriggerSet<{
  someExtraDataParams: string;
}>({
  zoneId: Zone.Xxx,
  initData: () => {
    return {
      someExtraDataParams: 'string',
    };
  },
  triggers: [],
});
```

I hope it would be easier to use and reduce several import line for types.

------

@valarnin  pinging if you have time to review this.