### PR TITLE
raidboss: add trailing colon to seal network timeline sync

### DIFF
--- a/ui/raidboss/data/02-arr/raid/t10.txt
+++ b/ui/raidboss/data/02-arr/raid/t10.txt
@@ -10,7 +10,7 @@ hideall "--sync--"
 # Initial Phase: Tankbuster, Charge, Repeat
 0.0 "Start"
 # Alpha Concourse will be sealed off
-0.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:588/ window 5,5
+0.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:588:/ window 5,5
 8.0 "Crackle Hiss" sync / 1[56]:[^:]*:Imdugud:B55:/
 16.0 "Critical Rip" sync / 1[56]:[^:]*:Imdugud:B56:/
 20.0 "Crackle Hiss" sync / 1[56]:[^:]*:Imdugud:B55:/

--- a/ui/raidboss/data/02-arr/raid/t11.txt
+++ b/ui/raidboss/data/02-arr/raid/t11.txt
@@ -10,7 +10,7 @@ hideall "--sync--"
 ### Phase 1
 0.0 "Start"
 # Core Override will be sealed off
-0.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:592/ window 10,10
+0.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:592:/ window 10,10
 9.4 "Resonance" sync / 1[56]:[^:]*:Kaliya:B6B:/ window 10,10
 
 19.7 "Nerve Gas"

--- a/ui/raidboss/data/02-arr/raid/t6.txt
+++ b/ui/raidboss/data/02-arr/raid/t6.txt
@@ -10,7 +10,7 @@ hideall "--sync--"
 ### Phase 1
 0.0 "Start"
 # Scar's Edge will be sealed off
-0.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:51C/ window 10,10
+0.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:51C:/ window 10,10
 7.5 "Bloody Caress" sync / 1[56]:[^:]*:Rafflesia:797:/ window 8,8
 11.5 "Thorn Whip" sync / 1[56]:[^:]*:Rafflesia:879:/
 18.5 "Briary Growth" sync / 1[56]:[^:]*:Rafflesia:884:/ window 20,20

--- a/ui/raidboss/data/02-arr/raid/t7.txt
+++ b/ui/raidboss/data/02-arr/raid/t7.txt
@@ -10,7 +10,7 @@ hideall "--sync--"
 ### Phase 1 (100%)
 
 # Bioweapon Storage will be sealed off
-0.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:51E/ window 10,10
+0.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:51E:/ window 10,10
 6.4 "Tail Slap" sync / 1[56]:[^:]*:Melusine:7A8:/ window 7,0
 12.3 "Cursed Voice" sync / 1[56]:[^:]*:Melusine:7AC:/
 14.3 "Circle Of Flames x2" #sync / 1[56]:[^:]*:Melusine:7AA:/

--- a/ui/raidboss/data/02-arr/raid/t8.txt
+++ b/ui/raidboss/data/02-arr/raid/t8.txt
@@ -13,7 +13,7 @@ hideall "--sync--"
 ### Phase 1: introduction to towers
 0.0 "Start"
 # Central Bow will be sealed off
-0.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:532/ window 10,10
+0.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:532:/ window 10,10
 6.1 "Diffusion Ray" sync / 1[56]:[^:]*:The Avatar:7C2:/ window 7,10
 26.0 "Homing Missile" sync / 1[56]:[^:]*:The Avatar:7C7:/
 27.2 "Diffusion Ray" sync / 1[56]:[^:]*:The Avatar:7C2:/

--- a/ui/raidboss/data/03-hw/alliance/dun_scaith.txt
+++ b/ui/raidboss/data/03-hw/alliance/dun_scaith.txt
@@ -10,7 +10,7 @@ hideall "--sync--"
 # -ii 1C90 1ABC -ic "Fierce Wind" "Void Sprite"
 
 # Main Deck will be sealed off
-0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:755/ window 0,5
+0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:755:/ window 0,5
 6.7 "Spike Of Darkness" sync / 1[56]:[^:]*:Deathgaze Hollow:1E51:/
 11.8 "--sync--" sync / 1[56]:[^:]*:Deathgaze Hollow:1C91:/
 16.6 "--sync--" sync / 1[56]:[^:]*:Deathgaze Hollow:1C92:/
@@ -117,7 +117,7 @@ hideall "--sync--"
 # -ic "Ferdiad's Fool"
 
 # The Rostrum will be sealed off
-1000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:758/ window 1000,5
+1000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:758:/ window 1000,5
 1014.2 "Black Wind x3" # sync / 1[56]:[^:]*:Ferdiad Hollow:1CAC:/
 1020.3 "Sleight" sync / 1[56]:[^:]*:Ferdiad Hollow:1C99:/
 1028.0 "Wormhole" sync / 1[56]:[^:]*:Ferdiad Hollow:1C9A:/
@@ -189,7 +189,7 @@ hideall "--sync--"
 # -ic "Allagan Dreadnaught" "Proto Bit"
 
 # The Queen's Pride will be sealed off
-2000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:759/ window 2000,5
+2000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:759:/ window 2000,5
 
 2007.8 "Aether Bend" sync / 1[56]:[^:]*:Proto Ultima:1D99:/
 2018.4 "Aetherochemical Laser 1" sync / 1[56]:[^:]*:Proto Ultima:1D96:/
@@ -249,7 +249,7 @@ hideall "--sync--"
 # -ic Shadowcourt Jester" "Chimera Poppet"
 
 # The Queen's Graces will be sealed off
-3000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:75A/ window 3000,5
+3000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:75A:/ window 3000,5
 3013.1 "Thirty Thorns" sync / 1[56]:[^:]*:Scathach:1D2B:/
 3030.2 "Thirty Arrows" sync / 1[56]:[^:]*:Scathach:1D2F:/ window 30,5
 3037.4 "Manos" sync / 1[56]:[^:]*:Scathach:1CD3:/ window 30,5

--- a/ui/raidboss/data/03-hw/alliance/weeping_city.txt
+++ b/ui/raidboss/data/03-hw/alliance/weeping_city.txt
@@ -11,7 +11,7 @@ hideall "--sync--"
 # -ic "Webmaiden" "Spitting Spider" "Skittering Spider" "Earth Aether"
 
 # The Queen's Room will be sealed off
-0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:6E0/
+0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:6E0:/
 9.8 "Dark Spike" sync / 1[56]:[^:]*:Arachne Eve:1823:/
 21.6 "Silken Spray" sync / 1[56]:[^:]*:Arachne Eve:1824:/
 30.4 "Arachne Web x3" duration 5 # sync / 1[56]:[^:]*:Arachne Eve:185E:/
@@ -134,7 +134,7 @@ hideall "--sync--"
 # -ii 366 17D5 17C1 17D6
 
 # The Shrine of the Goetic will be sealed off
-1000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:6E3/ window 1000,5
+1000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:6E3:/ window 1000,5
 1014.2 "Necropurge" sync / 1[56]:[^:]*:Shriveled Talon:17D7:/
 1024.4 "Megiddo Flame" sync / 1[56]:[^:]*:Forgall:17C0:/
 1032.4 "Necropurge" sync / 1[56]:[^:]*:Forgall:17BE:/
@@ -195,7 +195,7 @@ hideall "--sync--"
 # Cube opening block ----> Intermission --> Sphere bridge block --> (Cube|Sphere) rotation blocks |
 
 # The Gloriole will be sealed off
-2000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:6E5/ window 2000,5
+2000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:6E5:/ window 2000,5
 2015.0 "Meteor Headmarkers"
 2024.0 "Meteor Impact" sync / 1[56]:[^:]*:Singularity Fragment:1935:/
 
@@ -326,7 +326,7 @@ hideall "--sync--"
 # 1811 and 180D are releasing hair after Haircut and Split End cleaves
 
 # Tomb of the Nullstone will be sealed off
-4000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:6E6/ window 4000,5
+4000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:6E6:/ window 4000,5
 4004.1 "Bloodied Nail x4" # sync / 1[56]:[^:]*:Calofisteri:181F:/
 4018.8 "Coif Change" sync / 1[56]:[^:]*:Calofisteri:180[AE]:/ window 18.8,5
 4027.8 "Haircut" sync / 1[56]:[^:]*:Calofisteri:180[BF]:/

--- a/ui/raidboss/data/03-hw/dungeon/aetherochemical_research_facility.txt
+++ b/ui/raidboss/data/03-hw/dungeon/aetherochemical_research_facility.txt
@@ -7,7 +7,7 @@ hideall "--sync--"
 
 # -ii 10E1
 # Analysis and Proving will be sealed off
-0.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:63E/
+0.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:63E:/
 6.3 "Bastardbluss" sync / 1[56]:[^:]*:Regula van Hydrus:10DA:/ window 6.3,5
 
 13.4 "Judgment" sync / 1[56]:[^:]*:Regula van Hydrus:10DD:/ window 13.4,2.5
@@ -115,7 +115,7 @@ hideall "--sync--"
 # by a unique version of the skill as well.
 
 # Evaluation and Authentication will be sealed off
-1000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:63F/ window 1000,5
+1000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:63F:/ window 1000,5
 
 # Cobra is immediate
 1008.6 "Weighing of the Heart" sync / 1[56]:[^:]*:Harmachis:10E8:/ window 9,9

--- a/ui/raidboss/data/03-hw/dungeon/baelsars_wall.txt
+++ b/ui/raidboss/data/03-hw/dungeon/baelsars_wall.txt
@@ -16,7 +16,7 @@ hideall "--sync--"
 # We sync on Magitek Ray and hope for the best. It's all bad.
 
 # Via Praetoria will be sealed off
-0 "Start" sync / 29:[^:]*:7DC:[^:]*:746/ window 0,1
+0 "Start" sync / 29:[^:]*:7DC:[^:]*:746:/ window 0,1
 10.5 "Magitek Claw" sync / 1[56]:[^:]*:Magitek Predator:1CB2:/
 26.8 "Magitek Ray" sync / 1[56]:[^:]*:Magitek Predator:1CB3:/
 34.1 "Magitek Missile" sync / 1[56]:[^:]*:Magitek Predator:1CB4:/
@@ -39,7 +39,7 @@ hideall "--sync--"
 # -ii 1CB7 1CBA
 
 # The Magitek Installation will be sealed off
-1000.0 "Start" sync / 29:[^:]*:7DC:[^:]*:747/ window 1000,5
+1000.0 "Start" sync / 29:[^:]*:7DC:[^:]*:747:/ window 1000,5
 1007.1 "Magitek Cannon" sync / 1[56]:[^:]*:Armored Weapon:1CB8:/ window 7.1,5
 1013.2 "Launcher" sync / 1[56]:[^:]*:Armored Weapon:1CBC:/
 1019.4 "Dynamic Sensory Jammer" sync / 1[56]:[^:]*:Armored Weapon:1CB9:/ duration 6
@@ -84,7 +84,7 @@ hideall "--sync--"
 #~~~~~~~~~~~~~#
 
 # The Airship Landing will be sealed off
-2000.0 "Start" sync / 29:[^:]*:7DC:[^:]*:748/ window 2000,5
+2000.0 "Start" sync / 29:[^:]*:7DC:[^:]*:748:/ window 2000,5
 2006.1 "Dull Blade" sync / 1[56]:[^:]*:The Griffin:1CC1:/ window 6.1,5
 2012.2 "Beak Of The Griffin" sync / 1[56]:[^:]*:The Griffin:1CC3:/
 2019.3 "Flash Powder" sync / 1[56]:[^:]*:The Griffin:1CC4:/

--- a/ui/raidboss/data/03-hw/dungeon/fractal_continuum.txt
+++ b/ui/raidboss/data/03-hw/dungeon/fractal_continuum.txt
@@ -5,7 +5,7 @@ hideall "--sync--"
 #-ii F7D -p F7F:100
 
 # Exhibit Level III will be sealed off
-0.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:60D/ window 0,1
+0.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:60D:/ window 0,1
 10.3 "Rapid Sever" sync / 1[56]:[^:]*:Phantom Ray:F7A:/ window 15,15
 16.6 "Atmospheric Displacement" sync / 1[56]:[^:]*:Phantom Ray:F7E:/
 21.4 "Double Sever 1" sync / 1[56]:[^:]*:Phantom Ray:F7[BC]:/
@@ -49,7 +49,7 @@ hideall "--sync--"
 
 ###Minotaur
 # High-level Incubation Bay will be sealed off
-1000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:60E/ window 1999,5
+1000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:60E:/ window 1999,5
 1008.8 "11-Tonze Swipe" sync / 1[56]:[^:]*:Minotaur:F81:/ window 9,9
 1019.0 "111-Tonze Swing" sync / 1[56]:[^:]*:Minotaur:F82:/ window 20,20
 1028.2 "Disorienting Groan" sync / 1[56]:[^:]*:Minotaur:F84:/
@@ -94,7 +94,7 @@ hideall "--sync--"
 # Phase length is the same regardless of added abilities.
 
 # Reality Augmentation Bay will be sealed off
-2000 "--sync--" sync / 29:[^:]*:7DC:[^:]*:612/ window 2000,0
+2000 "--sync--" sync / 29:[^:]*:7DC:[^:]*:612:/ window 2000,0
 2006.2 "Sanctification" sync / 1[56]:[^:]*:The Curator:F89:/ window 7,7
 2011.4 "Unholy" sync / 1[56]:[^:]*:The Curator:F8A:/
 2020.6 "Sanctification" sync / 1[56]:[^:]*:The Curator:F89:/

--- a/ui/raidboss/data/03-hw/dungeon/gubal_library_hard.txt
+++ b/ui/raidboss/data/03-hw/dungeon/gubal_library_hard.txt
@@ -5,7 +5,7 @@ hideall "--sync--"
 # -ii 1951 1952
 
 # Hall of Magicks will be sealed off
-0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:657/
+0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:657:/
 6.1 "Triclip" sync / 1[56]:[^:]*:Demon of the Tome:193A:/ window 6.1,5
 17.3 "Folio" sync / 1[56]:[^:]*:Demon of the Tome:193C:/
 23.4 "--sync--" sync / 1[56]:[^:]*:Top Shelf Tome:193D:/
@@ -54,7 +54,7 @@ hideall "--sync--"
 # Whichever intermission comes second ends up with phantom "Gains Effect" lines
 
 # Astrology and Astromancy Camera will be sealed off
-1000.0 "--sync--"  sync / 29:[^:]*:7DC:[^:]*:658/ window 1000,0
+1000.0 "--sync--"  sync / 29:[^:]*:7DC:[^:]*:658:/ window 1000,0
 1007.3 "Searing Wind" sync / 1[56]:[^:]*:Liquid Flame:1944:/ window 7.3,5
 1014.3 "Bibliocide" sync / 1[56]:[^:]*:Liquid Flame:1945:/
 1025.7 "Sea Of Flames x3"
@@ -108,7 +108,7 @@ hideall "--sync--"
 # -ii 194F 1950 1958 195B 1969
 
 # Rare Tomes Room will be sealed off
-2000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:706/ window 2000,5
+2000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:706:/ window 2000,5
 2009.2 "Check Out" sync / 1[56]:[^:]*:Strix:194E:/ window 9.2,10
 2017.5 "Properties Of Darkness (buster)" sync / 1[56]:[^:]*:Strix:1954:/
 2029.6 "Properties Of Quakes" sync / 1[56]:[^:]*:Strix:1956:/

--- a/ui/raidboss/data/03-hw/dungeon/sohm_al.txt
+++ b/ui/raidboss/data/03-hw/dungeon/sohm_al.txt
@@ -8,7 +8,7 @@ hideall "--Reset--"
 # -p ED1:6.2
 
 # Greenlinn will be sealed off
-0 "Start" sync / 29:[^:]*:7DC:[^:]*:649/ window 0,1
+0 "Start" sync / 29:[^:]*:7DC:[^:]*:649:/ window 0,1
 6.2 "Bloody Caress" sync / 1[56]:[^:]*:Raskovnik:ED1:/ window 6.2,0
 12.3 "--sync--" sync / 1[56]:[^:]*:Raskovnik:ED2:/
 17.9 "Acid Rain" sync / 1[56]:[^:]*:Raskovnik:ED7:/
@@ -73,7 +73,7 @@ hideall "--Reset--"
 # -ic "Chyme Of The Mountain"
 
 # The Wound will be sealed off
-1000.0 "Start" sync / 29:[^:]*:7DC:[^:]*:64C/ window 1000,1
+1000.0 "Start" sync / 29:[^:]*:7DC:[^:]*:64C:/ window 1000,1
 
 1006.1 "Third Leg Forward" sync / 1[56]:[^:]*:Myath:1382:/ window 6.1,5
 1011.2 "Overbite" sync / 1[56]:[^:]*:Myath:EDB:/
@@ -117,7 +117,7 @@ hideall "--Reset--"
 # -ic "Comet"
 
 # Hess Afah will be sealed off
-2000.0 "Start" sync / 29:[^:]*:7DC:[^:]*:64D/ window 2000,1
+2000.0 "Start" sync / 29:[^:]*:7DC:[^:]*:64D:/ window 2000,1
 
 2006.0 "Abyssic Buster" sync / 1[56]:[^:]*:Tioman:EE3:/ window 6,6
 2013.2 "Chaos Blast" sync / 1[56]:[^:]*:Tioman:EE5:/

--- a/ui/raidboss/data/03-hw/dungeon/sohm_al_hard.txt
+++ b/ui/raidboss/data/03-hw/dungeon/sohm_al_hard.txt
@@ -11,7 +11,7 @@ hideall "--Reset--"
 # -ic "Spore Sac"
 
 # The Wound will be sealed off
-0.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:64C/ window 0,1
+0.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:64C:/ window 0,1
 2.4 "--sync--" sync / 1[56]:[^:]*:The Leightonward:5B5:/ window 2.4,1
 6.1 "Wild Horn" sync / 1[56]:[^:]*:The Leightonward:1C2D:/ window 6.1,5
 13.2 "Inflammable Fumes (Readies)" sync / 1[56]:[^:]*:The Leightonward:1C30:/
@@ -64,7 +64,7 @@ hideall "--Reset--"
 # -ii 1C3F
 
 # The Lava Tube will be sealed off
-2000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:763/ window 2000,1
+2000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:763:/ window 2000,1
 2012.0 "Molten Silk (Front)" sync / 1[56]:[^:]*:Lava Scorpion:1C43:/ window 12,5
 2022.2 "Flying Press" sync / 1[56]:[^:]*:Lava Scorpion:1C3E:/
 2038.4 "Deadly Thrust" sync / 1[56]:[^:]*:Lava Scorpion:1C40:/

--- a/ui/raidboss/data/03-hw/dungeon/the_lost_city_of_amdapor_hard.txt
+++ b/ui/raidboss/data/03-hw/dungeon/the_lost_city_of_amdapor_hard.txt
@@ -17,7 +17,7 @@ hideall "--sync--"
 # Timings seem to get off if the boss moves around, so extra syncs are added.
 
 # Tower of White will be sealed off
-1000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:541/ window 10000,0
+1000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:541:/ window 10000,0
 1022.7 "Psycho Squama" sync / 1[56]:[^:]*:Achamoth:15C6:/
 1044.0 "Psycho Squama" sync / 1[56]:[^:]*:Achamoth:15C6:/
 1055.1 "Neuro Squama" sync / 1[56]:[^:]*:Achamoth:15C5:/
@@ -53,7 +53,7 @@ hideall "--sync--"
 # -ii 15D1 15D3 15D4 15CF 15CC 15D6 1706 15CD 167B
 
 # Dark Wings will be sealed off
-2000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:698/ window 10000,0
+2000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:698:/ window 10000,0
 2012.0 "Ancient Aero" sync / 1[56]:[^:]*:Winged Lion:15CE:/
 2025.1 "Scratch" sync / 1[56]:[^:]*:Winged Lion:15D5:/
 2033.2 "Ancient Stone" sync / 1[56]:[^:]*:Winged Lion:15D2:/
@@ -119,7 +119,7 @@ hideall "--sync--"
 
 # Phase 1
 # The Protectorate will be sealed off
-3000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:69A/ window 10000,0
+3000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:69A:/ window 10000,0
 3007.0 "Glory" sync / 1[56]:[^:]*:Kuribu:15E4:/
 3015.1 "Regen" sync / 1[56]:[^:]*:Kuribu:15DC:/
 3022.2 "Transference" sync / 1[56]:[^:]*:Kuribu:15DE:/

--- a/ui/raidboss/data/03-hw/dungeon/the_vault.txt
+++ b/ui/raidboss/data/03-hw/dungeon/the_vault.txt
@@ -8,7 +8,7 @@ hideall "--sync--"
 # Barely worth including, but oh well.
 
 # The Quire will be sealed off
-0.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:622/ window 0,1
+0.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:622:/ window 0,1
 5.4 "Fast Blade" sync / 1[56]:[^:]*:Ser Adelphel Brightblade:2CD:/ window 5.4,5
 12.5 "Bloodstain" sync / 1[56]:[^:]*:Ser Adelphel Brightblade:44B:/
 15.8 "Fast Blade" sync / 1[56]:[^:]*:Ser Adelphel Brightblade:2CD:/
@@ -92,7 +92,7 @@ hideall "--sync--"
 
 # Pre-phase
 # Chapter House will be sealed off
-1000 "--sync--" sync / 29:[^:]*:7DC:[^:]*:623/ window 1000,1
+1000 "--sync--" sync / 29:[^:]*:7DC:[^:]*:623:/ window 1000,1
 1006.7 "Overpower" sync / 1[56]:[^:]*:Ser Grinnaux the Bull:88C:/ window 6.7,5
 1015.6 "Rive" sync / 1[56]:[^:]*:Ser Grinnaux the Bull:46F:/
 1018.9 "Overpower" sync / 1[56]:[^:]*:Ser Grinnaux the Bull:88C:/
@@ -155,7 +155,7 @@ hideall "--sync--"
 ###Ser Charibert
 
 # The Chancel will be sealed off
-2000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:624/ window 2000,0
+2000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:624:/ window 2000,0
 2006.3 "Altar Candle" sync / 1[56]:[^:]*:Ser Charibert:1030:/ window 6.3,5
 2015.0 "Heavensflame" sync / 1[56]:[^:]*:Ser Charibert:1031:/
 2019.2 "Holy Chain" sync / 1[56]:[^:]*:Ser Charibert:1033:/ window 15,15

--- a/ui/raidboss/data/03-hw/dungeon/xelphatol.txt
+++ b/ui/raidboss/data/03-hw/dungeon/xelphatol.txt
@@ -11,7 +11,7 @@ hideall "--sync--"
 # -ic "Ixali Stitcher" "Airstone"
 
 # The Cage will be sealed off
-0 "Start" sync / 29:[^:]*:7DC:[^:]*:6FD/ window 0,1
+0 "Start" sync / 29:[^:]*:7DC:[^:]*:6FD:/ window 0,1
 7.0 "Short Burst" sync / 1[56]:[^:]*:Nuzal Hueloc:19C6:/ window 7,5
 15.1 "Wind Blast" sync / 1[56]:[^:]*:Nuzal Hueloc:19C7:/
 19.2 "Short Burst" sync / 1[56]:[^:]*:Nuzal Hueloc:19C6:/
