### PR TITLE
raidboss: Add additional P9S Limit Cut triggers

### DIFF
--- a/ui/raidboss/data/06-ew/raid/p9s.ts
+++ b/ui/raidboss/data/06-ew/raid/p9s.ts
@@ -379,16 +379,6 @@ const triggerSet: TriggerSet<Data> = {
       },
       preRun: (data, matches) => {
         const correctedMatch = getHeadmarkerId(data, matches);
-        const limitCutNumberMap: { [id: string]: number } = {
-          '004F': 1,
-          '0050': 2,
-          '0051': 3,
-          '0052': 4,
-          '0053': 5,
-          '0054': 6,
-          '0055': 7,
-          '0056': 8,
-        };
         data.limitCutNumber = limitCutNumberMap[correctedMatch];
       },
       durationSeconds: (data) => data.seenChimericSuccession ? 20 : 30,

--- a/ui/raidboss/data/06-ew/raid/p9s.ts
+++ b/ui/raidboss/data/06-ew/raid/p9s.ts
@@ -1,5 +1,6 @@
 import Outputs from '../../../../../resources/outputs';
 import { Responses } from '../../../../../resources/responses';
+import { Directions } from '../../../../../resources/util';
 import ZoneId from '../../../../../resources/zone_id';
 import { RaidbossData } from '../../../../../types/data';
 import { NetMatches } from '../../../../../types/net_matches';
