### PR TITLE
raidboss: refactor TimelineUI to not include HTML elements

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "test": "mocha",
     "lint-staged": "lint-staged",
     "coverage-report": "ts-node util/gen_coverage_report.ts",
-    "util": "ts-node -r jsdom-global/register util/index.ts",
+    "util": "ts-node util/index.ts",
     "find-translations": "npm run util -- findTranslations",
     "translate-timeline": "npm run util -- translateTimeline",
     "generate": "npm run util -- generate",

--- a/ui/raidboss/emulator/overrides/RaidEmulatorTimelineUI.ts
+++ b/ui/raidboss/emulator/overrides/RaidEmulatorTimelineUI.ts
@@ -23,8 +23,8 @@ export default class RaidEmulatorTimelineUI extends TimelineUI {
   emulatedStatus = 'pause';
   $barContainer: HTMLElement;
   $progressTemplate: HTMLElement;
-  constructor(options: RaidbossOptions) {
-    super(options);
+  constructor(protected options: RaidbossOptions) {
+    super();
     const container = document.querySelector('.timer-bar-container');
     if (!(container instanceof HTMLElement))
       throw new UnreachableCode();

--- a/ui/raidboss/html_timeline_ui.ts
+++ b/ui/raidboss/html_timeline_ui.ts
@@ -73,7 +73,7 @@ const computeBackgroundFrom = (element: HTMLElement, classList: string): string 
 };
 
 export class HTMLTimelineUI extends TimelineUI {
-  private init: boolean;
+  private init = false;
   private lang: Lang;
 
   private root: HTMLElement | null = null;
@@ -89,9 +89,8 @@ export class HTMLTimelineUI extends TimelineUI {
 
   private popupText?: PopupTextGenerator;
 
-  constructor(protected override options: RaidbossOptions) {
-    super(options);
-    this.init = false;
+  constructor(protected options: RaidbossOptions) {
+    super();
     this.lang = this.options.TimelineLanguage || this.options.ParserLanguage || 'en';
     this.AddDebugInstructions();
   }

--- a/ui/raidboss/html_timeline_ui.ts
+++ b/ui/raidboss/html_timeline_ui.ts
@@ -1,0 +1,317 @@
+import { Lang, langToLocale } from '../../resources/languages';
+import TimerBar from '../../resources/timerbar';
+import { LooseTimelineTrigger } from '../../types/trigger';
+
+import { PopupTextGenerator } from './popup-text';
+import { RaidbossOptions } from './raidboss_options';
+import { TimelineUI } from './timeline';
+import { Event } from './timeline_parser';
+
+const kBig = 1000000000; // Something bigger than any fight length in seconds.
+
+const timelineInstructions = {
+  en: [
+    'These lines are',
+    'debug timeline entries.',
+    'If you lock the overlay,',
+    'they will disappear!',
+    'Real timelines automatically',
+    'appear when supported.',
+  ],
+  de: [
+    'Diese Zeilen sind',
+    'Timeline Debug-Einträge.',
+    'Wenn du das Overlay sperrst,',
+    'werden sie verschwinden!',
+    'Echte Timelines erscheinen automatisch,',
+    'wenn sie unterstützt werden.',
+  ],
+  fr: [
+    'Ces lignes sont',
+    'des timelines de test.',
+    'Si vous bloquez l\'overlay,',
+    'elles disparaîtront !',
+    'Les vraies Timelines',
+    'apparaîtront automatiquement.',
+  ],
+  ja: [
+    'こちらはデバッグ用の',
+    'タイムラインです。',
+    'オーバーレイをロックすれば、',
+    'デバッグ用テキストも消える',
+    'サポートするゾーンにはタイム',
+    'ラインを動的にロードする。',
+  ],
+  cn: [
+    '显示在此处的是',
+    '调试用时间轴。',
+    '将此悬浮窗锁定',
+    '则会立刻消失',
+    '真实的时间轴会根据',
+    '当前区域动态加载并显示',
+  ],
+  ko: [
+    '이 막대바는 디버그용',
+    '타임라인 입니다.',
+    '오버레이를 위치잠금하면,',
+    '이 막대바도 사라집니다.',
+    '지원되는 구역에서 타임라인이',
+    '자동으로 표시됩니다.',
+  ],
+};
+
+// TODO: Duplicated in 'jobs'
+const computeBackgroundFrom = (element: HTMLElement, classList: string): string => {
+  const div = document.createElement('div');
+  const classes = classList.split('.');
+  for (const cls of classes)
+    div.classList.add(cls);
+  element.appendChild(div);
+  const color = window.getComputedStyle(div).background;
+  element.removeChild(div);
+  return color;
+};
+
+export class HTMLTimelineUI extends TimelineUI {
+  private init: boolean;
+  private lang: Lang;
+
+  private root: HTMLElement | null = null;
+  private barColor: string | null = null;
+  private barExpiresSoonColor: string | null = null;
+  private timerlist: HTMLElement | null = null;
+
+  private activeBars: { [activebar: string]: TimerBar } = {};
+  private expireTimers: { [expireTimer: string]: number } = {};
+
+  private debugElement: HTMLElement | null = null;
+  private debugFightTimer: TimerBar | null = null;
+
+  private popupText?: PopupTextGenerator;
+
+  constructor(protected override options: RaidbossOptions) {
+    super(options);
+    this.init = false;
+    this.lang = this.options.TimelineLanguage || this.options.ParserLanguage || 'en';
+    this.AddDebugInstructions();
+  }
+
+  protected override Init(): void {
+    if (this.init)
+      return;
+    this.init = true;
+
+    this.root = document.getElementById('timeline-container');
+    if (!this.root)
+      throw new Error('can\'t find timeline-container');
+
+    // TODO: left for now as backwards compatibility with user css.  Remove this later??
+    this.root.classList.add(`lang-${this.lang}`);
+    this.root.lang = langToLocale(this.lang);
+    if (this.options.Skin)
+      this.root.classList.add(`skin-${this.options.Skin}`);
+
+    this.barColor = computeBackgroundFrom(this.root, 'timeline-bar-color');
+    this.barExpiresSoonColor = computeBackgroundFrom(this.root, 'timeline-bar-color.soon');
+
+    this.timerlist = document.getElementById('timeline');
+    if (this.timerlist) {
+      this.timerlist.style.gridTemplateRows =
+        `repeat(${this.options.MaxNumberOfTimerBars}, min-content)`;
+    }
+
+    this.activeBars = {};
+    this.expireTimers = {};
+  }
+
+  protected override AddDebugInstructions(): void {
+    const lang = this.lang in timelineInstructions ? this.lang : 'en';
+    const instructions = timelineInstructions[lang];
+
+    // Helper for positioning/resizing when locked.
+    const helper = document.getElementById('timeline-resize-helper');
+    if (!helper)
+      return;
+    const rows = Math.max(6, this.options.MaxNumberOfTimerBars);
+    helper.style.gridTemplateRows = `repeat(${rows}, 1fr)`;
+
+    for (let i = 0; i < this.options.MaxNumberOfTimerBars; ++i) {
+      const helperBar = document.createElement('div');
+      helperBar.classList.add('text');
+      helperBar.classList.add('resize-helper-bar');
+      helperBar.classList.add('timeline-bar-color');
+      if (i < 1)
+        helperBar.classList.add('soon');
+      if (i < instructions.length)
+        helperBar.innerText = instructions[i] ?? '';
+      else
+        helperBar.innerText = `${i + 1}`;
+      helper.appendChild(helperBar);
+    }
+
+    // For simplicity in code, always make debugElement valid,
+    // however it does not exist in the raid emulator.
+    this.debugElement = document.getElementById('timeline-debug');
+    if (!this.debugElement)
+      this.debugElement = document.createElement('div');
+  }
+
+  public override SetPopupTextInterface(popupText: PopupTextGenerator): void {
+    this.popupText = popupText;
+  }
+
+  protected override Reset(): void {
+    if (this.timeline) {
+      delete this.timeline.ui;
+      while (this.timerlist && this.timerlist.lastChild)
+        this.timerlist.removeChild(this.timerlist.lastChild);
+      if (this.debugElement)
+        this.debugElement.innerHTML = '';
+      this.debugFightTimer = null;
+      this.activeBars = {};
+    }
+  }
+
+  public override OnAddTimer(fightNow: number, e: Event, channeling: boolean): void {
+    const div = document.createElement('div');
+    const bar = TimerBar.create();
+    div.classList.add('timer-bar');
+    div.appendChild(bar);
+    bar.duration = channeling ? e.time - fightNow : this.options.ShowTimerBarsAtSeconds;
+    bar.value = e.time - fightNow;
+    bar.righttext = 'remain';
+    bar.lefttext = e.text;
+    bar.toward = 'right';
+    bar.stylefill = !channeling ? 'fill' : 'empty';
+
+    if (e.style)
+      bar.applyStyles(e.style);
+
+    if (!channeling && e.time - fightNow > this.options.BarExpiresSoonSeconds) {
+      bar.fg = this.barColor;
+      window.setTimeout(
+        this.OnTimerExpiresSoon.bind(this, e.id),
+        (e.time - fightNow - this.options.BarExpiresSoonSeconds) * 1000,
+      );
+    } else {
+      bar.fg = this.barExpiresSoonColor;
+    }
+
+    // Adding a timer with the same id immediately removes the previous.
+    const activeBar = this.activeBars[e.id];
+    if (activeBar) {
+      const div = activeBar.parentNode;
+      div?.parentNode?.removeChild(div);
+    }
+
+    if (e.sortKey)
+      div.style.order = e.sortKey.toString();
+    div.id = e.id.toString();
+    this.timerlist?.appendChild(div);
+    this.activeBars[e.id] = bar;
+    if (e.id in this.expireTimers) {
+      window.clearTimeout(this.expireTimers[e.id]);
+      delete this.expireTimers[e.id];
+    }
+  }
+
+  public override OnTimerExpiresSoon(id: number): void {
+    const bar = this.activeBars[id];
+    if (bar)
+      bar.fg = this.barExpiresSoonColor;
+  }
+
+  public override OnRemoveTimer(e: Event, expired: boolean, force = false): void {
+    if (!force && expired && this.options.KeepExpiredTimerBarsForSeconds) {
+      this.expireTimers[e.id] = window.setTimeout(
+        this.OnRemoveTimer.bind(this, e, false),
+        this.options.KeepExpiredTimerBarsForSeconds * 1000,
+      );
+      return;
+    } else if (e.id in this.expireTimers) {
+      window.clearTimeout(this.expireTimers[e.id]);
+      delete this.expireTimers[e.id];
+    }
+
+    const bar = this.activeBars[e.id];
+    if (!bar)
+      return;
+
+    const div = bar.parentNode;
+    const element = document.getElementById(e.id.toString());
+    if (!element)
+      return;
+
+    const removeBar = () => {
+      div?.parentNode?.removeChild(div);
+      delete this.activeBars[e.id];
+    };
+
+    if (!force)
+      element.classList.add('animate-timer-bar-removed');
+    if (window.getComputedStyle(element).animationName !== 'none') {
+      // Wait for animation to finish
+      element.addEventListener('animationend', removeBar);
+    } else {
+      removeBar();
+    }
+  }
+
+  public override OnShowInfoText(text: string, currentTime: number): void {
+    if (this.popupText)
+      this.popupText.Info(text, currentTime);
+  }
+
+  public override OnShowAlertText(text: string, currentTime: number): void {
+    if (this.popupText)
+      this.popupText.Alert(text, currentTime);
+  }
+
+  public override OnShowAlarmText(text: string, currentTime: number): void {
+    if (this.popupText)
+      this.popupText.Alarm(text, currentTime);
+  }
+
+  public override OnSpeakTTS(text: string, currentTime: number): void {
+    if (this.popupText)
+      this.popupText.TTS(text, currentTime);
+  }
+
+  public override OnTrigger(
+    trigger: LooseTimelineTrigger,
+    matches: RegExpExecArray | null,
+    currentTime: number,
+  ): void {
+    if (this.popupText)
+      this.popupText.Trigger(trigger, matches, currentTime);
+  }
+
+  public override OnSyncTime(fightNow: number, running: boolean): void {
+    if (!this.options.Debug || !this.debugElement)
+      return;
+
+    if (!running) {
+      if (this.debugFightTimer)
+        this.debugElement.removeChild(this.debugFightTimer);
+      this.debugFightTimer = null;
+      return;
+    }
+
+    if (!this.debugFightTimer) {
+      this.debugFightTimer = TimerBar.create();
+      this.debugFightTimer.width = '100px';
+      this.debugFightTimer.height = '17px';
+      this.debugFightTimer.duration = kBig;
+      this.debugFightTimer.lefttext = 'elapsed';
+      this.debugFightTimer.toward = 'right';
+      this.debugFightTimer.stylefill = 'fill';
+      this.debugFightTimer.bg = 'transparent';
+      this.debugFightTimer.fg = 'transparent';
+      this.debugElement.appendChild(this.debugFightTimer);
+    }
+
+    // Force this to be reset.
+    this.debugFightTimer.elapsed = 0;
+    this.debugFightTimer.elapsed = fightNow;
+  }
+}

--- a/ui/raidboss/raidboss.ts
+++ b/ui/raidboss/raidboss.ts
@@ -3,9 +3,10 @@ import { addRemotePlayerSelectUI } from '../../resources/player_override';
 import UserConfig from '../../resources/user_config';
 
 import raidbossFileData from './data/raidboss_manifest.txt';
+import { HTMLTimelineUI } from './html_timeline_ui';
 import { PopupText, PopupTextGenerator } from './popup-text';
 import defaultOptions from './raidboss_options';
-import { TimelineController, TimelineLoader, TimelineUI } from './timeline';
+import { TimelineController, TimelineLoader } from './timeline';
 
 import '../../resources/timerbar';
 import './raidboss_config';
@@ -82,7 +83,7 @@ UserConfig.getUserConfigLocation('raidboss', defaultOptions, () => {
   if (!options.TimelineEnabled)
     container.classList.add('hide-timeline');
 
-  const timelineUI = new TimelineUI(options);
+  const timelineUI = new HTMLTimelineUI(options);
   const timelineController = new TimelineController(options, timelineUI, raidbossFileData);
   const timelineLoader = new TimelineLoader(timelineController);
   const popupText = new PopupText(options, timelineLoader, raidbossFileData);

--- a/ui/raidboss/timeline.ts
+++ b/ui/raidboss/timeline.ts
@@ -1,6 +1,4 @@
-import { Lang, langToLocale } from '../../resources/languages';
 import { commonNetRegex } from '../../resources/netregexes';
-import TimerBar from '../../resources/timerbar';
 import { LocaleRegex } from '../../resources/translations';
 import { LogEvent } from '../../types/event';
 import { CactbotBaseRegExp } from '../../types/net_trigger';
@@ -19,57 +17,6 @@ import {
 
 const kBig = 1000000000; // Something bigger than any fight length in seconds.
 
-const timelineInstructions = {
-  en: [
-    'These lines are',
-    'debug timeline entries.',
-    'If you lock the overlay,',
-    'they will disappear!',
-    'Real timelines automatically',
-    'appear when supported.',
-  ],
-  de: [
-    'Diese Zeilen sind',
-    'Timeline Debug-Einträge.',
-    'Wenn du das Overlay sperrst,',
-    'werden sie verschwinden!',
-    'Echte Timelines erscheinen automatisch,',
-    'wenn sie unterstützt werden.',
-  ],
-  fr: [
-    'Ces lignes sont',
-    'des timelines de test.',
-    'Si vous bloquez l\'overlay,',
-    'elles disparaîtront !',
-    'Les vraies Timelines',
-    'apparaîtront automatiquement.',
-  ],
-  ja: [
-    'こちらはデバッグ用の',
-    'タイムラインです。',
-    'オーバーレイをロックすれば、',
-    'デバッグ用テキストも消える',
-    'サポートするゾーンにはタイム',
-    'ラインを動的にロードする。',
-  ],
-  cn: [
-    '显示在此处的是',
-    '调试用时间轴。',
-    '将此悬浮窗锁定',
-    '则会立刻消失',
-    '真实的时间轴会根据',
-    '当前区域动态加载并显示',
-  ],
-  ko: [
-    '이 막대바는 디버그용',
-    '타임라인 입니다.',
-    '오버레이를 위치잠금하면,',
-    '이 막대바도 사라집니다.',
-    '지원되는 구역에서 타임라인이',
-    '자동으로 표시됩니다.',
-  ],
-};
-
 const activeText = {
   en: 'Active:',
   de: 'Aktiv:',
@@ -79,17 +26,77 @@ const activeText = {
   ko: '시전중:',
 };
 
-// TODO: Duplicated in 'jobs'
-const computeBackgroundFrom = (element: HTMLElement, classList: string): string => {
-  const div = document.createElement('div');
-  const classes = classList.split('.');
-  for (const cls of classes)
-    div.classList.add(cls);
-  element.appendChild(div);
-  const color = window.getComputedStyle(div).background;
-  element.removeChild(div);
-  return color;
-};
+export class TimelineUI {
+  protected timeline: Timeline | null = null;
+
+  constructor(protected options: RaidbossOptions) {
+  }
+
+  protected Init(): void {
+    /* noop */
+  }
+
+  protected AddDebugInstructions(): void {
+    /* noop */
+  }
+
+  public SetPopupTextInterface(_popupText: PopupTextGenerator): void {
+    /* noop */
+  }
+
+  protected Reset(): void {
+    /* noop */
+  }
+
+  public SetTimeline(timeline: Timeline | null): void {
+    this.Init();
+    this.Reset();
+
+    this.timeline = timeline;
+    if (this.timeline)
+      this.timeline.ui = this;
+  }
+
+  public OnAddTimer(_fightNow: number, _e: Event, _channeling: boolean): void {
+    /* noop */
+  }
+
+  public OnTimerExpiresSoon(_id: number): void {
+    /* noop */
+  }
+
+  public OnRemoveTimer(_e: Event, _expired: boolean, _force = false): void {
+    /* noop */
+  }
+
+  public OnShowInfoText(_text: string, _currentTime: number): void {
+    /* noop */
+  }
+
+  public OnShowAlertText(_text: string, _currentTime: number): void {
+    /* noop */
+  }
+
+  public OnShowAlarmText(_text: string, _currentTime: number): void {
+    /* noop */
+  }
+
+  public OnSpeakTTS(_text: string, _currentTime: number): void {
+    /* noop */
+  }
+
+  public OnTrigger(
+    _trigger: LooseTimelineTrigger,
+    _matches: RegExpExecArray | null,
+    _currentTime: number,
+  ): void {
+    /* noop */
+  }
+
+  public OnSyncTime(_fightNow: number, _running: boolean): void {
+    /* noop */
+  }
+}
 
 export class Timeline {
   private replacements: TimelineReplacement[];
@@ -454,257 +461,6 @@ export class Timeline {
     this._RemoveExpiredTimers(fightNow);
     this._AddUpcomingTimers(fightNow);
     this._ScheduleUpdate(fightNow);
-  }
-}
-
-export class TimelineUI {
-  private init: boolean;
-  private lang: Lang;
-
-  private root: HTMLElement | null = null;
-  private barColor: string | null = null;
-  private barExpiresSoonColor: string | null = null;
-  private timerlist: HTMLElement | null = null;
-
-  private activeBars: { [activebar: string]: TimerBar } = {};
-  private expireTimers: { [expireTimer: string]: number } = {};
-
-  private debugElement: HTMLElement | null = null;
-  private debugFightTimer: TimerBar | null = null;
-
-  protected timeline: Timeline | null = null;
-
-  private popupText?: PopupTextGenerator;
-
-  constructor(protected options: RaidbossOptions) {
-    this.options = options;
-    this.init = false;
-    this.lang = this.options.TimelineLanguage || this.options.ParserLanguage || 'en';
-    this.AddDebugInstructions();
-  }
-
-  protected Init(): void {
-    if (this.init)
-      return;
-    this.init = true;
-
-    this.root = document.getElementById('timeline-container');
-    if (!this.root)
-      throw new Error('can\'t find timeline-container');
-
-    // TODO: left for now as backwards compatibility with user css.  Remove this later??
-    this.root.classList.add(`lang-${this.lang}`);
-    this.root.lang = langToLocale(this.lang);
-    if (this.options.Skin)
-      this.root.classList.add(`skin-${this.options.Skin}`);
-
-    this.barColor = computeBackgroundFrom(this.root, 'timeline-bar-color');
-    this.barExpiresSoonColor = computeBackgroundFrom(this.root, 'timeline-bar-color.soon');
-
-    this.timerlist = document.getElementById('timeline');
-    if (this.timerlist) {
-      this.timerlist.style.gridTemplateRows =
-        `repeat(${this.options.MaxNumberOfTimerBars}, min-content)`;
-    }
-
-    this.activeBars = {};
-    this.expireTimers = {};
-  }
-
-  protected AddDebugInstructions(): void {
-    const lang = this.lang in timelineInstructions ? this.lang : 'en';
-    const instructions = timelineInstructions[lang];
-
-    // Helper for positioning/resizing when locked.
-    const helper = document.getElementById('timeline-resize-helper');
-    if (!helper)
-      return;
-    const rows = Math.max(6, this.options.MaxNumberOfTimerBars);
-    helper.style.gridTemplateRows = `repeat(${rows}, 1fr)`;
-
-    for (let i = 0; i < this.options.MaxNumberOfTimerBars; ++i) {
-      const helperBar = document.createElement('div');
-      helperBar.classList.add('text');
-      helperBar.classList.add('resize-helper-bar');
-      helperBar.classList.add('timeline-bar-color');
-      if (i < 1)
-        helperBar.classList.add('soon');
-      if (i < instructions.length)
-        helperBar.innerText = instructions[i] ?? '';
-      else
-        helperBar.innerText = `${i + 1}`;
-      helper.appendChild(helperBar);
-    }
-
-    // For simplicity in code, always make debugElement valid,
-    // however it does not exist in the raid emulator.
-    this.debugElement = document.getElementById('timeline-debug');
-    if (!this.debugElement)
-      this.debugElement = document.createElement('div');
-  }
-
-  public SetPopupTextInterface(popupText: PopupTextGenerator): void {
-    this.popupText = popupText;
-  }
-
-  public SetTimeline(timeline: Timeline | null): void {
-    this.Init();
-    if (this.timeline) {
-      delete this.timeline.ui;
-      while (this.timerlist && this.timerlist.lastChild)
-        this.timerlist.removeChild(this.timerlist.lastChild);
-      if (this.debugElement)
-        this.debugElement.innerHTML = '';
-      this.debugFightTimer = null;
-      this.activeBars = {};
-    }
-
-    this.timeline = timeline;
-    if (this.timeline)
-      this.timeline.ui = this;
-  }
-
-  public OnAddTimer(fightNow: number, e: Event, channeling: boolean): void {
-    const div = document.createElement('div');
-    const bar = TimerBar.create();
-    div.classList.add('timer-bar');
-    div.appendChild(bar);
-    bar.duration = channeling ? e.time - fightNow : this.options.ShowTimerBarsAtSeconds;
-    bar.value = e.time - fightNow;
-    bar.righttext = 'remain';
-    bar.lefttext = e.text;
-    bar.toward = 'right';
-    bar.stylefill = !channeling ? 'fill' : 'empty';
-
-    if (e.style)
-      bar.applyStyles(e.style);
-
-    if (!channeling && e.time - fightNow > this.options.BarExpiresSoonSeconds) {
-      bar.fg = this.barColor;
-      window.setTimeout(
-        this.OnTimerExpiresSoon.bind(this, e.id),
-        (e.time - fightNow - this.options.BarExpiresSoonSeconds) * 1000,
-      );
-    } else {
-      bar.fg = this.barExpiresSoonColor;
-    }
-
-    // Adding a timer with the same id immediately removes the previous.
-    const activeBar = this.activeBars[e.id];
-    if (activeBar) {
-      const div = activeBar.parentNode;
-      div?.parentNode?.removeChild(div);
-    }
-
-    if (e.sortKey)
-      div.style.order = e.sortKey.toString();
-    div.id = e.id.toString();
-    this.timerlist?.appendChild(div);
-    this.activeBars[e.id] = bar;
-    if (e.id in this.expireTimers) {
-      window.clearTimeout(this.expireTimers[e.id]);
-      delete this.expireTimers[e.id];
-    }
-  }
-
-  public OnTimerExpiresSoon(id: number): void {
-    const bar = this.activeBars[id];
-    if (bar)
-      bar.fg = this.barExpiresSoonColor;
-  }
-
-  public OnRemoveTimer(e: Event, expired: boolean, force = false): void {
-    if (!force && expired && this.options.KeepExpiredTimerBarsForSeconds) {
-      this.expireTimers[e.id] = window.setTimeout(
-        this.OnRemoveTimer.bind(this, e, false),
-        this.options.KeepExpiredTimerBarsForSeconds * 1000,
-      );
-      return;
-    } else if (e.id in this.expireTimers) {
-      window.clearTimeout(this.expireTimers[e.id]);
-      delete this.expireTimers[e.id];
-    }
-
-    const bar = this.activeBars[e.id];
-    if (!bar)
-      return;
-
-    const div = bar.parentNode;
-    const element = document.getElementById(e.id.toString());
-    if (!element)
-      return;
-
-    const removeBar = () => {
-      div?.parentNode?.removeChild(div);
-      delete this.activeBars[e.id];
-    };
-
-    if (!force)
-      element.classList.add('animate-timer-bar-removed');
-    if (window.getComputedStyle(element).animationName !== 'none') {
-      // Wait for animation to finish
-      element.addEventListener('animationend', removeBar);
-    } else {
-      removeBar();
-    }
-  }
-
-  public OnShowInfoText(text: string, currentTime: number): void {
-    if (this.popupText)
-      this.popupText.Info(text, currentTime);
-  }
-
-  public OnShowAlertText(text: string, currentTime: number): void {
-    if (this.popupText)
-      this.popupText.Alert(text, currentTime);
-  }
-
-  public OnShowAlarmText(text: string, currentTime: number): void {
-    if (this.popupText)
-      this.popupText.Alarm(text, currentTime);
-  }
-
-  public OnSpeakTTS(text: string, currentTime: number): void {
-    if (this.popupText)
-      this.popupText.TTS(text, currentTime);
-  }
-
-  public OnTrigger(
-    trigger: LooseTimelineTrigger,
-    matches: RegExpExecArray | null,
-    currentTime: number,
-  ): void {
-    if (this.popupText)
-      this.popupText.Trigger(trigger, matches, currentTime);
-  }
-
-  public OnSyncTime(fightNow: number, running: boolean): void {
-    if (!this.options.Debug || !this.debugElement)
-      return;
-
-    if (!running) {
-      if (this.debugFightTimer)
-        this.debugElement.removeChild(this.debugFightTimer);
-      this.debugFightTimer = null;
-      return;
-    }
-
-    if (!this.debugFightTimer) {
-      this.debugFightTimer = TimerBar.create();
-      this.debugFightTimer.width = '100px';
-      this.debugFightTimer.height = '17px';
-      this.debugFightTimer.duration = kBig;
-      this.debugFightTimer.lefttext = 'elapsed';
-      this.debugFightTimer.toward = 'right';
-      this.debugFightTimer.stylefill = 'fill';
-      this.debugFightTimer.bg = 'transparent';
-      this.debugFightTimer.fg = 'transparent';
-      this.debugElement.appendChild(this.debugFightTimer);
-    }
-
-    // Force this to be reset.
-    this.debugFightTimer.elapsed = 0;
-    this.debugFightTimer.elapsed = fightNow;
   }
 }
 

--- a/ui/raidboss/timeline.ts
+++ b/ui/raidboss/timeline.ts
@@ -29,9 +29,6 @@ const activeText = {
 export class TimelineUI {
   protected timeline: Timeline | null = null;
 
-  constructor(protected options: RaidbossOptions) {
-  }
-
   protected Init(): void {
     /* noop */
   }

--- a/util/test_timeline.ts
+++ b/util/test_timeline.ts
@@ -547,29 +547,13 @@ class TestTimelineUI extends TimelineUI {
   public fightNow = 0;
 
   public constructor(protected override timeline: TestTimeline) {
-    super(defaultRaidbossOptions);
+    super();
   }
+
   public override OnSyncTime(fightNow: number, _running: boolean): void {
     this.fightNow = fightNow;
   }
-  public override OnRemoveTimer(_e: Event, _expired: boolean, _force?: boolean): void {
-    /* noop */
-  }
-  public override OnAddTimer(_fightNow: number, _e: Event, _channeling: boolean): void {
-    /* noop */
-  }
-  public override OnShowInfoText(_text: string, _currentTime: number): void {
-    /* noop */
-  }
-  public override OnShowAlertText(_text: string, _currentTime: number): void {
-    /* noop */
-  }
-  public override OnShowAlarmText(_text: string, _currentTime: number): void {
-    /* noop */
-  }
-  public override OnSpeakTTS(_text: string, _currentTime: number): void {
-    /* noop */
-  }
+
   public override OnTrigger(
     trigger: Partial<TimelineTrigger<RaidbossData>>,
     matches: RegExpExecArray,


### PR DESCRIPTION
Refactor TimelineUI into HTMLTimelineUI and base class TimelineUI.  This puts HTMLTimelineUI in its own file so it's possible to run test_timeline without including dom.