### PR TITLE
i18n: p12s, endsinger ko translations

### DIFF
--- a/resources/outputs.ts
+++ b/resources/outputs.ts
@@ -100,10 +100,11 @@ export default {
     fr: 'Tankbuster cleaves',
     ja: 'MT・ST同時範囲攻撃',
     cn: '双T扇形死刑',
-    ko: '광역 탱버',
+    ko: '동시 광역 탱버',
   },
   tankBusterCleavesOnYou: {
     en: 'Tank Cleaves on YOU',
+    ko: '광역 탱버 대상자',
   },
   avoidTankCleave: {
     en: 'Avoid tank cleave',

--- a/ui/raidboss/data/06-ew/raid/p12s.ts
+++ b/ui/raidboss/data/06-ew/raid/p12s.ts
@@ -429,7 +429,7 @@ const triggerSet: TriggerSet<Data> = {
         },
         ko: {
           '교체가 필요할 때만 알림': 'agnostic',
-          '0+2 (힐러원딜탱커)': 'not',
+          '0+2 (빠른 융합)': 'not',
           '1+2 (Yuki/Rinon)': 'one',
         },
       },

--- a/ui/raidboss/data/06-ew/raid/p12s.ts
+++ b/ui/raidboss/data/06-ew/raid/p12s.ts
@@ -397,6 +397,7 @@ const triggerSet: TriggerSet<Data> = {
       id: 'classicalConceptsPairOrder',
       name: {
         en: 'Classical Concepts: Pairs Order (Left->Right)',
+        ko: 'Classical Concepts: 도형 순서 (왼 -> 오)',
       },
       type: 'select',
       options: {
@@ -405,6 +406,11 @@ const triggerSet: TriggerSet<Data> = {
           '○XΔ□ (Lines)': 'cxts',
           '○Δ□X (Rocketship)': 'ctsx',
         },
+        ko: {
+          'X□○Δ (파보빨초)': 'xsct',
+          '○XΔ□ (1234)': 'cxts',
+          '○Δ□X (동세네엑)': 'ctsx',
+        },
       },
       default: 'xsct',
     },
@@ -412,12 +418,18 @@ const triggerSet: TriggerSet<Data> = {
       id: 'pangenesisFirstTower',
       name: {
         en: 'Pangenesis: First Towers',
+        ko: 'Pangenesis: 첫번째 기둥',
       },
       type: 'select',
       options: {
         en: {
           'Call Required Swaps Only': 'agnostic',
           '0+2 (HRT)': 'not',
+          '1+2 (Yuki/Rinon)': 'one',
+        },
+        ko: {
+          '교체가 필요할 때만 알림': 'agnostic',
+          '0+2 (힐러원딜탱커)': 'not',
           '1+2 (Yuki/Rinon)': 'one',
         },
       },
@@ -2244,32 +2256,39 @@ const triggerSet: TriggerSet<Data> = {
         combined: {
           en: '${dir} (Side) => ${mechanic} After',
           cn: '去 ${dir}(侧) => 稍后 ${mechanic}',
+          ko: '${dir} (옆) => ${mechanic}',
         },
         east: Outputs.east,
         west: Outputs.west,
         eastFromSouth: {
           en: 'Right/East',
           cn: '右/东',
+          ko: '오른쪽/동쪽',
         },
         eastFromNorth: {
           en: 'Left/East',
           cn: '左/东',
+          ko: '왼쪽/동쪽',
         },
         westFromSouth: {
           en: 'Left/West',
           cn: '左/西',
+          ko: '왼쪽/서쪽',
         },
         westFromNorth: {
           en: 'Right/West',
           cn: '右/西',
+          ko: '오른쪽/서쪽',
         },
         protean: {
           en: 'Protean',
           cn: '八方分散',
+          ko: '8방향 산개',
         },
         partners: {
           en: 'Partners',
           cn: '两人分摊',
+          ko: '파트너',
         },
       },
     },
