### PR TITLE
raidboss: fix triggers on "first time" trials

### DIFF
--- a/ui/raidboss/popup-text.ts
+++ b/ui/raidboss/popup-text.ts
@@ -613,11 +613,12 @@ export class PopupText {
   }
 
   OnChangeZone(e: EventResponses['ChangeZone']): void {
-    if (this.zoneName !== e.zoneName) {
-      this.zoneName = e.zoneName;
-      this.zoneId = e.zoneID;
-      this.ReloadTimelines();
-    }
+    // Note: this must check zone id and not zone name, as there are some zone name collisions.
+    if (this.zoneId === e.zoneID)
+      return;
+    this.zoneName = e.zoneName;
+    this.zoneId = e.zoneID;
+    this.ReloadTimelines();
   }
 
   ReloadTimelines(): void {


### PR DESCRIPTION
Some trials (e.g. Hydaelyn, Zodiark) have a set piece staging zone with the same name but a different zone id, e.g.

```
01|2023-05-04T08:04:28.4810000-07:00|404|The Dark Inside|fdb658b6504e7637
01|2023-05-04T08:09:52.4630000-07:00|3E0|The Dark Inside|f9ffe2b0702f8aa1
```

Raidboss was only detecting zone *name* changes and not zone *id* changes, and so it would try to load zone 0x404 (not found, pun not intended) and never switch to 0x3E0 (the real zone).

Fixes #4509.