### PR TITLE
raidboss: fix inconsistent "soon" timeline colors

### DIFF
--- a/ui/raidboss/timeline.ts
+++ b/ui/raidboss/timeline.ts
@@ -58,10 +58,6 @@ export class TimelineUI {
     /* noop */
   }
 
-  public OnTimerExpiresSoon(_id: number): void {
-    /* noop */
-  }
-
   public OnRemoveTimer(_e: Event, _expired: boolean, _force = false): void {
     /* noop */
   }


### PR DESCRIPTION
Largely the issue here is that each timeline bar has an id, and the timeout to recolor a bar to be "soon" was looking by id.  If the timeline ever got adjusted due to syncs or jumps, then the soon timer would end up firing for bars at different times.

To fix this, instead have the soon timer refer to the html element directly rather than an indirect id.
Track and clear this (to avoid outstanding useless timeouts) if the bar is ever removed.

While we're here, also refactor the expiring timeout into the same structure.

Fixes #627.