### PR TITLE
raidboss: fix UWU Ifrit 4th dash

### DIFF
--- a/ui/raidboss/data/04-sb/ultimate/ultima_weapon_ultimate.ts
+++ b/ui/raidboss/data/04-sb/ultimate/ultima_weapon_ultimate.ts
@@ -949,7 +949,7 @@ const triggerSet: TriggerSet<Data> = {
         const startDir = (firstNailDir + oppositeRotationDir + 8) % 8;
         const ifritDir = Directions.combatantStatePosTo8Dir(combatant, centerX, centerY);
 
-        for (let i = 1; i < 4; ++i) {
+        for (let i = 1; i <= 4; ++i) {
           const dashDir = (startDir + i * rotationDir + 8) % 8;
           if (dashDir % 4 !== ifritDir % 4)
             continue;


### PR DESCRIPTION
An off by one error meant that if awoken Ifrit was the 4th dash, it would not print out any dash instructions. Oops.