### PR TITLE
raidboss: TOP P5 delta tether + beyond defense filter

### DIFF
--- a/ui/raidboss/data/06-ew/ultimate/the_omega_protocol.ts
+++ b/ui/raidboss/data/06-ew/ultimate/the_omega_protocol.ts
@@ -1186,7 +1186,7 @@ const triggerSet: TriggerSet<Data> = {
       // DB0 Remote Code Smell (blue)
       netRegex: { effectId: ['D70', 'DB0'] },
       preRun: (data, matches) => data.deltaTethers[matches.target] = matches.target === 'D70' ? 'green' : 'blue',
-      infoText: (_data, matches, output) => {
+      infoText: (data, matches, output) => {
         if (matches.target !== data.me)
           return;
         if (matches.effectId === 'D70')

--- a/ui/raidboss/data/06-ew/ultimate/the_omega_protocol.ts
+++ b/ui/raidboss/data/06-ew/ultimate/the_omega_protocol.ts
@@ -1176,8 +1176,8 @@ const triggerSet: TriggerSet<Data> = {
     {
       id: 'TOP Delta Tethers',
       type: 'GainsEffect',
-      // D70 Local Code Smell
-      // DB0 Remote Code Smell
+      // D70 Local Code Smell (red/green)
+      // DB0 Remote Code Smell (blue)
       netRegex: { effectId: ['D70', 'DB0'] },
       condition: Conditions.targetIsYou(),
       infoText: (_data, matches, output) => {

--- a/ui/raidboss/data/06-ew/ultimate/the_omega_protocol.ts
+++ b/ui/raidboss/data/06-ew/ultimate/the_omega_protocol.ts
@@ -1173,6 +1173,27 @@ const triggerSet: TriggerSet<Data> = {
       },
       run: (data, _matches) => data.waveCannonStacks = [],
     },
+    {
+      id: 'TOP Delta Tethers',
+      type: 'GainsEffect',
+      // D70 Local Code Smell
+      // DB0 Remote Code Smell
+      netRegex: { effectId: ['D70', 'DB0'] },
+      condition: Conditions.targetIsYou(),
+      infoText: (_data, matches, output) => {
+        if (matches.effectId === 'D70')
+          return output.nearTether!();
+        return output.farTether!();
+      },
+      outputStrings: {
+        farTether: {
+          en: 'Blue Tether',
+        },
+        nearTether: {
+          en: 'Green Tether',
+        },
+      },
+    },
   ],
   timelineReplace: [
     {

--- a/ui/raidboss/data/06-ew/ultimate/the_omega_protocol.ts
+++ b/ui/raidboss/data/06-ew/ultimate/the_omega_protocol.ts
@@ -1186,7 +1186,7 @@ const triggerSet: TriggerSet<Data> = {
       // DB0 Remote Code Smell (blue)
       netRegex: { effectId: ['D70', 'DB0'] },
       preRun: (data, matches) => {
-        data.deltaTethers[matches.target] = matches.target === 'D70' ? 'green' : 'blue';
+        data.deltaTethers[matches.target] = matches.effectId === 'D70' ? 'green' : 'blue';
       },
       infoText: (data, matches, output) => {
         if (matches.target !== data.me)

--- a/ui/raidboss/data/06-ew/ultimate/the_omega_protocol.ts
+++ b/ui/raidboss/data/06-ew/ultimate/the_omega_protocol.ts
@@ -25,6 +25,7 @@ export type Glitch = 'mid' | 'remote';
 export type Cannon = 'spread' | 'stack';
 export type RotColor = 'blue' | 'red';
 export type Regression = 'local' | 'remote';
+export type TetherColor = 'blue' | 'green';
 
 export interface Data extends RaidbossData {
   combatantData: PluginCombatantState[];
@@ -48,6 +49,7 @@ export interface Data extends RaidbossData {
   patchVulnCount: number;
   waveCannonStacks: NetMatches['Ability'][];
   monitorPlayers: NetMatches['GainsEffect'][];
+  deltaTethers: { [name: string]: TetherColor };
 }
 
 // Due to changes introduced in patch 5.2, overhead markers now have a random offset
@@ -120,6 +122,7 @@ const triggerSet: TriggerSet<Data> = {
       patchVulnCount: 0,
       waveCannonStacks: [],
       monitorPlayers: [],
+      deltaTethers: {},
     };
   },
   triggers: [
@@ -689,8 +692,11 @@ const triggerSet: TriggerSet<Data> = {
           return { alarmText: output.dontStack!() };
         // Note: if you are doing uptime meteors then everybody stacks.
         // If you are not, then you'll need to ignore this as needed.
-        return { infoText: output.stack!() };
+        // Note2: For P5 Delta, all remaining blues will stack for pile pitch
+        if (data.deltaTethers[data.me] !== 'green')
+          return { infoText: output.stack!() };
       },
+      run: (data) => data.deltaTethers = {},
     },
     {
       id: 'TOP Cosmo Memory',
@@ -1179,8 +1185,10 @@ const triggerSet: TriggerSet<Data> = {
       // D70 Local Code Smell (red/green)
       // DB0 Remote Code Smell (blue)
       netRegex: { effectId: ['D70', 'DB0'] },
-      condition: Conditions.targetIsYou(),
+      preRun: (data, matches) => data.deltaTethers[matches.target] = matches.target === 'D70' ? 'green' : 'blue',
       infoText: (_data, matches, output) => {
+        if (matches.target !== data.me)
+          return;
         if (matches.effectId === 'D70')
           return output.nearTether!();
         return output.farTether!();

--- a/ui/raidboss/data/06-ew/ultimate/the_omega_protocol.ts
+++ b/ui/raidboss/data/06-ew/ultimate/the_omega_protocol.ts
@@ -1185,7 +1185,9 @@ const triggerSet: TriggerSet<Data> = {
       // D70 Local Code Smell (red/green)
       // DB0 Remote Code Smell (blue)
       netRegex: { effectId: ['D70', 'DB0'] },
-      preRun: (data, matches) => data.deltaTethers[matches.target] = matches.target === 'D70' ? 'green' : 'blue',
+      preRun: (data, matches) => {
+        data.deltaTethers[matches.target] = matches.target === 'D70' ? 'green' : 'blue';
+      },
       infoText: (data, matches, output) => {
         if (matches.target !== data.me)
           return;


### PR DESCRIPTION
The effects are unique for delta, so there wasn't a need to use phase filter.

I think maybe in the future it would say something more for the blue tether players like blue tether with some description about the world they may be with. For certain strats, players are using near world or distant world as a method to say which blue tether pair goes where.