### PR TITLE
raidemulator: Fix some minor bugs

### DIFF
--- a/ui/raidboss/emulator/data/network_log_converter/LineEvent0x14.ts
+++ b/ui/raidboss/emulator/data/network_log_converter/LineEvent0x14.ts
@@ -34,7 +34,7 @@ export class LineEvent0x14 extends LineEvent implements LESource, LETarget, LEAb
     this.id = parts[fields.sourceId]?.toUpperCase() ?? '';
     this.name = parts[fields.source] ?? '';
     this.abilityIdHex = parts[fields.id]?.toUpperCase() ?? '';
-    this.abilityId = parseInt(this.abilityIdHex);
+    this.abilityId = parseInt(this.abilityIdHex, 16);
     this.abilityName = parts[fields.ability] ?? '';
     this.targetId = parts[fields.targetId]?.toUpperCase() ?? '';
     this.targetName = parts[fields.target] ?? '';

--- a/ui/raidboss/emulator/data/network_log_converter/LineEvent0x15.ts
+++ b/ui/raidboss/emulator/data/network_log_converter/LineEvent0x15.ts
@@ -51,7 +51,7 @@ export class LineEvent0x15 extends LineEvent implements LESource, LETarget, LEAb
     const fieldOffset = this.flags === '3F' ? 2 : 0;
 
     this.damage = LineEvent.calculateDamage(parts[fields.damage + fieldOffset] ?? '');
-    this.abilityId = parseInt(parts[fields.id]?.toUpperCase() ?? '');
+    this.abilityId = parseInt(parts[fields.id]?.toUpperCase() ?? '', 16);
     this.abilityName = parts[fields.ability] ?? '';
     this.targetId = parts[fields.targetId]?.toUpperCase() ?? '';
     this.targetName = parts[fields.target] ?? '';

--- a/ui/raidboss/emulator/data/network_log_converter/LineEvent0x17.ts
+++ b/ui/raidboss/emulator/data/network_log_converter/LineEvent0x17.ts
@@ -20,7 +20,7 @@ export class LineEvent0x17 extends LineEvent implements LineEventSource, LineEve
 
     this.id = parts[fields.sourceId]?.toUpperCase() ?? '';
     this.name = parts[fields.name] ?? '';
-    this.abilityId = parseInt(parts[fields.id]?.toUpperCase() ?? '');
+    this.abilityId = parseInt(parts[fields.id]?.toUpperCase() ?? '', 16);
     this.abilityName = parts[fields.name] ?? '';
     this.reason = parts[fields.reason] ?? '';
   }

--- a/ui/raidboss/emulator/data/network_log_converter/LineEvent0x1A.ts
+++ b/ui/raidboss/emulator/data/network_log_converter/LineEvent0x1A.ts
@@ -24,7 +24,7 @@ export class LineEvent0x1A extends LineEvent {
   constructor(repo: LogRepository, line: string, parts: string[]) {
     super(repo, line, parts);
 
-    this.effectId = parseInt(parts[fields.effectId]?.toUpperCase() ?? '');
+    this.effectId = parseInt(parts[fields.effectId]?.toUpperCase() ?? '', 16);
     this.effect = parts[fields.effect] ?? '';
     this.durationString = parts[fields.duration] ?? '';
     this.durationFloat = parseFloat(this.durationString);

--- a/ui/raidboss/emulator/overrides/RaidEmulatorPopupText.ts
+++ b/ui/raidboss/emulator/overrides/RaidEmulatorPopupText.ts
@@ -167,6 +167,9 @@ export default class RaidEmulatorPopupText extends StubbedPopupText {
         zoneName: enc.encounterZoneName,
         zoneID: parseInt(enc.encounterZoneId, 16),
       });
+
+      // Always reset when changing encounters
+      this.Reset();
     });
   }
 


### PR DESCRIPTION
Just fixing some minor bugs.

1. Emulator didn't reset properly when changing encounters within the same zone, so now it does so explicitly
2. Various lines were `parseInt`-ing hex values without specifying base 16, this wasn't causing any bugs but did make it more annoying to debug and analyze the encounter manually via devtools