### PR TITLE
lint: add rule for string substr

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -192,6 +192,7 @@ const rules = {
     'error',
     'never',
   ],
+  'unicorn/prefer-string-slice': 'error',
   'valid-jsdoc': 'off',
 };
 
@@ -207,7 +208,7 @@ const tsOverrides = {
     'project': ['./tsconfig.json'],
     'tsconfigRootDir': __dirname,
   },
-  'plugins': ['@typescript-eslint', 'prefer-arrow'],
+  'plugins': ['@typescript-eslint', 'prefer-arrow', 'unicorn'],
   'rules': {
     '@typescript-eslint/consistent-type-assertions': [
       'error',
@@ -237,6 +238,7 @@ const tsOverrides = {
     '@typescript-eslint/no-unsafe-argument': 'error',
     '@typescript-eslint/no-unused-vars': ['warn', { 'args': 'all', 'argsIgnorePattern': '^_\\w?' }],
     '@typescript-eslint/object-curly-spacing': ['warn', 'always'],
+    '@typescript-eslint/prefer-string-starts-ends-with': 'error',
     '@typescript-eslint/strict-boolean-expressions': ['error', {
       // @TODO: Remove these keys over time, setting them back to default
       'allowNullableBoolean': true,

--- a/package-lock.json
+++ b/package-lock.json
@@ -60,6 +60,7 @@
         "eslint-plugin-prefer-arrow": "^1.2.3",
         "eslint-plugin-rulesdir": "^0.2.1",
         "eslint-plugin-tsc": "^2.0.0",
+        "eslint-plugin-unicorn": "^44.0.2",
         "fast-levenshtein": "^3.0.0",
         "fork-ts-checker-webpack-plugin": "^7.2.11",
         "fs-extra": "^10.1.0",
@@ -490,9 +491,9 @@
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.16.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.16.7.tgz",
-      "integrity": "sha512-hsEnFemeiW4D08A5gUAZxLBTXpZ39P+a+DGDsHw1yxqyQ/jzFEnxf5uTEGp+3bzAbNOxU1paTgYS4ECU/IgfDw==",
+      "version": "7.19.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.19.1.tgz",
+      "integrity": "sha512-awrNfaMtnHUr653GgGEs++LlAvW6w+DcPrOliSMXWCKo597CwL5Acf/wWdNkf/tfEQE3mjkeD1YOVZOUV/od1w==",
       "dev": true,
       "engines": {
         "node": ">=6.9.0"
@@ -3718,6 +3719,18 @@
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
       "dev": true
     },
+    "node_modules/builtin-modules": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-3.3.0.tgz",
+      "integrity": "sha512-zhaCDicdLuWN5UbN5IMnFqNMhNfo919sH85y2/ea+5Yg9TsTkeZxpL+JLbp6cgYFS4sRLp3YV4S6yDuqVWHYOw==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/bytes": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
@@ -3959,9 +3972,9 @@
       }
     },
     "node_modules/ci-info": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.3.0.tgz",
-      "integrity": "sha512-riT/3vI5YpVH6/qomlDnJow6TBee2PBKSEpx3O32EGPYbWGIRsIlGRms3Sm74wYE1JMo8RnO04Hb12+v1J5ICw==",
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.5.0.tgz",
+      "integrity": "sha512-yH4RezKOGlOhxkmhbeNuC4eYZKAUsEaGtBuBzDDP1eFUKiccDWzBABxBfOx31IDwDIXMTxWuwAxUGModvkbuVw==",
       "dev": true
     },
     "node_modules/clean-css": {
@@ -3974,6 +3987,18 @@
       },
       "engines": {
         "node": ">= 10.0"
+      }
+    },
+    "node_modules/clean-regexp": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/clean-regexp/-/clean-regexp-1.0.0.tgz",
+      "integrity": "sha512-GfisEZEJvzKrmGWkvfhgzcz/BllN1USeqD2V6tg14OAOgaCD2Z/PUEuxnAZ/nPvmaHRG7a8y77p1T/IRQ4D1Hw==",
+      "dev": true,
+      "dependencies": {
+        "escape-string-regexp": "^1.0.5"
+      },
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/clean-stack": {
@@ -5925,6 +5950,70 @@
         "node": ">=12",
         "npm": ">=6"
       }