@@ -71,7 +71,7 @@ hideall "--sync--"
 # -ii 19D2
 
 # The Tlachtli will be sealed off
-1000.0 "Start" sync / 29:[^:]*:7DC:[^:]*:6FE/ window 1000,5
+1000.0 "Start" sync / 29:[^:]*:7DC:[^:]*:6FE:/ window 1000,5
 1012.4 "On Low" sync / 1[56]:[^:]*:Dotoli Ciloc:19CE:/
 1024.5 "On High" sync / 1[56]:[^:]*:Dotoli Ciloc:19CF:/ window 24.5,10
 
@@ -97,7 +97,7 @@ hideall "--sync--"
 # -ii 19D8
 
 # The Vortex will be sealed off
-2000.0 "Start" sync / 29:[^:]*:7DC:[^:]*:6FF/ window 2000,5
+2000.0 "Start" sync / 29:[^:]*:7DC:[^:]*:6FF:/ window 2000,5
 2007.1 "Ixali Aero (buster)" sync / 1[56]:[^:]*:Tozol Huatotl:19D3:/ window 7.1,5
 2014.2 "Ixali Aero III (aoe)" sync / 1[56]:[^:]*:Tozol Huatotl:19D5:/
 2023.7 "Bill" sync / 1[56]:[^:]*:Abalathian Hornbill:19DA:/

--- a/ui/raidboss/data/03-hw/raid/a10n.txt
+++ b/ui/raidboss/data/03-hw/raid/a10n.txt
@@ -7,7 +7,7 @@ hideall "--Reset--"
 hideall "--sync--"
 
 # The Excruciationator will be sealed off
-0.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:736/ window 0,1
+0.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:736:/ window 0,1
 7.0 "Goblin Rush" sync / 1[56]:[^:]*:Lamebrix Strikebocks:1A17:/ window 7,3
 10.1 "Gobsway Rumblerocks" sync / 1[56]:[^:]*:Lamebrix Strikebocks:1AD0:/
 15.2 "Gobsway Rumblerocks" sync / 1[56]:[^:]*:Lamebrix Strikebocks:1AD0:/

--- a/ui/raidboss/data/03-hw/raid/a1s.txt
+++ b/ui/raidboss/data/03-hw/raid/a1s.txt
@@ -10,7 +10,7 @@ hideall "--sync--"
 ### Faust
 # -p E3C:1006 -ii E3E
 # Machinery Bay 44 will be sealed off
-1000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:65F/ window 1000,0
+1000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:65F:/ window 1000,0
 1006.0 "Kaltstrahl" sync / 1[56]:[^:]*:Faust:E3C:/ window 1006,5
 1009.7 "Sturm Doll Add"
 1016.0 "Kaltstrahl" sync / 1[56]:[^:]*:Faust:E3C:/
@@ -53,7 +53,7 @@ hideall "--sync--"
 # -ic "Oppressor 0.5"
 
 # Hangar 8 will be sealed off
-2000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:660/ window 2000,0
+2000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:660:/ window 2000,0
 2007.0 "Royal Fount" sync / 1[56]:[^:]*:Oppressor:E40:/ window 2010,5
 2011.1 "Gunnery Pod" sync / 1[56]:[^:]*:Oppressor:E41:/
 2016.2 "Hydrothermal Missile" sync / 1[56]:[^:]*:Oppressor:E43:/ duration 8

--- a/ui/raidboss/data/03-hw/raid/a3n.txt
+++ b/ui/raidboss/data/03-hw/raid/a3n.txt
@@ -8,7 +8,7 @@ hideall "--sync--"
 # -ii 1305 12FA
 
 # Condensate Demineralizer #9 will be sealed off
-0.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:66C/ window 10000,10000
+0.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:66C:/ window 10000,10000
 7.5 "Fluid Swing" sync /:Living Liquid:12EE:/
 11.6 "Splash x3" duration 3 #sync /:Living Liquid:12EF:/
 19.9 "Protean Wave" sync /:Living Liquid:12F0:/

--- a/ui/raidboss/data/03-hw/raid/a5s.txt
+++ b/ui/raidboss/data/03-hw/raid/a5s.txt
@@ -9,7 +9,7 @@ hideall "Relaxant"
 
 ### Hummel and Friends
 # The Clevering will be sealed off
-1000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:6AF/ window 1000,0
+1000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:6AF:/ window 1000,0
 1009.8 "Kaltstrahl x1" sync / 1[56]:[^:]*:Faust:16CC:/ window 10,5
 1018.9 "Kaltstrahl x2" duration 2.1 sync / 1[56]:[^:]*:Faust:16CC:/ window 5,0.5
 #1021.0 "Kaltstrahl" sync / 1[56]:[^:]*:Faust:16CC:/

--- a/ui/raidboss/data/03-hw/raid/a6n.txt
+++ b/ui/raidboss/data/03-hw/raid/a6n.txt
@@ -5,7 +5,7 @@
 
 # -ii 170E
 # Machinery Bay 67 will be sealed off
-0.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:6B7/ window 1,0
+0.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:6B7:/ window 1,0
 6.8 "Brute Force" sync / 1[56]:[^:]*:Blaster:170A:/ window 6.8,5
 10.9 "Mind Blast" sync / 1[56]:[^:]*:Blaster:170B:/
 15.0 "Ballistic Missile" sync / 1[56]:[^:]*:Blaster:15F4:/
@@ -27,7 +27,7 @@
 
 ### Brawler
 # Machinery Bay 68 will be sealed off
-1000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:6B8/ window 1000,0
+1000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:6B8:/ window 1000,0
 1008.7 "Magicked Mark" sync / 1[56]:[^:]*:Brawler:1715:/ window 8.7,5
 1010.8 "Attachment" sync / 1[56]:[^:]*:Brawler:1601:/
 1017.0 "Single Buster/Double Buster/Rocket Drill" sync / 1[56]:[^:]*:Brawler:(1717|1718|1719):/
@@ -47,7 +47,7 @@
 ### Swindler
 # -ii 171D
 # Machinery Bay 69 will be sealed off
-2000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:6B9/ window 2000,0
+2000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:6B9:/ window 2000,0
 2006.5 "Magicked Mark" sync / 1[56]:[^:]*:Swindler:171B:/
 2015.6 "Height" sync / 1[56]:[^:]*:Swindler:171C:/ window 15.6,20
 2018.8 "Magicked Mark" sync / 1[56]:[^:]*:Swindler:171B:/
@@ -67,7 +67,7 @@
 
 ### Vortexer
 # Machinery Bay 70 will be sealed off
-3000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:6BA/ window 3000,0
+3000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:6BA:/ window 3000,0
 3007.3 "Brute Force" sync / 1[56]:[^:]*:Vortexer:1721:/ window 7.3,5
 3017.4 "Elemental Jammer" sync / 1[56]:[^:]*:Vortexer:161B:/
 3019.5 "Ballistic Missile" sync / 1[56]:[^:]*:Vortexer:1622:/

--- a/ui/raidboss/data/03-hw/raid/a6s.txt
+++ b/ui/raidboss/data/03-hw/raid/a6s.txt
@@ -8,7 +8,7 @@ hideall "Ballistic Missile"
 
 ### Blaster
 # Machinery Bay 67 will be sealed off
-0.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:6B7/ window 1,0
+0.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:6B7:/ window 1,0
 7.0 "Brute Force" sync / 1[56]:[^:]*:Blaster:15F2:/ window 10,10
 14.1 "Mind Blast" sync / 1[56]:[^:]*:Blaster:15F3:/
 18.2 "Ballistic Missile" sync / 1[56]:[^:]*:Blaster:15F4:/
@@ -63,7 +63,7 @@ hideall "Ballistic Missile"
 # Note: "Brawler Mechanic" drifts relative to attachment depending on type.
 # Brawler Mechanics seem entirely/mostly random?
 # Machinery Bay 68 will be sealed off
-1000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:6B8/ window 1000,0
+1000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:6B8:/ window 1000,0
 1008.8 "Magicked Mark" sync / 1[56]:[^:]*:Brawler:1600:/ window 100,100
 1011.0 "Attachment" sync / 1[56]:[^:]*:Brawler:1601:/
 1017.2 "Brawler Mechanic" #sync / 1[56]:[^:]*:Brawler:160[2345]:/
@@ -109,7 +109,7 @@ hideall "Ballistic Missile"
 
 ### Swindler
 # Machinery Bay 69 will be sealed off
-2000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:6B9/ window 2000,0
+2000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:6B9:/ window 2000,0
 2021.2 "Height" sync / 1[56]:[^:]*:Swindler:160D:/ window 22,7
 2021.2 "Enumeration" sync / 1[56]:[^:]*:Swindler:160F:/
 2029.3 "Bio-Arithmeticks" sync / 1[56]:[^:]*:Swindler:1610:/
@@ -155,7 +155,7 @@ hideall "Ballistic Missile"
 
 ### Vortexer
 # Machinery Bay 70 will be sealed off
-3000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:6BA/ window 3000,0
+3000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:6BA:/ window 3000,0
 3006.7 "Brute Force" sync / 1[56]:[^:]*:Vortexer:1619:/ window 10,10
 3016.8 "Elemental Jammer" sync / 1[56]:[^:]*:Vortexer:161B:/
 3022.0 "Ballistic Missile" sync / 1[56]:[^:]*:Vortexer:1622:/

--- a/ui/raidboss/data/03-hw/raid/a9s.txt
+++ b/ui/raidboss/data/03-hw/raid/a9s.txt
@@ -9,7 +9,7 @@ hideall "--sync--"
 ### Faust Z
 # -p 1A2B:1006.5
 # The Cranial Plate will be sealed off
-1000.0	"--sync--"	sync / 29:[^:]*:7DC:[^:]*:72F/ window 10000
+1000.0	"--sync--"	sync / 29:[^:]*:7DC:[^:]*:72F:/ window 10000
 1006.5 "Kaltstrahl" sync / 1[56]:[^:]*:Faust Z:1A2B:/ window 1007,2.5
 1013.6 "Kaltstrahl" sync / 1[56]:[^:]*:Faust Z:1A2B:/
 1020.7 "Kaltstrahl" sync / 1[56]:[^:]*:Faust Z:1A2B:/
@@ -49,7 +49,7 @@ hideall "--sync--"
 
 # Phase 1
 # Life Support will be sealed off
-2000.0	"--sync--"	sync / 29:[^:]*:7DC:[^:]*:730/ window 10000
+2000.0	"--sync--"	sync / 29:[^:]*:7DC:[^:]*:730:/ window 10000
 2010.0 "Stockpile" sync / 1[56]:[^:]*:Refurbisher 0:1A38:/ window 2010,5
 2012.1 "Right Arm Reassembly" sync / 1[56]:[^:]*:Refurbisher 0:1A2E:/
 2014.3 "Power Generator x2 (NE)"

--- a/ui/raidboss/data/04-sb/alliance/orbonne_monastery.txt
+++ b/ui/raidboss/data/04-sb/alliance/orbonne_monastery.txt
@@ -11,7 +11,7 @@ hideall "--sync--"
 
 ### Phase 1
 # Realm of the Machinists will be sealed off
-1000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:B35/ window 1000,0
+1000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:B35:/ window 1000,0
 1012.0 "Energy Burst" sync / 1[56]:[^:]*:Mustadio:373B:/
 1022.7 "Arm Shot" sync / 1[56]:[^:]*:Mustadio:3739:/
 1033.2 "L/R Handgonne" sync / 1[56]:[^:]*:Mustadio:373[EF]:/
@@ -94,7 +94,7 @@ hideall "--sync--"
 
 ### Phase 1
 # Realm of the Templars will be sealed off
-2000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:B36/ window 2000,0
+2000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:B36:/ window 2000,0
 2012.8 "Divine Light" sync / 1[56]:[^:]*:Agrias:3867:/
 2023.3 "Thunder Slash" sync / 1[56]:[^:]*:Agrias:3866:/
 2043.5 "Judgment Blade" sync / 1[56]:[^:]*:Agrias:3857:/
@@ -155,7 +155,7 @@ hideall "--sync--"
 #######################
 # -p 377F:3500 -ii 3780
 # Lifeless Alley will be sealed off
-3000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:B37/ window 3000,0
+3000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:B37:/ window 3000,0
 3491.0 "--sync--" sync / 14:[^:]*:Dark Crusader:377F:/ window 500,0
 3500.0 "Dark Rite" sync / 1[56]:[^:]*:Dark Crusader:377F:/
 3509.0 "Noahionto" sync / 1[56]:[^:]*:Dark Crusader:377E:/
@@ -184,7 +184,7 @@ hideall "--sync--"
 
 ### Phase 1
 # Realm of the Thunder God will be sealed off
-4000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:B38/ window 4000,0
+4000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:B38:/ window 4000,0
 4015.0 "Cleansing Strike" sync / 1[56]:[^:]*:The Thunder God:3751:/
 4032.5 "Sword L/R" sync / 1[56]:[^:]*:The Thunder God:374[9A]:/
 4042.5 "Sword In/Out" sync / 1[56]:[^:]*:The Thunder God:37(50|4F):/
@@ -241,7 +241,7 @@ hideall "--sync--"
 
 ### Phase 1: Throwbacks
 # Crystalline Gaol will be sealed off
-5000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:B39/ window 5000,0
+5000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:B39:/ window 5000,0
 5015.0 "Holy IV Ground" sync / 1[56]:[^:]*:Ultima, the High Seraph:3899:/
 5029.2 "Auralight" sync / 1[56]:[^:]*:Ultima, the High Seraph:3898:/
 5035.7 "Holy IV" sync / 1[56]:[^:]*:Ultima, the High Seraph:389B:/

--- a/ui/raidboss/data/04-sb/alliance/ridorana_lighthouse.txt
+++ b/ui/raidboss/data/04-sb/alliance/ridorana_lighthouse.txt
@@ -8,7 +8,7 @@ hideall "--sync--"
 # Famfrit #
 ###########
 # Echoes from Time's Garden will be sealed off
-0 "Start" sync / 29:[^:]*:7DC:[^:]*:998/ window 0,1
+0 "Start" sync / 29:[^:]*:7DC:[^:]*:998:/ window 0,1
 13 "Tide Pod" sync / 1[56]:[^:]*:Famfrit, The Darkening Cloud:2C3E:/ window 13,1
 26 "Water IV" sync / 1[56]:[^:]*:Famfrit, The Darkening Cloud:2C3D:/
 35 "Briny Cannonade" sync / 1[56]:[^:]*:Famfrit, The Darkening Cloud:2C45:/
@@ -65,7 +65,7 @@ hideall "--sync--"
 ##########
 
 # The Spire's Bounds will be sealed off
-1000 "Start" sync / 29:[^:]*:7DC:[^:]*:99A/ window 1000,0
+1000 "Start" sync / 29:[^:]*:7DC:[^:]*:99A:/ window 1000,0
 1012 "Fire" sync / 1[56]:[^:]*:Belias, the Gigas:2CDB:/ window 1012,5
 1024 "Fire IV" sync / 1[56]:[^:]*:Belias, the Gigas:2CDC:/
 1033 "Time Eruption" sync / 1[56]:[^:]*:Belias, the Gigas:2CDE:/
@@ -126,7 +126,7 @@ hideall "--sync--"
 # Construct 7 #
 ###############
 # The Cleft of Profaning Wind will be sealed off
-2000 "Start" sync / 29:[^:]*:7DC:[^:]*:99C/ window 2000,0
+2000 "Start" sync / 29:[^:]*:7DC:[^:]*:99C:/ window 2000,0
 2016 "Destroy" sync / 1[56]:[^:]*:Construct 7:2C5A:/ window 2016,0
 2026 "Ignite" sync / 1[56]:[^:]*:Construct 7:2C67:/
 2029 "Accelerate" sync / 1[56]:[^:]*:Construct 7:2C65:/
@@ -189,7 +189,7 @@ hideall "--sync--"
 
 ### Yiazmat
 # The Clockwork Coliseum will be sealed off
-3000 "Start" sync / 29:[^:]*:7DC:[^:]*:99D/ window 3000,0
+3000 "Start" sync / 29:[^:]*:7DC:[^:]*:99D:/ window 3000,0
 3016 "Rake (single)" sync / 1[56]:[^:]*:Yiazmat:2C26:/ window 3016,0
 3026 "Gust Front" duration 4
 3034 "Stone Breath" sync / 1[56]:[^:]*:Yiazmat:2C29:/

--- a/ui/raidboss/data/04-sb/alliance/royal_city_of_rabanastre.txt
+++ b/ui/raidboss/data/04-sb/alliance/royal_city_of_rabanastre.txt
@@ -11,7 +11,7 @@ hideall "--start--"
 # -it "Mateus, The Corrupt"
 
 # Crumbling Bridge will be sealed off
-0.0 "--start--" sync / 29:[^:]*:7DC:[^:]*:949/ window 0,1
+0.0 "--start--" sync / 29:[^:]*:7DC:[^:]*:949:/ window 0,1
 # TODO: does this only start when the adds are dead?
 22.6 "--sync--" sync / 14:[^:]*:Mateus, The Corrupt:2633:/ window 30,10
 
@@ -62,7 +62,7 @@ hideall "--start--"
 # -it "Hashmal, Bringer of Order"
 
 # Palace Square will be sealed off
-1000.0 "--start--" sync / 29:[^:]*:7DC:[^:]*:94C/ window 10000,0
+1000.0 "--start--" sync / 29:[^:]*:7DC:[^:]*:94C:/ window 10000,0
 1011.0 "--sync--" sync / 14:[^:]*:Hashmal, Bringer of Order:25D8:/ window 20,20
 1015.0 "Quake IV" sync / 1[56]:[^:]*:Hashmal, Bringer of Order:25D8:/
 1020.4 "Jagged Edge 1" #sync / 1[56]:[^:]*:Hashmal, Bringer of Order:25CD:/
@@ -174,7 +174,7 @@ hideall "--start--"
 # -it "Rofocale"
 
 # Lesalia Garden Ruins will be sealed off
-2000.0 "--start--" sync / 29:[^:]*:7DC:[^:]*:94D/ window 10000,0
+2000.0 "--start--" sync / 29:[^:]*:7DC:[^:]*:94D:/ window 10000,0
 2012.8 "--sync--" sync / 14:[^:]*:Rofocale:2680:/ window 20,20
 2015.8 "Crush Helm" sync / 1[56]:[^:]*:Rofocale:2680:/ duration 3.4
 2035.5 "Chariot" sync / 1[56]:[^:]*:Rofocale:2674:/
@@ -290,7 +290,7 @@ hideall "--start--"
 
 ## Phase 1
 # Lesalia Temple Ruins will be sealed off
-4000.0 "--start--" sync / 29:[^:]*:7DC:[^:]*:94E/ window 10000,0
+4000.0 "--start--" sync / 29:[^:]*:7DC:[^:]*:94E:/ window 10000,0
 4006.7 "--sync--" sync / 14:[^:]*:Argath Thadalfus:262D:/ window 20,20
 4009.7 "Crippling Blow" sync / 1[56]:[^:]*:Argath Thadalfus:262D:/
 4017.9 "Crush Weapon x3" sync / 1[56]:[^:]*:Argath Thadalfus:2628:/

--- a/ui/raidboss/data/04-sb/dungeon/ala_mhigo.txt
+++ b/ui/raidboss/data/04-sb/dungeon/ala_mhigo.txt
@@ -5,7 +5,7 @@ hideall "--sync--"
 # -ii 2049 204A 204B 204C
 # boss will walk center before using 2048 Tail Laser, causes timeline drift
 # Rhalgr's Gate will be sealed off
-0.0 "--Start--" sync / 29:[^:]*:7DC:[^:]*:8F1/
+0.0 "--Start--" sync / 29:[^:]*:7DC:[^:]*:8F1:/
 9.6 "Electromagnetic Field" sync / 1[56]:[^:]*:Magitek Scorpion:204D:/ window 10,5
 18.8 "Target Search" sync / 1[56]:[^:]*:Magitek Scorpion:2046:/
 29.4 "Lock On" sync / 1[56]:[^:]*:Magitek Scorpion:2047:/
@@ -30,7 +30,7 @@ hideall "--sync--"
 # Aulus Mal Asina
 # -ii 2051 2052 205E
 # The Chamber of Knowledge will be sealed off
-1000.0 "--Start--" sync / 29:[^:]*:7DC:[^:]*:8F2/ window 1000,5
+1000.0 "--Start--" sync / 29:[^:]*:7DC:[^:]*:8F2:/ window 1000,5
 1013.0 "Mana Burst" sync / 1[56]:[^:]*:Aulus mal Asina:204F:/ window 14,5
 1019.1 "Order to Charge" sync / 1[56]:[^:]*:Aulus mal Asina:2057:/
 1020.0 "--sync--" sync / 1[56]:[^:]*:Prototype Bit:2053:/
@@ -94,7 +94,7 @@ hideall "--sync--"
 # -ii 2061 2062 2064 2067 2069 2589
 # boss will walk center before using 2065/2066/2068 Art of the Swell/Storm/Sword, causes timeline drift
 # The Hall of the Griffin will be sealed off
-2000.0 "--Start--" sync / 29:[^:]*:7DC:[^:]*:8F3/ window 2000,5
+2000.0 "--Start--" sync / 29:[^:]*:7DC:[^:]*:8F3:/ window 2000,5
 2009.7 "--sync--" sync / 1[56]:[^:]*:Zenos Yae Galvus:205F:/ window 10,5
 2023.4 "Storm?/Swell?" sync / 1[56]:[^:]*:Zenos Yae Galvus:206[56]:/ window 5,5
 

--- a/ui/raidboss/data/04-sb/dungeon/bardams_mettle.txt
+++ b/ui/raidboss/data/04-sb/dungeon/bardams_mettle.txt
@@ -10,7 +10,7 @@ hideall "Reconstruct"
 # -ic "Steppe Coeurl" "Steppe Sheep" "Steppe Yamaa"
 
 # Bardam's Hunt will be sealed off
-0 "Start" sync / 29:[^:]*:7DC:[^:]*:7B8/
+0 "Start" sync / 29:[^:]*:7DC:[^:]*:7B8:/
 11.7 "Heave" sync / 1[56]:[^:]*:Garula:1EF7:/ window 11.7,5
 20.9 "--sync--" sync / 1[56]:[^:]*:Garula:1EF8:/
 22.4 "Crumbling Crust" sync / 1[56]:[^:]*:Garula:1F13:/
@@ -34,7 +34,7 @@ hideall "Reconstruct"
 # -ii 1EFE 2578 2579 257A 257E 257B
 
 # The Rebirth of Bardam the Brave will be sealed off
-1000.0 "Start" sync / 29:[^:]*:7DC:[^:]*:7B9/ window 1000,5
+1000.0 "Start" sync / 29:[^:]*:7DC:[^:]*:7B9:/ window 1000,5
 1007.8 "Travail" sync / 1[56]:[^:]*:Bardam:1EFF:/ window 7.8,5
 1014.1 "Magnetism" sync / 1[56]:[^:]*:Hunter Of Bardam:1F08:/
 1020.3 "Tremblor" sync / 1[56]:[^:]*:Bardam:257C:/
@@ -72,7 +72,7 @@ hideall "Reconstruct"
 # -ii 1F0B 1F0E
 
 # The Voiceless Muse will be sealed off
