### PR TITLE
raidboss: improvements to p12s pangenesis

### DIFF
--- a/ui/raidboss/data/06-ew/raid/p12s.ts
+++ b/ui/raidboss/data/06-ew/raid/p12s.ts
@@ -2834,7 +2834,7 @@ const triggerSet: TriggerSet<Data> = {
       id: 'P12S Pangenesis Collect',
       type: 'GainsEffect',
       netRegex: { effectId: pangenesisEffectIds },
-      condition: (data) => !data.pangenesisDebuffsCalled && !data.isDoorBoss,
+      condition: (data) => !data.pangenesisDebuffsCalled && data.phase === 'pangenesis',
       run: (data, matches) => {
         const id = matches.effectId;
         if (id === pangenesisEffects.darkTilt) {
@@ -2965,7 +2965,7 @@ const triggerSet: TriggerSet<Data> = {
       id: 'P12S Pangenesis Tilt Gain',
       type: 'GainsEffect',
       netRegex: { effectId: [pangenesisEffects.lightTilt, pangenesisEffects.darkTilt] },
-      condition: (data, matches) => matches.target === data.me && !data.isDoorBoss,
+      condition: (data, matches) => matches.target === data.me && data.phase === 'pangenesis',
       run: (data, matches) => {
         const color = matches.effectId === pangenesisEffects.lightTilt ? 'light' : 'dark';
         data.pangenesisCurrentColor = color;
@@ -2975,7 +2975,7 @@ const triggerSet: TriggerSet<Data> = {
       id: 'P12S Pangenesis Tilt Lose',
       type: 'LosesEffect',
       netRegex: { effectId: [pangenesisEffects.lightTilt, pangenesisEffects.darkTilt] },
-      condition: (data, matches) => matches.target === data.me && !data.isDoorBoss,
+      condition: (data, matches) => matches.target === data.me && data.phase === 'pangenesis',
       run: (data) => data.pangenesisCurrentColor = undefined,
     },
     {
@@ -2983,7 +2983,7 @@ const triggerSet: TriggerSet<Data> = {
       type: 'Ability',
       // 8343 = Umbral Advent (light tower), 8344 = Astral Advent (dark tower)
       netRegex: { id: ['8343', '8344'] },
-      condition: (data, matches) => matches.target === data.me && !data.isDoorBoss,
+      condition: (data, matches) => matches.target === data.me && data.phase === 'pangenesis',
       run: (data, matches) => {
         const color = matches.id === '8343' ? 'light' : 'dark';
         data.lastPangenesisTowerColor = color;
@@ -2995,7 +2995,7 @@ const triggerSet: TriggerSet<Data> = {
       // 8343 = Umbral Advent (light tower), 8344 = Astral Advent (dark tower)
       // There's always 1-2 of each, so just watch one.
       netRegex: { id: '8343', capture: false },
-      condition: (data) => !data.isDoorBoss,
+      condition: (data) => data.phase === 'pangenesis',
       preRun: (data) => data.pangenesisTowerCount++,
       suppressSeconds: 3,
       alarmText: (data, _matches, output) => {
@@ -3019,7 +3019,7 @@ const triggerSet: TriggerSet<Data> = {
       type: 'GainsEffect',
       netRegex: { effectId: pangenesisEffects.lightTilt, capture: false },
       condition: (data) => {
-        if (data.isDoorBoss)
+        if (data.phase !== 'pangenesis')
           return false;
         return data.lastPangenesisTowerColor !== undefined && data.pangenesisTowerCount !== 3;
       },

--- a/ui/raidboss/data/06-ew/raid/p12s.ts
+++ b/ui/raidboss/data/06-ew/raid/p12s.ts
@@ -2885,11 +2885,11 @@ const triggerSet: TriggerSet<Data> = {
         if (myRole === 'shortLight')
           return output.shortLight!();
         if (myRole === 'longLight')
-          return output.longLight!();
+          return strat === 'not' ? output.longLightMerge!() : output.longLight!();
         if (myRole === 'shortDark')
           return output.shortDark!();
         if (myRole === 'longDark')
-          return output.longDark!();
+          return strat === 'not' ? output.longDarkMerge!() : output.longDark!();
 
         const myBuddy = Object.keys(data.pangenesisRole).find((x) => {
           return data.pangenesisRole[x] === myRole && x !== data.me;
@@ -2903,7 +2903,7 @@ const triggerSet: TriggerSet<Data> = {
           return output.nothing!({ player: player });
         }
         if (strat === 'not')
-          return output.oneWithTower!({ player: player, tower: output.secondTower!() });
+          return output.oneWithTower!({ player: player, tower: output.secondTowerMerge!() });
         else if (strat === 'one')
           return output.oneWithTower!({ player: player, tower: output.firstTower!() });
         return output.one!({ player: player });
@@ -2940,6 +2940,9 @@ const triggerSet: TriggerSet<Data> = {
           cn: '白2: 踩第2轮黑塔',
           ko: '긴 빛 (두번째 어둠 대상)',
         },
+        longLightMerge: {
+          en: 'Long Light (get second dark - merge first)',
+        },
         shortDark: {
           en: 'Short Dark (get first light)',
           ja: '早: 1番目のひかり塔',
@@ -2952,11 +2955,17 @@ const triggerSet: TriggerSet<Data> = {
           cn: '黑2: 踩第2轮白塔',
           ko: '긴 어둠 (두번째 빛 대상)',
         },
+        longDarkMerge: {
+          en: 'Long Dark (get second light - merge first)',
+        },
         firstTower: {
           en: 'First Tower',
         },
         secondTower: {
           en: 'Second Tower',
+        },
+        secondTowerMerge: {
+          en: 'Second Tower (Merge first)',
         },
         unknown: Outputs.unknown,
       },

--- a/ui/raidboss/data/06-ew/raid/p12s.ts
+++ b/ui/raidboss/data/06-ew/raid/p12s.ts
@@ -417,8 +417,8 @@ const triggerSet: TriggerSet<Data> = {
       options: {
         en: {
           'Call Required Swaps Only': 'agnostic',
-          '0+2 (Conga Line/HRT)': 'not',
-          '1+2 (Yuki)': 'one',
+          '0+2 (HRT)': 'not',
+          '1+2 (Yuki/Rinon)': 'one',
         },
       },
       default: 'agnostic',


### PR DESCRIPTION
Closes #5630 .

Added three config options:  1+2 (current), 0+2 (newly added), and 'agnostic' (which will not call stays or swaps associated with any particular strat, and will only call a swap if the last tower color is now the same as the player's debuff color (meaning they will die and wipe if they don't swap).  Set agnostic as the config default since it will correctly function regardless of strat.

(Also, small note re: the comments on #5630 - in the 0+2 strat, the players who take the first towers _always_ both swap to take the second (opposite color) towers.