### PR TITLE
ci: fix for yarn user

### DIFF
--- a/.github/scripts/npm-package.cjs
+++ b/.github/scripts/npm-package.cjs
@@ -10,6 +10,8 @@ const pkg = require('../../package.json');
 
 const projectRoot = path.join(__dirname, '..', '..');
 
+const npmrc = '//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}\nalways-auth=true';
+
 async function main() {
   // force pwd to at .../cactbot/
   process.chdir(projectRoot);
@@ -23,6 +25,8 @@ async function main() {
   fsExtra.copySync('types', 'npm-package/types', {});
   fs.renameSync('dist/resources', 'npm-package/resources');
   fs.renameSync('dist/util', 'npm-package/util');
+
+  fs.writeFileSync('npm-package/.npmrc', npmrc);
 
   const newPackageJSON = {
     type: 'module',

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -77,7 +77,6 @@ jobs:
 
       - run: node .github/scripts/npm-package.cjs
 
-      - run: cp .npmrc ./npm-package/
       - run: npm publish
         working-directory: npm-package
         env:

--- a/.npmrc
+++ b/.npmrc
@@ -1,4 +1,3 @@
-//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}
 # set git commit when bump version
 message="build: Bump version to %s"
 git-tag-version=true


### PR DESCRIPTION
`.github/scripts/npm-package.cjs` will create a `.npmrc ` in `npm-package/.npmrc` so release script will work.

