### PR TITLE
raidboss: p12sp2 uav phase improvements

### DIFF
--- a/ui/raidboss/data/06-ew/raid/p12s.ts
+++ b/ui/raidboss/data/06-ew/raid/p12s.ts
@@ -3205,6 +3205,7 @@ const triggerSet: TriggerSet<Data> = {
         uav1: {
           en: 'Break tether (w/ ${partner})',
           ja: '線切る (${partner})',
+          cn: '拉断连线 (和 ${partner})',
         },
         uav2: {
           en: 'Break tether (w/ ${partner}) => ${geocentrism}',

--- a/ui/raidboss/data/06-ew/raid/p12s.ts
+++ b/ui/raidboss/data/06-ew/raid/p12s.ts
@@ -3150,7 +3150,7 @@ const triggerSet: TriggerSet<Data> = {
         const uavCenterX = 100;
         const uavCenterY = 90;
 
-        const safeMap: Readonly<Partial<Record<DirectionOutput8, readonly DirectionOutput8[]>>> = {
+        const safeMap: Record<DirectionOutput8, readonly DirectionOutput8[]> = {
           // for each dir, identify the two dirs 90 degrees away
           dirN: ['dirW', 'dirE'],
           dirNE: ['dirNW', 'dirSE'],
@@ -3160,12 +3160,13 @@ const triggerSet: TriggerSet<Data> = {
           dirSW: ['dirNW', 'dirSE'],
           dirW: ['dirN', 'dirS'],
           dirNW: ['dirNE', 'dirSW'],
-        };
+          unknown: [],
+        } as const;
 
         const x = parseFloat(matches.x);
         const y = parseFloat(matches.y);
         const cloneDir = Directions.xyTo8DirOutput(x, y, uavCenterX, uavCenterY);
-        const [dir1, dir2] = safeMap[cloneDir] ?? [];
+        const [dir1, dir2] = safeMap[cloneDir];
         if (dir1 === undefined || dir2 === undefined)
           return;
         return output.combined!({ dir1: output[dir1]!(), dir2: output[dir2]!() });

--- a/ui/raidboss/data/06-ew/raid/p12s.ts
+++ b/ui/raidboss/data/06-ew/raid/p12s.ts
@@ -3042,7 +3042,7 @@ const triggerSet: TriggerSet<Data> = {
       type: 'StartsUsing',
       netRegex: { id: '832F', source: 'Pallas Athena', capture: false },
       condition: (data) => data.seenSecondTethers === false,
-      alertText: (_data, _matches, output) => output.stackForTethers!(),
+      infoText: (_data, _matches, output) => output.stackForTethers!(),
       outputStrings: {
         stackForTethers: {
           en: 'Stack for Tethers',
@@ -3072,8 +3072,8 @@ const triggerSet: TriggerSet<Data> = {
           dirSW: 'dirNE',
           dirW: 'dirE',
           dirNW: 'dirSE',
-        };
-        let safeDirs = Object.keys(unsafeMap) as DirectionOutput8[];
+        } as const;
+        let safeDirs = Object.keys(unsafeMap);
         data.darknessClones.forEach((clone) => {
           const x = parseFloat(clone.x);
           const y = parseFloat(clone.y);
@@ -3083,7 +3083,7 @@ const triggerSet: TriggerSet<Data> = {
         });
         if (safeDirs.length !== 2)
           return;
-        const [dir1, dir2] = safeDirs;
+        const [dir1, dir2] = safeDirs.sort();
         if (dir1 === undefined || dir2 === undefined)
           return;
         return output.combined!({ dir1: output[dir1]!(), dir2: output[dir2]!() });
@@ -3105,7 +3105,7 @@ const triggerSet: TriggerSet<Data> = {
         const uavCenterX = 100;
         const uavCenterY = 90;
 
-        const safeMap: Partial<Record<DirectionOutput8, DirectionOutput8[]>> = {
+        const safeMap: Readonly<Partial<Record<DirectionOutput8, readonly DirectionOutput8[]>>> = {
           // for each dir, identify the two dirs 90 degrees away
           dirN: ['dirW', 'dirE'],
           dirNE: ['dirNW', 'dirSE'],

--- a/ui/raidboss/data/06-ew/raid/p12s.ts
+++ b/ui/raidboss/data/06-ew/raid/p12s.ts
@@ -3054,8 +3054,7 @@ const triggerSet: TriggerSet<Data> = {
       id: 'P12S Ultima Ray 1',
       type: 'StartsUsing',
       netRegex: { id: '8330', source: 'Hemitheos' },
-      // don't display after geocentrism2 / before ultima blow
-      condition: (data) => data.geocentrism2OutputStr === undefined,
+      condition: (data) => data.phase === 'gaiaochos1',
       infoText: (data, matches, output) => {
         data.darknessClones.push(matches);
         if (data.darknessClones.length !== 3)

--- a/ui/raidboss/data/06-ew/raid/p12s.ts
+++ b/ui/raidboss/data/06-ew/raid/p12s.ts
@@ -12,7 +12,6 @@ import { TriggerSet } from '../../../../../types/trigger';
 // TODO: add phase dash calls?? (maybe this is overkill)
 
 // TODO: crush helm tankbusters??? (+esuna calls for non-invulning tanks??)
-// TODO: delay the second horizontal/vertical call until after break chains (or combine!)
 // TODO: detect(?!) hex strat for caloric2 and tell people who to go to??
 
 type Phase =


### PR DESCRIPTION
Sorry for the piecemeal PRs today - I keep ending up with more time on my hands than I thought.

This adds a preposition 'stack for tethers' call before both of the player-chain-break mechs during uav phases.  It also adds directional safe calls for the ultima ray (clone) dives, and combines the 'break tethers' call with the geocentrism call during uav2.