+    },
+    "node_modules/eslint-plugin-unicorn": {
+      "version": "44.0.2",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-unicorn/-/eslint-plugin-unicorn-44.0.2.tgz",
+      "integrity": "sha512-GLIDX1wmeEqpGaKcnMcqRvMVsoabeF0Ton0EX4Th5u6Kmf7RM9WBl705AXFEsns56ESkEs0uyelLuUTvz9Tr0w==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.19.1",
+        "ci-info": "^3.4.0",
+        "clean-regexp": "^1.0.0",
+        "eslint-utils": "^3.0.0",
+        "esquery": "^1.4.0",
+        "indent-string": "^4.0.0",
+        "is-builtin-module": "^3.2.0",
+        "lodash": "^4.17.21",
+        "pluralize": "^8.0.0",
+        "read-pkg-up": "^7.0.1",
+        "regexp-tree": "^0.1.24",
+        "safe-regex": "^2.1.1",
+        "semver": "^7.3.7",
+        "strip-indent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=14.18"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/eslint-plugin-unicorn?sponsor=1"
+      },
+      "peerDependencies": {
+        "eslint": ">=8.23.1"
+      }
+    },
+    "node_modules/eslint-plugin-unicorn/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dev": true,
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/eslint-plugin-unicorn/node_modules/semver": {
+      "version": "7.3.8",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
+      "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/eslint-plugin-unicorn/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "dev": true
     },
     "node_modules/eslint-scope": {
       "version": "5.1.1",
@@ -8565,6 +8654,21 @@
       ],
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/is-builtin-module": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-3.2.0.tgz",
+      "integrity": "sha512-phDA4oSGt7vl1n5tJvTWooWWAsXLY+2xCnxNqvKhGEzujg+A43wPlPOyDg3C8XQHN+6k/JTQWJ/j0dQh/qr+Hw==",
+      "dev": true,
+      "dependencies": {
+        "builtin-modules": "^3.3.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-callable": {
@@ -11955,6 +12059,15 @@
         "semver-compare": "^1.0.0"
       }
     },
+    "node_modules/pluralize": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-8.0.0.tgz",
+      "integrity": "sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/postcss": {
       "version": "8.4.13",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.13.tgz",
@@ -12944,6 +13057,15 @@
         "@babel/runtime": "^7.8.4"
       }
     },
+    "node_modules/regexp-tree": {
+      "version": "0.1.24",
+      "resolved": "https://registry.npmjs.org/regexp-tree/-/regexp-tree-0.1.24.tgz",
+      "integrity": "sha512-s2aEVuLhvnVJW6s/iPgEGK6R+/xngd2jNQ+xy4bXNDKxZKJH6jpPHY6kVeVv1IeLCHgswRj+Kl3ELaDjG6V1iw==",
+      "dev": true,
+      "bin": {
+        "regexp-tree": "bin/regexp-tree"
+      }
+    },
     "node_modules/regexp.prototype.flags": {
       "version": "1.4.3",
       "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.4.3.tgz",
@@ -13317,6 +13439,15 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+    },
+    "node_modules/safe-regex": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-2.1.1.tgz",
+      "integrity": "sha512-rx+x8AMzKb5Q5lQ95Zoi6ZbJqwCLkqi3XuJXp5P3rT8OEc6sZCJG5AE5dU3lsgRr/F4Bs31jSlVN+j5KrsGu9A==",
+      "dev": true,
+      "dependencies": {
+        "regexp-tree": "~0.1.1"
+      }
     },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
@@ -16473,9 +16604,9 @@
       }
     },
     "@babel/helper-validator-identifier": {
-      "version": "7.16.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.16.7.tgz",
-      "integrity": "sha512-hsEnFemeiW4D08A5gUAZxLBTXpZ39P+a+DGDsHw1yxqyQ/jzFEnxf5uTEGp+3bzAbNOxU1paTgYS4ECU/IgfDw==",
+      "version": "7.19.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.19.1.tgz",
+      "integrity": "sha512-awrNfaMtnHUr653GgGEs++LlAvW6w+DcPrOliSMXWCKo597CwL5Acf/wWdNkf/tfEQE3mjkeD1YOVZOUV/od1w==",
       "dev": true
     },
     "@babel/helper-validator-option": {
@@ -18949,6 +19080,12 @@
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
       "dev": true
     },
+    "builtin-modules": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-3.3.0.tgz",
+      "integrity": "sha512-zhaCDicdLuWN5UbN5IMnFqNMhNfo919sH85y2/ea+5Yg9TsTkeZxpL+JLbp6cgYFS4sRLp3YV4S6yDuqVWHYOw==",
+      "dev": true
+    },
     "bytes": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
@@ -19122,9 +19259,9 @@
       "dev": true
     },
     "ci-info": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.3.0.tgz",
