### PR TITLE
raidboss: timeline netregex for sourceGroups

### DIFF
--- a/ui/raidboss/data/02-arr/raid/t9.txt
+++ b/ui/raidboss/data/02-arr/raid/t9.txt
@@ -12,7 +12,7 @@ hideall "--sync--"
 16.6 "Ravensclaw" Ability { id: "7D5", source: "Nael deus Darnus" }
 
 21.8 "Stardust" Ability { id: "877", source: "Nael deus Darnus" } duration 9
-30.8 "--sync--" Ability { id: "7E9", source: "(Astral Debris|Umbral Debris)" }
+30.8 "--sync--" Ability { id: "7E9", source: ['Astral Debris', 'Umbral Debris'] }
 30.9 "Ravensbeak" Ability { id: "7D6", source: "Nael deus Darnus" } duration 13
 36.2 "Raven Dive" Ability { id: "7DD", source: "Nael deus Darnus" }
 40.8 "Iron Chariot" Ability { id: "7D8", source: "Nael deus Darnus" }
@@ -23,7 +23,7 @@ hideall "--sync--"
 
 58.6 "Stardust" Ability { id: "877", source: "Nael deus Darnus" } duration 9
 63.4 "Ravensclaw" Ability { id: "7D5", source: "Nael deus Darnus" }
-67.6 "--sync--" Ability { id: "7E9", source: "(Astral Debris|Umbral Debris)" }
+67.6 "--sync--" Ability { id: "7E9", source: ['Astral Debris', 'Umbral Debris'] }
 69.4 "Lunar Dynamo" Ability { id: "7DA", source: "Nael deus Darnus" }
 71.8 "Meteor Stream" Ability { id: "7DE", source: "Nael Geminus" }
 74.9 "Dalamud Dive" Ability { id: "7DC", source: "Nael deus Darnus" }
@@ -32,7 +32,7 @@ hideall "--sync--"
 
 95.0 "Stardust" Ability { id: "877", source: "Nael deus Darnus" } duration 9
 96.6 "--sync--" Ability { id: "7D7", source: "Nael deus Darnus" }
-104.0 "--sync--" Ability { id: "7E9", source: "(Astral Debris|Umbral Debris)" }
+104.0 "--sync--" Ability { id: "7E9", source: ['Astral Debris', 'Umbral Debris'] }
 107.2 "Meteor Stream" #Ability { id: "7DE", source: "Nael Geminus" }
 112.3 "Meteor Stream" #Ability { id: "7DE", source: "Nael Geminus" }
 115.4 "Dalamud Dive" Ability { id: "7DC", source: "Nael deus Darnus" }
@@ -42,7 +42,7 @@ hideall "--sync--"
 135.5 "Stardust" Ability { id: "877", source: "Nael deus Darnus" } duration 9
 140.0 "Ravensclaw" Ability { id: "7D5", source: "Nael deus Darnus" }
 143.2 "--sync--" Ability { id: "7D7", source: "Nael deus Darnus" }
-144.6 "--sync--" Ability { id: "7E9", source: "(Astral Debris|Umbral Debris)" }
+144.6 "--sync--" Ability { id: "7E9", source: ['Astral Debris', 'Umbral Debris'] }
 146.1 "Raven Dive" Ability { id: "7DD", source: "Nael deus Darnus" }
 150.7 "Iron Chariot" Ability { id: "7D8", source: "Nael deus Darnus" }
 152.6 "Thermionic Beam" Ability { id: "7DF", source: "Nael deus Darnus" }
@@ -51,7 +51,7 @@ hideall "--sync--"
 
 168.6 "Stardust" Ability { id: "877", source: "Nael deus Darnus" } duration 9
 177.4 "Ravensbeak" Ability { id: "7D6", source: "Nael deus Darnus" } duration 13
-177.7 "--sync--" Ability { id: "7E9", source: "(Astral Debris|Umbral Debris)" }
+177.7 "--sync--" Ability { id: "7E9", source: ['Astral Debris', 'Umbral Debris'] }
 183.9 "Lunar Dynamo" Ability { id: "7DA", source: "Nael deus Darnus" }
 186.2 "Meteor Stream" Ability { id: "7DE", source: "Nael Geminus" }
 189.3 "Dalamud Dive" Ability { id: "7DC", source: "Nael deus Darnus" }
@@ -60,7 +60,7 @@ hideall "--sync--"
 
 203.9 "Stardust" Ability { id: "877", source: "Nael deus Darnus" } duration 9
 208.0 "Ravensclaw" Ability { id: "7D5", source: "Nael deus Darnus" }
-213.0 "--sync--" Ability { id: "7E9", source: "(Astral Debris|Umbral Debris)" }
+213.0 "--sync--" Ability { id: "7E9", source: ['Astral Debris', 'Umbral Debris'] }
 217.5 "Meteor Stream" #Ability { id: "7DE", source: "Nael Geminus" }
 222.6 "Meteor Stream" #Ability { id: "7DE", source: "Nael Geminus" }
 225.8 "Dalamud Dive" Ability { id: "7DC", source: "Nael deus Darnus" }
@@ -68,7 +68,7 @@ hideall "--sync--"
 239.6 "Ravensclaw" Ability { id: "7D5", source: "Nael deus Darnus" }
 
 245.8 "Stardust" Ability { id: "877", source: "Nael deus Darnus" } duration 9
-254.8 "--sync--" Ability { id: "7E9", source: "(Astral Debris|Umbral Debris)" }
+254.8 "--sync--" Ability { id: "7E9", source: ['Astral Debris', 'Umbral Debris'] }
 255.5 "Raven Dive" Ability { id: "7DD", source: "Nael deus Darnus" }
 260.1 "Iron Chariot" Ability { id: "7D8", source: "Nael deus Darnus" }
 262.1 "Thermionic Beam" Ability { id: "7DF", source: "Nael deus Darnus" }
@@ -78,7 +78,7 @@ hideall "--sync--"
 
 283.0 "Stardust" Ability { id: "877", source: "Nael deus Darnus" } duration 9
 286.8 "Ravensclaw" Ability { id: "7D5", source: "Nael deus Darnus" }
-292.0 "--sync--" Ability { id: "7E9", source: "(Astral Debris|Umbral Debris)" }
+292.0 "--sync--" Ability { id: "7E9", source: ['Astral Debris', 'Umbral Debris'] }
 294.3 "Lunar Dynamo" Ability { id: "7DA", source: "Nael deus Darnus" }
 296.7 "Meteor Stream" Ability { id: "7DE", source: "Nael Geminus" }
 299.9 "Dalamud Dive" Ability { id: "7DC", source: "Nael deus Darnus" }
@@ -86,7 +86,7 @@ hideall "--sync--"
 
 314.3 "Stardust" Ability { id: "877", source: "Nael deus Darnus" } duration 9
 322.8 "Ravensbeak" Ability { id: "7D6", source: "Nael deus Darnus" }
-323.3 "--sync--" Ability { id: "7E9", source: "(Astral Debris|Umbral Debris)" }
+323.3 "--sync--" Ability { id: "7E9", source: ['Astral Debris', 'Umbral Debris'] }
 332.0 "Meteor Stream" Ability { id: "7DE", source: "Nael Geminus" }
 335.9 "--sync--" Ability { id: "7D7", source: "Nael deus Darnus" }
 337.0 "Meteor Stream" Ability { id: "7DE", source: "Nael Geminus" }
@@ -95,7 +95,7 @@ hideall "--sync--"
 
 355.0 "Stardust" Ability { id: "877", source: "Nael deus Darnus" } duration 9
 358.5 "Ravensclaw" Ability { id: "7D5", source: "Nael deus Darnus" }
-364.0 "--sync--" Ability { id: "7E9", source: "(Astral Debris|Umbral Debris)" }
+364.0 "--sync--" Ability { id: "7E9", source: ['Astral Debris', 'Umbral Debris'] }
 366.0 "Raven Dive" Ability { id: "7DD", source: "Nael deus Darnus" }
 370.5 "Iron Chariot" Ability { id: "7D8", source: "Nael deus Darnus" }
 372.7 "Thermionic Beam" Ability { id: "7DF", source: "Nael deus Darnus" }

