### PR TITLE
config: fix raidboss config not listing zones

### DIFF
--- a/ui/raidboss/raidboss_config.ts
+++ b/ui/raidboss/raidboss_config.ts
@@ -1273,11 +1273,11 @@ class RaidbossConfigurator {
       if (regex === undefined)
         return;
 
-      if (trig.type === undefined) {
-        if (!(regex instanceof RegExp))
-          return;
+      if (regex instanceof RegExp)
         return Regexes.parse(translateRegex(regex, lang, set.timelineReplace));
-      }
+
+      if (trig.type === undefined)
+        return;
 
       return Regexes.parse(
         buildRegex(trig.type, translateRegexBuildParam(regex, lang, set.timelineReplace)),


### PR DESCRIPTION
This was causing errors on triggers that had both `type` and a regular expression `netRegex` (which is most of them).