### PR TITLE
util: apply rsvs to abilities/effects in log splitter

### DIFF
--- a/resources/netlog_defs.ts
+++ b/resources/netlog_defs.ts
@@ -22,6 +22,8 @@ export type LogDefinition = {
   firstUnknownField?: number;
   // A map of all of the fields, unique field name to field index.
   fields?: { [fieldName: string]: number };
+  // A map of the field(s) that *may* contain RSV keys (for decoding)
+  possibleRsvFields?: { [fieldName: string]: number };
   subFields?: {
     [fieldName: string]: {
       [fieldValue: string]: {
@@ -342,6 +344,9 @@ const latestLogDefinitions = {
       z: 11,
       heading: 12,
     },
+    possibleRsvFields: {
+      ability: 5,
+    },
     blankFields: [6],
     playerIds: {
       2: 3,
@@ -389,6 +394,9 @@ const latestLogDefinitions = {
       sequence: 44,
       targetIndex: 45,
       targetCount: 46,
+    },
+    possibleRsvFields: {
+      ability: 5,
     },
     playerIds: {
       2: 3,
@@ -438,6 +446,9 @@ const latestLogDefinitions = {
       targetIndex: 45,
       targetCount: 46,
     },
+    possibleRsvFields: {
+      ability: 5,
+    },
     playerIds: {
       2: 3,
       6: 7,
@@ -459,6 +470,9 @@ const latestLogDefinitions = {
       id: 4,
       name: 5,
       reason: 6,
+    },
+    possibleRsvFields: {
+      name: 5,
     },
     playerIds: {
       2: 3,
@@ -550,6 +564,9 @@ const latestLogDefinitions = {
       targetMaxHp: 10,
       sourceMaxHp: 11,
     },
+    possibleRsvFields: {
+      effect: 3,
+    },
     playerIds: {
       5: 6,
       7: 8,
@@ -630,6 +647,9 @@ const latestLogDefinitions = {
       targetId: 7,
       target: 8,
       count: 9,
+    },
+    possibleRsvFields: {
+      effect: 3,
     },
     playerIds: {
       5: 6,
@@ -1118,7 +1138,6 @@ const latestLogDefinitions = {
       key: 4,
       value: 5,
     },
-    globalInclude: true,
     canAnonymize: true,
     firstOptionalField: undefined,
   },

--- a/resources/netlog_defs.ts
+++ b/resources/netlog_defs.ts
@@ -22,8 +22,8 @@ export type LogDefinition = {
   firstUnknownField?: number;
   // A map of all of the fields, unique field name to field index.
   fields?: { [fieldName: string]: number };
-  // A map of the field(s) that *may* contain RSV keys (for decoding)
-  possibleRsvFields?: { [fieldName: string]: number };
+  // A list of field ids that *may* contain RSV keys (for decoding)
+  possibleRsvFields?: readonly number[];
   subFields?: {
     [fieldName: string]: {
       [fieldValue: string]: {
@@ -344,9 +344,7 @@ const latestLogDefinitions = {
       z: 11,
       heading: 12,
     },
-    possibleRsvFields: {
-      ability: 5,
-    },
+    possibleRsvFields: [5],
     blankFields: [6],
     playerIds: {
       2: 3,
@@ -395,9 +393,7 @@ const latestLogDefinitions = {
       targetIndex: 45,
       targetCount: 46,
     },
-    possibleRsvFields: {
-      ability: 5,
-    },
+    possibleRsvFields: [5],
     playerIds: {
       2: 3,
       6: 7,
@@ -446,9 +442,7 @@ const latestLogDefinitions = {
       targetIndex: 45,
       targetCount: 46,
     },
-    possibleRsvFields: {
-      ability: 5,
-    },
+    possibleRsvFields: [5],
     playerIds: {
       2: 3,
       6: 7,
@@ -471,9 +465,7 @@ const latestLogDefinitions = {
       name: 5,
       reason: 6,
     },
-    possibleRsvFields: {
-      name: 5,
-    },
+    possibleRsvFields: [5],
     playerIds: {
       2: 3,
     },
@@ -564,9 +556,7 @@ const latestLogDefinitions = {
       targetMaxHp: 10,
       sourceMaxHp: 11,
     },
-    possibleRsvFields: {
-      effect: 3,
-    },
+    possibleRsvFields: [3],
     playerIds: {
       5: 6,
       7: 8,
@@ -648,9 +638,7 @@ const latestLogDefinitions = {
       target: 8,
       count: 9,
     },
-    possibleRsvFields: {
-      effect: 3,
-    },
+    possibleRsvFields: [3],
     playerIds: {
       5: 6,
       7: 8,

--- a/util/logtools/splitter.ts
+++ b/util/logtools/splitter.ts
@@ -16,7 +16,7 @@ export default class Splitter {
   private rsvLines: { [key: string]: string } = {};
   // log type => field #s that may contain rsv data
   private rsvLinesReceived = false;
-  private rsvTypeToFieldMap: { [type: string]: number[] } = {};
+  private rsvTypeToFieldMap: { [type: string]: readonly number[] } = {};
   private rsvSubstitutionMap: { [key: string]: string } = {};
 
   // startLine and stopLine are both inclusive.
@@ -32,7 +32,7 @@ export default class Splitter {
       // Populate rsvTypeToFieldMap
       const possibleRsvFields = def.possibleRsvFields;
       if (possibleRsvFields !== undefined)
-        this.rsvTypeToFieldMap[def.type] = Object.values(possibleRsvFields);
+        this.rsvTypeToFieldMap[def.type] = possibleRsvFields;
     }
   }
 
@@ -113,6 +113,10 @@ export default class Splitter {
         this.rsvLines = {};
         this.rsvSubstitutionMap = {};
       }
+      // All RSVs are handled identically regardless of namespace (ability, effect, etc.)
+      // At some point, we could separate rsv keys into namespace-specific objects for substitution
+      // But there's virtually no risk of collision right now,
+      // and we also haven't yet determined how to map a 262 line to a particular namespace.
       const idIdx = 4;
       const valueIdx = 5;
       const rsvId = splitLine[idIdx];

--- a/util/logtools/splitter.ts
+++ b/util/logtools/splitter.ts
@@ -1,4 +1,4 @@
-import logDefinitions, { LogDefinition } from '../../resources/netlog_defs';
+import logDefinitions, { LogDefinition, LogDefinitionMap } from '../../resources/netlog_defs';
 
 import { Notifier } from './notifier';
 
@@ -26,7 +26,8 @@ export default class Splitter {
     private notifier: Notifier,
     private includeGlobals: boolean,
   ) {
-    for (const def of Object.values(logDefinitions) as LogDefinition[]) {
+    const defs: LogDefinitionMap = logDefinitions;
+    for (const def of Object.values(defs)) {
       // Remap logDefinitions from log type (instead of name) to definition.
       this.logTypes[def.type] = def;
       // Populate rsvTypeToFieldMap


### PR DESCRIPTION
Addresses the original scope of #5486 .  Updating make_timeline/test_timeline to use RSV lines (or, for that matter, to use a substitution table) would take some additional work.

Because 262 lines are zone-specific, I unset `globalInclude` and added logic to the log splitter to collect and push only those zone-specific RSV lines for each split log.  (From what I can tell, `globalInclude` is only used by the splitter, but if that's incorrect and we need to make adjustments elsewhere, let me know.)