### PR TITLE
lint: include package-lock.json for linting

### DIFF
--- a/dprint.json
+++ b/dprint.json
@@ -9,8 +9,7 @@
     "./dist/",
     "./npm-package/",
     "./plugin/ThirdParty/",
-    "./publish/",
-    "**/*-lock.json"
+    "./publish/"
   ],
   "lineWidth": 100,
   "useTabs": false,


### PR DESCRIPTION
It was excluded before, but lint-staged considers *.json as something to lint, and so modifying it would cause lint-staged to complain.