### PR TITLE
i18n: 6.4 translations (continued)

### DIFF
--- a/ui/raidboss/data/03-hw/trial/zurvan-ex.ts
+++ b/ui/raidboss/data/03-hw/trial/zurvan-ex.ts
@@ -239,9 +239,11 @@ const triggerSet: TriggerSet<Data> = {
         },
         fire: {
           en: 'Fire',
+          de: 'Feuer',
         },
         ice: {
           en: 'Ice',
+          de: 'Eis',
         },
         unknown: Outputs.unknown,
       },
@@ -267,9 +269,11 @@ const triggerSet: TriggerSet<Data> = {
         },
         fire: {
           en: 'Fire',
+          de: 'Feuer',
         },
         ice: {
           en: 'Ice',
+          de: 'Eis',
         },
         unknown: Outputs.unknown,
       },

--- a/ui/raidboss/data/04-sb/ultimate/unending_coil_ultimate.ts
+++ b/ui/raidboss/data/04-sb/ultimate/unending_coil_ultimate.ts
@@ -794,6 +794,7 @@ const triggerSet: TriggerSet<Data> = {
         },
         thunderOnOthers: {
           en: 'Thunder on ${player1}, ${player2}',
+          de: 'Blitz auf ${player1}, ${player2}',
           ko: '번개 ${player1}, ${player2}',
         },
       },
