### PR TITLE
raidboss: p8s HC1/HC2 Tower Colors + Merge Targets

### DIFF
--- a/ui/raidboss/data/06-ew/raid/p8s.ts
+++ b/ui/raidboss/data/06-ew/raid/p8s.ts
@@ -2268,7 +2268,7 @@ const triggerSet: TriggerSet<Data> = {
             finalTowers = newConcept;
           }
           if (data.concept[data.me] === 'longalpha' || data.concept[data.me] === 'longbeta') {
-            const tempLong = JSON.parse(JSON.stringify(perfectionLong));
+            const tempLong = perfectionLong;
             // Remove player matching gamma value from long list
             const gammaPlayer = getMergePlayer(perfectionLong, 'gamma');
             if (gammaPlayer !== undefined)

--- a/ui/raidboss/data/06-ew/raid/p8s.ts
+++ b/ui/raidboss/data/06-ew/raid/p8s.ts
@@ -47,8 +47,8 @@ export interface Data extends RaidbossData {
   seenFirstAlignmentStackSpread?: boolean;
   concept: { [name: string]: InitialConcept };
   splicer: { [name: string]: Splicer };
-  perfectionLong: { [name: string]: string};
-  perfectionShort: { [name: string]: string};
+  perfectionLong: { [name: string]: string };
+  perfectionShort: { [name: string]: string };
   arcaneChannelCount: number;
   arcaneChannelColor: { [color: string]: boolean };
   alignmentTargets: string[];
@@ -2093,9 +2093,6 @@ const triggerSet: TriggerSet<Data> = {
       type: 'GainsEffect',
       netRegex: NetRegexes.gainsEffect({ effectId: 'D05' }),
       condition: (data, matches) => (data.me === matches.target && data.arcaneChannelCount > 1),
-      // TODO: it'd be nice to know the tower here so this could just say
-      // "take tower" or "avoid tower" with different severity or even
-      // who to merge with (!), but without that this is the best we got.
       infoText: (_data, _matches, output) => output.text!(),
       outputStrings: {
         text: {
@@ -2240,7 +2237,7 @@ const triggerSet: TriggerSet<Data> = {
         };
 
         // Get the player with corresponding perfection
-        const getMergePlayer = (perfectionList: { [name: string]: string},perfection: string) => {
+        const getMergePlayer = (perfectionList: { [name: string]: string }, perfection: string) => {
           let mergePlayer;
           Object.entries(perfectionList).find(([key, value]) => {
             if (value === perfection) {
@@ -2260,9 +2257,9 @@ const triggerSet: TriggerSet<Data> = {
         if (data.arcaneChannelCount >= 0 && data.arcaneChannelCount < 2) {
           // Uses Shorts with Splicers and Longs with Longs priority
           // High Concept 1 Second Towers could use long or short player
-          if (data.arcaneChannelCount !== 1)
+          if (data.arcaneChannelCount !== 1) {
             perfectionList = data.perfectionShort;
-          else {
+          } else {
             // Check which list we belong to, if any
             if (data.perfectionShort[data.me])
               perfectionList = data.perfectionShort;
@@ -2274,10 +2271,10 @@ const triggerSet: TriggerSet<Data> = {
           if (data.arcaneChannelColor['purple']) {
             // Gamma/Beta Players
             if (perfectionList !== undefined) {
-                if (perfectionList[data.me] === 'gamma')
-                  mergePerfection = 'beta';
-                if (perfectionList[data.me] === 'beta')
-                  mergePerfection = 'gamma';
+              if (perfectionList[data.me] === 'gamma')
+                mergePerfection = 'beta';
+              if (perfectionList[data.me] === 'beta')
+                mergePerfection = 'gamma';
             }
             towerColor = 'purple';
           } else if (data.arcaneChannelColor['blue']) {
@@ -2298,21 +2295,20 @@ const triggerSet: TriggerSet<Data> = {
                 mergePerfection = 'alpha';
             }
             towerColor = 'green';
-          }
-          else {
+          } else {
             // Failed to determine color of tower
             return;
           }
           if (mergePerfection && perfectionList !== undefined) {
             const mergePlayer = getMergePlayer(perfectionList, mergePerfection);
-            if (mergePlayer && towerColor !== undefined)
+            if (mergePlayer === undefined && towerColor !== undefined)
               return { alertText: output.colorTower1MergePlayer!({ color: output[towerColor]!(), player: mergePlayer }) };
           }
         }
-        
+
         // High Concept 2 Tower 1
         if (data.arcaneChannelCount >= 2) {
-          let towerColors = [];
+          const towerColors = [];
           // Need to implement handling of non-debuff players first
           if (data.arcaneChannelColor['purple'])
             towerColors.push('purple');
@@ -2320,12 +2316,12 @@ const triggerSet: TriggerSet<Data> = {
             towerColors.push('blue');
           if (data.arcaneChannelColor['green'])
             towerColors.push('green');
-          
+
           if (towerColors[0] && towerColors[1])
             return { infoText: output.colorTowers!({ color1: output[towerColors[0]]!(), color2: output[towerColors[1]]!() }) };
           if (towerColors[0])
             return { infoText: output.colorTower!({ color: output[towerColors[0]]!() }) };
-            
+
           // Failed to find color of tower
           return;
         }
@@ -2338,7 +2334,7 @@ const triggerSet: TriggerSet<Data> = {
           return { infoText: output.colorTowerAvoid!({ color: output[towerColor]!() }) };
         }
       },
-      run: (data, matches) => {
+      run: (data) => {
         data.arcaneChannelColor = {};
 
         // Reset unused perfections between HC1 and HC2 after second channel

--- a/ui/raidboss/data/06-ew/raid/p8s.ts
+++ b/ui/raidboss/data/06-ew/raid/p8s.ts
@@ -2087,7 +2087,7 @@ const triggerSet: TriggerSet<Data> = {
     },
     {
       id: 'P8S Perfection Splicer Collect',
-      // Record what the splicers chose as they will marge with unused short player
+      // Record what the splicers chose as they will merge with unused short player
       type: 'GainsEffect',
       netRegex: NetRegexes.gainsEffect({ effectId: ['D05', 'D06', 'D07'] }),
       condition: (data, matches) => {

--- a/ui/raidboss/data/06-ew/raid/p8s.ts
+++ b/ui/raidboss/data/06-ew/raid/p8s.ts
@@ -1917,27 +1917,25 @@ const triggerSet: TriggerSet<Data> = {
             data.perfectionLong[matches.target] = 'alpha';
           else
             data.perfectionShort[matches.target] = 'alpha';
-        }
-        else if (id === 'D03') {
+        } else if (id === 'D03') {
           data.concept[matches.target] = isLong ? 'longbeta' : 'shortbeta';
           if (isLong)
             data.perfectionLong[matches.target] = 'beta';
           else
             data.perfectionShort[matches.target] = 'beta';
-        }
-        else if (id === 'D04') {
+        } else if (id === 'D04') {
           data.concept[matches.target] = isLong ? 'longgamma' : 'shortgamma';
           if (isLong)
             data.perfectionLong[matches.target] = 'gamma';
           else
             data.perfectionShort[matches.target] = 'gamma';
-        }
-        else if (id === 'D11')
+        } else if (id === 'D11') {
           data.splicer[matches.target] = 'solosplice';
-        else if (id === 'D12')
+        } else if (id === 'D12') {
           data.splicer[matches.target] = 'multisplice';
-        else if (id === 'D13')
+        } else if (id === 'D13') {
           data.splicer[matches.target] = 'supersplice';
+        }
       },
     },
     {
@@ -2210,12 +2208,6 @@ const triggerSet: TriggerSet<Data> = {
           colorTowerAvoid: {
             en: 'Avoid ${color} Towers',
           },
-          colorTower: {
-            en: '${color} Towers',
-          },
-          colorTowers: {
-            en: '${color1}/${color2} Towers',
-          },
           alpha: {
             en: 'Alpha',
           },
@@ -2304,34 +2296,6 @@ const triggerSet: TriggerSet<Data> = {
             if (mergePlayer === undefined && towerColor !== undefined)
               return { alertText: output.colorTower1MergePlayer!({ color: output[towerColor]!(), player: mergePlayer }) };
           }
-        }
-
-        // High Concept 2 Tower 1
-        if (data.arcaneChannelCount >= 2) {
-          const towerColors = [];
-          // Need to implement handling of non-debuff players first
-          if (data.arcaneChannelColor['purple'])
-            towerColors.push('purple');
-          if (data.arcaneChannelColor['blue'])
-            towerColors.push('blue');
-          if (data.arcaneChannelColor['green'])
-            towerColors.push('green');
-
-          if (towerColors[0] && towerColors[1])
-            return { infoText: output.colorTowers!({ color1: output[towerColors[0]]!(), color2: output[towerColors[1]]!() }) };
-          if (towerColors[0])
-            return { infoText: output.colorTower!({ color: output[towerColors[0]]!() }) };
-
-          // Failed to find color of tower
-          return;
-        }
-
-        if (towerColor !== undefined) {
-          // Failed to find player to merge with
-          if (mergePerfection)
-            return { infoText: output.colorTower1MergeLetter!({ color: output[towerColor]!(), letter: output[mergePerfection]!() }) };
-          // Avoid tower
-          return { infoText: output.colorTowerAvoid!({ color: output[towerColor]!() }) };
         }
       },
       run: (data) => {

--- a/ui/raidboss/data/06-ew/raid/p8s.ts
+++ b/ui/raidboss/data/06-ew/raid/p8s.ts
@@ -2300,6 +2300,14 @@ const triggerSet: TriggerSet<Data> = {
               return { alertText: output.colorTower1MergePlayer!({ color: output[towerColor]!(), player: mergePlayer }) };
           }
         }
+
+        if (towerColor !== undefined) {
+          // Failed to find player to merge with
+          if (mergePerfection)
+            return { infoText: output.colorTower1MergeLetter!({ color: output[towerColor]!(), letter: output[mergePerfection]!() }) };
+          // Avoid tower
+          return { infoText: output.colorTowerAvoid!({ color: output[towerColor]!() }) };
+        }
       },
       run: (data) => {
         data.arcaneChannelColor = {};

--- a/ui/raidboss/data/06-ew/raid/p8s.ts
+++ b/ui/raidboss/data/06-ew/raid/p8s.ts
@@ -2243,6 +2243,7 @@ const triggerSet: TriggerSet<Data> = {
         let color;
         let letter;
         let mergePlayer;
+        let mergePlayer2;
         const towerColors = [];
         const perfectionShort = filterPerfections(data.concept, 'long');
         const perfectionLong = filterPerfections(data.concept, 'short');

--- a/ui/raidboss/data/06-ew/raid/p8s.ts
+++ b/ui/raidboss/data/06-ew/raid/p8s.ts
@@ -2090,7 +2090,7 @@ const triggerSet: TriggerSet<Data> = {
       // Trigger will likely be removed once HC2 Towers callout is available
       type: 'GainsEffect',
       netRegex: NetRegexes.gainsEffect({ effectId: 'D05' }),
-      condition: (data, matches) => (data.me === matches.target && data.arcaneChannelCount > 1),
+      condition: (data, matches) => (data.me === matches.target && data.arcaneChannelCount > 2),
       infoText: (_data, _matches, output) => output.text!(),
       outputStrings: {
         text: {
@@ -2107,7 +2107,7 @@ const triggerSet: TriggerSet<Data> = {
       // Trigger will likely be removed once HC2 Towers callout is available
       type: 'GainsEffect',
       netRegex: NetRegexes.gainsEffect({ effectId: 'D06' }),
-      condition: (data, matches) => (data.me === matches.target && data.arcaneChannelCount > 1),
+      condition: (data, matches) => (data.me === matches.target && data.arcaneChannelCount > 2),
       infoText: (_data, _matches, output) => output.text!(),
       outputStrings: {
         text: {
@@ -2124,7 +2124,7 @@ const triggerSet: TriggerSet<Data> = {
       // Trigger will likely be removed once HC2 Towers callout is available
       type: 'GainsEffect',
       netRegex: NetRegexes.gainsEffect({ effectId: 'D07' }),
-      condition: (data, matches) => (data.me === matches.target && data.arcaneChannelCount > 1),
+      condition: (data, matches) => (data.me === matches.target && data.arcaneChannelCount > 2),
       infoText: (_data, _matches, output) => output.text!(),
       outputStrings: {
         text: {
@@ -2142,8 +2142,8 @@ const triggerSet: TriggerSet<Data> = {
       type: 'GainsEffect',
       netRegex: NetRegexes.gainsEffect({ effectId: ['D05', 'D06', 'D07'] }),
       condition: (data, matches) => {
-        // Ignore Imperfection players
-        if (data.perfectionLong[matches.target] || data.perfectionShort[matches.target])
+        // Ignore Imperfection players, and do not collect on HC2
+        if (data.perfectionLong[matches.target] || data.perfectionShort[matches.target] || data.arcaneChannelCount > 1)
           return false;
         return true;
       },
@@ -2248,8 +2248,8 @@ const triggerSet: TriggerSet<Data> = {
         let mergePerfection;
         let towerColor;
 
-        // High Concept 1
-        if (data.arcaneChannelCount >= 0 && data.arcaneChannelCount < 2) {
+        // High Concept 1 Towers and High Concept 2 First Tower
+        if (data.arcaneChannelCount >= 0 && data.arcaneChannelCount < 3) {
           // Uses Shorts with Splicers and Longs with Longs priority
           // High Concept 1 Second Towers could use long or short player
           if (data.arcaneChannelCount !== 1) {

--- a/ui/raidboss/data/06-ew/raid/p8s.ts
+++ b/ui/raidboss/data/06-ew/raid/p8s.ts
@@ -2296,7 +2296,7 @@ const triggerSet: TriggerSet<Data> = {
           }
           if (mergePerfection && perfectionList !== undefined) {
             const mergePlayer = getMergePlayer(perfectionList, mergePerfection);
-            if (mergePlayer === undefined && towerColor !== undefined)
+            if (mergePlayer !== undefined && towerColor !== undefined)
               return { alertText: output.colorTower1MergePlayer!({ color: output[towerColor]!(), player: mergePlayer }) };
           }
         }

--- a/ui/raidboss/data/06-ew/raid/p8s.ts
+++ b/ui/raidboss/data/06-ew/raid/p8s.ts
@@ -163,8 +163,6 @@ const triggerSet: TriggerSet<Data> = {
       secondSnakeDebuff: {},
       concept: {},
       splicer: {},
-      perfectionLong: {},
-      perfectionShort: {},
       arcaneChannelCount: 0,
       arcaneChannelColor: {},
       alignmentTargets: [],
@@ -1968,19 +1966,18 @@ const triggerSet: TriggerSet<Data> = {
         const id = matches.effectId;
         // 8 and 26s second debuffs.
         const isLong = parseFloat(matches.duration) > 10;
-        if (id === 'D02') {
+        if (id === 'D02')
           data.concept[matches.target] = isLong ? 'longalpha' : 'shortalpha';
-        } else if (id === 'D03') {
+        else if (id === 'D03')
           data.concept[matches.target] = isLong ? 'longbeta' : 'shortbeta';
-        } else if (id === 'D04') {
+        else if (id === 'D04')
           data.concept[matches.target] = isLong ? 'longgamma' : 'shortgamma';
-        } else if (id === 'D11') {
+        else if (id === 'D11')
           data.splicer[matches.target] = 'solosplice';
-        } else if (id === 'D12') {
+        else if (id === 'D12')
           data.splicer[matches.target] = 'multisplice';
-        } else if (id === 'D13') {
+        else if (id === 'D13')
           data.splicer[matches.target] = 'supersplice';
-        }
       },
     },
     {
@@ -2155,7 +2152,7 @@ const triggerSet: TriggerSet<Data> = {
       // Remove player from perfection lists when they merge
       type: 'GainsEffect',
       netRegex: NetRegexes.gainsEffect({ effectId: ['D09', 'D0A', 'D0B', 'D0C'] }),
-      run: (data, matches) => delete data.concept[matches.target];,
+      run: (data, matches) => delete data.concept[matches.target],
     },
     {
       id: 'P8S Arcane Channel Collect',

--- a/ui/raidboss/data/06-ew/raid/p8s.ts
+++ b/ui/raidboss/data/06-ew/raid/p8s.ts
@@ -13,7 +13,7 @@ import { Output, TriggerSet } from '../../../../../types/trigger';
 // TODO: call out shriek specifically again when debuff soon? (or maybe even gaze/poison/stack too?)
 // TODO: initial tank auto call on final boss as soon as boss pulled
 
-export type Concept = 'shortalpha' | 'longalpha' | 'shortbeta' | 'longbeta' | 'shortgamma' | 'longgamma' | 'alpha' | 'beta' | 'gamma' | 'animal';
+export type Concept = 'shortalpha' | 'longalpha' | 'shortbeta' | 'longbeta' | 'shortgamma' | 'longgamma' | 'alpha' | 'beta' | 'gamma' | 'primal';
 export type Splicer = 'solosplice' | 'multisplice' | 'supersplice';
 export const towerColors = ['green', 'blue', 'purple'] as const;
 export type TowerColor = typeof towerColors[number];
@@ -1998,7 +1998,7 @@ const triggerSet: TriggerSet<Data> = {
         else if (id === 'D13')
           data.splicer[matches.target] = 'supersplice';
         else
-          data.concept[matches.target] = 'animal';
+          data.concept[matches.target] = 'primal';
       },
     },
     {
@@ -2223,11 +2223,12 @@ const triggerSet: TriggerSet<Data> = {
 
         const myConcept = data.concept[data.me];
         if (myConcept !== 'alpha' && myConcept !== 'beta' && myConcept !== 'gamma') {
-          // Long debuff and splicers avoid first towers
+          // Long debuffs, splicers, and primals avoid towers
           if (data.arcaneChannelCount !== 3)
             return { infoText: output.colorTowerAvoid!({ color: output[tower1]!() }) };
 
-          if (tower2 !== undefined && myConcept === 'animal')
+          // Primals on HC2 Second Towers get clones
+          if (tower2 !== undefined && myConcept === 'primal')
             return { alertText: output.cloneTether!() };
           // Likely not solveable anymore.
           return;

--- a/ui/raidboss/data/06-ew/raid/p8s.ts
+++ b/ui/raidboss/data/06-ew/raid/p8s.ts
@@ -2122,6 +2122,7 @@ const triggerSet: TriggerSet<Data> = {
       id: 'P8S Arcane Channel Collect',
       type: 'MapEffect',
       netRegex: NetRegexes.mapEffect({ flags: arcaneChannelFlags }),
+      // Flags exist in phase 1, only execute trigger if phase 2
       condition: (data) => data.seenFirstTankAutos,
       run: (data, matches) => {
         const colorInt = parseInt(matches.location, 16);

--- a/ui/raidboss/data/06-ew/raid/p8s.ts
+++ b/ui/raidboss/data/06-ew/raid/p8s.ts
@@ -2223,8 +2223,10 @@ const triggerSet: TriggerSet<Data> = {
 
         const myConcept = data.concept[data.me];
         if (myConcept !== 'alpha' && myConcept !== 'beta' && myConcept !== 'gamma') {
+          // Long debuff, splicers, and no debuffs avoid first towers
           if (data.arcaneChannelCount !== 3)
             return { infoText: output.colorTowerAvoid!({ color: output[tower1]!() }) };
+
           if (tower2 !== undefined && myConcept === 'animal')
             return { alertText: output.cloneTether!() };
           // Likely not solveable anymore.
@@ -2251,8 +2253,11 @@ const triggerSet: TriggerSet<Data> = {
         if (tower2 === undefined) {
           const color = output[tower1]!();
           const concepts = towerToConcept[tower1];
+
+          // Unused concept avoids tower
           if (!concepts.includes(myConcept))
             return { infoText: output.colorTowerAvoid!({ color: color }) };
+
           const [otherConcept] = [...concepts].filter((x) => x !== myConcept);
           if (otherConcept === undefined)
             throw new UnreachableCode();

--- a/ui/raidboss/data/06-ew/raid/p8s.ts
+++ b/ui/raidboss/data/06-ew/raid/p8s.ts
@@ -2390,7 +2390,7 @@ const triggerSet: TriggerSet<Data> = {
           return { alertText: output.colorTowerMergeLetter!({ color: output[color]!(), letter: output[letter]!() }) };
 
         if (color !== undefined && mergePlayer !== undefined && mergePlayer2 !== undefined)
-          return { alertText: output.colorTower1MergePlayers!({ color: output[color]!(), player1: data.ShortName(mergePlayer), player2: data.ShortName(mergePlayer2) }) };
+          return { alertText: output.colorTowerMergePlayers!({ color: output[color]!(), player1: data.ShortName(mergePlayer), player2: data.ShortName(mergePlayer2) }) };
 
         if (color !== undefined && mergePlayer !== undefined)
           return { alertText: output.colorTowerMergePlayer!({ color: output[color]!(), player: data.ShortName(mergePlayer) }) };

--- a/ui/raidboss/data/06-ew/raid/p8s.ts
+++ b/ui/raidboss/data/06-ew/raid/p8s.ts
@@ -2220,8 +2220,8 @@ const triggerSet: TriggerSet<Data> = {
           colorTowerAvoid: {
             en: 'Avoid ${color} Towers',
           },
-          colorTowersAvoid: {
-            en: 'Avoid ${color1}/${color2} Towers',
+          cloneTether: {
+            en: 'Get clone tether',
           },
           alpha: {
             en: 'Alpha',
@@ -2398,7 +2398,7 @@ const triggerSet: TriggerSet<Data> = {
         if (data.arcaneChannelCount !== 3)
           return { infoText: output.colorTowerAvoid!({ color: output[towerColors[0]]!() }) };
         if (towerColors[1] !== undefined)
-          return { infoText: output.colorTowersAvoid!({ color1: output[towerColors[0]]!(), color2: output[towerColors[1]]!() }) };
+          return { alertText: output.cloneTether!() };
       },
       run: (data) => {
         data.arcaneChannelColor = {};

--- a/ui/raidboss/data/06-ew/raid/p8s.ts
+++ b/ui/raidboss/data/06-ew/raid/p8s.ts
@@ -2143,7 +2143,9 @@ const triggerSet: TriggerSet<Data> = {
       netRegex: NetRegexes.gainsEffect({ effectId: ['D05', 'D06', 'D07'] }),
       condition: (data, matches) => {
         // Ignore Imperfection players
-        return (!data.perfectionLong[matches.target] || !data.perfectionShort[matches.target]);
+        if (data.perfectionLong[matches.target] || data.perfectionShort[matches.target])
+          return false;
+        return true;
       },
       run: (data, matches) => {
         let letter;

--- a/ui/raidboss/data/06-ew/raid/p8s.ts
+++ b/ui/raidboss/data/06-ew/raid/p8s.ts
@@ -2229,7 +2229,7 @@ const triggerSet: TriggerSet<Data> = {
 
         // Object is passed by reference, to avoid altering original list, clone is made
         const filterPerfections = (perfectionList: { [name: string]: InitialConcept }, includes: string) => {
-          const newPerfectionList = JSON.parse(JSON.stringify(perfectionList));
+          const newPerfectionList = strcturedClone(perfectionList);
           Object.keys(newPerfectionList).forEach((key) => {
             if ((newPerfectionList[key] ?? '').includes(includes))
               delete newPerfectionList[key];

--- a/ui/raidboss/data/06-ew/raid/p8s.ts
+++ b/ui/raidboss/data/06-ew/raid/p8s.ts
@@ -2168,22 +2168,6 @@ const triggerSet: TriggerSet<Data> = {
       },
     },
     {
-      id: 'P8S Arcane Channel Collect',
-      type: 'MapEffect',
-      netRegex: NetRegexes.mapEffect({ flags: arcaneChannelFlags }),
-      condition: (data) => data.seenFirstTankAutos,
-      run: (data, matches) => {
-        const colorInt = parseInt(matches.location, 16);
-
-        if (colorInt >= 0x1A && colorInt <= 0x23)
-          data.arcaneChannelColor['purple'] = true;
-        if (colorInt >= 0x24 && colorInt <= 0x2D)
-          data.arcaneChannelColor['blue'] = true;
-        if (colorInt >= 0x2E && colorInt <= 0x37)
-          data.arcaneChannelColor['green'] = true;
-      },
-    },
-    {
       id: 'P8S Arcane Channel Color',
       type: 'MapEffect',
       netRegex: NetRegexes.mapEffect({ flags: arcaneChannelFlags }),
@@ -2307,6 +2291,22 @@ const triggerSet: TriggerSet<Data> = {
           data.perfectionLong = {};
           data.perfectionShort = {};
         }
+      },
+    },
+    {
+      id: 'P8S Arcane Channel Collect',
+      type: 'MapEffect',
+      netRegex: NetRegexes.mapEffect({ flags: arcaneChannelFlags }),
+      condition: (data) => data.seenFirstTankAutos,
+      run: (data, matches) => {
+        const colorInt = parseInt(matches.location, 16);
+
+        if (colorInt >= 0x1A && colorInt <= 0x23)
+          data.arcaneChannelColor['purple'] = true;
+        if (colorInt >= 0x24 && colorInt <= 0x2D)
+          data.arcaneChannelColor['blue'] = true;
+        if (colorInt >= 0x2E && colorInt <= 0x37)
+          data.arcaneChannelColor['green'] = true;
       },
     },
     {

--- a/ui/raidboss/data/06-ew/raid/p8s.ts
+++ b/ui/raidboss/data/06-ew/raid/p8s.ts
@@ -2168,6 +2168,22 @@ const triggerSet: TriggerSet<Data> = {
       },
     },
     {
+      id: 'P8S Arcane Channel Collect',
+      type: 'MapEffect',
+      netRegex: NetRegexes.mapEffect({ flags: arcaneChannelFlags }),
+      condition: (data) => data.seenFirstTankAutos,
+      run: (data, matches) => {
+        const colorInt = parseInt(matches.location, 16);
+
+        if (colorInt >= 0x1A && colorInt <= 0x23)
+          data.arcaneChannelColor['purple'] = true;
+        if (colorInt >= 0x24 && colorInt <= 0x2D)
+          data.arcaneChannelColor['blue'] = true;
+        if (colorInt >= 0x2E && colorInt <= 0x37)
+          data.arcaneChannelColor['green'] = true;
+      },
+    },
+    {
       id: 'P8S Arcane Channel Color',
       type: 'MapEffect',
       netRegex: NetRegexes.mapEffect({ flags: arcaneChannelFlags }),
@@ -2179,6 +2195,7 @@ const triggerSet: TriggerSet<Data> = {
         }
         return false;
       },
+      delaySeconds: 0.1, // Delay to Allow multiple tower colors
       suppressSeconds: 1,
       response: (data, _matches, output) => {
         // cactbot-builtin-response
@@ -2291,22 +2308,6 @@ const triggerSet: TriggerSet<Data> = {
           data.perfectionLong = {};
           data.perfectionShort = {};
         }
-      },
-    },
-    {
-      id: 'P8S Arcane Channel Collect',
-      type: 'MapEffect',
-      netRegex: NetRegexes.mapEffect({ flags: arcaneChannelFlags }),
-      condition: (data) => data.seenFirstTankAutos,
-      run: (data, matches) => {
-        const colorInt = parseInt(matches.location, 16);
-
-        if (colorInt >= 0x1A && colorInt <= 0x23)
-          data.arcaneChannelColor['purple'] = true;
-        if (colorInt >= 0x24 && colorInt <= 0x2D)
-          data.arcaneChannelColor['blue'] = true;
-        if (colorInt >= 0x2E && colorInt <= 0x37)
-          data.arcaneChannelColor['green'] = true;
       },
     },
     {

--- a/ui/raidboss/data/06-ew/raid/p8s.ts
+++ b/ui/raidboss/data/06-ew/raid/p8s.ts
@@ -1911,7 +1911,7 @@ const triggerSet: TriggerSet<Data> = {
         const id = matches.effectId;
         // 8 and 26s second debuffs.
         const isLong = parseFloat(matches.duration) > 10;
-        if (id === 'D02')
+        if (id === 'D02') {
           data.concept[matches.target] = isLong ? 'longalpha' : 'shortalpha';
           if (isLong)
             data.perfectionLong[matches.target] = 'alpha';

--- a/ui/raidboss/data/06-ew/raid/p8s.ts
+++ b/ui/raidboss/data/06-ew/raid/p8s.ts
@@ -2255,8 +2255,9 @@ const triggerSet: TriggerSet<Data> = {
         } else if (data.arcaneChannelCount === 3) {
           // Unused Short merge with gamma
           if ((data.concept[data.me] ?? '').includes('short') || data.concept[data.me] === 'longgamma') {
-            // Need to make a clone to avoid missing a merge player during second set of towers
-            const newConcept = JSON.parse(JSON.stringify(data.concept));
+            // Need to make a copy to avoid missing a merge player during second set of towers
+            const newConcept = data.concept;
+
             // Remove players matching alpha and beta from long list
             const alphaPlayer = getMergePlayer(perfectionLong, 'alpha');
             const betaPlayer = getMergePlayer(perfectionLong, 'beta');

--- a/ui/raidboss/data/06-ew/raid/p8s.ts
+++ b/ui/raidboss/data/06-ew/raid/p8s.ts
@@ -2223,7 +2223,7 @@ const triggerSet: TriggerSet<Data> = {
 
         const myConcept = data.concept[data.me];
         if (myConcept !== 'alpha' && myConcept !== 'beta' && myConcept !== 'gamma') {
-          // Long debuff, splicers, and no debuffs avoid first towers
+          // Long debuff and splicers avoid first towers
           if (data.arcaneChannelCount !== 3)
             return { infoText: output.colorTowerAvoid!({ color: output[tower1]!() }) };
 

--- a/ui/raidboss/data/06-ew/raid/p8s.ts
+++ b/ui/raidboss/data/06-ew/raid/p8s.ts
@@ -2133,7 +2133,7 @@ const triggerSet: TriggerSet<Data> = {
       netRegex: NetRegexes.gainsEffect({ effectId: ['D05', 'D06', 'D07'] }),
       condition: (data, matches) => {
         // Ignore Imperfection players, and do not collect on HC2
-        if (data.perfectionLong[matches.target] || data.perfectionShort[matches.target] || data.arcaneChannelCount > 1)
+        if (data.concept[matches.target] || data.arcaneChannelCount > 1)
           return false;
         return true;
       },

--- a/ui/raidboss/data/06-ew/raid/p8s.ts
+++ b/ui/raidboss/data/06-ew/raid/p8s.ts
@@ -2229,7 +2229,7 @@ const triggerSet: TriggerSet<Data> = {
 
         // Object is passed by reference, to avoid altering original list, clone is made
         const filterPerfections = (perfectionList: { [name: string]: InitialConcept }, includes: string) => {
-          const newPerfectionList = structuredClone(perfectionList);
+          const newPerfectionList = JSON.parse(JSON.stringify(perfectionList));
           Object.keys(newPerfectionList).forEach((key) => {
             if ((newPerfectionList[key] ?? '').includes(includes))
               delete newPerfectionList[key];
@@ -2256,7 +2256,7 @@ const triggerSet: TriggerSet<Data> = {
           // Unused Short merge with gamma
           if ((data.concept[data.me] ?? '').includes('short') || data.concept[data.me] === 'longgamma') {
             // Need to make a clone to avoid missing a merge player during second set of towers
-            const newConcept = structuredClone(data.concept);
+            const newConcept = JSON.parse(JSON.stringify(data.concept));
             // Remove players matching alpha and beta from long list
             const alphaPlayer = getMergePlayer(perfectionLong, 'alpha');
             const betaPlayer = getMergePlayer(perfectionLong, 'beta');
@@ -2268,7 +2268,7 @@ const triggerSet: TriggerSet<Data> = {
             finalTowers = newConcept;
           }
           if (data.concept[data.me] === 'longalpha' || data.concept[data.me] === 'longbeta') {
-            const tempLong = structuredClone(perfectionLong);
+            const tempLong = JSON.parse(JSON.stringify(perfectionLong));
             // Remove player matching gamma value from long list
             const gammaPlayer = getMergePlayer(perfectionLong, 'gamma');
             if (gammaPlayer !== undefined)

--- a/ui/raidboss/data/06-ew/raid/p8s.ts
+++ b/ui/raidboss/data/06-ew/raid/p8s.ts
@@ -2186,15 +2186,7 @@ const triggerSet: TriggerSet<Data> = {
 
         // Get the player with corresponding perfection
         const getMergePlayer = (perfectionList: { [name: string]: string }, perfection: string) => {
-          let mergePlayer;
-          Object.entries(perfectionList).find(([key, value]) => {
-            if (value === perfection) {
-              mergePlayer = key;
-              return;
-            }
-            return false;
-          });
-          return mergePlayer;
+          return Object.keys(perfectionList).find((key) => perfectionList[key] === perfection);
         };
 
         let perfectionList;

--- a/ui/raidboss/data/06-ew/raid/p8s.ts
+++ b/ui/raidboss/data/06-ew/raid/p8s.ts
@@ -11,7 +11,6 @@ import { NetMatches } from '../../../../../types/net_matches';
 import { Output, TriggerSet } from '../../../../../types/trigger';
 
 // TODO: call out shriek specifically again when debuff soon? (or maybe even gaze/poison/stack too?)
-// TODO: better vent callouts
 // TODO: initial tank auto call on final boss as soon as boss pulled
 
 export type InitialConcept = 'shortalpha' | 'longalpha' | 'shortbeta' | 'longbeta' | 'shortgamma' | 'longgamma';

--- a/ui/raidboss/popup-text.ts
+++ b/ui/raidboss/popup-text.ts
@@ -832,9 +832,7 @@ export class PopupText {
       return;
 
     this.inCombat = inCombat;
-
-    // Update in combat
-    this.data = this.getDataObject();
+    this.data.inCombat = inCombat;
 
     if (!this.resetWhenOutOfCombat)
       return;
@@ -874,20 +872,6 @@ export class PopupText {
     this.data = this.getDataObject();
     this.StopTimers();
     this.triggerSuppress = {};
-
-    for (const initObj of this.dataInitializers) {
-      const init = initObj.func;
-      const data = init();
-      if (typeof data === 'object') {
-        this.data = {
-          ...data,
-          ...this.data,
-        };
-      } else {
-        console.log(`Error in file: ${initObj.file}: these triggers may not work;
-        initData function returned invalid object: ${init.toString()}`);
-      }
-    }
   }
 
   StopTimers(): void {
@@ -1477,7 +1461,7 @@ export class PopupText {
 
     // TODO: make a breaking change at some point and
     // make all this style consistent, sorry.
-    return {
+    let data: RaidbossData = {
       me: this.me,
       job: this.job,
       role: this.role,
@@ -1498,6 +1482,22 @@ export class PopupText {
       CanFeint: () => Util.canFeint(this.job),
       CanAddle: () => Util.canAddle(this.job),
     };
+
+    for (const initObj of this.dataInitializers) {
+      const init = initObj.func;
+      const initData = init();
+      if (typeof initData === 'object') {
+        data = {
+          ...data,
+          ...initData,
+        };
+      } else {
+        console.log(`Error in file: ${initObj.file}: these triggers may not work;
+        initData function returned invalid object: ${init.toString()}`);
+      }
+    }
+
+    return data;
   }
 }
 


### PR DESCRIPTION
Utilizes new MapEffects regex to determine the color of the tower and then existing debuff trigger to determine who to merge with. Will merge Long Debuffs together and Short Debuffs + Stack Players together.

This is a draft for now. Still need to fixup  HC2's non-debuff players and the two color towers.