### PR TITLE
build: update memfs dependency for node 18

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10367,12 +10367,12 @@
       }
     },
     "node_modules/memfs": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/memfs/-/memfs-3.4.1.tgz",
-      "integrity": "sha512-1c9VPVvW5P7I85c35zAdEr1TD5+F11IToIHIlrVIcflfnzPkJa0ZoYEoEdYDP8KgPFoSZ/opDrUsAoZWym3mtw==",
+      "version": "3.4.8",
+      "resolved": "https://registry.npmjs.org/memfs/-/memfs-3.4.8.tgz",
+      "integrity": "sha512-E8QAFfd4csESWOqKIpN+khILPFSAZwPR9S+DO/5UtJNcuanF1jLZz0oWUAPF7xd2c1r6dGjGx+jH1st+MFWufA==",
       "dev": true,
       "dependencies": {
-        "fs-monkey": "1.0.3"
+        "fs-monkey": "^1.0.3"
       },
       "engines": {
         "node": ">= 4.0.0"
@@ -23657,12 +23657,12 @@
       "dev": true
     },
     "memfs": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/memfs/-/memfs-3.4.1.tgz",
-      "integrity": "sha512-1c9VPVvW5P7I85c35zAdEr1TD5+F11IToIHIlrVIcflfnzPkJa0ZoYEoEdYDP8KgPFoSZ/opDrUsAoZWym3mtw==",
+      "version": "3.4.8",
+      "resolved": "https://registry.npmjs.org/memfs/-/memfs-3.4.8.tgz",
+      "integrity": "sha512-E8QAFfd4csESWOqKIpN+khILPFSAZwPR9S+DO/5UtJNcuanF1jLZz0oWUAPF7xd2c1r6dGjGx+jH1st+MFWufA==",
       "dev": true,
       "requires": {
-        "fs-monkey": "1.0.3"
+        "fs-monkey": "^1.0.3"
       }
     },
     "meow": {


### PR DESCRIPTION
3.4.2 has the required changes.  Updating to 3.4.8 just as that's the latest and it seems to work locally in testing.

See: #5009 