### PR TITLE
raidboss: p12s classic2 option to call actual w/no flip

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -6,6 +6,7 @@
 *.mp3 binary
 *.wav binary
 *.webm binary
+*.gif binary
 
 # Set the language for these files to jsonc to ensure GitHub doesn't show the comments as errors
 .vscode/*.json         linguist-language=jsonc

--- a/ui/raidboss/data/06-ew/raid/p12s.ts
+++ b/ui/raidboss/data/06-ew/raid/p12s.ts
@@ -452,7 +452,7 @@ const triggerSet: TriggerSet<Data> = {
       id: 'classicalConcepts2ActualNoFlip',
       comment: {
         en:
-          'Suppresses initial output & calls final position immediately in chosen pair order (e.g. no flip).  <a href="https://user-images.githubusercontent.com/67395342/258580930-1659573f-a492-4839-a275-e51449bb85c0.gif" target="_blank">Visual</a>',
+          'Only calls final position immediately in chosen pair order with no flip. For example, for BPOG, the blue X (crosses) will be far west. <a href="https://quisquous.github.io/cactbot/resources/images/06ew_raid_p12s_classic2_noflip.gif" target="_blank">Visual</a>',
       },
       name: {
         en: 'Classical Concepts 2: Actual only & no inversion',

--- a/ui/raidboss/data/06-ew/raid/p12s.ts
+++ b/ui/raidboss/data/06-ew/raid/p12s.ts
@@ -3168,8 +3168,6 @@ const triggerSet: TriggerSet<Data> = {
         }
         // the initial call is not being suppressed, so call it for classical2
         if (matches.id === '8331') {
-          if (data.triggerSetConfig.classicalConcepts2InitialSuppress)
-            return;
           outputStr = output.classic2initial!({
             column: output[columnOutput]!(),
             row: output[rowOutput]!(),


### PR DESCRIPTION
Closes #5752 -- adds a config checkbox so that the 'Actual' (final) correct position during classical2 will be called out on the classical2 cast, and no follow up alert during Panta Rhei.