### PR TITLE
raidboss: Allow Skins to Use CSS Background

### DIFF
--- a/resources/timerbar.ts
+++ b/resources/timerbar.ts
@@ -457,8 +457,8 @@ export default class TimerBar extends HTMLElement {
     if (!this._connected)
       return;
 
-    this.backgroundElement.style.backgroundColor = this._bg;
-    this.foregroundElement.style.backgroundColor = this._fg;
+    this.backgroundElement.style.background = this._bg;
+    this.foregroundElement.style.background = this._fg;
     this.rootElement.style.width = this._width;
     this.rootElement.style.height = this._height;
 

--- a/ui/raidboss/raidboss.css
+++ b/ui/raidboss/raidboss.css
@@ -152,11 +152,11 @@
 }
 
 .timeline-bar-color {
-  background-color: #88f;
+  background: #88f;
 }
 
 .timeline-bar-color.soon {
-  background-color: #f88;
+  background: #f88;
 }
 
 #timeline-debug {

--- a/ui/raidboss/timeline.ts
+++ b/ui/raidboss/timeline.ts
@@ -80,13 +80,13 @@ const activeText = {
 };
 
 // TODO: Duplicated in 'jobs'
-const computeBackgroundColorFrom = (element: HTMLElement, classList: string): string => {
+const computeBackgroundFrom = (element: HTMLElement, classList: string): string => {
   const div = document.createElement('div');
   const classes = classList.split('.');
   for (const cls of classes)
     div.classList.add(cls);
   element.appendChild(div);
-  const color = window.getComputedStyle(div).backgroundColor;
+  const color = window.getComputedStyle(div).background;
   element.removeChild(div);
   return color;
 };
@@ -498,8 +498,8 @@ export class TimelineUI {
     if (this.options.Skin)
       this.root.classList.add(`skin-${this.options.Skin}`);
 
-    this.barColor = computeBackgroundColorFrom(this.root, 'timeline-bar-color');
-    this.barExpiresSoonColor = computeBackgroundColorFrom(this.root, 'timeline-bar-color.soon');
+    this.barColor = computeBackgroundFrom(this.root, 'timeline-bar-color');
+    this.barExpiresSoonColor = computeBackgroundFrom(this.root, 'timeline-bar-color.soon');
 
     this.timerlist = document.getElementById('timeline');
     if (this.timerlist) {


### PR DESCRIPTION
Change timerbar CSS from `background-color` to `background` shorthand to allow for more options within a skin.