@@ -2308,22 +2327,27 @@ const triggerSet: TriggerSet<Data> = {
         combined: {
           en: '${mechanic} => ${dir}',
           cn: '${mechanic} => ${dir}',
+          ko: '${mechanic} => ${dir}',
         },
         protean: {
           en: 'Protean',
           cn: '八方分散',
+          ko: '8방향 산개',
         },
         partners: {
           en: 'Partners',
           cn: '两人分摊',
+          ko: '파트너',
         },
         inside: {
           en: 'Inside (avoid clones)',
           cn: '内侧 (躲避场边激光)',
+          ko: '안쪽 (분신 피하기)',
         },
         outside: {
           en: 'Outside (avoid clones)',
           cn: '外侧 (躲避场边激光)',
+          ko: '바깥쪽 (분신 피하기)',
         },
         avoid: {
           en: 'Avoid Line Cleaves',
@@ -2364,16 +2388,19 @@ const triggerSet: TriggerSet<Data> = {
         combined: {
           en: '${dir} => Out + ${mechanic}',
           cn: '${dir} => 远离 + ${mechanic}',
+          ko: '${dir} => 밖으로 + ${mechanic}',
         },
         north: Outputs.north,
         south: Outputs.south,
         protean: {
           en: 'Protean',
           cn: '八方分散',
+          ko: '8방향 산개',
         },
         partners: {
           en: 'Partners',
           cn: '两人分摊',
+          ko: '파트너',
         },
       },
     },
@@ -2444,38 +2471,47 @@ const triggerSet: TriggerSet<Data> = {
         outsideNW: {
           en: 'Outside NW',
           cn: '外侧 左上(西北)',
+          ko: '북서 바깥',
         },
         outsideNE: {
           en: 'Outside NE',
           cn: '外侧 右上(东北)',
+          ko: '북동 바깥',
         },
         insideNW: {
           en: 'Inside NW',
           cn: '内侧 左上(西北)',
+          ko: '북서 안',
         },
         insideNE: {
           en: 'Inside NE',
           cn: '内侧 右上(东北)',
+          ko: '북동 안',
         },
         insideSW: {
           en: 'Inside SW',
           cn: '内侧 左下(西南)',
+          ko: '남서 안',
         },
         insideSE: {
           en: 'Inside SE',
           cn: '内侧 右下(东南)',
+          ko: '남동 안',
         },
         outsideSW: {
           en: 'Outside SW',
           cn: '外侧 左下(西南)',
+          ko: '남서 바깥',
         },
         outsideSE: {
           en: 'Outside SE',
           cn: '外侧 右下(东南)',
+          ko: '남동 바깥',
         },
         default: {
           en: 'Find safe tile',
           cn: '找安全地板',
+          ko: '안전한 타일 찾기',
         },
       },
     },
@@ -2601,58 +2637,72 @@ const triggerSet: TriggerSet<Data> = {
           classic1: {
             en: '${column}, ${row} => ${intercept}',
             cn: '${column}, ${row} => ${intercept}',
+            ko: '${column}, ${row} => ${intercept}',
           },
           classic2initial: {
             en: 'Initial: ${column}, ${row} => ${intercept}',
             cn: '先去 ${column}, ${row} => ${intercept}',
+            ko: '시작: ${column}, ${row} => ${intercept}',
           },
           classic2actual: {
             en: 'Actual: ${column}, ${row} => ${intercept}',
             cn: '去 ${column}, ${row} => ${intercept}',
+            ko: '실제: ${column}, ${row} => ${intercept}',
           },
           outsideWest: {
             en: 'Outside West',
             cn: '第1列 (左西 外侧)',
+            ko: '1열 (서쪽 바깥)',
           },
           insideWest: {
             en: 'Inside West',
             cn: '第2列 (左西 内侧)',
+            ko: '2열 (서쪽 안)',
           },
           insideEast: {
             en: 'Inside East',
             cn: '第3列 (右东 内侧)',
+            ko: '3열 (동쪽 안)',
           },
           outsideEast: {
             en: 'Outside East',
             cn: '第4列 (右东 外侧)',
+            ko: '4열 (동쪽 바깥)',
           },
           northRow: {
             en: 'North Blue',
             cn: '第1个蓝方块',
+            ko: '위쪽 파란색',
           },
           middleRow: {
             en: 'Middle Blue',
             cn: '第2个蓝方块',
+            ko: '가운데 파란색',
           },
           southRow: {
             en: 'South Blue',
             cn: '第3个蓝方块',
+            ko: '아래쪽 파란색',
           },
           leanNorth: {
             en: 'Lean North',
             cn: '靠上(北)',
+            ko: '위쪽',
           },
           leanEast: {
             en: 'Lean East',
             cn: '靠右(东)',
+            ko: '오른쪽',
           },
           leanSouth: {
             en: 'Lean South',
             cn: '靠下(南)',
+            ko: '아래쪽',
           },
           leanWest: {
             en: 'Lean West',
             cn: '靠左(西)',
+            ko: '왼쪽',
           },
         };
 
