### PR TITLE
raidboss: timeline netregex for AddedCombatant

### DIFF
--- a/ui/raidboss/data/02-arr/raid/t4.txt
+++ b/ui/raidboss/data/02-arr/raid/t4.txt
@@ -1,22 +1,22 @@
 ### T4
 # http://forum.square-enix.com/ffxiv/threads/103985-EXTREME-BINDING-COIL-OF-BAHAMUT-TURN-4-GUIDE
 
-0.0 "6x Bug" sync / 03:........:Clockwork Bug:/  window 0,1
+0.0 "6x Bug" AddedCombatant { name: "Clockwork Bug" }  window 0,1
 
-63.0 "Knight + Soldier (NW)" sync / 03:........:Clockwork Knight:/  window 70,0
+63.0 "Knight + Soldier (NW)" AddedCombatant { name: "Clockwork Knight" }  window 70,0
 63.0 "Knight + Soldier (NE)"
 
-123.0 "Dreadnaught (NW)" sync / 03:........:Clockwork Dreadnaught:/  window 130,0
+123.0 "Dreadnaught (NW)" AddedCombatant { name: "Clockwork Dreadnaught" }  window 130,0
 123.0 "4x Bug (S)"
 
-183.0 "2x Rook (E/W)" sync / 03:........:Spinner-rook:/  window 190,0
+183.0 "2x Rook (E/W)" AddedCombatant { name: "Spinner-rook" }  window 190,0
 183.0 "4x Bug (outside)"
 
-243.0 "Dreadnaught (NE)" sync / 03:........:Clockwork Dreadnaught:/  window 115,0
+243.0 "Dreadnaught (NE)" AddedCombatant { name: "Clockwork Dreadnaught" }  window 115,0
 243.0 "Soldier (center)"
 243.0 "Knight (SE)"
 
-303.0 "Dreadnaught (NE)" sync / 03:........:Clockwork Dreadnaught:/  window 55,0
+303.0 "Dreadnaught (NE)" AddedCombatant { name: "Clockwork Dreadnaught" }  window 55,0
 303.0 "Knight (center)"
 303.0 "Soldier (SW)"
 303.0 "Rook (NE)"

--- a/ui/raidboss/data/02-arr/trial/shiva-ex.txt
+++ b/ui/raidboss/data/02-arr/trial/shiva-ex.txt
@@ -136,7 +136,7 @@ hideall "--Reset--"
 801.0 "--sync--" #Ability { id: "C7F", source: "Shiva" }
 # If you push *really* fast and skip a 3a/3b weapon phase, you'll miss the melt jump.
 # So, fix that up with a combatant sync here.
-806.6 "--adds targetable--" sync / 03:........:Ice Soldier:/  window 807,10
+806.6 "--adds targetable--" AddedCombatant { name: "Ice Soldier" }  window 807,10
 807.6 "Dreams Of Ice" Ability { id: "BEA", source: "Shiva" }
 813.2 "Frost Blade" Ability { id: "993", source: "Shiva" }
 818.5 "Icebrand" Ability { id: "BE1", source: "Shiva" }

--- a/ui/raidboss/data/02-arr/trial/shiva-hm.txt
+++ b/ui/raidboss/data/02-arr/trial/shiva-hm.txt
@@ -66,7 +66,7 @@ hideall "--Reset--"
 800.0 "Melt" Ability { id: "994", source: "Shiva" } window 800,0
 # If you push *really* fast and skip a weapon phase, you'll miss the melt jump.
 # So, fix that up with a combatant sync here.
-806.2 "--adds targetable--" sync / 03:........:Ice Soldier:/  window 807,2.5
+806.2 "--adds targetable--" AddedCombatant { name: "Ice Soldier" }  window 807,2.5
 809.9 "Dreams Of Ice" Ability { id: "99D", source: "Shiva" }
 
 # Note: Yes, really.  These times are different.

--- a/ui/raidboss/data/03-hw/alliance/dun_scaith.txt
+++ b/ui/raidboss/data/03-hw/alliance/dun_scaith.txt
@@ -291,7 +291,7 @@ hideall "--sync--"
 
 # Intermission at 45% HP. Might be a time push too? but it's uncertain.
 3300.0 "--untargetable--" sync / 22:........:Scathach:........:Scathach:00/ window 300,5
-3302.2 "--sync--" sync / 03:........:Shadowcourt Jester:/  window 300,5
+3302.2 "--sync--" AddedCombatant { name: "Shadowcourt Jester" }  window 300,5
 3323.6 "--towers appear--"
 3333.6 "Particle Beam" Ability { id: "1D2[78]", source: "Scathach" }
 
@@ -403,9 +403,9 @@ hideall "--sync--"
 # This is the dueling-lasers part where the party kills the big deathgate and two small ones.
 
 4274.0 "--sync--" sync / 22:........:Diabolos:........:Diabolos:00/ window 100,5
-4286.2 "--lifegate spawn--" sync / 03:........:Lifegate:/  window 300,5
+4286.2 "--lifegate spawn--" AddedCombatant { name: "Lifegate" }  window 300,5
 4300.0 "--sync--" Ability { id: "1C16", source: "Diabolos" } window 300,5
-4320.0 "--deathgate spawn--" sync / 03:........:Deathgate:/  window 50,5
+4320.0 "--deathgate spawn--" AddedCombatant { name: "Deathgate" }  window 50,5
 4477.1 "--sync--" Ability { id: "1AFB", source: "Diabolos" } window 177,5
 4488.5 "--sync--" Ability { id: "1AFD", source: "Diabolos" }
 4494.6 "Dream Shroud" Ability { id: "1DB1", source: "Diabolos Hollow" } window 194,5
@@ -452,7 +452,7 @@ hideall "--sync--"
 4613.6 "Shadethrust" Ability { id: "1C1A", source: "Diabolos Hollow" }
 4620.4 "Particle Beam" Ability { id: "1C2[456]", source: "Diabolos Hollow" }
 4620.8 "Hollow Camisado" Ability { id: "1C19", source: "Diabolos Hollow" }
-4624.1 "--deathgate spawn--" sync / 03:........:Deathgate:/  window 25,5
+4624.1 "--deathgate spawn--" AddedCombatant { name: "Deathgate" }  window 25,5
 4627.1 "Hollowshield" Ability { id: "1C1E", source: "Diabolos Hollow" } window 27.1,5
 4637.5 "Hollow Camisado" Ability { id: "1C19", source: "Diabolos Hollow" }
 4646.8 "Shadethrust" Ability { id: "1C1A", source: "Diabolos Hollow" } window 20,10

--- a/ui/raidboss/data/03-hw/dungeon/aetherochemical_research_facility.txt
+++ b/ui/raidboss/data/03-hw/dungeon/aetherochemical_research_facility.txt
@@ -415,7 +415,7 @@ hideall "--sync--"
 3092.6 "Height Of Chaos"
 
 # Intermission 1 at HP < 80%
-3100.0 "--sync--" sync / 03:........:Firesphere:/  window 100,5
+3100.0 "--sync--" AddedCombatant { name: "Firesphere" }  window 100,5
 
 3110.0 "Ancient Circle Appears"
 3115.1 "Ancient Circle" Ability { id: "1102", source: "Ascian Prime" }
@@ -442,7 +442,7 @@ hideall "--sync--"
 3260.0 "Shadow Flare"
 
 # Intermission 2 at HP < 40%
-3300.0 "--sync--" sync / 03:........:Firesphere:/  window 200,5
+3300.0 "--sync--" AddedCombatant { name: "Firesphere" }  window 200,5
 
 3304.6 "Ancient Circle Appears"
 3309.7 "Ancient Circle" Ability { id: "1102", source: "Ascian Prime" }

--- a/ui/raidboss/data/03-hw/raid/a11s.txt
+++ b/ui/raidboss/data/03-hw/raid/a11s.txt
@@ -22,7 +22,7 @@ hideall "--sync--"
 40.6 "Spin Crusher" Ability { id: "1A85", source: "Cruise Chaser" }
 
 # skippable
-45.8 "E.D.D. Add" sync / 03:........:E\.D\.D\.:/ window 50,5
+45.8 "E.D.D. Add" AddedCombatant { name: "E\\.D\\.D\\." } window 50,5
 
 # If we jump to this laser sword immediately after first, the timing is:
 # 9.2 (first sword) 21.7 (second sword)
@@ -135,7 +135,7 @@ hideall "--sync--"
 450.9 "Laser X Sword" Ability { id: "1A7F", source: "Cruise Chaser" }
 
 # maybe skippable
-458.7 "E.D.D. Add" sync / 03:........:E\.D\.D\.:/
+458.7 "E.D.D. Add" AddedCombatant { name: "E\\.D\\.D\\." }
 462.0 "Photon (dps)" Ability { id: "1A73", source: "Cruise Chaser" }
 470.2 "Whirlwind" Ability { id: "1A84", source: "Cruise Chaser" }
 
