### PR TITLE
jobs: use ffxivVersion instead of ffxivRegion

### DIFF
--- a/ui/jobs/buff_tracker.ts
+++ b/ui/jobs/buff_tracker.ts
@@ -32,7 +32,7 @@ import WidgetList from '../../resources/widget_list';
 import { NetMatches } from '../../types/net_matches';
 
 import { kAbility } from './constants';
-import { FfxivRegion } from './jobs';
+import { FfxivVersion } from './jobs';
 import { JobsOptions } from './jobs_options';
 import { makeAuraTimerIcon } from './utils';
 
@@ -278,7 +278,7 @@ export class BuffTracker {
     private leftBuffDiv: WidgetList,
     private rightBuffDiv: WidgetList,
     private partyTracker: PartyTracker,
-    private ffxivRegion: FfxivRegion,
+    private ffxivVersion: FfxivVersion,
   ) {
     this.options = options;
     this.playerName = playerName;
@@ -609,19 +609,19 @@ export class BuffTracker {
       },
     };
 
-    // Abilities that are different in Cn region.
-    const vCn: { [s: string]: BuffInfo } = {};
+    // Abilities that are different in 6.1 version.
+    const v61: { [s: string]: BuffInfo } = {};
 
-    // Abilities that are different in Ko region.
-    const vKo: { [s: string]: BuffInfo } = {};
+    // Abilities that are different in 6.0 version.
+    const v60: { [s: string]: BuffInfo } = {};
 
