### PR TITLE
util: Set lastInclude: true for ChangeMap

### DIFF
--- a/resources/netlog_defs.ts
+++ b/resources/netlog_defs.ts
@@ -838,6 +838,7 @@ const latestLogDefinitions = {
     },
     canAnonymize: true,
     firstOptionalField: undefined,
+    lastInclude: true,
   },
   SystemLogMessage: {
     type: '41',


### PR DESCRIPTION
This ensures that split logs will have the correct minimap image, even if the split log does not include the first pull after changing areas.