@@ -151,7 +151,7 @@ hideall "--sync--"
 505.2 "Transform" Ability { id: "1A49", source: "Cruise Chaser" }
 513.0 "--sync--" Ability { id: "1A4A", source: "Cruise Chaser" }
 517.8 "Blassty Blaster" Ability { id: "1A69", source: "Cruise Chaser" }
-520.8 "Multifield x3" sync / 03:........:Multifield:/
+520.8 "Multifield x3" AddedCombatant { name: "Multifield" }
 523.9 "Transform" Ability { id: "1A4E", source: "Cruise Chaser" }
 529.9 "Perfect Landing" Ability { id: "1A6B", source: "Cruise Chaser" }
 
@@ -194,7 +194,7 @@ hideall "--sync--"
 683.0 "--targetable--"
 
 693.2 "Laser X Sword" Ability { id: "1A7F", source: "Cruise Chaser" }
-697.2 "E.D.D. Add" sync / 03:........:E\.D\.D\.:/
+697.2 "E.D.D. Add" AddedCombatant { name: "E\\.D\\.D\\." }
 705.4 "Photon (dps)" Ability { id: "1A73", source: "Cruise Chaser" }
 714.6 "Left/Right Laser Sword" Ability { id: "1A7[A9]", source: "Cruise Chaser" }
 722.7 "Photon (healer)" Ability { id: "1A73", source: "Cruise Chaser" }

--- a/ui/raidboss/data/03-hw/raid/a12s.txt
+++ b/ui/raidboss/data/03-hw/raid/a12s.txt
@@ -34,7 +34,7 @@ hideall "--sync--"
 124.9 "Almost Holy" Ability { id: "19F7", source: "The General's Wing" }
 133.2 "Almost Holy" Ability { id: "19F7", source: "The General's Wing" }
 
-139.2 "The General's Might (W)" sync / 03:........:The General's Might:/  window 150,5
+139.2 "The General's Might (W)" AddedCombatant { name: "The General's Might" }  window 150,5
 139.2 "The General's Time (E)"
 141.6 "Almost Holy?" Ability { id: "19F7", source: "The General's Wing" }
 150.4 "Smash" Ability { id: "19F3", source: "The General's Might" } window 151,3

--- a/ui/raidboss/data/03-hw/raid/a2s.txt
+++ b/ui/raidboss/data/03-hw/raid/a2s.txt
@@ -18,7 +18,7 @@ hideall "--sync--"
 
 
 # Wave 2 (timed push)
-20.3 "--Wave 2--" sync / 03:........:Gordian Hardmind:/  window 21,5
+20.3 "--Wave 2--" AddedCombatant { name: "Gordian Hardmind" }  window 21,5
 20.3 "Sniper, Soldier x2 (NW)"
 20.3 "Hardmind (SW)"
 
@@ -26,7 +26,7 @@ hideall "--sync--"
 
 
 # Wave 3 (timed push)
-80.2 "--Wave 3--" sync / 03:........:Gordian Hardhelm:/  window 70,70
+80.2 "--Wave 3--" AddedCombatant { name: "Gordian Hardhelm" }  window 70,70
 80.2 "Hardhelm, Soldier (SW)"
 80.2 "Hardmind, Sniper, Soldier 2x (N)"
 
@@ -35,7 +35,7 @@ hideall "--sync--"
 
 
 # Wave 4 (triggered push)
-2000.0 "--Wave 4--" sync / 03:........:Boomtype Magitek Gobwalker G-VII:/  window 2000,0
+2000.0 "--Wave 4--" AddedCombatant { name: "Boomtype Magitek Gobwalker G-VII" }  window 2000,0
 2000.0 "Gobwalker (NE)"
 2000.0 "Sniper x2, Soldier x2 (mid)"
 
@@ -46,7 +46,7 @@ hideall "--sync--"
 
 
 # Wave 5 (timed push)
-2095.5 "--Wave 5--" sync / 03:........:Magitek Gobwidow G-IX:/  window 2070,100
+2095.5 "--Wave 5--" AddedCombatant { name: "Magitek Gobwidow G-IX" }  window 2070,100
 2095.5 "Gobwidow (N)"
 2095.5 "Gobwidow (S)"
 2095.5 "Soldier x2 (SW)"
@@ -62,7 +62,7 @@ hideall "--sync--"
 
 
 # Wave 6 (timed push)
-2168.0 "--Wave 6--" sync / 03:........:Jagd Doll:/  window 2170,100
+2168.0 "--Wave 6--" AddedCombatant { name: "Jagd Doll" }  window 2170,100
 2168.0 "Jagd Doll (NE)"
 2168.0 "Gobwalker (N)"
 2168.0 "Hardhelm (SW)"
@@ -94,7 +94,7 @@ hideall "--sync--"
 
 
 # Wave 7 (triggered push)
-3000.0 "--Wave 7--" sync / 03:........:Jagd Doll:/  window 825,0
+3000.0 "--Wave 7--" AddedCombatant { name: "Jagd Doll" }  window 825,0
 3000.0 "Jagd Doll x4 (mid)"
 
 3006.2 "Kaltstrahl" #Ability { id: "FD4", source: "Jagd Doll" }
@@ -112,7 +112,7 @@ hideall "--sync--"
 
 # Wave 8 (timed push)
 # TODO: include additional jagd doll stuff into here?
-3080.7 "--Wave 8--" sync / 03:........:Gordian Sniper:/  window 1075,100
+3080.7 "--Wave 8--" AddedCombatant { name: "Gordian Sniper" }  window 1075,100
 3080.7 "Sniper x3, Soldier (SW)"
 3080.7 "Hardmind (N)"
 3080.7 "Hardhelm (SE)"
@@ -126,7 +126,7 @@ hideall "--sync--"
 
 
 # Wave 9 (triggered push)
-4000.0 "--Wave 9--"  sync / 03:........:Magitek Gobwidow G-IX:/  window 1900,0
+4000.0 "--Wave 9--"  AddedCombatant { name: "Magitek Gobwidow G-IX" }  window 1900,0
 4000.0 "Gobwidow (NW)"
 4000.0 "Gobwidow, Jagd Doll (SW)"
 4000.0 "Gobwalker (NE)"
@@ -165,7 +165,7 @@ hideall "--sync--"
 
 
 # Enrage
-5000.0 "--sync--" sync / 03:........:Giant Bomb:/  window 5000,0
+5000.0 "--sync--" AddedCombatant { name: "Giant Bomb" }  window 5000,0
 5010.0 "Massive Explosion Enrage" Ability { id: "FDD", source: "Giant Bomb" }
 
 # Technically this loops, and has a special dialog where Quickthinx says:

--- a/ui/raidboss/data/03-hw/raid/a6s.txt
+++ b/ui/raidboss/data/03-hw/raid/a6s.txt
@@ -82,7 +82,7 @@ hideall "Ballistic Missile"
 
 ## Brawler Orb Phase
 1500.0 "--sync--" sync / 22:........:Brawler:........:Brawler:00/ window 500,0
-1503.4 "Power Plasma Alpha x2" sync / 03:........:Power Plasma Alpha:/  window 500,5
+1503.4 "Power Plasma Alpha x2" AddedCombatant { name: "Power Plasma Alpha" }  window 500,5
 1503.4 "Power Plasma Gamma x2"
 
 1508.6 "Attachment" Ability { id: "1601", source: "Brawler" }

--- a/ui/raidboss/data/03-hw/raid/a7s.txt
+++ b/ui/raidboss/data/03-hw/raid/a7s.txt
@@ -86,7 +86,7 @@ hideall "--sync--"
 249 "Stun Heart"
 249 "Sizzlebeam"
 258 "Sizzlespark" #can be skipped
-266 "Bomb x1" sync / 03:........:Bomb:/  window 50 jump 561
+266 "Bomb x1" AddedCombatant { name: "Bomb" }  window 50 jump 561
 267 ""
 267 ""
 267 ""
@@ -126,7 +126,7 @@ hideall "--sync--"
 
 ############################################
 ################# Version 1 - Phase 3
-561 "Bomb x1" sync / 03:........:Bomb:/  window 50,20
+561 "Bomb x1" AddedCombatant { name: "Bomb" }  window 50,20
 567 "Jails" #Green Prey & Red Tether
 570 "Zoomdoom" Ability { id: "15BE", source: "Quickthinx Allthoughts" } window 60
 570 "Doll"
@@ -171,7 +171,7 @@ hideall "--sync--"
 903 "Stun Heart"
 909 "Sizzlespark"
 917 "Sizzlespark"
-923 "Bombs / Sizzlebeam" sync / 03:........:Bomb:/  window 20 jump 1326
+923 "Bombs / Sizzlebeam" AddedCombatant { name: "Bomb" }  window 20 jump 1326
 924 "" Ability { id: "15EE", source: "Quickthinx Allthoughts" } window 20 jump 1526
 924 ""
 924 ""

