### PR TITLE
pullcounter: make able to reset zone counters

### DIFF
--- a/ui/pullcounter/pullcounter.ts
+++ b/ui/pullcounter/pullcounter.ts
@@ -325,6 +325,7 @@ class PullCounter {
       }
     } else {
       const id = this.zoneName;
+      this.pullCounts[id] = 0;
       console.log(`resetting pull count of: ${id}`);
       this.ShowElementFor(id);
     }


### PR DESCRIPTION
Currently `/echo pullcounter reset` does not work for this I guess?

Use case: When I do A or S-rank hunts with full-party, seems the counter increases, which is useless for me. To reset this, I need to edit the JSON file directly.