@@ -2836,14 +2886,17 @@ const triggerSet: TriggerSet<Data> = {
         baitAlphaDebuff: {
           en: 'Avoid Shapes => Bait Proteans (Alpha)',
           cn: '远离方块 => 引导射线 (α)',
+          ko: '도형 피하기 => 장판 유도 (알파)',
         },
         baitBetaDebuff: {
           en: 'Avoid Shapes => Bait Proteans (Beta)',
           cn: '远离方块 => 引导射线 (β)',
+          ko: '도형 피하기 => 장판 유도 (베타)',
         },
         default: {
           en: 'Bait Proteans',
           cn: '引导射线',
+          ko: '장판 유도',
         },
       },
     },
@@ -2863,14 +2916,17 @@ const triggerSet: TriggerSet<Data> = {
         baitAlphaDebuff: {
           en: 'Bait Proteans (Alpha)',
           cn: '引导射线 (α)',
+          ko: '장판 유도 (알파)',
         },
         baitBetaDebuff: {
           en: 'Bait Proteans (Beta)',
           cn: '引导射线 (β)',
+          ko: '장판 유도 (베타)',
         },
         default: {
           en: 'Bait Proteans',
           cn: '引导射线',
+          ko: '장판 유도',
         },
       },
     },
@@ -2888,6 +2944,7 @@ const triggerSet: TriggerSet<Data> = {
         moveAvoid: {
           en: 'Move! (avoid shapes)',
           cn: '快躲开! (远离方块)',
+          ko: '이동! (도형 피하기)',
         },
         move: Outputs.moveAway,
       },
@@ -2980,6 +3037,7 @@ const triggerSet: TriggerSet<Data> = {
         },
         nothingWithTower: {
           en: 'Nothing (w/${player}) - ${tower}',
+          ko: '디버프 없음 (+ ${player}) - ${tower}',
         },
         one: {
           en: 'One (w/${player})',
@@ -2989,6 +3047,7 @@ const triggerSet: TriggerSet<Data> = {
         },
         oneWithTower: {
           en: 'One (w/${player}) - ${tower}',
+          ko: '1번 (+ ${player}) - ${tower}',
         },
         shortLight: {
           en: 'Short Light (get first dark)',
@@ -3004,6 +3063,7 @@ const triggerSet: TriggerSet<Data> = {
         },
         longLightMerge: {
           en: 'Long Light (get second dark - merge first)',
+          ko: '긴 빛 (두번째 어둠 대상 - 융합 먼저)',
         },
         shortDark: {
           en: 'Short Dark (get first light)',
@@ -3019,15 +3079,19 @@ const triggerSet: TriggerSet<Data> = {
         },
         longDarkMerge: {
           en: 'Long Dark (get second light - merge first)',
+          ko: '긴 어둠 (두번째 빛 대상 - 융합 먼저)',
         },
         firstTower: {
           en: 'First Tower',
+          ko: '첫번째 기둥',
         },
         secondTower: {
           en: 'Second Tower',
+          ko: '두번째 기둥',
         },
         secondTowerMerge: {
           en: 'Second Tower (Merge first)',
+          ko: '두번째 기둥 (융합 먼저)',
         },
         unknown: Outputs.unknown,
       },
@@ -3177,6 +3241,7 @@ const triggerSet: TriggerSet<Data> = {
       outputStrings: {
         stackForTethers: {
           en: 'Stack for Tethers',
+          ko: '선 생기기 전에 모이기',
         },
       },
     },
@@ -3222,6 +3287,7 @@ const triggerSet: TriggerSet<Data> = {
       outputStrings: {
         combined: {
           en: '${dir1} / ${dir2} Safe',
+          ko: '${dir1} / ${dir2} 안전',
         },
         ...Directions.outputStrings8Dir,
       },
@@ -3260,6 +3326,7 @@ const triggerSet: TriggerSet<Data> = {
       outputStrings: {
         combined: {
           en: '${dir1} / ${dir2} Safe',
+          ko: '${dir1} / ${dir2} 안전',
         },
         ...Directions.outputStrings8Dir,
       },
@@ -3293,9 +3360,11 @@ const triggerSet: TriggerSet<Data> = {
           en: 'Break tether (w/ ${partner})',
           ja: '線切る (${partner})',
           cn: '拉断连线 (和 ${partner})',
+          ko: '선 끊기 (+ ${partner})',
         },
         uav2: {
           en: 'Break tether (w/ ${partner}) => ${geocentrism}',
+          ko: '선 끊기 (+ ${partner}) => ${geocentrism}',
         },
         unknown: Outputs.unknown,
       },
@@ -3321,10 +3390,12 @@ const triggerSet: TriggerSet<Data> = {
             en: 'Block tether',
             ja: '相棒の前でビームを受ける',
             cn: '挡枪',
+            ko: '선 대상자 앞에 서기',
           },
           stretchTether: {
             en: 'Stretch tether',
             cn: '拉线',
+            ko: '선 늘리기',
           },
         };
 
@@ -3405,6 +3476,7 @@ const triggerSet: TriggerSet<Data> = {
           en: 'Initial Fire (w/ ${partner})',
           ja: '自分に初炎 (${partner})', // FIXME
           cn: '火标记点名 (和 ${partner})',
+          ko: '첫 불 대상자 (+ ${partner})',
         },
       },
     },
