### PR TITLE
raidboss: Add JA translations for DSR Gigaflare

### DIFF
--- a/ui/raidboss/data/06-ew/ultimate/dragonsongs_reprise_ultimate.ts
+++ b/ui/raidboss/data/06-ew/ultimate/dragonsongs_reprise_ultimate.ts
@@ -2834,7 +2834,7 @@ const triggerSet: TriggerSet<Data> = {
         directions: {
           en: '${start} => ${rotation}',
           de: '${start} => ${rotation}',
-          ja: '${start} → ${rotation}',
+          ja: '${start} => ${rotation}',
           cn: '${start} => ${rotation}',
           ko: '${start} => ${rotation}',
         },

--- a/ui/raidboss/data/06-ew/ultimate/dragonsongs_reprise_ultimate.ts
+++ b/ui/raidboss/data/06-ew/ultimate/dragonsongs_reprise_ultimate.ts
@@ -2834,24 +2834,28 @@ const triggerSet: TriggerSet<Data> = {
         directions: {
           en: '${start} => ${rotation}',
           de: '${start} => ${rotation}',
+          ja: '${start} → ${rotation}',
           cn: '${start} => ${rotation}',
           ko: '${start} => ${rotation}',
         },
         backLeft: {
           en: 'Back left',
           de: 'Hinten links',
+          ja: '左後ろ',
           cn: '左后',
           ko: '뒤 왼쪽',
         },
         backRight: {
           en: 'Back right',
           de: 'Hinten rechts',
+          ja: '右後ろ',
           cn: '右后',
           ko: '뒤 오른쪽',
         },
         front: {
           en: 'Front',
           de: 'Vorne',
+          ja: '前',
           cn: '前',
           ko: '앞',
         },


### PR DESCRIPTION
Japanese translations for `directions`, `backLeft`, `backRight`, and `front`.
Arrow symbol `→` at `directions` can be `=>` for consistency, though `→` is more common in Japanese context.