### PR TITLE
raidboss: ex6 fix spark move trigger timing

### DIFF
--- a/ui/raidboss/data/06-ew/trial/golbez-ex.ts
+++ b/ui/raidboss/data/06-ew/trial/golbez-ex.ts
@@ -116,8 +116,9 @@ const triggerSet: TriggerSet<Data> = {
     },
     {
       id: 'GolbezEx Lingering Spark Move',
-      type: 'Ability',
-      netRegex: { id: '8468', source: 'Golbez', capture: false },
+      type: 'StartsUsing',
+      netRegex: { id: '846A', source: 'Golbez', capture: false },
+      suppressSeconds: 3,
       response: Responses.moveAway(),
     },
     {


### PR DESCRIPTION
Adjust the timing from castbar-based to when the invisible clones start casting, fixes move callout being a second early.