### PR TITLE
lint: add missing ts file extention to husky dprint

### DIFF
--- a/package.json
+++ b/package.json
@@ -128,7 +128,7 @@
   },
   "lint-staged": {
     "*.css": "stylelint",
-    "*.{js,cjs,mjs,json}": [
+    "*.{ts,js,cjs,mjs,json}": [
       "dprint check"
     ],
     "*.{js,cjs,mjs}": [


### PR DESCRIPTION
close https://github.com/quisquous/cactbot/issues/5021