### PR TITLE
raidboss: TOP P5 Omega Earlier Safe Spot Call

### DIFF
--- a/ui/raidboss/data/06-ew/ultimate/the_omega_protocol.ts
+++ b/ui/raidboss/data/06-ew/ultimate/the_omega_protocol.ts
@@ -1487,12 +1487,12 @@ const triggerSet: TriggerSet<Data> = {
       },
     },
     {
-      id: 'TOP Omega Safe Spots',
-      // 7B9B Diffuse Wave Cannon (North/South), is followed up with 7B78
-      // 7B9C Diffuse Wave Cannon (East/West), is followed up with 7B77
+      id: 'TOP Omega Pre-Safe Spot',
+      // Adds appear at end of the cast, but the AddCombatants line appears around
+      // the cast time of Omega Version
       type: 'StartsUsing',
-      netRegex: { id: ['7B9B', '7B9C'], source: 'Omega' },
-      durationSeconds: (_data, matches) => parseFloat(matches.castTime),
+      netRegex: { id: '8015', source: 'Omega-M', capture: false },
+      delaySeconds: 0.5,
       promise: async (data) => {
         data.combatantData = [];
         data.combatantData = (await callOverlayHandler({
@@ -1503,6 +1503,139 @@ const triggerSet: TriggerSet<Data> = {
           (b.ID ?? 0) - (a.ID ?? 0);
         data.combatantData = data.combatantData.sort(sortCombatants);
       },
+      infoText: (data, _matches, output) => {
+        // The higher id is first set
+        const omegaMNPCId = 15721;
+        const omegaFNPCId = 15722;
+        let isFIn = false;
+        let isMIn = false;
+        let northSouthSwordStaffDir;
+        let eastWestSwordStaffDir;
+        let distance;
+        const findOmegaF = (combatant: PluginCombatantState) => combatant.BNpcID === omegaFNPCId;
+        const findOmegaM = (combatant: PluginCombatantState) => combatant.BNpcID === omegaMNPCId;
+
+        const f = data.combatantData.filter(findOmegaF).shift();
+        const m = data.combatantData.filter(findOmegaM).shift();
+
+        if (f === undefined || m === undefined) {
+          console.error(`Omega Safe Spots: missing m/f: ${JSON.stringify(data.combatantData)}`);
+          return;
+        }
+        console.log(`Omega Safe Pre Spots: m/f: (${JSON.stringify(m)}), (${JSON.stringify(f)})); `);
+
+        if (f.WeaponId === 4)
+          isFIn = true;
+        if (m.WeaponId === 4)
+          isMIn = true;
+
+        if (isFIn)
+          distance = output.close!();
+        else if (isMIn)
+          distance = output.mid!();
+        else
+          distance = output.far!();
+
+        // The combatants only spawn in these intercards:
+        // 92.93, 92.93 (NW)      107.07, 92.93 (NE)
+        // 92.93, 107.07 (SW)     107.07, 107.07 (SE)
+        // They will either spawn NW/SE first or NE/SW
+        // Boss cleave is unknown at this time, so call both sides
+        const pos1 = (!isMIn && isFIn) ? f.PosY : m.PosY;
+        const pos2 = (!isMIn && isFIn) ? f.PosX : m.PosX;
+        const northSouthDir = pos1 < 100 ? output.dirN!() : output.dirS!();
+        const eastWestDir = pos2 < 100 ? output.dirW!() : output.dirE!();
+
+        // Secondary Spot for Staff + Sword
+        if (!isMIn && !isFIn) {
+          // East/West Safe
+          if (f.PosX < 100 && f.PosY < 100) {
+            // NW
+            eastWestSwordStaffDir = output.dirNNE!();
+          } else if (f.PosX < 100 && f.PosY > 100) {
+            // SW
+            eastWestSwordStaffDir = output.dirSSE!();
+          } else if (f.PosX > 100 && f.PosY < 100) {
+            // NE
+            eastWestSwordStaffDir = output.dirNNW!();
+          } else {
+            // SE
+            eastWestSwordStaffDir = output.dirSSW!();
+          }
+          // North/South Safe
+          if (f.PosX < 100 && f.PosY < 100) {
+            // NW
+            northSouthSwordStaffDir = output.dirWSW!();
+          } else if (f.PosX < 100 && f.PosY > 100) {
+            // SW
+            northSouthSwordStaffDir = output.dirWNW!();
+          } else if (f.PosX > 100 && f.PosY < 100) {
+            // NE
+            northSouthSwordStaffDir = output.dirESE!();
+          } else {
+            // SE
+            northSouthSwordStaffDir = output.dirENE!();
+          }
+          const staffSwordFar = output.staffSwordFar!({
+            northSouth: northSouthDir,
+            eastWest: eastWestDir,
+          });
+          const staffSwordMid = output.staffSwordMid!({
+            northSouth: northSouthSwordStaffDir,
+            eastWest: eastWestSwordStaffDir,
+          });
+          return output.staffSwordCombo!({ farText: staffSwordFar, midText: staffSwordMid });
+        }
+
+        return output.safeSpot!({
+          distance: distance,
+          northSouth: northSouthDir,
+          eastWest: eastWestDir,
+        });
+      },
+      outputStrings: {
+        safeSpot: {
+          en: '${distance} ${northSouth} or ${eastWest}',
+        },
+        staffSwordCombo: {
+          en: '${farText} / ${midText}',
+        },
+        staffSwordFar: {
+          en: 'Far ${northSouth} or ${eastWest}',
+        },
+        staffSwordMid: {
+          en: 'Mid ${northSouth} or ${eastWest}',
+        },
+        close: {
+          en: 'Close',
+        },
+        mid: {
+          en: 'Mid',
+        },
+        far: {
+          en: 'Far',
+        },
+        dirN: Outputs.dirN,
+        dirE: Outputs.dirE,
+        dirS: Outputs.dirS,
+        dirW: Outputs.dirW,
+        dirNNW: Outputs.dirNNW,
+        dirNNE: Outputs.dirNNE,
+        dirENE: Outputs.dirENE,
+        dirESE: Outputs.dirESE,
+        dirSSE: Outputs.dirSSE,
+        dirSSW: Outputs.dirSSW,
+        dirWSW: Outputs.dirWSW,
+        dirWNW: Outputs.dirWNW,
+      },
+    },
+    {
+      id: 'TOP Omega Safe Spots',
+      // 7B9B Diffuse Wave Cannon (North/South), is followed up with 7B78
+      // 7B9C Diffuse Wave Cannon (East/West), is followed up with 7B77
+      type: 'StartsUsing',
+      netRegex: { id: ['7B9B', '7B9C'], source: 'Omega' },
+      durationSeconds: (_data, matches) => parseFloat(matches.castTime),
       alertText: (data, matches, output) => {
         // The higher id is first set
         const omegaMNPCId = 15721;

--- a/ui/raidboss/data/06-ew/ultimate/the_omega_protocol.ts
+++ b/ui/raidboss/data/06-ew/ultimate/the_omega_protocol.ts
@@ -1490,9 +1490,10 @@ const triggerSet: TriggerSet<Data> = {
       id: 'TOP Omega Pre-Safe Spot',
       // Adds appear at end of the cast, but the AddCombatants line appears around
       // the cast time of Omega Version
-      type: 'StartsUsing',
+      type: 'Ability',
       netRegex: { id: '8015', source: 'Omega-M', capture: false },
-      delaySeconds: 0.5,
+      delaySeconds: 3.1,
+      supressSeconds: 1,
       promise: async (data) => {
         data.combatantData = [];
         data.combatantData = (await callOverlayHandler({

--- a/ui/raidboss/data/06-ew/ultimate/the_omega_protocol.ts
+++ b/ui/raidboss/data/06-ew/ultimate/the_omega_protocol.ts
@@ -1493,7 +1493,7 @@ const triggerSet: TriggerSet<Data> = {
       type: 'Ability',
       netRegex: { id: '8015', source: 'Omega-M', capture: false },
       delaySeconds: 3.1,
-      supressSeconds: 1,
+      suppressSeconds: 1,
       promise: async (data) => {
         data.combatantData = [];
         data.combatantData = (await callOverlayHandler({


### PR DESCRIPTION
There is an AddCombatants that occurs either before or shortly after the 8015 Run Dynamis: Omega Version cast starts. This utilizes OverlayPlugin, which the other two triggers still pull data from.

Previous PR did not have delay and so did not fire if the combatants were added late per the log line. Alternatively, this trigger can fire off a collection of AddCombatants that match the BNPCIds, but some care would need to be accounted for if they happened to be added before the Omega Version cast starts since that is also what triggers the 'omega' phase. Basing on AddCombatants (if this line varies) could also make a durationSeconds more varied. So I have stuck with the 8015 cast for now and may test different delays.