### PR TITLE
resources: Revert: use a shared wipe net regex

### DIFF
--- a/resources/netregexes.ts
+++ b/resources/netregexes.ts
@@ -408,9 +408,4 @@ export default class NetRegexes {
   static mapEffect(params?: NetParams['MapEffect']): CactbotBaseRegExp<'MapEffect'> {
     return buildRegex('MapEffect', params);
   }
-
-  static common = {
-    // TODO: remove 40000010 after patch 6.2 is released in all server
-    wipe: NetRegexes.network6d({ command: ['40000010', '4000000F'] }),
-  } as const;
 }

--- a/ui/pullcounter/pullcounter.ts
+++ b/ui/pullcounter/pullcounter.ts
@@ -223,7 +223,7 @@ class PullCounter {
   private bosses: Boss[] = [];
   private resetRegex = NetRegexes.echo({ line: '.*pullcounter reset.*?' });
   private wipeEndRegex = NetRegexes.echo({ line: 'end' });
-  private wipeFadeInRegex = NetRegexes.common.wipe;
+  private wipeFadeInRegex = NetRegexes.network6d({ command: ['40000010', '4000000F'] });
   private countdownEngageRegex: RegExp;
   private pullCounts: { [bossId: string]: number } = {};
 

--- a/ui/raidboss/emulator/EmulatorCommon.ts
+++ b/ui/raidboss/emulator/EmulatorCommon.ts
@@ -200,7 +200,7 @@ export default class EmulatorCommon {
   static engageRegexes = LocaleNetRegex.countdownEngage;
   static countdownRegexes = LocaleNetRegex.countdownStart;
   static unsealRegexes = LocaleNetRegex.areaUnseal;
-  static wipeRegex = NetRegexes.common.wipe;
+  static wipeRegex = NetRegexes.network6d({ command: ['40000010', '4000000F'] });
   static winRegex = NetRegexes.network6d({ command: '40000003' });
   static cactbotWipeRegex = NetRegexes.echo({ line: 'cactbot wipe.*?' });
 }

--- a/ui/raidboss/popup-text.ts
+++ b/ui/raidboss/popup-text.ts
@@ -427,7 +427,7 @@ export interface TriggerHelper {
 
 const wipeCactbotEcho = NetRegexes.echo({ line: 'cactbot wipe.*?' });
 const wipeEndEcho = NetRegexes.echo({ line: 'end' });
-const wipeFadeIn = NetRegexes.common.wipe;
+const wipeFadeIn = NetRegexes.network6d({ command: ['40000010', '4000000F'] });
 
 const isWipe = (line: string): boolean => {
   if (

--- a/ui/raidboss/timeline.ts
+++ b/ui/raidboss/timeline.ts
@@ -732,7 +732,7 @@ export class TimelineController {
 
     // Used to suppress any Engage! if there's a wipe between /countdown and Engage!.
     this.suppressNextEngage = false;
-    this.wipeRegex = NetRegexes.common.wipe;
+    this.wipeRegex = NetRegexes.network6d({ command: ['40000010', '4000000F'] });
   }
 
   public SetPopupTextInterface(popupText: PopupTextGenerator): void {

--- a/util/logtools/encounter_tools.ts
+++ b/util/logtools/encounter_tools.ts
@@ -63,7 +63,7 @@ export class EncounterFinder {
       changeZone: NetRegexes.changeZone(),
       cactbotWipe: NetRegexes.echo({ line: 'cactbot wipe.*?' }),
       win: NetRegexes.network6d({ command: '40000003' }),
-      wipe: NetRegexes.common.wipe,
+      wipe: NetRegexes.network6d({ command: ['40000010', '4000000F'] }),
       commence: NetRegexes.network6d({ command: '4000000[16]' }),
       playerAttackingMob: NetRegexes.ability({ sourceId: '1.{7}', targetId: '4.{7}' }),
       mobAttackingPlayer: NetRegexes.ability({ sourceId: '4.{7}', targetId: '1.{7}' }),


### PR DESCRIPTION
Bug report: go to <https://quisquous.github.io/cactbot/ui/raidboss/raidboss.html>

```
Uncaught ReferenceError: Cannot access 'NetRegexes' before initialization
    at buildRegex (netregexes.ts:163:56)
    at NetRegexes.network6d (netregexes.ts:379:12)
    at <static_initializer> (netregexes.ts:414:22)
    at 622 (netregexes.ts:159:27)
    at __webpack_require__ (bootstrap:19:1)
    at 456 (responses.ts:584:1)
    at __webpack_require__ (bootstrap:19:1)
    at 266 (player_override.ts:66:8)
    at __webpack_require__ (bootstrap:19:1)
    at startup:4:1
```

Reverts quisquous/cactbot#4946

