### PR TITLE
raidboss/test: improve testing of timeline netregex

### DIFF
--- a/test/helper/test_timeline.ts
+++ b/test/helper/test_timeline.ts
@@ -3,6 +3,7 @@ import path from 'path';
 
 import { assert } from 'chai';
 
+import { keysThatRequireTranslation } from '../../resources/netregexes';
 import Regexes from '../../resources/regexes';
 import { translateWithReplacements } from '../../resources/translations';
 import { LooseTriggerSet } from '../../types/trigger';
@@ -75,10 +76,30 @@ const getTestCases = (
   for (const [key, replaceText] of Object.entries(trans.replaceText ?? {}))
     textMap.set(Regexes.parse(key), replaceText);
 
+  // Add all original regexes to the set of things to do replacement on
+  // and add all translatable parameters as well.
+  const syncStrings: Set<string> = new Set<string>();
+  for (const sync of timeline.syncStarts) {
+    if (typeof sync.origInput === 'string') {
+      syncStrings.add(sync.origInput);
+      continue;
+    }
+    for (const [key, value] of Object.entries(sync.origInput)) {
+      if (!keysThatRequireTranslation.includes(key))
+        continue;
+      if (typeof value === 'object') {
+        for (const innerValue of value)
+          syncStrings.add(innerValue);
+      } else {
+        syncStrings.add(value);
+      }
+    }
+  }
+
   const testCases: TestCase[] = [
     {
       type: 'replaceSync',
-      items: new Set(timeline.syncStarts.map((x) => x.regex.source)),
+      items: syncStrings,
       replace: new Map(syncMap),
       replaceWithoutCommon: new Map(syncMap),
     },


### PR DESCRIPTION
This is a follow-up to #5962, which itself is related to #5939.

I forgot that `find_missing_timeline_translations.ts` is only half of the testing picture and `test_timeline.ts` needed to be updated too. This was found by trying to test more lines and having test timeline complain that InCombat regex lines were not translated.