### PR TITLE
raidboss: Fix ParseHelperType definitions

### DIFF
--- a/resources/netregexes.ts
+++ b/resources/netregexes.ts
@@ -1,4 +1,4 @@
-import { NetFieldsReverse } from '../types/net_fields';
+import { NetFields, NetFieldsReverse } from '../types/net_fields';
 import { NetParams } from '../types/net_props';
 import { CactbotBaseRegExp } from '../types/net_trigger';
 
@@ -58,7 +58,7 @@ const defaultParams = <
 
 type ParseHelperType<T extends LogDefinitionTypes> =
   & {
-    [field in Extract<keyof NetFieldsReverse[T], string>]?: string;
+    [field in keyof NetFields[T]]?: string | string[];
   }
   & { capture?: boolean };
 
@@ -430,7 +430,7 @@ export const commonNetRegex = {
 
 export const buildNetRegexForTrigger = <T extends keyof NetParams>(
   type: T,
-  params?: ParseHelperType<T>,
+  params?: NetParams[T],
 ): CactbotBaseRegExp<T> => {
   if (type === 'Ability')
     // ts can't narrow T to `Ability` here, need casting.

--- a/resources/regexes.ts
+++ b/resources/regexes.ts
@@ -1,4 +1,4 @@
-import { NetFieldsReverse } from '../types/net_fields';
+import { NetFields, NetFieldsReverse } from '../types/net_fields';
 import { NetParams } from '../types/net_props';
 import { CactbotBaseRegExp } from '../types/net_trigger';
 
@@ -40,7 +40,7 @@ const defaultParams = <
 
 type ParseHelperType<T extends LogDefinitionTypes> =
   & {
-    [field in Extract<keyof NetFieldsReverse[T], string>]?: string;
+    [field in keyof NetFields[T]]?: string | string[];
   }
   & { capture?: boolean };
 


### PR DESCRIPTION
To quote Discord DMs:

> valarnin: ... is it just me, or is the `ParseHelperType` in `netregexes.ts` just flat out incorrectly defined? I just have no clue how typescript allows it in its current state.
> Consider:

```ts
type ParseHelperType<T extends LogDefinitionTypes> =
  & {
    [field in Extract<keyof NetFieldsReverse[T], string>]?: string;
  }
  & { capture?: boolean };

type EmptyType = ParseHelperType<'Ability'>;

type ParseHelperTypeFixed<T extends LogDefinitionTypes> =
  & {
    [field in keyof NetFields[T]]?: string | string[];
  }
  & { capture?: boolean };

type CorrectType = ParseHelperTypeFixed<'Ability'>;
```

![image](https://user-images.githubusercontent.com/6119598/234692665-835dbaa2-10f8-455c-88a7-4d0fef128402.png)
![image](https://user-images.githubusercontent.com/6119598/234692681-59c71ab0-bccf-44c3-a25a-67cc5565075d.png)

> valarnin: (in fact, `Extract<keyof NetFieldsReverse[T], string>` evaluates to `never` because all keys of a given `NetFieldsReverse` type entry are numerical and therefore can never be assigned to `string`)