### PR TITLE
raidboss: TOP increase delay on omega dodge pre-call

### DIFF
--- a/ui/raidboss/data/06-ew/ultimate/the_omega_protocol.ts
+++ b/ui/raidboss/data/06-ew/ultimate/the_omega_protocol.ts
@@ -1558,7 +1558,7 @@ const triggerSet: TriggerSet<Data> = {
       // don't switch until ~2.7s after the ability goes off.
       type: 'Ability',
       netRegex: { id: '8015', source: 'Omega-M', capture: false },
-      delaySeconds: 3.1,
+      delaySeconds: 4,
       suppressSeconds: 1,
       promise: async (data) => {
         data.combatantData = [];


### PR DESCRIPTION
This is mostly for safety as all following triggers depend on this.