### PR TITLE
raidboss: TOP P5 Sigma Tower Orientation

### DIFF
--- a/ui/raidboss/data/06-ew/ultimate/the_omega_protocol.ts
+++ b/ui/raidboss/data/06-ew/ultimate/the_omega_protocol.ts
@@ -1407,7 +1407,7 @@ const triggerSet: TriggerSet<Data> = {
         return data.sigmaTowers.length === 6;
       },
       delaySeconds: 3,
-      promise: async (data, matches) => {
+      promise: async (data) => {
         data.combatantData = [];
         const ids = data.sigmaTowers.map((m) => parseInt(m.sourceId, 16));
         data.combatantData = (await callOverlayHandler({

--- a/ui/raidboss/data/06-ew/ultimate/the_omega_protocol.ts
+++ b/ui/raidboss/data/06-ew/ultimate/the_omega_protocol.ts
@@ -1431,7 +1431,7 @@ const triggerSet: TriggerSet<Data> = {
           3: [117.00, 100.00], // east
           4: [112.02, 112.02], // southeast
           5: [100.00, 117.00], // south
-          6: [89.98,112.02], // southwest
+          6: [89.98, 112.02], // southwest
           7: [100.00, 117.00], // west
         };
         // Only need to look at one of the perpendicular npcs

--- a/ui/raidboss/data/06-ew/ultimate/the_omega_protocol.ts
+++ b/ui/raidboss/data/06-ew/ultimate/the_omega_protocol.ts
@@ -1425,13 +1425,13 @@ const triggerSet: TriggerSet<Data> = {
 
         // Only need to look at the direct coordinate
         const dirToFarTower: { [dir: number]: number[] } = {
-          0: [87.97, 87.98],   // northwest
-          1: [100.00, 83.00],  // north
-          2: [112.02, 87.98],  // northeast
+          0: [87.97, 87.98], // northwest
+          1: [100.00, 83.00], // north
+          2: [112.02, 87.98], // northeast
           3: [117.00, 100.00], // east
           4: [112.02, 112.02], // southeast
           5: [100.00, 117.00], // south
-          6: [89.98,112.02],   // southwest
+          6: [89.98,112.02], // southwest
           7: [100.00, 117.00], // west
         };
         // Only need to look at one of the perpendicular npcs
@@ -1440,11 +1440,11 @@ const triggerSet: TriggerSet<Data> = {
           0: [106.51, 115.71], // northwest
           1: [115.71, 106.51], // north
           2: [106.51, 115.71], // northeast
-          3: [93.49, 115.71],  // east
-          4: [106.51, 84.29],  // southeast
-          5: [115.71, 93.49],  // south
+          3: [93.49, 115.71], // east
+          4: [106.51, 84.29], // southeast
+          5: [115.71, 93.49], // south
           6: [115.71, 106.51], // southwest
-          7: [106.51, 84.29],  // west
+          7: [106.51, 84.29], // west
         };
 
         // If tower not found here, it is opposite side
@@ -1454,7 +1454,9 @@ const triggerSet: TriggerSet<Data> = {
         const towerCheck1 = dirToTower[oppositeMDir];
         const towerCheck2 = dirToTower[data.sigmaMDir];
         if (towerCheck1 === undefined || towerCheck2 === undefined) {
-          console.error(`Sigma Tower: Unable to get matching tower position with Omega-M Location: ${data.sigmaMDir}`);
+          console.error(
+            `Sigma Tower: Unable to get matching tower position with Omega-M Location: ${data.sigmaMDir}`,
+          );
           return;
         }
 
@@ -1474,7 +1476,11 @@ const triggerSet: TriggerSet<Data> = {
           }
         }
         if (towerDir === undefined) {
-          console.error(`Sigma Tower: Unable to find matching tower position among combatants: ${JSON.stringify(data.combatantData)}`);
+          console.error(
+            `Sigma Tower: Unable to find matching tower position among combatants: ${
+              JSON.stringify(data.combatantData)
+            }`,
+          );
           return;
         }
 
@@ -1488,7 +1494,6 @@ const triggerSet: TriggerSet<Data> = {
           6: output.southwest!(),
           7: output.west!(),
         };
-        console.log(`Tower Orientation (3): ${dirs[towerDir]}`);
         return output.towerOrientation!({
           dir: dirs[towerDir] ?? output.unknown!(),
         });

--- a/ui/raidboss/data/06-ew/ultimate/the_omega_protocol.ts
+++ b/ui/raidboss/data/06-ew/ultimate/the_omega_protocol.ts
@@ -1329,7 +1329,7 @@ const triggerSet: TriggerSet<Data> = {
       // Same NPC that casts Sigma Version teleports to card/intercard
       type: 'Ability',
       netRegex: { id: '8014', source: 'Omega-M' },
-      delaySeconds: 5,
+      delaySeconds: 2,
       promise: async (data, matches) => {
         data.combatantData = [];
         data.combatantData = (await callOverlayHandler({

--- a/ui/raidboss/data/06-ew/ultimate/the_omega_protocol.ts
+++ b/ui/raidboss/data/06-ew/ultimate/the_omega_protocol.ts
@@ -1470,7 +1470,7 @@ const triggerSet: TriggerSet<Data> = {
             towerDir = oppositeMDir;
             break;
           }
-          if (combatant.PosX === towerCheck2[0] && combatant.PosY === towerCheck2[0]) {
+          if (combatant.PosX === towerCheck2[0] && combatant.PosY === towerCheck2[1]) {
             towerDir = data.sigmaMDir;
             break;
           }

--- a/ui/raidboss/data/06-ew/ultimate/the_omega_protocol.ts
+++ b/ui/raidboss/data/06-ew/ultimate/the_omega_protocol.ts
@@ -1402,6 +1402,10 @@ const triggerSet: TriggerSet<Data> = {
       // These NPCs are "seen" at their tower position at end of Towers
       type: 'Ability',
       netRegex: { id: '7B74', source: 'Omega' },
+      condition: (data, matches) => {
+        data.sigmaTowers.push(matches);
+        return data.sigmaTowers.length === 6;
+      },
       delaySeconds: 3,
       promise: async (data, matches) => {
         data.combatantData = [];

--- a/ui/raidboss/data/06-ew/ultimate/the_omega_protocol.ts
+++ b/ui/raidboss/data/06-ew/ultimate/the_omega_protocol.ts
@@ -1329,7 +1329,7 @@ const triggerSet: TriggerSet<Data> = {
       // Same NPC that casts Sigma Version teleports to card/intercard
       type: 'Ability',
       netRegex: { id: '8014', source: 'Omega-M' },
-      delaySeconds: 6,
+      delaySeconds: 5.5,
       suppressSeconds: 1,
       promise: async (data, matches) => {
         data.combatantData = [];

--- a/ui/raidboss/data/06-ew/ultimate/the_omega_protocol.ts
+++ b/ui/raidboss/data/06-ew/ultimate/the_omega_protocol.ts
@@ -1329,7 +1329,7 @@ const triggerSet: TriggerSet<Data> = {
       // Same NPC that casts Sigma Version teleports to card/intercard
       type: 'Ability',
       netRegex: { id: '8014', source: 'Omega-M' },
-      delaySeconds: 2,
+      delaySeconds: 5,
       promise: async (data, matches) => {
         data.combatantData = [];
         data.combatantData = (await callOverlayHandler({

--- a/ui/raidboss/data/06-ew/ultimate/the_omega_protocol.ts
+++ b/ui/raidboss/data/06-ew/ultimate/the_omega_protocol.ts
@@ -1351,10 +1351,10 @@ const triggerSet: TriggerSet<Data> = {
           const y = combatant.PosY - 100;
           const x = combatant.PosX - 100;
 
-          // During Thordan, knight dives start at the 8 cardinals + numerical
-          // slop on a radius=23 circle.
-          // N = (100, 77), E = (123, 100), S = (100, 123), W = (77, 100)
-          // NE = (116.26, 83.74), SE = (116.26, 116.26), SW = (83.74, 116.26), NW = (83.74, 83.74)
+          // During Sigma, Omega-M teleports to one of the 8 cardinals + numerical
+          // slop on a radius=20 circle.
+          // N = (100, 80), E = (120, 100), S = (100, 120), W = (80, 100)
+          // NE = (114.14, 85.86), SE = (114.14, 114.14), SW = (85.86, 114.14), NW = (85.86, 85.86)
           //
           // Map NW = 0, N = 1, ..., W = 7
 

--- a/ui/raidboss/data/06-ew/ultimate/the_omega_protocol.ts
+++ b/ui/raidboss/data/06-ew/ultimate/the_omega_protocol.ts
@@ -1329,7 +1329,8 @@ const triggerSet: TriggerSet<Data> = {
       // Same NPC that casts Sigma Version teleports to card/intercard
       type: 'Ability',
       netRegex: { id: '8014', source: 'Omega-M' },
-      delaySeconds: 5,
+      delaySeconds: 6,
+      suppressSeconds: 1,
       promise: async (data, matches) => {
         data.combatantData = [];
         data.combatantData = (await callOverlayHandler({


### PR DESCRIPTION
This uses my TOP P5 Sigma Omega-M location work.

Basically the log indicates that the Omega NPCs that cast 7B74 Wave Cannon will also cast the 7B04, 7B05, and 7B06 Storage Violation spells. The point where they cast this from is seen as the center of the tower. Theoretically, if this position is accurate and available at time of tower spawning we can pull the tower data from the list of these combatants.

Initially this draft is just taking M's location and checking each NPC if it exists at where we think the tower should be, if it does, then we narrow down the two sides the tower's orientation could be to where it is.