### PR TITLE
raidboss: timeline netregex for interrupt

### DIFF
--- a/ui/raidboss/data/04-sb/eureka/eureka_hydatos.txt
+++ b/ui/raidboss/data/04-sb/eureka/eureka_hydatos.txt
@@ -136,7 +136,7 @@ hideall "--sync--"
 3124.4 "Streak Lightning" #Ability { id: "3877", source: "Streak Lightning" }
 3134.9 "Ultimate Zantetsuken" StartsUsing { id: "3878", source: "Raiden" } duration 20
 
-3154.9 "--sync--" sync / 17:[^:]*:Raiden:3878:/ window 40,0
+3154.9 "--sync--" NetworkCancelAbility { id: "3878", source: "Raiden" } window 40,0
 3164.9 "Spirits of the Fallen" Ability { id: "387A", source: "Raiden" } window 40,5
 3171.2 "Booming Lament" Ability { id: "387D", source: "Raiden" }
 3177.3 "Cloud to Ground" Ability { id: "3870", source: "Raiden" }
@@ -158,7 +158,7 @@ hideall "--sync--"
 3316.0 "Lateral Zantetsuken" Ability { id: "386[BC]", source: "Raiden" }
 3321.7 "Ultimate Zantetsuken" StartsUsing { id: "3878", source: "Raiden" } duration 20
 
-3341.7 "--sync--" sync / 17:[^:]*:Raiden:3878:/ window 40,0
+3341.7 "--sync--" NetworkCancelAbility { id: "3878", source: "Raiden" } window 40,0
 3347.7 "Spirits of the Fallen" Ability { id: "387A", source: "Raiden" } window 40,5
 3353.8 "Shingan" Ability { id: "387B", source: "Raiden" }
 3365.4 "Ame-no-Sakahoko" Ability { id: "3868", source: "Raiden" }

--- a/ui/raidboss/data/06-ew/ultimate/dragonsongs_reprise_ultimate.txt
+++ b/ui/raidboss/data/06-ew/ultimate/dragonsongs_reprise_ultimate.txt
@@ -153,7 +153,7 @@ hideall "--sync--"
 
 # If Aetheric Burst gets interrupted, then we can sync earlier,
 # but if you kill it before then, there's less indication of when to sync.
-993.1 "--sync--" sync / 17:[^:]*:King Thordan:63C3:/ window 300,0
+993.1 "--sync--" NetworkCancelAbility { id: "63C3", source: "King Thordan" } window 300,0
 1000.0 "--sync--" Ability { id: "6708", source: "Nidhogg" } window 1000,0
 1002.3 "--targetable--"
 1002.3 "Final Chorus" Ability { id: "6709", source: "Nidhogg" }


### PR DESCRIPTION
`/sync\s*\/ 17:\[\^:\]\*:(?<source>[^:]*):(?<id>[^:]*):\//`

Done by running #5977.