### PR TITLE
lint: upgrade dprint to ease china users install

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -52,7 +52,7 @@
         "cross-env": "^7.0.3",
         "css-loader": "^6.5.1",
         "css-minimizer-webpack-plugin": "^3.4.1",
-        "dprint": "^0.32.1",
+        "dprint": "^0.40.2",
         "eslint": "^8.26.0",
         "eslint-config-google": "^0.14.0",
         "eslint-import-resolver-typescript": "^3.5.2",
@@ -1770,17 +1770,95 @@
         "node": ">=10.0.0"
       }
     },
+    "node_modules/@dprint/darwin-arm64": {
+      "version": "0.40.2",
+      "resolved": "https://registry.npmjs.org/@dprint/darwin-arm64/-/darwin-arm64-0.40.2.tgz",
+      "integrity": "sha512-qharMFhxpNq9brgvHLbqzzAgVgPWSHLfzNLwWWhKcGOUUDUIilfAo3SlvOz6w4nQiIifLpYZOvZqK7Lpf9mSSw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@dprint/darwin-x64": {
+      "version": "0.40.2",
+      "resolved": "https://registry.npmjs.org/@dprint/darwin-x64/-/darwin-x64-0.40.2.tgz",
+      "integrity": "sha512-FPDdOTVr1JfqtLBTCvqlihWslTy3LBUoi3H1gaqIazCKMj2dB9voFWkBiMT+REMHDrlVsoSpFAfsliNr/y7HPA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
     "node_modules/@dprint/json": {
       "version": "0.16.0",
       "resolved": "https://registry.npmjs.org/@dprint/json/-/json-0.16.0.tgz",
       "integrity": "sha512-fUTPmg6lEAmua8/yBfYin5cqlyJNjfIxeLY38iyKLBr76csnp9A+EgXCmXjQB4M7YKrwQhi/cZ05i8MpkNLMGQ==",
       "dev": true
     },
+    "node_modules/@dprint/linux-arm64-glibc": {
+      "version": "0.40.2",
+      "resolved": "https://registry.npmjs.org/@dprint/linux-arm64-glibc/-/linux-arm64-glibc-0.40.2.tgz",
+      "integrity": "sha512-GmUWfKwEwXA+onvewX9hEJSMcd9V184+uRbEhI5tG28tBP9+IjQhrY7jCjxPvaZA+EvzNPnAy5D1wbJdlNLBNA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@dprint/linux-x64-glibc": {
+      "version": "0.40.2",
+      "resolved": "https://registry.npmjs.org/@dprint/linux-x64-glibc/-/linux-x64-glibc-0.40.2.tgz",
+      "integrity": "sha512-vMHAHdsOY+2thieSWbIrIioDfPgvipwUgd0MZUWOqycTrXU6kLyi2B+5J/2Jc+QO3CiLIbumQd2FH/0vB1eWqA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@dprint/linux-x64-musl": {
+      "version": "0.40.2",
+      "resolved": "https://registry.npmjs.org/@dprint/linux-x64-musl/-/linux-x64-musl-0.40.2.tgz",
+      "integrity": "sha512-nFSbDWd9ORyOhJ7a+RmE39WbuPoQ3OQutIgfAmfikiu/wENzEwxxv4QJ7aFnBaoZb0wuVEEpXShr8vY4p0exkg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
     "node_modules/@dprint/typescript": {
       "version": "0.75.0",
       "resolved": "https://registry.npmjs.org/@dprint/typescript/-/typescript-0.75.0.tgz",
       "integrity": "sha512-66Io2E2rHIJ8s6eiQfyXe7eGI7bmQac/njkq50IcUMboCRIftfJmXCQOKqjpB14pGnNvwPCNvMInsTS70NpFAQ==",
       "dev": true
+    },
+    "node_modules/@dprint/win32-x64": {
+      "version": "0.40.2",
+      "resolved": "https://registry.npmjs.org/@dprint/win32-x64/-/win32-x64-0.40.2.tgz",
+      "integrity": "sha512-qF4VCQzFTZYD61lbQqXLU/IwUTbLK22CancO+uVtXmZRoKU9GaVjcBhMUB7URxsa8rvxWHhHT6ldillI/aOWCg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ]
     },
     "node_modules/@eslint/eslintrc": {
       "version": "1.3.3",
@@ -3867,15 +3945,6 @@
         "ieee754": "^1.1.13"
       }
     },
-    "node_modules/buffer-crc32": {
-      "version": "0.2.13",
-      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
-      "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
-      "dev": true,
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/buffer-from": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
@@ -5581,16 +5650,21 @@
       }
     },
     "node_modules/dprint": {
-      "version": "0.32.1",
-      "resolved": "https://registry.npmjs.org/dprint/-/dprint-0.32.1.tgz",
-      "integrity": "sha512-HBG9npq+26QW1IjhLyMfX0qMwkIYREZqMByNmLL9O778rsyK54eTkXPhuIBeF1FA2VIoZg3t/5si6FRvDtoQmw==",
+      "version": "0.40.2",
+      "resolved": "https://registry.npmjs.org/dprint/-/dprint-0.40.2.tgz",
+      "integrity": "sha512-3LdyUV0itEW59UPtsRA2StOWOu8FyOW+BgvJpH/tACRHKi0z5gaQnvSxdS3mbG7dgtEhdRnGg6JoiQyGib6NTg==",
       "dev": true,
       "hasInstallScript": true,
-      "dependencies": {
-        "yauzl": "=2.10.0"
-      },
       "bin": {
         "dprint": "bin.js"
+      },
+      "optionalDependencies": {
+        "@dprint/darwin-arm64": "0.40.2",
+        "@dprint/darwin-x64": "0.40.2",
+        "@dprint/linux-arm64-glibc": "0.40.2",
+        "@dprint/linux-x64-glibc": "0.40.2",
+        "@dprint/linux-x64-musl": "0.40.2",
+        "@dprint/win32-x64": "0.40.2"
       }
     },
     "node_modules/ee-first": {
@@ -6765,15 +6839,6 @@
       },
       "engines": {
         "node": ">=0.8.0"
-      }
-    },
-    "node_modules/fd-slicer": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
-      "integrity": "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==",
-      "dev": true,
-      "dependencies": {
-        "pend": "~1.2.0"
       }
     },
     "node_modules/fetch-blob": {
@@ -12065,12 +12130,6 @@
         "node": "*"
       }
     },
