### PR TITLE
raidboss/config: add per triggerset default output options

### DIFF
--- a/types/trigger.d.ts
+++ b/types/trigger.d.ts
@@ -88,12 +88,22 @@ export type ResponseField<Data extends RaidbossData, MatchType extends NetAnyMat
   | ResponseFunc<Data, MatchType>
   | ResponseOutput<Data, MatchType>;
 
+// Config UI options that apply to an individual trigger (by id).
 export type TriggerAutoConfig = {
   Output?: Output;
   Duration?: number;
   BeforeSeconds?: number;
   DelayAdjust?: number;
   OutputStrings?: OutputStrings;
+  TextAlertsEnabled?: boolean;
+  SoundAlertsEnabled?: boolean;
+  SpokenAlertsEnabled?: boolean;
+};
+
+// Config UI options that apply to an entire trigger set.
+// TODO: this doesn't apply to literal timeline alerts (not timeline triggers but
+// ancient timeline code that specifies alerts directly).
+export type TriggerSetAutoConfig = {
   TextAlertsEnabled?: boolean;
   SoundAlertsEnabled?: boolean;
   SpokenAlertsEnabled?: boolean;

--- a/ui/raidboss/raidboss_config.ts
+++ b/ui/raidboss/raidboss_config.ts
@@ -6,6 +6,7 @@ import Regexes from '../../resources/regexes';
 import { triggerOutputFunctions } from '../../resources/responses';
 import { translateRegex, translateRegexBuildParam } from '../../resources/translations';
 import UserConfig, {
+  ConfigEntry,
   ConfigValue,
   OptionsTemplate,
   UserFileCallback,
@@ -22,6 +23,7 @@ import {
   RaidbossFileData,
   TimelineField,
   TriggerAutoConfig,
+  TriggerSetAutoConfig,
 } from '../../types/trigger';
 import {
   CactbotConfigurator,
@@ -41,6 +43,11 @@ const kOptionKeys = {
   beforeSeconds: 'BeforeSeconds',
   delayAdjust: 'DelayAdjust',
   outputStrings: 'OutputStrings',
+  // folder for all trigger options
+  triggers: 'triggers',
+  // folder for all trigger set options
+  triggerSets: 'triggerSets',
+  // folder for options in trigger set config ui
   triggerSetConfig: 'TriggerSetConfig',
 } as const;
 
@@ -483,7 +490,7 @@ const addTriggerDetail = (
 // fields here.  This should be fixed.
 const setOptionsFromOutputValue = (
   value: SavedConfigEntry,
-  options: BaseOptions | TriggerAutoConfig,
+  options: BaseOptions | TriggerAutoConfig | TriggerSetAutoConfig,
 ) => {
   if (value === 'default') {
     // Nothing.
@@ -618,14 +625,32 @@ class RaidbossConfigurator {
       triggerContainer.appendChild(headerDiv);
 
       // TODO: print a warning if config exists without triggerset id??
-      if (
-        info.triggerSet.id !== undefined && info.triggerSet.config !== undefined &&
-        info.triggerSet.config.length > 0
-      ) {
+      if (info.triggerSet.id !== undefined) {
         const triggerSetConfig = document.createElement('div');
         triggerSetConfig.classList.add('overlay-options');
         triggerContainer.appendChild(triggerSetConfig);
-        for (const opt of info.triggerSet.config) {
+
+        const triggerSetAlertOutput = {
+          ...defaultTriggerSetAlertOutput,
+          id: kOptionKeys.output,
+          default: this.base.getStringOption(
+            'raidboss',
+            defaultAlertOutput.id,
+            defaultAlertOutput.default.toString(),
+          ),
+        } as const;
+        this.base.buildConfigEntry(
+          userOptions,
+          triggerSetConfig,
+          triggerSetAlertOutput,
+          'raidboss',
+          [
+            kOptionKeys.triggerSets,
+            info.triggerSet.id,
+          ],
+        );
+
+        for (const opt of info.triggerSet.config ?? []) {
           if (!this.base.developerOptions && opt.debugOnly)
             continue;
           this.base.buildConfigEntry(userOptions, triggerSetConfig, opt, 'raidboss', [
@@ -751,10 +776,14 @@ class RaidbossConfigurator {
             defaultValue = trig.beforeSeconds.toString();
 
           input.placeholder = defaultValue;
-          input.value = this.base.getStringOption('raidboss', ['triggers', trigId, optionKey], '');
+          input.value = this.base.getStringOption('raidboss', [
+            kOptionKeys.triggers,
+            trigId,
+            optionKey,
+          ], '');
           const setFunc = () => {
             const val = validDurationOrUndefined(input.value) || '';
-            this.base.setOption('raidboss', ['triggers', trigId, optionKey], val);
+            this.base.setOption('raidboss', [kOptionKeys.triggers, trigId, optionKey], val);
           };
           input.onchange = setFunc;
           input.oninput = setFunc;
@@ -780,10 +809,14 @@ class RaidbossConfigurator {
           input.type = 'text';
           input.step = 'any';
           input.placeholder = `0`;
-          input.value = this.base.getStringOption('raidboss', ['triggers', trigId, optionKey], '');
+          input.value = this.base.getStringOption('raidboss', [
+            kOptionKeys.triggers,
+            trigId,
+            optionKey,
+          ], '');
           const setFunc = () => {
             const val = validDelayAdjustOrUndefined(input.value) || '';
-            this.base.setOption('raidboss', ['triggers', trigId, optionKey], val);
+            this.base.setOption('raidboss', [kOptionKeys.triggers, trigId, optionKey], val);
           };
           input.onchange = setFunc;
           input.oninput = setFunc;
@@ -812,10 +845,14 @@ class RaidbossConfigurator {
             input.placeholder = `${trig.durationSeconds}`;
           else
             input.placeholder = this.base.translate(kMiscTranslations.valueDefault);
-          input.value = this.base.getStringOption('raidboss', ['triggers', trigId, optionKey], '');
+          input.value = this.base.getStringOption('raidboss', [
+            kOptionKeys.triggers,
+            trigId,
+            optionKey,
+          ], '');
           const setFunc = () => {
             const val = validDurationOrUndefined(input.value) || '';
-            this.base.setOption('raidboss', ['triggers', trigId, optionKey], val);
+            this.base.setOption('raidboss', [kOptionKeys.triggers, trigId, optionKey], val);
           };
           input.onchange = setFunc;
           input.oninput = setFunc;
@@ -846,11 +883,15 @@ class RaidbossConfigurator {
           input.placeholder = template;
           input.value = this.base.getStringOption(
             'raidboss',
-            ['triggers', trigId, optionKey, key],
+            [kOptionKeys.triggers, trigId, optionKey, key],
             '',
           );
           const setFunc = () =>
-            this.base.setOption('raidboss', ['triggers', trigId, optionKey, key], input.value);
+            this.base.setOption(
+              'raidboss',
+              [kOptionKeys.triggers, trigId, optionKey, key],
+              input.value,
+            );
           input.onchange = setFunc;
           input.oninput = setFunc;
 
@@ -1462,7 +1503,7 @@ class RaidbossConfigurator {
 
     const selectValue = this.base.getOption(
       'raidboss',
-      ['triggers', trigId, optionKey],
+      [kOptionKeys.triggers, trigId, optionKey],
       'default',
     );
 
@@ -1485,7 +1526,7 @@ class RaidbossConfigurator {
         let value = input.value;
         if (value.includes('default'))
           value = 'default';
-        this.base.setOption('raidboss', ['triggers', trigId, optionKey], input.value);
+        this.base.setOption('raidboss', [kOptionKeys.triggers, trigId, optionKey], input.value);
       };
     }
 
@@ -1554,8 +1595,8 @@ const processPerTriggerAutoConfig = (options: RaidbossOptions, savedConfig: Save
   const perTriggerAutoConfig = options[optionName] ??= {};
   if (typeof savedConfig !== 'object' || Array.isArray(savedConfig))
     return;
-  const triggers = savedConfig['triggers'];
-  if (triggers === undefined || typeof triggers !== 'object' || Array.isArray(triggers))
+  const triggers = savedConfig[kOptionKeys.triggers];
+  if (typeof triggers !== 'object' || Array.isArray(triggers))
     return;
 
   const outputObjs: { [key: string]: TriggerAutoConfig } = {};
@@ -1571,8 +1612,8 @@ const processPerTriggerAutoConfig = (options: RaidbossOptions, savedConfig: Save
 
     const autoConfig: TriggerAutoConfig = {};
 
-    const output = entry[kOptionKeys.output]?.toString();
-    if (output)
+    const output = entry[kOptionKeys.output];
+    if (typeof output === 'string')
       Object.assign(autoConfig, outputObjs[output]);
 
     const duration = validDurationOrUndefined(entry[kOptionKeys.duration]);
@@ -1603,8 +1644,39 @@ const processPerTriggerAutoConfig = (options: RaidbossOptions, savedConfig: Save
     )
       autoConfig[kOptionKeys.outputStrings] = outputStrings;
 
-    if (output || duration || outputStrings !== undefined)
+    if (typeof output === 'string' || duration || outputStrings !== undefined)
       perTriggerAutoConfig[id] = autoConfig;
+  }
+};
+
+const processPerTriggerSetAutoConfig = (
+  options: RaidbossOptions,
+  savedConfig: SavedConfigEntry,
+) => {
+  // raidboss will look up this.options.PerTriggerSetAutoConfig to find these values.
+  const optionName = 'PerTriggerSetAutoConfig';
+
+  const perTriggerSetAutoConfig = options[optionName] ??= {};
+  if (typeof savedConfig !== 'object' || Array.isArray(savedConfig))
+    return;
+  const triggerSets = savedConfig[kOptionKeys.triggerSets];
+  if (typeof triggerSets !== 'object' || Array.isArray(triggerSets))
+    return;
+
+  const outputObjs: { [key: string]: TriggerSetAutoConfig } = {};
+  const keys = Object.keys(kTriggerOptions);
+  for (const key of keys) {
+    const obj = outputObjs[key] = {};
+    setOptionsFromOutputValue(key, obj);
+  }
+
+  for (const [id, entry] of Object.entries(triggerSets)) {
+    if (typeof entry !== 'object' || Array.isArray(entry))
+      return;
+
+    const output = entry[kOptionKeys.output];
+    if (typeof output === 'string')
+      perTriggerSetAutoConfig[id] = { ...outputObjs[output] };
   }
 };
 
@@ -1697,6 +1769,73 @@ const processTriggerSetConfig = (options: RaidbossOptions, savedConfig: SavedCon
   }
 };
 
+// Reused for both top level UI and trigger set config UI.
+const defaultAlertOutput: ConfigEntry = {
+  id: 'DefaultAlertOutput',
+  name: {
+    en: 'Default alert output',
+    de: 'Standard Alert Ausgabe',
+    fr: 'Alerte par défaut',
+    ja: '警告情報出力既定値',
+    cn: '默认触发器提示输出模式',
+    ko: '기본 알람 출력 방식',
+  },
+  type: 'select',
+  options: {
+    en: {
+      '🆙🔊 Text and Sound': 'textAndSound',
+      '🆙💬 Text and TTS': 'ttsAndText',
+      '💬 TTS Only': 'ttsOnly',
+      '🆙 Text Only': 'textOnly',
+      '❌ Disabled': 'disabled',
+    },
+    de: {
+      '🆙🔊 Text und Ton': 'textAndSound',
+      '🆙💬 Text und TTS': 'ttsAndText',
+      '💬 Nur TTS': 'ttsOnly',
+      '🆙 Nur Text': 'textOnly',
+      '❌ Deaktiviert': 'disabled',
+    },
+    fr: {
+      '🆙🔊 Texte et son': 'textAndSound',
+      '🆙💬 Texte et TTS': 'ttsAndText',
+      '💬 TTS seulement': 'ttsOnly',
+      '🆙 Texte seulement': 'textOnly',
+      '❌ Désactivé': 'disabled',
+    },
+    ja: {
+      '🆙🔊 テキストと音声': 'textAndSound',
+      '🆙💬 テキストとTTS': 'ttsAndText',
+      '💬 TTSのみ': 'ttsOnly',
+      '🆙 テキストのみ': 'textOnly',
+      '❌ 無効': 'disabled',
+    },
+    cn: {
+      '🆙🔊 文本显示与提示音': 'textAndSound',
+      '🆙💬 文本显示与TTS': 'ttsAndText',
+      '💬 只使用TTS': 'ttsOnly',
+      '🆙 只使用文本显示': 'textOnly',
+      '❌ 禁用': 'disabled',
+    },
+    ko: {
+      '🆙🔊 텍스트와 소리': 'textAndSound',
+      '🆙💬 텍스트와 TTS': 'ttsAndText',
+      '💬 TTS만': 'ttsOnly',
+      '🆙 텍스트만': 'textOnly',
+      '❌ 비활성화': 'disabled',
+    },
+  },
+  default: 'textAndSound',
+  setterFunc: setOptionsFromOutputValue,
+} as const;
+
+const defaultTriggerSetAlertOutput = {
+  ...defaultAlertOutput,
+  name: {
+    en: 'Default trigger set alert output',
+  },
+} as const;
+
 const templateOptions: OptionsTemplate = {
   buildExtraUI: (base, container) => {
     const builder = new RaidbossConfigurator(base);
@@ -1711,6 +1850,7 @@ const templateOptions: OptionsTemplate = {
     const options = baseOptions as RaidbossOptions;
 
     processPerTriggerAutoConfig(options, savedConfig);
+    processPerTriggerSetAutoConfig(options, savedConfig);
     processPerZoneTimelineConfig(options, savedConfig);
     processTriggerSetConfig(options, savedConfig);
   },
@@ -1751,64 +1891,7 @@ const templateOptions: OptionsTemplate = {
       debugOnly: true,
       default: false,
     },
-    {
-      id: 'DefaultAlertOutput',
-      name: {
-        en: 'Default alert output',
-        de: 'Standard Alert Ausgabe',
-        fr: 'Alerte par défaut',
-        ja: '警告情報出力既定値',
-        cn: '默认触发器提示输出模式',
-        ko: '기본 알람 출력 방식',
-      },
-      type: 'select',
-      options: {
-        en: {
-          '🆙🔊 Text and Sound': 'textAndSound',
-          '🆙💬 Text and TTS': 'ttsAndText',
-          '💬 TTS Only': 'ttsOnly',
-          '🆙 Text Only': 'textOnly',
-          '❌ Disabled': 'disabled',
-        },
-        de: {
-          '🆙🔊 Text und Ton': 'textAndSound',
-          '🆙💬 Text und TTS': 'ttsAndText',
-          '💬 Nur TTS': 'ttsOnly',
-          '🆙 Nur Text': 'textOnly',
-          '❌ Deaktiviert': 'disabled',
-        },
-        fr: {
-          '🆙🔊 Texte et son': 'textAndSound',
-          '🆙💬 Texte et TTS': 'ttsAndText',
-          '💬 TTS seulement': 'ttsOnly',
-          '🆙 Texte seulement': 'textOnly',
-          '❌ Désactivé': 'disabled',
-        },
-        ja: {
-          '🆙🔊 テキストと音声': 'textAndSound',
-          '🆙💬 テキストとTTS': 'ttsAndText',
-          '💬 TTSのみ': 'ttsOnly',
-          '🆙 テキストのみ': 'textOnly',
-          '❌ 無効': 'disabled',
-        },
-        cn: {
-          '🆙🔊 文本显示与提示音': 'textAndSound',
-          '🆙💬 文本显示与TTS': 'ttsAndText',
-          '💬 只使用TTS': 'ttsOnly',
-          '🆙 只使用文本显示': 'textOnly',
-          '❌ 禁用': 'disabled',
-        },
-        ko: {
-          '🆙🔊 텍스트와 소리': 'textAndSound',
-          '🆙💬 텍스트와 TTS': 'ttsAndText',
-          '💬 TTS만': 'ttsOnly',
-          '🆙 텍스트만': 'textOnly',
-          '❌ 비활성화': 'disabled',
-        },
-      },
-      default: 'textAndSound',
-      setterFunc: setOptionsFromOutputValue,
-    },
+    defaultAlertOutput,
     {
       id: 'AlertsLanguage',
       name: {

--- a/ui/raidboss/raidboss_options.ts
+++ b/ui/raidboss/raidboss_options.ts
@@ -7,6 +7,7 @@ import {
   TriggerAutoConfig,
   TriggerField,
   TriggerOutput,
+  TriggerSetAutoConfig,
 } from '../../types/trigger';
 
 // This file defines the base options that raidboss expects to see.
@@ -34,6 +35,7 @@ export type TimelineConfig = Partial<{
 }>;
 
 export type PerTriggerAutoConfig = { [triggerId: string]: TriggerAutoConfig };
+export type PerTriggerSetAutoConfig = { [triggerSetId: string]: TriggerSetAutoConfig };
 export type PerTriggerOptions = { [triggerId: string]: PerTriggerOption };
 export type DisabledTriggers = { [triggerId: string]: boolean };
 export type PerZoneTimelineConfig = { [zoneId: number]: TimelineConfig };
@@ -49,6 +51,7 @@ type RaidbossNonConfigOptions = {
   AudioAllowed: boolean;
   DisabledTriggers: DisabledTriggers;
   PerTriggerAutoConfig: PerTriggerAutoConfig;
+  PerTriggerSetAutoConfig: PerTriggerSetAutoConfig;
   PerTriggerOptions: PerTriggerOptions;
   PerZoneTimelineConfig: PerZoneTimelineConfig;
   TriggerSetConfig: TriggerSetConfig;
@@ -74,6 +77,7 @@ const defaultRaidbossNonConfigOptions: RaidbossNonConfigOptions = {
   DisabledTriggers: {},
 
   PerTriggerAutoConfig: {},
+  PerTriggerSetAutoConfig: {},
   PerTriggerOptions: {},
   PerZoneTimelineConfig: {},
   TriggerSetConfig: {},


### PR DESCRIPTION
Every once in a while people ask for ways to override or disable a particular trigger set, so here you go.

If a trigger gets overridden from another trigger set, the overriding trigger set's options get used instead. This is probably not what people want, but it's consistent.