### PR TITLE
util: Auto-generate header data in make_timeline

### DIFF
--- a/util/logtools/make_timeline.ts
+++ b/util/logtools/make_timeline.ts
@@ -465,9 +465,9 @@ const assembleTimelineStrings = (
           encounterAbilityList[id] = name;
       }
 
-    // Ignore auto-attacks, NPC allies, and abilities based on user-entered flags.
-    if (ignoreTimelineAbilityEntry(entry, args))
-      continue;
+      // Ignore auto-attacks, NPC allies, and abilities based on user-entered flags.
+      if (ignoreTimelineAbilityEntry(entry, args))
+        continue;
     }
 
     // Ignore AoE spam
@@ -551,32 +551,32 @@ const assembleHeaderZoneInfoStrings = (fight: FightEncInfo): string[] => {
 
 const assembleHeaderAbilityStrings = (
   args: ExtendedArgs,
-  encounterAbilityList: { [string: string]: string }
-  ): string[] => {
-    const assembled = [];
-    const sortedIgnore = args.ignore_id?.sort();
-    if (sortedIgnore !== undefined) {
-      const iiLine = `# -ii ${sortedIgnore.join(' ')}\n`;
-      assembled.push(iiLine);
-      assembled.push('# Ignored Abilities');
-      for (const id of sortedIgnore) {
-        const abilityName = encounterAbilityList[id];
-        if (abilityName !== undefined) {
-          const detailedIgnoreLine = `# ${id} ${abilityName}`;
-          assembled.push(detailedIgnoreLine);
-        }
-      }
-    }
-    assembled.push('\n# All Encounter Abilities');
-    for (const id of (Object.keys(encounterAbilityList).sort())) {
+  encounterAbilityList: { [string: string]: string },
+): string[] => {
+  const assembled = [];
+  const sortedIgnore = args.ignore_id?.sort();
+  if (sortedIgnore !== undefined) {
+    const iiLine = `# -ii ${sortedIgnore.join(' ')}\n`;
+    assembled.push(iiLine);
+    assembled.push('# Ignored Abilities');
+    for (const id of sortedIgnore) {
       const abilityName = encounterAbilityList[id];
-      if (abilityName) {
-        const listedLine = `# ${id} ${abilityName}`;
-        assembled.push(listedLine);
+      if (abilityName !== undefined) {
+        const detailedIgnoreLine = `# ${id} ${abilityName}`;
+        assembled.push(detailedIgnoreLine);
       }
     }
-    assembled.push('\nhideall "--Reset--"\nhideall "--sync--"\n');
-    return assembled;
+  }
+  assembled.push('\n# All Encounter Abilities');
+  for (const id of (Object.keys(encounterAbilityList).sort())) {
+    const abilityName = encounterAbilityList[id];
+    if (abilityName) {
+      const listedLine = `# ${id} ${abilityName}`;
+      assembled.push(listedLine);
+    }
+  }
+  assembled.push('\nhideall "--Reset--"\nhideall "--sync--"\n');
+  return assembled;
 };
 
 const parseTimelineFromFile = async (


### PR DESCRIPTION
This aims to simplify the recent "soft standard" of listing out all ignored abilities in detail, as well as the full list of abilities used by enemies in the encounter, ignored or not. Sample output:

```
make_timeline.ts -lf 10 -it Nidhogg -ii 179D 179F

### THE MINSTREL'S BALLAD: NIDHOGG'S RAGE
# ZoneID: 236

# -ii 179D 179F

# Ignored Abilities
# 179D Hot Wing
# 179F Hot Tail

# All Encounter Abilities
# 1795 the Scarlet Whisper
# 1796 Deafening Bellow
# 1797 Cauterize
# 1798 Touchdown
# 1799 --sync--
# 179A Horrid Roar
# 179B Horrid Roar
# 179C Hot Wing
# 179D Hot Wing
# 179E Hot Tail
# 179F Hot Tail
###Loads more elided for space

hideall "--Reset--"
hideall "--sync--"
```

(Those random "--sync--" entries are because the entry processing step prior to this one automatically replaces Unknown abilities. I don't think it's too big a deal, but we can probably add a rule to convert those back to Unknown_XXXX.)

This same technique can probably be applied to auto-listing ignored combatants, but unfortunately that's not quite as simple. The input `-ic MonsterOne "Two-Word Monster" "Three Word Monster"` is rendered in the `args.ignored_combatants` array as `['MonsterOne', 'Two-Word Monster', 'Three Word Monster']`. A simple `.join()` is not enough to restore the quote marks that would be necessary.

Currently the zone info generation does not operate on either raw start/end times or on timelines generated from FFLogs. For raw times, there is simply no way to know the zone information, since invoking this way bypasses the collector-creation step. For FFLogs reports, the data is available in the responses from FFLogs, but we would have to make some out-of-scope adjustments to how fflogs.ts operates. It's completely doable, but I didn't have the motivation for that this weekend.

None of this is elegant, and I should go through and add some in-line comments to bring this in line with the rest of the file, but it's ready for criticism and improvement.