### PR TITLE
raidboss: TOP Add delay to P3 Monitors

### DIFF
--- a/ui/raidboss/data/06-ew/ultimate/the_omega_protocol.ts
+++ b/ui/raidboss/data/06-ew/ultimate/the_omega_protocol.ts
@@ -1150,6 +1150,7 @@ const triggerSet: TriggerSet<Data> = {
       // D7D = Oversampled Wave Cannon Loading (facing left)
       netRegex: { effectId: ['D7C', 'D7D'] },
       preRun: (data, matches) => data.monitorPlayers.push(matches),
+      delaySeconds: 0.5,
       response: (data, _matches, output) => {
         // cactbot-builtin-response
         output.responseOutputStrings = {


### PR DESCRIPTION
The current TTS output of both West/East Oversampled Wave Cannon and Oversampled Wave Cannon Loading is unintelligible without some sort of delay added.

I recommend adding delay to the personal monitor callout here. Thoughts? @quisquous 