### PR TITLE
build: remove timeline loader

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -74,7 +74,6 @@
         "node-fetch": "^3.2.10",
         "postcss": "^8.3.5",
         "proxy-agent": "^5.0.0",
-        "raw-loader": "^4.0.2",
         "recast": "^0.20.4",
         "style-loader": "^3.3.1",
         "stylelint": "^14.8.2",
@@ -12585,44 +12584,6 @@
       },
       "engines": {
         "node": ">= 0.8"
-      }
-    },
-    "node_modules/raw-loader": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/raw-loader/-/raw-loader-4.0.2.tgz",
-      "integrity": "sha512-ZnScIV3ag9A4wPX/ZayxL/jZH+euYb6FcUinPcgiQW0+UBtEv0O6Q3lGd3cqJ+GHH+rksEv3Pj99oxJ3u3VIKA==",
-      "dev": true,
-      "dependencies": {
-        "loader-utils": "^2.0.0",
-        "schema-utils": "^3.0.0"
-      },
-      "engines": {
-        "node": ">= 10.13.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/webpack"
-      },
-      "peerDependencies": {
-        "webpack": "^4.0.0 || ^5.0.0"
-      }
-    },
-    "node_modules/raw-loader/node_modules/schema-utils": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.1.1.tgz",
-      "integrity": "sha512-Y5PQxS4ITlC+EahLuXaY86TXfR7Dc5lw294alXOq86JAHCihAIZfqv8nNCWvaEJvaC51uN9hbLGeV0cFBdH+Fw==",
-      "dev": true,
-      "dependencies": {
-        "@types/json-schema": "^7.0.8",
-        "ajv": "^6.12.5",
-        "ajv-keywords": "^3.5.2"
-      },
-      "engines": {
-        "node": ">= 10.13.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/webpack"
       }
     },
     "node_modules/read-pkg": {
@@ -25297,29 +25258,6 @@
         "http-errors": "2.0.0",
         "iconv-lite": "0.4.24",
         "unpipe": "1.0.0"
-      }
-    },
-    "raw-loader": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/raw-loader/-/raw-loader-4.0.2.tgz",
-      "integrity": "sha512-ZnScIV3ag9A4wPX/ZayxL/jZH+euYb6FcUinPcgiQW0+UBtEv0O6Q3lGd3cqJ+GHH+rksEv3Pj99oxJ3u3VIKA==",
-      "dev": true,
-      "requires": {
-        "loader-utils": "^2.0.0",
-        "schema-utils": "^3.0.0"
-      },
-      "dependencies": {
-        "schema-utils": {
-          "version": "3.1.1",
-          "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.1.1.tgz",
-          "integrity": "sha512-Y5PQxS4ITlC+EahLuXaY86TXfR7Dc5lw294alXOq86JAHCihAIZfqv8nNCWvaEJvaC51uN9hbLGeV0cFBdH+Fw==",
-          "dev": true,
-          "requires": {
-            "@types/json-schema": "^7.0.8",
-            "ajv": "^6.12.5",
-            "ajv-keywords": "^3.5.2"
-          }
-        }
       }
     },
     "read-pkg": {

--- a/package.json
+++ b/package.json
@@ -86,7 +86,6 @@
     "node-fetch": "^3.2.10",
     "postcss": "^8.3.5",
     "proxy-agent": "^5.0.0",
-    "raw-loader": "^4.0.2",
     "recast": "^0.20.4",
     "style-loader": "^3.3.1",
     "stylelint": "^14.8.2",

--- a/webpack/loaders/timeline-loader.ts
+++ b/webpack/loaders/timeline-loader.ts
@@ -1,8 +1,0 @@
-import webpack from 'webpack';
-
-// Note: the timeline files are displayed/translated inside of the config,
-// and so we shouldn't simplify them here by stripping comments and blank lines.
-export default function(this: webpack.LoaderContext<never>, content: string): string {
-  this.cacheable(true);
-  return content;
-}

--- a/webpack/webpack.config.ts
+++ b/webpack/webpack.config.ts
@@ -189,11 +189,7 @@ export default (
         },
         {
           test: /data[\\\/](?!\w*_manifest\.txt).*\.txt$/,
-          use: [
-            {
-              loader: 'raw-loader',
-            },
-          ],
+          type: 'asset/source',
         },
       ],
     },

--- a/webpack/webpack.config.ts
+++ b/webpack/webpack.config.ts
@@ -193,9 +193,6 @@ export default (
             {
               loader: 'raw-loader',
             },
-            {
-              loader: './webpack/loaders/timeline-loader.ts',
-            },
           ],
         },
       ],


### PR DESCRIPTION
timeline is now parsed at runtime and currently `timeline-loader` do nothing, so no need to keep `timeline-loader`, just use `raw-loader`

also, `raw-loader` is deprecated in webpack5.