### PR TITLE
raidboss: Fix zone seal message for a7s timeline

### DIFF
--- a/ui/raidboss/data/03-hw/raid/a7s.txt
+++ b/ui/raidboss/data/03-hw/raid/a7s.txt
@@ -52,7 +52,7 @@ hideall "--sync--"
 ##############################################################
 ################# Intro
 
-0 "--sync--" sync / 00:0839::electrocution gallery will be sealed off in 15 seconds/ window 10000
+0 "--sync--" sync / 00:0839::The electrocution gallery will be sealed off in 15 seconds/ window 10000
 8 "Hammertime x2"
 21 "Sizzlebeam"
 31 "Sizzlespark"


### PR DESCRIPTION
The current text of the zone seal seems to be `[12:34:56.789] ChatLog 00:0839::The electrocution gallery will be sealed off in 15 seconds!`. This PR updates the timeline file accordingly.