### PR TITLE
raidboss: ASS/S add King's Will trigger

### DIFF
--- a/ui/raidboss/data/06-ew/dungeon/another_sildihn_subterrane-savage.ts
+++ b/ui/raidboss/data/06-ew/dungeon/another_sildihn_subterrane-savage.ts
@@ -358,6 +358,31 @@ const triggerSet: TriggerSet<Data> = {
       response: Responses.getOut(),
     },
     {
+      id: 'ASSS King\'s Will',
+      type: 'StartsUsing',
+      netRegex: { id: '7980', source: 'Sil\'dihn Dullahan' },
+      response: (data, matches, output) => {
+        // cactbot-builtin-response
+        output.responseOutputStrings = {
+          autosOnYou: {
+            en: 'big autos on YOU',
+          },
+          autosOnTarget: {
+            en: 'big autos on ${player}',
+          },
+        };
+
+        if (matches.target === data.me) {
+          return { infoText: output.autosOnYou!() };
+        }
+
+        if (data.role !== 'tank' && data.role !== 'healer')
+          return;
+
+        return { infoText: output.autosOnTarget!({ player: data.ShortName(matches.target) }) };
+      },
+    },
+    {
       id: 'ASSS Hells\' Nebula',
       type: 'StartsUsing',
       netRegex: { id: '7984', source: 'Aqueduct Armor', capture: false },

--- a/ui/raidboss/data/06-ew/dungeon/another_sildihn_subterrane-savage.ts
+++ b/ui/raidboss/data/06-ew/dungeon/another_sildihn_subterrane-savage.ts
@@ -360,26 +360,12 @@ const triggerSet: TriggerSet<Data> = {
     {
       id: 'ASSS King\'s Will',
       type: 'StartsUsing',
-      netRegex: { id: '7980', source: 'Sil\'dihn Dullahan' },
-      response: (data, matches, output) => {
-        // cactbot-builtin-response
-        output.responseOutputStrings = {
-          autosOnYou: {
-            en: 'big autos on YOU',
-          },
-          autosOnTarget: {
-            en: 'big autos on ${player}',
-          },
-        };
-
-        if (matches.target === data.me) {
-          return { infoText: output.autosOnYou!() };
-        }
-
-        if (data.role !== 'tank' && data.role !== 'healer')
-          return;
-
-        return { infoText: output.autosOnTarget!({ player: data.ShortName(matches.target) }) };
+      netRegex: { id: '7980', source: 'Sil\'dihn Dullahan', capture: false },
+      infoText: (_data, _matches, output) => output.text!(),
+      outputStrings: {
+        text: {
+          en: 'big autos',
+        },
       },
     },
     {

--- a/ui/raidboss/data/06-ew/dungeon/another_sildihn_subterrane.ts
+++ b/ui/raidboss/data/06-ew/dungeon/another_sildihn_subterrane.ts
@@ -359,26 +359,12 @@ const triggerSet: TriggerSet<Data> = {
     {
       id: 'ASS King\'s Will',
       type: 'StartsUsing',
-      netRegex: { id: '7968', source: 'Sil\'dihn Dullahan' },
-      response: (data, matches, output) => {
-        // cactbot-builtin-response
-        output.responseOutputStrings = {
-          autosOnYou: {
-            en: 'big autos on YOU',
-          },
-          autosOnTarget: {
-            en: 'big autos on ${player}',
-          },
-        };
-
-        if (matches.target === data.me) {
-          return { infoText: output.autosOnYou!() };
-        }
-
-        if (data.role !== 'tank' && data.role !== 'healer')
-          return;
-
-        return { infoText: output.autosOnTarget!({ player: data.ShortName(matches.target) }) };
+      netRegex: { id: '7968', source: 'Sil\'dihn Dullahan', capture: false },
+      infoText: (_data, _matches, output) => output.text!(),
+      outputStrings: {
+        text: {
+          en: 'big autos',
+        },
       },
     },
     {

--- a/ui/raidboss/data/06-ew/dungeon/another_sildihn_subterrane.ts
+++ b/ui/raidboss/data/06-ew/dungeon/another_sildihn_subterrane.ts
@@ -357,6 +357,31 @@ const triggerSet: TriggerSet<Data> = {
       response: Responses.getOut(),
     },
     {
+      id: 'ASS King\'s Will',
+      type: 'StartsUsing',
+      netRegex: { id: '7968', source: 'Sil\'dihn Dullahan' },
+      response: (data, matches, output) => {
+        // cactbot-builtin-response
+        output.responseOutputStrings = {
+          autosOnYou: {
+            en: 'big autos on YOU',
+          },
+          autosOnTarget: {
+            en: 'big autos on ${player}',
+          },
+        };
+
+        if (matches.target === data.me) {
+          return { infoText: output.autosOnYou!() };
+        }
+
+        if (data.role !== 'tank' && data.role !== 'healer')
+          return;
+
+        return { infoText: output.autosOnTarget!({ player: data.ShortName(matches.target) }) };
+      },
+    },
+    {
       id: 'ASS Hells\' Nebula',
       type: 'StartsUsing',
       netRegex: { id: '796C', source: 'Aqueduct Armor', capture: false },


### PR DESCRIPTION
King's Will is an ability done by trash mobs between the first and second boss in ASS and ASS(S) that gives the mob a 100% physical damage increase for the next 12s.  In Savage, this causes the mob's auto-attacks to increase from ~33k per hit to ~66k per hit, effectively becoming mini-tankbusters.  This trigger provides a heads-up callout to the tank or healer for the incoming damage.

There was a question if a trigger for this ability was useful when merging the initial ASS triggers, so this pull request is made in isolation so it can be rejected if undesired.