### PR TITLE
raidboss: additional p12s p1 triggers

### DIFF
--- a/resources/outputs.ts
+++ b/resources/outputs.ts
@@ -94,12 +94,28 @@ export default {
     cn: '顺劈',
     ko: '광역 탱버',
   },
+  tankBusterCleaves: {
+    en: 'Tank Buster Cleaves',
+    de: 'Tankbuster Cleaves',
+    fr: 'Tankbuster cleaves',
+    ja: 'MT・ST同時範囲攻撃',
+    cn: '双T扇形死刑',
+    ko: '광역 탱버',
+  },
   avoidTankCleave: {
     en: 'Avoid tank cleave',
     de: 'Tank Cleave ausweichen',
     fr: 'Évitez le tank cleave',
     ja: 'タンク範囲攻撃を避ける',
     cn: '远离顺劈',
+    ko: '광역 탱버 피하기',
+  },
+  avoidTankCleaves: {
+    en: 'Avoid Tank Cleaves',
+    de: 'Tankbuster Cleaves ausweichen',
+    fr: 'Évitez les cleaves (tankbusters)',
+    ja: '範囲攻撃を避けて',
+    cn: '躲避双T扇形死刑',
     ko: '광역 탱버 피하기',
   },
   tankCleaveOnYou: {

--- a/ui/raidboss/data/06-ew/raid/p12s.ts
+++ b/ui/raidboss/data/06-ew/raid/p12s.ts
@@ -104,7 +104,7 @@ const tetherAbilityToTowerMap: { [id: string]: EngravementLabel } = {
 
 type Paradeigma2SafeLane = 'east' | 'west';
 const paradeigma2SafeLanes: { [x: number]: Paradeigma2SafeLane[] } = {
-  // PosX of one add: [inside, outside] safe lanes:
+  // PosX of single add: [inside, outside] safe lanes,
   85: ['west', 'east'],
   95: ['east', 'west'],
   105: ['west', 'east'],
@@ -1287,7 +1287,7 @@ const triggerSet: TriggerSet<Data> = {
           cleaveSwap: Outputs.tankSwap,
           avoidTankCleave: Outputs.avoidTankCleave,
         };
-        // Mmultiple players can be hit by the line cleave AoE,
+        // Multiple players can be hit by the line cleave AoE,
         // but we only care about the intended target for the Followup trigger
         data.glaukopisFirstHit = matches.target;
 
@@ -1301,7 +1301,7 @@ const triggerSet: TriggerSet<Data> = {
       },
     },
     // Since multiple players could be hit by the 2nd cleave (whoopsie!), we need to check
-    // if *any* of the targets of the 2nd cleave were the original target of the 1st cleave.
+    // if *any* of the targets of the 2nd cleave were the original cast target (MT) of the 1st cleave.
     // If so, we'll assume the original target is using invuln, and no need to swap after the 2nd.
     {
       id: 'P12S Glaukopis Second Cleave Collect',

--- a/ui/raidboss/data/06-ew/raid/p12s.ts
+++ b/ui/raidboss/data/06-ew/raid/p12s.ts
@@ -1283,9 +1283,9 @@ const triggerSet: TriggerSet<Data> = {
         // cactbot-builtin-response
         output.responseOutputStrings = {
           cleaveOnYou: Outputs.tankCleaveOnYou,
-          cleaveNoTarget: Outputs.tankCleave,
+          tankBusterCleaves: Outputs.tankBusterCleaves,
           cleaveSwap: Outputs.tankSwap,
-          avoidTankCleave: Outputs.avoidTankCleave,
+          avoidTankCleaves: Outputs.avoidTankCleaves,
         };
         // Multiple players can be hit by the line cleave AoE,
         // but we only care about the intended target for the Followup trigger
@@ -1296,8 +1296,8 @@ const triggerSet: TriggerSet<Data> = {
         if (data.role === 'tank')
           return { alertText: output.cleaveSwap!() };
         if (data.role === 'healer' || data.job === 'BLU')
-          return { alertText: output.cleaveNoTarget!() };
-        return { infoText: output.avoidTankCleave!() };
+          return { alertText: output.tankBusterCleaves!() };
+        return { infoText: output.avoidTankCleaves!() };
       },
     },
     // Since multiple players could be hit by the 2nd cleave (whoopsie!), we need to check

--- a/ui/raidboss/data/06-ew/raid/p12s.ts
+++ b/ui/raidboss/data/06-ew/raid/p12s.ts
@@ -2056,6 +2056,7 @@ const triggerSet: TriggerSet<Data> = {
     },
     {
       'locale': 'de',
+      'missingTranslations': true,
       'replaceSync': {
         'Anthropos': 'Anthropos',
         '(?<! )Athena': 'Athena',

--- a/ui/raidboss/data/06-ew/raid/p12s.ts
+++ b/ui/raidboss/data/06-ew/raid/p12s.ts
@@ -356,9 +356,8 @@ const triggerSet: TriggerSet<Data> = {
     {
       id: 'P12S Ray of Light',
       type: 'StartsUsing',
-      // cast time: 4.7s; appears to be vfx corresponding to transition from orb to clone
       netRegex: { id: '82EE', source: 'Anthropos' },
-      delaySeconds: 0.7, // small delay to avoid collision with Engrave1 Tower Soak
+      delaySeconds: 0.7, // cast time: 4.7s; small delay to avoid collision with Engrave 1 Tower Soak
       suppressSeconds: 1,
       alertText: (_data, matches, output) => {
         const x = Math.round(parseFloat(matches.x));

--- a/ui/raidboss/data/06-ew/raid/p12s.ts
+++ b/ui/raidboss/data/06-ew/raid/p12s.ts
@@ -2056,7 +2056,6 @@ const triggerSet: TriggerSet<Data> = {
     },
     {
       'locale': 'de',
-      'missingTranslations': true,
       'replaceSync': {
         'Anthropos': 'Anthropos',
         '(?<! )Athena': 'Athena',

--- a/ui/raidboss/data/06-ew/raid/p12s.ts
+++ b/ui/raidboss/data/06-ew/raid/p12s.ts
@@ -1316,13 +1316,11 @@ const triggerSet: TriggerSet<Data> = {
       id: 'P12S Glaukopis Second Cleave Swap',
       type: 'Ability',
       netRegex: { id: '82FD', source: 'Athena', capture: false },
+      condition: (data) => data.role === 'tank' || data.job === 'BLU',
       delaySeconds: 0.1,
       suppressSeconds: 1,
       alertText: (data, _matches, output) => {
-        if (
-          data.me === data.glaukopisFirstHit && !data.glaukopisSecondHitSame &&
-        (data.role === 'tank' || data.job === 'BLU') // if a non-tank/BLU got hit by the 1st cleave, it was an accident and no swap reminder needed
-        )
+        if (data.me === data.glaukopisFirstHit && !data.glaukopisSecondHitSame)
           return output.tankSwap!();
       },
       run: (data) => {

--- a/ui/raidboss/data/06-ew/raid/p12s.ts
+++ b/ui/raidboss/data/06-ew/raid/p12s.ts
@@ -9,10 +9,6 @@ import { PluginCombatantState } from '../../../../../types/event';
 import { NetMatches } from '../../../../../types/net_matches';
 import { TriggerSet } from '../../../../../types/trigger';
 
-// TODO: north / south laser add call for first Paradeigma
-// TODO: laser add call (inner west / inner east?) for second Paradeigma
-// TODO: glaukopis tank swap call
-// TODO: glaukopis tank swap after 2nd hit (if different person took both)
 // TODO: add phase dash calls?? (maybe this is overkill)
 // TODO: Superchain 2B
 // TODO: final Sample safe spot
@@ -106,6 +102,15 @@ const tetherAbilityToTowerMap: { [id: string]: EngravementLabel } = {
   '82F2': 'darkTower',
 };
 
+type Paradeigma2SafeLane = 'east' | 'west';
+const paradeigma2SafeLanes: { [x: number]: Paradeigma2SafeLane[] } = {
+  // PosX of one add: [inside, outside] safe lanes:
+  85: ['west', 'east'],
+  95: ['east', 'west'],
+  105: ['west', 'east'],
+  115: ['east', 'west'],
+};
+
 const headmarkers = {
   ...wings,
   // vfx/lockon/eff/tank_laser_5sec_lockon_c0a1.avfx
@@ -172,6 +177,9 @@ export interface Data extends RaidbossData {
   isDoorBoss: boolean;
   phase?: 'superchain1' | 'palladion' | 'superchain2a' | 'superchain2b';
   combatantData: PluginCombatantState[];
+  paradeigmaCounter: number;
+  glaukopisFirstHit?: string;
+  glaukopisSecondHitSame: boolean;
   engravementCounter: number;
   engravement1BeamsPosMap: Map<string, string>;
   engravement1TetherIds: number[];
@@ -231,6 +239,8 @@ const triggerSet: TriggerSet<Data> = {
     return {
       isDoorBoss: true,
       combatantData: [],
+      paradeigmaCounter: 0,
+      glaukopisSecondHitSame: false,
       engravementCounter: 0,
       engravement1BeamsPosMap: new Map(),
       engravement1TetherIds: [],
@@ -294,6 +304,81 @@ const triggerSet: TriggerSet<Data> = {
       type: 'StartsUsing',
       netRegex: { id: '8304', source: 'Athena', capture: false },
       response: Responses.aoe(),
+    },
+    {
+      id: 'P12S Paradeigma Counter',
+      type: 'StartsUsing',
+      netRegex: { id: '82ED', source: 'Athena', capture: false },
+      run: (data) => data.paradeigmaCounter++,
+    },
+    {
+      id: 'P12S Paradeigma 1 Clones',
+      type: 'Ability',
+      // 8314 appears to transform the orbs ("Ideas") into clones once in position
+      netRegex: { id: '8314', source: 'Thymou Idea' },
+      condition: (data) => data.paradeigmaCounter === 1,
+      delaySeconds: 0.5, // need a small delay to let position data catch up
+      suppressSeconds: 10, // we only need y-pos of one add, and don't refire on the 2nd set of orbs
+      promise: async (data, matches) => {
+        data.combatantData = [];
+        const id = parseInt(matches.sourceId, 16);
+        data.combatantData = (await callOverlayHandler({
+          call: 'getCombatants',
+          ids: [id],
+        })).combatants;
+      },
+      infoText: (data, _matches, output) => {
+        if (data.combatantData.length === 0)
+          return output.clones!({ dir: output.unknown!() });
+        const y = data.combatantData[0]?.PosY;
+        if (y === undefined)
+          return output.clones!({ dir: output.unknown!() });
+        const cloneSide = y > centerY ? 'south' : 'north';
+        return output.clones!({ dir: output[cloneSide]!() });
+      },
+      outputStrings: {
+        clones: {
+          en: 'Clones ${dir}',
+        },
+        north: Outputs.north,
+        south: Outputs.south,
+        unknown: Outputs.unknown,
+      },
+    },
+    // In Ray 1 (Paradeigma2), two adds always spawn north in pairs with PosX of [85, 105] or [95, 115].
+    // Each cleaves 1/4th of the arena. So given one PosX, we can determine the inside/outside safe lanes.
+
+    // TODO: In Ray 2 (SC IIB), the adds have the same cleave width but spawn at [87, 103] or [97, 113].
+    // So "inside east", e.g., is a bit inaccurate.  Because of mech timing, there also isn't time to cross
+    // the arena.  So realistically, this should be combined with SC IIB triggers to indicate whether
+    //  the player needs to move inside or outside to avoid the cleave that will intersect the 2nd orb.
+    // For now, though, display a reminder to avoid the cleaves.
+    {
+      id: 'P12S Ray of Light',
+      type: 'StartsUsing',
+      // cast time: 4.7s; appears to be vfx corresponding to transition from orb to clone
+      netRegex: { id: '82EE', source: 'Anthropos' },
+      delaySeconds: 0.7, // small delay to avoid collision with Engrave1 Tower Soak
+      suppressSeconds: 1,
+      alertText: (_data, matches, output) => {
+        const x = Math.round(parseFloat(matches.x));
+        if (x === undefined)
+          return output.avoid!();
+        const [inside, outside] = paradeigma2SafeLanes[x] ?? [];
+        if (inside === undefined || outside === undefined)
+          return output.avoid!(); // will fire during Ray 2 (SC IIB)
+        return output.combined!({ inside: output[inside]!(), outside: output[outside]!() });
+      },
+      outputStrings: {
+        combined: {
+          en: 'Inside ${inside} / Outside ${outside}',
+        },
+        avoid: {
+          en: 'Avoid Line Cleaves',
+        },
+        east: Outputs.east,
+        west: Outputs.west,
+      },
     },
     {
       id: 'P12S First Wing',
@@ -1190,6 +1275,65 @@ const triggerSet: TriggerSet<Data> = {
       },
     },
     {
+      id: 'P12S Glaukopis First Cleave',
+      type: 'StartsUsing',
+      netRegex: { id: '82FC', source: 'Athena' },
+      response: (data, matches, output) => {
+        // don't use Responses.tankCleave(); we want to tell the non-targeted tank to swap
+        // cactbot-builtin-response
+        output.responseOutputStrings = {
+          cleaveOnYou: Outputs.tankCleaveOnYou,
+          cleaveNoTarget: Outputs.tankCleave,
+          cleaveSwap: Outputs.tankSwap,
+          avoidTankCleave: Outputs.avoidTankCleave,
+        };
+        // Mmultiple players can be hit by the line cleave AoE,
+        // but we only care about the intended target for the Followup trigger
+        data.glaukopisFirstHit = matches.target;
+
+        if (data.me === matches.target)
+          return { alertText: output.cleaveOnYou!() };
+        if (data.role === 'tank')
+          return { alertText: output.cleaveSwap!() };
+        if (data.job === 'BLU')
+          return { alertText: output.cleaveNoTarget!() };
+        return { infoText: output.avoidTankCleave!() };
+      },
+    },
+    // Since multiple players could be hit by the 2nd cleave (whoopsie!), we need to check
+    // if *any* of the targets of the 2nd cleave were the original target of the 1st cleave.
+    // If so, we'll assume the original target is using invuln, and no need to swap after the 2nd.
+    {
+      id: 'P12S Glaukopis Second Cleave Collect',
+      type: 'Ability',
+      netRegex: { id: '82FD', source: 'Athena' },
+      run: (data, matches) => {
+        if (matches.target === data.glaukopisFirstHit)
+          data.glaukopisSecondHitSame = true;
+      },
+    },
+    {
+      id: 'P12S Glaukopis Second Cleave Swap',
+      type: 'Ability',
+      netRegex: { id: '82FD', source: 'Athena', capture: false },
+      delaySeconds: 0.1,
+      suppressSeconds: 1,
+      alertText: (data, _matches, output) => {
+        if (
+          data.me === data.glaukopisFirstHit && !data.glaukopisSecondHitSame &&
+        (data.role === 'tank' || data.job === 'BLU') // if a non-tank/BLU got hit by the 1st cleave, it was an accident and no swap reminder needed
+        )
+          return output.tankSwap!();
+      },
+      run: (data) => {
+        delete data.glaukopisFirstHit;
+        data.glaukopisSecondHitSame = false;
+      },
+      outputStrings: {
+        tankSwap: Outputs.tankSwap,
+      },
+    },
+    {
       id: 'P12S Peridialogos',
       type: 'StartsUsing',
       netRegex: { id: '82FF', source: 'Athena', capture: false },
@@ -1660,6 +1804,15 @@ const triggerSet: TriggerSet<Data> = {
         data.superchain2aSecondMech = isSecondMechProtean ? 'protean' : 'partners';
       },
     },
+    // TODO: Combine with future SC IIB trigger?  Happens immediately after 1st orb (donut)
+    // and before 2nd orb (protean/partners). Also, rather than calling "sides", it should probably
+    // call the specific side where the 2nd orb is.
+    {
+      id: 'P12S Parthenos',
+      type: 'StartsUsing',
+      netRegex: { id: '8303', source: 'Athena', capture: false },
+      response: Responses.goSides(),
+    },
     // --------------------- Phase 2 ------------------------
     {
       id: 'P12S Geocentrism Vertical',
@@ -1905,6 +2058,7 @@ const triggerSet: TriggerSet<Data> = {
     },
     {
       'locale': 'de',
+      'missingTranslations': true,
       'replaceSync': {
         'Anthropos': 'Anthropos',
         '(?<! )Athena': 'Athena',

--- a/ui/raidboss/data/06-ew/raid/p12s.txt
+++ b/ui/raidboss/data/06-ew/raid/p12s.txt
@@ -13,7 +13,7 @@ hideall "--sync--"
 0.0 "--sync--" sync / 104:[^:]*:1($|:)/ window 0,1
 1.0 "--sync--" sync / 03:[^:]*:Hemitheos:00:5A:0{4}:00::12383:/ window 10,3 jump 1000.5 # Sync to P2 immediately through AddCombatant.
 11.1 "On the Soul" sync / 1[56]:[^:]*:Athena:8304:/ window 20,20
-21.2 "Paradeigma" sync / 1[56]:[^:]*:Athena:82ED:/
+21.2 "Paradeigma 1" sync / 1[56]:[^:]*:Athena:82ED:/
 24.3 "--middle--" sync / 1[56]:[^:]*:Athena:8315:/
 36.7 "Trinity of Souls 1" sync / 1[56]:[^:]*:Athena:(82E7|82E8):/
 36.7 "White Flame" sync / 1[56]:[^:]*:Anthropos:82EF:/
@@ -21,7 +21,7 @@ hideall "--sync--"
 41.7 "White Flame" sync / 1[56]:[^:]*:Anthropos:82EF:/
 41.9 "Trinity of Souls 3" sync / 1[56]:[^:]*:Athena:(82EB|82EC):/
 
-57.3 "Paradeigma" sync / 1[56]:[^:]*:Athena:82ED:/
+57.3 "Paradeigma 2" sync / 1[56]:[^:]*:Athena:82ED:/
 65.0 "Engravement of Souls" sync / 1[56]:[^:]*:Athena:8305:/
 74.8 "Searing Radiance/Shadowsear" sync / 1[56]:[^:]*:Anthropos:82F[12]:/
 75.8 "Astral Glow/Umbral Glow" sync / 1[56]:[^:]*:Athena:830[CD]:/
@@ -52,7 +52,7 @@ hideall "--sync--"
 172.1 "Dialogos" sync / 1[56]:[^:]*:Athena:8302:/
 178.8 "On the Soul" sync / 1[56]:[^:]*:Athena:8304:/
 190.0 "--middle--" sync / 1[56]:[^:]*:Athena:8315:/
-195.3 "Paradeigma" sync / 1[56]:[^:]*:Athena:82ED:/
+195.3 "Paradeigma 3" sync / 1[56]:[^:]*:Athena:82ED:/
 202.4 "Engravement of Souls" sync / 1[56]:[^:]*:Athena:8305:/
 212.5 "Shock" sync / 1[56]:[^:]*:Athena:8312:/
 213.6 "Sample" sync / 1[56]:[^:]*:Athena:82E0:/
@@ -95,7 +95,7 @@ hideall "--sync--"
 387.9 "On the Soul" sync / 1[56]:[^:]*:Athena:8304:/
 395.1 "--middle--" sync / 1[56]:[^:]*:Athena:8315:/
 402.5 "Superchain Theory IIB" sync / 1[56]:[^:]*:Athena:86FB:/
-408.6 "Paradeigma" sync / 1[56]:[^:]*:Athena:82ED:/
+408.6 "Paradeigma 4" sync / 1[56]:[^:]*:Athena:82ED:/
 415.6 "Superchain Coil/Superchain Burst" sync / 1[56]:[^:]*:Athena:82D[BC]:/
 418.6 "Parthenos" sync / 1[56]:[^:]*:Athena:8303:/
 422.5 "Superchain Coil/Superchain Burst" sync / 1[56]:[^:]*:Athena:82D[BC]:/

--- a/ui/raidboss/data/06-ew/trial/rubicante-ex.ts
+++ b/ui/raidboss/data/06-ew/trial/rubicante-ex.ts
@@ -356,22 +356,8 @@ const triggerSet: TriggerSet<Data> = {
       },
       run: (data) => data.dualfireTargets = [],
       outputStrings: {
-        tankBusterCleaves: {
-          en: 'Tank Buster Cleaves',
-          de: 'Tankbuster Cleaves',
-          fr: 'Tankbuster cleaves',
-          ja: 'MT・ST同時範囲攻撃',
-          cn: '双T扇形死刑',
-          ko: '광역 탱버',
-        },
-        avoidTankCleaves: {
-          en: 'Avoid Tank Cleaves',
-          de: 'Tankbuster Cleaves ausweichen',
-          fr: 'Évitez les cleaves (tankbusters)',
-          ja: '範囲攻撃を避けて',
-          cn: '躲避双T扇形死刑',
-          ko: '광역 탱버 피하기',
-        },
+        tankBusterCleaves: Outputs.tankBusterCleaves,
+        avoidTankCleaves: Outputs.avoidTankCleaves,
       },
     },
     {


### PR DESCRIPTION
Adds triggers for:

- Clones north/south during Paradeigma 1
- Clone line cleaves (e.g. inside east/outside west) during Paradeigma 2
- Glaukopis tank cleaves/swap
- Parthenos line cleave (during Superchain IIB)