### PR TITLE
i18n: Deleted a hidden `\b` in the p8s CN translation.

### DIFF
--- a/ui/raidboss/data/06-ew/raid/p8s.ts
+++ b/ui/raidboss/data/06-ew/raid/p8s.ts
@@ -539,7 +539,7 @@ const triggerSet: TriggerSet<Data> = {
           de: 'Im Norden raus',
           fr: 'Nord Extérieur',
           ja: '北の外側',
-          cn: '北 外侧',
+          cn: '北 外侧',
           ko: '북쪽 바깥',
         },
         insideNorth: {


### PR DESCRIPTION
Somehow there's a weird byte (i think it's a `\b`) between `'` and `北`, which got rendered as `口`. Deleted in this PR.

![image](https://user-images.githubusercontent.com/9408268/193421517-9d86f5ad-f06c-4f5c-bd05-1fad9ecf48fb.png)
