### PR TITLE
ci: upgrade actions checkout to v3

### DIFF
--- a/.github/workflows/build-artifact.yml
+++ b/.github/workflows/build-artifact.yml
@@ -30,7 +30,7 @@ jobs:
     runs-on: windows-latest
 
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v3
 
       - name: Set artifact name
         shell: bash

--- a/.github/workflows/css-lint.yml
+++ b/.github/workflows/css-lint.yml
@@ -18,7 +18,7 @@ jobs:
   stylelint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v3
 
       - uses: actions/setup-node@v2
         with:

--- a/.github/workflows/javascript-lint.yml
+++ b/.github/workflows/javascript-lint.yml
@@ -24,7 +24,7 @@ jobs:
   eslint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v3
 
       - uses: actions/setup-node@v2
         with:

--- a/.github/workflows/labels.yaml
+++ b/.github/workflows/labels.yaml
@@ -8,8 +8,11 @@ jobs:
   main:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-
+      - uses: actions/checkout@v3
+        with:
+          # force to ci checkout main repo to avoid
+          # unexpected PR code to be executed with out github token
+          ref: main
       - uses: actions/setup-node@v2
         with:
           node-version: '16'

--- a/.github/workflows/lint-pr-title.yaml
+++ b/.github/workflows/lint-pr-title.yaml
@@ -8,8 +8,11 @@ jobs:
   main:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-
+      - uses: actions/checkout@v3
+        with:
+          # force to ci checkout main repo to avoid
+          # unexpected PR code to be executed with out github token
+          ref: main
       - uses: actions/setup-node@v2
         with:
           node-version: '16'

--- a/.github/workflows/markdown-lint.yml
+++ b/.github/workflows/markdown-lint.yml
@@ -18,7 +18,7 @@ jobs:
   markdownlint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v3
 
       - uses: actions/setup-node@v2
         with:

--- a/.github/workflows/post-process.yml
+++ b/.github/workflows/post-process.yml
@@ -22,7 +22,7 @@ jobs:
   postprocess:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v3
 
       - uses: actions/setup-node@v2
         with:

--- a/.github/workflows/python-lint.yml
+++ b/.github/workflows/python-lint.yml
@@ -18,7 +18,7 @@ jobs:
   black:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v3
 
       - uses: actions/setup-python@v2
         with:
@@ -49,7 +49,7 @@ jobs:
   pylint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v3
 
       - uses: actions/setup-python@v2
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,9 @@ jobs:
       GITHUB_TOKEN: ${{ secrets.BOT_TOKEN }}
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
       - name: Set up msbuild
         uses: microsoft/setup-msbuild@v1.0.2
       - uses: actions/setup-node@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,7 +24,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v3
 
       - uses: actions/setup-node@v2
         with:

--- a/.github/workflows/update-gh-pages.yml
+++ b/.github/workflows/update-gh-pages.yml
@@ -27,7 +27,7 @@ jobs:
     needs: check-gh-pages
     if: needs.check-gh-pages.outputs.found == 'true'
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: actions/setup-node@v2
         with:
           node-version: '16'

--- a/.github/workflows/update-triggers-branch.yml
+++ b/.github/workflows/update-triggers-branch.yml
@@ -26,7 +26,7 @@ jobs:
     needs: check-triggers
     if: needs.check-triggers.outputs.found == 'true'
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v3
       - uses: actions/setup-node@v2
         with:
           node-version: '16'


### PR DESCRIPTION
bug of `actions/checkout@v2` is fixed in v3 I think, using v3 for a while, didn't get wrong commit checkout.

And it only fetch depth=1 by default to avoid fetching all commits https://github.com/quisquous/cactbot/issues/4865 , take 2m to 2s.
