### PR TITLE
oopsy: 6.3 buff updates

### DIFF
--- a/ui/oopsyraidsy/buff_map.ts
+++ b/ui/oopsyraidsy/buff_map.ts
@@ -173,6 +173,12 @@ export const missedAbilityBuffMap: readonly MissableAbility[] = [
     abilityId: '64B9',
   },
   {
+    // BRD
+    id: 'Nature\'s Minne',
+    type: 'heal',
+    abilityId: '1CF0',
+  },
+  {
     // SMN (5.x ability, removed in Endwalker)
     id: 'Devotion',
     type: 'damage',


### PR DESCRIPTION
6.3: BRD Nature's Minne changed from single target to party-wide buff.