### PR TITLE
util: add fflogs support to test_timeline

### DIFF
--- a/util/logtools/fflogs.ts
+++ b/util/logtools/fflogs.ts
@@ -163,7 +163,7 @@ class FFLogs {
     key: string,
     startTime: number,
     endTime: number,
-    filter = 'source.disposition="enemy" and type="cast"',
+    filter = 'source.disposition="enemy" and (type="cast" or type="begincast")',
     translate = true,
   ): Promise<FFLogsEventEntry[]> => {
     const eventOptionParams = new URLSearchParams({


### PR DESCRIPTION
This also fixes a bug in test_timeline's `testLineEvents` where it was not setting the time before processing a log line. Normally, time advances linearly with a timer and ticks periodically, and this causes the set of active syncs to be updated.  For test timelines, there's no such timer, so the current time needs to be set prior to processing the log line or the set of active syncs will be stale.

This is not an issue for `-f` style logs, as there's usually enough log lines to update the time appropriately.  However, for fflogs that only include boss abilities, this causes many incorrect stale syncs.

Additionally, it seems unnecessary to sync after every long line, which might create incorrect timings.  If the sync occurs because a regex matches, then the time will be updated as needed.