### PR TITLE
resources: support for mapeffects

### DIFF
--- a/docs/LogGuide.md
+++ b/docs/LogGuide.md
@@ -2072,13 +2072,13 @@ These are lines emitted directly by the ffxiv plugin when something goes wrong.
 
 ### Line 257 (0x101): MapEffect
 
-This message is sent to cause a specific visual effect to render 
+This message is sent to cause a specific visual effect to render
 in the game client during instanced content.
 MapEffect lines are not tied to any particular actor or action
 but may provide visual-based information about how an upcoming mechanic will resolve.
 
 For example,
-after Aetheric Polyominoid or Polyominoid Sigma casts in P6S, 
+after Aetheric Polyominoid or Polyominoid Sigma casts in P6S,
 MapEffect messages are sent to cause the game client to render  '+' and 'x' effects on specific map tiles,
 indicating to the player which tiles will later be rendered unsafe by Polyominous Dark IV.
 
@@ -2120,12 +2120,12 @@ ACT Log Line Examples:
 
 <!-- AUTO-GENERATED-CONTENT:END (logLines:type=MapEffect&lang=en-US) -->
 
-The `instance` parameter is identical to `instance` in [actor control line)](#line33). 
+The `instance` parameter is identical to `instance` in [actor control line)](#line33).
 See above for more information.
 
 The `id` parameter identifies the visual effect that will be rendered in the game.
 For example,
-in P6S, id '00020001' equates to a '+'-shaped tile and id '00400020' equates to an 'x'-shaped tile.  
+in P6S, id '00020001' equates to a '+'-shaped tile and id '00400020' equates to an 'x'-shaped tile.
 Ids do not appear to be unique across multiple instances:
 as the above examples illustrate
 id '00020001' is used in both P5S and P6S to render completely different visual effects.

--- a/docs/LogGuide.md
+++ b/docs/LogGuide.md
@@ -2073,14 +2073,14 @@ These are lines emitted directly by the ffxiv plugin when something goes wrong.
 ### Line 257 (0x101): MapEffect
 
 This message is sent to cause a specific visual effect to render 
-in the game client during instanced content. MapEffect lines are not 
-tied to any particular actor or action, but may provide visual-based 
-information about how an upcoming mechanic will resolve.
+in the game client during instanced content.
+MapEffect lines are not tied to any particular actor or action
+but may provide visual-based information about how an upcoming mechanic will resolve.
 
-For example, after Aetheric Polyominoid or Polyominoid Sigma casts in P6S, 
-MapEffect messages are sent to cause the game client to render  '+' and 'x' 
-effects on specific map tiles, indicating to the player which tiles will 
-later be rendered unsafe by Polyominous Dark IV.
+For example,
+after Aetheric Polyominoid or Polyominoid Sigma casts in P6S, 
+MapEffect messages are sent to cause the game client to render  '+' and 'x' effects on specific map tiles,
+indicating to the player which tiles will later be rendered unsafe by Polyominous Dark IV.
 
 <!-- AUTO-GENERATED-CONTENT:START (logLines:type=MapEffect&lang=en-US) -->
 

--- a/docs/LogGuide.md
+++ b/docs/LogGuide.md
@@ -2123,17 +2123,21 @@ ACT Log Line Examples:
 The `instance` parameter is identical to `instance` in [actor control line)](#line33). 
 See above for more information.
 
-The `id` parameter identifies the visual effect that will be rendered in the game.  For example,
+The `id` parameter identifies the visual effect that will be rendered in the game.
+For example,
 in P6S, id '00020001' equates to a '+'-shaped tile and id '00400020' equates to an 'x'-shaped tile.  
-Ids do not appear to be unique across multiple instances: as the above examples illustrate, id 
-'00020001' is used in both P5S and P6S to render completely different visual effects.
+Ids do not appear to be unique across multiple instances:
+as the above examples illustrate
+id '00020001' is used in both P5S and P6S to render completely different visual effects.
 
-That said, it does appear from initial analysis that when a map effect is rendered, a second MapEffect
-line with an id of '00080004' is sent at the conclusion of the effect, which may correspond to removal
-of the effect.  This appears to be consistent behavior across several fights so far, but more information
-is needed.
+That said,
+it does appear from initial analysis that when a map effect is rendered,
+a second MapEffect line with an id of '00080004' is sent at the conclusion of the effect,
+which may correspond to removal of the effect.
+This appears to be consistent behavior across several fights so far,
+but more information is needed.
 
-The `location` parameter indicates the location in the current instance where the effect will be
-rendered.  Locations are not consistent across instances and appear to be unique to each instance.
-E.g., a location of '05' in P6S corresponds to one of the 16 tiles on the map floor, whereas the '05'
-location in P5S appears to correspond to different map coordinates.
+The `location` parameter indicates the location in the current instance where the effect will be rendered.
+Locations are not consistent across instances and appear to be unique to each instance.
+E.g., a location of '05' in P6S corresponds to one of the 16 tiles on the map floor,
+whereas the '05' location in P5S appears to correspond to different map coordinates.

--- a/docs/LogGuide.md
+++ b/docs/LogGuide.md
@@ -141,6 +141,10 @@ This guide was last updated for:
   - [Line 252 (0xFC): PacketDump](#line-252-0xfc-packetdump)
   - [Line 253 (0xFD): Version](#line-253-0xfd-version)
   - [Line 254 (0xFE): Error](#line-254-0xfe-error)
+    - [Line 257 (0x100): MapEffect](#line-257-0x101-mapeffect)
+    - [Structure](#structure-27)
+    - [Regexes](#regexes-18)
+    - [Examples](#examples-27)
 <!-- AUTO-GENERATED-CONTENT:END -->
 
 ## Data Flow
@@ -2063,3 +2067,73 @@ ACT log lines are blank for this type.
 ### Line 254 (0xFE): Error
 
 These are lines emitted directly by the ffxiv plugin when something goes wrong.
+
+<a name="line257"></a>
+
+### Line 257 (0x101): MapEffect
+
+This message is sent to cause a specific visual effect to render 
+in the game client during instanced content. MapEffect lines are not 
+tied to any particular actor or action, but may provide visual-based 
+information about how an upcoming mechanic will resolve.
+
+For example, after Aetheric Polyominoid or Polyominoid Sigma casts in P6S, 
+MapEffect messages are sent to cause the game client to render  '+' and 'x' 
+effects on specific map tiles, indicating to the player which tiles will 
+later be rendered unsafe by Polyominous Dark IV.
+
+<!-- AUTO-GENERATED-CONTENT:START (logLines:type=MapEffect&lang=en-US) -->
+
+#### Structure
+
+```log
+Network Log Line Structure:
+257|[timestamp]|[instance]|[id]|[location]|[data0]|[data1]
+
+ACT Log Line Structure:
+[timestamp] 257 101:[instance]:[id]:[location]:[data0]:[data1]
+```
+
+#### Regexes
+
+```log
+Network Log Line Regex:
+^(?<type>257)\|(?<timestamp>[^|]*)\|(?<instance>[^|]*)\|(?<id>[^|]*)\|(?<location>[^|]*)\|(?<data0>[^|]*)\|(?<data1>[^|]*)\|
+
+ACT Log Line Regex:
+(?<timestamp>^.{14}) 257 (?<type>101):(?<instance>[^:]*):(?<id>[^:]*):(?<location>[^:]*):(?<data0>[^:]*):(?<data1>[^:]*)(?:$|:)
+```
+
+#### Examples
+
+```log
+Network Log Line Examples:
+257|2022-09-27T18:03:45.2834013-07:00|800375A9|00020001|09|F3|0000|de00c57494e85e79
+257|2022-09-27T18:06:07.7744035-07:00|800375A9|00400020|01|00|0000|72933fe583158786
+257|2022-09-29T20:07:48.7330170-07:00|800375A5|00020001|05|00|0000|28c0449a8d0efa7d
+
+ACT Log Line Examples:
+[18:03:45.283] 257 101:800375A9:00020001:09:F3:0000
+[18:06:07.774] 257 101:800375A9:00400020:01:00:0000
+[20:07:48.733] 257 101:800375A5:00020001:05:00:0000
+```
+
+<!-- AUTO-GENERATED-CONTENT:END (logLines:type=MapEffect&lang=en-US) -->
+
+The `instance` parameter is identical to `instance` in [actor control line)](#line33). 
+See above for more information.
+
+The `id` parameter identifies the visual effect that will be rendered in the game.  For example,
+in P6S, id '00020001' equates to a '+'-shaped tile and id '00400020' equates to an 'x'-shaped tile.  
+Ids do not appear to be unique across multiple instances: as the above examples illustrate, id 
+'00020001' is used in both P5S and P6S to render completely different visual effects.
+
+That said, it does appear from early analysis that when a map effect is rendered, a second MapEffect
+line with an id of '00080004' is sent at the conclusion of the effect, which may correspond to removal
+of the effect.  This appears to be consistent behavior across several fights so far, but more information
+is needed.
+
+The `location` parameter indicates the location in the current instance where the effect will be
+rendered.  Locations are not consistent across instances and appear to be unique to each instance.
+E.g., a location of '05' in P6S corresponds to one of the 16 tiles on the map floor, whereas the '05'
+location in P5S appears to be at different map coordinates.

--- a/docs/LogGuide.md
+++ b/docs/LogGuide.md
@@ -141,7 +141,7 @@ This guide was last updated for:
   - [Line 252 (0xFC): PacketDump](#line-252-0xfc-packetdump)
   - [Line 253 (0xFD): Version](#line-253-0xfd-version)
   - [Line 254 (0xFE): Error](#line-254-0xfe-error)
-    - [Line 257 (0x100): MapEffect](#line-257-0x101-mapeffect)
+  - [Line 257 (0x100): MapEffect](#line-257-0x101-mapeffect)
     - [Structure](#structure-27)
     - [Regexes](#regexes-18)
     - [Examples](#examples-27)
@@ -2128,7 +2128,7 @@ in P6S, id '00020001' equates to a '+'-shaped tile and id '00400020' equates to 
 Ids do not appear to be unique across multiple instances: as the above examples illustrate, id 
 '00020001' is used in both P5S and P6S to render completely different visual effects.
 
-That said, it does appear from early analysis that when a map effect is rendered, a second MapEffect
+That said, it does appear from initial analysis that when a map effect is rendered, a second MapEffect
 line with an id of '00080004' is sent at the conclusion of the effect, which may correspond to removal
 of the effect.  This appears to be consistent behavior across several fights so far, but more information
 is needed.
@@ -2136,4 +2136,4 @@ is needed.
 The `location` parameter indicates the location in the current instance where the effect will be
 rendered.  Locations are not consistent across instances and appear to be unique to each instance.
 E.g., a location of '05' in P6S corresponds to one of the 16 tiles on the map floor, whereas the '05'
-location in P5S appears to be at different map coordinates.
+location in P5S appears to correspond to different map coordinates.

--- a/resources/netlog_defs.ts
+++ b/resources/netlog_defs.ts
@@ -915,7 +915,8 @@ const latestLogDefinitions = {
       data0: 5,
       data1: 6,
     },
-    isUnknown: true,
+    canAnonymize: true,
+    isUnknown: false,
     firstOptionalField: undefined,
   },
   None: {

--- a/resources/netlog_defs.ts
+++ b/resources/netlog_defs.ts
@@ -900,8 +900,8 @@ const latestLogDefinitions = {
     type: '257',
     name: 'MapEffect',
     source: 'FFXIV_ACT_Plugin',
-    // in the 2.7.7.7 beta, ACT appears to post these messages with the int value instead of
-    // a string for messageType, but need to confirm once build is final
+    // in the 2.6.6.7 beta, ACT appears to post these messages with the int value instead of
+    // a string for messageType, but need to confirm once build is final.
     messageType: '257',
     fields: {
       type: 0,

--- a/resources/netlog_defs.ts
+++ b/resources/netlog_defs.ts
@@ -899,7 +899,7 @@ const latestLogDefinitions = {
   MapEffect: {
     type: '257',
     name: 'MapEffect',
-    source: 'FFXIV_ACT_Plugin',
+    source: 'OverlayPlugin',
     // in the 2.6.6.7 beta, ACT appears to post these messages with the int value instead of
     // a string for messageType, but need to confirm once build is final.
     messageType: '257',

--- a/resources/netlog_defs.ts
+++ b/resources/netlog_defs.ts
@@ -896,6 +896,28 @@ const latestLogDefinitions = {
     canAnonymize: false,
     firstOptionalField: undefined,
   },
+  MapEffect: {
+    type: '257',
+    name: 'MapEffect',
+    source: 'FFXIV_ACT_Plugin',
+    // in the 2.7.7.7 beta, ACT appears to post these messages with the int value instead of
+    // a string for messageType, but need to confirm once build is final
+    messageType: '257',
+    fields: {
+      type: 0,
+      timestamp: 1,
+      instance: 2,
+      id: 3,
+      // values for the location field seem to vary between instances
+      // (e.g. a location of '08' in P5S does not appear to be the same location in P5S as in P6S)
+      // but this field does appear to consistently contain position info for the effect rendering
+      location: 4,
+      data0: 5,
+      data1: 6,
+    },
+    isUnknown: true,
+    firstOptionalField: undefined,
+  },
   None: {
     type: '[0-9]+',
     name: 'None',

--- a/resources/netlog_defs.ts
+++ b/resources/netlog_defs.ts
@@ -900,8 +900,6 @@ const latestLogDefinitions = {
     type: '257',
     name: 'MapEffect',
     source: 'OverlayPlugin',
-    // in the 2.6.6.7 beta, ACT appears to post these messages with the int value instead of
-    // a string for messageType, but need to confirm once build is final.
     messageType: '257',
     fields: {
       type: 0,

--- a/resources/netregexes.ts
+++ b/resources/netregexes.ts
@@ -401,4 +401,11 @@ export default class NetRegexes {
   ): CactbotBaseRegExp<'SystemLogMessage'> {
     return buildRegex('SystemLogMessage', params);
   }
+
+  /**
+   * matches: https://github.com/quisquous/cactbot/blob/main/docs/LogGuide.md#line-257-0x101-mapeffect
+   */
+  static mapEffect(params?: NetParams['MapEffect']): CactbotBaseRegExp<'MapEffect'> {
+    return buildRegex('MapEffect', params);
+  }
 }

--- a/resources/regexes.ts
+++ b/resources/regexes.ts
@@ -393,6 +393,13 @@ export default class Regexes {
   }
 
   /**
+   * matches: https://github.com/quisquous/cactbot/blob/main/docs/LogGuide.md#line-257-0x101-mapeffect
+   */
+  static mapEffect(params?: NetParams['MapEffect']): CactbotBaseRegExp<'MapEffect'> {
+    return parseHelper(params, 'MapEffect', defaultParams('MapEffect', Regexes.logVersion));
+  }
+
+  /**
    * Helper function for building named capture group
    */
   static maybeCapture(

--- a/util/gen_log_guide.ts
+++ b/util/gen_log_guide.ts
@@ -451,6 +451,19 @@ const lineDocs: LineDocs = {
       ],
     },
   },
+  MapEffect: {
+    regexes: {
+      network: NetRegexes.mapEffect({ capture: true }).source,
+      logLine: Regexes.mapEffect({ capture: true }).source,
+    },
+    examples: {
+      'en-US': [
+        '257|2022-09-27T18:03:45.2834013-07:00|800375A9|00020001|09|F3|0000|de00c57494e85e79',
+        '257|2022-09-27T18:06:07.7744035-07:00|800375A9|00400020|01|00|0000|72933fe583158786',
+        '257|2022-09-29T20:07:48.7330170-07:00|800375A5|00020001|05|00|0000|28c0449a8d0efa7d',
+      ],
+    },
+  },
 } as const;
 
 type LogGuideOptions = {


### PR DESCRIPTION
Added support in netlogs_defs and regexes/netregexes for new MapEffect (257) lines, along with some updates to LogGuide.  

There are dependencies both on the ACT FFXIV Plugin being updated to v2.6.6.7 (which adds processing support for these lines), and on an update to OverlayPlugin to  re-add support for these lines that was disabled in v0.19.6.  Marking this as draft for now until these dependencies are resolved.