### PR TITLE
raidboss: improvements to p12sp2 classical concepts

### DIFF
--- a/ui/raidboss/data/06-ew/raid/p12s.ts
+++ b/ui/raidboss/data/06-ew/raid/p12s.ts
@@ -2671,7 +2671,8 @@ const triggerSet: TriggerSet<Data> = {
             myInterceptOutput = 'leanEast';
           else if (interceptDelta === 1)
             myInterceptOutput = 'leanSouth';
-          else // interceptDelta === -5
+          // else: interceptDelta === -5
+          else
             myInterceptOutput = 'leanWest';
 
           if (data.phase === 'classical2') {

--- a/ui/raidboss/data/06-ew/raid/p12s.ts
+++ b/ui/raidboss/data/06-ew/raid/p12s.ts
@@ -2556,9 +2556,7 @@ const triggerSet: TriggerSet<Data> = {
           },
           northRow: Outputs.north,
           southRow: Outputs.south,
-          middleRow: {
-            en: 'Middle',
-          },
+          middleRow: Outputs.middle,
           leanNorth: {
             en: 'Lean North',
           },

--- a/ui/raidboss/data/06-ew/raid/p12s.ts
+++ b/ui/raidboss/data/06-ew/raid/p12s.ts
@@ -2532,13 +2532,13 @@ const triggerSet: TriggerSet<Data> = {
         // cactbot-builtin-response
         output.responseOutputStrings = {
           classic1: {
-            en: '${column}, ${row} Blue => ${intercept}',
+            en: '${column}, ${row} => ${intercept}',
           },
           classic2initial: {
-            en: 'Initial: ${column}, ${row} Blue => ${intercept}',
+            en: 'Initial: ${column}, ${row} => ${intercept}',
           },
           classic2actual: {
-            en: 'Actual: ${column}, ${row} Blue => ${intercept}',
+            en: 'Actual: ${column}, ${row} => ${intercept}',
           },
           outsideWest: {
             en: 'Outside West',
@@ -2552,9 +2552,15 @@ const triggerSet: TriggerSet<Data> = {
           outsideEast: {
             en: 'Outside East',
           },
-          northRow: Outputs.north,
-          southRow: Outputs.south,
-          middleRow: Outputs.middle,
+          northRow: {
+            en: 'North Blue',
+          },
+          middleRow: {
+            en: 'Middle Blue',
+          },
+          southRow: {
+            en: 'South Blue',
+          },
           leanNorth: {
             en: 'Lean North',
           },
@@ -2625,7 +2631,7 @@ const triggerSet: TriggerSet<Data> = {
             }
           });
 
-          let myIntercept;
+          let myIntercept; // don't set this initially in case there's something wrong with possibleLocations
           if (possibleLocations.length === 1) {
             // only one possible adjacent shape to intercept; we're done
             myIntercept = possibleIntercepts[0];
@@ -2636,28 +2642,25 @@ const triggerSet: TriggerSet<Data> = {
             // but this has never been observed in-game, and it generates two valid solution sets.
             // Since there is no single solution, we should not generate an output for it.
             const possible1 = possibleLocations[0];
-            if (possible1 !== undefined) {
-              const possible1AdjacentsMap = getConceptMap(possible1);
-              for (let x = 0; x < possible1AdjacentsMap.length; x++) {
-                const [possibleAdjacentLocation] = possible1AdjacentsMap[x] ?? [];
-                if (possibleAdjacentLocation === undefined)
-                  continue;
-                const possibleAdjacentColor = data.conceptData[possibleAdjacentLocation];
-                if (
-                  possibleAdjacentColor === 'blue' &&
-                  possibleAdjacentLocation !== myColumnBlueLocation
-                ) {
-                  // there's an adjacent blue (not the one the player is responsible for), so possibleLocations[0] is eliminated
-                  myIntercept = possibleIntercepts[1];
-                  break;
-                }
-                if (x === possible1AdjacentsMap.length - 1) {
-                  // last iteration & none of the adjacent shapes to possibleLocations[0] is a blue, so it's our spot
-                  myIntercept = possibleIntercepts[0];
-                }
+            myIntercept = possibleIntercepts[0];
+            if (possible1 === undefined)
+              return;
+            const possible1AdjacentsMap = getConceptMap(possible1);
+            for (const [possibleAdjacentLocation] of possible1AdjacentsMap) {
+              if (possibleAdjacentLocation === undefined)
+                continue;
+              const possibleAdjacentColor = data.conceptData[possibleAdjacentLocation];
+              if (
+                possibleAdjacentColor === 'blue' &&
+                possibleAdjacentLocation !== myColumnBlueLocation
+              ) {
+                // there's an adjacent blue (not the one the player is responsible for), so possibleLocations[0] is eliminated
+                myIntercept = possibleIntercepts[1];
+                break;
               }
             }
           }
+
           if (myIntercept === undefined)
             return;
 
@@ -2668,8 +2671,7 @@ const triggerSet: TriggerSet<Data> = {
             myInterceptOutput = 'leanEast';
           else if (interceptDelta === 1)
             myInterceptOutput = 'leanSouth';
-          // interceptDelta === -5
-          else
+          else // interceptDelta === -5
             myInterceptOutput = 'leanWest';
 
           if (data.phase === 'classical2') {
@@ -2743,7 +2745,9 @@ const triggerSet: TriggerSet<Data> = {
       alertText: (data, _matches, output) => {
         if (data.conceptDebuff === undefined)
           return output.default!();
-        return data.conceptDebuff === 'alpha' ? output.baitAlphaDebuff!() : output.baitBetaDebuff!();
+        return data.conceptDebuff === 'alpha'
+          ? output.baitAlphaDebuff!()
+          : output.baitBetaDebuff!();
       },
       run: (data) => delete data.conceptDebuff,
       outputStrings: {
@@ -2754,7 +2758,7 @@ const triggerSet: TriggerSet<Data> = {
           en: 'Avoid Shapes => Bait Proteans (Beta)',
         },
         default: {
-          en: 'Bait Proteans'
+          en: 'Bait Proteans',
         },
       },
     },
@@ -2766,7 +2770,9 @@ const triggerSet: TriggerSet<Data> = {
       alertText: (data, _matches, output) => {
         if (data.conceptDebuff === undefined)
           return output.default!();
-        return data.conceptDebuff === 'alpha' ? output.baitAlphaDebuff!() : output.baitBetaDebuff!();
+        return data.conceptDebuff === 'alpha'
+          ? output.baitAlphaDebuff!()
+          : output.baitBetaDebuff!();
       },
       outputStrings: {
         baitAlphaDebuff: {
@@ -2776,9 +2782,9 @@ const triggerSet: TriggerSet<Data> = {
           en: 'Bait Proteans (Beta)',
         },
         default: {
-          en: 'Bait Proteans'
+          en: 'Bait Proteans',
         },
-      }
+      },
     },
     {
       id: 'P12S Palladian Ray Followup',
@@ -2792,7 +2798,7 @@ const triggerSet: TriggerSet<Data> = {
       },
       outputStrings: {
         moveAvoid: {
-          en: 'Move! (avoid shapes)'
+          en: 'Move! (avoid shapes)',
         },
         move: Outputs.moveAway,
       },

--- a/ui/raidboss/data/06-ew/raid/p12s.ts
+++ b/ui/raidboss/data/06-ew/raid/p12s.ts
@@ -26,8 +26,9 @@ type Phase =
   | 'superchain2a'
   | 'superchain2b'
   | 'gaiaochos'
-  | 'classical'
-  | 'caloric';
+  | 'classical1'
+  | 'caloric'
+  | 'classical2';
 
 const centerX = 100;
 const centerY = 100;
@@ -180,6 +181,96 @@ type FloorTile =
   | 'outsideSW'
   | 'outsideSE';
 
+type ConceptColor = 'blue' | 'red' | 'yellow';
+type ConceptDebuff = 'alpha' | 'beta';
+type ConceptPair = 'circle' | 'triangle' | 'square' | 'cross';
+type ConceptRow = 'north' | 'middle' | 'south';
+type InterceptOutput = 'leanNorth' | 'leanEast' | 'leanSouth' | 'leanWest';
+
+const conceptPairMap: { [id: string]: ConceptPair } = {
+  [headmarkers.playstationCircle]: 'circle',
+  [headmarkers.playstationTriangle]: 'triangle',
+  [headmarkers.playstationSquare]: 'square',
+  [headmarkers.playstationCross]: 'cross',
+} as const;
+
+const conceptDebuffIds: { [effectId: string]: ConceptDebuff } = {
+  DE8: 'alpha',
+  DE9: 'beta',
+} as const;
+
+const conceptDebuffToColor: Record<ConceptDebuff, ConceptColor> = {
+  alpha: 'red',
+  beta: 'yellow',
+} as const;
+
+const npcBaseIdToConceptColor: { [npcId: number]: ConceptColor } = {
+  16183: 'red',
+  16184: 'blue',
+  16185: 'yellow',
+} as const;
+
+const conceptDebuffEffectIds: readonly string[] = Object.keys(conceptDebuffIds);
+const conceptNpcBaseIds: readonly string[] = Object.keys(npcBaseIdToConceptColor);
+const conceptPairIds: readonly string[] = Object.keys(conceptPairMap);
+
+// The below functions assign a numerical value to all (shapes) and intercept points:
+// xy: 88       96       104       112
+// 84  (0)--5--(10)--15--(20)--25--(30)
+//      |        |         |         |
+//      1       11        21        31
+//      |        |         |         |
+// 92  (2)--7--(12)--17--(22)--27--(32)
+//      |        |         |         |
+//      3       13        23        33
+//      |        |         |         |
+// 100 (4)--9--(14)--19--(24)--29--(34)
+
+const conceptLocationMap: Record<ConceptRow, number[]> = {
+  north: [0, 10, 20, 30],
+  middle: [2, 12, 22, 32],
+  south: [4, 14, 24, 34],
+};
+
+const getConceptLocation = (concept: NetMatches['AddedCombatant']): number => {
+  const x = parseFloat(concept.x);
+  const y = parseFloat(concept.y);
+
+  let row: ConceptRow;
+  if (y < 88)
+    row = 'north';
+  else
+    row = y > 96 ? 'south' : 'middle';
+  let col: number;
+  if (x < 92)
+    col = 0;
+  else if (x > 108)
+    col = 3;
+  else
+    col = x > 100 ? 2 : 1;
+  return conceptLocationMap[row][col]!;
+};
+
+const getConceptMap = (startLoc: number): number[][] => {
+  // takes a concept location and returns an array containing pairs of [adjacentLocation, interceptLocation]
+  const conceptMap: number[][] = [];
+  const expectedLocs = [
+    ...conceptLocationMap.north,
+    ...conceptLocationMap.middle,
+    ...conceptLocationMap.south,
+  ];
+  const [n, e, s, w] = [startLoc - 2, startLoc + 10, startLoc + 2, startLoc - 10];
+  if (expectedLocs.includes(n))
+    conceptMap.push([n, n + 1]);
+  if (expectedLocs.includes(e))
+    conceptMap.push([e, e - 5]);
+  if (expectedLocs.includes(s))
+    conceptMap.push([s, s - 1]);
+  if (expectedLocs.includes(w))
+    conceptMap.push([w, w + 5]);
+  return conceptMap;
+};
+
 const pangenesisEffects = {
   stableSystem: 'E22',
   unstableFactor: 'E09',
@@ -191,7 +282,6 @@ const pangenesisEffectIds: readonly string[] = Object.values(pangenesisEffects);
 
 type PangenesisRole = 'shortLight' | 'shortDark' | 'longLight' | 'longDark' | 'one' | 'not';
 
-type PlaystationMarker = 'circle' | 'cross' | 'triangle' | 'square';
 type CaloricMarker = 'fire' | 'wind';
 
 const getHeadmarkerId = (data: Data, matches: NetMatches['HeadMarker']) => {
@@ -206,7 +296,10 @@ const getHeadmarkerId = (data: Data, matches: NetMatches['HeadMarker']) => {
 };
 
 export interface Data extends RaidbossData {
-  readonly triggerSetConfig: { engravement1DropTower: 'quadrant' | 'clockwise' | 'tower' };
+  readonly triggerSetConfig: {
+    engravement1DropTower: 'quadrant' | 'clockwise' | 'tower';
+    classicalConceptsPairOrder: 'xsct' | 'cxts' | 'ctsx';
+  };
   decOffset?: number;
   expectedFirstHeadmarker?: string;
   isDoorBoss: boolean;
@@ -240,6 +333,12 @@ export interface Data extends RaidbossData {
   superchain2bSecondMech?: 'protean' | 'partners';
   superchain2bSecondDir?: 'east' | 'west';
   sampleTiles: NetMatches['Tether'][];
+  conceptPair?: ConceptPair;
+  conceptDebuff?: ConceptDebuff;
+  conceptData: { [location: number]: ConceptColor };
+  classical2InitialColumn?: number;
+  classical2InitialRow?: number;
+  classical2Intercept?: InterceptOutput;
   pangenesisDebuffsCalled?: boolean;
   pangenesisRole: { [name: string]: PangenesisRole };
   pangenesisTowerCount: number;
@@ -248,8 +347,6 @@ export interface Data extends RaidbossData {
   gaiaochosCounter: number;
   palladionGrapsTarget?: string;
   classicalCounter: number;
-  classicalMarker: { [name: string]: PlaystationMarker };
-  classicalAlphaBeta: { [name: string]: 'alpha' | 'beta' };
   caloricCounter: number;
   caloric1First: string[];
   caloric1Buff: { [name: string]: CaloricMarker };
@@ -296,6 +393,21 @@ const triggerSet: TriggerSet<Data> = {
       },
       default: 'tower',
     },
+    {
+      id: 'classicalConceptsPairOrder',
+      name: {
+        en: 'Classical Concepts: Pairs Order (Left->Right)',
+      },
+      type: 'select',
+      options: {
+        en: {
+          'X□○Δ (BPOG)': 'xsct',
+          '○XΔ□ (Lines)': 'cxts',
+          '○Δ□X (Rocketship)': 'ctsx',
+        },
+      },
+      default: 'xsct',
+    },
   ],
   timelineFile: 'p12s.txt',
   initData: () => {
@@ -318,6 +430,7 @@ const triggerSet: TriggerSet<Data> = {
       superchainCollect: [],
       whiteFlameCounter: 0,
       sampleTiles: [],
+      conceptData: {},
       pangenesisRole: {},
       pangenesisTowerCount: 0,
       gaiaochosCounter: 0,
@@ -370,7 +483,7 @@ const triggerSet: TriggerSet<Data> = {
             data.gaiaochosCounter++;
             break;
           case '8331':
-            data.phase = 'classical';
+            data.phase = data.classicalCounter === 0 ? 'classical1' : 'classical2';
             data.classicalCounter++;
             break;
           case '8338':
@@ -2366,6 +2479,266 @@ const triggerSet: TriggerSet<Data> = {
       },
     },
     {
+      id: 'P12S Classical Concepts Headmarker',
+      type: 'HeadMarker',
+      netRegex: {},
+      condition: Conditions.targetIsYou(),
+      run: (data, matches) => {
+        const id = getHeadmarkerId(data, matches);
+        if (!conceptPairIds.includes(id))
+          return;
+        const pair = conceptPairMap[id];
+        if (pair === undefined)
+          return;
+        data.conceptPair = pair;
+      },
+    },
+    {
+      id: 'P12S Classical Concepts Debuff',
+      type: 'GainsEffect',
+      netRegex: { effectId: conceptDebuffEffectIds },
+      condition: Conditions.targetIsYou(),
+      run: (data, matches) => data.conceptDebuff = conceptDebuffIds[matches.effectId],
+    },
+    {
+      id: 'P12S Classical Concepts Shape Collect',
+      type: 'AddedCombatant',
+      netRegex: { npcBaseId: conceptNpcBaseIds },
+      run: (data, matches) => {
+        const location = getConceptLocation(matches);
+        const color = npcBaseIdToConceptColor[parseInt(matches.npcBaseId)];
+        if (location !== undefined && color !== undefined)
+          data.conceptData[location] = color;
+      },
+    },
+    {
+      id: 'P12S Classical Concepts',
+      type: 'StartsUsing',
+      // 8331 = The Classical Concepts (6.7s cast)
+      // 8336 = Panta Rhei (9.7s cast during classical2 that inverts shapes)
+      netRegex: { id: ['8331', '8336'], source: 'Pallas Athena' },
+      delaySeconds: (_data, matches) => {
+        if (matches.id === '8331')
+          // for Classical Concepts, 6.7 cast time + 1.5 for debuff/headmarker data (some variability)
+          return 8.2;
+        return 0; // for Panta Rhei, fire immediately once cast starts
+      },
+      durationSeconds: (data, matches) => {
+        if (data.phase === 'classical1')
+          return 12; // keep active until shapes tether
+        if (matches.id === '8331')
+          return 7; // for classical2 initial, display initially to allow player to find (stand in) initial position
+        return 9.7; // for Panta Rhei, display until shape inversion completes
+      },
+      response: (data, matches, output) => {
+        // cactbot-builtin-response
+        output.responseOutputStrings = {
+          classic1: {
+            en: '${column}, ${row} Blue => ${intercept}',
+          },
+          classic2initial: {
+            en: 'Initial: ${column}, ${row} Blue => ${intercept}',
+          },
+          classic2actual: {
+            en: 'Actual: ${column}, ${row} Blue => ${intercept}',
+          },
+          outsideWest: {
+            en: 'Outside West',
+          },
+          insideWest: {
+            en: 'Inside West',
+          },
+          insideEast: {
+            en: 'Inside East',
+          },
+          outsideEast: {
+            en: 'Outside East',
+          },
+          northRow: Outputs.north,
+          southRow: Outputs.south,
+          middleRow: {
+            en: 'Middle',
+          },
+          leanNorth: {
+            en: 'Lean North',
+          },
+          leanEast: {
+            en: 'Lean East',
+          },
+          leanSouth: {
+            en: 'Lean South',
+          },
+          leanWest: {
+            en: 'Lean West',
+          },
+        };
+
+        if (
+          Object.keys(data.conceptData).length !== 12 ||
+          data.conceptDebuff === undefined ||
+          data.conceptPair === undefined
+        )
+          return;
+
+        let myColumn: number | undefined;
+        let myRow: number | undefined;
+        let myInterceptOutput: InterceptOutput | undefined;
+
+        if (matches.id === '8331') {
+          // for classic1 and classic2, find the (initial) position for the player to intercept
+          const columnOrderFromConfig: { [order: string]: ConceptPair[] } = {
+            xsct: ['cross', 'square', 'circle', 'triangle'],
+            cxts: ['circle', 'cross', 'triangle', 'square'],
+            ctsx: ['circle', 'triangle', 'square', 'cross'],
+          };
+          const columnOrder =
+            columnOrderFromConfig[data.triggerSetConfig.classicalConceptsPairOrder];
+          if (columnOrder?.length !== 4)
+            return;
+
+          myColumn = columnOrder.indexOf(data.conceptPair);
+          const myColumnLocations = [
+            conceptLocationMap.north[myColumn],
+            conceptLocationMap.middle[myColumn],
+            conceptLocationMap.south[myColumn],
+          ];
+          const [north, middle, south] = myColumnLocations;
+          if (north === undefined || middle === undefined || south === undefined)
+            return;
+
+          let myColumnBlueLocation: number;
+          if (data.conceptData[north] === 'blue')
+            myColumnBlueLocation = north;
+          else
+            myColumnBlueLocation = data.conceptData[middle] === 'blue' ? middle : south;
+          myRow = myColumnLocations.indexOf(myColumnBlueLocation);
+
+          const conceptMap = getConceptMap(myColumnBlueLocation);
+          const myShapeColor = conceptDebuffToColor[data.conceptDebuff];
+
+          const possibleLocations: number[] = [];
+          const possibleIntercepts: number[] = [];
+          conceptMap.forEach((adjacentPair) => {
+            const [location, intercept] = adjacentPair;
+            if (location !== undefined && intercept !== undefined) {
+              const adjacentColor = data.conceptData[location];
+              if (adjacentColor === myShapeColor) {
+                possibleLocations.push(location);
+                possibleIntercepts.push(intercept);
+              }
+            }
+          });
+
+          let myIntercept;
+          if (possibleLocations.length === 1) {
+            // only one possible adjacent shape to intercept; we're done
+            myIntercept = possibleIntercepts[0];
+          } else if (possibleLocations.length === 2) {
+            // two adjacent shapes that match player's debuff (does happen)
+            // the one that is NOT adjacent to a different blue is the correct shape.
+            // NOTE: There is a theoretical arrangement where both possibles are adjacent to another blue,
+            // but this has never been observed in-game, and it generates two valid solution sets.
+            // Since there is no single solution, we should not generate an output for it.
+            const possible1 = possibleLocations[0];
+            if (possible1 !== undefined) {
+              const possible1AdjacentsMap = getConceptMap(possible1);
+              for (let x = 0; x < possible1AdjacentsMap.length; x++) {
+                const [possibleAdjacentLocation] = possible1AdjacentsMap[x] ?? [];
+                if (possibleAdjacentLocation === undefined)
+                  continue;
+                const possibleAdjacentColor = data.conceptData[possibleAdjacentLocation];
+                if (
+                  possibleAdjacentColor === 'blue' &&
+                  possibleAdjacentLocation !== myColumnBlueLocation
+                ) {
+                  // there's an adjacent blue (not the one the player is responsible for), so possibleLocations[0] is eliminated
+                  myIntercept = possibleIntercepts[1];
+                  break;
+                }
+                if (x === possible1AdjacentsMap.length - 1) {
+                  // last iteration & none of the adjacent shapes to possibleLocations[0] is a blue, so it's our spot
+                  myIntercept = possibleIntercepts[0];
+                }
+              }
+            }
+          }
+          if (myIntercept === undefined)
+            return;
+
+          const interceptDelta = myIntercept - myColumnBlueLocation;
+          if (interceptDelta === -1)
+            myInterceptOutput = 'leanNorth';
+          else if (interceptDelta === 5)
+            myInterceptOutput = 'leanEast';
+          else if (interceptDelta === 1)
+            myInterceptOutput = 'leanSouth';
+          // interceptDelta === -5
+          else
+            myInterceptOutput = 'leanWest';
+
+          if (data.phase === 'classical2') {
+            data.classical2InitialColumn = myColumn;
+            data.classical2InitialRow = myRow;
+            data.classical2Intercept = myInterceptOutput;
+          }
+        } else {
+          // for Panta Rhei, get myColumn, myRow, and myInterceptOutput from data{} and invert them
+          if (data.classical2InitialColumn !== undefined)
+            myColumn = 3 - data.classical2InitialColumn;
+          if (data.classical2InitialRow !== undefined)
+            myRow = 2 - data.classical2InitialRow;
+          if (data.classical2Intercept !== undefined) {
+            const interceptOutputInvertMap: Record<InterceptOutput, InterceptOutput> = {
+              leanNorth: 'leanSouth',
+              leanSouth: 'leanNorth',
+              leanEast: 'leanEast',
+              leanWest: 'leanWest',
+            };
+            myInterceptOutput = interceptOutputInvertMap[data.classical2Intercept];
+          }
+        }
+
+        if (myColumn === undefined || myRow === undefined || myInterceptOutput === undefined)
+          return;
+
+        const columnOutput = ['outsideWest', 'insideWest', 'insideEast', 'outsideEast'][myColumn];
+        const rowOutput = ['northRow', 'middleRow', 'southRow'][myRow];
+        if (columnOutput === undefined || rowOutput === undefined)
+          return;
+
+        let outputStr;
+        if (data.phase === 'classical1') {
+          outputStr = output.classic1!({
+            column: output[columnOutput]!(),
+            row: output[rowOutput]!(),
+            intercept: output[myInterceptOutput]!(),
+          });
+          return { alertText: outputStr };
+        }
+        if (matches.id === '8331') { // classic2 initial
+          outputStr = output.classic2initial!({
+            column: output[columnOutput]!(),
+            row: output[rowOutput]!(),
+            intercept: output[myInterceptOutput]!(),
+          });
+          return { infoText: outputStr };
+        }
+        outputStr = output.classic2actual!({
+          column: output[columnOutput]!(),
+          row: output[rowOutput]!(),
+          intercept: output[myInterceptOutput]!(),
+        });
+        return { alertText: outputStr };
+      },
+      run: (data) => {
+        if (data.phase === 'classical1') {
+          delete data.conceptPair;
+          delete data.conceptDebuff;
+          data.conceptData = {};
+        }
+      },
+    },
+    {
       id: 'P12S Pangenesis Collect',
       type: 'GainsEffect',
       netRegex: { effectId: pangenesisEffectIds },
@@ -2672,98 +3045,6 @@ const triggerSet: TriggerSet<Data> = {
           ja: '線切る (${partner})',
         },
       },
-    },
-    {
-      id: 'P12S The Classical Concepts PS marker',
-      type: 'HeadMarker',
-      netRegex: {},
-      run: (data, matches) => {
-        const id = getHeadmarkerId(data, matches);
-        const psMarkerMap: { [id: string]: PlaystationMarker } = {
-          [headmarkers.playstationCircle]: 'circle',
-          [headmarkers.playstationTriangle]: 'triangle',
-          [headmarkers.playstationSquare]: 'square',
-          [headmarkers.playstationCross]: 'cross',
-        } as const;
-        const marker = psMarkerMap[id];
-        if (marker !== undefined)
-          data.classicalMarker[matches.target] = marker;
-      },
-    },
-    {
-      id: 'P12S The Classical Concepts Alpha Beta',
-      type: 'GainsEffect',
-      netRegex: { effectId: ['DE8', 'DE9'] },
-      run: (data, matches) => {
-        data.classicalAlphaBeta[matches.target] = matches.effectId === 'DE8' ? 'alpha' : 'beta';
-      },
-    },
-    {
-      id: 'P12S The Classical Concepts',
-      type: 'Ability',
-      netRegex: { id: '8331', source: 'Pallas Athena', capture: false },
-      delaySeconds: 2,
-      durationSeconds: (data) => data.classicalCounter === 1 ? 9 : 16,
-      suppressSeconds: 1,
-      infoText: (data, _matches, output) => {
-        const marker = data.classicalMarker[data.me];
-        const tether = data.classicalAlphaBeta[data.me];
-        if (marker === undefined || tether === undefined)
-          return;
-        return output.text!({ marker: output[marker]!(), shape: output[tether]!() });
-      },
-      outputStrings: {
-        text: {
-          en: '${marker} (block ${shape})',
-          ja: '${marker} + ${shape}', // FIXME
-        },
-        circle: {
-          en: 'Circle',
-          de: 'Kreis',
-          fr: 'Cercle',
-          ja: 'まる',
-          cn: '圆圈',
-          ko: '동그라미',
-        },
-        triangle: {
-          en: 'Triangle',
-          de: 'Dreieck',
-          fr: 'Triangle',
-          ja: 'さんかく',
-          cn: '三角',
-          ko: '삼각',
-        },
-        square: {
-          en: 'Square',
-          de: 'Viereck',
-          fr: 'Carré',
-          ja: 'しかく',
-          cn: '方块',
-          ko: '사각',
-        },
-        cross: {
-          en: 'X',
-          de: 'X',
-          fr: 'Croix',
-          ja: 'バツ',
-          cn: 'X',
-          ko: 'X',
-        },
-        alpha: {
-          // Deliberately say "pyramid" here to differentiate from "triangle" marker.
-          en: 'pyramid',
-        },
-        beta: {
-          en: 'cube',
-        },
-      },
-    },
-    {
-      id: 'P12S The Classical Concepts Move',
-      type: 'Ability',
-      netRegex: { id: '8323', source: 'Pallas Athena', capture: false },
-      delaySeconds: 2.5,
-      response: Responses.moveAway(),
     },
     {
       id: 'P12S Caloric Theory 1 Beacon Collect',

--- a/ui/raidboss/data/06-ew/raid/p12s.ts
+++ b/ui/raidboss/data/06-ew/raid/p12s.ts
@@ -15,9 +15,7 @@ import { TriggerSet } from '../../../../../types/trigger';
 // TODO: gaiochos group up for chains
 // TODO: delay the second horizontal/vertical call until after break chains (or combine!)
 // TODO: summon darkness tether break locations for gaiaochos 1 and 2
-// TODO: bait protean calls for classical 1 and 2
 
-// TODO: add triggerset ui for playstation order + classical location
 // TODO: detect(?!) hex strat for caloric2 and tell people who to go to??
 
 type Phase =
@@ -2731,9 +2729,72 @@ const triggerSet: TriggerSet<Data> = {
       run: (data) => {
         if (data.phase === 'classical1') {
           delete data.conceptPair;
-          delete data.conceptDebuff;
           data.conceptData = {};
         }
+      },
+    },
+    {
+      id: 'P12S Palladian Ray 1 Initial',
+      type: 'LosesEffect',
+      netRegex: { effectId: 'E04' }, // Shackled Together
+      condition: (data, matches) => data.me === matches.target && data.phase === 'classical1',
+      // shapes use 8333 (Implode) at t+5.6s, and 8324 (Palladian Ray cleaves) snapshots at t+8.9s
+      durationSeconds: 8,
+      alertText: (data, _matches, output) => {
+        if (data.conceptDebuff === undefined)
+          return output.default!();
+        return data.conceptDebuff === 'alpha' ? output.baitAlphaDebuff!() : output.baitBetaDebuff!();
+      },
+      run: (data) => delete data.conceptDebuff,
+      outputStrings: {
+        baitAlphaDebuff: {
+          en: 'Avoid Shapes => Bait Proteans (Alpha)',
+        },
+        baitBetaDebuff: {
+          en: 'Avoid Shapes => Bait Proteans (Beta)',
+        },
+        default: {
+          en: 'Bait Proteans'
+        },
+      },
+    },
+    {
+      id: 'P12S Palladian Ray 2 Initial',
+      type: 'Tether',
+      netRegex: { id: '0001', source: ['Concept of Fire', 'Concept of Earth'] },
+      condition: (data, matches) => data.me === matches.target && data.phase === 'classical2',
+      alertText: (data, _matches, output) => {
+        if (data.conceptDebuff === undefined)
+          return output.default!();
+        return data.conceptDebuff === 'alpha' ? output.baitAlphaDebuff!() : output.baitBetaDebuff!();
+      },
+      outputStrings: {
+        baitAlphaDebuff: {
+          en: 'Bait Proteans (Alpha)',
+        },
+        baitBetaDebuff: {
+          en: 'Bait Proteans (Beta)',
+        },
+        default: {
+          en: 'Bait Proteans'
+        },
+      }
+    },
+    {
+      id: 'P12S Palladian Ray Followup',
+      type: 'Ability',
+      netRegex: { id: '8323', source: 'Pallas Athena', capture: false },
+      delaySeconds: 2.5,
+      alertText: (data, _matches, output) => {
+        if (data.phase === 'classical2')
+          return output.moveAvoid!();
+        return output.move!();
+      },
+      outputStrings: {
+        moveAvoid: {
+          en: 'Move! (avoid shapes)'
+        },
+        move: Outputs.moveAway,
       },
     },
     {

--- a/ui/raidboss/data/06-ew/raid/p12s.ts
+++ b/ui/raidboss/data/06-ew/raid/p12s.ts
@@ -194,83 +194,6 @@ const conceptPairMap: { [id: string]: ConceptPair } = {
   [headmarkers.playstationCross]: 'cross',
 } as const;
 
-const conceptDebuffIds: { [effectId: string]: ConceptDebuff } = {
-  DE8: 'alpha',
-  DE9: 'beta',
-} as const;
-
-const conceptDebuffToColor: Record<ConceptDebuff, ConceptColor> = {
-  alpha: 'red',
-  beta: 'yellow',
-} as const;
-
-const npcBaseIdToConceptColor: { [npcId: number]: ConceptColor } = {
-  16183: 'red',
-  16184: 'blue',
-  16185: 'yellow',
-} as const;
-
-const conceptDebuffEffectIds: readonly string[] = Object.keys(conceptDebuffIds);
-const conceptNpcBaseIds: readonly string[] = Object.keys(npcBaseIdToConceptColor);
-const conceptPairIds: readonly string[] = Object.keys(conceptPairMap);
-
-// The below functions assign a numerical value to all (shapes) and intercept points:
-// xy: 88       96       104       112
-// 84  (0)--5--(10)--15--(20)--25--(30)
-//      |        |         |         |
-//      1       11        21        31
-//      |        |         |         |
-// 92  (2)--7--(12)--17--(22)--27--(32)
-//      |        |         |         |
-//      3       13        23        33
-//      |        |         |         |
-// 100 (4)--9--(14)--19--(24)--29--(34)
-
-const conceptLocationMap: Record<ConceptRow, number[]> = {
-  north: [0, 10, 20, 30],
-  middle: [2, 12, 22, 32],
-  south: [4, 14, 24, 34],
-};
-
-const getConceptLocation = (concept: NetMatches['AddedCombatant']): number => {
-  const x = parseFloat(concept.x);
-  const y = parseFloat(concept.y);
-
-  let row: ConceptRow;
-  if (y < 88)
-    row = 'north';
-  else
-    row = y > 96 ? 'south' : 'middle';
-  let col: number;
-  if (x < 92)
-    col = 0;
-  else if (x > 108)
-    col = 3;
-  else
-    col = x > 100 ? 2 : 1;
-  return conceptLocationMap[row][col]!;
-};
-
-const getConceptMap = (startLoc: number): number[][] => {
-  // takes a concept location and returns an array containing pairs of [adjacentLocation, interceptLocation]
-  const conceptMap: number[][] = [];
-  const expectedLocs = [
-    ...conceptLocationMap.north,
-    ...conceptLocationMap.middle,
-    ...conceptLocationMap.south,
-  ];
-  const [n, e, s, w] = [startLoc - 2, startLoc + 10, startLoc + 2, startLoc - 10];
-  if (expectedLocs.includes(n))
-    conceptMap.push([n, n + 1]);
-  if (expectedLocs.includes(e))
-    conceptMap.push([e, e - 5]);
-  if (expectedLocs.includes(s))
-    conceptMap.push([s, s - 1]);
-  if (expectedLocs.includes(w))
-    conceptMap.push([w, w + 5]);
-  return conceptMap;
-};
-
 const pangenesisEffects = {
   stableSystem: 'E22',
   unstableFactor: 'E09',
@@ -333,12 +256,6 @@ export interface Data extends RaidbossData {
   superchain2bSecondMech?: 'protean' | 'partners';
   superchain2bSecondDir?: 'east' | 'west';
   sampleTiles: NetMatches['Tether'][];
-  conceptPair?: ConceptPair;
-  conceptDebuff?: ConceptDebuff;
-  conceptData: { [location: number]: ConceptColor };
-  classical2InitialColumn?: number;
-  classical2InitialRow?: number;
-  classical2Intercept?: InterceptOutput;
   pangenesisDebuffsCalled?: boolean;
   pangenesisRole: { [name: string]: PangenesisRole };
   pangenesisTowerCount: number;

--- a/ui/raidboss/data/06-ew/raid/p12s.ts
+++ b/ui/raidboss/data/06-ew/raid/p12s.ts
@@ -194,6 +194,83 @@ const conceptPairMap: { [id: string]: ConceptPair } = {
   [headmarkers.playstationCross]: 'cross',
 } as const;
 
+const conceptDebuffIds: { [effectId: string]: ConceptDebuff } = {
+  DE8: 'alpha',
+  DE9: 'beta',
+} as const;
+
+const conceptDebuffToColor: Record<ConceptDebuff, ConceptColor> = {
+  alpha: 'red',
+  beta: 'yellow',
+} as const;
+
+const npcBaseIdToConceptColor: { [npcId: number]: ConceptColor } = {
+  16183: 'red',
+  16184: 'blue',
+  16185: 'yellow',
+} as const;
+
+const conceptDebuffEffectIds: readonly string[] = Object.keys(conceptDebuffIds);
+const conceptNpcBaseIds: readonly string[] = Object.keys(npcBaseIdToConceptColor);
+const conceptPairIds: readonly string[] = Object.keys(conceptPairMap);
+
+// The below functions assign a numerical value to all (shapes) and intercept points:
+// xy: 88       96       104       112
+// 84  (0)--5--(10)--15--(20)--25--(30)
+//      |        |         |         |
+//      1       11        21        31
+//      |        |         |         |
+// 92  (2)--7--(12)--17--(22)--27--(32)
+//      |        |         |         |
+//      3       13        23        33
+//      |        |         |         |
+// 100 (4)--9--(14)--19--(24)--29--(34)
+
+const conceptLocationMap: Record<ConceptRow, number[]> = {
+  north: [0, 10, 20, 30],
+  middle: [2, 12, 22, 32],
+  south: [4, 14, 24, 34],
+};
+
+const getConceptLocation = (concept: NetMatches['AddedCombatant']): number => {
+  const x = parseFloat(concept.x);
+  const y = parseFloat(concept.y);
+
+  let row: ConceptRow;
+  if (y < 88)
+    row = 'north';
+  else
+    row = y > 96 ? 'south' : 'middle';
+  let col: number;
+  if (x < 92)
+    col = 0;
+  else if (x > 108)
+    col = 3;
+  else
+    col = x > 100 ? 2 : 1;
+  return conceptLocationMap[row][col]!;
+};
+
+const getConceptMap = (startLoc: number): number[][] => {
+  // takes a concept location and returns an array containing pairs of [adjacentLocation, interceptLocation]
+  const conceptMap: number[][] = [];
+  const expectedLocs = [
+    ...conceptLocationMap.north,
+    ...conceptLocationMap.middle,
+    ...conceptLocationMap.south,
+  ];
+  const [n, e, s, w] = [startLoc - 2, startLoc + 10, startLoc + 2, startLoc - 10];
+  if (expectedLocs.includes(n))
+    conceptMap.push([n, n + 1]);
+  if (expectedLocs.includes(e))
+    conceptMap.push([e, e - 5]);
+  if (expectedLocs.includes(s))
+    conceptMap.push([s, s - 1]);
+  if (expectedLocs.includes(w))
+    conceptMap.push([w, w + 5]);
+  return conceptMap;
+};
+
 const pangenesisEffects = {
   stableSystem: 'E22',
   unstableFactor: 'E09',
@@ -256,6 +333,12 @@ export interface Data extends RaidbossData {
   superchain2bSecondMech?: 'protean' | 'partners';
   superchain2bSecondDir?: 'east' | 'west';
   sampleTiles: NetMatches['Tether'][];
+  conceptPair?: ConceptPair;
+  conceptDebuff?: ConceptDebuff;
+  conceptData: { [location: number]: ConceptColor };
+  classical2InitialColumn?: number;
+  classical2InitialRow?: number;
+  classical2Intercept?: InterceptOutput;
   pangenesisDebuffsCalled?: boolean;
   pangenesisRole: { [name: string]: PangenesisRole };
   pangenesisTowerCount: number;


### PR DESCRIPTION
Tested extensively against logs & vod, but could use some additional testing in game and validation on the timings.

Right now, for classical2, it will display the initial position for 7 seconds as an infoText, and right about as that expires, it will then display the inverted (actual) position as an alertText.  I left those as static values, but I'm undecided whether it would make more sense to add a config option to allow the user to specify when the alert should 'transition' from initial to actual.

Admittedly, I made a stylistic choice to do a single output trigger that covers the output for classical1 as well as the initial and actual calls for classical2.  It adds some trivial complexity around delay/duration, but the primary benefit I saw in this approach was a single set of customizable output strings, rather than multiple triggers users would separately need to modify.  (It also removes the need for some duplicative code.)  But I understand reasonable minds may differ on that choice.