### PR TITLE
raidboss: ASS/S add Hells' Nebula trigger

### DIFF
--- a/ui/raidboss/data/06-ew/dungeon/another_sildihn_subterrane-savage.ts
+++ b/ui/raidboss/data/06-ew/dungeon/another_sildihn_subterrane-savage.ts
@@ -366,7 +366,7 @@ const triggerSet: TriggerSet<Data> = {
       outputStrings: {
         text: {
           en: 'HP to 1',
-        }
+        },
       },
     },
     {

--- a/ui/raidboss/data/06-ew/dungeon/another_sildihn_subterrane-savage.ts
+++ b/ui/raidboss/data/06-ew/dungeon/another_sildihn_subterrane-savage.ts
@@ -361,6 +361,7 @@ const triggerSet: TriggerSet<Data> = {
       id: 'ASSS Hells\' Nebula',
       type: 'StartsUsing',
       netRegex: { id: '7984', source: 'Aqueduct Armor', capture: false },
+      condition: (data) => data.role === 'healer',
       infoText: (_data, _matches, output) => output.text!(),
       outputStrings: {
         text: {

--- a/ui/raidboss/data/06-ew/dungeon/another_sildihn_subterrane-savage.ts
+++ b/ui/raidboss/data/06-ew/dungeon/another_sildihn_subterrane-savage.ts
@@ -358,6 +358,17 @@ const triggerSet: TriggerSet<Data> = {
       response: Responses.getOut(),
     },
     {
+      id: 'ASSS Hells\' Nebula',
+      type: 'StartsUsing',
+      netRegex: { id: '7984', source: 'Aqueduct Armor', capture: false },
+      infoText: (_data, _matches, output) => output.text!(),
+      outputStrings: {
+        text: {
+          en: 'HP to 1',
+        }
+      },
+    },
+    {
       id: 'ASSS Infernal Weight',
       type: 'StartsUsing',
       netRegex: { id: '7983', source: 'Aqueduct Armor', capture: false },

--- a/ui/raidboss/data/06-ew/dungeon/another_sildihn_subterrane.ts
+++ b/ui/raidboss/data/06-ew/dungeon/another_sildihn_subterrane.ts
@@ -357,6 +357,17 @@ const triggerSet: TriggerSet<Data> = {
       response: Responses.getOut(),
     },
     {
+      id: 'ASS Hells\' Nebula',
+      type: 'StartsUsing',
+      netRegex: { id: '796C', source: 'Aqueduct Armor', capture: false },
+      infoText: (_data, _matches, output) => output.text(),
+      outputStrings: {
+        text: {
+          en: 'HP to 1',
+        }
+      },
+    },
+    {
       id: 'ASS Infernal Weight',
       type: 'StartsUsing',
       netRegex: { id: '796B', source: 'Aqueduct Armor', capture: false },

--- a/ui/raidboss/data/06-ew/dungeon/another_sildihn_subterrane.ts
+++ b/ui/raidboss/data/06-ew/dungeon/another_sildihn_subterrane.ts
@@ -360,7 +360,8 @@ const triggerSet: TriggerSet<Data> = {
       id: 'ASS Hells\' Nebula',
       type: 'StartsUsing',
       netRegex: { id: '796C', source: 'Aqueduct Armor', capture: false },
-      infoText: (_data, _matches, output) => output.text(),
+      condition: (data) => data.role === 'healer',
+      infoText: (_data, _matches, output) => output.text!(),
       outputStrings: {
         text: {
           en: 'HP to 1',

--- a/ui/raidboss/data/06-ew/dungeon/another_sildihn_subterrane.ts
+++ b/ui/raidboss/data/06-ew/dungeon/another_sildihn_subterrane.ts
@@ -365,7 +365,7 @@ const triggerSet: TriggerSet<Data> = {
       outputStrings: {
         text: {
           en: 'HP to 1',
-        }
+        },
       },
     },
     {


### PR DESCRIPTION
Hells' Nebula is an ability done by trash mobs between the first and second boss in ASS and ASS(S) that reduces all players' HP to 1.  There is no follow-up Doom debuff or other such mechanic that requires immediately topping up players' health, other than the next source of raidwide damage which is approximately 10s later.  This trigger provides a heads-up callout for the HP reduction.

There was a question if a trigger for this ability was useful when merging the initial ASS triggers, so this pull request is made in isolation so it can be rejected if undesired.