### PR TITLE
raidboss: ASS add Rush of Might Triggers

### DIFF
--- a/ui/raidboss/data/06-ew/dungeon/another_sildihn_subterrane.ts
+++ b/ui/raidboss/data/06-ew/dungeon/another_sildihn_subterrane.ts
@@ -414,12 +414,10 @@ const triggerSet: TriggerSet<Data> = {
         if (!gladiator)
           return;
         data.mightCasts.push(gladiator);
-        console.error(`Rush of Might 1: Added Combatant at (${gladiator.PosX}, ${gladiator.PosY})`);
       },
       infoText: (data, _matches, output) => {
         if (data.mightCasts.length !== 2)
           return;
-        console.error(`Rush of Might 1: Received two gladiators, executing.`);
         const mirage1 = data.mightCasts[0];
         const mirage2 = data.mightCasts[1];
 

--- a/ui/raidboss/data/06-ew/dungeon/another_sildihn_subterrane.ts
+++ b/ui/raidboss/data/06-ew/dungeon/another_sildihn_subterrane.ts
@@ -1,9 +1,11 @@
 import Conditions from '../../../../../resources/conditions';
 import { UnreachableCode } from '../../../../../resources/not_reached';
 import Outputs from '../../../../../resources/outputs';
+import { callOverlayHandler } from '../../../../../resources/overlay_plugin_api';
 import { Responses } from '../../../../../resources/responses';
 import ZoneId from '../../../../../resources/zone_id';
 import { RaidbossData } from '../../../../../types/data';
+import { PluginCombatantState } from '../../../../../types/event';
 import { TriggerSet } from '../../../../../types/trigger';
 
 // TODO: Silkie specify which puff to get behind in first Slippery Soap
@@ -16,6 +18,8 @@ export interface Data extends RaidbossData {
   suds?: string;
   soapCounter: number;
   beaterCounter: number;
+  mightCasts: PluginCombatantState[];
+  mightDir?: string;
   hasLingering?: boolean;
   thunderousEchoPlayer?: string;
   gildedCounter: number;
@@ -34,6 +38,7 @@ const triggerSet: TriggerSet<Data> = {
     return {
       soapCounter: 0,
       beaterCounter: 0,
+      mightCasts: [],
       gildedCounter: 0,
       silveredCounter: 0,
       arcaneFontCounter: 0,
@@ -364,6 +369,158 @@ const triggerSet: TriggerSet<Data> = {
       type: 'StartsUsing',
       netRegex: { id: '7671', source: 'Gladiator of Sil\'dih', capture: false },
       response: Responses.aoe(),
+    },
+    {
+      id: 'ASS Rush of Might 1',
+      // Boss casts 765C (12.2s) and 765B (10.2s), twice
+      // Gladiator of Mirage casts 7659, 7658, 765A, these target the environment
+      // North
+      //                East               West
+      //   Line 1: (-34.14, -270.14) (-35.86, -270.14)
+      //   Line 2: (-39.45, -275.45) (-30.55, -275.45)
+      //   Line 3: (-44.75, -280.75) (-25.25, -280.75)
+      // South
+      //                East               West
+      //   Line 1: (-34.14, -271.86) (-35.86, -271.86)
+      //   Line 2: (-39.45, -266.55) (-30.55, -266.55)
+      //   Line 3: (-44.75, -261.25) (-25.25, -261.25)
+      // Center is at (-35, -271)
+      type: 'StartsUsing',
+      netRegex: { id: '765C', source: 'Gladiator of Sil\'dih' },
+      delaySeconds: 0.4,
+      promise: async (data, matches) => {
+        if (data.mightCasts.length === 2)
+          data.mightCasts = [];
+
+        // select the Gladiator with same source id
+        let gladiatorData = null;
+        gladiatorData = await callOverlayHandler({
+          call: 'getCombatants',
+          ids: [parseInt(matches.sourceId, 16)],
+        });
+
+        // if we could not retrieve combatant data, the
+        // trigger will not work, so just resume promise here
+        if (gladiatorData === null) {
+          console.error(`Gladiator of Sil'dih: null data`);
+          return;
+        }
+        if (gladiatorData.combatants.length !== 1) {
+          console.error(`Gladiator of Sil'dih: expected 1, got ${gladiatorData.combatants.length}`);
+          return;
+        }
+
+        const gladiator = gladiatorData.combatants[0];
+        if (!gladiator)
+          return;
+        data.mightCasts.push(gladiator);
+        console.error(`Rush of Might 1: Added Combatant at (${gladiator.PosX}, ${gladiator.PosY})`);
+      },
+      infoText: (data, _matches, output) => {
+        if (data.mightCasts.length !== 2)
+          return;
+        console.error(`Rush of Might 1: Received two gladiators, executing.`);
+        const mirage1 = data.mightCasts[0];
+        const mirage2 = data.mightCasts[1];
+
+        if (mirage1 === undefined || mirage2 === undefined)
+          throw new UnreachableCode();
+
+        const x1 = mirage1.PosX;
+        const y1 = mirage1.PosY;
+        const x2 = mirage2.PosX;
+        const y2 = mirage2.PosY;
+
+        const getLine = (x: number) => {
+          // Round values to be easier to read:
+          //   1    2    3
+          // [-35, -40, -45]
+          // [-35, -30, -25]
+          const roundX = Math.round(x / 5) * 5;
+          if (roundX === -45 || roundX === -25)
+            return 3;
+          else if (roundX === -40 || roundX === -30)
+            return 2;
+          else if (roundX === -35)
+            return 1;
+          return undefined;
+        };
+        const line1 = getLine(x1);
+        const line2 = getLine(x2);
+        if (line1 === undefined || line2 === undefined) {
+          console.error(`Rush of Might 1: Failed to determine line from ${x1} or ${x2}`);
+          return;
+        }
+
+        const line = line1 > line2 ? line1 : line2;
+
+        // Get Intercard and greatest relative x value
+        let intercard;
+        const roundY = Math.round(y1 / 3) * 3;
+        // Round values to be easier to read:
+        //          1     2     3
+        // North [-270, -276, -282]
+        // South [-273, -267, -261] 
+        if (roundY === -270 || roundY === -276 || roundY === -282) {
+          // Get the x value of farthest north mirage
+          const x = y1 < y2 ? x1 : x2;
+          intercard = x < -35 ? 'northwest' : 'northeast';
+          data.mightDir = 'north';
+        } else if (roundY === -273 || roundY === -267 || roundY === -261) {
+          // Get the x value of farthest south mirage
+          const x = y1 > y2 ? x1 : x2;
+          intercard = x < -35 ? 'southwest' : 'southeast';
+          data.mightDir = 'south';
+        } else {
+          console.error(`Rush of Might 1: Failed to determine intercard from ${y1}`);
+          return;
+        }
+
+        let side;
+        if (line1 === 2 && line2 === 3 || line1 === 3 && line2 === 2) {
+          // Get side of line for case when one is 2 and one is 3
+          if (intercard === 'northwest' || intercard === 'southwest')
+            side = 'east';
+          else
+            side = 'west';
+        } else {
+          if (intercard === 'northwest' || intercard === 'southwest')
+            side = 'west';
+          else
+            side = 'east';
+        }
+        return output.text!({ intercard: output[intercard]!(), side: output[side]!(), line: line });
+      },
+      outputStrings: {
+        text: {
+          en: '${intercard}, ${side} of line #${line}',
+        },
+        east: Outputs.east,
+        west: Outputs.west,
+        northwest: Outputs.northwest,
+        northeast: Outputs.northeast,
+        southeast: Outputs.southeast,
+        southwest: Outputs.southwest,
+      },
+    },
+    {
+      id: 'ASS Rush of Might 2',
+      type: 'Ability',
+      netRegex: { id: '765B', source: 'Gladiator of Sil\'dih', capture: false },
+      suppressSeconds: 1,
+      infoText: (data, _matches, output) => {
+        if (data.mightDir === undefined)
+          return output.move!();
+        return output.text!({ dir: output[data.mightDir]!() });
+      },
+      outputStrings: {
+        text: {
+          en: 'Move ${dir}',
+        },
+        north: Outputs.north,
+        south: Outputs.south,
+        move: Outputs.moveAway,
+      },
     },
     {
       id: 'ASS Sculptor\'s Passion',


### PR DESCRIPTION
Utilizes OverlayPlugin to get more up to date data. Log data was inaccurate, this data was good when I tested.

I tested earlier and the second part was always correct. First part did not call due to wrong rounded y1 values, but that has been fixed so I think it's good. Wording will take some getting used to and there may be reason to make this relative callouts instead of current card/intercad based callouts since it can be difficult to understand at first.