### PR TITLE
i18n: fix cn translation for trigger set config output

### DIFF
--- a/ui/raidboss/raidboss_config.ts
+++ b/ui/raidboss/raidboss_config.ts
@@ -1836,7 +1836,7 @@ const defaultTriggerSetAlertOutput = {
   name: {
     en: 'Default trigger set alert output',
     de: 'Standard trigger-Set Alert Ausgabe',
-    cn: '默认自定义触发器提示输出模式',
+    cn: '默认触发器集合提示输出模式',
     ko: '기본 트리거 세트 알람 출력 방식',
   },
 } as const;


### PR DESCRIPTION
This changes was proposed in #5733 but it is not correct.

@lsl1225 此選項意在指示 TriggerSet 即觸發器集合之整體的輸出形式，但似乎您理解爲使用者自定義觸發器的相關設定。事實上使用者自定義的觸發器與 cactbot 內建的觸發器在設定介面是沒有區別的。
Please review and give an approve if you agree the change in this fixup PR.