### PR TITLE
resources: use healerNames getter

### DIFF
--- a/resources/party.ts
+++ b/resources/party.ts
@@ -132,7 +132,7 @@ export default class PartyTracker {
 
   // see: otherTank, but for healers.
   otherHealer(name: string): string | undefined {
-    const names = this.roleToPartyNames_['healer'];
+    const names = this.healerNames;
     if (names.length !== 2)
       return;
     if (names[0] === name)


### PR DESCRIPTION
For some reason, `healerNames` getter was already defined but not used.  This updates `otherHealer` to be consistent with `otherTank`.