### PR TITLE
raidboss: fix user triggerset configs not loading

### DIFF
--- a/types/trigger.d.ts
+++ b/types/trigger.d.ts
@@ -219,6 +219,8 @@ export type LooseTriggerSet =
       | { [lang in Lang]?: RegExp };
     triggers?: LooseTrigger[];
     timelineTriggers?: LooseTimelineTrigger[];
+    filename?: string;
+    isUserTriggerSet?: boolean;
   };
 
 export interface RaidbossFileData {

--- a/ui/config/config.ts
+++ b/ui/config/config.ts
@@ -242,10 +242,7 @@ export type ConfigLooseTrigger = LooseTrigger & LooseTimelineTrigger & {
   configOutput?: { [field: string]: string };
 };
 
-export type ConfigLooseTriggerSet = LooseTriggerSet & {
-  filename?: string;
-  isUserTriggerSet?: boolean;
-};
+export type ConfigLooseTriggerSet = LooseTriggerSet;
 
 export type ConfigLooseOopsyTrigger = LooseOopsyTrigger;
 

--- a/ui/raidboss/popup-text.ts
+++ b/ui/raidboss/popup-text.ts
@@ -576,6 +576,7 @@ export class PopupText {
   ProcessDataFiles(files: RaidbossFileData): void {
     this.triggerSets = [];
     this.triggerSetsById = {};
+
     for (const [filename, json] of Object.entries(files)) {
       if (!filename.endsWith('.js') && !filename.endsWith('.ts'))
         continue;
@@ -596,20 +597,27 @@ export class PopupText {
         filename: filename,
         ...json,
       };
-      if (processedSet.id) {
-        if (this.triggerSetsById[processedSet.id] !== undefined) {
-          console.log(
-            `${filename} has duplicate triggerSet id ${processedSet.id}, ignoring triggers`,
-          );
-          continue;
-        }
-        this.triggerSetsById[processedSet.id] = processedSet;
-      }
       this.triggerSets.push(processedSet);
     }
 
     // User triggers must come last so that they override built-in files.
     this.triggerSets.push(...this.options.Triggers);
+
+    // Eliminate any trigger sets with duplicate ids and record a lookup by id.
+    this.triggerSets = this.triggerSets.filter((triggerSet) => {
+      if (triggerSet.id === undefined)
+        return true;
+      if (this.triggerSetsById[triggerSet.id] !== undefined) {
+        console.log(
+          `${
+            triggerSet.filename ?? '???'
+          } has duplicate triggerSet id ${triggerSet.id}, ignoring triggers`,
+        );
+        return false;
+      }
+      this.triggerSetsById[triggerSet.id] = triggerSet;
+      return true;
+    });
   }
 
   OnChangeZone(e: EventResponses['ChangeZone']): void {
@@ -710,8 +718,10 @@ export class PopupText {
       }
 
       if (this.options.Debug) {
-        if (set.filename)
-          console.log('Loading ' + set.filename);
+        if (set.id !== undefined)
+          console.log(`Loading id ${set.id}`);
+        else if (set.filename !== undefined)
+          console.log(`Loading ${set.filename}`);
         else
           console.log('Loading user triggers for zone');
       }


### PR DESCRIPTION
There was an oversight that configs from user files were not being added to the set of triggersets by id, and so could never be looked up. This meant that only built-in trigger sets could use configs.

This should address that issue.

Fixes #5380.