### PR TITLE
util: split on CRLF and not just LF in sync_files

### DIFF
--- a/util/sync_files.ts
+++ b/util/sync_files.ts
@@ -229,7 +229,7 @@ const processFile = (filename: string, zone: ZoneReplace, inputText: string): st
     }
   }
 
-  const lines = inputText.split('\n');
+  const lines = inputText.split('\r\n');
   const prefixes = Object.entries(zone.prefix);
   const others = Object.entries(zone.other);
   const ids = Object.entries(zone.id);
@@ -248,7 +248,7 @@ const processFile = (filename: string, zone: ZoneReplace, inputText: string): st
     output.push(line);
   }
 
-  return output.join('\n');
+  return output.join('\r\n');
 };
 
 const processAllFiles = async (root: string) => {


### PR DESCRIPTION
This makes it so running sync_files is a no-op and doesn't require lintfix.