### PR TITLE
i18n: add ko translations

### DIFF
--- a/ui/oopsyraidsy/data/06-ew/ultimate/the_omega_protocol.ts
+++ b/ui/oopsyraidsy/data/06-ew/ultimate/the_omega_protocol.ts
@@ -164,6 +164,7 @@ const triggerSet: OopsyTriggerSet<Data> = {
             reportId: data.blameId?.[player],
             text: {
               en: `Missed Tower #${num}`,
+              ko: `기둥 #${num} 놓침`,
             },
           });
         }
@@ -188,6 +189,7 @@ const triggerSet: OopsyTriggerSet<Data> = {
           // There's only two tower players, so just blame them all.
           const towerText: LocaleText = {
             en: `Tower #${num}`,
+            ko: `기둥 #${num}`,
           };
           const text = GetShareMistakeText(towerText, 2);
           for (const player of towerPlayers) {
@@ -213,6 +215,7 @@ const triggerSet: OopsyTriggerSet<Data> = {
             reportId: data.blameId?.[player],
             text: {
               en: `Tower #${num} as #${playerNum}`,
+              ko: `기둥 #${num} 들어감 (#${playerNum})`,
             },
           });
         }
@@ -227,6 +230,7 @@ const triggerSet: OopsyTriggerSet<Data> = {
             reportId: data.blameId?.[player],
             text: {
               en: `Missed Tether #${num}`,
+              ko: `선 #${num} 놓침`,
             },
           });
         }
@@ -242,6 +246,7 @@ const triggerSet: OopsyTriggerSet<Data> = {
           const type = shouldTakeTether ? 'warn' : 'fail';
           const tetherText: LocaleText = {
             en: `${m.ability} #${num}`,
+            ko: `${m.ability} #${num}`,
           };
           const text = numTargets > 1 ? GetShareMistakeText(tetherText, numTargets) : tetherText;
 

--- a/ui/raidboss/data/05-shb/raid/e1s.ts
+++ b/ui/raidboss/data/05-shb/raid/e1s.ts
@@ -67,6 +67,12 @@ const triggerSet: TriggerSet<Data> = {
           '我柜子动了等下再玩',
           'CG',
         ],
+        ko: [
+          '잠수',
+          ':zzz:',
+          '라희',
+          '저 물좀 떠올게요',
+        ],
       };
       const goofs = goofsByLang[data.displayLang];
       if (!goofs)

--- a/ui/raidboss/data/06-ew/ultimate/the_omega_protocol.ts
+++ b/ui/raidboss/data/06-ew/ultimate/the_omega_protocol.ts
@@ -438,18 +438,22 @@ const triggerSet: TriggerSet<Data> = {
         blizzardBladework: {
           en: 'Out Out',
           de: 'Raus Raus',
+          ko: '밖 밖',
         },
         superliminalStrength: {
           en: 'In In on M',
           de: 'Rein Rein auf M',
+          ko: '안 안 남자',
         },
         superliminalBladework: {
           en: 'Under F',
           de: 'Unter W',
+          ko: '여자 밑',
         },
         blizzardStrength: {
           en: 'M Sides',
           de: 'Seitlich von M',
+          ko: '남자 양옆',
         },
       },
     },
@@ -784,6 +788,7 @@ const triggerSet: TriggerSet<Data> = {
       outputStrings: {
         text: {
           en: 'East Monitors',
+          ko: '오른쪽 모니터',
         },
       },
     },
@@ -795,6 +800,7 @@ const triggerSet: TriggerSet<Data> = {
       outputStrings: {
         text: {
           en: 'West Monitors',
+          ko: '왼쪽 모니터',
         },
       },
     },
@@ -812,9 +818,11 @@ const triggerSet: TriggerSet<Data> = {
           // assuming there's a N/S conga line?
           monitorOnYou: {
             en: 'Monitor (w/${player1}, ${player2})',
+            ko: '모니터 (+ ${player1}, ${player2})',
           },
           unmarked: {
             en: 'Unmarked',
+            ko: '무징',
           },
         };
 
@@ -850,9 +858,11 @@ const triggerSet: TriggerSet<Data> = {
         output.responseOutputStrings = {
           stacks: {
             en: 'Stacks (${player1}, ${player2})',
+            ko: '쉐어징 (${player1}, ${player2})',
           },
           stackOnYou: {
             en: 'Stack on You (w/${player})',
+            ko: '쉐어징 대상자 (+ ${player})',
           },
         };
         const [m1, m2] = data.waveCannonStacks;


### PR DESCRIPTION
- e1s
to avoid being captured by `find-translations`.

![피슬-감사합니다](https://user-images.githubusercontent.com/37621276/218310271-c24330e1-930c-4c85-8b7d-1264cae4568c.jpg)
