### PR TITLE
raidboss: re-fix P11S lightstream safespot

### DIFF
--- a/ui/raidboss/data/06-ew/raid/p11s.ts
+++ b/ui/raidboss/data/06-ew/raid/p11s.ts
@@ -694,7 +694,7 @@ const triggerSet: TriggerSet<Data> = {
         const sortedCylinders = data.cylinderCollect.sort((a, b) => {
           return a.targetId.localeCompare(b.targetId);
         });
-        const markers = sortedCylinders.map((x) => x.id);
+        const markers = sortedCylinders.map((m) => getHeadmarkerId(data, m));
 
         // Once sorted by id, the lasers will always be in NW, S, NE order.
         // Create a 3 digit binary value, Orange = 0, Blue = 1.


### PR DESCRIPTION
Fixes a bug from #5585, which itself was fixing #5584.

I don't know why I thought this worked in the emulator. Sorry for the hassle.

Fixes #5588.