-2000.0 "Start" sync / 29:[^:]*:7DC:[^:]*:7BA/ window 2000,5
+2000.0 "Start" sync / 29:[^:]*:7DC:[^:]*:7BA:/ window 2000,5
 2008.1 "Feathercut" sync / 1[56]:[^:]*:Yol:1F09:/
 2015.2 "Wind Unbound" sync / 1[56]:[^:]*:Yol:1F0A:/
 2023.9 "Pinion" sync / 1[56]:[^:]*:Yol Feather:1F11:/

--- a/ui/raidboss/data/04-sb/dungeon/castrum_abania.txt
+++ b/ui/raidboss/data/04-sb/dungeon/castrum_abania.txt
@@ -8,7 +8,7 @@ hideall "--sync--"
 
 # initial
 # Terrestrial Weaponry will be sealed off
-0.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:790/ window 0,1
+0.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:790:/ window 0,1
 13.5 "Magitek Fire II" sync / 1[56]:[^:]*:Magna Roader:1F15:/
 18.6 "Magitek Fire II" sync / 1[56]:[^:]*:Magna Roader:1F15:/
 25.7 "Magitek Fire III" sync / 1[56]:[^:]*:Magna Roader:1F16:/
@@ -77,7 +77,7 @@ hideall "--sync--"
 # -ii 82B1 82B2 83D3 82AE 82AF 82B0 83D4 83D5 83D6 82B9
 
 # Project Aegis will be sealed off
-1000.0 "Start" sync / 29:[^:]*:7DC:[^:]*:791/ window 10000,0
+1000.0 "Start" sync / 29:[^:]*:7DC:[^:]*:791:/ window 10000,0
 1008.3 "--sync--" sync / 14:[^:]*:Subject Number XXIV:82A9:/ window 10,10 jump 1095.0 # fire phase first
 1008.3 "--sync--" sync / 14:[^:]*:Subject Number XXIV:82A8:/ window 10,10 jump 1144.7 # ice phase first
 1008.3 "--sync--" sync / 14:[^:]*:Subject Number XXIV:82AA:/ window 10,10 jump 1193.6 # thunder phase first
@@ -143,7 +143,7 @@ hideall "--sync--"
 # * Ketu Cutter (1F27): 180/360 degree pinwheel
 # * Ketu Cut (2086) / Rahu Cut (2087) is powering up.
 # Assessment Grounds will be sealed off
-2000.0 "Start" sync / 29:[^:]*:7DC:[^:]*:792/ window 10000,0
+2000.0 "Start" sync / 29:[^:]*:7DC:[^:]*:792:/ window 10000,0
 2010.4 "Ketu Slash" sync / 1[56]:[^:]*:Inferno:1F26:/
 2017.9 "Rahu Blaster" sync / 1[56]:[^:]*:Inferno:1F29:/
 2028.8 "Ketu & Rahu" sync / 1[56]:[^:]*:Inferno:1F25:/

--- a/ui/raidboss/data/04-sb/dungeon/doma_castle.txt
+++ b/ui/raidboss/data/04-sb/dungeon/doma_castle.txt
@@ -5,7 +5,7 @@ hideall "--sync--"
 # -ii 209F 20A0
 # boss will walk center before using 209D Cermet Pile, causes timeline drift
 # The Third Armory will be sealed off
-0 "Start" sync / 29:[^:]*:7DC:[^:]*:7C1/
+0 "Start" sync / 29:[^:]*:7DC:[^:]*:7C1:/
 7.4 "Cermet Pile" sync / 1[56]:[^:]*:Magitek Rearguard:209D:/ window 10,10
 15.0 "Garlean Fire" sync / 1[56]:[^:]*:Magitek Rearguard:209E:/
 30.6 "Magitek Ray" sync / 1[56]:[^:]*:Rearguard Bit:20A1:/
@@ -49,7 +49,7 @@ hideall "--sync--"
 # -ii 20A4 20A6 20A7 2447
 # boss does not re-center
 # Training Grounds will be sealed off
-1000 "Start" sync / 29:[^:]*:7DC:[^:]*:7C2/ window 1000,0
+1000 "Start" sync / 29:[^:]*:7DC:[^:]*:7C2:/ window 1000,0
 1010.6 "Circle Of Death" sync / 1[56]:[^:]*:Magitek Hexadrone:20A2:/
 1018.9 "2-Tonze Magitek Missile" sync / 1[56]:[^:]*:Magitek Hexadrone:20A3:/
 1024.1 "Hexadrone Bits" sync / 03:........:Hexadrone Bit:/
@@ -91,7 +91,7 @@ hideall "--sync--"
 # -ii 20A9 20AB 20AC 20AE 20A7 2447
 # boss will walk center on 20B0 and stay center for 20AA Gunsaw, causes timeline drift
 # Hall of the Scarlet Swallow will be sealed off
-2000 "Start" sync / 29:[^:]*:7DC:[^:]*:7C3/ window 2000,0
+2000 "Start" sync / 29:[^:]*:7DC:[^:]*:7C3:/ window 2000,0
 2009.4 "Chainsaw" duration 5.5 sync / 1[56]:[^:]*:Hypertuned Grynewaht:20A8:/
 2022.7 "--center--"
 2022.7 "Delay-Action Charge" sync / 1[56]:[^:]*:Hypertuned Grynewaht:20AD:/ window 10,10 # boss walks center before using

--- a/ui/raidboss/data/04-sb/dungeon/drowned_city_of_skalla.txt
+++ b/ui/raidboss/data/04-sb/dungeon/drowned_city_of_skalla.txt
@@ -9,7 +9,7 @@ hideall "--sync--"
 # -ii 2655
 
 # The Green Screams will be sealed off
-0 "Start" sync / 29:[^:]*:7DC:[^:]*:93A/ window 0,1
+0 "Start" sync / 29:[^:]*:7DC:[^:]*:93A:/ window 0,1
 7.4 "Torpedo" sync / 1[56]:[^:]*:Kelpie:264F:/ window 7.4,5
 15.0 "Rising Seas" sync / 1[56]:[^:]*:Kelpie:2650:/
 26.7 "Gallop" sync / 1[56]:[^:]*:Kelpie:2653:/
@@ -46,7 +46,7 @@ hideall "--sync--"
 
 
 # A Door Unopened will be sealed off
-1000.0 "Start" sync / 29:[^:]*:7DC:[^:]*:93C/ window 1000,5
+1000.0 "Start" sync / 29:[^:]*:7DC:[^:]*:93C:/ window 1000,5
 1009.2 "Mystic Light" sync / 1[56]:[^:]*:The Old One:2657:/
 1015.0 "Mystic Flame" sync / 1[56]:[^:]*:The Old One:2658:/
 1018.1 "Order To Detonate (cast)" sync / 14:[^:]*:The Old One:265B:/ window 18.1,5 duration 19.7
@@ -98,7 +98,7 @@ hideall "--sync--"
 #~~~~~~~~~~~~~~~~~~~~~~#
 
 # The Golden Walls of Ruin will be sealed off
-2000.0 "Start" sync / 29:[^:]*:7DC:[^:]*:93E/ window 2000,5
+2000.0 "Start" sync / 29:[^:]*:7DC:[^:]*:93E:/ window 2000,5
 2012.6 "Rusting Claw" sync / 1[56]:[^:]*:Hrodric Poisontongue:2661:/ window 2012.6
 2026.2 "Tail Drive" sync / 1[56]:[^:]*:Hrodric Poisontongue:2663:/
 2035.9 "The Spin" sync / 1[56]:[^:]*:Hrodric Poisontongue:2664:/ window 35.9,5

--- a/ui/raidboss/data/04-sb/dungeon/fractal_continuum_hard.txt
+++ b/ui/raidboss/data/04-sb/dungeon/fractal_continuum_hard.txt
@@ -10,7 +10,7 @@ hideall "--sync--"
 # -ii 27A3 27A7 27A9
 
 # Reality Augmentation Bay will be sealed off
-0 "Start" sync / 29:[^:]*:7DC:[^:]*:612/
+0 "Start" sync / 29:[^:]*:7DC:[^:]*:612:/
 
 10.1 "Electrochemical Transfer" sync / 1[56]:[^:]*:Motherbit:27A4:/ window 11,5
 15.7 "--sync--" sync / 1[56]:[^:]*:Prototype Bit:27AB:/
@@ -51,7 +51,7 @@ hideall "--sync--"
 # regardless of whether X is followed by Y or by Z.
 
 # Exhibit Level VIII will be sealed off
-1000.0 "Start" sync / 29:[^:]*:7DC:[^:]*:95D/ window 1000,5
+1000.0 "Start" sync / 29:[^:]*:7DC:[^:]*:95D:/ window 1000,5
 1008.5 "Aetheroplasm" sync / 1[56]:[^:]*:The Ultima Warrior:2793:/ window 8.5,5
 1018.9 "Citadel Buster" sync / 1[56]:[^:]*:The Ultima Warrior:2792:/
 1029.8 "Ceruleum Vent" sync / 1[56]:[^:]*:The Ultima Warrior:2794:/
@@ -144,7 +144,7 @@ hideall "--sync--"
 # -ii 27B9 27BC 27BA 27BB
 
 # Genesis Engine will be sealed off
-2000.0 "Start" sync / 29:[^:]*:7DC:[^:]*:95E/ window 2000,5
+2000.0 "Start" sync / 29:[^:]*:7DC:[^:]*:95E:/ window 2000,5
 2012.0 "Death Spin" sync / 1[56]:[^:]*:The Ultima Beast:27AD:/ window 12,5
 2025.6 "Aether Bend" sync / 1[56]:[^:]*:The Ultima Beast:27AF:/
 2035.2 "--sync--" sync / 1[56]:[^:]*:The Ultima Beast:27B6:/

--- a/ui/raidboss/data/04-sb/dungeon/ghimlyt_dark.txt
+++ b/ui/raidboss/data/04-sb/dungeon/ghimlyt_dark.txt
@@ -10,7 +10,7 @@ hideall "--sync--"
 # -ii 394F 3775
 
 # The Field of Dust will be sealed off
-0 "Start" sync / 29:[^:]*:7DC:[^:]*:AB8/ window 0,1
+0 "Start" sync / 29:[^:]*:7DC:[^:]*:AB8:/ window 0,1
 12.9 "Jarring Blow" sync / 1[56]:[^:]*:Mark III-B Magitek Colossus:376E:/
 15.0 "--sync--" sync / 1[56]:[^:]*:Mark III-B Magitek Colossus:3771:/
 22.1 "Wild Fire Beam" sync / 1[56]:[^:]*:Mark III-B Magitek Colossus:3772:/ window 30,30
@@ -47,7 +47,7 @@ hideall "--sync--"
 # -ii 3AC6
 
 # Impact Crater will be sealed off
-1000.0 "Start" sync / 29:[^:]*:7DC:[^:]*:ABB/ window 1000,1
+1000.0 "Start" sync / 29:[^:]*:7DC:[^:]*:ABB:/ window 1000,1
 1012.2 "Nitrospin" sync / 1[56]:[^:]*:Prometheus:3455:/
 1023.4 "Needle Gun" sync / 1[56]:[^:]*:Prometheus:345A:/
 1031.1 "--untargetable--"
@@ -77,7 +77,7 @@ hideall "--sync--"
 #~~~~~~~~~~~~~#
 
 # Provisional Imperial Landing will be sealed off
-2000.0 "Start" sync / 29:[^:]*:7DC:[^:]*:ABD/ window 2000,5
+2000.0 "Start" sync / 29:[^:]*:7DC:[^:]*:ABD:/ window 2000,5
 2000.4 "--sync--" sync / 1[56]:[^:]*:Annia Quo Soranus:370F:/ jump 2097.0
 2000.4 "--sync--" sync / 1[56]:[^:]*:Julia Quo Soranus:370E:/ jump 2297.0
 2003.4 "Artificial Plasma?"

--- a/ui/raidboss/data/04-sb/dungeon/ghimlyt_dark64.txt
+++ b/ui/raidboss/data/04-sb/dungeon/ghimlyt_dark64.txt
@@ -10,7 +10,7 @@ hideall "--sync--"
 # -ii 394F 3775
 
 # The Field of Dust will be sealed off
-0 "Start" sync / 29:[^:]*:7DC:[^:]*:AB8/ window 0,1
+0 "Start" sync / 29:[^:]*:7DC:[^:]*:AB8:/ window 0,1
 12.9 "Jarring Blow" sync / 1[56]:[^:]*:Mark III-B Magitek Colossus:376E:/
 15.0 "--sync--" sync / 1[56]:[^:]*:Mark III-B Magitek Colossus:3771:/
 22.1 "Wild Fire Beam" sync / 1[56]:[^:]*:Mark III-B Magitek Colossus:3772:/ window 30,30
@@ -47,7 +47,7 @@ hideall "--sync--"
 # -ii 3AC6
 
 # Impact Crater will be sealed off
-1000.0 "Start" sync / 29:[^:]*:7DC:[^:]*:ABB/ window 1000,1
+1000.0 "Start" sync / 29:[^:]*:7DC:[^:]*:ABB:/ window 1000,1
 1012.2 "Nitrospin" sync / 1[56]:[^:]*:Prometheus:3455:/
 1023.4 "Needle Gun" sync / 1[56]:[^:]*:Prometheus:345A:/
 1031.1 "--untargetable--"
@@ -77,7 +77,7 @@ hideall "--sync--"
 #~~~~~~~~~~~~~#
 
 # Provisional Imperial Landing will be sealed off
-2000.0 "Start" sync / 29:[^:]*:7DC:[^:]*:ABD/ window 2000,5
+2000.0 "Start" sync / 29:[^:]*:7DC:[^:]*:ABD:/ window 2000,5
 2000.4 "--sync--" sync / 1[56]:[^:]*:Annia Quo Soranus:370F:/ jump 2097.0
 2000.4 "--sync--" sync / 1[56]:[^:]*:Julia Quo Soranus:370E:/ jump 2297.0
 2003.4 "Artificial Plasma?"

--- a/ui/raidboss/data/04-sb/dungeon/hells_lid.txt
+++ b/ui/raidboss/data/04-sb/dungeon/hells_lid.txt
@@ -10,7 +10,7 @@ hideall "--sync--"
 # -ii 27C0
 
 # Demonsgate will be sealed off
-0 "Start" sync / 29:[^:]*:7DC:[^:]*:954/ window 0,1
+0 "Start" sync / 29:[^:]*:7DC:[^:]*:954:/ window 0,1
 19.7 "100-Tonze Swing" sync / 1[56]:[^:]*:Otake-Maru:27BE:/ window 19.7,5
 27.3 "Volcanic Debris x8" # sync / 1[56]:[^:]*:Volcanic Debris:27C5:/
 28.3 "10-Tonze Slash" sync / 1[56]:[^:]*:Otake-Maru:27BF:/
@@ -54,7 +54,7 @@ hideall "--sync--"
 # -ic "Tsumuji-Kaze"
 
 # The Furnace will be sealed off
-1000.0  "Start" sync / 29:[^:]*:7DC:[^:]*:956/ window 1000,1
+1000.0  "Start" sync / 29:[^:]*:7DC:[^:]*:956:/ window 1000,1
 1011.5 "Whipping Whittret" sync / 1[56]:[^:]*:Kamaitachi:27C6:/ window 11.5,5
 1024.1 "Circling Winds" sync / 1[56]:[^:]*:Kamaitachi:27C8:/
 1037.8 "The Patient Blade" sync / 1[56]:[^:]*:Kamaitachi:27C7:/
@@ -91,7 +91,7 @@ hideall "--sync--"
 # -ii 27D2 27D5
 
 # The Polished Shell will be sealed off
-2000.0 "Start" sync / 29:[^:]*:7DC:[^:]*:959/ window 2000,1
+2000.0 "Start" sync / 29:[^:]*:7DC:[^:]*:959:/ window 2000,1
 2005.0 "Caduceus" sync / 1[56]:[^:]*:Genbu:27CF:/ window 5,5
 2013.1 "Hell Of Water" sync / 1[56]:[^:]*:Genbu:27D0:/
 2021.9 "Hell Of Waste" sync / 1[56]:[^:]*:Genbu:27D1:/

--- a/ui/raidboss/data/04-sb/dungeon/kugane_castle.txt
+++ b/ui/raidboss/data/04-sb/dungeon/kugane_castle.txt
@@ -12,7 +12,7 @@ hideall "--sync--"
 # The Harakiri Kosho adds seem to be on a separate timer and thus aren't included here.
 
 # Keisen Garden will be sealed off
-0 "Start" sync / 29:[^:]*:7DC:[^:]*:7AF/ window 0,1
+0 "Start" sync / 29:[^:]*:7DC:[^:]*:7AF:/ window 0,1
 9.6 "Clearout" sync / 1[56]:[^:]*:Zuiko-Maru:1E92:/ window 9.6,5
 21.8 "Kenki Release" sync / 1[56]:[^:]*:Zuiko-Maru:1E93:/ window 21.8,10
 30.9 "Clearout" sync / 1[56]:[^:]*:Zuiko-Maru:1E92:/
@@ -42,7 +42,7 @@ hideall "--sync--"
 # -ii 1E9C 1E9E
 
 # Budokan Training Grounds will be sealed off
-1000.0 "Start" sync / 29:[^:]*:7DC:[^:]*:7B3/ window 1000,5
+1000.0 "Start" sync / 29:[^:]*:7DC:[^:]*:7B3:/ window 1000,5
 1006.5 "Issen" sync / 1[56]:[^:]*:Dojun-Maru:1E97:/ window 1006.5,5
 1016.6 "Clockwork Medium" sync / 1[56]:[^:]*:Dojun-Maru:1E99:/
 1019.8 "Issen" sync / 1[56]:[^:]*:Dojun-Maru:1E97:/
@@ -82,7 +82,7 @@ hideall "--sync--"
 
 # Short opener
 # Noh Theater will be sealed off
-2000.0 "Start" sync / 29:[^:]*:7DC:[^:]*:7B5/ window 2000,5
+2000.0 "Start" sync / 29:[^:]*:7DC:[^:]*:7B5:/ window 2000,5
 2009.5 "Iai-Giri" sync / 1[56]:[^:]*:Yojimbo:1EA2:/ window 2009.5,5
 2012.7 "Wakizashi" sync / 1[56]:[^:]*:Yojimbo:1EA1:/
 2018.9 "Wakizashi" sync / 1[56]:[^:]*:Yojimbo:1EA1:/

--- a/ui/raidboss/data/04-sb/dungeon/shisui_of_the_violet_tides.txt
+++ b/ui/raidboss/data/04-sb/dungeon/shisui_of_the_violet_tides.txt
@@ -8,7 +8,7 @@ hideall "--sync--"
 
 # Phase 1: 100% -> 90%, autos + mini busters
 # Harutsuge Gate will be sealed off
-0.0 "Start" sync / 29:[^:]*:7DC:[^:]*:796/ window 10000,0
+0.0 "Start" sync / 29:[^:]*:7DC:[^:]*:796:/ window 10000,0
 4.5 "Sharp Strike" sync / 1[56]:[^:]*:Amikiri:1F72:/ window 20,20
 12.7 "Sharp Strike" #sync / 1[56]:[^:]*:Amikiri:1F72:/
 20.9 "Sharp Strike" #sync / 1[56]:[^:]*:Amikiri:1F72:/
@@ -44,7 +44,7 @@ hideall "--sync--"
 
 # Phase 1: 100 -> 90%, autos + mini busters
 # Akashio Hall will be sealed off
-1000.0 "Start" sync / 29:[^:]*:7DC:[^:]*:797/ window 10000,0
+1000.0 "Start" sync / 29:[^:]*:7DC:[^:]*:797:/ window 10000,0
 1006.4 "Tornadogenesis" sync / 1[56]:[^:]*:Ruby Princess:1F7F:/ window 20,20
 1013.5 "Tornadogenesis" #sync / 1[56]:[^:]*:Ruby Princess:1F7F:/
 1020.6 "Tornadogenesis" #sync / 1[56]:[^:]*:Ruby Princess:1F7F:/
@@ -119,7 +119,7 @@ hideall "--sync--"
 
 # Phase 1: 100% -> 90%, autos and mini busters
 # Shisui Gokagura will be sealed off
-2000.0 "Start" sync / 29:[^:]*:7DC:[^:]*:798/ window 10000,0
+2000.0 "Start" sync / 29:[^:]*:7DC:[^:]*:798:/ window 10000,0
 2006.5 "Foul Nail" sync / 1[56]:[^:]*:Shisui Yohi:1F87:/
 2013.6 "Foul Nail" sync / 1[56]:[^:]*:Shisui Yohi:1F87:/
 

--- a/ui/raidboss/data/04-sb/dungeon/sirensong_sea.txt
+++ b/ui/raidboss/data/04-sb/dungeon/sirensong_sea.txt
@@ -8,7 +8,7 @@ hideall "--sync--"
 # -ii 1F5A
 
 # Spae Rock will be sealed off
-0.0 "Start" sync / 29:[^:]*:7DC:[^:]*:7A9/ window 0,1
+0.0 "Start" sync / 29:[^:]*:7DC:[^:]*:7A9:/ window 0,1
 18.5 "Amorphous Applause" sync / 1[56]:[^:]*:Lugat:1F56:/
 29.6 "Hydroball" sync / 1[56]:[^:]*:Lugat:1F57:/
 
@@ -36,7 +36,7 @@ hideall "--sync--"
 # -ii 1F5D
 
 # Warden's Delight will be sealed off
-1000.0 "Start" sync / 29:[^:]*:7DC:[^:]*:7AB/ window 1000,5
+1000.0 "Start" sync / 29:[^:]*:7DC:[^:]*:7AB:/ window 1000,5
 1017.5 "Shadowflow" sync / 1[56]:[^:]*:The Governor:1F5E:/
 1018.0 "--sync--" sync / 1[56]:[^:]*:The Governor:1F5F:/
 1034.6 "Bloodburst" sync / 1[56]:[^:]*:The Governor:1F5C:/
@@ -70,7 +70,7 @@ hideall "--sync--"
 # -ii 1F63
 
 # Glowering Krautz will be sealed off
-2000.0 "Start" sync / 29:[^:]*:7DC:[^:]*:7AD/ window 2000,5
+2000.0 "Start" sync / 29:[^:]*:7DC:[^:]*:7AD:/ window 2000,5
 2011.5 "Virgin Tears" sync / 1[56]:[^:]*:Lorelei:1F69:/
 2024.7 "Morbid Advance/Morbid Retreat" sync / 1[56]:[^:]*:Lorelei:1F6[56]:/
 2033.9 "Head Butt" sync / 1[56]:[^:]*:Lorelei:1F64:/

--- a/ui/raidboss/data/04-sb/dungeon/st_mocianne_hard.txt
+++ b/ui/raidboss/data/04-sb/dungeon/st_mocianne_hard.txt
@@ -9,7 +9,7 @@ hideall "--sync--"
 # -ii 2E51 2E4C
 
 # Zymology will be sealed off