--- a/ui/raidboss/data/03-hw/raid/a8n.txt
+++ b/ui/raidboss/data/03-hw/raid/a8n.txt
@@ -48,7 +48,7 @@ hideall "Brute Force"
 # so we just do one full rotation and hope for the best.
 # If it would have looped past here, there are bigger problems!
 200.0 "--sync--" sync / 22:........:Onslaughter:........:Onslaughter:00/ window 200,0
-203.8 "--sync--" sync / 03:........:Brawler:/  window 150,30
+203.8 "--sync--" AddedCombatant { name: "Brawler" }  window 150,30
 206.2 "--targetable--"
 214.3 "Magicked Mark" Ability { id: "173B", source: "Brawler" }
 214.3 "Brute Force" Ability { id: "1744", source: "Vortexer" }
@@ -87,7 +87,7 @@ hideall "Brute Force"
 
 # CUTE ROBOTS 2
 # One full rotation plus a tail again, for the same reasons. Don't be slow!
-500.0 "--sync--" sync / 03:........:Blaster:/  window 300,30
+500.0 "--sync--" AddedCombatant { name: "Blaster" }  window 300,30
 502.1 "--targetable--"
 510.3 "Magicked Mark" Ability { id: "173F", source: "Swindler" }
 510.3 "Brute Force" Ability { id: "1738", source: "Blaster" }
@@ -119,7 +119,7 @@ hideall "Brute Force"
 618.7 "Mind Blast"
 
 # GO, GO, MEGAZORD MODE (BRUTE JUSTICE)
-800.0 "--sync--" sync / 03:........:Brute Justice:/  window 300,30
+800.0 "--sync--" AddedCombatant { name: "Brute Justice" }  window 300,30
 810.3 "--sync--" Ability { id: "1758", source: "Brute Justice" } window 610.3,30
 813.0 "--targetable--"
 826.9 "Double Rocket Punch" Ability { id: "174E", source: "Brute Justice" } window 26,30

--- a/ui/raidboss/data/03-hw/raid/a8s.txt
+++ b/ui/raidboss/data/03-hw/raid/a8s.txt
@@ -62,7 +62,7 @@ hideall "Brute Force"
 
 ### Phase 2: Robots
 300.0 "--sync--" sync / 22:........:Onslaughter:........:Onslaughter:00/ window 300,0
-303.0 "--sync--" sync / 03:........:Blaster:/  window 303,30
+303.0 "--sync--" AddedCombatant { name: "Blaster" }  window 303,30
 304.0 "Blaster (north)"
 304.0 "Brawler (middle)"
 306.2 "--targetable--"

--- a/ui/raidboss/data/03-hw/raid/a9s.txt
+++ b/ui/raidboss/data/03-hw/raid/a9s.txt
@@ -55,7 +55,7 @@ hideall "--sync--"
 2014.3 "Power Generator x2 (NE)"
 2014.3 "Lava (NE)" duration 42
 2023.4 "Scrap" Ability { id: "1A39", source: "Refurbisher 0" }
-2034.4 "--rocks fall--" #sync / 03:........:Scrap:/ 
+2034.4 "--rocks fall--" #AddedCombatant { name: "Scrap" } 
 2039.6 "Scrap Burst" Ability { id: "1A3A", source: "Refurbisher 0" }
 2048.8 "Scrap" Ability { id: "1A39", source: "Refurbisher 0" }
 2055.9 "Scrap" Ability { id: "1A39", source: "Refurbisher 0" }
@@ -83,7 +83,7 @@ hideall "--sync--"
 2173.9 "Lava (SW)" duration 15
 2180.2 "Acid Rain" #Ability { id: "1C0A", source: "Refurbisher 0" }
 2189.3 "Lava (SE)" duration 15
-2195.1 "--rocks fall--" #sync / 03:........:Scrap:/ 
+2195.1 "--rocks fall--" #AddedCombatant { name: "Scrap" } 
 2200.3 "Scrap Burst" Ability { id: "1A3A", source: "Refurbisher 0" }
 
 # Phase 4
@@ -91,7 +91,7 @@ hideall "--sync--"
 2226.5 "Power Generator x1 (SW)"
 2226.5 "Alarum x1 (SW)"
 2226.5 "Lava (SW)" duration 42
-2238.7 "--rocks fall--" #sync / 03:........:Scrap:/ 
+2238.7 "--rocks fall--" #AddedCombatant { name: "Scrap" } 
 2243.9 "Scrap Burst" Ability { id: "1A3A", source: "Refurbisher 0" }
 2253.1 "Scrap" Ability { id: "1A39", source: "Refurbisher 0" }
 2260.2 "Scrap" Ability { id: "1A39", source: "Refurbisher 0" }
@@ -124,7 +124,7 @@ hideall "--sync--"
 2376.4 "Scrap Bomb" Ability { id: "1A3E", source: "Refurbisher 0" }
 2384.6 "Scrap" Ability { id: "1A39", source: "Refurbisher 0" }
 2403.3 "Explosion (NW/SE)" Ability { id: "1A35", source: "Bomb" }
-2398.5 "--rocks fall--" #sync / 03:........:Scrap:/ 
+2398.5 "--rocks fall--" #AddedCombatant { name: "Scrap" } 
 2403.7 "Scrap Burst" Ability { id: "1A3A", source: "Refurbisher 0" }
 
 # Phase 7

--- a/ui/raidboss/data/03-hw/trial/sephirot-ex.txt
+++ b/ui/raidboss/data/03-hw/trial/sephirot-ex.txt
@@ -88,7 +88,7 @@ hideall "--sync--"
 1143.2 "Chesed Gevurah" Ability { id: "(1578|1579)", source: "Sephirot" }
 1143.8 "Life Force + Spirit" Ability { id: "(157A|157B)", source: "Sephirot" }
 1149.4 "Malkuth" Ability { id: "1582", source: "Sephirot" } window 30,30
-1150.5 "Adds Spawn" sync / 03:........:Storm Of Words:/
+1150.5 "Adds Spawn" AddedCombatant { name: "Storm Of Words" }
 1158.7 "Chesed Gevurah" Ability { id: "(1578|1579)", source: "Sephirot" }
 1159.3 "Life Force + Spirit" Ability { id: "(157A|157B)", source: "Sephirot" }
 1164.9 "Fiendish Wail" Ability { id: "1576", source: "Sephirot" }
@@ -128,7 +128,7 @@ hideall "--sync--"
 1340.5 "Chesed Gevurah" Ability { id: "(1578|1579)", source: "Sephirot" }
 1341.1 "Life Force + Spirit" Ability { id: "(157A|157B)", source: "Sephirot" }
 1346.7 "Malkuth" Ability { id: "1582", source: "Sephirot" }
-1347.8 "Adds Spawn" sync / 03:........:Storm Of Words:/
+1347.8 "Adds Spawn" AddedCombatant { name: "Storm Of Words" }
 1356.0 "Chesed Gevurah" Ability { id: "(1578|1579)", source: "Sephirot" }
 1356.6 "Life Force + Spirit" Ability { id: "(157A|157B)", source: "Sephirot" }
 1362.2 "Fiendish Wail" Ability { id: "1576", source: "Sephirot" }

--- a/ui/raidboss/data/03-hw/trial/sophia-ex.txt
+++ b/ui/raidboss/data/03-hw/trial/sophia-ex.txt
@@ -18,7 +18,7 @@ hideall "--sync--"
 41.4 "Arms Of Wisdom?" Ability { id: "19C4", source: "Sophia" } # May be skipped depending on DPS
 
 # This section will be reached either at 56.0, or at the time she is pushed to 90%
-56.0 "--clones appear--" sync / 03:........:Aion Teleos:/  window 56,5
+56.0 "--clones appear--" AddedCombatant { name: "Aion Teleos" }  window 56,5
 63.6 "Thunder II/III" Ability { id: "(19AC|19B0)", source: "Sophia" }
 63.6 "--sync--" Ability { id: "19AB", source: "Aion Teleos" } window 30,2.5
 69.7 "Aero III" Ability { id: "19AE", source: "Sophia" }
@@ -64,7 +64,7 @@ hideall "--sync--"
 361.5 "Dischordant Cleansing" # Ability { id: "(19B3|19B5)", source: "Sophia" }
 361.5 "Cintamani x2" duration 3 # Ability { id: "19C5", source: "Sophia" }
 370.8 "Arms Of Wisdom" Ability { id: "19C4", source: "Sophia" } window 30,5
-379.0 "--clones appear--" sync / 03:........:Aion Teleos:/  window 60,20
+379.0 "--clones appear--" AddedCombatant { name: "Aion Teleos" }  window 60,20
 382.0 "Cintamani x3" duration 6 # Ability { id: "19C5", source: "Sophia" }
 393.3 "--sync--" Ability { id: "19AB", source: "Aion Teleos" }
 393.3 "Thunder II/III" Ability { id: "(19AC|19B0)", source: "Sophia" }
@@ -100,7 +100,7 @@ hideall "--sync--"
 568.3 "Dischordant Cleansing" # Ability { id: "(19B3|19B5)", source: "Sophia" }
 575.7 "Quasar (Tilt)" # Ability { id: "1A4C", source: "Sophia" }
 581.5 "Cintamani x3" duration 6 # Ability { id: "19C5", source: "Sophia" }
