### PR TITLE
raidboss: fix p10s jade passage wrong output

### DIFF
--- a/ui/raidboss/data/06-ew/raid/p10s.ts
+++ b/ui/raidboss/data/06-ew/raid/p10s.ts
@@ -581,7 +581,7 @@ const triggerSet: TriggerSet<Data> = {
       suppressSeconds: 5,
       infoText: (_data, matches, output) => {
         const y = parseInt(matches.y);
-        return (Math.floor(y / 2) % 2 === 1) ? output.boxes!() : output.lines!();
+        return (Math.floor(y / 2) % 2 === 1) ? output.lines!() : output.boxes!();
       },
       outputStrings: {
         lines: {


### PR DESCRIPTION
Just played p10s in games, and it seems the result is opposite, still need someone to take further testing.