### PR TITLE
oopsy: fix role-based mistake tracking

### DIFF
--- a/ui/oopsyraidsy/player_state_tracker.ts
+++ b/ui/oopsyraidsy/player_state_tracker.ts
@@ -217,8 +217,8 @@ export class PlayerStateTracker {
       worldIdStr !== undefined && jobStr !== undefined
     ) {
       // Generate the party info we would get from OverlayPlugin via logs.
-      const worldId = parseInt(worldIdStr);
-      const job = parseInt(jobStr);
+      const worldId = parseInt(worldIdStr, 16);
+      const job = parseInt(jobStr, 16);
       // Consider everybody in the party for now and we'll figure it out later.
       const inParty = true;
       this.idToPartyInfo[id] = { id, name, worldId, job, inParty };


### PR DESCRIPTION
This was broken in #4499. Apparently I had implemented it, but forgot that job was in hex and so the id -> job -> role mapping was incorrect.  Oops.

Fixes #4530.