### PR TITLE
raidboss: Support for objects in trigger outputStrings

### DIFF
--- a/eslint/cactbot-output-strings.js
+++ b/eslint/cactbot-output-strings.js
@@ -40,6 +40,7 @@ const ruleModule = {
       notFoundProperty: 'no \'{{prop}}\' in \'{{outputParam}}\'',
       notFoundTemplate: '`output.{{prop}}(...)` doesn\'t have template \'{{template}}\'.',
       missingTemplateValue: 'template \'{{prop}}\' is missing in function call',
+      incorrectObjectKey: 'template \'{{prop}}\' specifies an object key with too many parts',
     },
   },
   create: function(context) {
@@ -237,15 +238,27 @@ const ruleModule = {
             const keysInParams = getAllKeys(args[0].properties);
             if (outputTemplate !== null && outputTemplate !== undefined) {
               for (const key of outputTemplate) {
+                const keyParts = key.split('.');
+                if (keyParts.length > 2) {
+                  context.report({
+                    node,
+                    messageId: 'incorrectObjectKey',
+                    data: {
+                      prop: key,
+                    },
+                  });
+                }
+                const trimmedKey = keyParts[0];
                 if (
-                  !t.isIdentifier(args[0]) && !keysInParams.includes(key) &&
-                  !keysInParams.includes(key.split('.')[0])
+                  !t.isIdentifier(args[0]) &&
+                  !keysInParams.includes(trimmedKey) &&
+                  !keysInParams.includes(trimmedKey.split('.')[0])
                 ) {
                   context.report({
                     node,
                     messageId: 'missingTemplateValue',
                     data: {
-                      prop: key,
+                      prop: trimmedKey,
                     },
                   });
                 }

--- a/eslint/cactbot-output-strings.js
+++ b/eslint/cactbot-output-strings.js
@@ -237,7 +237,10 @@ const ruleModule = {
             const keysInParams = getAllKeys(args[0].properties);
             if (outputTemplate !== null && outputTemplate !== undefined) {
               for (const key of outputTemplate) {
-                if (!t.isIdentifier(args[0]) && !keysInParams.includes(key)) {
+                if (
+                  !t.isIdentifier(args[0]) && !keysInParams.includes(key) &&
+                  !keysInParams.includes(key.split('.')[0])
+                ) {
                   context.report({
                     node,
                     messageId: 'missingTemplateValue',

--- a/eslint/cactbot-output-strings.js
+++ b/eslint/cactbot-output-strings.js
@@ -249,11 +249,7 @@ const ruleModule = {
                   });
                 }
                 const trimmedKey = keyParts[0];
-                if (
-                  !t.isIdentifier(args[0]) &&
-                  !keysInParams.includes(trimmedKey) &&
-                  !keysInParams.includes(trimmedKey.split('.')[0])
-                ) {
+                if (!t.isIdentifier(args[0]) && !keysInParams.includes(trimmedKey)) {
                   context.report({
                     node,
                     messageId: 'missingTemplateValue',

--- a/resources/party.ts
+++ b/resources/party.ts
@@ -198,7 +198,7 @@ export default class PartyTracker {
         return retVal;
       if (typeof retVal === 'number')
         return retVal.toString();
-      return shortName;
+      return ret.shortName;
     };
 
     return ret;

--- a/resources/party.ts
+++ b/resources/party.ts
@@ -16,7 +16,7 @@ const emptyRoleToPartyNames = () => {
 };
 
 export type BasePartyMemberParamObject = {
-  role: string;
+  role: Role;
   job: Job;
   id: string;
   name: string;
@@ -184,7 +184,7 @@ export default class PartyTracker {
       ret = {
         id: '???',
         job: 'NONE',
-        role: '???',
+        role: 'none',
         name: name,
         shortName: Util.shortName(name, playerNicks),
         toString: () => Util.shortName(name, playerNicks),

--- a/resources/party.ts
+++ b/resources/party.ts
@@ -178,18 +178,28 @@ export default class PartyTracker {
     playerNicks: { [name: string]: string },
   ): PartyMemberParamObject | undefined {
     const partyMember = this.details.find((member) => member.name === name);
-    if (!partyMember)
-      return;
-
-    const jobName = Util.jobEnumToJob(partyMember.job);
-    const role = Util.jobToRole(jobName);
-    const ret: PartyMemberParamObject = {
-      id: partyMember.id,
-      job: jobName,
-      role: role,
-      name: name,
-      shortName: Util.shortName(name, playerNicks),
-    };
+    let ret: PartyMemberParamObject;
+    if (!partyMember) {
+      // If we can't find this party member for some reason, use some sort of default
+      ret = {
+        id: '???',
+        job: 'NONE',
+        role: '???',
+        name: name,
+        shortName: Util.shortName(name, playerNicks),
+        toString: () => Util.shortName(name, playerNicks),
+      };
+    } else {
+      const jobName = Util.jobEnumToJob(partyMember.job);
+      const role = Util.jobToRole(jobName);
+      ret = {
+        id: partyMember.id,
+        job: jobName,
+        role: role,
+        name: name,
+        shortName: Util.shortName(name, playerNicks),
+      };
+    }
 
     // Need to assign this afterwards so it can reference `ret`
     ret.toString = () => {

--- a/resources/party.ts
+++ b/resources/party.ts
@@ -198,7 +198,7 @@ export default class PartyTracker {
         return retVal;
       if (typeof retVal === 'number')
         return retVal.toString();
-      return name;
+      return shortName;
     };
 
     return ret;

--- a/resources/util.ts
+++ b/resources/util.ts
@@ -422,6 +422,22 @@ const Util = {
     clearCombatantsOverride = clearFunc;
   },
   gameLogCodes: gameLogCodes,
+  shortName: (
+    name: string | undefined,
+    playerNicks: { [name: string]: string },
+  ): string => {
+    // TODO: make this unique among the party in case of first name collisions.
+    // TODO: probably this should be a general cactbot utility.
+    if (!name)
+      return '???';
+
+    const nick = playerNicks[name];
+    if (nick)
+      return nick;
+
+    const idx = name.indexOf(' ');
+    return idx < 0 ? name : name.slice(0, idx);
+  },
 } as const;
 
 export default Util;

--- a/resources/util.ts
+++ b/resources/util.ts
@@ -426,8 +426,6 @@ const Util = {
     name: string | undefined,
     playerNicks: { [name: string]: string },
   ): string => {
-    // TODO: make this unique among the party in case of first name collisions.
-    // TODO: probably this should be a general cactbot utility.
     if (!name)
       return '???';
 

--- a/test/helper/test_trigger.ts
+++ b/test/helper/test_trigger.ts
@@ -643,7 +643,10 @@ const testTriggerFile = (file: string, info: TriggerSetInfo) => {
 
           for (const key of keys) {
             for (const param of outputStringsParams[key] ?? []) {
-              if (!Regexes.parse(`\\b${param}\\s*:`).exec(funcStr)) {
+              if (
+                (!Regexes.parse(`\\b${param}\\s*:`).exec(funcStr)) &&
+                (!Regexes.parse(`\\b${param.split('.')[0] ?? ''}\\s*:`).exec(funcStr))
+              ) {
                 assert.fail(
                   `'${id}' does not define param '${param}' for outputStrings entry '${key}'`,
                 );

--- a/types/data.d.ts
+++ b/types/data.d.ts
@@ -1,5 +1,5 @@
 import { Lang } from '../resources/languages';
-import PartyTracker from '../resources/party';
+import PartyTracker, { PartyMemberParamObject } from '../resources/party';
 import { ConfigValue } from '../resources/user_config';
 
 import { SystemInfo } from './event';
@@ -42,6 +42,7 @@ export interface RaidbossData {
   CanCleanse: () => boolean;
   CanFeint: () => boolean;
   CanAddle: () => boolean;
+  partyMemberParam: (name: string) => PartyMemberParamObject | undefined;
 }
 
 export interface OopsyData {

--- a/types/trigger.d.ts
+++ b/types/trigger.d.ts
@@ -40,7 +40,7 @@ export type OutputStrings = { [outputKey: string]: LocaleText | string };
 export type Output = {
   responseOutputStrings: OutputStrings;
 } & {
-  [key: string]: (params?: { [param: string]: string | number | undefined }) => string;
+  [key: string]: (params?: { [param: string]: string | number | object | undefined }) => string;
 };
 
 // The output of any non-response raidboss trigger function.

--- a/types/trigger.d.ts
+++ b/types/trigger.d.ts
@@ -35,12 +35,21 @@ export type ZoneIdType = number | null;
 
 export type OutputStrings = { [outputKey: string]: LocaleText | string };
 
+export type OutputStringsParamObject = {
+  [key: string]: string | number | (() => string);
+  toString: () => string;
+};
+
+export type OuptutStringsParams = {
+  [param: string]: string | number | OutputStringsParamObject | undefined;
+};
+
 // TODO: is it awkward to have Outputs the static class and Output the unrelated type?
 // This type corresponds to TriggerOutputProxy.
 export type Output = {
   responseOutputStrings: OutputStrings;
 } & {
-  [key: string]: (params?: { [param: string]: string | number | object | undefined }) => string;
+  [key: string]: (params?: OuptutStringsParams) => string;
 };
 
 // The output of any non-response raidboss trigger function.

--- a/types/trigger.d.ts
+++ b/types/trigger.d.ts
@@ -36,11 +36,14 @@ export type ZoneIdType = number | null;
 export type OutputStrings = { [outputKey: string]: LocaleText | string };
 
 export type OutputStringsParamObject = {
+  // The indexer type requires that `() => string` be a possible value, or else `toString` can't be
+  // defined. Effectively, typescript sees it as `someParamObject['toString']()`, not as a direct
+  // function call of `someParamObject.toString()`.
   [key: string]: string | number | (() => string);
   toString: () => string;
 };
 
-export type OuptutStringsParams = {
+export type OutputStringsParams = {
   [param: string]: string | number | OutputStringsParamObject | undefined;
 };
 
@@ -49,7 +52,7 @@ export type OuptutStringsParams = {
 export type Output = {
   responseOutputStrings: OutputStrings;
 } & {
-  [key: string]: (params?: OuptutStringsParams) => string;
+  [key: string]: (params?: OutputStringsParams) => string;
 };
 
 // The output of any non-response raidboss trigger function.

--- a/ui/oopsyraidsy/damage_tracker.ts
+++ b/ui/oopsyraidsy/damage_tracker.ts
@@ -37,7 +37,6 @@ import {
   kShiftFlagValues,
   playerDamageFields,
   playerTargetFields,
-  ShortNamify,
   Translate,
   UnscrambleDamage,
 } from './oopsy_common';
@@ -166,7 +165,7 @@ export class DamageTracker {
           return true;
         return false;
       },
-      ShortName: (name?: string) => ShortNamify(name, this.options.PlayerNicks),
+      ShortName: (name?: string) => Util.shortName(name, this.options.PlayerNicks),
       IsPlayerId: IsPlayerId,
       DamageFromMatches: (matches: NetMatches['Ability']) => UnscrambleDamage(matches?.damage),
       options: this.options,

--- a/ui/oopsyraidsy/oopsy_common.ts
+++ b/ui/oopsyraidsy/oopsy_common.ts
@@ -89,23 +89,6 @@ Examples:
 
 /* eslint-enable */
 
-export const ShortNamify = (
-  name: string | undefined,
-  playerNicks: { [name: string]: string },
-): string => {
-  // TODO: make this unique among the party in case of first name collisions.
-  // TODO: probably this should be a general cactbot utility.
-  if (!name)
-    return '???';
-
-  const nick = playerNicks[name];
-  if (nick)
-    return nick;
-
-  const idx = name.indexOf(' ');
-  return idx < 0 ? name : name.slice(0, idx);
-};
-
 export const Translate = (lang: Lang, obj?: LocaleText | string): string | undefined => {
   if (typeof obj !== 'object')
     return obj;

--- a/ui/oopsyraidsy/oopsy_live_list.ts
+++ b/ui/oopsyraidsy/oopsy_live_list.ts
@@ -1,10 +1,11 @@
 import { UnreachableCode } from '../../resources/not_reached';
 import { callOverlayHandler } from '../../resources/overlay_plugin_api';
+import Util from '../../resources/util';
 import { OopsyMistake } from '../../types/oopsy';
 
 import { DeathReport } from './death_report';
 import { MistakeObserver, ViewEvent } from './mistake_observer';
-import { GetFormattedTime, ShortNamify, Translate } from './oopsy_common';
+import { GetFormattedTime, Translate } from './oopsy_common';
 import { OopsyOptions } from './oopsy_options';
 
 const kCopiedMessage = {
@@ -272,7 +273,7 @@ export class OopsyLiveList implements MistakeObserver {
 
     const iconClass = m.type;
     const blame = m.name ?? m.blame;
-    const blameText = blame ? ShortNamify(blame, this.options.PlayerNicks) + ': ' : '';
+    const blameText = blame ? Util.shortName(blame, this.options.PlayerNicks) + ': ' : '';
     const translatedText = Translate(this.options.DisplayLanguage, m.text);
     if (!translatedText)
       return;

--- a/ui/oopsyraidsy/oopsy_summary_list.ts
+++ b/ui/oopsyraidsy/oopsy_summary_list.ts
@@ -1,8 +1,9 @@
+import Util from '../../resources/util';
 import { OopsyMistake } from '../../types/oopsy';
 
 import { DeathReport } from './death_report';
 import { MistakeObserver, ViewEvent } from './mistake_observer';
-import { GetFormattedTime, ShortNamify, Translate } from './oopsy_common';
+import { GetFormattedTime, Translate } from './oopsy_common';
 import { OopsyOptions } from './oopsy_options';
 
 type TableEntry = {
@@ -84,7 +85,7 @@ export class OopsySummaryTable implements MistakeObserver {
     const longName = m.name ?? m.blame;
     if (!longName)
       return;
-    const name = ShortNamify(longName, this.options.PlayerNicks);
+    const name = Util.shortName(longName, this.options.PlayerNicks);
 
     // Don't create a player row if the summary doesn't care about this type of mistake.
     if (!this.types.includes(m.type))
@@ -216,7 +217,7 @@ export class OopsySummaryList implements MistakeObserver {
   OnMistakeObj(timestamp: number, m: OopsyMistake): void {
     const iconClass = m.type;
     const blame = m.name ?? m.blame;
-    const blameText = blame ? `${ShortNamify(blame, this.options.PlayerNicks)}: ` : '';
+    const blameText = blame ? `${Util.shortName(blame, this.options.PlayerNicks)}: ` : '';
     const text = Translate(this.options.DisplayLanguage, m.text);
     if (!text)
       return;

--- a/ui/oopsyraidsy/player_state_tracker.ts
+++ b/ui/oopsyraidsy/player_state_tracker.ts
@@ -1,6 +1,7 @@
 import logDefinitions from '../../resources/netlog_defs';
 import { UnreachableCode } from '../../resources/not_reached';
 import PartyTracker from '../../resources/party';
+import Util from '../../resources/util';
 import { Party } from '../../types/event';
 import {
   DeathReportData,
@@ -23,13 +24,7 @@ import {
   RequestTimestampCallback,
 } from './missed_buff_collector';
 import { MistakeCollector } from './mistake_collector';
-import {
-  GetShareMistakeText,
-  GetSoloMistakeText,
-  IsPlayerId,
-  ShortNamify,
-  Translate,
-} from './oopsy_common';
+import { GetShareMistakeText, GetSoloMistakeText, IsPlayerId, Translate } from './oopsy_common';
 import { OopsyOptions } from './oopsy_options';
 
 const emptyId = 'E0000000';
@@ -574,7 +569,7 @@ export class PlayerStateTracker {
     // TODO: oopsy could really use mouseover popups for details.
     if (missedNames.length < 4) {
       const nameList = missedNames.map((name) => {
-        return ShortNamify(name, this.options.PlayerNicks);
+        return Util.shortName(name, this.options.PlayerNicks);
       }).join(', ');
 
       // As a TrackedLineEvent has been pushed for each person missed already,

--- a/ui/raidboss/data/00-misc/test.ts
+++ b/ui/raidboss/data/00-misc/test.ts
@@ -365,7 +365,11 @@ const triggerSet: TriggerSet<Data> = {
     {
       id: 'Test OutputStrings',
       type: 'GameLog',
-      netRegex: { line: 'cactbot test outputStrings', code: Util.gameLogCodes.echo, capture: false },
+      netRegex: {
+        line: 'cactbot test outputStrings',
+        code: Util.gameLogCodes.echo,
+        capture: false,
+      },
       infoText: (data, _matches, output) => {
         // TODO: This doesn't work unless you're in a party, because party tracker is empty.
         // OverlayPlugin should probably always return the current player as being in the party
@@ -464,6 +468,7 @@ const triggerSet: TriggerSet<Data> = {
     },
     {
       locale: 'ja',
+      missingTranslations: true,
       replaceSync: {
         'You bid farewell to the striking dummy': '.*は木人に別れの挨拶をした',
         'You bow courteously to the striking dummy': '.*は木人にお辞儀した',
@@ -539,6 +544,7 @@ const triggerSet: TriggerSet<Data> = {
     },
     {
       locale: 'ko',
+      missingTranslations: true,
       replaceSync: {
         'You bid farewell to the striking dummy': '.*나무인형에게 작별 인사를 합니다',
         'You bow courteously to the striking dummy': '.*나무인형에게 공손하게 인사합니다',

--- a/ui/raidboss/data/00-misc/test.ts
+++ b/ui/raidboss/data/00-misc/test.ts
@@ -367,11 +367,10 @@ const triggerSet: TriggerSet<Data> = {
       type: 'GameLog',
       netRegex: NetRegexes.echo({ line: 'cactbot test outputStrings', capture: false }),
       infoText: (data, _matches, output) => {
-        const obj = {
-          ...data,
-          toString: () => data.me,
-        };
-        return output.text!({ customData: obj });
+        // TODO: This doesn't work unless you're in a party, because party tracker is empty.
+        // OverlayPlugin should probably always return the current player as being in the party
+        // regardless of the rest of the party composition.
+        return output.text!({ customData: data.partyMemberParam(data.me) });
       },
       outputStrings: {
         text: {

--- a/ui/raidboss/data/00-misc/test.ts
+++ b/ui/raidboss/data/00-misc/test.ts
@@ -365,7 +365,7 @@ const triggerSet: TriggerSet<Data> = {
     {
       id: 'Test OutputStrings',
       type: 'GameLog',
-      netRegex: NetRegexes.echo({ line: 'cactbot test outputStrings', capture: false }),
+      netRegex: { line: 'cactbot test outputStrings', code: Util.gameLogCodes.echo, capture: false },
       infoText: (data, _matches, output) => {
         // TODO: This doesn't work unless you're in a party, because party tracker is empty.
         // OverlayPlugin should probably always return the current player as being in the party
@@ -421,6 +421,7 @@ const triggerSet: TriggerSet<Data> = {
     },
     {
       locale: 'fr',
+      missingTranslations: true,
       replaceSync: {
         'cactbot lang': 'cactbot langue',
         'cactbot test response': 'cactbot test de réponse',

--- a/ui/raidboss/data/00-misc/test.ts
+++ b/ui/raidboss/data/00-misc/test.ts
@@ -362,10 +362,28 @@ const triggerSet: TriggerSet<Data> = {
         },
       },
     },
+    {
+      id: 'Test OutputStrings',
+      type: 'GameLog',
+      netRegex: NetRegexes.echo({ line: 'cactbot test outputStrings', capture: false }),
+      infoText: (data, _matches, output) => {
+        const obj = {
+          ...data,
+          toString: () => data.me,
+        };
+        return output.text!({ customData: obj });
+      },
+      outputStrings: {
+        text: {
+          en: 'data = ${customData}, data.job = ${customData.job}',
+        },
+      },
+    },
   ],
   timelineReplace: [
     {
       locale: 'de',
+      missingTranslations: true,
       replaceSync: {
         'You bid farewell to the striking dummy': 'Du winkst der Trainingspuppe zum Abschied zu',
         'You bow courteously to the striking dummy':
@@ -483,6 +501,7 @@ const triggerSet: TriggerSet<Data> = {
     },
     {
       locale: 'cn',
+      missingTranslations: true,
       replaceSync: {
         'You bid farewell to the striking dummy': '.*向木人告别',
         'You bow courteously to the striking dummy': '.*恭敬地对木人行礼',

--- a/ui/raidboss/popup-text.ts
+++ b/ui/raidboss/popup-text.ts
@@ -388,7 +388,7 @@ class TriggerOutputProxy {
         if (!(key in params) && key.includes('.')) {
           const parts = key.split('.');
           // Only a warning here (for user triggers), but mocha tests will error out for this case
-          // If the user specifices extra parts, just ignore them
+          // If the user specifies extra parts, just ignore them
           if (parts.length > 2)
             console.warn(`Trigger ${id} has extra path parts for object parameter ${key}.`);
           key = parts[0] ?? '';

--- a/ui/raidboss/raidboss_config.ts
+++ b/ui/raidboss/raidboss_config.ts
@@ -1259,6 +1259,7 @@ class RaidbossConfigurator {
       CanCleanse: () => false,
       CanFeint: () => false,
       CanAddle: () => false,
+      partyMemberParam: (_name) => undefined,
       parserLang: this.base.lang,
       displayLang: this.base.lang,
     };
@@ -2132,6 +2133,22 @@ const templateOptions: OptionsTemplate = {
       },
       type: 'checkbox',
       default: true,
+    },
+    {
+      id: 'DefaultPlayerLabel',
+      name: {
+        en: 'Default Player Label',
+      },
+      type: 'select',
+      options: {
+        en: {
+          'Short Name (Tini)': 'shortName',
+          'Role (Tank)': 'role',
+          'Job (WAR)': 'job',
+          'Full Name (Tini Poutini)': 'name',
+        },
+      },
+      default: 'shortName',
     },
     {
       id: 'ShowTimerBarsAtSeconds',

--- a/ui/raidboss/raidboss_options.ts
+++ b/ui/raidboss/raidboss_options.ts
@@ -1,4 +1,5 @@
 import { Lang } from '../../resources/languages';
+import { PartyMemberParamObjectKeys } from '../../resources/party';
 import UserConfig, { ConfigValue } from '../../resources/user_config';
 import { BaseOptions, RaidbossData } from '../../types/data';
 import { Matches } from '../../types/net_matches';
@@ -97,6 +98,7 @@ const defaultRaidbossConfigOptions = {
   TimelineLanguage: undefined as (Lang | undefined),
   TimelineEnabled: true,
   AlertsEnabled: true,
+  DefaultPlayerLabel: undefined as (PartyMemberParamObjectKeys | undefined),
   ShowTimerBarsAtSeconds: 30,
   KeepExpiredTimerBarsForSeconds: 0.7,
   BarExpiresSoonSeconds: 6,

--- a/ui/raidboss/raidboss_options.ts
+++ b/ui/raidboss/raidboss_options.ts
@@ -98,7 +98,7 @@ const defaultRaidbossConfigOptions = {
   TimelineLanguage: undefined as (Lang | undefined),
   TimelineEnabled: true,
   AlertsEnabled: true,
-  DefaultPlayerLabel: undefined as (PartyMemberParamObjectKeys | undefined),
+  DefaultPlayerLabel: 'shortName' as PartyMemberParamObjectKeys,
   ShowTimerBarsAtSeconds: 30,
   KeepExpiredTimerBarsForSeconds: 0.7,
   BarExpiresSoonSeconds: 6,


### PR DESCRIPTION
This is a preliminary PR to eventually allow more customization of outputStrings outputs by users. Eventually I'd like to see player names replaced with something like a player object with a default toString that returns player name, which could maybe be a helper on the `PartyTracker` object.

I have simulated that extremely basically with the `data` object test trigger added in `test.ts`. Users should be able to customize the `outputStrings` entry for `text` to print e.g. `${data.role}`. I'm looking for feedback/thoughts on if this approach makes sense, or if this idea should be approached in a different way, before I fully flesh this out.

I'm not super happy with the logic in `popup-text.ts`, feels like it could have benefited with a helper func or something rather than switch/casing over type in two separate spots like that, or maybe a recursive function?