-577.5 "--clones appear--" sync / 03:........:Aion Teleos:/  window 60,5
+577.5 "--clones appear--" AddedCombatant { name: "Aion Teleos" }  window 60,5
 592.8 "Arms Of Wisdom" Ability { id: "19C4", source: "Sophia" }
 599.9 "--sync--" Ability { id: "19AB", source: "Aion Teleos" } window 10,2.5
 599.9 "Thunder II/III" Ability { id: "(19AC|19B0)", source: "Sophia" }

--- a/ui/raidboss/data/04-sb/alliance/orbonne_monastery.txt
+++ b/ui/raidboss/data/04-sb/alliance/orbonne_monastery.txt
@@ -273,7 +273,7 @@ hideall "--sync--"
 5208.3 "Flare IV" Ability { id: "389D", source: "Ultima, the High Seraph" }
 
 ### Phase 2: 50% Push Remix "Death awaits defiance!"
-5400.0 "--sync--" sync / 03:........:Mustadio:/  window 400,0
+5400.0 "--sync--" AddedCombatant { name: "Mustadio" }  window 400,0
 5413.0 "Earth Hammer" Ability { id: "38D8", source: "Demi-Hashmal" } window 400,5
 5415.9 "Time Eruption" Ability { id: "38D0", source: "Demi-Belias" }
 5418.9 "Time Eruption" Ability { id: "38D1", source: "Demi-Belias" }

--- a/ui/raidboss/data/04-sb/alliance/royal_city_of_rabanastre.txt
+++ b/ui/raidboss/data/04-sb/alliance/royal_city_of_rabanastre.txt
@@ -18,7 +18,7 @@ hideall "--start--"
 # Ice phase
 27.6 "Unbind" Ability { id: "2633", source: "Mateus, The Corrupt" }
 33.6 "--sync--" Ability { id: "26A2", source: "Mateus, The Corrupt" }
-34.3 "--Aqua Sphere Adds--" sync / 03:........:Aqua Sphere:/ 
+34.3 "--Aqua Sphere Adds--" AddedCombatant { name: "Aqua Sphere" } 
 57.5 "Flash-Freeze" Ability { id: "2647", source: "Mateus, The Corrupt" }
 66.7 "--sync--" Ability { id: "2637", source: "Mateus, The Corrupt" }
 74.6 "Flash-Freeze" Ability { id: "2647", source: "Mateus, The Corrupt" }
@@ -30,7 +30,7 @@ hideall "--start--"
 127.8 "--sync--" Ability { id: "263B", source: "Mateus, The Corrupt" }
 139.9 "Blizzard IV" Ability { id: "263D", source: "Mateus, The Corrupt" }
 152.1 "Flash-Freeze" Ability { id: "2647", source: "Mateus, The Corrupt" }
-165.4 "--Flume Toad Adds--" sync / 03:........:Flume Toad:/ 
+165.4 "--Flume Toad Adds--" AddedCombatant { name: "Flume Toad" } 
 192.5 "Snowpierce 1" Ability { id: "2640", source: "Icicle" }
 # ??? More flume toads, hard to tell from logs
 214.6 "Snowpierce 2" Ability { id: "2640", source: "Icicle" }
@@ -40,7 +40,7 @@ hideall "--start--"
 # Adds
 259.2 "--untargetable--" # ??? from video
 259.8 "--sync--" Ability { id: "266C", source: "Mateus, The Corrupt" } window 260,20
-262.9 "--Azure Guard Adds--" sync / 03:........:Azure Guard:/ 
+262.9 "--Azure Guard Adds--" AddedCombatant { name: "Azure Guard" } 
 333.2 "--enrage--" # ??? estimating from video
 
 # End of add phase aoe
@@ -49,7 +49,7 @@ hideall "--start--"
 # loop
 524.3 "Unbind" Ability { id: "2633", source: "Mateus, The Corrupt" } window 200,200 jump 27.6
 530.3 "--sync--" #Ability { id: "26A2", source: "Mateus, The Corrupt" }
-531.0 "--Aqua Sphere Adds--" #sync / 03:........:Aqua Sphere:/ 
+531.0 "--Aqua Sphere Adds--" #AddedCombatant { name: "Aqua Sphere" } 
 554.2 "Flash-Freeze" #Ability { id: "2647", source: "Mateus, The Corrupt" }
 563.4 "--sync--" #Ability { id: "2637", source: "Mateus, The Corrupt" }
 571.3 "Flash-Freeze" #Ability { id: "2647", source: "Mateus, The Corrupt" }
@@ -193,7 +193,7 @@ hideall "--start--"
 2189.4 "Crush Helm" Ability { id: "2680", source: "Rofocale" } duration 3.4
 
 2199.3 "--invulnerable--" # ??? from video, no debuff in logs, can push to this by hp%
-2201.3 "Archaeodemon Adds" sync / 03:........:Archaeodemon:/  window 300,300
+2201.3 "Archaeodemon Adds" AddedCombatant { name: "Archaeodemon" }  window 300,300
 2208.3 "--lock out--" # ??? from video
 
 # TODO: could trigger instead off of Rofocale losing Sprint which happens ~here

--- a/ui/raidboss/data/04-sb/dungeon/bardams_mettle.txt
+++ b/ui/raidboss/data/04-sb/dungeon/bardams_mettle.txt
@@ -88,7 +88,7 @@ hideall "Reconstruct"
 2060.9 "Pinion" Ability { id: "1F11", source: "Yol Feather" }
 2069.3 "Wind Unbound" Ability { id: "1F0A", source: "Yol" }
 2071.4 "--untargetable--"
-2071.4 "--adds spawn--" sync / 03:........:Corpsecleaner Eagle:/  window 71.4,5
+2071.4 "--adds spawn--" AddedCombatant { name: "Corpsecleaner Eagle" }  window 71.4,5
 2078.0 "Pinion" Ability { id: "1F11", source: "Yol Feather" }
 2088.0 "Pinion" Ability { id: "1F11", source: "Yol Feather" }
 2098.0 "Pinion" Ability { id: "1F11", source: "Yol Feather" }

--- a/ui/raidboss/data/04-sb/dungeon/doma_castle.txt
+++ b/ui/raidboss/data/04-sb/dungeon/doma_castle.txt
@@ -9,14 +9,14 @@ hideall "--sync--"
 7.4 "Cermet Pile" Ability { id: "209D", source: "Magitek Rearguard" } window 10,10
 15.0 "Garlean Fire" Ability { id: "209E", source: "Magitek Rearguard" }
 30.6 "Magitek Ray" Ability { id: "20A1", source: "Rearguard Bit" }
-35.6 "Rearguard Mines" #sync / 03:........:Rearguard Mine:/
+35.6 "Rearguard Mines" #AddedCombatant { name: "Rearguard Mine" }
 37.8 "Cermet Pile" Ability { id: "209D", source: "Magitek Rearguard" } window 10,10
 40.8 "Magitek Ray" Ability { id: "20A1", source: "Rearguard Bit" }
 43.4 "Garlean Fire" Ability { id: "209E", source: "Magitek Rearguard" }
 48.9 "Magitek Ray" Ability { id: "20A1", source: "Rearguard Bit" }
 53.9 "Magitek Ray" Ability { id: "20A1", source: "Rearguard Bit" }
 60.9 "Cermet Pile" Ability { id: "209D", source: "Magitek Rearguard" } window 10,5
-68.5 "Rearguard Mines" #sync / 03:........:Rearguard Mine:/
+68.5 "Rearguard Mines" #AddedCombatant { name: "Rearguard Mine" }
 
 70.7 "Cermet Pile" Ability { id: "209D", source: "Magitek Rearguard" } window 5,10
 73.7 "Magitek Ray" Ability { id: "20A1", source: "Rearguard Bit" }
@@ -26,14 +26,14 @@ hideall "--sync--"
 88.9 "Magitek Ray" Ability { id: "20A1", source: "Rearguard Bit" }
 91.6 "Garlean Fire" Ability { id: "209E", source: "Magitek Rearguard" }
 97.2 "Magitek Ray" Ability { id: "20A1", source: "Rearguard Bit" }
-98.7 "Rearguard Mines" #sync / 03:........:Rearguard Mine:/
+98.7 "Rearguard Mines" #AddedCombatant { name: "Rearguard Mine" }
 101.3 "Cermet Pile" Ability { id: "209D", source: "Magitek Rearguard" } window 10,10
 104.3 "Magitek Ray" Ability { id: "20A1", source: "Rearguard Bit" }
 107.0 "Garlean Fire" Ability { id: "209E", source: "Magitek Rearguard" }
 112.5 "Magitek Ray" Ability { id: "20A1", source: "Rearguard Bit" }
 115.6 "Cermet Pile" Ability { id: "209D", source: "Magitek Rearguard" } window 10,10
 118.6 "Magitek Ray" Ability { id: "20A1", source: "Rearguard Bit" }