@@ -13,6 +14,10 @@ export interface Data extends RaidbossData {
   limitCutNumber?: number;
   combination?: 'front' | 'rear';
   seenChimericSuccession?: boolean;
+  levinOrbs: {
+    [combatantId: string]: { [property: string]: number };
+  };
+  limitCutDash: number;
 }
 
 const dualspells = {
@@ -49,6 +54,25 @@ const limitCutMarkers: readonly string[] = [
   headmarkers.limitCut8,
 ] as const;
 
+const limitCutNumberMap: { [id: string]: number } = {
+  '004F': 1,
+  '0050': 2,
+  '0051': 3,
+  '0052': 4,
+  '0053': 5,
+  '0054': 6,
+  '0055': 7,
+  '0056': 8,
+} as const;
+
+const limitCutPlayerActive: number[][] = [
+  // These ordered nested arrays contain the limit cut headmarkers for [ dash order, tower soak order ]
+  [2, 6],
+  [4, 8],
+  [6, 2],
+  [8, 4],
+];
+
 const firstHeadmarker = parseInt(headmarkers.dualityOfDeath, 16);
 
 const getHeadmarkerId = (data: Data, matches: NetMatches['HeadMarker']) => {
@@ -62,10 +86,19 @@ const getHeadmarkerId = (data: Data, matches: NetMatches['HeadMarker']) => {
   return (parseInt(matches.id, 16) - data.decOffset).toString(16).toUpperCase().padStart(4, '0');
 };
 
+const centerX = 100;
+const centerY = 100;
+
 const triggerSet: TriggerSet<Data> = {
   id: 'AnabaseiosTheNinthCircleSavage',
   zoneId: ZoneId.AnabaseiosTheNinthCircleSavage,
   timelineFile: 'p9s.txt',
+  initData: () => {
+    return {
+      levinOrbs: {},
+      limitCutDash: 0,
+    };
+  },
   triggers: [
     {
       id: 'P9S Headmarker Tracker',
@@ -235,7 +268,108 @@ const triggerSet: TriggerSet<Data> = {
       },
     },
     {
-      id: 'P9S Limit Cut',
+      // Ball of Levin combatants are added ~0.3 seconds after Kokytos finishes using Levinstrike Summoning
+      // and ~1.7 before Kokytos begins using Scrambled Succession (which is when limit cut markers appear)
+      id: 'P9S Limit Cut Levin Orb Collect',
+      type: 'AddedCombatant',
+      // There are multiple invsible combatants that share this name, but the ones that receive HeadMarkers
+      // in limit cut (the ones we care about) are distinguishable because their level attribute is set to 90.
+      netRegex: { name: 'Ball of Levin', level: '5A' },
+      run: (data, matches) => {
+        // (0 = N, 1 = NE ... 7 = NW)
+        const orb8Dir = Directions.addedCombatantPosTo8Dir(matches, centerX, centerY);
+
+        // Orbs should always spawn on cardinals
+        const expectedOrb8Dirs = [0, 2, 4, 6];
+        if (!expectedOrb8Dirs.includes(orb8Dir)) {
+          console.error('Unexpected orb location');
+          return;
+        }
+        data.levinOrbs[matches.id] = { dir: orb8Dir };
+      },
+    },
+    {
+      id: 'P9S Limit Cut Levin Orb Order Collect',
+      type: 'HeadMarker',
+      netRegex: {},
+      condition: (data, matches) => {
+        return limitCutMarkers.includes(getHeadmarkerId(data, matches)) &&
+          Object.keys(data.levinOrbs).includes(matches.targetId);
+      },
+      run: (data, matches) => {
+        const correctedMatch = getHeadmarkerId(data, matches);
+        const orbLimitCutNumber = limitCutNumberMap[correctedMatch];
+
+        // Levin orbs should always receive a odd-numbered limit cut headmarker
+        const expectedOrbLimitCutNumbers = [1, 3, 5, 7];
+        if (
+          orbLimitCutNumber === undefined || !expectedOrbLimitCutNumbers.includes(orbLimitCutNumber)
+        ) {
+          console.error('Invalid limit cut headmarker on orb');
+          return;
+        }
+
+        const orbData = data.levinOrbs[matches.targetId] ?? {};
+        if (typeof orbData.dir === 'undefined') {
+          console.error('Limit cut headmarker on unknown orb');
+          return;
+        }
+        orbData.order = orbLimitCutNumber;
+        data.levinOrbs[matches.targetId] = orbData;
+      },
+    },
+    {
+      id: 'P9S Limit Cut Levin Orb Start and Rotation',
+      type: 'StartsUsing',
+      netRegex: { id: '817D', source: 'Kokytos', capture: false },
+      delaySeconds: 1.5, // allow for orb headmarker data to be collected, and delay so as not to collide with player dash order callout
+      infoText: (data, _matches, output) => {
+        let firstOrb8Dir;
+        let secondOrb8Dir;
+        // Orb order is limit cut headmarkers 1 > 3 > 5 > 7
+        for (const combatant in data.levinOrbs) {
+          switch (data.levinOrbs[combatant]?.order) {
+            case 1:
+              firstOrb8Dir = data.levinOrbs[combatant]?.dir;
+              break;
+            case 3:
+              secondOrb8Dir = data.levinOrbs[combatant]?.dir;
+              break;
+          }
+        }
+        if (firstOrb8Dir === undefined || secondOrb8Dir === undefined)
+          return;
+        const firstOrb8DirStr = Directions.outputFrom8DirNum(firstOrb8Dir);
+        if (firstOrb8DirStr === undefined)
+          return;
+        const firstOrbDir = output[firstOrb8DirStr]!();
+
+        const cardinalDirs = [0, 2, 4, 6];
+        const firstOrbIdx = cardinalDirs.indexOf(firstOrb8Dir);
+        const secondOrbIdx = cardinalDirs.indexOf(secondOrb8Dir);
+
+        if (firstOrbIdx === -1 || secondOrbIdx === -1)
+          return;
+
+        const rotationDir = (secondOrbIdx - firstOrbIdx + 4) % 4 === 1
+          ? output.clockwise!()
+          : output.counterclock!();
+
+        if (firstOrbDir !== undefined && rotationDir !== undefined)
+          return output.text!({ dir: firstOrbDir, rotation: rotationDir });
+        return;
+      },
+      outputStrings: {
+        text: {
+          en: 'First Orb ${dir} => ${rotation}',
+        },
+        clockwise: Outputs.clockwise,
+        counterclock: Outputs.counterclockwise,
+        ...Directions.outputStringsCardinalDir,
+      },
+    },
+    {
+      id: 'P9S Limit Cut Player Dash Order',
       type: 'HeadMarker',
       netRegex: {},
       condition: (data, matches) => {
@@ -270,6 +404,70 @@ const triggerSet: TriggerSet<Data> = {
           ko: '${num}',
         },
         unknown: Outputs.unknown,
+      },
+    },
+    {
+      // When Kokytos uses 'Scrambled Succession' (817D), there is ~4.0s. until the first tower appears (8181)
+      // and about ~5.0s until he dashes and uses Firemeld (8180) on the #2 limit cut player.  Because these abilities
+      // have very short (or no) cast times, we can base the first combo trigger on the use of Scrambled Succession, and
+      // base subsequent combo triggers on the prior use of Firemeld (which is ~4.6s before the next tower spawns)
+      id: 'P9S Limit Cut First Dash/Tower Combo',
+      type: 'Ability',
+      netRegex: { id: '817D', source: 'Kokytos', capture: false },
+      condition: (data) => data.limitCutDash === 0,
+      alertText: (data, _matches, output) => {
+        const activePlayers = limitCutPlayerActive[data.limitCutDash];
+        if (activePlayers === undefined)
+          return;
+        const [dashPlayer, soakPlayer] = activePlayers;
+        if (dashPlayer === undefined || soakPlayer === undefined)
+          return;
+        if (data.limitCutNumber === dashPlayer)
+          return output.dash!();
+        else if (data.limitCutNumber === soakPlayer)
+          return output.soak!();
+        return;
+      },
+      outputStrings: {
+        dash: {
+          en: 'Bait dash',
+        },
+        soak: {
+          en: 'Soak tower',
+        },
+      },
+    },
+    {
+      id: 'P9S Limit Cut Combo Tracker',
+      type: 'Ability',
+      netRegex: { id: '8180', source: 'Kokytos', capture: false },
+      run: (data) => data.limitCutDash++,
+    },
+    {
+      id: 'P9S Limit Cut Later Dash/Tower Combo',
+      type: 'Ability',
+      netRegex: { id: '8180', source: 'Kokytos', capture: false },
+      condition: (data) => data.limitCutDash > 0 && data.limitCutDash < 4,
+      alertText: (data, _matches, output) => {
+        const activePlayers = limitCutPlayerActive[data.limitCutDash];
+        if (activePlayers === undefined)
+          return;
+        const [dashPlayer, soakPlayer] = activePlayers;
+        if (dashPlayer === undefined || soakPlayer === undefined)
+          return;
+        if (data.limitCutNumber === dashPlayer)
+          return output.dash!();
+        else if (data.limitCutNumber === soakPlayer)
+          return output.soak!();
+        return;
+      },
+      outputStrings: {
+        dash: {
+          en: 'Bait dash',
+        },
+        soak: {
+          en: 'Soak tower',
+        },
       },
     },
     {

--- a/ui/raidboss/data/06-ew/raid/p9s.ts
+++ b/ui/raidboss/data/06-ew/raid/p9s.ts
@@ -270,6 +270,7 @@ const triggerSet: TriggerSet<Data> = {
     {
       // Ball of Levin combatants are added ~0.3 seconds after Kokytos finishes using Levinstrike Summoning
       // and ~1.7 before Kokytos begins using Scrambled Succession (which is when limit cut markers appear)
+      // These combatants are added in their actual positions, so no need to check OP for combatant data.
       id: 'P9S Limit Cut Levin Orb Collect',
       type: 'AddedCombatant',
       // There are multiple invsible combatants that share this name, but the ones that receive HeadMarkers


### PR DESCRIPTION
Additional P9S limit cut triggers that will:
 - Display an initial infoText alert with the starting orb (#1) cardinal position and rotation direction.
 - Display 'soak tower' or 'bait dash' alertText alerts when it is the player's turn to either soak a tower or bait Kokytos's dash.
 
 This is based on the 6->8->2->4 tower soak order, which I believe is universal to every strat so far (and essentially required by the mechanic, given the timing of the magic vuln debuffs).

Tested in raidemulator against a number of pulls during prog (and validated with VOD).

Closes #5494 .