### PR TITLE
raidboss: TOP P6 Add Cosmo Arrow Exa Calls

### DIFF
--- a/ui/raidboss/data/06-ew/ultimate/the_omega_protocol.ts
+++ b/ui/raidboss/data/06-ew/ultimate/the_omega_protocol.ts
@@ -60,6 +60,7 @@ export interface Data extends RaidbossData {
   monitorPlayers: NetMatches['GainsEffect'][];
   deltaTethers: { [name: string]: TetherColor };
   trioDebuff: { [name: string]: TrioDebuff };
+  seenOmegaTethers?: boolean;
   cosmoArrowCount: number;
   cosmoArrowIn?: boolean;
   cosmoArrowExaCount: number;

--- a/ui/raidboss/data/06-ew/ultimate/the_omega_protocol.ts
+++ b/ui/raidboss/data/06-ew/ultimate/the_omega_protocol.ts
@@ -1984,12 +1984,12 @@ const triggerSet: TriggerSet<Data> = {
       type: 'Ability',
       netRegex: { id: '7BA4', source: 'Alpha Omega', capture: false },
       preRun: (data) => data.cosmoArrowExaCount = data.cosmoArrowExaCount + 1,
-      suppressSeconds: 1, // Only capture 1 in the set of casts
       durationSeconds: (data) => {
         if (data.cosmoArrowExaCount === 3 && data.cosmoArrowIn)
           return 5;
         return 3;
       },
+      suppressSeconds: 1, // Only capture 1 in the set of casts
       infoText: (data, _matches, output) => {
         if (data.cosmoArrowIn) {
           switch (data.cosmoArrowExaCount) {

--- a/ui/raidboss/data/06-ew/ultimate/the_omega_protocol.ts
+++ b/ui/raidboss/data/06-ew/ultimate/the_omega_protocol.ts
@@ -1991,7 +1991,7 @@ const triggerSet: TriggerSet<Data> = {
             case 3:
               return output.outWait2!();
             case 5:
-              return output.cardinalPosition!();
+              return output.cardinalPositionInt!();
             case 6:
               return output.in!();
           }
@@ -2004,7 +2004,7 @@ const triggerSet: TriggerSet<Data> = {
           case 5:
             return output.in!();
           case 4:
-            return output.cardinalPosition!();
+            return output.cardinalPositionOut!();
         }
       },
       run: (data) => {
@@ -2021,7 +2021,10 @@ const triggerSet: TriggerSet<Data> = {
         outWait2: {
           en: 'Out => Wait 2',
         },
-        cardinalPosition: Outputs.moveAway,
+        cardinalPositionIn: Outputs.moveAway,
+        cardinalPositionOut: {
+          en: 'Cardinal Out',
+        },
       },
     },
     {

--- a/ui/raidboss/data/06-ew/ultimate/the_omega_protocol.ts
+++ b/ui/raidboss/data/06-ew/ultimate/the_omega_protocol.ts
@@ -1997,7 +1997,7 @@ const triggerSet: TriggerSet<Data> = {
             case 3:
               return output.outWait2!();
             case 5:
-              return output.cardinalPositionIn!();
+              return output.SidesIn!();
             case 6:
               return output.in!();
           }
@@ -2010,7 +2010,7 @@ const triggerSet: TriggerSet<Data> = {
           case 5:
             return output.in!();
           case 4:
-            return output.cardinalPositionOut!();
+            return output.SidesOut!();
         }
       },
       run: (data) => {
@@ -2027,9 +2027,9 @@ const triggerSet: TriggerSet<Data> = {
         outWait2: {
           en: 'Out => Wait 2',
         },
-        cardinalPositionIn: Outputs.moveAway,
-        cardinalPositionOut: {
-          en: 'Cardinal Out',
+        SidesIn: Outputs.moveAway,
+        SidesOut: {
+          en: 'Sides + Out',
         },
       },
     },

--- a/ui/raidboss/data/06-ew/ultimate/the_omega_protocol.ts
+++ b/ui/raidboss/data/06-ew/ultimate/the_omega_protocol.ts
@@ -60,9 +60,9 @@ export interface Data extends RaidbossData {
   monitorPlayers: NetMatches['GainsEffect'][];
   deltaTethers: { [name: string]: TetherColor };
   trioDebuff: { [name: string]: TrioDebuff };
-  cosmoArrowIn?: boolean;
   cosmoArrowCount: number;
-  seenOmegaTethers?: boolean;
+  cosmoArrowIn?: boolean;
+  cosmoArrowExaCount: number;
 }
 
 const phaseReset = (data: Data) => {
@@ -186,6 +186,7 @@ const triggerSet: TriggerSet<Data> = {
       deltaTethers: {},
       trioDebuff: {},
       cosmoArrowCount: 0,
+      cosmoArrowExaCount: 0,
     };
   },
   timelineTriggers: [
@@ -1923,21 +1924,29 @@ const triggerSet: TriggerSet<Data> = {
       },
     },
     {
-      id: 'TOP Cosmo Arrow In/Out',
+      id: 'TOP Cosmo Arrow In/Out Collect',
       type: 'StartsUsing',
       // Sometimes cast by Omega, sometimes by Alpha Omega
-      netRegex: { id: '7BA3' },
-      suppressSeconds: 5, // Suppress for second Cosmo Arrow
-      infoText: (data, matches, output) => {
-        data.cosmoArrowCount = 0;
-        const x = parseInt(matches.x);
-        const y = parseInt(matches.y);
-        // Out Locations: (85, 80), (120, 85), (115, 120), (80, 115)
-        // In Locations: (100, 80), (80, 100)
-        // Can loosely check one NPC for if it is an inside location
-        data.cosmoArrowIn = (x === 100 || y === 100) ? true : false;
-        if (data.cosmoArrowIn)
+      netRegex: { id: '7BA3', capture: false },
+      run: (data) => {
+        // This will overcount but get reset after
+        data.cosmoArrowCount = data.cosmoArrowCount + 1;
+      },
+    },
+    {
+      id: 'TOP Cosmo Arrow In/Out First',
+      type: 'StartsUsing',
+      // Sometimes cast by Omega, sometimes by Alpha Omega
+      netRegex: { id: '7BA3', capture: false },
+      delaySeconds: 0.1,
+      suppressSeconds: 5,
+      infoText: (data, _matches, output) => {
+        data.cosmoArrowExaCount = 1;
+        if (data.cosmoArrowCount === 2) {
+          data.cosmoArrowIn = true;
           return output.inFirst!();
+        }
+        data.cosmoArrowIn = false;
         return output.outFirst!();
       },
       outputStrings: {
@@ -1950,19 +1959,34 @@ const triggerSet: TriggerSet<Data> = {
       },
     },
     {
+      id: 'TOP Cosmo Arrow In/Out Wait',
+      type: 'Ability',
+      // Sometimes cast by Omega, sometimes by Alpha Omega
+      netRegex: { id: '7BA3', capture: false },
+      suppressSeconds: 5,
+      infoText: (data, _matches, output) => {
+        if (data.cosmoArrowIn)
+          return output.inWait2!();
+        return output.outWait2!();
+      },
+      outputStrings: {
+        inWait2: {
+          en: 'In => Wait 2',
+        },
+        outWait2: {
+          en: 'Out => Wait 2',
+        },
+      },
+    },
+    {
       id: 'TOP Cosmo Arrow Dodges',
       type: 'Ability',
       netRegex: { id: '7BA4', source: 'Alpha Omega', capture: false },
       suppressSeconds: 1, // Only capture 1 in the set of casts
       infoText: (data, _matches, output) => {
-        data.cosmoArrowCount = data.cosmoArrowCount + 1;
-        if (data.cosmoArrowIn === undefined)
-          return;
-
+        data.cosmoArrowExaCount = data.cosmoArrowExaCount + 1;
         if (data.cosmoArrowIn) {
-          switch (data.cosmoArrowCount) {
-            case 1:
-              return output.inWait2!();
+          switch (data.cosmoArrowExaCount) {
             case 3:
               return output.outWait2!();
             case 5:
@@ -1974,15 +1998,18 @@ const triggerSet: TriggerSet<Data> = {
           return;
         }
 
-        switch (data.cosmoArrowCount) {
-          case 1:
-            return output.outWait2!();
+        switch (data.cosmoArrowExaCount) {
           case 3:
+          case 5:
             return output.in!();
           case 4:
             return output.cardinalPosition!();
-          case 5:
-            return output.in!();
+        }
+      },
+      run: (data) => {
+        if (data.cosmoArrowExaCount === 7) {
+          data.cosmoArrowExaCount = 0;
+          data.cosmoArrowCount = 0;
         }
       },
       outputStrings: {

--- a/ui/raidboss/data/06-ew/ultimate/the_omega_protocol.ts
+++ b/ui/raidboss/data/06-ew/ultimate/the_omega_protocol.ts
@@ -1940,6 +1940,7 @@ const triggerSet: TriggerSet<Data> = {
       // Sometimes cast by Omega, sometimes by Alpha Omega
       netRegex: { id: '7BA3', capture: false },
       delaySeconds: 0.1,
+      durationSeconds: 7,
       suppressSeconds: 5,
       infoText: (data, _matches, output) => {
         data.cosmoArrowExaCount = 1;

--- a/ui/raidboss/data/06-ew/ultimate/the_omega_protocol.ts
+++ b/ui/raidboss/data/06-ew/ultimate/the_omega_protocol.ts
@@ -1983,15 +1983,20 @@ const triggerSet: TriggerSet<Data> = {
       id: 'TOP Cosmo Arrow Dodges',
       type: 'Ability',
       netRegex: { id: '7BA4', source: 'Alpha Omega', capture: false },
+      preRun: (data) => data.cosmoArrowExaCount = data.cosmoArrowExaCount + 1,
       suppressSeconds: 1, // Only capture 1 in the set of casts
+      durationSeconds: (data) => {
+        if (data.cosmoArrowExaCount === 3 && data.cosmoArrowIn)
+          return 5;
+        return 3;
+      },
       infoText: (data, _matches, output) => {
-        data.cosmoArrowExaCount = data.cosmoArrowExaCount + 1;
         if (data.cosmoArrowIn) {
           switch (data.cosmoArrowExaCount) {
             case 3:
               return output.outWait2!();
             case 5:
-              return output.cardinalPositionInt!();
+              return output.cardinalPositionIn!();
             case 6:
               return output.in!();
           }


### PR DESCRIPTION
There are NPCs that are added at the first Cosmo Arrow that then cast 7BA3 Cosmo Arrow. The position that these NPCs spawn in at or where they start casting at can be used to determine if it is in or out exasquare first.

There are 4 NPCs used for the outer exasquare and two NPCs for the inner exasquare.

The second Cosmo Arrow will use these same NPCs.

This calls initial in/out before any visible aoes. The rest are timed with the ability.