-131.3 "Rearguard Mines" #sync / 03:........:Rearguard Mine:/
+131.3 "Rearguard Mines" #AddedCombatant { name: "Rearguard Mine" }
 
 133.2 "Cermet Pile" Ability { id: "209D", source: "Magitek Rearguard" } window 5,10 jump 70.7
 136.2 "Magitek Ray"
@@ -52,30 +52,30 @@ hideall "--sync--"
 1000 "Start" sync / 29:[^:]*:7DC:[^:]*:7C2:/ window 1000,0
 1010.6 "Circle Of Death" Ability { id: "20A2", source: "Magitek Hexadrone" }
 1018.9 "2-Tonze Magitek Missile" Ability { id: "20A3", source: "Magitek Hexadrone" }
-1024.1 "Hexadrone Bits" sync / 03:........:Hexadrone Bit:/
+1024.1 "Hexadrone Bits" AddedCombatant { name: "Hexadrone Bit" }
 1029.6 "Bits Activate"
 1039.6 "Circle Of Death" Ability { id: "20A2", source: "Magitek Hexadrone" }
-1045.7 "Hexadrone Bits" sync / 03:........:Hexadrone Bit:/
+1045.7 "Hexadrone Bits" AddedCombatant { name: "Hexadrone Bit" }
 1051.2 "Bits Activate"
 1049.8 "Circle Of Death" Ability { id: "20A2", source: "Magitek Hexadrone" }
 1064.5 "Magitek Missiles" Ability { id: "20A5", source: "Magitek Hexadrone" }
-1068.9 "Hexadrone Bits" sync / 03:........:Hexadrone Bit:/
+1068.9 "Hexadrone Bits" AddedCombatant { name: "Hexadrone Bit" }
 1074.4 "Bits Activate"
 1077.3 "2-Tonze Magitek Missile" Ability { id: "20A3", source: "Magitek Hexadrone" }
 
 1083.9 "Circle Of Death" Ability { id: "20A2", source: "Magitek Hexadrone" }
-1090.0 "Hexadrone Bits" sync / 03:........:Hexadrone Bit:/
+1090.0 "Hexadrone Bits" AddedCombatant { name: "Hexadrone Bit" }
 1095.5 "Bits Activate"
 1098.6 "Magitek Missiles" Ability { id: "20A5", source: "Magitek Hexadrone" }
-1111.2 "Hexadrone Bits" sync / 03:........:Hexadrone Bit:/
+1111.2 "Hexadrone Bits" AddedCombatant { name: "Hexadrone Bit" }
 1116.7 "Bits Activate"
 1112.9 "Magitek Missiles" Ability { id: "20A5", source: "Magitek Hexadrone" }
 1125.6 "Circle Of Death" Ability { id: "20A2", source: "Magitek Hexadrone" }
-1132.0 "Hexadrone Bits" sync / 03:........:Hexadrone Bit:/
+1132.0 "Hexadrone Bits" AddedCombatant { name: "Hexadrone Bit" }
 1137.5 "Bits Activate"
 1140.0 "2-Tonze Magitek Missile" Ability { id: "20A3", source: "Magitek Hexadrone" }
 1150.1 "Magitek Missiles" Ability { id: "20A5", source: "Magitek Hexadrone" }
-1159.5 "Hexadrone Bits" sync / 03:........:Hexadrone Bit:/
+1159.5 "Hexadrone Bits" AddedCombatant { name: "Hexadrone Bit" }
 1165.0 "Bits Activate"
 1168.0 "2-Tonze Magitek Missile" Ability { id: "20A3", source: "Magitek Hexadrone" }
 
@@ -105,7 +105,7 @@ hideall "--sync--"
 2084.9 "Gunsaw" duration 5.0  Ability { id: "20AA", source: "Hypertuned Grynewaht" }
 2098.2 "Delay-Action Charge" Ability { id: "20AD", source: "Hypertuned Grynewaht" }
 2098.2 "Clean Cut" #Ability { id: "20B1", source: "Magitek Chakram" }
-2102.6 "Magitek Bits" sync / 03:........:Retuned Magitek Bit:/
+2102.6 "Magitek Bits" AddedCombatant { name: "Retuned Magitek Bit" }
 2108.1 "Bits Activate"
 2117.9 "Chainsaw" duration 5.5 Ability { id: "20A8", source: "Hypertuned Grynewaht" }
 2120.9 "Thermobaric Charge" Ability { id: "20AF", source: "Hypertuned Grynewaht" }
@@ -118,7 +118,7 @@ hideall "--sync--"
 2174.1 "Delay-Action Charge" Ability { id: "20AD", source: "Hypertuned Grynewaht" }
 2174.1 "Clean Cut" #Ability { id: "20B1", source: "Magitek Chakram" }
 2179.7 "--center--" Ability { id: "20B0", source: "Hypertuned Grynewaht" } window 10,10
-2179.7 "Magitek Bits" sync / 03:........:Retuned Magitek Bit:/
+2179.7 "Magitek Bits" AddedCombatant { name: "Retuned Magitek Bit" }
 2185.2 "Bits Activate"
 2194.8 "Chainsaw" duration 5.5 Ability { id: "20A8", source: "Hypertuned Grynewaht" }
 2199.9 "Thermobaric Charge" Ability { id: "20AF", source: "Hypertuned Grynewaht" }
@@ -128,7 +128,7 @@ hideall "--sync--"
 2216.7 "Gunsaw" duration 5.0 Ability { id: "20AA", source: "Hypertuned Grynewaht" }
 2230.0 "Delay-Action Charge" Ability { id: "20AD", source: "Hypertuned Grynewaht" }
 2230.0 "Clean Cut" #Ability { id: "20B1", source: "Magitek Chakram" }
-2232.5 "Magitek Bits" sync / 03:........:Retuned Magitek Bit:/
+2232.5 "Magitek Bits" AddedCombatant { name: "Retuned Magitek Bit" }
 2238.0 "Bits Activate"
 2245.7 "Chainsaw" duration 5.5 Ability { id: "20A8", source: "Hypertuned Grynewaht" }
 2253.4 "Thermobaric Charge" Ability { id: "20AF", source: "Hypertuned Grynewaht" }

--- a/ui/raidboss/data/04-sb/dungeon/shisui_of_the_violet_tides.txt
+++ b/ui/raidboss/data/04-sb/dungeon/shisui_of_the_violet_tides.txt
@@ -150,7 +150,7 @@ hideall "--sync--"
 2209.6 "Foul Nail" #Ability { id: "1F87", source: "Shisui Yohi" }
 
 # Phase 3: 75% -> 60%, introduction to adds
-2300.0 "--adds--" sync / 03:........:Naishi-No-Kami:/  window 300,0
+2300.0 "--adds--" AddedCombatant { name: "Naishi-No-Kami" }  window 300,0
 2303.4 "Foul Nail" Ability { id: "1F87", source: "Shisui Yohi" }
 2313.5 "Mad Stare" Ability { id: "1F82", source: "Shisui Yohi" }
 

--- a/ui/raidboss/data/04-sb/dungeon/temple_of_the_fist.txt
+++ b/ui/raidboss/data/04-sb/dungeon/temple_of_the_fist.txt
@@ -10,7 +10,7 @@ hideall "--sync--"
 17.8 "Radial Blaster" Ability { id: "1FD3", source: "Coeurl Sruti" }
 22.0 "Pounce" Ability { id: "1FD1", source: "Coeurl Sruti" }
 
-38.5 "--Smriti Appears--" sync / 03:........:Coeurl Smriti:/  window 10,10
+38.5 "--Smriti Appears--" AddedCombatant { name: "Coeurl Smriti" }  window 10,10
 46.5 "Wide Blaster" Ability { id: "1FD4", source: "Coeurl Smriti" } window 15,15
 46.5 "Radial Blaster" Ability { id: "1FD3", source: "Coeurl Sruti" }
 52.6 "Pounce x2" Ability { id: "1FD1", source: "Coeurl Smriti" }

--- a/ui/raidboss/data/04-sb/raid/o5s.txt
+++ b/ui/raidboss/data/04-sb/raid/o5s.txt
@@ -39,8 +39,8 @@ hideall "--sync--"
 
 # chimney + train cars
 300 "--sync--" Ability { id: "28B3", source: "Phantom Train" } window 500,500
-305 "(T/H) Ghosts" sync / 03:........:Agony:/
-309 "(DPS) Ghosts" sync / 03:........:Malice:/
+305 "(T/H) Ghosts" AddedCombatant { name: "Agony" }
+309 "(DPS) Ghosts" AddedCombatant { name: "Malice" }
 
 
 491 "--sync--" Ability { id: "28A8", source: "Phantom Train" } window 500,500

--- a/ui/raidboss/data/04-sb/raid/o6s.txt
+++ b/ui/raidboss/data/04-sb/raid/o6s.txt
@@ -24,7 +24,7 @@ hideall "--sync--"
 130 "Release" Ability { id: "2804", source: "Demon Chadarnook" }
 
 143 "Possession" Ability { id: "2803", source: "Demon Chadarnook" } window 20
