### PR TITLE
lint: add errors for using deprecated functions

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -16,6 +16,7 @@ const settings = {
     'eslint:recommended',
     'google',
     'plugin:import/errors',
+    'plugin:deprecation/recommended',
   ],
   'ignorePatterns': [
     // Do not ignore dot files.  /o\
@@ -30,11 +31,13 @@ const settings = {
     'publish/',
     'resources/lib/',
   ],
+  'parser': '@typescript-eslint/parser',
   'parserOptions': {
     'ecmaVersion': 2022,
     'sourceType': 'module',
   },
   'plugins': [
+    'deprecation',
     'import',
     'rulesdir',
   ],

--- a/package-lock.json
+++ b/package-lock.json
@@ -56,6 +56,7 @@
         "eslint": "^8.26.0",
         "eslint-config-google": "^0.14.0",
         "eslint-import-resolver-typescript": "^3.5.2",
+        "eslint-plugin-deprecation": "^2.0.0",
         "eslint-plugin-import": "^2.22.1",
         "eslint-plugin-prefer-arrow": "^1.2.3",
         "eslint-plugin-rulesdir": "^0.2.1",
@@ -1883,6 +1884,21 @@
         "win32"
       ]
     },
+    "node_modules/@eslint-community/eslint-utils": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.4.0.tgz",
+      "integrity": "sha512-1/sA4dwrzBAyeUoQ6oxahHKmrZvsnLCg4RfxW3ZFGGmQkSNQPFNLV9CUEFQP1x9EYXHTo5p6xdhZM1Ne9p/AfA==",
+      "dev": true,
+      "dependencies": {
+        "eslint-visitor-keys": "^3.3.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "peerDependencies": {
+        "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0"
+      }
+    },
     "node_modules/@eslint/eslintrc": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.3.3.tgz",
@@ -2501,9 +2517,9 @@
       }
     },
     "node_modules/@types/json-schema": {
-      "version": "7.0.11",
-      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.11.tgz",
-      "integrity": "sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ==",
+      "version": "7.0.15",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
       "dev": true
     },
     "node_modules/@types/json5": {
@@ -2615,9 +2631,9 @@
       "dev": true
     },
     "node_modules/@types/semver": {
-      "version": "7.3.13",
-      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.3.13.tgz",
-      "integrity": "sha512-21cFJr9z3g5dW8B0CVI9g2O9beqaThGQ6ZFBqHfwhzLDKUxaqTIy3vnfah/UPkfOiF2pLq+tGz+W8RyCskuslw==",
+      "version": "7.5.5",
+      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.5.tgz",
+      "integrity": "sha512-+d+WYC1BxJ6yVOgUgzK8gWvp5qF8ssV5r4nsDcZWKRWcDQLQ619tvWAxJQYGgBrO1MnLJC7a5GtiYsAoQ47dJg==",
       "dev": true
     },
     "node_modules/@types/serve-index": {
@@ -6126,6 +6142,153 @@
         "ms": "^2.1.1"
       }
     },
+    "node_modules/eslint-plugin-deprecation": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-deprecation/-/eslint-plugin-deprecation-2.0.0.tgz",
+      "integrity": "sha512-OAm9Ohzbj11/ZFyICyR5N6LbOIvQMp7ZU2zI7Ej0jIc8kiGUERXPNMfw2QqqHD1ZHtjMub3yPZILovYEYucgoQ==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/utils": "^6.0.0",
+        "tslib": "^2.3.1",
+        "tsutils": "^3.21.0"
+      },
+      "peerDependencies": {
+        "eslint": "^7.0.0 || ^8.0.0",
+        "typescript": "^4.2.4 || ^5.0.0"
+      }
+    },
+    "node_modules/eslint-plugin-deprecation/node_modules/@typescript-eslint/scope-manager": {
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-6.10.0.tgz",
+      "integrity": "sha512-TN/plV7dzqqC2iPNf1KrxozDgZs53Gfgg5ZHyw8erd6jd5Ta/JIEcdCheXFt9b1NYb93a1wmIIVW/2gLkombDg==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/types": "6.10.0",
+        "@typescript-eslint/visitor-keys": "6.10.0"
+      },
+      "engines": {
+        "node": "^16.0.0 || >=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/eslint-plugin-deprecation/node_modules/@typescript-eslint/types": {
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.10.0.tgz",
+      "integrity": "sha512-36Fq1PWh9dusgo3vH7qmQAj5/AZqARky1Wi6WpINxB6SkQdY5vQoT2/7rW7uBIsPDcvvGCLi4r10p0OJ7ITAeg==",
+      "dev": true,
+      "engines": {
+        "node": "^16.0.0 || >=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/eslint-plugin-deprecation/node_modules/@typescript-eslint/typescript-estree": {
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-6.10.0.tgz",
+      "integrity": "sha512-ek0Eyuy6P15LJVeghbWhSrBCj/vJpPXXR+EpaRZqou7achUWL8IdYnMSC5WHAeTWswYQuP2hAZgij/bC9fanBg==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/types": "6.10.0",
+        "@typescript-eslint/visitor-keys": "6.10.0",
+        "debug": "^4.3.4",
+        "globby": "^11.1.0",
+        "is-glob": "^4.0.3",
+        "semver": "^7.5.4",
+        "ts-api-utils": "^1.0.1"
+      },
+      "engines": {
+        "node": "^16.0.0 || >=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-plugin-deprecation/node_modules/@typescript-eslint/utils": {
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-6.10.0.tgz",
+      "integrity": "sha512-v+pJ1/RcVyRc0o4wAGux9x42RHmAjIGzPRo538Z8M1tVx6HOnoQBCX/NoadHQlZeC+QO2yr4nNSFWOoraZCAyg==",
+      "dev": true,
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.4.0",
+        "@types/json-schema": "^7.0.12",
+        "@types/semver": "^7.5.0",
+        "@typescript-eslint/scope-manager": "6.10.0",
+        "@typescript-eslint/types": "6.10.0",
+        "@typescript-eslint/typescript-estree": "6.10.0",
+        "semver": "^7.5.4"
+      },
+      "engines": {
+        "node": "^16.0.0 || >=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/eslint-plugin-deprecation/node_modules/@typescript-eslint/visitor-keys": {
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.10.0.tgz",
+      "integrity": "sha512-xMGluxQIEtOM7bqFCo+rCMh5fqI+ZxV5RUUOa29iVPz1OgCZrtc7rFnz5cLUazlkPKYqX+75iuDq7m0HQ48nCg==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/types": "6.10.0",
+        "eslint-visitor-keys": "^3.4.1"
+      },
+      "engines": {
+        "node": "^16.0.0 || >=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/eslint-plugin-deprecation/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dev": true,
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/eslint-plugin-deprecation/node_modules/semver": {
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/eslint-plugin-deprecation/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "dev": true
+    },
     "node_modules/eslint-plugin-import": {
       "version": "2.26.0",
       "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.26.0.tgz",
@@ -6316,12 +6479,15 @@
       }
     },
     "node_modules/eslint-visitor-keys": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.3.0.tgz",
-      "integrity": "sha512-mQ+suqKJVyeuwGYHAdjMFqjCyfl8+Ldnxuyp3ldiMBFKkvytrXUZWaiPCEav8qDHKty44bD+qV1IP4T+w+xXRA==",
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+      "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
       "dev": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
       }
     },
     "node_modules/eslint/node_modules/ansi-styles": {
@@ -15074,6 +15240,18 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/ts-api-utils": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-1.0.3.tgz",
+      "integrity": "sha512-wNMeqtMz5NtwpT/UZGY5alT+VoKdSsOOP/kqHFcUW1P/VRhH2wJ48+DN2WwUliNbQ976ETwDL0Ifd2VVvgonvg==",
+      "dev": true,
+      "engines": {
+        "node": ">=16.13.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.2.0"
+      }
+    },
     "node_modules/ts-loader": {
       "version": "9.4.1",
       "resolved": "https://registry.npmjs.org/ts-loader/-/ts-loader-9.4.1.tgz",
@@ -17801,6 +17979,15 @@
       "dev": true,
       "optional": true
     },
+    "@eslint-community/eslint-utils": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.4.0.tgz",
+      "integrity": "sha512-1/sA4dwrzBAyeUoQ6oxahHKmrZvsnLCg4RfxW3ZFGGmQkSNQPFNLV9CUEFQP1x9EYXHTo5p6xdhZM1Ne9p/AfA==",
+      "dev": true,
+      "requires": {
+        "eslint-visitor-keys": "^3.3.0"
+      }
+    },
     "@eslint/eslintrc": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.3.3.tgz",
@@ -18362,9 +18549,9 @@
       }
     },
     "@types/json-schema": {
-      "version": "7.0.11",
-      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.11.tgz",
-      "integrity": "sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ==",
+      "version": "7.0.15",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
       "dev": true
     },
     "@types/json5": {
@@ -18476,9 +18663,9 @@
       "dev": true
     },
     "@types/semver": {
-      "version": "7.3.13",
-      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.3.13.tgz",
-      "integrity": "sha512-21cFJr9z3g5dW8B0CVI9g2O9beqaThGQ6ZFBqHfwhzLDKUxaqTIy3vnfah/UPkfOiF2pLq+tGz+W8RyCskuslw==",
+      "version": "7.5.5",
+      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.5.tgz",
+      "integrity": "sha512-+d+WYC1BxJ6yVOgUgzK8gWvp5qF8ssV5r4nsDcZWKRWcDQLQ619tvWAxJQYGgBrO1MnLJC7a5GtiYsAoQ47dJg==",
       "dev": true
     },
     "@types/serve-index": {
@@ -21243,6 +21430,99 @@
         }
       }
     },
