### PR TITLE
util: improve coverage report for Chinese/Korean

### DIFF
--- a/util/coverage/coverage.css
+++ b/util/coverage/coverage.css
@@ -79,7 +79,7 @@ body > div {
 
 #translation-grid {
   display: grid;
-  grid-template-columns: max-content repeat(3, minmax(60px, max-content));
+  grid-template-columns: max-content repeat(4, minmax(60px, max-content));
   column-gap: 20px;
   row-gap: 10px;
 }

--- a/util/coverage/coverage.d.ts
+++ b/util/coverage/coverage.d.ts
@@ -41,7 +41,9 @@ export type CoverageTotals = {
 
 export type TranslationTotals = {
   [lang in Exclude<Lang, 'en'>]: {
-    files: number;
+    translatedFiles: number;
+    totalFiles: number;
+    missingFiles: number;
     errors: number;
   };
 };

--- a/util/coverage/coverage.ts
+++ b/util/coverage/coverage.ts
@@ -301,6 +301,9 @@ const translationGridHeaders = {
     cn: '错误',
     ko: '오류',
   },
+  missingFiles: {
+    en: 'Missing',
+  },
   url: {
     en: 'Link to Missing Translation List',
     de: 'Link zur Liste mit den fehlenden Übersetzungen',
@@ -365,13 +368,10 @@ const buildExpansionGrid = (container: HTMLElement, lang: Lang, totals: Coverage
 const buildTranslationGrid = (
   container: HTMLElement,
   thisLang: Lang,
-  totals: CoverageTotals,
   translationTotals: TranslationTotals,
 ) => {
   for (const header of Object.values(translationGridHeaders))
     addDiv(container, 'label', translate(header, thisLang));
-
-  const totalZones = totals.overall.raidboss;
 
   for (const lang of languages) {
     if (lang === 'en')
@@ -380,9 +380,12 @@ const buildTranslationGrid = (
     const url = `missing_translations_${lang}.html`;
     const aHref = `<a href="${url}">${url}</a>`;
 
+    const langTotals = translationTotals[lang];
+
     addDiv(container, 'text', translate(langMap, thisLang)[lang]);
-    addDiv(container, 'data', `${translationTotals[lang].files} / ${totalZones}`);
-    addDiv(container, 'data', `${translationTotals[lang].errors}`);
+    addDiv(container, 'data', `${langTotals.translatedFiles} / ${langTotals.totalFiles}`);
+    addDiv(container, 'data', `${langTotals.errors}`);
+    addDiv(container, 'data', `${langTotals.missingFiles === 0 ? '' : langTotals.missingFiles}`);
     addDiv(container, 'text', aHref);
   }
 };
@@ -552,7 +555,7 @@ document.addEventListener('DOMContentLoaded', () => {
   const translationGrid = document.getElementById('translation-grid');
   if (!translationGrid)
     throw new UnreachableCode();
-  buildTranslationGrid(translationGrid, lang, coverageTotals, translationTotals);
+  buildTranslationGrid(translationGrid, lang, translationTotals);
 
   const zoneGrid = document.getElementById('zone-grid');
   if (!zoneGrid)

--- a/util/coverage/coverage_report.ts
+++ b/util/coverage/coverage_report.ts
@@ -15,10 +15,17 @@ export const coverageTotals: CoverageTotals = {
   },
 };
 
+const defaultTranslations = {
+  totalFiles: 0,
+  translatedFiles: 0,
+  missingFiles: 0,
+  errors: 0,
+} as const;
+
 export const translationTotals: TranslationTotals = {
-  de: { files: 0, errors: 0 },
-  fr: { files: 0, errors: 0 },
-  ja: { files: 0, errors: 0 },
-  cn: { files: 0, errors: 0 },
-  ko: { files: 0, errors: 0 },
+  de: { ...defaultTranslations },
+  fr: { ...defaultTranslations },
+  ja: { ...defaultTranslations },
+  cn: { ...defaultTranslations },
+  ko: { ...defaultTranslations },
 };

--- a/util/find_missing_timeline_translations.ts
+++ b/util/find_missing_timeline_translations.ts
@@ -57,18 +57,20 @@ export const findMissing = async (
     errorFunc(
       triggersFile,
       undefined,
-      'other',
+      'replaceSection',
       locale,
       `missing timelineReplace section`,
     );
+    return;
   } else if (!transBlockFound) {
     errorFunc(
       triggersFile,
       undefined,
-      'other',
+      'replaceSection',
       locale,
       `missing locale entry in timelineReplace section`,
     );
+    return;
   }
 
   const missingTimeline = findMissingTimeline(

--- a/util/find_missing_translations.ts
+++ b/util/find_missing_translations.ts
@@ -8,7 +8,7 @@ import { isLang, Lang } from '../resources/languages';
 import { walkDirSync } from './file_utils';
 import { findMissing } from './find_missing_timeline_translations';
 
-export type MissingTranslationErrorType = 'sync' | 'text' | 'code' | 'other';
+export type MissingTranslationErrorType = 'sync' | 'text' | 'code' | 'replaceSection' | 'other';
 
 export type ErrorFuncType = (
   file: string,


### PR DESCRIPTION
Currently the "missing translations" lists hundreds of errors for each timeline entry that can't be translated because this content doesn't exist yet.

To make it easier to find issues with content that can be fixed, create a new category of error for missing 'replaceSection' and separate out those errors into their own column on the sheet.

This also makes it possible to show better "how many fights are translated" numbers for other languages by not including fights that don't exist yet in that region.