--- a/ui/raidboss/data/03-hw/alliance/dun_scaith.ts
+++ b/ui/raidboss/data/03-hw/alliance/dun_scaith.ts
@@ -638,7 +638,7 @@ const triggerSet: TriggerSet<Data> = {
     {
       'locale': 'de',
       'replaceSync': {
-        'Aether': 'Äthersphäre',
+        'Aether(?!i)': 'Äthersphäre',
         'Aether Collector': 'Ätherakkumulator',
         'Aetherial Chakram': 'ätherisch(?:e|er|es|en) Chakram',
         'Connla': 'Connla',
@@ -739,7 +739,7 @@ const triggerSet: TriggerSet<Data> = {
     {
       'locale': 'fr',
       'replaceSync': {
-        'Aether': 'sphère éthérée',
+        'Aether(?!i)': 'sphère éthérée',
         'Aether Collector': 'accumulateur d\'éther',
         'Aetherial Chakram': 'chakram éthéré',
         'Connla': 'Connla',
@@ -1041,7 +1041,7 @@ const triggerSet: TriggerSet<Data> = {
     {
       'locale': 'ko',
       'replaceSync': {
-        'Aether': '에테르 구체',
+        'Aether(?!i)': '에테르 구체',
         'Aether Collector': '에테르 집적기',
         'Aetherial Chakram': '에테르 차크람',
         'Connla': '콘라',

--- a/ui/raidboss/data/03-hw/alliance/dun_scaith.txt
+++ b/ui/raidboss/data/03-hw/alliance/dun_scaith.txt
@@ -121,18 +121,18 @@ hideall "--sync--"
 1014.2 "Black Wind x3" # Ability { id: "1CAC", source: "Ferdiad Hollow" }
 1020.3 "Sleight" Ability { id: "1C99", source: "Ferdiad Hollow" }
 1028.0 "Wormhole" Ability { id: "1C9A", source: "Ferdiad Hollow" }
-1028.3 "--sync--" Ability { id: "1C49", source: "(Cursing Atomos|Wailing Atomos)" }
-1028.5 "Juggling Sphere" Ability { id: "1C(9F|A0)", source: "(Aether|Aetherial Chakram)" }
-1030.0 "--sync--" Ability { id: "1C9[CD]", source: "(Cursing Atomos|Wailing Atomos)" }
-1033.2 "Explosion" Ability { id: "1CA[12]", source: "(Aether|Aetherial Chakram)" }
+1028.3 "--sync--" Ability { id: "1C49", source: ['Cursing Atomos', 'Wailing Atomos'] }
+1028.5 "Juggling Sphere" Ability { id: "1C(9F|A0)", source: ['Aether', 'Aetherial Chakram'] }
+1030.0 "--sync--" Ability { id: "1C9[CD]", source: ['Cursing Atomos', 'Wailing Atomos'] }
+1033.2 "Explosion" Ability { id: "1CA[12]", source: ['Aether', 'Aetherial Chakram'] }
 1039.2 "Jester's Reap" Ability { id: "1E41", source: "Ferdiad Hollow" }
 1047.2 "Jongleur's X" Ability { id: "1C98", source: "Ferdiad Hollow" }
 1052.2 "Sleight" Ability { id: "1C99", source: "Ferdiad Hollow" }
 1060.5 "Wormhole" Ability { id: "1C9A", source: "Ferdiad Hollow" }
-1060.8 "--sync--" Ability { id: "1C49", source: "(Cursing Atomos|Wailing Atomos)" }
-1061.0 "Juggling Sphere" Ability { id: "1C(9F|A0)", source: "(Aether|Aetherial Chakram)" }
-1062.5 "--sync--" Ability { id: "1C9[CD]", source: "(Cursing Atomos|Wailing Atomos)" }
-1065.7 "Explosion" Ability { id: "1CA[12]", source: "(Aether|Aetherial Chakram)" }
+1060.8 "--sync--" Ability { id: "1C49", source: ['Cursing Atomos', 'Wailing Atomos'] }
+1061.0 "Juggling Sphere" Ability { id: "1C(9F|A0)", source: ['Aether', 'Aetherial Chakram'] }
+1062.5 "--sync--" Ability { id: "1C9[CD]", source: ['Cursing Atomos', 'Wailing Atomos'] }
+1065.7 "Explosion" Ability { id: "1CA[12]", source: ['Aether', 'Aetherial Chakram'] }
 1069.7 "Debilitator" Ability { id: "1CA6", source: "Ferdiad Hollow" }
 1079.9 "Jongleur's X" Ability { id: "1C98", source: "Ferdiad Hollow" }
 1087.4 "Flameflow" Ability { id: "1CA7", source: "Ferdiad Hollow" }
@@ -155,10 +155,10 @@ hideall "--sync--"
 
 1319.0 "Sleight" Ability { id: "1C99", source: "Ferdiad Hollow" }
 1327.5 "Wormhole" Ability { id: "1C9A", source: "Ferdiad Hollow" }
-1327.8 "--sync--" Ability { id: "1C49", source: "(Cursing Atomos|Wailing Atomos)" }
-1328.0 "Juggling Sphere" Ability { id: "1C(9F|A0)", source: "(Aether|Aetherial Chakram)" }
-1329.6 "--sync--" Ability { id: "1C9[CD]", source: "(Cursing Atomos|Wailing Atomos)" }
-1333.0 "Explosion" Ability { id: "1CA[12]", source: "(Aether|Aetherial Chakram)" } window 15,15
+1327.8 "--sync--" Ability { id: "1C49", source: ['Cursing Atomos', 'Wailing Atomos'] }
+1328.0 "Juggling Sphere" Ability { id: "1C(9F|A0)", source: ['Aether', 'Aetherial Chakram'] }
+1329.6 "--sync--" Ability { id: "1C9[CD]", source: ['Cursing Atomos', 'Wailing Atomos'] }
+1333.0 "Explosion" Ability { id: "1CA[12]", source: ['Aether', 'Aetherial Chakram'] } window 15,15
 1338.1 "Jester's Reap" Ability { id: "1E41", source: "Ferdiad Hollow" }
 1348.8 "Black Wind" # Ability { id: "1CAC", source: "Ferdiad Hollow" }
 1362.4 "Blackfire" Ability { id: "1CAA", source: "Ferdiad Hollow" }

--- a/ui/raidboss/data/03-hw/dungeon/aetherochemical_research_facility.txt
+++ b/ui/raidboss/data/03-hw/dungeon/aetherochemical_research_facility.txt
@@ -76,7 +76,7 @@ hideall "--sync--"
 360.0 "--sync--" Ability { id: "10DF", source: "Regula van Hydrus" }
 361.3 "Aetherochemical Grenado" Ability { id: "10E2", source: "Magitek Turret II" }
 365.0 "Magitek Slug" Ability { id: "10DB", source: "Regula van Hydrus" }
-368.0 "Self-detonate?" Ability { id: "10E3", source: "(Magitek Turret I|Magitek Turret II)" }
+368.0 "Self-detonate?" Ability { id: "10E3", source: ['Magitek Turret I', 'Magitek Turret II'] }
 368.7 "Magitek Slug" Ability { id: "10DB", source: "Regula van Hydrus" }
 372.5 "Magitek Slug" Ability { id: "10DB", source: "Regula van Hydrus" }
 373.7 "--sync--" Ability { id: "10DF", source: "Regula van Hydrus" }

--- a/ui/raidboss/data/03-hw/raid/a10n.txt
+++ b/ui/raidboss/data/03-hw/raid/a10n.txt
@@ -19,10 +19,10 @@ hideall "--sync--"
 56.7 "Trap" Ability { id: "(1AB0|1AB1)", source: "Lamebrix Strikebocks" } window 56.7,5
 58.0 "--sync--" Ability { id: "1AA2", source: "Lamebrix Strikebocks" }
 61.1 "Goblin Rush" Ability { id: "1A17", source: "Lamebrix Strikebocks" }
-61.7 "Frostbite/Impact" Ability { id: "(1AC7|1AC6)", source: "(Blizzard Arrow|Weight of the World)" }
+61.7 "Frostbite/Impact" Ability { id: "(1AC7|1AC6)", source: ['Blizzard Arrow', 'Weight of the World'] }
 69.0 "Trap" Ability { id: "(1AB0|1AB1)", source: "Lamebrix Strikebocks" }
 70.3 "--sync--" Ability { id: "1AA2", source: "Lamebrix Strikebocks" }
-74.0 "Impact/Frostbite" Ability { id: "(1AC7|1AC6)", source: "(Blizzard Arrow|Weight of the World)" }
+74.0 "Impact/Frostbite" Ability { id: "(1AC7|1AC6)", source: ['Blizzard Arrow', 'Weight of the World'] }
 74.9 "Illuminati Hand Cannon" Ability { id: "1AD2", source: "Lamebrix Strikebocks" }
 78.0 "Goblin Rush" Ability { id: "1A17", source: "Lamebrix Strikebocks" }
 87.1 "Gobslash Slicetops" Ability { id: "1AD1", source: "Lamebrix Strikebocks" }
@@ -83,9 +83,9 @@ hideall "--sync--"
 393.3 "Goblin Rush" Ability { id: "1A17", source: "Lamebrix Strikebocks" }
 398.2 "Trap #1" Ability { id: "(1AB0|1AB1)", source: "Lamebrix Strikebocks" } window 100,2.5
 402.3 "Trap #2" Ability { id: "(1AB0|1AB1)", source: "Lamebrix Strikebocks" }
-403.2 "Frostbite/Impact" Ability { id: "(1AC7|1AC6)", source: "(Blizzard Arrow|Weight of the World)" }
+403.2 "Frostbite/Impact" Ability { id: "(1AC7|1AC6)", source: ['Blizzard Arrow', 'Weight of the World'] }
 403.6 "--sync--" Ability { id: "1AA2", source: "Lamebrix Strikebocks" }
-407.3 "Impact/Frostbite" Ability { id: "(1AC7|1AC6)", source: "(Blizzard Arrow|Weight of the World)" }
+407.3 "Impact/Frostbite" Ability { id: "(1AC7|1AC6)", source: ['Blizzard Arrow', 'Weight of the World'] }
 408.9 "Illuminati Hand Cannon" Ability { id: "1AD2", source: "Lamebrix Strikebocks" }
 418.1 "Gobslash Slicetops" Ability { id: "1AD1", source: "Lamebrix Strikebocks" }
 422.1 "Goblin Rush" Ability { id: "1A17", source: "Lamebrix Strikebocks" }

--- a/ui/raidboss/data/03-hw/raid/a3s.txt
+++ b/ui/raidboss/data/03-hw/raid/a3s.txt
@@ -38,7 +38,7 @@ hideall "--sync--"
 107.6 "Wash Away" Ability { id: "F07", source: "Living Liquid" }
 109.6 "--split--"
 115.8 "Fluid Strike" Ability { id: "F06", source: "Living Liquid" }
-125.0 "Hand Of Prayer/Parting" Ability { id: "F0[BC]", source: "(Living Liquid|Liquid Limb)" }
+125.0 "Hand Of Prayer/Parting" Ability { id: "F0[BC]", source: ['Living Liquid', 'Liquid Limb'] }
 136.9 "Digititis" Ability { id: "F08", source: "Living Liquid" }
 137.1 "Equal Concentration" Ability { id: "F09", source: "Liquid Limb" }
 137.1 "--dps burn--" duration 27.4
@@ -47,7 +47,7 @@ hideall "--sync--"
 149.2 "Fluid Strike x2" Ability { id: "F06", source: "Living Liquid" }
 157.4 "Fluid Strike x2" Ability { id: "F06", source: "Living Liquid" }
 164.5 "Hand Of Pain" Ability { id: "F0A", source: "Living Liquid" }
-174.7 "Hand Of Prayer/Parting" Ability { id: "F0[BC]", source: "(Living Liquid|Liquid Limb)" }
+174.7 "Hand Of Prayer/Parting" Ability { id: "F0[BC]", source: ['Living Liquid', 'Liquid Limb'] }
 178.8 "Fluid Strike x2" Ability { id: "F06", source: "Living Liquid" }
 183.8 "--sync--" Ability { id: "F28", source: "Hydrate Core" }
 184.9 "--sync--" Ability { id: "F24", source: "Living Liquid" }

--- a/ui/raidboss/data/03-hw/trial/thordan-ex.txt
+++ b/ui/raidboss/data/03-hw/trial/thordan-ex.txt
@@ -43,7 +43,7 @@ hideall "--sync--"
 104.3 "Conviction" Ability { id: "149D", source: "Ser Hermenost" }
 107.4 "Sacred Cross" StartsUsing { id: "1490", source: "Ser Zephirin" } duration 19.7
 127.1 "--sync--" Ability { id: "1490", source: "Ser Zephirin" }
-133.1 "Spiral Thrust" Ability { id: "14A6", source: "(Ser Ignasse|Ser Paulecrain|Ser Vellguine)" }
+133.1 "Spiral Thrust" Ability { id: "14A6", source: ['Ser Ignasse', 'Ser Paulecrain', 'Ser Vellguine'] }
 
 # Intermission part 2
 # This loops until both Adelphel and Janlenoux are dead.
@@ -54,28 +54,28 @@ hideall "--sync--"
 # but it's more important that we sync during the loop,
 # so we accept a small amount of jumpiness in the timeline.
 140.2 "--targetable--"
-150.2 "Divine Right" Ability { id: "1493", source: "(Ser Adelphel|Ser Janlenoux)" }
-159.3 "Holy Bladedance" Ability { id: "1496", source: "(Ser Adelphel|Ser Janlenoux)" }
+150.2 "Divine Right" Ability { id: "1493", source: ['Ser Adelphel', 'Ser Janlenoux'] }
+159.3 "Holy Bladedance" Ability { id: "1496", source: ['Ser Adelphel', 'Ser Janlenoux'] }
 175.3 "Skyward Leap 1" Ability { id: "14A9", source: "Ser Vellguine" }
-177.3 "Divine Right" Ability { id: "1493", source: "(Ser Adelphel|Ser Janlenoux)" }
+177.3 "Divine Right" Ability { id: "1493", source: ['Ser Adelphel', 'Ser Janlenoux'] }
 178.3 "Skyward Leap 2" Ability { id: "14A9", source: "Ser Paulecrain" }
-179.4 "Heavenly Slash" Ability { id: "1494", source: "(Ser Adelphel|Ser Janlenoux)" }
+179.4 "Heavenly Slash" Ability { id: "1494", source: ['Ser Adelphel', 'Ser Janlenoux'] }
 181.3 "Skyward Leap 3" Ability { id: "14A9", source: "Ser Ignasse" }
-192.4 "Holiest Of Holy" Ability { id: "1495", source: "(Ser Adelphel|Ser Janlenoux)" }
-198.5 "Holy Bladedance" Ability { id: "1496", source: "(Ser Adelphel|Ser Janlenoux)" }
-205.6 "Divine Right" Ability { id: "1493", source: "(Ser Adelphel|Ser Janlenoux)" }
-212.7 "Holiest Of Holy" Ability { id: "1495", source: "(Ser Adelphel|Ser Janlenoux)" }
-216.8 "Heavenly Slash" Ability { id: "1494", source: "(Ser Adelphel|Ser Janlenoux)" }
+192.4 "Holiest Of Holy" Ability { id: "1495", source: ['Ser Adelphel', 'Ser Janlenoux'] }
+198.5 "Holy Bladedance" Ability { id: "1496", source: ['Ser Adelphel', 'Ser Janlenoux'] }
+205.6 "Divine Right" Ability { id: "1493", source: ['Ser Adelphel', 'Ser Janlenoux'] }
+212.7 "Holiest Of Holy" Ability { id: "1495", source: ['Ser Adelphel', 'Ser Janlenoux'] }
+216.8 "Heavenly Slash" Ability { id: "1494", source: ['Ser Adelphel', 'Ser Janlenoux'] }
 
-232.9 "Divine Right" Ability { id: "1493", source: "(Ser Adelphel|Ser Janlenoux)" }
-242.0 "Holy Bladedance" Ability { id: "1496", source: "(Ser Adelphel|Ser Janlenoux)" }
-260.0 "Divine Right" Ability { id: "1493", source: "(Ser Adelphel|Ser Janlenoux)" }
-262.1 "Heavenly Slash" Ability { id: "1494", source: "(Ser Adelphel|Ser Janlenoux)" }
-275.2 "Holiest Of Holy" Ability { id: "1495", source: "(Ser Adelphel|Ser Janlenoux)" }
-281.3 "Holy Bladedance" Ability { id: "1496", source: "(Ser Adelphel|Ser Janlenoux)" }
-288.3 "Divine Right" Ability { id: "1493", source: "(Ser Adelphel|Ser Janlenoux)" }
-295.4 "Holiest Of Holy" Ability { id: "1495", source: "(Ser Adelphel|Ser Janlenoux)" }
-299.5 "Heavenly Slash" Ability { id: "1494", source: "(Ser Adelphel|Ser Janlenoux)" } forcejump 216.8
+232.9 "Divine Right" Ability { id: "1493", source: ['Ser Adelphel', 'Ser Janlenoux'] }
+242.0 "Holy Bladedance" Ability { id: "1496", source: ['Ser Adelphel', 'Ser Janlenoux'] }
+260.0 "Divine Right" Ability { id: "1493", source: ['Ser Adelphel', 'Ser Janlenoux'] }
+262.1 "Heavenly Slash" Ability { id: "1494", source: ['Ser Adelphel', 'Ser Janlenoux'] }
+275.2 "Holiest Of Holy" Ability { id: "1495", source: ['Ser Adelphel', 'Ser Janlenoux'] }
+281.3 "Holy Bladedance" Ability { id: "1496", source: ['Ser Adelphel', 'Ser Janlenoux'] }
+288.3 "Divine Right" Ability { id: "1493", source: ['Ser Adelphel', 'Ser Janlenoux'] }
+295.4 "Holiest Of Holy" Ability { id: "1495", source: ['Ser Adelphel', 'Ser Janlenoux'] }
+299.5 "Heavenly Slash" Ability { id: "1494", source: ['Ser Adelphel', 'Ser Janlenoux'] } forcejump 216.8
 
 
 # Intermission part 3
@@ -83,8 +83,8 @@ hideall "--sync--"
 352.0 "--sync--" Ability { id: "1018", source: "Ser Grinnaux" } window 150,10
 353.0 "--sync--" Ability { id: "1018", source: "Ser Haumeric" } window 150,10
 359.6 "Hiemal Storm" Ability { id: "14AE", source: "Ser Haumeric" } window 328,10
-359.8 "--sync--" Ability { id: "14AF", source: "(Ser Haumeric|Ser Noudenet)" } # Hiemal Storm
-360.2 "Spiral Pierce" Ability { id: "14A7", source: "(Ser Ignasse|Ser Paulecrain|Ser Vellguine)" }
+359.8 "--sync--" Ability { id: "14AF", source: ['Ser Haumeric', 'Ser Noudenet'] } # Hiemal Storm
+360.2 "Spiral Pierce" Ability { id: "14A7", source: ['Ser Ignasse', 'Ser Paulecrain', 'Ser Vellguine'] }
 361.5 "Dimensional Collapse" Ability { id: "1499", source: "Ser Grinnaux" }
 361.9 "--sync--" Ability { id: "149A", source: "Ser Grinnaux" } # Dimensional Collapse
 365.0 "Faith Unmoving" Ability { id: "149B", source: "Ser Grinnaux" }
@@ -120,7 +120,7 @@ hideall "--sync--"
 466.4 "the Dragon's Eye" Ability { id: "1488", source: "King Thordan" }
 476.6 "Knights Of the Round" Ability { id: "148C", source: "King Thordan" }
 481.7 "Ascalon's Might" Ability { id: "147E", source: "King Thordan" }
-488.1 "Holy Shield Bash" Ability { id: "1497", source: "(Ser Adelphel|Ser Janlenoux)" }
+488.1 "Holy Shield Bash" Ability { id: "1497", source: ['Ser Adelphel', 'Ser Janlenoux'] }
 497.1 "Spear Of the Fury" Ability { id: "1492", source: "Ser Zephirin" } # A smile better suits a hero
 499.5 "Heavenly Heel" Ability { id: "1487", source: "King Thordan" }
 504.6 "The Dragon's Gaze/The Dragon's Glory" Ability { id: "(1489|148A)", source: "King Thordan" }
@@ -170,7 +170,7 @@ hideall "--sync--"
 645.3 "Heavensflame 2" #Ability { id: "14AC", source: "Ser Charibert" }
 646.4 "Heavensflame 3" #Ability { id: "14AC", source: "Ser Charibert" }
 646.8 "Hiemal Storm" Ability { id: "14AE", source: "Ser Haumeric" }
-647.4 "--sync--" Ability { id: "14AF", source: "(Ser Haumeric|Ser Noudenet)" } # Hiemal Storm
+647.4 "--sync--" Ability { id: "14AF", source: ['Ser Haumeric', 'Ser Noudenet'] } # Hiemal Storm
 648.7 "Ascalon's Mercy" Ability { id: "147F", source: "King Thordan" }
 656.8 "Ancient Quaga" Ability { id: "1485", source: "King Thordan" }
 662.9 "Heavenly Heel" Ability { id: "1487", source: "King Thordan" }
@@ -187,7 +187,7 @@ hideall "--sync--"
 707.6 "Heavensward Leap 2" Ability { id: "14AA", source: "Ser Paulecrain" }
 710.6 "Heavensward Leap 3" Ability { id: "14AA", source: "Ser Ignasse" }
 718.7 "Sacred Cross" StartsUsing { id: "1491", source: "Ser Zephirin" } duration 24.7
-724.6 "Pure Of Soul" Ability { id: "(14B1|14B2)", source: "(Ser Charibert|Ser Noudenet|Ser Haumeric)" }
+724.6 "Pure Of Soul" Ability { id: "(14B1|14B2)", source: ['Ser Charibert', 'Ser Noudenet', 'Ser Haumeric'] }
 732.6 "Absolute Conviction 1" Ability { id: "14A4", source: "Ser Guerrique" }
 735.5 "Absolute Conviction 2" Ability { id: "14A5", source: "Ser Hermenost" }
 740.6 "The Dragon's Gaze/The Dragon's Glory" Ability { id: "(1489|148A)", source: "King Thordan" }

--- a/ui/raidboss/data/04-sb/dungeon/temple_of_the_fist.txt
+++ b/ui/raidboss/data/04-sb/dungeon/temple_of_the_fist.txt
@@ -29,19 +29,19 @@ hideall "--sync--"
 123.9 "Radial Blaster"
 
 # Phase change after one dies
-150.0 "Basic Instinct" Ability { id: "1FD5", source: "(Coeurl Sruti|Coeurl Smriti)" } window 150,10
+150.0 "Basic Instinct" Ability { id: "1FD5", source: ['Coeurl Sruti', 'Coeurl Smriti'] } window 150,10
 
-156.2 "Electric Burst" Ability { id: "1FD6", source: "(Coeurl Sruti|Coeurl Smriti)" }
-160.3 "Pounce" Ability { id: "1FD1", source: "(Coeurl Sruti|Coeurl Smriti)" }
+156.2 "Electric Burst" Ability { id: "1FD6", source: ['Coeurl Sruti', 'Coeurl Smriti'] }
+160.3 "Pounce" Ability { id: "1FD1", source: ['Coeurl Sruti', 'Coeurl Smriti'] }
 167.8 "Heat Lightning" Ability { id: "1FD7", source: "Coeurl Sruti" }
-175.2 "Radial/Wide Blaster" Ability { id: "1FD[34]", source: "(Coeurl Sruti|Coeurl Smriti)" }
-180.4 "Pounce" Ability { id: "1FD1", source: "(Coeurl Sruti|Coeurl Smriti)" }
+175.2 "Radial/Wide Blaster" Ability { id: "1FD[34]", source: ['Coeurl Sruti', 'Coeurl Smriti'] }
+180.4 "Pounce" Ability { id: "1FD1", source: ['Coeurl Sruti', 'Coeurl Smriti'] }
 
-191.6 "Electric Burst" Ability { id: "1FD6", source: "(Coeurl Sruti|Coeurl Smriti)" } window 20,20
-195.7 "Pounce" Ability { id: "1FD1", source: "(Coeurl Sruti|Coeurl Smriti)" }
-203.2 "Heat Lightning" Ability { id: "1FD7", source: "(Coeurl Sruti|Coeurl Smriti)" }
-210.6 "Radial/Wide Blaster" Ability { id: "1FD[34]", source: "(Coeurl Sruti|Coeurl Smriti)" }
-215.8 "Pounce" Ability { id: "1FD1", source: "(Coeurl Sruti|Coeurl Smriti)" } jump 180.4
+191.6 "Electric Burst" Ability { id: "1FD6", source: ['Coeurl Sruti', 'Coeurl Smriti'] } window 20,20
+195.7 "Pounce" Ability { id: "1FD1", source: ['Coeurl Sruti', 'Coeurl Smriti'] }
+203.2 "Heat Lightning" Ability { id: "1FD7", source: ['Coeurl Sruti', 'Coeurl Smriti'] }
+210.6 "Radial/Wide Blaster" Ability { id: "1FD[34]", source: ['Coeurl Sruti', 'Coeurl Smriti'] }
+215.8 "Pounce" Ability { id: "1FD1", source: ['Coeurl Sruti', 'Coeurl Smriti'] } jump 180.4
 
 227.0 "Electric Burst"
 231.1 "Pounce"

--- a/ui/raidboss/data/05-shb/alliance/the_tower_at_paradigms_breach.txt
+++ b/ui/raidboss/data/05-shb/alliance/the_tower_at_paradigms_breach.txt
@@ -215,13 +215,13 @@ hideall "--sync--"
 2700.0 "--sync--" StartsUsing { id: "5C73", source: "Gretel" } window 700,0
 2700.0 "--sync--" StartsUsing { id: "5C74", source: "Hansel" } window 700,0
 # Gretel does 57C3 and Hansel does 57C4, and they both do 5C75
-2708.0 "Lamentation" Ability { id: "(5C73|5C74)", source: "(Gretel|Hansel)" } window 100,100
-2713.8 "Seed Of Magic Beta" Ability { id: "5C75", source: "(Gretel|Hansel)" }
-2718.1 "Lamentation" #Ability { id: "(5C73|5C74)", source: "(Gretel|Hansel)" }
-2723.9 "Seed Of Magic Beta" #Ability { id: "5C75", source: "(Gretel|Hansel)" }
-2728.2 "Lamentation" #Ability { id: "(5C73|5C74)", source: "(Gretel|Hansel)" }
-2734.0 "Seed Of Magic Beta" #Ability { id: "5C75", source: "(Gretel|Hansel)" }
-2738.3 "Lamentation" #Ability { id: "(5C73|5C74)", source: "(Gretel|Hansel)" }
+2708.0 "Lamentation" Ability { id: "(5C73|5C74)", source: ['Gretel', 'Hansel'] } window 100,100
+2713.8 "Seed Of Magic Beta" Ability { id: "5C75", source: ['Gretel', 'Hansel'] }
+2718.1 "Lamentation" #Ability { id: "(5C73|5C74)", source: ['Gretel', 'Hansel'] }
+2723.9 "Seed Of Magic Beta" #Ability { id: "5C75", source: ['Gretel', 'Hansel'] }
+2728.2 "Lamentation" #Ability { id: "(5C73|5C74)", source: ['Gretel', 'Hansel'] }
+2734.0 "Seed Of Magic Beta" #Ability { id: "5C75", source: ['Gretel', 'Hansel'] }
+2738.3 "Lamentation" #Ability { id: "(5C73|5C74)", source: ['Gretel', 'Hansel'] }
 
 
 ### Assorted Trash

--- a/ui/raidboss/data/05-shb/dungeon/akadaemia_anyder.txt
+++ b/ui/raidboss/data/05-shb/dungeon/akadaemia_anyder.txt
@@ -49,8 +49,8 @@ hideall "--sync--"
 # When one dies, the other powers up and starts casting stuff after it jumps back in.
 # However, I've never seen this cast get off, so just guessing on Marine Mayhem cast length.
 300.0 "--sync--" StartsUsing { id: "3E07", source: "(Doliodus|Cladoselache)" } window 300,0
-302.0 "Carcharian Verve" Ability { id: "3E07", source: "(Doliodus|Cladoselache)" } window 300,0
-305.5 "Marine Mayhem" Ability { id: "3E06", source: "(Doliodus|Cladoselache)" }
+302.0 "Carcharian Verve" Ability { id: "3E07", source: ['Doliodus', 'Cladoselache'] } window 300,0
+305.5 "Marine Mayhem" Ability { id: "3E06", source: ['Doliodus', 'Cladoselache'] }
 
 
 

--- a/ui/raidboss/data/05-shb/dungeon/akadaemia_anyder.txt
+++ b/ui/raidboss/data/05-shb/dungeon/akadaemia_anyder.txt
@@ -48,7 +48,7 @@ hideall "--sync--"
 
 # When one dies, the other powers up and starts casting stuff after it jumps back in.
 # However, I've never seen this cast get off, so just guessing on Marine Mayhem cast length.
-300.0 "--sync--" StartsUsing { id: "3E07", source: "(Doliodus|Cladoselache)" } window 300,0
+300.0 "--sync--" StartsUsing { id: "3E07", source: ['Doliodus', 'Cladoselache'] } window 300,0
 302.0 "Carcharian Verve" Ability { id: "3E07", source: ['Doliodus', 'Cladoselache'] } window 300,0
 305.5 "Marine Mayhem" Ability { id: "3E06", source: ['Doliodus', 'Cladoselache'] }
 

--- a/ui/raidboss/data/05-shb/eureka/delubrum_reginae.txt
+++ b/ui/raidboss/data/05-shb/eureka/delubrum_reginae.txt
@@ -542,8 +542,8 @@ hideall "--sync--"
 
 9044.2 "Queen's Will" Ability { id: "59B9", source: "The Queen" }
 9052.4 "Beck And Call To Arms" Ability { id: "5B99", source: "The Queen" }
-9056.7 "The Means" Ability { id: "59B[BD]", source: "(Queen's Gunner|Queen's Warrior)" }
-9056.7 "The Ends" Ability { id: "59B[AC]", source: "(Queen's Soldier|Queen's Knight)" }
+9056.7 "The Means" Ability { id: "59B[BD]", source: ['Queen\'s Gunner', 'Queen\'s Warrior'] }
+9056.7 "The Ends" Ability { id: "59B[AC]", source: ['Queen\'s Soldier', 'Queen\'s Knight'] }
 
 9066.6 "Empyrean Iniquity" Ability { id: "59C8", source: "The Queen" }
 9074.8 "--middle--" Ability { id: "5BCB", source: "The Queen" }
@@ -557,8 +557,8 @@ hideall "--sync--"
 9132.1 "Queen's Will" Ability { id: "59B9", source: "The Queen" }
 9140.2 "Beck And Call To Arms" Ability { id: "5B99", source: "The Queen" }
 9143.3 "--untargetable--"
-9144.5 "The Means" Ability { id: "59B[BD]", source: "(Queen's Gunner|Queen's Warrior)" }
-9144.5 "The Ends" Ability { id: "59B[AC]", source: "(Queen's Soldier|Queen's Knight)" }
+9144.5 "The Means" Ability { id: "59B[BD]", source: ['Queen\'s Gunner', 'Queen\'s Warrior'] }
+9144.5 "The Ends" Ability { id: "59B[AC]", source: ['Queen\'s Soldier', 'Queen\'s Knight'] }
 9151.5 "Judgment Blade" Ability { id: "59C[12]", source: "The Queen" }
 9156.2 "--targetable--"
 
@@ -594,8 +594,8 @@ hideall "--sync--"
 9338.0 "Beck And Call To Arms" Ability { id: "5B99", source: "The Queen" }
 9339.5 "--stunned--"
 9341.7 "Queen's Justice" Ability { id: "59BF", source: "Queen's Warrior" } # only on failure
-9342.4 "The Means" Ability { id: "59B[BD]", source: "(Queen's Gunner|Queen's Warrior)" }
-9342.4 "The Ends" Ability { id: "59B[AC]", source: "(Queen's Soldier|Queen's Knight)" }
+9342.4 "The Means" Ability { id: "59B[BD]", source: ['Queen\'s Gunner', 'Queen\'s Warrior'] }
+9342.4 "The Ends" Ability { id: "59B[AC]", source: ['Queen\'s Soldier', 'Queen\'s Knight'] }
 9345.4 "--unstunned--"
 9354.5 "Cleansing Slash" Ability { id: "59C5", source: "The Queen" }
 
@@ -616,8 +616,8 @@ hideall "--sync--"
 9437.6 "Queen's Will" Ability { id: "59B9", source: "The Queen" }
 9440.2 "--explosion--" Ability { id: "59C4", source: "The Queen" }
 9445.7 "Beck And Call To Arms" Ability { id: "5B99", source: "The Queen" }
-9450.0 "The Means" Ability { id: "59B[BD]", source: "(Queen's Gunner|Queen's Warrior)" }
-9450.0 "The Ends" Ability { id: "59B[AC]", source: "(Queen's Soldier|Queen's Knight)" }
+9450.0 "The Means" Ability { id: "59B[BD]", source: ['Queen\'s Gunner', 'Queen\'s Warrior'] }
+9450.0 "The Ends" Ability { id: "59B[AC]", source: ['Queen\'s Soldier', 'Queen\'s Knight'] }
 9459.9 "Cleansing Slash" Ability { id: "59C5", source: "The Queen" }
 
 9473.1 "Relentless Play" Ability { id: "59FC", source: "The Queen" } window 50,50 jump 9253.1

--- a/ui/raidboss/data/05-shb/eureka/delubrum_reginae_savage.txt
+++ b/ui/raidboss/data/05-shb/eureka/delubrum_reginae_savage.txt
@@ -847,7 +847,7 @@ hideall "--sync--"
 # Note: various "Blast" are renamed "Elemental Blast" and various "Arrow" are renamed
 # to be "Elemental Arrow" to avoid having too many skills on the timeline.
 
-# Note: Blade of Entropy is `Ability { id: "594[23456789]|595[6789ABCD]", source: "(Trinity Avowed|Avowed Avatar)" }``
+# Note: Blade of Entropy is `Ability { id: "594[23456789]|595[6789ABCD]", source: ['Trinity Avowed', 'Avowed Avatar'] }``
 
 # The Vault of Singing Crystal will be sealed off
 14000.0 "--sync--" SystemLogMessage { id: "7DC", param1: "E20" } window 20000,0
@@ -1496,7 +1496,7 @@ hideall "--sync--"
 20515.5 "--sync--" Ability { id: "5B8E", source: "Queen's Warrior" }
 20516.5 "--stunned--" # 3 or 7 second stun
 # Aetherial Burst does 5B89 and Aetherial Bolt does 5A0D
-20518.5 "Lots Cast" Ability { id: "(5B89|5A0D)", source: "(Aetherial Burst|Aetherial Bolt)" }
+20518.5 "Lots Cast" Ability { id: "(5B89|5A0D)", source: ['Aetherial Burst', 'Aetherial Bolt'] }
 20521.5 "Lots Cast" #Ability { id: "5B88", source: "Aetherial Bolt" }
 20522.7 "Lots Cast" #Ability { id: "5BB6", source: "Aetherial Bolt" }
 20523.5 "--unstunned--"

--- a/ui/raidboss/data/05-shb/trial/wol-ex.txt
+++ b/ui/raidboss/data/05-shb/trial/wol-ex.txt
@@ -264,11 +264,11 @@ hideall "Limit Break"
 4531.9 "Specter Of Light" Ability { id: "4F37", source: "Warrior Of Light" }
 4540.2 "Summon" Ability { id: "4F3F", source: "Spectral Summoner" }
 4554.4 "Flare Breath" Ability { id: "4F40", source: "Spectral Summoner" }
-4554.7 "Perfect Decimation" Ability { id: "4F05", source: "(Spectral Warrior|Warrior Of Light)" }
+4554.7 "Perfect Decimation" Ability { id: "4F05", source: ['Spectral Warrior', 'Warrior Of Light'] }
 4554.9 "Solemn Confiteor" Ability { id: "4F0C", source: "Warrior Of Light" }
 4566.1 "Solemn Confiteor" Ability { id: "4F0C", source: "Warrior Of Light" }
 4566.5 "Flare Breath" Ability { id: "4F40", source: "Spectral Summoner" }
-4566.9 "Perfect Decimation" Ability { id: "4F05", source: "(Spectral Warrior|Warrior Of Light)" }
+4566.9 "Perfect Decimation" Ability { id: "4F05", source: ['Spectral Warrior', 'Warrior Of Light'] }
 4568.2 "--sync--" Ability { id: "531E", source: "Spectral Warrior" }
 4572.4 "--sync--" Ability { id: "531E", source: "Spectral Summoner" }
 4572.8 "Summon Wyrm" Ability { id: "4F41", source: "Warrior Of Light" }
@@ -419,11 +419,11 @@ hideall "Limit Break"
 9014.3 "Specter Of Light" Ability { id: "4F37", source: "Warrior Of Light" }
 9022.6 "Summon" Ability { id: "4F3F", source: "Spectral Summoner" }
 9036.7 "Flare Breath" Ability { id: "4F40", source: "Spectral Summoner" }
-9037.0 "Perfect Decimation" Ability { id: "4F05", source: "(Spectral Warrior|Warrior Of Light)" }
+9037.0 "Perfect Decimation" Ability { id: "4F05", source: ['Spectral Warrior', 'Warrior Of Light'] }
 9037.2 "Solemn Confiteor" Ability { id: "4F0C", source: "Warrior Of Light" }
 9048.5 "Solemn Confiteor" Ability { id: "4F0C", source: "Warrior Of Light" }
 9048.8 "Flare Breath" Ability { id: "4F40", source: "Spectral Summoner" }
-9049.2 "Perfect Decimation" Ability { id: "4F05", source: "(Spectral Warrior|Warrior Of Light)" }
+9049.2 "Perfect Decimation" Ability { id: "4F05", source: ['Spectral Warrior', 'Warrior Of Light'] }
 9050.8 "--sync--" Ability { id: "531E", source: "Spectral Warrior" }
 9054.8 "--sync--" Ability { id: "531E", source: "Spectral Summoner" }
 9055.2 "Summon Wyrm" Ability { id: "4F41", source: "Warrior Of Light" }

--- a/ui/raidboss/data/06-ew/alliance/aglaia.txt
+++ b/ui/raidboss/data/06-ew/alliance/aglaia.txt
@@ -217,18 +217,18 @@ hideall "Fan Flames"
 4007.0 "--sync--" StartsUsing { id: "71D7", source: "Lioness of Aglaia" } window 10,10
 4012.0 "Double Immolation" Ability { id: "71D7", source: "Lioness of Aglaia" }
 4019.8 "--sync--" Ability { id: "71CD", source: "Lioness of Aglaia" } window 10,10
-4028.1 "Slash and Burn" Ability { id: "(71D0|71D2)", source: "(Lion of Aglaia|Lioness of Aglaia)" }
-4031.3 "Slash and Burn" Ability { id: "(71D6|71D5)", source: "(Lioness of Aglaia|Lion of Aglaia)" }
+4028.1 "Slash and Burn" Ability { id: "(71D0|71D2)", source: ['Lion of Aglaia', 'Lioness of Aglaia'] }
+4031.3 "Slash and Burn" Ability { id: "(71D6|71D5)", source: ['Lioness of Aglaia', 'Lion of Aglaia'] }
 4036.1 "--sync--" Ability { id: "71CD", source: "Lioness of Aglaia" } window 10,10
-4044.7 "Slash and Burn" Ability { id: "(71D0|71D2)", source: "(Lion of Aglaia|Lioness of Aglaia)" }
-4047.9 "Slash and Burn" Ability { id: "(71D6|71D5)", source: "(Lioness of Aglaia|Lion of Aglaia)" }
+4044.7 "Slash and Burn" Ability { id: "(71D0|71D2)", source: ['Lion of Aglaia', 'Lioness of Aglaia'] }
+4047.9 "Slash and Burn" Ability { id: "(71D6|71D5)", source: ['Lioness of Aglaia', 'Lion of Aglaia'] }
 4056.7 "--sync--" Ability { id: "71CD", source: "Lioness of Aglaia" } window 10,10
 4063.8 "Roaring Blaze" Ability { id: "71CE", source: "Lioness of Aglaia" }
 4066.8 "Roaring Blaze" Ability { id: "71CF", source: "Lion of Aglaia" }
 4072.4 "--sync--" Ability { id: "71CD", source: "Lioness of Aglaia" } window 10,10
 4079.5 "Roaring Blaze" Ability { id: "71CE", source: "Lion of Aglaia" }
 4082.5 "Roaring Blaze" Ability { id: "71CF", source: "Lioness of Aglaia" }
-4085.1 "Rejuvenating Spark" Ability { id: "71D9", source: "(Lion of Aglaia|Lioness of Aglaia)" }
+4085.1 "Rejuvenating Spark" Ability { id: "71D9", source: ['Lion of Aglaia', 'Lioness of Aglaia'] }
 4093.4 "--sync--" Ability { id: "71CD", source: "Lioness of Aglaia" } window 10,10
 4101.7 "Slash and Burn" Ability { id: "71D2", source: "Lioness of Aglaia" }
 # ??? (is this a loop?)
@@ -429,7 +429,7 @@ hideall "Fan Flames"
 6230.2 "Fired Up II" Ability { id: "738A", source: "Nald'thal" }
 6240.3 "Fortune's Flux" Ability { id: "7113", source: "Nald'thal" }
 6242.8 "--sync--" Ability { id: "7430", source: "Thal" }
-6242.8 "Seventh Passage" Ability { id: "73AF", source: "(Thal|Nald'thal)" }
+6242.8 "Seventh Passage" Ability { id: "73AF", source: ['Thal', 'Nald\'thal'] }
 6244.5 "Seventh Passage" Ability { id: "7118", source: "Nald'thal" }
 6244.8 "--sync--" Ability { id: "7431", source: "Thal" }
 6250.9 "Fired Up I" Ability { id: "7112", source: "Nald'thal" }

--- a/ui/raidboss/data/06-ew/raid/p7n.txt
+++ b/ui/raidboss/data/06-ew/raid/p7n.txt
@@ -58,7 +58,7 @@ hideall "--sync--"
 475.9 "Hemitheos's Aero II" Ability { id: "7809", source: "Agdistis" } window 30,30
 489.2 "Forbidden Fruit" Ability { id: "7801", source: "Agdistis" }
 492.3 "Shadow of Attis" Ability { id: "783C", source: "Agdistis" }
-500.7 "Static Moon/Stymphalian Strike" Ability { id: "(7802|7803)", source: "(Immature Io|Immature Stymphalide)" }
+500.7 "Static Moon/Stymphalian Strike" Ability { id: "(7802|7803)", source: ['Immature Io', 'Immature Stymphalide'] }
 505.4 "Burst" Ability { id: "783D", source: "Agdistis" }
 513.6 "Bough of Attis (out)" Ability { id: "77F9", source: "Agdistis" }
 521.2 "Bough of Attis (left/right)" Ability { id: "(77FB|77FC)", source: "Agdistis" }

--- a/ui/raidboss/data/06-ew/trial/endsinger-ex.txt
+++ b/ui/raidboss/data/06-ew/trial/endsinger-ex.txt
@@ -11,10 +11,10 @@ hideall "--sync--"
 0.0 "--sync--" InCombat { inGameCombat: "1" } window 0,1
 7.0 "--sync--" StartsUsing { id: "6FF6", source: "The Endsinger" } window 10,10
 11.7 "Elegeia Unforgotten" Ability { id: "6FF6", source: "The Endsinger" }
-25.1 "Star Collision" Ability { id: "6FF[AB]", source: "(Fiery Star|Azure Star)" }
+25.1 "Star Collision" Ability { id: "6FF[AB]", source: ['Fiery Star', 'Azure Star'] }
 26.7 "Diairesis" Ability { id: "6FFC", source: "The Endsinger" }
 29.9 "Elegeia Unforgotten" Ability { id: "6FF6", source: "The Endsinger" }
-43.3 "Star Collision" Ability { id: "6FF[AB]", source: "(Fiery Star|Azure Star)" }
+43.3 "Star Collision" Ability { id: "6FF[AB]", source: ['Fiery Star', 'Azure Star'] }
 44.9 "Diairesis" Ability { id: "6FFC", source: "The Endsinger" }
 55.3 "Grip of Despair" Ability { id: "701D", source: "The Endsinger" }
 
@@ -24,12 +24,12 @@ hideall "--sync--"
 74.5 "Telos" Ability { id: "702E", source: "The Endsinger" }
 84.6 "Hubris" Ability { id: "702C", source: "The Endsinger" }
 96.8 "Elegeia Unforgotten" Ability { id: "6FF6", source: "The Endsinger" }
-110.2 "Star Collision" Ability { id: "6FF[AB]", source: "(Fiery Star|Azure Star)" }
+110.2 "Star Collision" Ability { id: "6FF[AB]", source: ['Fiery Star', 'Azure Star'] }
 111.8 "Diairesis" Ability { id: "6FFC", source: "The Endsinger" }
 114.1 "Eironeia" Ability { id: "702F", source: "The Endsinger" }
 122.3 "Fatalism" Ability { id: "6FFD", source: "The Endsinger" }
-132.6 "Star Collision 1" Ability { id: "700[24]", source: "(Fiery Star|Azure Star)" }
-139.1 "Star Collision 2" Ability { id: "700[24]", source: "(Fiery Star|Azure Star)" }
+132.6 "Star Collision 1" Ability { id: "700[24]", source: ['Fiery Star', 'Azure Star'] }
+139.1 "Star Collision 2" Ability { id: "700[24]", source: ['Fiery Star', 'Azure Star'] }
 145.4 "Elenchos" Ability { id: "702[02]", source: "The Endsinger" }
 
 # 5Head 1
@@ -67,17 +67,17 @@ hideall "--sync--"
 363.1 "Telos" Ability { id: "702E", source: "The Endsinger" }
 373.2 "Hubris" Ability { id: "702C", source: "The Endsinger" }
 387.4 "Elegeia Unforgotten" Ability { id: "6FF6", source: "The Endsinger" }
-400.8 "Star Collision" Ability { id: "6FF[AB]", source: "(Fiery Star|Azure Star)" }
+400.8 "Star Collision" Ability { id: "6FF[AB]", source: ['Fiery Star', 'Azure Star'] }
 402.4 "Diairesis" Ability { id: "6FFC", source: "The Endsinger" }
 404.7 "Eironeia" Ability { id: "702F", source: "The Endsinger" }
 410.8 "Fatalism" Ability { id: "6FFD", source: "The Endsinger" }
 420.9 "Fatalism" Ability { id: "6FFD", source: "The Endsinger" }
 
 # Four Planets 1
-421.1 "Star Collision 1" Ability { id: "700[24]", source: "(Fiery Star|Azure Star)" }
-427.6 "Star Collision 2" Ability { id: "700[24]", source: "(Fiery Star|Azure Star)" }
-431.2 "Star Collision 3" Ability { id: "700[24]", source: "(Fiery Star|Azure Star)" }
-437.7 "Star Collision 4" Ability { id: "700[24]", source: "(Fiery Star|Azure Star)" }
+421.1 "Star Collision 1" Ability { id: "700[24]", source: ['Fiery Star', 'Azure Star'] }
+427.6 "Star Collision 2" Ability { id: "700[24]", source: ['Fiery Star', 'Azure Star'] }
+431.2 "Star Collision 3" Ability { id: "700[24]", source: ['Fiery Star', 'Azure Star'] }
+437.7 "Star Collision 4" Ability { id: "700[24]", source: ['Fiery Star', 'Azure Star'] }
 
 # Towers 2
 446.5 "Tower Explosion" #Ability { id: "702A", source: "The Endsinger" }
@@ -108,10 +108,10 @@ hideall "--sync--"
 623.1 "Fatalism" Ability { id: "6FFD", source: "The Endsinger" }
 
 # Four Planets 2
-623.3 "Star Collision 1" Ability { id: "700[24]", source: "(Fiery Star|Azure Star)" }
-629.8 "Star Collision 2" Ability { id: "700[24]", source: "(Fiery Star|Azure Star)" }
-633.4 "Star Collision 3" Ability { id: "700[24]", source: "(Fiery Star|Azure Star)" }
-639.9 "Star Collision 4" Ability { id: "700[24]", source: "(Fiery Star|Azure Star)" }
+623.3 "Star Collision 1" Ability { id: "700[24]", source: ['Fiery Star', 'Azure Star'] }
+629.8 "Star Collision 2" Ability { id: "700[24]", source: ['Fiery Star', 'Azure Star'] }
+633.4 "Star Collision 3" Ability { id: "700[24]", source: ['Fiery Star', 'Azure Star'] }
+639.9 "Star Collision 4" Ability { id: "700[24]", source: ['Fiery Star', 'Azure Star'] }
 647.2 "Telos" Ability { id: "702E", source: "The Endsinger" }
 661.4 "Fatalism" Ability { id: "7031", source: "The Endsinger" }
 

--- a/ui/raidboss/data/06-ew/trial/thordan-un.txt
+++ b/ui/raidboss/data/06-ew/trial/thordan-un.txt
@@ -48,7 +48,7 @@ hideall "--sync--"
 104.3 "Conviction" Ability { id: "89DC", source: "Ser Hermenost" }
 107.4 "Sacred Cross" StartsUsing { id: "89CF", source: "Ser Zephirin" } duration 19.7
 127.1 "--sync--" Ability { id: "89CF", source: "Ser Zephirin" }
-133.1 "Spiral Thrust" Ability { id: "89E5", source: "(Ser Ignasse|Ser Paulecrain|Ser Vellguine)" }
+133.1 "Spiral Thrust" Ability { id: "89E5", source: ['Ser Ignasse', 'Ser Paulecrain', 'Ser Vellguine'] }
 
 # Intermission part 2
 # This loops until both Adelphel and Janlenoux are dead.
@@ -59,28 +59,28 @@ hideall "--sync--"
 # but it's more important that we sync during the loop,
 # so we accept a small amount of jumpiness in the timeline.
 140.2 "--targetable--"
-150.2 "Divine Right" Ability { id: "89D2", source: "(Ser Adelphel|Ser Janlenoux)" }
-159.3 "Holy Bladedance" Ability { id: "89D5", source: "(Ser Adelphel|Ser Janlenoux)" }
+150.2 "Divine Right" Ability { id: "89D2", source: ['Ser Adelphel', 'Ser Janlenoux'] }
+159.3 "Holy Bladedance" Ability { id: "89D5", source: ['Ser Adelphel', 'Ser Janlenoux'] }
 175.3 "Skyward Leap 1" Ability { id: "89E8", source: "Ser Vellguine" }
-177.3 "Divine Right" Ability { id: "89D2", source: "(Ser Adelphel|Ser Janlenoux)" }
+177.3 "Divine Right" Ability { id: "89D2", source: ['Ser Adelphel', 'Ser Janlenoux'] }
 178.3 "Skyward Leap 2" Ability { id: "89E8", source: "Ser Paulecrain" }
-179.4 "Heavenly Slash" Ability { id: "89D3", source: "(Ser Adelphel|Ser Janlenoux)" }
+179.4 "Heavenly Slash" Ability { id: "89D3", source: ['Ser Adelphel', 'Ser Janlenoux'] }
 181.3 "Skyward Leap 3" Ability { id: "89E8", source: "Ser Ignasse" }
-192.4 "Holiest Of Holy" Ability { id: "89D4", source: "(Ser Adelphel|Ser Janlenoux)" }
-198.5 "Holy Bladedance" Ability { id: "89D5", source: "(Ser Adelphel|Ser Janlenoux)" }
-205.6 "Divine Right" Ability { id: "89D2", source: "(Ser Adelphel|Ser Janlenoux)" }
-212.7 "Holiest Of Holy" Ability { id: "89D4", source: "(Ser Adelphel|Ser Janlenoux)" }
-216.8 "Heavenly Slash" Ability { id: "89D3", source: "(Ser Adelphel|Ser Janlenoux)" }
+192.4 "Holiest Of Holy" Ability { id: "89D4", source: ['Ser Adelphel', 'Ser Janlenoux'] }
+198.5 "Holy Bladedance" Ability { id: "89D5", source: ['Ser Adelphel', 'Ser Janlenoux'] }
+205.6 "Divine Right" Ability { id: "89D2", source: ['Ser Adelphel', 'Ser Janlenoux'] }
+212.7 "Holiest Of Holy" Ability { id: "89D4", source: ['Ser Adelphel', 'Ser Janlenoux'] }
+216.8 "Heavenly Slash" Ability { id: "89D3", source: ['Ser Adelphel', 'Ser Janlenoux'] }
 
-232.9 "Divine Right" Ability { id: "89D2", source: "(Ser Adelphel|Ser Janlenoux)" }
-242.0 "Holy Bladedance" Ability { id: "89D5", source: "(Ser Adelphel|Ser Janlenoux)" }
-260.0 "Divine Right" Ability { id: "89D2", source: "(Ser Adelphel|Ser Janlenoux)" }
-262.1 "Heavenly Slash" Ability { id: "89D3", source: "(Ser Adelphel|Ser Janlenoux)" }
-275.2 "Holiest Of Holy" Ability { id: "89D4", source: "(Ser Adelphel|Ser Janlenoux)" }
-281.3 "Holy Bladedance" Ability { id: "89D5", source: "(Ser Adelphel|Ser Janlenoux)" }
-288.3 "Divine Right" Ability { id: "89D2", source: "(Ser Adelphel|Ser Janlenoux)" }
-295.4 "Holiest Of Holy" Ability { id: "89D4", source: "(Ser Adelphel|Ser Janlenoux)" }
-299.5 "Heavenly Slash" Ability { id: "89D3", source: "(Ser Adelphel|Ser Janlenoux)" } forcejump 216.8
+232.9 "Divine Right" Ability { id: "89D2", source: ['Ser Adelphel', 'Ser Janlenoux'] }
+242.0 "Holy Bladedance" Ability { id: "89D5", source: ['Ser Adelphel', 'Ser Janlenoux'] }
+260.0 "Divine Right" Ability { id: "89D2", source: ['Ser Adelphel', 'Ser Janlenoux'] }
+262.1 "Heavenly Slash" Ability { id: "89D3", source: ['Ser Adelphel', 'Ser Janlenoux'] }
+275.2 "Holiest Of Holy" Ability { id: "89D4", source: ['Ser Adelphel', 'Ser Janlenoux'] }
+281.3 "Holy Bladedance" Ability { id: "89D5", source: ['Ser Adelphel', 'Ser Janlenoux'] }
+288.3 "Divine Right" Ability { id: "89D2", source: ['Ser Adelphel', 'Ser Janlenoux'] }
+295.4 "Holiest Of Holy" Ability { id: "89D4", source: ['Ser Adelphel', 'Ser Janlenoux'] }
+299.5 "Heavenly Slash" Ability { id: "89D3", source: ['Ser Adelphel', 'Ser Janlenoux'] } forcejump 216.8
 
 
 # Intermission part 3
@@ -88,8 +88,8 @@ hideall "--sync--"
 352.0 "--sync--" Ability { id: "89B7", source: "Ser Grinnaux" } window 150,10
 353.0 "--sync--" Ability { id: "89B7", source: "Ser Haumeric" } window 150,10
 359.6 "Hiemal Storm" Ability { id: "89ED", source: "Ser Haumeric" } window 328,10
-359.8 "--sync--" Ability { id: "89EE", source: "(Ser Haumeric|Ser Noudenet)" } # Hiemal Storm
-360.2 "Spiral Pierce" Ability { id: "89E6", source: "(Ser Ignasse|Ser Paulecrain|Ser Vellguine)" }
+359.8 "--sync--" Ability { id: "89EE", source: ['Ser Haumeric', 'Ser Noudenet'] } # Hiemal Storm
+360.2 "Spiral Pierce" Ability { id: "89E6", source: ['Ser Ignasse', 'Ser Paulecrain', 'Ser Vellguine'] }
 361.5 "Dimensional Collapse" Ability { id: "89D8", source: "Ser Grinnaux" }
 361.9 "--sync--" Ability { id: "89D9", source: "Ser Grinnaux" } # Dimensional Collapse
 365.0 "Faith Unmoving" Ability { id: "89DA", source: "Ser Grinnaux" }
@@ -125,7 +125,7 @@ hideall "--sync--"
 466.4 "the Dragon's Eye" Ability { id: "89C7", source: "King Thordan" }
 476.6 "Knights Of the Round" Ability { id: "89CB", source: "King Thordan" }
 481.7 "Ascalon's Might" Ability { id: "89BD", source: "King Thordan" }
-488.1 "Holy Shield Bash" Ability { id: "89D6", source: "(Ser Adelphel|Ser Janlenoux)" }
+488.1 "Holy Shield Bash" Ability { id: "89D6", source: ['Ser Adelphel', 'Ser Janlenoux'] }
 497.1 "Spear Of the Fury" Ability { id: "89D1", source: "Ser Zephirin" } # A smile better suits a hero
 499.5 "Heavenly Heel" Ability { id: "89C6", source: "King Thordan" }
 504.6 "The Dragon's Gaze/The Dragon's Glory" Ability { id: "(89C8|89C9)", source: "King Thordan" }
@@ -175,7 +175,7 @@ hideall "--sync--"
 645.3 "Heavensflame 2" #Ability { id: "89EB", source: "Ser Charibert" }
 646.4 "Heavensflame 3" #Ability { id: "89EB", source: "Ser Charibert" }
 646.8 "Hiemal Storm" Ability { id: "89ED", source: "Ser Haumeric" }
-647.4 "--sync--" Ability { id: "89EE", source: "(Ser Haumeric|Ser Noudenet)" } # Hiemal Storm
+647.4 "--sync--" Ability { id: "89EE", source: ['Ser Haumeric', 'Ser Noudenet'] } # Hiemal Storm
 648.7 "Ascalon's Mercy" Ability { id: "89BE", source: "King Thordan" }
 656.8 "Ancient Quaga" Ability { id: "89C4", source: "King Thordan" }
 662.9 "Heavenly Heel" Ability { id: "89C6", source: "King Thordan" }
@@ -192,7 +192,7 @@ hideall "--sync--"
 707.6 "Heavensward Leap 2" Ability { id: "89E9", source: "Ser Paulecrain" }
 710.6 "Heavensward Leap 3" Ability { id: "89E9", source: "Ser Ignasse" }
 718.7 "Sacred Cross" StartsUsing { id: "89D0", source: "Ser Zephirin" } duration 24.7
-724.6 "Pure Of Soul" Ability { id: "(89F0|89F1)", source: "(Ser Charibert|Ser Noudenet|Ser Haumeric)" }
+724.6 "Pure Of Soul" Ability { id: "(89F0|89F1)", source: ['Ser Charibert', 'Ser Noudenet', 'Ser Haumeric'] }
 732.6 "Absolute Conviction 1" Ability { id: "89E3", source: "Ser Guerrique" }
 735.5 "Absolute Conviction 2" Ability { id: "89E4", source: "Ser Hermenost" }
 740.6 "The Dragon's Gaze/The Dragon's Glory" Ability { id: "(89C8|89C9)", source: "King Thordan" }

--- a/ui/raidboss/data/06-ew/trial/zodiark.txt
+++ b/ui/raidboss/data/06-ew/trial/zodiark.txt
@@ -29,7 +29,7 @@ hideall "Triple Esoteric Ray"
 58.3 "Paradeigma" Ability { id: "67C8", source: "Zodiark" }
 71.0 "Meteoros Eidolon" Ability { id: "67C6", source: "Behemoth" }
 76.1 "Paradeigma" Ability { id: "67C8", source: "Zodiark" }
-88.3 "Opheos Eidolon" Ability { id: "67C7", source: "(Python|Behemoth|Zodiark)" }
+88.3 "Opheos Eidolon" Ability { id: "67C7", source: ['Python', 'Behemoth', 'Zodiark'] }
 94.9 "Phlegethon x3" Ability { id: "67D0", source: "Zodiark" } duration 4.6
 103.1 "Styx x5" Ability { id: "67DB", source: "Zodiark" } duration 5.5
 115.7 "Paradeigma" Ability { id: "67C8", source: "Zodiark" }
@@ -56,7 +56,7 @@ hideall "Triple Esoteric Ray"
 253.6 "Paradeigma" Ability { id: "67BF", source: "Zodiark" }
 268.7 "Astral Flow" Ability { id: "6630", source: "Zodiark" }
 # Note: this mob is sometimes Zodiark and sometimes Python.
-274.6 "Opheos Eidolon" Ability { id: "67C7", source: "(Python|Behemoth|Zodiark)" } window 10,10
+274.6 "Opheos Eidolon" Ability { id: "67C7", source: ['Python', 'Behemoth', 'Zodiark'] } window 10,10
 
 # Star tethers
 280.9 "--sync--" StartsUsing { id: "67C3", source: "Zodiark" } window 300,10
@@ -83,7 +83,7 @@ hideall "Triple Esoteric Ray"
 409.7 "Esoteric Dyad/Esoteric Sect" Ability { id: "(67CB|67CC)", source: "Arcane Sigil" }
 416.2 "Paradeigma" Ability { id: "67BF", source: "Zodiark" }
 431.4 "Astral Flow" Ability { id: "(662F|6630)", source: "Zodiark" }
-437.2 "Opheos Eidolon" Ability { id: "67C7", source: "(Python|Behemoth|Zodiark)" }
+437.2 "Opheos Eidolon" Ability { id: "67C7", source: ['Python', 'Behemoth', 'Zodiark'] }
 446.5 "Styx x5" Ability { id: "67DA", source: "Zodiark" } duration 5.5
 456.6 "Exoterikos" Ability { id: "67C1", source: "Zodiark" }
 465.7 "Triple Esoteric Ray" Ability { id: "67C4", source: "Zodiark" }
@@ -101,7 +101,7 @@ hideall "Triple Esoteric Ray"
 517.5 "Algedon" Ability { id: "67D[12]", source: "Zodiark" }
 530.7 "Paradeigma" Ability { id: "67BF", source: "Zodiark" }
 545.9 "Astral Flow" Ability { id: "(662F|6630)", source: "Zodiark" }
-551.7 "Opheos Eidolon" Ability { id: "67C7", source: "(Python|Behemoth|Zodiark)" }
+551.7 "Opheos Eidolon" Ability { id: "67C7", source: ['Python', 'Behemoth', 'Zodiark'] }
 561.0 "Styx x5" Ability { id: "67DA", source: "Zodiark" } duration 5.5
 571.2 "Exoterikos" Ability { id: "67C1", source: "Zodiark" }
 580.3 "Triple Esoteric Ray" Ability { id: "67C4", source: "Zodiark" }

--- a/ui/raidboss/data/06-ew/ultimate/dragonsongs_reprise_ultimate.txt
+++ b/ui/raidboss/data/06-ew/ultimate/dragonsongs_reprise_ultimate.txt
@@ -26,9 +26,9 @@ hideall "--sync--"
 38.4 "--untargetable--"
 43.6 "--sync--" Ability { id: "62D6", source: "Ser Grinnaux" }
 # These slashes come from Ser Grinnaux, but sometimes name updates are sloppy.
-44.8 "Hyperdimensional Slash 1" Ability { id: "62D7", source: "(Ser Grinnaux|Ser Charibert)" }
+44.8 "Hyperdimensional Slash 1" Ability { id: "62D7", source: ['Ser Grinnaux', 'Ser Charibert'] }
 50.7 "--sync--" Ability { id: "6315", source: "Ser Grinnaux" }
-51.9 "Hyperdimensional Slash 2" Ability { id: "62D7", source: "(Ser Grinnaux|Ser Charibert)" }
+51.9 "Hyperdimensional Slash 2" Ability { id: "62D7", source: ['Ser Grinnaux', 'Ser Charibert'] }
 54.8 "--targetable--"
 59.8 "Faith Unmoving" Ability { id: "62DC", source: "Ser Grinnaux" }
 60.9 "Holiest of Holy" Ability { id: "62D4", source: "Ser Adelphel" }
@@ -356,13 +356,13 @@ hideall "--sync--"
 3668.4 "Cauterize" Ability { id: "6D3F", source: "Hraesvelgr" }
 3668.7 "--untargetable--"
 3674.5 "--sync--" Ability { id: "6D40", source: "Hraesvelgr" }
-3675.4 "Touchdown" Ability { id: "70E7", source: "(Hraesvelgr|Nidhogg)" }
+3675.4 "Touchdown" Ability { id: "70E7", source: ['Hraesvelgr', 'Nidhogg'] }
 3675.7 "--targetable--"
 3679.1 "Mortal Vow" Ability { id: "6D31", source: "Nidhogg" }
-3701.8 "Revenge of the Horde (enrage)" Ability { id: "6D21", source: "(Hraesvelgr|Nidhogg)" }
+3701.8 "Revenge of the Horde (enrage)" Ability { id: "6D21", source: ['Hraesvelgr', 'Nidhogg'] }
 
 3711.8 "Resentment?"
-3718.8 "Shockwave?" #Ability { id: "71E4", source: "(King Thordan|Nidhogg)" }
+3718.8 "Shockwave?" #Ability { id: "71E4", source: ['King Thordan', 'Nidhogg'] }
 3744.6 "Alternative End?" #Ability { id: "7438", source: "Dragon-king Thordan" }
 
 
@@ -370,7 +370,7 @@ hideall "--sync--"
 # Note: Shockwave could come from King Thordan or Nidhogg
 3809.5 "--sync--" Ability { id: "717A", source: "Right Eye" } window 200,0
 3809.5 "Resentment"
-3826.5 "Shockwave?" #Ability { id: "71E4", source: "(King Thordan|Nidhogg)" }
+3826.5 "Shockwave?" #Ability { id: "71E4", source: ['King Thordan', 'Nidhogg'] }
 3828.3 "--sync--" #Ability { id: "63F3", source: "Left Eye" }
 3828.5 "--sync--" #Ability { id: "63F3", source: "Right Eye" }
 3842.3 "Alternative End?" #Ability { id: "7438", source: "Dragon-king Thordan" }
@@ -406,14 +406,14 @@ hideall "--sync--"
 #  6DD3 = Third Proximity AoE
 # 6D91 = Flames of Ascalon (Out/Chariot)
 # 6D92 = Ice of Ascalon (In/Dynamo)
-4000.0 "Shockwave" Ability { id: "71E4", source: "(King Thordan|Nidhogg)" } window 400,0
+4000.0 "Shockwave" Ability { id: "71E4", source: ['King Thordan', 'Nidhogg'] } window 400,0
 4001.8 "--sync--" Ability { id: "63F3", source: "Left Eye" }
 4002.0 "--sync--" #Ability { id: "63F3", source: "Right Eye" }
 4015.8 "Alternative End" Ability { id: "7438", source: "Dragon-king Thordan" }
 4024.8 "--targetable--"
 4035.1 "--sync--" Ability { id: "6D9B", source: "Dragon-king Thordan" }
 4036.0 "Exaflare's Edge" duration 9.3 #Ability { id: "6D9C", source: "Dragon-king Thordan" }
-4036.2 "Ice of Ascalon/Flames of Ascalon" Ability { id: "(6D92|6D91)", source: "(Nidhogg|Dragon-king Thordan)" }
+4036.2 "Ice of Ascalon/Flames of Ascalon" Ability { id: "(6D92|6D91)", source: ['Nidhogg', 'Dragon-king Thordan'] }
 4043.2 "--sync--" Ability { id: "6D9E", source: "Dragon-king Thordan" }
 4044.3 "Trinity 1" #Ability { id: "(6D9F|6DA0|6DA1)", source: "Dragon-king Thordan" }
 4047.3 "--sync--" Ability { id: "6D9E", source: "Dragon-king Thordan" }

--- a/ui/raidboss/data/06-ew/ultimate/the_omega_protocol.txt
+++ b/ui/raidboss/data/06-ew/ultimate/the_omega_protocol.txt
@@ -92,13 +92,13 @@ hideall "--sync--"
 420.4 "Wave Repeater 4" Ability { id: "7B52", source: "Omega" }
 422.4 "Wave Repeater 1" Ability { id: "7B4F", source: "Omega" }
 424.5 "Wave Repeater 2" Ability { id: "7B50", source: "Omega" }
-426.4 "Colossal Blow" Ability { id: "7B4E", source: "(Left Arm Unit|Right Arm Unit)" } window 1,1
+426.4 "Colossal Blow" Ability { id: "7B4E", source: ['Left Arm Unit', 'Right Arm Unit'] } window 1,1
 426.6 "Wave Repeater 3" Ability { id: "7B51", source: "Omega" }
 # sniper cannon times are a little sloppy and have inconsistent actor names
 427.3 "High-powered Sniper Cannon x2" #Ability { id: "7B54", source: "Omega" }
 428.4 "Sniper Cannon x4" #Ability { id: "7B53", source: "Omega" }
 428.7 "Wave Repeater 4" Ability { id: "7B52", source: "Omega" }
-428.9 "Colossal Blow" Ability { id: "7B4E", source: "(Left Arm Unit|Right Arm Unit)" } window 1,1
+428.9 "Colossal Blow" Ability { id: "7B4E", source: ['Left Arm Unit', 'Right Arm Unit'] } window 1,1
 
 432.3 "--targetable--"
 436.3 "--sync--" StartsUsing { id: "7B55", source: "Omega" } window 40,40


### PR DESCRIPTION
`/(?<=\w* {[^}]*source: )"\((?<source>[^)]*)\)"/`

Splits source groups into their own parameters.
This reveals some translation collision, so fix that too.

Related to #5977.