### PR TITLE
util: Add basic network log seal support in timeline tools

### DIFF
--- a/util/logtools/make_timeline.ts
+++ b/util/logtools/make_timeline.ts
@@ -441,9 +441,17 @@ const assembleTimelineStrings = (
   let timelinePosition = 0;
   let lastEntry: TimelineEntry = { time: lastAbilityTime.toString(), lineType: 'None' };
   if (fight !== undefined && fight.sealName !== undefined) {
-    const zoneMessage = SFuncs.toProperCase(fight.sealName);
-    const tlString = `0.0 "--sync--" sync / 00:0839::${zoneMessage} will be sealed off/ window 0,1`;
-    assembled.push(tlString);
+    const sealMessage = SFuncs.toProperCase(fight.sealName);
+    if (fight.sealId !== undefined) {
+      const sealComment = `# ${sealMessage} will be sealed off`;
+      const netLogSeal = `0.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:${fight.sealId}/ window 0,1`;
+      assembled.push(sealComment);
+      assembled.push(netLogSeal);
+    } else {
+      const tlString =
+        `0.0 "--sync--" sync / 00:0839::${sealMessage} will be sealed off/ window 0,1`;
+      assembled.push(tlString);
+    }
   } else {
     assembled.push('0.0 "--sync--" sync / 104:[^:]*:1($|:)/ window 0,1');
   }


### PR DESCRIPTION
This wasn't as simple as I had hoped, but it does seem to work as it is. There's still a bit of fragility in `make_timeline` with this implementation, since it still relies on the seal name being present in game log form. We could change this to make "name from game log" optional in the `assembleTimelineStrings()` function, but that would involve some complex conditions to allow for use of either the network seal or the game log seal.

Alternatively, we could simply not care about game log seals at all, except to check "if there's a game log seal here, use the name it contains". Maybe something like this for the end of `assembleTimelineStrings()`?

```javascript
  if (fight !== undefined && fight.sealId !== undefined) {
    if (fight.sealName !== undefined) {
      const sealMessage = SFuncs.toProperCase(fight.sealName);
      const sealComment = `# ${sealMessage} will be sealed off`;
      assembled.push(sealComment);
    }
    const netLogSeal = `0.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:${fight.sealId}/ window 0,1`;
    assembled.push(netLogSeal);
  } else {
    assembled.push('0.0 "--sync--" sync / 104:[^:]*:1($|:)/ window 0,1');
  }
  ```

Ultimately it would be nice to have the seal names dumped to a resource file as we do with `ZoneId` and `ZoneName`, and then just look them up here, but I'm not feeling up to CSV stuff this weekend.