### PR TITLE
raidboss: ASS add Banishment triggers

### DIFF
--- a/ui/raidboss/data/06-ew/dungeon/another_sildihn_subterrane.ts
+++ b/ui/raidboss/data/06-ew/dungeon/another_sildihn_subterrane.ts
@@ -912,6 +912,99 @@ const triggerSet: TriggerSet<Data> = {
       condition: Conditions.targetIsYou(),
       run: (data, matches) => data.myLastCut = Date.parse(matches.timestamp),
     },
+    {
+      id: 'ASS Banishment',
+      // Players receive invisible effect that indicates rotation and direction
+      // of their teleport attached teleport pad
+      //
+      // At the same time, two teleports on North and South are also marked:
+      // one rotates outside the arena, the other rotates towards the inner rows
+      // Players have 12s to teleport using the safe teleports prior to Call of
+      // the Portal (CCC) expiration
+      //
+      // The first teleports occur at ~11.4s after these debuff go out
+      // After first teleport, lasers block rows but can be teleported over
+      // Hitting a laser results in stun and likely death
+      //
+      // Seconds after first teleport, two wards will go off that target the
+      // two nearest players. Players need to have teleported close enough
+      // to the ward to bait the ward away from other players
+      //
+      // Following the first set of baits, the player's teleport will go off
+      // which should have been positioned to teleport across the laser to bait
+      // the final ward away from other players
+      //
+      // 1CD Blue (Counterclockwise) Teleporting West
+      // 1CE Orange (Clockwise) Teleporting East
+      // 1D2 Orange (Clockwise) Teleporting West
+      // 1D3 Blue (Counterclockwise) Teleporting East
+      //
+      // There are multiple strategies, so this only describes what you have,
+      // from there you can create a personal call of where to go
+      type: 'GainsEffect',
+      netRegex: { effectId: 'B9A' },
+      condition: Conditions.targetIsYou(),
+      infoText: (_data, matches, output) => {
+        switch (matches.count) {
+          case '1CD':
+            return output.blueWest!();
+          case '1CE':
+            return output.orangeEast!();
+          case '1D2':
+            return output.orangeWest!();
+          case '1D3':
+            return output.blueEast!();
+        }
+      },
+      outputStrings: {
+        blueEast: {
+          en: 'Blue Teleporting East',
+        },
+        blueWest: {
+          en: 'Blue Teleporting West',
+        },
+        orangeEast: {
+          en: 'Orange Teleporting East',
+        },
+        orangeWest: {
+          en: 'Orange Teleporting West',
+        },
+      },
+    },
+    {
+      id: 'ASS Banishment First Ward',
+      // This debuff expires 4.7s before the first bait, but there is a slight
+      // animation lock from the teleport that occurs
+      // Repositioning may be required to bait the active ward's Infern Wave
+      // Using Call of the Portal (CCC) expiration for trigger
+      type: 'LosesEffect',
+      netRegex: { effectId: 'CCC' },
+      condition: Conditions.targetIsYou!(),
+      delaySeconds: 0.75, // Delay for animation lock from teleport to complete
+      infoText: (_data, _matches, output) => output.text!(),
+      outputStrings: {
+        text: {
+          en: 'Bait First Ward',
+        },
+      },
+    },
+    {
+      id: 'ASS Banishment Second Ward',
+      // After the second teleport and stun expiring, there is 2s before the
+      // the last ward casts Infern Wave that must be baited
+      // Rite of Passage (CCD) debuff is tied to the player's teleport going
+      // off
+      type: 'LosesEffect',
+      netRegex: { effectId: 'CCD' },
+      condition: Conditions.targetIsYou!(),
+      delaySeconds: 2, // Delay for stun to complete
+      infoText: (_data, _matches, output) => output.text!(),
+      outputStrings: {
+        text: {
+          en: 'Bait Second Ward',
+        },
+      },
+    },
   ],
   timelineReplace: [
     {

--- a/ui/raidboss/data/06-ew/dungeon/another_sildihn_subterrane.ts
+++ b/ui/raidboss/data/06-ew/dungeon/another_sildihn_subterrane.ts
@@ -934,10 +934,10 @@ const triggerSet: TriggerSet<Data> = {
       // which should have been positioned to teleport across the laser to bait
       // the final ward away from other players
       //
-      // 1CD Blue (Counterclockwise) Teleporting West
-      // 1CE Orange (Clockwise) Teleporting East
-      // 1D2 Orange (Clockwise) Teleporting West
-      // 1D3 Blue (Counterclockwise) Teleporting East
+      // 1CD Blue (Counterclockwise) Teleporting East
+      // 1CE Orange (Clockwise) Teleporting West
+      // 1D2 Orange (Clockwise) Teleporting East
+      // 1D3 Blue (Counterclockwise) Teleporting West
       //
       // There are multiple strategies, so this only describes what you have,
       // from there you can create a personal call of where to go
@@ -947,13 +947,13 @@ const triggerSet: TriggerSet<Data> = {
       infoText: (_data, matches, output) => {
         switch (matches.count) {
           case '1CD':
-            return output.blueWest!();
-          case '1CE':
-            return output.orangeEast!();
-          case '1D2':
-            return output.orangeWest!();
-          case '1D3':
             return output.blueEast!();
+          case '1CE':
+            return output.orangeWest!();
+          case '1D2':
+            return output.orangeEast!();
+          case '1D3':
+            return output.blueWest!();
         }
       },
       outputStrings: {

--- a/ui/raidboss/data/06-ew/dungeon/another_sildihn_subterrane.ts
+++ b/ui/raidboss/data/06-ew/dungeon/another_sildihn_subterrane.ts
@@ -979,7 +979,7 @@ const triggerSet: TriggerSet<Data> = {
       // Using Call of the Portal (CCC) expiration for trigger
       type: 'LosesEffect',
       netRegex: { effectId: 'CCC' },
-      condition: Conditions.targetIsYou!(),
+      condition: Conditions.targetIsYou(),
       delaySeconds: 0.75, // Delay for animation lock from teleport to complete
       infoText: (_data, _matches, output) => output.text!(),
       outputStrings: {
@@ -989,14 +989,14 @@ const triggerSet: TriggerSet<Data> = {
       },
     },
     {
-      id: 'ASS Banishment Second Ward',
+      id: 'ASS Banishment Bait Second Ward',
       // After the second teleport and stun expiring, there is 2s before the
       // the last ward casts Infern Wave that must be baited
       // Rite of Passage (CCD) debuff is tied to the player's teleport going
       // off
       type: 'LosesEffect',
       netRegex: { effectId: 'CCD' },
-      condition: Conditions.targetIsYou!(),
+      condition: Conditions.targetIsYou(),
       delaySeconds: 2, // Delay for stun to complete
       infoText: (_data, _matches, output) => output.text!(),
       outputStrings: {


### PR DESCRIPTION
During the final boss, Banishment is the mechanic that happens between Infern Brand 3 and Infern Ward 4. I have seen multiple strategies for this mechanic, some simpler than others.

It looked to me like there was an invisible debuff, B9A, that has its count field that correlates to the portal animation that the player has, so this can be used to make triggers for where to position to solve the mechanic. I compared raid_emulator with positioning I have in a log and created the mapping.

I also added two additional triggers for baiting the wards. I was not sure they are both necessary, I know the first one can be a bit more trickier as it has extra time before the bait and at least two players are likely to have been teleported in such a way that they need to move to not trigger an Infern Wave going in the wrong direction. The second wave has much longer stun lock before it goes off leaving less time to react.

Will be able to test this in game later.