-150 "Easterlies" sync / 03:........:Easterly:/
+150 "Easterlies" AddedCombatant { name: "Easterly" }
 153 "Rock Hard" Ability { id: "2812", source: "Portrayal of Earth" }
 155 "Demonic Shear" Ability { id: "2829", source: "Demon Chadarnook" }
 164 "Demonic Howl" Ability { id: "282B", source: "Demon Chadarnook" }
@@ -57,7 +57,7 @@ hideall "--sync--"
 352 "Release" Ability { id: "2804", source: "Demon Chadarnook" }
 
 365 "Possession" Ability { id: "2803", source: "Demon Chadarnook" } window 20
-373 "Easterlies" sync / 03:........:Easterly:/
+373 "Easterlies" AddedCombatant { name: "Easterly" }
 375 "Rock Hard" Ability { id: "2812", source: "Portrayal of Earth" }
 376 "Demonic Wave" Ability { id: "2830", source: "Portrayal of Water" }
 384 "Demonic Howl" Ability { id: "282B", source: "Demon Chadarnook" }
@@ -93,7 +93,7 @@ hideall "--sync--"
 590 "Release" Ability { id: "2804", source: "Demon Chadarnook" }
 
 603 "Possession" Ability { id: "2803", source: "Demon Chadarnook" } window 20
-611 "Easterlies" sync / 03:........:Easterly:/
+611 "Easterlies" AddedCombatant { name: "Easterly" }
 613 "Rock Hard" Ability { id: "2812", source: "Portrayal of Earth" }
 614 "Demonic Wave" Ability { id: "2830", source: "Portrayal of Water" }
 622 "Demonic Howl" Ability { id: "282B", source: "Demon Chadarnook" }

--- a/ui/raidboss/data/04-sb/trial/tsukuyomi-ex.txt
+++ b/ui/raidboss/data/04-sb/trial/tsukuyomi-ex.txt
@@ -51,8 +51,8 @@ hideall "--Reset--"
 # Add phase
 781.0 "Nightbloom" Ability { id: "2BC7", source: "Tsukuyomi" } window 800,0
 781.8 "--untargetable--"
-792.3 "Homeland adds (E->W)" sync / 03:........:Specter Of The Patriarch:/  window 40,20
-852.3 "Empire adds (SW->NW)" sync / 03:........:Specter Of Asahi:/  window 160,20
+792.3 "Homeland adds (E->W)" AddedCombatant { name: "Specter Of The Patriarch" }  window 40,20
+852.3 "Empire adds (SW->NW)" AddedCombatant { name: "Specter Of Asahi" }  window 160,20
 886.3 "Enrage"
 
 1000.0 "Concentrativity" Ability { id: "2BC8", source: "Specter of Zenos" } window 1000,0

--- a/ui/raidboss/data/04-sb/trial/tsukuyomi.txt
+++ b/ui/raidboss/data/04-sb/trial/tsukuyomi.txt
@@ -27,8 +27,8 @@ hideall "--Reset--"
 
 
 ### Phase 2: Adds
-127.8 "--Patriarch/Matriarch Adds--" sync / 03:........:Specter Of The Matriarch:/  window 30,10
-174.5 "--Empire/Homeland Adds--" sync / 03:........:Specter Of The Empire:/  window 80,10
+127.8 "--Patriarch/Matriarch Adds--" AddedCombatant { name: "Specter Of The Matriarch" }  window 30,10
+174.5 "--Empire/Homeland Adds--" AddedCombatant { name: "Specter Of The Empire" }  window 80,10
 # TODO: Specter of Asahi shows up alone after all other adds are dead, so can't have a timeline entry.
 
 400.0 "Concentrativity" Ability { id: "2BEF", source: "Specter of Zenos" } window 400,0

--- a/ui/raidboss/data/05-shb/dungeon/amaurot.txt
+++ b/ui/raidboss/data/05-shb/dungeon/amaurot.txt
@@ -42,8 +42,8 @@ hideall "--sync--"
 523.0 "Shrill Shriek" Ability { id: "3CCF", source: "Terminus Bellwether" } window 523,5
 525.0 "--untargetable--"
 525.0 "Adds (N)"
-561.3 "Adds (SW)" sync / 03:........:Terminus Roiler:/  window 60,60
-610.9 "Adds (S)" sync / 03:........:Terminus Pursuer:/  window 100,100
+561.3 "Adds (SW)" AddedCombatant { name: "Terminus Roiler" }  window 60,60
+610.9 "Adds (S)" AddedCombatant { name: "Terminus Pursuer" }  window 100,100
 800.0 "--sync--" StartsUsing { id: "3CD0", source: "Terminus Bellwether" } window 300,00
 840.0 "Burst" Ability { id: "3CD0", source: "Terminus Bellwether" } window 40,40
 

--- a/ui/raidboss/data/05-shb/eureka/delubrum_reginae_savage.txt
+++ b/ui/raidboss/data/05-shb/eureka/delubrum_reginae_savage.txt
@@ -13,44 +13,44 @@ hideall "--sync--"
 
 
 ### Slimes (The Barracks, left side)
-1000.0 "--sync--" sync / 03:........:Viscous Clot:/  window 1000,0
-1000.0 "--Reset--" sync / 03:........:Trinity Seeker:/  window 0,1000 jump 0
-1000.0 "Viscous Clot x3" sync / 03:........:Viscous Clot:/  window 1000,0
-1005.3 "Sanguine Clot x4" sync / 03:........:Sanguine Clot:/
-1012.1 "Viscous Clot x3" sync / 03:........:Viscous Clot:/
-1024.1 "Viscous Clot x3" sync / 03:........:Viscous Clot:/
-1025.4 "Sanguine Clot x4" sync / 03:........:Sanguine Clot:/
-1027.5 "Bozjan Soldier x2" sync / 03:........:Bozjan Soldier:/
-1036.1 "Viscous Clot x3" sync / 03:........:Viscous Clot:/
-1044.9 "Sanguine Clot x4" sync / 03:........:Sanguine Clot:/
-1048.2 "Viscous Clot x3" sync / 03:........:Viscous Clot:/
-1060.2 "Viscous Clot x3" sync / 03:........:Viscous Clot:/
-1065.1 "Sanguine Clot x4" sync / 03:........:Sanguine Clot:/
-1072.4 "Viscous Clot x3" sync / 03:........:Viscous Clot:/
-1077.1 "Bozjan Soldier x2" sync / 03:........:Bozjan Soldier:/
-1084.3 "Viscous Clot x3" sync / 03:........:Viscous Clot:/
-1085.0 "Sanguine Clot x4" sync / 03:........:Sanguine Clot:/
-1096.1 "Viscous Clot x3" sync / 03:........:Viscous Clot:/
-1105.2 "Sanguine Clot x3" sync / 03:........:Sanguine Clot:/
-1108.3 "Viscous Clot x2" sync / 03:........:Viscous Clot:/
-1120.0 "Viscous Clot x3" sync / 03:........:Viscous Clot:/
-1125.2 "Sanguine Clot x4" sync / 03:........:Sanguine Clot:/
-1127.4 "Bozjan Soldier x2" sync / 03:........:Bozjan Soldier:/
-1132.2 "Viscous Clot" sync / 03:........:Viscous Clot:/
-1144.2 "Viscous Clot x3" sync / 03:........:Viscous Clot:/
-1156.2 "Viscous Clot x3" sync / 03:........:Viscous Clot:/
-1162.1 "Viscous Clot" sync / 03:........:Viscous Clot:/
-1165.4 "Sanguine Clot x2" sync / 03:........:Sanguine Clot:/
-1168.2 "Viscous Clot x2" sync / 03:........:Viscous Clot:/
-1172.7 "Sanguine Clot x4" sync / 03:........:Sanguine Clot:/
-1177.4 "Bozjan Soldier x2" sync / 03:........:Bozjan Soldier:/
-1192.2 "Viscous Clot" sync / 03:........:Viscous Clot:/
-1204.2 "Viscous Clot x2" sync / 03:........:Viscous Clot:/
-1225.1 "Sanguine Clot" sync / 03:........:Sanguine Clot:/
-1227.2 "Bozjan Soldier x2" sync / 03:........:Bozjan Soldier:/
-1233.1 "Sanguine Clot x4" sync / 03:........:Sanguine Clot:/
-1277.3 "Bozjan Soldier x2" sync / 03:........:Bozjan Soldier:/
-1297.3 "Grim Reaper Enrage" sync / 03:........:Grim Reaper:/  window 300,10
+1000.0 "--sync--" AddedCombatant { name: "Viscous Clot" }  window 1000,0
+1000.0 "--Reset--" AddedCombatant { name: "Trinity Seeker" }  window 0,1000 jump 0
+1000.0 "Viscous Clot x3" AddedCombatant { name: "Viscous Clot" }  window 1000,0
+1005.3 "Sanguine Clot x4" AddedCombatant { name: "Sanguine Clot" }
+1012.1 "Viscous Clot x3" AddedCombatant { name: "Viscous Clot" }
+1024.1 "Viscous Clot x3" AddedCombatant { name: "Viscous Clot" }
+1025.4 "Sanguine Clot x4" AddedCombatant { name: "Sanguine Clot" }
+1027.5 "Bozjan Soldier x2" AddedCombatant { name: "Bozjan Soldier" }
+1036.1 "Viscous Clot x3" AddedCombatant { name: "Viscous Clot" }
+1044.9 "Sanguine Clot x4" AddedCombatant { name: "Sanguine Clot" }
+1048.2 "Viscous Clot x3" AddedCombatant { name: "Viscous Clot" }
+1060.2 "Viscous Clot x3" AddedCombatant { name: "Viscous Clot" }
+1065.1 "Sanguine Clot x4" AddedCombatant { name: "Sanguine Clot" }
+1072.4 "Viscous Clot x3" AddedCombatant { name: "Viscous Clot" }
+1077.1 "Bozjan Soldier x2" AddedCombatant { name: "Bozjan Soldier" }
+1084.3 "Viscous Clot x3" AddedCombatant { name: "Viscous Clot" }
+1085.0 "Sanguine Clot x4" AddedCombatant { name: "Sanguine Clot" }
+1096.1 "Viscous Clot x3" AddedCombatant { name: "Viscous Clot" }
+1105.2 "Sanguine Clot x3" AddedCombatant { name: "Sanguine Clot" }
+1108.3 "Viscous Clot x2" AddedCombatant { name: "Viscous Clot" }
+1120.0 "Viscous Clot x3" AddedCombatant { name: "Viscous Clot" }
+1125.2 "Sanguine Clot x4" AddedCombatant { name: "Sanguine Clot" }
+1127.4 "Bozjan Soldier x2" AddedCombatant { name: "Bozjan Soldier" }
+1132.2 "Viscous Clot" AddedCombatant { name: "Viscous Clot" }
+1144.2 "Viscous Clot x3" AddedCombatant { name: "Viscous Clot" }
+1156.2 "Viscous Clot x3" AddedCombatant { name: "Viscous Clot" }
+1162.1 "Viscous Clot" AddedCombatant { name: "Viscous Clot" }
+1165.4 "Sanguine Clot x2" AddedCombatant { name: "Sanguine Clot" }
+1168.2 "Viscous Clot x2" AddedCombatant { name: "Viscous Clot" }
+1172.7 "Sanguine Clot x4" AddedCombatant { name: "Sanguine Clot" }
+1177.4 "Bozjan Soldier x2" AddedCombatant { name: "Bozjan Soldier" }
+1192.2 "Viscous Clot" AddedCombatant { name: "Viscous Clot" }
+1204.2 "Viscous Clot x2" AddedCombatant { name: "Viscous Clot" }
+1225.1 "Sanguine Clot" AddedCombatant { name: "Sanguine Clot" }
+1227.2 "Bozjan Soldier x2" AddedCombatant { name: "Bozjan Soldier" }
+1233.1 "Sanguine Clot x4" AddedCombatant { name: "Sanguine Clot" }
+1277.3 "Bozjan Soldier x2" AddedCombatant { name: "Bozjan Soldier" }
+1297.3 "Grim Reaper Enrage" AddedCombatant { name: "Grim Reaper" }  window 300,10
 1302.3 "Death Scythe" #Ability { id: "5747", source: "Grim Reaper" }
 1305.3 "Death Scythe" #Ability { id: "5747", source: "Grim Reaper" }
 1308.3 "Death Scythe" #Ability { id: "5747", source: "Grim Reaper" }
