### PR TITLE
build: include source in sourcemap

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -41,6 +41,7 @@
     "noUnusedParameters": false,
     "noFallthroughCasesInSwitch": true,
     "noUncheckedIndexedAccess": true,
+    "inlineSources": true,
     //    "noPropertyAccessFromIndexSignature": false, // used by trigger output strings
     "forceConsistentCasingInFileNames": true
   },


### PR DESCRIPTION
I think [you are right](https://github.com/quisquous/cactbot/pull/4938#issuecomment-1287938337) here about source map and source file, I forget to enable `inlineSources` in tsconfig so source file is not included in source map, so it's actually broken.

