### PR TITLE
util: fix make_timeline ignoring all entries

### DIFF
--- a/util/logtools/make_timeline.ts
+++ b/util/logtools/make_timeline.ts
@@ -356,7 +356,7 @@ const ignoreTimelineAbilityEntry = (entry: TimelineEntry, args: ExtendedArgs): b
     return true;
 
   // If only-combatants was specified, ignore all combatants not in the list.
-  if (combatant !== undefined && !args.only_combatant?.includes(combatant))
+  if (combatant !== undefined && args.only_combatant && !args.only_combatant?.includes(combatant))
     return true;
   return false;
 };


### PR DESCRIPTION
I broke this with some last minutue "cleanup" in #5075 and neglected to test these final few changes enough.  Oops, sorry.