@@ -3431,6 +3503,7 @@ const triggerSet: TriggerSet<Data> = {
           en: 'Fire again',
           ja: '再び炎！無職とあたまわり',
           cn: '二次火标记点名',
+          ko: '두번째 불',
         },
       },
     },
@@ -3452,11 +3525,13 @@ const triggerSet: TriggerSet<Data> = {
           en: 'Stack with Fire',
           ja: '無職！炎とあたまわり', // FIXME
           cn: '与火标记分摊',
+          ko: '불 쉐어',
         },
         wind: {
           en: 'Spread Wind',
           ja: '風！ 散会',
           cn: '风点名散开',
+          ko: '바람 산개',
         },
       },
     },
@@ -3475,16 +3550,19 @@ const triggerSet: TriggerSet<Data> = {
             en: 'Fire (w/${team})',
             ja: '自分に炎 (${team})',
             cn: '火标记点名 (和 ${team})',
+            ko: '불 (+ ${team})',
           },
           wind: {
             en: 'Wind (w/${team})',
             ja: '自分に風 (${team})',
             cn: '风标记点名 (和 ${team})',
+            ko: '바람 (+ ${team})',
           },
           windBeacon: {
             en: 'Initial Wind',
             ja: '自分に初風', // FIXME
             cn: '风标记点名',
+            ko: '첫 바람 대상자',
           },
         };
 
@@ -3530,11 +3608,13 @@ const triggerSet: TriggerSet<Data> = {
             en: 'Fire Marker',
             ja: '自分に初炎!', // FIXME
             cn: '火标记点名',
+            ko: '불 대상자',
           },
           fireOn: {
             en: 'Fire on ${player}',
             ja: '初炎: ${player}',
             cn: '火标记点 ${player}',
+            ko: '불: ${player}',
           },
         };
 
@@ -3562,6 +3642,7 @@ const triggerSet: TriggerSet<Data> = {
           en: 'Wind Spread',
           ja: '自分に風、散会',
           cn: '风点名散开',
+          ko: '바람 산개',
         },
       },
     },
@@ -3578,6 +3659,7 @@ const triggerSet: TriggerSet<Data> = {
             en: 'Pass Fire',
             ja: '次に移る！',
             cn: '传火!',
+            ko: '불 건네기',
           },
           moveAway: Outputs.moveAway,
         };
