### PR TITLE
i18n: orthos general translations

### DIFF
--- a/ui/raidboss/data/06-ew/deepdungeon/eureka_orthos_general.ts
+++ b/ui/raidboss/data/06-ew/deepdungeon/eureka_orthos_general.ts
@@ -105,12 +105,21 @@ const triggerSet: TriggerSet<Data> = {
         // protomanders: https://xivapi.com/deepdungeonItem?pretty=true
         lethargy: {
           en: 'Lethargy',
+          de: 'Trägheit',
+          fr: 'ralentissement',
+          ja: 'スロウガ',
         },
         storms: {
           en: 'Storms',
+          de: 'Schwäche',
+          fr: 'Charybde',
+          ja: 'ミールストーム',
         },
         dread: {
           en: 'Dread',
+          de: 'Macht',
+          fr: 'cuirassé Dreadnaught',
+          ja: 'ドレッドノート化',
         },
         safety: {
           en: 'Safety',
@@ -237,16 +246,34 @@ const triggerSet: TriggerSet<Data> = {
       outputStrings: {
         duplicate: {
           en: '${demiclone} duplicate',
+          de: 'Doppelter ${demiclone}',
+          cn: '${demiclone} 重复',
+          ko: '${demiclone} 중복',
         },
         // demiclones: https://xivapi.com/DeepDungeonDemiclone?pretty=true
         unei: {
           en: 'Unei',
+          de: 'Unei',
+          fr: 'Unéi',
+          ja: 'ウネ',
+          cn: '乌内',
+          ko: '우네',
         },
         doga: {
           en: 'Doga',
+          de: 'Doga',
+          fr: 'Doga',
+          ja: 'ドーガ',
+          cn: '多加',
+          ko: '도가',
         },
         onion: {
           en: 'Onion Knight',
+          de: 'Zwiebelritter',
+          fr: 'chevalier Oignon',
+          ja: 'オニオンナイト',
+          cn: '洋葱剑士',
+          ko: '양파 기사',
         },
       },
     },


### PR DESCRIPTION
[deepdungeon_completion.csv](https://github.com/quisquous/cactbot/files/10954914/deepdungeon_completion.csv)

```
#,en,de,fr,ja,cn,ko
3600,【Deep Dungeon】,【Tiefes Gewölbe】,【Donjon sans fond】,【ディープダンジョン】,【深层迷宫】,【딥 던전】
3601,Cairn of Passage,Wegleuchte,pierre de téléportation,転移の石塔,转移石冢,전송 석탑
3602,Cairn of Return,Totenleuchte,pierre de résurrection,再生の石塔,再生石冢,부활 석탑
3603,Pomander of Safety,Tongefäß des Siegelbruchs,poterie magique de désamorçage,魔土器:呪印解除,魔陶器：咒印解除,마토기: 함정 해제
3604,Pomander of Sight,Tongefäß der Sicht,poterie magique de localisation,魔土器:サイトロ,魔陶器：全景,마토기: 사이트로
3605,Pomander of Strength,Tongefäß der Stärkung,poterie magique de puissance,魔土器:自己強化,魔陶器：强化自身,마토기: 자기 강화
3606,Pomander of Steel,Tongefäß der Abwehr,poterie magique de protection,魔土器:防御強化,魔陶器：强化防御,마토기: 방어 강화
3607,Pomander of Affluence,Tongefäß der Schätze,poterie magique de décèlement,魔土器:宝箱増加,魔陶器：宝箱增加,마토기: 보물상자 증가
3608,Pomander of Flight,Tongefäß des Feindtods,poterie magique de sécurisation,魔土器:敵排除,魔陶器：减少敌人,마토기: 적 감소
3609,Pomander of Alteration,Tongefäß der Feindwandlung,poterie magique d'affaiblissement,魔土器:敵変化,魔陶器：改变敌人,마토기: 적 대체
3610,Pomander of Purity,Tongefäß der Entzauberung,poterie magique d'anti-maléfice,魔土器:解呪,魔陶器：解咒,마토기: 저주 해제
3611,Pomander of Fortune,Tongefäß des Glücks,poterie magique de chance,魔土器:運気上昇,魔陶器：运气上升,마토기: 운 상승
3612,Pomander of Witching,Tongefäß der Wandlung,poterie magique de mutation,魔土器:形態変化,魔陶器：形态变化,마토기: 적 변형
3613,Pomander of Serenity,Tongefäß der Enthexung,poterie magique de dissipation,魔土器:魔法効果解除,魔陶器：魔法效果解除,마토기: 마법 효과 해제
3614,Pomander of Rage,Tongefäß der Manticoren,poterie magique de manticore,魔土器:マンティコア化,魔陶器：曼提克化,마토기: 만티코어 변신
3615,Pomander of Lust,Tongefäß der Sukkuben,poterie magique de succube,魔土器:サキュバス化,魔陶器：梦魔化,마토기: 서큐버스 변신
3616,Pomander of Intuition,Tongefäß des Finders,poterie magique d'intuition,魔土器:財宝感知,魔陶器：感知宝藏,마토기: 보물 탐지
3617,Pomander of Raising,Tongefäß des Lebens,poterie magique de résurrection,魔土器:リレイズ,魔陶器：重生,마토기: 리레이즈
3618,Pomander of Resolution,Tongefäß der Kuribu,poterie magique de Kuribu,魔土器:クリブ化,魔陶器：基路伯化,마토기: 쿠리부 변신
3619,Pomander of Frailty,Tongefäß der Feindschwächung,poterie magique d'incapacité,魔土器:敵弱体,魔陶器：弱化敌人,마토기: 적 약화
3620,Pomander of Concealment,Tongefäß des Verschwindens,poterie magique d'invisibilité,魔土器:バニシュ,魔陶器：隐形,마토기: 배니시
3621,Pomander of Petrification,Tongefäß der Feindversteinerung,poterie magique de pétrification,魔土器:敵石化,魔陶器：石化敌人,마토기: 적 석화
3622,Inferno magicite,Zauberstein des Ifrit,magilithe d'Ifrit,イフリートの魔石,伊弗利特魔石,이프리트 마석
3623,Crag magicite,Zauberstein des Titan,magilithe de Titan,タイタンの魔石,泰坦魔石,타이탄 마석
3624,Vortex magicite,Zauberstein der Garuda,magilithe de Garuda,ガルーダの魔石,迦楼罗魔石,가루다 마석
3625,elder magicite,Zauberstein des Odin,magilithe d'Odin,オーディンの魔石,奥丁魔石,오딘 마석
3626,Beacon of Passage,Weglaterne,Lanterne de téléportation,転移の灯篭,转移灯笼,전송 등불
3627,Beacon of Return,Totenlaterne,Lanterne de résurrection,再生の灯篭,再生灯笼,부활 등불
3628,Pylon of Return,Reanimator,résurrecteur,再生装置,,
3629,Pylon of Passage,Translokator,téléporteur,転移装置,,
3630,Unei demiclone,Demiklon-Unei,semi-clone d'Unéi,デミクローン・ウネ,,
3631,Doga demiclone,Demiklon-Doga,semi-clone de Doga,デミクローン・ドーガ,,
3632,onion knight demiclone,Demiklon-Zwiebelritter,semi-clone du chevalier Oignon,デミクローン・オニオンナイト,,
3633,Protomander of Lethargy,Ätherogefäß der Trägheit,magismobjet de ralentissement,魔科学器:スロウガ,,
3634,Protomander of Storms,Ätherogefäß der Schwäche,magismobjet de Charybde,魔科学器:ミールストーム,,
3635,Protomander of Dread,Ätherogefäß der Macht,magismobjet de cuirassé Dreadnaught,魔科学器:ドレッドノート化,,
3636,Protomander of Safety,Ätherogefäß des Siegelbruchs,magismobjet de désamorçage,魔科学器:呪印解除,,
3637,Protomander of Sight,Ätherogefäß der Sicht,magismobjet de localisation,魔科学器:サイトロ,,
3638,Protomander of Strength,Ätherogefäß der Stärkung,magismobjet de puissance,魔科学器:自己強化,,
3639,Protomander of Steel,Ätherogefäß der Abwehr,magismobjet de protection,魔科学器:防御強化,,
3640,Protomander of Affluence,Ätherogefäß der Schätze,magismobjet de décèlement,魔科学器:宝箱増加,,
3641,Protomander of Flight,Ätherogefäß des Feindtods,magismobjet de sécurisation,魔科学器:敵排除,,
3642,Protomander of Alteration,Ätherogefäß der Feindwandlung,magismobjet d'affaiblissement,魔科学器:敵変化,,
3643,Protomander of Purity,Ätherogefäß der Entzauberung,magismobjet d'anti-maléfice,魔科学器:解呪,,
3644,Protomander of Fortune,Ätherogefäß des Glücks,magismobjet de chance,魔科学器:運気上昇,,
3645,Protomander of Witching,Ätherogefäß der Wandlung,magismobjet de mutation,魔科学器:形態変化,,
3646,Protomander of Serenity,Ätherogefäß der Enthexung,magismobjet de dissipation,魔科学器:魔法効果解除,,
3647,Protomander of Intuition,Ätherogefäß des Finders,magismobjet d'intuition,魔科学器:財宝感知,,
3648,Protomander of Raising,Ätherogefäß des Lebens,magismobjet de résurrection,魔科学器:リレイズ,,
```

- Unei, Doga, onion knight
Orthos is not yet in CN and KO, but there are cards with the exact same name in Triple Triad, so I used that.