### PR TITLE
config: implement zoneLabel property

### DIFF
--- a/docs/OopsyraidsyGuide.md
+++ b/docs/OopsyraidsyGuide.md
@@ -10,6 +10,9 @@ import ZoneId from '../path/to/resources/zone_id';
 
 export default {
   zoneId: ZoneId.TheUnendingCoilOfBahamutUltimate,
+  zoneLabel: {
+    en: 'The Unending Coil of Bahamut (Ultimate)',
+  },
   damageWarn: {
     'UCU Lunar Dynamo': '26BC',
     // ...
@@ -58,6 +61,10 @@ The set of id names can be found in [zone_id.ts](../resources/zone_id.ts).
 Prefer using this over zoneRegex.
 A trigger set must have one of zoneId or zoneRegex to specify the zone
 (but not both).
+
+**zoneLabel**
+An optional name to use for this trigger set in the configuration interface.
+Overrides the zone name from [zone_info.ts](../resources/zone_info.ts).
 
 **zoneRegex**:
 A regular expression that matches against the zone name (coming from ACT).

--- a/docs/RaidbossGuide.md
+++ b/docs/RaidbossGuide.md
@@ -12,6 +12,9 @@ import ZoneId from '../path/to/resources/zone_id';
 
 export default {
   zoneId: ZoneId.TheWeaponsRefrainUltimate,
+  zoneLabel: {
+    en: 'The Weapon\'s Refrain (Ultimate)',
+  },
   overrideTimelineFile: false,
   timelineFile: 'filename.txt',
   timeline: `hideall`,
@@ -43,6 +46,10 @@ The set of id names can be found in [zone_id.ts](../resources/zone_id.ts).
 Prefer using this over zoneRegex.
 A trigger set must have one of zoneId or zoneRegex to specify the zone
 (but not both).
+
+**zoneLabel**
+An optional name to use for this trigger set in the configuration interface.
+Overrides the zone name from [zone_info.ts](../resources/zone_info.ts).
 
 **initData**
 A function that can be used to initialize the data this trigger set uses.

--- a/types/oopsy.d.ts
+++ b/types/oopsy.d.ts
@@ -106,6 +106,7 @@ type MistakeMap = { [mistakeId: string]: string };
 
 type SimpleOopsyTriggerSet = {
   zoneId: ZoneIdType | ZoneIdType[];
+  zoneLabel?: LocaleText;
   damageWarn?: MistakeMap;
   damageFail?: MistakeMap;
   gainsEffectWarn?: MistakeMap;

--- a/types/trigger.d.ts
+++ b/types/trigger.d.ts
@@ -173,7 +173,7 @@ type RequiredFieldsAsUnion<Type> = {
 export type BaseTriggerSet<Data extends RaidbossData> = {
   // ZoneId.MatchAll (aka null) is not supported in array form.
   zoneId: ZoneIdType | number[];
-  // label if the zoneId is an array or otherwise non-descriptive
+  // useful if the zoneId is an array or otherwise non-descriptive
   zoneLabel?: LocaleText;
   // If the timeline exists, but needs significant improvements and a rewrite.
   timelineNeedsFixing?: boolean;

--- a/types/trigger.d.ts
+++ b/types/trigger.d.ts
@@ -173,6 +173,8 @@ type RequiredFieldsAsUnion<Type> = {
 export type BaseTriggerSet<Data extends RaidbossData> = {
   // ZoneId.MatchAll (aka null) is not supported in array form.
   zoneId: ZoneIdType | number[];
+  // label if the zoneId is an array or otherwise non-descriptive
+  zoneLabel?: LocaleText;
   // If the timeline exists, but needs significant improvements and a rewrite.
   timelineNeedsFixing?: boolean;
   // If no timeline is possible for this zone, e.g. t3.

--- a/types/trigger.d.ts
+++ b/types/trigger.d.ts
@@ -173,7 +173,7 @@ type RequiredFieldsAsUnion<Type> = {
 export type BaseTriggerSet<Data extends RaidbossData> = {
   // ZoneId.MatchAll (aka null) is not supported in array form.
   zoneId: ZoneIdType | number[];
-  // useful if the zoneId is an array or otherwise non-descriptive
+  // useful if the zoneId is an array or zone name is otherwise non-descriptive
   zoneLabel?: LocaleText;
   // If the timeline exists, but needs significant improvements and a rewrite.
   timelineNeedsFixing?: boolean;

--- a/ui/config/config.ts
+++ b/ui/config/config.ts
@@ -192,7 +192,7 @@ const kDirectoryToCategory = {
   map: {
     en: 'Treasure Map',
   },
-  deep_dungeon: {
+  deepdungeon: {
     en: 'Deep Dungeon',
   },
 };

--- a/ui/config/config.ts
+++ b/ui/config/config.ts
@@ -186,6 +186,15 @@ const kDirectoryToCategory = {
     cn: '绝境战',
     ko: '절 난이도',
   },
+  hunts: {
+    en: 'Hunts & FATEs',
+  },
+  map: {
+    en: 'Treasure Maps',
+  },
+  deep_dungeon: {
+    en: 'Deep Dungeon',
+  },
 };
 
 // TODO: maybe we should also sort all the filenames properly too?
@@ -750,6 +759,14 @@ export class CactbotConfigurator {
           title = this.translate(zoneInfo.name);
       }
 
+      let zoneLabel: LocaleText | undefined = undefined;
+
+      // if a zoneLabel is set, use that instead
+      if (typeof triggerSet.zoneLabel === 'string') {
+        zoneLabel = triggerSet.zoneLabel;
+        title = this.translate(zoneLabel);
+      }
+
       const fileKey = filename.replace(/\//g, '-').replace(/.[jt]s$/, '');
       map[fileKey] = {
         filename: filename,
@@ -777,7 +794,12 @@ export class CactbotConfigurator {
       // may also use zoneRegex or also have errors and not have either.
       let title = '???';
       let zoneId: number | undefined = undefined;
-      if (typeof triggerSet.zoneId === 'number') {
+      let zoneLabel: LocaleText | undefined = undefined;
+      // if a zoneLabel is set, use that first
+      if (typeof triggerSet.zoneLabel === 'string') {
+        zoneLabel = triggerSet.zoneLabel;
+        title = this.translate(zoneLabel);
+      } else if (typeof triggerSet.zoneId === 'number') {
         zoneId = triggerSet.zoneId;
         // Use the translatable zone info name, if possible.
         const zoneInfo = ZoneInfo[zoneId];

--- a/ui/config/config.ts
+++ b/ui/config/config.ts
@@ -192,9 +192,6 @@ const kDirectoryToCategory = {
   map: {
     en: 'Treasure Map',
   },
-  deepdungeon: {
-    en: 'Deep Dungeon',
-  },
 };
 
 // TODO: maybe we should also sort all the filenames properly too?

--- a/ui/config/config.ts
+++ b/ui/config/config.ts
@@ -190,7 +190,7 @@ const kDirectoryToCategory = {
     en: 'Hunts & FATEs',
   },
   map: {
-    en: 'Treasure Maps',
+    en: 'Treasure Map',
   },
   deep_dungeon: {
     en: 'Deep Dungeon',
@@ -761,8 +761,8 @@ export class CactbotConfigurator {
 
       let zoneLabel: LocaleText | undefined = undefined;
 
-      // if a zoneLabel is set, use that instead
-      if (typeof triggerSet.zoneLabel === 'string') {
+      // if a zoneLabel is set, use for the title
+      if (triggerSet.zoneLabel) {
         zoneLabel = triggerSet.zoneLabel;
         title = this.translate(zoneLabel);
       }
@@ -795,8 +795,8 @@ export class CactbotConfigurator {
       let title = '???';
       let zoneId: number | undefined = undefined;
       let zoneLabel: LocaleText | undefined = undefined;
-      // if a zoneLabel is set, use that first
-      if (typeof triggerSet.zoneLabel === 'string') {
+      // if a zoneLabel is set, use for the title
+      if (triggerSet.zoneLabel) {
         zoneLabel = triggerSet.zoneLabel;
         title = this.translate(zoneLabel);
       } else if (typeof triggerSet.zoneId === 'number') {

--- a/ui/raidboss/data/00-misc/the_masked_carnivale.ts
+++ b/ui/raidboss/data/00-misc/the_masked_carnivale.ts
@@ -18,6 +18,9 @@ export interface Data extends RaidbossData {
 
 const triggerSet: TriggerSet<Data> = {
   zoneId: ZoneId.TheMaskedCarnivale,
+  zoneLabel: {
+    en: 'The Masked Carnivale',
+  },
   triggers: [
     // ================ Stage 01 Act 1 ================
     // intentionally blank


### PR DESCRIPTION
## Description
Implements an optional `zoneLabel` property for trigger sets.  Allows for providing a custom zone name for use in the configuration UI.

## Additonal Notes

Supports translated strings.

re: https://github.com/quisquous/cactbot/issues/5083#issuecomment-1313122130_