### PR TITLE
raidboss: add p10s Jade Passage trigger

### DIFF
--- a/ui/raidboss/data/06-ew/raid/p10s.ts
+++ b/ui/raidboss/data/06-ew/raid/p10s.ts
@@ -567,6 +567,19 @@ const triggerSet: TriggerSet<Data> = {
         west: Outputs.getLeftAndWest,
       },
     },
+    {
+      id: 'P10S Jade Passage',
+      type: 'StartsUsing',
+      netRegex: { id: '828C', capture: false },
+      suppressSeconds: 5,
+      infoText: (_data, _matches, output) => output.text!(),
+      outputStrings: {
+        text: {
+          en: 'Avoid Lasers',
+          cn: '注意躲避激光',
+        },
+      },
+    },
   ],
   timelineReplace: [
     {


### PR DESCRIPTION
add basic p10s Jade Passage trigger

It would be nice if the position of the laser could be displayed like 'stand on lines' or 'stand in box' refer to the pattern of the floor. but I can't find a way to do it.