### PR TITLE
raidboss: Fix Skins CSS for OVERLAY_WS

### DIFF
--- a/resources/user_config.ts
+++ b/resources/user_config.ts
@@ -401,15 +401,8 @@ class UserConfig {
   handleSkin(skinName: string) {
     if (!skinName || skinName === 'default')
       return;
-
-    let basePath = document.location.toString();
-    const slashIdx = basePath.lastIndexOf('/');
-    if (slashIdx !== -1)
-      basePath = basePath.substr(0, slashIdx);
-    if (basePath.slice(-1) !== '/')
-      basePath += '/';
-    const skinHref = basePath + 'skins/' + skinName + '/' + skinName + '.css';
-    this.appendCSSLink(skinHref);
+    const skinCSSRelativeHref = `skins/${skinName}/${skinName}.css`;
+    this.appendCSSLink(skinCSSRelativeHref);
   }
   appendJSLink(src: string) {
     const userJS = document.createElement('script');


### PR DESCRIPTION
For users using the `OVERLAY_WS` query parameter, the value could contain forward slashes, which causes a failure to load skin CSS. This wasn't an issue when the CSS was directly in timerbar.ts.

Fixes https://github.com/quisquous/cactbot/issues/4868