### PR TITLE
raidboss: Eden Normal timeline improvements

### DIFF
--- a/ui/raidboss/data/05-shb/raid/e2n.txt
+++ b/ui/raidboss/data/05-shb/raid/e2n.txt
@@ -32,7 +32,7 @@ hideall "Spell-In-Waiting"
 191.3 "Doomvoid Slicer" sync / 1[56]:[^:]*:Voidwalker:3E3C:/
 206.3 "Shadowflame" sync / 1[56]:[^:]*:Voidwalker:3E4D:/
 
-216.8 "Entropy" sync / 1[56]:[^:]*:Voidwalker:3E6E:/ window 30,5
+216.8 "Entropy" sync / 1[56]:[^:]*:Voidwalker:3E6E:/ window 50,5
 223.3 "Spell-In-Waiting" sync / 1[56]:[^:]*:Voidwalker:3E3E:/
 230.3 "Punishing Ray" sync / 1[56]:[^:]*:Voidwalker:3E47:/
 241.3 "Spell-In-Waiting" sync / 1[56]:[^:]*:Voidwalker:3E3E:/

--- a/ui/raidboss/data/05-shb/raid/e7n.txt
+++ b/ui/raidboss/data/05-shb/raid/e7n.txt
@@ -52,6 +52,7 @@ hideall "--sync--"
 
 
 # Rotation block. 135.6 seconds
+393.3 "--sync--" sync / 14:[^:]*:The Idol Of Darkness:(4E5[46]|4C53):/ window 400,20
 400.0 "Empty Flood" sync / 1[56]:[^:]*:The Idol Of Darkness:(4E5[46]|4C53):/ window 400,20
 410.3 "--targetable--"
 414.4 "Unjoined Aspect" sync / 1[56]:[^:]*:The Idol Of Darkness:4C3B:/

--- a/ui/raidboss/data/05-shb/raid/e8n.txt
+++ b/ui/raidboss/data/05-shb/raid/e8n.txt
@@ -14,7 +14,7 @@ hideall "--sync--"
 10.1 "--sync--" sync / 1[56]:[^:]*:Shiva:4DD7:/ window 15,5
 15.1 "Absolute Zero" sync / 1[56]:[^:]*:Shiva:4DD7:/
 27.2 "Redress" sync / 1[56]:[^:]*:Shiva:4F4F:/
-32.4 "Shining Armor" sync / 1[56]:[^:]*:Shiva:4DF1:/
+32.4 "Shining Armor" sync / 1[56]:[^:]*:Shiva:4DF1:/ window 32.4,5
 40.4 "Axe Kick/Scythe Kick" sync / 1[56]:[^:]*:Shiva:4DE[23]:/
 52.5 "Redress" sync / 1[56]:[^:]*:Shiva:4F4E:/
 57.6 "Frost Armor" sync / 1[56]:[^:]*:Shiva:4DF0:/
@@ -27,7 +27,7 @@ hideall "--sync--"
 111.2 "Icicle Impact" sync / 1[56]:[^:]*:Shiva:4E0A:/
 112.3 "Frigid Eruption" # sync / 1[56]:[^:]*:Shiva:4E09:/
 114.3 "Frigid Eruption" # sync / 1[56]:[^:]*:Shiva:4E09:/
-120.1 "Heavenly Strike" sync / 1[56]:[^:]*:Shiva:4DD8:/
+120.1 "Heavenly Strike" sync / 1[56]:[^:]*:Shiva:4DD8:/ window 120,10
 131.2 "Mirror, Mirror" sync / 1[56]:[^:]*:Shiva:4DD4:/
 143.4 "Driving Frost/Biting Frost" sync / 1[56]:[^:]*:Shiva:4DD[BC]:/
 148.5 "Reflected Frost" sync / 1[56]:[^:]*:Frozen Mirror:4DF[EF]:/
@@ -35,7 +35,7 @@ hideall "--sync--"
 165.7 "Shining Armor" sync / 1[56]:[^:]*:Shiva:4DF1:/
 173.7 "Axe Kick/Scythe Kick" sync / 1[56]:[^:]*:Shiva:4DE[23]:/
 181.9 "--Untargetable--"
-193.2 "Shattered World" sync / 1[56]:[^:]*:Shiva:4DE9:/
+193.2 "Shattered World" sync / 1[56]:[^:]*:Shiva:4DE9:/ window 193.2,15
 
 # Intermission. Fixed length.
 209.4 "Heart Asunder" sync / 1[56]:[^:]*:Mothercrystal:4E12:/
@@ -50,7 +50,7 @@ hideall "--sync--"
 261.2 "Rush" sync / 1[56]:[^:]*:Luminous Aether:4FC8:/
 
 # Post-intermission block
-272.6 "Skyfall" sync / 1[56]:[^:]*:Shiva:4E13:/
+272.6 "Skyfall" sync / 1[56]:[^:]*:Shiva:4E13:/ window 272.6,20
 287.9 "--targetable--"
 306.9 "Holy" sync / 1[56]:[^:]*:Shiva:4DE[CD]:/
 321.4 "Light Rampant" sync / 1[56]:[^:]*:Shiva:4DE8:/


### PR DESCRIPTION
Eden 7's change isn't that important, but it's an improvement, so I threw it in.

Eden 2 and 8 have had sync issues since before the start of Endwalker. Voidwalker's update should be self-explanatory. I'm still not sure where the Shiva sync issues come from, but on multiple occasions things have desynced by 3-5 seconds during the first phase. When I originally put this timeline together, player DPS was *far* too low to even think of breaking the timeline, so I never bothered to add safety sync windows.