-      "integrity": "sha512-riT/3vI5YpVH6/qomlDnJow6TBee2PBKSEpx3O32EGPYbWGIRsIlGRms3Sm74wYE1JMo8RnO04Hb12+v1J5ICw==",
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.5.0.tgz",
+      "integrity": "sha512-yH4RezKOGlOhxkmhbeNuC4eYZKAUsEaGtBuBzDDP1eFUKiccDWzBABxBfOx31IDwDIXMTxWuwAxUGModvkbuVw==",
       "dev": true
     },
     "clean-css": {
@@ -19134,6 +19271,15 @@
       "dev": true,
       "requires": {
         "source-map": "~0.6.0"
+      }
+    },
+    "clean-regexp": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/clean-regexp/-/clean-regexp-1.0.0.tgz",
+      "integrity": "sha512-GfisEZEJvzKrmGWkvfhgzcz/BllN1USeqD2V6tg14OAOgaCD2Z/PUEuxnAZ/nPvmaHRG7a8y77p1T/IRQ4D1Hw==",
+      "dev": true,
+      "requires": {
+        "escape-string-regexp": "^1.0.5"
       }
     },
     "clean-stack": {
@@ -20745,6 +20891,54 @@
       "dev": true,
       "requires": {
         "typescript-service": "^2.0.3"
+      }
+    },
+    "eslint-plugin-unicorn": {
+      "version": "44.0.2",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-unicorn/-/eslint-plugin-unicorn-44.0.2.tgz",
+      "integrity": "sha512-GLIDX1wmeEqpGaKcnMcqRvMVsoabeF0Ton0EX4Th5u6Kmf7RM9WBl705AXFEsns56ESkEs0uyelLuUTvz9Tr0w==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-validator-identifier": "^7.19.1",
+        "ci-info": "^3.4.0",
+        "clean-regexp": "^1.0.0",
+        "eslint-utils": "^3.0.0",
+        "esquery": "^1.4.0",
+        "indent-string": "^4.0.0",
+        "is-builtin-module": "^3.2.0",
+        "lodash": "^4.17.21",
+        "pluralize": "^8.0.0",
+        "read-pkg-up": "^7.0.1",
+        "regexp-tree": "^0.1.24",
+        "safe-regex": "^2.1.1",
+        "semver": "^7.3.7",
+        "strip-indent": "^3.0.0"
+      },
+      "dependencies": {
+        "lru-cache": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+          "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+          "dev": true,
+          "requires": {
+            "yallist": "^4.0.0"
+          }
+        },
+        "semver": {
+          "version": "7.3.8",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
+          "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
+          "dev": true,
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
+        },
+        "yallist": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+          "dev": true
+        }
       }
     },
     "eslint-scope": {
@@ -22537,6 +22731,15 @@
       "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.5.tgz",
       "integrity": "sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ==",
       "dev": true
+    },
+    "is-builtin-module": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-3.2.0.tgz",
+      "integrity": "sha512-phDA4oSGt7vl1n5tJvTWooWWAsXLY+2xCnxNqvKhGEzujg+A43wPlPOyDg3C8XQHN+6k/JTQWJ/j0dQh/qr+Hw==",
+      "dev": true,
+      "requires": {
+        "builtin-modules": "^3.3.0"
+      }
     },
     "is-callable": {
       "version": "1.2.4",
@@ -25038,6 +25241,12 @@
         "semver-compare": "^1.0.0"
       }
     },
+    "pluralize": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-8.0.0.tgz",
+      "integrity": "sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA==",
+      "dev": true
+    },
     "postcss": {
       "version": "8.4.13",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.13.tgz",
@@ -25728,6 +25937,12 @@
         "@babel/runtime": "^7.8.4"
       }
     },
