### PR TITLE
raidboss: ASS missing slippery soap count

### DIFF
--- a/ui/raidboss/data/06-ew/dungeon/another_sildihn_subterrane.ts
+++ b/ui/raidboss/data/06-ew/dungeon/another_sildihn_subterrane.ts
@@ -138,7 +138,7 @@ const triggerSet: TriggerSet<Data> = {
       id: 'ASS Slippery Soap',
       // Happens 5 times in the encounter
       type: 'Ability',
-      netRegex: { id: '79FB', source: ['Silkie', 'Eastern Ewer' },
+      netRegex: { id: '79FB', source: ['Silkie', 'Eastern Ewer'] },
       preRun: (data) => data.soapCounter++,
       alertText: (data, matches, output) => {
         if (data.suds === '7757') {

--- a/ui/raidboss/data/06-ew/dungeon/another_sildihn_subterrane.ts
+++ b/ui/raidboss/data/06-ew/dungeon/another_sildihn_subterrane.ts
@@ -138,7 +138,7 @@ const triggerSet: TriggerSet<Data> = {
       id: 'ASS Slippery Soap',
       // Happens 5 times in the encounter
       type: 'Ability',
-      netRegex: { id: '79FB', source: 'Silkie' },
+      netRegex: { id: '79FB', source: ['Silkie', 'Eastern Ewer' },
       preRun: (data) => data.soapCounter++,
       alertText: (data, matches, output) => {
         if (data.suds === '7757') {


### PR DESCRIPTION
As shown in the timeline, the one Slippery Soap here is cast not by Silkie, but the Eastern Ewer. Since the count is missed, the later triggers do not work.