### PR TITLE
raidboss: TOP P5 Sigma Omega-M location

### DIFF
--- a/ui/raidboss/data/06-ew/ultimate/the_omega_protocol.ts
+++ b/ui/raidboss/data/06-ew/ultimate/the_omega_protocol.ts
@@ -1329,7 +1329,7 @@ const triggerSet: TriggerSet<Data> = {
       // Same NPC that casts Sigma Version teleports to card/intercard
       type: 'Ability',
       netRegex: { id: '8014', source: 'Omega-M' },
-      delaySeconds: 5,
+      delaySeconds: 2,
       promise: async (data, matches) => {
         data.combatantData = [];
         data.combatantData = (await callOverlayHandler({

--- a/ui/raidboss/data/06-ew/ultimate/the_omega_protocol.ts
+++ b/ui/raidboss/data/06-ew/ultimate/the_omega_protocol.ts
@@ -1329,7 +1329,7 @@ const triggerSet: TriggerSet<Data> = {
       // Same NPC that casts Sigma Version teleports to card/intercard
       type: 'Ability',
       netRegex: { id: '8014', source: 'Omega-M' },
-      delaySeconds: 6,
+      delaySeconds: 5.5,
       suppressSeconds: 1,
       promise: async (data, matches) => {
         data.combatantData = [];

--- a/ui/raidboss/data/06-ew/ultimate/the_omega_protocol.ts
+++ b/ui/raidboss/data/06-ew/ultimate/the_omega_protocol.ts
@@ -1329,7 +1329,7 @@ const triggerSet: TriggerSet<Data> = {
       // Same NPC that casts Sigma Version teleports to card/intercard
       type: 'Ability',
       netRegex: { id: '8014', source: 'Omega-M' },
-      delaySeconds: 2,
+      delaySeconds: 5,
       promise: async (data, matches) => {
         data.combatantData = [];
         data.combatantData = (await callOverlayHandler({

--- a/ui/raidboss/data/06-ew/ultimate/the_omega_protocol.ts
+++ b/ui/raidboss/data/06-ew/ultimate/the_omega_protocol.ts
@@ -1351,10 +1351,10 @@ const triggerSet: TriggerSet<Data> = {
           const y = combatant.PosY - 100;
           const x = combatant.PosX - 100;
 
-          // During Thordan, knight dives start at the 8 cardinals + numerical
-          // slop on a radius=23 circle.
-          // N = (100, 77), E = (123, 100), S = (100, 123), W = (77, 100)
-          // NE = (116.26, 83.74), SE = (116.26, 116.26), SW = (83.74, 116.26), NW = (83.74, 83.74)
+          // During Sigma, Omega-M teleports to one of the 8 cardinals + numerical
+          // slop on a radius=20 circle.
+          // N = (100, 80), E = (120, 100), S = (100, 120), W = (80, 100)
+          // NE = (114.14, 85.86), SE = (114.14, 114.14), SW = (85.86, 114.14), NW = (85.86, 85.86)
           //
           // Map NW = 0, N = 1, ..., W = 7
 

--- a/ui/raidboss/data/06-ew/ultimate/the_omega_protocol.ts
+++ b/ui/raidboss/data/06-ew/ultimate/the_omega_protocol.ts
@@ -1329,7 +1329,8 @@ const triggerSet: TriggerSet<Data> = {
       // Same NPC that casts Sigma Version teleports to card/intercard
       type: 'Ability',
       netRegex: { id: '8014', source: 'Omega-M' },
-      delaySeconds: 5,
+      delaySeconds: 6,
+      suppressSeconds: 1,
       promise: async (data, matches) => {
         data.combatantData = [];
         data.combatantData = (await callOverlayHandler({

--- a/ui/raidboss/data/06-ew/ultimate/the_omega_protocol.ts
+++ b/ui/raidboss/data/06-ew/ultimate/the_omega_protocol.ts
@@ -1329,7 +1329,8 @@ const triggerSet: TriggerSet<Data> = {
       // Same NPC that casts Sigma Version teleports to card/intercard
       type: 'Ability',
       netRegex: { id: '8014', source: 'Omega-M' },
-      delaySeconds: 5.5,
+      delaySeconds: 5.4,
+      durationSeconds: 26, // Display until Discharger
       suppressSeconds: 1,
       promise: async (data, matches) => {
         data.combatantData = [];


### PR DESCRIPTION
Adds callout for the card/intercard Omega-M jumps to.

Fflogs seems to show that the same npc that casts Omega-M moves to the card/intercard, so assuming that is correct this may just need its delaySeconds tested to see how early the data is available.