### PR TITLE
util: support jumps in test_timeline

### DIFF
--- a/util/logtools/test_timeline.ts
+++ b/util/logtools/test_timeline.ts
@@ -435,6 +435,11 @@ class TestTimeline extends Timeline {
         // Skip text events with no sync.
         if (event.sync === undefined)
           continue;
+        // Skip events when jumping
+        if (
+          lastRecord?.event.sync?.jump !== undefined && lastRecord?.event.sync?.jump >= event.time
+        )
+          continue;
 
         ui.records.push({
           event: event,

--- a/util/logtools/test_timeline.ts
+++ b/util/logtools/test_timeline.ts
@@ -437,7 +437,7 @@ class TestTimeline extends Timeline {
           continue;
         // Skip events when jumping
         if (
-          lastRecord?.event.sync?.jump !== undefined && lastRecord?.event.sync?.jump >= event.time
+          lastRecord?.event.sync?.jump !== undefined && lastRecord?.event.sync?.jump > event.time
         )
           continue;
 

--- a/util/logtools/test_timeline.ts
+++ b/util/logtools/test_timeline.ts
@@ -436,6 +436,9 @@ class TestTimeline extends Timeline {
         if (event.sync === undefined)
           continue;
         // Skip events when jumping
+        // TODO: Instead of marking the destination as `missed',
+        // maybe add some new record type `jump'?
+        // https://github.com/quisquous/cactbot/pull/5435#issuecomment-1565543064
         if (
           lastRecord?.event.sync?.jump !== undefined && lastRecord?.event.sync?.jump > event.time
         )


### PR DESCRIPTION
This avoids having test_timeline report events as being missed when intentionally jumping over them.

I'm not 100% sure about this implementation, my understanding of this code is still pretty surface level, but it seems to work for me on a few logs I tested it against (mostly my new p9n stuff).

Also not sure if I should do `>=` or `>`. The latter still reports a missed entry for the line you're jumping to, e.g. this:

```
100.0 "foo" jump 200.0
150.0 "bar"
200.0 "foo"
201.0 "baz"
```

would output something like this with `>`:

```
       0.000 |    1 | 100.0 "foo" jump 200.0
      Missed |    3 | 200.0 "foo"
       0.000 |    4 | 201.0 "baz"
```

But with `>=` it outputs:

```
       0.000 |    1 | 100.0 "foo" jump 200.0
       0.000 |    4 | 201.0 "baz"
```

I'm not sure exactly what the behaviour should be like if you have multiple entries at the same time that you're jumping to, like:

```
100.0 "foo" jump 200.0
150.0 "bar"
200.0 "foo"
200.0 "baz"
```