### PR TITLE
raidboss: timeline netregex for gameLogWithName

### DIFF
--- a/ui/raidboss/data/02-arr/trial/ifrit-nm.txt
+++ b/ui/raidboss/data/02-arr/trial/ifrit-nm.txt
@@ -24,7 +24,7 @@ hideall "--sync--"
 126.1 "Incinerate"
 
 # 70%
-200.0 "--sync--" sync / 00:0044:Ifrit:Succumb to the inferno/ window 200,0
+200.0 "--sync--" GameLog { code: "0044", name: "Ifrit", line: "Succumb to the inferno.*?" } window 200,0
 201.0 "Incinerate" Ability { id: "1C5", source: "Ifrit" }
 209.0 "Eruption" Ability { id: "1C7", source: "Ifrit" } window 210,5
 213.5 "Vulcan Burst" Ability { id: "1C6", source: "Ifrit" }
@@ -39,7 +39,7 @@ hideall "--sync--"
 278.6 "Eruption"
 
 # 50%
-300.0 "--sync--" sync / 00:0044:Ifrit:Surrender thyself to the fires of judgment/ window 300,0
+300.0 "--sync--" GameLog { code: "0044", name: "Ifrit", line: "Surrender thyself to the fires of judgment.*?" } window 300,0
 305.0 "Nail Add"
 306.7 "Incinerate" Ability { id: "1C5", source: "Ifrit" }
 314.4 "Vulcan Burst" Ability { id: "1C6", source: "Ifrit" }

--- a/ui/raidboss/data/04-sb/dungeon/fractal_continuum_hard.txt
+++ b/ui/raidboss/data/04-sb/dungeon/fractal_continuum_hard.txt
@@ -57,9 +57,9 @@ hideall "--sync--"
 1029.8 "Ceruleum Vent" Ability { id: "2794", source: "The Ultima Warrior" }
 1042.0 "Aetheroplasm" Ability { id: "2793", source: "The Ultima Warrior" } # skipped if boss is at or below 95% HP
 
-1053.4 "--sync--" sync / 00:0044:Vocal Guidance System:This humanoid prototype can perfectly replicate/ window 53.4,10 jump 1100.0
-1053.4 "--sync--" sync / 00:0044:Vocal Guidance System:Utilizing our data on Sophia/ window 53.4,10 jump 1200.0
-1053.4 "--sync--" sync / 00:0044:Vocal Guidance System:Successfully mimicking the Demon Zurvan/ window 53.4,10 jump 1300.0
+1053.4 "--sync--" GameLog { code: "0044", name: "Vocal Guidance System", line: "This humanoid prototype can perfectly replicate.*?" } window 53.4,10 jump 1100.0
+1053.4 "--sync--" GameLog { code: "0044", name: "Vocal Guidance System", line: "Utilizing our data on Sophia.*?" } window 53.4,10 jump 1200.0
+1053.4 "--sync--" GameLog { code: "0044", name: "Vocal Guidance System", line: "Successfully mimicking the Demon Zurvan.*?" } window 53.4,10 jump 1300.0
 1060.9 "Primordial Aether"
 1062.0 "Ceruleum Vent?"
 1063.5 "Infinite Fire/Infinite Ice?"
@@ -71,7 +71,7 @@ hideall "--sync--"
 
 # Sephirot's block
 
-1100.0 "--sync--" sync / 00:0044:Vocal Guidance System:This humanoid prototype can perfectly replicate/
+1100.0 "--sync--" GameLog { code: "0044", name: "Vocal Guidance System", line: "This humanoid prototype can perfectly replicate.*?" }
 1107.5 "Primordial Aether" Ability { id: "2796", source: "The Ultima Warrior" } window 10,10
 1119.1 "Citadel Buster" Ability { id: "2792", source: "The Ultima Warrior" }
 1120.1 "Ratzon" Ability { id: "2797", source: "The Ultima Warrior" }
@@ -79,9 +79,9 @@ hideall "--sync--"
 1139.2 "Mass Aetheroplasm" Ability { id: "2795", source: "The Ultima Warrior" }
 1149.7 "Aetheroplasm" Ability { id: "2793", source: "The Ultima Warrior" }
 
