### PR TITLE
raidboss: support bareword keys in timeline netregex

### DIFF
--- a/ui/raidboss/data/00-misc/test.txt
+++ b/ui/raidboss/data/00-misc/test.txt
@@ -18,7 +18,10 @@ hideall "--sync--"
 
 0 "--Reset--" sync /You bid farewell to the striking dummy/ window 10000 jump 0
 
+# two examples with different quoting which should both be supported
+0 "--sync--" GameLog { line: 'testNetRegexTimeline' } window 100000,100000
 0 "--sync--" GameLog { "line": "testNetRegexTimeline" } window 100000,100000
+
 0 "--sync--" sync /:Engage!/ window 100000,100000
 0 "--sync--" sync /:You bow courteously to the striking dummy/ window 0,1
 3 "Almagest"

--- a/ui/raidboss/timeline_parser.ts
+++ b/ui/raidboss/timeline_parser.ts
@@ -1,3 +1,5 @@
+import JSON5 from 'json5';
+
 import { Lang } from '../../resources/languages';
 import logDefinitions, { LogDefinitionTypes } from '../../resources/netlog_defs';
 import { buildNetRegexForTrigger } from '../../resources/netregexes';
@@ -485,9 +487,8 @@ export class TimelineParser {
 
     let params: unknown;
     try {
-      // TODO: Use `exec` => `JSON.stringify` => `JSON.parse` instead?
-      // See https://github.com/quisquous/cactbot/pull/5939#issuecomment-1830484703
-      params = JSON.parse(syncCommand.netRegex);
+      // Use json5 here to support bareword keys and different quoting styles.
+      params = JSON5.parse(syncCommand.netRegex);
     } catch (e) {
       this.errors.push({
         lineNumber: lineNumber,


### PR DESCRIPTION
Rather than eval (which is probably TOO lenient)
switch to using json5 instead of json parsing.

This is a followup to a TODO from #5939.