### PR TITLE
config: treat cleared options as defaults

### DIFF
--- a/resources/user_config.ts
+++ b/resources/user_config.ts
@@ -481,7 +481,9 @@ class UserConfig {
       if (typeof savedConfig === 'object' && !Array.isArray(savedConfig)) {
         if (opt.id in savedConfig) {
           const newValue = savedConfig[opt.id];
-          if (newValue !== undefined) {
+          // Empty strings are always treated as default values.
+          // This means that the user has entered something and then cleared it.
+          if (newValue !== undefined && newValue !== '') {
             value = newValue;
             isDefault = false;
           }


### PR DESCRIPTION
This partially addresses #5648. Handling the appearance of these cleared options differently is more involved.