### PR TITLE
config/oopsy: fix setterFunc changes from #5353

### DIFF
--- a/ui/eureka/eureka_config.ts
+++ b/ui/eureka/eureka_config.ts
@@ -28,7 +28,7 @@ UserConfig.registerOptions('eureka', {
       },
       type: 'float',
       default: 90,
-      setterFunc: (value) => {
+      setterFunc: (value, options) => {
         let seconds: number;
         if (typeof value === 'string')
           seconds = parseFloat(value);
@@ -36,7 +36,8 @@ UserConfig.registerOptions('eureka', {
           seconds = value;
         else
           return;
-        return seconds * 1000;
+        // Store in a separate variable with a different unit.
+        options['FlagTimeoutMs'] = seconds * 1000;
       },
     },
     {
@@ -181,7 +182,7 @@ UserConfig.registerOptions('eureka', {
       },
       type: 'float',
       default: 1,
-      setterFunc: (value) => {
+      setterFunc: (value, options) => {
         let seconds: number;
         if (typeof value === 'string')
           seconds = parseFloat(value);
@@ -189,7 +190,8 @@ UserConfig.registerOptions('eureka', {
           seconds = value;
         else
           return;
-        return seconds * 1000;
+        // Store in a separate variable with a different unit.
+        options['RefreshRateMs'] = seconds * 1000;
       },
     },
   ],

--- a/ui/oopsyraidsy/oopsyraidsy_config.ts
+++ b/ui/oopsyraidsy/oopsyraidsy_config.ts
@@ -303,7 +303,7 @@ const templateOptions: OptionsTemplate = {
       },
       type: 'float',
       default: 4,
-      setterFunc: (value) => {
+      setterFunc: (value, options) => {
         let seconds;
         if (typeof value === 'string')
           seconds = parseFloat(value);
@@ -311,7 +311,9 @@ const templateOptions: OptionsTemplate = {
           seconds = value;
         else
           return;
-        return seconds * 1000;
+
+        // Store in a separate variable with a different unit.
+        options['TimeToShowDeathReportMs'] = seconds * 1000;
       },
     },
     {


### PR DESCRIPTION
Some setterFuncs were using different variable names. Since `Options` isn't typed very well here, this wasn't obvious. This undoes some of those changes. One thing this would cause is the death report showing up even if it was set to zero.

(Thanks, @g0shu)