-1154.8 "--sync--" sync / 00:0044:Vocal Guidance System:This humanoid prototype can perfectly replicate/ window 50,10 jump 1100.0
-1154.8 "--sync--" sync / 00:0044:Vocal Guidance System:Utilizing our data on Sophia/ window 50,10 jump 1200.0
-1154.8 "--sync--" sync / 00:0044:Vocal Guidance System:Successfully mimicking the Demon Zurvan/ window 50,10 jump 1300.0
+1154.8 "--sync--" GameLog { code: "0044", name: "Vocal Guidance System", line: "This humanoid prototype can perfectly replicate.*?" } window 50,10 jump 1100.0
+1154.8 "--sync--" GameLog { code: "0044", name: "Vocal Guidance System", line: "Utilizing our data on Sophia.*?" } window 50,10 jump 1200.0
+1154.8 "--sync--" GameLog { code: "0044", name: "Vocal Guidance System", line: "Successfully mimicking the Demon Zurvan.*?" } window 50,10 jump 1300.0
 1162.3 "Primordial Aether"
 1163.4 "Ceruleum Vent?"
 1164.9 "Infinite Fire/Infinite Ice?"
@@ -93,7 +93,7 @@ hideall "--sync--"
 
 # Sophia's Block
 
-1200.0 "--sync--" sync / 00:0044:Vocal Guidance System:Utilizing our data on Sophia/
+1200.0 "--sync--" GameLog { code: "0044", name: "Vocal Guidance System", line: "Utilizing our data on Sophia.*?" }
 1207.5 "Primordial Aether" Ability { id: "2796", source: "The Ultima Warrior" } window 10,10
 1218.1 "Ceruleum Vent" Ability { id: "2794", source: "The Ultima Warrior" }
 1225.3 "Citadel Buster" Ability { id: "2792", source: "The Ultima Warrior" }
@@ -102,9 +102,9 @@ hideall "--sync--"
 1232.3 "Dischordant Cleansing" Ability { id: "279A", source: "The Ultima Warrior" }
 1242.3 "Aetheroplasm" Ability { id: "2793", source: "The Ultima Warrior" }
 
-1248.5 "--sync--" sync / 00:0044:Vocal Guidance System:This humanoid prototype can perfectly replicate/ window 50,10 jump 1100.0
-1248.5 "--sync--" sync / 00:0044:Vocal Guidance System:Utilizing our data on Sophia/ window 50,10 jump 1200.0
-1248.5 "--sync--" sync / 00:0044:Vocal Guidance System:Successfully mimicking the Demon Zurvan/ window 50,10 jump 1300.0
+1248.5 "--sync--" GameLog { code: "0044", name: "Vocal Guidance System", line: "This humanoid prototype can perfectly replicate.*?" } window 50,10 jump 1100.0
+1248.5 "--sync--" GameLog { code: "0044", name: "Vocal Guidance System", line: "Utilizing our data on Sophia.*?" } window 50,10 jump 1200.0
+1248.5 "--sync--" GameLog { code: "0044", name: "Vocal Guidance System", line: "Successfully mimicking the Demon Zurvan.*?" } window 50,10 jump 1300.0
 1256.0 "Primordial Aether"
 1257.1 "Ceruleum Vent?"
 1258.6 "Infinite Fire/Infinite Ice?"
@@ -116,7 +116,7 @@ hideall "--sync--"
 
 # Zurvan's Block
 
-1300.0 "--sync--" sync / 00:0044:Vocal Guidance System:Successfully mimicking the Demon Zurvan/
+1300.0 "--sync--" GameLog { code: "0044", name: "Vocal Guidance System", line: "Successfully mimicking the Demon Zurvan.*?" }
 1308.5 "Primordial Aether" Ability { id: "2796", source: "The Ultima Warrior" } window 10,10
 1311.1 "Infinite Fire/Infinite Ice" Ability { id: "279[DE]", source: "The Ultima Warrior" }
 1319.1 "Ceruleum Vent" Ability { id: "2794", source: "The Ultima Warrior" }
@@ -125,9 +125,9 @@ hideall "--sync--"
 1343.0 "Citadel Buster" Ability { id: "2792", source: "The Ultima Warrior" }
 1354.0 "Aetheroplasm" Ability { id: "2793", source: "The Ultima Warrior" }
 