@@ -60,7 +60,7 @@ hideall "--sync--"
 1320.4 "Death Scythe" #Ability { id: "5747", source: "Grim Reaper" }
 1323.5 "Death Scythe" #Ability { id: "5747", source: "Grim Reaper" }
 1326.5 "Death Scythe" #Ability { id: "5747", source: "Grim Reaper" }
-1327.3 "Bozjan Soldier x2" sync / 03:........:Bozjan Soldier:/
+1327.3 "Bozjan Soldier x2" AddedCombatant { name: "Bozjan Soldier" }
 1329.5 "Death Scythe" #Ability { id: "5747", source: "Grim Reaper" }
 1332.6 "Death Scythe" #Ability { id: "5747", source: "Grim Reaper" }
 1335.6 "Death Scythe" Ability { id: "5747", source: "Grim Reaper" } window 5,10
@@ -77,36 +77,36 @@ hideall "--sync--"
 
 ### Golems (The Granary, right side)
 2000.0 "--sync--" sync / 22:........:Bicolor Golem:........:Bicolor Golem:01/ window 2000,0
-2000.0 "--Reset--" sync / 03:........:Trinity Seeker:/  window 0,1000 jump 0
+2000.0 "--Reset--" AddedCombatant { name: "Trinity Seeker" }  window 0,1000 jump 0
 2025.2 "Core Combustion" Ability { id: "5745", source: "Bicolor Golem" } window 2030,10
 2026.1 "--bleed--" # from blue golem
-2029.9 "Ruins Golem x2" sync / 03:........:Ruins Golem:/
+2029.9 "Ruins Golem x2" AddedCombatant { name: "Ruins Golem" }
 2032.1 "--sync--" StartsUsing { id: "5558", source: "Bicolor Golem" } window 20,10
 2037.1 "Metamorphose" Ability { id: "5558", source: "Bicolor Golem" }
-2069.9 "Ruins Golem x2" sync / 03:........:Ruins Golem:/
+2069.9 "Ruins Golem x2" AddedCombatant { name: "Ruins Golem" }
 2071.3 "--sync--" StartsUsing { id: "5558", source: "Bicolor Golem" } window 20,10
 2076.3 "Metamorphose" Ability { id: "5558", source: "Bicolor Golem" }
-2109.7 "Ruins Golem x2" sync / 03:........:Ruins Golem:/
-2140.1 "Ruins Golem x2" sync / 03:........:Ruins Golem:/
-2160.2 "Ruins Golem x2" sync / 03:........:Ruins Golem:/
-2170.3 "Ruins Golem x2" sync / 03:........:Ruins Golem:/
-2180.3 "Ruins Golem x2" sync / 03:........:Ruins Golem:/
-2189.9 "Ruins Golem x2" sync / 03:........:Ruins Golem:/
-2199.9 "Ruins Golem x2" sync / 03:........:Ruins Golem:/
-2209.9 "Ruins Golem x2" sync / 03:........:Ruins Golem:/
-2220.0 "Ruins Golem x2" sync / 03:........:Ruins Golem:/
-2230.0 "Ruins Golem x2" sync / 03:........:Ruins Golem:/
-2240.0 "Ruins Golem x2" sync / 03:........:Ruins Golem:/
-2250.1 "Ruins Golem x2" sync / 03:........:Ruins Golem:/
-2260.0 "Ruins Golem x2" sync / 03:........:Ruins Golem:/
-2270.0 "Ruins Golem x2" sync / 03:........:Ruins Golem:/
-2280.1 "Ruins Golem x2" sync / 03:........:Ruins Golem:/
-2290.1 "Ruins Golem x2" sync / 03:........:Ruins Golem:/
-2299.7 "Grim Reaper Enrage" sync / 03:........:Grim Reaper:/
-2300.2 "Ruins Golem x2" sync / 03:........:Ruins Golem:/
+2109.7 "Ruins Golem x2" AddedCombatant { name: "Ruins Golem" }
+2140.1 "Ruins Golem x2" AddedCombatant { name: "Ruins Golem" }
+2160.2 "Ruins Golem x2" AddedCombatant { name: "Ruins Golem" }
+2170.3 "Ruins Golem x2" AddedCombatant { name: "Ruins Golem" }
+2180.3 "Ruins Golem x2" AddedCombatant { name: "Ruins Golem" }
+2189.9 "Ruins Golem x2" AddedCombatant { name: "Ruins Golem" }
+2199.9 "Ruins Golem x2" AddedCombatant { name: "Ruins Golem" }
+2209.9 "Ruins Golem x2" AddedCombatant { name: "Ruins Golem" }
+2220.0 "Ruins Golem x2" AddedCombatant { name: "Ruins Golem" }
+2230.0 "Ruins Golem x2" AddedCombatant { name: "Ruins Golem" }
+2240.0 "Ruins Golem x2" AddedCombatant { name: "Ruins Golem" }
+2250.1 "Ruins Golem x2" AddedCombatant { name: "Ruins Golem" }
+2260.0 "Ruins Golem x2" AddedCombatant { name: "Ruins Golem" }
+2270.0 "Ruins Golem x2" AddedCombatant { name: "Ruins Golem" }
+2280.1 "Ruins Golem x2" AddedCombatant { name: "Ruins Golem" }
+2290.1 "Ruins Golem x2" AddedCombatant { name: "Ruins Golem" }
+2299.7 "Grim Reaper Enrage" AddedCombatant { name: "Grim Reaper" }
+2300.2 "Ruins Golem x2" AddedCombatant { name: "Ruins Golem" }
 2305.0 "Death Scythe" #Ability { id: "5747", source: "Grim Reaper" }
 2308.0 "Death Scythe" #Ability { id: "5747", source: "Grim Reaper" }
