### PR TITLE
raidboss: remove bad DE Peridialogos translation

### DIFF
--- a/ui/raidboss/data/06-ew/raid/p12s.ts
+++ b/ui/raidboss/data/06-ew/raid/p12s.ts
@@ -1756,7 +1756,6 @@ const triggerSet: TriggerSet<Data> = {
         },
         tanksInPartyOut: {
           en: 'Tanks In (Party Out)',
-          de: 'Gruppe Rein (Tanks Raus)',
           fr: 'Tanks à l\'intérieur (Équipe à l\'extérieur',
           ja: 'ボスに足元へ (パーティーは離れる)',
           cn: 'T进 (小队出)',


### PR DESCRIPTION
Reported by user on Discord that the German translation for P12S Peridialogos trigger was backwards.  This removes the bad translation for now.