### PR TITLE
i18n: more 6.4 translations

### DIFF
--- a/ui/raidboss/data/00-misc/test.ts
+++ b/ui/raidboss/data/00-misc/test.ts
@@ -350,6 +350,7 @@ const triggerSet: TriggerSet<Data> = {
       outputStrings: {
         casting: {
           en: 'ID ${id} is casting spell ID ${spellId}',
+          de: 'ID ${id} wirkt Zauber ID ${spellId}',
         },
       },
     },
@@ -357,7 +358,6 @@ const triggerSet: TriggerSet<Data> = {
   timelineReplace: [
     {
       locale: 'de',
-      missingTranslations: true,
       replaceSync: {
         'You bid farewell to the striking dummy': 'Du winkst der Trainingspuppe zum Abschied zu',
         'You bow courteously to the striking dummy':

--- a/ui/raidboss/data/00-misc/test.ts
+++ b/ui/raidboss/data/00-misc/test.ts
@@ -358,6 +358,7 @@ const triggerSet: TriggerSet<Data> = {
   timelineReplace: [
     {
       locale: 'de',
+      missingTranslations: true,
       replaceSync: {
         'You bid farewell to the striking dummy': 'Du winkst der Trainingspuppe zum Abschied zu',
         'You bow courteously to the striking dummy':

--- a/ui/raidboss/data/06-ew/raid/p10s.ts
+++ b/ui/raidboss/data/06-ew/raid/p10s.ts
@@ -131,6 +131,7 @@ const triggerSet: TriggerSet<Data> = {
       outputStrings: {
         text: {
           en: 'Point Tether Away',
+          de: 'Zeige Verbindung weg',
         },
       },
     },
@@ -144,6 +145,7 @@ const triggerSet: TriggerSet<Data> = {
       outputStrings: {
         text: {
           en: 'Break Tethers',
+          de: 'Verbindung brechen',
         },
       },
     },
@@ -182,6 +184,7 @@ const triggerSet: TriggerSet<Data> = {
       outputStrings: {
         text: {
           en: 'Stack',
+          de: 'Sammeln',
         },
       },
     },
@@ -202,6 +205,7 @@ const triggerSet: TriggerSet<Data> = {
         text: {
           // TODO: should we say "on posts" or "on back wall" based on count?
           en: 'Overlap Webs',
+          de: 'Netze überlappen',
         },
       },
     },
@@ -225,6 +229,7 @@ const triggerSet: TriggerSet<Data> = {
       outputStrings: {
         text: {
           en: 'Spread for Webs',
+          de: 'Für Netze verteilen',
         },
       },
     },
@@ -306,9 +311,11 @@ const triggerSet: TriggerSet<Data> = {
       outputStrings: {
         spreadThenPartners: {
           en: '(spread => partners, for later)',
+          de: '(Verteilen => Partner, für später)',
         },
         partnersThenSpread: {
           en: '(partners => spread, for later)',
+          de: '(Partner => Verteilen, für später)',
         },
       },
     },
@@ -336,9 +343,11 @@ const triggerSet: TriggerSet<Data> = {
       outputStrings: {
         spreadThenStack: {
           en: '(spread => role stack, for later)',
+          de: '(Verteilen => Rollengruppe, für später)',
         },
         stackThenSpread: {
           en: '(role stack => spread, for later)',
+          de: '(Rollengruppe => Verteilen, für später)',
         },
       },
     },
@@ -359,9 +368,11 @@ const triggerSet: TriggerSet<Data> = {
       outputStrings: {
         spreadThenStack: {
           en: 'Spread => Role Stack',
+          de: 'Verteilen => Rollengruppe',
         },
         spreadThenPartners: {
           en: 'Spread => Partners',
+          de: 'Verteilen => Partner',
         },
       },
     },
@@ -380,9 +391,11 @@ const triggerSet: TriggerSet<Data> = {
       outputStrings: {
         partnersThenStack: {
           en: 'Partners => Role Stack',
+          de: 'Partner => Rollengruppe',
         },
         partnersThenSpread: {
           en: 'Partners => Spread',
+          de: 'Partner => Verteilen',
         },
       },
     },
@@ -401,9 +414,11 @@ const triggerSet: TriggerSet<Data> = {
       outputStrings: {
         stackThenPartners: {
           en: 'Role Stack => Partners',
+          de: 'Rollengruppe => Partner',
         },
         stackThenSpread: {
           en: 'Role Stack => Spread',
+          de: 'Rollengruppe => Verteilen',
         },
       },
     },
@@ -429,18 +444,111 @@ const triggerSet: TriggerSet<Data> = {
         spread: Outputs.spread,
         partners: {
           en: 'Partners',
+          de: 'Partner',
         },
         stack: {
           en: 'Role Stack',
+          de: 'Rollengruppe',
         },
       },
     },
   ],
   timelineReplace: [
     {
-      locale: 'en',
-      replaceText: {
+      'locale': 'en',
+      'replaceText': {
         'Pandaemon\'s Holy/Circles of Pandaemonium': 'Holy/Circles',
+      },
+    },
+    {
+      'locale': 'de',
+      'missingTranslations': true,
+      'replaceSync': {
+        'Arcane Sphere': 'arkan(?:e|er|es|en) Sphäre',
+        'Pand\\\\u00e6moniac Pillar': 'pand\\u00e6monisch(?:e|er|es|en) Turm',
+        'Pand\\\\u00e6monium': 'Pand\\u00e6monium',
+      },
+      'replaceText': {
+        '\\(cast\\)': '(Wirken)',
+        '\\(cone\\)': '(Kegel-AoE)',
+        '\\(knockback\\)': '(Rückstoß)',
+        '\\(share\\)': '(Teilen)',
+        'Bury': 'Impakt',
+        'Circles of Pandaemonium': 'Pandaemonischer Ring',
+        'Dividing Wings': 'Teilungsstrahl',
+        'Entangling Web': 'Großnetz',
+        'Harrowing Hell': 'Höllenpein der Tiefe',
+        'Jade Passage': 'Jadeweg',
+        'Pandaemoniac Meltdown': 'Pandaemonischer Kollaps',
+        'Pandaemoniac Pillars': 'Pandaemonische Säule',
+        'Pandaemoniac Ray': 'Pandaemonischer Strahl',
+        'Pandaemon\'s Holy': 'Pandaemonisches Sanctus',
+        'Parted Plumes': 'Teilungsstrahl',
+        'Peal of Condemnation': 'Verdammungsschub',
+        'Peal of Damnation': 'Kanone der Verdammnis',
+        'Silkspit': 'Spucknetz',
+        'Soul Grasp': 'Seelengreifer',
+        'Touchdown': 'Himmelssturz',
+        'Ultima': 'Ultima',
+        'Wicked Step': 'Übler Schritt',
+      },
+    },
+    {
+      'locale': 'fr',
+      'missingTranslations': true,
+      'replaceSync': {
+        'Arcane Sphere': 'sphère arcanique',
+        'Pand\\\\u00e6moniac Pillar': 'pilier pand\\u00e6moniaque',
+        'Pand\\\\u00e6monium': 'Pand\\u00e6monium',
+      },
+      'replaceText': {
+        'Bury': 'Impact',
+        'Circles of Pandaemonium': 'Anneau pandaemoniaque',
+        'Dividing Wings': 'Ailes fendantes',
+        'Entangling Web': 'Grande toile',
+        'Harrowing Hell': 'Assaut sismique',
+        'Jade Passage': 'Sentier de Jade',
+        'Pandaemoniac Meltdown': 'Fusion pandaemoniaque',
+        'Pandaemoniac Pillars': 'Piliers pandaemoniaques',
+        'Pandaemoniac Ray': 'Rayon pandaemoniaque',
+        'Pandaemon\'s Holy': 'Miracle pandaemoniaque',
+        'Parted Plumes': 'Plumes fendantes',
+        'Peal of Condemnation': 'Électrochoc condamnant',
+        'Peal of Damnation': 'Électrochoc damnant',
+        'Silkspit': 'Crachat de toile',
+        'Soul Grasp': 'Saisie d\'âme',
+        'Touchdown': 'Atterrissage',
+        'Ultima': 'Ultima',
+        'Wicked Step': 'Pattes effilées',
+      },
+    },
+    {
+      'locale': 'ja',
+      'missingTranslations': true,
+      'replaceSync': {
+        'Arcane Sphere': '立体魔法陣',
+        'Pand\\\\u00e6moniac Pillar': '万魔殿の塔',
+        'Pand\\\\u00e6monium': 'パンデモニウム',
+      },
+      'replaceText': {
+        'Bury': '衝撃',
+        'Circles of Pandaemonium': 'パンデモニックリング',
+        'Dividing Wings': 'ディバイドウィング',
+        'Entangling Web': 'グランドウェブ',
+        'Harrowing Hell': '魔殿の震撃',
+        'Jade Passage': 'ロード・オブ・ジェイド',
+        'Pandaemoniac Meltdown': 'パンデモニックメルトン',
+        'Pandaemoniac Pillars': 'パンデモニックピラー',
+        'Pandaemoniac Ray': 'パンデモニックレイ',
+        'Pandaemon\'s Holy': 'パンデモニックホーリー',
+        'Parted Plumes': 'ディバイドプルーム',
+        'Peal of Condemnation': 'コンデムブラスター',
+        'Peal of Damnation': 'ダムドブラスター',
+        'Silkspit': 'スピットウェブ',
+        'Soul Grasp': 'ソウルグラスプ',
+        'Touchdown': 'タッチダウン',
+        'Ultima': 'アルテマ',
+        'Wicked Step': '尖脚',
       },
     },
   ],

--- a/ui/raidboss/data/06-ew/raid/p11s.ts
+++ b/ui/raidboss/data/06-ew/raid/p11s.ts
@@ -17,6 +17,28 @@ const triggerSet: TriggerSet<Data> = {
       response: Responses.bleedAoe(),
     },
   ],
+  timelineReplace: [
+    {
+      'locale': 'de',
+      'replaceSync': {
+        'Themis': 'Themis',
+      },
+    },
+    {
+      'locale': 'fr',
+      'missingTranslations': true,
+      'replaceSync': {
+        'Themis': 'Thémis',
+      },
+    },
+    {
+      'locale': 'ja',
+      'missingTranslations': true,
+      'replaceSync': {
+        'Themis': 'テミス',
+      },
+    },
+  ],
 };
 
 export default triggerSet;

--- a/ui/raidboss/data/06-ew/raid/p9s.ts
+++ b/ui/raidboss/data/06-ew/raid/p9s.ts
@@ -115,6 +115,7 @@ const triggerSet: TriggerSet<Data> = {
       outputStrings: {
         text: {
           en: 'Partners + Donut',
+          de: 'Partner + Donut',
           fr: 'Partenaires + Donut',
           cn: '双人分摊 + 月环',
         },
@@ -130,6 +131,7 @@ const triggerSet: TriggerSet<Data> = {
       outputStrings: {
         text: {
           en: 'Protean + Donut',
+          de: 'Himmelsrichtungen + Donut',
           fr: 'Positions + Donut',
           cn: '八方分散 + 月环',
         },
@@ -148,6 +150,7 @@ const triggerSet: TriggerSet<Data> = {
       outputStrings: {
         fireIceOut: {
           en: 'Out + Partners',
+          de: 'Raus + Partner',
           fr: 'Extérieur + Partenaires',
           cn: '远离 + 双人分摊',
         },
@@ -169,11 +172,13 @@ const triggerSet: TriggerSet<Data> = {
       outputStrings: {
         fireIceIn: {
           en: 'In + Partners',
+          de: 'Rein + Partner',
           fr: 'Intérieur + Partenaires',
           cn: '靠近 + 双人分摊',
         },
         thunderIceIn: {
           en: 'In + Protean',
+          de: 'Rein + Himmelsrichtungen',
           fr: 'Intérieur + Positions',
           cn: '靠近 + 八方分散',
         },
@@ -193,6 +198,7 @@ const triggerSet: TriggerSet<Data> = {
       outputStrings: {
         thunderIceOut: {
           en: 'Out + Protean',
+          de: 'Raus + Himmelsrichtungen',
           fr: 'Extérieur + Positions',
           cn: '远离 + 八方分散',
         },
@@ -213,6 +219,7 @@ const triggerSet: TriggerSet<Data> = {
       outputStrings: {
         text: {
           en: 'Knockback into Wall',
+          de: 'Rückstoß in die Wand',
           fr: 'Poussée sur un mur',
           cn: '向墙边击退',
         },
@@ -300,6 +307,7 @@ const triggerSet: TriggerSet<Data> = {
       outputStrings: {
         text: {
           en: 'Out => Back',
+          de: 'Raus => Hinten',
           fr: 'Extérieur => Derrière',
           cn: '远离 => 去背后',
         },
@@ -314,6 +322,7 @@ const triggerSet: TriggerSet<Data> = {
       outputStrings: {
         text: {
           en: 'In => Back',
+          de: 'Rein => Hinten',
           fr: 'Intérieur => Derrière',
           cn: '靠近 => 去背后',
         },
@@ -328,6 +337,7 @@ const triggerSet: TriggerSet<Data> = {
       outputStrings: {
         text: {
           en: 'Out => Front',
+          de: 'Raus => Vorne',
           fr: 'Extérieur => Devant',
           cn: '远离 => 去面前',
         },
@@ -342,6 +352,7 @@ const triggerSet: TriggerSet<Data> = {
       outputStrings: {
         text: {
           en: 'In => Front',
+          de: 'Rein => Vorne',
           fr: 'Intérieur => Devant',
           cn: '靠近 => 去面前',
         },
@@ -379,21 +390,25 @@ const triggerSet: TriggerSet<Data> = {
         in: Outputs.in,
         outAndFront: {
           en: 'Out + Front',
+          de: 'Raus + Vorne',
           fr: 'Extérieur + Devant',
           cn: '远离 => 去面前',
         },
         outAndBack: {
           en: 'Out + Back',
+          de: 'Raus + Hinten',
           fr: 'Extérieur + Derrière',
           cn: '远离 => 去背后',
         },
         inAndFront: {
           en: 'In + Front',
+          de: 'Rein + Vorne',
           fr: 'Intérieur + Devant',
           cn: '靠近 => 去面前',
         },
         inAndBack: {
           en: 'In + Back',
+          de: 'Rein + Hinten',
           fr: 'Intérieur + Derrière',
           cn: '靠近 => 去背后',
         },
@@ -408,11 +423,92 @@ const triggerSet: TriggerSet<Data> = {
   ],
   timelineReplace: [
     {
-      locale: 'en',
-      replaceText: {
+      'locale': 'en',
+      'replaceText': {
         'Aero IV/Fire IV': 'Aero/Fire IV',
         'Front Combination/Rear Combination': 'Front/Rear Combination',
         'Inside Roundhouse/Outside Roundhouse': 'Inside/Outside Roundhouse',
+      },
+    },
+    {
+      'locale': 'de',
+      'missingTranslations': true,
+      'replaceSync': {
+        'Kokytos': 'Kokytos',
+      },
+      'replaceText': {
+        '\\(Fighter': '(Kämpfer',
+        '\\(Mage': '(Magier',
+        'Aero IV': 'Windka',
+        'Blizzard III': 'Eisga',
+        'Disgorge': 'Seelenwende',
+        'Duality of Death': 'Dualer Tod',
+        'Dualspell': 'Doppelspruch',
+        'Fire(?! )': 'Feuer',
+        'Fire IV': 'Feuka',
+        'Front Combination': 'Trittfolge vor',
+        'Gluttony\'s Augur': 'Omen der Fresssucht',
+        'Ice': 'Eis',
+        'Inside Roundhouse': 'Rundumtritt innen',
+        'Outside Roundhouse': 'Rundumtritt außen',
+        'Pile Pyre': 'Flammenhaufen',
+        'Ravening': 'Seelenfresser',
+        'Rear Combination': 'Trittfolge zurück',
+        'Soul Surge': 'Seelenschub',
+        'Thunder III': 'Blitzga',
+        'Thunder(?! )': 'Blitz',
+      },
+    },
+    {
+      'locale': 'fr',
+      'missingTranslations': true,
+      'replaceSync': {
+        'Kokytos': 'Kokytos',
+      },
+      'replaceText': {
+        'Aero IV': 'Giga Vent',
+        'Blizzard III': 'Méga Glace',
+        'Disgorge': 'Renvoi d\'âme',
+        'Duality of Death': 'Mort double',
+        'Dualspell': 'Double sort',
+        'Fire(?! )': 'Feu',
+        'Fire IV': 'Giga Feu',
+        'Front Combination': 'Coups de pied pivotants avant en série',
+        'Gluttony\'s Augur': 'Augure de gloutonnerie',
+        'Inside Roundhouse': 'Coup de pied pivotant intérieur',
+        'Outside Roundhouse': 'Coup de pied pivotant extérieur',
+        'Pile Pyre': 'Flammes empilées',
+        'Ravening': 'Dévoration d\'âme',
+        'Rear Combination': 'Coups de pied pivotants arrière en série',
+        'Soul Surge': 'Déferlante d\'âme',
+        'Thunder III': 'Méga Foudre',
+        'Thunder(?! )': 'Foudre',
+      },
+    },
+    {
+      'locale': 'ja',
+      'missingTranslations': true,
+      'replaceSync': {
+        'Kokytos': 'コキュートス',
+      },
+      'replaceText': {
+        'Aero IV': 'エアロジャ',
+        'Blizzard III': 'ブリザガ',
+        'Disgorge': 'ソウルリバース',
+        'Duality of Death': 'デストゥワイス',
+        'Dualspell': 'ダブルスペル',
+        'Fire(?! )': 'ファイア',
+        'Fire IV': 'ファイジャ',
+        'Front Combination': '前方連転脚',
+        'Gluttony\'s Augur': 'グラトニーズアーガー',
+        'Inside Roundhouse': '内転脚',
+        'Outside Roundhouse': '外転脚',
+        'Pile Pyre': 'パイリングフレイム',
+        'Ravening': '魂喰らい',
+        'Rear Combination': '後方連転脚',
+        'Soul Surge': 'ソウルサージ',
+        'Thunder III': 'サンダガ',
+        'Thunder(?! )': 'サンダー',
       },
     },
   ],


### PR DESCRIPTION
P9S will error with `AssertionError: ui/raidboss/data/06-ew/raid/p9s.ts:locale de:no translation for replaceSync ' 104:[^:]*:1($|:)': expected false to be true` if i remove the `'missingTranslations': true,` element
 
For P10S i am currently missing deobfuscated content for following skills:
```
'Daemonic Bonds'
'Pandaemoniac Turrets'
'Pandaemoniac Web'
'Steel Web'
```
Also for P10S shouldn't it be `Daemoniac Bonds` instead of `Daemonic Bonds`?