### PR TITLE
plugin: disable strong name req for FFXIV_ACT_Plugin.Common

### DIFF
--- a/plugin/CactbotEventSource/CactbotEventSource.csproj
+++ b/plugin/CactbotEventSource/CactbotEventSource.csproj
@@ -54,8 +54,9 @@
     <Reference Include="Advanced Combat Tracker">
       <HintPath>..\ThirdParty\ACT\Advanced Combat Tracker.exe</HintPath>
     </Reference>
-    <Reference Include="FFXIV_ACT_Plugin.Common">
+    <Reference Include="FFXIV_ACT_Plugin.Common, Version=2.2.0.5, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\ThirdParty\FFXIV_ACT\SDK\FFXIV_ACT_Plugin.Common.dll</HintPath>
+      <SpecificVersion>False</SpecificVersion>
     </Reference>
     <Reference Include="HtmlRenderer, Version=0.11.4.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>


### PR DESCRIPTION
CN players use a modified FFXIV_ACT_Plugin to parse the game. (https://github.com/TundraWork/FFXIV_ACT_Plugin_CN)
This modified plugin do not have strong name, so cactbot report an error like this:
```
[2023/9/23 15:22:11] Error: LoadAddons: CactbotOverlay.dll: System.IO.FileLoadException: Could not load file or assembly 'FFXIV_ACT_Plugin.Common, Version=2.2.0.5, Culture=neutral, PublicKeyToken=9f740ac505d6bc50' or one of its dependencies. A strongly-named assembly is required. (Exception from HRESULT: 0x80131044)
File name: 'FFXIV_ACT_Plugin.Common, Version=2.2.0.5, Culture=neutral, PublicKeyToken=9f740ac505d6bc50' ---> System.IO.FileLoadException: A strongly-named assembly is required. (Exception from HRESULT: 0x80131044)
   at Cactbot.FFXIVPlugin.RegisterProcessChangedHandler(Action`1 handler)
   at Cactbot.CactbotEventSource.Start()
   at RainbowMage.OverlayPlugin.Registry.StartEventSource[T](T source)
   at RainbowMage.OverlayPlugin.PluginMain.LoadAddons()
```
I remove the strong name in `\plugin\ThirdParty\FFXIV_ACT\SDK\FFXIV_ACT_Plugin.Common.dll` and the config file is autoly changed like this. I rebuild the dll and the problem solved.
I'm not familiar with .net and not sure does this fully handled by this option, if something amiss pray tell me.