### PR TITLE
raidboss: p10s Jade Passage trigger box/line

### DIFF
--- a/ui/raidboss/data/06-ew/raid/p10s.ts
+++ b/ui/raidboss/data/06-ew/raid/p10s.ts
@@ -581,31 +581,14 @@ const triggerSet: TriggerSet<Data> = {
       suppressSeconds: 5,
       infoText: (_data, matches, output) => {
         const y = parseInt(matches.y);
-        const safeSpot: { [y: number]: string } = {
-          86: output.boxes!(),
-          88: output.lines!(),
-          90: output.boxes!(),
-          92: output.lines!(),
-          94: output.boxes!(),
-          96: output.lines!(),
-          98: output.boxes!(),
-          100: output.lines!(),
-          102: output.boxes!(),
-          104: output.lines!(),
-          106: output.boxes!(),
-          108: output.lines!(),
-          110: output.boxes!(),
-          112: output.lines!(),
-          114: output.boxes!(),
-        };
-        return safeSpot[y];
+        return (Math.floor(y / 2) % 2 === 1) ? output.boxes!() : output.lines!();
       },
       outputStrings: {
         lines: {
-          en: 'Lines',
+          en: 'On Lines (Avoid Lasers)',
         },
         boxes: {
-          en: 'Boxes',
+          en: 'Inside Boxes (Avoid Lasers)',
         },
       },
     },

--- a/ui/raidboss/data/06-ew/raid/p10s.ts
+++ b/ui/raidboss/data/06-ew/raid/p10s.ts
@@ -575,14 +575,37 @@ const triggerSet: TriggerSet<Data> = {
     },
     {
       id: 'P10S Jade Passage',
-      type: 'StartsUsing',
-      netRegex: { id: '828C', capture: false },
+      // Track addition of Arcane Sphere combatants
+      type: 'AddedCombatant',
+      netRegex: { npcNameId: '12356' },
       suppressSeconds: 5,
-      infoText: (_data, _matches, output) => output.text!(),
+      infoText: (_data, matches, output) => {
+        const y = parseInt(matches.y);
+        const safeSpot: { [y: number]: string } = {
+          86: output.boxes!(),
+          88: output.lines!(),
+          90: output.boxes!(),
+          92: output.lines!(),
+          94: output.boxes!(),
+          96: output.lines!(),
+          98: output.boxes!(),
+          100: output.lines!(),
+          102: output.boxes!(),
+          104: output.lines!(),
+          106: output.boxes!(),
+          108: output.lines!(),
+          110: output.boxes!(),
+          112: output.lines!(),
+          114: output.boxes!(),
+        };
+        return safeSpot[y];
+      },
       outputStrings: {
-        text: {
-          en: 'Avoid Lasers',
-          cn: '注意躲避激光',
+        lines: {
+          en: 'Lines',
+        },
+        boxes: {
+          en: 'Boxes',
         },
       },
     },


### PR DESCRIPTION
This uses the AddCombatant log lines instead of cast since it comes sooner.


Just based on the y values and not having tested in game, largest y value I assume is the lines, so using a map to quickly determine from one of the Arcane Spheres where it is located.

Boxes:
88.00
92.00
96.00
100.00
104.00
108.00
112.00

Lines:
86.00
90.00
94.00
98.00
102.00
106.00
110.00
114.00

This is also assuming the data in the log line is accurate, otherwise OverlayPlugin would be needed. It seems accurate to me and they get spawned in and removed between parts so no need to check for updated location.