### PR TITLE
Add instant reminder for P6S Transmission

### DIFF
--- a/06-ew/raid/p6s.js
+++ b/06-ew/raid/p6s.js
@@ -998,6 +998,35 @@ Options.Triggers.push({
       },
     },
     {
+      id: 'P6S Transmission Instant',
+      type: 'GainsEffect',
+      // CF3 Chelomorph (Wing icon - cleave behind player)
+      // D48 Glossomorph (Snake icon - cleave in front of player)
+      netRegex: { effectId: ['CF3', 'D48'] },
+      condition: Conditions.targetIsYou(),
+      infoText: (_data, matches, output) => {
+        return matches.effectId === 'D48' ? output.forwardCleave() : output.backwardCleave();
+      },
+      outputStrings: {
+        forwardCleave: {
+          en: 'Front Cleave, for later',
+          de: 'Kegel Aoe nach Vorne, für später',
+          fr: 'Cleave Avant, pour après',
+          ja: '後で口からおくび',
+          cn: '稍后 前方扇形',
+          ko: '곧 전방 부채꼴 장판',
+        },
+        backwardCleave: {
+          en: 'Rear Cleave, for later',
+          de: 'Kegel Aoe nach Hinten, für später',
+          fr: 'Cleave Arrière, pour après',
+          ja: '後で尻からおなら',
+          cn: '稍后 背后扇形',
+          ko: '곧 후방 부채꼴 장판',
+        },
+      },
+    },
+    {
       id: 'P6S Dark Spheres Collect',
       type: 'StartsUsing',
       netRegex: { id: '7880', source: 'Hegemone' },


### PR DESCRIPTION
In some "full uptime strats" like https://youtu.be/03kPYiaWBV8?t=109, players are required to do pre-position according to the buff they gain. It would be useful if cactbot can remind player instantly whether their buff is forwardCleave or backwardCleave.