### PR TITLE
util: refactor fflogs parseReport for sharing

### DIFF
--- a/util/logtools/make_timeline.ts
+++ b/util/logtools/make_timeline.ts
@@ -27,7 +27,7 @@ import FFLogs from './fflogs';
 
 // TODO: Add support for compiling log lines during the collector pre-pass.
 
-export type TimelineEntry = {
+type TimelineEntry = {
   time: string;
   combatant?: string;
   abilityId?: string;


### PR DESCRIPTION
There's a bunch of logic that goes into stitching together data from fflogs.  Move this to a shared place and use a data structure that's less tied to make_timeline to return data.