### PR TITLE
build: revert setup-msbuild version change

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Set up msbuild
-        uses: microsoft/setup-msbuild@v1.1.1
+        uses: microsoft/setup-msbuild@v1.0.2
 
       - uses: ./.github/actions/setup-js-env
 


### PR DESCRIPTION
Error: Unable to resolve action `microsoft/setup-msbuild@v1.1.1`, unable to find version `v1.1.1`

This was broken by the version change in #4892.