### PR TITLE
build: enable lib check, upgrade @types/node

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,7 @@
         "@types/markdown-magic": "^1.0.1",
         "@types/mini-css-extract-plugin": "^1.4.3",
         "@types/mocha": "^9.1.1",
-        "@types/node": "^15.12.2",
+        "@types/node": "^18.7.23",
         "@types/node-fetch": "^2.5.10",
         "@types/tar-fs": "^2.0.0",
         "@types/webpack": "^5.28.0",
@@ -2422,9 +2422,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "15.14.9",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-15.14.9.tgz",
-      "integrity": "sha512-qjd88DrCxupx/kJD5yQgZdcYKZKSIGBVDIBE1/LTGcNm3d2Np/jxojkdePDdfnBHJc5W7vSMpbJ1aB7p/Py69A==",
+      "version": "18.7.23",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.7.23.tgz",
+      "integrity": "sha512-DWNcCHolDq0ZKGizjx2DZjR/PqsYwAcYUJmfMWqtVU2MBMG5Mo+xFZrhGId5r/O5HOuMPyQEcM6KUBp5lBZZBg==",
       "dev": true
     },
     "node_modules/@types/node-fetch": {
@@ -17741,9 +17741,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "15.14.9",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-15.14.9.tgz",
-      "integrity": "sha512-qjd88DrCxupx/kJD5yQgZdcYKZKSIGBVDIBE1/LTGcNm3d2Np/jxojkdePDdfnBHJc5W7vSMpbJ1aB7p/Py69A==",
+      "version": "18.7.23",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.7.23.tgz",
+      "integrity": "sha512-DWNcCHolDq0ZKGizjx2DZjR/PqsYwAcYUJmfMWqtVU2MBMG5Mo+xFZrhGId5r/O5HOuMPyQEcM6KUBp5lBZZBg==",
       "dev": true
     },
     "@types/node-fetch": {

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "@types/markdown-magic": "^1.0.1",
     "@types/mini-css-extract-plugin": "^1.4.3",
     "@types/mocha": "^9.1.1",
-    "@types/node": "^15.12.2",
+    "@types/node": "^18.7.23",
     "@types/node-fetch": "^2.5.10",
     "@types/tar-fs": "^2.0.0",
     "@types/webpack": "^5.28.0",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,6 +15,7 @@
     "alwaysStrict": true,
     "noUnusedLocals": true,
     "noUnusedParameters": false,
+    "skipLibCheck": false,
     "noFallthroughCasesInSwitch": true,
     "noUncheckedIndexedAccess": true,
     //    "noPropertyAccessFromIndexSignature": false, // used by trigger output strings

--- a/types/event.d.ts
+++ b/types/event.d.ts
@@ -144,7 +144,7 @@ export type EnmityTargetCombatant = {
   MonsterType: number;
   Status: number;
   ModelStatus: number;
-  AggressionStatus;
+  AggressionStatus: number;
   TargetID: number;
   IsTargetable: boolean;
 


### PR DESCRIPTION
Enabling the lib check has two errors, one in event.d.ts which is easily fixed.  The other is in globby, due to import node:url.

Error:
```
node_modules/copy-webpack-plugin/node_modules/globby/index.d.ts:1:19 - error TS2307: Cannot find module 'node:url' or its corresponding type declarations.
```

This is fixed by upgrading @types/node.  Upgraded to the latest version, not to a specific version.

Closes #4882.
Closes #4885.
Closes #4880.