### PR TITLE
ci: change release.yml to use tag explicitly

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -105,7 +105,7 @@ jobs:
         uses: ncipollo/release-action@v1
         with:
           name: ${{ needs.validate_tag.outputs.version }}
-          tag: ${{ github.ref }}
+          tag: v${{ needs.validate_tag.outputs.version }}
           artifacts: cactbot-${{ needs.validate_tag.outputs.version }}.zip
           artifactContentType: application/zip
           draft: true


### PR DESCRIPTION
It doesn't seem to pick up the tag from earlier in the job and just says `refs/head/main` which is not helpful. Hopefully being explicit will fix this.