### PR TITLE
config: add config ui for trigger set options

### DIFF
--- a/eslint/cactbot-triggerset-property-order.js
+++ b/eslint/cactbot-triggerset-property-order.js
@@ -30,6 +30,7 @@ module.exports = {
     const raidbossOrderList = [
       'id',
       'zoneId',
+      'config',
       'overrideTimelineFile',
       'timelineFile',
       'timeline',

--- a/resources/user_config.ts
+++ b/resources/user_config.ts
@@ -61,23 +61,33 @@ export type ConfigEntry = {
   html?: LocaleText;
   // This must be a valid option even if there is a setterFunc, as `_getOptionLeafHelper`
   // for the config ui reads from the SavedConfig directly rather than post-setterFunc.
-  default: ConfigValue;
+  default: ConfigValue | ((options: BaseOptions) => ConfigValue);
   debug?: boolean;
   debugOnly?: boolean;
   // For select.
   options?: LocaleObject<{ [selectText: string]: string }>;
   // An optional function to transform a saved/default value into the final value.
   // `value` is the saved/default value.  `isDefault` is true if `value` is implicitly the default.
+  // The data flow here is `default` -> ui -> `setterFunc` -> final data in one direction only.
+  // `setterFunc` should be used for one setting -> multiple options, or for select option
+  // renaming, or for data cleanup if needed.
   setterFunc?: (
     value: SavedConfigEntry,
     options: BaseOptions,
     isDefault: boolean,
-  ) => ConfigValue | void;
+  ) => ConfigValue | void | undefined;
 };
+
+export interface NamedConfigEntry<NameUnion> extends Omit<ConfigEntry, 'id'> {
+  id: NameUnion;
+}
 
 export type OptionsTemplate = {
   buildExtraUI?: (base: CactbotConfigurator, container: HTMLElement) => void;
-  processExtraOptions?: (options: BaseOptions, savedConfig: SavedConfigEntry) => void;
+  processExtraOptions?: (
+    options: BaseOptions,
+    savedConfig: SavedConfigEntry,
+  ) => void;
   options: ConfigEntry[];
 };
 
@@ -303,11 +313,22 @@ class UserConfig {
       // processOptions needs to be called whether or not there are
       // any userOptions saved, as it sets up the defaults.
       this.savedConfig = (await readOptions)?.data ?? {};
-      this.processOptions(
-        options,
-        this.savedConfig[overlayName] ?? {},
-        this.optionTemplates[overlayName],
-      );
+
+      const template = this.optionTemplates[overlayName];
+      if (template !== undefined) {
+        const savedConfig = this.savedConfig[overlayName] ?? {};
+        this.processOptions(
+          options,
+          options,
+          savedConfig,
+          template.options,
+        );
+
+        // For things like raidboss that build extra UI, also give them a chance
+        // to handle anything that has been set on that UI.
+        if (template.processExtraOptions)
+          template.processExtraOptions(options, savedConfig);
+      }
 
       // If the overlay has a "Debug" setting, set to true via the config tool,
       // then also print out user files that have been loaded.
@@ -430,21 +451,30 @@ class UserConfig {
     if (head)
       head.appendChild(userCSS);
   }
-  processOptions(options: BaseOptions, savedConfig: SavedConfigEntry, template?: OptionsTemplate) {
+  processOptions(
+    options: BaseOptions,
+    output: { [key: string]: unknown },
+    savedConfig: SavedConfigEntry,
+    templateOptions?: ConfigEntry[],
+  ) {
     // Take options from the template, find them in savedConfig,
     // and apply them to options. This also handles setting
     // defaults for anything in the template, even if it does not
     // exist in savedConfig.
 
     // Not all overlays have option templates.
-    if (!template)
+    if (templateOptions === undefined)
       return;
 
-    const templateOptions = template.options;
     for (const opt of templateOptions) {
       // Grab the saved value or the default to set in options.
 
-      let value: SavedConfigEntry = opt.default;
+      let value: SavedConfigEntry;
+      if (typeof opt.default === 'function')
+        value = opt.default(options);
+      else
+        value = opt.default;
+
       let isDefault = true;
       if (typeof savedConfig === 'object' && !Array.isArray(savedConfig)) {
         if (opt.id in savedConfig) {
@@ -462,26 +492,21 @@ class UserConfig {
       if (opt.setterFunc) {
         const setValue = opt.setterFunc(value, options, isDefault);
         if (setValue !== undefined)
-          options[opt.id] = setValue;
+          output[opt.id] = setValue;
       } else if (opt.type === 'integer') {
         if (typeof value === 'number')
-          options[opt.id] = Math.floor(value);
+          output[opt.id] = Math.floor(value);
         else if (typeof value === 'string')
-          options[opt.id] = parseInt(value);
+          output[opt.id] = parseInt(value);
       } else if (opt.type === 'float') {
         if (typeof value === 'number')
-          options[opt.id] = value;
+          output[opt.id] = value;
         else if (typeof value === 'string')
-          options[opt.id] = parseFloat(value);
+          output[opt.id] = parseFloat(value);
       } else {
         options[opt.id] = value;
       }
     }
-
-    // For things like raidboss that build extra UI, also give them a chance
-    // to handle anything that has been set on that UI.
-    if (template.processExtraOptions)
-      template.processExtraOptions(options, savedConfig);
   }
   addUnlockText(lang: Lang) {
     const unlockText = {

--- a/test/helper/test_trigger.ts
+++ b/test/helper/test_trigger.ts
@@ -48,6 +48,7 @@ const getFakeRaidbossData = (triggerSet?: LooseTriggerSet): RaidbossData => {
     currentHP: 0,
     options: raidbossOptions,
     inCombat: true,
+    triggerSetConfig: {},
     ShortName: (x: string | undefined) => x ?? '',
     StopCombat: (): void => {/* noop */},
     ParseLocaleFloat: () => 0,

--- a/types/data.d.ts
+++ b/types/data.d.ts
@@ -1,5 +1,6 @@
 import { Lang } from '../resources/languages';
 import PartyTracker from '../resources/party';
+import { ConfigValue } from '../resources/user_config';
 
 import { SystemInfo } from './event';
 import { Job, Role } from './job';
@@ -30,6 +31,7 @@ export interface RaidbossData {
   currentHP: number;
   options: BaseOptions;
   inCombat: boolean;
+  triggerSetConfig: { [key: string]: ConfigValue };
   ShortName: (x?: string) => string;
   StopCombat: () => void;
   /** @deprecated Use parseFloat instead */

--- a/types/trigger.d.ts
+++ b/types/trigger.d.ts
@@ -1,4 +1,5 @@
 import { Lang, NonEnLang } from '../resources/languages';
+import { NamedConfigEntry } from '../resources/user_config';
 import { TimelineReplacement, TimelineStyle } from '../ui/raidboss/timeline_parser';
 
 import { RaidbossData } from './data';
@@ -177,6 +178,9 @@ export type BaseTriggerSet<Data extends RaidbossData> = {
   zoneId: ZoneIdType | number[];
   // useful if the zoneId is an array or zone name is otherwise non-descriptive
   zoneLabel?: LocaleText;
+  // trigger set ids to load configs from (this trigger set is loaded implicitly).
+  loadConfigs?: string[];
+  config?: NamedConfigEntry<Extract<keyof Data['triggerSetConfig'], string>>[];
   // If the timeline exists, but needs significant improvements and a rewrite.
   timelineNeedsFixing?: boolean;
   // If no timeline is possible for this zone, e.g. t3.

--- a/ui/raidboss/data/00-misc/test.ts
+++ b/ui/raidboss/data/00-misc/test.ts
@@ -1,5 +1,6 @@
 import NetRegexes from '../../../../resources/netregexes';
 import outputs from '../../../../resources/outputs';
+import { ConfigValue } from '../../../../resources/user_config';
 import Util from '../../../../resources/util';
 import ZoneId from '../../../../resources/zone_id';
 import { RaidbossData } from '../../../../types/data';
@@ -14,7 +15,10 @@ const strikingDummyNames: LocaleText = {
   ko: '나무인형',
 };
 
+export type ConfigIds = 'testTriggerOutput';
+
 export interface Data extends RaidbossData {
+  triggerSetConfig: { [key in ConfigIds]: ConfigValue };
   delayedDummyTimestampBefore: number;
   delayedDummyTimestampAfter: number;
   pokes: number;
@@ -23,6 +27,19 @@ export interface Data extends RaidbossData {
 const triggerSet: TriggerSet<Data> = {
   id: 'CactbotTest',
   zoneId: ZoneId.MiddleLaNoscea,
+  config: [
+    {
+      id: 'testTriggerOutput',
+      name: {
+        en: 'Output for "/echo cactbot test config"',
+      },
+      type: 'string',
+      default: () => {
+        // Test default function.
+        return 'Unset Option';
+      },
+    },
+  ],
   timelineFile: 'test.txt',
   // timeline here is additions to the timeline.  They can
   // be strings, or arrays of strings, or functions that
@@ -290,10 +307,24 @@ const triggerSet: TriggerSet<Data> = {
         },
       },
     },
+    {
+      id: 'Test Config',
+      type: 'GameLog',
+      netRegex: NetRegexes.echo({ line: 'cactbot test config.*?', capture: false }),
+      alertText: (data, _matches, output) => {
+        return output.text!({ value: data.triggerSetConfig.testTriggerOutput.toString() });
+      },
+      outputStrings: {
+        text: {
+          en: 'Config Value: ${value}',
+        },
+      },
+    },
   ],
   timelineReplace: [
     {
       locale: 'de',
+      missingTranslations: true,
       replaceSync: {
         'You bid farewell to the striking dummy': 'Du winkst der Trainingspuppe zum Abschied zu',
         'You bow courteously to the striking dummy':
@@ -322,6 +353,7 @@ const triggerSet: TriggerSet<Data> = {
     },
     {
       locale: 'fr',
+      missingTranslations: true,
       replaceSync: {
         'cactbot lang': 'cactbot langue',
         'cactbot test response': 'cactbot test de réponse',
@@ -354,6 +386,7 @@ const triggerSet: TriggerSet<Data> = {
     },
     {
       locale: 'ja',
+      missingTranslations: true,
       replaceSync: {
         'You bid farewell to the striking dummy': '.*は木人に別れの挨拶をした',
         'You bow courteously to the striking dummy': '.*は木人にお辞儀した',
@@ -381,6 +414,7 @@ const triggerSet: TriggerSet<Data> = {
     },
     {
       locale: 'cn',
+      missingTranslations: true,
       replaceSync: {
         'You bid farewell to the striking dummy': '.*向木人告别',
         'You bow courteously to the striking dummy': '.*恭敬地对木人行礼',
@@ -408,6 +442,7 @@ const triggerSet: TriggerSet<Data> = {
     },
     {
       locale: 'ko',
+      missingTranslations: true,
       replaceSync: {
         'You bid farewell to the striking dummy': '.*나무인형에게 작별 인사를 합니다',
         'You bow courteously to the striking dummy': '.*나무인형에게 공손하게 인사합니다',

--- a/ui/raidboss/data/05-shb/raid/e8s.ts
+++ b/ui/raidboss/data/05-shb/raid/e8s.ts
@@ -1,10 +1,14 @@
 import Conditions from '../../../../../resources/conditions';
 import { Responses } from '../../../../../resources/responses';
+import { ConfigValue } from '../../../../../resources/user_config';
 import ZoneId from '../../../../../resources/zone_id';
 import { RaidbossData } from '../../../../../types/data';
 import { TriggerSet } from '../../../../../types/trigger';
 
+export type ConfigIds = 'uptimeKnockbackStrat';
+
 export interface Data extends RaidbossData {
+  triggerSetConfig: { [key in ConfigIds]: ConfigValue };
   firstFrost?: string;
   rushCount?: number;
   akhMornTargets?: string[];
@@ -12,17 +16,6 @@ export interface Data extends RaidbossData {
   wyrmclawNumber?: number;
   wyrmfangNumber?: number;
 }
-
-// In your cactbot/user/raidboss.js file, add the line:
-//   Options.cactbote8sUptimeKnockbackStrat = true;
-// .. if you want cactbot to callout Mirror Mirror 4's double knockback
-// Callout happens during/after boss turns and requires <1.4s reaction time
-// to avoid both Green and Read Mirror knockbacks.
-// Example: https://clips.twitch.tv/CreativeDreamyAsparagusKlappa
-// Group splits into two groups behind boss after the jump.
-// Tanks adjust to where the Red and Green Mirror are located.
-// One tank must be inbetween the party, the other closest to Greem Mirror.
-// Once Green Mirror goes off, the tanks adjust for Red Mirror.
 
 // TODO: figure out *anything* with mirrors and mirror colors
 // TODO: yell at you to take the last tower for Light Rampant if needed
@@ -38,6 +31,32 @@ export interface Data extends RaidbossData {
 const triggerSet: TriggerSet<Data> = {
   id: 'EdensVerseRefulgenceSavage',
   zoneId: ZoneId.EdensVerseRefulgenceSavage,
+  config: [
+    {
+      // If you want cactbot to callout Mirror Mirror 4's double knockback, enable this option.
+      // Callout happens during/after boss turns and requires <1.4s reaction time
+      // to avoid both Green and Read Mirror knockbacks.
+      // Example: https://clips.twitch.tv/CreativeDreamyAsparagusKlappa
+      // Group splits into two groups behind boss after the jump.
+      // Tanks adjust to where the Red and Green Mirror are located.
+      // One tank must be inbetween the party, the other closest to Greem Mirror.
+      // Once Green Mirror goes off, the tanks adjust for Red Mirror.
+      id: 'uptimeKnockbackStrat',
+      name: {
+        en: 'Enable uptime knockback strat',
+        de: 'e8s: aktiviere cactbot Uptime Knockback Strategie', // FIXME
+        fr: 'e8s : activer cactbot pour la strat Uptime Knockback', // FIXME
+        ja: 'エデン零式共鳴編４層：cactbot「ヘヴンリーストライク (ノックバック)」ギミック', // FIXME
+        cn: 'E8S: cactbot击退提示功能', // FIXME
+        ko: '공명 영웅 4층: cactbot 정확한 타이밍 넉백방지 공략 활성화', // FIXME
+      },
+      type: 'checkbox',
+      default: (options) => {
+        const oldSetting = options['cactbote8sUptimeKnockbackStrat'];
+        return typeof oldSetting === 'boolean' ? oldSetting : false;
+      },
+    },
+  ],
   timelineFile: 'e8s.txt',
   timelineTriggers: [
     {
@@ -415,7 +434,7 @@ const triggerSet: TriggerSet<Data> = {
       id: 'E8S Hallowed Wings Knockback',
       type: 'StartsUsing',
       netRegex: { source: 'Shiva', id: '4D77', capture: false },
-      condition: (data) => data.options.cactbote8sUptimeKnockbackStrat === true,
+      condition: (data) => data.triggerSetConfig.uptimeKnockbackStrat === true,
       // This gives a warning within 1.4 seconds, so you can hit arm's length.
       delaySeconds: 8.6,
       durationSeconds: 1.4,

--- a/ui/raidboss/data/05-shb/ultimate/the_epic_of_alexander.ts
+++ b/ui/raidboss/data/05-shb/ultimate/the_epic_of_alexander.ts
@@ -1,12 +1,16 @@
 import Conditions from '../../../../../resources/conditions';
 import Outputs from '../../../../../resources/outputs';
 import { Responses } from '../../../../../resources/responses';
+import { ConfigValue } from '../../../../../resources/user_config';
 import ZoneId from '../../../../../resources/zone_id';
 import { RaidbossData } from '../../../../../types/data';
 import { NetMatches } from '../../../../../types/net_matches';
 import { Output, TriggerSet } from '../../../../../types/trigger';
 
+export type ConfigIds = 'cactbotWormholeStrat';
+
 export interface Data extends RaidbossData {
+  triggerSetConfig: { [key in ConfigIds]: ConfigValue };
   phase?: string;
   decOffset?: number;
   nisiMap?: { [name: string]: number };
@@ -44,26 +48,6 @@ export interface Data extends RaidbossData {
   secondTrineResponse?: string;
   trineLocations?: (number[] | undefined)[];
 }
-
-// In your cactbot/user/raidboss.js file, add the line:
-//   Options.cactbotWormholeStrat = true;
-// .. if you want cactbot strat for wormhole.
-//
-// This is more or less the TPS wormhole strat, with
-// some modifications to require less brain.
-//
-// Original TPS strat: https://www.youtube.com/watch?v=ScBsC5sZRwU
-//
-// Changes:
-// There's no "CC" side or "BJ" side, only left side and right side.
-// Start middle, face north, away from alexander.
-// Odds go left, evens go right.  1+4 go to robots, 2+3 go back, 5+6+7+8 go side of robot.
-// From there, do the same thing you normally would for your number in the TPS strat.
-// This means that sometimes 2 is baiting BJ and sometimes 3, so both need to leave room.
-// All cleaves go through the middle (easy to know where to face for evens if you don't surecast).
-// East/West cardinals always safe after chakrams.
-//
-// Diagram: https://ff14.toolboxgaming.space/?id=17050133675751&preview=1
 
 // TODO: Future network data mining opportunities.
 // These don't show up in the log (yet??):
@@ -351,6 +335,40 @@ const betaInstructions = (idx: number | undefined, output: Output) => {
 const triggerSet: TriggerSet<Data> = {
   id: 'TheEpicOfAlexanderUltimate',
   zoneId: ZoneId.TheEpicOfAlexanderUltimate,
+  config: [
+    {
+      // This is more or less the TPS wormhole strat, with
+      // some modifications to require less brain.
+      //
+      // Original TPS strat: https://www.youtube.com/watch?v=ScBsC5sZRwU
+      //
+      // Changes:
+      // There's no "CC" side or "BJ" side, only left side and right side.
+      // Start middle, face north, away from alexander.
+      // Odds go left, evens go right.  1+4 go to robots, 2+3 go back, 5+6+7+8 go side of robot.
+      // From there, do the same thing you normally would for your number in the TPS strat.
+      // This means that sometimes 2 is baiting BJ and sometimes 3, so both need to leave room.
+      // All cleaves go through the middle (easy to know where to face for evens if you don't surecast).
+      // East/West cardinals always safe after chakrams.
+      //
+      // Diagram: https://ff14.toolboxgaming.space/?id=17050133675751&preview=1
+      id: 'cactbotWormholeStrat',
+      name: {
+        en:
+          'Enable cactbot Wormhole strat: https://ff14.toolboxgaming.space/?id=17050133675751&preview=1',
+        de: 'Alex Ultimate: aktiviere cactbot Wormhole Strategie', // FIXME
+        fr: 'Alex fatal : activer cactbot pour la strat Wormhole', // FIXME
+        ja: '絶アレキサンダー討滅戦：cactbot「次元断絶のマーチ」ギミック', // FIXME
+        cn: '亚历山大绝境战: cactbot灵泉辅助功能', // FIXME
+        ko: '절 알렉: cactbot 웜홀 공략방식 활성화', // FIXME
+      },
+      type: 'checkbox',
+      default: (options) => {
+        const oldSetting = options['cactbotWormholeStrat'];
+        return typeof oldSetting === 'boolean' ? oldSetting : false;
+      },
+    },
+  ],
   timelineFile: 'the_epic_of_alexander.txt',
   timelineTriggers: [
     {
@@ -1521,7 +1539,7 @@ const triggerSet: TriggerSet<Data> = {
       type: 'Ability',
       netRegex: { source: 'Alexander Prime', id: '486E', capture: false },
       infoText: (data, _matches, output) => {
-        if (data.options.cactbotWormholeStrat === true)
+        if (data.triggerSetConfig.cactbotWormholeStrat === true)
           return output.baitChakramsWormholeStrat!();
 
         return output.baitChakrams!();
@@ -1550,7 +1568,7 @@ const triggerSet: TriggerSet<Data> = {
       type: 'HeadMarker',
       netRegex: {},
       condition: (data, matches) => {
-        if (data.options.cactbotWormholeStrat !== true)
+        if (data.triggerSetConfig.cactbotWormholeStrat !== true)
           return false;
         if (!(/00(?:4F|5[0-6])/).test(getHeadmarkerId(data, matches)))
           return false;
@@ -1658,7 +1676,7 @@ const triggerSet: TriggerSet<Data> = {
       type: 'Ability',
       netRegex: { source: 'Brute Justice', id: '484A', capture: false },
       condition: (data) => {
-        if (data.options.cactbotWormholeStrat !== true)
+        if (data.triggerSetConfig.cactbotWormholeStrat !== true)
           return false;
         if (data.phase !== 'wormhole')
           return;

--- a/ui/raidboss/raidboss_options.ts
+++ b/ui/raidboss/raidboss_options.ts
@@ -1,5 +1,5 @@
 import { Lang } from '../../resources/languages';
-import UserConfig from '../../resources/user_config';
+import UserConfig, { ConfigValue } from '../../resources/user_config';
 import { BaseOptions, RaidbossData } from '../../types/data';
 import { Matches } from '../../types/net_matches';
 import {
@@ -37,6 +37,7 @@ export type PerTriggerAutoConfig = { [triggerId: string]: TriggerAutoConfig };
 export type PerTriggerOptions = { [triggerId: string]: PerTriggerOption };
 export type DisabledTriggers = { [triggerId: string]: boolean };
 export type PerZoneTimelineConfig = { [zoneId: number]: TimelineConfig };
+export type TriggerSetConfig = { [triggerSetId: string]: { [key: string]: ConfigValue } };
 
 type RaidbossNonConfigOptions = {
   PlayerNicks: { [gameName: string]: string };
@@ -50,6 +51,7 @@ type RaidbossNonConfigOptions = {
   PerTriggerAutoConfig: PerTriggerAutoConfig;
   PerTriggerOptions: PerTriggerOptions;
   PerZoneTimelineConfig: PerZoneTimelineConfig;
+  TriggerSetConfig: TriggerSetConfig;
   Triggers: LooseTriggerSet[];
   PlayerNameOverride?: string;
   IsRemoteRaidboss: boolean;
@@ -74,6 +76,7 @@ const defaultRaidbossNonConfigOptions: RaidbossNonConfigOptions = {
   PerTriggerAutoConfig: {},
   PerTriggerOptions: {},
   PerZoneTimelineConfig: {},
+  TriggerSetConfig: {},
 
   Triggers: [],
 
@@ -112,8 +115,6 @@ const defaultRaidbossConfigOptions = {
   AlarmRumbleDuration: 750,
   AlarmRumbleWeak: 0.75,
   AlarmRumbleStrong: 0.75,
-  cactbotWormholeStrat: false,
-  cactbote8sUptimeKnockbackStrat: false,
 };
 type RaidbossConfigOptions = typeof defaultRaidbossConfigOptions;
 


### PR DESCRIPTION
This adds a new `config` entry to trigger sets that can add field entries to the top of the trigger set under the raidboss section in the config ui. Trigger sets must have an id to have any config loaded, saved, or displayed.

Triggers can use `data.triggerSetConfig['optionId']` here to access anything listed in the `config` section by id. The `Data` type for a trigger set can be extended in a way that will type check ids and add field names.

To avoid naming collisions, not all trigger set config values are loaded. Trigger sets get their own config's values loaded implicitly, but if they need to load some other trigger set's values, they can use `loadConfigs` and specify other trigger sets by id.

For backwards compat, `data.triggerSetConfig` contains all saved values (even ones that no longer have a `config` entry). Also, it is possible to use `loadConfigs` to load trigger set ids that no longer exist.

To also support backwards compat, `ConfigEntry.default` can now be a function that reads from options. See the e8s/TEA changes for how this works.