### PR TITLE
raidboss: add `forcejump` timeline command

### DIFF
--- a/docs/TimelineGuide.md
+++ b/docs/TimelineGuide.md
@@ -123,6 +123,9 @@ it will behave exactly like a normal `jump`.
 If the time passes this line,
 then it will jump as if it had synced exactly on time.
 This is not handled specially in `test_timeline`, which expects the sync to be correct.
+If the `window` extends past the `forcejump` time,
+this "overhang window" will still be respected even after force jumping
+until the next sync or jump occurs.
 
 ### Commands
 
@@ -274,7 +277,7 @@ Here's an example of using cactbot's tools to make a timeline file for Cape West
 This is pretty straightforward and only requires one person to test, so is a good first example.
 
 Note that the Cape Westwind trial was removed in Patch 6.1,
-and the timeline has since been removed from cactbot.  
+and the timeline has since been removed from cactbot.
 However, you can view the original timeline [here](https://github.com/quisquous/cactbot/blob/aa38bdf8f2551a504e1d3f595cd266d3baa193f2/ui/raidboss/data/02-arr/trial/cape_westwind.txt).
 
 ### Run the fight a few times
@@ -913,7 +916,7 @@ the timeline should start when combat begins,
 and should reset on a wipe or when the player is out of combat.
 
 However, in dungeons for example, the player is often in combat
-with mobs before the timeline should begin for the first boss encounter.  
+with mobs before the timeline should begin for the first boss encounter.
 For that matter, there are also several boss encounters in each dungeon.
 In those situations, we need discrete timelines for each boss encounter,
 and each boss's timeline should start only once that boss encounter begins.

--- a/docs/TimelineGuide.md
+++ b/docs/TimelineGuide.md
@@ -76,6 +76,8 @@ Every timeline entry begins with the ability time and the ability name.
 
 `Number "String" sync /Regex/ (window Number,Number) (jump Number) (duration Number)`
 
+`Number "String" sync /Regex/ (window Number,Number) (forcejump Number) (duration Number)`
+
 The parentheses here indicate optionality and are not literal parentheses.
 
 Number can be an integer, e.g. `34`, or a float, e.g. `84.381`.
@@ -109,6 +111,18 @@ If you jump to time 0, the timeline will stop playback.
 This is usually used for phase pushes and loops.
 There does not need to be a timeline entry for the time you jump to,
 although it is very common to have one.
+
+`forcejump Number` tells the timeline playback that there will always be a jump here
+regardless of whether the sync is encountered.
+This is intended for loops that will always be taken in an encounter.
+When this is used, no "lookahead" loop unrolling is needed,
+and the timeline will use the `forcejump` destination to list events in the future,
+because it knows that it will always jump there.
+If this line syncs prior to time passing it by,
+it will behave exactly like a normal `jump`.
+If the time passes this line,
+then it will jump as if it had synced exactly on time.
+This is not handled specially in `test_timeline`, which expects the sync to be correct.
 
 ### Commands
 

--- a/ui/raidboss/data/00-misc/test.ts
+++ b/ui/raidboss/data/00-misc/test.ts
@@ -363,6 +363,7 @@ const triggerSet: TriggerSet<Data> = {
   timelineReplace: [
     {
       locale: 'de',
+      missingTranslations: true,
       replaceSync: {
         'You bid farewell to the striking dummy': 'Du winkst der Trainingspuppe zum Abschied zu',
         'You bow courteously to the striking dummy':
@@ -454,6 +455,7 @@ const triggerSet: TriggerSet<Data> = {
     },
     {
       locale: 'cn',
+      missingTranslations: true,
       replaceSync: {
         'You bid farewell to the striking dummy': '.*向木人告别',
         'You bow courteously to the striking dummy': '.*恭敬地对木人行礼',

--- a/ui/raidboss/data/00-misc/test.txt
+++ b/ui/raidboss/data/00-misc/test.txt
@@ -28,3 +28,15 @@ hideall "--sync--"
 25 "Super Tankbuster" sync /:test sync:/ window 30,30
 30 "Dummy Stands Still"
 40 "Death"
+
+50 "--sync--" sync /:test sync2:/ window 100,1 forcejump 100
+
+# Loop test!
+102 "Two"
+103 "Three"
+104 "Four"
+106 "Six"
+110 "Ten" #duration 100
+115 "Fifteen"
+118 "Force Jump Three" sync /:test sync3:/ window 10,10 forcejump 103
+120 "Invisible" sync /:test sync4:/ forcejump 1000

--- a/ui/raidboss/timeline.ts
+++ b/ui/raidboss/timeline.ts
@@ -1,4 +1,5 @@
 import { commonNetRegex } from '../../resources/netregexes';
+import { UnreachableCode } from '../../resources/not_reached';
 import { LocaleRegex } from '../../resources/translations';
 import { LogEvent } from '../../types/event';
 import { CactbotBaseRegExp } from '../../types/net_trigger';
@@ -14,6 +15,34 @@ import {
   TimelineReplacement,
   TimelineStyle,
 } from './timeline_parser';
+
+// Hi, sorry about this whole class.  This is all pretty old code and honestly could
+// probably all be entirely rewritten at this point if anybody has the time or brain.
+//
+// This TimelineController class is involved in playing back the timeline efficiently.
+// As it says on the tin, it's the controller here and HtmlTimelineUI is the view.
+// The UI does very little and relies on TimelineController to manually add and remove
+// timer bars as necessary.  It does some animations when things are removed, but
+// only when it's been told to remove them.
+//
+// When any time is resynced even slightly, then all of the bars are removed and readded
+// with new times.  (This could probably be better to just update them in place!).
+// Similarly, any jump (even with lookahead) can't do any UI animations or anything
+// because the lookahead bars don't know anything about the new bars at the jump location.
+// This is kind of jarring but hopefully most people don't notice it.
+//
+// Things are also very precarious in terms of how this class walks through things.
+// If this.activeEvents is out of sync or unsorted, then it will clog up and new bars
+// will not be able to be added.  Durations are extremely awkward as they are manually
+// added once their original event has passed.  This means that if you ever jump
+// to a new location with an ongoing duration from the past, it will not appear.
+// It also has some issues if the duration extends past the jump (see comments inline).
+// Also because of this, we have to look through every event all the time to figure
+// out if there's a duration to care about (and probably we could figure this out
+// ahead of time like we do with placing text events + beforeSeconds at the correct
+// place in the timeline).
+//
+// There's also no testing, sorry.
 
 const kBig = 1000000000; // Something bigger than any fight length in seconds.
 
@@ -91,6 +120,14 @@ export class TimelineUI {
   }
 }
 
+const initialNextEventState = {
+  index: 0,
+  minFightNow: 0,
+  timeOffset: 0,
+  sortKeyOffset: 0,
+  jumpCount: 0,
+} as const;
+
 export class Timeline {
   private replacements: TimelineReplacement[];
 
@@ -104,13 +141,21 @@ export class Timeline {
   public texts: Text[];
   public syncStarts: Sync[];
   public syncEnds: Sync[];
+  public forceJumps: Sync[];
 
   public timebase = 0;
 
-  private nextEvent = 0;
+  private nextEventState: {
+    index: number;
+    minFightNow: number;
+    timeOffset: number;
+    sortKeyOffset: number;
+    jumpCount: number;
+  } = { ...initialNextEventState };
   private nextText = 0;
   private nextSyncStart = 0;
   private nextSyncEnd = 0;
+  private nextForceJump = 0;
 
   private updateTimer = 0;
 
@@ -143,6 +188,8 @@ export class Timeline {
     this.syncStarts = [];
     // Sorted by sync.end time.
     this.syncEnds = [];
+    // Sorted by event occurrence time.
+    this.forceJumps = [];
 
     this.LoadFile(text, triggers, styles);
     this.Stop();
@@ -162,15 +209,17 @@ export class Timeline {
     this.texts = parsed.texts;
     this.syncStarts = parsed.syncStarts;
     this.syncEnds = parsed.syncEnds;
+    this.forceJumps = parsed.forceJumps;
   }
 
   public Stop(): void {
     this.timebase = 0;
 
-    this.nextEvent = 0;
+    this.nextEventState = { ...initialNextEventState };
     this.nextText = 0;
     this.nextSyncStart = 0;
     this.nextSyncEnd = 0;
+    this.nextForceJump = 0;
 
     const fightNow = 0;
     this._AdvanceTimeTo(fightNow);
@@ -191,7 +240,7 @@ export class Timeline {
       return;
     this.timebase = newTimebase;
 
-    this.nextEvent = 0;
+    this.nextEventState = { ...initialNextEventState };
     this.nextText = 0;
     this.nextSyncStart = 0;
     this.nextSyncEnd = 0;
@@ -245,9 +294,13 @@ export class Timeline {
   }
 
   private _AdvanceTimeTo(fightNow: number): void {
-    let event = this.events[this.nextEvent];
-    while (this.nextEvent < this.events.length && event && event.time <= fightNow)
-      event = this.events[++this.nextEvent];
+    // This function advances time to fightNow without processing any events.
+    let event = this.events[this.nextEventState.index];
+    while (
+      this.nextEventState.index < this.events.length && event &&
+      event.time + this.nextEventState.timeOffset <= fightNow
+    )
+      event = this.events[++this.nextEventState.index];
     let text = this.texts[this.nextText];
     while (this.nextText < this.texts.length && text && text.time <= fightNow)
       text = this.texts[++this.nextText];
@@ -257,6 +310,9 @@ export class Timeline {
     let syncEnd = this.syncEnds[this.nextSyncEnd];
     while (this.nextSyncEnd < this.syncEnds.length && syncEnd && syncEnd.end <= fightNow)
       syncEnd = this.syncEnds[++this.nextSyncEnd];
+    let forceJump = this.forceJumps[this.nextForceJump];
+    while (this.nextForceJump < this.forceJumps.length && forceJump && forceJump.time <= fightNow)
+      forceJump = this.forceJumps[++this.nextForceJump];
   }
 
   private _ClearTimers(): void {
@@ -293,6 +349,17 @@ export class Timeline {
       const e = this.activeEvents[i];
       if (e && e.time <= fightNow && e.duration) {
         const durationEvent: Event = {
+          // FIXME: it is incorrect to have a duration timer share an id with its non-duration
+          // origin when the duration extends across the end of a short loop.  Re-adding the
+          // non-duration origin will remove (due to same id) the ongoing duration timer.
+          // HOWEVER, there's also various issues (sortKey is incorrect, and activeEvent.time
+          // also needs to be adjusted) so for now we'll work around this by just not supporting
+          // durations that extend across jumps.
+          //
+          // Example timeline:
+          //   3 "Loop Target"
+          //   7 "Long Duration Event" duration 100
+          //   8 "Jump Backwards to Loop Target" sync /etc/ jump 3
           id: e.id,
           time: e.time + e.duration,
           sortKey: e.sortKey,
@@ -302,6 +369,7 @@ export class Timeline {
         };
         events.push(durationEvent);
         this.activeEvents.splice(i, 1);
+        this.ui?.OnRemoveTimer(e, false, true);
         this.ui?.OnAddTimer(fightNow, durationEvent, true);
         --i;
       }
@@ -315,19 +383,52 @@ export class Timeline {
 
   private _AddUpcomingTimers(fightNow: number): void {
     while (
-      this.nextEvent < this.events.length &&
+      this.nextEventState.index < this.events.length &&
       this.activeEvents.length < this.options.MaxNumberOfTimerBars
     ) {
-      const e = this.events[this.nextEvent];
-      if (!e)
+      const e = this.events[this.nextEventState.index];
+      if (e === undefined)
+        throw new UnreachableCode();
+
+      // If we have too many bars, just hold at this next event state
+      // until space frees up and we can start processing again.
+      const timeUntilEvent = e.time + this.nextEventState.timeOffset - fightNow;
+      if (timeUntilEvent > this.options.ShowTimerBarsAtSeconds)
         break;
-      if (e.time - fightNow > this.options.ShowTimerBarsAtSeconds)
-        break;
-      if (fightNow < e.time && !(e.name in this.ignores)) {
-        this.activeEvents.push(e);
-        this.ui?.OnAddTimer(fightNow, e, false);
+
+      ++this.nextEventState.index;
+
+      // If this event is before a forced jump or has already happened, skip.
+      if (e.time <= this.nextEventState.minFightNow || timeUntilEvent <= 0)
+        continue;
+
+      if (!(e.name in this.ignores)) {
+        const activeEvent: Event = {
+          ...e,
+          id: `${e.id}-${this.nextEventState.jumpCount}`,
+          time: e.time + this.nextEventState.timeOffset,
+          sortKey: e.sortKey + this.nextEventState.sortKeyOffset,
+        };
+        this.activeEvents.push(activeEvent);
+        this.ui?.OnAddTimer(fightNow, activeEvent, false);
       }
-      ++this.nextEvent;
+
+      const sync = e.sync;
+      if (sync?.jumpType === 'force' && sync?.jump !== undefined) {
+        this.nextEventState.index = 0;
+        this.nextEventState.minFightNow = sync.jump;
+        this.nextEventState.timeOffset += sync.time - sync.jump;
+        this.nextEventState.jumpCount++;
+        // All events are numbered with a sort key.  We could find the max sort key of all
+        // timeline entries and multiply by jump count to get an ordering such that
+        // all sort keys at a higher jump count sort after previous ones.  However,
+        // since we doing a forced jump lookahead at this point, we will never see anything higher
+        // than `e.sortKey`, so we can use that as a max.  Once the timeline syncs for any
+        // reason, we'll be back to jumpCount=0 and normal sort keys.  Sadly, this will not
+        // be true if we ever fix the duration bug across loops (see comments inline)
+        // but it's a band-aid for now, sorry.  Probably HtmlTimelineUI needs smarter ordering.
+        this.nextEventState.sortKeyOffset = e.sortKey * this.nextEventState.jumpCount;
+      }
     }
   }
 
@@ -368,10 +469,10 @@ export class Timeline {
     let nextSyncStarting = kBig;
     let nextSyncEnding = kBig;
 
-    if (this.nextEvent < this.events.length) {
-      const nextEvent = this.events[this.nextEvent];
+    if (this.nextEventState.index < this.events.length) {
+      const nextEvent = this.events[this.nextEventState.index];
       if (nextEvent) {
-        const nextEventEndsAt = nextEvent.time;
+        const nextEventEndsAt = nextEvent.time + this.nextEventState.timeOffset;
         console.assert(
           nextEventStarting > fightNow,
           'nextEvent wasn\'t updated before calling _ScheduleUpdate',
@@ -431,22 +532,39 @@ export class Timeline {
       nextSyncStarting,
       nextSyncEnding,
     );
-    if (nextTime !== kBig) {
-      console.assert(nextTime > fightNow, 'nextTime is in the past');
-      this.updateTimer = window.setTimeout(
-        () => {
-          this._OnUpdateTimer(Date.now());
-        },
-        (nextTime - fightNow) * 1000,
-      );
-    }
+    if (nextTime === kBig)
+      return;
+
+    console.assert(nextTime > fightNow, 'nextTime is in the past');
+    this._CancelUpdate();
+    this.updateTimer = window.setTimeout(
+      () => this._OnUpdateTimer(Date.now()),
+      (nextTime - fightNow) * 1000,
+    );
   }
 
   public _OnUpdateTimer(currentTime: number): void {
     console.assert(this.timebase, '_OnTimerUpdate called while stopped');
-
+    // TODO: we should round this to avoid fightNow=10.003 style things
     // This is the number of seconds into the fight (subtracting Dates gives milliseconds).
     const fightNow = (currentTime - this.timebase) / 1000;
+
+    // Unlike other jumps which happen "immediately", an unconditional jump may have happened
+    // in the past (+/- some timer variation).  Should we just consider that the update
+    // always happens exactly at the time it should?
+    const unconditionalJump = this._CheckUnconditionalJump(fightNow);
+    if (unconditionalJump) {
+      const jumpSource = unconditionalJump.time;
+      this._AddPassedTexts(jumpSource, currentTime);
+      const jumpDest = unconditionalJump.jump;
+      if (jumpDest === undefined)
+        throw new UnreachableCode();
+      const offset = fightNow - jumpSource;
+      this.SyncTo(jumpDest, currentTime - offset);
+      this._OnUpdateTimer(currentTime);
+      return;
+    }
+
     // Send text events now or they'd be skipped by _AdvanceTimeTo().
     this._AddPassedTexts(fightNow, currentTime);
     this._AdvanceTimeTo(fightNow);
@@ -456,6 +574,12 @@ export class Timeline {
     this._RemoveExpiredTimers(fightNow);
     this._AddUpcomingTimers(fightNow);
     this._ScheduleUpdate(fightNow);
+  }
+
+  public _CheckUnconditionalJump(fightNow: number): Sync | undefined {
+    const forceJump = this.forceJumps[this.nextForceJump];
+    if (forceJump && forceJump.time <= fightNow)
+      return forceJump;
   }
 }
 


### PR DESCRIPTION
Rather than adding a `loop`, add a variant of `jump` called `forcejump` to the timeline language.  If the sync does not occur, the jump will always happen when the time passes. This allows the timeline controller to automatically add loop lookahead rather than manually specifing it.

There's some manual testing of this in the Frankenstein manual `test.txt` test case.

To track this, `nextEvent` now has a whole bunch more state to track where it is in the lookahead so that when adding additional events as timer bars, it doesn't duplicate its efforts.

Additionally, since the same event could be added twice (or more) times on the screen, they need to have different ids (now strings instead of numbers, that include the "jump count" of the number of times we've gone through a lookahead jump to differentiate them from their pre-jump selves). Similarly, they also need different sort keys, although this is kind of a hack for now.

This also adds some grumpy documentation of a bunch of issues found in the code and potential followups.
Sorry that this code is a mess, but I didn't want to rewrite the world at this time.

Closes #5144.