### PR TITLE
lint: use dprint json plugin from npm

### DIFF
--- a/dprint.json
+++ b/dprint.json
@@ -29,6 +29,6 @@
   },
   "plugins": [
     "./node_modules/@dprint/typescript/plugin.wasm",
-    "https://plugins.dprint.dev/json-0.15.6.wasm"
+    "./node_modules/@dprint/json/plugin.wasm"
   ]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
         "@babel/preset-env": "^7.14.5",
         "@babel/preset-typescript": "^7.14.5",
         "@babel/types": "^7.16.0",
+        "@dprint/json": "^0.16.0",
         "@dprint/typescript": "^0.75.0",
         "@types/argparse": "^1.0.38",
         "@types/chai": "^4.3.1",
@@ -1767,6 +1768,12 @@
       "engines": {
         "node": ">=10.0.0"
       }
+    },
+    "node_modules/@dprint/json": {
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/@dprint/json/-/json-0.16.0.tgz",
+      "integrity": "sha512-fUTPmg6lEAmua8/yBfYin5cqlyJNjfIxeLY38iyKLBr76csnp9A+EgXCmXjQB4M7YKrwQhi/cZ05i8MpkNLMGQ==",
+      "dev": true
     },
     "node_modules/@dprint/typescript": {
       "version": "0.75.0",
@@ -17334,6 +17341,12 @@
       "version": "0.5.7",
       "resolved": "https://registry.npmjs.org/@discoveryjs/json-ext/-/json-ext-0.5.7.tgz",
       "integrity": "sha512-dBVuXR082gk3jsFp7Rd/JI4kytwGHecnCoTtXFb7DB6CNHp4rg5k1bhg0nWdLGLnOV71lmDzGQaLMy8iPLY0pw==",
+      "dev": true
+    },
+    "@dprint/json": {
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/@dprint/json/-/json-0.16.0.tgz",
+      "integrity": "sha512-fUTPmg6lEAmua8/yBfYin5cqlyJNjfIxeLY38iyKLBr76csnp9A+EgXCmXjQB4M7YKrwQhi/cZ05i8MpkNLMGQ==",
       "dev": true
     },
     "@dprint/typescript": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1777,13 +1777,13 @@
     },
     "node_modules/@dprint/typescript": {
       "version": "0.75.0",
-      "resolved": "https://registry.npmmirror.com/@dprint/typescript/-/typescript-0.75.0.tgz",
+      "resolved": "https://registry.npmjs.org/@dprint/typescript/-/typescript-0.75.0.tgz",
       "integrity": "sha512-66Io2E2rHIJ8s6eiQfyXe7eGI7bmQac/njkq50IcUMboCRIftfJmXCQOKqjpB14pGnNvwPCNvMInsTS70NpFAQ==",
       "dev": true
     },
     "node_modules/@eslint/eslintrc": {
       "version": "1.3.3",
-      "resolved": "https://registry.npmmirror.com/@eslint/eslintrc/-/eslintrc-1.3.3.tgz",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.3.3.tgz",
       "integrity": "sha512-uj3pT6Mg+3t39fvLrj8iuCIJ38zKO9FpGtJ4BBJebJhEwjoT+KLVNCcHT5QC9NGRIEi7fZ0ZR8YRb884auB4Lg==",
       "dev": true,
       "dependencies": {
@@ -1803,7 +1803,7 @@
     },
     "node_modules/@eslint/eslintrc/node_modules/globals": {
       "version": "13.17.0",
-      "resolved": "https://registry.npmmirror.com/globals/-/globals-13.17.0.tgz",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-13.17.0.tgz",
       "integrity": "sha512-1C+6nQRb1GwGMKm2dH/E7enFAMxGTmGI7/dEdhy/DNelv85w9B72t3uc5frtMNXIbzrarJJ/lTCjcaZwbLJmyw==",
       "dev": true,
       "dependencies": {
@@ -1815,7 +1815,7 @@
     },
     "node_modules/@eslint/eslintrc/node_modules/type-fest": {
       "version": "0.20.2",
-      "resolved": "https://registry.npmmirror.com/type-fest/-/type-fest-0.20.2.tgz",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
       "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
       "dev": true,
       "engines": {
@@ -1843,7 +1843,7 @@
     },
     "node_modules/@humanwhocodes/config-array": {
       "version": "0.11.7",
-      "resolved": "https://registry.npmmirror.com/@humanwhocodes/config-array/-/config-array-0.11.7.tgz",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.7.tgz",
       "integrity": "sha512-kBbPWzN8oVMLb0hOUYXhmxggL/1cJE6ydvjDIGi9EnAGUyA7cLVKQg+d/Dsm+KZwx2czGHrCmMVLiyg8s5JPKw==",
       "dev": true,
       "dependencies": {
@@ -1857,7 +1857,7 @@
     },
     "node_modules/@humanwhocodes/module-importer": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmmirror.com/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
       "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
       "dev": true,
       "engines": {
@@ -1866,7 +1866,7 @@
     },
     "node_modules/@humanwhocodes/object-schema": {
       "version": "1.2.1",
-      "resolved": "https://registry.npmmirror.com/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz",
       "integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==",
       "dev": true
     },
@@ -3106,7 +3106,7 @@
     },
     "node_modules/acorn-jsx": {
       "version": "5.3.2",
-      "resolved": "https://registry.npmmirror.com/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
       "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
       "dev": true,
       "peerDependencies": {
@@ -5681,7 +5681,7 @@
     },
     "node_modules/eslint": {
       "version": "8.26.0",
-      "resolved": "https://registry.npmmirror.com/eslint/-/eslint-8.26.0.tgz",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.26.0.tgz",
       "integrity": "sha512-kzJkpaw1Bfwheq4VXUezFriD1GxszX6dUekM7Z3aC2o4hju+tsR/XyTC3RcoSD7jmy9VkPU3+N6YjVU2e96Oyg==",
       "dev": true,
       "dependencies": {
@@ -6038,7 +6038,7 @@
     },
     "node_modules/eslint/node_modules/eslint-scope": {
       "version": "7.1.1",
-      "resolved": "https://registry.npmmirror.com/eslint-scope/-/eslint-scope-7.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.1.1.tgz",
       "integrity": "sha512-QKQM/UXpIiHcLqJ5AOyIW7XZmzjkzQXYE54n1++wb0u9V/abW3l9uQnxX8Z5Xd18xyKIMTUAyQ0k1e8pz6LUrw==",
       "dev": true,
       "dependencies": {
@@ -6051,7 +6051,7 @@
     },
     "node_modules/eslint/node_modules/estraverse": {
       "version": "5.3.0",
-      "resolved": "https://registry.npmmirror.com/estraverse/-/estraverse-5.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
       "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
       "dev": true,
       "engines": {
@@ -6060,7 +6060,7 @@
     },
     "node_modules/eslint/node_modules/find-up": {
       "version": "5.0.0",
-      "resolved": "https://registry.npmmirror.com/find-up/-/find-up-5.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
       "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
       "dev": true,
       "dependencies": {
@@ -6073,7 +6073,7 @@
     },
     "node_modules/eslint/node_modules/globals": {
       "version": "13.17.0",
-      "resolved": "https://registry.npmmirror.com/globals/-/globals-13.17.0.tgz",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-13.17.0.tgz",
       "integrity": "sha512-1C+6nQRb1GwGMKm2dH/E7enFAMxGTmGI7/dEdhy/DNelv85w9B72t3uc5frtMNXIbzrarJJ/lTCjcaZwbLJmyw==",
       "dev": true,
       "dependencies": {
@@ -6094,7 +6094,7 @@
     },
     "node_modules/eslint/node_modules/is-path-inside": {
       "version": "3.0.3",
-      "resolved": "https://registry.npmmirror.com/is-path-inside/-/is-path-inside-3.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.3.tgz",
       "integrity": "sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==",
       "dev": true,
       "engines": {
@@ -6103,7 +6103,7 @@
     },
     "node_modules/eslint/node_modules/locate-path": {
       "version": "6.0.0",
-      "resolved": "https://registry.npmmirror.com/locate-path/-/locate-path-6.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
       "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
       "dev": true,
       "dependencies": {
@@ -6115,7 +6115,7 @@
     },
     "node_modules/eslint/node_modules/p-limit": {
       "version": "3.1.0",
-      "resolved": "https://registry.npmmirror.com/p-limit/-/p-limit-3.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
       "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
       "dev": true,
       "dependencies": {
@@ -6127,7 +6127,7 @@
     },
     "node_modules/eslint/node_modules/p-locate": {
       "version": "5.0.0",
-      "resolved": "https://registry.npmmirror.com/p-locate/-/p-locate-5.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
       "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
       "dev": true,
       "dependencies": {
@@ -6139,7 +6139,7 @@
     },
     "node_modules/eslint/node_modules/path-exists": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmmirror.com/path-exists/-/path-exists-4.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
       "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
       "dev": true,
       "engines": {
@@ -6160,7 +6160,7 @@
     },
     "node_modules/eslint/node_modules/type-fest": {
       "version": "0.20.2",
-      "resolved": "https://registry.npmmirror.com/type-fest/-/type-fest-0.20.2.tgz",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
       "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
       "dev": true,
       "engines": {
@@ -6169,7 +6169,7 @@
     },
     "node_modules/espree": {
       "version": "9.4.0",
-      "resolved": "https://registry.npmmirror.com/espree/-/espree-9.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-9.4.0.tgz",
       "integrity": "sha512-DQmnRpLj7f6TgN/NYb0MTzJXL+vJF9h3pHy4JhCIs3zwcgez8xmGg3sXHcEO97BrmO2OSvCwMdfdlyl+E9KjOw==",
       "dev": true,
       "dependencies": {
@@ -6183,7 +6183,7 @@
     },
     "node_modules/espree/node_modules/acorn": {
       "version": "8.8.1",
-      "resolved": "https://registry.npmmirror.com/acorn/-/acorn-8.8.1.tgz",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.1.tgz",
       "integrity": "sha512-7zFpHzhnqYKrkYdUjF1HI1bzd0VygEGX8lFk4k5zVMqHEoES+P+7TKI+EvLO9WVMJ8eekdO0aDEK044xTXwPPA==",
       "dev": true,
       "bin": {
@@ -7374,7 +7374,7 @@
     },
     "node_modules/grapheme-splitter": {
       "version": "1.0.4",
-      "resolved": "https://registry.npmmirror.com/grapheme-splitter/-/grapheme-splitter-1.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/grapheme-splitter/-/grapheme-splitter-1.0.4.tgz",
       "integrity": "sha512-bzh50DW9kTPM00T8y4o8vQg89Di9oLJVLW/KaOGIXJWP/iqCN6WKYkbNOF04vFLJhwcpYUh9ydh/+5vpOqV4YQ==",
       "dev": true
     },
@@ -8974,7 +8974,7 @@
     },
     "node_modules/js-sdsl": {
       "version": "4.1.5",
-      "resolved": "https://registry.npmmirror.com/js-sdsl/-/js-sdsl-4.1.5.tgz",
+      "resolved": "https://registry.npmjs.org/js-sdsl/-/js-sdsl-4.1.5.tgz",
       "integrity": "sha512-08bOAKweV2NUC1wqTtf3qZlnpOX/R2DU9ikpjOHs0H+ibQv3zpncVQg6um4uYtRtrwIX8M4Nh3ytK4HGlYAq7Q==",
       "dev": true
     },
@@ -8986,7 +8986,7 @@
     },
     "node_modules/js-yaml": {
       "version": "4.1.0",
-      "resolved": "https://registry.npmmirror.com/js-yaml/-/js-yaml-4.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
       "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
       "dev": true,
       "dependencies": {
@@ -8998,7 +8998,7 @@
     },
     "node_modules/js-yaml/node_modules/argparse": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmmirror.com/argparse/-/argparse-2.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "dev": true
     },
@@ -17351,13 +17351,13 @@
     },
     "@dprint/typescript": {
       "version": "0.75.0",
-      "resolved": "https://registry.npmmirror.com/@dprint/typescript/-/typescript-0.75.0.tgz",
+      "resolved": "https://registry.npmjs.org/@dprint/typescript/-/typescript-0.75.0.tgz",
       "integrity": "sha512-66Io2E2rHIJ8s6eiQfyXe7eGI7bmQac/njkq50IcUMboCRIftfJmXCQOKqjpB14pGnNvwPCNvMInsTS70NpFAQ==",
       "dev": true
     },
     "@eslint/eslintrc": {
       "version": "1.3.3",
-      "resolved": "https://registry.npmmirror.com/@eslint/eslintrc/-/eslintrc-1.3.3.tgz",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.3.3.tgz",
       "integrity": "sha512-uj3pT6Mg+3t39fvLrj8iuCIJ38zKO9FpGtJ4BBJebJhEwjoT+KLVNCcHT5QC9NGRIEi7fZ0ZR8YRb884auB4Lg==",
       "dev": true,
       "requires": {
@@ -17374,7 +17374,7 @@
       "dependencies": {
         "globals": {
           "version": "13.17.0",
-          "resolved": "https://registry.npmmirror.com/globals/-/globals-13.17.0.tgz",
+          "resolved": "https://registry.npmjs.org/globals/-/globals-13.17.0.tgz",
           "integrity": "sha512-1C+6nQRb1GwGMKm2dH/E7enFAMxGTmGI7/dEdhy/DNelv85w9B72t3uc5frtMNXIbzrarJJ/lTCjcaZwbLJmyw==",
           "dev": true,
           "requires": {
@@ -17383,7 +17383,7 @@
         },
         "type-fest": {
           "version": "0.20.2",
-          "resolved": "https://registry.npmmirror.com/type-fest/-/type-fest-0.20.2.tgz",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
           "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
           "dev": true
         }
@@ -17412,7 +17412,7 @@
     },
     "@humanwhocodes/config-array": {
       "version": "0.11.7",
-      "resolved": "https://registry.npmmirror.com/@humanwhocodes/config-array/-/config-array-0.11.7.tgz",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.7.tgz",
       "integrity": "sha512-kBbPWzN8oVMLb0hOUYXhmxggL/1cJE6ydvjDIGi9EnAGUyA7cLVKQg+d/Dsm+KZwx2czGHrCmMVLiyg8s5JPKw==",
       "dev": true,
       "requires": {
@@ -17423,13 +17423,13 @@
     },
     "@humanwhocodes/module-importer": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmmirror.com/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
       "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
       "dev": true
     },
     "@humanwhocodes/object-schema": {
       "version": "1.2.1",
-      "resolved": "https://registry.npmmirror.com/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz",
       "integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==",
       "dev": true
     },
@@ -18497,7 +18497,7 @@
     },
     "acorn-jsx": {
       "version": "5.3.2",
-      "resolved": "https://registry.npmmirror.com/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
       "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
       "dev": true,
       "requires": {}
@@ -20411,7 +20411,7 @@
     },
     "eslint": {
       "version": "8.26.0",
-      "resolved": "https://registry.npmmirror.com/eslint/-/eslint-8.26.0.tgz",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.26.0.tgz",
       "integrity": "sha512-kzJkpaw1Bfwheq4VXUezFriD1GxszX6dUekM7Z3aC2o4hju+tsR/XyTC3RcoSD7jmy9VkPU3+N6YjVU2e96Oyg==",
       "dev": true,
       "requires": {
@@ -20498,7 +20498,7 @@
         },
         "eslint-scope": {
           "version": "7.1.1",
-          "resolved": "https://registry.npmmirror.com/eslint-scope/-/eslint-scope-7.1.1.tgz",
+          "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.1.1.tgz",
           "integrity": "sha512-QKQM/UXpIiHcLqJ5AOyIW7XZmzjkzQXYE54n1++wb0u9V/abW3l9uQnxX8Z5Xd18xyKIMTUAyQ0k1e8pz6LUrw==",
           "dev": true,
           "requires": {
@@ -20508,13 +20508,13 @@
         },
         "estraverse": {
           "version": "5.3.0",
-          "resolved": "https://registry.npmmirror.com/estraverse/-/estraverse-5.3.0.tgz",
+          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
           "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
           "dev": true
         },
         "find-up": {
           "version": "5.0.0",
-          "resolved": "https://registry.npmmirror.com/find-up/-/find-up-5.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
           "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
           "dev": true,
           "requires": {
@@ -20524,7 +20524,7 @@
         },
         "globals": {
           "version": "13.17.0",
-          "resolved": "https://registry.npmmirror.com/globals/-/globals-13.17.0.tgz",
+          "resolved": "https://registry.npmjs.org/globals/-/globals-13.17.0.tgz",
           "integrity": "sha512-1C+6nQRb1GwGMKm2dH/E7enFAMxGTmGI7/dEdhy/DNelv85w9B72t3uc5frtMNXIbzrarJJ/lTCjcaZwbLJmyw==",
           "dev": true,
           "requires": {
@@ -20539,13 +20539,13 @@
         },
         "is-path-inside": {
           "version": "3.0.3",
-          "resolved": "https://registry.npmmirror.com/is-path-inside/-/is-path-inside-3.0.3.tgz",
+          "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.3.tgz",
           "integrity": "sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==",
           "dev": true
         },
         "locate-path": {
           "version": "6.0.0",
-          "resolved": "https://registry.npmmirror.com/locate-path/-/locate-path-6.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
           "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
           "dev": true,
           "requires": {
@@ -20554,7 +20554,7 @@
         },
         "p-limit": {
           "version": "3.1.0",
-          "resolved": "https://registry.npmmirror.com/p-limit/-/p-limit-3.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
           "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
           "dev": true,
           "requires": {
@@ -20563,7 +20563,7 @@
         },
         "p-locate": {
           "version": "5.0.0",
-          "resolved": "https://registry.npmmirror.com/p-locate/-/p-locate-5.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
           "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
           "dev": true,
           "requires": {
@@ -20572,7 +20572,7 @@
         },
         "path-exists": {
           "version": "4.0.0",
-          "resolved": "https://registry.npmmirror.com/path-exists/-/path-exists-4.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
           "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
           "dev": true
         },
@@ -20587,7 +20587,7 @@
         },
         "type-fest": {
           "version": "0.20.2",
-          "resolved": "https://registry.npmmirror.com/type-fest/-/type-fest-0.20.2.tgz",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
           "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
           "dev": true
         }
@@ -20782,7 +20782,7 @@
     },
     "espree": {
       "version": "9.4.0",
-      "resolved": "https://registry.npmmirror.com/espree/-/espree-9.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-9.4.0.tgz",
       "integrity": "sha512-DQmnRpLj7f6TgN/NYb0MTzJXL+vJF9h3pHy4JhCIs3zwcgez8xmGg3sXHcEO97BrmO2OSvCwMdfdlyl+E9KjOw==",
       "dev": true,
       "requires": {
@@ -20793,7 +20793,7 @@
       "dependencies": {
         "acorn": {
           "version": "8.8.1",
-          "resolved": "https://registry.npmmirror.com/acorn/-/acorn-8.8.1.tgz",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.1.tgz",
           "integrity": "sha512-7zFpHzhnqYKrkYdUjF1HI1bzd0VygEGX8lFk4k5zVMqHEoES+P+7TKI+EvLO9WVMJ8eekdO0aDEK044xTXwPPA==",
           "dev": true
         }
@@ -21689,7 +21689,7 @@
     },
     "grapheme-splitter": {
       "version": "1.0.4",
-      "resolved": "https://registry.npmmirror.com/grapheme-splitter/-/grapheme-splitter-1.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/grapheme-splitter/-/grapheme-splitter-1.0.4.tgz",
       "integrity": "sha512-bzh50DW9kTPM00T8y4o8vQg89Di9oLJVLW/KaOGIXJWP/iqCN6WKYkbNOF04vFLJhwcpYUh9ydh/+5vpOqV4YQ==",
       "dev": true
     },
@@ -22810,7 +22810,7 @@
     },
     "js-sdsl": {
       "version": "4.1.5",
-      "resolved": "https://registry.npmmirror.com/js-sdsl/-/js-sdsl-4.1.5.tgz",
+      "resolved": "https://registry.npmjs.org/js-sdsl/-/js-sdsl-4.1.5.tgz",
       "integrity": "sha512-08bOAKweV2NUC1wqTtf3qZlnpOX/R2DU9ikpjOHs0H+ibQv3zpncVQg6um4uYtRtrwIX8M4Nh3ytK4HGlYAq7Q==",
       "dev": true
     },
@@ -22822,7 +22822,7 @@
     },
     "js-yaml": {
       "version": "4.1.0",
-      "resolved": "https://registry.npmmirror.com/js-yaml/-/js-yaml-4.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
       "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
       "dev": true,
       "requires": {
@@ -22831,7 +22831,7 @@
       "dependencies": {
         "argparse": {
           "version": "2.0.1",
-          "resolved": "https://registry.npmmirror.com/argparse/-/argparse-2.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
           "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
           "dev": true
         }

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "@babel/preset-env": "^7.14.5",
     "@babel/preset-typescript": "^7.14.5",
     "@babel/types": "^7.16.0",
+    "@dprint/json": "^0.16.0",
     "@dprint/typescript": "^0.75.0",
     "@types/argparse": "^1.0.38",
     "@types/chai": "^4.3.1",


### PR DESCRIPTION
`@dprint/json` just released a new version, dprint now can use plugin downloaded by npm