### PR TITLE
raidboss: Ensuring timelines have a non-chatlog initial sync

### DIFF
--- a/ui/raidboss/data/06-ew/dungeon/alzadaals_legacy.txt
+++ b/ui/raidboss/data/06-ew/dungeon/alzadaals_legacy.txt
@@ -12,7 +12,7 @@ hideall "--sync--"
 # -ii 71E5
 
 0.0 "--sync--" sync / 00:0839::The Undersea Entrance will be sealed off/ window 0,1
-11.0 "Big Wave" sync / 1[56]:[^:]*:Ambujam:6F60:/
+11.0 "Big Wave" sync / 1[56]:[^:]*:Ambujam:6F60:/ window 11,5
 20.8 "Tentacle Dig" sync / 1[56]:[^:]*:Ambujam:6F55:/ window 20.8
 33.0 "--sync--" sync / 1[56]:[^:]*:Scarlet Tentacle:6F5B:/
 33.4 "Toxin Shower" sync / 1[56]:[^:]*:Ambujam:6F5C:/
@@ -44,7 +44,7 @@ hideall "--sync--"
 # -ii 71CC 6F1A 6F1C 6F1D 6F26 6F27
 
 1000.0 "--sync--" sync / 00:0839::The Threshold Of Bounty will be sealed off/ window 1000,1
-1011.0 "Articulated Bits" sync / 1[56]:[^:]*:Armored Chariot:6F19:/
+1011.0 "Articulated Bits" sync / 1[56]:[^:]*:Armored Chariot:6F19:/ window 1011,0
 1013.2 "Assail" sync / 1[56]:[^:]*:Armored Chariot:6F29:/
 1015.3 "--sync--" sync / 1[56]:[^:]*:Armored Chariot:(6F20|6F21):/
 1021.9 "Assault Cannon" sync / 1[56]:[^:]*:Armored Drudge:6F1B:/ duration 5
@@ -107,7 +107,7 @@ hideall "--sync--"
 # -ii 6F71 6F64 6F65 6F66 6F67 6F6D 6F6F
 
 2000.0 "--sync--" sync / 00:0839::Weaver'S Warding will be sealed off/ window 2000,1
-2015.2 "Billowing Bolts" sync / 1[56]:[^:]*:Kapikulu:6F70:/
+2015.2 "Billowing Bolts" sync / 1[56]:[^:]*:Kapikulu:6F70:/ window 2016,5
 2023.4 "--sync--" sync / 1[56]:[^:]*:Kapikulu:6F62:/
 2027.8 "Spin Out" sync / 1[56]:[^:]*:Kapikulu:6F63:/
 2044.1 "--sync--" sync / 1[56]:[^:]*:Kapikulu:6F62:/

--- a/ui/raidboss/data/06-ew/raid/p5n.txt
+++ b/ui/raidboss/data/06-ew/raid/p5n.txt
@@ -7,7 +7,7 @@ hideall "--sync--"
 0.0 "--Reset--" sync / 21:........:4000000F:/ window 100000 jump 0
 
 0.0 "--sync--" sync /Engage!/ window 0,1
-10.3 "--sync--" sync / 1[56]:[^:]*:Proto-Carbuncle:76D6:/ window 10,10
+10.3 "--sync--" sync / 1[56]:[^:]*:Proto-Carbuncle:76D6:/ window 11,10
 19.1 "Searing Ray" sync / 1[56]:[^:]*:Proto-Carbuncle:76D7:/
 28.2 "Ruby Glow" sync / 1[56]:[^:]*:Proto-Carbuncle:76D4:/
 31.4 "--sync--" sync / 1[56]:[^:]*:Proto-Carbuncle:76D6:/

--- a/ui/raidboss/data/06-ew/raid/p5n.txt
+++ b/ui/raidboss/data/06-ew/raid/p5n.txt
@@ -7,7 +7,7 @@ hideall "--sync--"
 0.0 "--Reset--" sync / 21:........:4000000F:/ window 100000 jump 0
 
 0.0 "--sync--" sync /Engage!/ window 0,1
-10.3 "--sync--" sync / 1[56]:[^:]*:Proto-Carbuncle:76D6:/ window 11,1
+10.3 "--sync--" sync / 1[56]:[^:]*:Proto-Carbuncle:76D6:/ window 11,10
 19.1 "Searing Ray" sync / 1[56]:[^:]*:Proto-Carbuncle:76D7:/
 28.2 "Ruby Glow" sync / 1[56]:[^:]*:Proto-Carbuncle:76D4:/
 31.4 "--sync--" sync / 1[56]:[^:]*:Proto-Carbuncle:76D6:/

