### PR TITLE
raidboss: fix P11S lightstream safespot

### DIFF
--- a/ui/raidboss/data/06-ew/raid/p11s.ts
+++ b/ui/raidboss/data/06-ew/raid/p11s.ts
@@ -10,8 +10,7 @@ export interface Data extends RaidbossData {
   lightDarkDebuff: { [name: string]: 'light' | 'dark' };
   lightDarkBuddy: { [name: string]: string };
   lightDarkTether: { [name: string]: 'near' | 'far' };
-  cylinderValue?: number;
-  numCylinders?: number;
+  cylinderCollect: NetMatches['HeadMarker'][];
 }
 
 const headmarkers = {
@@ -42,6 +41,7 @@ const triggerSet: TriggerSet<Data> = {
       lightDarkDebuff: {},
       lightDarkBuddy: {},
       lightDarkTether: {},
+      cylinderCollect: [],
     };
   },
   triggers: [
@@ -460,32 +460,31 @@ const triggerSet: TriggerSet<Data> = {
       netRegex: { target: 'Arcane Cylinder' },
       condition: (data, matches) => {
         const id = getHeadmarkerId(data, matches);
-        return (id === headmarkers.orangeCW || id === headmarkers.blueCCW);
-      },
-      run: (data, matches) => {
-        const id = getHeadmarkerId(data, matches);
-        // Create a 3 digit binary value, Orange = 0, Blue = 1.
-        // e.g. BBO = 110 = 6
-        data.cylinderValue ??= 0;
-        data.numCylinders ??= 0;
-        data.cylinderValue *= 2;
-        if (id === headmarkers.blueCCW)
-          data.cylinderValue += 1;
-        data.numCylinders++;
-      },
-    },
-    {
-      id: 'P11S Lightstream',
-      type: 'HeadMarker',
-      netRegex: { target: 'Arcane Cylinder' },
-      condition: (data, matches) => {
-        const id = getHeadmarkerId(data, matches);
-        return (data.numCylinders === 3 &&
-          (id === headmarkers.orangeCW || id === headmarkers.blueCCW));
+        if (id !== headmarkers.orangeCW && id !== headmarkers.blueCCW)
+          return false;
+        data.cylinderCollect.push(matches);
+        return data.cylinderCollect.length === 3;
       },
       alertText: (data, _matches, output) => {
-        if (!data.cylinderValue || !(data.cylinderValue >= 0) || data.cylinderValue > 7)
-          return;
+        let cylinderValue = 0;
+
+        // targetId is in hex, but that's still lexicographically sorted so no need to parseInt.
+        const sortedCylinders = data.cylinderCollect.sort((a, b) => {
+          return a.targetId.localeCompare(b.targetId);
+        });
+        const markers = sortedCylinders.map((x) => x.id);
+
+        // Once sorted by id, the lasers will always be in NW, S, NE order.
+        // Create a 3 digit binary value, Orange = 0, Blue = 1.
+        // e.g. BBO = 110 = 6
+        for (const marker of markers) {
+          cylinderValue *= 2;
+          if (marker === headmarkers.blueCCW)
+            cylinderValue += 1;
+        }
+
+        // The safe spot is the one just CW of two reds or just CCW of two blues.
+        // There's always two of one color and one of the other.
         const outputs: { [cylinderValue: number]: string | undefined } = {
           0b000: undefined,
           0b001: output.northwest!(),
@@ -496,12 +495,9 @@ const triggerSet: TriggerSet<Data> = {
           0b110: output.southeast!(),
           0b111: undefined,
         };
-        return outputs[data.cylinderValue];
+        return outputs[cylinderValue];
       },
-      run: (data) => {
-        delete data.cylinderValue;
-        delete data.numCylinders;
-      },
+      run: (data) => data.cylinderCollect = [],
       outputStrings: {
         east: Outputs.east,
         northeast: Outputs.northeast,


### PR DESCRIPTION
The lasers are not always in sorted order, apparently? From the one (1) example of them not being sorted, it appears that sorting by actor id puts them in the correct order.

Fixes #5584.