### PR TITLE
raidboss: Add support for netregexes in timelines

### DIFF
--- a/ui/raidboss/data/00-misc/test.ts
+++ b/ui/raidboss/data/00-misc/test.ts
@@ -393,6 +393,7 @@ const triggerSet: TriggerSet<Data> = {
   timelineReplace: [
     {
       locale: 'de',
+      missingTranslations: true,
       replaceSync: {
         'You bid farewell to the striking dummy': 'Du winkst der Trainingspuppe zum Abschied zu',
         'You bow courteously to the striking dummy':
@@ -514,6 +515,7 @@ const triggerSet: TriggerSet<Data> = {
     },
     {
       locale: 'cn',
+      missingTranslations: true,
       replaceSync: {
         'You bid farewell to the striking dummy': '.*向木人告别',
         'You bow courteously to the striking dummy': '.*恭敬地对木人行礼',
@@ -552,6 +554,7 @@ const triggerSet: TriggerSet<Data> = {
     },
     {
       locale: 'ko',
+      missingTranslations: true,
       replaceSync: {
         'You bid farewell to the striking dummy': '.*나무인형에게 작별 인사를 합니다',
         'You bow courteously to the striking dummy': '.*나무인형에게 공손하게 인사합니다',

--- a/ui/raidboss/data/00-misc/test.txt
+++ b/ui/raidboss/data/00-misc/test.txt
@@ -18,6 +18,7 @@ hideall "--sync--"
 
 0 "--Reset--" sync /You bid farewell to the striking dummy/ window 10000 jump 0
 
+0 "--sync--" GameLog { "line": "testNetRegexTimeline" } window 100000,100000
 0 "--sync--" sync /:Engage!/ window 100000,100000
 0 "--sync--" sync /:You bow courteously to the striking dummy/ window 0,1
 3 "Almagest"

--- a/ui/raidboss/emulator/overrides/RaidEmulatorTimelineController.ts
+++ b/ui/raidboss/emulator/overrides/RaidEmulatorTimelineController.ts
@@ -73,6 +73,7 @@ export default class RaidEmulatorTimelineController extends TimelineController {
 
     for (const line of logs) {
       this.activeTimeline.OnLogLine(line.convertedLine, line.timestamp);
+      this.activeTimeline.OnNetLogLine(line.networkLine, line.timestamp);
       // Only call _OnUpdateTimer if we have a timebase from the previous call to OnLogLine
       // This avoids spamming the console with a ton of messages
       if (this.activeTimeline.timebase)

--- a/ui/raidboss/emulator/overrides/RaidEmulatorTimelineController.ts
+++ b/ui/raidboss/emulator/overrides/RaidEmulatorTimelineController.ts
@@ -1,5 +1,5 @@
 import { UnreachableCode } from '../../../../resources/not_reached';
-import { LogEvent } from '../../../../types/event';
+import { EventResponses, LogEvent } from '../../../../types/event';
 import { LooseTimelineTrigger } from '../../../../types/trigger';
 import { TimelineController } from '../../timeline';
 import { TimelineReplacement, TimelineStyle } from '../../timeline_parser';
@@ -60,6 +60,10 @@ export default class RaidEmulatorTimelineController extends TimelineController {
 
   // Override
   public override OnLogEvent(_e: LogEvent): void {
+    throw new UnreachableCode();
+  }
+
+  public override OnNetLog(_e: EventResponses['LogLine']): void {
     throw new UnreachableCode();
   }
 

--- a/ui/raidboss/raidboss.ts
+++ b/ui/raidboss/raidboss.ts
@@ -95,4 +95,8 @@ UserConfig.getUserConfigLocation('raidboss', defaultOptions, () => {
   addOverlayListener('onLogEvent', (e) => {
     timelineController.OnLogEvent(e);
   });
+
+  addOverlayListener('LogLine', (e) => {
+    timelineController.OnNetLog(e);
+  });
 });

--- a/ui/raidboss/timeline.ts
+++ b/ui/raidboss/timeline.ts
@@ -1,7 +1,7 @@
 import { commonNetRegex } from '../../resources/netregexes';
 import { UnreachableCode } from '../../resources/not_reached';
 import { LocaleRegex } from '../../resources/translations';
-import { LogEvent } from '../../types/event';
+import { EventResponses, LogEvent } from '../../types/event';
 import { CactbotBaseRegExp } from '../../types/net_trigger';
 import { LooseTimelineTrigger, RaidbossFileData } from '../../types/trigger';
 
@@ -721,6 +721,15 @@ export class TimelineController {
       }
       this.activeTimeline.OnLogLine(log, currentTime);
     }
+  }
+
+  OnNetLog(e: EventResponses['LogLine']): void {
+    this.OnLogEvent({
+      type: 'onLogEvent',
+      detail: {
+        logs: [e.rawLine],
+      },
+    });
   }
 
   public SetActiveTimeline(

--- a/ui/raidboss/timeline.ts
+++ b/ui/raidboss/timeline.ts
@@ -137,6 +137,7 @@ export class Timeline {
   private activeText: string;
 
   protected activeSyncs: Sync[];
+  protected activeNetSyncs: Sync[];
   private activeEvents: Event[];
   private keepAliveEvents: {
     event: Event;
@@ -184,6 +185,7 @@ export class Timeline {
 
     // Not sorted.
     this.activeSyncs = [];
+    this.activeNetSyncs = [];
     // Sorted by event occurrence time.
     this.activeEvents = [];
     // Events that are no longer active but we are keeping on screen briefly.
@@ -281,10 +283,15 @@ export class Timeline {
 
   private _CollectActiveSyncs(fightNow: number): void {
     this.activeSyncs = [];
+    this.activeNetSyncs = [];
     for (let i = this.nextSyncEnd; i < this.syncEnds.length; ++i) {
       const syncEnd = this.syncEnds[i];
-      if (syncEnd && syncEnd.start <= fightNow)
-        this.activeSyncs.push(syncEnd);
+      if (syncEnd && syncEnd.start <= fightNow) {
+        if (syncEnd.regexType === 'parsed')
+          this.activeSyncs.push(syncEnd);
+        else
+          this.activeNetSyncs.push(syncEnd);
+      }
     }
 
     if (
@@ -292,25 +299,42 @@ export class Timeline {
       this.activeLastForceJumpSync.start <= fightNow &&
       this.activeLastForceJumpSync.end > fightNow
     ) {
-      this.activeSyncs.push(this.activeLastForceJumpSync);
+      if (this.activeLastForceJumpSync.regexType === 'parsed')
+        this.activeSyncs.push(this.activeLastForceJumpSync);
+      else
+        this.activeNetSyncs.push(this.activeLastForceJumpSync);
     } else {
       this.activeLastForceJumpSync = undefined;
+    }
+  }
+
+  public OnLogLineJump(sync: Sync, currentTime: number): void {
+    if ('jump' in sync) {
+      if (!sync.jump) {
+        this.SyncTo(0, currentTime, sync);
+        this.Stop();
+      } else {
+        this.SyncTo(sync.jump, currentTime, sync);
+      }
+    } else {
+      this.SyncTo(sync.time, currentTime, sync);
     }
   }
 
   public OnLogLine(line: string, currentTime: number): void {
     for (const sync of this.activeSyncs) {
       if (sync.regex.test(line)) {
-        if ('jump' in sync) {
-          if (!sync.jump) {
-            this.SyncTo(0, currentTime, sync);
-            this.Stop();
-          } else {
-            this.SyncTo(sync.jump, currentTime, sync);
-          }
-        } else {
-          this.SyncTo(sync.time, currentTime, sync);
-        }
+        this.OnLogLineJump(sync, currentTime);
+        break;
+      }
+    }
+  }
+
+  public OnNetLogLine(line: string, currentTime: number): void {
+    console.log(line);
+    for (const sync of this.activeNetSyncs) {
+      if (sync.regex.test(line)) {
+        this.OnLogLineJump(sync, currentTime);
         break;
       }
     }
@@ -724,12 +748,13 @@ export class TimelineController {
   }
 
   OnNetLog(e: EventResponses['LogLine']): void {
-    this.OnLogEvent({
-      type: 'onLogEvent',
-      detail: {
-        logs: [e.rawLine],
-      },
-    });
+    if (!this.activeTimeline)
+      return;
+
+    const currentTime = Date.now();
+
+    // TODO: Check for the countdown => wipe => engage logic for network lines
+    this.activeTimeline.OnNetLogLine(e.rawLine, currentTime);
   }
 
   public SetActiveTimeline(

--- a/ui/raidboss/timeline.ts
+++ b/ui/raidboss/timeline.ts
@@ -331,7 +331,6 @@ export class Timeline {
   }
 
   public OnNetLogLine(line: string, currentTime: number): void {
-    console.log(line);
     for (const sync of this.activeNetSyncs) {
       if (sync.regex.test(line)) {
         this.OnLogLineJump(sync, currentTime);

--- a/ui/raidboss/timeline_parser.ts
+++ b/ui/raidboss/timeline_parser.ts
@@ -17,15 +17,9 @@ const isStringArray = (value: unknown[]): value is string[] => {
   return value.find((v) => typeof v !== 'string') === undefined;
 };
 
-const isNumberArray = (value: unknown[]): value is number[] => {
-  return value.find((v) => typeof v !== 'number') === undefined;
-};
-
-const isStringOrNumberOrArray = (value: unknown): value is number[] | string[] => {
+const isStringOrStringArray = (value: unknown): value is number[] | string[] => {
   if (Array.isArray(value)) {
     if (isStringArray(value))
-      return true;
-    else if (isNumberArray(value))
       return true;
     return false;
   } else if (!['string', 'number'].includes(typeof value))
@@ -42,7 +36,7 @@ const isValidNetParams = <T extends LogDefinitionTypes>(
     if (!(key in logDefinitions[type].fields))
       return false;
     // Make sure our value is either a string/int or an array of strings/ints
-    if (!isStringOrNumberOrArray(params[key]))
+    if (!isStringOrStringArray(params[key]))
       return false;
   }
   return true;
@@ -507,6 +501,8 @@ export class TimelineParser {
     return this.buildRegexSync(
       uniqueid,
       `${netRegexType} ${syncCommand.netRegex}`,
+      // TODO: Use `translateRegexBuildParam` instead, store off params for use elsewhere.
+      // See https://github.com/quisquous/cactbot/pull/5939#discussion_r1399453530
       Regexes.parse(this.GetReplacedSync(buildNetRegexForTrigger(netRegexType, params))),
       syncCommand.args,
       seconds,

--- a/ui/raidboss/timeline_parser.ts
+++ b/ui/raidboss/timeline_parser.ts
@@ -22,7 +22,7 @@ const isStringOrStringArray = (value: unknown): value is string | string[] => {
     if (isStringArray(value))
       return true;
     return false;
-  } 
+  }
   return typeof value === 'string';
 };
 

--- a/ui/raidboss/timeline_parser.ts
+++ b/ui/raidboss/timeline_parser.ts
@@ -81,6 +81,7 @@ export type Error = {
 export type Sync = {
   id: number;
   origRegexStr: string;
+  regexType: 'parsed' | 'net';
   regex: RegExp;
   start: number;
   end: number;
@@ -479,6 +480,8 @@ export class TimelineParser {
 
     let params: unknown;
     try {
+      // TODO: Use `exec` => `JSON.stringify` => `JSON.parse` instead?
+      // See https://github.com/quisquous/cactbot/pull/5939#issuecomment-1830484703
       params = JSON.parse(syncCommand.netRegex);
     } catch (e) {
       this.errors.push({
@@ -499,6 +502,7 @@ export class TimelineParser {
     }
     return this.buildRegexSync(
       uniqueid,
+      'net',
       `${netRegexType} ${syncCommand.netRegex}`,
       // TODO: Use `translateRegexBuildParam` instead, store off params for use elsewhere.
       // See https://github.com/quisquous/cactbot/pull/5939#discussion_r1399453530
@@ -527,6 +531,7 @@ export class TimelineParser {
     line = line.replace(syncCommand.text, '').trim();
     return this.buildRegexSync(
       uniqueid,
+      'parsed',
       syncCommand.regex,
       Regexes.parse(this.GetReplacedSync(syncCommand.regex)),
       syncCommand.args,
@@ -539,6 +544,7 @@ export class TimelineParser {
 
   private buildRegexSync(
     uniqueid: number,
+    regexType: 'parsed' | 'net',
     regex: string,
     parsedRegex: RegExp,
     args: string | undefined,
@@ -550,6 +556,7 @@ export class TimelineParser {
     const sync: Sync = {
       id: uniqueid,
       origRegexStr: regex,
+      regexType: regexType,
       regex: parsedRegex,
       start: seconds - 2.5,
       end: seconds + 2.5,

--- a/ui/raidboss/timeline_parser.ts
+++ b/ui/raidboss/timeline_parser.ts
@@ -17,14 +17,13 @@ const isStringArray = (value: unknown[]): value is string[] => {
   return value.find((v) => typeof v !== 'string') === undefined;
 };
 
-const isStringOrStringArray = (value: unknown): value is number[] | string[] => {
+const isStringOrStringArray = (value: unknown): value is string | string[] => {
   if (Array.isArray(value)) {
     if (isStringArray(value))
       return true;
     return false;
-  } else if (!['string', 'number'].includes(typeof value))
-    return false;
-  return true;
+  } 
+  return typeof value === 'string';
 };
 
 const isValidNetParams = <T extends LogDefinitionTypes>(

--- a/util/logtools/test_timeline.ts
+++ b/util/logtools/test_timeline.ts
@@ -26,7 +26,9 @@ const defaultDriftWarn = 0.2;
 const defaultDriftFail = 1.0;
 
 const maxFieldId = (fields: { [fieldName: string]: number }): number => {
-  return Math.max(...Object.values(fields));
+  // +1 for the 0-indexing
+  // +1 for the always-excluded-from-field-mappings hash
+  return Math.max(...Object.values(fields)) + 2;
 };
 
 const maxAbilityFieldId = maxFieldId(logDefinitionsVersions.latest.Ability.fields);
@@ -116,6 +118,7 @@ const testLineEvents = async (
     testTimeline._OnUpdateTimer(line.timestamp);
     // If this log line matches, it will OnSync and adjust the time as needed.
     testTimeline.OnLogLine(line.convertedLine, line.timestamp);
+    testTimeline.OnNetLogLine(line.networkLine, line.timestamp);
   }
 
   console.log('Timeline:');


### PR DESCRIPTION
Closes #5145

Obviously needs plenty of testing etc.

Example added to `test.txt` timeline, can be triggered with `/e testNetRegexTimeline`.

Took the opportunity to refactor the `TimelineParser.parse` function to extract out some of the line matching, so there wasn't a need for a 30+-space-indented set of lines, and to allow reusing some of the logic for the rest of the line matching after the regex.