### PR TITLE
raidboss: ASS(S) mob name change

### DIFF
--- a/ui/raidboss/data/06-ew/dungeon/another_sildihn_subterrane-savage.ts
+++ b/ui/raidboss/data/06-ew/dungeon/another_sildihn_subterrane-savage.ts
@@ -1529,7 +1529,6 @@ const triggerSet: TriggerSet<Data> = {
     {
       'locale': 'de',
       'replaceSync': {
-        'Sil\'dihn Armor': 'Aquädukt-Kampfmaschine',
         'Aqueduct Belladonna': 'Aquädukt-Belladonna',
         'Aqueduct Dryad': 'Aquädukt-Dryade',
         'Aqueduct Kaluk': 'Aquädukt-Kaluk',
@@ -1541,6 +1540,7 @@ const triggerSet: TriggerSet<Data> = {
         'Hateful Visage': 'Hassendes Haupt',
         'Infern Brand': 'Infernales Mal',
         'Shadowcaster Zeless Gah': 'Schattenwirker Zeless Gah',
+        'Sil\'dihn Armor': 'Sil\'dih-Kampfmaschine',
         'Sil\'dihn Dullahan': 'Sil\'dih-Dullahan',
         'Silkie': 'Silkie',
         'The Trial of Balance': 'Prüfung der Gerechtigkeit',
@@ -1602,7 +1602,6 @@ const triggerSet: TriggerSet<Data> = {
     {
       'locale': 'fr',
       'replaceSync': {
-        'Sil\'dihn Armor': 'armure maléfique des aqueducs',
         'Aqueduct Belladonna': 'belladone des aqueducs',
         'Aqueduct Dryad': 'dryade des aqueducs',
         'Aqueduct Kaluk': 'kaluk des aqueducs',
@@ -1614,6 +1613,7 @@ const triggerSet: TriggerSet<Data> = {
         'Hateful Visage': 'Visage de haine',
         'Infern Brand': 'Étendard sacré',
         'Shadowcaster Zeless Gah': 'Zeless Gah la Flamme ombrée',
+        'Sil\'dihn Armor': 'armure maléfique sildien',
         'Sil\'dihn Dullahan': 'dullahan sildien',
         'Silkie': 'Silkie',
         'The Trial of Balance': 'Épreuve de la Justice',
@@ -1675,7 +1675,6 @@ const triggerSet: TriggerSet<Data> = {
     {
       'locale': 'ja',
       'replaceSync': {
-        'Sil\'dihn Armor': 'アクアダクト・イビルアーマー',
         'Aqueduct Belladonna': 'アクアダクト・ベラドンナ',
         'Aqueduct Dryad': 'アクアダクト・ドライアド',
         'Aqueduct Kaluk': 'アクアダクト・カルク',
@@ -1687,6 +1686,7 @@ const triggerSet: TriggerSet<Data> = {
         'Hateful Visage': '呪像起動',
         'Infern Brand': '呪具設置',
         'Shadowcaster Zeless Gah': '影火のゼレズ・ガー',
+        'Sil\'dihn Armor': 'シラディハ・イビルアーマー',
         'Sil\'dihn Dullahan': 'シラディハ・デュラハン',
         'Silkie': 'シルキー',
         'The Trial of Balance': '参の試練',

--- a/ui/raidboss/data/06-ew/dungeon/another_sildihn_subterrane-savage.ts
+++ b/ui/raidboss/data/06-ew/dungeon/another_sildihn_subterrane-savage.ts
@@ -383,7 +383,7 @@ const triggerSet: TriggerSet<Data> = {
     {
       id: 'ASSS Hells\' Nebula',
       type: 'StartsUsing',
-      netRegex: { id: '7984', source: 'Aqueduct Armor', capture: false },
+      netRegex: { id: '7984', source: 'Sil\'dihn Armor', capture: false },
       condition: (data) => data.role === 'healer',
       infoText: (_data, _matches, output) => output.text!(),
       outputStrings: {
@@ -396,7 +396,7 @@ const triggerSet: TriggerSet<Data> = {
     {
       id: 'ASSS Infernal Weight',
       type: 'StartsUsing',
-      netRegex: { id: '7983', source: 'Aqueduct Armor', capture: false },
+      netRegex: { id: '7983', source: 'Sil\'dihn Armor', capture: false },
       infoText: (_data, _matches, output) => output.text!(),
       outputStrings: {
         text: {
@@ -409,7 +409,7 @@ const triggerSet: TriggerSet<Data> = {
     {
       id: 'ASSS Dominion Slash',
       type: 'StartsUsing',
-      netRegex: { id: '7982', source: 'Aqueduct Armor', capture: false },
+      netRegex: { id: '7982', source: 'Sil\'dihn Armor', capture: false },
       response: Responses.getBehind(),
     },
     // ---------------- Gladiator of Sil'dih ----------------
@@ -1529,7 +1529,7 @@ const triggerSet: TriggerSet<Data> = {
     {
       'locale': 'de',
       'replaceSync': {
-        'Aqueduct Armor': 'Aquädukt-Kampfmaschine',
+        'Sil\'dihn Armor': 'Aquädukt-Kampfmaschine',
         'Aqueduct Belladonna': 'Aquädukt-Belladonna',
         'Aqueduct Dryad': 'Aquädukt-Dryade',
         'Aqueduct Kaluk': 'Aquädukt-Kaluk',
@@ -1602,7 +1602,7 @@ const triggerSet: TriggerSet<Data> = {
     {
       'locale': 'fr',
       'replaceSync': {
-        'Aqueduct Armor': 'armure maléfique des aqueducs',
+        'Sil\'dihn Armor': 'armure maléfique des aqueducs',
         'Aqueduct Belladonna': 'belladone des aqueducs',
         'Aqueduct Dryad': 'dryade des aqueducs',
         'Aqueduct Kaluk': 'kaluk des aqueducs',
@@ -1675,7 +1675,7 @@ const triggerSet: TriggerSet<Data> = {
     {
       'locale': 'ja',
       'replaceSync': {
-        'Aqueduct Armor': 'アクアダクト・イビルアーマー',
+        'Sil\'dihn Armor': 'アクアダクト・イビルアーマー',
         'Aqueduct Belladonna': 'アクアダクト・ベラドンナ',
         'Aqueduct Dryad': 'アクアダクト・ドライアド',
         'Aqueduct Kaluk': 'アクアダクト・カルク',


### PR DESCRIPTION
re: #5051 Mob name changed from Aqueduct Armor in 6.25 to Sil'dihn Armor in 6.28.

Translated names may need adjusting too?