### PR TITLE
raidboss: add delay to fix p12s classical concepts

### DIFF
--- a/ui/raidboss/data/06-ew/raid/p12s.ts
+++ b/ui/raidboss/data/06-ew/raid/p12s.ts
@@ -2621,7 +2621,7 @@ const triggerSet: TriggerSet<Data> = {
       netRegex: { id: ['8331', '8336'], source: 'Pallas Athena' },
       delaySeconds: (_data, matches) => {
         if (matches.id === '8331')
-          // for Classical Concepts, 6.7 cast time + 1.8 for debuff/headmarker data (some variability)
+          // for Classical Concepts, 6.7 cast time + 1.8 for shape/debuff/headmarker data (some variability)
           return 8.5;
         return 0; // for Panta Rhei, fire immediately once cast starts
       },

--- a/ui/raidboss/data/06-ew/raid/p12s.ts
+++ b/ui/raidboss/data/06-ew/raid/p12s.ts
@@ -2621,8 +2621,8 @@ const triggerSet: TriggerSet<Data> = {
       netRegex: { id: ['8331', '8336'], source: 'Pallas Athena' },
       delaySeconds: (_data, matches) => {
         if (matches.id === '8331')
-          // for Classical Concepts, 6.7 cast time + 1.5 for debuff/headmarker data (some variability)
-          return 8.2;
+          // for Classical Concepts, 6.7 cast time + 1.8 for debuff/headmarker data (some variability)
+          return 8.5;
         return 0; // for Panta Rhei, fire immediately once cast starts
       },
       durationSeconds: (data, matches) => {


### PR DESCRIPTION
Add +0.3 second delay to `P12S Classical Concepts` trigger to address issue of network/combatant data lag