### PR TITLE
util/test: add missing netRegex params to find translations

### DIFF
--- a/resources/translations.ts
+++ b/resources/translations.ts
@@ -128,6 +128,10 @@ type LocaleLine = { en: string } & Partial<Record<Exclude<Lang, 'en'>, string>>;
 
 type LocaleRegexesObj = Record<keyof typeof localeLines, Record<Lang, RegExp>>;
 
+export type AnonNetRegexParams = {
+  [name: string]: string | readonly string[] | boolean | undefined | unknown[];
+};
+
 class RegexSet {
   regexes?: LocaleRegexesObj;
   netRegexes?: LocaleRegexesObj;
@@ -267,16 +271,31 @@ export const translateText = (
   replacements?: TimelineReplacement[],
 ): string => translateWithReplacements(text, 'replaceText', replaceLang, replacements).text;
 
-// Translates timeline or trigger regex params for a given language.
 export const translateRegexBuildParam = <T extends TriggerTypes>(
   params: NetParams[T],
   replaceLang: Lang,
   replacements?: TimelineReplacement[],
-): NetParams[T] => {
-  type AnonymousParams = {
-    [name: string]: string | readonly string[] | boolean | undefined | unknown[];
-  };
-  const anonParams: AnonymousParams = params;
+): {
+  params: NetParams[T];
+  wasTranslated: boolean;
+  missingFields?: string[];
+} => {
+  return translateRegexBuildParamAnon(params, replaceLang, replacements);
+};
+
+export const translateRegexBuildParamAnon = (
+  anonParams: AnonNetRegexParams,
+  replaceLang: Lang,
+  replacements?: TimelineReplacement[],
+): {
+  params: AnonNetRegexParams;
+  wasTranslated: boolean;
+  missingFields?: string[];
+} => {
+  let missingFields: string[] | undefined = undefined;
+  let wasTranslated = true;
+  const params: AnonNetRegexParams = {};
+
   for (const key of keysThatRequireTranslation) {
     const value = anonParams[key];
     if (typeof value === 'boolean' || value === undefined)
@@ -288,20 +307,28 @@ export const translateRegexBuildParam = <T extends TriggerTypes>(
     // change.  It might be possible to assign to params[key] if we make
     // timestamp a string | string[]?
     if (typeof value === 'string') {
-      anonParams[key] = translateWithReplacements(
+      const result = translateWithReplacements(
         value,
         'replaceSync',
         replaceLang,
         replacements,
-      ).text;
+      );
+      params[key] = result.text;
+      wasTranslated = wasTranslated && result.wasTranslated;
+      if (!result.wasTranslated)
+        (missingFields ??= []).push(key);
     } else {
-      anonParams[key] = value.map((x) => {
+      params[key] = value.map((x) => {
         if (typeof x !== 'string')
           return x;
-        return translateWithReplacements(x, 'replaceSync', replaceLang, replacements).text;
+        const result = translateWithReplacements(x, 'replaceSync', replaceLang, replacements);
+        wasTranslated = wasTranslated && result.wasTranslated;
+        if (!result.wasTranslated)
+          (missingFields ??= []).push(key);
+        return result.text;
       });
     }
   }
 
-  return params;
+  return { params, wasTranslated, missingFields };
 };

--- a/test/helper/test_trigger.ts
+++ b/test/helper/test_trigger.ts
@@ -8,10 +8,7 @@ import path from 'path';
 
 import { assert } from 'chai';
 
-import NetRegexes, {
-  buildNetRegexForTrigger,
-  keysThatRequireTranslation,
-} from '../../resources/netregexes';
+import NetRegexes, { buildNetRegexForTrigger } from '../../resources/netregexes';
 import { UnreachableCode } from '../../resources/not_reached';
 import PartyTracker from '../../resources/party';
 import Regexes from '../../resources/regexes';
@@ -20,7 +17,11 @@ import {
   triggerFunctions,
   triggerTextOutputFunctions,
 } from '../../resources/responses';
-import { translateWithReplacements } from '../../resources/translations';
+import {
+  AnonNetRegexParams,
+  translateRegexBuildParamAnon,
+  translateWithReplacements,
+} from '../../resources/translations';
 import { RaidbossData } from '../../types/data';
 import { Matches } from '../../types/net_matches';
 import {
@@ -705,42 +706,16 @@ const testTriggerFile = (file: string, info: TriggerSetInfo) => {
           if (trigger.disabled)
             continue;
 
-          const textHasTranslation = (text: string): boolean => {
-            return translateWithReplacements(
-              text,
-              'replaceSync',
-              locale,
-              translations,
-            ).wasTranslated;
-          };
+          const result = translateRegexBuildParamAnon(trigger.netRegex ?? {}, locale, translations);
+          if (result.wasTranslated)
+            continue;
 
-          const checkIfFieldHasTranslation = (
-            field: string | readonly string[],
-            fieldName: string,
-          ) => {
-            if (typeof field === 'string') {
-              assert.isTrue(
-                textHasTranslation(field),
-                `${id}:locale ${locale}:missing timelineReplace replaceSync for ${fieldName} '${field}'`,
-              );
-            } else {
-              for (const s of field) {
-                assert.isTrue(
-                  textHasTranslation(s),
-                  `${id}:locale ${locale}:missing timelineReplace replaceSync for ${fieldName} '${s}'`,
-                );
-              }
-            }
-          };
-
-          for (const key of keysThatRequireTranslation) {
-            type AnonymousParams = {
-              [name: string]: string | readonly string[] | boolean | undefined;
-            };
-            const anonTriggerFields: AnonymousParams = trigger.netRegex;
-            const value = anonTriggerFields[key];
-            if (value !== undefined && typeof value !== 'boolean')
-              checkIfFieldHasTranslation(value, key);
+          const anonParams: AnonNetRegexParams = trigger.netRegex;
+          for (const field of result.missingFields ?? []) {
+            const fieldValueStr = JSON.stringify(anonParams[field]);
+            assert.fail(
+              `${id}:locale ${locale}:missing timelineReplace replaceSync for field "${field}" with value ${fieldValueStr}`,
+            );
           }
 
           continue;

--- a/ui/raidboss/popup-text.ts
+++ b/ui/raidboss/popup-text.ts
@@ -814,7 +814,11 @@ export class PopupText {
               } else {
                 const re = buildNetRegexForTrigger(
                   trigger.type,
-                  translateRegexBuildParam(defaultNetRegex, this.parserLang, set.timelineReplace),
+                  translateRegexBuildParam(
+                    defaultNetRegex,
+                    this.parserLang,
+                    set.timelineReplace,
+                  ).params,
                 );
                 trigger.localNetRegex = Regexes.parse(re);
               }

--- a/ui/raidboss/raidboss_config.ts
+++ b/ui/raidboss/raidboss_config.ts
@@ -1302,7 +1302,7 @@ class RaidbossConfigurator {
       return Regexes.parse(
         buildNetRegexForTrigger(
           trig.type,
-          translateRegexBuildParam(regex, lang, set.timelineReplace),
+          translateRegexBuildParam(regex, lang, set.timelineReplace).params,
         ),
       );
     };


### PR DESCRIPTION
This adds extra functionality to the existing netRegex param translation to indicate missing translations.

This allows test_trigger and find_missing_timeline_translations to both re-use the actual path at runtime that translates. This removes bespoke logic in test_trigger to do this same work and adds this logic to find_missing_timeline_translations to report missing netRegex translations (that it previously did not do).

Previously also, doing the translation of netRegex params overwrote the params in place with the new translation. This wasn't technically an issue because of the post-collision checks, which mean that you can apply translations any number of times and still get the same result as applying it once. However, this is very confusing and subtle behavior and so now it makes a copy of the params instead.