-2310.1 "Ruins Golem x2" sync / 03:........:Ruins Golem:/
+2310.1 "Ruins Golem x2" AddedCombatant { name: "Ruins Golem" }
 2311.1 "Death Scythe" #Ability { id: "5747", source: "Grim Reaper" }
 2314.1 "Death Scythe" #Ability { id: "5747", source: "Grim Reaper" }
 2317.1 "Death Scythe" Ability { id: "5747", source: "Grim Reaper" } window 5,10

--- a/ui/raidboss/data/05-shb/eureka/zadnor.txt
+++ b/ui/raidboss/data/05-shb/eureka/zadnor.txt
@@ -157,7 +157,7 @@ hideall "--sync--"
 # ???
 
 # Tamed Alkonost / Tamed Carrion Crow
-22500.0 "--sync--" sync / 03:........:Tamed Carrion Crow:/  window 600,0
+22500.0 "--sync--" AddedCombatant { name: "Tamed Carrion Crow" }  window 600,0
 22507.0 "--sync--" StartsUsing { id: "5F26", source: "Tamed Alkonost" } window 600,10
 22512.0 "Stormcall" Ability { id: "5F26", source: "Tamed Alkonost" }
 22526.9 "Orb 1" Ability { id: "5F27", source: "Vortical Orb" }

--- a/ui/raidboss/data/05-shb/trial/shiva-un.txt
+++ b/ui/raidboss/data/05-shb/trial/shiva-un.txt
@@ -128,7 +128,7 @@ hideall "--Reset--"
 801.0 "--sync--" #Ability { id: "53AE", source: "Shiva" }
 # If you push *really* fast and skip a 3a/3b weapon phase, you'll miss the melt jump.
 # So, fix that up with a combatant sync here.
-806.6 "--adds targetable--" sync / 03:........:Ice Soldier:/  window 807,10
+806.6 "--adds targetable--" AddedCombatant { name: "Ice Soldier" }  window 807,10
 807.6 "Dreams Of Ice" Ability { id: "536A", source: "Shiva" }
 813.2 "Frost Blade" Ability { id: "5366", source: "Shiva" }
 818.5 "Icebrand" Ability { id: "5373", source: "Shiva" }

--- a/ui/raidboss/data/06-ew/dungeon/aloalo_island.txt
+++ b/ui/raidboss/data/06-ew/dungeon/aloalo_island.txt
@@ -216,8 +216,8 @@ hideall "--sync--"
 2437.0 label "ketuduke-0304"
 2437.0 "--sync--" StartsUsing { id: "8A92", source: "Ketuduke" }
 2442.0 "Roar" Ability { id: "8A92", source: "Ketuduke" }
-# 2142.7 "--sync--" sync / 03:[^:]*:Aloalo Zaratan:/ # path 03
-# 2142.7 "--sync--" sync / 03:[^:]*:Aloalo Ogrebon:/ # path 04
+# 2142.7 "--sync--" AddedCombatant { name: "Aloalo Zaratan" } # path 03
+# 2142.7 "--sync--" AddedCombatant { name: "Aloalo Ogrebon" } # path 04
 2454.8 "Bubble Net" Ability { id: "8A93", source: "Ketuduke" }
 2465.4 "Updraft" Ability { id: "8D0F", source: "Ketuduke" }
 2467.6 "Hundred Lashings?" Ability { id: "8A97", source: "Aloalo Zaratan" } # path 03

--- a/ui/raidboss/data/06-ew/trial/sephirot-un.txt
+++ b/ui/raidboss/data/06-ew/trial/sephirot-un.txt
@@ -88,7 +88,7 @@ hideall "--sync--"
 1143.2 "Chesed Gevurah" Ability { id: "(76A5|76A6)", source: "Sephirot" }
 1143.8 "Life Force + Spirit" Ability { id: "(76A7|76A8)", source: "Sephirot" }
 1149.4 "Malkuth" Ability { id: "76AF", source: "Sephirot" } window 30,30
-1150.5 "Adds Spawn" sync / 03:........:Storm Of Words:/
+1150.5 "Adds Spawn" AddedCombatant { name: "Storm Of Words" }
 1158.7 "Chesed Gevurah" Ability { id: "(76A5|76A6)", source: "Sephirot" }
 1159.3 "Life Force + Spirit" Ability { id: "(76A7|76A8)", source: "Sephirot" }
 1164.9 "Fiendish Wail" Ability { id: "76A3", source: "Sephirot" }
@@ -128,7 +128,7 @@ hideall "--sync--"
 1340.5 "Chesed Gevurah" Ability { id: "(76A5|76A6)", source: "Sephirot" }
 1341.1 "Life Force + Spirit" Ability { id: "(76A7|76A8)", source: "Sephirot" }
 1346.7 "Malkuth" Ability { id: "76AF", source: "Sephirot" }
-1347.8 "Adds Spawn" sync / 03:........:Storm Of Words:/
+1347.8 "Adds Spawn" AddedCombatant { name: "Storm Of Words" }
 1356.0 "Chesed Gevurah" Ability { id: "(76A5|76A6)", source: "Sephirot" }
 1356.6 "Life Force + Spirit" Ability { id: "(76A7|76A8)", source: "Sephirot" }
 1362.2 "Fiendish Wail" Ability { id: "76A3", source: "Sephirot" }

--- a/ui/raidboss/data/06-ew/trial/sophia-un.txt
+++ b/ui/raidboss/data/06-ew/trial/sophia-un.txt
@@ -23,7 +23,7 @@ hideall "--sync--"
 41.4 "Arms Of Wisdom?" Ability { id: "7DBE", source: "Sophia" } # May be skipped depending on DPS
 
 # This section will be reached either at 56.0, or at the time she is pushed to 90%
-56.0 "--clones appear--" sync / 03:........:Aion Teleos:/  window 56,5
+56.0 "--clones appear--" AddedCombatant { name: "Aion Teleos" }  window 56,5
 63.6 "Thunder II/III" Ability { id: "(7DA6|7DAA)", source: "Sophia" }
 63.6 "--sync--" Ability { id: "7DA5", source: "Aion Teleos" } window 30,2.5
 69.7 "Aero III" Ability { id: "7DA8", source: "Sophia" }
@@ -69,7 +69,7 @@ hideall "--sync--"
 361.5 "Dischordant Cleansing" # Ability { id: "(7DAD|7DAF)", source: "Sophia" }
 361.5 "Cintamani x2" duration 3 # Ability { id: "7DBF", source: "Sophia" }
 370.8 "Arms Of Wisdom" Ability { id: "7DBE", source: "Sophia" } window 30,5
-379.0 "--clones appear--" sync / 03:........:Aion Teleos:/  window 60,20
+379.0 "--clones appear--" AddedCombatant { name: "Aion Teleos" }  window 60,20
 382.0 "Cintamani x3" duration 6 # Ability { id: "7DBF", source: "Sophia" }
 393.3 "--sync--" Ability { id: "7DA5", source: "Aion Teleos" }
 393.3 "Thunder II/III" Ability { id: "(7DA6|7DAA)", source: "Sophia" }
@@ -105,7 +105,7 @@ hideall "--sync--"
 568.3 "Dischordant Cleansing" # Ability { id: "(7DAD|7DAF)", source: "Sophia" }
 575.7 "Quasar (Tilt)" # Ability { id: "7E46", source: "Sophia" }
 581.5 "Cintamani x3" duration 6 # Ability { id: "7DBF", source: "Sophia" }
-577.5 "--clones appear--" sync / 03:........:Aion Teleos:/  window 60,5
+577.5 "--clones appear--" AddedCombatant { name: "Aion Teleos" }  window 60,5
 592.8 "Arms Of Wisdom" Ability { id: "7DBE", source: "Sophia" }
 599.9 "--sync--" Ability { id: "7DA5", source: "Aion Teleos" } window 10,2.5
 599.9 "Thunder II/III" Ability { id: "(7DA6|7DAA)", source: "Sophia" }


### PR DESCRIPTION
Done by running #5977. These are the only
(and the final remaining for all timeline netregex conversion) backslashes that needed to be converted:

```diff
-45.8 "E.D.D. Add" AddedCombatant { name: "E\.D\.D\." } window 50,5
+45.8 "E.D.D. Add" AddedCombatant { name: "E\\.D\\.D\\." } window 50,5
-458.7 "E.D.D. Add" AddedCombatant { name: "E\.D\.D\." }
+458.7 "E.D.D. Add" AddedCombatant { name: "E\\.D\\.D\\." }
-697.2 "E.D.D. Add" AddedCombatant { name: "E\.D\.D\." }
+697.2 "E.D.D. Add" AddedCombatant { name: "E\\.D\\.D\\." }
```