@@ -1430,6 +1431,7 @@ const triggerSet: TriggerSet<Data> = {
       outputStrings: {
         dive: {
           en: '${dir} Dive',
+          de: '${dir} Sturzbombe',
           ko: '${dir} 다이브',
         },
         ...Directions.outputStrings8Dir,
@@ -1487,6 +1489,7 @@ const triggerSet: TriggerSet<Data> = {
       outputStrings: {
         naelPosition: {
           en: 'Nael is ${dir}',
+          de: 'Nael ist im ${dir}',
           ko: '넬 ${dir}',
         },
         ...Directions.outputStrings8Dir,
@@ -1662,6 +1665,7 @@ const triggerSet: TriggerSet<Data> = {
       outputStrings: {
         naelPosition: {
           en: '${dir} Nael',
+          de: '${dir} Nael',
           ko: '넬 ${dir}',
         },
         left: Outputs.left,
@@ -1816,6 +1820,7 @@ const triggerSet: TriggerSet<Data> = {
       outputStrings: {
         grandOctet: {
           en: 'Bait dash, go ${startDir}, rotate ${path}',
+          de: 'Ansturm ködern, gehe nach ${startDir}, rotiere ${path}',
           ko: '돌진 유도, ${startDir}쪽으로, ${path}',
         },
         clockwise: Outputs.clockwise,
@@ -1897,7 +1902,6 @@ const triggerSet: TriggerSet<Data> = {
   timelineReplace: [
     {
       'locale': 'de',
-      'missingTranslations': true,
       'replaceSync': {
         'Bahamut Prime': 'Prim-Bahamut',
         'Fang of Light': 'Lichtklaue',

--- a/ui/raidboss/data/06-ew/raid/p10n.ts
+++ b/ui/raidboss/data/06-ew/raid/p10n.ts
@@ -170,7 +170,7 @@ const triggerSet: TriggerSet<Data> = {
       'locale': 'de',
       'missingTranslations': true,
       'replaceSync': {
-        'Pand\\\\u00e6monium': 'Pand\u00e6monium',
+        'Pand\\\\u00e6monium': 'Pand\\u00e6monium',
       },
       'replaceText': {
         '\\(marked\\)': '(Markiert)',
@@ -195,7 +195,7 @@ const triggerSet: TriggerSet<Data> = {
       'locale': 'fr',
       'missingTranslations': true,
       'replaceSync': {
-        'Pand\\\\u00e6monium': 'Pand\u00e6monium',
+        'Pand\\\\u00e6monium': 'Pand\\u00e6monium',
       },
       'replaceText': {
         'Cannonspawn': 'Croissance de canon',

--- a/ui/raidboss/data/06-ew/raid/p10n.ts
+++ b/ui/raidboss/data/06-ew/raid/p10n.ts
@@ -44,9 +44,11 @@ const triggerSet: TriggerSet<Data> = {
       outputStrings: {
         onYou: {
           en: 'Spread (avoid posts)',
+          de: 'Verteilen (vermeide Stäbe)',
         },
         onOthers: {
           en: 'Avoid marked players',
+          de: 'Vermeide markierte Spieler',
         },
       },
     },
@@ -66,6 +68,7 @@ const triggerSet: TriggerSet<Data> = {
       outputStrings: {
         text: {
           en: 'Avoid jails',
+          de: 'Gefängnisen vermeiden',
         },
       },
     },
@@ -78,6 +81,7 @@ const triggerSet: TriggerSet<Data> = {
       outputStrings: {
         text: {
           en: 'Under jails',
+          de: 'Geh unter ein Gefängnis',
         },
       },
     },
@@ -121,6 +125,7 @@ const triggerSet: TriggerSet<Data> = {
       outputStrings: {
         text: {
           en: 'Side platform(s)',
+          de: 'Seite-Platform(en)',
         },
       },
     },
@@ -151,10 +156,83 @@ const triggerSet: TriggerSet<Data> = {
       outputStrings: {
         soak: {
           en: 'Soak tower',
+          de: 'Türme nehmen',
         },
         avoid: {
           en: 'Avoid towers',
+          de: 'Türme vermeiden',
         },
+      },
+    },
+  ],
+  timelineReplace: [
+    {
+      'locale': 'de',
+      'missingTranslations': true,
+      'replaceSync': {
+        'Pand\u00e6monium': 'Pand\u00e6monium',
+      },
+      'replaceText': {
+        '\\(marked\\)': '(Markiert)',
+        '\\(resolves\\)': '(Effekt)',
+        '\\(knockback\\)': '(Rückstoß)',
+        'Cannonspawn': 'Kanonenbrut',
+        'Entangling Web': 'Großnetz',
+        'Harrowing Hell': 'Höllenpein der Tiefe',
+        'Imprisonment': 'Einkerkerung',
+        'Pandaemoniac Meltdown': 'Pandaemonischer Kollaps',
+        'Pandaemoniac Pillars': 'Pandaemonische Säule',
+        'Pandaemoniac Ray': 'Pandaemonischer Strahl',
+        'Parted Plumes': 'Teilungsstrahl',
+        'Silkspit': 'Spucknetz',
+        'Soul Grasp': 'Seelengreifer',
+        'Touchdown': 'Himmelssturz',
+        'Ultima': 'Ultima',
+        'Wicked Step': 'Übler Schritt',
+      },
+    },
+    {
+      'locale': 'fr',
+      'missingTranslations': true,
+      'replaceSync': {
+        'Pand\u00e6monium': 'Pand\u00e6monium',
+      },
+      'replaceText': {
+        'Cannonspawn': 'Croissance de canon',
+        'Entangling Web': 'Grande toile',
+        'Harrowing Hell': 'Assaut sismique',
+        'Imprisonment': 'Emprisonnement',
+        'Pandaemoniac Meltdown': 'Fusion pandaemoniaque',
+        'Pandaemoniac Pillars': 'Piliers pandaemoniaques',
+        'Pandaemoniac Ray': 'Rayon pandaemoniaque',
+        'Parted Plumes': 'Plumes fendantes',
+        'Silkspit': 'Crachat de toile',
+        'Soul Grasp': 'Saisie d\'âme',
+        'Touchdown': 'Atterrissage',
+        'Ultima': 'Ultima',
+        'Wicked Step': 'Pattes effilées',
+      },
+    },
+    {
+      'locale': 'ja',
+      'missingTranslations': true,
+      'replaceSync': {
+        'Pand\u00e6monium': 'パンデモニウム',
+      },
+      'replaceText': {
+        'Cannonspawn': 'キャノンスポーン',
+        'Entangling Web': 'グランドウェブ',
+        'Harrowing Hell': '魔殿の震撃',
+        'Imprisonment': 'インプリズメント',
+        'Pandaemoniac Meltdown': 'パンデモニックメルトン',
+        'Pandaemoniac Pillars': 'パンデモニックピラー',
+        'Pandaemoniac Ray': 'パンデモニックレイ',
+        'Parted Plumes': 'ディバイドプルーム',
+        'Silkspit': 'スピットウェブ',
+        'Soul Grasp': 'ソウルグラスプ',
+        'Touchdown': 'タッチダウン',
+        'Ultima': 'アルテマ',
+        'Wicked Step': '尖脚',
       },
     },
   ],

--- a/ui/raidboss/data/06-ew/raid/p10n.ts
+++ b/ui/raidboss/data/06-ew/raid/p10n.ts
@@ -170,7 +170,7 @@ const triggerSet: TriggerSet<Data> = {
       'locale': 'de',
       'missingTranslations': true,
       'replaceSync': {
-        'Pand\u00e6monium': 'Pand\u00e6monium',
+        'Pand\\\\u00e6monium': 'Pand\u00e6monium',
       },
       'replaceText': {
         '\\(marked\\)': '(Markiert)',
@@ -195,7 +195,7 @@ const triggerSet: TriggerSet<Data> = {
       'locale': 'fr',
       'missingTranslations': true,
       'replaceSync': {
-        'Pand\u00e6monium': 'Pand\u00e6monium',
+        'Pand\\\\u00e6monium': 'Pand\u00e6monium',
       },
       'replaceText': {
         'Cannonspawn': 'Croissance de canon',
@@ -217,7 +217,7 @@ const triggerSet: TriggerSet<Data> = {
       'locale': 'ja',
       'missingTranslations': true,
       'replaceSync': {
-        'Pand\u00e6monium': 'パンデモニウム',
+        'Pand\\\\u00e6monium': 'パンデモニウム',
       },
       'replaceText': {
         'Cannonspawn': 'キャノンスポーン',

--- a/ui/raidboss/data/06-ew/raid/p12n.ts
+++ b/ui/raidboss/data/06-ew/raid/p12n.ts
@@ -26,9 +26,11 @@ const wingOutputStrings = {
   // mean your left or the boss's left or that you've left off reading this.
   leftFlank: {
     en: 'Left Flank',
+    de: 'Linke Flanke',
   },
   rightFlank: {
     en: 'Right Flank',
+    de: 'Rechte Flanke',
   },
 } as const;
 
@@ -85,6 +87,7 @@ const triggerSet: TriggerSet<Data> = {
         right: Outputs.right,
         text: {
           en: '${first} => ${second} => ${third}',
+          de: '${first} => ${second} => ${third}',
         },
       },
     },
@@ -160,15 +163,19 @@ const triggerSet: TriggerSet<Data> = {
       outputStrings: {
         superchain1: {
           en: 'Follow Donut',
+          de: 'Donut folgen',
         },
         superchain2: {
           en: 'Short Donut => Long Donut',
+          de: 'Kurzer Donut => Langer Donut',
         },
         superchain3: {
           en: 'Follow Donut (avoid cleave)',
+          de: 'Donut folgen (Cleave ausweichen)',
         },
         superchain4: {
           en: 'Avoid Spheres',
+          de: 'Spheren vermeiden',
         },
       },
     },
@@ -186,6 +193,7 @@ const triggerSet: TriggerSet<Data> = {
       outputStrings: {
         text: {
           en: 'Avoid Chained Platforms',
+          de: 'Vermeide angekettete Platformen',
         },
       },
     },
@@ -202,6 +210,93 @@ const triggerSet: TriggerSet<Data> = {
       type: 'StartsUsing',
       netRegex: { id: '82D6', source: 'Athena' },
       response: Responses.stackMarkerOn(),
+    },
+  ],
+  timelineReplace: [
+    {
+      'locale': 'de',
+      'replaceSync': {
+        'Anthropos': 'Anthropos',
+        'Athena': 'Athena',
+        'Thymou Idea': 'Thymos',
+      },
+      'replaceText': {
+        '\\(spread\\)': '(Verteilen)',
+        '\\(stack\\)': '(Sammeln)',
+        'Clear Cut': 'Klarer Schnitt',
+        'Dialogos': 'Dialogos',
+        'Glaukopis': 'Glaukopis',
+        'On the Soul': 'Auf der Seele',
+        'Palladion': 'Palladion',
+        'Paradeigma': 'Paradigma',
+        'Parthenos': 'Parthenos',
+        'Ray of Light': 'Lichtstrahl',
+        'Sample': 'Vielfraß',
+        'Superchain Burst': 'Superkette - Ausbruch',
+        'Superchain Coil': 'Superkette - Kreis',
+        'Superchain Theory': 'Superkette - Theorie',
+        'Theos\'s Ultima': 'Theos Ultima',
+        'Trinity of Souls': 'Dreifaltigkeit der Seelen',
+        'Ultima Blade': 'Ultima-Klinge',
+        'Unnatural Enchainment': 'Seelenfessel',
+        'White Flame': 'Weißes Feuer',
+      },
+    },
+    {
+      'locale': 'fr',
+      'missingTranslations': true,
+      'replaceSync': {
+        'Anthropos': 'anthropos',
+        'Athena': 'Athéna',
+        'Thymou Idea': 'thymou idea',
+      },
+      'replaceText': {
+        'Clear Cut': 'Tranchage balayant',
+        'Dialogos': 'Dialogos',
+        'Glaukopis': 'Glaukopis',
+        'On the Soul': 'Sur les âmes',
+        'Palladion': 'Palladion',
+        'Paradeigma': 'Paradeigma',
+        'Parthenos': 'Parthénon',
+        'Ray of Light': 'Onde de lumière',
+        'Sample': 'Voracité',
+        'Superchain Burst': 'Salve des superchaînes',
+        'Superchain Coil': 'Cercle des superchaînes',
+        'Superchain Theory': 'Théorie des superchaînes',
+        'Theos\'s Ultima': 'Ultima de théos',
+        'Trinity of Souls': 'Âmes trinité',
+        'Ultima Blade': 'Lames Ultima',
+        'Unnatural Enchainment': 'Enchaînement d\'âmes',
+        'White Flame': 'Feu blanc',
+      },
+    },
+    {
+      'locale': 'ja',
+      'missingTranslations': true,
+      'replaceSync': {
+        'Anthropos': 'アンスロポス',
+        'Athena': 'アテナ',
+        'Thymou Idea': 'テューモス・イデア',
+      },
+      'replaceText': {
+        'Clear Cut': '斬り払い',
+        'Dialogos': 'ディアロゴス',
+        'Glaukopis': 'グラウコピス',
+        'On the Soul': 'オン・ザ・ソウル',
+        'Palladion': 'パラディオン',
+        'Paradeigma': 'パラデイグマ',
+        'Parthenos': 'パルテノン',
+        'Ray of Light': '光波',
+        'Sample': '貪食',
+        'Superchain Burst': 'スーパーチェイン・バースト',
+        'Superchain Coil': 'スーパーチェイン・サークル',
+        'Superchain Theory': 'スーパーチェイン・セオリー',
+        'Theos\'s Ultima': 'テオス・アルテマ',
+        'Trinity of Souls': 'トリニティ・ソウル',
+        'Ultima Blade': 'アルテマブレイド',
+        'Unnatural Enchainment': '魂の鎖',
+        'White Flame': '白火',
+      },
     },
   ],
 };

--- a/ui/raidboss/data/06-ew/trial/zurvan-un.ts
+++ b/ui/raidboss/data/06-ew/trial/zurvan-un.ts
@@ -242,9 +242,11 @@ const triggerSet: TriggerSet<Data> = {
         },
         fire: {
           en: 'Fire',
+          de: 'Feuer',
         },
         ice: {
           en: 'Ice',
+          de: 'Eis',
         },
         unknown: Outputs.unknown,
       },
@@ -270,9 +272,11 @@ const triggerSet: TriggerSet<Data> = {
         },
         fire: {
           en: 'Fire',
+          de: 'Feuer',
         },
         ice: {
           en: 'Ice',
+          de: 'Eis',
         },
         unknown: Outputs.unknown,
       },


### PR DESCRIPTION
@quisquous I am not 100% sure for p10n if the translated names will work as they are.
When running through the `translate-timeline`, they will return as "Pandæmonium" with the special "æ" or if this has to be escaped as well 

But i cant avoid errors, its either the translate timeline script does not show correct value but `npm run test` will pass OR (as it is right now) `run test` wont pass (`AssertionError: P10N Pandaemonic Pillars:locale de:missing timelineReplace replaceSync for source 'Pandæmonium': expected false to be true`) and translate timeline will display the correct value.