-0 "Start" sync / 29:[^:]*:7DC:[^:]*:68D/ window 0,1
+0 "Start" sync / 29:[^:]*:7DC:[^:]*:68D:/ window 0,1
 9.7 "Odious Air" sync / 1[56]:[^:]*:Nullchu:2E49:/ window 9.7,5
 21.8 "Vine Whip" sync / 1[56]:[^:]*:Nullchu:2E48:/
 33.9 "--sync--" sync / 1[56]:[^:]*:Nullchu:2E4D:/
@@ -53,7 +53,7 @@ hideall "--sync--"
 
 
 # The Soil Bed will be sealed off
-1000.0 "Start" sync / 29:[^:]*:7DC:[^:]*:AAA/ window 1000,5
+1000.0 "Start" sync / 29:[^:]*:7DC:[^:]*:AAA:/ window 1000,5
 1008.9 "Stone II" sync / 1[56]:[^:]*:Lakhamu:312A:/ window 1008.9,10
 1019.5 "Tectonics" sync / 1[56]:[^:]*:Lakhamu:312C:/
 1039.1 "Landslip" sync / 1[56]:[^:]*:Lakhamu:3132:/
@@ -114,7 +114,7 @@ hideall "--sync--"
 # -ii 3139 321C 33A0
 
 # Kingsloam will be sealed off
-2000.0 "Start" sync / 29:[^:]*:7DC:[^:]*:AAF/ window 2000,5
+2000.0 "Start" sync / 29:[^:]*:7DC:[^:]*:AAF:/ window 2000,5
 2008.6 "Mudsling" sync / 1[56]:[^:]*:Tokkapchi:3135:/
 2021.8 "Quickmire" sync / 1[56]:[^:]*:Tokkapchi:3136:/
 2028.8 "Quagmire" sync / 1[56]:[^:]*:Tokkapchi:3138:/

--- a/ui/raidboss/data/04-sb/dungeon/swallows_compass.txt
+++ b/ui/raidboss/data/04-sb/dungeon/swallows_compass.txt
@@ -10,7 +10,7 @@ hideall "--sync--"
 # -ii 2B99
 
 # The Heart of the Dragon will be sealed off
-0 "Start" sync / 29:[^:]*:7DC:[^:]*:98B/ window 0,1
+0 "Start" sync / 29:[^:]*:7DC:[^:]*:98B:/ window 0,1
 11.6 "Clout Of The Tengu" sync / 1[56]:[^:]*:Otengu:2B95:/
 22.5 "Yama-Kagura" sync / 1[56]:[^:]*:Otengu:2B96:/ window 22.5,5
 33.1 "Might Of The Tengu" sync / 1[56]:[^:]*:Otengu:2B94:/
@@ -41,7 +41,7 @@ hideall "--sync--"
 # -ii 2CD1 2B9B 2B9C 2B9F
 
 # The Dragon's Mouth will be sealed off
-1000.0 "Start" sync / 29:[^:]*:7DC:[^:]*:98E/ window 1000,1
+1000.0 "Start" sync / 29:[^:]*:7DC:[^:]*:98E:/ window 1000,1
 1011.2 "Greater Palm" sync / 1[56]:[^:]*:Daidarabotchi:2B9[DE]:/ window 11.2,5
 1023.1 "Greater Palm" sync / 1[56]:[^:]*:Daidarabotchi:2B9[DE]:/
 1035.3 "Tributary" sync / 1[56]:[^:]*:Daidarabotchi:2BA0:/ window 35,0
@@ -79,7 +79,7 @@ hideall "--sync--"
 # The opening block repeats without interrruption above 50% HP.
 # Note that Dasheng's abilities are not the same as those of the shadows!
 # Serenity will be sealed off
-2000.0 "Start" sync / 29:[^:]*:7DC:[^:]*:98F/ window 2000,5
+2000.0 "Start" sync / 29:[^:]*:7DC:[^:]*:98F:/ window 2000,5
 2011.8 "The Short End" sync / 1[56]:[^:]*:Qitian Dasheng:2BA6:/ window 11.8,5
 2025.5 "Both Ends" sync / 1[56]:[^:]*:Qitian Dasheng:2BA[89]:/
 2036.1 "Mount Huaguo" sync / 1[56]:[^:]*:Qitian Dasheng:2BAA:/ window 36.1,5

--- a/ui/raidboss/data/04-sb/dungeon/temple_of_the_fist.txt
+++ b/ui/raidboss/data/04-sb/dungeon/temple_of_the_fist.txt
@@ -5,7 +5,7 @@ hideall "--sync--"
 # -ii 1FD2 1FD8
 
 # Tourmaline Pond will be sealed off
-0.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:788/
+0.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:788:/
 6.4 "Pounce" sync / 1[56]:[^:]*:Coeurl Sruti:1FD1:/ window 7,7
 17.8 "Radial Blaster" sync / 1[56]:[^:]*:Coeurl Sruti:1FD3:/
 22.0 "Pounce" sync / 1[56]:[^:]*:Coeurl Sruti:1FD1:/
@@ -53,7 +53,7 @@ hideall "--sync--"
 # Arbuda
 
 # Harmony will be sealed off
-1000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:789/ window 1000,10
+1000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:789:/ window 1000,10
 1006.5 "Cardinal Shift" sync / 1[56]:[^:]*:Arbuda:1FDA:/ window 7,7
 1014.6 "Fourfold Shear" sync / 1[56]:[^:]*:Arbuda:1FD9:/
 1022.6 "Front/Back?Sides?" sync / 1[56]:[^:]*:Arbuda:1FD[BC]:/
@@ -92,7 +92,7 @@ hideall "--sync--"
 # -ii 1FF0 1FE8 1FEC
 
 # Guidance will be sealed off
-2000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:78A/ window 2000,10
+2000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:78A:/ window 2000,10
 2010.9 "Spirit Wave" sync / 1[56]:[^:]*:Ivon Coeurlfist:1FE7:/
 2018.6 "Hurricane Kick" sync / 1[56]:[^:]*:Ivon Coeurlfist:1FE5:/
 2026.7 "Touch of Slaughter" sync / 1[56]:[^:]*:Ivon Coeurlfist:1FE6:/

--- a/ui/raidboss/data/04-sb/dungeon/the_burn.txt
+++ b/ui/raidboss/data/04-sb/dungeon/the_burn.txt
@@ -10,7 +10,7 @@ hideall "--sync--"
 # -ii 3198 3199
 
 # The Scorpion's Den will be sealed off
-0 "Start" sync / 29:[^:]*:7DC:[^:]*:9B7/ window 0,1
+0 "Start" sync / 29:[^:]*:7DC:[^:]*:9B7:/ window 0,1
 10.4 "Crystal Needle" sync / 1[56]:[^:]*:Hedetet:3193:/
 25.8 "Hailfire" sync / 1[56]:[^:]*:Hedetet:3194:/ window 25,30
 29.8 "Resonant Frequency" sync / 1[56]:[^:]*:Dim Crystal:3198:/
@@ -40,7 +40,7 @@ hideall "--sync--"
 # -ii 2D76 2D77 34D5 34D6 34D9
 
 # The Gamma Segregate will be sealed off
-1000.0 "Start" sync / 29:[^:]*:7DC:[^:]*:9BA/ window 1000,5
+1000.0 "Start" sync / 29:[^:]*:7DC:[^:]*:9BA:/ window 1000,5
 1012.7 "Aetherochemical Flame" sync / 1[56]:[^:]*:Defective Drone:2D73:/
 1026.7 "Aetherochemical Residue" sync / 1[56]:[^:]*:Defective Drone:2D74:/
 1030.9 "--untargetable--"
@@ -69,7 +69,7 @@ hideall "--sync--"
 # -ii 3142 3145 3146 3149
 
 # The Aspersory will be sealed off
-2000.0 "Start" sync / 29:[^:]*:7DC:[^:]*:9BD/ window 2000,5
+2000.0 "Start" sync / 29:[^:]*:7DC:[^:]*:9BD:/ window 2000,5
 2013.2 "Rime Wreath" sync / 1[56]:[^:]*:Mist Dragon:314B:/
 2021.4 "Frost Breath" sync / 1[56]:[^:]*:Mist Dragon:314C:/
 2030.7 "Fog Plume" sync / 1[56]:[^:]*:Mist Dragon:3144:/

--- a/ui/raidboss/data/04-sb/dungeon/the_burn64.txt
+++ b/ui/raidboss/data/04-sb/dungeon/the_burn64.txt
@@ -10,7 +10,7 @@ hideall "--sync--"
 # -ii 3198 3199
 
 # The Scorpion's Den will be sealed off
-0 "Start" sync / 29:[^:]*:7DC:[^:]*:9B7/ window 0,1
+0 "Start" sync / 29:[^:]*:7DC:[^:]*:9B7:/ window 0,1
 10.4 "Crystal Needle" sync / 1[56]:[^:]*:Hedetet:3193:/
 25.8 "Hailfire" sync / 1[56]:[^:]*:Hedetet:3194:/ window 25,30
 29.8 "Resonant Frequency" sync / 1[56]:[^:]*:Dim Crystal:3198:/
@@ -40,7 +40,7 @@ hideall "--sync--"
 # -ii 2D76 2D77 34D5 34D6 34D9
 
 # The Gamma Segregate will be sealed off
-1000.0 "Start" sync / 29:[^:]*:7DC:[^:]*:9BA/ window 1000,5
+1000.0 "Start" sync / 29:[^:]*:7DC:[^:]*:9BA:/ window 1000,5
 1012.7 "Aetherochemical Flame" sync / 1[56]:[^:]*:Defective Drone:2D73:/
 1026.7 "Aetherochemical Residue" sync / 1[56]:[^:]*:Defective Drone:2D74:/
 1030.9 "--untargetable--"
@@ -69,7 +69,7 @@ hideall "--sync--"
 # -ii 3142 3145 3146 3149
 
 # The Aspersory will be sealed off
-2000.0 "Start" sync / 29:[^:]*:7DC:[^:]*:9BD/ window 2000,5
+2000.0 "Start" sync / 29:[^:]*:7DC:[^:]*:9BD:/ window 2000,5
 2013.2 "Rime Wreath" sync / 1[56]:[^:]*:Mist Dragon:314B:/
 2021.4 "Frost Breath" sync / 1[56]:[^:]*:Mist Dragon:314C:/
 2030.7 "Fog Plume" sync / 1[56]:[^:]*:Mist Dragon:3144:/

--- a/ui/raidboss/data/04-sb/eureka/eureka_hydatos.txt
+++ b/ui/raidboss/data/04-sb/eureka/eureka_hydatos.txt
@@ -113,7 +113,7 @@ hideall "--sync--"
 ##########
 # -ii 39B9 3994 3996 3995 3997 3872 3871 3873 -p 387A:3013 386D:3091
 # Shin-Zantetsuken Containment Unit will be sealed off
-3000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:B51/ window 3000,0
+3000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:B51:/ window 3000,0
 3013.0 "Spirits of the Fallen" sync / 1[56]:[^:]*:Raiden:387A:/ # drift -0.041
 3023.0 "Shingan" sync / 1[56]:[^:]*:Raiden:387B:/ # drift 0.05
 3034.1 "Thundercall" sync / 1[56]:[^:]*:Raiden:387F:/
@@ -174,7 +174,7 @@ hideall "--sync--"
 ###################
 # -p 3799:4016 -ii 38C4 378F 3791 3792 3954 378C
 # Lance of Virtue Containment Unit will be sealed off
-4000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:B52/ window 4000,0
+4000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:B52:/ window 4000,0
 4016.0 "Meteor" sync / 1[56]:[^:]*:Absolute Virtue:3799:/
 4022.0 "Eidos" sync / 1[56]:[^:]*:Absolute Virtue:378[67]:/
 4033.6 "Hostile Aspect" sync / 1[56]:[^:]*:Absolute Virtue:378B:/
@@ -250,7 +250,7 @@ hideall "--sync--"
 ##############
 # -ii 37AB 37B8 37A2 37AC 396E 397B 397C -p 37B2:5021.5
 # Proto Ozma Containment Unit will be sealed off
-5000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:B53/ window 5000,0
+5000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:B53:/ window 5000,0
 
 ### Initial Star Form (no meteor)
 5021.5 "Star Form" sync / 1[56]:[^:]*:Proto Ozma:37B2:/

--- a/ui/raidboss/data/05-shb/alliance/the_copied_factory.txt
+++ b/ui/raidboss/data/05-shb/alliance/the_copied_factory.txt
@@ -7,7 +7,7 @@ hideall "--sync--"
 # -ic 2P -p 48B2:108.5 -ii 4B31 48B3 48B4 48B7 48B6 48CB 48CC 48BA 4B32 48FA 48BC 48BD 48BE 48BF 48C0 48C1 48C2 48C9
 
 # Warehouse A will be sealed off
-100.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:D4C/ window 100,0
+100.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:D4C:/ window 100,0
 108.5 "Systematic Siege" sync / 1[56]:[^:]*:Serial-jointed Command Model:48B2:/ window 108.5,10
 122.6 "Clanging Blow" sync / 1[56]:[^:]*:Serial-jointed Command Model:48CE:/
 134.1 "Energy Bombardment" sync / 1[56]:[^:]*:Serial-jointed Command Model:48B8:/
@@ -57,7 +57,7 @@ hideall "--sync--"
 ### Trash
 # -ic 2P -ii 491D 491C -p 491B:715.5
 # Warehouse B will be sealed off
-600.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:D4D/ window 600,0
+600.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:D4D:/ window 600,0
 700.0 "--sync--" sync / 22:........:Small Flyer:........:Small Flyer:01/ window 100,0
 715.5 "Frontal Somersault" sync / 1[56]:[^:]*:Small Biped:491B:/ window 116,2.5
 721.4 "Frontal Somersault" sync / 1[56]:[^:]*:Small Biped:491B:/
@@ -111,7 +111,7 @@ hideall "--sync--"
 # branch out to six timelines again for the second half, but it'd be, well, a lot.
 
 # Quality Assurance will be sealed off
-900.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:D4E/ window 900,0
+900.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:D4E:/ window 900,0
 913.0 "Laser-Resistance Test x3" sync / 1[56]:[^:]*:Hobbes:4805:/ duration 2.3 window 913,10
 
 924.5 "--sync--" sync / 1[56]:[^:]*:Hobbes:480A:/
@@ -199,7 +199,7 @@ hideall "--sync--"
 ### Goliath Tank
 # -ic 2P -p 4932:1509 493D:1800 -ii 4937 4934 4938 4935 4939 4936 493A 4933 470D 4943 493E
 # Warehouse C will be sealed off
-1500.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:D50/ window 1500,0
+1500.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:D50:/ window 1500,0
 1509.0 "Energy Ring" sync / 1[56]:[^:]*:Goliath Tank:4932:/ duration 15.1 window 1509,10
 1516.9 "Exploding Tethers"
 1526.0 "Convenient Self-Destruction" sync / 1[56]:[^:]*:Medium Exploder:493C:/
@@ -234,7 +234,7 @@ hideall "--sync--"
 # One log has 472[6,7,7,A] as the four.  Left as all random for now.
 
 # Forward Deck will be sealed off
-2000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:D52/ window 2000,0
+2000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:D52:/ window 2000,0
 2015.7 "Marx Smash L/R" sync / 1[56]:[^:]*:Engels:472[67]:/ window 2015.7,5
 2029.6 "Marx Smash R/L" sync / 1[56]:[^:]*:Engels:472[67]:/
 2044.4 "Precision Guided Missile" sync / 1[56]:[^:]*:Engels:4754:/
@@ -327,7 +327,7 @@ hideall "--sync--"
 ### 9S
 # -ic 2P -p 48F5:3013.3 48E7:3310 48EB:3510 -ii 49C4 48F9 48F7 48DC 485E 48E3 48E6 48E0 48EC 48A5 48A7 48D6 4ABE
 # Rear Deck will be sealed off
-3000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:D53/ window 3000,0
+3000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:D53:/ window 3000,0
 3013.3 "Neutralization" sync / 1[56]:[^:]*:9S-Operated Walking Fortress:48F5:/ window 3013.3,10
 3021.5 "Laser Saturation" sync / 1[56]:[^:]*:9S-Operated Walking Fortress:48F6:/
 3030.2 "Laser Turret" sync / 1[56]:[^:]*:9S-Operated Walking Fortress:4A74:/

--- a/ui/raidboss/data/05-shb/alliance/the_puppets_bunker.txt
+++ b/ui/raidboss/data/05-shb/alliance/the_puppets_bunker.txt
@@ -7,7 +7,7 @@ hideall "--sync--"
 # -p 508D:112.8 -ii 5074 5075 5076 5091 5092 5081 5099 507E 5090 51BC
 
 # Elevated Detritus will be sealed off
-100.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:DB0/ window 100,0
+100.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:DB0:/ window 100,0
 112.8 "Firing Order: Anti-Personnel Laser" sync / 1[56]:[^:]*:813P-Operated Aegis Unit:508D:/ window 112.8,20
 125.1 "--sync--" sync / 1[56]:[^:]*:813P-Operated Aegis Unit:507[789A]:/
 140.1 "Maneuver: Beam Cannons" sync / 1[56]:[^:]*:813P-Operated Aegis Unit:5073:/
@@ -105,7 +105,7 @@ hideall "--sync--"
 # -ic "Yorha Close-Combat Unit: Spear" "Yorha Close-Combat Unit: Blade" "Yorha Close-Combat Unit: Martial"
 # -p 5212:1013.9 -ii 5214
 # Sunken Detritus will be sealed off
-1000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:DB1/ window 1000,0
+1000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:DB1:/ window 1000,0
 1013.9 "Maneuver: Long-Barreled Laser" sync / 1[56]:[^:]*:Light Artillery Unit:5212:/ window 1013.9,20
 1025.7 "Maneuver: Volt Array" sync / 1[56]:[^:]*:Light Artillery Unit:5211:/
 1036.0 "Authorization: No Restrictions" sync / 1[56]:[^:]*:Light Artillery Unit:520E:/
@@ -139,7 +139,7 @@ hideall "--sync--"
 # * however, syncing against multiple planes simultaneously might cause timeline jitter
 
 # Launch Deck will be sealed off
-2000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:DB2/ window 2000,0
+2000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:DB2:/ window 2000,0
 2005.1 "Apply Shield Protocol" sync / 1[56]:[^:]*:724P-Operated Superior Flight Unit \(A-Lpha\):4FA6:/ window 2005.1,20
 2018.3 "Maneuver: Missile Command" sync / 1[56]:[^:]*:724P-Operated Superior Flight Unit \(A-Lpha\):4FBD:/
 2031.5 "Maneuver: Incendiary Bombing" sync / 1[56]:[^:]*:724P-Operated Superior Flight Unit \(A-Lpha\):4FC3:/
@@ -224,7 +224,7 @@ hideall "--sync--"
 # -p 5006:3012.1 -ii 4FF6 4FF7 4FF8 4FF9 4FFC 5004 4FFA 4FFF 4FFE 5002
 
 # Core Command will be sealed off
-3000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:DB3/ window 3000,0
+3000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:DB3:/ window 3000,0
 3012.1 "Maneuver: Volt Array" sync / 1[56]:[^:]*:905P-Operated Heavy Artillery Unit:5006:/ window 3012.1,20
 3024.5 "Operation: Activate Laser Turret" sync / 1[56]:[^:]*:905P-Operated Heavy Artillery Unit:4FED:/
 3028.2 "Lower Laser" sync / 1[56]:[^:]*:905P-Operated Heavy Artillery Unit:5086:/ duration 3.5
@@ -300,7 +300,7 @@ hideall "--sync--"
 
 ### Heavy Artillery Unit: caster-friendly hallway section
 # Passage will be sealed off
-4000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:DB4/ window 4000,0
+4000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:DB4:/ window 4000,0
 
 
 ### The Compound
@@ -310,7 +310,7 @@ hideall "--sync--"
 # * Can't use "The Bridge" area sync due to checkpoint with Compound 2P.
 
 # The bridge will be sealed off
-#5000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:DB5/ window 5000,0
+#5000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:DB5:/ window 5000,0
 5002.0 "--sync--" sync / 1[56]:[^:]*:The Compound:53CA:/ window 5002,0
 5013.2 "Mechanical Laceration" sync / 1[56]:[^:]*:The Compound:51B8:/ window 6000,20
 5024.4 "Mechanical Decapitation/Dissection" sync / 1[56]:[^:]*:The Compound:51B[34]:/

--- a/ui/raidboss/data/05-shb/alliance/the_tower_at_paradigms_breach.txt
+++ b/ui/raidboss/data/05-shb/alliance/the_tower_at_paradigms_breach.txt
@@ -16,7 +16,7 @@ hideall "--sync--"
 # So, give up, and add extra syncs on abilities after.
 
 # Closed Area A will be sealed off
-1000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:E46/ window 10000,0
+1000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:E46:/ window 10000,0
 1012.0 "Roar" sync / 1[56]:[^:]*:Knave Of Hearts:5EB5:/ window 1012,10
 1022.1 "Colossal Impact" sync / 1[56]:[^:]*:Knave Of Hearts:5EA7:/
 1033.2 "Colossal Impact" sync / 1[56]:[^:]*:Knave Of Hearts:5EA4:/
@@ -98,7 +98,7 @@ hideall "--sync--"
 # -it "Hansel"
 
 # Staging Node B will be sealed off
-2000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:E49/ window 2000,0
+2000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:E49:/ window 2000,0
 2012.0 "Upgraded Shield" sync / 1[56]:[^:]*:Gretel:5C6[89]:/ window 2012,10
 2012.0 "Upgraded Lance" sync / 1[56]:[^:]*:Hansel:5C6[AB]:/ window 2012,10
 2025.2 "Wail" sync / 1[56]:[^:]*:Hansel:5C77:/
@@ -229,7 +229,7 @@ hideall "--sync--"
 # -ii 5BFD 5BF7 5BF8 592A
 # -p 5BFE:3513.1
 # Staging Node C will be sealed off
-3000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:E4A/ window 10000,0
+3000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:E4A:/ window 10000,0
 
 # A bunch of 2P doing 5FB7/5BF8 blade flurry, but hard to sync this.
 # Presumably once they die, then flight units show up.
@@ -263,7 +263,7 @@ hideall "--sync--"
 
 # Phase 1
 # Staging Node D will be sealed off
-4000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:E4B/ window 4000,0
+4000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:E4B:/ window 4000,0
 4009.0 "--sync--" sync / 14:[^:]*:Red Girl:6012:/ window 4009,10
 4014.0 "Cruelty" sync / 1[56]:[^:]*:Red Girl:6012:/
 4019.9 "Shockwave" sync / 1[56]:[^:]*:Red Girl:600E:/
@@ -362,7 +362,7 @@ hideall "--sync--"
 # -p 5C00:5013.3
 # -ii 5CEC 5CED 5CEE 5C02 5C05 5C07 5C08
 # Ascension Platform will be sealed off
-5000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:E4C/ window 5000,0
+5000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:E4C:/ window 5000,0
 5013.3 "Deploy Armaments" sync / 1[56]:[^:]*:Xun-Zi:5C0[03]:/ window 5013.3,7
 5023.4 "Deploy Armaments" sync / 1[56]:[^:]*:Xun-Zi:5C0[03]:/
 5036.4 "Universal Assault" sync / 1[56]:[^:]*:Xun-Zi:5C06:/
