### PR TITLE
raidboss: Fix seal common translation for param netRegex

### DIFF
--- a/test/helper/test_timeline.ts
+++ b/test/helper/test_timeline.ts
@@ -62,6 +62,7 @@ type TestCase = {
   type: keyof CommonReplacement;
   items: Set<string>;
   replace: ReplaceMap;
+  replaceWithoutCommon: ReplaceMap;
 };
 
 const getTestCases = (
@@ -80,12 +81,14 @@ const getTestCases = (
     {
       type: 'replaceSync',
       items: new Set(timeline.syncStarts.map((x) => x.regex.source)),
-      replace: syncMap,
+      replace: new Map(syncMap),
+      replaceWithoutCommon: new Map(syncMap),
     },
     {
       type: 'replaceText',
       items: new Set(timeline.events.map((x) => x.text)),
-      replace: textMap,
+      replace: new Map(textMap),
+      replaceWithoutCommon: new Map(textMap),
     },
   ];
 
@@ -295,7 +298,10 @@ const testTimelineFiles = (timelineFiles: string[]): void => {
             ].map((x) => Regexes.parse(x));
 
             for (const testCase of testCases) {
-              for (const regex of testCase.replace.keys()) {
+              // Don't test the common translations here, as some may include these characters.
+              // It's only regexes inside of `timelineReplace` in a trigger file that are
+              // the ones that need to be checked.
+              for (const regex of testCase.replaceWithoutCommon.keys()) {
                 for (const bad of badRegex) {
                   assert.isNull(
                     bad.exec(regex.source),

--- a/ui/raidboss/common_replacement.ts
+++ b/ui/raidboss/common_replacement.ts
@@ -2,9 +2,18 @@
 
 import { Lang, NonEnLang } from '../../resources/languages';
 
+// The seal key is kind of a hack because we use it in a lot of different
+// contexts and need to correctly grab the name of the zone that is sealed.
+// These are some various lookbehinds for those different contexts:
+
+// Regexes for a parsed ACT log line
 const parsedLB = '00:0839::';
+// Regexes for a network log line
 const networkLB = '00\\|[^|]*\\|0839\\|\\|';
+// Regex for a regex for a network log line.  <_<
 const netRegexLB = '\\\\\\|0839\\\\\\|\\[\\^\\|\\]\\*\\\\\\|';
+// A bare parameter (e.g. `X will be sealed off` via `netRegex: { line: 'X will be sealed off' },`)
+const paramLB = '^';
 
 // It's awkward to refer to these string keys, so name them as replaceSync[keys.sealKey].
 export const syncKeys = {
@@ -14,7 +23,7 @@ export const syncKeys = {
   //   network log lines: 00|timestamp|0839||Something will be sealed off
   //   NetRegexes: ^^00\|[^|]*\|0839\|[^|]*\|Something will be sealed off.*?\|
   seal:
-    `(?<=${parsedLB}|${networkLB}|${netRegexLB})([^|]*) will be sealed off(?: in (?:[0-9]+ seconds)?)?`,
+    `(?<=${parsedLB}|${networkLB}|${netRegexLB}|${paramLB})([^|]*) will be sealed off(?: in (?:[0-9]+ seconds)?)?`,
   unseal: 'is no longer sealed',
   engage: 'Engage!',
 };


### PR DESCRIPTION
This would break on the eureka_hydatos version:
`netRegex: { line: '.* will be sealed off.*?', capture: false },`

This patch allows this to be translated properly.  However, this patch doesn't change the trigger itself because more work needs to be done on message vs gamelog etc before using the parameter version.