### PR TITLE
util: fix when the log time is 00

### DIFF
--- a/util/logtools/encounter_tools.ts
+++ b/util/logtools/encounter_tools.ts
@@ -318,7 +318,7 @@ class TLFuncs {
   }
   static timeFromDate(date?: Date): string {
     if (date) {
-      const wholeTime = date.toLocaleTimeString('en-US', { hour12: false });
+      const wholeTime = date.toLocaleTimeString('en-US', { hourCycle: 'h23' });
       const milliseconds = date.getMilliseconds();
       // If milliseconds is under 100, the leading zeroes will be truncated.
       // We don't want that, so we pad it inside the formatter.


### PR DESCRIPTION
Closes #5246.

This is an alternative to #5246 based on the comment from valarin.