@@ -402,7 +402,7 @@ hideall "--sync--"
 # -p 5BDD:6012.3
 # -ii 5CEC 5CED 5CEE 5CEF 5FFC 5FFF 5BDA 5BDC
 # Beyond will be sealed off
-6000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:E4D/ window 6000,0
+6000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:E4D:/ window 6000,0
 6007.3 "--sync--" sync / 14:[^:]*:False Idol:5BDD:/ window 6007.3,10
 6012.3 "Screaming Score" sync / 1[56]:[^:]*:False Idol:5BDD:/
 6025.5 "Made Magic" sync / 1[56]:[^:]*:False Idol:5BD[67]:/

--- a/ui/raidboss/data/05-shb/dungeon/akadaemia_anyder.txt
+++ b/ui/raidboss/data/05-shb/dungeon/akadaemia_anyder.txt
@@ -11,7 +11,7 @@ hideall "--sync--"
 # This is maybe like +/- 1-2 seconds?
 
 # Ichthyology will be sealed off
-100.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:BC0/ window 100,0
+100.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:BC0:/ window 100,0
 110.5 "Protolithic Puncture" sync / 1[56]:[^:]*:Cladoselache:3E04:/ window 111,8
 119.5 "Tidal Guillotine" sync / 1[56]:[^:]*:Cladoselache:3E08:/
 128.7 "--2x targetable--" sync / 22:........:Doliodus:........:Doliodus:01/
@@ -57,7 +57,7 @@ hideall "--sync--"
 ### Morbol Marquis
 # -p 3E16:508.5 -ii 3E11 3E14
 # Phytobiology will be sealed off
-500.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:BC1/ window 500,0
+500.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:BC1:/ window 500,0
 505.0 "--sync--" sync / 1[56]:[^:]*:Morbol Marquis:3E14:/ window 505,5
 508.5 "Lash" sync / 1[56]:[^:]*:Morbol Marquis:3E16:/
 516.1 "Sap Shower" sync / 1[56]:[^:]*:Morbol Marquis:3E15:/
@@ -108,7 +108,7 @@ hideall "--sync--"
 ### Quetzalcoatl
 # -ii 3E1A 3E1B 3E22 3E20 -p 3E23:1008.2
 # Phantomology will be sealed off
-1000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:BC2/ window 1000,0
+1000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:BC2:/ window 1000,0
 1008.2 "Shockbolt" sync / 1[56]:[^:]*:Quetzalcoatl:3E23:/ window 1010,5
 1017.9 "Thunderbolt" sync / 1[56]:[^:]*:Quetzalcoatl:3E24:/
 1031.4 "Thunderstorm" sync / 1[56]:[^:]*:Quetzalcoatl:3E1C:/

--- a/ui/raidboss/data/05-shb/dungeon/amaurot.txt
+++ b/ui/raidboss/data/05-shb/dungeon/amaurot.txt
@@ -7,7 +7,7 @@ hideall "--sync--"
 # -p 3CCE:113.5 -ii 3CC6 3CCA 3CC8
 
 # The First Doom will be sealed off
-100.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:C8B/ window 100,0
+100.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:C8B:/ window 100,0
 113.5 "Venomous Breath" sync / 1[56]:[^:]*:The First Beast:3CCE:/ window 114,9
 122.7 "Meteor Rain" sync / 1[56]:[^:]*:The First Beast:3CC4:/
 132.9 "The Falling Sky" sync / 1[56]:[^:]*:The First Beast:3CC9:/
@@ -38,7 +38,7 @@ hideall "--sync--"
 ### Terminus Bellwether
 # -p 3CCF:523 -ii 465D 3CE4 3CD3 3CD2 3CD5 417D
 # The Second Doom will be sealed off
-500.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:C8C/ window 500,0
+500.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:C8C:/ window 500,0
 523.0 "Shrill Shriek" sync / 1[56]:[^:]*:Terminus Bellwether:3CCF:/ window 523,5
 525.0 "--untargetable--"
 525.0 "Adds (N)"
@@ -51,7 +51,7 @@ hideall "--sync--"
 ### Therion
 # -ii 3CD6 3CDD 3CD9 3CDE 3CE1 3CDB 4191 4192 -p 3CE3:1013
 # The Third Doom will be sealed off
-1000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:C8D/ window 1000,0
+1000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:C8D:/ window 1000,0
 1013.0 "Shadow Wreck" sync / 1[56]:[^:]*:Therion:3CE3:/ window 1013,10
 1026.2 "Apokalypsis" sync / 1[56]:[^:]*:Therion:3CD7:/ duration 5.9
 1042.8 "Therion Charge" sync / 1[56]:[^:]*:Therion:3CDA:/

--- a/ui/raidboss/data/05-shb/dungeon/anamnesis_anyder.txt
+++ b/ui/raidboss/data/05-shb/dungeon/anamnesis_anyder.txt
@@ -7,7 +7,7 @@ hideall "--sync--"
 # -p 4B69:1013.5 4E4B:1313
 # -ii 4B78 4B6D 4B6F
 # Katharsis will be sealed off
-1000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:D86/ window 1000,0
+1000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:D86:/ window 1000,0
 1013.5 "Fetid Fang" sync / 1[56]:[^:]*:Unknown:4B69:/ window 1014,10
 1032.3 "Scrutiny" sync / 1[56]:[^:]*:Unknown:4E25:/
 1034.3 "Explosion" sync / 1[56]:[^:]*:Sinister Bubble:4B6E:/
@@ -65,7 +65,7 @@ hideall "--sync--"
 # -p 4B58:2011
 # -ii 4B53 4B5C 4B5B
 # Doxa will be sealed off
-2000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:D87/ window 2000,0
+2000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:D87:/ window 2000,0
 2011.0 "The Final Verse" sync / 1[56]:[^:]*:Kyklops:4B58:/ window 2012,5
 2020.6 "Swing/Swipe/Cyclone" sync / 1[56]:[^:]*:Kyklops:4B5[457]:/
 2030.9 "Hammer/Blade Mark" sync / 1[56]:[^:]*:Kyklops:4B5[9A]:/
@@ -97,7 +97,7 @@ hideall "--sync--"
 # -p 4B8C:3013
 # -ii 4B7C 4B7E 4B8A 4B86 4B85 4B80 4B82 4B87
 # Noesis will be sealed off
-3000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:D89/ window 3000,0
+3000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:D89:/ window 3000,0
 3013.0 "Bonebreaker" sync / 1[56]:[^:]*:Rukshs Dheem:4B8C:/ window 3013,10
 3019.2 "Swift Shift" sync / 1[56]:[^:]*:Rukshs Dheem:4B83:/
 3026.5 "Seabed Ceremony" sync / 1[56]:[^:]*:Rukshs Dheem:4B7B:/

--- a/ui/raidboss/data/05-shb/dungeon/dohn_mheg.txt
+++ b/ui/raidboss/data/05-shb/dungeon/dohn_mheg.txt
@@ -6,7 +6,7 @@ hideall "--sync--"
 ### Aenc Thon, Lord of the Lingering Gaze
 # -ii 1EDB 22BD -p 2299:112.2
 # Teag Gye will be sealed off
-100.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:B93/ window 100,0
+100.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:B93:/ window 100,0
 
 112.2 "Candy Cane" sync / 1[56]:[^:]*:Aenc Thon, Lord of the Lingering Gaze:2299:/ window 113,5
 120.4 "Hydrofall" sync / 1[56]:[^:]*:Aenc Thon, Lord of the Lingering Gaze:22A7:/
@@ -35,7 +35,7 @@ hideall "--sync--"
 ### Griaule
 # -p 2873:507.5
 # The Atelier will be sealed off
-500.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:B96/ window 500,0
+500.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:B96:/ window 500,0
 
 507.5 "Rake" sync / 1[56]:[^:]*:Griaule:2873:/ window 508,5
 518.0 "Swinge" sync / 1[56]:[^:]*:Griaule:22CA:/
@@ -76,7 +76,7 @@ hideall "--sync--"
 ### Aenc Thon, Lord of the Lengthsome Gate
 # -p 35A4:1011 34D2:1300 -ii 34EC 3681 3396
 # The Throne Room will be sealed off
-1000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:B98/ window 1000,0
+1000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:B98:/ window 1000,0
 
 1011.0 "Crippling Blow" sync / 1[56]:[^:]*:Aenc Thon, Lord of the Lengthsome Gait:35A4:/ window 1011,5
 1018.2 "Virtuosic Capriccio" sync / 1[56]:[^:]*:Aenc Thon, Lord of the Lengthsome Gait:358C:/

--- a/ui/raidboss/data/05-shb/dungeon/heroes_gauntlet.txt
+++ b/ui/raidboss/data/05-shb/dungeon/heroes_gauntlet.txt
@@ -10,7 +10,7 @@ hideall "--sync--"
 # -ii 4FCD 4FCE 4FCF 4FD0 4FD5 5015
 
 # Mount Argai Mines will be sealed off
-0 "Start" sync / 29:[^:]*:7DC:[^:]*:DBB/ window 0,1
+0 "Start" sync / 29:[^:]*:7DC:[^:]*:DBB:/ window 0,1
 9.8 "Spectral Dream" sync / 1[56]:[^:]*:Spectral Thief:4FCB:/ window 9.8,5
 16.9 "Dash" sync / 1[56]:[^:]*:Spectral Thief:4FD3:/
 26.7 "Vacuum Blade" sync / 1[56]:[^:]*:Spectral Thief:506[12]:/
@@ -53,7 +53,7 @@ hideall "--sync--"
 # -ii 4F51 4F62 4F64 53B5 53B6 53B7 53B8 53B9 53BA
 
 # Summer Ballroom will be sealed off
-1000.0 "Start" sync / 29:[^:]*:7DC:[^:]*:DBC/ window 1000,5
+1000.0 "Start" sync / 29:[^:]*:7DC:[^:]*:DBC:/ window 1000,5
 1012.8 "Absolute Dark II" sync / 1[56]:[^:]*:Spectral Necromancer:4F61:/ window 1012.8,5
 1020.0 "Necromancy" sync / 1[56]:[^:]*:Spectral Necromancer:4F57:/
 1030.2 "Twisted Touch" sync / 1[56]:[^:]*:Spectral Necromancer:4F5E:/ window 30,30
@@ -98,7 +98,7 @@ hideall "--sync--"
 # -ic "Steelarm Cerigg" "Giott The Aleforged" "Lue-Reeq Of The Gilded Bow" "Granson Of The Mournful Blade"
 
 # Illuminated Plaza will be sealed off
-2000.0 "Start" sync / 29:[^:]*:7DC:[^:]*:DBD/ window 2000,5
+2000.0 "Start" sync / 29:[^:]*:7DC:[^:]*:DBD:/ window 2000,5
 2012.0 "Beastly Fury" sync / 1[56]:[^:]*:Spectral Berserker:520C:/ window 2012,5
 2024.4 "Wild Anguish" sync / 1[56]:[^:]*:Spectral Berserker:5208:/
 2036.3 "Raging Slice" sync / 1[56]:[^:]*:Spectral Berserker:520A:/

--- a/ui/raidboss/data/05-shb/dungeon/holminster_switch.txt
+++ b/ui/raidboss/data/05-shb/dungeon/holminster_switch.txt
@@ -6,7 +6,7 @@ hideall "--sync--"
 ### Forgiven Dissonance
 # -p 3DC5:112
 # The Wound will be sealed off
-100.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:CD4/ window 100,0
+100.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:CD4:/ window 100,0
 112.0 "The Path Of Light" sync / 1[56]:[^:]*:Forgiven Dissonance:3DC5:/ window 112,0
 120.4 "Brazen Bull" sync / 1[56]:[^:]*:Forgiven Dissonance:3DC9:/
 126.5 "Gibbet Cage" sync / 1[56]:[^:]*:Forgiven Dissonance:3DC8:/
@@ -48,7 +48,7 @@ hideall "--sync--"
 ### Tesleen, the Forgiven
 # -ii 3DD6 3DD3 -p 3DCF:513.5
 # The Auction will be sealed off
-500.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:CD5/ window 500,0
+500.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:CD5:/ window 500,0
 513.5 "The Tickler" sync / 1[56]:[^:]*:Tesleen, the Forgiven:3DCF:/ window 514,5
 523.6 "Scold's Bridle" sync / 1[56]:[^:]*:Tesleen, the Forgiven:3DD0:/
 533.8 "Fevered Flagellation" sync / 1[56]:[^:]*:Tesleen, the Forgiven:3DD5:/
@@ -79,7 +79,7 @@ hideall "--sync--"
 ### Philia
 # -ii 3DDD 3DDF 3DDE 3DDC 3DDB 3DE1 3DE0 3DE9 4196 3DE5 4181 -p 3DD8:1012.5
 # The Manor House Courtyard will be sealed off
-1000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:CD7/ window 1000,0
+1000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:CD7:/ window 1000,0
 1012.5 "Scavenger's Daughter" sync / 1[56]:[^:]*:Philia:3DD8:/ window 1012.5,10
 1022.8 "Head Crusher" sync / 1[56]:[^:]*:Philia:3DD7:/
 1032.9 "Pendulum Tank" sync / 1[56]:[^:]*:Philia:4189:/

--- a/ui/raidboss/data/05-shb/dungeon/malikahs_well.txt
+++ b/ui/raidboss/data/05-shb/dungeon/malikahs_well.txt
@@ -6,7 +6,7 @@ hideall "--sync--"
 ### Greater Armadillo
 # -ii 3CEA 3CE8 -p 3CE5:115
 # Terminus will be sealed off
-100.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:BD5/ window 100,0
+100.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:BD5:/ window 100,0
 
 115.0 "Stone Flail" sync / 1[56]:[^:]*:Greater Armadillo:3CE5:/ window 115,5
 133.6 "Head Toss" sync / 1[56]:[^:]*:Greater Armadillo:3CE6:/
@@ -44,7 +44,7 @@ hideall "--sync--"
 ### Amphibious Talos
 # -ii 3CF0 -p 3CEB:515.5
 # Malikah's Gift will be sealed off
-500.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:BD6/ window 500,0
+500.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:BD6:/ window 500,0
 515.5 "Efface" sync / 1[56]:[^:]*:Amphibious Talos:3CEB:/ window 515.5,10
 527.1 "Wellbore" sync / 1[56]:[^:]*:Amphibious Talos:3CED:/
 531.3 "Geyser Eruption" sync / 1[56]:[^:]*:Amphibious Talos:3CEE:/
@@ -71,7 +71,7 @@ hideall "--sync--"
 ### Storge
 # -ii 3CF7 3CA8 41A8 -p 3CF1:1015
 # Unquestioned Acceptance will be sealed off
-1000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:BD7/ window 1000,0
+1000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:BD7:/ window 1000,0
 1015.0 "Intestinal Crank" sync / 1[56]:[^:]*:Storge:3CF1:/ window 1015,5
 1028.2 "Heretic's Fork" sync / 1[56]:[^:]*:Storge:3CF2:/
 1043.0 "Breaking Wheel" sync / 1[56]:[^:]*:Storge:3CF5:/

--- a/ui/raidboss/data/05-shb/dungeon/matoyas_relict.txt
+++ b/ui/raidboss/data/05-shb/dungeon/matoyas_relict.txt
@@ -7,7 +7,7 @@ hideall "--sync--"
 # -p 547F:1011
 # -ii 368 5481 5487 548E 548F 5490 5492
 # Clayclot Cauldron will be sealed off
-1000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:E02/ window 1000,0
+1000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:E02:/ window 1000,0
 # Loop 3 times
 1011.0 "Hard Rock" sync / 1[56]:[^:]*:Mudman:547F:/ window 1012,10
 1020.2 "Petrified Peat" sync / 1[56]:[^:]*:Mudman:5480:/
@@ -47,7 +47,7 @@ hideall "--sync--"
 # -p 598F:2009.2
 # -ii 598E 5990 5992 5993 5994 5995 5996 5BB9
 # Clearnote Cauldron will be sealed off
-2000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:E03/ window 2000,0
+2000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:E03:/ window 2000,0
 
 2009.2 "Crash-Smash" sync / 1[56]:[^:]*:Nixie:598F:/ window 2010,10
 2023.4 "Shower Power" sync / 1[56]:[^:]*:Nixie:5991:/
@@ -71,7 +71,7 @@ hideall "--sync--"
 # -p 5913:3010.0
 # -ii 4A8F 5912 5914 5917 5918 591E 591F 5923 5925
 # Woebegone Workshop will be sealed off
-3000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:E05/ window 3000,0
+3000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:E05:/ window 3000,0
 
 3011.3 "Tender Loin" sync / 1[56]:[^:]*:Mother Porxie:5913:/ window 3012,10
 3029.5 "Huff And Puff" sync / 1[56]:[^:]*:Mother Porxie:5919:/

--- a/ui/raidboss/data/05-shb/dungeon/mt_gulg.txt
+++ b/ui/raidboss/data/05-shb/dungeon/mt_gulg.txt
@@ -9,7 +9,7 @@ hideall "Rite Of The Sacrament"
 ### Forgiven Cruelty
 # -p 3CFB:113 -ii 3CFE 3CFD 4301 3CFF
 # The Perished Path will be sealed off
-100.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:BB6/ window 100,0
+100.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:BB6:/ window 100,0
 113.0 "Rake" sync / 1[56]:[^:]*:Forgiven Cruelty:3CFB:/ window 115,5
 121.2 "Lumen Infinitum" sync / 1[56]:[^:]*:Forgiven Cruelty:41B2:/
 138.3 "Typhoon Wing" sync / 1[56]:[^:]*:Forgiven Cruelty:3D00:/
@@ -46,7 +46,7 @@ hideall "Rite Of The Sacrament"
 ### Forgiven Whimsy
 # -p 3D0B:514.5 -ii 3D0C 3D07 3D0A
 # The White Gate will be sealed off
-500.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:BB7/ window 500,0
+500.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:BB7:/ window 500,0
 514.5 "Sacrament Of Penance" sync / 1[56]:[^:]*:Forgiven Whimsy:3D0B:/ window 515,5
 518.3 "Reformation" sync / 1[56]:[^:]*:Forgiven Whimsy:3D04:/
 530.4 "Exegesis" sync / 1[56]:[^:]*:Forgiven Whimsy:425C:/
@@ -83,7 +83,7 @@ hideall "Rite Of The Sacrament"
 ### Forgiven Obscenity
 # -ii 3D15 4669 3D19 3D19 3D21 3D13 41CE 3D1B 3D20 -p 3D14:1014
 # The Winding Flare will be sealed off
-1000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:BB8/ window 1000,0
+1000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:BB8:/ window 1000,0
 1014.0 "Orison Fortissimo" sync / 1[56]:[^:]*:Forgiven Obscenity:3D14:/ window 1014,5
 1023.2 "Divine Diminuendo" sync / 1[56]:[^:]*:Forgiven Obscenity:3D16:/
 1032.4 "--sync--" sync / 1[56]:[^:]*:Forgiven Obscenity:3D17:/

--- a/ui/raidboss/data/05-shb/dungeon/paglthan.txt
+++ b/ui/raidboss/data/05-shb/dungeon/paglthan.txt
@@ -10,7 +10,7 @@ hideall "--sync--"
 # -ii 5C52 5C53
 
 # Gathering Ring will be sealed off
-0 "Start" sync / 29:[^:]*:7DC:[^:]*:B7B/ window 0,1
+0 "Start" sync / 29:[^:]*:7DC:[^:]*:B7B:/ window 0,1
 12.6 "Critical Rip" sync / 1[56]:[^:]*:Amhuluk:5C4E:/ window 12.6,10
 18.8 "--sync--" sync / 1[56]:[^:]*:Amhuluk:5C51:/
 30.2 "Lightning Bolt" sync / 1[56]:[^:]*:Amhuluk:5C4B:/
@@ -51,7 +51,7 @@ hideall "--sync--"
 # -ii 5B56 5B50
 
 # Sunseat will be sealed off
-2000.0 "Start" sync / 29:[^:]*:7DC:[^:]*:B7D/ window 2000,5
+2000.0 "Start" sync / 29:[^:]*:7DC:[^:]*:B7D:/ window 2000,5
 2010.0 "Twisted Scream" sync / 1[56]:[^:]*:Lunar Bahamut:5B47:/ window 2010,10
 2015.0 "Upburst x4" # sync / 1[56]:[^:]*:Lunar Nail:605B:/
 2021.6 "Big Burst x4" # sync / 1[56]:[^:]*:Lunar Nail:5B48:/

--- a/ui/raidboss/data/05-shb/dungeon/qitana_ravel.txt
+++ b/ui/raidboss/data/05-shb/dungeon/qitana_ravel.txt
@@ -6,7 +6,7 @@ hideall "--sync--"
 ### Lozatl
 # -p 3C89:113.7
 # The Divine Threshold will be sealed off
-100.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:BCC/ window 100,0
+100.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:BCC:/ window 100,0
 
 113.7 "Stonefist" sync / 1[56]:[^:]*:Lozatl:3C89:/ window 114,5
 121.0 "Sun Toss" sync / 1[56]:[^:]*:Lozatl:3C8A:/
@@ -44,7 +44,7 @@ hideall "--sync--"
 ### Batsquatch
 # -ii 3C94 3C96 3C97 3C95 -p 3C91:514.5
 # Shadowed Hollow will be sealed off
-500.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:BCF/ window 500,0
+500.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:BCF:/ window 500,0
 
 514.5 "Ripper Fang" sync / 1[56]:[^:]*:Batsquatch:3C91:/ window 515,5
 525.7 "Soundwave" sync / 1[56]:[^:]*:Batsquatch:3C92:/
@@ -76,7 +76,7 @@ hideall "--sync--"
 ### Eros
 #
 # The Song of Ox'Gatorl will be sealed off
-1000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:BD2/ window 1000,0
+1000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:BD2:/ window 1000,0
 
 1015.0 "Rend" sync / 1[56]:[^:]*:Eros:3C99:/ window 1015,5
 1026.2 "Hound Out Of Heaven" sync / 1[56]:[^:]*:Eros:3C9A:/

--- a/ui/raidboss/data/05-shb/dungeon/the_grand_cosmos.txt
+++ b/ui/raidboss/data/05-shb/dungeon/the_grand_cosmos.txt
@@ -6,7 +6,7 @@ hideall "--sync--"
 ### Seeker of Solitude
 # -ii 4768 49A4 476C 476F 4771 4770 -p 4769:111.7
 # The Martial Court will be sealed off
-100.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:D2F/ window 100,0
+100.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:D2F:/ window 100,0
 111.7 "Shadowbolt" sync / 1[56]:[^:]*:Seeker of Solitude:4769:/ window 112,5
 119.4 "Immortal Anathema" sync / 1[56]:[^:]*:Seeker of Solitude:49A3:/
 
@@ -38,7 +38,7 @@ hideall "--sync--"
 ### Leannan Sith
 # -ii 4724 471F -p 471B:512
 # The Font of Quintessence will be sealed off
