### PR TITLE
resources: update Sleep to role action

### DIFF
--- a/resources/util.ts
+++ b/resources/util.ts
@@ -62,7 +62,7 @@ const gatheringJobs: Job[] = ['MIN', 'BTN', 'FSH'];
 
 const stunJobs: Job[] = ['BLU', ...tankJobs, ...meleeDpsJobs];
 const silenceJobs: Job[] = ['BLU', ...tankJobs, ...rangedDpsJobs];
-const sleepJobs: Job[] = ['BLM', 'BLU', ...healerJobs];
+const sleepJobs: Job[] = [...casterDpsJobs, ...healerJobs];
 const feintJobs: Job[] = [...meleeDpsJobs];
 const addleJobs: Job[] = [...casterDpsJobs];
 const cleanseJobs: Job[] = ['BLU', 'BRD', ...healerJobs];

--- a/test/unittests/util_test.ts
+++ b/test/unittests/util_test.ts
@@ -25,17 +25,15 @@ const jobs: JobInfo[] = ((): JobInfo[] => {
   healerJobs.forEach((job) => jobs.push(new JobInfo(job, 'healer', ['Cleanse', 'Sleep'])));
   meleeDpsJobs.forEach((job) => jobs.push(new JobInfo(job, 'dps', ['Feint', 'Stun'])));
   rangedDpsJobs.forEach((job) => jobs.push(new JobInfo(job, 'dps', ['Silence'])));
-  casterDpsJobs.forEach((job) => jobs.push(new JobInfo(job, 'dps', ['Addle'])));
+  casterDpsJobs.forEach((job) => jobs.push(new JobInfo(job, 'dps', ['Addle', 'Sleep'])));
   craftingJobs.forEach((job) => jobs.push(new JobInfo(job, 'crafter')));
   gatheringJobs.forEach((job) => jobs.push(new JobInfo(job, 'gatherer')));
 
   // Special classes
   jobs.find((job: JobInfo) => job.name === 'BRD')?.actions.push('Cleanse');
-  jobs.find((job: JobInfo) => job.name === 'BLM')?.actions.push('Sleep');
   jobs.find((job: JobInfo) => job.name === 'BLU')?.actions.push(
     'Cleanse',
     'Silence',
-    'Sleep',
     'Stun',
   );
 


### PR DESCRIPTION
As of Endwalker (6.0), Sleep is now a role action for all magical ranged dps jobs.