### PR TITLE
raidboss: add p4-p6 initial timeline

### DIFF
--- a/ui/raidboss/data/06-ew/ultimate/the_omega_protocol.ts
+++ b/ui/raidboss/data/06-ew/ultimate/the_omega_protocol.ts
@@ -776,6 +776,7 @@ const triggerSet: TriggerSet<Data> = {
   timelineReplace: [
     {
       'locale': 'de',
+      'missingTranslations': true,
       'replaceSync': {
         'Omega(?!-)': 'Omega',
         'Omega-F': 'Omega-W',
@@ -831,6 +832,7 @@ const triggerSet: TriggerSet<Data> = {
     },
     {
       'locale': 'fr',
+      'missingTranslations': true,
       'replaceSync': {
         'Omega(?!-)': 'Oméga',
         'Omega-F': 'Oméga-F',
@@ -886,6 +888,7 @@ const triggerSet: TriggerSet<Data> = {
     },
     {
       'locale': 'ja',
+      'missingTranslations': true,
       'replaceSync': {
         'Omega(?!-)': 'オメガ',
         'Omega-F': 'オメガF',

--- a/ui/raidboss/data/06-ew/ultimate/the_omega_protocol.txt
+++ b/ui/raidboss/data/06-ew/ultimate/the_omega_protocol.txt
@@ -1,6 +1,6 @@
 ### The Omega Protocol
 # -p 7B03:15 7B40:206.4 7B13:400 7B47:600 7B7C:700 7F72:1100
-# -ii 7BFD 7B0A 7E70 7B0C 7B41 7E6B 7B3F 7BFE 7BFF 7B14 7B15 7B16 7B17 7B1C 7B1D 7B1E 7B2B 7B2C 7B39 7B20 7F75 7B36 7B37 7B35 7B43 7B28 7B32 7B23 7B24 7B49 7B4C 7C00  7B5F 7B60 7B5A 7B5B 7B6D 7B56 7B57 7BAE 7E51
+# -ii 7BFD 7B0A 7E70 7B0C 7B41 7E6B 7B3F 7BFE 7BFF 7B14 7B15 7B16 7B17 7B1C 7B1D 7B1E 7B2B 7B2C 7B39 7B20 7F75 7B36 7B37 7B35 7B43 7B28 7B32 7B23 7B24 7B49 7B4C 7C00  7B5F 7B60 7B5A 7B5B 7B6D 7B56 7B57 7AFB 7EF9 7C01 7B8B 7BAE 7E51
 
 hideall "--Reset--"
 hideall "--sync--"
@@ -139,9 +139,9 @@ hideall "--sync--"
 
 ### P4: Blue Screen
 600.0 "--sync--" sync / 1[56]:[^:]*:Omega:7B47:/ window 600,0
+600.0 "--untargetable--"
 607.1 "--sync--" sync / 1[56]:[^:]*:Omega:7B7A:/
-# TODO: Adjust targetable/untargetable
-607.3 "--targetable--"
+607.1 "--targetable--"
 615.2 "--sync--" sync / 1[56]:[^:]*:Omega:7B46:/
 619.0 "--sync--" sync / 1[56]:[^:]*:Omega:5779:/
 621.4 "Wave Cannon" sync / 1[56]:[^:]*:Omega:7B81:/
@@ -172,23 +172,25 @@ hideall "--sync--"
 650.6 "Wave Repeater 3" sync / 1[56]:[^:]*:Omega:7B51:/
 652.6 "Wave Repeater 4" sync / 1[56]:[^:]*:Omega:7B52:/
 661.6 "Blue Screen" sync / 1[56]:[^:]*:Omega:7B7B:/
+661.6 "--untargetable--"
 662.6 "Blue Screen Enrage" sync / 1[56]:[^:]*:Omega:7B7D:/
 
 
 ### P5: Run: Dynamis
 # Blue Screen DPS check passed
 700.0 "--sync--" sync / 1[56]:[^:]*:Omega:7B7C:/ window 700,0
+706.0 "--sync--" sync / 1[56]:[^:]*:Omega-F:7B86:/
 706.0 "--sync--" sync / 1[56]:[^:]*:Omega-M:7B85:/
 
 # Delta Version
-# TODO: Adjust targetable/untargetable
 715.6 "--targetable--"
 723.6 "Solar Ray 1" sync / 1[56]:[^:]*:Omega-M:81AC:/
 726.8 "Solar Ray 2" sync / 1[56]:[^:]*:Omega-M:7B01:/
 733.9 "--sync--" sync / 1[56]:[^:]*:Omega-M:7B42:/
 740.0 "Run: ****mi* (Delta Version)" sync / 1[56]:[^:]*:Omega-M:7B88:/
 743.0 "--untargetable--"
-
+747.2 "Peripheral Synthesis" sync / 1[56]:[^:]*:Omega:7B8C:/
+753.2 "Archive Peripheral" sync / 1[56]:[^:]*:Omega:7F76:/
 761.2 "Patch" #sync / 1[56]:[^:]*:Omega-M:7B63:/
 763.2 "Optical Laser" sync / 1[56]:[^:]*:Optical Unit:7B21:/
 764.9 "Patch" #sync / 1[56]:[^:]*:Omega-M:7B63:/
@@ -384,4 +386,5 @@ hideall "--sync--"
 # Tank 2 and Healer 2 Brilliant Dynamis Checks
 1382.8 "Magic Number" sync / 1[56]:[^:]*:Alpha Omega:7BB6:/
 
+1391.9 "--sync--" sync / 14:[^:]*:Alpha Omega:7BA0:/ window 50,50
 1407.9 "Run: ****mi* Enrage" sync / 1[56]:[^:]*:Alpha Omega:7BA0:/

--- a/ui/raidboss/data/06-ew/ultimate/the_omega_protocol.txt
+++ b/ui/raidboss/data/06-ew/ultimate/the_omega_protocol.txt
@@ -279,7 +279,7 @@ hideall "--sync--"
 
 ### P6: Alpha Omega
 # Blind Faith DPS check passed
-1100.0 "--sync--" sync / 1[56]:[^:]*:Omega-F:7F72:/
+1100.0 "--sync--" sync / 1[56]:[^:]*:Omega-F:7F72:/ window 1100,0
 
 # TODO: Adjust targetable
 1160.0 "--targetable--"

--- a/ui/raidboss/data/06-ew/ultimate/the_omega_protocol.txt
+++ b/ui/raidboss/data/06-ew/ultimate/the_omega_protocol.txt
@@ -132,7 +132,7 @@ hideall "--sync--"
 550.1 "Critical Error" sync / 1[56]:[^:]*:Omega:7B64:/
 
 560.2 "--sync--" sync / 1[56]:[^:]*:Omega:7B46:/
-571.4 "Oversampled Wave Cannon" sync / 1[56]:[^:]*:Omega:[7B6B|7B6C]:/
+571.4 "Oversampled Wave Cannon" sync / 1[56]:[^:]*:Omega:(7B6B|7B6C):/
 577.4 "--sync--" sync / 14:[^:]*:Omega:7B48:/ window 50,50
 587.4 "Ion Efflux Enrage" sync / 1[56]:[^:]*:Omega:7B48:/
 
@@ -232,7 +232,7 @@ hideall "--sync--"
 852.4 "Discharger" sync / 1[56]:[^:]*:Omega-M:7B2E:/
 856.4 "Storage Violation x5 / Storage Violation x6" sync / 1[56]:[^:]*:Omega:7B0[45]:/
 
-873.7 "Superliminal Steel/Optimized Blizzard III" sync / 1[56]:[^:]*:Omega-M:[7B2A|7B2D]:/
+873.7 "Superliminal Steel/Optimized Blizzard III" sync / 1[56]:[^:]*:Omega-M:(7B2A|7B2D):/
 880.6 "Hello, Near World 1" sync / 1[56]:[^:]*:Omega-F:7B89:/
 880.6 "Hello, Distant World 1" sync / 1[56]:[^:]*:Omega-F:8110:/
 880.6 "Hyper Pulse" sync / 1[56]:[^:]*:Right Arm Unit:7B72:/

--- a/ui/raidboss/data/06-ew/ultimate/the_omega_protocol.txt
+++ b/ui/raidboss/data/06-ew/ultimate/the_omega_protocol.txt
@@ -189,7 +189,7 @@ hideall "--sync--"
 733.9 "--sync--" sync / 1[56]:[^:]*:Omega-M:7B42:/
 740.0 "Run: ****mi* (Delta Version)" sync / 1[56]:[^:]*:Omega-M:7B88:/
 743.0 "--untargetable--"
-747.2 "Peripheral Synthesis" sync / 1[56]:[^:]*:Omega:7B8C:/
+750.2 "Peripheral Synthesis" sync / 1[56]:[^:]*:Omega:7B8C:/
 753.2 "Archive Peripheral" sync / 1[56]:[^:]*:Omega:7F76:/
 761.2 "Patch" #sync / 1[56]:[^:]*:Omega-M:7B63:/
 763.2 "Optical Laser" sync / 1[56]:[^:]*:Optical Unit:7B21:/

--- a/ui/raidboss/data/06-ew/ultimate/the_omega_protocol.txt
+++ b/ui/raidboss/data/06-ew/ultimate/the_omega_protocol.txt
@@ -1,6 +1,6 @@
 ### The Omega Protocol
-# -p 7B03:15 7B40:206.4 7B13:400
-# -ii 7BFD 7B0A 7E70 7B0C 7B41 7E6B 7B3F 7BFE 7BFF 7B14 7B15 7B16 7B17 7B1C 7B1D 7B1E 7B2B 7B2C 7B39 7B20 7F75 7B36 7B37 7B35 7B43 7B28 7B32 7B23 7B24 7B49 7B4C 7C00  7B5F 7B60 7B5A 7B5B 7B6D 7B56 7B57
+# -p 7B03:15 7B40:206.4 7B13:400 7B47:600 7B7C:700 7F72:1100
+# -ii 7BFD 7B0A 7E70 7B0C 7B41 7E6B 7B3F 7BFE 7BFF 7B14 7B15 7B16 7B17 7B1C 7B1D 7B1E 7B2B 7B2C 7B39 7B20 7F75 7B36 7B37 7B35 7B43 7B28 7B32 7B23 7B24 7B49 7B4C 7C00  7B5F 7B60 7B5A 7B5B 7B6D 7B56 7B57 7BAE 7E51
 
 hideall "--Reset--"
 hideall "--sync--"
@@ -134,4 +134,256 @@ hideall "--sync--"
 560.2 "--sync--" sync / 1[56]:[^:]*:Omega:7B46:/
 571.4 "Oversampled Wave Cannon" sync / 1[56]:[^:]*:Omega:7B6C:/
 577.4 "--sync--" sync / 14:[^:]*:Omega:7B48:/ window 50,50
-587.4 "Ion Efflux" sync / 1[56]:[^:]*:Omega:7B48:/
+587.4 "Ion Efflux Enrage" sync / 1[56]:[^:]*:Omega:7B48:/
+
+
+### P4: Blue Screen
+600.0 "--sync--" sync / 1[56]:[^:]*:Omega:7B47:/ window 600,0
+607.1 "--sync--" sync / 1[56]:[^:]*:Omega:7B7A:/
+# TODO: Adjust targetable/untargetable
+607.3 "--targetable--"
+615.2 "--sync--" sync / 1[56]:[^:]*:Omega:7B46:/
+619.0 "--sync--" sync / 1[56]:[^:]*:Omega:5779:/
+621.4 "Wave Cannon" sync / 1[56]:[^:]*:Omega:7B81:/
+622.1 "Wave Cannon 1" #sync / 1[56]:[^:]*:Omega:7B7E:/
+626.7 "Wave Cannon" #sync / 1[56]:[^:]*:Omega:7F16:/
+626.8 "Wave Cannon 2" #sync / 1[56]:[^:]*:Omega:7B80:/
+627.0 "Wave Cannon (Stacks)" sync / 1[56]:[^:]*:Omega:7B7F:/
+
+629.1 "--sync--" sync / 1[56]:[^:]*:Omega:5779:/
+629.4 "Wave Repeater 1" sync / 1[56]:[^:]*:Omega:7B4F:/
+631.5 "Wave Repeater 2" sync / 1[56]:[^:]*:Omega:7B50:/
+631.5 "Wave Cannon" sync / 1[56]:[^:]*:Omega:7F16:/
+632.1 "Wave Cannon 1" #sync / 1[56]:[^:]*:Omega:7B7E:/
+633.5 "Wave Repeater 3" sync / 1[56]:[^:]*:Omega:7B51:/
+635.5 "Wave Repeater 4" sync / 1[56]:[^:]*:Omega:7B52:/
+636.6 "Wave Cannon" #sync / 1[56]:[^:]*:Omega:7B82:/
+636.7 "Wave Cannon 2" #sync / 1[56]:[^:]*:Omega:7B80:/
+636.8 "Wave Cannon (Stacks)" sync / 1[56]:[^:]*:Omega:7B7F:/
+
+639.0 "--sync--" sync / 1[56]:[^:]*:Omega:5779:/
+641.6 "Wave Cannon" sync / 1[56]:[^:]*:Omega:7B83:/
+642.2 "Wave Cannon 1" #sync / 1[56]:[^:]*:Omega:7B7E:/
+646.6 "Wave Repeater 1" sync / 1[56]:[^:]*:Omega:7B4F:/
+646.7 "Wave Cannon" #sync / 1[56]:[^:]*:Omega:7B84:/
+646.8 "Wave Cannon 2" #sync / 1[56]:[^:]*:Omega:7B80:/
+646.9 "Wave Cannon (Stacks)" sync / 1[56]:[^:]*:Omega:7B7F:/
+648.6 "Wave Repeater 2" sync / 1[56]:[^:]*:Omega:7B50:/
+650.6 "Wave Repeater 3" sync / 1[56]:[^:]*:Omega:7B51:/
+652.6 "Wave Repeater 4" sync / 1[56]:[^:]*:Omega:7B52:/
+661.6 "Blue Screen" sync / 1[56]:[^:]*:Omega:7B7B:/
+662.6 "Blue Screen Enrage" sync / 1[56]:[^:]*:Omega:7B7D:/
+
+
+### P5: Run: Dynamis
+# Blue Screen DPS check passed
+700.0 "--sync--" sync / 1[56]:[^:]*:Omega:7B7C:/ window 700,0
+706.0 "--sync--" sync / 1[56]:[^:]*:Omega-M:7B85:/
+
+# Delta Version
+# TODO: Adjust targetable/untargetable
+715.6 "--targetable--"
+723.6 "Solar Ray 1" sync / 1[56]:[^:]*:Omega-M:81AC:/
+726.8 "Solar Ray 2" sync / 1[56]:[^:]*:Omega-M:7B01:/
+733.9 "--sync--" sync / 1[56]:[^:]*:Omega-M:7B42:/
+740.0 "Run: ****mi* (Delta Version)" sync / 1[56]:[^:]*:Omega-M:7B88:/
+743.0 "--untargetable--"
+
+761.2 "Patch" #sync / 1[56]:[^:]*:Omega-M:7B63:/
+763.2 "Optical Laser" sync / 1[56]:[^:]*:Optical Unit:7B21:/
+764.9 "Patch" #sync / 1[56]:[^:]*:Omega-M:7B63:/
+768.5 "Beyond Defense" sync / 1[56]:[^:]*:Omega-M:7B27:/
+771.1 "Hyper Pulse" sync / 1[56]:[^:]*:Right Arm Unit:7B70:/
+771.8 "Hyper Pulse" #sync / 1[56]:[^:]*:Right Arm Unit:7B71:/
+772.4 "Hyper Pulse" #sync / 1[56]:[^:]*:Right Arm Unit:7B71:/
+773.0 "Hyper Pulse" #sync / 1[56]:[^:]*:Right Arm Unit:7B71:/
+773.6 "Hyper Pulse" #sync / 1[56]:[^:]*:Right Arm Unit:7B71:/
+773.6 "Oversampled Wave Cannon" sync / 1[56]:[^:]*:Omega:7B6D:/
+774.0 "Pile Pitch" sync / 1[56]:[^:]*:Omega-M:7B29:/
+774.0 "Hyper Pulse" #sync / 1[56]:[^:]*:Right Arm Unit:7B71:/
+782.0 "Patch" #sync / 1[56]:[^:]*:Omega-M:7B63:/
+784.0 "Patch" #sync / 1[56]:[^:]*:Omega-M:7B63:/
+787.0 "Hello, Distant World 1" sync / 1[56]:[^:]*:Omega-M:8110:/
+787.0 "Hello, Near World 1" sync / 1[56]:[^:]*:Omega-M:7B89:/
+788.0 "Hello, Distant World 2" #sync / 1[56]:[^:]*:Omega-M:8111:/
+788.0 "Hello, Near World 2" #sync / 1[56]:[^:]*:Omega-M:7B8A:/
+789.0 "Hello, Distant World 3" #sync / 1[56]:[^:]*:Omega-M:8111:/
+789.0 "Hello, Near World 3" #sync / 1[56]:[^:]*:Omega-M:7B8A:/
+
+# Sigma Version
+# TODO: Adjust targetable/untargetable
+791.0 "--targetable--"
+815.6 "--sync--" sync / 1[56]:[^:]*:Omega-M:7B42:/
+821.7 "Run: ****mi* (Sigma Version)" sync / 1[56]:[^:]*:Omega-M:8014:/
+824.7 "--untargetable--"
+
+839.0 "Subject Simulation F" sync / 1[56]:[^:]*:Omega-M:7F2F:/
+840.0 "--sync--" sync / 1[56]:[^:]*:Omega-M:7B14:/
+841.1 "--sync--" sync / 1[56]:[^:]*:Omega-M:7B16:/
+843.8 "Hyper Pulse" sync / 1[56]:[^:]*:Right Arm Unit:7B72:/
+843.9 "Wave Cannon" #sync / 1[56]:[^:]*:Omega:7B74:/
+843.9 "Wave Cannon" #sync / 1[56]:[^:]*:Omega:7B74:/
+845.1 "--sync--" sync / 1[56]:[^:]*:Omega-M:7F30:/
+848.7 "--sync--" sync / 1[56]:[^:]*:Omega:7B15:/
+849.3 "--sync--" sync / 1[56]:[^:]*:Omega-M:7B20:/
+851.3 "--sync--" sync / 1[56]:[^:]*:Omega-M:7B43:/
+
+852.4 "Discharger" sync / 1[56]:[^:]*:Omega-M:7B2E:/
+856.4 "Storage Violation x5 / Storage Violation x6" sync / 1[56]:[^:]*:Omega:7B0[45]:/
+
+873.7 "Superliminal Steel/Optimized Blizzard III" sync / 1[56]:[^:]*:Omega-M:[7B2A|7B2D]:/
+880.6 "Hello, Near World 1" sync / 1[56]:[^:]*:Omega-F:7B89:/
+880.6 "Hello, Distant World 1" sync / 1[56]:[^:]*:Omega-F:8110:/
+880.6 "Hyper Pulse" sync / 1[56]:[^:]*:Right Arm Unit:7B72:/
+881.6 "Hello, Near World 2" #sync / 1[56]:[^:]*:Omega-F:7B8A:/
+881.6 "Hello, Distant World 2" #sync / 1[56]:[^:]*:Omega-F:8111:/
+882.6 "Hello, Near World 3" #sync / 1[56]:[^:]*:Omega-F:7B8A:/
+882.6 "Hello, Distant World 3" #sync / 1[56]:[^:]*:Omega-F:8111:/
+
+# Omega Version
+# TODO: Adjust targetable/untargetable
+884.6 "--targetable--"
+894.3 "Solar Ray 1" sync / 1[56]:[^:]*:Omega-M:81AD:/
+897.4 "Solar Ray 2" sync / 1[56]:[^:]*:Omega-M:7B02:/
+904.6 "--sync--" sync / 1[56]:[^:]*:Omega-M:7B43:/
+910.8 "Run: ****mi* (Omega Version)" sync / 1[56]:[^:]*:Omega-M:8015:/
+929.2 "Diffuse Wave Cannon" sync / 1[56]:[^:]*:Omega:7B79:/
+933.3 "Diffuse Wave Cannon" sync / 1[56]:[^:]*:Omega:7B79:/
+936.0 "--untargetable--"
+
+946.0 "Hello, Distant World 1" sync / 1[56]:[^:]*:Omega-F:8110:/
+946.0 "Hello, Near World 1" sync / 1[56]:[^:]*:Omega-F:7B89:/
+946.4 "Oversampled Wave Cannon" sync / 1[56]:[^:]*:Omega:7B6D:/
+947.0 "Hello, Distant World 2" #sync / 1[56]:[^:]*:Omega-F:8111:/
+947.0 "Hello, Near World 2" #sync / 1[56]:[^:]*:Omega-F:7B8A:/
+948.0 "Hello, Distant World 3" #sync / 1[56]:[^:]*:Omega-F:8111:/
+948.0 "Hello, Near World 3" #sync / 1[56]:[^:]*:Omega-F:7B8A:/
+
+962.2 "Blaster x2" sync / 1[56]:[^:]*:Omega-F:7E75:/
+964.0 "Hello, Distant World 1" sync / 1[56]:[^:]*:Omega-F:8110:/
+964.0 "Hello, Near World 1" sync / 1[56]:[^:]*:Omega-F:7B89:/
+965.0 "Hello, Distant World 2" #sync / 1[56]:[^:]*:Omega-F:8111:/
+965.0 "Hello, Near World 2" #sync / 1[56]:[^:]*:Omega-F:7B8A:/
+966.0 "Hello, Distant World 3" #sync / 1[56]:[^:]*:Omega-F:8111:/
+966.0 "Hello, Near World 3" #sync / 1[56]:[^:]*:Omega-F:7B8A:/
+
+# TODO: Adjust targetable/untargetable
+968.5 "--targetable--"
+977.4 "Solar Ray 1" sync / 1[56]:[^:]*:Omega-M:81AD:/
+980.5 "Solar Ray 2" sync / 1[56]:[^:]*:Omega-M:7B02:/
+988.2 "--sync--" sync / 1[56]:[^:]*:Omega-M:7B43:/
+999.3 "Blind Faith" sync / 1[56]:[^:]*:Omega-M:7B87:/
+1000.5 "Blind Faith Enrage" sync / 1[56]:[^:]*:Omega-F:7F73:/
+
+
+### P6: Alpha Omega
+# Blind Faith DPS check passed
+1100.0 "--sync--" sync / 1[56]:[^:]*:Omega-F:7F72:/
+
+# TODO: Adjust targetable
+1160.0 "--targetable--"
+# LB3 Check
+1167.8 "Cosmo Memory" sync / 1[56]:[^:]*:Alpha Omega:7BA1:/
+1171.9 "--sync--" sync / 1[56]:[^:]*:Alpha Omega:7C03:/
+1172.8 "Flash Gale 1" sync / 1[56]:[^:]*:Omega-F:7DDF:/
+1175.1 "--sync--" sync / 1[56]:[^:]*:Alpha Omega:7C03:/
+1176.0 "Flash Gale 2" sync / 1[56]:[^:]*:Alpha Omega:7DDF:/
+
+1182.2 "Cosmo Arrow" sync / 1[56]:[^:]*:Alpha Omega:7BA2:/
+1184.2 "Cosmo Arrow 1" #sync / 1[56]:[^:]*:Alpha Omega:7BA3:/
+1186.2 "Cosmo Arrow 2" #sync / 1[56]:[^:]*:Alpha Omega:7BA3:/
+1186.2 "Cosmo Arrow Exaflare 1" #sync / 1[56]:[^:]*:Alpha Omega:7BA4:/
+1188.2 "Cosmo Arrow Exaflare 2" #sync / 1[56]:[^:]*:Alpha Omega:7BA4:/
+1190.2 "Cosmo Arrow Exaflare 3" #sync / 1[56]:[^:]*:Alpha Omega:7BA4:/
+1192.2 "Cosmo Arrow Exaflare 4" #sync / 1[56]:[^:]*:Alpha Omega:7BA4:/
+1194.2 "Cosmo Arrow Exaflare 5" #sync / 1[56]:[^:]*:Alpha Omega:7BA4:/
+1196.2 "Cosmo Arrow Exaflare 6" #sync / 1[56]:[^:]*:Alpha Omega:7BA4:/
+1196.9 "Cosmo Dive" sync / 1[56]:[^:]*:Alpha Omega:7BA6:/
+1199.3 "Cosmo Dive Far" #sync / 1[56]:[^:]*:Alpha Omega:7BA8:/
+1199.3 "Cosmo Dive Near x2" #sync / 1[56]:[^:]*:Alpha Omega:7BA7:/
+1206.1 "--sync--" sync / 1[56]:[^:]*:Alpha Omega:7C03:/
+1207.0 "Flash Gale 1" sync / 1[56]:[^:]*:Alpha Omega:7DDF:/
+1209.3 "--sync--" sync / 1[56]:[^:]*:Alpha Omega:7C03:/
+1210.2 "Flash Gale 2" sync / 1[56]:[^:]*:Alpha Omega:7DDF:/
+
+1215.4 "Unlimited Wave Cannon" sync / 1[56]:[^:]*:Alpha Omega:7BAC:/
+1222.4 "Wave Cannon Exaflare 1" sync / 1[56]:[^:]*:Alpha Omega:7BAD:/ duration 5.7
+1223.4 "Wave Cannon Puddles 1" #sync / 1[56]:[^:]*:Alpha Omega:7BAF:/
+1223.4 "Wave Cannon Exaflare 2" #sync / 1[56]:[^:]*:Alpha Omega:7BAD:/ duration 5.7
+1224.3 "Wave Cannon Exaflare 3" #sync / 1[56]:[^:]*:Alpha Omega:7BAD:/ duration 5.7
+1225.2 "Wave Cannon Exaflare 4" #sync / 1[56]:[^:]*:Alpha Omega:7BAD:/ duration 5.7
+1225.2 "Wave Cannon Puddles 2" #sync / 1[56]:[^:]*:Alpha Omega:7BAF:/
+1227.1 "Wave Cannon Puddles 3" #sync / 1[56]:[^:]*:Alpha Omega:7BAF:/
+1229.0 "Wave Cannon Puddles 4" #sync / 1[56]:[^:]*:Alpha Omega:7BAF:/
+1230.9 "Wave Cannon Puddles 5" #sync / 1[56]:[^:]*:Alpha Omega:7BAF:/
+1232.9 "Wave Cannon Puddles 6" #sync / 1[56]:[^:]*:Alpha Omega:7BAF:/
+1236.0 "Wave Cannon 1" #sync / 1[56]:[^:]*:Alpha Omega:7BAB:/
+1238.0 "Wave Cannon 2" #sync / 1[56]:[^:]*:Alpha Omega:7BAB:/
+1243.9 "--sync--" sync / 1[56]:[^:]*:Alpha Omega:7BA9:/
+1244.3 "Wave Cannon (Wild Charge)" #sync / 1[56]:[^:]*:Alpha Omega:7BAA:/
+1248.4 "--sync--" sync / 1[56]:[^:]*:Alpha Omega:7C03:/
+1249.3 "Flash Gale 1" sync / 1[56]:[^:]*:Alpha Omega:7DDF:/
+1251.6 "--sync--" sync / 1[56]:[^:]*:Alpha Omega:7C03:/
+1252.5 "Flash Gale 2" sync / 1[56]:[^:]*:Alpha Omega:7DDF:/
+
+1258.7 "Cosmo Arrow" sync / 1[56]:[^:]*:Alpha Omega:7BA2:/
+1260.9 "Cosmo Arrow 1" #sync / 1[56]:[^:]*:Alpha Omega:7BA3:/
+1262.9 "Cosmo Arrow 2" #sync / 1[56]:[^:]*:Alpha Omega:7BA3:/
+1262.9 "Cosmo Arrow Exaflare 1" #sync / 1[56]:[^:]*:Alpha Omega:7BA4:/
+1264.9 "Cosmo Arrow Exaflare 2" #sync / 1[56]:[^:]*:Alpha Omega:7BA4:/
+1266.9 "Cosmo Arrow Exaflare 3" #sync / 1[56]:[^:]*:Alpha Omega:7BA4:/
+1266.9 "Cosmo Arrow Exaflare 4" #sync / 1[56]:[^:]*:Alpha Omega:7BA4:/
+1268.9 "Cosmo Arrow Exaflare 5" #sync / 1[56]:[^:]*:Alpha Omega:7BA4:/
+1269.9 "Wave Cannon 1" #sync / 1[56]:[^:]*:Alpha Omega:7BAB:/
+1270.9 "Cosmo Arrow" #sync / 1[56]:[^:]*:Alpha Omega:7BA4:/
+1271.9 "Wave Cannon 2" #sync / 1[56]:[^:]*:Alpha Omega:7BAB:/
+1272.9 "Cosmo Arrow" #sync / 1[56]:[^:]*:Alpha Omega:7BA4:/
+1277.8 "--sync--" sync / 1[56]:[^:]*:Alpha Omega:7BA9:/
+1278.2 "Wave Cannon (Wild Charge)" #sync / 1[56]:[^:]*:Alpha Omega:7BAA:/
+1282.3 "--sync--" sync / 1[56]:[^:]*:Alpha Omega:7C03:/
+1283.2 "Flash Gale 1" sync / 1[56]:[^:]*:Alpha Omega:7DDF:/
+1285.5 "--sync--" sync / 1[56]:[^:]*:Alpha Omega:7C03:/
+1286.4 "Flash Gale 2" sync / 1[56]:[^:]*:Alpha Omega:7DDF:/
+
+1291.7 "Unlimited Wave Cannon" sync / 1[56]:[^:]*:Alpha Omega:7BAC:/
+1298.7 "Wave Cannon Exaflare 1" #sync / 1[56]:[^:]*:Alpha Omega:7BAD:/ duration 5.7
+1299.7 "Wave Cannon Puddles 1" #sync / 1[56]:[^:]*:Alpha Omega:7BAF:/
+1299.7 "Wave Cannon Exaflare 2" #sync / 1[56]:[^:]*:Alpha Omega:7BAD:/ duration 5.7
+1300.6 "Wave Cannon Exaflare 3" #sync / 1[56]:[^:]*:Alpha Omega:7BAD:/ duration 5.7
+1301.5 "Wave Cannon Exaflare 4" #sync / 1[56]:[^:]*:Alpha Omega:7BAD:/ duration 5.7
+1301.5 "Wave Cannon Puddles 2" #sync / 1[56]:[^:]*:Alpha Omega:7BAF:/
+1303.4 "Wave Cannon Puddles 3" #sync / 1[56]:[^:]*:Alpha Omega:7BAF:/
+1305.3 "Wave Cannon Puddles 4" #sync / 1[56]:[^:]*:Alpha Omega:7BAF:/
+1307.2 "Wave Cannon Puddles 5" #sync / 1[56]:[^:]*:Alpha Omega:7BAF:/
+1309.2 "Wave Cannon Puddles 6" #sync / 1[56]:[^:]*:Alpha Omega:7BAF:/
+1310.0 "Cosmo Dive" sync / 1[56]:[^:]*:Alpha Omega:7BA6:/
+1312.4 "Cosmo Dive Far" #sync / 1[56]:[^:]*:Alpha Omega:7BA8:/
+1312.4 "Cosmo Dive Near x2" #sync / 1[56]:[^:]*:Alpha Omega:7BA7:/
+1319.2 "--sync--" sync / 1[56]:[^:]*:Alpha Omega:7C03:/
+1320.1 "Flash Gale 1" sync / 1[56]:[^:]*:Alpha Omega:7DDF:/
+1322.4 "--sync--" sync / 1[56]:[^:]*:Alpha Omega:7C03:/
+1323.2 "Flash Gale 2" sync / 1[56]:[^:]*:Alpha Omega:7DDF:/
+
+# Range/Caster Brilliant Dynamis Checks
+1331.6 "Cosmo Meteor" sync / 1[56]:[^:]*:Alpha Omega:7BB0:/
+1335.6 "Cosmo Meteor Baits" sync / 1[56]:[^:]*:Alpha Omega:7BB2:/
+
+1336.7 "Cosmo Meteor 1 x4" #sync / 1[56]:[^:]*:Alpha Omega:7FBB:/
+1337.7 "Cosmo Meteor 2 x4" #sync / 1[56]:[^:]*:Alpha Omega:7FBB:/
+# TODO: Adjust targetable
+1339.3 "--adds targetable--"
+1342.7 "Cosmo Meteor 1 x4" #sync / 1[56]:[^:]*:Alpha Omega:7FBB:/
+1343.7 "Cosmo Meteor 2 x4" #sync / 1[56]:[^:]*:Alpha Omega:7FBB:/
+
+1354.7 "Cosmo Meteor Stack" sync / 1[56]:[^:]*:Alpha Omega:7BB3:/
+1354.7 "Cosmo Meteor Flare x3" sync / 1[56]:[^:]*:Alpha Omega:7BB4:/
+1355.7 "Cosmo Meteor" sync / 1[56]:[^:]*:Alpha Omega:7BB1:/
+1357.0 "Cosmo Meteor Enrage" sync / 1[56]:[^:]*:Cosmo Meteor:7BB5:/
+
+# Tank 1 and Healer 1 Brilliant Dynamis Checks
+1366.7 "Magic Number" sync / 1[56]:[^:]*:Alpha Omega:7BB6:/
+
+# Tank 2 and Healer 2 Brilliant Dynamis Checks
+1382.8 "Magic Number" sync / 1[56]:[^:]*:Alpha Omega:7BB6:/
+
+1407.9 "Run: ****mi* Enrage" sync / 1[56]:[^:]*:Alpha Omega:7BA0:/

--- a/ui/raidboss/data/06-ew/ultimate/the_omega_protocol.txt
+++ b/ui/raidboss/data/06-ew/ultimate/the_omega_protocol.txt
@@ -332,12 +332,11 @@ hideall "--sync--"
 1262.9 "Cosmo Arrow Exaflare 1" #sync / 1[56]:[^:]*:Alpha Omega:7BA4:/
 1264.9 "Cosmo Arrow Exaflare 2" #sync / 1[56]:[^:]*:Alpha Omega:7BA4:/
 1266.9 "Cosmo Arrow Exaflare 3" #sync / 1[56]:[^:]*:Alpha Omega:7BA4:/
-1266.9 "Cosmo Arrow Exaflare 4" #sync / 1[56]:[^:]*:Alpha Omega:7BA4:/
-1268.9 "Cosmo Arrow Exaflare 5" #sync / 1[56]:[^:]*:Alpha Omega:7BA4:/
+1268.9 "Cosmo Arrow Exaflare 4" #sync / 1[56]:[^:]*:Alpha Omega:7BA4:/
 1269.9 "Wave Cannon 1" #sync / 1[56]:[^:]*:Alpha Omega:7BAB:/
-1270.9 "Cosmo Arrow" #sync / 1[56]:[^:]*:Alpha Omega:7BA4:/
+1270.9 "Cosmo Arrow Exaflare 5" #sync / 1[56]:[^:]*:Alpha Omega:7BA4:/
 1271.9 "Wave Cannon 2" #sync / 1[56]:[^:]*:Alpha Omega:7BAB:/
-1272.9 "Cosmo Arrow" #sync / 1[56]:[^:]*:Alpha Omega:7BA4:/
+1272.9 "Cosmo Arrow Exaflare 6" #sync / 1[56]:[^:]*:Alpha Omega:7BA4:/
 1277.8 "--sync--" sync / 1[56]:[^:]*:Alpha Omega:7BA9:/
 1278.2 "Wave Cannon (Wild Charge)" #sync / 1[56]:[^:]*:Alpha Omega:7BAA:/
 1282.3 "--sync--" sync / 1[56]:[^:]*:Alpha Omega:7C03:/

--- a/ui/raidboss/data/06-ew/ultimate/the_omega_protocol.txt
+++ b/ui/raidboss/data/06-ew/ultimate/the_omega_protocol.txt
@@ -132,7 +132,7 @@ hideall "--sync--"
 550.1 "Critical Error" sync / 1[56]:[^:]*:Omega:7B64:/
 
 560.2 "--sync--" sync / 1[56]:[^:]*:Omega:7B46:/
-571.4 "Oversampled Wave Cannon" sync / 1[56]:[^:]*:Omega:7B6C:/
+571.4 "Oversampled Wave Cannon" sync / 1[56]:[^:]*:Omega:[7B6B|7B6C]:/
 577.4 "--sync--" sync / 14:[^:]*:Omega:7B48:/ window 50,50
 587.4 "Ion Efflux Enrage" sync / 1[56]:[^:]*:Omega:7B48:/
 

--- a/ui/raidboss/data/06-ew/ultimate/the_omega_protocol.txt
+++ b/ui/raidboss/data/06-ew/ultimate/the_omega_protocol.txt
@@ -222,7 +222,6 @@ hideall "--sync--"
 841.1 "--sync--" sync / 1[56]:[^:]*:Omega-M:7B16:/
 843.8 "Hyper Pulse" sync / 1[56]:[^:]*:Right Arm Unit:7B72:/
 843.9 "Wave Cannon" #sync / 1[56]:[^:]*:Omega:7B74:/
-843.9 "Wave Cannon" #sync / 1[56]:[^:]*:Omega:7B74:/
 845.1 "--sync--" sync / 1[56]:[^:]*:Omega-M:7F30:/
 848.7 "--sync--" sync / 1[56]:[^:]*:Omega:7B15:/
 849.3 "--sync--" sync / 1[56]:[^:]*:Omega-M:7B20:/


### PR DESCRIPTION
Using fflogs logs from Kindred and a few other public logs that have enrage spells and timings to generate an initial timeline for p4-p6.

Patch timings likely need to be updated. Targetable/untargetable were manually added from first hit in logs, so will need to be adjusted.

There are multiple spells with names Wave Cannon, Cosmo Meteor, and Cosmo Arrow spells in p6. I clarified some of the spells in the timeline. Ignoring a spell that's named Inhale (7E51) and the propagating Wave Cannon Exaflares (7BAE).

I was not able to test this.