### PR TITLE
raidboss: Fix Euphrosyne boss 3 stack + spread call

### DIFF
--- a/ui/raidboss/data/06-ew/alliance/euphrosyne.ts
+++ b/ui/raidboss/data/06-ew/alliance/euphrosyne.ts
@@ -669,7 +669,7 @@ const triggerSet: TriggerSet<Data> = {
       },
       outputStrings: {
         text: Outputs.stackOnPlayer,
-      }
+      },
     },
     {
       id: 'Euphrosyne Menphina Blue Moon',

--- a/ui/raidboss/data/06-ew/alliance/euphrosyne.ts
+++ b/ui/raidboss/data/06-ew/alliance/euphrosyne.ts
@@ -661,7 +661,15 @@ const triggerSet: TriggerSet<Data> = {
       type: 'StartsUsing',
       netRegex: { id: '7D67', source: 'Halone' },
       condition: (data) => !data.haloneIceDartTargets.includes(data.me),
-      response: Responses.stackMarkerOn(),
+      delaySeconds: 0.5,
+      alertText: (data, matches, output) => {
+        if (data.haloneIceDartTargets.includes(data.me))
+          return;
+        return output.text!({ player: matches.target });
+      },
+      outputStrings: {
+        text: Outputs.stackOnPlayer,
+      }
     },
     {
       id: 'Euphrosyne Menphina Blue Moon',


### PR DESCRIPTION
The condition for the Rondel trigger can potentially run before `haloneIceDartTargets` is fully populated, leading to a situation where a player is simultaneously instructed to spread and stack. Because `condition` evaluates prior to `delaySeconds`, we have to move the condition in-line and return if it's met.