### PR TITLE
raidboss: p3 add some tether triggers

### DIFF
--- a/ui/raidboss/data/06-ew/ultimate/the_omega_protocol.ts
+++ b/ui/raidboss/data/06-ew/ultimate/the_omega_protocol.ts
@@ -782,6 +782,47 @@ const triggerSet: TriggerSet<Data> = {
       },
     },
     {
+      id: 'TOP Latent Defect Tether Towers',
+      type: 'GainsEffect',
+      // D71 Remote Code Smell (blue)
+      // DAF Local Code Smell(red/green)
+      // Using Code Smell as the regressions come ~8.75s after Latent Defect
+      // Debuffs are 23, 44, 65, and 86s
+      // TODO: Possibly include direction?
+      netRegex: { effectId: ['D71', 'DAF'] },
+      condition: Conditions.targetIsYou(),
+      delaySeconds: (_data, matches) => parseFloat(matches.duration) - 8.75,
+      alertText: (data, matches, output) => {
+        const regression = matches.effectId === 'DAF' ? 'local' : 'remote';
+        const defamation = data.defamationColor;
+        if (defamation === undefined)
+          return;
+        if (regression === 'remote')
+          return output.nearTether!({ color: defamation === 'red' ? output['blue']!() : output['red']!() });
+
+        if (parseFloat(matches.duration) < 80)
+          return output.farTether!({ color: output[defamation]!() });
+        return output.finalTowerFar!({ color: defamation === 'red' ? output['blue']!() : output['red']!() });
+      },
+      outputStrings: {
+        nearTether: {
+          en: 'Stack by ${color} Tower',
+        },
+        farTether: {
+          en: 'Get ${color} Defamation',
+        },
+        finalTowerFar: {
+          en: 'Between ${color} Towers'
+        },
+        red: {
+          en: 'Red',
+        },
+        blue: {
+          en: 'Blue',
+        },
+      },
+    },
+    {
       id: 'TOP Regression Collect',
       type: 'GainsEffect',
       // DC9 Local Regression (red/green)

--- a/ui/raidboss/data/06-ew/ultimate/the_omega_protocol.ts
+++ b/ui/raidboss/data/06-ew/ultimate/the_omega_protocol.ts
@@ -810,7 +810,7 @@ const triggerSet: TriggerSet<Data> = {
           (data.patchVulnCount % 2 === 1 && data.regression[data.me] === 'local') ||
           (data.patchVulnCount === 7 && data.regression[data.me] === 'remote')
         )
-         return output.breakTether!();
+          return output.breakTether!();
       },
       run: (data) => {
         // Clear count for later phases

--- a/ui/raidboss/data/06-ew/ultimate/the_omega_protocol.ts
+++ b/ui/raidboss/data/06-ew/ultimate/the_omega_protocol.ts
@@ -792,7 +792,7 @@ const triggerSet: TriggerSet<Data> = {
       netRegex: { effectId: ['D71', 'DAF'] },
       condition: Conditions.targetIsYou(),
       delaySeconds: (_data, matches) => parseFloat(matches.duration) - 8.75,
-      alertText: (data, matches, output) => {
+      infoText: (data, matches, output) => {
         const regression = matches.effectId === 'DAF' ? 'local' : 'remote';
         const defamation = data.defamationColor;
         if (defamation === undefined)

--- a/ui/raidboss/data/06-ew/ultimate/the_omega_protocol.ts
+++ b/ui/raidboss/data/06-ew/ultimate/the_omega_protocol.ts
@@ -840,6 +840,17 @@ const triggerSet: TriggerSet<Data> = {
       },
     },
     {
+      id: 'TOP Oversampled Wave Cannon East',
+      type: 'StartsUsing',
+      netRegex: { id: '7B6B', source: 'Omega', capture: false },
+      alertText: (_data, _matches, output) => output.text!(),
+      outputStrings: {
+        text: {
+          en: 'East Monitors',
+        },
+      },
+    },
+    {
       id: 'TOP Oversampled Wave Cannon West',
       type: 'StartsUsing',
       netRegex: { id: '7B6C', source: 'Omega', capture: false },

--- a/ui/raidboss/data/06-ew/ultimate/the_omega_protocol.ts
+++ b/ui/raidboss/data/06-ew/ultimate/the_omega_protocol.ts
@@ -806,7 +806,10 @@ const triggerSet: TriggerSet<Data> = {
       delaySeconds: (_data, matches) => parseFloat(matches.duration), // Could potentially reduce this?
       suppressSeconds: 1,
       infoText: (data, _matches, output) => {
-        if ((data.patchVulnCount % 2 === 1 && data.regression[data.me] === 'local') || (data.patchVulnCount === 7 && data.regression[data.me] === 'remote'))
+        if (
+          (data.patchVulnCount % 2 === 1 && data.regression[data.me] === 'local') ||
+          (data.patchVulnCount === 7 && data.regression[data.me] === 'remote')
+        )
          return output.breakTether!();
       },
       run: (data) => {
@@ -815,9 +818,9 @@ const triggerSet: TriggerSet<Data> = {
           data.patchVulnCount = 0;
       },
       outputStrings: {
-         breakTether: {
-           en: 'Break Tether',
-         },
+        breakTether: {
+          en: 'Break Tether',
+        },
       },
     },
   ],

--- a/ui/raidboss/data/06-ew/ultimate/the_omega_protocol.ts
+++ b/ui/raidboss/data/06-ew/ultimate/the_omega_protocol.ts
@@ -782,7 +782,17 @@ const triggerSet: TriggerSet<Data> = {
       },
     },
     {
-      id: 'TOP Regression Break Tether',
+      id: 'TOP Regression Collect',
+      type: 'GainsEffect',
+      // DC9 Local Regression (red/green)
+      // DCA Remote Regression (blue)
+      netRegex: { effectId: ['DC9', 'DCA'] },
+      run: (data, matches) => {
+        data.regression[matches.target] = matches.effectId === 'DC9' ? 'local' : 'remote';
+      },
+    },
+    {
+      id: 'TOP Second Regression Break Tether',
       type: 'GainsEffect',
       // DC9 Local Regression (red/green)
       // DCA Remote Regression (blue)
@@ -791,10 +801,8 @@ const triggerSet: TriggerSet<Data> = {
       // Will call out if has not broken yet and it is safe to break, if by end
       // of delay and first tether has not broken, it will not call
       netRegex: { effectId: ['DC9', 'DCA'] },
-      preRun: (data, matches) => {
-        data.regression[matches.target] = matches.effectId === 'DC9' ? 'local' : 'remote';
-      },
-      delaySeconds: (_data, matches) => parseFloat(matches.duration) - 6, // 4s remaining
+      condition: Conditions.targetIsYou(),
+      delaySeconds: (_data, matches) => parseFloat(matches.duration) - 6,
       alertText: (data, _matches, output) => {
         if (
           (data.patchVulnCount % 2 === 1 && data.regression[data.me] === 'local') ||
@@ -829,17 +837,6 @@ const triggerSet: TriggerSet<Data> = {
         // Clear count for later phases
         if (data.patchVulnCount === 8)
           data.patchVulnCount = 0;
-      },
-    },
-    {
-      id: 'TOP Oversampled Wave Cannon East',
-      type: 'StartsUsing',
-      netRegex: { id: '7B6B', source: 'Omega', capture: false },
-      alertText: (_data, _matches, output) => output.text!(),
-      outputStrings: {
-        text: {
-          en: 'East Monitors',
-        },
       },
     },
     {

--- a/ui/raidboss/data/06-ew/ultimate/the_omega_protocol.ts
+++ b/ui/raidboss/data/06-ew/ultimate/the_omega_protocol.ts
@@ -799,7 +799,7 @@ const triggerSet: TriggerSet<Data> = {
           return;
         if (regression === 'remote') {
           const color = defamation === 'red' ? output['blue']!() : output['red']!();
-          return output.nearTether!({color: color });
+          return output.nearTether!({ color: color });
         }
 
         if (parseFloat(matches.duration) < 80)
@@ -827,7 +827,7 @@ const triggerSet: TriggerSet<Data> = {
       },
     },
     {
-      id: 'TOP Regression Collect',
+      id: 'TOP P3 Regression Collect',
       type: 'GainsEffect',
       // DC9 Local Regression (red/green)
       // DCA Remote Regression (blue)
@@ -837,7 +837,7 @@ const triggerSet: TriggerSet<Data> = {
       },
     },
     {
-      id: 'TOP Second Regression Break Tether',
+      id: 'TOP P3 Second Regression Break Tether',
       type: 'GainsEffect',
       // DC9 Local Regression (red/green)
       // DCA Remote Regression (blue)
@@ -862,7 +862,7 @@ const triggerSet: TriggerSet<Data> = {
       },
     },
     {
-      id: 'TOP Regression Cleanup',
+      id: 'TOP P3 Regression Cleanup',
       type: 'LosesEffect',
       // DC9 Local Regression (red/green)
       // DCA Remote Regression (blue)

--- a/ui/raidboss/data/06-ew/ultimate/the_omega_protocol.ts
+++ b/ui/raidboss/data/06-ew/ultimate/the_omega_protocol.ts
@@ -794,7 +794,7 @@ const triggerSet: TriggerSet<Data> = {
       preRun: (data, matches) => {
         data.regression[matches.target] = matches.effectId === 'DC9' ? 'local' : 'remote';
       },
-      delaySeconds: (_data, matches) => parseFloat(matches.duration) - 4,
+      delaySeconds: (_data, matches) => parseFloat(matches.duration) - 6, // 4s remaining
       alertText: (data, _matches, output) => {
         if (
           (data.patchVulnCount % 2 === 1 && data.regression[data.me] === 'local') ||

--- a/ui/raidboss/data/06-ew/ultimate/the_omega_protocol.ts
+++ b/ui/raidboss/data/06-ew/ultimate/the_omega_protocol.ts
@@ -797,12 +797,16 @@ const triggerSet: TriggerSet<Data> = {
         const defamation = data.defamationColor;
         if (defamation === undefined)
           return;
-        if (regression === 'remote')
-          return output.nearTether!({ color: defamation === 'red' ? output['blue']!() : output['red']!() });
+        if (regression === 'remote') {
+          const color = defamation === 'red' ? output['blue']!() : output['red']!();
+          return output.nearTether!({color: color });
+        }
 
         if (parseFloat(matches.duration) < 80)
           return output.farTether!({ color: output[defamation]!() });
-        return output.finalTowerFar!({ color: defamation === 'red' ? output['blue']!() : output['red']!() });
+
+        const color = defamation === 'red' ? output['blue']!() : output['red']!();
+        return output.finalTowerFar!({ color: color });
       },
       outputStrings: {
         nearTether: {
@@ -812,7 +816,7 @@ const triggerSet: TriggerSet<Data> = {
           en: 'Get ${color} Defamation',
         },
         finalTowerFar: {
-          en: 'Between ${color} Towers'
+          en: 'Between ${color} Towers',
         },
         red: {
           en: 'Red',


### PR DESCRIPTION
- Adds a break tether callout for when the magic vulnerability up from the Patch spell expires and duration has <4s remaining.
- Adds callout for tether players for which tower to go to

~~Potential for this to be expanded to call the tower to run to with merging of my other PR #5264.~~

I don't really see it necessary to call the first break here since it happens naturally. For the last set I am not too sure on, I only know that the regression that breaks there changes order. ~~Not sure how these triggers impact P5, might need to condition these to only run in P3?~~ **EDIT:** P5 Uses different effectIds for its Local and Remote Regressions, but the same Magic Vulnerability debuff is used with Patch.