+    "eslint-plugin-deprecation": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-deprecation/-/eslint-plugin-deprecation-2.0.0.tgz",
+      "integrity": "sha512-OAm9Ohzbj11/ZFyICyR5N6LbOIvQMp7ZU2zI7Ej0jIc8kiGUERXPNMfw2QqqHD1ZHtjMub3yPZILovYEYucgoQ==",
+      "dev": true,
+      "requires": {
+        "@typescript-eslint/utils": "^6.0.0",
+        "tslib": "^2.3.1",
+        "tsutils": "^3.21.0"
+      },
+      "dependencies": {
+        "@typescript-eslint/scope-manager": {
+          "version": "6.10.0",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-6.10.0.tgz",
+          "integrity": "sha512-TN/plV7dzqqC2iPNf1KrxozDgZs53Gfgg5ZHyw8erd6jd5Ta/JIEcdCheXFt9b1NYb93a1wmIIVW/2gLkombDg==",
+          "dev": true,
+          "requires": {
+            "@typescript-eslint/types": "6.10.0",
+            "@typescript-eslint/visitor-keys": "6.10.0"
+          }
+        },
+        "@typescript-eslint/types": {
+          "version": "6.10.0",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.10.0.tgz",
+          "integrity": "sha512-36Fq1PWh9dusgo3vH7qmQAj5/AZqARky1Wi6WpINxB6SkQdY5vQoT2/7rW7uBIsPDcvvGCLi4r10p0OJ7ITAeg==",
+          "dev": true
+        },
+        "@typescript-eslint/typescript-estree": {
+          "version": "6.10.0",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-6.10.0.tgz",
+          "integrity": "sha512-ek0Eyuy6P15LJVeghbWhSrBCj/vJpPXXR+EpaRZqou7achUWL8IdYnMSC5WHAeTWswYQuP2hAZgij/bC9fanBg==",
+          "dev": true,
+          "requires": {
+            "@typescript-eslint/types": "6.10.0",
+            "@typescript-eslint/visitor-keys": "6.10.0",
+            "debug": "^4.3.4",
+            "globby": "^11.1.0",
+            "is-glob": "^4.0.3",
+            "semver": "^7.5.4",
+            "ts-api-utils": "^1.0.1"
+          }
+        },
+        "@typescript-eslint/utils": {
+          "version": "6.10.0",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-6.10.0.tgz",
+          "integrity": "sha512-v+pJ1/RcVyRc0o4wAGux9x42RHmAjIGzPRo538Z8M1tVx6HOnoQBCX/NoadHQlZeC+QO2yr4nNSFWOoraZCAyg==",
+          "dev": true,
+          "requires": {
+            "@eslint-community/eslint-utils": "^4.4.0",
+            "@types/json-schema": "^7.0.12",
+            "@types/semver": "^7.5.0",
+            "@typescript-eslint/scope-manager": "6.10.0",
+            "@typescript-eslint/types": "6.10.0",
+            "@typescript-eslint/typescript-estree": "6.10.0",
+            "semver": "^7.5.4"
+          }
+        },
+        "@typescript-eslint/visitor-keys": {
+          "version": "6.10.0",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.10.0.tgz",
+          "integrity": "sha512-xMGluxQIEtOM7bqFCo+rCMh5fqI+ZxV5RUUOa29iVPz1OgCZrtc7rFnz5cLUazlkPKYqX+75iuDq7m0HQ48nCg==",
+          "dev": true,
+          "requires": {
+            "@typescript-eslint/types": "6.10.0",
+            "eslint-visitor-keys": "^3.4.1"
+          }
+        },
+        "lru-cache": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+          "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+          "dev": true,
+          "requires": {
+            "yallist": "^4.0.0"
+          }
+        },
+        "semver": {
+          "version": "7.5.4",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+          "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
+          "dev": true,
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
+        },
+        "yallist": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+          "dev": true
+        }
+      }
+    },
     "eslint-plugin-import": {
       "version": "2.26.0",
       "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.26.0.tgz",
@@ -21388,9 +21668,9 @@
       }
     },
     "eslint-visitor-keys": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.3.0.tgz",
-      "integrity": "sha512-mQ+suqKJVyeuwGYHAdjMFqjCyfl8+Ldnxuyp3ldiMBFKkvytrXUZWaiPCEav8qDHKty44bD+qV1IP4T+w+xXRA==",
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+      "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
       "dev": true
     },
     "espree": {
@@ -27719,6 +27999,13 @@
       "resolved": "https://registry.npmjs.org/trough/-/trough-1.0.5.tgz",
       "integrity": "sha512-rvuRbTarPXmMb79SmzEp8aqXNKcK+y0XaB298IXueQ8I2PsrATcPBCSPyK/dDNa2iWOhKlfNnOjdAOTBU/nkFA==",
       "dev": true
+    },
+    "ts-api-utils": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-1.0.3.tgz",
+      "integrity": "sha512-wNMeqtMz5NtwpT/UZGY5alT+VoKdSsOOP/kqHFcUW1P/VRhH2wJ48+DN2WwUliNbQ976ETwDL0Ifd2VVvgonvg==",
+      "dev": true,
+      "requires": {}
     },
     "ts-loader": {
       "version": "9.4.1",

--- a/package.json
+++ b/package.json
@@ -80,6 +80,7 @@
     "eslint": "^8.26.0",
     "eslint-config-google": "^0.14.0",
     "eslint-import-resolver-typescript": "^3.5.2",
+    "eslint-plugin-deprecation": "^2.0.0",
     "eslint-plugin-import": "^2.22.1",
     "eslint-plugin-prefer-arrow": "^1.2.3",
     "eslint-plugin-rulesdir": "^0.2.1",

--- a/resources/overlay_plugin_api.ts
+++ b/resources/overlay_plugin_api.ts
@@ -298,12 +298,15 @@ export const init = (): void => {
     }
 
     // Here the OverlayPlugin API is registered to the window object,
-    // but this is mainly for backwards compatibility.For cactbot's built-in files,
+    // but this is mainly for backwards compatibility. For cactbot's built-in files,
     // it is recommended to use the various functions exported in resources/overlay_plugin_api.ts.
+
+    /* eslint-disable deprecation/deprecation */
     window.addOverlayListener = addOverlayListener;
     window.removeOverlayListener = removeOverlayListener;
     window.callOverlayHandler = callOverlayHandler;
     window.dispatchOverlayEvent = dispatchOverlayEvent;
+    /* eslint-enable deprecation/deprecation */
   }
 
   inited = true;