@@ -3623,7 +3705,7 @@ const triggerSet: TriggerSet<Data> = {
           fr: 'ExaBrasier + Grosse AoE!', // FIXME
           ja: 'エクサフレア + 全体攻撃',
           cn: '地火 + 大AoE伤害!',
-          ko: '엑사플레어 + 전체 공격!', // FIXME
+          ko: '엑사플레어 + 전체 공격!',
         },
       },
     },

--- a/ui/raidboss/data/06-ew/trial/endsinger-ex.ts
+++ b/ui/raidboss/data/06-ew/trial/endsinger-ex.ts
@@ -79,12 +79,15 @@ export const orbOutputStrings: OutputStrings = {
   w: Outputs.dirW,
   knockback: {
     en: '${dir} Knockback',
+    ko: '${dir} 넉백',
   },
   knockbackWithHead: {
     en: '${dir1} Knockback -> ${dir2}',
+    ko: '${dir1} 넉백 -> ${dir2}',
   },
   aoeWithHead: {
     en: 'Go ${dir1} (lean ${dir2})',
+    ko: '${dir1}쪽으로 (살짝 ${dir2}쪽으로)',
   },
 };
 
@@ -334,12 +337,15 @@ const triggerSet: TriggerSet<Data> = {
       outputStrings: {
         sides: {
           en: 'Out (Sides)',
+          ko: '밖으로 (양 옆)',
         },
         sidesWithTower: {
           en: 'Tower + Outside',
+          ko: '기둥 + 양 옆',
         },
         sidesWithStacks: {
           en: 'Outside + Healer Groups',
+          ko: '양 옆 + 힐러 그룹',
         },
       },
     },
@@ -360,12 +366,15 @@ const triggerSet: TriggerSet<Data> = {
       outputStrings: {
         middle: {
           en: 'Inside (Middle)',
+          ko: '안으로 (가운데)',
         },
         middleWithTower: {
           en: 'Tower + Inside',
+          ko: '기둥 + 안으로',
         },
         middleWithStacks: {
           en: 'Inside + Healer Groups',
+          ko: '안으로 + 힐러 그룹',
         },
       },
     },
@@ -416,6 +425,7 @@ const triggerSet: TriggerSet<Data> = {
         ...orbOutputStrings,
         temp: {
           en: '${text}',
+          ko: '${text}',
         },
       },
     },


### PR DESCRIPTION
Reasons for strategy translations, for other translators.

```ts
    {
      id: 'classicalConceptsPairOrder',
      name: {
        en: 'Classical Concepts: Pairs Order (Left->Right)',
        ko: 'Classical Concepts: 도형 순서 (왼 -> 오)',
      },
      type: 'select',
      options: {
        en: {
          'X□○Δ (BPOG)': 'xsct',
          '○XΔ□ (Lines)': 'cxts',
          '○Δ□X (Rocketship)': 'ctsx',
        },
        ko: {
          'X□○Δ (파보빨초)': 'xsct',
          '○XΔ□ (1234)': 'cxts',
          '○Δ□X (동세네엑)': 'ctsx',
        },
      },
      default: 'xsct',
    },
```

`BPOG` -> Blue, Purple, Orange, Green -> **파**랑, **보**라, **빨**강, **초**록 -> `파보빨초`
`Lines` -> 1 line with ○, 2 lines with X, 3 lines with Δ, 4 lines with □ -> `1234`.
`Rocketship` -> Just the initials of the Circle(동그라미), Triangle(세모), Square(네모), and X(엑스).

```ts
    {
      id: 'pangenesisFirstTower',
      name: {
        en: 'Pangenesis: First Towers',
        ko: 'Pangenesis: 첫번째 기둥',
      },
      type: 'select',
      options: {
        en: {
          'Call Required Swaps Only': 'agnostic',
          '0+2 (HRT)': 'not',
          '1+2 (Yuki/Rinon)': 'one',
        },
        ko: {
          '교체가 필요할 때만 알림': 'agnostic',
          '0+2 (힐러원딜탱커)': 'not',
          '1+2 (Yuki/Rinon)': 'one',
        },
      },
      default: 'agnostic',
    },
```
~~`HRT` -> Healer Range Tank~~