### PR TITLE
raidboss: fix abilityid for ASS/S Slippery Soap

### DIFF
--- a/ui/raidboss/data/06-ew/dungeon/another_sildihn_subterrane-savage.ts
+++ b/ui/raidboss/data/06-ew/dungeon/another_sildihn_subterrane-savage.ts
@@ -293,11 +293,10 @@ const triggerSet: TriggerSet<Data> = {
     {
       id: 'ASSS Slippery Soap',
       // Happens 5 times in the encounter
-      type: 'StartsUsing',
-      // this was originally triggered by 79FB, which is an (unmapped) ability targeting a player used by Silkie or Eastern Ewer
-      // but it always happens at the same time that Silkie starts using 7781 (the actual Slippery Soap cast)
-      // so it's more accurate to fire this trigger based off of Silkie's cast
-      netRegex: { id: '7781', source: 'Silkie' },
+      type: 'Ability',
+      // Silkie begins casting Slippery Soap (7781), and at the same time, either Silkie or an invisible actor will use 79FB on a player
+      // the 79FB ability appears to correspond to the stack marker on that player, so use that ability id instead
+      netRegex: { id: '79FB' },
       preRun: (data) => data.soapCounter++,
       alertText: (data, matches, output) => {
         if (data.suds === 'CE1') {

--- a/ui/raidboss/data/06-ew/dungeon/another_sildihn_subterrane.ts
+++ b/ui/raidboss/data/06-ew/dungeon/another_sildihn_subterrane.ts
@@ -292,11 +292,10 @@ const triggerSet: TriggerSet<Data> = {
     {
       id: 'ASS Slippery Soap',
       // Happens 5 times in the encounter
-      type: 'StartsUsing',
-      // this was originally triggered by 79FB, which is an (unmapped) ability targeting a player used by Silkie or Eastern Ewer
-      // but it always happens at the same time that Silkie starts using 775E (the actual Slippery Soap cast)
-      // so it's more accurate to fire this trigger based off of Silkie's cast
-      netRegex: { id: '775E', source: 'Silkie' },
+      type: 'Ability',
+      // Silkie begins casting Slippery Soap (775E), and at the same time, either Silkie or an invisible actor will use 79FB on a player
+      // the 79FB ability appears to correspond to the stack marker on that player, so use that ability id instead
+      netRegex: { id: '79FB' },
       preRun: (data) => data.soapCounter++,
       alertText: (data, matches, output) => {
         if (data.suds === 'CE1') {


### PR DESCRIPTION
Reverts changes to this trigger in #5036 and removes `source` from netRegex to account for the fact that this ability can be used sometimes by an invisible actor.  

Closes #5064 