### PR TITLE
raidboss: fix P10S bond and other triggers for non-English

### DIFF
--- a/ui/raidboss/data/06-ew/raid/p10s.ts
+++ b/ui/raidboss/data/06-ew/raid/p10s.ts
@@ -634,8 +634,8 @@ const triggerSet: TriggerSet<Data> = {
       'missingTranslations': true,
       'replaceSync': {
         'Arcane Sphere': 'arkan(?:e|er|es|en) Körper',
-        'Pand\\\\u00e6moniac Pillar': 'pand\\u00e6monisch(?:e|er|es|en) Turm',
-        'Pand\\\\u00e6monium': 'Pand\\u00e6monium',
+        'Pand\u00e6moniac Pillar': 'pand\u00e6monisch(?:e|er|es|en) Turm',
+        'Pand\u00e6monium': 'Pand\u00e6monium',
       },
       'replaceText': {
         '\\(cast\\)': '(Wirken)',
@@ -671,8 +671,8 @@ const triggerSet: TriggerSet<Data> = {
       'missingTranslations': true,
       'replaceSync': {
         'Arcane Sphere': 'sphère arcanique',
-        'Pand\\\\u00e6moniac Pillar': 'pilier pand\\u00e6moniaque',
-        'Pand\\\\u00e6monium': 'Pand\\u00e6monium',
+        'Pand\u00e6moniac Pillar': 'pilier pand\u00e6moniaque',
+        'Pand\u00e6monium': 'Pand\u00e6monium',
       },
       'replaceText': {
         'Bury': 'Impact',
@@ -704,8 +704,8 @@ const triggerSet: TriggerSet<Data> = {
       'missingTranslations': true,
       'replaceSync': {
         'Arcane Sphere': '立体魔法陣',
-        'Pand\\\\u00e6moniac Pillar': '万魔殿の塔',
-        'Pand\\\\u00e6monium': 'パンデモニウム',
+        'Pand\u00e6moniac Pillar': '万魔殿の塔',
+        'Pand\u00e6monium': 'パンデモニウム',
       },
       'replaceText': {
         'Bury': '衝撃',


### PR DESCRIPTION
The translation of the boss name did not work properly and so no trigger with a `source` property was firing.

Fixes #5643.