### PR TITLE
raidboss/oopsy: Thordan EX

### DIFF
--- a/ui/oopsyraidsy/data/03-hw/trial/thordan-ex.ts
+++ b/ui/oopsyraidsy/data/03-hw/trial/thordan-ex.ts
@@ -7,7 +7,8 @@ const triggerSet: OopsyTriggerSet<OopsyData> = {
   zoneId: ZoneId.TheMinstrelsBalladThordansReign,
   damageWarn: {
     'ThordanEX Meteorain': '1484', // Targeted puddle AoEs, phase 1
-    'ThordanEX Ascalons Mercy': '1480', // Fan-shaped conal AoEs
+    'ThordanEX Ascalons Mercy 1': '147F', // Fan-shaped conal AoEs
+    'ThordanEX Ascalons Mercy 2': '1480', // Fan-shaped conal AoEs
     'ThordanEX Charibert Heavensflame': '14AC', // Targeted puddle AoEs, phases 2/6
     'ThordanEX Spiral Thrust': '14A6', // Cross-arena dashes, Ignasse/Paulecrain/Vellguine
     'ThordanEX Grinnaux Dimensional Collapse': '149A', // Gravity puddles
@@ -15,13 +16,15 @@ const triggerSet: OopsyTriggerSet<OopsyData> = {
     'ThordanEX Guerrique Heavy Impact 2': '14A1', // Earth ring small
     'ThordanEX Guerrique Heavy Impact 3': '14A2', // Earth ring large
     'ThordanEX Guerrique Heavy Impact 4': '14A3', // Earth ring giant
-    'ThordanEX Noudenet Comet': '14B5', // Targeted puddle AoEs, phases 2/6
+    'ThordanEX Charibert Holy Chain': '14AD', // Failure to break chains on time
   },
   damageFail: {
+    'ThordanEX Hermenost Eternal Conviction': '149E', // Missed towers
     'ThordanEX Comet Circle Comet Impact': '14B3', // Small meteor enrage, might not be survivable
   },
-  gainsEffectFail: {
-    'ThordanEX Hermenost Eternal Conviction': '149E', // Missed towers
+  gainsEffectWarn: {
+    'ThordanEX Frostbite': '10C', // Standing in Hiemal Storm ice puddles
+    'ThordanEX Hysteria': '128', // Gaze mechanic failure
   },
   shareWarn: {
     'ThordanEX Ascalons Might': '147E', // Instant tank cleave
@@ -29,6 +32,7 @@ const triggerSet: OopsyTriggerSet<OopsyData> = {
     'ThordanEX Heavenly Slash': '1494', // Cleaving mini-buster, Adelphel/Janlenoux, phase 2
     'ThordanEX Haumeric Hiemal Storm': '14AF', // Ice spread circles, Haumeric, phase 2/6
     'ThordanEX Spiral Pierce': '14A7', // Tethered line AoEs, Ignasse/Paulecrain/Vellguine
+    'ThordanEX Noudenet Comet': '14B5', // Targeted puddle AoEs, phases 2/6
   },
   soloWarn: {
     'ThordanEX Dragons Rage': '148B', // Standard stack marker
@@ -44,12 +48,12 @@ const triggerSet: OopsyTriggerSet<OopsyData> = {
           id: matches.targetId,
           name: matches.target,
           text: {
-            en: 'Knocked off',
-            de: 'Runtergefallen',
-            fr: 'Renversé(e)',
-            ja: 'ノックバック',
-            cn: '击退坠落',
-            ko: '넉백',
+            en: 'Pushed into wall',
+            de: 'Rückstoß in die Wand',
+            fr: 'Poussé(e) dans le mur',
+            ja: '壁へノックバック',
+            cn: '击退至墙',
+            ko: '벽으로 넉백',
           },
         };
       },

--- a/ui/oopsyraidsy/data/03-hw/trial/thordan-ex.ts
+++ b/ui/oopsyraidsy/data/03-hw/trial/thordan-ex.ts
@@ -1,0 +1,60 @@
+import NetRegexes from '../../../../../resources/netregexes';
+import ZoneId from '../../../../../resources/zone_id';
+import { OopsyData } from '../../../../../types/data';
+import { OopsyTriggerSet } from '../../../../../types/oopsy';
+
+const triggerSet: OopsyTriggerSet<OopsyData> = {
+  zoneId: ZoneId.TheMinstrelsBalladThordansReign,
+  damageWarn: {
+    'ThordanEX Meteorain': '1484', // Targeted puddle AoEs, phase 1
+    'ThordanEX Ascalons Mercy': '1480', // Fan-shaped conal AoEs
+    'ThordanEX Charibert Heavensflame': '14AC', // Targeted puddle AoEs, phases 2/6
+    'ThordanEX Spiral Thrust': '14A6', // Cross-arena dashes, Ignasse/Paulecrain/Vellguine
+    'ThordanEX Grinnaux Dimensional Collapse': '149A', // Gravity puddles
+    'ThordanEX Guerrique Heavy Impact 1': '14A0', // Earth ring tiny
+    'ThordanEX Guerrique Heavy Impact 2': '14A1', // Earth ring small
+    'ThordanEX Guerrique Heavy Impact 3': '14A2', // Earth ring large
+    'ThordanEX Guerrique Heavy Impact 4': '14A3', // Earth ring giant
+    'ThordanEX Noudenet Comet': '14B5', // Targeted puddle AoEs, phases 2/6
+  },
+  damageFail: {
+    'ThordanEX Comet Circle Comet Impact': '14B3', // Small meteor enrage, might not be survivable
+  },
+  gainsEffectFail: {
+    'ThordanEX Hermenost Eternal Conviction': '149E', // Missed towers
+  },
+  shareWarn: {
+    'ThordanEX Ascalons Might': '147E', // Instant tank cleave
+    'ThordanEX Lightning Storm': '1482', // Lightning spread markers
+    'ThordanEX Heavenly Slash': '1494', // Cleaving mini-buster, Adelphel/Janlenoux, phase 2
+    'ThordanEX Haumeric Hiemal Storm': '14AF', // Ice spread circles, Haumeric, phase 2/6
+    'ThordanEX Spiral Pierce': '14A7', // Tethered line AoEs, Ignasse/Paulecrain/Vellguine
+  },
+  soloWarn: {
+    'ThordanEX Dragons Rage': '148B', // Standard stack marker
+    'ThordanEX Zephirin Spear Of The Fury': '1492', // Wild Charge
+  },
+  triggers: [
+    {
+      id: 'ThordanEx Grinnaux Faith Unmoving',
+      type: 'Ability',
+      netRegex: NetRegexes.ability({ id: '149B' }),
+      deathReason: (_data, matches) => {
+        return {
+          id: matches.targetId,
+          name: matches.target,
+          text: {
+            en: 'Knocked off',
+            de: 'Runtergefallen',
+            fr: 'Renversé(e)',
+            ja: 'ノックバック',
+            cn: '击退坠落',
+            ko: '넉백',
+          },
+        };
+      },
+    },
+  ],
+};
+
+export default triggerSet;

--- a/ui/raidboss/data/03-hw/trial/thordan-ex.ts
+++ b/ui/raidboss/data/03-hw/trial/thordan-ex.ts
@@ -217,8 +217,8 @@ const triggerSet: TriggerSet<Data> = {
         },
         doubleGaze: {
           en: 'Look away from Thordan and Eye',
-        }
-      }
+        },
+      },
     },
     {
       id: 'ThordanEX Conviction Towers',
@@ -237,7 +237,11 @@ const triggerSet: TriggerSet<Data> = {
     {
       id: 'ThordanEX Triple Spiral Thrust Call',
       type: 'Ability',
-      netRegex: { id: '1018', source: ['Ser Ignasse', 'Ser Paulecrain', 'Ser Vellguine'], capture: false }, // Shared ability from all knights when they teleport in.
+      netRegex: {
+        id: '1018',
+        source: ['Ser Ignasse', 'Ser Paulecrain', 'Ser Vellguine'],
+        capture: false,
+      }, // Shared ability from all knights when they teleport in.
       condition: (data) => data.phase === 2 && !data.seenThrust,
       delaySeconds: 0.5,
       infoText: (data, _matches, output) => {
@@ -280,7 +284,7 @@ const triggerSet: TriggerSet<Data> = {
       outputStrings: {
         attackSword: {
           en: 'Attack ${swordKnight}',
-        }
+        },
       },
     },
     {
@@ -299,13 +303,13 @@ const triggerSet: TriggerSet<Data> = {
     {
       id: 'ThordanEX Holy Bladedance Collect',
       type: 'StartsUsing',
-      netRegex: { id: '1496', source: ['Ser Adelphel', 'Ser Janlenoux'], },
+      netRegex: { id: '1496', source: ['Ser Adelphel', 'Ser Janlenoux'] },
       run: (data, matches) => {
         if (data.swordKnight === matches.source)
           data.swordTarget = matches.target;
         if (data.shieldKnight === matches.source)
           data.shieldTarget = matches.target;
-      }
+      },
     },
     {
       id: 'ThordanEX Holy Bladedance Call',
@@ -330,7 +334,7 @@ const triggerSet: TriggerSet<Data> = {
       },
       outputStrings: {
         unknownDance: {
-          en: 'Heavy busters'
+          en: 'Heavy busters',
         },
         singleDance: {
           en: '2x buster on ${target}',
@@ -338,7 +342,7 @@ const triggerSet: TriggerSet<Data> = {
         doubleDance: {
           en: 'Sword buster on ${sword} (shield on ${shield})',
         },
-      }
+      },
     },
     {
       id: 'ThordanEX Skyward Leap',
@@ -389,7 +393,7 @@ const triggerSet: TriggerSet<Data> = {
         },
         pierceOthers: {
           en: 'Avoid tether line AoEs',
-        }
+        },
       },
     },
     {
@@ -445,8 +449,8 @@ const triggerSet: TriggerSet<Data> = {
           en: 'Wild Charge: STAY OUT',
         },
         spearOther: {
-          en: 'Wild Charge: Intercept ${spearTarget}'
-        }
+          en: 'Wild Charge: Intercept ${spearTarget}',
+        },
       },
     },
     {
@@ -465,8 +469,8 @@ const triggerSet: TriggerSet<Data> = {
         const knightDir = Directions.outputFrom8DirNum(knightNum);
         const [dir1, dir2] = [knightDir, unsafeMap[knightDir]].sort();
         if (dir1 === undefined || dir2 === undefined)
-        return;
-      return output.combined!({ dir1: output[dir1]!(), dir2: output[dir2]!() });
+          return;
+        return output.combined!({ dir1: output[dir1]!(), dir2: output[dir2]!() });
       },
       outputStrings: {
         combined: {
@@ -493,7 +497,7 @@ const triggerSet: TriggerSet<Data> = {
         },
         ...fullDirNameMap,
       },
-    }
+    },
   ],
 
   timelineReplace: [

--- a/ui/raidboss/data/03-hw/trial/thordan-ex.ts
+++ b/ui/raidboss/data/03-hw/trial/thordan-ex.ts
@@ -1,0 +1,305 @@
+import Conditions from '../../../../../resources/conditions';
+import { Responses } from '../../../../../resources/responses';
+import ZoneId from '../../../../../resources/zone_id';
+import { RaidbossData } from '../../../../../types/data';
+import { TriggerSet } from '../../../../../types/trigger';
+
+
+export interface Data extends RaidbossData {
+  phase: number;
+  swordKnight?: string;
+  swordTarget?: string;
+  shieldKnight?: string;
+  shieldTarget?: string;
+  pierceTargets: string[];
+}
+
+const triggerSet: TriggerSet<Data> = {
+  id: 'TheMinstrelsBalladThordansReign',
+  zoneId: ZoneId.TheMinstrelsBalladThordansReign,
+  timelineFile: 'thordan-ex.txt',
+  initData: () => {
+    return {
+      phase: 1,
+      pierceTargets: [],
+    };
+  },
+  timelineTriggers: [
+    {
+      id: 'ThordanEX Ascalons Might',
+      regex: /Ascalon's Might/,
+      beforeSeconds: 4,
+      response: Responses.tankCleave(),
+    },
+    {
+      // This is timed off the towers appearing,
+      // so having no beforeSeconds parameter is correct.
+      id: 'ThordanEX Conviction',
+      regex: /--towers spawn--/,
+      response: Responses.getTowers(),
+    },
+    {
+      id: 'ThordanEX Heavenly Slash',
+      regex: /Heavenly Slash/,
+      beforeSeconds: 4,
+      response: Responses.tankCleave(),
+    },
+    {
+      id: 'ThordanEX Faith Unmoving',
+      regex: /Faith Unmoving/,
+      beforeSeconds: 5,
+      response: Responses.knockback(),
+    },
+    {
+      id: 'ThordanEX Dimensional Collapse',
+      regex: /Dimensional Collapse/,
+      beforeSeconds: 10,
+      alertText: (_data, _matches, output) => output.baitPuddles!(),
+      outputStrings: {
+        baitPuddles: {
+          en: 'Bait gravity puddles',
+        },
+      },
+    },
+    {
+      id: 'ThordanEX Light Of Ascalon',
+      regex: /The Light of Ascalon 1/,
+      beforeSeconds: 5,
+      infoText: (_data, _matches, output) => output.knockbackAoe!(),
+      outputStrings: {
+        knockbackAoe: {
+          en: 'AOE + knockback x7',
+        },
+      },
+    },
+    {
+      id: 'ThordanEX Ultimate End',
+      regex: /Ultimate End/,
+      beforeSeconds: 6,
+      response: Responses.bigAoe(),
+    },
+  ],
+  triggers: [
+    // Phase tracking
+    {
+      // Cue off Thordan's movement ability alongside him going untargetable
+      id: 'ThordanEX Intermission Phase',
+      type: 'Ability',
+      netRegex: { id: '105A', source: 'King Thordan', capture: false },
+      run: (data) => data.phase = 2,
+    },
+    {
+      // Cue off Knights of the Round
+      id: 'ThordanEX Post-Intermission Phase Tracker',
+      type: 'Ability',
+      netRegex: { id: '148C', source: 'King Thordan', capture: false },
+      run: (data) => data.phase += 1,
+    },
+    {
+      id: 'ThordanEX Lightning Storm',
+      type: 'HeadMarker',
+      netRegex: { id: '0018' },
+      condition: Conditions.targetIsYou(),
+      response: Responses.spread(),
+    },
+    {
+      id: 'ThordanEX Dragons Rage',
+      type: 'HeadMarker',
+      netRegex: { id: '003E' },
+      condition: Conditions.targetIsYou(),
+      response: Responses.stackMarkerOn(),
+    },
+    {
+      id: 'ThordanEX Ancient Quaga',
+      type: 'StartsUsing',
+      netRegex: { id: '1485', source: 'King Thordan', capture: false },
+      response: Responses.aoe(),
+    },
+    {
+      id: 'ThordanEX Heavenly Heel',
+      type: 'StartsUsing',
+      netRegex: { id: '1487', source: 'King Thordan' },
+      response: Responses.tankBuster(),
+    },
+    {
+      id: 'ThordanEX Dragons Gaze',
+      type: 'StartsUsing',
+      netRegex: { id: '1489', source: 'King Thordan', capture: false },
+      alertText: (data, _matches, output) => {
+        if (data.phase === 1)
+          return output.singleGaze!();
+        return output.doubleGaze!();
+      },
+      outputStrings: {
+        // We could do some composition magic to make this more "elegant",
+        // but for ease of translation it's best to just define fixed output strings.
+        singleGaze: {
+          en: 'Look away from Thordan',
+        },
+        doubleGaze: {
+          en: 'Look away from Thordan and Eye',
+        }
+      }
+    },
+    {
+      id: 'ThordanEX Conviction Towers',
+      type: 'StartsUsing',
+      netRegex: { id: '149D', source: 'Ser Hermenost', capture: false },
+      suppressSeconds: 5,
+      response: Responses.getTowers(),
+    },
+    {
+      id: 'ThordanEX Sword Of The Heavens',
+      type: 'GainsEffect',
+      netRegex: { effectId: '3B0' },
+      infoText: (_data, matches, output) => output.attackSword!({ swordKnight: matches.target }),
+      run: (data, matches) => data.swordKnight = matches.target,
+      outputStrings: {
+        attackSword: {
+          en: 'Attack ${swordKnight}',
+        }
+      },
+    },
+    {
+      id: 'ThordanEX Shield Of The Heavens',
+      type: 'GainsEffect',
+      netRegex: { effectId: '3B1' },
+      run: (data, matches) => data.shieldKnight = matches.target,
+    },
+    {
+      id: 'ThordanEX Holiest Of Holy',
+      type: 'StartsUsing',
+      netRegex: { id: '1495', source: ['Ser Adelphel', 'Ser Janlenoux'], capture: false },
+      suppressSeconds: 5,
+      response: Responses.aoe(),
+    },
+    {
+      id: 'ThordanEX Holy Bladedance Collect',
+      type: 'StartsUsing',
+      netRegex: { id: '1496', source: ['Ser Adelphel', 'Ser Janlenoux'], },
+      run: (data, matches) => {
+        if (data.swordKnight === matches.source)
+          data.swordTarget = matches.target;
+        if (data.shieldKnight === matches.source)
+          data.shieldTarget = matches.target;
+      }
+    },
+    {
+      id: 'ThordanEX Holy Bladedance Call',
+      type: 'StartsUsing',
+      netRegex: { id: '1496', source: ['Ser Adelphel', 'Ser Janlenoux'], capture: false },
+      delaySeconds: 0.5,
+      suppressSeconds: 5,
+      alertText: (data, _matches, output) => {
+        if (data.swordTarget === undefined || data.shieldTarget === undefined)
+          return output.unknownDance!();
+        if (data.swordTarget === data.shieldTarget)
+          return output.singleDance!({ target: data.swordTarget });
+        return output.doubleDance!({ sword: data.swordTarget, shield: data.shieldTarget });
+      },
+      outputStrings: {
+        unknownDance: {
+          en: 'Heavy busters'
+        },
+        singleDance: {
+          en: '2x buster on ${target}',
+        },
+        doubleDance: {
+          en: 'Sword buster on ${sword} (shield on ${shield})',
+        },
+      }
+    },
+    {
+      id: 'ThordanEX Skyward Leap',
+      type: 'HeadMarker',
+      netRegex: { id: '000E' },
+      condition: Conditions.targetIsYou(),
+      alarmText: (_data, _matches, output) => output.defamationYou!(),
+      outputStrings: {
+        defamationYou: {
+          en: 'Defamation on YOU',
+        },
+      },
+    },
+    {
+      id: 'ThordanEX Spiral Pierce Collect',
+      type: 'Tether',
+      netRegex: { id: '0005' },
+      run: (data, matches) => data.pierceTargets.push(matches.target),
+    },
+    {
+      id: 'ThordanEX Spiral Pierce',
+      type: 'Tether',
+      netRegex: { id: '0005', capture: false },
+      delaySeconds: 0.5,
+      suppressSeconds: 5,
+      alarmText: (data, _matches, output) => {
+        if (data.pierceTargets.includes(data.me))
+          return output.pierceYou!();
+        return output.pierceOthers!();
+      },
+      run: (data) => data.pierceTargets = [],
+      outputStrings: {
+        pierceYou: {
+          en: 'Line AoE on YOU',
+        },
+        pierceOthers: {
+          en: 'Avoid tether line AoEs',
+        }
+      },
+    },
+    {
+      id: 'ThordanEX Hiemal Storm',
+      type: 'HeadMarker',
+      netRegex: { id: '001D' },
+      condition: Conditions.targetIsYou(),
+      alertText: (_data, _matches, output) => output.icePuddleYou!(),
+      outputStrings: {
+        icePuddleYou: {
+          en: 'Ice puddle on YOU',
+        },
+      },
+    },
+    {
+      id: 'ThordanEX Comet Puddles',
+      type: 'HeadMarker',
+      netRegex: { id: '000B' },
+      condition: Conditions.targetIsYou(),
+      alertText: (_data, _matches, output) => output.meteorYou!(),
+      outputStrings: {
+        meteorYou: {
+          en: '4x meteor puddles on YOU',
+        },
+      },
+    },
+    {
+      id: 'ThordanEX Fury Spear',
+      type: 'HeadMarker',
+      netRegex: { id: '0010' },
+      alertText: (data, matches, output) => {
+        if (data.me === matches.target)
+          return output.spearYou!();
+        return output.spearOther!({ spearTarget: matches.target });
+      },
+      outputStrings: {
+        spearYou: {
+          en: 'Wild Charge on YOU',
+        },
+        spearOther: {
+          en: 'Wild Charge: Intercept ${spearTarget}'
+        }
+      },
+    },
+  ],
+
+  timelineReplace: [
+    {
+      'locale': 'en',
+      'replaceText': {
+        'The Dragon\'s Gaze/The Dragon\'s Glory': 'The Dragon\'s Gaze/Glory',
+      },
+    },
+  ],
+};
+
+export default triggerSet;

--- a/ui/raidboss/data/03-hw/trial/thordan-ex.ts
+++ b/ui/raidboss/data/03-hw/trial/thordan-ex.ts
@@ -452,7 +452,7 @@ const triggerSet: TriggerSet<Data> = {
       type: 'Ability',
       netRegex: { id: '1018', source: 'Ser Grinnaux' }, // Shared ability from all knights when they teleport in.
       condition: (data) => data.phase === 4,
-      delaySeconds: 7, // Grinnaux insta-casts Faith Unmoving 13s after appearing. Give ~7s of warning.
+      delaySeconds: 7, // Grinnaux insta-casts Faith Unmoving 13s after appearing. Give ~6s of warning.
       alertText: (_data, matches, output) => {
         const knightX = parseFloat(matches.x);
         const knightY = parseFloat(matches.y);

--- a/ui/raidboss/data/03-hw/trial/thordan-ex.txt
+++ b/ui/raidboss/data/03-hw/trial/thordan-ex.txt
@@ -32,6 +32,7 @@ hideall "--sync--"
 82.4 "--sync--" sync / 1[56]:[^:]*:King Thordan:105A:/ window 82.4,10
 91.4 "--sync--" sync / 1[56]:[^:]*:Ser Charibert:1018:/
 93.4 "--sync--" sync / 1[56]:[^:]*:Ser Hermenost:1018:/
+95.7 "--chains appear--"
 98.0 "--sync--" sync / 1[56]:[^:]*:Ser Charibert:14AB:/ window 10,10 # Heavensflame cast
 98.4 "Heavensflame 1" #sync / 1[56]:[^:]*:Ser Charibert:14AC:/
 99.4 "Heavensflame 2" #sync / 1[56]:[^:]*:Ser Charibert:14AC:/
@@ -168,6 +169,7 @@ hideall "--sync--"
 622.1 "the Dragon's Eye" sync / 1[56]:[^:]*:King Thordan:1488:/
 632.3 "Knights Of the Round" sync / 1[56]:[^:]*:King Thordan:148C:/
 638.4 "Ascalon's Might" sync / 1[56]:[^:]*:King Thordan:147E:/
+641.5 "--chains appear--"
 642.4 "Holy Meteor" sync / 1[56]:[^:]*:Ser Noudenet:14B0:/
 643.5 "Comet x4" duration 4 #sync / 1[56]:[^:]*:Ser Noudenet:14B5:/
 643.5 "The Dragon's Gaze/The Dragon's Glory" sync / 1[56]:[^:]*:King Thordan:(1489|148A):/

--- a/ui/raidboss/data/03-hw/trial/thordan-ex.txt
+++ b/ui/raidboss/data/03-hw/trial/thordan-ex.txt
@@ -60,20 +60,20 @@ hideall "--sync--"
 178.3 "Skyward Leap 2" sync / 1[56]:[^:]*:Ser Paulecrain:14A9:/
 179.4 "Heavenly Slash" sync / 1[56]:[^:]*:(Ser Adelphel|Ser Janlenoux):1494:/
 181.3 "Skyward Leap 3" sync / 1[56]:[^:]*:Ser Ignasse:14A9:/
-192.4 "Holiest of Holy" sync / 1[56]:[^:]*:(Ser Adelphel|Ser Janlenoux):1495:/
+192.4 "Holiest Of Holy" sync / 1[56]:[^:]*:(Ser Adelphel|Ser Janlenoux):1495:/
 198.5 "Holy Bladedance" sync / 1[56]:[^:]*:(Ser Adelphel|Ser Janlenoux):1496:/
 205.6 "Divine Right" sync / 1[56]:[^:]*:(Ser Adelphel|Ser Janlenoux):1493:/
-212.7 "Holiest of Holy" sync / 1[56]:[^:]*:(Ser Adelphel|Ser Janlenoux):1495:/
+212.7 "Holiest Of Holy" sync / 1[56]:[^:]*:(Ser Adelphel|Ser Janlenoux):1495:/
 216.8 "Heavenly Slash" sync / 1[56]:[^:]*:(Ser Adelphel|Ser Janlenoux):1494:/
 
 232.9 "Divine Right" sync / 1[56]:[^:]*:(Ser Adelphel|Ser Janlenoux):1493:/
 242.0 "Holy Bladedance" sync / 1[56]:[^:]*:(Ser Adelphel|Ser Janlenoux):1496:/
 260.0 "Divine Right" sync / 1[56]:[^:]*:(Ser Adelphel|Ser Janlenoux):1493:/
 262.1 "Heavenly Slash" sync / 1[56]:[^:]*:(Ser Adelphel|Ser Janlenoux):1494:/
-275.2 "Holiest of Holy" sync / 1[56]:[^:]*:(Ser Adelphel|Ser Janlenoux):1495:/
+275.2 "Holiest Of Holy" sync / 1[56]:[^:]*:(Ser Adelphel|Ser Janlenoux):1495:/
 281.3 "Holy Bladedance" sync / 1[56]:[^:]*:(Ser Adelphel|Ser Janlenoux):1496:/
 288.3 "Divine Right" sync / 1[56]:[^:]*:(Ser Adelphel|Ser Janlenoux):1493:/
-295.4 "Holiest of Holy" sync / 1[56]:[^:]*:(Ser Adelphel|Ser Janlenoux):1495:/
+295.4 "Holiest Of Holy" sync / 1[56]:[^:]*:(Ser Adelphel|Ser Janlenoux):1495:/
 299.5 "Heavenly Slash" sync / 1[56]:[^:]*:(Ser Adelphel|Ser Janlenoux):1494:/ forcejump 216.8
 
 
@@ -110,13 +110,13 @@ hideall "--sync--"
 
 
 427.0 "--sync--" sync / 1[56]:[^:]*:King Thordan:105B:/ window 260,10
-437.7 "The Light of Ascalon 1" #sync / 1[56]:[^:]*:Ascalon:148F:/
-439.1 "The Light of Ascalon 2" #sync / 1[56]:[^:]*:Ascalon:148F:/
-440.5 "The Light of Ascalon 3" #sync / 1[56]:[^:]*:Ascalon:148F:/
-441.9 "The Light of Ascalon 4" #sync / 1[56]:[^:]*:Ascalon:148F:/
-443.3 "The Light of Ascalon 5" #sync / 1[56]:[^:]*:Ascalon:148F:/
-444.7 "The Light of Ascalon 6" #sync / 1[56]:[^:]*:Ascalon:148F:/
-446.1 "The Light of Ascalon 7" #sync / 1[56]:[^:]*:Ascalon:148F:/
+437.7 "The Light Of Ascalon 1" #sync / 1[56]:[^:]*:Ascalon:148F:/
+439.1 "The Light Of Ascalon 2" #sync / 1[56]:[^:]*:Ascalon:148F:/
+440.5 "The Light Of Ascalon 3" #sync / 1[56]:[^:]*:Ascalon:148F:/
+441.9 "The Light Of Ascalon 4" #sync / 1[56]:[^:]*:Ascalon:148F:/
+443.3 "The Light Of Ascalon 5" #sync / 1[56]:[^:]*:Ascalon:148F:/
+444.7 "The Light Of Ascalon 6" #sync / 1[56]:[^:]*:Ascalon:148F:/
+446.1 "The Light Of Ascalon 7" #sync / 1[56]:[^:]*:Ascalon:148F:/
 447.2 "--sync--" sync / 1[56]:[^:]*:King Thordan:148D:/ # Ultimate End wind-up
 451.8 "--sync--" sync / 1[56]:[^:]*:[^:]:1059:/ # All the knights use this unknown attack here
 455.8 "Ultimate End" sync / 1[56]:[^:]*:King Thordan:148E:/
@@ -125,10 +125,10 @@ hideall "--sync--"
 # Phase 3
 # Save the [healer]!
 466.4 "the Dragon's Eye" sync / 1[56]:[^:]*:King Thordan:1488:/
-476.6 "Knights of the Round" sync / 1[56]:[^:]*:King Thordan:148C:/
+476.6 "Knights Of the Round" sync / 1[56]:[^:]*:King Thordan:148C:/
 481.7 "Ascalon's Might" sync / 1[56]:[^:]*:King Thordan:147E:/
 488.1 "Holy Shield Bash" sync / 1[56]:[^:]*:(Ser Adelphel|Ser Janlenoux):1497:/
-497.1 "Spear of the Fury" sync / 1[56]:[^:]*:Ser Zephirin:1492:/ # A smile better suits a hero
+497.1 "Spear Of the Fury" sync / 1[56]:[^:]*:Ser Zephirin:1492:/ # A smile better suits a hero
 499.5 "Heavenly Heel" sync / 1[56]:[^:]*:King Thordan:1487:/
 504.6 "The Dragon's Gaze/The Dragon's Glory" sync / 1[56]:[^:]*:King Thordan:(1489|148A):/
 516.6 "Ancient Quaga" sync / 1[56]:[^:]*:King Thordan:1485:/
@@ -136,7 +136,7 @@ hideall "--sync--"
 #Phase 4
 # Conviction Trio
 521.8 "the Dragon's Eye" sync / 1[56]:[^:]*:King Thordan:1488:/
-532.0 "Knights of the Round" sync / 1[56]:[^:]*:King Thordan:148C:/
+532.0 "Knights Of the Round" sync / 1[56]:[^:]*:King Thordan:148C:/
 543.1 "The Dragon's Gaze/The Dragon's Glory" sync / 1[56]:[^:]*:King Thordan:(1489|148A):/
 543.2 "Conviction" sync / 1[56]:[^:]*:Ser Hermenost:149C:/
 544.1 "Heavy Impact 1" sync / 1[56]:[^:]*:Ser Guerrique:14A0:/
@@ -153,7 +153,7 @@ hideall "--sync--"
 # Phase 5
 # Spiral Sky Trio
 572.1 "the Dragon's Eye" sync / 1[56]:[^:]*:King Thordan:1488:/
-582.2 "Knights of the Round" sync / 1[56]:[^:]*:King Thordan:148C:/
+582.2 "Knights Of the Round" sync / 1[56]:[^:]*:King Thordan:148C:/
 588.9 "Lightning Storm" sync / 1[56]:[^:]*:King Thordan:1481:/
 589.3 "--sync--" sync / 1[56]:[^:]*:King Thordan:1482:/# Lightning Storm
 597.3 "Spiral Thrust" sync / 1[56]:[^:]*:Ser Vellguine:14A6:/
@@ -166,7 +166,7 @@ hideall "--sync--"
 # Phase 6
 # Meteor Trio
 622.1 "the Dragon's Eye" sync / 1[56]:[^:]*:King Thordan:1488:/
-632.3 "Knights of the Round" sync / 1[56]:[^:]*:King Thordan:148C:/
+632.3 "Knights Of the Round" sync / 1[56]:[^:]*:King Thordan:148C:/
 638.4 "Ascalon's Might" sync / 1[56]:[^:]*:King Thordan:147E:/
 642.4 "Holy Meteor" sync / 1[56]:[^:]*:Ser Noudenet:14B0:/
 643.5 "Comet x4" duration 4 #sync / 1[56]:[^:]*:Ser Noudenet:14B5:/
@@ -185,15 +185,15 @@ hideall "--sync--"
 # Phase 7 -- zomg SO MUCH AOE DAMAGE
 # Heavensward Trio
 673.1 "the Dragon's Eye" sync / 1[56]:[^:]*:King Thordan:1488:/
-683.3 "Knights of the Round" sync / 1[56]:[^:]*:King Thordan:148C:/
+683.3 "Knights Of the Round" sync / 1[56]:[^:]*:King Thordan:148C:/
 688.4 "Ascalon's Might" sync / 1[56]:[^:]*:King Thordan:147E:/
-693.4 "Holiest of Holy" sync / 1[56]:[^:]*:Ser Janlenoux:1495:/
+693.4 "Holiest Of Holy" sync / 1[56]:[^:]*:Ser Janlenoux:1495:/
 698.5 "Ascalon's Might" sync / 1[56]:[^:]*:King Thordan:147E:/
 704.6 "Heavensward Leap 1" sync / 1[56]:[^:]*:Ser Vellguine:14AA:/
 707.6 "Heavensward Leap 2" sync / 1[56]:[^:]*:Ser Paulecrain:14AA:/
 710.6 "Heavensward Leap 3" sync / 1[56]:[^:]*:Ser Ignasse:14AA:/
 718.7 "Sacred Cross" sync / 14:[^:]*:Ser Zephirin:1491:/ duration 24.7
-724.6 "Pure of Soul" sync / 1[56]:[^:]*:(Ser Charibert|Ser Noudenet|Ser Haumeric):(14B1|14B2):/
+724.6 "Pure Of Soul" sync / 1[56]:[^:]*:(Ser Charibert|Ser Noudenet|Ser Haumeric):(14B1|14B2):/
 732.6 "Absolute Conviction 1" sync / 1[56]:[^:]*:Ser Guerrique:14A4:/
 735.5 "Absolute Conviction 2" sync / 1[56]:[^:]*:Ser Hermenost:14A5:/
 740.6 "The Dragon's Gaze/The Dragon's Glory" sync / 1[56]:[^:]*:King Thordan:(1489|148A):/
@@ -238,16 +238,16 @@ hideall "--sync--"
 # 1489 the Dragon's Gaze
 # 148A the Dragon's Glory
 # 148B the Dragon's Rage
-# 148C Knights of the Round
+# 148C Knights Of the Round
 # 148D Ultimate End
 # 148E Ultimate End
-# 148F the Light of Ascalon
+# 148F the Light Of Ascalon
 # 1490 Sacred Cross
 # 1491 Sacred Cross
-# 1492 Spear of the Fury
+# 1492 Spear Of the Fury
 # 1493 Divine Right
 # 1494 Heavenly Slash
-# 1495 Holiest of Holy
+# 1495 Holiest Of Holy
 # 1496 Holy Bladedance
 # 1497 Holy Shield Bash
 # 1499 Dimensional Collapse
@@ -272,8 +272,8 @@ hideall "--sync--"
 # 14AE Hiemal Storm
 # 14AF Hiemal Storm
 # 14B0 Holy Meteor
-# 14B1 Pure of Soul
-# 14B2 Pure of Soul
+# 14B1 Pure Of Soul
+# 14B2 Pure Of Soul
 # 14B3 Comet Impact
 # 14B4 Meteor Impact
 # 14B5 Comet

--- a/ui/raidboss/data/03-hw/trial/thordan-ex.txt
+++ b/ui/raidboss/data/03-hw/trial/thordan-ex.txt
@@ -1,0 +1,279 @@
+### THE MINSTREL'S BALLAD: THORDAN'S REIGN
+# ZoneId: 1
+
+# -ii 1019 1480 149F
+# -it "King Thordan" "Ser Janlenoux"
+
+hideall "--Reset--"
+hideall "--sync--"
+
+# Phase 1. Pushes at 70% HP?
+0.0 "--sync--" sync / 104:[^:]*:1($|:)/ window 0,1
+5.0 "Ascalon's Might" sync / 1[56]:[^:]*:King Thordan:147E:/
+14.8 "Meteorain" sync / 1[56]:[^:]*:King Thordan:1483:/
+15.1 "--sync--" sync / 1[56]:[^:]*:King Thordan:1484:/ # Meteorain
+20.0 "--sync--" sync / 1[56]:[^:]*:King Thordan:147F:/
+20.0 "Ascalon's Mercy" sync / 1[56]:[^:]*:King Thordan:1480:/
+22.1 "Ascalon's Might" sync / 1[56]:[^:]*:King Thordan:147E:/
+27.2 "the Dragon's Eye" sync / 1[56]:[^:]*:King Thordan:1488:/
+37.3 "the Dragon's Gaze" sync / 1[56]:[^:]*:King Thordan:1489:/
+42.4 "Ascalon's Might" sync / 1[56]:[^:]*:King Thordan:147E:/
+51.1 "Lightning Storm" sync / 1[56]:[^:]*:King Thordan:1481:/
+51.5 "--sync--" sync / 1[56]:[^:]*:King Thordan:1482:/ # Lightning Storm
+58.2 "the Dragon's Rage" sync / 1[56]:[^:]*:King Thordan:148B:/
+63.3 "Ancient Quaga" sync / 1[56]:[^:]*:King Thordan:1485:/
+69.4 "Ascalon's Might" sync / 1[56]:[^:]*:King Thordan:147E:/
+75.4 "Heavenly Heel" sync / 1[56]:[^:]*:King Thordan:1487:/
+77.5 "Ascalon's Might" sync / 1[56]:[^:]*:King Thordan:147E:/
+79.6 "--untargetable--"
+
+# Phase 2
+# Intermission part 1
+82.4 "--sync--" sync / 1[56]:[^:]*:King Thordan:105A:/ window 82.4,10
+91.4 "--sync--" sync / 1[56]:[^:]*:Ser Charibert:1018:/
+93.4 "--sync--" sync / 1[56]:[^:]*:Ser Hermenost:1018:/
+98.0 "--sync--" sync / 1[56]:[^:]*:Ser Charibert:14AB:/ window 10,10 # Heavensflame cast
+98.4 "Heavensflame 1" #sync / 1[56]:[^:]*:Ser Charibert:14AC:/
+99.4 "Heavensflame 2" #sync / 1[56]:[^:]*:Ser Charibert:14AC:/
+99.4 "--towers spawn--"
+100.4 "Heavensflame 3" #sync / 1[56]:[^:]*:Ser Charibert:14AC:/
+101.4 "Heavensflame 4" #sync / 1[56]:[^:]*:Ser Charibert:14AC:/
+101.5 "--sync--" sync / 1[56]:[^:]*:Ser Hermenost:149C:/ # Conviction (model animation, no actual snapshot)
+104.3 "Conviction" sync / 1[56]:[^:]*:Ser Hermenost:149D:/
+107.4 "Sacred Cross" sync / 14:[^:]*:Ser Zephirin:1490:/ duration 19.7
+127.1 "--sync--" sync / 1[56]:[^:]*:Ser Zephirin:1490:/
+133.1 "Spiral Thrust" sync / 1[56]:[^:]*:(Ser Ignasse|Ser Paulecrain|Ser Vellguine):14A6:/
+
+# Intermission part 2
+# This loops until both Adelphel and Janlenoux are dead.
+# 3x Skyward Leaps happen during this loop,
+# but the other knights hold their mechanics until after both are dead.
+
+# Adelphel and Janlenoux's shared mechanics can be offset by 0.1 seconds,
+# but it's more important that we sync during the loop,
+# so we accept a small amount of jumpiness in the timeline.
+140.2 "--targetable--"
+150.2 "Divine Right" sync / 1[56]:[^:]*:(Ser Adelphel|Ser Janlenoux):1493:/
+159.3 "Holy Bladedance" sync / 1[56]:[^:]*:(Ser Adelphel|Ser Janlenoux):1496:/
+175.3 "Skyward Leap 1" sync / 1[56]:[^:]*:Ser Vellguine:14A9:/
+177.3 "Divine Right" sync / 1[56]:[^:]*:(Ser Adelphel|Ser Janlenoux):1493:/
+178.3 "Skyward Leap 2" sync / 1[56]:[^:]*:Ser Paulecrain:14A9:/
+179.4 "Heavenly Slash" sync / 1[56]:[^:]*:(Ser Adelphel|Ser Janlenoux):1494:/
+181.3 "Skyward Leap 3" sync / 1[56]:[^:]*:Ser Ignasse:14A9:/
+192.4 "Holiest of Holy" sync / 1[56]:[^:]*:(Ser Adelphel|Ser Janlenoux):1495:/
+198.5 "Holy Bladedance" sync / 1[56]:[^:]*:(Ser Adelphel|Ser Janlenoux):1496:/
+205.6 "Divine Right" sync / 1[56]:[^:]*:(Ser Adelphel|Ser Janlenoux):1493:/
+212.7 "Holiest of Holy" sync / 1[56]:[^:]*:(Ser Adelphel|Ser Janlenoux):1495:/
+216.8 "Heavenly Slash" sync / 1[56]:[^:]*:(Ser Adelphel|Ser Janlenoux):1494:/
+
+232.9 "Divine Right" sync / 1[56]:[^:]*:(Ser Adelphel|Ser Janlenoux):1493:/
+242.0 "Holy Bladedance" sync / 1[56]:[^:]*:(Ser Adelphel|Ser Janlenoux):1496:/
+260.0 "Divine Right" sync / 1[56]:[^:]*:(Ser Adelphel|Ser Janlenoux):1493:/
+262.1 "Heavenly Slash" sync / 1[56]:[^:]*:(Ser Adelphel|Ser Janlenoux):1494:/
+275.2 "Holiest of Holy" sync / 1[56]:[^:]*:(Ser Adelphel|Ser Janlenoux):1495:/
+281.3 "Holy Bladedance" sync / 1[56]:[^:]*:(Ser Adelphel|Ser Janlenoux):1496:/
+288.3 "Divine Right" sync / 1[56]:[^:]*:(Ser Adelphel|Ser Janlenoux):1493:/
+295.4 "Holiest of Holy" sync / 1[56]:[^:]*:(Ser Adelphel|Ser Janlenoux):1495:/
+299.5 "Heavenly Slash" sync / 1[56]:[^:]*:(Ser Adelphel|Ser Janlenoux):1494:/ forcejump 216.8
+
+
+# Intermission part 3
+350.0 "--sync--" sync / 1[56]:[^:]*:Ser Paulecrain:1018:/ window 150,10
+352.0 "--sync--" sync / 1[56]:[^:]*:Ser Grinnaux:1018:/ window 150,10
+353.0 "--sync--" sync / 1[56]:[^:]*:Ser Haumeric:1018:/ window 150,10
+359.6 "Hiemal Storm" sync / 1[56]:[^:]*:Ser Haumeric:14AE:/ window 328,10
+359.8 "--sync--" sync / 1[56]:[^:]*:Ser Noudenet:14AF:/ # Hiemal Storm
+360.2 "Spiral Pierce" sync / 1[56]:[^:]*:(Ser Ignasse|Ser Paulecrain|Ser Vellguine):14A7:/
+361.5 "Dimensional Collapse" sync / 1[56]:[^:]*:Ser Grinnaux:1499:/
+361.9 "--sync--" sync / 1[56]:[^:]*:Ser Grinnaux:149A:/ # Dimensional Collapse
+365.0 "Faith Unmoving" sync / 1[56]:[^:]*:Ser Grinnaux:149B:/
+
+# Intermission part 4
+# Two sets of four Heavy Impacts used during this intermission.
+# They overlap heavily. Because they use different IDs for each ring,
+# it's safe to leave them all synced.
+366.0 "Holy Meteor" sync / 1[56]:[^:]*:Ser Noudenet:14B0:/ window 220,10
+374.6 "--sync--" sync / 1[56]:[^:]*:Ser Guerrique:149F:/ # Heavy Impact (intial cast, no earth ring)
+376.0 "Comet x4" duration 4 #sync / 1[56]:[^:]*:Ser Noudenet:14B5:/
+379.4 "Heavy Impact (round 1 ring 1)" sync / 1[56]:[^:]*:Ser Guerrique:14A0:/
+379.9 "--sync--" sync / 1[56]:[^:]*:Ser Guerrique:149F:/ # Heavy Impact (intial cast, no earth ring)
+381.4 "Heavy Impact (round 1 ring 2)" sync / 1[56]:[^:]*:Ser Guerrique:14A1:/
+383.4 "Heavy Impact (round 1 ring 3)" sync / 1[56]:[^:]*:Ser Guerrique:14A2:/
+383.8 "Comet x4" duration 4 #sync / 1[56]:[^:]*:Ser Noudenet:14B5:/
+384.6 "Heavy Impact (round 2 ring 1)" sync / 1[56]:[^:]*:Ser Guerrique:14A0:/
+385.3 "Heavy Impact (round 1 ring 4)" sync / 1[56]:[^:]*:Ser Guerrique:14A3:/
+386.5 "Heavy Impact (round 2 ring 2)" sync / 1[56]:[^:]*:Ser Guerrique:14A1:/
+388.5 "Heavy Impact (round 2 ring 3)" sync / 1[56]:[^:]*:Ser Guerrique:14A2:/
+390.5 "Heavy Impact (round 2 ring 4)" sync / 1[56]:[^:]*:Ser Guerrique:14A3:/
+398.1 "Comet Impact" sync / 1[56]:[^:]*:Comet Circle:14B3:/
+420.7 "Meteor Impact Enrage" sync / 1[56]:[^:]*:Meteor Circle:14B4:/
+
+
+427.0 "--sync--" sync / 1[56]:[^:]*:King Thordan:105B:/ window 260,10
+437.7 "The Light of Ascalon 1" #sync / 1[56]:[^:]*:Ascalon:148F:/
+439.1 "The Light of Ascalon 2" #sync / 1[56]:[^:]*:Ascalon:148F:/
+440.5 "The Light of Ascalon 3" #sync / 1[56]:[^:]*:Ascalon:148F:/
+441.9 "The Light of Ascalon 4" #sync / 1[56]:[^:]*:Ascalon:148F:/
+443.3 "The Light of Ascalon 5" #sync / 1[56]:[^:]*:Ascalon:148F:/
+444.7 "The Light of Ascalon 6" #sync / 1[56]:[^:]*:Ascalon:148F:/
+446.1 "The Light of Ascalon 7" #sync / 1[56]:[^:]*:Ascalon:148F:/
+447.2 "--sync--" sync / 1[56]:[^:]*:King Thordan:148D:/ # Ultimate End wind-up
+451.8 "--sync--" sync / 1[56]:[^:]*:[^:]:1059:/ # All the knights use this unknown attack here
+455.8 "Ultimate End" sync / 1[56]:[^:]*:King Thordan:148E:/
+460.3 "--targetable--"
+
+# Phase 3
+# Save the [healer]!
+466.4 "the Dragon's Eye" sync / 1[56]:[^:]*:King Thordan:1488:/
+476.6 "Knights of the Round" sync / 1[56]:[^:]*:King Thordan:148C:/
+481.7 "Ascalon's Might" sync / 1[56]:[^:]*:King Thordan:147E:/
+488.1 "Holy Shield Bash" sync / 1[56]:[^:]*:(Ser Adelphel|Ser Janlenoux):1497:/
+497.1 "Spear of the Fury" sync / 1[56]:[^:]*:Ser Zephirin:1492:/ # A smile better suits a hero
+499.5 "Heavenly Heel" sync / 1[56]:[^:]*:King Thordan:1487:/
+504.6 "The Dragon's Gaze/The Dragon's Glory" sync / 1[56]:[^:]*:King Thordan:(1489|148A):/
+516.6 "Ancient Quaga" sync / 1[56]:[^:]*:King Thordan:1485:/
+
+#Phase 4
+# Conviction Trio
+521.8 "the Dragon's Eye" sync / 1[56]:[^:]*:King Thordan:1488:/
+532.0 "Knights of the Round" sync / 1[56]:[^:]*:King Thordan:148C:/
+543.1 "The Dragon's Gaze/The Dragon's Glory" sync / 1[56]:[^:]*:King Thordan:(1489|148A):/
+543.2 "Conviction" sync / 1[56]:[^:]*:Ser Hermenost:149C:/
+544.1 "Heavy Impact 1" sync / 1[56]:[^:]*:Ser Guerrique:14A0:/
+546.0 "Conviction" sync / 1[56]:[^:]*:Ser Hermenost:149D:/
+546.0 "Heavy Impact 2" sync / 1[56]:[^:]*:Ser Guerrique:14A1:/
+548.0 "Heavy Impact 3" sync / 1[56]:[^:]*:Ser Guerrique:14A2:/
+550.0 "Heavy Impact 4" sync / 1[56]:[^:]*:Ser Guerrique:14A3:/
+552.4 "Dimensional Collapse" sync / 1[56]:[^:]*:Ser Grinnaux:1499:/
+552.8 "--sync--" sync / 1[56]:[^:]*:Ser Grinnaux:149A:/ # Dimensional Collapse
+555.9 "Faith Unmoving" sync / 1[56]:[^:]*:Ser Grinnaux:149B:/
+557.9 "the Dragon's Rage" sync / 1[56]:[^:]*:King Thordan:148B:/
+563.0 "Ascalon's Might" sync / 1[56]:[^:]*:King Thordan:147E:/
+
+# Phase 5
+# Spiral Sky Trio
+572.1 "the Dragon's Eye" sync / 1[56]:[^:]*:King Thordan:1488:/
+582.2 "Knights of the Round" sync / 1[56]:[^:]*:King Thordan:148C:/
+588.9 "Lightning Storm" sync / 1[56]:[^:]*:King Thordan:1481:/
+589.3 "--sync--" sync / 1[56]:[^:]*:King Thordan:1482:/# Lightning Storm
+597.3 "Spiral Thrust" sync / 1[56]:[^:]*:Ser Vellguine:14A6:/
+597.3 "Spiral Pierce" sync / 1[56]:[^:]*:Ser Paulecrain:14A7:/
+597.5 "Skyward Leap" sync / 1[56]:[^:]*:Ser Ignasse:14A9:/
+598.9 "the Dragon's Rage" sync / 1[56]:[^:]*:King Thordan:148B:/
+609.9 "Heavenly Heel" sync / 1[56]:[^:]*:King Thordan:1487:/
+612.0 "Ascalon's Might" sync / 1[56]:[^:]*:King Thordan:147E:/
+
+# Phase 6
+# Meteor Trio
+622.1 "the Dragon's Eye" sync / 1[56]:[^:]*:King Thordan:1488:/
+632.3 "Knights of the Round" sync / 1[56]:[^:]*:King Thordan:148C:/
+638.4 "Ascalon's Might" sync / 1[56]:[^:]*:King Thordan:147E:/
+642.4 "Holy Meteor" sync / 1[56]:[^:]*:Ser Noudenet:14B0:/
+643.5 "Comet x4" duration 4 #sync / 1[56]:[^:]*:Ser Noudenet:14B5:/
+643.5 "The Dragon's Gaze/The Dragon's Glory" sync / 1[56]:[^:]*:King Thordan:(1489|148A):/
+643.8 "--sync--" sync / 1[56]:[^:]*:Ser Charibert:14AB:/ # Heavensflame (cast)
+644.2 "Heavensflame 1" #sync / 1[56]:[^:]*:Ser Charibert:14AC:/
+645.3 "Heavensflame 2" #sync / 1[56]:[^:]*:Ser Charibert:14AC:/
+646.4 "Heavensflame 3" #sync / 1[56]:[^:]*:Ser Charibert:14AC:/
+646.8 "Hiemal Storm" sync / 1[56]:[^:]*:Ser Haumeric:14AE:/
+647.4 "--sync--" sync / 1[56]:[^:]*:Ser Noudenet:14AF:/ # Hiemal Storm
+648.7 "Ascalon's Mercy" sync / 1[56]:[^:]*:King Thordan:147F:/
+656.8 "Ancient Quaga" sync / 1[56]:[^:]*:King Thordan:1485:/
+662.9 "Heavenly Heel" sync / 1[56]:[^:]*:King Thordan:1487:/
+668.0 "Ancient Quaga" sync / 1[56]:[^:]*:King Thordan:1485:/
+
+# Phase 7 -- zomg SO MUCH AOE DAMAGE
+# Heavensward Trio
+673.1 "the Dragon's Eye" sync / 1[56]:[^:]*:King Thordan:1488:/
+683.3 "Knights of the Round" sync / 1[56]:[^:]*:King Thordan:148C:/
+688.4 "Ascalon's Might" sync / 1[56]:[^:]*:King Thordan:147E:/
+693.4 "Holiest of Holy" sync / 1[56]:[^:]*:Ser Janlenoux:1495:/
+698.5 "Ascalon's Might" sync / 1[56]:[^:]*:King Thordan:147E:/
+704.6 "Heavensward Leap 1" sync / 1[56]:[^:]*:Ser Vellguine:14AA:/
+707.6 "Heavensward Leap 2" sync / 1[56]:[^:]*:Ser Paulecrain:14AA:/
+710.6 "Heavensward Leap 3" sync / 1[56]:[^:]*:Ser Ignasse:14AA:/
+718.7 "Sacred Cross" sync / 14:[^:]*:Ser Zephirin:1491:/ duration 24.7
+724.6 "Pure of Soul" sync / 1[56]:[^:]*:(Ser Charibert|Ser Noudenet|Ser Haumeric):(14B1|14B2):/
+732.6 "Absolute Conviction 1" sync / 1[56]:[^:]*:Ser Guerrique:14A4:/
+735.5 "Absolute Conviction 2" sync / 1[56]:[^:]*:Ser Hermenost:14A5:/
+740.6 "The Dragon's Gaze/The Dragon's Glory" sync / 1[56]:[^:]*:King Thordan:(1489|148A):/
+743.4 "--sync--" sync / 1[56]:[^:]*:Ser Zephirin:1491:/ # Sacred Cross resolves
+750.7 "Ancient Quaga" sync / 1[56]:[^:]*:King Thordan:1485:/
+
+# Enrage sequence
+759.8 "Heavenly Heel" sync / 1[56]:[^:]*:King Thordan:1487:/
+761.9 "Ascalon's Might 1" sync / 1[56]:[^:]*:King Thordan:147E:/
+767.0 "Ascalon's Might 2" sync / 1[56]:[^:]*:King Thordan:147E:/
+770.1 "Ascalon's Might 3" sync / 1[56]:[^:]*:King Thordan:147E:/
+773.2 "Ascalon's Might 4" sync / 1[56]:[^:]*:King Thordan:147E:/
+776.3 "Ascalon's Might 5" sync / 1[56]:[^:]*:King Thordan:147E:/
+779.4 "Ascalon's Might 6" sync / 1[56]:[^:]*:King Thordan:147E:/
+791.4 "Ancient Quaga" sync / 1[56]:[^:]*:King Thordan:1486:/
+
+# IGNORED ABILITIES
+# 1018 --sync--
+# 1019 --sync--
+# 1480 Ascalon's Mercy
+# 149E Eternal Conviction
+
+# ALL ENCOUNTER ABILITIES
+# 366 attack
+# 1018 --sync--
+# 1019 --sync--
+# 1059 --sync--
+# 105A --sync--
+# 105B --sync--
+# 147D attack
+# 147E Ascalon's Might
+# 147F Ascalon's Mercy
+# 1480 Ascalon's Mercy
+# 1481 Lightning Storm
+# 1482 Lightning Storm
+# 1483 Meteorain
+# 1484 Meteorain
+# 1485 Ancient Quaga
+# 1486 Ancient Quaga
+# 1487 Heavenly Heel
+# 1488 the Dragon's Eye
+# 1489 the Dragon's Gaze
+# 148A the Dragon's Glory
+# 148B the Dragon's Rage
+# 148C Knights of the Round
+# 148D Ultimate End
+# 148E Ultimate End
+# 148F the Light of Ascalon
+# 1490 Sacred Cross
+# 1491 Sacred Cross
+# 1492 Spear of the Fury
+# 1493 Divine Right
+# 1494 Heavenly Slash
+# 1495 Holiest of Holy
+# 1496 Holy Bladedance
+# 1497 Holy Shield Bash
+# 1499 Dimensional Collapse
+# 149A Dimensional Collapse
+# 149B Faith Unmoving
+# 149C Conviction
+# 149D Conviction
+# 149E Eternal Conviction
+# 149F Heavy Impact
+# 14A0 Heavy Impact
+# 14A1 Heavy Impact
+# 14A2 Heavy Impact
+# 14A3 Heavy Impact
+# 14A4 Absolute Conviction
+# 14A5 Absolute Conviction
+# 14A6 Spiral Thrust
+# 14A7 Spiral Pierce
+# 14A9 Skyward Leap
+# 14AA Heavensward Leap
+# 14AB Heavensflame
+# 14AC Heavensflame
+# 14AE Hiemal Storm
+# 14AF Hiemal Storm
+# 14B0 Holy Meteor
+# 14B1 Pure of Soul
+# 14B2 Pure of Soul
+# 14B3 Comet Impact
+# 14B4 Meteor Impact
+# 14B5 Comet

--- a/ui/raidboss/data/03-hw/trial/thordan-ex.txt
+++ b/ui/raidboss/data/03-hw/trial/thordan-ex.txt
@@ -94,18 +94,10 @@ hideall "--sync--"
 # They overlap heavily. Because they use different IDs for each ring,
 # it's safe to leave them all synced.
 366.0 "Holy Meteor" sync / 1[56]:[^:]*:Ser Noudenet:14B0:/ window 220,10
-374.6 "--sync--" sync / 1[56]:[^:]*:Ser Guerrique:149F:/ # Heavy Impact (intial cast, no earth ring)
+374.6 "Heavy Impact Set 1" sync / 1[56]:[^:]*:Ser Guerrique:149F:/ duration 10
 376.0 "Comet x4" duration 4 #sync / 1[56]:[^:]*:Ser Noudenet:14B5:/
-379.4 "Heavy Impact (round 1 ring 1)" sync / 1[56]:[^:]*:Ser Guerrique:14A0:/
-379.9 "--sync--" sync / 1[56]:[^:]*:Ser Guerrique:149F:/ # Heavy Impact (intial cast, no earth ring)
-381.4 "Heavy Impact (round 1 ring 2)" sync / 1[56]:[^:]*:Ser Guerrique:14A1:/
-383.4 "Heavy Impact (round 1 ring 3)" sync / 1[56]:[^:]*:Ser Guerrique:14A2:/
+379.9 "Heavy Impact Set 2" sync / 1[56]:[^:]*:Ser Guerrique:149F:/ duration 10
 383.8 "Comet x4" duration 4 #sync / 1[56]:[^:]*:Ser Noudenet:14B5:/
-384.6 "Heavy Impact (round 2 ring 1)" sync / 1[56]:[^:]*:Ser Guerrique:14A0:/
-385.3 "Heavy Impact (round 1 ring 4)" sync / 1[56]:[^:]*:Ser Guerrique:14A3:/
-386.5 "Heavy Impact (round 2 ring 2)" sync / 1[56]:[^:]*:Ser Guerrique:14A1:/
-388.5 "Heavy Impact (round 2 ring 3)" sync / 1[56]:[^:]*:Ser Guerrique:14A2:/
-390.5 "Heavy Impact (round 2 ring 4)" sync / 1[56]:[^:]*:Ser Guerrique:14A3:/
 398.1 "Comet Impact" sync / 1[56]:[^:]*:Comet Circle:14B3:/
 420.7 "Meteor Impact Enrage" sync / 1[56]:[^:]*:Meteor Circle:14B4:/
 


### PR DESCRIPTION
(This will close #5742 )

This should largely be self-explanatory. We are fortunate that this content is old enough that positions and headings are accurate without having to do any work for them.

I've tested this live both solo and with others (thanks quisquous!) but it will definitely need some polish here and there. In particular, some complex mechanics feel very noisy. It would be nice to figure out what alerts can be downgraded to info.

Note that currently there's no support for keeping Defamation and Pierce players out of the stack during the meteor trio. This can be done without too much effort but I have no brain left for today.