### PR TITLE
radar: playerPos is not updated for now in ko 6.2

### DIFF
--- a/ui/radar/radar.ts
+++ b/ui/radar/radar.ts
@@ -230,6 +230,14 @@ class Radar {
           this.nameToHuntEntry[nameItem.toLowerCase()] = hunt;
       }
     }
+
+    // TODO: Remove this patch after OnPlayerChange is properly called in KO 6.2
+    setTimeout(() => {
+      if (this.playerPos === null && this.lang === 'ko') {
+        // A nonsense position, to inform this is partially broken.
+        this.playerPos = new Point2DWithZ(-999, -999, -999);
+      }
+    }, 1000)
   }
 
   AddMonster(log: string, hunt: HuntEntry, matches: NetMatches['AddedCombatant']) {

--- a/ui/radar/radar.ts
+++ b/ui/radar/radar.ts
@@ -237,7 +237,7 @@ class Radar {
         // A nonsense position, to inform this is partially broken.
         this.playerPos = new Point2DWithZ(-999, -999, -999);
       }
-    }, 1000)
+    }, 1000);
   }
 
   AddMonster(log: string, hunt: HuntEntry, matches: NetMatches['AddedCombatant']) {


### PR DESCRIPTION
Yes, this is broken for now, but the radar can find where a hunt is.

![image](https://user-images.githubusercontent.com/3071003/219164460-877b33e4-803b-42b1-9524-11db7ac88e21.png)

Because this is a temporary patch, just feel free to close this.