-1365.5 "--sync--" sync / 00:0044:Vocal Guidance System:This humanoid prototype can perfectly replicate/ window 50,10 jump 1100.0
-1365.5 "--sync--" sync / 00:0044:Vocal Guidance System:Utilizing our data on Sophia/ window 50,10 jump 1200.0
-1365.5 "--sync--" sync / 00:0044:Vocal Guidance System:Successfully mimicking the Demon Zurvan/ window 50,10 jump 1300.0
+1365.5 "--sync--" GameLog { code: "0044", name: "Vocal Guidance System", line: "This humanoid prototype can perfectly replicate.*?" } window 50,10 jump 1100.0
+1365.5 "--sync--" GameLog { code: "0044", name: "Vocal Guidance System", line: "Utilizing our data on Sophia.*?" } window 50,10 jump 1200.0
+1365.5 "--sync--" GameLog { code: "0044", name: "Vocal Guidance System", line: "Successfully mimicking the Demon Zurvan.*?" } window 50,10 jump 1300.0
 1373.0 "Primordial Aether"
 1374.1 "Ceruleum Vent?"
 1375.6 "Infinite Fire/Infinite Ice?"

--- a/ui/raidboss/data/04-sb/raid/o11n.ts
+++ b/ui/raidboss/data/04-sb/raid/o11n.ts
@@ -178,6 +178,7 @@ const triggerSet: TriggerSet<Data> = {
   timelineReplace: [
     {
       'locale': 'de',
+      'missingTranslations': true,
       'replaceSync': {
         'Engaging Delta Attack protocol': 'Reinitialisiere Deltaprotokoll',
         'Level Checker': 'Monitor',
@@ -205,6 +206,7 @@ const triggerSet: TriggerSet<Data> = {
     },
     {
       'locale': 'fr',
+      'missingTranslations': true,
       'replaceSync': {
         'Engaging Delta Attack protocol': 'Nécessité d\'utiliser l\'attaque Delta',
         'Level Checker': 'vérifiniveau',
@@ -233,6 +235,7 @@ const triggerSet: TriggerSet<Data> = {
     },
     {
       'locale': 'ja',
+      'missingTranslations': true,
       'replaceSync': {
         'Engaging Delta Attack protocol': 'デルタアタックの必要性を認定します',
         'Level Checker': 'レベルチェッカー',
@@ -260,6 +263,7 @@ const triggerSet: TriggerSet<Data> = {
     },
     {
       'locale': 'cn',
+      'missingTranslations': true,
       'replaceSync': {
         'Engaging Delta Attack protocol': '认定有必要使用三角攻击。',
         'Level Checker': '等级检测仪',
@@ -287,6 +291,7 @@ const triggerSet: TriggerSet<Data> = {
     },
     {
       'locale': 'ko',
+      'missingTranslations': true,
       'replaceSync': {
         'Engaging Delta Attack protocol': '델타 공격의 필요성을 인정합니다',
         'Level Checker': '레벨 측정기',

--- a/ui/raidboss/data/04-sb/raid/o11n.txt
+++ b/ui/raidboss/data/04-sb/raid/o11n.txt
@@ -53,7 +53,7 @@ hideall "--sync--"
 611.6 "Force Quit" Ability { id: "327A", source: "Level Checker" }
 
 ## Delta Attack
-1000.0 "--sync--" sync / 00:0044:Omega:Program failure detected/ window 1500,100
+1000.0 "--sync--" GameLog { code: "0044", name: "Omega", line: "Program failure detected.*?" } window 1500,100
 1007.0 "--sync--" StartsUsing { id: "327B", source: "Omega" } window 1500,100
 1037.0 "Delta Attack" Ability { id: "327B", source: "Omega" } window 1500,100
 1048.4 "--targetable--"

--- a/ui/raidboss/data/04-sb/raid/o12n.ts
+++ b/ui/raidboss/data/04-sb/raid/o12n.ts
@@ -182,6 +182,7 @@ const triggerSet: TriggerSet<Data> = {
   timelineReplace: [
     {
       'locale': 'de',
+      'missingTranslations': true,
       'replaceSync': {
         'Calculations indicate increased probability of defeat':
           'Warnung. Erhöhte Wahrscheinlichkeit einer Niederlage',
@@ -223,6 +224,7 @@ const triggerSet: TriggerSet<Data> = {
     },
     {
       'locale': 'fr',
+      'missingTranslations': true,
       'replaceSync': {
         '\\\\<blip\\\\> Warning\\\\\. Calculations indicate':
           'Alerte... Alerte... Forte augmentation',
@@ -264,6 +266,7 @@ const triggerSet: TriggerSet<Data> = {
     },
     {
       'locale': 'ja',
+      'missingTranslations': true,
       'replaceSync': {
         'Omega(?!-)': 'オメガ',
         'Omega-M': 'オメガM',
@@ -302,6 +305,7 @@ const triggerSet: TriggerSet<Data> = {
     },
     {
       'locale': 'cn',
+      'missingTranslations': true,
       'replaceSync': {
         'Calculations indicate increased probability of defeat': '警告……警告……失败的危险性上升……',
         'Omega(?!-)': '欧米茄',
@@ -341,6 +345,7 @@ const triggerSet: TriggerSet<Data> = {
     },
     {
       'locale': 'ko',
+      'missingTranslations': true,
       'replaceSync': {
         'Omega(?!-)': '오메가',
         'Omega-M': '오메가 M',

--- a/ui/raidboss/data/04-sb/raid/o12n.txt
+++ b/ui/raidboss/data/04-sb/raid/o12n.txt
@@ -51,7 +51,7 @@ hideall "--sync--"
 
 
 ### Phase 2: Passage of Arms
-500.0 "--sync--" sync / 00:0044:Omega-M:\<blip\> Limits of single combatant/ window 500,0
+500.0 "--sync--" GameLog { code: "0044", name: "Omega-M", line: "\<blip\> Limits of single combatant.*?" } window 500,0
 514.0 "Ground Zero" Ability { id: "3313", source: "Omega-M" } # drift 0.045001
 514.0 "Electric Slide" Ability { id: "3314", source: "Omega" }
 522.0 "Efficient Bladework" Ability { id: "32F3", source: "Omega-M" } # drift -0.045

--- a/ui/raidboss/data/04-sb/raid/o9n.ts
+++ b/ui/raidboss/data/04-sb/raid/o9n.ts
@@ -164,6 +164,7 @@ const triggerSet: TriggerSet<Data> = {
   timelineReplace: [
     {
       'locale': 'de',
+      'missingTranslations': true,
       'replaceSync': {
         'Chaos': 'Chaos',
         'YOU DARE!': 'Wie könnt ihr es wagen?!',
@@ -188,6 +189,7 @@ const triggerSet: TriggerSet<Data> = {
     },
     {
       'locale': 'fr',
+      'missingTranslations': true,
       'replaceSync': {
         'Chaos': 'Chaos',
         'YOU DARE!': '... Mon cristal !? Impossible !',
@@ -212,6 +214,7 @@ const triggerSet: TriggerSet<Data> = {
     },
     {
       'locale': 'ja',
+      'missingTranslations': true,
       'replaceSync': {
         'Chaos': 'カオス',
         'YOU DARE!': 'まさか……黒水晶を……！？',
@@ -236,6 +239,7 @@ const triggerSet: TriggerSet<Data> = {
     },
     {
       'locale': 'cn',
+      'missingTranslations': true,
       'replaceSync': {
         'Chaos': '卡奥斯',
         'YOU DARE!': '居然……把黑水晶给……',
@@ -260,6 +264,7 @@ const triggerSet: TriggerSet<Data> = {
     },
     {
       'locale': 'ko',
+      'missingTranslations': true,
       'replaceSync': {
         'Chaos': '카오스',
         'YOU DARE!': '네 이노오오옴',

--- a/ui/raidboss/data/04-sb/raid/o9n.txt
+++ b/ui/raidboss/data/04-sb/raid/o9n.txt
@@ -43,7 +43,7 @@ hideall "--sync--"
 1211.6 "--sync--" Ability { id: "3215", source: "Chaos" }
 1218.3 "Stray Flames" Ability { id: "316B", source: "Chaos" }
 1224.2 "Stray Spray" Ability { id: "316C", source: "Chaos" }
-1500.0 "--sync--" sync / 00:0044:Chaos:The crystal\.\.\.destroyed\!\?/ window 500,10
+1500.0 "--sync--" GameLog { code: "0044", name: "Chaos", line: "The crystal\.\.\.destroyed\!\?.*?" } window 500,10
 1503.0 "Soul of Chaos" Ability { id: "316A", source: "Chaos" } window 500,10
 1513.1 "--targetable--"
 # fake window into Water->Earth loop
@@ -77,7 +77,7 @@ hideall "--sync--"
 2212.8 "--sync--" Ability { id: "3215", source: "Chaos" }
 2219.5 "Stray Flames" Ability { id: "316B", source: "Chaos" }
 2225.4 "Stray Spray" Ability { id: "316C", source: "Chaos" }
-2500.0 "--sync--" sync / 00:0044:Chaos:The crystal\.\.\.destroyed\!\?/ window 500,10
+2500.0 "--sync--" GameLog { code: "0044", name: "Chaos", line: "The crystal\.\.\.destroyed\!\?.*?" } window 500,10
 2503.0 "Soul of Chaos" Ability { id: "316A", source: "Chaos" } window 500,10
 # fake window into Fire->Air loop
 2529.5 "Chaotic Dispersion" Ability { id: "314F", source: "Chaos" } window 50,50 jump 3212.6

--- a/ui/raidboss/data/05-shb/eureka/delubrum_reginae_savage.txt
+++ b/ui/raidboss/data/05-shb/eureka/delubrum_reginae_savage.txt
@@ -412,7 +412,7 @@ hideall "--sync--"
 # This is the zone, but can't use this sync as it can be seen by Dahu.  Sync to autos instead.
 # Pride of the Lioness will be sealed off
 #8000.0 "--sync--" SystemLogMessage { id: "7DC", param1: "E1C" } window 20000,0
-8000.0 "--Reset--" sync / 00:0044:Stygimoloch Warrior:Why\.\.\.won't\.\.\.you\.\.\./ window 0,2000 jump 0
+8000.0 "--Reset--" GameLog { code: "0044", name: "Stygimoloch Warrior", line: "Why\.\.\.won't\.\.\.you\.\.\..*?" } window 0,2000 jump 0
 # TODO: is there a reset dialog line for losing?
 # Alternatively, we could always insert " 19:${data.me} was defeated by" from script.
 

--- a/ui/raidboss/data/05-shb/trial/hades-ex.ts
+++ b/ui/raidboss/data/05-shb/trial/hades-ex.ts
@@ -704,6 +704,7 @@ const triggerSet: TriggerSet<Data> = {
   timelineReplace: [
     {
       'locale': 'de',
+      'missingTranslations': true,
       'replaceSync': {
         'Aetherial Gaol': 'Ätherkerker',
         'Arcane Font': 'Arkan(?:e|er|es|en) Körper',
@@ -768,6 +769,7 @@ const triggerSet: TriggerSet<Data> = {
     },
     {
       'locale': 'fr',
+      'missingTranslations': true,
       'replaceSync': {
         'Aetherial Gaol': 'Geôle Éthérée',
         'Arcane Font': 'Solide Arcanique',
@@ -962,6 +964,7 @@ const triggerSet: TriggerSet<Data> = {
     },
     {
       'locale': 'ko',
+      'missingTranslations': true,
       'replaceSync': {
         'Aetherial Gaol': '에테르 감옥',
         'Arcane Font': '입체 마법진',

--- a/ui/raidboss/data/05-shb/trial/hades-ex.txt
+++ b/ui/raidboss/data/05-shb/trial/hades-ex.txt
@@ -70,7 +70,7 @@ hideall "--sync--"
 
 
 ### Phase 3
-493.0 "--sync--" sync / 00:0044:Hades:Our plea transcends/ window 500,0
+493.0 "--sync--" GameLog { code: "0044", name: "Hades", line: "Our plea transcends.*?" } window 500,0
 # 00:0044:Hades:At last, you are one!
 499.9 "--targetable--"
 500.0 "--sync--" StartsUsing { id: "47C8", source: "Ascian Prime's Shade" } window 500,0

--- a/ui/raidboss/data/06-ew/dungeon/lapis_manalis.txt
+++ b/ui/raidboss/data/06-ew/dungeon/lapis_manalis.txt
@@ -162,7 +162,7 @@ hideall "--sync--"
 2145.1 "Hydrovent" Ability { id: "79A0", source: "Cagnazzo" }
 # probably more Hydrovent spam here until phase end or enrage
 
-2500.0 "--sync--" sync / 00:0044:Cagnazzo:No more games!/ window 500,0
+2500.0 "--sync--" GameLog { code: "0044", name: "Cagnazzo", line: "No more games!.*?" } window 500,0
 2513.0 "Tsunami" Ability { id: "79A1", source: "Cagnazzo" } window 500,1 # if we miss the chatline sync we'll still resync here
 2516.9 "--targetable--"
 2523.0 "--sync--" Ability { id: "799B", source: "Cagnazzo" }


### PR DESCRIPTION
`/sync\s*\/ 00:(?<code>[^:]*):(?<name>[^:]*):(?<line>[^:]*)\//`

Because parameters are now translated individually vs the sync as a whole, there are now missing translations (that were missing before, but not seen by the script).

Done by running #5977.