### PR TITLE
raidboss/p9s: fix ability ID of first auto

### DIFF
--- a/ui/raidboss/data/06-ew/raid/p9s.txt
+++ b/ui/raidboss/data/06-ew/raid/p9s.txt
@@ -32,7 +32,7 @@ hideall "--sync--"
 0.0 "--Reset--" sync / 21:........:4000000F:/ window 100000 jump 0
 
 0.0 "--sync--" sync / 104:[^:]*:1($|:)/ window 0,1
-7.2 "--sync--" sync / 14:[^:]*:Kokytos:814C:/ window 10,10
+7.2 "--sync--" sync / 14:[^:]*:Kokytos:814B:/ window 10,10
 12.2 "Gluttony's Augur" sync / 1[56]:[^:]*:Kokytos:814C:/
 19.6 "--middle--" sync / 1[56]:[^:]*:Kokytos:8144:/
 


### PR DESCRIPTION
I'm not 100% sure if this is right, but I think this was meant to be `814B` instead of `814C`, since the latter is `Gluttony's Augur`, and doesn't seem to make sense to have at 7.2 if we also do `-p 814C:12.2`.

Fixing this also seems to make `test_timeline.ts` sync better on my logs.