### PR TITLE
config: refactor setterFunc for configs

### DIFF
--- a/resources/user_config.ts
+++ b/resources/user_config.ts
@@ -64,7 +64,7 @@ export type ConfigEntry = {
   debugOnly?: boolean;
   // For select.
   options?: LocaleObject<{ [selectText: string]: string }>;
-  setterFunc?: (options: BaseOptions, value: SavedConfigEntry) => void;
+  setterFunc?: (value: SavedConfigEntry, options: BaseOptions) => ConfigValue | void;
 };
 
 export type OptionsTemplate = {
@@ -449,7 +449,9 @@ class UserConfig {
       // If this doesn't exist, just set the value directly.
       // Option template ids are identical to field names on Options.
       if (opt.setterFunc) {
-        opt.setterFunc(options, value);
+        const setValue = opt.setterFunc(value, options);
+        if (setValue !== undefined)
+          options[opt.id] = setValue;
       } else if (opt.type === 'integer') {
         if (typeof value === 'number')
           options[opt.id] = Math.floor(value);

--- a/resources/user_config.ts
+++ b/resources/user_config.ts
@@ -59,12 +59,20 @@ export type ConfigEntry = {
   name: LocaleText;
   type: 'checkbox' | 'select' | 'float' | 'integer' | 'string' | 'directory' | 'html';
   html?: LocaleText;
+  // This must be a valid option even if there is a setterFunc, as `_getOptionLeafHelper`
+  // for the config ui reads from the SavedConfig directly rather than post-setterFunc.
   default: ConfigValue;
   debug?: boolean;
   debugOnly?: boolean;
   // For select.
   options?: LocaleObject<{ [selectText: string]: string }>;
-  setterFunc?: (value: SavedConfigEntry, options: BaseOptions) => ConfigValue | void;
+  // An optional function to transform a saved/default value into the final value.
+  // `value` is the saved/default value.  `isDefault` is true if `value` is implicitly the default.
+  setterFunc?: (
+    value: SavedConfigEntry,
+    options: BaseOptions,
+    isDefault: boolean,
+  ) => ConfigValue | void;
 };
 
 export type OptionsTemplate = {
@@ -437,11 +445,14 @@ class UserConfig {
       // Grab the saved value or the default to set in options.
 
       let value: SavedConfigEntry = opt.default;
+      let isDefault = true;
       if (typeof savedConfig === 'object' && !Array.isArray(savedConfig)) {
         if (opt.id in savedConfig) {
           const newValue = savedConfig[opt.id];
-          if (newValue !== undefined)
+          if (newValue !== undefined) {
             value = newValue;
+            isDefault = false;
+          }
         }
       }
 
@@ -449,7 +460,7 @@ class UserConfig {
       // If this doesn't exist, just set the value directly.
       // Option template ids are identical to field names on Options.
       if (opt.setterFunc) {
-        const setValue = opt.setterFunc(value, options);
+        const setValue = opt.setterFunc(value, options, isDefault);
         if (setValue !== undefined)
           options[opt.id] = setValue;
       } else if (opt.type === 'integer') {

--- a/ui/config/general_config.ts
+++ b/ui/config/general_config.ts
@@ -98,13 +98,13 @@ UserConfig.registerOptions('general', {
       },
       default: 'default',
       debug: true,
-      setterFunc: (options, value) => {
+      setterFunc: (value) => {
         if (typeof value !== 'string')
           return;
         if (value === 'default')
           return;
         if (isLang(value))
-          options['DisplayLanguage'] = value;
+          return value;
       },
     },
   ],

--- a/ui/eureka/eureka_config.ts
+++ b/ui/eureka/eureka_config.ts
@@ -28,7 +28,7 @@ UserConfig.registerOptions('eureka', {
       },
       type: 'float',
       default: 90,
-      setterFunc: (options, value) => {
+      setterFunc: (value) => {
         let seconds: number;
         if (typeof value === 'string')
           seconds = parseFloat(value);
@@ -36,7 +36,7 @@ UserConfig.registerOptions('eureka', {
           seconds = value;
         else
           return;
-        options['FlagTimeoutMs'] = seconds * 1000;
+        return seconds * 1000;
       },
     },
     {
@@ -181,7 +181,7 @@ UserConfig.registerOptions('eureka', {
       },
       type: 'float',
       default: 1,
-      setterFunc: (options, value) => {
+      setterFunc: (value) => {
         let seconds: number;
         if (typeof value === 'string')
           seconds = parseFloat(value);
@@ -189,7 +189,7 @@ UserConfig.registerOptions('eureka', {
           seconds = value;
         else
           return;
-        options['RefreshRateMs'] = seconds * 1000;
+        return seconds * 1000;
       },
     },
   ],

--- a/ui/oopsyraidsy/oopsyraidsy_config.ts
+++ b/ui/oopsyraidsy/oopsyraidsy_config.ts
@@ -303,7 +303,7 @@ const templateOptions: OptionsTemplate = {
       },
       type: 'float',
       default: 4,
-      setterFunc: (options, value) => {
+      setterFunc: (value) => {
         let seconds;
         if (typeof value === 'string')
           seconds = parseFloat(value);
@@ -311,7 +311,7 @@ const templateOptions: OptionsTemplate = {
           seconds = value;
         else
           return;
-        options['TimeToShowDeathReportMs'] = seconds * 1000;
+        return seconds * 1000;
       },
     },
     {

--- a/ui/raidboss/raidboss_config.ts
+++ b/ui/raidboss/raidboss_config.ts
@@ -457,8 +457,8 @@ const addTriggerDetail = (
 // Unfortunately due to poor decisions in the past, PerTriggerOptions has different
 // fields here.  This should be fixed.
 const setOptionsFromOutputValue = (
-  options: BaseOptions | TriggerAutoConfig,
   value: SavedConfigEntry,
+  options: BaseOptions | TriggerAutoConfig,
 ) => {
   if (value === 'default') {
     // Nothing.
@@ -1485,7 +1485,7 @@ const processPerTriggerAutoConfig = (options: RaidbossOptions, savedConfig: Save
   const keys = Object.keys(kTriggerOptions);
   for (const key of keys) {
     const obj = outputObjs[key] = {};
-    setOptionsFromOutputValue(obj, key);
+    setOptionsFromOutputValue(key, obj);
   }
 
   for (const [id, entry] of Object.entries(triggers)) {
@@ -1757,10 +1757,12 @@ const templateOptions: OptionsTemplate = {
       },
       default: 'default',
       debug: true,
-      setterFunc: (options, value) => {
+      setterFunc: (value) => {
+        if (typeof value !== 'string')
+          return;
         if (value === 'default')
           return;
-        options['AlertsLanguage'] = value;
+        return value;
       },
     },
     {
@@ -1832,10 +1834,12 @@ const templateOptions: OptionsTemplate = {
       },
       default: 'default',
       debug: true,
-      setterFunc: (options, value) => {
+      setterFunc: (value) => {
+        if (typeof value !== 'string')
+          return;
         if (value === 'default')
           return;
-        options['TimelineLanguage'] = value;
+        return value;
       },
     },
     {


### PR DESCRIPTION
Most of the time a setterFunc wants to set its own value, so don't make it repeat its own id.  Rearrange the arg order so options is optional.