### PR TITLE
oopsy: update oopsy code to use player objects

### DIFF
--- a/types/data.d.ts
+++ b/types/data.d.ts
@@ -33,6 +33,7 @@ export interface RaidbossData {
   options: BaseOptions;
   inCombat: boolean;
   triggerSetConfig: { [key: string]: ConfigValue };
+  /** @deprecated Use data.party.member instead */
   ShortName: (x?: string) => string;
   StopCombat: () => void;
   /** @deprecated Use parseFloat instead */
@@ -52,6 +53,7 @@ export interface OopsyData {
   party: PartyTracker;
   inCombat: boolean;
   IsImmune: (x?: string) => boolean;
+  /** @deprecated Use data.party.member instead */
   ShortName: (x?: string) => string;
   IsPlayerId: (x?: string) => boolean;
   DamageFromMatches: (matches: NetMatches['Ability']) => number;

--- a/ui/oopsyraidsy/damage_tracker.ts
+++ b/ui/oopsyraidsy/damage_tracker.ts
@@ -1,5 +1,6 @@
 import logDefinitions from '../../resources/netlog_defs';
 import NetRegexes, { commonNetRegex } from '../../resources/netregexes';
+import PartyTracker from '../../resources/party';
 import { PlayerChangedDetail } from '../../resources/player_override';
 import Regexes from '../../resources/regexes';
 import { LocaleNetRegex } from '../../resources/translations';
@@ -125,6 +126,7 @@ export class DamageTracker {
   constructor(
     private options: OopsyOptions,
     private collector: MistakeCollector,
+    partyTracker: PartyTracker,
     private dataFiles: OopsyFileData,
   ) {
     const timestampCallback = (timestamp: number, callback: (timestamp: number) => void) =>
@@ -132,6 +134,7 @@ export class DamageTracker {
     this.playerStateTracker = new PlayerStateTracker(
       this.options,
       this.collector,
+      partyTracker,
       timestampCallback,
     );
 
@@ -170,7 +173,7 @@ export class DamageTracker {
           return true;
         return false;
       },
-      ShortName: (name?: string) => Util.shortName(name, this.options.PlayerNicks),
+      ShortName: (name?: string) => this.playerStateTracker.partyTracker.member(name).toString(),
       IsPlayerId: IsPlayerId,
       DamageFromMatches: (matches: NetMatches['Ability']) => UnscrambleDamage(matches?.damage),
       options: this.options,

--- a/ui/oopsyraidsy/data/00-misc/general.ts
+++ b/ui/oopsyraidsy/data/00-misc/general.ts
@@ -171,21 +171,22 @@ const triggerSet: OopsyTriggerSet<Data> = {
         const overwrittenRaise = data.lastRaisedLostTime[matches.targetId] === matches.timestamp;
         // if that's not the case, target doesn't have a raise yet
         if (!overwrittenRaise) {
-          data.originalRaiser[matches.targetId] = data.ShortName(matches.source);
+          data.originalRaiser[matches.targetId] = matches.source;
           return;
         }
         // otherwise, report overwritten raise
         if (originalRaiser !== undefined) {
           delete data.lastRaisedLostTime[matches.targetId];
+          const originalRaiserShort = data.party.member(originalRaiser).toString();
           return {
             type: 'warn',
             blame: matches.source,
             reportId: matches.sourceId,
             text: {
-              en: `overwrote ${originalRaiser}'s raise`,
-              de: `überschrieb ${originalRaiser}'s Wiederbeleben`,
-              cn: `顶掉了${originalRaiser}的复活`,
-              ko: `${originalRaiser}의 부활과 겹침`,
+              en: `overwrote ${originalRaiserShort}'s raise`,
+              de: `überschrieb ${originalRaiserShort}'s Wiederbeleben`,
+              cn: `顶掉了${originalRaiserShort}的复活`,
+              ko: `${originalRaiserShort}의 부활과 겹침`,
             },
           };
         }
@@ -208,15 +209,16 @@ const triggerSet: OopsyTriggerSet<Data> = {
         if (targetId !== undefined) {
           const originalRaiser = data.originalRaiser[targetId];
           if (originalRaiser !== undefined) {
+            const originalRaiserShort = data.party.member(originalRaiser).toString();
             return {
               type: 'warn',
               blame: matches.source,
               reportId: matches.sourceId,
               text: {
-                en: `overwrote ${originalRaiser}'s raise`,
-                de: `überschrieb ${originalRaiser}'s Wiederbeleben`,
-                cn: `顶掉了${originalRaiser}的复活`,
-                ko: `${originalRaiser}의 부활과 겹침`,
+                en: `overwrote ${originalRaiserShort}'s raise`,
+                de: `überschrieb ${originalRaiserShort}'s Wiederbeleben`,
+                cn: `顶掉了${originalRaiserShort}的复活`,
+                ko: `${originalRaiserShort}의 부활과 겹침`,
               },
             };
           }
@@ -241,7 +243,7 @@ const triggerSet: OopsyTriggerSet<Data> = {
           ? (data.targetMitTracker[matches.targetId] ??= {})
           : data.partyMitTracker;
         const newTime = new Date(matches.timestamp).getTime();
-        const newSource = data.ShortName(matches.source);
+        const newSource = matches.source;
         const lastTime = mitTracker[matches.id]?.time;
         const lastSource = mitTracker[matches.id]?.source;
 
@@ -258,15 +260,16 @@ const triggerSet: OopsyTriggerSet<Data> = {
           const leeway =
             (duration * 1000 - diff) > data.options.MinimumTimeForOverwrittenMit * 1000;
           if (diff < duration * 1000 && leeway) {
+            const lastSourceShort = data.party.member(lastSource).toString();
             return {
               type: 'heal',
               blame: matches.source,
               reportId: matches.sourceId,
               text: {
-                en: `overwrote ${lastSource}'s ${matches.ability}`,
-                de: `überschrieb ${lastSource}'s ${matches.ability}`,
-                cn: `顶掉了${lastSource}的${matches.ability}`,
-                ko: `${lastSource}의 ${matches.ability} 덮어씀`,
+                en: `overwrote ${lastSourceShort}'s ${matches.ability}`,
+                de: `überschrieb ${lastSourceShort}'s ${matches.ability}`,
+                cn: `顶掉了${lastSourceShort}的${matches.ability}`,
+                ko: `${lastSourceShort}의 ${matches.ability} 덮어씀`,
               },
             };
           }

--- a/ui/oopsyraidsy/data/05-shb/raid/e12s.ts
+++ b/ui/oopsyraidsy/data/05-shb/raid/e12s.ts
@@ -198,7 +198,7 @@ const triggerSet: OopsyTriggerSet<Data> = {
         }
 
         const owner = owners[0];
-        const ownerNick = data.ShortName(owner);
+        const ownerNick = data.party.member(owner).toString();
         let text = {
           en: `${matches.ability} (from ${ownerNick}, #${number})`,
           de: `${matches.ability} (von ${ownerNick}, #${number})`,
@@ -255,7 +255,7 @@ const triggerSet: OopsyTriggerSet<Data> = {
         return matches.target !== data.pillarIdToOwner[matches.sourceId];
       },
       mistake: (data, matches) => {
-        const pillarOwner = data.ShortName(data.pillarIdToOwner?.[matches.sourceId]);
+        const pillarOwner = data.party.member(data.pillarIdToOwner?.[matches.sourceId]).toString();
         return {
           type: 'fail',
           blame: matches.target,
@@ -330,7 +330,7 @@ const triggerSet: OopsyTriggerSet<Data> = {
         const hasFireDebuff = data.fire && data.fire[matches.target];
 
         if (hasSmallLion || hasFireDebuff) {
-          const ownerNick = data.ShortName(owner);
+          const ownerNick = data.party.member(owner).toString();
 
           const centerY = -75;
           const x = parseFloat(matches.x);

--- a/ui/oopsyraidsy/oopsy_live_list.ts
+++ b/ui/oopsyraidsy/oopsy_live_list.ts
@@ -1,6 +1,6 @@
 import { UnreachableCode } from '../../resources/not_reached';
 import { callOverlayHandler } from '../../resources/overlay_plugin_api';
-import Util from '../../resources/util';
+import PartyTracker from '../../resources/party';
 import { OopsyMistake } from '../../types/oopsy';
 
 import { DeathReport } from './death_report';
@@ -193,7 +193,11 @@ export class OopsyLiveList implements MistakeObserver {
   private deathReport?: DeathReportLive;
   private itemIdxToListener: { [itemIdx: number]: () => void } = {};
 
-  constructor(private options: OopsyOptions, private scroller: HTMLElement) {
+  constructor(
+    private options: OopsyOptions,
+    private scroller: HTMLElement,
+    private partyTracker: PartyTracker,
+  ) {
     const container = this.scroller.children[0];
     if (!container)
       throw new UnreachableCode();
@@ -274,7 +278,7 @@ export class OopsyLiveList implements MistakeObserver {
     const iconClass = m.type;
     const blame = m.name ?? m.blame;
     const blameText = blame !== undefined
-      ? `${Util.shortName(blame, this.options.PlayerNicks)}: `
+      ? `${this.partyTracker.member(blame).toString()}: `
       : '';
     const translatedText = Translate(this.options.DisplayLanguage, m.text);
     if (translatedText === undefined)

--- a/ui/oopsyraidsy/oopsy_summary_list.ts
+++ b/ui/oopsyraidsy/oopsy_summary_list.ts
@@ -1,4 +1,4 @@
-import Util from '../../resources/util';
+import PartyTracker from '../../resources/party';
 import { OopsyMistake } from '../../types/oopsy';
 
 import { DeathReport } from './death_report';
@@ -27,7 +27,10 @@ export class OopsySummaryTable implements MistakeObserver {
   private sortCol = 'death';
   private sortAsc = false;
 
-  constructor(private options: OopsyOptions, private table: HTMLElement) {
+  constructor(
+    private table: HTMLElement,
+    private partyTracker: PartyTracker,
+  ) {
     // this.table has one column for name, and then one for each of the types.
     document.documentElement.style.setProperty('--table-cols', (this.types.length + 1).toString());
   }
@@ -85,7 +88,7 @@ export class OopsySummaryTable implements MistakeObserver {
     const longName = m.name ?? m.blame;
     if (longName === undefined)
       return;
-    const name = Util.shortName(longName, this.options.PlayerNicks);
+    const name = this.partyTracker.member(longName).toString();
 
     // Don't create a player row if the summary doesn't care about this type of mistake.
     if (!this.types.includes(m.type))
@@ -154,7 +157,11 @@ export class OopsySummaryList implements MistakeObserver {
   private currentDiv: HTMLElement | null = null;
   private baseTime?: number;
 
-  constructor(private options: OopsyOptions, private container: HTMLElement) {
+  constructor(
+    private options: OopsyOptions,
+    private container: HTMLElement,
+    private partyTracker: PartyTracker,
+  ) {
     this.container.classList.remove('hide');
   }
 
@@ -218,7 +225,7 @@ export class OopsySummaryList implements MistakeObserver {
     const iconClass = m.type;
     const blame = m.name ?? m.blame;
     const blameText = blame !== undefined
-      ? `${Util.shortName(blame, this.options.PlayerNicks)}: `
+      ? `${this.partyTracker.member(blame).toString()}: `
       : '';
     const text = Translate(this.options.DisplayLanguage, m.text);
     if (text === undefined)

--- a/ui/oopsyraidsy/oopsy_viewer.ts
+++ b/ui/oopsyraidsy/oopsy_viewer.ts
@@ -1,5 +1,6 @@
 import { UnreachableCode } from '../../resources/not_reached';
 import { callOverlayHandler } from '../../resources/overlay_plugin_api';
+import PartyTracker from '../../resources/party';
 import UserConfig from '../../resources/user_config';
 import { LocaleText } from '../../types/trigger';
 
@@ -56,22 +57,24 @@ const initViewer = (options: OopsyOptions, _isConnected: boolean) => {
   // TODO: fix early pulls from logs (and also make them more accurate <_<)
   (options.DisabledTriggers ??= {})[earlyPullTriggerId] = true;
 
+  // TODO: should we fake this out for the viewer so that it knows jobs?
+  const partyTracker = new PartyTracker(options);
   const mistakeCollector = new MistakeCollector(options, false);
   const summaryElement = document.getElementById('summary');
 
   if (!summaryElement)
     throw new UnreachableCode();
 
-  const listView = new OopsySummaryList(options, summaryElement);
+  const listView = new OopsySummaryList(options, summaryElement, partyTracker);
   mistakeCollector.AddObserver(listView);
 
   const tableElement = document.getElementById('mistake-table');
   if (!tableElement)
     throw new UnreachableCode();
-  const table = new OopsySummaryTable(options, tableElement);
+  const table = new OopsySummaryTable(tableElement, partyTracker);
   mistakeCollector.AddObserver(table);
 
-  const damageTracker = new DamageTracker(options, mistakeCollector, oopsyFileData);
+  const damageTracker = new DamageTracker(options, mistakeCollector, partyTracker, oopsyFileData);
 
   const fileDrop = document.getElementById('filedrop');
   if (!fileDrop)

--- a/ui/oopsyraidsy/oopsyraidsy.ts
+++ b/ui/oopsyraidsy/oopsyraidsy.ts
@@ -1,5 +1,6 @@
 import { UnreachableCode } from '../../resources/not_reached';
 import { addOverlayListener, callOverlayHandler } from '../../resources/overlay_plugin_api';
+import PartyTracker from '../../resources/party';
 import UserConfig from '../../resources/user_config';
 import { OopsyMistakeType } from '../../types/oopsy';
 
@@ -45,6 +46,7 @@ export const addDebugInfo = (collector: MistakeCollector, numMistakes: number): 
 UserConfig.getUserConfigLocation('oopsyraidsy', defaultOptions, () => {
   const options = { ...defaultOptions };
 
+  const partyTracker = new PartyTracker(options);
   const mistakeCollector = new MistakeCollector(options, true);
   const summaryElement = document.getElementById('summary');
   const liveListElement = document.getElementById('livelist');
@@ -52,16 +54,16 @@ UserConfig.getUserConfigLocation('oopsyraidsy', defaultOptions, () => {
   // Choose the ui based on whether this is the summary view or the live list.
   // They have different elements in the file.
   if (summaryElement) {
-    const listView = new OopsySummaryList(options, summaryElement);
+    const listView = new OopsySummaryList(options, summaryElement, partyTracker);
     mistakeCollector.AddObserver(listView);
 
     const tableElement = document.getElementById('mistake-table');
     if (!tableElement)
       throw new UnreachableCode();
-    const table = new OopsySummaryTable(options, tableElement);
+    const table = new OopsySummaryTable(tableElement, partyTracker);
     mistakeCollector.AddObserver(table);
   } else if (liveListElement) {
-    const listView = new OopsyLiveList(options, liveListElement);
+    const listView = new OopsyLiveList(options, liveListElement, partyTracker);
     mistakeCollector.AddObserver(listView);
     addOverlayListener(
       'onInCombatChangedEvent',
@@ -77,7 +79,7 @@ UserConfig.getUserConfigLocation('oopsyraidsy', defaultOptions, () => {
   if (typeof params.get('debug') === 'string')
     addDebugInfo(mistakeCollector, 2200);
 
-  const damageTracker = new DamageTracker(options, mistakeCollector, oopsyFileData);
+  const damageTracker = new DamageTracker(options, mistakeCollector, partyTracker, oopsyFileData);
 
   addOverlayListener('LogLine', (e) => damageTracker.OnNetLog(e));
   addOverlayListener('onPlayerChangedEvent', (e) => damageTracker.OnPlayerChange(e));

--- a/ui/oopsyraidsy/player_state_tracker.ts
+++ b/ui/oopsyraidsy/player_state_tracker.ts
@@ -1,7 +1,6 @@
 import logDefinitions from '../../resources/netlog_defs';
 import { UnreachableCode } from '../../resources/not_reached';
 import PartyTracker from '../../resources/party';
-import Util from '../../resources/util';
 import { Party } from '../../types/event';
 import {
   DeathReportData,
@@ -80,8 +79,6 @@ export type TrackedEventType = TrackedEvent['type'];
 // * Generates some internal mistakes that need extra tracking (missed buffs, deaths)
 // * Tracks events in `trackedEvents` that can be handed to DeathReports for processing.
 export class PlayerStateTracker {
-  public partyTracker: PartyTracker;
-
   private missedBuffCollector;
   private triggerSets: ProcessedOopsyTriggerSet[] = [];
   private partyIds: Set<string> = new Set();
@@ -110,9 +107,9 @@ export class PlayerStateTracker {
   constructor(
     private options: OopsyOptions,
     private collector: MistakeCollector,
+    public partyTracker: PartyTracker,
     requestTimestampCallback: RequestTimestampCallback,
   ) {
-    this.partyTracker = new PartyTracker(this.options);
     this.missedBuffCollector = new MissedBuffCollector(
       requestTimestampCallback,
       (timestamp, buff) => this.OnBuffCollected(timestamp, buff),
@@ -569,7 +566,7 @@ export class PlayerStateTracker {
     // TODO: oopsy could really use mouseover popups for details.
     if (missedNames.length < 4) {
       const nameList = missedNames.map((name) => {
-        return Util.shortName(name, this.options.PlayerNicks);
+        return this.partyTracker.member(name).toString();
       }).join(', ');
 
       // As a TrackedLineEvent has been pushed for each person missed already,

--- a/ui/raidboss/popup-text.ts
+++ b/ui/raidboss/popup-text.ts
@@ -1040,10 +1040,6 @@ export class PopupText {
       this.Reset();
   }
 
-  ShortNamify(name?: string): string {
-    return Util.shortName(name, this.options.PlayerNicks);
-  }
-
   Reset(): void {
     Util.clearWatchCombatants();
     this.data = this.getDataObject();


### PR DESCRIPTION
Followup to #5861.

There's no "output strings" in oopsy, but it does use ShortName in a few places. Move this over to data.party.member(x).toString() in order to potentially support an oopsy option for how to display names.

This also changes some logic for mit tracking and raise tracking to use full names instead of short names when storing and comparing, only using the shortened version for output.

This also creates the party tracker earlier so that it can be passed to all the things that want to use it, and so all of oopsy can indirect through `PartyTracker` to find out short names.