### PR TITLE
lint: add eslint rule `import/no-useless-path-segments`

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -114,6 +114,7 @@ const rules = {
       'caseSensitive': true,
     },
   ],
+  'import/no-useless-path-segments': 'error',
   'import/no-webpack-loader-syntax': 'error',
   // Handled by dprint.
   'indent': 'off',

--- a/resources/player_override.ts
+++ b/resources/player_override.ts
@@ -1,7 +1,7 @@
-import { Lang } from '../resources/languages';
 import { Party, PlayerChangedRet } from '../types/event';
 import { Job } from '../types/job';
 
+import { Lang } from './languages';
 import { addOverlayListener } from './overlay_plugin_api';
 import Util from './util';
 

--- a/types/global.d.ts
+++ b/types/global.d.ts
@@ -1,0 +1,1 @@
+export type Nullable<T> = T | null;

--- a/types/global.d.ts
+++ b/types/global.d.ts
@@ -1,1 +1,0 @@
-export type Nullable<T> = T | null;

--- a/types/trigger.d.ts
+++ b/types/trigger.d.ts
@@ -1,8 +1,8 @@
 import { Lang, NonEnLang } from '../resources/languages';
-import { NetAnyMatches, NetMatches } from '../types/net_matches';
 import { TimelineReplacement, TimelineStyle } from '../ui/raidboss/timeline_parser';
 
 import { RaidbossData } from './data';
+import { NetAnyMatches, NetMatches } from './net_matches';
 import { CactbotBaseRegExp, TriggerTypes } from './net_trigger';
 
 // TargetedMatches can be used for generic functions in responses or conditions

--- a/ui/raidboss/emulator/overrides/RaidEmulatorPopupText.ts
+++ b/ui/raidboss/emulator/overrides/RaidEmulatorPopupText.ts
@@ -6,7 +6,8 @@ import { RaidbossOptions } from '../../raidboss_options';
 import { TimelineLoader } from '../../timeline';
 import LineEvent from '../data/network_log_converter/LineEvent';
 import RaidEmulator from '../data/RaidEmulator';
-import StubbedPopupText from '../overrides/StubbedPopupText';
+
+import StubbedPopupText from './StubbedPopupText';
 
 type DisplayedText = {
   element: HTMLElement;

--- a/ui/raidboss/emulator/overrides/RaidEmulatorTimelineUI.ts
+++ b/ui/raidboss/emulator/overrides/RaidEmulatorTimelineUI.ts
@@ -1,5 +1,5 @@
 import { UnreachableCode } from '../../../../resources/not_reached';
-import { RaidbossOptions } from '../../../../ui/raidboss/raidboss_options';
+import { RaidbossOptions } from '../../raidboss_options';
 import { TimelineUI } from '../../timeline';
 import { Event } from '../../timeline_parser';
 import RaidEmulator from '../data/RaidEmulator';


### PR DESCRIPTION
this rule force to import shortest path, like `types/trigger.d.ts` should import  `./net_matches` not `../types/net_matches`

autofix available