### PR TITLE
raidboss: handle player object arrays in output params

### DIFF
--- a/resources/party.ts
+++ b/resources/party.ts
@@ -159,7 +159,17 @@ export default class PartyTracker {
     return this.idToName_[id];
   }
 
-  member(name: string): PartyMemberParamObject | undefined {
+  member(name?: string): PartyMemberParamObject {
+    // For boilerplate convenience in triggers, handle undefined names.
+    if (name === undefined) {
+      const unknown = '???';
+      return {
+        name: unknown,
+        nick: unknown,
+        toString: () => unknown,
+      };
+    }
+
     const partyMember = this.details.find((member) => member.name === name);
     let ret: PartyMemberParamObject;
     const nick = Util.shortName(name, this.options.PlayerNicks);

--- a/types/trigger.d.ts
+++ b/types/trigger.d.ts
@@ -43,8 +43,9 @@ export type OutputStringsParamObject = {
   toString: () => string;
 };
 
+export type OutputStringsParam = string | number | OutputStringsParamObject;
 export type OutputStringsParams = {
-  [param: string]: string | number | OutputStringsParamObject | undefined;
+  [param: string]: OutputStringsParam | OutputStringsParam[] | undefined;
 };
 
 // TODO: is it awkward to have Outputs the static class and Output the unrelated type?


### PR DESCRIPTION
Followup to #5861 and discussions on #5891.

As the comment in the code specifies, if a trigger passes in `players: [player1, player2, player3]`, and a user specifies `${players.job}`, then return: `${players[0].job}, ${players[1].job}, ${players[2].job}`.

In general, this means that all array elements must either be simple strings/numbers or all share the same prop, or there will be errors below about non-existent properties. In practice, this likely will never happen.

This will also handle simpler cases like: `output.safeSpots!({ dirs: [output.front!(), output.back!(), output.left!()] })`

This also allows for `data.party.member(undefined)` to return '???', just to reduce boilerplate.