### PR TITLE
raidboss: TOP P5 Omega adjust Diffuse Wave Cannon

### DIFF
--- a/ui/raidboss/data/06-ew/ultimate/the_omega_protocol.txt
+++ b/ui/raidboss/data/06-ew/ultimate/the_omega_protocol.txt
@@ -247,10 +247,10 @@ hideall "--sync--"
 897.4 "Solar Ray 2" sync / 1[56]:[^:]*:Omega-M:7B02:/
 904.6 "--sync--" sync / 1[56]:[^:]*:Omega-M:7B43:/
 910.7 "Run: ****mi* (Omega Version)" sync / 1[56]:[^:]*:Omega-M:8015:/
-927.8 "Diffuse Wave Cannon" sync / 1[56]:[^:]*:Omega:(7B9C|7B77):/ duration 1.1
+927.8 "Diffuse Wave Cannon" sync / 1[56]:[^:]*:Omega:(7B9B|7B9C):/
 # 928.8 "Superliminal Steel" sync / 1[56]:[^:]*:Omega-F:7B2A:/
 # 928.8 "Beyond Strength" sync / 1[56]:[^:]*:Omega-M:7B25:/
-931.9 "Diffuse Wave Cannon" sync / 1[56]:[^:]*:Omega:(7B77|7B9C):/ duration 1.1
+931.9 "Diffuse Wave Cannon" sync / 1[56]:[^:]*:Omega:(7B78|7B77):/
 # 932.7 "Optimized Blizzard III" sync / 1[56]:[^:]*:Omega-F:7B2D:/
 # 932.7 "Beyond Strength" sync / 1[56]:[^:]*:Omega-M:7B25:/
 935.6 "--untargetable--"


### PR DESCRIPTION
I managed to get a second log of this with different directions, this is what I have found:
7B9B Diffuse Wave Cannon (Attacking North/South), is followed up with 7B78
7B9C Diffuse Wave Cannon (Attacking East/West), is followed up with 7B77

7B79 is always the damage in all 4 cases.

Duration is not needed because the 7B79 happens when the cast of 7B9B, 7B9C, 7B78, or 7B77 end.