### PR TITLE
raidboss: correct translation

### DIFF
--- a/resources/outputs.ts
+++ b/resources/outputs.ts
@@ -335,7 +335,7 @@ export default {
     en: 'Out of melee',
     de: 'Raus aus Nahkampf',
     fr: 'Sortez de la mêlée',
-    ja: '近接最大レンジ',
+    ja: '近接レンジ離れ',
     cn: '离开近战距离',
     ko: '근접범위 밖으로',
   },

--- a/resources/outputs.ts
+++ b/resources/outputs.ts
@@ -336,7 +336,7 @@ export default {
     de: 'Raus aus Nahkampf',
     fr: 'Sortez de la mêlée',
     ja: '近接最大レンジ',
-    cn: '近战最远距离回避',
+    cn: '离开近战距离',
     ko: '근접범위 밖으로',
   },
   inThenOut: {


### PR DESCRIPTION
This is a translation mistake. (misunderstood as maximum melee range)
<del>JP is also mistranslated. I can read but cannot write, @MaikoTan </del> Done.