### PR TITLE
Fixed french mistranslation for p11s

### DIFF
--- a/06-ew/raid/p11s.js
+++ b/06-ew/raid/p11s.js
@@ -74,7 +74,7 @@ Options.Triggers.push({
         text: {
           en: 'Party Out => In + Partners',
           de: 'Party Raus => Rein + Partner',
-          fr: 'Extérieur => Intérieur + package sur les heals',
+          fr: 'Extérieur => Intérieur + Partenaires',
           cn: '场外 => 场中 + 两人分摊',
           ko: '본대 밖으로 => 안으로 + 파트너',
         },
@@ -106,7 +106,7 @@ Options.Triggers.push({
         text: {
           en: 'Sides => In + Partners',
           de: 'Seiten => Rein + Partner',
-          fr: 'Côtés => Intérieur + Package sur les heals',
+          fr: 'Côtés => Intérieur + Partenaires',
           cn: '两侧 => 两人分摊 + 场内',
           ko: '양 옆 => 안으로 + 파트너',
         },


### PR DESCRIPTION
Fixed french mistranslation for dark mechanics, was calling for healer stacks instead of partners.