### PR TITLE
config: fix select type defaults after #5357

### DIFF
--- a/resources/user_config.ts
+++ b/resources/user_config.ts
@@ -504,7 +504,7 @@ class UserConfig {
         else if (typeof value === 'string')
           output[opt.id] = parseFloat(value);
       } else {
-        options[opt.id] = value;
+        output[opt.id] = value;
       }
     }
   }


### PR DESCRIPTION
For trigger set config ui that has a select box, the default was not being set.  This would only have broken #5367 at this point.

Huge thanks to @Legends0 for a ton of help tracking this down.