### PR TITLE
build/docs: Updated ttypescript version

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -79,8 +79,8 @@ in order to install local versions of husky, lint-staged, and eslint.
 It is recommended that you also install ts-node and typescript globally, e.g.
 
 ```shell
-npm install -g typescript@4.6.4
-npm install -g ts-node@10.8.0
+npm install -g typescript
+npm install -g ts-node
 ```
 
 This will let you run commands as `ts-node` directly instead of `npx ts-node`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -79,8 +79,8 @@ in order to install local versions of husky, lint-staged, and eslint.
 It is recommended that you also install ts-node and typescript globally, e.g.
 
 ```shell
-npm install -g typescript
-npm install -g ts-node
+npm install -g typescript@4.6.4
+npm install -g ts-node@10.8.0
 ```
 
 This will let you run commands as `ts-node` directly instead of `npx ts-node`.

--- a/README.md
+++ b/README.md
@@ -246,8 +246,9 @@ To install npm and start Webpack, follow these steps:
 1. Run `npm install` in the root of the cactbot directory.
 1. Run `npm run build` or `npm start`.
 
-Cactbot should always work with the latest LTS release
-If this is not the case, file an issue
+Cactbot should always work with the latest LTS release.
+
+If this is not the case, file an issue.
 
 See the [contributing](CONTRIBUTING.md#validating-changes-via-webpack) documentation
 for more details about using Webpack.

--- a/README.md
+++ b/README.md
@@ -242,7 +242,7 @@ instead of changing your local cactbot files.
 
 To install npm and start Webpack, follow these steps:
 
-1. Install [nodejs and npm](https://nodejs.org/en/download/)
+1. Install [nodejs 18.17.1 and npm 9.6.7](https://nodejs.org/en/download/)
 1. Run `npm install` in the root of the cactbot directory.
 1. Run `npm run build` or `npm start`.
 

--- a/README.md
+++ b/README.md
@@ -242,9 +242,12 @@ instead of changing your local cactbot files.
 
 To install npm and start Webpack, follow these steps:
 
-1. Install [nodejs 18.17.1 and npm 9.6.7](https://nodejs.org/en/download/)
+1. Install [nodejs LTS and npm](https://nodejs.org/en/download/)
 1. Run `npm install` in the root of the cactbot directory.
 1. Run `npm run build` or `npm start`.
+
+Cactbot should always work with the latest LTS release
+If this is not the case, file an issue
 
 See the [contributing](CONTRIBUTING.md#validating-changes-via-webpack) documentation
 for more details about using Webpack.

--- a/package-lock.json
+++ b/package-lock.json
@@ -87,7 +87,7 @@
         "ts-loader": "^9.3.0",
         "ts-node": "^10.8.0",
         "tsconfig-paths": "^3.9.0",
-        "ttypescript": "^1.5.12",
+        "ttypescript": "^1.5.15",
         "typescript": "^4.6.4",
         "webpack": "^5.76.0",
         "webpack-cli": "^4.9.2",
@@ -15279,9 +15279,9 @@
       "dev": true
     },
     "node_modules/ttypescript": {
-      "version": "1.5.13",
-      "resolved": "https://registry.npmjs.org/ttypescript/-/ttypescript-1.5.13.tgz",
-      "integrity": "sha512-KT/RBfGGlVJFqEI8cVvI3nMsmYcFvPSZh8bU0qX+pAwbi7/ABmYkzn7l/K8skw0xmYjVCoyaV6WLsBQxdadybQ==",
+      "version": "1.5.15",
+      "resolved": "https://registry.npmjs.org/ttypescript/-/ttypescript-1.5.15.tgz",
+      "integrity": "sha512-48ykDNHzFnPMnv4hYX1P8Q84TvCZyL1QlFxeuxsuZ48X2+ameBgPenvmCkHJtoOSxpoWTWi8NcgNrRnVDOmfSg==",
       "dev": true,
       "dependencies": {
         "resolve": ">=1.9.0"
@@ -27840,9 +27840,9 @@
       }
     },
     "ttypescript": {
-      "version": "1.5.13",
-      "resolved": "https://registry.npmjs.org/ttypescript/-/ttypescript-1.5.13.tgz",
-      "integrity": "sha512-KT/RBfGGlVJFqEI8cVvI3nMsmYcFvPSZh8bU0qX+pAwbi7/ABmYkzn7l/K8skw0xmYjVCoyaV6WLsBQxdadybQ==",
+      "version": "1.5.15",
+      "resolved": "https://registry.npmjs.org/ttypescript/-/ttypescript-1.5.15.tgz",
+      "integrity": "sha512-48ykDNHzFnPMnv4hYX1P8Q84TvCZyL1QlFxeuxsuZ48X2+ameBgPenvmCkHJtoOSxpoWTWi8NcgNrRnVDOmfSg==",
       "dev": true,
       "requires": {
         "resolve": ">=1.9.0"

--- a/package.json
+++ b/package.json
@@ -111,7 +111,7 @@
     "ts-loader": "^9.3.0",
     "ts-node": "^10.8.0",
     "tsconfig-paths": "^3.9.0",
-    "ttypescript": "^1.5.12",
+    "ttypescript": "^1.5.15",
     "typescript": "^4.6.4",
     "webpack": "^5.76.0",
     "webpack-cli": "^4.9.2",


### PR DESCRIPTION
Tested with a fresh environment on node 18.17.1. As was mentioned in #5764 , I also added version numbers to the recommended global packages in CONTRIBUTING (the same ones as in package.json), and version numbers to the README for nodejs and npm (current LTS).  
Apologies if I used the wrong label for this PR.