### PR TITLE
raidboss: fix broken sync key translation replace

### DIFF
--- a/ui/raidboss/common_replacement.ts
+++ b/ui/raidboss/common_replacement.ts
@@ -23,7 +23,7 @@ export const syncKeys = {
   //   network log lines: 00|timestamp|0839||Something will be sealed off
   //   NetRegexes: ^^00\|[^|]*\|0839\|[^|]*\|Something will be sealed off.*?\|
   seal:
-    `(?<=${parsedLB}|${networkLB}|${netRegexLB}|${paramLB})([^|]*) will be sealed off(?: in (?:[0-9]+ seconds)?)?`,
+    `(?<=${parsedLB}|${networkLB}|${netRegexLB}|${paramLB})([^|:]*) will be sealed off(?: in (?:[0-9]+ seconds)?)?`,
   unseal: 'is no longer sealed',
   engage: 'Engage!',
 };


### PR DESCRIPTION
Not sure when this broken, but it does wrong replace in current version for the translation having the text before the arena name ($1), like (cn lang for example):
- `^^00\|[^|]*\|0839\|[^|]*\|Something will be sealed off.*?\|` -> `^^00\|[^|]*\|0839\|[^|]*\|距Something被封锁还有.*?\|` (✔)
- ` 00:0839::Something will be sealed off` -> `距 00:0839::Something被封锁还有` (✘)
- `Something will be sealed off` -> `距Something被封锁还有` (✔)
- `00|2022-11-27T21:27:47.4638235+08:00|0839||Something will be sealed off` -> `00|2022-11-27T21:27:47.4638235+08:00|0839||距Something被封锁还有` (✔)

This PR add `:` in the regex for matching the area name in parsed log line to fix this issue, it should affect the triggers/timelines which using parsed log line to sync.