### PR TITLE
raidboss: fixed corrupt font file in dorgrin's skin

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,6 +2,7 @@
 
 *.png binary
 *.ogg binary
+*.otf binary
 *.mp3 binary
 *.wav binary
 *.webm binary


### PR DESCRIPTION
Due to file-ending handling, the original font **distributed** incorrectly and was unusable. This *should* correct the problem in future releases.