-    "node_modules/pend": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
-      "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
-      "dev": true
-    },
     "node_modules/picocolors": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
@@ -16438,16 +16497,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/yauzl": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
-      "integrity": "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==",
-      "dev": true,
-      "dependencies": {
-        "buffer-crc32": "~0.2.3",
-        "fd-slicer": "~1.1.0"
-      }
-    },
     "node_modules/yn": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
@@ -17656,17 +17705,59 @@
       "integrity": "sha512-dBVuXR082gk3jsFp7Rd/JI4kytwGHecnCoTtXFb7DB6CNHp4rg5k1bhg0nWdLGLnOV71lmDzGQaLMy8iPLY0pw==",
       "dev": true
     },
+    "@dprint/darwin-arm64": {
+      "version": "0.40.2",
+      "resolved": "https://registry.npmjs.org/@dprint/darwin-arm64/-/darwin-arm64-0.40.2.tgz",
+      "integrity": "sha512-qharMFhxpNq9brgvHLbqzzAgVgPWSHLfzNLwWWhKcGOUUDUIilfAo3SlvOz6w4nQiIifLpYZOvZqK7Lpf9mSSw==",
+      "dev": true,
+      "optional": true
+    },
+    "@dprint/darwin-x64": {
+      "version": "0.40.2",
+      "resolved": "https://registry.npmjs.org/@dprint/darwin-x64/-/darwin-x64-0.40.2.tgz",
+      "integrity": "sha512-FPDdOTVr1JfqtLBTCvqlihWslTy3LBUoi3H1gaqIazCKMj2dB9voFWkBiMT+REMHDrlVsoSpFAfsliNr/y7HPA==",
+      "dev": true,
+      "optional": true
+    },
     "@dprint/json": {
       "version": "0.16.0",
       "resolved": "https://registry.npmjs.org/@dprint/json/-/json-0.16.0.tgz",
       "integrity": "sha512-fUTPmg6lEAmua8/yBfYin5cqlyJNjfIxeLY38iyKLBr76csnp9A+EgXCmXjQB4M7YKrwQhi/cZ05i8MpkNLMGQ==",
       "dev": true
     },