+    "regexp-tree": {
+      "version": "0.1.24",
+      "resolved": "https://registry.npmjs.org/regexp-tree/-/regexp-tree-0.1.24.tgz",
+      "integrity": "sha512-s2aEVuLhvnVJW6s/iPgEGK6R+/xngd2jNQ+xy4bXNDKxZKJH6jpPHY6kVeVv1IeLCHgswRj+Kl3ELaDjG6V1iw==",
+      "dev": true
+    },
     "regexp.prototype.flags": {
       "version": "1.4.3",
       "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.4.3.tgz",
@@ -25999,6 +26214,15 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+    },
+    "safe-regex": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-2.1.1.tgz",
+      "integrity": "sha512-rx+x8AMzKb5Q5lQ95Zoi6ZbJqwCLkqi3XuJXp5P3rT8OEc6sZCJG5AE5dU3lsgRr/F4Bs31jSlVN+j5KrsGu9A==",
+      "dev": true,
+      "requires": {
+        "regexp-tree": "~0.1.1"
+      }
     },
     "safer-buffer": {
       "version": "2.1.2",

--- a/package.json
+++ b/package.json
@@ -83,6 +83,7 @@
     "eslint-plugin-prefer-arrow": "^1.2.3",
     "eslint-plugin-rulesdir": "^0.2.1",
     "eslint-plugin-tsc": "^2.0.0",
+    "eslint-plugin-unicorn": "^44.0.2",
     "fast-levenshtein": "^3.0.0",
     "fork-ts-checker-webpack-plugin": "^7.2.11",
     "fs-extra": "^10.1.0",

--- a/resources/datetime.ts
+++ b/resources/datetime.ts
@@ -6,7 +6,7 @@ const tzOffsetMap: { [key: string]: number } = {};
 
 export default class DateTimeFuncs {
   static getTimezoneOffsetMillis(timeString: string): number {
-    const timezoneOffsetString = timeString.slice(timeString.length - 6);
+    const timezoneOffsetString = timeString.slice(-6);
     const mappedValue = tzOffsetMap[timezoneOffsetString];
     if (mappedValue)
       return mappedValue;

--- a/resources/datetime.ts
+++ b/resources/datetime.ts
@@ -34,9 +34,9 @@ export default class DateTimeFuncs {
     const millisNum = time % 1000;
     const secsNum = (time % (60 * 1000) - millisNum) / 1000;
     // Milliseconds
-    const millis = `00${millisNum}`.substr(-3);
-    const secs = `0${secsNum}`.substr(-2);
-    const mins = `0${((time % (60 * 60 * 1000) - millisNum) / 1000 - secsNum) / 60}`.substr(-2);
+    const millis = `00${millisNum}`.slice(-3);
+    const secs = `0${secsNum}`.slice(-2);
+    const mins = `0${((time % (60 * 60 * 1000) - millisNum) / 1000 - secsNum) / 60}`.slice(-2);
     return negative + mins + ':' + secs + (includeMillis ? '.' + millis : '');
   }
 

--- a/resources/datetime.ts
+++ b/resources/datetime.ts
@@ -13,10 +13,10 @@ export default class DateTimeFuncs {
     const defaultOffset = new Date().getTimezoneOffset() * 1000;
     if (timezoneOffsetString === undefined)
       return defaultOffset;
-    const operator = timezoneOffsetString.substr(0, 1);
+    const operator = timezoneOffsetString[0];
     if (operator !== '+' && operator !== '-')
       return defaultOffset;
-    const timezoneOffsetParts = timezoneOffsetString.substr(1).split(':');
+    const timezoneOffsetParts = timezoneOffsetString.slice(1).split(':');
     const hoursString = timezoneOffsetParts[0];
     const minutesString = timezoneOffsetParts[1];
     if (hoursString === undefined || minutesString === undefined)

--- a/resources/datetime.ts
+++ b/resources/datetime.ts
@@ -6,7 +6,7 @@ const tzOffsetMap: { [key: string]: number } = {};
 
 export default class DateTimeFuncs {
   static getTimezoneOffsetMillis(timeString: string): number {
-    const timezoneOffsetString = timeString.substr(-6);
+    const timezoneOffsetString = timeString.slice(timeString.length - 6);
     const mappedValue = tzOffsetMap[timezoneOffsetString];
     if (mappedValue)
       return mappedValue;

--- a/resources/languages.ts
+++ b/resources/languages.ts
@@ -75,7 +75,7 @@ export const langToLocale = (lang: Lang): string => {
 
 export const browserLanguagesToLang = (languages: readonly string[]): Lang => {
   const lang = [...navigator.languages, 'en']
-    .map((l) => l.substring(0, 2))
+    .map((l) => l.slice(0, 2))
     // Remap `zh` to `cn` to match cactbot languages
     .map((l) => l === 'zh' ? 'cn' : l)
     .filter((l) => languages.includes(l))[0];

--- a/resources/responses.ts
+++ b/resources/responses.ts
@@ -148,7 +148,7 @@ const combineFuncs = function(
 };
 
 const isPlayerId = (id?: string) => {
-  return id !== undefined && id[0] !== '4';
+  return id !== undefined && !id.startsWith('4');
 };
 
 // For responses that unconditionally return static text.

--- a/resources/stringhandlers.ts
+++ b/resources/stringhandlers.ts
@@ -5,7 +5,7 @@ class StringFuncs {
 
   static toProperCase(str: string): string {
     return str.replace(/([^\W_]+[^\s-]*) */g, (txt) => {
-      return txt.charAt(0).toUpperCase() + txt.substr(1).toLowerCase();
+      return txt.charAt(0).toUpperCase() + txt.slice(1).toLowerCase();
     });
   }
 

--- a/resources/user_config.ts
+++ b/resources/user_config.ts
@@ -270,7 +270,7 @@ class UserConfig {
       // System Language
       if (e.detail.systemLocale) {
         options.SystemLocale = e.detail.systemLocale;
-        let shortLocale = e.detail.systemLocale.substring(0, 2);
+        let shortLocale = e.detail.systemLocale.slice(0, 2);
         if (shortLocale === 'zh')
           shortLocale = 'cn';
         if (isLang(shortLocale))

--- a/test/helper/test_manifest.ts
+++ b/test/helper/test_manifest.ts
@@ -52,7 +52,7 @@ const testManifestFile = (file: string) => {
   it('correct file types in manifest', () => {
     for (const file of manifestLines) {
       // All files must be .js/.ts and .txt.
-      if (/\.txt$/.test(file) || /\.[jt]s$/.test(file))
+      if (file.endsWith('.txt') || file.endsWith('.ts') || file.endsWith('.js'))
         continue;
       assert.fail(`${file} has invalid extension`);
     }

--- a/test/helper/test_trigger.ts
+++ b/test/helper/test_trigger.ts
@@ -269,7 +269,7 @@ const testTriggerFile = (file: string) => {
       // if prefix includes more than one word, just remove latter letters.
       if (prefix.includes(' '))
         prefix = prefix.slice(0, prefix.lastIndexOf(' ') + 1);
-      if (prefix[prefix.length - 1] !== ' ')
+      if (!prefix.endsWith(' '))
         assert.fail(`id prefix '${prefix}' is not a full word, must end in a space`);
     }
   });

--- a/test/helper/test_trigger.ts
+++ b/test/helper/test_trigger.ts
@@ -256,7 +256,7 @@ const testTriggerFile = (file: string) => {
           brokenPrefixes = true;
           continue;
         }
-        prefix = prefix.substr(0, idx);
+        prefix = prefix.slice(0, idx);
       }
     }
 
@@ -268,7 +268,7 @@ const testTriggerFile = (file: string) => {
     if (ids.size > 1 && !brokenPrefixes && prefix !== null && prefix.length > 0) {
       // if prefix includes more than one word, just remove latter letters.
       if (prefix.includes(' '))
-        prefix = prefix.substr(0, prefix.lastIndexOf(' ') + 1);
+        prefix = prefix.slice(0, prefix.lastIndexOf(' ') + 1);
       if (prefix[prefix.length - 1] !== ' ')
         assert.fail(`id prefix '${prefix}' is not a full word, must end in a space`);
     }

--- a/ui/oopsyraidsy/damage_tracker.ts
+++ b/ui/oopsyraidsy/damage_tracker.ts
@@ -319,7 +319,7 @@ export class DamageTracker {
     }
 
     // Length 1 or 2.
-    let lowByte = matches.flags.slice(matches.flags.length - 2);
+    let lowByte = matches.flags.slice(-2);
     if (lowByte.length === 1)
       lowByte = '0' + lowByte;
 

--- a/ui/oopsyraidsy/damage_tracker.ts
+++ b/ui/oopsyraidsy/damage_tracker.ts
@@ -319,7 +319,7 @@ export class DamageTracker {
     }
 
     // Length 1 or 2.
-    let lowByte = matches.flags.substr(-2);
+    let lowByte = matches.flags.slice(matches.flags.length - 2);
     if (lowByte.length === 1)
       lowByte = '0' + lowByte;
 

--- a/ui/oopsyraidsy/data/04-sb/dungeon/bardams_mettle.ts
+++ b/ui/oopsyraidsy/data/04-sb/dungeon/bardams_mettle.ts
@@ -18,7 +18,7 @@ const abilityWarn = (args: { abilityId: string; id: string }): OopsyTrigger<Data
     id: args.id,
     type: 'Ability',
     netRegex: NetRegexes.abilityFull({ id: args.abilityId }),
-    condition: (_data, matches) => matches.flags.substr(-2) === '0E',
+    condition: (_data, matches) => matches.flags.slice(matches.flags.length - 2) === '0E',
     mistake: (_data, matches) => {
       return {
         type: 'warn',

--- a/ui/oopsyraidsy/data/04-sb/dungeon/bardams_mettle.ts
+++ b/ui/oopsyraidsy/data/04-sb/dungeon/bardams_mettle.ts
@@ -18,7 +18,7 @@ const abilityWarn = (args: { abilityId: string; id: string }): OopsyTrigger<Data
     id: args.id,
     type: 'Ability',
     netRegex: NetRegexes.abilityFull({ id: args.abilityId }),
-    condition: (_data, matches) => matches.flags.slice(-2) === '0E',
+    condition: (_data, matches) => matches.flags.endsWith('0E'),
     mistake: (_data, matches) => {
       return {
         type: 'warn',

--- a/ui/oopsyraidsy/data/04-sb/dungeon/bardams_mettle.ts
+++ b/ui/oopsyraidsy/data/04-sb/dungeon/bardams_mettle.ts
@@ -18,7 +18,7 @@ const abilityWarn = (args: { abilityId: string; id: string }): OopsyTrigger<Data
     id: args.id,
     type: 'Ability',
     netRegex: NetRegexes.abilityFull({ id: args.abilityId }),
-    condition: (_data, matches) => matches.flags.slice(matches.flags.length - 2) === '0E',
+    condition: (_data, matches) => matches.flags.slice(-2) === '0E',
     mistake: (_data, matches) => {
       return {
         type: 'warn',

--- a/ui/oopsyraidsy/data/05-shb/eureka/delubrum_reginae.ts
+++ b/ui/oopsyraidsy/data/05-shb/eureka/delubrum_reginae.ts
@@ -87,7 +87,7 @@ const triggerSet: OopsyTriggerSet<Data> = {
         id: ['565A', '565B', '57FD', '57FE', '5B86', '5B87', '59D2', '5D93'],
         ...playerDamageFields,
       }),
-      condition: (_data, matches) => matches.flags.slice(-2) === '03',
+      condition: (_data, matches) => matches.flags.endsWith('03'),
       mistake: (_data, matches) => {
         return {
           type: 'warn',

--- a/ui/oopsyraidsy/data/05-shb/eureka/delubrum_reginae_savage.ts
+++ b/ui/oopsyraidsy/data/05-shb/eureka/delubrum_reginae_savage.ts
@@ -142,7 +142,7 @@ const triggerSet: OopsyTriggerSet<Data> = {
         id: ['5827', '5828', '5B6C', '5B6D', '5BB6', '5BB7', '5B88', '5B89'],
         ...playerDamageFields,
       }),
-      condition: (_data, matches) => matches.flags.slice(-2) === '03',
+      condition: (_data, matches) => matches.flags.endsWith('03'),
       mistake: (_data, matches) => {
         return { type: 'warn', blame: matches.target, text: matches.ability };
       },

--- a/ui/oopsyraidsy/death_report.ts
+++ b/ui/oopsyraidsy/death_report.ts
@@ -36,7 +36,7 @@ const processAbilityLine = (splitLine: string[]) => {
   }
 
   const amount = UnscrambleDamage(damage);
-  const lowByte = `00${flags}`.substr(-2);
+  const lowByte = `00${flags}`.slice(-2);
 
   return {
     amount: amount,
@@ -132,7 +132,7 @@ export class DeathReport {
     const deltaMs = timestamp - base;
     const prefix = deltaMs < 0 ? '-' : '';
     const deltaTotalSeconds = Math.round(Math.abs(deltaMs) / 1000);
-    const deltaSeconds = `00${deltaTotalSeconds % 60}`.substr(-2);
+    const deltaSeconds = `00${deltaTotalSeconds % 60}`.slice(-2);
     const deltaMinutes = Math.floor(deltaTotalSeconds / 60);
     return `${prefix}${deltaMinutes}:${deltaSeconds}`;
   }

--- a/ui/oopsyraidsy/oopsy_common.ts
+++ b/ui/oopsyraidsy/oopsy_common.ts
@@ -103,7 +103,7 @@ export const ShortNamify = (
     return nick;
 
   const idx = name.indexOf(' ');
-  return idx < 0 ? name : name.substr(0, idx);
+  return idx < 0 ? name : name.slice(0, idx);
 };
 
 export const Translate = (lang: Lang, obj?: LocaleText | string): string | undefined => {
@@ -131,7 +131,7 @@ export const UnscrambleDamage = (field?: string): number => {
   if (len <= 4)
     return 0;
   // Get the left two bytes as damage.
-  let damage = parseInt(field.substr(0, len - 4), 16);
+  let damage = parseInt(field.slice(0, len - 4), 16);
   // Check for third byte == 0x40.
   if (field[len - 4] === '4') {
     // Wrap in the 4th byte as extra damage.  See notes above.

--- a/ui/oopsyraidsy/oopsy_common.ts
+++ b/ui/oopsyraidsy/oopsy_common.ts
@@ -135,7 +135,7 @@ export const UnscrambleDamage = (field?: string): number => {
   // Check for third byte == 0x40.
   if (field[len - 4] === '4') {
     // Wrap in the 4th byte as extra damage.  See notes above.
-    const rightDamage = parseInt(field.substr(len - 2, 2), 16);
+    const rightDamage = parseInt(field.slice(len - 2, len), 16);
     damage = damage - rightDamage + (rightDamage << 16);
   }
   return damage;

--- a/ui/pullcounter/pullcounter.ts
+++ b/ui/pullcounter/pullcounter.ts
@@ -308,7 +308,7 @@ class PullCounter {
       const firstChar = word[0];
       if (firstChar === undefined)
         return '';
-      return firstChar.toUpperCase() + word.substr(1);
+      return firstChar.toUpperCase() + word.slice(1);
     }).join(' ');
 
     this.ReloadTriggers();

--- a/ui/raidboss/data/03-hw/dungeon/gubal_library_hard.ts
+++ b/ui/raidboss/data/03-hw/dungeon/gubal_library_hard.ts
@@ -43,8 +43,7 @@ const triggerSet: TriggerSet<Data> = {
       id: 'Gubal Hard Ferrofluid',
       type: 'HeadMarker',
       netRegex: { id: ['0030', '0031'] },
-      condition: (data, matches) =>
-        data.me === matches.target || matches.targetId.slice(0, 1) === '4',
+      condition: (data, matches) => data.me === matches.target || matches.targetId.startsWith('4'),
       preRun: (data, matches) => {
         data.markers ??= [];
         data.markers.push(matches.id);

--- a/ui/raidboss/data/04-sb/dungeon/ghimlyt_dark.ts
+++ b/ui/raidboss/data/04-sb/dungeon/ghimlyt_dark.ts
@@ -121,7 +121,7 @@ const triggerSet: TriggerSet<Data> = {
       id: 'Ghimlyt Dark Heirsbane',
       type: 'HeadMarker',
       netRegex: { id: '0001' },
-      condition: (_data, matches) => matches.targetId[0] !== '4',
+      condition: (_data, matches) => !matches.targetId.startsWith('4'),
       response: Responses.tankBuster(),
     },
     {

--- a/ui/raidboss/emulator/data/LogEventHandler.ts
+++ b/ui/raidboss/emulator/data/LogEventHandler.ts
@@ -49,7 +49,7 @@ Line Count: ${this.currentFight.length}
 `);
     void this.dispatch(
       'fight',
-      start.substr(0, 10),
+      start.slice(0, 10),
       this.currentZoneId,
       this.currentZoneName,
       this.currentFight,

--- a/ui/raidboss/emulator/data/network_log_converter/LineEvent.ts
+++ b/ui/raidboss/emulator/data/network_log_converter/LineEvent.ts
@@ -68,10 +68,10 @@ export default class LineEvent {
 
     damage = SFuncs.zeroPad(damage, 8);
     const parts = [
-      damage.substr(0, 2),
-      damage.substr(2, 2),
-      damage.substr(4, 2),
-      damage.substr(6, 2),
+      damage.slice(0, 2),
+      damage.slice(2, 4),
+      damage.slice(4, 6),
+      damage.slice(6, 8),
     ] as const;
 
     if (!LineEvent.isDamageBig(damage))

--- a/ui/raidboss/emulator/data/network_log_converter/LineEvent0x1F.ts
+++ b/ui/raidboss/emulator/data/network_log_converter/LineEvent0x1F.ts
@@ -5,10 +5,10 @@ import LineEvent from './LineEvent';
 import LogRepository from './LogRepository';
 
 const splitFunc = (s: string) => [
-  s.substr(6, 2),
-  s.substr(4, 2),
-  s.substr(2, 2),
-  s.substr(0, 2),
+  s.slice(6, 8),
+  s.slice(4, 6),
+  s.slice(2, 4),
+  s.slice(0, 2),
 ];
 
 const fields = logDefinitions.NetworkGauge.fields;

--- a/ui/raidboss/emulator/data/network_log_converter/LineEvent0x26.ts
+++ b/ui/raidboss/emulator/data/network_log_converter/LineEvent0x26.ts
@@ -47,11 +47,11 @@ export class LineEvent0x26 extends LineEvent implements LineEventSource, LineEve
 
     const padded = SFuncs.zeroPad(this.jobLevelData, 8);
 
-    this.jobIdHex = padded.substr(6, 2).toUpperCase();
+    this.jobIdHex = padded.slice(6, 8).toUpperCase();
     this.jobId = parseInt(this.jobIdHex, 16);
     this.job = Util.jobEnumToJob(this.jobId);
 
-    this.level = parseInt(padded.substr(4, 2), 16);
+    this.level = parseInt(padded.slice(4, 6), 16);
   }
 }
 

--- a/ui/raidboss/popup-text.ts
+++ b/ui/raidboss/popup-text.ts
@@ -915,7 +915,7 @@ export class PopupText {
       return nick;
 
     const idx = name.indexOf(' ');
-    return idx < 0 ? name : name.slice(0, Math.max(0, idx));
+    return idx < 0 ? name : name.slice(0, idx);
   }
 
   Reset(): void {

--- a/ui/raidboss/popup-text.ts
+++ b/ui/raidboss/popup-text.ts
@@ -806,7 +806,7 @@ export class PopupText {
       // And set the timeline files/timelines from each set that matches.
       if (set.timelineFile) {
         if (set.filename) {
-          const dir = set.filename.substring(0, set.filename.lastIndexOf('/'));
+          const dir = set.filename.slice(0, Math.max(0, set.filename.lastIndexOf('/')));
           timelineFiles.push(dir + '/' + set.timelineFile);
         } else {
           // Note: For user files, this should get handled by raidboss_config.js,

--- a/ui/raidboss/popup-text.ts
+++ b/ui/raidboss/popup-text.ts
@@ -915,7 +915,7 @@ export class PopupText {
       return nick;
 
     const idx = name.indexOf(' ');
-    return idx < 0 ? name : name.substr(0, idx);
+    return idx < 0 ? name : name.slice(0, idx);
   }
 
   Reset(): void {

--- a/ui/raidboss/popup-text.ts
+++ b/ui/raidboss/popup-text.ts
@@ -915,7 +915,7 @@ export class PopupText {
       return nick;
 
     const idx = name.indexOf(' ');
-    return idx < 0 ? name : name.slice(0, idx);
+    return idx < 0 ? name : name.slice(0, Math.max(0, idx));
   }
 
   Reset(): void {

--- a/ui/raidboss/raidboss_config.ts
+++ b/ui/raidboss/raidboss_config.ts
@@ -1427,7 +1427,7 @@ const flattenTimeline = (
   const lastIndex = Math.max(filename.lastIndexOf('/'), filename.lastIndexOf('\\'));
   // If lastIndex === -1, truncate name to the empty string.
   // if lastIndex > -1, truncate name after the final slash.
-  const dir = filename.substring(0, lastIndex + 1);
+  const dir = filename.slice(0, Math.max(0, lastIndex + 1));
 
   const timelineFile = `${dir}${set.timelineFile}`;
   delete set.timelineFile;

--- a/util/logtools/anonymizer.ts
+++ b/util/logtools/anonymizer.ts
@@ -145,7 +145,7 @@ export default class Anonymizer {
       }
 
       // Ignore monsters.
-      if (playerId[0] === '4')
+      if (playerId.startsWith('4'))
         continue;
 
       // Replace the id at this index with a fake player id.

--- a/util/logtools/anonymizer.ts
+++ b/util/logtools/anonymizer.ts
@@ -125,7 +125,7 @@ export default class Anonymizer {
       const playerId = field.toUpperCase();
 
       // Cutscenes get added combatant messages with ids such as 'FF000006' and no name.
-      const isCutsceneId = playerId.substr(0, 2) === 'FF';
+      const isCutsceneId = playerId.slice(0, 2) === 'FF';
 
       // Handle weirdly shaped ids.
       if (playerId.length !== 8 || isCutsceneId) {

--- a/util/logtools/anonymizer.ts
+++ b/util/logtools/anonymizer.ts
@@ -125,7 +125,7 @@ export default class Anonymizer {
       const playerId = field.toUpperCase();
 
       // Cutscenes get added combatant messages with ids such as 'FF000006' and no name.
-      const isCutsceneId = playerId.slice(0, 2) === 'FF';
+      const isCutsceneId = playerId.startsWith('FF');
 
       // Handle weirdly shaped ids.
       if (playerId.length !== 8 || isCutsceneId) {

--- a/util/logtools/encounter_tools.ts
+++ b/util/logtools/encounter_tools.ts
@@ -298,7 +298,7 @@ class TLFuncs {
   // TODO: Replace the line argument with a NetAnyMatches once
   // we move the ParseLine logic out of the emulator.
   static getTZOffsetFromLogLine(line: string): number {
-    const time = line.substring(0, 3).includes('|') ? line.substring(3, 36) : line.substring(4, 37);
+    const time = line.slice(0, 3).includes('|') ? line.slice(3, 36) : line.slice(4, 37);
     return DTFuncs.getTimezoneOffsetMillis(time);
   }
 

--- a/util/logtools/make_timeline.ts
+++ b/util/logtools/make_timeline.ts
@@ -313,7 +313,7 @@ const extractRawLinesFromLog = async (
   for await (const line of file) {
     // This will fail on lines with 3-digit identifiers,
     // but that's okay because those will never be start lines.
-    const lineTimeStamp = line.substring(14, 26);
+    const lineTimeStamp = line.slice(14, 26);
     if (start === lineTimeStamp && !started)
       started = start === lineTimeStamp;
     if (started)
@@ -354,7 +354,7 @@ const extractTLEntriesFromLog = (
     if (ability) {
       // Cull non-enemy lines
       // TODO: Handle this using the raid emulator's line parsing functionality.
-      if (ability.sourceId[0] !== '4')
+      if (!ability.sourceId.startsWith('4'))
         continue;
       const abilityEntry = parseAbilityToEntry(ability);
       entries.push(abilityEntry);


### PR DESCRIPTION
`String.substr` is not a standard API, replace them with `String.slice`.

add `@typescript-eslint/prefer-string-starts-ends-with` and `unicorn/prefer-string-slice`

both autofix available