### PR TITLE
test: remove non-existent FileChanged event

### DIFF
--- a/types/event.d.ts
+++ b/types/event.d.ts
@@ -196,11 +196,6 @@ export interface EventMap {
     charName: string;
   }) => void;
 
-  'FileChanged': (ev: {
-    type: 'FileChanged';
-    file: string;
-  }) => void;
-
   'OnlineStatusChanged': (ev: {
     type: 'OnlineStatusChanged';
     target: string;

--- a/ui/test/test.ts
+++ b/ui/test/test.ts
@@ -175,8 +175,4 @@ addOverlayListener('onUserFileChanged', (e) => {
   console.log(`User file ${e.file} changed!`);
 });
 
-addOverlayListener('FileChanged', (e) => {
-  console.log(`File ${e.file} changed!`);
-});
-
 void callOverlayHandler({ call: 'cactbotRequestState' });


### PR DESCRIPTION
It looks like this was removed in:
https://github.com/OverlayPlugin/OverlayPlugin/pull/165
