### PR TITLE
raidboss: add gameLogType field for GameLog triggers

### DIFF
--- a/test/helper/test_trigger.ts
+++ b/test/helper/test_trigger.ts
@@ -235,7 +235,11 @@ const testTriggerFile = (file: string, info: TriggerSetInfo) => {
             continue;
           }
           // TODO: we can check it from keys of `currentNetRegex`.
-          netRegexRegex = buildNetRegexForTrigger(currentTrigger.type, currentNetRegex);
+          netRegexRegex = buildNetRegexForTrigger(
+            currentTrigger.type,
+            currentTrigger.gameLogType,
+            currentNetRegex,
+          );
         }
 
         const capture = new RegExp(`(?:${netRegexRegex.toString()})?`).exec('');

--- a/types/trigger.d.ts
+++ b/types/trigger.d.ts
@@ -112,9 +112,14 @@ export type BaseTrigger<
   Type extends TriggerTypes,
 > = Omit<BaseNetTrigger<Data, Type>, 'type' | 'netRegex'>;
 
+export type GameLogType = 'Echo' | 'Dialog' | 'Message';
+export type TriggerGameLogType<Type extends TriggerTypes> = Type extends 'GameLog' ? GameLogType
+  : undefined;
+
 type BaseNetTrigger<Data extends RaidbossData, Type extends TriggerTypes> = {
   id: string;
   type: Type;
+  gameLogType?: TriggerGameLogType<Type>;
   netRegex: NetParams[Type] | CactbotBaseRegExp<Type>;
   disabled?: boolean;
   condition?: TriggerField<Data, NetMatches[Type], boolean | undefined>;

--- a/ui/raidboss/data/00-misc/test.ts
+++ b/ui/raidboss/data/00-misc/test.ts
@@ -236,8 +236,9 @@ const triggerSet: TriggerSet<Data> = {
     {
       id: 'Test Lang',
       type: 'GameLog',
+      gameLogType: 'Echo',
       // In game: /echo cactbot lang
-      netRegex: NetRegexes.echo({ line: 'cactbot lang.*?', capture: false }),
+      netRegex: { line: 'cactbot lang.*?', capture: false },
       infoText: (data, _matches, output) => output.text!({ lang: data.parserLang }),
       outputStrings: {
         text: {
@@ -253,7 +254,8 @@ const triggerSet: TriggerSet<Data> = {
     {
       id: 'Test Response',
       type: 'GameLog',
-      netRegex: NetRegexes.echo({ line: 'cactbot test response.*?', capture: false }),
+      gameLogType: 'Echo',
+      netRegex: { line: 'cactbot test response.*?', capture: false },
       response: (_data, _matches, output) => {
         // cactbot-builtin-response
         output.responseOutputStrings = {
@@ -273,7 +275,8 @@ const triggerSet: TriggerSet<Data> = {
     {
       id: 'Test Watch',
       type: 'GameLog',
-      netRegex: NetRegexes.echo({ line: 'cactbot test watch.*?', capture: false }),
+      gameLogType: 'Echo',
+      netRegex: { line: 'cactbot test watch.*?', capture: false },
       promise: (data) =>
         Util.watchCombatant({
           names: [
@@ -315,7 +318,8 @@ const triggerSet: TriggerSet<Data> = {
     {
       id: 'Test Config',
       type: 'GameLog',
-      netRegex: NetRegexes.echo({ line: 'cactbot test config.*?', capture: false }),
+      gameLogType: 'Echo',
+      netRegex: { line: 'cactbot test config.*?', capture: false },
       alertText: (data, _matches, output) => {
         return output.text!({ value: data.triggerSetConfig.testTriggerOutput.toString() });
       },
@@ -331,7 +335,8 @@ const triggerSet: TriggerSet<Data> = {
     {
       id: 'Test Combatant Cast Enable',
       type: 'GameLog',
-      netRegex: NetRegexes.echo({ line: 'cactbot test combatant cast.*?', capture: false }),
+      gameLogType: 'Echo',
+      netRegex: { line: 'cactbot test combatant cast.*?', capture: false },
       run: (data) => {
         data.watchingForCast = true;
       },

--- a/ui/raidboss/data/02-arr/dungeon/haukke_manor.ts
+++ b/ui/raidboss/data/02-arr/dungeon/haukke_manor.ts
@@ -1,5 +1,4 @@
 import Conditions from '../../../../../resources/conditions';
-import NetRegexes from '../../../../../resources/netregexes';
 import { Responses } from '../../../../../resources/responses';
 import ZoneId from '../../../../../resources/zone_id';
 import { RaidbossData } from '../../../../../types/data';
@@ -52,10 +51,11 @@ const triggerSet: TriggerSet<Data> = {
       // Void Lamp Spawn
       id: 'Haukke Normal Void Lamps',
       type: 'GameLog',
-      netRegex: NetRegexes.message({
+      gameLogType: 'Message',
+      netRegex: {
         line: 'The void lamps have begun emitting an eerie glow',
         capture: false,
-      }),
+      },
       infoText: (_data, _matches, output) => output.text!(),
       outputStrings: {
         text: {

--- a/ui/raidboss/data/02-arr/raid/t1.ts
+++ b/ui/raidboss/data/02-arr/raid/t1.ts
@@ -1,5 +1,4 @@
 import Conditions from '../../../../../resources/conditions';
-import NetRegexes from '../../../../../resources/netregexes';
 import { Responses } from '../../../../../resources/responses';
 import ZoneId from '../../../../../resources/zone_id';
 import { RaidbossData } from '../../../../../types/data';
@@ -89,10 +88,11 @@ const triggerSet: TriggerSet<Data> = {
     {
       id: 'T1 Slime Timer First',
       type: 'GameLog',
-      netRegex: NetRegexes.message({
+      gameLogType: 'Message',
+      netRegex: {
         line: 'The Allagan megastructure will be sealed off.*?',
         capture: false,
-      }),
+      },
       delaySeconds: 35,
       suppressSeconds: 5,
       infoText: (_data, _matches, output) => output.text!(),

--- a/ui/raidboss/data/02-arr/raid/t8.ts
+++ b/ui/raidboss/data/02-arr/raid/t8.ts
@@ -1,4 +1,3 @@
-import NetRegexes from '../../../../../resources/netregexes';
 import { Responses } from '../../../../../resources/responses';
 import ZoneId from '../../../../../resources/zone_id';
 import { RaidbossData } from '../../../../../types/data';
@@ -27,7 +26,8 @@ const triggerSet: TriggerSet<Data> = {
     {
       id: 'T8 Landmine Start',
       type: 'GameLog',
-      netRegex: NetRegexes.message({ line: 'Landmines have been scattered.*?', capture: false }),
+      gameLogType: 'Message',
+      netRegex: { line: 'Landmines have been scattered.*?', capture: false },
       alertText: (_data, _matches, output) => output.text!(),
       run: (data) => data.landmines = {},
       outputStrings: {

--- a/ui/raidboss/data/03-hw/alliance/dun_scaith.ts
+++ b/ui/raidboss/data/03-hw/alliance/dun_scaith.ts
@@ -1,5 +1,4 @@
 import Conditions from '../../../../../resources/conditions';
-import NetRegexes from '../../../../../resources/netregexes';
 import { Responses } from '../../../../../resources/responses';
 import ZoneId from '../../../../../resources/zone_id';
 import { RaidbossData } from '../../../../../types/data';
@@ -456,7 +455,8 @@ const triggerSet: TriggerSet<Data> = {
       // However, the RP text seems to be the only indicator.
       id: 'Dun Scaith Shadow Links',
       type: 'GameLog',
-      netRegex: NetRegexes.message({ line: 'Shadows gather on the floor.*?', capture: false }),
+      gameLogType: 'Message',
+      netRegex: { line: 'Shadows gather on the floor.*?', capture: false },
       suppressSeconds: 5,
       response: Responses.stopMoving(),
     },

--- a/ui/raidboss/data/03-hw/alliance/weeping_city.ts
+++ b/ui/raidboss/data/03-hw/alliance/weeping_city.ts
@@ -1,5 +1,4 @@
 import Conditions from '../../../../../resources/conditions';
-import NetRegexes from '../../../../../resources/netregexes';
 import { Responses } from '../../../../../resources/responses';
 import ZoneId from '../../../../../resources/zone_id';
 import { RaidbossData } from '../../../../../types/data';
@@ -84,16 +83,18 @@ const triggerSet: TriggerSet<Data> = {
       // only when that boss is in progress.
       id: 'Weeping City HeadMarker Arachne',
       type: 'GameLog',
-      netRegex: NetRegexes.message({
+      gameLogType: 'Message',
+      netRegex: {
         line: 'The Queen\'s Room will be sealed off.*?',
         capture: false,
-      }),
+      },
       run: (data) => data.arachneStarted = true,
     },
     {
       id: 'Weeping City HeadMarker Ozma',
       type: 'GameLog',
-      netRegex: NetRegexes.message({ line: 'The Gloriole will be sealed off.*?', capture: false }),
+      gameLogType: 'Message',
+      netRegex: { line: 'The Gloriole will be sealed off.*?', capture: false },
       run: (data) => {
         data.arachneStarted = false;
         data.ozmaStarted = true;
@@ -102,10 +103,11 @@ const triggerSet: TriggerSet<Data> = {
     {
       id: 'Weeping City HeadMarker Calofisteri',
       type: 'GameLog',
-      netRegex: NetRegexes.message({
+      gameLogType: 'Message',
+      netRegex: {
         line: 'The Tomb Of The Nullstone will be sealed off.*?',
         capture: false,
-      }),
+      },
       run: (data) => {
         data.ozmaStarted = false;
         data.calStarted = true;

--- a/ui/raidboss/data/04-sb/dungeon/bardams_mettle.ts
+++ b/ui/raidboss/data/04-sb/dungeon/bardams_mettle.ts
@@ -1,5 +1,4 @@
 import Conditions from '../../../../../resources/conditions';
-import NetRegexes from '../../../../../resources/netregexes';
 import { Responses } from '../../../../../resources/responses';
 import ZoneId from '../../../../../resources/zone_id';
 import { RaidbossData } from '../../../../../types/data';
@@ -50,10 +49,11 @@ const triggerSet: TriggerSet<Data> = {
       // If we're in the Yol encounter, we're obviously not fighting Bardam.
       id: 'Bardam\'s Mettle Dead Bardam',
       type: 'GameLog',
-      netRegex: NetRegexes.message({
+      gameLogType: 'Message',
+      netRegex: {
         line: 'Voiceless Muse will be sealed off.*?',
         capture: false,
-      }),
+      },
       run: (data) => data.deadBardam = true,
     },
     {

--- a/ui/raidboss/data/04-sb/eureka/eureka_hydatos.ts
+++ b/ui/raidboss/data/04-sb/eureka/eureka_hydatos.ts
@@ -92,13 +92,15 @@ const triggerSet: TriggerSet<Data> = {
     {
       id: 'BA Seal',
       type: 'GameLog',
-      netRegex: NetRegexes.message({ line: '.* will be sealed off.*?', capture: false }),
+      gameLogType: 'Message',
+      netRegex: { line: '.* will be sealed off.*?', capture: false },
       run: (data) => data.sealed = true,
     },
     {
       id: 'BA Clear Data',
       type: 'GameLog',
-      netRegex: NetRegexes.message({ line: '.*is no longer sealed.*?', capture: false }),
+      gameLogType: 'Message',
+      netRegex: { line: '.*is no longer sealed.*?', capture: false },
       run: (data) => {
         delete data.side;
         delete data.mythcall;
@@ -247,7 +249,8 @@ const triggerSet: TriggerSet<Data> = {
     {
       id: 'BA Owain Fire Element',
       type: 'GameLog',
-      netRegex: NetRegexes.dialog({ line: '[^:]*:Munderg, turn flesh to ash.*?', capture: false }),
+      gameLogType: 'Dialog',
+      netRegex: { line: '[^:]*:Munderg, turn flesh to ash.*?', capture: false },
       condition: (data) => data.side === 'east',
       alertText: (_data, _matches, output) => output.getToIce!(),
       infoText: (_data, _matches, output) => output.switchMagia!(),
@@ -273,7 +276,8 @@ const triggerSet: TriggerSet<Data> = {
     {
       id: 'BA Owain Ice Element',
       type: 'GameLog',
-      netRegex: NetRegexes.dialog({ line: '[^:]*:Munderg, turn blood to ice.*?', capture: false }),
+      gameLogType: 'Dialog',
+      netRegex: { line: '[^:]*:Munderg, turn blood to ice.*?', capture: false },
       condition: (data) => data.side === 'east',
       alertText: (_data, _matches, output) => output.getToFire!(),
       infoText: (_data, _matches, output) => output.switchMagia!(),

--- a/ui/raidboss/data/04-sb/trial/byakko-ex.ts
+++ b/ui/raidboss/data/04-sb/trial/byakko-ex.ts
@@ -1,5 +1,4 @@
 import Conditions from '../../../../../resources/conditions';
-import NetRegexes from '../../../../../resources/netregexes';
 import { Responses } from '../../../../../resources/responses';
 import ZoneId from '../../../../../resources/zone_id';
 import { RaidbossData } from '../../../../../types/data';
@@ -193,10 +192,11 @@ const triggerSet: TriggerSet<Data> = {
     {
       id: 'ByaEx Tiger Add',
       type: 'GameLog',
-      netRegex: NetRegexes.dialog({
+      gameLogType: 'Dialog',
+      netRegex: {
         line: '[^:]*:Twofold is my wrath, twice-cursed my foes!.*?',
         capture: false,
-      }),
+      },
       condition: (data) => data.role === 'tank',
       infoText: (_data, _matches, output) => output.text!(),
       outputStrings: {

--- a/ui/raidboss/data/04-sb/trial/tsukuyomi-ex.ts
+++ b/ui/raidboss/data/04-sb/trial/tsukuyomi-ex.ts
@@ -1,5 +1,4 @@
 import Conditions from '../../../../../resources/conditions';
-import NetRegexes from '../../../../../resources/netregexes';
 import Outputs from '../../../../../resources/outputs';
 import { Responses } from '../../../../../resources/responses';
 import ZoneId from '../../../../../resources/zone_id';
@@ -161,10 +160,11 @@ const triggerSet: TriggerSet<Data> = {
       // There's no "starts using" here.  She pushes at 35% to this ability.
       // This happens after 2nd meteors naturally, but if dps is good
       // then this could push unexpectedly earlier (or paired with buster).
-      netRegex: NetRegexes.dialog({
+      gameLogType: 'Dialog',
+      netRegex: {
         line: '[^:]*:No\. No\.\.\. Not yet\. Not\. Yet\..*?',
         capture: false,
-      }),
+      },
       response: Responses.aoe(),
     },
     {

--- a/ui/raidboss/data/04-sb/ultimate/unending_coil_ultimate.ts
+++ b/ui/raidboss/data/04-sb/ultimate/unending_coil_ultimate.ts
@@ -1,5 +1,4 @@
 import Conditions from '../../../../../resources/conditions';
-import NetRegexes from '../../../../../resources/netregexes';
 import Outputs from '../../../../../resources/outputs';
 import { callOverlayHandler } from '../../../../../resources/overlay_plugin_api';
 import { Responses } from '../../../../../resources/responses';
@@ -461,10 +460,11 @@ const triggerSet: TriggerSet<Data> = {
       // https://xivapi.com/NpcYell/6497?pretty=true
       id: 'UCU Nael Quote 1',
       type: 'GameLog',
-      netRegex: NetRegexes.dialog({
+      gameLogType: 'Dialog',
+      netRegex: {
         line: 'From on high I descend, the hallowed moon to call.*?',
         capture: false,
-      }),
+      },
       durationSeconds: 6,
       infoText: (_data, _matches, output) => output.text!(),
       outputStrings: {
@@ -482,10 +482,11 @@ const triggerSet: TriggerSet<Data> = {
       // https://xivapi.com/NpcYell/6496?pretty=true
       id: 'UCU Nael Quote 2',
       type: 'GameLog',
-      netRegex: NetRegexes.dialog({
+      gameLogType: 'Dialog',
+      netRegex: {
         line: 'From on high I descend, the iron path to walk.*?',
         capture: false,
-      }),
+      },
       durationSeconds: 6,
       infoText: (_data, _matches, output) => output.text!(),
       outputStrings: {
@@ -503,7 +504,8 @@ const triggerSet: TriggerSet<Data> = {
       // https://xivapi.com/NpcYell/6495?pretty=true
       id: 'UCU Nael Quote 3',
       type: 'GameLog',
-      netRegex: NetRegexes.dialog({ line: 'Take fire, O hallowed moon.*?', capture: false }),
+      gameLogType: 'Dialog',
+      netRegex: { line: 'Take fire, O hallowed moon.*?', capture: false },
       durationSeconds: 6,
       infoText: (_data, _matches, output) => output.text!(),
       outputStrings: {
@@ -521,10 +523,11 @@ const triggerSet: TriggerSet<Data> = {
       // https://xivapi.com/NpcYell/6494?pretty=true
       id: 'UCU Nael Quote 4',
       type: 'GameLog',
-      netRegex: NetRegexes.dialog({
+      gameLogType: 'Dialog',
+      netRegex: {
         line: 'Blazing path, lead me to iron rule.*?',
         capture: false,
-      }),
+      },
       infoText: (_data, _matches, output) => output.text!(),
       outputStrings: {
         text: {
@@ -541,10 +544,11 @@ const triggerSet: TriggerSet<Data> = {
       // https://xivapi.com/NpcYell/6493?pretty=true
       id: 'UCU Nael Quote 5',
       type: 'GameLog',
-      netRegex: NetRegexes.dialog({
+      gameLogType: 'Dialog',
+      netRegex: {
         line: 'O hallowed moon, take fire and scorch my foes.*?',
         capture: false,
-      }),
+      },
       infoText: (_data, _matches, output) => output.text!(),
       outputStrings: {
         text: {
@@ -561,10 +565,11 @@ const triggerSet: TriggerSet<Data> = {
       // https://xivapi.com/NpcYell/6492?pretty=true
       id: 'UCU Nael Quote 6',
       type: 'GameLog',
-      netRegex: NetRegexes.dialog({
+      gameLogType: 'Dialog',
+      netRegex: {
         line: 'O hallowed moon, shine you the iron path.*?',
         capture: false,
-      }),
+      },
       infoText: (_data, _matches, output) => output.text!(),
       outputStrings: {
         text: {
@@ -581,10 +586,11 @@ const triggerSet: TriggerSet<Data> = {
       // https://xivapi.com/NpcYell/6501?pretty=true
       id: 'UCU Nael Quote 7',
       type: 'GameLog',
-      netRegex: NetRegexes.dialog({
+      gameLogType: 'Dialog',
+      netRegex: {
         line: 'Fleeting light! \'Neath the red moon, scorch you the earth.*?',
         capture: false,
-      }),
+      },
       delaySeconds: 4,
       durationSeconds: 6,
       // Make this alert so it doesn't overlap with the dive infoText occuring here.
@@ -604,10 +610,11 @@ const triggerSet: TriggerSet<Data> = {
       // https://xivapi.com/NpcYell/6500?pretty=true
       id: 'UCU Nael Quote 8',
       type: 'GameLog',
-      netRegex: NetRegexes.dialog({
+      gameLogType: 'Dialog',
+      netRegex: {
         line: 'Fleeting light! Amid a rain of stars, exalt you the red moon.*?',
         capture: false,
-      }),
+      },
       delaySeconds: 4,
       durationSeconds: 6,
       // Make this alert so it doesn't overlap with the dive infoText occuring here.
@@ -627,10 +634,11 @@ const triggerSet: TriggerSet<Data> = {
       // https://xivapi.com/NpcYell/6502?pretty=true
       id: 'UCU Nael Quote 9',
       type: 'GameLog',
-      netRegex: NetRegexes.dialog({
+      gameLogType: 'Dialog',
+      netRegex: {
         line: 'From on high I descend, the moon and stars to bring.*?',
         capture: false,
-      }),
+      },
       durationSeconds: 9,
       infoText: (_data, _matches, output) => output.text!(),
       outputStrings: {
@@ -648,10 +656,11 @@ const triggerSet: TriggerSet<Data> = {
       // https://xivapi.com/NpcYell/6503?pretty=true
       id: 'UCU Nael Quote 10',
       type: 'GameLog',
-      netRegex: NetRegexes.dialog({
+      gameLogType: 'Dialog',
+      netRegex: {
         line: 'From hallowed moon I descend, a rain of stars to bring.*?',
         capture: false,
-      }),
+      },
       durationSeconds: 9,
       infoText: (_data, _matches, output) => output.text!(),
       outputStrings: {
@@ -669,10 +678,11 @@ const triggerSet: TriggerSet<Data> = {
       // https://xivapi.com/NpcYell/6507?pretty=true
       id: 'UCU Nael Quote 11',
       type: 'GameLog',
-      netRegex: NetRegexes.dialog({
+      gameLogType: 'Dialog',
+      netRegex: {
         line: 'From hallowed moon I bare iron, in my descent to wield.*?',
         capture: false,
-      }),
+      },
       durationSeconds: 9,
       infoText: (_data, _matches, output) => output.text!(),
       outputStrings: {
@@ -690,10 +700,10 @@ const triggerSet: TriggerSet<Data> = {
       // https://xivapi.com/NpcYell/6506?pretty=true
       id: 'UCU Nael Quote 12',
       type: 'GameLog',
-      netRegex: NetRegexes.dialog({
+      netRegex: {
         line: 'From hallowed moon I descend, upon burning earth to tread.*?',
         capture: false,
-      }),
+      },
       durationSeconds: 9,
       infoText: (_data, _matches, output) => output.text!(),
       outputStrings: {
@@ -711,10 +721,11 @@ const triggerSet: TriggerSet<Data> = {
       // https://xivapi.com/NpcYell/6504?pretty=true
       id: 'UCU Nael Quote 13',
       type: 'GameLog',
-      netRegex: NetRegexes.dialog({
+      gameLogType: 'Dialog',
+      netRegex: {
         line: 'Unbending iron, take fire and descend.*?',
         capture: false,
-      }),
+      },
       durationSeconds: 9,
       infoText: (_data, _matches, output) => output.text!(),
       outputStrings: {
@@ -732,10 +743,11 @@ const triggerSet: TriggerSet<Data> = {
       // https://xivapi.com/NpcYell/6505?pretty=true
       id: 'UCU Nael Quote 14',
       type: 'GameLog',
-      netRegex: NetRegexes.dialog({
+      gameLogType: 'Dialog',
+      netRegex: {
         line: 'Unbending iron, descend with fiery edge.*?',
         capture: false,
-      }),
+      },
       durationSeconds: 9,
       infoText: (_data, _matches, output) => output.text!(),
       outputStrings: {

--- a/ui/raidboss/data/05-shb/alliance/the_copied_factory.ts
+++ b/ui/raidboss/data/05-shb/alliance/the_copied_factory.ts
@@ -1,5 +1,4 @@
 import Conditions from '../../../../../resources/conditions';
-import NetRegexes from '../../../../../resources/netregexes';
 import { Responses } from '../../../../../resources/responses';
 import ZoneId from '../../../../../resources/zone_id';
 import { RaidbossData } from '../../../../../types/data';
@@ -124,10 +123,11 @@ const triggerSet: TriggerSet<Data> = {
     {
       id: 'Copied Hobbes Right Arm',
       type: 'GameLog',
-      netRegex: NetRegexes.message({
+      gameLogType: 'Message',
+      netRegex: {
         line: 'The wall-mounted right arm begins to move.*?',
         capture: false,
-      }),
+      },
       infoText: (_data, _matches, output) => output.text!(),
       run: (data) => data.alliance = data.alliance ?? 'A',
       outputStrings: {
@@ -144,10 +144,11 @@ const triggerSet: TriggerSet<Data> = {
     {
       id: 'Copied Hobbes Flamethrowers',
       type: 'GameLog',
-      netRegex: NetRegexes.message({
+      gameLogType: 'Message',
+      netRegex: {
         line: 'The wall-mounted flamethrowers activate\..*?',
         capture: false,
-      }),
+      },
       alertText: (_data, _matches, output) => output.text!(),
       run: (data) => data.alliance = data.alliance || 'B',
       outputStrings: {
@@ -164,10 +165,11 @@ const triggerSet: TriggerSet<Data> = {
     {
       id: 'Copied Hobbes Left Arm 1',
       type: 'GameLog',
-      netRegex: NetRegexes.message({
+      gameLogType: 'Message',
+      netRegex: {
         line: 'The wall-mounted left arm begins to move.*?',
         capture: false,
-      }),
+      },
       durationSeconds: 6,
       response: Responses.getOut('info'),
       run: (data) => data.alliance = data.alliance || 'C',
@@ -175,10 +177,11 @@ const triggerSet: TriggerSet<Data> = {
     {
       id: 'Copied Hobbes Left Arm 2',
       type: 'GameLog',
-      netRegex: NetRegexes.message({
+      gameLogType: 'Message',
+      netRegex: {
         line: 'The wall-mounted left arm begins to move.*?',
         capture: false,
-      }),
+      },
       delaySeconds: 8,
       alertText: (_data, _matches, output) => output.text!(),
       outputStrings: {
@@ -195,10 +198,11 @@ const triggerSet: TriggerSet<Data> = {
     {
       id: 'Copied Hobbes Left Arm 3',
       type: 'GameLog',
-      netRegex: NetRegexes.message({
+      gameLogType: 'Message',
+      netRegex: {
         line: 'The wall-mounted left arm begins to move.*?',
         capture: false,
-      }),
+      },
       delaySeconds: 10,
       alertText: (_data, _matches, output) => output.text!(),
       outputStrings: {
@@ -228,10 +232,11 @@ const triggerSet: TriggerSet<Data> = {
     {
       id: 'Copied Hobbes Electric Floor',
       type: 'GameLog',
-      netRegex: NetRegexes.message({
+      gameLogType: 'Message',
+      netRegex: {
         line: 'You hear frenzied movement from machines beneath.*?',
         capture: false,
-      }),
+      },
       durationSeconds: 10,
       suppressSeconds: 15,
       infoText: (_data, _matches, output) => output.text!(),
@@ -249,10 +254,11 @@ const triggerSet: TriggerSet<Data> = {
     {
       id: 'Copied Hobbes Conveyer Belts',
       type: 'GameLog',
-      netRegex: NetRegexes.message({
+      gameLogType: 'Message',
+      netRegex: {
         line: 'The conveyer belts whirr to life!.*?',
         capture: false,
-      }),
+      },
       infoText: (_data, _matches, output) => output.text!(),
       outputStrings: {
         text: {
@@ -268,10 +274,11 @@ const triggerSet: TriggerSet<Data> = {
     {
       id: 'Copied Hobbes Oil 1',
       type: 'GameLog',
-      netRegex: NetRegexes.message({
+      gameLogType: 'Message',
+      netRegex: {
         line: 'Flammable oil is leaking from the floor.*?',
         capture: false,
-      }),
+      },
       durationSeconds: 3,
       suppressSeconds: 15,
       alertText: (_data, _matches, output) => output.text!(),
@@ -289,10 +296,11 @@ const triggerSet: TriggerSet<Data> = {
     {
       id: 'Copied Hobbes Oil 2',
       type: 'GameLog',
-      netRegex: NetRegexes.message({
+      gameLogType: 'Message',
+      netRegex: {
         line: 'Flammable oil is leaking from the floor.*?',
         capture: false,
-      }),
+      },
       delaySeconds: 6,
       durationSeconds: 3,
       suppressSeconds: 15,

--- a/ui/raidboss/data/06-ew/dungeon/the_sildihn_subterrane.ts
+++ b/ui/raidboss/data/06-ew/dungeon/the_sildihn_subterrane.ts
@@ -1,4 +1,3 @@
-import NetRegexes from '../../../../../resources/netregexes';
 import Outputs from '../../../../../resources/outputs';
 import { Responses } from '../../../../../resources/responses';
 import ZoneId from '../../../../../resources/zone_id';
@@ -123,7 +122,8 @@ const triggerSet: TriggerSet<Data> = {
     {
       id: 'Sildihn Geryon Seal Left Mechs',
       type: 'GameLog',
-      netRegex: NetRegexes.message({ line: 'The Silt Pump will be sealed off.*?', capture: false }),
+      gameLogType: 'Message',
+      netRegex: { line: 'The Silt Pump will be sealed off.*?', capture: false },
       // May be overwritten by Runaway Sludge below.
       run: (data) => data.catapultMechs = leftDoorYesPump,
     },
@@ -151,10 +151,11 @@ const triggerSet: TriggerSet<Data> = {
     {
       id: 'Sildihn Geryon Seal Right Mechs',
       type: 'GameLog',
-      netRegex: NetRegexes.message({
+      gameLogType: 'Message',
+      netRegex: {
         line: 'The Settling Basin will be sealed off.*?',
         capture: false,
-      }),
+      },
       // May be overwritten by Suddenly Sewage below.
       run: (data) => data.catapultMechs = rightDoorNoCeruleum,
     },

--- a/ui/raidboss/popup-text.ts
+++ b/ui/raidboss/popup-text.ts
@@ -814,6 +814,7 @@ export class PopupText {
               } else {
                 const re = buildNetRegexForTrigger(
                   trigger.type,
+                  trigger.gameLogType,
                   translateRegexBuildParam(defaultNetRegex, this.parserLang, set.timelineReplace),
                 );
                 trigger.localNetRegex = Regexes.parse(re);

--- a/ui/raidboss/raidboss_config.ts
+++ b/ui/raidboss/raidboss_config.ts
@@ -1302,6 +1302,7 @@ class RaidbossConfigurator {
       return Regexes.parse(
         buildNetRegexForTrigger(
           trig.type,
+          trig.gameLogType,
           translateRegexBuildParam(regex, lang, set.timelineReplace),
         ),
       );


### PR DESCRIPTION
This is part of #4986.

This is an alternative PR to #5451.

In order to switch entirely over to `netRegex: { params }` style triggers, this PR adds a `gameLogType` field for `GameLog` triggers only.  If specified, it will add the right `code`.

Downsides: kind of awkward if `code` is already specified (and this will throw an error)

Other options:
* add a bunch more types so you could say `type: 'GameLogEcho'`, but this seemed much more hairy than was worth and the TriggerTypes type is already very very long
* export the codes from some common location, import them everywhere, but this is even more nonsense to import so that user triggers can eval properly