-    if (this.ffxivRegion === 'ko') {
-      for (const [key, entry] of Object.entries(vKo))
+    if (this.ffxivVersion < 6.2) {
+      for (const [key, entry] of Object.entries(v61))
         this.buffInfo[key] = entry;
     }
 
-    if (this.ffxivRegion === 'cn') {
-      for (const [key, entry] of Object.entries(vCn))
+    if (this.ffxivVersion < 6.1) {
+      for (const [key, entry] of Object.entries(v60))
         this.buffInfo[key] = entry;
     }
 

--- a/ui/jobs/buff_tracker.ts
+++ b/ui/jobs/buff_tracker.ts
@@ -610,18 +610,18 @@ export class BuffTracker {
     };
 
     // Abilities that are different in 6.1 version.
-    const v61: { [s: string]: BuffInfo } = {};
+    const v610: { [s: string]: BuffInfo } = {};
 
     // Abilities that are different in 6.0 version.
-    const v60: { [s: string]: BuffInfo } = {};
+    const v600: { [s: string]: BuffInfo } = {};
 
-    if (this.ffxivVersion < 6.2) {
-      for (const [key, entry] of Object.entries(v61))
+    if (this.ffxivVersion < 620) {
+      for (const [key, entry] of Object.entries(v610))
         this.buffInfo[key] = entry;
     }
 
-    if (this.ffxivVersion < 6.1) {
-      for (const [key, entry] of Object.entries(v60))
+    if (this.ffxivVersion < 610) {
+      for (const [key, entry] of Object.entries(v600))
         this.buffInfo[key] = entry;
     }
 

--- a/ui/jobs/combo_tracker.ts
+++ b/ui/jobs/combo_tracker.ts
@@ -3,8 +3,8 @@ import { EventEmitter } from 'eventemitter3';
 import {
   kComboActions,
   kComboBreakers,
-  kComboBreakers62,
   kComboBreakers61,
+  kComboBreakers62,
   kComboDelay,
 } from './constants';
 import { FfxivVersion } from './jobs';

--- a/ui/jobs/combo_tracker.ts
+++ b/ui/jobs/combo_tracker.ts
@@ -3,8 +3,8 @@ import { EventEmitter } from 'eventemitter3';
 import {
   kComboActions,
   kComboBreakers,
-  kComboBreakers61,
-  kComboBreakers62,
+  kComboBreakers610,
+  kComboBreakers620,
   kComboDelay,
 } from './constants';
 import { FfxivVersion } from './jobs';
@@ -115,10 +115,10 @@ export class ComboTracker extends EventEmitter<{ combo: ComboCallback }> {
 
   static setup(ffxivVersion: FfxivVersion, player: Player): ComboTracker {
     let breakers;
-    if (ffxivVersion < 6.3)
-      breakers = kComboBreakers62;
-    else if (ffxivVersion < 6.2)
-      breakers = kComboBreakers61;
+    if (ffxivVersion < 630)
+      breakers = kComboBreakers620;
+    else if (ffxivVersion < 620)
+      breakers = kComboBreakers610;
     else
       breakers = kComboBreakers;
 

--- a/ui/jobs/combo_tracker.ts
+++ b/ui/jobs/combo_tracker.ts
@@ -3,11 +3,11 @@ import { EventEmitter } from 'eventemitter3';
 import {
   kComboActions,
   kComboBreakers,
-  kComboBreakersCn,
-  kComboBreakersKo,
+  kComboBreakers62,
+  kComboBreakers61,
   kComboDelay,
 } from './constants';
-import { FfxivRegion } from './jobs';
+import { FfxivVersion } from './jobs';
 import { Player } from './player';
 
 type StartMap = {
@@ -113,12 +113,12 @@ export class ComboTracker extends EventEmitter<{ combo: ComboCallback }> {
     this.StateTransition(id);
   }
 
-  static setup(ffxivRegion: FfxivRegion, player: Player): ComboTracker {
+  static setup(ffxivVersion: FfxivVersion, player: Player): ComboTracker {
     let breakers;
-    if (ffxivRegion === 'ko')
-      breakers = kComboBreakersKo;
-    else if (ffxivRegion === 'cn')
-      breakers = kComboBreakersCn;
+    if (ffxivVersion < 6.3)
+      breakers = kComboBreakers62;
+    else if (ffxivVersion < 6.2)
+      breakers = kComboBreakers61;
     else
       breakers = kComboBreakers;
 

--- a/ui/jobs/components/base.ts
+++ b/ui/jobs/components/base.ts
@@ -4,7 +4,7 @@ import { Bars } from '../bars';
 import { ComboTracker } from '../combo_tracker';
 import { kComboDelay } from '../constants';
 import { JobsEventEmitter, PartialFieldMatches } from '../event_emitter';
-import { FfxivRegion } from '../jobs';
+import { FfxivVersion } from '../jobs';
 import { JobsOptions } from '../jobs_options';
 import { Player } from '../player';
 
@@ -24,7 +24,7 @@ export interface ComponentInterface {
   options: JobsOptions;
   partyTracker: PartyTracker;
   player: Player;
-  ffxivRegion: FfxivRegion;
+  ffxivVersion: FfxivVersion;
 }
 
 export class BaseComponent implements ComponentInterface {
@@ -33,7 +33,7 @@ export class BaseComponent implements ComponentInterface {
   options: JobsOptions;
   partyTracker: PartyTracker;
   player: Player;
-  ffxivRegion: FfxivRegion;
+  ffxivVersion: FfxivVersion;
 
   inCombat: boolean;
   comboDuration: number;
@@ -44,7 +44,7 @@ export class BaseComponent implements ComponentInterface {
     this.options = o.options;
     this.partyTracker = o.partyTracker;
     this.player = o.player;
-    this.ffxivRegion = o.ffxivRegion;
+    this.ffxivVersion = o.ffxivVersion;
     this.comboDuration = kComboDelay;
 
     this.inCombat = false;

--- a/ui/jobs/components/index.ts
+++ b/ui/jobs/components/index.ts
@@ -6,7 +6,7 @@ import { Bars } from '../bars';
 import { BuffTracker } from '../buff_tracker';
 import { kWellFedContentTypes } from '../constants';
 import { JobsEventEmitter } from '../event_emitter';
-import { FfxivRegion } from '../jobs';
+import { FfxivVersion } from '../jobs';
 import { JobsOptions } from '../jobs_options';
 import { Player } from '../player';
 import { doesJobNeedMPBar, isPvPZone, RegexesHolder } from '../utils';
@@ -89,7 +89,7 @@ export class ComponentManager {
   ee: JobsEventEmitter;
   options: JobsOptions;
   partyTracker: PartyTracker;
-  ffxivRegion: FfxivRegion;
+  ffxivVersion: FfxivVersion;
   player: Player;
   regexes?: RegexesHolder;
   component?: BaseComponent;
@@ -113,7 +113,7 @@ export class ComponentManager {
     this.options = o.options;
     this.partyTracker = o.partyTracker;
     this.player = o.player;
-    this.ffxivRegion = o.ffxivRegion;
+    this.ffxivVersion = o.ffxivVersion;
 
     this.shouldShow = {};
     this.contentType = undefined;
@@ -129,7 +129,7 @@ export class ComponentManager {
   }
 
   getJobComponents(job: Job): BaseComponent {
-    // if (this.o.ffxivRegion === 'cn/ko') {
+    // if (this.o.ffxivVersion < ???) {
     //   if (job === 'XXX')
     //     return new XXXOldComponent(this.o);
     // }
@@ -238,7 +238,7 @@ export class ComponentManager {
           this.bars.o.leftBuffsList,
           this.bars.o.rightBuffsList,
           this.partyTracker,
-          this.ffxivRegion,
+          this.ffxivVersion,
         );
       }
     });

--- a/ui/jobs/components/mch.ts
+++ b/ui/jobs/components/mch.ts
@@ -92,7 +92,7 @@ export class MCHComponent extends BaseComponent {
     // These two seconds are shown by half adjust, not like others' ceil.
     if (jobDetail.overheatActive === true) {
       this.heatGauge.parentNode.classList.add('overheat');
-      if (this.ffxivRegion !== 'ko')
+      if (this.ffxivVersion >= 6.3)
         this.heatGauge.innerText = this.overheatstack.toString();
       else
         this.heatGauge.innerText = Math.round(jobDetail.overheatMilliseconds / 1000).toString();
@@ -125,7 +125,7 @@ export class MCHComponent extends BaseComponent {
   }
 
   override onYouGainEffect(id: string, matches: PartialFieldMatches<'GainsEffect'>): void {
-    if (id === EffectId.Overheated && this.ffxivRegion !== 'ko')
+    if (id === EffectId.Overheated && this.ffxivVersion >= 6.3)
       this.overheatstack = parseInt(matches.count ?? '0');
   }
   override onMobGainsEffectFromYou(id: string, matches: PartialFieldMatches<'GainsEffect'>): void {

--- a/ui/jobs/components/mch.ts
+++ b/ui/jobs/components/mch.ts
@@ -92,7 +92,7 @@ export class MCHComponent extends BaseComponent {
     // These two seconds are shown by half adjust, not like others' ceil.
     if (jobDetail.overheatActive === true) {
       this.heatGauge.parentNode.classList.add('overheat');
-      if (this.ffxivVersion >= 6.3)
+      if (this.ffxivVersion >= 630)
         this.heatGauge.innerText = this.overheatstack.toString();
       else
         this.heatGauge.innerText = Math.round(jobDetail.overheatMilliseconds / 1000).toString();
@@ -125,7 +125,7 @@ export class MCHComponent extends BaseComponent {
   }
 
   override onYouGainEffect(id: string, matches: PartialFieldMatches<'GainsEffect'>): void {
-    if (id === EffectId.Overheated && this.ffxivVersion >= 6.3)
+    if (id === EffectId.Overheated && this.ffxivVersion >= 630)
       this.overheatstack = parseInt(matches.count ?? '0');
   }
   override onMobGainsEffectFromYou(id: string, matches: PartialFieldMatches<'GainsEffect'>): void {

--- a/ui/jobs/components/mch.ts
+++ b/ui/jobs/components/mch.ts
@@ -92,7 +92,7 @@ export class MCHComponent extends BaseComponent {
     // These two seconds are shown by half adjust, not like others' ceil.
     if (jobDetail.overheatActive === true) {
       this.heatGauge.parentNode.classList.add('overheat');
-      if (this.ffxivRegion === 'intl')
+      if (this.ffxivRegion !== 'ko')
         this.heatGauge.innerText = this.overheatstack.toString();
       else
         this.heatGauge.innerText = Math.round(jobDetail.overheatMilliseconds / 1000).toString();
@@ -125,7 +125,7 @@ export class MCHComponent extends BaseComponent {
   }
 
   override onYouGainEffect(id: string, matches: PartialFieldMatches<'GainsEffect'>): void {
-    if (id === EffectId.Overheated && this.ffxivRegion === 'intl')
+    if (id === EffectId.Overheated && this.ffxivRegion !== 'ko')
       this.overheatstack = parseInt(matches.count ?? '0');
   }
   override onMobGainsEffectFromYou(id: string, matches: PartialFieldMatches<'GainsEffect'>): void {

--- a/ui/jobs/components/pld.ts
+++ b/ui/jobs/components/pld.ts
@@ -55,7 +55,7 @@ export class PLDComponent extends BaseComponent {
     const requiescatContainer = document.createElement('div');
     requiescatContainer.id = 'pld-stacks-requiescat';
     this.stacksContainer.appendChild(requiescatContainer);
-    if (this.ffxivVersion >= 6.3) {
+    if (this.ffxivVersion >= 630) {
       for (let i = 0; i < 4; ++i) {
         const d = document.createElement('div');
         requiescatContainer.appendChild(d);
@@ -104,7 +104,7 @@ export class PLDComponent extends BaseComponent {
   }
 
   override onCombo(skill: string, combo: ComboTracker): void {
-    if (skill === kAbility.GoringBlade && this.ffxivVersion >= 6.3)
+    if (skill === kAbility.GoringBlade && this.ffxivVersion >= 630)
       return;
     this.comboTimer.duration = 0;
     if (skill === kAbility.GoringBlade)
@@ -118,11 +118,11 @@ export class PLDComponent extends BaseComponent {
   override onUseAbility(skill: string): void {
     switch (skill) {
       case kAbility.BladeOfValor:
-        if (this.ffxivVersion < 6.3)
+        if (this.ffxivVersion < 630)
           this.goreBox.duration = 21;
         break;
       case kAbility.GoringBlade:
-        if (this.ffxivVersion >= 6.3)
+        if (this.ffxivVersion >= 630)
           this.goreBox.duration = this.bars.player.getActionCooldown(60000, 'skill');
         break;
       case kAbility.Expiacion:
@@ -133,7 +133,7 @@ export class PLDComponent extends BaseComponent {
         this.tid1 = showDuration({
           tid: this.tid1,
           timerbox: this.fightOrFlightBox,
-          duration: this.ffxivVersion >= 6.3 ? 20 : 25,
+          duration: this.ffxivVersion >= 630 ? 20 : 25,
           cooldown: 60,
           threshold: this.player.gcdSkill * 2 + 1,
           activecolor: 'pld-color-fightorflight.active',

--- a/ui/jobs/components/pld.ts
+++ b/ui/jobs/components/pld.ts
@@ -55,7 +55,7 @@ export class PLDComponent extends BaseComponent {
     const requiescatContainer = document.createElement('div');
     requiescatContainer.id = 'pld-stacks-requiescat';
     this.stacksContainer.appendChild(requiescatContainer);
-    if (this.ffxivRegion === 'intl') {
+    if (this.ffxivRegion !== 'ko') {
       for (let i = 0; i < 4; ++i) {
         const d = document.createElement('div');
         requiescatContainer.appendChild(d);
@@ -104,12 +104,13 @@ export class PLDComponent extends BaseComponent {
   }
 
   override onCombo(skill: string, combo: ComboTracker): void {
+    if (skill === kAbility.GoringBlade && this.ffxivRegion !== 'ko')
+      return;
     this.comboTimer.duration = 0;
-    if (skill === kAbility.GoringBlade && this.ffxivRegion !== 'intl')
+    if (skill === kAbility.GoringBlade)
       this.goreBox.duration = 21;
     if (combo.isFinalSkill)
-      if (skill !== kAbility.GoringBlade || this.ffxivRegion !== 'intl')
-        return;
+      return;
     if (skill)
       this.comboTimer.duration = this.comboDuration;
   }
@@ -117,11 +118,11 @@ export class PLDComponent extends BaseComponent {
   override onUseAbility(skill: string): void {
     switch (skill) {
       case kAbility.BladeOfValor:
-        if (this.ffxivRegion !== 'intl')
+        if (this.ffxivRegion === 'ko')
           this.goreBox.duration = 21;
         break;
       case kAbility.GoringBlade:
-        if (this.ffxivRegion === 'intl')
+        if (this.ffxivRegion !== 'ko')
           this.goreBox.duration = this.bars.player.getActionCooldown(60000, 'skill');
         break;
       case kAbility.Expiacion:
@@ -132,7 +133,7 @@ export class PLDComponent extends BaseComponent {
         this.tid1 = showDuration({
           tid: this.tid1,
           timerbox: this.fightOrFlightBox,
-          duration: this.ffxivRegion === 'intl' ? 20 : 25,
+          duration: this.ffxivRegion !== 'ko' ? 20 : 25,
           cooldown: 60,
           threshold: this.player.gcdSkill * 2 + 1,
           activecolor: 'pld-color-fightorflight.active',

--- a/ui/jobs/components/pld.ts
+++ b/ui/jobs/components/pld.ts
@@ -55,7 +55,7 @@ export class PLDComponent extends BaseComponent {
     const requiescatContainer = document.createElement('div');
     requiescatContainer.id = 'pld-stacks-requiescat';
     this.stacksContainer.appendChild(requiescatContainer);
-    if (this.ffxivRegion !== 'ko') {
+    if (this.ffxivVersion >= 6.3) {
       for (let i = 0; i < 4; ++i) {
         const d = document.createElement('div');
         requiescatContainer.appendChild(d);
@@ -104,7 +104,7 @@ export class PLDComponent extends BaseComponent {
   }
 
   override onCombo(skill: string, combo: ComboTracker): void {
-    if (skill === kAbility.GoringBlade && this.ffxivRegion !== 'ko')
+    if (skill === kAbility.GoringBlade && this.ffxivVersion >= 6.3)
       return;
     this.comboTimer.duration = 0;
     if (skill === kAbility.GoringBlade)
@@ -118,11 +118,11 @@ export class PLDComponent extends BaseComponent {
   override onUseAbility(skill: string): void {
     switch (skill) {
       case kAbility.BladeOfValor:
-        if (this.ffxivRegion === 'ko')
+        if (this.ffxivVersion < 6.3)
           this.goreBox.duration = 21;
         break;
       case kAbility.GoringBlade:
-        if (this.ffxivRegion !== 'ko')
+        if (this.ffxivVersion >= 6.3)
           this.goreBox.duration = this.bars.player.getActionCooldown(60000, 'skill');
         break;
       case kAbility.Expiacion:
@@ -133,7 +133,7 @@ export class PLDComponent extends BaseComponent {
         this.tid1 = showDuration({
           tid: this.tid1,
           timerbox: this.fightOrFlightBox,
-          duration: this.ffxivRegion !== 'ko' ? 20 : 25,
+          duration: this.ffxivVersion >= 6.3 ? 20 : 25,
           cooldown: 60,
           threshold: this.player.gcdSkill * 2 + 1,
           activecolor: 'pld-color-fightorflight.active',

--- a/ui/jobs/components/sge.ts
+++ b/ui/jobs/components/sge.ts
@@ -84,7 +84,7 @@ export class SGEComponent extends BaseComponent {
       case kAbility.Phlegma2:
       case kAbility.Phlegma3:
         if (matches.targetIndex === '0') { // Avoid multiple call in AOE
-          if (this.ffxivVersion >= 6.3)
+          if (this.ffxivVersion >= 630)
             this.phlegma.duration = 40 + this.phlegma.value;
           else
             this.phlegma.duration = 45 + this.phlegma.value;

--- a/ui/jobs/components/sge.ts
+++ b/ui/jobs/components/sge.ts
@@ -84,7 +84,7 @@ export class SGEComponent extends BaseComponent {
       case kAbility.Phlegma2:
       case kAbility.Phlegma3:
         if (matches.targetIndex === '0') { // Avoid multiple call in AOE
-          if (this.ffxivRegion !== 'ko')
+          if (this.ffxivVersion >= 6.3)
             this.phlegma.duration = 40 + this.phlegma.value;
           else
             this.phlegma.duration = 45 + this.phlegma.value;

--- a/ui/jobs/components/sge.ts
+++ b/ui/jobs/components/sge.ts
@@ -84,7 +84,7 @@ export class SGEComponent extends BaseComponent {
       case kAbility.Phlegma2:
       case kAbility.Phlegma3:
         if (matches.targetIndex === '0') { // Avoid multiple call in AOE
-          if (this.ffxivRegion === 'intl')
+          if (this.ffxivRegion !== 'ko')
             this.phlegma.duration = 40 + this.phlegma.value;
           else
             this.phlegma.duration = 45 + this.phlegma.value;

--- a/ui/jobs/components/whm.ts
+++ b/ui/jobs/components/whm.ts
@@ -92,7 +92,7 @@ export class WHMComponent extends BaseComponent {
         this.diaBox.duration = 30;
         break;
       case kAbility.Assize:
-        if (this.ffxivRegion !== 'ko')
+        if (this.ffxivVersion >= 6.3)
           this.assizeBox.duration = 40;
         else
           this.assizeBox.duration = 45;

--- a/ui/jobs/components/whm.ts
+++ b/ui/jobs/components/whm.ts
@@ -92,7 +92,7 @@ export class WHMComponent extends BaseComponent {
         this.diaBox.duration = 30;
         break;
       case kAbility.Assize:
-        if (this.ffxivRegion === 'intl')
+        if (this.ffxivRegion !== 'ko')
           this.assizeBox.duration = 40;
         else
           this.assizeBox.duration = 45;

--- a/ui/jobs/components/whm.ts
+++ b/ui/jobs/components/whm.ts
@@ -92,7 +92,7 @@ export class WHMComponent extends BaseComponent {
         this.diaBox.duration = 30;
         break;
       case kAbility.Assize:
-        if (this.ffxivVersion >= 6.3)
+        if (this.ffxivVersion >= 630)
           this.assizeBox.duration = 40;
         else
           this.assizeBox.duration = 45;

--- a/ui/jobs/constants.ts
+++ b/ui/jobs/constants.ts
@@ -69,6 +69,7 @@ export const kAbility = {
   BladeofFaith: '6494',
   BladeofTruth: '6495',
   BladeOfValor: '6496',
+  Atonement: '404C',
   // WAR
   HeavySwing: '1F',
   Maim: '25',
@@ -468,6 +469,7 @@ export const kComboBreakers = [
   kAbility.TotalEclipse,
   kAbility.Prominence,
   kAbility.ShieldBash,
+  kAbility.Atonement,
   // WAR
   kAbility.HeavySwing,
   kAbility.Maim,

--- a/ui/jobs/constants.ts
+++ b/ui/jobs/constants.ts
@@ -69,7 +69,6 @@ export const kAbility = {
   BladeofFaith: '6494',
   BladeofTruth: '6495',
   BladeOfValor: '6496',
-  Atonement: '404C',
   // WAR
   HeavySwing: '1F',
   Maim: '25',
@@ -469,7 +468,6 @@ export const kComboBreakers = [
   kAbility.TotalEclipse,
   kAbility.Prominence,
   kAbility.ShieldBash,
-  kAbility.Atonement,
   // WAR
   kAbility.HeavySwing,
   kAbility.Maim,
@@ -541,6 +539,8 @@ export const kComboBreakers = [
 
 export const kComboBreakers620 = [
   ...kComboBreakers,
+  kAbility.GoringBlade,
+  kAbility.Confiteor,
 ];
 
 export const kComboBreakers610 = [

--- a/ui/jobs/constants.ts
+++ b/ui/jobs/constants.ts
@@ -69,7 +69,6 @@ export const kAbility = {
   BladeofFaith: '6494',
   BladeofTruth: '6495',
   BladeOfValor: '6496',
-  Atonement: '404C',
   // WAR
   HeavySwing: '1F',
   Maim: '25',
@@ -469,7 +468,6 @@ export const kComboBreakers = [
   kAbility.TotalEclipse,
   kAbility.Prominence,
   kAbility.ShieldBash,
-  kAbility.Atonement,
   // WAR
   kAbility.HeavySwing,
   kAbility.Maim,

--- a/ui/jobs/constants.ts
+++ b/ui/jobs/constants.ts
@@ -539,8 +539,6 @@ export const kComboBreakers = [
 
 export const kComboBreakersCn = [
   ...kComboBreakers,
-  kAbility.GoringBlade,
-  kAbility.Confiteor,
 ];
 
 export const kComboBreakersKo = [

--- a/ui/jobs/constants.ts
+++ b/ui/jobs/constants.ts
@@ -537,13 +537,13 @@ export const kComboBreakers = [
   kAbility.Bladeshower,
 ];
 
-export const kComboBreakers62 = [
+export const kComboBreakers620 = [
   ...kComboBreakers,
   kAbility.GoringBlade,
   kAbility.Confiteor,
 ];
 
-export const kComboBreakers61 = [
+export const kComboBreakers610 = [
   ...kComboBreakers,
 ];
 

--- a/ui/jobs/constants.ts
+++ b/ui/jobs/constants.ts
@@ -537,14 +537,14 @@ export const kComboBreakers = [
   kAbility.Bladeshower,
 ];
 
-export const kComboBreakersCn = [
-  ...kComboBreakers,
-];
-
-export const kComboBreakersKo = [
+export const kComboBreakers62 = [
   ...kComboBreakers,
   kAbility.GoringBlade,
   kAbility.Confiteor,
+];
+
+export const kComboBreakers61 = [
+  ...kComboBreakers,
 ];
 
 // [level][Sub][Div]

--- a/ui/jobs/jobs.ts
+++ b/ui/jobs/jobs.ts
@@ -21,12 +21,12 @@ UserConfig.getUserConfigLocation('jobs', defaultOptions, () => {
   // (Battle system changes will be merged in major update for CN/KO)
   // (e.g. intl 6.38 job changes are merged in cn patch 6.3)
   const ffxivlanguageToVersion: Record<Lang, FfxivVersion> = {
-    'en': 6.3,
-    'de': 6.3,
-    'fr': 6.3,
-    'ja': 6.3,
-    'cn': 6.3,
-    'ko': 6.2,
+    'en': 638,
+    'de': 638,
+    'fr': 638,
+    'ja': 638,
+    'cn': 630,
+    'ko': 625,
   };
   const ffxivVersion = ffxivlanguageToVersion[options.ParserLanguage];
 

--- a/ui/jobs/jobs.ts
+++ b/ui/jobs/jobs.ts
@@ -11,29 +11,29 @@ import { Player } from './player';
 import '../../resources/defaults.css';
 import './jobs.css';
 
-export type FfxivRegion = 'intl' | 'cn' | 'ko';
+export type FfxivVersion = number;
 
 UserConfig.getUserConfigLocation('jobs', defaultOptions, () => {
   const options = { ...defaultOptions };
 
-  // Because Korean regions are still on older version of FF14,
-  // set this value to whether or not we should treat this as 5.x or 6.x.
-  // This affects things like entire jobs (smn) or combo durations.
-
-  const ffxivlanguageToRegion: Record<Lang, FfxivRegion> = {
-    'en': 'intl',
-    'de': 'intl',
-    'fr': 'intl',
-    'ja': 'intl',
-    'cn': 'cn',
-    'ko': 'ko',
+  // Because CN and KO regions play an older version of FF14,
+  // set the game version here to change the behavior on older version.
+  // (Battle system changes will be merged in major update for CN/KO)
+  // (e.g. intl 6.38 job changes are merged in cn patch 6.3)
+  const ffxivlanguageToVersion: Record<Lang, FfxivVersion> = {
+    'en': 6.3,
+    'de': 6.3,
+    'fr': 6.3,
+    'ja': 6.3,
+    'cn': 6.3,
+    'ko': 6.2,
   };
-  const ffxivRegion = ffxivlanguageToRegion[options.ParserLanguage];
+  const ffxivVersion = ffxivlanguageToVersion[options.ParserLanguage];
 
   const emitter = new JobsEventEmitter();
   const partyTracker = new PartyTracker();
-  const player = new Player(emitter, partyTracker, ffxivRegion);
+  const player = new Player(emitter, partyTracker, ffxivVersion);
   const bars = new Bars(options, { emitter, player });
 
-  new ComponentManager({ bars, emitter, options, partyTracker, player, ffxivRegion });
+  new ComponentManager({ bars, emitter, options, partyTracker, player, ffxivVersion });
 });

--- a/ui/jobs/player.ts
+++ b/ui/jobs/player.ts
@@ -10,7 +10,7 @@ import { NetFields } from '../../types/net_fields';
 
 import { ComboCallback, ComboTracker } from './combo_tracker';
 import { JobsEventEmitter, PartialFieldMatches } from './event_emitter';
-import { FfxivRegion } from './jobs';
+import { FfxivVersion } from './jobs';
 import { calcGCDFromStat, normalizeLogLine } from './utils';
 
 export type Stats = Omit<
@@ -156,7 +156,7 @@ export class Player extends PlayerBase {
   constructor(
     jobsEmitter: JobsEventEmitter,
     partyTracker: PartyTracker,
-    private ffxivRegion: FfxivRegion,
+    private ffxivVersion: FfxivVersion,
   ) {
     super();
     this.ee = new EventEmitter();
@@ -164,7 +164,7 @@ export class Player extends PlayerBase {
     this.partyTracker = partyTracker;
 
     // setup combo tracker
-    this.combo = ComboTracker.setup(this.ffxivRegion, this);
+    this.combo = ComboTracker.setup(this.ffxivVersion, this);
 
     // setup event emitter
     this.jobsEmitter.on('player', (ev) => this.processPlayerChangedEvent(ev));


### PR DESCRIPTION
Based on #5389 
This allows us to change the behavior by just edit the version in jobs.ts, instead of changing all the conditions in each jobs module.