### PR TITLE
raidboss: text in alerts lang, not display lang

### DIFF
--- a/ui/raidboss/popup-text.ts
+++ b/ui/raidboss/popup-text.ts
@@ -921,7 +921,7 @@ export class PopupText {
 
     trigger.output = TriggerOutputProxy.makeOutput(
       trigger,
-      this.options.DisplayLanguage,
+      this.options.AlertsLanguage ?? this.options.DisplayLanguage,
       this.options.PerTriggerAutoConfig,
     );
   }

--- a/ui/raidboss/popup-text.ts
+++ b/ui/raidboss/popup-text.ts
@@ -921,7 +921,7 @@ export class PopupText {
 
     trigger.output = TriggerOutputProxy.makeOutput(
       trigger,
-      this.options.AlertsLanguage ?? this.options.DisplayLanguage,
+      this.displayLang,
       this.options.PerTriggerAutoConfig,
     );
   }


### PR DESCRIPTION
before:
![image](https://github.com/quisquous/cactbot/assets/33572696/38dda013-3605-4663-9b41-87878e247a89)

now:
![image](https://github.com/quisquous/cactbot/assets/33572696/dd7e5982-3235-4ec8-816f-77f42e80b742)
