### PR TITLE
plugin: add warning for misconfigured cactbot paths

### DIFF
--- a/plugin/CactbotEventSource/CactbotEventSource.cs
+++ b/plugin/CactbotEventSource/CactbotEventSource.cs
@@ -79,6 +79,8 @@ namespace Cactbot {
     public CactbotEventSource(TinyIoCContainer container) : base(container) {
       Name = "Cactbot Config";
 
+      container.Register(new CactbotPathWarning(container));
+
       RegisterPresets();
 
       RegisterEventTypes(new List<string>()

--- a/plugin/CactbotEventSource/CactbotEventSource.csproj
+++ b/plugin/CactbotEventSource/CactbotEventSource.csproj
@@ -91,6 +91,7 @@
   <ItemGroup>
     <Compile Include="CactbotEventSource.cs" />
     <Compile Include="CactbotEventSourceConfig.cs" />
+    <Compile Include="CactbotPathWarning.cs" />
     <Compile Include="FFXIVPlugin.cs" />
     <Compile Include="loc\Strings.Designer.cs">
       <AutoGen>True</AutoGen>

--- a/plugin/CactbotEventSource/CactbotPathWarning.cs
+++ b/plugin/CactbotEventSource/CactbotPathWarning.cs
@@ -1,0 +1,88 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Advanced_Combat_Tracker;
+using CactbotEventSource.loc;
+
+namespace RainbowMage.OverlayPlugin
+{
+    // Helper class to send a warning when cactbot paths don't match.
+    class CactbotPathWarning
+    {
+        private static string cactbotDllName = "CactbotOverlay.dll";
+
+        private static string GetCactbotOverlayPath()
+        {
+            foreach (var plugin in ActGlobals.oFormActMain.ActPlugins)
+            {
+                if (!plugin.cbEnabled.Checked || plugin.pluginObj == null)
+                    continue;
+                if (plugin.pluginFile.Name != cactbotDllName)
+                    continue;
+                return plugin.pluginFile.FullName;
+            }
+            return null;
+        }
+
+        private static List<IOverlayConfig> GetProbableBrokenCactbotOverlays(TinyIoCContainer container)
+        {
+            List<IOverlayConfig> overlays = new List<IOverlayConfig>();
+            var pluginConfig = container.Resolve<IPluginConfig>();
+            foreach (var overlay in pluginConfig.Overlays)
+            {
+                if (!(overlay is Overlays.MiniParseOverlayConfig))
+                    continue;
+                var miniParseOverlay = (Overlays.MiniParseOverlayConfig)overlay;
+                if (miniParseOverlay.Disabled)
+                    continue;
+                if (overlay.Url.Contains("cactbot-"))
+                    overlays.Add(overlay);
+            }
+            return overlays;
+        }
+
+        private static string GetGoodCactbotDirWithForwardSlashes(string fullPath)
+        {
+            var fullPathForwardSlash = fullPath.Replace('\\', '/');
+            var correctPath = "/cactbot/cactbot/";
+
+            var idx = fullPathForwardSlash.LastIndexOf(correctPath);
+            if (idx == -1)
+                return null;
+
+            var substringLen = correctPath.Length;
+            return fullPathForwardSlash.Substring(0, idx + substringLen);
+        }
+
+        public CactbotPathWarning(TinyIoCContainer container)
+        {
+            // Find the first enabled cactbot plugin.
+            var pluginPath = GetCactbotOverlayPath();
+            if (pluginPath == null)
+                return;
+
+            // Find any cactbot overlays that might contain a version string.
+            var overlays = GetProbableBrokenCactbotOverlays(container);
+            if (overlays.Count == 0)
+                return;
+
+            // Find the likely correct cactbot install path.
+            // If this is an old install, e.g. cactbot/cactbot-version and the
+            // plugin is in that path, just leave it for now as it will continue
+            // to work until the user removes the plugin and re-adds it.
+            // This will also ignore any other places that people have put
+            // cactbot manually or are building out of local builds.
+            var cactbotPath = GetGoodCactbotDirWithForwardSlashes(pluginPath);
+            if (cactbotPath == null)
+                return;
+
+            List<IOverlayConfig> broken = overlays.FindAll((overlay) => !overlay.Url.Contains(cactbotPath));
+            string brokenNames = String.Join(", ", broken.Select((overlay) => $"\"{overlay.Name}\""));
+
+            Advanced_Combat_Tracker.ActGlobals.oFormActMain.NotificationAdd(
+                Strings.CactbotPathWarningTitle,
+                string.Format(Strings.CactbotPathWarning, brokenNames)
+            );
+        }
+    }
+}

--- a/plugin/CactbotEventSource/loc/Strings.Designer.cs
+++ b/plugin/CactbotEventSource/loc/Strings.Designer.cs
@@ -19,7 +19,7 @@ namespace CactbotEventSource.loc {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "17.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class Strings {
@@ -84,6 +84,27 @@ namespace CactbotEventSource.loc {
         internal static string CactbotBaseInfo {
             get {
                 return ResourceManager.GetString("CactbotBaseInfo", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to These overlay(s) appear to be using an out of date cactbot path and likely are no longer receiving updates and working with new content: {0}
+        ///
+        ///
+        ///To fix this, you should remove and then re-add all of your cactbot overlays listed above.  To remove an overlay, go to ACT -&gt;Plugins -&gt; OverlayPlugin.dll -&gt; (overlay name).  Select the overlay, and click the Remove button.  Once removed, click the New button, select cactbot overlay type, and re-add it..
+        /// </summary>
+        internal static string CactbotPathWarning {
+            get {
+                return ResourceManager.GetString("CactbotPathWarning", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Broken Cactbot Overlay Paths.
+        /// </summary>
+        internal static string CactbotPathWarningTitle {
+            get {
+                return ResourceManager.GetString("CactbotPathWarningTitle", resourceCulture);
             }
         }
         

--- a/plugin/CactbotEventSource/loc/Strings.resx
+++ b/plugin/CactbotEventSource/loc/Strings.resx
@@ -126,6 +126,15 @@
   <data name="CactbotBaseInfo" xml:space="preserve">
     <value>cactbot: {0} {1} (dir: {2})</value>
   </data>
+  <data name="CactbotPathWarning" xml:space="preserve">
+    <value>These overlay(s) appear to be using an out of date cactbot path and likely are no longer receiving updates and working with new content: {0}
+
+
+To fix this, you should remove and then re-add all of your cactbot overlays listed above.  To remove an overlay, go to ACT -&gt;Plugins -&gt; OverlayPlugin.dll -&gt; (overlay name).  Select the overlay, and click the Remove button.  Once removed, click the New button, select cactbot overlay type, and re-add it.</value>
+  </data>
+  <data name="CactbotPathWarningTitle" xml:space="preserve">
+    <value>Broken Cactbot Overlay Paths</value>
+  </data>
   <data name="CactbotUserDirectory" xml:space="preserve">
     <value>cactbot user directory: {0}</value>
   </data>


### PR DESCRIPTION
Adds an ACT warning when there's an old path.

Wrong path: `cactbot/cactbot-version/ui/raidboss/etc`
Right path: `cactbot/cactbot/ui/raidboss/etc`

...where "version" is some cactbot version number.

This can happen if somebody adds and removes the cactbot plugin but doesn't add and remove their overlays *and* they were on an old version of cactbot that still had version numbers in the path.

Closes https://github.com/OverlayPlugin/OverlayPlugin/pull/227/