### PR TITLE
resources: Statuseffectlist first unknown field fix

### DIFF
--- a/resources/netlog_defs.ts
+++ b/resources/netlog_defs.ts
@@ -815,7 +815,7 @@ const latestLogDefinitions = {
     playerIds: {
       2: 3,
     },
-    firstUnknownField: 20,
+    firstUnknownField: 18,
     canAnonymize: true,
     firstOptionalField: 18,
   },


### PR DESCRIPTION
See https://github.com/quisquous/cactbot/issues/5842

While field 20 is technically the first field that could contain a player ID, truncating right there results in an incomplete triplet. Better to just delete the entirety of the first triplet instead of having a malformed line. 