### PR TITLE
raidboss: ASS Squeaky Clean cast

### DIFF
--- a/ui/raidboss/data/06-ew/dungeon/another_sildihn_subterrane.ts
+++ b/ui/raidboss/data/06-ew/dungeon/another_sildihn_subterrane.ts
@@ -140,13 +140,13 @@ const triggerSet: TriggerSet<Data> = {
     {
       id: 'ASS Squeaky Clean Right',
       type: 'StartsUsing',
-      netRegex: { id: '7755', source: 'Silkie', capture: false },
+      netRegex: { id: '7755', source: ['Silkie', 'Silken Puff'], capture: false },
       response: Responses.goLeft(),
     },
     {
       id: 'ASS Squeaky Clean Left',
       type: 'StartsUsing',
-      netRegex: { id: '7756', source: 'Silkie', capture: false },
+      netRegex: { id: '7756', source: ['Silkie', 'Silken Puff'], capture: false },
       response: Responses.goRight(),
     },
     {

--- a/ui/raidboss/data/06-ew/dungeon/another_sildihn_subterrane.ts
+++ b/ui/raidboss/data/06-ew/dungeon/another_sildihn_subterrane.ts
@@ -140,13 +140,13 @@ const triggerSet: TriggerSet<Data> = {
     {
       id: 'ASS Squeaky Clean Right',
       type: 'StartsUsing',
-      netRegex: { id: '7755', source: ['Silkie', 'Silken Puff'], capture: false },
+      netRegex: { id: '7751', source: 'Silkie', capture: false },
       response: Responses.goLeft(),
     },
     {
       id: 'ASS Squeaky Clean Left',
       type: 'StartsUsing',
-      netRegex: { id: '7756', source: ['Silkie', 'Silken Puff'], capture: false },
+      netRegex: { id: '7752', source: 'Silkie', capture: false },
       response: Responses.goRight(),
     },
     {


### PR DESCRIPTION
Had a few instances where the Silken Puff would cast Squeaky Clean instead of Silkie.

[18:09:51.371] StartsCasting 14:4001B920:Silkie:7752:Squeaky Clean:4001B920:Silkie:4.200:-335.01:-170.00:471.00:3.14 [18:09:51.371] StartsCasting 14:4001B92D:Silken Puff:7756:Squeaky Clean:4001B92D:Silken Puff:8.900:-331.00:-159.00:471.00:0.00 [18:09:51.371] StartsCasting 14:4001B92E:Silken Puff:7754:Squeaky Clean:4001B92E:Silken Puff:7.400:-347.00:-159.00:471.00:0.00 [18:09:51.371] StartsCasting 14:4001B92F:Silkie:7753:Squeaky Clean:4001B92F:Silkie:5.700:-341.51:-165.65:471.00:2.50