--- a/resources/regexes.ts
+++ b/resources/regexes.ts
@@ -381,16 +381,7 @@ export default class Regexes {
    * matches: https://github.com/quisquous/cactbot/blob/main/docs/LogGuide.md#line-03-0x03-addcombatant
    */
   static addedCombatant(params?: NetParams['AddedCombatant']): CactbotBaseRegExp<'AddedCombatant'> {
-    return parseHelper(
-      params,
-      'AddedCombatant',
-      defaultParams('AddedCombatant', Regexes.logVersion, [
-        'type',
-        'timestamp',
-        'id',
-        'name',
-      ]),
-    );
+    return buildRegex('AddedCombatant', params);
   }
 
   /**
@@ -399,7 +390,7 @@ export default class Regexes {
   static addedCombatantFull(
     params?: NetParams['AddedCombatant'],
   ): CactbotBaseRegExp<'AddedCombatant'> {
-    return buildRegex('AddedCombatant', params);
+    return this.addedCombatant(params);
   }
 
   /**

--- a/resources/user_config.ts
+++ b/resources/user_config.ts
@@ -277,11 +277,14 @@ class UserConfig {
       // If options files want to override it, they can for testing.
 
       // Backward compatibility (language is now separated to three types.)
+      /* eslint-disable deprecation/deprecation */
       if (e.detail.language) {
         options.ParserLanguage = e.detail.language;
         options.ShortLocale = e.detail.language;
         options.DisplayLanguage = e.detail.language;
       }
+      /* eslint-enable deprecation/deprecation */
+
       // Parser Language
       if (e.detail.parserLanguage) {
         options.ParserLanguage = e.detail.parserLanguage;

--- a/test/unittests/netregex_test.ts
+++ b/test/unittests/netregex_test.ts
@@ -49,6 +49,7 @@ describe('netregex tests', () => {
     assert.equal(matches?.z, '0');
     assert.equal(matches?.heading, '-3.057414');
 
+    /* eslint-disable-next-line deprecation/deprecation */
     assert.equal(NetRegexes.ability().source, NetRegexes.abilityFull().source);
   });
   it('networkDoT', () => {
@@ -105,6 +106,7 @@ describe('netregex tests', () => {
       '03|2020-02-25T00:56:34.2610000-08:00|4000d2dc|Eos|0|50|10696f5f|0||1398|1008|96534|96534|10000|0|0|0|101.266|114.659|0|-4.792213E-05||b7fe3042f22622325af486c0f9c7438b',
     ] as const;
     regexCaptureTest((params?: RegexUtilParams) => NetRegexes.addedCombatant(params), lines);
+    /* eslint-disable-next-line deprecation/deprecation */
     regexCaptureTest((params?: RegexUtilParams) => NetRegexes.addedCombatantFull(params), lines);
 
     let matches = lines[0].match(NetRegexes.addedCombatant())?.groups;
@@ -112,7 +114,7 @@ describe('netregex tests', () => {
     assert.equal(matches?.id, '1059c805');
     assert.equal(matches?.name, 'Potato Chippy');
 
-    matches = lines[0].match(NetRegexes.addedCombatantFull())?.groups;
+    matches = lines[0].match(NetRegexes.addedCombatant())?.groups;
     assert.equal(matches?.type, '03');
     assert.equal(matches?.id, '1059c805');
     assert.equal(matches?.name, 'Potato Chippy');
@@ -127,7 +129,7 @@ describe('netregex tests', () => {
     assert.equal(matches?.z, '18.00033');
     assert.equal(matches?.heading, '2.118315');
 
-    matches = lines[1].match(NetRegexes.addedCombatantFull())?.groups;
+    matches = lines[1].match(NetRegexes.addedCombatant())?.groups;
     assert.equal(matches?.type, '03');
     assert.equal(matches?.name, 'Earthen Aether');
     assert.equal(matches?.npcNameId, '9321');

--- a/test/unittests/netregex_test.ts
+++ b/test/unittests/netregex_test.ts
@@ -109,6 +109,9 @@ describe('netregex tests', () => {
     /* eslint-disable-next-line deprecation/deprecation */
     regexCaptureTest((params?: RegexUtilParams) => NetRegexes.addedCombatantFull(params), lines);
 
+    /* eslint-disable-next-line deprecation/deprecation */
+    assert.equal(NetRegexes.addedCombatant().source, NetRegexes.addedCombatantFull().source);
+
     let matches = lines[0].match(NetRegexes.addedCombatant())?.groups;
     assert.equal(matches?.type, '03');
     assert.equal(matches?.id, '1059c805');

--- a/test/unittests/regex_test.ts
+++ b/test/unittests/regex_test.ts
@@ -124,6 +124,9 @@ describe('regex tests', () => {
     /* eslint-disable-next-line deprecation/deprecation */
     regexCaptureTest((params?: RegexUtilParams) => Regexes.addedCombatantFull(params), lines);
 
+    /* eslint-disable-next-line deprecation/deprecation */
+    assert.equal(Regexes.addedCombatant().source, Regexes.addedCombatantFull().source);
+
     let matches = lines[0].match(Regexes.addedCombatant())?.groups;
     assert.equal(matches?.name, 'Potato Chippy');
 

--- a/test/unittests/regex_test.ts
+++ b/test/unittests/regex_test.ts
@@ -60,6 +60,7 @@ describe('regex tests', () => {
     assert.equal(matches?.sequence, '0000B2D4');
     assert.equal(matches?.targetIndex, '0');
 
+    /* eslint-disable-next-line deprecation/deprecation */
     assert.equal(Regexes.ability().source, Regexes.abilityFull().source);
   });
   it('networkDoT', () => {
@@ -120,12 +121,13 @@ describe('regex tests', () => {
     ] as const;
 
     regexCaptureTest((params?: RegexUtilParams) => Regexes.addedCombatant(params), lines);
+    /* eslint-disable-next-line deprecation/deprecation */
     regexCaptureTest((params?: RegexUtilParams) => Regexes.addedCombatantFull(params), lines);
 
     let matches = lines[0].match(Regexes.addedCombatant())?.groups;
     assert.equal(matches?.name, 'Potato Chippy');
 
-    matches = lines[0].match(Regexes.addedCombatantFull())?.groups;
+    matches = lines[0].match(Regexes.addedCombatant())?.groups;
     assert.equal(matches?.id, '1059C805');
     assert.equal(matches?.name, 'Potato Chippy');
     assert.equal(matches?.job, '1B');
@@ -139,7 +141,7 @@ describe('regex tests', () => {
     assert.equal(matches?.z, '18.00033');
     assert.equal(matches?.heading, '2.118315');
 
-    matches = lines[1].match(Regexes.addedCombatantFull())?.groups;
+    matches = lines[1].match(Regexes.addedCombatant())?.groups;
     assert.equal(matches?.id, '400264F6');
     assert.equal(matches?.name, 'Earthen Aether');
     assert.equal(matches?.npcNameId, '9321');

--- a/ui/config/config.ts
+++ b/ui/config/config.ts
@@ -578,6 +578,8 @@ export class CactbotConfigurator {
     container.appendChild(collapser);
 
     const a = document.createElement('a');
+    // TODO: fix me
+    /* eslint-disable-next-line deprecation/deprecation */
     a.name = group;
     collapser.appendChild(a);
 
@@ -920,6 +922,10 @@ export class CactbotConfigurator {
       let title = '???';
       let zoneId: number | undefined = undefined;
       let zoneLabel: LocaleText | undefined = undefined;
+
+      /* eslint-disable-next-line deprecation/deprecation */
+      const origZoneRegex = triggerSet.zoneRegex;
+
       // if a zoneLabel is set, use for the title
       if (triggerSet.zoneLabel) {
         zoneLabel = triggerSet.zoneLabel;
@@ -932,11 +938,11 @@ export class CactbotConfigurator {
           title = this.translate(zoneInfo.name);
       } else if (triggerSet.zoneId === null) {
         title = this.translate(kPrefixToCategory['00-misc']);
-      } else if (triggerSet.zoneRegex) {
+      } else if (origZoneRegex) {
         // zoneRegex can be a localized object.
-        let zoneRegex = triggerSet.zoneRegex instanceof RegExp
-          ? triggerSet.zoneRegex
-          : triggerSet.zoneRegex[this.lang];
+        let zoneRegex = origZoneRegex instanceof RegExp
+          ? origZoneRegex
+          : origZoneRegex[this.lang];
         if (typeof zoneRegex === 'string')
           zoneRegex = Regexes.parse(zoneRegex);
         if (zoneRegex instanceof RegExp)

--- a/ui/eureka/eureka.ts
+++ b/ui/eureka/eureka.ts
@@ -402,7 +402,7 @@ class EurekaTracker {
 
     if (this.zoneInfo.fairy) {
       const fairyName = this.TransByParserLang(this.zoneInfo.fairy);
-      this.fairyRegex = NetRegexes.addedCombatantFull({ name: fairyName });
+      this.fairyRegex = NetRegexes.addedCombatant({ name: fairyName });
     }
     this.playerElement = document.createElement('div');
     this.playerElement.classList.add('player');

--- a/ui/oopsyraidsy/damage_tracker.ts
+++ b/ui/oopsyraidsy/damage_tracker.ts
@@ -98,7 +98,7 @@ export class DamageTracker {
   private countdownEngageRegex: RegExp;
   private countdownStartRegex: RegExp;
   private countdownCancelRegex: RegExp;
-  private abilityFullRegex: CactbotBaseRegExp<'Ability'>;
+  private abilityRegex: CactbotBaseRegExp<'Ability'>;
   private wipeCactbotEcho: CactbotBaseRegExp<'GameLog'>;
   private wipeEndEcho: CactbotBaseRegExp<'GameLog'>;
   private combatState = new CombatState(this);
@@ -142,7 +142,7 @@ export class DamageTracker {
     this.countdownEngageRegex = LocaleNetRegex.countdownEngage[lang];
     this.countdownStartRegex = LocaleNetRegex.countdownStart[lang];
     this.countdownCancelRegex = LocaleNetRegex.countdownCancel[lang];
-    this.abilityFullRegex = NetRegexes.abilityFull();
+    this.abilityRegex = NetRegexes.ability();
     this.wipeCactbotEcho = commonNetRegex.cactbotWipeEcho;
     this.wipeEndEcho = commonNetRegex.userWipeEcho;
 
@@ -334,7 +334,7 @@ export class DamageTracker {
     // This is kind of obnoxious to have to regex match every ability line that's already split.
     // But, it turns it into a usable match object.
     // TODO: use log definitions here??
-    const lineMatches = this.abilityFullRegex.exec(line);
+    const lineMatches = this.abilityRegex.exec(line);
     if (!lineMatches || !lineMatches.groups)
       return;
 
@@ -544,7 +544,7 @@ export class DamageTracker {
       const trigger: OopsyTrigger<OopsyData> = {
         id: key,
         type: 'Ability',
-        netRegex: NetRegexes.abilityFull({ id: id, ...playerDamageFields }),
+        netRegex: NetRegexes.ability({ id: id, ...playerDamageFields }),
         mistake: (_data, matches) => {
           return {
             type: type,
@@ -620,7 +620,7 @@ export class DamageTracker {
       const trigger: OopsyTrigger<OopsyData> = {
         id: key,
         type: 'Ability',
-        netRegex: NetRegexes.abilityFull({ type: '21', id: id, ...playerDamageFields }),
+        netRegex: NetRegexes.ability({ type: '21', id: id, ...playerDamageFields }),
         mistake: (_data, matches) => {
           return {
             type: type,

--- a/ui/oopsyraidsy/data/00-misc/test.ts
+++ b/ui/oopsyraidsy/data/00-misc/test.ts
@@ -65,7 +65,7 @@ const triggerSet: OopsyTriggerSet<Data> = {
     {
       id: 'Test Bootshine',
       type: 'Ability',
-      netRegex: NetRegexes.abilityFull({ id: '35' }),
+      netRegex: NetRegexes.ability({ id: '35' }),
       condition: (data, matches) => {
         if (matches.source !== data.me)
           return false;

--- a/ui/oopsyraidsy/data/02-arr/trial/titan-ex.ts
+++ b/ui/oopsyraidsy/data/02-arr/trial/titan-ex.ts
@@ -27,7 +27,7 @@ const triggerSet: OopsyTriggerSet<Data> = {
     {
       id: 'TitanEx Landslide Pushed Off',
       type: 'Ability',
-      netRegex: NetRegexes.abilityFull({ id: '5BB', ...playerDamageFields }),
+      netRegex: NetRegexes.ability({ id: '5BB', ...playerDamageFields }),
       deathReason: (_data, matches) => {
         return {
           id: matches.targetId,

--- a/ui/oopsyraidsy/data/03-hw/dungeon/gubal_library_hard.ts
+++ b/ui/oopsyraidsy/data/03-hw/dungeon/gubal_library_hard.ts
@@ -80,7 +80,7 @@ const triggerSet: OopsyTriggerSet<Data> = {
       // Targets with Imp when Thunder III resolves receive a vulnerability stack and brief stun
       id: 'GubalHm Imp Thunder',
       type: 'Ability',
-      netRegex: NetRegexes.abilityFull({ id: '195[AB]', ...playerDamageFields }),
+      netRegex: NetRegexes.ability({ id: '195[AB]', ...playerDamageFields }),
       condition: (data, matches) => data.hasImp?.[matches.target],
       mistake: (_data, matches) => {
         return {
@@ -101,7 +101,7 @@ const triggerSet: OopsyTriggerSet<Data> = {
     {
       id: 'GubalHm Quake',
       type: 'Ability',
-      netRegex: NetRegexes.abilityFull({ id: '1956', ...playerDamageFields }),
+      netRegex: NetRegexes.ability({ id: '1956', ...playerDamageFields }),
       // Always hits target, but if correctly resolved will deal 0 damage
       condition: (data, matches) => data.DamageFromMatches(matches) > 0,
       mistake: (_data, matches) => {
@@ -116,7 +116,7 @@ const triggerSet: OopsyTriggerSet<Data> = {
     {
       id: 'GubalHm Tornado',
       type: 'Ability',
-      netRegex: NetRegexes.abilityFull({ id: '195[78]', ...playerDamageFields }),
+      netRegex: NetRegexes.ability({ id: '195[78]', ...playerDamageFields }),
       // Always hits target, but if correctly resolved will deal 0 damage
       condition: (data, matches) => data.DamageFromMatches(matches) > 0,
       mistake: (_data, matches) => {

--- a/ui/oopsyraidsy/data/03-hw/raid/a12n.ts
+++ b/ui/oopsyraidsy/data/03-hw/raid/a12n.ts
@@ -34,7 +34,7 @@ const triggerSet: OopsyTriggerSet<Data> = {
       // It is a failure for a Severity marker to stack with the Solidarity group.
       id: 'A12N Assault Failure',
       type: 'Ability',
-      netRegex: NetRegexes.abilityFull({ id: '1AF2', ...playerDamageFields }),
+      netRegex: NetRegexes.ability({ id: '1AF2', ...playerDamageFields }),
       condition: (data, matches) => data.assault?.includes(matches.target),
       mistake: (_data, matches) => {
         return {

--- a/ui/oopsyraidsy/data/04-sb/alliance/orbonne_monastery.ts
+++ b/ui/oopsyraidsy/data/04-sb/alliance/orbonne_monastery.ts
@@ -81,7 +81,7 @@ const triggerSet: OopsyTriggerSet<Data> = {
       // castbar that you need to have Heavenly Shield up for, or you get a vuln and knockback.
       id: 'Orbonne Agrias Judgment Blade',
       type: 'Ability',
-      netRegex: NetRegexes.abilityFull({ id: '3857', ...playerDamageFields }),
+      netRegex: NetRegexes.ability({ id: '3857', ...playerDamageFields }),
       condition: (data, matches) => data.DamageFromMatches(matches) > 0,
       mistake: (_data, matches) => {
         return {
@@ -96,7 +96,7 @@ const triggerSet: OopsyTriggerSet<Data> = {
       // same as Judgment Blade, but from Sword Knight
       id: 'Orbonne Agrias Mortal Blow',
       type: 'Ability',
-      netRegex: NetRegexes.abilityFull({ id: '385E', ...playerDamageFields }),
+      netRegex: NetRegexes.ability({ id: '385E', ...playerDamageFields }),
       condition: (data, matches) => data.DamageFromMatches(matches) > 0,
       mistake: (_data, matches) => {
         return {

--- a/ui/oopsyraidsy/data/04-sb/alliance/royal_city_of_rabanastre.ts
+++ b/ui/oopsyraidsy/data/04-sb/alliance/royal_city_of_rabanastre.ts
@@ -89,7 +89,7 @@ const triggerSet: OopsyTriggerSet<Data> = {
       // unnamed damage from being hit by Rofocale driving in circles during add phase
       id: 'Rabanastre Rofocale Chariot Ring',
       type: 'Ability',
-      netRegex: NetRegexes.abilityFull({ id: '268C', ...playerDamageFields }),
+      netRegex: NetRegexes.ability({ id: '268C', ...playerDamageFields }),
       mistake: (_data, matches) => {
         return {
           type: 'fail',

--- a/ui/oopsyraidsy/data/04-sb/dungeon/bardams_mettle.ts
+++ b/ui/oopsyraidsy/data/04-sb/dungeon/bardams_mettle.ts
@@ -17,7 +17,7 @@ const abilityWarn = (args: { abilityId: string; id: string }): OopsyTrigger<Data
   const trigger: OopsyTrigger<Data> = {
     id: args.id,
     type: 'Ability',
-    netRegex: NetRegexes.abilityFull({ id: args.abilityId }),
+    netRegex: NetRegexes.ability({ id: args.abilityId }),
     condition: (_data, matches) => matches.flags.endsWith('0E'),
     mistake: (_data, matches) => {
       return {

--- a/ui/oopsyraidsy/data/04-sb/dungeon/bardams_mettle63.ts
+++ b/ui/oopsyraidsy/data/04-sb/dungeon/bardams_mettle63.ts
@@ -17,7 +17,7 @@ const abilityWarn = (args: { abilityId: string; id: string }): OopsyTrigger<Data
   const trigger: OopsyTrigger<Data> = {
     id: args.id,
     type: 'Ability',
-    netRegex: NetRegexes.abilityFull({ id: args.abilityId }),
+    netRegex: NetRegexes.ability({ id: args.abilityId }),
     condition: (_data, matches) => matches.flags.endsWith('0E'),
     mistake: (_data, matches) => {
       return {

--- a/ui/oopsyraidsy/data/04-sb/raid/o12s.ts
+++ b/ui/oopsyraidsy/data/04-sb/raid/o12s.ts
@@ -92,7 +92,7 @@ const triggerSet: OopsyTriggerSet<Data> = {
       // 332E = Pile Pitch stack
       // 333E = Electric Slide (Omega-M square 1-4 dashes)
       // 333F = Electric Slide (Omega-F triangle 1-4 dashes)
-      netRegex: NetRegexes.abilityFull({ id: ['332E', '333E', '333F'], ...playerDamageFields }),
+      netRegex: NetRegexes.ability({ id: ['332E', '333E', '333F'], ...playerDamageFields }),
       condition: (data, matches) => data.vuln && data.vuln[matches.target],
       mistake: (_data, matches) => {
         return {

--- a/ui/oopsyraidsy/data/04-sb/raid/o2n.ts
+++ b/ui/oopsyraidsy/data/04-sb/raid/o2n.ts
@@ -38,7 +38,7 @@ const triggerSet: OopsyTriggerSet<Data> = {
     {
       id: 'O2N Earthquake',
       type: 'Ability',
-      netRegex: NetRegexes.abilityFull({ id: '2515', ...playerDamageFields }),
+      netRegex: NetRegexes.ability({ id: '2515', ...playerDamageFields }),
       // This deals damage only to non-floating targets.
       condition: (data, matches) => data.DamageFromMatches(matches) > 0,
       mistake: (_data, matches) => {

--- a/ui/oopsyraidsy/data/04-sb/raid/o2s.ts
+++ b/ui/oopsyraidsy/data/04-sb/raid/o2s.ts
@@ -25,7 +25,7 @@ const triggerSet: OopsyTriggerSet<Data> = {
       // Floating over one is untested.
       id: 'O2S Petrosphere Explosion',
       type: 'Ability',
-      netRegex: NetRegexes.abilityFull({ id: '245D', ...playerDamageFields }),
+      netRegex: NetRegexes.ability({ id: '245D', ...playerDamageFields }),
       condition: (data, matches) => data.DamageFromMatches(matches) > 0,
       mistake: (_data, matches) => {
         return {
@@ -40,7 +40,7 @@ const triggerSet: OopsyTriggerSet<Data> = {
       // floating yellow arena circles; only do damage if floating
       id: 'O2S Potent Petrosphere Explosion',
       type: 'Ability',
-      netRegex: NetRegexes.abilityFull({ id: '2362', ...playerDamageFields }),
+      netRegex: NetRegexes.ability({ id: '2362', ...playerDamageFields }),
       condition: (data, matches) => data.DamageFromMatches(matches) > 0,
       mistake: (_data, matches) => {
         return {
@@ -55,7 +55,7 @@ const triggerSet: OopsyTriggerSet<Data> = {
       // Must be floating to survive; hits everyone but only does damage if not floating.
       id: 'O2S Earthquake',
       type: 'Ability',
-      netRegex: NetRegexes.abilityFull({ id: '247A', ...playerDamageFields }),
+      netRegex: NetRegexes.ability({ id: '247A', ...playerDamageFields }),
       condition: (data, matches) => data.DamageFromMatches(matches) > 0,
       mistake: (_data, matches) => {
         return {

--- a/ui/oopsyraidsy/data/04-sb/raid/o3s.ts
+++ b/ui/oopsyraidsy/data/04-sb/raid/o3s.ts
@@ -40,7 +40,7 @@ const triggerSet: OopsyTriggerSet<Data> = {
       // Everybody gets hits by this, but it's only a failure if it does damage.
       id: 'O3S The Game',
       type: 'Ability',
-      netRegex: NetRegexes.abilityFull({ id: '2301', ...playerDamageFields }),
+      netRegex: NetRegexes.ability({ id: '2301', ...playerDamageFields }),
       condition: (data, matches) => data.DamageFromMatches(matches) > 0,
       mistake: (_data, matches) => {
         return {

--- a/ui/oopsyraidsy/data/04-sb/raid/o4n.ts
+++ b/ui/oopsyraidsy/data/04-sb/raid/o4n.ts
@@ -50,7 +50,7 @@ const triggerSet: OopsyTriggerSet<Data> = {
       // Short knockback from Exdeath
       id: 'O4N Vacuum Wave',
       type: 'Ability',
-      netRegex: NetRegexes.abilityFull({ id: '24B8', ...playerDamageFields }),
+      netRegex: NetRegexes.ability({ id: '24B8', ...playerDamageFields }),
       deathReason: (_data, matches) => {
         return {
           id: matches.targetId,

--- a/ui/oopsyraidsy/data/04-sb/raid/o4s.ts
+++ b/ui/oopsyraidsy/data/04-sb/raid/o4s.ts
@@ -68,7 +68,7 @@ const triggerSet: OopsyTriggerSet<Data> = {
     {
       id: 'O4S Blizzard III',
       type: 'Ability',
-      netRegex: NetRegexes.abilityFull({ id: '23F8', ...playerDamageFields }),
+      netRegex: NetRegexes.ability({ id: '23F8', ...playerDamageFields }),
       // Ignore unavoidable raid aoe Blizzard III.
       condition: (data) => !data.isDecisiveBattleElement,
       mistake: (_data, matches) => {
@@ -83,7 +83,7 @@ const triggerSet: OopsyTriggerSet<Data> = {
     {
       id: 'O4S Thunder III',
       type: 'Ability',
-      netRegex: NetRegexes.abilityFull({ id: '23FD', ...playerDamageFields }),
+      netRegex: NetRegexes.ability({ id: '23FD', ...playerDamageFields }),
       // Only consider this during random mechanic after decisive battle.
       condition: (data) => data.isDecisiveBattleElement,
       mistake: (_data, matches) => {
@@ -120,7 +120,7 @@ const triggerSet: OopsyTriggerSet<Data> = {
     {
       id: 'O4S Forked Lightning',
       type: 'Ability',
-      netRegex: NetRegexes.abilityFull({ id: '242E', ...playerDamageFields }),
+      netRegex: NetRegexes.ability({ id: '242E', ...playerDamageFields }),
       mistake: (_data, matches) => {
         return {
           type: 'fail',
@@ -168,7 +168,7 @@ const triggerSet: OopsyTriggerSet<Data> = {
     {
       id: 'O4S Double Attack Collect',
       type: 'Ability',
-      netRegex: NetRegexes.abilityFull({ id: '241C', ...playerDamageFields }),
+      netRegex: NetRegexes.ability({ id: '241C', ...playerDamageFields }),
       run: (data, matches) => {
         data.doubleAttackMatches = data.doubleAttackMatches || [];
         data.doubleAttackMatches.push(matches);
@@ -177,7 +177,7 @@ const triggerSet: OopsyTriggerSet<Data> = {
     {
       id: 'O4S Double Attack',
       type: 'Ability',
-      netRegex: NetRegexes.abilityFull({ id: '241C', ...playerDamageFields }),
+      netRegex: NetRegexes.ability({ id: '241C', ...playerDamageFields }),
       mistake: (data) => {
         const arr = data.doubleAttackMatches;
         if (!arr)

--- a/ui/oopsyraidsy/data/04-sb/raid/o5n.ts
+++ b/ui/oopsyraidsy/data/04-sb/raid/o5n.ts
@@ -55,7 +55,7 @@ const triggerSet: OopsyTriggerSet<Data> = {
       // Getting hit by a ghost without throttle (the mandatory post-chimney one).
       id: 'O5N Possess',
       type: 'Ability',
-      netRegex: NetRegexes.abilityFull({ id: '28AC', ...playerDamageFields }),
+      netRegex: NetRegexes.ability({ id: '28AC', ...playerDamageFields }),
       condition: (data, matches) => !data.hasThrottle?.[matches.target],
       mistake: (_data, matches) => {
         return {

--- a/ui/oopsyraidsy/data/04-sb/raid/o5s.ts
+++ b/ui/oopsyraidsy/data/04-sb/raid/o5s.ts
@@ -49,7 +49,7 @@ const triggerSet: OopsyTriggerSet<Data> = {
       // Getting hit by a ghost without throttle (the mandatory post-chimney one).
       id: 'O5S Possess',
       type: 'Ability',
-      netRegex: NetRegexes.abilityFull({ id: '28AC', ...playerDamageFields }),
+      netRegex: NetRegexes.ability({ id: '28AC', ...playerDamageFields }),
       condition: (data, matches) => !data.hasThrottle?.[matches.target],
       mistake: (_data, matches) => {
         return {

--- a/ui/oopsyraidsy/data/04-sb/raid/o6s.ts
+++ b/ui/oopsyraidsy/data/04-sb/raid/o6s.ts
@@ -58,7 +58,7 @@ const triggerSet: OopsyTriggerSet<Data> = {
       // Look away; does damage if failed.
       id: 'O6S Divine Lure',
       type: 'Ability',
-      netRegex: NetRegexes.abilityFull({ id: '2822', ...playerDamageFields }),
+      netRegex: NetRegexes.ability({ id: '2822', ...playerDamageFields }),
       condition: (data, matches) => data.DamageFromMatches(matches) > 0,
       mistake: (_data, matches) => {
         return {

--- a/ui/oopsyraidsy/data/04-sb/raid/o8n.ts
+++ b/ui/oopsyraidsy/data/04-sb/raid/o8n.ts
@@ -31,7 +31,7 @@ const triggerSet: OopsyTriggerSet<Data> = {
       // Look away; does damage if failed.
       id: 'O8N Indolent Will',
       type: 'Ability',
-      netRegex: NetRegexes.abilityFull({ id: '292C', ...playerDamageFields }),
+      netRegex: NetRegexes.ability({ id: '292C', ...playerDamageFields }),
       condition: (data, matches) => data.DamageFromMatches(matches) > 0,
       mistake: (_data, matches) => {
         return {
@@ -46,7 +46,7 @@ const triggerSet: OopsyTriggerSet<Data> = {
       // Look towards; does damage if failed.
       id: 'O8N Ave Maria',
       type: 'Ability',
-      netRegex: NetRegexes.abilityFull({ id: '292B', ...playerDamageFields }),
+      netRegex: NetRegexes.ability({ id: '292B', ...playerDamageFields }),
       condition: (data, matches) => data.DamageFromMatches(matches) > 0,
       mistake: (_data, matches) => {
         return {

--- a/ui/oopsyraidsy/data/04-sb/raid/o8s.ts
+++ b/ui/oopsyraidsy/data/04-sb/raid/o8s.ts
@@ -66,7 +66,7 @@ const triggerSet: OopsyTriggerSet<Data> = {
       // Look away; does damage if failed.
       id: 'O8S Indolent Will',
       type: 'Ability',
-      netRegex: NetRegexes.abilityFull({ id: '28E4', ...playerDamageFields }),
+      netRegex: NetRegexes.ability({ id: '28E4', ...playerDamageFields }),
       condition: (data, matches) => data.DamageFromMatches(matches) > 0,
       mistake: (_data, matches) => {
         return {
@@ -81,7 +81,7 @@ const triggerSet: OopsyTriggerSet<Data> = {
       // Look towards; does damage if failed.
       id: 'O8S Ave Maria',
       type: 'Ability',
-      netRegex: NetRegexes.abilityFull({ id: '28E3', ...playerDamageFields }),
+      netRegex: NetRegexes.ability({ id: '28E3', ...playerDamageFields }),
       condition: (data, matches) => data.DamageFromMatches(matches) > 0,
       mistake: (_data, matches) => {
         return {

--- a/ui/oopsyraidsy/data/04-sb/trial/byakko-ex.ts
+++ b/ui/oopsyraidsy/data/04-sb/trial/byakko-ex.ts
@@ -30,7 +30,7 @@ const triggerSet: OopsyTriggerSet<Data> = {
       // Pink bubble collision
       id: 'ByaEx Ominous Wind',
       type: 'Ability',
-      netRegex: NetRegexes.abilityFull({ id: '27EC', ...playerDamageFields }),
+      netRegex: NetRegexes.ability({ id: '27EC', ...playerDamageFields }),
       mistake: (_data, matches) => {
         return {
           type: 'warn',

--- a/ui/oopsyraidsy/data/04-sb/trial/lakshmi-ex.ts
+++ b/ui/oopsyraidsy/data/04-sb/trial/lakshmi-ex.ts
@@ -39,7 +39,7 @@ const triggerSet: OopsyTriggerSet<Data> = {
     {
       id: 'LakshmiEx Divine Denial Knocked Off',
       type: 'Ability',
-      netRegex: NetRegexes.abilityFull({ id: '2149', ...playerDamageFields }),
+      netRegex: NetRegexes.ability({ id: '2149', ...playerDamageFields }),
       deathReason: (_data, matches) => {
         return {
           id: matches.targetId,

--- a/ui/oopsyraidsy/data/04-sb/trial/lakshmi.ts
+++ b/ui/oopsyraidsy/data/04-sb/trial/lakshmi.ts
@@ -33,7 +33,7 @@ const triggerSet: OopsyTriggerSet<Data> = {
     {
       id: 'Lakshmi Divine Denial Knocked Off',
       type: 'Ability',
-      netRegex: NetRegexes.abilityFull({ id: '2485', ...playerDamageFields }),
+      netRegex: NetRegexes.ability({ id: '2485', ...playerDamageFields }),
       deathReason: (_data, matches) => {
         return {
           id: matches.targetId,

--- a/ui/oopsyraidsy/data/04-sb/trial/shinryu-ex.ts
+++ b/ui/oopsyraidsy/data/04-sb/trial/shinryu-ex.ts
@@ -62,7 +62,7 @@ const triggerSet: OopsyTriggerSet<Data> = {
     {
       id: 'ShinryuEx Tidal Wave',
       type: 'Ability',
-      netRegex: NetRegexes.abilityFull({ id: '25DA', ...playerDamageFields }),
+      netRegex: NetRegexes.ability({ id: '25DA', ...playerDamageFields }),
       deathReason: (_data, matches) => {
         return {
           id: matches.targetId,
@@ -82,7 +82,7 @@ const triggerSet: OopsyTriggerSet<Data> = {
       // Knockback from center.
       id: 'ShinryuEx Aerial Blast',
       type: 'Ability',
-      netRegex: NetRegexes.abilityFull({ id: '25DF', ...playerDamageFields }),
+      netRegex: NetRegexes.ability({ id: '25DF', ...playerDamageFields }),
       deathReason: (_data, matches) => {
         return {
           id: matches.targetId,

--- a/ui/oopsyraidsy/data/04-sb/trial/shinryu.ts
+++ b/ui/oopsyraidsy/data/04-sb/trial/shinryu.ts
@@ -47,7 +47,7 @@ const triggerSet: OopsyTriggerSet<Data> = {
     {
       id: 'Shinryu Tidal Wave',
       type: 'Ability',
-      netRegex: NetRegexes.abilityFull({ id: '1F8B', ...playerDamageFields }),
+      netRegex: NetRegexes.ability({ id: '1F8B', ...playerDamageFields }),
       deathReason: (_data, matches) => {
         return {
           id: matches.targetId,
@@ -67,7 +67,7 @@ const triggerSet: OopsyTriggerSet<Data> = {
       // Knockback from center.
       id: 'Shinryu Aerial Blast',
       type: 'Ability',
-      netRegex: NetRegexes.abilityFull({ id: '1F90', ...playerDamageFields }),
+      netRegex: NetRegexes.ability({ id: '1F90', ...playerDamageFields }),
       deathReason: (_data, matches) => {
         return {
           id: matches.targetId,

--- a/ui/oopsyraidsy/data/04-sb/trial/suzaku-ex.ts
+++ b/ui/oopsyraidsy/data/04-sb/trial/suzaku-ex.ts
@@ -39,7 +39,7 @@ const triggerSet: OopsyTriggerSet<Data> = {
     {
       id: 'SuzakuEx Ruthless Refrain',
       type: 'Ability',
-      netRegex: NetRegexes.abilityFull({ id: '32DB', ...playerDamageFields }),
+      netRegex: NetRegexes.ability({ id: '32DB', ...playerDamageFields }),
       deathReason: (_data, matches) => {
         return {
           id: matches.targetId,
@@ -58,7 +58,7 @@ const triggerSet: OopsyTriggerSet<Data> = {
     {
       id: 'SuzakuEx Mesmerizing Melody',
       type: 'Ability',
-      netRegex: NetRegexes.abilityFull({ id: '32DA', ...playerDamageFields }),
+      netRegex: NetRegexes.ability({ id: '32DA', ...playerDamageFields }),
       deathReason: (_data, matches) => {
         return {
           id: matches.targetId,

--- a/ui/oopsyraidsy/data/04-sb/trial/suzaku.ts
+++ b/ui/oopsyraidsy/data/04-sb/trial/suzaku.ts
@@ -26,7 +26,7 @@ const triggerSet: OopsyTriggerSet<Data> = {
     {
       id: 'Suzaku Normal Ruthless Refrain',
       type: 'Ability',
-      netRegex: NetRegexes.abilityFull({ id: '3230', ...playerDamageFields }),
+      netRegex: NetRegexes.ability({ id: '3230', ...playerDamageFields }),
       deathReason: (_data, matches) => {
         return {
           id: matches.targetId,

--- a/ui/oopsyraidsy/data/04-sb/ultimate/ultima_weapon_ultimate.ts
+++ b/ui/oopsyraidsy/data/04-sb/ultimate/ultima_weapon_ultimate.ts
@@ -69,7 +69,7 @@ const triggerSet: OopsyTriggerSet<Data> = {
       // first person listed damage-wise, so they are likely the culprit.
       id: 'UWU Featherlance',
       type: 'Ability',
-      netRegex: NetRegexes.abilityFull({ id: '2B43', ...playerDamageFields }),
+      netRegex: NetRegexes.ability({ id: '2B43', ...playerDamageFields }),
       suppressSeconds: 5,
       mistake: (_data, matches) => {
         return {

--- a/ui/oopsyraidsy/data/04-sb/ultimate/unending_coil_ultimate.ts
+++ b/ui/oopsyraidsy/data/04-sb/ultimate/unending_coil_ultimate.ts
@@ -24,7 +24,7 @@ const triggerSet: OopsyTriggerSet<Data> = {
       // Instant death has a special flag value, differentiating
       // from the explosion damage you take when somebody else
       // pops one.
-      netRegex: NetRegexes.abilityFull({
+      netRegex: NetRegexes.ability({
         id: '26AB',
         ...playerDamageFields,
         flags: kFlagInstantDeath,
@@ -48,7 +48,7 @@ const triggerSet: OopsyTriggerSet<Data> = {
     {
       id: 'UCU Thermionic Burst',
       type: 'Ability',
-      netRegex: NetRegexes.abilityFull({ id: '26B9', ...playerDamageFields }),
+      netRegex: NetRegexes.ability({ id: '26B9', ...playerDamageFields }),
       mistake: (_data, matches) => {
         return {
           type: 'fail',
@@ -68,7 +68,7 @@ const triggerSet: OopsyTriggerSet<Data> = {
     {
       id: 'UCU Chain Lightning',
       type: 'Ability',
-      netRegex: NetRegexes.abilityFull({ id: '26C8', ...playerDamageFields }),
+      netRegex: NetRegexes.ability({ id: '26C8', ...playerDamageFields }),
       mistake: (_data, matches) => {
         // It's hard to assign blame for lightning.  The debuffs
         // go out and then explode in order, but the attacker is

--- a/ui/oopsyraidsy/data/05-shb/dungeon/heroes_gauntlet.ts
+++ b/ui/oopsyraidsy/data/05-shb/dungeon/heroes_gauntlet.ts
@@ -59,7 +59,7 @@ const triggerSet: OopsyTriggerSet<Data> = {
     {
       id: 'THG Wild Rampage',
       type: 'Ability',
-      netRegex: NetRegexes.abilityFull({ id: '5207', ...playerDamageFields }),
+      netRegex: NetRegexes.ability({ id: '5207', ...playerDamageFields }),
       // This is zero damage if you are in the crater.
       condition: (data, matches) => data.DamageFromMatches(matches) > 0,
       mistake: (_data, matches) => {

--- a/ui/oopsyraidsy/data/05-shb/eureka/delubrum_reginae.ts
+++ b/ui/oopsyraidsy/data/05-shb/eureka/delubrum_reginae.ts
@@ -85,7 +85,7 @@ const triggerSet: OopsyTriggerSet<Data> = {
       // and the first explosion "hits" everyone, although with "1B" flags.
       id: 'Delubrum Lots Cast',
       type: 'Ability',
-      netRegex: NetRegexes.abilityFull({
+      netRegex: NetRegexes.ability({
         id: ['565A', '565B', '57FD', '57FE', '5B86', '5B87', '59D2', '5D93'],
         ...playerDamageFields,
       }),

--- a/ui/oopsyraidsy/data/05-shb/eureka/delubrum_reginae_savage.ts
+++ b/ui/oopsyraidsy/data/05-shb/eureka/delubrum_reginae_savage.ts
@@ -138,7 +138,7 @@ const triggerSet: OopsyTriggerSet<Data> = {
       // These ability ids can be ordered differently and "hit" people when levitating.
       id: 'DelubrumSav Guard Lots Cast',
       type: 'Ability',
-      netRegex: NetRegexes.abilityFull({
+      netRegex: NetRegexes.ability({
         id: ['5827', '5828', '5B6C', '5B6D', '5BB6', '5BB7', '5B88', '5B89'],
         ...playerDamageFields,
       }),

--- a/ui/oopsyraidsy/data/05-shb/raid/e10s.ts
+++ b/ui/oopsyraidsy/data/05-shb/raid/e10s.ts
@@ -87,7 +87,7 @@ const triggerSet: OopsyTriggerSet<Data> = {
       // This can be mitigated by the whole group, so add a damage condition.
       id: 'E10S Barbs Of Agony',
       type: 'Ability',
-      netRegex: NetRegexes.abilityFull({ id: ['572A', '5B27'], ...playerDamageFields }),
+      netRegex: NetRegexes.ability({ id: ['572A', '5B27'], ...playerDamageFields }),
       condition: (data, matches) => data.DamageFromMatches(matches) > 0,
       mistake: (_data, matches) => {
         return {

--- a/ui/oopsyraidsy/data/05-shb/raid/e12s.ts
+++ b/ui/oopsyraidsy/data/05-shb/raid/e12s.ts
@@ -88,7 +88,7 @@ const triggerSet: OopsyTriggerSet<Data> = {
       // This can be shielded through as long as that person doesn't stack.
       id: 'E12S Icicle Impact',
       type: 'Ability',
-      netRegex: NetRegexes.abilityFull({ id: '4E5A', ...playerDamageFields }),
+      netRegex: NetRegexes.ability({ id: '4E5A', ...playerDamageFields }),
       condition: (data, matches) => data.DamageFromMatches(matches) > 0,
       mistake: (_data, matches) => {
         return {
@@ -122,7 +122,7 @@ const triggerSet: OopsyTriggerSet<Data> = {
       // use the "Classical Sculpture" ability and end up on the arena for real.
       id: 'E12S Promise Chiseled Sculpture Classical Sculpture',
       type: 'Ability',
-      netRegex: NetRegexes.abilityFull({ source: 'Chiseled Sculpture', id: '58B2' }),
+      netRegex: NetRegexes.ability({ source: 'Chiseled Sculpture', id: '58B2' }),
       run: (data, matches) => {
         // This will run per person that gets hit by the same sculpture, but that's fine.
         // Record the y position of each sculpture so we can use it for better text later.
@@ -308,11 +308,11 @@ const triggerSet: OopsyTriggerSet<Data> = {
     {
       id: 'E12S Promise Small Lion Lionsblaze',
       type: 'Ability',
-      netRegex: NetRegexes.abilityFull({ source: 'Beastly Sculpture', id: '58B9' }),
-      netRegexDe: NetRegexes.abilityFull({ source: 'Abbild Eines Löwen', id: '58B9' }),
-      netRegexFr: NetRegexes.abilityFull({ source: 'Création Léonine', id: '58B9' }),
-      netRegexJa: NetRegexes.abilityFull({ source: '創られた獅子', id: '58B9' }),
-      netRegexCn: NetRegexes.abilityFull({ source: '被创造的狮子', id: '58B9' }),
+      netRegex: NetRegexes.ability({ source: 'Beastly Sculpture', id: '58B9' }),
+      netRegexDe: NetRegexes.ability({ source: 'Abbild Eines Löwen', id: '58B9' }),
+      netRegexFr: NetRegexes.ability({ source: 'Création Léonine', id: '58B9' }),
+      netRegexJa: NetRegexes.ability({ source: '創られた獅子', id: '58B9' }),
+      netRegexCn: NetRegexes.ability({ source: '被创造的狮子', id: '58B9' }),
       mistake: (data, matches) => {
         // Folks baiting the big lion second can take the first small lion hit,
         // so it's not sufficient to check only the owner.
@@ -368,7 +368,7 @@ const triggerSet: OopsyTriggerSet<Data> = {
     {
       id: 'E12S Promise North Big Lion',
       type: 'AddedCombatant',
-      netRegex: NetRegexes.addedCombatantFull({ name: 'Regal Sculpture' }),
+      netRegex: NetRegexes.addedCombatant({ name: 'Regal Sculpture' }),
       run: (data, matches) => {
         const y = parseFloat(matches.y);
         const centerY = -75;
@@ -473,7 +473,7 @@ const triggerSet: OopsyTriggerSet<Data> = {
     {
       id: 'E12S Oracle Shadoweye',
       type: 'Ability',
-      netRegex: NetRegexes.abilityFull({ id: '58D2', ...playerDamageFields }),
+      netRegex: NetRegexes.ability({ id: '58D2', ...playerDamageFields }),
       condition: (data, matches) => data.DamageFromMatches(matches) > 0,
       mistake: (_data, matches) => {
         return {

--- a/ui/oopsyraidsy/data/05-shb/raid/e2n.ts
+++ b/ui/oopsyraidsy/data/05-shb/raid/e2n.ts
@@ -22,7 +22,7 @@ const triggerSet: OopsyTriggerSet<Data> = {
     {
       id: 'E2N Nyx',
       type: 'Ability',
-      netRegex: NetRegexes.abilityFull({ id: '3E3D', ...playerDamageFields }),
+      netRegex: NetRegexes.ability({ id: '3E3D', ...playerDamageFields }),
       mistake: (_data, matches) => {
         return {
           type: 'warn',

--- a/ui/oopsyraidsy/data/05-shb/raid/e2s.ts
+++ b/ui/oopsyraidsy/data/05-shb/raid/e2s.ts
@@ -40,7 +40,7 @@ const triggerSet: OopsyTriggerSet<Data> = {
     {
       id: 'E2S Nyx',
       type: 'Ability',
-      netRegex: NetRegexes.abilityFull({ id: '3E51', ...playerDamageFields }),
+      netRegex: NetRegexes.ability({ id: '3E51', ...playerDamageFields }),
       mistake: (_data, matches) => {
         return {
           type: 'warn',

--- a/ui/oopsyraidsy/data/05-shb/raid/e4s.ts
+++ b/ui/oopsyraidsy/data/05-shb/raid/e4s.ts
@@ -51,7 +51,7 @@ const triggerSet: OopsyTriggerSet<Data> = {
     {
       id: 'E4S Fault Line',
       type: 'Ability',
-      netRegex: NetRegexes.abilityFull({ id: '411E', ...playerDamageFields }),
+      netRegex: NetRegexes.ability({ id: '411E', ...playerDamageFields }),
       condition: (data, matches) => data.faultLineTarget !== matches.target,
       mistake: (_data, matches) => {
         return {

--- a/ui/oopsyraidsy/data/05-shb/raid/e5n.ts
+++ b/ui/oopsyraidsy/data/05-shb/raid/e5n.ts
@@ -58,7 +58,7 @@ const triggerSet: OopsyTriggerSet<Data> = {
     {
       id: 'E5N Divine Judgement Volts',
       type: 'Ability',
-      netRegex: NetRegexes.abilityFull({ id: '4B9A', ...playerDamageFields }),
+      netRegex: NetRegexes.ability({ id: '4B9A', ...playerDamageFields }),
       condition: (data, matches) => !data.hasOrb || !data.hasOrb[matches.target],
       mistake: (_data, matches) => {
         return {
@@ -89,7 +89,7 @@ const triggerSet: OopsyTriggerSet<Data> = {
       // This ability is seen only if players stacked the clouds instead of spreading them.
       id: 'E5N The Parting Clouds',
       type: 'Ability',
-      netRegex: NetRegexes.abilityFull({ id: '4B9D', ...playerDamageFields }),
+      netRegex: NetRegexes.ability({ id: '4B9D', ...playerDamageFields }),
       suppressSeconds: 30,
       mistake: (data, matches) => {
         for (const name of data.cloudMarkers ?? []) {

--- a/ui/oopsyraidsy/data/05-shb/raid/e5s.ts
+++ b/ui/oopsyraidsy/data/05-shb/raid/e5s.ts
@@ -66,7 +66,7 @@ const triggerSet: OopsyTriggerSet<Data> = {
     {
       id: 'E5S Divine Judgement Volts',
       type: 'Ability',
-      netRegex: NetRegexes.abilityFull({ id: '4BB7', ...playerDamageFields }),
+      netRegex: NetRegexes.ability({ id: '4BB7', ...playerDamageFields }),
       condition: (data, matches) => !data.hasOrb || !data.hasOrb[matches.target],
       mistake: (_data, matches) => {
         return {
@@ -80,7 +80,7 @@ const triggerSet: OopsyTriggerSet<Data> = {
     {
       id: 'E5S Volt Strike Orb',
       type: 'Ability',
-      netRegex: NetRegexes.abilityFull({ id: '4BC3', ...playerDamageFields }),
+      netRegex: NetRegexes.ability({ id: '4BC3', ...playerDamageFields }),
       condition: (data, matches) => !data.hasOrb || !data.hasOrb[matches.target],
       mistake: (_data, matches) => {
         return {
@@ -94,7 +94,7 @@ const triggerSet: OopsyTriggerSet<Data> = {
     {
       id: 'E5S Deadly Discharge Big Knockback',
       type: 'Ability',
-      netRegex: NetRegexes.abilityFull({ id: '4BB2', ...playerDamageFields }),
+      netRegex: NetRegexes.ability({ id: '4BB2', ...playerDamageFields }),
       condition: (data, matches) => !data.hasOrb || !data.hasOrb[matches.target],
       mistake: (_data, matches) => {
         return {
@@ -108,7 +108,7 @@ const triggerSet: OopsyTriggerSet<Data> = {
     {
       id: 'E5S Lightning Bolt',
       type: 'Ability',
-      netRegex: NetRegexes.abilityFull({ id: '4BB9', ...playerDamageFields }),
+      netRegex: NetRegexes.ability({ id: '4BB9', ...playerDamageFields }),
       condition: (data, matches) => {
         // Having a non-idempotent condition function is a bit <_<
         // Only consider lightning bolt damage if you have a debuff to clear.
@@ -149,7 +149,7 @@ const triggerSet: OopsyTriggerSet<Data> = {
       // This ability is seen only if players stacked the clouds instead of spreading them.
       id: 'E5S The Parting Clouds',
       type: 'Ability',
-      netRegex: NetRegexes.abilityFull({ id: '4BBA', ...playerDamageFields }),
+      netRegex: NetRegexes.ability({ id: '4BBA', ...playerDamageFields }),
       suppressSeconds: 30,
       mistake: (data, matches) => {
         for (const name of data.cloudMarkers ?? []) {

--- a/ui/oopsyraidsy/data/05-shb/raid/e7n.ts
+++ b/ui/oopsyraidsy/data/05-shb/raid/e7n.ts
@@ -82,7 +82,7 @@ const triggerSet: OopsyTriggerSet<Data> = {
     {
       id: 'E7N Light\'s Course',
       type: 'Ability',
-      netRegex: NetRegexes.abilityFull({
+      netRegex: NetRegexes.ability({
         id: ['4C3E', '4C40', '4C22', '4C3C', '4E63'],
         ...playerDamageFields,
       }),
@@ -108,7 +108,7 @@ const triggerSet: OopsyTriggerSet<Data> = {
     {
       id: 'E7N Darks\'s Course',
       type: 'Ability',
-      netRegex: NetRegexes.abilityFull({
+      netRegex: NetRegexes.ability({
         id: ['4C3D', '4C23', '4C41', '4C43'],
         ...playerDamageFields,
       }),

--- a/ui/oopsyraidsy/data/05-shb/raid/e7s.ts
+++ b/ui/oopsyraidsy/data/05-shb/raid/e7s.ts
@@ -110,7 +110,7 @@ const triggerSet: OopsyTriggerSet<Data> = {
     {
       id: 'E7S Light\'s Course',
       type: 'Ability',
-      netRegex: NetRegexes.abilityFull({
+      netRegex: NetRegexes.ability({
         id: ['4C62', '4C63', '4C64', '4C5B', '4C5F'],
         ...playerDamageFields,
       }),
@@ -136,7 +136,7 @@ const triggerSet: OopsyTriggerSet<Data> = {
     {
       id: 'E7S Darks\'s Course',
       type: 'Ability',
-      netRegex: NetRegexes.abilityFull({
+      netRegex: NetRegexes.ability({
         id: ['4C65', '4C66', '4C67', '4C5A', '4C60'],
         ...playerDamageFields,
       }),
@@ -166,7 +166,7 @@ const triggerSet: OopsyTriggerSet<Data> = {
       id: 'E7S Crusade Knockback',
       type: 'Ability',
       // 4C76 is the knockback damage, 4C58 is the damage for standing on the puck.
-      netRegex: NetRegexes.abilityFull({ id: '4C76', ...playerDamageFields }),
+      netRegex: NetRegexes.ability({ id: '4C76', ...playerDamageFields }),
       deathReason: (_data, matches) => {
         return {
           id: matches.targetId,

--- a/ui/oopsyraidsy/data/05-shb/raid/e8n.ts
+++ b/ui/oopsyraidsy/data/05-shb/raid/e8n.ts
@@ -39,7 +39,7 @@ const triggerSet: OopsyTriggerSet<Data> = {
     {
       id: 'E8N Heavenly Strike',
       type: 'Ability',
-      netRegex: NetRegexes.abilityFull({ id: '4DD8', ...playerDamageFields }),
+      netRegex: NetRegexes.ability({ id: '4DD8', ...playerDamageFields }),
       deathReason: (_data, matches) => {
         return {
           id: matches.targetId,

--- a/ui/oopsyraidsy/data/05-shb/raid/e9s.ts
+++ b/ui/oopsyraidsy/data/05-shb/raid/e9s.ts
@@ -53,7 +53,7 @@ const triggerSet: OopsyTriggerSet<Data> = {
       // it's ok to still show as a warning??
       id: 'E9S Condensed Anti-Air Particle Beam',
       type: 'Ability',
-      netRegex: NetRegexes.abilityFull({ type: '22', id: '5615', ...playerDamageFields }),
+      netRegex: NetRegexes.ability({ type: '22', id: '5615', ...playerDamageFields }),
       condition: (data, matches) => data.DamageFromMatches(matches) > 0,
       mistake: (_data, matches) => {
         return {
@@ -68,7 +68,7 @@ const triggerSet: OopsyTriggerSet<Data> = {
       // Anti-air "out".  This can be invulned by a tank along with the spread above.
       id: 'E9S Anti-Air Phaser Unlimited',
       type: 'Ability',
-      netRegex: NetRegexes.abilityFull({ id: '5612', ...playerDamageFields }),
+      netRegex: NetRegexes.ability({ id: '5612', ...playerDamageFields }),
       condition: (data, matches) => data.DamageFromMatches(matches) > 0,
       mistake: (_data, matches) => {
         return {

--- a/ui/oopsyraidsy/data/05-shb/trial/hades-ex.ts
+++ b/ui/oopsyraidsy/data/05-shb/trial/hades-ex.ts
@@ -57,7 +57,7 @@ const triggerSet: OopsyTriggerSet<Data> = {
     {
       id: 'HadesEx Dark II',
       type: 'Ability',
-      netRegex: NetRegexes.abilityFull({ type: '22', id: '47BA', ...playerDamageFields }),
+      netRegex: NetRegexes.ability({ type: '22', id: '47BA', ...playerDamageFields }),
       // Don't blame people who don't have tethers.
       condition: (data, matches) => data.hasDark && data.hasDark.includes(matches.target),
       mistake: (_data, matches) => {
@@ -92,7 +92,7 @@ const triggerSet: OopsyTriggerSet<Data> = {
     {
       id: 'HadesEx Death Shriek',
       type: 'Ability',
-      netRegex: NetRegexes.abilityFull({ id: '47CB', ...playerDamageFields }),
+      netRegex: NetRegexes.ability({ id: '47CB', ...playerDamageFields }),
       condition: (data, matches) => data.DamageFromMatches(matches) > 0,
       mistake: (_data, matches) => {
         return {

--- a/ui/oopsyraidsy/data/05-shb/trial/varis-ex.ts
+++ b/ui/oopsyraidsy/data/05-shb/trial/varis-ex.ts
@@ -37,7 +37,7 @@ const triggerSet: OopsyTriggerSet<Data> = {
     {
       id: 'VarisEx Terminus Est',
       type: 'Ability',
-      netRegex: NetRegexes.abilityFull({ id: '4CB4', ...playerDamageFields }),
+      netRegex: NetRegexes.ability({ id: '4CB4', ...playerDamageFields }),
       suppressSeconds: 1,
       mistake: (_data, matches) => {
         return {

--- a/ui/oopsyraidsy/data/05-shb/ultimate/the_epic_of_alexander.ts
+++ b/ui/oopsyraidsy/data/05-shb/ultimate/the_epic_of_alexander.ts
@@ -69,7 +69,7 @@ const triggerSet: OopsyTriggerSet<Data> = {
       // but also themselves.
       id: 'TEA Exhaust',
       type: 'Ability',
-      netRegex: NetRegexes.abilityFull({ id: '481F', ...playerDamageFields }),
+      netRegex: NetRegexes.ability({ id: '481F', ...playerDamageFields }),
       condition: (_data, matches) => matches.target === matches.source,
       mistake: (_data, matches) => {
         return {
@@ -107,7 +107,7 @@ const triggerSet: OopsyTriggerSet<Data> = {
     {
       id: 'TEA Reducible Complexity',
       type: 'Ability',
-      netRegex: NetRegexes.abilityFull({ id: '4821', ...playerDamageFields }),
+      netRegex: NetRegexes.ability({ id: '4821', ...playerDamageFields }),
       mistake: (data, matches) => {
         return {
           type: 'fail',
@@ -127,7 +127,7 @@ const triggerSet: OopsyTriggerSet<Data> = {
     {
       id: 'TEA Drainage',
       type: 'Ability',
-      netRegex: NetRegexes.abilityFull({ id: '4827', ...playerDamageFields }),
+      netRegex: NetRegexes.ability({ id: '4827', ...playerDamageFields }),
       condition: (data, matches) => !data.party.isTank(matches.target),
       mistake: (_data, matches) => {
         return {
@@ -178,7 +178,7 @@ const triggerSet: OopsyTriggerSet<Data> = {
       // first person listed damage-wise, so they are likely the culprit.
       id: 'TEA Outburst',
       type: 'Ability',
-      netRegex: NetRegexes.abilityFull({ id: '482A', ...playerDamageFields }),
+      netRegex: NetRegexes.ability({ id: '482A', ...playerDamageFields }),
       suppressSeconds: 5,
       mistake: (_data, matches) => {
         return {

--- a/ui/oopsyraidsy/data/06-ew/dungeon/vanaspati.ts
+++ b/ui/oopsyraidsy/data/06-ew/dungeon/vanaspati.ts
@@ -38,7 +38,7 @@ const triggerSet: OopsyTriggerSet<Data> = {
       // Lookaway mechanic, does no damage on success.
       id: 'Vanaspati Terminus Twitcher Double Hex Eye',
       type: 'Ability',
-      netRegex: NetRegexes.abilityFull({ id: '6C21', ...playerDamageFields }),
+      netRegex: NetRegexes.ability({ id: '6C21', ...playerDamageFields }),
       condition: (data, matches) => data.DamageFromMatches(matches) > 0,
       mistake: (_data, matches) => {
         return {

--- a/ui/oopsyraidsy/data/06-ew/trial/zodiark-ex.ts
+++ b/ui/oopsyraidsy/data/06-ew/trial/zodiark-ex.ts
@@ -31,7 +31,7 @@ const triggerSet: OopsyTriggerSet<Data> = {
     {
       id: 'ZodiarkEx Algedon Push',
       type: 'Ability',
-      netRegex: NetRegexes.abilityFull({ id: '67EE', ...playerDamageFields }),
+      netRegex: NetRegexes.ability({ id: '67EE', ...playerDamageFields }),
       deathReason: (_data, matches) => {
         return {
           id: matches.targetId,

--- a/ui/oopsyraidsy/data/06-ew/trial/zodiark.ts
+++ b/ui/oopsyraidsy/data/06-ew/trial/zodiark.ts
@@ -30,7 +30,7 @@ const triggerSet: OopsyTriggerSet<Data> = {
     {
       id: 'Zodiark Algedon Push',
       type: 'Ability',
-      netRegex: NetRegexes.abilityFull({ id: '67D3', ...playerDamageFields }),
+      netRegex: NetRegexes.ability({ id: '67D3', ...playerDamageFields }),
       deathReason: (_data, matches) => {
         return {
           id: matches.targetId,

--- a/ui/oopsyraidsy/oopsy_live_list.ts
+++ b/ui/oopsyraidsy/oopsy_live_list.ts
@@ -348,6 +348,8 @@ export class OopsyLiveList implements MistakeObserver {
       el.value = str;
       document.body.appendChild(el);
       el.select();
+      // TODO: fix me
+      /* eslint-disable-next-line deprecation/deprecation */
       document.execCommand('copy');
       document.body.removeChild(el);
 

--- a/ui/radar/radar.ts
+++ b/ui/radar/radar.ts
@@ -199,8 +199,8 @@ class Radar {
   private lang: Lang;
   private nameToHuntEntry: HuntMap;
   private regexes: {
-    abilityFull: CactbotBaseRegExp<'Ability'>;
-    addedCombatantFull: CactbotBaseRegExp<'AddedCombatant'>;
+    ability: CactbotBaseRegExp<'Ability'>;
+    addedCombatant: CactbotBaseRegExp<'AddedCombatant'>;
     instanceChanged: CactbotBaseRegExp<'GameLog'>;
     wasDefeated: CactbotBaseRegExp<'WasDefeated'>;
   };
@@ -213,8 +213,8 @@ class Radar {
     this.lang = this.options.ParserLanguage ?? 'en';
     this.nameToHuntEntry = {};
     this.regexes = {
-      abilityFull: NetRegexes.abilityFull(),
-      addedCombatantFull: NetRegexes.addedCombatantFull(),
+      ability: NetRegexes.ability(),
+      addedCombatant: NetRegexes.addedCombatant(),
       instanceChanged: instanceChangedRegexes[this.options.ParserLanguage],
       wasDefeated: NetRegexes.wasDefeated(),
     };
@@ -426,7 +426,7 @@ class Radar {
 
     // added new combatant
     if (type === '03') {
-      const m = this.regexes.addedCombatantFull.exec(log);
+      const m = this.regexes.addedCombatant.exec(log);
       const matches = m?.groups;
       if (!matches)
         return;
@@ -441,7 +441,7 @@ class Radar {
 
     // network ability
     if (type === '21' || type === '22') {
-      const m = this.regexes.abilityFull.exec(log);
+      const m = this.regexes.ability.exec(log);
       const matches = m?.groups;
       if (!matches)
         return;

--- a/ui/raidboss/data/00-misc/test.ts
+++ b/ui/raidboss/data/00-misc/test.ts
@@ -69,7 +69,7 @@ const triggerSet: TriggerSet<Data> = {
     },
     (data) => {
       return [
-        `40 "Death To ${data.ShortName(data.me)}!!"`,
+        `40 "Death To ${data.me}!!"`,
         'hideall "Death"',
       ];
     },

--- a/ui/raidboss/popup-text.ts
+++ b/ui/raidboss/popup-text.ts
@@ -774,17 +774,20 @@ export class PopupText {
         continue;
       }
 
+      /* eslint-disable-next-line deprecation/deprecation */
+      const origZoneRegex = set.zoneRegex;
+
       if (set.zoneId !== undefined) {
         if (
           set.zoneId !== ZoneId.MatchAll && set.zoneId !== this.zoneId &&
           !(typeof set.zoneId === 'object' && set.zoneId.includes(this.zoneId))
         )
           continue;
-      } else if (set.zoneRegex) {
-        let zoneRegex = set.zoneRegex;
+      } else if (origZoneRegex) {
+        let zoneRegex = origZoneRegex;
         if (typeof zoneRegex !== 'object') {
           console.error(
-            `zoneRegex must be translatable object or regexp: ${JSON.stringify(set.zoneRegex)}`,
+            `zoneRegex must be translatable object or regexp: ${JSON.stringify(origZoneRegex)}`,
           );
           continue;
         } else if (!(zoneRegex instanceof RegExp)) {
@@ -794,12 +797,12 @@ export class PopupText {
           } else if (zoneRegex['en']) {
             zoneRegex = zoneRegex['en'];
           } else {
-            console.error(`unknown zoneRegex parser language: ${JSON.stringify(set.zoneRegex)}`);
+            console.error(`unknown zoneRegex parser language: ${JSON.stringify(origZoneRegex)}`);
             continue;
           }
 
           if (!(zoneRegex instanceof RegExp)) {
-            console.error(`zoneRegex must be regexp: ${JSON.stringify(set.zoneRegex)}`);
+            console.error(`zoneRegex must be regexp: ${JSON.stringify(origZoneRegex)}`);
             continue;
           }
         }

--- a/util/gen_log_guide.ts
+++ b/util/gen_log_guide.ts
@@ -173,8 +173,8 @@ const lineDocs: LineDocs = {
   },
   AddedCombatant: {
     regexes: {
-      network: NetRegexes.addedCombatantFull({ capture: true }).source,
-      logLine: Regexes.addedCombatantFull({ capture: true }).source,
+      network: NetRegexes.addedCombatant({ capture: true }).source,
+      logLine: Regexes.addedCombatant({ capture: true }).source,
     },
     examples: {
       'en-US': [
@@ -237,8 +237,8 @@ const lineDocs: LineDocs = {
   },
   Ability: {
     regexes: {
-      network: NetRegexes.abilityFull({ capture: true }).source,
-      logLine: Regexes.abilityFull({ capture: true }).source,
+      network: NetRegexes.ability({ capture: true }).source,
+      logLine: Regexes.ability({ capture: true }).source,
     },
     examples: {
       'en-US': [


### PR DESCRIPTION
This is mostly to prevent the use of data.ShortName (when triggers should be using data.party.member instead), but apparently there were a lot of deprecated function uses to clean up while I was here. Thanks, lint.

Apparently also, Regexes.addedCombatantFull was not the same as Regexes.addedCombatant, even though the NetRegexes versions are the same. Fixed that here.