-500.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:D30/ window 500,0 
+500.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:D30:/ window 500,0 
 512.0 "Storm Of Color" sync / 1[56]:[^:]*:Leannan Sith:471B:/ window 512,10
 522.3 "Ode To Lost Love" sync / 1[56]:[^:]*:Leannan Sith:471C:/
 
@@ -81,7 +81,7 @@ hideall "--sync--"
 ### Lugus
 # -ii 475B 4766 475A 475E -p 475D:1026.8
 # The Chamber of Celestial Song will be sealed off
-1000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:D31/ window 1000,0
+1000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:D31:/ window 1000,0
 1015.3 "Scorching Left/Right" sync / 1[56]:[^:]*:Lugus:476[23]:/ window 1015.3,10
 1026.8 "Black Flame" sync / 1[56]:[^:]*:Lugus:475D:/
 1030.3 "Otherworldly Heat" sync / 1[56]:[^:]*:Lugus:475C:/

--- a/ui/raidboss/data/05-shb/dungeon/twinning.txt
+++ b/ui/raidboss/data/05-shb/dungeon/twinning.txt
@@ -6,7 +6,7 @@ hideall "--sync--"
 ### Alpha Zaghnal
 # -p 3D65:108.5 -ii 3D66 3D67 3D68 3D69 3D6A 41CA 3D6C
 # Repurposing will be sealed off
-100.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:B9F/ window 100,0
+100.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:B9F:/ window 100,0
 108.5 "Augurium" sync / 1[56]:[^:]*:Alpha Zaghnal:3D65:/ window 109,9
 117.6 "Beastly Roar" sync / 1[56]:[^:]*:Alpha Zaghnal:3D64:/
 122.9 "Beast Rampant" sync / 1[56]:[^:]*:Alpha Zaghnal:3D60:/
@@ -34,7 +34,7 @@ hideall "--sync--"
 ### Mithridates
 # -p 3DED:512 -ii 3DEC 3DEF
 # Aetherial Observation will be sealed off
-500.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:BA0/ window 500,0
+500.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:BA0:/ window 500,0
 
 512.0 "Thunder Beam" sync / 1[56]:[^:]*:Mithridates:3DED:/ window 512,10
 522.2 "Electric Discharge" sync / 1[56]:[^:]*:Mithridates:3DF0:/
@@ -66,7 +66,7 @@ hideall "Temporal Paradox"
 hideall "Temporal Flow"
 
 # The Cornice will be sealed off
-1000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:BA2/ window 1000,0
+1000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:BA2:/ window 1000,0
 
 1013.8 "Magitek Crossray" sync / 1[56]:[^:]*:The Tycoon:3DF8:/ window 1013.8,5
 1016.2 "Temporal Paradox" sync / 1[56]:[^:]*:The Tycoon:3DF7:/

--- a/ui/raidboss/data/05-shb/eureka/bozjan_southern_front.txt
+++ b/ui/raidboss/data/05-shb/eureka/bozjan_southern_front.txt
@@ -67,9 +67,9 @@ hideall "--sync--"
 
 ### Brionac / 4th Legion Helldiver
 # The Grand Gates will be sealed off
-20000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:DD9/ window 100000,0
+20000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:DD9:/ window 100000,0
 # Eaglesight will be sealed off
-20000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:DD8/ window 100000,0
+20000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:DD8:/ window 100000,0
 # JavaScript will insert a sync to jump to 4th Legion Helldiver if you are on the bottom.
 # Unfortunately, there is nothing in the log to differentiate otherwise.
 
@@ -143,7 +143,7 @@ hideall "--sync--"
 
 # Uncomment this to more easily test this timeline.
 # Eaglesight will be sealed off
-# 30000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:DD8/ window 100000,0
+# 30000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:DD8:/ window 100000,0
 
 # Fake intro, where you don't know if you're on the top or the bottom.
 # Don't sync because sometimes these bosses are +/- 3 seconds @_@
@@ -198,7 +198,7 @@ hideall "--sync--"
 
 ### Albeleo the Maleficent
 # Bladesmeet will be sealed off
-40000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:DD5/ window 100000,0
+40000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:DD5:/ window 100000,0
 
 
 ### Adrammelech
@@ -207,7 +207,7 @@ hideall "--sync--"
 # note: accursed becoming IV casts have different ability ids the first time through.
 
 # The airship landing will be sealed off
-50000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:DDA/ window 100000,0
+50000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:DDA:/ window 100000,0
 50014.3 "Holy IV" sync / 1[56]:[^:]*:Adrammelech:4F96:/
 
 50021.8 "Curse Of The Fiend" sync / 1[56]:[^:]*:Adrammelech:4F7A:/
@@ -285,7 +285,7 @@ hideall "--sync--"
 
 # Phase 1
 # Majesty's Auspice will be sealed off
-60000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:DDB/ window 100000,0
+60000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:DDB:/ window 100000,0
 60014.3 "Molting Plumage" sync / 1[56]:[^:]*:Dawon:517A:/
 60025.9 "Explosion" sync / 1[56]:[^:]*:Verdant Plume:5182:/
 60033.5 "Scratch" sync / 1[56]:[^:]*:Dawon:517B:/

--- a/ui/raidboss/data/05-shb/eureka/delubrum_reginae.txt
+++ b/ui/raidboss/data/05-shb/eureka/delubrum_reginae.txt
@@ -18,7 +18,7 @@ hideall "--sync--"
 
 # Initial Merciful Air
 # The Theater of One will be sealed off
-1000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:E1B/ window 10000,0
+1000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:E1B:/ window 10000,0
 1012.2 "Verdant Tempest" sync / 1[56]:[^:]*:Trinity Seeker:5AB6:/
 1019.4 "First Mercy" sync / 1[56]:[^:]*:Trinity Seeker:5B5D:/
 1022.6 "Second Mercy" sync / 1[56]:[^:]*:Trinity Seeker:5B5E:/
@@ -160,7 +160,7 @@ hideall "--sync--"
 # -p 5755:2023
 # -ii 575A 575C
 # The Hall of Supplication will be sealed off
-2000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:E1D/ window 10000,0
+2000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:E1D:/ window 10000,0
 2007.0 "--sync--" sync / 14:[^:]*:Dahu:576[12]:/ window 10,2
 2010.0 "Right-Sided Shockwave/Left-Sided Shockwave" #sync / 1[56]:[^:]*:Dahu:576[12]:/
 2012.6 "Left-Sided Shockwave/Right-Sided Shockwave" #sync / 1[56]:[^:]*:Dahu:576[12]:/
@@ -213,7 +213,7 @@ hideall "--sync--"
 # All four (just autos) -> randomly each individually -> final phase with aetherial wards
 
 # The Hall of Hieromancy will be sealed off
-3000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:E1E/ window 10000,0
+3000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:E1E:/ window 10000,0
 # ranged auto should be reasonably timed
 3002.5 "--sync--" sync / 1[56]:[^:]*:Queen's Gunner:5857:/ window 3,1
 # can't sync this untargetable as the mobs will hop away sooner if they are damaged enough.
@@ -370,7 +370,7 @@ hideall "--sync--"
 # -p 57A3:5011.3
 # (no -ii, a refreshingly direct timeline)
 # Pride of the Lion will be sealed off
-5000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:E1F/ window 10000,0
+5000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:E1F:/ window 10000,0
 
 # one circle, one square
 5008.3 "--sync--" sync / 14:[^:]*:Bozjan Phantom:57A3:/ window 10,10
@@ -446,7 +446,7 @@ hideall "--sync--"
 # -p 5975:7013
 # -ii 5962 4F55 4F99 5B24 5968 4F56 4F9A 5964 5969 5965 5967 596A 596C
 # The Vault of Singing Crystal will be sealed off
-7000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:E20/ window 10000,0
+7000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:E20:/ window 10000,0
 7008.0 "--sync--" sync / 14:[^:]*:Trinity Avowed:5975:/ window 10,10
 7013.0 "Wrath Of Bozja" sync / 1[56]:[^:]*:Trinity Avowed:5975:/
 7021.1 "Glory Of Bozja" sync / 1[56]:[^:]*:Trinity Avowed:5976:/
@@ -534,7 +534,7 @@ hideall "--sync--"
 # -p 59C8:9015.5
 # -ii 5B83 5B82 59E0 59E2 59DA 59CC 5B40 59CD 5B8D
 # Queensheart will be sealed off
-9000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:E23/ window 10000,0
+9000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:E23:/ window 10000,0
 9010.5 "--sync--" sync / 14:[^:]*:The Queen:59C8:/ window 15,15
 9015.5 "Empyrean Iniquity" sync / 1[56]:[^:]*:The Queen:59C8:/
 9025.7 "Cleansing Slash" sync / 1[56]:[^:]*:The Queen:59C5:/

--- a/ui/raidboss/data/05-shb/eureka/delubrum_reginae_savage.txt
+++ b/ui/raidboss/data/05-shb/eureka/delubrum_reginae_savage.txt
@@ -123,7 +123,7 @@ hideall "--sync--"
 # -p 5AD3:4011.4 5A98:4079.5 5A99:4171.7 5A97:4265.8
 # -ii 1961 1963 5B33 5AB8 5AB9 5ABA 5ABB 5ABC 5AD1 5B2A 5B2B 5AC1 5AC2 5AC3 5AC4 5AC5 5AC6 5ACB 5BBC 5ACD
 # The Theater of One will be sealed off
-4000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:E1B/ window 20000,0
+4000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:E1B:/ window 20000,0
 # .*is no longer sealed
 4000.0 "--Reset--" sync / 29:[^:]*:7DE:/ window 0,2000 jump 0
 
@@ -311,7 +311,7 @@ hideall "--sync--"
 # override it.  Dahu will only end when Dahu is killed, which can only be seen if you
 # are in the Dahu fight.
 # The Hall of Supplication will be sealed off
-6000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:E1D/ window 6000,0
+6000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:E1D:/ window 6000,0
 6000.0 "--Reset--" sync / 19:[^:]*:Dahu:/ window 0,2000 jump 0
 6008.4 "Reverberating Roar" sync / 1[56]:[^:]*:Dahu:576D:/ window 10,2.5
 6014.5 "Reverberating Roar" sync / 1[56]:[^:]*:Dahu:576D:/
@@ -411,7 +411,7 @@ hideall "--sync--"
 
 # This is the zone, but can't use this sync as it can be seen by Dahu.  Sync to autos instead.
 # Pride of the Lioness will be sealed off
-#8000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:E1C/ window 20000,0
+#8000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:E1C:/ window 20000,0
 8000.0 "--Reset--" sync / 00:0044:Stygimoloch Warrior:Why\.\.\.won't\.\.\.you\.\.\./ window 0,2000 jump 0
 # TODO: is there a reset dialog line for losing?
 # Alternatively, we could always insert " 19:${data.me} was defeated by" from script.
@@ -505,7 +505,7 @@ hideall "--sync--"
 # - 5823 (59BE)
 
 # The Hall of Hieromancy will be sealed off
-10000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:E1E/ window 20000,0
+10000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:E1E:/ window 20000,0
 # .*is no longer sealed
 10000.0 "--Reset--" sync / 29:[^:]*:7DE:/ window 0,2000 jump 0
 # ranged auto should be reasonably timed
@@ -682,7 +682,7 @@ hideall "--sync--"
 # Manipulate -> Invert -> Adds -> then loop Manipulate+Buster OR Invert+Buster
 
 # Pride of the Lion will be sealed off
-12000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:E1F/ window 20000,0
+12000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:E1F:/ window 20000,0
 # .*is no longer sealed
 12000.0 "--Reset--" sync / 29:[^:]*:7DE:/ window 0,2000 jump 0
 12007.1 "--sync--" sync / 14:[^:]*:Bozjan Phantom:57BD:/ window 20000,0
@@ -850,7 +850,7 @@ hideall "--sync--"
 # Note: Blade of Entropy is `sync / 1[56]:[^:]*:(Trinity Avowed|Avowed Avatar):594[23456789]|595[6789ABCD]:/``
 
 # The Vault of Singing Crystal will be sealed off
-14000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:E20/ window 20000,0
+14000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:E20:/ window 20000,0
 # .*is no longer sealed
 14000.0 "--Reset--" sync / 29:[^:]*:7DE:/ window 0,2000 jump 0
 14006.7 "--sync--" sync / 14:[^:]*:Trinity Avowed:594E:/ window 10,10
@@ -1256,7 +1256,7 @@ hideall "--sync--"
 # -ii 1961 55A6 57D0 57CE 57DD 57DC 57C8 57CA 57C6 57CC 5B38 57D3 57D6 57E2 501B 57DF 501A
 # -it "Stygimoloch Lord"
 # The Path of Divine Clarity will be sealed off
-18000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:E22/ window 20000,0
+18000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:E22:/ window 20000,0
 # .*is no longer sealed
 18000.0 "--Reset--" sync / 29:[^:]*:7DE:/ window 0,2000 jump 0
 
@@ -1385,7 +1385,7 @@ hideall "--sync--"
 # TODO: what is 5BCB? (--middle--?)
 # TODO: what is 55A8?
 # Queensheart will be sealed off
-20000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:E23/ window 20000,0
+20000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:E23:/ window 20000,0
 # .*is no longer sealed
 20000.0 "--Reset--" sync / 29:[^:]*:7DE:/ window 0,2000 jump 0
 20010.3 "--sync--" sync / 14:[^:]*:The Queen:59F9:/ window 20,20

--- a/ui/raidboss/data/05-shb/eureka/zadnor.txt
+++ b/ui/raidboss/data/05-shb/eureka/zadnor.txt
@@ -75,7 +75,7 @@ hideall "--sync--"
 # -p 5E7C:21016 5E7E:21300
 # -ii 61BE 5E7D 5E75 5E88 5E8A 5E79 5E7B
 # Loading Dock will be sealed off
-#21000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:E5C/ window 100000,0
+#21000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:E5C:/ window 100000,0
 21016.0 "Pyrokinesis" sync / 1[56]:[^:]*:Sartauvoir The Inferno:5E7C:/ window 100000,0
 21028.2 "--sync--" sync / 1[56]:[^:]*:Sartauvoir The Inferno:5E6C:/
 21034.3 "Time Eruption 1" sync / 1[56]:[^:]*:Sartauvoir The Inferno:5E6E:/
@@ -126,7 +126,7 @@ hideall "--sync--"
 # -ii 6226 6227 6228 6229 5F13 5F1D 5F20 5F15 5F1C 5F29 5F31
 
 # Flagship Landing will be sealed off
-#22000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:E5B/ window 100000,0
+#22000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:E5B:/ window 100000,0
 
 # Blackburn
 22011.0 "--sync--" sync / 14:[^:]*:4Th Legion Blackburn:5F12:/ window 100000,0
@@ -189,7 +189,7 @@ hideall "--sync--"
 # -p 5C8F:23013.3
 # -ii 5C89 5C90 5C83 5C84 5C85 6179 614E 5C8C 5C87
 # Magitek Development will be sealed off
-23000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:E5E/ window 100000,0
+23000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:E5E:/ window 100000,0
 23013.3 "Putrified Soul" sync / 1[56]:[^:]*:4Th-Make Cuchulainn:5C8F:/
 23022.4 "Burgeoning Dread" sync / 1[56]:[^:]*:4Th-Make Cuchulainn:5C88:/
 23043.7 "Putrified Soul" sync / 1[56]:[^:]*:4Th-Make Cuchulainn:5C8F:/
@@ -236,7 +236,7 @@ hideall "--sync--"
 # -it "Saunion"
 # -ii 5DB6 5DB8 6150 5DC7 60C4 5DCF 5DB3 5DD2 61E4 61E5
 # The Greater Hold will be sealed off
-24000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:E60/ window 100000,0
+24000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:E60:/ window 100000,0
 24011.7 "Magitek Halo/Magitek Crossray" sync / 1[56]:[^:]*:Saunion:5DB[57]:/
 24022.9 "High-Powered Magitek Ray" sync / 1[56]:[^:]*:Saunion:5DC5:/
 24034.1 "Magitek Crossray/Magitek Halo" sync / 1[56]:[^:]*:Saunion:5DB[57]:/
@@ -330,7 +330,7 @@ hideall "--sync--"
 # -p 5CC6:25013 5CB7:25805
 # -ii 6143 61A2 5CC7 61C4 5CB2 5CB8 5CC5 6092 6091 6093 5CC3 5CB4 5CB5 5CC1 5CAD 5CA1 5CA2
 # The Fallen Ring will be sealed off
-25000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:E61/ window 100000,0
+25000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:E61:/ window 100000,0
 25013.0 "Aetheric Explosion" sync / 1[56]:[^:]*:The Diablo Armament:5CC6:/
 25023.4 "Aetherochemical Laser 1" sync / 1[56]:[^:]*:The Diablo Armament:5CA[45]:/
 25027.5 "Aetherochemical Laser 2" sync / 1[56]:[^:]*:The Diablo Armament:5CA[45]:/

--- a/ui/raidboss/data/06-ew/alliance/aglaia.txt
+++ b/ui/raidboss/data/06-ew/alliance/aglaia.txt
@@ -20,7 +20,7 @@ hideall "Fan Flames"
 # Note: "--hammer--" lines are done visually, as there seem to be no log line for them.
 
 # Ingenuity's Foothold will be sealed off
-1000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:104D/ window 10000,0
+1000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:104D:/ window 10000,0
 1005.5 "--sync--" sync / 14:[^:]*:Byregot:7176:/ window 10,10
 1010.5 "Ordeal of Thunder" sync / 1[56]:[^:]*:Byregot:7176:/
 1022.4 "Byregot's Strike" sync / 1[56]:[^:]*:Byregot:725A:/
@@ -111,7 +111,7 @@ hideall "Fan Flames"
 # -ii 70D8 70E2 70E4 70DC
 
 # The Path will be sealed off
-2000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:104E/ window 10000,0
+2000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:104E:/ window 10000,0
 2004.8 "--sync--" sync / 14:[^:]*:Rhalgr's Emissary:70E0:/ window 10,10
 2012.8 "Destructive Static" sync / 1[56]:[^:]*:Rhalgr's Emissary:70E0:/
 2019.8 "Destructive Charge" sync / 1[56]:[^:]*:Rhalgr's Emissary:70DA:/ duration 17
@@ -142,7 +142,7 @@ hideall "Fan Flames"
 # TODO: is the ordering of fake vs real Broken World correct? Every log has been this.
 
 # Monument to Destruction will be sealed off
-3000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:104F/ window 10000,0
+3000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:104F:/ window 10000,0
 3007.5 "--sync--" sync / 14:[^:]*:Rhalgr:70A5:/ window 10,10
 3012.5 "Lightning Reign" sync / 1[56]:[^:]*:Rhalgr:70A5:/
 3023.6 "Advent of the Eighth" sync / 1[56]:[^:]*:Rhalgr:70A7:/
@@ -213,7 +213,7 @@ hideall "Fan Flames"
 # TODO: These do "Rejuvenating Spark" (71D9) to rebalance health.  Does that adjust timings?
 
 # Endless City will be sealed off
-4000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:1050/ window 10000,0
+4000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:1050:/ window 10000,0
 4007.0 "--sync--" sync / 14:[^:]*:Lioness of Aglaia:71D7:/ window 10,10
 4012.0 "Double Immolation" sync / 1[56]:[^:]*:Lioness of Aglaia:71D7:/
 4019.8 "--sync--" sync / 1[56]:[^:]*:Lioness of Aglaia:71CD:/ window 10,10
@@ -267,7 +267,7 @@ hideall "Fan Flames"
 # -ii 70A1 7082 7083 709F 708E 72BE 7093 7094 71EE 7089 731C 708C 7092 7087
 
 # Circle of Inquiry will be sealed off
-5000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:1051/ window 10000,0
+5000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:1051:/ window 10000,0
 5006.2 "--sync--" sync / 14:[^:]*:Azeyma:70A0:/ window 10,10
 5012.2 "Warden's Prominence" sync / 1[56]:[^:]*:Azeyma:70A0:/
 
@@ -394,7 +394,7 @@ hideall "Fan Flames"
 # TODO: Is Fired Up I/II always knockback -> out and I/II/III is out -> knockback -> knockback or out?
 
 # The Twin Halls will be sealed off
-6000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:1052/ window 10000,0
+6000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:1052:/ window 10000,0
 6008.2 "--sync--" sync / 14:[^:]*:Nald'thal:70E9:/ window 10,10
 6013.2 "As Above, So Below" sync / 1[56]:[^:]*:Nald'thal:(70E8|70E9):/
 6027.4 "Heat Above, Flames Below" sync / 1[56]:[^:]*:Nald'thal:73A5:/

--- a/ui/raidboss/data/06-ew/alliance/euphrosyne.txt
+++ b/ui/raidboss/data/06-ew/alliance/euphrosyne.txt
@@ -15,7 +15,7 @@ hideall "Season's Passing"
 # -ii 7C26 7C09 7C10 7C0F 7C14 7C15 7C23
 
 # Fertile Plains will be sealed off
-1000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:10A9/ window 10000,0
+1000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:10A9:/ window 10000,0
 1007.0 "--sync--" sync / 14:[^:]*:Nophica:7C24:/ window 20,20
 1012.0 "Abundance" sync / 1[56]:[^:]*:Nophica:7C24:/
 1020.7 "Matron's Plenty" sync / 1[56]:[^:]*:Nophica:7C08:/
@@ -93,7 +93,7 @@ hideall "Season's Passing"
 # This is overall an awkward timeline.  The two bosses can definitely desync by ~1-2s.
 
 # The Bole will be sealed off
-2000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:10AB/ window 10000,0
+2000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:10AB:/ window 10000,0
 2009.0 "--sync--" sync / 14:[^:]*:Nymeia:7A38:/ window 10,10
 2013.5 "Spinner's Wheel" sync / 1[56]:[^:]*:Nymeia:7A38:/
 2019.2 "--sync--" sync / 14:[^:]*:Althyk:7A46:/ window 10,10
@@ -180,7 +180,7 @@ hideall "Season's Passing"
 # -it "Glacial Spear"
 
 # The Barbs will be sealed off
-3000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:10AD/ window 10000,0
+3000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:10AD:/ window 10000,0
 3009.0 "--sync--" sync / 14:[^:]*:Halone:7D79:/
 3013.0 "Rain of Spears x3" sync / 1[56]:[^:]*:Halone:7D79:/
 
@@ -319,7 +319,7 @@ hideall "Season's Passing"
 # -it "Ceremonial Pillar"
 
 # The Chamber of Revolutions will be sealed off
-4000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:10BC/ window 10000,0
+4000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:10BC:/ window 10000,0
 4013.1 "Blue Moon" sync / 1[56]:[^:]*:Menphina:7BFA:/
 4020.9 "Love's Light" sync / 1[56]:[^:]*:Menphina:7BB8:/
 4026.6 "Full Bright" sync / 1[56]:[^:]*:Menphina:7BBB:/

--- a/ui/raidboss/data/06-ew/alliance/thaleia.txt
+++ b/ui/raidboss/data/06-ew/alliance/thaleia.txt
@@ -15,7 +15,7 @@ hideall "--sync--"
 # Long pull: https://www.fflogs.com/reports/a:ZBxnrKWpPfdt2gCV#fight=11&type=damage-done
 
 # The River of Knowledge will be sealed off
