### PR TITLE
build: stabilize emulator service worker's output filename

### DIFF
--- a/ui/raidboss/raidemulator.ts
+++ b/ui/raidboss/raidemulator.ts
@@ -170,6 +170,7 @@ const raidEmulatorOnLoad = async () => {
   const emulatedWebSocket = new RaidEmulatorOverlayApiHook(emulator);
   emulatedWebSocket.connected = websocketConnected;
   const logConverterWorker = new Worker(
+    /* webpackChunkName: "emulator.worker" */
     new URL('./emulator/data/NetworkLogConverter.worker.ts', import.meta.url),
   );
 

--- a/ui/raidboss/raidemulator.ts
+++ b/ui/raidboss/raidemulator.ts
@@ -170,7 +170,7 @@ const raidEmulatorOnLoad = async () => {
   const emulatedWebSocket = new RaidEmulatorOverlayApiHook(emulator);
   emulatedWebSocket.connected = websocketConnected;
   const logConverterWorker = new Worker(
-    /* webpackChunkName: "ui/raidboss/emulator.worker" */
+    /* webpackEntryOptions: { filename: "ui/raidboss/raidemulator.worker.js" } */
     new URL('./emulator/data/NetworkLogConverter.worker.ts', import.meta.url),
   );
 

--- a/ui/raidboss/raidemulator.ts
+++ b/ui/raidboss/raidemulator.ts
@@ -170,7 +170,7 @@ const raidEmulatorOnLoad = async () => {
   const emulatedWebSocket = new RaidEmulatorOverlayApiHook(emulator);
   emulatedWebSocket.connected = websocketConnected;
   const logConverterWorker = new Worker(
-    /* webpackChunkName: "emulator.worker" */
+    /* webpackChunkName: "ui/raidboss/emulator.worker" */
     new URL('./emulator/data/NetworkLogConverter.worker.ts', import.meta.url),
   );
 


### PR DESCRIPTION
close https://github.com/quisquous/cactbot/issues/3247

currently the final file of emulator's service worker script is named by chunk name `[id].bundle.js`, and its id is curretnly 378, so webpack will generate a service worker file with meanless filename `378.bundle.js` in `dist/` .


set `webpackEntryOptions: { filename: "ui/raidboss/raidemulator.worker.js" }` so it will be generated to `dist/ui/raidboss/raidemulator.worker.js`