### PR TITLE
raidboss: fix `NetRegexes.ability` is alias

### DIFF
--- a/resources/netregexes.ts
+++ b/resources/netregexes.ts
@@ -412,3 +412,14 @@ export const commonNetRegex = {
   cactbotWipeEcho: NetRegexes.echo({ line: 'cactbot wipe.*?' }),
   userWipeEcho: NetRegexes.echo({ line: 'end' }),
 } as const;
+
+export const buildNetRegexForTrigger = <T extends keyof NetParams>(
+  type: T,
+  params?: ParseHelperType<T>,
+): CactbotBaseRegExp<T> => {
+  if (type === 'Ability')
+    // ts can't narrow T to `Ability` here, need casting.
+    return NetRegexes.ability(params) as CactbotBaseRegExp<T>;
+
+  return buildRegex<T>(type, params);
+};

--- a/test/helper/test_trigger.ts
+++ b/test/helper/test_trigger.ts
@@ -8,7 +8,10 @@ import path from 'path';
 
 import chai from 'chai';
 
-import NetRegexes, { buildRegex, keysThatRequireTranslation } from '../../resources/netregexes';
+import NetRegexes, {
+  buildNetRegexForTrigger,
+  keysThatRequireTranslation,
+} from '../../resources/netregexes';
 import { UnreachableCode } from '../../resources/not_reached';
 import Regexes from '../../resources/regexes';
 import {
@@ -186,7 +189,7 @@ const testTriggerFile = (file: string) => {
             continue;
           }
           // TODO: we can check it from keys of `currentNetRegex`.
-          netRegexRegex = buildRegex(currentTrigger.type, currentNetRegex);
+          netRegexRegex = buildNetRegexForTrigger(currentTrigger.type, currentNetRegex);
         }
 
         const capture = new RegExp(`(?:${netRegexRegex.toString()})?`).exec('');

--- a/ui/raidboss/popup-text.ts
+++ b/ui/raidboss/popup-text.ts
@@ -1,5 +1,5 @@
 import { Lang } from '../../resources/languages';
-import { buildRegex, commonNetRegex } from '../../resources/netregexes';
+import { buildNetRegexForTrigger, commonNetRegex } from '../../resources/netregexes';
 import { UnreachableCode } from '../../resources/not_reached';
 import { callOverlayHandler, addOverlayListener } from '../../resources/overlay_plugin_api';
 import PartyTracker from '../../resources/party';
@@ -747,7 +747,7 @@ export class PopupText {
                   continue;
                 }
 
-                const re = buildRegex(
+                const re = buildNetRegexForTrigger(
                   trigger.type,
                   translateRegexBuildParam(defaultNetRegex, this.parserLang, set.timelineReplace),
                 );

--- a/ui/raidboss/raidboss_config.ts
+++ b/ui/raidboss/raidboss_config.ts
@@ -1,5 +1,5 @@
 import { isLang, Lang } from '../../resources/languages';
-import { buildRegex } from '../../resources/netregexes';
+import { buildNetRegexForTrigger } from '../../resources/netregexes';
 import { UnreachableCode } from '../../resources/not_reached';
 import PartyTracker from '../../resources/party';
 import Regexes from '../../resources/regexes';
@@ -1280,7 +1280,10 @@ class RaidbossConfigurator {
         return;
 
       return Regexes.parse(
-        buildRegex(trig.type, translateRegexBuildParam(regex, lang, set.timelineReplace)),
+        buildNetRegexForTrigger(
+          trig.type,
+          translateRegexBuildParam(regex, lang, set.timelineReplace),
+        ),
       );
     };
 


### PR DESCRIPTION
`NetRegexes.ability` match NetworkAbility and NetworkAOEAbility, but `buildRegex('Ability', ...) ` only match NetworkAbility 

Add a function `buildNetRegexForTrigger` to dispatch ability trigger to use `NetRegexes.ability` to build regex

should fix https://github.com/quisquous/cactbot/issues/4984