### PR TITLE
raidboss: Euphrosyne Matron's Harvest additional ID

### DIFF
--- a/ui/raidboss/data/06-ew/alliance/euphrosyne.ts
+++ b/ui/raidboss/data/06-ew/alliance/euphrosyne.ts
@@ -147,7 +147,7 @@ const triggerSet: TriggerSet<Data> = {
     {
       id: 'Euphrosyne Nophica Matron\'s Harvest',
       type: 'StartsUsing',
-      netRegex: { id: '7C1D', source: 'Nophica', capture: false },
+      netRegex: { id: '7C1[DE]', source: 'Nophica', capture: false },
       response: Responses.aoe(),
     },
     {


### PR DESCRIPTION
Nophica's Matron's Harvest raidwide has a second ID that is used second and sometimes third in the fight.