### PR TITLE
build: increase target version in webpack build

### DIFF
--- a/webpack/webpack.config.ts
+++ b/webpack/webpack.config.ts
@@ -142,7 +142,7 @@ export default (
                 [
                   '@babel/preset-env',
                   {
-                    targets: { chrome: '75' },
+                    targets: { chrome: '95' },
                   },
                 ],
                 [


### PR DESCRIPTION
As OverlayPlugin was upgrade to CEF v95 for a long time, we can increase the target version to 95 for some newer javascript syntax as they might shorter cause a smaller bundle.