--- a/ui/raidboss/data/06-ew/raid/p5n.txt
+++ b/ui/raidboss/data/06-ew/raid/p5n.txt
@@ -7,7 +7,7 @@ hideall "--sync--"
 0.0 "--Reset--" sync / 21:........:4000000F:/ window 100000 jump 0
 
 0.0 "--sync--" sync /Engage!/ window 0,1
-10.3 "--sync--" sync / 1[56]:[^:]*:Proto-Carbuncle:76D6:/ window 11,10
+10.3 "--sync--" sync / 1[56]:[^:]*:Proto-Carbuncle:76D6:/ window 11,1
 19.1 "Searing Ray" sync / 1[56]:[^:]*:Proto-Carbuncle:76D7:/
 28.2 "Ruby Glow" sync / 1[56]:[^:]*:Proto-Carbuncle:76D4:/
 31.4 "--sync--" sync / 1[56]:[^:]*:Proto-Carbuncle:76D6:/

--- a/ui/raidboss/data/06-ew/raid/p7n.txt
+++ b/ui/raidboss/data/06-ew/raid/p7n.txt
@@ -9,7 +9,7 @@ hideall "--sync--"
 # -ii 77F6 77F7 77FA 77FD 77FF 7800 7804 7806 7807 780A 783E 7841
 
 0.0 "--sync--" sync /Engage!/ window 0,1
-3.0 "--sync--" sync / 1[56]:[^:]*:Agdistis:78E3:/ window 3,5
+3.0 "--sync--" sync / 1[56]:[^:]*:Agdistis:78E3:/ window 3,0
 15.8 "Bough of Attis (out)" sync / 1[56]:[^:]*:Agdistis:77F9:/ window 16,5
 23.4 "Bough of Attis (left/right)" sync / 1[56]:[^:]*:Agdistis:(77FB|77FC):/
 37.6 "Hemitheos's Holy" sync / 1[56]:[^:]*:Agdistis:7808:/

--- a/ui/raidboss/data/06-ew/raid/p7n.txt
+++ b/ui/raidboss/data/06-ew/raid/p7n.txt
@@ -9,7 +9,7 @@ hideall "--sync--"
 # -ii 77F6 77F7 77FA 77FD 77FF 7800 7804 7806 7807 780A 783E 7841
 
 0.0 "--sync--" sync /Engage!/ window 0,1
-3.0 "--sync--" sync / 1[56]:[^:]*:Agdistis:78E3:/
+3.0 "--sync--" sync / 1[56]:[^:]*:Agdistis:78E3:/ window 3,5
 15.8 "Bough of Attis (out)" sync / 1[56]:[^:]*:Agdistis:77F9:/ window 16,5
 23.4 "Bough of Attis (left/right)" sync / 1[56]:[^:]*:Agdistis:(77FB|77FC):/
 37.6 "Hemitheos's Holy" sync / 1[56]:[^:]*:Agdistis:7808:/

--- a/ui/raidboss/data/06-ew/trial/barbariccia.txt
+++ b/ui/raidboss/data/06-ew/trial/barbariccia.txt
@@ -12,7 +12,7 @@ hideall "Brush with Death"
 0.0 "--sync--" sync /Engage!/ window 0,1
 
 # Intro
-15.1 "Void Aero IV" sync / 1[56]:[^:]*:Barbariccia:75B6:/ window 10,10
+15.1 "Void Aero IV" sync / 1[56]:[^:]*:Barbariccia:75B6:/ window 16,10
 22.3 "--sync--" sync / 1[56]:[^:]*:Barbariccia:7381:/
 34.6 "Savage Barbery" sync / 1[56]:[^:]*:Barbariccia:75C1:/ window 10,10
 41.6 "Hair Raid" sync / 1[56]:[^:]*:Barbariccia:75C2:/


### PR DESCRIPTION
From https://github.com/xpdota/event-trigger/issues/130

The problem is that if a user enables "Hide chatlog for privacy" in the parsing plugin OR is simply chainpulling with no countdown, and a timeline doesn't have any valid initial sync other than that (i.e. sync with a large enough window to be valid for 0.0), then the timeline will just never start.

I looked at also just using OP's combat start to start the timeline, but this doesn't necessarily work for timelines where the actual contents don't start at 0.