### PR TITLE
plugin: update DEPS.json5

### DIFF
--- a/plugin/CactbotEventSource/CactbotEventSource.cs
+++ b/plugin/CactbotEventSource/CactbotEventSource.cs
@@ -43,7 +43,7 @@ namespace Cactbot {
     private Version overlay_plugin_version_;
     private Version ffxiv_plugin_version_;
     private Version act_version_;
-    private GameRegion game_region_ = GameRegion.International;
+    private Cactbot.VersionChecker.GameRegion game_region_ = Cactbot.VersionChecker.GameRegion.International;
 
     public delegate void ForceReloadHandler(JSEvents.ForceReloadEvent e);
     public event ForceReloadHandler OnForceReload;
@@ -249,11 +249,11 @@ namespace Cactbot {
 
       switch (game_region_)
       {
-        case GameRegion.Chinese:
+        case Cactbot.VersionChecker.GameRegion.Chinese:
           ffxiv_ = new FFXIVProcessCn(this.logger);
           logger.Log(LogLevel.Info, Strings.Version, "cn");
           break;
-        case GameRegion.Korean:
+        case Cactbot.VersionChecker.GameRegion.Korean:
           ffxiv_ = new FFXIVProcessKo(this.logger);
           logger.Log(LogLevel.Info, Strings.Version, "ko");
           break;

--- a/util/DEPS.json5
+++ b/util/DEPS.json5
@@ -9,7 +9,7 @@
         "hash": ["sha256", "8822e08147a44d0b82548068033dc18177c1fac993e8564e1ac32ed94c570e08"],
     },
     "FFXIV_ACT": {
-        "url": "https://github.com/ravahn/FFXIV_ACT_Plugin/raw/master/Releases/FFXIV_ACT_Plugin_SDK_2.6.9.3.zip",
+        "url": "https://github.com/ravahn/FFXIV_ACT_Plugin/raw/master/Releases/FFXIV_ACT_Plugin_SDK_2.4.2.1.zip",
         "dest": "plugin/ThirdParty/FFXIV_ACT",
         "strip": 0,
         "hash": ["sha256", "76fa369d0c1c6f9ab8afa01bf657a7dcf611324f15cf380fbe6a4dc0e150bcc5"],

--- a/util/DEPS.json5
+++ b/util/DEPS.json5
@@ -3,21 +3,21 @@
 //   I just borrowed the basic concept and naming scheme.
 {
     "ACT": {
-        "url": "https://github.com/EQAditu/AdvancedCombatTracker/releases/download/3.4.6.267/ACTv3.zip",
+        "url": "https://github.com/EQAditu/AdvancedCombatTracker/releases/download/3.6.2.279/ACTv3.zip",
         "dest": "plugin/ThirdParty/ACT",
         "strip": 0,
-        "hash": ["sha256", "b97b92b82e29a532611ca5319061df54516fd71b691c1c507ba69da5b3985fad"],
+        "hash": ["sha256", "8822e08147a44d0b82548068033dc18177c1fac993e8564e1ac32ed94c570e08"],
     },
     "FFXIV_ACT": {
-        "url": "https://github.com/ravahn/FFXIV_ACT_Plugin/raw/master/Releases/FFXIV_ACT_Plugin_SDK_2.0.6.1.zip",
+        "url": "https://github.com/ravahn/FFXIV_ACT_Plugin/raw/master/Releases/FFXIV_ACT_Plugin_SDK_2.6.9.3.zip",
         "dest": "plugin/ThirdParty/FFXIV_ACT",
         "strip": 0,
-        "hash": ["sha256", "ed98fa01ec2c7ed2ac843fa8ea2eec1d66f86fad4c6864de4d73d5cfbf163dce"],
+        "hash": ["sha256", "76fa369d0c1c6f9ab8afa01bf657a7dcf611324f15cf380fbe6a4dc0e150bcc5"],
     },
     "OverlayPlugin": {
-        "url": "https://github.com/ngld/OverlayPlugin/releases/download/v0.18.2/OverlayPlugin-0.18.2.zip",
+        "url": "https://github.com/OverlayPlugin/OverlayPlugin/releases/download/v0.19.21/OverlayPlugin-0.19.21.zip",
         "dest": "plugin/ThirdParty/OverlayPlugin",
         "strip": 1,
-        "hash": ["sha256", "26efb161179d92806f42c39cb8b4f8b91ed5ddc4a2bf764301abc847f5974bfc"],
+        "hash": ["sha256", "5abd855169dc02bb8a337bdff511f24e1ed0b783dca197bdce3e9ec160735624"],
     },
 }

--- a/util/DEPS.json5
+++ b/util/DEPS.json5
@@ -9,10 +9,10 @@
         "hash": ["sha256", "8822e08147a44d0b82548068033dc18177c1fac993e8564e1ac32ed94c570e08"],
     },
     "FFXIV_ACT": {
-        "url": "https://github.com/ravahn/FFXIV_ACT_Plugin/raw/master/Releases/FFXIV_ACT_Plugin_SDK_2.4.2.1.zip",
+        "url": "https://github.com/ravahn/FFXIV_ACT_Plugin/raw/master/Releases/FFXIV_ACT_Plugin_SDK_2.2.1.6.zip",
         "dest": "plugin/ThirdParty/FFXIV_ACT",
         "strip": 0,
-        "hash": ["sha256", "76fa369d0c1c6f9ab8afa01bf657a7dcf611324f15cf380fbe6a4dc0e150bcc5"],
+        "hash": ["sha256", "9a801d2df30c186b3915cb75dd12d1c75e559de09f71038bf1f68f7d8a3aa34a"],
     },
     "OverlayPlugin": {
         "url": "https://github.com/OverlayPlugin/OverlayPlugin/releases/download/v0.19.21/OverlayPlugin-0.19.21.zip",


### PR DESCRIPTION
After updateing DEPS.json5, i got following compilation error: 'CactbotEventSource.cs(46,13): error CS0104: "GameRegion" ist ein mehrdeutiger Verweis zwischen "Cactbot.VersionChecker.GameRegion" und "RainbowMage.OverlayPlugin.GameRegion"' thats why i touched CactbotEventSource.cs