### PR TITLE
util: remove index.ts path from test_timeline

### DIFF
--- a/util/index.ts
+++ b/util/index.ts
@@ -4,7 +4,6 @@ import inquirerFuzzyPath, { FuzzyPathQuestionOptions } from 'inquirer-fuzzy-path
 
 import { registerFindMissingTranslations } from './find_missing_translations';
 import { registerGenerateDataFiles } from './generate_data_files';
-import { registerTestTimeline } from './test_timeline';
 import { registerTranslateTimeline } from './translate_timeline';
 
 declare module 'inquirer' {
@@ -35,7 +34,6 @@ const subparsers = argumentParser.addSubparsers({
 registerTranslateTimeline(actionChoices, subparsers);
 registerGenerateDataFiles(actionChoices, subparsers);
 registerFindMissingTranslations(actionChoices, subparsers);
-registerTestTimeline(actionChoices, subparsers);
 
 inquirer.registerPrompt('fuzzypath', inquirerFuzzyPath);
 


### PR DESCRIPTION
There's many things that make sense to run from `npm run util` but make and test timeline both have a lot of parameters and are more suited for command-line repeated iteration with the same / edited parameters.

Rather than supporting two paths for all of the parameters, only support command line args, removing a bunch of code.

This makes it possible to run `ts-node util/test_timeline.ts` directly now.