-1000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:1169/ window 10000,0
+1000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:1169:/ window 10000,0
 1005.0 "--sync--" sync / 14:[^:]*:Thaliak:88D1:/ window 10,10
 1010.0 "Katarraktes" sync / 1[56]:[^:]*:Thaliak:88D1:/
 
@@ -134,7 +134,7 @@ hideall "--sync--"
 # Long pull: https://www.fflogs.com/reports/qW8TMthAcD1JbmNk#fight=21&type=damage-done
 
 # The Briny Deep will be sealed off
-2000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:116A/ window 10000,0
+2000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:116A:/ window 10000,0
 2007.1 "--sync--" sync / 14:[^:]*:Llymlaen:880B:/ window 10,10
 2012.1 "Tempest" sync / 1[56]:[^:]*:Llymlaen:880B:/
 2023.2 "Seafoam Spiral/Wind Rose" sync / 1[56]:[^:]*:Llymlaen:(880D|880C):/
@@ -322,7 +322,7 @@ hideall "--sync--"
 # Long pull: https://www.fflogs.com/reports/GzjrkH97xXWFZvAM#fight=4&type=damage-done
 
 # The Windward Pass will be sealed off
-3000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:116B/ window 10000,0
+3000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:116B:/ window 10000,0
 
 # Phase 1
 3010.0 "--sync--" sync / 1[56]:[^:]*:Oschon:8999:/ window 10,10
@@ -500,7 +500,7 @@ hideall "--sync--"
 # Long pull: https://www.fflogs.com/reports/wRA1yPgGx8McNjnf#fight=7&type=damage-done
 
 # The Twelve's Embrace will be sealed off
-4000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:116D/ window 10000,0
+4000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:116D:/ window 10000,0
 4009.6 "--sync--" sync / 14:[^:]*:Eulogia:8A03:/ window 10,10
 4014.6 "Dawn of Time" sync / 1[56]:[^:]*:Eulogia:8A03:/
 

--- a/ui/raidboss/data/06-ew/dungeon/aetherfont.txt
+++ b/ui/raidboss/data/06-ew/dungeon/aetherfont.txt
@@ -16,7 +16,7 @@ hideall "--sync--"
 # -p 823A:111.3
 
 # Landfast Floe will be sealed off
-100.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:10CD/ window 100000,0
+100.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:10CD:/ window 100000,0
 106.3 "--sync--" sync / 14:[^:]*:Lyngbakr:823A:/ window 10,10
 111.3 "Upsweep" sync / 1[56]:[^:]*:Lyngbakr:823A:/
 121.7 "Tidal Breath" sync / 1[56]:[^:]*:Lyngbakr:8240:/
@@ -57,7 +57,7 @@ hideall "--sync--"
 # -p 872D:510
 
 # Cyancap Cavern will be sealed off
-500.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:10CE/ window 100000,0
+500.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:10CE:/ window 100000,0
 505.0 "--sync--" sync / 14:[^:]*:Arkas:872D:/ window 10,10
 510.0 "Battle Cry" sync / 1[56]:[^:]*:Arkas:872D:/
 521.3 "Lightning Leap" sync / 1[56]:[^:]*:Arkas:824E:/
@@ -116,7 +116,7 @@ hideall "--sync--"
 # -p 824C:1009.6
 
 # The Deep Below will be sealed off
-1000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:10CF/ window 100000,0
+1000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:10CF:/ window 100000,0
 1004.6 "--sync--" sync / 14:[^:]*:Octomammoth:824C:/ window 10,10
 1009.6 "Tidal Roar" sync / 1[56]:[^:]*:Octomammoth:824C:/
 1032.7 "Octostroke" sync / 1[56]:[^:]*:Octomammoth:8243:/

--- a/ui/raidboss/data/06-ew/dungeon/aloalo_island.txt
+++ b/ui/raidboss/data/06-ew/dungeon/aloalo_island.txt
@@ -15,7 +15,7 @@ hideall "--sync--"
 # -ii 8B89 8B98 8B9C 8B9D 8B93
 
 # Ketulu Cove will be sealed off
-#1000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:1128/ window 10000,0
+#1000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:1128:/ window 10000,0
 1000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:1128:/ window 10000,0
 1006.1 "--middle--" sync / 1[56]:[^:]*:Quaqua:8B8F:/
 1007.4 "--sync--" sync / 14:[^:]*:Quaqua:8B94:/ window 10,10
@@ -155,7 +155,7 @@ hideall "--sync--"
 # -ii 8A78 8AA6 8A7A 8A7B 8A81 8D1D 8AA4 8A89 8A8A 8A82 8A83 8A8C 8D10 8A94 8A98 8A99 8A96
 
 # Seasong's Rest will be sealed off
-#2000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:112B/ window 10000,0
+#2000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:112B:/ window 10000,0
 2000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:112B:/ window 10000,0
 2009.0 "--sync--" sync / 14:[^:]*:Ketuduke:8AA5:/
 2014.0 "Tidal Roar" sync / 1[56]:[^:]*:Ketuduke:8AA5:/
@@ -315,7 +315,7 @@ hideall "--sync--"
 # -ii 8B89 8BA2 8CD1 8B93
 
 # Elder Stump will be sealed off
-#3000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:1129/ window 10000,0
+#3000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:1129:/ window 10000,0
 3000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:1129:/ window 10000,0
 
 3007.0 "--middle--" sync / 1[56]:[^:]*:Quaqua:8B8F:/
@@ -435,7 +435,7 @@ hideall "--sync--"
 # -ii 8878 8879 8873 8CDD
 
 # The Origin Spring will be sealed off
-#4000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:112C/ window 10000,0
+#4000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:112C:/ window 10000,0
 4000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:112C:/ window 10000,0
 4011.2 "--sync--" sync / 14:[^:]*:Lala:887F:/ window 10,10
 4016.2 "Inferno Theorem" sync / 1[56]:[^:]*:Lala:887F:/
@@ -604,7 +604,7 @@ hideall "--sync--"
 # -ii 8B89 8B93
 
 # Ancient Forum will be sealed off
-#5000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:112A/ window 10000,0
+#5000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:112A:/ window 10000,0
 5000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:112A:/ window 10000,0
 5007.8 "--middle--" sync / 1[56]:[^:]*:Quaqua:8B8F:/
 5009.1 "--sync--" sync / 14:[^:]*:Quaqua:8B94:/ window 10,10
@@ -732,7 +732,7 @@ hideall "--sync--"
 # -ii 8A04 8932 892C 8986 8925 8926 8981 8935 89F6 89F7 8CEB 89FB 8941 8942 8943
 
 # Slumbering Canopy will be sealed off
-#6000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:112D/ window 10000,0
+#6000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:112D:/ window 10000,0
 6000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:112D:/ window 10000,0
 # Can be triggered by players earlier
 6004.0 "Hidden Mine" #sync / 1[56]:[^:]*:Mine:892D:/
@@ -926,7 +926,7 @@ hideall "--sync--"
 # -ii 87C1 87C3 8C34 8C35 8D38 8E47
 
 # Kairimai Loquloqai will be sealed off
-#7000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:112E/ window 10000,0
+#7000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:112E:/ window 10000,0
 7000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:11DE:/ window 10000,0
 7006.8 "--sync--" sync / 14:[^:]*:Loquloqui:87BC:/ window 10,10
 7011.8 "Long-lost Light" sync / 1[56]:[^:]*:Loquloqui:87BC:/

--- a/ui/raidboss/data/06-ew/dungeon/alzadaals_legacy.txt
+++ b/ui/raidboss/data/06-ew/dungeon/alzadaals_legacy.txt
@@ -13,7 +13,7 @@ hideall "--sync--"
 # -ii 71E5
 
 # Undersea Entrance will be sealed off
-0.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:103E/ window 0,1
+0.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:103E:/ window 0,1
 11.0 "Big Wave" sync / 1[56]:[^:]*:Ambujam:6F60:/ window 11,5
 20.8 "Tentacle Dig" sync / 1[56]:[^:]*:Ambujam:6F55:/ window 20.8
 33.0 "--sync--" sync / 1[56]:[^:]*:Scarlet Tentacle:6F5B:/
@@ -46,7 +46,7 @@ hideall "--sync--"
 # -ii 71CC 6F1A 6F1C 6F1D 6F26 6F27
 
 # The Threshold of Bounty will be sealed off
-1000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:103F/ window 1000,1
+1000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:103F:/ window 1000,1
 1011.0 "Articulated Bits" sync / 1[56]:[^:]*:Armored Chariot:6F19:/ window 1011,0
 1013.2 "Assail" sync / 1[56]:[^:]*:Armored Chariot:6F29:/
 1015.3 "--sync--" sync / 1[56]:[^:]*:Armored Chariot:(6F20|6F21):/
@@ -110,7 +110,7 @@ hideall "--sync--"
 # -ii 6F71 6F64 6F65 6F66 6F67 6F6D 6F6F
 
 # Weaver's Warding will be sealed off
-2000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:1040/ window 2000,1
+2000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:1040:/ window 2000,1
 2015.2 "Billowing Bolts" sync / 1[56]:[^:]*:Kapikulu:6F70:/ window 2016,5
 2023.4 "--sync--" sync / 1[56]:[^:]*:Kapikulu:6F62:/
 2027.8 "Spin Out" sync / 1[56]:[^:]*:Kapikulu:6F63:/

--- a/ui/raidboss/data/06-ew/dungeon/another_mount_rokkon-savage.txt
+++ b/ui/raidboss/data/06-ew/dungeon/another_mount_rokkon-savage.txt
@@ -26,7 +26,7 @@ hideall "--sync--"
 # is just a dodge check.
 
 # Trial of Benevolence will be sealed off
-1000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:10F8/ window 10000,0
+1000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:10F8:/ window 10000,0
 1007.0 "--sync--" sync / 14:[^:]*:Shishio:8441:/ window 10000,0
 1012.0 "Enkyo" sync / 1[56]:[^:]*:Shishio:8441:/
 
@@ -160,7 +160,7 @@ hideall "--sync--"
 # -ii 8502 8504 8555 8504 8545 851D 851E 8584 8585 852F 854B 8257 8549 8554 8628 8544 854E 853E 852B 854C 854A
 
 # Trial of Wisdom will be sealed off
-2000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:10F9/ window 10000,0
+2000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:10F9:/ window 10000,0
 2009.3 "--sync--" sync / 14:[^:]*:Gorai the Uncaged:8534:/ window 10000,0
 2014.3 "Unenlightenment" sync / 1[56]:[^:]*:Gorai the Uncaged:8534:/
 
@@ -299,7 +299,7 @@ hideall "--sync--"
 # -ii 8507 85EC 85ED 8601 860B 8C28 8607 85FD 8604 8606 8537 8538
 
 # Trial of Responsibility will be sealed off
-3000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:10FA/ window 10000,0
+3000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:10FA:/ window 10000,0
 3011.4 "--sync--" sync / 14:[^:]*:Moko the Restless:860C:/ window 10000,10
 3016.4 "Kenki Release" sync / 1[56]:[^:]*:Moko the Restless:860C:/
 

--- a/ui/raidboss/data/06-ew/dungeon/another_mount_rokkon.txt
+++ b/ui/raidboss/data/06-ew/dungeon/another_mount_rokkon.txt
@@ -21,7 +21,7 @@ hideall "--sync--"
 # is just a dodge check.
 
 # Trial of Benevolence will be sealed off
-1000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:10F8/ window 10000,0
+1000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:10F8:/ window 10000,0
 1007.0 "--sync--" sync / 14:[^:]*:Shishio:841A:/ window 10000,0
 1012.0 "Enkyo" sync / 1[56]:[^:]*:Shishio:841A:/
 
@@ -155,7 +155,7 @@ hideall "--sync--"
 # -ii 8502 8504 8535 8504 851A 851D 851E 8513 8515 852F 8525 8257 8522 8533 8528 8519 852A 852D 852B 8527 8523
 
 # Trial of Wisdom will be sealed off
-2000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:10F9/ window 10000,0
+2000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:10F9:/ window 10000,0
 2009.3 "--sync--" sync / 14:[^:]*:Gorai the Uncaged:8534:/ window 10000,0
 2014.3 "Unenlightenment" sync / 1[56]:[^:]*:Gorai the Uncaged:8534:/
 
@@ -294,7 +294,7 @@ hideall "--sync--"
 # -ii 8507 85B8 85B9 85D2 85DF 8C27 85DA 85CE 85D5 85D7 8537 8538
 
 # Trial of Responsibility will be sealed off
-3000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:10FA/ window 10000,0
+3000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:10FA:/ window 10000,0
 3011.4 "--sync--" sync / 14:[^:]*:Moko the Restless:85E0:/ window 10000,10
 3016.4 "Kenki Release" sync / 1[56]:[^:]*:Moko the Restless:85E0:/
 

--- a/ui/raidboss/data/06-ew/dungeon/another_sildihn_subterrane-savage.txt
+++ b/ui/raidboss/data/06-ew/dungeon/another_sildihn_subterrane-savage.txt
@@ -18,7 +18,7 @@ hideall "--sync--"
 # -ii 7783 7784 7785 778B 778C 778D 77ED 77EE
 
 # Trial of Knowledge is sealed off
-0.0 "--sync--" sync / 29:[^:]*:7DD:[^:]*:1087/ window 0,1
+0.0 "--sync--" sync / 29:[^:]*:7DD:[^:]*:1087:/ window 0,1
 12.2 "--sync--" sync / 14:[^:]*:Silkie:777C:/ window 15,15
 14.9 "Fizzling Suds" sync / 1[56]:[^:]*:Silkie:777C:/
 21.0 "Soap's Up" sync / 1[56]:[^:]*:Silkie:777D:/
@@ -107,7 +107,7 @@ hideall "--sync--"
 # -ii 77B1 77B2 77B8 77B9 77BF 77A2 79F4
 
 # Trial of Might will be sealed off
-1000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:1088/ window 1000,1
+1000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:1088:/ window 1000,1
 1006.8 "--sync--" sync / 14:[^:]*:Gladiator of Sil'dih:77B3:/ window 1007.3,5
 1011.5 "Flash of Steel" sync / 1[56]:[^:]*:Gladiator of Sil'dih:77B3:/
 1023.6 "Specter of Might" sync / 1[56]:[^:]*:Gladiator of Sil'dih:77B5:/
@@ -178,7 +178,7 @@ hideall "--sync--"
 # -ii 76CA 74B8
 
 # Trial of Balance will be sealed off
-2000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:1089/ window 2000,1
+2000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:1089:/ window 2000,1
 2006.8 "--sync--" sync / 14:[^:]*:Shadowcaster Zeless Gah:76C5:/ window 2007.3,5
 2011.5 "Show of Strength" sync / 1[56]:[^:]*:Shadowcaster Zeless Gah:76C5:/
 2023.7 "Infern Brand" sync / 1[56]:[^:]*:Shadowcaster Zeless Gah:7491:/

--- a/ui/raidboss/data/06-ew/dungeon/another_sildihn_subterrane.txt
+++ b/ui/raidboss/data/06-ew/dungeon/another_sildihn_subterrane.txt
@@ -13,7 +13,7 @@ hideall "--sync--"
 # -ii 7760 7761 7762 7768 7769 776A 77ED 77EE
 
 # Trial of Knowledge is sealed off
-0.0 "--sync--" sync / 29:[^:]*:7DD:[^:]*:1087/ window 0,1
+0.0 "--sync--" sync / 29:[^:]*:7DD:[^:]*:1087:/ window 0,1
 12.2 "--sync--" sync / 14:[^:]*:Silkie:7759:/ window 15,15
 14.9 "Fizzling Suds" sync / 1[56]:[^:]*:Silkie:7759:/
 21.0 "Soap's Up" sync / 1[56]:[^:]*:Silkie:775A:/
@@ -102,7 +102,7 @@ hideall "--sync--"
 # -ii 766F 7670 7676 7677 77BF 7660 79F3
 
 # Trial of Might will be sealed off
-1000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:1088/ window 1000,1
+1000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:1088:/ window 1000,1
 1006.8 "--sync--" sync / 14:[^:]*:Gladiator of Sil'dih:7671:/ window 1007.3,5
 1011.5 "Flash of Steel" sync / 1[56]:[^:]*:Gladiator of Sil'dih:7671:/
 1023.6 "Specter of Might" sync / 1[56]:[^:]*:Gladiator of Sil'dih:7673:/
@@ -173,7 +173,7 @@ hideall "--sync--"
 # -ii 74B7 74B8
 
 # Trial of Balance will be sealed off
-2000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:1089/ window 2000,1
+2000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:1089:/ window 2000,1
 2006.8 "--sync--" sync / 14:[^:]*:Shadowcaster Zeless Gah:74AF:/ window 2007.3,5
 2011.5 "Show of Strength" sync / 1[56]:[^:]*:Shadowcaster Zeless Gah:74AF:/
 2023.7 "Infern Brand" sync / 1[56]:[^:]*:Shadowcaster Zeless Gah:7491:/

--- a/ui/raidboss/data/06-ew/dungeon/ktisis_hyperboreia.txt
+++ b/ui/raidboss/data/06-ew/dungeon/ktisis_hyperboreia.txt
@@ -13,7 +13,7 @@ hideall "--sync--"
 # -ii 1961 6258 6E90 -it Lyssa
 
 # Frozen Sphere will be sealed off
-0.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:EB6/ window 0,1
+0.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:EB6:/ window 0,1
 10.7 "Skull Dasher" sync / 1[56]:[^:]*:Lyssa:625E:/ window 10.7,10
 21.2 "Frostbite and Seek" sync / 1[56]:[^:]*:Lyssa:6257:/
 23.2 "--untargetable--"
@@ -64,7 +64,7 @@ hideall "--sync--"
 # "Pyric Breath" sync / 1[56]:[^:]*:Ladon Lord:(6486|6487|6488|6489|648A|648B):/
 
 # Concept Review will be sealed off
-1000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:EB7/ window 1000,5
+1000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:EB7:/ window 1000,5
 1010.3 "Scratch" sync / 1[56]:[^:]*:Ladon Lord:648F:/ window 1010.3,10
 1019.3 "Inhale" sync / 1[56]:[^:]*:Ladon Lord:6484:/
 1025.5 "--sync--" sync / 1[56]:[^:]*:Ladon Lord:6485:/
@@ -116,7 +116,7 @@ hideall "--sync--"
 # -ii 368
 
 # Celestial Sphere will be sealed off
-2000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:EB8/ window 2000,10
+2000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:EB8:/ window 2000,10
 2013.1 "Trismegistos" sync / 1[56]:[^:]*:Hermes:651E:/ window 2013.1,10
 2020.2 "--middle--"
 2024.2 "Hermetica" sync / 1[56]:[^:]*:Hermes:6520:/

--- a/ui/raidboss/data/06-ew/dungeon/lapis_manalis.txt
+++ b/ui/raidboss/data/06-ew/dungeon/lapis_manalis.txt
@@ -13,7 +13,7 @@ hideall "--sync--"
 # -ii 7A7D 7A7E
 
 # The Silvan Throne will be sealed off
-0.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:10B2/ window 0,1
+0.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:10B2:/ window 0,1
 6.0 "--sync--" sync / 1[56]:[^:]*:Albion:802C:/
 10.6 "Call of the Mountain" sync / 1[56]:[^:]*:Albion:7A7C:/
 
@@ -62,7 +62,7 @@ hideall "--sync--"
 # -ii 7F71 7A9D
 
 # Forum Messorum will be sealed off
-1000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:10B3/ window 1000,1
+1000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:10B3:/ window 1000,1
 1010.2 "--sync--" sync / 1[56]:[^:]*:Galatea Magna:7F71:/ # manually added for early sync
 1015.2 "Waxing Cycle/Waning Cycle" sync / 1[56]:[^:]*:Galatea Magna:(7A91|7F6E):/
 1016.8 "--sync--" sync / 1[56]:[^:]*:Galatea Magna:7F6F:/
@@ -134,7 +134,7 @@ hideall "--sync--"
 # -it "Cagnazzo"
 
 # Deepspine will be sealed off
-2000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:10B4/ window 2000,1
+2000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:10B4:/ window 2000,1
 2015.6 "Stygian Deluge" sync / 1[56]:[^:]*:Cagnazzo:79A3:/
 2025.4 "--sync--" sync / 1[56]:[^:]*:Cagnazzo:798F:/
 2038.0 "Antediluvian 1" sync / 1[56]:[^:]*:Cagnazzo:7990:/

--- a/ui/raidboss/data/06-ew/dungeon/mount_rokkon.txt
+++ b/ui/raidboss/data/06-ew/dungeon/mount_rokkon.txt
@@ -12,7 +12,7 @@ hideall "--sync--"
 # -ii 838A 8391 8382
 
 # Last Glimpse will be sealed off
-1000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:10DC/ window 10000,0
+1000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:10DC:/ window 10000,0
 1011.6 "Glory Neverlasting" sync / 1[56]:[^:]*:Yozakura the Fleeting:83A9:/
 1021.6 "Art of the Windblossom" sync / 1[56]:[^:]*:Yozakura the Fleeting:8369:/
 1030.7 "Oka Ranman" sync / 1[56]:[^:]*:Yozakura the Fleeting:836E:/
@@ -170,7 +170,7 @@ hideall "--sync--"
 # -ii 8597 86D2 878A 85A0 859A 859E 871C 85A4 85A7
 
 # Hall of the Unseen will be sealed off
-2000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:10DF/ window 10000,0
+2000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:10DF:/ window 10000,0
 2011.9 "Kenki Release" sync / 1[56]:[^:]*:Moko the Restless:85AD:/
 2022.1 "--middle--" sync / 1[56]:[^:]*:Moko the Restless:85AF:/
 2028.5 "Iai-kasumi-giri" sync / 1[56]:[^:]*:Moko the Restless:8587:/
@@ -421,7 +421,7 @@ hideall "--sync--"
 # -ii 8396 8399 839A 839D 839F
 
 # Hall of Temptation will be sealed off
-4000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:10DD/ window 10000,0
+4000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:10DD:/ window 10000,0
 4011.6 "Glory Neverlasting" sync / 1[56]:[^:]*:Yozakura the Fleeting:83A9:/
 
 # -> door
@@ -540,7 +540,7 @@ hideall "--sync--"
 # -ii 84D4 8501 84EE 84E6 84E5 84E9 84E0 84FF 84F9 84F7 84F4 84F5
 
 # Hall of Becoming will be sealed off
-5000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:10E0/ window 10000,0
+5000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:10E0:/ window 10000,0
 5012.6 "--sync--" sync / 14:[^:]*:Gorai the Uncaged:8500:/
 5017.6 "Unenlightenment" sync / 1[56]:[^:]*:Gorai the Uncaged:8500:/
 
@@ -720,7 +720,7 @@ hideall "--sync--"
 # -ii 83A2 83A3 83A8 8382 838A
 
 # Autumn Rivers' End will be sealed off
-6000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:10DE/ window 10000,0
+6000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:10DE:/ window 10000,0
 6012.0 "Glory Neverlasting" sync / 1[56]:[^:]*:Yozakura the Fleeting:83A9:/
 
 # -> no dogu