+    "@dprint/linux-arm64-glibc": {
+      "version": "0.40.2",
+      "resolved": "https://registry.npmjs.org/@dprint/linux-arm64-glibc/-/linux-arm64-glibc-0.40.2.tgz",
+      "integrity": "sha512-GmUWfKwEwXA+onvewX9hEJSMcd9V184+uRbEhI5tG28tBP9+IjQhrY7jCjxPvaZA+EvzNPnAy5D1wbJdlNLBNA==",
+      "dev": true,
+      "optional": true
+    },
+    "@dprint/linux-x64-glibc": {
+      "version": "0.40.2",
+      "resolved": "https://registry.npmjs.org/@dprint/linux-x64-glibc/-/linux-x64-glibc-0.40.2.tgz",
+      "integrity": "sha512-vMHAHdsOY+2thieSWbIrIioDfPgvipwUgd0MZUWOqycTrXU6kLyi2B+5J/2Jc+QO3CiLIbumQd2FH/0vB1eWqA==",
+      "dev": true,
+      "optional": true
+    },
+    "@dprint/linux-x64-musl": {
+      "version": "0.40.2",
+      "resolved": "https://registry.npmjs.org/@dprint/linux-x64-musl/-/linux-x64-musl-0.40.2.tgz",
+      "integrity": "sha512-nFSbDWd9ORyOhJ7a+RmE39WbuPoQ3OQutIgfAmfikiu/wENzEwxxv4QJ7aFnBaoZb0wuVEEpXShr8vY4p0exkg==",
+      "dev": true,
+      "optional": true
+    },
     "@dprint/typescript": {
       "version": "0.75.0",
       "resolved": "https://registry.npmjs.org/@dprint/typescript/-/typescript-0.75.0.tgz",
       "integrity": "sha512-66Io2E2rHIJ8s6eiQfyXe7eGI7bmQac/njkq50IcUMboCRIftfJmXCQOKqjpB14pGnNvwPCNvMInsTS70NpFAQ==",
       "dev": true
+    },
+    "@dprint/win32-x64": {
+      "version": "0.40.2",
+      "resolved": "https://registry.npmjs.org/@dprint/win32-x64/-/win32-x64-0.40.2.tgz",
+      "integrity": "sha512-qF4VCQzFTZYD61lbQqXLU/IwUTbLK22CancO+uVtXmZRoKU9GaVjcBhMUB7URxsa8rvxWHhHT6ldillI/aOWCg==",
+      "dev": true,
+      "optional": true
     },
     "@eslint/eslintrc": {
       "version": "1.3.3",
@@ -19355,12 +19446,6 @@
         "ieee754": "^1.1.13"
       }
     },
-    "buffer-crc32": {
-      "version": "0.2.13",
-      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
-      "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
-      "dev": true
-    },
     "buffer-from": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
@@ -20621,12 +20706,17 @@
       }
     },
     "dprint": {
-      "version": "0.32.1",
-      "resolved": "https://registry.npmjs.org/dprint/-/dprint-0.32.1.tgz",
-      "integrity": "sha512-HBG9npq+26QW1IjhLyMfX0qMwkIYREZqMByNmLL9O778rsyK54eTkXPhuIBeF1FA2VIoZg3t/5si6FRvDtoQmw==",
+      "version": "0.40.2",
+      "resolved": "https://registry.npmjs.org/dprint/-/dprint-0.40.2.tgz",
+      "integrity": "sha512-3LdyUV0itEW59UPtsRA2StOWOu8FyOW+BgvJpH/tACRHKi0z5gaQnvSxdS3mbG7dgtEhdRnGg6JoiQyGib6NTg==",
       "dev": true,
       "requires": {
-        "yauzl": "=2.10.0"
+        "@dprint/darwin-arm64": "0.40.2",
+        "@dprint/darwin-x64": "0.40.2",
+        "@dprint/linux-arm64-glibc": "0.40.2",
+        "@dprint/linux-x64-glibc": "0.40.2",
+        "@dprint/linux-x64-musl": "0.40.2",
+        "@dprint/win32-x64": "0.40.2"
       }
     },
     "ee-first": {
@@ -21535,15 +21625,6 @@
       "dev": true,
       "requires": {
         "websocket-driver": ">=0.5.1"
-      }
-    },
-    "fd-slicer": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
-      "integrity": "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==",
-      "dev": true,
-      "requires": {
-        "pend": "~1.2.0"
       }
     },
     "fetch-blob": {
@@ -25414,12 +25495,6 @@
       "integrity": "sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==",
       "dev": true
     },
-    "pend": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
-      "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
-      "dev": true
-    },
     "picocolors": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
@@ -28653,16 +28728,6 @@
           "integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==",
           "dev": true
         }
-      }
-    },
-    "yauzl": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
-      "integrity": "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==",
-      "dev": true,
-      "requires": {
-        "buffer-crc32": "~0.2.3",
-        "fd-slicer": "~1.1.0"
       }
     },
     "yn": {

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "cross-env": "^7.0.3",
     "css-loader": "^6.5.1",
     "css-minimizer-webpack-plugin": "^3.4.1",
-    "dprint": "^0.32.1",
+    "dprint": "^0.40.2",
     "eslint": "^8.26.0",
     "eslint-config-google": "^0.14.0",
     "eslint-import-resolver-typescript": "^3.5.2",


### PR DESCRIPTION
Historically the dprint package downloads binary from github release, which is blocked in some china areas, but in the new version, they push the dprint binary directly to npmjs.com which is much easier to download for china users, so we can just upgrade dprint.