### PR TITLE
raidboss/oopsy: support jobs instead of names in triggers

### DIFF
--- a/ui/oopsyraidsy/oopsyraidsy_config.ts
+++ b/ui/oopsyraidsy/oopsyraidsy_config.ts
@@ -276,6 +276,22 @@ const templateOptions: OptionsTemplate = {
       default: false,
     },
     {
+      id: 'DefaultPlayerLabel',
+      name: {
+        en: 'Default Player Label',
+      },
+      type: 'select',
+      options: {
+        en: {
+          'Nickname (Tini)': 'nick',
+          'Role (Tank)': 'role',
+          'Job (WAR)': 'job',
+          'Full Name (Tini Poutini)': 'name',
+        },
+      },
+      default: 'nick',
+    },
+    {
       id: 'NumLiveListItemsInCombat',
       name: {
         en: 'Number of mistakes to show in combat',

--- a/ui/raidboss/raidboss_config.ts
+++ b/ui/raidboss/raidboss_config.ts
@@ -2147,6 +2147,28 @@ const templateOptions: OptionsTemplate = {
       default: false,
     },
     {
+      id: 'DefaultPlayerLabel',
+      comment: {
+        en: `The default way to specify players in trigger output. By default, it will use
+             nicknames/first names. This can be used to print out player jobs instead.
+             If you are not in a party or players are out of a party (or there are bugs),
+             it will default to the player's nickname if there's no other information.`,
+      },
+      name: {
+        en: 'Default Player Label',
+      },
+      type: 'select',
+      options: {
+        en: {
+          'Nickname (Tini)': 'nick',
+          'Role (Tank)': 'role',
+          'Job (WAR)': 'job',
+          'Full Name (Tini Poutini)': 'name',
+        },
+      },
+      default: 'nick',
+    },
+    {
       id: 'ShowTimerBarsAtSeconds',
       name: {
         en: 'Timer bar show window (seconds)',


### PR DESCRIPTION
You can now also write `${player.job}`, `${player.role}`, `${player.nick}`, or `${player.name}` in triggers now as well if you want to override output strings individually.

If the property isn't there (somebody not in your party, bugs, typos), it will default to nickname.

Fixes #3000.