@@ -844,7 +844,7 @@ hideall "--sync--"
 # -ii 86DE 83DA 83DE 83DF 83E0 83E3 83E4 83E5 83E2 87F9 87FB 83DB 87A3 87A4 87A6 87AB 83ED 872B 83F2
 
 # Stone's Silence will be sealed off
-7000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:10E1/ window 10000,0
+7000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:10E1:/ window 10000,0
 7015.7 "Enkyo" sync / 1[56]:[^:]*:Shishio:83F5:/
 7017.8 "--middle--" sync / 1[56]:[^:]*:Shishio:83F7:/
 7022.0 "Stormcloud Summons" sync / 1[56]:[^:]*:Shishio:83D7:/
@@ -1027,7 +1027,7 @@ hideall "--sync--"
 # -ii 8058 8049 804A 804B 8047
 
 # Pond of Spring Rain will be sealed off
-8000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:10E2/ window 10000,0
+8000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:10E2:/ window 10000,0
 8013.0 "Flagrant Combustion" sync / 1[56]:[^:]*:Enenra:8042:/
 8016.1 "--jump--" sync / 1[56]:[^:]*:Enenra:84C2:/
 8029.9 "Out of the Smoke" sync / 1[56]:[^:]*:Enenra:804C:/

--- a/ui/raidboss/data/06-ew/dungeon/smileton.txt
+++ b/ui/raidboss/data/06-ew/dungeon/smileton.txt
@@ -14,7 +14,7 @@ hideall "--sync--"
 # -ii 6741 6736 6737 6C5E 673A 673B 673C 673D
 
 # Smileport will be sealed off
-1000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:EBE/ window 10000,0
+1000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:EBE:/ window 10000,0
 1009.0 "Lines of Fire" sync / 1[56]:[^:]*:Face:6735:/
 1018.1 "Mixed Feelings" sync / 1[56]:[^:]*:Face:6738:/
 1023.2 "Lines of Fire" sync / 1[56]:[^:]*:Face:6735:/
@@ -56,7 +56,7 @@ hideall "--sync--"
  # -ii 6749 674B
 
 # The Welcome Wheel will be sealed off
-2000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:EBF/ window 10000,0
+2000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:EBF:/ window 10000,0
 2011.0 "Circular Saw" sync / 1[56]:[^:]*:Frameworker:6745:/
 2017.6 "--sync--" sync / 1[56]:[^:]*:Frameworker:674A:/
 2022.8 "Leap Forward" sync / 1[56]:[^:]*:Frameworker:6746:/
@@ -84,7 +84,7 @@ hideall "--sync--"
 # -ii 674C 6755
 
 # The Frame will be sealed off
-3000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:EC0/ window 10000,0
+3000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:EC0:/ window 10000,0
 3009.0 "Explosives Distribution" sync / 1[56]:[^:]*:The Big Cheese:674E:/
 3022.2 "Iron Kiss" sync / 1[56]:[^:]*:Bomb:674D:/
 3028.2 "Piercing Missile" sync / 1[56]:[^:]*:The Big Cheese:6751:/

--- a/ui/raidboss/data/06-ew/dungeon/stigma_dreamscape.txt
+++ b/ui/raidboss/data/06-ew/dungeon/stigma_dreamscape.txt
@@ -12,7 +12,7 @@ hideall "--sync--"
 #~~~~~~~~~~~~~#
 
 # A-4 Command will be sealed off
-0.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:ECF/ window 0,1
+0.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:ECF:/ window 0,1
 12.6 "Side Cannons" sync / 1[56]:[^:]*:Proto-Omega:(6320|6321):/ window 12.6,10
 24.2 "Forward Interceptors/Rear Interceptors" sync / 1[56]:[^:]*:Proto-Omega:(6322|6324):/
 29.3 "Chemical Missile" sync / 1[56]:[^:]*:Proto-Omega:6328:/
@@ -45,7 +45,7 @@ hideall "--sync--"
 # -ii 368 63AE 63B2
 
 # A-4 Conquest will be sealed off
-1000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:ED0/ window 1000,10
+1000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:ED0:/ window 1000,10
 1010.7 "Wheel" sync / 1[56]:[^:]*:Arch-Lambda:63B5:/ window 1010.7,10
 1021.0 "--sync--" sync / 1[56]:[^:]*:Arch-Lambda:63AA:/
 1028.4 "Auto-mobile Assault Cannon" sync / 1[56]:[^:]*:Arch-Lambda:63AB:/
@@ -85,7 +85,7 @@ hideall "--sync--"
 # -ii 6435
 
 # A-4 Headquarters will be sealed off
-2000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:ED2/ window 2000,1
+2000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:ED2:/ window 2000,1
 2010.0 "AI Takeover" sync / 1[56]:[^:]*:Stigma-4:6429:/
 2015.6 "Touchdown?" sync / 1[56]:[^:]*:Hybrid Dragon:68F9:/
 2024.7 "Proto-wave Cannon?" sync / 1[56]:[^:]*:Omega Frame:(642A|642B):/

--- a/ui/raidboss/data/06-ew/dungeon/the_aitiascope.txt
+++ b/ui/raidboss/data/06-ew/dungeon/the_aitiascope.txt
@@ -16,7 +16,7 @@ hideall "--sync--"
 # -ii 60C3 6444 6446
 
 # Central Observatory will be sealed off
-1000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:F98/ window 10000,0
+1000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:F98:/ window 10000,0
 1012.0 "Frustration" sync / 1[56]:[^:]*:Livia the Undeterred:6448:/
 1022.2 "Aglaea Bite" sync / 1[56]:[^:]*:Livia the Undeterred:6449:/
 1029.3 "--middle--"
@@ -66,7 +66,7 @@ hideall "--sync--"
 # -ii 6454
 
 # Saltcrystal Strings will be sealed off
-2000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:F99/ window 10000,0
+2000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:F99:/ window 10000,0
 2012.0 "Tartarean Impact" sync / 1[56]:[^:]*:Rhitahtyn the Unshakable:6455:/
 2020.5 "Tartarean Spark" sync / 1[56]:[^:]*:Rhitahtyn the Unshakable:6457:/
 
@@ -115,7 +115,7 @@ hideall "--sync--"
 # -ii 6088
 
 # Midnight Downwell will be sealed off
-3000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:F9A/ window 10000,0
+3000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:F9A:/ window 10000,0
 3012.0 "Dark Forte" sync / 1[56]:[^:]*:Amon the Undying:6464:/
 3022.2 "Thundaga Forte (proximity)" sync / 1[56]:[^:]*:Amon the Undying:645A:/
 3028.0 "Thundaga Forte 1" sync / 1[56]:[^:]*:Amon the Undying:645B:/

--- a/ui/raidboss/data/06-ew/dungeon/the_dead_ends.txt
+++ b/ui/raidboss/data/06-ew/dungeon/the_dead_ends.txt
@@ -14,7 +14,7 @@ hideall "--sync--"
 # -ii 6542 6EBC 6544 653E
 
 # Shell Mound will be sealed off
-1000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:1008/ window 10000,0
+1000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:1008:/ window 10000,0
 1013.1 "--sync--" sync / 14:[^:]*:Caustic Grebuloff:653C:/
 1018.1 "Miasmata" sync / 1[56]:[^:]*:Caustic Grebuloff:653C:/
 1028.5 "Necrotic Fluid" sync / 1[56]:[^:]*:Weeping Miasma:653F:/ duration 10.6
@@ -46,7 +46,7 @@ hideall "--sync--"
 hideall "Disengage Hatch"
 
 # Deterrence Grounds will be sealed off
-2000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:1009/ window 10000,0
+2000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:1009:/ window 10000,0
 2007.0 "--sync--" sync / 14:[^:]*:Peacekeeper:6550:/
 2012.0 "Decimation" sync / 1[56]:[^:]*:Peacekeeper:6550:/
 2018.1 "Electromagnetic Repellant" sync / 1[56]:[^:]*:Peacekeeper:6EC8:/
@@ -97,7 +97,7 @@ hideall "Disengage Hatch"
 # -ii 655A 655C 655F
 
 # The World Tree will be sealed off
-3000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:100A/ window 10000,0
+3000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:100A:/ window 10000,0
 3008.5 "--sync--" sync / 14:[^:]*:Ra-la:655E:/
 3013.5 "Warm Glow" sync / 1[56]:[^:]*:Ra-la:655E:/
 3023.7 "Pity" sync / 1[56]:[^:]*:Ra-la:655D:/

--- a/ui/raidboss/data/06-ew/dungeon/the_fell_court_of_troia.txt
+++ b/ui/raidboss/data/06-ew/dungeon/the_fell_court_of_troia.txt
@@ -17,7 +17,7 @@ hideall "--sync--"
 # Hard to tell if there's a time based push, but have seen it push when some adds still alive?
 
 # Penitence will be sealed off
-1000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:1058/ window 10000,0
+1000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:1058:/ window 10000,0
 
 1200.0 "--sync--" sync / 14:[^:]*:Evil Dreamer:73B8:/ window 200,0
 1208.0 "Dark Vision" sync / 1[56]:[^:]*:Evil Dreamer:73B8:/
@@ -50,7 +50,7 @@ hideall "--sync--"
 # TODO: Beatific Scorn is 747 + 5/8/4/7, or 3/8/6/7, are these directions??
 
 # Seat of the Foremost will be sealed off
-2000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:1059/ window 10000,0
+2000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:1059:/ window 10000,0
 2011.3 "--middle--" sync / 1[56]:[^:]*:Beatrice:747C:/
 2016.5 "Eye of Troia" sync / 1[56]:[^:]*:Beatrice:747A:/
 2022.5 "Death Foreseen" sync / 1[56]:[^:]*:Beatrice:747D:/
@@ -107,7 +107,7 @@ hideall "--sync--"
 # -it "Scarmiglione"
 
 # The Garden of Epopts will be sealed off
-3000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:105A/ window 10000,0
+3000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:105A:/ window 10000,0
 3005.1 "--sync--" sync / 1[56]:[^:]*:Scarmiglione:7631:/ window 10,10
 3009.1 "Cursed Echo" sync / 1[56]:[^:]*:Scarmiglione:7631:/
 3016.3 "--sync--" sync / 1[56]:[^:]*:Scarmiglione:761D:/

--- a/ui/raidboss/data/06-ew/dungeon/the_lunar_subterrane.txt
+++ b/ui/raidboss/data/06-ew/dungeon/the_lunar_subterrane.txt
@@ -15,7 +15,7 @@ hideall "--sync--"
 # -ii  87E5 89B6 87DF
 
 # Cloven Crystal Square will be sealed off
-1000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:1153/ window 10000,0
+1000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:1153:/ window 10000,0
 1006.0 "--sync--" sync / 14:[^:]*:Dark Elf:87D9:/ window 10,10
 1009.0 "Hexing Staves" sync / 1[56]:[^:]*:Dark Elf:87D9:/
 1017.1 "Ruinous Confluence" sync / 1[56]:[^:]*:Dark Elf:8985:/
@@ -68,7 +68,7 @@ hideall "--sync--"
 # Note: timing is the same, even once all towers have fallen
 
 # Bloodied Barbican will be sealed off
-2000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:1154/ window 10000,0
+2000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:1154:/ window 10000,0
 2009.5 "--sync--" sync / 14:[^:]*:Damcyan Antlion:87FD:/ window 10,10
 2014.5 "Sandblast" sync / 1[56]:[^:]*:Damcyan Antlion:87FD:/
 2023.6 "Landslip" sync / 1[56]:[^:]*:Damcyan Antlion:8802:/
@@ -152,7 +152,7 @@ hideall "--sync--"
 # -ii 8CDA 88B2 88B6 8CD8 88C0 88B9 8C20 88B4
 
 # Carnelian Courtyard will be sealed off
-3000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:1155/ window 10000,0
+3000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:1155:/ window 10000,0
 3007.3 "--sync--" sync / 14:[^:]*:Durante:88C3:/ window 10,10
 3012.3 "Old Magic" sync / 1[56]:[^:]*:Durante:88C3:/
 3014.4 "--middle--" sync / 1[56]:[^:]*:Durante:88AF:/

--- a/ui/raidboss/data/06-ew/dungeon/the_sildihn_subterrane.txt
+++ b/ui/raidboss/data/06-ew/dungeon/the_sildihn_subterrane.txt
@@ -11,7 +11,7 @@ hideall "--sync--"
 # -ii 7A1C 74D3
 
 # Silt Pump will be sealed off
-1000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:1068/ window 100000,0
+1000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:1068:/ window 100000,0
 1005.6 "--sync--" sync / 14:[^:]*:Geryon the Steer:74CF:/
 1010.6 "Colossal Strike" sync / 1[56]:[^:]*:Geryon the Steer:74CF:/
 
@@ -143,7 +143,7 @@ hideall "--sync--"
 # -ii 7A1C 74D3
 
 # Sifting Site will be sealed off
-3000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:1070/ window 100000,0
+3000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:1070:/ window 100000,0
 3005.0 "--sync--" sync / 14:[^:]*:Geryon the Steer:74CF:/
 3010.0 "Colossal Strike" sync / 1[56]:[^:]*:Geryon the Steer:74CF:/
 3019.1 "Exploding Catapult" sync / 1[56]:[^:]*:Geryon the Steer:74C7:/
@@ -281,7 +281,7 @@ hideall "--sync--"
 # -ii 7A1C 74D3
 
 # Settling Basin will be sealed off
-5000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:106D/ window 100000,0
+5000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:106D:/ window 100000,0
 5005.0 "--sync--" sync / 14:[^:]*:Geryon the Steer:74CF:/
 5010.0 "Colossal Strike" sync / 1[56]:[^:]*:Geryon the Steer:74CF:/
 
@@ -411,7 +411,7 @@ hideall "--sync--"
 # -ii 772F 7730 7731 7732 7733 7734 7743 7749 7741 7746 774B 774C 77C0
 
 # Forgotten Forecourt will be sealed off
-7000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:1069/ window 100000,0
+7000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:1069:/ window 100000,0
 7009.3 "--sync--" sync / 14:[^:]*:Silkie:772C:/ window 10,10
 7014.3 "Total Wash" sync / 1[56]:[^:]*:Silkie:772C:/
 7022.0 "Squeaky Left/Squeaky Right" sync / 1[56]:[^:]*:Silkie:(772E|772D):/
@@ -516,7 +516,7 @@ hideall "--sync--"
 # -ii 764E 763A 763B 763C 764D 7654 7655
 
 # The Cornice of Favor will be sealed off
-8000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:1071/ window 100000,0
+8000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:1071:/ window 100000,0
 8007.0 "--sync--" sync / 14:[^:]*:Gladiator of Sil'dih:7656:/ window 20,20
 8012.0 "Flash of Steel" sync / 1[56]:[^:]*:Gladiator of Sil'dih:7656:/
 8019.2 "--middle--" sync / 1[56]:[^:]*:Gladiator of Sil'dih:7639:/
@@ -615,7 +615,7 @@ hideall "--sync--"
 # -ii 7498 7497 74
 
 # Eternal Ease will be sealed off
-9000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:106E/ window 100000,0
+9000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:106E:/ window 100000,0
 9010.6 "--sync--" sync / 14:[^:]*:Shadowcaster Zeless Gah:74AE:/ window 20,20
 9015.6 "Show of Strength" sync / 1[56]:[^:]*:Shadowcaster Zeless Gah:74AE:/
 
@@ -634,7 +634,7 @@ hideall "--sync--"
 ### Path 05
 # Note: this could be combined with Path 07 with knockback/draw-in replacements
 # Eternal Ease will be sealed off
-10000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:106E/
+10000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:106E:/
 10010.6 "--sync--" sync / 14:[^:]*:Shadowcaster Zeless Gah:74AE:/ window 20,20
 10015.6 "Show of Strength" sync / 1[56]:[^:]*:Shadowcaster Zeless Gah:74AE:/
 10019.7 "--sync--" sync / 14:[^:]*:Shadowcaster Zeless Gah:74A2:/
@@ -721,7 +721,7 @@ hideall "--sync--"
 
 ### Path 06
 # Eternal Ease will be sealed off
-11000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:106E/
+11000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:106E:/
 11010.6 "--sync--" sync / 14:[^:]*:Shadowcaster Zeless Gah:74AE:/ window 20,20
 11015.6 "Show of Strength" sync / 1[56]:[^:]*:Shadowcaster Zeless Gah:74AE:/
 # 2 static portals
@@ -808,7 +808,7 @@ hideall "--sync--"
 ### Path 07
 # Note: this could be combined with Path 05 with knockback/draw-in replacements
 # Eternal Ease will be sealed off
-12000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:106E/
+12000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:106E:/
 12010.6 "--sync--" sync / 14:[^:]*:Shadowcaster Zeless Gah:74AE:/ window 20,20
 12015.6 "Show of Strength" sync / 1[56]:[^:]*:Shadowcaster Zeless Gah:74AE:/
 12019.7 "--sync--" sync / 14:[^:]*:Shadowcaster Zeless Gah:74A7:/
@@ -908,7 +908,7 @@ hideall "--sync--"
 # It's possible that 70EF/7102 are "normal" and 70F0/70F1 are reversed.
 
 # Cold Arms' Quietus will be sealed off
-13000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:1076/ window 100000,0
+13000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:1076:/ window 100000,0
 13011.8 "--sync--" sync / 14:[^:]*:Thorne Knight:70EB:/
 13016.8 "Cogwheel" sync / 1[56]:[^:]*:Thorne Knight:70EB:/
 13030.3 "Spring to Life" sync / 1[56]:[^:]*:Thorne Knight:(70ED|70EE):/

--- a/ui/raidboss/data/06-ew/dungeon/the_tower_of_babil.txt
+++ b/ui/raidboss/data/06-ew/dungeon/the_tower_of_babil.txt
@@ -15,7 +15,7 @@ hideall "--sync--"
 
 # Common opener
 # Magitek Servicing will be sealed off
-0.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:101C/ window 0,1
+0.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:101C:/ window 0,1
 5.7 "--sync--" sync / 14:[^:]*:Barnabas:6247:/ window 5.7,5
 8.9 "Ground and Pound" sync / 1[56]:[^:]*:Barnabas:6247:/
 27.3 "Ground and Pound" sync / 1[56]:[^:]*:Barnabas:62EA:/
@@ -89,7 +89,7 @@ hideall "--sync--"
 #~~~~~~~~~~~#
 
 # Martial Conditioning will be sealed off
-1000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:101D/ window 1000,5
+1000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:101D:/ window 1000,5
 1009.7 "Thermal Suppression" sync / 1[56]:[^:]*:Lugae:62FA:/ window 1009.7,10
 1018.2 "Magitek Missile" sync / 1[56]:[^:]*:Lugae:62F6:/
 1022.5 "Surface Missile" sync / 1[56]:[^:]*:Lugae:62F7:/
@@ -143,7 +143,7 @@ hideall "--sync--"
 # -ii 52BE 5E68 6305
 
 # The Iron Womb will be sealed off
-2000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:101E/ window 2000,1
+2000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:101E:/ window 2000,1
 2009.8 "Lunar Nail" sync / 1[56]:[^:]*:Anima:62FE:/ window 2009.8,10
 2020.7 "Phantom Pain" sync / 1[56]:[^:]*:Anima:62FF:/
 2029.8 "Mega Graviton" sync / 1[56]:[^:]*:Anima:6300:/

--- a/ui/raidboss/data/06-ew/dungeon/the_tower_of_zot.txt
+++ b/ui/raidboss/data/06-ew/dungeon/the_tower_of_zot.txt
@@ -14,7 +14,7 @@ hideall "--sync--"
 
 ## Fixed-ish opening block
 # Ingenuity's Ingress will be sealed off
-0.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:E95/ window 0,1
+0.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:E95:/ window 0,1
 8.9 "Manusya Bio" sync / 1[56]:[^:]*:Minduruva:62A0:/ window 8.9,5
 12.1 "--sync--" sync / 1[56]:[^:]*:Minduruva:6299:/
 17.5 "Manusya Blizzard III" sync / 1[56]:[^:]*:Minduruva:6296:/
@@ -88,7 +88,7 @@ hideall "--sync--"
 
 # Opening block
 # Prosperity's Promise will be sealed off
-1000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:E96/ window 1000,5
+1000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:E96:/ window 1000,5
 1009.3 "Isitva Siddhi" sync / 1[56]:[^:]*:Sanduruva:62A9:/ window 1009.3,5
 1015.7 "Prapti Siddhi #1" sync / 1[56]:[^:]*:Sanduruva:62A8:/
 1019.6 "Prapti Siddhi #2" #sync / 1[56]:[^:]*:Sanduruva:62A8:/
@@ -130,7 +130,7 @@ hideall "--sync--"
 # we sync aggressively all over the rotation block.
 
 # Wisdom's Ward will be sealed off
-2000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:E97/ window 2000,5
+2000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:E97:/ window 2000,5
 2002.5 "--sync--" sync / 1[56]:[^:]*:Cinduruva:62BA:/ window 2002.5,2
 2009.8 "Samsara" sync / 1[56]:[^:]*:Cinduruva:62B9:/
 2025.6 "Manusya Faith" sync / 1[56]:[^:]*:Sanduruva:62AA:/

--- a/ui/raidboss/data/06-ew/dungeon/vanaspati.txt
+++ b/ui/raidboss/data/06-ew/dungeon/vanaspati.txt
@@ -14,7 +14,7 @@ hideall "--sync--"
 # -ii 366 6291 6292
 
 # Trnakiya will be sealed off
-0.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:FAC/ window 0,1
+0.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:FAC:/ window 0,1
 7.1 "--sync--" sync / 14:[^:]*:Terminus Snatcher:6238:/ window 10,10
 12.1 "Note of Despair" sync / 1[56]:[^:]*:Terminus Snatcher:6238:/
 19.6 "Mouth Off" sync / 1[56]:[^:]*:Terminus Snatcher:6231:/
@@ -52,7 +52,7 @@ hideall "--sync--"
 # Note: 623F is also called "Poison Heart" but that's when the stack marker appears.
 
 # Insight will be sealed off
-1000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:FAD/ window 1000,0
+1000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:FAD:/ window 1000,0
 1006.2 "--sync--" sync / 14:[^:]*:Terminus Wrecker:6241:/ window 1010,10
 1011.2 "Meaningless Destruction" sync / 1[56]:[^:]*:Terminus Wrecker:6241:/
 1021.4 "Unholy Water" sync / 1[56]:[^:]*:Terminus Wrecker:6CCC:/
@@ -99,7 +99,7 @@ hideall "--sync--"
 hideall "Crumbling Sky"
 
 # Devatagara will be sealed off
-2000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:FAE/ window 2000,0
+2000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:FAE:/ window 2000,0
 2005.1 "--sync--" sync / 14:[^:]*:Svarbhanu:6252:/ window 2020,10
 2010.1 "Flames of Decay" sync / 1[56]:[^:]*:Svarbhanu:6252:/
 2018.0 "Chaotic Pulse" sync / 1[56]:[^:]*:Svarbhanu:6B61:/


### PR DESCRIPTION
This is a minor typo fix for #5966.

```diff
-1000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:10F8/ window 10000,0
+1000.0 "--sync--" sync / 29:[^:]*:7DC:[^:]*:10F8:/ window 10000,0
```

This was done by script.